### PR TITLE
fix: audit and gate bot commands

### DIFF
--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -4148,6 +4148,10 @@ export async function handleGatewayCommand(
     }
 
     case 'bot': {
+      const runtime = resolveAgentForRequest({ session });
+      if (resolveModelProvider(runtime.model) !== 'hybridai') {
+        return plainCommand('Only for hybridai provider');
+      }
       const sub = req.args[1]?.toLowerCase();
       if (sub === 'list') {
         try {
@@ -4169,6 +4173,7 @@ export async function handleGatewayCommand(
         const requested = req.args.slice(2).join(' ').trim();
         if (!requested)
           return badCommand('Usage', 'Usage: `bot set <id|name>`');
+        const previousBotId = session.chatbot_id;
         let resolvedBotId = requested;
         try {
           const bots = await fetchHybridAIBots({ cacheTtlMs: BOT_CACHE_TTL });
@@ -4182,13 +4187,26 @@ export async function handleGatewayCommand(
           // keep user-supplied value when lookup fails
         }
         updateSessionChatbot(session.id, resolvedBotId);
+        recordAuditEvent({
+          sessionId: session.id,
+          runId: makeAuditRunId('cmd'),
+          event: {
+            type: 'bot.set',
+            source: 'command',
+            requestedBot: requested,
+            previousBotId,
+            resolvedBotId,
+            changed: previousBotId !== resolvedBotId,
+            userId: req.userId,
+            username: req.username,
+          },
+        });
         return plainCommand(
           `Chatbot set to \`${resolvedBotId}\` for this session.`,
         );
       }
 
       if (sub === 'info') {
-        const runtime = resolveAgentForRequest({ session });
         const botId = runtime.chatbotId || 'Not set';
         let botLabel = botId;
         try {

--- a/tests/gateway-service.audit.test.ts
+++ b/tests/gateway-service.audit.test.ts
@@ -13,6 +13,8 @@ vi.mock('../src/agent/agent.js', () => ({
 }));
 
 const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_DISABLE_CONFIG_WATCHER =
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
 
 function makeTempHome(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-gateway-audit-'));
@@ -30,13 +32,19 @@ afterEach(() => {
   runAgentMock.mockReset();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+  vi.doUnmock('../src/providers/hybridai-bots.ts');
   vi.resetModules();
   restoreEnvVar('HOME', ORIGINAL_HOME);
+  restoreEnvVar(
+    'HYBRIDCLAW_DISABLE_CONFIG_WATCHER',
+    ORIGINAL_DISABLE_CONFIG_WATCHER,
+  );
 });
 
 test('audit command shows recent structured audit events for the current session', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
   vi.resetModules();
 
   const { initDatabase } = await import('../src/memory/db.ts');
@@ -78,6 +86,7 @@ test('audit command shows recent structured audit events for the current session
 test('admin tools exposes recent tool error summaries', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
   vi.resetModules();
 
   const { initDatabase } = await import('../src/memory/db.ts');
@@ -121,9 +130,68 @@ test('admin tools exposes recent tool error summaries', async () => {
   });
 });
 
+test('bot set records a structured audit event for observability export', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
+  vi.resetModules();
+
+  const { initDatabase, getRecentStructuredAuditForSession, getSessionById } =
+    await import('../src/memory/db.ts');
+  initDatabase({ quiet: true });
+
+  vi.doMock('../src/providers/hybridai-bots.ts', () => ({
+    fetchHybridAIBots: vi.fn(async () => [
+      {
+        id: 'bot-research',
+        name: 'Research Bot',
+        description: 'Answers with research context',
+      },
+    ]),
+  }));
+
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+  const result = await handleGatewayCommand({
+    sessionId: 'session-bot-set-audit',
+    guildId: null,
+    channelId: 'channel-bot-set-audit',
+    userId: 'user-1',
+    username: 'alice',
+    args: ['bot', 'set', 'Research Bot'],
+  });
+
+  expect(result).toMatchObject({
+    kind: 'plain',
+    text: 'Chatbot set to `bot-research` for this session.',
+  });
+
+  const events = getRecentStructuredAuditForSession(
+    'session-bot-set-audit',
+    10,
+  );
+  expect(events).toHaveLength(1);
+  expect(events[0]?.event_type).toBe('bot.set');
+  expect(JSON.parse(events[0]?.payload || '{}')).toMatchObject({
+    type: 'bot.set',
+    source: 'command',
+    requestedBot: 'Research Bot',
+    previousBotId: null,
+    resolvedBotId: 'bot-research',
+    changed: true,
+    userId: 'user-1',
+    username: 'alice',
+  });
+  expect(getSessionById('session-bot-set-audit')?.chatbot_id).toBe(
+    'bot-research',
+  );
+});
+
 test('handleGatewayMessage records agent handoff before agent-side timeouts', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
   vi.resetModules();
 
   runAgentMock.mockResolvedValue({

--- a/tests/gateway-service.bot-auth.test.ts
+++ b/tests/gateway-service.bot-auth.test.ts
@@ -5,6 +5,8 @@ import path from 'node:path';
 import { afterEach, expect, test, vi } from 'vitest';
 
 const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_DISABLE_CONFIG_WATCHER =
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
 
 function makeTempHome(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-gateway-bot-auth-'));
@@ -24,11 +26,16 @@ afterEach(() => {
   vi.doUnmock('../src/providers/hybridai-bots.ts');
   vi.resetModules();
   restoreEnvVar('HOME', ORIGINAL_HOME);
+  restoreEnvVar(
+    'HYBRIDCLAW_DISABLE_CONFIG_WATCHER',
+    ORIGINAL_DISABLE_CONFIG_WATCHER,
+  );
 });
 
 test('bot list returns an actionable message on HybridAI auth failure', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
   vi.resetModules();
 
   const { initDatabase } = await import('../src/memory/db.ts');
@@ -54,4 +61,68 @@ test('bot list returns an actionable message on HybridAI auth failure', async ()
     kind: 'error',
     text: 'HybridAI bot commands require valid HybridAI API credentials. Run `hybridclaw hybridai login` and try again.',
   });
+});
+
+test.each([
+  {
+    name: 'list',
+    args: ['bot', 'list'],
+  },
+  {
+    name: 'set',
+    args: ['bot', 'set', 'Research Bot'],
+  },
+  {
+    name: 'info',
+    args: ['bot', 'info'],
+  },
+])('bot $name returns a provider-only message for non-HybridAI session models', async ({
+  args,
+  name,
+}) => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
+  vi.resetModules();
+
+  const fetchHybridAIBots = vi.fn(async () => [
+    {
+      id: 'bot-research',
+      name: 'Research Bot',
+    },
+  ]);
+  vi.doMock('../src/providers/hybridai-bots.ts', () => ({
+    fetchHybridAIBots,
+  }));
+
+  const {
+    getOrCreateSession,
+    getRecentStructuredAuditForSession,
+    getSessionById,
+    initDatabase,
+    updateSessionModel,
+  } = await import('../src/memory/db.ts');
+  initDatabase({ quiet: true });
+
+  const sessionId = `session-bot-provider-${name}`;
+  getOrCreateSession(sessionId, null, `channel-bot-provider-${name}`);
+  updateSessionModel(sessionId, 'openai-codex/gpt-5.4');
+
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+  const result = await handleGatewayCommand({
+    sessionId,
+    guildId: null,
+    channelId: `channel-bot-provider-${name}`,
+    args,
+  });
+
+  expect(result).toEqual({
+    kind: 'plain',
+    text: 'Only for hybridai provider',
+  });
+  expect(fetchHybridAIBots).not.toHaveBeenCalled();
+  expect(getRecentStructuredAuditForSession(sessionId, 10)).toEqual([]);
+  expect(getSessionById(sessionId)?.chatbot_id).toBeNull();
 });

--- a/tests/observability-ingest.test.ts
+++ b/tests/observability-ingest.test.ts
@@ -1,0 +1,169 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, expect, test, vi } from 'vitest';
+
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_HYBRIDAI_API_KEY = process.env.HYBRIDAI_API_KEY;
+const ORIGINAL_DISABLE_CONFIG_WATCHER =
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
+
+function makeTempHome(): string {
+  return fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-observability-ingest-'),
+  );
+}
+
+function restoreEnvVar(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+afterEach(async () => {
+  try {
+    const { stopObservabilityIngest } = await import(
+      '../src/audit/observability-ingest.ts'
+    );
+    stopObservabilityIngest();
+  } catch {
+    // Module may not have been loaded in this test.
+  }
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+  restoreEnvVar('HOME', ORIGINAL_HOME);
+  restoreEnvVar('HYBRIDAI_API_KEY', ORIGINAL_HYBRIDAI_API_KEY);
+  restoreEnvVar(
+    'HYBRIDCLAW_DISABLE_CONFIG_WATCHER',
+    ORIGINAL_DISABLE_CONFIG_WATCHER,
+  );
+});
+
+test('observability ingest forwards bot.set audit events to HybridAI', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  process.env.HYBRIDAI_API_KEY = 'test-key';
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
+  vi.resetModules();
+
+  const { getRuntimeConfig, saveRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  const runtimeConfig = getRuntimeConfig();
+  saveRuntimeConfig({
+    ...runtimeConfig,
+    hybridai: {
+      ...runtimeConfig.hybridai,
+      defaultChatbotId: 'bot-default',
+    },
+    observability: {
+      ...runtimeConfig.observability,
+      enabled: true,
+      botId: 'bot-observability',
+      agentId: 'agent-observability',
+      flushIntervalMs: 60_000,
+      batchMaxEvents: 10,
+    },
+  });
+
+  const fetchMock = vi.fn(
+    async (input: RequestInfo | URL, _init?: RequestInit) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      if (url.endsWith('/api/v1/agent-observability/ingest-token:ensure')) {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            created: true,
+            token: 'ingest-token',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      if (url.endsWith('/api/v1/agent-observability/events:batch')) {
+        return new Response(
+          JSON.stringify({
+            status: 'ok',
+            inserted_events: 1,
+            duplicate_events: 0,
+            broken_chain_events: 0,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    },
+  );
+  vi.stubGlobal('fetch', fetchMock);
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { recordAuditEvent } = await import('../src/audit/audit-events.ts');
+  const { startObservabilityIngest, stopObservabilityIngest } = await import(
+    '../src/audit/observability-ingest.ts'
+  );
+
+  initDatabase({ quiet: true });
+  recordAuditEvent({
+    sessionId: 'session-bot-set-observability',
+    runId: 'cmd-bot-set-observability',
+    event: {
+      type: 'bot.set',
+      source: 'command',
+      requestedBot: 'Research Bot',
+      previousBotId: null,
+      resolvedBotId: 'bot-research',
+      changed: true,
+      userId: 'user-1',
+      username: 'alice',
+    },
+  });
+
+  startObservabilityIngest();
+
+  await vi.waitFor(() => {
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  stopObservabilityIngest();
+
+  const [, ingestCall] = fetchMock.mock.calls;
+  const ingestUrl = String(ingestCall?.[0]);
+  const ingestInit = ingestCall?.[1];
+  const bodyText =
+    typeof ingestInit?.body === 'string'
+      ? ingestInit.body
+      : String(ingestInit?.body ?? '');
+  const payload = JSON.parse(bodyText) as {
+    bot_id: string;
+    agent_id: string;
+    events: Array<Record<string, unknown>>;
+  };
+
+  expect(ingestUrl).toContain('/api/v1/agent-observability/events:batch');
+  expect(payload.bot_id).toBe('bot-observability');
+  expect(payload.agent_id).toBe('agent-observability');
+  expect(payload.events).toHaveLength(1);
+  expect(payload.events[0]).toMatchObject({
+    session_id: 'session-bot-set-observability',
+    run_id: 'cmd-bot-set-observability',
+    event_type: 'bot.set',
+    payload: {
+      type: 'bot.set',
+      source: 'command',
+      requestedBot: 'Research Bot',
+      previousBotId: null,
+      resolvedBotId: 'bot-research',
+      changed: true,
+      userId: 'user-1',
+      username: 'alice',
+    },
+  });
+});


### PR DESCRIPTION
## Summary
- record structured `bot.set` audit events when HybridAI bot selection changes so they flow into the existing observability export
- gate `/bots`, `/bot list`, `/bot set`, and `/bot info` to HybridAI session models and return `Only for hybridai provider` as a plain command response for other providers
- add focused tests for the new audit row, observability export payload, auth handling, and non-HybridAI command gating

## Testing
- ./node_modules/.bin/vitest tests/gateway-service.bot-auth.test.ts tests/gateway-service.audit.test.ts tests/observability-ingest.test.ts
- npm run typecheck
- npm run lint