### PR TITLE
[codex] Remove chat composer focus border

### DIFF
--- a/docs/chat.html
+++ b/docs/chat.html
@@ -822,12 +822,6 @@
       outline: none;
     }
 
-    .composer textarea:focus-visible {
-      outline: 2px solid currentColor;
-      outline-offset: 2px;
-      border-radius: 10px;
-    }
-
     /* ── Action buttons ── */
     .composer-action {
       flex-shrink: 0;


### PR DESCRIPTION
## What changed
- removed the ":focus-visible" outline styling from the /chat composer textarea in docs/chat.html

## Why
- the web chat composer no longer needs the blue focus border on focus

## Impact
- the /chat input keeps its existing layout and behavior, but no longer draws the blue focus ring around the textarea

## Validation
- inspected the staged diff for docs/chat.html
- confirmed only docs/chat.html was committed for this PR
- did not run a browser test suite because this is a small static CSS change

## Root cause
- docs/chat.html explicitly applied a blue outline in .composer textarea:focus-visible