### PR TITLE
Fix Docker image crash: copy container/shared/ into runtime stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ RUN npm ci --omit=dev
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/console/dist ./console/dist
 
+# Shared JS modules required at runtime by gateway imports
+COPY --from=builder /app/container/shared ./container/shared
+
 EXPOSE 9090
 
 ENV HYBRIDCLAW_DATA_DIR=/workspace/.data


### PR DESCRIPTION
## Summary

The Docker image crashes on startup with `ERR_MODULE_NOT_FOUND: Cannot find module '/app/container/shared/context-guard-config.js'` because the runtime stage doesn't copy the `container/shared/` directory from the builder.

The compiled gateway JS in `dist/` contains relative imports to `../../container/shared/*.js` (context-guard-config, model-names, provider-context, response-text), so these files must exist in the runtime image.

## Fix

Added one line to copy `container/shared/` into the runtime stage:
```dockerfile
COPY --from=builder /app/container/shared ./container/shared
```

Only `container/shared/` is needed at runtime. `container/src/` (TypeScript sources), `container/dist/`, and `container/scripts/` are build-time only.

## Test plan

- [x] `docker build -t hybridclaw:latest .` succeeds
- [x] `docker run --rm hybridclaw:latest` starts without ERR_MODULE_NOT_FOUND crash
- [x] Gateway initializes and reaches trust-model acceptance prompt (expected without config)