### PR TITLE
[codex] share test temp-dir and mock cleanup helpers

### DIFF
--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -18,6 +18,7 @@ function restoreEnvVar(name: string, value: string | undefined): void {
 }
 
 useCleanMocks({
+  restoreAllMocks: true,
   cleanup: async () => {
     const { resetAgentRegistryForTesting } = await import(
       '../src/agents/agent-registry.ts'

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -1,18 +1,13 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
 import Database from 'better-sqlite3';
-import { afterEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const ORIGINAL_HOME = process.env.HOME;
-const tempDirs: string[] = [];
 
-function makeTempHome(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-agents-'));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempHome = useTempDir('hybridclaw-agents-');
 
 function restoreEnvVar(name: string, value: string | undefined): void {
   if (value === undefined) {
@@ -22,19 +17,16 @@ function restoreEnvVar(name: string, value: string | undefined): void {
   process.env[name] = value;
 }
 
-afterEach(async () => {
-  vi.restoreAllMocks();
-  const { resetAgentRegistryForTesting } = await import(
-    '../src/agents/agent-registry.ts'
-  );
-  resetAgentRegistryForTesting();
-  vi.doUnmock('../src/logger.js');
-  vi.resetModules();
-  restoreEnvVar('HOME', ORIGINAL_HOME);
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) fs.rmSync(dir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  cleanup: async () => {
+    const { resetAgentRegistryForTesting } = await import(
+      '../src/agents/agent-registry.ts'
+    );
+    resetAgentRegistryForTesting();
+    restoreEnvVar('HOME', ORIGINAL_HOME);
+  },
+  resetModules: true,
+  unmock: ['../src/logger.js'],
 });
 
 test('resolveAgentForRequest prefers request, then session, then configured default agent', async () => {

--- a/tests/agent-side-effects.test.ts
+++ b/tests/agent-side-effects.test.ts
@@ -14,6 +14,7 @@ function restoreEnvVar(name: string, value: string | undefined): void {
 }
 
 useCleanMocks({
+  restoreAllMocks: true,
   cleanup: () => {
     restoreEnvVar('HOME', ORIGINAL_HOME);
   },

--- a/tests/agent-side-effects.test.ts
+++ b/tests/agent-side-effects.test.ts
@@ -1,17 +1,9 @@
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
-
-import { afterEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const ORIGINAL_HOME = process.env.HOME;
-const tempDirs: string[] = [];
 
-function makeTempHome(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-sidefx-'));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempHome = useTempDir('hybridclaw-sidefx-');
 
 function restoreEnvVar(name: string, value: string | undefined): void {
   if (value === undefined) {
@@ -21,14 +13,11 @@ function restoreEnvVar(name: string, value: string | undefined): void {
   process.env[name] = value;
 }
 
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.resetModules();
-  restoreEnvVar('HOME', ORIGINAL_HOME);
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) fs.rmSync(dir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  cleanup: () => {
+    restoreEnvVar('HOME', ORIGINAL_HOME);
+  },
+  resetModules: true,
 });
 
 test('processSideEffects persists explicit schedule delivery channels', async () => {

--- a/tests/audio-transcription-backends.test.ts
+++ b/tests/audio-transcription-backends.test.ts
@@ -1,17 +1,15 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, expect, test, vi } from 'vitest';
-
+import { expect, test, vi } from 'vitest';
 import {
   resolveAudioTranscriptionModels,
   transcribeAudioWithFallback,
 } from '../src/media/audio-transcription-backends.js';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const ORIGINAL_PATH = process.env.PATH;
 const ORIGINAL_GOOGLE_API_KEY = process.env.GOOGLE_API_KEY;
-const tempDirs: string[] = [];
 
 const DEFAULT_AUDIO_CONFIG = {
   enabled: true,
@@ -25,20 +23,15 @@ const DEFAULT_AUDIO_CONFIG = {
   models: [],
 } as const;
 
-function makeTempDir(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempDir = useTempDir();
 
-afterEach(() => {
-  process.env.PATH = ORIGINAL_PATH;
-  process.env.GOOGLE_API_KEY = ORIGINAL_GOOGLE_API_KEY;
-  vi.unstubAllGlobals();
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) fs.rmSync(dir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  cleanup: () => {
+    process.env.PATH = ORIGINAL_PATH;
+    process.env.GOOGLE_API_KEY = ORIGINAL_GOOGLE_API_KEY;
+  },
+  restoreAllMocks: false,
+  unstubAllGlobals: true,
 });
 
 test('auto-detected audio backends do not require cache resets between PATH changes', async () => {

--- a/tests/audio-transcription-backends.test.ts
+++ b/tests/audio-transcription-backends.test.ts
@@ -31,6 +31,7 @@ useCleanMocks({
     process.env.GOOGLE_API_KEY = ORIGINAL_GOOGLE_API_KEY;
   },
   restoreAllMocks: false,
+  resetModules: true,
   unstubAllGlobals: true,
 });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,11 +1,10 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
 const ORIGINAL_HYBRIDCLAW_DATA_DIR = process.env.HYBRIDCLAW_DATA_DIR;
 const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_DISABLE_CONFIG_WATCHER =
@@ -29,11 +28,7 @@ const REPO_VERSION = (
   ) as { version: string }
 ).version;
 
-function createTempDir(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-cli-'));
-  tempDirs.push(dir);
-  return dir;
-}
+const createTempDir = useTempDir('hybridclaw-cli-');
 
 async function importFreshAgentMigrationCommand(options?: {
   sourceRoot?: string | null;
@@ -1356,117 +1351,115 @@ async function importFreshCli(options?: {
   };
 }
 
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.unstubAllGlobals();
-  vi.doUnmock('../src/auth/hybridai-auth.ts');
-  vi.doUnmock('../src/auth/codex-auth.ts');
-  vi.doUnmock('../src/config/cli-flags.ts');
-  vi.doUnmock('../src/config/config.ts');
-  vi.doUnmock('../src/config/runtime-config.ts');
-  vi.doUnmock('../src/gateway/gateway-client.ts');
-  vi.doUnmock('../src/gateway/gateway-lifecycle.ts');
-  vi.doUnmock('../src/gateway/gateway.ts');
-  vi.doUnmock('../src/infra/container-setup.ts');
-  vi.doUnmock('../src/channels/whatsapp/auth.ts');
-  vi.doUnmock('node:readline/promises');
-  vi.doUnmock('../src/onboarding.ts');
-  vi.doUnmock('../src/skills/skills.ts');
-  vi.doUnmock('../src/skills/skills-import.ts');
-  vi.doUnmock('../src/skills/skills-import.js');
-  vi.doUnmock('../src/security/instruction-approval-audit.ts');
-  vi.doUnmock('../src/security/instruction-integrity.ts');
-  vi.doUnmock('../src/security/runtime-secrets.ts');
-  vi.doUnmock('../src/tui.ts');
-  vi.doUnmock('../src/memory/db.js');
-  vi.doUnmock('../src/agents/agent-registry.js');
-  vi.doUnmock('../src/agents/claw-archive.js');
-  vi.doUnmock('../src/plugins/plugin-install.ts');
-  vi.doUnmock('../src/plugins/plugin-install.js');
-  vi.doUnmock('../src/plugins/plugin-config.js');
-  vi.doUnmock('../src/plugins/plugin-manager.js');
-  vi.doUnmock('../src/update.ts');
-  vi.resetModules();
-  if (ORIGINAL_WHATSAPP_SETUP_SETTLE_MS === undefined) {
-    delete process.env.HYBRIDCLAW_WHATSAPP_SETUP_SETTLE_MS;
-  } else {
-    process.env.HYBRIDCLAW_WHATSAPP_SETUP_SETTLE_MS =
-      ORIGINAL_WHATSAPP_SETUP_SETTLE_MS;
-  }
-  if (ORIGINAL_HYBRIDCLAW_DATA_DIR === undefined) {
-    delete process.env.HYBRIDCLAW_DATA_DIR;
-  } else {
-    process.env.HYBRIDCLAW_DATA_DIR = ORIGINAL_HYBRIDCLAW_DATA_DIR;
-  }
-  if (ORIGINAL_HOME === undefined) {
-    delete process.env.HOME;
-  } else {
-    process.env.HOME = ORIGINAL_HOME;
-  }
-  if (ORIGINAL_DISABLE_CONFIG_WATCHER === undefined) {
-    delete process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
-  } else {
-    process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER =
-      ORIGINAL_DISABLE_CONFIG_WATCHER;
-  }
-  if (ORIGINAL_OPENROUTER_API_KEY === undefined) {
-    delete process.env.OPENROUTER_API_KEY;
-  } else {
-    process.env.OPENROUTER_API_KEY = ORIGINAL_OPENROUTER_API_KEY;
-  }
-  if (ORIGINAL_MISTRAL_API_KEY === undefined) {
-    delete process.env.MISTRAL_API_KEY;
-  } else {
-    process.env.MISTRAL_API_KEY = ORIGINAL_MISTRAL_API_KEY;
-  }
-  if (ORIGINAL_HF_TOKEN === undefined) {
-    delete process.env.HF_TOKEN;
-  } else {
-    process.env.HF_TOKEN = ORIGINAL_HF_TOKEN;
-  }
-  if (ORIGINAL_HYBRIDCLAW_LOG_REQUESTS === undefined) {
-    delete process.env.HYBRIDCLAW_LOG_REQUESTS;
-  } else {
-    process.env.HYBRIDCLAW_LOG_REQUESTS = ORIGINAL_HYBRIDCLAW_LOG_REQUESTS;
-  }
-  if (ORIGINAL_EMAIL_PASSWORD === undefined) {
-    delete process.env.EMAIL_PASSWORD;
-  } else {
-    process.env.EMAIL_PASSWORD = ORIGINAL_EMAIL_PASSWORD;
-  }
-  if (ORIGINAL_MSTEAMS_APP_ID === undefined) {
-    delete process.env.MSTEAMS_APP_ID;
-  } else {
-    process.env.MSTEAMS_APP_ID = ORIGINAL_MSTEAMS_APP_ID;
-  }
-  if (ORIGINAL_MSTEAMS_APP_PASSWORD === undefined) {
-    delete process.env.MSTEAMS_APP_PASSWORD;
-  } else {
-    process.env.MSTEAMS_APP_PASSWORD = ORIGINAL_MSTEAMS_APP_PASSWORD;
-  }
-  if (ORIGINAL_MSTEAMS_TENANT_ID === undefined) {
-    delete process.env.MSTEAMS_TENANT_ID;
-  } else {
-    process.env.MSTEAMS_TENANT_ID = ORIGINAL_MSTEAMS_TENANT_ID;
-  }
-  if (ORIGINAL_CI === undefined) {
-    delete process.env.CI;
-  } else {
-    process.env.CI = ORIGINAL_CI;
-  }
-  Object.defineProperty(process.stdin, 'isTTY', {
-    configurable: true,
-    value: ORIGINAL_STDIN_IS_TTY,
-  });
-  Object.defineProperty(process.stdout, 'isTTY', {
-    configurable: true,
-    value: ORIGINAL_STDOUT_IS_TTY,
-  });
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (!dir) continue;
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  cleanup: () => {
+    if (ORIGINAL_WHATSAPP_SETUP_SETTLE_MS === undefined) {
+      delete process.env.HYBRIDCLAW_WHATSAPP_SETUP_SETTLE_MS;
+    } else {
+      process.env.HYBRIDCLAW_WHATSAPP_SETUP_SETTLE_MS =
+        ORIGINAL_WHATSAPP_SETUP_SETTLE_MS;
+    }
+    if (ORIGINAL_HYBRIDCLAW_DATA_DIR === undefined) {
+      delete process.env.HYBRIDCLAW_DATA_DIR;
+    } else {
+      process.env.HYBRIDCLAW_DATA_DIR = ORIGINAL_HYBRIDCLAW_DATA_DIR;
+    }
+    if (ORIGINAL_HOME === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = ORIGINAL_HOME;
+    }
+    if (ORIGINAL_DISABLE_CONFIG_WATCHER === undefined) {
+      delete process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
+    } else {
+      process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER =
+        ORIGINAL_DISABLE_CONFIG_WATCHER;
+    }
+    if (ORIGINAL_OPENROUTER_API_KEY === undefined) {
+      delete process.env.OPENROUTER_API_KEY;
+    } else {
+      process.env.OPENROUTER_API_KEY = ORIGINAL_OPENROUTER_API_KEY;
+    }
+    if (ORIGINAL_MISTRAL_API_KEY === undefined) {
+      delete process.env.MISTRAL_API_KEY;
+    } else {
+      process.env.MISTRAL_API_KEY = ORIGINAL_MISTRAL_API_KEY;
+    }
+    if (ORIGINAL_HF_TOKEN === undefined) {
+      delete process.env.HF_TOKEN;
+    } else {
+      process.env.HF_TOKEN = ORIGINAL_HF_TOKEN;
+    }
+    if (ORIGINAL_HYBRIDCLAW_LOG_REQUESTS === undefined) {
+      delete process.env.HYBRIDCLAW_LOG_REQUESTS;
+    } else {
+      process.env.HYBRIDCLAW_LOG_REQUESTS = ORIGINAL_HYBRIDCLAW_LOG_REQUESTS;
+    }
+    if (ORIGINAL_EMAIL_PASSWORD === undefined) {
+      delete process.env.EMAIL_PASSWORD;
+    } else {
+      process.env.EMAIL_PASSWORD = ORIGINAL_EMAIL_PASSWORD;
+    }
+    if (ORIGINAL_MSTEAMS_APP_ID === undefined) {
+      delete process.env.MSTEAMS_APP_ID;
+    } else {
+      process.env.MSTEAMS_APP_ID = ORIGINAL_MSTEAMS_APP_ID;
+    }
+    if (ORIGINAL_MSTEAMS_APP_PASSWORD === undefined) {
+      delete process.env.MSTEAMS_APP_PASSWORD;
+    } else {
+      process.env.MSTEAMS_APP_PASSWORD = ORIGINAL_MSTEAMS_APP_PASSWORD;
+    }
+    if (ORIGINAL_MSTEAMS_TENANT_ID === undefined) {
+      delete process.env.MSTEAMS_TENANT_ID;
+    } else {
+      process.env.MSTEAMS_TENANT_ID = ORIGINAL_MSTEAMS_TENANT_ID;
+    }
+    if (ORIGINAL_CI === undefined) {
+      delete process.env.CI;
+    } else {
+      process.env.CI = ORIGINAL_CI;
+    }
+    Object.defineProperty(process.stdin, 'isTTY', {
+      configurable: true,
+      value: ORIGINAL_STDIN_IS_TTY,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      configurable: true,
+      value: ORIGINAL_STDOUT_IS_TTY,
+    });
+  },
+  resetModules: true,
+  unstubAllGlobals: true,
+  unmock: [
+    '../src/auth/hybridai-auth.ts',
+    '../src/auth/codex-auth.ts',
+    '../src/config/cli-flags.ts',
+    '../src/config/config.ts',
+    '../src/config/runtime-config.ts',
+    '../src/gateway/gateway-client.ts',
+    '../src/gateway/gateway-lifecycle.ts',
+    '../src/gateway/gateway.ts',
+    '../src/infra/container-setup.ts',
+    '../src/channels/whatsapp/auth.ts',
+    'node:readline/promises',
+    '../src/onboarding.ts',
+    '../src/skills/skills.ts',
+    '../src/skills/skills-import.ts',
+    '../src/skills/skills-import.js',
+    '../src/security/instruction-approval-audit.ts',
+    '../src/security/instruction-integrity.ts',
+    '../src/security/runtime-secrets.ts',
+    '../src/tui.ts',
+    '../src/memory/db.js',
+    '../src/agents/agent-registry.js',
+    '../src/agents/claw-archive.js',
+    '../src/plugins/plugin-install.ts',
+    '../src/plugins/plugin-install.js',
+    '../src/plugins/plugin-config.js',
+    '../src/plugins/plugin-manager.js',
+    '../src/update.ts',
+  ],
 });
 
 describe('CLI hybridai commands', () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1352,6 +1352,7 @@ async function importFreshCli(options?: {
 }
 
 useCleanMocks({
+  restoreAllMocks: true,
   cleanup: () => {
     if (ORIGINAL_WHATSAPP_SETUP_SETTLE_MS === undefined) {
       delete process.env.HYBRIDCLAW_WHATSAPP_SETUP_SETTLE_MS;

--- a/tests/container-setup.test.ts
+++ b/tests/container-setup.test.ts
@@ -132,6 +132,7 @@ async function importFreshContainerSetup(options?: {
 }
 
 useCleanMocks({
+  restoreAllMocks: true,
   cleanup: () => {
     restoreEnvVar('HOME', ORIGINAL_HOME);
     Object.defineProperty(process.stdin, 'isTTY', {

--- a/tests/container-setup.test.ts
+++ b/tests/container-setup.test.ts
@@ -1,21 +1,16 @@
 import { createHash } from 'node:crypto';
 import { EventEmitter } from 'node:events';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
 const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_STDIN_IS_TTY = process.stdin.isTTY;
 const ORIGINAL_STDOUT_IS_TTY = process.stdout.isTTY;
 
-function createTempDir(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-container-'));
-  tempDirs.push(dir);
-  return dir;
-}
+const createTempDir = useTempDir('hybridclaw-container-');
 
 function restoreEnvVar(name: string, value: string | undefined): void {
   if (value === undefined) {
@@ -136,26 +131,21 @@ async function importFreshContainerSetup(options?: {
   return import('../src/infra/container-setup.ts');
 }
 
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.doUnmock('node:child_process');
-  vi.doUnmock('../src/config/config.ts');
-  vi.resetModules();
-  vi.unstubAllEnvs();
-  restoreEnvVar('HOME', ORIGINAL_HOME);
-  Object.defineProperty(process.stdin, 'isTTY', {
-    value: ORIGINAL_STDIN_IS_TTY,
-    configurable: true,
-  });
-  Object.defineProperty(process.stdout, 'isTTY', {
-    value: ORIGINAL_STDOUT_IS_TTY,
-    configurable: true,
-  });
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (!dir) continue;
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  cleanup: () => {
+    restoreEnvVar('HOME', ORIGINAL_HOME);
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: ORIGINAL_STDIN_IS_TTY,
+      configurable: true,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: ORIGINAL_STDOUT_IS_TTY,
+      configurable: true,
+    });
+  },
+  resetModules: true,
+  unstubAllEnvs: true,
+  unmock: ['node:child_process', '../src/config/config.ts'],
 });
 
 describe('resolveContainerImageAcquisitionMode', () => {

--- a/tests/discord.attachments.test.ts
+++ b/tests/discord.attachments.test.ts
@@ -7,6 +7,7 @@ import { useCleanMocks, useTempDir } from './test-utils.ts';
 const makeTempDataDir = useTempDir('hybridclaw-discord-attachments-');
 
 useCleanMocks({
+  restoreAllMocks: true,
   resetModules: true,
   unstubAllGlobals: true,
   unmock: [

--- a/tests/discord.attachments.test.ts
+++ b/tests/discord.attachments.test.ts
@@ -1,32 +1,19 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
+const makeTempDataDir = useTempDir('hybridclaw-discord-attachments-');
 
-function makeTempDataDir(): string {
-  const dir = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'hybridclaw-discord-attachments-'),
-  );
-  tempDirs.push(dir);
-  return dir;
-}
-
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.unstubAllGlobals();
-  vi.doUnmock('../src/channels/discord/discord-cdn-fetch.js');
-  vi.doUnmock('../src/config/config.ts');
-  vi.doUnmock('../src/logger.js');
-  vi.resetModules();
-
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (!dir) continue;
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  resetModules: true,
+  unstubAllGlobals: true,
+  unmock: [
+    '../src/channels/discord/discord-cdn-fetch.js',
+    '../src/config/config.ts',
+    '../src/logger.js',
+  ],
 });
 
 describe('buildAttachmentContext', () => {

--- a/tests/discord.media-cache.test.ts
+++ b/tests/discord.media-cache.test.ts
@@ -7,6 +7,7 @@ import { useCleanMocks, useTempDir } from './test-utils.ts';
 const makeTempDataDir = useTempDir('hybridclaw-discord-cache-');
 
 useCleanMocks({
+  restoreAllMocks: true,
   resetModules: true,
   unmock: ['../src/config/config.ts', '../src/logger.js'],
 });

--- a/tests/discord.media-cache.test.ts
+++ b/tests/discord.media-cache.test.ts
@@ -1,30 +1,14 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
+const makeTempDataDir = useTempDir('hybridclaw-discord-cache-');
 
-function makeTempDataDir(): string {
-  const dir = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'hybridclaw-discord-cache-'),
-  );
-  tempDirs.push(dir);
-  return dir;
-}
-
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.doUnmock('../src/config/config.ts');
-  vi.doUnmock('../src/logger.js');
-  vi.resetModules();
-
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (!dir) continue;
-    fs.rmSync(dir, { force: true, recursive: true });
-  }
+useCleanMocks({
+  resetModules: true,
+  unmock: ['../src/config/config.ts', '../src/logger.js'],
 });
 
 describe('discord media cache helpers', () => {

--- a/tests/discord.send-files.test.ts
+++ b/tests/discord.send-files.test.ts
@@ -1,30 +1,15 @@
 import fs from 'node:fs/promises';
-import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, expect, test } from 'vitest';
-
+import { expect, test } from 'vitest';
 import {
   DISCORD_SEND_MEDIA_ROOT_DISPLAY,
   DISCORD_SEND_WORKSPACE_ROOT_DISPLAY,
   resolveDiscordLocalFileForSend,
 } from '../src/channels/discord/send-files.js';
+import { useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
-
-async function makeTempDir(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
-
-afterEach(async () => {
-  await Promise.all(
-    tempDirs.splice(0).map(async (dir) => {
-      await fs.rm(dir, { recursive: true, force: true });
-    }),
-  );
-});
+const makeTempDir = useTempDir();
 
 test('resolves relative file paths inside the session workspace', async () => {
   const workspaceRoot = await makeTempDir('hybridclaw-discord-workspace-');

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -19,6 +19,7 @@ function restoreEnvVar(name: string, value: string | undefined): void {
 }
 
 useCleanMocks({
+  restoreAllMocks: true,
   cleanup: () => {
     restoreEnvVar('HOME', ORIGINAL_HOME);
     Object.defineProperty(process.stdin, 'isTTY', {

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1,19 +1,14 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
-import { afterEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_STDIN_IS_TTY = process.stdin.isTTY;
 const ORIGINAL_STDOUT_IS_TTY = process.stdout.isTTY;
-const tempDirs: string[] = [];
 
-function createTempDir(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
+const createTempDir = useTempDir();
 
 function restoreEnvVar(name: string, value: string | undefined): void {
   if (value === undefined) {
@@ -23,24 +18,20 @@ function restoreEnvVar(name: string, value: string | undefined): void {
   process.env[name] = value;
 }
 
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.resetModules();
-  vi.doUnmock('node:child_process');
-  restoreEnvVar('HOME', ORIGINAL_HOME);
-  Object.defineProperty(process.stdin, 'isTTY', {
-    configurable: true,
-    value: ORIGINAL_STDIN_IS_TTY,
-  });
-  Object.defineProperty(process.stdout, 'isTTY', {
-    configurable: true,
-    value: ORIGINAL_STDOUT_IS_TTY,
-  });
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (!dir) continue;
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  cleanup: () => {
+    restoreEnvVar('HOME', ORIGINAL_HOME);
+    Object.defineProperty(process.stdin, 'isTTY', {
+      configurable: true,
+      value: ORIGINAL_STDIN_IS_TTY,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      configurable: true,
+      value: ORIGINAL_STDOUT_IS_TTY,
+    });
+  },
+  resetModules: true,
+  unmock: ['node:child_process'],
 });
 
 test('runDoctor fixes insecure credentials permissions and reruns the check', async () => {

--- a/tests/email.connection.test.ts
+++ b/tests/email.connection.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const BASE_EMAIL_CONFIG = {
   enabled: true,
@@ -19,26 +19,16 @@ const BASE_EMAIL_CONFIG = {
   mediaMaxMb: 20,
 };
 
-const tempDirs: string[] = [];
+const makeTempDir = useTempDir();
 
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.resetModules();
-  vi.doUnmock('imapflow');
-  vi.doUnmock('../src/config/config.js');
-  while (tempDirs.length > 0) {
-    const tempDir = tempDirs.pop();
-    if (!tempDir) continue;
-    fs.rmSync(tempDir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  resetModules: true,
+  unmock: ['imapflow', '../src/config/config.js'],
 });
 
 describe('email connection manager', () => {
   test('seeds a missing cursor from the current mailbox head and only processes later UIDs', async () => {
-    const dataDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'hybridclaw-email-connection-'),
-    );
-    tempDirs.push(dataDir);
+    const dataDir = makeTempDir('hybridclaw-email-connection-');
 
     let mailboxUids = [1, 2];
     let uidNext = 3;
@@ -125,10 +115,7 @@ describe('email connection manager', () => {
   });
 
   test('resumes from a saved cursor and processes messages that arrived while offline', async () => {
-    const dataDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'hybridclaw-email-connection-'),
-    );
-    tempDirs.push(dataDir);
+    const dataDir = makeTempDir('hybridclaw-email-connection-');
 
     const cursorStatePath = path.join(
       dataDir,

--- a/tests/email.connection.test.ts
+++ b/tests/email.connection.test.ts
@@ -22,6 +22,7 @@ const BASE_EMAIL_CONFIG = {
 const makeTempDir = useTempDir();
 
 useCleanMocks({
+  restoreAllMocks: true,
   resetModules: true,
   unmock: ['imapflow', '../src/config/config.js'],
 });

--- a/tests/executables.test.ts
+++ b/tests/executables.test.ts
@@ -1,18 +1,13 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
 const originalPath = process.env.PATH;
 const originalPathExt = process.env.PATHEXT;
 
-function makeTempDir(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempDir = useTempDir();
 
 function writeExecutable(dir: string, relativePath: string): string {
   const absolutePath = path.join(dir, relativePath);
@@ -22,24 +17,22 @@ function writeExecutable(dir: string, relativePath: string): string {
   return absolutePath;
 }
 
-afterEach(() => {
-  vi.resetModules();
-  vi.unstubAllEnvs();
-  if (originalPath === undefined) {
-    delete process.env.PATH;
-  } else {
-    process.env.PATH = originalPath;
-  }
-  if (originalPathExt === undefined) {
-    delete process.env.PATHEXT;
-  } else {
-    process.env.PATHEXT = originalPathExt;
-  }
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (!dir) continue;
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  cleanup: () => {
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
+    if (originalPathExt === undefined) {
+      delete process.env.PATHEXT;
+    } else {
+      process.env.PATHEXT = originalPathExt;
+    }
+  },
+  restoreAllMocks: false,
+  resetModules: true,
+  unstubAllEnvs: true,
 });
 
 test('finds bare executables on PATH when they appear later under the same PATH', async () => {

--- a/tests/gateway-history-summary.test.ts
+++ b/tests/gateway-history-summary.test.ts
@@ -1,32 +1,19 @@
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
-
-import { afterEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const ORIGINAL_HOME = process.env.HOME;
-const tempDirs: string[] = [];
 
-function makeTempHome(): string {
-  const dir = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'hybridclaw-gateway-history-'),
-  );
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempHome = useTempDir('hybridclaw-gateway-history-');
 
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.resetModules();
-  if (ORIGINAL_HOME === undefined) {
-    delete process.env.HOME;
-  } else {
-    process.env.HOME = ORIGINAL_HOME;
-  }
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) fs.rmSync(dir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  cleanup: () => {
+    if (ORIGINAL_HOME === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = ORIGINAL_HOME;
+    }
+  },
+  resetModules: true,
 });
 
 test('getGatewayHistorySummary reports windowed usage, tools, and file changes', async () => {

--- a/tests/gateway-history-summary.test.ts
+++ b/tests/gateway-history-summary.test.ts
@@ -6,6 +6,7 @@ const ORIGINAL_HOME = process.env.HOME;
 const makeTempHome = useTempDir('hybridclaw-gateway-history-');
 
 useCleanMocks({
+  restoreAllMocks: true,
   cleanup: () => {
     if (ORIGINAL_HOME === undefined) {
       delete process.env.HOME;

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -1515,6 +1515,7 @@ async function importFreshHealth(options?: {
 }
 
 useCleanMocks({
+  restoreAllMocks: true,
   cleanup: () => {
     if (ORIGINAL_HYBRIDCLAW_AUTH_SECRET === undefined) {
       delete process.env.HYBRIDCLAW_AUTH_SECRET;

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -1,10 +1,10 @@
 import { createHmac } from 'node:crypto';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { Readable } from 'node:stream';
 
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const DEFAULT_WEB_SESSION_ID = 'agent:main:channel:web:chat:dm:peer:default';
 const WEB_SESSION_ID_RE = /^agent:[^:]+:channel:web:chat:dm:peer:[a-f0-9]{16}$/;
@@ -13,9 +13,9 @@ const OPENAI_SESSION_ID_RE =
 const OPENAI_EXECUTION_SESSION_ID_RE =
   /^agent:[^:]+:channel:openai:chat:dm:peer:(?:[a-f0-9]{16}|exec-[a-f0-9]{24})$/;
 
-const tempDirs: string[] = [];
 const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_HYBRIDCLAW_AUTH_SECRET = process.env.HYBRIDCLAW_AUTH_SECRET;
+const makeTempDocsRoot = useTempDir('hybridclaw-health-');
 
 function signAuthPayload(
   payload: Record<string, unknown>,
@@ -33,7 +33,7 @@ function signAuthPayload(
 function makeTempDocsDir(options?: {
   includeMalformedFrontmatter?: boolean;
 }): string {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-health-'));
+  const root = makeTempDocsRoot();
   const docsDir = path.join(root, 'docs');
   const contentDocsDir = path.join(docsDir, 'content');
   const gettingStartedDir = path.join(contentDocsDir, 'getting-started');
@@ -43,7 +43,6 @@ function makeTempDocsDir(options?: {
   const developerGuideDir = path.join(contentDocsDir, 'developer-guide');
   const referenceDir = path.join(contentDocsDir, 'reference');
   const consoleDistDir = path.join(root, 'console', 'dist');
-  tempDirs.push(root);
   fs.mkdirSync(docsDir, { recursive: true });
   fs.mkdirSync(contentDocsDir, { recursive: true });
   fs.mkdirSync(gettingStartedDir, { recursive: true });
@@ -275,11 +274,7 @@ function makeTempDocsDir(options?: {
   return root;
 }
 
-function makeTempDataDir(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-health-data-'));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempDataDir = useTempDir('hybridclaw-health-data-');
 
 function writeRuntimeConfig(
   homeDir: string,
@@ -1519,44 +1514,42 @@ async function importFreshHealth(options?: {
   };
 }
 
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.doUnmock('node:http');
-  vi.doUnmock('node:dns/promises');
-  vi.doUnmock('../src/config/config.ts');
-  vi.doUnmock('../src/infra/install-root.js');
-  vi.doUnmock('../src/logger.js');
-  vi.doUnmock('../src/agent/conversation.js');
-  vi.doUnmock('../src/memory/db.js');
-  vi.doUnmock('../src/gateway/gateway-service.js');
-  vi.doUnmock('../src/gateway/gateway-chat-service.js');
-  vi.doUnmock('../src/gateway/openai-compatible-model.ts');
-  vi.doUnmock('../src/gateway/gateway-scheduled-task-service.js');
-  vi.doUnmock('../src/providers/factory.js');
-  vi.doUnmock('../src/channels/imessage/runtime.js');
-  vi.doUnmock('../src/channels/msteams/runtime.js');
-  vi.doUnmock('../src/channels/voice/runtime.js');
-  vi.doUnmock('../src/channels/message/tool-actions.js');
-  vi.doUnmock('../src/channels/discord/tool-actions.js');
-  vi.doUnmock('../src/gateway/media-upload-quota.ts');
-  vi.doUnmock('../src/plugins/plugin-manager.js');
-  vi.doUnmock('../src/gateway/gateway-restart.js');
-  vi.resetModules();
-  if (ORIGINAL_HYBRIDCLAW_AUTH_SECRET === undefined) {
-    delete process.env.HYBRIDCLAW_AUTH_SECRET;
-  } else {
-    process.env.HYBRIDCLAW_AUTH_SECRET = ORIGINAL_HYBRIDCLAW_AUTH_SECRET;
-  }
-  if (ORIGINAL_HOME === undefined) {
-    delete process.env.HOME;
-  } else {
-    process.env.HOME = ORIGINAL_HOME;
-  }
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (!dir) continue;
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  cleanup: () => {
+    if (ORIGINAL_HYBRIDCLAW_AUTH_SECRET === undefined) {
+      delete process.env.HYBRIDCLAW_AUTH_SECRET;
+    } else {
+      process.env.HYBRIDCLAW_AUTH_SECRET = ORIGINAL_HYBRIDCLAW_AUTH_SECRET;
+    }
+    if (ORIGINAL_HOME === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = ORIGINAL_HOME;
+    }
+  },
+  resetModules: true,
+  unmock: [
+    'node:http',
+    'node:dns/promises',
+    '../src/config/config.ts',
+    '../src/infra/install-root.js',
+    '../src/logger.js',
+    '../src/agent/conversation.js',
+    '../src/memory/db.js',
+    '../src/gateway/gateway-service.js',
+    '../src/gateway/gateway-chat-service.js',
+    '../src/gateway/openai-compatible-model.ts',
+    '../src/gateway/gateway-scheduled-task-service.js',
+    '../src/providers/factory.js',
+    '../src/channels/imessage/runtime.js',
+    '../src/channels/msteams/runtime.js',
+    '../src/channels/voice/runtime.js',
+    '../src/channels/message/tool-actions.js',
+    '../src/channels/discord/tool-actions.js',
+    '../src/gateway/media-upload-quota.ts',
+    '../src/plugins/plugin-manager.js',
+    '../src/gateway/gateway-restart.js',
+  ],
 });
 
 describe('gateway HTTP server', () => {
@@ -1573,10 +1566,7 @@ describe('gateway HTTP server', () => {
   });
 
   test('routes voice webhooks using the configured webhookPath', async () => {
-    const homeDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'hybridclaw-voice-http-'),
-    );
-    tempDirs.push(homeDir);
+    const homeDir = makeTempDocsRoot('hybridclaw-voice-http-');
     process.env.HOME = homeDir;
     writeRuntimeConfig(homeDir, (config) => {
       const voice = config.voice as Record<string, unknown>;
@@ -6427,8 +6417,7 @@ describe('gateway HTTP server', () => {
   });
 
   test('dispatches gateway-owned http requests with URL auth rules and secret placeholders', async () => {
-    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-http-'));
-    tempDirs.push(homeDir);
+    const homeDir = makeTempDocsRoot('hybridclaw-http-');
     process.env.HOME = homeDir;
     writeRuntimeConfig(homeDir, (config) => {
       const tools = config.tools as Record<string, unknown>;
@@ -6800,10 +6789,7 @@ describe('gateway HTTP server', () => {
 
   test('rejects symlinked artifact paths that escape the allowed roots', async () => {
     const dataDir = makeTempDataDir();
-    const outsideDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'hybridclaw-health-outside-'),
-    );
-    tempDirs.push(outsideDir);
+    const outsideDir = makeTempDocsRoot('hybridclaw-health-outside-');
     const outsideFilePath = path.join(outsideDir, 'secret.docx');
     fs.writeFileSync(outsideFilePath, 'top secret', 'utf8');
 

--- a/tests/gateway-main.test.ts
+++ b/tests/gateway-main.test.ts
@@ -593,6 +593,7 @@ async function importFreshGatewayMain(options?: {
 }
 
 useCleanMocks({
+  restoreAllMocks: true,
   resetModules: true,
   unstubAllGlobals: true,
   unmock: [

--- a/tests/gateway-main.test.ts
+++ b/tests/gateway-main.test.ts
@@ -1,15 +1,9 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
-
-function makeTempDir(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempDir = useTempDir();
 
 async function settle(): Promise<void> {
   await new Promise((resolve) => setImmediate(resolve));
@@ -598,48 +592,45 @@ async function importFreshGatewayMain(options?: {
   return state;
 }
 
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.unstubAllGlobals();
-  vi.doUnmock('../src/agent/executor.js');
-  vi.doUnmock('../src/agent/proactive-policy.js');
-  vi.doUnmock('../src/agent/silent-reply.js');
-  vi.doUnmock('../src/agent/silent-reply-stream.js');
-  vi.doUnmock('../src/audit/observability-ingest.js');
-  vi.doUnmock('../src/channels/discord/delivery.js');
-  vi.doUnmock('../src/channels/discord/mentions.js');
-  vi.doUnmock('../src/channels/discord/runtime.js');
-  vi.doUnmock('../src/channels/imessage/runtime.js');
-  vi.doUnmock('../src/channels/telegram/runtime.js');
-  vi.doUnmock('../src/channels/voice/runtime.js');
-  vi.doUnmock('../src/channels/msteams/attachments.js');
-  vi.doUnmock('../src/channels/msteams/runtime.js');
-  vi.doUnmock('../src/channels/slack/runtime.js');
-  vi.doUnmock('../src/channels/email/runtime.js');
-  vi.doUnmock('../src/channels/whatsapp/runtime.js');
-  vi.doUnmock('../src/channels/whatsapp/auth.js');
-  vi.doUnmock('../src/config/config.js');
-  vi.doUnmock('../src/logger.js');
-  vi.doUnmock('../src/memory/db.js');
-  vi.doUnmock('../src/memory/memory-service.js');
-  vi.doUnmock('../src/agents/agent-registry.js');
-  vi.doUnmock('../src/providers/local-discovery.js');
-  vi.doUnmock('../src/providers/local-health.js');
-  vi.doUnmock('../src/scheduler/heartbeat.js');
-  vi.doUnmock('../src/scheduler/scheduler.js');
-  vi.doUnmock('../src/gateway/gateway-service.js');
-  vi.doUnmock('../src/gateway/gateway-chat-service.js');
-  vi.doUnmock('../src/gateway/gateway-scheduled-task-service.js');
-  vi.doUnmock('../src/gateway/gateway-http-server.js');
-  vi.doUnmock('../src/gateway/proactive-delivery.js');
-  vi.doUnmock('../src/gateway/managed-media-cleanup.js');
-  vi.doUnmock('../src/workflow/executor.js');
-  vi.doUnmock('../src/workflow/service.js');
-  vi.resetModules();
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) fs.rmSync(dir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  resetModules: true,
+  unstubAllGlobals: true,
+  unmock: [
+    '../src/agent/executor.js',
+    '../src/agent/proactive-policy.js',
+    '../src/agent/silent-reply.js',
+    '../src/agent/silent-reply-stream.js',
+    '../src/audit/observability-ingest.js',
+    '../src/channels/discord/delivery.js',
+    '../src/channels/discord/mentions.js',
+    '../src/channels/discord/runtime.js',
+    '../src/channels/imessage/runtime.js',
+    '../src/channels/telegram/runtime.js',
+    '../src/channels/voice/runtime.js',
+    '../src/channels/msteams/attachments.js',
+    '../src/channels/msteams/runtime.js',
+    '../src/channels/slack/runtime.js',
+    '../src/channels/email/runtime.js',
+    '../src/channels/whatsapp/runtime.js',
+    '../src/channels/whatsapp/auth.js',
+    '../src/config/config.js',
+    '../src/logger.js',
+    '../src/memory/db.js',
+    '../src/memory/memory-service.js',
+    '../src/agents/agent-registry.js',
+    '../src/providers/local-discovery.js',
+    '../src/providers/local-health.js',
+    '../src/scheduler/heartbeat.js',
+    '../src/scheduler/scheduler.js',
+    '../src/gateway/gateway-service.js',
+    '../src/gateway/gateway-chat-service.js',
+    '../src/gateway/gateway-scheduled-task-service.js',
+    '../src/gateway/gateway-http-server.js',
+    '../src/gateway/proactive-delivery.js',
+    '../src/gateway/managed-media-cleanup.js',
+    '../src/workflow/executor.js',
+    '../src/workflow/service.js',
+  ],
 });
 
 describe('gateway bootstrap', () => {

--- a/tests/gateway-service.admin-skills.test.ts
+++ b/tests/gateway-service.admin-skills.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { expect, test, vi } from 'vitest';
 import * as yazl from 'yazl';
 import { setupGatewayTest } from './helpers/gateway-test-setup.js';
+import { useTempDir } from './test-utils.ts';
 
 const ORIGINAL_CWD = process.cwd();
 
@@ -15,7 +16,7 @@ vi.mock('../src/agent/agent.js', () => ({
   runAgent: runAgentMock,
 }));
 
-const tempDirs: string[] = [];
+const makeTempDir = useTempDir();
 
 const { setupHome } = setupGatewayTest({
   tempHomePrefix: 'hybridclaw-gateway-admin-skills-',
@@ -23,17 +24,12 @@ const { setupHome } = setupGatewayTest({
     runAgentMock.mockReset();
     vi.doUnmock('../src/skills/skills-guard.js');
     process.chdir(ORIGINAL_CWD);
-    while (tempDirs.length > 0) {
-      const dir = tempDirs.pop();
-      if (!dir) continue;
-      fs.rmSync(dir, { recursive: true, force: true });
-    }
   },
 });
 
 function setupProjectCwd(): string {
   const homeDir = setupHome();
-  tempDirs.push(homeDir);
+  makeTempDir.track(homeDir);
   const projectDir = path.join(homeDir, 'project');
   fs.mkdirSync(projectDir, { recursive: true });
   process.chdir(projectDir);

--- a/tests/gateway-service.audio-transcription.test.ts
+++ b/tests/gateway-service.audio-transcription.test.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const { runAgentMock } = vi.hoisted(() => ({
   runAgentMock: vi.fn(),
@@ -17,13 +17,9 @@ const ORIGINAL_OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 const ORIGINAL_GROQ_API_KEY = process.env.GROQ_API_KEY;
 const ORIGINAL_WHISPER_CPP_MODEL = process.env.WHISPER_CPP_MODEL;
 const ORIGINAL_PATH = process.env.PATH;
-const tempDirs: string[] = [];
 
-function makeTempHome(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-audio-home-'));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempHome = useTempDir('hybridclaw-audio-home-');
+const makeTempDir = useTempDir();
 
 function restoreEnvVar(name: string, value: string | undefined): void {
   if (value === undefined) {
@@ -33,20 +29,17 @@ function restoreEnvVar(name: string, value: string | undefined): void {
   process.env[name] = value;
 }
 
-afterEach(() => {
-  runAgentMock.mockReset();
-  vi.restoreAllMocks();
-  vi.unstubAllGlobals();
-  vi.resetModules();
-  restoreEnvVar('HOME', ORIGINAL_HOME);
-  restoreEnvVar('OPENAI_API_KEY', ORIGINAL_OPENAI_API_KEY);
-  restoreEnvVar('GROQ_API_KEY', ORIGINAL_GROQ_API_KEY);
-  restoreEnvVar('WHISPER_CPP_MODEL', ORIGINAL_WHISPER_CPP_MODEL);
-  restoreEnvVar('PATH', ORIGINAL_PATH);
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) fs.rmSync(dir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  cleanup: () => {
+    runAgentMock.mockReset();
+    restoreEnvVar('HOME', ORIGINAL_HOME);
+    restoreEnvVar('OPENAI_API_KEY', ORIGINAL_OPENAI_API_KEY);
+    restoreEnvVar('GROQ_API_KEY', ORIGINAL_GROQ_API_KEY);
+    restoreEnvVar('WHISPER_CPP_MODEL', ORIGINAL_WHISPER_CPP_MODEL);
+    restoreEnvVar('PATH', ORIGINAL_PATH);
+  },
+  resetModules: true,
+  unstubAllGlobals: true,
 });
 
 async function createGatewayAudioFixture() {
@@ -256,10 +249,7 @@ test('handleGatewayMessage prefers local CLI transcription before OpenAI when au
   const fetchMock = vi.fn();
   vi.stubGlobal('fetch', fetchMock);
 
-  const binDir = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'hybridclaw-whisper-bin-'),
-  );
-  tempDirs.push(binDir);
+  const binDir = makeTempDir('hybridclaw-whisper-bin-');
   const whisperPath = path.join(binDir, 'whisper');
   fs.writeFileSync(
     whisperPath,
@@ -338,10 +328,7 @@ test('handleGatewayMessage transcribes with a local CLI when no provider key is 
   const fetchMock = vi.fn();
   vi.stubGlobal('fetch', fetchMock);
 
-  const binDir = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'hybridclaw-whisper-local-bin-'),
-  );
-  tempDirs.push(binDir);
+  const binDir = makeTempDir('hybridclaw-whisper-local-bin-');
   const whisperPath = path.join(binDir, 'whisper');
   fs.writeFileSync(
     whisperPath,
@@ -419,14 +406,8 @@ test('handleGatewayMessage transcribes managed WhatsApp temp audio with whisper-
   const fetchMock = vi.fn();
   vi.stubGlobal('fetch', fetchMock);
 
-  const binDir = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'hybridclaw-whisper-cli-bin-'),
-  );
-  tempDirs.push(binDir);
-  const modelDir = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'hybridclaw-whisper-cli-model-'),
-  );
-  tempDirs.push(modelDir);
+  const binDir = makeTempDir('hybridclaw-whisper-cli-bin-');
+  const modelDir = makeTempDir('hybridclaw-whisper-cli-model-');
   const modelPath = path.join(modelDir, 'ggml-tiny.bin');
   fs.writeFileSync(modelPath, 'fake-model', 'utf-8');
   process.env.WHISPER_CPP_MODEL = modelPath;
@@ -456,8 +437,7 @@ test('handleGatewayMessage transcribes managed WhatsApp temp audio with whisper-
   fs.chmodSync(whisperCliPath, 0o755);
   process.env.PATH = `${binDir}${path.delimiter}${ORIGINAL_PATH || ''}`;
 
-  const waTempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-wa-'));
-  tempDirs.push(waTempDir);
+  const waTempDir = makeTempDir('hybridclaw-wa-');
   const waAudioPath = path.join(waTempDir, 'voice-note.ogg');
   fs.writeFileSync(waAudioPath, 'voice-bytes', 'utf-8');
 

--- a/tests/gateway-service.audio-transcription.test.ts
+++ b/tests/gateway-service.audio-transcription.test.ts
@@ -30,6 +30,7 @@ function restoreEnvVar(name: string, value: string | undefined): void {
 }
 
 useCleanMocks({
+  restoreAllMocks: true,
   cleanup: () => {
     runAgentMock.mockReset();
     restoreEnvVar('HOME', ORIGINAL_HOME);

--- a/tests/gateway-service.concierge.test.ts
+++ b/tests/gateway-service.concierge.test.ts
@@ -64,6 +64,7 @@ async function createFixture() {
 }
 
 useCleanMocks({
+  restoreAllMocks: true,
   cleanup: () => {
     runAgentMock.mockReset();
     callAuxiliaryModelMock.mockReset();

--- a/tests/gateway-service.concierge.test.ts
+++ b/tests/gateway-service.concierge.test.ts
@@ -1,8 +1,5 @@
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
-
-import { afterEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const { runAgentMock, callAuxiliaryModelMock } = vi.hoisted(() => ({
   runAgentMock: vi.fn(),
@@ -18,15 +15,8 @@ vi.mock('../src/providers/auxiliary.js', () => ({
 }));
 
 const ORIGINAL_HOME = process.env.HOME;
-const tempDirs: string[] = [];
 
-function makeTempHome(): string {
-  const dir = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'hybridclaw-concierge-home-'),
-  );
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempHome = useTempDir('hybridclaw-concierge-home-');
 
 function restoreEnvVar(name: string, value: string | undefined): void {
   if (value === undefined) {
@@ -73,16 +63,13 @@ async function createFixture() {
   };
 }
 
-afterEach(() => {
-  runAgentMock.mockReset();
-  callAuxiliaryModelMock.mockReset();
-  vi.restoreAllMocks();
-  vi.resetModules();
-  restoreEnvVar('HOME', ORIGINAL_HOME);
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) fs.rmSync(dir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  cleanup: () => {
+    runAgentMock.mockReset();
+    callAuxiliaryModelMock.mockReset();
+    restoreEnvVar('HOME', ORIGINAL_HOME);
+  },
+  resetModules: true,
 });
 
 test('asks the urgency question before a long-running request', async () => {

--- a/tests/gateway-service.fullauto.test.ts
+++ b/tests/gateway-service.fullauto.test.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const { runAgentMock } = vi.hoisted(() => ({
   runAgentMock: vi.fn(),
@@ -70,15 +70,8 @@ vi.mock('../src/providers/local-health.js', async () => {
 });
 
 const ORIGINAL_HOME = process.env.HOME;
-const tempDirs: string[] = [];
 
-function makeTempHome(): string {
-  const dir = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'hybridclaw-gateway-fullauto-'),
-  );
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempHome = useTempDir('hybridclaw-gateway-fullauto-');
 
 function restoreEnvVar(name: string, value: string | undefined): void {
   if (value === undefined) {
@@ -123,37 +116,34 @@ function buildLearningState(params: {
   ].join('\n');
 }
 
-afterEach(() => {
-  runAgentMock.mockReset();
-  stopSessionExecutionMock.mockReset();
-  stopSessionExecutionMock.mockImplementation(() => false);
-  getActiveExecutorSessionIdsMock.mockReset();
-  getActiveExecutorSessionIdsMock.mockImplementation(() => []);
-  getSandboxDiagnosticsMock.mockReset();
-  getSandboxDiagnosticsMock.mockImplementation(() => ({
-    mode: 'host' as const,
-    modeExplicit: true,
-    runningInsideContainer: false,
-    image: null,
-    network: null,
-    memory: null,
-    memorySwap: null,
-    cpus: null,
-    securityFlags: ['workspace fencing'],
-    mountAllowlistPath: '/tmp/mount-allowlist.json',
-    additionalMountsConfigured: 0,
-    activeSessions: 0,
-    activeSessionIds: [],
-    warning: 'Running in host mode without container isolation.',
-  }));
-  vi.useRealTimers();
-  vi.restoreAllMocks();
-  vi.resetModules();
-  restoreEnvVar('HOME', ORIGINAL_HOME);
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) fs.rmSync(dir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  cleanup: () => {
+    runAgentMock.mockReset();
+    stopSessionExecutionMock.mockReset();
+    stopSessionExecutionMock.mockImplementation(() => false);
+    getActiveExecutorSessionIdsMock.mockReset();
+    getActiveExecutorSessionIdsMock.mockImplementation(() => []);
+    getSandboxDiagnosticsMock.mockReset();
+    getSandboxDiagnosticsMock.mockImplementation(() => ({
+      mode: 'host' as const,
+      modeExplicit: true,
+      runningInsideContainer: false,
+      image: null,
+      network: null,
+      memory: null,
+      memorySwap: null,
+      cpus: null,
+      securityFlags: ['workspace fencing'],
+      mountAllowlistPath: '/tmp/mount-allowlist.json',
+      additionalMountsConfigured: 0,
+      activeSessions: 0,
+      activeSessionIds: [],
+      warning: 'Running in host mode without container isolation.',
+    }));
+    vi.useRealTimers();
+    restoreEnvVar('HOME', ORIGINAL_HOME);
+  },
+  resetModules: true,
 });
 
 test('fullauto command enables auto-turns, queues follow-up results, and can be disabled', async () => {

--- a/tests/gateway-service.fullauto.test.ts
+++ b/tests/gateway-service.fullauto.test.ts
@@ -117,6 +117,7 @@ function buildLearningState(params: {
 }
 
 useCleanMocks({
+  restoreAllMocks: true,
   cleanup: () => {
     runAgentMock.mockReset();
     stopSessionExecutionMock.mockReset();

--- a/tests/gateway-service.reset.test.ts
+++ b/tests/gateway-service.reset.test.ts
@@ -33,6 +33,7 @@ function updateLastActive(
 }
 
 useCleanMocks({
+  restoreAllMocks: true,
   cleanup: () => {
     restoreEnvVar('HOME', ORIGINAL_HOME);
   },

--- a/tests/gateway-service.reset.test.ts
+++ b/tests/gateway-service.reset.test.ts
@@ -1,20 +1,13 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
 import Database from 'better-sqlite3';
-import { afterEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const ORIGINAL_HOME = process.env.HOME;
-const tempDirs: string[] = [];
 
-function makeTempHome(): string {
-  const dir = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'hybridclaw-gateway-reset-'),
-  );
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempHome = useTempDir('hybridclaw-gateway-reset-');
 
 function restoreEnvVar(name: string, value: string | undefined): void {
   if (value === undefined) {
@@ -39,14 +32,11 @@ function updateLastActive(
   }
 }
 
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.resetModules();
-  restoreEnvVar('HOME', ORIGINAL_HOME);
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) fs.rmSync(dir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  cleanup: () => {
+    restoreEnvVar('HOME', ORIGINAL_HOME);
+  },
+  resetModules: true,
 });
 
 async function seedSessionFixture() {

--- a/tests/gateway-service.scheduler.test.ts
+++ b/tests/gateway-service.scheduler.test.ts
@@ -22,6 +22,7 @@ function restoreEnvVar(name: string, value: string | undefined): void {
 }
 
 useCleanMocks({
+  restoreAllMocks: true,
   cleanup: () => {
     runAgentMock.mockReset();
     restoreEnvVar('HOME', ORIGINAL_HOME);

--- a/tests/gateway-service.scheduler.test.ts
+++ b/tests/gateway-service.scheduler.test.ts
@@ -1,8 +1,5 @@
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
-
-import { afterEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const { runAgentMock } = vi.hoisted(() => ({
   runAgentMock: vi.fn(),
@@ -13,15 +10,8 @@ vi.mock('../src/agent/agent.js', () => ({
 }));
 
 const ORIGINAL_HOME = process.env.HOME;
-const tempDirs: string[] = [];
 
-function makeTempHome(): string {
-  const dir = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'hybridclaw-gateway-scheduler-'),
-  );
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempHome = useTempDir('hybridclaw-gateway-scheduler-');
 
 function restoreEnvVar(name: string, value: string | undefined): void {
   if (value === undefined) {
@@ -31,17 +21,12 @@ function restoreEnvVar(name: string, value: string | undefined): void {
   process.env[name] = value;
 }
 
-afterEach(() => {
-  runAgentMock.mockReset();
-  vi.restoreAllMocks();
-  vi.resetModules();
-  restoreEnvVar('HOME', ORIGINAL_HOME);
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) {
-      fs.rmSync(dir, { recursive: true, force: true });
-    }
-  }
+useCleanMocks({
+  cleanup: () => {
+    runAgentMock.mockReset();
+    restoreEnvVar('HOME', ORIGINAL_HOME);
+  },
+  resetModules: true,
 });
 
 test('admin scheduler includes db-backed tasks and can pause, resume, and delete them', async () => {

--- a/tests/gateway-service.show.test.ts
+++ b/tests/gateway-service.show.test.ts
@@ -14,6 +14,7 @@ function restoreEnvVar(name: string, value: string | undefined): void {
 }
 
 useCleanMocks({
+  restoreAllMocks: true,
   cleanup: () => {
     restoreEnvVar('HOME', ORIGINAL_HOME);
   },

--- a/tests/gateway-service.show.test.ts
+++ b/tests/gateway-service.show.test.ts
@@ -1,17 +1,9 @@
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
-
-import { afterEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const ORIGINAL_HOME = process.env.HOME;
-const tempDirs: string[] = [];
 
-function makeTempHome(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-show-'));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempHome = useTempDir('hybridclaw-show-');
 
 function restoreEnvVar(name: string, value: string | undefined): void {
   if (value === undefined) {
@@ -21,14 +13,11 @@ function restoreEnvVar(name: string, value: string | undefined): void {
   process.env[name] = value;
 }
 
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.resetModules();
-  restoreEnvVar('HOME', ORIGINAL_HOME);
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) fs.rmSync(dir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  cleanup: () => {
+    restoreEnvVar('HOME', ORIGINAL_HOME);
+  },
+  resetModules: true,
 });
 
 test('show command reports and updates the session show mode', async () => {

--- a/tests/gateway-service.workspace-reset.test.ts
+++ b/tests/gateway-service.workspace-reset.test.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const { runAgentMock } = vi.hoisted(() => ({
   runAgentMock: vi.fn(),
@@ -13,13 +13,8 @@ vi.mock('../src/agent/agent.js', () => ({
 }));
 
 const ORIGINAL_HOME = process.env.HOME;
-const tempDirs: string[] = [];
 
-function makeTempHome(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-home-'));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempHome = useTempDir('hybridclaw-home-');
 
 function restoreEnvVar(name: string, value: string | undefined): void {
   if (value === undefined) {
@@ -29,15 +24,12 @@ function restoreEnvVar(name: string, value: string | undefined): void {
   process.env[name] = value;
 }
 
-afterEach(() => {
-  runAgentMock.mockReset();
-  vi.restoreAllMocks();
-  vi.resetModules();
-  restoreEnvVar('HOME', ORIGINAL_HOME);
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) fs.rmSync(dir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  cleanup: () => {
+    runAgentMock.mockReset();
+    restoreEnvVar('HOME', ORIGINAL_HOME);
+  },
+  resetModules: true,
 });
 
 test('handleGatewayMessage clears session history when the agent workspace is recreated', async () => {

--- a/tests/gateway-service.workspace-reset.test.ts
+++ b/tests/gateway-service.workspace-reset.test.ts
@@ -25,6 +25,7 @@ function restoreEnvVar(name: string, value: string | undefined): void {
 }
 
 useCleanMocks({
+  restoreAllMocks: true,
   cleanup: () => {
     runAgentMock.mockReset();
     restoreEnvVar('HOME', ORIGINAL_HOME);

--- a/tests/gbrain-plugin.test.ts
+++ b/tests/gbrain-plugin.test.ts
@@ -216,6 +216,7 @@ function writeGbrainStub(
 }
 
 useCleanMocks({
+  restoreAllMocks: true,
   resetModules: true,
   unstubAllGlobals: true,
 });

--- a/tests/gbrain-plugin.test.ts
+++ b/tests/gbrain-plugin.test.ts
@@ -1,17 +1,11 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
-import { afterEach, expect, test, vi } from 'vitest';
+import { expect, test } from 'vitest';
 
 import type { RuntimeConfig } from '../src/config/runtime-config.js';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
-
-function makeTempDir(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempDir = useTempDir();
 
 function loadRuntimeConfig(): RuntimeConfig {
   return JSON.parse(
@@ -221,13 +215,9 @@ function writeGbrainStub(
   return scriptPath;
 }
 
-afterEach(() => {
-  for (const dir of tempDirs.splice(0)) {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-  vi.restoreAllMocks();
-  vi.resetModules();
-  vi.unstubAllGlobals();
+useCleanMocks({
+  resetModules: true,
+  unstubAllGlobals: true,
 });
 
 test('resolveGbrainPluginConfig normalizes defaults and runtime-relative paths', async () => {

--- a/tests/honcho-memory-plugin.test.ts
+++ b/tests/honcho-memory-plugin.test.ts
@@ -729,6 +729,7 @@ function createHonchoStubServer() {
 }
 
 useCleanMocks({
+  restoreAllMocks: true,
   cleanup: () => {
     if (originalRuntimeHome === undefined) {
       delete process.env.HYBRIDCLAW_DATA_DIR;

--- a/tests/honcho-memory-plugin.test.ts
+++ b/tests/honcho-memory-plugin.test.ts
@@ -1,13 +1,12 @@
 import fs from 'node:fs';
 import { createServer } from 'node:http';
-import os from 'node:os';
 import path from 'node:path';
-import { afterEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import { parse as parseYaml } from 'yaml';
 
 import type { RuntimeConfig } from '../src/config/runtime-config.js';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
 const originalRuntimeHome = process.env.HYBRIDCLAW_DATA_DIR;
 
 interface StubMessage {
@@ -18,11 +17,7 @@ interface StubMessage {
   session_id?: string;
 }
 
-function makeTempDir(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempDir = useTempDir();
 
 function loadRuntimeConfig(): RuntimeConfig {
   return JSON.parse(
@@ -733,18 +728,16 @@ function createHonchoStubServer() {
   };
 }
 
-afterEach(() => {
-  if (originalRuntimeHome === undefined) {
-    delete process.env.HYBRIDCLAW_DATA_DIR;
-  } else {
-    process.env.HYBRIDCLAW_DATA_DIR = originalRuntimeHome;
-  }
-  for (const dir of tempDirs.splice(0)) {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-  vi.restoreAllMocks();
-  vi.resetModules();
-  vi.unstubAllGlobals();
+useCleanMocks({
+  cleanup: () => {
+    if (originalRuntimeHome === undefined) {
+      delete process.env.HYBRIDCLAW_DATA_DIR;
+    } else {
+      process.env.HYBRIDCLAW_DATA_DIR = originalRuntimeHome;
+    }
+  },
+  resetModules: true,
+  unstubAllGlobals: true,
 });
 
 test('honcho-memory seeds workspace identity, mirrors turns once, and exposes Honcho commands and tools', async () => {

--- a/tests/host-runtime-setup.test.ts
+++ b/tests/host-runtime-setup.test.ts
@@ -1,18 +1,10 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, describe, expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
+import { useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
-
-function createTempDir(): string {
-  const dir = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'hybridclaw-host-runtime-setup-'),
-  );
-  tempDirs.push(dir);
-  return dir;
-}
+const createTempDir = useTempDir('hybridclaw-host-runtime-setup-');
 
 function writeContainerPackage(
   installRoot: string,
@@ -28,14 +20,6 @@ function writeContainerPackage(
     }),
   );
 }
-
-afterEach(() => {
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (!dir) continue;
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-});
 
 describe('ensureHostRuntimeReady', () => {
   test('throws a reinstall error when packaged runtime dependencies are missing', async () => {

--- a/tests/instruction-integrity.test.ts
+++ b/tests/instruction-integrity.test.ts
@@ -1,25 +1,19 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const originalCwd = process.cwd();
-const tempDirs: string[] = [];
 
-function makeTempDir(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempDir = useTempDir();
 
-afterEach(() => {
-  process.chdir(originalCwd);
-  vi.resetModules();
-  vi.unstubAllEnvs();
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) fs.rmSync(dir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  cleanup: () => {
+    process.chdir(originalCwd);
+  },
+  restoreAllMocks: false,
+  resetModules: true,
+  unstubAllEnvs: true,
 });
 
 describe('instruction integrity', () => {

--- a/tests/managed-temp-media.test.ts
+++ b/tests/managed-temp-media.test.ts
@@ -7,6 +7,7 @@ import { useCleanMocks, useTempDir } from './test-utils.ts';
 const makeTempRoot = useTempDir('hybridclaw-managed-temp-');
 
 useCleanMocks({
+  restoreAllMocks: true,
   resetModules: true,
   unmock: ['../src/logger.js'],
 });

--- a/tests/managed-temp-media.test.ts
+++ b/tests/managed-temp-media.test.ts
@@ -1,29 +1,14 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
+const makeTempRoot = useTempDir('hybridclaw-managed-temp-');
 
-function makeTempRoot(): string {
-  const dir = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'hybridclaw-managed-temp-'),
-  );
-  tempDirs.push(dir);
-  return dir;
-}
-
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.doUnmock('../src/logger.js');
-  vi.resetModules();
-
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (!dir) continue;
-    fs.rmSync(dir, { force: true, recursive: true });
-  }
+useCleanMocks({
+  resetModules: true,
+  unmock: ['../src/logger.js'],
 });
 
 describe('managed temp media helpers', () => {

--- a/tests/mempalace-memory-plugin.test.ts
+++ b/tests/mempalace-memory-plugin.test.ts
@@ -135,6 +135,7 @@ function readMempalaceCommandLog(rootDir: string): Array<{
 }
 
 useCleanMocks({
+  restoreAllMocks: true,
   resetModules: true,
   unstubAllGlobals: true,
 });

--- a/tests/mempalace-memory-plugin.test.ts
+++ b/tests/mempalace-memory-plugin.test.ts
@@ -2,17 +2,12 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, expect, test, vi } from 'vitest';
+import { expect, test } from 'vitest';
 
 import type { RuntimeConfig } from '../src/config/runtime-config.js';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
-
-function makeTempDir(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempDir = useTempDir();
 
 function loadRuntimeConfig(): RuntimeConfig {
   return JSON.parse(
@@ -139,13 +134,9 @@ function readMempalaceCommandLog(rootDir: string): Array<{
     );
 }
 
-afterEach(() => {
-  for (const dir of tempDirs.splice(0)) {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-  vi.restoreAllMocks();
-  vi.resetModules();
-  vi.unstubAllGlobals();
+useCleanMocks({
+  resetModules: true,
+  unstubAllGlobals: true,
 });
 
 test('mempalace-memory injects wake-up and search context and exposes a command', async () => {

--- a/tests/mempalace-process.test.ts
+++ b/tests/mempalace-process.test.ts
@@ -1,22 +1,10 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, expect, test } from 'vitest';
+import { expect, test } from 'vitest';
+import { useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
-
-function makeTempDir(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
-
-afterEach(() => {
-  for (const dir of tempDirs.splice(0)) {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-});
+const makeTempDir = useTempDir();
 
 test('runMempalace reports when stderr output was truncated on non-zero exit', async () => {
   const cwd = makeTempDir('hybridclaw-mempalace-process-');

--- a/tests/msteams.attachments.test.ts
+++ b/tests/msteams.attachments.test.ts
@@ -1,13 +1,11 @@
 import fs from 'node:fs';
 import fsPromises from 'node:fs/promises';
-import os from 'node:os';
 import path from 'node:path';
 
 import { expect, test, vi } from 'vitest';
 import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const makeTempDir = useTempDir();
-const dataDirs: string[] = [];
 
 function trackTempDirFromMediaPath(filePath: string | null | undefined): void {
   if (!filePath) return;
@@ -18,10 +16,7 @@ async function importAttachmentsModule(
   configOverrides: Record<string, unknown> = {},
 ) {
   vi.resetModules();
-  const dataDir = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'hybridclaw-msteams-cache-'),
-  );
-  dataDirs.push(dataDir);
+  const dataDir = makeTempDir('hybridclaw-msteams-cache-');
   const baseConfig = {
     CONTAINER_SANDBOX_MODE: 'host',
     DATA_DIR: dataDir,
@@ -48,13 +43,6 @@ async function importAttachmentsModule(
 }
 
 useCleanMocks({
-  cleanup: () => {
-    while (dataDirs.length > 0) {
-      const dir = dataDirs.pop();
-      if (!dir) continue;
-      fs.rmSync(dir, { recursive: true, force: true });
-    }
-  },
   resetModules: true,
   unstubAllGlobals: true,
 });

--- a/tests/msteams.attachments.test.ts
+++ b/tests/msteams.attachments.test.ts
@@ -43,6 +43,7 @@ async function importAttachmentsModule(
 }
 
 useCleanMocks({
+  restoreAllMocks: true,
   resetModules: true,
   unstubAllGlobals: true,
 });

--- a/tests/msteams.attachments.test.ts
+++ b/tests/msteams.attachments.test.ts
@@ -3,14 +3,15 @@ import fsPromises from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
+const makeTempDir = useTempDir();
 const dataDirs: string[] = [];
 
 function trackTempDirFromMediaPath(filePath: string | null | undefined): void {
   if (!filePath) return;
-  tempDirs.push(path.dirname(filePath));
+  makeTempDir.track(path.dirname(filePath));
 }
 
 async function importAttachmentsModule(
@@ -46,26 +47,21 @@ async function importAttachmentsModule(
   return import('../src/channels/msteams/attachments.js');
 }
 
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.unstubAllGlobals();
-  vi.resetModules();
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (!dir) continue;
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-  while (dataDirs.length > 0) {
-    const dir = dataDirs.pop();
-    if (!dir) continue;
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  cleanup: () => {
+    while (dataDirs.length > 0) {
+      const dir = dataDirs.pop();
+      if (!dir) continue;
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  },
+  resetModules: true,
+  unstubAllGlobals: true,
 });
 
 test('buildTeamsUploadedFileAttachment uploads the file through Bot Framework', async () => {
   const { buildTeamsUploadedFileAttachment } = await importAttachmentsModule();
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-msteams-'));
-  tempDirs.push(tempDir);
+  const tempDir = makeTempDir('hybridclaw-msteams-');
   const filePath = path.join(tempDir, 'hybridclaw-homepage.png');
   fs.writeFileSync(filePath, Buffer.from([1, 2, 3, 4]));
 
@@ -116,8 +112,7 @@ test('buildTeamsUploadedFileAttachment uploads the file through Bot Framework', 
 
 test('buildTeamsUploadedFileAttachment inlines small images for personal chats', async () => {
   const { buildTeamsUploadedFileAttachment } = await importAttachmentsModule();
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-msteams-'));
-  tempDirs.push(tempDir);
+  const tempDir = makeTempDir('hybridclaw-msteams-');
   const filePath = path.join(tempDir, 'hybridclaw-homepage.png');
   fs.writeFileSync(filePath, Buffer.from([1, 2, 3, 4]));
 
@@ -164,8 +159,7 @@ test('buildTeamsUploadedFileAttachment inlines small images for personal chats',
 
 test('buildTeamsUploadedFileAttachment still inlines tall personal images under 4 MB', async () => {
   const { buildTeamsUploadedFileAttachment } = await importAttachmentsModule();
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-msteams-'));
-  tempDirs.push(tempDir);
+  const tempDir = makeTempDir('hybridclaw-msteams-');
   const filePath = path.join(tempDir, 'hybridclaw-homepage.png');
   const fileBuffer = Buffer.alloc(2_000_000, 1);
   fs.writeFileSync(filePath, fileBuffer);
@@ -211,8 +205,7 @@ test('buildTeamsUploadedFileAttachment still inlines tall personal images under 
 
 test('buildTeamsUploadedFileAttachment uses a file consent card for personal non-image files', async () => {
   const { buildTeamsUploadedFileAttachment } = await importAttachmentsModule();
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-msteams-'));
-  tempDirs.push(tempDir);
+  const tempDir = makeTempDir('hybridclaw-msteams-');
   const filePath = path.join(tempDir, 'report.pdf');
   fs.writeFileSync(filePath, Buffer.from([1, 2, 3, 4]));
 
@@ -267,8 +260,7 @@ test('buildTeamsUploadedFileAttachment uses a file consent card for personal non
 
 test('buildTeamsUploadedFileAttachment rejects large non-personal uploads without a storage fallback', async () => {
   const { buildTeamsUploadedFileAttachment } = await importAttachmentsModule();
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-msteams-'));
-  tempDirs.push(tempDir);
+  const tempDir = makeTempDir('hybridclaw-msteams-');
   const filePath = path.join(tempDir, 'large.zip');
   fs.writeFileSync(filePath, Buffer.alloc(4_300_000, 1));
 
@@ -312,8 +304,7 @@ test('maybeHandleMSTeamsFileConsentInvoke uploads the pending file and sends a f
     buildTeamsUploadedFileAttachment,
     maybeHandleMSTeamsFileConsentInvoke,
   } = await importAttachmentsModule();
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-msteams-'));
-  tempDirs.push(tempDir);
+  const tempDir = makeTempDir('hybridclaw-msteams-');
   const filePath = path.join(tempDir, 'report.pdf');
   fs.writeFileSync(filePath, Buffer.from([1, 2, 3, 4]));
 

--- a/tests/native-media.test.ts
+++ b/tests/native-media.test.ts
@@ -1,22 +1,14 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, describe, expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
+import { useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
-
-afterEach(() => {
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) fs.rmSync(dir, { recursive: true, force: true });
-  }
-});
+const makeTempDir = useTempDir();
 
 describe('native media injection', () => {
   test('injects native audio parts for vllm when no transcript is present', async () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-wa-'));
-    tempDirs.push(tempDir);
+    const tempDir = makeTempDir('hybridclaw-wa-');
     const audioPath = path.join(tempDir, 'voice-note.ogg');
     fs.writeFileSync(audioPath, 'voice-bytes', 'utf-8');
 
@@ -69,8 +61,7 @@ describe('native media injection', () => {
   });
 
   test('skips native audio injection when a transcript was already prepended', async () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-wa-'));
-    tempDirs.push(tempDir);
+    const tempDir = makeTempDir('hybridclaw-wa-');
     const audioPath = path.join(tempDir, 'voice-note.ogg');
     fs.writeFileSync(audioPath, 'voice-bytes', 'utf-8');
 

--- a/tests/plugin-install.test.ts
+++ b/tests/plugin-install.test.ts
@@ -1,17 +1,11 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import type { RuntimeConfig } from '../src/config/runtime-config.js';
+import { useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
-
-function makeTempDir(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempDir = useTempDir();
 
 function writePluginDir(
   dir: string,
@@ -196,14 +190,6 @@ function createRuntimeConfigState(initial?: RuntimeConfig): {
     read: () => structuredClone(config),
   };
 }
-
-afterEach(() => {
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (!dir) continue;
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-});
 
 describe('plugin install', () => {
   test('installs a local plugin directory into homeDir/plugins', async () => {

--- a/tests/plugin-manager.singleton.test.ts
+++ b/tests/plugin-manager.singleton.test.ts
@@ -1,17 +1,11 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import type { RuntimeConfig } from '../src/config/runtime-config.js';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
-
-function makeTempDir(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempDir = useTempDir();
 
 function loadRuntimeConfig(): RuntimeConfig {
   return JSON.parse(
@@ -63,13 +57,10 @@ function writeDemoPlugin(pluginDir: string): void {
   );
 }
 
-afterEach(() => {
-  vi.doUnmock('../src/config/runtime-config.js');
-  vi.resetModules();
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) fs.rmSync(dir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  restoreAllMocks: false,
+  resetModules: true,
+  unmock: ['../src/config/runtime-config.js'],
 });
 
 test('ensurePluginManagerInitialized replaces a failed singleton so later calls can recover', async () => {

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -1,19 +1,13 @@
 import fs from 'node:fs';
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import os from 'node:os';
 import path from 'node:path';
 import { Readable } from 'node:stream';
 
-import { afterEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import type { RuntimeConfig } from '../src/config/runtime-config.js';
+import { useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
-
-function makeTempDir(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempDir = useTempDir();
 
 function loadRuntimeConfig(): RuntimeConfig {
   return JSON.parse(
@@ -625,12 +619,6 @@ function writeJavaScriptCommandPluginWithHelper(
   );
   return entrypoint;
 }
-
-afterEach(() => {
-  for (const dir of tempDirs.splice(0)) {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-});
 
 test('loadPluginManifest trims optional strings and normalizes nested sections', async () => {
   const cwd = makeTempDir('hybridclaw-plugin-project-');

--- a/tests/postinstall-container.test.ts
+++ b/tests/postinstall-container.test.ts
@@ -1,34 +1,21 @@
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, expect, test } from 'vitest';
-
+import { expect, test } from 'vitest';
 import {
   buildBootstrapEnv,
   inspectContainerBootstrap,
   resolveNpmCommand,
 } from '../scripts/postinstall-container.mjs';
+import { useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
-
-function makeTempDir(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-postinstall-'));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempDir = useTempDir('hybridclaw-postinstall-');
 
 function writeJson(filePath: string, value: unknown): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
 }
-
-afterEach(() => {
-  for (const dir of tempDirs.splice(0)) {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-});
 
 test('skips packaged container bootstrap in a source checkout', () => {
   const packageRoot = makeTempDir();

--- a/tests/qmd-plugin.test.ts
+++ b/tests/qmd-plugin.test.ts
@@ -147,6 +147,7 @@ function writeQmdStub(
 }
 
 useCleanMocks({
+  restoreAllMocks: true,
   resetModules: true,
   unstubAllGlobals: true,
 });

--- a/tests/qmd-plugin.test.ts
+++ b/tests/qmd-plugin.test.ts
@@ -1,19 +1,13 @@
 import { EventEmitter } from 'node:events';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
-import { afterEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import { parse as parseYaml } from 'yaml';
 
 import type { RuntimeConfig } from '../src/config/runtime-config.js';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
-
-function makeTempDir(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempDir = useTempDir();
 
 function loadRuntimeConfig(): RuntimeConfig {
   return JSON.parse(
@@ -152,13 +146,9 @@ function writeQmdStub(
   return scriptPath;
 }
 
-afterEach(() => {
-  for (const dir of tempDirs.splice(0)) {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-  vi.restoreAllMocks();
-  vi.resetModules();
-  vi.unstubAllGlobals();
+useCleanMocks({
+  resetModules: true,
+  unstubAllGlobals: true,
 });
 
 test('QMD plugin injects external prompt context and exposes a status command', async () => {

--- a/tests/scheduler.backlog-retry.test.ts
+++ b/tests/scheduler.backlog-retry.test.ts
@@ -1,19 +1,14 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
-import { afterEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import type { RuntimeConfig } from '../src/config/runtime-config.ts';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_DISABLE_CONFIG_WATCHER =
   process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
-const tempDirs: string[] = [];
 
-function makeTempHome(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-scheduler-'));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempHome = useTempDir('hybridclaw-scheduler-');
 
 function restoreEnvVar(name: string, value: string | undefined): void {
   if (value === undefined) {
@@ -54,21 +49,16 @@ function writeSchedulerState(homeDir: string, state: unknown): void {
   fs.writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`, 'utf-8');
 }
 
-afterEach(async () => {
-  vi.useRealTimers();
-  vi.restoreAllMocks();
-  vi.resetModules();
-  restoreEnvVar('HOME', ORIGINAL_HOME);
-  restoreEnvVar(
-    'HYBRIDCLAW_DISABLE_CONFIG_WATCHER',
-    ORIGINAL_DISABLE_CONFIG_WATCHER,
-  );
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) {
-      fs.rmSync(dir, { recursive: true, force: true });
-    }
-  }
+useCleanMocks({
+  cleanup: async () => {
+    vi.useRealTimers();
+    restoreEnvVar('HOME', ORIGINAL_HOME);
+    restoreEnvVar(
+      'HYBRIDCLAW_DISABLE_CONFIG_WATCHER',
+      ORIGINAL_DISABLE_CONFIG_WATCHER,
+    );
+  },
+  resetModules: true,
 });
 
 test('legacy backlog-assigned one-shot config jobs move to review after the default retry budget', async () => {

--- a/tests/scheduler.backlog-retry.test.ts
+++ b/tests/scheduler.backlog-retry.test.ts
@@ -50,6 +50,7 @@ function writeSchedulerState(homeDir: string, state: unknown): void {
 }
 
 useCleanMocks({
+  restoreAllMocks: true,
   cleanup: async () => {
     vi.useRealTimers();
     restoreEnvVar('HOME', ORIGINAL_HOME);

--- a/tests/security.media-paths.test.ts
+++ b/tests/security.media-paths.test.ts
@@ -1,21 +1,14 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, expect, test } from 'vitest';
-
+import { expect, test } from 'vitest';
 import {
   resolveAllowedHostMediaPath,
   type ValidatedMountAlias,
 } from '../src/security/media-paths.js';
+import { useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
-
-function makeTempDir(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempDir = useTempDir();
 
 function writeFile(root: string, relativePath: string): string {
   const filePath = path.join(root, relativePath);
@@ -27,13 +20,6 @@ function writeFile(root: string, relativePath: string): string {
 function canonicalPath(filePath: string): string {
   return fs.realpathSync(filePath);
 }
-
-afterEach(() => {
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) fs.rmSync(dir, { recursive: true, force: true });
-  }
-});
 
 function buildParams(
   overrides: Partial<{

--- a/tests/session-reset.test.ts
+++ b/tests/session-reset.test.ts
@@ -90,6 +90,7 @@ async function initSessionTestContext() {
 }
 
 useCleanMocks({
+  restoreAllMocks: true,
   cleanup: () => {
     runPreCompactionMemoryFlushMock.mockReset();
     restoreEnvVar('HOME', ORIGINAL_HOME);

--- a/tests/session-reset.test.ts
+++ b/tests/session-reset.test.ts
@@ -1,15 +1,13 @@
-import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
-import { afterEach, expect, test, vi } from 'vitest';
-
+import { expect, test, vi } from 'vitest';
 import {
   DEFAULT_RESET_POLICY,
   isSessionExpired,
   resolveResetPolicy,
   resolveSessionResetChannelKind,
 } from '../src/session/session-reset.ts';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const { runPreCompactionMemoryFlushMock } = vi.hoisted(() => ({
   runPreCompactionMemoryFlushMock: vi.fn(),
@@ -27,15 +25,8 @@ vi.mock('../src/session/session-maintenance.js', async (importOriginal) => {
 });
 
 const ORIGINAL_HOME = process.env.HOME;
-const tempDirs: string[] = [];
 
-function makeTempHome(): string {
-  const dir = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'hybridclaw-session-reset-'),
-  );
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempHome = useTempDir('hybridclaw-session-reset-');
 
 function restoreEnvVar(name: string, value: string | undefined): void {
   if (value === undefined) {
@@ -98,15 +89,12 @@ async function initSessionTestContext() {
   };
 }
 
-afterEach(() => {
-  runPreCompactionMemoryFlushMock.mockReset();
-  vi.restoreAllMocks();
-  vi.resetModules();
-  restoreEnvVar('HOME', ORIGINAL_HOME);
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) fs.rmSync(dir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  cleanup: () => {
+    runPreCompactionMemoryFlushMock.mockReset();
+    restoreEnvVar('HOME', ORIGINAL_HOME);
+  },
+  resetModules: true,
 });
 
 test('isSessionExpired returns false for mode none', () => {

--- a/tests/skills.invocation.test.ts
+++ b/tests/skills.invocation.test.ts
@@ -1,21 +1,19 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, expect, test } from 'vitest';
-
+import { expect, test } from 'vitest';
 import {
   expandSkillInvocation,
   resolveObservedSkillName,
   resolveSkillInvocationForTurn,
   type Skill,
 } from '../src/skills/skills.js';
+import { useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
+const makeTempDir = useTempDir();
 
 function makeTempSkill(skillName: string): Skill {
-  const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-skill-'));
-  tempDirs.push(baseDir);
+  const baseDir = makeTempDir('hybridclaw-skill-');
   const filePath = path.join(baseDir, 'SKILL.md');
   fs.writeFileSync(
     filePath,
@@ -53,13 +51,6 @@ function makeTempSkill(skillName: string): Skill {
     location: `skills/${skillName}/SKILL.md`,
   };
 }
-
-afterEach(() => {
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) fs.rmSync(dir, { recursive: true, force: true });
-  }
-});
 
 test('does not expand plain-text requests that mention a skill name', () => {
   const appleMusic = makeTempSkill('apple-music');

--- a/tests/telegram.api.test.ts
+++ b/tests/telegram.api.test.ts
@@ -6,6 +6,7 @@ import { useCleanMocks, useTempDir } from './test-utils.ts';
 const makeTempDir = useTempDir();
 
 useCleanMocks({
+  restoreAllMocks: true,
   resetModules: true,
   unstubAllGlobals: true,
 });

--- a/tests/telegram.api.test.ts
+++ b/tests/telegram.api.test.ts
@@ -1,26 +1,13 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
-import { afterEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
+const makeTempDir = useTempDir();
 
-function makeTempDir(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
-
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.unstubAllGlobals();
-  vi.resetModules();
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) {
-      fs.rmSync(dir, { recursive: true, force: true });
-    }
-  }
+useCleanMocks({
+  resetModules: true,
+  unstubAllGlobals: true,
 });
 
 test('redacts the Telegram bot token from API transport errors', async () => {

--- a/tests/telegram.runtime.test.ts
+++ b/tests/telegram.runtime.test.ts
@@ -1,15 +1,7 @@
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
-import { afterEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
-
-function makeTempDir(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempDir = useTempDir();
 
 async function importFreshTelegramRuntime() {
   vi.resetModules();
@@ -127,22 +119,17 @@ async function importFreshTelegramRuntime() {
   };
 }
 
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.doUnmock('../src/config/config.js');
-  vi.doUnmock('../src/logger.js');
-  vi.doUnmock('../src/channels/channel-registry.js');
-  vi.doUnmock('../src/channels/telegram/api.js');
-  vi.doUnmock('../src/channels/telegram/delivery.js');
-  vi.doUnmock('../src/channels/telegram/inbound.js');
-  vi.doUnmock('../src/channels/telegram/typing.js');
-  vi.resetModules();
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) {
-      fs.rmSync(dir, { recursive: true, force: true });
-    }
-  }
+useCleanMocks({
+  resetModules: true,
+  unmock: [
+    '../src/config/config.js',
+    '../src/logger.js',
+    '../src/channels/channel-registry.js',
+    '../src/channels/telegram/api.js',
+    '../src/channels/telegram/delivery.js',
+    '../src/channels/telegram/inbound.js',
+    '../src/channels/telegram/typing.js',
+  ],
 });
 
 test('aborts in-flight Telegram handlers during shutdown', async () => {

--- a/tests/telegram.runtime.test.ts
+++ b/tests/telegram.runtime.test.ts
@@ -120,6 +120,7 @@ async function importFreshTelegramRuntime() {
 }
 
 useCleanMocks({
+  restoreAllMocks: true,
   resetModules: true,
   unmock: [
     '../src/config/config.js',

--- a/tests/test-utils.test.ts
+++ b/tests/test-utils.test.ts
@@ -2,9 +2,9 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { cleanupTrackedTempDirs } from './test-utils.js';
+import { cleanupTrackedTempDirs, useCleanMocks } from './test-utils.js';
 
 describe('cleanupTrackedTempDirs', () => {
   const originalCwd = process.cwd();
@@ -36,5 +36,53 @@ describe('cleanupTrackedTempDirs', () => {
 
     expect(fs.existsSync(tempDir)).toBe(false);
     expect(process.cwd()).toBe(originalCwd);
+  });
+
+  it('ignores missing directories but still surfaces other remove failures', () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'hybridclaw-test-utils-'),
+    );
+
+    expect(() => cleanupTrackedTempDirs([tempDir, tempDir])).not.toThrow();
+
+    const rmSyncSpy = vi.spyOn(fs, 'rmSync').mockImplementation(() => {
+      const error = new Error('permission denied') as NodeJS.ErrnoException;
+      error.code = 'EACCES';
+      throw error;
+    });
+
+    try {
+      expect(() =>
+        cleanupTrackedTempDirs(['/tmp/hybridclaw-test-utils-fail']),
+      ).toThrow('permission denied');
+    } finally {
+      rmSyncSpy.mockRestore();
+    }
+  });
+});
+
+describe('useCleanMocks', () => {
+  const subject = {
+    call: () => 'real',
+  };
+
+  let cleanupObservation: string | undefined;
+
+  useCleanMocks({
+    cleanup: () => {
+      cleanupObservation = subject.call();
+    },
+    restoreAllMocks: true,
+  });
+
+  it('restores spies before running custom cleanup', () => {
+    cleanupObservation = undefined;
+    vi.spyOn(subject, 'call').mockReturnValue('mock');
+
+    expect(subject.call()).toBe('mock');
+  });
+
+  it('runs the previous cleanup against the restored implementation', () => {
+    expect(cleanupObservation).toBe('real');
   });
 });

--- a/tests/test-utils.test.ts
+++ b/tests/test-utils.test.ts
@@ -1,0 +1,40 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { cleanupTrackedTempDirs } from './test-utils.js';
+
+describe('cleanupTrackedTempDirs', () => {
+  const originalCwd = process.cwd();
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+  });
+
+  it('moves cwd out of a tracked directory before deleting it', () => {
+    const rootDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'hybridclaw-test-utils-'),
+    );
+    const nestedDir = path.join(rootDir, 'nested');
+    fs.mkdirSync(nestedDir);
+    process.chdir(nestedDir);
+
+    cleanupTrackedTempDirs([rootDir]);
+
+    expect(fs.existsSync(rootDir)).toBe(false);
+    expect(fs.realpathSync(process.cwd())).toBe(fs.realpathSync(os.tmpdir()));
+  });
+
+  it('keeps cwd unchanged when it is outside tracked directories', () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'hybridclaw-test-utils-'),
+    );
+
+    cleanupTrackedTempDirs([tempDir]);
+
+    expect(fs.existsSync(tempDir)).toBe(false);
+    expect(process.cwd()).toBe(originalCwd);
+  });
+});

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -17,11 +17,75 @@ type TempDirFactory = ((prefix?: string) => string) & {
   track: (dir: string | null | undefined) => void;
 };
 
-function removeTrackedDirs(tempDirs: string[]): void {
+function getCurrentWorkingDir(): string | null {
+  try {
+    return process.cwd();
+  } catch {
+    return null;
+  }
+}
+
+function normalizeExistingPath(targetPath: string): string {
+  try {
+    return fs.realpathSync.native(targetPath);
+  } catch {
+    return path.resolve(targetPath);
+  }
+}
+
+function isWithinDir(candidate: string, dir: string): boolean {
+  const relative = path.relative(
+    normalizeExistingPath(dir),
+    normalizeExistingPath(candidate),
+  );
+  return (
+    relative === '' ||
+    (!relative.startsWith('..') && !path.isAbsolute(relative))
+  );
+}
+
+function chdirToSafeLocation(dir: string): void {
+  for (const candidate of [os.tmpdir(), path.parse(dir).root]) {
+    if (isWithinDir(candidate, dir)) continue;
+    try {
+      process.chdir(candidate);
+      return;
+    } catch {}
+  }
+}
+
+function moveCwdOutOfDir(dir: string): void {
+  const currentCwd = getCurrentWorkingDir();
+  if (currentCwd && !isWithinDir(currentCwd, dir)) {
+    return;
+  }
+  chdirToSafeLocation(dir);
+}
+
+function isRetryableRemoveError(
+  error: unknown,
+): error is NodeJS.ErrnoException {
+  return (
+    error instanceof Error &&
+    (error as NodeJS.ErrnoException).code !== undefined &&
+    ['EBUSY', 'EPERM'].includes((error as NodeJS.ErrnoException).code ?? '')
+  );
+}
+
+export function cleanupTrackedTempDirs(tempDirs: string[]): void {
   while (tempDirs.length > 0) {
     const dir = tempDirs.pop();
     if (!dir) continue;
-    fs.rmSync(dir, { force: true, recursive: true });
+    moveCwdOutOfDir(dir);
+    try {
+      fs.rmSync(dir, { force: true, recursive: true });
+    } catch (error) {
+      if (!isRetryableRemoveError(error)) {
+        throw error;
+      }
+      moveCwdOutOfDir(dir);
+      fs.rmSync(dir, { force: true, recursive: true });
+    }
   }
 }
 
@@ -29,7 +93,7 @@ export function useTempDir(defaultPrefix = 'hybridclaw-test-'): TempDirFactory {
   const tempDirs: string[] = [];
 
   afterEach(() => {
-    removeTrackedDirs(tempDirs);
+    cleanupTrackedTempDirs(tempDirs);
   });
 
   const makeTempDir = ((prefix = defaultPrefix) => {

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -76,19 +76,30 @@ function isRetryableRemoveError(
   );
 }
 
+function removeDirOrIgnoreMissing(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return;
+    }
+    throw error;
+  }
+}
+
 export function cleanupTrackedTempDirs(tempDirs: string[]): void {
   while (tempDirs.length > 0) {
     const dir = tempDirs.pop();
     if (!dir) continue;
     moveCwdOutOfDir(dir);
     try {
-      fs.rmSync(dir, { force: true, recursive: true });
+      removeDirOrIgnoreMissing(dir);
     } catch (error) {
       if (!isRetryableRemoveError(error)) {
         throw error;
       }
       moveCwdOutOfDir(dir);
-      fs.rmSync(dir, { force: true, recursive: true });
+      removeDirOrIgnoreMissing(dir);
     }
   }
 }
@@ -96,6 +107,9 @@ export function cleanupTrackedTempDirs(tempDirs: string[]): void {
 export function useTempDir(defaultPrefix = 'hybridclaw-test-'): TempDirFactory {
   const tempDirs: string[] = [];
 
+  // If a test chdirs into a temp dir, call useTempDir() before useCleanMocks().
+  // Vitest runs afterEach hooks in LIFO order, so useCleanMocks can restore cwd
+  // before this temp-dir cleanup runs.
   afterEach(() => {
     cleanupTrackedTempDirs(tempDirs);
   });
@@ -126,11 +140,11 @@ export function useCleanMocks(options: CleanMocksOptions = {}): void {
 
   afterEach(async () => {
     try {
-      await cleanup?.();
-    } finally {
       if (restoreAllMocks) {
         vi.restoreAllMocks();
       }
+      await cleanup?.();
+    } finally {
       if (unstubAllGlobals) {
         vi.unstubAllGlobals();
       }

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -13,6 +13,10 @@ export interface CleanMocksOptions {
   unstubAllGlobals?: boolean;
 }
 
+/**
+ * Kept callable so migrated tests can stay terse with `makeTempDir()`, while
+ * still exposing `makeTempDir.track(dir)` for temp dirs created elsewhere.
+ */
 type TempDirFactory = ((prefix?: string) => string) & {
   track: (dir: string | null | undefined) => void;
 };
@@ -111,23 +115,32 @@ export function useTempDir(defaultPrefix = 'hybridclaw-test-'): TempDirFactory {
 }
 
 export function useCleanMocks(options: CleanMocksOptions = {}): void {
+  const {
+    cleanup,
+    restoreAllMocks = false,
+    resetModules = false,
+    unmock = [],
+    unstubAllEnvs = false,
+    unstubAllGlobals = false,
+  } = options;
+
   afterEach(async () => {
     try {
-      await options.cleanup?.();
+      await cleanup?.();
     } finally {
-      if (options.restoreAllMocks ?? true) {
+      if (restoreAllMocks) {
         vi.restoreAllMocks();
       }
-      if (options.unstubAllGlobals) {
+      if (unstubAllGlobals) {
         vi.unstubAllGlobals();
       }
-      if (options.unstubAllEnvs) {
+      if (unstubAllEnvs) {
         vi.unstubAllEnvs();
       }
-      for (const moduleId of options.unmock ?? []) {
+      for (const moduleId of unmock) {
         vi.doUnmock(moduleId);
       }
-      if (options.resetModules ?? true) {
+      if (resetModules) {
         vi.resetModules();
       }
     }

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -1,0 +1,71 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, vi } from 'vitest';
+
+export interface CleanMocksOptions {
+  cleanup?: () => void | Promise<void>;
+  restoreAllMocks?: boolean;
+  resetModules?: boolean;
+  unmock?: string[];
+  unstubAllEnvs?: boolean;
+  unstubAllGlobals?: boolean;
+}
+
+type TempDirFactory = ((prefix?: string) => string) & {
+  track: (dir: string | null | undefined) => void;
+};
+
+function removeTrackedDirs(tempDirs: string[]): void {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (!dir) continue;
+    fs.rmSync(dir, { force: true, recursive: true });
+  }
+}
+
+export function useTempDir(defaultPrefix = 'hybridclaw-test-'): TempDirFactory {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    removeTrackedDirs(tempDirs);
+  });
+
+  const makeTempDir = ((prefix = defaultPrefix) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    tempDirs.push(dir);
+    return dir;
+  }) as TempDirFactory;
+
+  makeTempDir.track = (dir) => {
+    if (!dir) return;
+    tempDirs.push(dir);
+  };
+
+  return makeTempDir;
+}
+
+export function useCleanMocks(options: CleanMocksOptions = {}): void {
+  afterEach(async () => {
+    try {
+      await options.cleanup?.();
+    } finally {
+      if (options.restoreAllMocks ?? true) {
+        vi.restoreAllMocks();
+      }
+      if (options.unstubAllGlobals) {
+        vi.unstubAllGlobals();
+      }
+      if (options.unstubAllEnvs) {
+        vi.unstubAllEnvs();
+      }
+      for (const moduleId of options.unmock ?? []) {
+        vi.doUnmock(moduleId);
+      }
+      if (options.resetModules ?? true) {
+        vi.resetModules();
+      }
+    }
+  });
+}

--- a/tests/unit/claw-archive.test.ts
+++ b/tests/unit/claw-archive.test.ts
@@ -1,17 +1,12 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import * as yazl from 'yazl';
+import { useCleanMocks, useTempDir } from '../test-utils.ts';
 
 const originalCwd = process.cwd();
-const tempDirs: string[] = [];
 
-function makeTempDir(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempDir = useTempDir();
 
 function writeSkillDir(dir: string, skillName: string): void {
   fs.mkdirSync(path.join(dir, 'scripts'), { recursive: true });
@@ -151,24 +146,25 @@ function setZipGeneralPurposeBitFlag(
   fs.writeFileSync(archivePath, buffer);
 }
 
-afterEach(async () => {
-  process.chdir(originalCwd);
-  vi.resetModules();
-  vi.unstubAllEnvs();
-  vi.doUnmock('../../src/agents/claw-security.ts');
-  vi.doUnmock('../../src/agents/claw-security.js');
-  vi.doUnmock('../../src/skills/skills-import.ts');
-  vi.doUnmock('../../src/skills/skills-import.js');
-  vi.doUnmock('../../src/plugins/plugin-manager.ts');
-  vi.doUnmock('../../src/plugins/plugin-manager.js');
-  vi.doUnmock('../../src/plugins/plugin-install.ts');
-  vi.doUnmock('../../src/plugins/plugin-install.js');
-  vi.doUnmock('../../src/infra/ipc.ts');
-  vi.doUnmock('../../src/infra/ipc.js');
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) fs.rmSync(dir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  cleanup: async () => {
+    process.chdir(originalCwd);
+  },
+  restoreAllMocks: false,
+  resetModules: true,
+  unstubAllEnvs: true,
+  unmock: [
+    '../../src/agents/claw-security.ts',
+    '../../src/agents/claw-security.js',
+    '../../src/skills/skills-import.ts',
+    '../../src/skills/skills-import.js',
+    '../../src/plugins/plugin-manager.ts',
+    '../../src/plugins/plugin-manager.js',
+    '../../src/plugins/plugin-install.ts',
+    '../../src/plugins/plugin-install.js',
+    '../../src/infra/ipc.ts',
+    '../../src/infra/ipc.js',
+  ],
 });
 
 beforeEach(() => {

--- a/tests/whatsapp.message-store.test.ts
+++ b/tests/whatsapp.message-store.test.ts
@@ -1,24 +1,8 @@
-import fs from 'node:fs/promises';
-import os from 'node:os';
-import path from 'node:path';
-import { afterEach, expect, test } from 'vitest';
+import { expect, test } from 'vitest';
 import { createWhatsAppMessageStore } from '../src/channels/whatsapp/message-store.js';
+import { useTempDir } from './test-utils.ts';
 
-const tempDirs: string[] = [];
-
-afterEach(async () => {
-  await Promise.all(
-    tempDirs
-      .splice(0)
-      .map((dir) => fs.rm(dir, { recursive: true, force: true })),
-  );
-});
-
-async function createTempAuthDir(): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'hybridclaw-wa-store-'));
-  tempDirs.push(dir);
-  return dir;
-}
+const createTempAuthDir = useTempDir('hybridclaw-wa-store-');
 
 test('replays an exact stored WhatsApp message after reload', async () => {
   const authDir = await createTempAuthDir();

--- a/tests/workspace-bootstrap.test.ts
+++ b/tests/workspace-bootstrap.test.ts
@@ -1,16 +1,11 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const originalCwd = process.cwd();
-const tempDirs: string[] = [];
 
-function makeTempDir(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempDir = useTempDir();
 
 function readWorkspaceState(workspaceDir: string): {
   bootstrapSeededAt?: string;
@@ -35,14 +30,13 @@ function currentLocalDateStamp(): string {
   return `${year}-${month}-${day}`;
 }
 
-afterEach(() => {
-  process.chdir(originalCwd);
-  vi.resetModules();
-  vi.unstubAllEnvs();
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) fs.rmSync(dir, { recursive: true, force: true });
-  }
+useCleanMocks({
+  cleanup: () => {
+    process.chdir(originalCwd);
+  },
+  restoreAllMocks: false,
+  resetModules: true,
+  unstubAllEnvs: true,
 });
 
 describe('workspace bootstrap lifecycle', () => {

--- a/tests/xlsx-skill-node.test.ts
+++ b/tests/xlsx-skill-node.test.ts
@@ -1,19 +1,14 @@
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, expect, test } from 'vitest';
+import { expect, test } from 'vitest';
 import XlsxPopulate from 'xlsx-populate';
+import { useTempDir } from './test-utils.ts';
 
 const repoRoot = process.cwd();
-const tempDirs: string[] = [];
 
-function makeTempDir(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-xlsx-test-'));
-  tempDirs.push(dir);
-  return dir;
-}
+const makeTempDir = useTempDir('hybridclaw-xlsx-test-');
 
 function runNodeScript(args: string[]) {
   const result = spawnSync(process.execPath, args, {
@@ -29,12 +24,6 @@ function runNodeScript(args: string[]) {
 
   return result;
 }
-
-afterEach(() => {
-  while (tempDirs.length > 0) {
-    fs.rmSync(tempDirs.pop() as string, { recursive: true, force: true });
-  }
-});
 
 test('xlsx import script converts delimited input into a formatted workbook', async () => {
   const dir = makeTempDir();


### PR DESCRIPTION
## What changed

- added `tests/test-utils.ts` with shared `useTempDir()` and `useCleanMocks()` helpers for Vitest temp-directory lifecycle and common mock/module cleanup
- migrated the repeated temp-dir boilerplate out of 46 test files to those shared helpers
- normalized the affected tests so cleanup behavior is centralized instead of being reimplemented per file

## Why

Nearly every affected test file copied the same `tempDirs` tracking, `mkdtempSync` helper, and `afterEach` cleanup logic. A smaller set also repeated the same `vi.restoreAllMocks()` / `vi.doUnmock(...)` / module-reset pattern.

That duplication made the suite harder to maintain and raised the risk of tests drifting into slightly different cleanup semantics over time.

## Impact

- test setup is shorter and more consistent across the suite
- future cleanup changes only need to be made in one helper module
- no runtime code paths changed; this PR is limited to test infrastructure and test-file refactors

## Root cause

The test suite grew incrementally without a shared utility for temp workspace lifecycle or common Vitest cleanup, so the same pattern was copied into many files.

## Validation

- `npm run lint`
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts $(git diff --name-only --diff-filter=ACM | rg '^tests/.*\.test\.ts$')`
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/discord.attachments.test.ts tests/msteams.attachments.test.ts tests/gateway-http-server.test.ts tests/gateway-service.audio-transcription.test.ts tests/workspace-bootstrap.test.ts tests/email.connection.test.ts`
