### PR TITLE
fix: keep tui approvals in numbered flow

### DIFF
--- a/src/tui-approval.ts
+++ b/src/tui-approval.ts
@@ -1,8 +1,57 @@
 import { formatGatewayChatApprovalSummary } from './gateway/chat-approval.js';
 import type { GatewayChatApprovalEvent } from './gateway/gateway-types.js';
 
+export interface TuiApprovalDetails {
+  approvalId: string;
+  intent: string;
+  reason: string;
+  allowSession: boolean;
+  allowAgent: boolean;
+}
+
 export function formatTuiApprovalSummary(
   approval: Pick<GatewayChatApprovalEvent, 'approvalId' | 'intent' | 'reason'>,
 ): string {
   return formatGatewayChatApprovalSummary(approval);
+}
+
+export function parseTuiApprovalPrompt(
+  prompt: string,
+): TuiApprovalDetails | null {
+  const lines = prompt
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const intentLine = lines.find((line) =>
+    line.startsWith('I need your approval before I '),
+  );
+  const reasonLine = lines.find((line) => line.startsWith('Why: '));
+  const approvalIdLine = lines.find((line) => line.startsWith('Approval ID: '));
+
+  if (!intentLine || !reasonLine || !approvalIdLine) {
+    return null;
+  }
+
+  let intent = intentLine.slice('I need your approval before I '.length).trim();
+  if (intent.endsWith('.')) {
+    intent = intent.slice(0, -1).trim();
+  }
+
+  const reason = reasonLine.slice('Why: '.length).trim();
+  const approvalId = approvalIdLine.slice('Approval ID: '.length).trim();
+  if (!intent || !reason || !approvalId) {
+    return null;
+  }
+
+  return {
+    approvalId,
+    intent,
+    reason,
+    allowSession: lines.includes(
+      'Reply `yes for session` to trust this action for this session.',
+    ),
+    allowAgent: lines.includes(
+      'Reply `yes for agent` to trust it for this agent.',
+    ),
+  };
 }

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -39,7 +39,11 @@ import {
   parseModelInfoSummaryFromText,
   parseModelNamesFromListText,
 } from './model-selection.js';
