### PR TITLE
[codex] Stream web chat responses

### DIFF
--- a/docs/chat.html
+++ b/docs/chat.html
@@ -2902,7 +2902,6 @@
         assistantBlock: null,
         assistantText: '',
         assistantRenderFrame: 0,
-        assistantRenderScheduled: false,
         stopRequested: false,
         stopping: false,
       };
@@ -2929,7 +2928,6 @@
           return requestState.assistantBlock;
         };
         const renderStreamedAssistant = () => {
-          requestState.assistantRenderScheduled = false;
           requestState.assistantRenderFrame = 0;
           const assistantBlock = ensureAssistantBlock();
           if (!assistantBlock) return;
@@ -2939,14 +2937,13 @@
           });
         };
         const scheduleAssistantRender = () => {
-          if (requestState.assistantRenderScheduled) return;
-          requestState.assistantRenderScheduled = true;
+          if (requestState.assistantRenderFrame !== 0) return;
           requestState.assistantRenderFrame = window.requestAnimationFrame(() => {
             renderStreamedAssistant();
           });
         };
         const flushAssistantRender = () => {
-          if (!requestState.assistantRenderScheduled) return;
+          if (requestState.assistantRenderFrame === 0) return;
           window.cancelAnimationFrame(requestState.assistantRenderFrame);
           renderStreamedAssistant();
         };
@@ -3014,9 +3011,8 @@
           assistantBlock,
         };
       } catch (err) {
-        if (requestState.assistantRenderScheduled) {
+        if (requestState.assistantRenderFrame !== 0) {
           window.cancelAnimationFrame(requestState.assistantRenderFrame);
-          requestState.assistantRenderScheduled = false;
           requestState.assistantRenderFrame = 0;
         }
         if (requestState.stopRequested) {


### PR DESCRIPTION
## What changed

- switched the built-in `/chat` client to request streaming responses from `/api/chat`
- added an NDJSON stream reader in the browser chat so assistant text renders incrementally instead of waiting for the final payload
- preserved the existing finalization path for session ids, message metadata, replay actions, and artifacts once the terminal result arrives

## Why

The gateway already exposed streaming chat responses and the TUI was already using them, but the browser chat still posted a non-streaming request and only rendered the final response. That left the web chat behind the TUI despite both going through the same backend.

## Impact

- TUI and web chat now both stream assistant replies
- long-running web replies show progress immediately instead of appearing all at once
- no backend API contract changes were required

## Root cause

The gap was client-side: `/chat` was still calling `/api/chat` through the non-streaming JSON path rather than opting into the gateway's existing NDJSON stream mode.

## Validation

- `node --input-type=module -e "import fs from 'node:fs'; const html = fs.readFileSync('docs/chat.html','utf8'); const match = html.match(/<script>([\\s\\S]*)<\\/script>\\s*<\\/body>/); if (!match) throw new Error('script block not found'); new Function(match[1]); console.log('chat.html script parses');"`
- `npm run test:unit -- tests/gateway-client.test.ts tests/gateway-http-server.test.ts`