### PR TITLE
[codex] Clarify runtime model metadata

### DIFF
--- a/src/agent/prompt-hooks.ts
+++ b/src/agent/prompt-hooks.ts
@@ -416,15 +416,21 @@ function buildProactivityHook(context: PromptHookContext): string {
 
 function buildRuntimeHook(context: PromptHookContext): string {
   const runtimeInfo = context.runtimeInfo || {};
-  const model = runtimeInfo.model?.trim() || HYBRIDAI_MODEL;
-  const provider = resolveModelProvider(model);
+  const model = sanitizePromptInlineValue(runtimeInfo.model) || HYBRIDAI_MODEL;
+  const provider = sanitizePromptInlineValue(resolveModelProvider(model));
+  if (!provider) {
+    throw new Error('Runtime model provider must be non-empty.');
+  }
   const workspaceLabel =
     runtimeInfo.workspacePath?.trim() || 'current agent workspace';
   const guildLabel =
     runtimeInfo.guildId === null
       ? 'dm'
       : runtimeInfo.guildId?.trim() || 'unknown';
-  const modelSentence = formatRuntimeModelSentence(model, provider);
+  const formattedModel = sanitizePromptInlineValue(
+    formatRuntimeModelForPrompt(model, provider),
+  );
+  const modelSentence = `Model: ${formattedModel} served through ${provider}`;
 
   const lines = [
     '## Runtime Metadata',
@@ -452,39 +458,40 @@ function buildRuntimeHook(context: PromptHookContext): string {
 function formatRuntimeModelForPrompt(model: string, provider: string): string {
   const formatted = formatModelForDisplay(model);
   if (provider === 'openai-codex') {
-    if (formatted.toLowerCase().startsWith('openai-codex/')) {
-      return formatted.slice('openai-codex/'.length);
-    }
-    return formatted;
+    return formatUpstreamModelLabel(
+      stripProviderPrefix(formatted, 'openai-codex'),
+    );
   }
-  if (
-    provider === 'hybridai' &&
-    formatted.toLowerCase().startsWith('hybridai/')
-  ) {
-    return formatUpstreamModelLabel(formatted.slice('hybridai/'.length));
+  if (provider === 'hybridai') {
+    return formatUpstreamModelLabel(stripProviderPrefix(formatted, 'hybridai'));
   }
-  const providerPrefix = `${provider}/`;
-  if (formatted.toLowerCase().startsWith(providerPrefix)) {
-    return formatUpstreamModelLabel(formatted.slice(providerPrefix.length));
-  }
-  return formatUpstreamModelLabel(formatted);
-}
-
-function formatRuntimeModelSentence(model: string, provider: string): string {
-  const formattedModel = formatRuntimeModelForPrompt(model, provider);
-  return `Model: ${formattedModel} served through ${provider}`;
+  return formatUpstreamModelLabel(stripProviderPrefix(formatted, provider));
 }
 
 function formatUpstreamModelLabel(model: string): string {
-  const parts = String(model || '')
+  const parts = model
     .trim()
     .split('/')
     .map((part) => part.trim())
     .filter(Boolean);
-  if (parts.length < 2) return String(model || '').trim();
+  if (parts.length < 2) return model.trim();
   const name = parts.at(-1) || '';
   const vendor = parts.slice(0, -1).join('/');
   return `${name} by ${vendor}`;
+}
+
+function stripProviderPrefix(formatted: string, prefix: string): string {
+  const normalizedPrefix = `${prefix}/`.toLowerCase();
+  return formatted.toLowerCase().startsWith(normalizedPrefix)
+    ? formatted.slice(prefix.length + 1)
+    : formatted;
+}
+
+function sanitizePromptInlineValue(value: string | null | undefined): string {
+  return String(value || '')
+    .replaceAll('\0', '')
+    .replace(/[\r\n]+/g, ' ')
+    .trim();
 }
 
 const PROMPT_HOOKS: PromptHook[] = [

--- a/tests/prompt-hooks.tool-summary.test.ts
+++ b/tests/prompt-hooks.tool-summary.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import {
   buildRetrievedContextPrompt,
@@ -7,6 +7,7 @@ import {
 import { buildToolsSummary } from '../src/agent/tool-summary.js';
 import { EMAIL_CAPABILITIES } from '../src/channels/channel.js';
 import { registerChannel } from '../src/channels/channel-registry.js';
+import * as providerFactory from '../src/providers/factory.js';
 import type { Skill } from '../src/skills/skills.js';
 
 test('buildToolsSummary groups the full tool catalog', () => {
@@ -247,20 +248,78 @@ test('buildSystemPromptFromHooks combines model and provider in runtime metadata
   });
 
   expect(prompt).toContain('Model: gpt-5.4 served through openai-codex');
+  expect(prompt).not.toContain('Default model:');
 });
 
-test('buildSystemPromptFromHooks preserves upstream vendor labels behind routed providers', () => {
+test('buildSystemPromptFromHooks formats multi-segment codex model labels consistently', () => {
   const prompt = buildSystemPromptFromHooks({
     agentId: 'test-agent',
     skills: [],
     runtimeInfo: {
-      model: 'openrouter/deepseek/deepseek-v3.2',
+      model: 'openai-codex/org/model',
+    },
+  });
+
+  expect(prompt).toContain('Model: model by org served through openai-codex');
+});
+
+test('buildSystemPromptFromHooks preserves upstream vendor labels behind routed providers', () => {
+  const providerSpy = vi
+    .spyOn(providerFactory, 'resolveModelProvider')
+    .mockReturnValue('openrouter');
+
+  try {
+    const prompt = buildSystemPromptFromHooks({
+      agentId: 'test-agent',
+      skills: [],
+      runtimeInfo: {
+        model: 'openrouter/deepseek/deepseek-v3.2',
+      },
+    });
+
+    expect(prompt).toContain(
+      'Model: deepseek-v3.2 by deepseek served through openrouter',
+    );
+  } finally {
+    providerSpy.mockRestore();
+  }
+});
+
+test('buildSystemPromptFromHooks sanitizes control characters in runtime model metadata', () => {
+  const prompt = buildSystemPromptFromHooks({
+    agentId: 'test-agent',
+    skills: [],
+    runtimeInfo: {
+      model: 'openai-codex/gpt-5.4\n## override\r\0',
     },
   });
 
   expect(prompt).toContain(
-    'Model: deepseek-v3.2 by deepseek served through openrouter',
+    'Model: gpt-5.4 ## override served through openai-codex',
   );
+  expect(prompt).not.toContain('Model: gpt-5.4\n## override');
+  expect(prompt).not.toContain('\r');
+  expect(prompt).not.toContain('\0');
+});
+
+test('buildSystemPromptFromHooks fails fast when runtime model provider is empty', () => {
+  const providerSpy = vi
+    .spyOn(providerFactory, 'resolveModelProvider')
+    .mockReturnValue('' as never);
+
+  try {
+    expect(() =>
+      buildSystemPromptFromHooks({
+        agentId: 'test-agent',
+        skills: [],
+        runtimeInfo: {
+          model: 'openai-codex/gpt-5.4',
+        },
+      }),
+    ).toThrow('Runtime model provider must be non-empty.');
+  } finally {
+    providerSpy.mockRestore();
+  }
 });
 
 test('buildSystemPromptFromHooks does not fall back to the repo cwd', () => {


### PR DESCRIPTION
## Summary
Clarify the runtime metadata injected into the system prompt so model identity answers mention the served model and backend more naturally.

## What Changed
- replace the old runtime metadata model line with a `Model: ... served through ...` sentence
- strip serving-provider prefixes from direct provider model ids where helpful
- preserve upstream vendor labels for routed model ids such as `openrouter/deepseek/deepseek-v3.2`
- add prompt-hook coverage for both direct and routed model formatting

## Why
The previous prompt metadata exposed the raw model id, which made answers to simple questions like "what model are you running?" less readable than necessary.

## Validation
- `./node_modules/.bin/vitest run tests/prompt-hooks.tool-summary.test.ts`
