### PR TITLE
fix: include SPA pages (chat, agents) in Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,7 +20,10 @@ docker/
 
 # Tests and docs
 tests/
-docs/
+docs/development/
+docs/tools/
+docs/*.md
+docs/CNAME
 packages/
 plugins/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,9 @@ COPY --from=builder /app/console/dist ./console/dist
 COPY --from=builder /app/container/dist ./container/dist
 COPY --from=builder /app/container/shared ./container/shared
 
+# SPA pages served by the gateway (/chat, /agents, /)
+COPY docs/ ./docs/
+
 # Runtime templates and skills
 COPY templates/ ./templates/
 COPY skills/ ./skills/


### PR DESCRIPTION
## Summary
- The `/chat` and `/agents` gateway routes serve static HTML from `docs/`, but the Docker image excluded the entire `docs/` directory via `.dockerignore`, causing 404s in container/sandbox mode.
- Replace the blanket `docs/` exclusion with selective ignores for development-only files (`docs/development/`, `docs/tools/`, `docs/*.md`, `docs/CNAME`), keeping only the SPA assets needed at runtime (`chat.html`, `agents.html`, `index.html`, images, favicons).
- Add `COPY docs/ ./docs/` to the runtime stage of the Dockerfile.

## Test plan
- [x] `docker build` succeeds
- [x] Image contains `docs/chat.html`, `docs/agents.html`, `docs/index.html`, `docs/hai_logo_free.png`, `docs/hero.png`, `docs/static/*`
- [x] No markdown docs or development files are present in the image
- [ ] Deploy to sandbox and verify `/chat` and `/agents` return 200 with correct HTML