### PR TITLE
[codex] add byterover memory plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **ByteRover memory plugin**: New bundled `byterover-memory` external memory
+  provider that injects prompt-time recall through `brv query`, exposes
+  `brv_query` / `brv_curate` / `brv_status` model tools, and curates
+  completed turns, native memory writes, and pre-compaction summaries into
+  ByteRover's Context Tree. Works offline by default with optional cloud sync.
+- **Memory plugins overview page**: New comparison page at
+  `/docs/extensibility/memory-plugins` covering all five memory plugins and
+  built-in memory with a feature matrix, local vs cloud modes, and guidance
+  for choosing a plugin.
+- **Nested sidebar navigation**: The docs sidebar now supports `children`
+  arrays, used to group memory plugin pages under the overview entry.
+
+### Changed
+
+- **Memory plugin docs standardized**: All five plugin doc pages now follow
+  the same structure: Prerequisites, HybridClaw Setup, Config, Commands,
+  Example Prompts & Use Cases, Tips & Tricks, and Troubleshooting. Added
+  external links, local vs cloud options, and researched tips for each.
+
+### Fixed
+
+- **Plugin install skips redundant deps**: When a plugin declares
+  `nodeDependencies` or `pipDependencies` but the required binary is already
+  on PATH, `plugin install` now skips both the approval prompt and the npm/pip
+  install, printing a green `[check]` status instead.
+- **Plugin check reports global binaries**: `plugin check` now correctly
+  reports dependencies as installed when the corresponding binary is available
+  globally, instead of only checking the plugin's local `node_modules`.
+
 ## [0.12.6](https://github.com/HybridAIOne/hybridclaw/tree/v0.12.6)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Browse the full manual at
   [Extensibility](https://www.hybridclaw.io/docs/extensibility),
   [Bundled Skills](https://www.hybridclaw.io/docs/guides/bundled-skills),
   [Plugin System](https://www.hybridclaw.io/docs/extensibility/plugins),
+  [ByteRover Memory Plugin](https://www.hybridclaw.io/docs/extensibility/byterover-memory-plugin),
   [GBrain Plugin](https://www.hybridclaw.io/docs/extensibility/gbrain-plugin),
   [Honcho Memory Plugin](https://www.hybridclaw.io/docs/extensibility/honcho-memory-plugin), and
   [MemPalace Memory Plugin](https://www.hybridclaw.io/docs/extensibility/mempalace-memory-plugin)

--- a/docs/content/extensibility/README.md
+++ b/docs/content/extensibility/README.md
@@ -20,7 +20,7 @@ operate at different layers, and are designed to complement each other.
 | **Install** | Ship with the codebase | Drop a `SKILL.md` file | `hybridclaw plugin install` or drop a directory |
 | **Hot reload** | Requires rebuild | Immediate (loaded per turn) | `/plugin reload` in session |
 | **Config needed** | Code change | None | `hybridclaw.plugin.yaml` manifest |
-| **Example** | `read`, `write`, `web_fetch`, `bash` | `pdf`, `github-pr-workflow`, `notion` | `gbrain`, `honcho-memory` |
+| **Example** | `read`, `write`, `web_fetch`, `bash` | `pdf`, `github-pr-workflow`, `notion` | `byterover-memory`, `gbrain`, `honcho-memory` |
 
 ## Tools (Container Runtime)
 
@@ -150,8 +150,8 @@ Another example:
 | Tools | `container/src/tools.ts` |
 | Skills | `skills/<name>/SKILL.md`, agent workspace, `config.skills.extraDirs` |
 | Plugins | `~/.hybridclaw/plugins/<id>/`, `.hybridclaw/plugins/<id>/` |
-| Plugin docs | `docs/content/extensibility/plugins.md` |
-| Skill docs | `docs/content/extensibility/skills.md` |
+| Plugin docs | `docs/development/extensibility/plugins.md` |
+| Skill docs | `docs/development/extensibility/skills.md` |
 
 ## CLI and Session Commands
 

--- a/docs/content/extensibility/byterover-memory-plugin.md
+++ b/docs/content/extensibility/byterover-memory-plugin.md
@@ -1,0 +1,390 @@
+---
+title: ByteRover Memory Plugin
+description: Setup, configuration, commands, and runtime behavior for the bundled `byterover-memory` plugin.
+sidebar_position: 8
+---
+
+# ByteRover Memory Plugin
+
+HybridClaw ships a bundled ByteRover integration at
+[`plugins/byterover-memory`](https://github.com/HybridAIOne/hybridclaw/tree/main/plugins/byterover-memory).
+
+The plugin keeps HybridClaw built-in memory active and adds ByteRover in four
+places:
+
+- prompt-time recall through `brv query` using the latest user message
+- model tools: `brv_query`, `brv_curate`, and `brv_status`
+- a local operator command: `/byterover ...`
+- background curation for finished turns, successful native `memory` writes,
+  and pre-compaction summaries
+
+Like `honcho-memory`, ByteRover is marked as an external `memoryProvider`.
+Only one such plugin can be active at a time, alongside HybridClaw's built-in
+`MEMORY.md`, `USER.md`, and SQLite session store.
+
+## Prerequisites
+
+### Install the ByteRover CLI
+
+The plugin shells out to the `brv` CLI. Install it before enabling the plugin:
+
+```bash
+npm install -g byterover-cli
+# or
+curl -fsSL https://byterover.dev/install.sh | sh
+```
+
+Verify the installation:
+
+```bash
+brv --version
+```
+
+For alternative installation methods, see the
+[ByteRover CLI repository](https://github.com/campfirein/byterover-cli) and
+the [ByteRover documentation](https://docs.byterover.dev).
+
+> **Tip:** You can skip the manual install. Running
+> `hybridclaw plugin install ./plugins/byterover-memory` will offer to install
+> `byterover-cli` as a local npm dependency inside the plugin directory
+> automatically.
+
+### Initialize the Context Tree
+
+ByteRover stores its Context Tree relative to the directory where you run
+`brv`. The HybridClaw plugin uses `workingDirectory` in its config (default:
+`~/.hybridclaw/byterover`) as the working directory for all `brv` calls.
+
+ByteRover is directory-scoped — the Context Tree lives in `.brv/` relative to
+where you run `brv`. Choose one of these two setups:
+
+### Option A: Project-scoped (recommended)
+
+The plugin and your shell both use the same project directory. No extra config
+needed — `brv query` from the project root and `/byterover query` in TUI hit
+the same context tree.
+
+```bash
+cd ~/src/my-project
+brv
+```
+
+Then point the plugin at the same directory:
+
+```text
+/plugin config byterover-memory workingDirectory ~/src/my-project
+```
+
+### Option B: Global memory
+
+A single context tree shared across all projects, stored in the plugin's
+default directory. Good for cross-project knowledge like personal preferences
+and general decisions.
+
+```bash
+mkdir -p ~/.hybridclaw/byterover
+cd ~/.hybridclaw/byterover
+brv
+```
+
+No plugin config change needed — `~/.hybridclaw/byterover` is the default
+`workingDirectory`. When querying from the shell, remember to `cd` there
+first:
+
+```bash
+cd ~/.hybridclaw/byterover && brv query auth
+```
+
+### First launch (both options)
+
+ByteRover auto-configures on first launch. Inside the `brv` interactive REPL,
+it will prompt you to:
+
+1. **Select an LLM provider** — choose from 18 supported providers or use
+   ByteRover's built-in option. You need an API key for your chosen provider.
+2. **Pick a model** — ByteRover prompts you to select after provider setup.
+
+After the initial setup, curate some initial context inside the `brv` REPL so
+the Context Tree is not empty:
+
+```text
+brv> /curate This project uses TypeScript and PostgreSQL.
+```
+
+Then exit the REPL and verify the setup from your normal shell:
+
+```bash
+brv status
+```
+
+Expected: `Context Tree: Initialized` and a non-empty `.brv/context-tree/`
+directory.
+
+### Local vs Cloud
+
+ByteRover works in two modes:
+
+- **Local (default)**: the Context Tree is stored in `.brv/context-tree/` as
+  human-readable markdown files. No account or API key required. All queries
+  and curation happen locally through your configured LLM provider.
+- **Cloud sync (optional)**: with a `BRV_API_KEY`, you can push your Context
+  Tree to ByteRover's cloud for backup, cross-machine sync, and team sharing.
+  Cloud sync is always explicit through `brv push` — nothing leaves your
+  machine unless you choose to push. Optionally initialize version control
+  with `brv vc init` for Git-based tracking of your Context Tree.
+
+For local-only use, just install the CLI and initialize. For cloud sync, sign
+up at [byterover.dev](https://byterover.dev) and set your API key (see below).
+
+## HybridClaw Setup
+
+### Install the plugin
+
+```bash
+hybridclaw plugin install ./plugins/byterover-memory
+```
+
+If `brv` is not yet on your `PATH`, the installer will offer to install
+`byterover-cli` as a local npm dependency inside the plugin directory.
+
+### From a local TUI or web session
+
+```text
+/plugin install ./plugins/byterover-memory --yes
+/plugin enable byterover-memory
+/byterover status
+```
+
+Both `/plugin install` and `/plugin enable` automatically reload the plugin
+runtime — no separate `/plugin reload` is needed.
+
+### Set credentials (optional)
+
+For cloud sync, store the ByteRover API key through HybridClaw secrets:
+
+```text
+/secret set BRV_API_KEY your-byterover-key
+```
+
+The key is optional. Without it, ByteRover runs in local-first mode.
+
+### Verify
+
+```text
+/plugin list
+/plugin check byterover-memory
+/byterover status
+/show tools
+```
+
+Expected: `byterover-memory` shows as enabled, `brv` resolves, `/byterover
+status` responds, and `brv_query`, `brv_curate`, `brv_status` appear in the
+tool list.
+
+## Recommended Config
+
+The plugin works with defaults after install. A small explicit config for
+regular use:
+
+```json
+{
+  "plugins": {
+    "list": [
+      {
+        "id": "byterover-memory",
+        "enabled": true,
+        "config": {
+          "command": "brv",
+          "workingDirectory": "~/.hybridclaw/byterover",
+          "autoCurate": true,
+          "mirrorMemoryWrites": true,
+          "maxInjectedChars": 4000,
+          "queryTimeoutMs": 30000,
+          "curateTimeoutMs": 120000
+        }
+      }
+    ]
+  }
+}
+```
+
+Supported config keys:
+
+- `command`: ByteRover executable to spawn. Defaults to `brv`.
+- `workingDirectory`: cwd used for every `brv` invocation. Defaults to
+  `<runtime-home>/byterover`, so the knowledge tree is profile-scoped rather
+  than repo-scoped.
+- `autoCurate`: when `true`, queue `brv curate` after completed assistant
+  turns. Defaults to `true`.
+- `mirrorMemoryWrites`: when `true`, mirror successful native `memory` writes
+  into ByteRover as labeled curations. Defaults to `true`.
+- `maxInjectedChars`: prompt budget for auto-injected ByteRover recall.
+  Defaults to `4000`.
+- `queryTimeoutMs`: timeout for prompt recall, `brv_query`, and
+  `/byterover query`. Defaults to `30000`. ByteRover queries involve LLM
+  calls against the context tree, so they need more time than a simple search.
+- `curateTimeoutMs`: timeout for queued and explicit `brv curate` calls.
+  Defaults to `120000`.
+
+## Commands and Tools
+
+### Slash command
+
+```text
+/byterover status
+/byterover query auth migration
+/byterover curate Remember that concise answers are preferred.
+```
+
+The command is a direct CLI passthrough with `status` as the default when no
+subcommand is given.
+
+### Model tools
+
+| Tool | Description |
+| --- | --- |
+| `brv_status` | Show CLI health, working directory, and whether `BRV_API_KEY` is configured |
+| `brv_query` | Search ByteRover memory for relevant prior knowledge |
+| `brv_curate` | Explicitly store durable facts, decisions, or preferences |
+
+### Behavior
+
+- Before each turn, the plugin runs `brv query -- <latest-user-message>`.
+- If ByteRover returns usable text, that recall is injected into prompt context
+  as current-turn external memory.
+- The plugin also injects a short tool-use guide so the model knows when to use
+  `brv_query`, `brv_curate`, and `brv_status`.
+- After a completed turn, the plugin queues a `brv curate` call with a compact
+  `User:` / `Assistant:` summary.
+- Successful native `memory` writes are mirrored into ByteRover with labels
+  such as `User profile` or `Durable memory`.
+- Before compaction, the plugin curates the compaction summary plus a few recent
+  user/assistant excerpts so older context is not lost before SQLite archival.
+- All ByteRover calls run on the gateway host process, not inside the agent
+  container.
+
+## Example Prompts and Use Cases
+
+### Store project decisions
+
+```text
+We decided to use PostgreSQL instead of MongoDB for the user service.
+The migration is planned for Q3 and will require schema changes in
+three microservices.
+```
+
+ByteRover automatically curates this into its Context Tree after the turn
+completes. In a later session, asking about the user service database will
+surface this decision.
+
+### Cross-session recall
+
+```text
+What do we know about the auth migration?
+```
+
+The plugin queries ByteRover before the turn and injects relevant prior context
+into the prompt. The model answers using both session history and ByteRover
+recall.
+
+### Explicit curation
+
+```text
+Use brv_curate to remember: deploy to staging requires VPN access
+and the deploy key from 1Password under "Staging Deploy Key".
+```
+
+This stores the fact explicitly rather than waiting for background curation.
+
+### Debug what ByteRover knows
+
+```text
+/byterover query deployment process
+/byterover status
+```
+
+Use the slash command to inspect raw ByteRover output without going through the
+model.
+
+### Pre-compaction preservation
+
+Long sessions that trigger compaction automatically curate a summary into
+ByteRover before the older messages are archived. This means important context
+from early in a long session is preserved even after compaction discards the
+original messages.
+
+## Tips and Tricks
+
+- **Context Tree is git-friendly.** The `.brv/context-tree/` directory contains
+  plain markdown files organized as Domains > Topics > Context Files. You can
+  commit them to version control, review changes in PRs, and share across
+  machines without cloud sync.
+- **Start local, add cloud later.** The local-first mode requires no account
+  and works fully offline. Add `BRV_API_KEY` later when you want cross-machine
+  sync or team sharing.
+- **Use `brv restart` when stuck.** If ByteRover becomes unresponsive or hangs
+  after an update, `brv restart` clears the process state. Run it from the
+  shell, not through `/byterover`.
+- **CI and automation.** Use `--headless --format json` flags for
+  machine-parseable output in scripts and CI pipelines.
+- **Mind the working directory.** The `workingDirectory` config controls where
+  the Context Tree lives. The default is profile-scoped
+  (`~/.hybridclaw/byterover`), not repo-scoped. Set it explicitly if you want
+  per-project knowledge trees.
+- **No data leaves your machine by default.** Cloud sync only happens through
+  explicit `brv push`. The plugin never pushes automatically.
+- **Logging out preserves local data.** Running `brv logout` only clears cloud
+  credentials. Your local Context Tree is untouched.
+- **Pair with built-in memory.** Use HybridClaw's `MEMORY.md` for fast
+  operational notes and session-local preferences. Use ByteRover for durable
+  knowledge that should survive across projects and sessions.
+
+## Troubleshooting
+
+- **Plugin loads but no tools appear:**
+  Check `/byterover status`. If the `brv` binary is not found, set `command`
+  to the full path or ensure it is on `PATH` for the gateway process.
+
+- **No prompt recall appears:**
+  The plugin only injects recall when `brv query` returns non-empty results.
+  Curate some facts first, then verify with `/byterover query <term>`.
+
+- **Another memory provider is already active:**
+  ByteRover is marked `memoryProvider: true`. Only one exclusive provider can
+  be active. Disable the other plugin first (e.g., `honcho-memory`).
+
+- **Query timeouts (`/byterover query` or `brv_query`):**
+  ByteRover queries involve LLM calls against the context tree and can take
+  15-25 seconds depending on your provider. If you see timeout errors,
+  increase `queryTimeoutMs` (default: 30000):
+
+  ```text
+  /plugin config byterover-memory queryTimeoutMs 60000
+  ```
+
+- **Slow curation or timeouts:**
+  Background `brv curate` runs through your LLM provider. If your provider is
+  slow, increase `curateTimeoutMs` or check your provider configuration.
+
+- **Context Tree is empty after many sessions:**
+  Check that `autoCurate` is `true` (the default). Also verify that
+  `workingDirectory` points where you expect — the tree might be in a different
+  directory.
+
+- **`brv query` from the shell finds nothing, but TUI recall works:**
+  ByteRover is directory-scoped. The plugin uses `workingDirectory` (default:
+  `~/.hybridclaw/byterover`) for all `brv` calls, but running `brv query`
+  from your shell uses the current directory. To query the same tree the plugin
+  uses, either `cd` to the working directory first or pass `--dir`:
+
+  ```bash
+  cd ~/.hybridclaw/byterover && brv query auth
+  ```
+
+  Alternatively, set the plugin's `workingDirectory` to your project directory
+  so both the plugin and your shell use the same context tree.
+
+- **Cloud sync issues:**
+  Run `brv status` from the shell to check cloud connectivity. Verify your
+  `BRV_API_KEY` with `/secret list`. Remember that sync is explicit through
+  `brv push`, not automatic.

--- a/docs/content/extensibility/gbrain-plugin.md
+++ b/docs/content/extensibility/gbrain-plugin.md
@@ -219,16 +219,18 @@ local TUI or web sessions.
 
 ```text
 /plugin install ./plugins/gbrain
+/plugin enable gbrain
 /plugin config gbrain workingDirectory ~/brain
-/plugin reload
-/plugin check gbrain
+/gbrain status
 ```
+
+Both `/plugin install` and `/plugin enable` automatically reload the plugin
+runtime — no separate `/plugin reload` is needed.
 
 If you are updating the plugin from a local checkout:
 
 ```text
 /plugin reinstall ./plugins/gbrain
-/plugin reload
 /plugin check gbrain
 ```
 
@@ -578,6 +580,56 @@ For the upstream sync runbook, see
 For the upstream verification runbook, see
 [GBRAIN_VERIFY.md](https://github.com/garrytan/gbrain/blob/master/docs/GBRAIN_VERIFY.md).
 
+## Example Prompts and Use Cases
+
+### Recall knowledge about people or companies
+
+```text
+What do we know about Pedro Franceschi and his company?
+```
+
+The plugin queries GBrain before the turn and injects matching brain pages into
+prompt context. The model answers using both session history and GBrain recall.
+
+### Store durable facts back to the brain
+
+```text
+Use gbrain_put_page to save a new page about the partnership discussion
+with Acme Corp. Include the key terms we agreed on.
+```
+
+This writes directly to the GBrain knowledge base so the information is
+available in future sessions and across projects.
+
+### Research and follow-up
+
+```text
+Use GBrain to find the Acme company page, read the full page, then
+summarize the current state and open threads with citations.
+```
+
+This triggers a read flow: `gbrain_query` to find the page, then
+`gbrain_get_page` for the full content.
+
+### Track chronological events
+
+```text
+Use gbrain_add_timeline_entry to log that we signed the contract with
+Acme on 2026-04-15.
+```
+
+GBrain's timeline features let you track events and retrieve them
+chronologically.
+
+### Keep the brain current after external edits
+
+```text
+/gbrain sync --repo ~/brain
+/gbrain embed --stale
+```
+
+Run these after editing brain markdown files outside HybridClaw.
+
 ## Tips & Tricks
 
 - Prefer `query` for natural-language prompts. It is the default and lets
@@ -604,3 +656,37 @@ For the upstream verification runbook, see
   `gbrain embed --stale` and verify `OPENAI_API_KEY` is available.
 - If sync seems to run but results stay stale on Supabase, check for a
   Transaction mode pooler URL and switch to Session mode.
+
+## Troubleshooting
+
+- **Plugin loads but no `gbrain_*` tools appear:**
+  `gbrain --tools-json` likely failed during plugin registration. Check
+  `/gbrain status` and the gateway logs. Verify that `gbrain --version`
+  works from the shell the gateway process uses.
+
+- **No prompt recall appears:**
+  GBrain returned no matches. Check that the brain has indexed pages with
+  `gbrain stats` and that embeddings are built with `gbrain embed --stale`.
+
+- **Wrong brain is being queried:**
+  Set `workingDirectory` explicitly to your brain repo path. This is the
+  single most common source of "loaded plugin, wrong brain" confusion.
+
+- **Bun not found by gateway:**
+  If you installed GBrain through the Bun wrapper, `bun` must be on `PATH`
+  for the gateway process, not just your interactive shell. Alternatively,
+  point `command` at a compiled binary.
+
+- **Supabase sync shows success but page count is low:**
+  Check for a Transaction mode pooler URL in your connection string. GBrain
+  sync requires Session mode pooler or a direct connection string.
+
+- **Weak or purely lexical results from `gbrain query`:**
+  Embeddings may be missing or stale. Run `gbrain embed --stale` and verify
+  that `OPENAI_API_KEY` is available for the embedding model.
+
+- **Credential errors:**
+  Use `/secret set` for credentials rather than hardcoding in config. The
+  plugin reads `GBRAIN_DATABASE_URL`, `DATABASE_URL`, `OPENAI_API_KEY`, and
+  `ANTHROPIC_API_KEY` from HybridClaw secrets and injects them into the child
+  process.

--- a/docs/content/extensibility/honcho-memory-plugin.md
+++ b/docs/content/extensibility/honcho-memory-plugin.md
@@ -30,6 +30,27 @@ Only one plugin marked as an external `memoryProvider` can be active at a time.
 That keeps HybridClaw on a clear model: built-in memory plus at most one
 external provider.
 
+## Prerequisites
+
+### Create a Honcho account
+
+Honcho offers two deployment options:
+
+- **Managed cloud (recommended for getting started)**: sign up at
+  [honcho.dev](https://honcho.dev) to get an API key
+  (see [Honcho documentation](https://docs.honcho.dev) for details). The managed service
+  includes $100 in free credits (no credit card required), which covers
+  approximately 50 million tokens of ingestion. The `get_context()` call that
+  runs every turn is free. Background "dreaming" (asynchronous reasoning) is
+  also free.
+- **Self-hosted**: deploy the open-source
+  [Honcho server](https://github.com/plastic-labs/honcho) on your own
+  infrastructure. Set `baseUrl` to your server address and leave
+  `HONCHO_API_KEY` unset if auth is disabled.
+
+No binary installation is required. The plugin communicates with Honcho
+entirely through its HTTP API.
+
 ## What It Mirrors
 
 Honcho receives:
@@ -62,12 +83,16 @@ For a local checkout:
 hybridclaw plugin install ./plugins/honcho-memory
 ```
 
-Then set the Honcho credential through `/secret`. The plugin can run on its
-built-in defaults without any extra config:
+Then enable the plugin and set the Honcho credential through `/secret`:
 
 ```text
+/plugin enable honcho-memory
 /secret set HONCHO_API_KEY your-honcho-key
+/honcho status
 ```
+
+Both `/plugin install` and `/plugin enable` automatically reload the plugin
+runtime — no separate `/plugin reload` is needed.
 
 If you want to pin explicit settings in `config.json`, a small stable config
 looks like this:
@@ -447,6 +472,56 @@ The usual first-run flow is:
 If you already have useful context in `SOUL.md`, `IDENTITY.md`, `USER.md`, or
 `MEMORY.md`, the setup step will seed that data into Honcho on demand.
 
+## Example Prompts and Use Cases
+
+### Cross-session user preferences
+
+```text
+I prefer functional programming patterns over OOP. I use Neovim and work
+primarily in Rust and TypeScript.
+```
+
+Honcho builds an evolving user profile from these facts. In a future session,
+asking for code suggestions will reflect these preferences without repeating
+them.
+
+### Dialectic reasoning for complex decisions
+
+```text
+Should we use a monorepo or polyrepo for the new platform? Consider our
+team size (8 engineers) and the fact that we ship three separate products.
+```
+
+With dialectic reasoning enabled, Honcho uses its accumulated knowledge about
+you and your team to reason through trade-offs, not just retrieve facts.
+
+### Explicit conclusion storage
+
+```text
+Use honcho_conclude to save: we decided on a monorepo with Turborepo.
+The migration starts next sprint.
+```
+
+This stores a durable conclusion in Honcho that persists across sessions and
+can be retrieved through `honcho_search` or automatic prompt recall.
+
+### Inspect what Honcho knows
+
+```text
+/honcho identity --show
+/honcho search deployment process
+What does Honcho know about my coding preferences?
+```
+
+Use these to debug recall quality or verify that Honcho is building an accurate
+user model.
+
+### Long-running project continuity
+
+Use `sessionStrategy: global` or `/honcho map release-v2` to maintain a single
+Honcho thread across many HybridClaw sessions. This is useful for multi-week
+projects where you want the agent to remember all prior context.
+
 ## Tips And Tricks
 
 - Use the defaults first. In most cases, `/secret set HONCHO_API_KEY ...` plus
@@ -468,6 +543,17 @@ If you already have useful context in `SOUL.md`, `IDENTITY.md`, `USER.md`, or
   peer.
 - Use `/honcho sync` after a burst of conversation if you want to force a flush
   and refresh prompt context immediately.
+- **Dreaming is free.** Honcho's background reasoning runs continuously
+  without additional cost. You only pay for token ingestion ($2/M tokens on
+  the managed cloud).
+- **Beware compaction amnesia.** Long sessions get compacted and early context
+  can vanish. If the agent forgets decisions from earlier in the session, use
+  `honcho_conclude` to save them explicitly or switch to
+  `writeFrequency: turn` for immediate persistence.
+- **Cron jobs start with no history.** Background tasks and scheduled jobs spin
+  up fresh sessions with zero conversation history. Use `sessionStrategy:
+  global` or seed important context through workspace files if you need
+  continuity in automated workflows.
 
 ## Troubleshooting
 

--- a/docs/content/extensibility/memory-plugins.md
+++ b/docs/content/extensibility/memory-plugins.md
@@ -1,0 +1,128 @@
+---
+title: Memory Plugins
+description: Overview and comparison of HybridClaw's built-in memory and external memory plugin options.
+sidebar_position: 5
+---
+
+# Memory Plugins
+
+HybridClaw has a layered memory architecture. The built-in memory system is
+always active and handles session transcripts, file-backed notes (`MEMORY.md`,
+`USER.md`), semantic recall, and compaction summaries. Memory plugins add
+external recall and persistence on top of that foundation.
+
+## How Plugins Layer On Built-In Memory
+
+```text
+┌─────────────────────────────────────────────┐
+│  Prompt context for each turn               │
+├─────────────────────────────────────────────┤
+│  Built-in memory (always active)            │
+│  ├── MEMORY.md, USER.md, daily notes        │
+│  ├── SQLite session transcript              │
+│  ├── Semantic recall                        │
+│  └── Compaction summaries                   │
+├─────────────────────────────────────────────┤
+│  Memory plugin (optional, one at a time*)   │
+│  ├── Prompt-time recall injection           │
+│  ├── Model tools for search/write           │
+│  └── Background curation / sync             │
+└─────────────────────────────────────────────┘
+
+* Plugins marked memoryProvider: true are exclusive —
+  only one can be active. Additive plugins can run
+  alongside any configuration.
+```
+
+## Exclusive vs Additive Plugins
+
+Plugins declare one of two integration modes:
+
+- **Exclusive** (`memoryProvider: true`): replaces the external memory slot.
+  Only one exclusive plugin can be active at a time. Built-in memory remains
+  active. ByteRover and Honcho use this mode.
+- **Additive**: layers additional recall alongside built-in memory and any
+  active exclusive plugin. MemPalace, QMD, and GBrain use this mode.
+
+## Comparison
+
+| Plugin | Integration | Storage | Local | Cloud | Auto-install | API Key | Cost | Command |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **Built-in Memory** | Always active | SQLite + markdown files | Yes | No | N/A | No | Free | N/A |
+| **ByteRover** | Exclusive | Context Tree (`.brv/`) | Yes (default) | Optional sync | Yes (`npm`) | Optional (`BRV_API_KEY`) | Free local, paid cloud | `/byterover` |
+| **Honcho** | Exclusive | Cloud API / self-hosted | Yes (self-hosted) | Managed cloud | No binary needed | Yes (`HONCHO_API_KEY`) | $100 free credits, no card | `/honcho` |
+| **MemPalace** | Additive | ChromaDB + SQLite | Yes (only mode) | No | Yes (`pip`) | No | Free | `/mempalace` |
+| **QMD** | Additive | Local markdown index | Yes (only mode) | No | Manual | No | Free | `/qmd` |
+| **GBrain** | Additive | PGLite / Supabase | Yes (PGLite) | Supabase | Manual | `OPENAI_API_KEY` for embeddings | Free local, Supabase costs | `/gbrain` |
+
+## Choosing A Plugin
+
+### Built-in memory (no plugin)
+
+The default. Good enough for most workflows. Handles session history,
+file-backed durable notes, semantic recall, and compaction summaries out of the
+box with zero setup.
+
+### ByteRover
+
+Best for **structured, project-scoped knowledge**. ByteRover organizes memory
+into a hierarchical Context Tree (Domains > Topics > Context Files) stored as
+human-readable markdown in `.brv/context-tree/`. The tree is git-friendly and
+can be version-controlled. Works fully offline by default with optional cloud
+sync.
+
+- Install: `npm install -g byterover-cli`
+- [ByteRover Memory Plugin docs](byterover-memory-plugin.md)
+
+### Honcho
+
+Best for **cross-session user modeling and reasoning**. Honcho builds evolving
+peer representations of users and agents, supports dialectic reasoning, and
+extracts conclusions through continuous background "dreaming." Cloud-managed
+with generous free tier ($100 credits, no card required) or self-hostable.
+
+- Install: no binary needed, just an API key
+- [Honcho Memory Plugin docs](honcho-memory-plugin.md)
+
+### MemPalace
+
+Best for **local-first, privacy-focused memory** with zero API costs. Uses the
+ancient memory palace mnemonic as its organizational metaphor (Wings > Rooms >
+Drawers). All embeddings are computed locally via Sentence Transformers.
+Optionally exposes 19 MCP tools for taxonomy, knowledge graph, and diary
+features.
+
+- Install: `pip install mempalace`
+- [MemPalace Memory Plugin docs](mempalace-memory-plugin.md)
+
+### QMD
+
+Best for **searching an existing markdown corpus**. QMD indexes local markdown
+files, docs, and optionally exported session transcripts. Lightweight plugin
+with lexical, vector, and hybrid retrieval modes. Good when you already have a
+well-organized markdown knowledge base.
+
+- Install: external `qmd` CLI
+- [QMD Memory Plugin docs](qmd-memory-plugin.md)
+
+### GBrain
+
+Best for **world knowledge and research** — people, companies, meetings,
+concepts, and notes organized in a dedicated brain repo. Supports local PGLite
+or remote Supabase backends. Mirrors the GBrain tool catalog as `gbrain_*`
+plugin tools for read/write operations.
+
+- Install: `bun add -g github:garrytan/gbrain`
+- [GBrain Plugin docs](gbrain-plugin.md)
+
+## Multiple Plugins
+
+You can combine one exclusive plugin with any number of additive plugins. For
+example:
+
+- **Honcho + GBrain**: Honcho handles user modeling and session continuity
+  while GBrain provides world knowledge recall
+- **ByteRover + MemPalace**: ByteRover handles structured project knowledge
+  while MemPalace adds local search over historical conversations
+
+You cannot run two exclusive plugins (ByteRover + Honcho) at the same time.

--- a/docs/content/extensibility/mempalace-memory-plugin.md
+++ b/docs/content/extensibility/mempalace-memory-plugin.md
@@ -66,6 +66,11 @@ Important distinction:
 
 ## Before You Activate It
 
+[MemPalace](https://github.com/milla-jovovich/mempalace) is a free,
+open-source local memory system that uses ChromaDB and SQLite for storage with
+zero API costs. See the [MemPalace setup guide](https://www.mempalace.tech/guides/setup)
+for detailed instructions.
+
 You need an initialized palace before the plugin can do anything useful.
 HybridClaw can install the `mempalace` Python package into a plugin-local
 environment during `plugin install` if you approve dependency setup, but it
@@ -78,6 +83,11 @@ pip install mempalace
 mempalace init ~/projects/myapp
 mempalace mine ~/projects/myapp
 ```
+
+> **Tip:** You can skip the manual `pip install`. Running
+> `hybridclaw plugin install ./plugins/mempalace-memory` will offer to install
+> `mempalace` into a plugin-local `.venv` automatically. You still need to run
+> `mempalace init` and `mempalace mine` yourself.
 
 The important invariant is:
 
@@ -142,14 +152,14 @@ sessions.
 
 ```text
 /plugin install ./plugins/mempalace-memory --yes
-/plugin reload
+/plugin enable mempalace-memory
+/mempalace status
 ```
 
 If needed, set the palace location explicitly:
 
 ```text
 /plugin config mempalace-memory palacePath ~/.mempalace/palace
-/plugin reload
 ```
 
 To avoid ambiguity, setting `palacePath` explicitly is recommended even when
@@ -505,6 +515,79 @@ Supported config keys:
 - `timeoutMs`: timeout for `status`, `wake-up`, and automatic search calls. The
   plugin gives `mine` a longer minimum timeout automatically.
 
+## Example Prompts and Use Cases
+
+### Recall past decisions
+
+```text
+Why did we switch from REST to GraphQL for the internal API?
+```
+
+If this decision was discussed in a prior session and mined into MemPalace,
+the plugin surfaces the relevant context before the model answers.
+
+### Store operational knowledge
+
+```text
+Remember that the staging deploy requires running database migrations
+first, and the deploy key is in the team 1Password vault.
+```
+
+The built-in memory stores this immediately, and the plugin mirrors the write
+into MemPalace so it is also available through MemPalace search.
+
+### Manual search for specific memories
+
+```text
+/mempalace search "auth provider migration"
+/mempalace wake-up --wing hybridclaw
+```
+
+Use the slash command to inspect raw MemPalace results or wake up context for
+a specific wing.
+
+### Full MCP tool access (with MCP server)
+
+```text
+Use MemPalace to show me the current taxonomy of wings and rooms.
+Use MemPalace to search the knowledge graph for connections between
+the auth service and the user service.
+```
+
+These require the MemPalace MCP server to be configured separately from the
+plugin.
+
+### Cross-tool memory
+
+After a long debugging session, the important conclusions are automatically
+mined into MemPalace. In a future session with a different project, those
+debugging patterns are still retrievable.
+
+## Tips and Tricks
+
+- **Zero cost, fully local.** MemPalace runs entirely offline after the
+  initial model download. No API keys, no cloud accounts, no usage fees.
+- **Pin ChromaDB on macOS ARM.** MemPalace can crash with segfaults when
+  ChromaDB 1.5.6 is installed on Apple Silicon. If you hit this, downgrade
+  with `pip install chromadb==0.6.3` and rebuild. Track upstream fixes in
+  [MemPalace issue #100](https://github.com/milla-jovovich/mempalace/issues/100).
+- **GPU acceleration.** If you have an NVIDIA GPU, install GPU-accelerated
+  `onnxruntime` with CUDA runtime to significantly speed up local embeddings.
+  The "GPU device discovery failed" warning from onnxruntime is cosmetic and
+  harmless with multi-GPU setups.
+- **Large vaults (40k+ drawers).** Unbounded `col.get()` calls can crash with
+  too many SQL variables. If your palace is very large, see
+  [MemPalace issue #211](https://github.com/milla-jovovich/mempalace/issues/211)
+  for batch workarounds.
+- **Split large exports.** If your conversation exports are huge concatenated
+  files, use `mempalace split` before mining to get better segmentation.
+- **Set `palacePath` explicitly.** Even if you use MemPalace's default palace
+  location, setting `palacePath` in plugin config avoids confusion when
+  multiple palaces exist on the system.
+- **Pair with an exclusive provider.** MemPalace is additive, so it can run
+  alongside Honcho or ByteRover. Use the exclusive provider for session
+  modeling and MemPalace for long-term local search.
+
 ## What This Plugin Does Not Do
 
 This plugin is intentionally narrow. It does not:
@@ -521,3 +604,31 @@ This plugin is intentionally narrow. It does not:
 Use MemPalace itself for palace initialization, repair, reset, and other
 maintenance. Use this plugin when you want MemPalace to be the active recall
 and update path for HybridClaw chat memory.
+
+## Troubleshooting
+
+- **Plugin loads but `mempalace status` says "No palace found":**
+  The plugin is not pointed at an initialized palace. Set `palacePath`
+  explicitly to the directory where you ran `mempalace init`.
+
+- **Segfault on macOS ARM:**
+  ChromaDB version conflict. Run `pip install chromadb==0.6.3` in the plugin's
+  `.venv` or your global Python environment.
+
+- **Search returns no results for known facts:**
+  Check that you are searching the correct wing. Use
+  `/mempalace search "term" --wing <wing>` to narrow the search. Also verify
+  that mining has completed with `/mempalace status`.
+
+- **Auto-save is not working:**
+  Check `saveEveryMessages` in plugin config (default: 15). The plugin buffers
+  turns and only mines after the threshold is reached. Use a lower value for
+  testing or run `/mempalace mine` manually.
+
+- **Unicode crashes on Windows:**
+  MemPalace CLI uses Unicode characters that can crash on Windows cp1252
+  terminals. Use Windows Terminal or set your terminal to UTF-8 encoding.
+
+- **MCP tools not visible:**
+  The plugin does not expose MCP tools itself. Add the MemPalace MCP server
+  separately. See the "Optional: Add the MemPalace MCP Server" section above.

--- a/docs/content/extensibility/plugins.md
+++ b/docs/content/extensibility/plugins.md
@@ -68,6 +68,9 @@ or change one top-level `plugins.list[].config` key without editing
 
 ## Repo-Shipped Examples
 
+- `byterover-memory` mirrors turns into ByteRover, injects prompt-time recall
+  through `brv query`, and exposes `brv_query`, `brv_curate`, and `brv_status`
+  tools. Works offline with optional cloud sync.
 - `gbrain` shells out to the GBrain CLI, injects search results into prompt
   context, and mirrors the discovered GBrain operations as `gbrain_*` plugin
   tools

--- a/docs/content/extensibility/qmd-memory-plugin.md
+++ b/docs/content/extensibility/qmd-memory-plugin.md
@@ -11,10 +11,38 @@ HybridClaw ships an installable QMD memory plugin source at
 The plugin complements the built-in SQLite session memory with external QMD
 search over markdown notes, docs, and optional exported session transcripts.
 
+## Prerequisites
+
+### Install the QMD CLI
+
+[QMD](https://github.com/tobi/qmd) is a local CLI search engine for markdown
+documents, knowledge bases, and notes. It combines BM25 keyword search, vector
+semantic search, and LLM reranking — all executed locally on your machine.
+
+The plugin shells out to the `qmd` CLI and does not embed QMD as a library.
+Install QMD separately before enabling the plugin. QMD runs entirely locally
+and has no cloud mode — all indexing and search happens on your machine.
+
+See the [QMD repository](https://github.com/tobi/qmd) for installation
+instructions.
+
+After installing, index your markdown files and build embeddings:
+
+```bash
+qmd collection add ~/docs
+qmd embed
+qmd status
+```
+
+Verify that QMD can answer a query:
+
+```bash
+qmd query "a topic you know is in your docs"
+```
+
 ## Install
 
-1. Install QMD separately. The plugin shells out to the `qmd` CLI and does not
-   embed QMD as a library.
+1. The `qmd` CLI must be installed and on `PATH` (see Prerequisites above).
 2. Install the plugin from this repo:
 
    ```bash
@@ -25,11 +53,15 @@ search over markdown notes, docs, and optional exported session transcripts.
    configured `command` override is available, HybridClaw leaves the plugin
    disabled and reports the missing binary in `/plugin list`.
 
-3. Reload plugins in an active session:
+3. Enable the plugin and verify:
 
    ```text
-   /plugin reload
+   /plugin enable qmd-memory
+   /qmd status
    ```
+
+   Both `/plugin install` and `/plugin enable` automatically reload the plugin
+   runtime — no separate `/plugin reload` is needed.
 
    To switch the QMD retrieval mode from the TUI without editing JSON
    directly, you can also run:
@@ -135,6 +167,44 @@ or vector retrieval. Depending on your local QMD setup, the first `embed` or
 The installed plugin lives under `~/.hybridclaw/plugins/qmd-memory`, so reload
 alone does not pick up repo edits.
 
+## Example Prompts and Use Cases
+
+### Search project documentation
+
+```text
+How does the authentication middleware work?
+```
+
+If your project docs are indexed in QMD, the plugin surfaces matching snippets
+before the model answers, combining QMD knowledge with session context.
+
+### Index a new repository
+
+```text
+/qmd collection add .
+/qmd embed
+/qmd status
+```
+
+This indexes all markdown files in the current directory and builds embeddings
+for hybrid retrieval.
+
+### Debug retrieval quality
+
+```text
+/qmd search "auth middleware"
+/qmd query "how does authentication work?"
+```
+
+Compare `search` (lexical) vs `query` (hybrid) results to understand what QMD
+is finding.
+
+### Export sessions for future search
+
+Enable `sessionExport: true` in config so QMD can index past HybridClaw
+conversations as a normal markdown collection. This lets future sessions
+benefit from discussions in earlier ones.
+
 ## Tips & Tricks
 
 - Prefer `query` for natural-language prompts. It is the default and uses QMD's
@@ -176,3 +246,27 @@ To verify that the plugin is both loaded and actively contributing context:
 If `/plugin list` shows the plugin as enabled but the prompt dump lacks the
 retrieval section, the plugin loaded but QMD returned no usable matches for
 that turn.
+
+## Troubleshooting
+
+- **Plugin loads but stays disabled:**
+  The `qmd` binary is not on `PATH`. Either install QMD or set `command` in
+  plugin config to the full path.
+
+- **No retrieval context appears:**
+  QMD returned no matches for the user message. Try `/qmd status` to confirm
+  the collection has indexed pages, then `/qmd query <term>` to test
+  retrieval directly.
+
+- **Embeddings not built:**
+  Vector and hybrid search modes require embeddings. Run `/qmd embed` or
+  `qmd embed` from the shell. The first run may download models.
+
+- **Results are stale after adding docs:**
+  Run `/qmd collection add .` and `/qmd embed` again to re-index and rebuild
+  embeddings for new files.
+
+- **Prompt dump shows no QMD section:**
+  The plugin loaded but QMD returned no matches. This is normal when the user
+  message does not match any indexed content. Check the indexed collection
+  with `/qmd status`.

--- a/docs/development/agents.md
+++ b/docs/development/agents.md
@@ -44,6 +44,7 @@ Main docs landing pages:
 - [Extensibility](./extensibility/README.md)
 - [Adaptive Skills](./extensibility/adaptive-skills.md)
 - [Agent Packages](./extensibility/agent-packages.md)
+- [ByteRover Memory Plugin](./extensibility/byterover-memory-plugin.md)
 - [Honcho Memory Plugin](./extensibility/honcho-memory-plugin.md)
 - [MemPalace Memory Plugin](./extensibility/mempalace-memory-plugin.md)
 - [OTEL Plugin](./extensibility/otel-plugin.md)

--- a/docs/development/extensibility/README.md
+++ b/docs/development/extensibility/README.md
@@ -20,7 +20,7 @@ operate at different layers, and are designed to complement each other.
 | **Install** | Ship with the codebase | Drop a `SKILL.md` file | `hybridclaw plugin install` or drop a directory |
 | **Hot reload** | Requires rebuild | Immediate (loaded per turn) | `/plugin reload` in session |
 | **Config needed** | Code change | None | `hybridclaw.plugin.yaml` manifest |
-| **Example** | `read`, `write`, `web_fetch`, `bash` | `pdf`, `github-pr-workflow`, `notion` | `gbrain`, `honcho-memory` |
+| **Example** | `read`, `write`, `web_fetch`, `bash` | `pdf`, `github-pr-workflow`, `notion` | `byterover-memory`, `gbrain`, `honcho-memory` |
 
 ## Tools (Container Runtime)
 

--- a/docs/development/extensibility/byterover-memory-plugin.md
+++ b/docs/development/extensibility/byterover-memory-plugin.md
@@ -1,0 +1,390 @@
+---
+title: ByteRover Memory Plugin
+description: Setup, configuration, commands, and runtime behavior for the bundled `byterover-memory` plugin.
+sidebar_position: 8
+---
+
+# ByteRover Memory Plugin
+
+HybridClaw ships a bundled ByteRover integration at
+[`plugins/byterover-memory`](https://github.com/HybridAIOne/hybridclaw/tree/main/plugins/byterover-memory).
+
+The plugin keeps HybridClaw built-in memory active and adds ByteRover in four
+places:
+
+- prompt-time recall through `brv query` using the latest user message
+- model tools: `brv_query`, `brv_curate`, and `brv_status`
+- a local operator command: `/byterover ...`
+- background curation for finished turns, successful native `memory` writes,
+  and pre-compaction summaries
+
+Like `honcho-memory`, ByteRover is marked as an external `memoryProvider`.
+Only one such plugin can be active at a time, alongside HybridClaw's built-in
+`MEMORY.md`, `USER.md`, and SQLite session store.
+
+## Prerequisites
+
+### Install the ByteRover CLI
+
+The plugin shells out to the `brv` CLI. Install it before enabling the plugin:
+
+```bash
+npm install -g byterover-cli
+# or
+curl -fsSL https://byterover.dev/install.sh | sh
+```
+
+Verify the installation:
+
+```bash
+brv --version
+```
+
+For alternative installation methods, see the
+[ByteRover CLI repository](https://github.com/campfirein/byterover-cli) and
+the [ByteRover documentation](https://docs.byterover.dev).
+
+> **Tip:** You can skip the manual install. Running
+> `hybridclaw plugin install ./plugins/byterover-memory` will offer to install
+> `byterover-cli` as a local npm dependency inside the plugin directory
+> automatically.
+
+### Initialize the Context Tree
+
+ByteRover stores its Context Tree relative to the directory where you run
+`brv`. The HybridClaw plugin uses `workingDirectory` in its config (default:
+`~/.hybridclaw/byterover`) as the working directory for all `brv` calls.
+
+ByteRover is directory-scoped — the Context Tree lives in `.brv/` relative to
+where you run `brv`. Choose one of these two setups:
+
+### Option A: Project-scoped (recommended)
+
+The plugin and your shell both use the same project directory. No extra config
+needed — `brv query` from the project root and `/byterover query` in TUI hit
+the same context tree.
+
+```bash
+cd ~/src/my-project
+brv
+```
+
+Then point the plugin at the same directory:
+
+```text
+/plugin config byterover-memory workingDirectory ~/src/my-project
+```
+
+### Option B: Global memory
+
+A single context tree shared across all projects, stored in the plugin's
+default directory. Good for cross-project knowledge like personal preferences
+and general decisions.
+
+```bash
+mkdir -p ~/.hybridclaw/byterover
+cd ~/.hybridclaw/byterover
+brv
+```
+
+No plugin config change needed — `~/.hybridclaw/byterover` is the default
+`workingDirectory`. When querying from the shell, remember to `cd` there
+first:
+
+```bash
+cd ~/.hybridclaw/byterover && brv query auth
+```
+
+### First launch (both options)
+
+ByteRover auto-configures on first launch. Inside the `brv` interactive REPL,
+it will prompt you to:
+
+1. **Select an LLM provider** — choose from 18 supported providers or use
+   ByteRover's built-in option. You need an API key for your chosen provider.
+2. **Pick a model** — ByteRover prompts you to select after provider setup.
+
+After the initial setup, curate some initial context inside the `brv` REPL so
+the Context Tree is not empty:
+
+```text
+brv> /curate This project uses TypeScript and PostgreSQL.
+```
+
+Then exit the REPL and verify the setup from your normal shell:
+
+```bash
+brv status
+```
+
+Expected: `Context Tree: Initialized` and a non-empty `.brv/context-tree/`
+directory.
+
+### Local vs Cloud
+
+ByteRover works in two modes:
+
+- **Local (default)**: the Context Tree is stored in `.brv/context-tree/` as
+  human-readable markdown files. No account or API key required. All queries
+  and curation happen locally through your configured LLM provider.
+- **Cloud sync (optional)**: with a `BRV_API_KEY`, you can push your Context
+  Tree to ByteRover's cloud for backup, cross-machine sync, and team sharing.
+  Cloud sync is always explicit through `brv push` — nothing leaves your
+  machine unless you choose to push. Optionally initialize version control
+  with `brv vc init` for Git-based tracking of your Context Tree.
+
+For local-only use, just install the CLI and initialize. For cloud sync, sign
+up at [byterover.dev](https://byterover.dev) and set your API key (see below).
+
+## HybridClaw Setup
+
+### Install the plugin
+
+```bash
+hybridclaw plugin install ./plugins/byterover-memory
+```
+
+If `brv` is not yet on your `PATH`, the installer will offer to install
+`byterover-cli` as a local npm dependency inside the plugin directory.
+
+### From a local TUI or web session
+
+```text
+/plugin install ./plugins/byterover-memory --yes
+/plugin enable byterover-memory
+/byterover status
+```
+
+Both `/plugin install` and `/plugin enable` automatically reload the plugin
+runtime — no separate `/plugin reload` is needed.
+
+### Set credentials (optional)
+
+For cloud sync, store the ByteRover API key through HybridClaw secrets:
+
+```text
+/secret set BRV_API_KEY your-byterover-key
+```
+
+The key is optional. Without it, ByteRover runs in local-first mode.
+
+### Verify
+
+```text
+/plugin list
+/plugin check byterover-memory
+/byterover status
+/show tools
+```
+
+Expected: `byterover-memory` shows as enabled, `brv` resolves, `/byterover
+status` responds, and `brv_query`, `brv_curate`, `brv_status` appear in the
+tool list.
+
+## Recommended Config
+
+The plugin works with defaults after install. A small explicit config for
+regular use:
+
+```json
+{
+  "plugins": {
+    "list": [
+      {
+        "id": "byterover-memory",
+        "enabled": true,
+        "config": {
+          "command": "brv",
+          "workingDirectory": "~/.hybridclaw/byterover",
+          "autoCurate": true,
+          "mirrorMemoryWrites": true,
+          "maxInjectedChars": 4000,
+          "queryTimeoutMs": 30000,
+          "curateTimeoutMs": 120000
+        }
+      }
+    ]
+  }
+}
+```
+
+Supported config keys:
+
+- `command`: ByteRover executable to spawn. Defaults to `brv`.
+- `workingDirectory`: cwd used for every `brv` invocation. Defaults to
+  `<runtime-home>/byterover`, so the knowledge tree is profile-scoped rather
+  than repo-scoped.
+- `autoCurate`: when `true`, queue `brv curate` after completed assistant
+  turns. Defaults to `true`.
+- `mirrorMemoryWrites`: when `true`, mirror successful native `memory` writes
+  into ByteRover as labeled curations. Defaults to `true`.
+- `maxInjectedChars`: prompt budget for auto-injected ByteRover recall.
+  Defaults to `4000`.
+- `queryTimeoutMs`: timeout for prompt recall, `brv_query`, and
+  `/byterover query`. Defaults to `30000`. ByteRover queries involve LLM
+  calls against the context tree, so they need more time than a simple search.
+- `curateTimeoutMs`: timeout for queued and explicit `brv curate` calls.
+  Defaults to `120000`.
+
+## Commands and Tools
+
+### Slash command
+
+```text
+/byterover status
+/byterover query auth migration
+/byterover curate Remember that concise answers are preferred.
+```
+
+The command is a direct CLI passthrough with `status` as the default when no
+subcommand is given.
+
+### Model tools
+
+| Tool | Description |
+| --- | --- |
+| `brv_status` | Show CLI health, working directory, and whether `BRV_API_KEY` is configured |
+| `brv_query` | Search ByteRover memory for relevant prior knowledge |
+| `brv_curate` | Explicitly store durable facts, decisions, or preferences |
+
+### Behavior
+
+- Before each turn, the plugin runs `brv query -- <latest-user-message>`.
+- If ByteRover returns usable text, that recall is injected into prompt context
+  as current-turn external memory.
+- The plugin also injects a short tool-use guide so the model knows when to use
+  `brv_query`, `brv_curate`, and `brv_status`.
+- After a completed turn, the plugin queues a `brv curate` call with a compact
+  `User:` / `Assistant:` summary.
+- Successful native `memory` writes are mirrored into ByteRover with labels
+  such as `User profile` or `Durable memory`.
+- Before compaction, the plugin curates the compaction summary plus a few recent
+  user/assistant excerpts so older context is not lost before SQLite archival.
+- All ByteRover calls run on the gateway host process, not inside the agent
+  container.
+
+## Example Prompts and Use Cases
+
+### Store project decisions
+
+```text
+We decided to use PostgreSQL instead of MongoDB for the user service.
+The migration is planned for Q3 and will require schema changes in
+three microservices.
+```
+
+ByteRover automatically curates this into its Context Tree after the turn
+completes. In a later session, asking about the user service database will
+surface this decision.
+
+### Cross-session recall
+
+```text
+What do we know about the auth migration?
+```
+
+The plugin queries ByteRover before the turn and injects relevant prior context
+into the prompt. The model answers using both session history and ByteRover
+recall.
+
+### Explicit curation
+
+```text
+Use brv_curate to remember: deploy to staging requires VPN access
+and the deploy key from 1Password under "Staging Deploy Key".
+```
+
+This stores the fact explicitly rather than waiting for background curation.
+
+### Debug what ByteRover knows
+
+```text
+/byterover query deployment process
+/byterover status
+```
+
+Use the slash command to inspect raw ByteRover output without going through the
+model.
+
+### Pre-compaction preservation
+
+Long sessions that trigger compaction automatically curate a summary into
+ByteRover before the older messages are archived. This means important context
+from early in a long session is preserved even after compaction discards the
+original messages.
+
+## Tips and Tricks
+
+- **Context Tree is git-friendly.** The `.brv/context-tree/` directory contains
+  plain markdown files organized as Domains > Topics > Context Files. You can
+  commit them to version control, review changes in PRs, and share across
+  machines without cloud sync.
+- **Start local, add cloud later.** The local-first mode requires no account
+  and works fully offline. Add `BRV_API_KEY` later when you want cross-machine
+  sync or team sharing.
+- **Use `brv restart` when stuck.** If ByteRover becomes unresponsive or hangs
+  after an update, `brv restart` clears the process state. Run it from the
+  shell, not through `/byterover`.
+- **CI and automation.** Use `--headless --format json` flags for
+  machine-parseable output in scripts and CI pipelines.
+- **Mind the working directory.** The `workingDirectory` config controls where
+  the Context Tree lives. The default is profile-scoped
+  (`~/.hybridclaw/byterover`), not repo-scoped. Set it explicitly if you want
+  per-project knowledge trees.
+- **No data leaves your machine by default.** Cloud sync only happens through
+  explicit `brv push`. The plugin never pushes automatically.
+- **Logging out preserves local data.** Running `brv logout` only clears cloud
+  credentials. Your local Context Tree is untouched.
+- **Pair with built-in memory.** Use HybridClaw's `MEMORY.md` for fast
+  operational notes and session-local preferences. Use ByteRover for durable
+  knowledge that should survive across projects and sessions.
+
+## Troubleshooting
+
+- **Plugin loads but no tools appear:**
+  Check `/byterover status`. If the `brv` binary is not found, set `command`
+  to the full path or ensure it is on `PATH` for the gateway process.
+
+- **No prompt recall appears:**
+  The plugin only injects recall when `brv query` returns non-empty results.
+  Curate some facts first, then verify with `/byterover query <term>`.
+
+- **Another memory provider is already active:**
+  ByteRover is marked `memoryProvider: true`. Only one exclusive provider can
+  be active. Disable the other plugin first (e.g., `honcho-memory`).
+
+- **Query timeouts (`/byterover query` or `brv_query`):**
+  ByteRover queries involve LLM calls against the context tree and can take
+  15-25 seconds depending on your provider. If you see timeout errors,
+  increase `queryTimeoutMs` (default: 30000):
+
+  ```text
+  /plugin config byterover-memory queryTimeoutMs 60000
+  ```
+
+- **Slow curation or timeouts:**
+  Background `brv curate` runs through your LLM provider. If your provider is
+  slow, increase `curateTimeoutMs` or check your provider configuration.
+
+- **Context Tree is empty after many sessions:**
+  Check that `autoCurate` is `true` (the default). Also verify that
+  `workingDirectory` points where you expect — the tree might be in a different
+  directory.
+
+- **`brv query` from the shell finds nothing, but TUI recall works:**
+  ByteRover is directory-scoped. The plugin uses `workingDirectory` (default:
+  `~/.hybridclaw/byterover`) for all `brv` calls, but running `brv query`
+  from your shell uses the current directory. To query the same tree the plugin
+  uses, either `cd` to the working directory first or pass `--dir`:
+
+  ```bash
+  cd ~/.hybridclaw/byterover && brv query auth
+  ```
+
+  Alternatively, set the plugin's `workingDirectory` to your project directory
+  so both the plugin and your shell use the same context tree.
+
+- **Cloud sync issues:**
+  Run `brv status` from the shell to check cloud connectivity. Verify your
+  `BRV_API_KEY` with `/secret list`. Remember that sync is explicit through
+  `brv push`, not automatic.

--- a/docs/development/extensibility/gbrain-plugin.md
+++ b/docs/development/extensibility/gbrain-plugin.md
@@ -219,16 +219,18 @@ local TUI or web sessions.
 
 ```text
 /plugin install ./plugins/gbrain
+/plugin enable gbrain
 /plugin config gbrain workingDirectory ~/brain
-/plugin reload
-/plugin check gbrain
+/gbrain status
 ```
+
+Both `/plugin install` and `/plugin enable` automatically reload the plugin
+runtime — no separate `/plugin reload` is needed.
 
 If you are updating the plugin from a local checkout:
 
 ```text
 /plugin reinstall ./plugins/gbrain
-/plugin reload
 /plugin check gbrain
 ```
 
@@ -578,6 +580,56 @@ For the upstream sync runbook, see
 For the upstream verification runbook, see
 [GBRAIN_VERIFY.md](https://github.com/garrytan/gbrain/blob/master/docs/GBRAIN_VERIFY.md).
 
+## Example Prompts and Use Cases
+
+### Recall knowledge about people or companies
+
+```text
+What do we know about Pedro Franceschi and his company?
+```
+
+The plugin queries GBrain before the turn and injects matching brain pages into
+prompt context. The model answers using both session history and GBrain recall.
+
+### Store durable facts back to the brain
+
+```text
+Use gbrain_put_page to save a new page about the partnership discussion
+with Acme Corp. Include the key terms we agreed on.
+```
+
+This writes directly to the GBrain knowledge base so the information is
+available in future sessions and across projects.
+
+### Research and follow-up
+
+```text
+Use GBrain to find the Acme company page, read the full page, then
+summarize the current state and open threads with citations.
+```
+
+This triggers a read flow: `gbrain_query` to find the page, then
+`gbrain_get_page` for the full content.
+
+### Track chronological events
+
+```text
+Use gbrain_add_timeline_entry to log that we signed the contract with
+Acme on 2026-04-15.
+```
+
+GBrain's timeline features let you track events and retrieve them
+chronologically.
+
+### Keep the brain current after external edits
+
+```text
+/gbrain sync --repo ~/brain
+/gbrain embed --stale
+```
+
+Run these after editing brain markdown files outside HybridClaw.
+
 ## Tips & Tricks
 
 - Prefer `query` for natural-language prompts. It is the default and lets
@@ -604,3 +656,37 @@ For the upstream verification runbook, see
   `gbrain embed --stale` and verify `OPENAI_API_KEY` is available.
 - If sync seems to run but results stay stale on Supabase, check for a
   Transaction mode pooler URL and switch to Session mode.
+
+## Troubleshooting
+
+- **Plugin loads but no `gbrain_*` tools appear:**
+  `gbrain --tools-json` likely failed during plugin registration. Check
+  `/gbrain status` and the gateway logs. Verify that `gbrain --version`
+  works from the shell the gateway process uses.
+
+- **No prompt recall appears:**
+  GBrain returned no matches. Check that the brain has indexed pages with
+  `gbrain stats` and that embeddings are built with `gbrain embed --stale`.
+
+- **Wrong brain is being queried:**
+  Set `workingDirectory` explicitly to your brain repo path. This is the
+  single most common source of "loaded plugin, wrong brain" confusion.
+
+- **Bun not found by gateway:**
+  If you installed GBrain through the Bun wrapper, `bun` must be on `PATH`
+  for the gateway process, not just your interactive shell. Alternatively,
+  point `command` at a compiled binary.
+
+- **Supabase sync shows success but page count is low:**
+  Check for a Transaction mode pooler URL in your connection string. GBrain
+  sync requires Session mode pooler or a direct connection string.
+
+- **Weak or purely lexical results from `gbrain query`:**
+  Embeddings may be missing or stale. Run `gbrain embed --stale` and verify
+  that `OPENAI_API_KEY` is available for the embedding model.
+
+- **Credential errors:**
+  Use `/secret set` for credentials rather than hardcoding in config. The
+  plugin reads `GBRAIN_DATABASE_URL`, `DATABASE_URL`, `OPENAI_API_KEY`, and
+  `ANTHROPIC_API_KEY` from HybridClaw secrets and injects them into the child
+  process.

--- a/docs/development/extensibility/honcho-memory-plugin.md
+++ b/docs/development/extensibility/honcho-memory-plugin.md
@@ -30,6 +30,27 @@ Only one plugin marked as an external `memoryProvider` can be active at a time.
 That keeps HybridClaw on a clear model: built-in memory plus at most one
 external provider.
 
+## Prerequisites
+
+### Create a Honcho account
+
+Honcho offers two deployment options:
+
+- **Managed cloud (recommended for getting started)**: sign up at
+  [honcho.dev](https://honcho.dev) to get an API key
+  (see [Honcho documentation](https://docs.honcho.dev) for details). The managed service
+  includes $100 in free credits (no credit card required), which covers
+  approximately 50 million tokens of ingestion. The `get_context()` call that
+  runs every turn is free. Background "dreaming" (asynchronous reasoning) is
+  also free.
+- **Self-hosted**: deploy the open-source
+  [Honcho server](https://github.com/plastic-labs/honcho) on your own
+  infrastructure. Set `baseUrl` to your server address and leave
+  `HONCHO_API_KEY` unset if auth is disabled.
+
+No binary installation is required. The plugin communicates with Honcho
+entirely through its HTTP API.
+
 ## What It Mirrors
 
 Honcho receives:
@@ -62,12 +83,16 @@ For a local checkout:
 hybridclaw plugin install ./plugins/honcho-memory
 ```
 
-Then set the Honcho credential through `/secret`. The plugin can run on its
-built-in defaults without any extra config:
+Then enable the plugin and set the Honcho credential through `/secret`:
 
 ```text
+/plugin enable honcho-memory
 /secret set HONCHO_API_KEY your-honcho-key
+/honcho status
 ```
+
+Both `/plugin install` and `/plugin enable` automatically reload the plugin
+runtime — no separate `/plugin reload` is needed.
 
 If you want to pin explicit settings in `config.json`, a small stable config
 looks like this:
@@ -447,6 +472,56 @@ The usual first-run flow is:
 If you already have useful context in `SOUL.md`, `IDENTITY.md`, `USER.md`, or
 `MEMORY.md`, the setup step will seed that data into Honcho on demand.
 
+## Example Prompts and Use Cases
+
+### Cross-session user preferences
+
+```text
+I prefer functional programming patterns over OOP. I use Neovim and work
+primarily in Rust and TypeScript.
+```
+
+Honcho builds an evolving user profile from these facts. In a future session,
+asking for code suggestions will reflect these preferences without repeating
+them.
+
+### Dialectic reasoning for complex decisions
+
+```text
+Should we use a monorepo or polyrepo for the new platform? Consider our
+team size (8 engineers) and the fact that we ship three separate products.
+```
+
+With dialectic reasoning enabled, Honcho uses its accumulated knowledge about
+you and your team to reason through trade-offs, not just retrieve facts.
+
+### Explicit conclusion storage
+
+```text
+Use honcho_conclude to save: we decided on a monorepo with Turborepo.
+The migration starts next sprint.
+```
+
+This stores a durable conclusion in Honcho that persists across sessions and
+can be retrieved through `honcho_search` or automatic prompt recall.
+
+### Inspect what Honcho knows
+
+```text
+/honcho identity --show
+/honcho search deployment process
+What does Honcho know about my coding preferences?
+```
+
+Use these to debug recall quality or verify that Honcho is building an accurate
+user model.
+
+### Long-running project continuity
+
+Use `sessionStrategy: global` or `/honcho map release-v2` to maintain a single
+Honcho thread across many HybridClaw sessions. This is useful for multi-week
+projects where you want the agent to remember all prior context.
+
 ## Tips And Tricks
 
 - Use the defaults first. In most cases, `/secret set HONCHO_API_KEY ...` plus
@@ -468,6 +543,17 @@ If you already have useful context in `SOUL.md`, `IDENTITY.md`, `USER.md`, or
   peer.
 - Use `/honcho sync` after a burst of conversation if you want to force a flush
   and refresh prompt context immediately.
+- **Dreaming is free.** Honcho's background reasoning runs continuously
+  without additional cost. You only pay for token ingestion ($2/M tokens on
+  the managed cloud).
+- **Beware compaction amnesia.** Long sessions get compacted and early context
+  can vanish. If the agent forgets decisions from earlier in the session, use
+  `honcho_conclude` to save them explicitly or switch to
+  `writeFrequency: turn` for immediate persistence.
+- **Cron jobs start with no history.** Background tasks and scheduled jobs spin
+  up fresh sessions with zero conversation history. Use `sessionStrategy:
+  global` or seed important context through workspace files if you need
+  continuity in automated workflows.
 
 ## Troubleshooting
 

--- a/docs/development/extensibility/memory-plugins.md
+++ b/docs/development/extensibility/memory-plugins.md
@@ -1,0 +1,128 @@
+---
+title: Memory Plugins
+description: Overview and comparison of HybridClaw's built-in memory and external memory plugin options.
+sidebar_position: 5
+---
+
+# Memory Plugins
+
+HybridClaw has a layered memory architecture. The built-in memory system is
+always active and handles session transcripts, file-backed notes (`MEMORY.md`,
+`USER.md`), semantic recall, and compaction summaries. Memory plugins add
+external recall and persistence on top of that foundation.
+
+## How Plugins Layer On Built-In Memory
+
+```text
+┌─────────────────────────────────────────────┐
+│  Prompt context for each turn               │
+├─────────────────────────────────────────────┤
+│  Built-in memory (always active)            │
+│  ├── MEMORY.md, USER.md, daily notes        │
+│  ├── SQLite session transcript              │
+│  ├── Semantic recall                        │
+│  └── Compaction summaries                   │
+├─────────────────────────────────────────────┤
+│  Memory plugin (optional, one at a time*)   │
+│  ├── Prompt-time recall injection           │
+│  ├── Model tools for search/write           │
+│  └── Background curation / sync             │
+└─────────────────────────────────────────────┘
+
+* Plugins marked memoryProvider: true are exclusive —
+  only one can be active. Additive plugins can run
+  alongside any configuration.
+```
+
+## Exclusive vs Additive Plugins
+
+Plugins declare one of two integration modes:
+
+- **Exclusive** (`memoryProvider: true`): replaces the external memory slot.
+  Only one exclusive plugin can be active at a time. Built-in memory remains
+  active. ByteRover and Honcho use this mode.
+- **Additive**: layers additional recall alongside built-in memory and any
+  active exclusive plugin. MemPalace, QMD, and GBrain use this mode.
+
+## Comparison
+
+| Plugin | Integration | Storage | Local | Cloud | Auto-install | API Key | Cost | Command |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **Built-in Memory** | Always active | SQLite + markdown files | Yes | No | N/A | No | Free | N/A |
+| **ByteRover** | Exclusive | Context Tree (`.brv/`) | Yes (default) | Optional sync | Yes (`npm`) | Optional (`BRV_API_KEY`) | Free local, paid cloud | `/byterover` |
+| **Honcho** | Exclusive | Cloud API / self-hosted | Yes (self-hosted) | Managed cloud | No binary needed | Yes (`HONCHO_API_KEY`) | $100 free credits, no card | `/honcho` |
+| **MemPalace** | Additive | ChromaDB + SQLite | Yes (only mode) | No | Yes (`pip`) | No | Free | `/mempalace` |
+| **QMD** | Additive | Local markdown index | Yes (only mode) | No | Manual | No | Free | `/qmd` |
+| **GBrain** | Additive | PGLite / Supabase | Yes (PGLite) | Supabase | Manual | `OPENAI_API_KEY` for embeddings | Free local, Supabase costs | `/gbrain` |
+
+## Choosing A Plugin
+
+### Built-in memory (no plugin)
+
+The default. Good enough for most workflows. Handles session history,
+file-backed durable notes, semantic recall, and compaction summaries out of the
+box with zero setup.
+
+### ByteRover
+
+Best for **structured, project-scoped knowledge**. ByteRover organizes memory
+into a hierarchical Context Tree (Domains > Topics > Context Files) stored as
+human-readable markdown in `.brv/context-tree/`. The tree is git-friendly and
+can be version-controlled. Works fully offline by default with optional cloud
+sync.
+
+- Install: `npm install -g byterover-cli`
+- [ByteRover Memory Plugin docs](byterover-memory-plugin.md)
+
+### Honcho
+
+Best for **cross-session user modeling and reasoning**. Honcho builds evolving
+peer representations of users and agents, supports dialectic reasoning, and
+extracts conclusions through continuous background "dreaming." Cloud-managed
+with generous free tier ($100 credits, no card required) or self-hostable.
+
+- Install: no binary needed, just an API key
+- [Honcho Memory Plugin docs](honcho-memory-plugin.md)
+
+### MemPalace
+
+Best for **local-first, privacy-focused memory** with zero API costs. Uses the
+ancient memory palace mnemonic as its organizational metaphor (Wings > Rooms >
+Drawers). All embeddings are computed locally via Sentence Transformers.
+Optionally exposes 19 MCP tools for taxonomy, knowledge graph, and diary
+features.
+
+- Install: `pip install mempalace`
+- [MemPalace Memory Plugin docs](mempalace-memory-plugin.md)
+
+### QMD
+
+Best for **searching an existing markdown corpus**. QMD indexes local markdown
+files, docs, and optionally exported session transcripts. Lightweight plugin
+with lexical, vector, and hybrid retrieval modes. Good when you already have a
+well-organized markdown knowledge base.
+
+- Install: external `qmd` CLI
+- [QMD Memory Plugin docs](qmd-memory-plugin.md)
+
+### GBrain
+
+Best for **world knowledge and research** — people, companies, meetings,
+concepts, and notes organized in a dedicated brain repo. Supports local PGLite
+or remote Supabase backends. Mirrors the GBrain tool catalog as `gbrain_*`
+plugin tools for read/write operations.
+
+- Install: `bun add -g github:garrytan/gbrain`
+- [GBrain Plugin docs](gbrain-plugin.md)
+
+## Multiple Plugins
+
+You can combine one exclusive plugin with any number of additive plugins. For
+example:
+
+- **Honcho + GBrain**: Honcho handles user modeling and session continuity
+  while GBrain provides world knowledge recall
+- **ByteRover + MemPalace**: ByteRover handles structured project knowledge
+  while MemPalace adds local search over historical conversations
+
+You cannot run two exclusive plugins (ByteRover + Honcho) at the same time.

--- a/docs/development/extensibility/mempalace-memory-plugin.md
+++ b/docs/development/extensibility/mempalace-memory-plugin.md
@@ -66,6 +66,11 @@ Important distinction:
 
 ## Before You Activate It
 
+[MemPalace](https://github.com/milla-jovovich/mempalace) is a free,
+open-source local memory system that uses ChromaDB and SQLite for storage with
+zero API costs. See the [MemPalace setup guide](https://www.mempalace.tech/guides/setup)
+for detailed instructions.
+
 You need an initialized palace before the plugin can do anything useful.
 HybridClaw can install the `mempalace` Python package into a plugin-local
 environment during `plugin install` if you approve dependency setup, but it
@@ -78,6 +83,11 @@ pip install mempalace
 mempalace init ~/projects/myapp
 mempalace mine ~/projects/myapp
 ```
+
+> **Tip:** You can skip the manual `pip install`. Running
+> `hybridclaw plugin install ./plugins/mempalace-memory` will offer to install
+> `mempalace` into a plugin-local `.venv` automatically. You still need to run
+> `mempalace init` and `mempalace mine` yourself.
 
 The important invariant is:
 
@@ -142,14 +152,14 @@ sessions.
 
 ```text
 /plugin install ./plugins/mempalace-memory --yes
-/plugin reload
+/plugin enable mempalace-memory
+/mempalace status
 ```
 
 If needed, set the palace location explicitly:
 
 ```text
 /plugin config mempalace-memory palacePath ~/.mempalace/palace
-/plugin reload
 ```
 
 To avoid ambiguity, setting `palacePath` explicitly is recommended even when
@@ -505,6 +515,79 @@ Supported config keys:
 - `timeoutMs`: timeout for `status`, `wake-up`, and automatic search calls. The
   plugin gives `mine` a longer minimum timeout automatically.
 
+## Example Prompts and Use Cases
+
+### Recall past decisions
+
+```text
+Why did we switch from REST to GraphQL for the internal API?
+```
+
+If this decision was discussed in a prior session and mined into MemPalace,
+the plugin surfaces the relevant context before the model answers.
+
+### Store operational knowledge
+
+```text
+Remember that the staging deploy requires running database migrations
+first, and the deploy key is in the team 1Password vault.
+```
+
+The built-in memory stores this immediately, and the plugin mirrors the write
+into MemPalace so it is also available through MemPalace search.
+
+### Manual search for specific memories
+
+```text
+/mempalace search "auth provider migration"
+/mempalace wake-up --wing hybridclaw
+```
+
+Use the slash command to inspect raw MemPalace results or wake up context for
+a specific wing.
+
+### Full MCP tool access (with MCP server)
+
+```text
+Use MemPalace to show me the current taxonomy of wings and rooms.
+Use MemPalace to search the knowledge graph for connections between
+the auth service and the user service.
+```
+
+These require the MemPalace MCP server to be configured separately from the
+plugin.
+
+### Cross-tool memory
+
+After a long debugging session, the important conclusions are automatically
+mined into MemPalace. In a future session with a different project, those
+debugging patterns are still retrievable.
+
+## Tips and Tricks
+
+- **Zero cost, fully local.** MemPalace runs entirely offline after the
+  initial model download. No API keys, no cloud accounts, no usage fees.
+- **Pin ChromaDB on macOS ARM.** MemPalace can crash with segfaults when
+  ChromaDB 1.5.6 is installed on Apple Silicon. If you hit this, downgrade
+  with `pip install chromadb==0.6.3` and rebuild. Track upstream fixes in
+  [MemPalace issue #100](https://github.com/milla-jovovich/mempalace/issues/100).
+- **GPU acceleration.** If you have an NVIDIA GPU, install GPU-accelerated
+  `onnxruntime` with CUDA runtime to significantly speed up local embeddings.
+  The "GPU device discovery failed" warning from onnxruntime is cosmetic and
+  harmless with multi-GPU setups.
+- **Large vaults (40k+ drawers).** Unbounded `col.get()` calls can crash with
+  too many SQL variables. If your palace is very large, see
+  [MemPalace issue #211](https://github.com/milla-jovovich/mempalace/issues/211)
+  for batch workarounds.
+- **Split large exports.** If your conversation exports are huge concatenated
+  files, use `mempalace split` before mining to get better segmentation.
+- **Set `palacePath` explicitly.** Even if you use MemPalace's default palace
+  location, setting `palacePath` in plugin config avoids confusion when
+  multiple palaces exist on the system.
+- **Pair with an exclusive provider.** MemPalace is additive, so it can run
+  alongside Honcho or ByteRover. Use the exclusive provider for session
+  modeling and MemPalace for long-term local search.
+
 ## What This Plugin Does Not Do
 
 This plugin is intentionally narrow. It does not:
@@ -521,3 +604,31 @@ This plugin is intentionally narrow. It does not:
 Use MemPalace itself for palace initialization, repair, reset, and other
 maintenance. Use this plugin when you want MemPalace to be the active recall
 and update path for HybridClaw chat memory.
+
+## Troubleshooting
+
+- **Plugin loads but `mempalace status` says "No palace found":**
+  The plugin is not pointed at an initialized palace. Set `palacePath`
+  explicitly to the directory where you ran `mempalace init`.
+
+- **Segfault on macOS ARM:**
+  ChromaDB version conflict. Run `pip install chromadb==0.6.3` in the plugin's
+  `.venv` or your global Python environment.
+
+- **Search returns no results for known facts:**
+  Check that you are searching the correct wing. Use
+  `/mempalace search "term" --wing <wing>` to narrow the search. Also verify
+  that mining has completed with `/mempalace status`.
+
+- **Auto-save is not working:**
+  Check `saveEveryMessages` in plugin config (default: 15). The plugin buffers
+  turns and only mines after the threshold is reached. Use a lower value for
+  testing or run `/mempalace mine` manually.
+
+- **Unicode crashes on Windows:**
+  MemPalace CLI uses Unicode characters that can crash on Windows cp1252
+  terminals. Use Windows Terminal or set your terminal to UTF-8 encoding.
+
+- **MCP tools not visible:**
+  The plugin does not expose MCP tools itself. Add the MemPalace MCP server
+  separately. See the "Optional: Add the MemPalace MCP Server" section above.

--- a/docs/development/extensibility/plugins.md
+++ b/docs/development/extensibility/plugins.md
@@ -68,6 +68,9 @@ or change one top-level `plugins.list[].config` key without editing
 
 ## Repo-Shipped Examples
 
+- `byterover-memory` mirrors turns into ByteRover, injects prompt-time recall
+  through `brv query`, and exposes `brv_query`, `brv_curate`, and `brv_status`
+  tools. Works offline with optional cloud sync.
 - `gbrain` shells out to the GBrain CLI, injects search results into prompt
   context, and mirrors the discovered GBrain operations as `gbrain_*` plugin
   tools

--- a/docs/development/extensibility/qmd-memory-plugin.md
+++ b/docs/development/extensibility/qmd-memory-plugin.md
@@ -11,10 +11,38 @@ HybridClaw ships an installable QMD memory plugin source at
 The plugin complements the built-in SQLite session memory with external QMD
 search over markdown notes, docs, and optional exported session transcripts.
 
+## Prerequisites
+
+### Install the QMD CLI
+
+[QMD](https://github.com/tobi/qmd) is a local CLI search engine for markdown
+documents, knowledge bases, and notes. It combines BM25 keyword search, vector
+semantic search, and LLM reranking — all executed locally on your machine.
+
+The plugin shells out to the `qmd` CLI and does not embed QMD as a library.
+Install QMD separately before enabling the plugin. QMD runs entirely locally
+and has no cloud mode — all indexing and search happens on your machine.
+
+See the [QMD repository](https://github.com/tobi/qmd) for installation
+instructions.
+
+After installing, index your markdown files and build embeddings:
+
+```bash
+qmd collection add ~/docs
+qmd embed
+qmd status
+```
+
+Verify that QMD can answer a query:
+
+```bash
+qmd query "a topic you know is in your docs"
+```
+
 ## Install
 
-1. Install QMD separately. The plugin shells out to the `qmd` CLI and does not
-   embed QMD as a library.
+1. The `qmd` CLI must be installed and on `PATH` (see Prerequisites above).
 2. Install the plugin from this repo:
 
    ```bash
@@ -25,11 +53,15 @@ search over markdown notes, docs, and optional exported session transcripts.
    configured `command` override is available, HybridClaw leaves the plugin
    disabled and reports the missing binary in `/plugin list`.
 
-3. Reload plugins in an active session:
+3. Enable the plugin and verify:
 
    ```text
-   /plugin reload
+   /plugin enable qmd-memory
+   /qmd status
    ```
+
+   Both `/plugin install` and `/plugin enable` automatically reload the plugin
+   runtime — no separate `/plugin reload` is needed.
 
    To switch the QMD retrieval mode from the TUI without editing JSON
    directly, you can also run:
@@ -135,6 +167,44 @@ or vector retrieval. Depending on your local QMD setup, the first `embed` or
 The installed plugin lives under `~/.hybridclaw/plugins/qmd-memory`, so reload
 alone does not pick up repo edits.
 
+## Example Prompts and Use Cases
+
+### Search project documentation
+
+```text
+How does the authentication middleware work?
+```
+
+If your project docs are indexed in QMD, the plugin surfaces matching snippets
+before the model answers, combining QMD knowledge with session context.
+
+### Index a new repository
+
+```text
+/qmd collection add .
+/qmd embed
+/qmd status
+```
+
+This indexes all markdown files in the current directory and builds embeddings
+for hybrid retrieval.
+
+### Debug retrieval quality
+
+```text
+/qmd search "auth middleware"
+/qmd query "how does authentication work?"
+```
+
+Compare `search` (lexical) vs `query` (hybrid) results to understand what QMD
+is finding.
+
+### Export sessions for future search
+
+Enable `sessionExport: true` in config so QMD can index past HybridClaw
+conversations as a normal markdown collection. This lets future sessions
+benefit from discussions in earlier ones.
+
 ## Tips & Tricks
 
 - Prefer `query` for natural-language prompts. It is the default and uses QMD's
@@ -176,3 +246,27 @@ To verify that the plugin is both loaded and actively contributing context:
 If `/plugin list` shows the plugin as enabled but the prompt dump lacks the
 retrieval section, the plugin loaded but QMD returned no usable matches for
 that turn.
+
+## Troubleshooting
+
+- **Plugin loads but stays disabled:**
+  The `qmd` binary is not on `PATH`. Either install QMD or set `command` in
+  plugin config to the full path.
+
+- **No retrieval context appears:**
+  QMD returned no matches for the user message. Try `/qmd status` to confirm
+  the collection has indexed pages, then `/qmd query <term>` to test
+  retrieval directly.
+
+- **Embeddings not built:**
+  Vector and hybrid search modes require embeddings. Run `/qmd embed` or
+  `qmd embed` from the shell. The first run may download models.
+
+- **Results are stale after adding docs:**
+  Run `/qmd collection add .` and `/qmd embed` again to re-index and rebuild
+  embeddings for new files.
+
+- **Prompt dump shows no QMD section:**
+  The plugin loaded but QMD returned no matches. This is normal when the user
+  message does not match any indexed content. Check the indexed collection
+  with `/qmd status`.

--- a/docs/static/docs.css
+++ b/docs/static/docs.css
@@ -340,6 +340,11 @@ pre {
   font-size: 0.95rem;
 }
 
+.docs-nav-link-child {
+  padding-left: 28px;
+  font-size: 0.9rem;
+}
+
 .docs-nav-link:hover,
 .docs-toc-link:hover {
   background: var(--brand-blue-soft);

--- a/docs/static/docs.js
+++ b/docs/static/docs.js
@@ -82,19 +82,33 @@ export const DEVELOPMENT_DOCS_SECTIONS = [
       { title: 'Adaptive Skills', path: 'extensibility/adaptive-skills.md' },
       { title: 'Agent Packages', path: 'extensibility/agent-packages.md' },
       {
-        title: 'Honcho Memory Plugin',
-        path: 'extensibility/honcho-memory-plugin.md',
-      },
-      {
-        title: 'MemPalace Memory Plugin',
-        path: 'extensibility/mempalace-memory-plugin.md',
+        title: 'Memory Plugins',
+        path: 'extensibility/memory-plugins.md',
+        children: [
+          {
+            title: 'ByteRover Memory Plugin',
+            path: 'extensibility/byterover-memory-plugin.md',
+          },
+          {
+            title: 'GBrain Plugin',
+            path: 'extensibility/gbrain-plugin.md',
+          },
+          {
+            title: 'Honcho Memory Plugin',
+            path: 'extensibility/honcho-memory-plugin.md',
+          },
+          {
+            title: 'MemPalace Memory Plugin',
+            path: 'extensibility/mempalace-memory-plugin.md',
+          },
+          {
+            title: 'QMD Memory Plugin',
+            path: 'extensibility/qmd-memory-plugin.md',
+          },
+        ],
       },
       { title: 'OTEL Plugin', path: 'extensibility/otel-plugin.md' },
       { title: 'Plugins', path: 'extensibility/plugins.md' },
-      {
-        title: 'QMD Memory Plugin',
-        path: 'extensibility/qmd-memory-plugin.md',
-      },
       { title: 'Skills', path: 'extensibility/skills.md' },
     ],
   },
@@ -716,14 +730,27 @@ function renderBreadcrumbs(docPath, basePath) {
     .join('');
 }
 
+function renderNavLink(page, currentDocPath, basePath, isChild) {
+  const activeClass = page.path === currentDocPath ? ' is-active' : '';
+  const childClass = isChild ? ' docs-nav-link-child' : '';
+  return `<a class="docs-nav-link${activeClass}${childClass}" href="${escapeHtml(
+    buildDocHtmlHref(page.path, basePath),
+  )}">${escapeHtml(page.title)}</a>`;
+}
+
 function renderSidebar(currentDocPath, basePath) {
   return DEVELOPMENT_DOCS_SECTIONS.map((section) => {
     const links = section.pages
       .map((page) => {
-        const activeClass = page.path === currentDocPath ? ' is-active' : '';
-        return `<a class="docs-nav-link${activeClass}" href="${escapeHtml(
-          buildDocHtmlHref(page.path, basePath),
-        )}">${escapeHtml(page.title)}</a>`;
+        let html = renderNavLink(page, currentDocPath, basePath, false);
+        if (page.children) {
+          html += page.children
+            .map((child) =>
+              renderNavLink(child, currentDocPath, basePath, true),
+            )
+            .join('');
+        }
+        return html;
       })
       .join('');
     return `<section class="docs-nav-group"><h2>${escapeHtml(

--- a/plugins/byterover-memory/hybridclaw.plugin.yaml
+++ b/plugins/byterover-memory/hybridclaw.plugin.yaml
@@ -1,0 +1,52 @@
+id: byterover-memory
+name: ByteRover Memory
+version: 0.1.0
+kind: memory
+memoryProvider: true
+description: Mirror HybridClaw turns into ByteRover, inject prompt-time recall, and expose ByteRover memory tools.
+entrypoint: src/index.js
+credentials:
+  - BRV_API_KEY
+requires:
+  bins:
+    - name: brv
+      configKey: command
+      installHint: npm install -g byterover-cli
+      installUrl: https://github.com/campfirein/byterover-cli
+nodeDependencies:
+  - byterover-cli
+externalDependencies:
+  - name: brv
+    check: brv --version
+    installHint: npm install -g byterover-cli
+    installUrl: https://github.com/campfirein/byterover-cli
+configSchema:
+  type: object
+  additionalProperties: false
+  properties:
+    command:
+      type: string
+      default: brv
+    workingDirectory:
+      type: string
+    autoCurate:
+      type: boolean
+      default: true
+    mirrorMemoryWrites:
+      type: boolean
+      default: true
+    maxInjectedChars:
+      type: number
+      default: 4000
+      minimum: 500
+      maximum: 16000
+    queryTimeoutMs:
+      type: number
+      default: 30000
+      minimum: 1000
+      maximum: 120000
+    curateTimeoutMs:
+      type: number
+      default: 120000
+      minimum: 1000
+      maximum: 600000

--- a/plugins/byterover-memory/package.json
+++ b/plugins/byterover-memory/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "hybridclaw-plugin-byterover-memory",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "HybridClaw memory plugin for ByteRover CLI recall and curation",
+  "engines": {
+    "node": "22.x"
+  }
+}

--- a/plugins/byterover-memory/src/byterover-process.js
+++ b/plugins/byterover-memory/src/byterover-process.js
@@ -120,6 +120,7 @@ export async function runByteRover(subcommandArgs, config, options = {}) {
     let settled = false;
     let timedOut = false;
     let killTimer = null;
+    let timer = null;
 
     const finish = (result) => {
       if (settled) return;
@@ -135,7 +136,7 @@ export async function runByteRover(subcommandArgs, config, options = {}) {
       });
     };
 
-    const timer =
+    timer =
       typeof timeoutMs === 'number' &&
       Number.isFinite(timeoutMs) &&
       timeoutMs > 0

--- a/plugins/byterover-memory/src/byterover-process.js
+++ b/plugins/byterover-memory/src/byterover-process.js
@@ -1,0 +1,207 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+
+const BRV_ENV_ALLOWLIST = [
+  'PATH',
+  'HOME',
+  'TMPDIR',
+  'XDG_CACHE_HOME',
+  'XDG_CONFIG_HOME',
+  'XDG_DATA_HOME',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+];
+const BRV_WINDOWS_ENV_ALLOWLIST = [
+  'APPDATA',
+  'ComSpec',
+  'LOCALAPPDATA',
+  'PATHEXT',
+  'SystemRoot',
+  'TEMP',
+  'TMP',
+  'USERPROFILE',
+];
+const PROCESS_KILL_GRACE_MS = 250;
+const MIN_CAPTURE_BYTES = 32_768;
+const CAPTURE_BYTES_PER_CHAR = 2;
+
+export function normalizeByteRoverText(value) {
+  return String(value || '')
+    .replace(/\r/g, '')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+export function truncateByteRoverText(value, maxChars) {
+  const normalized = normalizeByteRoverText(value);
+  if (!maxChars || normalized.length <= maxChars) return normalized;
+  return `${normalized.slice(0, Math.max(0, maxChars - 1)).trimEnd()}…`;
+}
+
+function buildProcessEnv(apiKey) {
+  const env = {};
+  const allowlist =
+    process.platform === 'win32'
+      ? [...BRV_ENV_ALLOWLIST, ...BRV_WINDOWS_ENV_ALLOWLIST]
+      : BRV_ENV_ALLOWLIST;
+
+  for (const key of allowlist) {
+    const value = process.env[key];
+    if (typeof value === 'string' && value.length > 0) {
+      env[key] = value;
+    }
+  }
+  if (typeof apiKey === 'string' && apiKey.trim()) {
+    env.BRV_API_KEY = apiKey.trim();
+  }
+  return env;
+}
+
+function resolveCaptureLimitBytes(maxChars) {
+  const configuredBudget =
+    typeof maxChars === 'number' && Number.isFinite(maxChars)
+      ? Math.max(0, Math.trunc(maxChars)) * CAPTURE_BYTES_PER_CHAR
+      : 0;
+  return Math.max(MIN_CAPTURE_BYTES, configuredBudget);
+}
+
+function createOutputCollector(maxBytes) {
+  return {
+    maxBytes,
+    totalBytes: 0,
+    truncated: false,
+    chunks: [],
+  };
+}
+
+function appendOutputChunk(collector, chunk) {
+  const buffer = Buffer.isBuffer(chunk)
+    ? chunk
+    : Buffer.from(String(chunk), 'utf-8');
+  const remaining = collector.maxBytes - collector.totalBytes;
+  if (remaining <= 0) {
+    collector.truncated = true;
+    return;
+  }
+  if (buffer.length <= remaining) {
+    collector.totalBytes += buffer.length;
+    collector.chunks.push(buffer);
+    return;
+  }
+  collector.totalBytes += remaining;
+  collector.chunks.push(buffer.subarray(0, remaining));
+  collector.truncated = true;
+}
+
+function readCollectedOutput(collector) {
+  if (collector.chunks.length === 0) return '';
+  return Buffer.concat(collector.chunks).toString('utf-8');
+}
+
+export async function runByteRover(subcommandArgs, config, options = {}) {
+  const timeoutMs =
+    typeof options.timeoutMs === 'number' && Number.isFinite(options.timeoutMs)
+      ? options.timeoutMs
+      : config.queryTimeoutMs;
+  const captureLimitBytes = resolveCaptureLimitBytes(options.maxChars);
+  const args = subcommandArgs.map((arg) => String(arg));
+  fs.mkdirSync(config.workingDirectory, { recursive: true });
+
+  return await new Promise((resolve) => {
+    const child = spawn(config.command, args, {
+      cwd: config.workingDirectory,
+      env: buildProcessEnv(options.apiKey),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const stdoutCollector = createOutputCollector(captureLimitBytes);
+    const stderrCollector = createOutputCollector(captureLimitBytes);
+    let settled = false;
+    let timedOut = false;
+    let killTimer = null;
+
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      clearTimeout(killTimer);
+      resolve({
+        ...result,
+        stdout: readCollectedOutput(stdoutCollector),
+        stderr: readCollectedOutput(stderrCollector),
+        stdoutTruncated: stdoutCollector.truncated,
+        stderrTruncated: stderrCollector.truncated,
+      });
+    };
+
+    const timer =
+      typeof timeoutMs === 'number' &&
+      Number.isFinite(timeoutMs) &&
+      timeoutMs > 0
+        ? setTimeout(() => {
+            timedOut = true;
+            child.kill('SIGTERM');
+            killTimer = setTimeout(() => {
+              if (!settled) {
+                child.kill('SIGKILL');
+              }
+            }, PROCESS_KILL_GRACE_MS);
+          }, timeoutMs)
+        : null;
+
+    child.stdout?.on('data', (chunk) =>
+      appendOutputChunk(stdoutCollector, chunk),
+    );
+    child.stderr?.on('data', (chunk) =>
+      appendOutputChunk(stderrCollector, chunk),
+    );
+    child.on('error', (error) => finish({ ok: false, error }));
+    child.on('close', (code, signal) => {
+      if (timedOut) {
+        finish({
+          ok: false,
+          error: new Error(`ByteRover timed out after ${timeoutMs}ms.`),
+        });
+        return;
+      }
+      if (signal) {
+        finish({
+          ok: false,
+          error: new Error(`ByteRover terminated with signal ${signal}.`),
+        });
+        return;
+      }
+      if (code !== 0) {
+        const stderrText = normalizeByteRoverText(
+          readCollectedOutput(stderrCollector),
+        );
+        const stdoutText = normalizeByteRoverText(
+          readCollectedOutput(stdoutCollector),
+        );
+        const errorMessage =
+          stderrText ||
+          stdoutText ||
+          `ByteRover exited with code ${String(code)}.`;
+        finish({
+          ok: false,
+          error: new Error(errorMessage),
+        });
+        return;
+      }
+      finish({ ok: true });
+    });
+  });
+}
+
+export async function runByteRoverCommandText(
+  subcommandArgs,
+  config,
+  options = {},
+) {
+  const result = await runByteRover(subcommandArgs, config, options);
+  if (!result.ok) {
+    throw result.error;
+  }
+  return truncateByteRoverText(result.stdout, options.maxChars);
+}

--- a/plugins/byterover-memory/src/config.js
+++ b/plugins/byterover-memory/src/config.js
@@ -1,0 +1,87 @@
+import os from 'node:os';
+import path from 'node:path';
+
+const DEFAULT_MAX_INJECTED_CHARS = 4000;
+const DEFAULT_QUERY_TIMEOUT_MS = 30_000;
+const DEFAULT_CURATE_TIMEOUT_MS = 120_000;
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeInteger(value, fallback, key, bounds = {}) {
+  const raw =
+    typeof value === 'number' && Number.isFinite(value)
+      ? Math.trunc(value)
+      : fallback;
+  if (!Number.isFinite(raw)) {
+    throw new Error(`byterover-memory plugin config.${key} must be a number.`);
+  }
+  if (
+    typeof bounds.minimum === 'number' &&
+    Number.isFinite(bounds.minimum) &&
+    raw < bounds.minimum
+  ) {
+    throw new Error(
+      `byterover-memory plugin config.${key} must be >= ${bounds.minimum}.`,
+    );
+  }
+  if (
+    typeof bounds.maximum === 'number' &&
+    Number.isFinite(bounds.maximum) &&
+    raw > bounds.maximum
+  ) {
+    throw new Error(
+      `byterover-memory plugin config.${key} must be <= ${bounds.maximum}.`,
+    );
+  }
+  return raw;
+}
+
+function resolveRuntimePath(value, runtime) {
+  const normalized = normalizeString(value);
+  if (!normalized) return '';
+  if (normalized === '~') return os.homedir();
+  if (normalized.startsWith('~/')) {
+    return path.join(os.homedir(), normalized.slice(2));
+  }
+  if (path.isAbsolute(normalized)) return normalized;
+  return path.resolve(runtime.cwd, normalized);
+}
+
+function resolveDefaultWorkingDirectory(runtime) {
+  const runtimeHome = normalizeString(runtime?.homeDir);
+  if (runtimeHome) {
+    return path.resolve(runtimeHome, 'byterover');
+  }
+  return path.resolve(os.homedir(), '.hybridclaw', 'byterover');
+}
+
+export function resolveByteRoverPluginConfig(pluginConfig, runtime) {
+  return Object.freeze({
+    command: normalizeString(pluginConfig?.command) || 'brv',
+    workingDirectory:
+      resolveRuntimePath(pluginConfig?.workingDirectory, runtime) ||
+      resolveDefaultWorkingDirectory(runtime),
+    autoCurate: pluginConfig?.autoCurate !== false,
+    mirrorMemoryWrites: pluginConfig?.mirrorMemoryWrites !== false,
+    maxInjectedChars: normalizeInteger(
+      pluginConfig?.maxInjectedChars,
+      DEFAULT_MAX_INJECTED_CHARS,
+      'maxInjectedChars',
+      { minimum: 500, maximum: 16_000 },
+    ),
+    queryTimeoutMs: normalizeInteger(
+      pluginConfig?.queryTimeoutMs,
+      DEFAULT_QUERY_TIMEOUT_MS,
+      'queryTimeoutMs',
+      { minimum: 1_000, maximum: 120_000 },
+    ),
+    curateTimeoutMs: normalizeInteger(
+      pluginConfig?.curateTimeoutMs,
+      DEFAULT_CURATE_TIMEOUT_MS,
+      'curateTimeoutMs',
+      { minimum: 1_000, maximum: 600_000 },
+    ),
+  });
+}

--- a/plugins/byterover-memory/src/index.js
+++ b/plugins/byterover-memory/src/index.js
@@ -165,7 +165,7 @@ function normalizeManualCommandArgs(args) {
     const payload = stripMatchingQuotes(normalizedArgs.slice(1).join(' '));
     return payload ? [command, '--', payload] : [command];
   }
-  return normalizedArgs;
+  return [command, ...normalizedArgs.slice(1)];
 }
 
 function timeoutForCommand(command, config) {

--- a/plugins/byterover-memory/src/index.js
+++ b/plugins/byterover-memory/src/index.js
@@ -261,31 +261,35 @@ function createByteRoverRuntime(api, config) {
   }
 
   return {
-    async start() {
-      try {
-        const output = await runByteRoverCommandText(['status'], config, {
-          apiKey: getApiKey(),
-          timeoutMs: Math.min(config.queryTimeoutMs, 15_000),
-          maxChars: 2000,
-        });
-        api.logger.debug(
-          {
-            command: config.command,
-            workingDirectory: config.workingDirectory,
-            output: truncateByteRoverText(output, 240),
-          },
-          'ByteRover startup health-check passed',
-        );
-      } catch (error) {
-        api.logger.warn(
-          {
-            error,
-            command: config.command,
-            workingDirectory: config.workingDirectory,
-          },
-          'ByteRover startup health-check failed',
-        );
-      }
+    start() {
+      // Fire-and-forget: don't block gateway startup for the health check.
+      // ByteRover queries involve LLM calls and can take 10-30s.
+      void runByteRoverCommandText(['status'], config, {
+        apiKey: getApiKey(),
+        timeoutMs: Math.min(config.queryTimeoutMs, 15_000),
+        maxChars: 2000,
+      }).then(
+        (output) => {
+          api.logger.debug(
+            {
+              command: config.command,
+              workingDirectory: config.workingDirectory,
+              output: truncateByteRoverText(output, 240),
+            },
+            'ByteRover startup health-check passed',
+          );
+        },
+        (error) => {
+          api.logger.warn(
+            {
+              error,
+              command: config.command,
+              workingDirectory: config.workingDirectory,
+            },
+            'ByteRover startup health-check failed',
+          );
+        },
+      );
     },
     async stop() {
       await queue.catch(() => undefined);

--- a/plugins/byterover-memory/src/index.js
+++ b/plugins/byterover-memory/src/index.js
@@ -1,0 +1,532 @@
+import {
+  runByteRoverCommandText,
+  truncateByteRoverText,
+} from './byterover-process.js';
+import { resolveByteRoverPluginConfig } from './config.js';
+
+const MIN_QUERY_CHARS = 10;
+const MIN_RESULT_CHARS = 20;
+const MAX_QUERY_CHARS = 5000;
+const MAX_TOOL_RESULT_CHARS = 8000;
+const MAX_TURN_MESSAGE_CHARS = 2000;
+const MAX_COMPACTION_MESSAGE_CHARS = 500;
+const MAX_COMPACTION_MESSAGES = 10;
+
+function normalizeString(value) {
+  return String(value || '').trim();
+}
+
+function collapseWhitespace(value) {
+  return normalizeString(value).replace(/\s+/g, ' ');
+}
+
+function normalizeSearchQuery(value) {
+  const normalized = collapseWhitespace(value);
+  if (normalized.length < MIN_QUERY_CHARS) return '';
+  if (normalized.length <= MAX_QUERY_CHARS) return normalized;
+  return `${normalized.slice(0, Math.max(0, MAX_QUERY_CHARS - 1)).trimEnd()}…`;
+}
+
+function truncateForCurate(value, maxChars) {
+  const normalized = normalizeString(value);
+  if (normalized.length <= maxChars) return normalized;
+  return `${normalized.slice(0, Math.max(0, maxChars - 1)).trimEnd()}…`;
+}
+
+function stripMatchingQuotes(value) {
+  const normalized = normalizeString(value);
+  if (normalized.length < 2) return normalized;
+  const first = normalized[0];
+  const last = normalized.at(-1);
+  if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+    return normalized.slice(1, -1).trim();
+  }
+  return normalized;
+}
+
+function getLatestMessageByRole(messages, role) {
+  let latestMessage = null;
+  for (const message of messages || []) {
+    if (String(message?.role || '').toLowerCase() !== role) continue;
+    if (!latestMessage) {
+      latestMessage = message;
+      continue;
+    }
+    const currentTime = Date.parse(String(message.created_at || ''));
+    const latestTime = Date.parse(String(latestMessage.created_at || ''));
+    if (
+      (Number.isFinite(currentTime) ? currentTime : Number.NEGATIVE_INFINITY) >=
+      (Number.isFinite(latestTime) ? latestTime : Number.NEGATIVE_INFINITY)
+    ) {
+      latestMessage = message;
+    }
+  }
+  return latestMessage;
+}
+
+function getLatestUserQuery(recentMessages) {
+  return normalizeSearchQuery(
+    getLatestMessageByRole(recentMessages, 'user')?.content,
+  );
+}
+
+function buildQueryArgs(query) {
+  return ['query', '--', query];
+}
+
+function buildCurateArgs(content) {
+  return ['curate', '--', content];
+}
+
+function describeMemoryFile(memoryFilePath) {
+  if (memoryFilePath === 'USER.md') return 'User profile';
+  if (memoryFilePath === 'MEMORY.md') return 'Durable memory';
+  return `Daily memory note (${memoryFilePath})`;
+}
+
+function resolveMirroredMemoryContent(context) {
+  if (context.action === 'append' || context.action === 'write') {
+    return normalizeString(context.content);
+  }
+  if (context.action === 'replace') {
+    return normalizeString(context.newText);
+  }
+  return '';
+}
+
+function buildMemoryWriteCurateContent(context) {
+  const content = resolveMirroredMemoryContent(context);
+  if (!content) return '';
+  return `[${describeMemoryFile(context.memoryFilePath)}]\n${content}`;
+}
+
+function buildTurnCurateContent(messages) {
+  const userMessage = getLatestMessageByRole(messages, 'user');
+  const assistantMessage = getLatestMessageByRole(messages, 'assistant');
+  const userContent = normalizeString(userMessage?.content);
+  if (userContent.length < MIN_QUERY_CHARS) return '';
+  const assistantContent = normalizeString(assistantMessage?.content);
+  const lines = [
+    `User: ${truncateForCurate(userContent, MAX_TURN_MESSAGE_CHARS)}`,
+  ];
+  if (assistantContent) {
+    lines.push(
+      `Assistant: ${truncateForCurate(assistantContent, MAX_TURN_MESSAGE_CHARS)}`,
+    );
+  }
+  return lines.join('\n');
+}
+
+function buildCompactionCurateContent(summary, olderMessages) {
+  const sections = ['[Pre-compaction context]'];
+  const normalizedSummary = normalizeString(summary);
+  if (normalizedSummary) {
+    sections.push('');
+    sections.push('Summary:');
+    sections.push(truncateForCurate(normalizedSummary, 1500));
+  }
+
+  const excerpts = (olderMessages || [])
+    .filter((message) => {
+      const role = String(message?.role || '').toLowerCase();
+      if (role !== 'user' && role !== 'assistant') return false;
+      return normalizeString(message?.content).length > 0;
+    })
+    .slice(-MAX_COMPACTION_MESSAGES)
+    .map((message) => {
+      const role = String(message.role || '').toLowerCase();
+      const content = truncateForCurate(
+        message.content,
+        MAX_COMPACTION_MESSAGE_CHARS,
+      );
+      return `${role}: ${content}`;
+    });
+
+  if (excerpts.length === 0 && !normalizedSummary) return '';
+  if (excerpts.length > 0) {
+    sections.push('');
+    sections.push(...excerpts);
+  }
+  return sections.join('\n');
+}
+
+function normalizeManualCommandArgs(args) {
+  const normalizedArgs = Array.isArray(args)
+    ? args.map((arg) => String(arg || '').trim()).filter(Boolean)
+    : [];
+  if (normalizedArgs.length === 0) {
+    return ['status'];
+  }
+  const command = normalizedArgs[0].toLowerCase();
+  if (
+    (command === 'query' || command === 'curate') &&
+    !normalizedArgs.includes('--')
+  ) {
+    const payload = stripMatchingQuotes(normalizedArgs.slice(1).join(' '));
+    return payload ? [command, '--', payload] : [command];
+  }
+  return normalizedArgs;
+}
+
+function timeoutForCommand(command, config) {
+  const normalized = normalizeString(command).toLowerCase();
+  if (normalized === 'status' || normalized === 'query') {
+    return config.queryTimeoutMs;
+  }
+  if (normalized === 'curate') {
+    return config.curateTimeoutMs;
+  }
+  return Math.max(config.queryTimeoutMs, config.curateTimeoutMs);
+}
+
+function buildStatusText(output, config, apiKey) {
+  return [
+    `Command: ${config.command}`,
+    `Working directory: ${config.workingDirectory}`,
+    `BRV_API_KEY: ${apiKey ? 'configured' : 'unset (optional)'}`,
+    '',
+    output,
+  ].join('\n');
+}
+
+function formatCommandFailure(error, config, args) {
+  const message =
+    error instanceof Error ? error.message : String(error || 'Unknown error');
+  return [
+    'ByteRover command failed.',
+    `Command: ${config.command}`,
+    `Working directory: ${config.workingDirectory}`,
+    ...(args.length > 0 ? [`Arguments: ${args.join(' ')}`] : []),
+    '',
+    message,
+  ].join('\n');
+}
+
+function createByteRoverRuntime(api, config) {
+  let queue = Promise.resolve();
+
+  function getApiKey() {
+    return normalizeString(api.getCredential('BRV_API_KEY'));
+  }
+
+  async function runQuery(query, maxChars = MAX_TOOL_RESULT_CHARS) {
+    return await runByteRoverCommandText(buildQueryArgs(query), config, {
+      apiKey: getApiKey(),
+      timeoutMs: config.queryTimeoutMs,
+      maxChars,
+    });
+  }
+
+  async function runCurate(content) {
+    return await runByteRoverCommandText(buildCurateArgs(content), config, {
+      apiKey: getApiKey(),
+      timeoutMs: config.curateTimeoutMs,
+      maxChars: 2000,
+    });
+  }
+
+  function enqueueCurate(params) {
+    const { reason, sessionId, content } = params;
+    if (!normalizeString(content)) {
+      return queue.catch(() => undefined);
+    }
+    const task = queue
+      .catch(() => undefined)
+      .then(async () => {
+        try {
+          const output = await runCurate(content);
+          api.logger.debug(
+            {
+              reason,
+              sessionId,
+              workingDirectory: config.workingDirectory,
+              output: truncateByteRoverText(output, 240),
+            },
+            'ByteRover curate completed',
+          );
+        } catch (error) {
+          api.logger.warn(
+            {
+              error,
+              reason,
+              sessionId,
+              workingDirectory: config.workingDirectory,
+            },
+            'ByteRover curate failed',
+          );
+        }
+      });
+    queue = task;
+    return task;
+  }
+
+  return {
+    async start() {
+      try {
+        const output = await runByteRoverCommandText(['status'], config, {
+          apiKey: getApiKey(),
+          timeoutMs: Math.min(config.queryTimeoutMs, 15_000),
+          maxChars: 2000,
+        });
+        api.logger.debug(
+          {
+            command: config.command,
+            workingDirectory: config.workingDirectory,
+            output: truncateByteRoverText(output, 240),
+          },
+          'ByteRover startup health-check passed',
+        );
+      } catch (error) {
+        api.logger.warn(
+          {
+            error,
+            command: config.command,
+            workingDirectory: config.workingDirectory,
+          },
+          'ByteRover startup health-check failed',
+        );
+      }
+    },
+    async stop() {
+      await queue.catch(() => undefined);
+    },
+    async getContextForPrompt({ recentMessages }) {
+      const query = getLatestUserQuery(recentMessages);
+      if (!query) return null;
+      try {
+        const output = await runQuery(query, config.maxInjectedChars);
+        if (normalizeString(output).length < MIN_RESULT_CHARS) {
+          return null;
+        }
+        return truncateByteRoverText(
+          [
+            'ByteRover recalled context for the latest user message:',
+            `Query: ${query}`,
+            '',
+            output,
+          ].join('\n'),
+          config.maxInjectedChars,
+        );
+      } catch (error) {
+        api.logger.warn(
+          {
+            error,
+            query,
+            workingDirectory: config.workingDirectory,
+          },
+          'ByteRover prompt recall failed',
+        );
+        return null;
+      }
+    },
+    renderPromptGuide() {
+      return [
+        'ByteRover memory tools are enabled.',
+        'Use `brv_query` when prior project decisions, preferences, or patterns may matter.',
+        'Use `brv_curate` to save durable facts, corrections, or workflows worth keeping across sessions.',
+        'Use `brv_status` or `/byterover status` to inspect CLI health and the working directory.',
+      ].join('\n');
+    },
+    onTurnComplete(params) {
+      if (!config.autoCurate) return;
+      const content = buildTurnCurateContent(params.messages);
+      void enqueueCurate({
+        sessionId: params.sessionId,
+        reason: 'turn complete',
+        content,
+      });
+    },
+    onMemoryWrite(context) {
+      if (!config.mirrorMemoryWrites) return;
+      const content = buildMemoryWriteCurateContent(context);
+      if (!content) return;
+      void enqueueCurate({
+        sessionId: context.sessionId,
+        reason: `memory write ${context.action}`,
+        content,
+      });
+    },
+    async onBeforeCompaction(context) {
+      const content = buildCompactionCurateContent(
+        context.summary,
+        context.olderMessages,
+      );
+      await enqueueCurate({
+        sessionId: context.sessionId,
+        reason: 'before compaction',
+        content,
+      });
+    },
+    async handleToolStatus() {
+      try {
+        const output = await runByteRoverCommandText(['status'], config, {
+          apiKey: getApiKey(),
+          timeoutMs: timeoutForCommand('status', config),
+          maxChars: MAX_TOOL_RESULT_CHARS,
+        });
+        return buildStatusText(output, config, getApiKey());
+      } catch (error) {
+        return formatCommandFailure(error, config, ['status']);
+      }
+    },
+    async handleToolQuery(args) {
+      const query = normalizeSearchQuery(args?.query);
+      if (!query) {
+        return 'Error: query is required.';
+      }
+      try {
+        const output = await runQuery(query);
+        if (normalizeString(output).length < MIN_RESULT_CHARS) {
+          return 'No relevant ByteRover memories found.';
+        }
+        return output;
+      } catch (error) {
+        return formatCommandFailure(error, config, ['query', '--', query]);
+      }
+    },
+    async handleToolCurate(args) {
+      const content = normalizeString(args?.content);
+      if (!content) {
+        return 'Error: content is required.';
+      }
+      try {
+        await runCurate(content);
+        return 'ByteRover memory updated.';
+      } catch (error) {
+        return formatCommandFailure(error, config, ['curate', '--', content]);
+      }
+    },
+    async handleCommand(args) {
+      const commandArgs = normalizeManualCommandArgs(args);
+      try {
+        const output = await runByteRoverCommandText(commandArgs, config, {
+          apiKey: getApiKey(),
+          timeoutMs: timeoutForCommand(commandArgs[0], config),
+          maxChars: MAX_TOOL_RESULT_CHARS,
+        });
+        if (commandArgs[0] === 'status') {
+          return buildStatusText(output, config, getApiKey());
+        }
+        return output;
+      } catch (error) {
+        return formatCommandFailure(error, config, commandArgs);
+      }
+    },
+  };
+}
+
+export default {
+  id: 'byterover-memory',
+  kind: 'memory',
+  register(api) {
+    const config = resolveByteRoverPluginConfig(api.pluginConfig, api.runtime);
+    const runtime = createByteRoverRuntime(api, config);
+
+    api.registerMemoryLayer({
+      id: 'byterover-memory-layer',
+      priority: 48,
+      start() {
+        return runtime.start();
+      },
+      stop() {
+        return runtime.stop();
+      },
+      getContextForPrompt(params) {
+        return runtime.getContextForPrompt(params);
+      },
+      onTurnComplete(params) {
+        return runtime.onTurnComplete(params);
+      },
+    });
+
+    api.registerPromptHook({
+      id: 'byterover-memory-guide',
+      priority: 48,
+      render() {
+        return runtime.renderPromptGuide();
+      },
+    });
+
+    api.registerTool({
+      name: 'brv_status',
+      description:
+        'Check ByteRover CLI health, working-directory state, and optional API-key availability.',
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: [],
+      },
+      handler() {
+        return runtime.handleToolStatus();
+      },
+    });
+
+    api.registerTool({
+      name: 'brv_query',
+      description:
+        'Search ByteRover persistent memory for relevant project knowledge, preferences, or past decisions.',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description: 'What to search for in ByteRover memory.',
+          },
+        },
+        required: ['query'],
+      },
+      handler(args) {
+        return runtime.handleToolQuery(args);
+      },
+    });
+
+    api.registerTool({
+      name: 'brv_curate',
+      description:
+        'Store a durable fact, decision, preference, or pattern in ByteRover memory.',
+      parameters: {
+        type: 'object',
+        properties: {
+          content: {
+            type: 'string',
+            description: 'The information to save into ByteRover.',
+          },
+        },
+        required: ['content'],
+      },
+      handler(args) {
+        return runtime.handleToolCurate(args);
+      },
+    });
+
+    api.registerCommand({
+      name: 'byterover',
+      description: 'Run ByteRover CLI commands (defaults to status).',
+      handler(args) {
+        return runtime.handleCommand(args);
+      },
+    });
+
+    api.on('memory_write', (context) => runtime.onMemoryWrite(context), {
+      priority: 48,
+    });
+
+    api.on(
+      'before_compaction',
+      async (context) => {
+        await runtime.onBeforeCompaction(context);
+      },
+      { priority: 48 },
+    );
+
+    api.logger.info(
+      {
+        workingDirectory: config.workingDirectory,
+        autoCurate: config.autoCurate,
+        mirrorMemoryWrites: config.mirrorMemoryWrites,
+        maxInjectedChars: config.maxInjectedChars,
+      },
+      'ByteRover memory plugin registered',
+    );
+  },
+};

--- a/src/cli/plugin-command.ts
+++ b/src/cli/plugin-command.ts
@@ -1,26 +1,12 @@
 import readline from 'node:readline/promises';
 import { runtimeConfigPath } from '../config/runtime-config.js';
 import { formatPluginSummaryList } from '../plugins/plugin-formatting.js';
+import { formatDependencyPlanDetails } from '../plugins/plugin-install.js';
 import { normalizeArgs } from './common.js';
 import { isHelpRequest, printPluginUsage } from './help.js';
 
-function formatDependencyPlanDetails(plan: {
-  usesPackageJson: boolean;
-  nodePackages: string[];
-  pipPackages: string[];
-}): string {
-  const parts: string[] = [];
-  if (plan.usesPackageJson) {
-    parts.push('npm install from package.json');
-  }
-  if (plan.nodePackages.length > 0) {
-    parts.push(`npm packages: ${plan.nodePackages.join(', ')}`);
-  }
-  if (plan.pipPackages.length > 0) {
-    parts.push(`pip packages: ${plan.pipPackages.join(', ')}`);
-  }
-  return parts.join('; ');
-}
+const green = (s: string): string =>
+  process.stdout.isTTY ? `\x1b[32m${s}\x1b[0m` : s;
 
 async function confirmDependencyInstall(plan: {
   usesPackageJson: boolean;
@@ -382,6 +368,11 @@ export async function handlePluginCommand(args: string[]): Promise<void> {
     try {
       result = await installPlugin(source, {
         approveDependencyInstall: yes === '--yes',
+        onDependenciesAlreadySatisfied: (plan) => {
+          console.log(
+            `${green('[check]')} plugin dependencies (${formatDependencyPlanDetails(plan)}) already installed`,
+          );
+        },
       });
     } catch (error) {
       if (isDependencyApprovalRequiredError(error)) {
@@ -401,11 +392,11 @@ export async function handlePluginCommand(args: string[]): Promise<void> {
 
     if (result.alreadyInstalled) {
       console.log(
-        `Plugin ${result.pluginId} is already present at ${result.pluginDir}.`,
+        `${green('[ok]')} Plugin ${result.pluginId} is already present at ${result.pluginDir}.`,
       );
     } else {
       console.log(
-        `Installed plugin ${result.pluginId} to ${result.pluginDir}.`,
+        `${green('[ok]')} Installed plugin ${result.pluginId} to ${result.pluginDir}.`,
       );
     }
     printDependencyInstallSummary(result);
@@ -452,6 +443,11 @@ export async function handlePluginCommand(args: string[]): Promise<void> {
     try {
       result = await reinstallPlugin(source, {
         approveDependencyInstall: yes === '--yes',
+        onDependenciesAlreadySatisfied: (plan) => {
+          console.log(
+            `${green('[check]')} plugin dependencies (${formatDependencyPlanDetails(plan)}) already installed`,
+          );
+        },
       });
     } catch (error) {
       if (isDependencyApprovalRequiredError(error)) {
@@ -471,11 +467,11 @@ export async function handlePluginCommand(args: string[]): Promise<void> {
 
     if (result.replacedExistingInstall) {
       console.log(
-        `Reinstalled plugin ${result.pluginId} to ${result.pluginDir}.`,
+        `${green('[ok]')} Reinstalled plugin ${result.pluginId} to ${result.pluginDir}.`,
       );
     } else {
       console.log(
-        `Installed plugin ${result.pluginId} to ${result.pluginDir}.`,
+        `${green('[ok]')} Installed plugin ${result.pluginId} to ${result.pluginDir}.`,
       );
     }
     printDependencyInstallSummary(result);

--- a/src/gateway/gateway-plugin-service.ts
+++ b/src/gateway/gateway-plugin-service.ts
@@ -18,6 +18,7 @@ import {
 import { formatPluginSummaryList } from '../plugins/plugin-formatting.js';
 import {
   checkPlugin,
+  formatDependencyPlanDetails,
   installPlugin,
   reinstallPlugin,
   uninstallPlugin,
@@ -667,15 +668,27 @@ export async function handlePluginGatewayCommand(params: {
         '`plugin install` is only available from local TUI/web sessions.',
       );
     }
+    const depsSatisfiedLines: string[] = [];
+    const onDependenciesAlreadySatisfied = (plan: {
+      usesPackageJson: boolean;
+      nodePackages: string[];
+      pipPackages: string[];
+    }): void => {
+      depsSatisfiedLines.push(
+        `[check] plugin dependencies (${formatDependencyPlanDetails(plan)}) already installed`,
+      );
+    };
     try {
       const result = await installPlugin(source, {
         approveDependencyInstall: yes === '--yes',
+        onDependenciesAlreadySatisfied,
       });
       const reloadResult = await reloadPluginRuntime();
       const lines = [
         result.alreadyInstalled
           ? `Plugin \`${result.pluginId}\` is already present at \`${result.pluginDir}\`.`
           : `Installed plugin \`${result.pluginId}\` to \`${result.pluginDir}\`.`,
+        ...depsSatisfiedLines,
         ...buildDependencyInstallLines(result),
         `Plugin \`${result.pluginId}\` will auto-discover from \`${result.pluginDir}\`.`,
         ...buildMissingBinaryGuidanceLines(
@@ -768,15 +781,27 @@ export async function handlePluginGatewayCommand(params: {
         '`plugin reinstall` is only available from local TUI/web sessions.',
       );
     }
+    const reinstallDepsSatisfiedLines: string[] = [];
+    const onReinstallDependenciesAlreadySatisfied = (plan: {
+      usesPackageJson: boolean;
+      nodePackages: string[];
+      pipPackages: string[];
+    }): void => {
+      reinstallDepsSatisfiedLines.push(
+        `[check] plugin dependencies (${formatDependencyPlanDetails(plan)}) already installed`,
+      );
+    };
     try {
       const result = await reinstallPlugin(source, {
         approveDependencyInstall: yes === '--yes',
+        onDependenciesAlreadySatisfied: onReinstallDependenciesAlreadySatisfied,
       });
       const reloadResult = await reloadPluginRuntime();
       const lines = [
         result.replacedExistingInstall
           ? `Reinstalled plugin \`${result.pluginId}\` to \`${result.pluginDir}\`.`
           : `Installed plugin \`${result.pluginId}\` to \`${result.pluginDir}\`.`,
+        ...reinstallDepsSatisfiedLines,
         ...buildDependencyInstallLines(result),
         `Plugin \`${result.pluginId}\` will auto-discover from \`${result.pluginDir}\`.`,
         ...buildMissingBinaryGuidanceLines(

--- a/src/plugins/plugin-dependencies.ts
+++ b/src/plugins/plugin-dependencies.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { hasExecutableCommand } from '../utils/executables.js';
 import type {
   PluginExternalDependency,
   PluginManifest,
@@ -396,11 +397,24 @@ export function installPluginDependencyPlan(
   };
 }
 
+export function allRequiredBinsAvailable(
+  manifest: PluginManifest,
+  cwd: string,
+): boolean {
+  const bins = manifest.requires?.bins;
+  if (!bins || bins.length === 0) return false;
+  return bins.every((req) => hasExecutableCommand(req.name, { cwd }));
+}
+
 export function checkPluginDependencies(
   pluginDir: string,
   manifest: PluginManifest,
   runCheckCommand: PluginDependencyCommandChecker = defaultPluginDependencyCheckCommand,
+  options?: { cwd?: string },
 ): PluginDependencyCheckReport {
+  const cwd = options?.cwd ?? process.cwd();
+  const binsOnPath = allRequiredBinsAvailable(manifest, cwd);
+
   const hasPackageJson = fs.existsSync(path.join(pluginDir, 'package.json'));
   const packageJsonDependencies = readPackageJsonDependencies(pluginDir).map(
     (pkg) => ({
@@ -414,7 +428,7 @@ export function checkPluginDependencies(
     ...(hasPackageJson ? [] : collectLegacyManifestNodePackages(manifest)),
   ]).map((pkg) => ({
     package: pkg,
-    installed: isNodePackageInstalled(pluginDir, pkg),
+    installed: isNodePackageInstalled(pluginDir, pkg) || binsOnPath,
   }));
 
   const venvPython = getPluginVenvPythonPath(pluginDir);
@@ -423,12 +437,13 @@ export function checkPluginDependencies(
   ).map((pkg) => ({
     package: pkg,
     installed:
-      fs.existsSync(venvPython) &&
-      runCheckCommand({
-        command: venvPython,
-        args: ['-m', 'pip', 'show', extractCheckPackageName(pkg)],
-        cwd: pluginDir,
-      }).ok,
+      binsOnPath ||
+      (fs.existsSync(venvPython) &&
+        runCheckCommand({
+          command: venvPython,
+          args: ['-m', 'pip', 'show', extractCheckPackageName(pkg)],
+          cwd: pluginDir,
+        }).ok),
   }));
 
   const externalDependencies = (manifest.externalDependencies ?? []).map(

--- a/src/plugins/plugin-install.ts
+++ b/src/plugins/plugin-install.ts
@@ -12,6 +12,7 @@ import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
 import { readStoredRuntimeSecret } from '../security/runtime-secrets.js';
 import { hasExecutableCommand } from '../utils/executables.js';
 import {
+  allRequiredBinsAvailable,
   checkPluginDependencies,
   defaultPluginDependencyCheckCommand,
   getPluginLocalBinDirs,
@@ -50,12 +51,31 @@ type PluginSource =
 
 export type PluginInstallCommandRunner = (command: PluginCommand) => void;
 
+export function formatDependencyPlanDetails(plan: {
+  usesPackageJson: boolean;
+  nodePackages: string[];
+  pipPackages: string[];
+}): string {
+  const parts: string[] = [];
+  if (plan.usesPackageJson) {
+    parts.push('npm install from package.json');
+  }
+  if (plan.nodePackages.length > 0) {
+    parts.push(`npm packages: ${plan.nodePackages.join(', ')}`);
+  }
+  if (plan.pipPackages.length > 0) {
+    parts.push(`pip packages: ${plan.pipPackages.join(', ')}`);
+  }
+  return parts.join('; ');
+}
+
 export interface InstallPluginOptions {
   homeDir?: string;
   cwd?: string;
   runCommand?: PluginInstallCommandRunner;
   runCheckCommand?: PluginDependencyCommandChecker;
   approveDependencyInstall?: boolean;
+  onDependenciesAlreadySatisfied?: (plan: PluginDependencyPlan) => void;
   getRuntimeConfig?: PluginConfigGetter;
   updateRuntimeConfig?: PluginConfigUpdater;
 }
@@ -552,6 +572,7 @@ function installPreparedPlugin(
     runCommand: PluginInstallCommandRunner;
     runCheckCommand: PluginDependencyCommandChecker;
     approveDependencyInstall: boolean;
+    onDependenciesAlreadySatisfied?: (plan: PluginDependencyPlan) => void;
     getRuntimeConfig: PluginConfigGetter;
     updateRuntimeConfig: PluginConfigUpdater;
     replaceExisting: boolean;
@@ -564,11 +585,17 @@ function installPreparedPlugin(
   const manifest = loadPluginManifest(path.join(sourceDir, MANIFEST_FILE_NAME));
   const pluginDir = path.join(installRoot, manifest.id);
   const dependencyPlan = planPluginDependencyInstall(sourceDir, manifest);
+  let skipDependencyInstall = false;
   if (
     hasInstallablePluginDependencies(dependencyPlan) &&
     !options.approveDependencyInstall
   ) {
-    throw new PluginDependencyApprovalRequiredError(dependencyPlan);
+    if (allRequiredBinsAvailable(manifest, options.cwd)) {
+      skipDependencyInstall = true;
+      options.onDependenciesAlreadySatisfied?.(dependencyPlan);
+    } else {
+      throw new PluginDependencyApprovalRequiredError(dependencyPlan);
+    }
   }
   const cleanupDirs: string[] = [];
   let backupDir: string | null = null;
@@ -595,16 +622,16 @@ function installPreparedPlugin(
           pluginDir,
           manifest,
         );
-        const dependencySummary = hasInstallablePluginDependencies(
-          pluginDependencyPlan,
-        )
-          ? installPluginDependencyPlan(
-              pluginDir,
-              pluginDependencyPlan,
-              options.runCommand,
-              options.runCheckCommand,
-            )
-          : emptyDependencyInstallSummary();
+        const dependencySummary =
+          !skipDependencyInstall &&
+          hasInstallablePluginDependencies(pluginDependencyPlan)
+            ? installPluginDependencyPlan(
+                pluginDir,
+                pluginDependencyPlan,
+                options.runCommand,
+                options.runCheckCommand,
+              )
+            : emptyDependencyInstallSummary();
         const configuredRequiredBins = autoConfigurePluginLocalBinaries({
           pluginId: manifest.id,
           pluginDir,
@@ -617,6 +644,7 @@ function installPreparedPlugin(
           pluginDir,
           manifest,
           options.runCheckCommand,
+          { cwd: options.cwd },
         );
         const missingRequiredBins = collectMissingRequiredBins(
           manifest.id,
@@ -656,16 +684,16 @@ function installPreparedPlugin(
       pluginDir,
       manifest,
     );
-    const dependencySummary = hasInstallablePluginDependencies(
-      pluginDependencyPlan,
-    )
-      ? installPluginDependencyPlan(
-          pluginDir,
-          pluginDependencyPlan,
-          options.runCommand,
-          options.runCheckCommand,
-        )
-      : emptyDependencyInstallSummary();
+    const dependencySummary =
+      !skipDependencyInstall &&
+      hasInstallablePluginDependencies(pluginDependencyPlan)
+        ? installPluginDependencyPlan(
+            pluginDir,
+            pluginDependencyPlan,
+            options.runCommand,
+            options.runCheckCommand,
+          )
+        : emptyDependencyInstallSummary();
     const configuredRequiredBins = autoConfigurePluginLocalBinaries({
       pluginId: manifest.id,
       pluginDir,
@@ -678,6 +706,7 @@ function installPreparedPlugin(
       pluginDir,
       manifest,
       options.runCheckCommand,
+      { cwd: options.cwd },
     );
     const missingRequiredBins = collectMissingRequiredBins(
       manifest.id,
@@ -750,6 +779,7 @@ export async function installPlugin(
       runCommand,
       runCheckCommand,
       approveDependencyInstall: options.approveDependencyInstall === true,
+      onDependenciesAlreadySatisfied: options.onDependenciesAlreadySatisfied,
       getRuntimeConfig: getConfig,
       updateRuntimeConfig: updateConfig,
       replaceExisting: false,
@@ -798,6 +828,7 @@ export async function reinstallPlugin(
         runCommand,
         runCheckCommand,
         approveDependencyInstall: options.approveDependencyInstall === true,
+        onDependenciesAlreadySatisfied: options.onDependenciesAlreadySatisfied,
         getRuntimeConfig: getConfig,
         updateRuntimeConfig: updateConfig,
         replaceExisting: true,
@@ -852,6 +883,7 @@ export async function checkPlugin(
     candidate.dir,
     candidate.manifest,
     runCheckCommand,
+    { cwd },
   );
   const configuredRequiredBins = (candidate.manifest.requires?.bins ?? [])
     .map((requirement) => {

--- a/tests/byterover-memory-plugin.test.ts
+++ b/tests/byterover-memory-plugin.test.ts
@@ -1,0 +1,411 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, expect, test, vi } from 'vitest';
+
+import type { RuntimeConfig } from '../src/config/runtime-config.js';
+
+const tempDirs: string[] = [];
+const originalBrvApiKey = process.env.BRV_API_KEY;
+
+function makeTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function loadRuntimeConfig(): RuntimeConfig {
+  return JSON.parse(
+    fs.readFileSync(path.join(process.cwd(), 'config.example.json'), 'utf-8'),
+  ) as RuntimeConfig;
+}
+
+function installBundledPlugin(cwd: string): void {
+  const sourceDir = path.join(process.cwd(), 'plugins', 'byterover-memory');
+  const targetDir = path.join(
+    cwd,
+    '.hybridclaw',
+    'plugins',
+    'byterover-memory',
+  );
+  fs.mkdirSync(path.dirname(targetDir), { recursive: true });
+  fs.cpSync(sourceDir, targetDir, { recursive: true });
+}
+
+function writeByteRoverStub(rootDir: string): string {
+  const scriptPath = path.join(rootDir, 'mock-brv.mjs');
+  const commandLogPath = path.join(rootDir, 'byterover-command-log.jsonl');
+  fs.writeFileSync(
+    scriptPath,
+    [
+      '#!/usr/bin/env node',
+      'import fs from "node:fs";',
+      `const commandLogPath = ${JSON.stringify(commandLogPath)};`,
+      'const argv = process.argv.slice(2);',
+      'const command = String(argv[0] || "");',
+      'const args = argv.slice(1);',
+      'fs.appendFileSync(commandLogPath, JSON.stringify({',
+      '  command,',
+      '  args,',
+      '  cwd: process.cwd(),',
+      '  apiKey: process.env.BRV_API_KEY || "",',
+      '}) + "\\n", "utf8");',
+      'if (command === "status") {',
+      '  console.log("ByteRover ready");',
+      '  console.log("Tree nodes: 42");',
+      '  process.exit(0);',
+      '}',
+      'if (command === "query") {',
+      '  const queryIndex = args.indexOf("--");',
+      '  const query = queryIndex >= 0 ? args.slice(queryIndex + 1).join(" ") : args.join(" ");',
+      '  if (query.toLowerCase().includes("unknown")) {',
+      '    console.log("No relevant memories found.");',
+      '    process.exit(0);',
+      '  }',
+      '  console.log("Decision: Clerk reduced auth integration time.");',
+      '  console.log("Preference: concise answers are preferred.");',
+      '  process.exit(0);',
+      '}',
+      'if (command === "curate") {',
+      '  console.log("Curated into ByteRover tree.");',
+      '  process.exit(0);',
+      '}',
+      'console.error("unexpected command: " + command);',
+      'process.exit(1);',
+      '',
+    ].join('\n'),
+    'utf-8',
+  );
+  fs.chmodSync(scriptPath, 0o755);
+  return scriptPath;
+}
+
+function readByteRoverCommandLog(rootDir: string): Array<{
+  command: string;
+  args: string[];
+  cwd: string;
+  apiKey: string;
+}> {
+  const logPath = path.join(rootDir, 'byterover-command-log.jsonl');
+  if (!fs.existsSync(logPath)) return [];
+  return fs
+    .readFileSync(logPath, 'utf-8')
+    .split('\n')
+    .filter(Boolean)
+    .map(
+      (line) =>
+        JSON.parse(line) as {
+          command: string;
+          args: string[];
+          cwd: string;
+          apiKey: string;
+        },
+    );
+}
+
+function decodeCommandPayload(args: string[]): string {
+  const markerIndex = args.indexOf('--');
+  if (markerIndex < 0) return args.join(' ');
+  return args.slice(markerIndex + 1).join(' ');
+}
+
+afterEach(() => {
+  if (typeof originalBrvApiKey === 'string') {
+    process.env.BRV_API_KEY = originalBrvApiKey;
+  } else {
+    delete process.env.BRV_API_KEY;
+  }
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+test('resolveByteRoverPluginConfig resolves defaults and ~ paths', async () => {
+  const cwd = makeTempDir('hybridclaw-byterover-project-');
+  const runtimeHome = makeTempDir('hybridclaw-byterover-home-');
+  const { resolveByteRoverPluginConfig } = await import(
+    '../plugins/byterover-memory/src/config.js'
+  );
+
+  const resolved = resolveByteRoverPluginConfig(
+    {
+      command: 'custom-brv',
+      workingDirectory: '~/byterover-sandbox',
+      autoCurate: false,
+      maxInjectedChars: 1200,
+      queryTimeoutMs: 15000,
+      curateTimeoutMs: 180000,
+    },
+    {
+      cwd,
+      homeDir: runtimeHome,
+      installRoot: '/tmp/install-root',
+      runtimeConfigPath: '/tmp/config.json',
+    },
+  );
+
+  expect(resolved.command).toBe('custom-brv');
+  expect(resolved.workingDirectory).toBe(
+    path.join(os.homedir(), 'byterover-sandbox'),
+  );
+  expect(resolved.autoCurate).toBe(false);
+  expect(resolved.mirrorMemoryWrites).toBe(true);
+  expect(resolved.maxInjectedChars).toBe(1200);
+  expect(resolved.queryTimeoutMs).toBe(15000);
+  expect(resolved.curateTimeoutMs).toBe(180000);
+
+  const defaults = resolveByteRoverPluginConfig(
+    {},
+    {
+      cwd,
+      homeDir: runtimeHome,
+      installRoot: '/tmp/install-root',
+      runtimeConfigPath: '/tmp/config.json',
+    },
+  );
+  expect(defaults.command).toBe('brv');
+  expect(defaults.workingDirectory).toBe(path.join(runtimeHome, 'byterover'));
+  expect(defaults.autoCurate).toBe(true);
+  expect(defaults.mirrorMemoryWrites).toBe(true);
+});
+
+test('byterover-memory injects recall context, exposes tools and command, and curates HybridClaw events', async () => {
+  process.env.BRV_API_KEY = 'test-brv-key';
+
+  const homeDir = makeTempDir('hybridclaw-byterover-home-');
+  const cwd = makeTempDir('hybridclaw-byterover-project-');
+  installBundledPlugin(cwd);
+  const byteroverCommand = writeByteRoverStub(cwd);
+  const workingDirectory = path.join(homeDir, 'byterover-store');
+  const resolvedWorkingDirectory = path.join(
+    fs.realpathSync(path.dirname(workingDirectory)),
+    'byterover-store',
+  );
+
+  const config = loadRuntimeConfig();
+  config.plugins.list = [
+    {
+      id: 'byterover-memory',
+      enabled: true,
+      config: {
+        command: byteroverCommand,
+        workingDirectory,
+        maxInjectedChars: 900,
+      },
+    },
+  ];
+
+  const { PluginManager } = await import('../src/plugins/plugin-manager.js');
+  const manager = new PluginManager({
+    homeDir,
+    cwd,
+    getRuntimeConfig: () => config,
+  });
+
+  await manager.ensureInitialized();
+
+  expect(manager.getLoadedPlugins()).toEqual([
+    expect.objectContaining({
+      id: 'byterover-memory',
+      enabled: true,
+      status: 'loaded',
+    }),
+  ]);
+  expect(manager.getToolDefinitions()).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ name: 'brv_curate' }),
+      expect.objectContaining({ name: 'brv_query' }),
+      expect.objectContaining({ name: 'brv_status' }),
+    ]),
+  );
+
+  const promptContext = await manager.collectPromptContext({
+    sessionId: 'session-1',
+    userId: 'user-1',
+    agentId: 'main',
+    channelId: 'web',
+    workspacePath: cwd,
+    recentMessages: [
+      {
+        id: 1,
+        session_id: 'session-1',
+        user_id: 'user-1',
+        username: 'alice',
+        role: 'user',
+        content:
+          'Why did we switch auth providers, and what response style do I prefer?',
+        created_at: '2026-04-10T10:00:00.000Z',
+      },
+    ],
+  });
+
+  expect(promptContext.join('\n\n')).toContain(
+    'ByteRover memory tools are enabled.',
+  );
+  expect(promptContext.join('\n\n')).toContain(
+    'ByteRover recalled context for the latest user message:',
+  );
+  expect(promptContext.join('\n\n')).toContain(
+    'Clerk reduced auth integration time.',
+  );
+
+  await expect(
+    manager.executeTool({
+      toolName: 'brv_status',
+      args: {},
+      sessionId: 'session-1',
+      channelId: 'web',
+    }),
+  ).resolves.toContain(`Working directory: ${workingDirectory}`);
+
+  await expect(
+    manager.executeTool({
+      toolName: 'brv_query',
+      args: { query: 'auth provider decision' },
+      sessionId: 'session-1',
+      channelId: 'web',
+    }),
+  ).resolves.toContain('Preference: concise answers are preferred.');
+
+  await expect(
+    manager.executeTool({
+      toolName: 'brv_curate',
+      args: { content: 'Remember the repo uses Biome formatting.' },
+      sessionId: 'session-1',
+      channelId: 'web',
+    }),
+  ).resolves.toBe('ByteRover memory updated.');
+
+  const command = manager.findCommand('byterover');
+  expect(command).toBeDefined();
+  await expect(
+    Promise.resolve(
+      command?.handler(['status'], {
+        sessionId: 'session-1',
+        channelId: 'web',
+        userId: 'user-1',
+      }),
+    ),
+  ).resolves.toContain(`Command: ${byteroverCommand}`);
+
+  await manager.notifyTurnComplete({
+    sessionId: 'session-1',
+    userId: 'user-1',
+    agentId: 'main',
+    workspacePath: cwd,
+    messages: [
+      {
+        id: 2,
+        session_id: 'session-1',
+        user_id: 'user-1',
+        username: 'alice',
+        role: 'user',
+        content: 'Remember zebra lantern 42 for the release checklist.',
+        created_at: '2026-04-10T10:01:00.000Z',
+      },
+      {
+        id: 3,
+        session_id: 'session-1',
+        user_id: 'assistant',
+        username: null,
+        role: 'assistant',
+        content: 'I will keep that in mind for the release checklist.',
+        created_at: '2026-04-10T10:01:05.000Z',
+      },
+    ],
+  });
+
+  await manager.notifyMemoryWrites({
+    sessionId: 'session-1',
+    agentId: 'main',
+    channelId: 'web',
+    toolExecutions: [
+      {
+        name: 'memory',
+        arguments:
+          '{"action":"append","target":"user","content":"Prefers concise answers."}',
+        result: 'Appended 25 chars to USER.md',
+        durationMs: 8,
+      },
+    ],
+  });
+
+  await manager.notifyBeforeCompaction({
+    sessionId: 'session-1',
+    agentId: 'main',
+    channelId: 'web',
+    summary: 'Auth migration decisions and tone preferences.',
+    olderMessages: [
+      {
+        id: 4,
+        session_id: 'session-1',
+        user_id: 'user-1',
+        username: 'alice',
+        role: 'user',
+        content: 'Clerk reduced the auth integration time significantly.',
+        created_at: '2026-04-10T09:00:00.000Z',
+      },
+      {
+        id: 5,
+        session_id: 'session-1',
+        user_id: 'assistant',
+        username: null,
+        role: 'assistant',
+        content: 'We should preserve that decision and keep responses concise.',
+        created_at: '2026-04-10T09:00:10.000Z',
+      },
+    ],
+  });
+
+  await manager.shutdown();
+
+  const commandLog = readByteRoverCommandLog(cwd);
+  expect(commandLog).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        command: 'status',
+        cwd: resolvedWorkingDirectory,
+        apiKey: 'test-brv-key',
+      }),
+      expect.objectContaining({
+        command: 'query',
+        cwd: resolvedWorkingDirectory,
+        apiKey: 'test-brv-key',
+      }),
+      expect.objectContaining({
+        command: 'curate',
+        cwd: resolvedWorkingDirectory,
+        apiKey: 'test-brv-key',
+      }),
+    ]),
+  );
+
+  const curatePayloads = commandLog
+    .filter((entry) => entry.command === 'curate')
+    .map((entry) => decodeCommandPayload(entry.args));
+  expect(
+    curatePayloads.some((payload) =>
+      payload.includes('Remember the repo uses Biome formatting.'),
+    ),
+  ).toBe(true);
+  expect(
+    curatePayloads.some((payload) =>
+      payload.includes(
+        'User: Remember zebra lantern 42 for the release checklist.',
+      ),
+    ),
+  ).toBe(true);
+  expect(
+    curatePayloads.some((payload) =>
+      payload.includes('[User profile]\nPrefers concise answers.'),
+    ),
+  ).toBe(true);
+  expect(
+    curatePayloads.some((payload) =>
+      payload.includes('[Pre-compaction context]'),
+    ),
+  ).toBe(true);
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -2880,10 +2880,15 @@ describe('CLI hybridai commands', () => {
 
     expect(installPlugin).toHaveBeenCalledWith(
       '@scope/hybridclaw-plugin-example',
-      { approveDependencyInstall: true },
+      {
+        approveDependencyInstall: true,
+        onDependenciesAlreadySatisfied: expect.any(Function),
+      },
     );
     expect(logSpy).toHaveBeenCalledWith(
-      'Installed plugin example-plugin to /tmp/.hybridclaw/plugins/example-plugin.',
+      expect.stringContaining(
+        'Installed plugin example-plugin to /tmp/.hybridclaw/plugins/example-plugin.',
+      ),
     );
     expect(logSpy).toHaveBeenCalledWith(
       'Plugin example-plugin will auto-discover from /tmp/.hybridclaw/plugins/example-plugin.',
@@ -3059,9 +3064,12 @@ describe('CLI hybridai commands', () => {
 
     expect(reinstallPlugin).toHaveBeenCalledWith('./plugins/example-plugin', {
       approveDependencyInstall: true,
+      onDependenciesAlreadySatisfied: expect.any(Function),
     });
     expect(logSpy).toHaveBeenCalledWith(
-      'Reinstalled plugin example-plugin to /tmp/.hybridclaw/plugins/example-plugin.',
+      expect.stringContaining(
+        'Reinstalled plugin example-plugin to /tmp/.hybridclaw/plugins/example-plugin.',
+      ),
     );
     expect(logSpy).toHaveBeenCalledWith(
       'Plugin example-plugin will auto-discover from /tmp/.hybridclaw/plugins/example-plugin.',

--- a/tests/gateway-service.plugins.test.ts
+++ b/tests/gateway-service.plugins.test.ts
@@ -831,6 +831,7 @@ test('handleGatewayCommand installs a plugin from a local TUI/web session and re
 
   expect(installPluginMock).toHaveBeenCalledWith('./plugins/qmd-memory', {
     approveDependencyInstall: true,
+    onDependenciesAlreadySatisfied: expect.any(Function),
   });
   expect(reloadPluginManagerMock).toHaveBeenCalled();
   expect(result.kind).toBe('info');
@@ -1188,6 +1189,7 @@ test('handleGatewayCommand reinstalls a plugin from a local TUI/web session and 
 
   expect(reinstallPluginMock).toHaveBeenCalledWith('./plugins/qmd-memory', {
     approveDependencyInstall: true,
+    onDependenciesAlreadySatisfied: expect.any(Function),
   });
   expect(reloadPluginManagerMock).toHaveBeenCalled();
   expect(result.kind).toBe('info');

--- a/tests/plugin-install.test.ts
+++ b/tests/plugin-install.test.ts
@@ -163,6 +163,38 @@ function writePipPluginDir(dir: string): void {
   );
 }
 
+function writeNodeDepPluginDir(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'hybridclaw.plugin.yaml'),
+    [
+      'id: node-dep-plugin',
+      'name: Node Dep Plugin',
+      'version: 1.0.0',
+      'kind: tool',
+      'requires:',
+      '  bins:',
+      '    - name: node',
+      '      configKey: command',
+      'nodeDependencies:',
+      '  - some-cli-package',
+      'configSchema:',
+      '  type: object',
+      '  properties:',
+      '    command:',
+      '      type: string',
+      '      default: node',
+      '',
+    ].join('\n'),
+    'utf-8',
+  );
+  fs.writeFileSync(
+    path.join(dir, 'index.js'),
+    "export default { id: 'node-dep-plugin', register() {} };\n",
+    'utf-8',
+  );
+}
+
 function createRuntimeConfigState(initial?: RuntimeConfig): {
   getRuntimeConfig: () => RuntimeConfig;
   updateRuntimeConfig: ReturnType<typeof vi.fn>;
@@ -486,6 +518,39 @@ describe('plugin install', () => {
       }),
     ).rejects.toBeInstanceOf(PluginDependencyApprovalRequiredError);
     expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  test('skips dependency install when required binaries are already on PATH', async () => {
+    const homeDir = makeTempDir('hybridclaw-plugin-home-');
+    const cwd = makeTempDir('hybridclaw-plugin-cwd-');
+    const sourceDir = path.join(cwd, 'node-dep-plugin');
+    const runtimeConfig = createRuntimeConfigState();
+    writeNodeDepPluginDir(sourceDir);
+
+    const runCommand = vi.fn();
+    const satisfiedCallback = vi.fn();
+    const { installPlugin } = await import('../src/plugins/plugin-install.js');
+
+    // node is on PATH, so nodeDependencies should be skipped
+    const result = await installPlugin(sourceDir, {
+      homeDir,
+      cwd,
+      runCommand,
+      getRuntimeConfig: runtimeConfig.getRuntimeConfig,
+      updateRuntimeConfig: runtimeConfig.updateRuntimeConfig,
+      onDependenciesAlreadySatisfied: satisfiedCallback,
+    });
+
+    expect(satisfiedCallback).toHaveBeenCalledTimes(1);
+    expect(satisfiedCallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nodePackages: ['some-cli-package'],
+      }),
+    );
+    // runCommand should NOT be called for npm install
+    expect(runCommand).not.toHaveBeenCalled();
+    expect(result.pluginId).toBe('node-dep-plugin');
+    expect(result.dependenciesInstalled).toBe(false);
   });
 
   test('installs pip dependencies, auto-configures local binaries, and checks the plugin', async () => {


### PR DESCRIPTION
## What changed
- add a bundled `byterover-memory` external memory provider plugin
- wire ByteRover prompt recall, `brv_query` / `brv_curate` / `brv_status` tools, and a `/byterover` command into HybridClaw's plugin memory-layer system
- mirror completed turns, native memory writes, and pre-compaction summaries into ByteRover curation flows
- add targeted ByteRover plugin tests and a new extensibility guide, plus docs index links

## Why
HybridClaw already supports external memory providers, and Hermes has a ByteRover integration pattern worth matching. This adds a native HybridClaw implementation that fits the existing memory-provider slot and plugin lifecycle hooks without changing built-in memory behavior.

## Impact
- operators can install and enable ByteRover as the active external memory provider
- models get prompt-time recall plus explicit ByteRover tools
- ByteRover stays additive alongside built-in SQLite, `MEMORY.md`, and `USER.md`

## Validation
- `npm run typecheck`
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/byterover-memory-plugin.test.ts`
