### PR TITLE
[codex] Fix provider auth and model guidance

### DIFF
--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -1811,7 +1811,7 @@ function buildGatewayAuthStatusResponse(provider: GatewayAuthStatusProvider): {
 function buildProviderEnableCommand(
   provider: 'openrouter' | 'mistral' | 'huggingface',
 ): string {
-  return `/config set ${provider}.enabled true`;
+  return `config set ${provider}.enabled true`;
 }
 
 function buildModelListProviderSetupMessage(
@@ -1824,9 +1824,9 @@ function buildModelListProviderSetupMessage(
       if (getHybridAIAuthStatus().authenticated) return null;
       return [
         'HybridAI is not authorized.',
-        'Authorize it first:',
+        'Authorize it first from a terminal:',
         '  hybridclaw auth login hybridai',
-        'Then rerun `/model list hybridai`.',
+        'Then rerun `model list hybridai`.',
       ].join('\n');
     }
     case 'openai-codex': {
@@ -1836,9 +1836,9 @@ function buildModelListProviderSetupMessage(
         status.reloginRequired
           ? 'Codex authorization expired.'
           : 'Codex is not authorized.',
-        'Authorize it first:',
+        'Authorize it first from a terminal:',
         '  hybridclaw auth login codex',
-        'Then rerun `/model list codex`.',
+        'Then rerun `model list codex`.',
       ].join('\n');
     }
     case 'openrouter': {
@@ -1849,12 +1849,15 @@ function buildModelListProviderSetupMessage(
           ? 'OpenRouter is not authorized.'
           : 'OpenRouter is disabled.',
         ...(!authorized
-          ? ['Authorize it first:', '  hybridclaw auth login openrouter']
+          ? [
+              'Authorize it first from a terminal:',
+              '  hybridclaw auth login openrouter',
+            ]
           : []),
         ...(config.openrouter.enabled
           ? []
           : ['Enable it:', `  ${buildProviderEnableCommand('openrouter')}`]),
-        'Then rerun `/model list openrouter`.',
+        'Then rerun `model list openrouter`.',
       ].join('\n');
     }
     case 'mistral': {
@@ -1863,12 +1866,15 @@ function buildModelListProviderSetupMessage(
       return [
         !authorized ? 'Mistral is not authorized.' : 'Mistral is disabled.',
         ...(!authorized
-          ? ['Authorize it first:', '  hybridclaw auth login mistral']
+          ? [
+              'Authorize it first from a terminal:',
+              '  hybridclaw auth login mistral',
+            ]
           : []),
         ...(config.mistral.enabled
           ? []
           : ['Enable it:', `  ${buildProviderEnableCommand('mistral')}`]),
-        'Then rerun `/model list mistral`.',
+        'Then rerun `model list mistral`.',
       ].join('\n');
     }
     case 'huggingface': {
@@ -1879,12 +1885,15 @@ function buildModelListProviderSetupMessage(
           ? 'Hugging Face is not authorized.'
           : 'Hugging Face is disabled.',
         ...(!authorized
-          ? ['Authorize it first:', '  hybridclaw auth login huggingface']
+          ? [
+              'Authorize it first from a terminal:',
+              '  hybridclaw auth login huggingface',
+            ]
           : []),
         ...(config.huggingface.enabled
           ? []
           : ['Enable it:', `  ${buildProviderEnableCommand('huggingface')}`]),
-        'Then rerun `/model list huggingface`.',
+        'Then rerun `model list huggingface`.',
       ].join('\n');
     }
     default:

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -1433,8 +1433,9 @@ test('model list openrouter asks for authorization before reporting no models', 
   }
   expect(result.title).toBe('Available Models');
   expect(result.text).toContain('OpenRouter is not authorized.');
+  expect(result.text).toContain('Authorize it first from a terminal:');
   expect(result.text).toContain('hybridclaw auth login openrouter');
-  expect(result.text).toContain('Then rerun `/model list openrouter`.');
+  expect(result.text).toContain('Then rerun `model list openrouter`.');
   expect(result.text).not.toContain('No models available for provider');
 });
 
@@ -1472,8 +1473,8 @@ test('model list openrouter asks to enable the provider when credentials exist b
   }
   expect(result.title).toBe('Available Models');
   expect(result.text).toContain('OpenRouter is disabled.');
-  expect(result.text).toContain('/config set openrouter.enabled true');
-  expect(result.text).toContain('Then rerun `/model list openrouter`.');
+  expect(result.text).toContain('config set openrouter.enabled true');
+  expect(result.text).toContain('Then rerun `model list openrouter`.');
   expect(result.text).not.toContain('No models available for provider');
 });
 


### PR DESCRIPTION
## Summary
- make gateway `/auth status <provider>` support all unified providers instead of hard-coding `hybridai`
- replace the generic `/model list openrouter` empty state with actionable setup guidance when OpenRouter is unauthorized or disabled
- add gateway regression tests for provider auth status support and OpenRouter setup messaging

## Root Cause
The gateway slash-command handler only accepted `auth status hybridai`, even though the CLI and help text advertised provider-specific status for the broader unified auth surface. The model-list path also treated provider setup failures as an empty catalog, so users saw `No models available` instead of the real remediation step.

## Impact
Users can now run `/auth status` for the supported providers from local TUI and web sessions, and `/model list openrouter` points them to the correct authorization or enablement command instead of implying the catalog is empty.

## Validation
- `./node_modules/.bin/vitest tests/gateway-status.test.ts`
- `npm run typecheck`
- `npm run lint`
