### PR TITLE
[codex] Add encrypted runtime secret store and secret-backed auth flows

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1546,16 +1546,23 @@ function isWhatsAppAuthLockError(err: unknown): err is Error {
 }
 
 function printMissingEnvVarError(message: string, envVar?: string): void {
-  const envVarHint: Record<string, string> = {
-    HYBRIDAI_API_KEY: `Set HYBRIDAI_API_KEY in ${runtimeSecretsPath()} or your shell, then run the command again. You can also run \`hybridclaw onboarding\` to set it interactively.`,
-    OPENROUTER_API_KEY: `Set OPENROUTER_API_KEY in ${runtimeSecretsPath()} or your shell, ensure \`openrouter.enabled\` is true in ${runtimeConfigPath()}, then run the command again.`,
-    MISTRAL_API_KEY: `Set MISTRAL_API_KEY in ${runtimeSecretsPath()} or your shell, ensure \`mistral.enabled\` is true in ${runtimeConfigPath()}, then run the command again.`,
-    HF_TOKEN: `Set HF_TOKEN in ${runtimeSecretsPath()} or your shell, ensure \`huggingface.enabled\` is true in ${runtimeConfigPath()}, then run the command again.`,
+  const envVarMessage: Record<string, string> = {
+    HYBRIDAI_API_KEY: 'HybridAI provider is not configured.',
+    OPENROUTER_API_KEY: 'OpenRouter provider is not configured.',
+    MISTRAL_API_KEY: 'Mistral provider is not configured.',
+    HF_TOKEN: 'Hugging Face provider is not configured.',
   };
+  const envVarHint: Record<string, string> = {
+    HYBRIDAI_API_KEY: `Run \`hybridclaw auth login hybridai\`, or set HYBRIDAI_API_KEY in ${runtimeSecretsPath()} or your shell, then run the command again.`,
+    OPENROUTER_API_KEY: `Run \`hybridclaw auth login openrouter\`, or set OPENROUTER_API_KEY in ${runtimeSecretsPath()} or your shell, then run the command again.`,
+    MISTRAL_API_KEY: `Run \`hybridclaw auth login mistral\`, or set MISTRAL_API_KEY in ${runtimeSecretsPath()} or your shell, then run the command again.`,
+    HF_TOKEN: `Run \`hybridclaw auth login huggingface\`, or set HF_TOKEN in ${runtimeSecretsPath()} or your shell, then run the command again.`,
+  };
+  const renderedMessage = envVar ? envVarMessage[envVar] || message : message;
   const hint = envVar
     ? envVarHint[envVar]
     : 'Set this variable and rerun the command.';
-  console.error(`hybridclaw error: ${message}`);
+  console.error(`hybridclaw error: ${renderedMessage}`);
   console.error(`Hint: ${hint}`);
   console.error(
     `HybridClaw stores runtime secrets in ${runtimeSecretsPath()}. If .env exists in the current working directory, supported secrets are migrated there automatically.`,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -34,7 +34,20 @@ ensureRuntimeConfigFile();
 
 export class MissingRequiredEnvVarError extends Error {
   constructor(public readonly envVar: string) {
-    super(`Missing required env var: ${envVar}`);
+    const messageByEnvVar: Record<string, string> = {
+      HYBRIDAI_API_KEY:
+        'HybridAI provider is not configured. Use `/auth login hybridai` in the TUI, or switch to a model from another configured provider.',
+      OPENROUTER_API_KEY:
+        'OpenRouter provider is not configured. Use `/auth login openrouter` in the TUI, or switch to a model from another configured provider.',
+      MISTRAL_API_KEY:
+        'Mistral provider is not configured. Use `/auth login mistral` in the TUI, or switch to a model from another configured provider.',
+      HF_TOKEN:
+        'Hugging Face provider is not configured. Use `/auth login huggingface` in the TUI, or switch to a model from another configured provider.',
+    };
+    super(
+      messageByEnvVar[envVar] ||
+        `Required credential is not configured: ${envVar}.`,
+    );
     this.name = 'MissingRequiredEnvVarError';
   }
 }

--- a/src/model-selection.ts
+++ b/src/model-selection.ts
@@ -8,6 +8,26 @@ export function normalizeModelCandidates(models: string[]): string[] {
   return Array.from(deduped);
 }
 
+export interface SelectableModelEntry {
+  label: string;
+  value: string;
+  isFree: boolean;
+  recommended: boolean;
+}
+
+export function sortSelectableModelEntries<T extends SelectableModelEntry>(
+  models: T[],
+): T[] {
+  return [...models].sort((left, right) => {
+    const leftKey = String(left.value || left.label || '').trim();
+    const rightKey = String(right.value || right.label || '').trim();
+    return leftKey.localeCompare(rightKey, undefined, {
+      numeric: true,
+      sensitivity: 'base',
+    });
+  });
+}
+
 export function parseModelNamesFromListText(text: string): string[] {
   return normalizeModelCandidates(
     String(text || '')

--- a/src/tui-slash-menu.ts
+++ b/src/tui-slash-menu.ts
@@ -319,17 +319,18 @@ export function buildTuiSlashMenuEntries(
     entries.push(buildGenericRootEntry(definition, sortIndex));
     sortIndex += 1;
 
+    const childEntries: TuiSlashMenuEntry[] = [];
     const subcommands = definition.options?.filter(isSubcommandOption) ?? [];
 
     for (const subcommand of subcommands) {
-      entries.push(
+      childEntries.push(
         buildGenericSubcommandEntry(definition.name, subcommand, sortIndex),
       );
       sortIndex += 1;
 
       for (const menuEntry of subcommand.tuiMenuEntries || []) {
         sortIndex = appendSyntheticMenuEntry({
-          entries,
+          entries: childEntries,
           entry: menuEntry,
           defaultDepth: 3,
           sortIndex,
@@ -339,12 +340,23 @@ export function buildTuiSlashMenuEntries(
 
     for (const menuEntry of definition.tuiMenuEntries || []) {
       sortIndex = appendSyntheticMenuEntry({
-        entries,
+        entries: childEntries,
         entry: menuEntry,
         defaultDepth: 2,
         sortIndex,
       });
     }
+
+    if (definition.name === 'model') {
+      childEntries.sort((left, right) =>
+        left.label.localeCompare(right.label, undefined, {
+          numeric: true,
+          sensitivity: 'base',
+        }),
+      );
+    }
+
+    entries.push(...childEntries);
   }
 
   return entries;

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -45,6 +45,7 @@ import {
   normalizeModelCandidates,
   parseModelInfoSummaryFromText,
   parseModelNamesFromListText,
+  sortSelectableModelEntries,
 } from './model-selection.js';
 import {
   formatModelForDisplay,
@@ -503,9 +504,13 @@ function printHelp(): void {
     `  ${TEAL}TAB${RESET} accept suggestion ${MUTED}|${RESET} ${TEAL}Ctrl-N/Ctrl-P${RESET} navigate slash menu ${MUTED}|${RESET} ${TEAL}Shift+Return${RESET}/${TEAL}Ctrl-J${RESET} line break ${MUTED}|${RESET} ${TEAL}ESC${RESET} close menu`,
   );
   console.log(
+    `  ${TEAL}${pasteShortcutLabel}${RESET} ${pasteShortcutLabel.length < 18 ? ' '.repeat(18 - pasteShortcutLabel.length) : ''}Queue a copied file or clipboard image`,
+  );
+  console.log(`  ${TEAL}ESC${RESET}               Interrupt current request`);
+  console.log(
     `  ${TEAL}Context injection:${RESET} ${TEAL}@file${RESET} ${TEAL}@folder${RESET} ${TEAL}@diff${RESET} ${TEAL}@staged${RESET} ${TEAL}@git${RESET}`,
   );
-  console.log(`  ${TEAL}/help${RESET}             Show this help`);
+  console.log();
   console.log(
     `  ${TEAL}/agent [info|list|switch|create|model] [id] [--model <model>]${RESET} Inspect or manage agents`,
   );
@@ -544,6 +549,7 @@ function printHelp(): void {
   console.log(
     `  ${TEAL}/fullauto [status|off|on [prompt]|prompt]${RESET} Enable or inspect session full-auto mode`,
   );
+  console.log(`  ${TEAL}/help${RESET}             Show this help`);
   console.log(`  ${TEAL}/info${RESET}             Show current settings`);
   console.log(
     `  ${TEAL}/mcp [list|add|toggle|remove|reconnect] [name] [json]${RESET} Manage MCP servers`,
@@ -584,10 +590,6 @@ function printHelp(): void {
   console.log(
     `  ${TEAL}/usage [summary|daily|monthly|model [daily|monthly] [agentId]]${RESET} Show usage`,
   );
-  console.log(
-    `  ${TEAL}${pasteShortcutLabel}${RESET} ${pasteShortcutLabel.length < 18 ? ' '.repeat(18 - pasteShortcutLabel.length) : ''}Queue a copied file or clipboard image`,
-  );
-  console.log(`  ${TEAL}ESC${RESET}               Interrupt current request`);
   console.log();
 }
 
@@ -1319,12 +1321,14 @@ async function fetchCurrentSessionModel(): Promise<string | null> {
 async function fetchSelectableModels(): Promise<
   Array<{ label: string; value: string; isFree: boolean; recommended: boolean }>
 > {
-  const fallback = normalizeModelCandidates(CONFIGURED_MODELS).map((model) => ({
-    label: formatModelForDisplay(model),
-    value: normalizeHybridAIModelForRuntime(model),
-    isFree: false,
-    recommended: false,
-  }));
+  const fallback = sortSelectableModelEntries(
+    normalizeModelCandidates(CONFIGURED_MODELS).map((model) => ({
+      label: formatModelForDisplay(model),
+      value: normalizeHybridAIModelForRuntime(model),
+      isFree: false,
+      recommended: false,
+    })),
+  );
   try {
     const result = await requestGatewayCommand(['model', 'list']);
     if (result.kind === 'error') return fallback;
@@ -1348,16 +1352,18 @@ async function fetchSelectableModels(): Promise<
           recommended: entry.recommended === true,
         });
       }
-      return models.length > 0 ? models : fallback;
+      return models.length > 0 ? sortSelectableModelEntries(models) : fallback;
     }
     const models = parseModelNamesFromListText(result.text || '');
     return models.length > 0
-      ? models.map((model) => ({
-          label: model,
-          value: normalizeHybridAIModelForRuntime(model),
-          isFree: false,
-          recommended: false,
-        }))
+      ? sortSelectableModelEntries(
+          models.map((model) => ({
+            label: model,
+            value: normalizeHybridAIModelForRuntime(model),
+            isFree: false,
+            recommended: false,
+          })),
+        )
       : fallback;
   } catch {
     return fallback;

--- a/tests/model-selection.test.ts
+++ b/tests/model-selection.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeModelCandidates,
   parseModelInfoSummaryFromText,
   parseModelNamesFromListText,
+  sortSelectableModelEntries,
 } from '../src/model-selection.js';
 
 test('normalizeModelCandidates trims and deduplicates model names', () => {
@@ -29,6 +30,42 @@ test('parseModelNamesFromListText strips current markers from gateway list outpu
   ).toEqual([
     'gpt-5-nano',
     'lmstudio/qwen/qwen3.5-9b',
+    'openai-codex/gpt-5-codex',
+  ]);
+});
+
+test('sortSelectableModelEntries groups the selector by normalized model id', () => {
+  expect(
+    sortSelectableModelEntries([
+      {
+        label: 'lmstudio/bonsai-8b',
+        value: 'lmstudio/bonsai-8b',
+        isFree: false,
+        recommended: false,
+      },
+      {
+        label: 'hybridai/mistral-large',
+        value: 'hybridai/mistral-large',
+        isFree: false,
+        recommended: false,
+      },
+      {
+        label: 'hybridai/grok-4.20-0309-non-reasoning',
+        value: 'hybridai/grok-4.20-0309-non-reasoning',
+        isFree: false,
+        recommended: false,
+      },
+      {
+        label: 'openai-codex/gpt-5-codex',
+        value: 'openai-codex/gpt-5-codex',
+        isFree: false,
+        recommended: false,
+      },
+    ]).map((entry) => entry.value),
+  ).toEqual([
+    'hybridai/grok-4.20-0309-non-reasoning',
+    'hybridai/mistral-large',
+    'lmstudio/bonsai-8b',
     'openai-codex/gpt-5-codex',
   ]);
 });

--- a/tests/tui-slash-menu.test.ts
+++ b/tests/tui-slash-menu.test.ts
@@ -41,6 +41,22 @@ test('builds canonical, choice-based, and TUI-only slash menu entries', () => {
   expect(labels).toContain('/skill import --force <source>');
 });
 
+test('keeps /model submenu entries in alphabetical order', () => {
+  const labels = buildTuiSlashMenuEntries()
+    .map((entry) => entry.label)
+    .filter((label) => label === '/model' || label.startsWith('/model '));
+
+  expect(labels).toEqual([
+    '/model',
+    '/model clear',
+    '/model default [name]',
+    '/model info',
+    '/model list [provider]',
+    '/model select',
+    '/model set <name>',
+  ]);
+});
+
 test('does not duplicate concierge slash menu entries', () => {
   const labels = buildTuiSlashMenuEntries().map((entry) => entry.label);
 


### PR DESCRIPTION
## Summary

This branch adds an encrypted runtime secret store and wires secret-backed authentication through the local runtime, gateway, and TUI/web command surfaces.

## What changed

- encrypt runtime credentials in `~/.hybridclaw/credentials.json` with master-key separation and migration from legacy plaintext secret files
- add SecretRef and named-secret support across runtime config, local `/secret` commands, onboarding, auth flows, and doctor/help surfaces
- add gateway-side secret injection for authenticated `http_request` calls so models can target protected APIs without seeing plaintext credentials
- update docs, changelog, and related runtime/help text to reflect the new secret model and auth workflow
- include follow-up UX polish on model-selection messaging and `/model` menu ordering in the TUI

## Why

HybridClaw previously relied more heavily on plaintext secret storage and broader ambient secret exposure. This change tightens the default runtime boundary so operators can keep credentials encrypted at rest and let the gateway inject secrets only at request time.

## User impact

- local credentials move to encrypted storage with migration support
- operators can manage reusable named secrets and secret routing from the TUI/web command surfaces
- authenticated API requests can be executed without placing raw tokens in prompts or visible tool arguments
- onboarding, auth, and model-selection messaging are clearer when a provider is not configured

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint`
- `./node_modules/.bin/vitest run tests/model-selection.test.ts tests/tui-slash-menu.test.ts`