### PR TITLE
chore: harden workflow permissions and add CI concurrency control

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,12 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   # Build Docker images (no push) to catch Dockerfile regressions before merge.
@@ -78,6 +82,8 @@ jobs:
         run: npx vitest run --config vitest.e2e.config.ts tests/agent-container.e2e.test.ts
 
   unit-tests:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,8 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions: {}
+
 jobs:
   claude:
     if: |


### PR DESCRIPTION
## Summary

- **Least-privilege permissions (`ci.yml`):** The previous top-level `contents: write` granted write access to the repository token for every job in the workflow. Only the `unit-tests` job requires write access (for the `peaceiris/actions-gh-pages` coverage-badge publish step). This PR demotes the top-level default to `contents: read` and adds a job-level `permissions: { contents: write }` block to `unit-tests` only. `docker-preflight` and `npm-e2e` now correctly run with read-only tokens.

- **Concurrency control (`ci.yml`):** `docker-build.yml` and `pages.yml` already use concurrency groups to cancel stale runs. `ci.yml` had none, so rapid pushes or force-pushes on a PR could queue up multiple redundant runs. A workflow-level `concurrency` group keyed on `github.ref` with `cancel-in-progress: true` is added, matching the pattern used elsewhere in the repo.

- **Explicit token baseline (`claude.yml`):** The workflow had no top-level `permissions:` block, meaning it inherited whatever the repo default is (typically `contents: write`). The job-level block already scopes down correctly, but adding an explicit `permissions: {}` at the top level makes the intent unambiguous and prevents accidental privilege escalation if the repo default ever changes.

## Test plan

- [ ] Confirm CI run on this PR passes all jobs
- [ ] Verify `docker-preflight` and `npm-e2e` jobs do not have a `permissions` block (they inherit the read-only baseline)
- [ ] Verify `unit-tests` job has `permissions: { contents: write }` in the rendered workflow
- [ ] Check that a second push to this PR cancels the in-flight run from the first push (concurrency group working)