### PR TITLE
fix: consolidate mobile chat into single compact header row

### DIFF
--- a/docs/chat.html
+++ b/docs/chat.html
@@ -3932,7 +3932,13 @@
       void uploadSelectedFiles(attachmentInputEl.files);
     });
     document.getElementById('newChat').addEventListener('click', newChat);
-    document.getElementById('sidebarToggle').addEventListener('click', () => {
+    const sidebarToggleBtn = document.getElementById('sidebarToggle');
+    const mobileSidebarMedia = window.matchMedia('(max-width: 900px)');
+    sidebarToggleBtn.addEventListener('click', () => {
+      if (mobileSidebarMedia.matches) {
+        closeMobileSidebar();
+        return;
+      }
       layoutEl.classList.toggle('is-sidebar-collapsed');
     });
 


### PR DESCRIPTION
## Summary
- Merge icon-only tab styles from the 720px breakpoint into 900px so **all mobile widths** get a single-row topbar: `[hamburger] [logo] [icon tabs]`
- Add inline brand logo (26px) visible only on mobile between hamburger and nav icons
- Reduce topbar, composer, and message area padding for maximum chat content space

Previously ~50% of the mobile screen was consumed by the sidebar, two-row text tabs, and padding. Now the entire header is a single ~40px compact row.

## Test plan
- [x] Open `/chat` on a mobile device or Chrome DevTools device emulation (iPhone, Pixel)
- [x] Verify single compact row with logo + icon-only tabs + hamburger
- [x] Tap hamburger → sidebar slides out with backdrop
- [x] Tap backdrop or Escape → sidebar closes
- [x] Resize to >900px → normal desktop layout with full sidebar and text tabs
- [x] Verify chat messages and composer have full remaining vertical space

🤖 Generated with [Claude Code](https://claude.com/claude-code)