### PR TITLE
feat: notify HybridAI when a bot is used by HybridClaw

### DIFF
--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -107,7 +107,10 @@ import {
   modelRequiresChatbotId,
   resolveModelProvider,
 } from '../providers/factory.js';
-import { fetchHybridAIBots } from '../providers/hybridai-bots.js';
+import {
+  fetchHybridAIBots,
+  updateBotUsedFor,
+} from '../providers/hybridai-bots.js';
 import { resolveModelContextWindowFallback } from '../providers/hybridai-models.js';
 import {
   getLocalModelInfo,
@@ -4025,7 +4028,16 @@ export async function handleGatewayCommand(
         } catch {
           // keep user-supplied value when lookup fails
         }
+        const previousBotId = session.chatbot_id;
         updateSessionChatbot(session.id, resolvedBotId);
+
+        // Notify HybridAI about the bot change (fire-and-forget)
+        const agentId = resolveSessionAgentId(session);
+        if (previousBotId && previousBotId !== resolvedBotId) {
+          void updateBotUsedFor(previousBotId, null);
+        }
+        void updateBotUsedFor(resolvedBotId, agentId);
+
         return plainCommand(
           `Chatbot set to \`${resolvedBotId}\` for this session.`,
         );
@@ -4565,6 +4577,9 @@ export async function handleGatewayCommand(
         await disableFullAutoSession({ sessionId: session.id });
         interruptGatewaySessionExecution(req.sessionId);
         const deleted = memoryService.clearSessionHistory(session.id);
+        if (session.chatbot_id) {
+          void updateBotUsedFor(session.chatbot_id, null);
+        }
         updateSessionChatbot(session.id, null);
         updateSessionModel(session.id, null);
         updateSessionRag(session.id, HYBRIDAI_ENABLE_RAG);

--- a/src/providers/hybridai-bots.ts
+++ b/src/providers/hybridai-bots.ts
@@ -1,5 +1,6 @@
 import { getHybridAIApiKey } from '../auth/hybridai-auth.js';
 import { HYBRIDAI_BASE_URL } from '../config/config.js';
+import { logger } from '../logger.js';
 import type { HybridAIBot } from '../types.js';
 
 interface BotCacheEntry {
@@ -55,4 +56,37 @@ export async function fetchHybridAIBots(options?: {
     botCache = null;
   }
   return bots;
+}
+
+/**
+ * Notify HybridAI that a bot is being used (or no longer used) by HybridClaw.
+ * Fires and logs errors but never throws so callers can treat it as best-effort.
+ */
+export async function updateBotUsedFor(
+  botId: string,
+  agentId: string | null,
+): Promise<void> {
+  const apiKey = getHybridAIApiKey();
+  if (!apiKey) return;
+
+  const usedfor = agentId ? `HybridClaw:${agentId}` : null;
+  const url = `${HYBRIDAI_BASE_URL}/api/bots/settings/${encodeURIComponent(botId)}`;
+  try {
+    const res = await fetch(url, {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ usedfor }),
+    });
+    if (!res.ok) {
+      logger.warn(
+        { botId, usedfor, status: res.status },
+        'Failed to update bot usedfor flag',
+      );
+    }
+  } catch (err) {
+    logger.warn({ botId, usedfor, err }, 'Error updating bot usedfor flag');
+  }
 }


### PR DESCRIPTION
On bot set, PATCH /api/bots/settings/<bot_id> with usedfor=HybridClaw:<agentId>. On bot change or session reset, clear the previous bot's usedfor flag. All API calls are fire-and-forget to avoid blocking the user flow.