### PR TITLE
refactor: refine shared type boundaries

### DIFF
--- a/container/src/types.ts
+++ b/container/src/types.ts
@@ -143,15 +143,9 @@ export const TASK_MODEL_KEYS = [
 
 export type TaskModelKey = (typeof TASK_MODEL_KEYS)[number];
 
-export interface TaskModelPolicies {
-  vision?: TaskModelPolicy;
-  compression?: TaskModelPolicy;
-  web_extract?: TaskModelPolicy;
-  session_search?: TaskModelPolicy;
-  skills_hub?: TaskModelPolicy;
-  mcp?: TaskModelPolicy;
-  flush_memories?: TaskModelPolicy;
-}
+export type TaskModelPolicies = {
+  [K in TaskModelKey]?: TaskModelPolicy;
+};
 
 export interface ContextGuardConfig {
   enabled: boolean;
@@ -159,6 +153,39 @@ export interface ContextGuardConfig {
   compactionRatio: number;
   overflowRatio: number;
   maxRetries: number;
+}
+
+// CamelCase projection of a scheduled_tasks row received over gateway/container IPC.
+export interface ScheduledTaskInput {
+  id: number;
+  cronExpr: string;
+  runAt: string | null;
+  everyMs: number | null;
+  prompt: string;
+  enabled: number;
+  lastRun: string | null;
+  createdAt: string;
+}
+
+export interface WebSearchConfig {
+  provider:
+    | 'auto'
+    | 'brave'
+    | 'perplexity'
+    | 'tavily'
+    | 'duckduckgo'
+    | 'searxng';
+  fallbackProviders: (
+    | 'brave'
+    | 'perplexity'
+    | 'tavily'
+    | 'duckduckgo'
+    | 'searxng'
+  )[];
+  defaultCount: number;
+  cacheTtlMinutes: number;
+  searxngBaseUrl: string;
+  tavilySearchDepth: 'basic' | 'advanced';
 }
 
 export interface ContainerInput {
@@ -188,16 +215,7 @@ export interface ContainerInput {
   maxTokens?: number;
   channelId: string;
   configuredDiscordChannels?: string[];
-  scheduledTasks?: {
-    id: number;
-    cronExpr: string;
-    runAt: string | null;
-    everyMs: number | null;
-    prompt: string;
-    enabled: number;
-    lastRun: string | null;
-    createdAt: string;
-  }[];
+  scheduledTasks?: ScheduledTaskInput[];
   allowedTools?: string[];
   blockedTools?: string[];
   media?: MediaContextItem[];
@@ -206,26 +224,7 @@ export interface ContainerInput {
   mcpServers?: Record<string, McpServerConfig>;
   taskModels?: TaskModelPolicies;
   contextGuard?: ContextGuardConfig;
-  webSearch?: {
-    provider:
-      | 'auto'
-      | 'brave'
-      | 'perplexity'
-      | 'tavily'
-      | 'duckduckgo'
-      | 'searxng';
-    fallbackProviders: (
-      | 'brave'
-      | 'perplexity'
-      | 'tavily'
-      | 'duckduckgo'
-      | 'searxng'
-    )[];
-    defaultCount: number;
-    cacheTtlMinutes: number;
-    searxngBaseUrl: string;
-    tavilySearchDepth: 'basic' | 'advanced';
-  };
+  webSearch?: WebSearchConfig;
 }
 
 export interface MediaContextItem {

--- a/src/agent/executor-types.ts
+++ b/src/agent/executor-types.ts
@@ -1,11 +1,10 @@
 import type { ChatMessage } from '../types/api.js';
+import type { ContainerOutput, MediaContextItem } from '../types/container.js';
 import type {
-  ContainerOutput,
-  MediaContextItem,
   PendingApproval,
   PluginRuntimeToolDefinition,
   ToolProgressEvent,
-} from '../types/container.js';
+} from '../types/execution.js';
 import type { ScheduledTask } from '../types/scheduler.js';
 
 export interface ExecutorRequest {

--- a/src/agent/side-effects.ts
+++ b/src/agent/side-effects.ts
@@ -1,10 +1,8 @@
 import { logger } from '../logger.js';
 import { createTask, deleteTask } from '../memory/db.js';
 import { rearmScheduler } from '../scheduler/scheduler.js';
-import type {
-  ContainerOutput,
-  DelegationSideEffect,
-} from '../types/container.js';
+import type { ContainerOutput } from '../types/container.js';
+import type { DelegationSideEffect } from '../types/side-effects.js';
 
 interface SideEffectHandlers {
   onDelegation?: (effect: DelegationSideEffect) => void;

--- a/src/audit/audit-events.ts
+++ b/src/audit/audit-events.ts
@@ -1,6 +1,6 @@
 import { logger } from '../logger.js';
 import { logStructuredAuditEvent } from '../memory/db.js';
-import type { ToolExecution } from '../types/container.js';
+import type { ToolExecution } from '../types/execution.js';
 import {
   type AuditEventPayload,
   appendAuditEvent,

--- a/src/channels/msteams/attachments.ts
+++ b/src/channels/msteams/attachments.ts
@@ -14,10 +14,8 @@ import {
   MSTEAMS_TENANT_ID,
 } from '../../config/config.js';
 import { logger } from '../../logger.js';
-import type {
-  ArtifactMetadata,
-  MediaContextItem,
-} from '../../types/container.js';
+import type { MediaContextItem } from '../../types/container.js';
+import type { ArtifactMetadata } from '../../types/execution.js';
 import { isRecord, normalizeValue } from './utils.js';
 
 const OUTBOUND_MIME_TYPE_BY_EXTENSION: Record<string, string> = {

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -29,7 +29,7 @@ import {
   type SessionDmScope,
 } from '../session/session-routing.js';
 import type { AdaptiveSkillsConfig } from '../skills/adaptive-skills-types.js';
-import type { McpServerConfig } from '../types/container.js';
+import type { McpServerConfig } from '../types/models.js';
 import { normalizeTrimmedStringSet } from '../utils/normalized-strings.js';
 
 export const CONFIG_FILE_NAME = 'config.json';

--- a/src/gateway/fullauto.ts
+++ b/src/gateway/fullauto.ts
@@ -40,7 +40,7 @@ import type { ChatMessage } from '../types/api.js';
 import type {
   ArtifactMetadata,
   ToolProgressEvent,
-} from '../types/container.js';
+} from '../types/execution.js';
 import type { Session } from '../types/session.js';
 import { sleep } from '../utils/sleep.js';
 import {

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -39,11 +39,8 @@ import {
   buildSessionKey,
   classifySessionKeyShape,
 } from '../session/session-key.js';
-import type {
-  MediaContextItem,
-  PendingApproval,
-  ToolProgressEvent,
-} from '../types/container.js';
+import type { MediaContextItem } from '../types/container.js';
+import type { PendingApproval, ToolProgressEvent } from '../types/execution.js';
 import {
   hasSessionAuth,
   setSessionCookie,

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -220,22 +220,24 @@ import {
 } from '../skills/skills-observation.js';
 import type { ChatMessage } from '../types/api.js';
 import type { StructuredAuditEntry } from '../types/audit.js';
+import type { MediaContextItem } from '../types/container.js';
 import type {
   ArtifactMetadata,
-  DelegationSideEffect,
-  DelegationTaskSpec,
-  McpServerConfig,
-  MediaContextItem,
   PendingApproval,
   ToolExecution,
   ToolProgressEvent,
-} from '../types/container.js';
+} from '../types/execution.js';
+import type { McpServerConfig } from '../types/models.js';
 import type { ScheduledTask } from '../types/scheduler.js';
 import type {
   CanonicalSessionContext,
   Session,
   StoredMessage,
 } from '../types/session.js';
+import type {
+  DelegationSideEffect,
+  DelegationTaskSpec,
+} from '../types/side-effects.js';
 import type { TokenUsageStats } from '../types/usage.js';
 import { sleep } from '../utils/sleep.js';
 import { ensureBootstrapFiles, resetWorkspace } from '../workspace.js';

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -7,12 +7,10 @@ import type {
   RuntimeMSTeamsChannelConfig,
   RuntimeSchedulerJob,
 } from '../config/runtime-config.js';
-import type {
-  McpServerConfig,
-  MediaContextItem,
-  PendingApproval,
-} from '../types/container.js';
+import type { MediaContextItem } from '../types/container.js';
+import type { PendingApproval } from '../types/execution.js';
 import type { MemoryCitation } from '../types/memory.js';
+import type { McpServerConfig } from '../types/models.js';
 import type { TokenUsageStats } from '../types/usage.js';
 
 export type GatewayMessageComponents = NonNullable<

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -76,7 +76,7 @@ import {
   startScheduler,
   stopScheduler,
 } from '../scheduler/scheduler.js';
-import type { ArtifactMetadata } from '../types/container.js';
+import type { ArtifactMetadata } from '../types/execution.js';
 import { buildApprovalConfirmationComponents } from './approval-confirmation.js';
 import { extractGatewayChatApprovalEvent } from './chat-approval.js';
 import {

--- a/src/gateway/text-channel-commands.ts
+++ b/src/gateway/text-channel-commands.ts
@@ -8,7 +8,7 @@ import {
   mapTuiSlashCommandToGatewayArgs,
   parseTuiSlashCommand,
 } from '../tui-slash-command.js';
-import type { ArtifactMetadata } from '../types/container.js';
+import type { ArtifactMetadata } from '../types/execution.js';
 import { extractGatewayChatApprovalEvent } from './chat-approval.js';
 import {
   normalizePendingApprovalReply,

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -52,13 +52,13 @@ import { resolveTaskModelPolicies } from '../providers/task-routing.js';
 import { resolveConfiguredAdditionalMounts } from '../security/mount-config.js';
 import { validateAdditionalMounts } from '../security/mount-security.js';
 import { redactSecrets } from '../security/redact.js';
+import type { ContainerInput, ContainerOutput } from '../types/container.js';
 import type {
   ArtifactMetadata,
-  ContainerInput,
-  ContainerOutput,
   PendingApproval,
   ToolProgressEvent,
-} from '../types/container.js';
+} from '../types/execution.js';
+import type { ScheduledTaskInput } from '../types/scheduler.js';
 import type { AdditionalMount } from '../types/security.js';
 import {
   agentWorkspaceDir,
@@ -676,16 +676,18 @@ export async function runContainer(
     maxTokens: HYBRIDAI_MAX_TOKENS,
     channelId,
     configuredDiscordChannels: collectConfiguredDiscordChannelIds(channelId),
-    scheduledTasks: scheduledTasks?.map((t) => ({
-      id: t.id,
-      cronExpr: t.cron_expr,
-      runAt: t.run_at,
-      everyMs: t.every_ms,
-      prompt: t.prompt,
-      enabled: t.enabled,
-      lastRun: t.last_run,
-      createdAt: t.created_at,
-    })),
+    scheduledTasks: scheduledTasks?.map(
+      (task): ScheduledTaskInput => ({
+        id: task.id,
+        cronExpr: task.cron_expr,
+        runAt: task.run_at,
+        everyMs: task.every_ms,
+        prompt: task.prompt,
+        enabled: task.enabled,
+        lastRun: task.last_run,
+        createdAt: task.created_at,
+      }),
+    ),
     allowedTools,
     blockedTools,
     media,

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -35,12 +35,9 @@ import { resolveUploadedMediaCacheHostDir } from '../media/uploaded-media-cache.
 import { resolveModelRuntimeCredentials } from '../providers/factory.js';
 import { resolveTaskModelPolicies } from '../providers/task-routing.js';
 import { redactSecrets } from '../security/redact.js';
-import type {
-  ContainerInput,
-  ContainerOutput,
-  PendingApproval,
-  ToolProgressEvent,
-} from '../types/container.js';
+import type { ContainerInput, ContainerOutput } from '../types/container.js';
+import type { PendingApproval, ToolProgressEvent } from '../types/execution.js';
+import type { ScheduledTaskInput } from '../types/scheduler.js';
 import {
   collectConfiguredDiscordChannelIds,
   remapOutputArtifacts,
@@ -505,16 +502,18 @@ export async function runHostProcess(
     maxTokens: HYBRIDAI_MAX_TOKENS,
     channelId,
     configuredDiscordChannels: collectConfiguredDiscordChannelIds(channelId),
-    scheduledTasks: scheduledTasks?.map((task) => ({
-      id: task.id,
-      cronExpr: task.cron_expr,
-      runAt: task.run_at,
-      everyMs: task.every_ms,
-      prompt: task.prompt,
-      enabled: task.enabled,
-      lastRun: task.last_run,
-      createdAt: task.created_at,
-    })),
+    scheduledTasks: scheduledTasks?.map(
+      (task): ScheduledTaskInput => ({
+        id: task.id,
+        cronExpr: task.cron_expr,
+        runAt: task.run_at,
+        everyMs: task.every_ms,
+        prompt: task.prompt,
+        enabled: task.enabled,
+        lastRun: task.last_run,
+        createdAt: task.created_at,
+      }),
+    ),
     allowedTools,
     blockedTools,
     media,

--- a/src/infra/ipc.ts
+++ b/src/infra/ipc.ts
@@ -4,11 +4,8 @@ import path from 'node:path';
 import { resolveAgentWorkspaceId } from '../agents/agent-registry.js';
 import { CONTAINER_MAX_OUTPUT_SIZE, DATA_DIR } from '../config/config.js';
 import { logger } from '../logger.js';
-import {
-  type ContainerInput,
-  type ContainerOutput,
-  TASK_MODEL_KEYS,
-} from '../types/container.js';
+import type { ContainerInput, ContainerOutput } from '../types/container.js';
+import { TASK_MODEL_KEYS } from '../types/models.js';
 
 /**
  * Get session directory, creating it if needed.

--- a/src/infra/worker-signature.ts
+++ b/src/infra/worker-signature.ts
@@ -1,4 +1,4 @@
-import { TASK_MODEL_KEYS, type TaskModelKey } from '../types/container.js';
+import { TASK_MODEL_KEYS, type TaskModelKey } from '../types/models.js';
 
 interface WorkerSignatureTaskModel {
   provider?: string;

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -30,7 +30,7 @@ import {
   runtimeSecretsPath,
   saveRuntimeSecrets,
 } from './security/runtime-secrets.js';
-import type { HybridAIBot } from './types/api.js';
+import type { HybridAIBot } from './types/hybridai.js';
 
 interface ApiKeyValidationResult {
   ok: boolean;

--- a/src/providers/hybridai-bots.ts
+++ b/src/providers/hybridai-bots.ts
@@ -1,7 +1,7 @@
 import { getHybridAIApiKey } from '../auth/hybridai-auth.js';
 import { HYBRIDAI_BASE_URL } from '../config/config.js';
 import { logger } from '../logger.js';
-import type { HybridAIBot } from '../types/api.js';
+import type { HybridAIBot } from '../types/hybridai.js';
 
 interface BotCacheEntry {
   bots: HybridAIBot[];

--- a/src/providers/task-routing.ts
+++ b/src/providers/task-routing.ts
@@ -9,7 +9,7 @@ import {
   type TaskModelKey,
   type TaskModelPolicies,
   type TaskModelPolicy,
-} from '../types/container.js';
+} from '../types/models.js';
 import { resolveModelRuntimeCredentials } from './factory.js';
 import {
   findVisionCapableModel,

--- a/src/skills/skills-observation.ts
+++ b/src/skills/skills-observation.ts
@@ -6,7 +6,7 @@ import {
   incrementAmendmentRunCount,
   recordSkillObservation as insertSkillObservation,
 } from '../memory/db.js';
-import type { ToolExecution } from '../types/container.js';
+import type { ToolExecution } from '../types/execution.js';
 import type {
   AdaptiveSkillsConfig,
   SkillErrorCategory,

--- a/src/skills/skills.ts
+++ b/src/skills/skills.ts
@@ -19,7 +19,7 @@ import {
 import { resolveInstallPath } from '../infra/install-root.js';
 import { agentWorkspaceDir } from '../infra/ipc.js';
 import { logger } from '../logger.js';
-import type { ToolExecution } from '../types/container.js';
+import type { ToolExecution } from '../types/execution.js';
 import { hasExecutableCommand } from '../utils/executables.js';
 import { guardSkillDirectory } from './skills-guard.js';
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -39,10 +39,3 @@ export interface ToolCall {
     arguments: string;
   };
 }
-
-export interface HybridAIBot {
-  id: string;
-  name: string;
-  description?: string;
-  model?: string;
-}

--- a/src/types/container.ts
+++ b/src/types/container.ts
@@ -1,6 +1,22 @@
 import type { ChatMessage } from './api.js';
+import type {
+  ArtifactMetadata,
+  PendingApproval,
+  PluginRuntimeToolDefinition,
+  ToolExecution,
+} from './execution.js';
 import type { MemoryCitation } from './memory.js';
-import type { ScheduleSideEffect } from './scheduler.js';
+import type {
+  ContextGuardConfig,
+  McpServerConfig,
+  ProviderKind,
+  TaskModelPolicies,
+} from './models.js';
+import type { ScheduledTaskInput } from './scheduler.js';
+import type {
+  DelegationSideEffect,
+  ScheduleSideEffect,
+} from './side-effects.js';
 import type { TokenUsageStats } from './usage.js';
 
 export interface MediaContextItem {
@@ -12,88 +28,25 @@ export interface MediaContextItem {
   filename: string;
 }
 
-export interface McpServerConfig {
-  transport: 'stdio' | 'http' | 'sse';
-  command?: string;
-  args?: string[];
-  env?: Record<string, string>;
-  cwd?: string;
-  url?: string;
-  headers?: Record<string, string>;
-  enabled?: boolean;
-}
-
-export interface RuntimeToolSchemaProperty {
-  type: string | string[];
-  description?: string;
-  items?: RuntimeToolSchemaProperty;
-  properties?: Record<string, RuntimeToolSchemaProperty>;
-  required?: string[];
-  enum?: string[];
-  minItems?: number;
-  maxItems?: number;
-}
-
-export interface RuntimeToolSchema {
-  type: 'object';
-  properties: Record<string, RuntimeToolSchemaProperty>;
-  required: string[];
-}
-
-export interface PluginRuntimeToolDefinition {
-  name: string;
-  description: string;
-  parameters: RuntimeToolSchema;
-}
-
-export interface TaskModelPolicy {
-  provider?:
-    | 'hybridai'
-    | 'openai-codex'
-    | 'openrouter'
-    | 'ollama'
-    | 'lmstudio'
-    | 'vllm';
-  baseUrl?: string;
-  apiKey?: string;
-  requestHeaders?: Record<string, string>;
-  isLocal?: boolean;
-  contextWindow?: number;
-  thinkingFormat?: 'qwen';
-  model: string;
-  chatbotId?: string;
-  maxTokens?: number;
-  error?: string;
-}
-
-export const TASK_MODEL_KEYS = [
-  'vision',
-  'compression',
-  'web_extract',
-  'session_search',
-  'skills_hub',
-  'mcp',
-  'flush_memories',
-] as const;
-
-export type TaskModelKey = (typeof TASK_MODEL_KEYS)[number];
-
-export interface TaskModelPolicies {
-  vision?: TaskModelPolicy;
-  compression?: TaskModelPolicy;
-  web_extract?: TaskModelPolicy;
-  session_search?: TaskModelPolicy;
-  skills_hub?: TaskModelPolicy;
-  mcp?: TaskModelPolicy;
-  flush_memories?: TaskModelPolicy;
-}
-
-export interface ContextGuardConfig {
-  enabled: boolean;
-  perResultShare: number;
-  compactionRatio: number;
-  overflowRatio: number;
-  maxRetries: number;
+export interface WebSearchConfig {
+  provider:
+    | 'auto'
+    | 'brave'
+    | 'perplexity'
+    | 'tavily'
+    | 'duckduckgo'
+    | 'searxng';
+  fallbackProviders: (
+    | 'brave'
+    | 'perplexity'
+    | 'tavily'
+    | 'duckduckgo'
+    | 'searxng'
+  )[];
+  defaultCount: number;
+  cacheTtlMinutes: number;
+  searxngBaseUrl: string;
+  tavilySearchDepth: 'basic' | 'advanced';
 }
 
 export interface ContainerInput {
@@ -103,13 +56,7 @@ export interface ContainerInput {
   enableRag: boolean;
   apiKey: string;
   baseUrl: string;
-  provider?:
-    | 'hybridai'
-    | 'openai-codex'
-    | 'openrouter'
-    | 'ollama'
-    | 'lmstudio'
-    | 'vllm';
+  provider?: ProviderKind;
   requestHeaders?: Record<string, string>;
   isLocal?: boolean;
   contextWindow?: number;
@@ -123,16 +70,7 @@ export interface ContainerInput {
   maxTokens?: number;
   channelId: string;
   configuredDiscordChannels?: string[];
-  scheduledTasks?: {
-    id: number;
-    cronExpr: string;
-    runAt: string | null;
-    everyMs: number | null;
-    prompt: string;
-    enabled: number;
-    lastRun: string | null;
-    createdAt: string;
-  }[];
+  scheduledTasks?: ScheduledTaskInput[];
   allowedTools?: string[];
   blockedTools?: string[];
   media?: MediaContextItem[];
@@ -141,79 +79,7 @@ export interface ContainerInput {
   mcpServers?: Record<string, McpServerConfig>;
   taskModels?: TaskModelPolicies;
   contextGuard?: ContextGuardConfig;
-  webSearch?: {
-    provider:
-      | 'auto'
-      | 'brave'
-      | 'perplexity'
-      | 'tavily'
-      | 'duckduckgo'
-      | 'searxng';
-    fallbackProviders: (
-      | 'brave'
-      | 'perplexity'
-      | 'tavily'
-      | 'duckduckgo'
-      | 'searxng'
-    )[];
-    defaultCount: number;
-    cacheTtlMinutes: number;
-    searxngBaseUrl: string;
-    tavilySearchDepth: 'basic' | 'advanced';
-  };
-}
-
-export interface ToolExecution {
-  name: string;
-  arguments: string;
-  result: string;
-  durationMs: number;
-  isError?: boolean;
-  blocked?: boolean;
-  blockedReason?: string;
-  approvalTier?: 'green' | 'yellow' | 'red';
-  approvalBaseTier?: 'green' | 'yellow' | 'red';
-  approvalDecision?:
-    | 'auto'
-    | 'implicit'
-    | 'approved_once'
-    | 'approved_session'
-    | 'approved_agent'
-    | 'approved_fullauto'
-    | 'promoted'
-    | 'required'
-    | 'denied';
-  approvalActionKey?: string;
-  approvalIntent?: string;
-  approvalReason?: string;
-  approvalRequestId?: string;
-  approvalExpiresAt?: number;
-  approvalAllowSession?: boolean;
-  approvalAllowAgent?: boolean;
-}
-
-export interface PendingApproval {
-  approvalId: string;
-  prompt: string;
-  intent: string;
-  reason: string;
-  allowSession: boolean;
-  allowAgent: boolean;
-  expiresAt: number | null;
-}
-
-export interface ToolProgressEvent {
-  sessionId: string;
-  toolName: string;
-  phase: 'start' | 'finish';
-  preview?: string;
-  durationMs?: number;
-}
-
-export interface ArtifactMetadata {
-  path: string;
-  filename: string;
-  mimeType: string;
+  webSearch?: WebSearchConfig;
 }
 
 export interface ContainerOutput {
@@ -231,20 +97,4 @@ export interface ContainerOutput {
     schedules?: ScheduleSideEffect[];
     delegations?: DelegationSideEffect[];
   };
-}
-
-export interface DelegationTaskSpec {
-  prompt: string;
-  label?: string;
-  model?: string;
-}
-
-export interface DelegationSideEffect {
-  action: 'delegate';
-  mode?: 'single' | 'parallel' | 'chain';
-  prompt?: string;
-  label?: string;
-  model?: string;
-  tasks?: DelegationTaskSpec[];
-  chain?: DelegationTaskSpec[];
 }

--- a/src/types/execution.ts
+++ b/src/types/execution.ts
@@ -1,0 +1,75 @@
+export interface RuntimeToolSchemaProperty {
+  type: string | string[];
+  description?: string;
+  items?: RuntimeToolSchemaProperty;
+  properties?: Record<string, RuntimeToolSchemaProperty>;
+  required?: string[];
+  enum?: string[];
+  minItems?: number;
+  maxItems?: number;
+}
+
+export interface RuntimeToolSchema {
+  type: 'object';
+  properties: Record<string, RuntimeToolSchemaProperty>;
+  required: string[];
+}
+
+export interface PluginRuntimeToolDefinition {
+  name: string;
+  description: string;
+  parameters: RuntimeToolSchema;
+}
+
+export interface ToolExecution {
+  name: string;
+  arguments: string;
+  result: string;
+  durationMs: number;
+  isError?: boolean;
+  blocked?: boolean;
+  blockedReason?: string;
+  approvalTier?: 'green' | 'yellow' | 'red';
+  approvalBaseTier?: 'green' | 'yellow' | 'red';
+  approvalDecision?:
+    | 'auto'
+    | 'implicit'
+    | 'approved_once'
+    | 'approved_session'
+    | 'approved_agent'
+    | 'approved_fullauto'
+    | 'promoted'
+    | 'required'
+    | 'denied';
+  approvalActionKey?: string;
+  approvalIntent?: string;
+  approvalReason?: string;
+  approvalRequestId?: string;
+  approvalExpiresAt?: number;
+  approvalAllowSession?: boolean;
+  approvalAllowAgent?: boolean;
+}
+
+export interface PendingApproval {
+  approvalId: string;
+  prompt: string;
+  intent: string;
+  reason: string;
+  allowSession: boolean;
+  allowAgent: boolean;
+  expiresAt: number | null;
+}
+
+export interface ToolProgressEvent {
+  sessionId: string;
+  toolName: string;
+  phase: 'start' | 'finish';
+  preview?: string;
+  durationMs?: number;
+}
+
+export interface ArtifactMetadata {
+  path: string;
+  filename: string;
+  mimeType: string;
+}

--- a/src/types/hybridai.ts
+++ b/src/types/hybridai.ts
@@ -1,0 +1,6 @@
+export interface HybridAIBot {
+  id: string;
+  name: string;
+  description?: string;
+  model?: string;
+}

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1,0 +1,56 @@
+export type ProviderKind =
+  | 'hybridai'
+  | 'openai-codex'
+  | 'openrouter'
+  | 'ollama'
+  | 'lmstudio'
+  | 'vllm';
+
+export interface McpServerConfig {
+  transport: 'stdio' | 'http' | 'sse';
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+  url?: string;
+  headers?: Record<string, string>;
+  enabled?: boolean;
+}
+
+export interface TaskModelPolicy {
+  provider?: ProviderKind;
+  baseUrl?: string;
+  apiKey?: string;
+  requestHeaders?: Record<string, string>;
+  isLocal?: boolean;
+  contextWindow?: number;
+  thinkingFormat?: 'qwen';
+  model: string;
+  chatbotId?: string;
+  maxTokens?: number;
+  error?: string;
+}
+
+export const TASK_MODEL_KEYS = [
+  'vision',
+  'compression',
+  'web_extract',
+  'session_search',
+  'skills_hub',
+  'mcp',
+  'flush_memories',
+] as const;
+
+export type TaskModelKey = (typeof TASK_MODEL_KEYS)[number];
+
+export type TaskModelPolicies = {
+  [K in TaskModelKey]?: TaskModelPolicy;
+};
+
+export interface ContextGuardConfig {
+  enabled: boolean;
+  perResultShare: number;
+  compactionRatio: number;
+  overflowRatio: number;
+  maxRetries: number;
+}

--- a/src/types/scheduler.ts
+++ b/src/types/scheduler.ts
@@ -1,13 +1,3 @@
-export type ScheduleSideEffect =
-  | {
-      action: 'add';
-      cronExpr?: string;
-      runAt?: string;
-      everyMs?: number;
-      prompt: string;
-    }
-  | { action: 'remove'; taskId: number };
-
 export interface ScheduledTask {
   id: number;
   session_id: string;
@@ -21,4 +11,16 @@ export interface ScheduledTask {
   last_status: string | null;
   consecutive_errors: number;
   created_at: string;
+}
+
+// CamelCase projection of ScheduledTask passed over the container IPC boundary.
+export interface ScheduledTaskInput {
+  id: number;
+  cronExpr: string;
+  runAt: string | null;
+  everyMs: number | null;
+  prompt: string;
+  enabled: number;
+  lastRun: string | null;
+  createdAt: string;
 }

--- a/src/types/side-effects.ts
+++ b/src/types/side-effects.ts
@@ -1,0 +1,25 @@
+export type ScheduleSideEffect =
+  | {
+      action: 'add';
+      cronExpr?: string;
+      runAt?: string;
+      everyMs?: number;
+      prompt: string;
+    }
+  | { action: 'remove'; taskId: number };
+
+export interface DelegationTaskSpec {
+  prompt: string;
+  label?: string;
+  model?: string;
+}
+
+export interface DelegationSideEffect {
+  action: 'delegate';
+  mode?: 'single' | 'parallel' | 'chain';
+  prompt?: string;
+  label?: string;
+  model?: string;
+  tasks?: DelegationTaskSpec[];
+  chain?: DelegationTaskSpec[];
+}


### PR DESCRIPTION
## Summary
- split overloaded shared type modules into clearer execution, model, side-effect, and HybridAI-specific domains
- replace anonymous IPC payload shapes with named types for scheduled task and web search config
- derive shared policy maps and provider unions from canonical keys instead of restating them manually

## Validation
- npm run typecheck
- npm run check
- npm --prefix container run lint
- ./node_modules/.bin/vitest run tests/gateway-service.media-routing.test.ts tests/memory-service.test.ts tests/memory-compaction.test.ts tests/memory-service.compaction-router.test.ts