### PR TITLE
fix: retry web fetch with bot ua on Cloudflare challenge

### DIFF
--- a/container/src/web-fetch.ts
+++ b/container/src/web-fetch.ts
@@ -40,7 +40,7 @@ const JAVASCRIPT_REQUIRED_PATTERNS = [
 ];
 const BROWSER_USER_AGENT =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36';
-const BOT_USER_AGENT =
+export const BOT_USER_AGENT =
   'hybridclaw/1.0 (+https://github.com/hybridaione/hybridclaw; AI assistant bot)';
 
 // ---------------------------------------------------------------------------
@@ -457,6 +457,8 @@ export async function webFetch(params: {
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
   try {
+    // The initial fetch and optional Cloudflare retry share one overall timeout
+    // budget; we intentionally do not reset the timer per attempt.
     const doFetch = (userAgent: string) =>
       fetchWithRedirects(
         params.url,
@@ -467,6 +469,7 @@ export async function webFetch(params: {
 
     let { response: res, finalUrl } = await doFetch(BROWSER_USER_AGENT);
     if (isCloudflareChallenge(res)) {
+      void res.body?.cancel().catch(() => {});
       ({ response: res, finalUrl } = await doFetch(BOT_USER_AGENT));
     }
 

--- a/tests/unit/web-fetch.test.ts
+++ b/tests/unit/web-fetch.test.ts
@@ -8,18 +8,22 @@ afterEach(() => {
 
 describe('web fetch Cloudflare challenge retry', () => {
   it('retries once with an honest bot user agent after a Cloudflare challenge', async () => {
+    const challengeResponse = new Response('challenge', {
+      status: 403,
+      statusText: 'Forbidden',
+      headers: {
+        'Cf-Mitigated': 'challenge',
+        'Content-Type': 'text/plain',
+      },
+    });
+    const challengeBody = challengeResponse.body;
+    if (!challengeBody) {
+      throw new Error('Expected challenge response body to exist');
+    }
+    const cancelSpy = vi.spyOn(challengeBody, 'cancel');
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(
-        new Response('challenge', {
-          status: 403,
-          statusText: 'Forbidden',
-          headers: {
-            'Cf-Mitigated': 'challenge',
-            'Content-Type': 'text/plain',
-          },
-        }),
-      )
+      .mockResolvedValueOnce(challengeResponse)
       .mockResolvedValueOnce(
         new Response('Allowed content via bot allowlist.', {
           status: 200,
@@ -30,7 +34,9 @@ describe('web fetch Cloudflare challenge retry', () => {
       );
     vi.stubGlobal('fetch', fetchMock);
 
-    const { webFetch } = await import('../../container/src/web-fetch.js');
+    const { BOT_USER_AGENT, webFetch } = await import(
+      '../../container/src/web-fetch.js'
+    );
     const result = await webFetch({
       url: 'https://example.com/cloudflare-challenge-retry',
       extractMode: 'text',
@@ -44,10 +50,10 @@ describe('web fetch Cloudflare challenge retry', () => {
     });
     expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
       headers: expect.objectContaining({
-        'User-Agent':
-          'hybridclaw/1.0 (+https://github.com/hybridaione/hybridclaw; AI assistant bot)',
+        'User-Agent': BOT_USER_AGENT,
       }),
     });
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
     expect(result.status).toBe(200);
     expect(result.text).toBe('Allowed content via bot allowlist.');
   });


### PR DESCRIPTION
## Summary
- retry `web_fetch` once with a self-identifying HybridClaw bot user agent when Cloudflare returns `403` with `Cf-Mitigated: challenge`
- keep the existing browser-like user agent for the first request and preserve existing behavior for non-challenge responses
- add unit coverage for both the retry path and the no-retry 403 boundary

## Testing
- `npm run test:unit -- tests/unit/web-fetch.test.ts`
- `npm --prefix container run lint`
- `npm run build`