### PR TITLE
Add gateway web session auth

### DIFF
--- a/src/gateway/auth-token.ts
+++ b/src/gateway/auth-token.ts
@@ -1,0 +1,250 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import fs from 'node:fs';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+const AUTH_SECRET_FILE = '/run/secrets/hybridclaw_auth_secret';
+export const SESSION_COOKIE_NAME = 'hybridclaw_session';
+export const SESSION_TTL_SECONDS = 24 * 60 * 60;
+
+export interface VerifiedAuthTokenPayload extends Record<string, unknown> {
+  exp: number;
+}
+
+interface ParsedToken {
+  headerSegment: string | null;
+  payloadSegment: string;
+  signatureSegment: string;
+  signedPortion: string;
+}
+
+function readSharedSecret(): string {
+  try {
+    const fileSecret = fs.readFileSync(AUTH_SECRET_FILE, 'utf8').trim();
+    if (fileSecret) return fileSecret;
+  } catch {
+    // Fall back to the environment variable.
+  }
+
+  return (process.env.HYBRIDCLAW_AUTH_SECRET || '').trim();
+}
+
+function parseSignedToken(token: string): ParsedToken | null {
+  const trimmed = token.trim();
+  if (!trimmed) return null;
+
+  const parts = trimmed.split('.');
+  if (parts.length === 2) {
+    const [payloadSegment, signatureSegment] = parts;
+    if (!payloadSegment || !signatureSegment) return null;
+    return {
+      headerSegment: null,
+      payloadSegment,
+      signatureSegment,
+      signedPortion: payloadSegment,
+    };
+  }
+
+  if (parts.length === 3) {
+    const [headerSegment, payloadSegment, signatureSegment] = parts;
+    if (!headerSegment || !payloadSegment || !signatureSegment) return null;
+    return {
+      headerSegment,
+      payloadSegment,
+      signatureSegment,
+      signedPortion: `${headerSegment}.${payloadSegment}`,
+    };
+  }
+
+  return null;
+}
+
+function decodeJsonSegment(segment: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(
+      Buffer.from(segment, 'base64url').toString('utf8'),
+    ) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeExpirySeconds(
+  payload: Record<string, unknown>,
+): number | null {
+  const candidate =
+    payload.exp ?? payload.expiresAt ?? payload.expires_at ?? null;
+  const value =
+    typeof candidate === 'string' && /^\d+$/.test(candidate.trim())
+      ? Number(candidate.trim())
+      : candidate;
+
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+
+  return value >= 1_000_000_000_000
+    ? Math.floor(value / 1000)
+    : Math.floor(value);
+}
+
+function safeEqual(value: string, expected: string): boolean {
+  const valueBuffer = Buffer.from(value);
+  const expectedBuffer = Buffer.from(expected);
+  if (valueBuffer.length !== expectedBuffer.length) return false;
+  return timingSafeEqual(valueBuffer, expectedBuffer);
+}
+
+function hasValidSignature(
+  signedPortion: string,
+  signatureSegment: string,
+  secret: string,
+): boolean {
+  const digest = createHmac('sha256', secret).update(signedPortion).digest();
+  return (
+    safeEqual(signatureSegment, digest.toString('base64url')) ||
+    safeEqual(signatureSegment, digest.toString('hex'))
+  );
+}
+
+function verifySignedToken(
+  token: string,
+  secret: string,
+): VerifiedAuthTokenPayload | null {
+  const parsed = parseSignedToken(token);
+  if (!parsed) return null;
+
+  if (
+    !hasValidSignature(parsed.signedPortion, parsed.signatureSegment, secret)
+  ) {
+    return null;
+  }
+
+  if (parsed.headerSegment) {
+    const header = decodeJsonSegment(parsed.headerSegment);
+    if (header?.alg !== 'HS256') return null;
+  }
+
+  const payload = decodeJsonSegment(parsed.payloadSegment);
+  if (!payload) return null;
+
+  const exp = normalizeExpirySeconds(payload);
+  if (!exp || exp <= Math.floor(Date.now() / 1000)) {
+    return null;
+  }
+
+  return { ...payload, exp };
+}
+
+function requireVerifiedToken(token: string): VerifiedAuthTokenPayload {
+  const secret = readSharedSecret();
+  if (!secret) {
+    throw new Error('HybridClaw auth secret is not configured.');
+  }
+
+  const payload = verifySignedToken(token, secret);
+  if (!payload) {
+    throw new Error('Invalid or expired auth token.');
+  }
+
+  return payload;
+}
+
+function signPayload(payload: Record<string, unknown>, secret: string): string {
+  const payloadSegment = Buffer.from(JSON.stringify(payload)).toString(
+    'base64url',
+  );
+  const signatureSegment = createHmac('sha256', secret)
+    .update(payloadSegment)
+    .digest('base64url');
+  return `${payloadSegment}.${signatureSegment}`;
+}
+
+function extractCookieValue(
+  cookieHeader: string | string[] | undefined,
+  cookieName: string,
+): string | null {
+  const source = Array.isArray(cookieHeader)
+    ? cookieHeader.join('; ')
+    : cookieHeader || '';
+  if (!source) return null;
+
+  for (const segment of source.split(';')) {
+    const trimmed = segment.trim();
+    if (!trimmed) continue;
+    const separatorIndex = trimmed.indexOf('=');
+    if (separatorIndex <= 0) continue;
+    const name = trimmed.slice(0, separatorIndex);
+    if (name !== cookieName) continue;
+    return trimmed.slice(separatorIndex + 1);
+  }
+
+  return null;
+}
+
+function appendSetCookie(res: ServerResponse, cookie: string): void {
+  const existing = res.getHeader('Set-Cookie');
+  if (existing === undefined) {
+    res.setHeader('Set-Cookie', cookie);
+    return;
+  }
+
+  if (Array.isArray(existing)) {
+    res.setHeader('Set-Cookie', [...existing.map(String), cookie]);
+    return;
+  }
+
+  res.setHeader('Set-Cookie', [String(existing), cookie]);
+}
+
+export function verifyLaunchToken(token: string): VerifiedAuthTokenPayload {
+  return requireVerifiedToken(token);
+}
+
+export function hasSessionAuth(req: IncomingMessage): boolean {
+  const token = extractCookieValue(req.headers.cookie, SESSION_COOKIE_NAME);
+  if (!token) return false;
+
+  try {
+    return requireVerifiedToken(token).typ === 'session';
+  } catch {
+    return false;
+  }
+}
+
+export function setSessionCookie(
+  res: ServerResponse,
+  payload: Record<string, unknown>,
+): void {
+  const secret = readSharedSecret();
+  if (!secret) {
+    throw new Error('HybridClaw auth secret is not configured.');
+  }
+
+  const issuedAt = Math.floor(Date.now() / 1000);
+  const expiresAt = issuedAt + SESSION_TTL_SECONDS;
+  const token = signPayload(
+    {
+      ...payload,
+      exp: expiresAt,
+      iat: issuedAt,
+      typ: 'session',
+    },
+    secret,
+  );
+
+  appendSetCookie(
+    res,
+    [
+      `${SESSION_COOKIE_NAME}=${token}`,
+      'Path=/',
+      `Max-Age=${SESSION_TTL_SECONDS}`,
+      `Expires=${new Date(expiresAt * 1000).toUTCString()}`,
+      'HttpOnly',
+      'SameSite=Lax',
+    ].join('; '),
+  );
+}

--- a/src/gateway/health.ts
+++ b/src/gateway/health.ts
@@ -13,6 +13,7 @@ import {
   GATEWAY_API_TOKEN,
   HEALTH_HOST,
   HEALTH_PORT,
+  HYBRIDAI_BASE_URL,
   MSTEAMS_WEBHOOK_PATH,
   WEB_API_TOKEN,
 } from '../config/config.js';
@@ -25,6 +26,11 @@ import { resolveInstallPath } from '../infra/install-root.js';
 import { logger } from '../logger.js';
 import { claimQueuedProactiveMessages } from '../memory/db.js';
 import type { PendingApproval, ToolProgressEvent } from '../types.js';
+import {
+  hasSessionAuth,
+  setSessionCookie,
+  verifyLaunchToken,
+} from './auth-token.js';
 import { extractGatewayChatApprovalEvent } from './chat-approval.js';
 import {
   filterChatResultForSession,
@@ -77,6 +83,7 @@ const DISCORD_MEDIA_CACHE_DIR = path.resolve(
   path.join(DATA_DIR, 'discord-media-cache'),
 );
 const MAX_REQUEST_BYTES = 1_000_000; // 1MB
+const HYBRIDAI_LOGIN_PATH = '/login?context=hybridclaw&next=/admin_api_keys';
 
 const SITE_MIME_TYPES: Record<string, string> = {
   '.css': 'text/css; charset=utf-8',
@@ -228,6 +235,52 @@ function sendJson(
 function sendText(res: ServerResponse, statusCode: number, text: string): void {
   res.writeHead(statusCode, { 'Content-Type': 'text/plain; charset=utf-8' });
   res.end(text);
+}
+
+function sendRedirect(
+  res: ServerResponse,
+  statusCode: number,
+  location: string,
+): void {
+  res.writeHead(statusCode, {
+    'Cache-Control': 'no-store',
+    Location: location,
+  });
+  res.end();
+}
+
+function resolveHybridAILoginUrl(): string | null {
+  const baseUrl = HYBRIDAI_BASE_URL.trim().replace(/\/+$/, '');
+  if (!baseUrl) return null;
+  return `${baseUrl}${HYBRIDAI_LOGIN_PATH}`;
+}
+
+function requiresSessionAuth(pathname: string): boolean {
+  return (
+    pathname === '/chat' ||
+    pathname === '/chat.html' ||
+    pathname === '/agents' ||
+    pathname === '/agents.html' ||
+    pathname === '/admin' ||
+    pathname.startsWith('/admin/')
+  );
+}
+
+function ensureSessionAuth(req: IncomingMessage, res: ServerResponse): boolean {
+  if (hasSessionAuth(req)) return true;
+
+  const loginUrl = resolveHybridAILoginUrl();
+  if (!loginUrl) {
+    sendText(
+      res,
+      401,
+      'Unauthorized. Sign in via HybridAI before accessing the web console.',
+    );
+    return false;
+  }
+
+  sendRedirect(res, 302, loginUrl);
+  return false;
 }
 
 function isWithinRoot(candidate: string, root: string): boolean {
@@ -1256,6 +1309,28 @@ export function startHealthServer(): void {
       return;
     }
 
+    if (pathname === '/auth/callback') {
+      if (method !== 'GET') {
+        sendJson(res, 405, { error: 'Method Not Allowed' });
+        return;
+      }
+
+      const token = (url.searchParams.get('token') || '').trim();
+      if (!token) {
+        sendText(res, 401, 'Unauthorized. Invalid or expired auth token.');
+        return;
+      }
+
+      try {
+        const payload = verifyLaunchToken(token);
+        setSessionCookie(res, payload);
+        sendRedirect(res, 302, '/admin');
+      } catch {
+        sendText(res, 401, 'Unauthorized. Invalid or expired auth token.');
+      }
+      return;
+    }
+
     if (pathname.startsWith('/api/')) {
       if (pathname === MSTEAMS_WEBHOOK_PATH && method === 'POST') {
         void handleMSTeamsWebhook(req, res).catch((error) => {
@@ -1414,6 +1489,10 @@ export function startHealthServer(): void {
           sendJson(res, statusCode, { error: errorText });
         }
       })();
+      return;
+    }
+
+    if (requiresSessionAuth(pathname) && !ensureSessionAuth(req, res)) {
       return;
     }
 

--- a/tests/gateway-auth-token.test.ts
+++ b/tests/gateway-auth-token.test.ts
@@ -1,0 +1,124 @@
+import { createHmac } from 'node:crypto';
+
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+const ORIGINAL_HYBRIDCLAW_AUTH_SECRET = process.env.HYBRIDCLAW_AUTH_SECRET;
+
+function signAuthPayload(
+  payload: Record<string, unknown>,
+  secret: string,
+): string {
+  const payloadSegment = Buffer.from(JSON.stringify(payload)).toString(
+    'base64url',
+  );
+  const signature = createHmac('sha256', secret)
+    .update(payloadSegment)
+    .digest('base64url');
+  return `${payloadSegment}.${signature}`;
+}
+
+function makeResponse() {
+  const headers: Record<string, string | string[]> = {};
+
+  return {
+    headers,
+    getHeader(name: string) {
+      return headers[name];
+    },
+    setHeader(name: string, value: string | string[]) {
+      headers[name] = value;
+    },
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.resetModules();
+  if (ORIGINAL_HYBRIDCLAW_AUTH_SECRET === undefined) {
+    delete process.env.HYBRIDCLAW_AUTH_SECRET;
+  } else {
+    process.env.HYBRIDCLAW_AUTH_SECRET = ORIGINAL_HYBRIDCLAW_AUTH_SECRET;
+  }
+});
+
+describe('gateway auth token helpers', () => {
+  test('verifies a valid launch token signed with the shared secret', async () => {
+    process.env.HYBRIDCLAW_AUTH_SECRET = 'unit-secret';
+    const { verifyLaunchToken } = await import('../src/gateway/auth-token.ts');
+    const token = signAuthPayload(
+      {
+        exp: Math.floor(Date.now() / 1000) + 60,
+        sub: 'user-1',
+      },
+      'unit-secret',
+    );
+
+    expect(verifyLaunchToken(token)).toMatchObject({
+      sub: 'user-1',
+    });
+  });
+
+  test('rejects tampered or expired launch tokens', async () => {
+    process.env.HYBRIDCLAW_AUTH_SECRET = 'unit-secret';
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-17T12:00:00.000Z'));
+    const { verifyLaunchToken } = await import('../src/gateway/auth-token.ts');
+    const validToken = signAuthPayload(
+      {
+        exp: Math.floor(Date.now() / 1000) + 60,
+        sub: 'user-1',
+      },
+      'unit-secret',
+    );
+    const expiredToken = signAuthPayload(
+      {
+        exp: Math.floor(Date.now() / 1000) - 1,
+        sub: 'user-1',
+      },
+      'unit-secret',
+    );
+
+    expect(() => verifyLaunchToken(`${validToken}x`)).toThrow(
+      'Invalid or expired auth token.',
+    );
+    expect(() => verifyLaunchToken(expiredToken)).toThrow(
+      'Invalid or expired auth token.',
+    );
+  });
+
+  test('sets an HttpOnly signed session cookie that hasSessionAuth accepts until it expires', async () => {
+    process.env.HYBRIDCLAW_AUTH_SECRET = 'unit-secret';
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-17T12:00:00.000Z'));
+    const { SESSION_COOKIE_NAME, hasSessionAuth, setSessionCookie } =
+      await import('../src/gateway/auth-token.ts');
+    const res = makeResponse();
+
+    setSessionCookie(res as never, { sub: 'user-1' });
+
+    const setCookieHeader = res.headers['Set-Cookie'];
+    expect(setCookieHeader).toEqual(
+      expect.stringContaining(`${SESSION_COOKIE_NAME}=`),
+    );
+    expect(setCookieHeader).toEqual(expect.stringContaining('HttpOnly'));
+    expect(setCookieHeader).toEqual(expect.stringContaining('Max-Age=86400'));
+
+    const sessionCookie = String(setCookieHeader).split(';', 1)[0];
+    expect(
+      hasSessionAuth({
+        headers: {
+          cookie: sessionCookie,
+        },
+      } as never),
+    ).toBe(true);
+
+    vi.setSystemTime(new Date('2026-03-18T12:00:01.000Z'));
+    expect(
+      hasSessionAuth({
+        headers: {
+          cookie: sessionCookie,
+        },
+      } as never),
+    ).toBe(false);
+  });
+});

--- a/tests/gateway-health.test.ts
+++ b/tests/gateway-health.test.ts
@@ -1,3 +1,4 @@
+import { createHmac } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -6,6 +7,20 @@ import { Readable } from 'node:stream';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 const tempDirs: string[] = [];
+const ORIGINAL_HYBRIDCLAW_AUTH_SECRET = process.env.HYBRIDCLAW_AUTH_SECRET;
+
+function signAuthPayload(
+  payload: Record<string, unknown>,
+  secret: string,
+): string {
+  const payloadSegment = Buffer.from(JSON.stringify(payload)).toString(
+    'base64url',
+  );
+  const signature = createHmac('sha256', secret)
+    .update(payloadSegment)
+    .digest('base64url');
+  return `${payloadSegment}.${signature}`;
+}
 
 function makeTempDocsDir(): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-health-'));
@@ -69,16 +84,29 @@ function makeRequest(params: {
 }
 
 function makeResponse() {
+  const headers: Record<string, string | string[]> = {};
+  const resolveHeaderKey = (name: string): string => {
+    const existing = Object.keys(headers).find(
+      (key) => key.toLowerCase() === name.toLowerCase(),
+    );
+    return existing || name;
+  };
   const response = {
     writableEnded: false,
     headersSent: false,
     destroyed: false,
     statusCode: 0,
-    headers: {} as Record<string, string>,
+    headers,
     body: '',
-    writeHead(statusCode: number, headers: Record<string, string>) {
+    setHeader(name: string, value: string | string[]) {
+      headers[resolveHeaderKey(name)] = value;
+    },
+    getHeader(name: string) {
+      return headers[resolveHeaderKey(name)];
+    },
+    writeHead(statusCode: number, headers: Record<string, string | string[]>) {
       response.statusCode = statusCode;
-      response.headers = headers;
+      Object.assign(response.headers, headers);
       response.headersSent = true;
     },
     write(chunk: unknown) {
@@ -127,8 +155,16 @@ async function importFreshHealth(options?: {
   dataDir?: string;
   webApiToken?: string;
   gatewayApiToken?: string;
+  authSecret?: string;
+  hybridAiBaseUrl?: string;
 }) {
   vi.resetModules();
+
+  if (options?.authSecret === undefined) {
+    delete process.env.HYBRIDCLAW_AUTH_SECRET;
+  } else {
+    process.env.HYBRIDCLAW_AUTH_SECRET = options.authSecret;
+  }
 
   const docsDir = options?.docsDir || makeTempDocsDir();
   const dataDir = options?.dataDir || makeTempDataDir();
@@ -501,6 +537,7 @@ async function importFreshHealth(options?: {
     GATEWAY_API_TOKEN: options?.gatewayApiToken || '',
     HEALTH_HOST: '127.0.0.1',
     HEALTH_PORT: 9090,
+    HYBRIDAI_BASE_URL: options?.hybridAiBaseUrl || 'https://hybridai.one',
     MSTEAMS_WEBHOOK_PATH: '/api/msteams/messages',
     WEB_API_TOKEN: options?.webApiToken || '',
   }));
@@ -612,6 +649,11 @@ afterEach(() => {
   vi.doUnmock('../src/channels/message/tool-actions.js');
   vi.doUnmock('../src/channels/discord/tool-actions.js');
   vi.resetModules();
+  if (ORIGINAL_HYBRIDCLAW_AUTH_SECRET === undefined) {
+    delete process.env.HYBRIDCLAW_AUTH_SECRET;
+  } else {
+    process.env.HYBRIDCLAW_AUTH_SECRET = ORIGINAL_HYBRIDCLAW_AUTH_SECRET;
+  }
   while (tempDirs.length > 0) {
     const dir = tempDirs.pop();
     if (!dir) continue;
@@ -661,9 +703,38 @@ describe('gateway health server', () => {
     expect(res.body).toContain('<h1>Docs</h1>');
   });
 
-  test('serves the standalone agents docs page via /agents alias', async () => {
+  test('redirects protected docs routes to HybridAI login when no session cookie is present', async () => {
     const state = await importFreshHealth();
     const req = makeRequest({ url: '/agents' });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.Location).toBe(
+      'https://hybridai.one/login?context=hybridclaw&next=/admin_api_keys',
+    );
+  });
+
+  test('serves the standalone agents docs page with a valid session cookie', async () => {
+    const authSecret = 'health-secret';
+    const issuedAtSeconds = Math.floor(Date.now() / 1000);
+    const sessionToken = signAuthPayload(
+      {
+        exp: issuedAtSeconds + 60,
+        iat: issuedAtSeconds,
+        sub: 'user-1',
+        typ: 'session',
+      },
+      authSecret,
+    );
+    const state = await importFreshHealth({ authSecret });
+    const req = makeRequest({
+      url: '/agents',
+      headers: {
+        cookie: `hybridclaw_session=${sessionToken}`,
+      },
+    });
     const res = makeResponse();
 
     state.handler(req as never, res as never);
@@ -673,9 +744,21 @@ describe('gateway health server', () => {
     expect(res.body).toContain('<h1>Agents</h1>');
   });
 
-  test('serves admin SPA files and falls back to index.html', async () => {
-    const state = await importFreshHealth();
+  test('serves admin SPA files and falls back to index.html with a valid session cookie', async () => {
+    const authSecret = 'health-secret';
+    const issuedAtSeconds = Math.floor(Date.now() / 1000);
+    const sessionToken = signAuthPayload(
+      {
+        exp: issuedAtSeconds + 60,
+        iat: issuedAtSeconds,
+        sub: 'user-1',
+        typ: 'session',
+      },
+      authSecret,
+    );
+    const state = await importFreshHealth({ authSecret });
     const req = makeRequest({ url: '/admin/sessions' });
+    req.headers.cookie = `hybridclaw_session=${sessionToken}`;
     const res = makeResponse();
 
     state.handler(req as never, res as never);
@@ -683,6 +766,49 @@ describe('gateway health server', () => {
     expect(res.statusCode).toBe(200);
     expect(res.headers['Content-Type']).toBe('text/html; charset=utf-8');
     expect(res.body).toContain('<h1>Admin</h1>');
+  });
+
+  test('accepts a valid launch token on /auth/callback, sets a session cookie, and redirects to /admin', async () => {
+    const authSecret = 'health-secret';
+    const launchToken = signAuthPayload(
+      {
+        exp: Math.floor(Date.now() / 1000) + 60,
+        sub: 'user-1',
+      },
+      authSecret,
+    );
+    const state = await importFreshHealth({ authSecret });
+    const req = makeRequest({
+      url: `/auth/callback?token=${encodeURIComponent(launchToken)}`,
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.Location).toBe('/admin');
+    expect(res.headers['Set-Cookie']).toEqual(
+      expect.stringContaining('hybridclaw_session='),
+    );
+    expect(res.headers['Set-Cookie']).toEqual(
+      expect.stringContaining('HttpOnly'),
+    );
+    expect(res.headers['Set-Cookie']).toEqual(
+      expect.stringContaining('SameSite=Lax'),
+    );
+  });
+
+  test('returns 401 from /auth/callback when the launch token is invalid', async () => {
+    const state = await importFreshHealth({ authSecret: 'health-secret' });
+    const req = makeRequest({
+      url: '/auth/callback?token=bad-token',
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toBe('Unauthorized. Invalid or expired auth token.');
   });
 
   test('returns history for authorized loopback API requests', async () => {


### PR DESCRIPTION
## Summary
- add launch-token verification and signed session cookie helpers for the gateway
- add `GET /auth/callback` and gate `/chat`, `/agents`, and `/admin*` behind session auth
- leave `/health` and `/api/*` on the existing bearer-token auth flow

## Testing
- npm run test:unit -- tests/gateway-auth-token.test.ts tests/gateway-health.test.ts
- npm run typecheck
- npm run lint