### PR TITLE
[codex] align codex model catalog

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -187,17 +187,7 @@
     "models": ["gpt-4.1-mini", "gpt-5-nano", "gpt-5"]
   },
   "codex": {
-    "baseUrl": "https://chatgpt.com/backend-api/codex",
-    "models": [
-      "openai-codex/gpt-5-codex",
-      "openai-codex/gpt-5.3-codex",
-      "openai-codex/gpt-5.4",
-      "openai-codex/gpt-5.3-codex-spark",
-      "openai-codex/gpt-5.2-codex",
-      "openai-codex/gpt-5.1-codex-max",
-      "openai-codex/gpt-5.2",
-      "openai-codex/gpt-5.1-codex-mini"
-    ]
+    "baseUrl": "https://chatgpt.com/backend-api/codex"
   },
   "openrouter": {
     "enabled": false,

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -469,7 +469,6 @@ export interface RuntimeConfig {
   };
   codex: {
     baseUrl: string;
-    models: string[];
   };
   openrouter: {
     enabled: boolean;
@@ -670,17 +669,6 @@ export type RuntimeConfigChangeListener = (
   prev: RuntimeConfig,
 ) => void;
 
-const LEGACY_SINGLE_CODEX_MODEL_LIST = ['openai-codex/gpt-5-codex'];
-const DEFAULT_CODEX_MODEL_LIST = [
-  'openai-codex/gpt-5-codex',
-  'openai-codex/gpt-5.3-codex',
-  'openai-codex/gpt-5.4',
-  'openai-codex/gpt-5.3-codex-spark',
-  'openai-codex/gpt-5.2-codex',
-  'openai-codex/gpt-5.1-codex-max',
-  'openai-codex/gpt-5.2',
-  'openai-codex/gpt-5.1-codex-mini',
-] as const;
 const DEFAULT_OPENROUTER_MODEL_LIST = [
   'openrouter/anthropic/claude-sonnet-4',
 ] as const;
@@ -891,7 +879,6 @@ const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
   },
   codex: {
     baseUrl: CODEX_DEFAULT_BASE_URL,
-    models: [...DEFAULT_CODEX_MODEL_LIST],
   },
   openrouter: {
     enabled: false,
@@ -1643,22 +1630,6 @@ function normalizeMcpServers(value: unknown): Record<string, McpServerConfig> {
     const serverConfig = normalizeMcpServerConfig(rawConfig);
     if (!serverConfig) continue;
     normalized[name] = serverConfig;
-  }
-  return normalized;
-}
-
-function normalizeCodexModelArray(
-  value: unknown,
-  fallback: string[],
-): string[] {
-  const normalized = normalizeStringArray(value, fallback);
-  if (
-    normalized.length === LEGACY_SINGLE_CODEX_MODEL_LIST.length &&
-    normalized.every(
-      (model, index) => model === LEGACY_SINGLE_CODEX_MODEL_LIST[index],
-    )
-  ) {
-    return [...DEFAULT_CODEX_MODEL_LIST];
   }
   return normalized;
 }
@@ -3516,10 +3487,6 @@ function normalizeRuntimeConfig(
     rawHybridAi.models,
     DEFAULT_RUNTIME_CONFIG.hybridai.models,
   );
-  const codexModelList = normalizeCodexModelArray(
-    rawCodex.models,
-    DEFAULT_RUNTIME_CONFIG.codex.models,
-  );
   const openRouterModelList = normalizeStringArray(
     rawOpenRouter.models,
     DEFAULT_RUNTIME_CONFIG.openrouter.models,
@@ -3806,7 +3773,6 @@ function normalizeRuntimeConfig(
         rawCodex.baseUrl,
         DEFAULT_RUNTIME_CONFIG.codex.baseUrl,
       ),
-      models: codexModelList,
     },
     openrouter: {
       enabled: normalizeBoolean(

--- a/src/migration/agent-home-migration.ts
+++ b/src/migration/agent-home-migration.ts
@@ -603,7 +603,6 @@ function applyOpenClawProviderConfig(
     if (name.includes('codex') || name.includes('openai-codex')) {
       if (baseUrl && (overwrite || !draft.codex.baseUrl))
         draft.codex.baseUrl = baseUrl;
-      draft.codex.models = applyModels(draft.codex.models);
       imported.push(providerName);
       continue;
     }
@@ -818,7 +817,7 @@ function applyImportedModel(draft: RuntimeConfig, model: string): void {
     return;
   }
   if (trimmed.startsWith('openai-codex/')) {
-    draft.codex.models = mergeUniqueStrings(draft.codex.models, [trimmed]);
+    return;
   }
 }
 

--- a/src/migration/agent-home-migration.ts
+++ b/src/migration/agent-home-migration.ts
@@ -12,6 +12,7 @@ import {
 } from '../config/runtime-config.js';
 import { resolveInstallPath } from '../infra/install-root.js';
 import { agentWorkspaceDir } from '../infra/ipc.js';
+import { logger } from '../logger.js';
 import {
   loadRuntimeSecrets,
   type RuntimeSecretKey,
@@ -603,6 +604,12 @@ function applyOpenClawProviderConfig(
     if (name.includes('codex') || name.includes('openai-codex')) {
       if (baseUrl && (overwrite || !draft.codex.baseUrl))
         draft.codex.baseUrl = baseUrl;
+      if (providerModels.length > 0) {
+        logger.warn(
+          { provider: providerName, models: providerModels },
+          'Ignoring imported Codex model list; Codex models are discovery-driven and not written to config',
+        );
+      }
       imported.push(providerName);
       continue;
     }
@@ -817,6 +824,10 @@ function applyImportedModel(draft: RuntimeConfig, model: string): void {
     return;
   }
   if (trimmed.startsWith('openai-codex/')) {
+    logger.warn(
+      { model: trimmed },
+      'Preserved imported Codex default model, but Codex models are discovery-driven and not written to config',
+    );
     return;
   }
 }

--- a/src/providers/codex-discovery.ts
+++ b/src/providers/codex-discovery.ts
@@ -2,10 +2,40 @@ import {
   getCodexAuthStatus,
   resolveCodexCredentials,
 } from '../auth/codex-auth.js';
+import { APP_VERSION } from '../config/config.js';
 import { isRecord, normalizeBaseUrl, readPositiveInteger } from './utils.js';
 
 const CODEX_DISCOVERY_TTL_MS = 3_600_000;
 const CODEX_MODEL_PREFIX = 'openai-codex/';
+const CODEX_FORWARD_COMPAT_MODELS = [
+  {
+    model: 'openai-codex/gpt-5.3-codex',
+    templateModels: ['openai-codex/gpt-5.2-codex'],
+  },
+  {
+    model: 'openai-codex/gpt-5.4',
+    templateModels: [
+      'openai-codex/gpt-5.3-codex',
+      'openai-codex/gpt-5.2-codex',
+    ],
+  },
+  {
+    model: 'openai-codex/gpt-5.4-mini',
+    templateModels: [
+      'openai-codex/gpt-5.4',
+      'openai-codex/gpt-5.1-codex-mini',
+      'openai-codex/gpt-5.3-codex',
+      'openai-codex/gpt-5.2-codex',
+    ],
+  },
+  {
+    model: 'openai-codex/gpt-5.3-codex-spark',
+    templateModels: [
+      'openai-codex/gpt-5.3-codex',
+      'openai-codex/gpt-5.2-codex',
+    ],
+  },
+] as const;
 
 function normalizeCodexModelName(modelId: string): string {
   const normalized = String(modelId || '').trim();
@@ -19,7 +49,21 @@ function normalizeCodexModelName(modelId: string): string {
 function readCodexModelEntries(payload: unknown): unknown[] {
   if (Array.isArray(payload)) return payload;
   if (isRecord(payload) && Array.isArray(payload.data)) return payload.data;
+  if (isRecord(payload) && Array.isArray(payload.models)) return payload.models;
   return [];
+}
+
+function readCodexModelId(entry: Record<string, unknown>): string {
+  if (typeof entry.id === 'string' && entry.id.trim()) return entry.id;
+  if (typeof entry.slug === 'string' && entry.slug.trim()) return entry.slug;
+  if (typeof entry.display_name === 'string' && entry.display_name.trim()) {
+    return entry.display_name;
+  }
+  return '';
+}
+
+function isCodexModelSupportedInApi(entry: Record<string, unknown>): boolean {
+  return entry.supported_in_api !== false;
 }
 
 function readCodexContextWindow(entry: Record<string, unknown>): number | null {
@@ -40,6 +84,27 @@ function readCodexMaxTokens(entry: Record<string, unknown>): number | null {
     readPositiveInteger(entry.max_completion_tokens) ??
     readPositiveInteger(entry.maxCompletionTokens)
   );
+}
+
+function addForwardCompatCodexModels(modelNames: string[]): string[] {
+  const ordered: string[] = [];
+  const seen = new Set<string>();
+
+  for (const modelName of modelNames) {
+    const normalized = normalizeCodexModelName(modelName);
+    if (!normalized || seen.has(normalized)) continue;
+    ordered.push(normalized);
+    seen.add(normalized);
+  }
+
+  for (const entry of CODEX_FORWARD_COMPAT_MODELS) {
+    if (seen.has(entry.model)) continue;
+    if (!entry.templateModels.some((template) => seen.has(template))) continue;
+    ordered.push(entry.model);
+    seen.add(entry.model);
+  }
+
+  return ordered;
 }
 
 export interface CodexDiscoveryStore {
@@ -70,13 +135,14 @@ export function createCodexDiscoveryStore(): CodexDiscoveryStore {
 
   async function fetchCodexModels(): Promise<string[]> {
     const credentials = await resolveCodexCredentials();
-    const response = await fetch(
+    const url = new URL(
       `${normalizeBaseUrl(process.env.HYBRIDCLAW_CODEX_BASE_URL || credentials.baseUrl)}/models`,
-      {
-        headers: credentials.headers,
-        signal: AbortSignal.timeout(5_000),
-      },
     );
+    url.searchParams.set('client_version', APP_VERSION);
+    const response = await fetch(url, {
+      headers: credentials.headers,
+      signal: AbortSignal.timeout(5_000),
+    });
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`);
     }
@@ -87,8 +153,8 @@ export function createCodexDiscoveryStore(): CodexDiscoveryStore {
     const contextWindows = new Map<string, number>();
     const maxTokens = new Map<string, number>();
     for (const entry of data) {
-      if (!isRecord(entry) || typeof entry.id !== 'string') continue;
-      const normalized = normalizeCodexModelName(entry.id);
+      if (!isRecord(entry) || !isCodexModelSupportedInApi(entry)) continue;
+      const normalized = normalizeCodexModelName(readCodexModelId(entry));
       if (!normalized) continue;
       discovered.add(normalized);
       const contextWindow = readCodexContextWindow(entry);
@@ -100,8 +166,9 @@ export function createCodexDiscoveryStore(): CodexDiscoveryStore {
         maxTokens.set(normalized, maxTokensForModel);
       }
     }
-    replaceDiscoveryCache([...discovered], contextWindows, maxTokens);
-    return [...discovered];
+    const discoveredModelNames = addForwardCompatCodexModels([...discovered]);
+    replaceDiscoveryCache(discoveredModelNames, contextWindows, maxTokens);
+    return discoveredModelNames;
   }
 
   async function discoverModels(opts?: { force?: boolean }): Promise<string[]> {

--- a/src/providers/codex-discovery.ts
+++ b/src/providers/codex-discovery.ts
@@ -7,6 +7,9 @@ import { isRecord, normalizeBaseUrl, readPositiveInteger } from './utils.js';
 
 const CODEX_DISCOVERY_TTL_MS = 3_600_000;
 const CODEX_MODEL_PREFIX = 'openai-codex/';
+// Keep entries ordered so any model used as a template appears earlier in the
+// list than models derived from it. appendForwardCompatCodexModels augments the
+// seen set as it walks this table once from top to bottom.
 const CODEX_FORWARD_COMPAT_MODELS = [
   {
     model: 'openai-codex/gpt-5.3-codex',
@@ -56,9 +59,6 @@ function readCodexModelEntries(payload: unknown): unknown[] {
 function readCodexModelId(entry: Record<string, unknown>): string {
   if (typeof entry.id === 'string' && entry.id.trim()) return entry.id;
   if (typeof entry.slug === 'string' && entry.slug.trim()) return entry.slug;
-  if (typeof entry.display_name === 'string' && entry.display_name.trim()) {
-    return entry.display_name;
-  }
   return '';
 }
 
@@ -86,16 +86,9 @@ function readCodexMaxTokens(entry: Record<string, unknown>): number | null {
   );
 }
 
-function addForwardCompatCodexModels(modelNames: string[]): string[] {
-  const ordered: string[] = [];
-  const seen = new Set<string>();
-
-  for (const modelName of modelNames) {
-    const normalized = normalizeCodexModelName(modelName);
-    if (!normalized || seen.has(normalized)) continue;
-    ordered.push(normalized);
-    seen.add(normalized);
-  }
+function appendForwardCompatCodexModels(modelNames: string[]): string[] {
+  const ordered = [...modelNames];
+  const seen = new Set(modelNames);
 
   for (const entry of CODEX_FORWARD_COMPAT_MODELS) {
     if (seen.has(entry.model)) continue;
@@ -166,7 +159,12 @@ export function createCodexDiscoveryStore(): CodexDiscoveryStore {
         maxTokens.set(normalized, maxTokensForModel);
       }
     }
-    const discoveredModelNames = addForwardCompatCodexModels([...discovered]);
+    const discoveredModelNames = appendForwardCompatCodexModels([
+      ...discovered,
+    ]);
+    // Forward-compat models are catalog-only additions. Metadata maps stay
+    // limited to models returned directly by the API; downstream static
+    // fallbacks fill known context-window defaults for derived entries.
     replaceDiscoveryCache(discoveredModelNames, contextWindows, maxTokens);
     return discoveredModelNames;
   }

--- a/src/providers/hybridai-models.ts
+++ b/src/providers/hybridai-models.ts
@@ -18,6 +18,7 @@ const STATIC_VISION_CAPABLE_MODELS = new Set<string>([
   'gpt-5.2',
   'gpt-5.2-codex',
   'gpt-5.2-pro',
+  'gpt-5.4-mini',
   'gpt-5.3-codex',
   'gpt-5.4',
 
@@ -78,6 +79,7 @@ const STATIC_MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   'gpt-5.2-chat-latest': 128_000,
   'gpt-5.2-codex': 400_000,
   'gpt-5.2-pro': 400_000,
+  'gpt-5.4-mini': 272_000,
   'gpt-5.4': 400_000,
   'gpt-5.3-codex': 400_000,
   'gpt-5.3-codex-spark': 128_000,

--- a/tests/agent-home-migration.test.ts
+++ b/tests/agent-home-migration.test.ts
@@ -662,6 +662,53 @@ test('migrates compatible OpenClaw state into HybridClaw', async () => {
   );
 });
 
+test('does not import Codex model lists from OpenClaw migration input', async () => {
+  const homeDir = makeTempHome();
+  const sourceRoot = path.join(homeDir, '.openclaw');
+
+  fs.mkdirSync(sourceRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(sourceRoot, 'openclaw.json'),
+    `${JSON.stringify(
+      {
+        agents: {
+          defaults: {
+            model: 'openai-codex/custom-preview',
+          },
+        },
+        models: {
+          providers: {
+            codex: {
+              baseUrl: 'https://codex.example/v1',
+              models: [
+                'openai-codex/custom-preview',
+                'openai-codex/custom-shadow',
+              ],
+            },
+          },
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    'utf-8',
+  );
+
+  const migration = await importFreshMigrator(homeDir);
+  await migration.migrateAgentHome({
+    sourceKind: 'openclaw',
+    sourceRoot,
+    migrateSecrets: false,
+  });
+
+  const config = readJson(path.join(homeDir, '.hybridclaw', 'config.json'));
+
+  expect((config.hybridai as { defaultModel: string }).defaultModel).toBe(
+    'openai-codex/custom-preview',
+  );
+  expect(config.codex).not.toHaveProperty('models');
+});
+
 test('migrates compatible Hermes Agent state into HybridClaw', async () => {
   const homeDir = makeTempHome();
   const sourceRoot = path.join(homeDir, '.hermes');

--- a/tests/agent-home-migration.test.ts
+++ b/tests/agent-home-migration.test.ts
@@ -665,6 +665,17 @@ test('migrates compatible OpenClaw state into HybridClaw', async () => {
 test('does not import Codex model lists from OpenClaw migration input', async () => {
   const homeDir = makeTempHome();
   const sourceRoot = path.join(homeDir, '.openclaw');
+  const loggerWarn = vi.fn();
+
+  vi.doMock('../src/logger.js', () => ({
+    logger: {
+      warn: loggerWarn,
+      info: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+    },
+  }));
 
   fs.mkdirSync(sourceRoot, { recursive: true });
   fs.writeFileSync(
@@ -707,6 +718,20 @@ test('does not import Codex model lists from OpenClaw migration input', async ()
     'openai-codex/custom-preview',
   );
   expect(config.codex).not.toHaveProperty('models');
+  expect(loggerWarn).toHaveBeenCalledWith(
+    { model: 'openai-codex/custom-preview' },
+    'Preserved imported Codex default model, but Codex models are discovery-driven and not written to config',
+  );
+  expect(loggerWarn).toHaveBeenCalledWith(
+    {
+      provider: 'codex',
+      models: [
+        'openai-codex/custom-preview',
+        'openai-codex/custom-shadow',
+      ],
+    },
+    'Ignoring imported Codex model list; Codex models are discovery-driven and not written to config',
+  );
 });
 
 test('migrates compatible Hermes Agent state into HybridClaw', async () => {

--- a/tests/configured-models.test.ts
+++ b/tests/configured-models.test.ts
@@ -99,7 +99,6 @@ describe('configured model catalog', () => {
     const homeDir = makeTempHome();
     writeRuntimeConfig(homeDir, (config) => {
       config.hybridai.models = ['gpt-5-nano', 'shared-model', 'gpt-5'];
-      config.codex.models = ['shared-model', 'openai-codex/gpt-5.4'];
       config.openrouter.enabled = true;
       config.openrouter.models = [
         'shared-model',
@@ -121,10 +120,6 @@ describe('configured model catalog', () => {
       'gpt-5-nano',
       'shared-model',
       'gpt-5',
-    ]);
-    expect(snapshot.codex.models).toEqual([
-      'shared-model',
-      'openai-codex/gpt-5.4',
     ]);
     expect(config.OPENROUTER_ENABLED).toBe(true);
     expect(snapshot.openrouter.models).toEqual([

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -413,9 +413,7 @@ test('checkProviders treats probe failures as provider health failures', async (
         defaultModel: 'gpt-5-nano',
         models: ['gpt-5'],
       },
-      codex: {
-        models: [],
-      },
+      codex: {},
       openrouter: {
         enabled: false,
         models: [],

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -159,8 +159,13 @@ test('getGatewayStatus includes Codex auth state', async () => {
   );
   vi.stubGlobal(
     'fetch',
-    vi.fn(async (input: string) => {
-      if (input.startsWith('https://chatgpt.com/backend-api/codex/models')) {
+    vi.fn(async (input: string | URL) => {
+      const url = new URL(String(input));
+      if (
+        url.origin === 'https://chatgpt.com' &&
+        url.pathname === '/backend-api/codex/models'
+      ) {
+        expect(url.searchParams.get('client_version')).toBeTruthy();
         return new Response(
           JSON.stringify({
             data: [
@@ -199,7 +204,7 @@ test('getGatewayStatus includes Codex auth state', async () => {
   expect(status.providerHealth?.codex).toMatchObject({
     kind: 'remote',
     reachable: true,
-    modelCount: 2,
+    modelCount: 3,
   });
   expect(status.providerHealth?.hybridai).toMatchObject({
     kind: 'remote',
@@ -248,8 +253,13 @@ test('getGatewayAdminModels discovers Codex models from the models endpoint', as
 
   vi.stubGlobal(
     'fetch',
-    vi.fn(async (input: string) => {
-      if (input.startsWith('https://chatgpt.com/backend-api/codex/models')) {
+    vi.fn(async (input: string | URL) => {
+      const url = new URL(String(input));
+      if (
+        url.origin === 'https://chatgpt.com' &&
+        url.pathname === '/backend-api/codex/models'
+      ) {
+        expect(url.searchParams.get('client_version')).toBeTruthy();
         return new Response(
           JSON.stringify({
             data: [
@@ -281,7 +291,7 @@ test('getGatewayAdminModels discovers Codex models from the models endpoint', as
   const result = await getGatewayAdminModels();
 
   expect(result.providerStatus?.codex).toMatchObject({
-    modelCount: 2,
+    modelCount: 3,
   });
   expect(result.models).toEqual(
     expect.arrayContaining([
@@ -295,8 +305,116 @@ test('getGatewayAdminModels discovers Codex models from the models endpoint', as
         contextWindow: 400_000,
         maxTokens: 128_000,
       }),
+      expect.objectContaining({
+        id: 'openai-codex/gpt-5.4-mini',
+        contextWindow: 272_000,
+        maxTokens: null,
+      }),
     ]),
   );
+});
+
+test('model list codex uses the current Codex models payload shape', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+  mockHealthProbes({ hybridaiReachable: true });
+
+  const { saveCodexAuthStore, extractExpiresAtFromJwt } = await import(
+    '../src/auth/codex-auth.ts'
+  );
+  const accessToken = makeJwt({
+    exp: Math.floor(Date.now() / 1000) + 600,
+    chatgpt_account_id: 'acct_gateway_model_list_codex',
+  });
+  saveCodexAuthStore(
+    {
+      version: 1,
+      credentials: {
+        accessToken,
+        refreshToken: 'refresh_gateway_model_list_codex',
+        accountId: 'acct_gateway_model_list_codex',
+        expiresAt: extractExpiresAtFromJwt(accessToken),
+        provider: 'openai-codex',
+        authMethod: 'oauth',
+        source: 'device-code',
+        lastRefresh: new Date().toISOString(),
+      },
+      updatedAt: new Date().toISOString(),
+    },
+    homeDir,
+  );
+  writeRuntimeConfig(homeDir, (config) => {
+    config.openrouter.enabled = false;
+    config.local.backends.ollama.enabled = false;
+    config.local.backends.lmstudio.enabled = false;
+    config.local.backends.vllm.enabled = false;
+  });
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (
+        url.origin === 'https://chatgpt.com' &&
+        url.pathname === '/backend-api/codex/models'
+      ) {
+        expect(url.searchParams.get('client_version')).toBeTruthy();
+        expect(init?.headers).toMatchObject({
+          Authorization: `Bearer ${accessToken}`,
+          'Chatgpt-Account-Id': 'acct_gateway_model_list_codex',
+          'OpenAI-Beta': 'responses=experimental',
+        });
+        return new Response(
+          JSON.stringify({
+            models: [
+              {
+                slug: 'gpt-5.2-codex',
+                display_name: 'gpt-5.2-codex',
+                supported_in_api: true,
+                context_window: 272_000,
+              },
+              {
+                slug: 'legacy-hidden-preview',
+                display_name: 'legacy-hidden-preview',
+                supported_in_api: false,
+                context_window: 1,
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      throw new Error(`Unexpected URL: ${input}`);
+    }),
+  );
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+
+  const result = await handleGatewayCommand({
+    sessionId: 'session-model-list-codex-current-shape',
+    guildId: null,
+    channelId: 'channel-model-list-codex-current-shape',
+    args: ['model', 'list', 'codex'],
+  });
+
+  expect(result.kind).toBe('info');
+  if (result.kind !== 'info') {
+    throw new Error(`Unexpected result kind: ${result.kind}`);
+  }
+  expect(result.title).toBe('Available Models (codex)');
+  expect(result.text).toContain('openai-codex/gpt-5.2-codex');
+  expect(result.text).toContain('openai-codex/gpt-5.3-codex');
+  expect(result.text).toContain('openai-codex/gpt-5.3-codex-spark');
+  expect(result.text).toContain('openai-codex/gpt-5.4');
+  expect(result.text).toContain('openai-codex/gpt-5.4-mini');
+  expect(result.text).not.toContain('legacy-hidden-preview');
+  expect(result.text).not.toContain('No models available for provider');
 });
 
 test('getGatewayStatus includes enabled remote model providers in provider health', async () => {

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -157,36 +157,33 @@ test('getGatewayStatus includes Codex auth state', async () => {
     },
     homeDir,
   );
-  vi.stubGlobal(
-    'fetch',
-    vi.fn(async (input: string | URL) => {
-      const url = new URL(String(input));
-      if (
-        url.origin === 'https://chatgpt.com' &&
-        url.pathname === '/backend-api/codex/models'
-      ) {
-        expect(url.searchParams.get('client_version')).toBeTruthy();
-        return new Response(
-          JSON.stringify({
-            data: [
-              {
-                id: 'gpt-5-codex',
-                context_window: 400_000,
-                max_output_tokens: 128_000,
-              },
-              {
-                id: 'gpt-5.4',
-                context_window: 400_000,
-                max_output_tokens: 128_000,
-              },
-            ],
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } },
-        );
-      }
-      throw new Error(`Unexpected URL: ${input}`);
-    }),
-  );
+  const fetchMock = vi.fn(async (input: string | URL) => {
+    const url = new URL(String(input));
+    if (
+      url.origin === 'https://chatgpt.com' &&
+      url.pathname === '/backend-api/codex/models'
+    ) {
+      return new Response(
+        JSON.stringify({
+          data: [
+            {
+              id: 'gpt-5-codex',
+              context_window: 400_000,
+              max_output_tokens: 128_000,
+            },
+            {
+              id: 'gpt-5.4',
+              context_window: 400_000,
+              max_output_tokens: 128_000,
+            },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+    throw new Error(`Unexpected URL: ${input}`);
+  });
+  vi.stubGlobal('fetch', fetchMock);
   initDatabase({ quiet: true });
 
   const { getGatewayStatus } = await import(
@@ -206,6 +203,18 @@ test('getGatewayStatus includes Codex auth state', async () => {
     reachable: true,
     modelCount: 3,
   });
+  const codexRequest = fetchMock.mock.calls
+    .map(([input, init]) => ({
+      url: new URL(String(input)),
+      init: init as RequestInit | undefined,
+    }))
+    .find(
+      ({ url }) =>
+        url.origin === 'https://chatgpt.com' &&
+        url.pathname === '/backend-api/codex/models',
+    );
+  expect(codexRequest).toBeDefined();
+  expect(codexRequest?.url.searchParams.get('client_version')).toBeTruthy();
   expect(status.providerHealth?.hybridai).toMatchObject({
     kind: 'remote',
     reachable: true,
@@ -251,36 +260,33 @@ test('getGatewayAdminModels discovers Codex models from the models endpoint', as
     config.local.backends.vllm.enabled = false;
   });
 
-  vi.stubGlobal(
-    'fetch',
-    vi.fn(async (input: string | URL) => {
-      const url = new URL(String(input));
-      if (
-        url.origin === 'https://chatgpt.com' &&
-        url.pathname === '/backend-api/codex/models'
-      ) {
-        expect(url.searchParams.get('client_version')).toBeTruthy();
-        return new Response(
-          JSON.stringify({
-            data: [
-              {
-                id: 'gpt-5-codex',
-                context_window: 400_000,
-                max_output_tokens: 128_000,
-              },
-              {
-                id: 'gpt-5.4',
-                context_window: 400_000,
-                max_output_tokens: 128_000,
-              },
-            ],
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } },
-        );
-      }
-      throw new Error(`Unexpected URL: ${input}`);
-    }),
-  );
+  const fetchMock = vi.fn(async (input: string | URL) => {
+    const url = new URL(String(input));
+    if (
+      url.origin === 'https://chatgpt.com' &&
+      url.pathname === '/backend-api/codex/models'
+    ) {
+      return new Response(
+        JSON.stringify({
+          data: [
+            {
+              id: 'gpt-5-codex',
+              context_window: 400_000,
+              max_output_tokens: 128_000,
+            },
+            {
+              id: 'gpt-5.4',
+              context_window: 400_000,
+              max_output_tokens: 128_000,
+            },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+    throw new Error(`Unexpected URL: ${input}`);
+  });
+  vi.stubGlobal('fetch', fetchMock);
 
   const { initDatabase } = await import('../src/memory/db.ts');
   const { getGatewayAdminModels } = await import(
@@ -293,6 +299,18 @@ test('getGatewayAdminModels discovers Codex models from the models endpoint', as
   expect(result.providerStatus?.codex).toMatchObject({
     modelCount: 3,
   });
+  const codexRequest = fetchMock.mock.calls
+    .map(([input, init]) => ({
+      url: new URL(String(input)),
+      init: init as RequestInit | undefined,
+    }))
+    .find(
+      ({ url }) =>
+        url.origin === 'https://chatgpt.com' &&
+        url.pathname === '/backend-api/codex/models',
+    );
+  expect(codexRequest).toBeDefined();
+  expect(codexRequest?.url.searchParams.get('client_version')).toBeTruthy();
   expect(result.models).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -351,43 +369,35 @@ test('model list codex uses the current Codex models payload shape', async () =>
     config.local.backends.vllm.enabled = false;
   });
 
-  vi.stubGlobal(
-    'fetch',
-    vi.fn(async (input: string | URL, init?: RequestInit) => {
-      const url = new URL(String(input));
-      if (
-        url.origin === 'https://chatgpt.com' &&
-        url.pathname === '/backend-api/codex/models'
-      ) {
-        expect(url.searchParams.get('client_version')).toBeTruthy();
-        expect(init?.headers).toMatchObject({
-          Authorization: `Bearer ${accessToken}`,
-          'Chatgpt-Account-Id': 'acct_gateway_model_list_codex',
-          'OpenAI-Beta': 'responses=experimental',
-        });
-        return new Response(
-          JSON.stringify({
-            models: [
-              {
-                slug: 'gpt-5.2-codex',
-                display_name: 'gpt-5.2-codex',
-                supported_in_api: true,
-                context_window: 272_000,
-              },
-              {
-                slug: 'legacy-hidden-preview',
-                display_name: 'legacy-hidden-preview',
-                supported_in_api: false,
-                context_window: 1,
-              },
-            ],
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } },
-        );
-      }
-      throw new Error(`Unexpected URL: ${input}`);
-    }),
-  );
+  const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+    const url = new URL(String(input));
+    if (
+      url.origin === 'https://chatgpt.com' &&
+      url.pathname === '/backend-api/codex/models'
+    ) {
+      return new Response(
+        JSON.stringify({
+          models: [
+            {
+              slug: 'gpt-5.2-codex',
+              display_name: 'gpt-5.2-codex',
+              supported_in_api: true,
+              context_window: 272_000,
+            },
+            {
+              slug: 'legacy-hidden-preview',
+              display_name: 'legacy-hidden-preview',
+              supported_in_api: false,
+              context_window: 1,
+            },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+    throw new Error(`Unexpected URL: ${input}`);
+  });
+  vi.stubGlobal('fetch', fetchMock);
 
   const { initDatabase } = await import('../src/memory/db.ts');
   const { handleGatewayCommand } = await import(
@@ -415,6 +425,23 @@ test('model list codex uses the current Codex models payload shape', async () =>
   expect(result.text).toContain('openai-codex/gpt-5.4-mini');
   expect(result.text).not.toContain('legacy-hidden-preview');
   expect(result.text).not.toContain('No models available for provider');
+  const codexRequest = fetchMock.mock.calls
+    .map(([input, init]) => ({
+      url: new URL(String(input)),
+      init: init as RequestInit | undefined,
+    }))
+    .find(
+      ({ url }) =>
+        url.origin === 'https://chatgpt.com' &&
+        url.pathname === '/backend-api/codex/models',
+    );
+  expect(codexRequest).toBeDefined();
+  expect(codexRequest?.url.searchParams.get('client_version')).toBeTruthy();
+  expect(codexRequest?.init?.headers).toMatchObject({
+    Authorization: `Bearer ${accessToken}`,
+    'Chatgpt-Account-Id': 'acct_gateway_model_list_codex',
+    'OpenAI-Beta': 'responses=experimental',
+  });
 });
 
 test('getGatewayStatus includes enabled remote model providers in provider health', async () => {

--- a/tests/hybridai-models.test.ts
+++ b/tests/hybridai-models.test.ts
@@ -34,6 +34,9 @@ test('resolveModelContextWindowFallback resolves known defaults', () => {
   expect(resolveModelContextWindowFallback('gpt-5:latest')).toBe(400_000);
   expect(resolveModelContextWindowFallback('gpt-5.1')).toBe(400_000);
   expect(resolveModelContextWindowFallback('gpt-5.3')).toBe(400_000);
+  expect(resolveModelContextWindowFallback('openai-codex/gpt-5.4-mini')).toBe(
+    272_000,
+  );
   expect(resolveModelContextWindowFallback('openai-codex/gpt-5.4')).toBe(
     400_000,
   );
@@ -58,6 +61,7 @@ test('isStaticModelVisionCapable returns true for known vision models', () => {
   expect(isStaticModelVisionCapable('gpt-5')).toBe(true);
   expect(isStaticModelVisionCapable('gpt-5-mini')).toBe(true);
   expect(isStaticModelVisionCapable('gpt-4.1-mini')).toBe(true);
+  expect(isStaticModelVisionCapable('gpt-5.4-mini')).toBe(true);
   expect(isStaticModelVisionCapable('gpt-5.3-codex')).toBe(true);
   expect(isStaticModelVisionCapable('claude-opus-4-6')).toBe(true);
   expect(isStaticModelVisionCapable('gemini-3-pro')).toBe(true);

--- a/tests/local-cli.test.ts
+++ b/tests/local-cli.test.ts
@@ -627,7 +627,6 @@ test('channels whatsapp setup preserves an existing custom ack reaction', async 
         },
         codex: {
           baseUrl: 'https://chatgpt.com/backend-api/codex',
-          models: ['openai-codex/gpt-5-codex'],
         },
         local: {
           backends: {

--- a/tests/model-catalog.test.ts
+++ b/tests/model-catalog.test.ts
@@ -362,33 +362,25 @@ test('available model catalog discovers Codex models from the models endpoint', 
     homeDir,
   );
 
-  vi.stubGlobal(
-    'fetch',
-    vi.fn(async (input: string | URL, init?: RequestInit) => {
-      const url = new URL(String(input));
-      if (
-        url.origin === 'https://chatgpt.com' &&
-        url.pathname === '/backend-api/codex/models'
-      ) {
-        expect(url.searchParams.get('client_version')).toBeTruthy();
-        expect(init?.headers).toMatchObject({
-          Authorization: `Bearer ${accessToken}`,
-          'Chatgpt-Account-Id': 'acct_catalog',
-          'OpenAI-Beta': 'responses=experimental',
-        });
-        return new Response(
-          JSON.stringify({
-            data: [
-              { id: 'gpt-5-codex', context_window: 400_000 },
-              { id: 'gpt-5.4', context_window: 400_000 },
-            ],
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } },
-        );
-      }
-      throw new Error(`Unexpected URL: ${input}`);
-    }),
-  );
+  const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+    const url = new URL(String(input));
+    if (
+      url.origin === 'https://chatgpt.com' &&
+      url.pathname === '/backend-api/codex/models'
+    ) {
+      return new Response(
+        JSON.stringify({
+          data: [
+            { id: 'gpt-5-codex', context_window: 400_000 },
+            { id: 'gpt-5.4', context_window: 400_000 },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+    throw new Error(`Unexpected URL: ${input}`);
+  });
+  vi.stubGlobal('fetch', fetchMock);
 
   const { catalog } = await importFreshCatalog(homeDir);
   const choices = await catalog.getAvailableModelChoices(25);
@@ -414,6 +406,23 @@ test('available model catalog discovers Codex models from the models endpoint', 
     'openai-codex/gpt-5.4',
     'openai-codex/gpt-5.4-mini',
   ]);
+  const codexRequest = fetchMock.mock.calls
+    .map(([input, init]) => ({
+      url: new URL(String(input)),
+      init: init as RequestInit | undefined,
+    }))
+    .find(
+      ({ url }) =>
+        url.origin === 'https://chatgpt.com' &&
+        url.pathname === '/backend-api/codex/models',
+    );
+  expect(codexRequest).toBeDefined();
+  expect(codexRequest?.url.searchParams.get('client_version')).toBeTruthy();
+  expect(codexRequest?.init?.headers).toMatchObject({
+    Authorization: `Bearer ${accessToken}`,
+    'Chatgpt-Account-Id': 'acct_catalog',
+    'OpenAI-Beta': 'responses=experimental',
+  });
 });
 
 test('available model catalog discovers Codex models from the current models payload', async () => {
@@ -451,43 +460,40 @@ test('available model catalog discovers Codex models from the current models pay
     homeDir,
   );
 
-  vi.stubGlobal(
-    'fetch',
-    vi.fn(async (input: string | URL, init?: RequestInit) => {
-      const url = new URL(String(input));
-      if (
-        url.origin === 'https://chatgpt.com' &&
-        url.pathname === '/backend-api/codex/models'
-      ) {
-        expect(url.searchParams.get('client_version')).toBeTruthy();
-        expect(init?.headers).toMatchObject({
-          Authorization: `Bearer ${accessToken}`,
-          'Chatgpt-Account-Id': 'acct_catalog_current_shape',
-          'OpenAI-Beta': 'responses=experimental',
-        });
-        return new Response(
-          JSON.stringify({
-            models: [
-              {
-                slug: 'gpt-5.2-codex',
-                display_name: 'gpt-5.2-codex',
-                supported_in_api: true,
-                context_window: 272_000,
-              },
-              {
-                slug: 'internal-preview',
-                display_name: 'internal-preview',
-                supported_in_api: false,
-                context_window: 1,
-              },
-            ],
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } },
-        );
-      }
-      throw new Error(`Unexpected URL: ${input}`);
-    }),
-  );
+  const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+    const url = new URL(String(input));
+    if (
+      url.origin === 'https://chatgpt.com' &&
+      url.pathname === '/backend-api/codex/models'
+    ) {
+      return new Response(
+        JSON.stringify({
+          models: [
+            {
+              slug: 'gpt-5.2-codex',
+              display_name: 'gpt-5.2-codex',
+              supported_in_api: true,
+              context_window: 272_000,
+            },
+            {
+              display_name: 'GPT-5.2 Codex (Preview)',
+              supported_in_api: true,
+              context_window: 272_000,
+            },
+            {
+              slug: 'internal-preview',
+              display_name: 'internal-preview',
+              supported_in_api: false,
+              context_window: 1,
+            },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+    throw new Error(`Unexpected URL: ${input}`);
+  });
+  vi.stubGlobal('fetch', fetchMock);
 
   const { catalog } = await importFreshCatalog(homeDir);
   const choices = await catalog.getAvailableModelChoices(25);
@@ -523,6 +529,26 @@ test('available model catalog discovers Codex models from the current models pay
     'openai-codex/gpt-5.4',
     'openai-codex/gpt-5.4-mini',
   ]);
+  expect(catalog.getAvailableModelList('codex')).not.toContain(
+    'openai-codex/GPT-5.2 Codex (Preview)',
+  );
+  const codexRequest = fetchMock.mock.calls
+    .map(([input, init]) => ({
+      url: new URL(String(input)),
+      init: init as RequestInit | undefined,
+    }))
+    .find(
+      ({ url }) =>
+        url.origin === 'https://chatgpt.com' &&
+        url.pathname === '/backend-api/codex/models',
+    );
+  expect(codexRequest).toBeDefined();
+  expect(codexRequest?.url.searchParams.get('client_version')).toBeTruthy();
+  expect(codexRequest?.init?.headers).toMatchObject({
+    Authorization: `Bearer ${accessToken}`,
+    'Chatgpt-Account-Id': 'acct_catalog_current_shape',
+    'OpenAI-Beta': 'responses=experimental',
+  });
 });
 
 test('available model catalog returns the full Hugging Face discovery list', async () => {

--- a/tests/model-catalog.test.ts
+++ b/tests/model-catalog.test.ts
@@ -364,8 +364,13 @@ test('available model catalog discovers Codex models from the models endpoint', 
 
   vi.stubGlobal(
     'fetch',
-    vi.fn(async (input: string, init?: RequestInit) => {
-      if (input.startsWith('https://chatgpt.com/backend-api/codex/models')) {
+    vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (
+        url.origin === 'https://chatgpt.com' &&
+        url.pathname === '/backend-api/codex/models'
+      ) {
+        expect(url.searchParams.get('client_version')).toBeTruthy();
         expect(init?.headers).toMatchObject({
           Authorization: `Bearer ${accessToken}`,
           'Chatgpt-Account-Id': 'acct_catalog',
@@ -398,11 +403,125 @@ test('available model catalog discovers Codex models from the models endpoint', 
         name: 'openai-codex/gpt-5.4',
         value: 'openai-codex/gpt-5.4',
       },
+      {
+        name: 'openai-codex/gpt-5.4-mini',
+        value: 'openai-codex/gpt-5.4-mini',
+      },
     ]),
   );
   expect(catalog.getAvailableModelList('codex')).toEqual([
     'openai-codex/gpt-5-codex',
     'openai-codex/gpt-5.4',
+    'openai-codex/gpt-5.4-mini',
+  ]);
+});
+
+test('available model catalog discovers Codex models from the current models payload', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  writeRuntimeConfig(homeDir, (config) => {
+    config.openrouter.enabled = false;
+    config.local.backends.ollama.enabled = false;
+    config.local.backends.lmstudio.enabled = false;
+    config.local.backends.vllm.enabled = false;
+  });
+
+  const { saveCodexAuthStore, extractExpiresAtFromJwt } = await import(
+    '../src/auth/codex-auth.ts'
+  );
+  const accessToken = makeJwt({
+    exp: Math.floor(Date.now() / 1000) + 600,
+    chatgpt_account_id: 'acct_catalog_current_shape',
+  });
+  saveCodexAuthStore(
+    {
+      version: 1,
+      credentials: {
+        accessToken,
+        refreshToken: 'refresh_catalog_current_shape',
+        accountId: 'acct_catalog_current_shape',
+        expiresAt: extractExpiresAtFromJwt(accessToken),
+        provider: 'openai-codex',
+        authMethod: 'oauth',
+        source: 'device-code',
+        lastRefresh: new Date().toISOString(),
+      },
+      updatedAt: new Date().toISOString(),
+    },
+    homeDir,
+  );
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (
+        url.origin === 'https://chatgpt.com' &&
+        url.pathname === '/backend-api/codex/models'
+      ) {
+        expect(url.searchParams.get('client_version')).toBeTruthy();
+        expect(init?.headers).toMatchObject({
+          Authorization: `Bearer ${accessToken}`,
+          'Chatgpt-Account-Id': 'acct_catalog_current_shape',
+          'OpenAI-Beta': 'responses=experimental',
+        });
+        return new Response(
+          JSON.stringify({
+            models: [
+              {
+                slug: 'gpt-5.2-codex',
+                display_name: 'gpt-5.2-codex',
+                supported_in_api: true,
+                context_window: 272_000,
+              },
+              {
+                slug: 'internal-preview',
+                display_name: 'internal-preview',
+                supported_in_api: false,
+                context_window: 1,
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      throw new Error(`Unexpected URL: ${input}`);
+    }),
+  );
+
+  const { catalog } = await importFreshCatalog(homeDir);
+  const choices = await catalog.getAvailableModelChoices(25);
+
+  expect(choices).toEqual(
+    expect.arrayContaining([
+      {
+        name: 'openai-codex/gpt-5.2-codex',
+        value: 'openai-codex/gpt-5.2-codex',
+      },
+      {
+        name: 'openai-codex/gpt-5.3-codex',
+        value: 'openai-codex/gpt-5.3-codex',
+      },
+      {
+        name: 'openai-codex/gpt-5.3-codex-spark',
+        value: 'openai-codex/gpt-5.3-codex-spark',
+      },
+      {
+        name: 'openai-codex/gpt-5.4',
+        value: 'openai-codex/gpt-5.4',
+      },
+      {
+        name: 'openai-codex/gpt-5.4-mini',
+        value: 'openai-codex/gpt-5.4-mini',
+      },
+    ]),
+  );
+  expect(catalog.getAvailableModelList('codex')).toEqual([
+    'openai-codex/gpt-5.2-codex',
+    'openai-codex/gpt-5.3-codex',
+    'openai-codex/gpt-5.3-codex-spark',
+    'openai-codex/gpt-5.4',
+    'openai-codex/gpt-5.4-mini',
   ]);
 });
 

--- a/tests/providers.task-routing.test.ts
+++ b/tests/providers.task-routing.test.ts
@@ -422,7 +422,6 @@ test('warns when no vision fallback is available after OpenRouter discovery refr
     config.openrouter.models = ['openrouter/acme/text-only'];
     config.hybridai.defaultModel = 'gpt-5-nano';
     config.hybridai.models = ['gpt-5-nano'];
-    config.codex.models = ['openai-codex/gpt-5.3-codex-spark'];
     config.local.backends.ollama.enabled = false;
     config.local.backends.lmstudio.enabled = false;
     config.local.backends.vllm.enabled = false;
@@ -486,7 +485,6 @@ test('returns a deferred policy error when fallback credential resolution fails'
     config.openrouter.enabled = false;
     config.hybridai.defaultModel = 'gpt-5-nano';
     config.hybridai.models = ['gpt-5-nano'];
-    config.codex.models = ['openai-codex/gpt-5.1-codex-max'];
     config.local.backends.ollama.enabled = false;
     config.local.backends.lmstudio.enabled = false;
     config.local.backends.vllm.enabled = false;

--- a/tests/runtime-config.migration-logging.test.ts
+++ b/tests/runtime-config.migration-logging.test.ts
@@ -240,11 +240,17 @@ describe('runtime config migration logging', () => {
     expect(stored.mcpServers.validSse.url).toBe('https://example.com/mcp');
   });
 
-  it('expands the legacy single-entry Codex model list on startup', async () => {
+  it('drops stale Codex model lists on startup', async () => {
     const homeDir = makeTempHome();
-    writeRuntimeConfig(homeDir, (config) => {
-      config.codex.models = ['openai-codex/gpt-5-codex'];
-    });
+    const configPath = path.join(homeDir, '.hybridclaw', 'config.json');
+    writeRuntimeConfig(homeDir);
+    const raw = JSON.parse(
+      fs.readFileSync(configPath, 'utf-8'),
+    ) as RuntimeConfig;
+    (raw.codex as Record<string, unknown>).models = [
+      'openai-codex/gpt-5-codex',
+    ];
+    fs.writeFileSync(configPath, `${JSON.stringify(raw, null, 2)}\n`, 'utf-8');
 
     await importFreshRuntimeConfig(homeDir);
 
@@ -255,16 +261,7 @@ describe('runtime config migration logging', () => {
       ),
     ) as RuntimeConfig;
 
-    expect(stored.codex.models).toEqual([
-      'openai-codex/gpt-5-codex',
-      'openai-codex/gpt-5.3-codex',
-      'openai-codex/gpt-5.4',
-      'openai-codex/gpt-5.3-codex-spark',
-      'openai-codex/gpt-5.2-codex',
-      'openai-codex/gpt-5.1-codex-max',
-      'openai-codex/gpt-5.2',
-      'openai-codex/gpt-5.1-codex-mini',
-    ]);
+    expect(stored.codex).not.toHaveProperty('models');
   });
 
   it('normalizes per-channel disabled skills on startup', async () => {


### PR DESCRIPTION
## Summary
- keep Codex model discovery sourced from the live `/models` endpoint with `client_version` and support the current `models[].slug` payload shape
- add Codex forward-compat catalog entries derived from discovered live template models so `model list codex` surfaces the same missing IDs seen in OpenClaw/Hermes-style catalogs
- remove the stale `codex.models` runtime-config field and stop OpenClaw/Hermes migration from writing Codex model lists into config
- add and update regression coverage for discovery, gateway model listing, runtime-config normalization, migration import, and Codex model metadata

## Root Cause
The live Codex catalog contract changed, while HybridClaw was still missing the post-discovery forward-compat layer used by comparable tools and still carried a stale `codex.models` config path that no longer drove runtime behavior.

## Validation
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/model-catalog.test.ts tests/gateway-status.test.ts tests/hybridai-models.test.ts`
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/runtime-config.migration-logging.test.ts tests/configured-models.test.ts tests/providers.task-routing.test.ts tests/agent-home-migration.test.ts tests/doctor.test.ts`
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/agent-home-migration.test.ts`
- `npm run lint`
- `./node_modules/.bin/biome check src/providers/codex-discovery.ts src/providers/hybridai-models.ts tests/model-catalog.test.ts tests/gateway-status.test.ts tests/hybridai-models.test.ts`
- `./node_modules/.bin/biome check src/config/runtime-config.ts config.example.json tests/runtime-config.migration-logging.test.ts tests/configured-models.test.ts tests/providers.task-routing.test.ts tests/agent-home-migration.test.ts tests/doctor.test.ts tests/local-cli.test.ts`
