### PR TITLE
[codex] Fix docs deep-link fallback

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -21,7 +21,11 @@
   <script type="module">
     import { mountDocsApp } from '/static/docs.js';
 
-    mountDocsApp({ allowFallback: true }).catch((error) => {
+    mountDocsApp({
+      allowFallback: true,
+      basePath: '/docs',
+      contentBasePath: '/development',
+    }).catch((error) => {
       console.error('Failed to mount development docs app', error);
       const fallback = document.querySelector('[data-docs-fallback]');
       fallback?.removeAttribute('hidden');


### PR DESCRIPTION
## Summary
- configure the GitHub Pages fallback entrypoint to mount the docs shell with `/docs` as the route base and `/development` as the markdown content base
- keep deep links like `/docs/getting-started/` resolving through the same content path as the docs index

## Root cause
GitHub Pages serves `/docs/getting-started/` through `docs/404.html`. That fallback mounted the docs app with default paths, so the app tried to fetch markdown from `/docs/getting-started/README.md` instead of `/development/getting-started/README.md` and rendered the in-app not-found state.

## Validation
- `node --input-type=module -e "import { buildDocMarkdownHref, resolveDocPathFromPathname } from './docs/static/docs.js'; console.log(resolveDocPathFromPathname('/docs/getting-started/', '/docs')); console.log(buildDocMarkdownHref('getting-started/README.md', '/docs', '/development'));"`
- confirmed it resolves the route to `getting-started/README.md` and the markdown fetch path to `/development/getting-started/README.md`

## Impact
Deep links and sidebar navigation under `/docs/...` use the correct markdown source when GitHub Pages falls back to `404.html`.
