### PR TITLE
[codex] Fix bare yes approval interception

### DIFF
--- a/container/src/approval-policy.ts
+++ b/container/src/approval-policy.ts
@@ -1027,17 +1027,13 @@ export class TrustedCoworkerApprovalRuntime {
   handleApprovalResponse(messages: ChatMessage[]): ApprovalPrelude | null {
     this.reloadPolicyIfNeeded();
     this.cleanupExpiredPending();
+    if (this.pending.size === 0) return null;
 
     const latest = latestUserMessageText(messages);
     if (!latest) return null;
 
     const parsedResponse = parseApprovalUserResponse(latest);
     if (!parsedResponse) return null;
-    if (this.pending.size === 0) {
-      return {
-        immediateMessage: 'There is no pending approval request right now.',
-      };
-    }
 
     const target = this.resolvePendingTarget(parsedResponse.requestId);
     if (!target) {

--- a/tests/approval-policy.test.ts
+++ b/tests/approval-policy.test.ts
@@ -306,6 +306,16 @@ describe('TrustedCoworkerApprovalRuntime', () => {
     expect(approved.implicitDelayMs).toBeUndefined();
   });
 
+  test('bare yes without a pending approval is treated as a normal prompt', () => {
+    const runtime = new TrustedCoworkerApprovalRuntime(
+      '/tmp/hybridclaw-missing-policy.yaml',
+    );
+
+    const prelude = runtime.handleApprovalResponse([userMessage('Yes')]);
+
+    expect(prelude).toBeNull();
+  });
+
   test('yes for session persists trust for repeated action key', () => {
     const runtime = new TrustedCoworkerApprovalRuntime(
       '/tmp/hybridclaw-missing-policy.yaml',


### PR DESCRIPTION
## What changed
- stop treating a bare `yes`/`Yes` message as an approval response when no approval is pending
- keep approval interception active only when there is an actual pending approval request
- add a regression test covering the no-pending-approval case

## Why
Issue #188 reported that typing `Yes` as a normal prompt was being consumed by the approval runtime instead of reaching the model.

## Root cause
The approval prelude parsed approval-style replies before proving that any approval was pending, so ordinary user prompts like `Yes` could be short-circuited into an approval response path.

## Impact
- normal conversational prompts like `Yes` now continue to the model when there is no pending approval
- real approval replies still work when an approval request is active

## Validation
- `npm run format`
- `npm run test:unit -- tests/approval-policy.test.ts`
- `npm run typecheck`