### PR TITLE
fix: resolve MaxListenersExceededWarning and Vite chunk size warning in CI

### DIFF
--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -11,13 +11,11 @@ export default defineConfig({
     chunkSizeWarningLimit: 1000,
     rollupOptions: {
       output: {
-        manualChunks: {
-          // Keep React and its ecosystem in one chunk so the browser can
-          // cache it independently of application code.
-          vendor: ['react', 'react-dom'],
-          router: ['@tanstack/react-router'],
-          query: ['@tanstack/react-query'],
-          terminal: ['xterm', '@xterm/addon-fit'],
+        manualChunks(id) {
+          if (id.includes('react-dom') || id.includes('/react/')) return 'vendor';
+          if (id.includes('@tanstack/react-router')) return 'router';
+          if (id.includes('@tanstack/react-query')) return 'query';
+          if (id.includes('xterm') || id.includes('@xterm/')) return 'terminal';
         },
       },
     },

--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -6,6 +6,21 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     emptyOutDir: true,
+    // Raise the limit to 1 MB — the admin console intentionally bundles
+    // sizeable vendor libs (xterm, tanstack router/query, React DOM).
+    chunkSizeWarningLimit: 1000,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          // Keep React and its ecosystem in one chunk so the browser can
+          // cache it independently of application code.
+          vendor: ['react', 'react-dom'],
+          router: ['@tanstack/react-router'],
+          query: ['@tanstack/react-query'],
+          terminal: ['xterm', '@xterm/addon-fit'],
+        },
+      },
+    },
   },
   plugins: [react()],
   server: {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -171,8 +171,7 @@ if (
   !process
     .listeners('uncaughtException')
     .some(
-      (l) =>
-        (l as unknown as Record<string, boolean>)[UNCAUGHT_EXCEPTION_TAG],
+      (l) => (l as unknown as Record<string, boolean>)[UNCAUGHT_EXCEPTION_TAG],
     )
 ) {
   process.on('uncaughtException', uncaughtExceptionHandler);
@@ -182,8 +181,7 @@ if (
   !process
     .listeners('unhandledRejection')
     .some(
-      (l) =>
-        (l as unknown as Record<string, boolean>)[UNHANDLED_REJECTION_TAG],
+      (l) => (l as unknown as Record<string, boolean>)[UNHANDLED_REJECTION_TAG],
     )
 ) {
   process.on('unhandledRejection', unhandledRejectionHandler);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -143,11 +143,48 @@ onRuntimeConfigChange((next, prev) => {
   }
 });
 
-process.on('uncaughtException', (err) => {
+// Use a module-level symbol so the same named handler can be detected across
+// re-imports that occur in tests (vi.resetModules + dynamic import). Without
+// this guard, every reimport of this module appends a fresh listener to the
+// process, quickly exceeding the default MaxListeners limit of 10.
+const UNCAUGHT_EXCEPTION_TAG = '__hybridclaw_uncaughtException__';
+const UNHANDLED_REJECTION_TAG = '__hybridclaw_unhandledRejection__';
+
+function uncaughtExceptionHandler(err: Error) {
   logger.fatal({ err }, 'Uncaught exception');
   process.exit(1);
-});
+}
 
-process.on('unhandledRejection', (reason) => {
+function unhandledRejectionHandler(reason: unknown) {
   logger.error({ err: reason }, 'Unhandled rejection');
-});
+}
+
+// Tag the handlers so we can detect whether they are already registered.
+(uncaughtExceptionHandler as unknown as Record<string, boolean>)[
+  UNCAUGHT_EXCEPTION_TAG
+] = true;
+(unhandledRejectionHandler as unknown as Record<string, boolean>)[
+  UNHANDLED_REJECTION_TAG
+] = true;
+
+if (
+  !process
+    .listeners('uncaughtException')
+    .some(
+      (l) =>
+        (l as unknown as Record<string, boolean>)[UNCAUGHT_EXCEPTION_TAG],
+    )
+) {
+  process.on('uncaughtException', uncaughtExceptionHandler);
+}
+
+if (
+  !process
+    .listeners('unhandledRejection')
+    .some(
+      (l) =>
+        (l as unknown as Record<string, boolean>)[UNHANDLED_REJECTION_TAG],
+    )
+) {
+  process.on('unhandledRejection', unhandledRejectionHandler);
+}


### PR DESCRIPTION
## Summary

- **MaxListenersExceededWarning** — `src/logger.ts` registered `uncaughtException` and `unhandledRejection` listeners at module scope. Vitest tests that call `vi.resetModules()` and then dynamically re-import `src/logger.ts` caused the same process singleton to accumulate a new pair of listeners on each re-import. `tests/gateway-status.test.ts` alone has 50+ `vi.resetModules()` calls, so the per-worker listener count blew past the default limit of 10, producing the warning across all vitest workers.

- **Vite chunk size warning** — `console/vite.config.ts` had no `chunkSizeWarningLimit` and no `manualChunks` config. The admin SPA bundles sizeable vendor libraries (`xterm`, `@tanstack/react-router`, `@tanstack/react-query`, `react-dom`), which together exceed the default 500 kB threshold. This fired during both the Docker gateway build (`npm run build:console` in the Dockerfile builder stage) and the `npm-e2e` CI job (which also calls `npm run build`).

## Fixes

### Warning 1 — MaxListenersExceededWarning (`src/logger.ts`)

Introduced named handler functions (`uncaughtExceptionHandler`, `unhandledRejectionHandler`) and tagged each with a well-known property. Before calling `process.on()`, the code now checks `process.listeners()` for the presence of that tag, so the handler is registered at most once per process regardless of how many times the module is reimported.

### Warning 2 — Vite chunk size (`console/vite.config.ts`)

- Set `build.chunkSizeWarningLimit` to `1000` kB, appropriate for an internally-served admin console that intentionally bundles large vendor libraries.
- Added `build.rollupOptions.output.manualChunks` to split `react`/`react-dom`, `@tanstack/react-router`, `@tanstack/react-query`, and `xterm`/`@xterm/addon-fit` into separate named chunks, improving browser caching and reducing the application entry-point size.

## Test plan

- [ ] CI unit tests pass without `MaxListenersExceededWarning` in vitest worker output
- [ ] `npm run build:console` completes without `Adjust chunk size limit` warning
- [ ] Docker gateway preflight build succeeds without chunk size warning
- [ ] Console SPA loads and routes correctly in browser