### PR TITLE
Fix Docker-only web login redirect and rename gateway HTTP server

### DIFF
--- a/tests/gateway-main.test.ts
+++ b/tests/gateway-main.test.ts
@@ -420,7 +420,7 @@ describe('gateway bootstrap', () => {
       await settle();
 
       expect(capturedState).not.toBeNull();
-      expect(capturedState?.startHealthServer).not.toHaveBeenCalled();
+      expect(capturedState?.startGatewayHttpServer).not.toHaveBeenCalled();
       expect(capturedState?.initDiscord).not.toHaveBeenCalled();
       expect(
         capturedState?.resumeEnabledFullAutoSessions,
@@ -432,7 +432,7 @@ describe('gateway bootstrap', () => {
     const state = await bootstrapPromise;
 
     expect(state.initGatewayService).toHaveBeenCalledTimes(1);
-    expect(state.startHealthServer).toHaveBeenCalledTimes(1);
+    expect(state.startGatewayHttpServer).toHaveBeenCalledTimes(1);
     expect(state.initDiscord).toHaveBeenCalledTimes(1);
     expect(state.resumeEnabledFullAutoSessions).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Summary
- only redirect /admin, /chat, and /agents to HybridAI login when the gateway is actually running inside Docker
- rename the gateway HTTP entrypoint from health.ts to gateway-http-server.ts and update the gateway bootstrap and tests
- add host-vs-Docker coverage for the protected web routes

## Testing
- npm run test:unit -- tests/gateway-http-server.test.ts tests/gateway-main.test.ts
- npm run typecheck