### PR TITLE
fix: stop retrying runtime config watcher after EMFILE

### DIFF
--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -863,6 +863,7 @@ const listeners = new Set<RuntimeConfigChangeListener>();
 const WATCHER_RETRY_BASE_DELAY_MS = 1_000;
 const WATCHER_RETRY_MAX_DELAY_MS = 60_000;
 const WATCHER_RETRY_MAX_ATTEMPTS = 10;
+const WATCHER_STABLE_RESET_DELAY_MS = 1_000;
 const NON_RETRYABLE_WATCHER_ERROR_CODES = new Set([
   'EMFILE',
   'ENFILE',
@@ -870,6 +871,7 @@ const NON_RETRYABLE_WATCHER_ERROR_CODES = new Set([
 ]);
 let watcherRetryAttempt = 0;
 let watcherRestartTimer: ReturnType<typeof setTimeout> | null = null;
+let watcherStableTimer: ReturnType<typeof setTimeout> | null = null;
 let watcherPermanentlyDisabled = false;
 
 function isRuntimeConfigWatcherDisabled(): boolean {
@@ -890,6 +892,10 @@ function disableWatcher(reason: string): void {
   if (watcherRestartTimer) {
     clearTimeout(watcherRestartTimer);
     watcherRestartTimer = null;
+  }
+  if (watcherStableTimer) {
+    clearTimeout(watcherStableTimer);
+    watcherStableTimer = null;
   }
   console.warn(`[runtime-config] watcher disabled: ${reason}`);
 }
@@ -3408,6 +3414,10 @@ function scheduleReload(trigger: string): void {
 function scheduleWatcherRestart(reason: string): void {
   if (isRuntimeConfigWatcherDisabled() || watcherPermanentlyDisabled) return;
   if (watcherRestartTimer) return;
+  if (watcherStableTimer) {
+    clearTimeout(watcherStableTimer);
+    watcherStableTimer = null;
+  }
   if (watcherRetryAttempt >= WATCHER_RETRY_MAX_ATTEMPTS) {
     console.warn(
       `[runtime-config] watcher disabled after ${WATCHER_RETRY_MAX_ATTEMPTS} retries (${reason})`,
@@ -3429,6 +3439,15 @@ function scheduleWatcherRestart(reason: string): void {
   }, delay);
 }
 
+function markWatcherStable(activeWatcher: fs.FSWatcher): void {
+  if (configWatcher !== activeWatcher) return;
+  watcherRetryAttempt = 0;
+  if (watcherStableTimer) {
+    clearTimeout(watcherStableTimer);
+    watcherStableTimer = null;
+  }
+}
+
 function startWatcher(): void {
   if (isRuntimeConfigWatcherDisabled() || watcherPermanentlyDisabled) return;
   if (configWatcher) return;
@@ -3438,6 +3457,7 @@ function startWatcher(): void {
       path.dirname(CONFIG_PATH),
       { persistent: false },
       (_event, filename) => {
+        markWatcherStable(activeWatcher);
         if (!filename) {
           scheduleReload('unknown');
           return;
@@ -3446,7 +3466,10 @@ function startWatcher(): void {
         scheduleReload(`watch:${filename.toString()}`);
       },
     );
-    watcherRetryAttempt = 0;
+    const activeWatcher = configWatcher;
+    watcherStableTimer = setTimeout(() => {
+      markWatcherStable(activeWatcher);
+    }, WATCHER_STABLE_RESET_DELAY_MS);
     if (watcherRestartTimer) {
       clearTimeout(watcherRestartTimer);
       watcherRestartTimer = null;
@@ -3456,6 +3479,10 @@ function startWatcher(): void {
       const reason = err instanceof Error ? err.message : String(err);
       configWatcher?.close();
       configWatcher = null;
+      if (watcherStableTimer) {
+        clearTimeout(watcherStableTimer);
+        watcherStableTimer = null;
+      }
       if (!shouldRetryWatcherError(err)) {
         disableWatcher(reason);
         return;

--- a/tests/runtime-config.migration-logging.test.ts
+++ b/tests/runtime-config.migration-logging.test.ts
@@ -55,6 +55,17 @@ async function importFreshRuntimeConfig(homeDir: string): Promise<void> {
   await import('../src/config/runtime-config.ts');
 }
 
+type FakeWatcher = EventEmitter &
+  fs.FSWatcher & {
+    close: ReturnType<typeof vi.fn>;
+  };
+
+function createFakeWatcher(): FakeWatcher {
+  const watcher = new EventEmitter() as FakeWatcher;
+  watcher.close = vi.fn();
+  return watcher;
+}
+
 afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
@@ -347,9 +358,9 @@ describe('runtime config migration logging', () => {
         close: ReturnType<typeof vi.fn>;
       };
     fakeWatcher.close = vi.fn();
-    const watchSpy = vi.spyOn(fs, 'watch').mockImplementation(
-      () => fakeWatcher as unknown as fs.FSWatcher,
-    );
+    const watchSpy = vi
+      .spyOn(fs, 'watch')
+      .mockImplementation(() => fakeWatcher as unknown as fs.FSWatcher);
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     await importFreshRuntimeConfig(homeDir);
@@ -373,5 +384,82 @@ describe('runtime config migration logging', () => {
         String(message).includes('[runtime-config] watcher restart in'),
       ),
     ).toBe(false);
+  });
+
+  it('increments retry attempts when restarted watchers fail before they become stable', async () => {
+    const homeDir = makeTempHome();
+    writeRuntimeConfig(homeDir);
+    delete process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
+    vi.useFakeTimers();
+    const retryableError = Object.assign(new Error('EIO: transient watch failure'), {
+      code: 'EIO',
+    });
+    const watchers: FakeWatcher[] = [];
+    const watchSpy = vi.spyOn(fs, 'watch').mockImplementation(() => {
+      const watcher = createFakeWatcher();
+      watchers.push(watcher);
+      return watcher as unknown as fs.FSWatcher;
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await importFreshRuntimeConfig(homeDir);
+
+    setTimeout(() => {
+      watchers[0]?.emit('error', retryableError);
+    }, 0);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    setTimeout(() => {
+      watchers[1]?.emit('error', retryableError);
+    }, 0);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const restartLogs = warnSpy.mock.calls
+      .map(([message]) => String(message))
+      .filter((message) => message.includes('[runtime-config] watcher restart in'));
+
+    expect(watchSpy).toHaveBeenCalledTimes(2);
+    expect(restartLogs.filter((message) => message.includes('attempt 1/10'))).toHaveLength(1);
+    expect(restartLogs.filter((message) => message.includes('attempt 2/10'))).toHaveLength(1);
+  });
+
+  it('resets retry attempts after a restarted watcher stays healthy without file activity', async () => {
+    const homeDir = makeTempHome();
+    writeRuntimeConfig(homeDir);
+    delete process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
+    vi.useFakeTimers();
+    const retryableError = Object.assign(new Error('EIO: transient watch failure'), {
+      code: 'EIO',
+    });
+    const watchers: FakeWatcher[] = [];
+    const watchSpy = vi.spyOn(fs, 'watch').mockImplementation(() => {
+      const watcher = createFakeWatcher();
+      watchers.push(watcher);
+      return watcher as unknown as fs.FSWatcher;
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await importFreshRuntimeConfig(homeDir);
+
+    setTimeout(() => {
+      watchers[0]?.emit('error', retryableError);
+    }, 0);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    setTimeout(() => {
+      watchers[1]?.emit('error', retryableError);
+    }, 0);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const restartLogs = warnSpy.mock.calls
+      .map(([message]) => String(message))
+      .filter((message) => message.includes('[runtime-config] watcher restart in'));
+
+    expect(watchSpy).toHaveBeenCalledTimes(2);
+    expect(restartLogs.filter((message) => message.includes('attempt 1/10'))).toHaveLength(2);
+    expect(restartLogs.filter((message) => message.includes('attempt 2/10'))).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- treat EMFILE, ENFILE, and ENOSPC watcher failures as non-retryable
- disable the runtime config watcher cleanly instead of flooding interactive onboarding with restart logs
- add a regression test covering watch-descriptor exhaustion during runtime config startup

## Testing
- npm run test:unit -- tests/runtime-config.migration-logging.test.ts
- npm run typecheck
- npm run lint