### PR TITLE
chore: replace hand-rolled Docker tag scripts with metadata-action

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -33,16 +33,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Resolve image tags
+      - name: Compute lowercase owner
+        env:
+          REPO_OWNER: ${{ github.repository_owner }}
+        run: echo "OWNER_LC=$(echo "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+      - name: Docker metadata
         id: meta
-        shell: bash
-        run: |
-          set -euo pipefail
-          OWNER_LC="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
-          SHA_SHORT="${GITHUB_SHA::7}"
-          IMAGE="ghcr.io/${OWNER_LC}/${{ matrix.image }}"
-          TAGS="${IMAGE}:sha-${SHA_SHORT}"$'\n'"${IMAGE}:main"
-          { echo "tags<<EOF"; echo "${TAGS}"; echo "EOF"; } >> "${GITHUB_OUTPUT}"
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: ghcr.io/${{ env.OWNER_LC }}/${{ matrix.image }}
+          tags: |
+            type=sha,prefix=sha-,format=short
+            type=raw,value=main
 
       - name: Setup Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -101,18 +101,24 @@ jobs:
         with:
           ref: ${{ needs.validate.outputs.ref }}
 
-      - name: Compute lowercase owner
+      - name: Compute build vars
         env:
           REPO_OWNER: ${{ github.repository_owner }}
-        run: echo "OWNER_LC=$(echo "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+          PUBLISH_DOCKERHUB: ${{ needs.validate.outputs.publish_dockerhub }}
+        run: |
+          OWNER_LC="$(echo "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')"
+          echo "OWNER_LC=$OWNER_LC" >> "$GITHUB_ENV"
+          IMAGES="ghcr.io/${OWNER_LC}/hybridclaw-agent"
+          if [[ "$PUBLISH_DOCKERHUB" == "true" ]]; then
+            IMAGES="${IMAGES}"$'\n'"hybridaione/hybridclaw-agent"
+          fi
+          { echo "DOCKER_IMAGES<<EOF"; echo "$IMAGES"; echo "EOF"; } >> "$GITHUB_ENV"
 
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
-          images: |
-            ghcr.io/${{ env.OWNER_LC }}/hybridclaw-agent
-            ${{ needs.validate.outputs.publish_dockerhub == 'true' && 'hybridaione/hybridclaw-agent' || '' }}
+          images: ${{ env.DOCKER_IMAGES }}
           tags: |
             type=raw,value=${{ needs.validate.outputs.tag }}
             type=raw,value=latest,enable=${{ !contains(needs.validate.outputs.tag, '-') }}
@@ -168,18 +174,24 @@ jobs:
         with:
           ref: ${{ needs.validate.outputs.ref }}
 
-      - name: Compute lowercase owner
+      - name: Compute build vars
         env:
           REPO_OWNER: ${{ github.repository_owner }}
