### PR TITLE
ci: revert GHCR auth to GITHUB_TOKEN, drop GitHub App

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -5,12 +5,11 @@ on:
     tags:
       - 'v*'
 
-# No top-level packages: write — the GITHUB_TOKEN is not used for registry
-# auth. A dedicated GitHub App token (GHCR_APP_ID / GHCR_APP_PRIVATE_KEY) is
-# used instead, which is scoped to packages: write only and cannot create
-# runners, open PRs, or perform any other org action.
 permissions:
   contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Validate tag/package.json alignment once; both image jobs depend on this.
@@ -74,13 +73,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Get GHCR token
-        id: ghcr-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
-        with:
-          app-id: ${{ secrets.GHCR_APP_ID }}
-          private-key: ${{ secrets.GHCR_APP_PRIVATE_KEY }}
-
       - name: Resolve agent image tags
         id: meta
         shell: bash
@@ -121,17 +113,15 @@ jobs:
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ steps.ghcr-token.outputs.token }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push agent image
+        id: push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./container
           push: true
-          # provenance and sbom disabled: multi-platform builds via QEMU emit
-          # an extra attestation manifest that confuses some older Docker clients
-          # pulling the image. Re-evaluate when dropping linux/arm64 QEMU builds.
           provenance: false
           sbom: false
           platforms: linux/amd64,linux/arm64
@@ -145,13 +135,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Get GHCR token
-        id: ghcr-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
-        with:
-          app-id: ${{ secrets.GHCR_APP_ID }}
-          private-key: ${{ secrets.GHCR_APP_PRIVATE_KEY }}
 
       - name: Resolve gateway image tags
         id: meta
@@ -193,16 +176,16 @@ jobs:
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ steps.ghcr-token.outputs.token }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push gateway image
+        id: push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./Dockerfile
           push: true
-          # provenance and sbom disabled: see agent job comment above.
           provenance: false
           sbom: false
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## What

Reverts the GitHub App approach from #65 in favour of the standard `GITHUB_TOKEN` pattern recommended by GitHub's own documentation.

## Why

After researching GitHub's docs and community reports, the prior 403 failures were caused by the **org's package access inheritance setting being disabled**, not a fundamental limitation of `GITHUB_TOKEN`. A GitHub App was unnecessary overhead.

GitHub's canonical workflow for GHCR publishing uses `GITHUB_TOKEN` + `packages: write` — no App, no PAT.

## Changes

- Restore `GITHUB_TOKEN` for GHCR login
- Add `attestations: write` + `id-token: write` per GitHub's recommended permissions for container workflows
- Drop `GHCR_APP_ID` / `GHCR_APP_PRIVATE_KEY` secret dependency entirely
- Keep pinned action SHAs from #65 (still a good practice)

## Required org setting (one-time)

An org admin needs to enable package access inheritance at:

**https://github.com/organizations/HybridAIOne/settings/packages** → **Allow inheritance of access permissions**

Without this, `GITHUB_TOKEN` cannot create new packages in the org namespace and the workflow will 403 again.

## Cleanup

After merging, the `hybridclaw-ghcr-publisher` GitHub App and its two repo secrets (`GHCR_APP_ID`, `GHCR_APP_PRIVATE_KEY`) can be deleted.