### PR TITLE
fix: normalize scheduler cron timezone handling

### DIFF
--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -26,6 +26,9 @@ const CONFIG_ONESHOT_RETRY_MS = 60_000;
 const SCHEDULER_STATE_VERSION = 1;
 const SCHEDULER_STATE_PATH = path.join(DATA_DIR, 'scheduler-jobs-state.json');
 const SQLITE_SECOND_PRECISION_TS_RE = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
+const DEFAULT_SCHEDULER_TIME_ZONE = 'UTC';
+
+type CronWeekdayNumbering = 'crontab' | 'monday-zero-based';
 
 export function parseSchedulerTimestampMs(
   raw: string | null | undefined,
@@ -92,20 +95,30 @@ const schedulerState: SchedulerStateFile = loadSchedulerState();
 
 // --- Prompt framing ---
 
-function formatFireTime(): string {
+function resolveSchedulerTimeZone(timeZone: string | undefined): string {
+  const trimmed = timeZone?.trim();
+  return trimmed || DEFAULT_SCHEDULER_TIME_ZONE;
+}
+
+function formatFireTime(timeZone = DEFAULT_SCHEDULER_TIME_ZONE): string {
   return new Date().toLocaleString('en-US', {
     weekday: 'short',
     month: 'short',
     day: 'numeric',
     hour: '2-digit',
     minute: '2-digit',
+    timeZone,
     timeZoneName: 'short',
   });
 }
 
-export function wrapCronPrompt(jobLabel: string, message: string): string {
-  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
-  return `[cron:${jobLabel}] ${message}\nCurrent time: ${formatFireTime()} (${tz})\n\nReturn your response as plain text; it will be delivered automatically. Execute the instruction directly and do not ask follow-up questions. If the task explicitly calls for messaging a specific external recipient, note who/where it should go instead of sending it yourself.`;
+export function wrapCronPrompt(
+  jobLabel: string,
+  message: string,
+  timeZone = DEFAULT_SCHEDULER_TIME_ZONE,
+): string {
+  const resolvedTz = resolveSchedulerTimeZone(timeZone);
+  return `[cron:${jobLabel}] ${message}\nCurrent time: ${formatFireTime(resolvedTz)} (${resolvedTz})\n\nReturn your response as plain text; it will be delivered automatically. Execute the instruction directly and do not ask follow-up questions. If the task explicitly calls for messaging a specific external recipient, note who/where it should go instead of sending it yourself.`;
 }
 
 function defaultConfigJobMeta(): ConfigJobMeta {
@@ -231,15 +244,104 @@ function resolveConfigJobLabel(
   return candidate || job.id;
 }
 
+function parseMondayZeroBasedWeekdayValue(value: string): number | null {
+  if (!/^\d+$/.test(value)) return null;
+  const parsed = Number.parseInt(value, 10);
+  return parsed >= 0 && parsed <= 6 ? parsed : null;
+}
+
+function expandMondayZeroBasedWeekdayBase(
+  value: string,
+  hasStep: boolean,
+): number[] | null {
+  if (value === '*') return [0, 1, 2, 3, 4, 5, 6];
+  const single = parseMondayZeroBasedWeekdayValue(value);
+  if (single != null) {
+    if (!hasStep) return [single];
+    return Array.from(
+      { length: 7 - single },
+      (_unused, index) => single + index,
+    );
+  }
+
+  const match = value.match(/^(\d+)-(\d+)$/);
+  if (!match) return null;
+  const start = parseMondayZeroBasedWeekdayValue(match[1]);
+  const end = parseMondayZeroBasedWeekdayValue(match[2]);
+  if (start == null || end == null) return null;
+
+  const days: number[] = [];
+  let current = start;
+  while (true) {
+    days.push(current);
+    if (current === end) return days;
+    current = (current + 1) % 7;
+    if (days.length > 7) return null;
+  }
+}
+
+function normalizeMondayZeroBasedCronWeekdaySegment(segment: string): string {
+  const trimmed = segment.trim();
+  if (!trimmed || trimmed === '?') return trimmed;
+
+  const parts = trimmed.split('/');
+  if (parts.length > 2) return trimmed;
+  const [rawBase, rawStep] = parts;
+  const step =
+    rawStep == null
+      ? 1
+      : /^\d+$/.test(rawStep)
+        ? Number.parseInt(rawStep, 10)
+        : null;
+  if (step == null || step <= 0) return trimmed;
+  if (rawBase === '*' && step === 1) return trimmed;
+
+  const baseValues = expandMondayZeroBasedWeekdayBase(rawBase, rawStep != null);
+  if (!baseValues) return trimmed;
+
+  const normalizedValues = baseValues
+    .filter((_value, index) => index % step === 0)
+    .map((value) => String((value + 1) % 7));
+  return normalizedValues.join(',');
+}
+
+function normalizeMondayZeroBasedCronWeekdayField(field: string): string {
+  return field
+    .split(',')
+    .map((segment) => normalizeMondayZeroBasedCronWeekdaySegment(segment))
+    .join(',');
+}
+
+export function normalizeMondayZeroBasedCronExpressionWeekdays(
+  expr: string,
+): string {
+  const fields = expr.trim().split(/\s+/);
+  if (fields.length !== 5 && fields.length !== 6 && fields.length !== 7) {
+    return expr.trim();
+  }
+  const dayOfWeekIndex = fields.length === 5 ? 4 : 5;
+  fields[dayOfWeekIndex] = normalizeMondayZeroBasedCronWeekdayField(
+    fields[dayOfWeekIndex] || '',
+  );
+  return fields.join(' ');
+}
+
 function parseCronExpression(
   expr: string,
-  tz: string | undefined,
+  options: {
+    currentDateMs?: number;
+    tz?: string;
+    weekdayNumbering?: CronWeekdayNumbering;
+  } = {},
 ): ReturnType<typeof CronExpressionParser.parse> {
-  const trimmedTz = tz?.trim();
-  if (trimmedTz) {
-    return CronExpressionParser.parse(expr, { tz: trimmedTz });
-  }
-  return CronExpressionParser.parse(expr);
+  const normalizedExpr =
+    options.weekdayNumbering === 'monday-zero-based'
+      ? normalizeMondayZeroBasedCronExpressionWeekdays(expr)
+      : expr.trim();
+  return CronExpressionParser.parse(normalizedExpr, {
+    currentDate: new Date(options.currentDateMs ?? Date.now()),
+    tz: resolveSchedulerTimeZone(options.tz),
+  });
 }
 
 function nextFireMsForDbTask(
@@ -259,7 +361,9 @@ function nextFireMsForDbTask(
   if (!task.cron_expr) return null;
 
   try {
-    const ms = CronExpressionParser.parse(task.cron_expr)
+    const ms = parseCronExpression(task.cron_expr, {
+      currentDateMs: nowMs,
+    })
       .next()
       .toDate()
       .getTime();
@@ -331,10 +435,11 @@ function nextFireMsForConfigJob(
 
   if (!job.schedule.expr) return null;
   try {
-    const ms = parseCronExpression(
-      job.schedule.expr,
-      job.schedule.tz || undefined,
-    )
+    const ms = parseCronExpression(job.schedule.expr, {
+      currentDateMs: nowMs,
+      tz: job.schedule.tz || undefined,
+      weekdayNumbering: 'monday-zero-based',
+    })
       .next()
       .toDate()
       .getTime();
@@ -416,7 +521,11 @@ async function dispatchConfigJob(job: RuntimeSchedulerJob): Promise<void> {
     job.delivery.kind === 'channel' ? job.delivery.to : 'scheduler';
   const prompt =
     job.action.kind === 'agent_turn'
-      ? wrapCronPrompt(jobLabel, job.action.message)
+      ? wrapCronPrompt(
+          jobLabel,
+          job.action.message,
+          job.schedule.tz || undefined,
+        )
       : job.action.message;
   await taskRunner({
     source: 'config-job',
@@ -551,7 +660,9 @@ async function tick(): Promise<void> {
         }
 
         if (!task.cron_expr) continue;
-        const cron = CronExpressionParser.parse(task.cron_expr);
+        const cron = parseCronExpression(task.cron_expr, {
+          currentDateMs: nowMs,
+        });
         const prev = cron.prev();
         const lastRunMs = parseSchedulerTimestampMs(task.last_run) ?? 0;
 
@@ -671,10 +782,12 @@ async function tick(): Promise<void> {
         }
 
         if (!job.schedule.expr) continue;
-        const cron = parseCronExpression(
-          job.schedule.expr,
-          job.schedule.tz || undefined,
-        );
+        const cron = parseCronExpression(job.schedule.expr, {
+          currentDateMs: nowMs,
+          tz: job.schedule.tz || undefined,
+          // Config-backed jobs can arrive from Monday-first weekday sources upstream.
+          weekdayNumbering: 'monday-zero-based',
+        });
         const prev = cron.prev().toDate();
         const lastRun = meta.lastRun ? new Date(meta.lastRun) : new Date(0);
         if (prev <= lastRun) continue;

--- a/tests/scheduler.cron.test.ts
+++ b/tests/scheduler.cron.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  getScheduledTaskNextRunAt,
+  normalizeMondayZeroBasedCronExpressionWeekdays,
+  wrapCronPrompt,
+} from '../src/scheduler/scheduler.js';
+import type { ScheduledTask } from '../src/types.js';
+
+function makeCronTask(cronExpr: string): ScheduledTask {
+  return {
+    id: 1,
+    session_id: 'session-1',
+    channel_id: 'channel-1',
+    cron_expr: cronExpr,
+    run_at: null,
+    every_ms: null,
+    prompt: 'Say hello',
+    enabled: 1,
+    last_run: null,
+    last_status: null,
+    consecutive_errors: 0,
+    created_at: '2026-03-14T00:00:00.000Z',
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('scheduler cron normalization', () => {
+  test('wrapCronPrompt formats current time in the requested timezone', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-14T12:00:00.000Z'));
+
+    const prompt = wrapCronPrompt(
+      'weekday-report',
+      'Send the report.',
+      'America/Los_Angeles',
+    );
+
+    expect(prompt).toContain('(America/Los_Angeles)');
+    expect(prompt).toMatch(/Current time: .*05:00.*\(America\/Los_Angeles\)/);
+  });
+
+  test('getScheduledTaskNextRunAt uses the supplied clock and UTC by default', () => {
+    const nextRunAt = getScheduledTaskNextRunAt(
+      makeCronTask('0 9 * * *'),
+      new Date('2026-03-14T08:30:00.000Z').getTime(),
+    );
+
+    expect(nextRunAt).toBe('2026-03-14T09:00:00.000Z');
+  });
+
+  test('normalizes monday-zero-based weekday fields before cron parsing', () => {
+    expect(
+      normalizeMondayZeroBasedCronExpressionWeekdays('0 9 * * 0-6/2'),
+    ).toBe('0 9 * * 1,3,5,0');
+  });
+});


### PR DESCRIPTION
## Summary
- make scheduler cron prompt timestamps and cron parsing use an explicit timezone instead of host-local defaults
- pass the scheduler evaluation clock into cron-parser so next-fire calculations are deterministic
- normalize Monday-first zero-based weekday fields for config-backed scheduler jobs and add regression tests

## Validation
- ./node_modules/.bin/biome check --write src/scheduler/scheduler.ts tests/scheduler.cron.test.ts
- ./node_modules/.bin/vitest run tests/scheduler.timestamp.test.ts tests/scheduler.cron.test.ts
- npm run typecheck
- npm run lint