### PR TITLE
fix(gateway): honor HYBRIDAI_BASE_URL from env

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -399,6 +399,14 @@ function dedupeStringList(values: string[]): string[] {
   return out;
 }
 
+function normalizeConfiguredBaseUrl(
+  raw: string | undefined,
+  fallback: string,
+): string {
+  const trimmed = String(raw || '').trim().replace(/\/+$/, '');
+  return trimmed || fallback;
+}
+
 function applyRuntimeConfig(config: RuntimeConfig): void {
   DISCORD_PREFIX = config.discord.prefix;
   DISCORD_GUILD_MEMBERS_INTENT = config.discord.guildMembersIntent;
@@ -498,7 +506,10 @@ function applyRuntimeConfig(config: RuntimeConfig): void {
   );
   EMAIL_MEDIA_MAX_MB = Math.max(1, config.email.mediaMaxMb);
 
-  HYBRIDAI_BASE_URL = config.hybridai.baseUrl;
+  HYBRIDAI_BASE_URL = normalizeConfiguredBaseUrl(
+    process.env.HYBRIDAI_BASE_URL,
+    config.hybridai.baseUrl,
+  );
   HYBRIDAI_MODEL = config.hybridai.defaultModel;
   HYBRIDAI_CHATBOT_ID =
     (process.env.HYBRIDAI_CHATBOT_ID?.trim() || '') ||

--- a/tests/gateway-service.bot-auth.test.ts
+++ b/tests/gateway-service.bot-auth.test.ts
@@ -391,6 +391,62 @@ test('bot list suggests http when HybridAI baseUrl uses https for a local non-TL
   );
 });
 
+test('bot list error uses HYBRIDAI_BASE_URL from env when present', async () => {
+  setupHome({ HYBRIDAI_BASE_URL: 'https://preview-pr-123.example.com' });
+
+  vi.doMock('../src/providers/hybridai-bots.ts', () => {
+    class HybridAIBotFetchError extends Error {
+      status: number;
+      code?: number | string;
+      type?: string;
+      constructor(params: {
+        status: number;
+        message: string;
+        code?: number | string;
+        type?: string;
+      }) {
+        super(params.message);
+        this.name = 'HybridAIBotFetchError';
+        this.status = params.status;
+        this.code = params.code;
+        this.type = params.type;
+      }
+    }
+
+    return {
+      HybridAIBotFetchError,
+      fetchHybridAIBots: vi.fn(async () => {
+        throw new HybridAIBotFetchError({
+          status: 0,
+          type: 'network_error',
+          message: 'fetch failed (connect ECONNREFUSED 10.0.0.1:443)',
+        });
+      }),
+    };
+  });
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  initDatabase({ quiet: true });
+
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+  const result = await handleGatewayCommand({
+    sessionId: 'session-bot-env-base-url',
+    guildId: null,
+    channelId: 'channel-bot-env-base-url',
+    args: ['bot', 'list'],
+  });
+
+  expect(result.kind).toBe('error');
+  if (result.kind !== 'error') {
+    throw new Error(`Unexpected result kind: ${result.kind}`);
+  }
+  expect(result.text).toBe(
+    'HybridAI is not reachable at `https://preview-pr-123.example.com`. Check `hybridai.baseUrl` and confirm the HybridAI service is running.',
+  );
+});
+
 test('bot list still classifies generic auth errors without HybridAIBotFetchError metadata', async () => {
   setupHome();
 


### PR DESCRIPTION
## Summary
- let the gateway use \ from the environment instead of always falling back to runtime-config defaults
- add a regression test covering the reachability error text when a preview URL is injected

## Why
Preview sandboxes need to talk back to the preview chat deployment rather than hard-coding \. This also prevents misleading errors during sandbox launch when the gateway receives a non-production base URL from the chat app.

## Testing
- npx vitest run --configLoader runner --config vitest.unit.config.ts tests/gateway-service.bot-auth.test.ts --testTimeout=10000