### PR TITLE
[codex] Add TUI approval picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Coming up]
 
+### Changed
+
+- **Interactive TUI approval picker**: Local TUI approval requests open a
+  keyboard-driven picker with `Up`/`Down` navigation, `Enter` confirmation,
+  number-key quick select, `Esc` to skip, and a text fallback for
+  non-interactive terminals.
+
+### Fixed
+
+- **TUI approval replay handling**: Replayed or restated approval prompts reuse
+  cached approval details more reliably, and web `/approve` flows preserve
+  pending-approval metadata so follow-up approvals reopen the same picker
+  instead of dropping back to raw text.
+- **TUI exit summaries**: Exit output either shows the remote usage/tool/file
+  totals for the session or an explicit unavailable summary, and gateway
+  history breakdowns resolve canonical TUI session ids consistently for
+  tool/file counts.
+
 ## [0.12.4](https://github.com/HybridAIOne/hybridclaw/tree/v0.12.4)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ Once the gateway is running, open HybridClaw locally:
 - **Gateway service** (Node.js) — shared message/command handlers, SQLite persistence (KV + semantic + knowledge graph + canonical sessions + usage events), scheduler, heartbeat, web/API, loopback OpenAI-compatible API, and channel integrations for Discord, Slack, Microsoft Teams, Telegram, iMessage, WhatsApp, and email
 - **TUI client** — thin client over HTTP (`/api/chat`, `/api/command`) with
   a structured startup banner that surfaces model, sandbox, gateway, and
-  chatbot context before the first prompt
+  chatbot context before the first prompt, an interactive approval picker for
+  pending approvals, and an exit summary with a ready-to-run resume command
 - **Container** (Docker, ephemeral) — HybridAI API client, sandboxed tool executor, and preinstalled browser automation runtime with cursor-aware snapshots for JS-heavy custom UI
 - Communication via file-based IPC (input.json / output.json)
 

--- a/docs/development/getting-started/quickstart.md
+++ b/docs/development/getting-started/quickstart.md
@@ -50,6 +50,10 @@ In a second terminal:
 hybridclaw tui
 ```
 
+The local TUI shows a startup banner before the first prompt, opens an
+interactive approval picker for pending approvals, and prints a resumable
+session summary on exit.
+
 ## Open The Built-In Web Surfaces
 
 With the gateway running locally:

--- a/docs/development/reference/commands.md
+++ b/docs/development/reference/commands.md
@@ -323,9 +323,13 @@ the same gateway command surface used by TUI and web chat.
   help aliases
 - The TUI startup banner summarizes the active model, sandbox, gateway,
   provider, and chatbot context before the first prompt
+- Pending approvals in the TUI open an interactive picker with `Up` / `Down`
+  navigation, `Enter` confirmation, number-key quick select, and `Esc` to
+  skip; non-interactive terminals keep the text prompt fallback
 - pressing `Up` or `Down` on an empty prompt recalls earlier prompts
 - press `Ctrl-C` or `Ctrl-D` twice within five seconds to exit the TUI
-- on exit, HybridClaw prints token/file/tool totals and a ready-to-run
+- on exit, HybridClaw prints token/file/tool totals when remote history is
+  available, otherwise an explicit unavailable summary, plus a ready-to-run
   `hybridclaw tui --resume <sessionId>` command for that session
 
 Example secret flow:

--- a/docs/index.html
+++ b/docs/index.html
@@ -1648,7 +1648,7 @@
       </div>
       <div class="feature-card">
         <h3 style="color: var(--accent-1);">4. Connect interface</h3>
-        <p>Use Discord, the built-in web chat, or run <code>hybridclaw tui</code> for a terminal-native chat experience with a startup banner that summarizes the active model, sandbox, gateway, and chatbot context. Web chat accepts uploads and pasted files, and TUI can queue a copied file or clipboard image with <code>/paste</code> or <code>Ctrl-V</code>.</p>
+        <p>Use Discord, the built-in web chat, or run <code>hybridclaw tui</code> for a terminal-native chat experience with a startup banner, an interactive approval picker, and an exit summary with a ready-to-run resume command. Web chat accepts uploads and pasted files, and TUI can queue a copied file or clipboard image with <code>/paste</code> or <code>Ctrl-V</code>.</p>
       </div>
       <div class="feature-card">
         <h3 style="color: var(--accent-1);">5. Diagnose issues fast</h3>

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -632,6 +632,9 @@ async function resolveApiChatSlashCommandResult(
 
   const textParts: string[] = [];
   const artifacts: NonNullable<GatewayChatResult['artifacts']> = [];
+  let pendingApproval:
+    | NonNullable<GatewayChatResult['pendingApproval']>
+    | undefined;
   let sessionId = chatRequest.sessionId;
   let sessionKey: string | undefined;
   let mainSessionKey: string | undefined;
@@ -657,6 +660,9 @@ async function resolveApiChatSlashCommandResult(
       }
       if (handled.artifacts.length > 0) {
         artifacts.push(...handled.artifacts);
+      }
+      if (handled.pendingApproval) {
+        pendingApproval = handled.pendingApproval;
       }
       continue;
     }
@@ -701,6 +707,7 @@ async function resolveApiChatSlashCommandResult(
     ...(sessionKey ? { sessionKey } : {}),
     ...(mainSessionKey ? { mainSessionKey } : {}),
     ...(artifacts.length > 0 ? { artifacts } : {}),
+    ...(pendingApproval ? { pendingApproval } : {}),
   };
 }
 

--- a/src/gateway/text-channel-commands.ts
+++ b/src/gateway/text-channel-commands.ts
@@ -23,7 +23,10 @@ import {
   handleGatewayCommand,
   renderGatewayCommand,
 } from './gateway-service.js';
-import type { GatewayCommandResult } from './gateway-types.js';
+import type {
+  GatewayChatResult,
+  GatewayCommandResult,
+} from './gateway-types.js';
 import {
   cleanupExpiredPendingApprovals,
   clearPendingApproval,
@@ -41,6 +44,7 @@ export interface HandledTextChannelApprovalResult {
   sessionKey?: string;
   mainSessionKey?: string;
   approvalId?: string;
+  pendingApproval?: NonNullable<GatewayChatResult['pendingApproval']>;
   text: string | null;
   artifacts: ArtifactMetadata[];
 }
@@ -371,6 +375,7 @@ export async function handleTextChannelApprovalCommand(params: {
       sessionKey: approvalResult.sessionKey,
       mainSessionKey: approvalResult.mainSessionKey,
       approvalId: pendingApproval.approvalId,
+      pendingApproval: approvalResult.pendingApproval,
       text: formatInfo('Pending Approval', resultText),
       artifacts: approvalResult.artifacts || [],
     };

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -2620,6 +2620,7 @@ export function getSessionToolCallBreakdown(
   sessionId: string,
   sinceTimestamp: string | null = null,
 ): Array<{ toolName: string; count: number }> {
+  const resolvedSessionId = resolveSessionIdCompat(sessionId);
   const normalizedSince =
     typeof sinceTimestamp === 'string' && sinceTimestamp.trim()
       ? sinceTimestamp.trim()
@@ -2635,7 +2636,7 @@ export function getSessionToolCallBreakdown(
        AND event_type = 'tool.call'
        AND (? IS NULL OR timestamp >= ?)
      ORDER BY id ASC`,
-    sessionId,
+    resolvedSessionId,
     normalizedSince,
     normalizedSince,
   );
