### PR TITLE
fix: tighten doctor checks and foreground gateway pid handling

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import readline from 'node:readline/promises';
@@ -52,7 +52,6 @@ import {
 } from './config/runtime-config.js';
 import {
   ensureGatewayRunDir,
-  findGatewayPidByPort,
   GATEWAY_LOG_FILE_ENV,
   GATEWAY_LOG_PATH,
   GATEWAY_STDIO_TO_LOG_ENV,
@@ -78,6 +77,9 @@ import { sleep } from './utils/sleep.js';
 
 const PACKAGE_NAME = '@hybridaione/hybridclaw';
 let cachedInstallRoot: string | null = null;
+let foregroundGatewayExitHandler: (() => void) | null = null;
+let foregroundGatewaySigintHandler: (() => void) | null = null;
+let foregroundGatewaySigtermHandler: (() => void) | null = null;
 
 function resolveWhatsAppSetupSettleMs(): number {
   const raw = String(
@@ -115,6 +117,132 @@ function resolveInstallRoot(): string {
 
   cachedInstallRoot = process.cwd();
   return cachedInstallRoot;
+}
+
+function cleanupForegroundGatewayPidFile(): void {
+  try {
+    removeGatewayPidFile();
+  } catch {
+    // best effort during process teardown
+  }
+}
+
+function removeForegroundGatewayPidHandlers(): void {
+  if (foregroundGatewayExitHandler) {
+    process.removeListener('exit', foregroundGatewayExitHandler);
+    foregroundGatewayExitHandler = null;
+  }
+  if (foregroundGatewaySigintHandler) {
+    process.removeListener('SIGINT', foregroundGatewaySigintHandler);
+    foregroundGatewaySigintHandler = null;
+  }
+  if (foregroundGatewaySigtermHandler) {
+    process.removeListener('SIGTERM', foregroundGatewaySigtermHandler);
+    foregroundGatewaySigtermHandler = null;
+  }
+}
+
+function registerForegroundGatewayPid(commandName: string): {
+  markReady: () => void;
+  cleanup: () => void;
+} {
+  removeForegroundGatewayPidHandlers();
+  cleanupForegroundGatewayPidFile();
+
+  let ready = false;
+  const handleExit = () => {
+    cleanupForegroundGatewayPidFile();
+  };
+  const handleSignal = (signal: NodeJS.Signals) => {
+    cleanupForegroundGatewayPidFile();
+    removeForegroundGatewayPidHandlers();
+    if (ready) return;
+    try {
+      process.kill(process.pid, signal);
+    } catch {
+      // best effort; allow the current process state to unwind
+    }
+  };
+
+  foregroundGatewayExitHandler = handleExit;
+  foregroundGatewaySigintHandler = () => {
+    handleSignal('SIGINT');
+  };
+  foregroundGatewaySigtermHandler = () => {
+    handleSignal('SIGTERM');
+  };
+
+  process.on('exit', foregroundGatewayExitHandler);
+  process.on('SIGINT', foregroundGatewaySigintHandler);
+  process.on('SIGTERM', foregroundGatewaySigtermHandler);
+
+  writeGatewayPid({
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+    cwd: process.cwd(),
+    command:
+      process.argv.length > 1
+        ? [process.execPath, ...process.argv.slice(1)]
+        : [commandName],
+  });
+
+  return {
+    markReady: () => {
+      ready = true;
+    },
+    cleanup: () => {
+      cleanupForegroundGatewayPidFile();
+      removeForegroundGatewayPidHandlers();
+    },
+  };
+}
+
+function parseGatewayBaseUrl(): URL | null {
+  try {
+    return new URL(GATEWAY_BASE_URL);
+  } catch {
+    return null;
+  }
+}
+
+function isLocalGatewayHost(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase();
+  return (
+    normalized === '127.0.0.1' ||
+    normalized === 'localhost' ||
+    normalized === '::1'
+  );
+}
+
+function resolveGatewayListenPort(url: URL): number {
+  if (url.port) {
+    const parsed = Number.parseInt(url.port, 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return url.protocol === 'https:' ? 443 : 80;
+}
+
+function findGatewayPidByPort(): number | null {
+  const parsed = parseGatewayBaseUrl();
+  if (!parsed || !isLocalGatewayHost(parsed.hostname)) return null;
+  const port = resolveGatewayListenPort(parsed);
+
+  const result = spawnSync(
+    'lsof',
+    ['-nP', `-iTCP:${port}`, '-sTCP:LISTEN', '-t'],
+    {
+      encoding: 'utf-8',
+    },
+  );
+  if (result.error) return null;
+  const output = (result.stdout || '').trim();
+  if (!output) return null;
+
+  const firstPid = output
+    .split('\n')
+    .map((line) => Number.parseInt(line.trim(), 10))
+    .find((pid) => Number.isFinite(pid) && pid > 0);
+  return firstPid && Number.isFinite(firstPid) ? firstPid : null;
 }
 
 async function ensureRuntimeContainer(
@@ -637,7 +765,7 @@ function printDoctorUsage(): void {
   hybridclaw doctor
   hybridclaw doctor --fix
   hybridclaw doctor --json
-  hybridclaw doctor <runtime|gateway|config|credentials|database|providers|local-backends|docker|channels|security|disk>
+  hybridclaw doctor <runtime|gateway|config|credentials|database|providers|local-backends|docker|channels|skills|security|disk>
 
 Notes:
   - Runs independent diagnostic categories in parallel and reports ok, warning, and error states.
@@ -849,13 +977,20 @@ async function runGatewayForeground(
     console.log(`${commandName}: forcing gateway log level to debug.`);
   }
   ensureGatewayRunDir();
+  const foregroundGatewayPid = registerForegroundGatewayPid(commandName);
   if (process.env[GATEWAY_STDIO_TO_LOG_ENV] === '1') {
     delete process.env[GATEWAY_LOG_FILE_ENV];
   } else {
     process.env[GATEWAY_LOG_FILE_ENV] = GATEWAY_LOG_PATH;
   }
   await ensureRuntimeContainer(commandName, true, sandboxMode);
-  await import('./gateway/gateway.js');
+  try {
+    await import('./gateway/gateway.js');
+    foregroundGatewayPid.markReady();
+  } catch (error) {
+    foregroundGatewayPid.cleanup();
+    throw error;
+  }
 }
 
 async function startGatewayBackend(

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -12,6 +12,7 @@ import {
   normalizeComponent,
   normalizeDoctorComponentList,
   summarizeCounts,
+  toErrorMessage,
 } from './doctor/utils.js';
 
 export type {
@@ -69,10 +70,7 @@ async function runChecks(checks: DoctorCheck[]): Promise<DiagResult[]> {
       return;
     }
 
-    const message =
-      result.reason instanceof Error
-        ? result.reason.message
-        : String(result.reason);
+    const message = toErrorMessage(result.reason);
     results.push(
       makeResult(
         check.category,
@@ -159,7 +157,7 @@ async function applyFixes(
           category: result.category,
           label: result.label,
           status: 'failed',
-          message: error instanceof Error ? error.message : String(error),
+          message: toErrorMessage(error),
         });
 
         for (
@@ -182,10 +180,7 @@ async function applyFixes(
               category: appliedFix.category,
               label: appliedFix.label,
               status: 'rollback_failed',
-              message:
-                rollbackError instanceof Error
-                  ? rollbackError.message
-                  : String(rollbackError),
+              message: toErrorMessage(rollbackError),
             });
           }
         }
@@ -239,9 +234,20 @@ export async function runDoctor(args: DoctorArgs): Promise<DoctorReport> {
   };
 }
 
-function fixSymbol(status: DoctorFixOutcome['status']): string {
+type RenderedFixStatus = Extract<
+  DoctorFixOutcome['status'],
+  'applied' | 'failed' | 'skipped'
+>;
+
+function isRenderedFixStatus(
+  status: DoctorFixOutcome['status'],
+): status is RenderedFixStatus {
+  return status === 'applied' || status === 'failed' || status === 'skipped';
+}
+
+function fixSymbol(status: RenderedFixStatus): string {
   if (status === 'applied') return '✓';
-  if (status === 'failed' || status === 'rollback_failed') return '✖';
+  if (status === 'failed') return '✖';
   return '⚠';
 }
 
@@ -260,9 +266,17 @@ export function renderDoctorReport(report: DoctorReport): string {
     );
   }
 
-  if (report.fixes.length > 0) {
+  const renderedFixes = report.fixes.filter(
+    (
+      fix,
+    ): fix is DoctorFixOutcome & {
+      status: RenderedFixStatus;
+    } => isRenderedFixStatus(fix.status),
+  );
+
+  if (renderedFixes.length > 0) {
     lines.push('');
-    for (const fix of report.fixes) {
+    for (const fix of renderedFixes) {
       lines.push(
         `${fixSymbol(fix.status)} Fix ${fix.label.padEnd(labelWidth)}  ${fix.message}`,
       );
@@ -287,7 +301,7 @@ export async function runDoctorCli(argv: string[]): Promise<number> {
     }
     return report.summary.exitCode;
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
+    console.error(toErrorMessage(error));
     return 1;
   }
 }

--- a/src/doctor/checks/config.ts
+++ b/src/doctor/checks/config.ts
@@ -13,6 +13,7 @@ import {
   makeResult,
   readUnixMode,
   shortenHomePath,
+  toErrorMessage,
 } from '../utils.js';
 
 export async function checkConfig(): Promise<DiagResult[]> {
@@ -39,7 +40,7 @@ export async function checkConfig(): Promise<DiagResult[]> {
         'config',
         'Config',
         'error',
-        `${displayPath} is not valid JSON (${error instanceof Error ? error.message : String(error)})`,
+        `${displayPath} is not valid JSON (${toErrorMessage(error)})`,
       ),
     ];
   }
@@ -92,7 +93,7 @@ export async function checkConfig(): Promise<DiagResult[]> {
       severity,
       message,
       writableByOthers
-        ? buildChmodFix(filePath, 0o644, `Restrict ${displayPath} permissions`)
+        ? buildChmodFix(filePath, 0o600, `Restrict ${displayPath} permissions`)
         : undefined,
     ),
   ];

--- a/src/doctor/checks/credentials.ts
+++ b/src/doctor/checks/credentials.ts
@@ -8,6 +8,7 @@ import {
   makeResult,
   readUnixMode,
   shortenHomePath,
+  toErrorMessage,
 } from '../utils.js';
 
 export async function checkCredentials(): Promise<DiagResult[]> {
@@ -46,7 +47,7 @@ export async function checkCredentials(): Promise<DiagResult[]> {
         'credentials',
         'Credentials',
         'error',
-        `${displayPath} is not valid JSON (${error instanceof Error ? error.message : String(error)})`,
+        `${displayPath} is not valid JSON (${toErrorMessage(error)})`,
       ),
     ];
   }

--- a/src/doctor/checks/database.ts
+++ b/src/doctor/checks/database.ts
@@ -3,7 +3,12 @@ import Database from 'better-sqlite3';
 import { DB_PATH } from '../../config/config.js';
 import { DATABASE_SCHEMA_VERSION, initDatabase } from '../../memory/db.js';
 import type { DiagResult } from '../types.js';
-import { formatBytes, makeResult, shortenHomePath } from '../utils.js';
+import {
+  formatBytes,
+  makeResult,
+  shortenHomePath,
+  toErrorMessage,
+} from '../utils.js';
 
 export async function checkDatabase(): Promise<DiagResult[]> {
   const dbPath = DB_PATH;
@@ -59,7 +64,7 @@ export async function checkDatabase(): Promise<DiagResult[]> {
         'database',
         'Database',
         'error',
-        `Failed to open ${displayPath} (${error instanceof Error ? error.message : String(error)})`,
+        `Failed to open ${displayPath} (${toErrorMessage(error)})`,
       ),
     ];
   }

--- a/src/doctor/checks/disk.ts
+++ b/src/doctor/checks/disk.ts
@@ -13,12 +13,17 @@ export async function checkDisk(): Promise<DiagResult[]> {
   const freeBytes = readDiskFreeBytes(DATA_DIR);
   const dbSize = fs.existsSync(DB_PATH) ? fs.statSync(DB_PATH).size : 0;
   const auditSize = readDirSize(path.join(DATA_DIR, 'audit'));
+  const freeSpaceKnown = freeBytes != null;
   return [
     makeResult(
       'disk',
       'Disk',
-      freeBytes >= 100 * 1024 * 1024 ? 'ok' : 'error',
-      `${formatBytes(freeBytes)} free, DB ${formatBytes(dbSize)}, audit ${formatBytes(auditSize)}`,
+      !freeSpaceKnown
+        ? 'warn'
+        : freeBytes >= 100 * 1024 * 1024
+          ? 'ok'
+          : 'error',
+      `${freeSpaceKnown ? `${formatBytes(freeBytes)} free` : 'free space unavailable'}, DB ${formatBytes(dbSize)}, audit ${formatBytes(auditSize)}`,
     ),
   ];
 }

--- a/src/doctor/checks/gateway.ts
+++ b/src/doctor/checks/gateway.ts
@@ -7,18 +7,24 @@ import {
 import type { GatewayStatus } from '../../gateway/gateway-types.js';
 import { restartGatewayFromDoctor } from '../gateway-repair.js';
 import type { DiagResult } from '../types.js';
-import { formatDuration, makeResult } from '../utils.js';
+import { formatDuration, makeResult, toErrorMessage } from '../utils.js';
 
 export async function checkGateway(): Promise<DiagResult[]> {
   const pidState = readGatewayPid();
   const pidRunning = Boolean(pidState && isPidRunning(pidState.pid));
   let health: GatewayStatus | null = null;
   let apiError = '';
+  const removeStalePidFix: NonNullable<DiagResult['fix']> = {
+    summary: 'Remove the stale gateway PID file',
+    apply: async () => {
+      removeGatewayPidFile();
+    },
+  };
 
   try {
     health = await gatewayHealth();
   } catch (error) {
-    apiError = error instanceof Error ? error.message : String(error);
+    apiError = toErrorMessage(error);
   }
 
   if (health && pidRunning) {
@@ -41,14 +47,7 @@ export async function checkGateway(): Promise<DiagResult[]> {
         pidState
           ? 'Gateway reachable, but the local PID file is stale'
           : 'Gateway reachable, but no managed PID file is present',
-        pidState
-          ? {
-              summary: 'Remove the stale gateway PID file',
-              apply: async () => {
-                removeGatewayPidFile();
-              },
-            }
-          : undefined,
+        pidState ? removeStalePidFix : undefined,
       ),
     ];
   }
@@ -60,12 +59,7 @@ export async function checkGateway(): Promise<DiagResult[]> {
         'Gateway',
         'warn',
         `Stale PID file for pid ${pidState.pid}; gateway API is unreachable`,
-        {
-          summary: 'Remove the stale gateway PID file',
-          apply: async () => {
-            removeGatewayPidFile();
-          },
-        },
+        removeStalePidFix,
       ),
     ];
   }

--- a/src/doctor/checks/index.ts
+++ b/src/doctor/checks/index.ts
@@ -10,6 +10,7 @@ import { checkLocalBackendsCategory } from './local-backends.js';
 import { checkProviders } from './providers.js';
 import { checkRuntime } from './runtime.js';
 import { checkSecurity } from './security.js';
+import { checkSkills } from './skills.js';
 
 export function doctorChecks(): DoctorCheck[] {
   return [
@@ -57,6 +58,11 @@ export function doctorChecks(): DoctorCheck[] {
       category: 'channels',
       label: 'Channels',
       run: checkChannels,
+    },
+    {
+      category: 'skills',
+      label: 'Skills',
+      run: checkSkills,
     },
     {
       category: 'security',

--- a/src/doctor/checks/providers.ts
+++ b/src/doctor/checks/providers.ts
@@ -8,7 +8,7 @@ import {
   probeOpenRouter,
 } from '../provider-probes.js';
 import type { DiagResult } from '../types.js';
-import { makeResult, severityFrom } from '../utils.js';
+import { makeResult, severityFrom, toErrorMessage } from '../utils.js';
 
 type ProviderKey = 'hybridai' | 'codex' | 'openrouter';
 
@@ -144,12 +144,7 @@ export async function checkProviders(): Promise<DiagResult[]> {
       probesByKey.set(plan.key, result.value.probe);
       return;
     }
-    errorsByKey.set(
-      plan.key,
-      result.reason instanceof Error
-        ? result.reason.message
-        : String(result.reason),
-    );
+    errorsByKey.set(plan.key, toErrorMessage(result.reason));
   });
 
   const segments: string[] = [];

--- a/src/doctor/checks/security.ts
+++ b/src/doctor/checks/security.ts
@@ -11,21 +11,11 @@ import {
   verifyInstructionIntegrity,
 } from '../../security/instruction-integrity.js';
 import type { DiagResult } from '../types.js';
-import { makeResult, severityFrom } from '../utils.js';
+import { findExistingPath, makeResult, severityFrom } from '../utils.js';
 
 function checkWritablePath(targetPath: string): boolean {
-  const existing = (() => {
-    let current = path.resolve(targetPath);
-    while (!fs.existsSync(current)) {
-      const parent = path.dirname(current);
-      if (parent === current) return targetPath;
-      current = parent;
-    }
-    return current;
-  })();
-
   try {
-    fs.accessSync(existing, fs.constants.W_OK);
+    fs.accessSync(findExistingPath(targetPath), fs.constants.W_OK);
     return true;
   } catch {
     return false;

--- a/src/doctor/checks/skills.ts
+++ b/src/doctor/checks/skills.ts
@@ -1,0 +1,118 @@
+import {
+  getRuntimeConfig,
+  setRuntimeSkillScopeEnabled,
+  updateRuntimeConfig,
+} from '../../config/runtime-config.js';
+import {
+  loadSkillCatalog,
+  type SkillCatalogEntry,
+} from '../../skills/skills.js';
+import {
+  guardSkillDirectory,
+  type SkillGuardScanResult,
+} from '../../skills/skills-guard.js';
+import type { DiagResult } from '../types.js';
+import { makeResult } from '../utils.js';
+
+interface FlaggedSkill {
+  skill: SkillCatalogEntry;
+  result: SkillGuardScanResult;
+}
+
+function formatFlaggedSkill(flagged: FlaggedSkill): string {
+  const count = flagged.result.findings.length;
+  return `${flagged.skill.name} (${count} finding${count === 1 ? '' : 's'})`;
+}
+
+function scanGuardedSkill(skill: SkillCatalogEntry): FlaggedSkill | null {
+  const result = guardSkillDirectory({
+    skillName: skill.name,
+    skillPath: skill.baseDir,
+    sourceTag: skill.source,
+  }).result;
+  if (result.verdict === 'safe') return null;
+  return {
+    skill,
+    result,
+  };
+}
+
+export async function checkSkills(): Promise<DiagResult[]> {
+  const catalog = loadSkillCatalog();
+  if (catalog.length === 0) {
+    return [
+      makeResult('skills', 'Skills', 'ok', 'No loadable skills discovered'),
+    ];
+  }
+
+  const flagged = catalog
+    .map((skill) => scanGuardedSkill(skill))
+    .filter(Boolean) as FlaggedSkill[];
+  const enabledFlagged = flagged.filter((entry) => entry.skill.enabled);
+  const disabledFlagged = flagged.filter((entry) => !entry.skill.enabled);
+  const disabledCount = catalog.filter((skill) => !skill.enabled).length;
+
+  if (enabledFlagged.length > 0) {
+    const skillNames = enabledFlagged.map((entry) => entry.skill.name);
+    const previousDisabled = new Set(
+      (getRuntimeConfig().skills?.disabled ?? [])
+        .map((name) => String(name).trim())
+        .filter(Boolean),
+    );
+    const summarySkills = enabledFlagged.map(formatFlaggedSkill).join(', ');
+    const disabledSuffix =
+      disabledFlagged.length > 0
+        ? `; ${disabledFlagged.length} flagged skill${disabledFlagged.length === 1 ? '' : 's'} already disabled`
+        : '';
+
+    return [
+      makeResult(
+        'skills',
+        'Skills',
+        'warn',
+        `${enabledFlagged.length} enabled skill${enabledFlagged.length === 1 ? '' : 's'} flagged by the security scanner: ${summarySkills}${disabledSuffix}`,
+        {
+          summary: `Disable flagged skills: ${skillNames.join(', ')}`,
+          apply: async () => {
+            updateRuntimeConfig((draft) => {
+              for (const skillName of skillNames) {
+                setRuntimeSkillScopeEnabled(draft, skillName, false);
+              }
+            });
+          },
+          rollback: async () => {
+            updateRuntimeConfig((draft) => {
+              for (const skillName of skillNames) {
+                setRuntimeSkillScopeEnabled(
+                  draft,
+                  skillName,
+                  !previousDisabled.has(skillName),
+                );
+              }
+            });
+          },
+        },
+      ),
+    ];
+  }
+
+  if (disabledFlagged.length > 0) {
+    return [
+      makeResult(
+        'skills',
+        'Skills',
+        'ok',
+        `${catalog.length} skill${catalog.length === 1 ? '' : 's'} checked; ${disabledFlagged.length} flagged skill${disabledFlagged.length === 1 ? '' : 's'} already disabled`,
+      ),
+    ];
+  }
+
+  return [
+    makeResult(
+      'skills',
+      'Skills',
+      'ok',
+      `${catalog.length} skill${catalog.length === 1 ? '' : 's'} checked${disabledCount > 0 ? `, ${disabledCount} disabled` : ''}; all loadable skills passed guard checks`,
+    ),
+  ];
+}

--- a/src/doctor/gateway-repair.ts
+++ b/src/doctor/gateway-repair.ts
@@ -79,6 +79,7 @@ export async function restartGatewayFromDoctor(): Promise<void> {
     cwd: process.cwd(),
     env: { ...process.env },
     encoding: 'utf-8',
+    timeout: 30_000,
   });
   if (result.error) {
     throw result.error;

--- a/src/doctor/types.ts
+++ b/src/doctor/types.ts
@@ -8,6 +8,7 @@ export const DOCTOR_CATEGORIES = [
   'local-backends',
   'docker',
   'channels',
+  'skills',
   'security',
   'disk',
 ] as const;
@@ -59,9 +60,3 @@ export interface DoctorReport {
   };
   fixes: DoctorFixOutcome[];
 }
-
-export const SEVERITY_ORDER: Record<DiagResult['severity'], number> = {
-  ok: 0,
-  warn: 1,
-  error: 2,
-};

--- a/src/doctor/utils.ts
+++ b/src/doctor/utils.ts
@@ -3,7 +3,13 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import type { DiagResult, DoctorCategory, DoctorReport } from './types.js';
-import { DOCTOR_CATEGORIES, SEVERITY_ORDER } from './types.js';
+import { DOCTOR_CATEGORIES } from './types.js';
+
+const SEVERITY_ORDER: Record<DiagResult['severity'], number> = {
+  ok: 0,
+  warn: 1,
+  error: 2,
+};
 
 export function shortenHomePath(filePath: string): string {
   const homeDir = os.homedir();
@@ -66,21 +72,59 @@ export function findExistingPath(filePath: string): string {
   return current;
 }
 
-export function readDiskFreeBytes(targetPath: string): number {
-  const stat = fs.statfsSync(findExistingPath(targetPath));
-  return Number(stat.bavail) * Number(stat.bsize);
+export function readDiskFreeBytes(targetPath: string): number | null {
+  try {
+    const stat = fs.statfsSync(findExistingPath(targetPath));
+    const freeBytes = Number(stat.bavail) * Number(stat.bsize);
+    return Number.isFinite(freeBytes) && freeBytes >= 0 ? freeBytes : null;
+  } catch {
+    return null;
+  }
 }
 
 export function readDirSize(dirPath: string): number {
-  if (!fs.existsSync(dirPath)) return 0;
-  const stat = fs.statSync(dirPath);
-  if (stat.isFile()) return stat.size;
-  if (!stat.isDirectory()) return 0;
-  let total = 0;
-  for (const entry of fs.readdirSync(dirPath, { withFileTypes: true })) {
-    total += readDirSize(path.join(dirPath, entry.name));
-  }
-  return total;
+  const visited = new Set<string>();
+
+  const measure = (targetPath: string): number => {
+    let stat: fs.Stats;
+    try {
+      stat = fs.lstatSync(targetPath);
+    } catch {
+      return 0;
+    }
+
+    if (stat.isFile()) return stat.size;
+    if (!stat.isDirectory()) return 0;
+
+    const visitKey = (() => {
+      try {
+        return fs.realpathSync(targetPath);
+      } catch {
+        return path.resolve(targetPath);
+      }
+    })();
+    if (visited.has(visitKey)) return 0;
+    visited.add(visitKey);
+
+    let total = 0;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(targetPath, { withFileTypes: true });
+    } catch {
+      return 0;
+    }
+
+    for (const entry of entries) {
+      try {
+        total += measure(path.join(targetPath, entry.name));
+      } catch {
+        // best effort; skip unreadable or unstable entries
+      }
+    }
+    return total;
+  };
+
+  return measure(dirPath);
 }
 
 export function runVersionCommand(command: string): string | null {
@@ -118,6 +162,10 @@ export function makeResult(
   };
 }
 
+export function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 export function summarizeCounts(
   results: DiagResult[],
 ): DoctorReport['summary'] {
@@ -149,23 +197,20 @@ export function normalizeComponent(
     configuration: 'config',
     credentials: 'credentials',
     creds: 'credentials',
-    secrets: 'credentials',
     db: 'database',
     database: 'database',
     provider: 'providers',
     providers: 'providers',
-    local: 'local-backends',
-    backend: 'local-backends',
     backends: 'local-backends',
     'local-backends': 'local-backends',
-    localbackends: 'local-backends',
     docker: 'docker',
     container: 'docker',
     channels: 'channels',
     channel: 'channels',
+    skill: 'skills',
+    skills: 'skills',
     security: 'security',
     disk: 'disk',
-    storage: 'disk',
   };
   return aliasMap[value] || null;
 }

--- a/src/gateway/gateway-lifecycle.ts
+++ b/src/gateway/gateway-lifecycle.ts
@@ -1,7 +1,6 @@
-import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { DATA_DIR, GATEWAY_BASE_URL } from '../config/config.js';
+import { DATA_DIR } from '../config/config.js';
 
 export interface GatewayPidState {
   pid: number;
@@ -63,52 +62,4 @@ export function isPidRunning(pid: number): boolean {
   } catch {
     return false;
   }
-}
-
-function parseGatewayBaseUrl(): URL | null {
-  try {
-    return new URL(GATEWAY_BASE_URL);
-  } catch {
-    return null;
-  }
-}
-
-function isLocalGatewayHost(hostname: string): boolean {
-  const normalized = hostname.trim().toLowerCase();
-  return (
-    normalized === '127.0.0.1' ||
-    normalized === 'localhost' ||
-    normalized === '::1'
-  );
-}
-
-function resolveGatewayListenPort(url: URL): number {
-  if (url.port) {
-    const parsed = Number.parseInt(url.port, 10);
-    if (Number.isFinite(parsed) && parsed > 0) return parsed;
-  }
-  return url.protocol === 'https:' ? 443 : 80;
-}
-
-export function findGatewayPidByPort(): number | null {
-  const parsed = parseGatewayBaseUrl();
-  if (!parsed || !isLocalGatewayHost(parsed.hostname)) return null;
-  const port = resolveGatewayListenPort(parsed);
-
-  const result = spawnSync(
-    'lsof',
-    ['-nP', `-iTCP:${port}`, '-sTCP:LISTEN', '-t'],
-    {
-      encoding: 'utf-8',
-    },
-  );
-  if (result.error) return null;
-  const output = (result.stdout || '').trim();
-  if (!output) return null;
-
-  const firstPid = output
-    .split('\n')
-    .map((line) => Number.parseInt(line.trim(), 10))
-    .find((pid) => Number.isFinite(pid) && pid > 0);
-  return firstPid && Number.isFinite(firstPid) ? firstPid : null;
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -55,6 +55,15 @@ async function importFreshCli(options?: {
   };
   gatewayReachable?: boolean;
   sandboxMode?: 'host' | 'container';
+  gatewayFlags?: {
+    foreground?: boolean;
+    sandboxMode?: 'host' | 'container' | null;
+    debug?: boolean;
+    help?: boolean;
+    passthrough?: string[];
+  };
+  ensureContainerImageReadyError?: Error | null;
+  gatewayModuleError?: Error | null;
   promptResponses?: string[];
 }) {
   vi.resetModules();
@@ -117,7 +126,11 @@ async function importFreshCli(options?: {
   const runUpdateCommand = vi.fn();
   const runDoctorCli = vi.fn(async () => 0);
   const ensureRuntimeCredentials = vi.fn();
-  const ensureContainerImageReady = vi.fn();
+  const ensureContainerImageReady = vi.fn(async () => {
+    if (options?.ensureContainerImageReadyError) {
+      throw options.ensureContainerImageReadyError;
+    }
+  });
   const saveRuntimeSecrets = vi.fn(() => '/tmp/credentials.json');
   const loadSkillCatalog = vi.fn(() => [
     { name: 'pdf' },
@@ -141,6 +154,7 @@ async function importFreshCli(options?: {
     waitForSocket: whatsappWaitForSocket,
   }));
   const ensureRuntimeConfigFile = vi.fn(() => false);
+  const onRuntimeConfigChange = vi.fn(() => () => {});
   const getRuntimeConfig = vi.fn(() => ({
     skills: {
       extraDirs: [],
@@ -302,6 +316,13 @@ async function importFreshCli(options?: {
     ragDefault: true,
     timestamp: new Date().toISOString(),
   }));
+  const ensureGatewayRunDir = vi.fn();
+  const findGatewayPidByPort = vi.fn(() => null);
+  const readGatewayPid = vi.fn(() => null);
+  const removeGatewayPidFile = vi.fn();
+  const writeGatewayPid = vi.fn();
+  const isPidRunning = vi.fn(() => true);
+  const gatewayModuleLoaded = vi.fn();
   const tuiModuleLoaded = vi.fn();
   const runTui = vi.fn(async () => {
     tuiModuleLoaded();
@@ -348,9 +369,11 @@ async function importFreshCli(options?: {
   vi.doMock('../src/config/cli-flags.ts', () => ({
     findUnsupportedGatewayLifecycleFlag: vi.fn(() => null),
     parseGatewayFlags: vi.fn(() => ({
-      foreground: false,
-      sandboxMode: null,
-      passthrough: [],
+      foreground: options?.gatewayFlags?.foreground ?? false,
+      sandboxMode: options?.gatewayFlags?.sandboxMode ?? null,
+      debug: options?.gatewayFlags?.debug ?? false,
+      help: options?.gatewayFlags?.help ?? false,
+      passthrough: options?.gatewayFlags?.passthrough ?? [],
     })),
   }));
   vi.doMock('../src/config/config.ts', () => ({
@@ -365,6 +388,7 @@ async function importFreshCli(options?: {
     ensureRuntimeConfigFile,
     getRuntimeSkillScopeDisabledNames,
     getRuntimeConfig,
+    onRuntimeConfigChange,
     runtimeConfigPath,
     setRuntimeSkillScopeEnabled,
     updateRuntimeConfig,
@@ -373,6 +397,22 @@ async function importFreshCli(options?: {
     gatewayHealth,
     gatewayStatus,
   }));
+  vi.doMock('../src/gateway/gateway-lifecycle.ts', () => ({
+    ensureGatewayRunDir,
+    findGatewayPidByPort,
+    GATEWAY_LOG_FILE_ENV: 'HYBRIDCLAW_GATEWAY_LOG_FILE',
+    GATEWAY_LOG_PATH: '/tmp/hybridclaw-data/gateway/gateway.log',
+    GATEWAY_STDIO_TO_LOG_ENV: 'HYBRIDCLAW_GATEWAY_STDIO_TO_LOG',
+    isPidRunning,
+    readGatewayPid,
+    removeGatewayPidFile,
+    writeGatewayPid,
+  }));
+  vi.doMock('../src/gateway/gateway.ts', () => {
+    if (options?.gatewayModuleError) throw options.gatewayModuleError;
+    gatewayModuleLoaded();
+    return {};
+  });
   vi.doMock('../src/infra/container-setup.ts', () => ({
     ensureContainerImageReady,
   }));
@@ -452,6 +492,13 @@ async function importFreshCli(options?: {
     updateRuntimeConfig,
     gatewayHealth,
     gatewayStatus,
+    ensureGatewayRunDir,
+    findGatewayPidByPort,
+    readGatewayPid,
+    removeGatewayPidFile,
+    writeGatewayPid,
+    isPidRunning,
+    gatewayModuleLoaded,
     loadSkillCatalog,
     readlineCreateInterface,
     readlineQuestion,
@@ -469,6 +516,8 @@ afterEach(() => {
   vi.doUnmock('../src/config/config.ts');
   vi.doUnmock('../src/config/runtime-config.ts');
   vi.doUnmock('../src/gateway/gateway-client.ts');
+  vi.doUnmock('../src/gateway/gateway-lifecycle.ts');
+  vi.doUnmock('../src/gateway/gateway.ts');
   vi.doUnmock('../src/infra/container-setup.ts');
   vi.doUnmock('../src/channels/whatsapp/auth.ts');
   vi.doUnmock('node:readline/promises');
@@ -1250,6 +1299,85 @@ describe('CLI hybridai commands', () => {
 
     expect(runDoctorCli).toHaveBeenCalledWith(['--fix', 'docker']);
     expect(process.exitCode).toBe(1);
+  });
+
+  it('writes and cleans up a managed PID file for gateway start --foreground', async () => {
+    const {
+      cli,
+      ensureGatewayRunDir,
+      ensureRuntimeCredentials,
+      gatewayModuleLoaded,
+      removeGatewayPidFile,
+      writeGatewayPid,
+    } = await importFreshCli({
+      gatewayFlags: {
+        foreground: true,
+        sandboxMode: 'host',
+      },
+    });
+    const registered = new Map<string, Array<(...args: unknown[]) => void>>();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(process, 'on').mockImplementation(((
+      event: string | symbol,
+      listener: (...args: unknown[]) => void,
+    ) => {
+      const key = String(event);
+      const listeners = registered.get(key) ?? [];
+      listeners.push(listener);
+      registered.set(key, listeners);
+      return process;
+    }) as never);
+
+    await cli.main(['gateway', 'start', '--foreground', '--sandbox=host']);
+
+    expect(ensureRuntimeCredentials).toHaveBeenCalledWith({
+      commandName: 'hybridclaw gateway start --foreground',
+    });
+    expect(ensureGatewayRunDir).toHaveBeenCalled();
+    expect(writeGatewayPid).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pid: process.pid,
+        cwd: process.cwd(),
+      }),
+    );
+    expect(gatewayModuleLoaded).toHaveBeenCalled();
+    expect(registered.get('exit')).toHaveLength(1);
+    expect(registered.get('SIGINT')).toHaveLength(1);
+    expect(registered.get('SIGTERM')).toHaveLength(1);
+
+    removeGatewayPidFile.mockClear();
+    registered.get('exit')?.[0]();
+
+    expect(removeGatewayPidFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up the managed PID file if gateway foreground startup fails', async () => {
+    const startupError = new Error('gateway bootstrap failed');
+    const { cli, removeGatewayPidFile, writeGatewayPid } = await importFreshCli(
+      {
+        gatewayFlags: {
+          foreground: true,
+          sandboxMode: 'container',
+        },
+        ensureContainerImageReadyError: startupError,
+      },
+    );
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(process, 'on').mockImplementation(
+      ((_: string | symbol, __: (...args: unknown[]) => void) =>
+        process) as never,
+    );
+
+    await expect(
+      cli.main(['gateway', 'start', '--foreground', '--sandbox=container']),
+    ).rejects.toThrow('gateway bootstrap failed');
+
+    expect(writeGatewayPid).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pid: process.pid,
+      }),
+    );
+    expect(removeGatewayPidFile).toHaveBeenCalledTimes(1);
   });
 
   it('launches tui without local runtime preflight when gateway is already reachable', async () => {

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -75,6 +75,37 @@ test('runDoctor fixes insecure credentials permissions and reruns the check', as
   expect(fs.statSync(credentialsPath).mode & 0o777).toBe(0o600);
 });
 
+test('checkConfig fixes world-readable config permissions to owner-only', async () => {
+  const dir = createTempDir('hybridclaw-doctor-config-');
+  const configPath = path.join(dir, 'config.json');
+  fs.writeFileSync(
+    configPath,
+    `${JSON.stringify({ version: 16, hybridai: { defaultModel: 'gpt-5-nano' }, ops: { dbPath: '/tmp/hybridclaw.db' }, container: { image: 'hybridclaw-agent' } }, null, 2)}\n`,
+    'utf-8',
+  );
+  fs.chmodSync(configPath, 0o666);
+
+  vi.doMock('../src/config/runtime-config.js', () => ({
+    CONFIG_VERSION: 16,
+    ensureRuntimeConfigFile: vi.fn(),
+    getRuntimeConfig: () => ({
+      hybridai: { defaultModel: 'gpt-5-nano' },
+      ops: { dbPath: '/tmp/hybridclaw.db' },
+      container: { image: 'hybridclaw-agent' },
+    }),
+    runtimeConfigPath: () => configPath,
+  }));
+
+  const { checkConfig } = await import('../src/doctor/checks/config.ts');
+  const [result] = await checkConfig();
+
+  expect(result.severity).toBe('warn');
+  expect(result.fix).toBeDefined();
+
+  await result.fix?.apply();
+  expect(fs.statSync(configPath).mode & 0o777).toBe(0o600);
+});
+
 test('checkProviders treats probe failures as provider health failures', async () => {
   vi.doMock('../src/config/runtime-config.js', () => ({
     getRuntimeConfig: () => ({
@@ -198,6 +229,52 @@ test('checkGateway exposes a restart fix when the PID is alive but the API is un
   expect(restartGatewayFromDoctor).toHaveBeenCalledTimes(1);
 });
 
+test('checkDisk warns when free space cannot be determined', async () => {
+  const dir = createTempDir('hybridclaw-doctor-disk-');
+  const dbPath = path.join(dir, 'hybridclaw.db');
+  fs.writeFileSync(dbPath, 'db', 'utf-8');
+
+  vi.doMock('../src/config/config.js', () => ({
+    DATA_DIR: dir,
+    DB_PATH: dbPath,
+  }));
+  vi.spyOn(fs, 'statfsSync').mockImplementation(() => {
+    throw new Error('unsupported');
+  });
+
+  const { checkDisk } = await import('../src/doctor/checks/disk.ts');
+  const [result] = await checkDisk();
+
+  expect(result.severity).toBe('warn');
+  expect(result.message).toContain('free space unavailable');
+  expect(result.message).toContain('DB 2 B');
+});
+
+test('readDirSize skips unreadable entries and symlink loops', async () => {
+  const dir = createTempDir('hybridclaw-doctor-size-');
+  fs.writeFileSync(path.join(dir, 'good.txt'), 'good', 'utf-8');
+  fs.writeFileSync(path.join(dir, 'bad.txt'), 'bad', 'utf-8');
+  fs.symlinkSync('.', path.join(dir, 'loop'));
+
+  type LstatArgs = Parameters<typeof fs.lstatSync>;
+  const originalLstatSync = fs.lstatSync.bind(fs) as (
+    ...args: LstatArgs
+  ) => ReturnType<typeof fs.lstatSync>;
+  vi.spyOn(fs, 'lstatSync').mockImplementation(((
+    filePath: LstatArgs[0],
+    options?: LstatArgs[1],
+  ) => {
+    if (String(filePath).endsWith('bad.txt')) {
+      throw new Error('permission denied');
+    }
+    return originalLstatSync(filePath, options as LstatArgs[1]);
+  }) as never);
+
+  const { readDirSize } = await import('../src/doctor/utils.ts');
+
+  expect(readDirSize(dir)).toBe(4);
+});
+
 test('checkDocker only reports daemon and image state', async () => {
   vi.doMock('node:child_process', () => ({
     spawnSync: vi.fn(() => ({
@@ -231,6 +308,15 @@ test('checkDocker only reports daemon and image state', async () => {
   expect(result.severity).toBe('ok');
   expect(result.message).toBe('Daemon running, image hybridclaw-agent present');
   expect(result.message).not.toContain('free');
+});
+
+test('restartGatewayFromDoctor configures a bounded spawn timeout', () => {
+  const source = fs.readFileSync(
+    path.join(process.cwd(), 'src', 'doctor', 'gateway-repair.ts'),
+    'utf-8',
+  );
+
+  expect(source).toContain('timeout: 30_000');
 });
 
 test('checkSecurity does not offer an auto-fix for modified instruction copies', async () => {
@@ -267,6 +353,144 @@ test('checkSecurity does not offer an auto-fix for modified instruction copies',
   expect(result.severity).toBe('warn');
   expect(result.message).toContain('SECURITY.md:modified');
   expect(result.fix).toBeUndefined();
+});
+
+test('checkSkills warns on enabled caution skills and disables them with fix', async () => {
+  const disabledSkills = new Set<string>();
+
+  vi.doMock('../src/config/runtime-config.js', () => ({
+    getRuntimeConfig: () => ({
+      skills: {
+        disabled: [...disabledSkills],
+      },
+    }),
+    setRuntimeSkillScopeEnabled: (
+      draft: { skills: { disabled: string[] } },
+      skillName: string,
+      enabled: boolean,
+    ) => {
+      const nextDisabled = new Set(draft.skills.disabled);
+      if (enabled) {
+        nextDisabled.delete(skillName);
+      } else {
+        nextDisabled.add(skillName);
+      }
+      draft.skills.disabled = [...nextDisabled].sort((left, right) =>
+        left.localeCompare(right),
+      );
+    },
+    updateRuntimeConfig: (
+      mutate: (draft: { skills: { disabled: string[] } }) => void,
+    ) => {
+      const draft = {
+        skills: {
+          disabled: [...disabledSkills],
+        },
+      };
+      mutate(draft);
+      disabledSkills.clear();
+      for (const skillName of draft.skills.disabled) {
+        disabledSkills.add(skillName);
+      }
+      return draft;
+    },
+  }));
+  vi.doMock('../src/skills/skills.js', () => ({
+    loadSkillCatalog: () => [
+      {
+        name: 'workspace-risk',
+        description: 'Workspace skill with a suspicious pattern',
+        userInvocable: false,
+        disableModelInvocation: false,
+        always: false,
+        requires: {
+          bins: [],
+          env: [],
+        },
+        metadata: {
+          hybridclaw: {
+            tags: [],
+            relatedSkills: [],
+            install: [],
+          },
+        },
+        filePath: '/tmp/workspace-risk/SKILL.md',
+        baseDir: '/tmp/workspace-risk',
+        source: 'workspace',
+        available: true,
+        enabled: true,
+        missing: [],
+      },
+      {
+        name: 'safe-skill',
+        description: 'Safe skill',
+        userInvocable: false,
+        disableModelInvocation: false,
+        always: false,
+        requires: {
+          bins: [],
+          env: [],
+        },
+        metadata: {
+          hybridclaw: {
+            tags: [],
+            relatedSkills: [],
+            install: [],
+          },
+        },
+        filePath: '/tmp/safe-skill/SKILL.md',
+        baseDir: '/tmp/safe-skill',
+        source: 'workspace',
+        available: true,
+        enabled: true,
+        missing: [],
+      },
+    ],
+  }));
+  vi.doMock('../src/skills/skills-guard.js', () => ({
+    guardSkillDirectory: ({ skillName }: { skillName: string }) => ({
+      allowed: true,
+      reason: 'allowed for test',
+      result: {
+        skillName,
+        skillPath: `/tmp/${skillName}`,
+        sourceTag: 'workspace',
+        trustLevel: 'workspace',
+        verdict: skillName === 'workspace-risk' ? 'caution' : 'safe',
+        findings:
+          skillName === 'workspace-risk'
+            ? [
+                {
+                  patternId: 'shell_rc_mod',
+                  severity: 'medium',
+                  category: 'persistence',
+                  file: 'SKILL.md',
+                  line: 7,
+                  match: '.zshrc',
+                  description: 'references shell startup file',
+                },
+              ]
+            : [],
+        scannedAt: '2026-03-17T10:00:00.000Z',
+        summary: `${skillName} summary`,
+        fromCache: false,
+      },
+    }),
+  }));
+
+  const { checkSkills } = await import('../src/doctor/checks/skills.ts');
+  const [result] = await checkSkills();
+
+  expect(result.severity).toBe('warn');
+  expect(result.message).toContain('workspace-risk');
+  expect(result.fix?.summary).toContain('Disable flagged skills');
+  expect(disabledSkills.size).toBe(0);
+
+  await result.fix?.apply();
+  expect(disabledSkills.has('workspace-risk')).toBe(true);
+
+  await result.fix?.rollback?.();
+  expect(disabledSkills.has('workspace-risk')).toBe(false);
 });
 
 test('checkChannels distinguishes intentionally disabled channels from missing setup', async () => {
@@ -440,6 +664,18 @@ test('renderDoctorReport prints the summary and applied fixes', async () => {
         status: 'applied',
         message: 'Applied fix for docker',
       },
+      {
+        category: 'gateway',
+        label: 'Gateway',
+        status: 'rolled_back',
+        message: 'Rolled back after a later fix failed',
+      },
+      {
+        category: 'database',
+        label: 'Database',
+        status: 'rollback_failed',
+        message: 'Rollback failed',
+      },
     ],
   });
 
@@ -447,5 +683,23 @@ test('renderDoctorReport prints the summary and applied fixes', async () => {
   expect(output).toContain('✓ Gateway');
   expect(output).toContain('⚠ Docker');
   expect(output).toContain('✓ Fix Docker');
+  expect(output).not.toContain('Rolled back after a later fix failed');
+  expect(output).not.toContain('Rollback failed');
   expect(output).toContain('1 ok · 1 warning · 0 errors');
+});
+
+test('normalizeComponent keeps the minimal doctor aliases', async () => {
+  const { normalizeComponent } = await import('../src/doctor/utils.ts');
+
+  expect(normalizeComponent('local-backends')).toBe('local-backends');
+  expect(normalizeComponent('backends')).toBe('local-backends');
+  expect(normalizeComponent('db')).toBe('database');
+  expect(normalizeComponent('creds')).toBe('credentials');
+  expect(normalizeComponent('container')).toBe('docker');
+
+  expect(normalizeComponent('backend')).toBeNull();
+  expect(normalizeComponent('local')).toBeNull();
+  expect(normalizeComponent('localbackends')).toBeNull();
+  expect(normalizeComponent('secrets')).toBeNull();
+  expect(normalizeComponent('storage')).toBeNull();
 });


### PR DESCRIPTION
## Summary
- add a dedicated doctor skills check and tighten follow-up doctor fixes around permissions, error reporting, disk sizing, and gateway stale PID handling
- move foreground gateway PID management into the CLI startup path so `gateway start --foreground` writes and cleans up its managed PID file reliably
- extend the CLI and doctor test coverage for the new checks, fixes, rollback rendering, and foreground gateway startup behavior

## Testing
- npm run typecheck
- npm run lint
- npm run test:unit -- tests/doctor.test.ts tests/cli.test.ts