### PR TITLE
feat(console): sidebar UI polish

### DIFF
--- a/console/src/components/sidebar/app-sidebar.tsx
+++ b/console/src/components/sidebar/app-sidebar.tsx
@@ -50,11 +50,35 @@ export function AppSidebar(props: {
       <SidebarFooter>
         <div className={styles.footerBlock}>
           <SidebarMeta version={props.version} />
-          <SidebarActions
-            showLogout={props.showLogout}
-            onLogout={props.onLogout}
-          />
+          <SidebarFooterActions>
+            <SidebarFooterMenu>
+              <SidebarFooterAction>
+                <ThemeToggle />
+              </SidebarFooterAction>
+            </SidebarFooterMenu>
+          </SidebarFooterActions>
         </div>
+        {props.showLogout ? (
+          <>
+            <div className={styles.footerDivider} />
+            <SidebarFooterActions>
+              <SidebarFooterMenu>
+                <SidebarFooterAction>
+                  <button
+                    className={styles.footerButton}
+                    type="button"
+                    onClick={props.onLogout}
+                  >
+                    <span className={styles.icon} aria-hidden="true">
+                      <LogOut />
+                    </span>
+                    Forget token
+                  </button>
+                </SidebarFooterAction>
+              </SidebarFooterMenu>
+            </SidebarFooterActions>
+          </>
+        ) : null}
       </SidebarFooter>
     </Sidebar>
   );
@@ -110,28 +134,3 @@ function SidebarMeta(props: { version?: string }) {
   );
 }
 
-function SidebarActions(props: { showLogout: boolean; onLogout: () => void }) {
-  return (
-    <SidebarFooterActions>
-      <SidebarFooterMenu>
-        <SidebarFooterAction>
-          <ThemeToggle />
-        </SidebarFooterAction>
-        {props.showLogout ? (
-          <SidebarFooterAction>
-            <button
-              className={styles.footerButton}
-              type="button"
-              onClick={props.onLogout}
-            >
-              <span className={styles.icon} aria-hidden="true">
-                <LogOut />
-              </span>
-              Forget token
-            </button>
-          </SidebarFooterAction>
-        ) : null}
-      </SidebarFooterMenu>
-    </SidebarFooterActions>
-  );
-}

