### PR TITLE
feat: add Fetch Email-Config button to admin email channel editor

### DIFF
--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -397,6 +397,10 @@ export function fetchConfig(token: string): Promise<AdminConfigResponse> {
   return requestJson<AdminConfigResponse>('/api/admin/config', { token });
 }
 
+export function fetchEmailConfig(token: string): Promise<unknown> {
+  return requestJson<unknown>('/api/admin/email-config/fetch', { token });
+}
+
 export function saveConfig(
   token: string,
   config: AdminConfig,

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -21,6 +21,10 @@ export interface GatewayStatus {
     expiresAt: number | null;
     reloginRequired: boolean;
   };
+  hybridai?: {
+    apiKeyConfigured: boolean;
+    apiKeySource: 'env' | 'runtime-secrets' | null;
+  };
   sandbox?: {
     mode: 'container' | 'host';
     activeSessions: number;

--- a/console/src/routes/channels.test.tsx
+++ b/console/src/routes/channels.test.tsx
@@ -12,6 +12,7 @@ import { ToastProvider } from '../components/toast';
 import { ChannelsPage } from './channels';
 
 const fetchConfigMock = vi.fn<() => Promise<AdminConfigResponse>>();
+const fetchEmailConfigMock = vi.fn();
 const saveConfigMock = vi.fn();
 const setRuntimeSecretMock = vi.fn();
 const validateTokenMock = vi.fn();
@@ -19,6 +20,7 @@ const useAuthMock = vi.fn();
 
 vi.mock('../api/client', () => ({
   fetchConfig: () => fetchConfigMock(),
+  fetchEmailConfig: (...args: unknown[]) => fetchEmailConfigMock(...args),
   saveConfig: (...args: unknown[]) => saveConfigMock(...args),
   setRuntimeSecret: (...args: unknown[]) => setRuntimeSecretMock(...args),
   validateToken: (...args: unknown[]) => validateTokenMock(...args),
@@ -253,11 +255,16 @@ function renderChannelsPage(): void {
 describe('ChannelsPage', () => {
   beforeEach(() => {
     fetchConfigMock.mockReset();
+    fetchEmailConfigMock.mockReset();
     saveConfigMock.mockReset();
     setRuntimeSecretMock.mockReset();
     validateTokenMock.mockReset();
     useAuthMock.mockReset();
     const gatewayStatus = {
+      hybridai: {
+        apiKeyConfigured: false,
+        apiKeySource: null,
+      },
       discord: {
         tokenConfigured: false,
         tokenSource: null,
@@ -1147,10 +1154,101 @@ describe('ChannelsPage', () => {
 
     renderChannelsPage();
 
-    await screen.findByRole('button', { name: /Email/i });
-    fireEvent.click(screen.getByRole('button', { name: /Email/i }));
+    const [emailChannelButton] = await screen.findAllByRole('button', {
+      name: /Email/i,
+    });
+    fireEvent.click(emailChannelButton);
     screen.getByRole('button', { name: 'Change password' });
     expect(screen.queryByRole('button', { name: 'Set password' })).toBeNull();
+  });
+
+  it('hides fetch email config when no HybridAI API key is configured', async () => {
+    fetchConfigMock.mockResolvedValue({
+      path: '/tmp/config.json',
+      config: makeConfig(),
+    });
+
+    renderChannelsPage();
+
+    const [emailChannelButton] = await screen.findAllByRole('button', {
+      name: /Email/i,
+    });
+    fireEvent.click(emailChannelButton);
+
+    expect(
+      screen.queryByRole('button', { name: 'Fetch HybridAI Agent Email' }),
+    ).toBeNull();
+  });
+
+  it('shows fetch email config when a HybridAI API key is configured', async () => {
+    fetchConfigMock.mockResolvedValue({
+      path: '/tmp/config.json',
+      config: makeConfig(),
+    });
+    validateTokenMock.mockResolvedValue({
+      status: 'ok',
+      webAuthConfigured: true,
+      version: 'test',
+      imageTag: null,
+      uptime: 1,
+      sessions: 0,
+      activeContainers: 0,
+      defaultModel: 'gpt-5',
+      ragDefault: true,
+      timestamp: new Date().toISOString(),
+      hybridai: {
+        apiKeyConfigured: true,
+        apiKeySource: 'runtime-secrets',
+      },
+      email: {
+        passwordConfigured: false,
+        passwordSource: null,
+      },
+      imessage: {
+        passwordConfigured: false,
+        passwordSource: null,
+      },
+      whatsapp: {
+        linked: false,
+        jid: null,
+        pairingQrText: null,
+        pairingUpdatedAt: null,
+      },
+    });
+    useAuthMock.mockReturnValue({
+      token: 'test-token',
+      gatewayStatus: {
+        hybridai: {
+          apiKeyConfigured: true,
+          apiKeySource: 'runtime-secrets',
+        },
+        email: {
+          passwordConfigured: false,
+          passwordSource: null,
+        },
+        imessage: {
+          passwordConfigured: false,
+          passwordSource: null,
+        },
+        whatsapp: {
+          linked: false,
+          jid: null,
+          pairingQrText: null,
+          pairingUpdatedAt: null,
+        },
+      },
+    });
+
+    renderChannelsPage();
+
+    const [emailChannelButton] = await screen.findAllByRole('button', {
+      name: /Email/i,
+    });
+    fireEvent.click(emailChannelButton);
+
+    expect(
+      screen.getByRole('button', { name: 'Fetch HybridAI Agent Email' }),
+    ).toBeTruthy();
   });
 
   it('updates Telegram bot tokens through encrypted runtime secrets', async () => {

--- a/console/src/routes/channels.tsx
+++ b/console/src/routes/channels.tsx
@@ -1055,14 +1055,27 @@ function EmailChannelEditor(props: {
             ...(cfg.smtp_secure != null ? { smtpSecure: cfg.smtp_secure } : {}),
           },
         }));
+        // Save password as runtime secret before showing success
+        if (cfg.password) {
+          try {
+            await setRuntimeSecret(
+              props.token,
+              'EMAIL_PASSWORD',
+              cfg.password,
+            );
+            props.onSecretSaved();
+          } catch (err) {
+            toast.error(
+              'Password could not be saved',
+              getErrorMessage(err),
+            );
+            toast.info('Email fields were populated, but password was not saved.');
+            return;
+          }
+        }
         toast.success(
           `Email config loaded from handle "${withConfig.handle}".`,
         );
-        // If a password was included, save it as runtime secret
-        if (cfg.password) {
-          await setRuntimeSecret(props.token, 'EMAIL_PASSWORD', cfg.password);
-          props.onSecretSaved();
-        }
       } else {
         // No email_config in handles — show available handles info
         const summary = handles

--- a/console/src/routes/channels.tsx
+++ b/console/src/routes/channels.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import {
   fetchConfig,
+  fetchEmailConfig,
   saveConfig,
   setRuntimeSecret,
   validateToken,
@@ -1007,6 +1008,78 @@ function EmailChannelEditor(props: {
   token: string;
   onSecretSaved: () => void;
 }) {
+  const [fetchingEmailConfig, setFetchingEmailConfig] = useState(false);
+  const toast = useToast();
+
+  async function handleFetchEmailConfig() {
+    setFetchingEmailConfig(true);
+    try {
+      const result = (await fetchEmailConfig(props.token)) as {
+        handles?: Array<{
+          handle?: string;
+          label?: string;
+          status?: string;
+          email_config?: {
+            address?: string;
+            imap_host?: string;
+            imap_port?: number;
+            imap_secure?: boolean;
+            smtp_host?: string;
+            smtp_port?: number;
+            smtp_secure?: boolean;
+            password?: string;
+          };
+        }>;
+      };
+
+      const handles = result?.handles;
+      if (!Array.isArray(handles) || handles.length === 0) {
+        toast.info('No agent handles found on HybridAI.');
+        return;
+      }
+
+      // Find first handle with email_config, or just show what we got
+      const withConfig = handles.find((h) => h.email_config);
+      if (withConfig?.email_config) {
+        const cfg = withConfig.email_config;
+        props.updateDraft((current) => ({
+          ...current,
+          email: {
+            ...current.email,
+            ...(cfg.address ? { address: cfg.address } : {}),
+            ...(cfg.imap_host ? { imapHost: cfg.imap_host } : {}),
+            ...(cfg.imap_port != null ? { imapPort: cfg.imap_port } : {}),
+            ...(cfg.imap_secure != null ? { imapSecure: cfg.imap_secure } : {}),
+            ...(cfg.smtp_host ? { smtpHost: cfg.smtp_host } : {}),
+            ...(cfg.smtp_port != null ? { smtpPort: cfg.smtp_port } : {}),
+            ...(cfg.smtp_secure != null ? { smtpSecure: cfg.smtp_secure } : {}),
+          },
+        }));
+        toast.success(
+          `Email config loaded from handle "${withConfig.handle}".`,
+        );
+        // If a password was included, save it as runtime secret
+        if (cfg.password) {
+          await setRuntimeSecret(props.token, 'EMAIL_PASSWORD', cfg.password);
+          props.onSecretSaved();
+        }
+      } else {
+        // No email_config in handles — show available handles info
+        const summary = handles
+          .map((h) => `${h.handle} (${h.status})`)
+          .join(', ');
+        toast.info(`Handles found: ${summary}. No email config attached.`);
+      }
+    } catch (error) {
+      toast.error(
+        'Failed to fetch email config',
+        getErrorMessage(error),
+      );
+    } finally {
+      setFetchingEmailConfig(false);
+    }
+  }
+
   return (
     <>
       <BooleanField
@@ -1024,6 +1097,17 @@ function EmailChannelEditor(props: {
           }))
         }
       />
+
+      <div style={{ marginBottom: '1rem' }}>
+        <button
+          type="button"
+          className="btn btn-secondary"
+          disabled={fetchingEmailConfig}
+          onClick={handleFetchEmailConfig}
+        >
+          {fetchingEmailConfig ? 'Fetching…' : 'Fetch Email-Config'}
+        </button>
+      </div>
 
       <div className="field-grid">
         <label className="field">

--- a/console/src/routes/channels.tsx
+++ b/console/src/routes/channels.tsx
@@ -1005,6 +1005,7 @@ function EmailChannelEditor(props: {
   updateDraft: ConfigUpdater;
   passwordConfigured: boolean;
   passwordSource: SecretSource;
+  hybridaiApiKeyConfigured: boolean;
   token: string;
   onSecretSaved: () => void;
 }) {
@@ -1034,7 +1035,7 @@ function EmailChannelEditor(props: {
 
       const handles = result?.handles;
       if (!Array.isArray(handles) || handles.length === 0) {
-        toast.info('No agent handles found on HybridAI.');
+        toast.info('No HybridAI agent handles found.');
         return;
       }
 
@@ -1074,14 +1075,16 @@ function EmailChannelEditor(props: {
           }
         }
         toast.success(
-          `Email config loaded from handle "${withConfig.handle}".`,
+          `HybridAI agent email config loaded from handle "${withConfig.handle}".`,
         );
       } else {
         // No email_config in handles — show available handles info
         const summary = handles
           .map((h) => `${h.handle} (${h.status})`)
           .join(', ');
-        toast.info(`Handles found: ${summary}. No email config attached.`);
+        toast.info(
+          `HybridAI agent handles found: ${summary}. No agent email config attached.`,
+        );
       }
     } catch (error) {
       toast.error('Failed to fetch email config', getErrorMessage(error));
@@ -1108,16 +1111,18 @@ function EmailChannelEditor(props: {
         }
       />
 
-      <div className="button-row">
-        <button
-          type="button"
+      {props.hybridaiApiKeyConfigured ? (
+        <div className="button-row">
+          <button
+            type="button"
           className="ghost-button"
           disabled={fetchingEmailConfig}
           onClick={handleFetchEmailConfig}
         >
-          {fetchingEmailConfig ? 'Fetching…' : 'Fetch Email-Config'}
+          {fetchingEmailConfig ? 'Fetching…' : 'Fetch HybridAI Agent Email'}
         </button>
       </div>
+      ) : null}
 
       <div className="field-grid">
         <label className="field">
@@ -2388,6 +2393,7 @@ function renderSelectedEditor(
       source: SecretSource;
     };
   },
+  hybridaiApiKeyConfigured: boolean,
   whatsappStatus: {
     linked: boolean;
     pairingQrText: string | null;
@@ -2457,6 +2463,7 @@ function renderSelectedEditor(
           updateDraft={updateDraft}
           passwordConfigured={secretStatus.email.configured}
           passwordSource={secretStatus.email.source}
+          hybridaiApiKeyConfigured={hybridaiApiKeyConfigured}
           token={token}
           onSecretSaved={onSecretSaved}
         />
@@ -2587,6 +2594,8 @@ export function ChannelsPage() {
     linked: statusQuery.data?.whatsapp?.linked ?? false,
     pairingQrText: statusQuery.data?.whatsapp?.pairingQrText ?? null,
   };
+  const hybridaiApiKeyConfigured =
+    statusQuery.data?.hybridai?.apiKeyConfigured ?? false;
 
   return (
     <div className="page-stack">
@@ -2637,6 +2646,7 @@ export function ChannelsPage() {
                   updateDraft,
                   auth.token,
                   secretStatus,
+                  hybridaiApiKeyConfigured,
                   whatsappStatus,
                   () => {
                     void queryClient.invalidateQueries({

--- a/console/src/routes/channels.tsx
+++ b/console/src/routes/channels.tsx
@@ -1059,18 +1059,13 @@ function EmailChannelEditor(props: {
         // Save password as runtime secret before showing success
         if (cfg.password) {
           try {
-            await setRuntimeSecret(
-              props.token,
-              'EMAIL_PASSWORD',
-              cfg.password,
-            );
+            await setRuntimeSecret(props.token, 'EMAIL_PASSWORD', cfg.password);
             props.onSecretSaved();
           } catch (err) {
-            toast.error(
-              'Password could not be saved',
-              getErrorMessage(err),
+            toast.error('Password could not be saved', getErrorMessage(err));
+            toast.info(
+              'Email fields were populated, but password was not saved.',
             );
-            toast.info('Email fields were populated, but password was not saved.');
             return;
           }
         }
@@ -1115,13 +1110,13 @@ function EmailChannelEditor(props: {
         <div className="button-row">
           <button
             type="button"
-          className="ghost-button"
-          disabled={fetchingEmailConfig}
-          onClick={handleFetchEmailConfig}
-        >
-          {fetchingEmailConfig ? 'Fetching…' : 'Fetch HybridAI Agent Email'}
-        </button>
-      </div>
+            className="ghost-button"
+            disabled={fetchingEmailConfig}
+            onClick={handleFetchEmailConfig}
+          >
+            {fetchingEmailConfig ? 'Fetching…' : 'Fetch HybridAI Agent Email'}
+          </button>
+        </div>
       ) : null}
 
       <div className="field-grid">

--- a/console/src/routes/channels.tsx
+++ b/console/src/routes/channels.tsx
@@ -1071,10 +1071,7 @@ function EmailChannelEditor(props: {
         toast.info(`Handles found: ${summary}. No email config attached.`);
       }
     } catch (error) {
-      toast.error(
-        'Failed to fetch email config',
-        getErrorMessage(error),
-      );
+      toast.error('Failed to fetch email config', getErrorMessage(error));
     } finally {
       setFetchingEmailConfig(false);
     }
@@ -1098,10 +1095,10 @@ function EmailChannelEditor(props: {
         }
       />
 
-      <div style={{ marginBottom: '1rem' }}>
+      <div className="button-row">
         <button
           type="button"
-          className="btn btn-secondary"
+          className="ghost-button"
           disabled={fetchingEmailConfig}
           onClick={handleFetchEmailConfig}
         >

--- a/console/src/routes/channels.tsx
+++ b/console/src/routes/channels.tsx
@@ -1017,20 +1017,19 @@ function EmailChannelEditor(props: {
     try {
       const result = (await fetchEmailConfig(props.token)) as {
         handles?: Array<{
+          id?: string;
           handle?: string;
-          label?: string;
           status?: string;
-          email_config?: {
-            address?: string;
-            imap_host?: string;
-            imap_port?: number;
-            imap_secure?: boolean;
-            smtp_host?: string;
-            smtp_port?: number;
-            smtp_secure?: boolean;
-            password?: string;
-          };
         }>;
+        credentials?: {
+          email?: string;
+          password?: string;
+          imap_host?: string;
+          imap_port?: number;
+          smtp_host?: string;
+          smtp_port?: number;
+        } | null;
+        handleId?: string;
       };
 
       const handles = result?.handles;
@@ -1039,48 +1038,49 @@ function EmailChannelEditor(props: {
         return;
       }
 
-      // Find first handle with email_config, or just show what we got
-      const withConfig = handles.find((h) => h.email_config);
-      if (withConfig?.email_config) {
-        const cfg = withConfig.email_config;
-        props.updateDraft((current) => ({
-          ...current,
-          email: {
-            ...current.email,
-            ...(cfg.address ? { address: cfg.address } : {}),
-            ...(cfg.imap_host ? { imapHost: cfg.imap_host } : {}),
-            ...(cfg.imap_port != null ? { imapPort: cfg.imap_port } : {}),
-            ...(cfg.imap_secure != null ? { imapSecure: cfg.imap_secure } : {}),
-            ...(cfg.smtp_host ? { smtpHost: cfg.smtp_host } : {}),
-            ...(cfg.smtp_port != null ? { smtpPort: cfg.smtp_port } : {}),
-            ...(cfg.smtp_secure != null ? { smtpSecure: cfg.smtp_secure } : {}),
-          },
-        }));
-        // Save password as runtime secret before showing success
-        if (cfg.password) {
-          try {
-            await setRuntimeSecret(props.token, 'EMAIL_PASSWORD', cfg.password);
-            props.onSecretSaved();
-          } catch (err) {
-            toast.error('Password could not be saved', getErrorMessage(err));
-            toast.info(
-              'Email fields were populated, but password was not saved.',
-            );
-            return;
-          }
-        }
-        toast.success(
-          `HybridAI agent email config loaded from handle "${withConfig.handle}".`,
-        );
-      } else {
-        // No email_config in handles — show available handles info
+      const creds = result?.credentials;
+      if (!creds) {
         const summary = handles
           .map((h) => `${h.handle} (${h.status})`)
           .join(', ');
         toast.info(
-          `HybridAI agent handles found: ${summary}. No agent email config attached.`,
+          `Handles found: ${summary}. Could not retrieve mailbox credentials.`,
         );
+        return;
       }
+
+      props.updateDraft((current) => ({
+        ...current,
+        email: {
+          ...current.email,
+          ...(creds.email ? { address: creds.email } : {}),
+          ...(creds.imap_host ? { imapHost: creds.imap_host } : {}),
+          ...(creds.imap_port != null ? { imapPort: creds.imap_port } : {}),
+          ...(creds.smtp_host ? { smtpHost: creds.smtp_host } : {}),
+          ...(creds.smtp_port != null ? { smtpPort: creds.smtp_port } : {}),
+        },
+      }));
+
+      // Save password as runtime secret before showing success
+      if (creds.password) {
+        try {
+          await setRuntimeSecret(
+            props.token,
+            'EMAIL_PASSWORD',
+            creds.password,
+          );
+          props.onSecretSaved();
+        } catch (err) {
+          toast.error('Password could not be saved', getErrorMessage(err));
+          toast.info(
+            'Email fields were populated, but password was not saved.',
+          );
+          return;
+        }
+      }
+
+      const label = result.handleId || 'HybridAI';
+      toast.success(`Email config loaded from ${label}.`);
     } catch (error) {
       toast.error('Failed to fetch email config', getErrorMessage(error));
     } finally {

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -2929,6 +2929,48 @@ async function handleApiAdminConfig(
   sendJson(res, 200, saveGatewayAdminConfig(body.config as RuntimeConfig));
 }
 
+function extractUpstreamError(payload: unknown, status: number): string {
+  const record = payload as Record<string, unknown> | null;
+  const nested = record?.error;
+  return String(
+    (typeof record?.message === 'string' && record.message) ||
+      (typeof nested === 'string' && nested) ||
+      (nested &&
+        typeof nested === 'object' &&
+        typeof (nested as Record<string, unknown>).message === 'string' &&
+        (nested as Record<string, unknown>).message) ||
+      `HybridAI API returned HTTP ${status}`,
+  );
+}
+
+async function hybridAIFetch(
+  baseUrl: string,
+  apiKey: string,
+  path: string,
+  method: 'GET' | 'POST' = 'GET',
+): Promise<{ ok: boolean; status: number; payload: unknown }> {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers: { Authorization: `Bearer ${apiKey}` },
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  const contentType = response.headers.get('content-type') || '';
+  let payload: unknown;
+  if (contentType.includes('application/json')) {
+    payload = await response.json().catch(() => null);
+  } else {
+    const text = await response.text().catch(() => '');
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      payload = text;
+    }
+  }
+
+  return { ok: response.ok, status: response.status, payload };
+}
+
 async function handleApiAdminEmailConfigFetch(
   res: ServerResponse,
 ): Promise<void> {
@@ -2948,12 +2990,14 @@ async function handleApiAdminEmailConfigFetch(
     '',
   );
 
-  let response: Response;
+  // Step 1: list agent handles
+  let handlesResult: { ok: boolean; status: number; payload: unknown };
   try {
-    response = await fetch(`${baseUrl}/api/v1/agent-handles/`, {
-      headers: { Authorization: `Bearer ${apiKey}` },
-      signal: AbortSignal.timeout(10_000),
-    });
+    handlesResult = await hybridAIFetch(
+      baseUrl,
+      apiKey,
+      '/api/v1/agent-handles/',
+    );
   } catch (error) {
     sendJson(res, 502, {
       error: `Could not reach HybridAI API: ${error instanceof Error ? error.message : String(error)}`,
@@ -2961,40 +3005,65 @@ async function handleApiAdminEmailConfigFetch(
     return;
   }
 
-  const contentType = response.headers.get('content-type') || '';
-  let payload: unknown;
-  if (contentType.includes('application/json')) {
-    payload = await response.json().catch(() => null);
-  } else {
-    const text = await response.text().catch(() => '');
-    try {
-      payload = JSON.parse(text);
-    } catch {
-      payload = text;
-    }
+  if (!handlesResult.ok) {
+    sendJson(res, 502, {
+      error: extractUpstreamError(handlesResult.payload, handlesResult.status),
+    });
+    return;
   }
 
-  if (!response.ok) {
-    const record = payload as Record<string, unknown> | null;
-    const nested = record?.error;
-    const msg =
-      (typeof record?.message === 'string' && record.message) ||
-      (typeof nested === 'string' && nested) ||
-      (nested &&
-        typeof nested === 'object' &&
-        typeof (nested as Record<string, unknown>).message === 'string' &&
-        (nested as Record<string, unknown>).message) ||
-      `HybridAI API returned HTTP ${response.status}`;
-    // Map all upstream errors to 502 so that 401/403 from HybridAI doesn't
-    // get mistaken for a gateway auth failure (which would clear WEB_API_TOKEN).
+  const handlesPayload = handlesResult.payload as {
+    handles?: Array<{ id?: string; handle?: string; status?: string }>;
+  };
+  const handles = Array.isArray(handlesPayload?.handles)
+    ? handlesPayload.handles
+    : [];
+
+  if (handles.length === 0) {
+    res.setHeader('Cache-Control', 'no-store');
+    sendJson(res, 200, { handles: [], credentials: null });
+    return;
+  }
+
+  // Step 2: fetch mailbox credentials for the first active handle
+  const activeHandle =
+    handles.find((h) => h.status === 'active') || handles[0];
+  const handleId = activeHandle.id || activeHandle.handle;
+
+  if (!handleId) {
+    res.setHeader('Cache-Control', 'no-store');
+    sendJson(res, 200, { handles, credentials: null });
+    return;
+  }
+
+  let credResult: { ok: boolean; status: number; payload: unknown };
+  try {
+    credResult = await hybridAIFetch(
+      baseUrl,
+      apiKey,
+      `/api/v1/agent-handles/${encodeURIComponent(handleId)}/mailbox/credentials`,
+      'POST',
+    );
+  } catch (error) {
     sendJson(res, 502, {
-      error: String(msg),
+      error: `Could not fetch mailbox credentials: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    return;
+  }
+
+  if (!credResult.ok) {
+    sendJson(res, 502, {
+      error: extractUpstreamError(credResult.payload, credResult.status),
     });
     return;
   }
 
   res.setHeader('Cache-Control', 'no-store');
-  sendJson(res, 200, payload);
+  sendJson(res, 200, {
+    handles,
+    credentials: credResult.payload,
+    handleId,
+  });
 }
 
 async function handleApiAdminModels(

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -31,6 +31,7 @@ import {
   MSTEAMS_WEBHOOK_PATH,
   WEB_API_TOKEN,
 } from '../config/config.js';
+import { getHybridAIApiKey } from '../auth/hybridai-auth.js';
 import type {
   RuntimeConfig,
   RuntimeDiscordChannelConfig,
@@ -2928,6 +2929,65 @@ async function handleApiAdminConfig(
   sendJson(res, 200, saveGatewayAdminConfig(body.config as RuntimeConfig));
 }
 
+async function handleApiAdminEmailConfigFetch(
+  res: ServerResponse,
+): Promise<void> {
+  let apiKey: string;
+  try {
+    apiKey = getHybridAIApiKey();
+  } catch {
+    sendJson(res, 400, {
+      error:
+        'HYBRIDAI_API_KEY is not configured. Run `hybridclaw auth login hybridai` first.',
+    });
+    return;
+  }
+
+  const baseUrl = (HYBRIDAI_BASE_URL || 'https://hybridai.one').replace(
+    /\/+$/,
+    '',
+  );
+
+  let response: Response;
+  try {
+    response = await fetch(`${baseUrl}/api/v1/agent-handles/`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (error) {
+    sendJson(res, 502, {
+      error: `Could not reach HybridAI API: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    return;
+  }
+
+  const contentType = response.headers.get('content-type') || '';
+  let payload: unknown;
+  if (contentType.includes('application/json')) {
+    payload = await response.json().catch(() => null);
+  } else {
+    const text = await response.text().catch(() => '');
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      payload = text;
+    }
+  }
+
+  if (!response.ok) {
+    const msg =
+      (payload as Record<string, unknown>)?.message ||
+      (payload as Record<string, unknown>)?.error ||
+      `HybridAI API returned HTTP ${response.status}`;
+    sendJson(res, response.status >= 500 ? 502 : response.status, {
+      error: String(msg),
+    });
+    return;
+  }
+
+  sendJson(res, 200, payload);
+}
+
 async function handleApiAdminModels(
   req: IncomingMessage,
   res: ServerResponse,
@@ -3838,6 +3898,13 @@ export function startGatewayHttpServer(): GatewayHttpServer {
             (method === 'GET' || method === 'PUT')
           ) {
             await handleApiAdminConfig(req, res);
+            return;
+          }
+          if (
+            pathname === '/api/admin/email-config/fetch' &&
+            method === 'GET'
+          ) {
+            await handleApiAdminEmailConfigFetch(res);
             return;
           }
           if (pathname === '/api/admin/audit' && method === 'GET') {

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 import { createSilentReplyStreamFilter } from '../agent/silent-reply-stream.js';
 import { getAgentById, resolveAgentConfig } from '../agents/agent-registry.js';
 import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
+import { getHybridAIApiKey } from '../auth/hybridai-auth.js';
 import {
   type DiscordToolActionRequest,
   normalizeDiscordToolAction,
@@ -31,7 +32,6 @@ import {
   MSTEAMS_WEBHOOK_PATH,
   WEB_API_TOKEN,
 } from '../config/config.js';
-import { getHybridAIApiKey } from '../auth/hybridai-auth.js';
 import type {
   RuntimeConfig,
   RuntimeDiscordChannelConfig,
@@ -2979,7 +2979,9 @@ async function handleApiAdminEmailConfigFetch(
       (payload as Record<string, unknown>)?.message ||
       (payload as Record<string, unknown>)?.error ||
       `HybridAI API returned HTTP ${response.status}`;
-    sendJson(res, response.status >= 500 ? 502 : response.status, {
+    // Map all upstream errors to 502 so that 401/403 from HybridAI doesn't
+    // get mistaken for a gateway auth failure (which would clear WEB_API_TOKEN).
+    sendJson(res, 502, {
       error: String(msg),
     });
     return;

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -2975,9 +2975,15 @@ async function handleApiAdminEmailConfigFetch(
   }
 
   if (!response.ok) {
+    const record = payload as Record<string, unknown> | null;
+    const nested = record?.error;
     const msg =
-      (payload as Record<string, unknown>)?.message ||
-      (payload as Record<string, unknown>)?.error ||
+      (typeof record?.message === 'string' && record.message) ||
+      (typeof nested === 'string' && nested) ||
+      (nested &&
+        typeof nested === 'object' &&
+        typeof (nested as Record<string, unknown>).message === 'string' &&
+        (nested as Record<string, unknown>).message) ||
       `HybridAI API returned HTTP ${response.status}`;
     // Map all upstream errors to 502 so that 401/403 from HybridAI doesn't
     // get mistaken for a gateway auth failure (which would clear WEB_API_TOKEN).
@@ -2987,6 +2993,7 @@ async function handleApiAdminEmailConfigFetch(
     return;
   }
 
+  res.setHeader('Cache-Control', 'no-store');
   sendJson(res, 200, payload);
 }
 

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -3635,6 +3635,7 @@ export function buildTokenUsageAuditPayload(
 
 export async function getGatewayStatus(): Promise<GatewayStatus> {
   const codex = getCodexAuthStatus();
+  const hybridai = getHybridAIAuthStatus();
   const [localBackendsResult, hybridaiResult, whatsappAuthResult] =
     await Promise.allSettled([
       localBackendsProbe.get(),
@@ -3748,6 +3749,10 @@ export async function getGatewayStatus(): Promise<GatewayStatus> {
       accountId: codex.accountId,
       expiresAt: codex.expiresAt,
       reloginRequired: codex.reloginRequired,
+    },
+    hybridai: {
+      apiKeyConfigured: hybridai.authenticated,
+      apiKeySource: hybridai.source,
     },
     sandbox,
     observability: getObservabilityIngestState(),

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -356,6 +356,10 @@ export interface GatewayStatus {
     expiresAt: number | null;
     reloginRequired: boolean;
   };
+  hybridai?: {
+    apiKeyConfigured: boolean;
+    apiKeySource: 'env' | 'runtime-secrets' | null;
+  };
   sandbox?: {
     mode: 'container' | 'host';
     modeExplicit: boolean;

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -6,6 +6,7 @@ import { afterEach, expect, test, vi } from 'vitest';
 import type { RuntimeConfig } from '../src/config/runtime-config.js';
 
 const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_CWD = process.cwd();
 const ORIGINAL_DISCORD_TOKEN = process.env.DISCORD_TOKEN;
 const ORIGINAL_HYBRIDAI_API_KEY = process.env.HYBRIDAI_API_KEY;
 const ORIGINAL_OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
@@ -66,6 +67,7 @@ afterEach(() => {
   vi.doUnmock('../src/providers/local-health.js');
   vi.resetModules();
   restoreEnvVar('HOME', ORIGINAL_HOME);
+  process.chdir(ORIGINAL_CWD);
   restoreEnvVar('DISCORD_TOKEN', ORIGINAL_DISCORD_TOKEN);
   restoreEnvVar('HYBRIDAI_API_KEY', ORIGINAL_HYBRIDAI_API_KEY);
   restoreEnvVar('OPENROUTER_API_KEY', ORIGINAL_OPENROUTER_API_KEY);
@@ -216,6 +218,10 @@ test('getGatewayStatus includes Codex auth state', async () => {
     );
   expect(codexRequest).toBeDefined();
   expect(codexRequest?.url.searchParams.get('client_version')).toBeTruthy();
+  expect(status.hybridai).toEqual({
+    apiKeyConfigured: true,
+    apiKeySource: 'env',
+  });
   expect(status.providerHealth?.hybridai).toMatchObject({
     kind: 'remote',
     reachable: true,
@@ -691,6 +697,32 @@ test('getGatewayStatus includes voice Twilio credential status', async () => {
     authTokenSource: 'runtime-secrets',
     webhookPath: '/voice',
     maxConcurrentCalls: 8,
+  });
+});
+
+test('getGatewayStatus reports missing HybridAI API keys separately from provider health', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  delete process.env.HYBRIDAI_API_KEY;
+  process.chdir(homeDir);
+  vi.resetModules();
+  mockHealthProbes();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { getGatewayStatus } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  const status = await getGatewayStatus();
+
+  expect(status.hybridai).toEqual({
+    apiKeyConfigured: false,
+    apiKeySource: null,
+  });
+  expect(status.providerHealth?.hybridai).toMatchObject({
+    kind: 'remote',
+    reachable: false,
   });
 });
 


### PR DESCRIPTION
Adds a button that calls the HybridAI agent handles API to retrieve email configuration and auto-populate IMAP/SMTP fields.