### PR TITLE
chore: use npm ci in CI and align Node.js version across workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           cache: npm
 
       - name: Install test dependencies (e2e)
-        run: npm install
+        run: npm ci
 
       - name: Gateway e2e tests (local, no API key)
         if: matrix.name == 'gateway'
@@ -90,7 +90,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Install container dependencies
         run: npm run setup
@@ -196,7 +196,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build release artifacts
         run: npm run build

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -250,7 +250,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 24
+          node-version: 22
+          cache: npm
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

- **`npm install` → `npm ci`**: All three jobs in `ci.yml` (`docker-preflight`, `unit-tests`, `npm-e2e`) were using `npm install` during CI runs. Replaced with `npm ci` for lockfile-exact reproducible installs — `npm ci` is faster, respects the lockfile strictly, and fails if the lockfile is out of sync with `package.json`.
- **Node.js version alignment**: `publish-release.yml`'s `publish-npm` job was using `node-version: 24` while `ci.yml` uses `22`. Aligned the release job to `22` to match the `engines.node: "22.x"` field in `package.json` and ensure test and release environments run on the same Node.js version.
- **Added `cache: npm`** to the `publish-npm` job's `setup-node` step, consistent with all other Node.js steps in both workflow files.

## Test plan

- [ ] Verify CI workflow passes on this PR (all three jobs use `npm ci`)
- [ ] Verify no unintended changes to `npm run setup` or any other npm script invocations
- [ ] Confirm `publish-release.yml` diff is limited to `node-version: 22` and `cache: npm` addition