### PR TITLE
fix: support HEALTH_HOST env var override

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -569,7 +569,7 @@ function applyRuntimeConfig(config: RuntimeConfig): void {
   MEMORY_CONSOLIDATION_INTERVAL_HOURS =
     config.memory.consolidationIntervalHours;
 
-  HEALTH_HOST = config.ops.healthHost;
+  HEALTH_HOST = process.env.HEALTH_HOST || config.ops.healthHost;
   HEALTH_PORT = config.ops.healthPort;
   WEB_API_TOKEN = process.env.WEB_API_TOKEN || config.ops.webApiToken;
   GATEWAY_BASE_URL = config.ops.gatewayBaseUrl;


### PR DESCRIPTION
## Summary

- The gateway's `healthHost` was only configurable via `config.json`, but deployers (like the sandbox-service) need to set it to `0.0.0.0` so the health endpoint is reachable from outside containers.
- Adds a `HEALTH_HOST` env var override following the same pattern as `WEB_API_TOKEN` and `GATEWAY_API_TOKEN`.
- The sandbox-service can now pass `HEALTH_HOST=0.0.0.0` when launching containers — no container auto-detection needed.

## Changes

- `src/config/config.ts`: `HEALTH_HOST` now reads `process.env.HEALTH_HOST` before falling back to `config.ops.healthHost`.

## Test plan

- [x] `npm run typecheck` passes
- [ ] Manual: set `HEALTH_HOST=0.0.0.0` env var, confirm gateway binds to all interfaces
- [ ] Manual: without env var, confirm gateway defaults to `127.0.0.1`
- [ ] Manual: explicit `ops.healthHost` in config.json still works when env var is not set