### PR TITLE
fix: include system prompt tokens in compaction budget

### DIFF
--- a/src/session/session-maintenance.ts
+++ b/src/session/session-maintenance.ts
@@ -15,6 +15,7 @@ import { logger } from '../logger.js';
 import { memoryService } from '../memory/memory-service.js';
 import { loadSkills } from '../skills/skills.js';
 import type { ChatMessage, StoredMessage } from '../types.js';
+import { agentWorkspaceDir } from '../infra/ipc.js';
 import { exportCompactedSessionJsonl } from './session-export.js';
 import {
   estimateTokenCountFromMessages,
@@ -103,6 +104,9 @@ function buildSystemPrompt(
     purpose: 'memory-flush',
     promptMode: 'minimal',
     extraSafetyText: extra,
+    runtimeInfo: {
+      workspacePath: agentWorkspaceDir(agentId),
+    },
     allowedTools: ['memory'],
   });
 }
@@ -282,7 +286,12 @@ export async function maybeCompactSession(params: {
     })),
   );
   const summaryTokens = estimateTokenCountFromText(session.session_summary);
-  const totalTokens = msgTokens + summaryTokens;
+  const systemPrompt = buildSystemPrompt(
+    params.agentId,
+    session.session_summary,
+  );
+  const systemPromptTokens = estimateTokenCountFromText(systemPrompt);
+  const totalTokens = msgTokens + summaryTokens + systemPromptTokens;
   const shouldCompactForTokens = totalTokens >= budget;
   const shouldCompactForMessageCount = session.message_count >= threshold;
 
@@ -293,6 +302,7 @@ export async function maybeCompactSession(params: {
       loadedMessages: allMessages.length,
       msgTokens,
       summaryTokens,
+      systemPromptTokens,
       totalTokens,
       tokenBudget,
       budgetRatio,
@@ -355,6 +365,7 @@ export async function maybeCompactSession(params: {
       keepRecent,
       msgTokens,
       summaryTokens,
+      systemPromptTokens,
       totalTokens,
       tokenBudget,
       budgetRatio,


### PR DESCRIPTION
## Summary
- The `maybeCompactSession()` budget check calculated `totalTokens` as `msgTokens + summaryTokens`, ignoring system prompt tokens (which can consume 15-20k+ tokens)
- Added system prompt token estimation using the existing `buildSystemPrompt()` helper and `estimateTokenCountFromText()`
- Added `systemPromptTokens` to both the debug and info log objects for observability

## Test plan
- [x] `npm run typecheck` passes
- [x] `tests/memory-compaction.test.ts` passes
- [x] `tests/heartbeat.test.ts` passes
- [x] No existing tests required changes (heartbeat mocks `maybeCompactSession` entirely; compaction tests exercise a different module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)