### PR TITLE
fix: disable Baileys init queries to prevent startup bad-request error

### DIFF
--- a/src/channels/whatsapp/connection.ts
+++ b/src/channels/whatsapp/connection.ts
@@ -266,6 +266,7 @@ export function createWhatsAppConnectionManager(params?: {
           keys: makeCacheableSignalKeyStore(state.keys, baileysLogger),
         },
         browser: [...WHATSAPP_BROWSER_IDENTITY],
+        fireInitQueries: false,
         getMessage: (key) => messageStore.getMessage(key),
         logger: baileysLogger,
         markOnlineOnConnect: false,

--- a/src/channels/whatsapp/connection.ts
+++ b/src/channels/whatsapp/connection.ts
@@ -266,7 +266,7 @@ export function createWhatsAppConnectionManager(params?: {
           keys: makeCacheableSignalKeyStore(state.keys, baileysLogger),
         },
         browser: [...WHATSAPP_BROWSER_IDENTITY],
-        fireInitQueries: false,
+        fireInitQueries: false, // Avoid intermittent 400/bad-request from Baileys fetchProps init query; metadata-only and not required for message flow.
         getMessage: (key) => messageStore.getMessage(key),
         logger: baileysLogger,
         markOnlineOnConnect: false,


### PR DESCRIPTION
## Summary
- Disables Baileys `fireInitQueries` option to suppress the `bad-request` error logged on every WhatsApp startup
- The init queries (`fetchProps`, `fetchBlocklist`, `fetchPrivacySettings`) are non-essential WA Web parity metadata and not required for message flow
- WhatsApp servers intermittently reject the `fetchProps` IQ query with a 400, causing noisy ERROR logs

## Test plan
- [ ] Start the app with WhatsApp channel enabled and verify the `unexpected error in 'init queries'` error no longer appears
- [ ] Send and receive WhatsApp messages to confirm messaging is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)