### PR TITLE
[codex] Add versioned admin agent markdown editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Coming up]
 
+### Added
+
+- **Admin agent file editor**: The admin console now includes `/admin/agents`
+  for editing each registered agent's allowlisted workspace bootstrap markdown
+  files, with saved revision history and restore controls.
+
 ### Changed
 
 - **Interactive TUI approval picker**: Local TUI approval requests open a

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ hybridclaw tui
 Open locally:
 
 - Chat UI: `http://127.0.0.1:9090/chat`
-- Admin UI: `http://127.0.0.1:9090/admin` for channels, scheduler, audit, and config
+- Admin UI: `http://127.0.0.1:9090/admin` for channels, agent files,
+  scheduler, audit, and config
 - Agents UI: `http://127.0.0.1:9090/agents`
 - OpenAI-compatible API: `http://127.0.0.1:9090/v1/models` and `http://127.0.0.1:9090/v1/chat/completions`
 
@@ -92,7 +93,8 @@ operator and maintainer manual lives at
 Once the gateway is running, open HybridClaw locally:
 
 - Web Chat: `http://127.0.0.1:9090/chat`
-- Admin Console: `http://127.0.0.1:9090/admin` for channels, scheduler, audit, and config
+- Admin Console: `http://127.0.0.1:9090/admin` for channels, agent files,
+  scheduler, audit, and config
 - Agent Dashboard: `http://127.0.0.1:9090/agents`
 - or connect Slack, WhatsApp, Telegram, Discord, Microsoft Teams, Email
 
@@ -130,6 +132,7 @@ Once the gateway is running, open HybridClaw locally:
 ## Built for real workflows
 
 - channels
+- versioned agent workspace prompt files
 - browser sessions
 - office docs
 - skills / plugins / MCP