-        run: echo "OWNER_LC=$(echo "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+          PUBLISH_DOCKERHUB: ${{ needs.validate.outputs.publish_dockerhub }}
+        run: |
+          OWNER_LC="$(echo "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')"
+          echo "OWNER_LC=$OWNER_LC" >> "$GITHUB_ENV"
+          IMAGES="ghcr.io/${OWNER_LC}/hybridclaw-gateway"
+          if [[ "$PUBLISH_DOCKERHUB" == "true" ]]; then
+            IMAGES="${IMAGES}"$'\n'"hybridaione/hybridclaw-gateway"
+          fi
+          { echo "DOCKER_IMAGES<<EOF"; echo "$IMAGES"; echo "EOF"; } >> "$GITHUB_ENV"
 
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
-          images: |
-            ghcr.io/${{ env.OWNER_LC }}/hybridclaw-gateway
-            ${{ needs.validate.outputs.publish_dockerhub == 'true' && 'hybridaione/hybridclaw-gateway' || '' }}
+          images: ${{ env.DOCKER_IMAGES }}
           tags: |
             type=raw,value=${{ needs.validate.outputs.tag }}
             type=raw,value=latest,enable=${{ !contains(needs.validate.outputs.tag, '-') }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -101,28 +101,22 @@ jobs:
         with:
           ref: ${{ needs.validate.outputs.ref }}
 
-      - name: Resolve agent image tags
-        id: meta
-        shell: bash
+      - name: Compute lowercase owner
         env:
-          TAG: ${{ needs.validate.outputs.tag }}
-          PUBLISH_DOCKERHUB: ${{ needs.validate.outputs.publish_dockerhub }}
-        run: |
-          set -euo pipefail
-          OWNER_LC="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
-          GHCR_IMAGE="ghcr.io/${OWNER_LC}/hybridclaw-agent"
-          DOCKERHUB_IMAGE="hybridaione/hybridclaw-agent"
-          TAGS="${GHCR_IMAGE}:${TAG}"
-          if [[ "${TAG}" != *-* ]]; then
-            TAGS="${TAGS}"$'\n'"${GHCR_IMAGE}:latest"
-          fi
-          if [[ "${PUBLISH_DOCKERHUB}" == "true" ]]; then
-            TAGS="${TAGS}"$'\n'"${DOCKERHUB_IMAGE}:${TAG}"
-            if [[ "${TAG}" != *-* ]]; then
-              TAGS="${TAGS}"$'\n'"${DOCKERHUB_IMAGE}:latest"
-            fi
-          fi
-          { echo "tags<<EOF"; echo "${TAGS}"; echo "EOF"; } >> "${GITHUB_OUTPUT}"
+          REPO_OWNER: ${{ github.repository_owner }}
+        run: echo "OWNER_LC=$(echo "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: |
+            ghcr.io/${{ env.OWNER_LC }}/hybridclaw-agent
+            ${{ needs.validate.outputs.publish_dockerhub == 'true' && 'hybridaione/hybridclaw-agent' || '' }}
+          tags: |
+            type=raw,value=${{ needs.validate.outputs.tag }}
+            type=raw,value=latest,enable=${{ !contains(needs.validate.outputs.tag, '-') }}
+          labels: ${{ needs.validate.outputs.labels }}
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
@@ -174,28 +168,22 @@ jobs:
         with:
           ref: ${{ needs.validate.outputs.ref }}
 
-      - name: Resolve gateway image tags
-        id: meta
-        shell: bash
+      - name: Compute lowercase owner
         env:
-          TAG: ${{ needs.validate.outputs.tag }}
-          PUBLISH_DOCKERHUB: ${{ needs.validate.outputs.publish_dockerhub }}
-        run: |
-          set -euo pipefail
-          OWNER_LC="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
-          GHCR_IMAGE="ghcr.io/${OWNER_LC}/hybridclaw-gateway"
-          DOCKERHUB_IMAGE="hybridaione/hybridclaw-gateway"
-          TAGS="${GHCR_IMAGE}:${TAG}"
-          if [[ "${TAG}" != *-* ]]; then
-            TAGS="${TAGS}"$'\n'"${GHCR_IMAGE}:latest"
-          fi
-          if [[ "${PUBLISH_DOCKERHUB}" == "true" ]]; then
-            TAGS="${TAGS}"$'\n'"${DOCKERHUB_IMAGE}:${TAG}"
-            if [[ "${TAG}" != *-* ]]; then
-              TAGS="${TAGS}"$'\n'"${DOCKERHUB_IMAGE}:latest"
-            fi
-          fi
-          { echo "tags<<EOF"; echo "${TAGS}"; echo "EOF"; } >> "${GITHUB_OUTPUT}"
+          REPO_OWNER: ${{ github.repository_owner }}
+        run: echo "OWNER_LC=$(echo "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: |
+            ghcr.io/${{ env.OWNER_LC }}/hybridclaw-gateway
+            ${{ needs.validate.outputs.publish_dockerhub == 'true' && 'hybridaione/hybridclaw-gateway' || '' }}
+          tags: |
+            type=raw,value=${{ needs.validate.outputs.tag }}
+            type=raw,value=latest,enable=${{ !contains(needs.validate.outputs.tag, '-') }}
+          labels: ${{ needs.validate.outputs.labels }}
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3


### PR DESCRIPTION
## Summary

- Replaces the duplicated bash "Resolve agent/gateway image tags" steps in `publish-release.yml` (`publish-agent` and `publish-gateway` jobs) with `docker/metadata-action@v5.7.0`
- Replaces the "Resolve image tags" bash step in `docker-build.yml` with the same action
- Eliminates ~40 lines of brittle shell that manually constructed tag strings and implemented stable-vs-pre-release `latest`-suppression logic
- All downstream steps (`docker/build-push-action`, `verify-published-tags`) continue to consume `steps.meta.outputs.tags` unchanged — no wiring changes needed

## Behaviour preserved

| Scenario | Before | After |
|---|---|---|
| Stable release (`v1.2.3`) | GHCR `:v1.2.3` + `:latest`; DockerHub same if secrets set | Same via `type=raw,value=latest,enable=true` |
| Pre-release (`v1.2.3-rc.1`) | GHCR `:v1.2.3-rc.1` only | Same via `enable=${{ !contains(..., '-') }}` |
| DockerHub | Added when `publish_dockerhub == 'true'` | Same via conditional image line |
| Main branch builds | `sha-<short>` + `main` | Same via `type=sha,prefix=sha-,format=short` + `type=raw,value=main` |

## Test plan

- [ ] Trigger a `workflow_dispatch` run of Publish Release with a pre-release tag and verify only the versioned tag is pushed (no `latest`)
- [ ] Trigger with a stable tag and verify both versioned and `latest` tags appear on GHCR
- [ ] Verify a main-branch push produces `sha-<short>` and `main` tags via Docker Build workflow