### PR TITLE
[codex] add locomo eval suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ docs/development/workplan-*.md
 
 # OS
 .DS_Store
+
+# Temporary files
+*.tmp*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
   BotFather token setup, DM/group policy controls, admin Channels support,
   managed `TELEGRAM_BOT_TOKEN` storage, inbound media handling, and canonical
   outbound `telegram:<chatId>` send targets.
+- **Built-in memory inspection command**: Added local `/memory inspect
+  [sessionId]`, `/memory query <query>`, and `hybridclaw gateway memory inspect
+  [sessionId]` diagnostics to show `MEMORY.md`, today's daily note, recent raw
+  history, `session_summary`, recent semantic-memory rows, canonical
+  cross-session recall state, and the exact prompt-memory block the current
+  session would attach for a query.
 
 ### Changed
 

--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,5 @@
 {
-  "version": 18,
+  "version": 21,
   "security": {
     "trustModelAccepted": false,
     "trustModelAcceptedAt": "",
@@ -356,7 +356,19 @@
   },
   "memory": {
     "decayRate": 0.1,
-    "consolidationIntervalHours": 24
+    "consolidationIntervalHours": 24,
+    "consolidationLanguage": "en",
+    "semanticPromptHardCap": 12,
+    "embedding": {
+      "provider": "hashed",
+      "model": "onnx-community/embeddinggemma-300m-ONNX",
+      "revision": "75a84c732f1884df76bec365346230e32f582c82",
+      "dtype": "q8"
+    },
+    "queryMode": "no-stopwords",
+    "backend": "hybrid",
+    "rerank": "bm25",
+    "tokenizer": "porter"
   },
   "sessionRouting": {
     "dmScope": "per-channel-peer",

--- a/container/src/tools.ts
+++ b/container/src/tools.ts
@@ -81,6 +81,7 @@ function guardCommand(command: string): string | null {
 
 type ScheduledTaskInfo = {
   id: number;
+  channelId: string;
   cronExpr: string;
   runAt: string | null;
   everyMs: number | null;
@@ -2891,7 +2892,8 @@ async function executeToolInternal(
             else schedule = `every ${Math.round(secs / 3600)}h`;
           } else schedule = t.cronExpr;
           const status = t.enabled ? 'enabled' : 'disabled';
-          return `#${t.id} [${status}] ${schedule} — ${t.prompt}`;
+          const destination = t.channelId ? ` -> ${t.channelId}` : '';
+          return `#${t.id} [${status}] ${schedule}${destination} — ${t.prompt}`;
         });
         return lines.join('\n');
       }
@@ -2903,6 +2905,8 @@ async function executeToolInternal(
           readStringValue(args.text);
         if (!promptInput) return failTool('Error: prompt is required');
         const prompt = promptInput;
+        const channelId =
+          readStringValue(args.channel) || readStringValue(args.channelId);
         const atSeconds = readPositiveNumberValue(
           args.at_seconds ?? args.atSeconds,
         );
@@ -2925,8 +2929,9 @@ async function executeToolInternal(
             action: 'add',
             runAt: runAt.toISOString(),
             prompt,
+            channelId,
           });
-          return `Scheduled one-shot task at ${runAt.toISOString()}: ${prompt}`;
+          return `Scheduled one-shot task at ${runAt.toISOString()}${channelId ? ` -> ${channelId}` : ''}: ${prompt}`;
         }
 
         if (args.cron) {
@@ -2934,8 +2939,9 @@ async function executeToolInternal(
             action: 'add',
             cronExpr: args.cron,
             prompt,
+            channelId,
           });
-          return `Scheduled recurring task with cron "${args.cron}": ${prompt}`;
+          return `Scheduled recurring task with cron "${args.cron}"${channelId ? ` -> ${channelId}` : ''}: ${prompt}`;
         }
 
         if (args.every) {
@@ -2947,8 +2953,9 @@ async function executeToolInternal(
             action: 'add',
             everyMs,
             prompt,
+            channelId,
           });
-          return `Scheduled interval task every ${secs}s: ${prompt}`;
+          return `Scheduled interval task every ${secs}s${channelId ? ` -> ${channelId}` : ''}: ${prompt}`;
         }
 
         return failTool(
@@ -3826,9 +3833,9 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
       description:
         'Manage scheduled tasks and reminders. Actions:\n' +
         '- "list": show all scheduled tasks\n' +
-        '- "add": create a task. Provide execution instruction in "prompt" (or aliases "message"/"text"), plus one schedule field: "at" (ISO-8601 one-shot), "at_seconds" (one-shot seconds from now), "cron" (recurring cron expression), or "every" (recurring interval seconds)\n' +
+        '- "add": create a task. Provide execution instruction in "prompt" (or aliases "message"/"text"), plus one schedule field: "at" (ISO-8601 one-shot), "at_seconds" (one-shot seconds from now), "cron" (recurring cron expression), or "every" (recurring interval seconds). Optional "channel" overrides where the generated result is delivered.\n' +
         '- "remove": delete a task by taskId\n' +
-        'The "prompt" is what the model will receive when the task fires. Use an explicit instruction (not the original user sentence).',
+        'The "prompt" is what the model will receive when the task fires. Use an explicit instruction (not the original user sentence). If you set "channel", describe the content to generate for that destination instead of telling the model to send it itself.',
       parameters: {
         type: 'object',
         properties: {
@@ -3860,6 +3867,11 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
             type: 'number',
             description:
               'Interval in seconds for simple recurring schedule (minimum 10)',
+          },
+          channel: {
+            type: 'string',
+            description:
+              'Optional delivery channel override for "add" (for example an email address, Discord channel id, Telegram target, iMessage handle, or "tui")',
           },
           taskId: {
             type: 'number',

--- a/container/src/types.ts
+++ b/container/src/types.ts
@@ -161,6 +161,7 @@ export interface ContextGuardConfig {
 // CamelCase projection of a scheduled_tasks row received over gateway/container IPC.
 export interface ScheduledTaskInput {
   id: number;
+  channelId: string;
   cronExpr: string;
   runAt: string | null;
   everyMs: number | null;
@@ -329,6 +330,7 @@ export type ScheduleSideEffect =
       runAt?: string;
       everyMs?: number;
       prompt: string;
+      channelId?: string;
     }
   | { action: 'remove'; taskId: number };
 

--- a/docs/development/agents.md
+++ b/docs/development/agents.md
@@ -55,6 +55,7 @@ Main docs landing pages:
 - [Internals](./internals/README.md)
 - [Architecture](./internals/architecture.md)
 - [Runtime](./internals/runtime.md)
+- [Memory](./internals/memory.md)
 - [Session Routing](./internals/session-routing.md)
 
 ## Reference

--- a/docs/development/internals/README.md
+++ b/docs/development/internals/README.md
@@ -13,5 +13,7 @@ These pages focus on how HybridClaw is built and operated under the hood.
 - [Architecture](./architecture.md) for the major runtime pieces and data flow
 - [Runtime Internals](./runtime.md) for sandboxing, diagnostics, audit, and
   operational behavior
+- [Memory](./memory.md) for the built-in memory layers, prompt injection path,
+  and compaction/consolidation lifecycle
 - [Session Routing](./session-routing.md) for canonical session keys and
   linked-identity boundaries

--- a/docs/development/internals/memory.md
+++ b/docs/development/internals/memory.md
@@ -1,0 +1,330 @@
+---
+title: Memory
+description: Built-in HybridClaw memory layers, prompt injection paths, compaction, and default limits.
+sidebar_position: 4
+---
+
+# Memory
+
+HybridClaw's built-in memory is layered. Different stores solve different
+problems:
+
+- `MEMORY.md` is curated long-term workspace memory
+- `memory/YYYY-MM-DD.md` is today's raw memory intake
+- raw session messages preserve the current conversation
+- `session_summary` compresses older current-session history
+- semantic memory stores query-recallable interaction summaries
+- canonical memory preserves cross-session and cross-channel continuity
+
+On a normal turn, HybridClaw does not inject every stored artifact wholesale.
+Some layers are loaded through the bootstrap prompt, some are injected through
+the memory hook, and some remain storage-only until a later consolidation or
+recall step.
+
+## At A Glance
+
+```text
+user turn
+  |
+  +--> raw session messages ------------------------------+
+  |                                                      |
+  |                                                      v
+  |                                            recent history in prompt
+  |                                            older history -> compaction
+  |                                                      |
+  |                                                      v
+  |                                               session_summary
+  |                                                      |
+  |                                                      v
+  |                                                memory hook
+  |
+  +--> semantic memory ("User asked ... I responded ...")
+  |                                                      |
+  |                                                      v
+  |                                         query-matched semantic recall
+  |                                                      |
+  |                                                      v
+  |                                                memory hook
+  |
+  +--> canonical cross-channel log ----------------------+
+  |                                                      |
+  |                                                      v
+  |                               canonical summary + recent other-session recall
+  |                                                      |
+  |                                                      v
+  |                                                memory hook
+  |
+  +--> memory tool / pre-compaction memory flush ------> memory/YYYY-MM-DD.md
+                                                         (today only)
+                                                                |
+                                                                v
+                                               bootstrap hook loads today's file
+                                                                |
+                                                   nightly dream / /dream rewrites
+                                                                |
+                                                                v
+                                                            MEMORY.md
+                                                                |
+                                                                v
+                                             bootstrap hook loads MEMORY.md
+```
+
+## Prompt-Time View
+
+On a standard built-in-memory turn, HybridClaw assembles memory from three main
+places:
+
+1. Bootstrap files
+   This includes `MEMORY.md` and today's `memory/YYYY-MM-DD.md` note when it
+   exists.
+2. Memory hook
+   This includes canonical cross-channel context, the current session summary,
+   and relevant semantic recall.
+3. Recent raw history
+   Recent session messages are passed as normal chat history messages, not as a
+   summary block.
+
+That means `MEMORY.md` and today's daily note are not the same thing as the
+semantic DB or the current session summary. They enter the prompt through
+different paths and follow different update rules.
+
+## The Memory Layers
+
+### `MEMORY.md`
+
+`MEMORY.md` is the curated long-term memory file in the agent workspace.
+HybridClaw loads it as part of the bootstrap prompt on every normal turn.
+
+Important properties:
+
+- it is prompt-time context, not a database row
+- it is meant to stay curated and relatively stable
+- normal `memory` tool writes should not append to it directly
+- `/dream` and the scheduled consolidation pass rewrite it from older daily
+  notes
+
+Use `MEMORY.md` for durable, cleaned-up context that should persist across
+sessions without carrying all raw intake forever.
+
+### `memory/YYYY-MM-DD.md`
+
+This is the raw daily memory intake file.
+
+Important properties:
+
+- the `memory` tool appends here
+- the pre-compaction memory flush writes here before older history is
+  summarized away
+- only today's daily note is injected into the prompt
+- older daily notes are not loaded directly once they are no longer "today"
+- older daily notes are later folded into `MEMORY.md` during dream
+  consolidation
+
+This is the staging area between "the model noticed something worth keeping"
+and "the workspace has a cleaned-up long-term memory file."
+
+### Raw Session History
+
+Raw session history lives in the SQLite messages table.
+
+Important properties:
+
+- recent raw turns are passed directly in the conversation history
+- HybridClaw keeps only a bounded recent slice for prompt assembly
+- that slice is further compressed by character limits before sending
+- older turns are eventually compacted out of raw history
+
+This is the highest-fidelity memory for the current session, but it is the
+least durable because it is the first thing that gets compacted.
+
+### `session_summary`
+
+When the current session gets large enough, HybridClaw compacts older messages
+into `session_summary` and deletes those older raw rows from the active session
+history.
+
+Important properties:
+
+- it belongs to the current session only
+- it summarizes older turns that were compacted away
+- it is injected through the memory hook under `## Session Summary`
+- it decays by age and can eventually be dropped when confidence falls too low
+
+This is the bridge between short-term raw history and long-lived workspace
+memory files.
+
+### Semantic Memory DB
+
+Semantic memory is stored in SQLite separately from raw messages.
+
+On each normal built-in-memory turn, HybridClaw stores one episodic semantic
+memory for the completed interaction, roughly:
+
+```text
+User asked: ...
+I responded: ...
+```
+
+Compaction can also store semantic summary memories.
+
+Important properties:
+
+- semantic memories are query-matched, not always injected
+- prompt assembly recalls only a small top-N set
+- recalled rows update their access metadata, so recall is stateful
+- stale rows decay during dream consolidation
+
+This is the main built-in retrieval layer for "older but still relevant"
+context.
+
+### Canonical Cross-Channel Memory
+
+Canonical memory is the cross-session and cross-channel continuity layer keyed
+by `(agentId, userId)`.
+
+After each turn, HybridClaw appends the exchange to the canonical log for that
+user. At prompt time, it can inject:
+
+- a compacted canonical summary
+- a recent window of messages from other sessions or channels for the same user
+
+Important properties:
+
+- it is separate from the current session's raw history
+- it is meant for continuity across channels, not only within one thread
+- prompt assembly excludes the current session from this recall so it does not
+  duplicate the main history window
+
+If a user talks to the same agent in Discord, web chat, and TUI, this is the
+layer that helps those sessions remember each other.
+
+## Normal Turn Lifecycle
+
+The built-in path for a successful turn is roughly:
+
+1. Store the user and assistant messages in the session message log.
+2. Store one semantic memory for the completed interaction.
+3. Append the same exchange to canonical cross-channel memory.
+4. On the next turn, load bootstrap files including `MEMORY.md` and today's
+   daily note.
+5. Build the memory hook from canonical context, `session_summary`, and
+   semantic recall.
+6. Include recent raw session history as chat messages.
+7. When thresholds are exceeded, run pre-compaction memory flush, write a new
+   `session_summary`, and delete older raw messages.
+8. On `/dream` or the scheduled consolidation run, fold older daily notes into
+   `MEMORY.md` and decay stale semantic memories.
+
+## Defaults, Caps, And Thresholds
+
+The values below describe the built-in defaults in the current codebase.
+
+### Bootstrap File And Daily Note Caps
+
+| Limit | Default | Meaning |
+| --- | ---: | --- |
+| bootstrap file read cap | `20,000` chars per file | `MEMORY.md` and other bootstrap files are trimmed before prompt assembly |
+| daily note prompt load | today only | only `memory/YYYY-MM-DD.md` for the current date is injected |
+
+### Recent Session History
+
+| Limit | Default | Meaning |
+| --- | ---: | --- |
+| recent history fetch window | `40` messages | max recent non-silent messages loaded into prompt history |
+| history char budget | `24,000` chars | total char budget after history optimization |
+| per-message history cap | `1,200` chars | each history message is bounded before budgeting |
+| protected head messages | `4` | oldest messages kept during middle compression |
+| protected tail messages | `8` | newest messages kept during middle compression |
+
+### Session Compaction
+
+| Limit | Default | Meaning |
+| --- | ---: | --- |
+| compaction enabled | `true` | current-session compaction runs automatically |
+| message-count trigger | `200` messages | compaction can trigger on message volume alone |
+| token budget | `100,000` estimated tokens | base compaction budget |
+| trigger ratio | `0.7` | compaction triggers at about `70,000` estimated tokens |
+| keep recent after compaction | `40` messages | recent raw turns retained after older rows are summarized |
+| summary max size | `8,000` chars | `session_summary` is truncated to this size |
+| compaction source transcript | `240` messages / `80,000` chars | max older-history excerpt sent into the compaction summary prompt |
+
+### Pre-Compaction Memory Flush
+
+| Limit | Default | Meaning |
+| --- | ---: | --- |
+| memory flush enabled | `true` | run a memory-writing pass before compaction |
+| flush source window | `80` messages | max older messages shown to the memory flush turn |
+| flush source cap | `24,000` chars | max transcript chars shown to the memory flush turn |
+
+### Semantic Memory
+
+| Limit | Default | Meaning |
+| --- | ---: | --- |
+| semantic write cap | `1,200` chars | stored semantic memory content is normalized and truncated to this size |
+| prompt recall default | `5` memories | normal prompt assembly asks for up to five semantic matches |
+| prompt recall hard cap | `12` memories | `buildPromptMemoryContext()` clamps prompt injection to at most twelve memories |
+| low-level recall hard cap | `50` memories | lower-level semantic recall API maximum for non-prompt callers |
+| semantic min confidence | `0.2` | rows below this are not recalled by default |
+| semantic decay rate | `0.1` | nightly decay multiplies stale confidence by `0.9` |
+| semantic stale threshold | `7` days | only memories not accessed for at least seven days are decayed |
+| semantic decay floor | `0.1` | nightly decay never pushes confidence below this floor |
+
+### Session Summary Decay
+
+| Limit | Default | Meaning |
+| --- | ---: | --- |
+| summary decay rate | `0.04` | summary confidence decays by age before prompt injection |
+| summary min confidence | `0.1` | minimum decayed summary confidence |
+| summary discard threshold | `0.22` | summaries below this confidence are omitted from the prompt |
+
+### Canonical Cross-Channel Memory
+
+| Limit | Default | Meaning |
+| --- | ---: | --- |
+| canonical storage window | `50` messages | recent canonical messages kept before another compaction cycle |
+| canonical compaction threshold | `100` messages | canonical summary refresh can trigger after this many stored messages |
+| canonical summary cap | `4,000` chars | max size of compacted canonical summary |
+| canonical message cap | `220` chars | each canonical message is shortened before summary building |
+| prompt fetch window | `12` messages | prompt-time canonical recall window before excluding current session |
+| prompt display window | `6` messages | only the last six canonical messages are rendered into the prompt section |
+
+### Dream Consolidation
+
+| Limit | Default | Meaning |
+| --- | ---: | --- |
+| scheduled interval | `24` hours | default nightly consolidation cadence |
+| disable scheduled runs | `0` hours | disables automatic consolidation |
+| consolidation language | `en` | language hint for model-backed cleanup passes |
+| semantic decay rate source | `memory.decayRate` | scheduled consolidation reuses this runtime config value |
+
+## What Operators Can Tune
+
+These areas are explicitly configurable:
+
+- `sessionCompaction.tokenBudget`
+- `sessionCompaction.budgetRatio`
+- `sessionCompaction.threshold`
+- `sessionCompaction.keepRecent`
+- `sessionCompaction.summaryMaxChars`
+- `sessionCompaction.preCompactionMemoryFlush.*`
+- `memory.decayRate`
+- `memory.consolidationIntervalHours`
+- `memory.consolidationLanguage`
+
+These commonly noticed caps are currently code defaults rather than normal
+operator config:
+
+- bootstrap file cap of `20,000` chars
+- recent prompt history fetch window of `40` messages
+- prompt-time semantic recall hard cap of `12`
+- prompt-time canonical fetch window of `12`
+
+## Plugin Caveat
+
+This page describes HybridClaw's built-in memory layer.
+
+If a plugin declares that it replaces built-in memory behavior, the gateway can
+skip parts of the native memory injection and compaction flow. Plugins that
+layer on top of native memory, such as additive external memory providers, do
+not change the built-in behavior described above unless they explicitly replace
+it.

--- a/docs/development/internals/memory.md
+++ b/docs/development/internals/memory.md
@@ -215,6 +215,41 @@ The built-in path for a successful turn is roughly:
 8. On `/dream` or the scheduled consolidation run, fold older daily notes into
    `MEMORY.md` and decay stale semantic memories.
 
+## Inspecting And Querying Live Memory
+
+For local diagnostics, HybridClaw exposes:
+
+```text
+/memory inspect [sessionId]
+/memory query <query>
+hybridclaw gateway memory inspect [sessionId]
+```
+
+These commands are local-only because they print internal memory state.
+
+`/memory inspect [sessionId]` reports:
+
+- the current workspace `MEMORY.md` file
+- today's `memory/YYYY-MM-DD.md` note in the workspace timezone
+- recent raw session history and the transcript mirror path
+- the stored `session_summary`, compaction count, and last memory flush time
+- recent semantic-memory rows stored for the session
+- canonical cross-session scope plus the prompt-time cross-channel recall view
+
+`/memory query <query>` shows the exact built-in prompt-memory block the
+current session would attach for that query, including:
+
+- whether the stored `session_summary` would be included
+- which semantic recalls would attach and their `[mem:n]` citations
+- the final attached block exactly as prompt assembly would format it
+
+The query command is a read-only diagnostic: it mirrors prompt assembly without
+updating semantic recall access metadata.
+
+Use these commands when you need to explain why HybridClaw answered with
+certain prior context, or when you want to verify which memory layer is missing
+something.
+
 ## Defaults, Caps, And Thresholds
 
 The values below describe the built-in defaults in the current codebase.
@@ -262,12 +297,26 @@ The values below describe the built-in defaults in the current codebase.
 | --- | ---: | --- |
 | semantic write cap | `1,200` chars | stored semantic memory content is normalized and truncated to this size |
 | prompt recall default | `5` memories | normal prompt assembly asks for up to five semantic matches |
-| prompt recall hard cap | `12` memories | `buildPromptMemoryContext()` clamps prompt injection to at most twelve memories |
+| prompt recall hard cap | `12` memories | `buildPromptMemoryContext()` clamps prompt injection to at most `memory.semanticPromptHardCap` memories |
 | low-level recall hard cap | `50` memories | lower-level semantic recall API maximum for non-prompt callers |
+| embedding provider | `hashed` | `memory.embedding.provider` selects the semantic vector source: the built-in hashed fallback or a local Transformers.js model |
+| Transformers.js model | `onnx-community/embeddinggemma-300m-ONNX` | `memory.embedding.model` controls the Hugging Face model id when the Transformers.js provider is enabled |
+| Transformers.js revision | `75a84c732f1884df76bec365346230e32f582c82` | `memory.embedding.revision` pins the exact Hugging Face model revision downloaded on first use |
+| Transformers.js dtype | `q8` | `memory.embedding.dtype` selects the local ONNX quantization variant (`fp32`, `q8`, or `q4`) |
+| query prep mode | `no-stopwords` | `memory.queryMode` can keep the raw query or strip common stopwords before recall |
+| recall backend | `hybrid` | `memory.backend` selects cosine retrieval, full-text BM25 retrieval, or a hybrid fusion of both |
+| rerank mode | `bm25` | `memory.rerank` can BM25-rerank the chosen candidate set before the final prompt slice |
+| tokenizer | `porter` | `memory.tokenizer` selects the SQLite FTS tokenizer used for lexical matching: `unicode61`, `porter`, or `trigram` |
 | semantic min confidence | `0.2` | rows below this are not recalled by default |
 | semantic decay rate | `0.1` | nightly decay multiplies stale confidence by `0.9` |
 | semantic stale threshold | `7` days | only memories not accessed for at least seven days are decayed |
 | semantic decay floor | `0.1` | nightly decay never pushes confidence below this floor |
+
+If you enable `memory.embedding.provider = "transformers"`, the first cosine
+query will download and cache the configured ONNX model under
+`~/.hybridclaw/cache/transformers`. Gated Hugging Face models follow the
+standard `HF_TOKEN` / `HF_ACCESS_TOKEN` environment variables supported by
+Transformers.js.
 
 ### Session Summary Decay
 

--- a/docs/development/internals/session-routing.md
+++ b/docs/development/internals/session-routing.md
@@ -1,7 +1,7 @@
 ---
 title: Session Routing
 description: Canonical session keys, routing boundaries, and identity isolation across HybridClaw channels.
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # Session Routing

--- a/docs/development/reference/commands.md
+++ b/docs/development/reference/commands.md
@@ -79,8 +79,7 @@ hybridclaw eval --fresh-agent --omit-prompt=bootstrap inspect eval inspect_evals
   for quick smoke tests over a small question slice
 - by default, `locomo --mode qa` creates one fresh template-seeded agent
   workspace per conversation sample; use `--current-agent` to reuse the current
-  agent workspace, or `--fresh-agent` to force a new agent for every
-  individual QA request
+  agent workspace
 - `swebench-verified`, `agentbench`, and `gaia` currently print starter
   recipes and setup guidance rather than a native managed runner
 - outside suite-specific overrides, the default eval mode keeps the current

--- a/docs/development/reference/commands.md
+++ b/docs/development/reference/commands.md
@@ -16,6 +16,7 @@ hybridclaw gateway stop
 hybridclaw gateway status
 hybridclaw gateway <command...>
 hybridclaw gateway compact
+hybridclaw gateway memory inspect [sessionId]
 hybridclaw gateway reset [yes|no]
 hybridclaw eval [list|env|<suite>] [--current-agent|--fresh-agent] [--ablate-system] [--include-prompt=<parts>] [--omit-prompt=<parts>]
 hybridclaw eval locomo [setup|run|status|stop|results|logs]
@@ -45,6 +46,10 @@ example `sessions` or `bot info`.
 `gateway compact` archives older session history into memory while preserving a
 recent active tail, and `gateway reset [yes|no]` clears history plus the
 current workspace after confirmation.
+`gateway memory inspect [sessionId]` is a local diagnostic that shows the
+current built-in memory layers for a session: `MEMORY.md`, today's daily note,
+recent raw history, compacted `session_summary`, recent semantic-memory rows,
+and canonical cross-session recall state.
 `hybridclaw tui --resume <sessionId>` and `hybridclaw --resume <sessionId>`
 reopen an earlier TUI session by canonical session id.
 
@@ -59,6 +64,18 @@ hybridclaw eval env
 hybridclaw eval locomo setup
 hybridclaw eval locomo run --budget 4000 --max-questions 20
 hybridclaw eval locomo run --mode retrieval --budget 4000 --max-questions 20
+hybridclaw eval locomo run --mode retrieval --retrieval-query raw --budget 4000 --max-questions 20
+hybridclaw eval locomo run --mode retrieval --retrieval-backend full-text --budget 4000 --max-questions 20
+hybridclaw eval locomo run --mode retrieval --retrieval-backend hybrid --budget 4000 --max-questions 20
+hybridclaw eval locomo run --mode retrieval --retrieval-rerank bm25 --budget 4000 --max-questions 20
+hybridclaw eval locomo run --mode retrieval --retrieval-tokenizer porter --budget 4000 --max-questions 20
+hybridclaw eval locomo run --mode retrieval --retrieval-tokenizer trigram --budget 4000 --max-questions 20
+hybridclaw eval locomo run --mode retrieval --retrieval-embedding transformers --budget 4000 --max-questions 20
+hybridclaw eval locomo run --mode retrieval --matrix --budget 4000
+hybridclaw eval locomo run --mode retrieval --matrix backend --budget 4000
+hybridclaw eval locomo run --mode retrieval --matrix rerank --budget 4000
+hybridclaw eval locomo run --mode retrieval --matrix tokenizer --budget 4000
+hybridclaw eval locomo run --mode retrieval --matrix embedding --budget 4000
 hybridclaw eval tau2 setup
 hybridclaw eval tau2 run --domain telecom --num-trials 1 --num-tasks 10
 hybridclaw eval terminal-bench-2.0 setup
@@ -75,6 +92,16 @@ hybridclaw eval --fresh-agent --omit-prompt=bootstrap inspect eval inspect_evals
 - `locomo --mode retrieval` skips model generation, ingests each conversation
   into an isolated native memory session, and scores evidence hit-rate from
   recalled semantic memories
+- `locomo --mode retrieval --matrix` runs the default retrieval sweep across
+  backend, rerank, and tokenizer combinations and renders one comparison table
+- `locomo --mode retrieval --matrix backend|rerank|tokenizer|embedding` runs a
+  single-dimension sweep and keeps the other retrieval settings at their
+  defaults
+- retrieval-mode knobs are benchmark-only: `--retrieval-query
+  raw|no-stopwords`, `--retrieval-backend cosine|full-text|hybrid`,
+  `--retrieval-rerank none|bm25` (default: `bm25`),
+  `--retrieval-tokenizer unicode61|porter|trigram`, and
+  `--retrieval-embedding hashed|transformers`
 - `locomo --num-samples` limits conversation records; use `--max-questions`
   for quick smoke tests over a small question slice
 - by default, `locomo --mode qa` creates one fresh template-seeded agent
@@ -258,6 +285,10 @@ the same gateway command surface used by TUI and web chat.
 
 - `/help` shows the same canonical slash-command list in TUI and embedded web
   chat, filtered per surface and kept in a consistent alphabetical order
+- local TUI/web sessions also support `/memory inspect [sessionId]` to inspect
+  the built-in memory layers for the current or an explicit session id
+- local TUI/web sessions support `/memory query <query>` to preview the exact
+  prompt-memory block the current session would attach for that query
 - Local TUI and web chat sessions expose `/config`, `/config check`,
   `/config reload`, `/config set <key> <value>`, `/config revisions`,
   `/concierge`, `/auth status hybridai`, and `/secret list|set|unset|show|route`

--- a/docs/development/reference/commands.md
+++ b/docs/development/reference/commands.md
@@ -18,6 +18,7 @@ hybridclaw gateway <command...>
 hybridclaw gateway compact
 hybridclaw gateway reset [yes|no]
 hybridclaw eval [list|env|<suite>] [--current-agent|--fresh-agent] [--ablate-system] [--include-prompt=<parts>] [--omit-prompt=<parts>]
+hybridclaw eval locomo [setup|run|status|stop|results|logs]
 hybridclaw eval terminal-bench-2.0 [setup|run|status|stop|results|logs]
 hybridclaw eval tau2 [setup|run|status|stop|results]
 hybridclaw eval [--current-agent|--fresh-agent] [--ablate-system] [--include-prompt=<parts>] [--omit-prompt=<parts>] <command...>
@@ -55,6 +56,8 @@ HybridClaw's loopback OpenAI-compatible API.
 ```bash
 hybridclaw eval list
 hybridclaw eval env
+hybridclaw eval locomo setup
+hybridclaw eval locomo run --budget 4000 --num-samples 2
 hybridclaw eval tau2 setup
 hybridclaw eval tau2 run --domain telecom --num-trials 1 --num-tasks 10
 hybridclaw eval terminal-bench-2.0 setup
@@ -64,7 +67,9 @@ hybridclaw eval --fresh-agent --omit-prompt=bootstrap inspect eval inspect_evals
 
 - local-only surface from CLI, TUI, or embedded web chat; it is not intended
   for Discord, Teams, WhatsApp, email, or other remote chat channels
-- managed suites today: `tau2` and `terminal-bench-2.0`
+- managed suites today: `locomo`, `tau2`, and `terminal-bench-2.0`
+- `locomo` runs a native HybridClaw memory harness against the official
+  LoCoMo conversations and compares recent-tail context with semantic recall
 - `swebench-verified`, `agentbench`, and `gaia` currently print starter
   recipes and setup guidance rather than a native managed runner
 - the default eval mode keeps the current agent workspace but opens a fresh

--- a/docs/development/reference/commands.md
+++ b/docs/development/reference/commands.md
@@ -57,7 +57,8 @@ HybridClaw's loopback OpenAI-compatible API.
 hybridclaw eval list
 hybridclaw eval env
 hybridclaw eval locomo setup
-hybridclaw eval locomo run --budget 4000 --num-samples 2
+hybridclaw eval locomo run --budget 4000 --max-questions 20
+hybridclaw eval locomo run --mode retrieval --budget 4000 --max-questions 20
 hybridclaw eval tau2 setup
 hybridclaw eval tau2 run --domain telecom --num-trials 1 --num-tasks 10
 hybridclaw eval terminal-bench-2.0 setup
@@ -68,12 +69,22 @@ hybridclaw eval --fresh-agent --omit-prompt=bootstrap inspect eval inspect_evals
 - local-only surface from CLI, TUI, or embedded web chat; it is not intended
   for Discord, Teams, WhatsApp, email, or other remote chat channels
 - managed suites today: `locomo`, `tau2`, and `terminal-bench-2.0`
-- `locomo` runs a native HybridClaw memory harness against the official
-  LoCoMo conversations and compares recent-tail context with semantic recall
+- `locomo --mode qa` runs a native HybridClaw QA harness against the official
+  LoCoMo conversations, generates answers through the local OpenAI-compatible
+  gateway, and scores those answers with LoCoMo-style question metrics
+- `locomo --mode retrieval` skips model generation, ingests each conversation
+  into an isolated native memory session, and scores evidence hit-rate from
+  recalled semantic memories
+- `locomo --num-samples` limits conversation records; use `--max-questions`
+  for quick smoke tests over a small question slice
+- by default, `locomo --mode qa` creates one fresh template-seeded agent
+  workspace per conversation sample; use `--current-agent` to reuse the current
+  agent workspace, or `--fresh-agent` to force a new agent for every
+  individual QA request
 - `swebench-verified`, `agentbench`, and `gaia` currently print starter
   recipes and setup guidance rather than a native managed runner
-- the default eval mode keeps the current agent workspace but opens a fresh
-  OpenAI-compatible session per request
+- outside suite-specific overrides, the default eval mode keeps the current
+  agent workspace but opens a fresh OpenAI-compatible session per request
 - `--fresh-agent` uses a temporary template-seeded agent workspace for each
   eval request
 - detached run logs and summaries are stored under

--- a/docs/development/reference/configuration.md
+++ b/docs/development/reference/configuration.md
@@ -90,10 +90,19 @@ leak into the saved revision metadata.
   `per-channel-peer` mode keeps DMs isolated by transport and peer identity,
   while `per-linked-identity` plus `sessionRouting.identityLinks` collapses
   verified aliases onto one shared main session
-- `memory.decayRate`, `memory.consolidationIntervalHours`, and
-  `memory.consolidationLanguage` for nightly "dream" consolidation and cleanup;
-  `0` disables scheduled runs, `24` matches `dream on`, and `dream now`
-  triggers an immediate local consolidation run
+- `memory.decayRate`, `memory.consolidationIntervalHours`,
+  `memory.consolidationLanguage`, `memory.semanticPromptHardCap`,
+  `memory.embedding.*`, `memory.queryMode`, `memory.backend`,
+  `memory.rerank`, and `memory.tokenizer` for built-in
+  memory cleanup, prompt-time semantic recall limits, and live semantic
+  retrieval behavior (`memory.backend` accepts `cosine`, `full-text`, or
+  `hybrid`, while `memory.tokenizer` accepts `unicode61`, `porter`, or
+  `trigram`; `memory.embedding.provider` accepts `hashed` or
+  `transformers`, with the Transformers.js provider configured by
+  `memory.embedding.model`, `memory.embedding.revision`, and
+  `memory.embedding.dtype`); `0`
+  disables scheduled runs, `24` matches `dream on`, and `dream now` triggers
+  an immediate local consolidation run
 - `agents.defaultAgentId` for the default agent used by new requests and fresh
   web sessions when no agent is pinned explicitly
 - `skills.disabled` and `skills.channelDisabled.*` for skill availability

--- a/docs/static/docs.js
+++ b/docs/static/docs.js
@@ -62,6 +62,7 @@ export const DEVELOPMENT_DOCS_SECTIONS = [
       { title: 'Internals', path: 'internals/README.md' },
       { title: 'Architecture', path: 'internals/architecture.md' },
       { title: 'Runtime', path: 'internals/runtime.md' },
+      { title: 'Memory', path: 'internals/memory.md' },
       { title: 'Session Routing', path: 'internals/session-routing.md' },
     ],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "pptxgenjs": "4.0.1",
         "qrcode-terminal": "0.12.0",
         "sanitize-html": "2.17.1",
+        "stemmer": "2.0.1",
         "ws": "8.20.0",
         "xlsx-populate": "1.21.0",
         "yaml": "2.8.3",
@@ -86,7 +87,7 @@
     },
     "container": {
       "name": "hybridclaw-agent",
-      "version": "0.12.0",
+      "version": "0.12.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
         "@mozilla/readability": "0.6.0",
@@ -10879,6 +10880,19 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stemmer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/stemmer/-/stemmer-2.0.1.tgz",
+      "integrity": "sha512-bkWvSX2JR4nSZFfs113kd4C6X13bBBrg4fBKv2pVdzpdQI2LA5pZcWzTFNdkYsiUNl13E4EzymSRjZ0D55jBYg==",
+      "license": "MIT",
+      "bin": {
+        "stemmer": "cli.js"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/streamx": {
       "version": "2.25.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "container"
       ],
       "dependencies": {
+        "@huggingface/transformers": "3.8.1",
         "@whiskeysockets/baileys": "7.0.0-rc.9",
         "ajv": "8.18.0",
         "better-sqlite3": "12.8.0",
@@ -1950,6 +1951,27 @@
         "hono": "^4"
       }
     },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.6.tgz",
+      "integrity": "sha512-MyMWyLnjqo+KRJYSH7oWNbsOn5onuIvfXYPcc0WOGxU0eHUV7oAYUoQTl2BMdu7ml+ea/bu11UM+EshbeHwtIA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/transformers": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-3.8.1.tgz",
+      "integrity": "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.3",
+        "onnxruntime-node": "1.21.0",
+        "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4",
+        "sharp": "^0.34.1"
+      }
+    },
     "node_modules/@hybridaione/hybridclaw-console": {
       "resolved": "console",
       "link": true
@@ -1959,7 +1981,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1976,7 +1997,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1999,7 +2019,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2022,7 +2041,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2039,7 +2057,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2056,7 +2073,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2073,7 +2089,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2090,7 +2105,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2107,7 +2121,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2124,7 +2137,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2141,7 +2153,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2158,7 +2169,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2175,7 +2185,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2192,7 +2201,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2215,7 +2223,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2238,7 +2245,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2261,7 +2267,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2284,7 +2289,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2307,7 +2311,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2330,7 +2333,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2353,7 +2355,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2373,7 +2374,6 @@
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.7.0"
       },
@@ -2396,7 +2396,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2416,7 +2415,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2436,7 +2434,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2511,6 +2508,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -5063,6 +5072,13 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
     },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
+    },
     "node_modules/botbuilder": {
       "version": "4.23.3",
       "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.23.3.tgz",
@@ -5946,6 +5962,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -5956,6 +5989,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/degenerator": {
@@ -6018,6 +6068,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
     },
     "node_modules/discord-api-types": {
       "version": "0.38.42",
@@ -6388,6 +6444,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.4",
@@ -6892,6 +6954,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
@@ -7143,6 +7211,66 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-agent/node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -7167,6 +7295,12 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "license": "MIT"
     },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -7174,6 +7308,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -7901,6 +8047,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -8692,6 +8844,18 @@
         "node": ">= 20"
       }
     },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -8777,6 +8941,18 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mitt": {
@@ -9124,6 +9300,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -9164,6 +9349,49 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0.tgz",
+      "integrity": "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.21.0.tgz",
+      "integrity": "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.21.0",
+        "tar": "^7.0.1"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==",
+      "license": "MIT"
     },
     "node_modules/open": {
       "version": "10.2.0",
@@ -9544,6 +9772,12 @@
       "engines": {
         "node": ">=16.20.0"
       }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
     },
     "node_modules/playwright": {
       "version": "1.58.2",
@@ -10109,6 +10343,23 @@
       "integrity": "sha512-22MOP1Rh7sAo1BZpDG6R5RFYzR2lYEgwq7HEmyW2qcsOqR2lQKmn+O//xV3YG/0rrhMC6KVX2hU+ZXuaw9a5bw==",
       "license": "MIT"
     },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.9",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
@@ -10408,6 +10659,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT"
+    },
     "node_modules/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
@@ -10550,7 +10807,6 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -10858,6 +11114,12 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -11081,6 +11343,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -11107,6 +11385,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/teen_process": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "prepare": "command -v git >/dev/null 2>&1 && test -w .git/config && husky || true"
   },
   "dependencies": {
+    "@huggingface/transformers": "3.8.1",
     "@whiskeysockets/baileys": "7.0.0-rc.9",
     "ajv": "8.18.0",
     "better-sqlite3": "12.8.0",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "pptxgenjs": "4.0.1",
     "qrcode-terminal": "0.12.0",
     "sanitize-html": "2.17.1",
+    "stemmer": "2.0.1",
     "ws": "8.20.0",
     "xlsx-populate": "1.21.0",
     "yaml": "2.8.3",

--- a/src/agent/side-effects.ts
+++ b/src/agent/side-effects.ts
@@ -25,9 +25,10 @@ export function processSideEffects(
     for (const effect of schedules) {
       try {
         if (effect.action === 'add') {
+          const deliveryChannelId = effect.channelId?.trim() || channelId;
           const taskId = createTask(
             sessionId,
-            channelId,
+            deliveryChannelId,
             effect.cronExpr || '',
             effect.prompt,
             effect.runAt,
@@ -37,7 +38,7 @@ export function processSideEffects(
             {
               taskId,
               sessionId,
-              channelId,
+              channelId: deliveryChannelId,
               cronExpr: effect.cronExpr,
               runAt: effect.runAt,
               everyMs: effect.everyMs,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1511,6 +1511,11 @@ export async function main(
       await runTerminalBenchNativeCli(subargs);
       break;
     }
+    case '__eval-locomo-native': {
+      const { runLocomoNativeCli } = await import('./evals/locomo-native.js');
+      await runLocomoNativeCli(subargs);
+      break;
+    }
     case 'tui':
       await launchTui(subargs);
       break;

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -62,6 +62,18 @@ Examples:
   hybridclaw eval locomo setup
   hybridclaw eval locomo run --budget 4000 --max-questions 20
   hybridclaw eval locomo run --mode retrieval --budget 4000 --max-questions 20
+  hybridclaw eval locomo run --mode retrieval --retrieval-query raw --budget 4000 --max-questions 20
+  hybridclaw eval locomo run --mode retrieval --retrieval-backend full-text --budget 4000 --max-questions 20
+  hybridclaw eval locomo run --mode retrieval --retrieval-backend hybrid --budget 4000 --max-questions 20
+  hybridclaw eval locomo run --mode retrieval --retrieval-rerank bm25 --budget 4000 --max-questions 20
+  hybridclaw eval locomo run --mode retrieval --retrieval-tokenizer porter --budget 4000 --max-questions 20
+  hybridclaw eval locomo run --mode retrieval --retrieval-tokenizer trigram --budget 4000 --max-questions 20
+  hybridclaw eval locomo run --mode retrieval --retrieval-embedding transformers --budget 4000 --max-questions 20
+  hybridclaw eval locomo run --mode retrieval --matrix --budget 4000
+  hybridclaw eval locomo run --mode retrieval --matrix backend --budget 4000
+  hybridclaw eval locomo run --mode retrieval --matrix rerank --budget 4000
+  hybridclaw eval locomo run --mode retrieval --matrix tokenizer --budget 4000
+  hybridclaw eval locomo run --mode retrieval --matrix embedding --budget 4000
   hybridclaw eval tau2
   hybridclaw eval tau2 setup
   hybridclaw eval terminal-bench-2.0 setup
@@ -82,6 +94,9 @@ Notes:
   - \`locomo\` downloads the official \`locomo10.json\` dataset during \`setup\`.
   - \`locomo --mode qa\` sends evaluate_gpts-style QA prompts through HybridClaw's local OpenAI-compatible gateway and scores the generated answers.
   - \`locomo --mode retrieval\` skips model generation, ingests each conversation into an isolated native memory session, and scores evidence hit-rate from recalled semantic memories.
+  - \`locomo --mode retrieval --matrix\` runs the default retrieval sweep across backend, rerank, and tokenizer combinations and prints one comparison table.
+  - \`locomo --mode retrieval --matrix backend|rerank|tokenizer|embedding\` runs a single-dimension sweep and keeps the other retrieval settings at their defaults.
+  - Retrieval-mode knobs are benchmark-only: \`--retrieval-query raw|no-stopwords\`, \`--retrieval-backend cosine|full-text|hybrid\`, \`--retrieval-rerank none|bm25\` (default: \`bm25\`), \`--retrieval-tokenizer unicode61|porter|trigram\`, and \`--retrieval-embedding hashed|transformers\`.
   - \`locomo --num-samples\` limits conversation records; use \`--max-questions\` for fast smoke runs over a small QA slice.
   - By default, \`locomo --mode qa\` creates one fresh template-seeded agent workspace per conversation sample. Use \`--current-agent\` to reuse the current agent workspace.
   - \`terminal-bench-2.0 run --num-tasks 10\` runs the native HybridClaw Terminal-Bench harness against local task containers.
@@ -124,6 +139,7 @@ Interactive slash commands inside TUI:
   /help
   /info
   /mcp list   /mcp add <name> <json>   /mcp toggle <name>   /mcp remove <name>   /mcp reconnect <name>
+  /memory inspect [sessionId]   /memory query <query>
   /model [name]   /model info|list [provider]|set <name>|clear|default [name]
   /paste
   /plugin [list|enable|disable|config|install|reinstall|reload|uninstall]

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -60,7 +60,8 @@ Examples:
   hybridclaw eval env --fresh-agent
   hybridclaw eval locomo
   hybridclaw eval locomo setup
-  hybridclaw eval locomo run --budget 4000 --num-samples 2
+  hybridclaw eval locomo run --budget 4000 --max-questions 20
+  hybridclaw eval locomo run --mode retrieval --budget 4000 --max-questions 20
   hybridclaw eval tau2
   hybridclaw eval tau2 setup
   hybridclaw eval terminal-bench-2.0 setup
@@ -78,13 +79,17 @@ Notes:
   - Detached benchmark commands are launched directly with \`hybridclaw eval <command...>\`.
   - Only \`locomo\`, \`terminal-bench-2.0\`, and \`tau2\` have active HybridClaw implementations today.
   - \`swebench-verified\`, \`agentbench\`, and \`gaia\` are stub entries that return \`not implemented yet\`.
-  - \`locomo\` is a native memory benchmark that downloads the official \`locomo10.json\` dataset during \`setup\` and compares recent-tail context against HybridClaw semantic recall.
+  - \`locomo\` downloads the official \`locomo10.json\` dataset during \`setup\`.
+  - \`locomo --mode qa\` sends evaluate_gpts-style QA prompts through HybridClaw's local OpenAI-compatible gateway and scores the generated answers.
+  - \`locomo --mode retrieval\` skips model generation, ingests each conversation into an isolated native memory session, and scores evidence hit-rate from recalled semantic memories.
+  - \`locomo --num-samples\` limits conversation records; use \`--max-questions\` for fast smoke runs over a small QA slice.
+  - By default, \`locomo --mode qa\` creates one fresh template-seeded agent workspace per conversation sample. Use \`--current-agent\` to reuse the current agent workspace, or \`--fresh-agent\` to force a new agent for every individual QA request.
   - \`terminal-bench-2.0 run --num-tasks 10\` runs the native HybridClaw Terminal-Bench harness against local task containers.
   - \`tau2\` has managed subcommands: \`setup\`, \`run\`, \`status\`, \`stop\`, and \`results\`.
   - \`tau2 setup\` prefers a uv-managed Python 3.12 virtual environment when \`uv\` is available, then smoke-tests the installed \`tau2\` CLI.
   - For \`tau2 run\`, omitted \`--agent-llm\` and \`--user-llm\` flags default to \`$HYBRIDCLAW_EVAL_MODEL\`.
   - TUI and web sessions receive proactive ASCII progress bars for supported evals like \`tau2 run --num-tasks ...\`.
-  - The default eval mode uses the current agent workspace but a fresh transient OpenAI-compatible session per request.
+  - Outside suite-specific overrides, the default eval mode uses the current agent workspace but a fresh transient OpenAI-compatible session per request.
   - \`--fresh-agent\` uses a temporary template-seeded agent workspace for each eval request.
   - \`--ablate-system\` removes HybridClaw's injected system prompt for the eval request.
   - Prompt parts include hook names like \`memory\`, \`runtime\`, \`safety\`, \`bootstrap\` and bootstrap subparts like \`soul\`, \`identity\`, \`user\`, \`tools\`, \`memory-file\`, and \`skills\`.

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -83,7 +83,7 @@ Notes:
   - \`locomo --mode qa\` sends evaluate_gpts-style QA prompts through HybridClaw's local OpenAI-compatible gateway and scores the generated answers.
   - \`locomo --mode retrieval\` skips model generation, ingests each conversation into an isolated native memory session, and scores evidence hit-rate from recalled semantic memories.
   - \`locomo --num-samples\` limits conversation records; use \`--max-questions\` for fast smoke runs over a small QA slice.
-  - By default, \`locomo --mode qa\` creates one fresh template-seeded agent workspace per conversation sample. Use \`--current-agent\` to reuse the current agent workspace, or \`--fresh-agent\` to force a new agent for every individual QA request.
+  - By default, \`locomo --mode qa\` creates one fresh template-seeded agent workspace per conversation sample. Use \`--current-agent\` to reuse the current agent workspace.
   - \`terminal-bench-2.0 run --num-tasks 10\` runs the native HybridClaw Terminal-Bench harness against local task containers.
   - \`tau2\` has managed subcommands: \`setup\`, \`run\`, \`status\`, \`stop\`, and \`results\`.
   - \`tau2 setup\` prefers a uv-managed Python 3.12 virtual environment when \`uv\` is available, then smoke-tests the installed \`tau2\` CLI.

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -47,6 +47,7 @@ Commands:
 
 export function printEvalUsage(): void {
   console.log(`Usage: hybridclaw eval [list|env|<suite>] [--current-agent|--fresh-agent] [--ablate-system] [--include-prompt=<parts>] [--omit-prompt=<parts>]
+       hybridclaw eval locomo [setup|run|status|stop|results|logs]
        hybridclaw eval terminal-bench-2.0 [setup|run|status|stop|results|logs]
        hybridclaw eval tau2 [setup|run|status|stop|results]
        hybridclaw eval [--current-agent|--fresh-agent] [--ablate-system] [--include-prompt=<parts>] [--omit-prompt=<parts>] <command...>
@@ -57,6 +58,9 @@ Examples:
   hybridclaw eval list
   hybridclaw eval env
   hybridclaw eval env --fresh-agent
+  hybridclaw eval locomo
+  hybridclaw eval locomo setup
+  hybridclaw eval locomo run --budget 4000 --num-samples 2
   hybridclaw eval tau2
   hybridclaw eval tau2 setup
   hybridclaw eval terminal-bench-2.0 setup
@@ -72,8 +76,9 @@ Examples:
 Notes:
   - This is a local-only command. It is not intended for remote chat channels.
   - Detached benchmark commands are launched directly with \`hybridclaw eval <command...>\`.
-  - Only \`terminal-bench-2.0\` and \`tau2\` have active HybridClaw implementations today.
+  - Only \`locomo\`, \`terminal-bench-2.0\`, and \`tau2\` have active HybridClaw implementations today.
   - \`swebench-verified\`, \`agentbench\`, and \`gaia\` are stub entries that return \`not implemented yet\`.
+  - \`locomo\` is a native memory benchmark that downloads the official \`locomo10.json\` dataset during \`setup\` and compares recent-tail context against HybridClaw semantic recall.
   - \`terminal-bench-2.0 run --num-tasks 10\` runs the native HybridClaw Terminal-Bench harness against local task containers.
   - \`tau2\` has managed subcommands: \`setup\`, \`run\`, \`status\`, \`stop\`, and \`results\`.
   - \`tau2 setup\` prefers a uv-managed Python 3.12 virtual environment when \`uv\` is available, then smoke-tests the installed \`tau2\` CLI.

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -1707,6 +1707,32 @@ function buildSlashCommandCatalogDefinitions(
           description: 'Stub entry for a planned SWE-bench Verified runner',
         },
         {
+          id: 'eval.locomo',
+          label: '/eval locomo',
+          insertText: '/eval locomo',
+          description: 'Show the native LOCOMO memory benchmark commands',
+        },
+        {
+          id: 'eval.locomo.setup',
+          label: '/eval locomo setup',
+          insertText: '/eval locomo setup',
+          description:
+            'Download the official LOCOMO dataset into the local eval workspace',
+        },
+        {
+          id: 'eval.locomo.run',
+          label: '/eval locomo run --budget 4000 --num-samples 2',
+          insertText: '/eval locomo run --budget 4000 --num-samples 2',
+          description:
+            'Run a small native LOCOMO memory benchmark sample with recent-tail and semantic-recall modes',
+        },
+        {
+          id: 'eval.locomo.results',
+          label: '/eval locomo results',
+          insertText: '/eval locomo results',
+          description: 'Show the latest LOCOMO summary and comparison metrics',
+        },
+        {
           id: 'eval.terminal-bench-2.0',
           label: '/eval terminal-bench-2.0',
           insertText: '/eval terminal-bench-2.0',

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -83,6 +83,7 @@ const REGISTERED_TEXT_COMMAND_NAMES = new Set([
   'rag',
   'model',
   'status',
+  'memory',
   'show',
   'approve',
   'usage',
@@ -220,6 +221,11 @@ const LOCAL_SESSION_HELP_PRESENTATIONS: Record<
     command:
       '/model [<name>|info|list [provider]|set <name>|clear|default [name]]',
     description: 'Inspect or set session/default model',
+  },
+  memory: {
+    command: '/memory inspect [sessionId] | /memory query <query>',
+    description:
+      'Inspect memory layers or preview prompt-time memory attachment',
   },
   plugin: {
     command:
@@ -394,6 +400,14 @@ export function mapCanonicalCommandToGatewayArgs(
     case 'status':
       return ['status'];
 
+    case 'memory': {
+      const sub = (parts[1] || '').trim().toLowerCase();
+      if (!sub) return ['memory', 'inspect'];
+      if (sub === 'inspect') return ['memory', 'inspect', ...parts.slice(2)];
+      if (sub === 'query') return ['memory', 'query', ...parts.slice(2)];
+      return ['memory', 'inspect', ...parts.slice(1)];
+    }
+
     case 'auth': {
       const sub = (parts[1] || '').trim().toLowerCase();
       if (!sub) return ['auth'];
@@ -561,6 +575,27 @@ function buildSlashCommandCatalogDefinitions(
     {
       name: 'status',
       description: 'Show HybridClaw runtime status (only visible to you)',
+    },
+    {
+      name: 'memory',
+      description:
+        'Inspect memory layers or preview prompt-time memory attachment',
+      localSurfaces: ['tui', 'web'],
+      tuiMenuEntries: [
+        {
+          id: 'memory.inspect',
+          label: '/memory inspect [sessionId]',
+          insertText: '/memory inspect ',
+          description: 'Inspect the built-in memory layers for a session',
+        },
+        {
+          id: 'memory.query',
+          label: '/memory query <query>',
+          insertText: '/memory query ',
+          description:
+            'Preview the exact memory block the current session would attach',
+        },
+      ],
     },
     {
       name: 'show',

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -15,6 +15,28 @@ import {
 } from '../agents/agent-types.js';
 import type { SkillConfigChannelKind } from '../channels/channel.js';
 import { normalizeSkillConfigChannelKind } from '../channels/channel-registry.js';
+import type {
+  MemoryEmbeddingDtype,
+  MemoryEmbeddingProviderKind,
+} from '../memory/embeddings.js';
+import {
+  DEFAULT_MEMORY_EMBEDDING_PROVIDER,
+  DEFAULT_MEMORY_TRANSFORMERS_DTYPE,
+  DEFAULT_MEMORY_TRANSFORMERS_MODEL,
+  DEFAULT_MEMORY_TRANSFORMERS_REVISION,
+  normalizeMemoryEmbeddingDtype,
+  normalizeMemoryEmbeddingProviderKind,
+} from '../memory/embeddings.js';
+import type {
+  MemoryQueryMode,
+  MemoryRecallBackend,
+  MemoryRecallRerank,
+  MemoryRecallTokenizer,
+} from '../memory/semantic-recall.js';
+import {
+  normalizeMemoryRecallBackend,
+  normalizeMemoryRecallTokenizer,
+} from '../memory/semantic-recall.js';
 import { CODEX_DEFAULT_BASE_URL } from '../providers/codex-constants.js';
 import type { LocalProviderConfig } from '../providers/local-types.js';
 import {
@@ -55,7 +77,7 @@ import {
 import { DEFAULT_RUNTIME_HOME_DIR } from './runtime-paths.js';
 
 export const CONFIG_FILE_NAME = 'config.json';
-export const CONFIG_VERSION = 18;
+export const CONFIG_VERSION = 21;
 export const SECURITY_POLICY_VERSION = '2026-02-28';
 const LEGACY_DEFAULT_DB_PATH = 'data/hybridclaw.db';
 const DEFAULT_DB_PATH = path.join(
@@ -534,6 +556,17 @@ export interface RuntimeConfig {
     decayRate: number;
     consolidationIntervalHours: number;
     consolidationLanguage: string;
+    semanticPromptHardCap: number;
+    embedding: {
+      provider: MemoryEmbeddingProviderKind;
+      model: string;
+      revision: string;
+      dtype: MemoryEmbeddingDtype;
+    };
+    queryMode: MemoryQueryMode;
+    backend: MemoryRecallBackend;
+    rerank: MemoryRecallRerank;
+    tokenizer: MemoryRecallTokenizer;
   };
   ops: {
     healthHost: string;
@@ -1023,6 +1056,17 @@ const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
     decayRate: 0.1,
     consolidationIntervalHours: 24,
     consolidationLanguage: 'en',
+    semanticPromptHardCap: 12,
+    embedding: {
+      provider: DEFAULT_MEMORY_EMBEDDING_PROVIDER,
+      model: DEFAULT_MEMORY_TRANSFORMERS_MODEL,
+      revision: DEFAULT_MEMORY_TRANSFORMERS_REVISION,
+      dtype: DEFAULT_MEMORY_TRANSFORMERS_DTYPE,
+    },
+    queryMode: 'no-stopwords',
+    backend: 'hybrid',
+    rerank: 'bm25',
+    tokenizer: 'porter',
   },
   ops: {
     healthHost: '127.0.0.1',
@@ -4140,6 +4184,77 @@ function normalizeRuntimeConfig(
         DEFAULT_RUNTIME_CONFIG.memory.consolidationLanguage,
         { allowEmpty: false },
       ).toLowerCase(),
+      semanticPromptHardCap: normalizeInteger(
+        rawMemory.semanticPromptHardCap,
+        DEFAULT_RUNTIME_CONFIG.memory.semanticPromptHardCap,
+        { min: 1, max: 50 },
+      ),
+      embedding: {
+        provider: normalizeMemoryEmbeddingProviderKind(
+          normalizeString(
+            isRecord(rawMemory.embedding)
+              ? rawMemory.embedding.provider
+              : undefined,
+            DEFAULT_RUNTIME_CONFIG.memory.embedding.provider,
+            { allowEmpty: false },
+          ),
+          DEFAULT_RUNTIME_CONFIG.memory.embedding.provider,
+        ),
+        model: normalizeString(
+          isRecord(rawMemory.embedding) ? rawMemory.embedding.model : undefined,
+          DEFAULT_RUNTIME_CONFIG.memory.embedding.model,
+          { allowEmpty: false },
+        ),
+        revision: normalizeString(
+          isRecord(rawMemory.embedding)
+            ? rawMemory.embedding.revision
+            : undefined,
+          DEFAULT_RUNTIME_CONFIG.memory.embedding.revision,
+          { allowEmpty: false },
+        ),
+        dtype: normalizeMemoryEmbeddingDtype(
+          normalizeString(
+            isRecord(rawMemory.embedding)
+              ? rawMemory.embedding.dtype
+              : undefined,
+            DEFAULT_RUNTIME_CONFIG.memory.embedding.dtype,
+            { allowEmpty: false },
+          ),
+          DEFAULT_RUNTIME_CONFIG.memory.embedding.dtype,
+        ),
+      },
+      queryMode:
+        normalizeString(
+          rawMemory.queryMode,
+          DEFAULT_RUNTIME_CONFIG.memory.queryMode,
+          { allowEmpty: false },
+        ) === 'no-stopwords'
+          ? 'no-stopwords'
+          : 'raw',
+      backend: normalizeMemoryRecallBackend(
+        normalizeString(
+          rawMemory.backend,
+          DEFAULT_RUNTIME_CONFIG.memory.backend,
+          { allowEmpty: false },
+        ),
+        DEFAULT_RUNTIME_CONFIG.memory.backend,
+      ),
+      rerank:
+        normalizeString(
+          rawMemory.rerank,
+          DEFAULT_RUNTIME_CONFIG.memory.rerank,
+          { allowEmpty: false },
+        ) === 'bm25'
+          ? 'bm25'
+          : 'none',
+      tokenizer: normalizeMemoryRecallTokenizer(
+        normalizeString(
+          rawMemory.tokenizer,
+          DEFAULT_RUNTIME_CONFIG.memory.tokenizer,
+          { allowEmpty: false },
+        ),
+        DEFAULT_RUNTIME_CONFIG.memory.tokenizer,
+      ),
     },
     ops: {
       healthHost: normalizeString(rawOps.healthHost, defaultOps.healthHost, {

--- a/src/evals/eval-command.ts
+++ b/src/evals/eval-command.ts
@@ -6,6 +6,7 @@ import { MAX_CONCURRENT_CONTAINERS } from '../config/config.js';
 import { isContainerMaxConcurrentExplicit } from '../config/runtime-config.js';
 import type { GatewayCommandResult } from '../gateway/gateway-types.js';
 import { resolveInstallRoot } from '../infra/install-root.js';
+import { logger } from '../logger.js';
 import {
   enqueueProactiveMessage,
   isDatabaseInitialized,
@@ -17,6 +18,15 @@ import {
   encodeEvalProfileModel,
   isKnownEvalPromptPart,
 } from './eval-profile.js';
+import type {
+  LocomoAgentMode,
+  LocomoCategoryAggregate as LocomoNativeCategoryAggregate,
+  LocomoTokenUsage as LocomoNativeTokenUsage,
+} from './locomo-types.js';
+import {
+  LOCOMO_DATASET_FILENAME,
+  LOCOMO_SETUP_MARKER,
+} from './locomo-types.js';
 
 type EvalSuiteId =
   | 'swebench-verified'
@@ -46,8 +56,6 @@ interface ManagedSuiteRunPreparation {
   displayCommand: string;
   cwd: string;
 }
-
-type LocomoAgentMode = 'conversation-fresh' | 'current-agent' | 'fresh-request';
 
 interface EvalEnvironment {
   baseUrl: string;
@@ -183,19 +191,6 @@ interface TerminalBenchNativeTokenUsage {
   apiUsageAvailable: boolean;
 }
 
-interface LocomoNativeCategoryAggregate {
-  meanScore: number;
-  questionCount: number;
-  contextF1: number | null;
-}
-
-interface LocomoNativeTokenUsage {
-  promptTokens: number;
-  completionTokens: number;
-  totalTokens: number;
-  responsesWithUsage: number;
-}
-
 interface LocomoNativeSummary {
   jobDir: string;
   resultPath: string;
@@ -290,7 +285,7 @@ const EVAL_SUITES: EvalSuiteDefinition[] = [
       '`--mode retrieval` skips model generation, ingests each conversation into an isolated native memory session, and scores evidence hit-rate from recalled semantic memories.',
       'The `qa` prompt shape follows the upstream `evaluate_gpts` flow: truncated conversation context plus a short-answer QA prompt for each LoCoMo question.',
       '`--num-samples` limits conversation records. Use `--max-questions` for quick smoke runs over a small number of LoCoMo questions.',
-      'By default, LOCOMO creates one fresh template-seeded agent per conversation sample. Use `--current-agent` to reuse the current agent workspace, or `--fresh-agent` to force a new agent for every individual QA request.',
+      'By default, LOCOMO creates one fresh template-seeded agent per conversation sample. Use `--current-agent` to reuse the current agent workspace.',
       'Prompt/profile eval flags flow through `HYBRIDCLAW_EVAL_MODEL`, so agent/workspace mode and prompt ablations affect the benchmarked run.',
     ],
   },
@@ -737,12 +732,17 @@ function getManagedSuiteMarkerPath(
 ): string {
   return path.join(
     getManagedSuiteInstallDir(suite, dataDir),
-    '.hybridclaw-setup-ok',
+    LOCOMO_SETUP_MARKER,
   );
 }
 
 function getLocomoDatasetPath(dataDir: string): string {
-  return path.join(getEvalBaseDir(dataDir), 'locomo', 'data', 'locomo10.json');
+  return path.join(
+    getEvalBaseDir(dataDir),
+    'locomo',
+    'data',
+    LOCOMO_DATASET_FILENAME,
+  );
 }
 
 function getManagedSuitePythonPath(
@@ -816,7 +816,7 @@ function getManagedSuiteSetupCommand(
   }
 
   const installDirQuoted = quoteShellArg(installDir);
-  const markerFile = '.hybridclaw-setup-ok';
+  const markerFile = LOCOMO_SETUP_MARKER;
   const venvPython =
     process.platform === 'win32'
       ? '.venv\\Scripts\\python.exe'
@@ -1006,10 +1006,7 @@ function prepareManagedSuiteRun(
   workspaceModeExplicit: boolean,
 ): ManagedSuiteRunPreparation | null {
   if (suite.id === 'locomo') {
-    const agentMode = resolveLocomoAgentMode(
-      env.profile,
-      workspaceModeExplicit,
-    );
+    const agentMode = resolveLocomoAgentMode(workspaceModeExplicit);
     return {
       commandArgs: ['locomo', 'run', ...args],
       command: buildInternalEvalCommand('__eval-locomo-native', [
@@ -1093,15 +1090,9 @@ function prepareManagedSuiteRun(
 }
 
 function resolveLocomoAgentMode(
-  profile: EvalProfile,
   workspaceModeExplicit: boolean,
 ): LocomoAgentMode {
-  if (!workspaceModeExplicit) {
-    return 'conversation-fresh';
-  }
-  return profile.workspaceMode === 'fresh-agent'
-    ? 'fresh-request'
-    : 'current-agent';
+  return workspaceModeExplicit ? 'current-agent' : 'conversation-fresh';
 }
 
 function quoteShellArg(value: string): string {
@@ -1382,8 +1373,81 @@ function readTerminalBenchJobDir(meta: EvalRunMeta): string | null {
   return jobDir ? jobDir : null;
 }
 
-function readFiniteTokenNumber(value: unknown, fallback = 0): number {
+function readFiniteNumber(
+  value: unknown,
+  fallback: number | null = null,
+): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function readFiniteTokenNumber(value: unknown, fallback = 0): number {
+  return readFiniteNumber(value, fallback) ?? fallback;
+}
+
+function readStringValue(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function readLocomoCategoryAggregates(
+  value: unknown,
+): Record<string, LocomoNativeCategoryAggregate> {
+  if (!value || typeof value !== 'object') {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(value).map(([category, aggregate]) => {
+      const parsedAggregate =
+        aggregate && typeof aggregate === 'object' ? aggregate : {};
+      return [
+        category,
+        {
+          meanScore:
+            readFiniteNumber(
+              (parsedAggregate as { meanScore?: unknown }).meanScore,
+              0,
+            ) ?? 0,
+          questionCount:
+            readFiniteNumber(
+              (parsedAggregate as { questionCount?: unknown }).questionCount,
+              0,
+            ) ?? 0,
+          contextF1: readFiniteNumber(
+            (parsedAggregate as { contextF1?: unknown }).contextF1,
+          ),
+        },
+      ];
+    }),
+  ) as Record<string, LocomoNativeCategoryAggregate>;
+}
+
+function readLocomoTokenUsage(value: unknown): LocomoNativeTokenUsage | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const tokenUsage = value as {
+    promptTokens?: unknown;
+    completionTokens?: unknown;
+    totalTokens?: unknown;
+    responsesWithUsage?: unknown;
+  };
+  const promptTokens = readFiniteNumber(tokenUsage.promptTokens);
+  const completionTokens = readFiniteNumber(tokenUsage.completionTokens);
+  const totalTokens = readFiniteNumber(tokenUsage.totalTokens);
+  const responsesWithUsage = readFiniteNumber(tokenUsage.responsesWithUsage);
+  if (
+    promptTokens == null ||
+    completionTokens == null ||
+    totalTokens == null ||
+    responsesWithUsage == null
+  ) {
+    return null;
+  }
+  return {
+    promptTokens,
+    completionTokens,
+    totalTokens,
+    responsesWithUsage,
+  };
 }
 
 function readTerminalBenchJobTokenUsage(
@@ -1565,110 +1629,34 @@ function readLocomoNativeSummary(
   const resultPath = path.join(jobDir, 'result.json');
   if (!fs.existsSync(resultPath)) return null;
   try {
-    const parsed = JSON.parse(fs.readFileSync(resultPath, 'utf-8')) as {
-      mode?: unknown;
-      dataset?: unknown;
-      model?: unknown;
-      budgetTokens?: unknown;
-      sampleCount?: unknown;
-      questionCount?: unknown;
-      overallScore?: unknown;
-      contextF1?: unknown;
-      predictionsPath?: unknown;
-      tokenUsage?: {
-        promptTokens?: unknown;
-        completionTokens?: unknown;
-        totalTokens?: unknown;
-        responsesWithUsage?: unknown;
-      };
-      categories?: Record<
-        string,
-        {
-          meanScore?: unknown;
-          questionCount?: unknown;
-          contextF1?: unknown;
-        }
-      >;
-    };
-    const categories = Object.fromEntries(
-      Object.entries(parsed.categories || {}).map(([category, value]) => [
-        category,
-        {
-          meanScore:
-            typeof value?.meanScore === 'number' &&
-            Number.isFinite(value.meanScore)
-              ? value.meanScore
-              : 0,
-          questionCount:
-            typeof value?.questionCount === 'number' &&
-            Number.isFinite(value.questionCount)
-              ? value.questionCount
-              : 0,
-          contextF1:
-            typeof value?.contextF1 === 'number' &&
-            Number.isFinite(value.contextF1)
-              ? value.contextF1
-              : null,
-        },
-      ]),
-    ) as Record<string, LocomoNativeCategoryAggregate>;
-    const tokenUsage =
-      parsed.tokenUsage &&
-      typeof parsed.tokenUsage === 'object' &&
-      typeof parsed.tokenUsage.promptTokens === 'number' &&
-      Number.isFinite(parsed.tokenUsage.promptTokens) &&
-      typeof parsed.tokenUsage.completionTokens === 'number' &&
-      Number.isFinite(parsed.tokenUsage.completionTokens) &&
-      typeof parsed.tokenUsage.totalTokens === 'number' &&
-      Number.isFinite(parsed.tokenUsage.totalTokens) &&
-      typeof parsed.tokenUsage.responsesWithUsage === 'number' &&
-      Number.isFinite(parsed.tokenUsage.responsesWithUsage)
-        ? {
-            promptTokens: parsed.tokenUsage.promptTokens,
-            completionTokens: parsed.tokenUsage.completionTokens,
-            totalTokens: parsed.tokenUsage.totalTokens,
-            responsesWithUsage: parsed.tokenUsage.responsesWithUsage,
-          }
-        : null;
+    const parsed = JSON.parse(fs.readFileSync(resultPath, 'utf-8')) as Record<
+      string,
+      unknown
+    >;
     return {
       jobDir,
       resultPath,
-      predictionsPath:
-        typeof parsed.predictionsPath === 'string'
-          ? parsed.predictionsPath
-          : null,
+      predictionsPath: readStringValue(parsed.predictionsPath),
       mode: parsed.mode === 'retrieval' ? 'retrieval' : 'qa',
-      dataset: typeof parsed.dataset === 'string' ? parsed.dataset : null,
-      model: typeof parsed.model === 'string' ? parsed.model : null,
-      budgetTokens:
-        typeof parsed.budgetTokens === 'number' &&
-        Number.isFinite(parsed.budgetTokens)
-          ? parsed.budgetTokens
-          : null,
-      sampleCount:
-        typeof parsed.sampleCount === 'number' &&
-        Number.isFinite(parsed.sampleCount)
-          ? parsed.sampleCount
-          : null,
-      questionCount:
-        typeof parsed.questionCount === 'number' &&
-        Number.isFinite(parsed.questionCount)
-          ? parsed.questionCount
-          : null,
-      overallScore:
-        typeof parsed.overallScore === 'number' &&
-        Number.isFinite(parsed.overallScore)
-          ? parsed.overallScore
-          : null,
-      contextF1:
-        typeof parsed.contextF1 === 'number' &&
-        Number.isFinite(parsed.contextF1)
-          ? parsed.contextF1
-          : null,
-      categories,
-      tokenUsage,
+      dataset: readStringValue(parsed.dataset),
+      model: readStringValue(parsed.model),
+      budgetTokens: readFiniteNumber(parsed.budgetTokens),
+      sampleCount: readFiniteNumber(parsed.sampleCount),
+      questionCount: readFiniteNumber(parsed.questionCount),
+      overallScore: readFiniteNumber(parsed.overallScore),
+      contextF1: readFiniteNumber(parsed.contextF1),
+      categories: readLocomoCategoryAggregates(parsed.categories),
+      tokenUsage: readLocomoTokenUsage(parsed.tokenUsage),
     };
-  } catch {
+  } catch (error) {
+    logger.debug(
+      {
+        err: error,
+        runId: meta.runId,
+        resultPath,
+      },
+      'Failed to parse LOCOMO result summary',
+    );
     return null;
   }
 }
@@ -1681,144 +1669,45 @@ function readLocomoNativeProgress(
   const progressPath = path.join(jobDir, 'progress.json');
   if (!fs.existsSync(progressPath)) return null;
   try {
-    const parsed = JSON.parse(fs.readFileSync(progressPath, 'utf-8')) as {
-      mode?: unknown;
-      dataset?: unknown;
-      model?: unknown;
-      budgetTokens?: unknown;
-      sampleCount?: unknown;
-      completedSampleCount?: unknown;
-      questionCount?: unknown;
-      completedQuestionCount?: unknown;
-      overallScore?: unknown;
-      contextF1?: unknown;
-      currentSampleId?: unknown;
-      currentSampleQuestionCount?: unknown;
-      currentSampleQuestionTotal?: unknown;
-      predictionsPath?: unknown;
-      resultPath?: unknown;
-      tokenUsage?: {
-        promptTokens?: unknown;
-        completionTokens?: unknown;
-        totalTokens?: unknown;
-        responsesWithUsage?: unknown;
-      };
-      categories?: Record<
-        string,
-        {
-          meanScore?: unknown;
-          questionCount?: unknown;
-          contextF1?: unknown;
-        }
-      >;
-    };
-    const categories = Object.fromEntries(
-      Object.entries(parsed.categories || {}).map(([category, value]) => [
-        category,
-        {
-          meanScore:
-            typeof value?.meanScore === 'number' &&
-            Number.isFinite(value.meanScore)
-              ? value.meanScore
-              : 0,
-          questionCount:
-            typeof value?.questionCount === 'number' &&
-            Number.isFinite(value.questionCount)
-              ? value.questionCount
-              : 0,
-          contextF1:
-            typeof value?.contextF1 === 'number' &&
-            Number.isFinite(value.contextF1)
-              ? value.contextF1
-              : null,
-        },
-      ]),
-    ) as Record<string, LocomoNativeCategoryAggregate>;
-    const tokenUsage =
-      parsed.tokenUsage &&
-      typeof parsed.tokenUsage === 'object' &&
-      typeof parsed.tokenUsage.promptTokens === 'number' &&
-      Number.isFinite(parsed.tokenUsage.promptTokens) &&
-      typeof parsed.tokenUsage.completionTokens === 'number' &&
-      Number.isFinite(parsed.tokenUsage.completionTokens) &&
-      typeof parsed.tokenUsage.totalTokens === 'number' &&
-      Number.isFinite(parsed.tokenUsage.totalTokens) &&
-      typeof parsed.tokenUsage.responsesWithUsage === 'number' &&
-      Number.isFinite(parsed.tokenUsage.responsesWithUsage)
-        ? {
-            promptTokens: parsed.tokenUsage.promptTokens,
-            completionTokens: parsed.tokenUsage.completionTokens,
-            totalTokens: parsed.tokenUsage.totalTokens,
-            responsesWithUsage: parsed.tokenUsage.responsesWithUsage,
-          }
-        : null;
+    const parsed = JSON.parse(fs.readFileSync(progressPath, 'utf-8')) as Record<
+      string,
+      unknown
+    >;
     return {
       jobDir,
       progressPath,
       resultPath:
-        typeof parsed.resultPath === 'string'
-          ? parsed.resultPath
-          : path.join(jobDir, 'result.json'),
-      predictionsPath:
-        typeof parsed.predictionsPath === 'string'
-          ? parsed.predictionsPath
-          : null,
+        readStringValue(parsed.resultPath) || path.join(jobDir, 'result.json'),
+      predictionsPath: readStringValue(parsed.predictionsPath),
       mode: parsed.mode === 'retrieval' ? 'retrieval' : 'qa',
-      dataset: typeof parsed.dataset === 'string' ? parsed.dataset : null,
-      model: typeof parsed.model === 'string' ? parsed.model : null,
-      budgetTokens:
-        typeof parsed.budgetTokens === 'number' &&
-        Number.isFinite(parsed.budgetTokens)
-          ? parsed.budgetTokens
-          : null,
-      sampleCount:
-        typeof parsed.sampleCount === 'number' &&
-        Number.isFinite(parsed.sampleCount)
-          ? parsed.sampleCount
-          : null,
-      completedSampleCount:
-        typeof parsed.completedSampleCount === 'number' &&
-        Number.isFinite(parsed.completedSampleCount)
-          ? parsed.completedSampleCount
-          : null,
-      questionCount:
-        typeof parsed.questionCount === 'number' &&
-        Number.isFinite(parsed.questionCount)
-          ? parsed.questionCount
-          : null,
-      completedQuestionCount:
-        typeof parsed.completedQuestionCount === 'number' &&
-        Number.isFinite(parsed.completedQuestionCount)
-          ? parsed.completedQuestionCount
-          : null,
-      overallScore:
-        typeof parsed.overallScore === 'number' &&
-        Number.isFinite(parsed.overallScore)
-          ? parsed.overallScore
-          : null,
-      contextF1:
-        typeof parsed.contextF1 === 'number' &&
-        Number.isFinite(parsed.contextF1)
-          ? parsed.contextF1
-          : null,
-      currentSampleId:
-        typeof parsed.currentSampleId === 'string'
-          ? parsed.currentSampleId
-          : null,
-      currentSampleQuestionCount:
-        typeof parsed.currentSampleQuestionCount === 'number' &&
-        Number.isFinite(parsed.currentSampleQuestionCount)
-          ? parsed.currentSampleQuestionCount
-          : null,
-      currentSampleQuestionTotal:
-        typeof parsed.currentSampleQuestionTotal === 'number' &&
-        Number.isFinite(parsed.currentSampleQuestionTotal)
-          ? parsed.currentSampleQuestionTotal
-          : null,
-      categories,
-      tokenUsage,
+      dataset: readStringValue(parsed.dataset),
+      model: readStringValue(parsed.model),
+      budgetTokens: readFiniteNumber(parsed.budgetTokens),
+      sampleCount: readFiniteNumber(parsed.sampleCount),
+      completedSampleCount: readFiniteNumber(parsed.completedSampleCount),
+      questionCount: readFiniteNumber(parsed.questionCount),
+      completedQuestionCount: readFiniteNumber(parsed.completedQuestionCount),
+      overallScore: readFiniteNumber(parsed.overallScore),
+      contextF1: readFiniteNumber(parsed.contextF1),
+      currentSampleId: readStringValue(parsed.currentSampleId),
+      currentSampleQuestionCount: readFiniteNumber(
+        parsed.currentSampleQuestionCount,
+      ),
+      currentSampleQuestionTotal: readFiniteNumber(
+        parsed.currentSampleQuestionTotal,
+      ),
+      categories: readLocomoCategoryAggregates(parsed.categories),
+      tokenUsage: readLocomoTokenUsage(parsed.tokenUsage),
     };
-  } catch {
+  } catch (error) {
+    logger.debug(
+      {
+        err: error,
+        runId: meta.runId,
+        progressPath,
+      },
+      'Failed to parse LOCOMO progress summary',
+    );
     return null;
   }
 }
@@ -3317,6 +3206,15 @@ async function handleManagedSuiteRun(params: {
     return errorResult(
       `${params.suite.title} Setup Required`,
       `Run \`/eval ${params.suite.id} setup\` first.`,
+    );
+  }
+  if (
+    params.suite.id === 'locomo' &&
+    params.env.profile.workspaceMode === 'fresh-agent'
+  ) {
+    return errorResult(
+      `${params.suite.title} Run`,
+      'Native LOCOMO does not support `--fresh-agent`. It already uses one fresh agent per conversation by default; use `--current-agent` to reuse the current agent workspace.',
     );
   }
   if (

--- a/src/evals/eval-command.ts
+++ b/src/evals/eval-command.ts
@@ -11,6 +11,8 @@ import {
   enqueueProactiveMessage,
   isDatabaseInitialized,
 } from '../memory/db.js';
+import { normalizeMemoryEmbeddingProviderKind } from '../memory/embeddings.js';
+import { normalizeMemoryRecallBackend } from '../memory/semantic-recall.js';
 import {
   buildDefaultEvalProfile,
   describeEvalProfile,
@@ -21,7 +23,17 @@ import {
 import type {
   LocomoAgentMode,
   LocomoCategoryAggregate as LocomoNativeCategoryAggregate,
+  LocomoRetrievalVariantProgress as LocomoNativeRetrievalVariantProgress,
+  LocomoRetrievalVariantSummary as LocomoNativeRetrievalVariantSummary,
   LocomoTokenUsage as LocomoNativeTokenUsage,
+  LocomoProgressPhase,
+  LocomoRetrievalBackend,
+  LocomoRetrievalEmbeddingProvider,
+  LocomoRetrievalPolicy,
+  LocomoRetrievalQueryMode,
+  LocomoRetrievalRerank,
+  LocomoRetrievalSweep,
+  LocomoRetrievalTokenizer,
 } from './locomo-types.js';
 import {
   LOCOMO_DATASET_FILENAME,
@@ -196,6 +208,15 @@ interface LocomoNativeSummary {
   resultPath: string;
   predictionsPath: string | null;
   mode: 'qa' | 'retrieval';
+  matrix: boolean;
+  matrixSweep: LocomoRetrievalSweep | null;
+  retrievalPolicy: LocomoRetrievalPolicy | null;
+  retrievalQueryMode: LocomoRetrievalQueryMode | null;
+  retrievalBackend: LocomoRetrievalBackend | null;
+  retrievalRerank: LocomoRetrievalRerank | null;
+  retrievalTokenizer: LocomoRetrievalTokenizer | null;
+  retrievalEmbeddingProvider: LocomoRetrievalEmbeddingProvider | null;
+  retrievalEmbeddingModel: string | null;
   dataset: string | null;
   model: string | null;
   budgetTokens: number | null;
@@ -205,6 +226,10 @@ interface LocomoNativeSummary {
   contextF1: number | null;
   categories: Record<string, LocomoNativeCategoryAggregate>;
   tokenUsage: LocomoNativeTokenUsage | null;
+  variantCount: number | null;
+  bestVariantId: string | null;
+  bestVariantLabel: string | null;
+  variants: LocomoNativeRetrievalVariantSummary[];
 }
 
 interface LocomoNativeProgress {
@@ -213,6 +238,15 @@ interface LocomoNativeProgress {
   resultPath: string;
   predictionsPath: string | null;
   mode: 'qa' | 'retrieval';
+  matrix: boolean;
+  matrixSweep: LocomoRetrievalSweep | null;
+  retrievalPolicy: LocomoRetrievalPolicy | null;
+  retrievalQueryMode: LocomoRetrievalQueryMode | null;
+  retrievalBackend: LocomoRetrievalBackend | null;
+  retrievalRerank: LocomoRetrievalRerank | null;
+  retrievalTokenizer: LocomoRetrievalTokenizer | null;
+  retrievalEmbeddingProvider: LocomoRetrievalEmbeddingProvider | null;
+  retrievalEmbeddingModel: string | null;
   dataset: string | null;
   model: string | null;
   budgetTokens: number | null;
@@ -222,11 +256,18 @@ interface LocomoNativeProgress {
   completedQuestionCount: number | null;
   overallScore: number | null;
   contextF1: number | null;
+  currentPhase: LocomoProgressPhase | null;
   currentSampleId: string | null;
+  currentSampleEmbeddedTurnCount: number | null;
+  currentSampleTurnCount: number | null;
   currentSampleQuestionCount: number | null;
   currentSampleQuestionTotal: number | null;
   categories: Record<string, LocomoNativeCategoryAggregate>;
   tokenUsage: LocomoNativeTokenUsage | null;
+  variantCount: number | null;
+  completedVariantCount: number | null;
+  currentVariant: LocomoNativeRetrievalVariantProgress | null;
+  variants: LocomoNativeRetrievalVariantSummary[];
 }
 
 const MAX_QUEUED_EVAL_MESSAGES = 200;
@@ -279,10 +320,25 @@ const EVAL_SUITES: EvalSuiteDefinition[] = [
       '/eval locomo setup',
       '/eval locomo run --budget 4000 --max-questions 20',
       '/eval locomo run --mode retrieval --budget 4000 --max-questions 20',
+      '/eval locomo run --mode retrieval --retrieval-query raw --budget 4000 --max-questions 20',
+      '/eval locomo run --mode retrieval --retrieval-backend full-text --budget 4000 --max-questions 20',
+      '/eval locomo run --mode retrieval --retrieval-backend hybrid --budget 4000 --max-questions 20',
+      '/eval locomo run --mode retrieval --retrieval-rerank bm25 --budget 4000 --max-questions 20',
+      '/eval locomo run --mode retrieval --retrieval-tokenizer porter --budget 4000 --max-questions 20',
+      '/eval locomo run --mode retrieval --retrieval-tokenizer trigram --budget 4000 --max-questions 20',
+      '/eval locomo run --mode retrieval --retrieval-embedding transformers --budget 4000 --max-questions 20',
+      '/eval locomo run --mode retrieval --matrix --budget 4000',
+      '/eval locomo run --mode retrieval --matrix backend --budget 4000',
+      '/eval locomo run --mode retrieval --matrix rerank --budget 4000',
+      '/eval locomo run --mode retrieval --matrix tokenizer --budget 4000',
+      '/eval locomo run --mode retrieval --matrix embedding --budget 4000',
     ],
     notes: [
       'The default `qa` mode generates LoCoMo answers through HybridClaw’s local OpenAI-compatible gateway and scores the model outputs directly.',
       '`--mode retrieval` skips model generation, ingests each conversation into an isolated native memory session, and scores evidence hit-rate from recalled semantic memories.',
+      '`--mode retrieval --matrix` runs the default retrieval sweep across backend, rerank, and tokenizer combinations and renders a combined comparison table.',
+      '`--mode retrieval --matrix backend|rerank|tokenizer|embedding` runs a single-dimension sweep and keeps the other retrieval settings at the standard LOCOMO retrieval defaults (`no-stopwords`, `bm25`, `unicode61`) unless that dimension is the one being varied.',
+      'Retrieval-only knobs are benchmark controls: `--retrieval-query raw|no-stopwords`, `--retrieval-backend cosine|full-text|hybrid`, `--retrieval-rerank none|bm25` (default: `bm25`), `--retrieval-tokenizer unicode61|porter|trigram`, and `--retrieval-embedding hashed|transformers`.',
       'The `qa` prompt shape follows the upstream `evaluate_gpts` flow: truncated conversation context plus a short-answer QA prompt for each LoCoMo question.',
       '`--num-samples` limits conversation records. Use `--max-questions` for quick smoke runs over a small number of LoCoMo questions.',
       'By default, LOCOMO creates one fresh template-seeded agent per conversation sample. Use `--current-agent` to reuse the current agent workspace.',
@@ -510,6 +566,57 @@ function renderKeyValueSection(
   );
 }
 
+const ANSI_RESET = '\x1b[0m';
+const ANSI_INVERSE = '\x1b[7m';
+const ANSI_BEST_VALUE = '\x1b[1;93m';
+
+function stripAnsi(value: string): string {
+  let output = '';
+  for (let index = 0; index < value.length; ) {
+    if (value.charCodeAt(index) === 27 && value[index + 1] === '[') {
+      index += 2;
+      while (index < value.length) {
+        const code = value.charCodeAt(index);
+        index += 1;
+        if (code >= 64 && code <= 126) break;
+      }
+      continue;
+    }
+    output += value[index] || '';
+    index += 1;
+  }
+  return output;
+}
+
+function visibleLength(value: string): number {
+  return [...stripAnsi(value)].length;
+}
+
+function padAnsiEnd(value: string, width: number): string {
+  const missing = Math.max(0, width - visibleLength(value));
+  return `${value}${' '.repeat(missing)}`;
+}
+
+function styleLocomoMatrixCell(
+  value: string,
+  options?: {
+    inverse?: boolean;
+    highlight?: boolean;
+  },
+): string {
+  const codes: string[] = [];
+  if (options?.inverse) {
+    codes.push(ANSI_INVERSE);
+  }
+  if (options?.highlight) {
+    codes.push(ANSI_BEST_VALUE);
+  }
+  if (codes.length === 0) {
+    return value;
+  }
+  return `${codes.join('')}${value}${ANSI_RESET}`;
+}
+
 function renderSectionCard(title: string, lines: string[]): string {
   const bodyLines = lines.flatMap((line) =>
     String(line || '')
@@ -517,11 +624,13 @@ function renderSectionCard(title: string, lines: string[]): string {
       .map((entry) => entry.trimEnd()),
   );
   const contentWidth = Math.max(
-    title.length + 2,
-    ...bodyLines.map((line) => line.length),
+    visibleLength(title) + 2,
+    ...bodyLines.map((line) => visibleLength(line)),
   );
   const topBorder = `┌─ ${title} ${'─'.repeat(Math.max(1, contentWidth - title.length - 1))}┐`;
-  const middle = bodyLines.map((line) => `│ ${line.padEnd(contentWidth)} │`);
+  const middle = bodyLines.map(
+    (line) => `│ ${padAnsiEnd(line, contentWidth)} │`,
+  );
   const bottomBorder = `└${'─'.repeat(contentWidth + 2)}┘`;
   return [topBorder, ...middle, bottomBorder].join('\n');
 }
@@ -1450,6 +1559,222 @@ function readLocomoTokenUsage(value: unknown): LocomoNativeTokenUsage | null {
   };
 }
 
+function readLocomoRetrievalVariantSummary(
+  value: unknown,
+): LocomoNativeRetrievalVariantSummary | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const variant = value as Record<string, unknown>;
+  const id = readStringValue(variant.id);
+  const label = readStringValue(variant.label);
+  const retrievalPolicy = readLocomoRetrievalPolicy(variant.retrievalPolicy);
+  const retrievalQueryMode = readLocomoRetrievalQueryMode(
+    variant.retrievalQueryMode,
+  );
+  const retrievalBackend = readLocomoRetrievalBackend(variant.retrievalBackend);
+  const retrievalRerank = readLocomoRetrievalRerank(variant.retrievalRerank);
+  const retrievalTokenizer = readLocomoRetrievalTokenizer(
+    variant.retrievalTokenizer,
+  );
+  const retrievalEmbeddingProvider = readLocomoRetrievalEmbeddingProvider(
+    variant.retrievalEmbeddingProvider,
+  );
+  const retrievalEmbeddingModel = readStringValue(
+    variant.retrievalEmbeddingModel,
+  );
+  const sampleCount = readFiniteNumber(variant.sampleCount);
+  const questionCount = readFiniteNumber(variant.questionCount);
+  const overallScore = readFiniteNumber(variant.overallScore);
+  if (
+    !id ||
+    !label ||
+    retrievalPolicy == null ||
+    retrievalQueryMode == null ||
+    retrievalBackend == null ||
+    retrievalRerank == null ||
+    retrievalTokenizer == null ||
+    retrievalEmbeddingProvider == null ||
+    sampleCount == null ||
+    questionCount == null ||
+    overallScore == null
+  ) {
+    return null;
+  }
+  return {
+    id,
+    label,
+    retrievalPolicy,
+    retrievalQueryMode,
+    retrievalBackend,
+    retrievalRerank,
+    retrievalTokenizer,
+    retrievalEmbeddingProvider,
+    retrievalEmbeddingModel,
+    sampleCount,
+    questionCount,
+    overallScore,
+    contextF1: readFiniteNumber(variant.contextF1),
+    categories: readLocomoCategoryAggregates(variant.categories),
+  };
+}
+
+function readLocomoRetrievalVariantProgress(
+  value: unknown,
+): LocomoNativeRetrievalVariantProgress | null {
+  const summary = readLocomoRetrievalVariantSummary(value);
+  if (!summary || !value || typeof value !== 'object') {
+    return null;
+  }
+  const variant = value as Record<string, unknown>;
+  const completedSampleCount = readFiniteNumber(variant.completedSampleCount);
+  const completedQuestionCount = readFiniteNumber(
+    variant.completedQuestionCount,
+  );
+  if (completedSampleCount == null || completedQuestionCount == null) {
+    return null;
+  }
+  const currentPhase = readLocomoProgressPhase(variant.currentPhase);
+  const currentSampleId = readStringValue(variant.currentSampleId);
+  const currentSampleEmbeddedTurnCount = readFiniteNumber(
+    variant.currentSampleEmbeddedTurnCount,
+  );
+  const currentSampleTurnCount = readFiniteNumber(
+    variant.currentSampleTurnCount,
+  );
+  const currentSampleQuestionCount = readFiniteNumber(
+    variant.currentSampleQuestionCount,
+  );
+  const currentSampleQuestionTotal = readFiniteNumber(
+    variant.currentSampleQuestionTotal,
+  );
+  return {
+    ...summary,
+    currentPhase,
+    completedSampleCount,
+    completedQuestionCount,
+    currentSampleId,
+    currentSampleEmbeddedTurnCount,
+    currentSampleTurnCount,
+    currentSampleQuestionCount,
+    currentSampleQuestionTotal,
+  };
+}
+
+function readLocomoRetrievalVariants(
+  value: unknown,
+): LocomoNativeRetrievalVariantSummary[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => readLocomoRetrievalVariantSummary(entry))
+    .filter(
+      (entry): entry is LocomoNativeRetrievalVariantSummary => entry !== null,
+    );
+}
+
+function readLocomoRetrievalPolicy(
+  value: unknown,
+): LocomoRetrievalPolicy | null {
+  if (value === 'prompt-capped' || value === 'budget-only') {
+    return value;
+  }
+  return null;
+}
+
+function readLocomoRetrievalSweep(value: unknown): LocomoRetrievalSweep | null {
+  if (
+    value === 'all' ||
+    value === 'backend' ||
+    value === 'rerank' ||
+    value === 'tokenizer' ||
+    value === 'embedding'
+  ) {
+    return value;
+  }
+  return null;
+}
+
+function readLocomoProgressPhase(value: unknown): LocomoProgressPhase | null {
+  if (
+    value === 'warming-embedding' ||
+    value === 'ingesting' ||
+    value === 'evaluating'
+  ) {
+    return value;
+  }
+  return null;
+}
+
+function readLocomoRetrievalEmbeddingProvider(
+  value: unknown,
+): LocomoRetrievalEmbeddingProvider | null {
+  const normalized = normalizeMemoryEmbeddingProviderKind(value, 'hashed');
+  const raw = String(value || '')
+    .trim()
+    .toLowerCase();
+  if (
+    raw === 'hashed' ||
+    raw === 'hash' ||
+    raw === 'transformers' ||
+    raw === 'transformers.js'
+  ) {
+    return normalized;
+  }
+  return null;
+}
+
+function readLocomoRetrievalQueryMode(
+  value: unknown,
+): LocomoRetrievalQueryMode | null {
+  if (value === 'raw' || value === 'no-stopwords') {
+    return value;
+  }
+  return null;
+}
+
+function readLocomoRetrievalBackend(
+  value: unknown,
+): LocomoRetrievalBackend | null {
+  const normalized = normalizeMemoryRecallBackend(value, 'cosine');
+  const raw = String(value || '')
+    .trim()
+    .toLowerCase();
+  if (
+    raw === 'cosine' ||
+    raw === 'semantic' ||
+    raw === 'full-text' ||
+    raw === 'fulltext' ||
+    raw === 'fts-bm25' ||
+    raw === 'hybrid'
+  ) {
+    return normalized;
+  }
+  return null;
+}
+
+function readLocomoRetrievalRerank(
+  value: unknown,
+): LocomoRetrievalRerank | null {
+  if (value === 'none' || value === 'bm25') {
+    return value;
+  }
+  return null;
+}
+
+function readLocomoRetrievalTokenizer(
+  value: unknown,
+): LocomoRetrievalTokenizer | null {
+  if (value === 'default' || value === 'unicode61') {
+    return 'unicode61';
+  }
+  if (value === 'porter' || value === 'trigram') {
+    return value;
+  }
+  return null;
+}
+
 function readTerminalBenchJobTokenUsage(
   jobDir: string,
   taskNames?: readonly string[],
@@ -1638,6 +1963,21 @@ function readLocomoNativeSummary(
       resultPath,
       predictionsPath: readStringValue(parsed.predictionsPath),
       mode: parsed.mode === 'retrieval' ? 'retrieval' : 'qa',
+      matrix: parsed.matrix === true,
+      matrixSweep: readLocomoRetrievalSweep(parsed.matrixSweep),
+      retrievalPolicy: readLocomoRetrievalPolicy(parsed.retrievalPolicy),
+      retrievalQueryMode: readLocomoRetrievalQueryMode(
+        parsed.retrievalQueryMode,
+      ),
+      retrievalBackend: readLocomoRetrievalBackend(parsed.retrievalBackend),
+      retrievalRerank: readLocomoRetrievalRerank(parsed.retrievalRerank),
+      retrievalTokenizer: readLocomoRetrievalTokenizer(
+        parsed.retrievalTokenizer,
+      ),
+      retrievalEmbeddingProvider: readLocomoRetrievalEmbeddingProvider(
+        parsed.retrievalEmbeddingProvider,
+      ),
+      retrievalEmbeddingModel: readStringValue(parsed.retrievalEmbeddingModel),
       dataset: readStringValue(parsed.dataset),
       model: readStringValue(parsed.model),
       budgetTokens: readFiniteNumber(parsed.budgetTokens),
@@ -1647,6 +1987,10 @@ function readLocomoNativeSummary(
       contextF1: readFiniteNumber(parsed.contextF1),
       categories: readLocomoCategoryAggregates(parsed.categories),
       tokenUsage: readLocomoTokenUsage(parsed.tokenUsage),
+      variantCount: readFiniteNumber(parsed.variantCount),
+      bestVariantId: readStringValue(parsed.bestVariantId),
+      bestVariantLabel: readStringValue(parsed.bestVariantLabel),
+      variants: readLocomoRetrievalVariants(parsed.variants),
     };
   } catch (error) {
     logger.debug(
@@ -1680,6 +2024,21 @@ function readLocomoNativeProgress(
         readStringValue(parsed.resultPath) || path.join(jobDir, 'result.json'),
       predictionsPath: readStringValue(parsed.predictionsPath),
       mode: parsed.mode === 'retrieval' ? 'retrieval' : 'qa',
+      matrix: parsed.matrix === true,
+      matrixSweep: readLocomoRetrievalSweep(parsed.matrixSweep),
+      retrievalPolicy: readLocomoRetrievalPolicy(parsed.retrievalPolicy),
+      retrievalQueryMode: readLocomoRetrievalQueryMode(
+        parsed.retrievalQueryMode,
+      ),
+      retrievalBackend: readLocomoRetrievalBackend(parsed.retrievalBackend),
+      retrievalRerank: readLocomoRetrievalRerank(parsed.retrievalRerank),
+      retrievalTokenizer: readLocomoRetrievalTokenizer(
+        parsed.retrievalTokenizer,
+      ),
+      retrievalEmbeddingProvider: readLocomoRetrievalEmbeddingProvider(
+        parsed.retrievalEmbeddingProvider,
+      ),
+      retrievalEmbeddingModel: readStringValue(parsed.retrievalEmbeddingModel),
       dataset: readStringValue(parsed.dataset),
       model: readStringValue(parsed.model),
       budgetTokens: readFiniteNumber(parsed.budgetTokens),
@@ -1689,7 +2048,12 @@ function readLocomoNativeProgress(
       completedQuestionCount: readFiniteNumber(parsed.completedQuestionCount),
       overallScore: readFiniteNumber(parsed.overallScore),
       contextF1: readFiniteNumber(parsed.contextF1),
+      currentPhase: readLocomoProgressPhase(parsed.currentPhase),
       currentSampleId: readStringValue(parsed.currentSampleId),
+      currentSampleEmbeddedTurnCount: readFiniteNumber(
+        parsed.currentSampleEmbeddedTurnCount,
+      ),
+      currentSampleTurnCount: readFiniteNumber(parsed.currentSampleTurnCount),
       currentSampleQuestionCount: readFiniteNumber(
         parsed.currentSampleQuestionCount,
       ),
@@ -1698,6 +2062,10 @@ function readLocomoNativeProgress(
       ),
       categories: readLocomoCategoryAggregates(parsed.categories),
       tokenUsage: readLocomoTokenUsage(parsed.tokenUsage),
+      variantCount: readFiniteNumber(parsed.variantCount),
+      completedVariantCount: readFiniteNumber(parsed.completedVariantCount),
+      currentVariant: readLocomoRetrievalVariantProgress(parsed.currentVariant),
+      variants: readLocomoRetrievalVariants(parsed.variants),
     };
   } catch (error) {
     logger.debug(
@@ -1731,6 +2099,252 @@ function formatLocomoTokenUsage(
 ): string | null {
   if (!value) return null;
   return `${value.totalTokens} total (${value.promptTokens} prompt + ${value.completionTokens} completion)`;
+}
+
+function formatLocomoRetrievalPolicy(
+  value: LocomoRetrievalPolicy | null | undefined,
+): string | null {
+  if (value === 'budget-only') {
+    return 'uncapped recall, token budget only';
+  }
+  if (value === 'prompt-capped') {
+    return 'prompt-capped recall';
+  }
+  return null;
+}
+
+function formatLocomoRetrievalSweep(
+  value: LocomoRetrievalSweep | null | undefined,
+): string | null {
+  if (value === 'all') {
+    return 'full';
+  }
+  if (value === 'backend') {
+    return 'backend';
+  }
+  if (value === 'rerank') {
+    return 'rerank';
+  }
+  if (value === 'tokenizer') {
+    return 'tokenizer';
+  }
+  if (value === 'embedding') {
+    return 'embedding';
+  }
+  return null;
+}
+
+function formatLocomoRetrievalQueryMode(
+  value: LocomoRetrievalQueryMode | null | undefined,
+): string | null {
+  if (value === 'raw') {
+    return 'raw question';
+  }
+  if (value === 'no-stopwords') {
+    return 'stopwords removed';
+  }
+  return null;
+}
+
+function formatLocomoRetrievalBackend(
+  value: LocomoRetrievalBackend | null | undefined,
+): string | null {
+  if (value === 'cosine') {
+    return 'cosine';
+  }
+  if (value === 'full-text') {
+    return 'full text';
+  }
+  if (value === 'hybrid') {
+    return 'hybrid';
+  }
+  return null;
+}
+
+function formatLocomoRetrievalRerank(
+  value: LocomoRetrievalRerank | null | undefined,
+): string | null {
+  if (value === 'none') {
+    return 'none';
+  }
+  if (value === 'bm25') {
+    return 'BM25 before budget';
+  }
+  return null;
+}
+
+function formatLocomoRetrievalTokenizer(
+  value: LocomoRetrievalTokenizer | null | undefined,
+): string | null {
+  if (value === 'unicode61') {
+    return 'unicode61';
+  }
+  if (value === 'porter') {
+    return 'porter';
+  }
+  if (value === 'trigram') {
+    return 'trigram';
+  }
+  return null;
+}
+
+function formatLocomoRetrievalEmbeddingProvider(
+  value: LocomoRetrievalEmbeddingProvider | null | undefined,
+): string | null {
+  if (value === 'hashed') {
+    return 'hashed';
+  }
+  if (value === 'transformers') {
+    return 'Transformers.js';
+  }
+  return null;
+}
+
+function formatLocomoProgressPhase(
+  value: LocomoProgressPhase | null | undefined,
+): string | null {
+  if (value === 'warming-embedding') {
+    return 'loading embedding model';
+  }
+  if (value === 'ingesting') {
+    return 'ingesting memory';
+  }
+  if (value === 'evaluating') {
+    return 'evaluating questions';
+  }
+  return null;
+}
+
+function formatLocomoMatrixMetric(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) {
+    return '-';
+  }
+  return value.toFixed(4);
+}
+
+function areLocomoMetricValuesEqual(left: number, right: number): boolean {
+  return Math.abs(left - right) <= 1e-9;
+}
+
+function computeLocomoVariantMetricHighlightStats(
+  variants: LocomoNativeRetrievalVariantSummary[],
+): Array<{ max: number | null; shouldHighlight: boolean }> {
+  const metricGetters = [
+    (variant: LocomoNativeRetrievalVariantSummary) => variant.overallScore,
+    (variant: LocomoNativeRetrievalVariantSummary) => variant.contextF1 ?? null,
+    (variant: LocomoNativeRetrievalVariantSummary) =>
+      variant.categories['1']?.meanScore ?? null,
+    (variant: LocomoNativeRetrievalVariantSummary) =>
+      variant.categories['2']?.meanScore ?? null,
+    (variant: LocomoNativeRetrievalVariantSummary) =>
+      variant.categories['3']?.meanScore ?? null,
+    (variant: LocomoNativeRetrievalVariantSummary) =>
+      variant.categories['4']?.meanScore ?? null,
+    (variant: LocomoNativeRetrievalVariantSummary) =>
+      variant.categories['5']?.meanScore ?? null,
+  ];
+  return metricGetters.map((getter) => {
+    const values = variants
+      .map((variant) => getter(variant))
+      .filter(
+        (value): value is number => value != null && Number.isFinite(value),
+      );
+    if (values.length === 0) {
+      return { max: null, shouldHighlight: false };
+    }
+    const max = Math.max(...values);
+    const min = Math.min(...values);
+    return {
+      max,
+      shouldHighlight: !areLocomoMetricValuesEqual(max, min),
+    };
+  });
+}
+
+function renderLocomoVariantComparisonSection(
+  title: string,
+  variants: LocomoNativeRetrievalVariantSummary[],
+): string {
+  if (!variants.length) {
+    return '';
+  }
+  const highlightStats = computeLocomoVariantMetricHighlightStats(variants);
+  const bestHitRate =
+    highlightStats[0]?.max != null && Number.isFinite(highlightStats[0].max)
+      ? highlightStats[0].max
+      : null;
+  const rows = variants.map((variant) => {
+    const metrics = [
+      variant.overallScore,
+      variant.contextF1 ?? null,
+      variant.categories['1']?.meanScore ?? null,
+      variant.categories['2']?.meanScore ?? null,
+      variant.categories['3']?.meanScore ?? null,
+      variant.categories['4']?.meanScore ?? null,
+      variant.categories['5']?.meanScore ?? null,
+    ];
+    return [
+      variant.label,
+      ...metrics.map((metric, index) => {
+        const formatted = formatLocomoMatrixMetric(metric);
+        const highlight = highlightStats[index]?.shouldHighlight;
+        const max = highlightStats[index]?.max;
+        if (
+          !highlight ||
+          metric == null ||
+          max == null ||
+          !Number.isFinite(metric) ||
+          !areLocomoMetricValuesEqual(metric, max)
+        ) {
+          return formatted;
+        }
+        return `${formatted}*`;
+      }),
+    ];
+  });
+  const header = ['Variant', 'HitRate', 'F1', 'C1', 'C2', 'C3', 'C4', 'C5'];
+  const widths = header.map((entry, index) =>
+    Math.max(
+      visibleLength(entry),
+      ...rows.map((row) => visibleLength(String(row[index] || ''))),
+    ),
+  );
+  return renderSectionCard(title, [
+    header.map((entry, index) => padAnsiEnd(entry, widths[index])).join('  '),
+    widths.map((width) => '-'.repeat(width)).join('  '),
+    ...rows.map((row, rowIndex) => {
+      const bestHitRateStat = highlightStats[0];
+      const isBestOverall =
+        bestHitRate != null &&
+        Number.isFinite(variants[rowIndex]?.overallScore) &&
+        areLocomoMetricValuesEqual(
+          variants[rowIndex]?.overallScore ?? 0,
+          bestHitRate,
+        );
+      return row
+        .map((entry, index) =>
+          styleLocomoMatrixCell(
+            padAnsiEnd(String(entry), widths[index]),
+            index === 0
+              ? { inverse: isBestOverall }
+              : {
+                  inverse: isBestOverall,
+                  highlight:
+                    bestHitRateStat != null &&
+                    index > 0 &&
+                    highlightStats[index - 1]?.shouldHighlight === true &&
+                    typeof entry === 'string' &&
+                    !entry.startsWith('-') &&
+                    areLocomoMetricValuesEqual(
+                      Number.parseFloat(entry),
+                      highlightStats[index - 1]?.max ?? Number.NaN,
+                    ),
+                },
+          ),
+        )
+        .join('  ');
+    }),
+  ]);
 }
 
 function describeManagedSuiteRunLifecycle(
@@ -1947,6 +2561,34 @@ function formatProgressBar(completed: number, total: number): string {
   return `[${'#'.repeat(filled)}${'-'.repeat(
     EVAL_PROGRESS_BAR_WIDTH - filled,
   )}]`;
+}
+
+function formatProgressValue(
+  completed: number | null | undefined,
+  total: number | null | undefined,
+): string | null {
+  if (
+    completed == null ||
+    total == null ||
+    !Number.isFinite(completed) ||
+    !Number.isFinite(total) ||
+    total <= 0
+  ) {
+    return null;
+  }
+  const normalizedCompleted = clampProgress(completed, total);
+  const normalizedTotal = Math.max(1, Math.floor(total));
+  const percent = Math.round((normalizedCompleted / normalizedTotal) * 100);
+  return `${formatProgressBar(normalizedCompleted, normalizedTotal)} ${normalizedCompleted}/${normalizedTotal} (${percent}%)`;
+}
+
+function formatLocomoEvaluationProgressValue(
+  progress: LocomoNativeProgress,
+): string | null {
+  return formatProgressValue(
+    progress.completedQuestionCount,
+    progress.questionCount,
+  );
 }
 
 function formatProgressMessage(params: {
@@ -2733,6 +3375,41 @@ function renderManagedSuiteStatus(
                 `Samples: ${latestLocomoSummary.sampleCount ?? 'unknown'}`,
                 `Questions: ${latestLocomoSummary.questionCount ?? 'unknown'}`,
                 `Budget: ${latestLocomoSummary.budgetTokens ?? 'unknown'}`,
+                ...(latestLocomoSummary.mode === 'retrieval' &&
+                latestLocomoSummary.retrievalPolicy
+                  ? [
+                      `Recall policy: ${formatLocomoRetrievalPolicy(latestLocomoSummary.retrievalPolicy) || 'unknown'}`,
+                    ]
+                  : []),
+                ...(latestLocomoSummary.mode === 'retrieval' &&
+                !latestLocomoSummary.matrix
+                  ? [
+                      `Query prep: ${formatLocomoRetrievalQueryMode(latestLocomoSummary.retrievalQueryMode) || 'unknown'}`,
+                      `Backend: ${formatLocomoRetrievalBackend(latestLocomoSummary.retrievalBackend) || 'unknown'}`,
+                      `Rerank: ${formatLocomoRetrievalRerank(latestLocomoSummary.retrievalRerank) || 'unknown'}`,
+                      `Tokenizer: ${formatLocomoRetrievalTokenizer(latestLocomoSummary.retrievalTokenizer) || 'unknown'}`,
+                      `Embedding: ${formatLocomoRetrievalEmbeddingProvider(latestLocomoSummary.retrievalEmbeddingProvider) || 'unknown'}`,
+                      `Embedding model: ${latestLocomoSummary.retrievalEmbeddingModel || 'unknown'}`,
+                    ]
+                  : []),
+                ...(latestLocomoSummary.mode === 'retrieval' &&
+                latestLocomoSummary.matrix &&
+                latestLocomoSummary.retrievalEmbeddingModel
+                  ? [
+                      `Embedding model: ${latestLocomoSummary.retrievalEmbeddingModel}`,
+                    ]
+                  : []),
+                ...(latestLocomoSummary.matrix
+                  ? [
+                      `Sweep: ${formatLocomoRetrievalSweep(latestLocomoSummary.matrixSweep) || 'unknown'}`,
+                      `Variants: ${latestLocomoSummary.variants.length}/${latestLocomoSummary.variantCount ?? latestLocomoSummary.variants.length}`,
+                      ...(latestLocomoSummary.bestVariantLabel
+                        ? [
+                            `Best variant: ${latestLocomoSummary.bestVariantLabel}`,
+                          ]
+                        : []),
+                    ]
+                  : []),
                 `${
                   latestLocomoSummary.mode === 'retrieval'
                     ? 'Hit rate'
@@ -2751,18 +3428,20 @@ function renderManagedSuiteStatus(
                       }`,
                     ]
                   : []),
-                ...Object.entries(latestLocomoSummary.categories)
-                  .sort(([left], [right]) => Number(left) - Number(right))
-                  .map(
-                    ([category, value]) =>
-                      `cat${category}: ${
-                        formatLocomoCategoryValue(
-                          category,
-                          value,
-                          latestLocomoSummary.mode,
-                        ) || 'n/a'
-                      }`,
-                  ),
+                ...(!latestLocomoSummary.matrix
+                  ? Object.entries(latestLocomoSummary.categories)
+                      .sort(([left], [right]) => Number(left) - Number(right))
+                      .map(
+                        ([category, value]) =>
+                          `cat${category}: ${
+                            formatLocomoCategoryValue(
+                              category,
+                              value,
+                              latestLocomoSummary.mode,
+                            ) || 'n/a'
+                          }`,
+                      )
+                  : []),
                 ...(latestLocomoSummary.tokenUsage
                   ? [
                       `Tokens: ${formatLocomoTokenUsage(
@@ -2786,6 +3465,41 @@ function renderManagedSuiteStatus(
                   latestLocomoProgress.completedQuestionCount ?? 'unknown'
                 }/${latestLocomoProgress.questionCount ?? '?'}`,
                 `Budget: ${latestLocomoProgress.budgetTokens ?? 'unknown'}`,
+                ...(latestLocomoProgress.mode === 'retrieval' &&
+                latestLocomoProgress.retrievalPolicy
+                  ? [
+                      `Recall policy: ${formatLocomoRetrievalPolicy(latestLocomoProgress.retrievalPolicy) || 'unknown'}`,
+                    ]
+                  : []),
+                ...(latestLocomoProgress.mode === 'retrieval' &&
+                !latestLocomoProgress.matrix
+                  ? [
+                      `Query prep: ${formatLocomoRetrievalQueryMode(latestLocomoProgress.retrievalQueryMode) || 'unknown'}`,
+                      `Backend: ${formatLocomoRetrievalBackend(latestLocomoProgress.retrievalBackend) || 'unknown'}`,
+                      `Rerank: ${formatLocomoRetrievalRerank(latestLocomoProgress.retrievalRerank) || 'unknown'}`,
+                      `Tokenizer: ${formatLocomoRetrievalTokenizer(latestLocomoProgress.retrievalTokenizer) || 'unknown'}`,
+                      `Embedding: ${formatLocomoRetrievalEmbeddingProvider(latestLocomoProgress.retrievalEmbeddingProvider) || 'unknown'}`,
+                      `Embedding model: ${latestLocomoProgress.retrievalEmbeddingModel || 'unknown'}`,
+                    ]
+                  : []),
+                ...(latestLocomoProgress.mode === 'retrieval' &&
+                latestLocomoProgress.matrix &&
+                latestLocomoProgress.retrievalEmbeddingModel
+                  ? [
+                      `Embedding model: ${latestLocomoProgress.retrievalEmbeddingModel}`,
+                    ]
+                  : []),
+                ...(latestLocomoProgress.matrix
+                  ? [
+                      `Sweep: ${formatLocomoRetrievalSweep(latestLocomoProgress.matrixSweep) || 'unknown'}`,
+                      `Variants: ${latestLocomoProgress.completedVariantCount ?? latestLocomoProgress.variants.length}/${latestLocomoProgress.variantCount ?? '?'}`,
+                      ...(latestLocomoProgress.currentVariant
+                        ? [
+                            `Current variant: ${latestLocomoProgress.currentVariant.label}`,
+                          ]
+                        : []),
+                    ]
+                  : []),
                 `${
                   latestLocomoProgress.mode === 'retrieval'
                     ? 'Hit rate so far'
@@ -2797,6 +3511,11 @@ function renderManagedSuiteStatus(
                 }`,
                 ...(latestLocomoProgress.mode === 'retrieval'
                   ? [
+                      ...(latestLocomoProgress.currentPhase
+                        ? [
+                            `Phase: ${formatLocomoProgressPhase(latestLocomoProgress.currentPhase) || 'unknown'}`,
+                          ]
+                        : []),
                       `Context F1 so far: ${
                         latestLocomoProgress.contextF1 != null
                           ? latestLocomoProgress.contextF1.toFixed(3)
@@ -2807,6 +3526,13 @@ function renderManagedSuiteStatus(
                 ...(latestLocomoProgress.currentSampleId
                   ? [
                       `Current sample: ${latestLocomoProgress.currentSampleId}`,
+                      ...(latestLocomoProgress.currentSampleEmbeddedTurnCount !=
+                        null &&
+                      latestLocomoProgress.currentSampleTurnCount != null
+                        ? [
+                            `Embedding turns: ${latestLocomoProgress.currentSampleEmbeddedTurnCount}/${latestLocomoProgress.currentSampleTurnCount}`,
+                          ]
+                        : []),
                       ...(latestLocomoProgress.currentSampleQuestionCount !=
                         null &&
                       latestLocomoProgress.currentSampleQuestionTotal != null
@@ -2816,18 +3542,20 @@ function renderManagedSuiteStatus(
                         : []),
                     ]
                   : []),
-                ...Object.entries(latestLocomoProgress.categories)
-                  .sort(([left], [right]) => Number(left) - Number(right))
-                  .map(
-                    ([category, value]) =>
-                      `cat${category}: ${
-                        formatLocomoCategoryValue(
-                          category,
-                          value,
-                          latestLocomoProgress.mode,
-                        ) || 'n/a'
-                      }`,
-                  ),
+                ...(!latestLocomoProgress.matrix
+                  ? Object.entries(latestLocomoProgress.categories)
+                      .sort(([left], [right]) => Number(left) - Number(right))
+                      .map(
+                        ([category, value]) =>
+                          `cat${category}: ${
+                            formatLocomoCategoryValue(
+                              category,
+                              value,
+                              latestLocomoProgress.mode,
+                            ) || 'n/a'
+                          }`,
+                      )
+                  : []),
                 ...(latestLocomoProgress.tokenUsage
                   ? [
                       `Tokens: ${formatLocomoTokenUsage(
@@ -2881,8 +3609,12 @@ function renderManagedSuiteResults(
     suite.id === 'terminal-bench-2.0' && latestJob.operation === 'run'
       ? readTerminalBenchNativeProgress(latestJob)
       : null;
+  const locomoRunActive =
+    suite.id === 'locomo' &&
+    latestJob.operation === 'run' &&
+    isRunMetaActive(latestJob);
   const locomoSummary =
-    suite.id === 'locomo' && latestJob.operation === 'run'
+    suite.id === 'locomo' && latestJob.operation === 'run' && !locomoRunActive
       ? readLocomoNativeSummary(latestJob)
       : null;
   const locomoProgress =
@@ -2952,6 +3684,20 @@ function renderManagedSuiteResults(
   }
   if (suite.id === 'locomo') {
     const locomoData = locomoSummary || locomoProgress;
+    const locomoVariantRows =
+      locomoData?.mode === 'retrieval' && locomoData.matrix
+        ? [
+            ...locomoData.variants,
+            ...(!locomoSummary && locomoProgress?.currentVariant
+              ? [
+                  {
+                    ...locomoProgress.currentVariant,
+                    label: `${locomoProgress.currentVariant.label} (running)`,
+                  },
+                ]
+              : []),
+          ]
+        : [];
     const overviewSection = renderKeyValueSection('Overview', [
       [
         'Evaluated model',
@@ -2964,6 +3710,68 @@ function renderManagedSuiteResults(
       ['Mode', locomoData?.mode || null],
       ['Dataset', locomoData?.dataset || null],
       ['Samples', locomoData?.sampleCount ?? null],
+      [
+        'Variants',
+        locomoData?.mode === 'retrieval' && locomoData.matrix
+          ? `${locomoSummary ? locomoData.variants.length : (locomoProgress?.completedVariantCount ?? locomoData.variants.length)}/${locomoData.variantCount ?? locomoData.variants.length}`
+          : null,
+      ],
+      [
+        'Sweep',
+        locomoData?.mode === 'retrieval' && locomoData.matrix
+          ? formatLocomoRetrievalSweep(locomoData.matrixSweep)
+          : null,
+      ],
+      [
+        'Recall policy',
+        locomoData?.mode === 'retrieval'
+          ? formatLocomoRetrievalPolicy(locomoData.retrievalPolicy)
+          : null,
+      ],
+      [
+        'Query prep',
+        locomoData?.mode === 'retrieval' && !locomoData.matrix
+          ? formatLocomoRetrievalQueryMode(locomoData.retrievalQueryMode)
+          : null,
+      ],
+      [
+        'Backend',
+        locomoData?.mode === 'retrieval' && !locomoData.matrix
+          ? formatLocomoRetrievalBackend(locomoData.retrievalBackend)
+          : null,
+      ],
+      [
+        'Rerank',
+        locomoData?.mode === 'retrieval' && !locomoData.matrix
+          ? formatLocomoRetrievalRerank(locomoData.retrievalRerank)
+          : null,
+      ],
+      [
+        'Tokenizer',
+        locomoData?.mode === 'retrieval' && !locomoData.matrix
+          ? formatLocomoRetrievalTokenizer(locomoData.retrievalTokenizer)
+          : null,
+      ],
+      [
+        'Embedding',
+        locomoData?.mode === 'retrieval' && !locomoData.matrix
+          ? formatLocomoRetrievalEmbeddingProvider(
+              locomoData.retrievalEmbeddingProvider,
+            )
+          : null,
+      ],
+      [
+        'Embedding model',
+        locomoData?.mode === 'retrieval'
+          ? locomoData.retrievalEmbeddingModel
+          : null,
+      ],
+      [
+        'Best variant',
+        locomoSummary && locomoData?.mode === 'retrieval' && locomoData.matrix
+          ? locomoSummary.bestVariantLabel
+          : null,
+      ],
       [
         'Questions',
         locomoSummary
@@ -2982,53 +3790,85 @@ function renderManagedSuiteResults(
       [
         locomoSummary
           ? locomoData?.mode === 'retrieval'
-            ? 'Hit rate'
+            ? locomoData.matrix
+              ? 'Best hit rate'
+              : 'Hit rate'
             : 'Overall score'
           : locomoData?.mode === 'retrieval'
-            ? 'Hit rate so far'
+            ? locomoData.matrix
+              ? 'Current hit rate'
+              : 'Hit rate so far'
             : 'Score so far',
         locomoData?.overallScore ?? null,
       ],
       [
-        locomoSummary ? 'Context F1' : 'Context F1 so far',
+        locomoSummary
+          ? locomoData?.matrix
+            ? 'Best context F1'
+            : 'Context F1'
+          : locomoData?.matrix
+            ? 'Current context F1'
+            : 'Context F1 so far',
         locomoData?.mode === 'retrieval'
           ? (locomoData?.contextF1 ?? null)
           : null,
       ],
-      [
-        'Current sample',
-        !locomoSummary && locomoProgress
-          ? locomoProgress.currentSampleId
-          : null,
-      ],
     ]);
-    const categorySection = renderKeyValueSection(
-      locomoSummary ? 'Categories' : 'Categories So Far',
-      Object.entries(locomoData?.categories || {})
-        .sort(([left], [right]) => Number(left) - Number(right))
-        .map(
-          ([category, value]) =>
+    const progressSection =
+      !locomoSummary && locomoProgress
+        ? renderKeyValueSection('Progress', [
+            ['Phase', formatLocomoProgressPhase(locomoProgress.currentPhase)],
+            ['Current sample', locomoProgress.currentSampleId],
             [
-              `cat${category}`,
-              formatLocomoCategoryValue(
-                category,
-                value,
-                locomoData?.mode || 'qa',
+              'Embedding',
+              formatProgressValue(
+                locomoProgress.currentSampleEmbeddedTurnCount,
+                locomoProgress.currentSampleTurnCount,
               ),
-            ] as const,
-        ),
-    );
+            ],
+            ['Evaluation', formatLocomoEvaluationProgressValue(locomoProgress)],
+            [
+              'Variants',
+              locomoProgress.mode === 'retrieval' && locomoProgress.matrix
+                ? formatProgressValue(
+                    locomoProgress.completedVariantCount ??
+                      locomoProgress.variants.length,
+                    locomoProgress.variantCount,
+                  )
+                : null,
+            ],
+            [
+              'Current variant',
+              locomoProgress.mode === 'retrieval' && locomoProgress.matrix
+                ? locomoProgress.currentVariant?.label
+                : null,
+            ],
+          ])
+        : null;
+    const categorySection =
+      locomoData?.mode === 'retrieval' && locomoData.matrix
+        ? renderLocomoVariantComparisonSection(
+            locomoSummary ? 'Variants' : 'Variants So Far',
+            locomoVariantRows,
+          )
+        : renderKeyValueSection(
+            locomoSummary ? 'Categories' : 'Categories So Far',
+            Object.entries(locomoData?.categories || {})
+              .sort(([left], [right]) => Number(left) - Number(right))
+              .map(
+                ([category, value]) =>
+                  [
+                    `cat${category}`,
+                    formatLocomoCategoryValue(
+                      category,
+                      value,
+                      locomoData?.mode || 'qa',
+                    ),
+                  ] as const,
+              ),
+          );
     const usageSection = renderKeyValueSection('Usage', [
       ['Tokens', formatLocomoTokenUsage(locomoData?.tokenUsage)],
-      [
-        'Current sample questions',
-        !locomoSummary &&
-        locomoProgress &&
-        locomoProgress.currentSampleQuestionCount != null &&
-        locomoProgress.currentSampleQuestionTotal != null
-          ? `${locomoProgress.currentSampleQuestionCount}/${locomoProgress.currentSampleQuestionTotal}`
-          : null,
-      ],
     ]);
     const runSection = renderKeyValueSection('Run', [
       ['Run ID', latestJob.runId],
@@ -3049,6 +3889,7 @@ function renderManagedSuiteResults(
       `${suite.title} Results`,
       joinSections([
         overviewSection,
+        progressSection,
         categorySection,
         usageSection,
         runSection,

--- a/src/evals/eval-command.ts
+++ b/src/evals/eval-command.ts
@@ -19,6 +19,7 @@ import {
 
 type EvalSuiteId =
   | 'swebench-verified'
+  | 'locomo'
   | 'terminal-bench-2.0'
   | 'agentbench'
   | 'gaia';
@@ -79,7 +80,7 @@ interface EvalRunPreparation {
 
 interface EvalSetupCommand {
   command: string;
-  strategy: 'uv' | 'system-python';
+  strategy: 'native' | 'uv' | 'system-python';
 }
 
 interface EvalRunMeta {
@@ -171,6 +172,23 @@ interface TerminalBenchNativeTokenUsage {
   apiUsageAvailable: boolean;
 }
 
+interface LocomoNativeModeAggregate {
+  overallF1: number;
+  overallHitRate: number;
+  totalQuestions: number;
+}
+
+interface LocomoNativeSummary {
+  jobDir: string;
+  resultPath: string;
+  dataset: string | null;
+  budgetTokens: number | null;
+  topK: number | null;
+  sampleCount: number | null;
+  requestedMode: string | null;
+  modes: Record<string, LocomoNativeModeAggregate>;
+}
+
 const MAX_QUEUED_EVAL_MESSAGES = 200;
 const EVAL_PROGRESS_BAR_WIDTH = 20;
 const EVAL_PROGRESS_POLL_INTERVAL_MS = 1000;
@@ -205,6 +223,26 @@ const EVAL_SUITES: EvalSuiteDefinition[] = [
     notes: [
       'This step evaluates a predictions JSONL; produce patches with your HybridClaw-driven harness first.',
       '`/eval ...` injects the OpenAI-compatible HybridClaw endpoint for any predictor step you run through this helper.',
+    ],
+  },
+  {
+    id: 'locomo',
+    title: 'LOCOMO',
+    summary:
+      'Native HybridClaw long-conversation memory benchmark over the official LoCoMo dataset.',
+    aliases: ['lo-co-mo', 'locomo-memory'],
+    prereqs: [
+      'Node.js 22',
+      'network access during `setup` to download `locomo10.json`',
+    ],
+    starter: [
+      '/eval locomo setup',
+      '/eval locomo run --budget 4000 --num-samples 2',
+    ],
+    notes: [
+      'This native harness evaluates retrieval quality directly instead of delegating answer generation to an external Python benchmark.',
+      'Results compare a naive recent-tail baseline against HybridClaw semantic memory recall on the official LoCoMo conversations.',
+      'Prompt/profile eval flags are accepted on the outer `/eval` command but do not change the native LoCoMo scoring path.',
     ],
   },
   {
@@ -330,7 +368,7 @@ function renderSuiteList(): string[] {
 }
 
 function isImplementedManagedSuite(suite: EvalSuiteDefinition): boolean {
-  return suite.id === 'terminal-bench-2.0';
+  return suite.id === 'terminal-bench-2.0' || suite.id === 'locomo';
 }
 
 function renderUnimplementedSuite(
@@ -351,6 +389,7 @@ function renderUnimplementedSuite(
     ...describeEvalProfile(env.profile).map((entry) => `- ${entry}`),
     '',
     'Implemented suites today:',
+    '- `/eval locomo ...`',
     '- `/eval terminal-bench-2.0 ...`',
     '- `/eval tau2 ...`',
   ].join('\n');
@@ -363,6 +402,7 @@ function renderUsage(env: EvalEnvironment): string {
     'Usage:',
     '- `/eval list`',
     '- `/eval env [--current-agent|--fresh-agent] [--ablate-system] [--include-prompt=<parts>] [--omit-prompt=<parts>]`',
+    '- `/eval locomo [setup|run|status|stop|results|logs]`',
     '- `/eval terminal-bench-2.0 [setup|run|status|stop|results|logs]`',
     '- `/eval tau2 [setup|run|status|stop|results]`',
     '- `/eval <suite> [--current-agent|--fresh-agent] [--ablate-system] [--include-prompt=<parts>] [--omit-prompt=<parts>]`',
@@ -379,7 +419,7 @@ function renderUsage(env: EvalEnvironment): string {
     'Suites:',
     ...renderSuiteList(),
     '',
-    'Only `terminal-bench-2.0` and `tau2` are implemented today.',
+    'Only `locomo`, `terminal-bench-2.0`, and `tau2` are implemented today.',
   ].join('\n');
 }
 
@@ -523,7 +563,7 @@ function renderRecipe(
     '',
     'Managed commands:',
     `- \`/eval ${suite.id} setup\``,
-    `- \`/eval ${suite.id} run --num-tasks 10\``,
+    `- \`${getManagedSuiteRunExample(suite)}\``,
     `- \`/eval ${suite.id} status\``,
     `- \`/eval ${suite.id} stop\``,
     `- \`/eval ${suite.id} results\``,
@@ -531,6 +571,17 @@ function renderRecipe(
     '',
     'Launch the starter or your own command with `/eval <shell command...>`.',
   ].join('\n');
+}
+
+function getManagedSuiteRunExample(suite: EvalSuiteDefinition): string {
+  switch (suite.id) {
+    case 'locomo':
+      return '/eval locomo run --budget 4000 --num-samples 2';
+    case 'terminal-bench-2.0':
+      return '/eval terminal-bench-2.0 run --num-tasks 10';
+    default:
+      return `/eval ${suite.id} run`;
+  }
 }
 
 function renderTau2Usage(env: EvalEnvironment, dataDir: string): string {
@@ -602,12 +653,22 @@ function getTau2InstallDir(dataDir: string): string {
 function getManagedSuiteSetup(
   suite: EvalSuiteDefinition,
 ): ManagedEvalSuiteSetup | null {
-  if (suite.id !== 'terminal-bench-2.0') return null;
-  return {
-    installDirName: 'terminal-bench-2.0',
-    strategyDescription:
-      'uv-managed Python 3.12 venv with Hugging Face datasets install and native Terminal-Bench helper smoke test',
-  };
+  switch (suite.id) {
+    case 'locomo':
+      return {
+        installDirName: 'locomo',
+        strategyDescription:
+          'native HybridClaw LOCOMO harness with official locomo10 dataset download',
+      };
+    case 'terminal-bench-2.0':
+      return {
+        installDirName: 'terminal-bench-2.0',
+        strategyDescription:
+          'uv-managed Python 3.12 venv with Hugging Face datasets install and native Terminal-Bench helper smoke test',
+      };
+    default:
+      return null;
+  }
 }
 
 function getManagedSuiteInstallDir(
@@ -629,6 +690,10 @@ function getManagedSuiteMarkerPath(
     getManagedSuiteInstallDir(suite, dataDir),
     '.hybridclaw-setup-ok',
   );
+}
+
+function getLocomoDatasetPath(dataDir: string): string {
+  return path.join(getEvalBaseDir(dataDir), 'locomo', 'data', 'locomo10.json');
 }
 
 function getManagedSuitePythonPath(
@@ -654,6 +719,12 @@ function isManagedSuiteInstalled(
   suite: EvalSuiteDefinition,
   dataDir: string,
 ): boolean {
+  if (suite.id === 'locomo') {
+    return (
+      fs.existsSync(getManagedSuiteMarkerPath(suite, dataDir)) &&
+      fs.existsSync(getLocomoDatasetPath(dataDir))
+    );
+  }
   return (
     fs.existsSync(getManagedSuiteMarkerPath(suite, dataDir)) &&
     fs.existsSync(getManagedSuitePythonPath(suite, dataDir))
@@ -684,6 +755,17 @@ function getManagedSuiteSetupCommand(
   }
 
   const installDir = getManagedSuiteInstallDir(suite, dataDir);
+  if (suite.id === 'locomo') {
+    return {
+      strategy: 'native',
+      command: buildInternalEvalCommand('__eval-locomo-native', [
+        'setup',
+        '--install-dir',
+        installDir,
+      ]),
+    };
+  }
+
   const installDirQuoted = quoteShellArg(installDir);
   const markerFile = '.hybridclaw-setup-ok';
   const venvPython =
@@ -761,12 +843,30 @@ function getManagedSuiteNextStep(
   _dataDir: string,
 ): string {
   switch (suite.id) {
+    case 'locomo': {
+      return '/eval locomo run --budget 4000 --num-samples 2';
+    }
     case 'terminal-bench-2.0': {
       return `/eval terminal-bench-2.0 run --num-tasks 10`;
     }
     default:
       return `/eval ${suite.id}`;
   }
+}
+
+function buildInternalEvalCommand(commandName: string, args: string[]): string {
+  const cliEntry = process.argv[1]?.trim();
+  if (!cliEntry) {
+    throw new Error('Unable to resolve the HybridClaw CLI entry point.');
+  }
+  return buildCommandString([
+    quoteShellArg(process.execPath),
+    quoteShellArg(path.resolve(cliEntry)),
+    commandName,
+    ...args.map((entry) =>
+      entry.startsWith('--') ? entry : quoteShellArg(entry),
+    ),
+  ]);
 }
 
 function getTerminalBenchDatasetHelperPath(dataDir: string): string {
@@ -831,6 +931,19 @@ function prepareManagedSuiteRun(
   effectiveAgentId: string,
   args: string[],
 ): ManagedSuiteRunPreparation | null {
+  if (suite.id === 'locomo') {
+    return {
+      commandArgs: ['locomo', 'run', ...args],
+      command: buildInternalEvalCommand('__eval-locomo-native', [
+        'run',
+        '--install-dir',
+        getManagedSuiteInstallDir(suite, dataDir),
+        ...args,
+      ]),
+      displayCommand: buildCommandString([suite.id, 'run', ...args]),
+      cwd: dataDir,
+    };
+  }
   if (suite.id !== 'terminal-bench-2.0') return null;
   ensureTerminalBenchDatasetHelper(dataDir);
 
@@ -1343,6 +1456,95 @@ function readTerminalBenchNativeProgress(
     pending,
     tokenUsage: readTerminalBenchJobTokenUsage(jobDir),
   };
+}
+
+function readLocomoJobDir(meta: EvalRunMeta): string | null {
+  if (meta.suiteId !== 'locomo' || meta.operation !== 'run') {
+    return null;
+  }
+  const stdoutText = readLogFileText(meta.stdoutPath);
+  const match = stdoutText.match(/^Job dir:\s*(.+)$/m);
+  const jobDir = String(match?.[1] || '').trim();
+  return jobDir || null;
+}
+
+function readLocomoNativeSummary(
+  meta: EvalRunMeta,
+): LocomoNativeSummary | null {
+  const jobDir = readLocomoJobDir(meta);
+  if (!jobDir) return null;
+  const resultPath = path.join(jobDir, 'result.json');
+  if (!fs.existsSync(resultPath)) return null;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(resultPath, 'utf-8')) as {
+      dataset?: unknown;
+      budgetTokens?: unknown;
+      topK?: unknown;
+      sampleCount?: unknown;
+      requestedMode?: unknown;
+      modes?: Record<
+        string,
+        {
+          overallF1?: unknown;
+          overallHitRate?: unknown;
+          totalQuestions?: unknown;
+        }
+      >;
+    };
+    const modes = Object.fromEntries(
+      Object.entries(parsed.modes || {}).map(([mode, value]) => [
+        mode,
+        {
+          overallF1:
+            typeof value?.overallF1 === 'number' &&
+            Number.isFinite(value.overallF1)
+              ? value.overallF1
+              : 0,
+          overallHitRate:
+            typeof value?.overallHitRate === 'number' &&
+            Number.isFinite(value.overallHitRate)
+              ? value.overallHitRate
+              : 0,
+          totalQuestions:
+            typeof value?.totalQuestions === 'number' &&
+            Number.isFinite(value.totalQuestions)
+              ? value.totalQuestions
+              : 0,
+        },
+      ]),
+    ) as Record<string, LocomoNativeModeAggregate>;
+    return {
+      jobDir,
+      resultPath,
+      dataset: typeof parsed.dataset === 'string' ? parsed.dataset : null,
+      budgetTokens:
+        typeof parsed.budgetTokens === 'number' &&
+        Number.isFinite(parsed.budgetTokens)
+          ? parsed.budgetTokens
+          : null,
+      topK:
+        typeof parsed.topK === 'number' && Number.isFinite(parsed.topK)
+          ? parsed.topK
+          : null,
+      sampleCount:
+        typeof parsed.sampleCount === 'number' &&
+        Number.isFinite(parsed.sampleCount)
+          ? parsed.sampleCount
+          : null,
+      requestedMode:
+        typeof parsed.requestedMode === 'string' ? parsed.requestedMode : null,
+      modes,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function formatLocomoModeValue(
+  value: LocomoNativeModeAggregate | undefined,
+): string | null {
+  if (!value) return null;
+  return `Hit ${value.overallHitRate.toFixed(3)} | F1 ${value.overallF1.toFixed(3)} | Q ${value.totalQuestions}`;
 }
 
 function describeManagedSuiteRunLifecycle(
@@ -2300,6 +2502,10 @@ function renderManagedSuiteStatus(
     suite.id === 'terminal-bench-2.0' && latestRun
       ? readTerminalBenchNativeSummary(latestRun)
       : null;
+  const latestLocomoSummary =
+    suite.id === 'locomo' && latestRun
+      ? readLocomoNativeSummary(latestRun)
+      : null;
   const setupFailure =
     !installed && latestSetup ? describeRunFailureReason(latestSetup) : null;
 
@@ -2307,6 +2513,11 @@ function renderManagedSuiteStatus(
     `Install dir: ${installDir}`,
     `Installed: ${installed ? 'yes' : 'no'}`,
     `Marker: ${fs.existsSync(markerPath) ? markerPath : 'missing'}`,
+    ...(suite.id === 'locomo'
+      ? [
+          `Dataset: ${fs.existsSync(getLocomoDatasetPath(dataDir)) ? getLocomoDatasetPath(dataDir) : 'missing'}`,
+        ]
+      : []),
     ...(executablePath
       ? [
           `Executable: ${fs.existsSync(executablePath) ? executablePath : 'missing'}`,
@@ -2326,6 +2537,17 @@ function renderManagedSuiteStatus(
           `Command: ${latestRun.displayCommand || latestRun.command}`,
           `Stdout: ${latestRun.stdoutPath}`,
           `Stderr: ${latestRun.stderrPath}`,
+          ...(latestLocomoSummary
+            ? [
+                `Samples: ${latestLocomoSummary.sampleCount ?? 'unknown'}`,
+                `Budget: ${latestLocomoSummary.budgetTokens ?? 'unknown'}`,
+                `Top K: ${latestLocomoSummary.topK ?? 'unknown'}`,
+                ...Object.entries(latestLocomoSummary.modes).map(
+                  ([mode, value]) =>
+                    `${mode}: ${formatLocomoModeValue(value) || 'n/a'}`,
+                ),
+              ]
+            : []),
           ...(latestTerminalBenchSummary
             ? [
                 `Score: ${latestTerminalBenchSummary.mean.toFixed(3)}`,
@@ -2368,6 +2590,10 @@ function renderManagedSuiteResults(
   const terminalBenchProgress =
     suite.id === 'terminal-bench-2.0' && latestJob.operation === 'run'
       ? readTerminalBenchNativeProgress(latestJob)
+      : null;
+  const locomoSummary =
+    suite.id === 'locomo' && latestJob.operation === 'run'
+      ? readLocomoNativeSummary(latestJob)
       : null;
   if (suite.id === 'terminal-bench-2.0') {
     const overviewSection = renderKeyValueSection('Overview', [
@@ -2428,6 +2654,37 @@ function renderManagedSuiteResults(
     return infoResult(
       `${suite.title} Results`,
       joinSections([overviewSection, outcomeSection, runSection, pathsSection]),
+    );
+  }
+  if (suite.id === 'locomo') {
+    const overviewSection = renderKeyValueSection('Overview', [
+      ['Harness', `HybridClaw v${resolveHarnessVersion()}`],
+      ['Status', describeManagedSuiteRunLifecycle(latestJob)],
+      ['Dataset', locomoSummary?.dataset || null],
+      ['Samples', locomoSummary?.sampleCount ?? null],
+      ['Budget', locomoSummary?.budgetTokens ?? null],
+      ['Top K', locomoSummary?.topK ?? null],
+      ['Mode', locomoSummary?.requestedMode || null],
+    ]);
+    const modeSection = renderKeyValueSection(
+      'Modes',
+      Object.entries(locomoSummary?.modes || {})
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([mode, value]) => [mode, formatLocomoModeValue(value)] as const),
+    );
+    const runSection = renderKeyValueSection('Run', [
+      ['Run ID', latestJob.runId],
+      ['Command', latestJob.displayCommand || latestJob.command],
+    ]);
+    const pathsSection = renderKeyValueSection('Paths', [
+      ['Job dir', locomoSummary?.jobDir || null],
+      ['Result JSON', locomoSummary?.resultPath || null],
+      ['Stdout', latestJob.stdoutPath],
+      ['Stderr', latestJob.stderrPath],
+    ]);
+    return infoResult(
+      `${suite.title} Results`,
+      joinSections([overviewSection, modeSection, runSection, pathsSection]),
     );
   }
   return infoResult(
@@ -2701,6 +2958,7 @@ async function handleManagedSuiteCommand(params: {
         `${params.suite.title} is not implemented yet.`,
         '',
         'Implemented suites today:',
+        '- `/eval locomo ...`',
         '- `/eval terminal-bench-2.0 ...`',
         '- `/eval tau2 ...`',
       ].join('\n'),

--- a/src/evals/eval-command.ts
+++ b/src/evals/eval-command.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { MAX_CONCURRENT_CONTAINERS } from '../config/config.js';
 import { isContainerMaxConcurrentExplicit } from '../config/runtime-config.js';
 import type { GatewayCommandResult } from '../gateway/gateway-types.js';
+import { resolveInstallRoot } from '../infra/install-root.js';
 import {
   enqueueProactiveMessage,
   isDatabaseInitialized,
@@ -46,6 +47,8 @@ interface ManagedSuiteRunPreparation {
   cwd: string;
 }
 
+type LocomoAgentMode = 'conversation-fresh' | 'current-agent' | 'fresh-request';
+
 interface EvalEnvironment {
   baseUrl: string;
   apiKey: string;
@@ -76,6 +79,14 @@ interface EvalRunPreparation {
   commandArgs: string[];
   command: string;
   progress: EvalProgressSpec | null;
+}
+
+interface ParsedEvalAction {
+  action: string;
+  profile: EvalProfile;
+  commandArgs: string[];
+  workspaceModeExplicit: boolean;
+  error?: string;
 }
 
 interface EvalSetupCommand {
@@ -172,21 +183,55 @@ interface TerminalBenchNativeTokenUsage {
   apiUsageAvailable: boolean;
 }
 
-interface LocomoNativeModeAggregate {
-  overallF1: number;
-  overallHitRate: number;
-  totalQuestions: number;
+interface LocomoNativeCategoryAggregate {
+  meanScore: number;
+  questionCount: number;
+  contextF1: number | null;
+}
+
+interface LocomoNativeTokenUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  responsesWithUsage: number;
 }
 
 interface LocomoNativeSummary {
   jobDir: string;
   resultPath: string;
+  predictionsPath: string | null;
+  mode: 'qa' | 'retrieval';
   dataset: string | null;
+  model: string | null;
   budgetTokens: number | null;
-  topK: number | null;
   sampleCount: number | null;
-  requestedMode: string | null;
-  modes: Record<string, LocomoNativeModeAggregate>;
+  questionCount: number | null;
+  overallScore: number | null;
+  contextF1: number | null;
+  categories: Record<string, LocomoNativeCategoryAggregate>;
+  tokenUsage: LocomoNativeTokenUsage | null;
+}
+
+interface LocomoNativeProgress {
+  jobDir: string;
+  progressPath: string;
+  resultPath: string;
+  predictionsPath: string | null;
+  mode: 'qa' | 'retrieval';
+  dataset: string | null;
+  model: string | null;
+  budgetTokens: number | null;
+  sampleCount: number | null;
+  completedSampleCount: number | null;
+  questionCount: number | null;
+  completedQuestionCount: number | null;
+  overallScore: number | null;
+  contextF1: number | null;
+  currentSampleId: string | null;
+  currentSampleQuestionCount: number | null;
+  currentSampleQuestionTotal: number | null;
+  categories: Record<string, LocomoNativeCategoryAggregate>;
+  tokenUsage: LocomoNativeTokenUsage | null;
 }
 
 const MAX_QUEUED_EVAL_MESSAGES = 200;
@@ -229,7 +274,7 @@ const EVAL_SUITES: EvalSuiteDefinition[] = [
     id: 'locomo',
     title: 'LOCOMO',
     summary:
-      'Native HybridClaw long-conversation memory benchmark over the official LoCoMo dataset.',
+      'Native HybridClaw LoCoMo QA benchmark over the official long-conversation dataset.',
     aliases: ['lo-co-mo', 'locomo-memory'],
     prereqs: [
       'Node.js 22',
@@ -237,12 +282,16 @@ const EVAL_SUITES: EvalSuiteDefinition[] = [
     ],
     starter: [
       '/eval locomo setup',
-      '/eval locomo run --budget 4000 --num-samples 2',
+      '/eval locomo run --budget 4000 --max-questions 20',
+      '/eval locomo run --mode retrieval --budget 4000 --max-questions 20',
     ],
     notes: [
-      'This native harness evaluates retrieval quality directly instead of delegating answer generation to an external Python benchmark.',
-      'Results compare a naive recent-tail baseline against HybridClaw semantic memory recall on the official LoCoMo conversations.',
-      'Prompt/profile eval flags are accepted on the outer `/eval` command but do not change the native LoCoMo scoring path.',
+      'The default `qa` mode generates LoCoMo answers through HybridClaw’s local OpenAI-compatible gateway and scores the model outputs directly.',
+      '`--mode retrieval` skips model generation, ingests each conversation into an isolated native memory session, and scores evidence hit-rate from recalled semantic memories.',
+      'The `qa` prompt shape follows the upstream `evaluate_gpts` flow: truncated conversation context plus a short-answer QA prompt for each LoCoMo question.',
+      '`--num-samples` limits conversation records. Use `--max-questions` for quick smoke runs over a small number of LoCoMo questions.',
+      'By default, LOCOMO creates one fresh template-seeded agent per conversation sample. Use `--current-agent` to reuse the current agent workspace, or `--fresh-agent` to force a new agent for every individual QA request.',
+      'Prompt/profile eval flags flow through `HYBRIDCLAW_EVAL_MODEL`, so agent/workspace mode and prompt ablations affect the benchmarked run.',
     ],
   },
   {
@@ -576,7 +625,7 @@ function renderRecipe(
 function getManagedSuiteRunExample(suite: EvalSuiteDefinition): string {
   switch (suite.id) {
     case 'locomo':
-      return '/eval locomo run --budget 4000 --num-samples 2';
+      return '/eval locomo run --budget 4000 --max-questions 20';
     case 'terminal-bench-2.0':
       return '/eval terminal-bench-2.0 run --num-tasks 10';
     default:
@@ -844,7 +893,7 @@ function getManagedSuiteNextStep(
 ): string {
   switch (suite.id) {
     case 'locomo': {
-      return '/eval locomo run --budget 4000 --num-samples 2';
+      return '/eval locomo run --budget 4000 --max-questions 20';
     }
     case 'terminal-bench-2.0': {
       return `/eval terminal-bench-2.0 run --num-tasks 10`;
@@ -855,18 +904,42 @@ function getManagedSuiteNextStep(
 }
 
 function buildInternalEvalCommand(commandName: string, args: string[]): string {
-  const cliEntry = process.argv[1]?.trim();
-  if (!cliEntry) {
-    throw new Error('Unable to resolve the HybridClaw CLI entry point.');
-  }
+  const commandArgs =
+    resolveInternalEvalLauncherCommandArgs().map(quoteShellArg);
+
   return buildCommandString([
-    quoteShellArg(process.execPath),
-    quoteShellArg(path.resolve(cliEntry)),
+    ...commandArgs,
     commandName,
     ...args.map((entry) =>
       entry.startsWith('--') ? entry : quoteShellArg(entry),
     ),
   ]);
+}
+
+function resolveInternalEvalLauncherCommandArgs(): string[] {
+  const installRoot = resolveInstallRoot();
+  const sourceCliPath = path.join(installRoot, 'src', 'cli.ts');
+  const tsxCliPath = path.join(
+    installRoot,
+    'node_modules',
+    'tsx',
+    'dist',
+    'cli.mjs',
+  );
+  const distCliPath = path.join(installRoot, 'dist', 'cli.js');
+
+  if (fs.existsSync(sourceCliPath) && fs.existsSync(tsxCliPath)) {
+    return [process.execPath, tsxCliPath, sourceCliPath];
+  }
+  if (fs.existsSync(distCliPath)) {
+    return [process.execPath, distCliPath];
+  }
+
+  const cliEntry = process.argv[1]?.trim();
+  if (!cliEntry) {
+    throw new Error('Unable to resolve the HybridClaw CLI entry point.');
+  }
+  return [process.execPath, path.resolve(cliEntry)];
 }
 
 function getTerminalBenchDatasetHelperPath(dataDir: string): string {
@@ -930,14 +1003,21 @@ function prepareManagedSuiteRun(
   env: EvalEnvironment,
   effectiveAgentId: string,
   args: string[],
+  workspaceModeExplicit: boolean,
 ): ManagedSuiteRunPreparation | null {
   if (suite.id === 'locomo') {
+    const agentMode = resolveLocomoAgentMode(
+      env.profile,
+      workspaceModeExplicit,
+    );
     return {
       commandArgs: ['locomo', 'run', ...args],
       command: buildInternalEvalCommand('__eval-locomo-native', [
         'run',
         '--install-dir',
         getManagedSuiteInstallDir(suite, dataDir),
+        '--agent-mode',
+        agentMode,
         ...args,
       ]),
       displayCommand: buildCommandString([suite.id, 'run', ...args]),
@@ -975,12 +1055,9 @@ function prepareManagedSuiteRun(
     translatedArgs.push('--n-concurrent', String(defaultConcurrency));
   }
 
-  const cliEntry = process.argv[1]?.trim();
-  if (!cliEntry) return null;
   const promptMode = 'none';
   const internalArgs = [
-    quoteShellArg(process.execPath),
-    quoteShellArg(path.resolve(cliEntry)),
+    ...resolveInternalEvalLauncherCommandArgs().map(quoteShellArg),
     '__eval-terminal-bench-native',
     '--install-dir',
     quoteShellArg(getManagedSuiteInstallDir(suite, dataDir)),
@@ -1013,6 +1090,18 @@ function prepareManagedSuiteRun(
     displayCommand: buildCommandString([suite.id, 'run', ...args]),
     cwd: dataDir,
   };
+}
+
+function resolveLocomoAgentMode(
+  profile: EvalProfile,
+  workspaceModeExplicit: boolean,
+): LocomoAgentMode {
+  if (!workspaceModeExplicit) {
+    return 'conversation-fresh';
+  }
+  return profile.workspaceMode === 'fresh-agent'
+    ? 'fresh-request'
+    : 'current-agent';
 }
 
 function quoteShellArg(value: string): string {
@@ -1477,74 +1566,282 @@ function readLocomoNativeSummary(
   if (!fs.existsSync(resultPath)) return null;
   try {
     const parsed = JSON.parse(fs.readFileSync(resultPath, 'utf-8')) as {
+      mode?: unknown;
       dataset?: unknown;
+      model?: unknown;
       budgetTokens?: unknown;
-      topK?: unknown;
       sampleCount?: unknown;
-      requestedMode?: unknown;
-      modes?: Record<
+      questionCount?: unknown;
+      overallScore?: unknown;
+      contextF1?: unknown;
+      predictionsPath?: unknown;
+      tokenUsage?: {
+        promptTokens?: unknown;
+        completionTokens?: unknown;
+        totalTokens?: unknown;
+        responsesWithUsage?: unknown;
+      };
+      categories?: Record<
         string,
         {
-          overallF1?: unknown;
-          overallHitRate?: unknown;
-          totalQuestions?: unknown;
+          meanScore?: unknown;
+          questionCount?: unknown;
+          contextF1?: unknown;
         }
       >;
     };
-    const modes = Object.fromEntries(
-      Object.entries(parsed.modes || {}).map(([mode, value]) => [
-        mode,
+    const categories = Object.fromEntries(
+      Object.entries(parsed.categories || {}).map(([category, value]) => [
+        category,
         {
-          overallF1:
-            typeof value?.overallF1 === 'number' &&
-            Number.isFinite(value.overallF1)
-              ? value.overallF1
+          meanScore:
+            typeof value?.meanScore === 'number' &&
+            Number.isFinite(value.meanScore)
+              ? value.meanScore
               : 0,
-          overallHitRate:
-            typeof value?.overallHitRate === 'number' &&
-            Number.isFinite(value.overallHitRate)
-              ? value.overallHitRate
+          questionCount:
+            typeof value?.questionCount === 'number' &&
+            Number.isFinite(value.questionCount)
+              ? value.questionCount
               : 0,
-          totalQuestions:
-            typeof value?.totalQuestions === 'number' &&
-            Number.isFinite(value.totalQuestions)
-              ? value.totalQuestions
-              : 0,
+          contextF1:
+            typeof value?.contextF1 === 'number' &&
+            Number.isFinite(value.contextF1)
+              ? value.contextF1
+              : null,
         },
       ]),
-    ) as Record<string, LocomoNativeModeAggregate>;
+    ) as Record<string, LocomoNativeCategoryAggregate>;
+    const tokenUsage =
+      parsed.tokenUsage &&
+      typeof parsed.tokenUsage === 'object' &&
+      typeof parsed.tokenUsage.promptTokens === 'number' &&
+      Number.isFinite(parsed.tokenUsage.promptTokens) &&
+      typeof parsed.tokenUsage.completionTokens === 'number' &&
+      Number.isFinite(parsed.tokenUsage.completionTokens) &&
+      typeof parsed.tokenUsage.totalTokens === 'number' &&
+      Number.isFinite(parsed.tokenUsage.totalTokens) &&
+      typeof parsed.tokenUsage.responsesWithUsage === 'number' &&
+      Number.isFinite(parsed.tokenUsage.responsesWithUsage)
+        ? {
+            promptTokens: parsed.tokenUsage.promptTokens,
+            completionTokens: parsed.tokenUsage.completionTokens,
+            totalTokens: parsed.tokenUsage.totalTokens,
+            responsesWithUsage: parsed.tokenUsage.responsesWithUsage,
+          }
+        : null;
     return {
       jobDir,
       resultPath,
+      predictionsPath:
+        typeof parsed.predictionsPath === 'string'
+          ? parsed.predictionsPath
+          : null,
+      mode: parsed.mode === 'retrieval' ? 'retrieval' : 'qa',
       dataset: typeof parsed.dataset === 'string' ? parsed.dataset : null,
+      model: typeof parsed.model === 'string' ? parsed.model : null,
       budgetTokens:
         typeof parsed.budgetTokens === 'number' &&
         Number.isFinite(parsed.budgetTokens)
           ? parsed.budgetTokens
-          : null,
-      topK:
-        typeof parsed.topK === 'number' && Number.isFinite(parsed.topK)
-          ? parsed.topK
           : null,
       sampleCount:
         typeof parsed.sampleCount === 'number' &&
         Number.isFinite(parsed.sampleCount)
           ? parsed.sampleCount
           : null,
-      requestedMode:
-        typeof parsed.requestedMode === 'string' ? parsed.requestedMode : null,
-      modes,
+      questionCount:
+        typeof parsed.questionCount === 'number' &&
+        Number.isFinite(parsed.questionCount)
+          ? parsed.questionCount
+          : null,
+      overallScore:
+        typeof parsed.overallScore === 'number' &&
+        Number.isFinite(parsed.overallScore)
+          ? parsed.overallScore
+          : null,
+      contextF1:
+        typeof parsed.contextF1 === 'number' &&
+        Number.isFinite(parsed.contextF1)
+          ? parsed.contextF1
+          : null,
+      categories,
+      tokenUsage,
     };
   } catch {
     return null;
   }
 }
 
-function formatLocomoModeValue(
-  value: LocomoNativeModeAggregate | undefined,
+function readLocomoNativeProgress(
+  meta: EvalRunMeta,
+): LocomoNativeProgress | null {
+  const jobDir = readLocomoJobDir(meta);
+  if (!jobDir) return null;
+  const progressPath = path.join(jobDir, 'progress.json');
+  if (!fs.existsSync(progressPath)) return null;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(progressPath, 'utf-8')) as {
+      mode?: unknown;
+      dataset?: unknown;
+      model?: unknown;
+      budgetTokens?: unknown;
+      sampleCount?: unknown;
+      completedSampleCount?: unknown;
+      questionCount?: unknown;
+      completedQuestionCount?: unknown;
+      overallScore?: unknown;
+      contextF1?: unknown;
+      currentSampleId?: unknown;
+      currentSampleQuestionCount?: unknown;
+      currentSampleQuestionTotal?: unknown;
+      predictionsPath?: unknown;
+      resultPath?: unknown;
+      tokenUsage?: {
+        promptTokens?: unknown;
+        completionTokens?: unknown;
+        totalTokens?: unknown;
+        responsesWithUsage?: unknown;
+      };
+      categories?: Record<
+        string,
+        {
+          meanScore?: unknown;
+          questionCount?: unknown;
+          contextF1?: unknown;
+        }
+      >;
+    };
+    const categories = Object.fromEntries(
+      Object.entries(parsed.categories || {}).map(([category, value]) => [
+        category,
+        {
+          meanScore:
+            typeof value?.meanScore === 'number' &&
+            Number.isFinite(value.meanScore)
+              ? value.meanScore
+              : 0,
+          questionCount:
+            typeof value?.questionCount === 'number' &&
+            Number.isFinite(value.questionCount)
+              ? value.questionCount
+              : 0,
+          contextF1:
+            typeof value?.contextF1 === 'number' &&
+            Number.isFinite(value.contextF1)
+              ? value.contextF1
+              : null,
+        },
+      ]),
+    ) as Record<string, LocomoNativeCategoryAggregate>;
+    const tokenUsage =
+      parsed.tokenUsage &&
+      typeof parsed.tokenUsage === 'object' &&
+      typeof parsed.tokenUsage.promptTokens === 'number' &&
+      Number.isFinite(parsed.tokenUsage.promptTokens) &&
+      typeof parsed.tokenUsage.completionTokens === 'number' &&
+      Number.isFinite(parsed.tokenUsage.completionTokens) &&
+      typeof parsed.tokenUsage.totalTokens === 'number' &&
+      Number.isFinite(parsed.tokenUsage.totalTokens) &&
+      typeof parsed.tokenUsage.responsesWithUsage === 'number' &&
+      Number.isFinite(parsed.tokenUsage.responsesWithUsage)
+        ? {
+            promptTokens: parsed.tokenUsage.promptTokens,
+            completionTokens: parsed.tokenUsage.completionTokens,
+            totalTokens: parsed.tokenUsage.totalTokens,
+            responsesWithUsage: parsed.tokenUsage.responsesWithUsage,
+          }
+        : null;
+    return {
+      jobDir,
+      progressPath,
+      resultPath:
+        typeof parsed.resultPath === 'string'
+          ? parsed.resultPath
+          : path.join(jobDir, 'result.json'),
+      predictionsPath:
+        typeof parsed.predictionsPath === 'string'
+          ? parsed.predictionsPath
+          : null,
+      mode: parsed.mode === 'retrieval' ? 'retrieval' : 'qa',
+      dataset: typeof parsed.dataset === 'string' ? parsed.dataset : null,
+      model: typeof parsed.model === 'string' ? parsed.model : null,
+      budgetTokens:
+        typeof parsed.budgetTokens === 'number' &&
+        Number.isFinite(parsed.budgetTokens)
+          ? parsed.budgetTokens
+          : null,
+      sampleCount:
+        typeof parsed.sampleCount === 'number' &&
+        Number.isFinite(parsed.sampleCount)
+          ? parsed.sampleCount
+          : null,
+      completedSampleCount:
+        typeof parsed.completedSampleCount === 'number' &&
+        Number.isFinite(parsed.completedSampleCount)
+          ? parsed.completedSampleCount
+          : null,
+      questionCount:
+        typeof parsed.questionCount === 'number' &&
+        Number.isFinite(parsed.questionCount)
+          ? parsed.questionCount
+          : null,
+      completedQuestionCount:
+        typeof parsed.completedQuestionCount === 'number' &&
+        Number.isFinite(parsed.completedQuestionCount)
+          ? parsed.completedQuestionCount
+          : null,
+      overallScore:
+        typeof parsed.overallScore === 'number' &&
+        Number.isFinite(parsed.overallScore)
+          ? parsed.overallScore
+          : null,
+      contextF1:
+        typeof parsed.contextF1 === 'number' &&
+        Number.isFinite(parsed.contextF1)
+          ? parsed.contextF1
+          : null,
+      currentSampleId:
+        typeof parsed.currentSampleId === 'string'
+          ? parsed.currentSampleId
+          : null,
+      currentSampleQuestionCount:
+        typeof parsed.currentSampleQuestionCount === 'number' &&
+        Number.isFinite(parsed.currentSampleQuestionCount)
+          ? parsed.currentSampleQuestionCount
+          : null,
+      currentSampleQuestionTotal:
+        typeof parsed.currentSampleQuestionTotal === 'number' &&
+        Number.isFinite(parsed.currentSampleQuestionTotal)
+          ? parsed.currentSampleQuestionTotal
+          : null,
+      categories,
+      tokenUsage,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function formatLocomoCategoryValue(
+  category: string,
+  value: LocomoNativeCategoryAggregate | undefined,
+  mode: 'qa' | 'retrieval',
 ): string | null {
   if (!value) return null;
-  return `Hit ${value.overallHitRate.toFixed(3)} | F1 ${value.overallF1.toFixed(3)} | Q ${value.totalQuestions}`;
+  if (mode === 'retrieval') {
+    return `Category ${category} | Hit ${value.meanScore.toFixed(3)} | F1 ${(
+      value.contextF1 ?? 0
+    ).toFixed(3)} | Q ${value.questionCount}`;
+  }
+  return `Category ${category} | Score ${value.meanScore.toFixed(3)} | Q ${value.questionCount}`;
+}
+
+function formatLocomoTokenUsage(
+  value: LocomoNativeTokenUsage | null | undefined,
+): string | null {
+  if (!value) return null;
+  return `${value.totalTokens} total (${value.promptTokens} prompt + ${value.completionTokens} completion)`;
 }
 
 function describeManagedSuiteRunLifecycle(
@@ -2506,6 +2803,10 @@ function renderManagedSuiteStatus(
     suite.id === 'locomo' && latestRun
       ? readLocomoNativeSummary(latestRun)
       : null;
+  const latestLocomoProgress =
+    suite.id === 'locomo' && latestRun
+      ? readLocomoNativeProgress(latestRun)
+      : null;
   const setupFailure =
     !installed && latestSetup ? describeRunFailureReason(latestSetup) : null;
 
@@ -2539,13 +2840,113 @@ function renderManagedSuiteStatus(
           `Stderr: ${latestRun.stderrPath}`,
           ...(latestLocomoSummary
             ? [
+                `Mode: ${latestLocomoSummary.mode}`,
                 `Samples: ${latestLocomoSummary.sampleCount ?? 'unknown'}`,
+                `Questions: ${latestLocomoSummary.questionCount ?? 'unknown'}`,
                 `Budget: ${latestLocomoSummary.budgetTokens ?? 'unknown'}`,
-                `Top K: ${latestLocomoSummary.topK ?? 'unknown'}`,
-                ...Object.entries(latestLocomoSummary.modes).map(
-                  ([mode, value]) =>
-                    `${mode}: ${formatLocomoModeValue(value) || 'n/a'}`,
-                ),
+                `${
+                  latestLocomoSummary.mode === 'retrieval'
+                    ? 'Hit rate'
+                    : 'Overall score'
+                }: ${
+                  latestLocomoSummary.overallScore != null
+                    ? latestLocomoSummary.overallScore.toFixed(3)
+                    : 'unknown'
+                }`,
+                ...(latestLocomoSummary.mode === 'retrieval'
+                  ? [
+                      `Context F1: ${
+                        latestLocomoSummary.contextF1 != null
+                          ? latestLocomoSummary.contextF1.toFixed(3)
+                          : 'unknown'
+                      }`,
+                    ]
+                  : []),
+                ...Object.entries(latestLocomoSummary.categories)
+                  .sort(([left], [right]) => Number(left) - Number(right))
+                  .map(
+                    ([category, value]) =>
+                      `cat${category}: ${
+                        formatLocomoCategoryValue(
+                          category,
+                          value,
+                          latestLocomoSummary.mode,
+                        ) || 'n/a'
+                      }`,
+                  ),
+                ...(latestLocomoSummary.tokenUsage
+                  ? [
+                      `Tokens: ${formatLocomoTokenUsage(
+                        latestLocomoSummary.tokenUsage,
+                      )}`,
+                    ]
+                  : []),
+                ...(latestLocomoSummary.predictionsPath
+                  ? [`Predictions: ${latestLocomoSummary.predictionsPath}`]
+                  : []),
+              ]
+            : []),
+          ...(!latestLocomoSummary && latestLocomoProgress
+            ? [
+                `Mode: ${latestLocomoProgress.mode}`,
+                `Samples: ${latestLocomoProgress.sampleCount ?? 'unknown'}`,
+                `Completed samples: ${
+                  latestLocomoProgress.completedSampleCount ?? 'unknown'
+                }/${latestLocomoProgress.sampleCount ?? '?'}`,
+                `Questions: ${
+                  latestLocomoProgress.completedQuestionCount ?? 'unknown'
+                }/${latestLocomoProgress.questionCount ?? '?'}`,
+                `Budget: ${latestLocomoProgress.budgetTokens ?? 'unknown'}`,
+                `${
+                  latestLocomoProgress.mode === 'retrieval'
+                    ? 'Hit rate so far'
+                    : 'Score so far'
+                }: ${
+                  latestLocomoProgress.overallScore != null
+                    ? latestLocomoProgress.overallScore.toFixed(3)
+                    : 'unknown'
+                }`,
+                ...(latestLocomoProgress.mode === 'retrieval'
+                  ? [
+                      `Context F1 so far: ${
+                        latestLocomoProgress.contextF1 != null
+                          ? latestLocomoProgress.contextF1.toFixed(3)
+                          : 'unknown'
+                      }`,
+                    ]
+                  : []),
+                ...(latestLocomoProgress.currentSampleId
+                  ? [
+                      `Current sample: ${latestLocomoProgress.currentSampleId}`,
+                      ...(latestLocomoProgress.currentSampleQuestionCount !=
+                        null &&
+                      latestLocomoProgress.currentSampleQuestionTotal != null
+                        ? [
+                            `Current sample questions: ${latestLocomoProgress.currentSampleQuestionCount}/${latestLocomoProgress.currentSampleQuestionTotal}`,
+                          ]
+                        : []),
+                    ]
+                  : []),
+                ...Object.entries(latestLocomoProgress.categories)
+                  .sort(([left], [right]) => Number(left) - Number(right))
+                  .map(
+                    ([category, value]) =>
+                      `cat${category}: ${
+                        formatLocomoCategoryValue(
+                          category,
+                          value,
+                          latestLocomoProgress.mode,
+                        ) || 'n/a'
+                      }`,
+                  ),
+                ...(latestLocomoProgress.tokenUsage
+                  ? [
+                      `Tokens: ${formatLocomoTokenUsage(
+                        latestLocomoProgress.tokenUsage,
+                      )}`,
+                    ]
+                  : []),
+                `Progress JSON: ${latestLocomoProgress.progressPath}`,
               ]
             : []),
           ...(latestTerminalBenchSummary
@@ -2594,6 +2995,10 @@ function renderManagedSuiteResults(
   const locomoSummary =
     suite.id === 'locomo' && latestJob.operation === 'run'
       ? readLocomoNativeSummary(latestJob)
+      : null;
+  const locomoProgress =
+    suite.id === 'locomo' && latestJob.operation === 'run'
+      ? readLocomoNativeProgress(latestJob)
       : null;
   if (suite.id === 'terminal-bench-2.0') {
     const overviewSection = renderKeyValueSection('Overview', [
@@ -2657,34 +3062,109 @@ function renderManagedSuiteResults(
     );
   }
   if (suite.id === 'locomo') {
+    const locomoData = locomoSummary || locomoProgress;
     const overviewSection = renderKeyValueSection('Overview', [
+      [
+        'Evaluated model',
+        locomoData?.mode !== 'retrieval'
+          ? latestJob.baseModel || latestJob.model
+          : null,
+      ],
       ['Harness', `HybridClaw v${resolveHarnessVersion()}`],
       ['Status', describeManagedSuiteRunLifecycle(latestJob)],
-      ['Dataset', locomoSummary?.dataset || null],
-      ['Samples', locomoSummary?.sampleCount ?? null],
-      ['Budget', locomoSummary?.budgetTokens ?? null],
-      ['Top K', locomoSummary?.topK ?? null],
-      ['Mode', locomoSummary?.requestedMode || null],
+      ['Mode', locomoData?.mode || null],
+      ['Dataset', locomoData?.dataset || null],
+      ['Samples', locomoData?.sampleCount ?? null],
+      [
+        'Questions',
+        locomoSummary
+          ? locomoSummary.questionCount
+          : locomoProgress
+            ? `${locomoProgress.completedQuestionCount ?? '?'}/${locomoProgress.questionCount ?? '?'}`
+            : null,
+      ],
+      [
+        'Completed samples',
+        !locomoSummary && locomoProgress
+          ? `${locomoProgress.completedSampleCount ?? '?'}/${locomoProgress.sampleCount ?? '?'}`
+          : null,
+      ],
+      ['Budget', locomoData?.budgetTokens ?? null],
+      [
+        locomoSummary
+          ? locomoData?.mode === 'retrieval'
+            ? 'Hit rate'
+            : 'Overall score'
+          : locomoData?.mode === 'retrieval'
+            ? 'Hit rate so far'
+            : 'Score so far',
+        locomoData?.overallScore ?? null,
+      ],
+      [
+        locomoSummary ? 'Context F1' : 'Context F1 so far',
+        locomoData?.mode === 'retrieval'
+          ? (locomoData?.contextF1 ?? null)
+          : null,
+      ],
+      [
+        'Current sample',
+        !locomoSummary && locomoProgress
+          ? locomoProgress.currentSampleId
+          : null,
+      ],
     ]);
-    const modeSection = renderKeyValueSection(
-      'Modes',
-      Object.entries(locomoSummary?.modes || {})
-        .sort(([left], [right]) => left.localeCompare(right))
-        .map(([mode, value]) => [mode, formatLocomoModeValue(value)] as const),
+    const categorySection = renderKeyValueSection(
+      locomoSummary ? 'Categories' : 'Categories So Far',
+      Object.entries(locomoData?.categories || {})
+        .sort(([left], [right]) => Number(left) - Number(right))
+        .map(
+          ([category, value]) =>
+            [
+              `cat${category}`,
+              formatLocomoCategoryValue(
+                category,
+                value,
+                locomoData?.mode || 'qa',
+              ),
+            ] as const,
+        ),
     );
+    const usageSection = renderKeyValueSection('Usage', [
+      ['Tokens', formatLocomoTokenUsage(locomoData?.tokenUsage)],
+      [
+        'Current sample questions',
+        !locomoSummary &&
+        locomoProgress &&
+        locomoProgress.currentSampleQuestionCount != null &&
+        locomoProgress.currentSampleQuestionTotal != null
+          ? `${locomoProgress.currentSampleQuestionCount}/${locomoProgress.currentSampleQuestionTotal}`
+          : null,
+      ],
+    ]);
     const runSection = renderKeyValueSection('Run', [
       ['Run ID', latestJob.runId],
       ['Command', latestJob.displayCommand || latestJob.command],
     ]);
     const pathsSection = renderKeyValueSection('Paths', [
-      ['Job dir', locomoSummary?.jobDir || null],
-      ['Result JSON', locomoSummary?.resultPath || null],
+      ['Job dir', locomoData?.jobDir || null],
+      [
+        'Progress JSON',
+        !locomoSummary && locomoProgress ? locomoProgress.progressPath : null,
+      ],
+      ['Predictions JSON', locomoData?.predictionsPath || null],
+      ['Result JSON', locomoData?.resultPath || null],
       ['Stdout', latestJob.stdoutPath],
       ['Stderr', latestJob.stderrPath],
     ]);
     return infoResult(
       `${suite.title} Results`,
-      joinSections([overviewSection, modeSection, runSection, pathsSection]),
+      joinSections([
+        overviewSection,
+        categorySection,
+        usageSection,
+        runSection,
+        pathsSection,
+      ]),
     );
   }
   return infoResult(
@@ -2831,6 +3311,7 @@ async function handleManagedSuiteRun(params: {
   effectiveAgentId?: string;
   channelId?: string;
   args: string[];
+  workspaceModeExplicit: boolean;
 }): Promise<GatewayCommandResult> {
   if (!isManagedSuiteInstalled(params.suite, params.dataDir)) {
     return errorResult(
@@ -2854,6 +3335,7 @@ async function handleManagedSuiteRun(params: {
     params.env,
     params.effectiveAgentId || 'main',
     params.args,
+    params.workspaceModeExplicit,
   );
   if (!prepared) {
     return errorResult(
@@ -2941,6 +3423,7 @@ async function handleManagedSuiteCommand(params: {
   channelId?: string;
   subcommand?: string;
   args?: string[];
+  workspaceModeExplicit: boolean;
 }): Promise<GatewayCommandResult> {
   const subcommand = String(params.subcommand || '')
     .trim()
@@ -2981,6 +3464,7 @@ async function handleManagedSuiteCommand(params: {
         effectiveAgentId: params.effectiveAgentId,
         channelId: params.channelId,
         args: params.args || [],
+        workspaceModeExplicit: params.workspaceModeExplicit,
       });
     case 'status':
       return infoResult(
@@ -3106,6 +3590,13 @@ function parseEvalProfileFlag(
   }
 }
 
+function isWorkspaceModeFlag(arg: string): boolean {
+  const normalized = String(arg || '')
+    .trim()
+    .toLowerCase();
+  return normalized === '--current-agent' || normalized === '--fresh-agent';
+}
+
 function finalizeEvalProfile(profile: EvalProfile): EvalProfile {
   if (profile.workspaceMode === 'fresh-agent') {
     delete profile.agentId;
@@ -3118,13 +3609,9 @@ function finalizeEvalProfile(profile: EvalProfile): EvalProfile {
 function parseEvalAction(
   args: string[],
   effectiveAgentId?: string,
-): {
-  action: string;
-  profile: EvalProfile;
-  commandArgs: string[];
-  error?: string;
-} {
+): ParsedEvalAction {
   const profile = buildDefaultEvalProfile(effectiveAgentId);
+  let workspaceModeExplicit = false;
   if (
     args.length === 1 &&
     ['help', '--help', '-h'].includes(
@@ -3137,13 +3624,23 @@ function parseEvalAction(
       action: 'help',
       profile: finalizeEvalProfile(profile),
       commandArgs: [],
+      workspaceModeExplicit,
     };
   }
   let index = 0;
 
   while (index < args.length && args[index]?.startsWith('--')) {
     const error = parseEvalProfileFlag(args[index], profile);
-    if (error) return { action: '', profile, commandArgs: [], error };
+    if (error) {
+      return {
+        action: '',
+        profile,
+        commandArgs: [],
+        workspaceModeExplicit,
+        error,
+      };
+    }
+    workspaceModeExplicit ||= isWorkspaceModeFlag(args[index] || '');
     index += 1;
   }
 
@@ -3155,6 +3652,7 @@ function parseEvalAction(
       action: '',
       profile: finalizeEvalProfile(profile),
       commandArgs: [],
+      workspaceModeExplicit,
     };
   }
   const rawAction = String(args[index] || '').trim();
@@ -3165,6 +3663,7 @@ function parseEvalAction(
       action: '',
       profile: finalizeEvalProfile(profile),
       commandArgs: [],
+      workspaceModeExplicit,
       error:
         'Use `/eval <shell command...>` instead of `/eval run <shell command...>`.',
     };
@@ -3177,6 +3676,7 @@ function parseEvalAction(
           action: 'run',
           profile: finalizeEvalProfile(profile),
           commandArgs: [rawAction, ...args.slice(index)],
+          workspaceModeExplicit,
         };
       }
       const error = parseEvalProfileFlag(args[index], profile);
@@ -3185,8 +3685,10 @@ function parseEvalAction(
           action: 'run',
           profile: finalizeEvalProfile(profile),
           commandArgs: [rawAction, ...args.slice(index)],
+          workspaceModeExplicit,
         };
       }
+      workspaceModeExplicit ||= isWorkspaceModeFlag(args[index] || '');
       index += 1;
     }
 
@@ -3194,6 +3696,7 @@ function parseEvalAction(
       action,
       profile: finalizeEvalProfile(profile),
       commandArgs: [],
+      workspaceModeExplicit,
     };
   }
 
@@ -3201,6 +3704,7 @@ function parseEvalAction(
     action: 'run',
     profile: finalizeEvalProfile(profile),
     commandArgs: [rawAction, ...args.slice(index)],
+    workspaceModeExplicit,
   };
 }
 
@@ -3265,6 +3769,7 @@ export async function handleEvalCommand(
           channelId: params.channelId,
           subcommand: managedSubcommand,
           args: parsed.commandArgs.slice(2),
+          workspaceModeExplicit: parsed.workspaceModeExplicit,
         });
       }
     }
@@ -3327,5 +3832,6 @@ export async function handleEvalCommand(
     effectiveAgentId: params.effectiveAgentId,
     channelId: params.channelId,
     subcommand: 'help',
+    workspaceModeExplicit: parsed.workspaceModeExplicit,
   });
 }

--- a/src/evals/eval-command.ts
+++ b/src/evals/eval-command.ts
@@ -567,8 +567,8 @@ function renderKeyValueSection(
 }
 
 const ANSI_RESET = '\x1b[0m';
-const ANSI_INVERSE = '\x1b[7m';
-const ANSI_BEST_VALUE = '\x1b[1;93m';
+const ANSI_METRIC_VALUE = '\x1b[93m';
+const ANSI_BEST_VALUE = '\x1b[30;103m';
 
 function stripAnsi(value: string): string {
   let output = '';
@@ -597,24 +597,41 @@ function padAnsiEnd(value: string, width: number): string {
   return `${value}${' '.repeat(missing)}`;
 }
 
+function truncateTextEnd(value: string, width: number): string {
+  if (width <= 0) {
+    return '';
+  }
+  const characters = [...String(value || '')];
+  if (characters.length <= width) {
+    return value;
+  }
+  if (width === 1) {
+    return '…';
+  }
+  return `${characters.slice(0, width - 1).join('')}…`;
+}
+
+function resolveEvalRenderColumns(): number {
+  return Math.max(72, process.stdout.columns || 120);
+}
+
 function styleLocomoMatrixCell(
   value: string,
   options?: {
-    inverse?: boolean;
     highlight?: boolean;
+    metric?: boolean;
   },
 ): string {
-  const codes: string[] = [];
-  if (options?.inverse) {
-    codes.push(ANSI_INVERSE);
-  }
   if (options?.highlight) {
-    codes.push(ANSI_BEST_VALUE);
+    return `${ANSI_BEST_VALUE}${value}${ANSI_RESET}`;
   }
-  if (codes.length === 0) {
+  if (options?.metric) {
+    return `${ANSI_METRIC_VALUE}${value}${ANSI_RESET}`;
+  }
+  if (!options) {
     return value;
   }
-  return `${codes.join('')}${value}${ANSI_RESET}`;
+  return value;
 }
 
 function renderSectionCard(title: string, lines: string[]): string {
@@ -2273,77 +2290,91 @@ function renderLocomoVariantComparisonSection(
     highlightStats[0]?.max != null && Number.isFinite(highlightStats[0].max)
       ? highlightStats[0].max
       : null;
-  const rows = variants.map((variant) => {
-    const metrics = [
-      variant.overallScore,
-      variant.contextF1 ?? null,
-      variant.categories['1']?.meanScore ?? null,
-      variant.categories['2']?.meanScore ?? null,
-      variant.categories['3']?.meanScore ?? null,
-      variant.categories['4']?.meanScore ?? null,
-      variant.categories['5']?.meanScore ?? null,
-    ];
-    return [
-      variant.label,
-      ...metrics.map((metric, index) => {
-        const formatted = formatLocomoMatrixMetric(metric);
-        const highlight = highlightStats[index]?.shouldHighlight;
-        const max = highlightStats[index]?.max;
-        if (
-          !highlight ||
-          metric == null ||
-          max == null ||
-          !Number.isFinite(metric) ||
-          !areLocomoMetricValuesEqual(metric, max)
-        ) {
-          return formatted;
-        }
-        return `${formatted}*`;
-      }),
-    ];
-  });
   const header = ['Variant', 'HitRate', 'F1', 'C1', 'C2', 'C3', 'C4', 'C5'];
-  const widths = header.map((entry, index) =>
-    Math.max(
-      visibleLength(entry),
-      ...rows.map((row) => visibleLength(String(row[index] || ''))),
+  const metricColumns = variants.map((variant) => [
+    variant.overallScore,
+    variant.contextF1 ?? null,
+    variant.categories['1']?.meanScore ?? null,
+    variant.categories['2']?.meanScore ?? null,
+    variant.categories['3']?.meanScore ?? null,
+    variant.categories['4']?.meanScore ?? null,
+    variant.categories['5']?.meanScore ?? null,
+  ]);
+  const metricHighlightMatrix = metricColumns.map((metrics) =>
+    metrics.map(
+      (metric, index) =>
+        highlightStats[index]?.shouldHighlight === true &&
+        metric != null &&
+        Number.isFinite(metric) &&
+        areLocomoMetricValuesEqual(metric, highlightStats[index]?.max ?? NaN),
     ),
   );
-  return renderSectionCard(title, [
-    header.map((entry, index) => padAnsiEnd(entry, widths[index])).join('  '),
-    widths.map((width) => '-'.repeat(width)).join('  '),
-    ...rows.map((row, rowIndex) => {
-      const bestHitRateStat = highlightStats[0];
-      const isBestOverall =
-        bestHitRate != null &&
-        Number.isFinite(variants[rowIndex]?.overallScore) &&
-        areLocomoMetricValuesEqual(
-          variants[rowIndex]?.overallScore ?? 0,
-          bestHitRate,
-        );
-      return row
-        .map((entry, index) =>
-          styleLocomoMatrixCell(
-            padAnsiEnd(String(entry), widths[index]),
-            index === 0
-              ? { inverse: isBestOverall }
-              : {
-                  inverse: isBestOverall,
-                  highlight:
-                    bestHitRateStat != null &&
-                    index > 0 &&
-                    highlightStats[index - 1]?.shouldHighlight === true &&
-                    typeof entry === 'string' &&
-                    !entry.startsWith('-') &&
-                    areLocomoMetricValuesEqual(
-                      Number.parseFloat(entry),
-                      highlightStats[index - 1]?.max ?? Number.NaN,
-                    ),
-                },
-          ),
-        )
-        .join('  ');
+  const metricStrings = metricColumns.map((metrics, rowIndex) =>
+    metrics.map((metric, index) => {
+      const formatted = formatLocomoMatrixMetric(metric);
+      return metricHighlightMatrix[rowIndex]?.[index]
+        ? `${formatted}*`
+        : formatted;
     }),
+  );
+  const metricWidths = header
+    .slice(1)
+    .map((entry, index) =>
+      Math.max(
+        visibleLength(entry),
+        ...metricStrings.map((row) => visibleLength(row[index] || '')),
+      ),
+    );
+  const separator = '  ';
+  const totalMetricWidth =
+    metricWidths.reduce((total, width) => total + width, 0) +
+    separator.length * metricWidths.length;
+  const maxContentWidth = Math.max(60, resolveEvalRenderColumns() - 6);
+  const maxVariantWidth = Math.max(
+    visibleLength(header[0]),
+    ...variants.map((variant) => visibleLength(variant.label)),
+  );
+  const variantWidth = Math.max(
+    visibleLength(header[0]),
+    Math.min(maxVariantWidth, maxContentWidth - totalMetricWidth),
+  );
+  const rows = variants.map((variant, rowIndex) => {
+    const metrics = metricColumns[rowIndex];
+    const isBestOverall =
+      bestHitRate != null &&
+      Number.isFinite(variant.overallScore) &&
+      areLocomoMetricValuesEqual(variant.overallScore, bestHitRate);
+    const variantLabel = padAnsiEnd(
+      truncateTextEnd(variant.label, variantWidth),
+      variantWidth,
+    );
+    const metricCells = metrics.map((_metric, index) => {
+      const formatted = padAnsiEnd(
+        metricStrings[rowIndex][index] || '-',
+        metricWidths[index],
+      );
+      const highlight = metricHighlightMatrix[rowIndex]?.[index] === true;
+      return styleLocomoMatrixCell(formatted, {
+        highlight,
+        metric: true,
+      });
+    });
+    return [
+      styleLocomoMatrixCell(variantLabel, { highlight: isBestOverall }),
+      ...metricCells,
+    ];
+  });
+  return renderSectionCard(title, [
+    [
+      padAnsiEnd(header[0], variantWidth),
+      ...header
+        .slice(1)
+        .map((entry, index) => padAnsiEnd(entry, metricWidths[index])),
+    ].join(separator),
+    [variantWidth, ...metricWidths]
+      .map((width) => '-'.repeat(width))
+      .join(separator),
+    ...rows.map((row) => row.join(separator)),
   ]);
 }
 

--- a/src/evals/locomo-native.ts
+++ b/src/evals/locomo-native.ts
@@ -14,8 +14,10 @@ import {
 } from './eval-profile.js';
 import { scoreOfficialLocomoAnswer } from './locomo-official-scoring.js';
 
-const LOCOMO_DATASET_URL =
-  'https://raw.githubusercontent.com/snap-research/locomo/main/data/locomo10.json';
+const LOCOMO_DATASET_COMMIT = '3eb6f2c585f5e1699204e3c3bdf7adc5c28cb376';
+const LOCOMO_DATASET_URL = `https://raw.githubusercontent.com/snap-research/locomo/${LOCOMO_DATASET_COMMIT}/data/locomo10.json`;
+const LOCOMO_DATASET_SHA256 =
+  '79fa87e90f04081343b8c8debecb80a9a6842b76a7aa537dc9fdf651ea698ff4';
 const LOCOMO_DATASET_FILENAME = 'locomo10.json';
 const LOCOMO_SETUP_MARKER = '.hybridclaw-setup-ok';
 const DEFAULT_TOKEN_BUDGET = 4000;
@@ -321,11 +323,13 @@ async function runSetup(options: LocomoRunnerOptions): Promise<void> {
         `Failed to download LOCOMO dataset: HTTP ${response.status}`,
       );
     }
-    const raw = await response.text();
+    const rawBuffer = Buffer.from(await response.arrayBuffer());
+    verifyDownloadedDataset(rawBuffer, response.url);
+    const raw = rawBuffer.toString('utf-8');
     if (!raw.trim().startsWith('[')) {
       throw new Error('Downloaded LOCOMO dataset is not valid JSON.');
     }
-    fs.writeFileSync(datasetPath, raw, 'utf-8');
+    fs.writeFileSync(datasetPath, rawBuffer);
   } else {
     console.log(`Dataset already present at ${datasetPath}`);
   }
@@ -345,7 +349,9 @@ async function runEvaluation(options: LocomoRunnerOptions): Promise<void> {
     !fs.existsSync(getMarkerPath(options.installDir)) ||
     !fs.existsSync(datasetPath)
   ) {
-    throw new Error('LOCOMO is not set up. Run `/eval locomo setup` first.');
+    throw new Error(
+      'LOCOMO is not set up. Run `setup` first, or use `/eval locomo setup`.',
+    );
   }
 
   const runtime = readGatewayRuntime();
@@ -771,6 +777,21 @@ function loadSamples(datasetPath: string): LocomoSample[] {
     throw new Error(`Expected LOCOMO dataset array in ${datasetPath}.`);
   }
   return parsed as LocomoSample[];
+}
+
+function verifyDownloadedDataset(
+  rawBuffer: Uint8Array,
+  responseUrl: string | null | undefined,
+): void {
+  if (!responseUrl || responseUrl.trim() !== LOCOMO_DATASET_URL) {
+    return;
+  }
+  const actualSha256 = createHash('sha256').update(rawBuffer).digest('hex');
+  if (actualSha256 !== LOCOMO_DATASET_SHA256) {
+    throw new Error(
+      `Downloaded LOCOMO dataset failed SHA-256 verification (expected ${LOCOMO_DATASET_SHA256}, got ${actualSha256}).`,
+    );
+  }
 }
 
 async function evaluateSample(params: {

--- a/src/evals/locomo-native.ts
+++ b/src/evals/locomo-native.ts
@@ -1,27 +1,54 @@
+import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import { initDatabase, storeSemanticMemory } from '../memory/db.js';
+import { memoryService } from '../memory/memory-service.js';
+import { buildSessionKey } from '../session/session-key.js';
+import type { SemanticMemoryEntry } from '../types/memory.js';
+import type { Session } from '../types/session.js';
 import {
-  getOrCreateSession,
-  initDatabase,
-  recallSemanticMemories,
-  storeSemanticMemory,
-} from '../memory/db.js';
+  buildDefaultEvalProfile,
+  type EvalProfile,
+  encodeEvalProfileModel,
+  parseEvalProfileModel,
+} from './eval-profile.js';
+import { scoreOfficialLocomoAnswer } from './locomo-official-scoring.js';
 
 const LOCOMO_DATASET_URL =
   'https://raw.githubusercontent.com/snap-research/locomo/main/data/locomo10.json';
 const LOCOMO_DATASET_FILENAME = 'locomo10.json';
 const LOCOMO_SETUP_MARKER = '.hybridclaw-setup-ok';
-const EMBEDDING_DIMENSIONS = 128;
 const DEFAULT_TOKEN_BUDGET = 4000;
-const DEFAULT_TOP_K = 20;
+const ANSWER_BUFFER_TOKENS = 64;
+const DEFAULT_OPENAI_BASE_URL = 'http://127.0.0.1:9090/v1';
+const DEFAULT_EVAL_MODEL = 'hybridai/gpt-4.1-mini';
 
-type LocomoMode = 'recent' | 'semantic';
-type LocomoRequestedMode = 'all' | LocomoMode;
+const CONVERSATION_START_PROMPT =
+  'Below is a conversation between two people: {speakerA} and {speakerB}. The conversation takes place over multiple days and the date of each conversation is written at the beginning of the conversation.\n\n';
+
+const QA_PROMPT = `
+Based on the above context, write an answer in the form of a short phrase for the following question. Answer with exact words from the context whenever possible.
+
+Question: {question}
+Short answer:
+`.trim();
+
+const QA_PROMPT_CATEGORY_5 = `
+Based on the above context, answer the following question.
+
+Question: {question}
+Short answer:
+`.trim();
+
+type LocomoOperation = 'setup' | 'run';
+type LocomoEvaluationMode = 'qa' | 'retrieval';
+type LocomoAgentMode = 'conversation-fresh' | 'current-agent' | 'fresh-request';
 
 interface LocomoTurn {
   speaker: string;
   dia_id: string;
   text: string;
+  blip_caption?: string;
 }
 
 interface LocomoQA {
@@ -39,132 +66,122 @@ interface LocomoSample {
 }
 
 interface LocomoRunnerOptions {
-  operation: 'setup' | 'run';
+  operation: LocomoOperation;
   installDir: string;
   budgetTokens: number;
-  requestedMode: LocomoRequestedMode;
   numSamples: number | null;
-  topK: number;
+  maxQuestions: number | null;
+  mode: LocomoEvaluationMode;
+  agentMode: LocomoAgentMode;
 }
 
-interface CategoryAggregate {
-  f1: number;
-  hitRate: number;
+interface LocomoGatewayRuntime {
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+  baseModel: string;
+  profile: EvalProfile;
+}
+
+interface LocomoUsageSummary {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  responsesWithUsage: number;
+}
+
+interface LocomoCategoryAggregate {
+  meanScore: number;
   questionCount: number;
+  contextF1: number | null;
 }
 
-interface ModeAggregate {
-  overallF1: number;
-  overallHitRate: number;
-  totalQuestions: number;
-  byCategory: Record<string, CategoryAggregate>;
+interface LocomoQuestionPrediction {
+  category: number;
+  question: string;
+  answer: string;
+  prediction: string;
+  score: number;
+  evidence: string[];
+  contextF1?: number | null;
+  retrievedSourceMessageIds?: number[];
 }
 
-interface SampleModeSummary {
-  overallF1: number;
-  overallHitRate: number;
-  totalQuestions: number;
-}
-
-interface SampleSummary {
+interface LocomoSamplePrediction {
   sampleId: string;
-  modes: Partial<Record<LocomoMode, SampleModeSummary>>;
+  questionCount: number;
+  meanScore: number;
+  meanContextF1: number | null;
+  qa: LocomoQuestionPrediction[];
 }
 
 interface LocomoRunSummary {
   suite: 'locomo';
+  mode: LocomoEvaluationMode;
   dataset: string;
   generatedAt: string;
+  model: string | null;
   budgetTokens: number;
-  topK: number;
   sampleCount: number;
-  requestedMode: LocomoRequestedMode;
+  questionCount: number;
+  overallScore: number;
+  contextF1: number | null;
   resultPath: string;
-  modes: Partial<Record<LocomoMode, ModeAggregate>>;
-  samples: SampleSummary[];
+  predictionsPath: string;
+  categories: Record<string, LocomoCategoryAggregate>;
+  tokenUsage: LocomoUsageSummary | null;
+  samples: Array<{
+    sampleId: string;
+    questionCount: number;
+    meanScore: number;
+  }>;
 }
 
-interface SemanticSessionRecord {
-  sessionId: string;
-  turns: string[];
+interface LocomoProgressSummary {
+  suite: 'locomo';
+  mode: LocomoEvaluationMode;
+  dataset: string;
+  updatedAt: string;
+  model: string | null;
+  budgetTokens: number;
+  sampleCount: number;
+  completedSampleCount: number;
+  questionCount: number;
+  completedQuestionCount: number;
+  overallScore: number;
+  contextF1: number | null;
+  currentSampleId: string | null;
+  currentSampleQuestionCount: number | null;
+  currentSampleQuestionTotal: number | null;
+  progressPath: string;
+  resultPath: string;
+  predictionsPath: string;
+  categories: Record<string, LocomoCategoryAggregate>;
+  tokenUsage: LocomoUsageSummary | null;
 }
 
-const STOPWORDS = new Set([
-  'a',
-  'about',
-  'after',
-  'all',
-  'an',
-  'and',
-  'any',
-  'are',
-  'as',
-  'at',
-  'be',
-  'been',
-  'being',
-  'before',
-  'between',
-  'but',
-  'by',
-  'can',
-  'could',
-  'did',
-  'do',
-  'does',
-  'for',
-  'from',
-  'had',
-  'has',
-  'have',
-  'he',
-  'her',
-  'his',
-  'how',
-  'i',
-  'if',
-  'in',
-  'into',
-  'is',
-  'it',
-  'its',
-  'me',
-  'my',
-  'no',
-  'not',
-  'of',
-  'on',
-  'or',
-  'our',
-  'over',
-  'she',
-  'so',
-  'some',
-  'that',
-  'the',
-  'their',
-  'them',
-  'then',
-  'there',
-  'they',
-  'this',
-  'to',
-  'until',
-  'was',
-  'we',
-  'were',
-  'what',
-  'when',
-  'where',
-  'which',
-  'who',
-  'why',
-  'will',
-  'with',
-  'would',
-  'you',
-  'your',
-]);
+interface LocomoChatCompletionUsage {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+}
+
+interface LocomoCategoryRunningAggregate {
+  scoreTotal: number;
+  contextF1Total: number;
+  questionCount: number;
+}
+
+interface LocomoRetrievalSession {
+  session: Session;
+  messageIdByDiaId: Map<string, number>;
+}
+
+interface LocomoPreparedQuestion {
+  prompt: string;
+  scoreCategory: number;
+  categoryFiveAnswerKey: Record<'a' | 'b', string> | null;
+}
 
 export async function runLocomoNativeCli(argv: string[]): Promise<void> {
   const options = parseArgs(argv);
@@ -176,12 +193,13 @@ export async function runLocomoNativeCli(argv: string[]): Promise<void> {
 }
 
 function parseArgs(argv: string[]): LocomoRunnerOptions {
-  let operation: LocomoRunnerOptions['operation'] | null = null;
+  let operation: LocomoOperation | null = null;
   let installDir = '';
   let budgetTokens = DEFAULT_TOKEN_BUDGET;
-  let requestedMode: LocomoRequestedMode = 'all';
   let numSamples: number | null = null;
-  let topK = DEFAULT_TOP_K;
+  let maxQuestions: number | null = null;
+  let mode: LocomoEvaluationMode = 'qa';
+  let agentMode: LocomoAgentMode = 'conversation-fresh';
 
   for (let index = 0; index < argv.length; index += 1) {
     const current = String(argv[index] || '').trim();
@@ -204,26 +222,41 @@ function parseArgs(argv: string[]): LocomoRunnerOptions {
       if (!inlineValue) index += 1;
       continue;
     }
-    if (flag === '--mode') {
-      const value = nextValue().toLowerCase();
-      if (value === 'all' || value === 'recent' || value === 'semantic') {
-        requestedMode = value;
-      } else {
-        throw new Error(
-          `Unsupported LOCOMO mode \`${value || '(empty)'}\`. Use all, recent, or semantic.`,
-        );
-      }
-      if (!inlineValue) index += 1;
-      continue;
-    }
     if (flag === '--num-samples') {
       const parsed = clampPositiveInt(nextValue(), 0);
       numSamples = parsed > 0 ? parsed : null;
       if (!inlineValue) index += 1;
       continue;
     }
-    if (flag === '--top-k') {
-      topK = clampPositiveInt(nextValue(), DEFAULT_TOP_K);
+    if (flag === '--max-questions') {
+      const parsed = clampPositiveInt(nextValue(), 0);
+      maxQuestions = parsed > 0 ? parsed : null;
+      if (!inlineValue) index += 1;
+      continue;
+    }
+    if (flag === '--mode') {
+      const value = nextValue().toLowerCase();
+      if (value === 'qa' || value === 'retrieval') {
+        mode = value;
+      } else {
+        throw new Error(`Unsupported LOCOMO mode \`${value || '(empty)'}\`.`);
+      }
+      if (!inlineValue) index += 1;
+      continue;
+    }
+    if (flag === '--agent-mode') {
+      const value = nextValue().toLowerCase();
+      if (
+        value === 'conversation-fresh' ||
+        value === 'current-agent' ||
+        value === 'fresh-request'
+      ) {
+        agentMode = value;
+      } else {
+        throw new Error(
+          `Unsupported LOCOMO agent mode \`${value || '(empty)'}\`.`,
+        );
+      }
       if (!inlineValue) index += 1;
       continue;
     }
@@ -242,9 +275,10 @@ function parseArgs(argv: string[]): LocomoRunnerOptions {
     operation,
     installDir: path.resolve(installDir),
     budgetTokens,
-    requestedMode,
     numSamples,
-    topK,
+    maxQuestions,
+    mode,
+    agentMode,
   };
 }
 
@@ -266,6 +300,10 @@ function getMarkerPath(installDir: string): string {
 
 function getDatasetPath(installDir: string): string {
   return path.join(installDir, 'data', LOCOMO_DATASET_FILENAME);
+}
+
+function getProgressPath(jobDir: string): string {
+  return path.join(jobDir, 'progress.json');
 }
 
 async function runSetup(options: LocomoRunnerOptions): Promise<void> {
@@ -310,49 +348,420 @@ async function runEvaluation(options: LocomoRunnerOptions): Promise<void> {
     throw new Error('LOCOMO is not set up. Run `/eval locomo setup` first.');
   }
 
+  const runtime = readGatewayRuntime();
   const allSamples = loadSamples(datasetPath);
   const selectedSamples =
     options.numSamples && options.numSamples > 0
       ? allSamples.slice(0, options.numSamples)
       : allSamples;
+  const plannedSamples = applyQuestionLimit(
+    selectedSamples,
+    options.maxQuestions,
+  );
+  const totalQuestionCount = plannedSamples.reduce(
+    (total, sample) => total + sample.qa.length,
+    0,
+  );
 
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
   const jobDir = path.join(options.installDir, 'jobs', timestamp);
   fs.mkdirSync(jobDir, { recursive: true });
+  const progressPath = getProgressPath(jobDir);
+  const resultPath = path.join(jobDir, 'result.json');
+  const predictionsPath = path.join(jobDir, 'predictions.json');
+  const retrievalDbPath = path.join(jobDir, 'retrieval-memory.db');
 
   console.log(`Job dir: ${jobDir}`);
   console.log(`Dataset: ${datasetPath}`);
-  console.log(`Samples: ${selectedSamples.length}`);
+  console.log(`Mode: ${options.mode}`);
+  if (options.mode === 'qa') {
+    console.log(`Model: ${runtime.model}`);
+  } else {
+    console.log(`Memory DB: ${retrievalDbPath}`);
+  }
+  console.log(`Samples: ${plannedSamples.length}`);
   console.log(`Budget: ${options.budgetTokens}`);
-  console.log(`Mode: ${options.requestedMode}`);
-  console.log(`Top K: ${options.topK}`);
+  if (options.mode === 'qa') {
+    console.log(`Agent mode: ${options.agentMode}`);
+  }
+  if (options.maxQuestions) {
+    console.log(`Max questions: ${options.maxQuestions}`);
+  }
+  console.log(`Questions planned: ${totalQuestionCount}`);
 
-  const modes = resolveModes(options.requestedMode);
-  const semanticSessions = modes.includes('semantic')
-    ? ingestSemanticDataset(selectedSamples, path.join(jobDir, 'locomo.db'))
-    : new Map<string, SemanticSessionRecord>();
-  const summary = evaluateSamples({
+  if (options.mode === 'retrieval') {
+    initDatabase({ quiet: true, dbPath: retrievalDbPath });
+  }
+
+  const predictions: LocomoSamplePrediction[] = [];
+  const categories = new Map<number, LocomoCategoryRunningAggregate>();
+  const usageTotals: LocomoUsageSummary = {
+    promptTokens: 0,
+    completionTokens: 0,
+    totalTokens: 0,
+    responsesWithUsage: 0,
+  };
+  let questionCount = 0;
+  let scoreTotal = 0;
+  let contextF1Total = 0;
+  let completedSampleCount = 0;
+  const runTag = path.basename(jobDir);
+
+  writeProgressFile({
+    progressPath,
+    resultPath,
+    predictionsPath,
+    mode: options.mode,
     datasetPath,
-    jobDir,
+    model: options.mode === 'qa' ? runtime.model : null,
     budgetTokens: options.budgetTokens,
-    requestedMode: options.requestedMode,
-    topK: options.topK,
-    samples: selectedSamples,
-    modes,
-    semanticSessions,
+    sampleCount: plannedSamples.length,
+    completedSampleCount,
+    questionCount: totalQuestionCount,
+    completedQuestionCount: questionCount,
+    scoreTotal,
+    contextF1Total,
+    categories,
+    usageTotals,
+    currentSampleId: null,
+    currentSampleQuestionCount: null,
+    currentSampleQuestionTotal: null,
   });
 
+  for (const sample of plannedSamples) {
+    const samplePrediction =
+      options.mode === 'retrieval'
+        ? await evaluateRetrievalSample({
+            sample,
+            budgetTokens: options.budgetTokens,
+            categories,
+            session: ingestSampleIntoNativeMemory({
+              sample,
+              runTag,
+              agentMode: options.agentMode,
+              runtime,
+            }),
+            onQuestionProgress: ({ samplePrediction }) => {
+              const completedQuestionCount =
+                questionCount + samplePrediction.qa.length;
+              const partialScoreTotal =
+                scoreTotal +
+                samplePrediction.qa.reduce((total, qa) => total + qa.score, 0);
+              const partialContextF1Total =
+                contextF1Total +
+                samplePrediction.qa.reduce(
+                  (total, qa) => total + (qa.contextF1 || 0),
+                  0,
+                );
+              writeProgressFile({
+                progressPath,
+                resultPath,
+                predictionsPath,
+                mode: options.mode,
+                datasetPath,
+                model: null,
+                budgetTokens: options.budgetTokens,
+                sampleCount: plannedSamples.length,
+                completedSampleCount,
+                questionCount: totalQuestionCount,
+                completedQuestionCount,
+                scoreTotal: partialScoreTotal,
+                contextF1Total: partialContextF1Total,
+                categories,
+                usageTotals,
+                currentSampleId: samplePrediction.sampleId,
+                currentSampleQuestionCount: samplePrediction.qa.length,
+                currentSampleQuestionTotal: samplePrediction.questionCount,
+              });
+            },
+          })
+        : await evaluateSample({
+            runtime,
+            requestModel: resolveSampleRequestModel({
+              runtime,
+              agentMode: options.agentMode,
+              sampleId: sample.sample_id,
+              runTag,
+            }),
+            sample,
+            budgetTokens: options.budgetTokens,
+            usageTotals,
+            categories,
+            onQuestionProgress: ({ samplePrediction }) => {
+              const completedQuestionCount =
+                questionCount + samplePrediction.qa.length;
+              const partialScoreTotal =
+                scoreTotal +
+                samplePrediction.qa.reduce((total, qa) => total + qa.score, 0);
+              writeProgressFile({
+                progressPath,
+                resultPath,
+                predictionsPath,
+                mode: options.mode,
+                datasetPath,
+                model: runtime.model,
+                budgetTokens: options.budgetTokens,
+                sampleCount: plannedSamples.length,
+                completedSampleCount,
+                questionCount: totalQuestionCount,
+                completedQuestionCount,
+                scoreTotal: partialScoreTotal,
+                contextF1Total,
+                categories,
+                usageTotals,
+                currentSampleId: samplePrediction.sampleId,
+                currentSampleQuestionCount: samplePrediction.qa.length,
+                currentSampleQuestionTotal: samplePrediction.questionCount,
+              });
+            },
+          });
+    predictions.push(samplePrediction);
+    questionCount += samplePrediction.questionCount;
+    scoreTotal += samplePrediction.meanScore * samplePrediction.questionCount;
+    contextF1Total +=
+      (samplePrediction.meanContextF1 || 0) * samplePrediction.questionCount;
+    completedSampleCount += 1;
+    writeProgressFile({
+      progressPath,
+      resultPath,
+      predictionsPath,
+      mode: options.mode,
+      datasetPath,
+      model: options.mode === 'qa' ? runtime.model : null,
+      budgetTokens: options.budgetTokens,
+      sampleCount: plannedSamples.length,
+      completedSampleCount,
+      questionCount: totalQuestionCount,
+      completedQuestionCount: questionCount,
+      scoreTotal,
+      contextF1Total,
+      categories,
+      usageTotals,
+      currentSampleId:
+        completedSampleCount < plannedSamples.length
+          ? plannedSamples[completedSampleCount]?.sample_id || null
+          : null,
+      currentSampleQuestionCount: null,
+      currentSampleQuestionTotal:
+        completedSampleCount < plannedSamples.length
+          ? plannedSamples[completedSampleCount]?.qa.length || null
+          : null,
+    });
+  }
+
   fs.writeFileSync(
-    summary.resultPath,
-    JSON.stringify(summary, null, 2),
+    predictionsPath,
+    JSON.stringify(predictions, null, 2),
     'utf-8',
   );
+
+  const categorySummaries: Record<string, LocomoCategoryAggregate> = {};
+  for (const [category, aggregate] of categories.entries()) {
+    categorySummaries[String(category)] = {
+      meanScore: roundMetric(
+        aggregate.scoreTotal / Math.max(aggregate.questionCount, 1),
+      ),
+      questionCount: aggregate.questionCount,
+      contextF1:
+        options.mode === 'retrieval'
+          ? roundMetric(
+              aggregate.contextF1Total / Math.max(aggregate.questionCount, 1),
+            )
+          : null,
+    };
+  }
+
+  const summary: LocomoRunSummary = {
+    suite: 'locomo',
+    mode: options.mode,
+    dataset: path.basename(datasetPath),
+    generatedAt: new Date().toISOString(),
+    model: options.mode === 'qa' ? runtime.model : null,
+    budgetTokens: options.budgetTokens,
+    sampleCount: plannedSamples.length,
+    questionCount,
+    overallScore: roundMetric(scoreTotal / Math.max(questionCount, 1)),
+    contextF1:
+      options.mode === 'retrieval'
+        ? roundMetric(contextF1Total / Math.max(questionCount, 1))
+        : null,
+    resultPath,
+    predictionsPath,
+    categories: categorySummaries,
+    tokenUsage:
+      options.mode === 'qa' && usageTotals.responsesWithUsage > 0
+        ? usageTotals
+        : null,
+    samples: predictions.map((samplePrediction) => ({
+      sampleId: samplePrediction.sampleId,
+      questionCount: samplePrediction.questionCount,
+      meanScore: samplePrediction.meanScore,
+    })),
+  };
+
+  fs.writeFileSync(resultPath, JSON.stringify(summary, null, 2), 'utf-8');
   printSummaryTable(summary);
 }
 
-function resolveModes(requestedMode: LocomoRequestedMode): LocomoMode[] {
-  if (requestedMode === 'all') return ['recent', 'semantic'];
-  return [requestedMode];
+function applyQuestionLimit(
+  samples: LocomoSample[],
+  maxQuestions: number | null,
+): LocomoSample[] {
+  if (!maxQuestions || maxQuestions <= 0) {
+    return samples.map((sample) => ({
+      ...sample,
+      qa: Array.isArray(sample.qa) ? [...sample.qa] : [],
+    }));
+  }
+
+  const selected: LocomoSample[] = [];
+  let remaining = maxQuestions;
+  for (const sample of samples) {
+    if (remaining <= 0) break;
+    const qa = Array.isArray(sample.qa) ? sample.qa.slice(0, remaining) : [];
+    if (qa.length === 0) continue;
+    selected.push({
+      ...sample,
+      qa,
+    });
+    remaining -= qa.length;
+  }
+  return selected;
+}
+
+function writeProgressFile(params: {
+  progressPath: string;
+  resultPath: string;
+  predictionsPath: string;
+  mode: LocomoEvaluationMode;
+  datasetPath: string;
+  model: string | null;
+  budgetTokens: number;
+  sampleCount: number;
+  completedSampleCount: number;
+  questionCount: number;
+  completedQuestionCount: number;
+  scoreTotal: number;
+  contextF1Total: number;
+  categories: Map<number, LocomoCategoryRunningAggregate>;
+  usageTotals: LocomoUsageSummary;
+  currentSampleId: string | null;
+  currentSampleQuestionCount: number | null;
+  currentSampleQuestionTotal: number | null;
+}): void {
+  const categorySummaries: Record<string, LocomoCategoryAggregate> = {};
+  for (const [category, aggregate] of params.categories.entries()) {
+    categorySummaries[String(category)] = {
+      meanScore: roundMetric(
+        aggregate.scoreTotal / Math.max(aggregate.questionCount, 1),
+      ),
+      questionCount: aggregate.questionCount,
+      contextF1:
+        params.mode === 'retrieval'
+          ? roundMetric(
+              aggregate.contextF1Total / Math.max(aggregate.questionCount, 1),
+            )
+          : null,
+    };
+  }
+  const progress: LocomoProgressSummary = {
+    suite: 'locomo',
+    mode: params.mode,
+    dataset: path.basename(params.datasetPath),
+    updatedAt: new Date().toISOString(),
+    model: params.model,
+    budgetTokens: params.budgetTokens,
+    sampleCount: params.sampleCount,
+    completedSampleCount: params.completedSampleCount,
+    questionCount: params.questionCount,
+    completedQuestionCount: params.completedQuestionCount,
+    overallScore: roundMetric(
+      params.scoreTotal / Math.max(params.completedQuestionCount, 1),
+    ),
+    contextF1:
+      params.mode === 'retrieval'
+        ? roundMetric(
+            params.contextF1Total / Math.max(params.completedQuestionCount, 1),
+          )
+        : null,
+    currentSampleId: params.currentSampleId,
+    currentSampleQuestionCount: params.currentSampleQuestionCount,
+    currentSampleQuestionTotal: params.currentSampleQuestionTotal,
+    progressPath: params.progressPath,
+    resultPath: params.resultPath,
+    predictionsPath: params.predictionsPath,
+    categories: categorySummaries,
+    tokenUsage:
+      params.mode === 'qa' && params.usageTotals.responsesWithUsage > 0
+        ? params.usageTotals
+        : null,
+  };
+  fs.writeFileSync(
+    params.progressPath,
+    JSON.stringify(progress, null, 2),
+    'utf-8',
+  );
+}
+
+function readGatewayRuntime(): LocomoGatewayRuntime {
+  const baseUrl = String(process.env.OPENAI_BASE_URL || DEFAULT_OPENAI_BASE_URL)
+    .trim()
+    .replace(/\/+$/, '');
+  const apiKey = String(
+    process.env.OPENAI_API_KEY || 'hybridclaw-local',
+  ).trim();
+  const model = String(
+    process.env.HYBRIDCLAW_EVAL_MODEL || DEFAULT_EVAL_MODEL,
+  ).trim();
+  const parsed = parseEvalProfileModel(model || DEFAULT_EVAL_MODEL);
+
+  return {
+    baseUrl: baseUrl || DEFAULT_OPENAI_BASE_URL,
+    apiKey: apiKey || 'hybridclaw-local',
+    model: model || DEFAULT_EVAL_MODEL,
+    baseModel: parsed.model || DEFAULT_EVAL_MODEL,
+    profile: parsed.profile || buildDefaultEvalProfile(),
+  };
+}
+
+function resolveSampleRequestModel(params: {
+  runtime: LocomoGatewayRuntime;
+  agentMode: LocomoAgentMode;
+  sampleId: string;
+  runTag: string;
+}): string {
+  if (params.agentMode === 'current-agent') {
+    return params.runtime.model;
+  }
+  if (params.agentMode === 'fresh-request') {
+    return encodeEvalProfileModel(params.runtime.baseModel, {
+      workspaceMode: 'fresh-agent',
+      ablateSystemPrompt: params.runtime.profile.ablateSystemPrompt,
+      includePromptParts: [...params.runtime.profile.includePromptParts],
+      omitPromptParts: [...params.runtime.profile.omitPromptParts],
+    });
+  }
+
+  return encodeEvalProfileModel(params.runtime.baseModel, {
+    workspaceMode: 'current-agent',
+    ablateSystemPrompt: params.runtime.profile.ablateSystemPrompt,
+    includePromptParts: [...params.runtime.profile.includePromptParts],
+    omitPromptParts: [...params.runtime.profile.omitPromptParts],
+    agentId: buildConversationAgentId(params.sampleId, params.runTag),
+  });
+}
+
+function buildConversationAgentId(sampleId: string, runTag: string): string {
+  const sanitizedSampleId = String(sampleId || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 24);
+  const digest = createHash('sha1')
+    .update(`${runTag}:${sampleId}`)
+    .digest('hex')
+    .slice(0, 12);
+  return `locomo-${sanitizedSampleId || 'sample'}-${digest}`;
 }
 
 function loadSamples(datasetPath: string): LocomoSample[] {
@@ -364,217 +773,289 @@ function loadSamples(datasetPath: string): LocomoSample[] {
   return parsed as LocomoSample[];
 }
 
-function ingestSemanticDataset(
-  samples: LocomoSample[],
-  dbPath: string,
-): Map<string, SemanticSessionRecord> {
-  initDatabase({ dbPath, quiet: true });
-  const sessions = new Map<string, SemanticSessionRecord>();
+async function evaluateSample(params: {
+  runtime: LocomoGatewayRuntime;
+  requestModel: string;
+  sample: LocomoSample;
+  budgetTokens: number;
+  usageTotals: LocomoUsageSummary;
+  categories: Map<number, LocomoCategoryRunningAggregate>;
+  onQuestionProgress?: (params: {
+    samplePrediction: LocomoSamplePrediction;
+  }) => void;
+}): Promise<LocomoSamplePrediction> {
+  const qaPredictions: LocomoQuestionPrediction[] = [];
+  const sampleQuestionCount = (params.sample.qa || []).length;
 
-  for (const sample of samples) {
-    const sessionId = `locomo-${sample.sample_id}`;
-    getOrCreateSession(sessionId, null, 'eval-locomo', 'main');
+  for (const qa of params.sample.qa || []) {
+    const prepared = buildQuestionPrompt(
+      params.sample,
+      qa,
+      params.budgetTokens,
+    );
+    const completion = await requestModelAnswer({
+      runtime: params.runtime,
+      model: params.requestModel,
+      prompt: prepared.prompt,
+      user: `locomo-${params.sample.sample_id}`,
+    });
+    mergeUsage(params.usageTotals, completion.usage);
 
-    const turns = getTurns(sample);
-    const formattedTurns: string[] = [];
-    for (const turn of turns) {
-      const content = formatTurn(turn);
-      formattedTurns.push(content);
-      storeSemanticMemory({
-        sessionId,
-        role: 'user',
-        source: 'locomo',
-        scope: 'episodic',
-        metadata: {
-          diaId: turn.dia_id,
-          speaker: turn.speaker,
-        },
-        content,
-        confidence: 1,
-        embedding: embedText(content),
-      });
-    }
-    sessions.set(sample.sample_id, {
-      sessionId,
-      turns: formattedTurns,
+    const answer = answerToString(qa);
+    const prediction =
+      prepared.scoreCategory === 5
+        ? normalizeCategoryFivePrediction(
+            completion.content,
+            prepared.categoryFiveAnswerKey,
+          )
+        : normalizeModelPrediction(completion.content);
+    const score = scoreLocomoAnswer(qa, prediction);
+
+    qaPredictions.push({
+      category: prepared.scoreCategory,
+      question: qa.question,
+      answer,
+      prediction,
+      score,
+      evidence: Array.isArray(qa.evidence) ? qa.evidence : [],
+    });
+
+    const existing = params.categories.get(prepared.scoreCategory) || {
+      scoreTotal: 0,
+      contextF1Total: 0,
+      questionCount: 0,
+    };
+    existing.scoreTotal += score;
+    existing.questionCount += 1;
+    params.categories.set(prepared.scoreCategory, existing);
+    params.onQuestionProgress?.({
+      samplePrediction: {
+        sampleId: params.sample.sample_id,
+        questionCount: sampleQuestionCount,
+        meanScore: roundMetric(
+          qaPredictions.reduce((total, entry) => total + entry.score, 0) /
+            Math.max(qaPredictions.length, 1),
+        ),
+        meanContextF1: null,
+        qa: [...qaPredictions],
+      },
     });
   }
 
-  return sessions;
-}
-
-function evaluateSamples(params: {
-  datasetPath: string;
-  jobDir: string;
-  budgetTokens: number;
-  requestedMode: LocomoRequestedMode;
-  topK: number;
-  samples: LocomoSample[];
-  modes: LocomoMode[];
-  semanticSessions: Map<string, SemanticSessionRecord>;
-}): LocomoRunSummary {
-  const overall = new Map<LocomoMode, RunningAggregate>();
-  const sampleSummaries: SampleSummary[] = [];
-  for (const mode of params.modes) {
-    overall.set(mode, createRunningAggregate());
-  }
-
-  for (const sample of params.samples) {
-    const turns = getTurns(sample).map(formatTurn);
-    const sampleSummary: SampleSummary = {
-      sampleId: sample.sample_id,
-      modes: {},
-    };
-
-    for (const mode of params.modes) {
-      const aggregate = createRunningAggregate();
-      for (const qa of sample.qa || []) {
-        const answer = answerToString(qa);
-        const context =
-          mode === 'recent'
-            ? buildRecentContext(turns, params.budgetTokens)
-            : buildSemanticContext({
-                session: params.semanticSessions.get(sample.sample_id) || null,
-                question: qa.question,
-                topK: params.topK,
-                budgetTokens: params.budgetTokens,
-              });
-        accumulateScore({
-          aggregate,
-          category: qa.category,
-          answer,
-          context,
-          evidence: qa.evidence || [],
-          sample,
-        });
-      }
-
-      sampleSummary.modes[mode] = finalizeAggregate(aggregate);
-      mergeAggregate(overall.get(mode) || createRunningAggregate(), aggregate);
-    }
-
-    sampleSummaries.push(sampleSummary);
-  }
-
-  const modeSummaries: Partial<Record<LocomoMode, ModeAggregate>> = {};
-  for (const mode of params.modes) {
-    const aggregate = overall.get(mode);
-    if (!aggregate) continue;
-    modeSummaries[mode] = finalizeAggregate(aggregate);
-  }
-
-  const resultPath = path.join(params.jobDir, 'result.json');
+  const questionCount = qaPredictions.length;
+  const meanScore = roundMetric(
+    qaPredictions.reduce((total, qa) => total + qa.score, 0) /
+      Math.max(questionCount, 1),
+  );
   return {
-    suite: 'locomo',
-    dataset: path.basename(params.datasetPath),
-    generatedAt: new Date().toISOString(),
-    budgetTokens: params.budgetTokens,
-    topK: params.topK,
-    sampleCount: params.samples.length,
-    requestedMode: params.requestedMode,
-    resultPath,
-    modes: modeSummaries,
-    samples: sampleSummaries,
+    sampleId: params.sample.sample_id,
+    questionCount,
+    meanScore,
+    meanContextF1: null,
+    qa: qaPredictions,
   };
 }
 
-interface RunningAggregate {
-  totalF1: number;
-  totalHitRate: number;
-  totalQuestions: number;
-  byCategory: Map<number, CategoryAggregate>;
-}
-
-function createRunningAggregate(): RunningAggregate {
-  return {
-    totalF1: 0,
-    totalHitRate: 0,
-    totalQuestions: 0,
-    byCategory: new Map<number, CategoryAggregate>(),
-  };
-}
-
-function accumulateScore(params: {
-  aggregate: RunningAggregate;
-  category: number;
-  answer: string;
-  context: string;
-  evidence: string[];
+async function evaluateRetrievalSample(params: {
   sample: LocomoSample;
-}): void {
-  const f1 = tokenOverlapF1(params.context, params.answer);
-  const hitRate = recallHitRate(params.evidence, params.sample, params.context);
-  params.aggregate.totalF1 += f1;
-  params.aggregate.totalHitRate += hitRate;
-  params.aggregate.totalQuestions += 1;
+  budgetTokens: number;
+  categories: Map<number, LocomoCategoryRunningAggregate>;
+  session: LocomoRetrievalSession;
+  onQuestionProgress?: (params: {
+    samplePrediction: LocomoSamplePrediction;
+  }) => void;
+}): Promise<LocomoSamplePrediction> {
+  const qaPredictions: LocomoQuestionPrediction[] = [];
+  const sampleQuestionCount = (params.sample.qa || []).length;
 
-  const current = params.aggregate.byCategory.get(params.category) || {
-    f1: 0,
-    hitRate: 0,
-    questionCount: 0,
-  };
-  current.f1 += f1;
-  current.hitRate += hitRate;
-  current.questionCount += 1;
-  params.aggregate.byCategory.set(params.category, current);
-}
+  for (const qa of params.sample.qa || []) {
+    const memoryContext = memoryService.buildPromptMemoryContext({
+      session: params.session.session,
+      query: String(qa.question || '').trim(),
+      semanticLimit: 12,
+    });
+    const recalledMemories = budgetTruncateSemanticMemories(
+      memoryContext.semanticMemories,
+      params.budgetTokens,
+    );
+    const recalledContext = recalledMemories
+      .map((entry) => entry.content)
+      .join('\n\n')
+      .trim();
+    const retrievedSourceMessageIds = recalledMemories
+      .map((entry) => entry.source_message_id)
+      .filter(
+        (value): value is number =>
+          typeof value === 'number' && Number.isFinite(value) && value > 0,
+      );
+    const hitRate = computeRetrievalHitRate({
+      evidence: Array.isArray(qa.evidence) ? qa.evidence : [],
+      messageIdByDiaId: params.session.messageIdByDiaId,
+      retrievedSourceMessageIds,
+    });
+    const contextF1 = computeContextTokenF1(
+      recalledContext,
+      answerToString(qa),
+    );
 
-function mergeAggregate(
-  target: RunningAggregate,
-  source: RunningAggregate,
-): void {
-  target.totalF1 += source.totalF1;
-  target.totalHitRate += source.totalHitRate;
-  target.totalQuestions += source.totalQuestions;
-  for (const [category, value] of source.byCategory.entries()) {
-    const current = target.byCategory.get(category) || {
-      f1: 0,
-      hitRate: 0,
+    qaPredictions.push({
+      category: qa.category,
+      question: qa.question,
+      answer: answerToString(qa),
+      prediction: recalledContext,
+      score: hitRate,
+      evidence: Array.isArray(qa.evidence) ? qa.evidence : [],
+      contextF1,
+      retrievedSourceMessageIds,
+    });
+
+    const existing = params.categories.get(qa.category) || {
+      scoreTotal: 0,
+      contextF1Total: 0,
       questionCount: 0,
     };
-    current.f1 += value.f1;
-    current.hitRate += value.hitRate;
-    current.questionCount += value.questionCount;
-    target.byCategory.set(category, current);
+    existing.scoreTotal += hitRate;
+    existing.contextF1Total += contextF1;
+    existing.questionCount += 1;
+    params.categories.set(qa.category, existing);
+    params.onQuestionProgress?.({
+      samplePrediction: {
+        sampleId: params.sample.sample_id,
+        questionCount: sampleQuestionCount,
+        meanScore: roundMetric(
+          qaPredictions.reduce((total, entry) => total + entry.score, 0) /
+            Math.max(qaPredictions.length, 1),
+        ),
+        meanContextF1: roundMetric(
+          qaPredictions.reduce(
+            (total, entry) => total + (entry.contextF1 || 0),
+            0,
+          ) / Math.max(qaPredictions.length, 1),
+        ),
+        qa: [...qaPredictions],
+      },
+    });
   }
-}
 
-function finalizeAggregate(aggregate: RunningAggregate): ModeAggregate {
-  const totalQuestions = Math.max(aggregate.totalQuestions, 1);
-  const byCategory: Record<string, CategoryAggregate> = {};
-  for (const [category, value] of aggregate.byCategory.entries()) {
-    byCategory[String(category)] = {
-      f1: roundMetric(value.f1 / Math.max(value.questionCount, 1)),
-      hitRate: roundMetric(value.hitRate / Math.max(value.questionCount, 1)),
-      questionCount: value.questionCount,
-    };
-  }
+  const questionCount = qaPredictions.length;
   return {
-    overallF1: roundMetric(aggregate.totalF1 / totalQuestions),
-    overallHitRate: roundMetric(aggregate.totalHitRate / totalQuestions),
-    totalQuestions: aggregate.totalQuestions,
-    byCategory,
+    sampleId: params.sample.sample_id,
+    questionCount,
+    meanScore: roundMetric(
+      qaPredictions.reduce((total, entry) => total + entry.score, 0) /
+        Math.max(questionCount, 1),
+    ),
+    meanContextF1: roundMetric(
+      qaPredictions.reduce(
+        (total, entry) => total + (entry.contextF1 || 0),
+        0,
+      ) / Math.max(questionCount, 1),
+    ),
+    qa: qaPredictions,
   };
 }
 
-function roundMetric(value: number): number {
-  if (!Number.isFinite(value)) return 0;
-  return Math.round(value * 1000) / 1000;
+function buildQuestionPrompt(
+  sample: LocomoSample,
+  qa: LocomoQA,
+  budgetTokens: number,
+): LocomoPreparedQuestion {
+  let question = String(qa.question || '').trim();
+  if (qa.category === 2) {
+    question += ' Use DATE of CONVERSATION to answer with an approximate date.';
+  }
+  if (qa.category === 5) {
+    question = buildCategoryFiveQuestion(sample, qa);
+  }
+
+  const speakers = getSpeakerNames(sample);
+  const conversationStart = CONVERSATION_START_PROMPT.replace(
+    '{speakerA}',
+    speakers[0],
+  ).replace('{speakerB}', speakers[1]);
+  const qaPromptTemplate = qa.category === 5 ? QA_PROMPT_CATEGORY_5 : QA_PROMPT;
+  const questionPrompt = qaPromptTemplate.replace('{question}', question);
+  const availableConversationTokens = Math.max(
+    1,
+    budgetTokens -
+      estimateTokenCount(conversationStart) -
+      estimateTokenCount(questionPrompt) -
+      ANSWER_BUFFER_TOKENS,
+  );
+  const conversation = selectConversationContext(
+    sample.conversation,
+    availableConversationTokens,
+  );
+
+  return {
+    prompt: `${conversationStart}${conversation}\n\n${questionPrompt}`.trim(),
+    scoreCategory: qa.category,
+    categoryFiveAnswerKey:
+      qa.category === 5 ? buildCategoryFiveAnswerKey(sample, qa) : null,
+  };
 }
 
-function getTurns(sample: LocomoSample): LocomoTurn[] {
-  const sessionNames = Object.keys(sample.conversation || {})
+function buildCategoryFiveQuestion(sample: LocomoSample, qa: LocomoQA): string {
+  const answerKey = buildCategoryFiveAnswerKey(sample, qa);
+  return `${qa.question} Select the correct answer: (a) ${answerKey.a} (b) ${answerKey.b}.`;
+}
+
+function buildCategoryFiveAnswerKey(
+  sample: LocomoSample,
+  qa: LocomoQA,
+): Record<'a' | 'b', string> {
+  const answer = answerToString(qa) || 'No information available';
+  const notMentioned = 'Not mentioned in the conversation';
+  const answerFirst = hashText(`${sample.sample_id}:${qa.question}`) % 2 === 0;
+  return answerFirst
+    ? { a: answer, b: notMentioned }
+    : { a: notMentioned, b: answer };
+}
+
+function getSpeakerNames(sample: LocomoSample): [string, string] {
+  const explicitA = String(sample.conversation.speaker_a || '').trim();
+  const explicitB = String(sample.conversation.speaker_b || '').trim();
+  if (explicitA && explicitB) {
+    return [explicitA, explicitB];
+  }
+
+  const discovered: string[] = [];
+  for (const turn of flattenConversationTurns(sample.conversation)) {
+    const speaker = turn.speaker.trim();
+    if (!speaker || discovered.includes(speaker)) continue;
+    discovered.push(speaker);
+    if (discovered.length === 2) break;
+  }
+
+  return [
+    discovered[0] || explicitA || 'Speaker A',
+    discovered[1] || explicitB || 'Speaker B',
+  ];
+}
+
+function flattenConversationTurns(
+  conversation: Record<string, unknown>,
+): Array<LocomoTurn & { sessionNum: number; dateTime: string }> {
+  const sessionNames = Object.keys(conversation || {})
     .filter((key) => /^session_\d+$/.test(key))
     .sort((left, right) => {
       const leftNum = Number.parseInt(left.slice('session_'.length), 10) || 0;
       const rightNum = Number.parseInt(right.slice('session_'.length), 10) || 0;
       return leftNum - rightNum;
     });
-  const turns: LocomoTurn[] = [];
+  const turns: Array<LocomoTurn & { sessionNum: number; dateTime: string }> =
+    [];
+
   for (const sessionName of sessionNames) {
-    const raw = sample.conversation[sessionName];
-    if (!Array.isArray(raw)) continue;
-    for (const entry of raw) {
+    const sessionNum =
+      Number.parseInt(sessionName.slice('session_'.length), 10) || 0;
+    const dateTime = String(
+      conversation[`session_${sessionNum}_date_time`] || '',
+    ).trim();
+    const rawTurns = conversation[sessionName];
+    if (!Array.isArray(rawTurns)) continue;
+
+    for (const entry of rawTurns) {
       if (!entry || typeof entry !== 'object') continue;
       const record = entry as Record<string, unknown>;
       const speaker = String(record.speaker || '').trim();
@@ -582,80 +1063,270 @@ function getTurns(sample: LocomoSample): LocomoTurn[] {
       const text = String(record.text || '').trim();
       if (!speaker || !diaId || !text) continue;
       turns.push({
+        sessionNum,
+        dateTime,
         speaker,
         dia_id: diaId,
         text,
+        ...(typeof record.blip_caption === 'string' &&
+        record.blip_caption.trim().length > 0
+          ? { blip_caption: record.blip_caption.trim() }
+          : {}),
       });
     }
   }
+
   return turns;
 }
 
-function formatTurn(turn: LocomoTurn): string {
-  return `${turn.speaker}: ${turn.text}`;
-}
-
-function answerToString(qa: LocomoQA): string {
-  if (typeof qa.answer === 'string') return qa.answer;
-  if (typeof qa.answer === 'number' && Number.isFinite(qa.answer)) {
-    return String(qa.answer);
-  }
-  if (qa.answer && typeof qa.answer === 'object') {
-    return JSON.stringify(qa.answer);
-  }
-  return String(qa.adversarial_answer || '').trim();
-}
-
-function buildRecentContext(turns: string[], budgetTokens: number): string {
-  const selected: string[] = [];
+function selectConversationContext(
+  conversation: Record<string, unknown>,
+  maxTokens: number,
+): string {
+  const chronologicalTurns = flattenConversationTurns(conversation);
+  const selected: Array<LocomoTurn & { sessionNum: number; dateTime: string }> =
+    [];
   let totalTokens = 0;
-  for (let index = turns.length - 1; index >= 0; index -= 1) {
-    const content = turns[index];
-    const nextTokens = estimateTokenCount(content);
-    if (totalTokens + nextTokens > budgetTokens && selected.length > 0) {
+
+  for (let index = chronologicalTurns.length - 1; index >= 0; index -= 1) {
+    const turn = chronologicalTurns[index];
+    const headerTokens =
+      selected.length === 0 || selected[0].sessionNum !== turn.sessionNum
+        ? estimateTokenCount(`DATE: ${turn.dateTime}\nCONVERSATION:\n`)
+        : 0;
+    const turnTokens = estimateTokenCount(formatConversationTurn(turn));
+    if (
+      totalTokens + headerTokens + turnTokens > maxTokens &&
+      selected.length
+    ) {
       break;
     }
-    selected.unshift(content);
-    totalTokens += nextTokens;
+    selected.unshift(turn);
+    totalTokens += headerTokens + turnTokens;
   }
-  return selected.join('\n');
+
+  if (selected.length === 0) {
+    const lastTurn = chronologicalTurns.at(-1);
+    return lastTurn
+      ? `DATE: ${lastTurn.dateTime || 'unknown'}\nCONVERSATION:\n${formatConversationTurn(lastTurn)}`.trim()
+      : '';
+  }
+
+  const sections: string[] = [];
+  let currentSessionNum: number | null = null;
+  let currentDateTime = '';
+  let currentTurns: string[] = [];
+
+  for (const turn of selected) {
+    if (currentSessionNum !== turn.sessionNum) {
+      if (currentTurns.length > 0) {
+        sections.push(
+          `DATE: ${currentDateTime}\nCONVERSATION:\n${currentTurns.join('')}`.trim(),
+        );
+      }
+      currentSessionNum = turn.sessionNum;
+      currentDateTime = turn.dateTime || 'unknown';
+      currentTurns = [];
+    }
+    currentTurns.push(formatConversationTurn(turn));
+  }
+
+  if (currentTurns.length > 0) {
+    sections.push(
+      `DATE: ${currentDateTime}\nCONVERSATION:\n${currentTurns.join('')}`.trim(),
+    );
+  }
+
+  return sections.join('\n\n').trim();
 }
 
-function buildSemanticContext(params: {
-  session: SemanticSessionRecord | null;
-  question: string;
-  topK: number;
-  budgetTokens: number;
+function formatConversationTurn(turn: LocomoTurn): string {
+  const base = `${turn.speaker} said, "${turn.text}"`;
+  if (turn.blip_caption) {
+    return `${base} and shared ${turn.blip_caption}.\n`;
+  }
+  return `${base}\n`;
+}
+
+function ingestSampleIntoNativeMemory(params: {
+  sample: LocomoSample;
+  runTag: string;
+  agentMode: LocomoAgentMode;
+  runtime: LocomoGatewayRuntime;
+}): LocomoRetrievalSession {
+  const agentId = resolveRetrievalAgentId(params);
+  const sessionId = buildSessionKey(
+    agentId,
+    'locomo',
+    'dm',
+    `${params.runTag}-${params.sample.sample_id}`,
+  );
+  const session = memoryService.getOrCreateSession(
+    sessionId,
+    null,
+    'locomo',
+    agentId,
+  );
+  const messageIdByDiaId = new Map<string, number>();
+  const [speakerA, speakerB] = getSpeakerNames(params.sample);
+
+  for (const turn of flattenConversationTurns(params.sample.conversation)) {
+    const role = turn.speaker === speakerB ? 'assistant' : 'user';
+    const content = formatRetrievalMemoryTurn(turn);
+    const messageId = memoryService.storeMessage({
+      sessionId,
+      userId: `locomo:${turn.speaker.toLowerCase().replace(/\s+/g, '-')}`,
+      username: turn.speaker,
+      role,
+      content,
+    });
+    messageIdByDiaId.set(normalizeDiaId(turn.dia_id), messageId);
+    storeSemanticMemory({
+      sessionId,
+      role,
+      source: 'locomo-retrieval',
+      scope: 'episodic',
+      metadata: {
+        sampleId: params.sample.sample_id,
+        diaId: turn.dia_id,
+        speaker: turn.speaker,
+        speakerA,
+        speakerB,
+      },
+      content,
+      confidence: 1,
+      embedding: buildHashedTokenEmbedding(content),
+      sourceMessageId: messageId,
+    });
+  }
+
+  return {
+    session,
+    messageIdByDiaId,
+  };
+}
+
+function resolveRetrievalAgentId(params: {
+  sample: LocomoSample;
+  runTag: string;
+  agentMode: LocomoAgentMode;
+  runtime: LocomoGatewayRuntime;
 }): string {
-  if (!params.session) return '';
-  const memories = recallSemanticMemories({
-    sessionId: params.session.sessionId,
-    query: params.question,
-    limit: params.topK,
-    minConfidence: 0,
-    queryEmbedding: embedText(params.question),
-  });
-  const selected: string[] = [];
+  if (params.agentMode === 'current-agent') {
+    return params.runtime.profile.agentId || 'main';
+  }
+  return buildConversationAgentId(params.sample.sample_id, params.runTag);
+}
+
+function formatRetrievalMemoryTurn(
+  turn: LocomoTurn & { dateTime?: string },
+): string {
+  const datePrefix = turn.dateTime ? `DATE: ${turn.dateTime}\n` : '';
+  return `${datePrefix}${formatConversationTurn(turn).trim()}`.trim();
+}
+
+function budgetTruncateSemanticMemories(
+  memories: SemanticMemoryEntry[],
+  budgetTokens: number,
+): SemanticMemoryEntry[] {
+  const selected: SemanticMemoryEntry[] = [];
   let totalTokens = 0;
+
   for (const memory of memories) {
     const content = String(memory.content || '').trim();
     if (!content) continue;
-    const nextTokens = estimateTokenCount(content);
-    if (totalTokens + nextTokens > params.budgetTokens && selected.length > 0) {
+    const contentTokens = estimateTokenCount(content);
+    if (totalTokens + contentTokens > budgetTokens && selected.length > 0) {
       break;
     }
-    selected.push(content);
-    totalTokens += nextTokens;
+    selected.push(memory);
+    totalTokens += contentTokens;
   }
-  return selected.join('\n');
+
+  return selected;
 }
 
-function estimateTokenCount(text: string): number {
-  return Math.max(1, Math.ceil(text.length / 4));
+function computeRetrievalHitRate(params: {
+  evidence: string[];
+  messageIdByDiaId: Map<string, number>;
+  retrievedSourceMessageIds: number[];
+}): number {
+  const expandedEvidenceIds = expandEvidenceIds(params.evidence);
+  if (expandedEvidenceIds.length === 0) return 1;
+
+  const retrievedIds = new Set(params.retrievedSourceMessageIds);
+  let found = 0;
+  let resolvable = 0;
+  for (const evidenceId of expandedEvidenceIds) {
+    const messageId = params.messageIdByDiaId.get(evidenceId);
+    if (!messageId) continue;
+    resolvable += 1;
+    if (retrievedIds.has(messageId)) {
+      found += 1;
+    }
+  }
+  if (resolvable === 0) return 0;
+  return found / resolvable;
 }
 
-function embedText(text: string): number[] | null {
-  const normalized = text
+function expandEvidenceIds(evidence: string[]): string[] {
+  const expanded: string[] = [];
+  for (const entry of evidence || []) {
+    const segments = String(entry || '')
+      .split(';')
+      .flatMap((part) => part.split(/\s+/g))
+      .map((part) => normalizeDiaId(part))
+      .filter((part) => /^D\d+:\d+$/i.test(part));
+    expanded.push(...segments);
+  }
+  return expanded;
+}
+
+function normalizeDiaId(value: string): string {
+  const match = /^D(\d+):(\d+)$/i.exec(String(value || '').trim());
+  if (!match) return String(value || '').trim();
+  return `D${Number.parseInt(match[1], 10)}:${Number.parseInt(match[2], 10)}`;
+}
+
+function computeContextTokenF1(prediction: string, answer: string): number {
+  const predictionTokens = tokenizeContextText(prediction);
+  const answerTokens = tokenizeContextText(answer);
+  if (predictionTokens.length === 0 && answerTokens.length === 0) return 1;
+  if (predictionTokens.length === 0 || answerTokens.length === 0) return 0;
+
+  const predictionCounts = new Map<string, number>();
+  const answerCounts = new Map<string, number>();
+  for (const token of predictionTokens) {
+    predictionCounts.set(token, (predictionCounts.get(token) || 0) + 1);
+  }
+  for (const token of answerTokens) {
+    answerCounts.set(token, (answerCounts.get(token) || 0) + 1);
+  }
+
+  let matches = 0;
+  for (const [token, count] of predictionCounts.entries()) {
+    const answerCount = answerCounts.get(token) || 0;
+    matches += Math.min(count, answerCount);
+  }
+  if (matches === 0) return 0;
+  const precision = matches / predictionTokens.length;
+  const recall = matches / answerTokens.length;
+  return (2 * precision * recall) / (precision + recall);
+}
+
+function tokenizeContextText(value: string): string[] {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9_\s-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .split(' ')
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0);
+}
+
+function buildHashedTokenEmbedding(text: string): number[] | null {
+  const normalized = String(text || '')
     .toLowerCase()
     .replace(/[^a-z0-9_\s-]/g, ' ')
     .replace(/\s+/g, ' ')
@@ -665,14 +1336,14 @@ function embedText(text: string): number[] | null {
   const tokens = normalized
     .split(' ')
     .map((token) => token.trim())
-    .filter((token) => token.length > 1 && !STOPWORDS.has(token))
+    .filter((token) => token.length > 1)
     .slice(0, 256);
   if (tokens.length === 0) return null;
 
-  const vector = new Float32Array(EMBEDDING_DIMENSIONS);
+  const vector = new Float32Array(128);
   for (const token of tokens) {
-    const hash = hashToken(token);
-    const index = hash % EMBEDDING_DIMENSIONS;
+    const hash = hashEmbeddingToken(token);
+    const index = hash % vector.length;
     const sign = (hash & 1) === 0 ? 1 : -1;
     vector[index] += sign * Math.min(4, token.length);
   }
@@ -686,7 +1357,7 @@ function embedText(text: string): number[] | null {
   return Array.from(vector, (value) => value * scale);
 }
 
-function hashToken(token: string): number {
+function hashEmbeddingToken(token: string): number {
   let hash = 2166136261;
   for (let index = 0; index < token.length; index += 1) {
     hash ^= token.charCodeAt(index);
@@ -695,95 +1366,174 @@ function hashToken(token: string): number {
   return hash >>> 0;
 }
 
-function tokenize(text: string): string[] {
-  return String(text || '')
-    .toLowerCase()
-    .split(/[^a-z0-9]+/g)
-    .map((token) => token.trim())
-    .filter(Boolean);
+async function requestModelAnswer(params: {
+  runtime: LocomoGatewayRuntime;
+  model: string;
+  prompt: string;
+  user: string;
+}): Promise<{ content: string; usage: LocomoChatCompletionUsage | null }> {
+  const url = `${params.runtime.baseUrl.replace(/\/+$/, '')}/chat/completions`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${params.runtime.apiKey}`,
+    },
+    body: JSON.stringify({
+      model: params.model,
+      user: params.user,
+      messages: [{ role: 'user', content: params.prompt }],
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `LOCOMO model call failed with HTTP ${response.status}: ${await response.text()}`,
+    );
+  }
+
+  const payload = (await response.json()) as {
+    choices?: Array<{
+      message?: {
+        content?: unknown;
+      };
+    }>;
+    usage?: LocomoChatCompletionUsage;
+  };
+  return {
+    content: String(payload.choices?.[0]?.message?.content || '').trim(),
+    usage:
+      payload.usage && typeof payload.usage === 'object' ? payload.usage : null,
+  };
 }
 
-function tokenOverlapF1(prediction: string, reference: string): number {
-  const predictionTokens = tokenize(prediction);
-  const referenceTokens = tokenize(reference);
-  if (predictionTokens.length === 0 || referenceTokens.length === 0) {
-    return 0;
-  }
-
-  const referenceCounts = new Map<string, number>();
-  for (const token of referenceTokens) {
-    referenceCounts.set(token, (referenceCounts.get(token) || 0) + 1);
-  }
-
-  let matches = 0;
-  for (const token of predictionTokens) {
-    const remaining = referenceCounts.get(token) || 0;
-    if (remaining <= 0) continue;
-    matches += 1;
-    referenceCounts.set(token, remaining - 1);
-  }
-
-  if (matches === 0) return 0;
-  const precision = matches / predictionTokens.length;
-  const recall = matches / referenceTokens.length;
-  return (2 * precision * recall) / (precision + recall);
+function mergeUsage(
+  target: LocomoUsageSummary,
+  usage: LocomoChatCompletionUsage | null,
+): void {
+  if (!usage) return;
+  const promptTokens =
+    typeof usage.prompt_tokens === 'number' &&
+    Number.isFinite(usage.prompt_tokens)
+      ? usage.prompt_tokens
+      : 0;
+  const completionTokens =
+    typeof usage.completion_tokens === 'number' &&
+    Number.isFinite(usage.completion_tokens)
+      ? usage.completion_tokens
+      : 0;
+  const totalTokens =
+    typeof usage.total_tokens === 'number' &&
+    Number.isFinite(usage.total_tokens)
+      ? usage.total_tokens
+      : promptTokens + completionTokens;
+  target.promptTokens += promptTokens;
+  target.completionTokens += completionTokens;
+  target.totalTokens += totalTokens;
+  target.responsesWithUsage += 1;
 }
 
-const DIA_ID_PATTERN = /^D(\d+):(\d+)$/i;
-
-function recallHitRate(
-  evidenceIds: string[],
-  sample: LocomoSample,
-  retrievedContent: string,
-): number {
-  if (!Array.isArray(evidenceIds) || evidenceIds.length === 0) {
-    return 1;
-  }
-  const expanded = evidenceIds.flatMap(splitEvidenceIds);
-  if (expanded.length === 0) return 0;
-
-  const turns = new Map(getTurns(sample).map((turn) => [turn.dia_id, turn]));
-  const haystack = retrievedContent.toLowerCase();
-  let found = 0;
-  let total = 0;
-
-  for (const evidenceId of expanded) {
-    const turn = turns.get(evidenceId);
-    if (!turn) continue;
-    total += 1;
-    if (haystack.includes(turn.text.toLowerCase())) {
-      found += 1;
-    }
-  }
-
-  if (total === 0) return 0;
-  return found / total;
-}
-
-function splitEvidenceIds(value: string): string[] {
+function normalizeModelPrediction(value: string): string {
   return String(value || '')
-    .split(';')
-    .flatMap((part) => part.split(/\s+/g))
-    .map((part) => normalizeDiaId(part.trim()))
-    .filter((part) => DIA_ID_PATTERN.test(part));
+    .replace(/^short answer:\s*/i, '')
+    .split('\n')[0]
+    .trim()
+    .replace(/^["']+|["']+$/g, '');
 }
 
-function normalizeDiaId(value: string): string {
-  const match = value.match(DIA_ID_PATTERN);
-  if (!match) return value;
-  return `D${Number.parseInt(match[1] || '0', 10)}:${Number.parseInt(match[2] || '0', 10)}`;
+function normalizeCategoryFivePrediction(
+  value: string,
+  answerKey: Record<'a' | 'b', string> | null,
+): string {
+  const normalized = normalizeModelPrediction(value).toLowerCase();
+  if (
+    normalized.includes('no information available') ||
+    normalized.includes('not mentioned')
+  ) {
+    return 'Not mentioned in the conversation';
+  }
+  if (answerKey && /^\(?a\)?$/.test(normalized)) {
+    return answerKey.a;
+  }
+  if (answerKey && /^\(?b\)?$/.test(normalized)) {
+    return answerKey.b;
+  }
+  return normalized;
+}
+
+function scoreLocomoAnswer(qa: LocomoQA, prediction: string): number {
+  return scoreOfficialLocomoAnswer({
+    category: qa.category,
+    prediction,
+    answer: answerToString(qa),
+  });
+}
+
+function answerToString(qa: LocomoQA): string {
+  if (typeof qa.answer === 'string') return qa.answer;
+  if (typeof qa.answer === 'number' && Number.isFinite(qa.answer)) {
+    return String(qa.answer);
+  }
+  if (qa.answer && typeof qa.answer === 'object') {
+    return JSON.stringify(qa.answer);
+  }
+  return String(qa.adversarial_answer || '').trim();
+}
+
+function estimateTokenCount(text: string): number {
+  return Math.max(1, Math.ceil(String(text || '').length / 4));
+}
+
+function roundMetric(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.round(value * 1000) / 1000;
+}
+
+function hashText(value: string): number {
+  const digest = createHash('sha1').update(value).digest();
+  return digest.readUInt32BE(0);
+}
+
+function formatLocomoCategoryLine(
+  category: string,
+  aggregate: LocomoCategoryAggregate,
+  mode: LocomoEvaluationMode,
+): string {
+  if (mode === 'retrieval') {
+    return `cat${category.padEnd(4)} Hit ${aggregate.meanScore.toFixed(3).padEnd(6)} F1 ${String(
+      (aggregate.contextF1 ?? 0).toFixed(3),
+    ).padEnd(6)} Q ${String(aggregate.questionCount)}`;
+  }
+  return `cat${category.padEnd(4)} Score ${aggregate.meanScore.toFixed(3).padEnd(6)} Q ${String(aggregate.questionCount)}`;
 }
 
 function printSummaryTable(summary: LocomoRunSummary): void {
   console.log('');
-  console.log('Mode      HitRate   F1       Questions');
-  for (const mode of Object.keys(summary.modes).sort()) {
-    const aggregate = summary.modes[mode as LocomoMode];
-    if (!aggregate) continue;
-    console.log(
-      `${mode.padEnd(9)} ${aggregate.overallHitRate.toFixed(3).padEnd(9)} ${aggregate.overallF1.toFixed(3).padEnd(8)} ${String(aggregate.totalQuestions)}`,
-    );
+  console.log(
+    summary.mode === 'retrieval'
+      ? 'Category  Hit     F1      Questions'
+      : 'Category  Score   Questions',
+  );
+  for (const [category, aggregate] of Object.entries(summary.categories).sort(
+    ([left], [right]) => Number(left) - Number(right),
+  )) {
+    console.log(formatLocomoCategoryLine(category, aggregate, summary.mode));
   }
   console.log('');
+  console.log(
+    summary.mode === 'retrieval'
+      ? `Hit rate: ${summary.overallScore.toFixed(3)}`
+      : `Overall score: ${summary.overallScore.toFixed(3)}`,
+  );
+  if (summary.mode === 'retrieval' && summary.contextF1 != null) {
+    console.log(`Context F1: ${summary.contextF1.toFixed(3)}`);
+  }
+  console.log(`Questions: ${summary.questionCount}`);
+  if (summary.tokenUsage) {
+    console.log(`Prompt tokens: ${summary.tokenUsage.promptTokens}`);
+    console.log(`Completion tokens: ${summary.tokenUsage.completionTokens}`);
+    console.log(`Total tokens: ${summary.tokenUsage.totalTokens}`);
+  }
+  console.log(`Predictions JSON: ${summary.predictionsPath}`);
   console.log(`Result JSON: ${summary.resultPath}`);
 }

--- a/src/evals/locomo-native.ts
+++ b/src/evals/locomo-native.ts
@@ -1,0 +1,789 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  getOrCreateSession,
+  initDatabase,
+  recallSemanticMemories,
+  storeSemanticMemory,
+} from '../memory/db.js';
+
+const LOCOMO_DATASET_URL =
+  'https://raw.githubusercontent.com/snap-research/locomo/main/data/locomo10.json';
+const LOCOMO_DATASET_FILENAME = 'locomo10.json';
+const LOCOMO_SETUP_MARKER = '.hybridclaw-setup-ok';
+const EMBEDDING_DIMENSIONS = 128;
+const DEFAULT_TOKEN_BUDGET = 4000;
+const DEFAULT_TOP_K = 20;
+
+type LocomoMode = 'recent' | 'semantic';
+type LocomoRequestedMode = 'all' | LocomoMode;
+
+interface LocomoTurn {
+  speaker: string;
+  dia_id: string;
+  text: string;
+}
+
+interface LocomoQA {
+  question: string;
+  answer?: unknown;
+  adversarial_answer?: string;
+  evidence?: string[];
+  category: number;
+}
+
+interface LocomoSample {
+  sample_id: string;
+  conversation: Record<string, unknown>;
+  qa: LocomoQA[];
+}
+
+interface LocomoRunnerOptions {
+  operation: 'setup' | 'run';
+  installDir: string;
+  budgetTokens: number;
+  requestedMode: LocomoRequestedMode;
+  numSamples: number | null;
+  topK: number;
+}
+
+interface CategoryAggregate {
+  f1: number;
+  hitRate: number;
+  questionCount: number;
+}
+
+interface ModeAggregate {
+  overallF1: number;
+  overallHitRate: number;
+  totalQuestions: number;
+  byCategory: Record<string, CategoryAggregate>;
+}
+
+interface SampleModeSummary {
+  overallF1: number;
+  overallHitRate: number;
+  totalQuestions: number;
+}
+
+interface SampleSummary {
+  sampleId: string;
+  modes: Partial<Record<LocomoMode, SampleModeSummary>>;
+}
+
+interface LocomoRunSummary {
+  suite: 'locomo';
+  dataset: string;
+  generatedAt: string;
+  budgetTokens: number;
+  topK: number;
+  sampleCount: number;
+  requestedMode: LocomoRequestedMode;
+  resultPath: string;
+  modes: Partial<Record<LocomoMode, ModeAggregate>>;
+  samples: SampleSummary[];
+}
+
+interface SemanticSessionRecord {
+  sessionId: string;
+  turns: string[];
+}
+
+const STOPWORDS = new Set([
+  'a',
+  'about',
+  'after',
+  'all',
+  'an',
+  'and',
+  'any',
+  'are',
+  'as',
+  'at',
+  'be',
+  'been',
+  'being',
+  'before',
+  'between',
+  'but',
+  'by',
+  'can',
+  'could',
+  'did',
+  'do',
+  'does',
+  'for',
+  'from',
+  'had',
+  'has',
+  'have',
+  'he',
+  'her',
+  'his',
+  'how',
+  'i',
+  'if',
+  'in',
+  'into',
+  'is',
+  'it',
+  'its',
+  'me',
+  'my',
+  'no',
+  'not',
+  'of',
+  'on',
+  'or',
+  'our',
+  'over',
+  'she',
+  'so',
+  'some',
+  'that',
+  'the',
+  'their',
+  'them',
+  'then',
+  'there',
+  'they',
+  'this',
+  'to',
+  'until',
+  'was',
+  'we',
+  'were',
+  'what',
+  'when',
+  'where',
+  'which',
+  'who',
+  'why',
+  'will',
+  'with',
+  'would',
+  'you',
+  'your',
+]);
+
+export async function runLocomoNativeCli(argv: string[]): Promise<void> {
+  const options = parseArgs(argv);
+  if (options.operation === 'setup') {
+    await runSetup(options);
+    return;
+  }
+  await runEvaluation(options);
+}
+
+function parseArgs(argv: string[]): LocomoRunnerOptions {
+  let operation: LocomoRunnerOptions['operation'] | null = null;
+  let installDir = '';
+  let budgetTokens = DEFAULT_TOKEN_BUDGET;
+  let requestedMode: LocomoRequestedMode = 'all';
+  let numSamples: number | null = null;
+  let topK = DEFAULT_TOP_K;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const current = String(argv[index] || '').trim();
+    if (!current) continue;
+    if (current === 'setup' || current === 'run') {
+      operation = current;
+      continue;
+    }
+
+    const [flag, inlineValue] = splitInlineFlag(current);
+    const nextValue = () => inlineValue || String(argv[index + 1] || '').trim();
+
+    if (flag === '--install-dir') {
+      installDir = nextValue();
+      if (!inlineValue) index += 1;
+      continue;
+    }
+    if (flag === '--budget') {
+      budgetTokens = clampPositiveInt(nextValue(), DEFAULT_TOKEN_BUDGET);
+      if (!inlineValue) index += 1;
+      continue;
+    }
+    if (flag === '--mode') {
+      const value = nextValue().toLowerCase();
+      if (value === 'all' || value === 'recent' || value === 'semantic') {
+        requestedMode = value;
+      } else {
+        throw new Error(
+          `Unsupported LOCOMO mode \`${value || '(empty)'}\`. Use all, recent, or semantic.`,
+        );
+      }
+      if (!inlineValue) index += 1;
+      continue;
+    }
+    if (flag === '--num-samples') {
+      const parsed = clampPositiveInt(nextValue(), 0);
+      numSamples = parsed > 0 ? parsed : null;
+      if (!inlineValue) index += 1;
+      continue;
+    }
+    if (flag === '--top-k') {
+      topK = clampPositiveInt(nextValue(), DEFAULT_TOP_K);
+      if (!inlineValue) index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown LOCOMO option: \`${current}\`.`);
+  }
+
+  if (!operation) {
+    throw new Error('Missing LOCOMO operation. Use `setup` or `run`.');
+  }
+  if (!installDir) {
+    throw new Error('Missing required `--install-dir`.');
+  }
+
+  return {
+    operation,
+    installDir: path.resolve(installDir),
+    budgetTokens,
+    requestedMode,
+    numSamples,
+    topK,
+  };
+}
+
+function splitInlineFlag(value: string): [string, string] {
+  const separator = value.indexOf('=');
+  if (separator < 0) return [value, ''];
+  return [value.slice(0, separator), value.slice(separator + 1).trim()];
+}
+
+function clampPositiveInt(value: string, fallback: number): number {
+  const parsed = Number.parseInt(String(value || '').trim(), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+function getMarkerPath(installDir: string): string {
+  return path.join(installDir, LOCOMO_SETUP_MARKER);
+}
+
+function getDatasetPath(installDir: string): string {
+  return path.join(installDir, 'data', LOCOMO_DATASET_FILENAME);
+}
+
+async function runSetup(options: LocomoRunnerOptions): Promise<void> {
+  fs.mkdirSync(options.installDir, { recursive: true });
+  fs.mkdirSync(path.dirname(getDatasetPath(options.installDir)), {
+    recursive: true,
+  });
+
+  const datasetPath = getDatasetPath(options.installDir);
+  if (!fs.existsSync(datasetPath)) {
+    console.log(`Downloading dataset from ${LOCOMO_DATASET_URL}`);
+    const response = await fetch(LOCOMO_DATASET_URL);
+    if (!response.ok) {
+      throw new Error(
+        `Failed to download LOCOMO dataset: HTTP ${response.status}`,
+      );
+    }
+    const raw = await response.text();
+    if (!raw.trim().startsWith('[')) {
+      throw new Error('Downloaded LOCOMO dataset is not valid JSON.');
+    }
+    fs.writeFileSync(datasetPath, raw, 'utf-8');
+  } else {
+    console.log(`Dataset already present at ${datasetPath}`);
+  }
+
+  const sampleCount = loadSamples(datasetPath).length;
+  fs.writeFileSync(getMarkerPath(options.installDir), 'ok\n', 'utf-8');
+
+  console.log(`Install dir: ${options.installDir}`);
+  console.log(`Dataset path: ${datasetPath}`);
+  console.log(`Samples: ${sampleCount}`);
+  console.log('LOCOMO setup complete.');
+}
+
+async function runEvaluation(options: LocomoRunnerOptions): Promise<void> {
+  const datasetPath = getDatasetPath(options.installDir);
+  if (
+    !fs.existsSync(getMarkerPath(options.installDir)) ||
+    !fs.existsSync(datasetPath)
+  ) {
+    throw new Error('LOCOMO is not set up. Run `/eval locomo setup` first.');
+  }
+
+  const allSamples = loadSamples(datasetPath);
+  const selectedSamples =
+    options.numSamples && options.numSamples > 0
+      ? allSamples.slice(0, options.numSamples)
+      : allSamples;
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const jobDir = path.join(options.installDir, 'jobs', timestamp);
+  fs.mkdirSync(jobDir, { recursive: true });
+
+  console.log(`Job dir: ${jobDir}`);
+  console.log(`Dataset: ${datasetPath}`);
+  console.log(`Samples: ${selectedSamples.length}`);
+  console.log(`Budget: ${options.budgetTokens}`);
+  console.log(`Mode: ${options.requestedMode}`);
+  console.log(`Top K: ${options.topK}`);
+
+  const modes = resolveModes(options.requestedMode);
+  const semanticSessions = modes.includes('semantic')
+    ? ingestSemanticDataset(selectedSamples, path.join(jobDir, 'locomo.db'))
+    : new Map<string, SemanticSessionRecord>();
+  const summary = evaluateSamples({
+    datasetPath,
+    jobDir,
+    budgetTokens: options.budgetTokens,
+    requestedMode: options.requestedMode,
+    topK: options.topK,
+    samples: selectedSamples,
+    modes,
+    semanticSessions,
+  });
+
+  fs.writeFileSync(
+    summary.resultPath,
+    JSON.stringify(summary, null, 2),
+    'utf-8',
+  );
+  printSummaryTable(summary);
+}
+
+function resolveModes(requestedMode: LocomoRequestedMode): LocomoMode[] {
+  if (requestedMode === 'all') return ['recent', 'semantic'];
+  return [requestedMode];
+}
+
+function loadSamples(datasetPath: string): LocomoSample[] {
+  const raw = fs.readFileSync(datasetPath, 'utf-8');
+  const parsed = JSON.parse(raw) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error(`Expected LOCOMO dataset array in ${datasetPath}.`);
+  }
+  return parsed as LocomoSample[];
+}
+
+function ingestSemanticDataset(
+  samples: LocomoSample[],
+  dbPath: string,
+): Map<string, SemanticSessionRecord> {
+  initDatabase({ dbPath, quiet: true });
+  const sessions = new Map<string, SemanticSessionRecord>();
+
+  for (const sample of samples) {
+    const sessionId = `locomo-${sample.sample_id}`;
+    getOrCreateSession(sessionId, null, 'eval-locomo', 'main');
+
+    const turns = getTurns(sample);
+    const formattedTurns: string[] = [];
+    for (const turn of turns) {
+      const content = formatTurn(turn);
+      formattedTurns.push(content);
+      storeSemanticMemory({
+        sessionId,
+        role: 'user',
+        source: 'locomo',
+        scope: 'episodic',
+        metadata: {
+          diaId: turn.dia_id,
+          speaker: turn.speaker,
+        },
+        content,
+        confidence: 1,
+        embedding: embedText(content),
+      });
+    }
+    sessions.set(sample.sample_id, {
+      sessionId,
+      turns: formattedTurns,
+    });
+  }
+
+  return sessions;
+}
+
+function evaluateSamples(params: {
+  datasetPath: string;
+  jobDir: string;
+  budgetTokens: number;
+  requestedMode: LocomoRequestedMode;
+  topK: number;
+  samples: LocomoSample[];
+  modes: LocomoMode[];
+  semanticSessions: Map<string, SemanticSessionRecord>;
+}): LocomoRunSummary {
+  const overall = new Map<LocomoMode, RunningAggregate>();
+  const sampleSummaries: SampleSummary[] = [];
+  for (const mode of params.modes) {
+    overall.set(mode, createRunningAggregate());
+  }
+
+  for (const sample of params.samples) {
+    const turns = getTurns(sample).map(formatTurn);
+    const sampleSummary: SampleSummary = {
+      sampleId: sample.sample_id,
+      modes: {},
+    };
+
+    for (const mode of params.modes) {
+      const aggregate = createRunningAggregate();
+      for (const qa of sample.qa || []) {
+        const answer = answerToString(qa);
+        const context =
+          mode === 'recent'
+            ? buildRecentContext(turns, params.budgetTokens)
+            : buildSemanticContext({
+                session: params.semanticSessions.get(sample.sample_id) || null,
+                question: qa.question,
+                topK: params.topK,
+                budgetTokens: params.budgetTokens,
+              });
+        accumulateScore({
+          aggregate,
+          category: qa.category,
+          answer,
+          context,
+          evidence: qa.evidence || [],
+          sample,
+        });
+      }
+
+      sampleSummary.modes[mode] = finalizeAggregate(aggregate);
+      mergeAggregate(overall.get(mode) || createRunningAggregate(), aggregate);
+    }
+
+    sampleSummaries.push(sampleSummary);
+  }
+
+  const modeSummaries: Partial<Record<LocomoMode, ModeAggregate>> = {};
+  for (const mode of params.modes) {
+    const aggregate = overall.get(mode);
+    if (!aggregate) continue;
+    modeSummaries[mode] = finalizeAggregate(aggregate);
+  }
+
+  const resultPath = path.join(params.jobDir, 'result.json');
+  return {
+    suite: 'locomo',
+    dataset: path.basename(params.datasetPath),
+    generatedAt: new Date().toISOString(),
+    budgetTokens: params.budgetTokens,
+    topK: params.topK,
+    sampleCount: params.samples.length,
+    requestedMode: params.requestedMode,
+    resultPath,
+    modes: modeSummaries,
+    samples: sampleSummaries,
+  };
+}
+
+interface RunningAggregate {
+  totalF1: number;
+  totalHitRate: number;
+  totalQuestions: number;
+  byCategory: Map<number, CategoryAggregate>;
+}
+
+function createRunningAggregate(): RunningAggregate {
+  return {
+    totalF1: 0,
+    totalHitRate: 0,
+    totalQuestions: 0,
+    byCategory: new Map<number, CategoryAggregate>(),
+  };
+}
+
+function accumulateScore(params: {
+  aggregate: RunningAggregate;
+  category: number;
+  answer: string;
+  context: string;
+  evidence: string[];
+  sample: LocomoSample;
+}): void {
+  const f1 = tokenOverlapF1(params.context, params.answer);
+  const hitRate = recallHitRate(params.evidence, params.sample, params.context);
+  params.aggregate.totalF1 += f1;
+  params.aggregate.totalHitRate += hitRate;
+  params.aggregate.totalQuestions += 1;
+
+  const current = params.aggregate.byCategory.get(params.category) || {
+    f1: 0,
+    hitRate: 0,
+    questionCount: 0,
+  };
+  current.f1 += f1;
+  current.hitRate += hitRate;
+  current.questionCount += 1;
+  params.aggregate.byCategory.set(params.category, current);
+}
+
+function mergeAggregate(
+  target: RunningAggregate,
+  source: RunningAggregate,
+): void {
+  target.totalF1 += source.totalF1;
+  target.totalHitRate += source.totalHitRate;
+  target.totalQuestions += source.totalQuestions;
+  for (const [category, value] of source.byCategory.entries()) {
+    const current = target.byCategory.get(category) || {
+      f1: 0,
+      hitRate: 0,
+      questionCount: 0,
+    };
+    current.f1 += value.f1;
+    current.hitRate += value.hitRate;
+    current.questionCount += value.questionCount;
+    target.byCategory.set(category, current);
+  }
+}
+
+function finalizeAggregate(aggregate: RunningAggregate): ModeAggregate {
+  const totalQuestions = Math.max(aggregate.totalQuestions, 1);
+  const byCategory: Record<string, CategoryAggregate> = {};
+  for (const [category, value] of aggregate.byCategory.entries()) {
+    byCategory[String(category)] = {
+      f1: roundMetric(value.f1 / Math.max(value.questionCount, 1)),
+      hitRate: roundMetric(value.hitRate / Math.max(value.questionCount, 1)),
+      questionCount: value.questionCount,
+    };
+  }
+  return {
+    overallF1: roundMetric(aggregate.totalF1 / totalQuestions),
+    overallHitRate: roundMetric(aggregate.totalHitRate / totalQuestions),
+    totalQuestions: aggregate.totalQuestions,
+    byCategory,
+  };
+}
+
+function roundMetric(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.round(value * 1000) / 1000;
+}
+
+function getTurns(sample: LocomoSample): LocomoTurn[] {
+  const sessionNames = Object.keys(sample.conversation || {})
+    .filter((key) => /^session_\d+$/.test(key))
+    .sort((left, right) => {
+      const leftNum = Number.parseInt(left.slice('session_'.length), 10) || 0;
+      const rightNum = Number.parseInt(right.slice('session_'.length), 10) || 0;
+      return leftNum - rightNum;
+    });
+  const turns: LocomoTurn[] = [];
+  for (const sessionName of sessionNames) {
+    const raw = sample.conversation[sessionName];
+    if (!Array.isArray(raw)) continue;
+    for (const entry of raw) {
+      if (!entry || typeof entry !== 'object') continue;
+      const record = entry as Record<string, unknown>;
+      const speaker = String(record.speaker || '').trim();
+      const diaId = String(record.dia_id || '').trim();
+      const text = String(record.text || '').trim();
+      if (!speaker || !diaId || !text) continue;
+      turns.push({
+        speaker,
+        dia_id: diaId,
+        text,
+      });
+    }
+  }
+  return turns;
+}
+
+function formatTurn(turn: LocomoTurn): string {
+  return `${turn.speaker}: ${turn.text}`;
+}
+
+function answerToString(qa: LocomoQA): string {
+  if (typeof qa.answer === 'string') return qa.answer;
+  if (typeof qa.answer === 'number' && Number.isFinite(qa.answer)) {
+    return String(qa.answer);
+  }
+  if (qa.answer && typeof qa.answer === 'object') {
+    return JSON.stringify(qa.answer);
+  }
+  return String(qa.adversarial_answer || '').trim();
+}
+
+function buildRecentContext(turns: string[], budgetTokens: number): string {
+  const selected: string[] = [];
+  let totalTokens = 0;
+  for (let index = turns.length - 1; index >= 0; index -= 1) {
+    const content = turns[index];
+    const nextTokens = estimateTokenCount(content);
+    if (totalTokens + nextTokens > budgetTokens && selected.length > 0) {
+      break;
+    }
+    selected.unshift(content);
+    totalTokens += nextTokens;
+  }
+  return selected.join('\n');
+}
+
+function buildSemanticContext(params: {
+  session: SemanticSessionRecord | null;
+  question: string;
+  topK: number;
+  budgetTokens: number;
+}): string {
+  if (!params.session) return '';
+  const memories = recallSemanticMemories({
+    sessionId: params.session.sessionId,
+    query: params.question,
+    limit: params.topK,
+    minConfidence: 0,
+    queryEmbedding: embedText(params.question),
+  });
+  const selected: string[] = [];
+  let totalTokens = 0;
+  for (const memory of memories) {
+    const content = String(memory.content || '').trim();
+    if (!content) continue;
+    const nextTokens = estimateTokenCount(content);
+    if (totalTokens + nextTokens > params.budgetTokens && selected.length > 0) {
+      break;
+    }
+    selected.push(content);
+    totalTokens += nextTokens;
+  }
+  return selected.join('\n');
+}
+
+function estimateTokenCount(text: string): number {
+  return Math.max(1, Math.ceil(text.length / 4));
+}
+
+function embedText(text: string): number[] | null {
+  const normalized = text
+    .toLowerCase()
+    .replace(/[^a-z0-9_\s-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!normalized) return null;
+
+  const tokens = normalized
+    .split(' ')
+    .map((token) => token.trim())
+    .filter((token) => token.length > 1 && !STOPWORDS.has(token))
+    .slice(0, 256);
+  if (tokens.length === 0) return null;
+
+  const vector = new Float32Array(EMBEDDING_DIMENSIONS);
+  for (const token of tokens) {
+    const hash = hashToken(token);
+    const index = hash % EMBEDDING_DIMENSIONS;
+    const sign = (hash & 1) === 0 ? 1 : -1;
+    vector[index] += sign * Math.min(4, token.length);
+  }
+
+  let norm = 0;
+  for (let index = 0; index < vector.length; index += 1) {
+    norm += vector[index] * vector[index];
+  }
+  if (norm <= Number.EPSILON) return null;
+  const scale = 1 / Math.sqrt(norm);
+  return Array.from(vector, (value) => value * scale);
+}
+
+function hashToken(token: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < token.length; index += 1) {
+    hash ^= token.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function tokenize(text: string): string[] {
+  return String(text || '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/g)
+    .map((token) => token.trim())
+    .filter(Boolean);
+}
+
+function tokenOverlapF1(prediction: string, reference: string): number {
+  const predictionTokens = tokenize(prediction);
+  const referenceTokens = tokenize(reference);
+  if (predictionTokens.length === 0 || referenceTokens.length === 0) {
+    return 0;
+  }
+
+  const referenceCounts = new Map<string, number>();
+  for (const token of referenceTokens) {
+    referenceCounts.set(token, (referenceCounts.get(token) || 0) + 1);
+  }
+
+  let matches = 0;
+  for (const token of predictionTokens) {
+    const remaining = referenceCounts.get(token) || 0;
+    if (remaining <= 0) continue;
+    matches += 1;
+    referenceCounts.set(token, remaining - 1);
+  }
+
+  if (matches === 0) return 0;
+  const precision = matches / predictionTokens.length;
+  const recall = matches / referenceTokens.length;
+  return (2 * precision * recall) / (precision + recall);
+}
+
+const DIA_ID_PATTERN = /^D(\d+):(\d+)$/i;
+
+function recallHitRate(
+  evidenceIds: string[],
+  sample: LocomoSample,
+  retrievedContent: string,
+): number {
+  if (!Array.isArray(evidenceIds) || evidenceIds.length === 0) {
+    return 1;
+  }
+  const expanded = evidenceIds.flatMap(splitEvidenceIds);
+  if (expanded.length === 0) return 0;
+
+  const turns = new Map(getTurns(sample).map((turn) => [turn.dia_id, turn]));
+  const haystack = retrievedContent.toLowerCase();
+  let found = 0;
+  let total = 0;
+
+  for (const evidenceId of expanded) {
+    const turn = turns.get(evidenceId);
+    if (!turn) continue;
+    total += 1;
+    if (haystack.includes(turn.text.toLowerCase())) {
+      found += 1;
+    }
+  }
+
+  if (total === 0) return 0;
+  return found / total;
+}
+
+function splitEvidenceIds(value: string): string[] {
+  return String(value || '')
+    .split(';')
+    .flatMap((part) => part.split(/\s+/g))
+    .map((part) => normalizeDiaId(part.trim()))
+    .filter((part) => DIA_ID_PATTERN.test(part));
+}
+
+function normalizeDiaId(value: string): string {
+  const match = value.match(DIA_ID_PATTERN);
+  if (!match) return value;
+  return `D${Number.parseInt(match[1] || '0', 10)}:${Number.parseInt(match[2] || '0', 10)}`;
+}
+
+function printSummaryTable(summary: LocomoRunSummary): void {
+  console.log('');
+  console.log('Mode      HitRate   F1       Questions');
+  for (const mode of Object.keys(summary.modes).sort()) {
+    const aggregate = summary.modes[mode as LocomoMode];
+    if (!aggregate) continue;
+    console.log(
+      `${mode.padEnd(9)} ${aggregate.overallHitRate.toFixed(3).padEnd(9)} ${aggregate.overallF1.toFixed(3).padEnd(8)} ${String(aggregate.totalQuestions)}`,
+    );
+  }
+  console.log('');
+  console.log(`Result JSON: ${summary.resultPath}`);
+}

--- a/src/evals/locomo-native.ts
+++ b/src/evals/locomo-native.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
-import { initDatabase, storeSemanticMemory } from '../memory/db.js';
+import { initDatabase } from '../memory/db.js';
 import { memoryService } from '../memory/memory-service.js';
 import { buildSessionKey } from '../session/session-key.js';
 import type { SemanticMemoryEntry } from '../types/memory.js';
@@ -13,17 +13,28 @@ import {
   parseEvalProfileModel,
 } from './eval-profile.js';
 import { scoreOfficialLocomoAnswer } from './locomo-official-scoring.js';
+import type {
+  LocomoAgentMode,
+  LocomoCategoryAggregate,
+  LocomoTokenUsage,
+} from './locomo-types.js';
+import {
+  LOCOMO_DATASET_FILENAME,
+  LOCOMO_SETUP_MARKER,
+} from './locomo-types.js';
 
 const LOCOMO_DATASET_COMMIT = '3eb6f2c585f5e1699204e3c3bdf7adc5c28cb376';
 const LOCOMO_DATASET_URL = `https://raw.githubusercontent.com/snap-research/locomo/${LOCOMO_DATASET_COMMIT}/data/locomo10.json`;
 const LOCOMO_DATASET_SHA256 =
   '79fa87e90f04081343b8c8debecb80a9a6842b76a7aa537dc9fdf651ea698ff4';
-const LOCOMO_DATASET_FILENAME = 'locomo10.json';
-const LOCOMO_SETUP_MARKER = '.hybridclaw-setup-ok';
 const DEFAULT_TOKEN_BUDGET = 4000;
 const ANSWER_BUFFER_TOKENS = 64;
 const DEFAULT_OPENAI_BASE_URL = 'http://127.0.0.1:9090/v1';
 const DEFAULT_EVAL_MODEL = 'hybridai/gpt-4.1-mini';
+const LOCOMO_DATASET_DOWNLOAD_TIMEOUT_MS = 120_000;
+const LOCOMO_MODEL_CALL_TIMEOUT_MS = 30_000;
+const LOCOMO_QA_CONCURRENCY = 4;
+const LOCOMO_PROGRESS_WRITE_INTERVAL_QUESTIONS = 20;
 
 const CONVERSATION_START_PROMPT =
   'Below is a conversation between two people: {speakerA} and {speakerB}. The conversation takes place over multiple days and the date of each conversation is written at the beginning of the conversation.\n\n';
@@ -42,9 +53,13 @@ Question: {question}
 Short answer:
 `.trim();
 
+const flattenedConversationTurnsCache = new WeakMap<
+  Record<string, unknown>,
+  LocomoFlattenedTurn[]
+>();
+
 type LocomoOperation = 'setup' | 'run';
 type LocomoEvaluationMode = 'qa' | 'retrieval';
-type LocomoAgentMode = 'conversation-fresh' | 'current-agent' | 'fresh-request';
 
 interface LocomoTurn {
   speaker: string;
@@ -52,6 +67,11 @@ interface LocomoTurn {
   text: string;
   blip_caption?: string;
 }
+
+type LocomoFlattenedTurn = LocomoTurn & {
+  sessionNum: number;
+  dateTime: string;
+};
 
 interface LocomoQA {
   question: string;
@@ -83,19 +103,6 @@ interface LocomoGatewayRuntime {
   model: string;
   baseModel: string;
   profile: EvalProfile;
-}
-
-interface LocomoUsageSummary {
-  promptTokens: number;
-  completionTokens: number;
-  totalTokens: number;
-  responsesWithUsage: number;
-}
-
-interface LocomoCategoryAggregate {
-  meanScore: number;
-  questionCount: number;
-  contextF1: number | null;
 }
 
 interface LocomoQuestionPrediction {
@@ -131,7 +138,7 @@ interface LocomoRunSummary {
   resultPath: string;
   predictionsPath: string;
   categories: Record<string, LocomoCategoryAggregate>;
-  tokenUsage: LocomoUsageSummary | null;
+  tokenUsage: LocomoTokenUsage | null;
   samples: Array<{
     sampleId: string;
     questionCount: number;
@@ -159,7 +166,7 @@ interface LocomoProgressSummary {
   resultPath: string;
   predictionsPath: string;
   categories: Record<string, LocomoCategoryAggregate>;
-  tokenUsage: LocomoUsageSummary | null;
+  tokenUsage: LocomoTokenUsage | null;
 }
 
 interface LocomoChatCompletionUsage {
@@ -248,11 +255,7 @@ function parseArgs(argv: string[]): LocomoRunnerOptions {
     }
     if (flag === '--agent-mode') {
       const value = nextValue().toLowerCase();
-      if (
-        value === 'conversation-fresh' ||
-        value === 'current-agent' ||
-        value === 'fresh-request'
-      ) {
+      if (value === 'conversation-fresh' || value === 'current-agent') {
         agentMode = value;
       } else {
         throw new Error(
@@ -317,14 +320,19 @@ async function runSetup(options: LocomoRunnerOptions): Promise<void> {
   const datasetPath = getDatasetPath(options.installDir);
   if (!fs.existsSync(datasetPath)) {
     console.log(`Downloading dataset from ${LOCOMO_DATASET_URL}`);
-    const response = await fetch(LOCOMO_DATASET_URL);
+    const response = await fetchWithTimeout(
+      LOCOMO_DATASET_URL,
+      undefined,
+      LOCOMO_DATASET_DOWNLOAD_TIMEOUT_MS,
+      'LOCOMO dataset download',
+    );
     if (!response.ok) {
       throw new Error(
         `Failed to download LOCOMO dataset: HTTP ${response.status}`,
       );
     }
     const rawBuffer = Buffer.from(await response.arrayBuffer());
-    verifyDownloadedDataset(rawBuffer, response.url);
+    verifyDownloadedDataset(rawBuffer);
     const raw = rawBuffer.toString('utf-8');
     if (!raw.trim().startsWith('[')) {
       throw new Error('Downloaded LOCOMO dataset is not valid JSON.');
@@ -345,12 +353,22 @@ async function runSetup(options: LocomoRunnerOptions): Promise<void> {
 
 async function runEvaluation(options: LocomoRunnerOptions): Promise<void> {
   const datasetPath = getDatasetPath(options.installDir);
-  if (
-    !fs.existsSync(getMarkerPath(options.installDir)) ||
-    !fs.existsSync(datasetPath)
-  ) {
+  const markerPath = getMarkerPath(options.installDir);
+  const hasMarker = fs.existsSync(markerPath);
+  const hasDataset = fs.existsSync(datasetPath);
+  if (!hasMarker && !hasDataset) {
     throw new Error(
       'LOCOMO is not set up. Run `setup` first, or use `/eval locomo setup`.',
+    );
+  }
+  if (!hasDataset) {
+    throw new Error(
+      `LOCOMO dataset is missing at ${datasetPath}. Re-run \`setup\`, or use \`/eval locomo setup\`.`,
+    );
+  }
+  if (!hasMarker) {
+    throw new Error(
+      `LOCOMO setup marker is missing at ${markerPath}. Re-run \`setup\`, or use \`/eval locomo setup\`.`,
     );
   }
 
@@ -401,7 +419,7 @@ async function runEvaluation(options: LocomoRunnerOptions): Promise<void> {
 
   const predictions: LocomoSamplePrediction[] = [];
   const categories = new Map<number, LocomoCategoryRunningAggregate>();
-  const usageTotals: LocomoUsageSummary = {
+  const usageTotals: LocomoTokenUsage = {
     promptTokens: 0,
     completionTokens: 0,
     totalTokens: 0,
@@ -434,6 +452,43 @@ async function runEvaluation(options: LocomoRunnerOptions): Promise<void> {
     currentSampleQuestionTotal: null,
   });
 
+  const writeQuestionProgress = (params: {
+    samplePrediction: LocomoSamplePrediction;
+    model: string | null;
+    contextF1TotalForSnapshot: number;
+  }): void => {
+    if (
+      !shouldWriteQuestionProgressSnapshot(params.samplePrediction.qa.length)
+    ) {
+      return;
+    }
+    const completedQuestionCount =
+      questionCount + params.samplePrediction.qa.length;
+    const partialScoreTotal =
+      scoreTotal +
+      params.samplePrediction.qa.reduce((total, qa) => total + qa.score, 0);
+    writeProgressFile({
+      progressPath,
+      resultPath,
+      predictionsPath,
+      mode: options.mode,
+      datasetPath,
+      model: params.model,
+      budgetTokens: options.budgetTokens,
+      sampleCount: plannedSamples.length,
+      completedSampleCount,
+      questionCount: totalQuestionCount,
+      completedQuestionCount,
+      scoreTotal: partialScoreTotal,
+      contextF1Total: params.contextF1TotalForSnapshot,
+      categories,
+      usageTotals,
+      currentSampleId: params.samplePrediction.sampleId,
+      currentSampleQuestionCount: params.samplePrediction.qa.length,
+      currentSampleQuestionTotal: params.samplePrediction.questionCount,
+    });
+  };
+
   for (const sample of plannedSamples) {
     const samplePrediction =
       options.mode === 'retrieval'
@@ -448,36 +503,16 @@ async function runEvaluation(options: LocomoRunnerOptions): Promise<void> {
               runtime,
             }),
             onQuestionProgress: ({ samplePrediction }) => {
-              const completedQuestionCount =
-                questionCount + samplePrediction.qa.length;
-              const partialScoreTotal =
-                scoreTotal +
-                samplePrediction.qa.reduce((total, qa) => total + qa.score, 0);
               const partialContextF1Total =
                 contextF1Total +
                 samplePrediction.qa.reduce(
                   (total, qa) => total + (qa.contextF1 || 0),
                   0,
                 );
-              writeProgressFile({
-                progressPath,
-                resultPath,
-                predictionsPath,
-                mode: options.mode,
-                datasetPath,
+              writeQuestionProgress({
+                samplePrediction,
                 model: null,
-                budgetTokens: options.budgetTokens,
-                sampleCount: plannedSamples.length,
-                completedSampleCount,
-                questionCount: totalQuestionCount,
-                completedQuestionCount,
-                scoreTotal: partialScoreTotal,
-                contextF1Total: partialContextF1Total,
-                categories,
-                usageTotals,
-                currentSampleId: samplePrediction.sampleId,
-                currentSampleQuestionCount: samplePrediction.qa.length,
-                currentSampleQuestionTotal: samplePrediction.questionCount,
+                contextF1TotalForSnapshot: partialContextF1Total,
               });
             },
           })
@@ -494,30 +529,10 @@ async function runEvaluation(options: LocomoRunnerOptions): Promise<void> {
             usageTotals,
             categories,
             onQuestionProgress: ({ samplePrediction }) => {
-              const completedQuestionCount =
-                questionCount + samplePrediction.qa.length;
-              const partialScoreTotal =
-                scoreTotal +
-                samplePrediction.qa.reduce((total, qa) => total + qa.score, 0);
-              writeProgressFile({
-                progressPath,
-                resultPath,
-                predictionsPath,
-                mode: options.mode,
-                datasetPath,
+              writeQuestionProgress({
+                samplePrediction,
                 model: runtime.model,
-                budgetTokens: options.budgetTokens,
-                sampleCount: plannedSamples.length,
-                completedSampleCount,
-                questionCount: totalQuestionCount,
-                completedQuestionCount,
-                scoreTotal: partialScoreTotal,
-                contextF1Total,
-                categories,
-                usageTotals,
-                currentSampleId: samplePrediction.sampleId,
-                currentSampleQuestionCount: samplePrediction.qa.length,
-                currentSampleQuestionTotal: samplePrediction.questionCount,
+                contextF1TotalForSnapshot: contextF1Total,
               });
             },
           });
@@ -561,22 +576,6 @@ async function runEvaluation(options: LocomoRunnerOptions): Promise<void> {
     'utf-8',
   );
 
-  const categorySummaries: Record<string, LocomoCategoryAggregate> = {};
-  for (const [category, aggregate] of categories.entries()) {
-    categorySummaries[String(category)] = {
-      meanScore: roundMetric(
-        aggregate.scoreTotal / Math.max(aggregate.questionCount, 1),
-      ),
-      questionCount: aggregate.questionCount,
-      contextF1:
-        options.mode === 'retrieval'
-          ? roundMetric(
-              aggregate.contextF1Total / Math.max(aggregate.questionCount, 1),
-            )
-          : null,
-    };
-  }
-
   const summary: LocomoRunSummary = {
     suite: 'locomo',
     mode: options.mode,
@@ -593,7 +592,7 @@ async function runEvaluation(options: LocomoRunnerOptions): Promise<void> {
         : null,
     resultPath,
     predictionsPath,
-    categories: categorySummaries,
+    categories: buildCategorySummaries(categories, options.mode),
     tokenUsage:
       options.mode === 'qa' && usageTotals.responsesWithUsage > 0
         ? usageTotals
@@ -635,6 +634,38 @@ function applyQuestionLimit(
   return selected;
 }
 
+function shouldWriteQuestionProgressSnapshot(
+  completedSampleQuestionCount: number,
+): boolean {
+  return (
+    completedSampleQuestionCount === 1 ||
+    completedSampleQuestionCount % LOCOMO_PROGRESS_WRITE_INTERVAL_QUESTIONS ===
+      0
+  );
+}
+
+function buildCategorySummaries(
+  categories: Map<number, LocomoCategoryRunningAggregate>,
+  mode: LocomoEvaluationMode,
+): Record<string, LocomoCategoryAggregate> {
+  const categorySummaries: Record<string, LocomoCategoryAggregate> = {};
+  for (const [category, aggregate] of categories.entries()) {
+    categorySummaries[String(category)] = {
+      meanScore: roundMetric(
+        aggregate.scoreTotal / Math.max(aggregate.questionCount, 1),
+      ),
+      questionCount: aggregate.questionCount,
+      contextF1:
+        mode === 'retrieval'
+          ? roundMetric(
+              aggregate.contextF1Total / Math.max(aggregate.questionCount, 1),
+            )
+          : null,
+    };
+  }
+  return categorySummaries;
+}
+
 function writeProgressFile(params: {
   progressPath: string;
   resultPath: string;
@@ -650,26 +681,11 @@ function writeProgressFile(params: {
   scoreTotal: number;
   contextF1Total: number;
   categories: Map<number, LocomoCategoryRunningAggregate>;
-  usageTotals: LocomoUsageSummary;
+  usageTotals: LocomoTokenUsage;
   currentSampleId: string | null;
   currentSampleQuestionCount: number | null;
   currentSampleQuestionTotal: number | null;
 }): void {
-  const categorySummaries: Record<string, LocomoCategoryAggregate> = {};
-  for (const [category, aggregate] of params.categories.entries()) {
-    categorySummaries[String(category)] = {
-      meanScore: roundMetric(
-        aggregate.scoreTotal / Math.max(aggregate.questionCount, 1),
-      ),
-      questionCount: aggregate.questionCount,
-      contextF1:
-        params.mode === 'retrieval'
-          ? roundMetric(
-              aggregate.contextF1Total / Math.max(aggregate.questionCount, 1),
-            )
-          : null,
-    };
-  }
   const progress: LocomoProgressSummary = {
     suite: 'locomo',
     mode: params.mode,
@@ -696,7 +712,7 @@ function writeProgressFile(params: {
     progressPath: params.progressPath,
     resultPath: params.resultPath,
     predictionsPath: params.predictionsPath,
-    categories: categorySummaries,
+    categories: buildCategorySummaries(params.categories, params.mode),
     tokenUsage:
       params.mode === 'qa' && params.usageTotals.responsesWithUsage > 0
         ? params.usageTotals
@@ -739,14 +755,6 @@ function resolveSampleRequestModel(params: {
   if (params.agentMode === 'current-agent') {
     return params.runtime.model;
   }
-  if (params.agentMode === 'fresh-request') {
-    return encodeEvalProfileModel(params.runtime.baseModel, {
-      workspaceMode: 'fresh-agent',
-      ablateSystemPrompt: params.runtime.profile.ablateSystemPrompt,
-      includePromptParts: [...params.runtime.profile.includePromptParts],
-      omitPromptParts: [...params.runtime.profile.omitPromptParts],
-    });
-  }
 
   return encodeEvalProfileModel(params.runtime.baseModel, {
     workspaceMode: 'current-agent',
@@ -776,16 +784,34 @@ function loadSamples(datasetPath: string): LocomoSample[] {
   if (!Array.isArray(parsed)) {
     throw new Error(`Expected LOCOMO dataset array in ${datasetPath}.`);
   }
+  const firstSample = parsed[0];
+  if (firstSample !== undefined) {
+    const sample =
+      firstSample && typeof firstSample === 'object' ? firstSample : null;
+    const sampleId = sample
+      ? (sample as { sample_id?: unknown }).sample_id
+      : null;
+    const conversation = sample
+      ? (sample as { conversation?: unknown }).conversation
+      : null;
+    const qa = sample ? (sample as { qa?: unknown }).qa : null;
+    if (
+      typeof sampleId !== 'string' ||
+      !sampleId.trim() ||
+      !conversation ||
+      typeof conversation !== 'object' ||
+      Array.isArray(conversation) ||
+      !Array.isArray(qa)
+    ) {
+      throw new Error(
+        `Invalid LOCOMO sample at index 0 in ${datasetPath}. Expected a non-empty string sample_id, an object conversation, and an array qa.`,
+      );
+    }
+  }
   return parsed as LocomoSample[];
 }
 
-function verifyDownloadedDataset(
-  rawBuffer: Uint8Array,
-  responseUrl: string | null | undefined,
-): void {
-  if (!responseUrl || responseUrl.trim() !== LOCOMO_DATASET_URL) {
-    return;
-  }
+function verifyDownloadedDataset(rawBuffer: Uint8Array): void {
   const actualSha256 = createHash('sha256').update(rawBuffer).digest('hex');
   if (actualSha256 !== LOCOMO_DATASET_SHA256) {
     throw new Error(
@@ -794,78 +820,133 @@ function verifyDownloadedDataset(
   }
 }
 
+function isFetchTimeoutError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === 'TimeoutError' || error.name === 'AbortError')
+  );
+}
+
+async function fetchWithTimeout(
+  input: string,
+  init: RequestInit | undefined,
+  timeoutMs: number,
+  label: string,
+): Promise<Response> {
+  try {
+    return await fetch(input, {
+      ...init,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (error) {
+    if (isFetchTimeoutError(error)) {
+      throw new Error(`${label} timed out after ${timeoutMs}ms.`);
+    }
+    throw error;
+  }
+}
+
 async function evaluateSample(params: {
   runtime: LocomoGatewayRuntime;
   requestModel: string;
   sample: LocomoSample;
   budgetTokens: number;
-  usageTotals: LocomoUsageSummary;
+  usageTotals: LocomoTokenUsage;
   categories: Map<number, LocomoCategoryRunningAggregate>;
   onQuestionProgress?: (params: {
     samplePrediction: LocomoSamplePrediction;
   }) => void;
 }): Promise<LocomoSamplePrediction> {
-  const qaPredictions: LocomoQuestionPrediction[] = [];
-  const sampleQuestionCount = (params.sample.qa || []).length;
+  const sampleQa = Array.isArray(params.sample.qa) ? params.sample.qa : [];
+  const sampleQuestionCount = sampleQa.length;
+  const qaPredictions: Array<LocomoQuestionPrediction | null> = Array.from(
+    { length: sampleQuestionCount },
+    () => null,
+  );
+  let nextQuestionIndex = 0;
 
-  for (const qa of params.sample.qa || []) {
-    const prepared = buildQuestionPrompt(
-      params.sample,
-      qa,
-      params.budgetTokens,
-    );
-    const completion = await requestModelAnswer({
-      runtime: params.runtime,
-      model: params.requestModel,
-      prompt: prepared.prompt,
-      user: `locomo-${params.sample.sample_id}`,
-    });
-    mergeUsage(params.usageTotals, completion.usage);
+  const runWorker = async (): Promise<void> => {
+    while (true) {
+      const questionIndex = nextQuestionIndex;
+      nextQuestionIndex += 1;
+      if (questionIndex >= sampleQa.length) {
+        return;
+      }
 
-    const answer = answerToString(qa);
-    const prediction =
-      prepared.scoreCategory === 5
-        ? normalizeCategoryFivePrediction(
-            completion.content,
-            prepared.categoryFiveAnswerKey,
-          )
-        : normalizeModelPrediction(completion.content);
-    const score = scoreLocomoAnswer(qa, prediction);
+      const qa = sampleQa[questionIndex];
+      const prepared = buildQuestionPrompt(
+        params.sample,
+        qa,
+        params.budgetTokens,
+      );
+      const completion = await requestModelAnswer({
+        runtime: params.runtime,
+        model: params.requestModel,
+        prompt: prepared.prompt,
+        user: `locomo-${params.sample.sample_id}`,
+      });
+      mergeUsage(params.usageTotals, completion.usage);
 
-    qaPredictions.push({
-      category: prepared.scoreCategory,
-      question: qa.question,
-      answer,
-      prediction,
-      score,
-      evidence: Array.isArray(qa.evidence) ? qa.evidence : [],
-    });
+      const answer = answerToString(qa);
+      const prediction =
+        prepared.scoreCategory === 5
+          ? normalizeCategoryFivePrediction(
+              completion.content,
+              prepared.categoryFiveAnswerKey,
+            )
+          : normalizeModelPrediction(completion.content);
+      const score = scoreLocomoAnswer(qa, prediction);
+      qaPredictions[questionIndex] = {
+        category: prepared.scoreCategory,
+        question: qa.question,
+        answer,
+        prediction,
+        score,
+        evidence: Array.isArray(qa.evidence) ? qa.evidence : [],
+      };
 
-    const existing = params.categories.get(prepared.scoreCategory) || {
-      scoreTotal: 0,
-      contextF1Total: 0,
-      questionCount: 0,
-    };
-    existing.scoreTotal += score;
-    existing.questionCount += 1;
-    params.categories.set(prepared.scoreCategory, existing);
-    params.onQuestionProgress?.({
-      samplePrediction: {
-        sampleId: params.sample.sample_id,
-        questionCount: sampleQuestionCount,
-        meanScore: roundMetric(
-          qaPredictions.reduce((total, entry) => total + entry.score, 0) /
-            Math.max(qaPredictions.length, 1),
-        ),
-        meanContextF1: null,
-        qa: [...qaPredictions],
-      },
-    });
-  }
+      const existing = params.categories.get(prepared.scoreCategory) || {
+        scoreTotal: 0,
+        contextF1Total: 0,
+        questionCount: 0,
+      };
+      existing.scoreTotal += score;
+      existing.questionCount += 1;
+      params.categories.set(prepared.scoreCategory, existing);
 
-  const questionCount = qaPredictions.length;
+      const completedPredictions = qaPredictions.filter(
+        (entry): entry is LocomoQuestionPrediction => entry !== null,
+      );
+      params.onQuestionProgress?.({
+        samplePrediction: {
+          sampleId: params.sample.sample_id,
+          questionCount: sampleQuestionCount,
+          meanScore: roundMetric(
+            completedPredictions.reduce(
+              (total, entry) => total + entry.score,
+              0,
+            ) / Math.max(completedPredictions.length, 1),
+          ),
+          meanContextF1: null,
+          qa: completedPredictions,
+        },
+      });
+    }
+  };
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(LOCOMO_QA_CONCURRENCY, sampleQa.length) },
+      () => runWorker(),
+    ),
+  );
+
+  const completedQaPredictions = qaPredictions.filter(
+    (entry): entry is LocomoQuestionPrediction => entry !== null,
+  );
+  const questionCount = completedQaPredictions.length;
   const meanScore = roundMetric(
-    qaPredictions.reduce((total, qa) => total + qa.score, 0) /
+    completedQaPredictions.reduce((total, qa) => total + qa.score, 0) /
       Math.max(questionCount, 1),
   );
   return {
@@ -873,7 +954,7 @@ async function evaluateSample(params: {
     questionCount,
     meanScore,
     meanContextF1: null,
-    qa: qaPredictions,
+    qa: completedQaPredictions,
   };
 }
 
@@ -910,9 +991,9 @@ async function evaluateRetrievalSample(params: {
           typeof value === 'number' && Number.isFinite(value) && value > 0,
       );
     const hitRate = computeRetrievalHitRate({
+      sample: params.sample,
       evidence: Array.isArray(qa.evidence) ? qa.evidence : [],
-      messageIdByDiaId: params.session.messageIdByDiaId,
-      retrievedSourceMessageIds,
+      retrievedContent: recalledContext,
     });
     const contextF1 = computeContextTokenF1(
       recalledContext,
@@ -1056,7 +1137,12 @@ function getSpeakerNames(sample: LocomoSample): [string, string] {
 
 function flattenConversationTurns(
   conversation: Record<string, unknown>,
-): Array<LocomoTurn & { sessionNum: number; dateTime: string }> {
+): LocomoFlattenedTurn[] {
+  const cached = flattenedConversationTurnsCache.get(conversation);
+  if (cached) {
+    return cached;
+  }
+
   const sessionNames = Object.keys(conversation || {})
     .filter((key) => /^session_\d+$/.test(key))
     .sort((left, right) => {
@@ -1064,8 +1150,7 @@ function flattenConversationTurns(
       const rightNum = Number.parseInt(right.slice('session_'.length), 10) || 0;
       return leftNum - rightNum;
     });
-  const turns: Array<LocomoTurn & { sessionNum: number; dateTime: string }> =
-    [];
+  const turns: LocomoFlattenedTurn[] = [];
 
   for (const sessionName of sessionNames) {
     const sessionNum =
@@ -1097,6 +1182,7 @@ function flattenConversationTurns(
     }
   }
 
+  flattenedConversationTurnsCache.set(conversation, turns);
   return turns;
 }
 
@@ -1105,8 +1191,7 @@ function selectConversationContext(
   maxTokens: number,
 ): string {
   const chronologicalTurns = flattenConversationTurns(conversation);
-  const selected: Array<LocomoTurn & { sessionNum: number; dateTime: string }> =
-    [];
+  const selected: LocomoFlattenedTurn[] = [];
   let totalTokens = 0;
 
   for (let index = chronologicalTurns.length - 1; index >= 0; index -= 1) {
@@ -1202,7 +1287,7 @@ function ingestSampleIntoNativeMemory(params: {
       content,
     });
     messageIdByDiaId.set(normalizeDiaId(turn.dia_id), messageId);
-    storeSemanticMemory({
+    memoryService.storeSemanticMemory({
       sessionId,
       role,
       source: 'locomo-retrieval',
@@ -1216,7 +1301,6 @@ function ingestSampleIntoNativeMemory(params: {
       },
       content,
       confidence: 1,
-      embedding: buildHashedTokenEmbedding(content),
       sourceMessageId: messageId,
     });
   }
@@ -1268,21 +1352,36 @@ function budgetTruncateSemanticMemories(
 }
 
 function computeRetrievalHitRate(params: {
+  sample: LocomoSample;
   evidence: string[];
-  messageIdByDiaId: Map<string, number>;
-  retrievedSourceMessageIds: number[];
+  retrievedContent: string;
 }): number {
   const expandedEvidenceIds = expandEvidenceIds(params.evidence);
   if (expandedEvidenceIds.length === 0) return 1;
 
-  const retrievedIds = new Set(params.retrievedSourceMessageIds);
+  const turnMap = new Map<string, LocomoTurn>();
+  for (const turn of flattenConversationTurns(params.sample.conversation)) {
+    turnMap.set(turn.dia_id, turn);
+  }
+
+  const lowerRetrieved = String(params.retrievedContent || '').toLowerCase();
   let found = 0;
   let resolvable = 0;
   for (const evidenceId of expandedEvidenceIds) {
-    const messageId = params.messageIdByDiaId.get(evidenceId);
-    if (!messageId) continue;
+    const turn = turnMap.get(evidenceId);
+    if (!turn) {
+      console.log(
+        `WARNING: dia_id "${evidenceId}" not found in sample ${params.sample.sample_id}`,
+      );
+      continue;
+    }
     resolvable += 1;
-    if (retrievedIds.has(messageId)) {
+    if (turn.text.length < 20) {
+      console.log(
+        `WARNING: short turn text (${turn.text.length} chars) for dia_id ${evidenceId}: ${JSON.stringify(turn.text)}`,
+      );
+    }
+    if (lowerRetrieved.includes(turn.text.toLowerCase())) {
       found += 1;
     }
   }
@@ -1338,54 +1437,17 @@ function computeContextTokenF1(prediction: string, answer: string): number {
 function tokenizeContextText(value: string): string[] {
   return String(value || '')
     .toLowerCase()
-    .replace(/[^a-z0-9_\s-]/g, ' ')
-    .replace(/\s+/g, ' ')
     .trim()
-    .split(' ')
-    .map((token) => token.trim())
-    .filter((token) => token.length > 0);
+    .split(/\s+/)
+    .filter(Boolean);
 }
 
-function buildHashedTokenEmbedding(text: string): number[] | null {
-  const normalized = String(text || '')
-    .toLowerCase()
-    .replace(/[^a-z0-9_\s-]/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
-  if (!normalized) return null;
-
-  const tokens = normalized
-    .split(' ')
-    .map((token) => token.trim())
-    .filter((token) => token.length > 1)
-    .slice(0, 256);
-  if (tokens.length === 0) return null;
-
-  const vector = new Float32Array(128);
-  for (const token of tokens) {
-    const hash = hashEmbeddingToken(token);
-    const index = hash % vector.length;
-    const sign = (hash & 1) === 0 ? 1 : -1;
-    vector[index] += sign * Math.min(4, token.length);
-  }
-
-  let norm = 0;
-  for (let index = 0; index < vector.length; index += 1) {
-    norm += vector[index] * vector[index];
-  }
-  if (norm <= Number.EPSILON) return null;
-  const scale = 1 / Math.sqrt(norm);
-  return Array.from(vector, (value) => value * scale);
-}
-
-function hashEmbeddingToken(token: string): number {
-  let hash = 2166136261;
-  for (let index = 0; index < token.length; index += 1) {
-    hash ^= token.charCodeAt(index);
-    hash = Math.imul(hash, 16777619);
-  }
-  return hash >>> 0;
-}
+export const testOnlyLocomoNativeRetrieval = {
+  computeContextTokenF1,
+  computeRetrievalHitRate,
+  expandEvidenceIds,
+  normalizeDiaId,
+};
 
 async function requestModelAnswer(params: {
   runtime: LocomoGatewayRuntime;
@@ -1394,23 +1456,26 @@ async function requestModelAnswer(params: {
   user: string;
 }): Promise<{ content: string; usage: LocomoChatCompletionUsage | null }> {
   const url = `${params.runtime.baseUrl.replace(/\/+$/, '')}/chat/completions`;
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${params.runtime.apiKey}`,
+  const response = await fetchWithTimeout(
+    url,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${params.runtime.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: params.model,
+        user: params.user,
+        messages: [{ role: 'user', content: params.prompt }],
+      }),
     },
-    body: JSON.stringify({
-      model: params.model,
-      user: params.user,
-      messages: [{ role: 'user', content: params.prompt }],
-    }),
-  });
+    LOCOMO_MODEL_CALL_TIMEOUT_MS,
+    'LOCOMO model call',
+  );
 
   if (!response.ok) {
-    throw new Error(
-      `LOCOMO model call failed with HTTP ${response.status}: ${await response.text()}`,
-    );
+    throw new Error(`LOCOMO model call failed with HTTP ${response.status}.`);
   }
 
   const payload = (await response.json()) as {
@@ -1429,7 +1494,7 @@ async function requestModelAnswer(params: {
 }
 
 function mergeUsage(
-  target: LocomoUsageSummary,
+  target: LocomoTokenUsage,
   usage: LocomoChatCompletionUsage | null,
 ): void {
   if (!usage) return;
@@ -1511,8 +1576,12 @@ function roundMetric(value: number): number {
 }
 
 function hashText(value: string): number {
-  const digest = createHash('sha1').update(value).digest();
-  return digest.readUInt32BE(0);
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
 }
 
 function formatLocomoCategoryLine(
@@ -1558,3 +1627,7 @@ function printSummaryTable(summary: LocomoRunSummary): void {
   console.log(`Predictions JSON: ${summary.predictionsPath}`);
   console.log(`Result JSON: ${summary.resultPath}`);
 }
+
+export const testOnlyLocomoNative = {
+  flattenConversationTurns,
+};

--- a/src/evals/locomo-native.ts
+++ b/src/evals/locomo-native.ts
@@ -1,10 +1,12 @@
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import { getRuntimeConfig } from '../config/runtime-config.js';
 import { initDatabase } from '../memory/db.js';
+import { normalizeMemoryEmbeddingProviderKind } from '../memory/embeddings.js';
 import { memoryService } from '../memory/memory-service.js';
+import { normalizeMemoryRecallBackend } from '../memory/semantic-recall.js';
 import { buildSessionKey } from '../session/session-key.js';
-import type { SemanticMemoryEntry } from '../types/memory.js';
 import type { Session } from '../types/session.js';
 import {
   buildDefaultEvalProfile,
@@ -16,6 +18,16 @@ import { scoreOfficialLocomoAnswer } from './locomo-official-scoring.js';
 import type {
   LocomoAgentMode,
   LocomoCategoryAggregate,
+  LocomoProgressPhase,
+  LocomoRetrievalBackend,
+  LocomoRetrievalEmbeddingProvider,
+  LocomoRetrievalPolicy,
+  LocomoRetrievalQueryMode,
+  LocomoRetrievalRerank,
+  LocomoRetrievalSweep,
+  LocomoRetrievalTokenizer,
+  LocomoRetrievalVariantProgress,
+  LocomoRetrievalVariantSummary,
   LocomoTokenUsage,
 } from './locomo-types.js';
 import {
@@ -35,6 +47,15 @@ const LOCOMO_DATASET_DOWNLOAD_TIMEOUT_MS = 120_000;
 const LOCOMO_MODEL_CALL_TIMEOUT_MS = 30_000;
 const LOCOMO_QA_CONCURRENCY = 4;
 const LOCOMO_PROGRESS_WRITE_INTERVAL_QUESTIONS = 20;
+const LOCOMO_PROGRESS_WRITE_INTERVAL_TURNS = 50;
+const DEFAULT_LOCOMO_RETRIEVAL_QUERY_MODE: LocomoRetrievalQueryMode =
+  'no-stopwords';
+const DEFAULT_LOCOMO_RETRIEVAL_BACKEND: LocomoRetrievalBackend = 'cosine';
+const DEFAULT_LOCOMO_RETRIEVAL_RERANK: LocomoRetrievalRerank = 'bm25';
+const DEFAULT_LOCOMO_RETRIEVAL_TOKENIZER: LocomoRetrievalTokenizer =
+  'unicode61';
+const DEFAULT_LOCOMO_RETRIEVAL_EMBEDDING_PROVIDER: LocomoRetrievalEmbeddingProvider =
+  'hashed';
 
 const CONVERSATION_START_PROMPT =
   'Below is a conversation between two people: {speakerA} and {speakerB}. The conversation takes place over multiple days and the date of each conversation is written at the beginning of the conversation.\n\n';
@@ -94,7 +115,14 @@ interface LocomoRunnerOptions {
   numSamples: number | null;
   maxQuestions: number | null;
   mode: LocomoEvaluationMode;
+  matrix: boolean;
+  matrixSweep: LocomoRetrievalSweep;
   agentMode: LocomoAgentMode;
+  retrievalQueryMode: LocomoRetrievalQueryMode;
+  retrievalBackend: LocomoRetrievalBackend;
+  retrievalRerank: LocomoRetrievalRerank;
+  retrievalTokenizer: LocomoRetrievalTokenizer;
+  retrievalEmbeddingProvider: LocomoRetrievalEmbeddingProvider;
 }
 
 interface LocomoGatewayRuntime {
@@ -127,18 +155,31 @@ interface LocomoSamplePrediction {
 interface LocomoRunSummary {
   suite: 'locomo';
   mode: LocomoEvaluationMode;
+  matrix: boolean;
+  matrixSweep: LocomoRetrievalSweep | null;
+  retrievalPolicy: LocomoRetrievalPolicy | null;
+  retrievalQueryMode: LocomoRetrievalQueryMode | null;
+  retrievalBackend: LocomoRetrievalBackend | null;
+  retrievalRerank: LocomoRetrievalRerank | null;
+  retrievalTokenizer: LocomoRetrievalTokenizer | null;
+  retrievalEmbeddingProvider: LocomoRetrievalEmbeddingProvider | null;
+  retrievalEmbeddingModel: string | null;
   dataset: string;
   generatedAt: string;
   model: string | null;
   budgetTokens: number;
   sampleCount: number;
   questionCount: number;
-  overallScore: number;
+  overallScore: number | null;
   contextF1: number | null;
   resultPath: string;
   predictionsPath: string;
   categories: Record<string, LocomoCategoryAggregate>;
   tokenUsage: LocomoTokenUsage | null;
+  variantCount: number | null;
+  bestVariantId: string | null;
+  bestVariantLabel: string | null;
+  variants: LocomoRetrievalVariantSummary[];
   samples: Array<{
     sampleId: string;
     questionCount: number;
@@ -149,6 +190,15 @@ interface LocomoRunSummary {
 interface LocomoProgressSummary {
   suite: 'locomo';
   mode: LocomoEvaluationMode;
+  matrix: boolean;
+  matrixSweep: LocomoRetrievalSweep | null;
+  retrievalPolicy: LocomoRetrievalPolicy | null;
+  retrievalQueryMode: LocomoRetrievalQueryMode | null;
+  retrievalBackend: LocomoRetrievalBackend | null;
+  retrievalRerank: LocomoRetrievalRerank | null;
+  retrievalTokenizer: LocomoRetrievalTokenizer | null;
+  retrievalEmbeddingProvider: LocomoRetrievalEmbeddingProvider | null;
+  retrievalEmbeddingModel: string | null;
   dataset: string;
   updatedAt: string;
   model: string | null;
@@ -157,9 +207,12 @@ interface LocomoProgressSummary {
   completedSampleCount: number;
   questionCount: number;
   completedQuestionCount: number;
-  overallScore: number;
+  overallScore: number | null;
   contextF1: number | null;
+  currentPhase: LocomoProgressPhase | null;
   currentSampleId: string | null;
+  currentSampleEmbeddedTurnCount: number | null;
+  currentSampleTurnCount: number | null;
   currentSampleQuestionCount: number | null;
   currentSampleQuestionTotal: number | null;
   progressPath: string;
@@ -167,6 +220,10 @@ interface LocomoProgressSummary {
   predictionsPath: string;
   categories: Record<string, LocomoCategoryAggregate>;
   tokenUsage: LocomoTokenUsage | null;
+  variantCount: number | null;
+  completedVariantCount: number | null;
+  currentVariant: LocomoRetrievalVariantProgress | null;
+  variants: LocomoRetrievalVariantSummary[];
 }
 
 interface LocomoChatCompletionUsage {
@@ -184,12 +241,54 @@ interface LocomoCategoryRunningAggregate {
 interface LocomoRetrievalSession {
   session: Session;
   messageIdByDiaId: Map<string, number>;
+  close: () => void;
+}
+
+interface LocomoIngestionProgress {
+  sampleId: string;
+  embeddedTurnCount: number;
+  turnCount: number;
 }
 
 interface LocomoPreparedQuestion {
   prompt: string;
   scoreCategory: number;
   categoryFiveAnswerKey: Record<'a' | 'b', string> | null;
+}
+
+interface LocomoRetrievedMemory {
+  content: string;
+  sourceMessageId: number | null;
+  confidence: number;
+}
+
+interface LocomoRetrievalVariantPlan {
+  id: string;
+  label: string;
+  retrievalQueryMode: LocomoRetrievalQueryMode;
+  retrievalBackend: LocomoRetrievalBackend;
+  retrievalRerank: LocomoRetrievalRerank;
+  retrievalTokenizer: LocomoRetrievalTokenizer;
+  retrievalEmbeddingProvider: LocomoRetrievalEmbeddingProvider;
+  retrievalEmbeddingModel: string | null;
+}
+
+interface LocomoEvaluatedRetrievalVariant
+  extends LocomoRetrievalVariantSummary {
+  predictions: LocomoSamplePrediction[];
+}
+
+interface LocomoRetrievalVariantPredictionManifestEntry {
+  id: string;
+  label: string;
+  retrievalQueryMode: LocomoRetrievalQueryMode;
+  retrievalBackend: LocomoRetrievalBackend;
+  retrievalRerank: LocomoRetrievalRerank;
+  retrievalTokenizer: LocomoRetrievalTokenizer;
+  retrievalEmbeddingProvider: LocomoRetrievalEmbeddingProvider;
+  predictionsPath: string;
+  sampleCount: number;
+  questionCount: number;
 }
 
 export async function runLocomoNativeCli(argv: string[]): Promise<void> {
@@ -208,7 +307,18 @@ function parseArgs(argv: string[]): LocomoRunnerOptions {
   let numSamples: number | null = null;
   let maxQuestions: number | null = null;
   let mode: LocomoEvaluationMode = 'qa';
+  let matrix = false;
+  let matrixSweep: LocomoRetrievalSweep = 'all';
   let agentMode: LocomoAgentMode = 'conversation-fresh';
+  let retrievalQueryMode: LocomoRetrievalQueryMode =
+    DEFAULT_LOCOMO_RETRIEVAL_QUERY_MODE;
+  let retrievalBackend: LocomoRetrievalBackend =
+    DEFAULT_LOCOMO_RETRIEVAL_BACKEND;
+  let retrievalRerank: LocomoRetrievalRerank = DEFAULT_LOCOMO_RETRIEVAL_RERANK;
+  let retrievalTokenizer: LocomoRetrievalTokenizer =
+    DEFAULT_LOCOMO_RETRIEVAL_TOKENIZER;
+  let retrievalEmbeddingProvider: LocomoRetrievalEmbeddingProvider =
+    DEFAULT_LOCOMO_RETRIEVAL_EMBEDDING_PROVIDER;
 
   for (let index = 0; index < argv.length; index += 1) {
     const current = String(argv[index] || '').trim();
@@ -253,6 +363,24 @@ function parseArgs(argv: string[]): LocomoRunnerOptions {
       if (!inlineValue) index += 1;
       continue;
     }
+    if (flag === '--matrix') {
+      const nextToken = String(argv[index + 1] || '').trim();
+      const value = (inlineValue || nextToken).toLowerCase().trim();
+      matrix = true;
+      if (value && isLocomoRetrievalSweep(value)) {
+        matrixSweep = value;
+        if (!inlineValue) index += 1;
+      } else if (!inlineValue && nextToken && !nextToken.startsWith('-')) {
+        throw new Error(
+          `Unsupported LOCOMO matrix sweep \`${value || '(empty)'}\`. Use \`all\`, \`backend\`, \`rerank\`, \`tokenizer\`, or \`embedding\`.`,
+        );
+      } else if (inlineValue) {
+        throw new Error(
+          `Unsupported LOCOMO matrix sweep \`${value || '(empty)'}\`. Use \`all\`, \`backend\`, \`rerank\`, \`tokenizer\`, or \`embedding\`.`,
+        );
+      }
+      continue;
+    }
     if (flag === '--agent-mode') {
       const value = nextValue().toLowerCase();
       if (value === 'conversation-fresh' || value === 'current-agent') {
@@ -260,6 +388,85 @@ function parseArgs(argv: string[]): LocomoRunnerOptions {
       } else {
         throw new Error(
           `Unsupported LOCOMO agent mode \`${value || '(empty)'}\`.`,
+        );
+      }
+      if (!inlineValue) index += 1;
+      continue;
+    }
+    if (flag === '--retrieval-query') {
+      const value = nextValue().toLowerCase();
+      if (value === 'raw' || value === 'no-stopwords') {
+        retrievalQueryMode = value;
+      } else {
+        throw new Error(
+          `Unsupported LOCOMO retrieval query mode \`${value || '(empty)'}\`.`,
+        );
+      }
+      if (!inlineValue) index += 1;
+      continue;
+    }
+    if (flag === '--retrieval-backend') {
+      const value = nextValue().toLowerCase();
+      if (
+        value === 'cosine' ||
+        value === 'semantic' ||
+        value === 'full-text' ||
+        value === 'fulltext' ||
+        value === 'fts-bm25' ||
+        value === 'hybrid'
+      ) {
+        retrievalBackend = normalizeMemoryRecallBackend(value, 'cosine');
+      } else {
+        throw new Error(
+          `Unsupported LOCOMO retrieval backend \`${value || '(empty)'}\`.`,
+        );
+      }
+      if (!inlineValue) index += 1;
+      continue;
+    }
+    if (flag === '--retrieval-rerank') {
+      const value = nextValue().toLowerCase();
+      if (value === 'none' || value === 'bm25') {
+        retrievalRerank = value;
+      } else {
+        throw new Error(
+          `Unsupported LOCOMO retrieval rerank mode \`${value || '(empty)'}\`.`,
+        );
+      }
+      if (!inlineValue) index += 1;
+      continue;
+    }
+    if (flag === '--retrieval-tokenizer') {
+      const value = nextValue().toLowerCase();
+      if (
+        value === 'default' ||
+        value === 'unicode61' ||
+        value === 'porter' ||
+        value === 'trigram'
+      ) {
+        retrievalTokenizer = value === 'default' ? 'unicode61' : value;
+      } else {
+        throw new Error(
+          `Unsupported LOCOMO retrieval tokenizer \`${value || '(empty)'}\`.`,
+        );
+      }
+      if (!inlineValue) index += 1;
+      continue;
+    }
+    if (flag === '--retrieval-embedding') {
+      const value = nextValue().toLowerCase();
+      retrievalEmbeddingProvider = normalizeMemoryEmbeddingProviderKind(
+        value,
+        'hashed',
+      );
+      if (
+        value !== 'hashed' &&
+        value !== 'hash' &&
+        value !== 'transformers' &&
+        value !== 'transformers.js'
+      ) {
+        throw new Error(
+          `Unsupported LOCOMO retrieval embedding provider \`${value || '(empty)'}\`.`,
         );
       }
       if (!inlineValue) index += 1;
@@ -275,6 +482,31 @@ function parseArgs(argv: string[]): LocomoRunnerOptions {
   if (!installDir) {
     throw new Error('Missing required `--install-dir`.');
   }
+  if (
+    mode !== 'retrieval' &&
+    (matrix ||
+      retrievalQueryMode !== DEFAULT_LOCOMO_RETRIEVAL_QUERY_MODE ||
+      retrievalBackend !== DEFAULT_LOCOMO_RETRIEVAL_BACKEND ||
+      retrievalRerank !== DEFAULT_LOCOMO_RETRIEVAL_RERANK ||
+      retrievalTokenizer !== DEFAULT_LOCOMO_RETRIEVAL_TOKENIZER ||
+      retrievalEmbeddingProvider !==
+        DEFAULT_LOCOMO_RETRIEVAL_EMBEDDING_PROVIDER)
+  ) {
+    throw new Error('LOCOMO retrieval-only flags require `--mode retrieval`.');
+  }
+  if (
+    matrix &&
+    (retrievalQueryMode !== DEFAULT_LOCOMO_RETRIEVAL_QUERY_MODE ||
+      retrievalBackend !== DEFAULT_LOCOMO_RETRIEVAL_BACKEND ||
+      retrievalRerank !== DEFAULT_LOCOMO_RETRIEVAL_RERANK ||
+      retrievalTokenizer !== DEFAULT_LOCOMO_RETRIEVAL_TOKENIZER ||
+      retrievalEmbeddingProvider !==
+        DEFAULT_LOCOMO_RETRIEVAL_EMBEDDING_PROVIDER)
+  ) {
+    throw new Error(
+      'LOCOMO `--matrix` runs the full retrieval sweep and cannot be combined with explicit retrieval flags.',
+    );
+  }
 
   return {
     operation,
@@ -283,8 +515,25 @@ function parseArgs(argv: string[]): LocomoRunnerOptions {
     numSamples,
     maxQuestions,
     mode,
+    matrix,
+    matrixSweep,
     agentMode,
+    retrievalQueryMode,
+    retrievalBackend,
+    retrievalRerank,
+    retrievalTokenizer,
+    retrievalEmbeddingProvider,
   };
+}
+
+function isLocomoRetrievalSweep(value: string): value is LocomoRetrievalSweep {
+  return (
+    value === 'all' ||
+    value === 'backend' ||
+    value === 'rerank' ||
+    value === 'tokenizer' ||
+    value === 'embedding'
+  );
 }
 
 function splitInlineFlag(value: string): [string, string] {
@@ -394,6 +643,10 @@ async function runEvaluation(options: LocomoRunnerOptions): Promise<void> {
   const resultPath = path.join(jobDir, 'result.json');
   const predictionsPath = path.join(jobDir, 'predictions.json');
   const retrievalDbPath = path.join(jobDir, 'retrieval-memory.db');
+  const runTag = path.basename(jobDir);
+  const retrievalMatrixVariants = buildLocomoRetrievalMatrixVariants(
+    options.matrixSweep,
+  );
 
   console.log(`Job dir: ${jobDir}`);
   console.log(`Dataset: ${datasetPath}`);
@@ -402,6 +655,34 @@ async function runEvaluation(options: LocomoRunnerOptions): Promise<void> {
     console.log(`Model: ${runtime.model}`);
   } else {
     console.log(`Memory DB: ${retrievalDbPath}`);
+    if (options.matrix) {
+      console.log(
+        `Matrix: ${retrievalMatrixVariants.length} retrieval variants`,
+      );
+      console.log(`Matrix sweep: ${options.matrixSweep}`);
+      const retrievalEmbeddingModel = resolveLocomoRunEmbeddingModel({
+        matrix: true,
+        matrixSweep: options.matrixSweep,
+        retrievalEmbeddingProvider: options.retrievalEmbeddingProvider,
+      });
+      if (retrievalEmbeddingModel) {
+        console.log(`Retrieval embedding model: ${retrievalEmbeddingModel}`);
+      }
+    } else {
+      console.log(`Retrieval query: ${options.retrievalQueryMode}`);
+      console.log(`Retrieval backend: ${options.retrievalBackend}`);
+      console.log(`Retrieval rerank: ${options.retrievalRerank}`);
+      console.log(`Retrieval tokenizer: ${options.retrievalTokenizer}`);
+      console.log(`Retrieval embedding: ${options.retrievalEmbeddingProvider}`);
+      const retrievalEmbeddingModel = resolveLocomoRunEmbeddingModel({
+        matrix: false,
+        matrixSweep: null,
+        retrievalEmbeddingProvider: options.retrievalEmbeddingProvider,
+      });
+      if (retrievalEmbeddingModel) {
+        console.log(`Retrieval embedding model: ${retrievalEmbeddingModel}`);
+      }
+    }
   }
   console.log(`Samples: ${plannedSamples.length}`);
   console.log(`Budget: ${options.budgetTokens}`);
@@ -417,6 +698,23 @@ async function runEvaluation(options: LocomoRunnerOptions): Promise<void> {
     initDatabase({ quiet: true, dbPath: retrievalDbPath });
   }
 
+  if (options.mode === 'retrieval' && options.matrix) {
+    await runRetrievalMatrixEvaluation({
+      options,
+      runtime,
+      plannedSamples,
+      totalQuestionCount,
+      datasetPath,
+      jobDir,
+      progressPath,
+      resultPath,
+      predictionsPath,
+      runTag,
+      variants: retrievalMatrixVariants,
+    });
+    return;
+  }
+
   const predictions: LocomoSamplePrediction[] = [];
   const categories = new Map<number, LocomoCategoryRunningAggregate>();
   const usageTotals: LocomoTokenUsage = {
@@ -429,13 +727,47 @@ async function runEvaluation(options: LocomoRunnerOptions): Promise<void> {
   let scoreTotal = 0;
   let contextF1Total = 0;
   let completedSampleCount = 0;
-  const runTag = path.basename(jobDir);
+  const retrievalSettings =
+    options.mode === 'retrieval'
+      ? {
+          retrievalPolicy: 'budget-only' as const,
+          retrievalQueryMode: options.retrievalQueryMode,
+          retrievalBackend: options.retrievalBackend,
+          retrievalRerank: options.retrievalRerank,
+          retrievalTokenizer: options.retrievalTokenizer,
+          retrievalEmbeddingProvider: options.retrievalEmbeddingProvider,
+          retrievalEmbeddingModel: resolveLocomoRunEmbeddingModel({
+            matrix: false,
+            matrixSweep: null,
+            retrievalEmbeddingProvider: options.retrievalEmbeddingProvider,
+          }),
+          currentPhase:
+            options.retrievalEmbeddingProvider === 'transformers'
+              ? ('warming-embedding' as const)
+              : ('ingesting' as const),
+        }
+      : null;
+  const initialSample: LocomoSample | null =
+    options.mode === 'retrieval' ? (plannedSamples[0] ?? null) : null;
+  const initialSampleTurnCount = initialSample
+    ? flattenConversationTurns(initialSample.conversation).length
+    : null;
 
   writeProgressFile({
     progressPath,
     resultPath,
     predictionsPath,
     mode: options.mode,
+    matrix: false,
+    matrixSweep: null,
+    retrievalPolicy: retrievalSettings?.retrievalPolicy ?? null,
+    retrievalQueryMode: retrievalSettings?.retrievalQueryMode ?? null,
+    retrievalBackend: retrievalSettings?.retrievalBackend ?? null,
+    retrievalRerank: retrievalSettings?.retrievalRerank ?? null,
+    retrievalTokenizer: retrievalSettings?.retrievalTokenizer ?? null,
+    retrievalEmbeddingProvider:
+      retrievalSettings?.retrievalEmbeddingProvider ?? null,
+    retrievalEmbeddingModel: retrievalSettings?.retrievalEmbeddingModel ?? null,
     datasetPath,
     model: options.mode === 'qa' ? runtime.model : null,
     budgetTokens: options.budgetTokens,
@@ -447,10 +779,64 @@ async function runEvaluation(options: LocomoRunnerOptions): Promise<void> {
     contextF1Total,
     categories,
     usageTotals,
-    currentSampleId: null,
+    currentPhase: retrievalSettings?.currentPhase ?? null,
+    currentSampleId: initialSample?.sample_id || null,
+    currentSampleEmbeddedTurnCount: retrievalSettings ? 0 : null,
+    currentSampleTurnCount: retrievalSettings ? initialSampleTurnCount : null,
     currentSampleQuestionCount: null,
     currentSampleQuestionTotal: null,
+    variantCount: null,
+    completedVariantCount: null,
+    currentVariant: null,
+    variants: [],
   });
+
+  if (
+    options.mode === 'retrieval' &&
+    options.retrievalEmbeddingProvider === 'transformers'
+  ) {
+    memoryService.warmupEmbeddingProvider(options.retrievalEmbeddingProvider);
+    writeProgressFile({
+      progressPath,
+      resultPath,
+      predictionsPath,
+      mode: options.mode,
+      matrix: false,
+      matrixSweep: null,
+      retrievalPolicy: 'budget-only',
+      retrievalQueryMode: options.retrievalQueryMode,
+      retrievalBackend: options.retrievalBackend,
+      retrievalRerank: options.retrievalRerank,
+      retrievalTokenizer: options.retrievalTokenizer,
+      retrievalEmbeddingProvider: options.retrievalEmbeddingProvider,
+      retrievalEmbeddingModel: resolveLocomoRunEmbeddingModel({
+        matrix: false,
+        matrixSweep: null,
+        retrievalEmbeddingProvider: options.retrievalEmbeddingProvider,
+      }),
+      datasetPath,
+      model: null,
+      budgetTokens: options.budgetTokens,
+      sampleCount: plannedSamples.length,
+      completedSampleCount,
+      questionCount: totalQuestionCount,
+      completedQuestionCount: questionCount,
+      scoreTotal,
+      contextF1Total,
+      categories,
+      usageTotals,
+      currentPhase: 'ingesting',
+      currentSampleId: initialSample?.sample_id || null,
+      currentSampleEmbeddedTurnCount: 0,
+      currentSampleTurnCount: initialSampleTurnCount,
+      currentSampleQuestionCount: null,
+      currentSampleQuestionTotal: null,
+      variantCount: null,
+      completedVariantCount: null,
+      currentVariant: null,
+      variants: [],
+    });
+  }
 
   const writeQuestionProgress = (params: {
     samplePrediction: LocomoSamplePrediction;
@@ -472,6 +858,29 @@ async function runEvaluation(options: LocomoRunnerOptions): Promise<void> {
       resultPath,
       predictionsPath,
       mode: options.mode,
+      matrix: false,
+      matrixSweep: null,
+      retrievalPolicy: options.mode === 'retrieval' ? 'budget-only' : null,
+      retrievalQueryMode:
+        options.mode === 'retrieval' ? options.retrievalQueryMode : null,
+      retrievalBackend:
+        options.mode === 'retrieval' ? options.retrievalBackend : null,
+      retrievalRerank:
+        options.mode === 'retrieval' ? options.retrievalRerank : null,
+      retrievalTokenizer:
+        options.mode === 'retrieval' ? options.retrievalTokenizer : null,
+      retrievalEmbeddingProvider:
+        options.mode === 'retrieval'
+          ? options.retrievalEmbeddingProvider
+          : null,
+      retrievalEmbeddingModel:
+        options.mode === 'retrieval'
+          ? resolveLocomoRunEmbeddingModel({
+              matrix: false,
+              matrixSweep: null,
+              retrievalEmbeddingProvider: options.retrievalEmbeddingProvider,
+            })
+          : null,
       datasetPath,
       model: params.model,
       budgetTokens: options.budgetTokens,
@@ -483,39 +892,146 @@ async function runEvaluation(options: LocomoRunnerOptions): Promise<void> {
       contextF1Total: params.contextF1TotalForSnapshot,
       categories,
       usageTotals,
+      currentPhase: options.mode === 'retrieval' ? 'evaluating' : null,
       currentSampleId: params.samplePrediction.sampleId,
+      currentSampleEmbeddedTurnCount: null,
+      currentSampleTurnCount: null,
       currentSampleQuestionCount: params.samplePrediction.qa.length,
       currentSampleQuestionTotal: params.samplePrediction.questionCount,
+      variantCount: null,
+      completedVariantCount: null,
+      currentVariant: null,
+      variants: [],
     });
   };
 
   for (const sample of plannedSamples) {
     const samplePrediction =
       options.mode === 'retrieval'
-        ? await evaluateRetrievalSample({
-            sample,
-            budgetTokens: options.budgetTokens,
-            categories,
-            session: ingestSampleIntoNativeMemory({
+        ? await (async () => {
+            const sampleTurnCount = flattenConversationTurns(
+              sample.conversation,
+            ).length;
+            writeProgressFile({
+              progressPath,
+              resultPath,
+              predictionsPath,
+              mode: options.mode,
+              matrix: false,
+              matrixSweep: null,
+              retrievalPolicy: 'budget-only',
+              retrievalQueryMode: options.retrievalQueryMode,
+              retrievalBackend: options.retrievalBackend,
+              retrievalRerank: options.retrievalRerank,
+              retrievalTokenizer: options.retrievalTokenizer,
+              retrievalEmbeddingProvider: options.retrievalEmbeddingProvider,
+              retrievalEmbeddingModel: resolveLocomoRunEmbeddingModel({
+                matrix: false,
+                matrixSweep: null,
+                retrievalEmbeddingProvider: options.retrievalEmbeddingProvider,
+              }),
+              datasetPath,
+              model: null,
+              budgetTokens: options.budgetTokens,
+              sampleCount: plannedSamples.length,
+              completedSampleCount,
+              questionCount: totalQuestionCount,
+              completedQuestionCount: questionCount,
+              scoreTotal,
+              contextF1Total,
+              categories,
+              usageTotals,
+              currentPhase: 'ingesting',
+              currentSampleId: sample.sample_id,
+              currentSampleEmbeddedTurnCount: 0,
+              currentSampleTurnCount: sampleTurnCount,
+              currentSampleQuestionCount: null,
+              currentSampleQuestionTotal: null,
+              variantCount: null,
+              completedVariantCount: null,
+              currentVariant: null,
+              variants: [],
+            });
+            const session = ingestSampleIntoNativeMemory({
               sample,
               runTag,
               agentMode: options.agentMode,
               runtime,
-            }),
-            onQuestionProgress: ({ samplePrediction }) => {
-              const partialContextF1Total =
-                contextF1Total +
-                samplePrediction.qa.reduce(
-                  (total, qa) => total + (qa.contextF1 || 0),
-                  0,
-                );
-              writeQuestionProgress({
-                samplePrediction,
-                model: null,
-                contextF1TotalForSnapshot: partialContextF1Total,
+              retrievalEmbeddingProvider: options.retrievalEmbeddingProvider,
+              onProgress: ({ sampleId, embeddedTurnCount, turnCount }) => {
+                writeProgressFile({
+                  progressPath,
+                  resultPath,
+                  predictionsPath,
+                  mode: options.mode,
+                  matrix: false,
+                  matrixSweep: null,
+                  retrievalPolicy: 'budget-only',
+                  retrievalQueryMode: options.retrievalQueryMode,
+                  retrievalBackend: options.retrievalBackend,
+                  retrievalRerank: options.retrievalRerank,
+                  retrievalTokenizer: options.retrievalTokenizer,
+                  retrievalEmbeddingProvider:
+                    options.retrievalEmbeddingProvider,
+                  retrievalEmbeddingModel: resolveLocomoRunEmbeddingModel({
+                    matrix: false,
+                    matrixSweep: null,
+                    retrievalEmbeddingProvider:
+                      options.retrievalEmbeddingProvider,
+                  }),
+                  datasetPath,
+                  model: null,
+                  budgetTokens: options.budgetTokens,
+                  sampleCount: plannedSamples.length,
+                  completedSampleCount,
+                  questionCount: totalQuestionCount,
+                  completedQuestionCount: questionCount,
+                  scoreTotal,
+                  contextF1Total,
+                  categories,
+                  usageTotals,
+                  currentPhase: 'ingesting',
+                  currentSampleId: sampleId,
+                  currentSampleEmbeddedTurnCount: embeddedTurnCount,
+                  currentSampleTurnCount: turnCount,
+                  currentSampleQuestionCount: null,
+                  currentSampleQuestionTotal: null,
+                  variantCount: null,
+                  completedVariantCount: null,
+                  currentVariant: null,
+                  variants: [],
+                });
+              },
+            });
+            try {
+              return await evaluateRetrievalSample({
+                sample,
+                budgetTokens: options.budgetTokens,
+                categories,
+                session,
+                retrievalQueryMode: options.retrievalQueryMode,
+                retrievalBackend: options.retrievalBackend,
+                retrievalRerank: options.retrievalRerank,
+                retrievalTokenizer: options.retrievalTokenizer,
+                retrievalEmbeddingProvider: options.retrievalEmbeddingProvider,
+                onQuestionProgress: ({ samplePrediction }) => {
+                  const partialContextF1Total =
+                    contextF1Total +
+                    samplePrediction.qa.reduce(
+                      (total, qa) => total + (qa.contextF1 || 0),
+                      0,
+                    );
+                  writeQuestionProgress({
+                    samplePrediction,
+                    model: null,
+                    contextF1TotalForSnapshot: partialContextF1Total,
+                  });
+                },
               });
-            },
-          })
+            } finally {
+              session.close();
+            }
+          })()
         : await evaluateSample({
             runtime,
             requestModel: resolveSampleRequestModel({
@@ -547,6 +1063,29 @@ async function runEvaluation(options: LocomoRunnerOptions): Promise<void> {
       resultPath,
       predictionsPath,
       mode: options.mode,
+      matrix: false,
+      matrixSweep: null,
+      retrievalPolicy: options.mode === 'retrieval' ? 'budget-only' : null,
+      retrievalQueryMode:
+        options.mode === 'retrieval' ? options.retrievalQueryMode : null,
+      retrievalBackend:
+        options.mode === 'retrieval' ? options.retrievalBackend : null,
+      retrievalRerank:
+        options.mode === 'retrieval' ? options.retrievalRerank : null,
+      retrievalTokenizer:
+        options.mode === 'retrieval' ? options.retrievalTokenizer : null,
+      retrievalEmbeddingProvider:
+        options.mode === 'retrieval'
+          ? options.retrievalEmbeddingProvider
+          : null,
+      retrievalEmbeddingModel:
+        options.mode === 'retrieval'
+          ? resolveLocomoRunEmbeddingModel({
+              matrix: false,
+              matrixSweep: null,
+              retrievalEmbeddingProvider: options.retrievalEmbeddingProvider,
+            })
+          : null,
       datasetPath,
       model: options.mode === 'qa' ? runtime.model : null,
       budgetTokens: options.budgetTokens,
@@ -558,15 +1097,36 @@ async function runEvaluation(options: LocomoRunnerOptions): Promise<void> {
       contextF1Total,
       categories,
       usageTotals,
+      currentPhase:
+        options.mode === 'retrieval' &&
+        completedSampleCount < plannedSamples.length
+          ? 'ingesting'
+          : null,
       currentSampleId:
         completedSampleCount < plannedSamples.length
           ? plannedSamples[completedSampleCount]?.sample_id || null
+          : null,
+      currentSampleEmbeddedTurnCount:
+        options.mode === 'retrieval' &&
+        completedSampleCount < plannedSamples.length
+          ? 0
+          : null,
+      currentSampleTurnCount:
+        options.mode === 'retrieval' &&
+        completedSampleCount < plannedSamples.length
+          ? flattenConversationTurns(
+              plannedSamples[completedSampleCount]?.conversation || {},
+            ).length
           : null,
       currentSampleQuestionCount: null,
       currentSampleQuestionTotal:
         completedSampleCount < plannedSamples.length
           ? plannedSamples[completedSampleCount]?.qa.length || null
           : null,
+      variantCount: null,
+      completedVariantCount: null,
+      currentVariant: null,
+      variants: [],
     });
   }
 
@@ -579,6 +1139,27 @@ async function runEvaluation(options: LocomoRunnerOptions): Promise<void> {
   const summary: LocomoRunSummary = {
     suite: 'locomo',
     mode: options.mode,
+    matrix: false,
+    matrixSweep: null,
+    retrievalPolicy: options.mode === 'retrieval' ? 'budget-only' : null,
+    retrievalQueryMode:
+      options.mode === 'retrieval' ? options.retrievalQueryMode : null,
+    retrievalBackend:
+      options.mode === 'retrieval' ? options.retrievalBackend : null,
+    retrievalRerank:
+      options.mode === 'retrieval' ? options.retrievalRerank : null,
+    retrievalTokenizer:
+      options.mode === 'retrieval' ? options.retrievalTokenizer : null,
+    retrievalEmbeddingProvider:
+      options.mode === 'retrieval' ? options.retrievalEmbeddingProvider : null,
+    retrievalEmbeddingModel:
+      options.mode === 'retrieval'
+        ? resolveLocomoRunEmbeddingModel({
+            matrix: false,
+            matrixSweep: null,
+            retrievalEmbeddingProvider: options.retrievalEmbeddingProvider,
+          })
+        : null,
     dataset: path.basename(datasetPath),
     generatedAt: new Date().toISOString(),
     model: options.mode === 'qa' ? runtime.model : null,
@@ -597,6 +1178,10 @@ async function runEvaluation(options: LocomoRunnerOptions): Promise<void> {
       options.mode === 'qa' && usageTotals.responsesWithUsage > 0
         ? usageTotals
         : null,
+    variantCount: null,
+    bestVariantId: null,
+    bestVariantLabel: null,
+    variants: [],
     samples: predictions.map((samplePrediction) => ({
       sampleId: samplePrediction.sampleId,
       questionCount: samplePrediction.questionCount,
@@ -606,6 +1191,741 @@ async function runEvaluation(options: LocomoRunnerOptions): Promise<void> {
 
   fs.writeFileSync(resultPath, JSON.stringify(summary, null, 2), 'utf-8');
   printSummaryTable(summary);
+}
+
+function buildLocomoRetrievalMatrixVariants(
+  sweep: LocomoRetrievalSweep,
+): LocomoRetrievalVariantPlan[] {
+  const variants: LocomoRetrievalVariantPlan[] = [];
+  const queryModes: LocomoRetrievalQueryMode[] = ['no-stopwords'];
+  const backends: LocomoRetrievalBackend[] =
+    sweep === 'all' || sweep === 'backend'
+      ? ['cosine', 'full-text', 'hybrid']
+      : ['cosine'];
+  const reranks: LocomoRetrievalRerank[] =
+    sweep === 'all' || sweep === 'rerank' ? ['none', 'bm25'] : ['bm25'];
+  const tokenizers: LocomoRetrievalTokenizer[] =
+    sweep === 'all' || sweep === 'tokenizer'
+      ? ['unicode61', 'porter', 'trigram']
+      : ['unicode61'];
+  const embeddingProviders: LocomoRetrievalEmbeddingProvider[] =
+    sweep === 'embedding' ? ['hashed', 'transformers'] : ['hashed'];
+
+  for (const backend of backends) {
+    for (const queryMode of queryModes) {
+      for (const tokenizer of tokenizers) {
+        for (const embeddingProvider of embeddingProviders) {
+          for (const rerank of reranks) {
+            if (
+              backend === 'cosine' &&
+              rerank === 'none' &&
+              tokenizer !== 'unicode61'
+            ) {
+              continue;
+            }
+            const idParts: string[] = [backend];
+            if (queryMode === 'no-stopwords') {
+              idParts.push('no-stopwords');
+            }
+            if (tokenizer !== 'unicode61') {
+              idParts.push(tokenizer);
+            }
+            if (rerank !== 'none') {
+              idParts.push(rerank);
+            }
+            if (embeddingProvider !== 'hashed') {
+              idParts.push(embeddingProvider);
+            }
+            const id = idParts.join('-');
+            variants.push({
+              id,
+              label: formatLocomoRetrievalVariantLabel({
+                queryMode,
+                backend,
+                rerank,
+                tokenizer,
+                embeddingProvider,
+              }),
+              retrievalQueryMode: queryMode,
+              retrievalBackend: backend,
+              retrievalRerank: rerank,
+              retrievalTokenizer: tokenizer,
+              retrievalEmbeddingProvider: embeddingProvider,
+              retrievalEmbeddingModel:
+                resolveLocomoRetrievalEmbeddingModel(embeddingProvider),
+            });
+          }
+        }
+      }
+    }
+  }
+
+  return variants;
+}
+
+function resolveLocomoRetrievalEmbeddingModel(
+  embeddingProvider: LocomoRetrievalEmbeddingProvider,
+): string | null {
+  if (embeddingProvider !== 'transformers') {
+    return null;
+  }
+  return String(getRuntimeConfig().memory.embedding.model || '').trim() || null;
+}
+
+function resolveLocomoRunEmbeddingModel(params: {
+  matrix: boolean;
+  matrixSweep: LocomoRetrievalSweep | null;
+  retrievalEmbeddingProvider: LocomoRetrievalEmbeddingProvider;
+}): string | null {
+  if (!params.matrix) {
+    return resolveLocomoRetrievalEmbeddingModel(
+      params.retrievalEmbeddingProvider,
+    );
+  }
+  if (params.matrixSweep === 'embedding') {
+    return resolveLocomoRetrievalEmbeddingModel('transformers');
+  }
+  return null;
+}
+
+function formatLocomoRetrievalVariantLabel(params: {
+  queryMode: LocomoRetrievalQueryMode;
+  backend: LocomoRetrievalBackend;
+  rerank: LocomoRetrievalRerank;
+  tokenizer: LocomoRetrievalTokenizer;
+  embeddingProvider: LocomoRetrievalEmbeddingProvider;
+}): string {
+  const parts: string[] = [params.backend];
+  if (params.tokenizer === 'porter') {
+    parts.push('porter');
+  } else if (params.tokenizer === 'trigram') {
+    parts.push('trigram');
+  }
+  if (params.rerank === 'bm25') {
+    parts.push('bm25');
+  }
+  if (params.embeddingProvider === 'transformers') {
+    parts.push('transformers');
+  }
+  return parts.join(' + ');
+}
+
+function buildLocomoRetrievalVariantSummary(params: {
+  variant: LocomoRetrievalVariantPlan;
+  sampleCount: number;
+  questionCount: number;
+  scoreTotal: number;
+  contextF1Total: number;
+  categories: Map<number, LocomoCategoryRunningAggregate>;
+}): LocomoRetrievalVariantSummary {
+  return {
+    id: params.variant.id,
+    label: params.variant.label,
+    retrievalPolicy: 'budget-only',
+    retrievalQueryMode: params.variant.retrievalQueryMode,
+    retrievalBackend: params.variant.retrievalBackend,
+    retrievalRerank: params.variant.retrievalRerank,
+    retrievalTokenizer: params.variant.retrievalTokenizer,
+    retrievalEmbeddingProvider: params.variant.retrievalEmbeddingProvider,
+    retrievalEmbeddingModel: params.variant.retrievalEmbeddingModel,
+    sampleCount: params.sampleCount,
+    questionCount: params.questionCount,
+    overallScore: roundMetric(
+      params.scoreTotal / Math.max(params.questionCount, 1),
+    ),
+    contextF1: roundMetric(
+      params.contextF1Total / Math.max(params.questionCount, 1),
+    ),
+    categories: buildCategorySummaries(params.categories, 'retrieval'),
+  };
+}
+
+function buildLocomoRetrievalVariantProgress(params: {
+  variant: LocomoRetrievalVariantPlan;
+  sampleCount: number;
+  completedSampleCount: number;
+  questionCount: number;
+  completedQuestionCount: number;
+  scoreTotal: number;
+  contextF1Total: number;
+  categories: Map<number, LocomoCategoryRunningAggregate>;
+  currentPhase: LocomoProgressPhase | null;
+  currentSampleId: string | null;
+  currentSampleEmbeddedTurnCount: number | null;
+  currentSampleTurnCount: number | null;
+  currentSampleQuestionCount: number | null;
+  currentSampleQuestionTotal: number | null;
+}): LocomoRetrievalVariantProgress {
+  return {
+    id: params.variant.id,
+    label: params.variant.label,
+    retrievalPolicy: 'budget-only',
+    retrievalQueryMode: params.variant.retrievalQueryMode,
+    retrievalBackend: params.variant.retrievalBackend,
+    retrievalRerank: params.variant.retrievalRerank,
+    retrievalTokenizer: params.variant.retrievalTokenizer,
+    retrievalEmbeddingProvider: params.variant.retrievalEmbeddingProvider,
+    retrievalEmbeddingModel: params.variant.retrievalEmbeddingModel,
+    sampleCount: params.sampleCount,
+    questionCount: params.questionCount,
+    overallScore: roundMetric(
+      params.scoreTotal / Math.max(params.completedQuestionCount, 1),
+    ),
+    contextF1: roundMetric(
+      params.contextF1Total / Math.max(params.completedQuestionCount, 1),
+    ),
+    categories: buildCategorySummaries(params.categories, 'retrieval'),
+    currentPhase: params.currentPhase,
+    completedSampleCount: params.completedSampleCount,
+    completedQuestionCount: params.completedQuestionCount,
+    currentSampleId: params.currentSampleId,
+    currentSampleEmbeddedTurnCount: params.currentSampleEmbeddedTurnCount,
+    currentSampleTurnCount: params.currentSampleTurnCount,
+    currentSampleQuestionCount: params.currentSampleQuestionCount,
+    currentSampleQuestionTotal: params.currentSampleQuestionTotal,
+  };
+}
+
+function pickBestLocomoRetrievalVariant(
+  variants: LocomoRetrievalVariantSummary[],
+): LocomoRetrievalVariantSummary | null {
+  if (variants.length === 0) {
+    return null;
+  }
+  return [...variants].sort((left, right) => {
+    if (right.overallScore !== left.overallScore) {
+      return right.overallScore - left.overallScore;
+    }
+    if ((right.contextF1 ?? 0) !== (left.contextF1 ?? 0)) {
+      return (right.contextF1 ?? 0) - (left.contextF1 ?? 0);
+    }
+    return left.label.localeCompare(right.label);
+  })[0];
+}
+
+async function runRetrievalMatrixEvaluation(params: {
+  options: LocomoRunnerOptions;
+  runtime: LocomoGatewayRuntime;
+  plannedSamples: LocomoSample[];
+  totalQuestionCount: number;
+  datasetPath: string;
+  jobDir: string;
+  progressPath: string;
+  resultPath: string;
+  predictionsPath: string;
+  runTag: string;
+  variants: LocomoRetrievalVariantPlan[];
+}): Promise<void> {
+  const completedVariants: LocomoRetrievalVariantSummary[] = [];
+  const variantPredictionManifests: LocomoRetrievalVariantPredictionManifestEntry[] =
+    [];
+  const matrixPredictionsDir = path.join(params.jobDir, 'matrix-predictions');
+  fs.mkdirSync(matrixPredictionsDir, { recursive: true });
+
+  writeLocomoMatrixPredictionsIndex({
+    predictionsPath: params.predictionsPath,
+    matrixSweep: params.options.matrixSweep,
+    variants: variantPredictionManifests,
+  });
+
+  writeProgressFile({
+    progressPath: params.progressPath,
+    resultPath: params.resultPath,
+    predictionsPath: params.predictionsPath,
+    mode: 'retrieval',
+    matrix: true,
+    matrixSweep: params.options.matrixSweep,
+    retrievalPolicy: 'budget-only',
+    retrievalQueryMode: null,
+    retrievalBackend: null,
+    retrievalRerank: null,
+    retrievalTokenizer: null,
+    retrievalEmbeddingProvider: null,
+    retrievalEmbeddingModel: resolveLocomoRunEmbeddingModel({
+      matrix: true,
+      matrixSweep: params.options.matrixSweep,
+      retrievalEmbeddingProvider: 'hashed',
+    }),
+    datasetPath: params.datasetPath,
+    model: null,
+    budgetTokens: params.options.budgetTokens,
+    sampleCount: params.plannedSamples.length,
+    completedSampleCount: 0,
+    questionCount: params.totalQuestionCount,
+    completedQuestionCount: 0,
+    scoreTotal: 0,
+    contextF1Total: 0,
+    categories: new Map(),
+    usageTotals: {
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+      responsesWithUsage: 0,
+    },
+    currentPhase: null,
+    currentSampleId: null,
+    currentSampleEmbeddedTurnCount: null,
+    currentSampleTurnCount: null,
+    currentSampleQuestionCount: null,
+    currentSampleQuestionTotal: null,
+    variantCount: params.variants.length,
+    completedVariantCount: 0,
+    currentVariant: null,
+    variants: completedVariants,
+  });
+
+  for (const variant of params.variants) {
+    const evaluatedVariant = await runSingleRetrievalVariantEvaluation({
+      variant,
+      plannedSamples: params.plannedSamples,
+      totalQuestionCount: params.totalQuestionCount,
+      budgetTokens: params.options.budgetTokens,
+      runtime: params.runtime,
+      runTag: `${params.runTag}-${variant.id}`,
+      agentMode: params.options.agentMode,
+      onProgress: (currentVariant) => {
+        writeProgressFile({
+          progressPath: params.progressPath,
+          resultPath: params.resultPath,
+          predictionsPath: params.predictionsPath,
+          mode: 'retrieval',
+          matrix: true,
+          matrixSweep: params.options.matrixSweep,
+          retrievalPolicy: 'budget-only',
+          retrievalQueryMode: null,
+          retrievalBackend: null,
+          retrievalRerank: null,
+          retrievalTokenizer: null,
+          retrievalEmbeddingProvider: null,
+          retrievalEmbeddingModel: resolveLocomoRunEmbeddingModel({
+            matrix: true,
+            matrixSweep: params.options.matrixSweep,
+            retrievalEmbeddingProvider: 'hashed',
+          }),
+          datasetPath: params.datasetPath,
+          model: null,
+          budgetTokens: params.options.budgetTokens,
+          sampleCount: params.plannedSamples.length,
+          completedSampleCount: currentVariant.completedSampleCount,
+          questionCount: params.totalQuestionCount,
+          completedQuestionCount: currentVariant.completedQuestionCount,
+          scoreTotal: currentVariant.overallScore,
+          contextF1Total: currentVariant.contextF1 ?? 0,
+          categories: new Map(),
+          usageTotals: {
+            promptTokens: 0,
+            completionTokens: 0,
+            totalTokens: 0,
+            responsesWithUsage: 0,
+          },
+          currentPhase: currentVariant.currentPhase,
+          currentSampleId: currentVariant.currentSampleId,
+          currentSampleEmbeddedTurnCount:
+            currentVariant.currentSampleEmbeddedTurnCount,
+          currentSampleTurnCount: currentVariant.currentSampleTurnCount,
+          currentSampleQuestionCount: currentVariant.currentSampleQuestionCount,
+          currentSampleQuestionTotal: currentVariant.currentSampleQuestionTotal,
+          variantCount: params.variants.length,
+          completedVariantCount: completedVariants.length,
+          currentVariant,
+          variants: completedVariants,
+        });
+      },
+    });
+
+    completedVariants.push({
+      id: evaluatedVariant.id,
+      label: evaluatedVariant.label,
+      retrievalPolicy: evaluatedVariant.retrievalPolicy,
+      retrievalQueryMode: evaluatedVariant.retrievalQueryMode,
+      retrievalBackend: evaluatedVariant.retrievalBackend,
+      retrievalRerank: evaluatedVariant.retrievalRerank,
+      retrievalTokenizer: evaluatedVariant.retrievalTokenizer,
+      retrievalEmbeddingProvider: evaluatedVariant.retrievalEmbeddingProvider,
+      retrievalEmbeddingModel: evaluatedVariant.retrievalEmbeddingModel,
+      sampleCount: evaluatedVariant.sampleCount,
+      questionCount: evaluatedVariant.questionCount,
+      overallScore: evaluatedVariant.overallScore,
+      contextF1: evaluatedVariant.contextF1,
+      categories: evaluatedVariant.categories,
+    });
+    const variantPredictionsPath = path.join(
+      matrixPredictionsDir,
+      `${evaluatedVariant.id}.json`,
+    );
+    fs.writeFileSync(
+      variantPredictionsPath,
+      JSON.stringify(
+        {
+          suite: 'locomo',
+          mode: 'retrieval',
+          matrix: true,
+          matrixSweep: params.options.matrixSweep,
+          variant: {
+            id: evaluatedVariant.id,
+            label: evaluatedVariant.label,
+            retrievalQueryMode: evaluatedVariant.retrievalQueryMode,
+            retrievalBackend: evaluatedVariant.retrievalBackend,
+            retrievalRerank: evaluatedVariant.retrievalRerank,
+            retrievalTokenizer: evaluatedVariant.retrievalTokenizer,
+            retrievalEmbeddingProvider:
+              evaluatedVariant.retrievalEmbeddingProvider,
+            retrievalEmbeddingModel: evaluatedVariant.retrievalEmbeddingModel,
+            sampleCount: evaluatedVariant.sampleCount,
+            questionCount: evaluatedVariant.questionCount,
+          },
+          predictions: evaluatedVariant.predictions,
+        },
+        null,
+        2,
+      ),
+      'utf-8',
+    );
+    variantPredictionManifests.push({
+      id: evaluatedVariant.id,
+      label: evaluatedVariant.label,
+      retrievalQueryMode: evaluatedVariant.retrievalQueryMode,
+      retrievalBackend: evaluatedVariant.retrievalBackend,
+      retrievalRerank: evaluatedVariant.retrievalRerank,
+      retrievalTokenizer: evaluatedVariant.retrievalTokenizer,
+      retrievalEmbeddingProvider: evaluatedVariant.retrievalEmbeddingProvider,
+      predictionsPath: variantPredictionsPath,
+      sampleCount: evaluatedVariant.sampleCount,
+      questionCount: evaluatedVariant.questionCount,
+    });
+    writeLocomoMatrixPredictionsIndex({
+      predictionsPath: params.predictionsPath,
+      matrixSweep: params.options.matrixSweep,
+      variants: variantPredictionManifests,
+    });
+
+    writeProgressFile({
+      progressPath: params.progressPath,
+      resultPath: params.resultPath,
+      predictionsPath: params.predictionsPath,
+      mode: 'retrieval',
+      matrix: true,
+      matrixSweep: params.options.matrixSweep,
+      retrievalPolicy: 'budget-only',
+      retrievalQueryMode: null,
+      retrievalBackend: null,
+      retrievalRerank: null,
+      retrievalTokenizer: null,
+      retrievalEmbeddingProvider: null,
+      retrievalEmbeddingModel: resolveLocomoRunEmbeddingModel({
+        matrix: true,
+        matrixSweep: params.options.matrixSweep,
+        retrievalEmbeddingProvider: 'hashed',
+      }),
+      datasetPath: params.datasetPath,
+      model: null,
+      budgetTokens: params.options.budgetTokens,
+      sampleCount: params.plannedSamples.length,
+      completedSampleCount: params.plannedSamples.length,
+      questionCount: params.totalQuestionCount,
+      completedQuestionCount: params.totalQuestionCount,
+      scoreTotal: 0,
+      contextF1Total: 0,
+      categories: new Map(),
+      usageTotals: {
+        promptTokens: 0,
+        completionTokens: 0,
+        totalTokens: 0,
+        responsesWithUsage: 0,
+      },
+      currentPhase: null,
+      currentSampleId: null,
+      currentSampleEmbeddedTurnCount: null,
+      currentSampleTurnCount: null,
+      currentSampleQuestionCount: null,
+      currentSampleQuestionTotal: null,
+      variantCount: params.variants.length,
+      completedVariantCount: completedVariants.length,
+      currentVariant: null,
+      variants: completedVariants,
+    });
+  }
+
+  const bestVariant = pickBestLocomoRetrievalVariant(completedVariants);
+  const summary: LocomoRunSummary = {
+    suite: 'locomo',
+    mode: 'retrieval',
+    matrix: true,
+    matrixSweep: params.options.matrixSweep,
+    retrievalPolicy: 'budget-only',
+    retrievalQueryMode: null,
+    retrievalBackend: null,
+    retrievalRerank: null,
+    retrievalTokenizer: null,
+    retrievalEmbeddingProvider: null,
+    retrievalEmbeddingModel: resolveLocomoRunEmbeddingModel({
+      matrix: true,
+      matrixSweep: params.options.matrixSweep,
+      retrievalEmbeddingProvider: 'hashed',
+    }),
+    dataset: path.basename(params.datasetPath),
+    generatedAt: new Date().toISOString(),
+    model: null,
+    budgetTokens: params.options.budgetTokens,
+    sampleCount: params.plannedSamples.length,
+    questionCount: params.totalQuestionCount,
+    overallScore: bestVariant?.overallScore ?? null,
+    contextF1: bestVariant?.contextF1 ?? null,
+    resultPath: params.resultPath,
+    predictionsPath: params.predictionsPath,
+    categories: bestVariant?.categories ?? {},
+    tokenUsage: null,
+    variantCount: params.variants.length,
+    bestVariantId: bestVariant?.id ?? null,
+    bestVariantLabel: bestVariant?.label ?? null,
+    variants: completedVariants,
+    samples: [],
+  };
+
+  fs.writeFileSync(
+    params.resultPath,
+    JSON.stringify(summary, null, 2),
+    'utf-8',
+  );
+  printSummaryTable(summary);
+}
+
+function writeLocomoMatrixPredictionsIndex(params: {
+  predictionsPath: string;
+  matrixSweep: LocomoRetrievalSweep;
+  variants: LocomoRetrievalVariantPredictionManifestEntry[];
+}): void {
+  fs.writeFileSync(
+    params.predictionsPath,
+    JSON.stringify(
+      {
+        suite: 'locomo',
+        mode: 'retrieval',
+        matrix: true,
+        matrixSweep: params.matrixSweep,
+        variants: params.variants,
+      },
+      null,
+      2,
+    ),
+    'utf-8',
+  );
+}
+
+async function runSingleRetrievalVariantEvaluation(params: {
+  variant: LocomoRetrievalVariantPlan;
+  plannedSamples: LocomoSample[];
+  totalQuestionCount: number;
+  budgetTokens: number;
+  runtime: LocomoGatewayRuntime;
+  runTag: string;
+  agentMode: LocomoAgentMode;
+  onProgress?: (currentVariant: LocomoRetrievalVariantProgress) => void;
+}): Promise<LocomoEvaluatedRetrievalVariant> {
+  const predictions: LocomoSamplePrediction[] = [];
+  const categories = new Map<number, LocomoCategoryRunningAggregate>();
+  let questionCount = 0;
+  let scoreTotal = 0;
+  let contextF1Total = 0;
+  let completedSampleCount = 0;
+  const initialSample = params.plannedSamples[0] ?? null;
+  const initialSampleTurnCount = initialSample
+    ? flattenConversationTurns(initialSample.conversation).length
+    : null;
+
+  params.onProgress?.(
+    buildLocomoRetrievalVariantProgress({
+      variant: params.variant,
+      sampleCount: params.plannedSamples.length,
+      completedSampleCount,
+      questionCount: params.totalQuestionCount,
+      completedQuestionCount: questionCount,
+      scoreTotal,
+      contextF1Total,
+      categories,
+      currentPhase:
+        params.variant.retrievalEmbeddingProvider === 'transformers'
+          ? 'warming-embedding'
+          : 'ingesting',
+      currentSampleId: initialSample?.sample_id || null,
+      currentSampleEmbeddedTurnCount: 0,
+      currentSampleTurnCount: initialSampleTurnCount,
+      currentSampleQuestionCount: null,
+      currentSampleQuestionTotal: null,
+    }),
+  );
+  if (params.variant.retrievalEmbeddingProvider === 'transformers') {
+    memoryService.warmupEmbeddingProvider(
+      params.variant.retrievalEmbeddingProvider,
+    );
+    params.onProgress?.(
+      buildLocomoRetrievalVariantProgress({
+        variant: params.variant,
+        sampleCount: params.plannedSamples.length,
+        completedSampleCount,
+        questionCount: params.totalQuestionCount,
+        completedQuestionCount: questionCount,
+        scoreTotal,
+        contextF1Total,
+        categories,
+        currentPhase: 'ingesting',
+        currentSampleId: initialSample?.sample_id || null,
+        currentSampleEmbeddedTurnCount: 0,
+        currentSampleTurnCount: initialSampleTurnCount,
+        currentSampleQuestionCount: null,
+        currentSampleQuestionTotal: null,
+      }),
+    );
+  }
+
+  for (const sample of params.plannedSamples) {
+    const sampleTurnCount = flattenConversationTurns(
+      sample.conversation,
+    ).length;
+    params.onProgress?.(
+      buildLocomoRetrievalVariantProgress({
+        variant: params.variant,
+        sampleCount: params.plannedSamples.length,
+        completedSampleCount,
+        questionCount: params.totalQuestionCount,
+        completedQuestionCount: questionCount,
+        scoreTotal,
+        contextF1Total,
+        categories,
+        currentPhase: 'ingesting',
+        currentSampleId: sample.sample_id,
+        currentSampleEmbeddedTurnCount: 0,
+        currentSampleTurnCount: sampleTurnCount,
+        currentSampleQuestionCount: null,
+        currentSampleQuestionTotal: null,
+      }),
+    );
+    const session = ingestSampleIntoNativeMemory({
+      sample,
+      runTag: params.runTag,
+      agentMode: params.agentMode,
+      runtime: params.runtime,
+      retrievalEmbeddingProvider: params.variant.retrievalEmbeddingProvider,
+      onProgress: ({ sampleId, embeddedTurnCount, turnCount }) => {
+        params.onProgress?.(
+          buildLocomoRetrievalVariantProgress({
+            variant: params.variant,
+            sampleCount: params.plannedSamples.length,
+            completedSampleCount,
+            questionCount: params.totalQuestionCount,
+            completedQuestionCount: questionCount,
+            scoreTotal,
+            contextF1Total,
+            categories,
+            currentPhase: 'ingesting',
+            currentSampleId: sampleId,
+            currentSampleEmbeddedTurnCount: embeddedTurnCount,
+            currentSampleTurnCount: turnCount,
+            currentSampleQuestionCount: null,
+            currentSampleQuestionTotal: null,
+          }),
+        );
+      },
+    });
+    try {
+      const samplePrediction = await evaluateRetrievalSample({
+        sample,
+        budgetTokens: params.budgetTokens,
+        categories,
+        session,
+        retrievalQueryMode: params.variant.retrievalQueryMode,
+        retrievalBackend: params.variant.retrievalBackend,
+        retrievalRerank: params.variant.retrievalRerank,
+        retrievalTokenizer: params.variant.retrievalTokenizer,
+        retrievalEmbeddingProvider: params.variant.retrievalEmbeddingProvider,
+        onQuestionProgress: ({ samplePrediction: partialSamplePrediction }) => {
+          params.onProgress?.(
+            buildLocomoRetrievalVariantProgress({
+              variant: params.variant,
+              sampleCount: params.plannedSamples.length,
+              completedSampleCount,
+              questionCount: params.totalQuestionCount,
+              completedQuestionCount:
+                questionCount + partialSamplePrediction.qa.length,
+              scoreTotal:
+                scoreTotal +
+                partialSamplePrediction.qa.reduce(
+                  (total, entry) => total + entry.score,
+                  0,
+                ),
+              contextF1Total:
+                contextF1Total +
+                partialSamplePrediction.qa.reduce(
+                  (total, entry) => total + (entry.contextF1 || 0),
+                  0,
+                ),
+              categories,
+              currentPhase: 'evaluating',
+              currentSampleId: partialSamplePrediction.sampleId,
+              currentSampleEmbeddedTurnCount: null,
+              currentSampleTurnCount: null,
+              currentSampleQuestionCount: partialSamplePrediction.qa.length,
+              currentSampleQuestionTotal: partialSamplePrediction.questionCount,
+            }),
+          );
+        },
+      });
+      predictions.push(samplePrediction);
+      questionCount += samplePrediction.questionCount;
+      scoreTotal += samplePrediction.meanScore * samplePrediction.questionCount;
+      contextF1Total +=
+        (samplePrediction.meanContextF1 || 0) * samplePrediction.questionCount;
+      completedSampleCount += 1;
+      params.onProgress?.(
+        buildLocomoRetrievalVariantProgress({
+          variant: params.variant,
+          sampleCount: params.plannedSamples.length,
+          completedSampleCount,
+          questionCount: params.totalQuestionCount,
+          completedQuestionCount: questionCount,
+          scoreTotal,
+          contextF1Total,
+          categories,
+          currentPhase:
+            completedSampleCount < params.plannedSamples.length
+              ? 'ingesting'
+              : null,
+          currentSampleId:
+            completedSampleCount < params.plannedSamples.length
+              ? params.plannedSamples[completedSampleCount]?.sample_id || null
+              : null,
+          currentSampleEmbeddedTurnCount:
+            completedSampleCount < params.plannedSamples.length ? 0 : null,
+          currentSampleTurnCount:
+            completedSampleCount < params.plannedSamples.length
+              ? flattenConversationTurns(
+                  params.plannedSamples[completedSampleCount]?.conversation ||
+                    {},
+                ).length
+              : null,
+          currentSampleQuestionCount: null,
+          currentSampleQuestionTotal:
+            completedSampleCount < params.plannedSamples.length
+              ? params.plannedSamples[completedSampleCount]?.qa.length || null
+              : null,
+        }),
+      );
+    } finally {
+      session.close();
+    }
+  }
+
+  return {
+    ...buildLocomoRetrievalVariantSummary({
+      variant: params.variant,
+      sampleCount: params.plannedSamples.length,
+      questionCount,
+      scoreTotal,
+      contextF1Total,
+      categories,
+    }),
+    predictions,
+  };
 }
 
 function applyQuestionLimit(
@@ -644,6 +1964,17 @@ function shouldWriteQuestionProgressSnapshot(
   );
 }
 
+function shouldWriteIngestionProgressSnapshot(
+  embeddedTurnCount: number,
+  totalTurnCount: number,
+): boolean {
+  return (
+    embeddedTurnCount === 1 ||
+    embeddedTurnCount === totalTurnCount ||
+    embeddedTurnCount % LOCOMO_PROGRESS_WRITE_INTERVAL_TURNS === 0
+  );
+}
+
 function buildCategorySummaries(
   categories: Map<number, LocomoCategoryRunningAggregate>,
   mode: LocomoEvaluationMode,
@@ -671,6 +2002,15 @@ function writeProgressFile(params: {
   resultPath: string;
   predictionsPath: string;
   mode: LocomoEvaluationMode;
+  matrix: boolean;
+  matrixSweep: LocomoRetrievalSweep | null;
+  retrievalPolicy: LocomoRetrievalPolicy | null;
+  retrievalQueryMode: LocomoRetrievalQueryMode | null;
+  retrievalBackend: LocomoRetrievalBackend | null;
+  retrievalRerank: LocomoRetrievalRerank | null;
+  retrievalTokenizer: LocomoRetrievalTokenizer | null;
+  retrievalEmbeddingProvider: LocomoRetrievalEmbeddingProvider | null;
+  retrievalEmbeddingModel: string | null;
   datasetPath: string;
   model: string | null;
   budgetTokens: number;
@@ -682,41 +2022,87 @@ function writeProgressFile(params: {
   contextF1Total: number;
   categories: Map<number, LocomoCategoryRunningAggregate>;
   usageTotals: LocomoTokenUsage;
+  currentPhase: LocomoProgressPhase | null;
   currentSampleId: string | null;
+  currentSampleEmbeddedTurnCount: number | null;
+  currentSampleTurnCount: number | null;
   currentSampleQuestionCount: number | null;
   currentSampleQuestionTotal: number | null;
+  variantCount: number | null;
+  completedVariantCount: number | null;
+  currentVariant: LocomoRetrievalVariantProgress | null;
+  variants: LocomoRetrievalVariantSummary[];
 }): void {
+  const bestCompletedVariant = pickBestLocomoRetrievalVariant(params.variants);
+  const currentAggregate =
+    params.matrix && params.mode === 'retrieval' ? params.currentVariant : null;
+  const visibleAggregate = currentAggregate || bestCompletedVariant;
   const progress: LocomoProgressSummary = {
     suite: 'locomo',
     mode: params.mode,
+    matrix: params.matrix,
+    matrixSweep: params.matrixSweep,
+    retrievalPolicy: params.retrievalPolicy,
+    retrievalQueryMode: params.retrievalQueryMode,
+    retrievalBackend: params.retrievalBackend,
+    retrievalRerank: params.retrievalRerank,
+    retrievalTokenizer: params.retrievalTokenizer,
+    retrievalEmbeddingProvider: params.retrievalEmbeddingProvider,
+    retrievalEmbeddingModel: params.retrievalEmbeddingModel,
     dataset: path.basename(params.datasetPath),
     updatedAt: new Date().toISOString(),
     model: params.model,
     budgetTokens: params.budgetTokens,
     sampleCount: params.sampleCount,
-    completedSampleCount: params.completedSampleCount,
+    completedSampleCount:
+      currentAggregate?.completedSampleCount ?? params.completedSampleCount,
     questionCount: params.questionCount,
-    completedQuestionCount: params.completedQuestionCount,
-    overallScore: roundMetric(
-      params.scoreTotal / Math.max(params.completedQuestionCount, 1),
-    ),
+    completedQuestionCount:
+      currentAggregate?.completedQuestionCount ?? params.completedQuestionCount,
+    overallScore:
+      params.matrix && params.mode === 'retrieval'
+        ? (visibleAggregate?.overallScore ?? null)
+        : roundMetric(
+            params.scoreTotal / Math.max(params.completedQuestionCount, 1),
+          ),
     contextF1:
-      params.mode === 'retrieval'
-        ? roundMetric(
-            params.contextF1Total / Math.max(params.completedQuestionCount, 1),
-          )
-        : null,
-    currentSampleId: params.currentSampleId,
-    currentSampleQuestionCount: params.currentSampleQuestionCount,
-    currentSampleQuestionTotal: params.currentSampleQuestionTotal,
+      params.matrix && params.mode === 'retrieval'
+        ? (visibleAggregate?.contextF1 ?? null)
+        : params.mode === 'retrieval'
+          ? roundMetric(
+              params.contextF1Total /
+                Math.max(params.completedQuestionCount, 1),
+            )
+          : null,
+    currentPhase: currentAggregate?.currentPhase ?? params.currentPhase,
+    currentSampleId:
+      currentAggregate?.currentSampleId ?? params.currentSampleId,
+    currentSampleEmbeddedTurnCount:
+      currentAggregate?.currentSampleEmbeddedTurnCount ??
+      params.currentSampleEmbeddedTurnCount,
+    currentSampleTurnCount:
+      currentAggregate?.currentSampleTurnCount ?? params.currentSampleTurnCount,
+    currentSampleQuestionCount:
+      currentAggregate?.currentSampleQuestionCount ??
+      params.currentSampleQuestionCount,
+    currentSampleQuestionTotal:
+      currentAggregate?.currentSampleQuestionTotal ??
+      params.currentSampleQuestionTotal,
     progressPath: params.progressPath,
     resultPath: params.resultPath,
     predictionsPath: params.predictionsPath,
-    categories: buildCategorySummaries(params.categories, params.mode),
+    categories:
+      params.matrix && params.mode === 'retrieval'
+        ? (visibleAggregate?.categories ?? {})
+        : buildCategorySummaries(params.categories, params.mode),
     tokenUsage:
       params.mode === 'qa' && params.usageTotals.responsesWithUsage > 0
         ? params.usageTotals
         : null,
+    variantCount: params.variantCount,
+    completedVariantCount: params.completedVariantCount,
+    currentVariant: params.currentVariant,
+    variants: params.variants,
   };
   fs.writeFileSync(
     params.progressPath,
@@ -963,6 +2349,11 @@ async function evaluateRetrievalSample(params: {
   budgetTokens: number;
   categories: Map<number, LocomoCategoryRunningAggregate>;
   session: LocomoRetrievalSession;
+  retrievalQueryMode: LocomoRetrievalQueryMode;
+  retrievalBackend: LocomoRetrievalBackend;
+  retrievalRerank: LocomoRetrievalRerank;
+  retrievalTokenizer: LocomoRetrievalTokenizer;
+  retrievalEmbeddingProvider: LocomoRetrievalEmbeddingProvider;
   onQuestionProgress?: (params: {
     samplePrediction: LocomoSamplePrediction;
   }) => void;
@@ -971,21 +2362,25 @@ async function evaluateRetrievalSample(params: {
   const sampleQuestionCount = (params.sample.qa || []).length;
 
   for (const qa of params.sample.qa || []) {
-    const memoryContext = memoryService.buildPromptMemoryContext({
-      session: params.session.session,
+    const recalledMemories = recallLocomoRetrievalMemories({
+      session: params.session,
       query: String(qa.question || '').trim(),
-      semanticLimit: 12,
+      retrievalQueryMode: params.retrievalQueryMode,
+      retrievalBackend: params.retrievalBackend,
+      retrievalRerank: params.retrievalRerank,
+      retrievalTokenizer: params.retrievalTokenizer,
+      retrievalEmbeddingProvider: params.retrievalEmbeddingProvider,
     });
-    const recalledMemories = budgetTruncateSemanticMemories(
-      memoryContext.semanticMemories,
+    const budgetedMemories = budgetTruncateRetrievedMemories(
+      recalledMemories,
       params.budgetTokens,
     );
-    const recalledContext = recalledMemories
+    const recalledContext = budgetedMemories
       .map((entry) => entry.content)
       .join('\n\n')
       .trim();
-    const retrievedSourceMessageIds = recalledMemories
-      .map((entry) => entry.source_message_id)
+    const retrievedSourceMessageIds = budgetedMemories
+      .map((entry) => entry.sourceMessageId)
       .filter(
         (value): value is number =>
           typeof value === 'number' && Number.isFinite(value) && value > 0,
@@ -1055,6 +2450,46 @@ async function evaluateRetrievalSample(params: {
     ),
     qa: qaPredictions,
   };
+}
+
+function recallLocomoRetrievalMemories(params: {
+  session: LocomoRetrievalSession;
+  query: string;
+  retrievalQueryMode: LocomoRetrievalQueryMode;
+  retrievalBackend: LocomoRetrievalBackend;
+  retrievalRerank: LocomoRetrievalRerank;
+  retrievalTokenizer: LocomoRetrievalTokenizer;
+  retrievalEmbeddingProvider: LocomoRetrievalEmbeddingProvider;
+}): LocomoRetrievedMemory[] {
+  const limit = Math.max(1, params.session.messageIdByDiaId.size);
+  return mapRetrievedSemanticMemories(
+    memoryService.recallSemanticMemories({
+      sessionId: params.session.session.id,
+      query: params.query,
+      queryMode: params.retrievalQueryMode,
+      backend: params.retrievalBackend,
+      rerank: params.retrievalRerank,
+      tokenizer: params.retrievalTokenizer,
+      embeddingProvider: params.retrievalEmbeddingProvider,
+      limit,
+      limitHardCap: null,
+      minConfidence: 0,
+    }),
+  );
+}
+
+function mapRetrievedSemanticMemories(
+  memories: Array<{
+    content: string;
+    source_message_id: number | null;
+    confidence: number;
+  }>,
+): LocomoRetrievedMemory[] {
+  return memories.map((memory) => ({
+    content: memory.content,
+    sourceMessageId: memory.source_message_id ?? null,
+    confidence: memory.confidence,
+  }));
 }
 
 function buildQuestionPrompt(
@@ -1259,6 +2694,8 @@ function ingestSampleIntoNativeMemory(params: {
   runTag: string;
   agentMode: LocomoAgentMode;
   runtime: LocomoGatewayRuntime;
+  retrievalEmbeddingProvider: LocomoRetrievalEmbeddingProvider;
+  onProgress?: (progress: LocomoIngestionProgress) => void;
 }): LocomoRetrievalSession {
   const agentId = resolveRetrievalAgentId(params);
   const sessionId = buildSessionKey(
@@ -1275,8 +2712,14 @@ function ingestSampleIntoNativeMemory(params: {
   );
   const messageIdByDiaId = new Map<string, number>();
   const [speakerA, speakerB] = getSpeakerNames(params.sample);
+  const turns = flattenConversationTurns(params.sample.conversation);
+  params.onProgress?.({
+    sampleId: params.sample.sample_id,
+    embeddedTurnCount: 0,
+    turnCount: turns.length,
+  });
 
-  for (const turn of flattenConversationTurns(params.sample.conversation)) {
+  for (const [index, turn] of turns.entries()) {
     const role = turn.speaker === speakerB ? 'assistant' : 'user';
     const content = formatRetrievalMemoryTurn(turn);
     const messageId = memoryService.storeMessage({
@@ -1301,13 +2744,23 @@ function ingestSampleIntoNativeMemory(params: {
       },
       content,
       confidence: 1,
+      embeddingProvider: params.retrievalEmbeddingProvider,
       sourceMessageId: messageId,
     });
+    const embeddedTurnCount = index + 1;
+    if (shouldWriteIngestionProgressSnapshot(embeddedTurnCount, turns.length)) {
+      params.onProgress?.({
+        sampleId: params.sample.sample_id,
+        embeddedTurnCount,
+        turnCount: turns.length,
+      });
+    }
   }
 
   return {
     session,
     messageIdByDiaId,
+    close: () => {},
   };
 }
 
@@ -1330,11 +2783,11 @@ function formatRetrievalMemoryTurn(
   return `${datePrefix}${formatConversationTurn(turn).trim()}`.trim();
 }
 
-function budgetTruncateSemanticMemories(
-  memories: SemanticMemoryEntry[],
+function budgetTruncateRetrievedMemories(
+  memories: LocomoRetrievedMemory[],
   budgetTokens: number,
-): SemanticMemoryEntry[] {
-  const selected: SemanticMemoryEntry[] = [];
+): LocomoRetrievedMemory[] {
+  const selected: LocomoRetrievedMemory[] = [];
   let totalTokens = 0;
 
   for (const memory of memories) {
@@ -1597,8 +3050,68 @@ function formatLocomoCategoryLine(
   return `cat${category.padEnd(4)} Score ${aggregate.meanScore.toFixed(3).padEnd(6)} Q ${String(aggregate.questionCount)}`;
 }
 
+function buildLocomoVariantComparisonTable(
+  variants: LocomoRetrievalVariantSummary[],
+): string[] {
+  const header = ['Variant', 'HitRate', 'F1', 'C1', 'C2', 'C3', 'C4', 'C5'];
+  const rows = variants.map((variant) => [
+    variant.label,
+    formatLocomoMatrixMetric(variant.overallScore),
+    formatLocomoMatrixMetric(variant.contextF1),
+    formatLocomoMatrixMetric(variant.categories['1']?.meanScore ?? null),
+    formatLocomoMatrixMetric(variant.categories['2']?.meanScore ?? null),
+    formatLocomoMatrixMetric(variant.categories['3']?.meanScore ?? null),
+    formatLocomoMatrixMetric(variant.categories['4']?.meanScore ?? null),
+    formatLocomoMatrixMetric(variant.categories['5']?.meanScore ?? null),
+  ]);
+  const widths = header.map((title, index) =>
+    Math.max(
+      title.length,
+      ...rows.map((row) => String(row[index] || '').length),
+    ),
+  );
+  return [
+    header.map((entry, index) => entry.padEnd(widths[index])).join('  '),
+    widths.map((width) => '-'.repeat(width)).join('  '),
+    ...rows.map((row) =>
+      row.map((entry, index) => String(entry).padEnd(widths[index])).join('  '),
+    ),
+  ];
+}
+
+function formatLocomoMatrixMetric(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) {
+    return '-';
+  }
+  return value.toFixed(4);
+}
+
 function printSummaryTable(summary: LocomoRunSummary): void {
   console.log('');
+  if (
+    summary.matrix &&
+    summary.mode === 'retrieval' &&
+    summary.variants.length
+  ) {
+    for (const line of buildLocomoVariantComparisonTable(summary.variants)) {
+      console.log(line);
+    }
+    console.log('');
+    if (summary.bestVariantLabel) {
+      console.log(`Best variant: ${summary.bestVariantLabel}`);
+    }
+    if (summary.overallScore != null) {
+      console.log(`Best hit rate: ${summary.overallScore.toFixed(3)}`);
+    }
+    if (summary.contextF1 != null) {
+      console.log(`Best context F1: ${summary.contextF1.toFixed(3)}`);
+    }
+    console.log(`Variants: ${summary.variantCount ?? summary.variants.length}`);
+    console.log(`Questions per variant: ${summary.questionCount}`);
+    console.log(`Predictions JSON: ${summary.predictionsPath}`);
+    console.log(`Result JSON: ${summary.resultPath}`);
+    return;
+  }
   console.log(
     summary.mode === 'retrieval'
       ? 'Category  Hit     F1      Questions'
@@ -1610,11 +3123,35 @@ function printSummaryTable(summary: LocomoRunSummary): void {
     console.log(formatLocomoCategoryLine(category, aggregate, summary.mode));
   }
   console.log('');
+  const headlineScore = summary.overallScore ?? 0;
   console.log(
     summary.mode === 'retrieval'
-      ? `Hit rate: ${summary.overallScore.toFixed(3)}`
-      : `Overall score: ${summary.overallScore.toFixed(3)}`,
+      ? `Hit rate: ${headlineScore.toFixed(3)}`
+      : `Overall score: ${headlineScore.toFixed(3)}`,
   );
+  if (summary.mode === 'retrieval' && summary.retrievalPolicy) {
+    console.log(`Recall policy: ${summary.retrievalPolicy}`);
+  }
+  if (summary.mode === 'retrieval' && summary.retrievalQueryMode) {
+    console.log(`Retrieval query: ${summary.retrievalQueryMode}`);
+  }
+  if (summary.mode === 'retrieval' && summary.retrievalBackend) {
+    console.log(`Retrieval backend: ${summary.retrievalBackend}`);
+  }
+  if (summary.mode === 'retrieval' && summary.retrievalRerank) {
+    console.log(`Retrieval rerank: ${summary.retrievalRerank}`);
+  }
+  if (summary.mode === 'retrieval' && summary.retrievalTokenizer) {
+    console.log(`Retrieval tokenizer: ${summary.retrievalTokenizer}`);
+  }
+  if (summary.mode === 'retrieval' && summary.retrievalEmbeddingProvider) {
+    console.log(`Retrieval embedding: ${summary.retrievalEmbeddingProvider}`);
+  }
+  if (summary.mode === 'retrieval' && summary.retrievalEmbeddingModel) {
+    console.log(
+      `Retrieval embedding model: ${summary.retrievalEmbeddingModel}`,
+    );
+  }
   if (summary.mode === 'retrieval' && summary.contextF1 != null) {
     console.log(`Context F1: ${summary.contextF1.toFixed(3)}`);
   }

--- a/src/evals/locomo-official-scoring.ts
+++ b/src/evals/locomo-official-scoring.ts
@@ -1,0 +1,111 @@
+import { stemmer } from 'stemmer';
+
+const PUNCTUATION_REGEX = /[!"#$%&'()*+./:;<=>?@[\\\]^_`{|}~-]/g;
+const ARTICLES_REGEX = /\b(a|an|the|and)\b/g;
+
+// Direct port of LoCoMo QA scoring semantics from task_eval/evaluation.py.
+export function scoreOfficialLocomoAnswer(params: {
+  category: number;
+  prediction: string;
+  answer: string;
+}): number {
+  const { category, prediction, answer } = params;
+  if (category === 1) {
+    return roundMetric(multiAnswerF1(prediction, answer));
+  }
+  if (category === 2 || category === 4) {
+    return roundMetric(singleAnswerF1(prediction, answer));
+  }
+  if (category === 3) {
+    return roundMetric(singleAnswerF1(prediction, answer.split(';')[0] || ''));
+  }
+  if (category === 5) {
+    const normalized = prediction.toLowerCase();
+    return normalized.includes('no information available') ||
+      normalized.includes('not mentioned')
+      ? 1
+      : 0;
+  }
+  throw new Error(`Unsupported LOCOMO question category: ${category}`);
+}
+
+function normalizeAnswer(value: string): string {
+  return String(value || '')
+    .replace(/,/g, '')
+    .toLowerCase()
+    .replace(PUNCTUATION_REGEX, '')
+    .replace(ARTICLES_REGEX, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .join(' ');
+}
+
+function stemTokens(value: string): string[] {
+  return normalizeAnswer(value)
+    .split(' ')
+    .filter(Boolean)
+    .map((token) => stemmer(token));
+}
+
+function singleAnswerF1(prediction: string, groundTruth: string): number {
+  const predictionTokens = stemTokens(prediction);
+  const groundTruthTokens = stemTokens(groundTruth);
+  if (predictionTokens.length === 0 || groundTruthTokens.length === 0) {
+    return 0;
+  }
+
+  const groundTruthCounts = new Map<string, number>();
+  for (const token of groundTruthTokens) {
+    groundTruthCounts.set(token, (groundTruthCounts.get(token) || 0) + 1);
+  }
+
+  let commonCount = 0;
+  for (const token of predictionTokens) {
+    const remaining = groundTruthCounts.get(token) || 0;
+    if (remaining <= 0) continue;
+    commonCount += 1;
+    groundTruthCounts.set(token, remaining - 1);
+  }
+
+  if (commonCount === 0) return 0;
+  const precision = commonCount / predictionTokens.length;
+  const recall = commonCount / groundTruthTokens.length;
+  return (2 * precision * recall) / (precision + recall);
+}
+
+function multiAnswerF1(prediction: string, groundTruth: string): number {
+  const predictions = splitAnswers(prediction);
+  const groundTruths = splitAnswers(groundTruth);
+  if (predictions.length === 0 || groundTruths.length === 0) {
+    return 0;
+  }
+
+  let total = 0;
+  for (const truth of groundTruths) {
+    let best = 0;
+    for (const candidate of predictions) {
+      best = Math.max(best, singleAnswerF1(candidate, truth));
+    }
+    total += best;
+  }
+  return total / groundTruths.length;
+}
+
+function splitAnswers(value: string): string[] {
+  return String(value || '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function roundMetric(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.round(value * 1000) / 1000;
+}
+
+export const testOnlyLocomoOfficialScoring = {
+  normalizeAnswer,
+  singleAnswerF1,
+  multiAnswerF1,
+};

--- a/src/evals/locomo-types.ts
+++ b/src/evals/locomo-types.ts
@@ -1,4 +1,28 @@
+import type { MemoryEmbeddingProviderKind } from '../memory/embeddings.js';
+import type {
+  MemoryQueryMode,
+  MemoryRecallBackend,
+  MemoryRecallRerank,
+  MemoryRecallTokenizer,
+} from '../memory/semantic-recall.js';
+
 export type LocomoAgentMode = 'conversation-fresh' | 'current-agent';
+export type LocomoRetrievalPolicy = 'prompt-capped' | 'budget-only';
+export type LocomoRetrievalSweep =
+  | 'all'
+  | 'backend'
+  | 'rerank'
+  | 'tokenizer'
+  | 'embedding';
+export type LocomoRetrievalQueryMode = MemoryQueryMode;
+export type LocomoRetrievalBackend = MemoryRecallBackend;
+export type LocomoRetrievalRerank = MemoryRecallRerank;
+export type LocomoRetrievalTokenizer = MemoryRecallTokenizer;
+export type LocomoRetrievalEmbeddingProvider = MemoryEmbeddingProviderKind;
+export type LocomoProgressPhase =
+  | 'warming-embedding'
+  | 'ingesting'
+  | 'evaluating';
 export const LOCOMO_DATASET_FILENAME = 'locomo10.json';
 export const LOCOMO_SETUP_MARKER = '.hybridclaw-setup-ok';
 
@@ -13,4 +37,33 @@ export interface LocomoTokenUsage {
   completionTokens: number;
   totalTokens: number;
   responsesWithUsage: number;
+}
+
+export interface LocomoRetrievalVariantSummary {
+  id: string;
+  label: string;
+  retrievalPolicy: LocomoRetrievalPolicy;
+  retrievalQueryMode: LocomoRetrievalQueryMode;
+  retrievalBackend: LocomoRetrievalBackend;
+  retrievalRerank: LocomoRetrievalRerank;
+  retrievalTokenizer: LocomoRetrievalTokenizer;
+  retrievalEmbeddingProvider: LocomoRetrievalEmbeddingProvider;
+  retrievalEmbeddingModel: string | null;
+  sampleCount: number;
+  questionCount: number;
+  overallScore: number;
+  contextF1: number | null;
+  categories: Record<string, LocomoCategoryAggregate>;
+}
+
+export interface LocomoRetrievalVariantProgress
+  extends LocomoRetrievalVariantSummary {
+  currentPhase: LocomoProgressPhase | null;
+  completedSampleCount: number;
+  completedQuestionCount: number;
+  currentSampleId: string | null;
+  currentSampleEmbeddedTurnCount: number | null;
+  currentSampleTurnCount: number | null;
+  currentSampleQuestionCount: number | null;
+  currentSampleQuestionTotal: number | null;
 }

--- a/src/evals/locomo-types.ts
+++ b/src/evals/locomo-types.ts
@@ -1,0 +1,16 @@
+export type LocomoAgentMode = 'conversation-fresh' | 'current-agent';
+export const LOCOMO_DATASET_FILENAME = 'locomo10.json';
+export const LOCOMO_SETUP_MARKER = '.hybridclaw-setup-ok';
+
+export interface LocomoCategoryAggregate {
+  meanScore: number;
+  questionCount: number;
+  contextF1: number | null;
+}
+
+export interface LocomoTokenUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  responsesWithUsage: number;
+}

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -4,6 +4,10 @@ import os from 'node:os';
 import path from 'node:path';
 import { CronExpressionParser } from 'cron-parser';
 import { buildMcpServerNamespaces } from '../../container/shared/mcp-tool-namespaces.js';
+import {
+  currentDateStampInTimezone,
+  extractUserTimezone,
+} from '../../container/shared/workspace-time.js';
 import { runAgent } from '../agent/agent.js';
 import { buildConversationContext } from '../agent/conversation.js';
 import {
@@ -114,6 +118,7 @@ import {
   getStructuredAuditForSession,
   getTasksForSession,
   getUsageTotals,
+  listSemanticMemoriesForSession,
   listStructuredAuditEntries,
   listUsageByAgent,
   listUsageByModel,
@@ -239,6 +244,7 @@ import type { ChatMessage } from '../types/api.js';
 import type { StructuredAuditEntry } from '../types/audit.js';
 import type { MediaContextItem } from '../types/container.js';
 import type { ArtifactMetadata, ToolExecution } from '../types/execution.js';
+import type { MemoryCitation, SemanticMemoryEntry } from '../types/memory.js';
 import type { McpServerConfig } from '../types/models.js';
 import type {
   ConversationHistoryPage,
@@ -1543,6 +1549,278 @@ function resolveSessionAgentId(session: { agent_id: string }): string {
   const sessionAgent = session.agent_id?.trim();
   if (sessionAgent) return sessionAgent;
   return resolveDefaultAgentId(getRuntimeConfig());
+}
+
+const MEMORY_INSPECT_FILE_PREVIEW_MAX_CHARS = 280;
+const MEMORY_INSPECT_MESSAGE_PREVIEW_MAX_CHARS = 140;
+const MEMORY_INSPECT_SEMANTIC_PREVIEW_MAX_CHARS = 180;
+const MEMORY_INSPECT_RECENT_MESSAGE_LIMIT = 4;
+const MEMORY_INSPECT_RECENT_SEMANTIC_LIMIT = 3;
+const MEMORY_INSPECT_CANONICAL_WINDOW = 12;
+const MEMORY_INSPECT_CANONICAL_PREVIEW_LIMIT = 3;
+
+function formatInspectionTimestamp(raw: string | null | undefined): string {
+  const value = String(raw || '').trim();
+  if (!value) return 'none';
+  return `${formatDisplayTimestamp(value)} (${formatRelativeTime(value)})`;
+}
+
+function readInspectionFilePreview(filePath: string): {
+  exists: boolean;
+  chars: number;
+  preview: string | null;
+} {
+  try {
+    if (!fs.existsSync(filePath)) {
+      return {
+        exists: false,
+        chars: 0,
+        preview: null,
+      };
+    }
+    const content = fs.readFileSync(filePath, 'utf-8').trim();
+    return {
+      exists: true,
+      chars: content.length,
+      preview: content
+        ? abbreviateForUser(content, MEMORY_INSPECT_FILE_PREVIEW_MAX_CHARS)
+        : '(empty)',
+    };
+  } catch {
+    return {
+      exists: false,
+      chars: 0,
+      preview: null,
+    };
+  }
+}
+
+function formatMemoryInspectMessage(message: {
+  role: string;
+  content: string;
+}): string {
+  return `- ${String(message.role || 'unknown')
+    .trim()
+    .toLowerCase()}: ${abbreviateForUser(
+    String(message.content || ''),
+    MEMORY_INSPECT_MESSAGE_PREVIEW_MAX_CHARS,
+  )}`;
+}
+
+function formatMemoryInspectSemanticEntry(entry: {
+  id: number;
+  source: string;
+  scope: string;
+  confidence: number;
+  content: string;
+}): string {
+  return `- [${entry.id}] ${entry.source}/${entry.scope} ${Math.round(
+    Math.max(0, Math.min(1, entry.confidence)) * 100,
+  )}%: ${abbreviateForUser(
+    entry.content,
+    MEMORY_INSPECT_SEMANTIC_PREVIEW_MAX_CHARS,
+  )}`;
+}
+
+function formatMemoryInspectCanonicalEntry(entry: {
+  role: string;
+  content: string;
+  session_id: string;
+}): string {
+  return `- ${String(entry.role || 'unknown')
+    .trim()
+    .toLowerCase()} [${entry.session_id}]: ${abbreviateForUser(
+    entry.content,
+    MEMORY_INSPECT_MESSAGE_PREVIEW_MAX_CHARS,
+  )}`;
+}
+
+function resolveWorkspaceTodayMemoryNote(workspacePath: string): {
+  timezone: string | null;
+  fileName: string;
+  filePath: string;
+} {
+  const userPath = path.join(workspacePath, 'USER.md');
+  let timezone: string | null = null;
+  try {
+    if (fs.existsSync(userPath)) {
+      timezone =
+        extractUserTimezone(fs.readFileSync(userPath, 'utf-8')) || null;
+    }
+  } catch {
+    timezone = null;
+  }
+  const dateStamp = currentDateStampInTimezone(timezone || undefined);
+  const fileName = `memory/${dateStamp}.md`;
+  return {
+    timezone,
+    fileName,
+    filePath: path.join(workspacePath, fileName),
+  };
+}
+
+function buildMemoryInspectReport(params: { session: Session }): string {
+  const targetSession = params.session;
+  const agentId = resolveSessionAgentId(targetSession);
+  const workspacePath = path.resolve(agentWorkspaceDir(agentId));
+  const memoryFilePath = path.join(workspacePath, 'MEMORY.md');
+  const memoryFile = readInspectionFilePreview(memoryFilePath);
+  const todayNote = resolveWorkspaceTodayMemoryNote(workspacePath);
+  const todayNotePreview = readInspectionFilePreview(todayNote.filePath);
+  const transcriptPath = path.join(
+    workspacePath,
+    '.session-transcripts',
+    `${targetSession.id}.jsonl`,
+  );
+  const recentMessages = memoryService.getRecentMessages(
+    targetSession.id,
+    MEMORY_INSPECT_RECENT_MESSAGE_LIMIT,
+  );
+  const summaryText = String(targetSession.session_summary || '').trim();
+  const recentSemantic = listSemanticMemoriesForSession(
+    targetSession.id,
+    MEMORY_INSPECT_RECENT_SEMANTIC_LIMIT,
+  );
+  const canonicalScope = resolveCanonicalContextScope(targetSession);
+  const canonicalContext = canonicalScope
+    ? memoryService.getCanonicalContext({
+        agentId,
+        userId: canonicalScope,
+        windowSize: MEMORY_INSPECT_CANONICAL_WINDOW,
+        excludeSessionId: targetSession.id,
+      })
+    : { summary: null, recent_messages: [] };
+  const canonicalPreview = canonicalContext.recent_messages.slice(
+    -MEMORY_INSPECT_CANONICAL_PREVIEW_LIMIT,
+  );
+
+  return [
+    `Session: ${targetSession.id}`,
+    `Agent: ${agentId}`,
+    `Workspace: ${workspacePath}`,
+    `Session key: ${targetSession.session_key || '(none)'}`,
+    `Main session key: ${targetSession.main_session_key || '(none)'}`,
+    '',
+    '1. Workspace memory file (`MEMORY.md`)',
+    `Present: ${memoryFile.exists ? 'yes' : 'no'}`,
+    `Path: ${memoryFilePath}`,
+    `Chars: ${memoryFile.exists ? formatCompactNumber(memoryFile.chars) : '0'}`,
+    `Preview: ${memoryFile.preview || '(missing)'}`,
+    '',
+    `2. Workspace daily note for today (\`${todayNote.fileName}\`)`,
+    `Present: ${todayNotePreview.exists ? 'yes' : 'no'}`,
+    `Timezone: ${todayNote.timezone || 'local default'}`,
+    `Path: ${todayNote.filePath}`,
+    `Chars: ${todayNotePreview.exists ? formatCompactNumber(todayNotePreview.chars) : '0'}`,
+    `Preview: ${todayNotePreview.preview || '(missing)'}`,
+    '',
+    '3. Raw session history',
+    `Active messages: ${formatCompactNumber(targetSession.message_count)}`,
+    `Transcript mirror: ${fs.existsSync(transcriptPath) ? transcriptPath : '(missing)'}`,
+    `Recent tail (${recentMessages.length}):`,
+    ...(recentMessages.length > 0
+      ? recentMessages.map(formatMemoryInspectMessage)
+      : ['- (none)']),
+    '',
+    '4. Compacted session summary',
+    `Stored: ${summaryText ? 'yes' : 'no'}`,
+    `Compactions: ${formatCompactNumber(targetSession.compaction_count)}`,
+    `Summary updated: ${formatInspectionTimestamp(targetSession.summary_updated_at)}`,
+    `Last memory flush: ${formatInspectionTimestamp(targetSession.memory_flush_at)}`,
+    `Preview: ${
+      summaryText
+        ? abbreviateForUser(summaryText, MEMORY_INSPECT_FILE_PREVIEW_MAX_CHARS)
+        : '(none)'
+    }`,
+    '',
+    '5. Semantic memory store',
+    'Prompt behavior: query-matched only; stored rows are not injected wholesale.',
+    `Recent stored entries (${recentSemantic.length} shown):`,
+    ...(recentSemantic.length > 0
+      ? recentSemantic.map(formatMemoryInspectSemanticEntry)
+      : ['- (none)']),
+    '',
+    '6. Canonical cross-channel memory',
+    `Scope: ${canonicalScope || '(none)'}`,
+    `Prompt-time summary present: ${canonicalContext.summary ? 'yes' : 'no'}`,
+    `Summary preview: ${
+      canonicalContext.summary
+        ? abbreviateForUser(
+            canonicalContext.summary,
+            MEMORY_INSPECT_FILE_PREVIEW_MAX_CHARS,
+          )
+        : '(none)'
+    }`,
+    `Prompt-time recent messages from other sessions: ${formatCompactNumber(
+      canonicalContext.recent_messages.length,
+    )}`,
+    ...(canonicalPreview.length > 0
+      ? canonicalPreview.map(formatMemoryInspectCanonicalEntry)
+      : ['- (none)']),
+  ].join('\n');
+}
+
+function formatMemoryQueryCitation(
+  citation: MemoryCitation,
+  memory: SemanticMemoryEntry | undefined,
+): string {
+  return `- ${citation.ref} -> memory ${citation.memoryId} (${Math.round(
+    Math.max(0, Math.min(1, citation.confidence)) * 100,
+  )}%): ${abbreviateForUser(
+    memory?.content || citation.content,
+    MEMORY_INSPECT_SEMANTIC_PREVIEW_MAX_CHARS,
+  )}`;
+}
+
+function buildMemoryQueryReport(params: {
+  session: Session;
+  query: string;
+}): string {
+  const targetSession = params.session;
+  const query = params.query.trim();
+  const promptContext = memoryService.buildPromptMemoryContext({
+    session: targetSession,
+    query,
+    touchSemanticRecall: false,
+  });
+  const summaryText = String(targetSession.session_summary || '').trim();
+  const summaryIncluded = summaryText
+    ? Boolean(promptContext.promptSummary?.includes(summaryText))
+    : false;
+  const promptSummary =
+    promptContext.promptSummary || '(nothing would be attached)';
+
+  return [
+    `Session: ${targetSession.id}`,
+    `Query: ${query}`,
+    'Mode: read-only diagnostic (matches prompt assembly without updating semantic recall access metadata)',
+    `Stored session summary: ${summaryText ? 'yes' : 'no'}`,
+    `Summary included: ${summaryText ? (summaryIncluded ? 'yes' : 'no') : 'n/a'}`,
+    `Summary confidence: ${
+      promptContext.summaryConfidence == null
+        ? 'n/a'
+        : `${Math.round(Math.max(0, Math.min(1, promptContext.summaryConfidence)) * 100)}%`
+    }`,
+    `Semantic matches attached: ${formatCompactNumber(
+      promptContext.semanticMemories.length,
+    )}`,
+    `Semantic prompt hard cap: ${formatCompactNumber(
+      getRuntimeConfig().memory.semanticPromptHardCap,
+    )}`,
+    '',
+    'Matched semantic memories:',
+    ...(promptContext.citationIndex.length > 0
+      ? promptContext.citationIndex.map((citation, index) =>
+          formatMemoryQueryCitation(
+            citation,
+            promptContext.semanticMemories[index],
+          ),
+        )
+      : ['- (none)']),
+    '',
+    'Exact attached block:',
+    promptSummary,
+  ].join('\n');
 }
 
 type TraceExportResult = Awaited<
@@ -7014,6 +7292,62 @@ export async function handleGatewayCommand(
             err instanceof Error ? err.message : String(err),
           );
         }
+      }
+
+      case 'memory': {
+        if (!isLocalSession(req)) {
+          return badCommand(
+            'Memory Commands Restricted',
+            '`memory inspect` and `memory query` expose workspace and session memory details and are only available from local TUI/web sessions.',
+          );
+        }
+
+        const rawSub = (req.args[1] || '').trim();
+        const sub = rawSub.toLowerCase();
+        if (sub && sub !== 'inspect' && sub !== 'query') {
+          return badCommand(
+            'Usage',
+            'Usage: `memory inspect [sessionId]` | `memory query <query>`',
+          );
+        }
+
+        if (sub === 'query') {
+          const query = req.args.slice(2).join(' ').trim();
+          if (!query) {
+            return badCommand('Usage', 'Usage: `memory query <query>`');
+          }
+          return infoCommand(
+            'Memory Query',
+            buildMemoryQueryReport({
+              session,
+              query,
+            }),
+          );
+        }
+
+        const targetSessionArg =
+          sub === 'inspect' ? req.args[2] : req.args[1] || session.id || '';
+        const targetSessionId =
+          String(targetSessionArg || '').trim() || session.id;
+        if (!targetSessionId) {
+          return badCommand(
+            'Usage',
+            'Usage: `memory inspect [sessionId]` | `memory query <query>`',
+          );
+        }
+
+        const targetSession = memoryService.getSessionById(targetSessionId);
+        if (!targetSession) {
+          return badCommand(
+            'Not Found',
+            `Session \`${targetSessionId}\` was not found.`,
+          );
+        }
+
+        return infoCommand(
+          'Memory Inspection',
+          buildMemoryInspectReport({ session: targetSession }),
+        );
       }
 
       case 'status': {

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -795,6 +795,7 @@ export async function runContainer(
     scheduledTasks: scheduledTasks?.map(
       (task): ScheduledTaskInput => ({
         id: task.id,
+        channelId: task.channel_id,
         cronExpr: task.cron_expr,
         runAt: task.run_at,
         everyMs: task.every_ms,

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -699,6 +699,7 @@ export async function runHostProcess(
     scheduledTasks: scheduledTasks?.map(
       (task): ScheduledTaskInput => ({
         id: task.id,
+        channelId: task.channel_id,
         cronExpr: task.cron_expr,
         runAt: task.run_at,
         everyMs: task.every_ms,

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -81,6 +81,18 @@ import type {
   UsageWindow,
 } from '../types/usage.js';
 import { isApprovalHistoryMessage } from '../utils/approval-text.js';
+import {
+  buildMemoryFtsDocument,
+  buildMemoryFtsMatchQuery,
+  getMemoryFtsTokenizerSpec,
+  type MemoryRecallBackend,
+  type MemoryRecallRerank,
+  type MemoryRecallTokenizer,
+  normalizeMemoryRecallBackend,
+  normalizeMemoryRecallRerank,
+  normalizeMemoryRecallTokenizer,
+  tokenizeMemoryRecallQuery,
+} from './semantic-recall.js';
 
 let db: Database.Database;
 let databaseInitialized = false;
@@ -4584,19 +4596,11 @@ function parseTimestamp(raw: string): number {
   return Number.isNaN(parsed) ? 0 : parsed;
 }
 
-function parseQueryTerms(query: string): string[] {
-  const lower = query
-    .toLowerCase()
-    .split(/[^a-z0-9_-]+/g)
-    .map((term) => term.trim())
-    .filter((term) => term.length >= 2);
-  if (lower.length === 0) return [];
-  const unique = new Set<string>();
-  for (const term of lower) {
-    unique.add(term);
-    if (unique.size >= 8) break;
-  }
-  return [...unique];
+function parseQueryTerms(
+  query: string,
+  tokenizer: MemoryRecallTokenizer,
+): string[] {
+  return tokenizeMemoryRecallQuery(query, 8, tokenizer);
 }
 
 const MAX_EMBEDDING_DIMENSIONS = 2048;
@@ -4812,6 +4816,7 @@ function recallSemanticMemoriesByLike(params: {
   limit: number;
   minConfidence: number;
   filter?: SemanticRecallFilter;
+  touch?: boolean;
 }): SemanticMemoryEntry[] {
   if (params.queryTerms.length === 0) return [];
   const candidateLimit = Math.max(params.limit * 8, 50);
@@ -4871,7 +4876,9 @@ function recallSemanticMemoriesByLike(params: {
     .slice(0, params.limit)
     .map((entry) => entry.row);
 
-  touchSemanticMemoryRows(ranked);
+  if (params.touch !== false) {
+    touchSemanticMemoryRows(ranked);
+  }
   return ranked;
 }
 
@@ -4881,6 +4888,7 @@ function recallSemanticMemoriesByVector(params: {
   limit: number;
   minConfidence: number;
   filter?: SemanticRecallFilter;
+  touch?: boolean;
 }): SemanticMemoryEntry[] {
   const candidateLimit = Math.max(params.limit * 10, 100);
   const whereClauses: string[] = [
@@ -4929,7 +4937,241 @@ function recallSemanticMemoriesByVector(params: {
     .slice(0, params.limit)
     .map((entry) => entry.row);
 
-  touchSemanticMemoryRows(ranked);
+  if (params.touch !== false) {
+    touchSemanticMemoryRows(ranked);
+  }
+  return ranked;
+}
+
+function rankSemanticMemoriesWithFts(params: {
+  rows: SemanticMemoryEntry[];
+  query: string;
+  limit: number;
+  tokenizer: MemoryRecallTokenizer;
+  rankMode: 'source' | 'bm25';
+}): SemanticMemoryEntry[] {
+  if (params.rows.length === 0) return [];
+  const matchQuery = buildMemoryFtsMatchQuery(
+    params.query,
+    12,
+    params.tokenizer,
+  );
+  if (!matchQuery) {
+    return [];
+  }
+
+  const ftsDb = new Database(':memory:');
+  try {
+    const tokenizerSpec = getMemoryFtsTokenizerSpec(params.tokenizer);
+    ftsDb.exec(
+      `CREATE VIRTUAL TABLE semantic_recall USING fts5(memory_id UNINDEXED, content, tokenize='${tokenizerSpec}')`,
+    );
+  } catch (error) {
+    ftsDb.close();
+    throw new Error(
+      `Full-text semantic recall requires SQLite FTS5 support: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  try {
+    const rowsById = new Map<number, SemanticMemoryEntry>();
+    const insert = ftsDb.prepare(
+      'INSERT INTO semantic_recall (memory_id, content) VALUES (?, ?)',
+    );
+    const transaction = ftsDb.transaction(() => {
+      for (const row of params.rows) {
+        rowsById.set(row.id, row);
+        insert.run(
+          row.id,
+          buildMemoryFtsDocument(row.content, params.tokenizer),
+        );
+      }
+    });
+    transaction();
+
+    if (params.rankMode === 'source') {
+      const matches = ftsDb
+        .prepare(
+          `SELECT memory_id
+           FROM semantic_recall
+           WHERE semantic_recall MATCH ?`,
+        )
+        .all(matchQuery) as Array<{
+        memory_id: number;
+      }>;
+      const matchedIds = new Set<number>(
+        matches.map((match) => Number(match.memory_id)),
+      );
+      const ordered: SemanticMemoryEntry[] = [];
+      for (const row of params.rows) {
+        if (!matchedIds.has(row.id)) {
+          continue;
+        }
+        ordered.push(row);
+        if (ordered.length >= Math.max(1, params.limit)) {
+          break;
+        }
+      }
+      return ordered;
+    }
+
+    const matches = ftsDb
+      .prepare(
+        `SELECT memory_id
+         FROM semantic_recall
+         WHERE semantic_recall MATCH ?
+         ORDER BY bm25(semantic_recall)
+         LIMIT ?`,
+      )
+      .all(matchQuery, Math.max(1, params.limit)) as Array<{
+      memory_id: number;
+    }>;
+
+    const ordered: SemanticMemoryEntry[] = [];
+    for (const match of matches) {
+      const row = rowsById.get(Number(match.memory_id));
+      if (row) {
+        ordered.push(row);
+      }
+    }
+    return ordered;
+  } finally {
+    ftsDb.close();
+  }
+}
+
+function rerankSemanticMemoriesWithFts(params: {
+  rows: SemanticMemoryEntry[];
+  query: string;
+  tokenizer: MemoryRecallTokenizer;
+}): SemanticMemoryEntry[] {
+  const reranked = rankSemanticMemoriesWithFts({
+    rows: params.rows,
+    query: params.query,
+    limit: params.rows.length,
+    tokenizer: params.tokenizer,
+    rankMode: 'bm25',
+  });
+  if (reranked.length === 0) {
+    return params.rows;
+  }
+
+  const seen = new Set<number>();
+  const ordered: SemanticMemoryEntry[] = [];
+  for (const row of reranked) {
+    seen.add(row.id);
+    ordered.push(row);
+  }
+  for (const row of params.rows) {
+    if (seen.has(row.id)) {
+      continue;
+    }
+    ordered.push(row);
+  }
+  return ordered;
+}
+
+function fuseHybridSemanticMemories(params: {
+  cosineRows: SemanticMemoryEntry[];
+  fullTextRows: SemanticMemoryEntry[];
+}): SemanticMemoryEntry[] {
+  if (params.cosineRows.length === 0) {
+    return params.fullTextRows;
+  }
+  if (params.fullTextRows.length === 0) {
+    return params.cosineRows;
+  }
+
+  const rowsById = new Map<number, SemanticMemoryEntry>();
+  const scoreById = new Map<number, number>();
+  const cosineRankById = new Map<number, number>();
+  const fullTextRankById = new Map<number, number>();
+
+  for (let index = 0; index < params.cosineRows.length; index += 1) {
+    const row = params.cosineRows[index];
+    rowsById.set(row.id, row);
+    cosineRankById.set(row.id, index + 1);
+    scoreById.set(row.id, (scoreById.get(row.id) || 0) + 1 / (60 + index + 1));
+  }
+
+  for (let index = 0; index < params.fullTextRows.length; index += 1) {
+    const row = params.fullTextRows[index];
+    rowsById.set(row.id, row);
+    fullTextRankById.set(row.id, index + 1);
+    scoreById.set(row.id, (scoreById.get(row.id) || 0) + 1 / (60 + index + 1));
+  }
+
+  return [...rowsById.values()].sort((left, right) => {
+    const leftScore = scoreById.get(left.id) || 0;
+    const rightScore = scoreById.get(right.id) || 0;
+    if (rightScore !== leftScore) return rightScore - leftScore;
+
+    const leftFullTextRank =
+      fullTextRankById.get(left.id) || Number.MAX_SAFE_INTEGER;
+    const rightFullTextRank =
+      fullTextRankById.get(right.id) || Number.MAX_SAFE_INTEGER;
+    if (leftFullTextRank !== rightFullTextRank) {
+      return leftFullTextRank - rightFullTextRank;
+    }
+
+    const leftCosineRank =
+      cosineRankById.get(left.id) || Number.MAX_SAFE_INTEGER;
+    const rightCosineRank =
+      cosineRankById.get(right.id) || Number.MAX_SAFE_INTEGER;
+    if (leftCosineRank !== rightCosineRank) {
+      return leftCosineRank - rightCosineRank;
+    }
+
+    if (right.confidence !== left.confidence) {
+      return right.confidence - left.confidence;
+    }
+    return parseTimestamp(right.accessed_at) - parseTimestamp(left.accessed_at);
+  });
+}
+
+function recallSemanticMemoriesByFts(params: {
+  sessionId: string;
+  normalizedQuery: string;
+  limit: number;
+  minConfidence: number;
+  tokenizer: MemoryRecallTokenizer;
+  rankMode: 'source' | 'bm25';
+  filter?: SemanticRecallFilter;
+  touch?: boolean;
+}): SemanticMemoryEntry[] {
+  const whereClauses: string[] = [
+    'session_id = ?',
+    'deleted = 0',
+    'confidence >= ?',
+  ];
+  const args: unknown[] = [params.sessionId, params.minConfidence];
+  applySemanticRecallFilterClauses({
+    whereClauses,
+    args,
+    filter: params.filter,
+  });
+  const rows = queryAll<RawSemanticMemoryRow>(
+    db,
+    `SELECT *
+     FROM semantic_memories
+     WHERE ${whereClauses.join('\n         AND ')}
+     ORDER BY accessed_at DESC, confidence DESC`,
+    ...args,
+  ).map(mapSemanticMemoryRow);
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const ranked = rankSemanticMemoriesWithFts({
+    rows,
+    query: params.normalizedQuery,
+    limit: params.limit,
+    tokenizer: params.tokenizer,
+    rankMode: params.rankMode,
+  });
+  if (params.touch !== false) {
+    touchSemanticMemoryRows(ranked);
+  }
   return ranked;
 }
 
@@ -4938,6 +5180,7 @@ function recallSemanticMemoriesByRecent(params: {
   limit: number;
   minConfidence: number;
   filter?: SemanticRecallFilter;
+  touch?: boolean;
 }): SemanticMemoryEntry[] {
   const whereClauses: string[] = [
     'session_id = ?',
@@ -4961,8 +5204,30 @@ function recallSemanticMemoriesByRecent(params: {
     ...args,
   );
   const mapped = rows.map(mapSemanticMemoryRow);
-  touchSemanticMemoryRows(mapped);
+  if (params.touch !== false) {
+    touchSemanticMemoryRows(mapped);
+  }
   return mapped;
+}
+
+export function listSemanticMemoriesForSession(
+  sessionId: string,
+  limit = 5,
+): SemanticMemoryEntry[] {
+  const resolvedSessionId = resolveSessionIdCompat(sessionId);
+  const boundedLimit = Math.max(1, Math.min(Math.floor(limit || 5), 50));
+  const rows = queryAll<RawSemanticMemoryRow>(
+    db,
+    `SELECT *
+     FROM semantic_memories
+     WHERE session_id = ?
+       AND deleted = 0
+     ORDER BY accessed_at DESC, confidence DESC
+     LIMIT ?`,
+    resolvedSessionId,
+    boundedLimit,
+  );
+  return rows.map(mapSemanticMemoryRow);
 }
 
 export function storeSemanticMemory(params: {
@@ -5029,22 +5294,44 @@ export function recallSemanticMemories(params: {
   sessionId: string;
   query: string;
   limit?: number;
+  limitHardCap?: number | null;
   minConfidence?: number;
   queryEmbedding?: number[] | null;
+  backend?: MemoryRecallBackend;
+  rerank?: MemoryRecallRerank;
+  tokenizer?: MemoryRecallTokenizer;
   filter?: SemanticRecallFilter;
+  touch?: boolean;
 }): SemanticMemoryEntry[] {
   const resolvedSessionId = resolveSessionIdCompat(params.sessionId);
   const normalizedQuery = params.query.trim().toLowerCase();
-  const queryTerms = parseQueryTerms(normalizedQuery);
+  const tokenizer = normalizeMemoryRecallTokenizer(
+    params.tokenizer,
+    'unicode61',
+  );
+  const queryTerms = parseQueryTerms(normalizedQuery, tokenizer);
   const queryEmbedding = normalizeEmbeddingInput(params.queryEmbedding);
 
-  const limit = Math.max(1, Math.min(Math.floor(params.limit || 5), 50));
+  const requestedLimit = Math.max(1, Math.floor(params.limit || 5));
+  const limitHardCap =
+    typeof params.limitHardCap === 'number' &&
+    Number.isFinite(params.limitHardCap)
+      ? Math.max(1, Math.floor(params.limitHardCap))
+      : params.limitHardCap === null
+        ? null
+        : 50;
+  const limit =
+    limitHardCap == null
+      ? requestedLimit
+      : Math.min(requestedLimit, limitHardCap);
   const rawMinConfidence =
     typeof params.minConfidence === 'number' &&
     Number.isFinite(params.minConfidence)
       ? params.minConfidence
       : 0.2;
   const minConfidence = Math.max(0, Math.min(1, rawMinConfidence));
+  const backend = normalizeMemoryRecallBackend(params.backend, 'cosine');
+  const rerank = normalizeMemoryRecallRerank(params.rerank, 'none');
 
   if (!queryEmbedding && queryTerms.length === 0) {
     return recallSemanticMemoriesByRecent({
@@ -5052,27 +5339,108 @@ export function recallSemanticMemories(params: {
       limit,
       minConfidence,
       filter: params.filter,
+      touch: params.touch,
     });
   }
 
-  if (queryEmbedding) {
-    return recallSemanticMemoriesByVector({
+  if (backend === 'full-text') {
+    const fullTextCandidateLimit =
+      rerank === 'bm25' ? Math.max(limit * 10, 100) : limit;
+    const fullTextCandidates = recallSemanticMemoriesByFts({
       sessionId: resolvedSessionId,
-      queryEmbedding,
-      limit,
+      normalizedQuery,
+      limit: fullTextCandidateLimit,
       minConfidence,
+      tokenizer,
+      rankMode: 'source',
       filter: params.filter,
+      touch: false,
     });
+    const selected =
+      rerank === 'bm25'
+        ? rerankSemanticMemoriesWithFts({
+            rows: fullTextCandidates,
+            query: normalizedQuery,
+            tokenizer,
+          }).slice(0, limit)
+        : fullTextCandidates;
+    if (params.touch !== false) {
+      touchSemanticMemoryRows(selected);
+    }
+    return selected;
   }
 
-  return recallSemanticMemoriesByLike({
-    sessionId: resolvedSessionId,
-    normalizedQuery,
-    queryTerms,
-    limit,
-    minConfidence,
-    filter: params.filter,
-  });
+  const cosineCandidateLimit = Math.max(limit * 10, 100);
+  const cosineCandidates = queryEmbedding
+    ? recallSemanticMemoriesByVector({
+        sessionId: resolvedSessionId,
+        queryEmbedding,
+        limit:
+          backend === 'hybrid' || rerank === 'bm25'
+            ? cosineCandidateLimit
+            : limit,
+        minConfidence,
+        filter: params.filter,
+        touch: false,
+      })
+    : recallSemanticMemoriesByLike({
+        sessionId: resolvedSessionId,
+        normalizedQuery,
+        queryTerms,
+        limit:
+          backend === 'hybrid' || rerank === 'bm25'
+            ? Math.max(limit * 8, 50)
+            : limit,
+        minConfidence,
+        filter: params.filter,
+        touch: false,
+      });
+
+  if (backend === 'hybrid') {
+    const fullTextCandidates = recallSemanticMemoriesByFts({
+      sessionId: resolvedSessionId,
+      normalizedQuery,
+      limit: cosineCandidateLimit,
+      minConfidence,
+      tokenizer,
+      rankMode: 'source',
+      filter: params.filter,
+      touch: false,
+    });
+    const fused = fuseHybridSemanticMemories({
+      cosineRows: cosineCandidates,
+      fullTextRows: fullTextCandidates,
+    });
+    const selected =
+      rerank === 'bm25'
+        ? rerankSemanticMemoriesWithFts({
+            rows: fused,
+            query: normalizedQuery,
+            tokenizer,
+          }).slice(0, limit)
+        : fused.slice(0, limit);
+    if (params.touch !== false) {
+      touchSemanticMemoryRows(selected);
+    }
+    return selected;
+  }
+
+  if (rerank === 'bm25') {
+    const reranked = rerankSemanticMemoriesWithFts({
+      rows: cosineCandidates,
+      query: normalizedQuery,
+      tokenizer,
+    }).slice(0, limit);
+    if (params.touch !== false) {
+      touchSemanticMemoryRows(reranked);
+    }
+    return reranked;
+  }
+
+  if (params.touch !== false) {
+    touchSemanticMemoryRows(cosineCandidates);
+  }
+  return cosineCandidates;
 }
 
 export function forgetSemanticMemory(id: number): boolean {

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -1,0 +1,63 @@
+import path from 'node:path';
+
+import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+
+export type MemoryEmbeddingProviderKind = 'hashed' | 'transformers';
+export type MemoryEmbeddingDtype = 'fp32' | 'q8' | 'q4';
+export type MemoryEmbeddingInputKind = 'query' | 'document';
+
+export interface MemoryEmbeddingRuntimeConfig {
+  provider: MemoryEmbeddingProviderKind;
+  model: string;
+  revision: string;
+  dtype: MemoryEmbeddingDtype;
+}
+
+export const DEFAULT_MEMORY_EMBEDDING_PROVIDER: MemoryEmbeddingProviderKind =
+  'hashed';
+export const DEFAULT_MEMORY_TRANSFORMERS_MODEL =
+  'onnx-community/embeddinggemma-300m-ONNX';
+export const DEFAULT_MEMORY_TRANSFORMERS_REVISION =
+  '75a84c732f1884df76bec365346230e32f582c82';
+export const DEFAULT_MEMORY_TRANSFORMERS_DTYPE: MemoryEmbeddingDtype = 'q8';
+
+export function normalizeMemoryEmbeddingProviderKind(
+  value: unknown,
+  fallback: MemoryEmbeddingProviderKind,
+): MemoryEmbeddingProviderKind {
+  const normalized = String(value || '')
+    .trim()
+    .toLowerCase();
+  if (normalized === 'transformers' || normalized === 'transformers.js') {
+    return 'transformers';
+  }
+  if (normalized === 'hashed' || normalized === 'hash') {
+    return 'hashed';
+  }
+  return fallback;
+}
+
+export function normalizeMemoryEmbeddingDtype(
+  value: unknown,
+  fallback: MemoryEmbeddingDtype,
+): MemoryEmbeddingDtype {
+  const normalized = String(value || '')
+    .trim()
+    .toLowerCase();
+  if (normalized === 'fp32') {
+    return 'fp32';
+  }
+  if (normalized === 'q4') {
+    return 'q4';
+  }
+  if (normalized === 'q8') {
+    return 'q8';
+  }
+  return fallback;
+}
+
+export function getDefaultMemoryEmbeddingCacheDir(
+  homeDir = DEFAULT_RUNTIME_HOME_DIR,
+): string {
+  return path.join(homeDir, 'cache', 'transformers');
+}

--- a/src/memory/memory-service.ts
+++ b/src/memory/memory-service.ts
@@ -349,21 +349,25 @@ class HashedTokenEmbeddingProvider implements EmbeddingProvider {
       .slice(0, 256);
     if (tokens.length === 0) return null;
 
-    const vector = new Float32Array(this.dimensions);
+    const vector = Array<number>(this.dimensions).fill(0);
     for (const token of tokens) {
       const hash = this.hashToken(token);
       const index = hash % this.dimensions;
       const sign = (hash & 1) === 0 ? 1 : -1;
-      vector[index] += sign * Math.min(4, token.length);
+      vector[index] = (vector[index] || 0) + sign * Math.min(4, token.length);
     }
 
     let norm = 0;
     for (let i = 0; i < vector.length; i += 1) {
-      norm += vector[i] * vector[i];
+      const value = vector[i] || 0;
+      norm += value * value;
     }
     if (norm <= Number.EPSILON) return null;
     const scale = 1 / Math.sqrt(norm);
-    return Array.from(vector, (value) => value * scale);
+    for (let i = 0; i < vector.length; i += 1) {
+      vector[i] = (vector[i] || 0) * scale;
+    }
+    return vector;
   }
 
   private hashToken(token: string): number {
@@ -660,6 +664,32 @@ export class MemoryService {
     );
   }
 
+  storeSemanticMemory(params: {
+    sessionId: string;
+    role: string;
+    source?: string | null;
+    scope?: string | null;
+    metadata?: Record<string, unknown> | string | null;
+    content: string;
+    confidence?: number;
+    embedding?: number[] | null;
+    sourceMessageId?: number | null;
+  }): number {
+    const content = params.content.trim();
+    if (!content) {
+      throw new Error('Cannot store empty semantic memory content.');
+    }
+
+    return this.backend.storeSemanticMemory({
+      ...params,
+      content,
+      embedding:
+        params.embedding === undefined
+          ? this.embeddingProvider.embed(content)
+          : params.embedding,
+    });
+  }
+
   storeTurn(params: StoreTurnParams): {
     userMessageId: number;
     assistantMessageId: number;
@@ -689,7 +719,7 @@ export class MemoryService {
       };
     }
 
-    this.backend.storeSemanticMemory({
+    this.storeSemanticMemory({
       sessionId: params.sessionId,
       role: 'assistant',
       source: 'conversation',
@@ -697,7 +727,6 @@ export class MemoryService {
       metadata: {},
       content: interactionText,
       confidence: 1,
-      embedding: this.embeddingProvider.embed(interactionText),
       sourceMessageId: assistantMessageId,
     });
 

--- a/src/memory/memory-service.ts
+++ b/src/memory/memory-service.ts
@@ -1,5 +1,6 @@
 import { resolveAgentForRequest } from '../agents/agent-registry.js';
 import { SESSION_COMPACTION_SUMMARY_MAX_CHARS } from '../config/config.js';
+import { getRuntimeConfig } from '../config/runtime-config.js';
 import { callAuxiliaryModel } from '../providers/auxiliary.js';
 import type {
   SessionExpiryEvaluation,
@@ -61,9 +62,23 @@ import {
   type SemanticRecallFilter,
 } from './db.js';
 import {
+  getDefaultMemoryEmbeddingCacheDir,
+  type MemoryEmbeddingProviderKind,
+  normalizeMemoryEmbeddingProviderKind,
+} from './embeddings.js';
+import {
   MemoryConsolidationEngine,
   type MemoryConsolidationReport,
 } from './memory-consolidation.js';
+import {
+  type MemoryQueryMode,
+  type MemoryRecallBackend,
+  type MemoryRecallRerank,
+  type MemoryRecallTokenizer,
+  normalizeMemoryRecallBackend,
+  prepareMemoryRecallQuery,
+} from './semantic-recall.js';
+import { TransformersJsEmbeddingProvider } from './transformers-embedding-provider.js';
 
 export interface CompactionCandidate {
   cutoffId: number;
@@ -172,9 +187,14 @@ export interface MemoryBackend {
     sessionId: string;
     query: string;
     limit?: number;
+    limitHardCap?: number | null;
     minConfidence?: number;
     queryEmbedding?: number[] | null;
+    backend?: MemoryRecallBackend;
+    rerank?: MemoryRecallRerank;
+    tokenizer?: MemoryRecallTokenizer;
     filter?: SemanticRecallFilter;
+    touch?: boolean;
   }) => SemanticMemoryEntry[];
   forgetSemanticMemory: (id: number) => boolean;
   decaySemanticMemories: (params?: {
@@ -191,6 +211,7 @@ export interface MemoryBackend {
 
 export interface MemoryServiceConfig {
   semanticRecallLimit: number;
+  semanticPromptHardCap: number;
   semanticMinConfidence: number;
   semanticMaxContentChars: number;
   semanticDecayRate: number;
@@ -203,7 +224,11 @@ export interface MemoryServiceConfig {
 }
 
 export interface EmbeddingProvider {
-  embed(text: string): number[] | null;
+  embed?(text: string): number[] | null;
+  embedQuery?(text: string): number[] | null;
+  embedDocument?(text: string): number[] | null;
+  warmup?(): void;
+  dispose?(): void;
 }
 
 export interface StoreTurnParams {
@@ -224,6 +249,7 @@ export interface BuildMemoryPromptParams {
   session: Session;
   query: string;
   semanticLimit?: number;
+  touchSemanticRecall?: boolean;
 }
 
 export interface BuildMemoryPromptResult {
@@ -237,12 +263,20 @@ export interface RecallSemanticMemoriesParams {
   sessionId: string;
   query: string;
   limit?: number;
+  limitHardCap?: number | null;
   minConfidence?: number;
+  queryMode?: MemoryQueryMode;
+  backend?: MemoryRecallBackend;
+  rerank?: MemoryRecallRerank;
+  tokenizer?: MemoryRecallTokenizer;
+  embeddingProvider?: MemoryEmbeddingProviderKind;
   filter?: SemanticRecallFilter;
+  touch?: boolean;
 }
 
 const DEFAULT_CONFIG: MemoryServiceConfig = {
   semanticRecallLimit: 5,
+  semanticPromptHardCap: 12,
   semanticMinConfidence: 0.2,
   semanticMaxContentChars: 1_200,
   semanticDecayRate: 0.1,
@@ -370,6 +404,14 @@ class HashedTokenEmbeddingProvider implements EmbeddingProvider {
     return vector;
   }
 
+  embedQuery(text: string): number[] | null {
+    return this.embed(text);
+  }
+
+  embedDocument(text: string): number[] | null {
+    return this.embed(text);
+  }
+
   private hashToken(token: string): number {
     let hash = 2166136261;
     for (let i = 0; i < token.length; i += 1) {
@@ -383,12 +425,15 @@ class HashedTokenEmbeddingProvider implements EmbeddingProvider {
 export class MemoryService {
   private readonly backend: MemoryBackend;
   private readonly config: MemoryServiceConfig;
-  private readonly embeddingProvider: EmbeddingProvider;
+  private readonly defaultEmbeddingProvider: EmbeddingProvider;
+  private readonly fixedEmbeddingProvider: EmbeddingProvider | null;
   private readonly consolidationEngine: MemoryConsolidationEngine;
   private readonly compactionLocks = new Map<
     string,
     Promise<CompactionResult>
   >();
+  private runtimeEmbeddingProviderKey: string | null = null;
+  private runtimeEmbeddingProvider: EmbeddingProvider | null = null;
 
   constructor(
     backend: MemoryBackend = DEFAULT_BACKEND,
@@ -397,9 +442,10 @@ export class MemoryService {
   ) {
     this.backend = backend;
     this.config = { ...DEFAULT_CONFIG, ...(config || {}) };
-    this.embeddingProvider =
-      embeddingProvider ||
-      new HashedTokenEmbeddingProvider(this.config.embeddingDimensions);
+    this.fixedEmbeddingProvider = embeddingProvider || null;
+    this.defaultEmbeddingProvider = new HashedTokenEmbeddingProvider(
+      this.config.embeddingDimensions,
+    );
     this.consolidationEngine = new MemoryConsolidationEngine(this.backend, {
       decayRate: this.config.semanticDecayRate,
       staleAfterDays: this.config.semanticDecayStaleAfterDays,
@@ -583,7 +629,7 @@ export class MemoryService {
               stageTotal,
             }),
         },
-        embed: (text) => this.embeddingProvider.embed(text),
+        embed: (text) => this.embedDocument(text),
         config: {
           maxSummaryChars: SESSION_COMPACTION_SUMMARY_MAX_CHARS,
         },
@@ -599,25 +645,48 @@ export class MemoryService {
   recallSemanticMemories(
     params: RecallSemanticMemoriesParams,
   ): SemanticMemoryEntry[] {
-    const limit = Math.max(
+    const requestedLimit = Math.max(
       1,
-      Math.min(Math.floor(params.limit || this.config.semanticRecallLimit), 50),
+      Math.floor(params.limit || this.config.semanticRecallLimit),
     );
+    const limitHardCap =
+      typeof params.limitHardCap === 'number' &&
+      Number.isFinite(params.limitHardCap)
+        ? Math.max(1, Math.floor(params.limitHardCap))
+        : params.limitHardCap === null
+          ? null
+          : 50;
+    const limit =
+      limitHardCap == null
+        ? requestedLimit
+        : Math.min(requestedLimit, limitHardCap);
     const rawMinConfidence =
       typeof params.minConfidence === 'number' &&
       Number.isFinite(params.minConfidence)
         ? params.minConfidence
         : this.config.semanticMinConfidence;
     const minConfidence = Math.max(0, Math.min(1, rawMinConfidence));
-    const query = params.query.trim();
+    const queryMode = params.queryMode ?? this.resolveSemanticQueryMode();
+    const backend = params.backend ?? this.resolveSemanticRecallBackend();
+    const rerank = params.rerank ?? this.resolveSemanticRecallRerank();
+    const tokenizer = params.tokenizer ?? this.resolveSemanticRecallTokenizer();
+    const query = prepareMemoryRecallQuery(params.query, queryMode);
 
     return this.backend.recallSemanticMemories({
       sessionId: params.sessionId,
       query,
       limit,
+      limitHardCap,
       minConfidence,
-      queryEmbedding: this.embeddingProvider.embed(query),
+      queryEmbedding:
+        backend === 'full-text'
+          ? null
+          : this.embedQuery(query, params.embeddingProvider),
+      backend,
+      rerank,
+      tokenizer,
       filter: params.filter,
+      touch: params.touch,
     });
   }
 
@@ -673,6 +742,7 @@ export class MemoryService {
     content: string;
     confidence?: number;
     embedding?: number[] | null;
+    embeddingProvider?: MemoryEmbeddingProviderKind;
     sourceMessageId?: number | null;
   }): number {
     const content = params.content.trim();
@@ -685,7 +755,7 @@ export class MemoryService {
       content,
       embedding:
         params.embedding === undefined
-          ? this.embeddingProvider.embed(content)
+          ? this.embedDocument(content, params.embeddingProvider)
           : params.embedding,
     });
   }
@@ -727,6 +797,7 @@ export class MemoryService {
       metadata: {},
       content: interactionText,
       confidence: 1,
+      embeddingProvider: undefined,
       sourceMessageId: assistantMessageId,
     });
 
@@ -757,7 +828,7 @@ export class MemoryService {
       1,
       Math.min(
         Math.floor(params.semanticLimit || this.config.semanticRecallLimit),
-        12,
+        this.resolveSemanticPromptHardCap(),
       ),
     );
     const semanticMemories = this.recallSemanticMemories({
@@ -765,6 +836,7 @@ export class MemoryService {
       query: params.query,
       limit: semanticLimit,
       minConfidence: this.config.semanticMinConfidence,
+      touch: params.touchSemanticRecall,
     });
     const citationIndex: MemoryCitation[] = semanticMemories.map(
       (memory, i) => ({
@@ -793,7 +865,7 @@ export class MemoryService {
       sections.push(
         [
           '### Relevant Memory Recall',
-          'Topic-matched context from older turns (vector cosine search).',
+          'Topic-matched context from older turns.',
           'If you use any of these memories in your response, cite them inline using their tag (e.g. [mem:1]).',
           ...lines,
         ].join('\n'),
@@ -813,6 +885,131 @@ export class MemoryService {
     const compact = content.replace(/\s+/g, ' ').trim();
     if (compact.length <= this.config.semanticMaxContentChars) return compact;
     return compact.slice(0, this.config.semanticMaxContentChars);
+  }
+
+  private embedQuery(
+    text: string,
+    embeddingProvider?: MemoryEmbeddingProviderKind,
+  ): number[] | null {
+    return this.embedWithProvider('query', text, embeddingProvider);
+  }
+
+  warmupEmbeddingProvider(
+    embeddingProvider?: MemoryEmbeddingProviderKind,
+  ): void {
+    const provider = this.resolveEmbeddingProvider(embeddingProvider);
+    provider.warmup?.();
+  }
+
+  private embedDocument(
+    text: string,
+    embeddingProvider?: MemoryEmbeddingProviderKind,
+  ): number[] | null {
+    return this.embedWithProvider('document', text, embeddingProvider);
+  }
+
+  private embedWithProvider(
+    kind: 'query' | 'document',
+    text: string,
+    embeddingProvider?: MemoryEmbeddingProviderKind,
+  ): number[] | null {
+    const provider = this.resolveEmbeddingProvider(embeddingProvider);
+    if (kind === 'query' && typeof provider.embedQuery === 'function') {
+      return provider.embedQuery(text);
+    }
+    if (kind === 'document' && typeof provider.embedDocument === 'function') {
+      return provider.embedDocument(text);
+    }
+    if (typeof provider.embed === 'function') {
+      return provider.embed(text);
+    }
+    throw new Error('Embedding provider does not implement any embed method.');
+  }
+
+  private resolveEmbeddingProvider(
+    embeddingProvider?: MemoryEmbeddingProviderKind,
+  ): EmbeddingProvider {
+    if (this.fixedEmbeddingProvider) {
+      return this.fixedEmbeddingProvider;
+    }
+    if (this.backend !== DEFAULT_BACKEND) {
+      return this.defaultEmbeddingProvider;
+    }
+
+    const runtimeEmbedding = getRuntimeConfig().memory.embedding;
+    const providerKind = normalizeMemoryEmbeddingProviderKind(
+      embeddingProvider ?? runtimeEmbedding.provider,
+      runtimeEmbedding.provider,
+    );
+    if (providerKind !== 'transformers') {
+      this.runtimeEmbeddingProvider?.dispose?.();
+      this.runtimeEmbeddingProvider = null;
+      this.runtimeEmbeddingProviderKey = null;
+      return this.defaultEmbeddingProvider;
+    }
+
+    const providerKey = JSON.stringify(runtimeEmbedding);
+    if (
+      this.runtimeEmbeddingProviderKey === providerKey &&
+      this.runtimeEmbeddingProvider
+    ) {
+      return this.runtimeEmbeddingProvider;
+    }
+
+    this.runtimeEmbeddingProvider?.dispose?.();
+    this.runtimeEmbeddingProvider = new TransformersJsEmbeddingProvider({
+      model: runtimeEmbedding.model,
+      revision: runtimeEmbedding.revision,
+      dtype: runtimeEmbedding.dtype,
+      cacheDir: getDefaultMemoryEmbeddingCacheDir(),
+    });
+    this.runtimeEmbeddingProviderKey = providerKey;
+    return this.runtimeEmbeddingProvider;
+  }
+
+  private resolveSemanticPromptHardCap(): number {
+    const configured = Math.max(
+      1,
+      Math.min(Math.floor(this.config.semanticPromptHardCap), 50),
+    );
+    if (this.backend !== DEFAULT_BACKEND) {
+      return configured;
+    }
+    const runtimeValue = getRuntimeConfig().memory.semanticPromptHardCap;
+    return Math.max(1, Math.min(Math.floor(runtimeValue), 50));
+  }
+
+  private resolveSemanticQueryMode(): MemoryQueryMode {
+    if (this.backend !== DEFAULT_BACKEND) {
+      return 'raw';
+    }
+    return getRuntimeConfig().memory.queryMode === 'no-stopwords'
+      ? 'no-stopwords'
+      : 'raw';
+  }
+
+  private resolveSemanticRecallBackend(): MemoryRecallBackend {
+    if (this.backend !== DEFAULT_BACKEND) {
+      return 'cosine';
+    }
+    return normalizeMemoryRecallBackend(
+      getRuntimeConfig().memory.backend,
+      'cosine',
+    );
+  }
+
+  private resolveSemanticRecallRerank(): MemoryRecallRerank {
+    if (this.backend !== DEFAULT_BACKEND) {
+      return 'none';
+    }
+    return getRuntimeConfig().memory.rerank === 'bm25' ? 'bm25' : 'none';
+  }
+
+  private resolveSemanticRecallTokenizer(): MemoryRecallTokenizer {
+    if (this.backend !== DEFAULT_BACKEND) {
+      return 'unicode61';
+    }
+    return getRuntimeConfig().memory.tokenizer;
   }
 
   private async runCompactionPrompt(params: {

--- a/src/memory/semantic-recall.ts
+++ b/src/memory/semantic-recall.ts
@@ -1,0 +1,215 @@
+export type MemoryQueryMode = 'raw' | 'no-stopwords';
+export type MemoryRecallBackend = 'full-text' | 'cosine' | 'hybrid';
+export type MemoryRecallRerank = 'none' | 'bm25';
+export type MemoryRecallTokenizer = 'unicode61' | 'porter' | 'trigram';
+
+const MEMORY_RECALL_STOPWORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'are',
+  'as',
+  'at',
+  'be',
+  'by',
+  'did',
+  'do',
+  'does',
+  'for',
+  'from',
+  'had',
+  'has',
+  'have',
+  'he',
+  'her',
+  'his',
+  'how',
+  'i',
+  'if',
+  'in',
+  'into',
+  'is',
+  'it',
+  'its',
+  'me',
+  'my',
+  'of',
+  'on',
+  'or',
+  'our',
+  'she',
+  'so',
+  'than',
+  'that',
+  'the',
+  'their',
+  'them',
+  'there',
+  'they',
+  'this',
+  'to',
+  'was',
+  'we',
+  'were',
+  'what',
+  'when',
+  'where',
+  'which',
+  'who',
+  'why',
+  'will',
+  'with',
+  'you',
+  'your',
+]);
+
+export function normalizeMemoryRecallText(value: string): string {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9_\s-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function tokenizeMemoryRecallQuery(
+  value: string,
+  maxTerms = 12,
+  tokenizer: MemoryRecallTokenizer = 'unicode61',
+): string[] {
+  const terms =
+    tokenizer === 'trigram'
+      ? tokenizeMemoryRecallTrigrams(value)
+      : tokenizeMemoryRecallTerms(value);
+  const unique = new Set<string>();
+  for (const term of terms) {
+    unique.add(term);
+    if (unique.size >= Math.max(1, Math.floor(maxTerms))) {
+      break;
+    }
+  }
+  return [...unique];
+}
+
+function tokenizeMemoryRecallTerms(value: string): string[] {
+  return normalizeMemoryRecallText(value)
+    .split(' ')
+    .map((term) => term.trim())
+    .filter((term) => term.length >= 2);
+}
+
+function tokenizeMemoryRecallTrigrams(value: string): string[] {
+  const tokens = tokenizeMemoryRecallTerms(value);
+  const trigrams: string[] = [];
+  for (const token of tokens) {
+    if (token.length < 3) {
+      trigrams.push(token);
+      continue;
+    }
+    for (let index = 0; index <= token.length - 3; index += 1) {
+      trigrams.push(token.slice(index, index + 3));
+    }
+  }
+  return trigrams;
+}
+
+export function prepareMemoryRecallQuery(
+  query: string,
+  mode: MemoryQueryMode,
+): string {
+  const normalized = normalizeMemoryRecallText(query);
+  if (mode !== 'no-stopwords') {
+    return normalized;
+  }
+  const filtered = tokenizeMemoryRecallQuery(normalized).filter(
+    (term) => !MEMORY_RECALL_STOPWORDS.has(term),
+  );
+  return filtered.length > 0 ? filtered.join(' ') : normalized;
+}
+
+export function normalizeMemoryRecallBackend(
+  value: unknown,
+  fallback: MemoryRecallBackend,
+): MemoryRecallBackend {
+  const normalized = String(value || '')
+    .trim()
+    .toLowerCase();
+  if (normalized === 'full-text' || normalized === 'fulltext') {
+    return 'full-text';
+  }
+  if (normalized === 'fts-bm25') {
+    return 'full-text';
+  }
+  if (normalized === 'hybrid') {
+    return 'hybrid';
+  }
+  if (normalized === 'cosine' || normalized === 'semantic') {
+    return 'cosine';
+  }
+  return fallback;
+}
+
+export function normalizeMemoryRecallRerank(
+  value: unknown,
+  fallback: MemoryRecallRerank,
+): MemoryRecallRerank {
+  const normalized = String(value || '')
+    .trim()
+    .toLowerCase();
+  if (normalized === 'bm25') {
+    return 'bm25';
+  }
+  if (normalized === 'none') {
+    return 'none';
+  }
+  return fallback;
+}
+
+export function normalizeMemoryRecallTokenizer(
+  value: unknown,
+  fallback: MemoryRecallTokenizer,
+): MemoryRecallTokenizer {
+  const normalized = String(value || '')
+    .trim()
+    .toLowerCase();
+  if (normalized === 'unicode61' || normalized === 'default') {
+    return 'unicode61';
+  }
+  if (normalized === 'porter') {
+    return 'porter';
+  }
+  if (normalized === 'trigram') {
+    return 'trigram';
+  }
+  return fallback;
+}
+
+export function buildMemoryFtsMatchQuery(
+  query: string,
+  maxTerms = 12,
+  tokenizer: MemoryRecallTokenizer = 'unicode61',
+): string {
+  const terms =
+    tokenizer === 'trigram'
+      ? tokenizeMemoryRecallQuery(query, maxTerms, 'unicode61')
+      : tokenizeMemoryRecallQuery(query, maxTerms, tokenizer);
+  return terms.map((term) => `"${term.replace(/"/g, '""')}"`).join(' OR ');
+}
+
+export function buildMemoryFtsDocument(
+  content: string,
+  _tokenizer: MemoryRecallTokenizer = 'unicode61',
+): string {
+  return content;
+}
+
+export function getMemoryFtsTokenizerSpec(
+  tokenizer: MemoryRecallTokenizer,
+): string {
+  if (tokenizer === 'porter') {
+    return 'porter unicode61';
+  }
+  if (tokenizer === 'trigram') {
+    return 'trigram';
+  }
+  return 'unicode61';
+}

--- a/src/memory/transformers-embedding-provider.ts
+++ b/src/memory/transformers-embedding-provider.ts
@@ -1,0 +1,481 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  MessageChannel,
+  type MessagePort,
+  receiveMessageOnPort,
+  Worker,
+} from 'node:worker_threads';
+
+import { logger } from '../logger.js';
+import type {
+  MemoryEmbeddingDtype,
+  MemoryEmbeddingInputKind,
+} from './embeddings.js';
+import type { EmbeddingProvider } from './memory-service.js';
+
+const WORKER_POLL_INTERVAL_MS = 50;
+const WORKER_REQUEST_TIMEOUT_MS = 120_000;
+
+interface TransformersWorkerRequest {
+  requestId: number;
+  kind: 'embed' | 'warmup';
+  text?: string;
+}
+
+interface TransformersWorkerSuccess {
+  requestId: number;
+  ok: true;
+  embedding: number[] | null;
+}
+
+interface TransformersWorkerFailure {
+  requestId: number;
+  ok: false;
+  error: string;
+}
+
+interface TransformersWorkerStatus {
+  type: 'status';
+  stage: string;
+  requestId: number | null;
+  detail: string | null;
+}
+
+type TransformersWorkerResponse =
+  | TransformersWorkerSuccess
+  | TransformersWorkerFailure
+  | TransformersWorkerStatus;
+
+export interface BlockingEmbeddingRuntime {
+  embed(text: string): number[] | null;
+  warmup?(): void;
+  dispose?(): void;
+}
+
+export interface TransformersJsEmbeddingProviderOptions {
+  model: string;
+  revision: string;
+  dtype: MemoryEmbeddingDtype;
+  cacheDir: string;
+}
+
+interface WorkerBootstrapData extends TransformersJsEmbeddingProviderOptions {
+  control: SharedArrayBuffer;
+  port: MessagePort;
+}
+
+interface WorkerStatusSnapshot {
+  stage: string;
+  requestId: number | null;
+  detail: string | null;
+  at: string;
+}
+
+const transformersEmbeddingLogger = logger.child({
+  component: 'transformers-embedding',
+});
+
+export class TransformersJsEmbeddingProvider implements EmbeddingProvider {
+  private readonly runtime: BlockingEmbeddingRuntime;
+  private readonly model: string;
+
+  constructor(
+    options: TransformersJsEmbeddingProviderOptions,
+    runtime?: BlockingEmbeddingRuntime,
+  ) {
+    this.model = options.model;
+    this.runtime =
+      runtime || new PollingWorkerTransformersEmbeddingRuntime(options);
+  }
+
+  embedQuery(text: string): number[] | null {
+    const normalized = text.trim();
+    if (!normalized) return null;
+    return this.runtime.embed(
+      buildTransformersEmbeddingInput(normalized, 'query', this.model),
+    );
+  }
+
+  embedDocument(text: string): number[] | null {
+    const normalized = text.trim();
+    if (!normalized) return null;
+    return this.runtime.embed(
+      buildTransformersEmbeddingInput(normalized, 'document', this.model),
+    );
+  }
+
+  warmup(): void {
+    this.runtime.warmup?.();
+  }
+
+  dispose(): void {
+    this.runtime.dispose?.();
+  }
+}
+
+class PollingWorkerTransformersEmbeddingRuntime
+  implements BlockingEmbeddingRuntime
+{
+  private readonly options: TransformersJsEmbeddingProviderOptions;
+  private readonly pollIntervalMs: number;
+  private readonly timeoutMs: number;
+
+  private worker: Worker | null = null;
+  private port: MessagePort | null = null;
+  private control: Int32Array | null = null;
+  private nextRequestId = 1;
+  private lastStatus: WorkerStatusSnapshot | null = null;
+  private lastWorkerError: Error | null = null;
+  private lastWorkerExitCode: number | null = null;
+  private shuttingDown = false;
+
+  constructor(options: TransformersJsEmbeddingProviderOptions) {
+    this.options = options;
+    this.pollIntervalMs = WORKER_POLL_INTERVAL_MS;
+    this.timeoutMs = WORKER_REQUEST_TIMEOUT_MS;
+  }
+
+  warmup(): void {
+    const requestId = this.nextRequestId;
+    this.nextRequestId += 1;
+    transformersEmbeddingLogger.info(
+      {
+        requestId,
+        model: this.options.model,
+        revision: this.options.revision,
+        dtype: this.options.dtype,
+      },
+      'Transformers.js embedding warmup started',
+    );
+    this.sendRequest({
+      requestId,
+      request: {
+        requestId,
+        kind: 'warmup',
+      },
+      detailForError: {
+        requestKind: 'warmup',
+        textLength: null,
+      },
+    });
+    transformersEmbeddingLogger.info(
+      {
+        requestId,
+        model: this.options.model,
+      },
+      'Transformers.js embedding warmup completed',
+    );
+  }
+
+  embed(text: string): number[] | null {
+    const normalized = text.trim();
+    if (!normalized) return null;
+    const requestId = this.nextRequestId;
+    this.nextRequestId += 1;
+
+    if (shouldLogEmbeddingRequestMilestone(requestId)) {
+      transformersEmbeddingLogger.info(
+        {
+          requestId,
+          model: this.options.model,
+          textLength: normalized.length,
+        },
+        'Transformers.js embedding request started',
+      );
+    }
+
+    const embedding = this.sendRequest({
+      requestId,
+      request: {
+        requestId,
+        kind: 'embed',
+        text: normalized,
+      },
+      detailForError: {
+        requestKind: 'embed',
+        textLength: normalized.length,
+      },
+    });
+
+    if (shouldLogEmbeddingRequestMilestone(requestId)) {
+      transformersEmbeddingLogger.info(
+        {
+          requestId,
+          model: this.options.model,
+          textLength: normalized.length,
+        },
+        'Transformers.js embedding request completed',
+      );
+    }
+    return embedding;
+  }
+
+  dispose(): void {
+    this.shuttingDown = true;
+    this.port?.close();
+    this.port = null;
+    void this.worker?.terminate();
+    this.worker = null;
+    this.control = null;
+    this.lastStatus = null;
+    this.lastWorkerError = null;
+    this.lastWorkerExitCode = null;
+  }
+
+  private ensureWorker(): {
+    worker: Worker;
+    port: MessagePort;
+    control: Int32Array;
+  } {
+    if (this.worker && this.port && this.control) {
+      return {
+        worker: this.worker,
+        port: this.port,
+        control: this.control,
+      };
+    }
+
+    const controlBuffer = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT);
+    const control = new Int32Array(controlBuffer);
+    const { port1, port2 } = new MessageChannel();
+    this.shuttingDown = false;
+    transformersEmbeddingLogger.info(
+      {
+        model: this.options.model,
+        revision: this.options.revision,
+        dtype: this.options.dtype,
+        cacheDir: this.options.cacheDir,
+      },
+      'Starting Transformers.js embedding worker',
+    );
+    const worker = new Worker(buildWorkerModuleUrl(), {
+      workerData: {
+        ...this.options,
+        control: controlBuffer,
+        port: port2,
+      } satisfies WorkerBootstrapData,
+      transferList: [port2],
+    });
+    worker.on('online', () => {
+      transformersEmbeddingLogger.info(
+        { model: this.options.model },
+        'Transformers.js embedding worker is online',
+      );
+    });
+    worker.on('error', (error) => {
+      this.lastWorkerError = error;
+      transformersEmbeddingLogger.error(
+        { err: error, model: this.options.model },
+        'Transformers.js embedding worker error',
+      );
+      if (this.control) {
+        Atomics.store(this.control, 0, 1);
+        Atomics.notify(this.control, 0);
+      }
+    });
+    worker.on('exit', (code) => {
+      if (this.shuttingDown) {
+        return;
+      }
+      this.lastWorkerExitCode = code;
+      if (code === 0) {
+        transformersEmbeddingLogger.info(
+          { model: this.options.model, exitCode: code },
+          'Transformers.js embedding worker exited',
+        );
+      } else {
+        transformersEmbeddingLogger.error(
+          { model: this.options.model, exitCode: code },
+          'Transformers.js embedding worker exited unexpectedly',
+        );
+      }
+      if (this.control) {
+        Atomics.store(this.control, 0, 1);
+        Atomics.notify(this.control, 0);
+      }
+    });
+
+    this.worker = worker;
+    this.port = port1;
+    this.control = control;
+    this.lastWorkerError = null;
+    this.lastWorkerExitCode = null;
+
+    return {
+      worker,
+      port: port1,
+      control,
+    };
+  }
+
+  private sendRequest(params: {
+    requestId: number;
+    request: TransformersWorkerRequest;
+    detailForError: {
+      requestKind: 'embed' | 'warmup';
+      textLength: number | null;
+    };
+  }): number[] | null {
+    const { worker, port, control } = this.ensureWorker();
+
+    Atomics.store(control, 0, 0);
+    worker.postMessage(params.request);
+
+    const deadline = Date.now() + this.timeoutMs;
+    while (Date.now() <= deadline) {
+      if (this.lastWorkerError) {
+        const error = this.lastWorkerError;
+        this.lastWorkerError = null;
+        throw new Error(
+          `Transformers.js embedding worker failed for ${this.options.model}: ${error.message}`,
+        );
+      }
+      if (this.lastWorkerExitCode !== null) {
+        const exitCode = this.lastWorkerExitCode;
+        this.lastWorkerExitCode = null;
+        throw new Error(
+          `Transformers.js embedding worker exited with code ${exitCode} for ${this.options.model}. Check eval logs for [transformers-embedding] diagnostics.`,
+        );
+      }
+
+      const packet = receiveMessageOnPort(port);
+      const message = packet?.message as TransformersWorkerResponse | undefined;
+      if (message && isWorkerStatusMessage(message)) {
+        this.recordWorkerStatus(message);
+        continue;
+      }
+      if (
+        message &&
+        'requestId' in message &&
+        message.requestId === params.requestId
+      ) {
+        if (!message.ok) {
+          throw new Error(message.error);
+        }
+        return message.embedding;
+      }
+
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) break;
+      Atomics.wait(control, 0, 0, Math.min(this.pollIntervalMs, remainingMs));
+    }
+
+    throw new Error(
+      formatTransformersEmbeddingTimeoutMessage({
+        timeoutMs: this.timeoutMs,
+        model: this.options.model,
+        requestId: params.requestId,
+        requestKind: params.detailForError.requestKind,
+        textLength: params.detailForError.textLength,
+        lastStatus: this.lastStatus,
+      }),
+    );
+  }
+
+  private recordWorkerStatus(message: TransformersWorkerStatus): void {
+    this.lastStatus = {
+      stage: message.stage,
+      requestId: message.requestId,
+      detail: message.detail,
+      at: new Date().toISOString(),
+    };
+    const logPayload = {
+      model: this.options.model,
+      stage: message.stage,
+      requestId: message.requestId,
+      detail: message.detail,
+    };
+    if (
+      message.stage === 'worker-started' ||
+      message.stage === 'pipeline-loading' ||
+      message.stage === 'pipeline-ready' ||
+      message.stage === 'warmup' ||
+      message.stage === 'warmup-completed' ||
+      message.stage === 'request-failed' ||
+      ((message.stage === 'embed' || message.stage === 'embed-completed') &&
+        shouldLogEmbeddingRequestMilestone(message.requestId))
+    ) {
+      transformersEmbeddingLogger.info(
+        logPayload,
+        'Transformers.js embedding worker status',
+      );
+      return;
+    }
+    transformersEmbeddingLogger.debug(
+      logPayload,
+      'Transformers.js embedding worker status',
+    );
+  }
+}
+
+function shouldLogEmbeddingRequestMilestone(
+  requestId: number | null | undefined,
+): boolean {
+  return requestId === 1 || (requestId != null && requestId % 100 === 0);
+}
+
+function isWorkerStatusMessage(
+  value: TransformersWorkerResponse,
+): value is TransformersWorkerStatus {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'type' in value &&
+    value.type === 'status'
+  );
+}
+
+function formatTransformersEmbeddingTimeoutMessage(params: {
+  timeoutMs: number;
+  model: string;
+  requestId: number;
+  requestKind: 'embed' | 'warmup';
+  textLength: number | null;
+  lastStatus: WorkerStatusSnapshot | null;
+}): string {
+  const lastStatus = params.lastStatus
+    ? ` Last worker status: ${params.lastStatus.stage}${
+        params.lastStatus.requestId != null
+          ? ` (request ${params.lastStatus.requestId})`
+          : ''
+      }${params.lastStatus.detail ? ` - ${params.lastStatus.detail}` : ''}.`
+    : '';
+  const requestDescription =
+    params.requestKind === 'warmup'
+      ? `warmup request ${params.requestId}`
+      : `request ${params.requestId}, ${params.textLength || 0} chars`;
+  return `Transformers.js embedding request timed out after ${params.timeoutMs}ms for model ${params.model} (${requestDescription}).${lastStatus} Check eval logs for [transformers-embedding] diagnostics.`;
+}
+
+function buildTransformersEmbeddingInput(
+  text: string,
+  kind: MemoryEmbeddingInputKind,
+  model: string,
+): string {
+  if (!isEmbeddingGemmaModel(model)) {
+    return text;
+  }
+  if (kind === 'query') {
+    return `task: search result | query: ${text}`;
+  }
+  return `title: none | text: ${text}`;
+}
+
+function isEmbeddingGemmaModel(model: string): boolean {
+  return model.toLowerCase().includes('embeddinggemma');
+}
+
+function isSourceTsWorker(): boolean {
+  return path.extname(fileURLToPath(import.meta.url)) === '.ts';
+}
+
+function buildWorkerModuleUrl(): URL {
+  if (isSourceTsWorker()) {
+    return new URL(
+      './transformers-embedding-worker-bootstrap.mjs',
+      import.meta.url,
+    );
+  }
+  return new URL('./transformers-embedding-worker.js', import.meta.url);
+}

--- a/src/memory/transformers-embedding-provider.ts
+++ b/src/memory/transformers-embedding-provider.ts
@@ -72,9 +72,12 @@ interface WorkerStatusSnapshot {
   at: string;
 }
 
-const transformersEmbeddingLogger = logger.child({
-  component: 'transformers-embedding',
-});
+const transformersEmbeddingLogger =
+  'child' in logger && typeof logger.child === 'function'
+    ? logger.child({
+        component: 'transformers-embedding',
+      })
+    : logger;
 
 export class TransformersJsEmbeddingProvider implements EmbeddingProvider {
   private readonly runtime: BlockingEmbeddingRuntime;

--- a/src/memory/transformers-embedding-worker-bootstrap.mjs
+++ b/src/memory/transformers-embedding-worker-bootstrap.mjs
@@ -1,0 +1,4 @@
+import { register } from 'tsx/esm/api';
+
+register();
+await import('./transformers-embedding-worker.ts');

--- a/src/memory/transformers-embedding-worker.ts
+++ b/src/memory/transformers-embedding-worker.ts
@@ -1,0 +1,176 @@
+import { type MessagePort, parentPort, workerData } from 'node:worker_threads';
+
+import { env, pipeline } from '@huggingface/transformers';
+
+interface WorkerBootstrapData {
+  model: string;
+  revision: string;
+  dtype: 'fp32' | 'q8' | 'q4';
+  cacheDir: string;
+  control: SharedArrayBuffer;
+  port: MessagePort;
+}
+
+interface TransformersWorkerRequest {
+  requestId: number;
+  kind: 'embed' | 'warmup';
+  text?: string;
+}
+
+interface TransformersWorkerStatus {
+  type: 'status';
+  stage: string;
+  requestId: number | null;
+  detail: string | null;
+}
+
+const { model, revision, dtype, cacheDir, control, port } =
+  workerData as WorkerBootstrapData;
+const controlState = new Int32Array(control);
+
+type FeatureExtractor = (
+  text: string,
+  options: {
+    pooling: 'mean';
+    normalize: true;
+  },
+) => Promise<{ data: ArrayLike<number> }>;
+
+let extractorPromise: Promise<FeatureExtractor> | null = null;
+
+if (!parentPort) {
+  throw new Error('Transformers embedding worker requires a parent port.');
+}
+
+env.cacheDir = cacheDir;
+env.allowLocalModels = true;
+env.allowRemoteModels = true;
+
+emitStatus('worker-started', null, `model=${model} dtype=${dtype}`);
+
+parentPort.on('message', (message: TransformersWorkerRequest) => {
+  void handleRequest(message);
+});
+
+async function handleRequest(
+  message: TransformersWorkerRequest,
+): Promise<void> {
+  try {
+    emitStatus(message.kind, message.requestId, buildRequestDetail(message));
+    const extractor = await getExtractor();
+    const output =
+      message.kind === 'embed'
+        ? await extractor(String(message.text || ''), {
+            pooling: 'mean',
+            normalize: true,
+          })
+        : null;
+    port.postMessage({
+      requestId: message.requestId,
+      ok: true,
+      embedding: output ? Array.from(output.data) : null,
+    });
+    emitStatus(`${message.kind}-completed`, message.requestId, null);
+  } catch (error) {
+    emitStatus(
+      'request-failed',
+      message.requestId,
+      error instanceof Error ? error.message : String(error),
+    );
+    port.postMessage({
+      requestId: message.requestId,
+      ok: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : `Transformers.js embedding failed: ${String(error)}`,
+    });
+  } finally {
+    Atomics.store(controlState, 0, 1);
+    Atomics.notify(controlState, 0);
+  }
+}
+
+async function getExtractor() {
+  if (!extractorPromise) {
+    emitStatus(
+      'pipeline-loading',
+      null,
+      `model=${model} revision=${revision} dtype=${dtype}`,
+    );
+    const createPipeline = pipeline as unknown as (
+      task: 'feature-extraction',
+      model: string,
+      options: {
+        revision: string;
+        dtype: 'fp32' | 'q8' | 'q4';
+        cache_dir: string;
+        device: 'cpu';
+      },
+    ) => Promise<FeatureExtractor>;
+    extractorPromise = createPipeline('feature-extraction', model, {
+      revision,
+      dtype,
+      cache_dir: cacheDir,
+      device: 'cpu',
+    });
+    await extractorPromise.then(() => {
+      emitStatus(
+        'pipeline-ready',
+        null,
+        `model=${model} revision=${revision} dtype=${dtype}`,
+      );
+    });
+  }
+  return extractorPromise;
+}
+
+function emitStatus(
+  stage: string,
+  requestId: number | null,
+  detail: string | null,
+): void {
+  const payload: TransformersWorkerStatus = {
+    type: 'status',
+    stage,
+    requestId,
+    detail,
+  };
+  port.postMessage(payload);
+  notifyControl();
+  writeTransformersWorkerLog(stage, requestId, detail);
+}
+
+function notifyControl(): void {
+  Atomics.store(controlState, 0, 1);
+  Atomics.notify(controlState, 0);
+}
+
+function writeTransformersWorkerLog(
+  stage: string,
+  requestId: number | null,
+  detail: string | null,
+): void {
+  if (
+    (stage === 'embed' || stage === 'embed-completed') &&
+    !shouldLogEmbeddingRequestMilestone(requestId)
+  ) {
+    return;
+  }
+  const requestPart = requestId != null ? ` request=${requestId}` : '';
+  const detailPart = detail ? ` ${detail}` : '';
+  process.stderr.write(
+    `[transformers-embedding] ${new Date().toISOString()} stage=${stage}${requestPart}${detailPart}\n`,
+  );
+}
+
+function shouldLogEmbeddingRequestMilestone(requestId: number | null): boolean {
+  return requestId === 1 || (requestId != null && requestId % 100 === 0);
+}
+
+function buildRequestDetail(message: TransformersWorkerRequest): string | null {
+  if (message.kind === 'warmup') {
+    return `model=${model} revision=${revision} dtype=${dtype}`;
+  }
+  return `${String(message.text || '').length} chars`;
+}

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -7,9 +7,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { CronExpressionParser } from 'cron-parser';
-
 import { SYSTEM_CAPABILITIES } from '../channels/channel.js';
 import { registerChannel } from '../channels/channel-registry.js';
+import { isEmailAddress } from '../channels/email/allowlist.js';
+import { isIMessageHandle } from '../channels/imessage/handle.js';
+import { isTelegramChannelId } from '../channels/telegram/target.js';
+import { isWhatsAppJid } from '../channels/whatsapp/phone.js';
 import { DATA_DIR, getConfigSnapshot } from '../config/config.js';
 import {
   type RuntimeSchedulerJob,
@@ -32,6 +35,7 @@ const SCHEDULER_STATE_VERSION = 1;
 const SCHEDULER_STATE_PATH = path.join(DATA_DIR, 'scheduler-jobs-state.json');
 const SQLITE_SECOND_PRECISION_TS_RE = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
 const DEFAULT_SCHEDULER_TIME_ZONE = 'UTC';
+const DISCORD_CHANNEL_ID_RE = /^\d{16,22}$/;
 
 type CronWeekdayNumbering = 'crontab' | 'monday-zero-based';
 
@@ -118,13 +122,29 @@ function formatFireTime(timeZone = DEFAULT_SCHEDULER_TIME_ZONE): string {
   });
 }
 
+function describeScheduledDeliveryTarget(
+  channelId: string | undefined,
+): string {
+  const trimmed = channelId?.trim();
+  if (!trimmed) return 'the current session';
+  if (isEmailAddress(trimmed)) return `email to ${trimmed}`;
+  if (DISCORD_CHANNEL_ID_RE.test(trimmed)) return `Discord channel ${trimmed}`;
+  if (isTelegramChannelId(trimmed)) return `Telegram target ${trimmed}`;
+  if (isIMessageHandle(trimmed)) return `iMessage target ${trimmed}`;
+  if (isWhatsAppJid(trimmed)) return `WhatsApp chat ${trimmed}`;
+  if (trimmed === 'tui') return 'the local TUI inbox';
+  return `channel ${trimmed}`;
+}
+
 export function wrapCronPrompt(
   jobLabel: string,
   message: string,
   timeZone = DEFAULT_SCHEDULER_TIME_ZONE,
+  deliveryChannelId?: string,
 ): string {
   const resolvedTz = resolveSchedulerTimeZone(timeZone);
-  return `[cron:${jobLabel}] ${message}\nCurrent time: ${formatFireTime(resolvedTz)} (${resolvedTz})\n\nReturn your response as plain text; it will be delivered automatically. Execute the instruction directly and do not ask follow-up questions. If the task explicitly calls for messaging a specific external recipient, note who/where it should go instead of sending it yourself.`;
+  const deliveryTarget = describeScheduledDeliveryTarget(deliveryChannelId);
+  return `[cron:${jobLabel}] ${message}\nCurrent time: ${formatFireTime(resolvedTz)} (${resolvedTz})\nDelivery target: ${deliveryTarget}. Your plain-text response will be delivered there automatically.\n\nReturn your response as plain text; it will be delivered automatically. Execute the instruction directly and do not ask follow-up questions. If the task explicitly calls for messaging a specific external recipient, note who/where it should go instead of sending it yourself.`;
 }
 
 function defaultConfigJobMeta(): ConfigJobMeta {
@@ -616,7 +636,12 @@ function arm(): void {
 
 async function dispatchDbTask(task: ScheduledTask): Promise<void> {
   if (!taskRunner) return;
-  const prompt = wrapCronPrompt(`#${task.id}`, task.prompt);
+  const prompt = wrapCronPrompt(
+    `#${task.id}`,
+    task.prompt,
+    DEFAULT_SCHEDULER_TIME_ZONE,
+    task.channel_id,
+  );
   await taskRunner({
     source: 'db-task',
     taskId: task.id,
@@ -642,6 +667,7 @@ async function dispatchConfigJob(job: RuntimeSchedulerJob): Promise<void> {
           jobLabel,
           job.action.message,
           job.schedule.tz || undefined,
+          job.delivery.kind === 'channel' ? job.delivery.to : undefined,
         )
       : job.action.message;
   await taskRunner({

--- a/src/tui-proactive.ts
+++ b/src/tui-proactive.ts
@@ -2,7 +2,7 @@ export function proactiveBadgeLabel(
   source: string | null | undefined,
 ): string | null {
   if (source === 'fullauto') return 'fullauto';
-  if (source === 'eval') return null;
+  if (source === 'eval') return 'eval';
   return 'reminder';
 }
 

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -749,7 +749,11 @@ function isModelCatalogCommandResult(result: GatewayCommandResult): boolean {
 
 function isEvalResultsCommandResult(result: GatewayCommandResult): boolean {
   const title = String(result.title || '').trim();
-  return title === 'Terminal-Bench 2.0 Results' || title === 'tau2 Results';
+  return (
+    title === 'Terminal-Bench 2.0 Results' ||
+    title === 'tau2 Results' ||
+    title === 'LOCOMO Results'
+  );
 }
 
 interface TuiSectionCard {
@@ -757,7 +761,268 @@ interface TuiSectionCard {
   rows: string[];
 }
 
-function parseTuiSectionCards(text: string): TuiSectionCard[] {
+function stripAnsiTui(value: string): string {
+  let output = '';
+  for (let index = 0; index < value.length; ) {
+    if (value.charCodeAt(index) === 27 && value[index + 1] === '[') {
+      index += 2;
+      while (index < value.length) {
+        const code = value.charCodeAt(index);
+        index += 1;
+        if (code >= 64 && code <= 126) break;
+      }
+      continue;
+    }
+    output += value[index] || '';
+    index += 1;
+  }
+  return output;
+}
+
+function visibleTuiLength(value: string): number {
+  return [...stripAnsiTui(value)].length;
+}
+
+function padAnsiTuiEnd(value: string, width: number): string {
+  return `${value}${' '.repeat(Math.max(0, width - visibleTuiLength(value)))}`;
+}
+
+type TuiAnsiToken =
+  | { kind: 'ansi'; value: string }
+  | { kind: 'char'; value: string };
+
+function tokenizeAnsiTui(value: string): TuiAnsiToken[] {
+  const source = String(value || '');
+  const tokens: TuiAnsiToken[] = [];
+  for (let index = 0; index < source.length; ) {
+    if (source.charCodeAt(index) === 27 && source[index + 1] === '[') {
+      const start = index;
+      index += 2;
+      while (index < source.length) {
+        const code = source.charCodeAt(index);
+        index += 1;
+        if (code >= 64 && code <= 126) break;
+      }
+      tokens.push({ kind: 'ansi', value: source.slice(start, index) });
+      continue;
+    }
+    const symbol = [...source.slice(index)][0] || source[index] || '';
+    tokens.push({ kind: 'char', value: symbol });
+    index += symbol.length || 1;
+  }
+  return tokens;
+}
+
+function trimAnsiTuiCell(value: string): string {
+  const tokens = tokenizeAnsiTui(value);
+  const trimmedLeading: TuiAnsiToken[] = [];
+  const pendingAnsi: TuiAnsiToken[] = [];
+  let started = false;
+
+  for (const token of tokens) {
+    if (token.kind === 'ansi') {
+      if (started) {
+        trimmedLeading.push(token);
+      } else {
+        pendingAnsi.push(token);
+      }
+      continue;
+    }
+    if (!started && token.value === ' ') {
+      continue;
+    }
+    if (!started) {
+      trimmedLeading.push(...pendingAnsi);
+      started = true;
+    }
+    trimmedLeading.push(token);
+  }
+
+  const trailingAnsi: TuiAnsiToken[] = [];
+  while (
+    trimmedLeading.length > 0 &&
+    trimmedLeading[trimmedLeading.length - 1]?.kind === 'ansi'
+  ) {
+    trailingAnsi.unshift(trimmedLeading.pop() as TuiAnsiToken);
+  }
+  while (
+    trimmedLeading.length > 0 &&
+    trimmedLeading[trimmedLeading.length - 1]?.kind === 'char' &&
+    trimmedLeading[trimmedLeading.length - 1]?.value === ' '
+  ) {
+    trimmedLeading.pop();
+  }
+  if (trimmedLeading.length === 0) return '';
+  return [...trimmedLeading, ...trailingAnsi]
+    .map((token) => token.value)
+    .join('');
+}
+
+function sliceAnsiTuiVisible(
+  value: string,
+  start: number,
+  width: number,
+): string {
+  if (width <= 0) return '';
+  const end = start + width;
+  const tokens = tokenizeAnsiTui(value);
+  const output: TuiAnsiToken[] = [];
+  const pendingAnsi: TuiAnsiToken[] = [];
+  let visibleIndex = 0;
+  let started = false;
+  let finished = false;
+
+  for (const token of tokens) {
+    if (token.kind === 'ansi') {
+      if (finished) {
+        output.push(token);
+        continue;
+      }
+      if (started || visibleIndex >= start) {
+        pendingAnsi.push(token);
+      }
+      continue;
+    }
+
+    if (visibleIndex >= start && visibleIndex < end) {
+      if (!started) {
+        output.push(...pendingAnsi);
+        pendingAnsi.length = 0;
+        started = true;
+      }
+      output.push(token);
+    } else if (started && visibleIndex >= end) {
+      finished = true;
+      break;
+    }
+    visibleIndex += 1;
+    if (visibleIndex >= end && started) {
+      finished = true;
+    }
+    if (!started) {
+      pendingAnsi.length = 0;
+    }
+  }
+
+  return output.map((token) => token.value).join('');
+}
+
+function truncateAnsiTuiEnd(value: string, width: number): string {
+  if (width <= 0) return '';
+  const source = String(value || '');
+  if (visibleTuiLength(source) <= width) return source;
+  if (width === 1) return '…';
+
+  let output = '';
+  let visibleCount = 0;
+  for (let index = 0; index < source.length; ) {
+    if (source.charCodeAt(index) === 27 && source[index + 1] === '[') {
+      const start = index;
+      index += 2;
+      while (index < source.length) {
+        const code = source.charCodeAt(index);
+        index += 1;
+        if (code >= 64 && code <= 126) break;
+      }
+      output += source.slice(start, index);
+      continue;
+    }
+    const symbol =
+      [...source.slice(index, index + 2)][0] || source[index] || '';
+    const symbolLength = [...symbol].length || 1;
+    if (visibleCount + 1 >= width) {
+      output += '…';
+      return output.endsWith(RESET) ? output : `${output}${RESET}`;
+    }
+    output += symbol;
+    visibleCount += 1;
+    index += symbolLength;
+  }
+  return output;
+}
+
+function looksLikeTuiTableSection(rows: readonly string[]): boolean {
+  if (rows.length < 2) return false;
+  const headerCells = rows[0]?.split(/ {2,}/).filter(Boolean) || [];
+  if (headerCells.length < 3) return false;
+  return /^[- ]+$/u.test(stripAnsiTui(rows[1] || ''));
+}
+
+function reflowTuiTableSection(
+  rows: readonly string[],
+  innerWidth: number,
+): string[] | null {
+  if (!looksLikeTuiTableSection(rows)) return null;
+  const separator = '  ';
+  const sourceWidths = String(rows[1] || '')
+    .split(/ {2,}/)
+    .filter(Boolean)
+    .map((entry) => entry.length);
+  const columnCount = sourceWidths.length;
+  if (columnCount < 3) return null;
+  const parseRow = (row: string): string[] => {
+    let offset = 0;
+    return sourceWidths.map((width, index) => {
+      const cell = trimAnsiTuiCell(sliceAnsiTuiVisible(row, offset, width));
+      offset += width;
+      if (index < sourceWidths.length - 1) {
+        offset += separator.length;
+      }
+      return cell;
+    });
+  };
+  const headerCells = parseRow(rows[0] || '');
+  const bodyRows = rows.slice(2).map((row) => parseRow(row));
+  if (bodyRows.some((row) => row.length !== columnCount)) {
+    return null;
+  }
+  const tableRows = [headerCells, ...bodyRows];
+
+  const metricWidths = Array.from(
+    { length: columnCount - 1 },
+    (_, metricIndex) =>
+      Math.max(
+        visibleTuiLength(tableRows[0]?.[metricIndex + 1] || ''),
+        ...tableRows.map((row) => visibleTuiLength(row[metricIndex + 1] || '')),
+      ),
+  );
+  const minVariantWidth = Math.max(
+    7,
+    visibleTuiLength(tableRows[0]?.[0] || ''),
+  );
+  const availableVariantWidth =
+    innerWidth -
+    metricWidths.reduce((total, width) => total + width, 0) -
+    separator.length * (columnCount - 1);
+  if (availableVariantWidth < minVariantWidth) {
+    return null;
+  }
+  const variantWidth = Math.min(
+    Math.max(
+      minVariantWidth,
+      ...tableRows.slice(1).map((row) => visibleTuiLength(row[0] || '')),
+    ),
+    availableVariantWidth,
+  );
+
+  return tableRows.flatMap((row, index) => {
+    if (index === 1) {
+      return [
+        [variantWidth, ...metricWidths]
+          .map((width) => '-'.repeat(width))
+          .join(separator),
+      ];
+    }
+    const cells = row.map((cell, cellIndex) => {
+      const width =
+        cellIndex === 0 ? variantWidth : metricWidths[cellIndex - 1];
+      return padAnsiTuiEnd(truncateAnsiTuiEnd(cell, width), width);
+    });
+    return [cells.join(separator)];
+  });
+}
+
+export function parseTuiSectionCards(text: string): TuiSectionCard[] {
   const lines = String(text || '')
     .replace(/\r\n?/g, '\n')
     .split('\n');
@@ -794,14 +1059,12 @@ function parseTuiSectionCards(text: string): TuiSectionCard[] {
   return sections;
 }
 
-function renderTuiEvalResultsPanel(
+export function renderTuiEvalResultsPanel(
   sections: readonly TuiSectionCard[],
   columns: number,
 ): string[] {
   const innerWidth = Math.max(16, Math.floor(columns || 80) - 7);
   const lines: string[] = [];
-  const pad = (value: string) =>
-    value + ' '.repeat(Math.max(0, innerWidth - value.length));
   const pushBorder = (
     left: '╭' | '├' | '╰',
     fill: string,
@@ -812,13 +1075,21 @@ function renderTuiEvalResultsPanel(
     );
   };
   const pushRow = (text = '', color = '') => {
-    const content = color ? `${color}${pad(text)}${RESET}` : pad(text);
+    const padded = padAnsiTuiEnd(text, innerWidth);
+    const content = color ? `${color}${padded}${RESET}` : padded;
     lines.push(`  ${MUTED}│${RESET} ${content} ${MUTED}│${RESET}`);
   };
 
   sections.forEach((section, index) => {
     pushBorder(index === 0 ? '╭' : '├', '─', index === 0 ? '╮' : '┤');
     pushRow(section.title, `${BOLD}${GOLD}`);
+    const tableRows = reflowTuiTableSection(section.rows, innerWidth);
+    if (tableRows) {
+      for (const row of tableRows) {
+        pushRow(row);
+      }
+      return;
+    }
     for (const row of section.rows) {
       for (const wrapped of wrapTuiBlock(row, innerWidth, '').split('\n')) {
         pushRow(wrapped);

--- a/src/types/scheduler.ts
+++ b/src/types/scheduler.ts
@@ -16,6 +16,7 @@ export interface ScheduledTask {
 // CamelCase projection of ScheduledTask passed over the container IPC boundary.
 export interface ScheduledTaskInput {
   id: number;
+  channelId: string;
   cronExpr: string;
   runAt: string | null;
   everyMs: number | null;

--- a/src/types/side-effects.ts
+++ b/src/types/side-effects.ts
@@ -5,6 +5,7 @@ export type ScheduleSideEffect =
       runAt?: string;
       everyMs?: number;
       prompt: string;
+      channelId?: string;
     }
   | { action: 'remove'; taskId: number };
 

--- a/tests/agent-side-effects.test.ts
+++ b/tests/agent-side-effects.test.ts
@@ -1,0 +1,78 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, expect, test, vi } from 'vitest';
+
+const ORIGINAL_HOME = process.env.HOME;
+const tempDirs: string[] = [];
+
+function makeTempHome(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-sidefx-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function restoreEnvVar(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  restoreEnvVar('HOME', ORIGINAL_HOME);
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('processSideEffects persists explicit schedule delivery channels', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+
+  const rearmScheduler = vi.fn();
+  vi.doMock('../src/scheduler/scheduler.js', () => ({
+    rearmScheduler,
+  }));
+
+  const { initDatabase, getTasksForSession } = await import('../src/memory/db.ts');
+  const { processSideEffects } = await import('../src/agent/side-effects.ts');
+
+  initDatabase({ quiet: true });
+
+  processSideEffects(
+    {
+      status: 'success',
+      result: 'ok',
+      toolsUsed: [],
+      sideEffects: {
+        schedules: [
+          {
+            action: 'add',
+            everyMs: 1_800_000,
+            channelId: 'ops@example.com',
+            prompt: 'Write a short operational update email.',
+          },
+        ],
+      },
+    },
+    'session-1',
+    'tui',
+  );
+
+  const tasks = getTasksForSession('session-1');
+  expect(tasks).toHaveLength(1);
+  expect(tasks[0]).toMatchObject({
+    session_id: 'session-1',
+    channel_id: 'ops@example.com',
+    every_ms: 1_800_000,
+    prompt: 'Write a short operational update email.',
+  });
+  expect(rearmScheduler).toHaveBeenCalledTimes(1);
+});

--- a/tests/agent-side-effects.test.ts
+++ b/tests/agent-side-effects.test.ts
@@ -41,7 +41,9 @@ test('processSideEffects persists explicit schedule delivery channels', async ()
     rearmScheduler,
   }));
 
-  const { initDatabase, getTasksForSession } = await import('../src/memory/db.ts');
+  const { initDatabase, getTasksForSession } = await import(
+    '../src/memory/db.ts'
+  );
   const { processSideEffects } = await import('../src/agent/side-effects.ts');
 
   initDatabase({ quiet: true });

--- a/tests/command-registry.test.ts
+++ b/tests/command-registry.test.ts
@@ -263,6 +263,9 @@ test('registers eval as a local slash/text command', async () => {
             label: '/eval list',
           }),
           expect.objectContaining({
+            label: '/eval locomo',
+          }),
+          expect.objectContaining({
             label: '/eval swebench-verified',
           }),
         ]),
@@ -272,6 +275,10 @@ test('registers eval as a local slash/text command', async () => {
   expect(mapCanonicalCommandToGatewayArgs(['eval', 'gaia'])).toEqual([
     'eval',
     'gaia',
+  ]);
+  expect(mapCanonicalCommandToGatewayArgs(['eval', 'locomo'])).toEqual([
+    'eval',
+    'locomo',
   ]);
 });
 

--- a/tests/container.cron-tool.test.ts
+++ b/tests/container.cron-tool.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test } from 'vitest';
+
+import {
+  executeTool,
+  getPendingSideEffects,
+  resetSideEffects,
+  setScheduledTasks,
+} from '../container/src/tools.js';
+
+describe.sequential('container cron tool', () => {
+  afterEach(() => {
+    resetSideEffects();
+    setScheduledTasks(undefined);
+  });
+
+  test('accepts an explicit delivery channel when adding a task', async () => {
+    const result = await executeTool(
+      'cron',
+      JSON.stringify({
+        action: 'add',
+        every: 1800,
+        channel: 'ops@example.com',
+        prompt: 'Write a short operational update email.',
+      }),
+    );
+
+    expect(result).toContain('ops@example.com');
+    expect(getPendingSideEffects()?.schedules).toEqual([
+      {
+        action: 'add',
+        everyMs: 1_800_000,
+        channelId: 'ops@example.com',
+        prompt: 'Write a short operational update email.',
+      },
+    ]);
+  });
+
+  test('lists the delivery channel for injected scheduled tasks', async () => {
+    setScheduledTasks([
+      {
+        id: 16,
+        channelId: 'ops@example.com',
+        cronExpr: '',
+        runAt: null,
+        everyMs: 1_800_000,
+        prompt: 'Write a short operational update email.',
+        enabled: 1,
+        lastRun: null,
+        createdAt: '2026-04-11T12:58:18.861Z',
+      },
+    ]);
+
+    const result = await executeTool(
+      'cron',
+      JSON.stringify({ action: 'list' }),
+    );
+
+    expect(result).toContain('ops@example.com');
+    expect(result).toContain('#16');
+  });
+});

--- a/tests/discord-slash-commands.test.ts
+++ b/tests/discord-slash-commands.test.ts
@@ -48,6 +48,7 @@ test('buildSlashCommandDefinitions includes the expanded Discord command set', (
       'rag',
       'ralph',
       'mcp',
+      'memory',
       'plugin',
       'clear',
       'reset',

--- a/tests/eval-command.test.ts
+++ b/tests/eval-command.test.ts
@@ -630,20 +630,14 @@ test('runs managed locomo with current agent override', async () => {
   expect(shellArgs[1]).toContain('current-agent');
 });
 
-test('runs managed locomo with fresh-agent override', async () => {
+test('rejects fresh-agent override for managed locomo', async () => {
   const dataDir = fs.mkdtempSync(
     path.join(os.tmpdir(), 'hybridclaw-eval-run-'),
   );
   installLocomoLayout(dataDir);
-  spawnMock.mockReturnValue({
-    pid: 6798,
-    unref: vi.fn(),
-    on: vi.fn(),
-    off: vi.fn(),
-  });
 
   const { handleEvalCommand } = await import('../src/evals/eval-command.ts');
-  await handleEvalCommand({
+  const result = await handleEvalCommand({
     args: ['--fresh-agent', 'locomo', 'run', '--max-questions', '20'],
     dataDir,
     gatewayBaseUrl: 'http://127.0.0.1:9090',
@@ -652,9 +646,15 @@ test('runs managed locomo with fresh-agent override', async () => {
     effectiveModel: 'hybridai/gpt-4.1-mini',
   });
 
-  const [, shellArgs] = spawnMock.mock.calls[0] as [string, string[]];
-  expect(shellArgs[1]).toContain('--agent-mode');
-  expect(shellArgs[1]).toContain('fresh-request');
+  expect(result.kind).toBe('error');
+  if (result.kind !== 'error') {
+    throw new Error(`Unexpected result kind: ${result.kind}`);
+  }
+  expect(result.title).toBe('LOCOMO Run');
+  expect(result.text).toContain(
+    'Native LOCOMO does not support `--fresh-agent`.',
+  );
+  expect(spawnMock).not.toHaveBeenCalled();
 });
 
 test('runs managed locomo with retrieval mode', async () => {
@@ -1475,6 +1475,77 @@ test('shows locomo retrieval summary in results when a run exists', async () => 
   );
   expect(result.text).not.toContain('Tokens');
   expect(result.text).toContain('Predictions JSON');
+});
+
+test('logs debug when locomo result json is malformed', async () => {
+  const dataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-eval-run-'),
+  );
+  installLocomoLayout(dataDir);
+  const runDir = path.join(dataDir, 'evals', 'eval-locomo-run-badjson-abc123');
+  const jobDir = path.join(dataDir, 'evals', 'locomo', 'jobs', '2026-04-10');
+  fs.mkdirSync(runDir, { recursive: true });
+  fs.mkdirSync(jobDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(jobDir, 'result.json'),
+    '{not valid json',
+    'utf-8',
+  );
+  fs.writeFileSync(
+    path.join(runDir, 'run.json'),
+    JSON.stringify(
+      {
+        runId: 'eval-locomo-run-badjson',
+        suiteId: 'locomo',
+        operation: 'run',
+        pid: 4452,
+        startedAt: '2026-04-10T08:00:00.000Z',
+        finishedAt: '2026-04-10T08:01:00.000Z',
+        exitCode: 0,
+        cwd: path.join(dataDir, 'evals', 'locomo'),
+        command: 'locomo run --budget 4000 --max-questions 20',
+        displayCommand: 'locomo run --budget 4000 --max-questions 20',
+        openaiBaseUrl: 'http://127.0.0.1:9090/v1',
+        model: 'hybridai/gpt-4.1-mini',
+        baseModel: 'hybridai/gpt-4.1-mini',
+        authMode: 'loopback',
+        profile: {
+          workspaceMode: 'current-agent',
+          ablateSystemPrompt: false,
+          includePromptParts: [],
+          omitPromptParts: [],
+        },
+        stdoutPath: path.join(runDir, 'stdout.log'),
+        stderrPath: path.join(runDir, 'stderr.log'),
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(path.join(runDir, 'stdout.log'), `Job dir: ${jobDir}\n`);
+  fs.writeFileSync(path.join(runDir, 'stderr.log'), '');
+
+  const { logger } = await import('../src/logger.ts');
+  const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => logger);
+  const { handleEvalCommand } = await import('../src/evals/eval-command.ts');
+  const result = await handleEvalCommand({
+    args: ['locomo', 'results'],
+    dataDir,
+    gatewayBaseUrl: 'http://127.0.0.1:9090',
+    webApiToken: '',
+    effectiveAgentId: 'main',
+    effectiveModel: 'hybridai/gpt-4.1-mini',
+  });
+
+  expect(result.kind).toBe('info');
+  expect(result.title).toBe('LOCOMO Results');
+  expect(debugSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      runId: 'eval-locomo-run-badjson',
+      resultPath: path.join(jobDir, 'result.json'),
+    }),
+    'Failed to parse LOCOMO result summary',
+  );
 });
 
 test('shows locomo run progress in results while a run is active', async () => {

--- a/tests/eval-command.test.ts
+++ b/tests/eval-command.test.ts
@@ -80,6 +80,66 @@ function installTau2Layout(dataDir: string): void {
   fs.writeFileSync(path.join(installDir, '.venv', 'bin', 'python'), '');
 }
 
+function installLocomoLayout(dataDir: string): void {
+  const installDir = path.join(dataDir, 'evals', 'locomo');
+  fs.mkdirSync(path.join(installDir, 'data'), { recursive: true });
+  fs.writeFileSync(
+    path.join(installDir, 'data', 'locomo10.json'),
+    JSON.stringify([]),
+  );
+  fs.writeFileSync(path.join(installDir, '.hybridclaw-setup-ok'), '');
+}
+
+function writeLocomoResult(
+  jobDir: string,
+  result: {
+    sampleCount?: number;
+    budgetTokens?: number;
+    topK?: number;
+    requestedMode?: string;
+    modes?: Record<
+      string,
+      {
+        overallF1: number;
+        overallHitRate: number;
+        totalQuestions: number;
+      }
+    >;
+  },
+): void {
+  fs.mkdirSync(jobDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(jobDir, 'result.json'),
+    JSON.stringify(
+      {
+        suite: 'locomo',
+        dataset: 'locomo10.json',
+        generatedAt: '2026-04-10T08:00:00.000Z',
+        sampleCount: result.sampleCount ?? 2,
+        budgetTokens: result.budgetTokens ?? 4000,
+        topK: result.topK ?? 20,
+        requestedMode: result.requestedMode ?? 'all',
+        resultPath: path.join(jobDir, 'result.json'),
+        modes: result.modes ?? {
+          recent: {
+            overallF1: 0.125,
+            overallHitRate: 0.25,
+            totalQuestions: 40,
+          },
+          semantic: {
+            overallF1: 0.35,
+            overallHitRate: 0.6,
+            totalQuestions: 40,
+          },
+        },
+        samples: [],
+      },
+      null,
+      2,
+    ),
+  );
+}
+
 function writeTerminalBenchAgentResult(
   jobDir: string,
   taskName: string,
@@ -234,6 +294,29 @@ test('shows managed tau2 usage', async () => {
   );
 });
 
+test('shows managed locomo usage', async () => {
+  const { handleEvalCommand } = await import('../src/evals/eval-command.ts');
+
+  const result = await handleEvalCommand({
+    args: ['locomo'],
+    dataDir: fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-eval-')),
+    gatewayBaseUrl: 'http://127.0.0.1:9090',
+    webApiToken: '',
+    effectiveAgentId: 'main',
+    effectiveModel: 'hybridai/gpt-4.1-mini',
+  });
+
+  expect(result.kind).toBe('info');
+  if (result.kind !== 'info') {
+    throw new Error(`Unexpected result kind: ${result.kind}`);
+  }
+  expect(result.title).toBe('LOCOMO');
+  expect(result.text).toContain('/eval locomo setup');
+  expect(result.text).toContain(
+    '/eval locomo run --budget 4000 --num-samples 2',
+  );
+});
+
 test('starts detached tau2 setup', async () => {
   const dataDir = fs.mkdtempSync(
     path.join(os.tmpdir(), 'hybridclaw-eval-run-'),
@@ -295,6 +378,87 @@ test('reports non-terminal suites as not implemented yet', async () => {
   expect(result.text).toContain('/eval terminal-bench-2.0');
   expect(result.text).toContain('/eval tau2');
   expect(spawnMock).not.toHaveBeenCalled();
+});
+
+test('starts detached locomo setup', async () => {
+  const dataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-eval-run-'),
+  );
+  spawnMock.mockReturnValue({
+    pid: 6791,
+    unref: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  });
+
+  const { handleEvalCommand } = await import('../src/evals/eval-command.ts');
+  const result = await handleEvalCommand({
+    args: ['locomo', 'setup'],
+    dataDir,
+    gatewayBaseUrl: 'http://127.0.0.1:9090',
+    webApiToken: '',
+    effectiveAgentId: 'main',
+    effectiveModel: 'hybridai/gpt-4.1-mini',
+  });
+
+  expect(result.kind).toBe('info');
+  if (result.kind !== 'info') {
+    throw new Error(`Unexpected result kind: ${result.kind}`);
+  }
+  expect(result.title).toBe('LOCOMO Setup Started');
+  expect(result.text).toContain('Command: locomo setup');
+  expect(result.text).toContain(
+    'Setup strategy: native HybridClaw LOCOMO harness with official locomo10 dataset download.',
+  );
+  expect(result.text).toContain('Use `/eval locomo status`');
+  expect(result.text).toContain('Use `/eval locomo results`');
+
+  const [, shellArgs] = spawnMock.mock.calls[0] as [string, string[]];
+  expect(shellArgs[1]).toContain('__eval-locomo-native');
+  expect(shellArgs[1]).toContain('setup');
+  expect(shellArgs[1]).toContain('--install-dir');
+});
+
+test('runs managed locomo with native runner defaults', async () => {
+  const dataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-eval-run-'),
+  );
+  installLocomoLayout(dataDir);
+  spawnMock.mockReturnValue({
+    pid: 6798,
+    unref: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  });
+
+  const { handleEvalCommand } = await import('../src/evals/eval-command.ts');
+  const result = await handleEvalCommand({
+    args: ['locomo', 'run', '--budget', '4000', '--num-samples', '2'],
+    dataDir,
+    gatewayBaseUrl: 'http://127.0.0.1:9090',
+    webApiToken: '',
+    effectiveAgentId: 'main',
+    effectiveModel: 'hybridai/gpt-4.1-mini',
+  });
+
+  expect(result.kind).toBe('info');
+  if (result.kind !== 'info') {
+    throw new Error(`Unexpected result kind: ${result.kind}`);
+  }
+  expect(result.title).toBe('LOCOMO Run Started');
+  expect(result.text).toContain(
+    'Command: locomo run --budget 4000 --num-samples 2',
+  );
+  expect(result.text).toContain(
+    'Use `/eval locomo status` and `/eval locomo results` to follow this run.',
+  );
+
+  const [, shellArgs] = spawnMock.mock.calls[0] as [string, string[]];
+  expect(shellArgs[1]).toContain('__eval-locomo-native');
+  expect(shellArgs[1]).toContain('run');
+  expect(shellArgs[1]).toContain('--install-dir');
+  expect(shellArgs[1]).toContain('--budget');
+  expect(shellArgs[1]).toContain('--num-samples');
 });
 
 test('starts detached terminal-bench setup', async () => {
@@ -672,6 +836,68 @@ test('reports managed suite latest run in status output', async () => {
   expect(result.text).toContain('Errors: 0');
 });
 
+test('reports locomo latest run in status output', async () => {
+  const dataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-eval-run-'),
+  );
+  installLocomoLayout(dataDir);
+  const runDir = path.join(dataDir, 'evals', 'eval-locomo-run-abc123');
+  const jobDir = path.join(dataDir, 'evals', 'locomo', 'jobs', '2026-04-10');
+  fs.mkdirSync(runDir, { recursive: true });
+  writeLocomoResult(jobDir, {});
+  fs.writeFileSync(
+    path.join(runDir, 'run.json'),
+    JSON.stringify(
+      {
+        runId: 'eval-locomo-run',
+        suiteId: 'locomo',
+        operation: 'run',
+        pid: 4451,
+        startedAt: '2026-04-10T08:00:00.000Z',
+        finishedAt: '2026-04-10T08:01:00.000Z',
+        exitCode: 0,
+        cwd: path.join(dataDir, 'evals', 'locomo'),
+        command: `${process.execPath} ${path.join(process.cwd(), 'dist', 'cli.js')} __eval-locomo-native run --install-dir ${path.join(dataDir, 'evals', 'locomo')} --budget 4000 --num-samples 2`,
+        displayCommand: 'locomo run --budget 4000 --num-samples 2',
+        openaiBaseUrl: 'http://127.0.0.1:9090/v1',
+        model: 'hybridai/gpt-4.1-mini',
+        baseModel: 'hybridai/gpt-4.1-mini',
+        authMode: 'loopback',
+        profile: {
+          workspaceMode: 'current-agent',
+          ablateSystemPrompt: false,
+          includePromptParts: [],
+          omitPromptParts: [],
+        },
+        stdoutPath: path.join(runDir, 'stdout.log'),
+        stderrPath: path.join(runDir, 'stderr.log'),
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(path.join(runDir, 'stdout.log'), `Job dir: ${jobDir}\n`);
+  fs.writeFileSync(path.join(runDir, 'stderr.log'), '');
+
+  const { handleEvalCommand } = await import('../src/evals/eval-command.ts');
+  const result = await handleEvalCommand({
+    args: ['locomo', 'status'],
+    dataDir,
+    gatewayBaseUrl: 'http://127.0.0.1:9090',
+    webApiToken: '',
+    effectiveAgentId: 'main',
+    effectiveModel: 'hybridai/gpt-4.1-mini',
+  });
+
+  expect(result.kind).toBe('info');
+  expect(result.text).toContain('Latest run: eval-locomo-run (completed)');
+  expect(result.text).toContain('Dataset:');
+  expect(result.text).toContain('Budget: 4000');
+  expect(result.text).toContain('Top K: 20');
+  expect(result.text).toContain('recent: Hit 0.250 | F1 0.125 | Q 40');
+  expect(result.text).toContain('semantic: Hit 0.600 | F1 0.350 | Q 40');
+});
+
 test('shows generic managed suite setup logs in results', async () => {
   const dataDir = fs.mkdtempSync(
     path.join(os.tmpdir(), 'hybridclaw-eval-run-'),
@@ -730,6 +956,70 @@ test('shows generic managed suite setup logs in results', async () => {
   expect(result.text).not.toContain('Stdout tail:');
   expect(result.text).not.toContain('installed datasets');
   expect(result.text).not.toContain('docker check pending');
+});
+
+test('shows locomo run summary in results when a run exists', async () => {
+  const dataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-eval-run-'),
+  );
+  installLocomoLayout(dataDir);
+  const runDir = path.join(dataDir, 'evals', 'eval-locomo-run-abc123');
+  const jobDir = path.join(dataDir, 'evals', 'locomo', 'jobs', '2026-04-10');
+  fs.mkdirSync(runDir, { recursive: true });
+  writeLocomoResult(jobDir, {});
+  fs.writeFileSync(
+    path.join(runDir, 'run.json'),
+    JSON.stringify(
+      {
+        runId: 'eval-locomo-run',
+        suiteId: 'locomo',
+        operation: 'run',
+        pid: 4452,
+        startedAt: '2026-04-10T08:00:00.000Z',
+        finishedAt: '2026-04-10T08:01:00.000Z',
+        exitCode: 0,
+        cwd: path.join(dataDir, 'evals', 'locomo'),
+        command: 'locomo run --budget 4000 --num-samples 2',
+        displayCommand: 'locomo run --budget 4000 --num-samples 2',
+        openaiBaseUrl: 'http://127.0.0.1:9090/v1',
+        model: 'hybridai/gpt-4.1-mini',
+        baseModel: 'hybridai/gpt-4.1-mini',
+        authMode: 'loopback',
+        profile: {
+          workspaceMode: 'current-agent',
+          ablateSystemPrompt: false,
+          includePromptParts: [],
+          omitPromptParts: [],
+        },
+        stdoutPath: path.join(runDir, 'stdout.log'),
+        stderrPath: path.join(runDir, 'stderr.log'),
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(path.join(runDir, 'stdout.log'), `Job dir: ${jobDir}\n`);
+  fs.writeFileSync(path.join(runDir, 'stderr.log'), '');
+
+  const { handleEvalCommand } = await import('../src/evals/eval-command.ts');
+  const result = await handleEvalCommand({
+    args: ['locomo', 'results'],
+    dataDir,
+    gatewayBaseUrl: 'http://127.0.0.1:9090',
+    webApiToken: '',
+    effectiveAgentId: 'main',
+    effectiveModel: 'hybridai/gpt-4.1-mini',
+  });
+
+  expect(result.kind).toBe('info');
+  expect(result.title).toBe('LOCOMO Results');
+  expect(result.text).toMatch(/Dataset\s+locomo10\.json/);
+  expect(result.text).toMatch(/Samples\s+2/);
+  expect(result.text).toMatch(/Budget\s+4000/);
+  expect(result.text).toMatch(/Mode\s+all/);
+  expect(result.text).toMatch(/recent\s+Hit 0\.250 \| F1 0\.125 \| Q 40/);
+  expect(result.text).toMatch(/semantic\s+Hit 0\.600 \| F1 0\.350 \| Q 40/);
+  expect(result.text).toContain('Result JSON');
 });
 
 test('shows managed suite run summary in results when a run exists', async () => {

--- a/tests/eval-command.test.ts
+++ b/tests/eval-command.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 const spawnMock = vi.fn();
 const spawnSyncMock = vi.fn(() => ({ status: 0 }));
@@ -10,6 +10,8 @@ const isContainerMaxConcurrentExplicitMock = vi.fn(() => false);
 const maxConcurrentContainersState = { value: 5 };
 const originalHome = process.env.HOME;
 const originalHybridClawHome = process.env.HYBRIDCLAW_HOME;
+const originalDisableConfigWatcher =
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
 const originalProcessKill = process.kill;
 const harnessVersion = (
   JSON.parse(
@@ -17,6 +19,24 @@ const harnessVersion = (
   ) as { version: string }
 ).version;
 const harnessLabel = `Harness          HybridClaw v${harnessVersion}`;
+
+function stripAnsi(value: string): string {
+  let output = '';
+  for (let index = 0; index < value.length; ) {
+    if (value.charCodeAt(index) === 27 && value[index + 1] === '[') {
+      index += 2;
+      while (index < value.length) {
+        const code = value.charCodeAt(index);
+        index += 1;
+        if (code >= 64 && code <= 126) break;
+      }
+      continue;
+    }
+    output += value[index] || '';
+    index += 1;
+  }
+  return output;
+}
 
 vi.mock('../src/config/config.ts', async () => {
   const actual = await vi.importActual('../src/config/config.ts');
@@ -41,6 +61,22 @@ vi.mock('node:child_process', () => ({
   spawnSync: (...args: unknown[]) => spawnSyncMock(...args),
 }));
 
+beforeEach(() => {
+  const homeDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-eval-home-'),
+  );
+  const configPath = path.join(homeDir, '.hybridclaw', 'config.json');
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  const config = JSON.parse(
+    fs.readFileSync(path.join(process.cwd(), 'config.example.json'), 'utf-8'),
+  ) as Record<string, unknown>;
+  const ops = config.ops as Record<string, unknown>;
+  ops.dbPath = path.join(homeDir, '.hybridclaw', 'data', 'hybridclaw.db');
+  fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
+  process.env.HOME = homeDir;
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
+});
+
 afterEach(() => {
   spawnMock.mockReset();
   spawnSyncMock.mockClear();
@@ -58,6 +94,12 @@ afterEach(() => {
     delete process.env.HYBRIDCLAW_HOME;
   } else {
     process.env.HYBRIDCLAW_HOME = originalHybridClawHome;
+  }
+  if (originalDisableConfigWatcher == null) {
+    delete process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
+  } else {
+    process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER =
+      originalDisableConfigWatcher;
   }
 });
 
@@ -101,6 +143,21 @@ function writeLocomoResult(
   jobDir: string,
   result: {
     mode?: 'qa' | 'retrieval';
+    matrix?: boolean;
+    matrixSweep?:
+      | 'all'
+      | 'backend'
+      | 'rerank'
+      | 'tokenizer'
+      | 'embedding'
+      | null;
+    retrievalPolicy?: 'prompt-capped' | 'budget-only' | null;
+    retrievalQueryMode?: 'raw' | 'no-stopwords' | null;
+    retrievalBackend?: 'cosine' | 'full-text' | 'hybrid' | null;
+    retrievalRerank?: 'none' | 'bm25' | null;
+    retrievalTokenizer?: 'unicode61' | 'porter' | 'trigram' | null;
+    retrievalEmbeddingProvider?: 'hashed' | 'transformers' | null;
+    retrievalEmbeddingModel?: string | null;
     sampleCount?: number;
     questionCount?: number;
     budgetTokens?: number;
@@ -131,6 +188,42 @@ function writeLocomoResult(
       {
         suite: 'locomo',
         mode: result.mode ?? 'qa',
+        matrix: result.matrix === true,
+        matrixSweep:
+          result.matrix === true ? (result.matrixSweep ?? 'all') : null,
+        retrievalPolicy:
+          result.mode === 'retrieval'
+            ? (result.retrievalPolicy ?? 'budget-only')
+            : null,
+        retrievalQueryMode:
+          result.mode === 'retrieval' && result.matrix !== true
+            ? (result.retrievalQueryMode ?? 'no-stopwords')
+            : null,
+        retrievalBackend:
+          result.mode === 'retrieval' && result.matrix !== true
+            ? (result.retrievalBackend ?? 'cosine')
+            : null,
+        retrievalRerank:
+          result.mode === 'retrieval' && result.matrix !== true
+            ? (result.retrievalRerank ?? 'bm25')
+            : null,
+        retrievalTokenizer:
+          result.mode === 'retrieval' && result.matrix !== true
+            ? (result.retrievalTokenizer ?? 'unicode61')
+            : null,
+        retrievalEmbeddingProvider:
+          result.mode === 'retrieval' && result.matrix !== true
+            ? (result.retrievalEmbeddingProvider ?? 'hashed')
+            : null,
+        retrievalEmbeddingModel:
+          result.mode === 'retrieval'
+            ? (result.retrievalEmbeddingModel ??
+              (result.retrievalEmbeddingProvider === 'transformers'
+                ? 'onnx-community/embeddinggemma-300m-ONNX'
+                : result.matrix === true && result.matrixSweep === 'embedding'
+                  ? 'onnx-community/embeddinggemma-300m-ONNX'
+                  : null))
+            : null,
         dataset: 'locomo10.json',
         generatedAt: '2026-04-10T08:00:00.000Z',
         model:
@@ -145,23 +238,26 @@ function writeLocomoResult(
           result.mode === 'retrieval' ? (result.contextF1 ?? 0.113) : null,
         resultPath: path.join(jobDir, 'result.json'),
         predictionsPath: path.join(jobDir, 'predictions.json'),
-        categories: result.categories ?? {
-          '1': {
-            meanScore: 0.625,
-            questionCount: 16,
-            contextF1: result.mode === 'retrieval' ? 0.125 : null,
-          },
-          '2': {
-            meanScore: 0.5,
-            questionCount: 8,
-            contextF1: result.mode === 'retrieval' ? 0.1 : null,
-          },
-          '5': {
-            meanScore: 0.75,
-            questionCount: 16,
-            contextF1: result.mode === 'retrieval' ? 0.05 : null,
-          },
-        },
+        categories:
+          result.matrix === true
+            ? {}
+            : (result.categories ?? {
+                '1': {
+                  meanScore: 0.625,
+                  questionCount: 16,
+                  contextF1: result.mode === 'retrieval' ? 0.125 : null,
+                },
+                '2': {
+                  meanScore: 0.5,
+                  questionCount: 8,
+                  contextF1: result.mode === 'retrieval' ? 0.1 : null,
+                },
+                '5': {
+                  meanScore: 0.75,
+                  questionCount: 16,
+                  contextF1: result.mode === 'retrieval' ? 0.05 : null,
+                },
+              }),
         tokenUsage:
           result.mode === 'retrieval'
             ? null
@@ -171,6 +267,96 @@ function writeLocomoResult(
                 totalTokens: 1380,
                 responsesWithUsage: 40,
               }),
+        variantCount: result.matrix === true ? 16 : null,
+        bestVariantId: result.matrix === true ? 'full-text' : null,
+        bestVariantLabel: result.matrix === true ? 'full-text' : null,
+        variants:
+          result.matrix === true
+            ? [
+                {
+                  id: 'cosine',
+                  label: 'cosine',
+                  retrievalPolicy: 'budget-only',
+                  retrievalQueryMode: 'no-stopwords',
+                  retrievalBackend: 'cosine',
+                  retrievalRerank: 'none',
+                  retrievalTokenizer: 'unicode61',
+                  retrievalEmbeddingProvider: 'hashed',
+                  sampleCount: result.sampleCount ?? 2,
+                  questionCount: result.questionCount ?? 40,
+                  overallScore: 0.535,
+                  contextF1: 0.002,
+                  categories: {
+                    '1': {
+                      meanScore: 0.31,
+                      questionCount: 16,
+                      contextF1: 0.002,
+                    },
+                    '2': {
+                      meanScore: 0.652,
+                      questionCount: 8,
+                      contextF1: 0.001,
+                    },
+                    '3': {
+                      meanScore: 0.326,
+                      questionCount: 4,
+                      contextF1: 0.002,
+                    },
+                    '4': {
+                      meanScore: 0.602,
+                      questionCount: 8,
+                      contextF1: 0.002,
+                    },
+                    '5': {
+                      meanScore: 0.51,
+                      questionCount: 4,
+                      contextF1: 0.002,
+                    },
+                  },
+                },
+                {
+                  id: 'full-text',
+                  label: 'full-text',
+                  retrievalPolicy: 'budget-only',
+                  retrievalQueryMode: 'no-stopwords',
+                  retrievalBackend: 'full-text',
+                  retrievalRerank: 'none',
+                  retrievalTokenizer: 'unicode61',
+                  retrievalEmbeddingProvider: 'hashed',
+                  sampleCount: result.sampleCount ?? 2,
+                  questionCount: result.questionCount ?? 40,
+                  overallScore: result.overallScore ?? 0.747,
+                  contextF1: result.contextF1 ?? 0.002,
+                  categories: {
+                    '1': {
+                      meanScore: 0.481,
+                      questionCount: 16,
+                      contextF1: 0.002,
+                    },
+                    '2': {
+                      meanScore: 0.837,
+                      questionCount: 8,
+                      contextF1: 0.001,
+                    },
+                    '3': {
+                      meanScore: 0.423,
+                      questionCount: 4,
+                      contextF1: 0.002,
+                    },
+                    '4': {
+                      meanScore: 0.808,
+                      questionCount: 8,
+                      contextF1: 0.003,
+                    },
+                    '5': {
+                      meanScore: 0.805,
+                      questionCount: 4,
+                      contextF1: 0.002,
+                    },
+                  },
+                },
+              ]
+            : [],
         samples: [],
       },
       null,
@@ -183,6 +369,21 @@ function writeLocomoProgress(
   jobDir: string,
   progress: {
     mode?: 'qa' | 'retrieval';
+    matrix?: boolean;
+    matrixSweep?:
+      | 'all'
+      | 'backend'
+      | 'rerank'
+      | 'tokenizer'
+      | 'embedding'
+      | null;
+    retrievalPolicy?: 'prompt-capped' | 'budget-only' | null;
+    retrievalQueryMode?: 'raw' | 'no-stopwords' | null;
+    retrievalBackend?: 'cosine' | 'full-text' | 'hybrid' | null;
+    retrievalRerank?: 'none' | 'bm25' | null;
+    retrievalTokenizer?: 'unicode61' | 'porter' | 'trigram' | null;
+    retrievalEmbeddingProvider?: 'hashed' | 'transformers' | null;
+    retrievalEmbeddingModel?: string | null;
     sampleCount?: number;
     completedSampleCount?: number;
     questionCount?: number;
@@ -191,7 +392,10 @@ function writeLocomoProgress(
     overallScore?: number;
     contextF1?: number | null;
     model?: string;
+    currentPhase?: 'warming-embedding' | 'ingesting' | 'evaluating' | null;
     currentSampleId?: string | null;
+    currentSampleEmbeddedTurnCount?: number | null;
+    currentSampleTurnCount?: number | null;
     currentSampleQuestionCount?: number | null;
     currentSampleQuestionTotal?: number | null;
     tokenUsage?: {
@@ -217,6 +421,43 @@ function writeLocomoProgress(
       {
         suite: 'locomo',
         mode: progress.mode ?? 'qa',
+        matrix: progress.matrix === true,
+        matrixSweep:
+          progress.matrix === true ? (progress.matrixSweep ?? 'all') : null,
+        retrievalPolicy:
+          progress.mode === 'retrieval'
+            ? (progress.retrievalPolicy ?? 'budget-only')
+            : null,
+        retrievalQueryMode:
+          progress.mode === 'retrieval' && progress.matrix !== true
+            ? (progress.retrievalQueryMode ?? 'no-stopwords')
+            : null,
+        retrievalBackend:
+          progress.mode === 'retrieval' && progress.matrix !== true
+            ? (progress.retrievalBackend ?? 'cosine')
+            : null,
+        retrievalRerank:
+          progress.mode === 'retrieval' && progress.matrix !== true
+            ? (progress.retrievalRerank ?? 'bm25')
+            : null,
+        retrievalTokenizer:
+          progress.mode === 'retrieval' && progress.matrix !== true
+            ? (progress.retrievalTokenizer ?? 'unicode61')
+            : null,
+        retrievalEmbeddingProvider:
+          progress.mode === 'retrieval' && progress.matrix !== true
+            ? (progress.retrievalEmbeddingProvider ?? 'hashed')
+            : null,
+        retrievalEmbeddingModel:
+          progress.mode === 'retrieval'
+            ? (progress.retrievalEmbeddingModel ??
+              (progress.retrievalEmbeddingProvider === 'transformers'
+                ? 'onnx-community/embeddinggemma-300m-ONNX'
+                : progress.matrix === true &&
+                    progress.matrixSweep === 'embedding'
+                  ? 'onnx-community/embeddinggemma-300m-ONNX'
+                  : null))
+            : null,
         dataset: 'locomo10.json',
         updatedAt: '2026-04-10T08:00:00.000Z',
         model:
@@ -231,19 +472,26 @@ function writeLocomoProgress(
         overallScore: progress.overallScore ?? 0.429,
         contextF1:
           progress.mode === 'retrieval' ? (progress.contextF1 ?? 0.091) : null,
+        currentPhase: progress.currentPhase ?? null,
         currentSampleId: progress.currentSampleId ?? 'conv-26',
+        currentSampleEmbeddedTurnCount:
+          progress.currentSampleEmbeddedTurnCount ?? null,
+        currentSampleTurnCount: progress.currentSampleTurnCount ?? null,
         currentSampleQuestionCount: progress.currentSampleQuestionCount ?? 7,
         currentSampleQuestionTotal: progress.currentSampleQuestionTotal ?? 20,
         progressPath: path.join(jobDir, 'progress.json'),
         resultPath: path.join(jobDir, 'result.json'),
         predictionsPath: path.join(jobDir, 'predictions.json'),
-        categories: progress.categories ?? {
-          '1': {
-            meanScore: 0.571,
-            questionCount: 7,
-            contextF1: progress.mode === 'retrieval' ? 0.111 : null,
-          },
-        },
+        categories:
+          progress.matrix === true
+            ? {}
+            : (progress.categories ?? {
+                '1': {
+                  meanScore: 0.571,
+                  questionCount: 7,
+                  contextF1: progress.mode === 'retrieval' ? 0.111 : null,
+                },
+              }),
         tokenUsage:
           progress.mode === 'retrieval'
             ? null
@@ -253,6 +501,69 @@ function writeLocomoProgress(
                 totalTokens: 245,
                 responsesWithUsage: 7,
               }),
+        variantCount: progress.matrix === true ? 18 : null,
+        completedVariantCount: progress.matrix === true ? 1 : null,
+        currentVariant:
+          progress.matrix === true
+            ? {
+                id: 'hybrid-bm25',
+                label: 'hybrid + bm25',
+                retrievalPolicy: 'budget-only',
+                retrievalQueryMode: 'no-stopwords',
+                retrievalBackend: 'hybrid',
+                retrievalRerank: 'bm25',
+                retrievalTokenizer: 'unicode61',
+                retrievalEmbeddingProvider: 'hashed',
+                sampleCount: progress.sampleCount ?? 2,
+                completedSampleCount: progress.completedSampleCount ?? 0,
+                questionCount: progress.questionCount ?? 20,
+                completedQuestionCount: progress.completedQuestionCount ?? 7,
+                overallScore: progress.overallScore ?? 0.429,
+                contextF1: progress.contextF1 ?? 0.091,
+                currentPhase: progress.currentPhase ?? null,
+                currentSampleId: progress.currentSampleId ?? 'conv-26',
+                currentSampleEmbeddedTurnCount:
+                  progress.currentSampleEmbeddedTurnCount ?? null,
+                currentSampleTurnCount: progress.currentSampleTurnCount ?? null,
+                currentSampleQuestionCount:
+                  progress.currentSampleQuestionCount ?? 7,
+                currentSampleQuestionTotal:
+                  progress.currentSampleQuestionTotal ?? 20,
+                categories: {
+                  '1': {
+                    meanScore: 0.571,
+                    questionCount: 7,
+                    contextF1: 0.111,
+                  },
+                },
+              }
+            : null,
+        variants:
+          progress.matrix === true
+            ? [
+                {
+                  id: 'cosine',
+                  label: 'cosine',
+                  retrievalPolicy: 'budget-only',
+                  retrievalQueryMode: 'no-stopwords',
+                  retrievalBackend: 'cosine',
+                  retrievalRerank: 'none',
+                  retrievalTokenizer: 'unicode61',
+                  retrievalEmbeddingProvider: 'hashed',
+                  sampleCount: progress.sampleCount ?? 2,
+                  questionCount: progress.questionCount ?? 20,
+                  overallScore: 0.535,
+                  contextF1: 0.002,
+                  categories: {
+                    '1': {
+                      meanScore: 0.31,
+                      questionCount: 7,
+                      contextF1: 0.002,
+                    },
+                  },
+                },
+              ]
+            : [],
       },
       null,
       2,
@@ -671,7 +982,24 @@ test('runs managed locomo with retrieval mode', async () => {
 
   const { handleEvalCommand } = await import('../src/evals/eval-command.ts');
   await handleEvalCommand({
-    args: ['locomo', 'run', '--mode', 'retrieval', '--max-questions', '20'],
+    args: [
+      'locomo',
+      'run',
+      '--mode',
+      'retrieval',
+      '--retrieval-query',
+      'no-stopwords',
+      '--retrieval-backend',
+      'full-text',
+      '--retrieval-rerank',
+      'bm25',
+      '--retrieval-tokenizer',
+      'trigram',
+      '--retrieval-embedding',
+      'transformers',
+      '--max-questions',
+      '20',
+    ],
     dataDir,
     gatewayBaseUrl: 'http://127.0.0.1:9090',
     webApiToken: '',
@@ -682,6 +1010,197 @@ test('runs managed locomo with retrieval mode', async () => {
   const [, shellArgs] = spawnMock.mock.calls[0] as [string, string[]];
   expect(shellArgs[1]).toContain('--mode');
   expect(shellArgs[1]).toContain('retrieval');
+  expect(shellArgs[1]).toContain('--retrieval-query');
+  expect(shellArgs[1]).toContain('no-stopwords');
+  expect(shellArgs[1]).toContain('--retrieval-backend');
+  expect(shellArgs[1]).toContain('full-text');
+  expect(shellArgs[1]).toContain('--retrieval-rerank');
+  expect(shellArgs[1]).toContain('bm25');
+  expect(shellArgs[1]).toContain('--retrieval-tokenizer');
+  expect(shellArgs[1]).toContain('trigram');
+  expect(shellArgs[1]).toContain('--retrieval-embedding');
+  expect(shellArgs[1]).toContain('transformers');
+});
+
+test('runs managed locomo retrieval matrix sweep', async () => {
+  const dataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-eval-run-'),
+  );
+  installLocomoLayout(dataDir);
+  spawnMock.mockReturnValue({
+    pid: 6798,
+    unref: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  });
+
+  const { handleEvalCommand } = await import('../src/evals/eval-command.ts');
+  await handleEvalCommand({
+    args: [
+      'locomo',
+      'run',
+      '--mode',
+      'retrieval',
+      '--matrix',
+      '--budget',
+      '4000',
+    ],
+    dataDir,
+    gatewayBaseUrl: 'http://127.0.0.1:9090',
+    webApiToken: '',
+    effectiveAgentId: 'main',
+    effectiveModel: 'hybridai/gpt-4.1-mini',
+  });
+
+  const [, shellArgs] = spawnMock.mock.calls[0] as [string, string[]];
+  expect(shellArgs[1]).toContain('--mode');
+  expect(shellArgs[1]).toContain('retrieval');
+  expect(shellArgs[1]).toContain('--matrix');
+  expect(shellArgs[1]).not.toContain('--retrieval-query');
+  expect(shellArgs[1]).not.toContain('--retrieval-backend');
+  expect(shellArgs[1]).not.toContain('--retrieval-rerank');
+});
+
+test('runs managed locomo retrieval rerank matrix sweep', async () => {
+  const dataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-eval-run-'),
+  );
+  installLocomoLayout(dataDir);
+  spawnMock.mockReturnValue({
+    pid: 6798,
+    unref: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  });
+
+  const { handleEvalCommand } = await import('../src/evals/eval-command.ts');
+  await handleEvalCommand({
+    args: [
+      'locomo',
+      'run',
+      '--mode',
+      'retrieval',
+      '--matrix',
+      'rerank',
+      '--budget',
+      '4000',
+    ],
+    dataDir,
+    gatewayBaseUrl: 'http://127.0.0.1:9090',
+    webApiToken: '',
+    effectiveAgentId: 'main',
+    effectiveModel: 'hybridai/gpt-4.1-mini',
+  });
+
+  const [, shellArgs] = spawnMock.mock.calls[0] as [string, string[]];
+  expect(shellArgs[1]).toContain('--matrix');
+  expect(shellArgs[1]).toContain('rerank');
+  expect(shellArgs[1]).not.toContain('--retrieval-query');
+  expect(shellArgs[1]).not.toContain('--retrieval-backend');
+  expect(shellArgs[1]).not.toContain('--retrieval-rerank');
+});
+
+test('runs managed locomo retrieval embedding matrix sweep', async () => {
+  const dataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-eval-run-'),
+  );
+  installLocomoLayout(dataDir);
+  spawnMock.mockReturnValue({
+    pid: 6798,
+    unref: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  });
+
+  const { handleEvalCommand } = await import('../src/evals/eval-command.ts');
+  await handleEvalCommand({
+    args: [
+      'locomo',
+      'run',
+      '--mode',
+      'retrieval',
+      '--matrix',
+      'embedding',
+      '--budget',
+      '4000',
+    ],
+    dataDir,
+    gatewayBaseUrl: 'http://127.0.0.1:9090',
+    webApiToken: '',
+    effectiveAgentId: 'main',
+    effectiveModel: 'hybridai/gpt-4.1-mini',
+  });
+
+  const [, shellArgs] = spawnMock.mock.calls[0] as [string, string[]];
+  expect(shellArgs[1]).toContain('--matrix');
+  expect(shellArgs[1]).toContain('embedding');
+  expect(shellArgs[1]).not.toContain('--retrieval-query');
+  expect(shellArgs[1]).not.toContain('--retrieval-backend');
+  expect(shellArgs[1]).not.toContain('--retrieval-rerank');
+  expect(shellArgs[1]).not.toContain('--retrieval-tokenizer');
+  expect(shellArgs[1]).not.toContain('--retrieval-embedding');
+});
+
+test('does not apply memory config defaults to locomo retrieval flags', async () => {
+  const dataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-eval-run-'),
+  );
+  installLocomoLayout(dataDir);
+  const homeDir = process.env.HOME;
+  if (!homeDir) {
+    throw new Error('Expected HOME to be set for eval-command tests.');
+  }
+  const configPath = path.join(homeDir, '.hybridclaw', 'config.json');
+  const config = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as {
+    memory: {
+      queryMode: string;
+      backend: string;
+      rerank: string;
+      tokenizer: string;
+      embedding: {
+        provider: string;
+      };
+    };
+  };
+  config.memory.queryMode = 'no-stopwords';
+  config.memory.backend = 'full-text';
+  config.memory.rerank = 'bm25';
+  config.memory.tokenizer = 'trigram';
+  config.memory.embedding.provider = 'transformers';
+  fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
+  spawnMock.mockReturnValue({
+    pid: 6798,
+    unref: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  });
+
+  const { handleEvalCommand } = await import('../src/evals/eval-command.ts');
+  const result = await handleEvalCommand({
+    args: ['locomo', 'run', '--mode', 'retrieval', '--max-questions', '20'],
+    dataDir,
+    gatewayBaseUrl: 'http://127.0.0.1:9090',
+    webApiToken: '',
+    effectiveAgentId: 'main',
+    effectiveModel: 'hybridai/gpt-4.1-mini',
+  });
+
+  expect(result.kind).toBe('info');
+  if (result.kind !== 'info') {
+    throw new Error(`Unexpected result kind: ${result.kind}`);
+  }
+  expect(result.text).not.toContain('--retrieval-query');
+  expect(result.text).not.toContain('--retrieval-backend');
+  expect(result.text).not.toContain('--retrieval-rerank');
+  expect(result.text).not.toContain('--retrieval-tokenizer');
+  expect(result.text).not.toContain('--retrieval-embedding');
+
+  const [, shellArgs] = spawnMock.mock.calls[0] as [string, string[]];
+  expect(shellArgs[1]).not.toContain('--retrieval-query');
+  expect(shellArgs[1]).not.toContain('--retrieval-backend');
+  expect(shellArgs[1]).not.toContain('--retrieval-rerank');
+  expect(shellArgs[1]).not.toContain('--retrieval-tokenizer');
+  expect(shellArgs[1]).not.toContain('--retrieval-embedding');
 });
 
 test('starts detached terminal-bench setup', async () => {
@@ -1143,6 +1662,7 @@ test('reports locomo retrieval latest run in status output', async () => {
   fs.mkdirSync(runDir, { recursive: true });
   writeLocomoResult(jobDir, {
     mode: 'retrieval',
+    retrievalEmbeddingProvider: 'transformers',
     overallScore: 0.812,
     contextF1: 0.143,
     categories: {
@@ -1200,6 +1720,12 @@ test('reports locomo retrieval latest run in status output', async () => {
 
   expect(result.kind).toBe('info');
   expect(result.text).toContain('Mode: retrieval');
+  expect(result.text).toContain(
+    'Recall policy: uncapped recall, token budget only',
+  );
+  expect(result.text).toContain('Query prep: stopwords removed');
+  expect(result.text).toContain('Backend: cosine');
+  expect(result.text).toContain('Rerank: BM25 before budget');
   expect(result.text).toContain('Hit rate: 0.812');
   expect(result.text).toContain('Context F1: 0.143');
   expect(result.text).toContain(
@@ -1409,6 +1935,7 @@ test('shows locomo retrieval summary in results when a run exists', async () => 
   fs.mkdirSync(runDir, { recursive: true });
   writeLocomoResult(jobDir, {
     mode: 'retrieval',
+    retrievalEmbeddingProvider: 'transformers',
     overallScore: 0.812,
     contextF1: 0.143,
     categories: {
@@ -1467,6 +1994,17 @@ test('shows locomo retrieval summary in results when a run exists', async () => 
   expect(result.kind).toBe('info');
   expect(result.title).toBe('LOCOMO Results');
   expect(result.text).toMatch(/Mode\s+retrieval/);
+  expect(result.text).toMatch(
+    /Recall policy\s+uncapped recall, token budget only/,
+  );
+  expect(result.text).toMatch(/Query prep\s+stopwords removed/);
+  expect(result.text).toMatch(/Backend\s+cosine/);
+  expect(result.text).toMatch(/Rerank\s+BM25 before budget/);
+  expect(result.text).toMatch(/Tokenizer\s+unicode61/);
+  expect(result.text).toMatch(/Embedding\s+Transformers\.js/);
+  expect(result.text).toMatch(
+    /Embedding model\s+onnx-community\/embeddinggemma-300m-ONNX/,
+  );
   expect(result.text).not.toMatch(/Evaluated model\s+/);
   expect(result.text).toMatch(/Hit rate\s+0\.812/);
   expect(result.text).toMatch(/Context F1\s+0\.143/);
@@ -1475,6 +2013,82 @@ test('shows locomo retrieval summary in results when a run exists', async () => 
   );
   expect(result.text).not.toContain('Tokens');
   expect(result.text).toContain('Predictions JSON');
+});
+
+test('shows locomo retrieval matrix summary table in results', async () => {
+  const dataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-eval-run-'),
+  );
+  installLocomoLayout(dataDir);
+  const runDir = path.join(dataDir, 'evals', 'eval-locomo-run-matrix-abc123');
+  const jobDir = path.join(dataDir, 'evals', 'locomo', 'jobs', '2026-04-11');
+  fs.mkdirSync(runDir, { recursive: true });
+  writeLocomoResult(jobDir, {
+    mode: 'retrieval',
+    matrix: true,
+    matrixSweep: 'rerank',
+    overallScore: 0.747,
+    contextF1: 0.002,
+  });
+  fs.writeFileSync(
+    path.join(runDir, 'run.json'),
+    JSON.stringify(
+      {
+        runId: 'eval-locomo-run-matrix',
+        suiteId: 'locomo',
+        operation: 'run',
+        pid: 4452,
+        startedAt: '2026-04-11T08:00:00.000Z',
+        finishedAt: '2026-04-11T08:01:00.000Z',
+        exitCode: 0,
+        cwd: path.join(dataDir, 'evals', 'locomo'),
+        command: 'locomo run --mode retrieval --matrix --budget 4000',
+        displayCommand: 'locomo run --mode retrieval --matrix --budget 4000',
+        openaiBaseUrl: 'http://127.0.0.1:9090/v1',
+        model: 'hybridai/gpt-4.1-mini',
+        baseModel: 'hybridai/gpt-4.1-mini',
+        authMode: 'loopback',
+        profile: {
+          workspaceMode: 'current-agent',
+          ablateSystemPrompt: false,
+          includePromptParts: [],
+          omitPromptParts: [],
+        },
+        stdoutPath: path.join(runDir, 'stdout.log'),
+        stderrPath: path.join(runDir, 'stderr.log'),
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(path.join(runDir, 'stdout.log'), `Job dir: ${jobDir}\n`);
+  fs.writeFileSync(path.join(runDir, 'stderr.log'), '');
+
+  const { handleEvalCommand } = await import('../src/evals/eval-command.ts');
+  const result = await handleEvalCommand({
+    args: ['locomo', 'results'],
+    dataDir,
+    gatewayBaseUrl: 'http://127.0.0.1:9090',
+    webApiToken: '',
+    effectiveAgentId: 'main',
+    effectiveModel: 'hybridai/gpt-4.1-mini',
+  });
+
+  expect(result.kind).toBe('info');
+  expect(result.title).toBe('LOCOMO Results');
+  expect(result.text).toMatch(/Sweep\s+rerank/);
+  expect(result.text).toMatch(/Variants\s+2\/16/);
+  expect(result.text).toMatch(/Best variant\s+full-text/);
+  expect(result.text).toMatch(/Best hit rate\s+0\.747/);
+  expect(result.text).not.toMatch(/Query prep\s+/);
+  expect(result.text).not.toMatch(/Backend\s+/);
+  expect(result.text).toContain('\x1b[7m');
+  expect(result.text).toContain('\x1b[1;93m');
+  const plainText = stripAnsi(result.text);
+  expect(plainText).toContain('full-text');
+  expect(plainText).toContain('0.7470');
+  expect(result.text).toContain('Variant');
+  expect(result.text).toContain('HitRate');
 });
 
 test('logs debug when locomo result json is malformed', async () => {
@@ -1603,11 +2217,193 @@ test('shows locomo run progress in results while a run is active', async () => {
   expect(result.kind).toBe('info');
   expect(result.title).toBe('LOCOMO Results');
   expect(result.text).toMatch(/Status\s+running/);
+  expect(result.text).toContain('⏳ Progress');
   expect(result.text).toMatch(/Questions\s+7\/20/);
   expect(result.text).toMatch(/Completed samples\s+0\/2/);
   expect(result.text).toMatch(/Score so far\s+0\.429/);
   expect(result.text).toMatch(/Current sample\s+conv-26/);
-  expect(result.text).toMatch(/Current sample questions\s+7\/20/);
+  expect(result.text).toMatch(/Evaluation\s+\[[#-]+\]\s+7\/20\s+\(35%\)/);
+  expect(result.text).toContain('Progress JSON');
+});
+
+test('shows locomo retrieval matrix progress in results while a run is active', async () => {
+  const dataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-eval-run-'),
+  );
+  installLocomoLayout(dataDir);
+  const runDir = path.join(dataDir, 'evals', 'eval-locomo-run-matrix-abc123');
+  const jobDir = path.join(dataDir, 'evals', 'locomo', 'jobs', '2026-04-11');
+  fs.mkdirSync(runDir, { recursive: true });
+  writeLocomoProgress(jobDir, {
+    mode: 'retrieval',
+    matrix: true,
+    matrixSweep: 'rerank',
+    sampleCount: 10,
+    completedSampleCount: 3,
+    questionCount: 1986,
+    completedQuestionCount: 441,
+    overallScore: 0.612,
+    contextF1: 0.003,
+    currentPhase: 'ingesting',
+    currentSampleId: 'conv-30',
+    currentSampleEmbeddedTurnCount: 37,
+    currentSampleTurnCount: 239,
+    currentSampleQuestionCount: 18,
+    currentSampleQuestionTotal: 105,
+  });
+  process.kill = vi.fn();
+  fs.writeFileSync(
+    path.join(runDir, 'run.json'),
+    JSON.stringify(
+      {
+        runId: 'eval-locomo-run-matrix',
+        suiteId: 'locomo',
+        operation: 'run',
+        pid: 4452,
+        startedAt: '2026-04-11T08:00:00.000Z',
+        cwd: path.join(dataDir, 'evals', 'locomo'),
+        command: 'locomo run --mode retrieval --matrix --budget 4000',
+        displayCommand: 'locomo run --mode retrieval --matrix --budget 4000',
+        openaiBaseUrl: 'http://127.0.0.1:9090/v1',
+        model: 'hybridai/gpt-4.1-mini',
+        baseModel: 'hybridai/gpt-4.1-mini',
+        authMode: 'loopback',
+        profile: {
+          workspaceMode: 'current-agent',
+          ablateSystemPrompt: false,
+          includePromptParts: [],
+          omitPromptParts: [],
+        },
+        stdoutPath: path.join(runDir, 'stdout.log'),
+        stderrPath: path.join(runDir, 'stderr.log'),
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(path.join(runDir, 'stdout.log'), `Job dir: ${jobDir}\n`);
+  fs.writeFileSync(path.join(runDir, 'stderr.log'), '');
+
+  const { handleEvalCommand } = await import('../src/evals/eval-command.ts');
+  const result = await handleEvalCommand({
+    args: ['locomo', 'results'],
+    dataDir,
+    gatewayBaseUrl: 'http://127.0.0.1:9090',
+    webApiToken: '',
+    effectiveAgentId: 'main',
+    effectiveModel: 'hybridai/gpt-4.1-mini',
+  });
+
+  expect(result.kind).toBe('info');
+  expect(result.title).toBe('LOCOMO Results');
+  expect(result.text).toMatch(/Status\s+running/);
+  expect(result.text).toContain('⏳ Progress');
+  expect(result.text).toMatch(/Sweep\s+rerank/);
+  expect(result.text).toMatch(/Variants\s+1\/18/);
+  expect(result.text).toMatch(/Variants\s+\[[#-]+\]\s+1\/18\s+\(6%\)/);
+  expect(result.text).toMatch(/Phase\s+ingesting memory/);
+  expect(result.text).toMatch(/Current variant\s+hybrid \+ bm25/);
+  expect(result.text).toMatch(/Current sample\s+conv-30/);
+  expect(result.text).toMatch(/Embedding\s+\[[#-]+\]\s+37\/239\s+\(15%\)/);
+  expect(result.text).toMatch(/Evaluation\s+\[[#-]+\]\s+441\/1986\s+\(22%\)/);
+  expect(result.text).toMatch(/Current hit rate\s+0\.612/);
+  expect(result.text).toContain('Variants So Far');
+  expect(result.text).toContain('hybrid + bm25 (running)');
+  expect(result.text).toContain('Progress JSON');
+});
+
+test('prefers locomo progress over completed summary while the run is still active', async () => {
+  const dataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-eval-run-'),
+  );
+  installLocomoLayout(dataDir);
+  const runDir = path.join(dataDir, 'evals', 'eval-locomo-run-active-abc123');
+  const jobDir = path.join(dataDir, 'evals', 'locomo', 'jobs', '2026-04-11');
+  fs.mkdirSync(runDir, { recursive: true });
+  writeLocomoResult(jobDir, {
+    mode: 'retrieval',
+    retrievalEmbeddingProvider: 'transformers',
+    retrievalEmbeddingModel: 'onnx-community/embeddinggemma-300m-ONNX',
+    sampleCount: 1,
+    questionCount: 1,
+    overallScore: 1,
+    contextF1: 0.001,
+    categories: {
+      '2': {
+        meanScore: 1,
+        questionCount: 1,
+        contextF1: 0.001,
+      },
+    },
+  });
+  writeLocomoProgress(jobDir, {
+    mode: 'retrieval',
+    sampleCount: 1,
+    completedSampleCount: 0,
+    questionCount: 1,
+    completedQuestionCount: 0,
+    overallScore: null,
+    contextF1: null,
+    currentPhase: 'ingesting',
+    currentSampleId: 'conv-26',
+    currentSampleEmbeddedTurnCount: 150,
+    currentSampleTurnCount: 419,
+  });
+  process.kill = vi.fn();
+  fs.writeFileSync(
+    path.join(runDir, 'run.json'),
+    JSON.stringify(
+      {
+        runId: 'eval-locomo-run-active',
+        suiteId: 'locomo',
+        operation: 'run',
+        pid: 4452,
+        startedAt: '2026-04-11T08:00:00.000Z',
+        cwd: path.join(dataDir, 'evals', 'locomo'),
+        command:
+          'locomo run --mode retrieval --retrieval-embedding transformers --budget 4000 --max-questions 1',
+        displayCommand:
+          'locomo run --mode retrieval --retrieval-embedding transformers --budget 4000 --max-questions 1',
+        openaiBaseUrl: 'http://127.0.0.1:9090/v1',
+        model: 'hybridai/gpt-5.4-nano',
+        baseModel: 'hybridai/gpt-5.4-nano',
+        authMode: 'loopback',
+        profile: {
+          workspaceMode: 'current-agent',
+          ablateSystemPrompt: false,
+          includePromptParts: [],
+          omitPromptParts: [],
+        },
+        stdoutPath: path.join(runDir, 'stdout.log'),
+        stderrPath: path.join(runDir, 'stderr.log'),
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(path.join(runDir, 'stdout.log'), `Job dir: ${jobDir}\n`);
+  fs.writeFileSync(path.join(runDir, 'stderr.log'), '');
+
+  const { handleEvalCommand } = await import('../src/evals/eval-command.ts');
+  const result = await handleEvalCommand({
+    args: ['locomo', 'results'],
+    dataDir,
+    gatewayBaseUrl: 'http://127.0.0.1:9090',
+    webApiToken: '',
+    effectiveAgentId: 'main',
+    effectiveModel: 'hybridai/gpt-4.1-mini',
+  });
+
+  expect(result.kind).toBe('info');
+  expect(result.title).toBe('LOCOMO Results');
+  expect(result.text).toMatch(/Status\s+running/);
+  expect(result.text).toContain('⏳ Progress');
+  expect(result.text).toMatch(/Phase\s+ingesting memory/);
+  expect(result.text).toMatch(/Current sample\s+conv-26/);
+  expect(result.text).toMatch(/Embedding\s+\[[#-]+\]\s+150\/419\s+\(36%\)/);
+  expect(result.text).toMatch(/Evaluation\s+\[[#-]+\]\s+0\/1\s+\(0%\)/);
+  expect(result.text).not.toMatch(/Hit rate\s+1/);
+  expect(result.text).not.toMatch(/Category 2 \| Hit 1\.000/);
   expect(result.text).toContain('Progress JSON');
 });
 

--- a/tests/eval-command.test.ts
+++ b/tests/eval-command.test.ts
@@ -2082,11 +2082,10 @@ test('shows locomo retrieval matrix summary table in results', async () => {
   expect(result.text).toMatch(/Best hit rate\s+0\.747/);
   expect(result.text).not.toMatch(/Query prep\s+/);
   expect(result.text).not.toMatch(/Backend\s+/);
-  expect(result.text).toContain('\x1b[7m');
-  expect(result.text).toContain('\x1b[1;93m');
+  expect(result.text).toContain('\x1b[30;103m');
   const plainText = stripAnsi(result.text);
   expect(plainText).toContain('full-text');
-  expect(plainText).toContain('0.7470');
+  expect(plainText).toContain('0.7470*');
   expect(result.text).toContain('Variant');
   expect(result.text).toContain('HitRate');
 });

--- a/tests/eval-command.test.ts
+++ b/tests/eval-command.test.ts
@@ -61,6 +61,13 @@ afterEach(() => {
   }
 });
 
+function quoteForShell(value: string): string {
+  if (process.platform === 'win32') {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
 function installTau2Layout(dataDir: string): void {
   const installDir = path.join(dataDir, 'evals', 'tau2-bench');
   fs.mkdirSync(path.join(installDir, '.git'), { recursive: true });
@@ -93,46 +100,159 @@ function installLocomoLayout(dataDir: string): void {
 function writeLocomoResult(
   jobDir: string,
   result: {
+    mode?: 'qa' | 'retrieval';
     sampleCount?: number;
+    questionCount?: number;
     budgetTokens?: number;
-    topK?: number;
-    requestedMode?: string;
-    modes?: Record<
+    overallScore?: number;
+    contextF1?: number | null;
+    model?: string;
+    tokenUsage?: {
+      promptTokens: number;
+      completionTokens: number;
+      totalTokens: number;
+      responsesWithUsage: number;
+    };
+    categories?: Record<
       string,
       {
-        overallF1: number;
-        overallHitRate: number;
-        totalQuestions: number;
+        meanScore: number;
+        questionCount: number;
+        contextF1?: number | null;
+      }
+    >;
+  },
+): void {
+  fs.mkdirSync(jobDir, { recursive: true });
+  fs.writeFileSync(path.join(jobDir, 'predictions.json'), JSON.stringify([]));
+  fs.writeFileSync(
+    path.join(jobDir, 'result.json'),
+    JSON.stringify(
+      {
+        suite: 'locomo',
+        mode: result.mode ?? 'qa',
+        dataset: 'locomo10.json',
+        generatedAt: '2026-04-10T08:00:00.000Z',
+        model:
+          result.mode === 'retrieval'
+            ? null
+            : (result.model ?? 'hybridai/gpt-4.1-mini'),
+        sampleCount: result.sampleCount ?? 2,
+        questionCount: result.questionCount ?? 40,
+        budgetTokens: result.budgetTokens ?? 4000,
+        overallScore: result.overallScore ?? 0.537,
+        contextF1:
+          result.mode === 'retrieval' ? (result.contextF1 ?? 0.113) : null,
+        resultPath: path.join(jobDir, 'result.json'),
+        predictionsPath: path.join(jobDir, 'predictions.json'),
+        categories: result.categories ?? {
+          '1': {
+            meanScore: 0.625,
+            questionCount: 16,
+            contextF1: result.mode === 'retrieval' ? 0.125 : null,
+          },
+          '2': {
+            meanScore: 0.5,
+            questionCount: 8,
+            contextF1: result.mode === 'retrieval' ? 0.1 : null,
+          },
+          '5': {
+            meanScore: 0.75,
+            questionCount: 16,
+            contextF1: result.mode === 'retrieval' ? 0.05 : null,
+          },
+        },
+        tokenUsage:
+          result.mode === 'retrieval'
+            ? null
+            : (result.tokenUsage ?? {
+                promptTokens: 1200,
+                completionTokens: 180,
+                totalTokens: 1380,
+                responsesWithUsage: 40,
+              }),
+        samples: [],
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+function writeLocomoProgress(
+  jobDir: string,
+  progress: {
+    mode?: 'qa' | 'retrieval';
+    sampleCount?: number;
+    completedSampleCount?: number;
+    questionCount?: number;
+    completedQuestionCount?: number;
+    budgetTokens?: number;
+    overallScore?: number;
+    contextF1?: number | null;
+    model?: string;
+    currentSampleId?: string | null;
+    currentSampleQuestionCount?: number | null;
+    currentSampleQuestionTotal?: number | null;
+    tokenUsage?: {
+      promptTokens: number;
+      completionTokens: number;
+      totalTokens: number;
+      responsesWithUsage: number;
+    };
+    categories?: Record<
+      string,
+      {
+        meanScore: number;
+        questionCount: number;
+        contextF1?: number | null;
       }
     >;
   },
 ): void {
   fs.mkdirSync(jobDir, { recursive: true });
   fs.writeFileSync(
-    path.join(jobDir, 'result.json'),
+    path.join(jobDir, 'progress.json'),
     JSON.stringify(
       {
         suite: 'locomo',
+        mode: progress.mode ?? 'qa',
         dataset: 'locomo10.json',
-        generatedAt: '2026-04-10T08:00:00.000Z',
-        sampleCount: result.sampleCount ?? 2,
-        budgetTokens: result.budgetTokens ?? 4000,
-        topK: result.topK ?? 20,
-        requestedMode: result.requestedMode ?? 'all',
+        updatedAt: '2026-04-10T08:00:00.000Z',
+        model:
+          progress.mode === 'retrieval'
+            ? null
+            : (progress.model ?? 'hybridai/gpt-4.1-mini'),
+        budgetTokens: progress.budgetTokens ?? 4000,
+        sampleCount: progress.sampleCount ?? 2,
+        completedSampleCount: progress.completedSampleCount ?? 0,
+        questionCount: progress.questionCount ?? 20,
+        completedQuestionCount: progress.completedQuestionCount ?? 7,
+        overallScore: progress.overallScore ?? 0.429,
+        contextF1:
+          progress.mode === 'retrieval' ? (progress.contextF1 ?? 0.091) : null,
+        currentSampleId: progress.currentSampleId ?? 'conv-26',
+        currentSampleQuestionCount: progress.currentSampleQuestionCount ?? 7,
+        currentSampleQuestionTotal: progress.currentSampleQuestionTotal ?? 20,
+        progressPath: path.join(jobDir, 'progress.json'),
         resultPath: path.join(jobDir, 'result.json'),
-        modes: result.modes ?? {
-          recent: {
-            overallF1: 0.125,
-            overallHitRate: 0.25,
-            totalQuestions: 40,
-          },
-          semantic: {
-            overallF1: 0.35,
-            overallHitRate: 0.6,
-            totalQuestions: 40,
+        predictionsPath: path.join(jobDir, 'predictions.json'),
+        categories: progress.categories ?? {
+          '1': {
+            meanScore: 0.571,
+            questionCount: 7,
+            contextF1: progress.mode === 'retrieval' ? 0.111 : null,
           },
         },
-        samples: [],
+        tokenUsage:
+          progress.mode === 'retrieval'
+            ? null
+            : (progress.tokenUsage ?? {
+                promptTokens: 210,
+                completionTokens: 35,
+                totalTokens: 245,
+                responsesWithUsage: 7,
+              }),
       },
       null,
       2,
@@ -313,7 +433,11 @@ test('shows managed locomo usage', async () => {
   expect(result.title).toBe('LOCOMO');
   expect(result.text).toContain('/eval locomo setup');
   expect(result.text).toContain(
-    '/eval locomo run --budget 4000 --num-samples 2',
+    '/eval locomo run --budget 4000 --max-questions 20',
+  );
+  expect(result.text).toContain('`--max-questions` for quick smoke runs');
+  expect(result.text).toContain(
+    'By default, LOCOMO creates one fresh template-seeded agent per conversation sample.',
   );
 });
 
@@ -414,12 +538,20 @@ test('starts detached locomo setup', async () => {
   expect(result.text).toContain('Use `/eval locomo results`');
 
   const [, shellArgs] = spawnMock.mock.calls[0] as [string, string[]];
+  expect(shellArgs[1]).toContain(
+    quoteForShell(
+      path.join(process.cwd(), 'node_modules', 'tsx', 'dist', 'cli.mjs'),
+    ),
+  );
+  expect(shellArgs[1]).toContain(
+    quoteForShell(path.join(process.cwd(), 'src', 'cli.ts')),
+  );
   expect(shellArgs[1]).toContain('__eval-locomo-native');
   expect(shellArgs[1]).toContain('setup');
   expect(shellArgs[1]).toContain('--install-dir');
 });
 
-test('runs managed locomo with native runner defaults', async () => {
+test('runs managed locomo with question cap flag', async () => {
   const dataDir = fs.mkdtempSync(
     path.join(os.tmpdir(), 'hybridclaw-eval-run-'),
   );
@@ -433,7 +565,7 @@ test('runs managed locomo with native runner defaults', async () => {
 
   const { handleEvalCommand } = await import('../src/evals/eval-command.ts');
   const result = await handleEvalCommand({
-    args: ['locomo', 'run', '--budget', '4000', '--num-samples', '2'],
+    args: ['locomo', 'run', '--budget', '4000', '--max-questions', '20'],
     dataDir,
     gatewayBaseUrl: 'http://127.0.0.1:9090',
     webApiToken: '',
@@ -447,18 +579,109 @@ test('runs managed locomo with native runner defaults', async () => {
   }
   expect(result.title).toBe('LOCOMO Run Started');
   expect(result.text).toContain(
-    'Command: locomo run --budget 4000 --num-samples 2',
+    'Command: locomo run --budget 4000 --max-questions 20',
   );
   expect(result.text).toContain(
     'Use `/eval locomo status` and `/eval locomo results` to follow this run.',
   );
 
   const [, shellArgs] = spawnMock.mock.calls[0] as [string, string[]];
+  expect(shellArgs[1]).toContain(
+    quoteForShell(
+      path.join(process.cwd(), 'node_modules', 'tsx', 'dist', 'cli.mjs'),
+    ),
+  );
+  expect(shellArgs[1]).toContain(
+    quoteForShell(path.join(process.cwd(), 'src', 'cli.ts')),
+  );
   expect(shellArgs[1]).toContain('__eval-locomo-native');
   expect(shellArgs[1]).toContain('run');
   expect(shellArgs[1]).toContain('--install-dir');
+  expect(shellArgs[1]).toContain('--agent-mode');
+  expect(shellArgs[1]).toContain('conversation-fresh');
   expect(shellArgs[1]).toContain('--budget');
-  expect(shellArgs[1]).toContain('--num-samples');
+  expect(shellArgs[1]).toContain('--max-questions');
+});
+
+test('runs managed locomo with current agent override', async () => {
+  const dataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-eval-run-'),
+  );
+  installLocomoLayout(dataDir);
+  spawnMock.mockReturnValue({
+    pid: 6798,
+    unref: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  });
+
+  const { handleEvalCommand } = await import('../src/evals/eval-command.ts');
+  await handleEvalCommand({
+    args: ['--current-agent', 'locomo', 'run', '--max-questions', '20'],
+    dataDir,
+    gatewayBaseUrl: 'http://127.0.0.1:9090',
+    webApiToken: '',
+    effectiveAgentId: 'charly',
+    effectiveModel: 'hybridai/gpt-4.1-mini',
+  });
+
+  const [, shellArgs] = spawnMock.mock.calls[0] as [string, string[]];
+  expect(shellArgs[1]).toContain('--agent-mode');
+  expect(shellArgs[1]).toContain('current-agent');
+});
+
+test('runs managed locomo with fresh-agent override', async () => {
+  const dataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-eval-run-'),
+  );
+  installLocomoLayout(dataDir);
+  spawnMock.mockReturnValue({
+    pid: 6798,
+    unref: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  });
+
+  const { handleEvalCommand } = await import('../src/evals/eval-command.ts');
+  await handleEvalCommand({
+    args: ['--fresh-agent', 'locomo', 'run', '--max-questions', '20'],
+    dataDir,
+    gatewayBaseUrl: 'http://127.0.0.1:9090',
+    webApiToken: '',
+    effectiveAgentId: 'charly',
+    effectiveModel: 'hybridai/gpt-4.1-mini',
+  });
+
+  const [, shellArgs] = spawnMock.mock.calls[0] as [string, string[]];
+  expect(shellArgs[1]).toContain('--agent-mode');
+  expect(shellArgs[1]).toContain('fresh-request');
+});
+
+test('runs managed locomo with retrieval mode', async () => {
+  const dataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-eval-run-'),
+  );
+  installLocomoLayout(dataDir);
+  spawnMock.mockReturnValue({
+    pid: 6798,
+    unref: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  });
+
+  const { handleEvalCommand } = await import('../src/evals/eval-command.ts');
+  await handleEvalCommand({
+    args: ['locomo', 'run', '--mode', 'retrieval', '--max-questions', '20'],
+    dataDir,
+    gatewayBaseUrl: 'http://127.0.0.1:9090',
+    webApiToken: '',
+    effectiveAgentId: 'main',
+    effectiveModel: 'hybridai/gpt-4.1-mini',
+  });
+
+  const [, shellArgs] = spawnMock.mock.calls[0] as [string, string[]];
+  expect(shellArgs[1]).toContain('--mode');
+  expect(shellArgs[1]).toContain('retrieval');
 });
 
 test('starts detached terminal-bench setup', async () => {
@@ -545,6 +768,14 @@ test('runs managed terminal-bench with native HybridClaw runner defaults', async
   );
 
   const [, shellArgs] = spawnMock.mock.calls[0] as [string, string[]];
+  expect(shellArgs[1]).toContain(
+    quoteForShell(
+      path.join(process.cwd(), 'node_modules', 'tsx', 'dist', 'cli.mjs'),
+    ),
+  );
+  expect(shellArgs[1]).toContain(
+    quoteForShell(path.join(process.cwd(), 'src', 'cli.ts')),
+  );
   expect(shellArgs[1]).toContain('__eval-terminal-bench-native');
   expect(shellArgs[1]).toContain('--install-dir');
   expect(shellArgs[1]).toContain('--data-dir');
@@ -892,10 +1123,151 @@ test('reports locomo latest run in status output', async () => {
   expect(result.kind).toBe('info');
   expect(result.text).toContain('Latest run: eval-locomo-run (completed)');
   expect(result.text).toContain('Dataset:');
+  expect(result.text).toContain('Questions: 40');
   expect(result.text).toContain('Budget: 4000');
-  expect(result.text).toContain('Top K: 20');
-  expect(result.text).toContain('recent: Hit 0.250 | F1 0.125 | Q 40');
-  expect(result.text).toContain('semantic: Hit 0.600 | F1 0.350 | Q 40');
+  expect(result.text).toContain('Overall score: 0.537');
+  expect(result.text).toContain('cat1: Category 1 | Score 0.625 | Q 16');
+  expect(result.text).toContain(
+    'Tokens: 1380 total (1200 prompt + 180 completion)',
+  );
+  expect(result.text).toContain('Predictions:');
+});
+
+test('reports locomo retrieval latest run in status output', async () => {
+  const dataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-eval-run-'),
+  );
+  installLocomoLayout(dataDir);
+  const runDir = path.join(dataDir, 'evals', 'eval-locomo-run-abc123');
+  const jobDir = path.join(dataDir, 'evals', 'locomo', 'jobs', '2026-04-10');
+  fs.mkdirSync(runDir, { recursive: true });
+  writeLocomoResult(jobDir, {
+    mode: 'retrieval',
+    overallScore: 0.812,
+    contextF1: 0.143,
+    categories: {
+      '1': {
+        meanScore: 0.875,
+        questionCount: 16,
+        contextF1: 0.188,
+      },
+    },
+  });
+  fs.writeFileSync(
+    path.join(runDir, 'run.json'),
+    JSON.stringify(
+      {
+        runId: 'eval-locomo-run',
+        suiteId: 'locomo',
+        operation: 'run',
+        pid: 4451,
+        startedAt: '2026-04-10T08:00:00.000Z',
+        finishedAt: '2026-04-10T08:01:00.000Z',
+        exitCode: 0,
+        cwd: path.join(dataDir, 'evals', 'locomo'),
+        command: `${process.execPath} ${path.join(process.cwd(), 'dist', 'cli.js')} __eval-locomo-native run --install-dir ${path.join(dataDir, 'evals', 'locomo')} --mode retrieval --budget 4000 --num-samples 2`,
+        displayCommand:
+          'locomo run --mode retrieval --budget 4000 --num-samples 2',
+        openaiBaseUrl: 'http://127.0.0.1:9090/v1',
+        model: 'hybridai/gpt-4.1-mini',
+        baseModel: 'hybridai/gpt-4.1-mini',
+        authMode: 'loopback',
+        profile: {
+          workspaceMode: 'current-agent',
+          ablateSystemPrompt: false,
+          includePromptParts: [],
+          omitPromptParts: [],
+        },
+        stdoutPath: path.join(runDir, 'stdout.log'),
+        stderrPath: path.join(runDir, 'stderr.log'),
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(path.join(runDir, 'stdout.log'), `Job dir: ${jobDir}\n`);
+  fs.writeFileSync(path.join(runDir, 'stderr.log'), '');
+
+  const { handleEvalCommand } = await import('../src/evals/eval-command.ts');
+  const result = await handleEvalCommand({
+    args: ['locomo', 'status'],
+    dataDir,
+    gatewayBaseUrl: 'http://127.0.0.1:9090',
+    webApiToken: '',
+    effectiveAgentId: 'main',
+    effectiveModel: 'hybridai/gpt-4.1-mini',
+  });
+
+  expect(result.kind).toBe('info');
+  expect(result.text).toContain('Mode: retrieval');
+  expect(result.text).toContain('Hit rate: 0.812');
+  expect(result.text).toContain('Context F1: 0.143');
+  expect(result.text).toContain(
+    'cat1: Category 1 | Hit 0.875 | F1 0.188 | Q 16',
+  );
+  expect(result.text).not.toContain('Tokens:');
+});
+
+test('reports locomo in-flight progress in status output', async () => {
+  const dataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-eval-run-'),
+  );
+  installLocomoLayout(dataDir);
+  const runDir = path.join(dataDir, 'evals', 'eval-locomo-run-abc123');
+  const jobDir = path.join(dataDir, 'evals', 'locomo', 'jobs', '2026-04-10');
+  fs.mkdirSync(runDir, { recursive: true });
+  writeLocomoProgress(jobDir, {});
+  process.kill = vi.fn();
+  fs.writeFileSync(
+    path.join(runDir, 'run.json'),
+    JSON.stringify(
+      {
+        runId: 'eval-locomo-run',
+        suiteId: 'locomo',
+        operation: 'run',
+        pid: 4451,
+        startedAt: '2026-04-10T08:00:00.000Z',
+        cwd: path.join(dataDir, 'evals', 'locomo'),
+        command: `${process.execPath} ${path.join(process.cwd(), 'dist', 'cli.js')} __eval-locomo-native run --install-dir ${path.join(dataDir, 'evals', 'locomo')} --budget 4000 --max-questions 20`,
+        displayCommand: 'locomo run --budget 4000 --max-questions 20',
+        openaiBaseUrl: 'http://127.0.0.1:9090/v1',
+        model: 'hybridai/gpt-4.1-mini',
+        baseModel: 'hybridai/gpt-4.1-mini',
+        authMode: 'loopback',
+        profile: {
+          workspaceMode: 'current-agent',
+          ablateSystemPrompt: false,
+          includePromptParts: [],
+          omitPromptParts: [],
+        },
+        stdoutPath: path.join(runDir, 'stdout.log'),
+        stderrPath: path.join(runDir, 'stderr.log'),
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(path.join(runDir, 'stdout.log'), `Job dir: ${jobDir}\n`);
+  fs.writeFileSync(path.join(runDir, 'stderr.log'), '');
+
+  const { handleEvalCommand } = await import('../src/evals/eval-command.ts');
+  const result = await handleEvalCommand({
+    args: ['locomo', 'status'],
+    dataDir,
+    gatewayBaseUrl: 'http://127.0.0.1:9090',
+    webApiToken: '',
+    effectiveAgentId: 'main',
+    effectiveModel: 'hybridai/gpt-4.1-mini',
+  });
+
+  expect(result.kind).toBe('info');
+  expect(result.text).toContain('Latest run: eval-locomo-run (running)');
+  expect(result.text).toContain('Completed samples: 0/2');
+  expect(result.text).toContain('Questions: 7/20');
+  expect(result.text).toContain('Score so far: 0.429');
+  expect(result.text).toContain('Current sample: conv-26');
+  expect(result.text).toContain('Current sample questions: 7/20');
+  expect(result.text).toContain('Progress JSON:');
 });
 
 test('shows generic managed suite setup logs in results', async () => {
@@ -1013,13 +1385,159 @@ test('shows locomo run summary in results when a run exists', async () => {
 
   expect(result.kind).toBe('info');
   expect(result.title).toBe('LOCOMO Results');
+  expect(result.text).toMatch(/Evaluated model\s+hybridai\/gpt-4\.1-mini/);
   expect(result.text).toMatch(/Dataset\s+locomo10\.json/);
   expect(result.text).toMatch(/Samples\s+2/);
+  expect(result.text).toMatch(/Questions\s+40/);
   expect(result.text).toMatch(/Budget\s+4000/);
-  expect(result.text).toMatch(/Mode\s+all/);
-  expect(result.text).toMatch(/recent\s+Hit 0\.250 \| F1 0\.125 \| Q 40/);
-  expect(result.text).toMatch(/semantic\s+Hit 0\.600 \| F1 0\.350 \| Q 40/);
+  expect(result.text).toMatch(/Overall score\s+0\.537/);
+  expect(result.text).toMatch(/cat1\s+Category 1 \| Score 0\.625 \| Q 16/);
+  expect(result.text).toMatch(
+    /Tokens\s+1380 total \(1200 prompt \+ 180 completion\)/,
+  );
+  expect(result.text).toContain('Predictions JSON');
   expect(result.text).toContain('Result JSON');
+});
+
+test('shows locomo retrieval summary in results when a run exists', async () => {
+  const dataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-eval-run-'),
+  );
+  installLocomoLayout(dataDir);
+  const runDir = path.join(dataDir, 'evals', 'eval-locomo-run-abc123');
+  const jobDir = path.join(dataDir, 'evals', 'locomo', 'jobs', '2026-04-10');
+  fs.mkdirSync(runDir, { recursive: true });
+  writeLocomoResult(jobDir, {
+    mode: 'retrieval',
+    overallScore: 0.812,
+    contextF1: 0.143,
+    categories: {
+      '1': {
+        meanScore: 0.875,
+        questionCount: 16,
+        contextF1: 0.188,
+      },
+    },
+  });
+  fs.writeFileSync(
+    path.join(runDir, 'run.json'),
+    JSON.stringify(
+      {
+        runId: 'eval-locomo-run',
+        suiteId: 'locomo',
+        operation: 'run',
+        pid: 4452,
+        startedAt: '2026-04-10T08:00:00.000Z',
+        finishedAt: '2026-04-10T08:01:00.000Z',
+        exitCode: 0,
+        cwd: path.join(dataDir, 'evals', 'locomo'),
+        command: 'locomo run --mode retrieval --budget 4000 --num-samples 2',
+        displayCommand:
+          'locomo run --mode retrieval --budget 4000 --num-samples 2',
+        openaiBaseUrl: 'http://127.0.0.1:9090/v1',
+        model: 'hybridai/gpt-4.1-mini',
+        baseModel: 'hybridai/gpt-4.1-mini',
+        authMode: 'loopback',
+        profile: {
+          workspaceMode: 'current-agent',
+          ablateSystemPrompt: false,
+          includePromptParts: [],
+          omitPromptParts: [],
+        },
+        stdoutPath: path.join(runDir, 'stdout.log'),
+        stderrPath: path.join(runDir, 'stderr.log'),
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(path.join(runDir, 'stdout.log'), `Job dir: ${jobDir}\n`);
+  fs.writeFileSync(path.join(runDir, 'stderr.log'), '');
+
+  const { handleEvalCommand } = await import('../src/evals/eval-command.ts');
+  const result = await handleEvalCommand({
+    args: ['locomo', 'results'],
+    dataDir,
+    gatewayBaseUrl: 'http://127.0.0.1:9090',
+    webApiToken: '',
+    effectiveAgentId: 'main',
+    effectiveModel: 'hybridai/gpt-4.1-mini',
+  });
+
+  expect(result.kind).toBe('info');
+  expect(result.title).toBe('LOCOMO Results');
+  expect(result.text).toMatch(/Mode\s+retrieval/);
+  expect(result.text).not.toMatch(/Evaluated model\s+/);
+  expect(result.text).toMatch(/Hit rate\s+0\.812/);
+  expect(result.text).toMatch(/Context F1\s+0\.143/);
+  expect(result.text).toMatch(
+    /cat1\s+Category 1 \| Hit 0\.875 \| F1 0\.188 \| Q 16/,
+  );
+  expect(result.text).not.toContain('Tokens');
+  expect(result.text).toContain('Predictions JSON');
+});
+
+test('shows locomo run progress in results while a run is active', async () => {
+  const dataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-eval-run-'),
+  );
+  installLocomoLayout(dataDir);
+  const runDir = path.join(dataDir, 'evals', 'eval-locomo-run-abc123');
+  const jobDir = path.join(dataDir, 'evals', 'locomo', 'jobs', '2026-04-10');
+  fs.mkdirSync(runDir, { recursive: true });
+  writeLocomoProgress(jobDir, {});
+  process.kill = vi.fn();
+  fs.writeFileSync(
+    path.join(runDir, 'run.json'),
+    JSON.stringify(
+      {
+        runId: 'eval-locomo-run',
+        suiteId: 'locomo',
+        operation: 'run',
+        pid: 4452,
+        startedAt: '2026-04-10T08:00:00.000Z',
+        cwd: path.join(dataDir, 'evals', 'locomo'),
+        command: 'locomo run --budget 4000 --max-questions 20',
+        displayCommand: 'locomo run --budget 4000 --max-questions 20',
+        openaiBaseUrl: 'http://127.0.0.1:9090/v1',
+        model: 'hybridai/gpt-4.1-mini',
+        baseModel: 'hybridai/gpt-4.1-mini',
+        authMode: 'loopback',
+        profile: {
+          workspaceMode: 'current-agent',
+          ablateSystemPrompt: false,
+          includePromptParts: [],
+          omitPromptParts: [],
+        },
+        stdoutPath: path.join(runDir, 'stdout.log'),
+        stderrPath: path.join(runDir, 'stderr.log'),
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(path.join(runDir, 'stdout.log'), `Job dir: ${jobDir}\n`);
+  fs.writeFileSync(path.join(runDir, 'stderr.log'), '');
+
+  const { handleEvalCommand } = await import('../src/evals/eval-command.ts');
+  const result = await handleEvalCommand({
+    args: ['locomo', 'results'],
+    dataDir,
+    gatewayBaseUrl: 'http://127.0.0.1:9090',
+    webApiToken: '',
+    effectiveAgentId: 'main',
+    effectiveModel: 'hybridai/gpt-4.1-mini',
+  });
+
+  expect(result.kind).toBe('info');
+  expect(result.title).toBe('LOCOMO Results');
+  expect(result.text).toMatch(/Status\s+running/);
+  expect(result.text).toMatch(/Questions\s+7\/20/);
+  expect(result.text).toMatch(/Completed samples\s+0\/2/);
+  expect(result.text).toMatch(/Score so far\s+0\.429/);
+  expect(result.text).toMatch(/Current sample\s+conv-26/);
+  expect(result.text).toMatch(/Current sample questions\s+7\/20/);
+  expect(result.text).toContain('Progress JSON');
 });
 
 test('shows managed suite run summary in results when a run exists', async () => {

--- a/tests/gateway-service.eval-command.test.ts
+++ b/tests/gateway-service.eval-command.test.ts
@@ -53,8 +53,12 @@ test('eval help is available through the gateway command path', async () => {
   expect(result.text).toContain(
     '`/eval [--current-agent|--fresh-agent] [--ablate-system] [--include-prompt=<parts>] [--omit-prompt=<parts>] <shell command...>`',
   );
+  expect(result.text).toContain(
+    '/eval locomo [setup|run|status|stop|results|logs]',
+  );
   expect(result.text).toContain('/eval tau2 [setup|run|status|stop|results]');
   expect(result.text).toContain('swebench-verified');
+  expect(result.text).toContain('locomo');
   expect(result.text).toContain('terminal-bench-2.0');
   expect(result.text).toContain('agentbench');
   expect(result.text).toContain('gaia');

--- a/tests/gateway-service.memory-inspect.test.ts
+++ b/tests/gateway-service.memory-inspect.test.ts
@@ -135,7 +135,9 @@ test('memory inspect reports the built-in memory layers for the current session'
     'User asked: Render the deploy animation I responded: I can render it after the assets are in place.',
   );
   expect(result.text).toContain('6. Canonical cross-channel memory');
-  expect(result.text).toContain('Remember the deploy checklist from yesterday.');
+  expect(result.text).toContain(
+    'Remember the deploy checklist from yesterday.',
+  );
 });
 
 test('memory inspect rejects remote sessions', async () => {

--- a/tests/gateway-service.memory-inspect.test.ts
+++ b/tests/gateway-service.memory-inspect.test.ts
@@ -1,0 +1,226 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import { setupGatewayTest } from './helpers/gateway-test-setup.js';
+
+const { setupHome } = setupGatewayTest({
+  tempHomePrefix: 'hybridclaw-gateway-memory-inspect-',
+});
+
+test('memory inspect reports the built-in memory layers for the current session', async () => {
+  setupHome();
+
+  const { currentDateStampInTimezone } = await import(
+    '../container/shared/workspace-time.js'
+  );
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { agentWorkspaceDir } = await import('../src/infra/ipc.js');
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+  const { handleGatewayCommand, resolveCanonicalContextScope } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  const session = memoryService.getOrCreateSession(
+    'session-memory-inspect',
+    null,
+    'web',
+    'main',
+  );
+  const canonicalScope = resolveCanonicalContextScope(session);
+  const workspacePath = agentWorkspaceDir('main');
+  fs.mkdirSync(path.join(workspacePath, 'memory'), { recursive: true });
+  fs.mkdirSync(path.join(workspacePath, '.session-transcripts'), {
+    recursive: true,
+  });
+  fs.writeFileSync(
+    path.join(workspacePath, 'MEMORY.md'),
+    '# MEMORY.md - Session Memory\n\nFavorite deploy note: keep it short.\n',
+  );
+  const todayMemoryFile = path.join(
+    workspacePath,
+    'memory',
+    `${currentDateStampInTimezone(undefined)}.md`,
+  );
+  fs.writeFileSync(
+    todayMemoryFile,
+    'Today note: reproduced the issue and captured the fix plan.\n',
+  );
+  fs.writeFileSync(
+    path.join(
+      workspacePath,
+      '.session-transcripts',
+      'session-memory-inspect.jsonl',
+    ),
+    [
+      JSON.stringify({
+        sessionId: 'session-memory-inspect',
+        role: 'user',
+        content: 'Render the deploy animation',
+      }),
+      JSON.stringify({
+        sessionId: 'session-memory-inspect',
+        role: 'assistant',
+        content: 'I can render it after the assets are in place.',
+      }),
+    ].join('\n'),
+  );
+
+  memoryService.storeTurn({
+    sessionId: session.id,
+    user: {
+      userId: 'user-1',
+      username: 'alice',
+      content: 'Render the deploy animation',
+    },
+    assistant: {
+      userId: 'assistant',
+      username: null,
+      content: 'I can render it after the assets are in place.',
+    },
+  });
+  memoryService.updateSessionSummary(
+    session.id,
+    'Earlier turns covered the deploy animation plan and pending asset work.',
+  );
+  memoryService.markSessionMemoryFlush(session.id);
+  memoryService.appendCanonicalMessages({
+    agentId: 'main',
+    userId: canonicalScope,
+    newMessages: [
+      {
+        role: 'user',
+        content: 'Remember the deploy checklist from yesterday.',
+        sessionId: 'other-session',
+        channelId: 'discord:dm',
+      },
+      {
+        role: 'assistant',
+        content: 'Stored the deploy checklist context for later reuse.',
+        sessionId: 'other-session',
+        channelId: 'discord:dm',
+      },
+    ],
+  });
+
+  const result = await handleGatewayCommand({
+    sessionId: session.id,
+    guildId: null,
+    channelId: 'web',
+    args: ['memory', 'inspect'],
+  });
+
+  expect(result.kind).toBe('info');
+  if (result.kind !== 'info') {
+    throw new Error(`Unexpected result kind: ${result.kind}`);
+  }
+  expect(result.title).toBe('Memory Inspection');
+  expect(result.text).toContain('Session: session-memory-inspect');
+  expect(result.text).toContain('1. Workspace memory file (`MEMORY.md`)');
+  expect(result.text).toContain('Favorite deploy note: keep it short.');
+  expect(result.text).toContain('2. Workspace daily note for today');
+  expect(result.text).toContain(
+    'Today note: reproduced the issue and captured the fix plan.',
+  );
+  expect(result.text).toContain('3. Raw session history');
+  expect(result.text).toContain('Render the deploy animation');
+  expect(result.text).toContain('4. Compacted session summary');
+  expect(result.text).toContain(
+    'Earlier turns covered the deploy animation plan and pending asset work.',
+  );
+  expect(result.text).toContain('5. Semantic memory store');
+  expect(result.text).toContain(
+    'User asked: Render the deploy animation I responded: I can render it after the assets are in place.',
+  );
+  expect(result.text).toContain('6. Canonical cross-channel memory');
+  expect(result.text).toContain('Remember the deploy checklist from yesterday.');
+});
+
+test('memory inspect rejects remote sessions', async () => {
+  setupHome();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+
+  const result = await handleGatewayCommand({
+    sessionId: 'session-memory-inspect-remote',
+    guildId: 'guild-1',
+    channelId: 'discord:channel-1',
+    args: ['memory', 'inspect'],
+  });
+
+  expect(result.kind).toBe('error');
+  expect(result.title).toBe('Memory Commands Restricted');
+  expect(result.text).toContain('only available from local TUI/web sessions');
+});
+
+test('memory query previews the attached prompt block without mutating recall access metadata', async () => {
+  setupHome();
+
+  const { initDatabase, listSemanticMemoriesForSession } = await import(
+    '../src/memory/db.ts'
+  );
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  const session = memoryService.getOrCreateSession(
+    'session-memory-query',
+    null,
+    'web',
+    'main',
+  );
+  memoryService.storeTurn({
+    sessionId: session.id,
+    user: {
+      userId: 'user-1',
+      username: 'alice',
+      content: 'Render the deploy animation',
+    },
+    assistant: {
+      userId: 'assistant',
+      username: null,
+      content: 'I can render it after the assets are in place.',
+    },
+  });
+  memoryService.updateSessionSummary(
+    session.id,
+    'Earlier turns covered the deploy animation plan and pending asset work.',
+  );
+
+  const result = await handleGatewayCommand({
+    sessionId: session.id,
+    guildId: null,
+    channelId: 'web',
+    args: ['memory', 'query', 'deploy', 'animation'],
+  });
+
+  expect(result.kind).toBe('info');
+  if (result.kind !== 'info') {
+    throw new Error(`Unexpected result kind: ${result.kind}`);
+  }
+  expect(result.title).toBe('Memory Query');
+  expect(result.text).toContain('Query: deploy animation');
+  expect(result.text).toContain(
+    'Mode: read-only diagnostic (matches prompt assembly without updating semantic recall access metadata)',
+  );
+  expect(result.text).toContain('Summary included: yes');
+  expect(result.text).toContain('Matched semantic memories:');
+  expect(result.text).toContain('Exact attached block:');
+  expect(result.text).toContain('Relevant Memory Recall');
+  expect(result.text).toContain(
+    'Earlier turns covered the deploy animation plan and pending asset work.',
+  );
+  expect(result.text).toContain('Render the deploy animation');
+
+  const memories = listSemanticMemoriesForSession(session.id, 5);
+  expect(memories[0]?.access_count).toBe(0);
+});

--- a/tests/locomo-native.test.ts
+++ b/tests/locomo-native.test.ts
@@ -1059,10 +1059,7 @@ test('locomo native retrieval context F1 matches whitespace token overlap semant
     testOnlyLocomoNativeRetrieval.computeContextTokenF1('fetch,', 'fetch'),
   ).toBe(0);
   expect(
-    testOnlyLocomoNativeRetrieval.computeContextTokenF1(
-      'fetch fetch',
-      'fetch',
-    ),
+    testOnlyLocomoNativeRetrieval.computeContextTokenF1('fetch fetch', 'fetch'),
   ).toBeCloseTo(2 / 3, 6);
 });
 

--- a/tests/locomo-native.test.ts
+++ b/tests/locomo-native.test.ts
@@ -179,6 +179,12 @@ function buildSampleDataset(): string {
   ]);
 }
 
+function installDatasetFixture(installDir: string, dataset: string): void {
+  fs.mkdirSync(path.join(installDir, 'data'), { recursive: true });
+  fs.writeFileSync(path.join(installDir, '.hybridclaw-setup-ok'), 'ok\n');
+  fs.writeFileSync(path.join(installDir, 'data', 'locomo10.json'), dataset);
+}
+
 function buildTwoSampleDataset(): string {
   return JSON.stringify([
     ...JSON.parse(buildSampleDataset()),
@@ -936,6 +942,88 @@ test('locomo native run throttles in-sample progress writes', async () => {
   expect(progressWrites).toHaveLength(3);
 });
 
+test('locomo retrieval writes ingestion progress before question progress', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  process.env.OPENAI_BASE_URL = 'http://127.0.0.1:9090/v1';
+  process.env.OPENAI_API_KEY = 'test-key';
+  process.env.HYBRIDCLAW_EVAL_MODEL = 'hybridai/gpt-4.1-mini';
+
+  installDatasetFixture(installDir, buildSampleDataset());
+  vi.spyOn(memoryService, 'recallSemanticMemories').mockReturnValue([
+    {
+      id: 1,
+      session_id: 'locomo',
+      user_id: 'locomo',
+      role: 'user',
+      source: 'locomo-retrieval',
+      scope: 'episodic',
+      metadata: {},
+      content: 'Pepper',
+      confidence: 1,
+      embedding: null,
+      source_message_id: 1,
+      created_at: new Date().toISOString(),
+      accessed_at: new Date().toISOString(),
+      access_count: 0,
+    },
+  ]);
+  globalThis.fetch = vi.fn<typeof fetch>(async () => {
+    throw new Error('retrieval mode should not call the model gateway');
+  });
+
+  const writeFileSpy = vi.spyOn(fs, 'writeFileSync');
+
+  await runLocomoNativeCli([
+    'run',
+    '--install-dir',
+    installDir,
+    '--mode',
+    'retrieval',
+    '--budget',
+    '4000',
+    '--num-samples',
+    '1',
+  ]);
+
+  const progressSnapshots = writeFileSpy.mock.calls
+    .filter(([filePath]) => String(filePath).endsWith('progress.json'))
+    .map(
+      ([, content]) => JSON.parse(String(content)) as Record<string, unknown>,
+    );
+
+  expect(
+    progressSnapshots.some(
+      (snapshot) =>
+        snapshot.currentPhase === 'ingesting' &&
+        snapshot.currentSampleId === 'sample-1' &&
+        snapshot.currentSampleEmbeddedTurnCount === 0 &&
+        snapshot.currentSampleTurnCount === 3,
+    ),
+  ).toBe(true);
+  expect(
+    progressSnapshots.some(
+      (snapshot) =>
+        snapshot.currentPhase === 'ingesting' &&
+        snapshot.currentSampleId === 'sample-1' &&
+        snapshot.currentSampleEmbeddedTurnCount === 1 &&
+        snapshot.currentSampleTurnCount === 3,
+    ),
+  ).toBe(true);
+  expect(
+    progressSnapshots.some(
+      (snapshot) =>
+        snapshot.currentPhase === 'evaluating' &&
+        snapshot.currentSampleQuestionCount === 1 &&
+        snapshot.currentSampleQuestionTotal === 2,
+    ),
+  ).toBe(true);
+});
+
 test('official LOCOMO scoring keeps lexical F1 behavior for paraphrases', () => {
   expect(
     scoreOfficialLocomoAnswer({
@@ -986,6 +1074,11 @@ test('locomo native retrieval mode scores native memory hit rate without model c
     fs.readFileSync(path.join(jobRoot, jobDirName, 'result.json'), 'utf-8'),
   ) as {
     mode: string;
+    retrievalPolicy: string | null;
+    retrievalQueryMode: string | null;
+    retrievalBackend: string | null;
+    retrievalRerank: string | null;
+    retrievalTokenizer: string | null;
     model: string | null;
     overallScore: number;
     contextF1: number | null;
@@ -1011,6 +1104,11 @@ test('locomo native retrieval mode scores native memory hit rate without model c
   }>;
 
   expect(summary.mode).toBe('retrieval');
+  expect(summary.retrievalPolicy).toBe('budget-only');
+  expect(summary.retrievalQueryMode).toBe('no-stopwords');
+  expect(summary.retrievalBackend).toBe('cosine');
+  expect(summary.retrievalRerank).toBe('bm25');
+  expect(summary.retrievalTokenizer).toBe('unicode61');
   expect(summary.model).toBeNull();
   expect(summary.overallScore).toBe(1);
   expect(summary.contextF1).toBeGreaterThan(0);
@@ -1026,6 +1124,954 @@ test('locomo native retrieval mode scores native memory hit rate without model c
         entry.retrievedSourceMessageIds.length > 0,
     ),
   ).toBe(true);
+});
+
+test('locomo retrieval mode bypasses prompt-memory caps and relies on raw memory recall plus budgeting', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  fs.mkdirSync(path.join(installDir, 'data'), { recursive: true });
+  fs.writeFileSync(
+    path.join(installDir, 'data', 'locomo10.json'),
+    buildSampleDataset(),
+    'utf-8',
+  );
+  fs.writeFileSync(path.join(installDir, '.hybridclaw-setup-ok'), 'ok\n');
+
+  const buildPromptSpy = vi.spyOn(memoryService, 'buildPromptMemoryContext');
+  const recallSpy = vi.spyOn(memoryService, 'recallSemanticMemories');
+  recallSpy.mockReturnValue(
+    Array.from({ length: 20 }, (_, index) => ({
+      id: index + 1,
+      session_id: 'locomo-session',
+      role: 'assistant',
+      source: 'locomo-retrieval',
+      scope: 'episodic',
+      metadata: {},
+      content: `Synthetic recalled memory ${index + 1}`,
+      confidence: 1,
+      embedding: null,
+      source_message_id: index + 1,
+      created_at: new Date().toISOString(),
+      accessed_at: new Date().toISOString(),
+      access_count: 0,
+    })),
+  );
+  globalThis.fetch = vi.fn<typeof fetch>(async () => {
+    throw new Error('retrieval mode should not call the model gateway');
+  });
+
+  await runLocomoNativeCli([
+    'run',
+    '--install-dir',
+    installDir,
+    '--mode',
+    'retrieval',
+    '--budget',
+    '4000',
+    '--num-samples',
+    '1',
+  ]);
+
+  expect(buildPromptSpy).not.toHaveBeenCalled();
+  expect(recallSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      limit: 3,
+      limitHardCap: null,
+      minConfidence: 0,
+      query: expect.any(String),
+      sessionId: expect.any(String),
+    }),
+  );
+});
+
+test('locomo retrieval mode can strip stopwords from the recall query', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  fs.mkdirSync(path.join(installDir, 'data'), { recursive: true });
+  fs.writeFileSync(
+    path.join(installDir, 'data', 'locomo10.json'),
+    buildSampleDataset(),
+    'utf-8',
+  );
+  fs.writeFileSync(path.join(installDir, '.hybridclaw-setup-ok'), 'ok\n');
+
+  const recallSpy = vi.spyOn(memoryService, 'recallSemanticMemories');
+  recallSpy.mockReturnValue([]);
+  globalThis.fetch = vi.fn<typeof fetch>(async () => {
+    throw new Error('retrieval mode should not call the model gateway');
+  });
+
+  await runLocomoNativeCli([
+    'run',
+    '--install-dir',
+    installDir,
+    '--mode',
+    'retrieval',
+    '--retrieval-query',
+    'no-stopwords',
+    '--budget',
+    '4000',
+    '--num-samples',
+    '1',
+  ]);
+
+  expect(recallSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      query: 'What does Pepper love playing every evening?',
+      queryMode: 'no-stopwords',
+    }),
+  );
+});
+
+test('locomo retrieval mode passes the full-text backend through memoryService', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  fs.mkdirSync(path.join(installDir, 'data'), { recursive: true });
+  fs.writeFileSync(
+    path.join(installDir, 'data', 'locomo10.json'),
+    buildSampleDataset(),
+    'utf-8',
+  );
+  fs.writeFileSync(path.join(installDir, '.hybridclaw-setup-ok'), 'ok\n');
+
+  const recallSpy = vi.spyOn(memoryService, 'recallSemanticMemories');
+  recallSpy.mockReturnValue([]);
+  globalThis.fetch = vi.fn<typeof fetch>(async () => {
+    throw new Error('retrieval mode should not call the model gateway');
+  });
+
+  await runLocomoNativeCli([
+    'run',
+    '--install-dir',
+    installDir,
+    '--mode',
+    'retrieval',
+    '--retrieval-backend',
+    'full-text',
+    '--budget',
+    '4000',
+    '--num-samples',
+    '1',
+  ]);
+
+  expect(recallSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      backend: 'full-text',
+    }),
+  );
+
+  const jobRoot = path.join(installDir, 'jobs');
+  const [jobDirName] = fs.readdirSync(jobRoot);
+  const summary = JSON.parse(
+    fs.readFileSync(path.join(jobRoot, jobDirName, 'result.json'), 'utf-8'),
+  ) as {
+    retrievalBackend: string | null;
+    overallScore: number;
+  };
+  expect(summary.retrievalBackend).toBe('full-text');
+  expect(summary.overallScore).toBe(0);
+});
+
+test('locomo retrieval mode passes full-text BM25 rerank through memoryService', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  fs.mkdirSync(path.join(installDir, 'data'), { recursive: true });
+  fs.writeFileSync(
+    path.join(installDir, 'data', 'locomo10.json'),
+    buildSampleDataset(),
+    'utf-8',
+  );
+  fs.writeFileSync(path.join(installDir, '.hybridclaw-setup-ok'), 'ok\n');
+
+  const recallSpy = vi.spyOn(memoryService, 'recallSemanticMemories');
+  recallSpy.mockReturnValue([]);
+  globalThis.fetch = vi.fn<typeof fetch>(async () => {
+    throw new Error('retrieval mode should not call the model gateway');
+  });
+
+  await runLocomoNativeCli([
+    'run',
+    '--install-dir',
+    installDir,
+    '--mode',
+    'retrieval',
+    '--retrieval-backend',
+    'full-text',
+    '--retrieval-rerank',
+    'bm25',
+    '--budget',
+    '4000',
+    '--num-samples',
+    '1',
+  ]);
+
+  expect(recallSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      backend: 'full-text',
+      rerank: 'bm25',
+    }),
+  );
+
+  const jobRoot = path.join(installDir, 'jobs');
+  const [jobDirName] = fs.readdirSync(jobRoot);
+  const summary = JSON.parse(
+    fs.readFileSync(path.join(jobRoot, jobDirName, 'result.json'), 'utf-8'),
+  ) as {
+    retrievalBackend: string | null;
+    retrievalRerank: string | null;
+  };
+
+  expect(summary.retrievalBackend).toBe('full-text');
+  expect(summary.retrievalRerank).toBe('bm25');
+});
+
+test('locomo retrieval mode passes BM25 rerank through memoryService', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  fs.mkdirSync(path.join(installDir, 'data'), { recursive: true });
+  fs.writeFileSync(
+    path.join(installDir, 'data', 'locomo10.json'),
+    JSON.stringify([
+      {
+        sample_id: 'sample-rerank',
+        conversation: {
+          speaker_a: 'Alice',
+          speaker_b: 'Bob',
+          session_1_date_time: '2024-03-01 10:00:00',
+          session_1: [
+            {
+              speaker: 'Alice',
+              dia_id: 'D1:1',
+              text: 'Pepper loves playing fetch every evening.',
+            },
+            {
+              speaker: 'Bob',
+              dia_id: 'D1:2',
+              text: 'The weather turned rainy today.',
+            },
+          ],
+        },
+        qa: [
+          {
+            question: 'What does Pepper love playing every evening?',
+            answer: 'fetch',
+            evidence: ['D1:1'],
+            category: 1,
+          },
+        ],
+      },
+    ]),
+    'utf-8',
+  );
+  fs.writeFileSync(path.join(installDir, '.hybridclaw-setup-ok'), 'ok\n');
+
+  const recallSpy = vi.spyOn(memoryService, 'recallSemanticMemories');
+  recallSpy.mockReturnValue([
+    {
+      id: 2,
+      session_id: 'locomo-session',
+      role: 'assistant',
+      source: 'locomo-retrieval',
+      scope: 'episodic',
+      metadata: {},
+      content:
+        'DATE: 2024-03-01 10:00:00\nBob said, "The weather turned rainy today."',
+      confidence: 1,
+      embedding: null,
+      source_message_id: 2,
+      created_at: new Date().toISOString(),
+      accessed_at: new Date().toISOString(),
+      access_count: 0,
+    },
+    {
+      id: 1,
+      session_id: 'locomo-session',
+      role: 'user',
+      source: 'locomo-retrieval',
+      scope: 'episodic',
+      metadata: {},
+      content:
+        'DATE: 2024-03-01 10:00:00\nAlice said, "Pepper loves playing fetch every evening."',
+      confidence: 1,
+      embedding: null,
+      source_message_id: 1,
+      created_at: new Date().toISOString(),
+      accessed_at: new Date().toISOString(),
+      access_count: 0,
+    },
+  ]);
+  globalThis.fetch = vi.fn<typeof fetch>(async () => {
+    throw new Error('retrieval mode should not call the model gateway');
+  });
+
+  await runLocomoNativeCli([
+    'run',
+    '--install-dir',
+    installDir,
+    '--mode',
+    'retrieval',
+    '--retrieval-rerank',
+    'bm25',
+    '--budget',
+    '1',
+    '--num-samples',
+    '1',
+  ]);
+
+  expect(recallSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      rerank: 'bm25',
+    }),
+  );
+
+  const jobRoot = path.join(installDir, 'jobs');
+  const [jobDirName] = fs.readdirSync(jobRoot);
+  const summary = JSON.parse(
+    fs.readFileSync(path.join(jobRoot, jobDirName, 'result.json'), 'utf-8'),
+  ) as {
+    retrievalRerank: string | null;
+    overallScore: number;
+    predictionsPath: string;
+  };
+
+  expect(summary.retrievalRerank).toBe('bm25');
+  expect(summary.overallScore).toBe(0);
+});
+
+test('locomo retrieval mode passes trigram tokenizer through memoryService', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  fs.mkdirSync(path.join(installDir, 'data'), { recursive: true });
+  fs.writeFileSync(
+    path.join(installDir, 'data', 'locomo10.json'),
+    buildSampleDataset(),
+    'utf-8',
+  );
+  fs.writeFileSync(path.join(installDir, '.hybridclaw-setup-ok'), 'ok\n');
+
+  const recallSpy = vi.spyOn(memoryService, 'recallSemanticMemories');
+  recallSpy.mockReturnValue([]);
+  globalThis.fetch = vi.fn<typeof fetch>(async () => {
+    throw new Error('retrieval mode should not call the model gateway');
+  });
+
+  await runLocomoNativeCli([
+    'run',
+    '--install-dir',
+    installDir,
+    '--mode',
+    'retrieval',
+    '--retrieval-tokenizer',
+    'trigram',
+    '--budget',
+    '4000',
+    '--num-samples',
+    '1',
+  ]);
+
+  expect(recallSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      tokenizer: 'trigram',
+    }),
+  );
+});
+
+test('locomo retrieval matrix sweeps all retrieval variants and writes a combined summary', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  fs.mkdirSync(path.join(installDir, 'data'), { recursive: true });
+  fs.writeFileSync(
+    path.join(installDir, 'data', 'locomo10.json'),
+    buildSampleDataset(),
+    'utf-8',
+  );
+  fs.writeFileSync(path.join(installDir, '.hybridclaw-setup-ok'), 'ok\n');
+
+  const recallSpy = vi.spyOn(memoryService, 'recallSemanticMemories');
+  recallSpy.mockImplementation((params) => {
+    const query = String(params.query || '');
+    const answerContent = query.includes('Pepper')
+      ? 'DATE: 2024-03-01 10:00:00\nAlice said, "Pepper loves playing fetch every evening."'
+      : 'DATE: 2024-03-01 10:00:00\nAlice said, "Tomorrow I will pack crunchy carrots for lunch."';
+    if (params.backend === 'cosine') {
+      return [];
+    }
+    return [
+      {
+        id: 1,
+        session_id: 'locomo-session',
+        role: 'user',
+        source: 'locomo-retrieval',
+        scope: 'episodic',
+        metadata: {},
+        content: answerContent,
+        confidence: 1,
+        embedding: null,
+        source_message_id: 1,
+        created_at: new Date().toISOString(),
+        accessed_at: new Date().toISOString(),
+        access_count: 0,
+      },
+    ];
+  });
+  globalThis.fetch = vi.fn<typeof fetch>(async () => {
+    throw new Error('retrieval mode should not call the model gateway');
+  });
+
+  await runLocomoNativeCli([
+    'run',
+    '--install-dir',
+    installDir,
+    '--mode',
+    'retrieval',
+    '--matrix',
+    '--budget',
+    '4000',
+    '--num-samples',
+    '1',
+  ]);
+
+  const jobRoot = path.join(installDir, 'jobs');
+  const [jobDirName] = fs.readdirSync(jobRoot);
+  const jobDir = path.join(jobRoot, jobDirName);
+  const summary = JSON.parse(
+    fs.readFileSync(path.join(jobDir, 'result.json'), 'utf-8'),
+  ) as {
+    matrix: boolean;
+    matrixSweep: string | null;
+    retrievalQueryMode: string | null;
+    retrievalBackend: string | null;
+    retrievalRerank: string | null;
+    retrievalTokenizer: string | null;
+    variantCount: number | null;
+    bestVariantLabel: string | null;
+    overallScore: number | null;
+    variants: Array<{
+      id: string;
+      label: string;
+      retrievalQueryMode: string;
+      retrievalBackend: string;
+      retrievalRerank: string;
+      overallScore: number;
+    }>;
+    predictionsPath: string;
+  };
+  const predictions = JSON.parse(
+    fs.readFileSync(summary.predictionsPath, 'utf-8'),
+  ) as {
+    matrix: boolean;
+    variants: Array<{
+      id: string;
+      label: string;
+      predictionsPath: string;
+      sampleCount: number;
+      questionCount: number;
+    }>;
+  };
+  const firstVariantPredictions = JSON.parse(
+    fs.readFileSync(predictions.variants[0]?.predictionsPath || '', 'utf-8'),
+  ) as {
+    matrix: boolean;
+    predictions: unknown[];
+  };
+
+  expect(summary.matrix).toBe(true);
+  expect(summary.matrixSweep).toBe('all');
+  expect(summary.retrievalQueryMode).toBeNull();
+  expect(summary.retrievalBackend).toBeNull();
+  expect(summary.retrievalRerank).toBeNull();
+  expect(summary.variantCount).toBe(16);
+  expect(summary.variants).toHaveLength(16);
+  expect(summary.bestVariantLabel).toBe('full-text');
+  expect(summary.overallScore).toBe(1);
+  expect(summary.variants.map((variant) => variant.label)).toContain('cosine');
+  expect(summary.variants.map((variant) => variant.label)).not.toContain(
+    'cosine + porter',
+  );
+  expect(summary.variants.map((variant) => variant.label)).not.toContain(
+    'cosine + trigram',
+  );
+  expect(summary.variants.map((variant) => variant.label)).toContain(
+    'full-text',
+  );
+  expect(summary.variants.map((variant) => variant.label)).toContain(
+    'full-text + bm25',
+  );
+  expect(summary.variants.map((variant) => variant.label)).toContain(
+    'full-text + porter',
+  );
+  expect(summary.variants.map((variant) => variant.label)).toContain('hybrid');
+  expect(predictions.matrix).toBe(true);
+  expect(predictions.variants).toHaveLength(16);
+  expect(predictions.variants[0]?.predictionsPath).toContain(
+    '/matrix-predictions/',
+  );
+  expect(firstVariantPredictions.matrix).toBe(true);
+  expect(firstVariantPredictions.predictions.length).toBeGreaterThan(0);
+  expect(recallSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      backend: 'full-text',
+      rerank: 'none',
+      queryMode: 'no-stopwords',
+      tokenizer: 'unicode61',
+    }),
+  );
+  expect(recallSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      backend: 'full-text',
+      rerank: 'none',
+      queryMode: 'no-stopwords',
+      tokenizer: 'porter',
+    }),
+  );
+  expect(recallSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      backend: 'hybrid',
+      rerank: 'bm25',
+      queryMode: 'no-stopwords',
+      tokenizer: 'trigram',
+    }),
+  );
+});
+
+test('locomo retrieval backend matrix sweep varies backend only', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+  installDatasetFixture(installDir, buildSampleDataset());
+
+  const recallSpy = vi.spyOn(memoryService, 'recallSemanticMemories');
+  recallSpy.mockImplementation((params) => {
+    const answerContent =
+      params.backend === 'full-text' ? 'Pepper' : 'Alice said Pepper';
+    return [
+      {
+        id: 1,
+        session_id: 'locomo',
+        user_id: 'locomo',
+        role: 'user',
+        source: 'locomo-retrieval',
+        scope: 'episodic',
+        metadata: {},
+        content: answerContent,
+        confidence: 1,
+        embedding: null,
+        source_message_id: 1,
+        created_at: new Date().toISOString(),
+        accessed_at: new Date().toISOString(),
+        access_count: 0,
+      },
+    ];
+  });
+  globalThis.fetch = vi.fn<typeof fetch>(async () => {
+    throw new Error('retrieval mode should not call the model gateway');
+  });
+
+  await runLocomoNativeCli([
+    'run',
+    '--install-dir',
+    installDir,
+    '--mode',
+    'retrieval',
+    '--matrix',
+    'backend',
+    '--budget',
+    '4000',
+    '--num-samples',
+    '1',
+  ]);
+
+  const jobRoot = path.join(installDir, 'jobs');
+  const [jobDirName] = fs.readdirSync(jobRoot);
+  const jobDir = path.join(jobRoot, jobDirName);
+  const summary = JSON.parse(
+    fs.readFileSync(path.join(jobDir, 'result.json'), 'utf-8'),
+  ) as {
+    matrix: boolean;
+    matrixSweep: string | null;
+    variantCount: number | null;
+    variants: Array<{
+      label: string;
+      retrievalBackend: string;
+      retrievalRerank: string;
+      retrievalTokenizer: string;
+    }>;
+  };
+
+  expect(summary.matrix).toBe(true);
+  expect(summary.matrixSweep).toBe('backend');
+  expect(summary.variantCount).toBe(3);
+  expect(summary.variants.map((variant) => variant.label)).toEqual([
+    'cosine + bm25',
+    'full-text + bm25',
+    'hybrid + bm25',
+  ]);
+  expect(
+    summary.variants.every((variant) => variant.retrievalRerank === 'bm25'),
+  ).toBe(true);
+  expect(
+    summary.variants.every(
+      (variant) => variant.retrievalTokenizer === 'unicode61',
+    ),
+  ).toBe(true);
+});
+
+test('locomo retrieval rerank matrix sweep varies rerank only', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+  installDatasetFixture(installDir, buildSampleDataset());
+
+  const recallSpy = vi.spyOn(memoryService, 'recallSemanticMemories');
+  recallSpy.mockReturnValue([
+    {
+      id: 1,
+      session_id: 'locomo',
+      user_id: 'locomo',
+      role: 'user',
+      source: 'locomo-retrieval',
+      scope: 'episodic',
+      metadata: {},
+      content: 'Pepper',
+      confidence: 1,
+      embedding: null,
+      source_message_id: 1,
+      created_at: new Date().toISOString(),
+      accessed_at: new Date().toISOString(),
+      access_count: 0,
+    },
+  ]);
+  globalThis.fetch = vi.fn<typeof fetch>(async () => {
+    throw new Error('retrieval mode should not call the model gateway');
+  });
+
+  await runLocomoNativeCli([
+    'run',
+    '--install-dir',
+    installDir,
+    '--mode',
+    'retrieval',
+    '--matrix',
+    'rerank',
+    '--budget',
+    '4000',
+    '--num-samples',
+    '1',
+  ]);
+
+  const jobRoot = path.join(installDir, 'jobs');
+  const [jobDirName] = fs.readdirSync(jobRoot);
+  const jobDir = path.join(jobRoot, jobDirName);
+  const summary = JSON.parse(
+    fs.readFileSync(path.join(jobDir, 'result.json'), 'utf-8'),
+  ) as {
+    matrixSweep: string | null;
+    variantCount: number | null;
+    variants: Array<{
+      label: string;
+      retrievalBackend: string;
+      retrievalRerank: string;
+      retrievalTokenizer: string;
+    }>;
+  };
+
+  expect(summary.matrixSweep).toBe('rerank');
+  expect(summary.variantCount).toBe(2);
+  expect(summary.variants.map((variant) => variant.label)).toEqual([
+    'cosine',
+    'cosine + bm25',
+  ]);
+  expect(
+    summary.variants.every((variant) => variant.retrievalBackend === 'cosine'),
+  ).toBe(true);
+  expect(
+    summary.variants.every(
+      (variant) => variant.retrievalTokenizer === 'unicode61',
+    ),
+  ).toBe(true);
+  expect(recallSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      backend: 'cosine',
+      rerank: 'bm25',
+      queryMode: 'no-stopwords',
+      tokenizer: 'unicode61',
+    }),
+  );
+});
+
+test('locomo retrieval tokenizer matrix sweep varies tokenizer only', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+  installDatasetFixture(installDir, buildSampleDataset());
+
+  const recallSpy = vi.spyOn(memoryService, 'recallSemanticMemories');
+  recallSpy.mockReturnValue([
+    {
+      id: 1,
+      session_id: 'locomo',
+      user_id: 'locomo',
+      role: 'user',
+      source: 'locomo-retrieval',
+      scope: 'episodic',
+      metadata: {},
+      content: 'Pepper',
+      confidence: 1,
+      embedding: null,
+      source_message_id: 1,
+      created_at: new Date().toISOString(),
+      accessed_at: new Date().toISOString(),
+      access_count: 0,
+    },
+  ]);
+  globalThis.fetch = vi.fn<typeof fetch>(async () => {
+    throw new Error('retrieval mode should not call the model gateway');
+  });
+
+  await runLocomoNativeCli([
+    'run',
+    '--install-dir',
+    installDir,
+    '--mode',
+    'retrieval',
+    '--matrix',
+    'tokenizer',
+    '--budget',
+    '4000',
+    '--num-samples',
+    '1',
+  ]);
+
+  const jobRoot = path.join(installDir, 'jobs');
+  const [jobDirName] = fs.readdirSync(jobRoot);
+  const jobDir = path.join(jobRoot, jobDirName);
+  const summary = JSON.parse(
+    fs.readFileSync(path.join(jobDir, 'result.json'), 'utf-8'),
+  ) as {
+    matrixSweep: string | null;
+    variantCount: number | null;
+    variants: Array<{
+      label: string;
+      retrievalBackend: string;
+      retrievalRerank: string;
+      retrievalTokenizer: string;
+    }>;
+  };
+
+  expect(summary.matrixSweep).toBe('tokenizer');
+  expect(summary.variantCount).toBe(3);
+  expect(summary.variants.map((variant) => variant.label)).toEqual([
+    'cosine + bm25',
+    'cosine + porter + bm25',
+    'cosine + trigram + bm25',
+  ]);
+  expect(
+    summary.variants.every((variant) => variant.retrievalBackend === 'cosine'),
+  ).toBe(true);
+  expect(
+    summary.variants.every((variant) => variant.retrievalRerank === 'bm25'),
+  ).toBe(true);
+  expect(recallSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      backend: 'cosine',
+      rerank: 'bm25',
+      queryMode: 'no-stopwords',
+      tokenizer: 'trigram',
+    }),
+  );
+});
+
+test('locomo retrieval embedding matrix sweep varies embedding provider only', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+  installDatasetFixture(installDir, buildSampleDataset());
+
+  const storeSpy = vi
+    .spyOn(memoryService, 'storeSemanticMemory')
+    .mockReturnValue(1);
+  const recallSpy = vi.spyOn(memoryService, 'recallSemanticMemories');
+  const warmupSpy = vi
+    .spyOn(memoryService, 'warmupEmbeddingProvider')
+    .mockImplementation(() => {});
+  recallSpy.mockReturnValue([
+    {
+      id: 1,
+      session_id: 'locomo',
+      user_id: 'locomo',
+      role: 'user',
+      source: 'locomo-retrieval',
+      scope: 'episodic',
+      metadata: {},
+      content: 'Pepper',
+      confidence: 1,
+      embedding: null,
+      source_message_id: 1,
+      created_at: new Date().toISOString(),
+      accessed_at: new Date().toISOString(),
+      access_count: 0,
+    },
+  ]);
+  globalThis.fetch = vi.fn<typeof fetch>(async () => {
+    throw new Error('retrieval mode should not call the model gateway');
+  });
+
+  await runLocomoNativeCli([
+    'run',
+    '--install-dir',
+    installDir,
+    '--mode',
+    'retrieval',
+    '--matrix',
+    'embedding',
+    '--budget',
+    '4000',
+    '--num-samples',
+    '1',
+  ]);
+
+  const jobRoot = path.join(installDir, 'jobs');
+  const [jobDirName] = fs.readdirSync(jobRoot);
+  const jobDir = path.join(jobRoot, jobDirName);
+  const summary = JSON.parse(
+    fs.readFileSync(path.join(jobDir, 'result.json'), 'utf-8'),
+  ) as {
+    matrixSweep: string | null;
+    variantCount: number | null;
+    variants: Array<{
+      label: string;
+      retrievalBackend: string;
+      retrievalRerank: string;
+      retrievalTokenizer: string;
+      retrievalEmbeddingProvider: string;
+    }>;
+  };
+
+  expect(summary.matrixSweep).toBe('embedding');
+  expect(summary.variantCount).toBe(2);
+  expect(summary.variants.map((variant) => variant.label)).toEqual([
+    'cosine + bm25',
+    'cosine + bm25 + transformers',
+  ]);
+  expect(
+    summary.variants.map((variant) => variant.retrievalEmbeddingProvider),
+  ).toEqual(['hashed', 'transformers']);
+  expect(
+    summary.variants.every((variant) => variant.retrievalBackend === 'cosine'),
+  ).toBe(true);
+  expect(
+    summary.variants.every((variant) => variant.retrievalRerank === 'bm25'),
+  ).toBe(true);
+  expect(
+    summary.variants.every(
+      (variant) => variant.retrievalTokenizer === 'unicode61',
+    ),
+  ).toBe(true);
+  expect(warmupSpy).toHaveBeenCalledWith('transformers');
+  const firstTransformersStoreIndex = storeSpy.mock.calls.findIndex(
+    ([params]) => params.embeddingProvider === 'transformers',
+  );
+  expect(firstTransformersStoreIndex).toBeGreaterThanOrEqual(0);
+  expect(warmupSpy.mock.invocationCallOrder[0]).toBeLessThan(
+    storeSpy.mock.invocationCallOrder[firstTransformersStoreIndex] ||
+      Number.POSITIVE_INFINITY,
+  );
+  expect(storeSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      embeddingProvider: 'transformers',
+    }),
+  );
+  expect(recallSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      backend: 'cosine',
+      rerank: 'bm25',
+      queryMode: 'no-stopwords',
+      tokenizer: 'unicode61',
+      embeddingProvider: 'transformers',
+    }),
+  );
+});
+
+test('locomo retrieval matrix rejects explicit retrieval overrides', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+
+  await expect(
+    runLocomoNativeCli([
+      'run',
+      '--install-dir',
+      installDir,
+      '--mode',
+      'retrieval',
+      '--matrix',
+      '--retrieval-backend',
+      'full-text',
+    ]),
+  ).rejects.toThrow(/cannot be combined with explicit retrieval flags/i);
+});
+
+test('locomo retrieval matrix rejects unknown matrix sweep', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+
+  await expect(
+    runLocomoNativeCli([
+      'run',
+      '--install-dir',
+      installDir,
+      '--mode',
+      'retrieval',
+      '--matrix',
+      'nonsense',
+    ]),
+  ).rejects.toThrow(/unsupported locomo matrix sweep/i);
 });
 
 test('locomo native retrieval hit-rate matches substring evidence recall semantics', () => {

--- a/tests/locomo-native.test.ts
+++ b/tests/locomo-native.test.ts
@@ -1,0 +1,138 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, expect, test, vi } from 'vitest';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (originalFetch) {
+    globalThis.fetch = originalFetch;
+  } else {
+    delete (globalThis as { fetch?: typeof fetch }).fetch;
+  }
+});
+
+function buildSampleDataset(): string {
+  return JSON.stringify([
+    {
+      sample_id: 'sample-1',
+      conversation: {
+        speaker_a: 'Alice',
+        speaker_b: 'Bob',
+        session_1_date_time: '2024-03-01 10:00:00',
+        session_1: [
+          {
+            speaker: 'Alice',
+            dia_id: 'D1:1',
+            text: 'Pepper loves playing fetch every evening.',
+          },
+          {
+            speaker: 'Bob',
+            dia_id: 'D1:2',
+            text: 'The weather turned rainy today.',
+          },
+          {
+            speaker: 'Alice',
+            dia_id: 'D1:3',
+            text: 'Tomorrow I will pack crunchy carrots for lunch.',
+          },
+        ],
+      },
+      qa: [
+        {
+          question: 'What does Pepper love playing every evening?',
+          answer: 'fetch',
+          evidence: ['D1:1'],
+          category: 1,
+        },
+        {
+          question: 'What will Alice pack for lunch tomorrow?',
+          answer: 'carrots',
+          evidence: ['D1:3'],
+          category: 1,
+        },
+      ],
+    },
+  ]);
+}
+
+test('locomo native setup downloads the dataset and writes the setup marker', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+  const dataset = buildSampleDataset();
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  globalThis.fetch = vi
+    .fn<typeof fetch>()
+    .mockResolvedValue(new Response(dataset, { status: 200 }));
+
+  await runLocomoNativeCli(['setup', '--install-dir', installDir]);
+
+  expect(fs.existsSync(path.join(installDir, '.hybridclaw-setup-ok'))).toBe(
+    true,
+  );
+  expect(
+    fs.readFileSync(path.join(installDir, 'data', 'locomo10.json'), 'utf-8'),
+  ).toBe(dataset);
+});
+
+test('locomo native run writes recent and semantic benchmark summaries', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  fs.mkdirSync(path.join(installDir, 'data'), { recursive: true });
+  fs.writeFileSync(
+    path.join(installDir, 'data', 'locomo10.json'),
+    buildSampleDataset(),
+    'utf-8',
+  );
+  fs.writeFileSync(path.join(installDir, '.hybridclaw-setup-ok'), 'ok\n');
+
+  await runLocomoNativeCli([
+    'run',
+    '--install-dir',
+    installDir,
+    '--budget',
+    '14',
+    '--num-samples',
+    '1',
+    '--top-k',
+    '5',
+  ]);
+
+  const jobRoot = path.join(installDir, 'jobs');
+  const [jobDirName] = fs.readdirSync(jobRoot);
+  const summary = JSON.parse(
+    fs.readFileSync(path.join(jobRoot, jobDirName, 'result.json'), 'utf-8'),
+  ) as {
+    suite: string;
+    sampleCount: number;
+    modes: Record<
+      string,
+      {
+        overallF1: number;
+        overallHitRate: number;
+        totalQuestions: number;
+      }
+    >;
+  };
+
+  expect(summary.suite).toBe('locomo');
+  expect(summary.sampleCount).toBe(1);
+  expect(summary.modes.recent).toBeDefined();
+  expect(summary.modes.semantic).toBeDefined();
+  expect(summary.modes.semantic.totalQuestions).toBe(2);
+  expect(summary.modes.semantic.overallHitRate).toBeGreaterThan(
+    summary.modes.recent.overallHitRate,
+  );
+  expect(summary.modes.semantic.overallF1).toBeGreaterThan(
+    summary.modes.recent.overallF1,
+  );
+});

--- a/tests/locomo-native.test.ts
+++ b/tests/locomo-native.test.ts
@@ -14,6 +14,8 @@ const originalFetch = globalThis.fetch;
 const originalOpenAIBaseUrl = process.env.OPENAI_BASE_URL;
 const originalOpenAIApiKey = process.env.OPENAI_API_KEY;
 const originalEvalModel = process.env.HYBRIDCLAW_EVAL_MODEL;
+const LOCOMO_DATASET_URL =
+  'https://raw.githubusercontent.com/snap-research/locomo/3eb6f2c585f5e1699204e3c3bdf7adc5c28cb376/data/locomo10.json';
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -147,18 +149,51 @@ test('locomo native setup downloads the dataset and writes the setup marker', as
   );
   const dataset = buildSampleDataset();
   vi.spyOn(console, 'log').mockImplementation(() => {});
-  globalThis.fetch = vi
-    .fn<typeof fetch>()
-    .mockResolvedValue(new Response(dataset, { status: 200 }));
+  globalThis.fetch = vi.fn<typeof fetch>().mockResolvedValue({
+    ok: true,
+    status: 200,
+    url: '',
+    arrayBuffer: async () => Buffer.from(dataset, 'utf-8'),
+  } as Response);
 
   await runLocomoNativeCli(['setup', '--install-dir', installDir]);
 
+  expect(globalThis.fetch).toHaveBeenCalledWith(LOCOMO_DATASET_URL);
   expect(fs.existsSync(path.join(installDir, '.hybridclaw-setup-ok'))).toBe(
     true,
   );
   expect(
     fs.readFileSync(path.join(installDir, 'data', 'locomo10.json'), 'utf-8'),
   ).toBe(dataset);
+});
+
+test('locomo native setup rejects downloads that fail the pinned digest check', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  globalThis.fetch = vi.fn<typeof fetch>().mockResolvedValue({
+    ok: true,
+    status: 200,
+    url: LOCOMO_DATASET_URL,
+    arrayBuffer: async () => Buffer.from(buildSampleDataset(), 'utf-8'),
+  } as Response);
+
+  await expect(
+    runLocomoNativeCli(['setup', '--install-dir', installDir]),
+  ).rejects.toThrow(/SHA-256 verification/);
+});
+
+test('locomo native run reports setup guidance that works for cli and slash wrappers', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+
+  await expect(
+    runLocomoNativeCli(['run', '--install-dir', installDir]),
+  ).rejects.toThrow('LOCOMO is not set up. Run `setup` first');
 });
 
 test('locomo native run generates answers through the local gateway and scores them', async () => {

--- a/tests/locomo-native.test.ts
+++ b/tests/locomo-native.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { afterEach, expect, test, vi } from 'vitest';
 
 import { parseEvalProfileModel } from '../src/evals/eval-profile.ts';
+import { testOnlyLocomoNativeRetrieval } from '../src/evals/locomo-native.ts';
 import {
   scoreOfficialLocomoAnswer,
   testOnlyLocomoOfficialScoring,
@@ -16,9 +17,102 @@ const originalOpenAIApiKey = process.env.OPENAI_API_KEY;
 const originalEvalModel = process.env.HYBRIDCLAW_EVAL_MODEL;
 const LOCOMO_DATASET_URL =
   'https://raw.githubusercontent.com/snap-research/locomo/3eb6f2c585f5e1699204e3c3bdf7adc5c28cb376/data/locomo10.json';
+const LOCOMO_DATASET_SHA256 =
+  '79fa87e90f04081343b8c8debecb80a9a6842b76a7aa537dc9fdf651ea698ff4';
+
+async function flushMicrotasks(count = 4): Promise<void> {
+  for (let index = 0; index < count; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function buildTimeoutError(): Error {
+  return Object.assign(new Error('timed out'), { name: 'TimeoutError' });
+}
+
+function buildCompletionResponse(answer: string): Response {
+  return new Response(
+    JSON.stringify({
+      choices: [{ message: { content: answer } }],
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 2,
+        total_tokens: 12,
+      },
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    },
+  );
+}
+
+function toBuffer(
+  value: string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>,
+): Buffer {
+  if (typeof value === 'string') {
+    return Buffer.from(value);
+  }
+  if (ArrayBuffer.isView(value)) {
+    return Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+  }
+  return Buffer.from(value);
+}
+
+async function mockPinnedDatasetDigest(dataset: string): Promise<void> {
+  vi.resetModules();
+  vi.doMock('node:crypto', async () => {
+    const actual =
+      await vi.importActual<typeof import('node:crypto')>('node:crypto');
+    return {
+      ...actual,
+      createHash(algorithm: string) {
+        if (algorithm !== 'sha256') {
+          return actual.createHash(algorithm);
+        }
+
+        const fallbackHash = actual.createHash('sha256');
+        const chunks: Buffer[] = [];
+        const mockedHash = {
+          update(
+            value: string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>,
+          ) {
+            const buffer = toBuffer(value);
+            chunks.push(buffer);
+            fallbackHash.update(buffer);
+            return mockedHash;
+          },
+          digest(encoding?: import('node:crypto').BinaryToTextEncoding) {
+            const buffer = Buffer.concat(chunks);
+            if (buffer.equals(Buffer.from(dataset, 'utf-8'))) {
+              return LOCOMO_DATASET_SHA256;
+            }
+            return encoding
+              ? fallbackHash.digest(encoding)
+              : fallbackHash.digest();
+          },
+        };
+
+        return mockedHash as unknown as ReturnType<typeof actual.createHash>;
+      },
+    };
+  });
+}
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.doUnmock('node:crypto');
+  vi.resetModules();
   if (originalFetch) {
     globalThis.fetch = originalFetch;
   } else {
@@ -142,23 +236,51 @@ function buildCategoryFiveDataset(): string {
   ]);
 }
 
-test('locomo native setup downloads the dataset and writes the setup marker', async () => {
+test('locomo native caches flattened conversation turns per conversation object', async () => {
+  const { testOnlyLocomoNative } = await import(
+    '../src/evals/locomo-native.ts'
+  );
+  const [sample] = JSON.parse(buildSampleDataset()) as Array<{
+    conversation: Record<string, unknown>;
+  }>;
+
+  const first = testOnlyLocomoNative.flattenConversationTurns(
+    sample.conversation,
+  );
+  const second = testOnlyLocomoNative.flattenConversationTurns(
+    sample.conversation,
+  );
+
+  expect(second).toBe(first);
+  expect(second.map((turn) => turn.dia_id)).toEqual(['D1:1', 'D1:2', 'D1:3']);
+});
+
+test('locomo native setup downloads the dataset and verifies bytes after redirects', async () => {
+  const dataset = buildSampleDataset();
+  await mockPinnedDatasetDigest(dataset);
   const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
   const installDir = fs.mkdtempSync(
     path.join(os.tmpdir(), 'hybridclaw-locomo-'),
   );
-  const dataset = buildSampleDataset();
+  const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
   vi.spyOn(console, 'log').mockImplementation(() => {});
-  globalThis.fetch = vi.fn<typeof fetch>().mockResolvedValue({
+  const fetchMock = vi.fn<typeof fetch>().mockResolvedValue({
     ok: true,
     status: 200,
-    url: '',
+    url: 'https://objects.githubusercontent.com/redirected/locomo10.json',
     arrayBuffer: async () => Buffer.from(dataset, 'utf-8'),
   } as Response);
+  globalThis.fetch = fetchMock;
 
   await runLocomoNativeCli(['setup', '--install-dir', installDir]);
 
-  expect(globalThis.fetch).toHaveBeenCalledWith(LOCOMO_DATASET_URL);
+  expect(timeoutSpy).toHaveBeenCalledWith(120_000);
+  expect(fetchMock).toHaveBeenCalledWith(
+    LOCOMO_DATASET_URL,
+    expect.objectContaining({
+      signal: timeoutSpy.mock.results[0]?.value,
+    }),
+  );
   expect(fs.existsSync(path.join(installDir, '.hybridclaw-setup-ok'))).toBe(
     true,
   );
@@ -167,7 +289,32 @@ test('locomo native setup downloads the dataset and writes the setup marker', as
   ).toBe(dataset);
 });
 
-test('locomo native setup rejects downloads that fail the pinned digest check', async () => {
+test('locomo native setup times out stalled dataset downloads', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+  const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  const fetchMock = vi
+    .fn<typeof fetch>()
+    .mockRejectedValue(buildTimeoutError());
+  globalThis.fetch = fetchMock;
+
+  await expect(
+    runLocomoNativeCli(['setup', '--install-dir', installDir]),
+  ).rejects.toThrow(/^LOCOMO dataset download timed out after 120000ms\.$/);
+
+  expect(timeoutSpy).toHaveBeenCalledWith(120_000);
+  expect(fetchMock).toHaveBeenCalledWith(
+    LOCOMO_DATASET_URL,
+    expect.objectContaining({
+      signal: timeoutSpy.mock.results[0]?.value,
+    }),
+  );
+});
+
+test('locomo native setup rejects downloads that fail the pinned digest check after redirects', async () => {
   const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
   const installDir = fs.mkdtempSync(
     path.join(os.tmpdir(), 'hybridclaw-locomo-'),
@@ -176,7 +323,7 @@ test('locomo native setup rejects downloads that fail the pinned digest check', 
   globalThis.fetch = vi.fn<typeof fetch>().mockResolvedValue({
     ok: true,
     status: 200,
-    url: LOCOMO_DATASET_URL,
+    url: 'https://objects.githubusercontent.com/redirected/locomo10.json',
     arrayBuffer: async () => Buffer.from(buildSampleDataset(), 'utf-8'),
   } as Response);
 
@@ -194,6 +341,56 @@ test('locomo native run reports setup guidance that works for cli and slash wrap
   await expect(
     runLocomoNativeCli(['run', '--install-dir', installDir]),
   ).rejects.toThrow('LOCOMO is not set up. Run `setup` first');
+});
+
+test('locomo native run reports when the cached dataset is missing', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+
+  fs.writeFileSync(path.join(installDir, '.hybridclaw-setup-ok'), 'ok\n');
+
+  await expect(
+    runLocomoNativeCli(['run', '--install-dir', installDir]),
+  ).rejects.toThrow('LOCOMO dataset is missing');
+});
+
+test('locomo native run reports when the setup marker is missing', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+
+  fs.mkdirSync(path.join(installDir, 'data'), { recursive: true });
+  fs.writeFileSync(
+    path.join(installDir, 'data', 'locomo10.json'),
+    buildSampleDataset(),
+    'utf-8',
+  );
+
+  await expect(
+    runLocomoNativeCli(['run', '--install-dir', installDir]),
+  ).rejects.toThrow('LOCOMO setup marker is missing');
+});
+
+test('locomo native run rejects malformed cached datasets immediately', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+
+  fs.mkdirSync(path.join(installDir, 'data'), { recursive: true });
+  fs.writeFileSync(
+    path.join(installDir, 'data', 'locomo10.json'),
+    JSON.stringify([{ sample_id: 'broken-sample', conversation: {} }]),
+    'utf-8',
+  );
+  fs.writeFileSync(path.join(installDir, '.hybridclaw-setup-ok'), 'ok\n');
+
+  await expect(
+    runLocomoNativeCli(['run', '--install-dir', installDir]),
+  ).rejects.toThrow(/Invalid LOCOMO sample at index 0/);
 });
 
 test('locomo native run generates answers through the local gateway and scores them', async () => {
@@ -306,6 +503,159 @@ test('locomo native run generates answers through the local gateway and scores t
   ]);
   expect(requestModels).toHaveLength(2);
   expect(requestModels[0]).toBe(requestModels[1]);
+});
+
+test('locomo native run evaluates QA questions concurrently while preserving question order', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  process.env.OPENAI_BASE_URL = 'http://127.0.0.1:9090/v1';
+  process.env.OPENAI_API_KEY = 'test-key';
+  process.env.HYBRIDCLAW_EVAL_MODEL = 'hybridai/gpt-4.1-mini';
+
+  fs.mkdirSync(path.join(installDir, 'data'), { recursive: true });
+  fs.writeFileSync(
+    path.join(installDir, 'data', 'locomo10.json'),
+    buildSampleDataset(),
+    'utf-8',
+  );
+  fs.writeFileSync(path.join(installDir, '.hybridclaw-setup-ok'), 'ok\n');
+
+  const firstResponse = createDeferred<Response>();
+  const secondResponse = createDeferred<Response>();
+  let activeRequests = 0;
+  let maxConcurrentRequests = 0;
+
+  globalThis.fetch = vi.fn<typeof fetch>(async (_input, init) => {
+    activeRequests += 1;
+    maxConcurrentRequests = Math.max(maxConcurrentRequests, activeRequests);
+    const body = JSON.parse(String(init?.body || '{}')) as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    const prompt = body.messages[0]?.content || '';
+    const response = prompt.includes('pack for lunch tomorrow')
+      ? await secondResponse.promise
+      : await firstResponse.promise;
+    activeRequests -= 1;
+    return response;
+  });
+
+  const runPromise = runLocomoNativeCli([
+    'run',
+    '--install-dir',
+    installDir,
+    '--budget',
+    '4000',
+    '--num-samples',
+    '1',
+  ]);
+
+  await flushMicrotasks();
+  expect(maxConcurrentRequests).toBe(2);
+  secondResponse.resolve(buildCompletionResponse('carrots'));
+  firstResponse.resolve(buildCompletionResponse('fetch'));
+  await runPromise;
+
+  const jobRoot = path.join(installDir, 'jobs');
+  const [jobDirName] = fs.readdirSync(jobRoot);
+  const summary = JSON.parse(
+    fs.readFileSync(path.join(jobRoot, jobDirName, 'result.json'), 'utf-8'),
+  ) as {
+    predictionsPath: string;
+  };
+  const predictions = JSON.parse(
+    fs.readFileSync(summary.predictionsPath, 'utf-8'),
+  ) as Array<{
+    qa: Array<{ prediction: string }>;
+  }>;
+
+  expect(predictions[0]?.qa.map((entry) => entry.prediction)).toEqual([
+    'fetch',
+    'carrots',
+  ]);
+});
+
+test('locomo native run times out stalled model calls', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+  const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  process.env.OPENAI_BASE_URL = 'http://127.0.0.1:9090/v1';
+  process.env.OPENAI_API_KEY = 'test-key';
+  process.env.HYBRIDCLAW_EVAL_MODEL = 'hybridai/gpt-4.1-mini';
+
+  fs.mkdirSync(path.join(installDir, 'data'), { recursive: true });
+  fs.writeFileSync(
+    path.join(installDir, 'data', 'locomo10.json'),
+    buildSampleDataset(),
+    'utf-8',
+  );
+  fs.writeFileSync(path.join(installDir, '.hybridclaw-setup-ok'), 'ok\n');
+  const fetchMock = vi
+    .fn<typeof fetch>()
+    .mockRejectedValue(buildTimeoutError());
+  globalThis.fetch = fetchMock;
+
+  await expect(
+    runLocomoNativeCli([
+      'run',
+      '--install-dir',
+      installDir,
+      '--budget',
+      '4000',
+      '--num-samples',
+      '1',
+    ]),
+  ).rejects.toThrow(/^LOCOMO model call timed out after 30000ms\.$/);
+
+  expect(timeoutSpy).toHaveBeenCalledWith(30_000);
+  expect(fetchMock).toHaveBeenCalledWith(
+    'http://127.0.0.1:9090/v1/chat/completions',
+    expect.objectContaining({
+      signal: timeoutSpy.mock.results[0]?.value,
+    }),
+  );
+});
+
+test('locomo native run does not echo failed model response bodies', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  process.env.OPENAI_BASE_URL = 'http://127.0.0.1:9090/v1';
+  process.env.OPENAI_API_KEY = 'test-key';
+  process.env.HYBRIDCLAW_EVAL_MODEL = 'hybridai/gpt-4.1-mini';
+
+  fs.mkdirSync(path.join(installDir, 'data'), { recursive: true });
+  fs.writeFileSync(
+    path.join(installDir, 'data', 'locomo10.json'),
+    buildSampleDataset(),
+    'utf-8',
+  );
+  fs.writeFileSync(path.join(installDir, '.hybridclaw-setup-ok'), 'ok\n');
+  globalThis.fetch = vi.fn<typeof fetch>().mockResolvedValue(
+    new Response('token=test-key server stack trace', {
+      status: 401,
+      headers: { 'Content-Type': 'text/plain' },
+    }),
+  );
+
+  await expect(
+    runLocomoNativeCli([
+      'run',
+      '--install-dir',
+      installDir,
+      '--budget',
+      '4000',
+      '--num-samples',
+      '1',
+    ]),
+  ).rejects.toThrow(/^LOCOMO model call failed with HTTP 401\.$/);
 });
 
 test('locomo native default creates one fresh agent per conversation sample', async () => {
@@ -546,6 +896,46 @@ test('locomo native run respects max question limits and writes progress metadat
   expect(predictions[0]?.qa).toHaveLength(1);
 });
 
+test('locomo native run throttles in-sample progress writes', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  process.env.OPENAI_BASE_URL = 'http://127.0.0.1:9090/v1';
+  process.env.OPENAI_API_KEY = 'test-key';
+  process.env.HYBRIDCLAW_EVAL_MODEL = 'hybridai/gpt-4.1-mini';
+
+  fs.mkdirSync(path.join(installDir, 'data'), { recursive: true });
+  fs.writeFileSync(
+    path.join(installDir, 'data', 'locomo10.json'),
+    buildSampleDataset(),
+    'utf-8',
+  );
+  fs.writeFileSync(path.join(installDir, '.hybridclaw-setup-ok'), 'ok\n');
+  globalThis.fetch = vi.fn<typeof fetch>(async () =>
+    buildCompletionResponse('fetch'),
+  );
+
+  const writeFileSpy = vi.spyOn(fs, 'writeFileSync');
+
+  await runLocomoNativeCli([
+    'run',
+    '--install-dir',
+    installDir,
+    '--budget',
+    '4000',
+    '--num-samples',
+    '1',
+  ]);
+
+  const progressWrites = writeFileSpy.mock.calls.filter(([filePath]) =>
+    String(filePath).endsWith('progress.json'),
+  );
+
+  expect(progressWrites).toHaveLength(3);
+});
+
 test('official LOCOMO scoring keeps lexical F1 behavior for paraphrases', () => {
   expect(
     scoreOfficialLocomoAnswer({
@@ -636,6 +1026,44 @@ test('locomo native retrieval mode scores native memory hit rate without model c
         entry.retrievedSourceMessageIds.length > 0,
     ),
   ).toBe(true);
+});
+
+test('locomo native retrieval hit-rate matches substring evidence recall semantics', () => {
+  const [sample] = JSON.parse(buildSampleDataset()) as Array<{
+    sample_id: string;
+    conversation: Record<string, unknown>;
+    qa: Array<{ evidence: string[] }>;
+  }>;
+
+  const hitRate = testOnlyLocomoNativeRetrieval.computeRetrievalHitRate({
+    sample,
+    evidence: ['D1:1', 'D1:3'],
+    retrievedContent: [
+      'DATE: 2024-03-01 10:00:00',
+      'Alice said, "Pepper loves playing fetch every evening."',
+      'Alice said, "Tomorrow I will pack crunchy carrots for lunch."',
+    ].join('\n'),
+  });
+  const missRate = testOnlyLocomoNativeRetrieval.computeRetrievalHitRate({
+    sample,
+    evidence: ['D1:1', 'D1:3'],
+    retrievedContent: 'Bob said, "The weather turned rainy today."',
+  });
+
+  expect(hitRate).toBe(1);
+  expect(missRate).toBe(0);
+});
+
+test('locomo native retrieval context F1 matches whitespace token overlap semantics', () => {
+  expect(
+    testOnlyLocomoNativeRetrieval.computeContextTokenF1('fetch,', 'fetch'),
+  ).toBe(0);
+  expect(
+    testOnlyLocomoNativeRetrieval.computeContextTokenF1(
+      'fetch fetch',
+      'fetch',
+    ),
+  ).toBeCloseTo(2 / 3, 6);
 });
 
 test('official LOCOMO scoring uses Porter stemming semantics', () => {

--- a/tests/locomo-native.test.ts
+++ b/tests/locomo-native.test.ts
@@ -4,7 +4,16 @@ import path from 'node:path';
 
 import { afterEach, expect, test, vi } from 'vitest';
 
+import { parseEvalProfileModel } from '../src/evals/eval-profile.ts';
+import {
+  scoreOfficialLocomoAnswer,
+  testOnlyLocomoOfficialScoring,
+} from '../src/evals/locomo-official-scoring.ts';
+
 const originalFetch = globalThis.fetch;
+const originalOpenAIBaseUrl = process.env.OPENAI_BASE_URL;
+const originalOpenAIApiKey = process.env.OPENAI_API_KEY;
+const originalEvalModel = process.env.HYBRIDCLAW_EVAL_MODEL;
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -12,6 +21,21 @@ afterEach(() => {
     globalThis.fetch = originalFetch;
   } else {
     delete (globalThis as { fetch?: typeof fetch }).fetch;
+  }
+  if (originalOpenAIBaseUrl == null) {
+    delete process.env.OPENAI_BASE_URL;
+  } else {
+    process.env.OPENAI_BASE_URL = originalOpenAIBaseUrl;
+  }
+  if (originalOpenAIApiKey == null) {
+    delete process.env.OPENAI_API_KEY;
+  } else {
+    process.env.OPENAI_API_KEY = originalOpenAIApiKey;
+  }
+  if (originalEvalModel == null) {
+    delete process.env.HYBRIDCLAW_EVAL_MODEL;
+  } else {
+    process.env.HYBRIDCLAW_EVAL_MODEL = originalEvalModel;
   }
 });
 
@@ -59,6 +83,63 @@ function buildSampleDataset(): string {
   ]);
 }
 
+function buildTwoSampleDataset(): string {
+  return JSON.stringify([
+    ...JSON.parse(buildSampleDataset()),
+    {
+      sample_id: 'sample-2',
+      conversation: {
+        speaker_a: 'Carol',
+        speaker_b: 'Dan',
+        session_1_date_time: '2024-03-02 10:00:00',
+        session_1: [
+          {
+            speaker: 'Carol',
+            dia_id: 'D2:1',
+            text: 'I adopted a greyhound named Orbit last spring.',
+          },
+        ],
+      },
+      qa: [
+        {
+          question: 'What is the name of Carol’s dog?',
+          answer: 'Orbit',
+          evidence: ['D2:1'],
+          category: 1,
+        },
+      ],
+    },
+  ]);
+}
+
+function buildCategoryFiveDataset(): string {
+  return JSON.stringify([
+    {
+      sample_id: 'sample-5',
+      conversation: {
+        speaker_a: 'Alice',
+        speaker_b: 'Bob',
+        session_1_date_time: '2024-03-01 10:00:00',
+        session_1: [
+          {
+            speaker: 'Alice',
+            dia_id: 'D1:1',
+            text: 'Pepper loves playing fetch every evening.',
+          },
+        ],
+      },
+      qa: [
+        {
+          question: 'What is Bob planning for his ski trip next month?',
+          answer: 'ski trip',
+          evidence: [],
+          category: 5,
+        },
+      ],
+    },
+  ]);
+}
+
 test('locomo native setup downloads the dataset and writes the setup marker', async () => {
   const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
   const installDir = fs.mkdtempSync(
@@ -80,12 +161,16 @@ test('locomo native setup downloads the dataset and writes the setup marker', as
   ).toBe(dataset);
 });
 
-test('locomo native run writes recent and semantic benchmark summaries', async () => {
+test('locomo native run generates answers through the local gateway and scores them', async () => {
   const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
   const installDir = fs.mkdtempSync(
     path.join(os.tmpdir(), 'hybridclaw-locomo-'),
   );
   vi.spyOn(console, 'log').mockImplementation(() => {});
+  process.env.OPENAI_BASE_URL = 'http://127.0.0.1:9090/v1';
+  process.env.OPENAI_API_KEY = 'test-key';
+  process.env.HYBRIDCLAW_EVAL_MODEL = 'hybridai/gpt-4.1-mini';
+  const requestModels: string[] = [];
 
   fs.mkdirSync(path.join(installDir, 'data'), { recursive: true });
   fs.writeFileSync(
@@ -94,17 +179,46 @@ test('locomo native run writes recent and semantic benchmark summaries', async (
     'utf-8',
   );
   fs.writeFileSync(path.join(installDir, '.hybridclaw-setup-ok'), 'ok\n');
+  globalThis.fetch = vi.fn<typeof fetch>(async (input, init) => {
+    if (String(input) !== 'http://127.0.0.1:9090/v1/chat/completions') {
+      throw new Error(`Unexpected fetch URL: ${String(input)}`);
+    }
+    const body = JSON.parse(String(init?.body || '{}')) as {
+      model: string;
+      messages: Array<{ role: string; content: string }>;
+    };
+    requestModels.push(body.model);
+    const parsedModel = parseEvalProfileModel(body.model);
+    expect(parsedModel.model).toBe('hybridai/gpt-4.1-mini');
+    expect(parsedModel.profile.agentId).toBeTruthy();
+    const prompt = body.messages[0]?.content || '';
+    const answer = prompt.includes('pack for lunch tomorrow')
+      ? 'carrots'
+      : 'fetch';
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: answer } }],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 2,
+          total_tokens: 12,
+        },
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+  });
 
   await runLocomoNativeCli([
     'run',
     '--install-dir',
     installDir,
     '--budget',
-    '14',
+    '4000',
     '--num-samples',
     '1',
-    '--top-k',
-    '5',
   ]);
 
   const jobRoot = path.join(installDir, 'jobs');
@@ -113,26 +227,391 @@ test('locomo native run writes recent and semantic benchmark summaries', async (
     fs.readFileSync(path.join(jobRoot, jobDirName, 'result.json'), 'utf-8'),
   ) as {
     suite: string;
+    model: string;
     sampleCount: number;
-    modes: Record<
+    questionCount: number;
+    overallScore: number;
+    tokenUsage: {
+      totalTokens: number;
+    };
+    categories: Record<
       string,
       {
-        overallF1: number;
-        overallHitRate: number;
-        totalQuestions: number;
+        meanScore: number;
+        questionCount: number;
       }
     >;
+    predictionsPath: string;
   };
 
   expect(summary.suite).toBe('locomo');
+  expect(summary.model).toBe('hybridai/gpt-4.1-mini');
   expect(summary.sampleCount).toBe(1);
-  expect(summary.modes.recent).toBeDefined();
-  expect(summary.modes.semantic).toBeDefined();
-  expect(summary.modes.semantic.totalQuestions).toBe(2);
-  expect(summary.modes.semantic.overallHitRate).toBeGreaterThan(
-    summary.modes.recent.overallHitRate,
+  expect(summary.questionCount).toBe(2);
+  expect(summary.overallScore).toBe(1);
+  expect(summary.categories['1']).toEqual({
+    meanScore: 1,
+    questionCount: 2,
+    contextF1: null,
+  });
+  expect(summary.tokenUsage.totalTokens).toBe(24);
+  expect(fs.existsSync(summary.predictionsPath)).toBe(true);
+  const predictions = JSON.parse(
+    fs.readFileSync(summary.predictionsPath, 'utf-8'),
+  ) as Array<{
+    sampleId: string;
+    meanScore: number;
+    qa: Array<{ prediction: string; score: number }>;
+  }>;
+  expect(predictions[0]?.sampleId).toBe('sample-1');
+  expect(predictions[0]?.meanScore).toBe(1);
+  expect(predictions[0]?.qa.map((entry) => entry.prediction)).toEqual([
+    'fetch',
+    'carrots',
+  ]);
+  expect(requestModels).toHaveLength(2);
+  expect(requestModels[0]).toBe(requestModels[1]);
+});
+
+test('locomo native default creates one fresh agent per conversation sample', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
   );
-  expect(summary.modes.semantic.overallF1).toBeGreaterThan(
-    summary.modes.recent.overallF1,
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  process.env.OPENAI_BASE_URL = 'http://127.0.0.1:9090/v1';
+  process.env.OPENAI_API_KEY = 'test-key';
+  process.env.HYBRIDCLAW_EVAL_MODEL = 'hybridai/gpt-4.1-mini';
+
+  fs.mkdirSync(path.join(installDir, 'data'), { recursive: true });
+  fs.writeFileSync(
+    path.join(installDir, 'data', 'locomo10.json'),
+    buildTwoSampleDataset(),
+    'utf-8',
   );
+  fs.writeFileSync(path.join(installDir, '.hybridclaw-setup-ok'), 'ok\n');
+  const requestModels: string[] = [];
+  globalThis.fetch = vi.fn<typeof fetch>(async (_input, init) => {
+    const body = JSON.parse(String(init?.body || '{}')) as {
+      model: string;
+      messages: Array<{ role: string; content: string }>;
+    };
+    requestModels.push(body.model);
+    const prompt = body.messages[0]?.content || '';
+    let answer = 'fetch';
+    if (prompt.includes('pack for lunch tomorrow')) {
+      answer = 'carrots';
+    } else if (prompt.includes('name of Carol')) {
+      answer = 'Orbit';
+    }
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: answer } }],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 2,
+          total_tokens: 12,
+        },
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+  });
+
+  await runLocomoNativeCli([
+    'run',
+    '--install-dir',
+    installDir,
+    '--budget',
+    '4000',
+    '--num-samples',
+    '2',
+  ]);
+
+  expect(requestModels).toHaveLength(3);
+  const [first, second, third] = requestModels.map((model) =>
+    parseEvalProfileModel(model),
+  );
+  expect(first.model).toBe('hybridai/gpt-4.1-mini');
+  expect(first.profile.agentId).toBeTruthy();
+  expect(second.profile.agentId).toBe(first.profile.agentId);
+  expect(third.profile.agentId).toBeTruthy();
+  expect(third.profile.agentId).not.toBe(first.profile.agentId);
+});
+
+test('locomo native run maps category-5 option labels back to the correct answer key', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  process.env.OPENAI_BASE_URL = 'http://127.0.0.1:9090/v1';
+  process.env.OPENAI_API_KEY = 'test-key';
+  process.env.HYBRIDCLAW_EVAL_MODEL = 'hybridai/gpt-4.1-mini';
+
+  fs.mkdirSync(path.join(installDir, 'data'), { recursive: true });
+  fs.writeFileSync(
+    path.join(installDir, 'data', 'locomo10.json'),
+    buildCategoryFiveDataset(),
+    'utf-8',
+  );
+  fs.writeFileSync(path.join(installDir, '.hybridclaw-setup-ok'), 'ok\n');
+  globalThis.fetch = vi.fn<typeof fetch>(async (_input, init) => {
+    const body = JSON.parse(String(init?.body || '{}')) as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    const prompt = body.messages[0]?.content || '';
+    const answer = prompt.includes('(a) Not mentioned in the conversation')
+      ? 'a'
+      : 'b';
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: answer } }],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 2,
+          total_tokens: 12,
+        },
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+  });
+
+  await runLocomoNativeCli([
+    'run',
+    '--install-dir',
+    installDir,
+    '--budget',
+    '4000',
+    '--num-samples',
+    '1',
+  ]);
+
+  const jobRoot = path.join(installDir, 'jobs');
+  const [jobDirName] = fs.readdirSync(jobRoot);
+  const summary = JSON.parse(
+    fs.readFileSync(path.join(jobRoot, jobDirName, 'result.json'), 'utf-8'),
+  ) as {
+    overallScore: number;
+    categories: Record<
+      string,
+      {
+        meanScore: number;
+        questionCount: number;
+      }
+    >;
+    predictionsPath: string;
+  };
+
+  expect(summary.overallScore).toBe(1);
+  expect(summary.categories['5']).toEqual({
+    meanScore: 1,
+    questionCount: 1,
+    contextF1: null,
+  });
+  const predictions = JSON.parse(
+    fs.readFileSync(summary.predictionsPath, 'utf-8'),
+  ) as Array<{
+    qa: Array<{ prediction: string; score: number }>;
+  }>;
+  expect(predictions[0]?.qa[0]).toMatchObject({
+    prediction: 'Not mentioned in the conversation',
+    score: 1,
+  });
+});
+
+test('locomo native run respects max question limits and writes progress metadata', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  process.env.OPENAI_BASE_URL = 'http://127.0.0.1:9090/v1';
+  process.env.OPENAI_API_KEY = 'test-key';
+  process.env.HYBRIDCLAW_EVAL_MODEL = 'hybridai/gpt-4.1-mini';
+
+  fs.mkdirSync(path.join(installDir, 'data'), { recursive: true });
+  fs.writeFileSync(
+    path.join(installDir, 'data', 'locomo10.json'),
+    buildSampleDataset(),
+    'utf-8',
+  );
+  fs.writeFileSync(path.join(installDir, '.hybridclaw-setup-ok'), 'ok\n');
+  globalThis.fetch = vi.fn<typeof fetch>().mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        choices: [{ message: { content: 'fetch' } }],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 2,
+          total_tokens: 12,
+        },
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    ),
+  );
+
+  await runLocomoNativeCli([
+    'run',
+    '--install-dir',
+    installDir,
+    '--budget',
+    '4000',
+    '--num-samples',
+    '1',
+    '--max-questions',
+    '1',
+  ]);
+
+  expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  const jobRoot = path.join(installDir, 'jobs');
+  const [jobDirName] = fs.readdirSync(jobRoot);
+  const jobDir = path.join(jobRoot, jobDirName);
+  const summary = JSON.parse(
+    fs.readFileSync(path.join(jobDir, 'result.json'), 'utf-8'),
+  ) as {
+    sampleCount: number;
+    questionCount: number;
+    overallScore: number;
+    predictionsPath: string;
+  };
+  const progress = JSON.parse(
+    fs.readFileSync(path.join(jobDir, 'progress.json'), 'utf-8'),
+  ) as {
+    sampleCount: number;
+    completedSampleCount: number;
+    questionCount: number;
+    completedQuestionCount: number;
+    overallScore: number;
+    currentSampleId: string | null;
+  };
+  const predictions = JSON.parse(
+    fs.readFileSync(summary.predictionsPath, 'utf-8'),
+  ) as Array<{
+    qa: Array<{ prediction: string }>;
+  }>;
+
+  expect(summary.sampleCount).toBe(1);
+  expect(summary.questionCount).toBe(1);
+  expect(summary.overallScore).toBe(1);
+  expect(progress.sampleCount).toBe(1);
+  expect(progress.completedSampleCount).toBe(1);
+  expect(progress.questionCount).toBe(1);
+  expect(progress.completedQuestionCount).toBe(1);
+  expect(progress.overallScore).toBe(1);
+  expect(progress.currentSampleId).toBeNull();
+  expect(predictions[0]?.qa).toHaveLength(1);
+});
+
+test('official LOCOMO scoring keeps lexical F1 behavior for paraphrases', () => {
+  expect(
+    scoreOfficialLocomoAnswer({
+      category: 1,
+      answer: 'Transgender woman',
+      prediction: 'a trans woman',
+    }),
+  ).toBe(0.5);
+});
+
+test('locomo native retrieval mode scores native memory hit rate without model calls', async () => {
+  const { runLocomoNativeCli } = await import('../src/evals/locomo-native.ts');
+  const installDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-locomo-'),
+  );
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  process.env.OPENAI_BASE_URL = 'http://127.0.0.1:9090/v1';
+  process.env.OPENAI_API_KEY = 'test-key';
+  process.env.HYBRIDCLAW_EVAL_MODEL = 'hybridai/gpt-4.1-mini';
+
+  fs.mkdirSync(path.join(installDir, 'data'), { recursive: true });
+  fs.writeFileSync(
+    path.join(installDir, 'data', 'locomo10.json'),
+    buildSampleDataset(),
+    'utf-8',
+  );
+  fs.writeFileSync(path.join(installDir, '.hybridclaw-setup-ok'), 'ok\n');
+  globalThis.fetch = vi.fn<typeof fetch>(async () => {
+    throw new Error('retrieval mode should not call the model gateway');
+  });
+
+  await runLocomoNativeCli([
+    'run',
+    '--install-dir',
+    installDir,
+    '--mode',
+    'retrieval',
+    '--budget',
+    '4000',
+    '--num-samples',
+    '1',
+  ]);
+
+  expect(globalThis.fetch).not.toHaveBeenCalled();
+  const jobRoot = path.join(installDir, 'jobs');
+  const [jobDirName] = fs.readdirSync(jobRoot);
+  const summary = JSON.parse(
+    fs.readFileSync(path.join(jobRoot, jobDirName, 'result.json'), 'utf-8'),
+  ) as {
+    mode: string;
+    model: string | null;
+    overallScore: number;
+    contextF1: number | null;
+    tokenUsage: unknown;
+    categories: Record<
+      string,
+      {
+        meanScore: number;
+        questionCount: number;
+        contextF1: number | null;
+      }
+    >;
+    predictionsPath: string;
+  };
+  const predictions = JSON.parse(
+    fs.readFileSync(summary.predictionsPath, 'utf-8'),
+  ) as Array<{
+    qa: Array<{
+      score: number;
+      contextF1: number | null;
+      retrievedSourceMessageIds: number[];
+    }>;
+  }>;
+
+  expect(summary.mode).toBe('retrieval');
+  expect(summary.model).toBeNull();
+  expect(summary.overallScore).toBe(1);
+  expect(summary.contextF1).toBeGreaterThan(0);
+  expect(summary.tokenUsage).toBeNull();
+  expect(summary.categories['1']?.meanScore).toBe(1);
+  expect(summary.categories['1']?.contextF1).toBeGreaterThan(0);
+  expect(predictions[0]?.qa).toHaveLength(2);
+  expect(predictions[0]?.qa.every((entry) => entry.score === 1)).toBe(true);
+  expect(
+    predictions[0]?.qa.every(
+      (entry) =>
+        Array.isArray(entry.retrievedSourceMessageIds) &&
+        entry.retrievedSourceMessageIds.length > 0,
+    ),
+  ).toBe(true);
+});
+
+test('official LOCOMO scoring uses Porter stemming semantics', () => {
+  expect(
+    testOnlyLocomoOfficialScoring.singleAnswerF1('adopted', 'adoption'),
+  ).toBe(1);
+  expect(
+    scoreOfficialLocomoAnswer({
+      category: 2,
+      answer: 'adoption',
+      prediction: 'adopted',
+    }),
+  ).toBe(1);
 });

--- a/tests/memory-service.test.ts
+++ b/tests/memory-service.test.ts
@@ -49,6 +49,22 @@ function createTempDbPath(): string {
   return path.join(dir, 'test.db');
 }
 
+function createTempRuntimeHome(): string {
+  const homeDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-memory-config-'),
+  );
+  const configPath = path.join(homeDir, '.hybridclaw', 'config.json');
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  const config = JSON.parse(
+    fs.readFileSync(path.join(process.cwd(), 'config.example.json'), 'utf-8'),
+  ) as Record<string, unknown>;
+  const ops = config.ops as Record<string, unknown>;
+  ops.dbPath = path.join(homeDir, '.hybridclaw', 'data', 'hybridclaw.db');
+  delete (config.container as Record<string, unknown>).sandboxMode;
+  fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
+  return homeDir;
+}
+
 function makeSession(partial?: Partial<Session>): Session {
   return {
     id: 'session:test',
@@ -173,6 +189,232 @@ describe.sequential('semantic memory DB', () => {
     expect(results.length).toBe(1);
     expect(results[0].content.toLowerCase()).toContain('gardening');
     expect(results[0].embedding).toBeNull();
+  });
+
+  test('can use full-text retrieval as the semantic recall backend', () => {
+    const dbPath = createTempDbPath();
+    initDatabase({ quiet: true, dbPath });
+    getOrCreateSession('s-fts', null, 'channel-fts');
+
+    storeSemanticMemory({
+      sessionId: 's-fts',
+      role: 'assistant',
+      content: 'AtlasFox release checklist and deployment notes.',
+      confidence: 0.9,
+    });
+    storeSemanticMemory({
+      sessionId: 's-fts',
+      role: 'assistant',
+      content: 'Weekend groceries and garden fertilizer reminders.',
+      confidence: 0.9,
+    });
+
+    const results = recallSemanticMemories({
+      sessionId: 's-fts',
+      query: 'atlasfox deployment',
+      backend: 'full-text',
+      limit: 2,
+      minConfidence: 0.2,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.content).toContain('AtlasFox');
+  });
+
+  test('can use trigram tokenization for full-text semantic recall', () => {
+    const dbPath = createTempDbPath();
+    initDatabase({ quiet: true, dbPath });
+    getOrCreateSession('s-fts-trigram', null, 'channel-fts-trigram');
+
+    storeSemanticMemory({
+      sessionId: 's-fts-trigram',
+      role: 'assistant',
+      content: 'AtlasFox microservice rollout notes.',
+      confidence: 0.9,
+    });
+
+    const baseline = recallSemanticMemories({
+      sessionId: 's-fts-trigram',
+      query: 'service',
+      backend: 'full-text',
+      tokenizer: 'unicode61',
+      limit: 2,
+      minConfidence: 0.2,
+    });
+    const trigram = recallSemanticMemories({
+      sessionId: 's-fts-trigram',
+      query: 'service',
+      backend: 'full-text',
+      tokenizer: 'trigram',
+      limit: 2,
+      minConfidence: 0.2,
+    });
+
+    expect(baseline).toHaveLength(0);
+    expect(trigram).toHaveLength(1);
+    expect(trigram[0]?.content).toContain('microservice');
+  });
+
+  test('can use porter tokenization for full-text semantic recall', () => {
+    const dbPath = createTempDbPath();
+    initDatabase({ quiet: true, dbPath });
+    getOrCreateSession('s-fts-porter', null, 'channel-fts-porter');
+
+    storeSemanticMemory({
+      sessionId: 's-fts-porter',
+      role: 'assistant',
+      content: 'AtlasFox adoption rollout notes.',
+      confidence: 0.9,
+    });
+
+    const unicode61 = recallSemanticMemories({
+      sessionId: 's-fts-porter',
+      query: 'adopted',
+      backend: 'full-text',
+      tokenizer: 'unicode61',
+      limit: 2,
+      minConfidence: 0.2,
+    });
+    const porter = recallSemanticMemories({
+      sessionId: 's-fts-porter',
+      query: 'adopted',
+      backend: 'full-text',
+      tokenizer: 'porter',
+      limit: 2,
+      minConfidence: 0.2,
+    });
+
+    expect(unicode61).toHaveLength(0);
+    expect(porter).toHaveLength(1);
+    expect(porter[0]?.content).toContain('adoption');
+  });
+
+  test('can BM25-rerank full-text recall candidates before the final limit', () => {
+    const dbPath = createTempDbPath();
+    initDatabase({ quiet: true, dbPath });
+    getOrCreateSession('s-fts-rerank', null, 'channel-fts-rerank');
+
+    storeSemanticMemory({
+      sessionId: 's-fts-rerank',
+      role: 'assistant',
+      content: 'AtlasFox release note.',
+      confidence: 0.9,
+      accessedAt: '2026-04-11T12:10:00.000Z',
+    });
+    storeSemanticMemory({
+      sessionId: 's-fts-rerank',
+      role: 'assistant',
+      content: 'AtlasFox deployment checklist and rollback checklist.',
+      confidence: 0.9,
+      accessedAt: '2026-04-11T12:00:00.000Z',
+    });
+
+    const baseline = recallSemanticMemories({
+      sessionId: 's-fts-rerank',
+      query: 'atlasfox deployment checklist',
+      backend: 'full-text',
+      rerank: 'none',
+      limit: 2,
+      minConfidence: 0.2,
+    });
+    const redundantRerank = recallSemanticMemories({
+      sessionId: 's-fts-rerank',
+      query: 'atlasfox deployment checklist',
+      backend: 'full-text',
+      rerank: 'bm25',
+      limit: 2,
+      minConfidence: 0.2,
+    });
+
+    expect(baseline[0]?.content).toContain('AtlasFox release note');
+    expect(redundantRerank[0]?.content).toContain('deployment checklist');
+  });
+
+  test('can BM25-rerank semantic recall candidates before the final limit', () => {
+    const dbPath = createTempDbPath();
+    initDatabase({ quiet: true, dbPath });
+    getOrCreateSession('s-rerank', null, 'channel-rerank');
+
+    const constantEmbeddingProvider = {
+      embed: () => [1, 0, 0, 0],
+    };
+    const service = new MemoryService(
+      undefined,
+      undefined,
+      constantEmbeddingProvider,
+    );
+
+    service.storeSemanticMemory({
+      sessionId: 's-rerank',
+      role: 'assistant',
+      content: 'Weekend groceries and garden fertilizer reminders.',
+      confidence: 1,
+    });
+    service.storeSemanticMemory({
+      sessionId: 's-rerank',
+      role: 'assistant',
+      content: 'AtlasFox release checklist and deployment notes.',
+      confidence: 0.4,
+    });
+
+    const baseline = service.recallSemanticMemories({
+      sessionId: 's-rerank',
+      query: 'atlasfox deployment',
+      backend: 'cosine',
+      rerank: 'none',
+      limit: 1,
+      minConfidence: 0.2,
+    });
+    const reranked = service.recallSemanticMemories({
+      sessionId: 's-rerank',
+      query: 'atlasfox deployment',
+      backend: 'cosine',
+      rerank: 'bm25',
+      limit: 1,
+      minConfidence: 0.2,
+    });
+
+    expect(baseline[0]?.content).toContain('Weekend groceries');
+    expect(reranked[0]?.content).toContain('AtlasFox');
+  });
+
+  test('can fuse cosine and full-text recall in hybrid mode', () => {
+    const dbPath = createTempDbPath();
+    initDatabase({ quiet: true, dbPath });
+    getOrCreateSession('s-hybrid', null, 'channel-hybrid');
+
+    const constantEmbeddingProvider = {
+      embed: () => [1, 0, 0, 0],
+    };
+    const service = new MemoryService(
+      undefined,
+      undefined,
+      constantEmbeddingProvider,
+    );
+
+    service.storeSemanticMemory({
+      sessionId: 's-hybrid',
+      role: 'assistant',
+      content: 'Weekend groceries and garden fertilizer reminders.',
+      confidence: 1,
+    });
+    service.storeSemanticMemory({
+      sessionId: 's-hybrid',
+      role: 'assistant',
+      content: 'AtlasFox release checklist and deployment notes.',
+      confidence: 0.4,
+    });
+
+    const results = service.recallSemanticMemories({
+      sessionId: 's-hybrid',
+      query: 'atlasfox deployment',
+      backend: 'hybrid',
+      rerank: 'none',
+      limit: 1,
+      minConfidence: 0.2,
+    });
+
+    expect(results[0]?.content).toContain('AtlasFox');
   });
 
   test('decays stale memories and keeps fresh ones unchanged', () => {
@@ -1392,6 +1634,225 @@ describe('MemoryService', () => {
     expect(recallCalls).toBe(2);
   });
 
+  test('buildPromptMemoryContext honors the semantic prompt hard cap', () => {
+    const recalled: SemanticMemoryEntry[] = Array.from(
+      { length: 5 },
+      (_, i) => ({
+        id: i + 1,
+        session_id: 'session:test',
+        role: 'assistant',
+        source: 'conversation',
+        scope: 'episodic',
+        metadata: {},
+        content: `Memory ${i + 1}`,
+        confidence: 0.9,
+        embedding: null,
+        source_message_id: null,
+        created_at: new Date().toISOString(),
+        accessed_at: new Date().toISOString(),
+        access_count: 0,
+      }),
+    );
+    const backend: MemoryBackend = {
+      resetSessionIfExpired: () => false,
+      getOrCreateSession: (sessionId, guildId, channelId) =>
+        makeSession({
+          id: sessionId,
+          guild_id: guildId,
+          channel_id: channelId,
+        }),
+      getSessionById: () => makeSession(),
+      getConversationHistory: () => [] as StoredMessage[],
+      getConversationHistoryPage: () => ({
+        sessionKey: null,
+        mainSessionKey: null,
+        history: [] as StoredMessage[],
+        branchFamilies: [],
+      }),
+      getRecentMessages: () => [] as StoredMessage[],
+      get: () => null,
+      set: () => {},
+      delete: () => false,
+      list: () => [],
+      appendCanonicalMessages: () => ({
+        canonical_id: 'entity-id:u1',
+        agent_id: 'entity-id',
+        user_id: 'u1',
+        messages: [],
+        compaction_cursor: 0,
+        compacted_summary: null,
+        message_count: 0,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }),
+      getCanonicalContext: () => ({ summary: null, recent_messages: [] }),
+      addKnowledgeEntity: () => 'entity-id',
+      addKnowledgeRelation: () => 'relation-id',
+      queryKnowledgeGraph: () => [],
+      getCompactionCandidateMessages: () => null,
+      storeMessage: () => 42,
+      storeSemanticMemory: () => 10,
+      recallSemanticMemories: ({ limit }) =>
+        recalled.slice(0, limit || recalled.length).map((row) => ({ ...row })),
+      forgetSemanticMemory: () => false,
+      decaySemanticMemories: () => 0,
+      clearSessionHistory: () => 0,
+      deleteMessagesBeforeId: () => 0,
+      deleteMessagesByIds: () => 0,
+      updateSessionSummary: () => {},
+      markSessionMemoryFlush: () => {},
+    };
+
+    const service = new MemoryService(backend, {
+      semanticRecallLimit: 5,
+      semanticPromptHardCap: 2,
+    });
+    const result = service.buildPromptMemoryContext({
+      session: makeSession(),
+      query: 'memory',
+      semanticLimit: 20,
+    });
+
+    expect(result.semanticMemories).toHaveLength(2);
+    expect(result.citationIndex).toHaveLength(2);
+    expect(result.promptSummary).toContain('[mem:1]');
+    expect(result.promptSummary).toContain('[mem:2]');
+    expect(result.promptSummary).not.toContain('[mem:3]');
+  });
+
+  test('buildPromptMemoryContext uses runtime semantic recall config', async () => {
+    const originalHome = process.env.HOME;
+    const runtimeHome = createTempRuntimeHome();
+    process.env.HOME = runtimeHome;
+    vi.resetModules();
+
+    try {
+      const runtimeConfigModule = await import(
+        '../src/config/runtime-config.js'
+      );
+      const dbModule = await import('../src/memory/db.js');
+      const memoryServiceModule = await import(
+        '../src/memory/memory-service.js'
+      );
+      const dbPath = createTempDbPath();
+      dbModule.initDatabase({ quiet: true, dbPath });
+      dbModule.getOrCreateSession('runtime-memory-config', null, 'channel-r');
+
+      runtimeConfigModule.updateRuntimeConfig((draft) => {
+        draft.memory.queryMode = 'no-stopwords';
+        draft.memory.backend = 'full-text';
+        draft.memory.rerank = 'bm25';
+        draft.memory.tokenizer = 'porter';
+      });
+
+      const service = new memoryServiceModule.MemoryService(
+        undefined,
+        undefined,
+        {
+          embed: () => [1, 0, 0, 0],
+        },
+      );
+      service.storeSemanticMemory({
+        sessionId: 'runtime-memory-config',
+        role: 'assistant',
+        content: 'Weekend groceries and garden fertilizer reminders.',
+        confidence: 1,
+      });
+      service.storeSemanticMemory({
+        sessionId: 'runtime-memory-config',
+        role: 'assistant',
+        content: 'AtlasFox deployment plan and release checklist.',
+        confidence: 0.4,
+      });
+      const session = dbModule.getSessionById('runtime-memory-config');
+      if (!session) {
+        throw new Error('Expected runtime-memory-config session.');
+      }
+
+      const result = service.buildPromptMemoryContext({
+        session,
+        query: 'what is the atlasfox deployment plan',
+      });
+
+      expect(result.semanticMemories[0]?.content).toContain('AtlasFox');
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      vi.resetModules();
+      fs.rmSync(runtimeHome, { recursive: true, force: true });
+    }
+  });
+
+  test('explicit semantic recall params override runtime memory config', async () => {
+    const originalHome = process.env.HOME;
+    const runtimeHome = createTempRuntimeHome();
+    process.env.HOME = runtimeHome;
+    vi.resetModules();
+
+    try {
+      const runtimeConfigModule = await import(
+        '../src/config/runtime-config.js'
+      );
+      const dbModule = await import('../src/memory/db.js');
+      const memoryServiceModule = await import(
+        '../src/memory/memory-service.js'
+      );
+      const dbPath = createTempDbPath();
+      dbModule.initDatabase({ quiet: true, dbPath });
+      dbModule.getOrCreateSession('runtime-memory-override', null, 'channel-o');
+
+      runtimeConfigModule.updateRuntimeConfig((draft) => {
+        draft.memory.queryMode = 'no-stopwords';
+        draft.memory.backend = 'full-text';
+        draft.memory.rerank = 'bm25';
+        draft.memory.tokenizer = 'porter';
+      });
+
+      const service = new memoryServiceModule.MemoryService(
+        undefined,
+        undefined,
+        {
+          embed: () => [1, 0, 0, 0],
+        },
+      );
+      service.storeSemanticMemory({
+        sessionId: 'runtime-memory-override',
+        role: 'assistant',
+        content: 'Weekend groceries and garden fertilizer reminders.',
+        confidence: 1,
+      });
+      service.storeSemanticMemory({
+        sessionId: 'runtime-memory-override',
+        role: 'assistant',
+        content: 'AtlasFox deployment plan and release checklist.',
+        confidence: 0.4,
+      });
+
+      const results = service.recallSemanticMemories({
+        sessionId: 'runtime-memory-override',
+        query: 'what is the plan',
+        queryMode: 'raw',
+        backend: 'cosine',
+        rerank: 'none',
+        tokenizer: 'unicode61',
+        limit: 1,
+      });
+
+      expect(results[0]?.content).toContain('Weekend groceries');
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      vi.resetModules();
+      fs.rmSync(runtimeHome, { recursive: true, force: true });
+    }
+  });
+
   test('storeTurn writes one interaction semantic memory in OpenFang format', () => {
     const storedSemantic: Array<{
       role: string;
@@ -1664,6 +2125,34 @@ describe('MemoryService', () => {
 
     expect(first[0]?.access_count).toBe(0);
     expect(second[0]?.access_count).toBe(1);
+  });
+
+  test('buildPromptMemoryContext can skip semantic access tracking in read-only mode', () => {
+    const dbPath = createTempDbPath();
+    initDatabase({ quiet: true, dbPath });
+    const session = getOrCreateSession('s-access-readonly', null, 'channel-h');
+
+    storeSemanticMemory({
+      sessionId: session.id,
+      role: 'assistant',
+      content: 'Release codename is AtlasFox.',
+      confidence: 1,
+    });
+
+    const service = new MemoryService();
+    const first = service.buildPromptMemoryContext({
+      session,
+      query: 'release codename atlasfox',
+      touchSemanticRecall: false,
+    });
+    const second = service.buildPromptMemoryContext({
+      session,
+      query: 'release codename atlasfox',
+      touchSemanticRecall: false,
+    });
+
+    expect(first.semanticMemories[0]?.access_count).toBe(0);
+    expect(second.semanticMemories[0]?.access_count).toBe(0);
   });
 
   test('forgets semantic memory and excludes it from recall', () => {

--- a/tests/memory-service.test.ts
+++ b/tests/memory-service.test.ts
@@ -1564,6 +1564,78 @@ describe('MemoryService', () => {
     expect(semanticWrites).toBe(0);
   });
 
+  test('storeSemanticMemory derives plain array embeddings with the default provider', () => {
+    let capturedEmbedding: number[] | null | undefined;
+    const backend: MemoryBackend = {
+      resetSessionIfExpired: () => false,
+      getOrCreateSession: (sessionId, guildId, channelId) =>
+        makeSession({
+          id: sessionId,
+          guild_id: guildId,
+          channel_id: channelId,
+        }),
+      getSessionById: () => makeSession(),
+      getConversationHistory: () => [] as StoredMessage[],
+      getConversationHistoryPage: () => ({
+        sessionKey: null,
+        mainSessionKey: null,
+        history: [] as StoredMessage[],
+        branchFamilies: [],
+      }),
+      getRecentMessages: () => [] as StoredMessage[],
+      get: () => null,
+      set: () => {},
+      delete: () => false,
+      list: () => [],
+      appendCanonicalMessages: () => ({
+        canonical_id: 'entity-id:u1',
+        agent_id: 'entity-id',
+        user_id: 'u1',
+        messages: [],
+        compaction_cursor: 0,
+        compacted_summary: null,
+        message_count: 0,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }),
+      getCanonicalContext: () => ({ summary: null, recent_messages: [] }),
+      addKnowledgeEntity: () => 'entity-id',
+      addKnowledgeRelation: () => 'relation-id',
+      queryKnowledgeGraph: () => [],
+      getCompactionCandidateMessages: () => null,
+      storeMessage: () => 42,
+      storeSemanticMemory: ({ embedding }) => {
+        capturedEmbedding = embedding;
+        return 10;
+      },
+      recallSemanticMemories: () => [] as SemanticMemoryEntry[],
+      forgetSemanticMemory: () => false,
+      decaySemanticMemories: () => 0,
+      clearSessionHistory: () => 0,
+      deleteMessagesBeforeId: () => 0,
+      deleteMessagesByIds: () => 0,
+      updateSessionSummary: () => {},
+      markSessionMemoryFlush: () => {},
+    };
+
+    const service = new MemoryService(backend, { embeddingDimensions: 32 });
+    service.storeSemanticMemory({
+      sessionId: 'session:test',
+      role: 'assistant',
+      content: 'Rust systems programming notes',
+      confidence: 0.9,
+    });
+
+    expect(Array.isArray(capturedEmbedding)).toBe(true);
+    expect(capturedEmbedding).not.toBeInstanceOf(Float32Array);
+    expect(capturedEmbedding).toHaveLength(32);
+    expect(
+      capturedEmbedding?.every(
+        (value) => typeof value === 'number' && Number.isFinite(value),
+      ),
+    ).toBe(true);
+  });
+
   test('semantic recall increments access_count on repeated identical queries', () => {
     const dbPath = createTempDbPath();
     initDatabase({ quiet: true, dbPath });

--- a/tests/runtime-config.secret-refs.test.ts
+++ b/tests/runtime-config.secret-refs.test.ts
@@ -65,6 +65,46 @@ afterEach(() => {
 });
 
 describe('runtime config secret refs', () => {
+  test('loads memory recall settings from config.json', async () => {
+    const homeDir = makeTempHome();
+    writeRawRuntimeConfig(homeDir, (config) => {
+      const memory = config.memory as Record<string, unknown>;
+      memory.semanticPromptHardCap = 27;
+      memory.embedding = {
+        provider: 'transformers',
+        model: 'onnx-community/embeddinggemma-300m-ONNX',
+        revision: '75a84c732f1884df76bec365346230e32f582c82',
+        dtype: 'q4',
+      };
+      memory.queryMode = 'no-stopwords';
+      memory.backend = 'full-text';
+      memory.rerank = 'bm25';
+      memory.tokenizer = 'porter';
+    });
+
+    const runtimeConfig = await importFreshRuntimeConfig(homeDir);
+
+    expect(runtimeConfig.getRuntimeConfig().memory.semanticPromptHardCap).toBe(
+      27,
+    );
+    expect(runtimeConfig.getRuntimeConfig().memory.embedding.provider).toBe(
+      'transformers',
+    );
+    expect(runtimeConfig.getRuntimeConfig().memory.embedding.model).toBe(
+      'onnx-community/embeddinggemma-300m-ONNX',
+    );
+    expect(runtimeConfig.getRuntimeConfig().memory.embedding.revision).toBe(
+      '75a84c732f1884df76bec365346230e32f582c82',
+    );
+    expect(runtimeConfig.getRuntimeConfig().memory.embedding.dtype).toBe('q4');
+    expect(runtimeConfig.getRuntimeConfig().memory.queryMode).toBe(
+      'no-stopwords',
+    );
+    expect(runtimeConfig.getRuntimeConfig().memory.backend).toBe('full-text');
+    expect(runtimeConfig.getRuntimeConfig().memory.rerank).toBe('bm25');
+    expect(runtimeConfig.getRuntimeConfig().memory.tokenizer).toBe('porter');
+  });
+
   test('resolves store and env secret refs for targeted config fields', async () => {
     const homeDir = makeTempHome();
     const runtimeSecrets = await importFreshRuntimeSecrets(homeDir);
@@ -79,7 +119,7 @@ describe('runtime config secret refs', () => {
     writeRawRuntimeConfig(homeDir, (config) => {
       const ops = config.ops as Record<string, unknown>;
       ops.webApiToken = { source: 'store', id: 'WEB_API_TOKEN' };
-      ops.gatewayApiToken = '${TEST_GATEWAY_TOKEN}';
+      ops.gatewayApiToken = '$' + '{TEST_GATEWAY_TOKEN}';
 
       const imessage = config.imessage as Record<string, unknown>;
       imessage.enabled = true;

--- a/tests/scheduler.cron.test.ts
+++ b/tests/scheduler.cron.test.ts
@@ -43,6 +43,17 @@ describe('scheduler cron normalization', () => {
     expect(prompt).toMatch(/Current time: .*05:00.*\(America\/Los_Angeles\)/);
   });
 
+  test('wrapCronPrompt includes the delivery target context', () => {
+    const prompt = wrapCronPrompt(
+      'half-hourly-email',
+      'Write a short operational update.',
+      'UTC',
+      'ops@example.com',
+    );
+
+    expect(prompt).toContain('Delivery target: email to ops@example.com.');
+  });
+
   test('getScheduledTaskNextRunAt uses the supplied clock and UTC by default', () => {
     const nextRunAt = getScheduledTaskNextRunAt(
       makeCronTask('0 9 * * *'),

--- a/tests/transformers-embedding-provider.test.ts
+++ b/tests/transformers-embedding-provider.test.ts
@@ -1,0 +1,195 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_DISABLE_CONFIG_WATCHER =
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
+
+function restoreEnvVar(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+function makeTempHome(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-embed-provider-'));
+}
+
+function writeRuntimeConfig(
+  homeDir: string,
+  mutator?: (config: Record<string, unknown>) => void,
+): void {
+  const configPath = path.join(homeDir, '.hybridclaw', 'config.json');
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  const config = JSON.parse(
+    fs.readFileSync(path.join(process.cwd(), 'config.example.json'), 'utf-8'),
+  ) as Record<string, unknown>;
+  const ops = config.ops as Record<string, unknown>;
+  ops.dbPath = path.join(homeDir, '.hybridclaw', 'data', 'hybridclaw.db');
+  delete (config.container as Record<string, unknown>).sandboxMode;
+  mutator?.(config);
+  fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  restoreEnvVar('HOME', ORIGINAL_HOME);
+  restoreEnvVar(
+    'HYBRIDCLAW_DISABLE_CONFIG_WATCHER',
+    ORIGINAL_DISABLE_CONFIG_WATCHER,
+  );
+});
+
+describe('TransformersJsEmbeddingProvider', () => {
+  test('applies EmbeddingGemma query and document prompts', async () => {
+    const seen: string[] = [];
+    const { TransformersJsEmbeddingProvider } = await import(
+      '../src/memory/transformers-embedding-provider.js'
+    );
+    const provider = new TransformersJsEmbeddingProvider(
+      {
+        model: 'onnx-community/embeddinggemma-300m-ONNX',
+        revision: 'rev',
+        dtype: 'q8',
+        cacheDir: '/tmp/hybridclaw-cache',
+      },
+      {
+        embed(text) {
+          seen.push(text);
+          return [1, 0];
+        },
+      },
+    );
+
+    expect(provider.embedQuery('Find Caroline')).toEqual([1, 0]);
+    expect(provider.embedDocument('Caroline is a trans woman.')).toEqual([
+      1, 0,
+    ]);
+    expect(seen).toEqual([
+      'task: search result | query: Find Caroline',
+      'title: none | text: Caroline is a trans woman.',
+    ]);
+  });
+
+  test('leaves non-EmbeddingGemma inputs unchanged', async () => {
+    const seen: string[] = [];
+    const { TransformersJsEmbeddingProvider } = await import(
+      '../src/memory/transformers-embedding-provider.js'
+    );
+    const provider = new TransformersJsEmbeddingProvider(
+      {
+        model: 'Xenova/all-MiniLM-L6-v2',
+        revision: 'rev',
+        dtype: 'q8',
+        cacheDir: '/tmp/hybridclaw-cache',
+      },
+      {
+        embed(text) {
+          seen.push(text);
+          return [1];
+        },
+      },
+    );
+
+    provider.embedQuery('Find Caroline');
+    provider.embedDocument('Caroline is a trans woman.');
+
+    expect(seen).toEqual(['Find Caroline', 'Caroline is a trans woman.']);
+  });
+
+  test('forwards warmup requests to the blocking runtime', async () => {
+    const warmup = vi.fn();
+    const { TransformersJsEmbeddingProvider } = await import(
+      '../src/memory/transformers-embedding-provider.js'
+    );
+    const provider = new TransformersJsEmbeddingProvider(
+      {
+        model: 'onnx-community/embeddinggemma-300m-ONNX',
+        revision: 'rev',
+        dtype: 'q8',
+        cacheDir: '/tmp/hybridclaw-cache',
+      },
+      {
+        embed() {
+          return [1, 0];
+        },
+        warmup,
+      },
+    );
+
+    provider.warmup();
+
+    expect(warmup).toHaveBeenCalledTimes(1);
+  });
+
+  test('MemoryService uses the configured transformers embedding provider', async () => {
+    const homeDir = makeTempHome();
+    writeRuntimeConfig(homeDir, (config) => {
+      const memory = config.memory as Record<string, unknown>;
+      memory.embedding = {
+        provider: 'transformers',
+        model: 'onnx-community/embeddinggemma-300m-ONNX',
+        revision: '75a84c732f1884df76bec365346230e32f582c82',
+        dtype: 'q4',
+      };
+    });
+
+    process.env.HOME = homeDir;
+    process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
+    vi.resetModules();
+
+    const providerOptions: Array<Record<string, unknown>> = [];
+    const queryInputs: string[] = [];
+    const documentInputs: string[] = [];
+
+    vi.doMock('../src/memory/transformers-embedding-provider.js', () => ({
+      TransformersJsEmbeddingProvider: class {
+        constructor(options: Record<string, unknown>) {
+          providerOptions.push(options);
+        }
+
+        embedQuery(text: string) {
+          queryInputs.push(text);
+          return [0.2, 0.8];
+        }
+
+        embedDocument(text: string) {
+          documentInputs.push(text);
+          return [0.8, 0.2];
+        }
+
+        dispose() {}
+      },
+    }));
+
+    const { MemoryService } = await import('../src/memory/memory-service.js');
+
+    const service = new MemoryService();
+    const provider = (
+      service as MemoryService & {
+        resolveEmbeddingProvider: () => {
+          embedQuery: (text: string) => number[] | null;
+          embedDocument: (text: string) => number[] | null;
+        };
+      }
+    ).resolveEmbeddingProvider();
+
+    expect(providerOptions).toHaveLength(1);
+    expect(providerOptions[0]?.model).toBe(
+      'onnx-community/embeddinggemma-300m-ONNX',
+    );
+    expect(providerOptions[0]?.dtype).toBe('q4');
+    expect(provider.embedDocument('Caroline is a trans woman.')).toEqual([
+      0.8, 0.2,
+    ]);
+    expect(provider.embedQuery('Who is Caroline?')).toEqual([0.2, 0.8]);
+    expect(documentInputs).toEqual(['Caroline is a trans woman.']);
+    expect(queryInputs).toEqual(['Who is Caroline?']);
+  });
+});

--- a/tests/tui-format.test.ts
+++ b/tests/tui-format.test.ts
@@ -1,6 +1,10 @@
 import { expect, test } from 'vitest';
 
-import { formatTuiTitledCommandBlock } from '../src/tui.ts';
+import {
+  formatTuiTitledCommandBlock,
+  parseTuiSectionCards,
+  renderTuiEvalResultsPanel,
+} from '../src/tui.ts';
 
 test('formats titled command blocks with the standard left gutter', () => {
   expect(
@@ -15,4 +19,30 @@ test('formats titled command blocks with the standard left gutter', () => {
     '  Plugin: demo-plugin',
     '  Directory: /tmp/demo-plugin',
   ]);
+});
+
+test('reflows locomo variant tables to the live tui width without splitting rows', () => {
+  const text = [
+    '┌─ Variants So Far ─────────┐',
+    '│ Variant                       HitRate  F1       C1       C2       C3       C4       C5      │',
+    '│ --------------------------  -------  -------  -------  -------  -------  -------  ------- │',
+    '│ cosine                       0.5560   0.0020   0.3160   0.6240   0.3450   0.6490   0.5280  │',
+    '│ \x1b[30;103mcosine + porter + bm25    \x1b[0m  \x1b[30;103m0.8050*\x1b[0m  \x1b[93m0.0020 \x1b[0m  \x1b[30;103m0.5920*\x1b[0m  \x1b[30;103m0.8860*\x1b[0m  \x1b[93m0.4340 \x1b[0m  \x1b[30;103m0.8630*\x1b[0m  \x1b[30;103m0.8640*\x1b[0m │',
+    '└────────────────────────────┘',
+  ].join('\n');
+
+  const rendered = renderTuiEvalResultsPanel(parseTuiSectionCards(text), 96);
+  const joined = rendered.join('\n');
+  const dataLine = rendered.find(
+    (line) =>
+      line.includes('cosine + porter + bm25') &&
+      line.includes('0.8630*') &&
+      line.includes('0.8640*'),
+  );
+
+  expect(joined).toContain('Variants So Far');
+  expect(joined).toContain('cosine + porter + bm25');
+  expect(joined).toContain('0.8630*');
+  expect(joined).toContain('0.8640*');
+  expect(dataLine).toBeTruthy();
 });

--- a/tests/tui-proactive.test.ts
+++ b/tests/tui-proactive.test.ts
@@ -11,7 +11,7 @@ test('uses fullauto badge for full-auto proactive messages', () => {
 });
 
 test('suppresses reminder chrome for eval proactive messages', () => {
-  expect(proactiveBadgeLabel('eval')).toBeNull();
+  expect(proactiveBadgeLabel('eval')).toBe('eval');
   expect(proactiveSourceSuffix('eval')).toBe('');
 });
 

--- a/tests/tui-slash-command.test.ts
+++ b/tests/tui-slash-command.test.ts
@@ -51,6 +51,16 @@ test('maps Discord-style slash commands to gateway command args', () => {
   expect(mapTuiSlashCommandToGatewayArgs(['help'])).toEqual(['help']);
   expect(mapTuiSlashCommandToGatewayArgs(['h'])).toEqual(['help']);
   expect(mapTuiSlashCommandToGatewayArgs(['status'])).toEqual(['status']);
+  expect(mapTuiSlashCommandToGatewayArgs(['memory'])).toEqual([
+    'memory',
+    'inspect',
+  ]);
+  expect(
+    mapTuiSlashCommandToGatewayArgs(['memory', 'inspect', 'session-1']),
+  ).toEqual(['memory', 'inspect', 'session-1']);
+  expect(
+    mapTuiSlashCommandToGatewayArgs(['memory', 'query', 'deploy', 'animation']),
+  ).toEqual(['memory', 'query', 'deploy', 'animation']);
   expect(
     mapTuiSlashCommandToGatewayArgs(['auth', 'status', 'hybridai']),
   ).toEqual(['auth', 'status', 'hybridai']);

--- a/tests/tui-slash-menu.test.ts
+++ b/tests/tui-slash-menu.test.ts
@@ -14,6 +14,8 @@ test('builds canonical, choice-based, and TUI-only slash menu entries', () => {
   const labels = entries.map((entry) => entry.label);
 
   expect(labels).toContain('/show tools');
+  expect(labels).toContain('/memory inspect [sessionId]');
+  expect(labels).toContain('/memory query <query>');
   expect(labels).toContain('/model select');
   expect(labels).toContain('/dream <now|on|off>');
   expect(labels).toContain('/dream now');

--- a/tests/tui-slash-menu.test.ts
+++ b/tests/tui-slash-menu.test.ts
@@ -45,6 +45,7 @@ test('builds canonical, choice-based, and TUI-only slash menu entries', () => {
   expect(labels).toContain('/plugin check <plugin-id>');
   expect(labels).toContain('/eval [list|env|<suite>|<command...>]');
   expect(labels).toContain('/eval list');
+  expect(labels).toContain('/eval locomo');
   expect(labels).toContain('/eval tau2');
   expect(labels).toContain('/eval swebench-verified');
   expect(labels).not.toContain('/eval tau2-bench');


### PR DESCRIPTION
## What changed
- add a native managed `/eval locomo` suite that downloads the official `locomo10.json` dataset during setup
- add a hidden internal LOCOMO runner that benchmarks recent-tail context against HybridClaw semantic memory recall and writes structured run results
- wire LOCOMO into eval command handling, CLI help, slash-command discovery, and developer command docs
- add focused tests for the native runner and `/eval` integration paths

## Why
The upstream LOCOMO repository is a Python QA evaluation harness, while HybridClaw needs a native `/eval` memory benchmark that fits the existing managed eval workflow and exercises HybridClaw's own memory stack.

## Impact
- operators can run `setup`, `run`, `status`, `results`, and `logs` for LOCOMO through the same managed eval surface as the other implemented suites
- LOCOMO results now compare a naive recent-history baseline with semantic recall under a fixed token budget
- the implementation stays inside HybridClaw rather than shelling out to the upstream project

## Validation
- `npm run format`
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/locomo-native.test.ts tests/eval-command.test.ts tests/gateway-service.eval-command.test.ts tests/command-registry.test.ts tests/tui-slash-menu.test.ts`
- `npm run typecheck`
