### PR TITLE
[codex] Follow up console chat migration fixes

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -13,14 +13,17 @@
     "@tanstack/react-query": "5.90.21",
     "@tanstack/react-router": "1.167.4",
     "@xterm/addon-fit": "0.11.0",
+    "marked": "17.0.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "sanitize-html": "2.17.1",
     "xterm": "5.3.0"
   },
   "devDependencies": {
     "@testing-library/react": "^16.1.0",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
+    "@types/sanitize-html": "2.16.1",
     "@vitejs/plugin-react": "5.2.0",
     "jsdom": "26.1.0",
     "typescript": "5.9.3",

--- a/console/src/api/chat-types.ts
+++ b/console/src/api/chat-types.ts
@@ -24,12 +24,12 @@ export interface AssistantPresentation {
 export interface BranchFamily {
   anchorSessionId: string;
   anchorMessageId: number | string;
-  variants: string[];
+  variants: BranchVariant[];
 }
 
-export interface BootstrapAutostart {
-  status: string;
-  fileName: string;
+export interface BranchVariant {
+  sessionId: string;
+  messageId: number | string;
 }
 
 export interface ChatHistoryResponse {
@@ -37,7 +37,6 @@ export interface ChatHistoryResponse {
   history: ChatHistoryMessage[];
   assistantPresentation?: AssistantPresentation | null;
   branchFamilies?: BranchFamily[];
-  bootstrapAutostart?: BootstrapAutostart | null;
 }
 
 export interface ChatCommandSuggestion {
@@ -102,11 +101,6 @@ export interface MediaUploadResponse {
   media: MediaItem;
 }
 
-export interface AppStatusResponse {
-  defaultAgentId?: string;
-  version?: string;
-}
-
 export interface BranchResponse {
   sessionId: string;
 }
@@ -118,7 +112,7 @@ export interface CommandResponse {
 
 export interface ChatMessage {
   id: string;
-  role: 'user' | 'assistant' | 'system' | 'thinking' | 'approval';
+  role: 'user' | 'assistant' | 'system' | 'approval';
   content: string;
   rawContent?: string;
   sessionId: string;

--- a/console/src/api/chat.test.ts
+++ b/console/src/api/chat.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { artifactUrl, executeCommand, fetchArtifactBlob } from './chat';
+import { AUTH_REQUIRED_EVENT } from './client';
+
+describe('chat artifact helpers', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('builds artifact URLs without embedding the auth token', () => {
+    expect(artifactUrl('/tmp/report.pdf')).toBe(
+      '/api/artifact?path=%2Ftmp%2Freport.pdf',
+    );
+    expect(artifactUrl('/tmp/report.pdf')).not.toContain('token=');
+  });
+
+  it('fetches artifacts with Authorization headers and dispatches auth-required on 401', async () => {
+    const events: CustomEvent[] = [];
+    const listener = (event: Event) => {
+      events.push(event as CustomEvent);
+    };
+    window.addEventListener(AUTH_REQUIRED_EVENT, listener);
+
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Unauthorized.' }), {
+        status: 401,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+
+    await expect(
+      fetchArtifactBlob('test-token', '/tmp/report.pdf'),
+    ).rejects.toThrow('Unauthorized.');
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/artifact?path=%2Ftmp%2Freport.pdf',
+      expect.objectContaining({
+        cache: 'no-store',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-token',
+        }),
+      }),
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]?.detail).toMatchObject({
+      message: 'Unauthorized.',
+    });
+
+    window.removeEventListener(AUTH_REQUIRED_EVENT, listener);
+  });
+
+  it('posts chat commands through the shared web command payload', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ status: 'ok' }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+
+    await executeCommand('test-token', 'session-a', 'web-user-1', ['stop']);
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/command',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        }),
+      }),
+    );
+
+    const request = vi.mocked(fetch).mock.calls[0]?.[1];
+    expect(JSON.parse(String(request?.body))).toEqual({
+      sessionId: 'session-a',
+      guildId: null,
+      channelId: 'web',
+      args: ['stop'],
+      userId: 'web-user-1',
+      username: 'web',
+    });
+  });
+});

--- a/console/src/api/chat.ts
+++ b/console/src/api/chat.ts
@@ -1,5 +1,4 @@
 import type {
-  AppStatusResponse,
   BranchResponse,
   ChatCommandsResponse,
   ChatHistoryResponse,
@@ -7,11 +6,12 @@ import type {
   CommandResponse,
   MediaUploadResponse,
 } from './chat-types';
-import { requestJson } from './client';
-
-export function fetchAppStatus(token: string): Promise<AppStatusResponse> {
-  return requestJson<AppStatusResponse>('/api/status', { token });
-}
+import {
+  buildWebCommandRequestBody,
+  dispatchAuthRequired,
+  requestHeaders,
+  requestJson,
+} from './client';
 
 export function fetchChatRecent(
   token: string,
@@ -75,14 +75,12 @@ export function executeCommand(
   return requestJson<CommandResponse>('/api/command', {
     token,
     method: 'POST',
-    body: {
+    body: buildWebCommandRequestBody({
       sessionId,
-      guildId: null,
-      channelId: 'web',
+      args,
       userId,
       username: 'web',
-      args,
-    },
+    }),
   });
 }
 
@@ -101,8 +99,42 @@ export function uploadMedia(
   });
 }
 
-export function artifactUrl(path: string, token?: string): string {
+export function artifactUrl(path: string): string {
   const params = new URLSearchParams({ path });
-  if (token) params.set('token', token);
   return `/api/artifact?${params.toString()}`;
+}
+
+export async function fetchArtifactBlob(
+  token: string,
+  artifactPath: string,
+): Promise<Blob> {
+  const response = await fetch(artifactUrl(artifactPath), {
+    headers: requestHeaders(token),
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    const contentType = (response.headers.get('content-type') || '')
+      .toLowerCase()
+      .trim();
+    let message = `${response.status} ${response.statusText}`;
+
+    if (contentType.includes('application/json')) {
+      const payload = (await response.json().catch(() => null)) as {
+        error?: string;
+        text?: string;
+      } | null;
+      message = payload?.error || payload?.text || message;
+    } else {
+      const text = (await response.text().catch(() => '')).trim();
+      if (text) message = text;
+    }
+
+    if (response.status === 401) {
+      dispatchAuthRequired(message);
+    }
+    throw new Error(message);
+  }
+
+  return response.blob();
 }

--- a/console/src/api/client.test.ts
+++ b/console/src/api/client.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  AUTH_REQUIRED_EVENT,
+  buildWebCommandRequestBody,
+  setRuntimeSecret,
+  uploadSkillZip,
+} from './client';
+
+describe('client command helpers', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('builds the shared web command payload with optional user identity', () => {
+    expect(
+      buildWebCommandRequestBody({
+        sessionId: 'session-a',
+        args: ['stop'],
+      }),
+    ).toEqual({
+      sessionId: 'session-a',
+      guildId: null,
+      channelId: 'web',
+      args: ['stop'],
+    });
+
+    expect(
+      buildWebCommandRequestBody({
+        sessionId: 'session-a',
+        args: ['echo', 'hello'],
+        userId: 'web-user-1',
+        username: 'web',
+      }),
+    ).toEqual({
+      sessionId: 'session-a',
+      guildId: null,
+      channelId: 'web',
+      args: ['echo', 'hello'],
+      userId: 'web-user-1',
+      username: 'web',
+    });
+  });
+
+  it('posts admin commands through the shared web command payload', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ status: 'ok' }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+
+    await setRuntimeSecret('test-token', 'OPENAI_API_KEY', 'test-secret');
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/command',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        }),
+      }),
+    );
+
+    const request = vi.mocked(fetch).mock.calls[0]?.[1];
+    expect(JSON.parse(String(request?.body))).toEqual({
+      sessionId: 'web-admin-secrets',
+      guildId: null,
+      channelId: 'web',
+      args: ['secret', 'set', 'OPENAI_API_KEY', 'test-secret'],
+    });
+  });
+
+  it('uploads skill zips through requestJson rawBody and custom content-type', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ skills: [] }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+
+    const file = new File(['zip-bytes'], 'skill.zip', {
+      type: 'application/zip',
+    });
+
+    await uploadSkillZip('test-token', file);
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/admin/skills/upload',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/zip',
+        }),
+        body: file,
+      }),
+    );
+  });
+
+  it('dispatches auth-required when skill zip upload returns 401', async () => {
+    const events: CustomEvent[] = [];
+    const listener = (event: Event) => {
+      events.push(event as CustomEvent);
+    };
+    window.addEventListener(AUTH_REQUIRED_EVENT, listener);
+
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Unauthorized.' }), {
+        status: 401,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+
+    const file = new File(['zip-bytes'], 'skill.zip', {
+      type: 'application/zip',
+    });
+
+    await expect(uploadSkillZip('test-token', file)).rejects.toThrow(
+      'Unauthorized.',
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.detail).toMatchObject({
+      message: 'Unauthorized.',
+    });
+
+    window.removeEventListener(AUTH_REQUIRED_EVENT, listener);
+  });
+});

--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -43,6 +43,15 @@ import type {
 export const TOKEN_STORAGE_KEY = 'hybridclaw_token';
 export const AUTH_REQUIRED_EVENT = 'hybridclaw:auth-required';
 
+export interface WebCommandRequestBody {
+  sessionId: string;
+  guildId: null;
+  channelId: 'web';
+  args: string[];
+  userId?: string;
+  username?: string;
+}
+
 export function requestHeaders(token: string, body?: unknown): HeadersInit {
   const trimmed = token.trim();
   return {
@@ -55,6 +64,22 @@ export function requestHeaders(token: string, body?: unknown): HeadersInit {
   };
 }
 
+export function buildWebCommandRequestBody(options: {
+  sessionId: string;
+  args: string[];
+  userId?: string;
+  username?: string;
+}): WebCommandRequestBody {
+  return {
+    sessionId: options.sessionId,
+    guildId: null,
+    channelId: 'web',
+    args: options.args,
+    ...(options.userId ? { userId: options.userId } : {}),
+    ...(options.username ? { username: options.username } : {}),
+  };
+}
+
 export function dispatchAuthRequired(message: string): void {
   clearStoredToken();
   window.dispatchEvent(
@@ -62,6 +87,35 @@ export function dispatchAuthRequired(message: string): void {
       detail: { message },
     }),
   );
+}
+
+export async function readErrorResponseMessage(
+  response: Response,
+): Promise<string> {
+  const fallback = `${response.status} ${response.statusText}`;
+  const text = (await response.text().catch(() => '')).trim();
+  if (!text) return fallback;
+
+  try {
+    const payload = JSON.parse(text) as {
+      error?: string;
+      text?: string;
+    };
+    return payload.error || payload.text || text;
+  } catch {
+    return text;
+  }
+}
+
+export async function throwResponseError(
+  response: Response,
+  options?: { onAuthError?: 'dispatch' | 'ignore' },
+): Promise<never> {
+  const message = await readErrorResponseMessage(response);
+  if (response.status === 401 && options?.onAuthError !== 'ignore') {
+    dispatchAuthRequired(message);
+  }
+  throw new Error(message);
 }
 
 export async function requestJson<T>(
@@ -87,20 +141,15 @@ export async function requestJson<T>(
         : (options.rawBody ?? undefined),
   });
 
+  if (!response.ok) {
+    await throwResponseError(response, {
+      onAuthError: options.onAuthError,
+    });
+  }
   const payload = (await response.json().catch(() => ({}))) as {
     error?: string;
     text?: string;
   };
-  if (!response.ok) {
-    const message =
-      payload.error ||
-      payload.text ||
-      `${response.status} ${response.statusText}`;
-    if (response.status === 401 && options.onAuthError !== 'ignore') {
-      dispatchAuthRequired(message);
-    }
-    throw new Error(message);
-  }
   return payload as T;
 }
 
