### PR TITLE
refactor: DRY provider model-matching and agentId normalization

### DIFF
--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -1,17 +1,11 @@
+import { createModelMatcher } from './provider-utils.js';
 import type {
   AIProvider,
   ResolvedModelRuntimeCredentials,
   ResolveProviderRuntimeParams,
 } from './types.js';
 
-const ANTHROPIC_MODEL_PREFIX = 'anthropic/';
-
-export function isAnthropicModel(model: string): boolean {
-  return String(model || '')
-    .trim()
-    .toLowerCase()
-    .startsWith(ANTHROPIC_MODEL_PREFIX);
-}
+export const isAnthropicModel = createModelMatcher('anthropic/');
 
 async function resolveAnthropicRuntimeCredentials(
   params: ResolveProviderRuntimeParams,

--- a/src/providers/huggingface.ts
+++ b/src/providers/huggingface.ts
@@ -1,10 +1,10 @@
-import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import { HUGGINGFACE_BASE_URL } from '../config/config.js';
 import { getDiscoveredHuggingFaceModelContextWindow } from './huggingface-discovery.js';
 import {
   HUGGINGFACE_MODEL_PREFIX,
   readHuggingFaceApiKey,
 } from './huggingface-utils.js';
+import { createModelMatcher, normalizeAgentId } from './provider-utils.js';
 import type {
   AIProvider,
   ResolvedModelRuntimeCredentials,
@@ -12,17 +12,12 @@ import type {
 } from './types.js';
 import { normalizeBaseUrl } from './utils.js';
 
-export function isHuggingFaceModel(model: string): boolean {
-  return String(model || '')
-    .trim()
-    .toLowerCase()
-    .startsWith(HUGGINGFACE_MODEL_PREFIX);
-}
+export const isHuggingFaceModel = createModelMatcher(HUGGINGFACE_MODEL_PREFIX);
 
 async function resolveHuggingFaceRuntimeCredentials(
   params: ResolveProviderRuntimeParams,
 ): Promise<ResolvedModelRuntimeCredentials> {
-  const agentId = String(params.agentId || '').trim() || DEFAULT_AGENT_ID;
+  const agentId = normalizeAgentId(params.agentId);
   return {
     provider: 'huggingface',
     apiKey: readHuggingFaceApiKey({ required: true }),

--- a/src/providers/local-ollama.ts
+++ b/src/providers/local-ollama.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import {
   LOCAL_DEFAULT_CONTEXT_WINDOW,
   LOCAL_OLLAMA_BASE_URL,
@@ -9,6 +8,7 @@ import {
   resolveOllamaApiBase,
 } from './local-discovery.js';
 import { stripProviderPrefix } from './model-names.js';
+import { normalizeAgentId } from './provider-utils.js';
 import type {
   AIProvider,
   ResolvedModelRuntimeCredentials,
@@ -27,7 +27,7 @@ async function resolveOllamaRuntimeCredentials(
   const modelName = normalizeOllamaModelName(params.model);
   const modelInfo =
     getLocalModelInfo(params.model) || getLocalModelInfo(modelName);
-  const agentId = String(params.agentId || '').trim() || DEFAULT_AGENT_ID;
+  const agentId = normalizeAgentId(params.agentId);
   return {
     provider: 'ollama',
     apiKey: '',

--- a/src/providers/mistral.ts
+++ b/src/providers/mistral.ts
@@ -1,6 +1,6 @@
-import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import { MISTRAL_BASE_URL } from '../config/config.js';
 import { MISTRAL_MODEL_PREFIX, readMistralApiKey } from './mistral-utils.js';
+import { createModelMatcher, normalizeAgentId } from './provider-utils.js';
 import type {
   AIProvider,
   ResolvedModelRuntimeCredentials,
@@ -8,17 +8,12 @@ import type {
 } from './types.js';
 import { normalizeBaseUrl } from './utils.js';
 
-export function isMistralModel(model: string): boolean {
-  return String(model || '')
-    .trim()
-    .toLowerCase()
-    .startsWith(MISTRAL_MODEL_PREFIX);
-}
+export const isMistralModel = createModelMatcher(MISTRAL_MODEL_PREFIX);
 
 async function resolveMistralRuntimeCredentials(
   params: ResolveProviderRuntimeParams,
 ): Promise<ResolvedModelRuntimeCredentials> {
-  const agentId = String(params.agentId || '').trim() || DEFAULT_AGENT_ID;
+  const agentId = normalizeAgentId(params.agentId);
   return {
     provider: 'mistral',
     apiKey: readMistralApiKey({ required: true }),

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -1,6 +1,6 @@
-import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import { resolveCodexCredentials } from '../auth/codex-auth.js';
 import { CODEX_BASE_URL } from '../config/config.js';
+import { createModelMatcher, normalizeAgentId } from './provider-utils.js';
 import type {
   AIProvider,
   ResolvedModelRuntimeCredentials,
@@ -9,18 +9,13 @@ import type {
 
 export const OPENAI_CODEX_MODEL_PREFIX = 'openai-codex/';
 
-export function isOpenAICodexModel(model: string): boolean {
-  return String(model || '')
-    .trim()
-    .toLowerCase()
-    .startsWith(OPENAI_CODEX_MODEL_PREFIX);
-}
+export const isOpenAICodexModel = createModelMatcher(OPENAI_CODEX_MODEL_PREFIX);
 
 async function resolveOpenAIRuntimeCredentials(
   params: ResolveProviderRuntimeParams,
 ): Promise<ResolvedModelRuntimeCredentials> {
   const codex = await resolveCodexCredentials();
-  const agentId = String(params.agentId || '').trim() || DEFAULT_AGENT_ID;
+  const agentId = normalizeAgentId(params.agentId);
   return {
     provider: 'openai-codex',
     apiKey: codex.apiKey,

--- a/src/providers/openrouter.ts
+++ b/src/providers/openrouter.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import { OPENROUTER_BASE_URL } from '../config/config.js';
 import {
   discoverOpenRouterModels,
@@ -10,6 +9,7 @@ import {
   OPENROUTER_MODEL_PREFIX,
   readOpenRouterApiKey,
 } from './openrouter-utils.js';
+import { createModelMatcher, normalizeAgentId } from './provider-utils.js';
 import type {
   AIProvider,
   ResolvedModelRuntimeCredentials,
@@ -17,17 +17,12 @@ import type {
 } from './types.js';
 import { normalizeBaseUrl } from './utils.js';
 
-export function isOpenRouterModel(model: string): boolean {
-  return String(model || '')
-    .trim()
-    .toLowerCase()
-    .startsWith(OPENROUTER_MODEL_PREFIX);
-}
+export const isOpenRouterModel = createModelMatcher(OPENROUTER_MODEL_PREFIX);
 
 async function resolveOpenRouterRuntimeCredentials(
   params: ResolveProviderRuntimeParams,
 ): Promise<ResolvedModelRuntimeCredentials> {
-  const agentId = String(params.agentId || '').trim() || DEFAULT_AGENT_ID;
+  const agentId = normalizeAgentId(params.agentId);
   await discoverOpenRouterModels();
   return {
     provider: 'openrouter',

--- a/src/providers/provider-utils.ts
+++ b/src/providers/provider-utils.ts
@@ -5,11 +5,14 @@ import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
  * provider prefix (case-insensitive, trimmed).
  */
 export function createModelMatcher(prefix: string): (model: string) => boolean {
+  const normalizedPrefix = String(prefix || '')
+    .trim()
+    .toLowerCase();
   return (model: string): boolean =>
     String(model || '')
       .trim()
       .toLowerCase()
-      .startsWith(prefix);
+      .startsWith(normalizedPrefix);
 }
 
 /**

--- a/src/providers/provider-utils.ts
+++ b/src/providers/provider-utils.ts
@@ -1,0 +1,20 @@
+import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
+
+/**
+ * Returns a function that checks whether a model string starts with the given
+ * provider prefix (case-insensitive, trimmed).
+ */
+export function createModelMatcher(prefix: string): (model: string) => boolean {
+  return (model: string): boolean =>
+    String(model || '')
+      .trim()
+      .toLowerCase()
+      .startsWith(prefix);
+}
+
+/**
+ * Normalizes a raw agentId value, falling back to DEFAULT_AGENT_ID.
+ */
+export function normalizeAgentId(raw: string | undefined | null): string {
+  return String(raw || '').trim() || DEFAULT_AGENT_ID;
+}

--- a/tests/provider-utils.test.ts
+++ b/tests/provider-utils.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createModelMatcher,
+  normalizeAgentId,
+} from '../src/providers/provider-utils.ts';
+
+describe('createModelMatcher', () => {
+  it('matches a model that starts with the prefix', () => {
+    const match = createModelMatcher('openai/');
+    expect(match('openai/gpt-4o')).toBe(true);
+  });
+
+  it('rejects a model that does not start with the prefix', () => {
+    const match = createModelMatcher('openai/');
+    expect(match('anthropic/claude-3')).toBe(false);
+  });
+
+  it('is case-insensitive', () => {
+    const match = createModelMatcher('OpenAI/');
+    expect(match('openai/gpt-4o')).toBe(true);
+    expect(match('OPENAI/GPT-4O')).toBe(true);
+  });
+
+  it('trims whitespace from both prefix and model', () => {
+    const match = createModelMatcher('  openai/ ');
+    expect(match(' openai/gpt-4o ')).toBe(true);
+  });
+
+  it('handles empty or nullish model gracefully', () => {
+    const match = createModelMatcher('openai/');
+    expect(match('')).toBe(false);
+    // biome-ignore lint/suspicious/noExplicitAny: testing runtime safety with nullish values
+    expect(match(null as any)).toBe(false);
+    // biome-ignore lint/suspicious/noExplicitAny: testing runtime safety with nullish values
+    expect(match(undefined as any)).toBe(false);
+  });
+
+  it('handles empty prefix (matches everything)', () => {
+    const match = createModelMatcher('');
+    expect(match('anything')).toBe(true);
+  });
+});
+
+describe('normalizeAgentId', () => {
+  it('returns the trimmed value when present', () => {
+    expect(normalizeAgentId('  my-agent  ')).toBe('my-agent');
+  });
+
+  it('falls back to DEFAULT_AGENT_ID for empty string', () => {
+    expect(normalizeAgentId('')).toBe('main');
+  });
+
+  it('falls back to DEFAULT_AGENT_ID for null', () => {
+    expect(normalizeAgentId(null)).toBe('main');
+  });
+
+  it('falls back to DEFAULT_AGENT_ID for undefined', () => {
+    expect(normalizeAgentId(undefined)).toBe('main');
+  });
+
+  it('falls back to DEFAULT_AGENT_ID for whitespace-only string', () => {
+    expect(normalizeAgentId('   ')).toBe('main');
+  });
+});


### PR DESCRIPTION
## Summary
- Extract `createModelMatcher(prefix)` and `normalizeAgentId(raw)` into new `src/providers/provider-utils.ts`
- Replace duplicated model-prefix detection in 5 provider files (anthropic, openai, mistral, huggingface, openrouter)
- Replace duplicated agentId normalization in 5 provider files (openai, mistral, huggingface, openrouter, local-ollama)
- Intentionally skips ollama's model matcher (custom fallback logic) and `isAnthropicProviderModel` (complex multi-pattern matching)

## Test plan
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Biome lint/format passes
- [ ] Verify existing provider tests still pass in CI
- [ ] Smoke-test model routing with each provider prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)