### PR TITLE
fix: support multiline enter in tui

### DIFF
--- a/src/tui-input.ts
+++ b/src/tui-input.ts
@@ -3,8 +3,11 @@ import type readline from 'node:readline';
 type InternalReadline = readline.Interface & {
   _insertString?: (value: string) => void;
   _ttyWrite?: (chunk: string, key: readline.Key) => void;
+  line?: string;
 };
 
+const TUI_CONTINUATION_INDENT = '    ';
+const TUI_CONTINUATION_LINE_BREAK = `\n${TUI_CONTINUATION_INDENT}`;
 const SHIFT_RETURN_SEQUENCES = new Set(['\x1b[13;2u', '\x1b[13;2~']);
 const SPLIT_SHIFT_RETURN_SEQUENCE = '\x1b[27;2;13~';
 const SPLIT_SHIFT_RETURN_PREFIX = '\x1b[27;2;';
@@ -55,6 +58,7 @@ export class TuiMultilineInputController {
   private readonly closeHandler: () => void;
   private installedTtyWrite: InternalReadline['_ttyWrite'] | undefined;
   private pendingSplitShiftReturnSequence = '';
+  private insertedContinuationLineBreakCount = 0;
 
   constructor(params: { rl: readline.Interface }) {
     this.rl = params.rl as InternalReadline;
@@ -74,6 +78,10 @@ export class TuiMultilineInputController {
     }
 
     this.installedTtyWrite = (chunk: string, key: readline.Key) => {
+      if ((this.rl.line || '').length === 0) {
+        this.insertedContinuationLineBreakCount = 0;
+      }
+
       const rawSequence = String(key.sequence ?? chunk ?? '');
       if (this.pendingSplitShiftReturnSequence) {
         const nextSequence = `${this.pendingSplitShiftReturnSequence}${rawSequence}`;
@@ -81,7 +89,7 @@ export class TuiMultilineInputController {
           this.pendingSplitShiftReturnSequence = nextSequence;
           if (nextSequence === SPLIT_SHIFT_RETURN_SEQUENCE) {
             this.pendingSplitShiftReturnSequence = '';
-            this.rl._insertString?.('\n');
+            this.insertContinuationLineBreak();
           }
           return;
         }
@@ -103,11 +111,40 @@ export class TuiMultilineInputController {
         return;
       }
 
-      this.rl._insertString?.('\n');
+      this.insertContinuationLineBreak();
     };
 
     this.rl._ttyWrite = this.installedTtyWrite;
     this.rl.on('close', this.closeHandler);
+  }
+
+  normalizeSubmittedInput(input: string): string {
+    const remainingInsertions = this.insertedContinuationLineBreakCount;
+    this.insertedContinuationLineBreakCount = 0;
+    if (
+      remainingInsertions <= 0 ||
+      !input.includes(TUI_CONTINUATION_LINE_BREAK)
+    ) {
+      return input;
+    }
+
+    let remaining = remainingInsertions;
+    let cursor = 0;
+    let normalized = '';
+
+    while (cursor < input.length) {
+      const matchIndex = input.indexOf(TUI_CONTINUATION_LINE_BREAK, cursor);
+      if (matchIndex < 0 || remaining <= 0) {
+        normalized += input.slice(cursor);
+        break;
+      }
+
+      normalized += `${input.slice(cursor, matchIndex)}\n`;
+      cursor = matchIndex + TUI_CONTINUATION_LINE_BREAK.length;
+      remaining -= 1;
+    }
+
+    return normalized;
   }
 
   dispose(): void {
@@ -118,6 +155,7 @@ export class TuiMultilineInputController {
       );
     }
     this.pendingSplitShiftReturnSequence = '';
+    this.insertedContinuationLineBreakCount = 0;
     if (
       this.installedTtyWrite &&
       this.rl._ttyWrite === this.installedTtyWrite &&
@@ -127,5 +165,10 @@ export class TuiMultilineInputController {
     }
     this.installedTtyWrite = undefined;
     this.rl.off('close', this.closeHandler);
+  }
+
+  private insertContinuationLineBreak(): void {
+    this.insertedContinuationLineBreakCount += 1;
+    this.rl._insertString?.(TUI_CONTINUATION_LINE_BREAK);
   }
 }

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -1798,7 +1798,9 @@ async function main(): Promise<void> {
       pendingInputTimer = null;
     }
     if (pendingInputLines.length === 0) return;
-    const combined = pendingInputLines.join('\n');
+    const combined = multilineInputController.normalizeSubmittedInput(
+      pendingInputLines.join('\n'),
+    );
     pendingInputLines = [];
     enqueueInput(combined);
   };

--- a/tests/tui-input.test.ts
+++ b/tests/tui-input.test.ts
@@ -77,6 +77,7 @@ test('intercepts multiline enter and inserts a newline into the readline buffer'
   const closeHandlers: Array<() => void> = [];
   const off = vi.fn();
   const rl = {
+    line: '',
     _insertString: vi.fn((value: string) => {
       inserted.push(value);
     }),
@@ -100,7 +101,7 @@ test('intercepts multiline enter and inserts a newline into the readline buffer'
     shift: false,
   });
 
-  expect(inserted).toEqual(['\n']);
+  expect(inserted).toEqual(['\n    ']);
   expect(originalTtyWrite).not.toHaveBeenCalled();
 
   for (const handler of closeHandlers) {
@@ -112,6 +113,7 @@ test('intercepts multiline enter and inserts a newline into the readline buffer'
 test('passes plain return through to readline submit handling', () => {
   const originalTtyWrite = vi.fn();
   const rl = {
+    line: '',
     _insertString: vi.fn(),
     _ttyWrite: originalTtyWrite,
     on: vi.fn(),
@@ -144,6 +146,7 @@ test('consumes split shift-return sequences and inserts a newline', () => {
   const inserted: string[] = [];
   const originalTtyWrite = vi.fn();
   const rl = {
+    line: '',
     _insertString: vi.fn((value: string) => {
       inserted.push(value);
     }),
@@ -185,6 +188,39 @@ test('consumes split shift-return sequences and inserts a newline', () => {
     shift: false,
   });
 
-  expect(inserted).toEqual(['\n']);
+  expect(inserted).toEqual(['\n    ']);
   expect(originalTtyWrite).not.toHaveBeenCalled();
+});
+
+test('normalizes continuation indent before submission', () => {
+  const rl = {
+    line: '',
+    _insertString: vi.fn(),
+    _ttyWrite: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  } as unknown as readline.Interface;
+
+  const controller = new TuiMultilineInputController({ rl });
+  controller.install();
+
+  (
+    rl as unknown as {
+      _ttyWrite: (chunk: string, key: readline.Key) => void;
+      line: string;
+    }
+  )._ttyWrite('', {
+    name: 'enter',
+    sequence: '\n',
+    ctrl: false,
+    meta: false,
+    shift: false,
+  });
+
+  expect(controller.normalizeSubmittedInput('first\n    second')).toBe(
+    'first\nsecond',
+  );
+  expect(controller.normalizeSubmittedInput('first\n    second')).toBe(
+    'first\n    second',
+  );
 });


### PR DESCRIPTION
## Summary
- add a TUI multiline input controller that turns Ctrl-J and shifted-enter variants into newline insertion instead of submit
- install the controller in the TUI readline setup and document the shortcut in /help
- cover the key classification and readline interception behavior with unit tests

## Validation
- npm run typecheck
- ./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/tui-input.test.ts
- ./node_modules/.bin/biome check src/tui.ts src/tui-input.ts tests/tui-input.test.ts