### PR TITLE
[codex] extract gateway plugin service

### DIFF
--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -73,6 +73,7 @@ import {
 } from './chat-result.js';
 import { serveDocs } from './docs.js';
 import {
+  getGatewayAdminPlugins,
   handleGatewayPluginWebhook,
   runGatewayPluginTool,
 } from './gateway-plugin-service.js';
@@ -81,8 +82,6 @@ import {
   deleteGatewayAdminAgent,
   deleteGatewayAdminSession,
   ensureGatewayBootstrapAutostart,
-  type GatewayChatRequest,
-  type GatewayCommandRequest,
   GatewayRequestError,
   getGatewayAdminAgents,
   getGatewayAdminAudit,
@@ -92,7 +91,6 @@ import {
   getGatewayAdminMcp,
   getGatewayAdminModels,
   getGatewayAdminOverview,
-  getGatewayAdminPlugins,
   getGatewayAdminScheduler,
   getGatewayAdminSessions,
   getGatewayAdminSkills,
@@ -121,8 +119,10 @@ import {
 } from './gateway-service.js';
 import type {
   GatewayChatBranchRequestBody,
+  GatewayChatRequest,
   GatewayChatRequestBody,
   GatewayChatResult,
+  GatewayCommandRequest,
 } from './gateway-types.js';
 import { resolveWorkspaceRelativePath } from './gateway-utils.js';
 import { consumeGatewayMediaUploadQuota } from './media-upload-quota.js';

--- a/src/gateway/gateway-plugin-service.ts
+++ b/src/gateway/gateway-plugin-service.ts
@@ -1,5 +1,4 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import { listAgents } from '../agents/agent-registry.js';
 import { sendWebhookJson, WebhookHttpError } from '../channels/webhook-http.js';
 import {
   getRuntimeConfig,
@@ -29,12 +28,10 @@ import {
   shutdownPluginManager,
 } from '../plugins/plugin-manager.js';
 import { isPluginInboundWebhookPath } from '../plugins/plugin-webhooks.js';
-import { configureFullAutoRuntime } from './fullauto.js';
 import type {
+  GatewayAdminPluginsResponse,
   GatewayChatRequest,
   GatewayChatResult,
-} from './gateway-service.js';
-import type {
   GatewayCommandRequest,
   GatewayCommandResult,
 } from './gateway-types.js';
@@ -154,10 +151,6 @@ export async function initGatewayService(params: {
     return;
   }
   gatewayServiceInitializing = (async () => {
-    listAgents();
-    configureFullAutoRuntime({
-      handleGatewayMessage: params.handleGatewayMessage,
-    });
     setPluginInboundMessageDispatcher(
       async (pluginId, request) =>
         await params.handleGatewayMessage({
@@ -489,6 +482,81 @@ export async function handlePluginGatewayCommand(params: {
     'Usage',
     'Usage: `plugin list|config <plugin-id> [key] [value|--unset]|enable <plugin-id>|disable <plugin-id>|install <path|npm-spec>|reinstall <path|npm-spec>|reload|uninstall <plugin-id>`',
   );
+}
+
+function normalizePluginCommandResult(value: unknown): GatewayCommandResult {
+  if (typeof value === 'string') {
+    return { kind: 'plain', text: value };
+  }
+  if (value == null) {
+    return { kind: 'plain', text: '' };
+  }
+  return { kind: 'plain', text: JSON.stringify(value, null, 2) };
+}
+
+export async function tryHandlePluginDefinedGatewayCommand(params: {
+  command: string;
+  req: GatewayCommandRequest;
+  pluginManager: PluginManager | null;
+}): Promise<GatewayCommandResult | null> {
+  const pluginCommand = params.pluginManager?.findCommand(params.command);
+  if (!pluginCommand) {
+    return null;
+  }
+  try {
+    return normalizePluginCommandResult(
+      await pluginCommand.handler(params.req.args.slice(1), {
+        sessionId: params.req.sessionId,
+        channelId: params.req.channelId,
+        userId: params.req.userId,
+        username: params.req.username ?? null,
+        guildId: params.req.guildId ?? null,
+      }),
+    );
+  } catch (error) {
+    return badCommand(
+      'Plugin Command Failed',
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+export async function getGatewayAdminPlugins(): Promise<GatewayAdminPluginsResponse> {
+  const pluginManager = await ensurePluginManagerInitialized();
+  const plugins = pluginManager
+    .listPluginSummary()
+    .map((plugin) => ({
+      id: plugin.id,
+      name: plugin.name || null,
+      version: plugin.version || null,
+      description: plugin.description || null,
+      source: plugin.source,
+      enabled: plugin.enabled,
+      status: plugin.error ? ('failed' as const) : ('loaded' as const),
+      error: plugin.error || null,
+      commands: [...plugin.commands].sort((left, right) =>
+        left.localeCompare(right),
+      ),
+      tools: [...plugin.tools].sort((left, right) => left.localeCompare(right)),
+      hooks: [...plugin.hooks].sort((left, right) => left.localeCompare(right)),
+    }))
+    .sort((left, right) => left.id.localeCompare(right.id));
+
+  return {
+    totals: {
+      totalPlugins: plugins.length,
+      enabledPlugins: plugins.filter((plugin) => plugin.enabled).length,
+      failedPlugins: plugins.filter((plugin) => plugin.status === 'failed')
+        .length,
+      commands: plugins.reduce(
+        (sum, plugin) => sum + plugin.commands.length,
+        0,
+      ),
+      tools: plugins.reduce((sum, plugin) => sum + plugin.tools.length, 0),
+      hooks: plugins.reduce((sum, plugin) => sum + plugin.hooks.length, 0),
+    },
+    plugins,
+  };
 }
 
 export async function handleGatewayPluginWebhook(

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -134,10 +134,7 @@ import {
   updateSessionShowMode,
 } from '../memory/db.js';
 import { memoryService } from '../memory/memory-service.js';
-import {
-  ensurePluginManagerInitialized,
-  listLoadedPluginCommands,
-} from '../plugins/plugin-manager.js';
+import { listLoadedPluginCommands } from '../plugins/plugin-manager.js';
 import {
   modelRequiresChatbotId,
   resolveModelProvider,
@@ -304,6 +301,7 @@ import { GATEWAY_LOG_REQUESTS_ENV } from './gateway-lifecycle.js';
 import {
   handlePluginGatewayCommand,
   tryEnsurePluginManagerInitializedForGateway,
+  tryHandlePluginDefinedGatewayCommand,
 } from './gateway-plugin-service.js';
 import {
   interruptGatewaySessionExecution,
@@ -326,7 +324,6 @@ import {
   type GatewayAdminModelsResponse,
   type GatewayAdminModelUsageRow,
   type GatewayAdminOverview,
-  type GatewayAdminPluginsResponse,
   type GatewayAdminSchedulerJob,
   type GatewayAdminSchedulerResponse,
   type GatewayAdminSession,
@@ -336,6 +333,7 @@ import {
   type GatewayAdminUsageSummary,
   type GatewayAgentsResponse,
   type GatewayAssistantPresentation,
+  type GatewayChatRequest,
   type GatewayChatRequestBody,
   type GatewayChatResult,
   type GatewayCommandRequest,
@@ -655,29 +653,6 @@ interface DelegationTaskRunInput {
   agentId: string;
   mode: DelegationMode;
   task: NormalizedDelegationTask;
-}
-
-export interface GatewayChatRequest {
-  sessionId: GatewayChatRequestBody['sessionId'];
-  sessionMode?: GatewayChatRequestBody['sessionMode'];
-  guildId: GatewayChatRequestBody['guildId'];
-  channelId: GatewayChatRequestBody['channelId'];
-  userId: GatewayChatRequestBody['userId'];
-  username: GatewayChatRequestBody['username'];
-  content: GatewayChatRequestBody['content'];
-  media?: GatewayChatRequestBody['media'];
-  agentId?: GatewayChatRequestBody['agentId'];
-  chatbotId?: GatewayChatRequestBody['chatbotId'];
-  model?: GatewayChatRequestBody['model'];
-  enableRag?: GatewayChatRequestBody['enableRag'];
-  onTextDelta?: (delta: string) => void;
-  onToolProgress?: (event: ToolProgressEvent) => void;
-  onApprovalProgress?: (approval: PendingApproval) => void;
-  onProactiveMessage?: (
-    message: ProactiveMessagePayload,
-  ) => void | Promise<void>;
-  abortSignal?: AbortSignal;
-  source?: string;
 }
 
 function shouldForceNewTuiSession(
@@ -1940,16 +1915,6 @@ function infoCommand(
 
 function plainCommand(text: string): GatewayCommandResult {
   return { kind: 'plain', text };
-}
-
-function normalizePluginCommandResult(value: unknown): GatewayCommandResult {
-  if (typeof value === 'string') {
-    return plainCommand(value);
-  }
-  if (value == null) {
-    return plainCommand('');
-  }
-  return plainCommand(JSON.stringify(value, null, 2));
 }
 
 function formatRatioAsPercent(value: number): string {
@@ -3496,44 +3461,6 @@ export function getGatewayAdminAudit(params?: {
       eventType,
       limit,
     }).map(mapAdminAuditEntry),
-  };
-}
-
-export async function getGatewayAdminPlugins(): Promise<GatewayAdminPluginsResponse> {
-  const pluginManager = await ensurePluginManagerInitialized();
-  const plugins = pluginManager
-    .listPluginSummary()
-    .map((plugin) => ({
-      id: plugin.id,
-      name: plugin.name || null,
-      version: plugin.version || null,
-      description: plugin.description || null,
-      source: plugin.source,
-      enabled: plugin.enabled,
-      status: plugin.error ? ('failed' as const) : ('loaded' as const),
-      error: plugin.error || null,
-      commands: [...plugin.commands].sort((left, right) =>
-        left.localeCompare(right),
-      ),
-      tools: [...plugin.tools].sort((left, right) => left.localeCompare(right)),
-      hooks: [...plugin.hooks].sort((left, right) => left.localeCompare(right)),
-    }))
-    .sort((left, right) => left.id.localeCompare(right.id));
-
-  return {
-    totals: {
-      totalPlugins: plugins.length,
-      enabledPlugins: plugins.filter((plugin) => plugin.enabled).length,
-      failedPlugins: plugins.filter((plugin) => plugin.status === 'failed')
-        .length,
-      commands: plugins.reduce(
-        (sum, plugin) => sum + plugin.commands.length,
-        0,
-      ),
-      tools: plugins.reduce((sum, plugin) => sum + plugin.tools.length, 0),
-      hooks: plugins.reduce((sum, plugin) => sum + plugin.hooks.length, 0),
-    },
-    plugins,
   };
 }
 
@@ -8212,24 +8139,13 @@ export async function handleGatewayCommand(
       }
 
       default: {
-        const pluginCommand = pluginManager?.findCommand(cmd);
-        if (pluginCommand) {
-          try {
-            return normalizePluginCommandResult(
-              await pluginCommand.handler(req.args.slice(1), {
-                sessionId: req.sessionId,
-                channelId: req.channelId,
-                userId: req.userId,
-                username: req.username ?? null,
-                guildId: req.guildId ?? null,
-              }),
-            );
-          } catch (error) {
-            return badCommand(
-              'Plugin Command Failed',
-              error instanceof Error ? error.message : String(error),
-            );
-          }
+        const pluginCommandResult = await tryHandlePluginDefinedGatewayCommand({
+          command: cmd,
+          req,
+          pluginManager,
+        });
+        if (pluginCommandResult) {
+          return pluginCommandResult;
         }
         return badCommand(
           'Unknown Command',

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -8,7 +8,11 @@ import type {
   RuntimeSchedulerJob,
 } from '../config/runtime-config.js';
 import type { MediaContextItem } from '../types/container.js';
-import type { PendingApproval } from '../types/execution.js';
+import type {
+  ArtifactMetadata,
+  PendingApproval,
+  ToolProgressEvent,
+} from '../types/execution.js';
 import type { MemoryCitation } from '../types/memory.js';
 import type { McpServerConfig } from '../types/models.js';
 import type { TokenUsageStats } from '../types/usage.js';
@@ -134,6 +138,30 @@ export interface GatewayChatRequestBody {
   chatbotId?: string | null;
   model?: string | null;
   enableRag?: boolean;
+}
+
+export interface GatewayChatRequest {
+  sessionId: GatewayChatRequestBody['sessionId'];
+  sessionMode?: GatewayChatRequestBody['sessionMode'];
+  guildId: GatewayChatRequestBody['guildId'];
+  channelId: GatewayChatRequestBody['channelId'];
+  userId: GatewayChatRequestBody['userId'];
+  username: GatewayChatRequestBody['username'];
+  content: GatewayChatRequestBody['content'];
+  media?: GatewayChatRequestBody['media'];
+  agentId?: GatewayChatRequestBody['agentId'];
+  chatbotId?: GatewayChatRequestBody['chatbotId'];
+  model?: GatewayChatRequestBody['model'];
+  enableRag?: GatewayChatRequestBody['enableRag'];
+  onTextDelta?: (delta: string) => void;
+  onToolProgress?: (event: ToolProgressEvent) => void;
+  onApprovalProgress?: (approval: PendingApproval) => void;
+  onProactiveMessage?: (message: {
+    text: string;
+    artifacts?: ArtifactMetadata[];
+  }) => void | Promise<void>;
+  abortSignal?: AbortSignal;
+  source?: string;
 }
 
 export interface GatewayMediaUploadResult {

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -7,7 +7,10 @@ import {
 } from '../agent/proactive-policy.js';
 import { isSilentReply, stripSilentToken } from '../agent/silent-reply.js';
 import { createSilentReplyStreamFilter } from '../agent/silent-reply-stream.js';
-import { resolveAgentForRequest } from '../agents/agent-registry.js';
+import {
+  listAgents,
+  resolveAgentForRequest,
+} from '../agents/agent-registry.js';
 import {
   startObservabilityIngest,
   stopObservabilityIngest,
@@ -93,6 +96,7 @@ import {
   normalizePendingApprovalReply,
   normalizePlaceholderToolReply,
 } from './chat-result.js';
+import { configureFullAutoRuntime } from './fullauto.js';
 import { classifyGatewayError } from './gateway-error-utils.js';
 import { startGatewayHttpServer } from './gateway-http-server.js';
 import {
@@ -1680,6 +1684,8 @@ function startOrRestartMemoryConsolidationScheduler(): void {
 async function main(): Promise<void> {
   logger.info('Starting HybridClaw gateway');
   initDatabase();
+  listAgents();
+  configureFullAutoRuntime({ handleGatewayMessage });
   await initGatewayService({ handleGatewayMessage });
   resumeEnabledFullAutoSessions();
   void runManagedMediaCleanup('startup').catch((error) => {

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -904,7 +904,6 @@ async function importFreshHealth(options?: {
     getGatewayAdminMcp,
     getGatewayAdminModels,
     getGatewayAdminOverview,
-    getGatewayAdminPlugins,
     getGatewayAdminScheduler,
     getGatewayAdminSessions,
     getGatewayAdminSkills,
@@ -932,6 +931,7 @@ async function importFreshHealth(options?: {
     upsertGatewayAdminSchedulerJob,
   }));
   vi.doMock('../src/gateway/gateway-plugin-service.js', () => ({
+    getGatewayAdminPlugins,
     handleGatewayPluginWebhook,
     runGatewayPluginTool,
   }));

--- a/tests/gateway-main.test.ts
+++ b/tests/gateway-main.test.ts
@@ -100,7 +100,9 @@ function createGatewayMainTestState(options?: {
     initGatewayService: vi.fn(
       options?.initGatewayServiceImpl || (async () => {}),
     ),
+    listAgents: vi.fn(() => []),
     stopGatewayPlugins: vi.fn(async () => {}),
+    configureFullAutoRuntime: vi.fn(),
     listQueuedProactiveMessages: vi.fn(() => []),
     loggerDebug: vi.fn(),
     loggerError: vi.fn(),
@@ -337,7 +339,11 @@ async function importFreshGatewayMain(options?: {
     },
   }));
   vi.doMock('../src/agents/agent-registry.js', () => ({
+    listAgents: state.listAgents,
     resolveAgentForRequest: state.resolveAgentForRequest,
+  }));
+  vi.doMock('../src/gateway/fullauto.js', () => ({
+    configureFullAutoRuntime: state.configureFullAutoRuntime,
   }));
   vi.doMock('../src/providers/local-discovery.js', () => ({
     startDiscoveryLoop: state.startDiscoveryLoop,

--- a/tests/gateway-service.fullauto.test.ts
+++ b/tests/gateway-service.fullauto.test.ts
@@ -212,6 +212,9 @@ test('fullauto command enables auto-turns, queues follow-up results, and can be 
   const { memoryService } = await import('../src/memory/memory-service.ts');
   const { DEFAULT_AGENT_ID } = await import('../src/agents/agent-types.ts');
   const { agentWorkspaceDir } = await import('../src/infra/ipc.ts');
+  const { configureFullAutoRuntime } = await import(
+    '../src/gateway/fullauto.ts'
+  );
   const { getGatewayAgents, handleGatewayCommand, handleGatewayMessage } =
     await import('../src/gateway/gateway-service.ts');
   const { initGatewayService } = await import(
@@ -219,6 +222,7 @@ test('fullauto command enables auto-turns, queues follow-up results, and can be 
   );
 
   initDatabase({ quiet: true });
+  configureFullAutoRuntime({ handleGatewayMessage });
   await initGatewayService({ handleGatewayMessage });
 
   const sessionId = 'session-fullauto';
@@ -386,6 +390,9 @@ test('bare fullauto shows status and does not enable background looping', async 
 
   const { initDatabase } = await import('../src/memory/db.ts');
   const { memoryService } = await import('../src/memory/memory-service.ts');
+  const { configureFullAutoRuntime } = await import(
+    '../src/gateway/fullauto.ts'
+  );
   const { handleGatewayCommand, handleGatewayMessage } = await import(
     '../src/gateway/gateway-service.ts'
   );
@@ -394,6 +401,7 @@ test('bare fullauto shows status and does not enable background looping', async 
   );
 
   initDatabase({ quiet: true });
+  configureFullAutoRuntime({ handleGatewayMessage });
   await initGatewayService({ handleGatewayMessage });
 
   const sessionId = 'session-fullauto-status-only';
@@ -458,6 +466,9 @@ test('stop clears the full-auto running guard and ignores stale auto-turn comple
   const { initDatabase, listQueuedProactiveMessages, updateSessionChatbot } =
     await import('../src/memory/db.ts');
   const { memoryService } = await import('../src/memory/memory-service.ts');
+  const { configureFullAutoRuntime } = await import(
+    '../src/gateway/fullauto.ts'
+  );
   const { handleGatewayCommand, handleGatewayMessage } = await import(
     '../src/gateway/gateway-service.ts'
   );
@@ -466,6 +477,7 @@ test('stop clears the full-auto running guard and ignores stale auto-turn comple
   );
 
   initDatabase({ quiet: true });
+  configureFullAutoRuntime({ handleGatewayMessage });
   await initGatewayService({ handleGatewayMessage });
 
   const sessionId = 'session-fullauto-stop';
@@ -581,6 +593,9 @@ test('manual supervision preempts the active full-auto turn and keeps looping en
   const { initDatabase, listQueuedProactiveMessages, updateSessionChatbot } =
     await import('../src/memory/db.ts');
   const { memoryService } = await import('../src/memory/memory-service.ts');
+  const { configureFullAutoRuntime } = await import(
+    '../src/gateway/fullauto.ts'
+  );
   const { handleGatewayCommand, handleGatewayMessage } = await import(
     '../src/gateway/gateway-service.ts'
   );
@@ -589,6 +604,7 @@ test('manual supervision preempts the active full-auto turn and keeps looping en
   );
 
   initDatabase({ quiet: true });
+  configureFullAutoRuntime({ handleGatewayMessage });
   await initGatewayService({ handleGatewayMessage });
 
   const sessionId = 'session-fullauto-supervise';
@@ -691,12 +707,16 @@ test('persisted full-auto sessions resume on startup', async () => {
     '../src/memory/db.ts'
   );
   initDatabaseAfterRestart({ quiet: true });
+  const { configureFullAutoRuntime } = await import(
+    '../src/gateway/fullauto.ts'
+  );
   const { handleGatewayMessage, resumeEnabledFullAutoSessions } = await import(
     '../src/gateway/gateway-service.ts'
   );
   const { initGatewayService } = await import(
     '../src/gateway/gateway-plugin-service.ts'
   );
+  configureFullAutoRuntime({ handleGatewayMessage });
   await initGatewayService({ handleGatewayMessage });
 
   expect(resumeEnabledFullAutoSessions()).toBe(1);
@@ -781,6 +801,9 @@ test('watchdog interrupts stalled full-auto turns and retries after recovery del
   const { initDatabase, listQueuedProactiveMessages, updateSessionChatbot } =
     await import('../src/memory/db.ts');
   const { memoryService } = await import('../src/memory/memory-service.ts');
+  const { configureFullAutoRuntime } = await import(
+    '../src/gateway/fullauto.ts'
+  );
   const { handleGatewayCommand, handleGatewayMessage } = await import(
     '../src/gateway/gateway-service.ts'
   );
@@ -789,6 +812,7 @@ test('watchdog interrupts stalled full-auto turns and retries after recovery del
   );
 
   initDatabase({ quiet: true });
+  configureFullAutoRuntime({ handleGatewayMessage });
   await initGatewayService({ handleGatewayMessage });
 
   const sessionId = 'session-fullauto-watchdog';

--- a/tests/gateway-service.plugins.test.ts
+++ b/tests/gateway-service.plugins.test.ts
@@ -946,7 +946,7 @@ test('getGatewayAdminPlugins summarizes plugin status for the admin console', as
   setupHome();
 
   const { getGatewayAdminPlugins } = await import(
-    '../src/gateway/gateway-service.ts'
+    '../src/gateway/gateway-plugin-service.ts'
   );
 
   pluginManagerMock.listPluginSummary.mockReset();


### PR DESCRIPTION
## Summary
- extract gateway plugin initialization, webhook/tool entry points, and built-in plugin command handling into `src/gateway/gateway-plugin-service.ts`
- update gateway startup and HTTP server wiring to import those plugin-specific entry points from the new module
- trim `src/gateway/gateway-service.ts` down to core gateway message/command flow while keeping plugin chat-loop integration in place

## Why
Plugin-related gateway services were split across `gateway-service.ts` alongside unrelated gateway runtime code. Pulling the service-oriented plugin surfaces into a dedicated module makes the boundary clearer and reduces the amount of plugin-specific control flow in the main gateway service file.

## Impact
Gateway plugin startup, webhook dispatch, tool execution, and built-in `plugin ...` command handling now live behind a dedicated gateway plugin service module. Existing runtime behavior is intended to stay the same.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npx biome check src/gateway/gateway-plugin-service.ts src/gateway/gateway-service.ts src/gateway/gateway.ts src/gateway/gateway-http-server.ts`
