### PR TITLE
[codex] Guard local iMessage self-chat attributedBody fallback

### DIFF
--- a/src/channels/imessage/backend-local.ts
+++ b/src/channels/imessage/backend-local.ts
@@ -58,6 +58,11 @@ interface LocalMessageRow {
   chatDisplayName: string | null;
 }
 
+const SELF_CHAT_ATTRIBUTED_CONTROL_COMMAND_RE =
+  /^\/(clear|reset|stop|pause|cancel|resume)\b/i;
+const MAX_SELF_CHAT_ATTRIBUTED_LINES = 6;
+const MAX_SELF_CHAT_ATTRIBUTED_CHARS = 400;
+
 function normalizeLocalInboundText(value: string): string {
   const trimmed = String(value || '').trim();
   if (!trimmed) return '';
@@ -106,6 +111,24 @@ function decodeAttributedBodyText(value: Buffer | null): string | null {
   return candidate || null;
 }
 
+function looksLikeSelfChatAttributedReplay(value: string): boolean {
+  const normalized = String(value || '').replace(/\r\n?/g, '\n').trim();
+  if (!normalized) return false;
+
+  const nonEmptyLines = normalized
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (normalized.length > MAX_SELF_CHAT_ATTRIBUTED_CHARS) {
+    return true;
+  }
+  if (nonEmptyLines.length > MAX_SELF_CHAT_ATTRIBUTED_LINES) {
+    return true;
+  }
+  const markerMatches = normalized.match(/\[[^\]\n]{1,40}\]/g);
+  return (markerMatches?.length || 0) >= 2;
+}
+
 function resolveMessageText(row: LocalMessageRow): string {
   const direct = normalizeLocalInboundText(String(row.text || ''));
   if (direct) return direct;
@@ -114,6 +137,31 @@ function resolveMessageText(row: LocalMessageRow): string {
     decodeAttributedBodyText(row.attributedBody) || '',
   );
   if (decodedAttributedBody) {
+    if (isSelfChatConversation(row)) {
+      if (
+        SELF_CHAT_ATTRIBUTED_CONTROL_COMMAND_RE.test(decodedAttributedBody)
+      ) {
+        logger.warn(
+          {
+            rowid: row.rowid,
+            messageGuid: row.messageGuid,
+          },
+          'Skipping local self-chat attributedBody control command without plain text',
+        );
+        return '';
+      }
+      if (looksLikeSelfChatAttributedReplay(decodedAttributedBody)) {
+        logger.warn(
+          {
+            rowid: row.rowid,
+            messageGuid: row.messageGuid,
+            attributedBodyBytes: row.attributedBody?.length || 0,
+          },
+          'Skipping local self-chat attributedBody row that looks like replayed history',
+        );
+        return '';
+      }
+    }
     return decodedAttributedBody;
   }
 

--- a/tests/imessage.local-backend.test.ts
+++ b/tests/imessage.local-backend.test.ts
@@ -182,6 +182,92 @@ describe('local iMessage backend', () => {
     await backend.shutdown();
   });
 
+  test('skips self-chat attributedBody control commands without plain text', async () => {
+    vi.useFakeTimers();
+    const { createLocalIMessageBackend, warn } = await importFreshLocalBackend({
+      rows: [
+        {
+          rowid: 21,
+          messageGuid: 'self-clear-1',
+          messageDate: 123456790,
+          text: null,
+          attributedBody: Buffer.from(
+            'prefix NSString /clear \u0002iI\u0001NSDictionary trailing',
+            'utf8',
+          ),
+          isFromMe: 0,
+          handle: '+14155551212',
+          chatGuid: null,
+          chatIdentifier: '+14155551212',
+          chatDisplayName: null,
+        },
+      ],
+    });
+    const onInbound = vi.fn(async () => {});
+    const backend = createLocalIMessageBackend({ onInbound });
+
+    await backend.start();
+    await vi.advanceTimersByTimeAsync(2500);
+
+    expect(onInbound).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rowid: 21,
+        messageGuid: 'self-clear-1',
+      }),
+      'Skipping local self-chat attributedBody control command without plain text',
+    );
+    await backend.shutdown();
+  });
+
+  test('skips self-chat attributedBody rows that look like replayed history', async () => {
+    vi.useFakeTimers();
+    const { createLocalIMessageBackend, warn } = await importFreshLocalBackend({
+      rows: [
+        {
+          rowid: 23,
+          messageGuid: 'self-replay-1',
+          messageDate: 123456791,
+          text: null,
+          attributedBody: Buffer.from(
+            [
+              'prefix NSString Who are you?',
+              '[/hybridclaw] Status-Update',
+              '[Charly] Ich bin Charly',
+              'Noch eine alte Nachricht',
+              'Und noch eine',
+              'Option A',
+              'Option B',
+              '\u0002iI\u0001NSDictionary trailing',
+            ].join('\n'),
+            'utf8',
+          ),
+          isFromMe: 0,
+          handle: '+14155551212',
+          chatGuid: null,
+          chatIdentifier: '+14155551212',
+          chatDisplayName: null,
+        },
+      ],
+    });
+    const onInbound = vi.fn(async () => {});
+    const backend = createLocalIMessageBackend({ onInbound });
+
+    await backend.start();
+    await vi.advanceTimersByTimeAsync(2500);
+
+    expect(onInbound).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rowid: 23,
+        messageGuid: 'self-replay-1',
+        attributedBodyBytes: expect.any(Number),
+      }),
+      'Skipping local self-chat attributedBody row that looks like replayed history',
+    );
+    await backend.shutdown();
+  });
+
   test('skips unsupported attributedBody-only rows and logs a warning', async () => {
     vi.useFakeTimers();
     const { createLocalIMessageBackend, warn } = await importFreshLocalBackend({


### PR DESCRIPTION
## What changed
- tightened the local iMessage backend self-chat fallback so `attributedBody`-only control commands are ignored when there is no plain-text payload
- added a replay-history guard for oversized or marker-heavy self-chat `attributedBody` blobs that look like reflected conversation history
- added regression coverage for both failure modes in the local iMessage backend test file

## Why
A self-chat iMessage row was being decoded from `attributedBody` into a concatenated replay of older messages. That malformed inbound payload could be treated as fresh user input and trigger control flow such as session clearing before emitting an unsolicited Charly intro.

## Impact
This keeps local iMessage self-chat sessions from executing replayed `attributedBody` artifacts as new prompts while preserving the normal plain-text and supported attributed-body paths.

## Validation
- `./node_modules/.bin/vitest run tests/imessage.local-backend.test.ts`