@@ -2718,6 +2719,7 @@ export function getSessionFileChangeCounts(
   createdCount: number;
   deletedCount: number;
 } {
+  const resolvedSessionId = resolveSessionIdCompat(sessionId);
   const normalizedSince =
     typeof sinceTimestamp === 'string' && sinceTimestamp.trim()
       ? sinceTimestamp.trim()
@@ -2733,7 +2735,7 @@ export function getSessionFileChangeCounts(
        AND event_type IN ('tool.call', 'tool.result')
        AND (? IS NULL OR timestamp >= ?)
      ORDER BY id ASC`,
-    sessionId,
+    resolvedSessionId,
     normalizedSince,
     normalizedSince,
   );

--- a/src/tui-approval-prompt.ts
+++ b/src/tui-approval-prompt.ts
@@ -6,11 +6,6 @@ import { wrapTuiBlock } from './tui-thinking.js';
 
 export type TuiApprovalSelectionOption = ApprovalScopeMode | 'skip';
 
-export type TuiApprovalPromptResult =
-  | { kind: 'select'; option: TuiApprovalSelectionOption }
-  | { kind: 'amend' }
-  | { kind: 'explain' };
-
 export interface TuiApprovalPromptPalette {
   reset: string;
   bold: string;
@@ -202,26 +197,6 @@ export function buildTuiApprovalSelectionOptions(params: {
   return options;
 }
 
-export function buildTuiApprovalFollowupDraft(params: {
-  kind: 'amend' | 'explain';
-  approval: Pick<TuiApprovalDetails, 'intent' | 'reason'>;
-}): string {
-  const intent = params.approval.intent.trim();
-  if (params.kind === 'amend') {
-    if (intent) {
-      return `Please avoid this action if possible: ${intent}. Use a safer alternative.`;
-    }
-    return 'Please avoid the approval-required action if possible and use a safer alternative.';
-  }
-  if (intent) {
-    return `Explain why this action is needed: ${intent}. What lower-risk alternatives did you consider?`;
-  }
-  if (params.approval.reason.trim()) {
-    return `Explain why this approval is needed given: ${params.approval.reason.trim()}`;
-  }
-  return 'Explain why this approval is needed and what lower-risk alternatives you considered.';
-}
-
 export function renderTuiApprovalPromptLines(params: {
   approval: Pick<TuiApprovalDetails, 'approvalId' | 'intent' | 'reason'>;
   options: TuiApprovalSelectionOption[];
@@ -293,11 +268,7 @@ export function renderTuiApprovalPromptLines(params: {
   }
 
   lines.push('');
-  for (const line of wrapPlainLines(
-    'Esc to cancel | Tab to amend | Ctrl-E to explain',
-    safeWidth,
-    '  ',
-  )) {
+  for (const line of wrapPlainLines('Esc to cancel', safeWidth, '  ')) {
     lines.push(`${palette.muted}${line}${palette.reset}`);
   }
 
@@ -311,7 +282,8 @@ export async function promptTuiApprovalSelection(params: {
   palette?: Partial<TuiApprovalPromptPalette>;
   output?: NodeJS.WriteStream;
   initialCursor?: number;
-}): Promise<TuiApprovalPromptResult | undefined> {
+  restorePrompt?: boolean;
+}): Promise<TuiApprovalSelectionOption | undefined> {
   const { rl, options } = params;
   const palette = resolveTuiApprovalPromptPalette(params.palette);
   const output = params.output || process.stdout;
@@ -330,9 +302,9 @@ export async function promptTuiApprovalSelection(params: {
     0,
     Math.min(params.initialCursor ?? 0, options.length - 1),
   );
-  let finish = (_value: TuiApprovalPromptResult) => {};
+  let finish = (_value: TuiApprovalSelectionOption) => {};
   const closeHandler = () => {
-    finish({ kind: 'select', option: 'skip' });
+    finish('skip');
   };
 
   const clear = () => {
@@ -369,39 +341,31 @@ export async function promptTuiApprovalSelection(params: {
     rl.off('close', closeHandler);
     internal.line = savedLine;
     internal.cursor = Math.min(savedCursor, savedLine.length);
-    if (internal._refreshLine) {
-      internal._refreshLine();
-    } else if (typeof rl.prompt === 'function') {
-      rl.prompt(true);
+    if (params.restorePrompt !== false) {
+      if (internal._refreshLine) {
+        internal._refreshLine();
+      } else if (typeof rl.prompt === 'function') {
+        rl.prompt(true);
+      }
     }
   };
 
   const selectIndex = (index: number) => {
     const selected = options[index];
     if (!selected) return;
-    finish({ kind: 'select', option: selected });
+    finish(selected);
   };
 
   const handleTtyWrite = (chunk: string, key: readline.Key) => {
     const raw = String(key.sequence ?? chunk ?? '').trim();
 
-    if (key.ctrl === true && key.name === 'e') {
-      finish({ kind: 'explain' });
-      return;
-    }
-
     if (key.ctrl === true && key.name === 'c') {
-      finish({ kind: 'select', option: 'skip' });
-      return;
-    }
-
-    if (key.name === 'tab') {
-      finish({ kind: 'amend' });
+      finish('skip');
       return;
     }
 
     if (key.name === 'escape' || key.name === 'q' || key.name === 'n') {
-      finish({ kind: 'select', option: 'skip' });
+      finish('skip');
       return;
     }
 
@@ -423,7 +387,7 @@ export async function promptTuiApprovalSelection(params: {
     }
 
     if (key.name === 'y') {
-      finish({ kind: 'select', option: 'once' });
+      finish('once');
       return;
     }
 
@@ -435,8 +399,8 @@ export async function promptTuiApprovalSelection(params: {
     }
   };
 
-  return new Promise<TuiApprovalPromptResult>((resolve) => {
-    finish = (value: TuiApprovalPromptResult) => {
+  return new Promise<TuiApprovalSelectionOption>((resolve) => {
+    finish = (value: TuiApprovalSelectionOption) => {
       restore();
       resolve(value);
     };

--- a/src/tui-approval-prompt.ts
+++ b/src/tui-approval-prompt.ts
@@ -35,19 +35,8 @@ type InternalReadline = readline.Interface & {
   line: string;
   cursor: number;
   _refreshLine?: () => void;
+  _ttyWrite?: (chunk: string, key: readline.Key) => void;
 };
-
-interface TuiApprovalPromptInput {
-  isTTY?: boolean;
-  on(
-    event: 'keypress',
-    listener: (chunk: string, key: readline.Key) => void,
-  ): this;
-  off(
-    event: 'keypress',
-    listener: (chunk: string, key: readline.Key) => void,
-  ): this;
-}
 
 function getAnsiSequenceLength(value: string, index: number): number {
   if (value.charCodeAt(index) !== 27 || value[index + 1] !== '[') {
@@ -95,6 +84,20 @@ function truncateLine(value: string, width: number, reset = ''): string {
   if (!truncated) return output;
 
   return hasAnsi ? `${output}...${reset}` : `${output}...`;
+}
+
+function visibleTerminalLength(value: string): number {
+  let visible = 0;
+  for (let index = 0; index < value.length; ) {
+    const ansiSequenceLength = getAnsiSequenceLength(value, index);
+    if (ansiSequenceLength > 0) {
+      index += ansiSequenceLength;
+      continue;
+    }
+    visible += 1;
+    index += (value.codePointAt(index) || 0) > 0xffff ? 2 : 1;
+  }
+  return visible;
 }
 
 function sentenceCase(value: string): string {
@@ -307,71 +310,68 @@ export async function promptTuiApprovalSelection(params: {
   rl: readline.Interface;
   approval: Pick<TuiApprovalDetails, 'approvalId' | 'intent' | 'reason'>;
   options: TuiApprovalSelectionOption[];
-  input?: TuiApprovalPromptInput;
   output?: NodeJS.WriteStream;
   initialCursor?: number;
   restorePrompt?: boolean;
 }): Promise<TuiApprovalSelectionOption | undefined> {
   const { rl, options } = params;
-  const input = params.input || process.stdin;
   const output = params.output || process.stdout;
   const internal = rl as InternalReadline;
+  const originalTtyWrite = internal._ttyWrite?.bind(internal);
 
   if (options.length === 0) {
     throw new Error('TUI approval prompt requires at least one option.');
   }
 
-  if (!output.isTTY || !input.isTTY) {
+  if (!output.isTTY || !originalTtyWrite) {
     return undefined;
   }
 
   const savedLine = internal.line;
   const savedCursor = internal.cursor;
-  const lineListeners = rl.listeners('line') as Array<(line: string) => void>;
-  const sigintListeners = rl.listeners('SIGINT') as Array<() => void>;
-  let renderedLineCount = 0;
+  let renderedRows = 0;
   let restored = false;
   let cursor = Math.max(
     0,
     Math.min(params.initialCursor ?? 0, options.length - 1),
   );
   let finish = (_value: TuiApprovalSelectionOption) => {};
+  let installedTtyWrite: InternalReadline['_ttyWrite'] | undefined;
   const closeHandler = () => {
     finish('skip');
   };
 
-  const buildClearFrame = () => {
-    if (renderedLineCount <= 0) return '';
-    return `${renderedLineCount > 1 ? `\x1b[${renderedLineCount - 1}A` : ''}\r\x1b[J`;
-  };
-
   const render = () => {
-    const clearFrame = buildClearFrame();
+    const columns = Math.max(1, output.columns || 80);
     const lines = renderTuiApprovalPromptLines({
       approval: params.approval,
       options,
       cursor,
-      width: output.columns || 80,
+      width: columns,
     });
-    output.write(`${clearFrame}\x1b[?25l${lines.join('\n')}`);
-    renderedLineCount = lines.length;
+    output.write(
+      `${renderedRows > 1 ? `\x1b[${renderedRows - 1}A` : ''}\r\x1b[J\x1b[?25l${lines.join('\n')}`,
+    );
+    renderedRows = lines.reduce(
+      (total, line) =>
+        total + Math.max(1, Math.ceil(visibleTerminalLength(line) / columns)),
+      0,
+    );
   };
 
   const restore = () => {
     if (restored) return;
     restored = true;
-    output.write(`${buildClearFrame()}\x1b[?25h`);
-    renderedLineCount = 0;
-    input.off('keypress', handleKeypress);
+    output.write(
+      `${renderedRows > 1 ? `\x1b[${renderedRows - 1}A` : ''}\r\x1b[J\x1b[?25h`,
+    );
+    renderedRows = 0;
     output.off('resize', render);
     rl.off('close', closeHandler);
-    rl.off('SIGINT', handleSigint);
-    for (const listener of lineListeners) {
-      rl.on('line', listener);
+    if (installedTtyWrite && internal._ttyWrite === installedTtyWrite) {
+      internal._ttyWrite = originalTtyWrite;
     }
-    for (const listener of sigintListeners) {
-      rl.on('SIGINT', listener);
-    }
+    installedTtyWrite = undefined;
     internal.line = savedLine;
     internal.cursor = Math.min(savedCursor, savedLine.length);
     if (params.restorePrompt !== false) {
@@ -387,10 +387,6 @@ export async function promptTuiApprovalSelection(params: {
     const selected = options[index];
     if (!selected) return;
     finish(selected);
-  };
-
-  const handleSigint = () => {
-    finish('skip');
   };
 
   const handleKeypress = (chunk: string, key: readline.Key) => {
@@ -437,14 +433,10 @@ export async function promptTuiApprovalSelection(params: {
       resolve(value);
     };
 
-    for (const listener of lineListeners) {
-      rl.off('line', listener);
-    }
-    for (const listener of sigintListeners) {
-      rl.off('SIGINT', listener);
-    }
-    rl.on('SIGINT', handleSigint);
-    input.on('keypress', handleKeypress);
+    installedTtyWrite = (chunk: string, key: readline.Key) => {
+      handleKeypress(chunk, key);
+    };
+    internal._ttyWrite = installedTtyWrite;
     output.on('resize', render);
     rl.on('close', closeHandler);
     render();

--- a/src/tui-approval-prompt.ts
+++ b/src/tui-approval-prompt.ts
@@ -6,42 +6,44 @@ import { wrapTuiBlock } from './tui-thinking.js';
 
 export type TuiApprovalSelectionOption = ApprovalScopeMode | 'skip';
 
-export interface TuiApprovalPromptPalette {
-  reset: string;
-  bold: string;
-  muted: string;
-  teal: string;
-  gold: string;
-  green: string;
-  red: string;
-}
+const TUI_APPROVAL_PROMPT_PALETTE = Object.freeze({
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  muted: '\x1b[90m',
+  teal: '\x1b[36m',
+  gold: '\x1b[33m',
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+});
 
-export const DEFAULT_TUI_APPROVAL_PROMPT_PALETTE: Readonly<TuiApprovalPromptPalette> =
-  Object.freeze({
-    reset: '\x1b[0m',
-    bold: '\x1b[1m',
-    muted: '\x1b[90m',
-    teal: '\x1b[36m',
-    gold: '\x1b[33m',
-    green: '\x1b[32m',
-    red: '\x1b[31m',
-  });
+// biome-ignore lint/complexity/useRegexLiterals: the literal form trips noControlCharactersInRegex for these ANSI escape-code ranges.
+const TERMINAL_ESCAPE_PATTERN = new RegExp(
+  '[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))',
+  'g',
+);
+const ALLOWED_SGR_PATTERN = /^\x1b\[[0-9;]*m$/u;
+// Keep tabs/newlines alone here; the render path only needs to strip control
+// bytes that can mutate the terminal state or cursor position.
+const DISALLOWED_TERMINAL_CONTROL_PATTERN =
+  /[\u0000-\u0008\u000B-\u001A\u001C-\u001F\u007F\u009B]/g;
 
 type InternalReadline = readline.Interface & {
   line: string;
   cursor: number;
   _refreshLine?: () => void;
-  _ttyWrite?: (chunk: string, key: readline.Key) => void;
 };
 
-function resolveTuiApprovalPromptPalette(
-  palette?: Partial<TuiApprovalPromptPalette>,
-): TuiApprovalPromptPalette {
-  return {
-    ...DEFAULT_TUI_APPROVAL_PROMPT_PALETTE,
-    ...palette,
-  };
-}
+interface TuiApprovalPromptInput {
+  isTTY?: boolean;
+  on(
+    event: 'keypress',
+    listener: (chunk: string, key: readline.Key) => void,
+  ): this;
+  off(
+    event: 'keypress',
+    listener: (chunk: string, key: readline.Key) => void,
+  ): this;
+};
 
 function getAnsiSequenceLength(value: string, index: number): number {
   if (value.charCodeAt(index) !== 27 || value[index + 1] !== '[') {
@@ -60,49 +62,49 @@ function getAnsiSequenceLength(value: string, index: number): number {
   return 0;
 }
 
-function truncateLine(value: string, width: number): string {
+function truncateLine(value: string, width: number, reset = ''): string {
   if (width <= 0) return '';
-  let visibleLength = 0;
-  for (let index = 0; index < value.length; ) {
-    const ansiSequenceLength = getAnsiSequenceLength(value, index);
-    if (ansiSequenceLength > 0) {
-      index += ansiSequenceLength;
-      continue;
-    }
-    visibleLength += 1;
-    index += 1;
-  }
-  if (visibleLength <= width) return value;
-
   const targetVisibleLength = width === 1 ? 1 : width - 3;
   let output = '';
-  let writtenVisibleLength = 0;
+  let visibleLength = 0;
+  let truncated = false;
   const hasAnsi = value.includes('\x1b[');
 
-  for (
-    let index = 0;
-    index < value.length && writtenVisibleLength < targetVisibleLength;
-  ) {
+  for (let index = 0; index < value.length; ) {
     const ansiSequenceLength = getAnsiSequenceLength(value, index);
     if (ansiSequenceLength > 0) {
       output += value.slice(index, index + ansiSequenceLength);
       index += ansiSequenceLength;
       continue;
     }
+
+    if (visibleLength >= targetVisibleLength) {
+      truncated = true;
+      break;
+    }
+
     output += value[index] || '';
-    writtenVisibleLength += 1;
+    visibleLength += 1;
     index += 1;
   }
 
-  return hasAnsi
-    ? `${output}...${DEFAULT_TUI_APPROVAL_PROMPT_PALETTE.reset}`
-    : `${output}...`;
+  if (!truncated) return output;
+
+  return hasAnsi ? `${output}...${reset}` : `${output}...`;
 }
 
 function sentenceCase(value: string): string {
   const normalized = String(value || '').trim();
   if (!normalized) return '';
   return normalized[0].toUpperCase() + normalized.slice(1);
+}
+
+function sanitizeTerminalText(value: string): string {
+  return String(value || '')
+    .replace(TERMINAL_ESCAPE_PATTERN, (sequence) =>
+      ALLOWED_SGR_PATTERN.test(sequence) ? sequence : '',
+    )
+    .replace(DISALLOWED_TERMINAL_CONTROL_PATTERN, '');
 }
 
 function wrapPlainLines(text: string, width: number, indent = '  '): string[] {
@@ -117,63 +119,86 @@ function extractIntentPreview(intent: string): string | null {
   return preview || null;
 }
 
-function resolveIntentKindLabel(intent: string): string {
-  const normalized = intent.trim().toLowerCase();
-  if (
-    normalized.startsWith('run shell command ') ||
-    normalized.startsWith('run mutating command ') ||
-    normalized.startsWith('run read-only command ') ||
-    normalized.startsWith('run `') ||
-    normalized.startsWith('install dependencies with ')
-  ) {
-    return 'Bash command';
-  }
-  if (normalized.startsWith('run script ')) {
-    return 'Script execution';
-  }
-  if (normalized.startsWith('control a local app')) {
-    return 'Host action';
-  }
-  if (
-    normalized.startsWith('contact new host ') ||
-    normalized.startsWith('access ') ||
-    normalized.startsWith('contact ') ||
-    normalized.startsWith('fetch ')
-  ) {
-    return 'Network request';
-  }
-  if (normalized.startsWith('install python packages ')) {
-    return 'Python packages';
-  }
-  if (normalized.startsWith('install ')) {
-    return 'Dependency install';
-  }
-  return 'Approval request';
-}
-
-function resolveIntentSummary(intent: string, preview: string | null): string {
+function resolveIntentPresentation(
+  intent: string,
+  preview: string | null,
+): { kindLabel: string; summary: string } {
   const normalized = intent.trim();
-  if (!normalized) return 'Approval required';
+  if (!normalized) {
+    return {
+      kindLabel: 'Approval request',
+      summary: 'Approval required',
+    };
+  }
+
   const lower = normalized.toLowerCase();
-  if (preview && lower.startsWith('run shell command ')) {
-    return 'Run shell command';
+  if (
+    lower.startsWith('run shell command ') ||
+    lower.startsWith('run mutating command ') ||
+    lower.startsWith('run read-only command ') ||
+    lower.startsWith('run `') ||
+    lower.startsWith('install dependencies with ')
+  ) {
+    let summary = sentenceCase(normalized);
+    if (preview && lower.startsWith('run shell command ')) {
+      summary = 'Run shell command';
+    } else if (preview && lower.startsWith('run mutating command ')) {
+      summary = 'Run mutating command';
+    } else if (preview && lower.startsWith('run read-only command ')) {
+      summary = 'Run read-only command';
+    } else if (preview && lower.startsWith('install dependencies with ')) {
+      summary = 'Install dependencies';
+    }
+    return {
+      kindLabel: 'Bash command',
+      summary,
+    };
   }
-  if (preview && lower.startsWith('run mutating command ')) {
-    return 'Run mutating command';
+
+  if (lower.startsWith('run script ')) {
+    return {
+      kindLabel: 'Script execution',
+      summary: preview ? 'Run script' : sentenceCase(normalized),
+    };
   }
-  if (preview && lower.startsWith('run read-only command ')) {
-    return 'Run read-only command';
+
+  if (lower.startsWith('control a local app')) {
+    return {
+      kindLabel: 'Host action',
+      summary:
+        preview && lower.startsWith('control a local app with ')
+          ? 'Control a local app'
+          : sentenceCase(normalized),
+    };
   }
-  if (preview && lower.startsWith('run script ')) {
-    return 'Run script';
+  if (
+    lower.startsWith('contact new host ') ||
+    lower.startsWith('access ') ||
+    lower.startsWith('contact ') ||
+    lower.startsWith('fetch ')
+  ) {
+    return {
+      kindLabel: 'Network request',
+      summary: sentenceCase(normalized),
+    };
   }
-  if (preview && lower.startsWith('control a local app with ')) {
-    return 'Control a local app';
+  if (lower.startsWith('install python packages ')) {
+    return {
+      kindLabel: 'Python packages',
+      summary: sentenceCase(normalized),
+    };
   }
-  if (preview && lower.startsWith('install dependencies with ')) {
-    return 'Install dependencies';
+  if (lower.startsWith('install ')) {
+    return {
+      kindLabel: 'Dependency install',
+      summary: sentenceCase(normalized),
+    };
   }
-  return sentenceCase(normalized);
+
+  return {
+    kindLabel: 'Approval request',
+    summary: sentenceCase(normalized),
+  };
 }
 
 function formatApprovalOptionLabel(option: TuiApprovalSelectionOption): string {
@@ -202,19 +227,23 @@ export function renderTuiApprovalPromptLines(params: {
   options: TuiApprovalSelectionOption[];
   cursor: number;
   width: number;
-  palette?: Partial<TuiApprovalPromptPalette>;
 }): string[] {
-  const palette = resolveTuiApprovalPromptPalette(params.palette);
+  const palette = TUI_APPROVAL_PROMPT_PALETTE;
   const safeWidth = Math.max(20, params.width);
   const maxIndex = Math.max(0, params.options.length - 1);
   const cursor = Math.max(0, Math.min(params.cursor, maxIndex));
-  const preview = extractIntentPreview(params.approval.intent);
-  const kindLabel = resolveIntentKindLabel(params.approval.intent);
-  const summary = resolveIntentSummary(params.approval.intent, preview);
+  const intent = sanitizeTerminalText(params.approval.intent);
+  const reason = sanitizeTerminalText(params.approval.reason);
+  const preview = extractIntentPreview(intent);
+  const { kindLabel, summary } = resolveIntentPresentation(
+    intent,
+    preview,
+  );
   const lines = [
     truncateLine(
       `  ${palette.bold}${palette.gold}Approval required${palette.reset}`,
       safeWidth,
+      palette.reset,
     ),
     '',
   ];
@@ -233,7 +262,7 @@ export function renderTuiApprovalPromptLines(params: {
 
   lines.push('');
   for (const line of wrapPlainLines(
-    `Why: ${params.approval.reason}`,
+    `Why: ${reason}`,
     safeWidth,
     '  ',
   )) {
@@ -244,6 +273,7 @@ export function renderTuiApprovalPromptLines(params: {
     truncateLine(
       `  ${palette.bold}Do you want to proceed?${palette.reset}`,
       safeWidth,
+      palette.reset,
     ),
   );
 
@@ -263,12 +293,13 @@ export function renderTuiApprovalPromptLines(params: {
       truncateLine(
         ` ${pointer} ${number} ${optionColor}${formatApprovalOptionLabel(option)}${palette.reset}`,
         safeWidth,
+        palette.reset,
       ),
     );
   }
 
   lines.push('');
-  for (const line of wrapPlainLines('Esc to cancel', safeWidth, '  ')) {
+  for (const line of wrapPlainLines('Esc to skip', safeWidth, '  ')) {
     lines.push(`${palette.muted}${line}${palette.reset}`);
   }
 
@@ -279,23 +310,28 @@ export async function promptTuiApprovalSelection(params: {
   rl: readline.Interface;
   approval: Pick<TuiApprovalDetails, 'approvalId' | 'intent' | 'reason'>;
   options: TuiApprovalSelectionOption[];
-  palette?: Partial<TuiApprovalPromptPalette>;
+  input?: TuiApprovalPromptInput;
   output?: NodeJS.WriteStream;
   initialCursor?: number;
   restorePrompt?: boolean;
 }): Promise<TuiApprovalSelectionOption | undefined> {
   const { rl, options } = params;
-  const palette = resolveTuiApprovalPromptPalette(params.palette);
+  const input = params.input || process.stdin;
   const output = params.output || process.stdout;
   const internal = rl as InternalReadline;
-  const originalTtyWrite = internal._ttyWrite;
 
-  if (!output.isTTY || !originalTtyWrite || options.length === 0) {
+  if (options.length === 0) {
+    throw new Error('TUI approval prompt requires at least one option.');
+  }
+
+  if (!output.isTTY || !input.isTTY) {
     return undefined;
   }
 
   const savedLine = internal.line;
   const savedCursor = internal.cursor;
+  const lineListeners = rl.listeners('line') as Array<(line: string) => void>;
+  const sigintListeners = rl.listeners('SIGINT') as Array<() => void>;
   let renderedLineCount = 0;
   let restored = false;
   let cursor = Math.max(
@@ -307,38 +343,38 @@ export async function promptTuiApprovalSelection(params: {
     finish('skip');
   };
 
-  const clear = () => {
-    if (renderedLineCount <= 0) return;
-    readline.moveCursor(output, 0, -(renderedLineCount - 1));
-    readline.cursorTo(output, 0);
-    readline.clearScreenDown(output);
-    renderedLineCount = 0;
+  const buildClearFrame = () => {
+    if (renderedLineCount <= 0) return '';
+    return `${renderedLineCount > 1 ? `\x1b[${renderedLineCount - 1}A` : ''}\r\x1b[J`;
   };
 
   const render = () => {
-    clear();
-    output.write('\x1b[?25l');
+    const clearFrame = buildClearFrame();
     const lines = renderTuiApprovalPromptLines({
       approval: params.approval,
       options,
       cursor,
       width: output.columns || 80,
-      palette,
     });
-    output.write(lines.join('\n'));
+    output.write(`${clearFrame}\x1b[?25l${lines.join('\n')}`);
     renderedLineCount = lines.length;
   };
 
   const restore = () => {
     if (restored) return;
     restored = true;
-    clear();
-    output.write('\x1b[?25h');
-    if (internal._ttyWrite === handleTtyWrite) {
-      internal._ttyWrite = originalTtyWrite;
-    }
+    output.write(`${buildClearFrame()}\x1b[?25h`);
+    renderedLineCount = 0;
+    input.off('keypress', handleKeypress);
     output.off('resize', render);
     rl.off('close', closeHandler);
+    rl.off('SIGINT', handleSigint);
+    for (const listener of lineListeners) {
+      rl.on('line', listener);
+    }
+    for (const listener of sigintListeners) {
+      rl.on('SIGINT', listener);
+    }
     internal.line = savedLine;
     internal.cursor = Math.min(savedCursor, savedLine.length);
     if (params.restorePrompt !== false) {
@@ -356,7 +392,11 @@ export async function promptTuiApprovalSelection(params: {
     finish(selected);
   };
 
-  const handleTtyWrite = (chunk: string, key: readline.Key) => {
+  const handleSigint = () => {
+    finish('skip');
+  };
+
+  const handleKeypress = (chunk: string, key: readline.Key) => {
     const raw = String(key.sequence ?? chunk ?? '').trim();
 
     if (key.ctrl === true && key.name === 'c') {
@@ -386,11 +426,6 @@ export async function promptTuiApprovalSelection(params: {
       return;
     }
 
-    if (key.name === 'y') {
-      finish('once');
-      return;
-    }
-
     if (/^\d$/u.test(raw)) {
       const index = Number.parseInt(raw, 10) - 1;
       if (Number.isFinite(index) && index >= 0 && index < options.length) {
@@ -405,7 +440,14 @@ export async function promptTuiApprovalSelection(params: {
       resolve(value);
     };
 
-    internal._ttyWrite = handleTtyWrite;
+    for (const listener of lineListeners) {
+      rl.off('line', listener);
+    }
+    for (const listener of sigintListeners) {
+      rl.off('SIGINT', listener);
+    }
+    rl.on('SIGINT', handleSigint);
+    input.on('keypress', handleKeypress);
     output.on('resize', render);
     rl.on('close', closeHandler);
     render();

--- a/src/tui-approval-prompt.ts
+++ b/src/tui-approval-prompt.ts
@@ -1,0 +1,449 @@
+import readline from 'node:readline';
+
+import type { ApprovalScopeMode } from './approval-commands.js';
+import type { TuiApprovalDetails } from './tui-approval.js';
+import { wrapTuiBlock } from './tui-thinking.js';
+
+export type TuiApprovalSelectionOption = ApprovalScopeMode | 'skip';
+
+export type TuiApprovalPromptResult =
+  | { kind: 'select'; option: TuiApprovalSelectionOption }
+  | { kind: 'amend' }
+  | { kind: 'explain' };
+
+export interface TuiApprovalPromptPalette {
+  reset: string;
+  bold: string;
+  muted: string;
+  teal: string;
+  gold: string;
+  green: string;
+  red: string;
+}
+
+export const DEFAULT_TUI_APPROVAL_PROMPT_PALETTE: Readonly<TuiApprovalPromptPalette> =
+  Object.freeze({
+    reset: '\x1b[0m',
+    bold: '\x1b[1m',
+    muted: '\x1b[90m',
+    teal: '\x1b[36m',
+    gold: '\x1b[33m',
+    green: '\x1b[32m',
+    red: '\x1b[31m',
+  });
+
+type InternalReadline = readline.Interface & {
+  line: string;
+  cursor: number;
+  _refreshLine?: () => void;
+  _ttyWrite?: (chunk: string, key: readline.Key) => void;
+};
+
+function resolveTuiApprovalPromptPalette(
+  palette?: Partial<TuiApprovalPromptPalette>,
+): TuiApprovalPromptPalette {
+  return {
+    ...DEFAULT_TUI_APPROVAL_PROMPT_PALETTE,
+    ...palette,
+  };
+}
+
+function getAnsiSequenceLength(value: string, index: number): number {
+  if (value.charCodeAt(index) !== 27 || value[index + 1] !== '[') {
+    return 0;
+  }
+
+  let cursor = index + 2;
+  while (cursor < value.length) {
+    const code = value.charCodeAt(cursor);
+    if (code >= 64 && code <= 126) {
+      return cursor - index + 1;
+    }
+    cursor += 1;
+  }
+
+  return 0;
+}
+
+function truncateLine(value: string, width: number): string {
+  if (width <= 0) return '';
+  let visibleLength = 0;
+  for (let index = 0; index < value.length; ) {
+    const ansiSequenceLength = getAnsiSequenceLength(value, index);
+    if (ansiSequenceLength > 0) {
+      index += ansiSequenceLength;
+      continue;
+    }
+    visibleLength += 1;
+    index += 1;
+  }
+  if (visibleLength <= width) return value;
+
+  const targetVisibleLength = width === 1 ? 1 : width - 3;
+  let output = '';
+  let writtenVisibleLength = 0;
+  const hasAnsi = value.includes('\x1b[');
+
+  for (
+    let index = 0;
+    index < value.length && writtenVisibleLength < targetVisibleLength;
+  ) {
+    const ansiSequenceLength = getAnsiSequenceLength(value, index);
+    if (ansiSequenceLength > 0) {
+      output += value.slice(index, index + ansiSequenceLength);
+      index += ansiSequenceLength;
+      continue;
+    }
+    output += value[index] || '';
+    writtenVisibleLength += 1;
+    index += 1;
+  }
+
+  return hasAnsi
+    ? `${output}...${DEFAULT_TUI_APPROVAL_PROMPT_PALETTE.reset}`
+    : `${output}...`;
+}
+
+function sentenceCase(value: string): string {
+  const normalized = String(value || '').trim();
+  if (!normalized) return '';
+  return normalized[0].toUpperCase() + normalized.slice(1);
+}
+
+function wrapPlainLines(text: string, width: number, indent = '  '): string[] {
+  const normalized = String(text || '').trim();
+  if (!normalized) return [];
+  return wrapTuiBlock(normalized, Math.max(20, width), indent).split('\n');
+}
+
+function extractIntentPreview(intent: string): string | null {
+  const match = /`([^`]+)`/.exec(intent);
+  const preview = match?.[1]?.trim();
+  return preview || null;
+}
+
+function resolveIntentKindLabel(intent: string): string {
+  const normalized = intent.trim().toLowerCase();
+  if (
+    normalized.startsWith('run shell command ') ||
+    normalized.startsWith('run mutating command ') ||
+    normalized.startsWith('run read-only command ') ||
+    normalized.startsWith('run `') ||
+    normalized.startsWith('install dependencies with ')
+  ) {
+    return 'Bash command';
+  }
+  if (normalized.startsWith('run script ')) {
+    return 'Script execution';
+  }
+  if (normalized.startsWith('control a local app')) {
+    return 'Host action';
+  }
+  if (
+    normalized.startsWith('contact new host ') ||
+    normalized.startsWith('access ') ||
+    normalized.startsWith('contact ') ||
+    normalized.startsWith('fetch ')
+  ) {
+    return 'Network request';
+  }
+  if (normalized.startsWith('install python packages ')) {
+    return 'Python packages';
+  }
+  if (normalized.startsWith('install ')) {
+    return 'Dependency install';
+  }
+  return 'Approval request';
+}
+
+function resolveIntentSummary(intent: string, preview: string | null): string {
+  const normalized = intent.trim();
+  if (!normalized) return 'Approval required';
+  const lower = normalized.toLowerCase();
+  if (preview && lower.startsWith('run shell command ')) {
+    return 'Run shell command';
+  }
+  if (preview && lower.startsWith('run mutating command ')) {
+    return 'Run mutating command';
+  }
+  if (preview && lower.startsWith('run read-only command ')) {
+    return 'Run read-only command';
+  }
+  if (preview && lower.startsWith('run script ')) {
+    return 'Run script';
+  }
+  if (preview && lower.startsWith('control a local app with ')) {
+    return 'Control a local app';
+  }
+  if (preview && lower.startsWith('install dependencies with ')) {
+    return 'Install dependencies';
+  }
+  return sentenceCase(normalized);
+}
+
+function formatApprovalOptionLabel(option: TuiApprovalSelectionOption): string {
+  if (option === 'once') return 'Yes';
+  if (option === 'session') return 'Yes for session';
+  if (option === 'agent') return 'Yes for agent';
+  if (option === 'all') return 'Yes for all';
+  return 'No';
+}
+
+export function buildTuiApprovalSelectionOptions(params: {
+  allowSession: boolean;
+  allowAgent: boolean;
+  allowAll: boolean;
+}): TuiApprovalSelectionOption[] {
+  const options: TuiApprovalSelectionOption[] = ['once'];
+  if (params.allowSession) options.push('session');
+  if (params.allowAgent) options.push('agent');
+  if (params.allowAll) options.push('all');
+  options.push('skip');
+  return options;
+}
+
+export function buildTuiApprovalFollowupDraft(params: {
+  kind: 'amend' | 'explain';
+  approval: Pick<TuiApprovalDetails, 'intent' | 'reason'>;
+}): string {
+  const intent = params.approval.intent.trim();
+  if (params.kind === 'amend') {
+    if (intent) {
+      return `Please avoid this action if possible: ${intent}. Use a safer alternative.`;
+    }
+    return 'Please avoid the approval-required action if possible and use a safer alternative.';
+  }
+  if (intent) {
+    return `Explain why this action is needed: ${intent}. What lower-risk alternatives did you consider?`;
+  }
+  if (params.approval.reason.trim()) {
+    return `Explain why this approval is needed given: ${params.approval.reason.trim()}`;
+  }
+  return 'Explain why this approval is needed and what lower-risk alternatives you considered.';
+}
+
+export function renderTuiApprovalPromptLines(params: {
+  approval: Pick<TuiApprovalDetails, 'approvalId' | 'intent' | 'reason'>;
+  options: TuiApprovalSelectionOption[];
+  cursor: number;
+  width: number;
+  palette?: Partial<TuiApprovalPromptPalette>;
+}): string[] {
+  const palette = resolveTuiApprovalPromptPalette(params.palette);
+  const safeWidth = Math.max(20, params.width);
+  const maxIndex = Math.max(0, params.options.length - 1);
+  const cursor = Math.max(0, Math.min(params.cursor, maxIndex));
+  const preview = extractIntentPreview(params.approval.intent);
+  const kindLabel = resolveIntentKindLabel(params.approval.intent);
+  const summary = resolveIntentSummary(params.approval.intent, preview);
+  const lines = [
+    truncateLine(
+      `  ${palette.bold}${palette.gold}Approval required${palette.reset}`,
+      safeWidth,
+    ),
+    '',
+  ];
+
+  for (const line of wrapPlainLines(kindLabel, safeWidth, '  ')) {
+    lines.push(`${palette.bold}${palette.muted}${line}${palette.reset}`);
+  }
+  if (preview) {
+    for (const line of wrapPlainLines(preview, safeWidth, '   ')) {
+      lines.push(`${palette.bold}${palette.teal}${line}${palette.reset}`);
+    }
+  }
+  for (const line of wrapPlainLines(summary, safeWidth, '  ')) {
+    lines.push(`${palette.muted}${line}${palette.reset}`);
+  }
+
+  lines.push('');
+  for (const line of wrapPlainLines(
+    `Why: ${params.approval.reason}`,
+    safeWidth,
+    '  ',
+  )) {
+    lines.push(line);
+  }
+  lines.push('');
+  lines.push(
+    truncateLine(
+      `  ${palette.bold}Do you want to proceed?${palette.reset}`,
+      safeWidth,
+    ),
+  );
+
+  for (const [index, option] of params.options.entries()) {
+    const active = index === cursor;
+    const pointer = active
+      ? `${palette.bold}${palette.gold}>${palette.reset}`
+      : ' ';
+    const optionColor =
+      option === 'skip'
+        ? palette.red
+        : active
+          ? `${palette.bold}${palette.green}`
+          : palette.reset;
+    const number = `${index + 1}.`;
+    lines.push(
+      truncateLine(
+        ` ${pointer} ${number} ${optionColor}${formatApprovalOptionLabel(option)}${palette.reset}`,
+        safeWidth,
+      ),
+    );
+  }
+
+  lines.push('');
+  for (const line of wrapPlainLines(
+    'Esc to cancel | Tab to amend | Ctrl-E to explain',
+    safeWidth,
+    '  ',
+  )) {
+    lines.push(`${palette.muted}${line}${palette.reset}`);
+  }
+
+  return lines;
+}
+
+export async function promptTuiApprovalSelection(params: {
+  rl: readline.Interface;
+  approval: Pick<TuiApprovalDetails, 'approvalId' | 'intent' | 'reason'>;
+  options: TuiApprovalSelectionOption[];
+  palette?: Partial<TuiApprovalPromptPalette>;
+  output?: NodeJS.WriteStream;
+  initialCursor?: number;
+}): Promise<TuiApprovalPromptResult | undefined> {
+  const { rl, options } = params;
+  const palette = resolveTuiApprovalPromptPalette(params.palette);
+  const output = params.output || process.stdout;
+  const internal = rl as InternalReadline;
+  const originalTtyWrite = internal._ttyWrite;
+
+  if (!output.isTTY || !originalTtyWrite || options.length === 0) {
+    return undefined;
+  }
+
+  const savedLine = internal.line;
+  const savedCursor = internal.cursor;
+  let renderedLineCount = 0;
+  let restored = false;
+  let cursor = Math.max(
+    0,
+    Math.min(params.initialCursor ?? 0, options.length - 1),
+  );
+  let finish = (_value: TuiApprovalPromptResult) => {};
+  const closeHandler = () => {
+    finish({ kind: 'select', option: 'skip' });
+  };
+
+  const clear = () => {
+    if (renderedLineCount <= 0) return;
+    readline.moveCursor(output, 0, -(renderedLineCount - 1));
+    readline.cursorTo(output, 0);
+    readline.clearScreenDown(output);
+    renderedLineCount = 0;
+  };
+
+  const render = () => {
+    clear();
+    output.write('\x1b[?25l');
+    const lines = renderTuiApprovalPromptLines({
+      approval: params.approval,
+      options,
+      cursor,
+      width: output.columns || 80,
+      palette,
+    });
+    output.write(lines.join('\n'));
+    renderedLineCount = lines.length;
+  };
+
+  const restore = () => {
+    if (restored) return;
+    restored = true;
+    clear();
+    output.write('\x1b[?25h');
+    if (internal._ttyWrite === handleTtyWrite) {
+      internal._ttyWrite = originalTtyWrite;
+    }
+    output.off('resize', render);
+    rl.off('close', closeHandler);
+    internal.line = savedLine;
+    internal.cursor = Math.min(savedCursor, savedLine.length);
+    if (internal._refreshLine) {
+      internal._refreshLine();
+    } else if (typeof rl.prompt === 'function') {
+      rl.prompt(true);
+    }
+  };
+
+  const selectIndex = (index: number) => {
+    const selected = options[index];
+    if (!selected) return;
+    finish({ kind: 'select', option: selected });
+  };
+
+  const handleTtyWrite = (chunk: string, key: readline.Key) => {
+    const raw = String(key.sequence ?? chunk ?? '').trim();
+
+    if (key.ctrl === true && key.name === 'e') {
+      finish({ kind: 'explain' });
+      return;
+    }
+
+    if (key.ctrl === true && key.name === 'c') {
+      finish({ kind: 'select', option: 'skip' });
+      return;
+    }
+
+    if (key.name === 'tab') {
+      finish({ kind: 'amend' });
+      return;
+    }
+
+    if (key.name === 'escape' || key.name === 'q' || key.name === 'n') {
+      finish({ kind: 'select', option: 'skip' });
+      return;
+    }
+
+    if (key.name === 'up' || key.name === 'k') {
+      cursor = (cursor - 1 + options.length) % options.length;
+      render();
+      return;
+    }
+
+    if (key.name === 'down' || key.name === 'j') {
+      cursor = (cursor + 1) % options.length;
+      render();
+      return;
+    }
+
+    if (key.name === 'return' || key.name === 'enter') {
+      selectIndex(cursor);
+      return;
+    }
+
+    if (key.name === 'y') {
+      finish({ kind: 'select', option: 'once' });
+      return;
+    }
+
+    if (/^\d$/u.test(raw)) {
+      const index = Number.parseInt(raw, 10) - 1;
+      if (Number.isFinite(index) && index >= 0 && index < options.length) {
+        selectIndex(index);
+      }
+    }
+  };
+
+  return new Promise<TuiApprovalPromptResult>((resolve) => {
+    finish = (value: TuiApprovalPromptResult) => {
+      restore();
+      resolve(value);
+    };
+
+    internal._ttyWrite = handleTtyWrite;
+    output.on('resize', render);
+    rl.on('close', closeHandler);
+    render();
+  });
+}

--- a/src/tui-approval-prompt.ts
+++ b/src/tui-approval-prompt.ts
@@ -1,4 +1,4 @@
-import readline from 'node:readline';
+import type readline from 'node:readline';
 
 import type { ApprovalScopeMode } from './approval-commands.js';
 import type { TuiApprovalDetails } from './tui-approval.js';
@@ -21,11 +21,15 @@ const TERMINAL_ESCAPE_PATTERN = new RegExp(
   '[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))',
   'g',
 );
-const ALLOWED_SGR_PATTERN = /^\x1b\[[0-9;]*m$/u;
+// biome-ignore lint/complexity/useRegexLiterals: the literal form trips noControlCharactersInRegex for these ANSI escape-code ranges.
+const ALLOWED_SGR_PATTERN = new RegExp('^\\u001B\\[[0-9;]*m$', 'u');
 // Keep tabs/newlines alone here; the render path only needs to strip control
 // bytes that can mutate the terminal state or cursor position.
-const DISALLOWED_TERMINAL_CONTROL_PATTERN =
-  /[\u0000-\u0008\u000B-\u001A\u001C-\u001F\u007F\u009B]/g;
+// biome-ignore lint/complexity/useRegexLiterals: the literal form trips noControlCharactersInRegex for these ANSI escape-code ranges.
+const DISALLOWED_TERMINAL_CONTROL_PATTERN = new RegExp(
+  '[\\u0000-\\u0008\\u000B-\\u001A\\u001C-\\u001F\\u007F\\u009B]',
+  'g',
+);
 
 type InternalReadline = readline.Interface & {
   line: string;
@@ -43,7 +47,7 @@ interface TuiApprovalPromptInput {
     event: 'keypress',
     listener: (chunk: string, key: readline.Key) => void,
   ): this;
-};
+}
 
 function getAnsiSequenceLength(value: string, index: number): number {
   if (value.charCodeAt(index) !== 27 || value[index + 1] !== '[') {
@@ -235,10 +239,7 @@ export function renderTuiApprovalPromptLines(params: {
   const intent = sanitizeTerminalText(params.approval.intent);
   const reason = sanitizeTerminalText(params.approval.reason);
   const preview = extractIntentPreview(intent);
-  const { kindLabel, summary } = resolveIntentPresentation(
-    intent,
-    preview,
-  );
+  const { kindLabel, summary } = resolveIntentPresentation(intent, preview);
   const lines = [
     truncateLine(
       `  ${palette.bold}${palette.gold}Approval required${palette.reset}`,
@@ -261,11 +262,7 @@ export function renderTuiApprovalPromptLines(params: {
   }
 
   lines.push('');
-  for (const line of wrapPlainLines(
-    `Why: ${reason}`,
-    safeWidth,
-    '  ',
-  )) {
+  for (const line of wrapPlainLines(`Why: ${reason}`, safeWidth, '  ')) {
     lines.push(line);
   }
   lines.push('');

--- a/src/tui-approval.ts
+++ b/src/tui-approval.ts
@@ -61,3 +61,22 @@ export function parseTuiApprovalPrompt(
     ),
   };
 }
+
+export function isTuiApprovalRestatement(prompt: string): boolean {
+  const normalized = String(prompt || '')
+    .trim()
+    .toLowerCase();
+  if (!normalized) return false;
+  if (
+    normalized.includes('reply with one of:') &&
+    normalized.includes('yes for session') &&
+    normalized.includes('yes for agent') &&
+    normalized.includes('yes for all')
+  ) {
+    return true;
+  }
+  return (
+    normalized.includes('need your explicit approval first') ||
+    normalized.includes('need your approval first')
+  );
+}

--- a/src/tui-exit-summary.ts
+++ b/src/tui-exit-summary.ts
@@ -1,81 +1,21 @@
 import type { GatewayHistorySummary } from './gateway/gateway-types.js';
 
-function hasVisibleExitSummaryActivity(
-  summary: GatewayHistorySummary,
-): boolean {
-  return (
-    summary.toolCallCount > 0 ||
-    summary.inputTokenCount > 0 ||
-    summary.outputTokenCount > 0 ||
-    summary.costUsd > 0 ||
-    summary.fileChanges.readCount > 0 ||
-    summary.fileChanges.modifiedCount > 0 ||
-    summary.fileChanges.createdCount > 0 ||
-    summary.fileChanges.deletedCount > 0 ||
-    summary.toolBreakdown.some(
-      (entry) =>
-        Boolean(entry?.toolName?.trim()) &&
-        Number.isFinite(entry.count) &&
-        entry.count > 0,
-    )
-  );
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, Math.max(0, Math.floor(ms)));
-  });
-}
-
 export async function fetchTuiRemoteExitSummary(params: {
   loadRemote: () => Promise<GatewayHistorySummary | null>;
-  retries?: number;
-  retryDelayMs?: number;
 }): Promise<{
   summary: GatewayHistorySummary | null;
   error: string | null;
 }> {
-  const retries =
-    typeof params.retries === 'number' && Number.isFinite(params.retries)
-      ? Math.max(0, Math.floor(params.retries))
-      : 2;
-  const retryDelayMs =
-    typeof params.retryDelayMs === 'number' &&
-    Number.isFinite(params.retryDelayMs)
-      ? Math.max(0, Math.floor(params.retryDelayMs))
-      : 150;
-  let lastError: string | null = null;
-
-  for (let attempt = 0; attempt <= retries; attempt += 1) {
-    try {
-      const summary = await params.loadRemote();
-      if (summary) {
-        if (
-          !hasVisibleExitSummaryActivity(summary) &&
-          (summary.messageCount > 0 || summary.userMessageCount > 0)
-        ) {
-          lastError = 'Gateway history returned an empty activity summary.';
-        } else {
-          return {
-            summary,
-            error: null,
-          };
-        }
-      }
-      if (!lastError) {
-        lastError = 'Gateway history returned no summary.';
-      }
-    } catch (error) {
-      lastError = error instanceof Error ? error.message : String(error);
-    }
-
-    if (attempt < retries) {
-      await sleep(retryDelayMs);
-    }
+  try {
+    const summary = await params.loadRemote();
+    return {
+      summary,
+      error: summary ? null : 'Gateway history returned no summary.',
+    };
+  } catch (error) {
+    return {
+      summary: null,
+      error: error instanceof Error ? error.message : String(error),
+    };
   }
-
-  return {
-    summary: null,
-    error: lastError,
-  };
 }

--- a/src/tui-exit-summary.ts
+++ b/src/tui-exit-summary.ts
@@ -1,0 +1,81 @@
+import type { GatewayHistorySummary } from './gateway/gateway-types.js';
+
+function hasVisibleExitSummaryActivity(
+  summary: GatewayHistorySummary,
+): boolean {
+  return (
+    summary.toolCallCount > 0 ||
+    summary.inputTokenCount > 0 ||
+    summary.outputTokenCount > 0 ||
+    summary.costUsd > 0 ||
+    summary.fileChanges.readCount > 0 ||
+    summary.fileChanges.modifiedCount > 0 ||
+    summary.fileChanges.createdCount > 0 ||
+    summary.fileChanges.deletedCount > 0 ||
+    summary.toolBreakdown.some(
+      (entry) =>
+        Boolean(entry?.toolName?.trim()) &&
+        Number.isFinite(entry.count) &&
+        entry.count > 0,
+    )
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, Math.max(0, Math.floor(ms)));
+  });
+}
+
+export async function fetchTuiRemoteExitSummary(params: {
+  loadRemote: () => Promise<GatewayHistorySummary | null>;
+  retries?: number;
+  retryDelayMs?: number;
+}): Promise<{
+  summary: GatewayHistorySummary | null;
+  error: string | null;
+}> {
+  const retries =
+    typeof params.retries === 'number' && Number.isFinite(params.retries)
+      ? Math.max(0, Math.floor(params.retries))
+      : 2;
+  const retryDelayMs =
+    typeof params.retryDelayMs === 'number' &&
+    Number.isFinite(params.retryDelayMs)
+      ? Math.max(0, Math.floor(params.retryDelayMs))
+      : 150;
+  let lastError: string | null = null;
+
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    try {
+      const summary = await params.loadRemote();
+      if (summary) {
+        if (
+          !hasVisibleExitSummaryActivity(summary) &&
+          (summary.messageCount > 0 || summary.userMessageCount > 0)
+        ) {
+          lastError = 'Gateway history returned an empty activity summary.';
+        } else {
+          return {
+            summary,
+            error: null,
+          };
+        }
+      }
+      if (!lastError) {
+        lastError = 'Gateway history returned no summary.';
+      }
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+
+    if (attempt < retries) {
+      await sleep(retryDelayMs);
+    }
+  }
+
+  return {
+    summary: null,
+    error: lastError,
+  };
+}

--- a/src/tui-session.ts
+++ b/src/tui-session.ts
@@ -24,6 +24,13 @@ export interface TuiExitSummary {
   resumeCommand: string;
 }
 
+export interface TuiUnavailableExitSummary {
+  sessionId: string;
+  durationMs: number;
+  error: string;
+  resumeCommand: string;
+}
+
 function padTimestampPart(value: number): string {
   return String(Math.max(0, Math.trunc(value))).padStart(2, '0');
 }
@@ -126,6 +133,18 @@ export function buildTuiExitSummaryLines(summary: TuiExitSummary): string[] {
     `Tokens:     ${formatInteger(summary.inputTokenCount)} in / ${formatInteger(summary.outputTokenCount)} out  (~${formatApproxUsd(summary.costUsd)})`,
     toolCallsLine,
     `Files:      ${formatInteger(summary.readFileCount)} read, ${formatInteger(summary.modifiedFileCount)} modified, ${formatInteger(summary.createdFileCount)} created, ${formatInteger(summary.deletedFileCount)} deleted`,
+    '',
+    `Resume: ${summary.resumeCommand} ${summary.sessionId}`,
+  ];
+}
+
+export function buildTuiUnavailableExitSummaryLines(
+  summary: TuiUnavailableExitSummary,
+): string[] {
+  return [
+    `Session ${summary.sessionId} completed in ${formatTuiSessionDuration(summary.durationMs)}`,
+    '',
+    `Summary:    unavailable (${summary.error})`,
     '',
     `Resume: ${summary.resumeCommand} ${summary.sessionId}`,
   ];

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -62,6 +62,11 @@ import {
   parseTuiApprovalPrompt,
   type TuiApprovalDetails,
 } from './tui-approval.js';
+import {
+  buildTuiApprovalFollowupDraft,
+  buildTuiApprovalSelectionOptions,
+  promptTuiApprovalSelection,
+} from './tui-approval-prompt.js';
 import type { TuiStartupBannerSkillCategory } from './tui-banner.js';
 import { renderTuiStartupBanner } from './tui-banner.js';
 import {
@@ -120,6 +125,8 @@ const TUI_EXIT_CONFIRM_WINDOW_MS = 5000;
 type TuiTheme = 'dark' | 'light';
 type TuiReadlineInterface = readline.Interface & {
   history: string[];
+  line: string;
+  cursor: number;
   _refreshLine?: () => void;
 };
 
@@ -489,19 +496,62 @@ function resolvePendingApproval(
 
 async function promptApprovalSelection(
   rl: readline.Interface,
-  requestId: string,
-  allowSession: boolean,
-  allowAgent: boolean,
-  allowAll: boolean,
+  pendingApproval: TuiApprovalDetails,
 ): Promise<string | null> {
-  const options: Array<ApprovalScopeMode | 'skip'> = ['once'];
-  if (allowSession) options.push('session');
-  if (allowAgent) options.push('agent');
-  if (allowAll) options.push('all');
-  options.push('skip');
+  const options = buildTuiApprovalSelectionOptions({
+    allowSession: pendingApproval.allowSession,
+    allowAgent: pendingApproval.allowAgent,
+    allowAll: pendingApproval.allowAll,
+  });
   clearTuiSlashMenu();
+  const result = await promptTuiApprovalSelection({
+    rl,
+    approval: pendingApproval,
+    options,
+    palette: {
+      reset: RESET,
+      bold: BOLD,
+      muted: MUTED,
+      teal: TEAL,
+      gold: GOLD,
+      green: GREEN,
+      red: RED,
+    },
+  });
+  if (result?.kind === 'select') {
+    return mapApprovalSelectionToCommand(
+      result.option,
+      pendingApproval.approvalId,
+      options,
+    );
+  }
+  if (result?.kind === 'amend') {
+    setTuiInputDraft(
+      rl,
+      buildTuiApprovalFollowupDraft({
+        kind: 'amend',
+        approval: pendingApproval,
+      }),
+    );
+    return null;
+  }
+  if (result?.kind === 'explain') {
+    setTuiInputDraft(
+      rl,
+      buildTuiApprovalFollowupDraft({
+        kind: 'explain',
+        approval: pendingApproval,
+      }),
+    );
+    return null;
+  }
+
+  const summary = formatTuiApprovalSummary(pendingApproval);
+  if (TUI_APPROVAL_PRESENTATION.showText) {
+    printResponse(summary);
+  }
   console.log(
-    `  ${BOLD}${GOLD}Approval options${RESET} ${MUTED}(request ${requestId})${RESET}`,
+    `  ${BOLD}${GOLD}Approval options${RESET} ${MUTED}(request ${pendingApproval.approvalId})${RESET}`,
   );
   options.forEach((option, index) => {
     const label =
@@ -522,7 +572,11 @@ async function promptApprovalSelection(
       resolve,
     );
   });
-  const command = mapApprovalSelectionToCommand(answer, requestId, options);
+  const command = mapApprovalSelectionToCommand(
+    answer,
+    pendingApproval.approvalId,
+    options,
+  );
   if (answer.trim() && !command) {
     printInfo(
       `Unrecognized selection "${answer.trim()}". You can reply manually with yes/skip and the request id.`,
@@ -545,16 +599,7 @@ async function handleTuiPendingApproval(
     allowAgent: pendingApproval.allowAgent,
     allowAll: pendingApproval.allowAll,
   };
-  if (TUI_APPROVAL_PRESENTATION.showText) {
-    printResponse(summary);
-  }
-  const approvalCommand = await promptApprovalSelection(
-    rl,
-    pendingApproval.approvalId,
-    pendingApproval.allowSession,
-    pendingApproval.allowAgent,
-    pendingApproval.allowAll,
-  );
+  const approvalCommand = await promptApprovalSelection(rl, pendingApproval);
   if (approvalCommand) {
     await submitApprovalReplay(approvalCommand, rl);
   }
@@ -1598,6 +1643,16 @@ function promptTuiInput(rl: readline.Interface): void {
   if (tuiExitInProgress || isReadlineClosed(rl)) return;
   clearTuiSlashMenu();
   rl.prompt();
+  syncTuiSlashMenu();
+}
+
+function setTuiInputDraft(rl: readline.Interface, text: string): void {
+  if (tuiExitInProgress || isReadlineClosed(rl)) return;
+  clearTuiSlashMenu();
+  const internal = rl as TuiReadlineInterface;
+  internal.line = text;
+  internal.cursor = text.length;
+  internal._refreshLine?.();
   syncTuiSlashMenu();
 }
 

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -91,6 +91,7 @@ import { TuiMultilineInputController } from './tui-input.js';
 import { proactiveBadgeLabel, proactiveSourceSuffix } from './tui-proactive.js';
 import {
   buildTuiExitSummaryLines,
+  buildTuiUnavailableExitSummaryLines,
   generateTuiSessionId,
   type TuiRunOptions,
 } from './tui-session.js';
@@ -339,7 +340,7 @@ let activeRunAbortController: AbortController | null = null;
 let proactivePollInFlight = false;
 let tuiFullAutoState: TuiFullAutoState = DEFAULT_TUI_FULLAUTO_STATE;
 let fullAutoSteeringInFlight = false;
-let tuiPendingApproval: {
+type TuiCachedApproval = {
   requestId: string;
   summary: string;
   intent: string;
@@ -347,7 +348,9 @@ let tuiPendingApproval: {
   allowSession: boolean;
   allowAgent: boolean;
   allowAll: boolean;
-} | null = null;
+};
+
+let tuiPendingApproval: TuiCachedApproval | null = null;
 let tuiShowMode: SessionShowMode = DEFAULT_SESSION_SHOW_MODE;
 let tuiSlashMenu: TuiSlashMenuController | null = null;
 let tuiSessionId = generateTuiSessionId();
@@ -499,6 +502,20 @@ function resolvePendingApproval(
     : null;
 }
 
+function resolveCachedApprovalDetails(
+  pendingApproval: TuiCachedApproval | null,
+): TuiApprovalDetails | null {
+  if (!pendingApproval) return null;
+  return {
+    approvalId: pendingApproval.requestId,
+    intent: pendingApproval.intent,
+    reason: pendingApproval.reason,
+    allowSession: pendingApproval.allowSession,
+    allowAgent: pendingApproval.allowAgent,
+    allowAll: pendingApproval.allowAll,
+  };
+}
+
 async function promptApprovalSelection(
   rl: readline.Interface,
   pendingApproval: TuiApprovalDetails,
@@ -514,15 +531,6 @@ async function promptApprovalSelection(
     approval: pendingApproval,
     options,
     restorePrompt: false,
-    palette: {
-      reset: RESET,
-      bold: BOLD,
-      muted: MUTED,
-      teal: TEAL,
-      gold: GOLD,
-      green: GREEN,
-      red: RED,
-    },
   });
   if (result !== undefined) {
     return mapApprovalSelectionToCommand(
@@ -1713,26 +1721,32 @@ async function finalizeTuiExit(): Promise<void> {
   tuiSlashMenu = null;
 
   const { summary, error } = await fetchTuiExitSummary();
+  const durationMs = Date.now() - tuiSessionStartedAtMs;
 
   console.log();
   console.log();
-  const summaryLines = buildTuiExitSummaryLines({
-    sessionId: tuiSessionId,
-    durationMs: Date.now() - tuiSessionStartedAtMs,
-    inputTokenCount: summary?.inputTokenCount ?? 0,
-    outputTokenCount: summary?.outputTokenCount ?? 0,
-    costUsd: summary?.costUsd ?? 0,
-    toolCallCount: summary?.toolCallCount ?? 0,
-    toolBreakdown: summary?.toolBreakdown ?? [],
-    readFileCount: summary?.fileChanges.readCount ?? 0,
-    modifiedFileCount: summary?.fileChanges.modifiedCount ?? 0,
-    createdFileCount: summary?.fileChanges.createdCount ?? 0,
-    deletedFileCount: summary?.fileChanges.deletedCount ?? 0,
-    resumeCommand: tuiResumeCommand,
-  });
-  if (!summary && error) {
-    summaryLines.splice(2, 3, `Summary:    unavailable (${error})`);
-  }
+  const summaryLines =
+    summary || !error
+      ? buildTuiExitSummaryLines({
+          sessionId: tuiSessionId,
+          durationMs,
+          inputTokenCount: summary?.inputTokenCount ?? 0,
+          outputTokenCount: summary?.outputTokenCount ?? 0,
+          costUsd: summary?.costUsd ?? 0,
+          toolCallCount: summary?.toolCallCount ?? 0,
+          toolBreakdown: summary?.toolBreakdown ?? [],
+          readFileCount: summary?.fileChanges.readCount ?? 0,
+          modifiedFileCount: summary?.fileChanges.modifiedCount ?? 0,
+          createdFileCount: summary?.fileChanges.createdCount ?? 0,
+          deletedFileCount: summary?.fileChanges.deletedCount ?? 0,
+          resumeCommand: tuiResumeCommand,
+        })
+      : buildTuiUnavailableExitSummaryLines({
+          sessionId: tuiSessionId,
+          durationMs,
+          error,
+          resumeCommand: tuiResumeCommand,
+        });
   for (const line of summaryLines) {
     console.log(line);
   }
@@ -2224,16 +2238,7 @@ async function processMessage(
     const pendingApproval = resolvePendingApproval(
       result,
       streamedApproval,
-      tuiPendingApproval
-        ? {
-            approvalId: tuiPendingApproval.requestId,
-            intent: tuiPendingApproval.intent,
-            reason: tuiPendingApproval.reason,
-            allowSession: tuiPendingApproval.allowSession,
-            allowAgent: tuiPendingApproval.allowAgent,
-            allowAll: tuiPendingApproval.allowAll,
-          }
-        : null,
+      resolveCachedApprovalDetails(tuiPendingApproval),
     );
 
     s.flushVisibleText();
@@ -2349,16 +2354,7 @@ async function processFullAutoSteeringMessage(
       const pendingApproval = resolvePendingApproval(
         result,
         null,
-        tuiPendingApproval
-          ? {
-              approvalId: tuiPendingApproval.requestId,
-              intent: tuiPendingApproval.intent,
-              reason: tuiPendingApproval.reason,
-              allowSession: tuiPendingApproval.allowSession,
-              allowAgent: tuiPendingApproval.allowAgent,
-              allowAll: tuiPendingApproval.allowAll,
-            }
-          : null,
+        resolveCachedApprovalDetails(tuiPendingApproval),
       );
       if (pendingApproval) {
         await handleTuiPendingApproval(pendingApproval, rl);

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -59,11 +59,11 @@ import {
 } from './providers/model-names.js';
 import {
   formatTuiApprovalSummary,
+  isTuiApprovalRestatement,
   parseTuiApprovalPrompt,
   type TuiApprovalDetails,
 } from './tui-approval.js';
 import {
-  buildTuiApprovalFollowupDraft,
   buildTuiApprovalSelectionOptions,
   promptTuiApprovalSelection,
 } from './tui-approval-prompt.js';
@@ -74,6 +74,7 @@ import {
   loadTuiClipboardUploadCandidates,
 } from './tui-clipboard.js';
 import { formatTuiExitWarning, TuiExitController } from './tui-exit.js';
+import { fetchTuiRemoteExitSummary } from './tui-exit-summary.js';
 import {
   DEFAULT_TUI_FULLAUTO_STATE,
   deriveTuiFullAutoState,
@@ -125,8 +126,6 @@ const TUI_EXIT_CONFIRM_WINDOW_MS = 5000;
 type TuiTheme = 'dark' | 'light';
 type TuiReadlineInterface = readline.Interface & {
   history: string[];
-  line: string;
-  cursor: number;
   _refreshLine?: () => void;
 };
 
@@ -466,6 +465,7 @@ async function submitApprovalReplay(
 function resolvePendingApproval(
   result: GatewayChatResult,
   streamedApproval: GatewayChatApprovalEvent | null,
+  cachedApproval?: TuiApprovalDetails | null,
 ): TuiApprovalDetails | null {
   if (streamedApproval) {
     return {
@@ -491,7 +491,12 @@ function resolvePendingApproval(
   }
 
   const prompt = String(result.result || '').trim();
-  return prompt ? parseTuiApprovalPrompt(prompt) : null;
+  if (!prompt) return null;
+  const parsedPrompt = parseTuiApprovalPrompt(prompt);
+  if (parsedPrompt) return parsedPrompt;
+  return cachedApproval && isTuiApprovalRestatement(prompt)
+    ? cachedApproval
+    : null;
 }
 
 async function promptApprovalSelection(
@@ -508,6 +513,7 @@ async function promptApprovalSelection(
     rl,
     approval: pendingApproval,
     options,
+    restorePrompt: false,
     palette: {
       reset: RESET,
       bold: BOLD,
@@ -518,32 +524,12 @@ async function promptApprovalSelection(
       red: RED,
     },
   });
-  if (result?.kind === 'select') {
+  if (result !== undefined) {
     return mapApprovalSelectionToCommand(
-      result.option,
+      result,
       pendingApproval.approvalId,
       options,
     );
-  }
-  if (result?.kind === 'amend') {
-    setTuiInputDraft(
-      rl,
-      buildTuiApprovalFollowupDraft({
-        kind: 'amend',
-        approval: pendingApproval,
-      }),
-    );
-    return null;
-  }
-  if (result?.kind === 'explain') {
-    setTuiInputDraft(
-      rl,
-      buildTuiApprovalFollowupDraft({
-        kind: 'explain',
-        approval: pendingApproval,
-      }),
-    );
-    return null;
   }
 
   const summary = formatTuiApprovalSummary(pendingApproval);
@@ -1646,16 +1632,6 @@ function promptTuiInput(rl: readline.Interface): void {
   syncTuiSlashMenu();
 }
 
-function setTuiInputDraft(rl: readline.Interface, text: string): void {
-  if (tuiExitInProgress || isReadlineClosed(rl)) return;
-  clearTuiSlashMenu();
-  const internal = rl as TuiReadlineInterface;
-  internal.line = text;
-  internal.cursor = text.length;
-  internal._refreshLine?.();
-  syncTuiSlashMenu();
-}
-
 function refreshPrompt(rl: readline.Interface): void {
   if (tuiExitInProgress || isReadlineClosed(rl)) return;
   clearTuiSlashMenu();
@@ -1705,26 +1681,29 @@ async function fetchTuiInputHistory(
 }
 
 async function fetchTuiExitSummary(): Promise<{
-  inputTokenCount: number;
-  outputTokenCount: number;
-  costUsd: number;
-  toolCallCount: number;
-  toolBreakdown: Array<{ toolName: string; count: number }>;
-  fileChanges: {
-    readCount: number;
-    modifiedCount: number;
-    createdCount: number;
-    deletedCount: number;
-  };
-} | null> {
-  try {
-    const response = await gatewayHistory(tuiSessionId, 1, {
-      summarySinceMs: tuiSessionStartedAtMs,
-    });
-    return response.summary || null;
-  } catch {
-    return null;
-  }
+  summary: {
+    inputTokenCount: number;
+    outputTokenCount: number;
+    costUsd: number;
+    toolCallCount: number;
+    toolBreakdown: Array<{ toolName: string; count: number }>;
+    fileChanges: {
+      readCount: number;
+      modifiedCount: number;
+      createdCount: number;
+      deletedCount: number;
+    };
+  } | null;
+  error: string | null;
+}> {
+  return fetchTuiRemoteExitSummary({
+    loadRemote: async () => {
+      const response = await gatewayHistory(tuiSessionId, 1, {
+        summarySinceMs: tuiSessionStartedAtMs,
+      });
+      return response.summary || null;
+    },
+  });
 }
 
 async function finalizeTuiExit(): Promise<void> {
@@ -1733,11 +1712,11 @@ async function finalizeTuiExit(): Promise<void> {
   clearTuiSlashMenu();
   tuiSlashMenu = null;
 
-  const summary = await fetchTuiExitSummary();
+  const { summary, error } = await fetchTuiExitSummary();
 
   console.log();
   console.log();
-  for (const line of buildTuiExitSummaryLines({
+  const summaryLines = buildTuiExitSummaryLines({
     sessionId: tuiSessionId,
     durationMs: Date.now() - tuiSessionStartedAtMs,
     inputTokenCount: summary?.inputTokenCount ?? 0,
@@ -1750,7 +1729,11 @@ async function finalizeTuiExit(): Promise<void> {
     createdFileCount: summary?.fileChanges.createdCount ?? 0,
     deletedFileCount: summary?.fileChanges.deletedCount ?? 0,
     resumeCommand: tuiResumeCommand,
-  })) {
+  });
+  if (!summary && error) {
+    summaryLines.splice(2, 3, `Summary:    unavailable (${error})`);
+  }
+  for (const line of summaryLines) {
     console.log(line);
   }
   console.log();
@@ -2238,7 +2221,20 @@ async function processMessage(
     const hasUsageFooters = toolNames.length > 0 || pluginNames.length > 0;
     const hasStreamedText = sawVisibleTextDelta;
     const finalText = result.result || 'No response.';
-    const pendingApproval = resolvePendingApproval(result, streamedApproval);
+    const pendingApproval = resolvePendingApproval(
+      result,
+      streamedApproval,
+      tuiPendingApproval
+        ? {
+            approvalId: tuiPendingApproval.requestId,
+            intent: tuiPendingApproval.intent,
+            reason: tuiPendingApproval.reason,
+            allowSession: tuiPendingApproval.allowSession,
+            allowAgent: tuiPendingApproval.allowAgent,
+            allowAll: tuiPendingApproval.allowAll,
+          }
+        : null,
+    );
 
     s.flushVisibleText();
     s.stop();
@@ -2350,7 +2346,20 @@ async function processFullAutoSteeringMessage(
         printError(result.error || 'Unknown error');
         return;
       }
-      const pendingApproval = resolvePendingApproval(result, null);
+      const pendingApproval = resolvePendingApproval(
+        result,
+        null,
+        tuiPendingApproval
+          ? {
+              approvalId: tuiPendingApproval.requestId,
+              intent: tuiPendingApproval.intent,
+              reason: tuiPendingApproval.reason,
+              allowSession: tuiPendingApproval.allowSession,
+              allowAgent: tuiPendingApproval.allowAgent,
+              allowAll: tuiPendingApproval.allowAll,
+            }
+          : null,
+      );
       if (pendingApproval) {
         await handleTuiPendingApproval(pendingApproval, rl);
         return;

--- a/tests/gateway-history-summary.test.ts
+++ b/tests/gateway-history-summary.test.ts
@@ -184,3 +184,78 @@ test('getGatewayHistorySummary returns zero counts for unknown sessions', async 
     },
   });
 });
+
+test('getGatewayHistorySummary accepts canonical session keys and preserves tool/file summaries', async () => {
+  process.env.HOME = makeTempHome();
+  vi.resetModules();
+
+  const { initDatabase, recordUsageEvent } = await import(
+    '../src/memory/db.ts'
+  );
+  const { emitToolExecutionAuditEvents, makeAuditRunId } = await import(
+    '../src/audit/audit-events.ts'
+  );
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+  const { getGatewayHistorySummary } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+
+  const session = memoryService.getOrCreateSession(
+    'agent:main:channel:tui:chat:dm:peer:test-key',
+    null,
+    'tui',
+  );
+  const sinceMs = Date.now();
+
+  recordUsageEvent({
+    sessionId: session.id,
+    agentId: session.agent_id,
+    model: 'gpt-5',
+    inputTokens: 123,
+    outputTokens: 45,
+    toolCalls: 2,
+    costUsd: 0.01,
+    timestamp: new Date(sinceMs + 2_000).toISOString(),
+  });
+  emitToolExecutionAuditEvents({
+    sessionId: session.id,
+    runId: makeAuditRunId('after'),
+    toolExecutions: [
+      {
+        name: 'read',
+        arguments: '{"path":"existing.txt"}',
+        result: 'ok',
+        durationMs: 8,
+      },
+      {
+        name: 'edit',
+        arguments: '{"path":"existing.txt","old":"a","new":"b"}',
+        result: 'ok',
+        durationMs: 12,
+      },
+    ],
+  });
+
+  expect(
+    getGatewayHistorySummary(session.session_key || session.id, { sinceMs }),
+  ).toEqual({
+    messageCount: 0,
+    userMessageCount: 0,
+    toolCallCount: 2,
+    inputTokenCount: 123,
+    outputTokenCount: 45,
+    costUsd: 0.01,
+    toolBreakdown: [
+      { toolName: 'edit', count: 1 },
+      { toolName: 'read', count: 1 },
+    ],
+    fileChanges: {
+      readCount: 1,
+      modifiedCount: 1,
+      createdCount: 0,
+      deletedCount: 0,
+    },
+  });
+});

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -4857,6 +4857,89 @@ describe('gateway HTTP server', () => {
     await pendingApprovals.clearPendingApproval('session-web-approve');
   });
 
+  test('preserves pending approval metadata for /approve yes on the web chat stream path', async () => {
+    const state = await importFreshHealth();
+    const pendingApprovals = await import(
+      '../src/gateway/pending-approvals.js'
+    );
+    await pendingApprovals.setPendingApproval('session-web-approve', {
+      approvalId: 'approve-123',
+      prompt: 'I need approval before continuing.',
+      createdAt: Date.now(),
+      expiresAt: Date.now() + 60_000,
+      userId: 'user-web',
+    });
+    state.handleGatewayMessage.mockResolvedValue({
+      status: 'success',
+      result:
+        'Approval needed for: access clawhub.ai\nWhy: this would contact a new external host\nApproval ID: be945bbf',
+      sessionId: 'session-web-approve',
+      toolsUsed: ['web_fetch'],
+      pendingApproval: {
+        approvalId: 'be945bbf',
+        prompt:
+          'I need your approval before I access clawhub.ai.\nWhy: this would contact a new external host\nApproval ID: be945bbf',
+        intent: 'access clawhub.ai',
+        reason: 'this would contact a new external host',
+        allowSession: true,
+        allowAgent: true,
+        allowAll: true,
+        expiresAt: 1_710_000_000_000,
+      },
+      artifacts: [],
+    });
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/chat',
+      body: {
+        sessionId: 'session-web-approve',
+        channelId: 'web',
+        userId: 'user-web',
+        username: 'web',
+        content: '/approve yes',
+        stream: true,
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.handleGatewayCommand).not.toHaveBeenCalled();
+    expect(state.handleGatewayMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-web-approve',
+        content: 'yes approve-123',
+      }),
+    );
+    const events = res.body
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    expect(events).toEqual([
+      {
+        type: 'result',
+        result: expect.objectContaining({
+          status: 'success',
+          sessionId: 'session-web-approve',
+          pendingApproval: {
+            approvalId: 'be945bbf',
+            prompt:
+              'I need your approval before I access clawhub.ai.\nWhy: this would contact a new external host\nApproval ID: be945bbf',
+            intent: 'access clawhub.ai',
+            reason: 'this would contact a new external host',
+            allowSession: true,
+            allowAgent: true,
+            allowAll: true,
+            expiresAt: 1_710_000_000_000,
+          },
+        }),
+      },
+    ]);
+
+    await pendingApprovals.clearPendingApproval('session-web-approve');
+  });
+
   test('normalizes silent message-send chat responses', async () => {
     const state = await importFreshHealth();
     state.handleGatewayMessage.mockImplementation(

--- a/tests/tui-approval-prompt.test.ts
+++ b/tests/tui-approval-prompt.test.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from 'node:events';
 import type readline from 'node:readline';
 
 import { expect, test, vi } from 'vitest';
@@ -13,6 +12,16 @@ import {
 const ANSI_PATTERN = new RegExp('\\u001B\\[[0-9;]*[A-Za-z]', 'g');
 // biome-ignore lint/complexity/useRegexLiterals: the literal form trips noControlCharactersInRegex for these ANSI escape-code ranges.
 const CONTROL_PATTERN = new RegExp('[\\u0000-\\u001F\\u007F]', 'g');
+// biome-ignore lint/complexity/useRegexLiterals: the literal form trips noControlCharactersInRegex for these ANSI escape-code ranges.
+const REDRAW_PATTERN = new RegExp(
+  '^(?:\\u001B\\[\\d+A)?\\r\\u001B\\[J\\u001B\\[\\?25l',
+  'u',
+);
+// biome-ignore lint/complexity/useRegexLiterals: the literal form trips noControlCharactersInRegex for these ANSI escape-code ranges.
+const RESTORE_PATTERN = new RegExp(
+  '^(?:\\u001B\\[\\d+A)?\\r\\u001B\\[J\\u001B\\[\\?25h$',
+  'u',
+);
 
 function stripAnsi(value: string): string {
   return value.replace(ANSI_PATTERN, '');
@@ -107,6 +116,7 @@ function buildApprovalPromptHarness() {
   const rl = {
     line: '',
     cursor: 0,
+    _ttyWrite: vi.fn(),
     _refreshLine: vi.fn(),
     listeners: vi.fn((event: string) => {
       if (event === 'line') return [lineListener];
@@ -117,22 +127,19 @@ function buildApprovalPromptHarness() {
     off: vi.fn(),
     prompt: vi.fn(),
   } as unknown as readline.Interface;
-  const input = Object.assign(new EventEmitter(), {
-    isTTY: true,
-    on: EventEmitter.prototype.on,
-    off: EventEmitter.prototype.off,
-  });
-
   return {
     rl: rl as unknown as {
       line: string;
       cursor: number;
+      _ttyWrite: (chunk: string, key: readline.Key) => void;
       _refreshLine: () => void;
       listeners: (event: string) => unknown[];
     },
-    input,
     output,
     writes,
+    pressKey: (chunk: string, key: readline.Key) => {
+      rl._ttyWrite(chunk, key);
+    },
   };
 }
 
@@ -148,20 +155,22 @@ test('promptTuiApprovalSelection moves with arrows and confirms the highlighted 
     rl: harness.rl as unknown as readline.Interface,
     approval: APPROVAL,
     options: ['once', 'session', 'agent', 'skip'],
-    input: harness.input,
     output: harness.output,
   });
 
   expect(harness.writes).toHaveLength(1);
-  harness.input.emit('keypress', '', { name: 'down' });
+  expect(harness.writes[0]?.startsWith('\r\x1b[J\x1b[?25l')).toBe(true);
+  harness.pressKey('', { name: 'down' });
   expect(harness.writes).toHaveLength(2);
-  harness.input.emit('keypress', '', { name: 'down' });
+  expect(harness.writes[1]).toMatch(REDRAW_PATTERN);
+  harness.pressKey('', { name: 'down' });
   expect(harness.writes).toHaveLength(3);
-  harness.input.emit('keypress', '\r', { name: 'return' });
+  expect(harness.writes[2]).toMatch(REDRAW_PATTERN);
+  harness.pressKey('\r', { name: 'return' });
 
   await expect(prompt).resolves.toBe('agent');
   expect(harness.rl._refreshLine).toHaveBeenCalledTimes(1);
-  expect(harness.writes.length).toBeGreaterThan(0);
+  expect(harness.writes.at(-1)).toMatch(RESTORE_PATTERN);
 });
 
 test('promptTuiApprovalSelection can skip prompt redraw before an immediate replay', async () => {
@@ -170,12 +179,11 @@ test('promptTuiApprovalSelection can skip prompt redraw before an immediate repl
     rl: harness.rl as unknown as readline.Interface,
     approval: APPROVAL,
     options: ['once', 'skip'],
-    input: harness.input,
     output: harness.output,
     restorePrompt: false,
   });
 
-  harness.input.emit('keypress', '\r', { name: 'return' });
+  harness.pressKey('\r', { name: 'return' });
 
   await expect(prompt).resolves.toBe('once');
   expect(harness.rl._refreshLine).not.toHaveBeenCalled();
@@ -187,12 +195,11 @@ test('promptTuiApprovalSelection supports numeric quick select and escape deny',
     rl: numericHarness.rl as unknown as readline.Interface,
     approval: APPROVAL,
     options: ['once', 'session', 'agent', 'all', 'skip'],
-    input: numericHarness.input,
     output: numericHarness.output,
   });
 
-  numericHarness.input.emit('keypress', 'y', { name: 'y', sequence: 'y' });
-  numericHarness.input.emit('keypress', '4', { name: '4', sequence: '4' });
+  numericHarness.pressKey('y', { name: 'y', sequence: 'y' });
+  numericHarness.pressKey('4', { name: '4', sequence: '4' });
   await expect(numericPrompt).resolves.toBe('all');
 
   const denyHarness = buildApprovalPromptHarness();
@@ -203,11 +210,10 @@ test('promptTuiApprovalSelection supports numeric quick select and escape deny',
       approvalId: 'approve999',
     },
     options: ['once', 'skip'],
-    input: denyHarness.input,
     output: denyHarness.output,
   });
 
-  denyHarness.input.emit('keypress', '\u001b', {
+  denyHarness.pressKey('\u001b', {
     name: 'escape',
     sequence: '\u001b',
   });
@@ -239,7 +245,6 @@ test('promptTuiApprovalSelection throws when called without approval options', a
       rl: harness.rl as unknown as readline.Interface,
       approval: APPROVAL,
       options: [],
-      input: harness.input,
       output: harness.output,
     }),
   ).rejects.toThrow('TUI approval prompt requires at least one option.');

--- a/tests/tui-approval-prompt.test.ts
+++ b/tests/tui-approval-prompt.test.ts
@@ -1,5 +1,5 @@
-import type readline from 'node:readline';
 import { EventEmitter } from 'node:events';
+import type readline from 'node:readline';
 
 import { expect, test, vi } from 'vitest';
 
@@ -9,8 +9,13 @@ import {
   renderTuiApprovalPromptLines,
 } from '../src/tui-approval-prompt.js';
 
+// biome-ignore lint/complexity/useRegexLiterals: the literal form trips noControlCharactersInRegex for these ANSI escape-code ranges.
+const ANSI_PATTERN = new RegExp('\\u001B\\[[0-9;]*[A-Za-z]', 'g');
+// biome-ignore lint/complexity/useRegexLiterals: the literal form trips noControlCharactersInRegex for these ANSI escape-code ranges.
+const CONTROL_PATTERN = new RegExp('[\\u0000-\\u001F\\u007F]', 'g');
+
 function stripAnsi(value: string): string {
-  return value.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '');
+  return value.replace(ANSI_PATTERN, '');
 }
 
 test('buildTuiApprovalSelectionOptions keeps once first and skip last', () => {
@@ -75,7 +80,7 @@ test('renderTuiApprovalPromptLines strips disallowed terminal control sequences 
     width: 80,
   });
   const output = lines.join('\n');
-  const text = stripAnsi(output).replace(/[\u0000-\u001F\u007F]/g, '');
+  const text = stripAnsi(output).replace(CONTROL_PATTERN, '');
 
   expect(output).not.toContain('\x1b]0;owned\x07');
   expect(output).not.toContain('\x1b[2J');

--- a/tests/tui-approval-prompt.test.ts
+++ b/tests/tui-approval-prompt.test.ts
@@ -1,0 +1,219 @@
+import type readline from 'node:readline';
+
+import { expect, test, vi } from 'vitest';
+
+import {
+  buildTuiApprovalFollowupDraft,
+  buildTuiApprovalSelectionOptions,
+  promptTuiApprovalSelection,
+  renderTuiApprovalPromptLines,
+} from '../src/tui-approval-prompt.js';
+
+const PALETTE = {
+  reset: '',
+  bold: '',
+  muted: '',
+  teal: '',
+  gold: '',
+  green: '',
+  red: '',
+};
+
+test('buildTuiApprovalSelectionOptions keeps once first and skip last', () => {
+  expect(
+    buildTuiApprovalSelectionOptions({
+      allowSession: true,
+      allowAgent: true,
+      allowAll: true,
+    }),
+  ).toEqual(['once', 'session', 'agent', 'all', 'skip']);
+});
+
+test('renderTuiApprovalPromptLines highlights the selected row and help text', () => {
+  const lines = renderTuiApprovalPromptLines({
+    approval: {
+      approvalId: 'approve123',
+      intent: 'run shell command `git status`',
+      reason: 'this command may change local state',
+    },
+    options: ['once', 'session', 'skip'],
+    cursor: 1,
+    width: 80,
+    palette: PALETTE,
+  });
+
+  expect(lines.join('\n')).toContain('Approval required');
+  expect(lines.join('\n')).toContain('Bash command');
+  expect(lines.join('\n')).toContain('git status');
+  expect(lines.join('\n')).toContain('Do you want to proceed?');
+  expect(lines.join('\n')).toContain('> 2. Yes for session');
+  expect(lines.join('\n')).toContain('Tab to amend');
+  expect(lines.join('\n')).toContain('Ctrl-E to explain');
+});
+
+function buildApprovalPromptHarness() {
+  const writes: string[] = [];
+  const originalTtyWrite = vi.fn();
+  const output = {
+    isTTY: true,
+    columns: 80,
+    write: (chunk: string) => {
+      writes.push(chunk);
+      return true;
+    },
+    on: vi.fn(),
+    off: vi.fn(),
+  } as unknown as NodeJS.WriteStream;
+  const rl = {
+    line: '',
+    cursor: 0,
+    _refreshLine: vi.fn(),
+    _ttyWrite: originalTtyWrite,
+    on: vi.fn(),
+    off: vi.fn(),
+    prompt: vi.fn(),
+  } as unknown as readline.Interface;
+
+  return {
+    rl: rl as unknown as {
+      line: string;
+      cursor: number;
+      _refreshLine: () => void;
+      _ttyWrite: (chunk: string, key: readline.Key) => void;
+    },
+    output,
+    writes,
+    originalTtyWrite,
+  };
+}
+
+const APPROVAL = {
+  approvalId: 'approve123',
+  intent: 'run shell command `git status`',
+  reason: 'this command may change local state',
+} as const;
+
+test('buildTuiApprovalFollowupDraft prepares amend and explain prompts', () => {
+  expect(
+    buildTuiApprovalFollowupDraft({
+      kind: 'amend',
+      approval: APPROVAL,
+    }),
+  ).toContain(
+    'Please avoid this action if possible: run shell command `git status`',
+  );
+  expect(
+    buildTuiApprovalFollowupDraft({
+      kind: 'explain',
+      approval: APPROVAL,
+    }),
+  ).toContain(
+    'Explain why this action is needed: run shell command `git status`',
+  );
+});
+
+test('promptTuiApprovalSelection moves with arrows and confirms the highlighted option', async () => {
+  const harness = buildApprovalPromptHarness();
+  const prompt = promptTuiApprovalSelection({
+    rl: harness.rl as unknown as readline.Interface,
+    approval: APPROVAL,
+    options: ['once', 'session', 'agent', 'skip'],
+    output: harness.output,
+    palette: PALETTE,
+  });
+
+  harness.rl._ttyWrite('', { name: 'down' });
+  harness.rl._ttyWrite('', { name: 'down' });
+  harness.rl._ttyWrite('\r', { name: 'return' });
+
+  await expect(prompt).resolves.toEqual({
+    kind: 'select',
+    option: 'agent',
+  });
+  expect(harness.originalTtyWrite).not.toHaveBeenCalled();
+  expect(harness.rl._refreshLine).toHaveBeenCalledTimes(1);
+  expect(harness.writes.length).toBeGreaterThan(0);
+});
+
+test('promptTuiApprovalSelection supports numeric quick select and escape deny', async () => {
+  const numericHarness = buildApprovalPromptHarness();
+  const numericPrompt = promptTuiApprovalSelection({
+    rl: numericHarness.rl as unknown as readline.Interface,
+    approval: APPROVAL,
+    options: ['once', 'session', 'agent', 'all', 'skip'],
+    output: numericHarness.output,
+    palette: PALETTE,
+  });
+
+  numericHarness.rl._ttyWrite('4', { name: '4', sequence: '4' });
+  await expect(numericPrompt).resolves.toEqual({
+    kind: 'select',
+    option: 'all',
+  });
+
+  const denyHarness = buildApprovalPromptHarness();
+  const denyPrompt = promptTuiApprovalSelection({
+    rl: denyHarness.rl as unknown as readline.Interface,
+    approval: {
+      ...APPROVAL,
+      approvalId: 'approve999',
+    },
+    options: ['once', 'skip'],
+    output: denyHarness.output,
+    palette: PALETTE,
+  });
+
+  denyHarness.rl._ttyWrite('\u001b', { name: 'escape', sequence: '\u001b' });
+  await expect(denyPrompt).resolves.toEqual({
+    kind: 'select',
+    option: 'skip',
+  });
+});
+
+test('promptTuiApprovalSelection exposes amend and explain shortcuts', async () => {
+  const amendHarness = buildApprovalPromptHarness();
+  const amendPrompt = promptTuiApprovalSelection({
+    rl: amendHarness.rl as unknown as readline.Interface,
+    approval: APPROVAL,
+    options: ['once', 'skip'],
+    output: amendHarness.output,
+    palette: PALETTE,
+  });
+
+  amendHarness.rl._ttyWrite('\t', { name: 'tab', sequence: '\t' });
+  await expect(amendPrompt).resolves.toEqual({ kind: 'amend' });
+
+  const explainHarness = buildApprovalPromptHarness();
+  const explainPrompt = promptTuiApprovalSelection({
+    rl: explainHarness.rl as unknown as readline.Interface,
+    approval: APPROVAL,
+    options: ['once', 'skip'],
+    output: explainHarness.output,
+    palette: PALETTE,
+  });
+
+  explainHarness.rl._ttyWrite('\u0005', {
+    ctrl: true,
+    name: 'e',
+    sequence: '\u0005',
+  });
+  await expect(explainPrompt).resolves.toEqual({ kind: 'explain' });
+});
+
+test('promptTuiApprovalSelection returns undefined without a tty renderer', async () => {
+  const harness = buildApprovalPromptHarness();
+  const output = {
+    ...harness.output,
+    isTTY: false,
+  } as NodeJS.WriteStream;
+
+  await expect(
+    promptTuiApprovalSelection({
+      rl: harness.rl as unknown as readline.Interface,
+      approval: APPROVAL,
+      options: ['once', 'skip'],
+      output,
+      palette: PALETTE,
+    }),
+  ).resolves.toBeUndefined();
+});

--- a/tests/tui-approval-prompt.test.ts
+++ b/tests/tui-approval-prompt.test.ts
@@ -3,7 +3,6 @@ import type readline from 'node:readline';
 import { expect, test, vi } from 'vitest';
 
 import {
-  buildTuiApprovalFollowupDraft,
   buildTuiApprovalSelectionOptions,
   promptTuiApprovalSelection,
   renderTuiApprovalPromptLines,
@@ -47,8 +46,7 @@ test('renderTuiApprovalPromptLines highlights the selected row and help text', (
   expect(lines.join('\n')).toContain('git status');
   expect(lines.join('\n')).toContain('Do you want to proceed?');
   expect(lines.join('\n')).toContain('> 2. Yes for session');
-  expect(lines.join('\n')).toContain('Tab to amend');
-  expect(lines.join('\n')).toContain('Ctrl-E to explain');
+  expect(lines.join('\n')).toContain('Esc to cancel');
 });
 
 function buildApprovalPromptHarness() {
@@ -93,25 +91,6 @@ const APPROVAL = {
   reason: 'this command may change local state',
 } as const;
 
-test('buildTuiApprovalFollowupDraft prepares amend and explain prompts', () => {
-  expect(
-    buildTuiApprovalFollowupDraft({
-      kind: 'amend',
-      approval: APPROVAL,
-    }),
-  ).toContain(
-    'Please avoid this action if possible: run shell command `git status`',
-  );
-  expect(
-    buildTuiApprovalFollowupDraft({
-      kind: 'explain',
-      approval: APPROVAL,
-    }),
-  ).toContain(
-    'Explain why this action is needed: run shell command `git status`',
-  );
-});
-
 test('promptTuiApprovalSelection moves with arrows and confirms the highlighted option', async () => {
   const harness = buildApprovalPromptHarness();
   const prompt = promptTuiApprovalSelection({
@@ -126,13 +105,27 @@ test('promptTuiApprovalSelection moves with arrows and confirms the highlighted 
   harness.rl._ttyWrite('', { name: 'down' });
   harness.rl._ttyWrite('\r', { name: 'return' });
 
-  await expect(prompt).resolves.toEqual({
-    kind: 'select',
-    option: 'agent',
-  });
+  await expect(prompt).resolves.toBe('agent');
   expect(harness.originalTtyWrite).not.toHaveBeenCalled();
   expect(harness.rl._refreshLine).toHaveBeenCalledTimes(1);
   expect(harness.writes.length).toBeGreaterThan(0);
+});
+
+test('promptTuiApprovalSelection can skip prompt redraw before an immediate replay', async () => {
+  const harness = buildApprovalPromptHarness();
+  const prompt = promptTuiApprovalSelection({
+    rl: harness.rl as unknown as readline.Interface,
+    approval: APPROVAL,
+    options: ['once', 'skip'],
+    output: harness.output,
+    palette: PALETTE,
+    restorePrompt: false,
+  });
+
+  harness.rl._ttyWrite('\r', { name: 'return' });
+
+  await expect(prompt).resolves.toBe('once');
+  expect(harness.rl._refreshLine).not.toHaveBeenCalled();
 });
 
 test('promptTuiApprovalSelection supports numeric quick select and escape deny', async () => {
@@ -146,10 +139,7 @@ test('promptTuiApprovalSelection supports numeric quick select and escape deny',
   });
 
   numericHarness.rl._ttyWrite('4', { name: '4', sequence: '4' });
-  await expect(numericPrompt).resolves.toEqual({
-    kind: 'select',
-    option: 'all',
-  });
+  await expect(numericPrompt).resolves.toBe('all');
 
   const denyHarness = buildApprovalPromptHarness();
   const denyPrompt = promptTuiApprovalSelection({
@@ -164,40 +154,7 @@ test('promptTuiApprovalSelection supports numeric quick select and escape deny',
   });
 
   denyHarness.rl._ttyWrite('\u001b', { name: 'escape', sequence: '\u001b' });
-  await expect(denyPrompt).resolves.toEqual({
-    kind: 'select',
-    option: 'skip',
-  });
-});
-
-test('promptTuiApprovalSelection exposes amend and explain shortcuts', async () => {
-  const amendHarness = buildApprovalPromptHarness();
-  const amendPrompt = promptTuiApprovalSelection({
-    rl: amendHarness.rl as unknown as readline.Interface,
-    approval: APPROVAL,
-    options: ['once', 'skip'],
-    output: amendHarness.output,
-    palette: PALETTE,
-  });
-
-  amendHarness.rl._ttyWrite('\t', { name: 'tab', sequence: '\t' });
-  await expect(amendPrompt).resolves.toEqual({ kind: 'amend' });
-
-  const explainHarness = buildApprovalPromptHarness();
-  const explainPrompt = promptTuiApprovalSelection({
-    rl: explainHarness.rl as unknown as readline.Interface,
-    approval: APPROVAL,
-    options: ['once', 'skip'],
-    output: explainHarness.output,
-    palette: PALETTE,
-  });
-
-  explainHarness.rl._ttyWrite('\u0005', {
-    ctrl: true,
-    name: 'e',
-    sequence: '\u0005',
-  });
-  await expect(explainPrompt).resolves.toEqual({ kind: 'explain' });
+  await expect(denyPrompt).resolves.toBe('skip');
 });
 
 test('promptTuiApprovalSelection returns undefined without a tty renderer', async () => {

--- a/tests/tui-approval-prompt.test.ts
+++ b/tests/tui-approval-prompt.test.ts
@@ -1,4 +1,5 @@
 import type readline from 'node:readline';
+import { EventEmitter } from 'node:events';
 
 import { expect, test, vi } from 'vitest';
 
@@ -8,15 +9,9 @@ import {
   renderTuiApprovalPromptLines,
 } from '../src/tui-approval-prompt.js';
 
-const PALETTE = {
-  reset: '',
-  bold: '',
-  muted: '',
-  teal: '',
-  gold: '',
-  green: '',
-  red: '',
-};
+function stripAnsi(value: string): string {
+  return value.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '');
+}
 
 test('buildTuiApprovalSelectionOptions keeps once first and skip last', () => {
   expect(
@@ -38,20 +33,60 @@ test('renderTuiApprovalPromptLines highlights the selected row and help text', (
     options: ['once', 'session', 'skip'],
     cursor: 1,
     width: 80,
-    palette: PALETTE,
+  });
+  const text = stripAnsi(lines.join('\n'));
+
+  expect(text).toContain('Approval required');
+  expect(text).toContain('Bash command');
+  expect(text).toContain('git status');
+  expect(text).toContain('Do you want to proceed?');
+  expect(text).toContain('> 2. Yes for session');
+  expect(text).toContain('Esc to skip');
+});
+
+test('renderTuiApprovalPromptLines truncates ANSI-styled preview lines', () => {
+  const lines = renderTuiApprovalPromptLines({
+    approval: {
+      approvalId: 'approve123',
+      intent:
+        'run shell command `git status --branch --short --show-stash --ahead-behind`',
+      reason: 'this command may change local state',
+    },
+    options: ['once', 'skip'],
+    cursor: 0,
+    width: 24,
   });
 
-  expect(lines.join('\n')).toContain('Approval required');
-  expect(lines.join('\n')).toContain('Bash command');
-  expect(lines.join('\n')).toContain('git status');
-  expect(lines.join('\n')).toContain('Do you want to proceed?');
-  expect(lines.join('\n')).toContain('> 2. Yes for session');
-  expect(lines.join('\n')).toContain('Esc to cancel');
+  expect(
+    lines.some((line) => line.includes('...') && line.endsWith('\x1b[0m')),
+  ).toBe(true);
+});
+
+test('renderTuiApprovalPromptLines strips disallowed terminal control sequences from gateway content', () => {
+  const lines = renderTuiApprovalPromptLines({
+    approval: {
+      approvalId: 'approve123',
+      intent:
+        'run shell command `git status\x1b]0;owned\x07\x1b[31m --short\x1b[0m`',
+      reason: 'this command may \x1b[2Jchange local state\x07',
+    },
+    options: ['once', 'skip'],
+    cursor: 0,
+    width: 80,
+  });
+  const output = lines.join('\n');
+  const text = stripAnsi(output).replace(/[\u0000-\u001F\u007F]/g, '');
+
+  expect(output).not.toContain('\x1b]0;owned\x07');
+  expect(output).not.toContain('\x1b[2J');
+  expect(output).not.toContain('\x07');
+  expect(output).toContain('\x1b[31m --short\x1b[0m');
+  expect(text).toContain('git status --short');
+  expect(text).toContain('Why: this command may change local state');
 });
 
 function buildApprovalPromptHarness() {
   const writes: string[] = [];
-  const originalTtyWrite = vi.fn();
   const output = {
     isTTY: true,
     columns: 80,
@@ -62,26 +97,37 @@ function buildApprovalPromptHarness() {
     on: vi.fn(),
     off: vi.fn(),
   } as unknown as NodeJS.WriteStream;
+  const lineListener = vi.fn();
+  const sigintListener = vi.fn();
   const rl = {
     line: '',
     cursor: 0,
     _refreshLine: vi.fn(),
-    _ttyWrite: originalTtyWrite,
+    listeners: vi.fn((event: string) => {
+      if (event === 'line') return [lineListener];
+      if (event === 'SIGINT') return [sigintListener];
+      return [];
+    }),
     on: vi.fn(),
     off: vi.fn(),
     prompt: vi.fn(),
   } as unknown as readline.Interface;
+  const input = Object.assign(new EventEmitter(), {
+    isTTY: true,
+    on: EventEmitter.prototype.on,
+    off: EventEmitter.prototype.off,
+  });
 
   return {
     rl: rl as unknown as {
       line: string;
       cursor: number;
       _refreshLine: () => void;
-      _ttyWrite: (chunk: string, key: readline.Key) => void;
+      listeners: (event: string) => unknown[];
     },
+    input,
     output,
     writes,
-    originalTtyWrite,
   };
 }
 
@@ -97,16 +143,18 @@ test('promptTuiApprovalSelection moves with arrows and confirms the highlighted 
     rl: harness.rl as unknown as readline.Interface,
     approval: APPROVAL,
     options: ['once', 'session', 'agent', 'skip'],
+    input: harness.input,
     output: harness.output,
-    palette: PALETTE,
   });
 
-  harness.rl._ttyWrite('', { name: 'down' });
-  harness.rl._ttyWrite('', { name: 'down' });
-  harness.rl._ttyWrite('\r', { name: 'return' });
+  expect(harness.writes).toHaveLength(1);
+  harness.input.emit('keypress', '', { name: 'down' });
+  expect(harness.writes).toHaveLength(2);
+  harness.input.emit('keypress', '', { name: 'down' });
+  expect(harness.writes).toHaveLength(3);
+  harness.input.emit('keypress', '\r', { name: 'return' });
 
   await expect(prompt).resolves.toBe('agent');
-  expect(harness.originalTtyWrite).not.toHaveBeenCalled();
   expect(harness.rl._refreshLine).toHaveBeenCalledTimes(1);
   expect(harness.writes.length).toBeGreaterThan(0);
 });
@@ -117,12 +165,12 @@ test('promptTuiApprovalSelection can skip prompt redraw before an immediate repl
     rl: harness.rl as unknown as readline.Interface,
     approval: APPROVAL,
     options: ['once', 'skip'],
+    input: harness.input,
     output: harness.output,
-    palette: PALETTE,
     restorePrompt: false,
   });
 
-  harness.rl._ttyWrite('\r', { name: 'return' });
+  harness.input.emit('keypress', '\r', { name: 'return' });
 
   await expect(prompt).resolves.toBe('once');
   expect(harness.rl._refreshLine).not.toHaveBeenCalled();
@@ -134,11 +182,12 @@ test('promptTuiApprovalSelection supports numeric quick select and escape deny',
     rl: numericHarness.rl as unknown as readline.Interface,
     approval: APPROVAL,
     options: ['once', 'session', 'agent', 'all', 'skip'],
+    input: numericHarness.input,
     output: numericHarness.output,
-    palette: PALETTE,
   });
 
-  numericHarness.rl._ttyWrite('4', { name: '4', sequence: '4' });
+  numericHarness.input.emit('keypress', 'y', { name: 'y', sequence: 'y' });
+  numericHarness.input.emit('keypress', '4', { name: '4', sequence: '4' });
   await expect(numericPrompt).resolves.toBe('all');
 
   const denyHarness = buildApprovalPromptHarness();
@@ -149,11 +198,14 @@ test('promptTuiApprovalSelection supports numeric quick select and escape deny',
       approvalId: 'approve999',
     },
     options: ['once', 'skip'],
+    input: denyHarness.input,
     output: denyHarness.output,
-    palette: PALETTE,
   });
 
-  denyHarness.rl._ttyWrite('\u001b', { name: 'escape', sequence: '\u001b' });
+  denyHarness.input.emit('keypress', '\u001b', {
+    name: 'escape',
+    sequence: '\u001b',
+  });
   await expect(denyPrompt).resolves.toBe('skip');
 });
 
@@ -170,7 +222,20 @@ test('promptTuiApprovalSelection returns undefined without a tty renderer', asyn
       approval: APPROVAL,
       options: ['once', 'skip'],
       output,
-      palette: PALETTE,
     }),
   ).resolves.toBeUndefined();
+});
+
+test('promptTuiApprovalSelection throws when called without approval options', async () => {
+  const harness = buildApprovalPromptHarness();
+
+  await expect(
+    promptTuiApprovalSelection({
+      rl: harness.rl as unknown as readline.Interface,
+      approval: APPROVAL,
+      options: [],
+      input: harness.input,
+      output: harness.output,
+    }),
+  ).rejects.toThrow('TUI approval prompt requires at least one option.');
 });

--- a/tests/tui-approval.test.ts
+++ b/tests/tui-approval.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest';
 
 import {
   formatTuiApprovalSummary,
+  isTuiApprovalRestatement,
   parseTuiApprovalPrompt,
 } from '../src/tui-approval.js';
 
@@ -153,4 +154,31 @@ test('parses session-only approval prompts for command-style approvals', () => {
     allowAgent: false,
     allowAll: false,
   });
+});
+
+test('detects prose approval restatements that omit the canonical approval id block', () => {
+  expect(
+    isTuiApprovalRestatement(
+      [
+        '> Use web_fetch to read hybridclaw.com',
+        '',
+        'I can do that, but I need your explicit approval first.',
+        '',
+        'Reply with one of:',
+        '- `yes` (approve just this fetch)',
+        '- `yes for session`',
+        '- `yes for agent`',
+        '- `yes for all`',
+        '- `no`',
+      ].join('\n'),
+    ),
+  ).toBe(true);
+});
+
+test('does not treat ordinary assistant prose as an approval restatement', () => {
+  expect(
+    isTuiApprovalRestatement(
+      'I can explain the docs page from memory, but fetching it would be more accurate.',
+    ),
+  ).toBe(false);
 });

--- a/tests/tui-exit-summary.test.ts
+++ b/tests/tui-exit-summary.test.ts
@@ -29,59 +29,26 @@ test('fetchTuiRemoteExitSummary returns the remote summary when available', asyn
   });
 });
 
-test('fetchTuiRemoteExitSummary retries remote fetches before returning an error', async () => {
-  let attempts = 0;
-
+test('fetchTuiRemoteExitSummary returns the gateway error when the fetch fails', async () => {
   await expect(
     fetchTuiRemoteExitSummary({
       loadRemote: async () => {
-        attempts += 1;
         throw new Error('Gateway request failed');
       },
-      retries: 2,
-      retryDelayMs: 0,
     }),
   ).resolves.toEqual({
     summary: null,
     error: 'Gateway request failed',
   });
-  expect(attempts).toBe(3);
 });
 
 test('fetchTuiRemoteExitSummary reports an empty remote history summary explicitly', async () => {
   await expect(
     fetchTuiRemoteExitSummary({
       loadRemote: async () => null,
-      retries: 0,
     }),
   ).resolves.toEqual({
     summary: null,
     error: 'Gateway history returned no summary.',
-  });
-});
-
-test('fetchTuiRemoteExitSummary rejects remote summaries that have messages but no visible activity', async () => {
-  await expect(
-    fetchTuiRemoteExitSummary({
-      loadRemote: async () => ({
-        messageCount: 2,
-        userMessageCount: 1,
-        toolCallCount: 0,
-        inputTokenCount: 0,
-        outputTokenCount: 0,
-        costUsd: 0,
-        toolBreakdown: [],
-        fileChanges: {
-          readCount: 0,
-          modifiedCount: 0,
-          createdCount: 0,
-          deletedCount: 0,
-        },
-      }),
-      retries: 0,
-    }),
-  ).resolves.toEqual({
-    summary: null,
-    error: 'Gateway history returned an empty activity summary.',
   });
 });

--- a/tests/tui-exit-summary.test.ts
+++ b/tests/tui-exit-summary.test.ts
@@ -1,0 +1,87 @@
+import { expect, test } from 'vitest';
+
+import { fetchTuiRemoteExitSummary } from '../src/tui-exit-summary.js';
+
+const ACTIVE_SUMMARY = {
+  messageCount: 6,
+  userMessageCount: 3,
+  toolCallCount: 2,
+  inputTokenCount: 67_622,
+  outputTokenCount: 355,
+  costUsd: 0,
+  toolBreakdown: [{ toolName: 'web_fetch', count: 2 }],
+  fileChanges: {
+    readCount: 0,
+    modifiedCount: 0,
+    createdCount: 0,
+    deletedCount: 0,
+  },
+} as const;
+
+test('fetchTuiRemoteExitSummary returns the remote summary when available', async () => {
+  await expect(
+    fetchTuiRemoteExitSummary({
+      loadRemote: async () => ACTIVE_SUMMARY,
+    }),
+  ).resolves.toEqual({
+    summary: ACTIVE_SUMMARY,
+    error: null,
+  });
+});
+
+test('fetchTuiRemoteExitSummary retries remote fetches before returning an error', async () => {
+  let attempts = 0;
+
+  await expect(
+    fetchTuiRemoteExitSummary({
+      loadRemote: async () => {
+        attempts += 1;
+        throw new Error('Gateway request failed');
+      },
+      retries: 2,
+      retryDelayMs: 0,
+    }),
+  ).resolves.toEqual({
+    summary: null,
+    error: 'Gateway request failed',
+  });
+  expect(attempts).toBe(3);
+});
+
+test('fetchTuiRemoteExitSummary reports an empty remote history summary explicitly', async () => {
+  await expect(
+    fetchTuiRemoteExitSummary({
+      loadRemote: async () => null,
+      retries: 0,
+    }),
+  ).resolves.toEqual({
+    summary: null,
+    error: 'Gateway history returned no summary.',
+  });
+});
+
+test('fetchTuiRemoteExitSummary rejects remote summaries that have messages but no visible activity', async () => {
+  await expect(
+    fetchTuiRemoteExitSummary({
+      loadRemote: async () => ({
+        messageCount: 2,
+        userMessageCount: 1,
+        toolCallCount: 0,
+        inputTokenCount: 0,
+        outputTokenCount: 0,
+        costUsd: 0,
+        toolBreakdown: [],
+        fileChanges: {
+          readCount: 0,
+          modifiedCount: 0,
+          createdCount: 0,
+          deletedCount: 0,
+        },
+      }),
+      retries: 0,
+    }),
+  ).resolves.toEqual({
+    summary: null,
+    error: 'Gateway history returned an empty activity summary.',
+  });
+});

--- a/tests/tui-session.test.ts
+++ b/tests/tui-session.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest';
 
 import {
   buildTuiExitSummaryLines,
+  buildTuiUnavailableExitSummaryLines,
   formatTuiSessionDuration,
   generateTuiSessionId,
   resolveTuiRunOptions,
@@ -72,6 +73,23 @@ test('buildTuiExitSummaryLines formats the session summary block', () => {
     'Tokens:     12,847 in / 8,203 out  (~$0.42)',
     'Tool calls: 23 (14 edit, 6 bash, 3 read)',
     'Files:      3 read, 7 modified, 2 created, 1 deleted',
+    '',
+    'Resume: hybridclaw tui --resume 20260316_122238_532f05',
+  ]);
+});
+
+test('buildTuiUnavailableExitSummaryLines formats the unavailable summary block', () => {
+  expect(
+    buildTuiUnavailableExitSummaryLines({
+      sessionId: '20260316_122238_532f05',
+      durationMs: 461_000,
+      error: 'Gateway history returned no summary.',
+      resumeCommand: 'hybridclaw tui --resume',
+    }),
+  ).toEqual([
+    'Session 20260316_122238_532f05 completed in 7m 41s',
+    '',
+    'Summary:    unavailable (Gateway history returned no summary.)',
     '',
     'Resume: hybridclaw tui --resume 20260316_122238_532f05',
   ]);


### PR DESCRIPTION
## What changed

This updates the TUI approval flow from a plain numeric prompt to an interactive approval picker.

- adds a focused approval modal with up/down navigation, enter-to-confirm, number-key quick select, and Esc cancel
- reshapes the approval presentation to read more like a Claude-style approval card
- preserves the existing text prompt fallback for non-interactive terminals

## Why

The previous flow worked, but it was slower and less ergonomic than modern terminal coding tools. Approval prompts are a frequent interaction, so the TUI should support direct keyboard navigation instead of requiring typed responses.

## Impact

Users in the local TUI can handle approvals more quickly and with less typing while keeping the same approval policy behavior.

## Validation

- ./node_modules/.bin/vitest run tests/tui-approval-prompt.test.ts tests/tui-approval.test.ts tests/tui-skill-config.test.ts
- npm run typecheck
- npm run lint

## Notes

I did not run a manual npm run tui smoke test in an interactive terminal session.
