### PR TITLE
[codex] Prefer public runtime image pulls

### DIFF
--- a/src/infra/container-setup.ts
+++ b/src/infra/container-setup.ts
@@ -479,6 +479,7 @@ async function buildAndValidateImage(params: {
   }
 
   try {
+    let reasonLoggedBeforeBuild = false;
     if (
       acquisitionMode === 'pull-or-build' ||
       acquisitionMode === 'pull-only'
@@ -494,6 +495,7 @@ async function buildAndValidateImage(params: {
         );
       }
       console.log(`${commandName}: ${reason}`);
+      reasonLoggedBeforeBuild = true;
       for (const pullImage of pullImages) {
         console.log(
           `${commandName}: Pulling container image '${pullImage}'...`,
@@ -523,9 +525,10 @@ async function buildAndValidateImage(params: {
       }
     }
 
-    console.log(
-      `${commandName}: ${reason} Building container image '${imageName}'...`,
-    );
+    const buildLogMessage = reasonLoggedBeforeBuild
+      ? `${commandName}: Building container image '${imageName}'...`
+      : `${commandName}: ${reason} Building container image '${imageName}'...`;
+    console.log(buildLogMessage);
     await buildContainerImage(cwd, imageName);
     recordImageState(cwd, imageName, fingerprint);
     console.log(`${commandName}: Built container image '${imageName}'.`);

--- a/tests/container-setup.test.ts
+++ b/tests/container-setup.test.ts
@@ -391,6 +391,83 @@ describe('ensureContainerImageReady', () => {
     ).toBe(false);
   });
 
+  test('does not repeat the refresh reason when pull-or-build falls back to a local build', async () => {
+    const cwd = createTempDir();
+    const homeDir = createTempDir();
+    writeTrackedFiles(cwd);
+    writeState(homeDir, cwd, 'hybridclaw-agent', 'stale-fingerprint');
+    vi.stubEnv(
+      'HYBRIDCLAW_CONTAINER_PULL_IMAGE',
+      'ghcr.io/hybridaione/hybridclaw-agent:latest',
+    );
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+
+    const spawnMock = vi.fn((command: string, args: string[]) => {
+      const dockerAvailable = mockDockerAvailable(command, args);
+      if (dockerAvailable) return dockerAvailable;
+      if (
+        command === 'docker' &&
+        args[0] === 'image' &&
+        args[1] === 'inspect'
+      ) {
+        return makeSpawnResult({ code: 0 });
+      }
+      if (
+        command === 'docker' &&
+        args[0] === 'pull' &&
+        args[1] === 'ghcr.io/hybridaione/hybridclaw-agent:latest'
+      ) {
+        return makeSpawnResult({ code: 1, err: 'pull failed' });
+      }
+      if (
+        command === 'npm' &&
+        args[0] === 'run' &&
+        args[1] === 'build:container'
+      ) {
+        return makeSpawnResult({ code: 0 });
+      }
+      throw new Error(`Unexpected spawn: ${command} ${args.join(' ')}`);
+    });
+
+    const containerSetup = await importFreshContainerSetup({
+      homeDir,
+      spawnMock,
+    });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(
+      containerSetup.ensureContainerImageReady({
+        commandName: 'hybridclaw gateway restart',
+        cwd,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(logSpy).toHaveBeenCalledWith(
+      'hybridclaw gateway restart: Container sources changed since the last recorded build.',
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      "hybridclaw gateway restart: Pulling container image 'ghcr.io/hybridaione/hybridclaw-agent:latest'...",
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      "hybridclaw gateway restart: Building container image 'hybridclaw-agent'...",
+    );
+    expect(logSpy).not.toHaveBeenCalledWith(
+      "hybridclaw gateway restart: Container sources changed since the last recorded build. Building container image 'hybridclaw-agent'...",
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      "hybridclaw gateway restart: Unable to pull image 'ghcr.io/hybridaione/hybridclaw-agent:latest'.",
+    );
+    expect(warnSpy).toHaveBeenCalledWith('Details: pull failed');
+  });
+
   test('refreshes stale packaged installs by pulling from Docker Hub before building locally', async () => {
     const cwd = createTempDir();
     const homeDir = createTempDir();


### PR DESCRIPTION
## What changed
- prefer Docker Hub runtime image tags before GHCR for packaged installs
- make packaged-install refresh logs clearer by stating the refresh reason once and using a packaged-install specific message
- add regression tests for Docker Hub-first pulls, GHCR fallback, and the new logging behavior

## Why
Packaged `npm install` users were hitting private GHCR pulls first, which failed without GitHub authentication even though the public Docker Hub images were available. The retry logging also repeated the same stale-image reason for every pull candidate.

## Impact
Packaged installs will try the public runtime image first, and `hybridclaw tui` will log a clearer one-time reason when checking for a newer published container image.

## Validation
- `./node_modules/.bin/vitest tests/container-setup.test.ts`
- `npm run typecheck`
- `npm run lint`
- `docker pull hybridaione/hybridclaw-agent:v0.10.0`
- `docker pull hybridaione/hybridclaw-agent:latest`
