### PR TITLE
fix: tighten media path handling and pdf truncation

### DIFF
--- a/src/channels/discord/attachments.ts
+++ b/src/channels/discord/attachments.ts
@@ -280,7 +280,8 @@ const CACHED_ATTACHMENT_DESCRIPTORS = [
     buildFailureLine: (name) =>
       `- ${name}: image attachment (cache failed, using URL fallback)`,
     successLogMessage: 'Discord image attachment cached successfully',
-    failureLogMessage: 'Discord image attachment cache failed; using CDN fallback',
+    failureLogMessage:
+      'Discord image attachment cache failed; using CDN fallback',
     failureLogMimeType: (contentType) => contentType || null,
   },
   {
@@ -295,7 +296,8 @@ const CACHED_ATTACHMENT_DESCRIPTORS = [
     buildFailureLine: (name) =>
       `- ${name}: PDF attachment (cache failed, using URL fallback)`,
     successLogMessage: 'Discord PDF attachment cached successfully',
-    failureLogMessage: 'Discord PDF attachment cache failed; using CDN fallback',
+    failureLogMessage:
+      'Discord PDF attachment cache failed; using CDN fallback',
     failureLogMimeType: (contentType) => contentType || 'application/pdf',
     includeHostPathInSuccessLog: true,
   },
@@ -444,9 +446,10 @@ export async function buildAttachmentContext(
         name,
         contentType,
       );
-      const maxBytes = cachedDescriptor?.kind === 'audio'
-        ? MAX_AUDIO_ATTACHMENT_BYTES
-        : MAX_ATTACHMENT_BYTES;
+      const maxBytes =
+        cachedDescriptor?.kind === 'audio'
+          ? MAX_AUDIO_ATTACHMENT_BYTES
+          : MAX_ATTACHMENT_BYTES;
       if (size > maxBytes) {
         lines.push(
           `- ${name}: skipped (size ${size} bytes exceeds ${Math.floor(maxBytes / (1024 * 1024))}MB limit)`,

--- a/src/channels/discord/runtime.ts
+++ b/src/channels/discord/runtime.ts
@@ -11,7 +11,6 @@ import {
 } from 'discord.js';
 import { resolveAgentForRequest } from '../../agents/agent-registry.js';
 import {
-  DATA_DIR,
   DISCORD_ACK_REACTION,
   DISCORD_ACK_REACTION_SCOPE,
   DISCORD_COMMAND_ALLOWED_USER_IDS,
@@ -99,7 +98,10 @@ import {
   type LifecyclePhase,
   LifecycleReactionController,
 } from './reactions.js';
-import { resolveDiscordLocalFileForSend } from './send-files.js';
+import {
+  DISCORD_SEND_MEDIA_ROOT_HOST_DIR,
+  resolveDiscordLocalFileForSend,
+} from './send-files.js';
 import { resolveSendAllowed } from './send-permissions.js';
 import {
   buildSlashCommandDefinitions,
@@ -566,10 +568,6 @@ async function requireDiscordClientReady(): Promise<Client> {
   throw new Error('Discord client is not ready yet.');
 }
 
-const DISCORD_MEDIA_CACHE_HOST_DIR = path.resolve(
-  path.join(DATA_DIR, 'discord-media-cache'),
-);
-
 function resolveDiscordToolSessionWorkspaceRoot(
   sessionId: string | undefined,
 ): string | null {
@@ -595,7 +593,7 @@ async function resolveDiscordToolSendAttachments(
   const resolvedPath = resolveDiscordLocalFileForSend({
     filePath: rawPath,
     sessionWorkspaceRoot: workspaceRoot,
-    mediaCacheRoot: DISCORD_MEDIA_CACHE_HOST_DIR,
+    mediaCacheRoot: DISCORD_SEND_MEDIA_ROOT_HOST_DIR,
   });
   if (!resolvedPath) {
     if (!workspaceRoot) {

--- a/src/channels/discord/send-files.ts
+++ b/src/channels/discord/send-files.ts
@@ -1,7 +1,12 @@
 import path from 'node:path';
 
+import { DATA_DIR } from '../../config/config.js';
+
 export const DISCORD_SEND_WORKSPACE_ROOT_DISPLAY = '/workspace';
 export const DISCORD_SEND_MEDIA_ROOT_DISPLAY = '/discord-media-cache';
+export const DISCORD_SEND_MEDIA_ROOT_HOST_DIR = path.resolve(
+  path.join(DATA_DIR, 'discord-media-cache'),
+);
 
 function normalizeSlashes(value: string): string {
   return value.replace(/\\/g, '/');

--- a/src/channels/message/tool-actions.ts
+++ b/src/channels/message/tool-actions.ts
@@ -1,6 +1,5 @@
 import path from 'node:path';
 import { resolveAgentForRequest } from '../../agents/agent-registry.js';
-import { DATA_DIR } from '../../config/config.js';
 import {
   isDiscordChannelId,
   isSupportedProactiveChannelId,
@@ -8,12 +7,11 @@ import {
 import { agentWorkspaceDir } from '../../infra/ipc.js';
 import { enqueueProactiveMessage, getSessionById } from '../../memory/db.js';
 import { runDiscordToolAction } from '../discord/runtime.js';
-import { resolveDiscordLocalFileForSend } from '../discord/send-files.js';
 import {
-  type DiscordToolAction,
-  type DiscordToolActionRequest,
-  normalizeDiscordToolAction,
-} from '../discord/tool-actions.js';
+  DISCORD_SEND_MEDIA_ROOT_HOST_DIR,
+  resolveDiscordLocalFileForSend,
+} from '../discord/send-files.js';
+import type { DiscordToolActionRequest } from '../discord/tool-actions.js';
 import { getWhatsAppAuthStatus } from '../whatsapp/auth.js';
 import {
   canonicalizeWhatsAppUserJid,
@@ -26,17 +24,9 @@ import {
   sendWhatsAppMediaToChat,
 } from '../whatsapp/runtime.js';
 
-export type MessageToolAction = DiscordToolAction;
-export type MessageToolActionRequest = DiscordToolActionRequest;
-
 const LOCAL_MESSAGE_QUEUE_LIMIT = 100;
 const MESSAGE_TOOL_WHATSAPP_PREFIX_RE = /^whatsapp:/i;
 const MESSAGE_TOOL_LOCAL_SOURCE = 'message-tool';
-const MESSAGE_MEDIA_CACHE_HOST_DIR = path.resolve(
-  path.join(DATA_DIR, 'discord-media-cache'),
-);
-
-export const normalizeMessageToolAction = normalizeDiscordToolAction;
 
 function resolveMessageToolSessionWorkspaceRoot(
   sessionId: string | undefined,
@@ -52,7 +42,7 @@ function resolveMessageToolSessionWorkspaceRoot(
 }
 
 function resolveMessageToolSendFilePath(
-  request: MessageToolActionRequest,
+  request: DiscordToolActionRequest,
 ): string | null {
   const rawPath = String(request.filePath || '').trim();
   if (!rawPath) return null;
@@ -63,7 +53,7 @@ function resolveMessageToolSendFilePath(
   const resolvedPath = resolveDiscordLocalFileForSend({
     filePath: rawPath,
     sessionWorkspaceRoot: workspaceRoot,
-    mediaCacheRoot: MESSAGE_MEDIA_CACHE_HOST_DIR,
+    mediaCacheRoot: DISCORD_SEND_MEDIA_ROOT_HOST_DIR,
   });
   if (!resolvedPath) {
     if (!workspaceRoot) {
@@ -104,7 +94,7 @@ function normalizeLocalMessageTarget(rawTarget: string): string | null {
   return isSupportedProactiveChannelId(trimmed) ? trimmed : null;
 }
 
-function hasMessageComponents(request: MessageToolActionRequest): boolean {
+function hasMessageComponents(request: DiscordToolActionRequest): boolean {
   return (
     Array.isArray(request.components) ||
     (request.components !== null && typeof request.components === 'object')
@@ -112,7 +102,7 @@ function hasMessageComponents(request: MessageToolActionRequest): boolean {
 }
 
 async function runWhatsAppMessageSendAction(
-  request: MessageToolActionRequest,
+  request: DiscordToolActionRequest,
   channelId: string,
 ): Promise<Record<string, unknown>> {
   const content = String(request.content || '').trim();
@@ -159,7 +149,7 @@ async function runWhatsAppMessageSendAction(
 }
 
 async function runLocalMessageSendAction(
-  request: MessageToolActionRequest,
+  request: DiscordToolActionRequest,
   channelId: string,
 ): Promise<Record<string, unknown>> {
   const content = String(request.content || '').trim();
@@ -192,7 +182,7 @@ async function runLocalMessageSendAction(
 }
 
 export async function runMessageToolAction(
-  request: MessageToolActionRequest,
+  request: DiscordToolActionRequest,
 ): Promise<Record<string, unknown>> {
   if (request.action !== 'send') {
     return await runDiscordToolAction(request);

--- a/src/media/pdf-context.ts
+++ b/src/media/pdf-context.ts
@@ -148,9 +148,20 @@ function escapeFileBlockContent(value: string): string {
     .replace(/<\s*file\b/gi, '&lt;file');
 }
 
-function clampText(value: string, maxChars: number): string {
+const TRUNCATION_SUFFIX = '\n...[truncated]';
+
+export function clampText(value: string, maxChars: number): string {
+  if (maxChars <= 0) return '';
   if (value.length <= maxChars) return value;
-  return `${value.slice(0, Math.max(1_000, maxChars - 16)).trimEnd()}\n...[truncated]`;
+  if (maxChars <= TRUNCATION_SUFFIX.length) {
+    return value.slice(0, maxChars);
+  }
+
+  const head = value.slice(0, maxChars - TRUNCATION_SUFFIX.length).trimEnd();
+  if (!head) {
+    return value.slice(0, maxChars);
+  }
+  return `${head}${TRUNCATION_SUFFIX}`;
 }
 
 function addPdfReference(

--- a/src/security/media-paths.ts
+++ b/src/security/media-paths.ts
@@ -60,10 +60,7 @@ function resolveUnderPrefix(
   prefix: string,
   root: string,
 ): string | null {
-  if (
-    normalizedPath !== prefix &&
-    !normalizedPath.startsWith(`${prefix}/`)
-  ) {
+  if (normalizedPath !== prefix && !normalizedPath.startsWith(`${prefix}/`)) {
     return null;
   }
 
@@ -105,11 +102,7 @@ function resolveDisplayPathToHost(params: {
   );
   if (workspaceResolved) return workspaceResolved;
 
-  return resolveUnderPrefix(
-    normalized,
-    mediaCacheRootDisplay,
-    mediaCacheRoot,
-  );
+  return resolveUnderPrefix(normalized, mediaCacheRootDisplay, mediaCacheRoot);
 }
 
 export function buildValidatedMountAliases(params: {

--- a/tests/pdf-context.test.ts
+++ b/tests/pdf-context.test.ts
@@ -6,7 +6,10 @@ import { PDFDocument, StandardFonts } from 'pdf-lib';
 import { afterEach, describe, expect, test } from 'vitest';
 
 import { setSandboxModeOverride } from '../src/config/config.js';
-import { injectPdfContextMessages } from '../src/media/pdf-context.js';
+import {
+  clampText,
+  injectPdfContextMessages,
+} from '../src/media/pdf-context.js';
 import type { ChatMessage } from '../src/types.js';
 
 async function createPdf(filePath: string, text: string): Promise<void> {
@@ -29,6 +32,19 @@ function latestSystemMessage(messages: ChatMessage[]): ChatMessage | undefined {
 describe('injectPdfContextMessages', () => {
   afterEach(() => {
     setSandboxModeOverride(null);
+  });
+
+  test('clampText respects small caps including the truncation suffix', () => {
+    const clamped = clampText('x'.repeat(2_000), 80);
+
+    expect(clamped.length).toBeLessThanOrEqual(80);
+    expect(clamped.endsWith('...[truncated]')).toBe(true);
+  });
+
+  test('clampText does not exceed tiny caps', () => {
+    const clamped = clampText('x'.repeat(2_000), 10);
+
+    expect(clamped).toHaveLength(10);
   });
 
   test('injects current-turn PDF text for an explicit local file path', async () => {

--- a/tests/security.media-paths.test.ts
+++ b/tests/security.media-paths.test.ts
@@ -35,13 +35,15 @@ afterEach(() => {
   }
 });
 
-function buildParams(overrides: Partial<{
-  rawPath: string;
-  workspaceRoot: string;
-  mediaCacheRoot: string;
-  mountAliases: ValidatedMountAlias[];
-  allowHostAbsolutePaths: boolean;
-}> = {}) {
+function buildParams(
+  overrides: Partial<{
+    rawPath: string;
+    workspaceRoot: string;
+    mediaCacheRoot: string;
+    mountAliases: ValidatedMountAlias[];
+    allowHostAbsolutePaths: boolean;
+  }> = {},
+) {
   const workspaceRoot = overrides.workspaceRoot || makeTempDir('hc-workspace-');
   const mediaCacheRoot =
     overrides.mediaCacheRoot || makeTempDir('hc-discord-cache-');


### PR DESCRIPTION
This pull request refactors how the Discord media cache directory is referenced and used throughout the codebase, ensuring a single source of truth for the cache path and improving maintainability. It also improves the `clampText` function for text truncation and adds related tests. Minor formatting and cleanup changes are included as well.

**Media cache directory refactor:**

* Introduced `DISCORD_SEND_MEDIA_ROOT_HOST_DIR` in `src/channels/discord/send-files.ts` as the canonical reference for the Discord media cache directory, replacing multiple ad hoc definitions across files.
* Updated all usages of the media cache directory in `src/channels/discord/runtime.ts` and `src/channels/message/tool-actions.ts` to use the new constant, removing redundant or inconsistent path definitions. [[1]](diffhunk://#diff-a3b2aa6ce4b91112a97f0b6edf5f832cc9b23093129db9544bccc4b91c2ecda9L569-L572) [[2]](diffhunk://#diff-a3b2aa6ce4b91112a97f0b6edf5f832cc9b23093129db9544bccc4b91c2ecda9L598-R596) [[3]](diffhunk://#diff-a078106402c76fbd774a24705eb1efd154770341782c2a388a52d9d9dd170667L3-R14) [[4]](diffhunk://#diff-a078106402c76fbd774a24705eb1efd154770341782c2a388a52d9d9dd170667L29-L39) [[5]](diffhunk://#diff-a078106402c76fbd774a24705eb1efd154770341782c2a388a52d9d9dd170667L66-R56)

**Type and import cleanup:**

* Standardized usage of `DiscordToolActionRequest` for message tool actions and cleaned up related imports and type exports in `src/channels/message/tool-actions.ts`. [[1]](diffhunk://#diff-a078106402c76fbd774a24705eb1efd154770341782c2a388a52d9d9dd170667L3-R14) [[2]](diffhunk://#diff-a078106402c76fbd774a24705eb1efd154770341782c2a388a52d9d9dd170667L29-L39) [[3]](diffhunk://#diff-a078106402c76fbd774a24705eb1efd154770341782c2a388a52d9d9dd170667L55-R45) [[4]](diffhunk://#diff-a078106402c76fbd774a24705eb1efd154770341782c2a388a52d9d9dd170667L107-R105) [[5]](diffhunk://#diff-a078106402c76fbd774a24705eb1efd154770341782c2a388a52d9d9dd170667L162-R152) [[6]](diffhunk://#diff-a078106402c76fbd774a24705eb1efd154770341782c2a388a52d9d9dd170667L195-R185)

**Text truncation improvements:**

* Enhanced `clampText` in `src/media/pdf-context.ts` to handle edge cases where the maximum length is very small and to ensure the truncation suffix does not cause overflow.
* Added unit tests for `clampText` to verify correct behavior for small and tiny caps in `tests/pdf-context.test.ts`. [[1]](diffhunk://#diff-751cdffb7df8bf370b7a4d266333e31ff93531f115be38ec483c27bbd30fb631L9-R12) [[2]](diffhunk://#diff-751cdffb7df8bf370b7a4d266333e31ff93531f115be38ec483c27bbd30fb631R37-R49)

**Formatting and minor code cleanup:**

* Reformatted some long lines for readability in `src/channels/discord/attachments.ts` and simplified conditional logic in `src/security/media-paths.ts`. [[1]](diffhunk://#diff-3a48462ff8c12eeecf1ffcbc872f7f7d3452b2871a8bbb5d4813668c08246218L283-R284) [[2]](diffhunk://#diff-3a48462ff8c12eeecf1ffcbc872f7f7d3452b2871a8bbb5d4813668c08246218L298-R300) [[3]](diffhunk://#diff-3a48462ff8c12eeecf1ffcbc872f7f7d3452b2871a8bbb5d4813668c08246218L447-R450) [[4]](diffhunk://#diff-20d2955e349ffe9697daa7f6d13e041c86d4be0dee1edad86f53ceb04a4a095dL63-R63) [[5]](diffhunk://#diff-20d2955e349ffe9697daa7f6d13e041c86d4be0dee1edad86f53ceb04a4a095dL108-R105) [[6]](diffhunk://#diff-ec197c424d1df7668cefef32896e1eb47ecb9e2efb6aecdd8058c2070bf86bf7L38-R46)