### PR TITLE
fix: resolve /chat and /agents routes returning 404

### DIFF
--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -389,12 +389,12 @@ async function readJsonBody(req: IncomingMessage): Promise<unknown> {
   }
 }
 
-function resolveSiteFile(pathname: string): string | null {
-  return resolveStaticFile(
-    SITE_DIR,
-    pathname === '/' ? '/index.html' : pathname,
-  );
-}
+/** Map clean route names to their HTML files in docs/. */
+const SITE_PAGE_ROUTES: Record<string, string> = {
+  '/': '/index.html',
+  '/chat': '/chat.html',
+  '/agents': '/agents.html',
+};
 
 function resolveStaticFile(rootDir: string, pathname: string): string | null {
   const cleanPath = pathname === '/' ? '/index.html' : pathname;
@@ -406,14 +406,22 @@ function resolveStaticFile(rootDir: string, pathname: string): string | null {
   return candidate;
 }
 
+function resolveSiteFile(pathname: string): string | null {
+  const mapped = SITE_PAGE_ROUTES[pathname];
+  if (mapped) {
+    return resolveStaticFile(SITE_DIR, mapped);
+  }
+  // Try the pathname as-is (e.g. /static/app.css), then with .html fallback
+  const direct = resolveStaticFile(SITE_DIR, pathname);
+  if (direct) return direct;
+  if (!path.extname(pathname)) {
+    return resolveStaticFile(SITE_DIR, `${pathname}.html`);
+  }
+  return null;
+}
+
 function serveStatic(pathname: string, res: ServerResponse): boolean {
-  const filePath = resolveSiteFile(
-    pathname === '/chat'
-      ? '/chat.html'
-      : pathname === '/agents'
-        ? '/agents.html'
-        : pathname,
-  );
+  const filePath = resolveSiteFile(pathname);
   if (!filePath) return false;
   const ext = path.extname(filePath).toLowerCase();
   const mimeType = SITE_MIME_TYPES[ext] || 'application/octet-stream';


### PR DESCRIPTION
## Summary

- Replaces the inline ternary route mapping in `serveStatic()` with an explicit `SITE_PAGE_ROUTES` lookup table that maps `/`, `/chat`, and `/agents` to their HTML files in `docs/`
- Adds extensionless `.html` fallback in `resolveSiteFile()` so paths without an extension automatically try the `.html` variant before returning 404
- Simplifies `serveStatic()` to a single `resolveSiteFile(pathname)` call instead of pre-mapping routes

## Test plan

- [x] `npm run build` compiles cleanly
- [x] `npm run typecheck` passes
- [x] `npm run check` (biome) passes
- [x] `vitest run tests/gateway-http-server.test.ts` — all 43 tests pass
- [x] `vitest run tests/gateway-agents-docs.test.ts` — all 3 tests pass
- [ ] Manual: verify `/chat`, `/agents`, `/admin`, and `/` return 200 in a running gateway