-import { formatTuiApprovalSummary } from './tui-approval.js';
+import {
+  formatTuiApprovalSummary,
+  parseTuiApprovalPrompt,
+  type TuiApprovalDetails,
+} from './tui-approval.js';
 import {
   DEFAULT_TUI_FULLAUTO_STATE,
   deriveTuiFullAutoState,
@@ -271,7 +275,7 @@ let tuiFullAutoState: TuiFullAutoState = DEFAULT_TUI_FULLAUTO_STATE;
 let fullAutoSteeringInFlight = false;
 let tuiPendingApproval: {
   requestId: string;
-  prompt: string;
+  summary: string;
   intent: string;
   reason: string;
   allowSession: boolean;
@@ -327,6 +331,35 @@ function mapApprovalSelectionToCommand(
 function isApprovalResponseContent(content: string): boolean {
   const normalized = content.trim().toLowerCase().replace(/\s+/g, ' ');
   return /^(yes|skip)\s+\S+(?:\s+for\s+(session|agent))?$/.test(normalized);
+}
+
+function resolvePendingApproval(
+  result: GatewayChatResult,
+  streamedApproval: GatewayChatApprovalEvent | null,
+): TuiApprovalDetails | null {
+  if (streamedApproval) {
+    return {
+      approvalId: streamedApproval.approvalId,
+      intent: streamedApproval.intent,
+      reason: streamedApproval.reason,
+      allowSession: streamedApproval.allowSession,
+      allowAgent: streamedApproval.allowAgent,
+    };
+  }
+
+  const pendingApproval = extractGatewayChatApprovalEvent(result);
+  if (pendingApproval) {
+    return {
+      approvalId: pendingApproval.approvalId,
+      intent: pendingApproval.intent,
+      reason: pendingApproval.reason,
+      allowSession: pendingApproval.allowSession,
+      allowAgent: pendingApproval.allowAgent,
+    };
+  }
+
+  const prompt = String(result.result || '').trim();
+  return prompt ? parseTuiApprovalPrompt(prompt) : null;
 }
 
 async function promptApprovalSelection(
@@ -1110,7 +1143,7 @@ async function handleSlashCommand(
           );
           return true;
         }
-        printInfo(tuiPendingApproval.prompt);
+        printInfo(tuiPendingApproval.summary);
         return true;
       }
 
@@ -1236,8 +1269,7 @@ async function processMessage(
     ];
     const hasStreamedText = sawVisibleTextDelta;
     const finalText = result.result || 'No response.';
-    const pendingApproval =
-      streamedApproval || extractGatewayChatApprovalEvent(result);
+    const pendingApproval = resolvePendingApproval(result, streamedApproval);
 
     s.flushVisibleText();
     s.stop();
@@ -1269,15 +1301,16 @@ async function processMessage(
     }
 
     if (pendingApproval) {
+      const summary = formatTuiApprovalSummary(pendingApproval);
       tuiPendingApproval = {
         requestId: pendingApproval.approvalId,
-        prompt: pendingApproval.prompt,
+        summary,
         intent: pendingApproval.intent,
         reason: pendingApproval.reason,
         allowSession: pendingApproval.allowSession,
         allowAgent: pendingApproval.allowAgent,
       };
-      printResponse(formatTuiApprovalSummary(pendingApproval));
+      printResponse(summary);
       const approvalCommand = await promptApprovalSelection(
         rl,
         pendingApproval.approvalId,
@@ -1349,6 +1382,29 @@ async function processFullAutoSteeringMessage(
       }
       if (result.status === 'error') {
         printError(result.error || 'Unknown error');
+        return;
+      }
+      const pendingApproval = resolvePendingApproval(result, null);
+      if (pendingApproval) {
+        const summary = formatTuiApprovalSummary(pendingApproval);
+        tuiPendingApproval = {
+          requestId: pendingApproval.approvalId,
+          summary,
+          intent: pendingApproval.intent,
+          reason: pendingApproval.reason,
+          allowSession: pendingApproval.allowSession,
+          allowAgent: pendingApproval.allowAgent,
+        };
+        printResponse(summary);
+        const approvalCommand = await promptApprovalSelection(
+          rl,
+          pendingApproval.approvalId,
+          pendingApproval.allowSession,
+          pendingApproval.allowAgent,
+        );
+        if (approvalCommand) {
+          await processMessage(approvalCommand, rl);
+        }
         return;
       }
       printResponse(result.result || 'No response.');

--- a/tests/tui-approval.test.ts
+++ b/tests/tui-approval.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from 'vitest';
 
-import { formatTuiApprovalSummary } from '../src/tui-approval.js';
+import {
+  formatTuiApprovalSummary,
+  parseTuiApprovalPrompt,
+} from '../src/tui-approval.js';
 
 test('formats a compact approval summary with intent and reason', () => {
   expect(
@@ -26,4 +29,51 @@ test('omits empty intent and reason lines', () => {
       reason: '',
     }),
   ).toBe('Approval ID: approve123');
+});
+
+test('parses raw runtime approval prompts into TUI approval details', () => {
+  expect(
+    parseTuiApprovalPrompt(
+      [
+        'I need your approval before I control a local app with `open -a Calendar`.',
+        'Why: this command controls host GUI or application state',
+        'If you skip this, i will avoid controlling host applications and keep the task read-only.',
+        'Approval ID: approve123',
+        'Reply `yes` to approve once.',
+        'Reply `yes for session` to trust this action for this session.',
+        'Reply `yes for agent` to trust it for this agent.',
+        'Reply `no` to deny.',
+        'Approval expires in 120s.',
+      ].join('\n'),
+    ),
+  ).toEqual({
+    approvalId: 'approve123',
+    intent: 'control a local app with `open -a Calendar`',
+    reason: 'this command controls host GUI or application state',
+    allowSession: true,
+    allowAgent: true,
+  });
+});
+
+test('parses pinned runtime approval prompts without durable trust options', () => {
+  expect(
+    parseTuiApprovalPrompt(
+      [
+        'I need your approval before I run script `danger.sh`.',
+        'Why: script execution is treated as high risk',
+        'Approval ID: approve123',
+        'Reply `yes` to approve once.',
+        'Reply `yes for session` is unavailable for pinned-sensitive actions.',
+        'Reply `yes for agent` is unavailable for pinned-sensitive actions.',
+        'Reply `no` to deny.',
+        'Approval expires in 120s.',
+      ].join('\n'),
+    ),
+  ).toEqual({
+    approvalId: 'approve123',
+    intent: 'run script `danger.sh`',
+    reason: 'script execution is treated as high risk',
+    allowSession: false,
+    allowAgent: false,
+  });
 });


### PR DESCRIPTION
## Summary
- normalize all TUI approval displays through the compact summary + numbered selection flow
- parse raw runtime approval prompts as a fallback so leaked verbal prompts are still rendered as numbered approvals
- stop /approve view from echoing the raw runtime prompt text

## Validation
- ./node_modules/.bin/vitest tests/tui-approval.test.ts
- npm run typecheck