### PR TITLE
feat: make clawhub API URL configurable via env var

### DIFF
--- a/src/skills/skills-import-hubs.ts
+++ b/src/skills/skills-import-hubs.ts
@@ -12,7 +12,7 @@ import {
 } from './skills-import-github.js';
 
 const CLAWHUB_API_BASE_URL =
-  process.env.CLAWHUB_API_BASE_URL?.replace(/\/+$/, '') ??
+  process.env.CLAWHUB_API_BASE_URL?.trim().replace(/\/+$/, '') ||
   'https://clawhub.ai/api/v1';
 const KNOWN_CLAUDE_MARKETPLACES = [
   'anthropics/skills',

--- a/tests/skills-import.test.ts
+++ b/tests/skills-import.test.ts
@@ -639,6 +639,147 @@ description: Keep learning.
     ).toBe(true);
   });
 
+  test('uses CLAWHUB_API_BASE_URL env var for ClawHub imports', async () => {
+    vi.stubEnv('CLAWHUB_API_BASE_URL', 'https://clawhub-proxy.internal/api/v1');
+
+    const { importSkill } = await import('../src/skills/skills-import.ts');
+
+    const archiveBytes = await createZipArchive([
+      {
+        name: 'SKILL.md',
+        content: `---
+name: self-improving-agent
+description: Keep learning.
+---
+
+# Self Improving Agent
+`,
+      },
+    ]);
+
+    const fetchStub = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === 'https://api.github.com/repos/self-improving-agent') {
+        return jsonResponse({ message: 'Not Found' }, 404);
+      }
+      if (
+        url ===
+        'https://clawhub-proxy.internal/api/v1/skills/self-improving-agent'
+      ) {
+        return jsonResponse({
+          latestVersion: { version: '3.0.6' },
+        });
+      }
+      if (
+        url ===
+        'https://clawhub-proxy.internal/api/v1/download?slug=self-improving-agent&version=3.0.6'
+      ) {
+        return binaryResponse(archiveBytes, 'application/zip');
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    const result = await importSkill('clawhub/self-improving-agent', {
+      fetchImpl: fetchStub as typeof fetch,
+    });
+
+    expect(result.skillName).toBe('self-improving-agent');
+  });
+
+  test('strips trailing slashes from CLAWHUB_API_BASE_URL', async () => {
+    vi.stubEnv(
+      'CLAWHUB_API_BASE_URL',
+      'https://clawhub-proxy.internal/api/v1///',
+    );
+
+    const { importSkill } = await import('../src/skills/skills-import.ts');
+
+    const archiveBytes = await createZipArchive([
+      {
+        name: 'SKILL.md',
+        content: `---
+name: self-improving-agent
+description: Keep learning.
+---
+
+# Self Improving Agent
+`,
+      },
+    ]);
+
+    const fetchStub = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === 'https://api.github.com/repos/self-improving-agent') {
+        return jsonResponse({ message: 'Not Found' }, 404);
+      }
+      if (
+        url ===
+        'https://clawhub-proxy.internal/api/v1/skills/self-improving-agent'
+      ) {
+        return jsonResponse({
+          latestVersion: { version: '1.0.0' },
+        });
+      }
+      if (
+        url ===
+        'https://clawhub-proxy.internal/api/v1/download?slug=self-improving-agent&version=1.0.0'
+      ) {
+        return binaryResponse(archiveBytes, 'application/zip');
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    const result = await importSkill('clawhub/self-improving-agent', {
+      fetchImpl: fetchStub as typeof fetch,
+    });
+
+    expect(result.skillName).toBe('self-improving-agent');
+  });
+
+  test('falls back to default URL when CLAWHUB_API_BASE_URL is empty', async () => {
+    vi.stubEnv('CLAWHUB_API_BASE_URL', '  ');
+
+    const { importSkill } = await import('../src/skills/skills-import.ts');
+
+    const archiveBytes = await createZipArchive([
+      {
+        name: 'SKILL.md',
+        content: `---
+name: self-improving-agent
+description: Keep learning.
+---
+
+# Self Improving Agent
+`,
+      },
+    ]);
+
+    const fetchStub = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === 'https://api.github.com/repos/self-improving-agent') {
+        return jsonResponse({ message: 'Not Found' }, 404);
+      }
+      if (url === 'https://clawhub.ai/api/v1/skills/self-improving-agent') {
+        return jsonResponse({
+          latestVersion: { version: '3.0.6' },
+        });
+      }
+      if (
+        url ===
+        'https://clawhub.ai/api/v1/download?slug=self-improving-agent&version=3.0.6'
+      ) {
+        return binaryResponse(archiveBytes, 'application/zip');
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    const result = await importSkill('clawhub/self-improving-agent', {
+      fetchImpl: fetchStub as typeof fetch,
+    });
+
+    expect(result.skillName).toBe('self-improving-agent');
+  });
+
   test('imports a LobeHub agent as a generated skill', async () => {
     const { importSkill } = await import('../src/skills/skills-import.ts');
 


### PR DESCRIPTION
## Summary
- Reads `CLAWHUB_API_BASE_URL` from the environment, falling back to `https://clawhub.ai/api/v1` (no behavior change by default)
- Strips trailing slashes from the env var to prevent double-slash in URLs
- Enables deployments to run a local caching proxy (e.g. Nginx pull-through cache) and point all skill imports at it, avoiding clawhub.ai rate limits when many sandboxes share one outbound IP

## Test plan
- Without `CLAWHUB_API_BASE_URL` set: behavior is identical to before
- With `CLAWHUB_API_BASE_URL=http://clawhub-cache:8080/api/v1`: skill imports hit the local proxy instead of clawhub.ai