### PR TITLE
[codex] Fix docs packaging in gateway image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,11 +18,9 @@ container/node_modules/
 .vscode
 docker/
 
-# Tests and docs
+# Tests and non-runtime docs assets
 tests/
-docs/development/
 docs/tools/
-docs/*.md
 docs/CNAME
 packages/
 plugins/


### PR DESCRIPTION
## What changed
- stop excluding runtime documentation markdown from the gateway Docker build context
- keep excluding `docs/tools/` and other non-runtime assets from the image context

## Why
The gateway serves `/docs` from the top-level runtime image. That route reads markdown from `docs/development/` at runtime. Local source runs worked because the files existed in the checkout, but the built image omitted `docs/development/` and `docs/*.md` due to `.dockerignore`, so remote `/docs` requests fell through to the generic `Not Found` handler.

## Impact
Cloud or other deployed gateway instances built from the top-level `Dockerfile` will ship the docs content needed for `/docs` and `/development/*.md`.

## Validation
- built a fresh gateway image with `docker build -t hybridclaw-docs-check .`
- confirmed `COPY --link docs/ ./docs/` succeeds in the runtime stage
- confirmed `/app/docs/development/README.md` exists inside the built image
- HTTP validation was not completed because the gateway container exits without `HYBRIDAI_API_KEY`, which is unrelated to this packaging fix
