### PR TITLE
feat(console): replace inline banners with toast notifications

### DIFF
--- a/console/src/components/dialog/dialog.test.tsx
+++ b/console/src/components/dialog/dialog.test.tsx
@@ -1,0 +1,101 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from './index';
+
+function TestDialog(props: { onConfirm?: () => void }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger>Open</DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Confirm</DialogTitle>
+          <DialogDescription>Are you sure?</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose>Cancel</DialogClose>
+          <button
+            type="button"
+            onClick={() => {
+              props.onConfirm?.();
+              setOpen(false);
+            }}
+          >
+            Yes
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+describe('Dialog', () => {
+  it('opens when trigger is clicked and closes on DialogClose', () => {
+    render(<TestDialog />);
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    expect(screen.getByText('Confirm')).toBeTruthy();
+    expect(screen.getByText('Are you sure?')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('fires the confirm callback', () => {
+    const onConfirm = vi.fn();
+    render(<TestDialog onConfirm={onConfirm} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Yes' }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('has correct aria attributes', () => {
+    render(<TestDialog />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+    expect(dialog.getAttribute('aria-labelledby')).toBeTruthy();
+    expect(dialog.getAttribute('aria-describedby')).toBeTruthy();
+  });
+
+  it('closes when the backdrop is clicked', () => {
+    render(<TestDialog />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+    expect(screen.getByRole('dialog')).toBeTruthy();
+
+    // The backdrop is the sibling before the viewport that wraps the dialog.
+    const dialog = screen.getByRole('dialog');
+    const backdrop = dialog.parentElement?.previousElementSibling;
+    expect(backdrop).toBeTruthy();
+    act(() => {
+      fireEvent.click(backdrop);
+    });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('closes when Escape is pressed', () => {
+    render(<TestDialog />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+    expect(screen.getByRole('dialog')).toBeTruthy();
+
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+});

--- a/console/src/components/dialog/dialog.test.tsx
+++ b/console/src/components/dialog/dialog.test.tsx
@@ -83,7 +83,7 @@ describe('Dialog', () => {
     const backdrop = dialog.parentElement?.previousElementSibling;
     expect(backdrop).toBeTruthy();
     act(() => {
-      fireEvent.click(backdrop);
+      fireEvent.click(backdrop as Element);
     });
     expect(screen.queryByRole('dialog')).toBeNull();
   });

--- a/console/src/components/dialog/index.module.css
+++ b/console/src/components/dialog/index.module.css
@@ -1,0 +1,110 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  background: rgb(10 15 25 / 0.5);
+  animation: dialogFadeIn 150ms ease;
+}
+
+.viewport {
+  position: fixed;
+  inset: 0;
+  z-index: 51;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  pointer-events: none;
+}
+
+.content {
+  pointer-events: auto;
+  width: 100%;
+  max-width: 440px;
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+  background: var(--panel-bg);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-popover);
+  padding: 24px;
+  display: grid;
+  gap: 20px;
+  animation: dialogSlideIn 150ms ease;
+}
+
+.sm {
+  max-width: 360px;
+}
+
+.lg {
+  max-width: 560px;
+}
+
+.header {
+  display: grid;
+  gap: 8px;
+}
+
+.title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+}
+
+.description {
+  margin: 0;
+  color: var(--muted-foreground);
+  line-height: 1.5;
+}
+
+.footer {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+@keyframes dialogFadeIn {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes dialogSlideIn {
+  from {
+    opacity: 0;
+    transform: scale(0.96) translateY(4px);
+  }
+}
+
+.backdrop.exiting {
+  animation: dialogFadeOut 150ms ease forwards;
+}
+
+.content.exiting {
+  animation: dialogSlideOut 150ms ease forwards;
+}
+
+@keyframes dialogFadeOut {
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes dialogSlideOut {
+  to {
+    opacity: 0;
+    transform: scale(0.96) translateY(4px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .backdrop,
+  .content,
+  .backdrop.exiting,
+  .content.exiting {
+    animation: none;
+  }
+}

--- a/console/src/components/dialog/index.tsx
+++ b/console/src/components/dialog/index.tsx
@@ -1,7 +1,7 @@
 /**
  * Dialog — a modal dialog built on our own accessibility primitives.
  *
- * Follows the Base UI compound-component pattern: compose sub-components
+ * Follows the compound-component pattern (à la Radix / Base UI): compose sub-components
  * to build the dialog layout you need.
  *
  * Usage:
@@ -29,6 +29,7 @@ import {
   type ButtonHTMLAttributes,
   createContext,
   type ReactNode,
+  useCallback,
   useContext,
   useEffect,
   useId,
@@ -37,6 +38,7 @@ import {
 } from 'react';
 import { createPortal } from 'react-dom';
 import { useEscapeKeydown } from '../../hooks/useEscapeKeydown';
+import { useExitAnimation } from '../../hooks/useExitAnimation';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
 import { useHideOthers } from '../../hooks/useHideOthers';
 import { useScrollLock } from '../../hooks/useScrollLock';
@@ -120,7 +122,7 @@ export function DialogTrigger(
 export function DialogContent(props: {
   children: ReactNode;
   className?: string;
-  /** Width variant. Defaults to "default" (~440px). */
+  /** Width variant: "sm" (~360px), "default" (~440px), "lg" (~560px). */
   size?: 'sm' | 'default' | 'lg';
 }) {
   const ctx = useDialogContext();
@@ -136,29 +138,8 @@ export function DialogContent(props: {
     prevOpenRef.current = open;
   }, [open]);
 
-  // Remove from DOM after exit animation completes.
-  useEffect(() => {
-    if (!exiting) return;
-    const el = panelRef.current;
-    if (!el) {
-      setExiting(false);
-      return;
-    }
-    const style = getComputedStyle(el);
-    if (
-      style.animationName === 'none' ||
-      style.animationName === '' ||
-      style.animationDuration === '0s'
-    ) {
-      setExiting(false);
-      return;
-    }
-    function handleAnimationEnd() {
-      setExiting(false);
-    }
-    el.addEventListener('animationend', handleAnimationEnd, { once: true });
-    return () => el.removeEventListener('animationend', handleAnimationEnd);
-  }, [exiting]);
+  const clearExiting = useCallback(() => setExiting(false), []);
+  useExitAnimation(panelRef, exiting, clearExiting);
 
   useScrollLock(open);
   useFocusTrap(panelRef, open);

--- a/console/src/components/dialog/index.tsx
+++ b/console/src/components/dialog/index.tsx
@@ -29,6 +29,7 @@ import {
   type ButtonHTMLAttributes,
   createContext,
   type ReactNode,
+  type RefObject,
   useCallback,
   useContext,
   useEffect,
@@ -124,6 +125,10 @@ export function DialogContent(props: {
   className?: string;
   /** Width variant: "sm" (~360px), "default" (~440px), "lg" (~560px). */
   size?: 'sm' | 'default' | 'lg';
+  /** Element to focus on open. Defaults to first focusable element. */
+  initialFocus?: RefObject<HTMLElement | null>;
+  /** When true, clicking the backdrop does not close the dialog. */
+  preventCloseOnOutsideClick?: boolean;
 }) {
   const ctx = useDialogContext();
   const panelRef = useRef<HTMLDivElement>(null);
@@ -131,6 +136,9 @@ export function DialogContent(props: {
   const [exiting, setExiting] = useState(false);
   const prevOpenRef = useRef(open);
 
+  // Track open->closed transitions to keep the panel mounted during the CSS
+  // exit animation. Once the animation completes, useExitAnimation calls
+  // clearExiting and the portal unmounts.
   useEffect(() => {
     if (prevOpenRef.current && !open) {
       setExiting(true);
@@ -142,9 +150,19 @@ export function DialogContent(props: {
   useExitAnimation(panelRef, exiting, clearExiting);
 
   useScrollLock(open);
-  useFocusTrap(panelRef, open);
+  useFocusTrap(panelRef, open, props.initialFocus);
   useEscapeKeydown(() => onOpenChange(false), open);
   useHideOthers(panelRef, open);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production' && open) {
+      if (!document.getElementById(titleId)) {
+        console.warn(
+          'Dialog: no <DialogTitle> found. Add one for accessible labelling (aria-labelledby).',
+        );
+      }
+    }
+  }, [open, titleId]);
 
   if (typeof document === 'undefined' || (!open && !exiting)) return null;
 
@@ -160,7 +178,9 @@ export function DialogContent(props: {
       <div
         className={cx(styles.backdrop, exiting && styles.exiting)}
         aria-hidden="true"
-        onClick={() => !exiting && onOpenChange(false)}
+        onClick={() =>
+          !exiting && !props.preventCloseOnOutsideClick && onOpenChange(false)
+        }
       />
       <div className={styles.viewport}>
         <div

--- a/console/src/components/dialog/index.tsx
+++ b/console/src/components/dialog/index.tsx
@@ -1,0 +1,280 @@
+/**
+ * Dialog — a modal dialog built on our own accessibility primitives.
+ *
+ * Follows the Base UI compound-component pattern: compose sub-components
+ * to build the dialog layout you need.
+ *
+ * Usage:
+ *   <Dialog open={open} onOpenChange={setOpen}>
+ *     <DialogContent>
+ *       <DialogHeader>
+ *         <DialogTitle>Confirm deletion</DialogTitle>
+ *         <DialogDescription>This cannot be undone.</DialogDescription>
+ *       </DialogHeader>
+ *       <DialogFooter>
+ *         <DialogClose className="ghost-button">Cancel</DialogClose>
+ *         <button className="danger-button" onClick={onConfirm}>Delete</button>
+ *       </DialogFooter>
+ *     </DialogContent>
+ *   </Dialog>
+ *
+ * For dialogs triggered by a button, use DialogTrigger:
+ *   <Dialog open={open} onOpenChange={setOpen}>
+ *     <DialogTrigger className="primary-button">Open</DialogTrigger>
+ *     <DialogContent>…</DialogContent>
+ *   </Dialog>
+ */
+
+import {
+  type ButtonHTMLAttributes,
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+import { useEscapeKeydown } from '../../hooks/useEscapeKeydown';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
+import { useHideOthers } from '../../hooks/useHideOthers';
+import { useScrollLock } from '../../hooks/useScrollLock';
+import { cx } from '../../lib/cx';
+import styles from './index.module.css';
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+type DialogContextValue = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  titleId: string;
+  descriptionId: string;
+};
+
+const DialogContext = createContext<DialogContextValue | null>(null);
+
+function useDialogContext() {
+  const ctx = useContext(DialogContext);
+  if (!ctx) throw new Error('Dialog components must be used within <Dialog>.');
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Dialog (root)
+// ---------------------------------------------------------------------------
+
+export function Dialog(props: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: ReactNode;
+}) {
+  const titleId = useId();
+  const descriptionId = useId();
+
+  return (
+    <DialogContext.Provider
+      value={{
+        open: props.open,
+        onOpenChange: props.onOpenChange,
+        titleId,
+        descriptionId,
+      }}
+    >
+      {props.children}
+    </DialogContext.Provider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// DialogTrigger
+// ---------------------------------------------------------------------------
+
+export function DialogTrigger(
+  props: ButtonHTMLAttributes<HTMLButtonElement> & { children: ReactNode },
+) {
+  const { onOpenChange } = useDialogContext();
+  const { children, className, onClick, ...rest } = props;
+
+  return (
+    <button
+      {...rest}
+      type="button"
+      className={className}
+      onClick={(e) => {
+        onClick?.(e);
+        onOpenChange(true);
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// DialogContent
+// ---------------------------------------------------------------------------
+
+export function DialogContent(props: {
+  children: ReactNode;
+  className?: string;
+  /** Width variant. Defaults to "default" (~440px). */
+  size?: 'sm' | 'default' | 'lg';
+}) {
+  const ctx = useDialogContext();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const { open, onOpenChange, titleId, descriptionId } = ctx;
+  const [exiting, setExiting] = useState(false);
+  const prevOpenRef = useRef(open);
+
+  useEffect(() => {
+    if (prevOpenRef.current && !open) {
+      setExiting(true);
+    }
+    prevOpenRef.current = open;
+  }, [open]);
+
+  // Remove from DOM after exit animation completes.
+  useEffect(() => {
+    if (!exiting) return;
+    const el = panelRef.current;
+    if (!el) {
+      setExiting(false);
+      return;
+    }
+    const style = getComputedStyle(el);
+    if (
+      style.animationName === 'none' ||
+      style.animationName === '' ||
+      style.animationDuration === '0s'
+    ) {
+      setExiting(false);
+      return;
+    }
+    function handleAnimationEnd() {
+      setExiting(false);
+    }
+    el.addEventListener('animationend', handleAnimationEnd, { once: true });
+    return () => el.removeEventListener('animationend', handleAnimationEnd);
+  }, [exiting]);
+
+  useScrollLock(open);
+  useFocusTrap(panelRef, open);
+  useEscapeKeydown(() => onOpenChange(false), open);
+  useHideOthers(panelRef, open);
+
+  if (typeof document === 'undefined' || (!open && !exiting)) return null;
+
+  const sizeClass =
+    props.size === 'sm'
+      ? styles.sm
+      : props.size === 'lg'
+        ? styles.lg
+        : undefined;
+
+  return createPortal(
+    <>
+      <div
+        className={cx(styles.backdrop, exiting && styles.exiting)}
+        aria-hidden="true"
+        onClick={() => !exiting && onOpenChange(false)}
+      />
+      <div className={styles.viewport}>
+        <div
+          ref={panelRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={titleId}
+          aria-describedby={descriptionId}
+          data-state={exiting ? 'closed' : 'open'}
+          className={cx(
+            styles.content,
+            sizeClass,
+            exiting && styles.exiting,
+            props.className,
+          )}
+        >
+          {props.children}
+        </div>
+      </div>
+    </>,
+    document.body,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// DialogHeader / DialogTitle / DialogDescription
+// ---------------------------------------------------------------------------
+
+export function DialogHeader(props: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cx(styles.header, props.className)}>{props.children}</div>
+  );
+}
+
+export function DialogTitle(props: {
+  children: ReactNode;
+  className?: string;
+}) {
+  const { titleId } = useDialogContext();
+  return (
+    <h3 id={titleId} className={cx(styles.title, props.className)}>
+      {props.children}
+    </h3>
+  );
+}
+
+export function DialogDescription(props: {
+  children: ReactNode;
+  className?: string;
+}) {
+  const { descriptionId } = useDialogContext();
+  return (
+    <p id={descriptionId} className={cx(styles.description, props.className)}>
+      {props.children}
+    </p>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// DialogFooter
+// ---------------------------------------------------------------------------
+
+export function DialogFooter(props: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cx(styles.footer, props.className)}>{props.children}</div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// DialogClose
+// ---------------------------------------------------------------------------
+
+export function DialogClose(
+  props: ButtonHTMLAttributes<HTMLButtonElement> & { children: ReactNode },
+) {
+  const { onOpenChange } = useDialogContext();
+  const { children, className, onClick, ...rest } = props;
+
+  return (
+    <button
+      {...rest}
+      type="button"
+      className={className}
+      onClick={(e) => {
+        onClick?.(e);
+        onOpenChange(false);
+      }}
+    >
+      {children}
+    </button>
+  );
+}

--- a/console/src/components/dialog/index.tsx
+++ b/console/src/components/dialog/index.tsx
@@ -131,6 +131,7 @@ export function DialogContent(props: {
   preventCloseOnOutsideClick?: boolean;
 }) {
   const ctx = useDialogContext();
+  const portalRef = useRef<HTMLDivElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const { open, onOpenChange, titleId, descriptionId } = ctx;
   const [exiting, setExiting] = useState(false);
@@ -152,7 +153,7 @@ export function DialogContent(props: {
   useScrollLock(open);
   useFocusTrap(panelRef, open, props.initialFocus);
   useEscapeKeydown(() => onOpenChange(false), open);
-  useHideOthers(panelRef, open);
+  useHideOthers(portalRef, open);
 
   useEffect(() => {
     if (process.env.NODE_ENV !== 'production' && open) {
@@ -174,7 +175,7 @@ export function DialogContent(props: {
         : undefined;
 
   return createPortal(
-    <>
+    <div ref={portalRef}>
       <div
         className={cx(styles.backdrop, exiting && styles.exiting)}
         aria-hidden="true"
@@ -200,7 +201,7 @@ export function DialogContent(props: {
           {props.children}
         </div>
       </div>
-    </>,
+    </div>,
     document.body,
   );
 }

--- a/console/src/components/sheet/index.tsx
+++ b/console/src/components/sheet/index.tsx
@@ -109,13 +109,14 @@ export function SheetContent({
   ...rest
 }: SheetContentProps) {
   const ctx = useSheetContext();
+  const portalRef = useRef<HTMLDivElement>(null);
   const panelRef = useRef<HTMLElement>(null);
   const { open, onOpenChange, titleId, descriptionId } = ctx;
 
   useScrollLock(open);
   useFocusTrap(panelRef, open);
   useEscapeKeydown(() => onOpenChange(false), open);
-  useHideOthers(panelRef, open);
+  useHideOthers(portalRef, open);
 
   const sideClass = {
     left: styles.left,
@@ -127,7 +128,7 @@ export function SheetContent({
   if (typeof document === 'undefined') return null;
 
   return createPortal(
-    <>
+    <div ref={portalRef}>
       {/* Overlay — click to dismiss; permanently aria-hidden because Escape
           is the keyboard-accessible dismiss path. */}
       <div
@@ -157,7 +158,7 @@ export function SheetContent({
       >
         {children}
       </section>
-    </>,
+    </div>,
     document.body,
   );
 }

--- a/console/src/components/sidebar/sidebar.test.tsx
+++ b/console/src/components/sidebar/sidebar.test.tsx
@@ -672,7 +672,7 @@ describe('Error boundaries', () => {
 describe('useHideOthers', () => {
   afterEach(cleanup);
 
-  it('sets aria-hidden on siblings when mobile drawer is open', () => {
+  it('sets inert on siblings when mobile drawer is open', () => {
     setViewport(800);
     const sibling = document.createElement('div');
     sibling.setAttribute('data-testid', 'app-sibling');
@@ -693,10 +693,10 @@ describe('useHideOthers', () => {
     );
 
     act(() => captured.value?.setOpenMobile(true));
-    expect(sibling.getAttribute('aria-hidden')).toBe('true');
+    expect((sibling as HTMLElement).inert).toBe(true);
 
     act(() => captured.value?.setOpenMobile(false));
-    expect(sibling.hasAttribute('aria-hidden')).toBe(false);
+    expect((sibling as HTMLElement).inert).toBe(false);
 
     document.body.removeChild(sibling);
   });

--- a/console/src/components/toast/index.module.css
+++ b/console/src/components/toast/index.module.css
@@ -8,6 +8,11 @@
   width: 380px;
   max-width: calc(100vw - 48px);
   pointer-events: none;
+  outline: none;
+}
+
+.viewport:empty {
+  display: none;
 }
 
 .toast {

--- a/console/src/components/toast/index.module.css
+++ b/console/src/components/toast/index.module.css
@@ -22,10 +22,12 @@
   gap: 12px;
   padding: 14px 16px;
   border-radius: var(--radius-md);
-  border: 1px solid var(--line);
-  background: var(--panel-bg);
+  border: 1px solid color-mix(in srgb, var(--line) 72%, transparent);
+  background: color-mix(in srgb, var(--panel-bg) 76%, transparent);
   color: var(--text);
   box-shadow: var(--shadow-raised);
+  backdrop-filter: blur(12px) saturate(120%);
+  -webkit-backdrop-filter: blur(12px) saturate(120%);
   animation: toastSlideIn 200ms ease;
 }
 
@@ -59,8 +61,8 @@
 /* ── Type variants ──────────────────────────────────────────────────────── */
 
 .success {
-  background: var(--success-soft);
-  border-color: var(--success-border);
+  background: color-mix(in srgb, var(--success-soft) 68%, transparent);
+  border-color: color-mix(in srgb, var(--success-border) 72%, transparent);
 }
 
 .success .title {
@@ -68,8 +70,8 @@
 }
 
 .error {
-  background: var(--danger-soft);
-  border-color: var(--danger-border);
+  background: color-mix(in srgb, var(--danger-soft) 68%, transparent);
+  border-color: color-mix(in srgb, var(--danger-border) 72%, transparent);
 }
 
 .error .title {
@@ -77,8 +79,8 @@
 }
 
 .info {
-  background: var(--accent);
-  border-color: color-mix(in srgb, var(--primary) 24%, var(--line));
+  background: color-mix(in srgb, var(--accent) 68%, transparent);
+  border-color: color-mix(in srgb, var(--primary) 24%, transparent);
 }
 
 .info .title {

--- a/console/src/components/toast/index.module.css
+++ b/console/src/components/toast/index.module.css
@@ -1,0 +1,148 @@
+.viewport {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 100;
+  display: grid;
+  gap: 8px;
+  width: 380px;
+  max-width: calc(100vw - 48px);
+  pointer-events: none;
+}
+
+.toast {
+  pointer-events: auto;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--line);
+  background: var(--panel-bg);
+  color: var(--text);
+  box-shadow: var(--shadow-raised);
+  animation: toastSlideIn 200ms ease;
+}
+
+.toast.exiting {
+  animation: toastSlideOut 200ms ease forwards;
+}
+
+/* ── Inner layout ───────────────────────────────────────────────────────── */
+
+.body {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.title {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.875rem;
+  line-height: 1.35;
+}
+
+.description {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  color: var(--muted-foreground);
+}
+
+/* ── Type variants ──────────────────────────────────────────────────────── */
+
+.success {
+  background: var(--success-soft);
+  border-color: var(--success-border);
+}
+
+.success .title {
+  color: var(--success);
+}
+
+.error {
+  background: var(--danger-soft);
+  border-color: var(--danger-border);
+}
+
+.error .title {
+  color: var(--danger);
+}
+
+.info {
+  background: var(--accent);
+  border-color: color-mix(in srgb, var(--primary) 24%, var(--line));
+}
+
+.info .title {
+  color: var(--primary);
+}
+
+/* ── Actions ────────────────────────────────────────────────────────────── */
+
+.actions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.actionButton {
+  padding: 4px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-bg);
+  color: var(--text);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.actionButton:hover {
+  border-color: var(--line-strong);
+}
+
+.closeButton {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.closeButton:hover {
+  background: var(--panel-muted);
+  color: var(--text);
+}
+
+/* ── Animations ─────────────────────────────────────────────────────────── */
+
+@keyframes toastSlideIn {
+  from {
+    opacity: 0;
+    transform: translateX(16px);
+  }
+}
+
+@keyframes toastSlideOut {
+  to {
+    opacity: 0;
+    transform: translateX(16px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toast,
+  .toast.exiting {
+    animation: none;
+  }
+}

--- a/console/src/components/toast/index.tsx
+++ b/console/src/components/toast/index.tsx
@@ -103,8 +103,12 @@ export function ToastProvider(props: {
 
   // Single listener for window focus state, shared by all toasts.
   useEffect(() => {
-    function onBlur() { setWindowBlurred(true); }
-    function onFocus() { setWindowBlurred(false); }
+    function onBlur() {
+      setWindowBlurred(true);
+    }
+    function onFocus() {
+      setWindowBlurred(false);
+    }
     window.addEventListener('blur', onBlur);
     window.addEventListener('focus', onFocus);
     return () => {
@@ -191,7 +195,12 @@ export function ToastProvider(props: {
         return;
       }
       if (e.key !== 'Escape') return;
-      if (document.querySelector('[role="dialog"][aria-modal="true"]:not([data-state="closed"])')) return;
+      if (
+        document.querySelector(
+          '[role="dialog"][aria-modal="true"]:not([data-state="closed"])',
+        )
+      )
+        return;
       const target = e.target as HTMLElement | null;
       if (
         target?.tagName === 'INPUT' ||

--- a/console/src/components/toast/index.tsx
+++ b/console/src/components/toast/index.tsx
@@ -87,6 +87,10 @@ export function useToast(): ToastManager {
 // Module-level counter for unique toast IDs. Not suitable for SSR.
 let nextId = 0;
 
+function clampDuration(value: number): number {
+  return Math.max(0, value);
+}
+
 export function ToastProvider(props: {
   children: ReactNode;
   /** Max visible toasts. Default: 3. */
@@ -95,6 +99,19 @@ export function ToastProvider(props: {
   const limit = props.limit ?? 3;
   const [toasts, setToasts] = useState<ToastEntry[]>([]);
   const viewportRef = useRef<HTMLDivElement>(null);
+  const [windowBlurred, setWindowBlurred] = useState(false);
+
+  // Single listener for window focus state, shared by all toasts.
+  useEffect(() => {
+    function onBlur() { setWindowBlurred(true); }
+    function onFocus() { setWindowBlurred(false); }
+    window.addEventListener('blur', onBlur);
+    window.addEventListener('focus', onFocus);
+    return () => {
+      window.removeEventListener('blur', onBlur);
+      window.removeEventListener('focus', onFocus);
+    };
+  }, []);
 
   const remove = useCallback((id: string) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));
@@ -114,7 +131,7 @@ export function ToastProvider(props: {
         title: options.title,
         description: options.description,
         type: options.type ?? 'default',
-        duration: Math.max(0, options.duration ?? 5000),
+        duration: clampDuration(options.duration ?? 5000),
         action: options.action,
         exiting: false,
       };
@@ -138,18 +155,11 @@ export function ToastProvider(props: {
     setToasts((prev) =>
       prev.map((t) => {
         if (t.id !== id) return t;
-        return {
-          ...t,
-          ...(options.title !== undefined && { title: options.title }),
-          ...(options.description !== undefined && {
-            description: options.description,
-          }),
-          ...(options.type !== undefined && { type: options.type }),
-          ...(options.duration !== undefined && {
-            duration: Math.max(0, options.duration),
-          }),
-          ...(options.action !== undefined && { action: options.action }),
-        };
+        const next = { ...t, ...options };
+        if (options.duration !== undefined) {
+          next.duration = clampDuration(options.duration);
+        }
+        return next;
       }),
     );
   }, []);
@@ -221,6 +231,7 @@ export function ToastProvider(props: {
           <ToastViewport
             ref={viewportRef}
             toasts={toasts}
+            windowBlurred={windowBlurred}
             onDismiss={dismiss}
             onRemove={remove}
           />,
@@ -238,6 +249,7 @@ const ToastViewport = forwardRef<
   HTMLDivElement,
   {
     toasts: ToastEntry[];
+    windowBlurred: boolean;
     onDismiss: (id: string) => void;
     onRemove: (id: string) => void;
   }
@@ -254,6 +266,7 @@ const ToastViewport = forwardRef<
         <ToastItem
           key={toast.id}
           toast={toast}
+          windowBlurred={props.windowBlurred}
           onDismiss={props.onDismiss}
           onRemove={props.onRemove}
         />
@@ -268,34 +281,18 @@ const ToastViewport = forwardRef<
 
 function ToastItem(props: {
   toast: ToastEntry;
+  windowBlurred: boolean;
   onDismiss: (id: string) => void;
   onRemove: (id: string) => void;
 }) {
-  const { toast, onDismiss, onRemove } = props;
+  const { toast, windowBlurred, onDismiss, onRemove } = props;
   const elementRef = useRef<HTMLDivElement>(null);
   const [paused, setPaused] = useState(false);
   const [focused, setFocused] = useState(false);
-  const [windowBlurred, setWindowBlurred] = useState(false);
   const remainingRef = useRef(toast.duration);
   const startRef = useRef(0);
 
   const suspended = paused || focused || windowBlurred;
-
-  // Pause auto-dismiss when the browser window loses focus.
-  useEffect(() => {
-    function onBlur() {
-      setWindowBlurred(true);
-    }
-    function onFocus() {
-      setWindowBlurred(false);
-    }
-    window.addEventListener('blur', onBlur);
-    window.addEventListener('focus', onFocus);
-    return () => {
-      window.removeEventListener('blur', onBlur);
-      window.removeEventListener('focus', onFocus);
-    };
-  }, []);
 
   useEffect(() => {
     if (toast.duration <= 0 || toast.exiting || suspended) return;

--- a/console/src/components/toast/index.tsx
+++ b/console/src/components/toast/index.tsx
@@ -191,7 +191,7 @@ export function ToastProvider(props: {
         return;
       }
       if (e.key !== 'Escape') return;
-      if (document.querySelector('[role="dialog"][aria-modal="true"]')) return;
+      if (document.querySelector('[role="dialog"][aria-modal="true"]:not([data-state="closed"])')) return;
       const target = e.target as HTMLElement | null;
       if (
         target?.tagName === 'INPUT' ||

--- a/console/src/components/toast/index.tsx
+++ b/console/src/components/toast/index.tsx
@@ -1,7 +1,7 @@
 /**
  * Toast — a non-blocking notification system.
  *
- * Follows the Base UI pattern: a provider wraps the app, and an imperative
+ * Follows the provider + imperative hook pattern (à la Radix / Base UI): a provider wraps the app, and an
  * hook lets any component fire toasts.
  *
  * Setup (once, in app root):
@@ -27,6 +27,7 @@ import {
   useState,
 } from 'react';
 import { createPortal } from 'react-dom';
+import { useExitAnimation } from '../../hooks/useExitAnimation';
 import { cx } from '../../lib/cx';
 import styles from './index.module.css';
 
@@ -145,21 +146,24 @@ export function ToastProvider(props: {
     [add],
   );
 
-  // Escape key dismisses the most recent toast (unless a dialog is open).
+  // Escape dismisses the most recent toast, unless a dialog is open or focus is in a form input.
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       if (e.key !== 'Escape') return;
       if (document.querySelector('[role="dialog"][aria-modal="true"]')) return;
-      const target = e.target as HTMLElement;
+      const target = e.target as HTMLElement | null;
       if (
-        target.tagName === 'INPUT' ||
-        target.tagName === 'TEXTAREA' ||
-        target.tagName === 'SELECT' ||
-        target.isContentEditable
+        target?.tagName === 'INPUT' ||
+        target?.tagName === 'TEXTAREA' ||
+        target?.tagName === 'SELECT' ||
+        target?.isContentEditable
       )
         return;
       setToasts((prev) => {
-        const last = [...prev].reverse().find((t) => !t.exiting);
+        let last: ToastEntry | undefined;
+        for (let i = prev.length - 1; i >= 0; i--) {
+          if (!prev[i].exiting) { last = prev[i]; break; }
+        }
         if (!last) return prev;
         return prev.map((t) =>
           t.id === last.id ? { ...t, exiting: true } : t,
@@ -232,7 +236,6 @@ function ToastItem(props: {
   const remainingRef = useRef(toast.duration);
   const startRef = useRef(0);
 
-  // Auto-dismiss timer with hover pause support.
   useEffect(() => {
     if (toast.duration <= 0 || toast.exiting || paused) return;
     startRef.current = Date.now();
@@ -244,32 +247,11 @@ function ToastItem(props: {
     };
   }, [toast.id, toast.duration, toast.exiting, paused, onDismiss]);
 
-  // Remove element after exit animation completes.
-  useEffect(() => {
-    if (!toast.exiting) return;
-    const el = elementRef.current;
-    if (!el) {
-      onRemove(toast.id);
-      return;
-    }
-    const style = getComputedStyle(el);
-    if (
-      style.animationName === 'none' ||
-      style.animationName === '' ||
-      style.animationDuration === '0s'
-    ) {
-      onRemove(toast.id);
-      return;
-    }
-    function handleAnimationEnd() {
-      onRemove(toast.id);
-    }
-    el.addEventListener('animationend', handleAnimationEnd, { once: true });
-    return () => el.removeEventListener('animationend', handleAnimationEnd);
-  }, [toast.exiting, toast.id, onRemove]);
+  const handleRemove = useCallback(() => onRemove(toast.id), [onRemove, toast.id]);
+  useExitAnimation(elementRef, toast.exiting, handleRemove);
 
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: role is set dynamically
+    // biome-ignore lint/a11y/noStaticElementInteractions: mouse handlers only control auto-dismiss pause, not user interactivity
     <div
       ref={elementRef}
       className={cx(

--- a/console/src/components/toast/index.tsx
+++ b/console/src/components/toast/index.tsx
@@ -186,8 +186,10 @@ export function ToastProvider(props: {
     [add],
   );
 
-  // Escape dismisses the most recent toast, unless a dialog is open or focus
-  // is in a form input. F8 moves focus to the toast viewport (Radix convention).
+  // Escape dismisses the most recent toast only when focus is inside the
+  // toast viewport (Base UI pattern). When a modal is open its inert marking
+  // prevents the viewport from receiving focus, so no cross-component
+  // coordination is needed. F8 moves focus to the viewport (Radix convention).
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       if (e.key === 'F8') {
@@ -196,17 +198,8 @@ export function ToastProvider(props: {
       }
       if (e.key !== 'Escape') return;
       if (
-        document.querySelector(
-          '[role="dialog"][aria-modal="true"]:not([data-state="closed"])',
-        )
-      )
-        return;
-      const target = e.target as HTMLElement | null;
-      if (
-        target?.tagName === 'INPUT' ||
-        target?.tagName === 'TEXTAREA' ||
-        target?.tagName === 'SELECT' ||
-        target?.isContentEditable
+        !viewportRef.current ||
+        !viewportRef.current.contains(document.activeElement)
       )
         return;
       setToasts((prev) => {

--- a/console/src/components/toast/index.tsx
+++ b/console/src/components/toast/index.tsx
@@ -162,7 +162,10 @@ export function ToastProvider(props: {
       setToasts((prev) => {
         let last: ToastEntry | undefined;
         for (let i = prev.length - 1; i >= 0; i--) {
-          if (!prev[i].exiting) { last = prev[i]; break; }
+          if (!prev[i].exiting) {
+            last = prev[i];
+            break;
+          }
         }
         if (!last) return prev;
         return prev.map((t) =>
@@ -247,7 +250,10 @@ function ToastItem(props: {
     };
   }, [toast.id, toast.duration, toast.exiting, paused, onDismiss]);
 
-  const handleRemove = useCallback(() => onRemove(toast.id), [onRemove, toast.id]);
+  const handleRemove = useCallback(
+    () => onRemove(toast.id),
+    [onRemove, toast.id],
+  );
   useExitAnimation(elementRef, toast.exiting, handleRemove);
 
   return (

--- a/console/src/components/toast/index.tsx
+++ b/console/src/components/toast/index.tsx
@@ -19,10 +19,12 @@
 
 import {
   createContext,
+  forwardRef,
   type ReactNode,
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -65,6 +67,8 @@ interface ToastManager {
   success: (title: string, description?: string) => string;
   error: (title: string, description?: string) => string;
   info: (title: string, description?: string) => string;
+  /** Update an existing toast's content. Non-provided fields are unchanged. */
+  update: (id: string, options: Partial<ToastOptions>) => void;
   dismiss: (id: string) => void;
 }
 
@@ -80,6 +84,7 @@ export function useToast(): ToastManager {
 // Provider
 // ---------------------------------------------------------------------------
 
+// Module-level counter for unique toast IDs. Not suitable for SSR.
 let nextId = 0;
 
 export function ToastProvider(props: {
@@ -89,6 +94,7 @@ export function ToastProvider(props: {
 }) {
   const limit = props.limit ?? 3;
   const [toasts, setToasts] = useState<ToastEntry[]>([]);
+  const viewportRef = useRef<HTMLDivElement>(null);
 
   const remove = useCallback((id: string) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));
@@ -108,7 +114,7 @@ export function ToastProvider(props: {
         title: options.title,
         description: options.description,
         type: options.type ?? 'default',
-        duration: options.duration ?? 5000,
+        duration: Math.max(0, options.duration ?? 5000),
         action: options.action,
         exiting: false,
       };
@@ -128,6 +134,26 @@ export function ToastProvider(props: {
     [limit],
   );
 
+  const update = useCallback((id: string, options: Partial<ToastOptions>) => {
+    setToasts((prev) =>
+      prev.map((t) => {
+        if (t.id !== id) return t;
+        return {
+          ...t,
+          ...(options.title !== undefined && { title: options.title }),
+          ...(options.description !== undefined && {
+            description: options.description,
+          }),
+          ...(options.type !== undefined && { type: options.type }),
+          ...(options.duration !== undefined && {
+            duration: Math.max(0, options.duration),
+          }),
+          ...(options.action !== undefined && { action: options.action }),
+        };
+      }),
+    );
+  }, []);
+
   const success = useCallback(
     (title: string, description?: string) =>
       add({ title, description, type: 'success' }),
@@ -136,7 +162,7 @@ export function ToastProvider(props: {
 
   const error = useCallback(
     (title: string, description?: string) =>
-      add({ title, description, type: 'error' }),
+      add({ title, description, type: 'error', duration: 0 }),
     [add],
   );
 
@@ -146,9 +172,14 @@ export function ToastProvider(props: {
     [add],
   );
 
-  // Escape dismisses the most recent toast, unless a dialog is open or focus is in a form input.
+  // Escape dismisses the most recent toast, unless a dialog is open or focus
+  // is in a form input. F8 moves focus to the toast viewport (Radix convention).
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'F8') {
+        viewportRef.current?.focus({ preventScroll: true });
+        return;
+      }
       if (e.key !== 'Escape') return;
       if (document.querySelector('[role="dialog"][aria-modal="true"]')) return;
       const target = e.target as HTMLElement | null;
@@ -177,7 +208,10 @@ export function ToastProvider(props: {
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, []);
 
-  const manager: ToastManager = { add, success, error, info, dismiss };
+  const manager = useMemo<ToastManager>(
+    () => ({ add, success, error, info, update, dismiss }),
+    [add, success, error, info, update, dismiss],
+  );
 
   return (
     <ToastContext.Provider value={manager}>
@@ -185,6 +219,7 @@ export function ToastProvider(props: {
       {typeof document !== 'undefined' &&
         createPortal(
           <ToastViewport
+            ref={viewportRef}
             toasts={toasts}
             onDismiss={dismiss}
             onRemove={remove}
@@ -199,18 +234,21 @@ export function ToastProvider(props: {
 // Viewport (renders the toast stack)
 // ---------------------------------------------------------------------------
 
-function ToastViewport(props: {
-  toasts: ToastEntry[];
-  onDismiss: (id: string) => void;
-  onRemove: (id: string) => void;
-}) {
-  if (props.toasts.length === 0) return null;
-
+const ToastViewport = forwardRef<
+  HTMLDivElement,
+  {
+    toasts: ToastEntry[];
+    onDismiss: (id: string) => void;
+    onRemove: (id: string) => void;
+  }
+>(function ToastViewport(props, ref) {
   return (
     <div
+      ref={ref}
       className={styles.viewport}
-      aria-live="polite"
-      aria-relevant="additions"
+      // No aria-live here — each toast item carries its own aria-live value
+      // so error toasts use "assertive" while others use "polite".
+      tabIndex={-1}
     >
       {props.toasts.map((toast) => (
         <ToastItem
@@ -222,7 +260,7 @@ function ToastViewport(props: {
       ))}
     </div>
   );
-}
+});
 
 // ---------------------------------------------------------------------------
 // Individual toast
@@ -236,11 +274,31 @@ function ToastItem(props: {
   const { toast, onDismiss, onRemove } = props;
   const elementRef = useRef<HTMLDivElement>(null);
   const [paused, setPaused] = useState(false);
+  const [focused, setFocused] = useState(false);
+  const [windowBlurred, setWindowBlurred] = useState(false);
   const remainingRef = useRef(toast.duration);
   const startRef = useRef(0);
 
+  const suspended = paused || focused || windowBlurred;
+
+  // Pause auto-dismiss when the browser window loses focus.
   useEffect(() => {
-    if (toast.duration <= 0 || toast.exiting || paused) return;
+    function onBlur() {
+      setWindowBlurred(true);
+    }
+    function onFocus() {
+      setWindowBlurred(false);
+    }
+    window.addEventListener('blur', onBlur);
+    window.addEventListener('focus', onFocus);
+    return () => {
+      window.removeEventListener('blur', onBlur);
+      window.removeEventListener('focus', onFocus);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (toast.duration <= 0 || toast.exiting || suspended) return;
     startRef.current = Date.now();
     const timer = setTimeout(() => onDismiss(toast.id), remainingRef.current);
     return () => {
@@ -248,7 +306,7 @@ function ToastItem(props: {
       remainingRef.current -= Date.now() - startRef.current;
       if (remainingRef.current < 0) remainingRef.current = 0;
     };
-  }, [toast.id, toast.duration, toast.exiting, paused, onDismiss]);
+  }, [toast.id, toast.duration, toast.exiting, suspended, onDismiss]);
 
   const handleRemove = useCallback(
     () => onRemove(toast.id),
@@ -269,8 +327,12 @@ function ToastItem(props: {
       )}
       data-type={toast.type}
       role={toast.type === 'error' ? 'alert' : 'status'}
+      aria-live={toast.type === 'error' ? 'assertive' : 'polite'}
+      aria-atomic="true"
       onMouseEnter={() => setPaused(true)}
       onMouseLeave={() => setPaused(false)}
+      onFocus={() => setFocused(true)}
+      onBlur={() => setFocused(false)}
     >
       <div className={styles.body}>
         <p className={styles.title}>{toast.title}</p>
@@ -284,7 +346,11 @@ function ToastItem(props: {
             type="button"
             className={styles.actionButton}
             onClick={() => {
-              toast.action?.onClick();
+              try {
+                toast.action?.onClick();
+              } catch (e) {
+                console.error('Toast action callback failed:', e);
+              }
               onDismiss(toast.id);
             }}
           >

--- a/console/src/components/toast/index.tsx
+++ b/console/src/components/toast/index.tsx
@@ -1,0 +1,317 @@
+/**
+ * Toast — a non-blocking notification system.
+ *
+ * Follows the Base UI pattern: a provider wraps the app, and an imperative
+ * hook lets any component fire toasts.
+ *
+ * Setup (once, in app root):
+ *   <ToastProvider>
+ *     <App />
+ *   </ToastProvider>
+ *
+ * Usage (anywhere inside the provider):
+ *   const toast = useToast();
+ *   toast.success('Saved.');
+ *   toast.error('Something went wrong.');
+ *   toast.info('FYI.');
+ *   toast.add({ title: 'Custom', description: '…', type: 'default' });
+ */
+
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+import { cx } from '../../lib/cx';
+import styles from './index.module.css';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ToastType = 'default' | 'success' | 'error' | 'info';
+
+export interface ToastOptions {
+  title: string;
+  description?: string;
+  type?: ToastType;
+  /** Auto-dismiss after this many ms. 0 = no auto-dismiss. Default: 5000. */
+  duration?: number;
+  /** Optional action button. */
+  action?: { label: string; onClick: () => void };
+}
+
+interface ToastEntry extends Required<Pick<ToastOptions, 'title' | 'type'>> {
+  id: string;
+  description?: string;
+  duration: number;
+  action?: { label: string; onClick: () => void };
+  /** Set to true when the dismiss animation starts. */
+  exiting: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+interface ToastManager {
+  add: (options: ToastOptions) => string;
+  success: (title: string, description?: string) => string;
+  error: (title: string, description?: string) => string;
+  info: (title: string, description?: string) => string;
+  dismiss: (id: string) => void;
+}
+
+const ToastContext = createContext<ToastManager | null>(null);
+
+export function useToast(): ToastManager {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error('useToast must be used within <ToastProvider>.');
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+let nextId = 0;
+
+export function ToastProvider(props: {
+  children: ReactNode;
+  /** Max visible toasts. Default: 3. */
+  limit?: number;
+}) {
+  const limit = props.limit ?? 3;
+  const [toasts, setToasts] = useState<ToastEntry[]>([]);
+
+  const remove = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((prev) =>
+      prev.map((t) => (t.id === id ? { ...t, exiting: true } : t)),
+    );
+  }, []);
+
+  const add = useCallback(
+    (options: ToastOptions): string => {
+      const id = `toast-${++nextId}`;
+      const entry: ToastEntry = {
+        id,
+        title: options.title,
+        description: options.description,
+        type: options.type ?? 'default',
+        duration: options.duration ?? 5000,
+        action: options.action,
+        exiting: false,
+      };
+      setToasts((prev) => {
+        const next = [...prev, entry];
+        // If over limit, mark oldest for exit.
+        if (next.length > limit) {
+          const overflow = next.length - limit;
+          return next.map((t, i) =>
+            i < overflow && !t.exiting ? { ...t, exiting: true } : t,
+          );
+        }
+        return next;
+      });
+      return id;
+    },
+    [limit],
+  );
+
+  const success = useCallback(
+    (title: string, description?: string) =>
+      add({ title, description, type: 'success' }),
+    [add],
+  );
+
+  const error = useCallback(
+    (title: string, description?: string) =>
+      add({ title, description, type: 'error' }),
+    [add],
+  );
+
+  const info = useCallback(
+    (title: string, description?: string) =>
+      add({ title, description, type: 'info' }),
+    [add],
+  );
+
+  // Escape key dismisses the most recent toast (unless a dialog is open).
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key !== 'Escape') return;
+      if (document.querySelector('[role="dialog"][aria-modal="true"]')) return;
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.tagName === 'SELECT' ||
+        target.isContentEditable
+      )
+        return;
+      setToasts((prev) => {
+        const last = [...prev].reverse().find((t) => !t.exiting);
+        if (!last) return prev;
+        return prev.map((t) =>
+          t.id === last.id ? { ...t, exiting: true } : t,
+        );
+      });
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  const manager: ToastManager = { add, success, error, info, dismiss };
+
+  return (
+    <ToastContext.Provider value={manager}>
+      {props.children}
+      {typeof document !== 'undefined' &&
+        createPortal(
+          <ToastViewport
+            toasts={toasts}
+            onDismiss={dismiss}
+            onRemove={remove}
+          />,
+          document.body,
+        )}
+    </ToastContext.Provider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Viewport (renders the toast stack)
+// ---------------------------------------------------------------------------
+
+function ToastViewport(props: {
+  toasts: ToastEntry[];
+  onDismiss: (id: string) => void;
+  onRemove: (id: string) => void;
+}) {
+  if (props.toasts.length === 0) return null;
+
+  return (
+    <div
+      className={styles.viewport}
+      aria-live="polite"
+      aria-relevant="additions"
+    >
+      {props.toasts.map((toast) => (
+        <ToastItem
+          key={toast.id}
+          toast={toast}
+          onDismiss={props.onDismiss}
+          onRemove={props.onRemove}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Individual toast
+// ---------------------------------------------------------------------------
+
+function ToastItem(props: {
+  toast: ToastEntry;
+  onDismiss: (id: string) => void;
+  onRemove: (id: string) => void;
+}) {
+  const { toast, onDismiss, onRemove } = props;
+  const elementRef = useRef<HTMLDivElement>(null);
+  const [paused, setPaused] = useState(false);
+  const remainingRef = useRef(toast.duration);
+  const startRef = useRef(0);
+
+  // Auto-dismiss timer with hover pause support.
+  useEffect(() => {
+    if (toast.duration <= 0 || toast.exiting || paused) return;
+    startRef.current = Date.now();
+    const timer = setTimeout(() => onDismiss(toast.id), remainingRef.current);
+    return () => {
+      clearTimeout(timer);
+      remainingRef.current -= Date.now() - startRef.current;
+      if (remainingRef.current < 0) remainingRef.current = 0;
+    };
+  }, [toast.id, toast.duration, toast.exiting, paused, onDismiss]);
+
+  // Remove element after exit animation completes.
+  useEffect(() => {
+    if (!toast.exiting) return;
+    const el = elementRef.current;
+    if (!el) {
+      onRemove(toast.id);
+      return;
+    }
+    const style = getComputedStyle(el);
+    if (
+      style.animationName === 'none' ||
+      style.animationName === '' ||
+      style.animationDuration === '0s'
+    ) {
+      onRemove(toast.id);
+      return;
+    }
+    function handleAnimationEnd() {
+      onRemove(toast.id);
+    }
+    el.addEventListener('animationend', handleAnimationEnd, { once: true });
+    return () => el.removeEventListener('animationend', handleAnimationEnd);
+  }, [toast.exiting, toast.id, onRemove]);
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: role is set dynamically
+    <div
+      ref={elementRef}
+      className={cx(
+        styles.toast,
+        toast.type === 'success' && styles.success,
+        toast.type === 'error' && styles.error,
+        toast.type === 'info' && styles.info,
+        toast.exiting && styles.exiting,
+      )}
+      data-type={toast.type}
+      role={toast.type === 'error' ? 'alert' : 'status'}
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => setPaused(false)}
+    >
+      <div className={styles.body}>
+        <p className={styles.title}>{toast.title}</p>
+        {toast.description ? (
+          <p className={styles.description}>{toast.description}</p>
+        ) : null}
+      </div>
+      <div className={styles.actions}>
+        {toast.action ? (
+          <button
+            type="button"
+            className={styles.actionButton}
+            onClick={() => {
+              toast.action?.onClick();
+              onDismiss(toast.id);
+            }}
+          >
+            {toast.action.label}
+          </button>
+        ) : null}
+        <button
+          type="button"
+          className={styles.closeButton}
+          aria-label="Dismiss"
+          onClick={() => onDismiss(toast.id)}
+        >
+          &times;
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/console/src/components/toast/toast.test.tsx
+++ b/console/src/components/toast/toast.test.tsx
@@ -1,0 +1,156 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ToastProvider, useToast } from './index';
+
+function ToastTriggers() {
+  const toast = useToast();
+  return (
+    <>
+      <button type="button" onClick={() => toast.success('Saved')}>
+        Success
+      </button>
+      <button type="button" onClick={() => toast.error('Failed', 'Details')}>
+        Error
+      </button>
+      <button type="button" onClick={() => toast.info('FYI')}>
+        Info
+      </button>
+    </>
+  );
+}
+
+function setup() {
+  return render(
+    <ToastProvider>
+      <ToastTriggers />
+    </ToastProvider>,
+  );
+}
+
+describe('Toast', () => {
+  it('shows a success toast', () => {
+    setup();
+    act(() => {
+      screen.getByRole('button', { name: 'Success' }).click();
+    });
+    expect(screen.getByText('Saved')).toBeTruthy();
+    expect(
+      screen
+        .getByText('Saved')
+        .closest('[data-type]')
+        ?.getAttribute('data-type'),
+    ).toBe('success');
+  });
+
+  it('shows an error toast with description', () => {
+    setup();
+    act(() => {
+      screen.getByRole('button', { name: 'Error' }).click();
+    });
+    expect(screen.getByText('Failed')).toBeTruthy();
+    expect(screen.getByText('Details')).toBeTruthy();
+  });
+
+  it('auto-dismisses after duration', () => {
+    vi.useFakeTimers();
+    setup();
+
+    act(() => {
+      screen.getByRole('button', { name: 'Info' }).click();
+    });
+    expect(screen.getByText('FYI')).toBeTruthy();
+
+    // After 5s the dismiss fires; in jsdom the animationend fallback removes immediately.
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(screen.queryByText('FYI')).toBeNull();
+
+    vi.useRealTimers();
+  });
+
+  it('respects the limit prop', () => {
+    render(
+      <ToastProvider limit={2}>
+        <ToastTriggers />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      screen.getByRole('button', { name: 'Success' }).click();
+      screen.getByRole('button', { name: 'Error' }).click();
+      screen.getByRole('button', { name: 'Info' }).click();
+    });
+
+    // 3 were added but limit=2, so the first should be marked exiting
+    // and immediately removed in jsdom (no real animation).
+    const allToasts = document.querySelectorAll('[data-type]');
+    expect(allToasts.length).toBeLessThanOrEqual(3);
+  });
+
+  it('uses role="alert" for error toasts', () => {
+    setup();
+    act(() => {
+      screen.getByRole('button', { name: 'Error' }).click();
+    });
+    expect(screen.getByRole('alert')).toBeTruthy();
+  });
+
+  it('uses role="status" for non-error toasts', () => {
+    setup();
+    act(() => {
+      screen.getByRole('button', { name: 'Success' }).click();
+    });
+    expect(screen.getByRole('status')).toBeTruthy();
+  });
+
+  it('pauses auto-dismiss on hover', () => {
+    vi.useFakeTimers();
+    setup();
+
+    act(() => {
+      screen.getByRole('button', { name: 'Info' }).click();
+    });
+
+    const toast = screen.getByText('FYI').closest('[data-type]');
+    expect(toast).toBeTruthy();
+
+    // Hover after 2 seconds.
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    fireEvent.mouseEnter(toast);
+
+    // Wait another 5 seconds while hovered — toast should stay.
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(screen.getByText('FYI')).toBeTruthy();
+
+    // Unhover — remaining ~3s should elapse.
+    fireEvent.mouseLeave(toast);
+    act(() => {
+      vi.advanceTimersByTime(3500);
+    });
+    expect(screen.queryByText('FYI')).toBeNull();
+
+    vi.useRealTimers();
+  });
+
+  it('dismisses the most recent toast on Escape', () => {
+    setup();
+    act(() => {
+      screen.getByRole('button', { name: 'Success' }).click();
+      screen.getByRole('button', { name: 'Info' }).click();
+    });
+
+    expect(screen.getByText('Saved')).toBeTruthy();
+    expect(screen.getByText('FYI')).toBeTruthy();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    // Most recent (FYI) should be dismissed; Saved should remain.
+    expect(screen.queryByText('FYI')).toBeNull();
+    expect(screen.getByText('Saved')).toBeTruthy();
+  });
+});

--- a/console/src/components/toast/toast.test.tsx
+++ b/console/src/components/toast/toast.test.tsx
@@ -167,7 +167,7 @@ describe('Toast', () => {
     vi.useRealTimers();
   });
 
-  it('dismisses the most recent toast on Escape', () => {
+  it('dismisses the most recent toast on Escape when viewport is focused', () => {
     setup();
     act(() => {
       screen.getByRole('button', { name: 'Success' }).click();
@@ -177,10 +177,27 @@ describe('Toast', () => {
     expect(screen.getByText('Saved')).toBeTruthy();
     expect(screen.getByText('FYI')).toBeTruthy();
 
+    // Focus the toast viewport (simulates pressing F8).
+    const viewport = screen.getByText('FYI').closest('[tabindex="-1"]');
+    expect(viewport).toBeTruthy();
+    act(() => (viewport as HTMLElement).focus());
+
     fireEvent.keyDown(document, { key: 'Escape' });
 
     // Most recent (FYI) should be dismissed; Saved should remain.
     expect(screen.queryByText('FYI')).toBeNull();
+    expect(screen.getByText('Saved')).toBeTruthy();
+  });
+
+  it('does not dismiss toast on Escape when focus is elsewhere', () => {
+    setup();
+    act(() => {
+      screen.getByRole('button', { name: 'Success' }).click();
+    });
+
+    expect(screen.getByText('Saved')).toBeTruthy();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
     expect(screen.getByText('Saved')).toBeTruthy();
   });
 

--- a/console/src/components/toast/toast.test.tsx
+++ b/console/src/components/toast/toast.test.tsx
@@ -15,6 +15,26 @@ function ToastTriggers() {
       <button type="button" onClick={() => toast.info('FYI')}>
         Info
       </button>
+      <button
+        type="button"
+        onClick={() =>
+          toast.add({
+            title: 'With action',
+            action: {
+              label: 'Undo',
+              onClick: () => document.dispatchEvent(new Event('test-action')),
+            },
+          })
+        }
+      >
+        Action
+      </button>
+      <button
+        type="button"
+        onClick={() => toast.add({ title: 'Persistent', duration: 0 })}
+      >
+        Sticky
+      </button>
     </>
   );
 }
@@ -82,10 +102,10 @@ describe('Toast', () => {
       screen.getByRole('button', { name: 'Info' }).click();
     });
 
-    // 3 were added but limit=2, so the first should be marked exiting
-    // and immediately removed in jsdom (no real animation).
+    // 3 were added but limit=2. In jsdom the exit animation fallback fires
+    // immediately, so the overflow toast is removed synchronously.
     const allToasts = document.querySelectorAll('[data-type]');
-    expect(allToasts.length).toBeLessThanOrEqual(3);
+    expect(allToasts.length).toBe(2);
   });
 
   it('uses role="alert" for error toasts', () => {
@@ -112,7 +132,7 @@ describe('Toast', () => {
       screen.getByRole('button', { name: 'Info' }).click();
     });
 
-    const toast = screen.getByText('FYI').closest('[data-type]');
+    const toast = screen.getByText('FYI').closest('[data-type]') as Element;
     expect(toast).toBeTruthy();
 
     // Hover after 2 seconds.
@@ -152,5 +172,50 @@ describe('Toast', () => {
     // Most recent (FYI) should be dismissed; Saved should remain.
     expect(screen.queryByText('FYI')).toBeNull();
     expect(screen.getByText('Saved')).toBeTruthy();
+  });
+
+  it('dismisses a toast when the close button is clicked', () => {
+    setup();
+    act(() => {
+      screen.getByRole('button', { name: 'Success' }).click();
+    });
+    expect(screen.getByText('Saved')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    expect(screen.queryByText('Saved')).toBeNull();
+  });
+
+  it('fires the action callback and dismisses', () => {
+    const handler = vi.fn();
+    document.addEventListener('test-action', handler);
+
+    setup();
+    act(() => {
+      screen.getByRole('button', { name: 'Action' }).click();
+    });
+    expect(screen.getByText('With action')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Undo' }));
+    expect(handler).toHaveBeenCalledOnce();
+    expect(screen.queryByText('With action')).toBeNull();
+
+    document.removeEventListener('test-action', handler);
+  });
+
+  it('does not auto-dismiss when duration is 0', () => {
+    vi.useFakeTimers();
+    setup();
+
+    act(() => {
+      screen.getByRole('button', { name: 'Sticky' }).click();
+    });
+    expect(screen.getByText('Persistent')).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(screen.getByText('Persistent')).toBeTruthy();
+
+    vi.useRealTimers();
   });
 });

--- a/console/src/components/toast/toast.test.tsx
+++ b/console/src/components/toast/toast.test.tsx
@@ -48,6 +48,16 @@ function setup() {
 }
 
 describe('Toast', () => {
+  it('throws when useToast is called outside ToastProvider', () => {
+    function Bare() {
+      useToast();
+      return null;
+    }
+    expect(() => render(<Bare />)).toThrow(
+      'useToast must be used within <ToastProvider>.',
+    );
+  });
+
   it('shows a success toast', () => {
     setup();
     act(() => {
@@ -200,6 +210,23 @@ describe('Toast', () => {
     expect(screen.queryByText('With action')).toBeNull();
 
     document.removeEventListener('test-action', handler);
+  });
+
+  it('error toasts do not auto-dismiss', () => {
+    vi.useFakeTimers();
+    setup();
+
+    act(() => {
+      screen.getByRole('button', { name: 'Error' }).click();
+    });
+    expect(screen.getByText('Failed')).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(screen.getByText('Failed')).toBeTruthy();
+
+    vi.useRealTimers();
   });
 
   it('does not auto-dismiss when duration is 0', () => {

--- a/console/src/hooks/useEscapeKeydown.ts
+++ b/console/src/hooks/useEscapeKeydown.ts
@@ -1,9 +1,9 @@
 import { useEffect, useRef } from 'react';
 
 /**
- * Fires `onEscape` when the Escape key is pressed, unless focus is inside an
- * editable element (input, textarea, select, contenteditable) where Escape has its
- * own meaning.
+ * Fires `onEscape` when the Escape key is pressed, skipping form-like elements
+ * (input, textarea, select, contenteditable) to avoid conflicts with their own
+ * keyboard interactions.
  */
 export function useEscapeKeydown(onEscape: () => void, active: boolean): void {
   const onEscapeRef = useRef(onEscape);

--- a/console/src/hooks/useExitAnimation.ts
+++ b/console/src/hooks/useExitAnimation.ts
@@ -1,0 +1,44 @@
+import { type RefObject, useEffect } from 'react';
+
+/**
+ * Calls `onComplete` after the CSS exit animation finishes on `elementRef`.
+ * Listens for both `animationend` and `animationcancel` events, filtering
+ * out events from child elements. Falls back to an immediate call when
+ * animations are disabled (prefers-reduced-motion, jsdom, etc.).
+ *
+ * @param onComplete Must be referentially stable (wrap in `useCallback`).
+ */
+export function useExitAnimation(
+  elementRef: RefObject<HTMLElement | null>,
+  exiting: boolean,
+  onComplete: () => void,
+): void {
+  useEffect(() => {
+    if (!exiting) return;
+    const el = elementRef.current;
+    if (!el) {
+      onComplete();
+      return;
+    }
+    const style = getComputedStyle(el);
+    if (
+      style.animationName === 'none' ||
+      style.animationName === '' ||
+      style.animationDuration === '0s'
+    ) {
+      onComplete();
+      return;
+    }
+    function handleAnimation(event: AnimationEvent) {
+      // Ignore events bubbling from children.
+      if (event.target !== el) return;
+      onComplete();
+    }
+    el.addEventListener('animationend', handleAnimation);
+    el.addEventListener('animationcancel', handleAnimation);
+    return () => {
+      el.removeEventListener('animationend', handleAnimation);
+      el.removeEventListener('animationcancel', handleAnimation);
+    };
+  }, [exiting, elementRef, onComplete]);
+}

--- a/console/src/hooks/useExitAnimation.ts
+++ b/console/src/hooks/useExitAnimation.ts
@@ -1,10 +1,11 @@
 import { type RefObject, useEffect } from 'react';
 
 /**
- * Calls `onComplete` after the CSS exit animation finishes on `elementRef`.
- * Listens for both `animationend` and `animationcancel` events, filtering
- * out events from child elements. Falls back to an immediate call when
- * animations are disabled (prefers-reduced-motion, jsdom, etc.).
+ * Calls `onComplete` after the CSS exit animation or transition finishes on
+ * `elementRef`. Listens for `animationend`, `animationcancel`, `transitionend`,
+ * and `transitioncancel` events, filtering out events from child elements.
+ * Falls back to an immediate call when animations/transitions are disabled
+ * (prefers-reduced-motion, jsdom, etc.).
  *
  * @param onComplete Must be referentially stable (wrap in `useCallback`).
  */
@@ -21,24 +22,33 @@ export function useExitAnimation(
       return;
     }
     const style = getComputedStyle(el);
-    if (
-      style.animationName === 'none' ||
-      style.animationName === '' ||
-      style.animationDuration === '0s'
-    ) {
+    const hasAnimation =
+      style.animationName !== 'none' &&
+      style.animationName !== '' &&
+      style.animationDuration !== '0s';
+    const hasTransition =
+      style.transitionProperty !== 'none' &&
+      style.transitionProperty !== '' &&
+      style.transitionDuration !== '0s';
+    if (!hasAnimation && !hasTransition) {
       onComplete();
       return;
     }
-    function handleAnimation(event: AnimationEvent) {
-      // Ignore events bubbling from children.
-      if (event.target !== el) return;
+    let fired = false;
+    function handleEnd(event: Event) {
+      if (event.target !== el || fired) return;
+      fired = true;
       onComplete();
     }
-    el.addEventListener('animationend', handleAnimation);
-    el.addEventListener('animationcancel', handleAnimation);
+    el.addEventListener('animationend', handleEnd);
+    el.addEventListener('animationcancel', handleEnd);
+    el.addEventListener('transitionend', handleEnd);
+    el.addEventListener('transitioncancel', handleEnd);
     return () => {
-      el.removeEventListener('animationend', handleAnimation);
-      el.removeEventListener('animationcancel', handleAnimation);
+      el.removeEventListener('animationend', handleEnd);
+      el.removeEventListener('animationcancel', handleEnd);
+      el.removeEventListener('transitionend', handleEnd);
+      el.removeEventListener('transitioncancel', handleEnd);
     };
   }, [exiting, elementRef, onComplete]);
 }

--- a/console/src/hooks/useFocusTrap.ts
+++ b/console/src/hooks/useFocusTrap.ts
@@ -26,6 +26,7 @@ function getFocusable(container: HTMLElement): HTMLElement[] {
 export function useFocusTrap(
   containerRef: RefObject<HTMLElement | null>,
   active: boolean,
+  initialFocusRef?: RefObject<HTMLElement | null>,
 ): void {
   useEffect(() => {
     if (!active) return;
@@ -37,7 +38,8 @@ export function useFocusTrap(
     // Defer initial focus one frame so the element is visible after any
     // CSS transition that runs synchronously with the state change.
     const raf = requestAnimationFrame(() => {
-      getFocusable(container)[0]?.focus({ preventScroll: true });
+      const target = initialFocusRef?.current ?? getFocusable(container)[0];
+      target?.focus({ preventScroll: true });
     });
 
     function onKeyDown(e: KeyboardEvent) {
@@ -87,5 +89,5 @@ export function useFocusTrap(
       container.removeEventListener('focusout', onFocusOut);
       previouslyFocused?.focus({ preventScroll: true });
     };
-  }, [active, containerRef]);
+  }, [active, containerRef, initialFocusRef]);
 }

--- a/console/src/hooks/useHideOthers.ts
+++ b/console/src/hooks/useHideOthers.ts
@@ -1,13 +1,13 @@
 import { type RefObject, useEffect } from 'react';
 
 /**
- * While `active`, sets `aria-hidden="true"` on every direct child of
+ * While `active`, sets the `inert` attribute on every direct child of
  * `document.body` that is not — and does not contain — the element referenced
- * by `containerRef`. This prevents assistive technology from interacting with
- * background content while a modal / drawer is open.
+ * by `containerRef`. `inert` both hides elements from assistive technology
+ * and makes them non-focusable / non-clickable, providing stronger modal
+ * isolation than `aria-hidden` alone.
  *
- * Restores each element's previous `aria-hidden` value (or removes the
- * attribute entirely if it wasn't present) on cleanup.
+ * Restores each element's previous state on cleanup.
  */
 export function useHideOthers(
   containerRef: RefObject<HTMLElement | null>,
@@ -18,21 +18,17 @@ export function useHideOthers(
     const container = containerRef.current;
     if (!container) return;
 
-    const previous = new Map<Element, string | null>();
+    const previous = new Map<Element, boolean>();
 
     for (const child of document.body.children) {
       if (child === container || child.contains(container)) continue;
-      previous.set(child, child.getAttribute('aria-hidden'));
-      child.setAttribute('aria-hidden', 'true');
+      previous.set(child, (child as HTMLElement).inert ?? false);
+      (child as HTMLElement).inert = true;
     }
 
     return () => {
-      for (const [el, prev] of previous) {
-        if (prev === null) {
-          el.removeAttribute('aria-hidden');
-        } else {
-          el.setAttribute('aria-hidden', prev);
-        }
+      for (const [el, wasInert] of previous) {
+        (el as HTMLElement).inert = wasInert;
       }
     };
   }, [active, containerRef]);

--- a/console/src/hooks/useHideOthers.ts
+++ b/console/src/hooks/useHideOthers.ts
@@ -1,13 +1,35 @@
 import { type RefObject, useEffect } from 'react';
 
 /**
- * While `active`, sets the `inert` attribute on every direct child of
- * `document.body` that is not — and does not contain — the element referenced
- * by `containerRef`. `inert` both hides elements from assistive technology
- * and makes them non-focusable / non-clickable, providing stronger modal
- * isolation than `aria-hidden` alone.
- *
- * Restores each element's previous state on cleanup.
+ * Module-level reference count per element.  When count > 0 the element is
+ * inert; when it drops back to 0, inert is removed.  This lets concurrent
+ * modals (Dialog + Sheet, nested dialogs, etc.) compose correctly — each
+ * caller is independent and the last one to deactivate restores the element.
+ */
+const inertCount = new WeakMap<Element, number>();
+
+function markInert(el: Element): void {
+  const count = (inertCount.get(el) ?? 0) + 1;
+  inertCount.set(el, count);
+  if (count === 1) {
+    (el as HTMLElement).inert = true;
+  }
+}
+
+function unmarkInert(el: Element): void {
+  const count = (inertCount.get(el) ?? 1) - 1;
+  if (count <= 0) {
+    inertCount.delete(el);
+    (el as HTMLElement).inert = false;
+  } else {
+    inertCount.set(el, count);
+  }
+}
+
+/**
+ * While `active`, marks every direct child of `document.body` — except the
+ * one containing `containerRef` — as `inert`.  Reference-counted so
+ * concurrent/nested modals compose correctly.
  */
 export function useHideOthers(
   containerRef: RefObject<HTMLElement | null>,
@@ -18,17 +40,17 @@ export function useHideOthers(
     const container = containerRef.current;
     if (!container) return;
 
-    const previous = new Map<Element, boolean>();
+    const marked: Element[] = [];
 
     for (const child of document.body.children) {
       if (child === container || child.contains(container)) continue;
-      previous.set(child, (child as HTMLElement).inert ?? false);
-      (child as HTMLElement).inert = true;
+      markInert(child);
+      marked.push(child);
     }
 
     return () => {
-      for (const [el, wasInert] of previous) {
-        (el as HTMLElement).inert = wasInert;
+      for (const el of marked) {
+        unmarkInert(el);
       }
     };
   }, [active, containerRef]);

--- a/console/src/hooks/useScrollLock.ts
+++ b/console/src/hooks/useScrollLock.ts
@@ -8,9 +8,20 @@ let lockCount = 0;
 export function useScrollLock(active: boolean): void {
   useEffect(() => {
     if (!active) return;
-    if (lockCount++ === 0) document.body.style.overflow = 'hidden';
+    if (lockCount++ === 0) {
+      // Compensate for the scrollbar disappearing to prevent layout shift.
+      const scrollbarWidth =
+        window.innerWidth - document.documentElement.clientWidth;
+      document.body.style.overflow = 'hidden';
+      if (scrollbarWidth > 0) {
+        document.body.style.paddingRight = `${scrollbarWidth}px`;
+      }
+    }
     return () => {
-      if (--lockCount === 0) document.body.style.overflow = '';
+      if (--lockCount === 0) {
+        document.body.style.overflow = '';
+        document.body.style.paddingRight = '';
+      }
     };
   }, [active]);
 }

--- a/console/src/lib/error-message.test.ts
+++ b/console/src/lib/error-message.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { getErrorMessage } from './error-message';
+
+describe('getErrorMessage', () => {
+  it('extracts message from Error instances', () => {
+    expect(getErrorMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('returns fallback for Error with empty message', () => {
+    expect(getErrorMessage(new Error())).toBe('An unexpected error occurred.');
+    expect(getErrorMessage(new Error(''))).toBe(
+      'An unexpected error occurred.',
+    );
+  });
+
+  it('returns strings as-is', () => {
+    expect(getErrorMessage('something broke')).toBe('something broke');
+  });
+
+  it('extracts .message from plain objects', () => {
+    expect(getErrorMessage({ message: 'Unauthorized' })).toBe('Unauthorized');
+    expect(getErrorMessage({ message: 'rate limited', statusCode: 429 })).toBe(
+      'rate limited',
+    );
+  });
+
+  it('returns fallback for plain object with empty .message', () => {
+    expect(getErrorMessage({ message: '' })).toBe(
+      'An unexpected error occurred.',
+    );
+  });
+
+  it('ignores .message if it is not a string', () => {
+    expect(getErrorMessage({ message: 42 })).toBe('[object Object]');
+  });
+
+  it('stringifies null and undefined', () => {
+    expect(getErrorMessage(null)).toBe('null');
+    expect(getErrorMessage(undefined)).toBe('undefined');
+  });
+
+  it('stringifies numbers', () => {
+    expect(getErrorMessage(404)).toBe('404');
+  });
+});

--- a/console/src/lib/error-message.ts
+++ b/console/src/lib/error-message.ts
@@ -1,0 +1,6 @@
+/** Extract a human-readable message from an unknown thrown value. */
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  return String(error);
+}

--- a/console/src/lib/error-message.ts
+++ b/console/src/lib/error-message.ts
@@ -1,6 +1,17 @@
 /** Extract a human-readable message from an unknown thrown value. */
 export function getErrorMessage(error: unknown): string {
-  if (error instanceof Error) return error.message;
+  if (error instanceof Error)
+    return error.message || 'An unexpected error occurred.';
   if (typeof error === 'string') return error;
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof (error as { message: unknown }).message === 'string'
+  ) {
+    return (
+      (error as { message: string }).message || 'An unexpected error occurred.'
+    );
+  }
   return String(error);
 }

--- a/console/src/main.tsx
+++ b/console/src/main.tsx
@@ -1,11 +1,14 @@
 import ReactDOM from 'react-dom/client';
 import { App } from './app';
 import { AuthProvider } from './auth';
+import { ToastProvider } from './components/toast';
 import './theme.css';
 import './styles.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <AuthProvider>
-    <App />
+    <ToastProvider>
+      <App />
+    </ToastProvider>
   </AuthProvider>,
 );

--- a/console/src/routes/channels.test.tsx
+++ b/console/src/routes/channels.test.tsx
@@ -1,5 +1,4 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ToastProvider } from '../components/toast';
 import {
   fireEvent,
   render,
@@ -8,8 +7,8 @@ import {
   within,
 } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
 import type { AdminConfig, AdminConfigResponse } from '../api/types';
+import { ToastProvider } from '../components/toast';
 import { ChannelsPage } from './channels';
 
 const fetchConfigMock = vi.fn<() => Promise<AdminConfigResponse>>();

--- a/console/src/routes/channels.test.tsx
+++ b/console/src/routes/channels.test.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ToastProvider } from '../components/toast';
 import {
   fireEvent,
   render,
@@ -213,7 +214,9 @@ function renderChannelsPage(): void {
 
   render(
     <QueryClientProvider client={queryClient}>
-      <ChannelsPage />
+      <ToastProvider>
+        <ChannelsPage />
+      </ToastProvider>
     </QueryClientProvider>,
   );
 }
@@ -980,7 +983,7 @@ describe('ChannelsPage', () => {
       );
     });
 
-    screen.getByText('Token updated in encrypted runtime secrets.');
+    screen.getByText('Bot token updated in encrypted runtime secrets.');
   });
 
   it('shows change password when passwordConfigured is true without a source', async () => {
@@ -1127,6 +1130,6 @@ describe('ChannelsPage', () => {
       );
     });
 
-    screen.getByText('Token updated in encrypted runtime secrets.');
+    screen.getByText('Bot token updated in encrypted runtime secrets.');
   });
 });

--- a/console/src/routes/channels.tsx
+++ b/console/src/routes/channels.tsx
@@ -78,10 +78,6 @@ function ListField(props: {
   );
 }
 
-function capitalizeLabel(value: string): string {
-  return value.charAt(0).toUpperCase() + value.slice(1);
-}
-
 function ManagedSecretField(props: {
   label: string;
   secretName:
@@ -183,7 +179,6 @@ function ManagedSecretField(props: {
           </div>
         </div>
       ) : null}
-
     </div>
   );
 }
@@ -2236,7 +2231,6 @@ export function ChannelsPage() {
                 Reset changes
               </button>
             </div>
-
           </div>
         </Panel>
       </div>

--- a/console/src/routes/channels.tsx
+++ b/console/src/routes/channels.tsx
@@ -9,7 +9,9 @@ import {
 import type { AdminConfig } from '../api/types';
 import { useAuth } from '../auth';
 import { ChannelLogo } from '../components/channel-logo';
+import { useToast } from '../components/toast';
 import { BooleanField, Panel } from '../components/ui';
+import { getErrorMessage } from '../lib/error-message';
 import { joinStringList, parseStringList } from '../lib/format';
 import {
   buildChannelCatalog,
@@ -107,6 +109,7 @@ function ManagedSecretField(props: {
   const actionLabel = hasExistingPassword
     ? `Change ${props.secretLabel}`
     : `Set ${props.secretLabel}`;
+  const toast = useToast();
   const saveSecretMutation = useMutation({
     mutationFn: async (value: string) => {
       return setRuntimeSecret(props.token, props.secretName, value);
@@ -116,6 +119,10 @@ function ManagedSecretField(props: {
       props.onSecretSaved();
       setIsEditing(false);
       setNextValue('');
+      toast.success(`${props.label} updated in encrypted runtime secrets.`);
+    },
+    onError: (error) => {
+      toast.error('Save failed', getErrorMessage(error));
     },
   });
 
@@ -177,18 +184,6 @@ function ManagedSecretField(props: {
         </div>
       ) : null}
 
-      {saveSecretMutation.isSuccess ? (
-        <p className="success-banner">
-          {`${capitalizeLabel(props.secretLabel)} updated in encrypted runtime secrets.`}
-        </p>
-      ) : null}
-      {saveSecretMutation.isError ? (
-        <p className="error-banner">
-          {saveSecretMutation.error instanceof Error
-            ? saveSecretMutation.error.message
-            : `Failed to update ${props.secretLabel}.`}
-        </p>
-      ) : null}
     </div>
   );
 }
@@ -2058,6 +2053,7 @@ function renderSelectedEditor(
 export function ChannelsPage() {
   const auth = useAuth();
   const queryClient = useQueryClient();
+  const toast = useToast();
   const [draft, setDraft] = useState<AdminConfig | null>(null);
   const [selectedKind, setSelectedKind] = useState<ChannelKind | null>(null);
 
@@ -2079,6 +2075,10 @@ export function ChannelsPage() {
     onSuccess: (payload) => {
       queryClient.setQueryData(['config', auth.token], payload);
       setDraft(cloneConfig(payload.config));
+      toast.success('Channel settings saved.');
+    },
+    onError: (error) => {
+      toast.error('Save failed', getErrorMessage(error));
     },
   });
 
@@ -2237,14 +2237,6 @@ export function ChannelsPage() {
               </button>
             </div>
 
-            {saveMutation.isSuccess ? (
-              <p className="success-banner">Channel settings saved.</p>
-            ) : null}
-            {saveMutation.isError ? (
-              <p className="error-banner">
-                {(saveMutation.error as Error).message}
-              </p>
-            ) : null}
           </div>
         </Panel>
       </div>

--- a/console/src/routes/config.tsx
+++ b/console/src/routes/config.tsx
@@ -4,8 +4,8 @@ import { fetchConfig, saveConfig } from '../api/client';
 import type { AdminConfig } from '../api/types';
 import { useAuth } from '../auth';
 import { useToast } from '../components/toast';
-import { getErrorMessage } from '../lib/error-message';
 import { BooleanField, PageHeader, Panel } from '../components/ui';
+import { getErrorMessage } from '../lib/error-message';
 
 function cloneConfig<T>(value: T): T {
   return structuredClone(value);

--- a/console/src/routes/config.tsx
+++ b/console/src/routes/config.tsx
@@ -4,6 +4,7 @@ import { fetchConfig, saveConfig } from '../api/client';
 import type { AdminConfig } from '../api/types';
 import { useAuth } from '../auth';
 import { useToast } from '../components/toast';
+import { getErrorMessage } from '../lib/error-message';
 import { BooleanField, PageHeader, Panel } from '../components/ui';
 
 function cloneConfig<T>(value: T): T {
@@ -32,7 +33,7 @@ export function ConfigPage() {
       toast.success('Runtime config saved.');
     },
     onError: (error) => {
-      toast.error('Save failed', (error as Error).message);
+      toast.error('Save failed', getErrorMessage(error));
     },
   });
 
@@ -97,10 +98,7 @@ export function ConfigPage() {
                     setDraft(parsed);
                     saveMutation.mutate(parsed);
                   } catch (error) {
-                    toast.error(
-                      'Invalid JSON',
-                      error instanceof Error ? error.message : String(error),
-                    );
+                    toast.error('Invalid JSON', getErrorMessage(error));
                   }
                 }}
               >

--- a/console/src/routes/config.tsx
+++ b/console/src/routes/config.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { fetchConfig, saveConfig } from '../api/client';
 import type { AdminConfig } from '../api/types';
 import { useAuth } from '../auth';
+import { useToast } from '../components/toast';
 import { BooleanField, PageHeader, Panel } from '../components/ui';
 
 function cloneConfig<T>(value: T): T {
@@ -11,6 +12,7 @@ function cloneConfig<T>(value: T): T {
 
 export function ConfigPage() {
   const auth = useAuth();
+  const toast = useToast();
   const [rawMode, setRawMode] = useState(false);
   const [draft, setDraft] = useState<AdminConfig | null>(null);
   const [rawJson, setRawJson] = useState('');
@@ -27,6 +29,10 @@ export function ConfigPage() {
     onSuccess: (payload) => {
       setDraft(cloneConfig(payload.config));
       setRawJson(JSON.stringify(payload.config, null, 2));
+      toast.success('Runtime config saved.');
+    },
+    onError: (error) => {
+      toast.error('Save failed', (error as Error).message);
     },
   });
 
@@ -91,7 +97,8 @@ export function ConfigPage() {
                     setDraft(parsed);
                     saveMutation.mutate(parsed);
                   } catch (error) {
-                    window.alert(
+                    toast.error(
+                      'Invalid JSON',
                       error instanceof Error ? error.message : String(error),
                     );
                   }
@@ -369,14 +376,6 @@ export function ConfigPage() {
             {saveMutation.isPending ? 'Saving...' : 'Save config'}
           </button>
         </div>
-        {saveMutation.isSuccess ? (
-          <p className="success-banner">Runtime config saved.</p>
-        ) : null}
-        {saveMutation.isError ? (
-          <p className="error-banner">
-            {(saveMutation.error as Error).message}
-          </p>
-        ) : null}
       </Panel>
     </div>
   );

--- a/console/src/routes/dashboard.tsx
+++ b/console/src/routes/dashboard.tsx
@@ -1,7 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchOverview } from '../api/client';
 import { useAuth } from '../auth';
-import { getErrorMessage } from '../lib/error-message';
 import {
   MetricCard,
   PageHeader,
@@ -10,6 +9,7 @@ import {
   useSortableRows,
 } from '../components/ui';
 import { useLiveEvents } from '../hooks/use-live-events';
+import { getErrorMessage } from '../lib/error-message';
 import {
   formatCompactNumber,
   formatRelativeTime,

--- a/console/src/routes/dashboard.tsx
+++ b/console/src/routes/dashboard.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchOverview } from '../api/client';
 import { useAuth } from '../auth';
+import { getErrorMessage } from '../lib/error-message';
 import {
   MetricCard,
   PageHeader,
@@ -89,7 +90,7 @@ export function DashboardPage() {
   if (overviewQuery.isError && !overview) {
     return (
       <div className="empty-state error">
-        {(overviewQuery.error as Error).message}
+        {getErrorMessage(overviewQuery.error)}
       </div>
     );
   }

--- a/console/src/routes/email.test.tsx
+++ b/console/src/routes/email.test.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ToastProvider } from '../components/toast';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
@@ -100,7 +101,9 @@ function renderEmailPage(options?: {
 
   render(
     <QueryClientProvider client={queryClient}>
-      <EmailPage />
+      <ToastProvider>
+        <EmailPage />
+      </ToastProvider>
     </QueryClientProvider>,
   );
 }

--- a/console/src/routes/email.test.tsx
+++ b/console/src/routes/email.test.tsx
@@ -1,5 +1,4 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ToastProvider } from '../components/toast';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
@@ -8,6 +7,7 @@ import type {
   AdminEmailMailboxResponse,
   AdminEmailMessageResponse,
 } from '../api/types';
+import { ToastProvider } from '../components/toast';
 import { EmailPage } from './email';
 
 const fetchAdminEmailMailboxMock =

--- a/console/src/routes/email.tsx
+++ b/console/src/routes/email.tsx
@@ -13,7 +13,9 @@ import type {
 } from '../api/types';
 import { useAuth } from '../auth';
 import { useAppShellConfig } from '../components/app-shell';
+import { useToast } from '../components/toast';
 import { PageHeader } from '../components/ui';
+import { getErrorMessage } from '../lib/error-message';
 import { formatDateTime, formatRelativeTime } from '../lib/format';
 
 const MAILBOX_MESSAGE_LIMIT = 40;
@@ -311,6 +313,7 @@ export function EmailPage() {
   const auth = useAuth();
   const shellConfig = useAppShellConfig();
   const queryClient = useQueryClient();
+  const toast = useToast();
   const [search, setSearch] = useState('');
   const [selectedFolder, setSelectedFolder] = useState<string | null>(null);
   const [messageOffset, setMessageOffset] = useState(0);
@@ -450,6 +453,9 @@ export function EmailPage() {
         }),
       ]);
     },
+    onError: (error) => {
+      toast.error('Delete failed', getErrorMessage(error));
+    },
     onSettled: () => {
       setDeletingMessageId(null);
     },
@@ -471,7 +477,7 @@ export function EmailPage() {
   if (mailboxQuery.isError && !mailboxQuery.data) {
     return (
       <div className="empty-state error">
-        {(mailboxQuery.error as Error).message}
+        {getErrorMessage(mailboxQuery.error)}
       </div>
     );
   }
@@ -511,9 +517,6 @@ export function EmailPage() {
   const selectedMessage = messageDetailQuery.data?.message || null;
   const selectedThread = messageDetailQuery.data?.thread || [];
   const isMessageOpen = selectedMessageSummary !== null;
-  const deleteError =
-    deleteMutation.error instanceof Error ? deleteMutation.error.message : null;
-
   return (
     <div className="page-stack">
       <PageHeader
@@ -632,9 +635,6 @@ export function EmailPage() {
                   </div>
                 </div>
               </div>
-              {deleteError ? (
-                <div className="mailbox-inline-error">{deleteError}</div>
-              ) : null}
 
               <div className="mailbox-thread-list">
                 {folderMessagesQuery.isLoading && !folderMessagesQuery.data ? (
@@ -643,7 +643,7 @@ export function EmailPage() {
                   </div>
                 ) : folderMessagesQuery.isError ? (
                   <div className="empty-state error">
-                    {(folderMessagesQuery.error as Error).message}
+                    {getErrorMessage(folderMessagesQuery.error)}
                   </div>
                 ) : filteredMessages.length === 0 ? (
                   <div className="empty-state">
@@ -756,9 +756,6 @@ export function EmailPage() {
                   <span>Delete</span>
                 </button>
               </div>
-              {deleteError ? (
-                <div className="mailbox-inline-error">{deleteError}</div>
-              ) : null}
 
               {messageDetailQuery.isLoading && !messageDetailQuery.data ? (
                 <div className="empty-state mailbox-detail-empty">
@@ -766,7 +763,7 @@ export function EmailPage() {
                 </div>
               ) : messageDetailQuery.isError ? (
                 <div className="empty-state error mailbox-detail-empty">
-                  {(messageDetailQuery.error as Error).message}
+                  {getErrorMessage(messageDetailQuery.error)}
                 </div>
               ) : !selectedMessage ? (
                 <div className="empty-state mailbox-detail-empty">

--- a/console/src/routes/gateway.test.tsx
+++ b/console/src/routes/gateway.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ToastProvider } from '../components/toast';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ToastProvider } from '../components/toast';
 
 import { GatewayPage } from './gateway';
 

--- a/console/src/routes/gateway.test.tsx
+++ b/console/src/routes/gateway.test.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ToastProvider } from '../components/toast';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -78,7 +79,9 @@ function renderGatewayPage(): void {
 
   render(
     <QueryClientProvider client={queryClient}>
-      <GatewayPage />
+      <ToastProvider>
+        <GatewayPage />
+      </ToastProvider>
     </QueryClientProvider>,
   );
 }

--- a/console/src/routes/gateway.tsx
+++ b/console/src/routes/gateway.tsx
@@ -4,8 +4,8 @@ import { restartGateway, validateToken } from '../api/client';
 import { useAuth } from '../auth';
 import { useToast } from '../components/toast';
 import { BooleanPill, MetricCard, PageHeader, Panel } from '../components/ui';
-import { getErrorMessage } from '../lib/error-message';
 import { useLiveEvents } from '../hooks/use-live-events';
+import { getErrorMessage } from '../lib/error-message';
 import { formatDateTime, formatUptime } from '../lib/format';
 
 const GATEWAY_RESTART_POLL_MS = 1000;

--- a/console/src/routes/gateway.tsx
+++ b/console/src/routes/gateway.tsx
@@ -2,7 +2,9 @@ import { useMutation } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { restartGateway, validateToken } from '../api/client';
 import { useAuth } from '../auth';
+import { useToast } from '../components/toast';
 import { BooleanPill, MetricCard, PageHeader, Panel } from '../components/ui';
+import { getErrorMessage } from '../lib/error-message';
 import { useLiveEvents } from '../hooks/use-live-events';
 import { formatDateTime, formatUptime } from '../lib/format';
 
@@ -10,6 +12,7 @@ const GATEWAY_RESTART_POLL_MS = 1000;
 
 export function GatewayPage() {
   const auth = useAuth();
+  const toast = useToast();
   const live = useLiveEvents(auth.token);
   const [polledStatus, setPolledStatus] =
     useState<typeof auth.gatewayStatus>(null);
@@ -27,6 +30,9 @@ export function GatewayPage() {
     },
     onSuccess: () => {
       setIsRestarting(true);
+    },
+    onError: (error) => {
+      toast.error('Gateway restart failed', getErrorMessage(error));
     },
   });
 
@@ -74,11 +80,6 @@ export function GatewayPage() {
     'Gateway restart is unavailable in the current launch mode.';
   const sandboxWarning =
     status.sandbox?.mode === 'host' ? null : status.sandbox?.warning || null;
-  const restartError =
-    restartMutation.error instanceof Error
-      ? restartMutation.error.message
-      : 'Gateway restart failed.';
-
   return (
     <div className="page-stack">
       <PageHeader
@@ -118,10 +119,6 @@ export function GatewayPage() {
       {!restartSupported ? (
         <p className="supporting-text">{restartReason}</p>
       ) : null}
-      {restartMutation.isError ? (
-        <p className="error-banner">{restartError}</p>
-      ) : null}
-
       <div className="metric-grid">
         <MetricCard label="Uptime" value={formatUptime(status.uptime)} />
         <MetricCard label="Sessions" value={String(status.sessions)} />

--- a/console/src/routes/jobs.tsx
+++ b/console/src/routes/jobs.tsx
@@ -15,7 +15,9 @@ import {
 } from '../api/client';
 import type { AdminSchedulerJob, JobAgent, JobSession } from '../api/types';
 import { useAuth } from '../auth';
+import { useToast } from '../components/toast';
 import { PageHeader } from '../components/ui';
+import { getErrorMessage } from '../lib/error-message';
 import { formatDateTime } from '../lib/format';
 
 type JobColumnId = 'backlog' | 'in_progress' | 'review' | 'done' | 'cancelled';
@@ -490,6 +492,7 @@ function JobDetailCard(props: {
 export function JobsPage() {
   const auth = useAuth();
   const queryClient = useQueryClient();
+  const toast = useToast();
   const [search, setSearch] = useState('');
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [draggedKey, setDraggedKey] = useState<string | null>(null);
@@ -533,10 +536,11 @@ export function JobsPage() {
       );
       return { previous };
     },
-    onError: (_error, _job, context) => {
+    onError: (error, _job, context) => {
       if (context?.previous) {
         queryClient.setQueryData(['scheduler', auth.token], context.previous);
       }
+      toast.error('Save failed', getErrorMessage(error));
     },
     onSuccess: (payload) => {
       queryClient.setQueryData(['scheduler', auth.token], payload);
@@ -556,6 +560,9 @@ export function JobsPage() {
       }),
     onSuccess: (payload) => {
       queryClient.setQueryData(['scheduler', auth.token], payload);
+    },
+    onError: (error) => {
+      toast.error('Move failed', getErrorMessage(error));
     },
   });
 
@@ -691,7 +698,7 @@ export function JobsPage() {
   if (schedulerQuery.isError && !schedulerQuery.data) {
     return (
       <div className="empty-state error">
-        {(schedulerQuery.error as Error).message}
+        {getErrorMessage(schedulerQuery.error)}
       </div>
     );
   }
@@ -717,17 +724,7 @@ export function JobsPage() {
 
       {jobsContextQuery.isError ? (
         <p className="error-banner">
-          {(jobsContextQuery.error as Error).message}
-        </p>
-      ) : null}
-      {saveJobMutation.isError ? (
-        <p className="error-banner">
-          {(saveJobMutation.error as Error).message}
-        </p>
-      ) : null}
-      {moveJobMutation.isError ? (
-        <p className="error-banner">
-          {(moveJobMutation.error as Error).message}
+          {getErrorMessage(jobsContextQuery.error)}
         </p>
       ) : null}
 

--- a/console/src/routes/jobs.tsx
+++ b/console/src/routes/jobs.tsx
@@ -722,6 +722,8 @@ export function JobsPage() {
         }
       />
 
+      {/* Query errors stay as inline banners (not toasts) — they represent a
+          persistent broken state, not a one-time operation failure. */}
       {jobsContextQuery.isError ? (
         <p className="error-banner">
           {getErrorMessage(jobsContextQuery.error)}

--- a/console/src/routes/mcp.tsx
+++ b/console/src/routes/mcp.tsx
@@ -371,7 +371,6 @@ export function McpPage() {
                 <p>{selectedServer.summary}</p>
               </div>
             ) : null}
-
           </div>
         </Panel>
       </div>

--- a/console/src/routes/mcp.tsx
+++ b/console/src/routes/mcp.tsx
@@ -3,7 +3,9 @@ import { useEffect, useState } from 'react';
 import { deleteMcpServer, fetchMcp, saveMcpServer } from '../api/client';
 import type { AdminMcpConfig, AdminMcpServer } from '../api/types';
 import { useAuth } from '../auth';
+import { useToast } from '../components/toast';
 import { BooleanField, BooleanPill, PageHeader, Panel } from '../components/ui';
+import { getErrorMessage } from '../lib/error-message';
 
 interface McpDraft {
   originalName: string | null;
@@ -96,6 +98,7 @@ function normalizeDraft(draft: McpDraft): {
 export function McpPage() {
   const auth = useAuth();
   const queryClient = useQueryClient();
+  const toast = useToast();
   const [selectedName, setSelectedName] = useState<string | null>(null);
   const [draft, setDraft] = useState<McpDraft>(createDraft());
 
@@ -113,6 +116,10 @@ export function McpPage() {
         (entry) => entry.name === draft.name.trim(),
       );
       setDraft(createDraft(selected));
+      toast.success(`Saved MCP server ${draft.name.trim()}.`);
+    },
+    onError: (error) => {
+      toast.error('Save failed', getErrorMessage(error));
     },
   });
 
@@ -122,6 +129,10 @@ export function McpPage() {
       queryClient.setQueryData(['mcp', auth.token], payload);
       setSelectedName(null);
       setDraft(createDraft());
+      toast.success('MCP server deleted.');
+    },
+    onError: (error) => {
+      toast.error('Delete failed', getErrorMessage(error));
     },
   });
 
@@ -361,21 +372,6 @@ export function McpPage() {
               </div>
             ) : null}
 
-            {saveMutation.isError ? (
-              <p className="error-banner">
-                {(saveMutation.error as Error).message}
-              </p>
-            ) : null}
-            {deleteMutation.isError ? (
-              <p className="error-banner">
-                {(deleteMutation.error as Error).message}
-              </p>
-            ) : null}
-            {saveMutation.isSuccess ? (
-              <p className="success-banner">
-                Saved MCP server {draft.name.trim()}.
-              </p>
-            ) : null}
           </div>
         </Panel>
       </div>

--- a/console/src/routes/models.test.tsx
+++ b/console/src/routes/models.test.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ToastProvider } from '../components/toast';
 import { render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AdminModelsResponse } from '../api/types';
@@ -74,7 +75,9 @@ function renderModelsPage(): void {
 
   render(
     <QueryClientProvider client={queryClient}>
-      <ModelsPage />
+      <ToastProvider>
+        <ModelsPage />
+      </ToastProvider>
     </QueryClientProvider>,
   );
 }

--- a/console/src/routes/models.test.tsx
+++ b/console/src/routes/models.test.tsx
@@ -1,8 +1,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ToastProvider } from '../components/toast';
 import { render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AdminModelsResponse } from '../api/types';
+import { ToastProvider } from '../components/toast';
 import { ModelsPage } from './models';
 
 const fetchModelsMock = vi.fn<() => Promise<AdminModelsResponse>>();

--- a/console/src/routes/models.tsx
+++ b/console/src/routes/models.tsx
@@ -3,13 +3,13 @@ import { useEffect, useState } from 'react';
 import { fetchModels, saveModels } from '../api/client';
 import { useAuth } from '../auth';
 import { useToast } from '../components/toast';
-import { getErrorMessage } from '../lib/error-message';
 import {
   PageHeader,
   Panel,
   SortableHeader,
   useSortableRows,
 } from '../components/ui';
+import { getErrorMessage } from '../lib/error-message';
 import {
   formatCompactNumber,
   formatRelativeTime,
@@ -301,7 +301,6 @@ export function ModelsPage() {
                   {saveMutation.isPending ? 'Saving...' : 'Save selection'}
                 </button>
               </div>
-
             </div>
           )}
         </Panel>

--- a/console/src/routes/models.tsx
+++ b/console/src/routes/models.tsx
@@ -2,6 +2,8 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { fetchModels, saveModels } from '../api/client';
 import { useAuth } from '../auth';
+import { useToast } from '../components/toast';
+import { getErrorMessage } from '../lib/error-message';
 import {
   PageHeader,
   Panel,
@@ -144,6 +146,7 @@ function formatModelMetadata(model: ModelEntry): string {
 export function ModelsPage() {
   const auth = useAuth();
   const queryClient = useQueryClient();
+  const toast = useToast();
   const [filter, setFilter] = useState('');
   const [draft, setDraft] = useState<ModelDraft>(createDraft());
 
@@ -161,6 +164,10 @@ export function ModelsPage() {
       queryClient.setQueryData(['models', auth.token], payload);
       setDraft(createDraft(payload));
       void queryClient.invalidateQueries({ queryKey: ['overview'] });
+      toast.success(`Default model is now ${payload.defaultModel}.`);
+    },
+    onError: (error) => {
+      toast.error('Save failed', getErrorMessage(error));
     },
   });
 
@@ -295,16 +302,6 @@ export function ModelsPage() {
                 </button>
               </div>
 
-              {saveMutation.isSuccess ? (
-                <p className="success-banner">
-                  Default model is now {saveMutation.data.defaultModel}.
-                </p>
-              ) : null}
-              {saveMutation.isError ? (
-                <p className="error-banner">
-                  {(saveMutation.error as Error).message}
-                </p>
-              ) : null}
             </div>
           )}
         </Panel>

--- a/console/src/routes/scheduler.test.tsx
+++ b/console/src/routes/scheduler.test.tsx
@@ -10,6 +10,7 @@ import type {
   AdminSchedulerResponse,
   GatewayStatus,
 } from '../api/types';
+import { ToastProvider } from '../components/toast';
 import { normalizeSchedulerAtInput, SchedulerPage } from './scheduler';
 
 const fetchChannelsMock = vi.fn<() => Promise<AdminChannelsResponse>>();
@@ -318,7 +319,9 @@ function renderSchedulerPage(): void {
   });
   render(
     <QueryClientProvider client={queryClient}>
-      <SchedulerPage />
+      <ToastProvider>
+        <SchedulerPage />
+      </ToastProvider>
     </QueryClientProvider>,
   );
 }

--- a/console/src/routes/scheduler.tsx
+++ b/console/src/routes/scheduler.tsx
@@ -1008,7 +1008,6 @@ function SchedulerJobEditor(props: {
             </button>
           ) : null}
         </div>
-
       </div>
     </Panel>
   );

--- a/console/src/routes/scheduler.tsx
+++ b/console/src/routes/scheduler.tsx
@@ -1057,10 +1057,6 @@ export function SchedulerPage() {
     onSuccess: (payload, nextDraft) => {
       replaceSchedulerJobs(payload, auth.token, queryClient);
       setSelectedId(nextDraft.id.trim());
-      const name =
-        payload.jobs.find((job) => job.id === nextDraft.id.trim())?.name ||
-        nextDraft.id.trim();
-      toast.success(`Saved ${name}.`);
       window.location.href = '/admin/jobs';
     },
     onError: (error) => {

--- a/console/src/routes/scheduler.tsx
+++ b/console/src/routes/scheduler.tsx
@@ -16,7 +16,9 @@ import type {
   GatewayStatus,
 } from '../api/types';
 import { useAuth } from '../auth';
+import { useToast } from '../components/toast';
 import { BooleanField, BooleanPill, PageHeader, Panel } from '../components/ui';
+import { getErrorMessage } from '../lib/error-message';
 import { formatDateTime } from '../lib/format';
 import { buildChannelCatalog } from './channels-catalog';
 
@@ -534,8 +536,6 @@ function SchedulerTaskDetail(props: {
   deletePending: boolean;
   onPauseToggle: () => void;
   onDelete: () => void;
-  pauseError: Error | null;
-  deleteError: Error | null;
 }) {
   return (
     <Panel title="Task" accent="warm">
@@ -606,13 +606,6 @@ function SchedulerTaskDetail(props: {
             {props.deletePending ? 'Deleting...' : 'Delete task'}
           </button>
         </div>
-
-        {props.pauseError ? (
-          <p className="error-banner">{props.pauseError.message}</p>
-        ) : null}
-        {props.deleteError ? (
-          <p className="error-banner">{props.deleteError.message}</p>
-        ) : null}
       </div>
     </Panel>
   );
@@ -626,10 +619,6 @@ function SchedulerJobEditor(props: {
   savePending: boolean;
   pausePending: boolean;
   deletePending: boolean;
-  saveError: Error | null;
-  pauseError: Error | null;
-  deleteError: Error | null;
-  saveResult: AdminSchedulerResponse | undefined;
   onDraftChange: (update: (current: SchedulerDraft) => SchedulerDraft) => void;
   onSave: () => void;
   onCancel: () => void;
@@ -1020,23 +1009,6 @@ function SchedulerJobEditor(props: {
           ) : null}
         </div>
 
-        {props.saveResult ? (
-          <p className="success-banner">
-            Saved{' '}
-            {props.saveResult.jobs.find((job) => job.id === draft.id)?.name ||
-              draft.id}
-            .
-          </p>
-        ) : null}
-        {props.saveError ? (
-          <p className="error-banner">{props.saveError.message}</p>
-        ) : null}
-        {props.pauseError ? (
-          <p className="error-banner">{props.pauseError.message}</p>
-        ) : null}
-        {props.deleteError ? (
-          <p className="error-banner">{props.deleteError.message}</p>
-        ) : null}
       </div>
     </Panel>
   );
@@ -1044,6 +1016,7 @@ function SchedulerJobEditor(props: {
 
 export function SchedulerPage() {
   const auth = useAuth();
+  const toast = useToast();
   const queryClient = useQueryClient();
   const [selectedId, setSelectedId] = useState<string | null>(() => {
     const requestedId =
@@ -1085,7 +1058,14 @@ export function SchedulerPage() {
     onSuccess: (payload, nextDraft) => {
       replaceSchedulerJobs(payload, auth.token, queryClient);
       setSelectedId(nextDraft.id.trim());
+      const name =
+        payload.jobs.find((job) => job.id === nextDraft.id.trim())?.name ||
+        nextDraft.id.trim();
+      toast.success(`Saved ${name}.`);
       window.location.href = '/admin/jobs';
+    },
+    onError: (error) => {
+      toast.error('Save failed', getErrorMessage(error));
     },
   });
 
@@ -1098,8 +1078,12 @@ export function SchedulerPage() {
     },
     onSuccess: (payload) => {
       replaceSchedulerJobs(payload, auth.token, queryClient);
+      toast.success('Deleted.');
       setSelectedId(null);
       setDraft(createDraft());
+    },
+    onError: (error) => {
+      toast.error('Delete failed', getErrorMessage(error));
     },
   });
 
@@ -1120,8 +1104,9 @@ export function SchedulerPage() {
             action,
           });
     },
-    onSuccess: (payload) => {
+    onSuccess: (payload, action) => {
       replaceSchedulerJobs(payload, auth.token, queryClient);
+      toast.success(action === 'pause' ? 'Paused.' : 'Resumed.');
       if (!selectedJob) return;
       const refreshed =
         payload.jobs.find((job) => job.id === selectedJob.id) || null;
@@ -1133,6 +1118,9 @@ export function SchedulerPage() {
       if (isConfigJob(refreshed)) {
         setDraft(createDraft(refreshed));
       }
+    },
+    onError: (error) => {
+      toast.error('Pause/resume failed', getErrorMessage(error));
     },
   });
 
@@ -1233,8 +1221,6 @@ export function SchedulerPage() {
               pauseMutation.mutate(selectedJob.disabled ? 'resume' : 'pause')
             }
             onDelete={() => deleteMutation.mutate()}
-            pauseError={pauseMutation.error as Error | null}
-            deleteError={deleteMutation.error as Error | null}
           />
         ) : (
           <SchedulerJobEditor
@@ -1245,10 +1231,6 @@ export function SchedulerPage() {
             savePending={saveMutation.isPending}
             pausePending={pauseMutation.isPending}
             deletePending={deleteMutation.isPending}
-            saveError={saveMutation.error as Error | null}
-            pauseError={pauseMutation.error as Error | null}
-            deleteError={deleteMutation.error as Error | null}
-            saveResult={saveMutation.isSuccess ? saveMutation.data : undefined}
             onDraftChange={(update) => setDraft((current) => update(current))}
             onSave={() => {
               const nextDraft = prepareDraftForSave(

--- a/console/src/routes/sessions.tsx
+++ b/console/src/routes/sessions.tsx
@@ -2,14 +2,26 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useDeferredValue, useEffect, useState } from 'react';
 import { deleteSession, fetchSessions } from '../api/client';
 import { useAuth } from '../auth';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../components/dialog';
+import { useToast } from '../components/toast';
 import { BooleanPill, PageHeader, Panel } from '../components/ui';
 import { formatRelativeTime } from '../lib/format';
 
 export function SessionsPage() {
   const auth = useAuth();
   const queryClient = useQueryClient();
+  const toast = useToast();
   const [search, setSearch] = useState('');
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const deferredSearch = useDeferredValue(search);
 
   const sessionsQuery = useQuery({
@@ -19,12 +31,19 @@ export function SessionsPage() {
 
   const deleteMutation = useMutation({
     mutationFn: (sessionId: string) => deleteSession(auth.token, sessionId),
-    onSuccess: (_, sessionId) => {
+    onSuccess: (data, sessionId) => {
       void queryClient.invalidateQueries({ queryKey: ['sessions'] });
       void queryClient.invalidateQueries({ queryKey: ['overview'] });
+      toast.success(
+        'Session deleted',
+        `Removed ${data.deletedMessages} messages and ${data.deletedTasks} tasks.`,
+      );
       if (selectedId === sessionId) {
         setSelectedId(null);
       }
+    },
+    onError: (error) => {
+      toast.error('Delete failed', (error as Error).message);
     },
   });
 
@@ -159,31 +178,41 @@ export function SessionsPage() {
                 className="danger-button"
                 type="button"
                 disabled={deleteMutation.isPending}
-                onClick={() => {
-                  const confirmed = window.confirm(
-                    `Delete session ${selectedSession.id} and all related records?`,
-                  );
-                  if (!confirmed) return;
-                  deleteMutation.mutate(selectedSession.id);
-                }}
+                onClick={() => setDeleteConfirmOpen(true)}
               >
                 {deleteMutation.isPending ? 'Deleting...' : 'Delete session'}
               </button>
-              {deleteMutation.isSuccess ? (
-                <p className="success-banner">
-                  Removed {deleteMutation.data.deletedMessages} messages and{' '}
-                  {deleteMutation.data.deletedTasks} tasks.
-                </p>
-              ) : null}
-              {deleteMutation.isError ? (
-                <p className="error-banner">
-                  {(deleteMutation.error as Error).message}
-                </p>
-              ) : null}
             </div>
           )}
         </Panel>
       </div>
+      <Dialog open={deleteConfirmOpen} onOpenChange={setDeleteConfirmOpen}>
+        <DialogContent size="sm">
+          <DialogHeader>
+            <DialogTitle>Delete session</DialogTitle>
+            <DialogDescription>
+              {selectedSession
+                ? `Delete session ${selectedSession.id} and all related records? This cannot be undone.`
+                : 'This cannot be undone.'}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DialogClose className="ghost-button">Cancel</DialogClose>
+            <button
+              className="danger-button"
+              type="button"
+              onClick={() => {
+                setDeleteConfirmOpen(false);
+                if (selectedSession) {
+                  deleteMutation.mutate(selectedSession.id);
+                }
+              }}
+            >
+              Delete
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/console/src/routes/sessions.tsx
+++ b/console/src/routes/sessions.tsx
@@ -13,6 +13,7 @@ import {
 } from '../components/dialog';
 import { useToast } from '../components/toast';
 import { BooleanPill, PageHeader, Panel } from '../components/ui';
+import { getErrorMessage } from '../lib/error-message';
 import { formatRelativeTime } from '../lib/format';
 
 export function SessionsPage() {
@@ -43,7 +44,7 @@ export function SessionsPage() {
       }
     },
     onError: (error) => {
-      toast.error('Delete failed', (error as Error).message);
+      toast.error('Delete failed', getErrorMessage(error));
     },
   });
 

--- a/console/src/routes/skills.tsx
+++ b/console/src/routes/skills.tsx
@@ -17,6 +17,8 @@ import type {
   AdminSkill,
 } from '../api/types';
 import { useAuth } from '../auth';
+import { useToast } from '../components/toast';
+import { getErrorMessage } from '../lib/error-message';
 import {
   BooleanField,
   BooleanPill,
@@ -235,6 +237,7 @@ function createEmptyDraft(): SkillDraft {
 export function SkillsPage() {
   const auth = useAuth();
   const queryClient = useQueryClient();
+  const toast = useToast();
   const [filter, setFilter] = useState('');
   const [selectedSkillName, setSelectedSkillName] = useState('');
   const [showCreate, setShowCreate] = useState(false);
@@ -265,6 +268,9 @@ export function SkillsPage() {
     onSuccess: (payload) => {
       queryClient.setQueryData(['skills', auth.token], payload);
     },
+    onError: (error) => {
+      toast.error('Toggle failed', getErrorMessage(error));
+    },
   });
 
   const reviewMutation = useMutation({
@@ -291,6 +297,9 @@ export function SkillsPage() {
           ],
         }),
       ]);
+    },
+    onError: (error) => {
+      toast.error('Review failed', getErrorMessage(error));
     },
   });
 
@@ -320,6 +329,9 @@ export function SkillsPage() {
       setShowCreate(false);
       setDraft(createEmptyDraft());
     },
+    onError: (error) => {
+      toast.error('Create failed', getErrorMessage(error));
+    },
   });
 
   const uploadMutation = useMutation({
@@ -331,6 +343,9 @@ export function SkillsPage() {
       queryClient.setQueryData(['skills', auth.token], payload);
       setShowCreate(false);
       setZipFile(null);
+    },
+    onError: (error) => {
+      toast.error('Upload failed', getErrorMessage(error));
     },
   });
 
@@ -509,11 +524,6 @@ export function SkillsPage() {
                   {uploadMutation.isPending ? 'Uploading...' : 'Upload skill'}
                 </button>
               </div>
-              {uploadMutation.isError ? (
-                <p className="error-banner">
-                  {(uploadMutation.error as Error).message}
-                </p>
-              ) : null}
             </div>
           ) : (
             <div className="stack-form">
@@ -741,11 +751,6 @@ export function SkillsPage() {
                 </button>
               </div>
 
-              {createMutation.isError ? (
-                <p className="error-banner">
-                  {(createMutation.error as Error).message}
-                </p>
-              ) : null}
             </div>
           )}
         </Panel>
@@ -914,11 +919,6 @@ export function SkillsPage() {
             </table>
           </div>
         )}
-        {toggleMutation.isError ? (
-          <p className="error-banner">
-            {(toggleMutation.error as Error).message}
-          </p>
-        ) : null}
       </Panel>
 
       <div className="two-column-grid">
@@ -1097,11 +1097,6 @@ export function SkillsPage() {
               ))}
             </div>
           )}
-          {reviewMutation.isError ? (
-            <p className="error-banner">
-              {(reviewMutation.error as Error).message}
-            </p>
-          ) : null}
         </Panel>
       </div>
 

--- a/console/src/routes/skills.tsx
+++ b/console/src/routes/skills.tsx
@@ -18,7 +18,6 @@ import type {
 } from '../api/types';
 import { useAuth } from '../auth';
 import { useToast } from '../components/toast';
-import { getErrorMessage } from '../lib/error-message';
 import {
   BooleanField,
   BooleanPill,
@@ -30,6 +29,7 @@ import {
   SortableHeader,
   useSortableRows,
 } from '../components/ui';
+import { getErrorMessage } from '../lib/error-message';
 import { formatDateTime, formatRelativeTime } from '../lib/format';
 import { compareBoolean, compareNumber, compareText } from '../lib/sort';
 
@@ -750,7 +750,6 @@ export function SkillsPage() {
                   {createMutation.isPending ? 'Creating...' : 'Create skill'}
                 </button>
               </div>
-
             </div>
           )}
         </Panel>


### PR DESCRIPTION
## Summary

- Replace inline success/error banners with non-blocking toast notifications across all console routes, so feedback no longer pushes page content around or gets lost below the fold
- Toasts auto-dismiss, pause on hover, and stack with overflow management — errors use `role="alert"` for screen reader urgency
- Add reusable Dialog and Toast primitives with full a11y (focus trap, scroll lock, escape-to-close, `aria-live`)

## Test plan

- [ ] Trigger save/delete/pause actions across routes (channels, config, gateway, jobs, mcp, models, scheduler, sessions, skills, email) — toast appears with correct success/error messaging
- [ ] Toast auto-dismisses after ~5s; hovering pauses the timer
- [ ] At most 3 toasts visible — oldest exits when a 4th fires
- [ ] Screen reader announces errors immediately (`role="alert"`) and success/info politely (`role="status"`)
- [ ] Dialog opens/closes via trigger, backdrop click, and Escape
- [ ] Animations respect `prefers-reduced-motion`
- [ ] `vitest` passes (new + existing tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)