### PR TITLE
[codex] Normalize provider model prefix stripping

### DIFF
--- a/container/shared/model-names.d.ts
+++ b/container/shared/model-names.d.ts
@@ -5,6 +5,11 @@ export declare function hasKnownNonHybridProviderPrefix(model: string): boolean;
 
 export declare function hasDisplayOnlyHybridAIPrefix(model: string): boolean;
 
+export declare function stripProviderPrefix(
+  model: string,
+  prefix: string,
+): string;
+
 export declare function stripHybridAIModelPrefix(model: string): string;
 
 export declare function formatHybridAIModelForCatalog(model: string): string;

--- a/container/shared/model-names.js
+++ b/container/shared/model-names.js
@@ -32,16 +32,28 @@ export function hasDisplayOnlyHybridAIPrefix(model) {
   );
 }
 
-export function stripHybridAIModelPrefix(model) {
+export function stripProviderPrefix(model, prefix) {
   const normalized = String(model || '').trim();
-  if (!normalized.toLowerCase().startsWith(HYBRIDAI_MODEL_PREFIX)) {
+  const normalizedPrefix = `${String(prefix || '')
+    .trim()
+    .replace(/\/+$/g, '')}/`;
+  if (!normalizedPrefix || normalizedPrefix === '/') {
     return normalized;
   }
-  return normalized.slice(HYBRIDAI_MODEL_PREFIX.length).trim();
+  if (!normalized.toLowerCase().startsWith(normalizedPrefix.toLowerCase())) {
+    return normalized;
+  }
+  const upstreamModel = normalized.slice(normalizedPrefix.length).trim();
+  return upstreamModel || normalized;
+}
+
+export function stripHybridAIModelPrefix(model) {
+  return stripProviderPrefix(model, HYBRIDAI_MODEL_PREFIX);
 }
 
 export function formatHybridAIModelForCatalog(model) {
   const normalized = stripHybridAIModelPrefix(model);
+  if (normalized.toLowerCase() === HYBRIDAI_MODEL_PREFIX) return '';
   if (!normalized) return '';
   return `${HYBRIDAI_MODEL_PREFIX}${normalized}`;
 }

--- a/src/gateway/openai-compatible-model.ts
+++ b/src/gateway/openai-compatible-model.ts
@@ -1,4 +1,7 @@
-import { stripHybridAIModelPrefix } from '../providers/model-names.js';
+import {
+  stripHybridAIModelPrefix,
+  stripProviderPrefix,
+} from '../providers/model-names.js';
 import {
   isOpenAICompatProviderId,
   type RuntimeProviderId,
@@ -110,11 +113,7 @@ function normalizeOpenAICompatModelName(
 }
 
 function normalizeCodexModelName(model: string): string {
-  const trimmed = String(model || '').trim();
-  const prefix = 'openai-codex/';
-  return trimmed.toLowerCase().startsWith(prefix)
-    ? trimmed.slice(prefix.length) || trimmed
-    : trimmed;
+  return stripProviderPrefix(model, 'openai-codex');
 }
 
 function contentToText(content: ChatMessage['content']): string {

--- a/src/providers/auxiliary.ts
+++ b/src/providers/auxiliary.ts
@@ -7,7 +7,10 @@ import {
 import { logger } from '../logger.js';
 import type { ChatMessage } from '../types/api.js';
 import { resolveModelRuntimeCredentials } from './factory.js';
-import { stripHybridAIModelPrefix } from './model-names.js';
+import {
+  stripHybridAIModelPrefix,
+  stripProviderPrefix,
+} from './model-names.js';
 import type { RuntimeProviderId } from './provider-ids.js';
 import { resolveProviderRequestMaxTokens } from './request-max-tokens.js';
 import {
@@ -463,17 +466,11 @@ function normalizeOpenAICompatModelName(
 }
 
 function normalizeCodexModelName(model: string): string {
-  const trimmed = model.trim();
-  const prefix = 'openai-codex/';
-  if (!trimmed.toLowerCase().startsWith(prefix)) return trimmed;
-  return trimmed.slice(prefix.length) || trimmed;
+  return stripProviderPrefix(model, 'openai-codex');
 }
 
 function normalizeOllamaModelName(model: string): string {
-  const trimmed = model.trim();
-  const prefix = 'ollama/';
-  if (!trimmed.toLowerCase().startsWith(prefix)) return trimmed;
-  return trimmed.slice(prefix.length) || trimmed;
+  return stripProviderPrefix(model, 'ollama');
 }
 
 function normalizeOllamaBaseUrl(baseUrl: string): string {

--- a/src/providers/auxiliary.ts
+++ b/src/providers/auxiliary.ts
@@ -7,6 +7,7 @@ import {
 import { logger } from '../logger.js';
 import type { ChatMessage } from '../types/api.js';
 import { resolveModelRuntimeCredentials } from './factory.js';
+import { stripHybridAIModelPrefix } from './model-names.js';
 import type { RuntimeProviderId } from './provider-ids.js';
 import { resolveProviderRequestMaxTokens } from './request-max-tokens.js';
 import {
@@ -543,7 +544,7 @@ async function callHybridAITextModel(
 ): Promise<string> {
   const body = withCoreRequestBody(
     {
-      model: context.model,
+      model: stripHybridAIModelPrefix(context.model),
       chatbot_id: context.chatbotId,
       messages,
       tools: options.tools,

--- a/src/providers/local-ollama.ts
+++ b/src/providers/local-ollama.ts
@@ -8,6 +8,7 @@ import {
   resolveLocalModelThinkingFormat,
   resolveOllamaApiBase,
 } from './local-discovery.js';
+import { stripProviderPrefix } from './model-names.js';
 import type {
   AIProvider,
   ResolvedModelRuntimeCredentials,
@@ -17,9 +18,7 @@ import type {
 const OLLAMA_MODEL_PREFIX = 'ollama/';
 
 function normalizeOllamaModelName(model: string): string {
-  const trimmed = String(model || '').trim();
-  if (!trimmed.toLowerCase().startsWith(OLLAMA_MODEL_PREFIX)) return trimmed;
-  return trimmed.slice(OLLAMA_MODEL_PREFIX.length) || trimmed;
+  return stripProviderPrefix(model, 'ollama');
 }
 
 async function resolveOllamaRuntimeCredentials(

--- a/src/providers/model-names.ts
+++ b/src/providers/model-names.ts
@@ -4,6 +4,7 @@ import {
   hasKnownNonHybridProviderPrefix,
   normalizeHybridAIModelForRuntime,
   stripHybridAIModelPrefix,
+  stripProviderPrefix,
 } from '../../container/shared/model-names.js';
 
 export {
@@ -11,6 +12,7 @@ export {
   HYBRIDAI_MODEL_PREFIX,
   normalizeHybridAIModelForRuntime,
   stripHybridAIModelPrefix,
+  stripProviderPrefix,
 };
 
 export function formatModelForDisplay(model: string): string {

--- a/tests/model-names.test.ts
+++ b/tests/model-names.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  formatHybridAIModelForCatalog,
+  stripHybridAIModelPrefix,
+  stripProviderPrefix,
+} from '../src/providers/model-names.js';
+
+describe('model name helpers', () => {
+  test('stripProviderPrefix removes matched provider prefixes case-insensitively', () => {
+    expect(stripProviderPrefix('openai-codex/gpt-5.4', 'openai-codex')).toBe(
+      'gpt-5.4',
+    );
+    expect(stripProviderPrefix('OLLAMA/llama3.2', 'ollama')).toBe('llama3.2');
+  });
+
+  test('stripProviderPrefix preserves unmatched or empty upstream names', () => {
+    expect(
+      stripProviderPrefix('anthropic/claude-sonnet-4', 'openai-codex'),
+    ).toBe('anthropic/claude-sonnet-4');
+    expect(stripProviderPrefix('openai-codex/', 'openai-codex')).toBe(
+      'openai-codex/',
+    );
+  });
+
+  test('stripHybridAIModelPrefix preserves prefix-only inputs instead of returning an empty model', () => {
+    expect(stripHybridAIModelPrefix('hybridai/gpt-5-nano')).toBe('gpt-5-nano');
+    expect(stripHybridAIModelPrefix('hybridai/')).toBe('hybridai/');
+  });
+
+  test('formatHybridAIModelForCatalog still drops prefix-only hybridai inputs', () => {
+    expect(formatHybridAIModelForCatalog('hybridai/')).toBe('');
+  });
+});

--- a/tests/openai-compatible-model.test.ts
+++ b/tests/openai-compatible-model.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+import { callOpenAICompatibleModel } from '../src/gateway/openai-compatible-model.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+test('openai-compatible Codex calls strip the provider prefix from request models', async () => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input).toBe('https://chatgpt.com/backend-api/codex/responses');
+      const body = JSON.parse(String(init?.body || '{}')) as Record<
+        string,
+        unknown
+      >;
+      expect(body.model).toBe('gpt-5.4');
+      return new Response(
+        JSON.stringify({
+          id: 'resp_1',
+          model: 'gpt-5.4',
+          output: [
+            {
+              type: 'message',
+              content: [{ type: 'output_text', text: 'ok' }],
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    }),
+  );
+
+  const result = await callOpenAICompatibleModel({
+    runtime: {
+      provider: 'openai-codex',
+      apiKey: 'codex-key',
+      baseUrl: 'https://chatgpt.com/backend-api/codex',
+      chatbotId: '',
+      enableRag: false,
+      requestHeaders: { 'OpenAI-Beta': 'responses=experimental' },
+      agentId: 'main',
+      isLocal: false,
+      contextWindow: 200_000,
+      thinkingFormat: undefined,
+    },
+    model: 'openai-codex/gpt-5.4',
+    messages: [{ role: 'user', content: 'hello' }],
+    tools: [],
+  });
+
+  expect(result.choices[0]?.message.content).toBe('ok');
+});

--- a/tests/providers.auxiliary.test.ts
+++ b/tests/providers.auxiliary.test.ts
@@ -178,6 +178,91 @@ test('host auxiliary caller falls back to resolved runtime credentials', async (
   });
 });
 
+test('host auxiliary caller strips the HybridAI display prefix from request models', async () => {
+  const resolveTaskModelPolicy = vi.fn(async () => undefined);
+  const resolveModelRuntimeCredentials = vi.fn(async () => ({
+    provider: 'hybridai' as const,
+    apiKey: 'hybridai-key',
+    baseUrl: 'https://hybridai.one',
+    chatbotId: 'bot_123',
+    enableRag: false,
+    requestHeaders: {},
+    agentId: 'main',
+    isLocal: false,
+    contextWindow: 200_000,
+    maxTokens: 2048,
+    thinkingFormat: undefined,
+  }));
+  vi.doMock('../src/providers/task-routing.js', async () => {
+    const actual = await vi.importActual<
+      typeof import('../src/providers/task-routing.js')
+    >('../src/providers/task-routing.js');
+    return {
+      ...actual,
+      resolveTaskModelPolicy,
+    };
+  });
+  vi.doMock('../src/providers/factory.js', async () => {
+    const actual = await vi.importActual<
+      typeof import('../src/providers/factory.js')
+    >('../src/providers/factory.js');
+    return {
+      ...actual,
+      resolveModelRuntimeCredentials,
+    };
+  });
+
+  const fetchMock = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input).toBe('https://hybridai.one/v1/chat/completions');
+      const body = JSON.parse(String(init?.body || '{}')) as Record<
+        string,
+        unknown
+      >;
+      expect(body).toMatchObject({
+        model: 'gpt-5-nano',
+        chatbot_id: 'bot_123',
+        enable_rag: false,
+        temperature: 0.1,
+      });
+      return new Response(
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                role: 'assistant',
+                content: 'HybridAI cleanup response.',
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    },
+  );
+  vi.stubGlobal('fetch', fetchMock);
+
+  const { callAuxiliaryModel } = await import('../src/providers/auxiliary.js');
+  const result = await callAuxiliaryModel({
+    task: 'flush_memories',
+    agentId: 'main',
+    fallbackModel: 'hybridai/gpt-5-nano',
+    fallbackChatbotId: 'bot_123',
+    maxTokens: 2048,
+    temperature: 0.1,
+    messages: [{ role: 'user', content: 'Rewrite this memory.' }],
+  });
+
+  expect(result).toEqual({
+    provider: 'hybridai',
+    model: 'hybridai/gpt-5-nano',
+    content: 'HybridAI cleanup response.',
+  });
+});
+
 test('host auxiliary caller streams Codex responses for auxiliary tasks', async () => {
   const resolveTaskModelPolicy = vi.fn(async () => undefined);
   const resolveModelRuntimeCredentials = vi.fn(async () => ({

--- a/tests/providers.auxiliary.test.ts
+++ b/tests/providers.auxiliary.test.ts
@@ -9,18 +9,13 @@ afterEach(() => {
   vi.doUnmock('../src/providers/factory.js');
 });
 
-test('host auxiliary caller uses the configured compression task model', async () => {
-  const resolveTaskModelPolicy = vi.fn(async () => ({
-    provider: 'lmstudio' as const,
-    baseUrl: 'http://127.0.0.1:1234/v1',
-    apiKey: '',
-    requestHeaders: {},
-    isLocal: true,
-    model: 'lmstudio/qwen/qwen2.5-instruct',
-    chatbotId: '',
-    maxTokens: 321,
-  }));
-  const resolveModelRuntimeCredentials = vi.fn();
+function setupProviderMocks({
+  resolveTaskModelPolicy,
+  resolveModelRuntimeCredentials,
+}: {
+  resolveTaskModelPolicy: ReturnType<typeof vi.fn>;
+  resolveModelRuntimeCredentials: ReturnType<typeof vi.fn>;
+}): void {
   vi.doMock('../src/providers/task-routing.js', async () => {
     const actual = await vi.importActual<
       typeof import('../src/providers/task-routing.js')
@@ -38,6 +33,24 @@ test('host auxiliary caller uses the configured compression task model', async (
       ...actual,
       resolveModelRuntimeCredentials,
     };
+  });
+}
+
+test('host auxiliary caller uses the configured compression task model', async () => {
+  const resolveTaskModelPolicy = vi.fn(async () => ({
+    provider: 'lmstudio' as const,
+    baseUrl: 'http://127.0.0.1:1234/v1',
+    apiKey: '',
+    requestHeaders: {},
+    isLocal: true,
+    model: 'lmstudio/qwen/qwen2.5-instruct',
+    chatbotId: '',
+    maxTokens: 321,
+  }));
+  const resolveModelRuntimeCredentials = vi.fn();
+  setupProviderMocks({
+    resolveTaskModelPolicy,
+    resolveModelRuntimeCredentials,
   });
 
   const fetchMock = vi.fn(
@@ -105,23 +118,9 @@ test('host auxiliary caller falls back to resolved runtime credentials', async (
     contextWindow: 32_768,
     thinkingFormat: undefined,
   }));
-  vi.doMock('../src/providers/task-routing.js', async () => {
-    const actual = await vi.importActual<
-      typeof import('../src/providers/task-routing.js')
-    >('../src/providers/task-routing.js');
-    return {
-      ...actual,
-      resolveTaskModelPolicy,
-    };
-  });
-  vi.doMock('../src/providers/factory.js', async () => {
-    const actual = await vi.importActual<
-      typeof import('../src/providers/factory.js')
-    >('../src/providers/factory.js');
-    return {
-      ...actual,
-      resolveModelRuntimeCredentials,
-    };
+  setupProviderMocks({
+    resolveTaskModelPolicy,
+    resolveModelRuntimeCredentials,
   });
 
   const fetchMock = vi.fn(
@@ -193,23 +192,9 @@ test('host auxiliary caller strips the HybridAI display prefix from request mode
     maxTokens: 2048,
     thinkingFormat: undefined,
   }));
-  vi.doMock('../src/providers/task-routing.js', async () => {
-    const actual = await vi.importActual<
-      typeof import('../src/providers/task-routing.js')
-    >('../src/providers/task-routing.js');
-    return {
-      ...actual,
-      resolveTaskModelPolicy,
-    };
-  });
-  vi.doMock('../src/providers/factory.js', async () => {
-    const actual = await vi.importActual<
-      typeof import('../src/providers/factory.js')
-    >('../src/providers/factory.js');
-    return {
-      ...actual,
-      resolveModelRuntimeCredentials,
-    };
+  setupProviderMocks({
+    resolveTaskModelPolicy,
+    resolveModelRuntimeCredentials,
   });
 
   const fetchMock = vi.fn(
@@ -277,23 +262,9 @@ test('host auxiliary caller streams Codex responses for auxiliary tasks', async 
     contextWindow: 200_000,
     thinkingFormat: undefined,
   }));
-  vi.doMock('../src/providers/task-routing.js', async () => {
-    const actual = await vi.importActual<
-      typeof import('../src/providers/task-routing.js')
-    >('../src/providers/task-routing.js');
-    return {
-      ...actual,
-      resolveTaskModelPolicy,
-    };
-  });
-  vi.doMock('../src/providers/factory.js', async () => {
-    const actual = await vi.importActual<
-      typeof import('../src/providers/factory.js')
-    >('../src/providers/factory.js');
-    return {
-      ...actual,
-      resolveModelRuntimeCredentials,
-    };
+  setupProviderMocks({
+    resolveTaskModelPolicy,
+    resolveModelRuntimeCredentials,
   });
 
   const streamBody = [
@@ -357,23 +328,9 @@ test('host auxiliary caller supports explicit provider overrides and max_complet
     maxTokens: 64_000,
     thinkingFormat: undefined,
   }));
-  vi.doMock('../src/providers/task-routing.js', async () => {
-    const actual = await vi.importActual<
-      typeof import('../src/providers/task-routing.js')
-    >('../src/providers/task-routing.js');
-    return {
-      ...actual,
-      resolveTaskModelPolicy,
-    };
-  });
-  vi.doMock('../src/providers/factory.js', async () => {
-    const actual = await vi.importActual<
-      typeof import('../src/providers/factory.js')
-    >('../src/providers/factory.js');
-    return {
-      ...actual,
-      resolveModelRuntimeCredentials,
-    };
+  setupProviderMocks({
+    resolveTaskModelPolicy,
+    resolveModelRuntimeCredentials,
   });
 
   const fetchMock = vi
@@ -473,23 +430,9 @@ test('host auxiliary caller falls back to 32000 max tokens for OpenRouter Anthro
     contextWindow: 200_000,
     thinkingFormat: undefined,
   }));
-  vi.doMock('../src/providers/task-routing.js', async () => {
-    const actual = await vi.importActual<
-      typeof import('../src/providers/task-routing.js')
-    >('../src/providers/task-routing.js');
-    return {
-      ...actual,
-      resolveTaskModelPolicy,
-    };
-  });
-  vi.doMock('../src/providers/factory.js', async () => {
-    const actual = await vi.importActual<
-      typeof import('../src/providers/factory.js')
-    >('../src/providers/factory.js');
-    return {
-      ...actual,
-      resolveModelRuntimeCredentials,
-    };
+  setupProviderMocks({
+    resolveTaskModelPolicy,
+    resolveModelRuntimeCredentials,
   });
 
   const fetchMock = vi.fn(
@@ -551,23 +494,9 @@ test('host auxiliary caller does not retry max_completion_tokens for unrelated u
     maxTokens: 48_000,
     thinkingFormat: undefined,
   }));
-  vi.doMock('../src/providers/task-routing.js', async () => {
-    const actual = await vi.importActual<
-      typeof import('../src/providers/task-routing.js')
-    >('../src/providers/task-routing.js');
-    return {
-      ...actual,
-      resolveTaskModelPolicy,
-    };
-  });
-  vi.doMock('../src/providers/factory.js', async () => {
-    const actual = await vi.importActual<
-      typeof import('../src/providers/factory.js')
-    >('../src/providers/factory.js');
-    return {
-      ...actual,
-      resolveModelRuntimeCredentials,
-    };
+  setupProviderMocks({
+    resolveTaskModelPolicy,
+    resolveModelRuntimeCredentials,
   });
 
   const fetchMock = vi.fn(
@@ -632,23 +561,9 @@ test('host auxiliary caller falls back to openrouter when task resolution fails'
     contextWindow: 200_000,
     thinkingFormat: undefined,
   }));
-  vi.doMock('../src/providers/task-routing.js', async () => {
-    const actual = await vi.importActual<
-      typeof import('../src/providers/task-routing.js')
-    >('../src/providers/task-routing.js');
-    return {
-      ...actual,
-      resolveTaskModelPolicy,
-    };
-  });
-  vi.doMock('../src/providers/factory.js', async () => {
-    const actual = await vi.importActual<
-      typeof import('../src/providers/factory.js')
-    >('../src/providers/factory.js');
-    return {
-      ...actual,
-      resolveModelRuntimeCredentials,
-    };
+  setupProviderMocks({
+    resolveTaskModelPolicy,
+    resolveModelRuntimeCredentials,
   });
   const warn = vi.fn();
   vi.doMock('../src/logger.js', () => ({


### PR DESCRIPTION
## What changed

This change centralizes provider-prefix stripping in a shared `stripProviderPrefix` helper and reuses it across HybridAI, Codex, and Ollama model normalization paths.

It also fixes the host auxiliary HybridAI request path so display-only model names like `hybridai/gpt-5-nano` are normalized to the upstream model id before the API request is sent.

The test coverage now includes the shared helper behavior, the HybridAI auxiliary regression, and OpenAI-compatible Codex request normalization.

## Why

Provider-prefixed display names were being normalized inconsistently across runtime paths. The HybridAI auxiliary path could still send `hybridai/...` to the API, and Codex/Ollama prefix stripping logic was duplicated in multiple places.

## Impact

HybridAI-backed auxiliary text calls now send the runtime model id expected by the API.

Codex and Ollama request normalization now reuse the same shared helper, which reduces drift between providers and makes future prefix handling easier to keep consistent.

## Validation

- `./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/providers.auxiliary.test.ts tests/model-names.test.ts tests/openai-compatible-model.test.ts`
- `npm run typecheck`