### PR TITLE
[codex] Surface invalid runtime config errors

### DIFF
--- a/src/config/runtime-config-revisions.ts
+++ b/src/config/runtime-config-revisions.ts
@@ -35,6 +35,16 @@ export interface RuntimeConfigRevision extends RuntimeConfigRevisionSummary {
   content: string;
 }
 
+export interface RuntimeConfigRevisionState {
+  actor: string;
+  route: string;
+  source: string;
+  md5: string;
+  byteLength: number;
+  content: string;
+  updatedAt: string;
+}
+
 export interface RuntimeConfigObservedFile {
   exists: boolean;
   content: string | null;
@@ -216,6 +226,20 @@ function mapRevisionSummaryRow(
   };
 }
 
+function mapRevisionStateRow(
+  row: ConfigRevisionStateRow,
+): RuntimeConfigRevisionState {
+  return {
+    actor: row.actor,
+    route: row.route,
+    source: row.source,
+    md5: row.current_md5,
+    byteLength: Buffer.byteLength(row.current_content, 'utf-8'),
+    content: row.current_content,
+    updatedAt: row.updated_at,
+  };
+}
+
 export function runtimeConfigRevisionStorePath(): string {
   return CONFIG_REVISION_DB_PATH;
 }
@@ -381,6 +405,21 @@ export function getRuntimeConfigRevision(
       )
       .get(configPath, revisionId);
     return row ? mapRevisionRow(row) : null;
+  });
+}
+
+export function getRuntimeConfigRevisionState(
+  configPath: string,
+): RuntimeConfigRevisionState | null {
+  return withRevisionDatabase((database) => {
+    const row = database
+      .prepare<[string], ConfigRevisionStateRow>(
+        `SELECT config_path, current_md5, current_content, actor, route, source, updated_at
+         FROM config_revision_state
+         WHERE config_path = ?`,
+      )
+      .get(configPath);
+    return row ? mapRevisionStateRow(row) : null;
   });
 }
 

--- a/src/config/runtime-config-revisions.ts
+++ b/src/config/runtime-config-revisions.ts
@@ -39,9 +39,14 @@ export interface RuntimeConfigRevisionState {
   actor: string;
   route: string;
   source: string;
-  md5: string;
-  byteLength: number;
   content: string;
+  updatedAt: string;
+}
+
+export interface RuntimeConfigRevisionStateMetadata {
+  actor: string;
+  route: string;
+  source: string;
   updatedAt: string;
 }
 
@@ -74,10 +79,20 @@ interface ConfigRevisionSummaryRow {
   replaced_by_md5: string | null;
 }
 
