### PR TITLE
feat: add HYBRIDCLAW_ACCEPT_TRUST env var for headless trust acceptance

### DIFF
--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -845,7 +845,7 @@ export async function ensureRuntimeCredentials(
         ? 'openrouter'
         : 'hybridai');
   const force = options.force === true;
-  const securityAccepted = isSecurityTrustAccepted(runtimeConfig);
+  let securityAccepted = isSecurityTrustAccepted(runtimeConfig);
   const needsSecurityAcceptance = !securityAccepted || force;
   const hasRequiredCredentials = currentProviderIsLocal
     ? true
@@ -858,9 +858,14 @@ export async function ensureRuntimeCredentials(
 
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     if (!securityAccepted) {
-      throw new Error(
-        'Security trust model is not accepted. Run `hybridclaw onboarding` in an interactive terminal to accept TRUST_MODEL.md.',
-      );
+      if (process.env.HYBRIDCLAW_ACCEPT_TRUST === 'true') {
+        acceptSecurityTrustModel();
+        securityAccepted = true;
+      } else {
+        throw new Error(
+          'Security trust model is not accepted. Run `hybridclaw onboarding` in an interactive terminal to accept TRUST_MODEL.md, or set HYBRIDCLAW_ACCEPT_TRUST=true to accept automatically.',
+        );
+      }
     }
     if (currentAuth === 'openai-codex') {
       throw new Error(


### PR DESCRIPTION
## Summary

- Adds `HYBRIDCLAW_ACCEPT_TRUST=true` environment variable to auto-accept the security trust model in non-TTY environments
- When running `hybridclaw gateway` in a headless container (no TTY), the onboarding gate throws an error requiring interactive trust acceptance — this makes it impossible to use the gateway image in sandbox containers
- When the env var is set and the process has no TTY, `acceptSecurityTrustModel()` is called automatically, persisting the acceptance to the runtime config

## Changes

- `src/onboarding.ts`: In the non-TTY code path (~line 860), before throwing the "trust model not accepted" error, check for `HYBRIDCLAW_ACCEPT_TRUST === 'true'` and auto-accept if set
- Updated the error message to mention the env var as an alternative

## Test plan

- [ ] Run `hybridclaw gateway` in a container without TTY — verify it fails with updated error message mentioning `HYBRIDCLAW_ACCEPT_TRUST`
- [ ] Run with `HYBRIDCLAW_ACCEPT_TRUST=true` in a container without TTY — verify it auto-accepts and starts successfully
- [ ] Run normally in a TTY terminal — verify no behavior change (interactive onboarding still works as before)