--- a/console/src/components/sidebar/app-sidebar.tsx
+++ b/console/src/components/sidebar/app-sidebar.tsx
@@ -53,7 +53,7 @@ export function AppSidebar(props: {
           <SidebarFooterActions>
             <SidebarFooterMenu>
               <SidebarFooterAction>
-                <ThemeToggle />
+                <ThemeToggle labelClassName={styles.themeToggleLabel} />
               </SidebarFooterAction>
             </SidebarFooterMenu>
           </SidebarFooterActions>
@@ -133,4 +133,3 @@ function SidebarMeta(props: { version?: string }) {
     </div>
   );
 }
-

--- a/console/src/components/sidebar/app-sidebar.tsx
+++ b/console/src/components/sidebar/app-sidebar.tsx
@@ -1,8 +1,6 @@
 import { Link } from '@tanstack/react-router';
 import { useState } from 'react';
 import { cx } from '../../lib/cx';
-import { HybridClaw, LogOut } from '../icons';
-import { ThemeToggle } from '../theme-toggle';
 import {
   Dialog,
   DialogClose,
@@ -12,6 +10,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../dialog';
+import { HybridClaw, LogOut } from '../icons';
+import { ThemeToggle } from '../theme-toggle';
 import {
   Sidebar,
   SidebarContent,

--- a/console/src/components/sidebar/index.module.css
+++ b/console/src/components/sidebar/index.module.css
@@ -125,7 +125,7 @@
 }
 
 .groupLabel::after {
-  content: '';
+  content: "";
   flex: 1;
   height: 1px;
   background: var(--sidebar-border);
@@ -314,7 +314,7 @@
 .root[data-state="collapsed"] .footerMeta,
 .root[data-state="collapsed"] .footerDivider,
 .root[data-state="collapsed"] .footerButton span:not(.icon),
-.root[data-state="collapsed"] :global(.theme-toggle-label) {
+.root[data-state="collapsed"] .themeToggleLabel {
   display: none;
 }
 

--- a/console/src/components/sidebar/index.module.css
+++ b/console/src/components/sidebar/index.module.css
@@ -104,7 +104,6 @@
   gap: 8px;
 }
 
-.groupLabel,
 .eyebrow {
   margin: 0;
   text-transform: uppercase;
@@ -115,7 +114,21 @@
 }
 
 .groupLabel {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
   padding: 0 8px;
+  font-size: 0.64rem;
+  font-weight: 500;
+  color: var(--muted-foreground);
+}
+
+.groupLabel::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--sidebar-border);
 }
 
 .menu {
@@ -243,6 +256,12 @@
   gap: 6px;
 }
 
+.footerDivider {
+  height: 1px;
+  margin: 6px 0;
+  background: var(--sidebar-border);
+}
+
 .footerActions,
 .footerMenu,
 .footerAction {
@@ -293,7 +312,9 @@
 .root[data-state="collapsed"] .groupLabel,
 .root[data-state="collapsed"] .brandText,
 .root[data-state="collapsed"] .footerMeta,
-.root[data-state="collapsed"] .footerButton span:not(.icon) {
+.root[data-state="collapsed"] .footerDivider,
+.root[data-state="collapsed"] .footerButton span:not(.icon),
+.root[data-state="collapsed"] :global(.theme-toggle-label) {
   display: none;
 }
 

--- a/console/src/components/theme-toggle.tsx
+++ b/console/src/components/theme-toggle.tsx
@@ -73,6 +73,9 @@ export function ThemeToggle() {
         title="Change theme"
       >
         <ThemeIcon theme={theme} />
+        <span className="theme-toggle-label">
+          {theme.charAt(0).toUpperCase() + theme.slice(1)}
+        </span>
       </DropdownTrigger>
       <DropdownContent className="theme-toggle-menu" align="end">
         {options.map((option) => (

--- a/console/src/components/theme-toggle.tsx
+++ b/console/src/components/theme-toggle.tsx
@@ -1,4 +1,5 @@
 import { setTheme, useTheme } from '../theme';
+import type { Theme } from '../theme-bootstrap';
 import {
   Dropdown,
   DropdownContent,
@@ -50,18 +51,17 @@ const SystemIcon = () => (
   </svg>
 );
 
-function ThemeIcon({ theme }: { theme: 'light' | 'dark' | 'system' }) {
+function ThemeIcon({ theme }: { theme: Theme }) {
   if (theme === 'light') return <SunIcon />;
   if (theme === 'dark') return <MoonIcon />;
   return <SystemIcon />;
 }
 
-const THEME_OPTIONS: { value: 'light' | 'dark' | 'system'; label: string }[] =
-  [
-    { value: 'light', label: 'Light' },
-    { value: 'dark', label: 'Dark' },
-    { value: 'system', label: 'System' },
-  ];
+const THEME_OPTIONS: { value: Theme; label: string }[] = [
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+  { value: 'system', label: 'System' },
+];
 
 export function ThemeToggle(props: { labelClassName?: string }) {
   const { theme, resolved } = useTheme();

--- a/console/src/components/theme-toggle.tsx
+++ b/console/src/components/theme-toggle.tsx
@@ -56,14 +56,16 @@ function ThemeIcon({ theme }: { theme: 'light' | 'dark' | 'system' }) {
   return <SystemIcon />;
 }
 
-export function ThemeToggle() {
-  const { theme, resolved } = useTheme();
-
-  const options: { value: 'light' | 'dark' | 'system'; label: string }[] = [
+const THEME_OPTIONS: { value: 'light' | 'dark' | 'system'; label: string }[] =
+  [
     { value: 'light', label: 'Light' },
     { value: 'dark', label: 'Dark' },
     { value: 'system', label: 'System' },
   ];
+
+export function ThemeToggle(props: { labelClassName?: string }) {
+  const { theme, resolved } = useTheme();
+  const label = THEME_OPTIONS.find((o) => o.value === theme)?.label ?? theme;
 
   return (
     <Dropdown>
@@ -73,12 +75,10 @@ export function ThemeToggle() {
         title="Change theme"
       >
         <ThemeIcon theme={theme} />
-        <span className="theme-toggle-label">
-          {theme.charAt(0).toUpperCase() + theme.slice(1)}
-        </span>
+        <span className={props.labelClassName}>{label}</span>
       </DropdownTrigger>
       <DropdownContent className="theme-toggle-menu" align="end">
-        {options.map((option) => (
+        {THEME_OPTIONS.map((option) => (
           <DropdownItem
             key={option.value}
             className="theme-toggle-option"

--- a/console/src/routes/sessions.tsx
+++ b/console/src/routes/sessions.tsx
@@ -2,7 +2,6 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useDeferredValue, useEffect, useState } from 'react';
 import { deleteSession, fetchSessions } from '../api/client';
 import { useAuth } from '../auth';
-import { useToast } from '../components/toast';
 import {
   Dialog,
   DialogClose,
@@ -12,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../components/dialog';
+import { useToast } from '../components/toast';
 import { BooleanPill, PageHeader, Panel } from '../components/ui';
 import { getErrorMessage } from '../lib/error-message';
 import { formatRelativeTime } from '../lib/format';


### PR DESCRIPTION
## Summary

- **Section labels**: replaced all-caps group labels ("OVERVIEW" etc.) with a subtle inline divider style — small muted text followed by a 1px rule extending to the sidebar edge
- **Theme toggle**: added a text label showing the current theme ("Light" / "Dark" / "System") next to the icon; hides automatically when the sidebar is collapsed
- **Forget token**: moved to its own row below a thin divider so it no longer sits flush alongside the version number

## Test plan

- [ ] Expand sidebar: section labels show as subtle divider lines with text, not all-caps banners
- [ ] Theme toggle shows "Light" / "Dark" / "System" text beside the icon; updates on change
- [ ] "Forget token" appears on a separate row below a thin line, clearly separated from the version
- [ ] Collapse sidebar: theme label, forget-token text, and divider all hide; icons remain
- [ ] Forget token button still fires the logout handler