-interface ConfigRevisionStateRow {
-  config_path: string;
+interface ConfigRevisionTrackedStateRow {
   current_md5: string;
   current_content: string;
+}
+
+interface ConfigRevisionStateRow {
+  current_content: string;
+  actor: string;
+  route: string;
+  source: string;
+  updated_at: string;
+}
+
+interface ConfigRevisionStateMetadataRow {
   actor: string;
   route: string;
   source: string;
@@ -233,9 +248,18 @@ function mapRevisionStateRow(
     actor: row.actor,
     route: row.route,
     source: row.source,
-    md5: row.current_md5,
-    byteLength: Buffer.byteLength(row.current_content, 'utf-8'),
     content: row.current_content,
+    updatedAt: row.updated_at,
+  };
+}
+
+function mapRevisionStateMetadataRow(
+  row: ConfigRevisionStateMetadataRow,
+): RuntimeConfigRevisionStateMetadata {
+  return {
+    actor: row.actor,
+    route: row.route,
+    source: row.source,
     updatedAt: row.updated_at,
   };
 }
@@ -256,8 +280,8 @@ export function syncRuntimeConfigRevisionState(
     return database
       .transaction(() => {
         const state = database
-          .prepare<[string], ConfigRevisionStateRow>(
-            `SELECT config_path, current_md5, current_content, actor, route, source, updated_at
+          .prepare<[string], ConfigRevisionTrackedStateRow>(
+            `SELECT current_md5, current_content
              FROM config_revision_state
              WHERE config_path = ?`,
           )
@@ -414,12 +438,27 @@ export function getRuntimeConfigRevisionState(
   return withRevisionDatabase((database) => {
     const row = database
       .prepare<[string], ConfigRevisionStateRow>(
-        `SELECT config_path, current_md5, current_content, actor, route, source, updated_at
+        `SELECT current_content, actor, route, source, updated_at
          FROM config_revision_state
          WHERE config_path = ?`,
       )
       .get(configPath);
     return row ? mapRevisionStateRow(row) : null;
+  });
+}
+
+export function getRuntimeConfigRevisionStateMetadata(
+  configPath: string,
+): RuntimeConfigRevisionStateMetadata | null {
+  return withRevisionDatabase((database) => {
+    const row = database
+      .prepare<[string], ConfigRevisionStateMetadataRow>(
+        `SELECT actor, route, source, updated_at
+         FROM config_revision_state
+         WHERE config_path = ?`,
+      )
+      .get(configPath);
+    return row ? mapRevisionStateMetadataRow(row) : null;
   });
 }
 

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -69,11 +69,13 @@ import {
   deleteRuntimeConfigRevision as deleteTrackedRuntimeConfigRevision,
   getRuntimeConfigRevision as getTrackedRuntimeConfigRevision,
   getRuntimeConfigRevisionState as getTrackedRuntimeConfigRevisionState,
+  getRuntimeConfigRevisionStateMetadata as getTrackedRuntimeConfigRevisionStateMetadata,
   listRuntimeConfigRevisions as listTrackedRuntimeConfigRevisions,
   type RuntimeConfigChangeMeta,
   type RuntimeConfigObservedFile,
   type RuntimeConfigRevision,
   type RuntimeConfigRevisionState,
+  type RuntimeConfigRevisionStateMetadata,
   type RuntimeConfigRevisionSummary,
   runtimeConfigRevisionStorePath,
   syncRuntimeConfigRevisionState,
@@ -5050,6 +5052,7 @@ export type {
   RuntimeConfigChangeMeta,
   RuntimeConfigRevision,
   RuntimeConfigRevisionState,
+  RuntimeConfigRevisionStateMetadata,
   RuntimeConfigRevisionSummary,
 };
 
@@ -5183,6 +5186,10 @@ export function getRuntimeConfigRevision(
 
 export function getLastKnownGoodRuntimeConfigState(): RuntimeConfigRevisionState | null {
   return getTrackedRuntimeConfigRevisionState(CONFIG_PATH);
+}
+
+export function getLastKnownGoodRuntimeConfigMetadata(): RuntimeConfigRevisionStateMetadata | null {
+  return getTrackedRuntimeConfigRevisionStateMetadata(CONFIG_PATH);
 }
 
 export function deleteRuntimeConfigRevision(revisionId: number): boolean {

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -68,10 +68,12 @@ import {
   clearRuntimeConfigRevisions as clearTrackedRuntimeConfigRevisions,
   deleteRuntimeConfigRevision as deleteTrackedRuntimeConfigRevision,
   getRuntimeConfigRevision as getTrackedRuntimeConfigRevision,
+  getRuntimeConfigRevisionState as getTrackedRuntimeConfigRevisionState,
   listRuntimeConfigRevisions as listTrackedRuntimeConfigRevisions,
   type RuntimeConfigChangeMeta,
   type RuntimeConfigObservedFile,
   type RuntimeConfigRevision,
+  type RuntimeConfigRevisionState,
   type RuntimeConfigRevisionSummary,
   runtimeConfigRevisionStorePath,
   syncRuntimeConfigRevisionState,
@@ -121,6 +123,12 @@ export interface RuntimeSecurityConfig {
   trustModelAcceptedAt: string;
   trustModelVersion: string;
   trustModelAcceptedBy: string;
+}
+
+export interface RuntimeConfigLoadError {
+  trigger: string;
+  path: string;
+  message: string;
 }
 
 export type DiscordGroupPolicy = 'open' | 'allowlist' | 'disabled';
@@ -1198,6 +1206,7 @@ let currentConfigMetadata = {
   containerSandboxModeExplicit: false,
   containerMaxConcurrentExplicit: false,
 };
+let currentConfigLoadError: RuntimeConfigLoadError | null = null;
 let configWatcher: fs.FSWatcher | null = null;
 let reloadTimer: ReturnType<typeof setTimeout> | null = null;
 const listeners = new Set<RuntimeConfigChangeListener>();
@@ -4717,6 +4726,7 @@ function writeConfigFile(
 function applyConfig(next: RuntimeConfig): void {
   const prev = currentConfig;
   currentConfig = cloneConfig(next);
+  currentConfigLoadError = null;
 
   if (JSON.stringify(prev) === JSON.stringify(currentConfig)) return;
   for (const listener of listeners) {
@@ -4763,6 +4773,11 @@ function reloadFromDisk(trigger: string): void {
       source: 'external',
     });
   } catch (err) {
+    currentConfigLoadError = {
+      trigger,
+      path: CONFIG_PATH,
+      message: err instanceof Error ? err.message : String(err),
+    };
     console.warn(
       `[runtime-config] reload failed (${trigger}): ${err instanceof Error ? err.message : String(err)}`,
     );
@@ -4980,6 +4995,11 @@ export function reloadRuntimeConfig(trigger = 'manual'): RuntimeConfig {
       source: 'external',
     });
   } catch (err) {
+    currentConfigLoadError = {
+      trigger,
+      path: CONFIG_PATH,
+      message: err instanceof Error ? err.message : String(err),
+    };
     throw new Error(
       `Failed to reload runtime config (${trigger}): ${err instanceof Error ? err.message : String(err)}`,
     );
@@ -4988,6 +5008,10 @@ export function reloadRuntimeConfig(trigger = 'manual'): RuntimeConfig {
 
 export function getRuntimeConfig(): RuntimeConfig {
   return cloneConfig(currentConfig);
+}
+
+export function getRuntimeConfigLoadError(): RuntimeConfigLoadError | null {
+  return currentConfigLoadError ? { ...currentConfigLoadError } : null;
 }
 
 export function resolveDefaultAgentId(
@@ -5025,6 +5049,7 @@ export function onRuntimeConfigChange(
 export type {
   RuntimeConfigChangeMeta,
   RuntimeConfigRevision,
+  RuntimeConfigRevisionState,
   RuntimeConfigRevisionSummary,
 };
 
@@ -5156,6 +5181,10 @@ export function getRuntimeConfigRevision(
   return getTrackedRuntimeConfigRevision(CONFIG_PATH, revisionId);
 }
 
+export function getLastKnownGoodRuntimeConfigState(): RuntimeConfigRevisionState | null {
+  return getTrackedRuntimeConfigRevisionState(CONFIG_PATH);
+}
+
 export function deleteRuntimeConfigRevision(revisionId: number): boolean {
   return deleteTrackedRuntimeConfigRevision(CONFIG_PATH, revisionId);
 }
@@ -5186,6 +5215,31 @@ export function restoreRuntimeConfigRevision(
     normalizeRuntimeConfig(parsed as DeepPartial<RuntimeConfig>),
     meta,
   );
+}
+
+export function restoreLastKnownGoodRuntimeConfig(
+  meta?: RuntimeConfigChangeMeta,
+): RuntimeConfig {
+  const state = getLastKnownGoodRuntimeConfigState();
+  if (!state) {
+    throw new Error('No last-known-good runtime config snapshot was found.');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(state.content) as unknown;
+  } catch (err) {
+    throw new Error(
+      `Last-known-good runtime config snapshot is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!isRecord(parsed)) {
+    throw new Error(
+      'Last-known-good runtime config snapshot is not an object.',
+    );
+  }
+
+  return saveRuntimeConfigSource(parsed as Record<string, unknown>, meta);
 }
 
 export function runtimeConfigRevisionPath(): string {

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -10,9 +10,15 @@ import { refreshRuntimeSecretsFromEnv } from './config/config.js';
 import {
   acceptSecurityTrustModel,
   ensureRuntimeConfigFile,
+  getLastKnownGoodRuntimeConfigState,
   getRuntimeConfig,
+  getRuntimeConfigLoadError,
   isSecurityTrustAccepted,
+  listRuntimeConfigRevisions,
+  restoreLastKnownGoodRuntimeConfig,
+  restoreRuntimeConfigRevision,
   runtimeConfigPath,
+  runtimeConfigRevisionPath,
   SECURITY_POLICY_VERSION,
   updateRuntimeConfig,
 } from './config/runtime-config.js';
@@ -419,6 +425,40 @@ function formatAcceptanceMeta(): string {
   return `${at} (${config.security.trustModelVersion}; by ${by})`;
 }
 
+function buildInvalidRuntimeConfigErrorMessage(commandLabel: string): string {
+  const loadError = getRuntimeConfigLoadError();
+  if (!loadError) return '';
+
+  const lastKnownGood = getLastKnownGoodRuntimeConfigState();
+  const summary =
+    `Failed to load runtime config ${loadError.path}: ${loadError.message}. ` +
+    'HybridClaw is using in-memory defaults, so stored trust acceptance and other settings are unavailable.';
+
+  if (lastKnownGood) {
+    return (
+      `${summary} ` +
+      `Run \`hybridclaw onboarding\` interactively to restore the last known-good saved config snapshot from ${lastKnownGood.updatedAt}. ` +
+      `Revision store: ${runtimeConfigRevisionPath()}.`
+    );
+  }
+
+  const revisions = listRuntimeConfigRevisions();
+  if (revisions.length === 0) {
+    return (
+      `${summary} ` +
+      `No config revisions are saved yet. Fix ${loadError.path} manually, then rerun ${commandLabel}.`
+    );
+  }
+
+  const latest = revisions[0];
+  return (
+    `${summary} ` +
+    `Run \`hybridclaw config revisions\` to inspect saved revisions or ` +
+    `\`hybridclaw config revisions rollback ${latest.id}\` to restore the latest known-good revision. ` +
+    `Revision store: ${runtimeConfigRevisionPath()}.`
+  );
+}
+
 function printHeadline(text: string): void {
   console.log(`\n${ICON_TITLE} ${BOLD}${TEAL}${text}${RESET}\n`);
 }
@@ -720,6 +760,92 @@ async function ensureSecurityTrustAcceptance(
   printSuccess(`Saved trust-model acceptance to ${runtimeConfigPath()}.`);
   console.log();
   return true;
+}
+
+async function ensureValidRuntimeConfig(
+  rl: readline.Interface | null,
+  commandLabel: string,
+): Promise<void> {
+  const loadError = getRuntimeConfigLoadError();
+  if (!loadError) return;
+
+  const lastKnownGood = getLastKnownGoodRuntimeConfigState();
+  const summary =
+    `Failed to load runtime config ${loadError.path}: ${loadError.message}. ` +
+    'HybridClaw is using in-memory defaults, so stored trust acceptance and other settings are unavailable.';
+
+  if (!rl) {
+    throw new Error(buildInvalidRuntimeConfigErrorMessage(commandLabel));
+  }
+
+  printHeadline('Runtime config error');
+  printWarn(summary);
+  printMeta('Active config', runtimeConfigPath());
+  printMeta('Revision store', runtimeConfigRevisionPath());
+
+  if (lastKnownGood) {
+    printInfo('Last known-good saved config snapshot:');
+    console.log(
+      `  ${lastKnownGood.updatedAt} | route=${lastKnownGood.route} | actor=${lastKnownGood.actor}`,
+    );
+    console.log();
+
+    const shouldRestore = await promptYesNo(
+      rl,
+      `Restore ${runtimeConfigPath()} from the last known-good saved config snapshot (${lastKnownGood.updatedAt})?`,
+      true,
+      ICON_SETUP,
+    );
+    if (!shouldRestore) {
+      throw new Error(buildInvalidRuntimeConfigErrorMessage(commandLabel));
+    }
+
+    restoreLastKnownGoodRuntimeConfig({
+      route: 'onboarding.invalid-config-restore-last-known-good',
+      source: 'internal',
+    });
+    printSuccess(
+      `Restored runtime config from the last known-good saved snapshot (${lastKnownGood.updatedAt}).`,
+    );
+    printSuccess(`Updated runtime config at ${runtimeConfigPath()}.`);
+    console.log();
+    return;
+  }
+
+  const revisions = listRuntimeConfigRevisions();
+  if (revisions.length === 0) {
+    printWarn(
+      `No saved config revisions were found. Fix ${runtimeConfigPath()} manually, then rerun ${commandLabel}.`,
+    );
+    throw new Error(summary);
+  }
+
+  printInfo('Recent saved config revisions:');
+  for (const revision of revisions.slice(0, 5)) {
+    console.log(
+      `  #${revision.id} | ${revision.createdAt} | route=${revision.route} | actor=${revision.actor}`,
+    );
+  }
+  console.log();
+
+  const latest = revisions[0];
+  const shouldRollback = await promptYesNo(
+    rl,
+    `Roll back ${runtimeConfigPath()} to revision #${latest.id} from ${latest.createdAt}?`,
+    true,
+    ICON_SETUP,
+  );
+  if (!shouldRollback) {
+    throw new Error(buildInvalidRuntimeConfigErrorMessage(commandLabel));
+  }
+
+  restoreRuntimeConfigRevision(latest.id, {
+    route: `onboarding.invalid-config-rollback#${latest.id}`,
+    source: 'internal',
+  });
+  printSuccess(`Rolled back runtime config to revision #${latest.id}.`);
+  printSuccess(`Updated runtime config at ${runtimeConfigPath()}.`);
+  console.log();
 }
 
 async function runHybridAIApiKeyOnboarding(params: {
@@ -1154,11 +1280,13 @@ export async function ensureRuntimeCredentials(
 
   const interactive = process.stdin.isTTY && process.stdout.isTTY;
   let rl: readline.Interface | null = null;
+  const commandLabel = options.commandName || 'hybridclaw';
   if (interactive) {
     rl = readline.createInterface({
       input: process.stdin,
       output: process.stdout,
     });
+    await ensureValidRuntimeConfig(rl, commandLabel);
     try {
       const migrated = await maybeOfferAgentHomeMigrations(
         rl,
@@ -1169,6 +1297,8 @@ export async function ensureRuntimeCredentials(
       rl.close();
       throw new Error('Failed during agent migration offer.', { cause: error });
     }
+  } else {
+    await ensureValidRuntimeConfig(null, commandLabel);
   }
 
   const runtimeConfig = getRuntimeConfig();
@@ -1281,7 +1411,6 @@ export async function ensureRuntimeCredentials(
     );
   }
 
-  const commandLabel = options.commandName || 'hybridclaw';
   if (!rl) {
     throw new Error('Interactive onboarding interface was not initialized.');
   }

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -10,7 +10,7 @@ import { refreshRuntimeSecretsFromEnv } from './config/config.js';
 import {
   acceptSecurityTrustModel,
   ensureRuntimeConfigFile,
-  getLastKnownGoodRuntimeConfigState,
+  getLastKnownGoodRuntimeConfigMetadata,
   getRuntimeConfig,
   getRuntimeConfigLoadError,
   isSecurityTrustAccepted,
@@ -425,38 +425,103 @@ function formatAcceptanceMeta(): string {
   return `${at} (${config.security.trustModelVersion}; by ${by})`;
 }
 
-function buildInvalidRuntimeConfigErrorMessage(commandLabel: string): string {
-  const loadError = getRuntimeConfigLoadError();
-  if (!loadError) return '';
+type RuntimeConfigLoadError = NonNullable<
+  ReturnType<typeof getRuntimeConfigLoadError>
+>;
+type RuntimeConfigRevisionSummary = ReturnType<
+  typeof listRuntimeConfigRevisions
+>[number];
+type InvalidRuntimeConfigRecoveryState =
+  | {
+      kind: 'last-known-good';
+      lastKnownGood: NonNullable<
+        ReturnType<typeof getLastKnownGoodRuntimeConfigMetadata>
+      >;
+      summary: string;
+    }
+  | {
+      kind: 'no-revisions';
+      summary: string;
+    }
+  | {
+      kind: 'latest-revision';
+      latestRevision: RuntimeConfigRevisionSummary;
+      revisions: ReturnType<typeof listRuntimeConfigRevisions>;
+      summary: string;
+    };
 
-  const lastKnownGood = getLastKnownGoodRuntimeConfigState();
-  const summary =
+function buildInvalidRuntimeConfigSummary(
+  loadError: RuntimeConfigLoadError,
+): string {
+  return (
     `Failed to load runtime config ${loadError.path}: ${loadError.message}. ` +
-    'HybridClaw is using in-memory defaults, so stored trust acceptance and other settings are unavailable.';
+    'HybridClaw is using in-memory defaults, so stored trust acceptance and other settings are unavailable.'
+  );
+}
+
+function resolveInvalidRuntimeConfigRecoveryState(): InvalidRuntimeConfigRecoveryState | null {
+  const loadError = getRuntimeConfigLoadError();
+  if (!loadError) return null;
+
+  const lastKnownGood = getLastKnownGoodRuntimeConfigMetadata();
+  const summary = buildInvalidRuntimeConfigSummary(loadError);
 
   if (lastKnownGood) {
-    return (
-      `${summary} ` +
-      `Run \`hybridclaw onboarding\` interactively to restore the last known-good saved config snapshot from ${lastKnownGood.updatedAt}. ` +
-      `Revision store: ${runtimeConfigRevisionPath()}.`
-    );
+    return {
+      kind: 'last-known-good',
+      lastKnownGood,
+      summary,
+    };
   }
 
   const revisions = listRuntimeConfigRevisions();
   if (revisions.length === 0) {
-    return (
-      `${summary} ` +
-      `No config revisions are saved yet. Fix ${loadError.path} manually, then rerun ${commandLabel}.`
-    );
+    return {
+      kind: 'no-revisions',
+      summary,
+    };
   }
 
-  const latest = revisions[0];
-  return (
-    `${summary} ` +
-    `Run \`hybridclaw config revisions\` to inspect saved revisions or ` +
-    `\`hybridclaw config revisions rollback ${latest.id}\` to restore the latest known-good revision. ` +
-    `Revision store: ${runtimeConfigRevisionPath()}.`
-  );
+  const latestRevision = revisions[0];
+  if (!latestRevision) {
+    return {
+      kind: 'no-revisions',
+      summary,
+    };
+  }
+
+  return {
+    kind: 'latest-revision',
+    latestRevision,
+    revisions,
+    summary,
+  };
+}
+
+function buildInvalidRuntimeConfigErrorMessage(
+  commandLabel: string,
+  recoveryState: InvalidRuntimeConfigRecoveryState,
+): string {
+  switch (recoveryState.kind) {
+    case 'last-known-good':
+      return (
+        `${recoveryState.summary} ` +
+        `Run \`hybridclaw onboarding\` interactively to restore the last known-good saved config snapshot from ${recoveryState.lastKnownGood.updatedAt}. ` +
+        `Revision store: ${runtimeConfigRevisionPath()}.`
+      );
+    case 'no-revisions':
+      return (
+        `${recoveryState.summary} ` +
+        `No config revisions are saved yet. Fix ${runtimeConfigPath()} manually, then rerun ${commandLabel}.`
+      );
+    case 'latest-revision':
+      return (
+        `${recoveryState.summary} ` +
+        `Run \`hybridclaw config revisions\` to inspect saved revisions or ` +
+        `\`hybridclaw config revisions rollback ${recoveryState.latestRevision.id}\` to restore the latest known-good revision. ` +
+        `Revision store: ${runtimeConfigRevisionPath()}.`
+      );
+  }
 }
 
 function printHeadline(text: string): void {
@@ -766,86 +831,91 @@ async function ensureValidRuntimeConfig(
   rl: readline.Interface | null,
   commandLabel: string,
 ): Promise<void> {
-  const loadError = getRuntimeConfigLoadError();
-  if (!loadError) return;
-
-  const lastKnownGood = getLastKnownGoodRuntimeConfigState();
-  const summary =
-    `Failed to load runtime config ${loadError.path}: ${loadError.message}. ` +
-    'HybridClaw is using in-memory defaults, so stored trust acceptance and other settings are unavailable.';
+  const recoveryState = resolveInvalidRuntimeConfigRecoveryState();
+  if (!recoveryState) return;
 
   if (!rl) {
-    throw new Error(buildInvalidRuntimeConfigErrorMessage(commandLabel));
+    throw new Error(
+      buildInvalidRuntimeConfigErrorMessage(commandLabel, recoveryState),
+    );
   }
 
   printHeadline('Runtime config error');
-  printWarn(summary);
+  printWarn(recoveryState.summary);
   printMeta('Active config', runtimeConfigPath());
   printMeta('Revision store', runtimeConfigRevisionPath());
 
-  if (lastKnownGood) {
-    printInfo('Last known-good saved config snapshot:');
-    console.log(
-      `  ${lastKnownGood.updatedAt} | route=${lastKnownGood.route} | actor=${lastKnownGood.actor}`,
-    );
-    console.log();
+  switch (recoveryState.kind) {
+    case 'last-known-good': {
+      const { lastKnownGood } = recoveryState;
+      printInfo('Last known-good saved config snapshot:');
+      console.log(
+        `  ${lastKnownGood.updatedAt} | route=${lastKnownGood.route} | actor=${lastKnownGood.actor}`,
+      );
+      console.log();
 
-    const shouldRestore = await promptYesNo(
-      rl,
-      `Restore ${runtimeConfigPath()} from the last known-good saved config snapshot (${lastKnownGood.updatedAt})?`,
-      true,
-      ICON_SETUP,
-    );
-    if (!shouldRestore) {
-      throw new Error(buildInvalidRuntimeConfigErrorMessage(commandLabel));
+      const shouldRestore = await promptYesNo(
+        rl,
+        `Restore ${runtimeConfigPath()} from the last known-good saved config snapshot (${lastKnownGood.updatedAt})?`,
+        true,
+        ICON_SETUP,
+      );
+      if (!shouldRestore) {
+        throw new Error(
+          buildInvalidRuntimeConfigErrorMessage(commandLabel, recoveryState),
+        );
+      }
+
+      restoreLastKnownGoodRuntimeConfig({
+        route: 'onboarding.invalid-config-restore-last-known-good',
+        source: 'internal',
+      });
+      printSuccess(
+        `Restored runtime config from the last known-good saved snapshot (${lastKnownGood.updatedAt}).`,
+      );
+      printSuccess(`Updated runtime config at ${runtimeConfigPath()}.`);
+      console.log();
+      return;
     }
+    case 'no-revisions':
+      printWarn(
+        `No saved config revisions were found. Fix ${runtimeConfigPath()} manually, then rerun ${commandLabel}.`,
+      );
+      throw new Error(recoveryState.summary);
+    case 'latest-revision': {
+      printInfo('Recent saved config revisions:');
+      for (const revision of recoveryState.revisions.slice(0, 5)) {
+        console.log(
+          `  #${revision.id} | ${revision.createdAt} | route=${revision.route} | actor=${revision.actor}`,
+        );
+      }
+      console.log();
 
-    restoreLastKnownGoodRuntimeConfig({
-      route: 'onboarding.invalid-config-restore-last-known-good',
-      source: 'internal',
-    });
-    printSuccess(
-      `Restored runtime config from the last known-good saved snapshot (${lastKnownGood.updatedAt}).`,
-    );
-    printSuccess(`Updated runtime config at ${runtimeConfigPath()}.`);
-    console.log();
-    return;
+      const { latestRevision } = recoveryState;
+      const shouldRollback = await promptYesNo(
+        rl,
+        `Roll back ${runtimeConfigPath()} to revision #${latestRevision.id} from ${latestRevision.createdAt}?`,
+        true,
+        ICON_SETUP,
+      );
+      if (!shouldRollback) {
+        throw new Error(
+          buildInvalidRuntimeConfigErrorMessage(commandLabel, recoveryState),
+        );
+      }
+
+      restoreRuntimeConfigRevision(latestRevision.id, {
+        route: `onboarding.invalid-config-rollback#${latestRevision.id}`,
+        source: 'internal',
+      });
+      printSuccess(
+        `Rolled back runtime config to revision #${latestRevision.id}.`,
+      );
+      printSuccess(`Updated runtime config at ${runtimeConfigPath()}.`);
+      console.log();
+      return;
+    }
   }
-
-  const revisions = listRuntimeConfigRevisions();
-  if (revisions.length === 0) {
-    printWarn(
-      `No saved config revisions were found. Fix ${runtimeConfigPath()} manually, then rerun ${commandLabel}.`,
-    );
-    throw new Error(summary);
-  }
-
-  printInfo('Recent saved config revisions:');
-  for (const revision of revisions.slice(0, 5)) {
-    console.log(
-      `  #${revision.id} | ${revision.createdAt} | route=${revision.route} | actor=${revision.actor}`,
-    );
-  }
-  console.log();
-
-  const latest = revisions[0];
-  const shouldRollback = await promptYesNo(
-    rl,
-    `Roll back ${runtimeConfigPath()} to revision #${latest.id} from ${latest.createdAt}?`,
-    true,
-    ICON_SETUP,
-  );
-  if (!shouldRollback) {
-    throw new Error(buildInvalidRuntimeConfigErrorMessage(commandLabel));
-  }
-
-  restoreRuntimeConfigRevision(latest.id, {
-    route: `onboarding.invalid-config-rollback#${latest.id}`,
-    source: 'internal',
-  });
-  printSuccess(`Rolled back runtime config to revision #${latest.id}.`);
-  printSuccess(`Updated runtime config at ${runtimeConfigPath()}.`);
-  console.log();
 }
 
 async function runHybridAIApiKeyOnboarding(params: {

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -181,7 +181,7 @@ test('interactive onboarding suggests starting the TUI after HybridAI setup', as
   expect(output).toContain('Start HybridClaw now with `hybridclaw tui`.');
 });
 
-test('interactive onboarding offers rollback when runtime config is invalid JSON', async () => {
+test('interactive onboarding offers last-known-good restore when runtime config is invalid JSON', async () => {
   const homeDir = makeTempHome();
   writeRuntimeConfig(homeDir);
 
@@ -211,6 +211,9 @@ test('interactive onboarding offers rollback when runtime config is invalid JSON
     '{\n  "security": {\n    "trustModelAccepted": true,\n  }\n}\n',
     'utf-8',
   );
+  expect(() =>
+    runtimeConfig.reloadRuntimeConfig('test-invalid-config'),
+  ).toThrow(/Failed to reload runtime config/);
 
   const answers = ['y'];
   vi.doMock('node:readline/promises', () => ({
@@ -227,7 +230,6 @@ test('interactive onboarding offers rollback when runtime config is invalid JSON
       }),
     },
   }));
-  vi.resetModules();
 
   const lines: string[] = [];
   vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
@@ -251,6 +253,89 @@ test('interactive onboarding offers rollback when runtime config is invalid JSON
       trustModelVersion: '2026-02-28',
     },
   });
+});
+
+test('declining invalid runtime config restore only loads revision metadata', async () => {
+  const homeDir = makeTempHome();
+  writeRuntimeConfig(homeDir);
+
+  process.env.HOME = homeDir;
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
+  delete process.env.HYBRIDAI_API_KEY;
+  process.chdir(homeDir);
+  Object.defineProperty(process.stdin, 'isTTY', {
+    value: true,
+    configurable: true,
+  });
+  Object.defineProperty(process.stdout, 'isTTY', {
+    value: true,
+    configurable: true,
+  });
+
+  vi.resetModules();
+  const runtimeConfig = await import('../src/config/runtime-config.ts');
+  runtimeConfig.acceptSecurityTrustModel({
+    acceptedAt: '2026-03-10T10:00:00.000Z',
+    acceptedBy: 'test',
+  });
+
+  const configPath = path.join(homeDir, '.hybridclaw', 'config.json');
+  fs.writeFileSync(
+    configPath,
+    '{\n  "security": {\n    "trustModelAccepted": true,\n  }\n}\n',
+    'utf-8',
+  );
+  expect(() =>
+    runtimeConfig.reloadRuntimeConfig('test-invalid-config'),
+  ).toThrow(/Failed to reload runtime config/);
+
+  const getLastKnownGoodMetadataSpy = vi.spyOn(
+    runtimeConfig,
+    'getLastKnownGoodRuntimeConfigMetadata',
+  );
+  const getLastKnownGoodStateSpy = vi.spyOn(
+    runtimeConfig,
+    'getLastKnownGoodRuntimeConfigState',
+  );
+  const listRevisionsSpy = vi.spyOn(
+    runtimeConfig,
+    'listRuntimeConfigRevisions',
+  );
+
+  const answers = ['n'];
+  vi.doMock('node:readline/promises', () => ({
+    default: {
+      createInterface: () => ({
+        question: vi.fn(async (prompt: string) => {
+          const answer = answers.shift();
+          if (answer === undefined) {
+            throw new Error(`Unexpected onboarding prompt: ${prompt}`);
+          }
+          return answer;
+        }),
+        close: vi.fn(),
+      }),
+    },
+  }));
+
+  const lines: string[] = [];
+  vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    lines.push(args.map((value) => String(value)).join(' '));
+  });
+  const onboarding = await import('../src/onboarding.ts');
+  const resultPromise = onboarding.ensureRuntimeCredentials({
+    commandName: 'hybridclaw gateway restart --foreground',
+    requireCredentials: false,
+  });
+
+  await expect(resultPromise).rejects.toThrow(/Failed to load runtime config/);
+  await expect(resultPromise).rejects.toThrow(
+    /last known-good saved config snapshot/,
+  );
+  expect(getLastKnownGoodMetadataSpy).toHaveBeenCalledTimes(1);
+  expect(getLastKnownGoodStateSpy).not.toHaveBeenCalled();
+  expect(listRevisionsSpy).not.toHaveBeenCalled();
+  expect(lines.join('\n')).toContain('Runtime config error');
 });
 
 test('first-run onboarding offers Hermes migration before auth setup', async () => {
@@ -410,7 +495,9 @@ test('non-interactive onboarding reports invalid runtime config before trust acc
 
   const configPath = path.join(homeDir, '.hybridclaw', 'config.json');
   fs.writeFileSync(configPath, '{ not valid json !!!', 'utf-8');
-  vi.resetModules();
+  expect(() =>
+    runtimeConfig.reloadRuntimeConfig('test-invalid-config'),
+  ).toThrow(/Failed to reload runtime config/);
 
   const onboarding = await import('../src/onboarding.ts');
   const resultPromise = onboarding.ensureRuntimeCredentials({

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -181,6 +181,78 @@ test('interactive onboarding suggests starting the TUI after HybridAI setup', as
   expect(output).toContain('Start HybridClaw now with `hybridclaw tui`.');
 });
 
+test('interactive onboarding offers rollback when runtime config is invalid JSON', async () => {
+  const homeDir = makeTempHome();
+  writeRuntimeConfig(homeDir);
+
+  process.env.HOME = homeDir;
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
+  delete process.env.HYBRIDAI_API_KEY;
+  process.chdir(homeDir);
+  Object.defineProperty(process.stdin, 'isTTY', {
+    value: true,
+    configurable: true,
+  });
+  Object.defineProperty(process.stdout, 'isTTY', {
+    value: true,
+    configurable: true,
+  });
+
+  vi.resetModules();
+  const runtimeConfig = await import('../src/config/runtime-config.ts');
+  runtimeConfig.acceptSecurityTrustModel({
+    acceptedAt: '2026-03-10T10:00:00.000Z',
+    acceptedBy: 'test',
+  });
+
+  const configPath = path.join(homeDir, '.hybridclaw', 'config.json');
+  fs.writeFileSync(
+    configPath,
+    '{\n  "security": {\n    "trustModelAccepted": true,\n  }\n}\n',
+    'utf-8',
+  );
+
+  const answers = ['y'];
+  vi.doMock('node:readline/promises', () => ({
+    default: {
+      createInterface: () => ({
+        question: vi.fn(async (prompt: string) => {
+          const answer = answers.shift();
+          if (answer === undefined) {
+            throw new Error(`Unexpected onboarding prompt: ${prompt}`);
+          }
+          return answer;
+        }),
+        close: vi.fn(),
+      }),
+    },
+  }));
+  vi.resetModules();
+
+  const lines: string[] = [];
+  vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    lines.push(args.map((value) => String(value)).join(' '));
+  });
+  const onboarding = await import('../src/onboarding.ts');
+  await onboarding.ensureRuntimeCredentials({
+    commandName: 'hybridclaw gateway restart --foreground',
+    requireCredentials: false,
+  });
+
+  const output = lines.join('\n');
+  expect(output).toContain('Runtime config error');
+  expect(output).toContain(
+    'Restored runtime config from the last known-good saved snapshot',
+  );
+  expect(output).not.toContain('Security trust model acceptance');
+  expect(JSON.parse(fs.readFileSync(configPath, 'utf-8'))).toMatchObject({
+    security: {
+      trustModelAccepted: true,
+      trustModelVersion: '2026-02-28',
+    },
+  });
+});
+
 test('first-run onboarding offers Hermes migration before auth setup', async () => {
   const homeDir = makeTempHome();
   const hermesRoot = path.join(homeDir, '.hermes');
@@ -310,6 +382,46 @@ test('first-run onboarding offers Hermes migration before auth setup', async () 
     fs.readFileSync(path.join(runtimeRoot, 'credentials.json'), 'utf-8'),
   ).not.toContain('hai-imported-from-hermes');
   expect(migrateAgentHomeMock).toHaveBeenCalled();
+});
+
+test('non-interactive onboarding reports invalid runtime config before trust acceptance', async () => {
+  const homeDir = makeTempHome();
+  writeRuntimeConfig(homeDir);
+
+  process.env.HOME = homeDir;
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
+  delete process.env.HYBRIDAI_API_KEY;
+  process.chdir(homeDir);
+  Object.defineProperty(process.stdin, 'isTTY', {
+    value: false,
+    configurable: true,
+  });
+  Object.defineProperty(process.stdout, 'isTTY', {
+    value: false,
+    configurable: true,
+  });
+
+  vi.resetModules();
+  const runtimeConfig = await import('../src/config/runtime-config.ts');
+  runtimeConfig.acceptSecurityTrustModel({
+    acceptedAt: '2026-03-10T10:00:00.000Z',
+    acceptedBy: 'test',
+  });
+
+  const configPath = path.join(homeDir, '.hybridclaw', 'config.json');
+  fs.writeFileSync(configPath, '{ not valid json !!!', 'utf-8');
+  vi.resetModules();
+
+  const onboarding = await import('../src/onboarding.ts');
+  const resultPromise = onboarding.ensureRuntimeCredentials({
+    commandName: 'hybridclaw gateway restart --foreground',
+    requireCredentials: false,
+  });
+  await expect(resultPromise).rejects.toThrow(/Failed to load runtime config/);
+  await expect(resultPromise).rejects.toThrow(/hybridclaw onboarding/);
+  await expect(resultPromise).rejects.toThrow(
+    /last known-good saved config snapshot/,
+  );
 });
 
 test('interactive onboarding does not print the start hint when TUI is already launching', async () => {


### PR DESCRIPTION
## What changed

- surface invalid runtime config parse failures before trust-model onboarding runs
- record the current runtime config load error and expose the last known-good saved config snapshot
- let interactive onboarding offer restoring that last known-good snapshot when `config.json` is invalid
- add onboarding tests covering both interactive restore and non-interactive failure reporting

## Why

When `~/.hybridclaw/config.json` contains invalid JSON, HybridClaw was falling back to in-memory defaults and then prompting for TRUST_MODEL acceptance. That hid the real problem and made previously accepted trust state look lost.

## Validation

- `./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/onboarding.test.ts`
- `./node_modules/.bin/biome check src/config/runtime-config-revisions.ts src/config/runtime-config.ts src/onboarding.ts tests/onboarding.test.ts`
- `npm run typecheck`
