### PR TITLE
fix: harden discord media cache

### DIFF
--- a/src/channels/discord/attachments.ts
+++ b/src/channels/discord/attachments.ts
@@ -1,31 +1,27 @@
-import { randomUUID } from 'node:crypto';
-import fs from 'node:fs';
-import path from 'node:path';
 import type {
   Attachment as DiscordAttachment,
   Message as DiscordMessage,
 } from 'discord.js';
 
-import { CONTAINER_SANDBOX_MODE, DATA_DIR } from '../../config/config.js';
 import { logger } from '../../logger.js';
 import { AUDIO_FILE_EXTENSION_RE } from '../../media/mime-utils.js';
 import type { MediaContextItem } from '../../types.js';
+import {
+  fetchDiscordCdnBuffer,
+  fetchDiscordCdnText,
+  isSafeDiscordCdnUrl,
+} from './discord-cdn-fetch.js';
+import {
+  scheduleDiscordMediaCacheCleanup,
+  writeDiscordMediaCacheFile,
+} from './media-cache.js';
 
-const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+const MAX_IMAGE_ATTACHMENT_BYTES = 6 * 1024 * 1024;
+const MAX_DOCUMENT_ATTACHMENT_BYTES = 100 * 1024 * 1024;
 const MAX_AUDIO_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 const MAX_ATTACHMENT_CONTEXT_CHARS = 16_000;
 const MAX_SINGLE_ATTACHMENT_CHARS = 8_000;
-const DISCORD_MEDIA_CACHE_DIR = path.resolve(
-  path.join(DATA_DIR, 'discord-media-cache'),
-);
-const CONTAINER_DISCORD_MEDIA_CACHE_DIR = '/discord-media-cache';
 const DISCORD_ATTACHMENT_FETCH_TIMEOUT_MS = 12_000;
