### PR TITLE
fix: tighten memory db query typing

### DIFF
--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import Database from 'better-sqlite3';
 import type { AgentConfig, AgentModelConfig } from '../agents/agent-types.js';
 import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
-import type { AuditEventPayload, WireRecord } from '../audit/audit-trail.js';
+import type { WireRecord } from '../audit/audit-trail.js';
 import { DB_PATH } from '../config/config.js';
 import { getRuntimeConfig } from '../config/runtime-config.js';
 import { logger } from '../logger.js';


### PR DESCRIPTION
## Summary
- replace ad hoc `better-sqlite3` row assertions in `src/memory/db.ts` with typed query helpers
- derive local DB row aliases from exported domain types where schemas overlap to reduce drift risk
- keep memory DB behavior unchanged while tightening typed reads across sessions, tasks, audit, and skill tables

## Testing
- npm run typecheck
- npm run test:unit -- tests/memory-service.test.ts