@@ -427,12 +476,10 @@ function runAdminCommand(
   return requestJson<AdminCommandResult>('/api/command', {
     token,
     method: 'POST',
-    body: {
+    body: buildWebCommandRequestBody({
       sessionId: 'web-admin-secrets',
-      guildId: null,
-      channelId: 'web',
       args,
-    },
+    }),
   });
 }
 
@@ -674,30 +721,18 @@ export function createSkill(
   });
 }
 
-export async function uploadSkillZip(
+export function uploadSkillZip(
   token: string,
   file: File,
 ): Promise<AdminSkillsResponse> {
-  const response = await fetch('/api/admin/skills/upload', {
+  return requestJson<AdminSkillsResponse>('/api/admin/skills/upload', {
+    token,
     method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token.trim()}`,
+    rawBody: file,
+    extraHeaders: {
       'Content-Type': 'application/zip',
     },
-    body: file,
   });
-  const payload = (await response.json().catch(() => ({}))) as {
-    error?: string;
-  };
-  if (!response.ok) {
-    const message =
-      payload.error || `${response.status} ${response.statusText}`;
-    if (response.status === 401) {
-      dispatchAuthRequired(message);
-    }
-    throw new Error(message);
-  }
-  return payload as AdminSkillsResponse;
 }
 
 export function fetchPlugins(token: string): Promise<AdminPluginsResponse> {

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -11,6 +11,7 @@ export interface GatewayStatus {
   uptime: number;
   sessions: number;
   activeContainers: number;
+  defaultAgentId: string;
   defaultModel: string;
   ragDefault: boolean;
   timestamp: string;

--- a/console/src/components/admin-nav.ts
+++ b/console/src/components/admin-nav.ts
@@ -1,0 +1,23 @@
+import { type SidebarNavItem, SIDEBAR_NAV_GROUPS } from './sidebar/navigation';
+
+type AdminNavItemSummary = Pick<SidebarNavItem, 'to' | 'label'>;
+
+const ALL_NAV_ITEMS: ReadonlyArray<AdminNavItemSummary> =
+  SIDEBAR_NAV_GROUPS.flatMap((group) =>
+    group.items.map(({ to, label }) => ({ to, label })),
+  );
+
+const HIDDEN_NAV_ITEMS: ReadonlyArray<AdminNavItemSummary> = [
+  { to: '/chat', label: 'Chat' },
+];
+
+export function resolveCurrentAdminNavItem(
+  adminPath: string,
+  navItems: ReadonlyArray<AdminNavItemSummary>,
+): AdminNavItemSummary {
+  return (
+    navItems.find((item) => item.to === adminPath) ??
+    HIDDEN_NAV_ITEMS.find((item) => item.to === adminPath) ??
+    ALL_NAV_ITEMS[0]
+  );
+}

--- a/console/src/components/admin-nav.ts
+++ b/console/src/components/admin-nav.ts
@@ -1,4 +1,4 @@
-import { type SidebarNavItem, SIDEBAR_NAV_GROUPS } from './sidebar/navigation';
+import { SIDEBAR_NAV_GROUPS, type SidebarNavItem } from './sidebar/navigation';
 
 type AdminNavItemSummary = Pick<SidebarNavItem, 'to' | 'label'>;
 

--- a/console/src/components/app-shell.test.tsx
+++ b/console/src/components/app-shell.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { resolveCurrentAdminNavItem } from './admin-nav';
+
+describe('resolveCurrentAdminNavItem', () => {
+  const visibleNavItems = [
+    { to: '/', label: 'Dashboard' },
+    { to: '/approvals', label: 'Approvals' },
+  ] as const;
+
+  it('keeps the chat title for the hidden admin chat route', () => {
+    expect(resolveCurrentAdminNavItem('/chat', visibleNavItems)).toEqual({
+      to: '/chat',
+      label: 'Chat',
+    });
+  });
+
+  it('prefers visible sidebar items when present', () => {
+    expect(resolveCurrentAdminNavItem('/approvals', visibleNavItems)).toEqual({
+      to: '/approvals',
+      label: 'Approvals',
+    });
+  });
+});

--- a/console/src/components/app-shell.tsx
+++ b/console/src/components/app-shell.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react';
 import { fetchConfig } from '../api/client';
 import { useAuth } from '../auth';
+import { resolveCurrentAdminNavItem } from './admin-nav';
 import { Admin, Agents, Chat, Docs, Github } from './icons';
 import { AppSidebar } from './sidebar/app-sidebar';
 import {
@@ -17,8 +18,6 @@ import {
   SidebarTrigger,
 } from './sidebar/index';
 import { SIDEBAR_NAV_GROUPS } from './sidebar/navigation';
-
-const ALL_NAV_ITEMS = SIDEBAR_NAV_GROUPS.flatMap((group) => group.items);
 const SIDEBAR_STYLE = getSidebarStyleVars('15.5rem', '18rem');
 
 type AppShellConfigContextValue = {
@@ -71,8 +70,7 @@ export function AppShell(props: { children: ReactNode }) {
     ),
   })).filter((group) => group.items.length > 0);
   const navItems = sidebarGroups.flatMap((group) => group.items);
-  const currentNavItem =
-    navItems.find((item) => item.to === adminPath) ?? ALL_NAV_ITEMS[0];
+  const currentNavItem = resolveCurrentAdminNavItem(adminPath, navItems);
 
   return (
     <AppShellConfigContext.Provider value={{ configReady, emailEnabled }}>

--- a/console/src/components/app-shell.tsx
+++ b/console/src/components/app-shell.tsx
@@ -18,6 +18,7 @@ import {
   SidebarTrigger,
 } from './sidebar/index';
 import { SIDEBAR_NAV_GROUPS } from './sidebar/navigation';
+
 const SIDEBAR_STYLE = getSidebarStyleVars('15.5rem', '18rem');
 
 type AppShellConfigContextValue = {

--- a/console/src/components/sidebar/navigation.ts
+++ b/console/src/components/sidebar/navigation.ts
@@ -3,7 +3,6 @@ import {
   Agents,
   Audit,
   Channels,
-  Chat,
   Cog,
   Config,
   Dashboard,
@@ -38,7 +37,6 @@ export const SIDEBAR_NAV_GROUPS: ReadonlyArray<SidebarNavGroup> = [
     items: [
       { to: '/', label: 'Dashboard', icon: Dashboard },
       { to: '/approvals', label: 'Approvals', icon: Policy },
-      { to: '/chat', label: 'Chat', icon: Chat },
       { to: '/audit', label: 'Audit', icon: Audit },
       { to: '/jobs', label: 'Jobs', icon: Jobs },
     ],

--- a/console/src/components/sidebar/sidebar.test.tsx
+++ b/console/src/components/sidebar/sidebar.test.tsx
@@ -459,6 +459,7 @@ describe('AppSidebar', () => {
     for (const item of SIDEBAR_NAV_GROUPS.flatMap((g) => g.items)) {
       expect(screen.getByText(item.label)).toBeDefined();
     }
+    expect(screen.queryByText('Chat')).toBeNull();
   });
 
   it('renders version when provided', () => {

--- a/console/src/lib/chat-stream.test.ts
+++ b/console/src/lib/chat-stream.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AUTH_REQUIRED_EVENT } from '../api/client';
+import { requestChatStream } from './chat-stream';
+
+describe('requestChatStream', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('dispatches auth-required and surfaces the parsed error message on 401', async () => {
+    const events: CustomEvent[] = [];
+    const listener = (event: Event) => {
+      events.push(event as CustomEvent);
+    };
+    window.addEventListener(AUTH_REQUIRED_EVENT, listener);
+
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Unauthorized.' }), {
+        status: 401,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+
+    await expect(
+      requestChatStream('/api/chat', {
+        token: 'test-token',
+        body: { sessionId: 'session-a', stream: true },
+        callbacks: {
+          onTextDelta: vi.fn(),
+          onApproval: vi.fn(),
+        },
+      }),
+    ).rejects.toThrow('Unauthorized.');
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/chat',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Accept: 'application/x-ndjson',
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        }),
+        body: JSON.stringify({ sessionId: 'session-a', stream: true }),
+      }),
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]?.detail).toMatchObject({
+      message: 'Unauthorized.',
+    });
+
+    window.removeEventListener(AUTH_REQUIRED_EVENT, listener);
+  });
+
+  it('warns when malformed NDJSON lines are ignored and still returns the final result', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const onTextDelta = vi.fn();
+    const onApproval = vi.fn();
+
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      body: null,
+      text: async () =>
+        '{"type":"text","delta":"Hello"}\n{bad json\n{"type":"result","result":{"status":"ok","result":"Done"}}',
+    } as Response);
+
+    await expect(
+      requestChatStream('/api/chat', {
+        token: 'test-token',
+        body: { sessionId: 'session-a', stream: true },
+        callbacks: {
+          onTextDelta,
+          onApproval,
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: 'ok',
+      result: 'Done',
+    });
+
+    expect(onTextDelta).toHaveBeenCalledWith('Hello');
+    expect(onApproval).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Ignoring malformed chat stream line',
+      '{bad json',
+    );
+
+    warnSpy.mockRestore();
+  });
+});

--- a/console/src/lib/chat-stream.ts
+++ b/console/src/lib/chat-stream.ts
@@ -1,5 +1,5 @@
 import type { ChatStreamApproval, ChatStreamResult } from '../api/chat-types';
-import { dispatchAuthRequired, requestHeaders } from '../api/client';
+import { requestHeaders, throwResponseError } from '../api/client';
 
 export interface ChatStreamCallbacks {
   onTextDelta: (delta: string) => void;
@@ -26,23 +26,7 @@ export async function requestChatStream(
   });
 
   if (!response.ok) {
-    const errorText = (await response.text().catch(() => '')).trim();
-    let errorMessage = `${response.status} ${response.statusText}`;
-    if (errorText) {
-      try {
-        const payload = JSON.parse(errorText) as {
-          error?: string;
-          text?: string;
-        };
-        errorMessage = payload.error || payload.text || errorText;
-      } catch {
-        errorMessage = errorText;
-      }
-    }
-    if (response.status === 401) {
-      dispatchAuthRequired(errorMessage);
-    }
-    throw new Error(errorMessage);
+    await throwResponseError(response);
   }
 
   const { callbacks } = options;
@@ -55,6 +39,7 @@ export async function requestChatStream(
     try {
       payload = JSON.parse(trimmedLine) as Record<string, unknown>;
     } catch {
+      console.warn('Ignoring malformed chat stream line', trimmedLine);
       return null;
     }
     if (!payload || typeof payload !== 'object') return null;

--- a/console/src/lib/markdown.test.ts
+++ b/console/src/lib/markdown.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { renderMarkdown } from './markdown';
+
+describe('renderMarkdown', () => {
+  it('renders safe markdown links with hardened link attributes', () => {
+    expect(renderMarkdown('[HybridClaw](https://example.com/docs)')).toContain(
+      '<a href="https://example.com/docs" rel="noopener noreferrer" target="_blank">HybridClaw</a>',
+    );
+  });
+
+  it('sanitizes common xss payloads', () => {
+    const html = renderMarkdown(`
+<script>alert("pwned")</script>
+<img src="https://evil.test/x" onerror="alert('xss')">
+[bad](javascript:alert(1))
+<a href="javascript:alert('owned')" onclick="alert('xss')">raw</a>
+    `);
+
+    expect(html).not.toContain('<script');
+    expect(html).not.toContain('<img');
+    expect(html).not.toContain('onerror=');
+    expect(html).not.toContain('onclick=');
+    expect(html).not.toContain('href="javascript:');
+    expect(html).toContain(
+      '<a rel="noopener noreferrer" target="_blank">raw</a>',
+    );
+  });
+
+  it('escapes dangerous html inside code spans', () => {
+    expect(renderMarkdown('`<img src=x onerror=alert(1)>`')).toContain(
+      '<code>&lt;img src=x onerror=alert(1)&gt;</code>',
+    );
+  });
+
+  it('keeps basic markdown structure such as tables and lists', () => {
+    const html = renderMarkdown(`
+| Name | Value |
+| :--- | ---: |
+| Alpha | 1 |
+
+- first
+- second
+    `);
+
+    expect(html).toContain('<table>');
+    expect(html).toContain('<tbody>');
+    expect(html).toContain('<ul>');
+    expect(html).toContain('<li>first</li>');
+  });
+});

--- a/console/src/lib/markdown.ts
+++ b/console/src/lib/markdown.ts
@@ -1,275 +1,75 @@
-// Ported from the legacy docs/chat.html inline renderer.
+import { marked } from 'marked';
+import sanitizeHtml from 'sanitize-html';
 
-const HTML_ESCAPE_MAP: Record<string, string> = {
-  '&': '&amp;',
-  '<': '&lt;',
-  '>': '&gt;',
-  '"': '&quot;',
-  "'": '&#39;',
+const CHAT_MARKDOWN_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
+  allowedTags: [
+    'a',
+    'blockquote',
+    'br',
+    'code',
+    'del',
+    'em',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'hr',
+    'li',
+    'ol',
+    'p',
+    'pre',
+    'strong',
+    'table',
+    'tbody',
+    'td',
+    'th',
+    'thead',
+    'tr',
+    'ul',
+  ],
+  allowedAttributes: {
+    a: ['href', 'rel', 'target', 'title'],
+    code: ['class'],
+    td: ['style'],
+    th: ['style'],
+  },
+  allowedStyles: {
+    td: {
+      'text-align': [/^left$/, /^center$/, /^right$/],
+    },
+    th: {
+      'text-align': [/^left$/, /^center$/, /^right$/],
+    },
+  },
+  allowedSchemes: ['http', 'https', 'mailto'],
+  allowedSchemesAppliedToAttributes: ['href'],
+  allowProtocolRelative: false,
+  transformTags: {
+    a: sanitizeHtml.simpleTransform(
+      'a',
+      {
+        rel: 'noopener noreferrer',
+        target: '_blank',
+      },
+      true,
+    ),
+  },
 };
 
-function escapeHtml(raw: string): string {
-  return String(raw).replace(/[&<>"']/g, (ch) => HTML_ESCAPE_MAP[ch]);
-}
+export function renderMarkdown(raw: string): string {
+  const normalized = String(raw || '').replace(/\r\n/g, '\n');
+  if (!normalized.trim()) return '';
 
-function sanitizeUrl(rawUrl: string): string {
-  const url = String(rawUrl || '').trim();
-  if (!url) return '';
-  const lowered = url.toLowerCase();
-  if (
-    lowered.startsWith('http://') ||
-    lowered.startsWith('https://') ||
-    lowered.startsWith('mailto:')
-  ) {
-    return url;
-  }
-  return '';
-}
-
-function renderInlineMarkdown(raw: string): string {
-  let text = String(raw || '');
-  const inlineCode: string[] = [];
-  const links: string[] = [];
-
-  text = text.replace(/`([^`\n]+)`/g, (_match, code: string) => {
-    const idx = inlineCode.push(`<code>${escapeHtml(code)}</code>`) - 1;
-    return `@@IC${idx}@@`;
+  const rendered = marked.parse(normalized, {
+    async: false,
+    breaks: true,
+    gfm: true,
   });
 
-  text = text.replace(
-    /\[([^\]]+)\]\(([^)\s]+)\)/g,
-    (_match, label: string, href: string) => {
-      const safeHref = sanitizeUrl(href);
-      const safeLabel = escapeHtml(label);
-      const html = safeHref
-        ? `<a href="${escapeHtml(safeHref)}" target="_blank" rel="noopener noreferrer">${safeLabel}</a>`
-        : safeLabel;
-      const idx = links.push(html) - 1;
-      return `@@LK${idx}@@`;
-    },
-  );
-
-  text = escapeHtml(text);
-  text = text.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
-  text = text.replace(/\*([^*]+)\*/g, '<em>$1</em>');
-  text = text.replace(/__([^_]+)__/g, '<strong>$1</strong>');
-  text = text.replace(/_([^_]+)_/g, '<em>$1</em>');
-
-  text = text.replace(
-    /@@LK(\d+)@@/g,
-    (_match, index: string) => links[Number(index)] || '',
-  );
-  text = text.replace(
-    /@@IC(\d+)@@/g,
-    (_match, index: string) => inlineCode[Number(index)] || '',
-  );
-  return text;
-}
-
-function splitMarkdownTableRow(line: string): string[] {
-  let value = String(line || '').trim();
-  if (value.startsWith('|')) value = value.slice(1);
-  if (value.endsWith('|')) value = value.slice(0, -1);
-  return value.split('|').map((cell) => cell.trim());
-}
-
-function isMarkdownTableSeparator(line: string): boolean {
-  const cells = splitMarkdownTableRow(line);
-  if (!cells.length) return false;
-  return cells.every((cell) => /^:?-{3,}:?$/.test(cell));
-}
-
-function isMarkdownTableBodyRow(line: string): boolean {
-  const trimmed = String(line || '').trim();
-  return (
-    trimmed.includes('|') &&
-    trimmed !== '|' &&
-    !isMarkdownTableSeparator(trimmed)
-  );
-}
-
-function cellAlignment(separatorCell: string): 'left' | 'center' | 'right' {
-  const trimmed = String(separatorCell || '').trim();
-  if (trimmed.startsWith(':') && trimmed.endsWith(':')) return 'center';
-  if (trimmed.endsWith(':')) return 'right';
-  return 'left';
-}
-
-function renderMarkdownTable(
-  headerLine: string,
-  separatorLine: string,
-  bodyLines: string[],
-): string {
-  const headers = splitMarkdownTableRow(headerLine);
-  const separators = splitMarkdownTableRow(separatorLine);
-  const alignments = headers.map((_, index) =>
-    cellAlignment(separators[index] || '---'),
-  );
-  const bodyRows = bodyLines.map((line) => splitMarkdownTableRow(line));
-
-  const thead = `<thead><tr>${headers
-    .map(
-      (cell, index) =>
-        `<th style="text-align:${alignments[index]}">${renderInlineMarkdown(cell)}</th>`,
-    )
-    .join('')}</tr></thead>`;
-  const tbody = `<tbody>${bodyRows
-    .map(
-      (row) =>
-        `<tr>${headers
-          .map(
-            (_, index) =>
-              `<td style="text-align:${alignments[index]}">${renderInlineMarkdown(row[index] || '')}</td>`,
-          )
-          .join('')}</tr>`,
-    )
-    .join('')}</tbody>`;
-  return `<div class="md-table-wrap"><table>${thead}${tbody}</table></div>`;
-}
-
-export function renderMarkdown(raw: string): string {
-  let text = String(raw || '').replace(/\r\n/g, '\n');
-  const codeBlocks: string[] = [];
-
-  text = text.replace(
-    /```([^\n`]*)\n([\s\S]*?)```/g,
-    (_match, _lang: string, code: string) => {
-      const idx =
-        codeBlocks.push(
-          `<pre><code>${escapeHtml(code.replace(/\n$/, ''))}</code></pre>`,
-        ) - 1;
-      return `@@CB${idx}@@`;
-    },
-  );
-
-  const lines = text.split('\n');
-  const out: string[] = [];
-  let paragraphLines: string[] = [];
-  let openList = '';
-
-  const closeList = (): void => {
-    if (openList) {
-      out.push(openList === 'ul' ? '</ul>' : '</ol>');
-      openList = '';
-    }
-  };
-
-  const flushParagraph = (): void => {
-    if (paragraphLines.length === 0) return;
-    const html = paragraphLines
-      .map((line) => renderInlineMarkdown(line))
-      .join('<br>');
-    out.push(`<p>${html}</p>`);
-    paragraphLines = [];
-  };
-
-  let index = 0;
-  while (index < lines.length) {
-    const line = lines[index];
-    const codeMatch = line.match(/^@@CB(\d+)@@$/);
-    if (codeMatch) {
-      flushParagraph();
-      closeList();
-      out.push(codeBlocks[Number(codeMatch[1])] || '');
-      index += 1;
-      continue;
-    }
-
-    if (!line.trim()) {
-      flushParagraph();
-      if (openList) {
-        let ahead = index + 1;
-        while (ahead < lines.length && !(lines[ahead] || '').trim()) ahead++;
-        const nextNonEmpty = ahead < lines.length ? lines[ahead] : '';
-        const continuesList =
-          (openList === 'ul' && /^\s*[-*+]\s+/.test(nextNonEmpty)) ||
-          (openList === 'ol' && /^\s*\d+\.\s+/.test(nextNonEmpty));
-        if (!continuesList) closeList();
-      }
-      index += 1;
-      continue;
-    }
-
-    const nextLine = lines[index + 1] || '';
-    if (line.includes('|') && isMarkdownTableSeparator(nextLine)) {
-      flushParagraph();
-      closeList();
-      const bodyLines: string[] = [];
-      let tableIndex = index + 2;
-      while (
-        tableIndex < lines.length &&
-        isMarkdownTableBodyRow(lines[tableIndex])
-      ) {
-        bodyLines.push(lines[tableIndex]);
-        tableIndex += 1;
-      }
-      out.push(renderMarkdownTable(line, nextLine, bodyLines));
-      index = tableIndex;
-      continue;
-    }
-
-    const heading = line.match(/^(#{1,3})\s+(.*)$/);
-    if (heading) {
-      flushParagraph();
-      closeList();
-      const level = heading[1].length;
-      out.push(`<h${level}>${renderInlineMarkdown(heading[2])}</h${level}>`);
-      index += 1;
-      continue;
-    }
-
-    const quote = line.match(/^>\s?(.*)$/);
-    if (quote) {
-      flushParagraph();
-      closeList();
-      out.push(`<blockquote>${renderInlineMarkdown(quote[1])}</blockquote>`);
-      index += 1;
-      continue;
-    }
-
-    const hline = line.match(/^\s*((\*\s*){3,}|(-\s*){3,}|(_\s*){3,})\s*$/);
-    if (hline) {
-      flushParagraph();
-      closeList();
-      out.push('<hr>');
-      index += 1;
-      continue;
-    }
-
-    const unordered = line.match(/^\s*[-*+]\s+(.*)$/);
-    if (unordered) {
-      flushParagraph();
-      if (openList !== 'ul') {
-        closeList();
-        out.push('<ul>');
-        openList = 'ul';
-      }
-      out.push(`<li>${renderInlineMarkdown(unordered[1])}</li>`);
-      index += 1;
-      continue;
-    }
-
-    const ordered = line.match(/^\s*\d+\.\s+(.*)$/);
-    if (ordered) {
-      flushParagraph();
-      if (openList !== 'ol') {
-        closeList();
-        out.push('<ol>');
-        openList = 'ol';
-      }
-      out.push(`<li>${renderInlineMarkdown(ordered[1])}</li>`);
-      index += 1;
-      continue;
-    }
-
-    paragraphLines.push(line);
-    index += 1;
-  }
-
-  flushParagraph();
-  closeList();
-
-  return out
-    .join('\n')
-    .replace(/@@CB(\d+)@@/g, (_m, i: string) => codeBlocks[Number(i)] || '');
+  return sanitizeHtml(
+    typeof rendered === 'string' ? rendered : String(rendered || ''),
+    CHAT_MARKDOWN_SANITIZE_OPTIONS,
+  ).trim();
 }

--- a/console/src/routes/channels.test.tsx
+++ b/console/src/routes/channels.test.tsx
@@ -917,9 +917,11 @@ describe('ChannelsPage', () => {
     await screen.findByRole('button', { name: /WhatsApp/i });
 
     fireEvent.click(screen.getByRole('button', { name: /WhatsApp/i }));
-    const panel = screen
-      .getByRole('heading', { name: 'WhatsApp settings' })
-      .closest('section');
+    const panel = (
+      await screen.findByRole('heading', {
+        name: 'WhatsApp settings',
+      })
+    ).closest('section');
     expect(panel).not.toBeNull();
     const enabledToggle = within(panel as HTMLElement).getByRole('group', {
       name: 'Enabled',

--- a/console/src/routes/channels.tsx
+++ b/console/src/routes/channels.tsx
@@ -1064,11 +1064,7 @@ function EmailChannelEditor(props: {
       // Save password as runtime secret before showing success
       if (creds.password) {
         try {
-          await setRuntimeSecret(
-            props.token,
-            'EMAIL_PASSWORD',
-            creds.password,
-          );
+          await setRuntimeSecret(props.token, 'EMAIL_PASSWORD', creds.password);
           props.onSecretSaved();
         } catch (err) {
           toast.error('Password could not be saved', getErrorMessage(err));
@@ -2533,11 +2529,13 @@ export function ChannelsPage() {
   useEffect(() => {
     const firstCatalogEntry = catalog[0];
     if (!firstCatalogEntry) return;
-    if (selectedKind && catalog.some((entry) => entry.kind === selectedKind)) {
-      return;
-    }
-    setSelectedKind(firstCatalogEntry.kind);
-  }, [catalog, selectedKind]);
+    setSelectedKind((current) => {
+      if (current && catalog.some((entry) => entry.kind === current)) {
+        return current;
+      }
+      return firstCatalogEntry.kind;
+    });
+  }, [catalog]);
 
   const updateDraft: ConfigUpdater = (updater) => {
     saveMutation.reset();

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -82,6 +82,10 @@
 }
 
 .sessionItem {
+  appearance: none;
+  width: 100%;
+  border: 0;
+  background: transparent;
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -90,6 +94,9 @@
   cursor: pointer;
   transition: background 0.12s;
   overflow: hidden;
+  text-align: left;
+  font: inherit;
+  color: inherit;
 }
 
 .sessionItem:hover {
@@ -102,7 +109,7 @@
 }
 
 .sessionTitle {
-  font-size: 0.84rem;
+  font-size: 0.875rem;
   font-weight: 500;
   color: var(--text);
   white-space: nowrap;
@@ -510,14 +517,24 @@
 
 .artifactDownload {
   margin-left: auto;
+  padding: 0;
+  border: none;
+  background: transparent;
   font-size: 0.82rem;
   color: var(--primary);
   text-decoration: none;
   flex-shrink: 0;
+  cursor: pointer;
 }
 
 .artifactDownload:hover {
   text-decoration: underline;
+}
+
+.artifactDownload:disabled {
+  opacity: 0.6;
+  cursor: default;
+  text-decoration: none;
 }
 
 .artifactPreview {

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -1,0 +1,351 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  BranchResponse,
+  ChatHistoryResponse,
+  ChatRecentResponse,
+  MediaUploadResponse,
+} from '../../api/chat-types';
+import type { GatewayStatus } from '../../api/types';
+import { ChatPage } from './chat-page';
+
+const validateTokenMock = vi.fn<(token: string) => Promise<GatewayStatus>>();
+const fetchChatRecentMock =
+  vi.fn<(token: string, userId: string) => Promise<ChatRecentResponse>>();
+const fetchChatHistoryMock =
+  vi.fn<(token: string, sessionId: string) => Promise<ChatHistoryResponse>>();
+const createChatBranchMock =
+  vi.fn<
+    (
+      token: string,
+      sessionId: string,
+      beforeMessageId: number | string,
+    ) => Promise<BranchResponse>
+  >();
+const uploadMediaMock =
+  vi.fn<(token: string, file: File) => Promise<MediaUploadResponse>>();
+const useAuthMock = vi.fn();
+const sendMessageMock = vi.fn();
+const stopRequestMock = vi.fn();
+const isActiveMock = vi.fn();
+const useChatStreamMock = vi.fn();
+
+vi.mock('../../api/chat', () => ({
+  fetchChatRecent: (token: string, userId: string) =>
+    fetchChatRecentMock(token, userId),
+  fetchChatHistory: (token: string, sessionId: string) =>
+    fetchChatHistoryMock(token, sessionId),
+  createChatBranch: (
+    token: string,
+    sessionId: string,
+    beforeMessageId: number | string,
+  ) => createChatBranchMock(token, sessionId, beforeMessageId),
+  uploadMedia: (token: string, file: File) => uploadMediaMock(token, file),
+}));
+
+vi.mock('../../api/client', () => ({
+  validateToken: (token: string) => validateTokenMock(token),
+}));
+
+vi.mock('../../auth', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+vi.mock('./use-chat-stream', () => ({
+  useChatStream: (...args: unknown[]) => useChatStreamMock(...args),
+}));
+
+function renderChatPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ChatPage />
+    </QueryClientProvider>,
+  );
+
+  return queryClient;
+}
+
+describe('ChatPage', () => {
+  beforeEach(() => {
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    localStorage.clear();
+    localStorage.setItem('hybridclaw_session', 'session-a');
+    localStorage.setItem('hybridclaw_user_id', 'web-user-1');
+
+    validateTokenMock.mockReset();
+    fetchChatRecentMock.mockReset();
+    fetchChatHistoryMock.mockReset();
+    createChatBranchMock.mockReset();
+    uploadMediaMock.mockReset();
+    useAuthMock.mockReset();
+    sendMessageMock.mockReset();
+    stopRequestMock.mockReset();
+    isActiveMock.mockReset();
+    useChatStreamMock.mockReset();
+
+    useAuthMock.mockReturnValue({ token: 'test-token' });
+    validateTokenMock.mockResolvedValue({
+      status: 'ok',
+      webAuthConfigured: true,
+      version: '0.0.0',
+      imageTag: null,
+      uptime: 0,
+      sessions: 0,
+      activeContainers: 0,
+      defaultAgentId: 'main',
+      defaultModel: 'gpt-5',
+      ragDefault: false,
+      timestamp: '2026-04-14T10:00:00.000Z',
+    });
+    fetchChatRecentMock.mockResolvedValue({
+      sessions: [
+        {
+          sessionId: 'session-a',
+          title: 'Session A',
+          lastActive: '2026-04-14T10:00:00.000Z',
+          messageCount: 2,
+        },
+        {
+          sessionId: 'session-b',
+          title: 'Session B',
+          lastActive: '2026-04-14T09:30:00.000Z',
+          messageCount: 3,
+        },
+      ],
+    });
+    isActiveMock.mockReturnValue(false);
+    useChatStreamMock.mockReturnValue({
+      sendMessage: sendMessageMock,
+      stopRequest: stopRequestMock,
+      isStreaming: false,
+      streamingMsgId: null,
+      isActive: isActiveMock,
+    });
+  });
+
+  it('loads history, sends from the composer, and switches recent sessions', async () => {
+    fetchChatHistoryMock.mockImplementation(
+      async (_token, sessionId): Promise<ChatHistoryResponse> => ({
+        sessionId,
+        history:
+          sessionId === 'session-b'
+            ? [
+                {
+                  id: 201,
+                  role: 'assistant',
+                  content: 'Opened session B',
+                },
+              ]
+            : [
+                {
+                  id: 101,
+                  role: 'assistant',
+                  content: 'Opened session A',
+                },
+              ],
+      }),
+    );
+
+    renderChatPage();
+
+    expect(await screen.findByText('Opened session A')).not.toBeNull();
+
+    const input = screen.getByLabelText('Message input');
+    fireEvent.input(input, { target: { value: 'hello from web chat' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() =>
+      expect(sendMessageMock).toHaveBeenCalledWith('hello from web chat', []),
+    );
+
+    fireEvent.click(
+      screen.getByText('Session B').closest('button') as HTMLButtonElement,
+    );
+
+    expect(await screen.findByText('Opened session B')).not.toBeNull();
+    await waitFor(() =>
+      expect(fetchChatHistoryMock).toHaveBeenCalledWith(
+        'test-token',
+        'session-b',
+      ),
+    );
+  });
+
+  it('reuses cached history when switching back to a recent session inside the stale window', async () => {
+    fetchChatHistoryMock.mockImplementation(
+      async (_token, sessionId): Promise<ChatHistoryResponse> => ({
+        sessionId,
+        history: [
+          {
+            id: sessionId === 'session-b' ? 201 : 101,
+            role: 'assistant',
+            content:
+              sessionId === 'session-b'
+                ? 'Opened session B'
+                : 'Opened session A',
+          },
+        ],
+      }),
+    );
+
+    renderChatPage();
+
+    expect(await screen.findByText('Opened session A')).not.toBeNull();
+
+    fireEvent.click(
+      screen.getByText('Session B').closest('button') as HTMLButtonElement,
+    );
+    expect(await screen.findByText('Opened session B')).not.toBeNull();
+
+    fireEvent.click(
+      screen.getByText('Session A').closest('button') as HTMLButtonElement,
+    );
+    expect(await screen.findByText('Opened session A')).not.toBeNull();
+
+    expect(fetchChatHistoryMock).toHaveBeenCalledTimes(2);
+    expect(fetchChatHistoryMock.mock.calls).toEqual([
+      ['test-token', 'session-a'],
+      ['test-token', 'session-b'],
+    ]);
+  });
+
+  it('assigns branch controls to loaded history and opens sibling branches', async () => {
+    fetchChatHistoryMock.mockImplementation(
+      async (_token, sessionId): Promise<ChatHistoryResponse> => ({
+        sessionId,
+        history: [
+          {
+            id: 42,
+            role: 'assistant',
+            content:
+              sessionId === 'session-b'
+                ? 'Alternate assistant reply'
+                : 'Primary assistant reply',
+          },
+        ],
+        branchFamilies: [
+          {
+            anchorSessionId: 'session-a',
+            anchorMessageId: 42,
+            variants: [
+              { sessionId: 'session-a', messageId: 42 },
+              { sessionId: 'session-b', messageId: 42 },
+            ],
+          },
+        ],
+      }),
+    );
+
+    renderChatPage();
+
+    const initialCounter = await screen.findByText('1/2');
+    const initialActions = initialCounter.parentElement;
+    if (!(initialActions instanceof HTMLElement)) {
+      throw new Error('Missing branch action container');
+    }
+
+    fireEvent.click(within(initialActions).getByRole('button', { name: '›' }));
+
+    expect(await screen.findByText('Alternate assistant reply')).not.toBeNull();
+    expect(await screen.findByText('2/2')).not.toBeNull();
+    await waitFor(() =>
+      expect(fetchChatHistoryMock).toHaveBeenCalledWith(
+        'test-token',
+        'session-b',
+      ),
+    );
+  });
+
+  it('keeps a single sidebar tree when the mobile drawer opens', async () => {
+    fetchChatHistoryMock.mockResolvedValue({
+      sessionId: 'session-a',
+      history: [
+        {
+          id: 101,
+          role: 'assistant',
+          content: 'Opened session A',
+        },
+      ],
+    });
+
+    renderChatPage();
+
+    expect(await screen.findByText('Opened session A')).not.toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open sidebar' }));
+
+    expect(screen.getAllByText('Recent')).toHaveLength(1);
+    expect(
+      screen.getByRole('button', { name: 'Close sidebar' }),
+    ).not.toBeNull();
+  });
+
+  it('shows an error and keeps edit mode open when the message cannot be branched', async () => {
+    fetchChatHistoryMock.mockResolvedValue({
+      sessionId: 'session-a',
+      history: [
+        {
+          role: 'user',
+          content: 'Draft message without server id',
+        },
+      ],
+    });
+
+    renderChatPage();
+
+    expect(
+      await screen.findByText('Draft message without server id'),
+    ).not.toBeNull();
+
+    fireEvent.click(screen.getByTitle('Edit'));
+
+    const editBox = screen.getAllByRole('textbox')[1] as HTMLTextAreaElement;
+    fireEvent.change(editBox, {
+      target: { value: 'Updated draft message' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(createChatBranchMock).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText('This message cannot be edited right now.'),
+    ).not.toBeNull();
+    expect(screen.getByDisplayValue('Updated draft message')).not.toBeNull();
+  });
+
+  it('surfaces gateway status load failures instead of swallowing them', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    validateTokenMock.mockRejectedValue(new Error('Gateway offline'));
+    fetchChatHistoryMock.mockResolvedValue({
+      sessionId: 'session-a',
+      history: [],
+    });
+
+    renderChatPage();
+
+    expect(
+      await screen.findByText(
+        'Failed to load the default agent. New chats will use main until gateway status loads.',
+      ),
+    ).not.toBeNull();
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Failed to load gateway status for chat page',
+      expect.any(Error),
+    );
+
+    errorSpy.mockRestore();
+  });
+});

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -1,13 +1,17 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   createChatBranch,
-  fetchAppStatus,
   fetchChatHistory,
   fetchChatRecent,
   uploadMedia,
 } from '../../api/chat';
-import type { ChatMessage, MediaItem } from '../../api/chat-types';
+import type {
+  BranchVariant,
+  ChatMessage,
+  MediaItem,
+} from '../../api/chat-types';
+import { validateToken } from '../../api/client';
 import { useAuth } from '../../auth';
 import {
   type ApprovalAction,
@@ -24,9 +28,37 @@ import {
 import { cx } from '../../lib/cx';
 import css from './chat-page.module.css';
 import { ChatSidebar } from './chat-sidebar';
+import type { ChatUiMessage } from './chat-ui-message';
 import { Composer } from './composer';
 import { EditInline, MessageBlock } from './message-block';
 import { useChatStream } from './use-chat-stream';
+
+type BranchInfo = {
+  current: number;
+  total: number;
+};
+
+function buildBranchInfoMap(
+  messages: ChatUiMessage[],
+  branchFamilies: Map<string, BranchVariant[]>,
+): Map<string, BranchInfo> {
+  const map = new Map<string, BranchInfo>();
+  for (const msg of messages) {
+    const key = msg.branchKey;
+    if (!key) continue;
+    const variants = branchFamilies.get(key);
+    if (!variants || variants.length < 2) continue;
+    const currentIdx = variants.findIndex(
+      (variant) => variant.sessionId === msg.sessionId,
+    );
+    if (currentIdx < 0) continue;
+    map.set(msg.id, {
+      current: currentIdx + 1,
+      total: variants.length,
+    });
+  }
+  return map;
+}
 
 export function ChatPage() {
   const auth = useAuth();
@@ -38,12 +70,15 @@ export function ChatPage() {
     const stored = readStoredSessionId();
     return stored || generateWebSessionId();
   });
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [messages, setMessages] = useState<ChatUiMessage[]>([]);
   const [error, setError] = useState('');
   const [editingId, setEditingId] = useState<string | null>(null);
   const [approvalBusy, setApprovalBusy] = useState(false);
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
-  const [branchFamilies, setBranchFamilies] = useState<Map<string, string[]>>(
+  const [branchFamilies, setBranchFamilies] = useState<
+    Map<string, BranchVariant[]>
+  >(new Map());
+  const [branchInfoMap, setBranchInfoMap] = useState<Map<string, BranchInfo>>(
     new Map(),
   );
 
@@ -84,7 +119,7 @@ export function ChatPage() {
   }, [sessionId]);
 
   useEffect(() => {
-    void fetchAppStatus(auth.token)
+    void validateToken(auth.token)
       .then((status) => {
         if (status.defaultAgentId) {
           defaultAgentIdRef.current = status.defaultAgentId
@@ -92,7 +127,14 @@ export function ChatPage() {
             .toLowerCase();
         }
       })
-      .catch(() => {});
+      .catch((err) => {
+        console.error('Failed to load gateway status for chat page', err);
+        setError(
+          (prev) =>
+            prev ||
+            'Failed to load the default agent. New chats will use main until gateway status loads.',
+        );
+      });
   }, [auth.token]);
 
   const recentQuery = useQuery({
@@ -102,58 +144,77 @@ export function ChatPage() {
   });
   const recentSessions = recentQuery.data?.sessions ?? [];
 
-  // Load history when session changes; flush queued edit if pending
+  const historyQuery = useQuery({
+    queryKey: ['chat-history', auth.token, sessionId],
+    queryFn: () => fetchChatHistory(auth.token, sessionId),
+    enabled: Boolean(sessionId),
+    staleTime: 45_000,
+    refetchOnWindowFocus: false,
+  });
+
+  // Apply loaded history when session changes; flush queued edit if pending
   useEffect(() => {
-    if (!sessionId) return;
-    let cancelled = false;
+    const data = historyQuery.data;
+    if (!sessionId || !data) return;
 
-    void fetchChatHistory(auth.token, sessionId)
-      .then((data) => {
-        if (cancelled) return;
-        // Only update sessionId if the server returned a different one
-        if (data.sessionId && data.sessionId !== sessionId) {
-          setSessionId(data.sessionId);
-        }
+    // Only update sessionId if the server returned a different one
+    if (data.sessionId && data.sessionId !== sessionId) {
+      setSessionId(data.sessionId);
+    }
 
-        const loaded: ChatMessage[] = (data.history ?? []).map((msg) => ({
-          id: nextMsgId(),
-          role: msg.role,
-          content: msg.content,
-          rawContent: msg.content,
-          sessionId: data.sessionId ?? sessionId,
-          messageId: msg.id ?? null,
-          media: [],
-          artifacts: [],
-          replayRequest:
-            msg.role === 'user' ? { content: msg.content, media: [] } : null,
-          assistantPresentation: data.assistantPresentation ?? null,
-        }));
-        setMessages(loaded);
-        setBranchFamilies(
-          new Map(
-            (data.branchFamilies ?? []).map((bf) => [
-              `${bf.anchorSessionId}:${bf.anchorMessageId}`,
-              bf.variants,
-            ]),
-          ),
-        );
+    const resolvedSessionId = data.sessionId ?? sessionId;
+    const loadedBranchFamilies = new Map(
+      (data.branchFamilies ?? []).map((bf) => [
+        `${bf.anchorSessionId}:${bf.anchorMessageId}`,
+        bf.variants,
+      ]),
+    );
+    const branchKeysByMessageId = new Map<number | string, string>();
+    for (const [branchKey, variants] of loadedBranchFamilies.entries()) {
+      const currentVariant = variants.find(
+        (variant) => variant.sessionId === resolvedSessionId,
+      );
+      if (!currentVariant) continue;
+      branchKeysByMessageId.set(currentVariant.messageId, branchKey);
+    }
 
-        const pending = pendingEditRef.current;
-        if (pending) {
-          pendingEditRef.current = null;
-          void sendMessageRef.current(pending.content, pending.media);
-        }
-      })
-      .catch((err) => {
-        if (!cancelled)
-          setError(err instanceof Error ? err.message : String(err));
-      });
+    const loaded: ChatMessage[] = (data.history ?? []).map((msg) => ({
+      id: nextMsgId(),
+      role: msg.role,
+      content: msg.content,
+      rawContent: msg.content,
+      sessionId: resolvedSessionId,
+      messageId: msg.id ?? null,
+      media: [],
+      artifacts: [],
+      replayRequest:
+        msg.role === 'user' ? { content: msg.content, media: [] } : null,
+      assistantPresentation: data.assistantPresentation ?? null,
+      branchKey:
+        msg.id !== undefined && msg.id !== null
+          ? (branchKeysByMessageId.get(msg.id) ?? null)
+          : null,
+    }));
+    setMessages(loaded);
+    setBranchFamilies(loadedBranchFamilies);
+    setBranchInfoMap(buildBranchInfoMap(loaded, loadedBranchFamilies));
+    setError('');
 
-    return () => {
-      cancelled = true;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sessionId, auth.token]);
+    const pending = pendingEditRef.current;
+    if (pending) {
+      pendingEditRef.current = null;
+      void sendMessageRef.current(pending.content, pending.media);
+    }
+  }, [historyQuery.data, sessionId]);
+
+  useEffect(() => {
+    if (!historyQuery.error) return;
+    setError(
+      historyQuery.error instanceof Error
+        ? historyQuery.error.message
+        : String(historyQuery.error),
+    );
+  }, [historyQuery.error]);
 
   const scrollRafRef = useRef(0);
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally re-runs on message changes to auto-scroll
@@ -176,6 +237,8 @@ export function ChatPage() {
 
   const resetChatState = useCallback(() => {
     setMessages([]);
+    setBranchFamilies(new Map());
+    setBranchInfoMap(new Map());
     setError('');
     setEditingId(null);
     setMobileSidebarOpen(false);
@@ -183,8 +246,11 @@ export function ChatPage() {
 
   const handleEditSave = useCallback(
     async (msg: ChatMessage, newContent: string) => {
+      if (!msg.messageId || !msg.sessionId) {
+        setError('This message cannot be edited right now.');
+        return;
+      }
       setEditingId(null);
-      if (!msg.messageId || !msg.sessionId) return;
       try {
         const branch = await createChatBranch(
           auth.token,
@@ -276,27 +342,18 @@ export function ChatPage() {
       if (!key) return;
       const variants = branchFamilies.get(key);
       if (!variants || variants.length < 2) return;
-      const nextIdx = variants.indexOf(msg.sessionId) + direction;
+      const currentIdx = variants.findIndex(
+        (variant) => variant.sessionId === msg.sessionId,
+      );
+      if (currentIdx < 0) return;
+      const nextIdx = currentIdx + direction;
       if (nextIdx < 0 || nextIdx >= variants.length) return;
-      handleOpenSession(variants[nextIdx]);
+      const nextVariant = variants[nextIdx];
+      if (!nextVariant) return;
+      handleOpenSession(nextVariant.sessionId);
     },
     [branchFamilies, handleOpenSession],
   );
-
-  const branchInfoMap = useMemo(() => {
-    const map = new Map<string, { current: number; total: number }>();
-    for (const msg of messages) {
-      const key = msg.branchKey;
-      if (!key) continue;
-      const variants = branchFamilies.get(key);
-      if (!variants || variants.length < 2) continue;
-      map.set(msg.id, {
-        current: variants.indexOf(msg.sessionId) + 1,
-        total: variants.length,
-      });
-    }
-    return map;
-  }, [messages, branchFamilies]);
 
   /* ── Render ─────────────────────────────────────────────── */
 
@@ -311,24 +368,19 @@ export function ChatPage() {
 
   return (
     <div className={css.chatPage}>
-      <div className={css.sidebar}>
+      {mobileSidebarOpen ? (
+        <button
+          type="button"
+          className={css.sidebarBackdrop}
+          tabIndex={-1}
+          aria-label="Close sidebar"
+          onClick={() => setMobileSidebarOpen(false)}
+        />
+      ) : null}
+
+      <div className={cx(css.sidebar, mobileSidebarOpen && css.sidebarOpen)}>
         <ChatSidebar {...sidebarProps} />
       </div>
-
-      {mobileSidebarOpen ? (
-        <>
-          <button
-            type="button"
-            className={css.sidebarBackdrop}
-            tabIndex={-1}
-            aria-label="Close sidebar"
-            onClick={() => setMobileSidebarOpen(false)}
-          />
-          <div className={cx(css.sidebar, css.sidebarOpen)}>
-            <ChatSidebar {...sidebarProps} />
-          </div>
-        </>
-      ) : null}
 
       <div className={css.chatMain}>
         <div className={css.mobileHeader}>
@@ -353,7 +405,7 @@ export function ChatPage() {
           <div className={css.messageArea} ref={messageAreaRef}>
             <div className={css.messageList}>
               {messages.map((msg) =>
-                editingId === msg.id ? (
+                editingId === msg.id && msg.role !== 'thinking' ? (
                   <div key={msg.id} className={css.messageBlock}>
                     <EditInline
                       initial={msg.rawContent ?? msg.content}
@@ -375,7 +427,10 @@ export function ChatPage() {
                     onApprovalAction={handleApprovalAction}
                     approvalBusy={approvalBusy}
                     branchInfo={branchInfoMap.get(msg.id) ?? null}
-                    onBranchNav={(dir) => handleBranchNav(msg, dir)}
+                    onBranchNav={(dir) => {
+                      if (msg.role === 'thinking') return;
+                      handleBranchNav(msg, dir);
+                    }}
                   />
                 ),
               )}

--- a/console/src/routes/chat/chat-sidebar.tsx
+++ b/console/src/routes/chat/chat-sidebar.tsx
@@ -31,24 +31,26 @@ export function ChatSidebar(props: {
           <div className={css.sidebarLabel}>Recent</div>
           <ul className={css.sessionList} aria-live="polite">
             {props.sessions.map((s) => (
-              <li
-                key={s.sessionId}
-                className={cx(
-                  css.sessionItem,
-                  s.sessionId === props.activeSessionId &&
-                    css.sessionItemActive,
-                )}
-                onClick={() => props.onOpenSession(s.sessionId)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') props.onOpenSession(s.sessionId);
-                }}
-              >
-                <span className={css.sessionTitle}>
-                  {s.title || 'Untitled'}
-                </span>
-                <span className={css.sessionTime}>
-                  {formatRelativeTime(s.lastActive)}
-                </span>
+              <li key={s.sessionId}>
+                <button
+                  type="button"
+                  className={cx(
+                    css.sessionItem,
+                    s.sessionId === props.activeSessionId &&
+                      css.sessionItemActive,
+                  )}
+                  aria-current={
+                    s.sessionId === props.activeSessionId ? 'page' : undefined
+                  }
+                  onClick={() => props.onOpenSession(s.sessionId)}
+                >
+                  <span className={css.sessionTitle}>
+                    {s.title || 'Untitled'}
+                  </span>
+                  <span className={css.sessionTime}>
+                    {formatRelativeTime(s.lastActive)}
+                  </span>
+                </button>
               </li>
             ))}
           </ul>

--- a/console/src/routes/chat/chat-ui-message.ts
+++ b/console/src/routes/chat/chat-ui-message.ts
@@ -1,0 +1,8 @@
+import type { ChatMessage } from '../../api/chat-types';
+
+export type ThinkingChatMessage = Omit<ChatMessage, 'role' | 'content'> & {
+  role: 'thinking';
+  content: '';
+};
+
+export type ChatUiMessage = ChatMessage | ThinkingChatMessage;

--- a/console/src/routes/chat/composer.test.tsx
+++ b/console/src/routes/chat/composer.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ChatCommandsResponse, MediaItem } from '../../api/chat-types';
+import { Composer } from './composer';
+
+const fetchChatCommandsMock =
+  vi.fn<(token: string, query?: string) => Promise<ChatCommandsResponse>>();
+
+vi.mock('../../api/chat', () => ({
+  fetchChatCommands: (token: string, query?: string) =>
+    fetchChatCommandsMock(token, query),
+}));
+
+describe('Composer', () => {
+  beforeEach(() => {
+    fetchChatCommandsMock.mockReset();
+  });
+
+  it('strips the leading slash before fetching command suggestions', async () => {
+    fetchChatCommandsMock.mockResolvedValue({
+      commands: [],
+    });
+
+    render(
+      <Composer
+        isStreaming={false}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        onUploadFiles={vi.fn<(_: File[]) => Promise<MediaItem[]>>()}
+        token="test-token"
+      />,
+    );
+
+    fireEvent.input(screen.getByLabelText('Message input'), {
+      target: { value: '/approve' },
+    });
+
+    await waitFor(() =>
+      expect(fetchChatCommandsMock).toHaveBeenCalledWith(
+        'test-token',
+        'approve',
+      ),
+    );
+  });
+});

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -99,9 +99,10 @@ export function Composer(props: {
     resize();
     const val = textareaRef.current?.value ?? '';
     if (val.startsWith('/')) {
+      const query = val.slice(1).trim();
       if (suggestTimerRef.current) clearTimeout(suggestTimerRef.current);
       suggestTimerRef.current = setTimeout(() => {
-        void fetchSuggestions(val);
+        void fetchSuggestions(query);
       }, 150);
     } else {
       setShowSuggestions(false);

--- a/console/src/routes/chat/message-block.test.tsx
+++ b/console/src/routes/chat/message-block.test.tsx
@@ -1,0 +1,246 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ChatArtifact, ChatMessage } from '../../api/chat-types';
+import type { ChatUiMessage } from './chat-ui-message';
+import { MessageBlock } from './message-block';
+
+const fetchArtifactBlobMock =
+  vi.fn<(token: string, artifactPath: string) => Promise<Blob>>();
+const renderMarkdownMock = vi.fn<(content: string) => string>();
+
+vi.mock('../../api/chat', () => ({
+  fetchArtifactBlob: (token: string, artifactPath: string) =>
+    fetchArtifactBlobMock(token, artifactPath),
+}));
+
+vi.mock('../../lib/markdown', () => ({
+  renderMarkdown: (content: string) => renderMarkdownMock(content),
+}));
+
+function makeMessage(
+  artifacts: ChatArtifact[],
+  overrides?: Partial<ChatMessage>,
+): ChatMessage {
+  return {
+    id: 'message-1',
+    role: 'assistant',
+    content: 'Artifact output',
+    sessionId: 'session-a',
+    artifacts,
+    replayRequest: null,
+    ...overrides,
+  };
+}
+
+describe('MessageBlock artifacts', () => {
+  beforeEach(() => {
+    fetchArtifactBlobMock.mockReset();
+    renderMarkdownMock.mockReset();
+    renderMarkdownMock.mockImplementation((content) => `<p>${content}</p>`);
+    vi.stubGlobal('fetch', vi.fn());
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      writable: true,
+      value: vi.fn(() => 'blob:artifact'),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      writable: true,
+      value: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders image previews from blob URLs instead of tokenized artifact URLs', async () => {
+    fetchArtifactBlobMock.mockResolvedValue(
+      new Blob(['image-bytes'], { type: 'image/png' }),
+    );
+
+    const { container } = render(
+      <MessageBlock
+        message={makeMessage([
+          {
+            path: '/tmp/image.png',
+            filename: 'image.png',
+            mimeType: 'image/png',
+          },
+        ])}
+        token="test-token"
+        isStreaming={false}
+        onCopy={vi.fn()}
+        onEdit={vi.fn()}
+        onRegenerate={vi.fn()}
+        onApprovalAction={vi.fn()}
+        approvalBusy={false}
+        branchInfo={null}
+        onBranchNav={vi.fn()}
+      />,
+    );
+
+    const preview = await screen.findByAltText('image.png');
+    expect(preview.getAttribute('src')).toBe('blob:artifact');
+    expect(fetchArtifactBlobMock).toHaveBeenCalledWith(
+      'test-token',
+      '/tmp/image.png',
+    );
+    expect(
+      container.querySelector('[src*="token="], [href*="token="]'),
+    ).toBeNull();
+  });
+
+  it('renders a local thinking placeholder without invoking markdown rendering', () => {
+    const thinkingMessage: ChatUiMessage = {
+      id: 'thinking-1',
+      role: 'thinking',
+      content: '',
+      sessionId: 'session-a',
+    };
+
+    const { container } = render(
+      <MessageBlock
+        message={thinkingMessage}
+        token="test-token"
+        isStreaming={false}
+        onCopy={vi.fn()}
+        onEdit={vi.fn()}
+        onRegenerate={vi.fn()}
+        onApprovalAction={vi.fn()}
+        approvalBusy={false}
+        branchInfo={null}
+        onBranchNav={vi.fn()}
+      />,
+    );
+
+    expect(renderMarkdownMock).not.toHaveBeenCalled();
+    expect(container.querySelectorAll('span')).toHaveLength(3);
+  });
+
+  it('downloads non-image artifacts through the authenticated blob helper', async () => {
+    fetchArtifactBlobMock.mockResolvedValue(
+      new Blob(['pdf-bytes'], { type: 'application/pdf' }),
+    );
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {});
+
+    render(
+      <MessageBlock
+        message={makeMessage([
+          {
+            path: '/tmp/report.pdf',
+            filename: 'report.pdf',
+            mimeType: 'application/pdf',
+          },
+        ])}
+        token="test-token"
+        isStreaming={false}
+        onCopy={vi.fn()}
+        onEdit={vi.fn()}
+        onRegenerate={vi.fn()}
+        onApprovalAction={vi.fn()}
+        approvalBusy={false}
+        branchInfo={null}
+        onBranchNav={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download' }));
+
+    await waitFor(() =>
+      expect(fetchArtifactBlobMock).toHaveBeenCalledWith(
+        'test-token',
+        '/tmp/report.pdf',
+      ),
+    );
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('throttles markdown parsing while an assistant message is streaming', async () => {
+    vi.useFakeTimers();
+
+    const { rerender } = render(
+      <MessageBlock
+        message={makeMessage([], { content: 'A' })}
+        token="test-token"
+        isStreaming
+        onCopy={vi.fn()}
+        onEdit={vi.fn()}
+        onRegenerate={vi.fn()}
+        onApprovalAction={vi.fn()}
+        approvalBusy={false}
+        branchInfo={null}
+        onBranchNav={vi.fn()}
+      />,
+    );
+
+    expect(renderMarkdownMock).toHaveBeenCalledTimes(1);
+    expect(renderMarkdownMock).toHaveBeenLastCalledWith('A');
+
+    rerender(
+      <MessageBlock
+        message={makeMessage([], { content: 'AB' })}
+        token="test-token"
+        isStreaming
+        onCopy={vi.fn()}
+        onEdit={vi.fn()}
+        onRegenerate={vi.fn()}
+        onApprovalAction={vi.fn()}
+        approvalBusy={false}
+        branchInfo={null}
+        onBranchNav={vi.fn()}
+      />,
+    );
+    rerender(
+      <MessageBlock
+        message={makeMessage([], { content: 'ABC' })}
+        token="test-token"
+        isStreaming
+        onCopy={vi.fn()}
+        onEdit={vi.fn()}
+        onRegenerate={vi.fn()}
+        onApprovalAction={vi.fn()}
+        approvalBusy={false}
+        branchInfo={null}
+        onBranchNav={vi.fn()}
+      />,
+    );
+
+    expect(renderMarkdownMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(120);
+    });
+
+    expect(renderMarkdownMock).toHaveBeenCalledTimes(2);
+    expect(renderMarkdownMock).toHaveBeenLastCalledWith('ABC');
+
+    rerender(
+      <MessageBlock
+        message={makeMessage([], { content: 'ABCD' })}
+        token="test-token"
+        isStreaming={false}
+        onCopy={vi.fn()}
+        onEdit={vi.fn()}
+        onRegenerate={vi.fn()}
+        onApprovalAction={vi.fn()}
+        approvalBusy={false}
+        branchInfo={null}
+        onBranchNav={vi.fn()}
+      />,
+    );
+
+    expect(renderMarkdownMock).toHaveBeenCalledTimes(3);
+    expect(renderMarkdownMock).toHaveBeenLastCalledWith('ABCD');
+  });
+});

--- a/console/src/routes/chat/message-block.tsx
+++ b/console/src/routes/chat/message-block.tsx
@@ -1,10 +1,18 @@
-import { memo, useMemo, useState } from 'react';
-import { artifactUrl } from '../../api/chat';
+import {
+  memo,
+  startTransition,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { fetchArtifactBlob } from '../../api/chat';
 import type { ChatArtifact, ChatMessage } from '../../api/chat-types';
 import type { ApprovalAction } from '../../lib/chat-helpers';
 import { cx } from '../../lib/cx';
 import { renderMarkdown } from '../../lib/markdown';
 import css from './chat-page.module.css';
+import type { ChatUiMessage } from './chat-ui-message';
 
 const APPROVAL_BUTTONS: ReadonlyArray<{
   label: string;
@@ -17,10 +25,129 @@ const APPROVAL_BUTTONS: ReadonlyArray<{
   { label: 'Allow all', action: 'all' },
 ];
 
+const STREAM_MARKDOWN_RENDER_INTERVAL_MS = 120;
+
+function useRenderedMarkdown(
+  content: string,
+  enabled: boolean,
+  isStreaming: boolean,
+): string {
+  const [streamedContent, setStreamedContent] = useState(content);
+  const latestContentRef = useRef(content);
+  const timerRef = useRef<number | null>(null);
+
+  latestContentRef.current = content;
+
+  useEffect(() => {
+    if (!enabled) {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      setStreamedContent('');
+      return;
+    }
+
+    if (!isStreaming) {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      setStreamedContent(content);
+      return;
+    }
+
+    if (timerRef.current !== null || content === streamedContent) return;
+
+    timerRef.current = window.setTimeout(() => {
+      timerRef.current = null;
+      startTransition(() => {
+        setStreamedContent(latestContentRef.current);
+      });
+    }, STREAM_MARKDOWN_RENDER_INTERVAL_MS);
+  }, [content, enabled, isStreaming, streamedContent]);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  const markdownSource = enabled
+    ? isStreaming
+      ? streamedContent
+      : content
+    : '';
+  return useMemo(
+    () => (enabled ? renderMarkdown(markdownSource) : ''),
+    [enabled, markdownSource],
+  );
+}
+
 function ArtifactCard(props: { artifact: ChatArtifact; token: string }) {
   const { artifact, token } = props;
-  const href = artifact.path ? artifactUrl(artifact.path, token) : undefined;
+  const previewUrlRef = useRef<string | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [downloading, setDownloading] = useState(false);
   const isImage = (artifact.mimeType ?? '').startsWith('image/');
+
+  useEffect(() => {
+    const previousUrl = previewUrlRef.current;
+    previewUrlRef.current = null;
+    if (previousUrl) URL.revokeObjectURL(previousUrl);
+    setPreviewUrl(null);
+
+    if (!isImage || !artifact.path) return;
+
+    let cancelled = false;
+    void fetchArtifactBlob(token, artifact.path)
+      .then((blob) => {
+        if (cancelled) return;
+        const objectUrl = URL.createObjectURL(blob);
+        previewUrlRef.current = objectUrl;
+        setPreviewUrl(objectUrl);
+      })
+      .catch(() => {
+        if (!cancelled) setPreviewUrl(null);
+      });
+
+    return () => {
+      cancelled = true;
+      const objectUrl = previewUrlRef.current;
+      previewUrlRef.current = null;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [artifact.path, isImage, token]);
+
+  const downloadLabel = downloading ? 'Downloading…' : 'Download';
+  const handleDownload = async () => {
+    if (!artifact.path || downloading) return;
+
+    setDownloading(true);
+    try {
+      const objectUrl =
+        previewUrl ??
+        URL.createObjectURL(await fetchArtifactBlob(token, artifact.path));
+      const link = document.createElement('a');
+      link.href = objectUrl;
+      link.download = artifact.filename ?? 'artifact';
+      link.rel = 'noopener noreferrer';
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+
+      if (!previewUrl) {
+        window.setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+      }
+    } catch {
+      // Auth failures still dispatch globally via fetchArtifactBlob.
+    } finally {
+      setDownloading(false);
+    }
+  };
+
   return (
     <div className={css.artifactCard}>
       <span className={css.artifactFilename}>
@@ -29,19 +156,21 @@ function ArtifactCard(props: { artifact: ChatArtifact; token: string }) {
       {artifact.type ? (
         <span className={css.artifactBadge}>{artifact.type}</span>
       ) : null}
-      {href ? (
-        <a
+      {artifact.path ? (
+        <button
+          type="button"
           className={css.artifactDownload}
-          href={href}
-          target="_blank"
-          rel="noopener noreferrer"
+          disabled={downloading}
+          onClick={() => {
+            void handleDownload();
+          }}
         >
-          Download
-        </a>
+          {downloadLabel}
+        </button>
       ) : null}
-      {isImage && href ? (
+      {isImage && previewUrl ? (
         <div className={css.artifactPreview}>
-          <img src={href} alt={artifact.filename ?? 'preview'} />
+          <img src={previewUrl} alt={artifact.filename ?? 'preview'} />
         </div>
       ) : null}
     </div>
@@ -49,7 +178,7 @@ function ArtifactCard(props: { artifact: ChatArtifact; token: string }) {
 }
 
 export const MessageBlock = memo(function MessageBlock(props: {
-  message: ChatMessage;
+  message: ChatUiMessage;
   token: string;
   isStreaming: boolean;
   onCopy: (text: string) => void;
@@ -63,16 +192,40 @@ export const MessageBlock = memo(function MessageBlock(props: {
   const { message: msg, token } = props;
   const [copied, setCopied] = useState(false);
 
-  const renderedHtml = useMemo(
-    () => renderMarkdown(msg.content),
-    [msg.content],
-  );
-
   const handleCopy = () => {
     props.onCopy(msg.rawContent ?? msg.content);
     setCopied(true);
     setTimeout(() => setCopied(false), 900);
   };
+
+  const artifactEntries = useMemo(() => {
+    const seenKeys = new Map<string, number>();
+    return (msg.artifacts ?? []).map((artifact) => {
+      const parts = [
+        artifact.path,
+        artifact.filename,
+        artifact.mimeType,
+        artifact.type,
+      ].filter(Boolean);
+      const baseKey = parts.length > 0 ? parts.join('|') : 'artifact';
+      const seenCount = seenKeys.get(baseKey) ?? 0;
+      seenKeys.set(baseKey, seenCount + 1);
+      return {
+        artifact,
+        key: `${baseKey}:${seenCount}`,
+      };
+    });
+  }, [msg.artifacts]);
+
+  const isMarkdownMessage =
+    msg.role === 'assistant' ||
+    msg.role === 'approval' ||
+    Boolean(msg.pendingApproval);
+  const renderedHtml = useRenderedMarkdown(
+    msg.content,
+    isMarkdownMessage,
+    props.isStreaming,
+  );
 
   if (msg.role === 'thinking') {
     return (
@@ -98,7 +251,7 @@ export const MessageBlock = memo(function MessageBlock(props: {
   const bubbleClass = cx(
     css.bubble,
     isUser && css.bubbleUser,
-    isAssistant && css.bubbleAssistant,
+    (isAssistant || isApproval) && css.bubbleAssistant,
     msg.role === 'system' && css.bubbleSystem,
   );
 
@@ -128,7 +281,7 @@ export const MessageBlock = memo(function MessageBlock(props: {
         {isAssistant || isApproval ? (
           <div
             className={css.markdownContent}
-            // biome-ignore lint/security/noDangerouslySetInnerHtml: markdown output is escaped via escapeHtml + sanitizeUrl
+            // biome-ignore lint/security/noDangerouslySetInnerHtml: markdown output is rendered by marked and sanitized through sanitize-html
             dangerouslySetInnerHTML={{ __html: renderedHtml }}
           />
         ) : (
@@ -170,12 +323,8 @@ export const MessageBlock = memo(function MessageBlock(props: {
         ) : null}
       </div>
 
-      {(msg.artifacts ?? []).map((art) => (
-        <ArtifactCard
-          key={art.path ?? art.filename ?? ''}
-          artifact={art}
-          token={token}
-        />
+      {artifactEntries.map(({ artifact, key }) => (
+        <ArtifactCard key={key} artifact={artifact} token={token} />
       ))}
 
       {!props.isStreaming ? (

--- a/console/src/routes/chat/use-chat-stream.test.ts
+++ b/console/src/routes/chat/use-chat-stream.test.ts
@@ -1,0 +1,352 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  ChatStreamApproval,
+  ChatStreamResult,
+} from '../../api/chat-types';
+import type { ChatUiMessage } from './chat-ui-message';
+import { useChatStream } from './use-chat-stream';
+
+const executeCommandMock = vi.fn();
+const requestChatStreamMock = vi.fn();
+const nextMsgIdMock = vi.fn();
+
+vi.mock('../../api/chat', () => ({
+  executeCommand: (...args: unknown[]) => executeCommandMock(...args),
+}));
+
+vi.mock('../../lib/chat-helpers', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/chat-helpers')>(
+    '../../lib/chat-helpers',
+  );
+  return {
+    ...actual,
+    nextMsgId: (...args: Parameters<typeof actual.nextMsgId>) =>
+      nextMsgIdMock(...args),
+  };
+});
+
+vi.mock('../../lib/chat-stream', () => ({
+  requestChatStream: (...args: unknown[]) => requestChatStreamMock(...args),
+}));
+
+function makeHarness(initialMessages: ChatUiMessage[] = []) {
+  let messages = [...initialMessages];
+  let sessionId = 'session-a';
+  let error = '';
+
+  return {
+    get messages() {
+      return messages;
+    },
+    get sessionId() {
+      return sessionId;
+    },
+    get error() {
+      return error;
+    },
+    setMessages(update: React.SetStateAction<ChatUiMessage[]>) {
+      messages = typeof update === 'function' ? update(messages) : update;
+    },
+    setSessionId(update: React.SetStateAction<string>) {
+      sessionId = typeof update === 'function' ? update(sessionId) : update;
+    },
+    setError(update: React.SetStateAction<string>) {
+      error = typeof update === 'function' ? update(error) : update;
+    },
+  };
+}
+
+describe('useChatStream', () => {
+  beforeEach(() => {
+    executeCommandMock.mockReset();
+    requestChatStreamMock.mockReset();
+    nextMsgIdMock.mockReset();
+    let nextId = 0;
+    nextMsgIdMock.mockImplementation(() => `msg-${++nextId}`);
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0);
+      return 1;
+    });
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  });
+
+  it('keeps replayRequest on hidden-user approval responses', async () => {
+    const approval: ChatStreamApproval = {
+      type: 'approval',
+      approvalId: 'approval-1',
+      prompt: 'Need approval',
+      allowSession: true,
+      allowAgent: true,
+      allowAll: true,
+    };
+    const harness = makeHarness();
+
+    requestChatStreamMock.mockImplementation(
+      async (
+        _url: string,
+        params: {
+          callbacks: {
+            onApproval: (event: ChatStreamApproval) => void;
+          };
+        },
+      ): Promise<ChatStreamResult> => {
+        params.callbacks.onApproval(approval);
+        return {
+          status: 'ok',
+          assistantMessageId: 'assistant-1',
+          result: 'Approval requested',
+        };
+      },
+    );
+
+    const { result } = renderHook(() =>
+      useChatStream({
+        token: 'test-token',
+        userId: 'web-user-1',
+        getSessionId: () => 'session-a',
+        setMessages: harness.setMessages,
+        setSessionId: harness.setSessionId,
+        setError: harness.setError,
+        refreshRecent: vi.fn(),
+      }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage('/approve session approval-1', [], {
+        hideUser: true,
+      });
+    });
+
+    expect(harness.messages).toHaveLength(1);
+    expect(harness.messages[0]).toMatchObject({
+      role: 'approval',
+      content: 'Approval requested',
+      messageId: 'assistant-1',
+      replayRequest: {
+        content: '/approve session approval-1',
+        media: [],
+      },
+      pendingApproval: approval,
+    });
+  });
+
+  it('backfills the created user message by local id instead of matching on content', async () => {
+    const harness = makeHarness([
+      {
+        id: 'existing-user',
+        role: 'user',
+        content: 'repeat this',
+        rawContent: 'repeat this',
+        sessionId: 'session-a',
+        messageId: null,
+        media: [],
+        artifacts: [],
+        replayRequest: { content: 'repeat this', media: [] },
+      },
+    ]);
+
+    requestChatStreamMock.mockImplementation(
+      async (
+        _url: string,
+        params: {
+          callbacks: {
+            onTextDelta: (delta: string) => void;
+          };
+        },
+      ): Promise<ChatStreamResult> => {
+        params.callbacks.onTextDelta('Answer');
+        return {
+          status: 'ok',
+          sessionId: 'session-a',
+          userMessageId: 'server-user-2',
+          assistantMessageId: 'assistant-2',
+          result: 'Answer',
+        };
+      },
+    );
+
+    const { result } = renderHook(() =>
+      useChatStream({
+        token: 'test-token',
+        userId: 'web-user-1',
+        getSessionId: () => 'session-a',
+        setMessages: harness.setMessages,
+        setSessionId: harness.setSessionId,
+        setError: harness.setError,
+        refreshRecent: vi.fn(),
+      }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage('repeat this', []);
+    });
+
+    const existingUser = harness.messages.find(
+      (msg) => msg.id === 'existing-user',
+    );
+    const createdUser = harness.messages.find(
+      (msg) => msg.role === 'user' && msg.id !== 'existing-user',
+    );
+    const assistant = harness.messages.find((msg) => msg.role === 'assistant');
+
+    expect(existingUser?.messageId ?? null).toBeNull();
+    expect(createdUser).toMatchObject({
+      content: 'repeat this',
+      messageId: 'server-user-2',
+      sessionId: 'session-a',
+    });
+    expect(assistant).toMatchObject({
+      content: 'Answer',
+      messageId: 'assistant-2',
+      replayRequest: {
+        content: 'repeat this',
+        media: [],
+      },
+    });
+  });
+
+  it('allocates a separate local id for the streamed assistant message', async () => {
+    const harness = makeHarness();
+
+    requestChatStreamMock.mockImplementation(
+      async (
+        _url: string,
+        params: {
+          callbacks: {
+            onTextDelta: (delta: string) => void;
+          };
+        },
+      ): Promise<ChatStreamResult> => {
+        params.callbacks.onTextDelta('Answer');
+        return {
+          status: 'ok',
+          sessionId: 'session-a',
+          userMessageId: 'server-user-1',
+          assistantMessageId: 'assistant-1',
+          result: 'Answer',
+        };
+      },
+    );
+
+    const { result } = renderHook(() =>
+      useChatStream({
+        token: 'test-token',
+        userId: 'web-user-1',
+        getSessionId: () => 'session-a',
+        setMessages: harness.setMessages,
+        setSessionId: harness.setSessionId,
+        setError: harness.setError,
+        refreshRecent: vi.fn(),
+      }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage('hello', []);
+    });
+
+    expect(nextMsgIdMock).toHaveBeenCalledTimes(3);
+    expect(harness.messages).toHaveLength(2);
+    expect(harness.messages[0]?.id).toBe('msg-1');
+    expect(harness.messages[1]).toMatchObject({
+      id: 'msg-3',
+      role: 'assistant',
+      content: 'Answer',
+      sessionId: 'session-a',
+      messageId: 'assistant-1',
+    });
+  });
+
+  it('removes the thinking placeholder and appends one system error on stream failure', async () => {
+    const harness = makeHarness();
+
+    requestChatStreamMock.mockRejectedValue(new Error('Gateway exploded'));
+
+    const { result } = renderHook(() =>
+      useChatStream({
+        token: 'test-token',
+        userId: 'web-user-1',
+        getSessionId: () => 'session-a',
+        setMessages: harness.setMessages,
+        setSessionId: harness.setSessionId,
+        setError: harness.setError,
+        refreshRecent: vi.fn(),
+      }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage('hello', []);
+    });
+
+    expect(harness.messages).toHaveLength(2);
+    expect(harness.messages.map((msg) => msg.role)).toEqual(['user', 'system']);
+    expect(
+      harness.messages.find((msg) => msg.role === 'thinking'),
+    ).toBeUndefined();
+    expect(harness.messages[1]).toMatchObject({
+      role: 'system',
+      content: 'Error: Gateway exploded',
+      sessionId: 'session-a',
+    });
+  });
+
+  it('returns false and sets an error when a concurrent send is rejected', async () => {
+    const harness = makeHarness();
+    let resolveStream: ((value: ChatStreamResult) => void) | null = null;
+
+    requestChatStreamMock.mockImplementation(
+      () =>
+        new Promise<ChatStreamResult>((resolve) => {
+          resolveStream = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() =>
+      useChatStream({
+        token: 'test-token',
+        userId: 'web-user-1',
+        getSessionId: () => 'session-a',
+        setMessages: harness.setMessages,
+        setSessionId: harness.setSessionId,
+        setError: harness.setError,
+        refreshRecent: vi.fn(),
+      }),
+    );
+
+    let firstSend: Promise<boolean>;
+    act(() => {
+      firstSend = result.current.sendMessage('hello', []);
+    });
+
+    let accepted = true;
+    await act(async () => {
+      accepted = await result.current.sendMessage(
+        '/approve session approval-1',
+        [],
+        {
+          hideUser: true,
+        },
+      );
+    });
+
+    expect(accepted).toBe(false);
+    expect(harness.error).toBe(
+      'Wait for the current run to finish before sending another message.',
+    );
+    expect(requestChatStreamMock).toHaveBeenCalledTimes(1);
+    expect(
+      harness.messages.filter((msg) => msg.role === 'thinking'),
+    ).toHaveLength(1);
+
+    await act(async () => {
+      resolveStream?.({
+        status: 'ok',
+        sessionId: 'session-a',
+        userMessageId: 'server-user-1',
+        assistantMessageId: 'assistant-1',
+        result: 'Answer',
+      });
+      await firstSend;
+    });
+  });
+});

--- a/console/src/routes/chat/use-chat-stream.ts
+++ b/console/src/routes/chat/use-chat-stream.ts
@@ -8,6 +8,7 @@ import type {
 } from '../../api/chat-types';
 import { buildApprovalSummary, nextMsgId } from '../../lib/chat-helpers';
 import { requestChatStream } from '../../lib/chat-stream';
+import type { ChatUiMessage, ThinkingChatMessage } from './chat-ui-message';
 
 interface ActiveRequest {
   controller: AbortController;
@@ -23,18 +24,19 @@ interface UseChatStreamOptions {
   token: string;
   userId: string;
   getSessionId: () => string;
-  setMessages: React.Dispatch<React.SetStateAction<ChatMessage[]>>;
+  setMessages: React.Dispatch<React.SetStateAction<ChatUiMessage[]>>;
   setSessionId: React.Dispatch<React.SetStateAction<string>>;
   setError: React.Dispatch<React.SetStateAction<string>>;
   refreshRecent: () => void;
 }
 
 export interface UseChatStreamReturn {
+  /** Returns true when a new send was started, false when rejected due to an active run. */
   sendMessage: (
     content: string,
     media: MediaItem[],
-    opts?: { hideUser?: boolean; branchKey?: string },
-  ) => Promise<void>;
+    opts?: { hideUser?: boolean },
+  ) => Promise<boolean>;
   stopRequest: () => Promise<void>;
   isStreaming: boolean;
   /** The message ID currently being streamed, or null. */
@@ -63,16 +65,22 @@ export function useChatStream(
     async (
       content: string,
       media: MediaItem[],
-      opts?: { hideUser?: boolean; branchKey?: string },
+      opts?: { hideUser?: boolean },
     ) => {
-      if (activeRequestRef.current) return;
+      if (activeRequestRef.current) {
+        setError(
+          'Wait for the current run to finish before sending another message.',
+        );
+        return false;
+      }
 
       const targetSessionId = getSessionId();
+      const userMsgId = !opts?.hideUser ? nextMsgId() : null;
       setError('');
 
-      if (!opts?.hideUser) {
+      if (userMsgId) {
         const userMsg: ChatMessage = {
-          id: nextMsgId(),
+          id: userMsgId,
           role: 'user',
           content,
           rawContent: content,
@@ -80,7 +88,6 @@ export function useChatStream(
           media,
           artifacts: [],
           replayRequest: { content, media },
-          branchKey: opts?.branchKey ?? null,
         };
         setMessages((prev) => [...prev, userMsg]);
       }
@@ -93,10 +100,10 @@ export function useChatStream(
           role: 'thinking',
           content: '',
           sessionId: targetSessionId,
-        },
+        } satisfies ThinkingChatMessage,
       ]);
 
-      const streamId = `stream-${thinkingId}`;
+      const streamId = nextMsgId();
       setStreamingMsgId(streamId);
 
       const req: ActiveRequest = {
@@ -217,12 +224,12 @@ export function useChatStream(
                   messageId: result.assistantMessageId ?? null,
                   artifacts: finalArtifacts,
                   pendingApproval: finalApproval,
-                  replayRequest: opts?.hideUser ? null : { content, media },
+                  replayRequest: { content, media },
                 }
-              : m.role === 'user' &&
-                  m.sessionId === targetSessionId &&
-                  !m.messageId &&
-                  m.rawContent === content
+              : userMsgId &&
+                  m.id === userMsgId &&
+                  m.role === 'user' &&
+                  !m.messageId
                 ? {
                     ...m,
                     messageId: result.userMessageId ?? null,
@@ -235,24 +242,28 @@ export function useChatStream(
         refreshRecent();
       } catch (err) {
         if (req.renderFrame) cancelAnimationFrame(req.renderFrame);
-        setMessages((prev) => prev.filter((m) => m.id !== thinkingId));
-        if (!req.stopping) {
-          const text = err instanceof Error ? err.message : String(err);
-          setMessages((prev) => [
-            ...prev,
+        const errorText =
+          !req.stopping && err instanceof Error ? err.message : String(err);
+        setMessages((prev) => {
+          const withoutThinking = prev.filter((m) => m.id !== thinkingId);
+          if (req.stopping) return withoutThinking;
+          return [
+            ...withoutThinking,
             {
               id: nextMsgId(),
               role: 'system',
-              content: `Error: ${text}`,
+              content: `Error: ${errorText}`,
               sessionId: targetSessionId,
             },
-          ]);
-        }
+          ];
+        });
       } finally {
         activeRequestRef.current = null;
         setIsStreaming(false);
         setStreamingMsgId(null);
       }
+
+      return true;
     },
     [
       token,

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,14 +73,17 @@
         "@tanstack/react-query": "5.90.21",
         "@tanstack/react-router": "1.167.4",
         "@xterm/addon-fit": "0.11.0",
+        "marked": "17.0.4",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "sanitize-html": "2.17.1",
         "xterm": "5.3.0"
       },
       "devDependencies": {
         "@testing-library/react": "^16.1.0",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
+        "@types/sanitize-html": "2.16.1",
         "@vitejs/plugin-react": "5.2.0",
         "jsdom": "26.1.0",
         "typescript": "5.9.3",


### PR DESCRIPTION
## What changed
- addressed the follow-up review feedback on the console chat migration branch
- hardened the web chat client around auth/error handling, artifact downloads, markdown rendering, stream parsing, and command/request helpers
- cleaned up chat-only UI state by separating transient `thinking` placeholders from persisted message types
- removed duplicated API/client code paths and added targeted tests for command payloads, upload handling, stream errors, and malformed NDJSON warnings
- tightened UX edge cases in `/chat`, including silent concurrent sends, invalid edit saves, cached history behavior, and admin-sidebar visibility

## Why
The original migration PR was merged, but this branch still carried the review-driven follow-up fixes and hardening changes that had not yet been published in a new PR.

## Validation
- `npm --workspace console run test -- src/lib/chat-stream.test.ts src/api/client.test.ts src/api/chat.test.ts src/routes/chat/use-chat-stream.test.ts src/routes/chat/chat-page.test.tsx src/routes/chat/message-block.test.tsx src/routes/chat/composer.test.tsx src/lib/markdown.test.ts`
- `npm --workspace console run typecheck`