### PR TITLE
feat(config): support HYBRIDAI_CHATBOT_ID env var override

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -500,7 +500,9 @@ function applyRuntimeConfig(config: RuntimeConfig): void {
 
   HYBRIDAI_BASE_URL = config.hybridai.baseUrl;
   HYBRIDAI_MODEL = config.hybridai.defaultModel;
-  HYBRIDAI_CHATBOT_ID = process.env.HYBRIDAI_CHATBOT_ID || config.hybridai.defaultChatbotId;
+  HYBRIDAI_CHATBOT_ID =
+    (process.env.HYBRIDAI_CHATBOT_ID?.trim() || '') ||
+    config.hybridai.defaultChatbotId;
   HYBRIDAI_MAX_TOKENS = Math.max(
     256,
     Math.min(32_768, config.hybridai.maxTokens),

--- a/tests/configured-models.test.ts
+++ b/tests/configured-models.test.ts
@@ -39,6 +39,8 @@ async function importFreshConfig(homeDir: string) {
   return import('../src/config/config.ts');
 }
 
+const ORIGINAL_HYBRIDAI_CHATBOT_ID = process.env.HYBRIDAI_CHATBOT_ID;
+
 afterEach(() => {
   vi.restoreAllMocks();
   vi.resetModules();
@@ -53,6 +55,43 @@ afterEach(() => {
     process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER =
       ORIGINAL_DISABLE_CONFIG_WATCHER;
   }
+  if (ORIGINAL_HYBRIDAI_CHATBOT_ID === undefined) {
+    delete process.env.HYBRIDAI_CHATBOT_ID;
+  } else {
+    process.env.HYBRIDAI_CHATBOT_ID = ORIGINAL_HYBRIDAI_CHATBOT_ID;
+  }
+});
+
+describe('env var overrides', () => {
+  it('HYBRIDAI_CHATBOT_ID env var overrides config.json value', async () => {
+    const homeDir = makeTempHome();
+    writeRuntimeConfig(homeDir, (config) => {
+      config.hybridai.defaultChatbotId = 'from-config';
+    });
+    process.env.HYBRIDAI_CHATBOT_ID = 'from-env';
+    const config = await importFreshConfig(homeDir);
+    expect(config.HYBRIDAI_CHATBOT_ID).toBe('from-env');
+  });
+
+  it('falls back to config.json when HYBRIDAI_CHATBOT_ID is not set', async () => {
+    const homeDir = makeTempHome();
+    writeRuntimeConfig(homeDir, (config) => {
+      config.hybridai.defaultChatbotId = 'from-config';
+    });
+    delete process.env.HYBRIDAI_CHATBOT_ID;
+    const config = await importFreshConfig(homeDir);
+    expect(config.HYBRIDAI_CHATBOT_ID).toBe('from-config');
+  });
+
+  it('treats whitespace-only HYBRIDAI_CHATBOT_ID as unset', async () => {
+    const homeDir = makeTempHome();
+    writeRuntimeConfig(homeDir, (config) => {
+      config.hybridai.defaultChatbotId = 'from-config';
+    });
+    process.env.HYBRIDAI_CHATBOT_ID = '   ';
+    const config = await importFreshConfig(homeDir);
+    expect(config.HYBRIDAI_CHATBOT_ID).toBe('from-config');
+  });
 });
 
 describe('configured model catalog', () => {


### PR DESCRIPTION
## Summary
- Add `HYBRIDAI_CHATBOT_ID` environment variable override in `src/config/config.ts`, following the same pattern as `HEALTH_HOST` (PR #108)
- Env var takes precedence over `config.json`'s `hybridai.defaultChatbotId`, falling back to the config file value when unset
- Enables sandbox deployments to configure the chatbot ID without writing config.json

## Test plan
- [x] Build passes (pre-existing errors in `claw-archive`/`claw-security` unrelated)
- [x] 1312/1314 tests pass (2 pre-existing failures on main, unrelated)
- [ ] Deploy with `HYBRIDAI_CHATBOT_ID` set and verify it takes effect
- [ ] Deploy without the env var and verify config.json value is still used