-const DISCORD_CDN_HOST_PATTERNS: RegExp[] = [
-  /^cdn\.discordapp\.com$/i,
-  /^media\.discordapp\.net$/i,
-  /^cdn\.discordapp\.net$/i,
-  /^images-ext-\d+\.discordapp\.net$/i,
-];
 
 export interface AttachmentContextResult {
   context: string;
@@ -77,57 +73,21 @@ function looksLikeOfficeAttachment(name: string, contentType: string): boolean {
   return /\.(docx|xlsx|pptx)$/i.test(name);
 }
 
-function sanitizeAttachmentFilename(name: string): string {
-  const base = name
-    .trim()
-    .replace(/[^\w.-]+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-+|-+$/g, '');
-  const bounded = base.slice(0, 96);
-  return bounded || 'attachment';
-}
-
-function normalizeAttachmentPathForContainer(hostPath: string): string | null {
-  const relative = path.relative(DISCORD_MEDIA_CACHE_DIR, hostPath);
-  if (!relative || relative.startsWith('..') || path.isAbsolute(relative))
-    return null;
-  return `${CONTAINER_DISCORD_MEDIA_CACHE_DIR}/${relative.replace(/\\/g, '/')}`;
-}
-
-function normalizeAttachmentPathForRuntime(hostPath: string): string | null {
-  if (CONTAINER_SANDBOX_MODE === 'host') {
-    return hostPath;
-  }
-  return normalizeAttachmentPathForContainer(hostPath);
-}
-
-function isAllowedDiscordAttachmentUrl(rawUrl: string): boolean {
-  let parsed: URL;
-  try {
-    parsed = new URL(rawUrl);
-  } catch {
-    return false;
-  }
-  if (parsed.protocol !== 'https:') return false;
-  return DISCORD_CDN_HOST_PATTERNS.some((pattern) =>
-    pattern.test(parsed.hostname),
-  );
-}
-
 async function fetchAttachmentText(
-  url: string,
+  sourceCandidates: string[],
   maxChars: number,
 ): Promise<string | null> {
-  try {
-    const response = await fetch(url);
-    if (!response.ok) return null;
-    const text = await response.text();
-    if (!text) return null;
-    if (text.length <= maxChars) return text;
-    return `${text.slice(0, Math.max(1_000, maxChars - 32))}\n...[truncated]`;
-  } catch {
-    return null;
+  for (const candidateUrl of sourceCandidates) {
+    if (!isSafeDiscordCdnUrl(candidateUrl)) continue;
+    try {
+      const text = await fetchDiscordCdnText(candidateUrl, {
+        maxChars,
+        timeoutMs: DISCORD_ATTACHMENT_FETCH_TIMEOUT_MS,
+      });
+      if (text) return text;
+    } catch {}
   }
+  return null;
 }
 
 interface CachedDiscordAttachmentResult {
@@ -151,7 +111,7 @@ async function cacheDiscordAttachment(params: {
     messageId,
     order,
     fallbackMimeType,
-    maxBytes = MAX_ATTACHMENT_BYTES,
+    maxBytes = MAX_DOCUMENT_ATTACHMENT_BYTES,
     acceptMime,
   } = params;
   const attachmentName = attachment.name || 'image';
@@ -159,29 +119,20 @@ async function cacheDiscordAttachment(params: {
     .map((value) => String(value || '').trim())
     .filter(Boolean);
 
-  await fs.promises.mkdir(DISCORD_MEDIA_CACHE_DIR, { recursive: true });
-
   const fetchErrors: string[] = [];
   for (const candidateUrl of sourceCandidates) {
-    if (!isAllowedDiscordAttachmentUrl(candidateUrl)) {
+    if (!isSafeDiscordCdnUrl(candidateUrl)) {
       fetchErrors.push(`blocked_url:${candidateUrl}`);
       continue;
     }
 
-    const controller = new AbortController();
-    const timer = setTimeout(
-      () => controller.abort(),
-      DISCORD_ATTACHMENT_FETCH_TIMEOUT_MS,
-    );
     try {
-      const response = await fetch(candidateUrl, { signal: controller.signal });
-      if (!response.ok) {
-        fetchErrors.push(`http_${response.status}@${candidateUrl}`);
-        continue;
-      }
-
+      const response = await fetchDiscordCdnBuffer(candidateUrl, {
+        maxBytes,
+        timeoutMs: DISCORD_ATTACHMENT_FETCH_TIMEOUT_MS,
+      });
       const resolvedMime = String(
-        response.headers.get('content-type') || fallbackMimeType || '',
+        response.contentType || fallbackMimeType || '',
       )
         .split(';')[0]
         .trim()
@@ -193,32 +144,12 @@ async function cacheDiscordAttachment(params: {
         continue;
       }
 
-      const contentLength = Number.parseInt(
-        response.headers.get('content-length') || '',
-        10,
-      );
-      if (Number.isFinite(contentLength) && contentLength > maxBytes) {
-        fetchErrors.push(`too_large_header:${contentLength}@${candidateUrl}`);
-        continue;
-      }
-
-      const buffer = Buffer.from(await response.arrayBuffer());
-      if (buffer.length > maxBytes) {
-        fetchErrors.push(`too_large_body:${buffer.length}@${candidateUrl}`);
-        continue;
-      }
-
-      const unique = randomUUID().slice(0, 8);
-      const datePrefix = new Date().toISOString().slice(0, 10);
-      const fileName = `${Date.now()}-${messageId}-${String(order).padStart(3, '0')}-${unique}-${sanitizeAttachmentFilename(attachmentName)}`;
-      const hostPath = path.join(DISCORD_MEDIA_CACHE_DIR, datePrefix, fileName);
-      await fs.promises.mkdir(path.dirname(hostPath), { recursive: true });
-      await fs.promises.writeFile(hostPath, buffer);
-      const runtimePath = normalizeAttachmentPathForRuntime(hostPath);
-      if (!runtimePath) {
-        fetchErrors.push(`cache_path_error:${hostPath}`);
-        continue;
-      }
+      const { hostPath, runtimePath } = await writeDiscordMediaCacheFile({
+        attachmentName,
+        buffer: response.body,
+        messageId,
+        order,
+      });
       return {
         path: runtimePath,
         hostPath,
@@ -227,14 +158,12 @@ async function cacheDiscordAttachment(params: {
       };
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
-      fetchErrors.push(`fetch_error:${detail}@${candidateUrl}`);
-    } finally {
-      clearTimeout(timer);
+      fetchErrors.push(`${detail}@${candidateUrl}`);
     }
   }
 
   const fallbackUrl =
-    sourceCandidates.find((url) => isAllowedDiscordAttachmentUrl(url)) ||
+    sourceCandidates.find((url) => isSafeDiscordCdnUrl(url)) ||
     sourceCandidates[0] ||
     '';
   return {
@@ -251,6 +180,7 @@ interface CachedAttachmentDescriptor {
   kind: 'image' | 'pdf' | 'office' | 'audio';
   matches: (name: string, contentType: string) => boolean;
   acceptMime: (mimeType: string, attachmentName: string) => boolean;
+  maxBytes: number;
   resolveMimeType: (
     cachedMimeType: string | null,
     contentType: string,
@@ -273,6 +203,7 @@ const CACHED_ATTACHMENT_DESCRIPTORS = [
     kind: 'image',
     matches: looksLikeImageAttachment,
     acceptMime: (mimeType) => mimeType.startsWith('image/'),
+    maxBytes: MAX_IMAGE_ATTACHMENT_BYTES,
     resolveMimeType: (cachedMimeType, contentType) =>
       cachedMimeType || contentType || null,
     buildSuccessLine: ({ name, size, mimeType }) =>
@@ -289,6 +220,7 @@ const CACHED_ATTACHMENT_DESCRIPTORS = [
     matches: looksLikePdfAttachment,
     acceptMime: (mimeType, attachmentName) =>
       mimeType === 'application/pdf' || /\.pdf$/i.test(attachmentName),
+    maxBytes: MAX_DOCUMENT_ATTACHMENT_BYTES,
     resolveMimeType: (cachedMimeType, contentType) =>
       cachedMimeType || contentType || 'application/pdf',
     buildSuccessLine: ({ name, size, mimeType }) =>
@@ -306,6 +238,7 @@ const CACHED_ATTACHMENT_DESCRIPTORS = [
     matches: looksLikeOfficeAttachment,
     acceptMime: (mimeType, attachmentName) =>
       looksLikeOfficeAttachment(attachmentName, mimeType),
+    maxBytes: MAX_DOCUMENT_ATTACHMENT_BYTES,
     resolveMimeType: (cachedMimeType, contentType) =>
       cachedMimeType || contentType || null,
     buildSuccessLine: ({ name, size, mimeType, path }) =>
@@ -324,6 +257,7 @@ const CACHED_ATTACHMENT_DESCRIPTORS = [
     acceptMime: (mimeType, attachmentName) =>
       mimeType.startsWith('audio/') ||
       looksLikeAudioAttachment(attachmentName, mimeType),
+    maxBytes: MAX_AUDIO_ATTACHMENT_BYTES,
     resolveMimeType: (cachedMimeType, contentType) =>
       cachedMimeType || contentType || null,
     buildSuccessLine: ({ name, size, mimeType }) =>
@@ -435,9 +369,14 @@ export async function buildAttachmentContext(
   const media: MediaContextItem[] = [];
   let remainingChars = MAX_ATTACHMENT_CONTEXT_CHARS;
   let mediaOrder = 0;
+  let cleanupScheduled = false;
 
   for (const msg of messages) {
     if (!msg.attachments || msg.attachments.size === 0) continue;
+    if (!cleanupScheduled) {
+      scheduleDiscordMediaCacheCleanup();
+      cleanupScheduled = true;
+    }
     for (const attachment of msg.attachments.values()) {
       const name = attachment.name || 'unnamed';
       const size = attachment.size || 0;
@@ -447,9 +386,7 @@ export async function buildAttachmentContext(
         contentType,
       );
       const maxBytes =
-        cachedDescriptor?.kind === 'audio'
-          ? MAX_AUDIO_ATTACHMENT_BYTES
-          : MAX_ATTACHMENT_BYTES;
+        cachedDescriptor?.maxBytes ?? MAX_DOCUMENT_ATTACHMENT_BYTES;
       if (size > maxBytes) {
         lines.push(
           `- ${name}: skipped (size ${size} bytes exceeds ${Math.floor(maxBytes / (1024 * 1024))}MB limit)`,
@@ -500,7 +437,12 @@ export async function buildAttachmentContext(
           MAX_SINGLE_ATTACHMENT_CHARS,
           Math.max(500, remainingChars),
         );
-        const text = await fetchAttachmentText(attachment.url, maxChars);
+        const text = await fetchAttachmentText(
+          [attachment.url, attachment.proxyURL]
+            .map((value) => String(value || '').trim())
+            .filter(Boolean),
+          maxChars,
+        );
         if (!text) {
           lines.push(`- ${name}: text attachment (failed to read content)`);
           continue;

--- a/src/channels/discord/discord-cdn-fetch.ts
+++ b/src/channels/discord/discord-cdn-fetch.ts
@@ -1,0 +1,267 @@
+import type { LookupAddress } from 'node:dns';
+import { lookup } from 'node:dns/promises';
+import type { IncomingHttpHeaders } from 'node:http';
+import https from 'node:https';
+import type { LookupFunction } from 'node:net';
+import net from 'node:net';
+import { URL } from 'node:url';
+
+export const DISCORD_CDN_HOST_PATTERNS: RegExp[] = [
+  /^cdn\.discordapp\.com$/i,
+  /^media\.discordapp\.net$/i,
+  /^cdn\.discordapp\.net$/i,
+  /^images-ext-\d+\.discordapp\.net$/i,
+];
+
+interface DiscordCdnFetchOptions {
+  timeoutMs?: number;
+  maxBytes?: number | null;
+}
+
+export interface DiscordCdnFetchResult {
+  body: Buffer;
+  contentLength: number | null;
+  contentType: string | null;
+  url: string;
+}
+
+function isPrivateIpv4(ip: string): boolean {
+  const parts = ip.split('.').map((part) => Number.parseInt(part, 10));
+  if (
+    parts.length !== 4 ||
+    parts.some((part) => Number.isNaN(part) || part < 0 || part > 255)
+  ) {
+    return false;
+  }
+  const [a, b] = parts;
+  if (a === 10) return true;
+  if (a === 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  if (a === 0) return true;
+  return false;
+}
+
+function isPrivateIpv6(ip: string): boolean {
+  const lower = ip.toLowerCase().split('%')[0];
+  if (lower === '::1') return true;
+  if (lower.startsWith('fc') || lower.startsWith('fd')) return true;
+  if (/^fe[89ab]/.test(lower)) return true;
+  if (lower.startsWith('::ffff:')) {
+    const mapped = lower.slice('::ffff:'.length);
+    return net.isIP(mapped) === 4 ? isPrivateIpv4(mapped) : false;
+  }
+  return false;
+}
+
+function isPrivateIp(ip: string): boolean {
+  const version = net.isIP(ip);
+  if (version === 4) return isPrivateIpv4(ip);
+  if (version === 6) return isPrivateIpv6(ip);
+  return false;
+}
+
+function isPrivateHostLabel(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase();
+  if (!normalized) return true;
+  if (
+    normalized === 'localhost' ||
+    normalized.endsWith('.localhost') ||
+    normalized.endsWith('.local')
+  ) {
+    return true;
+  }
+  return net.isIP(normalized) > 0 ? isPrivateIp(normalized) : false;
+}
+
+function toHeaderString(
+  headers: IncomingHttpHeaders,
+  headerName: string,
+): string | null {
+  const value = headers[headerName.toLowerCase()];
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) return value[0] || null;
+  return null;
+}
+
+function parseContentLength(headers: IncomingHttpHeaders): number | null {
+  const raw = toHeaderString(headers, 'content-length');
+  if (!raw) return null;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+async function lookupPublicHostAddresses(
+  hostname: string,
+  family: 0 | 4 | 6 = 0,
+): Promise<LookupAddress[]> {
+  const normalized = hostname.trim().toLowerCase();
+  if (isPrivateHostLabel(normalized)) {
+    throw new Error(`ssrf_blocked_host:${normalized}`);
+  }
+
+  const resolved = await lookup(normalized, {
+    all: true,
+    verbatim: true,
+    ...(family === 4 || family === 6 ? { family } : {}),
+  });
+  if (resolved.length === 0) {
+    throw new Error(`dns_lookup_failed:${normalized}`);
+  }
+  if (resolved.some((entry) => isPrivateIp(entry.address))) {
+    throw new Error(`ssrf_blocked_host:${normalized}`);
+  }
+  return resolved;
+}
+
+function createSsrfGuardedLookup(): LookupFunction {
+  return (hostname, options, callback) => {
+    const family =
+      options.family === 4 || options.family === 6 ? options.family : 0;
+    void lookupPublicHostAddresses(hostname, family)
+      .then((resolved) => {
+        if (options.all) {
+          callback(null, resolved, resolved[0]?.family);
+          return;
+        }
+        const first = resolved[0];
+        callback(null, first.address, first.family);
+      })
+      .catch((error) => {
+        callback(
+          error instanceof Error ? (error as NodeJS.ErrnoException) : null,
+          '',
+          undefined,
+        );
+      });
+  };
+}
+
+function parseDiscordCdnUrl(rawUrl: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error(`invalid_url:${rawUrl}`);
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`blocked_url:${rawUrl}`);
+  }
+  if (
+    !DISCORD_CDN_HOST_PATTERNS.some((pattern) => pattern.test(parsed.hostname))
+  ) {
+    throw new Error(`blocked_url:${rawUrl}`);
+  }
+  return parsed;
+}
+
+export function isSafeDiscordCdnUrl(raw: string): boolean {
+  try {
+    parseDiscordCdnUrl(raw);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function fetchDiscordCdnBuffer(
+  rawUrl: string,
+  options: DiscordCdnFetchOptions = {},
+): Promise<DiscordCdnFetchResult> {
+  const parsed = parseDiscordCdnUrl(rawUrl);
+  await lookupPublicHostAddresses(parsed.hostname);
+
+  const timeoutMs = Math.max(1, Math.floor(options.timeoutMs ?? 12_000));
+  const maxBytes =
+    typeof options.maxBytes === 'number' && Number.isFinite(options.maxBytes)
+      ? Math.max(1, Math.floor(options.maxBytes))
+      : null;
+
+  return await new Promise<DiscordCdnFetchResult>((resolve, reject) => {
+    let settled = false;
+    const resolveOnce = (result: DiscordCdnFetchResult) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+    const rejectOnce = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      reject(error instanceof Error ? error : new Error(String(error)));
+    };
+
+    const request = https.request(
+      parsed,
+      {
+        lookup: createSsrfGuardedLookup(),
+        method: 'GET',
+      },
+      (response) => {
+        const statusCode = response.statusCode ?? 0;
+        if (statusCode < 200 || statusCode >= 300) {
+          response.resume();
+          rejectOnce(new Error(`http_${statusCode}`));
+          return;
+        }
+
+        const contentLength = parseContentLength(response.headers);
+        if (
+          maxBytes !== null &&
+          contentLength !== null &&
+          contentLength > maxBytes
+        ) {
+          response.resume();
+          rejectOnce(new Error(`too_large_header:${contentLength}`));
+          return;
+        }
+
+        const chunks: Buffer[] = [];
+        let totalBytes = 0;
+
+        response.on('data', (chunk) => {
+          const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+          totalBytes += buffer.length;
+          if (maxBytes !== null && totalBytes > maxBytes) {
+            response.destroy(new Error(`too_large_body:${totalBytes}`));
+            return;
+          }
+          chunks.push(buffer);
+        });
+        response.on('error', rejectOnce);
+        response.on('end', () => {
+          resolveOnce({
+            body: Buffer.concat(chunks),
+            contentLength,
+            contentType: toHeaderString(response.headers, 'content-type'),
+            url: parsed.toString(),
+          });
+        });
+      },
+    );
+
+    request.setTimeout(timeoutMs, () => {
+      request.destroy(new Error('timeout'));
+    });
+    request.on('error', rejectOnce);
+    request.end();
+  });
+}
+
+export async function fetchDiscordCdnText(
+  rawUrl: string,
+  options: {
+    maxChars: number;
+    maxBytes?: number;
+    timeoutMs?: number;
+  },
+): Promise<string> {
+  const result = await fetchDiscordCdnBuffer(rawUrl, {
+    maxBytes: options.maxBytes ?? Math.max(65_536, options.maxChars * 4),
+    timeoutMs: options.timeoutMs,
+  });
+  const text = result.body.toString('utf8');
+  if (text.length <= options.maxChars) return text;
+  return `${text.slice(0, Math.max(1_000, options.maxChars - 32))}\n...[truncated]`;
+}

--- a/src/channels/discord/media-cache.ts
+++ b/src/channels/discord/media-cache.ts
@@ -1,0 +1,238 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { CONTAINER_SANDBOX_MODE, DATA_DIR } from '../../config/config.js';
+import { logger } from '../../logger.js';
+
+const DISCORD_MEDIA_CACHE_DIR = path.resolve(
+  path.join(DATA_DIR, 'discord-media-cache'),
+);
+const CONTAINER_DISCORD_MEDIA_CACHE_DIR = '/discord-media-cache';
+const DISCORD_MEDIA_CACHE_DIR_MODE = 0o700;
+const DISCORD_MEDIA_CACHE_FILE_MODE = 0o644;
+const DISCORD_MEDIA_CACHE_TTL_MS = 24 * 60 * 60 * 1_000;
+const DISCORD_MEDIA_CACHE_CLEANUP_MIN_INTERVAL_MS = 5 * 60 * 1_000;
+const MAX_SANITIZED_FILENAME_CHARS = 60;
+const INVALID_FILENAME_CHARS_RE = /[^\p{L}\p{N}._-]+/gu;
+const TRIM_FILENAME_PUNCTUATION_RE = /^[-_.]+|[-_.]+$/g;
+
+let cleanupPromise: Promise<void> | null = null;
+let lastCleanupStartedAt = 0;
+
+function normalizeAttachmentPathForContainer(hostPath: string): string | null {
+  const relative = path.relative(DISCORD_MEDIA_CACHE_DIR, hostPath);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative))
+    return null;
+  return `${CONTAINER_DISCORD_MEDIA_CACHE_DIR}/${relative.replace(/\\/g, '/')}`;
+}
+
+export function normalizeAttachmentPathForRuntime(
+  hostPath: string,
+): string | null {
+  if (CONTAINER_SANDBOX_MODE === 'host') {
+    return hostPath;
+  }
+  return normalizeAttachmentPathForContainer(hostPath);
+}
+
+function sanitizeFilenameSegment(value: string): string {
+  return value
+    .normalize('NFKC')
+    .trim()
+    .replace(INVALID_FILENAME_CHARS_RE, '-')
+    .replace(/-+/g, '-')
+    .replace(/\.{2,}/g, '.')
+    .replace(TRIM_FILENAME_PUNCTUATION_RE, '');
+}
+
+export function sanitizeAttachmentFilename(name: string): string {
+  const normalized = name.normalize('NFKC').trim();
+  const parsed = path.parse(normalized);
+  const extensionCore = sanitizeFilenameSegment(
+    parsed.ext.replace(/^\.+/, '').toLowerCase(),
+  );
+  const extension = extensionCore ? `.${extensionCore}` : '';
+  const maxBaseChars = Math.max(
+    1,
+    MAX_SANITIZED_FILENAME_CHARS - extension.length,
+  );
+  const fallbackBase = 'attachment'.slice(0, maxBaseChars);
+  const base =
+    sanitizeFilenameSegment(parsed.name).slice(0, maxBaseChars) || fallbackBase;
+  return `${base}${extension}`;
+}
+
+async function enforcePathMode(filePath: string, mode: number): Promise<void> {
+  try {
+    await fs.promises.chmod(filePath, mode);
+  } catch (error) {
+    logger.debug(
+      {
+        error,
+        filePath,
+        mode: mode.toString(8),
+      },
+      'Best-effort cache permission update failed',
+    );
+  }
+}
+
+async function ensureCacheDirectory(dirPath: string): Promise<void> {
+  await fs.promises.mkdir(dirPath, {
+    mode: DISCORD_MEDIA_CACHE_DIR_MODE,
+    recursive: true,
+  });
+  await enforcePathMode(dirPath, DISCORD_MEDIA_CACHE_DIR_MODE);
+}
+
+async function pruneExpiredEntries(
+  rootDir: string,
+  currentDir: string,
+  expiresBeforeMs: number,
+  stats: { prunedDirs: number; removedFiles: number },
+): Promise<void> {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(currentDir, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw error;
+  }
+
+  for (const entry of entries) {
+    const entryPath = path.join(currentDir, entry.name);
+    let stat: fs.Stats;
+    try {
+      stat = await fs.promises.lstat(entryPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw error;
+    }
+
+    if (stat.isSymbolicLink()) {
+      try {
+        await fs.promises.unlink(entryPath);
+        stats.removedFiles += 1;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      }
+      continue;
+    }
+
+    if (stat.isDirectory()) {
+      await pruneExpiredEntries(rootDir, entryPath, expiresBeforeMs, stats);
+      continue;
+    }
+
+    if (stat.mtimeMs >= expiresBeforeMs) continue;
+
+    try {
+      await fs.promises.rm(entryPath, { force: true, recursive: false });
+      stats.removedFiles += 1;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+  }
+
+  if (currentDir === rootDir) return;
+
+  try {
+    const remainingEntries = await fs.promises.readdir(currentDir);
+    if (remainingEntries.length > 0) return;
+    await fs.promises.rmdir(currentDir);
+    stats.prunedDirs += 1;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT' && code !== 'ENOTEMPTY') throw error;
+  }
+}
+
+export async function cleanupDiscordMediaCache(params?: {
+  nowMs?: number;
+  rootDir?: string;
+  ttlMs?: number;
+}): Promise<void> {
+  const rootDir = params?.rootDir
+    ? path.resolve(params.rootDir)
+    : DISCORD_MEDIA_CACHE_DIR;
+  const ttlMs =
+    typeof params?.ttlMs === 'number' && Number.isFinite(params.ttlMs)
+      ? Math.max(1, Math.floor(params.ttlMs))
+      : DISCORD_MEDIA_CACHE_TTL_MS;
+
+  let stat: fs.Stats;
+  try {
+    stat = await fs.promises.stat(rootDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw error;
+  }
+  if (!stat.isDirectory()) return;
+
+  const expiresBeforeMs = (params?.nowMs ?? Date.now()) - ttlMs;
+  const stats = { prunedDirs: 0, removedFiles: 0 };
+  await pruneExpiredEntries(rootDir, rootDir, expiresBeforeMs, stats);
+  if (stats.removedFiles > 0 || stats.prunedDirs > 0) {
+    logger.debug(
+      {
+        cacheDir: rootDir,
+        prunedDirs: stats.prunedDirs,
+        removedFiles: stats.removedFiles,
+      },
+      'Discord media cache cleanup completed',
+    );
+  }
+}
+
+export function scheduleDiscordMediaCacheCleanup(): void {
+  const now = Date.now();
+  if (
+    cleanupPromise ||
+    now - lastCleanupStartedAt < DISCORD_MEDIA_CACHE_CLEANUP_MIN_INTERVAL_MS
+  ) {
+    return;
+  }
+
+  lastCleanupStartedAt = now;
+  cleanupPromise = cleanupDiscordMediaCache()
+    .catch((error) => {
+      logger.warn(
+        {
+          cacheDir: DISCORD_MEDIA_CACHE_DIR,
+          error,
+        },
+        'Discord media cache cleanup failed',
+      );
+    })
+    .finally(() => {
+      cleanupPromise = null;
+    });
+}
+
+export async function writeDiscordMediaCacheFile(params: {
+  attachmentName: string;
+  buffer: Buffer;
+  messageId: string;
+  order: number;
+}): Promise<{ hostPath: string; runtimePath: string }> {
+  const datePrefix = new Date().toISOString().slice(0, 10);
+  const unique = randomUUID().slice(0, 8);
+  const fileName = `${Date.now()}-${params.messageId}-${String(params.order).padStart(3, '0')}-${unique}-${sanitizeAttachmentFilename(params.attachmentName)}`;
+  const dayDir = path.join(DISCORD_MEDIA_CACHE_DIR, datePrefix);
+  const hostPath = path.join(dayDir, fileName);
+
+  await ensureCacheDirectory(DISCORD_MEDIA_CACHE_DIR);
+  await ensureCacheDirectory(dayDir);
+  await fs.promises.writeFile(hostPath, params.buffer, {
+    mode: DISCORD_MEDIA_CACHE_FILE_MODE,
+  });
+  await enforcePathMode(hostPath, DISCORD_MEDIA_CACHE_FILE_MODE);
+
+  const runtimePath = normalizeAttachmentPathForRuntime(hostPath);
+  if (!runtimePath) {
+    throw new Error(`cache_path_error:${hostPath}`);
+  }
+
+  return { hostPath, runtimePath };
+}

--- a/tests/discord.attachments.test.ts
+++ b/tests/discord.attachments.test.ts
@@ -17,6 +17,7 @@ function makeTempDataDir(): string {
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+  vi.doUnmock('../src/channels/discord/discord-cdn-fetch.js');
   vi.doUnmock('../src/config/config.ts');
   vi.doUnmock('../src/logger.js');
   vi.resetModules();
@@ -32,22 +33,18 @@ describe('buildAttachmentContext', () => {
   test('caches PDF attachments into the media context', async () => {
     const dataDir = makeTempDataDir();
     const fetchBody = Buffer.from('%PDF-1.7\n', 'utf8');
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      headers: {
-        get(name: string) {
-          if (name === 'content-type') {
-            return 'application/pdf';
-          }
-          if (name === 'content-length') return String(fetchBody.length);
-          return null;
-        },
-      },
-      arrayBuffer: async () => fetchBody,
-      text: async () => fetchBody.toString('utf8'),
+    const fetchDiscordCdnBufferMock = vi.fn(async () => ({
+      body: fetchBody,
+      contentLength: fetchBody.length,
+      contentType: 'application/pdf',
+      url: 'https://cdn.discordapp.com/attachments/1/2/spec.pdf',
     }));
 
-    vi.stubGlobal('fetch', fetchMock);
+    vi.doMock('../src/channels/discord/discord-cdn-fetch.js', () => ({
+      fetchDiscordCdnBuffer: fetchDiscordCdnBufferMock,
+      fetchDiscordCdnText: vi.fn(),
+      isSafeDiscordCdnUrl: vi.fn(() => true),
+    }));
     vi.doMock('../src/config/config.ts', () => ({
       CONTAINER_SANDBOX_MODE: 'container',
       DATA_DIR: dataDir,
@@ -80,7 +77,7 @@ describe('buildAttachmentContext', () => {
 
     const result = await buildAttachmentContext([message as never]);
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchDiscordCdnBufferMock).toHaveBeenCalledTimes(1);
     expect(result.context).toContain('[Attachments]');
     expect(result.context).toContain('spec.pdf: PDF attachment cached');
     expect(result.media).toHaveLength(1);
@@ -95,22 +92,19 @@ describe('buildAttachmentContext', () => {
   test('caches office attachments into the media context', async () => {
     const dataDir = makeTempDataDir();
     const fetchBody = Buffer.from('xlsx-payload', 'utf8');
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      headers: {
-        get(name: string) {
-          if (name === 'content-type') {
-            return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
-          }
-          if (name === 'content-length') return String(fetchBody.length);
-          return null;
-        },
-      },
-      arrayBuffer: async () => fetchBody,
-      text: async () => fetchBody.toString('utf8'),
+    const fetchDiscordCdnBufferMock = vi.fn(async () => ({
+      body: fetchBody,
+      contentLength: fetchBody.length,
+      contentType:
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      url: 'https://cdn.discordapp.com/attachments/1/2/financials.xlsx',
     }));
 
-    vi.stubGlobal('fetch', fetchMock);
+    vi.doMock('../src/channels/discord/discord-cdn-fetch.js', () => ({
+      fetchDiscordCdnBuffer: fetchDiscordCdnBufferMock,
+      fetchDiscordCdnText: vi.fn(),
+      isSafeDiscordCdnUrl: vi.fn(() => true),
+    }));
     vi.doMock('../src/config/config.ts', () => ({
       CONTAINER_SANDBOX_MODE: 'container',
       DATA_DIR: dataDir,
@@ -144,7 +138,7 @@ describe('buildAttachmentContext', () => {
 
     const result = await buildAttachmentContext([message as never]);
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchDiscordCdnBufferMock).toHaveBeenCalledTimes(1);
     expect(result.context).toContain('[Attachments]');
     expect(result.context).toContain(
       'financials.xlsx: office attachment cached',
@@ -168,22 +162,18 @@ describe('buildAttachmentContext', () => {
   test('caches audio attachments into the media context', async () => {
     const dataDir = makeTempDataDir();
     const fetchBody = Buffer.from('ogg-payload', 'utf8');
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      headers: {
-        get(name: string) {
-          if (name === 'content-type') {
-            return 'audio/ogg; codecs=opus';
-          }
-          if (name === 'content-length') return String(fetchBody.length);
-          return null;
-        },
-      },
-      arrayBuffer: async () => fetchBody,
-      text: async () => fetchBody.toString('utf8'),
+    const fetchDiscordCdnBufferMock = vi.fn(async () => ({
+      body: fetchBody,
+      contentLength: fetchBody.length,
+      contentType: 'audio/ogg; codecs=opus',
+      url: 'https://cdn.discordapp.com/attachments/1/2/voice-note.ogg',
     }));
 
-    vi.stubGlobal('fetch', fetchMock);
+    vi.doMock('../src/channels/discord/discord-cdn-fetch.js', () => ({
+      fetchDiscordCdnBuffer: fetchDiscordCdnBufferMock,
+      fetchDiscordCdnText: vi.fn(),
+      isSafeDiscordCdnUrl: vi.fn(() => true),
+    }));
     vi.doMock('../src/config/config.ts', () => ({
       CONTAINER_SANDBOX_MODE: 'container',
       DATA_DIR: dataDir,
@@ -216,7 +206,7 @@ describe('buildAttachmentContext', () => {
 
     const result = await buildAttachmentContext([message as never]);
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchDiscordCdnBufferMock).toHaveBeenCalledTimes(1);
     expect(result.context).toContain('[Attachments]');
     expect(result.context).toContain('voice-note.ogg: audio attachment cached');
     expect(result.media).toHaveLength(1);
@@ -226,5 +216,58 @@ describe('buildAttachmentContext', () => {
       path: expect.stringMatching(/^\/discord-media-cache\//),
       sizeBytes: fetchBody.length,
     });
+  });
+
+  test('applies the tighter image size limit before fetching', async () => {
+    const dataDir = makeTempDataDir();
+    const fetchDiscordCdnBufferMock = vi.fn();
+
+    vi.doMock('../src/channels/discord/discord-cdn-fetch.js', () => ({
+      fetchDiscordCdnBuffer: fetchDiscordCdnBufferMock,
+      fetchDiscordCdnText: vi.fn(),
+      isSafeDiscordCdnUrl: vi.fn(() => true),
+    }));
+    vi.doMock('../src/config/config.ts', () => ({
+      CONTAINER_SANDBOX_MODE: 'container',
+      DATA_DIR: dataDir,
+    }));
+    vi.doMock('../src/logger.js', () => ({
+      logger: {
+        debug: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+      },
+    }));
+
+    const { buildAttachmentContext } = await import(
+      '../src/channels/discord/attachments.js'
+    );
+
+    const attachment = {
+      contentType: 'image/png',
+      id: 'att-image-1',
+      name: 'diagram.png',
+      proxyURL: 'https://media.discordapp.net/attachments/1/2/diagram.png',
+      size: 7 * 1024 * 1024,
+      url: 'https://cdn.discordapp.com/attachments/1/2/diagram.png',
+    };
+    const message = {
+      attachments: new Map([[attachment.id, attachment]]),
+      id: 'msg-image-1',
+    };
+
+    const result = await buildAttachmentContext([message as never]);
+
+    expect(fetchDiscordCdnBufferMock).not.toHaveBeenCalled();
+    expect(result.context).toContain('diagram.png: skipped');
+    expect(result.context).toContain('exceeds 6MB limit');
+    expect(result.media).toEqual([
+      expect.objectContaining({
+        filename: 'diagram.png',
+        path: null,
+        sizeBytes: 7 * 1024 * 1024,
+      }),
+    ]);
   });
 });

--- a/tests/discord.cdn-fetch.test.ts
+++ b/tests/discord.cdn-fetch.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.doUnmock('node:dns/promises');
+  vi.doUnmock('node:https');
+  vi.resetModules();
+});
+
+describe('discord CDN fetch helper', () => {
+  test('blocks Discord CDN hosts that resolve to private addresses', async () => {
+    const lookupMock = vi.fn(async () => [
+      { address: '127.0.0.1', family: 4 as const },
+    ]);
+    const requestMock = vi.fn();
+
+    vi.doMock('node:dns/promises', () => ({
+      lookup: lookupMock,
+    }));
+    vi.doMock('node:https', () => ({
+      default: {
+        request: requestMock,
+      },
+    }));
+
+    const { fetchDiscordCdnBuffer } = await import(
+      '../src/channels/discord/discord-cdn-fetch.js'
+    );
+
+    await expect(
+      fetchDiscordCdnBuffer(
+        'https://cdn.discordapp.com/attachments/1/2/image.png',
+      ),
+    ).rejects.toThrow(/ssrf_blocked_host:cdn\.discordapp\.com/);
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+
+  test('returns bytes from allowed Discord CDN responses', async () => {
+    const lookupMock = vi.fn(async () => [
+      { address: '162.159.128.233', family: 4 as const },
+    ]);
+    const requestMock = vi.fn((url, _options, callback) => {
+      let timeoutCallback: (() => void) | null = null;
+      const requestListeners = new Map<
+        string,
+        Array<(error?: Error) => void>
+      >();
+
+      const request = {
+        destroy(error?: Error) {
+          if (error) {
+            for (const listener of requestListeners.get('error') || []) {
+              listener(error);
+            }
+          }
+        },
+        end() {
+          const responseListeners = new Map<
+            string,
+            Array<(value?: Buffer | Error) => void>
+          >();
+          const response = {
+            destroy(error?: Error) {
+              if (error) {
+                for (const listener of responseListeners.get('error') || []) {
+                  listener(error);
+                }
+              }
+            },
+            headers: {
+              'content-length': '7',
+              'content-type': 'image/png',
+            },
+            on(event: string, listener: (value?: Buffer | Error) => void) {
+              const current = responseListeners.get(event) || [];
+              current.push(listener);
+              responseListeners.set(event, current);
+              return response;
+            },
+            resume() {
+              return response;
+            },
+            statusCode: 200,
+          };
+
+          callback(response);
+          for (const listener of responseListeners.get('data') || []) {
+            listener(Buffer.from('pngdata'));
+          }
+          for (const listener of responseListeners.get('end') || []) {
+            listener();
+          }
+        },
+        on(event: string, listener: (error?: Error) => void) {
+          const current = requestListeners.get(event) || [];
+          current.push(listener);
+          requestListeners.set(event, current);
+          return request;
+        },
+        setTimeout(_timeoutMs: number, callbackFn: () => void) {
+          timeoutCallback = callbackFn;
+          return request;
+        },
+      };
+
+      expect(timeoutCallback).toBeNull();
+      expect(String(url)).toContain('cdn.discordapp.com');
+      return request;
+    });
+
+    vi.doMock('node:dns/promises', () => ({
+      lookup: lookupMock,
+    }));
+    vi.doMock('node:https', () => ({
+      default: {
+        request: requestMock,
+      },
+    }));
+
+    const { fetchDiscordCdnBuffer } = await import(
+      '../src/channels/discord/discord-cdn-fetch.js'
+    );
+
+    const result = await fetchDiscordCdnBuffer(
+      'https://cdn.discordapp.com/attachments/1/2/image.png',
+      { timeoutMs: 5000 },
+    );
+
+    expect(result.body.equals(Buffer.from('pngdata'))).toBe(true);
+    expect(result.contentLength).toBe(7);
+    expect(result.contentType).toBe('image/png');
+    expect(lookupMock).toHaveBeenCalled();
+    expect(requestMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/discord.media-cache.test.ts
+++ b/tests/discord.media-cache.test.ts
@@ -1,0 +1,132 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+const tempDirs: string[] = [];
+
+function makeTempDataDir(): string {
+  const dir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-discord-cache-'),
+  );
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.doUnmock('../src/config/config.ts');
+  vi.doUnmock('../src/logger.js');
+  vi.resetModules();
+
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (!dir) continue;
+    fs.rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+describe('discord media cache helpers', () => {
+  test('writeDiscordMediaCacheFile preserves unicode names and enforces permissions', async () => {
+    const dataDir = makeTempDataDir();
+
+    vi.doMock('../src/config/config.ts', () => ({
+      CONTAINER_SANDBOX_MODE: 'container',
+      DATA_DIR: dataDir,
+    }));
+    vi.doMock('../src/logger.js', () => ({
+      logger: {
+        debug: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+      },
+    }));
+
+    const { sanitizeAttachmentFilename, writeDiscordMediaCacheFile } =
+      await import('../src/channels/discord/media-cache.js');
+
+    expect(
+      sanitizeAttachmentFilename(
+        '  Résumé квартал 非常に長い名前の資料 2026 final version ???.pdf  ',
+      ),
+    ).toMatch(/^[\p{L}\p{N}._-]+$/u);
+    expect(
+      sanitizeAttachmentFilename(
+        'Résumé квартал 非常に長い名前の資料 2026 final version ???.pdf',
+      ).length,
+    ).toBeLessThanOrEqual(60);
+
+    const result = await writeDiscordMediaCacheFile({
+      attachmentName:
+        'Résumé квартал 非常に長い名前の資料 2026 final version ???.pdf',
+      buffer: Buffer.from('%PDF-1.7\n', 'utf8'),
+      messageId: 'msg-1',
+      order: 1,
+    });
+
+    expect(result.runtimePath).toMatch(
+      /^\/discord-media-cache\/\d{4}-\d{2}-\d{2}\//,
+    );
+    expect(path.basename(result.hostPath)).toMatch(
+      /Résumé-квартал-非常に長い名前の資料-2026-final-version\.pdf$/u,
+    );
+
+    const cacheRoot = path.join(dataDir, 'discord-media-cache');
+    const rootStat = fs.statSync(cacheRoot);
+    const fileStat = fs.statSync(result.hostPath);
+    expect(rootStat.mode & 0o777).toBe(0o700);
+    expect(fileStat.mode & 0o777).toBe(0o644);
+  });
+
+  test('cleanupDiscordMediaCache removes expired files and prunes empty date directories', async () => {
+    const dataDir = makeTempDataDir();
+
+    vi.doMock('../src/config/config.ts', () => ({
+      CONTAINER_SANDBOX_MODE: 'container',
+      DATA_DIR: dataDir,
+    }));
+    vi.doMock('../src/logger.js', () => ({
+      logger: {
+        debug: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+      },
+    }));
+
+    const { cleanupDiscordMediaCache } = await import(
+      '../src/channels/discord/media-cache.js'
+    );
+
+    const cacheRoot = path.join(dataDir, 'discord-media-cache');
+    const expiredDir = path.join(cacheRoot, '2026-03-12');
+    const freshDir = path.join(cacheRoot, '2026-03-13');
+    const expiredFile = path.join(expiredDir, 'old.pdf');
+    const freshFile = path.join(freshDir, 'fresh.pdf');
+
+    fs.mkdirSync(expiredDir, { mode: 0o700, recursive: true });
+    fs.mkdirSync(freshDir, { mode: 0o700, recursive: true });
+    fs.writeFileSync(expiredFile, 'old');
+    fs.writeFileSync(freshFile, 'fresh');
+
+    const nowMs = Date.now();
+    fs.utimesSync(
+      expiredFile,
+      new Date(nowMs - 2_000),
+      new Date(nowMs - 2_000),
+    );
+    fs.utimesSync(freshFile, new Date(nowMs), new Date(nowMs));
+
+    await cleanupDiscordMediaCache({
+      nowMs,
+      ttlMs: 1_000,
+    });
+
+    expect(fs.existsSync(expiredFile)).toBe(false);
+    expect(fs.existsSync(expiredDir)).toBe(false);
+    expect(fs.existsSync(freshFile)).toBe(true);
+    expect(fs.existsSync(freshDir)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Discord CDN fetch helper with DNS-based SSRF blocking and bounded downloads
- add a media cache helper for Unicode-aware filenames, explicit permissions, 24h TTL cleanup, and empty-dir pruning
- update Discord attachment caching to use per-kind size caps and add focused tests for cache behavior and SSRF protection

## Validation
- `npx biome check --write tests/discord.attachments.test.ts tests/discord.media-cache.test.ts tests/discord.cdn-fetch.test.ts`
- `npm run lint`
- `npm run test:unit`

## Notes
- `npm run format` reports existing repo-wide Biome diagnostics outside this change and did not apply global rewrites