### PR TITLE
fix: move mobile sidebar trigger to right side of topbar

### DIFF
--- a/console/src/components/app-shell.tsx
+++ b/console/src/components/app-shell.tsx
@@ -87,7 +87,6 @@ export function AppShell(props: { children: ReactNode }) {
           <div className="topbar">
             <div className="topbar-title">
               <div className="topbar-heading">
-                <SidebarTrigger className="topbar-sidebar-trigger" />
                 <h2>{currentNavItem.label}</h2>
               </div>
             </div>
@@ -120,6 +119,7 @@ export function AppShell(props: { children: ReactNode }) {
                 );
               })}
             </nav>
+            <SidebarTrigger className="topbar-sidebar-trigger" />
           </div>
           <div className="page-content">{props.children}</div>
         </SidebarInset>


### PR DESCRIPTION
## Summary

- Moves the burger menu button (SidebarTrigger) from the left side of the topbar to the right side on mobile viewports
- Aligns with common mobile UI conventions where the menu/hamburger button is on the right

## Test plan

- [ ] Open the console on a viewport narrower than 1080px (or use browser devtools mobile emulation)
- [ ] Verify the burger menu icon appears on the right side of the topbar
- [ ] Verify tapping it still opens/closes the sidebar correctly
- [ ] Verify desktop layout (>1080px) is unaffected — burger menu should remain hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)