### PR TITLE
[codex] Add doctor-driven resource hygiene maintenance

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -490,6 +490,29 @@
   "scheduler": {
     "jobs": [
       {
+        "id": "resource-hygiene",
+        "name": "Resource Hygiene",
+        "description": "Runs conservative doctor-based resource hygiene twice daily and auto-applies only safe cleanup.",
+        "schedule": {
+          "kind": "every",
+          "at": null,
+          "everyMs": 43200000,
+          "expr": null,
+          "tz": "UTC"
+        },
+        "action": {
+          "kind": "system_event",
+          "message": "resource_hygiene_maintenance"
+        },
+        "delivery": {
+          "kind": "last-channel",
+          "channel": "",
+          "to": "",
+          "webhookUrl": ""
+        },
+        "enabled": true
+      },
+      {
         "id": "morning-standup",
         "name": "Daily Standup Report",
         "description": "Runs standup summary every weekday at 9am.",

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -43,6 +43,7 @@ import {
   isRuntimeProviderId,
   type RuntimeProviderId,
 } from '../providers/provider-ids.js';
+import { DEFAULT_RESOURCE_HYGIENE_SCHEDULER_JOB } from '../scheduler/system-jobs.js';
 import {
   isSecretRefInput,
   parseSecretInput,
@@ -80,7 +81,6 @@ import {
   runtimeConfigRevisionStorePath,
   syncRuntimeConfigRevisionState,
 } from './runtime-config-revisions.js';
-
 import { DEFAULT_RUNTIME_HOME_DIR } from './runtime-paths.js';
 
 export const CONFIG_FILE_NAME = 'config.json';
@@ -1270,7 +1270,7 @@ const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
     },
   },
   scheduler: {
-    jobs: [],
+    jobs: [DEFAULT_RESOURCE_HYGIENE_SCHEDULER_JOB],
   },
 };
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -3,14 +3,13 @@ import { doctorChecks } from './doctor/checks/index.js';
 import type {
   DiagResult,
   DoctorArgs,
-  DoctorCheck,
   DoctorFixOutcome,
   DoctorReport,
 } from './doctor/types.js';
 import {
-  makeResult,
   normalizeComponent,
   normalizeDoctorComponentList,
+  runChecks,
   summarizeCounts,
   toErrorMessage,
 } from './doctor/utils.js';
@@ -57,31 +56,6 @@ function parseDoctorArgs(args: string[]): DoctorArgs {
   }
 
   return { component, fix, json };
-}
-
-async function runChecks(checks: DoctorCheck[]): Promise<DiagResult[]> {
-  const settled = await Promise.allSettled(checks.map((check) => check.run()));
-  const results: DiagResult[] = [];
-
-  settled.forEach((result, index) => {
-    const check = checks[index];
-    if (result.status === 'fulfilled') {
-      results.push(...result.value);
-      return;
-    }
-
-    const message = toErrorMessage(result.reason);
-    results.push(
-      makeResult(
-        check.category,
-        check.label,
-        'error',
-        `Diagnostic failed: ${message}`,
-      ),
-    );
-  });
-
-  return results;
 }
 
 function shouldPromptForFixes(args: DoctorArgs): boolean {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -96,9 +96,12 @@ async function confirmFix(
   rl: readline.Interface,
   result: DiagResult,
 ): Promise<boolean> {
+  const requiresApprovalSuffix = result.fix?.requiresApproval
+    ? ' (approval required)'
+    : '';
   const prompt = result.fix?.summary
-    ? `Apply fix for ${result.label}? ${result.fix.summary} [y/N] `
-    : `Apply fix for ${result.label}? [y/N] `;
+    ? `Apply fix for ${result.label}${requiresApprovalSuffix}? ${result.fix.summary} [y/N] `
+    : `Apply fix for ${result.label}${requiresApprovalSuffix}? [y/N] `;
   const answer = (await rl.question(prompt)).trim().toLowerCase();
   return answer === 'y' || answer === 'yes';
 }
@@ -126,6 +129,16 @@ async function applyFixes(
     for (let index = 0; index < results.length; index += 1) {
       const result = results[index];
       if (!result.fix || result.severity === 'ok') continue;
+
+      if (!rl && result.fix.requiresApproval) {
+        outcomes.push({
+          category: result.category,
+          label: result.label,
+          status: 'skipped',
+          message: 'Skipped because interactive approval is required',
+        });
+        continue;
+      }
 
       if (rl && !(await confirmFix(rl, result))) {
         outcomes.push({

--- a/src/doctor/checks/index.ts
+++ b/src/doctor/checks/index.ts
@@ -8,6 +8,7 @@ import { checkDocker } from './docker.js';
 import { checkGateway } from './gateway.js';
 import { checkLocalBackendsCategory } from './local-backends.js';
 import { checkProviders } from './providers.js';
+import { resourceHygieneDoctorChecks } from './resource-hygiene.js';
 import { checkRuntime } from './runtime.js';
 import { checkSecurity } from './security.js';
 import { checkSkills } from './skills.js';
@@ -74,5 +75,6 @@ export function doctorChecks(): DoctorCheck[] {
       label: 'Disk',
       run: checkDisk,
     },
+    ...resourceHygieneDoctorChecks(),
   ];
 }

--- a/src/doctor/checks/resource-hygiene.ts
+++ b/src/doctor/checks/resource-hygiene.ts
@@ -1,0 +1,799 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import {
+  listAgents,
+  resolveAgentForRequest,
+  resolveAgentWorkspaceId,
+} from '../../agents/agent-registry.js';
+import {
+  DATA_DIR,
+  DB_PATH,
+  SESSION_COMPACTION_ENABLED,
+  SESSION_COMPACTION_THRESHOLD,
+} from '../../config/config.js';
+import { maybeCompactSession } from '../../session/session-maintenance.js';
+import type { DiagFix, DiagResult, DoctorCheck } from '../types.js';
+import {
+  formatBytes,
+  formatDuration,
+  makeResult,
+  readDirSize,
+  readDiskFreeBytes,
+  shortenHomePath,
+  toErrorMessage,
+} from '../utils.js';
+
+const AGENTS_DIR_NAME = 'agents';
+const EVALS_DIR_NAME = 'evals';
+const SESSION_EXPORTS_DIR_NAME = '.session-exports';
+const TRACE_EXPORTS_DIR_NAME = '.trace-exports';
+const WORKSPACE_DIR_NAME = 'workspace';
+const PROMPT_DUMP_FILE_NAME = 'last_prompt.jsonl';
+const CRITICAL_FREE_SPACE_BYTES = 100 * 1024 * 1024;
+const STALE_WORKSPACE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const TEMP_MEDIA_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const RUN_LOG_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const ORPHANED_EXPORT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const PROMPT_DUMP_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const SESSION_COMPACTION_IDLE_MAX_AGE_MS = 6 * 60 * 60 * 1000;
+const MANAGED_TEMP_MEDIA_DIR_PREFIXES = ['hybridclaw-wa-', 'hybridclaw-slack-'];
+
+interface CleanupCandidate {
+  path: string;
+  displayPath: string;
+  sizeBytes: number;
+  ageMs: number;
+}
+
+interface WorkspaceCandidate extends CleanupCandidate {
+  workspaceId: string;
+  gitBacked: boolean;
+}
+
+interface SessionSnapshot {
+  id: string;
+  agentId: string;
+  channelId: string;
+  chatbotId: string | null;
+  model: string | null;
+  enableRag: boolean;
+  messageCount: number;
+  lastActive: string;
+  lastActiveMs: number | null;
+}
+
+interface SessionDatabaseSnapshot {
+  currentSessions: SessionSnapshot[];
+  allSessionKeys: Set<string>;
+}
+
+function safeFilePart(raw: string): string {
+  const normalized = raw.trim().replace(/[^a-zA-Z0-9_-]/g, '_');
+  return normalized || 'session';
+}
+
+function formatAge(ageMs: number): string {
+  return formatDuration(ageMs / 1000);
+}
+
+function sumCandidateBytes(candidates: CleanupCandidate[]): number {
+  return candidates.reduce((sum, candidate) => sum + candidate.sizeBytes, 0);
+}
+
+function maxCandidateAgeMs(candidates: CleanupCandidate[]): number {
+  return candidates.reduce(
+    (max, candidate) => Math.max(max, candidate.ageMs),
+    0,
+  );
+}
+
+function removeCleanupPath(targetPath: string): void {
+  const stat = fs.lstatSync(targetPath);
+  if (stat.isSymbolicLink()) {
+    fs.unlinkSync(targetPath);
+    return;
+  }
+  fs.rmSync(targetPath, { recursive: true, force: true });
+}
+
+function buildCleanupFix(params: {
+  summary: string;
+  candidates: CleanupCandidate[];
+  requiresApproval?: boolean;
+}): DiagFix {
+  return {
+    summary: params.summary,
+    requiresApproval: params.requiresApproval === true,
+    apply: async () => {
+      for (const candidate of params.candidates) {
+        if (!fs.existsSync(candidate.path)) continue;
+        removeCleanupPath(candidate.path);
+      }
+    },
+  };
+}
+
+function readCriticalDiskState(): {
+  freeBytes: number | null;
+  critical: boolean;
+} {
+  const freeBytes = readDiskFreeBytes(DATA_DIR);
+  return {
+    freeBytes,
+    critical: freeBytes != null && freeBytes < CRITICAL_FREE_SPACE_BYTES,
+  };
+}
+
+function openReadonlyDatabase(): Database.Database {
+  return new Database(DB_PATH, {
+    readonly: true,
+    fileMustExist: true,
+  });
+}
+
+function databaseHasColumn(
+  db: Database.Database,
+  tableName: string,
+  columnName: string,
+): boolean {
+  const rows = db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{
+    name?: string;
+  }>;
+  return rows.some((row) => row.name === columnName);
+}
+
+function loadSessionSnapshotFromDatabase(): SessionDatabaseSnapshot {
+  const db = openReadonlyDatabase();
+  try {
+    const currentSessionSql = databaseHasColumn(db, 'sessions', 'is_current')
+      ? `SELECT id, agent_id, channel_id, chatbot_id, model, enable_rag, message_count, last_active
+           FROM sessions
+          WHERE is_current = 1`
+      : `SELECT id, agent_id, channel_id, chatbot_id, model, enable_rag, message_count, last_active
+           FROM sessions`;
+    const currentSessionRows = db.prepare(currentSessionSql).all() as Array<{
+      id: string;
+      agent_id: string;
+      channel_id: string;
+      chatbot_id: string | null;
+      model: string | null;
+      enable_rag: number;
+      message_count: number;
+      last_active: string;
+    }>;
+    const allSessionRows = db
+      .prepare('SELECT id FROM sessions')
+      .all() as Array<{ id: string }>;
+
+    return {
+      currentSessions: currentSessionRows.map((row) => {
+        const lastActiveMs = Date.parse(row.last_active);
+        return {
+          id: row.id,
+          agentId: row.agent_id,
+          channelId: row.channel_id,
+          chatbotId: row.chatbot_id,
+          model: row.model,
+          enableRag: Number(row.enable_rag || 0) > 0,
+          messageCount: Math.max(0, Math.floor(row.message_count || 0)),
+          lastActive: row.last_active,
+          lastActiveMs: Number.isFinite(lastActiveMs) ? lastActiveMs : null,
+        };
+      }),
+      allSessionKeys: new Set(
+        allSessionRows.map((row) => safeFilePart(String(row.id || ''))),
+      ),
+    };
+  } finally {
+    db.close();
+  }
+}
+
+function readDirEntries(dirPath: string): fs.Dirent[] {
+  try {
+    return fs.readdirSync(dirPath, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+function listManagedTempMediaCandidates(
+  nowMs = Date.now(),
+): CleanupCandidate[] {
+  const rootDir = os.tmpdir();
+  const candidates: CleanupCandidate[] = [];
+
+  for (const entry of readDirEntries(rootDir)) {
+    if (
+      !MANAGED_TEMP_MEDIA_DIR_PREFIXES.some((prefix) =>
+        entry.name.startsWith(prefix),
+      )
+    ) {
+      continue;
+    }
+
+    const entryPath = path.join(rootDir, entry.name);
+    let stat: fs.Stats;
+    try {
+      stat = fs.lstatSync(entryPath);
+    } catch {
+      continue;
+    }
+
+    const ageMs = Math.max(0, nowMs - stat.mtimeMs);
+    if (ageMs < TEMP_MEDIA_MAX_AGE_MS) continue;
+    const sizeBytes = stat.isDirectory() ? readDirSize(entryPath) : stat.size;
+    candidates.push({
+      path: entryPath,
+      displayPath: shortenHomePath(entryPath),
+      sizeBytes,
+      ageMs,
+    });
+  }
+
+  return candidates;
+}
+
+function listFinishedEvalRunCandidates(nowMs = Date.now()): CleanupCandidate[] {
+  const baseDir = path.join(DATA_DIR, EVALS_DIR_NAME);
+  const candidates: CleanupCandidate[] = [];
+
+  for (const entry of readDirEntries(baseDir)) {
+    if (!entry.isDirectory()) continue;
+    const runDir = path.join(baseDir, entry.name);
+    const metaPath = path.join(runDir, 'run.json');
+    if (!fs.existsSync(metaPath)) continue;
+
+    let finishedAtMs: number | null = null;
+    try {
+      const raw = fs.readFileSync(metaPath, 'utf-8');
+      const parsed = JSON.parse(raw) as { finishedAt?: string | null };
+      const finishedAt = String(parsed.finishedAt || '').trim();
+      if (finishedAt) {
+        const parsedMs = Date.parse(finishedAt);
+        finishedAtMs = Number.isFinite(parsedMs) ? parsedMs : null;
+      }
+    } catch {
+      continue;
+    }
+    if (finishedAtMs == null) continue;
+
+    const ageMs = Math.max(0, nowMs - finishedAtMs);
+    if (ageMs < RUN_LOG_MAX_AGE_MS) continue;
+    candidates.push({
+      path: runDir,
+      displayPath: shortenHomePath(runDir),
+      sizeBytes: readDirSize(runDir),
+      ageMs,
+    });
+  }
+
+  return candidates;
+}
+
+function listPotentialStaleWorkspaceCandidates(
+  configuredWorkspaceIds: Set<string>,
+  nowMs = Date.now(),
+): WorkspaceCandidate[] {
+  const agentsRoot = path.join(DATA_DIR, AGENTS_DIR_NAME);
+  const candidates: WorkspaceCandidate[] = [];
+
+  for (const entry of readDirEntries(agentsRoot)) {
+    if (!entry.isDirectory()) continue;
+    if (configuredWorkspaceIds.has(entry.name)) continue;
+
+    const rootPath = path.join(agentsRoot, entry.name);
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(rootPath);
+    } catch {
+      continue;
+    }
+    const ageMs = Math.max(0, nowMs - stat.mtimeMs);
+    if (ageMs < STALE_WORKSPACE_MAX_AGE_MS) continue;
+
+    const workspacePath = path.join(rootPath, WORKSPACE_DIR_NAME);
+    candidates.push({
+      path: rootPath,
+      displayPath: shortenHomePath(rootPath),
+      sizeBytes: readDirSize(rootPath),
+      ageMs,
+      workspaceId: entry.name,
+      gitBacked: fs.existsSync(path.join(workspacePath, '.git')),
+    });
+  }
+
+  return candidates;
+}
+
+function listPotentialOrphanedExportCandidates(
+  nowMs = Date.now(),
+): CleanupCandidate[] {
+  const agentsRoot = path.join(DATA_DIR, AGENTS_DIR_NAME);
+  const candidates: CleanupCandidate[] = [];
+
+  for (const entry of readDirEntries(agentsRoot)) {
+    if (!entry.isDirectory()) continue;
+    const workspacePath = path.join(agentsRoot, entry.name, WORKSPACE_DIR_NAME);
+    for (const exportDirName of [
+      SESSION_EXPORTS_DIR_NAME,
+      TRACE_EXPORTS_DIR_NAME,
+    ]) {
+      const exportRoot = path.join(workspacePath, exportDirName);
+      for (const exportEntry of readDirEntries(exportRoot)) {
+        if (!exportEntry.isDirectory()) continue;
+        const exportPath = path.join(exportRoot, exportEntry.name);
+        let stat: fs.Stats;
+        try {
+          stat = fs.statSync(exportPath);
+        } catch {
+          continue;
+        }
+        const ageMs = Math.max(0, nowMs - stat.mtimeMs);
+        if (ageMs < ORPHANED_EXPORT_MAX_AGE_MS) continue;
+        candidates.push({
+          path: exportPath,
+          displayPath: shortenHomePath(exportPath),
+          sizeBytes: readDirSize(exportPath),
+          ageMs,
+        });
+      }
+    }
+  }
+
+  return candidates;
+}
+
+function readPromptDumpCandidate(nowMs = Date.now()): CleanupCandidate | null {
+  const promptDumpPath = path.join(DATA_DIR, PROMPT_DUMP_FILE_NAME);
+  if (!fs.existsSync(promptDumpPath)) return null;
+
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(promptDumpPath);
+  } catch {
+    return null;
+  }
+
+  const ageMs = Math.max(0, nowMs - stat.mtimeMs);
+  if (ageMs < PROMPT_DUMP_MAX_AGE_MS) return null;
+  return {
+    path: promptDumpPath,
+    displayPath: shortenHomePath(promptDumpPath),
+    sizeBytes: stat.size,
+    ageMs,
+  };
+}
+
+function formatCleanupMessage(params: {
+  count: number;
+  totalBytes: number;
+  oldestAgeMs: number;
+  freeBytes?: number | null;
+  note: string;
+}): string {
+  const parts = [
+    `${params.count} item${params.count === 1 ? '' : 's'}`,
+    `${formatBytes(params.totalBytes)} reclaimable`,
+    `oldest ${formatAge(params.oldestAgeMs)}`,
+    params.note,
+  ];
+  if (params.freeBytes != null) {
+    parts.push(`${formatBytes(params.freeBytes)} free`);
+  }
+  return parts.join(', ');
+}
+
+export async function checkStaleWorkspaces(): Promise<DiagResult[]> {
+  const configuredWorkspaceIds = new Set(
+    listAgents().map((agent) =>
+      safeFilePart(resolveAgentWorkspaceId(agent.id)),
+    ),
+  );
+  const potentialCandidates = listPotentialStaleWorkspaceCandidates(
+    configuredWorkspaceIds,
+  );
+
+  if (potentialCandidates.length === 0) {
+    return [
+      makeResult(
+        'disk',
+        'Stale workspaces',
+        'ok',
+        `No orphaned workspace directories older than ${formatAge(STALE_WORKSPACE_MAX_AGE_MS)}`,
+      ),
+    ];
+  }
+
+  let snapshot: SessionDatabaseSnapshot;
+  try {
+    snapshot = loadSessionSnapshotFromDatabase();
+  } catch (error) {
+    return [
+      makeResult(
+        'disk',
+        'Stale workspaces',
+        'error',
+        `Cannot verify orphaned workspaces without ${shortenHomePath(DB_PATH)} (${toErrorMessage(error)})`,
+      ),
+    ];
+  }
+
+  const activeWorkspaceIds = new Set(
+    snapshot.currentSessions.map((session) =>
+      safeFilePart(resolveAgentWorkspaceId(session.agentId)),
+    ),
+  );
+  const staleCandidates = potentialCandidates.filter(
+    (candidate) => !activeWorkspaceIds.has(candidate.workspaceId),
+  );
+
+  if (staleCandidates.length === 0) {
+    return [
+      makeResult(
+        'disk',
+        'Stale workspaces',
+        'ok',
+        'No orphaned workspace directories outside configured agents and active sessions',
+      ),
+    ];
+  }
+
+  const { freeBytes, critical } = readCriticalDiskState();
+  const safeCandidates = staleCandidates.filter(
+    (candidate) => !candidate.gitBacked,
+  );
+  const riskyCandidates = staleCandidates.filter(
+    (candidate) => candidate.gitBacked,
+  );
+  const results: DiagResult[] = [];
+
+  if (safeCandidates.length > 0) {
+    results.push(
+      makeResult(
+        'disk',
+        'Stale workspaces',
+        critical ? 'error' : 'warn',
+        formatCleanupMessage({
+          count: safeCandidates.length,
+          totalBytes: sumCandidateBytes(safeCandidates),
+          oldestAgeMs: maxCandidateAgeMs(safeCandidates),
+          freeBytes,
+          note: 'orphaned workspace directories are outside configured agents and active sessions',
+        }),
+        buildCleanupFix({
+          summary: `Remove ${safeCandidates.length} orphaned workspace director${safeCandidates.length === 1 ? 'y' : 'ies'}`,
+          candidates: safeCandidates,
+          requiresApproval: critical,
+        }),
+      ),
+    );
+  }
+
+  if (riskyCandidates.length > 0) {
+    results.push(
+      makeResult(
+        'disk',
+        'Git-backed stale workspaces',
+        'error',
+        formatCleanupMessage({
+          count: riskyCandidates.length,
+          totalBytes: sumCandidateBytes(riskyCandidates),
+          oldestAgeMs: maxCandidateAgeMs(riskyCandidates),
+          freeBytes,
+          note: 'orphaned workspace directories contain .git and require approval',
+        }),
+        buildCleanupFix({
+          summary: `Remove ${riskyCandidates.length} git-backed orphaned workspace director${riskyCandidates.length === 1 ? 'y' : 'ies'}`,
+          candidates: riskyCandidates,
+          requiresApproval: true,
+        }),
+      ),
+    );
+  }
+
+  return results;
+}
+
+export async function checkOldTempMedia(): Promise<DiagResult[]> {
+  const candidates = listManagedTempMediaCandidates();
+  if (candidates.length === 0) {
+    return [
+      makeResult(
+        'disk',
+        'Old temp media',
+        'ok',
+        `No managed temp media older than ${formatAge(TEMP_MEDIA_MAX_AGE_MS)}`,
+      ),
+    ];
+  }
+
+  const { freeBytes, critical } = readCriticalDiskState();
+  return [
+    makeResult(
+      'disk',
+      'Old temp media',
+      critical ? 'error' : 'warn',
+      formatCleanupMessage({
+        count: candidates.length,
+        totalBytes: sumCandidateBytes(candidates),
+        oldestAgeMs: maxCandidateAgeMs(candidates),
+        freeBytes,
+        note: 'managed temp media directories are safe to prune',
+      }),
+      buildCleanupFix({
+        summary: `Delete ${candidates.length} managed temp media entr${candidates.length === 1 ? 'y' : 'ies'}`,
+        candidates,
+        requiresApproval: critical,
+      }),
+    ),
+  ];
+}
+
+export async function checkOldRunLogs(): Promise<DiagResult[]> {
+  const candidates = listFinishedEvalRunCandidates();
+  if (candidates.length === 0) {
+    return [
+      makeResult(
+        'disk',
+        'Old run logs',
+        'ok',
+        `No finished run logs older than ${formatAge(RUN_LOG_MAX_AGE_MS)}`,
+      ),
+    ];
+  }
+
+  const { freeBytes, critical } = readCriticalDiskState();
+  return [
+    makeResult(
+      'disk',
+      'Old run logs',
+      critical ? 'error' : 'warn',
+      formatCleanupMessage({
+        count: candidates.length,
+        totalBytes: sumCandidateBytes(candidates),
+        oldestAgeMs: maxCandidateAgeMs(candidates),
+        freeBytes,
+        note: 'finished eval run directories are safe to prune',
+      }),
+      buildCleanupFix({
+        summary: `Prune ${candidates.length} finished run log director${candidates.length === 1 ? 'y' : 'ies'}`,
+        candidates,
+        requiresApproval: critical,
+      }),
+    ),
+  ];
+}
+
+export async function checkSessionCompactionBacklog(): Promise<DiagResult[]> {
+  if (!SESSION_COMPACTION_ENABLED) {
+    return [
+      makeResult(
+        'database',
+        'Session compaction backlog',
+        'ok',
+        'Automatic session compaction is disabled in runtime config',
+      ),
+    ];
+  }
+
+  let snapshot: SessionDatabaseSnapshot;
+  try {
+    snapshot = loadSessionSnapshotFromDatabase();
+  } catch (error) {
+    return [
+      makeResult(
+        'database',
+        'Session compaction backlog',
+        'error',
+        `Cannot inspect session backlog without ${shortenHomePath(DB_PATH)} (${toErrorMessage(error)})`,
+      ),
+    ];
+  }
+
+  const nowMs = Date.now();
+  const threshold = Math.max(SESSION_COMPACTION_THRESHOLD, 20);
+  const backlog = snapshot.currentSessions
+    .filter(
+      (session) =>
+        session.messageCount >= threshold &&
+        session.lastActiveMs != null &&
+        nowMs - session.lastActiveMs >= SESSION_COMPACTION_IDLE_MAX_AGE_MS,
+    )
+    .sort((left, right) => right.messageCount - left.messageCount);
+
+  if (backlog.length === 0) {
+    return [
+      makeResult(
+        'database',
+        'Session compaction backlog',
+        'ok',
+        `No idle sessions exceed the ${threshold}-message compaction threshold`,
+      ),
+    ];
+  }
+
+  const { freeBytes, critical } = readCriticalDiskState();
+  return [
+    makeResult(
+      'database',
+      'Session compaction backlog',
+      critical ? 'error' : 'warn',
+      [
+        `${backlog.length} idle session${backlog.length === 1 ? '' : 's'} exceed the ${threshold}-message threshold`,
+        `largest ${backlog[0]?.messageCount ?? threshold} messages`,
+        backlog[0]?.lastActive
+          ? `oldest activity ${backlog[0].lastActive}`
+          : null,
+        freeBytes != null ? `${formatBytes(freeBytes)} free` : null,
+      ]
+        .filter((part): part is string => Boolean(part))
+        .join(', '),
+      {
+        summary: `Compact ${backlog.length} oversized idle session${backlog.length === 1 ? '' : 's'}`,
+        requiresApproval: critical,
+        apply: async () => {
+          for (const session of backlog) {
+            const resolved = resolveAgentForRequest({
+              agentId: session.agentId,
+              model: session.model,
+              chatbotId: session.chatbotId,
+            });
+            await maybeCompactSession({
+              sessionId: session.id,
+              agentId: resolved.agentId,
+              chatbotId: resolved.chatbotId,
+              enableRag: session.enableRag,
+              model: resolved.model,
+              channelId: session.channelId || 'scheduler',
+            });
+          }
+        },
+      },
+    ),
+  ];
+}
+
+export async function checkOrphanedExportsAndPromptDumps(): Promise<
+  DiagResult[]
+> {
+  const results: DiagResult[] = [];
+  const exportCandidates = listPotentialOrphanedExportCandidates();
+  const promptDumpCandidate = readPromptDumpCandidate();
+
+  if (exportCandidates.length > 0) {
+    let snapshot: SessionDatabaseSnapshot;
+    let snapshotLoaded = true;
+    try {
+      snapshot = loadSessionSnapshotFromDatabase();
+    } catch (error) {
+      snapshotLoaded = false;
+      results.push(
+        makeResult(
+          'disk',
+          'Orphaned exports',
+          'error',
+          `Cannot verify export ownership without ${shortenHomePath(DB_PATH)} (${toErrorMessage(error)})`,
+        ),
+      );
+      snapshot = {
+        currentSessions: [],
+        allSessionKeys: new Set<string>(),
+      };
+    }
+
+    if (snapshotLoaded) {
+      const orphanedExports = exportCandidates.filter((candidate) => {
+        const sessionDirName = path.basename(candidate.path);
+        return !snapshot.allSessionKeys.has(sessionDirName);
+      });
+
+      if (orphanedExports.length > 0) {
+        const { freeBytes, critical } = readCriticalDiskState();
+        results.push(
+          makeResult(
+            'disk',
+            'Orphaned exports',
+            critical ? 'error' : 'warn',
+            formatCleanupMessage({
+              count: orphanedExports.length,
+              totalBytes: sumCandidateBytes(orphanedExports),
+              oldestAgeMs: maxCandidateAgeMs(orphanedExports),
+              freeBytes,
+              note: 'session export directories no longer match any stored session',
+            }),
+            buildCleanupFix({
+              summary: `Remove ${orphanedExports.length} orphaned export director${orphanedExports.length === 1 ? 'y' : 'ies'}`,
+              candidates: orphanedExports,
+              requiresApproval: critical,
+            }),
+          ),
+        );
+      } else {
+        results.push(
+          makeResult(
+            'disk',
+            'Orphaned exports',
+            'ok',
+            'No orphaned session exports older than 7d',
+          ),
+        );
+      }
+    }
+  } else {
+    results.push(
+      makeResult(
+        'disk',
+        'Orphaned exports',
+        'ok',
+        'No orphaned session exports older than 7d',
+      ),
+    );
+  }
+
+  if (promptDumpCandidate) {
+    const { freeBytes, critical } = readCriticalDiskState();
+    results.push(
+      makeResult(
+        'disk',
+        'Prompt dump',
+        critical ? 'error' : 'warn',
+        [
+          `${promptDumpCandidate.displayPath} is older than ${formatAge(PROMPT_DUMP_MAX_AGE_MS)}`,
+          `${formatBytes(promptDumpCandidate.sizeBytes)} reclaimable`,
+          freeBytes != null ? `${formatBytes(freeBytes)} free` : null,
+        ]
+          .filter((part): part is string => Boolean(part))
+          .join(', '),
+        buildCleanupFix({
+          summary: `Remove stale prompt dump at ${promptDumpCandidate.displayPath}`,
+          candidates: [promptDumpCandidate],
+          requiresApproval: critical,
+        }),
+      ),
+    );
+  } else {
+    results.push(
+      makeResult(
+        'disk',
+        'Prompt dump',
+        'ok',
+        `No prompt dump older than ${formatAge(PROMPT_DUMP_MAX_AGE_MS)}`,
+      ),
+    );
+  }
+
+  return results;
+}
+
+export function resourceHygieneDoctorChecks(): DoctorCheck[] {
+  return [
+    {
+      category: 'disk',
+      label: 'Stale workspaces',
+      run: checkStaleWorkspaces,
+    },
+    {
+      category: 'disk',
+      label: 'Old temp media',
+      run: checkOldTempMedia,
+    },
+    {
+      category: 'disk',
+      label: 'Old run logs',
+      run: checkOldRunLogs,
+    },
+    {
+      category: 'database',
+      label: 'Session compaction backlog',
+      run: checkSessionCompactionBacklog,
+    },
+    {
+      category: 'disk',
+      label: 'Orphaned exports / prompt dumps',
+      run: checkOrphanedExportsAndPromptDumps,
+    },
+  ];
+}

--- a/src/doctor/checks/resource-hygiene.ts
+++ b/src/doctor/checks/resource-hygiene.ts
@@ -615,6 +615,21 @@ export async function checkSessionCompactionBacklog(): Promise<DiagResult[]> {
     ];
   }
 
+  const oldestBacklogSession = backlog.reduce<SessionSnapshot | null>(
+    (oldest, session) => {
+      if (session.lastActiveMs == null) return oldest;
+      if (
+        oldest == null ||
+        oldest.lastActiveMs == null ||
+        session.lastActiveMs < oldest.lastActiveMs
+      ) {
+        return session;
+      }
+      return oldest;
+    },
+    null,
+  );
+
   const { freeBytes, critical } = readCriticalDiskState();
   return [
     makeResult(
@@ -624,8 +639,8 @@ export async function checkSessionCompactionBacklog(): Promise<DiagResult[]> {
       [
         `${backlog.length} idle session${backlog.length === 1 ? '' : 's'} exceed the ${threshold}-message threshold`,
         `largest ${backlog[0]?.messageCount ?? threshold} messages`,
-        backlog[0]?.lastActive
-          ? `oldest activity ${backlog[0].lastActive}`
+        oldestBacklogSession?.lastActive
+          ? `oldest activity ${oldestBacklogSession.lastActive}`
           : null,
         freeBytes != null ? `${formatBytes(freeBytes)} free` : null,
       ]
@@ -717,7 +732,7 @@ export async function checkOrphanedExportsAndPromptDumps(): Promise<
             'disk',
             'Orphaned exports',
             'ok',
-            'No orphaned session exports older than 7d',
+            `No orphaned session exports older than ${formatAge(ORPHANED_EXPORT_MAX_AGE_MS)}`,
           ),
         );
       }
@@ -728,7 +743,7 @@ export async function checkOrphanedExportsAndPromptDumps(): Promise<
         'disk',
         'Orphaned exports',
         'ok',
-        'No orphaned session exports older than 7d',
+        `No orphaned session exports older than ${formatAge(ORPHANED_EXPORT_MAX_AGE_MS)}`,
       ),
     );
   }

--- a/src/doctor/checks/resource-hygiene.ts
+++ b/src/doctor/checks/resource-hygiene.ts
@@ -13,6 +13,7 @@ import {
   SESSION_COMPACTION_ENABLED,
   SESSION_COMPACTION_THRESHOLD,
 } from '../../config/config.js';
+import { deleteSessionData } from '../../memory/db.js';
 import { maybeCompactSession } from '../../session/session-maintenance.js';
 import type { DiagFix, DiagResult, DoctorCheck } from '../types.js';
 import {
@@ -39,6 +40,7 @@ const RUN_LOG_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 const ORPHANED_EXPORT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 const PROMPT_DUMP_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 const SESSION_COMPACTION_IDLE_MAX_AGE_MS = 6 * 60 * 60 * 1000;
+const EMPTY_SESSION_MAX_AGE_MS = 48 * 60 * 60 * 1000;
 const MANAGED_TEMP_MEDIA_DIR_PREFIXES = ['hybridclaw-wa-', 'hybridclaw-slack-'];
 
 interface CleanupCandidate {
@@ -65,9 +67,16 @@ interface SessionSnapshot {
   lastActiveMs: number | null;
 }
 
+interface EmptySessionSnapshot {
+  id: string;
+  lastActive: string;
+  lastActiveMs: number | null;
+}
+
 interface SessionDatabaseSnapshot {
   currentSessions: SessionSnapshot[];
   allSessionKeys: Set<string>;
+  emptySessions: EmptySessionSnapshot[];
 }
 
 interface ExportCandidateShell {
@@ -201,6 +210,14 @@ function loadSessionSnapshotFromDatabase(): SessionDatabaseSnapshot {
       .prepare('SELECT id FROM sessions')
       .all() as Array<{ id: string }>;
 
+    const emptySessionRows = db
+      .prepare(
+        `SELECT id, last_active
+           FROM sessions
+          WHERE COALESCE(message_count, 0) = 0`,
+      )
+      .all() as Array<{ id: string; last_active: string }>;
+
     return {
       currentSessions: currentSessionRows.map((row) => {
         const lastActiveMs = Date.parse(row.last_active);
@@ -219,6 +236,14 @@ function loadSessionSnapshotFromDatabase(): SessionDatabaseSnapshot {
       allSessionKeys: new Set(
         allSessionRows.map((row) => safeFilePart(String(row.id || ''))),
       ),
+      emptySessions: emptySessionRows.map((row) => {
+        const lastActiveMs = Date.parse(row.last_active);
+        return {
+          id: row.id,
+          lastActive: row.last_active,
+          lastActiveMs: Number.isFinite(lastActiveMs) ? lastActiveMs : null,
+        };
+      }),
     };
   } finally {
     db.close();
@@ -840,6 +865,82 @@ export async function checkStalePromptDump(
   ];
 }
 
+export async function checkEmptySessions(
+  ctx: HygieneRunContext = new HygieneRunContext(),
+): Promise<DiagResult[]> {
+  let snapshot: SessionDatabaseSnapshot;
+  try {
+    snapshot = ctx.getSnapshot();
+  } catch (error) {
+    return [
+      makeResult(
+        'database',
+        'Empty sessions',
+        'error',
+        `Cannot inspect sessions without ${shortenHomePath(DB_PATH)} (${toErrorMessage(error)})`,
+      ),
+    ];
+  }
+
+  const nowMs = Date.now();
+  const stale = snapshot.emptySessions.filter(
+    (session) =>
+      session.lastActiveMs != null &&
+      nowMs - session.lastActiveMs >= EMPTY_SESSION_MAX_AGE_MS,
+  );
+
+  if (stale.length === 0) {
+    return [
+      makeResult(
+        'database',
+        'Empty sessions',
+        'ok',
+        `No empty sessions older than ${formatAge(EMPTY_SESSION_MAX_AGE_MS)}`,
+      ),
+    ];
+  }
+
+  const oldestSession = stale.reduce<EmptySessionSnapshot | null>(
+    (oldest, session) => {
+      if (session.lastActiveMs == null) return oldest;
+      if (
+        oldest == null ||
+        oldest.lastActiveMs == null ||
+        session.lastActiveMs < oldest.lastActiveMs
+      ) {
+        return session;
+      }
+      return oldest;
+    },
+    null,
+  );
+
+  return [
+    makeResult(
+      'database',
+      'Empty sessions',
+      'warn',
+      [
+        `${stale.length} ${pluralize(stale.length, 'session has', 'sessions have')} zero messages and ${pluralize(stale.length, 'is', 'are')} older than ${formatAge(EMPTY_SESSION_MAX_AGE_MS)}`,
+        oldestSession?.lastActive
+          ? `oldest activity ${oldestSession.lastActive}`
+          : null,
+      ]
+        .filter((part): part is string => Boolean(part))
+        .join(', '),
+      {
+        summary: `Delete ${stale.length} empty ${pluralize(stale.length, 'session', 'sessions')}`,
+        requiresApproval: false,
+        apply: async () => {
+          for (const session of stale) {
+            deleteSessionData(session.id);
+          }
+        },
+      },
+    ),
+  ];
+}
+
 export function resourceHygieneDoctorChecks(): DoctorCheck[] {
   const ctx = new HygieneRunContext();
   return [
@@ -872,6 +973,11 @@ export function resourceHygieneDoctorChecks(): DoctorCheck[] {
       category: 'disk',
       label: 'Stale prompt dump',
       run: () => checkStalePromptDump(ctx),
+    },
+    {
+      category: 'database',
+      label: 'Empty sessions',
+      run: () => checkEmptySessions(ctx),
     },
   ];
 }

--- a/src/doctor/checks/resource-hygiene.ts
+++ b/src/doctor/checks/resource-hygiene.ts
@@ -70,6 +70,40 @@ interface SessionDatabaseSnapshot {
   allSessionKeys: Set<string>;
 }
 
+interface ExportCandidateShell {
+  path: string;
+  displayPath: string;
+  ageMs: number;
+}
+
+class HygieneRunContext {
+  private _snapshot: SessionDatabaseSnapshot | null = null;
+  private _snapshotError: unknown = null;
+  private _snapshotLoaded = false;
+  private _diskState: { freeBytes: number | null; critical: boolean } | null =
+    null;
+
+  getSnapshot(): SessionDatabaseSnapshot {
+    if (!this._snapshotLoaded) {
+      try {
+        this._snapshot = loadSessionSnapshotFromDatabase();
+      } catch (error) {
+        this._snapshotError = error;
+      }
+      this._snapshotLoaded = true;
+    }
+    if (this._snapshotError) throw this._snapshotError;
+    return this._snapshot!;
+  }
+
+  getDiskState(): { freeBytes: number | null; critical: boolean } {
+    if (!this._diskState) {
+      this._diskState = readCriticalDiskState();
+    }
+    return this._diskState;
+  }
+}
+
 function safeFilePart(raw: string): string {
   const normalized = raw.trim().replace(/[^a-zA-Z0-9_-]/g, '_');
   return normalized || 'session';
@@ -310,9 +344,9 @@ function listPotentialStaleWorkspaceCandidates(
 
 function listPotentialOrphanedExportCandidates(
   nowMs = Date.now(),
-): CleanupCandidate[] {
+): ExportCandidateShell[] {
   const agentsRoot = path.join(DATA_DIR, AGENTS_DIR_NAME);
-  const candidates: CleanupCandidate[] = [];
+  const candidates: ExportCandidateShell[] = [];
 
   for (const entry of readDirEntries(agentsRoot)) {
     if (!entry.isDirectory()) continue;
@@ -336,7 +370,6 @@ function listPotentialOrphanedExportCandidates(
         candidates.push({
           path: exportPath,
           displayPath: shortenHomePath(exportPath),
-          sizeBytes: readDirSize(exportPath),
           ageMs,
         });
       }
@@ -344,6 +377,15 @@ function listPotentialOrphanedExportCandidates(
   }
 
   return candidates;
+}
+
+function resolveExportCandidateSizes(
+  shells: ExportCandidateShell[],
+): CleanupCandidate[] {
+  return shells.map((shell) => ({
+    ...shell,
+    sizeBytes: readDirSize(shell.path),
+  }));
 }
 
 function readPromptDumpCandidate(nowMs = Date.now()): CleanupCandidate | null {
@@ -386,7 +428,9 @@ function formatCleanupMessage(params: {
   return parts.join(', ');
 }
 
-export async function checkStaleWorkspaces(): Promise<DiagResult[]> {
+export async function checkStaleWorkspaces(
+  ctx: HygieneRunContext = new HygieneRunContext(),
+): Promise<DiagResult[]> {
   const configuredWorkspaceIds = new Set(
     listAgents().map((agent) =>
       safeFilePart(resolveAgentWorkspaceId(agent.id)),
@@ -409,7 +453,7 @@ export async function checkStaleWorkspaces(): Promise<DiagResult[]> {
 
   let snapshot: SessionDatabaseSnapshot;
   try {
-    snapshot = loadSessionSnapshotFromDatabase();
+    snapshot = ctx.getSnapshot();
   } catch (error) {
     return [
       makeResult(
@@ -441,7 +485,7 @@ export async function checkStaleWorkspaces(): Promise<DiagResult[]> {
     ];
   }
 
-  const { freeBytes, critical } = readCriticalDiskState();
+  const { freeBytes, critical } = ctx.getDiskState();
   const safeCandidates = staleCandidates.filter(
     (candidate) => !candidate.gitBacked,
   );
@@ -497,7 +541,9 @@ export async function checkStaleWorkspaces(): Promise<DiagResult[]> {
   return results;
 }
 
-export async function checkOldTempMedia(): Promise<DiagResult[]> {
+export async function checkOldTempMedia(
+  ctx: HygieneRunContext = new HygieneRunContext(),
+): Promise<DiagResult[]> {
   const candidates = listManagedTempMediaCandidates();
   if (candidates.length === 0) {
     return [
@@ -510,7 +556,7 @@ export async function checkOldTempMedia(): Promise<DiagResult[]> {
     ];
   }
 
-  const { freeBytes, critical } = readCriticalDiskState();
+  const { freeBytes, critical } = ctx.getDiskState();
   return [
     makeResult(
       'disk',
@@ -532,7 +578,9 @@ export async function checkOldTempMedia(): Promise<DiagResult[]> {
   ];
 }
 
-export async function checkOldRunLogs(): Promise<DiagResult[]> {
+export async function checkOldRunLogs(
+  ctx: HygieneRunContext = new HygieneRunContext(),
+): Promise<DiagResult[]> {
   const candidates = listFinishedEvalRunCandidates();
   if (candidates.length === 0) {
     return [
@@ -545,7 +593,7 @@ export async function checkOldRunLogs(): Promise<DiagResult[]> {
     ];
   }
 
-  const { freeBytes, critical } = readCriticalDiskState();
+  const { freeBytes, critical } = ctx.getDiskState();
   return [
     makeResult(
       'disk',
@@ -567,7 +615,9 @@ export async function checkOldRunLogs(): Promise<DiagResult[]> {
   ];
 }
 
-export async function checkSessionCompactionBacklog(): Promise<DiagResult[]> {
+export async function checkSessionCompactionBacklog(
+  ctx: HygieneRunContext = new HygieneRunContext(),
+): Promise<DiagResult[]> {
   if (!SESSION_COMPACTION_ENABLED) {
     return [
       makeResult(
@@ -581,7 +631,7 @@ export async function checkSessionCompactionBacklog(): Promise<DiagResult[]> {
 
   let snapshot: SessionDatabaseSnapshot;
   try {
-    snapshot = loadSessionSnapshotFromDatabase();
+    snapshot = ctx.getSnapshot();
   } catch (error) {
     return [
       makeResult(
@@ -642,7 +692,7 @@ export async function checkSessionCompactionBacklog(): Promise<DiagResult[]> {
     null,
   );
 
-  const { freeBytes, critical } = readCriticalDiskState();
+  const { freeBytes, critical } = ctx.getDiskState();
   return [
     makeResult(
       'database',
@@ -683,7 +733,9 @@ export async function checkSessionCompactionBacklog(): Promise<DiagResult[]> {
   ];
 }
 
-export async function checkOrphanedExports(): Promise<DiagResult[]> {
+export async function checkOrphanedExports(
+  ctx: HygieneRunContext = new HygieneRunContext(),
+): Promise<DiagResult[]> {
   const exportCandidates = listPotentialOrphanedExportCandidates();
 
   if (exportCandidates.length === 0) {
@@ -699,7 +751,7 @@ export async function checkOrphanedExports(): Promise<DiagResult[]> {
 
   let snapshot: SessionDatabaseSnapshot;
   try {
-    snapshot = loadSessionSnapshotFromDatabase();
+    snapshot = ctx.getSnapshot();
   } catch (error) {
     return [
       makeResult(
@@ -711,12 +763,12 @@ export async function checkOrphanedExports(): Promise<DiagResult[]> {
     ];
   }
 
-  const orphanedExports = exportCandidates.filter((candidate) => {
+  const orphanedShells = exportCandidates.filter((candidate) => {
     const sessionDirName = path.basename(candidate.path);
     return !snapshot.allSessionKeys.has(sessionDirName);
   });
 
-  if (orphanedExports.length === 0) {
+  if (orphanedShells.length === 0) {
     return [
       makeResult(
         'disk',
@@ -727,7 +779,8 @@ export async function checkOrphanedExports(): Promise<DiagResult[]> {
     ];
   }
 
-  const { freeBytes, critical } = readCriticalDiskState();
+  const orphanedExports = resolveExportCandidateSizes(orphanedShells);
+  const { freeBytes, critical } = ctx.getDiskState();
   return [
     makeResult(
       'disk',
@@ -749,7 +802,9 @@ export async function checkOrphanedExports(): Promise<DiagResult[]> {
   ];
 }
 
-export async function checkStalePromptDump(): Promise<DiagResult[]> {
+export async function checkStalePromptDump(
+  ctx: HygieneRunContext = new HygieneRunContext(),
+): Promise<DiagResult[]> {
   const promptDumpCandidate = readPromptDumpCandidate();
 
   if (!promptDumpCandidate) {
@@ -763,7 +818,7 @@ export async function checkStalePromptDump(): Promise<DiagResult[]> {
     ];
   }
 
-  const { freeBytes, critical } = readCriticalDiskState();
+  const { freeBytes, critical } = ctx.getDiskState();
   return [
     makeResult(
       'disk',
@@ -786,36 +841,37 @@ export async function checkStalePromptDump(): Promise<DiagResult[]> {
 }
 
 export function resourceHygieneDoctorChecks(): DoctorCheck[] {
+  const ctx = new HygieneRunContext();
   return [
     {
       category: 'disk',
       label: 'Stale workspaces',
-      run: checkStaleWorkspaces,
+      run: () => checkStaleWorkspaces(ctx),
     },
     {
       category: 'disk',
       label: 'Old temp media',
-      run: checkOldTempMedia,
+      run: () => checkOldTempMedia(ctx),
     },
     {
       category: 'disk',
       label: 'Old run logs',
-      run: checkOldRunLogs,
+      run: () => checkOldRunLogs(ctx),
     },
     {
       category: 'database',
       label: 'Session compaction backlog',
-      run: checkSessionCompactionBacklog,
+      run: () => checkSessionCompactionBacklog(ctx),
     },
     {
       category: 'disk',
       label: 'Orphaned exports',
-      run: checkOrphanedExports,
+      run: () => checkOrphanedExports(ctx),
     },
     {
       category: 'disk',
       label: 'Stale prompt dump',
-      run: checkStalePromptDump,
+      run: () => checkStalePromptDump(ctx),
     },
   ];
 }

--- a/src/doctor/checks/resource-hygiene.ts
+++ b/src/doctor/checks/resource-hygiene.ts
@@ -102,7 +102,9 @@ class HygieneRunContext {
       this._snapshotLoaded = true;
     }
     if (this._snapshotError) throw this._snapshotError;
-    return this._snapshot!;
+    if (!this._snapshot)
+      throw new Error('Session snapshot is unexpectedly null');
+    return this._snapshot;
   }
 
   getDiskState(): { freeBytes: number | null; critical: boolean } {

--- a/src/doctor/checks/resource-hygiene.ts
+++ b/src/doctor/checks/resource-hygiene.ts
@@ -19,6 +19,7 @@ import {
   formatBytes,
   formatDuration,
   makeResult,
+  pluralize,
   readDirSize,
   readDiskFreeBytes,
   shortenHomePath,
@@ -90,11 +91,6 @@ function maxCandidateAgeMs(candidates: CleanupCandidate[]): number {
 }
 
 function removeCleanupPath(targetPath: string): void {
-  const stat = fs.lstatSync(targetPath);
-  if (stat.isSymbolicLink()) {
-    fs.unlinkSync(targetPath);
-    return;
-  }
   fs.rmSync(targetPath, { recursive: true, force: true });
 }
 
@@ -108,7 +104,6 @@ function buildCleanupFix(params: {
     requiresApproval: params.requiresApproval === true,
     apply: async () => {
       for (const candidate of params.candidates) {
-        if (!fs.existsSync(candidate.path)) continue;
         removeCleanupPath(candidate.path);
       }
     },
@@ -133,11 +128,16 @@ function openReadonlyDatabase(): Database.Database {
   });
 }
 
+const ALLOWED_PRAGMA_TABLES = new Set(['sessions']);
+
 function databaseHasColumn(
   db: Database.Database,
   tableName: string,
   columnName: string,
 ): boolean {
+  if (!ALLOWED_PRAGMA_TABLES.has(tableName)) {
+    throw new Error(`Unexpected table: ${tableName}`);
+  }
   const rows = db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{
     name?: string;
   }>;
@@ -375,7 +375,7 @@ function formatCleanupMessage(params: {
   note: string;
 }): string {
   const parts = [
-    `${params.count} item${params.count === 1 ? '' : 's'}`,
+    `${params.count} ${pluralize(params.count, 'item', 'items')}`,
     `${formatBytes(params.totalBytes)} reclaimable`,
     `oldest ${formatAge(params.oldestAgeMs)}`,
     params.note,
@@ -464,7 +464,7 @@ export async function checkStaleWorkspaces(): Promise<DiagResult[]> {
           note: 'orphaned workspace directories are outside configured agents and active sessions',
         }),
         buildCleanupFix({
-          summary: `Remove ${safeCandidates.length} orphaned workspace director${safeCandidates.length === 1 ? 'y' : 'ies'}`,
+          summary: `Remove ${safeCandidates.length} orphaned workspace ${pluralize(safeCandidates.length, 'directory', 'directories')}`,
           candidates: safeCandidates,
           requiresApproval: critical,
         }),
@@ -486,7 +486,7 @@ export async function checkStaleWorkspaces(): Promise<DiagResult[]> {
           note: 'orphaned workspace directories contain .git and require approval',
         }),
         buildCleanupFix({
-          summary: `Remove ${riskyCandidates.length} git-backed orphaned workspace director${riskyCandidates.length === 1 ? 'y' : 'ies'}`,
+          summary: `Remove ${riskyCandidates.length} git-backed orphaned workspace ${pluralize(riskyCandidates.length, 'directory', 'directories')}`,
           candidates: riskyCandidates,
           requiresApproval: true,
         }),
@@ -524,7 +524,7 @@ export async function checkOldTempMedia(): Promise<DiagResult[]> {
         note: 'managed temp media directories are safe to prune',
       }),
       buildCleanupFix({
-        summary: `Delete ${candidates.length} managed temp media entr${candidates.length === 1 ? 'y' : 'ies'}`,
+        summary: `Delete ${candidates.length} managed temp media ${pluralize(candidates.length, 'entry', 'entries')}`,
         candidates,
         requiresApproval: critical,
       }),
@@ -559,7 +559,7 @@ export async function checkOldRunLogs(): Promise<DiagResult[]> {
         note: 'finished eval run directories are safe to prune',
       }),
       buildCleanupFix({
-        summary: `Prune ${candidates.length} finished run log director${candidates.length === 1 ? 'y' : 'ies'}`,
+        summary: `Prune ${candidates.length} finished run log ${pluralize(candidates.length, 'directory', 'directories')}`,
         candidates,
         requiresApproval: critical,
       }),
@@ -594,7 +594,19 @@ export async function checkSessionCompactionBacklog(): Promise<DiagResult[]> {
   }
 
   const nowMs = Date.now();
-  const threshold = Math.max(SESSION_COMPACTION_THRESHOLD, 20);
+
+  if (SESSION_COMPACTION_THRESHOLD < 20) {
+    return [
+      makeResult(
+        'database',
+        'Session compaction backlog',
+        'warn',
+        `SESSION_COMPACTION_THRESHOLD is ${SESSION_COMPACTION_THRESHOLD} (minimum is 20) — skipping compaction backlog check`,
+      ),
+    ];
+  }
+
+  const threshold = SESSION_COMPACTION_THRESHOLD;
   const backlog = snapshot.currentSessions
     .filter(
       (session) =>
@@ -637,7 +649,7 @@ export async function checkSessionCompactionBacklog(): Promise<DiagResult[]> {
       'Session compaction backlog',
       critical ? 'error' : 'warn',
       [
-        `${backlog.length} idle session${backlog.length === 1 ? '' : 's'} exceed the ${threshold}-message threshold`,
+        `${backlog.length} ${pluralize(backlog.length, 'idle session exceeds', 'idle sessions exceed')} the ${threshold}-message threshold`,
         `largest ${backlog[0]?.messageCount ?? threshold} messages`,
         oldestBacklogSession?.lastActive
           ? `oldest activity ${oldestBacklogSession.lastActive}`
@@ -647,7 +659,7 @@ export async function checkSessionCompactionBacklog(): Promise<DiagResult[]> {
         .filter((part): part is string => Boolean(part))
         .join(', '),
       {
-        summary: `Compact ${backlog.length} oversized idle session${backlog.length === 1 ? '' : 's'}`,
+        summary: `Compact ${backlog.length} oversized ${pluralize(backlog.length, 'idle session', 'idle sessions')}`,
         requiresApproval: critical,
         apply: async () => {
           for (const session of backlog) {
@@ -671,116 +683,106 @@ export async function checkSessionCompactionBacklog(): Promise<DiagResult[]> {
   ];
 }
 
-export async function checkOrphanedExportsAndPromptDumps(): Promise<
-  DiagResult[]
-> {
-  const results: DiagResult[] = [];
+export async function checkOrphanedExports(): Promise<DiagResult[]> {
   const exportCandidates = listPotentialOrphanedExportCandidates();
-  const promptDumpCandidate = readPromptDumpCandidate();
 
-  if (exportCandidates.length > 0) {
-    let snapshot: SessionDatabaseSnapshot;
-    let snapshotLoaded = true;
-    try {
-      snapshot = loadSessionSnapshotFromDatabase();
-    } catch (error) {
-      snapshotLoaded = false;
-      results.push(
-        makeResult(
-          'disk',
-          'Orphaned exports',
-          'error',
-          `Cannot verify export ownership without ${shortenHomePath(DB_PATH)} (${toErrorMessage(error)})`,
-        ),
-      );
-      snapshot = {
-        currentSessions: [],
-        allSessionKeys: new Set<string>(),
-      };
-    }
-
-    if (snapshotLoaded) {
-      const orphanedExports = exportCandidates.filter((candidate) => {
-        const sessionDirName = path.basename(candidate.path);
-        return !snapshot.allSessionKeys.has(sessionDirName);
-      });
-
-      if (orphanedExports.length > 0) {
-        const { freeBytes, critical } = readCriticalDiskState();
-        results.push(
-          makeResult(
-            'disk',
-            'Orphaned exports',
-            critical ? 'error' : 'warn',
-            formatCleanupMessage({
-              count: orphanedExports.length,
-              totalBytes: sumCandidateBytes(orphanedExports),
-              oldestAgeMs: maxCandidateAgeMs(orphanedExports),
-              freeBytes,
-              note: 'session export directories no longer match any stored session',
-            }),
-            buildCleanupFix({
-              summary: `Remove ${orphanedExports.length} orphaned export director${orphanedExports.length === 1 ? 'y' : 'ies'}`,
-              candidates: orphanedExports,
-              requiresApproval: critical,
-            }),
-          ),
-        );
-      } else {
-        results.push(
-          makeResult(
-            'disk',
-            'Orphaned exports',
-            'ok',
-            `No orphaned session exports older than ${formatAge(ORPHANED_EXPORT_MAX_AGE_MS)}`,
-          ),
-        );
-      }
-    }
-  } else {
-    results.push(
+  if (exportCandidates.length === 0) {
+    return [
       makeResult(
         'disk',
         'Orphaned exports',
         'ok',
         `No orphaned session exports older than ${formatAge(ORPHANED_EXPORT_MAX_AGE_MS)}`,
       ),
-    );
+    ];
   }
 
-  if (promptDumpCandidate) {
-    const { freeBytes, critical } = readCriticalDiskState();
-    results.push(
+  let snapshot: SessionDatabaseSnapshot;
+  try {
+    snapshot = loadSessionSnapshotFromDatabase();
+  } catch (error) {
+    return [
       makeResult(
         'disk',
-        'Prompt dump',
-        critical ? 'error' : 'warn',
-        [
-          `${promptDumpCandidate.displayPath} is older than ${formatAge(PROMPT_DUMP_MAX_AGE_MS)}`,
-          `${formatBytes(promptDumpCandidate.sizeBytes)} reclaimable`,
-          freeBytes != null ? `${formatBytes(freeBytes)} free` : null,
-        ]
-          .filter((part): part is string => Boolean(part))
-          .join(', '),
-        buildCleanupFix({
-          summary: `Remove stale prompt dump at ${promptDumpCandidate.displayPath}`,
-          candidates: [promptDumpCandidate],
-          requiresApproval: critical,
-        }),
+        'Orphaned exports',
+        'error',
+        `Cannot verify export ownership without ${shortenHomePath(DB_PATH)} (${toErrorMessage(error)})`,
       ),
-    );
-  } else {
-    results.push(
+    ];
+  }
+
+  const orphanedExports = exportCandidates.filter((candidate) => {
+    const sessionDirName = path.basename(candidate.path);
+    return !snapshot.allSessionKeys.has(sessionDirName);
+  });
+
+  if (orphanedExports.length === 0) {
+    return [
+      makeResult(
+        'disk',
+        'Orphaned exports',
+        'ok',
+        `No orphaned session exports older than ${formatAge(ORPHANED_EXPORT_MAX_AGE_MS)}`,
+      ),
+    ];
+  }
+
+  const { freeBytes, critical } = readCriticalDiskState();
+  return [
+    makeResult(
+      'disk',
+      'Orphaned exports',
+      critical ? 'error' : 'warn',
+      formatCleanupMessage({
+        count: orphanedExports.length,
+        totalBytes: sumCandidateBytes(orphanedExports),
+        oldestAgeMs: maxCandidateAgeMs(orphanedExports),
+        freeBytes,
+        note: 'session export directories no longer match any stored session',
+      }),
+      buildCleanupFix({
+        summary: `Remove ${orphanedExports.length} orphaned export ${pluralize(orphanedExports.length, 'directory', 'directories')}`,
+        candidates: orphanedExports,
+        requiresApproval: critical,
+      }),
+    ),
+  ];
+}
+
+export async function checkStalePromptDump(): Promise<DiagResult[]> {
+  const promptDumpCandidate = readPromptDumpCandidate();
+
+  if (!promptDumpCandidate) {
+    return [
       makeResult(
         'disk',
         'Prompt dump',
         'ok',
         `No prompt dump older than ${formatAge(PROMPT_DUMP_MAX_AGE_MS)}`,
       ),
-    );
+    ];
   }
 
-  return results;
+  const { freeBytes, critical } = readCriticalDiskState();
+  return [
+    makeResult(
+      'disk',
+      'Prompt dump',
+      critical ? 'error' : 'warn',
+      [
+        `${promptDumpCandidate.displayPath} is older than ${formatAge(PROMPT_DUMP_MAX_AGE_MS)}`,
+        `${formatBytes(promptDumpCandidate.sizeBytes)} reclaimable`,
+        freeBytes != null ? `${formatBytes(freeBytes)} free` : null,
+      ]
+        .filter((part): part is string => Boolean(part))
+        .join(', '),
+      buildCleanupFix({
+        summary: `Remove stale prompt dump at ${promptDumpCandidate.displayPath}`,
+        candidates: [promptDumpCandidate],
+        requiresApproval: critical,
+      }),
+    ),
+  ];
 }
 
 export function resourceHygieneDoctorChecks(): DoctorCheck[] {
@@ -807,8 +809,13 @@ export function resourceHygieneDoctorChecks(): DoctorCheck[] {
     },
     {
       category: 'disk',
-      label: 'Orphaned exports / prompt dumps',
-      run: checkOrphanedExportsAndPromptDumps,
+      label: 'Orphaned exports',
+      run: checkOrphanedExports,
+    },
+    {
+      category: 'disk',
+      label: 'Stale prompt dump',
+      run: checkStalePromptDump,
     },
   ];
 }

--- a/src/doctor/resource-hygiene.ts
+++ b/src/doctor/resource-hygiene.ts
@@ -1,0 +1,183 @@
+import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
+import { logger } from '../logger.js';
+import { resourceHygieneDoctorChecks } from './checks/resource-hygiene.js';
+import type { DiagResult, DoctorCheck, DoctorFixOutcome } from './types.js';
+import { makeResult, summarizeCounts, toErrorMessage } from './utils.js';
+
+export const RESOURCE_HYGIENE_MAINTENANCE_SESSION_ID =
+  'scheduler:resource-hygiene';
+
+export interface ResourceHygieneMaintenanceReport {
+  generatedAt: string;
+  results: DiagResult[];
+  summary: ReturnType<typeof summarizeCounts>;
+  fixes: DoctorFixOutcome[];
+  approvalRequired: Array<Pick<DiagResult, 'category' | 'label' | 'message'>>;
+}
+
+async function runChecks(checks: DoctorCheck[]): Promise<DiagResult[]> {
+  const settled = await Promise.allSettled(checks.map((check) => check.run()));
+  const results: DiagResult[] = [];
+
+  settled.forEach((result, index) => {
+    const check = checks[index];
+    if (result.status === 'fulfilled') {
+      results.push(...result.value);
+      return;
+    }
+
+    results.push(
+      makeResult(
+        check.category,
+        check.label,
+        'error',
+        `Diagnostic failed: ${toErrorMessage(result.reason)}`,
+      ),
+    );
+  });
+
+  return results;
+}
+
+async function applySafeWarnFixes(
+  results: DiagResult[],
+): Promise<DoctorFixOutcome[]> {
+  const outcomes: DoctorFixOutcome[] = [];
+
+  for (const result of results) {
+    if (!result.fix || result.severity === 'ok') continue;
+
+    if (result.fix.requiresApproval) {
+      outcomes.push({
+        category: result.category,
+        label: result.label,
+        status: 'skipped',
+        message: 'Skipped because manual approval is required',
+      });
+      continue;
+    }
+
+    if (result.severity !== 'warn') {
+      outcomes.push({
+        category: result.category,
+        label: result.label,
+        status: 'skipped',
+        message: 'Skipped because only warn-level fixes auto-apply',
+      });
+      continue;
+    }
+
+    try {
+      await result.fix.apply();
+      outcomes.push({
+        category: result.category,
+        label: result.label,
+        status: 'applied',
+        message:
+          result.fix.summary || `Applied fix for ${result.label.toLowerCase()}`,
+      });
+    } catch (error) {
+      outcomes.push({
+        category: result.category,
+        label: result.label,
+        status: 'failed',
+        message: toErrorMessage(error),
+      });
+    }
+  }
+
+  return outcomes;
+}
+
+export async function runResourceHygieneMaintenance(params?: {
+  trigger?: 'scheduler' | 'manual';
+}): Promise<ResourceHygieneMaintenanceReport> {
+  const generatedAt = new Date().toISOString();
+  const trigger = params?.trigger || 'scheduler';
+  const runId = makeAuditRunId('maintenance');
+  const checks = resourceHygieneDoctorChecks();
+
+  recordAuditEvent({
+    sessionId: RESOURCE_HYGIENE_MAINTENANCE_SESSION_ID,
+    runId,
+    event: {
+      type: 'maintenance.resource_hygiene.start',
+      trigger,
+      generatedAt,
+    },
+  });
+
+  const initialResults = await runChecks(checks);
+  const fixes = await applySafeWarnFixes(initialResults);
+  const finalResults = fixes.some((fix) => fix.status === 'applied')
+    ? await runChecks(checks)
+    : initialResults;
+  const summary = summarizeCounts(finalResults);
+  const approvalRequired = finalResults
+    .filter(
+      (result) =>
+        result.severity !== 'ok' && result.fix?.requiresApproval === true,
+    )
+    .map((result) => ({
+      category: result.category,
+      label: result.label,
+      message: result.message,
+    }));
+
+  if (approvalRequired.length > 0) {
+    recordAuditEvent({
+      sessionId: RESOURCE_HYGIENE_MAINTENANCE_SESSION_ID,
+      runId,
+      event: {
+        type: 'approval.request',
+        action: 'maintenance:resource-hygiene',
+        description: approvalRequired
+          .map((result) => `${result.label}: ${result.message}`)
+          .join('; '),
+        policyName: 'resource-hygiene',
+        source: trigger,
+      },
+    });
+  }
+
+  recordAuditEvent({
+    sessionId: RESOURCE_HYGIENE_MAINTENANCE_SESSION_ID,
+    runId,
+    event: {
+      type: 'maintenance.resource_hygiene.summary',
+      trigger,
+      generatedAt,
+      summary,
+      appliedFixes: fixes
+        .filter((fix) => fix.status === 'applied')
+        .map((fix) => fix.label),
+      failedFixes: fixes
+        .filter((fix) => fix.status === 'failed')
+        .map((fix) => `${fix.label}: ${fix.message}`),
+      approvalRequired: approvalRequired.map((result) => result.label),
+    },
+  });
+
+  logger.info(
+    {
+      trigger,
+      summary,
+      appliedFixes: fixes
+        .filter((fix) => fix.status === 'applied')
+        .map((fix) => fix.label),
+      failedFixes: fixes
+        .filter((fix) => fix.status === 'failed')
+        .map((fix) => `${fix.label}: ${fix.message}`),
+      approvalRequired: approvalRequired.map((result) => result.label),
+    },
+    'Resource hygiene maintenance completed',
+  );
+
+  return {
+    generatedAt,
+    results: finalResults,
+    summary,
+    fixes,
+    approvalRequired,
+  };
+}

--- a/src/doctor/resource-hygiene.ts
+++ b/src/doctor/resource-hygiene.ts
@@ -1,8 +1,8 @@
 import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
 import { logger } from '../logger.js';
 import { resourceHygieneDoctorChecks } from './checks/resource-hygiene.js';
-import type { DiagResult, DoctorCheck, DoctorFixOutcome } from './types.js';
-import { makeResult, summarizeCounts, toErrorMessage } from './utils.js';
+import type { DiagResult, DoctorFixOutcome } from './types.js';
+import { runChecks, summarizeCounts, toErrorMessage } from './utils.js';
 
 export const RESOURCE_HYGIENE_MAINTENANCE_SESSION_ID =
   'scheduler:resource-hygiene';
@@ -13,30 +13,6 @@ export interface ResourceHygieneMaintenanceReport {
   summary: ReturnType<typeof summarizeCounts>;
   fixes: DoctorFixOutcome[];
   approvalRequired: Array<Pick<DiagResult, 'category' | 'label' | 'message'>>;
-}
-
-async function runChecks(checks: DoctorCheck[]): Promise<DiagResult[]> {
-  const settled = await Promise.allSettled(checks.map((check) => check.run()));
-  const results: DiagResult[] = [];
-
-  settled.forEach((result, index) => {
-    const check = checks[index];
-    if (result.status === 'fulfilled') {
-      results.push(...result.value);
-      return;
-    }
-
-    results.push(
-      makeResult(
-        check.category,
-        check.label,
-        'error',
-        `Diagnostic failed: ${toErrorMessage(result.reason)}`,
-      ),
-    );
-  });
-
-  return results;
 }
 
 async function applySafeWarnFixes(
@@ -89,11 +65,9 @@ async function applySafeWarnFixes(
   return outcomes;
 }
 
-export async function runResourceHygieneMaintenance(params?: {
-  trigger?: 'scheduler' | 'manual';
-}): Promise<ResourceHygieneMaintenanceReport> {
+export async function runResourceHygieneMaintenance(): Promise<ResourceHygieneMaintenanceReport> {
   const generatedAt = new Date().toISOString();
-  const trigger = params?.trigger || 'scheduler';
+  const trigger = 'scheduler';
   const runId = makeAuditRunId('maintenance');
   const checks = resourceHygieneDoctorChecks();
 
@@ -140,6 +114,14 @@ export async function runResourceHygieneMaintenance(params?: {
     });
   }
 
+  const appliedFixLabels = fixes
+    .filter((fix) => fix.status === 'applied')
+    .map((fix) => fix.label);
+  const failedFixLabels = fixes
+    .filter((fix) => fix.status === 'failed')
+    .map((fix) => `${fix.label}: ${fix.message}`);
+  const approvalRequiredLabels = approvalRequired.map((result) => result.label);
+
   recordAuditEvent({
     sessionId: RESOURCE_HYGIENE_MAINTENANCE_SESSION_ID,
     runId,
@@ -148,13 +130,9 @@ export async function runResourceHygieneMaintenance(params?: {
       trigger,
       generatedAt,
       summary,
-      appliedFixes: fixes
-        .filter((fix) => fix.status === 'applied')
-        .map((fix) => fix.label),
-      failedFixes: fixes
-        .filter((fix) => fix.status === 'failed')
-        .map((fix) => `${fix.label}: ${fix.message}`),
-      approvalRequired: approvalRequired.map((result) => result.label),
+      appliedFixes: appliedFixLabels,
+      failedFixes: failedFixLabels,
+      approvalRequired: approvalRequiredLabels,
     },
   });
 
@@ -162,13 +140,9 @@ export async function runResourceHygieneMaintenance(params?: {
     {
       trigger,
       summary,
-      appliedFixes: fixes
-        .filter((fix) => fix.status === 'applied')
-        .map((fix) => fix.label),
-      failedFixes: fixes
-        .filter((fix) => fix.status === 'failed')
-        .map((fix) => `${fix.label}: ${fix.message}`),
-      approvalRequired: approvalRequired.map((result) => result.label),
+      appliedFixes: appliedFixLabels,
+      failedFixes: failedFixLabels,
+      approvalRequired: approvalRequiredLabels,
     },
     'Resource hygiene maintenance completed',
   );

--- a/src/doctor/types.ts
+++ b/src/doctor/types.ts
@@ -19,6 +19,7 @@ export interface DiagFix {
   summary: string;
   apply: () => Promise<void>;
   rollback?: () => Promise<void>;
+  requiresApproval?: boolean;
 }
 
 export interface DiagResult {

--- a/src/doctor/utils.ts
+++ b/src/doctor/utils.ts
@@ -2,7 +2,12 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import type { DiagResult, DoctorCategory, DoctorReport } from './types.js';
+import type {
+  DiagResult,
+  DoctorCategory,
+  DoctorCheck,
+  DoctorReport,
+} from './types.js';
 import { DOCTOR_CATEGORIES } from './types.js';
 
 const SEVERITY_ORDER: Record<DiagResult['severity'], number> = {
@@ -179,6 +184,30 @@ export function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+export async function runChecks(checks: DoctorCheck[]): Promise<DiagResult[]> {
+  const settled = await Promise.allSettled(checks.map((check) => check.run()));
+  const results: DiagResult[] = [];
+
+  settled.forEach((result, index) => {
+    const check = checks[index];
+    if (result.status === 'fulfilled') {
+      results.push(...result.value);
+      return;
+    }
+
+    results.push(
+      makeResult(
+        check.category,
+        check.label,
+        'error',
+        `Diagnostic failed: ${toErrorMessage(result.reason)}`,
+      ),
+    );
+  });
+
+  return results;
+}
+
 export function summarizeCounts(
   results: DiagResult[],
 ): DoctorReport['summary'] {
@@ -250,4 +279,12 @@ export function buildChmodFix(
             fs.chmodSync(filePath, previousMode & 0o777);
           },
   };
+}
+
+export function pluralize(
+  n: number,
+  singular: string,
+  plural: string,
+): string {
+  return n === 1 ? singular : plural;
 }

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -710,7 +710,7 @@ async function dispatchConfigJob(job: RuntimeSchedulerJob): Promise<void> {
     job.action.kind === 'system_event' &&
     job.action.message === RESOURCE_HYGIENE_SYSTEM_EVENT
   ) {
-    await runResourceHygieneMaintenance({ trigger: 'scheduler' });
+    await runResourceHygieneMaintenance();
     return;
   }
 

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -19,6 +19,7 @@ import {
   type RuntimeSchedulerJob,
   updateRuntimeConfig,
 } from '../config/runtime-config.js';
+import { runResourceHygieneMaintenance } from '../doctor/resource-hygiene.js';
 import { logger } from '../logger.js';
 import {
   deleteTask,
@@ -28,6 +29,7 @@ import {
   updateTaskLastRun,
 } from '../memory/db.js';
 import type { ScheduledTask } from '../types/scheduler.js';
+import { RESOURCE_HYGIENE_SYSTEM_EVENT } from './system-jobs.js';
 
 const MAX_TIMER_DELAY_MS = 300_000; // 5 min safety net for clock drift
 const MAX_CONSECUTIVE_FAILURES = 5;
@@ -704,6 +706,14 @@ async function dispatchDbTask(task: ScheduledTask): Promise<void> {
 }
 
 async function dispatchConfigJob(job: RuntimeSchedulerJob): Promise<void> {
+  if (
+    job.action.kind === 'system_event' &&
+    job.action.message === RESOURCE_HYGIENE_SYSTEM_EVENT
+  ) {
+    await runResourceHygieneMaintenance({ trigger: 'scheduler' });
+    return;
+  }
+
   if (!taskRunner) return;
   const jobLabel = resolveConfigJobLabel(job);
   const contextChannelId =

--- a/src/scheduler/system-jobs.ts
+++ b/src/scheduler/system-jobs.ts
@@ -1,0 +1,26 @@
+export const RESOURCE_HYGIENE_SYSTEM_EVENT = 'resource_hygiene_maintenance';
+
+export const DEFAULT_RESOURCE_HYGIENE_SCHEDULER_JOB = Object.freeze({
+  id: 'resource-hygiene',
+  name: 'Resource Hygiene',
+  description:
+    'Runs conservative doctor-based resource hygiene and auto-applies safe cleanup.',
+  schedule: {
+    kind: 'every',
+    at: null,
+    everyMs: 43_200_000,
+    expr: null,
+    tz: 'UTC',
+  },
+  action: {
+    kind: 'system_event',
+    message: RESOURCE_HYGIENE_SYSTEM_EVENT,
+  },
+  delivery: {
+    kind: 'last-channel',
+    channel: '',
+    to: '',
+    webhookUrl: '',
+  },
+  enabled: true,
+} as const);

--- a/src/scheduler/system-jobs.ts
+++ b/src/scheduler/system-jobs.ts
@@ -16,6 +16,8 @@ export const DEFAULT_RESOURCE_HYGIENE_SCHEDULER_JOB = Object.freeze({
     kind: 'system_event',
     message: RESOURCE_HYGIENE_SYSTEM_EVENT,
   },
+  // delivery is required by RuntimeSchedulerJob but ignored for system_event
+  // actions — dispatchConfigJob short-circuits before reaching delivery routing.
   delivery: {
     kind: 'last-channel',
     channel: '',

--- a/src/session/session-maintenance.ts
+++ b/src/session/session-maintenance.ts
@@ -12,6 +12,7 @@ import {
   SESSION_COMPACTION_THRESHOLD,
   SESSION_COMPACTION_TOKEN_BUDGET,
 } from '../config/config.js';
+import { stopSessionHostProcess } from '../infra/host-runner.js';
 import { agentWorkspaceDir } from '../infra/ipc.js';
 import { logger } from '../logger.js';
 import { memoryService } from '../memory/memory-service.js';
@@ -212,9 +213,10 @@ export async function runPreCompactionMemoryFlush(params: {
     );
   }
 
+  const flushSessionId = `memory-flush:${params.sessionId}:${Date.now()}`;
   try {
     const output = await runAgent({
-      sessionId: `memory-flush:${params.sessionId}:${Date.now()}`,
+      sessionId: flushSessionId,
       messages,
       chatbotId,
       enableRag: params.enableRag,
@@ -251,6 +253,8 @@ export async function runPreCompactionMemoryFlush(params: {
       { sessionId: params.sessionId, err },
       'Pre-compaction memory flush crashed',
     );
+  } finally {
+    stopSessionHostProcess(flushSessionId);
   }
 }
 

--- a/tests/doctor-fix-policy.test.ts
+++ b/tests/doctor-fix-policy.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+const ORIGINAL_STDIN_IS_TTY = process.stdin.isTTY;
+const ORIGINAL_STDOUT_IS_TTY = process.stdout.isTTY;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  Object.defineProperty(process.stdin, 'isTTY', {
+    configurable: true,
+    value: ORIGINAL_STDIN_IS_TTY,
+  });
+  Object.defineProperty(process.stdout, 'isTTY', {
+    configurable: true,
+    value: ORIGINAL_STDOUT_IS_TTY,
+  });
+});
+
+test('runDoctor skips approval-required fixes without an interactive terminal', async () => {
+  Object.defineProperty(process.stdin, 'isTTY', {
+    configurable: true,
+    value: false,
+  });
+  Object.defineProperty(process.stdout, 'isTTY', {
+    configurable: true,
+    value: false,
+  });
+
+  const applyMock = vi.fn(async () => {});
+
+  vi.doMock('../src/doctor/checks/index.js', () => ({
+    doctorChecks: () => [
+      {
+        category: 'disk' as const,
+        label: 'Risky cleanup',
+        run: async () => [
+          {
+            category: 'disk' as const,
+            label: 'Risky cleanup',
+            severity: 'error' as const,
+            message: 'Approval required before cleanup',
+            fix: {
+              summary: 'Delete git-backed workspace',
+              apply: applyMock,
+              requiresApproval: true,
+            },
+          },
+        ],
+      },
+    ],
+  }));
+
+  const { runDoctor } = await import('../src/doctor.ts');
+  const report = await runDoctor({
+    component: null,
+    fix: true,
+    json: false,
+  });
+
+  expect(applyMock).not.toHaveBeenCalled();
+  expect(report.fixes).toEqual([
+    expect.objectContaining({
+      label: 'Risky cleanup',
+      status: 'skipped',
+      message: 'Skipped because interactive approval is required',
+    }),
+  ]);
+});

--- a/tests/doctor.resource-hygiene.test.ts
+++ b/tests/doctor.resource-hygiene.test.ts
@@ -133,7 +133,7 @@ test('stale workspace check separates safe orphaned workspaces from git-backed o
   expect(fs.existsSync(riskyWorkspaceRoot)).toBe(true);
 });
 
-test('session compaction backlog fix compacts oversized idle sessions', async () => {
+test('session compaction backlog fix compacts oversized idle sessions and reports the oldest idle activity', async () => {
   const maybeCompactSessionMock = vi.fn(async () => {});
   vi.doMock('../src/session/session-maintenance.js', () => ({
     maybeCompactSession: maybeCompactSessionMock,
@@ -147,11 +147,25 @@ test('session compaction backlog fix compacts oversized idle sessions', async ()
   const { DB_PATH } = await import('../src/config/config.ts');
 
   initDatabase({ quiet: true });
-  const session = getOrCreateSession('session-backlog', null, 'web', 'main');
+  const newerLargerSession = getOrCreateSession(
+    'session-backlog-newer',
+    null,
+    'web',
+    'main',
+  );
+  const olderSmallerSession = getOrCreateSession(
+    'session-backlog-older',
+    null,
+    'web',
+    'main',
+  );
   const db = new Database(DB_PATH);
   db.prepare(
     'UPDATE sessions SET message_count = ?, last_active = ? WHERE id = ?',
-  ).run(250, '2026-04-01T00:00:00.000Z', session.id);
+  ).run(250, '2026-04-10T00:00:00.000Z', newerLargerSession.id);
+  db.prepare(
+    'UPDATE sessions SET message_count = ?, last_active = ? WHERE id = ?',
+  ).run(220, '2026-04-01T00:00:00.000Z', olderSmallerSession.id);
   db.close();
 
   const { checkSessionCompactionBacklog } = await import(
@@ -164,12 +178,20 @@ test('session compaction backlog fix compacts oversized idle sessions', async ()
     label: 'Session compaction backlog',
     severity: 'warn',
   });
+  expect(result.message).toContain('largest 250 messages');
+  expect(result.message).toContain('oldest activity 2026-04-01T00:00:00.000Z');
 
   await result.fix?.apply();
 
   expect(maybeCompactSessionMock).toHaveBeenCalledWith(
     expect.objectContaining({
-      sessionId: session.id,
+      sessionId: newerLargerSession.id,
+      channelId: 'web',
+    }),
+  );
+  expect(maybeCompactSessionMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      sessionId: olderSmallerSession.id,
       channelId: 'web',
     }),
   );

--- a/tests/doctor.resource-hygiene.test.ts
+++ b/tests/doctor.resource-hygiene.test.ts
@@ -1,0 +1,176 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterEach, expect, test, vi } from 'vitest';
+
+const ORIGINAL_HOME = process.env.HOME;
+const tempDirs: string[] = [];
+const tempPaths: string[] = [];
+
+function makeTempHome(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-hygiene-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function rememberPath(targetPath: string): string {
+  tempPaths.push(targetPath);
+  return targetPath;
+}
+
+function restoreEnvVar(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+function setOldMtime(targetPath: string, ageMs: number): void {
+  const date = new Date(Date.now() - ageMs);
+  fs.utimesSync(targetPath, date, date);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  restoreEnvVar('HOME', ORIGINAL_HOME);
+  while (tempPaths.length > 0) {
+    const targetPath = tempPaths.pop();
+    if (!targetPath) continue;
+    fs.rmSync(targetPath, { recursive: true, force: true });
+  }
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (!dir) continue;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('old temp media check prunes only managed temp directories older than 24h', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+
+  const oldDir = rememberPath(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-wa-')),
+  );
+  const recentDir = rememberPath(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-slack-')),
+  );
+  fs.writeFileSync(path.join(oldDir, 'stale.txt'), 'stale');
+  fs.writeFileSync(path.join(recentDir, 'recent.txt'), 'recent');
+  setOldMtime(path.join(oldDir, 'stale.txt'), 2 * 24 * 60 * 60 * 1000);
+  setOldMtime(oldDir, 2 * 24 * 60 * 60 * 1000);
+
+  const { checkOldTempMedia } = await import(
+    '../src/doctor/checks/resource-hygiene.ts'
+  );
+
+  const [result] = await checkOldTempMedia();
+
+  expect(result).toMatchObject({
+    label: 'Old temp media',
+    severity: 'warn',
+  });
+  await result.fix?.apply();
+
+  expect(fs.existsSync(oldDir)).toBe(false);
+  expect(fs.existsSync(recentDir)).toBe(true);
+});
+
+test('stale workspace check separates safe orphaned workspaces from git-backed ones', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { DATA_DIR } = await import('../src/config/config.ts');
+  initDatabase({ quiet: true });
+
+  const safeWorkspaceRoot = rememberPath(
+    path.join(DATA_DIR, 'agents', 'orphan-safe'),
+  );
+  const riskyWorkspaceRoot = rememberPath(
+    path.join(DATA_DIR, 'agents', 'orphan-git'),
+  );
+  fs.mkdirSync(path.join(safeWorkspaceRoot, 'workspace'), { recursive: true });
+  fs.writeFileSync(path.join(safeWorkspaceRoot, 'workspace', 'note.txt'), 'x');
+  fs.mkdirSync(path.join(riskyWorkspaceRoot, 'workspace', '.git'), {
+    recursive: true,
+  });
+  setOldMtime(path.join(safeWorkspaceRoot, 'workspace', 'note.txt'), 8 * 24 * 60 * 60 * 1000);
+  setOldMtime(path.join(riskyWorkspaceRoot, 'workspace', '.git'), 8 * 24 * 60 * 60 * 1000);
+  setOldMtime(safeWorkspaceRoot, 8 * 24 * 60 * 60 * 1000);
+  setOldMtime(riskyWorkspaceRoot, 8 * 24 * 60 * 60 * 1000);
+
+  const { checkStaleWorkspaces } = await import(
+    '../src/doctor/checks/resource-hygiene.ts'
+  );
+
+  const results = await checkStaleWorkspaces();
+  const safeResult = results.find(
+    (result) => result.label === 'Stale workspaces',
+  );
+  const riskyResult = results.find(
+    (result) => result.label === 'Git-backed stale workspaces',
+  );
+
+  expect(safeResult).toMatchObject({
+    severity: 'warn',
+  });
+  expect(riskyResult).toMatchObject({
+    severity: 'error',
+    fix: expect.objectContaining({
+      requiresApproval: true,
+    }),
+  });
+
+  await safeResult?.fix?.apply();
+
+  expect(fs.existsSync(safeWorkspaceRoot)).toBe(false);
+  expect(fs.existsSync(riskyWorkspaceRoot)).toBe(true);
+});
+
+test('session compaction backlog fix compacts oversized idle sessions', async () => {
+  const maybeCompactSessionMock = vi.fn(async () => {});
+  vi.doMock('../src/session/session-maintenance.js', () => ({
+    maybeCompactSession: maybeCompactSessionMock,
+  }));
+
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+
+  const { initDatabase, getOrCreateSession } = await import('../src/memory/db.ts');
+  const { DB_PATH } = await import('../src/config/config.ts');
+
+  initDatabase({ quiet: true });
+  const session = getOrCreateSession('session-backlog', null, 'web', 'main');
+  const db = new Database(DB_PATH);
+  db.prepare(
+    'UPDATE sessions SET message_count = ?, last_active = ? WHERE id = ?',
+  ).run(250, '2026-04-01T00:00:00.000Z', session.id);
+  db.close();
+
+  const { checkSessionCompactionBacklog } = await import(
+    '../src/doctor/checks/resource-hygiene.ts'
+  );
+
+  const [result] = await checkSessionCompactionBacklog();
+
+  expect(result).toMatchObject({
+    label: 'Session compaction backlog',
+    severity: 'warn',
+  });
+
+  await result.fix?.apply();
+
+  expect(maybeCompactSessionMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      sessionId: session.id,
+      channelId: 'web',
+    }),
+  );
+});

--- a/tests/resource-hygiene-maintenance.test.ts
+++ b/tests/resource-hygiene-maintenance.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+const {
+  infoMock,
+  recordAuditEventMock,
+  safeApplyMock,
+  riskyApplyMock,
+} = vi.hoisted(() => ({
+  infoMock: vi.fn(),
+  recordAuditEventMock: vi.fn(),
+  safeApplyMock: vi.fn(async () => {}),
+  riskyApplyMock: vi.fn(async () => {}),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  infoMock.mockReset();
+  recordAuditEventMock.mockReset();
+  safeApplyMock.mockReset();
+  riskyApplyMock.mockReset();
+});
+
+test('resource hygiene maintenance auto-applies only safe warn fixes', async () => {
+  vi.doMock('../src/doctor/checks/resource-hygiene.js', () => ({
+    resourceHygieneDoctorChecks: () => [
+      {
+        category: 'disk' as const,
+        label: 'Old temp media',
+        run: async () => [
+          {
+            category: 'disk' as const,
+            label: 'Old temp media',
+            severity: 'warn' as const,
+            message: 'Safe cleanup is available',
+            fix: {
+              summary: 'Delete old temp media',
+              apply: safeApplyMock,
+            },
+          },
+        ],
+      },
+      {
+        category: 'disk' as const,
+        label: 'Git-backed stale workspaces',
+        run: async () => [
+          {
+            category: 'disk' as const,
+            label: 'Git-backed stale workspaces',
+            severity: 'error' as const,
+            message: 'Approval required before cleanup',
+            fix: {
+              summary: 'Delete git-backed workspace',
+              apply: riskyApplyMock,
+              requiresApproval: true,
+            },
+          },
+        ],
+      },
+    ],
+  }));
+  vi.doMock('../src/audit/audit-events.js', () => ({
+    makeAuditRunId: () => 'maintenance-run',
+    recordAuditEvent: recordAuditEventMock,
+  }));
+  vi.doMock('../src/logger.js', () => ({
+    logger: {
+      info: infoMock,
+    },
+  }));
+
+  const { runResourceHygieneMaintenance } = await import(
+    '../src/doctor/resource-hygiene.ts'
+  );
+
+  const report = await runResourceHygieneMaintenance({ trigger: 'scheduler' });
+
+  expect(safeApplyMock).toHaveBeenCalledTimes(1);
+  expect(riskyApplyMock).not.toHaveBeenCalled();
+  expect(report.fixes).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        label: 'Old temp media',
+        status: 'applied',
+      }),
+      expect.objectContaining({
+        label: 'Git-backed stale workspaces',
+        status: 'skipped',
+        message: 'Skipped because manual approval is required',
+      }),
+    ]),
+  );
+  expect(
+    recordAuditEventMock.mock.calls.some(
+      ([payload]) =>
+        payload.event?.type === 'approval.request' &&
+        payload.event?.action === 'maintenance:resource-hygiene',
+    ),
+  ).toBe(true);
+  expect(infoMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      trigger: 'scheduler',
+      approvalRequired: ['Git-backed stale workspaces'],
+    }),
+    'Resource hygiene maintenance completed',
+  );
+});

--- a/tests/resource-hygiene-maintenance.test.ts
+++ b/tests/resource-hygiene-maintenance.test.ts
@@ -73,7 +73,7 @@ test('resource hygiene maintenance auto-applies only safe warn fixes', async () 
     '../src/doctor/resource-hygiene.ts'
   );
 
-  const report = await runResourceHygieneMaintenance({ trigger: 'scheduler' });
+  const report = await runResourceHygieneMaintenance();
 
   expect(safeApplyMock).toHaveBeenCalledTimes(1);
   expect(riskyApplyMock).not.toHaveBeenCalled();

--- a/tests/scheduler.resource-hygiene.test.ts
+++ b/tests/scheduler.resource-hygiene.test.ts
@@ -125,8 +125,6 @@ test('scheduler runs the built-in resource hygiene system event without delegati
   await vi.advanceTimersByTimeAsync(0);
   stopScheduler();
 
-  expect(runResourceHygieneMaintenanceMock).toHaveBeenCalledWith({
-    trigger: 'scheduler',
-  });
+  expect(runResourceHygieneMaintenanceMock).toHaveBeenCalledWith();
   expect(runner).not.toHaveBeenCalled();
 });

--- a/tests/scheduler.resource-hygiene.test.ts
+++ b/tests/scheduler.resource-hygiene.test.ts
@@ -1,0 +1,132 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, expect, test, vi } from 'vitest';
+import type { RuntimeConfig } from '../src/config/runtime-config.ts';
+
+const { runResourceHygieneMaintenanceMock } = vi.hoisted(() => ({
+  runResourceHygieneMaintenanceMock: vi.fn(async () => ({
+    generatedAt: '2026-04-14T00:00:00.000Z',
+    results: [],
+    summary: {
+      ok: 0,
+      warn: 0,
+      error: 0,
+      exitCode: 0,
+    },
+    fixes: [],
+    approvalRequired: [],
+  })),
+}));
+
+vi.mock('../src/doctor/resource-hygiene.js', () => ({
+  runResourceHygieneMaintenance: runResourceHygieneMaintenanceMock,
+}));
+
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_DISABLE_CONFIG_WATCHER =
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
+const tempDirs: string[] = [];
+
+function makeTempHome(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-scheduler-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function restoreEnvVar(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+function writeRuntimeConfig(
+  homeDir: string,
+  mutator: (config: RuntimeConfig) => void,
+): void {
+  const configPath = path.join(homeDir, '.hybridclaw', 'config.json');
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  const config = JSON.parse(
+    fs.readFileSync(path.join(process.cwd(), 'config.example.json'), 'utf-8'),
+  ) as RuntimeConfig;
+  config.ops.dbPath = path.join(
+    homeDir,
+    '.hybridclaw',
+    'data',
+    'hybridclaw.db',
+  );
+  config.scheduler.jobs = [];
+  mutator(config);
+  fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.resetModules();
+  runResourceHygieneMaintenanceMock.mockReset();
+  restoreEnvVar('HOME', ORIGINAL_HOME);
+  restoreEnvVar(
+    'HYBRIDCLAW_DISABLE_CONFIG_WATCHER',
+    ORIGINAL_DISABLE_CONFIG_WATCHER,
+  );
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (!dir) continue;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('scheduler runs the built-in resource hygiene system event without delegating to the task runner', async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-14T08:00:00.000Z'));
+
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
+
+  writeRuntimeConfig(homeDir, (config) => {
+    config.scheduler.jobs = [
+      {
+        id: 'resource-hygiene',
+        name: 'Resource Hygiene',
+        enabled: true,
+        schedule: {
+          kind: 'at',
+          at: '2026-04-14T08:00:00.000Z',
+          everyMs: null,
+          expr: null,
+          tz: 'UTC',
+        },
+        action: {
+          kind: 'system_event',
+          message: 'resource_hygiene_maintenance',
+        },
+        delivery: {
+          kind: 'last-channel',
+          channel: '',
+          to: '',
+          webhookUrl: '',
+        },
+      },
+    ];
+  });
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { startScheduler, stopScheduler } = await import(
+    '../src/scheduler/scheduler.ts'
+  );
+  initDatabase({ quiet: true });
+
+  const runner = vi.fn(async () => {});
+  startScheduler(runner);
+  await vi.advanceTimersByTimeAsync(0);
+  stopScheduler();
+
+  expect(runResourceHygieneMaintenanceMock).toHaveBeenCalledWith({
+    trigger: 'scheduler',
+  });
+  expect(runner).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## What changed
- add doctor-backed resource hygiene checks for stale workspaces, old temp media, old run logs, session compaction backlog, and orphaned exports / prompt dumps
- add a maintenance runner that executes those hygiene checks, auto-applies only safe `warn` fixes, records audit/log summaries, and flags approval-required cleanup separately
- wire a built-in twice-daily `resource-hygiene` scheduler system event into the default runtime config and `config.example.json`
- teach doctor fixes to declare `requiresApproval` so non-interactive `doctor --fix` skips risky remediations instead of applying them silently
- add focused tests for fix policy, hygiene checks, maintenance behavior, and scheduler execution

## Why
Doctor already had the right abstraction for conservative remediation via `DiagResult.fix`, but most checks were still report-only. This turns doctor into the policy engine for low-risk housekeeping instead of introducing a separate maintenance subsystem.

## Impact
- safe cleanup like temp media, finished eval logs, orphaned artifacts, and eligible session compaction can run automatically from the scheduled hygiene loop
- risky cleanup such as git-backed orphaned workspaces is surfaced as approval-required instead of being auto-applied
- installations that already define their own `scheduler.jobs` will need to add the new `resource-hygiene` job explicitly if they want the default behavior

## Validation
- `npm run format`
- `npm run typecheck`
- `npm run lint`
- `npm exec vitest -- tests/doctor-fix-policy.test.ts tests/doctor.resource-hygiene.test.ts tests/resource-hygiene-maintenance.test.ts tests/scheduler.resource-hygiene.test.ts`
