### PR TITLE
refactor: reduce test-only exports

### DIFF
--- a/src/config/cli-flags.ts
+++ b/src/config/cli-flags.ts
@@ -32,15 +32,15 @@ function isDebugFlag(arg: string): boolean {
   return String(arg || '').trim() === '--debug';
 }
 
-export function hasSandboxFlag(argv: string[]): boolean {
+function hasSandboxFlag(argv: string[]): boolean {
   return argv.some((arg) => isSandboxFlag(arg));
 }
 
-export function hasForegroundFlag(argv: string[]): boolean {
+function hasForegroundFlag(argv: string[]): boolean {
   return argv.some((arg) => isForegroundFlag(arg));
 }
 
-export function hasDebugFlag(argv: string[]): boolean {
+function hasDebugFlag(argv: string[]): boolean {
   return argv.some((arg) => isDebugFlag(arg));
 }
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -161,9 +161,9 @@ export let HYBRIDAI_MODEL = 'gpt-5-nano';
 export let HYBRIDAI_CHATBOT_ID = '';
 export let HYBRIDAI_MAX_TOKENS = 4_096;
 export let HYBRIDAI_ENABLE_RAG = true;
-export let HYBRIDAI_MODELS: string[] = ['gpt-5-nano', 'gpt-5-mini', 'gpt-5'];
+let HYBRIDAI_MODELS: string[] = ['gpt-5-nano', 'gpt-5-mini', 'gpt-5'];
 export let CODEX_BASE_URL = 'https://chatgpt.com/backend-api/codex';
-export let CODEX_MODELS: string[] = [
+let CODEX_MODELS: string[] = [
   'openai-codex/gpt-5-codex',
   'openai-codex/gpt-5.3-codex',
   'openai-codex/gpt-5.4',
@@ -175,9 +175,7 @@ export let CODEX_MODELS: string[] = [
 ];
 export let OPENROUTER_ENABLED = false;
 export let OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
-export let OPENROUTER_MODELS: string[] = [
-  'openrouter/anthropic/claude-sonnet-4',
-];
+let OPENROUTER_MODELS: string[] = ['openrouter/anthropic/claude-sonnet-4'];
 export let CONFIGURED_MODELS: string[] = dedupeStringList([
   ...HYBRIDAI_MODELS,
   ...CODEX_MODELS,

--- a/src/memory/compaction.ts
+++ b/src/memory/compaction.ts
@@ -295,7 +295,7 @@ async function runSummaryAttempt(params: {
   return normalized;
 }
 
-export function splitConversation(
+function splitConversation(
   messages: StoredMessage[],
   overrides?: Partial<CompactionConfig>,
 ): ConversationSplit {

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -31,10 +31,6 @@ function getActiveProviders(): AIProvider[] {
   ];
 }
 
-export function getAIProviders(): readonly AIProvider[] {
-  return getActiveProviders();
-}
-
 export function resolveProviderForModel(model: string): AIProvider {
   const normalizedModel = String(model || '').trim();
   return (

--- a/src/providers/local-discovery.ts
+++ b/src/providers/local-discovery.ts
@@ -194,7 +194,7 @@ async function fetchOpenAICompatModels(
     .filter((model) => Boolean(model.id));
 }
 
-export async function discoverOllamaModels(
+async function discoverOllamaModels(
   baseUrl = LOCAL_OLLAMA_BASE_URL,
   opts?: { maxModels?: number; concurrency?: number },
 ): Promise<LocalModelInfo[]> {
@@ -257,13 +257,13 @@ export async function discoverOllamaModels(
   return models.filter((model) => Boolean(model.id));
 }
 
-export async function discoverLmStudioModels(
+async function discoverLmStudioModels(
   baseUrl = LOCAL_LMSTUDIO_BASE_URL,
 ): Promise<LocalModelInfo[]> {
   return fetchOpenAICompatModels('lmstudio', baseUrl);
 }
 
-export async function discoverVllmModels(
+async function discoverVllmModels(
   baseUrl = LOCAL_VLLM_BASE_URL,
   apiKey = LOCAL_VLLM_API_KEY,
 ): Promise<LocalModelInfo[]> {

--- a/src/providers/local-health.ts
+++ b/src/providers/local-health.ts
@@ -224,8 +224,3 @@ export function stopHealthCheckLoop(): void {
   clearInterval(healthTimer);
   healthTimer = null;
 }
-
-export function resetLocalHealthState(): void {
-  stopHealthCheckLoop();
-  backendHealth.clear();
-}

--- a/src/security/mount-config.ts
+++ b/src/security/mount-config.ts
@@ -47,7 +47,7 @@ function normalizeReadonly(rawMode: string | undefined): boolean | null {
   return null;
 }
 
-export function parseBindSpec(spec: string): {
+function parseBindSpec(spec: string): {
   mount: AdditionalMount | null;
   warning?: string;
 } {

--- a/tests/cli-flags.test.ts
+++ b/tests/cli-flags.test.ts
@@ -2,9 +2,6 @@ import { describe, expect, it } from 'vitest';
 
 import {
   findUnsupportedGatewayLifecycleFlag,
-  hasDebugFlag,
-  hasForegroundFlag,
-  hasSandboxFlag,
   parseGatewayFlags,
 } from '../src/config/cli-flags.js';
 
@@ -51,28 +48,6 @@ describe('parseGatewayFlags', () => {
     expect(() => parseGatewayFlags(['--sandbox=weird'])).toThrow(
       /Invalid value for --sandbox/,
     );
-  });
-});
-
-describe('hasSandboxFlag', () => {
-  it('detects sandbox flags in gateway subcommand args', () => {
-    expect(hasSandboxFlag(['status', '--sandbox=host'])).toBe(true);
-    expect(hasSandboxFlag(['status'])).toBe(false);
-  });
-});
-
-describe('hasDebugFlag', () => {
-  it('detects debug flags in gateway subcommand args', () => {
-    expect(hasDebugFlag(['status', '--debug'])).toBe(true);
-    expect(hasDebugFlag(['status'])).toBe(false);
-  });
-});
-
-describe('hasForegroundFlag', () => {
-  it('detects foreground flags in gateway subcommand args', () => {
-    expect(hasForegroundFlag(['status', '--foreground'])).toBe(true);
-    expect(hasForegroundFlag(['status', '-f'])).toBe(true);
-    expect(hasForegroundFlag(['status'])).toBe(false);
   });
 });
 

--- a/tests/configured-models.test.ts
+++ b/tests/configured-models.test.ts
@@ -69,18 +69,19 @@ describe('configured model catalog', () => {
     });
 
     const config = await importFreshConfig(homeDir);
+    const snapshot = config.getConfigSnapshot();
 
-    expect(config.HYBRIDAI_MODELS).toEqual([
+    expect(snapshot.hybridai.models).toEqual([
       'gpt-5-nano',
       'shared-model',
       'gpt-5',
     ]);
-    expect(config.CODEX_MODELS).toEqual([
+    expect(snapshot.codex.models).toEqual([
       'shared-model',
       'openai-codex/gpt-5.4',
     ]);
     expect(config.OPENROUTER_ENABLED).toBe(true);
-    expect(config.OPENROUTER_MODELS).toEqual([
+    expect(snapshot.openrouter.models).toEqual([
       'shared-model',
       'openrouter/anthropic/claude-sonnet-4',
     ]);

--- a/tests/local-discovery.test.ts
+++ b/tests/local-discovery.test.ts
@@ -73,7 +73,12 @@ describe('local discovery', () => {
   test('discoverOllamaModels reads tags and show metadata with concurrency', async () => {
     const homeDir = makeTempHome();
     writeRuntimeConfig(homeDir, (config) => {
+      config.local.backends.ollama.enabled = true;
+      config.local.backends.lmstudio.enabled = false;
+      config.local.backends.vllm.enabled = false;
       config.local.backends.ollama.baseUrl = 'http://127.0.0.1:11434/v1/';
+      config.local.discovery.maxModels = 2;
+      config.local.discovery.concurrency = 2;
     });
     const discovery = await importFreshDiscovery(homeDir);
 
@@ -128,13 +133,7 @@ describe('local discovery', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const models = await discovery.discoverOllamaModels(
-      'http://127.0.0.1:11434/v1/',
-      {
-        maxModels: 2,
-        concurrency: 2,
-      },
-    );
+    const models = await discovery.discoverAllLocalModels({ force: true });
 
     expect(models).toEqual([
       expect.objectContaining({
@@ -159,7 +158,12 @@ describe('local discovery', () => {
 
   test('discoverLmStudioModels parses OpenAI-compatible /models output', async () => {
     const homeDir = makeTempHome();
-    writeRuntimeConfig(homeDir);
+    writeRuntimeConfig(homeDir, (config) => {
+      config.local.backends.ollama.enabled = false;
+      config.local.backends.lmstudio.enabled = true;
+      config.local.backends.vllm.enabled = false;
+      config.local.backends.lmstudio.baseUrl = 'http://127.0.0.1:1234/v1';
+    });
     const discovery = await importFreshDiscovery(homeDir);
 
     vi.stubGlobal(
@@ -175,9 +179,7 @@ describe('local discovery', () => {
       ),
     );
 
-    const models = await discovery.discoverLmStudioModels(
-      'http://127.0.0.1:1234/v1',
-    );
+    const models = await discovery.discoverAllLocalModels({ force: true });
 
     expect(models.map((model) => [model.backend, model.id])).toEqual([
       ['lmstudio', 'qwen2.5-coder:7b'],
@@ -189,7 +191,13 @@ describe('local discovery', () => {
 
   test('discoverVllmModels sends bearer auth only when configured', async () => {
     const homeDir = makeTempHome();
-    writeRuntimeConfig(homeDir);
+    writeRuntimeConfig(homeDir, (config) => {
+      config.local.backends.ollama.enabled = false;
+      config.local.backends.lmstudio.enabled = false;
+      config.local.backends.vllm.enabled = true;
+      config.local.backends.vllm.baseUrl = 'http://127.0.0.1:8000/v1';
+      config.local.backends.vllm.apiKey = 'secret';
+    });
     const discovery = await importFreshDiscovery(homeDir);
 
     const fetchMock = vi.fn(
@@ -201,15 +209,13 @@ describe('local discovery', () => {
     );
     vi.stubGlobal('fetch', fetchMock);
 
-    await discovery.discoverVllmModels('http://127.0.0.1:8000/v1', 'secret');
-    await discovery.discoverVllmModels('http://127.0.0.1:8000/v1', '');
+    await discovery.discoverAllLocalModels({ force: true });
 
     expect((fetchMock.mock.calls[0]?.[1] as RequestInit).headers).toMatchObject(
       {
         Authorization: 'Bearer secret',
       },
     );
-    expect((fetchMock.mock.calls[1]?.[1] as RequestInit).headers).toEqual({});
   });
 
   test('discoverAllLocalModels reloads vLLM discovery after the cache expires', async () => {
@@ -297,7 +303,12 @@ describe('local discovery', () => {
 
   test('discoverOllamaModels caps results at maxModels limit', async () => {
     const homeDir = makeTempHome();
-    writeRuntimeConfig(homeDir);
+    writeRuntimeConfig(homeDir, (config) => {
+      config.local.backends.ollama.enabled = true;
+      config.local.backends.lmstudio.enabled = false;
+      config.local.backends.vllm.enabled = false;
+      config.local.discovery.maxModels = 2;
+    });
     const discovery = await importFreshDiscovery(homeDir);
 
     vi.stubGlobal(
@@ -325,10 +336,7 @@ describe('local discovery', () => {
       }),
     );
 
-    const models = await discovery.discoverOllamaModels(
-      'http://127.0.0.1:11434',
-      { maxModels: 2 },
-    );
+    const models = await discovery.discoverAllLocalModels({ force: true });
 
     expect(models).toHaveLength(2);
     expect(models.map((m) => m.id)).toEqual(['model-a', 'model-b']);
@@ -336,7 +344,12 @@ describe('local discovery', () => {
 
   test('discoverOllamaModels detects reasoning models by id pattern', async () => {
     const homeDir = makeTempHome();
-    writeRuntimeConfig(homeDir);
+    writeRuntimeConfig(homeDir, (config) => {
+      config.local.backends.ollama.enabled = true;
+      config.local.backends.lmstudio.enabled = false;
+      config.local.backends.vllm.enabled = false;
+      config.local.discovery.maxModels = 10;
+    });
     const discovery = await importFreshDiscovery(homeDir);
 
     vi.stubGlobal(
@@ -365,10 +378,7 @@ describe('local discovery', () => {
       }),
     );
 
-    const models = await discovery.discoverOllamaModels(
-      'http://127.0.0.1:11434',
-      { maxModels: 10 },
-    );
+    const models = await discovery.discoverAllLocalModels({ force: true });
 
     expect(models.find((m) => m.id === 'deepseek-r1')?.isReasoning).toBe(true);
     expect(models.find((m) => m.id === 'reasoning-model')?.isReasoning).toBe(
@@ -380,7 +390,13 @@ describe('local discovery', () => {
 
   test('discoverVllmModels omits Authorization header when apiKey is empty', async () => {
     const homeDir = makeTempHome();
-    writeRuntimeConfig(homeDir);
+    writeRuntimeConfig(homeDir, (config) => {
+      config.local.backends.ollama.enabled = false;
+      config.local.backends.lmstudio.enabled = false;
+      config.local.backends.vllm.enabled = true;
+      config.local.backends.vllm.baseUrl = 'http://127.0.0.1:8000/v1';
+      config.local.backends.vllm.apiKey = '';
+    });
     const discovery = await importFreshDiscovery(homeDir);
 
     const fetchMock = vi.fn(
@@ -392,11 +408,8 @@ describe('local discovery', () => {
     );
     vi.stubGlobal('fetch', fetchMock);
 
-    await discovery.discoverVllmModels('http://127.0.0.1:8000/v1', undefined);
+    await discovery.discoverAllLocalModels({ force: true });
     expect((fetchMock.mock.calls[0]?.[1] as RequestInit).headers).toEqual({});
-
-    await discovery.discoverVllmModels('http://127.0.0.1:8000/v1', '');
-    expect((fetchMock.mock.calls[1]?.[1] as RequestInit).headers).toEqual({});
   });
 
   test('discoverAllLocalModels caches discovered names for prefixed selection', async () => {

--- a/tests/local-health.test.ts
+++ b/tests/local-health.test.ts
@@ -58,8 +58,6 @@ afterEach(async () => {
     process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER =
       ORIGINAL_DISABLE_CONFIG_WATCHER;
   }
-  const health = await import('../src/providers/local-health.js');
-  health.resetLocalHealthState();
 });
 
 describe('local health checks', () => {

--- a/tests/local-provider.test.ts
+++ b/tests/local-provider.test.ts
@@ -71,17 +71,19 @@ afterEach(async () => {
 });
 
 describe('local providers', () => {
-  test('provider factory registers local providers before HybridAI fallback', async () => {
+  test('provider factory resolves explicit provider prefixes without exposing provider internals', async () => {
     const homeDir = makeTempHome();
     writeRuntimeConfig(homeDir);
     const { factory } = await importFreshModules(homeDir);
 
-    expect(factory.getAIProviders().map((provider) => provider.id)).toEqual([
+    expect(factory.resolveModelProvider('openai-codex/gpt-5.4')).toBe(
       'openai-codex',
+    );
+    expect(factory.resolveModelProvider('anthropic/claude-sonnet-4')).toBe(
       'anthropic',
-      'ollama',
-      'hybridai',
-    ]);
+    );
+    expect(factory.resolveModelProvider('ollama/llama3.2')).toBe('ollama');
+    expect(factory.resolveModelProvider('gpt-5-nano')).toBe('hybridai');
   });
 
   test('explicit ollama model prefixes resolve to the ollama provider', async () => {
@@ -169,7 +171,7 @@ describe('local providers', () => {
     expect(credentials.apiKey).toBe('');
   });
 
-  test('factory provider order: local providers appear after anthropic, before hybridai fallback', async () => {
+  test('all enabled local provider prefixes remain routable', async () => {
     const homeDir = makeTempHome();
     writeRuntimeConfig(homeDir, (config) => {
       config.local.backends.ollama.enabled = true;
@@ -178,19 +180,12 @@ describe('local providers', () => {
     });
     const { factory } = await importFreshModules(homeDir);
 
-    const providerIds = factory.getAIProviders().map((p) => p.id);
-    const anthropicIndex = providerIds.indexOf('anthropic');
-    const ollamaIndex = providerIds.indexOf('ollama');
-    const lmstudioIndex = providerIds.indexOf('lmstudio');
-    const vllmIndex = providerIds.indexOf('vllm');
-    const hybridaiIndex = providerIds.indexOf('hybridai');
-
-    expect(anthropicIndex).toBeLessThan(ollamaIndex);
-    expect(ollamaIndex).toBeLessThan(hybridaiIndex);
-    expect(lmstudioIndex).toBeLessThan(hybridaiIndex);
-    expect(vllmIndex).toBeLessThan(hybridaiIndex);
-    // hybridai is always last
-    expect(hybridaiIndex).toBe(providerIds.length - 1);
+    expect(factory.resolveModelProvider('ollama/llama3.2')).toBe('ollama');
+    expect(factory.resolveModelProvider('lmstudio/qwen3.5-9b')).toBe(
+      'lmstudio',
+    );
+    expect(factory.resolveModelProvider('vllm/granite-3.2')).toBe('vllm');
+    expect(factory.resolveModelProvider('gpt-5-nano')).toBe('hybridai');
   });
 
   test('unknown models still fall back to HybridAI', async () => {

--- a/tests/memory-compaction.test.ts
+++ b/tests/memory-compaction.test.ts
@@ -3,10 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { describe, expect, test } from 'vitest';
-import {
-  compactConversation,
-  splitConversation,
-} from '../src/memory/compaction.js';
+import { compactConversation } from '../src/memory/compaction.js';
 import { listArchives } from '../src/memory/compaction-archive.js';
 import type { Session, StoredMessage } from '../src/types.js';
 
@@ -73,7 +70,10 @@ function makeStructuredSummary(label: string): string {
 }
 
 describe('memory compaction', () => {
-  test('splitConversation preserves system messages and a recent tail', () => {
+  test('compactConversation preserves system messages and a recent tail', async () => {
+    const archiveBaseDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'hybridclaw-compact-tail-'),
+    );
     const messages = [
       makeMessage(1, 'system', 'System instruction'),
       makeMessage(2, 'user', 'User asks for a release plan'),
@@ -83,16 +83,33 @@ describe('memory compaction', () => {
       makeMessage(6, 'user', 'User asks for risk tracking'),
       makeMessage(7, 'assistant', 'Assistant adds risks and owners'),
     ];
+    const deletedIds: number[][] = [];
 
-    const split = splitConversation(messages, {
-      keepRecentMessages: 3,
-      compactRatio: 0.7,
+    const result = await compactConversation({
+      session: makeSession(),
+      messages,
+      backend: {
+        deleteMessagesByIds: (_sessionId, ids) => {
+          deletedIds.push([...ids]);
+          return ids.length;
+        },
+        storeSemanticMemory: () => 1,
+        updateSessionSummary: () => {},
+      },
+      promptRunner: {
+        run: async () => makeStructuredSummary('recent-tail'),
+      },
+      embed: () => [0.5, 0.5],
+      config: {
+        archiveBaseDir,
+        keepRecentMessages: 3,
+        compactRatio: 0.7,
+      },
     });
 
-    expect(split.system.map((message) => message.id)).toEqual([1]);
-    expect(split.compactable.length).toBeGreaterThan(0);
-    expect(split.recent.length).toBeGreaterThanOrEqual(3);
-    expect(split.recent.at(-1)?.id).toBe(7);
+    expect(result.messagesCompacted).toBe(3);
+    expect(result.messagesPreserved).toBe(4);
+    expect(deletedIds[0]).toEqual([2, 3, 4]);
   });
 
   test('compactConversation archives transcript, stores semantic memory, and deletes only compacted messages', async () => {

--- a/tests/mount-config.test.ts
+++ b/tests/mount-config.test.ts
@@ -1,26 +1,67 @@
 import { describe, expect, test } from 'vitest';
 
 import {
-  parseBindSpec,
+  parseBindSpecs,
   resolveConfiguredAdditionalMounts,
 } from '../src/security/mount-config.ts';
 
 describe('mount config parsing', () => {
   test('parses OpenClaw-style bind specs', () => {
-    expect(parseBindSpec('/host/data:/docs:ro')).toEqual({
-      mount: {
-        hostPath: '/host/data',
-        containerPath: 'docs',
-        readonly: true,
-      },
+    expect(parseBindSpecs(['/host/data:/docs:ro'])).toEqual({
+      mounts: [
+        {
+          hostPath: '/host/data',
+          containerPath: 'docs',
+          readonly: true,
+        },
+      ],
+      warnings: [],
     });
 
-    expect(parseBindSpec('/host/cache:/cache:rw')).toEqual({
-      mount: {
-        hostPath: '/host/cache',
-        containerPath: 'cache',
-        readonly: false,
-      },
+    expect(parseBindSpecs(['/host/cache:/cache:rw'])).toEqual({
+      mounts: [
+        {
+          hostPath: '/host/cache',
+          containerPath: 'cache',
+          readonly: false,
+        },
+      ],
+      warnings: [],
+    });
+  });
+
+  test('surfaces warnings for invalid bind specs', () => {
+    expect(parseBindSpecs(['missing-delimiter'])).toEqual({
+      mounts: [],
+      warnings: [
+        'bind spec must use host:container[:ro|rw] format (for example "/host/data:/data:ro")',
+      ],
+    });
+
+    expect(parseBindSpecs(['/host/data:/workspace:ro'])).toEqual({
+      mounts: [],
+      warnings: [
+        'bind spec "/host/data:/workspace:ro" targets a reserved container path',
+      ],
+    });
+  });
+
+  test('deduplicates repeated bind specs', () => {
+    expect(
+      parseBindSpecs([
+        '/host/data:/docs:ro',
+        '/host/data:/docs:ro',
+        '/host/data:/docs',
+      ]),
+    ).toEqual({
+      mounts: [
+        {
+          hostPath: '/host/data',
+          containerPath: 'docs',
+          readonly: true,
+        },
+      ],
+      warnings: [],
     });
   });
 


### PR DESCRIPTION
## Summary
- remove a first batch of test-only exports from config, mount parsing, compaction, provider discovery, provider factory, and local health modules
- rewrite affected tests to exercise public/runtime-facing APIs instead of internal helpers
- keep the change scoped to the export-surface cleanup and leave unrelated container work out of the branch

## Validation
- ./node_modules/.bin/vitest run tests/cli-flags.test.ts tests/mount-config.test.ts tests/memory-compaction.test.ts tests/local-discovery.test.ts tests/local-provider.test.ts tests/configured-models.test.ts tests/local-health.test.ts
- npm run typecheck
- npm run lint