--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -1,6 +1,10 @@
 import type {
   AdminAdaptiveSkillAmendmentsResponse,
   AdminAdaptiveSkillHealthResponse,
+  AdminAgent,
+  AdminAgentMarkdownFileResponse,
+  AdminAgentMarkdownRevisionResponse,
+  AdminAgentsResponse,
   AdminAuditResponse,
   AdminChannelConfig,
   AdminChannelsResponse,
@@ -181,6 +185,76 @@ export function adminTerminalSocketUrl(
 
 export function fetchAgentsOverview(token: string): Promise<AgentsOverview> {
   return requestJson<AgentsOverviewResponse>('/api/agents', { token });
+}
+
+export async function fetchAdminAgents(token: string): Promise<AdminAgent[]> {
+  const payload = await requestJson<AdminAgentsResponse>('/api/admin/agents', {
+    token,
+  });
+  return payload.agents;
+}
+
+export function fetchAdminAgentMarkdownFile(
+  token: string,
+  params: {
+    agentId: string;
+    fileName: string;
+  },
+): Promise<AdminAgentMarkdownFileResponse> {
+  return requestJson<AdminAgentMarkdownFileResponse>(
+    `/api/admin/agents/${encodeURIComponent(params.agentId)}/files/${encodeURIComponent(params.fileName)}`,
+    { token },
+  );
+}
+
+export function saveAdminAgentMarkdownFile(
+  token: string,
+  params: {
+    agentId: string;
+    fileName: string;
+    content: string;
+  },
+): Promise<AdminAgentMarkdownFileResponse> {
+  return requestJson<AdminAgentMarkdownFileResponse>(
+    `/api/admin/agents/${encodeURIComponent(params.agentId)}/files/${encodeURIComponent(params.fileName)}`,
+    {
+      token,
+      method: 'PUT',
+      body: { content: params.content },
+    },
+  );
+}
+
+export function fetchAdminAgentMarkdownRevision(
+  token: string,
+  params: {
+    agentId: string;
+    fileName: string;
+    revisionId: string;
+  },
+): Promise<AdminAgentMarkdownRevisionResponse> {
+  return requestJson<AdminAgentMarkdownRevisionResponse>(
+    `/api/admin/agents/${encodeURIComponent(params.agentId)}/files/${encodeURIComponent(params.fileName)}/revisions/${encodeURIComponent(params.revisionId)}`,
+    { token },
+  );
+}
+
+export function restoreAdminAgentMarkdownRevision(
+  token: string,
+  params: {
+    agentId: string;
+    fileName: string;
+    revisionId: string;
+  },
+): Promise<AdminAgentMarkdownFileResponse> {
+  return requestJson<AdminAgentMarkdownFileResponse>(
+    `/api/admin/agents/${encodeURIComponent(params.agentId)}/files/${encodeURIComponent(params.fileName)}/revisions/${encodeURIComponent(params.revisionId)}/restore`,
+    {
+      token,
+      method: 'POST',
+      body: {},
+    },
+  );
 }
 
 export function fetchJobsContext(

--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -252,7 +252,6 @@ export function restoreAdminAgentMarkdownRevision(
     {
       token,
       method: 'POST',
-      body: {},
     },
   );
 }

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -599,6 +599,54 @@ export interface AdminSchedulerResponse {
   jobs: AdminSchedulerJob[];
 }
 
+export interface AdminAgentMarkdownFile {
+  name: string;
+  path: string;
+  exists: boolean;
+  updatedAt: string | null;
+  sizeBytes: number | null;
+}
+
+export interface AdminAgentMarkdownRevision {
+  id: string;
+  createdAt: string;
+  sizeBytes: number;
+  sha256: string;
+  source: 'save' | 'restore';
+}
+
+export interface AdminAgent {
+  id: string;
+  name: string | null;
+  model: string | null;
+  skills: string[] | null;
+  chatbotId: string | null;
+  enableRag: boolean | null;
+  workspace: string | null;
+  workspacePath: string;
+  markdownFiles: AdminAgentMarkdownFile[];
+}
+
+export interface AdminAgentsResponse {
+  agents: AdminAgent[];
+}
+
+export interface AdminAgentMarkdownFileResponse {
+  agent: AdminAgent;
+  file: AdminAgentMarkdownFile & {
+    content: string;
+    revisions: AdminAgentMarkdownRevision[];
+  };
+}
+
+export interface AdminAgentMarkdownRevisionResponse {
+  agent: AdminAgent;
+  fileName: string;
+  revision: AdminAgentMarkdownRevision & {
+    content: string;
+  };
+}
+
 export interface AgentCard {
   id: string;
   name: string | null;

--- a/console/src/components/sidebar/navigation.ts
+++ b/console/src/components/sidebar/navigation.ts
@@ -1,5 +1,6 @@
 import type { ComponentType } from 'react';
 import {
+  Agents,
   Audit,
   Channels,
   Cog,
@@ -54,6 +55,7 @@ export const SIDEBAR_NAV_GROUPS: ReadonlyArray<SidebarNavGroup> = [
   {
     label: 'Configuration',
     items: [
+      { to: '/agents', label: 'Agent Files', icon: Agents },
       { to: '/skills', label: 'Skills', icon: Skills },
       { to: '/plugins', label: 'Plugins', icon: Plugins },
       { to: '/tools', label: 'Tools', icon: Tools },

--- a/console/src/router.tsx
+++ b/console/src/router.tsx
@@ -6,6 +6,7 @@ import {
 } from '@tanstack/react-router';
 import { lazy, Suspense } from 'react';
 import { AppShell } from './components/app-shell';
+import { AgentFilesPage } from './routes/agents';
 import { AuditPage } from './routes/audit';
 import { ChannelsPage } from './routes/channels';
 import { ConfigPage } from './routes/config';
@@ -50,6 +51,12 @@ const dashboardRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/',
   component: DashboardPage,
+});
+
+const agentFilesRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/agents',
+  component: AgentFilesPage,
 });
 
 const terminalRoute = createRoute({
@@ -138,6 +145,7 @@ const toolsRoute = createRoute({
 
 const routeTree = rootRoute.addChildren([
   dashboardRoute,
+  agentFilesRoute,
   terminalRoute,
   gatewayRoute,
   sessionsRoute,

--- a/console/src/routes/agents.test.tsx
+++ b/console/src/routes/agents.test.tsx
@@ -179,7 +179,9 @@ describe('AgentFilesPage', () => {
     renderPage();
 
     expect(await screen.findByDisplayValue('# Main Rules')).not.toBeNull();
-    fireEvent.click(screen.getByRole('button', { name: /writer/i }));
+    fireEvent.change(screen.getByLabelText('Agent'), {
+      target: { value: 'writer' },
+    });
 
     expect(await screen.findByDisplayValue('# Writer Rules')).not.toBeNull();
     expect(fetchAdminAgentMarkdownFileMock).toHaveBeenCalledWith('test-token', {

--- a/console/src/routes/agents.test.tsx
+++ b/console/src/routes/agents.test.tsx
@@ -1,0 +1,296 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  AdminAgent,
+  AdminAgentMarkdownFileResponse,
+  AdminAgentMarkdownRevisionResponse,
+} from '../api/types';
+import { ToastProvider } from '../components/toast';
+import { AgentFilesPage } from './agents';
+
+const fetchAdminAgentsMock = vi.fn<() => Promise<AdminAgent[]>>();
+const fetchAdminAgentMarkdownFileMock =
+  vi.fn<
+    (
+      token: string,
+      params: { agentId: string; fileName: string },
+    ) => Promise<AdminAgentMarkdownFileResponse>
+  >();
+const fetchAdminAgentMarkdownRevisionMock =
+  vi.fn<
+    (
+      token: string,
+      params: { agentId: string; fileName: string; revisionId: string },
+    ) => Promise<AdminAgentMarkdownRevisionResponse>
+  >();
+const restoreAdminAgentMarkdownRevisionMock = vi.fn();
+const saveAdminAgentMarkdownFileMock = vi.fn();
+const useAuthMock = vi.fn();
+
+vi.mock('../api/client', () => ({
+  fetchAdminAgents: () => fetchAdminAgentsMock(),
+  fetchAdminAgentMarkdownFile: (
+    token: string,
+    params: { agentId: string; fileName: string },
+  ) => fetchAdminAgentMarkdownFileMock(token, params),
+  fetchAdminAgentMarkdownRevision: (
+    token: string,
+    params: { agentId: string; fileName: string; revisionId: string },
+  ) => fetchAdminAgentMarkdownRevisionMock(token, params),
+  restoreAdminAgentMarkdownRevision: (
+    token: string,
+    params: { agentId: string; fileName: string; revisionId: string },
+  ) => restoreAdminAgentMarkdownRevisionMock(token, params),
+  saveAdminAgentMarkdownFile: (
+    token: string,
+    params: { agentId: string; fileName: string; content: string },
+  ) => saveAdminAgentMarkdownFileMock(token, params),
+}));
+
+vi.mock('../auth', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+function makeAgent(overrides: Partial<AdminAgent>): AdminAgent {
+  return {
+    id: 'main',
+    name: 'Main Agent',
+    model: 'gpt-5',
+    skills: null,
+    chatbotId: null,
+    enableRag: true,
+    workspace: null,
+    workspacePath: '/tmp/main/workspace',
+    markdownFiles: [
+      {
+        name: 'AGENTS.md',
+        path: '/tmp/main/workspace/AGENTS.md',
+        exists: true,
+        updatedAt: '2026-04-13T10:00:00.000Z',
+        sizeBytes: 120,
+      },
+      {
+        name: 'USER.md',
+        path: '/tmp/main/workspace/USER.md',
+        exists: false,
+        updatedAt: null,
+        sizeBytes: null,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeDocument(
+  agent: AdminAgent,
+  fileName: string,
+  content: string,
+): AdminAgentMarkdownFileResponse {
+  const file =
+    agent.markdownFiles.find((entry) => entry.name === fileName) ||
+    agent.markdownFiles[0];
+  if (!file) {
+    throw new Error(`Missing file ${fileName}`);
+  }
+  return {
+    agent,
+    file: {
+      ...file,
+      content,
+      revisions: [
+        {
+          id: 'rev-1',
+          createdAt: '2026-04-13T09:00:00.000Z',
+          sizeBytes: 80,
+          sha256: 'abc123',
+          source: 'save',
+        },
+      ],
+    },
+  };
+}
+
+function renderPage(): QueryClient {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ToastProvider>
+        <AgentFilesPage />
+      </ToastProvider>
+    </QueryClientProvider>,
+  );
+
+  return queryClient;
+}
+
+describe('AgentFilesPage', () => {
+  beforeEach(() => {
+    fetchAdminAgentsMock.mockReset();
+    fetchAdminAgentMarkdownFileMock.mockReset();
+    fetchAdminAgentMarkdownRevisionMock.mockReset();
+    restoreAdminAgentMarkdownRevisionMock.mockReset();
+    saveAdminAgentMarkdownFileMock.mockReset();
+    useAuthMock.mockReset();
+    useAuthMock.mockReturnValue({
+      token: 'test-token',
+    });
+  });
+
+  it('loads the selected agent markdown file and switches agents', async () => {
+    const mainAgent = makeAgent({});
+    const writerAgent = makeAgent({
+      id: 'writer',
+      name: 'Writer',
+      model: null,
+      workspacePath: '/tmp/writer/workspace',
+      markdownFiles: [
+        {
+          name: 'AGENTS.md',
+          path: '/tmp/writer/workspace/AGENTS.md',
+          exists: false,
+          updatedAt: null,
+          sizeBytes: null,
+        },
+        {
+          name: 'USER.md',
+          path: '/tmp/writer/workspace/USER.md',
+          exists: true,
+          updatedAt: '2026-04-13T11:00:00.000Z',
+          sizeBytes: 42,
+        },
+      ],
+    });
+
+    fetchAdminAgentsMock.mockResolvedValue([mainAgent, writerAgent]);
+    fetchAdminAgentMarkdownFileMock.mockImplementation(
+      async (_token, params) =>
+        params.agentId === 'writer'
+          ? makeDocument(writerAgent, params.fileName, '# Writer Rules')
+          : makeDocument(mainAgent, params.fileName, '# Main Rules'),
+    );
+
+    renderPage();
+
+    expect(await screen.findByDisplayValue('# Main Rules')).not.toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /writer/i }));
+
+    expect(await screen.findByDisplayValue('# Writer Rules')).not.toBeNull();
+    expect(fetchAdminAgentMarkdownFileMock).toHaveBeenCalledWith('test-token', {
+      agentId: 'writer',
+      fileName: 'AGENTS.md',
+    });
+  });
+
+  it('saves edited markdown content for the selected agent file', async () => {
+    const agent = makeAgent({});
+    fetchAdminAgentsMock.mockResolvedValue([agent]);
+    fetchAdminAgentMarkdownFileMock.mockResolvedValue(
+      makeDocument(agent, 'AGENTS.md', '# Original Rules'),
+    );
+    saveAdminAgentMarkdownFileMock.mockResolvedValue(
+      makeDocument(agent, 'AGENTS.md', '# Updated Rules'),
+    );
+
+    renderPage();
+
+    await screen.findByDisplayValue('# Original Rules');
+    const editor = (await screen.findByLabelText(
+      'AGENTS.md',
+    )) as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: '# Updated Rules' } });
+    await waitFor(() => expect(editor.value).toBe('# Updated Rules'));
+    fireEvent.click(screen.getByRole('button', { name: 'Save Markdown' }));
+
+    await waitFor(() =>
+      expect(saveAdminAgentMarkdownFileMock).toHaveBeenCalledWith(
+        'test-token',
+        {
+          agentId: 'main',
+          fileName: 'AGENTS.md',
+          content: '# Updated Rules',
+        },
+      ),
+    );
+    expect(editor.value).toBe('# Updated Rules');
+  });
+
+  it('loads and restores a saved markdown revision', async () => {
+    const agent = makeAgent({});
+    fetchAdminAgentsMock.mockResolvedValue([agent]);
+    fetchAdminAgentMarkdownFileMock.mockResolvedValue(
+      makeDocument(agent, 'AGENTS.md', '# Current Rules'),
+    );
+    fetchAdminAgentMarkdownRevisionMock.mockResolvedValue({
+      agent,
+      fileName: 'AGENTS.md',
+      revision: {
+        id: 'rev-1',
+        createdAt: '2026-04-13T09:00:00.000Z',
+        sizeBytes: 80,
+        sha256: 'abc123',
+        source: 'save',
+        content: '# Previous Rules',
+      },
+    });
+    restoreAdminAgentMarkdownRevisionMock.mockResolvedValue(
+      makeDocument(agent, 'AGENTS.md', '# Previous Rules'),
+    );
+
+    renderPage();
+
+    await screen.findByDisplayValue('# Current Rules');
+    fireEvent.click(
+      screen.getByText(/80 bytes/i).closest('button') as HTMLButtonElement,
+    );
+
+    expect(await screen.findByDisplayValue('# Previous Rules')).not.toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Restore Version' }));
+
+    await waitFor(() =>
+      expect(restoreAdminAgentMarkdownRevisionMock).toHaveBeenCalledWith(
+        'test-token',
+        {
+          agentId: 'main',
+          fileName: 'AGENTS.md',
+          revisionId: 'rev-1',
+        },
+      ),
+    );
+  });
+
+  it('preserves dirty editor content when the selected file refetches', async () => {
+    const agent = makeAgent({});
+    fetchAdminAgentsMock.mockResolvedValue([agent]);
+    fetchAdminAgentMarkdownFileMock.mockResolvedValue(
+      makeDocument(agent, 'AGENTS.md', '# Original Rules'),
+    );
+
+    const queryClient = renderPage();
+
+    await screen.findByDisplayValue('# Original Rules');
+    const editor = (await screen.findByLabelText(
+      'AGENTS.md',
+    )) as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: '# Draft Rules' } });
+    await waitFor(() => expect(editor.value).toBe('# Draft Rules'));
+
+    fetchAdminAgentMarkdownFileMock.mockResolvedValue(
+      makeDocument(agent, 'AGENTS.md', '# Refetched Rules'),
+    );
+    await queryClient.invalidateQueries({
+      queryKey: ['admin-agent-markdown', 'test-token', 'main', 'AGENTS.md'],
+    });
+
+    await waitFor(() =>
+      expect(fetchAdminAgentMarkdownFileMock).toHaveBeenCalledTimes(2),
+    );
+    expect(editor.value).toBe('# Draft Rules');
+  });
+});

--- a/console/src/routes/agents.tsx
+++ b/console/src/routes/agents.tsx
@@ -10,7 +10,7 @@ import {
 import type { AdminAgent } from '../api/types';
 import { useAuth } from '../auth';
 import { useToast } from '../components/toast';
-import { PageHeader, Panel } from '../components/ui';
+import { Panel } from '../components/ui';
 import { getErrorMessage } from '../lib/error-message';
 import { formatDateTime, formatRelativeTime } from '../lib/format';
 
@@ -219,101 +219,42 @@ export function AgentFilesPage() {
     },
   });
 
-  const existingFileCount =
-    selectedAgent?.markdownFiles.filter((file) => file.exists).length || 0;
-  const totalFileCount = selectedAgent?.markdownFiles.length || 0;
   const isDirty =
     Boolean(fileQuery.data) &&
     draftContent !== (fileQuery.data?.file.content || '');
 
   return (
     <div className="page-stack">
-      <PageHeader
-        title="Agent Files"
-        description="Edit the allowlisted workspace markdown files for any registered agent."
-      />
-
-      <div className="two-column-grid sessions-layout">
-        <Panel
-          title="Agents"
-          subtitle={`${agentsQuery.data?.length || 0} registered agent${agentsQuery.data?.length === 1 ? '' : 's'}`}
-        >
-          {agentsQuery.isLoading ? (
-            <div className="empty-state">Loading agents...</div>
-          ) : !agentsQuery.data?.length ? (
-            <div className="empty-state">No agents are registered yet.</div>
-          ) : (
-            <div className="list-stack selectable-list">
-              {agentsQuery.data.map((agent) => {
-                const presentFiles = agent.markdownFiles.filter(
-                  (file) => file.exists,
-                ).length;
-                return (
-                  <button
-                    key={agent.id}
-                    className={
-                      agent.id === selectedAgent?.id
-                        ? 'selectable-row active'
-                        : 'selectable-row'
-                    }
-                    type="button"
-                    onClick={() => {
-                      setSelectedAgentId(agent.id);
-                      setSelectedRevisionId(null);
-                    }}
-                  >
-                    <div>
-                      <strong>{agent.name || agent.id}</strong>
-                      <small>
-                        {agent.id}
-                        {agent.model
-                          ? ` · ${agent.model}`
-                          : ' · runtime default'}
-                      </small>
-                    </div>
-                    <div className="row-status-stack">
-                      <small>
-                        {presentFiles}/{agent.markdownFiles.length} files
-                      </small>
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
-          )}
-        </Panel>
-
-        <Panel title="Markdown Editor" accent="warm">
-          {!selectedAgent ? (
-            <div className="empty-state">
-              Select an agent to edit its files.
-            </div>
-          ) : !selectedFileName ? (
-            <div className="empty-state">
-              This agent does not expose editable markdown files.
-            </div>
-          ) : (
-            <div className="detail-stack">
-              <div className="key-value-grid">
-                <div>
-                  <span>Agent</span>
-                  <strong>{selectedAgent.name || selectedAgent.id}</strong>
-                </div>
-                <div>
-                  <span>Model</span>
-                  <strong>{selectedAgent.model || 'runtime default'}</strong>
-                </div>
-                <div>
-                  <span>Workspace</span>
-                  <strong>{selectedAgent.workspacePath}</strong>
-                </div>
-                <div>
-                  <span>Markdown files</span>
-                  <strong>
-                    {existingFileCount}/{totalFileCount} present
-                  </strong>
-                </div>
-              </div>
+      <Panel accent="warm">
+        {agentsQuery.isLoading ? (
+          <div className="empty-state">Loading agents...</div>
+        ) : !agentsQuery.data?.length ? (
+          <div className="empty-state">No agents are registered yet.</div>
+        ) : !selectedAgent ? (
+          <div className="empty-state">Select an agent to edit its files.</div>
+        ) : !selectedFileName ? (
+          <div className="empty-state">
+            This agent does not expose editable markdown files.
+          </div>
+        ) : (
+          <div className="detail-stack">
+            <div className="field-grid">
+              <label className="field">
+                <span>Agent</span>
+                <select
+                  value={selectedAgent.id}
+                  onChange={(event) => {
+                    setSelectedAgentId(event.target.value);
+                    setSelectedRevisionId(null);
+                  }}
+                >
+                  {agentsQuery.data.map((agent) => (
+                    <option key={agent.id} value={agent.id}>
+                      {agent.name || agent.id}
+                    </option>
+                  ))}
+                </select>
+              </label>
 
               <label className="field">
                 <span>Markdown file</span>
@@ -331,172 +272,173 @@ export function AgentFilesPage() {
                   ))}
                 </select>
               </label>
-
-              {selectedFileSummary ? (
-                <div className="summary-block">
-                  <span>
-                    {selectedFileSummary.exists
-                      ? `Last updated ${formatRelativeTime(selectedFileSummary.updatedAt || '')} · ${formatDateTime(selectedFileSummary.updatedAt)}`
-                      : 'File not created yet'}
-                  </span>
-                  <p>{selectedFileSummary.path}</p>
-                </div>
-              ) : null}
-
-              {fileQuery.isLoading ? (
-                <div className="empty-state">Loading markdown file...</div>
-              ) : (
-                <>
-                  <label className="field textarea-field">
-                    <span>{selectedFileName}</span>
-                    <textarea
-                      className="code-editor"
-                      rows={28}
-                      value={draftContent}
-                      onChange={(event) => setDraftContent(event.target.value)}
-                    />
-                  </label>
-
-                  <div className="button-row">
-                    <button
-                      className="primary-button"
-                      type="button"
-                      disabled={
-                        saveMutation.isPending || !fileQuery.data || !isDirty
-                      }
-                      onClick={() => saveMutation.mutate()}
-                    >
-                      {saveMutation.isPending ? 'Saving...' : 'Save Markdown'}
-                    </button>
-                    <button
-                      className="ghost-button"
-                      type="button"
-                      disabled={
-                        !fileQuery.data || saveMutation.isPending || !isDirty
-                      }
-                      onClick={() => {
-                        const nextContent = fileQuery.data?.file.content || '';
-                        if (selectedDocumentKey) {
-                          hydratedDocumentKeyRef.current = selectedDocumentKey;
-                        }
-                        hydratedContentRef.current = nextContent;
-                        setDraftContent(nextContent);
-                      }}
-                    >
-                      Reset to Disk
-                    </button>
-                    <p className="supporting-text">
-                      {isDirty
-                        ? 'Unsaved changes.'
-                        : selectedFileSummary?.exists
-                          ? 'Disk copy loaded.'
-                          : 'Saving will create this file in the agent workspace.'}
-                    </p>
-                  </div>
-
-                  <div className="two-column-grid">
-                    <Panel
-                      title="Versions"
-                      subtitle={`${fileQuery.data?.file.revisions.length || 0} saved revision${fileQuery.data?.file.revisions.length === 1 ? '' : 's'}`}
-                    >
-                      {!fileQuery.data?.file.revisions.length ? (
-                        <div className="empty-state">
-                          Revisions appear here after the file changes.
-                        </div>
-                      ) : (
-                        <div className="list-stack selectable-list">
-                          {fileQuery.data.file.revisions.map((revision) => (
-                            <button
-                              key={revision.id}
-                              className={
-                                revision.id === selectedRevisionId
-                                  ? 'selectable-row active'
-                                  : 'selectable-row'
-                              }
-                              type="button"
-                              onClick={() => setSelectedRevisionId(revision.id)}
-                            >
-                              <div>
-                                <strong>
-                                  {formatDateTime(revision.createdAt)}
-                                </strong>
-                                <small>
-                                  {formatRelativeTime(revision.createdAt)} ·{' '}
-                                  {revision.source} · {revision.sizeBytes} bytes
-                                </small>
-                              </div>
-                            </button>
-                          ))}
-                        </div>
-                      )}
-                    </Panel>
-
-                    <Panel title="Version Preview" accent="warm">
-                      {!selectedRevisionId ? (
-                        <div className="empty-state">
-                          Select a saved version to preview or restore it.
-                        </div>
-                      ) : revisionQuery.isLoading ? (
-                        <div className="empty-state">Loading version...</div>
-                      ) : !revisionQuery.data ? (
-                        <div className="empty-state">
-                          Version details are unavailable.
-                        </div>
-                      ) : (
-                        <div className="detail-stack">
-                          <div className="summary-block">
-                            <span>
-                              {formatDateTime(
-                                revisionQuery.data.revision.createdAt,
-                              )}
-                            </span>
-                            <p>
-                              {revisionQuery.data.revision.sha256.slice(0, 16)}{' '}
-                              · {revisionQuery.data.revision.source}
-                            </p>
-                          </div>
-                          <label className="field textarea-field">
-                            <span>Saved content</span>
-                            <textarea
-                              className="code-editor"
-                              rows={14}
-                              readOnly
-                              value={revisionQuery.data.revision.content}
-                            />
-                          </label>
-                          <div className="button-row">
-                            <button
-                              className="primary-button"
-                              type="button"
-                              disabled={restoreMutation.isPending}
-                              onClick={() => restoreMutation.mutate()}
-                            >
-                              {restoreMutation.isPending
-                                ? 'Restoring...'
-                                : 'Restore Version'}
-                            </button>
-                            <button
-                              className="ghost-button"
-                              type="button"
-                              onClick={() =>
-                                setDraftContent(
-                                  revisionQuery.data?.revision.content || '',
-                                )
-                              }
-                            >
-                              Copy to Editor
-                            </button>
-                          </div>
-                        </div>
-                      )}
-                    </Panel>
-                  </div>
-                </>
-              )}
             </div>
-          )}
-        </Panel>
-      </div>
+
+            {selectedFileSummary ? (
+              <div className="agent-file-meta">
+                <p className="supporting-text agent-file-meta-line">
+                  {selectedFileSummary.exists
+                    ? `Last updated ${formatRelativeTime(selectedFileSummary.updatedAt || '')} · ${formatDateTime(selectedFileSummary.updatedAt)} · ${selectedFileSummary.path}`
+                    : 'File not created yet'}
+                </p>
+              </div>
+            ) : null}
+
+            {fileQuery.isLoading ? (
+              <div className="empty-state">Loading markdown file...</div>
+            ) : (
+              <>
+                <label className="field textarea-field">
+                  <span className="agent-file-editor-title">
+                    {selectedFileName}
+                  </span>
+                  <textarea
+                    className="code-editor"
+                    rows={28}
+                    value={draftContent}
+                    onChange={(event) => setDraftContent(event.target.value)}
+                  />
+                </label>
+
+                <div className="button-row">
+                  <button
+                    className="primary-button"
+                    type="button"
+                    disabled={
+                      saveMutation.isPending || !fileQuery.data || !isDirty
+                    }
+                    onClick={() => saveMutation.mutate()}
+                  >
+                    {saveMutation.isPending ? 'Saving...' : 'Save Markdown'}
+                  </button>
+                  <button
+                    className="ghost-button"
+                    type="button"
+                    disabled={
+                      !fileQuery.data || saveMutation.isPending || !isDirty
+                    }
+                    onClick={() => {
+                      const nextContent = fileQuery.data?.file.content || '';
+                      if (selectedDocumentKey) {
+                        hydratedDocumentKeyRef.current = selectedDocumentKey;
+                      }
+                      hydratedContentRef.current = nextContent;
+                      setDraftContent(nextContent);
+                    }}
+                  >
+                    Reset to Disk
+                  </button>
+                  <p className="supporting-text">
+                    {isDirty
+                      ? 'Unsaved changes.'
+                      : selectedFileSummary?.exists
+                        ? 'Disk copy loaded.'
+                        : 'Saving will create this file in the agent workspace.'}
+                  </p>
+                </div>
+
+                <div className="two-column-grid">
+                  <Panel
+                    title="Versions"
+                    subtitle={`${fileQuery.data?.file.revisions.length || 0} saved revision${fileQuery.data?.file.revisions.length === 1 ? '' : 's'}`}
+                  >
+                    {!fileQuery.data?.file.revisions.length ? (
+                      <div className="empty-state">
+                        Revisions appear here after the file changes.
+                      </div>
+                    ) : (
+                      <div className="list-stack selectable-list">
+                        {fileQuery.data.file.revisions.map((revision) => (
+                          <button
+                            key={revision.id}
+                            className={
+                              revision.id === selectedRevisionId
+                                ? 'selectable-row active'
+                                : 'selectable-row'
+                            }
+                            type="button"
+                            onClick={() => setSelectedRevisionId(revision.id)}
+                          >
+                            <div>
+                              <strong>
+                                {formatDateTime(revision.createdAt)}
+                              </strong>
+                              <small>
+                                {formatRelativeTime(revision.createdAt)} ·{' '}
+                                {revision.source} · {revision.sizeBytes} bytes
+                              </small>
+                            </div>
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </Panel>
+
+                  <Panel title="Version Preview" accent="warm">
+                    {!selectedRevisionId ? (
+                      <div className="empty-state">
+                        Select a saved version to preview or restore it.
+                      </div>
+                    ) : revisionQuery.isLoading ? (
+                      <div className="empty-state">Loading version...</div>
+                    ) : !revisionQuery.data ? (
+                      <div className="empty-state">
+                        Version details are unavailable.
+                      </div>
+                    ) : (
+                      <div className="detail-stack">
+                        <div className="summary-block">
+                          <span>
+                            {formatDateTime(
+                              revisionQuery.data.revision.createdAt,
+                            )}
+                          </span>
+                          <p>
+                            {revisionQuery.data.revision.sha256.slice(0, 16)} ·{' '}
+                            {revisionQuery.data.revision.source}
+                          </p>
+                        </div>
+                        <label className="field textarea-field">
+                          <span>Saved content</span>
+                          <textarea
+                            className="code-editor"
+                            rows={14}
+                            readOnly
+                            value={revisionQuery.data.revision.content}
+                          />
+                        </label>
+                        <div className="button-row">
+                          <button
+                            className="primary-button"
+                            type="button"
+                            disabled={restoreMutation.isPending}
+                            onClick={() => restoreMutation.mutate()}
+                          >
+                            {restoreMutation.isPending
+                              ? 'Restoring...'
+                              : 'Restore Version'}
+                          </button>
+                          <button
+                            className="ghost-button"
+                            type="button"
+                            onClick={() =>
+                              setDraftContent(
+                                revisionQuery.data?.revision.content || '',
+                              )
+                            }
+                          >
+                            Copy to Editor
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </Panel>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+      </Panel>
     </div>
   );
 }

--- a/console/src/routes/agents.tsx
+++ b/console/src/routes/agents.tsx
@@ -102,6 +102,10 @@ export function AgentFilesPage() {
     enabled: Boolean(selectedAgent?.id && selectedFileName),
     refetchOnWindowFocus: false,
   });
+  const selectedFileMetadata =
+    fileQuery.data?.file.name === selectedFileName
+      ? fileQuery.data.file
+      : selectedFileSummary;
 
   const revisionQuery = useQuery({
     queryKey: [
@@ -219,9 +223,9 @@ export function AgentFilesPage() {
     },
   });
 
-  const isDirty =
-    Boolean(fileQuery.data) &&
-    draftContent !== (fileQuery.data?.file.content || '');
+  const isDirty = fileQuery.data
+    ? draftContent !== fileQuery.data.file.content
+    : false;
 
   return (
     <div className="page-stack">
@@ -277,8 +281,10 @@ export function AgentFilesPage() {
             {selectedFileSummary ? (
               <div className="agent-file-meta">
                 <p className="supporting-text agent-file-meta-line">
-                  {selectedFileSummary.exists
-                    ? `Last updated ${formatRelativeTime(selectedFileSummary.updatedAt || '')} · ${formatDateTime(selectedFileSummary.updatedAt)} · ${selectedFileSummary.path}`
+                  {selectedFileMetadata?.exists
+                    ? selectedFileMetadata.updatedAt
+                      ? `Last updated ${formatRelativeTime(selectedFileMetadata.updatedAt)} · ${formatDateTime(selectedFileMetadata.updatedAt)} · ${selectedFileMetadata.path}`
+                      : selectedFileMetadata.path
                     : 'File not created yet'}
                 </p>
               </div>

--- a/console/src/routes/agents.tsx
+++ b/console/src/routes/agents.tsx
@@ -1,0 +1,502 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef, useState } from 'react';
+import {
+  fetchAdminAgentMarkdownFile,
+  fetchAdminAgentMarkdownRevision,
+  fetchAdminAgents,
+  restoreAdminAgentMarkdownRevision,
+  saveAdminAgentMarkdownFile,
+} from '../api/client';
+import type { AdminAgent } from '../api/types';
+import { useAuth } from '../auth';
+import { useToast } from '../components/toast';
+import { PageHeader, Panel } from '../components/ui';
+import { getErrorMessage } from '../lib/error-message';
+import { formatDateTime, formatRelativeTime } from '../lib/format';
+
+function getDefaultFileName(agent: AdminAgent | null): string | null {
+  if (!agent) return null;
+  return (
+    agent.markdownFiles.find((file) => file.exists)?.name ||
+    agent.markdownFiles[0]?.name ||
+    null
+  );
+}
+
+function getSelectedDocumentKey(
+  agentId: string | null | undefined,
+  fileName: string | null | undefined,
+): string | null {
+  if (!agentId || !fileName) return null;
+  return `${agentId}:${fileName}`;
+}
+
+export function AgentFilesPage() {
+  const auth = useAuth();
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
+  const [selectedFileName, setSelectedFileName] = useState<string | null>(null);
+  const [selectedRevisionId, setSelectedRevisionId] = useState<string | null>(
+    null,
+  );
+  const [draftContent, setDraftContent] = useState('');
+  const hydratedDocumentKeyRef = useRef<string | null>(null);
+  const hydratedContentRef = useRef('');
+
+  const agentsQuery = useQuery({
+    queryKey: ['admin-agents', auth.token],
+    queryFn: () => fetchAdminAgents(auth.token),
+  });
+
+  const selectedAgent =
+    agentsQuery.data?.find((agent) => agent.id === selectedAgentId) ||
+    agentsQuery.data?.[0] ||
+    null;
+
+  useEffect(() => {
+    if (selectedAgent && selectedAgent.id !== selectedAgentId) {
+      setSelectedAgentId(selectedAgent.id);
+    }
+  }, [selectedAgent, selectedAgentId]);
+
+  useEffect(() => {
+    if (!selectedAgent) {
+      if (selectedFileName !== null) {
+        setSelectedFileName(null);
+        setSelectedRevisionId(null);
+      }
+      return;
+    }
+    const availableFile =
+      selectedAgent.markdownFiles.find((file) => file.name === selectedFileName)
+        ?.name || getDefaultFileName(selectedAgent);
+    if (availableFile !== selectedFileName) {
+      setSelectedFileName(availableFile);
+      setSelectedRevisionId(null);
+    }
+  }, [selectedAgent, selectedFileName]);
+
+  const selectedFileSummary =
+    selectedAgent?.markdownFiles.find(
+      (file) => file.name === selectedFileName,
+    ) || null;
+  const selectedDocumentKey = getSelectedDocumentKey(
+    selectedAgent?.id,
+    selectedFileName,
+  );
+  const selectedFileQueryKey = [
+    'admin-agent-markdown',
+    auth.token,
+    selectedAgent?.id || '',
+    selectedFileName || '',
+  ] as const;
+
+  const fileQuery = useQuery({
+    queryKey: selectedFileQueryKey,
+    queryFn: () =>
+      fetchAdminAgentMarkdownFile(auth.token, {
+        agentId: selectedAgent?.id || '',
+        fileName: selectedFileName || '',
+      }),
+    enabled: Boolean(selectedAgent?.id && selectedFileName),
+    refetchOnWindowFocus: false,
+  });
+
+  const revisionQuery = useQuery({
+    queryKey: [
+      'admin-agent-markdown-revision',
+      auth.token,
+      selectedAgent?.id || '',
+      selectedFileName || '',
+      selectedRevisionId || '',
+    ],
+    queryFn: () =>
+      fetchAdminAgentMarkdownRevision(auth.token, {
+        agentId: selectedAgent?.id || '',
+        fileName: selectedFileName || '',
+        revisionId: selectedRevisionId || '',
+      }),
+    enabled: Boolean(
+      selectedAgent?.id && selectedFileName && selectedRevisionId,
+    ),
+    refetchOnWindowFocus: false,
+  });
+
+  useEffect(() => {
+    if (!selectedDocumentKey) {
+      hydratedDocumentKeyRef.current = null;
+      hydratedContentRef.current = '';
+      setDraftContent('');
+      return;
+    }
+    if (!fileQuery.data) return;
+    const nextContent = fileQuery.data.file.content;
+    const shouldHydrateDraft =
+      hydratedDocumentKeyRef.current !== selectedDocumentKey ||
+      draftContent === hydratedContentRef.current;
+    if (!shouldHydrateDraft) return;
+    hydratedDocumentKeyRef.current = selectedDocumentKey;
+    hydratedContentRef.current = nextContent;
+    setDraftContent(nextContent);
+  }, [draftContent, fileQuery.data, selectedDocumentKey]);
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      if (!selectedAgent || !selectedFileName) {
+        throw new Error('Select an agent and markdown file first.');
+      }
+      return saveAdminAgentMarkdownFile(auth.token, {
+        agentId: selectedAgent.id,
+        fileName: selectedFileName,
+        content: draftContent,
+      });
+    },
+    onSuccess: (payload) => {
+      const nextDocumentKey = getSelectedDocumentKey(
+        payload.agent.id,
+        payload.file.name,
+      );
+      queryClient.setQueryData(
+        [
+          'admin-agent-markdown',
+          auth.token,
+          payload.agent.id,
+          payload.file.name,
+        ],
+        payload,
+      );
+      void queryClient.invalidateQueries({
+        queryKey: ['admin-agents', auth.token],
+      });
+      hydratedDocumentKeyRef.current = nextDocumentKey;
+      hydratedContentRef.current = payload.file.content;
+      setDraftContent(payload.file.content);
+      toast.success(
+        `Saved ${payload.file.name} for ${payload.agent.name || payload.agent.id}.`,
+      );
+    },
+    onError: (error) => {
+      toast.error('Save failed', getErrorMessage(error));
+    },
+  });
+
+  const restoreMutation = useMutation({
+    mutationFn: async () => {
+      if (!selectedAgent || !selectedFileName || !selectedRevisionId) {
+        throw new Error('Select a version to restore first.');
+      }
+      return restoreAdminAgentMarkdownRevision(auth.token, {
+        agentId: selectedAgent.id,
+        fileName: selectedFileName,
+        revisionId: selectedRevisionId,
+      });
+    },
+    onSuccess: (payload) => {
+      const nextDocumentKey = getSelectedDocumentKey(
+        payload.agent.id,
+        payload.file.name,
+      );
+      queryClient.setQueryData(
+        [
+          'admin-agent-markdown',
+          auth.token,
+          payload.agent.id,
+          payload.file.name,
+        ],
+        payload,
+      );
+      void queryClient.invalidateQueries({
+        queryKey: ['admin-agents', auth.token],
+      });
+      hydratedDocumentKeyRef.current = nextDocumentKey;
+      hydratedContentRef.current = payload.file.content;
+      setDraftContent(payload.file.content);
+      toast.success(`Restored ${payload.file.name} from version history.`);
+    },
+    onError: (error) => {
+      toast.error('Restore failed', getErrorMessage(error));
+    },
+  });
+
+  const existingFileCount =
+    selectedAgent?.markdownFiles.filter((file) => file.exists).length || 0;
+  const totalFileCount = selectedAgent?.markdownFiles.length || 0;
+  const isDirty =
+    Boolean(fileQuery.data) &&
+    draftContent !== (fileQuery.data?.file.content || '');
+
+  return (
+    <div className="page-stack">
+      <PageHeader
+        title="Agent Files"
+        description="Edit the allowlisted workspace markdown files for any registered agent."
+      />
+
+      <div className="two-column-grid sessions-layout">
+        <Panel
+          title="Agents"
+          subtitle={`${agentsQuery.data?.length || 0} registered agent${agentsQuery.data?.length === 1 ? '' : 's'}`}
+        >
+          {agentsQuery.isLoading ? (
+            <div className="empty-state">Loading agents...</div>
+          ) : !agentsQuery.data?.length ? (
+            <div className="empty-state">No agents are registered yet.</div>
+          ) : (
+            <div className="list-stack selectable-list">
+              {agentsQuery.data.map((agent) => {
+                const presentFiles = agent.markdownFiles.filter(
+                  (file) => file.exists,
+                ).length;
+                return (
+                  <button
+                    key={agent.id}
+                    className={
+                      agent.id === selectedAgent?.id
+                        ? 'selectable-row active'
+                        : 'selectable-row'
+                    }
+                    type="button"
+                    onClick={() => {
+                      setSelectedAgentId(agent.id);
+                      setSelectedRevisionId(null);
+                    }}
+                  >
+                    <div>
+                      <strong>{agent.name || agent.id}</strong>
+                      <small>
+                        {agent.id}
+                        {agent.model
+                          ? ` · ${agent.model}`
+                          : ' · runtime default'}
+                      </small>
+                    </div>
+                    <div className="row-status-stack">
+                      <small>
+                        {presentFiles}/{agent.markdownFiles.length} files
+                      </small>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </Panel>
+
+        <Panel title="Markdown Editor" accent="warm">
+          {!selectedAgent ? (
+            <div className="empty-state">
+              Select an agent to edit its files.
+            </div>
+          ) : !selectedFileName ? (
+            <div className="empty-state">
+              This agent does not expose editable markdown files.
+            </div>
+          ) : (
+            <div className="detail-stack">
+              <div className="key-value-grid">
+                <div>
+                  <span>Agent</span>
+                  <strong>{selectedAgent.name || selectedAgent.id}</strong>
+                </div>
+                <div>
+                  <span>Model</span>
+                  <strong>{selectedAgent.model || 'runtime default'}</strong>
+                </div>
+                <div>
+                  <span>Workspace</span>
+                  <strong>{selectedAgent.workspacePath}</strong>
+                </div>
+                <div>
+                  <span>Markdown files</span>
+                  <strong>
+                    {existingFileCount}/{totalFileCount} present
+                  </strong>
+                </div>
+              </div>
+
+              <label className="field">
+                <span>Markdown file</span>
+                <select
+                  value={selectedFileName}
+                  onChange={(event) => {
+                    setSelectedFileName(event.target.value);
+                    setSelectedRevisionId(null);
+                  }}
+                >
+                  {selectedAgent.markdownFiles.map((file) => (
+                    <option key={file.name} value={file.name}>
+                      {file.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              {selectedFileSummary ? (
+                <div className="summary-block">
+                  <span>
+                    {selectedFileSummary.exists
+                      ? `Last updated ${formatRelativeTime(selectedFileSummary.updatedAt || '')} · ${formatDateTime(selectedFileSummary.updatedAt)}`
+                      : 'File not created yet'}
+                  </span>
+                  <p>{selectedFileSummary.path}</p>
+                </div>
+              ) : null}
+
+              {fileQuery.isLoading ? (
+                <div className="empty-state">Loading markdown file...</div>
+              ) : (
+                <>
+                  <label className="field textarea-field">
+                    <span>{selectedFileName}</span>
+                    <textarea
+                      className="code-editor"
+                      rows={28}
+                      value={draftContent}
+                      onChange={(event) => setDraftContent(event.target.value)}
+                    />
+                  </label>
+
+                  <div className="button-row">
+                    <button
+                      className="primary-button"
+                      type="button"
+                      disabled={
+                        saveMutation.isPending || !fileQuery.data || !isDirty
+                      }
+                      onClick={() => saveMutation.mutate()}
+                    >
+                      {saveMutation.isPending ? 'Saving...' : 'Save Markdown'}
+                    </button>
+                    <button
+                      className="ghost-button"
+                      type="button"
+                      disabled={
+                        !fileQuery.data || saveMutation.isPending || !isDirty
+                      }
+                      onClick={() => {
+                        const nextContent = fileQuery.data?.file.content || '';
+                        if (selectedDocumentKey) {
+                          hydratedDocumentKeyRef.current = selectedDocumentKey;
+                        }
+                        hydratedContentRef.current = nextContent;
+                        setDraftContent(nextContent);
+                      }}
+                    >
+                      Reset to Disk
+                    </button>
+                    <p className="supporting-text">
+                      {isDirty
+                        ? 'Unsaved changes.'
+                        : selectedFileSummary?.exists
+                          ? 'Disk copy loaded.'
+                          : 'Saving will create this file in the agent workspace.'}
+                    </p>
+                  </div>
+
+                  <div className="two-column-grid">
+                    <Panel
+                      title="Versions"
+                      subtitle={`${fileQuery.data?.file.revisions.length || 0} saved revision${fileQuery.data?.file.revisions.length === 1 ? '' : 's'}`}
+                    >
+                      {!fileQuery.data?.file.revisions.length ? (
+                        <div className="empty-state">
+                          Revisions appear here after the file changes.
+                        </div>
+                      ) : (
+                        <div className="list-stack selectable-list">
+                          {fileQuery.data.file.revisions.map((revision) => (
+                            <button
+                              key={revision.id}
+                              className={
+                                revision.id === selectedRevisionId
+                                  ? 'selectable-row active'
+                                  : 'selectable-row'
+                              }
+                              type="button"
+                              onClick={() => setSelectedRevisionId(revision.id)}
+                            >
+                              <div>
+                                <strong>
+                                  {formatDateTime(revision.createdAt)}
+                                </strong>
+                                <small>
+                                  {formatRelativeTime(revision.createdAt)} ·{' '}
+                                  {revision.source} · {revision.sizeBytes} bytes
+                                </small>
+                              </div>
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </Panel>
+
+                    <Panel title="Version Preview" accent="warm">
+                      {!selectedRevisionId ? (
+                        <div className="empty-state">
+                          Select a saved version to preview or restore it.
+                        </div>
+                      ) : revisionQuery.isLoading ? (
+                        <div className="empty-state">Loading version...</div>
+                      ) : !revisionQuery.data ? (
+                        <div className="empty-state">
+                          Version details are unavailable.
+                        </div>
+                      ) : (
+                        <div className="detail-stack">
+                          <div className="summary-block">
+                            <span>
+                              {formatDateTime(
+                                revisionQuery.data.revision.createdAt,
+                              )}
+                            </span>
+                            <p>
+                              {revisionQuery.data.revision.sha256.slice(0, 16)}{' '}
+                              · {revisionQuery.data.revision.source}
+                            </p>
+                          </div>
+                          <label className="field textarea-field">
+                            <span>Saved content</span>
+                            <textarea
+                              className="code-editor"
+                              rows={14}
+                              readOnly
+                              value={revisionQuery.data.revision.content}
+                            />
+                          </label>
+                          <div className="button-row">
+                            <button
+                              className="primary-button"
+                              type="button"
+                              disabled={restoreMutation.isPending}
+                              onClick={() => restoreMutation.mutate()}
+                            >
+                              {restoreMutation.isPending
+                                ? 'Restoring...'
+                                : 'Restore Version'}
+                            </button>
+                            <button
+                              className="ghost-button"
+                              type="button"
+                              onClick={() =>
+                                setDraftContent(
+                                  revisionQuery.data?.revision.content || '',
+                                )
+                              }
+                            >
+                              Copy to Editor
+                            </button>
+                          </div>
+                        </div>
+                      )}
+                    </Panel>
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+        </Panel>
+      </div>
+    </div>
+  );
+}

--- a/console/src/routes/gateway.test.tsx
+++ b/console/src/routes/gateway.test.tsx
@@ -153,10 +153,8 @@ describe('GatewayPage', () => {
 
     renderGatewayPage();
     fireEvent.click(screen.getByRole('button', { name: 'Restart Gateway' }));
-
     const dialog = screen.getByRole('alertdialog');
     fireEvent.click(within(dialog).getByRole('button', { name: 'Restart' }));
-
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
       await flushMicrotasks();

--- a/console/src/routes/jobs.test.tsx
+++ b/console/src/routes/jobs.test.tsx
@@ -1,13 +1,12 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
-import { ToastProvider } from '../components/toast';
 import type {
   AdminSchedulerJob,
   AdminSchedulerResponse,
   JobSession,
 } from '../api/types';
+import { ToastProvider } from '../components/toast';
 import { JobsPage } from './jobs';
 
 const fetchJobsContextMock = vi.fn();

--- a/console/src/routes/jobs.test.tsx
+++ b/console/src/routes/jobs.test.tsx
@@ -8,6 +8,7 @@ import type {
   AdminSchedulerResponse,
   JobSession,
 } from '../api/types';
+import { ToastProvider } from '../components/toast';
 import { JobsPage } from './jobs';
 
 const fetchJobsContextMock = vi.fn();

--- a/console/src/routes/jobs.test.tsx
+++ b/console/src/routes/jobs.test.tsx
@@ -8,7 +8,6 @@ import type {
   AdminSchedulerResponse,
   JobSession,
 } from '../api/types';
-import { ToastProvider } from '../components/toast';
 import { JobsPage } from './jobs';
 
 const fetchJobsContextMock = vi.fn();

--- a/console/src/styles.css
+++ b/console/src/styles.css
@@ -1050,6 +1050,25 @@ th {
   line-height: 1.55;
 }
 
+.agent-file-meta {
+  min-width: 0;
+}
+
+.agent-file-meta .supporting-text {
+  margin: 0;
+  font-size: 0.82rem;
+  line-height: 1.45;
+  color: var(--muted-foreground);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.agent-file-editor-title {
+  font-weight: 700;
+  color: var(--foreground);
+}
+
 .summary-block-header,
 .jobs-output-actions {
   display: flex;

--- a/docs/content/channels/admin-console.md
+++ b/docs/content/channels/admin-console.md
@@ -1,29 +1,41 @@
 ---
 title: Admin Console
-description: Manage channel status, settings, secrets, and browser-based setup flows from /admin/channels.
+description: Manage channel setup, agent prompt files, and browser-based operator workflows from /admin.
 sidebar_position: 10
 ---
 
 # Admin Console
 
 If the gateway is already running, open
-`http://127.0.0.1:9090/admin/channels` when you want a browser-based setup
-flow instead of the CLI.
+`http://127.0.0.1:9090/admin` when you want browser-based operator workflows
+instead of the CLI. The channel setup page lives at `/admin/channels`, and the
+agent prompt-file editor lives at `/admin/agents`.
 
-## What The Channels Page Can Do
+## What The Admin Console Can Do
 
-- show each transport as `active`, `configured`, or `available`
-- edit Discord, Slack, Telegram, WhatsApp, email, Microsoft Teams, and
-  iMessage settings from one place
-- save `DISCORD_TOKEN`, `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`,
-  `TELEGRAM_BOT_TOKEN`, `EMAIL_PASSWORD`, and `IMESSAGE_PASSWORD` through the
-  same encrypted runtime secret store used by the CLI
-- show the live WhatsApp pairing QR when the transport is enabled but not
-  linked yet
+- `/admin/channels` shows each transport as `active`, `configured`, or
+  `available`
+- `/admin/channels` edits Discord, Slack, Telegram, WhatsApp, email, Microsoft
+  Teams, and iMessage settings from one place
+- `/admin/channels` saves `DISCORD_TOKEN`, `SLACK_BOT_TOKEN`,
+  `SLACK_APP_TOKEN`, `TELEGRAM_BOT_TOKEN`, `EMAIL_PASSWORD`, and
+  `IMESSAGE_PASSWORD` through the same encrypted runtime secret store used by
+  the CLI
+- `/admin/channels` shows the live WhatsApp pairing QR when the transport is
+  enabled but not linked yet
+- `/admin/agents` lets operators pick any registered agent and edit the
+  allowlisted workspace bootstrap markdown files seeded into that agent's
+  runtime workspace
+- `/admin/agents` shows saved revisions for those markdown files and can
+  restore an earlier version without opening the workspace directory manually
 
 Channel edits in `/admin/channels` write the same runtime config that
 `hybridclaw channels ... setup`, `hybridclaw auth login ...`, `/config set`,
 and `/secret set` use.
+
+Agent-file edits in `/admin/agents` update the selected agent's shipped
+workspace bootstrap files such as `AGENTS.md`. The editor is intentionally
+scoped to the built-in allowlist and is not a general workspace file browser.
 
 ## When To Prefer The Admin Console
 
@@ -31,6 +43,8 @@ and `/secret set` use.
 - you prefer browser forms to long CLI flag lists
 - you need the WhatsApp pairing QR in a browser instead of a terminal
 - you want to verify saved settings without editing `config.json` directly
+- you want to update an agent's workspace instructions from the browser
+- you want revision history before restoring an earlier agent prompt file
 - you want to restart a running gateway from `/admin/gateway` without
   switching back to the CLI
 

--- a/docs/content/getting-started/quickstart.md
+++ b/docs/content/getting-started/quickstart.md
@@ -68,6 +68,10 @@ it is set, `/chat`, `/agents`, and `/admin` all reuse the same token gate.
 For access from another machine, keep the gateway on loopback and follow
 [Remote Access](../guides/remote-access.md).
 
+Use `/admin/channels` for transport setup and `/admin/agents` when you need to
+edit an agent's allowlisted workspace markdown files or restore a saved
+revision.
+
 ## Ground A Prompt With Files Or Repo Context
 
 - Web chat accepts uploads and pasted clipboard files or images before send.

--- a/docs/content/reference/faq.md
+++ b/docs/content/reference/faq.md
@@ -118,10 +118,13 @@ with linked-identity routing available when operators want shared continuity.
 Yes. The gateway serves `/admin` for the operator console, `/chat` for the web
 chat UI, `/agents` for the agent/session dashboard, and `/admin/terminal` for
 a browser-based PTY session. The admin console includes Dashboard, Terminal,
-Gateway, Sessions, Jobs, Channels, Bindings, Models, Scheduler, MCP, Audit,
-Skills, Plugins, Tools, and Config pages. The Channels page centralizes
-transport status, managed secrets, and setup controls for Discord, Telegram,
-WhatsApp, email, Microsoft Teams, and iMessage.
+Gateway, Sessions, Jobs, Channels, Email, Models, Scheduler, MCP, Audit,
+Agent Files, Skills, Plugins, Tools, and Config pages. The Channels page
+centralizes transport status, managed secrets, and setup controls for Discord,
+Telegram, WhatsApp, email, Microsoft Teams, and iMessage. The Agent Files page
+at `/admin/agents` lets operators edit the allowlisted workspace markdown
+files for a registered agent, inspect saved revisions, and restore an earlier
+version.
 
 ## Can I extend HybridClaw with plugins?
 

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -2314,25 +2314,28 @@ type ApiAdminAgentsRouteMatch =
 
 function parseApiAdminAgentsRoute(url: URL): ApiAdminAgentsRouteMatch {
   const segments = url.pathname.split('/').filter(Boolean);
-  const agentId = segments[3] ? decodeApiPathSegment(segments[3]) : '';
-  const fileName = segments[5] ? decodeApiPathSegment(segments[5]) : '';
-  const revisionId = segments[7] ? decodeApiPathSegment(segments[7]) : '';
+  const agentId = segments[3] ? decodeApiPathSegment(segments[3]).trim() : '';
+  const fileName = segments[5] ? decodeApiPathSegment(segments[5]).trim() : '';
+  const revisionId = segments[7]
+    ? decodeApiPathSegment(segments[7]).trim()
+    : '';
   const hasFilesPrefix = segments[4] === 'files';
   const hasRevisionsPrefix = segments[6] === 'revisions';
 
   if (segments.length === 3) {
     return { kind: 'collection', isKnownPath: true };
   }
-  if (segments.length === 4) {
+  if (segments.length === 4 && agentId) {
     return { kind: 'agent', isKnownPath: true, agentId };
   }
-  if (segments.length === 6 && hasFilesPrefix && fileName) {
+  if (segments.length === 6 && hasFilesPrefix && agentId && fileName) {
     return { kind: 'file', isKnownPath: true, agentId, fileName };
   }
   if (
     segments.length === 8 &&
     hasFilesPrefix &&
     hasRevisionsPrefix &&
+    agentId &&
     fileName &&
     revisionId
   ) {
@@ -2348,6 +2351,7 @@ function parseApiAdminAgentsRoute(url: URL): ApiAdminAgentsRouteMatch {
     segments.length === 9 &&
     hasFilesPrefix &&
     hasRevisionsPrefix &&
+    agentId &&
     fileName &&
     revisionId &&
     segments[8] === 'restore'
@@ -2371,10 +2375,13 @@ function parseApiAdminAgentsRoute(url: URL): ApiAdminAgentsRouteMatch {
 
 function sendApiAdminAgentError(res: ServerResponse, error: unknown): void {
   const message = error instanceof Error ? error.message : String(error);
+  const isKnownNotFoundMessage =
+    /^Agent ["`].+["`] was not found\.$/.test(message) ||
+    /^Revision ["`].+["`] was not found\.$/.test(message);
   const status =
     error instanceof GatewayRequestError
       ? error.statusCode
-      : /not found/i.test(message)
+      : isKnownNotFoundMessage
         ? 404
         : 400;
   sendJson(res, status, { error: message });
@@ -2386,7 +2393,7 @@ function sendMethodNotAllowed(res: ServerResponse): void {
 
 function requireAdminAgentIdPathValue(agentId: string): string {
   const normalizedAgentId = agentId.trim();
-  if (!normalizedAgentId || normalizedAgentId === 'agents') {
+  if (!normalizedAgentId) {
     throw new GatewayRequestError(400, 'Missing agent id in request path.');
   }
   return normalizedAgentId;

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -111,6 +111,8 @@ import {
   deleteGatewayAdminSession,
   ensureGatewayBootstrapAutostart,
   GatewayRequestError,
+  getGatewayAdminAgentMarkdownFile,
+  getGatewayAdminAgentMarkdownRevision,
   getGatewayAdminAgents,
   getGatewayAdminAudit,
   getGatewayAdminChannels,
@@ -135,6 +137,8 @@ import {
   handleGatewayCommand,
   removeGatewayAdminChannel,
   removeGatewayAdminMcpServer,
+  restoreGatewayAdminAgentMarkdownRevision,
+  saveGatewayAdminAgentMarkdownFile,
   saveGatewayAdminConfig,
   saveGatewayAdminModels,
   setGatewayAdminSkillEnabled,
@@ -2268,98 +2272,180 @@ async function handleApiAdminEmailMessageDelete(
   sendJson(res, 200, await deleteGatewayAdminEmailMessage({ folder, uid }));
 }
 
-async function handleApiAdminAgents(
-  req: IncomingMessage,
-  res: ServerResponse,
-  url: URL,
-): Promise<void> {
-  const method = req.method || 'GET';
-  if (method === 'GET') {
-    sendJson(res, 200, getGatewayAdminAgents());
-    return;
-  }
+type ApiAdminAgentPayloadBody = {
+  id?: unknown;
+  name?: unknown;
+  model?: unknown;
+  skills?: unknown;
+  chatbotId?: unknown;
+  enableRag?: unknown;
+  workspace?: unknown;
+};
 
-  if (method === 'DELETE') {
-    const pathname = url.pathname;
-    const agentId = pathname.split('/').pop()?.trim() || '';
-    if (!agentId || agentId === 'agents') {
-      sendJson(res, 400, { error: 'Missing agent id in request path.' });
-      return;
+type ApiAdminAgentPayload = {
+  id?: string;
+  name?: string;
+  model?: string;
+  skills?: string[] | null;
+  chatbotId?: string;
+  enableRag?: boolean;
+  workspace?: string;
+};
+
+type ApiAdminAgentsRouteMatch =
+  | { kind: 'collection'; isKnownPath: true }
+  | { kind: 'agent'; isKnownPath: true; agentId: string }
+  | { kind: 'file'; isKnownPath: true; agentId: string; fileName: string }
+  | {
+      kind: 'revision';
+      isKnownPath: true;
+      agentId: string;
+      fileName: string;
+      revisionId: string;
     }
-    try {
-      sendJson(res, 200, deleteGatewayAdminAgent(agentId));
-    } catch (error) {
-      sendJson(res, 400, {
-        error: error instanceof Error ? error.message : String(error),
-      });
+  | {
+      kind: 'restore';
+      isKnownPath: true;
+      agentId: string;
+      fileName: string;
+      revisionId: string;
     }
-    return;
+  | { kind: 'unknown'; isKnownPath: boolean };
+
+function parseApiAdminAgentsRoute(url: URL): ApiAdminAgentsRouteMatch {
+  const segments = url.pathname.split('/').filter(Boolean);
+  const agentId = segments[3] ? decodeApiPathSegment(segments[3]) : '';
+  const fileName = segments[5] ? decodeApiPathSegment(segments[5]) : '';
+  const revisionId = segments[7] ? decodeApiPathSegment(segments[7]) : '';
+  const hasFilesPrefix = segments[4] === 'files';
+  const hasRevisionsPrefix = segments[6] === 'revisions';
+
+  if (segments.length === 3) {
+    return { kind: 'collection', isKnownPath: true };
   }
-
-  const body = (await readJsonBody(req)) as {
-    id?: unknown;
-    name?: unknown;
-    model?: unknown;
-    skills?: unknown;
-    chatbotId?: unknown;
-    enableRag?: unknown;
-    workspace?: unknown;
-  };
-
+  if (segments.length === 4) {
+    return { kind: 'agent', isKnownPath: true, agentId };
+  }
+  if (segments.length === 6 && hasFilesPrefix && fileName) {
+    return { kind: 'file', isKnownPath: true, agentId, fileName };
+  }
   if (
-    body.skills !== undefined &&
-    body.skills !== null &&
-    !Array.isArray(body.skills)
+    segments.length === 8 &&
+    hasFilesPrefix &&
+    hasRevisionsPrefix &&
+    fileName &&
+    revisionId
   ) {
-    sendJson(res, 400, {
-      error: 'Expected `skills` to be an array or null.',
-    });
-    return;
+    return {
+      kind: 'revision',
+      isKnownPath: true,
+      agentId,
+      fileName,
+      revisionId,
+    };
+  }
+  if (
+    segments.length === 9 &&
+    hasFilesPrefix &&
+    hasRevisionsPrefix &&
+    fileName &&
+    revisionId &&
+    segments[8] === 'restore'
+  ) {
+    return {
+      kind: 'restore',
+      isKnownPath: true,
+      agentId,
+      fileName,
+      revisionId,
+    };
   }
 
-  const skills =
-    body.skills === null
-      ? null
-      : Array.isArray(body.skills)
-        ? normalizeTrimmedUniqueStringArray(body.skills)
-        : undefined;
+  return {
+    kind: 'unknown',
+    isKnownPath:
+      (segments.length === 5 && hasFilesPrefix) ||
+      (segments.length === 7 && hasFilesPrefix && hasRevisionsPrefix),
+  };
+}
 
-  const payload = {
-    id: String(body.id || '').trim(),
+function sendApiAdminAgentError(res: ServerResponse, error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  const status =
+    error instanceof GatewayRequestError
+      ? error.statusCode
+      : /not found/i.test(message)
+        ? 404
+        : 400;
+  sendJson(res, status, { error: message });
+}
+
+function sendMethodNotAllowed(res: ServerResponse): void {
+  sendJson(res, 405, { error: 'Method Not Allowed' });
+}
+
+function requireAdminAgentIdPathValue(agentId: string): string {
+  const normalizedAgentId = agentId.trim();
+  if (!normalizedAgentId || normalizedAgentId === 'agents') {
+    throw new GatewayRequestError(400, 'Missing agent id in request path.');
+  }
+  return normalizedAgentId;
+}
+
+function normalizeApiAdminAgentSkills(
+  skills: unknown,
+): string[] | null | undefined {
+  if (skills === undefined) return undefined;
+  if (skills === null) return null;
+  if (!Array.isArray(skills)) {
+    throw new GatewayRequestError(
+      400,
+      'Expected `skills` to be an array or null.',
+    );
+  }
+  return normalizeTrimmedUniqueStringArray(skills);
+}
+
+async function readApiAdminAgentPayload(
+  req: IncomingMessage,
+  options?: { requireId?: boolean },
+): Promise<ApiAdminAgentPayload> {
+  const body = (await readJsonBody(req)) as ApiAdminAgentPayloadBody;
+  const payload: ApiAdminAgentPayload = {
+    id: String(body.id || '').trim() || undefined,
     name: typeof body.name === 'string' ? body.name : undefined,
     model: typeof body.model === 'string' ? body.model : undefined,
-    skills,
+    skills: normalizeApiAdminAgentSkills(body.skills),
     chatbotId: typeof body.chatbotId === 'string' ? body.chatbotId : undefined,
     enableRag: typeof body.enableRag === 'boolean' ? body.enableRag : undefined,
     workspace: typeof body.workspace === 'string' ? body.workspace : undefined,
   };
+  if (options?.requireId && !payload.id) {
+    throw new GatewayRequestError(
+      400,
+      'Expected non-empty `id` in request body.',
+    );
+  }
+  return payload;
+}
 
-  if (method === 'POST') {
-    if (!payload.id) {
-      sendJson(res, 400, { error: 'Expected non-empty `id` in request body.' });
-      return;
-    }
-    try {
-      sendJson(res, 200, createGatewayAdminAgent(payload));
-    } catch (error) {
-      sendJson(res, 400, {
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
+async function handleApiAdminAgentCollectionResource(
+  req: IncomingMessage,
+  res: ServerResponse,
+  method: string,
+): Promise<void> {
+  if (method === 'GET') {
+    sendJson(res, 200, getGatewayAdminAgents());
     return;
   }
-
-  if (method === 'PUT') {
-    const agentId = url.pathname.split('/').pop()?.trim() || '';
-    if (!agentId || agentId === 'agents') {
-      sendJson(res, 400, { error: 'Missing agent id in request path.' });
-      return;
-    }
+  if (method === 'POST') {
     try {
+      const payload = await readApiAdminAgentPayload(req, { requireId: true });
       sendJson(
         res,
         200,
-        updateGatewayAdminAgent(agentId, {
+        createGatewayAdminAgent({
+          id: payload.id || '',
           name: payload.name,
           model: payload.model,
           skills: payload.skills,
@@ -2369,15 +2455,191 @@ async function handleApiAdminAgents(
         }),
       );
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      sendJson(res, /not found/i.test(message) ? 404 : 400, {
-        error: message,
-      });
+      sendApiAdminAgentError(res, error);
     }
     return;
   }
+  sendMethodNotAllowed(res);
+}
 
-  sendJson(res, 405, { error: 'Method Not Allowed' });
+async function handleApiAdminAgentResource(
+  req: IncomingMessage,
+  res: ServerResponse,
+  method: string,
+  agentId: string,
+): Promise<void> {
+  try {
+    const normalizedAgentId = requireAdminAgentIdPathValue(agentId);
+    if (method === 'DELETE') {
+      sendJson(res, 200, deleteGatewayAdminAgent(normalizedAgentId));
+      return;
+    }
+    if (method === 'PUT') {
+      const payload = await readApiAdminAgentPayload(req);
+      sendJson(
+        res,
+        200,
+        updateGatewayAdminAgent(normalizedAgentId, {
+          name: payload.name,
+          model: payload.model,
+          skills: payload.skills,
+          chatbotId: payload.chatbotId,
+          enableRag: payload.enableRag,
+          workspace: payload.workspace,
+        }),
+      );
+      return;
+    }
+    sendMethodNotAllowed(res);
+  } catch (error) {
+    sendApiAdminAgentError(res, error);
+  }
+}
+
+async function handleApiAdminAgentFileResource(
+  req: IncomingMessage,
+  res: ServerResponse,
+  method: string,
+  params: {
+    agentId: string;
+    fileName: string;
+  },
+): Promise<void> {
+  if (method === 'GET') {
+    try {
+      sendJson(
+        res,
+        200,
+        getGatewayAdminAgentMarkdownFile(params.agentId, params.fileName),
+      );
+    } catch (error) {
+      sendApiAdminAgentError(res, error);
+    }
+    return;
+  }
+  if (method === 'PUT') {
+    try {
+      const body = (await readJsonBody(req)) as { content?: unknown };
+      if (typeof body.content !== 'string') {
+        throw new GatewayRequestError(
+          400,
+          'Expected string `content` in request body.',
+        );
+      }
+      sendJson(
+        res,
+        200,
+        saveGatewayAdminAgentMarkdownFile({
+          agentId: params.agentId,
+          fileName: params.fileName,
+          content: body.content,
+        }),
+      );
+    } catch (error) {
+      sendApiAdminAgentError(res, error);
+    }
+    return;
+  }
+  sendMethodNotAllowed(res);
+}
+
+async function handleApiAdminAgentRevisionResource(
+  res: ServerResponse,
+  method: string,
+  params: {
+    agentId: string;
+    fileName: string;
+    revisionId: string;
+  },
+): Promise<void> {
+  if (method === 'GET') {
+    try {
+      sendJson(
+        res,
+        200,
+        getGatewayAdminAgentMarkdownRevision({
+          agentId: params.agentId,
+          fileName: params.fileName,
+          revisionId: params.revisionId,
+        }),
+      );
+    } catch (error) {
+      sendApiAdminAgentError(res, error);
+    }
+    return;
+  }
+  sendMethodNotAllowed(res);
+}
+
+async function handleApiAdminAgentRevisionRestoreResource(
+  res: ServerResponse,
+  method: string,
+  params: {
+    agentId: string;
+    fileName: string;
+    revisionId: string;
+  },
+): Promise<void> {
+  if (method === 'POST') {
+    try {
+      sendJson(
+        res,
+        200,
+        restoreGatewayAdminAgentMarkdownRevision({
+          agentId: params.agentId,
+          fileName: params.fileName,
+          revisionId: params.revisionId,
+        }),
+      );
+    } catch (error) {
+      sendApiAdminAgentError(res, error);
+    }
+    return;
+  }
+  sendMethodNotAllowed(res);
+}
+
+async function handleApiAdminAgents(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL,
+): Promise<void> {
+  const method = req.method || 'GET';
+  const route = parseApiAdminAgentsRoute(url);
+
+  switch (route.kind) {
+    case 'collection':
+      await handleApiAdminAgentCollectionResource(req, res, method);
+      return;
+    case 'agent':
+      await handleApiAdminAgentResource(req, res, method, route.agentId);
+      return;
+    case 'file':
+      await handleApiAdminAgentFileResource(req, res, method, {
+        agentId: route.agentId,
+        fileName: route.fileName,
+      });
+      return;
+    case 'revision':
+      await handleApiAdminAgentRevisionResource(res, method, {
+        agentId: route.agentId,
+        fileName: route.fileName,
+        revisionId: route.revisionId,
+      });
+      return;
+    case 'restore':
+      await handleApiAdminAgentRevisionRestoreResource(res, method, {
+        agentId: route.agentId,
+        fileName: route.fileName,
+        revisionId: route.revisionId,
+      });
+      return;
+    case 'unknown':
+      sendJson(res, route.isKnownPath ? 405 : 404, {
+        error: route.isKnownPath ? 'Method Not Allowed' : 'Not Found',
+      });
+      return;
+  }
 }
 
 function handleApiAdminSessions(res: ServerResponse): void {
@@ -3241,10 +3503,8 @@ export function startGatewayHttpServer(): GatewayHttpServer {
             return;
           }
           if (
-            (pathname === '/api/admin/agents' &&
-              (method === 'GET' || method === 'POST')) ||
-            (pathname.startsWith('/api/admin/agents/') &&
-              (method === 'PUT' || method === 'DELETE'))
+            pathname === '/api/admin/agents' ||
+            pathname.startsWith('/api/admin/agents/')
           ) {
             await handleApiAdminAgents(req, res, url);
             return;

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -268,6 +269,7 @@ import {
   ensureBootstrapFiles,
   resetWorkspace,
   resolveStartupBootstrapFile,
+  WORKSPACE_BOOTSTRAP_FILES,
 } from '../workspace.js';
 import {
   normalizePlaceholderToolReply,
@@ -315,6 +317,12 @@ import {
   parseTimestamp,
 } from './gateway-time.js';
 import {
+  type GatewayAdminAgent,
+  type GatewayAdminAgentMarkdownFile,
+  type GatewayAdminAgentMarkdownFileResponse,
+  type GatewayAdminAgentMarkdownRevision,
+  type GatewayAdminAgentMarkdownRevisionResponse,
+  type GatewayAdminAgentsResponse,
   type GatewayAdminAuditResponse,
   type GatewayAdminChannelsResponse,
   type GatewayAdminChannelUpsertRequest,
@@ -370,6 +378,17 @@ const BOOTSTRAP_AUTOSTART_MARKER_KEY = 'gateway.bootstrap_autostart.v1';
 const BOOTSTRAP_AUTOSTART_SOURCE = 'gateway.bootstrap';
 const activeBootstrapAutostartSessions = new Set<string>();
 const assistantPresentationImagePathCache = new Map<string, string | null>();
+const ADMIN_AGENT_MARKDOWN_MAX_BYTES = 200_000;
+const ADMIN_AGENT_MARKDOWN_REVISIONS_DIRNAME = 'markdown-revisions';
+const ADMIN_AGENT_MARKDOWN_FILE_SET = new Set<string>(
+  WORKSPACE_BOOTSTRAP_FILES,
+);
+type AdminAgentMarkdownFileName = (typeof WORKSPACE_BOOTSTRAP_FILES)[number];
+type StoredAdminAgentMarkdownRevision = GatewayAdminAgentMarkdownRevision & {
+  fileName: AdminAgentMarkdownFileName;
+  content: string;
+};
+
 function buildBootstrapAutostartPrompt(
   fileName: 'BOOTSTRAP.md' | 'OPENING.md',
 ): string {
@@ -781,17 +800,106 @@ function mapUsageSummary(value: {
   };
 }
 
-function mapGatewayAdminAgent(agent: AgentConfig): {
-  id: string;
-  name: string | null;
-  model: string | null;
-  skills: string[] | null;
-  chatbotId: string | null;
-  enableRag: boolean | null;
-  workspace: string | null;
+function getGatewayAdminAgentConfig(agentId: string): AgentConfig {
+  const normalizedAgentId = agentId.trim();
+  if (!normalizedAgentId) {
+    throw new Error('Agent id is required.');
+  }
+  const agent = getAgentById(normalizedAgentId);
+  if (!agent) {
+    throw new Error(`Agent "${normalizedAgentId}" was not found.`);
+  }
+  return agent;
+}
+
+function normalizeGatewayAdminAgentMarkdownFileName(
+  value: string,
+): AdminAgentMarkdownFileName {
+  const normalized = value.trim();
+  if (!ADMIN_AGENT_MARKDOWN_FILE_SET.has(normalized)) {
+    throw new Error(
+      `Unsupported markdown file "${normalized}". Allowed files: ${WORKSPACE_BOOTSTRAP_FILES.join(', ')}`,
+    );
+  }
+  return normalized as AdminAgentMarkdownFileName;
+}
+
+function resolveGatewayAdminAgentMarkdownFile(params: {
+  agentId: string;
+  fileName: string;
+}): {
+  agent: AgentConfig;
+  fileName: AdminAgentMarkdownFileName;
   workspacePath: string;
+  filePath: string;
 } {
+  const agent = getGatewayAdminAgentConfig(params.agentId);
+  const fileName = normalizeGatewayAdminAgentMarkdownFileName(params.fileName);
+  const resolvedAgent = resolveAgentConfig(agent.id);
+  const workspacePath = path.resolve(agentWorkspaceDir(resolvedAgent.id));
+  const filePath = path.resolve(workspacePath, fileName);
+  if (
+    filePath !== path.join(workspacePath, fileName) ||
+    path.dirname(filePath) !== workspacePath
+  ) {
+    throw new Error(
+      `Resolved path for "${fileName}" is outside the workspace.`,
+    );
+  }
+  return {
+    agent,
+    fileName,
+    workspacePath,
+    filePath,
+  };
+}
+
+function getGatewayAdminAgentMarkdownFileStats(filePath: string): {
+  exists: boolean;
+  updatedAt: string | null;
+  sizeBytes: number | null;
+} {
+  try {
+    const stat = fs.statSync(filePath);
+    if (!stat.isFile()) {
+      throw new Error('Not a regular file.');
+    }
+    return {
+      exists: true,
+      updatedAt: new Date(stat.mtimeMs).toISOString(),
+      sizeBytes: stat.size,
+    };
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err?.code === 'ENOENT') {
+      return {
+        exists: false,
+        updatedAt: null,
+        sizeBytes: null,
+      };
+    }
+    throw error;
+  }
+}
+
+function mapGatewayAdminAgentMarkdownFile(params: {
+  workspacePath: string;
+  fileName: AdminAgentMarkdownFileName;
+}): GatewayAdminAgentMarkdownFile {
+  const filePath = path.join(params.workspacePath, params.fileName);
+  const stats = getGatewayAdminAgentMarkdownFileStats(filePath);
+  return {
+    name: params.fileName,
+    path: filePath,
+    exists: stats.exists,
+    updatedAt: stats.updatedAt,
+    sizeBytes: stats.sizeBytes,
+  };
+}
+
+function mapGatewayAdminAgent(agent: AgentConfig): GatewayAdminAgent {
   const resolved = resolveAgentConfig(agent.id);
+  const workspacePath = path.resolve(agentWorkspaceDir(resolved.id));
   return {
     id: resolved.id,
     name: resolved.name || null,
@@ -801,8 +909,206 @@ function mapGatewayAdminAgent(agent: AgentConfig): {
     enableRag:
       typeof resolved.enableRag === 'boolean' ? resolved.enableRag : null,
     workspace: resolved.workspace || null,
-    workspacePath: path.resolve(agentWorkspaceDir(resolved.id)),
+    workspacePath,
+    markdownFiles: WORKSPACE_BOOTSTRAP_FILES.map((fileName) =>
+      mapGatewayAdminAgentMarkdownFile({ workspacePath, fileName }),
+    ),
   };
+}
+
+function readGatewayAdminAgentMarkdownFileContent(filePath: string): string {
+  const stats = getGatewayAdminAgentMarkdownFileStats(filePath);
+  if (!stats.exists) return '';
+  if (
+    typeof stats.sizeBytes === 'number' &&
+    stats.sizeBytes > ADMIN_AGENT_MARKDOWN_MAX_BYTES
+  ) {
+    throw new Error(
+      `Markdown file is too large to edit in the admin console (${stats.sizeBytes} bytes, limit ${ADMIN_AGENT_MARKDOWN_MAX_BYTES}).`,
+    );
+  }
+  return fs.readFileSync(filePath, 'utf-8');
+}
+
+function getGatewayAdminAgentMarkdownContentSize(content: string): number {
+  return Buffer.byteLength(content, 'utf-8');
+}
+
+function assertGatewayAdminAgentMarkdownContentSize(
+  content: string,
+  errorPrefix = 'Markdown content',
+): number {
+  const sizeBytes = getGatewayAdminAgentMarkdownContentSize(content);
+  if (sizeBytes > ADMIN_AGENT_MARKDOWN_MAX_BYTES) {
+    throw new Error(
+      `${errorPrefix} exceeds the ${ADMIN_AGENT_MARKDOWN_MAX_BYTES}-byte admin editor limit.`,
+    );
+  }
+  return sizeBytes;
+}
+
+function writeGatewayAdminAgentMarkdownFileContent(
+  filePath: string,
+  content: string,
+): void {
+  assertGatewayAdminAgentMarkdownContentSize(content);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tempPath = `${filePath}.tmp-${process.pid}-${Date.now().toString(36)}`;
+  fs.writeFileSync(tempPath, content, 'utf-8');
+  fs.renameSync(tempPath, filePath);
+}
+
+function getGatewayAdminAgentMarkdownRevisionDir(params: {
+  workspacePath: string;
+  fileName: AdminAgentMarkdownFileName;
+}): string {
+  return path.join(
+    path.dirname(params.workspacePath),
+    ADMIN_AGENT_MARKDOWN_REVISIONS_DIRNAME,
+    params.fileName,
+  );
+}
+
+function buildGatewayAdminAgentMarkdownRevision(
+  params: {
+    fileName: AdminAgentMarkdownFileName;
+    content: string;
+    source: GatewayAdminAgentMarkdownRevision['source'];
+  },
+  now = new Date(),
+): StoredAdminAgentMarkdownRevision {
+  const sizeBytes = assertGatewayAdminAgentMarkdownContentSize(
+    params.content,
+    'Markdown revision content',
+  );
+  return {
+    id: `${now.getTime().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+    fileName: params.fileName,
+    createdAt: now.toISOString(),
+    sizeBytes,
+    sha256: createHash('sha256').update(params.content).digest('hex'),
+    source: params.source,
+    content: params.content,
+  };
+}
+
+function writeGatewayAdminAgentMarkdownRevision(params: {
+  workspacePath: string;
+  fileName: AdminAgentMarkdownFileName;
+  content: string;
+  source: GatewayAdminAgentMarkdownRevision['source'];
+}): GatewayAdminAgentMarkdownRevision {
+  const revision = buildGatewayAdminAgentMarkdownRevision(params);
+  const revisionDir = getGatewayAdminAgentMarkdownRevisionDir(params);
+  fs.mkdirSync(revisionDir, { recursive: true });
+  const revisionPath = path.join(revisionDir, `${revision.id}.json`);
+  const tempPath = `${revisionPath}.tmp-${process.pid}-${Date.now().toString(36)}`;
+  fs.writeFileSync(tempPath, JSON.stringify(revision, null, 2), 'utf-8');
+  fs.renameSync(tempPath, revisionPath);
+  return {
+    id: revision.id,
+    createdAt: revision.createdAt,
+    sizeBytes: revision.sizeBytes,
+    sha256: revision.sha256,
+    source: revision.source,
+  };
+}
+
+function readGatewayAdminAgentMarkdownRevisionRecord(
+  revisionPath: string,
+): StoredAdminAgentMarkdownRevision | null {
+  try {
+    const parsed = JSON.parse(
+      fs.readFileSync(revisionPath, 'utf-8'),
+    ) as Partial<StoredAdminAgentMarkdownRevision>;
+    if (
+      typeof parsed.id !== 'string' ||
+      typeof parsed.fileName !== 'string' ||
+      typeof parsed.createdAt !== 'string' ||
+      typeof parsed.sizeBytes !== 'number' ||
+      typeof parsed.sha256 !== 'string' ||
+      (parsed.source !== 'save' && parsed.source !== 'restore') ||
+      typeof parsed.content !== 'string'
+    ) {
+      return null;
+    }
+    return {
+      id: parsed.id,
+      fileName: normalizeGatewayAdminAgentMarkdownFileName(parsed.fileName),
+      createdAt: parsed.createdAt,
+      sizeBytes: parsed.sizeBytes,
+      sha256: parsed.sha256,
+      source: parsed.source,
+      content: parsed.content,
+    };
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err?.code === 'ENOENT') {
+      return null;
+    }
+    logger.warn({ revisionPath, error }, 'Failed to read markdown revision');
+    return null;
+  }
+}
+
+function listGatewayAdminAgentMarkdownRevisions(params: {
+  workspacePath: string;
+  fileName: AdminAgentMarkdownFileName;
+}): GatewayAdminAgentMarkdownRevision[] {
+  const revisionDir = getGatewayAdminAgentMarkdownRevisionDir(params);
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(revisionDir);
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err?.code === 'ENOENT') return [];
+    throw error;
+  }
+  return entries
+    .filter((entry) => entry.endsWith('.json'))
+    .map((entry) =>
+      readGatewayAdminAgentMarkdownRevisionRecord(
+        path.join(revisionDir, entry),
+      ),
+    )
+    .filter(
+      (entry): entry is StoredAdminAgentMarkdownRevision => entry !== null,
+    )
+    .sort((left, right) => {
+      const byCreatedAt =
+        Date.parse(right.createdAt) - Date.parse(left.createdAt);
+      if (Number.isFinite(byCreatedAt) && byCreatedAt !== 0) {
+        return byCreatedAt;
+      }
+      return right.id.localeCompare(left.id);
+    })
+    .map((entry) => ({
+      id: entry.id,
+      createdAt: entry.createdAt,
+      sizeBytes: entry.sizeBytes,
+      sha256: entry.sha256,
+      source: entry.source,
+    }));
+}
+
+function getGatewayAdminAgentMarkdownRevisionRecord(params: {
+  workspacePath: string;
+  fileName: AdminAgentMarkdownFileName;
+  revisionId: string;
+}): StoredAdminAgentMarkdownRevision {
+  const revisionId = params.revisionId.trim();
+  if (!revisionId) {
+    throw new Error('Revision id is required.');
+  }
+  const revisionPath = path.join(
+    getGatewayAdminAgentMarkdownRevisionDir(params),
+    `${revisionId}.json`,
+  );
+  const record = readGatewayAdminAgentMarkdownRevisionRecord(revisionPath);
+  if (!record || record.fileName !== params.fileName) {
+    throw new Error(`Revision "${revisionId}" was not found.`);
+  }
+  return record;
 }
 
 function dedupeStrings(values: string[]): string[] {
@@ -3095,12 +3401,116 @@ export async function getGatewayAdminOverview(): Promise<GatewayAdminOverview> {
   };
 }
 
-export function getGatewayAdminAgents(): {
-  agents: Array<ReturnType<typeof mapGatewayAdminAgent>>;
-} {
+export function getGatewayAdminAgents(): GatewayAdminAgentsResponse {
   return {
     agents: listAgents().map((agent) => mapGatewayAdminAgent(agent)),
   };
+}
+
+export function getGatewayAdminAgentMarkdownFile(
+  agentId: string,
+  fileName: string,
+): GatewayAdminAgentMarkdownFileResponse {
+  const resolved = resolveGatewayAdminAgentMarkdownFile({ agentId, fileName });
+  return {
+    agent: mapGatewayAdminAgent(resolved.agent),
+    file: {
+      ...mapGatewayAdminAgentMarkdownFile({
+        workspacePath: resolved.workspacePath,
+        fileName: resolved.fileName,
+      }),
+      content: readGatewayAdminAgentMarkdownFileContent(resolved.filePath),
+      revisions: listGatewayAdminAgentMarkdownRevisions({
+        workspacePath: resolved.workspacePath,
+        fileName: resolved.fileName,
+      }),
+    },
+  };
+}
+
+export function getGatewayAdminAgentMarkdownRevision(params: {
+  agentId: string;
+  fileName: string;
+  revisionId: string;
+}): GatewayAdminAgentMarkdownRevisionResponse {
+  const resolved = resolveGatewayAdminAgentMarkdownFile(params);
+  const revision = getGatewayAdminAgentMarkdownRevisionRecord({
+    workspacePath: resolved.workspacePath,
+    fileName: resolved.fileName,
+    revisionId: params.revisionId,
+  });
+  return {
+    agent: mapGatewayAdminAgent(resolved.agent),
+    fileName: resolved.fileName,
+    revision: {
+      id: revision.id,
+      createdAt: revision.createdAt,
+      sizeBytes: revision.sizeBytes,
+      sha256: revision.sha256,
+      source: revision.source,
+      content: revision.content,
+    },
+  };
+}
+
+export function saveGatewayAdminAgentMarkdownFile(params: {
+  agentId: string;
+  fileName: string;
+  content: string;
+}): GatewayAdminAgentMarkdownFileResponse {
+  assertGatewayAdminAgentMarkdownContentSize(params.content);
+  const resolved = resolveGatewayAdminAgentMarkdownFile(params);
+  const existingContent = readGatewayAdminAgentMarkdownFileContent(
+    resolved.filePath,
+  );
+  const currentStats = getGatewayAdminAgentMarkdownFileStats(resolved.filePath);
+  if (currentStats.exists && existingContent === params.content) {
+    return getGatewayAdminAgentMarkdownFile(params.agentId, params.fileName);
+  }
+  if (currentStats.exists) {
+    writeGatewayAdminAgentMarkdownRevision({
+      workspacePath: resolved.workspacePath,
+      fileName: resolved.fileName,
+      content: existingContent,
+      source: 'save',
+    });
+  }
+  writeGatewayAdminAgentMarkdownFileContent(resolved.filePath, params.content);
+
+  return getGatewayAdminAgentMarkdownFile(params.agentId, params.fileName);
+}
+
+export function restoreGatewayAdminAgentMarkdownRevision(params: {
+  agentId: string;
+  fileName: string;
+  revisionId: string;
+}): GatewayAdminAgentMarkdownFileResponse {
+  const resolved = resolveGatewayAdminAgentMarkdownFile(params);
+  const revision = getGatewayAdminAgentMarkdownRevisionRecord({
+    workspacePath: resolved.workspacePath,
+    fileName: resolved.fileName,
+    revisionId: params.revisionId,
+  });
+  const currentStats = getGatewayAdminAgentMarkdownFileStats(resolved.filePath);
+  const currentContent = currentStats.exists
+    ? readGatewayAdminAgentMarkdownFileContent(resolved.filePath)
+    : '';
+  if (currentStats.exists && currentContent === revision.content) {
+    return getGatewayAdminAgentMarkdownFile(params.agentId, params.fileName);
+  }
+  if (currentStats.exists && currentContent !== revision.content) {
+    writeGatewayAdminAgentMarkdownRevision({
+      workspacePath: resolved.workspacePath,
+      fileName: resolved.fileName,
+      content: currentContent,
+      source: 'restore',
+    });
+  }
+  writeGatewayAdminAgentMarkdownFileContent(
+    resolved.filePath,
+    revision.content,
+  );
+  return getGatewayAdminAgentMarkdownFile(params.agentId, params.fileName);
 }
 
 export function createGatewayAdminAgent(params: {

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -379,15 +379,27 @@ const BOOTSTRAP_AUTOSTART_SOURCE = 'gateway.bootstrap';
 const activeBootstrapAutostartSessions = new Set<string>();
 const assistantPresentationImagePathCache = new Map<string, string | null>();
 const ADMIN_AGENT_MARKDOWN_MAX_BYTES = 200_000;
+const ADMIN_AGENT_MARKDOWN_MAX_REVISIONS = 50;
 const ADMIN_AGENT_MARKDOWN_REVISIONS_DIRNAME = 'markdown-revisions';
 const ADMIN_AGENT_MARKDOWN_FILE_SET = new Set<string>(
   WORKSPACE_BOOTSTRAP_FILES,
 );
 type AdminAgentMarkdownFileName = (typeof WORKSPACE_BOOTSTRAP_FILES)[number];
-type StoredAdminAgentMarkdownRevision = GatewayAdminAgentMarkdownRevision & {
-  fileName: AdminAgentMarkdownFileName;
+type GatewayAdminAgentMarkdownFileStats = Pick<
+  GatewayAdminAgentMarkdownFile,
+  'exists' | 'updatedAt' | 'sizeBytes'
+>;
+type GatewayAdminAgentMarkdownFileState = GatewayAdminAgentMarkdownFileStats & {
   content: string;
 };
+type StoredAdminAgentMarkdownRevisionMetadata =
+  GatewayAdminAgentMarkdownRevision & {
+    fileName: AdminAgentMarkdownFileName;
+  };
+type StoredAdminAgentMarkdownRevision =
+  StoredAdminAgentMarkdownRevisionMetadata & {
+    content: string;
+  };
 
 function buildBootstrapAutostartPrompt(
   fileName: 'BOOTSTRAP.md' | 'OPENING.md',
@@ -829,6 +841,7 @@ function resolveGatewayAdminAgentMarkdownFile(params: {
   fileName: string;
 }): {
   agent: AgentConfig;
+  resolvedAgent: AgentConfig;
   fileName: AdminAgentMarkdownFileName;
   workspacePath: string;
   filePath: string;
@@ -837,28 +850,19 @@ function resolveGatewayAdminAgentMarkdownFile(params: {
   const fileName = normalizeGatewayAdminAgentMarkdownFileName(params.fileName);
   const resolvedAgent = resolveAgentConfig(agent.id);
   const workspacePath = path.resolve(agentWorkspaceDir(resolvedAgent.id));
-  const filePath = path.resolve(workspacePath, fileName);
-  if (
-    filePath !== path.join(workspacePath, fileName) ||
-    path.dirname(filePath) !== workspacePath
-  ) {
-    throw new Error(
-      `Resolved path for "${fileName}" is outside the workspace.`,
-    );
-  }
+  const filePath = path.join(workspacePath, fileName);
   return {
     agent,
+    resolvedAgent,
     fileName,
     workspacePath,
     filePath,
   };
 }
 
-function getGatewayAdminAgentMarkdownFileStats(filePath: string): {
-  exists: boolean;
-  updatedAt: string | null;
-  sizeBytes: number | null;
-} {
+function getGatewayAdminAgentMarkdownFileStats(
+  filePath: string,
+): GatewayAdminAgentMarkdownFileStats {
   try {
     const stat = fs.statSync(filePath);
     if (!stat.isFile()) {
@@ -885,9 +889,10 @@ function getGatewayAdminAgentMarkdownFileStats(filePath: string): {
 function mapGatewayAdminAgentMarkdownFile(params: {
   workspacePath: string;
   fileName: AdminAgentMarkdownFileName;
+  stats?: GatewayAdminAgentMarkdownFileStats;
 }): GatewayAdminAgentMarkdownFile {
   const filePath = path.join(params.workspacePath, params.fileName);
-  const stats = getGatewayAdminAgentMarkdownFileStats(filePath);
+  const stats = params.stats ?? getGatewayAdminAgentMarkdownFileStats(filePath);
   return {
     name: params.fileName,
     path: filePath,
@@ -897,9 +902,56 @@ function mapGatewayAdminAgentMarkdownFile(params: {
   };
 }
 
-function mapGatewayAdminAgent(agent: AgentConfig): GatewayAdminAgent {
-  const resolved = resolveAgentConfig(agent.id);
-  const workspacePath = path.resolve(agentWorkspaceDir(resolved.id));
+function getGatewayAdminAgentMarkdownFilePresenceStats(
+  workspacePath: string,
+): Record<AdminAgentMarkdownFileName, GatewayAdminAgentMarkdownFileStats> {
+  const entriesByName = new Map<string, fs.Dirent>();
+  try {
+    for (const entry of fs.readdirSync(workspacePath, {
+      withFileTypes: true,
+    })) {
+      entriesByName.set(entry.name, entry);
+    }
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err?.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  return WORKSPACE_BOOTSTRAP_FILES.reduce(
+    (statsByName, fileName) => {
+      const entry = entriesByName.get(fileName);
+      statsByName[fileName] = {
+        exists: entry?.isFile() ?? false,
+        updatedAt: null,
+        sizeBytes: null,
+      };
+      return statsByName;
+    },
+    {} as Record<
+      AdminAgentMarkdownFileName,
+      GatewayAdminAgentMarkdownFileStats
+    >,
+  );
+}
+
+function mapGatewayAdminAgent(
+  agent: AgentConfig,
+  options?: {
+    resolvedAgent?: AgentConfig;
+    workspacePath?: string;
+    markdownFileStats?: Partial<
+      Record<AdminAgentMarkdownFileName, GatewayAdminAgentMarkdownFileStats>
+    >;
+    markdownFileOverrides?: Partial<
+      Record<AdminAgentMarkdownFileName, GatewayAdminAgentMarkdownFile>
+    >;
+  },
+): GatewayAdminAgent {
+  const resolved = options?.resolvedAgent ?? resolveAgentConfig(agent.id);
+  const workspacePath =
+    options?.workspacePath ?? path.resolve(agentWorkspaceDir(resolved.id));
   return {
     id: resolved.id,
     name: resolved.name || null,
@@ -910,15 +962,28 @@ function mapGatewayAdminAgent(agent: AgentConfig): GatewayAdminAgent {
       typeof resolved.enableRag === 'boolean' ? resolved.enableRag : null,
     workspace: resolved.workspace || null,
     workspacePath,
-    markdownFiles: WORKSPACE_BOOTSTRAP_FILES.map((fileName) =>
-      mapGatewayAdminAgentMarkdownFile({ workspacePath, fileName }),
+    markdownFiles: WORKSPACE_BOOTSTRAP_FILES.map(
+      (fileName) =>
+        options?.markdownFileOverrides?.[fileName] ||
+        mapGatewayAdminAgentMarkdownFile({
+          workspacePath,
+          fileName,
+          stats: options?.markdownFileStats?.[fileName],
+        }),
     ),
   };
 }
 
-function readGatewayAdminAgentMarkdownFileContent(filePath: string): string {
-  const stats = getGatewayAdminAgentMarkdownFileStats(filePath);
-  if (!stats.exists) return '';
+function readGatewayAdminAgentMarkdownFileState(
+  filePath: string,
+  stats = getGatewayAdminAgentMarkdownFileStats(filePath),
+): GatewayAdminAgentMarkdownFileState {
+  if (!stats.exists) {
+    return {
+      ...stats,
+      content: '',
+    };
+  }
   if (
     typeof stats.sizeBytes === 'number' &&
     stats.sizeBytes > ADMIN_AGENT_MARKDOWN_MAX_BYTES
@@ -927,7 +992,10 @@ function readGatewayAdminAgentMarkdownFileContent(filePath: string): string {
       `Markdown file is too large to edit in the admin console (${stats.sizeBytes} bytes, limit ${ADMIN_AGENT_MARKDOWN_MAX_BYTES}).`,
     );
   }
-  return fs.readFileSync(filePath, 'utf-8');
+  return {
+    ...stats,
+    content: fs.readFileSync(filePath, 'utf-8'),
+  };
 }
 
 function getGatewayAdminAgentMarkdownContentSize(content: string): number {
@@ -950,12 +1018,59 @@ function assertGatewayAdminAgentMarkdownContentSize(
 function writeGatewayAdminAgentMarkdownFileContent(
   filePath: string,
   content: string,
-): void {
-  assertGatewayAdminAgentMarkdownContentSize(content);
+  options?: {
+    sizeBytes?: number;
+  },
+): GatewayAdminAgentMarkdownFileStats {
+  if (typeof options?.sizeBytes !== 'number') {
+    assertGatewayAdminAgentMarkdownContentSize(content);
+  }
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   const tempPath = `${filePath}.tmp-${process.pid}-${Date.now().toString(36)}`;
   fs.writeFileSync(tempPath, content, 'utf-8');
   fs.renameSync(tempPath, filePath);
+  return getGatewayAdminAgentMarkdownFileStats(filePath);
+}
+
+function buildGatewayAdminAgentMarkdownFileResponse(params: {
+  resolved: ReturnType<typeof resolveGatewayAdminAgentMarkdownFile>;
+  fileState?: GatewayAdminAgentMarkdownFileState;
+  revisions?: GatewayAdminAgentMarkdownRevision[];
+}): GatewayAdminAgentMarkdownFileResponse {
+  const fileState =
+    params.fileState ??
+    readGatewayAdminAgentMarkdownFileState(params.resolved.filePath);
+  const mappedFile = mapGatewayAdminAgentMarkdownFile({
+    workspacePath: params.resolved.workspacePath,
+    fileName: params.resolved.fileName,
+    stats: fileState,
+  });
+  const markdownFileOverrides: Partial<
+    Record<AdminAgentMarkdownFileName, GatewayAdminAgentMarkdownFile>
+  > = {
+    [params.resolved.fileName]: mappedFile,
+  };
+  const markdownFileStats = getGatewayAdminAgentMarkdownFilePresenceStats(
+    params.resolved.workspacePath,
+  );
+  return {
+    agent: mapGatewayAdminAgent(params.resolved.agent, {
+      resolvedAgent: params.resolved.resolvedAgent,
+      workspacePath: params.resolved.workspacePath,
+      markdownFileStats,
+      markdownFileOverrides,
+    }),
+    file: {
+      ...mappedFile,
+      content: fileState.content,
+      revisions:
+        params.revisions ??
+        listGatewayAdminAgentMarkdownRevisions({
+          workspacePath: params.resolved.workspacePath,
+          fileName: params.resolved.fileName,
+        }),
+    },
+  };
 }
 
 function getGatewayAdminAgentMarkdownRevisionDir(params: {
@@ -969,20 +1084,18 @@ function getGatewayAdminAgentMarkdownRevisionDir(params: {
   );
 }
 
-function buildGatewayAdminAgentMarkdownRevision(
-  params: {
-    fileName: AdminAgentMarkdownFileName;
-    content: string;
-    source: GatewayAdminAgentMarkdownRevision['source'];
-  },
-  now = new Date(),
-): StoredAdminAgentMarkdownRevision {
+function buildGatewayAdminAgentMarkdownRevision(params: {
+  fileName: AdminAgentMarkdownFileName;
+  content: string;
+  source: GatewayAdminAgentMarkdownRevision['source'];
+}): StoredAdminAgentMarkdownRevision {
+  const now = new Date();
   const sizeBytes = assertGatewayAdminAgentMarkdownContentSize(
     params.content,
     'Markdown revision content',
   );
   return {
-    id: `${now.getTime().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+    id: randomUUID(),
     fileName: params.fileName,
     createdAt: now.toISOString(),
     sizeBytes,
@@ -990,6 +1103,22 @@ function buildGatewayAdminAgentMarkdownRevision(
     source: params.source,
     content: params.content,
   };
+}
+
+function buildGatewayAdminAgentMarkdownRevisionEntryName(
+  revision: Pick<StoredAdminAgentMarkdownRevision, 'createdAt' | 'id'>,
+): string {
+  const createdAtMs = Date.parse(revision.createdAt);
+  const timestampPrefix = Number.isFinite(createdAtMs)
+    ? createdAtMs.toString(36)
+    : '0';
+  return `${timestampPrefix}-${revision.id}.json`;
+}
+
+function getGatewayAdminAgentMarkdownRevisionContentPath(
+  revisionPath: string,
+): string {
+  return `${revisionPath.slice(0, -'.json'.length)}.md`;
 }
 
 function writeGatewayAdminAgentMarkdownRevision(params: {
@@ -1001,34 +1130,48 @@ function writeGatewayAdminAgentMarkdownRevision(params: {
   const revision = buildGatewayAdminAgentMarkdownRevision(params);
   const revisionDir = getGatewayAdminAgentMarkdownRevisionDir(params);
   fs.mkdirSync(revisionDir, { recursive: true });
-  const revisionPath = path.join(revisionDir, `${revision.id}.json`);
-  const tempPath = `${revisionPath}.tmp-${process.pid}-${Date.now().toString(36)}`;
-  fs.writeFileSync(tempPath, JSON.stringify(revision, null, 2), 'utf-8');
-  fs.renameSync(tempPath, revisionPath);
-  return {
+  const revisionPath = path.join(
+    revisionDir,
+    buildGatewayAdminAgentMarkdownRevisionEntryName(revision),
+  );
+  const contentPath =
+    getGatewayAdminAgentMarkdownRevisionContentPath(revisionPath);
+  const metadata: StoredAdminAgentMarkdownRevisionMetadata = {
     id: revision.id,
+    fileName: revision.fileName,
     createdAt: revision.createdAt,
     sizeBytes: revision.sizeBytes,
     sha256: revision.sha256,
     source: revision.source,
   };
+  const tempContentPath = `${contentPath}.tmp-${process.pid}-${Date.now().toString(36)}`;
+  fs.writeFileSync(tempContentPath, revision.content, 'utf-8');
+  fs.renameSync(tempContentPath, contentPath);
+  const tempMetadataPath = `${revisionPath}.tmp-${process.pid}-${Date.now().toString(36)}`;
+  fs.writeFileSync(
+    tempMetadataPath,
+    JSON.stringify(metadata, null, 2),
+    'utf-8',
+  );
+  fs.renameSync(tempMetadataPath, revisionPath);
+  trimGatewayAdminAgentMarkdownRevisions(params);
+  return metadata;
 }
 
-function readGatewayAdminAgentMarkdownRevisionRecord(
+function readGatewayAdminAgentMarkdownRevisionMetadataRecord(
   revisionPath: string,
-): StoredAdminAgentMarkdownRevision | null {
+): StoredAdminAgentMarkdownRevisionMetadata | null {
   try {
     const parsed = JSON.parse(
       fs.readFileSync(revisionPath, 'utf-8'),
-    ) as Partial<StoredAdminAgentMarkdownRevision>;
+    ) as Partial<StoredAdminAgentMarkdownRevisionMetadata>;
     if (
       typeof parsed.id !== 'string' ||
       typeof parsed.fileName !== 'string' ||
       typeof parsed.createdAt !== 'string' ||
       typeof parsed.sizeBytes !== 'number' ||
       typeof parsed.sha256 !== 'string' ||
-      (parsed.source !== 'save' && parsed.source !== 'restore') ||
-      typeof parsed.content !== 'string'
+      (parsed.source !== 'save' && parsed.source !== 'restore')
     ) {
       return null;
     }
@@ -1039,6 +1182,49 @@ function readGatewayAdminAgentMarkdownRevisionRecord(
       sizeBytes: parsed.sizeBytes,
       sha256: parsed.sha256,
       source: parsed.source,
+    };
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err?.code === 'ENOENT') {
+      return null;
+    }
+    logger.warn({ revisionPath, error }, 'Failed to read markdown revision');
+    return null;
+  }
+}
+
+function readGatewayAdminAgentMarkdownRevisionRecord(
+  revisionPath: string,
+): StoredAdminAgentMarkdownRevision | null {
+  const metadata =
+    readGatewayAdminAgentMarkdownRevisionMetadataRecord(revisionPath);
+  if (!metadata) {
+    return null;
+  }
+  const contentPath =
+    getGatewayAdminAgentMarkdownRevisionContentPath(revisionPath);
+  try {
+    return {
+      ...metadata,
+      content: fs.readFileSync(contentPath, 'utf-8'),
+    };
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err?.code !== 'ENOENT') {
+      logger.warn({ contentPath, error }, 'Failed to read markdown revision');
+      return null;
+    }
+  }
+
+  try {
+    const parsed = JSON.parse(
+      fs.readFileSync(revisionPath, 'utf-8'),
+    ) as Partial<StoredAdminAgentMarkdownRevision>;
+    if (typeof parsed.content !== 'string') {
+      return null;
+    }
+    return {
+      ...metadata,
       content: parsed.content,
     };
   } catch (error) {
@@ -1051,32 +1237,108 @@ function readGatewayAdminAgentMarkdownRevisionRecord(
   }
 }
 
-function listGatewayAdminAgentMarkdownRevisions(params: {
+function getGatewayAdminAgentMarkdownRevisionEntryTimestamp(
+  entry: string,
+): number {
+  const [revisionId] = entry.split('.json', 1);
+  const [encodedTimestamp] = revisionId.split('-', 1);
+  const timestamp = Number.parseInt(encodedTimestamp, 36);
+  return Number.isFinite(timestamp) ? timestamp : Number.NaN;
+}
+
+function compareGatewayAdminAgentMarkdownRevisionEntries(
+  left: string,
+  right: string,
+): number {
+  const byTimestamp =
+    getGatewayAdminAgentMarkdownRevisionEntryTimestamp(right) -
+    getGatewayAdminAgentMarkdownRevisionEntryTimestamp(left);
+  if (Number.isFinite(byTimestamp) && byTimestamp !== 0) {
+    return byTimestamp;
+  }
+  return right.localeCompare(left);
+}
+
+function listGatewayAdminAgentMarkdownRevisionEntries(params: {
   workspacePath: string;
   fileName: AdminAgentMarkdownFileName;
-}): GatewayAdminAgentMarkdownRevision[] {
+}): { revisionDir: string; entries: string[] } {
   const revisionDir = getGatewayAdminAgentMarkdownRevisionDir(params);
   let entries: string[];
   try {
     entries = fs.readdirSync(revisionDir);
   } catch (error) {
     const err = error as NodeJS.ErrnoException;
-    if (err?.code === 'ENOENT') return [];
+    if (err?.code === 'ENOENT') {
+      return {
+        revisionDir,
+        entries: [],
+      };
+    }
     throw error;
   }
-  return entries
-    .filter((entry) => entry.endsWith('.json'))
-    .map((entry) =>
-      readGatewayAdminAgentMarkdownRevisionRecord(
-        path.join(revisionDir, entry),
-      ),
-    )
-    .filter(
-      (entry): entry is StoredAdminAgentMarkdownRevision => entry !== null,
-    )
+  return {
+    revisionDir,
+    entries: entries
+      .filter((entry) => entry.endsWith('.json'))
+      .sort(compareGatewayAdminAgentMarkdownRevisionEntries),
+  };
+}
+
+function trimGatewayAdminAgentMarkdownRevisions(params: {
+  workspacePath: string;
+  fileName: AdminAgentMarkdownFileName;
+}): void {
+  const { revisionDir, entries } =
+    listGatewayAdminAgentMarkdownRevisionEntries(params);
+  for (const entry of entries.slice(ADMIN_AGENT_MARKDOWN_MAX_REVISIONS)) {
+    const revisionPath = path.join(revisionDir, entry);
+    const contentPath =
+      getGatewayAdminAgentMarkdownRevisionContentPath(revisionPath);
+    for (const targetPath of [revisionPath, contentPath]) {
+      try {
+        fs.unlinkSync(targetPath);
+      } catch (error) {
+        const err = error as NodeJS.ErrnoException;
+        if (err?.code === 'ENOENT') {
+          continue;
+        }
+        logger.warn(
+          { revisionDir, entry, targetPath, error },
+          'Failed to trim markdown revision',
+        );
+      }
+    }
+  }
+}
+
+function listGatewayAdminAgentMarkdownRevisions(params: {
+  workspacePath: string;
+  fileName: AdminAgentMarkdownFileName;
+}): GatewayAdminAgentMarkdownRevision[] {
+  const { revisionDir, entries } =
+    listGatewayAdminAgentMarkdownRevisionEntries(params);
+  const revisions: Array<
+    StoredAdminAgentMarkdownRevisionMetadata & { createdAtMs: number }
+  > = [];
+  for (const entry of entries) {
+    if (revisions.length >= ADMIN_AGENT_MARKDOWN_MAX_REVISIONS) {
+      break;
+    }
+    const record = readGatewayAdminAgentMarkdownRevisionMetadataRecord(
+      path.join(revisionDir, entry),
+    );
+    if (!record || record.fileName !== params.fileName) {
+      continue;
+    }
+    revisions.push({
+      ...record,
+      createdAtMs: Date.parse(record.createdAt),
+    });
+  }
+  return revisions
     .sort((left, right) => {
-      const byCreatedAt =
-        Date.parse(right.createdAt) - Date.parse(left.createdAt);
+      const byCreatedAt = right.createdAtMs - left.createdAtMs;
       if (Number.isFinite(byCreatedAt) && byCreatedAt !== 0) {
         return byCreatedAt;
       }
@@ -1091,19 +1353,35 @@ function listGatewayAdminAgentMarkdownRevisions(params: {
     }));
 }
 
+function normalizeGatewayAdminAgentMarkdownRevisionId(value: string): string {
+  const revisionId = value.trim();
+  if (!revisionId) {
+    throw new Error('Revision id is required.');
+  }
+  if (!/^[A-Za-z0-9-]+$/.test(revisionId)) {
+    throw new Error('Revision id is invalid.');
+  }
+  return revisionId;
+}
+
 function getGatewayAdminAgentMarkdownRevisionRecord(params: {
   workspacePath: string;
   fileName: AdminAgentMarkdownFileName;
   revisionId: string;
 }): StoredAdminAgentMarkdownRevision {
-  const revisionId = params.revisionId.trim();
-  if (!revisionId) {
-    throw new Error('Revision id is required.');
-  }
-  const revisionPath = path.join(
-    getGatewayAdminAgentMarkdownRevisionDir(params),
-    `${revisionId}.json`,
+  const revisionId = normalizeGatewayAdminAgentMarkdownRevisionId(
+    params.revisionId,
   );
+  const { revisionDir, entries } =
+    listGatewayAdminAgentMarkdownRevisionEntries(params);
+  const revisionEntry = entries.find(
+    (entry) =>
+      entry === `${revisionId}.json` || entry.endsWith(`-${revisionId}.json`),
+  );
+  if (!revisionEntry) {
+    throw new Error(`Revision "${revisionId}" was not found.`);
+  }
+  const revisionPath = path.join(revisionDir, revisionEntry);
   const record = readGatewayAdminAgentMarkdownRevisionRecord(revisionPath);
   if (!record || record.fileName !== params.fileName) {
     throw new Error(`Revision "${revisionId}" was not found.`);
@@ -3403,7 +3681,16 @@ export async function getGatewayAdminOverview(): Promise<GatewayAdminOverview> {
 
 export function getGatewayAdminAgents(): GatewayAdminAgentsResponse {
   return {
-    agents: listAgents().map((agent) => mapGatewayAdminAgent(agent)),
+    agents: listAgents().map((agent) => {
+      const resolved = resolveAgentConfig(agent.id);
+      const workspacePath = path.resolve(agentWorkspaceDir(resolved.id));
+      return mapGatewayAdminAgent(agent, {
+        resolvedAgent: resolved,
+        workspacePath,
+        markdownFileStats:
+          getGatewayAdminAgentMarkdownFilePresenceStats(workspacePath),
+      });
+    }),
   };
 }
 
@@ -3412,20 +3699,7 @@ export function getGatewayAdminAgentMarkdownFile(
   fileName: string,
 ): GatewayAdminAgentMarkdownFileResponse {
   const resolved = resolveGatewayAdminAgentMarkdownFile({ agentId, fileName });
-  return {
-    agent: mapGatewayAdminAgent(resolved.agent),
-    file: {
-      ...mapGatewayAdminAgentMarkdownFile({
-        workspacePath: resolved.workspacePath,
-        fileName: resolved.fileName,
-      }),
-      content: readGatewayAdminAgentMarkdownFileContent(resolved.filePath),
-      revisions: listGatewayAdminAgentMarkdownRevisions({
-        workspacePath: resolved.workspacePath,
-        fileName: resolved.fileName,
-      }),
-    },
-  };
+  return buildGatewayAdminAgentMarkdownFileResponse({ resolved });
 }
 
 export function getGatewayAdminAgentMarkdownRevision(params: {
@@ -3440,7 +3714,13 @@ export function getGatewayAdminAgentMarkdownRevision(params: {
     revisionId: params.revisionId,
   });
   return {
-    agent: mapGatewayAdminAgent(resolved.agent),
+    agent: mapGatewayAdminAgent(resolved.agent, {
+      resolvedAgent: resolved.resolvedAgent,
+      workspacePath: resolved.workspacePath,
+      markdownFileStats: getGatewayAdminAgentMarkdownFilePresenceStats(
+        resolved.workspacePath,
+      ),
+    }),
     fileName: resolved.fileName,
     revision: {
       id: revision.id,
@@ -3458,26 +3738,41 @@ export function saveGatewayAdminAgentMarkdownFile(params: {
   fileName: string;
   content: string;
 }): GatewayAdminAgentMarkdownFileResponse {
-  assertGatewayAdminAgentMarkdownContentSize(params.content);
+  const nextSizeBytes = assertGatewayAdminAgentMarkdownContentSize(
+    params.content,
+  );
   const resolved = resolveGatewayAdminAgentMarkdownFile(params);
-  const existingContent = readGatewayAdminAgentMarkdownFileContent(
+  const currentState = readGatewayAdminAgentMarkdownFileState(
     resolved.filePath,
   );
-  const currentStats = getGatewayAdminAgentMarkdownFileStats(resolved.filePath);
-  if (currentStats.exists && existingContent === params.content) {
-    return getGatewayAdminAgentMarkdownFile(params.agentId, params.fileName);
+  if (currentState.exists && currentState.content === params.content) {
+    return buildGatewayAdminAgentMarkdownFileResponse({
+      resolved,
+      fileState: currentState,
+    });
   }
-  if (currentStats.exists) {
+  if (currentState.exists) {
     writeGatewayAdminAgentMarkdownRevision({
       workspacePath: resolved.workspacePath,
       fileName: resolved.fileName,
-      content: existingContent,
+      content: currentState.content,
       source: 'save',
     });
   }
-  writeGatewayAdminAgentMarkdownFileContent(resolved.filePath, params.content);
-
-  return getGatewayAdminAgentMarkdownFile(params.agentId, params.fileName);
+  const nextStats = writeGatewayAdminAgentMarkdownFileContent(
+    resolved.filePath,
+    params.content,
+    {
+      sizeBytes: nextSizeBytes,
+    },
+  );
+  return buildGatewayAdminAgentMarkdownFileResponse({
+    resolved,
+    fileState: {
+      ...nextStats,
+      content: params.content,
+    },
+  });
 }
 
 export function restoreGatewayAdminAgentMarkdownRevision(params: {
@@ -3491,26 +3786,41 @@ export function restoreGatewayAdminAgentMarkdownRevision(params: {
     fileName: resolved.fileName,
     revisionId: params.revisionId,
   });
-  const currentStats = getGatewayAdminAgentMarkdownFileStats(resolved.filePath);
-  const currentContent = currentStats.exists
-    ? readGatewayAdminAgentMarkdownFileContent(resolved.filePath)
-    : '';
-  if (currentStats.exists && currentContent === revision.content) {
-    return getGatewayAdminAgentMarkdownFile(params.agentId, params.fileName);
+  const nextSizeBytes = assertGatewayAdminAgentMarkdownContentSize(
+    revision.content,
+    'Markdown revision content',
+  );
+  const currentState = readGatewayAdminAgentMarkdownFileState(
+    resolved.filePath,
+  );
+  if (currentState.exists && currentState.content === revision.content) {
+    return buildGatewayAdminAgentMarkdownFileResponse({
+      resolved,
+      fileState: currentState,
+    });
   }
-  if (currentStats.exists && currentContent !== revision.content) {
+  if (currentState.exists) {
     writeGatewayAdminAgentMarkdownRevision({
       workspacePath: resolved.workspacePath,
       fileName: resolved.fileName,
-      content: currentContent,
+      content: currentState.content,
       source: 'restore',
     });
   }
-  writeGatewayAdminAgentMarkdownFileContent(
+  const nextStats = writeGatewayAdminAgentMarkdownFileContent(
     resolved.filePath,
     revision.content,
+    {
+      sizeBytes: nextSizeBytes,
+    },
   );
-  return getGatewayAdminAgentMarkdownFile(params.agentId, params.fileName);
+  return buildGatewayAdminAgentMarkdownFileResponse({
+    resolved,
+    fileState: {
+      ...nextStats,
+      content: revision.content,
+    },
+  });
 }
 
 export function createGatewayAdminAgent(params: {

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -743,6 +743,54 @@ export interface GatewayAdminConfigResponse {
   config: RuntimeConfig;
 }
 
+export interface GatewayAdminAgentMarkdownFile {
+  name: string;
+  path: string;
+  exists: boolean;
+  updatedAt: string | null;
+  sizeBytes: number | null;
+}
+
+export interface GatewayAdminAgentMarkdownRevision {
+  id: string;
+  createdAt: string;
+  sizeBytes: number;
+  sha256: string;
+  source: 'save' | 'restore';
+}
+
+export interface GatewayAdminAgent {
+  id: string;
+  name: string | null;
+  model: string | null;
+  skills: string[] | null;
+  chatbotId: string | null;
+  enableRag: boolean | null;
+  workspace: string | null;
+  workspacePath: string;
+  markdownFiles: GatewayAdminAgentMarkdownFile[];
+}
+
+export interface GatewayAdminAgentsResponse {
+  agents: GatewayAdminAgent[];
+}
+
+export interface GatewayAdminAgentMarkdownFileResponse {
+  agent: GatewayAdminAgent;
+  file: GatewayAdminAgentMarkdownFile & {
+    content: string;
+    revisions: GatewayAdminAgentMarkdownRevision[];
+  };
+}
+
+export interface GatewayAdminAgentMarkdownRevisionResponse {
+  agent: GatewayAdminAgent;
+  fileName: string;
+  revision: GatewayAdminAgentMarkdownRevision & {
+    content: string;
+  };
+}
+
 export interface GatewayAdminModelCatalogEntry {
   id: string;
   discovered: boolean;

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -14,7 +14,7 @@ import { agentWorkspaceDir } from './infra/ipc.js';
 import { logger } from './logger.js';
 import { truncateHeadTailText } from './session/token-efficiency.js';
 
-const BOOTSTRAP_FILES = [
+export const WORKSPACE_BOOTSTRAP_FILES = [
   'AGENTS.md',
   'SOUL.md',
   'IDENTITY.md',
@@ -133,7 +133,9 @@ function writeWorkspaceOnboardingState(
   fs.renameSync(tempPath, statePath);
 }
 
-function readTemplateFile(filename: (typeof BOOTSTRAP_FILES)[number]): string {
+function readTemplateFile(
+  filename: (typeof WORKSPACE_BOOTSTRAP_FILES)[number],
+): string {
   const templatePath = path.join(TEMPLATES_DIR, filename);
   return fs.readFileSync(templatePath, 'utf-8');
 }
@@ -176,7 +178,7 @@ function normalizeContextFileContent(params: {
 
 function isWorkspaceFileCustomized(
   wsDir: string,
-  filename: (typeof BOOTSTRAP_FILES)[number],
+  filename: (typeof WORKSPACE_BOOTSTRAP_FILES)[number],
 ): boolean {
   const filePath = path.join(wsDir, filename);
   if (!fs.existsSync(filePath)) return false;
@@ -231,7 +233,7 @@ function hasOnboardingEvidenceAfterBootstrap(params: {
   const transcriptPath = path.join(params.wsDir, '.session-transcripts');
   if (hasPathChangedAfter(referenceMs, transcriptPath)) return true;
 
-  const customizedFiles: Array<(typeof BOOTSTRAP_FILES)[number]> = [
+  const customizedFiles: Array<(typeof WORKSPACE_BOOTSTRAP_FILES)[number]> = [
     'USER.md',
     'MEMORY.md',
     'IDENTITY.md',
@@ -318,7 +320,7 @@ export function ensureBootstrapFiles(
   };
   const nowIso = () => new Date().toISOString();
 
-  for (const filename of BOOTSTRAP_FILES) {
+  for (const filename of WORKSPACE_BOOTSTRAP_FILES) {
     if (ONE_TIME_BOOTSTRAP_FILES.has(filename)) continue;
     const destPath = path.join(wsDir, filename);
     if (fs.existsSync(destPath)) continue;
@@ -424,7 +426,7 @@ export function loadBootstrapFiles(agentId: string): ContextFile[] {
   const wsDir = agentWorkspaceDir(agentId);
   const files: ContextFile[] = [];
 
-  for (const filename of BOOTSTRAP_FILES) {
+  for (const filename of WORKSPACE_BOOTSTRAP_FILES) {
     const filePath = path.join(wsDir, filename);
     if (!fs.existsSync(filePath)) continue;
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -6,6 +6,10 @@ import { pathToFileURL } from 'node:url';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const tempDirs: string[] = [];
+const ORIGINAL_HYBRIDCLAW_DATA_DIR = process.env.HYBRIDCLAW_DATA_DIR;
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_DISABLE_CONFIG_WATCHER =
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
 const ORIGINAL_WHATSAPP_SETUP_SETTLE_MS =
   process.env.HYBRIDCLAW_WHATSAPP_SETUP_SETTLE_MS;
 const ORIGINAL_EMAIL_PASSWORD = process.env.EMAIL_PASSWORD;
@@ -63,6 +67,10 @@ async function importFreshAgentMigrationCommand(options?: {
 }) {
   vi.resetModules();
   vi.doUnmock('../src/cli/agent-migration-command.js');
+  const runtimeHomeDir = createTempDir();
+  process.env.HYBRIDCLAW_DATA_DIR = runtimeHomeDir;
+  process.env.HOME = runtimeHomeDir;
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
   Object.defineProperty(process.stdin, 'isTTY', {
     configurable: true,
     value: true,
@@ -431,6 +439,10 @@ async function importFreshCli(options?: {
   };
 }) {
   vi.resetModules();
+  const runtimeHomeDir = createTempDir();
+  process.env.HYBRIDCLAW_DATA_DIR = runtimeHomeDir;
+  process.env.HOME = runtimeHomeDir;
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
   process.env.HYBRIDCLAW_WHATSAPP_SETUP_SETTLE_MS = '0';
   delete process.env.CI;
   Object.defineProperty(process.stdin, 'isTTY', {
@@ -1380,6 +1392,22 @@ afterEach(() => {
   } else {
     process.env.HYBRIDCLAW_WHATSAPP_SETUP_SETTLE_MS =
       ORIGINAL_WHATSAPP_SETUP_SETTLE_MS;
+  }
+  if (ORIGINAL_HYBRIDCLAW_DATA_DIR === undefined) {
+    delete process.env.HYBRIDCLAW_DATA_DIR;
+  } else {
+    process.env.HYBRIDCLAW_DATA_DIR = ORIGINAL_HYBRIDCLAW_DATA_DIR;
+  }
+  if (ORIGINAL_HOME === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = ORIGINAL_HOME;
+  }
+  if (ORIGINAL_DISABLE_CONFIG_WATCHER === undefined) {
+    delete process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
+  } else {
+    process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER =
+      ORIGINAL_DISABLE_CONFIG_WATCHER;
   }
   if (ORIGINAL_OPENROUTER_API_KEY === undefined) {
     delete process.env.OPENROUTER_API_KEY;

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -946,6 +946,29 @@ async function importFreshHealth(options?: {
       source: 'restore' as const,
     },
   ];
+  const getTestAdminAgentMarkdownFiles = (agentId: string) =>
+    agentId === 'writer'
+      ? writerAdminAgentMarkdownFiles
+      : mainAdminAgentMarkdownFiles;
+  const getTestAdminAgentMarkdownRevisions = (agentId: string) =>
+    agentId === 'writer'
+      ? writerAdminAgentMarkdownRevisions
+      : mainAdminAgentMarkdownRevisions;
+  const getTestAdminAgentMarkdownFile = (agentId: string, fileName: string) =>
+    getTestAdminAgentMarkdownFiles(agentId).find(
+      (entry) => entry.name === fileName,
+    );
+  const makeTestAdminAgent = (agentId: string) => ({
+    id: agentId,
+    name: agentId === 'writer' ? 'Writer' : 'Main Agent',
+    model: agentId === 'writer' ? null : 'gpt-5',
+    skills: null,
+    chatbotId: null,
+    enableRag: agentId === 'writer' ? null : true,
+    workspace: null,
+    workspacePath: `/tmp/${agentId}/workspace`,
+    markdownFiles: getTestAdminAgentMarkdownFiles(agentId),
+  });
   const getGatewayAdminAgents = vi.fn(() => ({
     agents: [
       {
@@ -963,57 +986,20 @@ async function importFreshHealth(options?: {
   }));
   const getGatewayAdminAgentMarkdownFile = vi.fn(
     (agentId: string, fileName: string) => ({
-      agent: {
-        id: agentId,
-        name: agentId === 'writer' ? 'Writer' : 'Main Agent',
-        model: agentId === 'writer' ? null : 'gpt-5',
-        skills: null,
-        chatbotId: null,
-        enableRag: agentId === 'writer' ? null : true,
-        workspace: null,
-        workspacePath: `/tmp/${agentId}/workspace`,
-        markdownFiles:
-          agentId === 'writer'
-            ? writerAdminAgentMarkdownFiles
-            : mainAdminAgentMarkdownFiles,
-      },
+      agent: makeTestAdminAgent(agentId),
       file: {
-        ...(agentId === 'writer'
-          ? writerAdminAgentMarkdownFiles.find(
-              (entry) => entry.name === fileName,
-            )
-          : mainAdminAgentMarkdownFiles.find(
-              (entry) => entry.name === fileName,
-            )),
+        ...getTestAdminAgentMarkdownFile(agentId, fileName),
         content: `# ${agentId}:${fileName}\n`,
-        revisions:
-          agentId === 'writer'
-            ? writerAdminAgentMarkdownRevisions
-            : mainAdminAgentMarkdownRevisions,
+        revisions: getTestAdminAgentMarkdownRevisions(agentId),
       },
     }),
   );
   const getGatewayAdminAgentMarkdownRevision = vi.fn(
     (params: { agentId: string; fileName: string; revisionId: string }) => ({
-      agent: {
-        id: params.agentId,
-        name: params.agentId === 'writer' ? 'Writer' : 'Main Agent',
-        model: params.agentId === 'writer' ? null : 'gpt-5',
-        skills: null,
-        chatbotId: null,
-        enableRag: params.agentId === 'writer' ? null : true,
-        workspace: null,
-        workspacePath: `/tmp/${params.agentId}/workspace`,
-        markdownFiles:
-          params.agentId === 'writer'
-            ? writerAdminAgentMarkdownFiles
-            : mainAdminAgentMarkdownFiles,
-      },
+      agent: makeTestAdminAgent(params.agentId),
       fileName: params.fileName,
       revision: {
-        ...(params.agentId === 'writer'
-          ? writerAdminAgentMarkdownRevisions[0]
-          : mainAdminAgentMarkdownRevisions[0]),
+        ...getTestAdminAgentMarkdownRevisions(params.agentId)[0],
         id: params.revisionId,
         content: `# revision ${params.agentId}:${params.fileName}:${params.revisionId}\n`,
       },
@@ -1166,65 +1152,21 @@ async function importFreshHealth(options?: {
   );
   const saveGatewayAdminAgentMarkdownFile = vi.fn(
     (params: { agentId: string; fileName: string; content: string }) => ({
-      agent: {
-        id: params.agentId,
-        name: params.agentId === 'writer' ? 'Writer' : 'Main Agent',
-        model: params.agentId === 'writer' ? null : 'gpt-5',
-        skills: null,
-        chatbotId: null,
-        enableRag: params.agentId === 'writer' ? null : true,
-        workspace: null,
-        workspacePath: `/tmp/${params.agentId}/workspace`,
-        markdownFiles:
-          params.agentId === 'writer'
-            ? writerAdminAgentMarkdownFiles
-            : mainAdminAgentMarkdownFiles,
-      },
+      agent: makeTestAdminAgent(params.agentId),
       file: {
-        ...(params.agentId === 'writer'
-          ? writerAdminAgentMarkdownFiles.find(
-              (entry) => entry.name === params.fileName,
-            )
-          : mainAdminAgentMarkdownFiles.find(
-              (entry) => entry.name === params.fileName,
-            )),
+        ...getTestAdminAgentMarkdownFile(params.agentId, params.fileName),
         content: params.content,
-        revisions:
-          params.agentId === 'writer'
-            ? writerAdminAgentMarkdownRevisions
-            : mainAdminAgentMarkdownRevisions,
+        revisions: getTestAdminAgentMarkdownRevisions(params.agentId),
       },
     }),
   );
   const restoreGatewayAdminAgentMarkdownRevision = vi.fn(
     (params: { agentId: string; fileName: string; revisionId: string }) => ({
-      agent: {
-        id: params.agentId,
-        name: params.agentId === 'writer' ? 'Writer' : 'Main Agent',
-        model: params.agentId === 'writer' ? null : 'gpt-5',
-        skills: null,
-        chatbotId: null,
-        enableRag: params.agentId === 'writer' ? null : true,
-        workspace: null,
-        workspacePath: `/tmp/${params.agentId}/workspace`,
-        markdownFiles:
-          params.agentId === 'writer'
-            ? writerAdminAgentMarkdownFiles
-            : mainAdminAgentMarkdownFiles,
-      },
+      agent: makeTestAdminAgent(params.agentId),
       file: {
-        ...(params.agentId === 'writer'
-          ? writerAdminAgentMarkdownFiles.find(
-              (entry) => entry.name === params.fileName,
-            )
-          : mainAdminAgentMarkdownFiles.find(
-              (entry) => entry.name === params.fileName,
-            )),
+        ...getTestAdminAgentMarkdownFile(params.agentId, params.fileName),
         content: `# restored ${params.revisionId}\n`,
-        revisions:
-          params.agentId === 'writer'
-            ? writerAdminAgentMarkdownRevisions
-            : mainAdminAgentMarkdownRevisions,
+        revisions: getTestAdminAgentMarkdownRevisions(params.agentId),
       },
     }),
   );
@@ -3858,6 +3800,20 @@ describe('gateway HTTP server', () => {
     });
   });
 
+  test('returns 404 for admin agent routes with a blank decoded agent id segment', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({ url: '/api/admin/agents/%20' });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.updateGatewayAdminAgent).not.toHaveBeenCalled();
+    expect(state.deleteGatewayAdminAgent).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Not Found' });
+  });
+
   test('passes skill allowlists through admin agent creation requests', async () => {
     const state = await importFreshHealth();
     const req = makeRequest({
@@ -4111,6 +4067,44 @@ describe('gateway HTTP server', () => {
         source: 'save',
         content: '# revision main:AGENTS.md:main-rev-1\n',
       },
+    });
+  });
+
+  test('returns 404 for known admin agent markdown revision not-found errors', async () => {
+    const state = await importFreshHealth();
+    state.getGatewayAdminAgentMarkdownRevision.mockImplementationOnce(() => {
+      throw new Error('Revision "missing-rev" was not found.');
+    });
+    const req = makeRequest({
+      url: '/api/admin/agents/main/files/AGENTS.md/revisions/missing-rev',
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Revision "missing-rev" was not found.',
+    });
+  });
+
+  test('returns 400 for unrelated admin agent errors that contain "not found"', async () => {
+    const state = await importFreshHealth();
+    state.getGatewayAdminAgentMarkdownRevision.mockImplementationOnce(() => {
+      throw new Error('Validation key not found in request body.');
+    });
+    const req = makeRequest({
+      url: '/api/admin/agents/main/files/AGENTS.md/revisions/main-rev-1',
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Validation key not found in request body.',
     });
   });
 

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -896,6 +896,56 @@ async function importFreshHealth(options?: {
     providerStatus: {},
     models: [],
   }));
+  const mainAdminAgentMarkdownFiles = [
+    {
+      name: 'AGENTS.md',
+      path: '/tmp/main/workspace/AGENTS.md',
+      exists: true,
+      updatedAt: '2026-04-13T10:00:00.000Z',
+      sizeBytes: 120,
+    },
+    {
+      name: 'USER.md',
+      path: '/tmp/main/workspace/USER.md',
+      exists: false,
+      updatedAt: null,
+      sizeBytes: null,
+    },
+  ];
+  const writerAdminAgentMarkdownFiles = [
+    {
+      name: 'AGENTS.md',
+      path: '/tmp/writer/workspace/AGENTS.md',
+      exists: true,
+      updatedAt: '2026-04-13T11:00:00.000Z',
+      sizeBytes: 64,
+    },
+    {
+      name: 'USER.md',
+      path: '/tmp/writer/workspace/USER.md',
+      exists: true,
+      updatedAt: '2026-04-13T12:00:00.000Z',
+      sizeBytes: 72,
+    },
+  ];
+  const mainAdminAgentMarkdownRevisions = [
+    {
+      id: 'main-rev-1',
+      createdAt: '2026-04-13T09:00:00.000Z',
+      sizeBytes: 96,
+      sha256: 'mainsha',
+      source: 'save' as const,
+    },
+  ];
+  const writerAdminAgentMarkdownRevisions = [
+    {
+      id: 'writer-rev-1',
+      createdAt: '2026-04-13T11:30:00.000Z',
+      sizeBytes: 72,
+      sha256: 'writersha',
+      source: 'restore' as const,
+    },
+  ];
   const getGatewayAdminAgents = vi.fn(() => ({
     agents: [
       {
@@ -907,9 +957,68 @@ async function importFreshHealth(options?: {
         enableRag: true,
         workspace: null,
         workspacePath: '/tmp/main/workspace',
+        markdownFiles: mainAdminAgentMarkdownFiles,
       },
     ],
   }));
+  const getGatewayAdminAgentMarkdownFile = vi.fn(
+    (agentId: string, fileName: string) => ({
+      agent: {
+        id: agentId,
+        name: agentId === 'writer' ? 'Writer' : 'Main Agent',
+        model: agentId === 'writer' ? null : 'gpt-5',
+        skills: null,
+        chatbotId: null,
+        enableRag: agentId === 'writer' ? null : true,
+        workspace: null,
+        workspacePath: `/tmp/${agentId}/workspace`,
+        markdownFiles:
+          agentId === 'writer'
+            ? writerAdminAgentMarkdownFiles
+            : mainAdminAgentMarkdownFiles,
+      },
+      file: {
+        ...(agentId === 'writer'
+          ? writerAdminAgentMarkdownFiles.find(
+              (entry) => entry.name === fileName,
+            )
+          : mainAdminAgentMarkdownFiles.find(
+              (entry) => entry.name === fileName,
+            )),
+        content: `# ${agentId}:${fileName}\n`,
+        revisions:
+          agentId === 'writer'
+            ? writerAdminAgentMarkdownRevisions
+            : mainAdminAgentMarkdownRevisions,
+      },
+    }),
+  );
+  const getGatewayAdminAgentMarkdownRevision = vi.fn(
+    (params: { agentId: string; fileName: string; revisionId: string }) => ({
+      agent: {
+        id: params.agentId,
+        name: params.agentId === 'writer' ? 'Writer' : 'Main Agent',
+        model: params.agentId === 'writer' ? null : 'gpt-5',
+        skills: null,
+        chatbotId: null,
+        enableRag: params.agentId === 'writer' ? null : true,
+        workspace: null,
+        workspacePath: `/tmp/${params.agentId}/workspace`,
+        markdownFiles:
+          params.agentId === 'writer'
+            ? writerAdminAgentMarkdownFiles
+            : mainAdminAgentMarkdownFiles,
+      },
+      fileName: params.fileName,
+      revision: {
+        ...(params.agentId === 'writer'
+          ? writerAdminAgentMarkdownRevisions[0]
+          : mainAdminAgentMarkdownRevisions[0]),
+        id: params.revisionId,
+        content: `# revision ${params.agentId}:${params.fileName}:${params.revisionId}\n`,
+      },
+    }),
+  );
   const getGatewayAdminSessions = vi.fn(() => []);
   const getGatewayAdminScheduler = vi.fn(() => ({
     jobs: [],
@@ -1022,6 +1131,7 @@ async function importFreshHealth(options?: {
           typeof payload.enableRag === 'boolean' ? payload.enableRag : null,
         workspace: payload.workspace || null,
         workspacePath: '/tmp/main/workspace',
+        markdownFiles: mainAdminAgentMarkdownFiles,
       },
     }),
   );
@@ -1047,6 +1157,74 @@ async function importFreshHealth(options?: {
           typeof payload.enableRag === 'boolean' ? payload.enableRag : null,
         workspace: payload.workspace || null,
         workspacePath: `/tmp/${agentId}/workspace`,
+        markdownFiles:
+          agentId === 'writer'
+            ? writerAdminAgentMarkdownFiles
+            : mainAdminAgentMarkdownFiles,
+      },
+    }),
+  );
+  const saveGatewayAdminAgentMarkdownFile = vi.fn(
+    (params: { agentId: string; fileName: string; content: string }) => ({
+      agent: {
+        id: params.agentId,
+        name: params.agentId === 'writer' ? 'Writer' : 'Main Agent',
+        model: params.agentId === 'writer' ? null : 'gpt-5',
+        skills: null,
+        chatbotId: null,
+        enableRag: params.agentId === 'writer' ? null : true,
+        workspace: null,
+        workspacePath: `/tmp/${params.agentId}/workspace`,
+        markdownFiles:
+          params.agentId === 'writer'
+            ? writerAdminAgentMarkdownFiles
+            : mainAdminAgentMarkdownFiles,
+      },
+      file: {
+        ...(params.agentId === 'writer'
+          ? writerAdminAgentMarkdownFiles.find(
+              (entry) => entry.name === params.fileName,
+            )
+          : mainAdminAgentMarkdownFiles.find(
+              (entry) => entry.name === params.fileName,
+            )),
+        content: params.content,
+        revisions:
+          params.agentId === 'writer'
+            ? writerAdminAgentMarkdownRevisions
+            : mainAdminAgentMarkdownRevisions,
+      },
+    }),
+  );
+  const restoreGatewayAdminAgentMarkdownRevision = vi.fn(
+    (params: { agentId: string; fileName: string; revisionId: string }) => ({
+      agent: {
+        id: params.agentId,
+        name: params.agentId === 'writer' ? 'Writer' : 'Main Agent',
+        model: params.agentId === 'writer' ? null : 'gpt-5',
+        skills: null,
+        chatbotId: null,
+        enableRag: params.agentId === 'writer' ? null : true,
+        workspace: null,
+        workspacePath: `/tmp/${params.agentId}/workspace`,
+        markdownFiles:
+          params.agentId === 'writer'
+            ? writerAdminAgentMarkdownFiles
+            : mainAdminAgentMarkdownFiles,
+      },
+      file: {
+        ...(params.agentId === 'writer'
+          ? writerAdminAgentMarkdownFiles.find(
+              (entry) => entry.name === params.fileName,
+            )
+          : mainAdminAgentMarkdownFiles.find(
+              (entry) => entry.name === params.fileName,
+            )),
+        content: `# restored ${params.revisionId}\n`,
+        revisions:
+          params.agentId === 'writer'
+            ? writerAdminAgentMarkdownRevisions
+            : mainAdminAgentMarkdownRevisions,
       },
     }),
   );
@@ -1212,6 +1390,8 @@ async function importFreshHealth(options?: {
     GatewayRequestError,
     getGatewayAgents,
     getGatewayAdminAgents,
+    getGatewayAdminAgentMarkdownFile,
+    getGatewayAdminAgentMarkdownRevision,
     getGatewayAdminAudit,
     getGatewayAdminChannels,
     getGatewayAdminConfig,
@@ -1238,7 +1418,9 @@ async function importFreshHealth(options?: {
     resolveGatewayChatbotId,
     removeGatewayAdminChannel,
     removeGatewayAdminMcpServer,
+    restoreGatewayAdminAgentMarkdownRevision,
     saveGatewayAdminConfig,
+    saveGatewayAdminAgentMarkdownFile,
     saveGatewayAdminModels,
     setGatewayAdminSkillEnabled,
     updateGatewayAdminAgent,
@@ -1331,6 +1513,8 @@ async function importFreshHealth(options?: {
     getGatewayAdminEmailMessage,
     getGatewayAgents,
     getGatewayAdminAgents,
+    getGatewayAdminAgentMarkdownFile,
+    getGatewayAdminAgentMarkdownRevision,
     runGatewayPluginTool,
     getGatewayAdminModels,
     getGatewayAdminPlugins,
@@ -1349,7 +1533,9 @@ async function importFreshHealth(options?: {
     requestGatewayRestart,
     createGatewayAdminAgent,
     createGatewayAdminSkill,
+    restoreGatewayAdminAgentMarkdownRevision,
     updateGatewayAdminAgent,
+    saveGatewayAdminAgentMarkdownFile,
     deleteGatewayAdminAgent,
     GatewayRequestError,
     setGatewayAdminSkillEnabled,
@@ -3651,6 +3837,22 @@ describe('gateway HTTP server', () => {
           enableRag: true,
           workspace: null,
           workspacePath: '/tmp/main/workspace',
+          markdownFiles: [
+            {
+              name: 'AGENTS.md',
+              path: '/tmp/main/workspace/AGENTS.md',
+              exists: true,
+              updatedAt: '2026-04-13T10:00:00.000Z',
+              sizeBytes: 120,
+            },
+            {
+              name: 'USER.md',
+              path: '/tmp/main/workspace/USER.md',
+              exists: false,
+              updatedAt: null,
+              sizeBytes: null,
+            },
+          ],
         },
       ],
     });
@@ -3694,6 +3896,22 @@ describe('gateway HTTP server', () => {
         enableRag: null,
         workspace: null,
         workspacePath: '/tmp/main/workspace',
+        markdownFiles: [
+          {
+            name: 'AGENTS.md',
+            path: '/tmp/main/workspace/AGENTS.md',
+            exists: true,
+            updatedAt: '2026-04-13T10:00:00.000Z',
+            sizeBytes: 120,
+          },
+          {
+            name: 'USER.md',
+            path: '/tmp/main/workspace/USER.md',
+            exists: false,
+            updatedAt: null,
+            sizeBytes: null,
+          },
+        ],
       },
     });
   });
@@ -3759,7 +3977,304 @@ describe('gateway HTTP server', () => {
         enableRag: null,
         workspace: null,
         workspacePath: '/tmp/writer/workspace',
+        markdownFiles: [
+          {
+            name: 'AGENTS.md',
+            path: '/tmp/writer/workspace/AGENTS.md',
+            exists: true,
+            updatedAt: '2026-04-13T11:00:00.000Z',
+            sizeBytes: 64,
+          },
+          {
+            name: 'USER.md',
+            path: '/tmp/writer/workspace/USER.md',
+            exists: true,
+            updatedAt: '2026-04-13T12:00:00.000Z',
+            sizeBytes: 72,
+          },
+        ],
       },
+    });
+  });
+
+  test('returns the selected admin agent markdown file', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({
+      url: '/api/admin/agents/main/files/AGENTS.md',
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.getGatewayAdminAgentMarkdownFile).toHaveBeenCalledWith(
+      'main',
+      'AGENTS.md',
+    );
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({
+      agent: {
+        id: 'main',
+        name: 'Main Agent',
+        model: 'gpt-5',
+        skills: null,
+        chatbotId: null,
+        enableRag: true,
+        workspace: null,
+        workspacePath: '/tmp/main/workspace',
+        markdownFiles: [
+          {
+            name: 'AGENTS.md',
+            path: '/tmp/main/workspace/AGENTS.md',
+            exists: true,
+            updatedAt: '2026-04-13T10:00:00.000Z',
+            sizeBytes: 120,
+          },
+          {
+            name: 'USER.md',
+            path: '/tmp/main/workspace/USER.md',
+            exists: false,
+            updatedAt: null,
+            sizeBytes: null,
+          },
+        ],
+      },
+      file: {
+        name: 'AGENTS.md',
+        path: '/tmp/main/workspace/AGENTS.md',
+        exists: true,
+        updatedAt: '2026-04-13T10:00:00.000Z',
+        sizeBytes: 120,
+        content: '# main:AGENTS.md\n',
+        revisions: [
+          {
+            id: 'main-rev-1',
+            createdAt: '2026-04-13T09:00:00.000Z',
+            sizeBytes: 96,
+            sha256: 'mainsha',
+            source: 'save',
+          },
+        ],
+      },
+    });
+  });
+
+  test('returns the selected admin agent markdown revision', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({
+      url: '/api/admin/agents/main/files/AGENTS.md/revisions/main-rev-1',
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.getGatewayAdminAgentMarkdownRevision).toHaveBeenCalledWith({
+      agentId: 'main',
+      fileName: 'AGENTS.md',
+      revisionId: 'main-rev-1',
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({
+      agent: {
+        id: 'main',
+        name: 'Main Agent',
+        model: 'gpt-5',
+        skills: null,
+        chatbotId: null,
+        enableRag: true,
+        workspace: null,
+        workspacePath: '/tmp/main/workspace',
+        markdownFiles: [
+          {
+            name: 'AGENTS.md',
+            path: '/tmp/main/workspace/AGENTS.md',
+            exists: true,
+            updatedAt: '2026-04-13T10:00:00.000Z',
+            sizeBytes: 120,
+          },
+          {
+            name: 'USER.md',
+            path: '/tmp/main/workspace/USER.md',
+            exists: false,
+            updatedAt: null,
+            sizeBytes: null,
+          },
+        ],
+      },
+      fileName: 'AGENTS.md',
+      revision: {
+        id: 'main-rev-1',
+        createdAt: '2026-04-13T09:00:00.000Z',
+        sizeBytes: 96,
+        sha256: 'mainsha',
+        source: 'save',
+        content: '# revision main:AGENTS.md:main-rev-1\n',
+      },
+    });
+  });
+
+  test('saves the selected admin agent markdown file', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({
+      method: 'PUT',
+      url: '/api/admin/agents/writer/files/USER.md',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: {
+        content: '# Updated writer prompt\n',
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.saveGatewayAdminAgentMarkdownFile).toHaveBeenCalledWith({
+      agentId: 'writer',
+      fileName: 'USER.md',
+      content: '# Updated writer prompt\n',
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({
+      agent: {
+        id: 'writer',
+        name: 'Writer',
+        model: null,
+        skills: null,
+        chatbotId: null,
+        enableRag: null,
+        workspace: null,
+        workspacePath: '/tmp/writer/workspace',
+        markdownFiles: [
+          {
+            name: 'AGENTS.md',
+            path: '/tmp/writer/workspace/AGENTS.md',
+            exists: true,
+            updatedAt: '2026-04-13T11:00:00.000Z',
+            sizeBytes: 64,
+          },
+          {
+            name: 'USER.md',
+            path: '/tmp/writer/workspace/USER.md',
+            exists: true,
+            updatedAt: '2026-04-13T12:00:00.000Z',
+            sizeBytes: 72,
+          },
+        ],
+      },
+      file: {
+        name: 'USER.md',
+        path: '/tmp/writer/workspace/USER.md',
+        exists: true,
+        updatedAt: '2026-04-13T12:00:00.000Z',
+        sizeBytes: 72,
+        content: '# Updated writer prompt\n',
+        revisions: [
+          {
+            id: 'writer-rev-1',
+            createdAt: '2026-04-13T11:30:00.000Z',
+            sizeBytes: 72,
+            sha256: 'writersha',
+            source: 'restore',
+          },
+        ],
+      },
+    });
+  });
+
+  test('restores the selected admin agent markdown revision', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/admin/agents/writer/files/USER.md/revisions/writer-rev-1/restore',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: {},
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.restoreGatewayAdminAgentMarkdownRevision).toHaveBeenCalledWith(
+      {
+        agentId: 'writer',
+        fileName: 'USER.md',
+        revisionId: 'writer-rev-1',
+      },
+    );
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({
+      agent: {
+        id: 'writer',
+        name: 'Writer',
+        model: null,
+        skills: null,
+        chatbotId: null,
+        enableRag: null,
+        workspace: null,
+        workspacePath: '/tmp/writer/workspace',
+        markdownFiles: [
+          {
+            name: 'AGENTS.md',
+            path: '/tmp/writer/workspace/AGENTS.md',
+            exists: true,
+            updatedAt: '2026-04-13T11:00:00.000Z',
+            sizeBytes: 64,
+          },
+          {
+            name: 'USER.md',
+            path: '/tmp/writer/workspace/USER.md',
+            exists: true,
+            updatedAt: '2026-04-13T12:00:00.000Z',
+            sizeBytes: 72,
+          },
+        ],
+      },
+      file: {
+        name: 'USER.md',
+        path: '/tmp/writer/workspace/USER.md',
+        exists: true,
+        updatedAt: '2026-04-13T12:00:00.000Z',
+        sizeBytes: 72,
+        content: '# restored writer-rev-1\n',
+        revisions: [
+          {
+            id: 'writer-rev-1',
+            createdAt: '2026-04-13T11:30:00.000Z',
+            sizeBytes: 72,
+            sha256: 'writersha',
+            source: 'restore',
+          },
+        ],
+      },
+    });
+  });
+
+  test('returns 400 when admin agent markdown content is not a string', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({
+      method: 'PUT',
+      url: '/api/admin/agents/writer/files/USER.md',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: {
+        content: 42,
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.saveGatewayAdminAgentMarkdownFile).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Expected string `content` in request body.',
     });
   });
 

--- a/tests/gateway-service.agent-markdown.test.ts
+++ b/tests/gateway-service.agent-markdown.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import { setupGatewayTest } from './helpers/gateway-test-setup.js';
 
@@ -160,9 +160,477 @@ test('rejects oversized revision restores before mutating the workspace file', a
       fileName: 'AGENTS.md',
       revisionId: 'oversized',
     }),
-  ).toThrow('Markdown content exceeds the 200000-byte admin editor limit.');
+  ).toThrow(
+    'Markdown revision content exceeds the 200000-byte admin editor limit.',
+  );
 
   expect(fs.readFileSync(path.join(workspacePath, 'AGENTS.md'), 'utf-8')).toBe(
     '# AGENTS.md\n\n- Keep responses concise.\n',
   );
+});
+
+test('caps markdown revisions to the newest 50 saves', async () => {
+  setupHome();
+
+  const { agentWorkspaceDir } = await import('../src/infra/ipc.js');
+  const {
+    getGatewayAdminAgentMarkdownFile,
+    saveGatewayAdminAgentMarkdownFile,
+  } = await import('../src/gateway/gateway-service.ts');
+
+  const baseTimeMs = Date.parse('2026-04-13T10:00:00.000Z');
+  const createdRevisionIds: string[] = [];
+  vi.useFakeTimers();
+  try {
+    vi.setSystemTime(new Date(baseTimeMs));
+    saveGatewayAdminAgentMarkdownFile({
+      agentId: 'main',
+      fileName: 'AGENTS.md',
+      content: '# Version 0\n',
+    });
+
+    for (let index = 1; index <= 55; index += 1) {
+      vi.setSystemTime(new Date(baseTimeMs + index * 1_000));
+      const response = saveGatewayAdminAgentMarkdownFile({
+        agentId: 'main',
+        fileName: 'AGENTS.md',
+        content: `# Version ${index}\n`,
+      });
+      const revisionId = response.file.revisions[0]?.id;
+      if (!revisionId) {
+        throw new Error(`Expected revision id for save ${index}.`);
+      }
+      createdRevisionIds.push(revisionId);
+    }
+  } finally {
+    vi.useRealTimers();
+  }
+
+  const workspacePath = agentWorkspaceDir('main');
+  const revisionDir = path.join(
+    path.dirname(workspacePath),
+    'markdown-revisions',
+    'AGENTS.md',
+  );
+  const revisionFiles = fs
+    .readdirSync(revisionDir)
+    .filter((entry) => entry.endsWith('.json'));
+  expect(revisionFiles).toHaveLength(50);
+
+  const loaded = getGatewayAdminAgentMarkdownFile('main', 'AGENTS.md');
+  expect(loaded.file.revisions).toHaveLength(50);
+  expect(loaded.file.revisions.map((revision) => revision.id)).toEqual(
+    createdRevisionIds.slice(-50).reverse(),
+  );
+});
+
+test('lists admin agents with one workspace directory scan instead of per-file stats', async () => {
+  setupHome();
+
+  const { agentWorkspaceDir } = await import('../src/infra/ipc.js');
+  const { getGatewayAdminAgents, saveGatewayAdminAgentMarkdownFile } =
+    await import('../src/gateway/gateway-service.ts');
+  const { WORKSPACE_BOOTSTRAP_FILES } = await import('../src/workspace.ts');
+
+  saveGatewayAdminAgentMarkdownFile({
+    agentId: 'main',
+    fileName: 'AGENTS.md',
+    content: '# AGENTS.md\n\n- Keep responses concise.\n',
+  });
+
+  const workspacePath = agentWorkspaceDir('main');
+  const bootstrapFilePaths = new Set(
+    WORKSPACE_BOOTSTRAP_FILES.map((fileName) =>
+      path.join(workspacePath, fileName),
+    ),
+  );
+  const statSpy = vi.spyOn(fs, 'statSync');
+  const readdirSpy = vi.spyOn(fs, 'readdirSync');
+
+  try {
+    statSpy.mockClear();
+    readdirSpy.mockClear();
+
+    const response = getGatewayAdminAgents();
+    const mainAgent = response.agents.find((agent) => agent.id === 'main');
+    const mainAgentsFile = mainAgent?.markdownFiles.find(
+      (file) => file.name === 'AGENTS.md',
+    );
+
+    expect(mainAgentsFile).toEqual({
+      name: 'AGENTS.md',
+      path: path.join(workspacePath, 'AGENTS.md'),
+      exists: true,
+      updatedAt: null,
+      sizeBytes: null,
+    });
+
+    const bootstrapStatCalls = statSpy.mock.calls.filter(([targetPath]) => {
+      return (
+        typeof targetPath === 'string' && bootstrapFilePaths.has(targetPath)
+      );
+    });
+    const workspaceReadCalls = readdirSpy.mock.calls.filter(([targetPath]) => {
+      return targetPath === workspacePath;
+    });
+
+    expect(bootstrapStatCalls).toHaveLength(0);
+    expect(workspaceReadCalls).toHaveLength(1);
+  } finally {
+    statSpy.mockRestore();
+    readdirSpy.mockRestore();
+  }
+});
+
+test('reads only the newest 50 markdown revision files when listing versions', async () => {
+  setupHome();
+
+  const { agentWorkspaceDir } = await import('../src/infra/ipc.js');
+  const {
+    getGatewayAdminAgentMarkdownFile,
+    saveGatewayAdminAgentMarkdownFile,
+  } = await import('../src/gateway/gateway-service.ts');
+
+  saveGatewayAdminAgentMarkdownFile({
+    agentId: 'main',
+    fileName: 'AGENTS.md',
+    content: '# Current Rules\n',
+  });
+
+  const workspacePath = agentWorkspaceDir('main');
+  const revisionDir = path.join(
+    path.dirname(workspacePath),
+    'markdown-revisions',
+    'AGENTS.md',
+  );
+  fs.mkdirSync(revisionDir, { recursive: true });
+
+  const baseTimeMs = Date.parse('2026-04-13T12:00:00.000Z');
+  const revisionIds: string[] = [];
+  for (let index = 1; index <= 60; index += 1) {
+    const timestampMs = baseTimeMs + index * 1_000;
+    const revisionId = `${timestampMs.toString(36)}-rev${index
+      .toString()
+      .padStart(2, '0')}`;
+    revisionIds.push(revisionId);
+    fs.writeFileSync(
+      path.join(revisionDir, `${revisionId}.json`),
+      JSON.stringify(
+        {
+          id: revisionId,
+          fileName: 'AGENTS.md',
+          createdAt: new Date(timestampMs).toISOString(),
+          sizeBytes: index,
+          sha256: `sha-${index}`,
+          source: index % 2 === 0 ? 'restore' : 'save',
+          content: `# Revision ${index}\n`,
+        },
+        null,
+        2,
+      ),
+      'utf-8',
+    );
+  }
+
+  const readSpy = vi.spyOn(fs, 'readFileSync');
+  try {
+    readSpy.mockClear();
+
+    const loaded = getGatewayAdminAgentMarkdownFile('main', 'AGENTS.md');
+    expect(loaded.file.revisions).toHaveLength(50);
+    expect(loaded.file.revisions.map((revision) => revision.id)).toEqual(
+      revisionIds.slice(-50).reverse(),
+    );
+
+    const revisionReadCalls = readSpy.mock.calls.filter(([targetPath]) => {
+      return (
+        typeof targetPath === 'string' &&
+        targetPath.startsWith(revisionDir) &&
+        targetPath.endsWith('.json')
+      );
+    });
+
+    expect(revisionReadCalls).toHaveLength(50);
+  } finally {
+    readSpy.mockRestore();
+  }
+});
+
+test('lists split revision metadata without reading revision content files', async () => {
+  setupHome();
+
+  const { agentWorkspaceDir } = await import('../src/infra/ipc.js');
+  const {
+    getGatewayAdminAgentMarkdownFile,
+    saveGatewayAdminAgentMarkdownFile,
+  } = await import('../src/gateway/gateway-service.ts');
+
+  const baseTimeMs = Date.parse('2026-04-13T14:00:00.000Z');
+  vi.useFakeTimers();
+  try {
+    vi.setSystemTime(new Date(baseTimeMs));
+    saveGatewayAdminAgentMarkdownFile({
+      agentId: 'main',
+      fileName: 'AGENTS.md',
+      content: '# Version 0\n',
+    });
+
+    for (let index = 1; index <= 55; index += 1) {
+      vi.setSystemTime(new Date(baseTimeMs + index * 1_000));
+      saveGatewayAdminAgentMarkdownFile({
+        agentId: 'main',
+        fileName: 'AGENTS.md',
+        content: `# Version ${index}\n`,
+      });
+    }
+  } finally {
+    vi.useRealTimers();
+  }
+
+  const workspacePath = agentWorkspaceDir('main');
+  const revisionDir = path.join(
+    path.dirname(workspacePath),
+    'markdown-revisions',
+    'AGENTS.md',
+  );
+  expect(
+    fs
+      .readdirSync(revisionDir)
+      .filter((entry) => entry.endsWith('.json') || entry.endsWith('.md')),
+  ).toHaveLength(100);
+
+  const readSpy = vi.spyOn(fs, 'readFileSync');
+  try {
+    readSpy.mockClear();
+
+    const loaded = getGatewayAdminAgentMarkdownFile('main', 'AGENTS.md');
+    expect(loaded.file.revisions).toHaveLength(50);
+
+    const revisionMetadataReadCalls = readSpy.mock.calls.filter(
+      ([targetPath]) => {
+        return (
+          typeof targetPath === 'string' &&
+          targetPath.startsWith(revisionDir) &&
+          targetPath.endsWith('.json')
+        );
+      },
+    );
+    const revisionContentReadCalls = readSpy.mock.calls.filter(
+      ([targetPath]) => {
+        return (
+          typeof targetPath === 'string' &&
+          targetPath.startsWith(revisionDir) &&
+          targetPath.endsWith('.md')
+        );
+      },
+    );
+
+    expect(revisionMetadataReadCalls).toHaveLength(50);
+    expect(revisionContentReadCalls).toHaveLength(0);
+  } finally {
+    readSpy.mockRestore();
+  }
+});
+
+test('rejects invalid revision ids before reading revision files', async () => {
+  setupHome();
+
+  const {
+    getGatewayAdminAgentMarkdownRevision,
+    restoreGatewayAdminAgentMarkdownRevision,
+    saveGatewayAdminAgentMarkdownFile,
+  } = await import('../src/gateway/gateway-service.ts');
+
+  saveGatewayAdminAgentMarkdownFile({
+    agentId: 'main',
+    fileName: 'AGENTS.md',
+    content: '# AGENTS.md\n\n- Keep responses concise.\n',
+  });
+
+  expect(() =>
+    getGatewayAdminAgentMarkdownRevision({
+      agentId: 'main',
+      fileName: 'AGENTS.md',
+      revisionId: '../outside',
+    }),
+  ).toThrow('Revision id is invalid.');
+
+  expect(() =>
+    restoreGatewayAdminAgentMarkdownRevision({
+      agentId: 'main',
+      fileName: 'AGENTS.md',
+      revisionId: '../outside',
+    }),
+  ).toThrow('Revision id is invalid.');
+});
+
+test('reuses the resolved agent config within a markdown file detail request', async () => {
+  setupHome();
+
+  const agentRegistry = await import('../src/agents/agent-registry.ts');
+  const resolveSpy = vi.spyOn(agentRegistry, 'resolveAgentConfig');
+  const {
+    getGatewayAdminAgentMarkdownFile,
+    saveGatewayAdminAgentMarkdownFile,
+  } = await import('../src/gateway/gateway-service.ts');
+
+  saveGatewayAdminAgentMarkdownFile({
+    agentId: 'main',
+    fileName: 'AGENTS.md',
+    content: '# AGENTS.md\n\n- Keep responses concise.\n',
+  });
+
+  resolveSpy.mockClear();
+
+  const response = getGatewayAdminAgentMarkdownFile('main', 'AGENTS.md');
+  expect(response.file.content).toBe(
+    '# AGENTS.md\n\n- Keep responses concise.\n',
+  );
+  expect(
+    resolveSpy.mock.calls.filter(([agentId]) => agentId === 'main'),
+  ).toHaveLength(1);
+});
+
+test('reuses the target markdown file state within a save request', async () => {
+  setupHome();
+
+  const { agentWorkspaceDir } = await import('../src/infra/ipc.js');
+  const { saveGatewayAdminAgentMarkdownFile } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+  const { WORKSPACE_BOOTSTRAP_FILES } = await import('../src/workspace.ts');
+
+  saveGatewayAdminAgentMarkdownFile({
+    agentId: 'main',
+    fileName: 'AGENTS.md',
+    content: '# AGENTS.md\n\n- Keep responses concise.\n',
+  });
+
+  const workspacePath = agentWorkspaceDir('main');
+  const filePath = path.join(workspacePath, 'AGENTS.md');
+  const otherBootstrapFilePaths = new Set(
+    WORKSPACE_BOOTSTRAP_FILES.map((fileName) =>
+      path.join(workspacePath, fileName),
+    ).filter((targetPath) => targetPath !== filePath),
+  );
+  const statSpy = vi.spyOn(fs, 'statSync');
+  const readSpy = vi.spyOn(fs, 'readFileSync');
+  const readdirSpy = vi.spyOn(fs, 'readdirSync');
+
+  try {
+    statSpy.mockClear();
+    readSpy.mockClear();
+    readdirSpy.mockClear();
+
+    saveGatewayAdminAgentMarkdownFile({
+      agentId: 'main',
+      fileName: 'AGENTS.md',
+      content: '# AGENTS.md\n\n- Prefer concise answers.\n',
+    });
+
+    const targetStatCalls = statSpy.mock.calls.filter(([targetPath]) => {
+      return targetPath === filePath;
+    });
+    const targetReadCalls = readSpy.mock.calls.filter(([targetPath]) => {
+      return targetPath === filePath;
+    });
+    const otherBootstrapStatCalls = statSpy.mock.calls.filter(
+      ([targetPath]) => {
+        return (
+          typeof targetPath === 'string' &&
+          otherBootstrapFilePaths.has(targetPath)
+        );
+      },
+    );
+    const workspaceReadCalls = readdirSpy.mock.calls.filter(([targetPath]) => {
+      return targetPath === workspacePath;
+    });
+
+    expect(targetStatCalls).toHaveLength(2);
+    expect(targetReadCalls).toHaveLength(1);
+    expect(otherBootstrapStatCalls).toHaveLength(0);
+    expect(workspaceReadCalls).toHaveLength(1);
+  } finally {
+    statSpy.mockRestore();
+    readSpy.mockRestore();
+    readdirSpy.mockRestore();
+  }
+});
+
+test('reuses the target markdown file state within a restore request', async () => {
+  setupHome();
+
+  const { agentWorkspaceDir } = await import('../src/infra/ipc.js');
+  const {
+    restoreGatewayAdminAgentMarkdownRevision,
+    saveGatewayAdminAgentMarkdownFile,
+  } = await import('../src/gateway/gateway-service.ts');
+  const { WORKSPACE_BOOTSTRAP_FILES } = await import('../src/workspace.ts');
+
+  saveGatewayAdminAgentMarkdownFile({
+    agentId: 'main',
+    fileName: 'AGENTS.md',
+    content: '# AGENTS.md\n\n- Keep responses concise.\n',
+  });
+
+  const updated = saveGatewayAdminAgentMarkdownFile({
+    agentId: 'main',
+    fileName: 'AGENTS.md',
+    content: '# AGENTS.md\n\n- Prefer concise answers.\n',
+  });
+
+  const revisionId = updated.file.revisions[0]?.id;
+  if (!revisionId) {
+    throw new Error('Expected a saved markdown revision.');
+  }
+
+  const workspacePath = agentWorkspaceDir('main');
+  const filePath = path.join(workspacePath, 'AGENTS.md');
+  const otherBootstrapFilePaths = new Set(
+    WORKSPACE_BOOTSTRAP_FILES.map((fileName) =>
+      path.join(workspacePath, fileName),
+    ).filter((targetPath) => targetPath !== filePath),
+  );
+  const statSpy = vi.spyOn(fs, 'statSync');
+  const readSpy = vi.spyOn(fs, 'readFileSync');
+  const readdirSpy = vi.spyOn(fs, 'readdirSync');
+
+  try {
+    statSpy.mockClear();
+    readSpy.mockClear();
+    readdirSpy.mockClear();
+
+    restoreGatewayAdminAgentMarkdownRevision({
+      agentId: 'main',
+      fileName: 'AGENTS.md',
+      revisionId,
+    });
+
+    const targetStatCalls = statSpy.mock.calls.filter(([targetPath]) => {
+      return targetPath === filePath;
+    });
+    const targetReadCalls = readSpy.mock.calls.filter(([targetPath]) => {
+      return targetPath === filePath;
+    });
+    const otherBootstrapStatCalls = statSpy.mock.calls.filter(
+      ([targetPath]) => {
+        return (
+          typeof targetPath === 'string' &&
+          otherBootstrapFilePaths.has(targetPath)
+        );
+      },
+    );
+    const workspaceReadCalls = readdirSpy.mock.calls.filter(([targetPath]) => {
+      return targetPath === workspacePath;
+    });
+
+    expect(targetStatCalls).toHaveLength(2);
+    expect(targetReadCalls).toHaveLength(1);
+    expect(otherBootstrapStatCalls).toHaveLength(0);
+    expect(workspaceReadCalls).toHaveLength(1);
+  } finally {
+    statSpy.mockRestore();
+    readSpy.mockRestore();
+    readdirSpy.mockRestore();
+  }
 });

--- a/tests/gateway-service.agent-markdown.test.ts
+++ b/tests/gateway-service.agent-markdown.test.ts
@@ -1,0 +1,168 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import { setupGatewayTest } from './helpers/gateway-test-setup.js';
+
+const { setupHome } = setupGatewayTest({
+  tempHomePrefix: 'hybridclaw-gateway-agent-markdown-',
+});
+
+test('saves and reloads allowlisted agent workspace markdown files', async () => {
+  setupHome();
+
+  const { agentWorkspaceDir } = await import('../src/infra/ipc.js');
+  const {
+    getGatewayAdminAgentMarkdownFile,
+    getGatewayAdminAgentMarkdownRevision,
+    restoreGatewayAdminAgentMarkdownRevision,
+    saveGatewayAdminAgentMarkdownFile,
+  } = await import('../src/gateway/gateway-service.ts');
+
+  const initial = saveGatewayAdminAgentMarkdownFile({
+    agentId: 'main',
+    fileName: 'AGENTS.md',
+    content: '# AGENTS.md\n\n- Keep responses concise.\n',
+  });
+  expect(initial.file.revisions).toEqual([]);
+
+  const updated = saveGatewayAdminAgentMarkdownFile({
+    agentId: 'main',
+    fileName: 'AGENTS.md',
+    content: '# AGENTS.md\n\n- Prefer concise answers.\n',
+  });
+
+  const filePath = path.join(agentWorkspaceDir('main'), 'AGENTS.md');
+  expect(fs.readFileSync(filePath, 'utf-8')).toBe(
+    '# AGENTS.md\n\n- Prefer concise answers.\n',
+  );
+  expect(updated.file.path).toBe(filePath);
+  expect(updated.file.exists).toBe(true);
+  expect(updated.file.revisions).toHaveLength(1);
+  expect(updated.file.revisions[0]?.source).toBe('save');
+
+  const loaded = getGatewayAdminAgentMarkdownFile('main', 'AGENTS.md');
+  expect(loaded.file.content).toBe(
+    '# AGENTS.md\n\n- Prefer concise answers.\n',
+  );
+  expect(loaded.file.revisions).toHaveLength(1);
+
+  const revisionId = loaded.file.revisions[0]?.id;
+  if (!revisionId) {
+    throw new Error('Expected a saved markdown revision.');
+  }
+
+  const revision = getGatewayAdminAgentMarkdownRevision({
+    agentId: 'main',
+    fileName: 'AGENTS.md',
+    revisionId,
+  });
+  expect(revision.revision.content).toBe(
+    '# AGENTS.md\n\n- Keep responses concise.\n',
+  );
+
+  const restored = restoreGatewayAdminAgentMarkdownRevision({
+    agentId: 'main',
+    fileName: 'AGENTS.md',
+    revisionId,
+  });
+  expect(restored.file.content).toBe(
+    '# AGENTS.md\n\n- Keep responses concise.\n',
+  );
+  expect(restored.file.revisions.length).toBeGreaterThanOrEqual(2);
+  expect(restored.file.revisions[0]?.source).toBe('restore');
+});
+
+test('rejects non-allowlisted agent workspace markdown file names', async () => {
+  setupHome();
+
+  const { saveGatewayAdminAgentMarkdownFile } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  expect(() =>
+    saveGatewayAdminAgentMarkdownFile({
+      agentId: 'main',
+      fileName: 'notes.md',
+      content: '# notes\n',
+    }),
+  ).toThrow('Unsupported markdown file "notes.md"');
+});
+
+test('rejects oversized multibyte markdown saves before mutating the workspace file', async () => {
+  setupHome();
+
+  const { agentWorkspaceDir } = await import('../src/infra/ipc.js');
+  const { saveGatewayAdminAgentMarkdownFile } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  saveGatewayAdminAgentMarkdownFile({
+    agentId: 'main',
+    fileName: 'AGENTS.md',
+    content: '# AGENTS.md\n\n- Keep responses concise.\n',
+  });
+
+  const oversizedContent = '🙂'.repeat(60_000);
+  expect(() =>
+    saveGatewayAdminAgentMarkdownFile({
+      agentId: 'main',
+      fileName: 'AGENTS.md',
+      content: oversizedContent,
+    }),
+  ).toThrow('Markdown content exceeds the 200000-byte admin editor limit.');
+
+  expect(
+    fs.readFileSync(path.join(agentWorkspaceDir('main'), 'AGENTS.md'), 'utf-8'),
+  ).toBe('# AGENTS.md\n\n- Keep responses concise.\n');
+});
+
+test('rejects oversized revision restores before mutating the workspace file', async () => {
+  setupHome();
+
+  const { agentWorkspaceDir } = await import('../src/infra/ipc.js');
+  const {
+    restoreGatewayAdminAgentMarkdownRevision,
+    saveGatewayAdminAgentMarkdownFile,
+  } = await import('../src/gateway/gateway-service.ts');
+
+  saveGatewayAdminAgentMarkdownFile({
+    agentId: 'main',
+    fileName: 'AGENTS.md',
+    content: '# AGENTS.md\n\n- Keep responses concise.\n',
+  });
+
+  const workspacePath = agentWorkspaceDir('main');
+  const revisionDir = path.join(
+    path.dirname(workspacePath),
+    'markdown-revisions',
+    'AGENTS.md',
+  );
+  fs.mkdirSync(revisionDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(revisionDir, 'oversized.json'),
+    JSON.stringify({
+      id: 'oversized',
+      fileName: 'AGENTS.md',
+      createdAt: '2026-04-13T12:00:00.000Z',
+      sizeBytes: Buffer.byteLength('🙂'.repeat(60_000), 'utf-8'),
+      sha256: 'deadbeef',
+      source: 'save',
+      content: '🙂'.repeat(60_000),
+    }),
+    'utf-8',
+  );
+
+  expect(() =>
+    restoreGatewayAdminAgentMarkdownRevision({
+      agentId: 'main',
+      fileName: 'AGENTS.md',
+      revisionId: 'oversized',
+    }),
+  ).toThrow('Markdown content exceeds the 200000-byte admin editor limit.');
+
+  expect(fs.readFileSync(path.join(workspacePath, 'AGENTS.md'), 'utf-8')).toBe(
+    '# AGENTS.md\n\n- Keep responses concise.\n',
+  );
+});


### PR DESCRIPTION
## What changed
- add an admin console page for browsing agents, selecting allowlisted workspace markdown files, editing them, and restoring saved revisions
- add gateway admin endpoints and shared types for reading, saving, listing revisions, previewing revisions, and restoring revisions for agent workspace bootstrap markdown files
- store per-agent markdown revisions as snapshot files and expose revision metadata/content to the console
- follow up on review feedback by centralizing byte-based write validation, preventing refetches from clobbering dirty editor drafts, and splitting the admin agent HTTP handler into subresource-specific handlers
- add backend and console tests for markdown editing, revision restore, oversized-content rejection, and dirty-draft preservation

## Why it changed
Admins needed a narrow, backend-managed way to update agent bootstrap markdown without going through the filesystem directly. Version history was added so those edits are recoverable, and the follow-up review fixes tighten correctness and keep the route/editor logic easier to maintain.

## User and developer impact
- admins can edit allowlisted agent markdown files from `/admin/agents`
- each save or restore records a revision that can be previewed and restored later
- oversized multibyte content and oversized revisions now fail before mutating the workspace
- in-progress editor changes are no longer overwritten by query refetches
- the admin agent API route is split by resource type, reducing validation drift

## Root cause
The initial implementation duplicated write-path validation between save and restore and coupled local editor draft state directly to query refreshes. The route handler also accumulated multiple resource concerns in a single function.

## Validation
- `npx biome check --write src/gateway/gateway-http-server.ts src/gateway/gateway-service.ts tests/gateway-service.agent-markdown.test.ts console/src/routes/agents.tsx console/src/routes/agents.test.tsx`
- `npx vitest run tests/gateway-service.agent-markdown.test.ts tests/gateway-http-server.test.ts`
- `npx vitest run --config console/vitest.config.ts console/src/routes/agents.test.tsx`
- `npm run typecheck`

## Notes
- revisioning remains intentionally limited to the allowlisted workspace bootstrap markdown files
- the existing `gateway-http-server` test stderr noise around runtime secret permissions and startup DB access is unchanged; the suites still pass
