### PR TITLE
fix: gateway foreground mode and credential check after trust acceptance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,4 +59,4 @@ RUN mkdir -p /workspace/.data
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD node -e "fetch('http://127.0.0.1:9090/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 
-CMD ["node", "dist/cli.js", "gateway"]
+CMD ["node", "dist/cli.js", "gateway", "start", "--foreground"]

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -867,6 +867,8 @@ export async function ensureRuntimeCredentials(
         );
       }
     }
+    // After accepting trust via env var, credentials may already be present.
+    if (hasRequiredCredentials) return;
     if (currentAuth === 'openai-codex') {
       throw new Error(
         'OpenAI Codex credentials are missing. Run `hybridclaw codex login` or `hybridclaw onboarding` in an interactive terminal.',


### PR DESCRIPTION
## Summary
- Dockerfile CMD changed to `gateway start --foreground` so the process stays as PID 1 instead of daemonizing (Docker marks exited PID 1 as stopped)
- After accepting trust via `HYBRIDCLAW_ACCEPT_TRUST` env var, check if credentials are already present before throwing "API key missing"

## Context
When the gateway runs in a sandbox container (created by sandbox-service), the `gateway` command forks a background process and the parent exits. Docker sees PID 1 exit and marks the container as stopped. The `--foreground` flag keeps the gateway as PID 1.

The credential check fix is needed because `needsSecurityAcceptance` is computed before the env var trust acceptance, so the early return at line 857 doesn't trigger. After accepting trust, we need to re-check credentials.

## Test plan
- [ ] Build image and run in sandbox container with `HYBRIDCLAW_ACCEPT_TRUST=true` and `HYBRIDAI_API_KEY` set
- [ ] Verify gateway stays running (not exiting with code 0)
- [ ] Verify gateway doesn't throw "API key missing" when key is in env