### PR TITLE
[codex] stabilize container apt installs for publish-agent builds

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -15,10 +15,10 @@ FROM node:22-slim@sha256:80fdb3f57c815e1b638d221f30a826823467c4a56c8f6a8d7aa091c
 LABEL org.opencontainers.image.source="https://github.com/HybridAIOne/hybridclaw"
 LABEL org.opencontainers.image.description="HybridClaw sandboxed agent runtime"
 
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt/lists \
-    apt-get update && apt-get install -y --no-install-recommends \
-    ripgrep git curl python3 python3-pip poppler-utils qpdf pandoc
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    ripgrep git curl python3 python3-pip poppler-utils qpdf pandoc \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     python3 -m pip install --break-system-packages \
@@ -63,8 +63,8 @@ ENTRYPOINT ["node", "/app/dist/index.js"]
 FROM runtime-lite AS runtime
 
 USER root
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt/lists \
-    apt-get update && apt-get install -y --no-install-recommends \
-    libreoffice-calc libreoffice-impress libreoffice-writer
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    libreoffice-calc libreoffice-impress libreoffice-writer \
+    && rm -rf /var/lib/apt/lists/*
 USER node


### PR DESCRIPTION
## What changed

This removes the BuildKit `apt` cache mounts from the container runtime image and switches both package install steps to a plain `apt-get update && apt-get install ... && rm -rf /var/lib/apt/lists/*` flow.

## Why

`publish-agent` was failing during the `buildx` release build in the `apt-get install` step with exit code 100. The package set itself is valid on the pinned `node:22-slim` Debian 12 base. The more likely failure mode was stale architecture-specific `apt` metadata being reused during the multi-platform `linux/amd64,linux/arm64` build.

## Impact

This makes the container image build path more deterministic for multi-platform release builds, including the `publish-agent` workflow.

## Root cause

The runtime Dockerfile cached `/var/cache/apt` and `/var/lib/apt/lists` via BuildKit mounts. In a multi-arch `buildx` workflow, those caches can retain package indexes that do not match the current architecture, which can surface as `apt-get install` failures even though the requested packages exist.

## Validation

- `docker build --progress=plain --no-cache --target runtime -f container/Dockerfile ./container`
- `docker buildx build --progress=plain --platform linux/amd64 --no-cache --target runtime-lite -f container/Dockerfile ./container`
