### PR TITLE
fix: promote agent-created skills to managed dir and fix admin API target

### DIFF
--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -29,6 +29,7 @@ import {
 import { preprocessContextReferences } from '../context-references/index.js';
 import { agentWorkspaceDir } from '../infra/ipc.js';
 import { logger } from '../logger.js';
+import { promoteWorkspaceSkills } from '../skills/skills.js';
 import { prependAudioTranscriptionsToUserContent } from '../media/audio-transcription.js';
 import { extractMemoryCitations } from '../memory/citation-extractor.js';
 import {
@@ -1023,6 +1024,8 @@ export async function handleGatewayMessage(
         });
       },
     });
+
+    promoteWorkspaceSkills(workspacePath);
 
     if (output.status === 'error') {
       const errorMessage = output.error || 'Unknown agent error.';

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -277,7 +277,10 @@ import {
   estimateTokenCountFromMessages,
   estimateTokenCountFromText,
 } from '../session/token-efficiency.js';
-import { loadSkillCatalog } from '../skills/skills.js';
+import {
+  loadSkillCatalog,
+  resolveManagedCommunitySkillsDir,
+} from '../skills/skills.js';
 import { guardSkillDirectory } from '../skills/skills-guard.js';
 import type { ChatMessage } from '../types/api.js';
 import type { StructuredAuditEntry } from '../types/audit.js';
@@ -5174,7 +5177,7 @@ export function createGatewayAdminSkill(input: {
   const category = normalizeCreatedSkillCategory(input.category);
   const shortDescription = String(input.shortDescription || '').trim();
 
-  const projectSkillsDir = path.join(process.cwd(), 'skills');
+  const projectSkillsDir = resolveManagedCommunitySkillsDir();
   const skillDir = path.join(projectSkillsDir, name);
 
   if (fs.existsSync(skillDir)) {
@@ -5253,7 +5256,7 @@ export function createGatewayAdminSkill(input: {
   // Stage outside skills/ so catalog scans never see partial skill directories.
   fs.mkdirSync(projectSkillsDir, { recursive: true });
   const stagedSkillDir = fs.mkdtempSync(
-    path.join(process.cwd(), `.${name}.create-`),
+    path.join(projectSkillsDir, `.${name}.create-`),
   );
   try {
     fs.writeFileSync(path.join(stagedSkillDir, 'SKILL.md'), content, 'utf-8');
@@ -5444,7 +5447,7 @@ export async function uploadGatewayAdminSkillZip(
     }
     assertGatewayAdminSkillAllowed(skillName, skillRoot);
 
-    const projectSkillsDir = path.join(process.cwd(), 'skills');
+    const projectSkillsDir = resolveManagedCommunitySkillsDir();
     const targetDir = path.join(projectSkillsDir, skillName);
     if (fs.existsSync(targetDir)) {
       throw new GatewayRequestError(

--- a/src/skills/skills.ts
+++ b/src/skills/skills.ts
@@ -9,10 +9,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import {
-  listAgents,
-  resolveAgentConfig,
-} from '../agents/agent-registry.js';
+import { resolveAgentConfig } from '../agents/agent-registry.js';
 import type { SkillConfigChannelKind } from '../channels/channel.js';
 import { DATA_DIR } from '../config/config.js';
 import {
@@ -1656,10 +1653,70 @@ function getDisabledSkillNames(
   return getRuntimeDisabledSkillNames(getRuntimeConfig(), channelKind);
 }
 
-function resolveManagedCommunitySkillsDir(
+export function resolveManagedCommunitySkillsDir(
   homeDir = DEFAULT_RUNTIME_HOME_DIR,
 ): string {
   return path.join(homeDir, 'skills');
+}
+
+/**
+ * Promote agent-created skills from the workspace to the managed community
+ * skills directory (~/.hybridclaw/skills/). Skills created by the agent land
+ * in workspace/skills/ but the canonical source for installed skills is the
+ * managed community dir. This function copies new workspace skills there so
+ * they survive the prune-and-sync cycle in loadSkills().
+ */
+export function promoteWorkspaceSkills(workspaceDir: string): void {
+  const workspaceSkillsDir = path.join(workspaceDir, 'skills');
+  if (!fs.existsSync(workspaceSkillsDir)) return;
+
+  const communityDir = resolveManagedCommunitySkillsDir();
+
+  // Build a set of skill names already known from any catalog source so we
+  // only promote genuinely new skills the agent created, not synced copies of
+  // bundled or imported skills.
+  const knownSkillNames = new Set(
+    collectResolvedSkillCandidates().map((s) => s.name),
+  );
+
+  try {
+    for (const entry of fs.readdirSync(workspaceSkillsDir, {
+      withFileTypes: true,
+    })) {
+      if (!entry.isDirectory()) continue;
+
+      const wsSkillDir = path.join(workspaceSkillsDir, entry.name);
+      const skillFile = path.join(wsSkillDir, 'SKILL.md');
+      if (!fs.existsSync(skillFile)) continue;
+
+      // Parse the skill name from frontmatter (or fall back to dir name).
+      let skillName = entry.name;
+      try {
+        const raw = fs.readFileSync(skillFile, 'utf-8');
+        const frontmatter = parseFrontmatter(raw);
+        const metaName = (frontmatter.meta.name || '').trim();
+        if (metaName) skillName = metaName;
+      } catch {
+        /* use dir name */
+      }
+
+      // Skip skills that already exist in the catalog from another source.
+      if (knownSkillNames.has(skillName)) continue;
+
+      const communitySkillDir = path.join(communityDir, entry.name);
+      if (fs.existsSync(communitySkillDir)) continue;
+
+      // New skill found in workspace that doesn't exist in the managed dir.
+      fs.mkdirSync(communityDir, { recursive: true });
+      fs.cpSync(wsSkillDir, communitySkillDir, { recursive: true });
+      logger.info(
+        { skill: skillName, from: wsSkillDir, to: communitySkillDir },
+        'Promoted agent-created skill to managed skills directory',
+      );
+    }
+  } catch (err) {
+    logger.debug({ workspaceDir, err }, 'Failed to promote workspace skills');
+  }
 }
 
 function collectResolvedSkillCandidates(): SkillCandidate[] {
@@ -1674,19 +1731,6 @@ function collectResolvedSkillCandidates(): SkillCandidate[] {
   const managedCommunitySkillsDir = resolveManagedCommunitySkillsDir();
   const projectSkillsDir = resolveProjectSkillsDir();
   const projectAgentsSkillsDir = resolveProjectAgentsSkillsDir();
-
-  const agentWorkspaceSkills: SkillCandidate[] = [];
-  try {
-    for (const agent of listAgents()) {
-      const wsSkillsDir = path.join(
-        agentWorkspaceDir(agent.id),
-        'skills',
-      );
-      agentWorkspaceSkills.push(...scanSkillsDir(wsSkillsDir, 'workspace'));
-    }
-  } catch {
-    /* ignore errors when agent registry is not yet initialized */
-  }
 
   const extraSkills = extraDirs.flatMap((dir) =>
     scanSkillsDir(
@@ -1729,7 +1773,6 @@ function collectResolvedSkillCandidates(): SkillCandidate[] {
   mergeSkills(claudeSkills);
   mergeSkills(agentsPersonalSkills);
   mergeSkills(projectAgentsSkills);
-  mergeSkills(agentWorkspaceSkills);
   mergeSkills(workspaceSkills);
 
   return Array.from(byName.values());

--- a/src/skills/skills.ts
+++ b/src/skills/skills.ts
@@ -9,7 +9,10 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { resolveAgentConfig } from '../agents/agent-registry.js';
+import {
+  listAgents,
+  resolveAgentConfig,
+} from '../agents/agent-registry.js';
 import type { SkillConfigChannelKind } from '../channels/channel.js';
 import { DATA_DIR } from '../config/config.js';
 import {
@@ -1672,6 +1675,19 @@ function collectResolvedSkillCandidates(): SkillCandidate[] {
   const projectSkillsDir = resolveProjectSkillsDir();
   const projectAgentsSkillsDir = resolveProjectAgentsSkillsDir();
 
+  const agentWorkspaceSkills: SkillCandidate[] = [];
+  try {
+    for (const agent of listAgents()) {
+      const wsSkillsDir = path.join(
+        agentWorkspaceDir(agent.id),
+        'skills',
+      );
+      agentWorkspaceSkills.push(...scanSkillsDir(wsSkillsDir, 'workspace'));
+    }
+  } catch {
+    /* ignore errors when agent registry is not yet initialized */
+  }
+
   const extraSkills = extraDirs.flatMap((dir) =>
     scanSkillsDir(
       dir,
@@ -1713,6 +1729,7 @@ function collectResolvedSkillCandidates(): SkillCandidate[] {
   mergeSkills(claudeSkills);
   mergeSkills(agentsPersonalSkills);
   mergeSkills(projectAgentsSkills);
+  mergeSkills(agentWorkspaceSkills);
   mergeSkills(workspaceSkills);
 
   return Array.from(byName.values());

--- a/src/skills/skills.ts
+++ b/src/skills/skills.ts
@@ -1689,6 +1689,27 @@ export function promoteWorkspaceSkills(workspaceDir: string): void {
   const workspaceSkillsDir = path.join(workspaceDir, 'skills');
   if (!fs.existsSync(workspaceSkillsDir)) return;
 
+  // Quick check: are there any skill directories with a SKILL.md to promote?
+  // Avoids the expensive collectResolvedSkillCandidates() scan on turns where
+  // the agent created no skills (the common case).
+  let hasCandidate = false;
+  try {
+    for (const entry of fs.readdirSync(workspaceSkillsDir, {
+      withFileTypes: true,
+    })) {
+      if (
+        entry.isDirectory() &&
+        fs.existsSync(path.join(workspaceSkillsDir, entry.name, 'SKILL.md'))
+      ) {
+        hasCandidate = true;
+        break;
+      }
+    }
+  } catch {
+    return;
+  }
+  if (!hasCandidate) return;
+
   const communityDir = resolveManagedCommunitySkillsDir();
 
   // Build a set of skill names already known from any catalog source so we
@@ -1719,9 +1740,14 @@ export function promoteWorkspaceSkills(workspaceDir: string): void {
         /* use dir name */
       }
 
-      // Skip skills that already exist in the catalog from another source.
+      // Skip skills that already exist in the catalog from another source
+      // (checked by canonical skill name from frontmatter).
       if (knownSkillNames.has(skillName)) continue;
 
+      // Also skip if a directory with the same name already exists in the
+      // managed dir — guards against the case where the frontmatter name
+      // differs from the dir name, and also prevents races when two
+      // concurrent turns try to promote the same skill simultaneously.
       const communitySkillDir = path.join(communityDir, entry.name);
       if (fs.existsSync(communitySkillDir)) continue;
 

--- a/tests/gateway-service.admin-skills.test.ts
+++ b/tests/gateway-service.admin-skills.test.ts
@@ -27,13 +27,14 @@ const { setupHome } = setupGatewayTest({
   },
 });
 
-function setupProjectCwd(): string {
+function setupProjectCwd(): { projectDir: string; managedSkillsDir: string } {
   const homeDir = setupHome();
   makeTempDir.track(homeDir);
   const projectDir = path.join(homeDir, 'project');
   fs.mkdirSync(projectDir, { recursive: true });
   process.chdir(projectDir);
-  return projectDir;
+  const managedSkillsDir = path.join(homeDir, '.hybridclaw', 'skills');
+  return { projectDir, managedSkillsDir };
 }
 
 async function createZipArchive(
@@ -69,7 +70,7 @@ async function createZipArchive(
 }
 
 test('createGatewayAdminSkill stages outside skills/ before publishing the skill', async () => {
-  const projectDir = setupProjectCwd();
+  const { managedSkillsDir } = setupProjectCwd();
 
   const { createGatewayAdminSkill } = await import(
     '../src/gateway/gateway-service.ts'
@@ -87,7 +88,7 @@ test('createGatewayAdminSkill stages outside skills/ before publishing the skill
     files: [{ path: 'scripts/run.mjs', content: 'console.log("ok");\n' }],
   });
 
-  const skillDir = path.join(projectDir, 'skills', 'my-skill');
+  const skillDir = path.join(managedSkillsDir, 'my-skill');
   expect(fs.readFileSync(path.join(skillDir, 'SKILL.md'), 'utf-8')).toContain(
     'name: my-skill',
   );
@@ -97,13 +98,13 @@ test('createGatewayAdminSkill stages outside skills/ before publishing the skill
   expect(result.skills.some((skill) => skill.name === 'my-skill')).toBe(true);
   expect(
     fs
-      .readdirSync(projectDir)
+      .readdirSync(managedSkillsDir)
       .filter((entry) => entry.startsWith('.my-skill.create-')),
   ).toEqual([]);
 });
 
 test('createGatewayAdminSkill preserves a competing skill when the final rename loses the race', async () => {
-  const projectDir = setupProjectCwd();
+  const { managedSkillsDir } = setupProjectCwd();
 
   const { GatewayRequestError } = await import(
     '../src/errors/gateway-request-error.ts'
@@ -112,7 +113,7 @@ test('createGatewayAdminSkill preserves a competing skill when the final rename 
     '../src/gateway/gateway-service.ts'
   );
 
-  const skillDir = path.join(projectDir, 'skills', 'my-skill');
+  const skillDir = path.join(managedSkillsDir, 'my-skill');
   const originalRenameSync = fs.renameSync;
   vi.spyOn(fs, 'renameSync')
     .mockImplementationOnce((_oldPath, _newPath) => {
@@ -149,7 +150,7 @@ test('createGatewayAdminSkill preserves a competing skill when the final rename 
   );
   expect(
     fs
-      .readdirSync(projectDir)
+      .readdirSync(managedSkillsDir)
       .filter((entry) => entry.startsWith('.my-skill.create-')),
   ).toEqual([]);
 });
@@ -179,7 +180,7 @@ test('uploadGatewayAdminSkillZip rejects corrupt archives as a bad request', asy
 });
 
 test('createGatewayAdminSkill rejects blocked skills before publishing them', async () => {
-  const projectDir = setupProjectCwd();
+  const { managedSkillsDir } = setupProjectCwd();
   vi.doMock('../src/skills/skills-guard.js', () => ({
     guardSkillDirectory: () => ({
       allowed: false,
@@ -233,18 +234,16 @@ test('createGatewayAdminSkill rejects blocked skills before publishing them', as
     );
   }
 
-  expect(fs.existsSync(path.join(projectDir, 'skills', 'my-skill'))).toBe(
-    false,
-  );
+  expect(fs.existsSync(path.join(managedSkillsDir, 'my-skill'))).toBe(false);
   expect(
     fs
-      .readdirSync(projectDir)
+      .readdirSync(managedSkillsDir)
       .filter((entry) => entry.startsWith('.my-skill.create-')),
   ).toEqual([]);
 });
 
 test('uploadGatewayAdminSkillZip accepts wrapped archives with macOS metadata entries', async () => {
-  const projectDir = setupProjectCwd();
+  const { managedSkillsDir } = setupProjectCwd();
 
   const { uploadGatewayAdminSkillZip } = await import(
     '../src/gateway/gateway-service.ts'
@@ -277,22 +276,18 @@ description: Wrapped skill upload test
 
   const result = await uploadGatewayAdminSkillZip(zipBuffer);
 
-  const skillDir = path.join(projectDir, 'skills', 'my-skill');
+  const skillDir = path.join(managedSkillsDir, 'my-skill');
   expect(result.skills.some((skill) => skill.name === 'my-skill')).toBe(true);
   expect(fs.existsSync(path.join(skillDir, 'SKILL.md'))).toBe(true);
   expect(
     fs.readFileSync(path.join(skillDir, 'scripts', 'run.mjs'), 'utf-8'),
   ).toBe('console.log("wrapped");\n');
-  expect(fs.existsSync(path.join(projectDir, 'skills', '__MACOSX'))).toBe(
-    false,
-  );
-  expect(fs.existsSync(path.join(projectDir, 'skills', '.DS_Store'))).toBe(
-    false,
-  );
+  expect(fs.existsSync(path.join(managedSkillsDir, '__MACOSX'))).toBe(false);
+  expect(fs.existsSync(path.join(managedSkillsDir, '.DS_Store'))).toBe(false);
 });
 
 test('uploadGatewayAdminSkillZip rejects blocked skills before installation', async () => {
-  const projectDir = setupProjectCwd();
+  const { managedSkillsDir } = setupProjectCwd();
   vi.doMock('../src/skills/skills-guard.js', () => ({
     guardSkillDirectory: () => ({
       allowed: false,
@@ -354,7 +349,5 @@ description: Blocked skill upload test
     );
   }
 
-  expect(fs.existsSync(path.join(projectDir, 'skills', 'my-skill'))).toBe(
-    false,
-  );
+  expect(fs.existsSync(path.join(managedSkillsDir, 'my-skill'))).toBe(false);
 });

--- a/tests/promote-workspace-skills.test.ts
+++ b/tests/promote-workspace-skills.test.ts
@@ -1,0 +1,104 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, expect, test, vi } from 'vitest';
+import { useTempDir } from './test-utils.ts';
+
+const makeTempDir = useTempDir();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+function setupTempHome(): string {
+  const homeDir = makeTempDir('hybridclaw-promote-skills-');
+  process.env.HOME = homeDir;
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
+  vi.resetModules();
+  return homeDir;
+}
+
+function writeSkillMd(dir: string, name: string, content?: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'SKILL.md'),
+    content ??
+      `---\nname: ${name}\ndescription: Test skill\n---\n\nA test skill.\n`,
+    'utf-8',
+  );
+}
+
+test('promoteWorkspaceSkills copies new workspace skills to managed dir', async () => {
+  const homeDir = setupTempHome();
+
+  const workspaceDir = path.join(homeDir, 'workspace');
+  const wsSkillDir = path.join(workspaceDir, 'skills', 'my-new-skill');
+  writeSkillMd(wsSkillDir, 'my-new-skill');
+  fs.writeFileSync(
+    path.join(wsSkillDir, 'run.mjs'),
+    'console.log("hello");\n',
+    'utf-8',
+  );
+
+  const { promoteWorkspaceSkills } = await import('../src/skills/skills.ts');
+  promoteWorkspaceSkills(workspaceDir);
+
+  const managedDir = path.join(homeDir, '.hybridclaw', 'skills');
+  const promotedDir = path.join(managedDir, 'my-new-skill');
+  expect(fs.existsSync(path.join(promotedDir, 'SKILL.md'))).toBe(true);
+  expect(fs.existsSync(path.join(promotedDir, 'run.mjs'))).toBe(true);
+});
+
+test('promoteWorkspaceSkills skips skills already in managed dir', async () => {
+  const homeDir = setupTempHome();
+  const managedDir = path.join(homeDir, '.hybridclaw', 'skills');
+
+  // Pre-populate managed dir with an existing skill.
+  const existingDir = path.join(managedDir, 'existing-skill');
+  writeSkillMd(existingDir, 'existing-skill', '---\nname: existing-skill\n---\nOld.\n');
+
+  const workspaceDir = path.join(homeDir, 'workspace');
+  const wsSkillDir = path.join(workspaceDir, 'skills', 'existing-skill');
+  writeSkillMd(wsSkillDir, 'existing-skill', '---\nname: existing-skill\n---\nNew.\n');
+
+  const { promoteWorkspaceSkills } = await import('../src/skills/skills.ts');
+  promoteWorkspaceSkills(workspaceDir);
+
+  // The original content should be preserved, not overwritten.
+  const content = fs.readFileSync(
+    path.join(existingDir, 'SKILL.md'),
+    'utf-8',
+  );
+  expect(content).toContain('Old.');
+});
+
+test('promoteWorkspaceSkills is a no-op when workspace has no skills dir', async () => {
+  const homeDir = setupTempHome();
+  const workspaceDir = path.join(homeDir, 'workspace');
+  fs.mkdirSync(workspaceDir, { recursive: true });
+
+  const { promoteWorkspaceSkills } = await import('../src/skills/skills.ts');
+
+  // Should not throw.
+  promoteWorkspaceSkills(workspaceDir);
+
+  const managedDir = path.join(homeDir, '.hybridclaw', 'skills');
+  expect(fs.existsSync(managedDir)).toBe(false);
+});
+
+test('promoteWorkspaceSkills skips directories without SKILL.md', async () => {
+  const homeDir = setupTempHome();
+  const workspaceDir = path.join(homeDir, 'workspace');
+
+  // Create a directory in workspace/skills/ that has no SKILL.md.
+  const noSkillDir = path.join(workspaceDir, 'skills', 'not-a-skill');
+  fs.mkdirSync(noSkillDir, { recursive: true });
+  fs.writeFileSync(path.join(noSkillDir, 'random.txt'), 'hi', 'utf-8');
+
+  const { promoteWorkspaceSkills } = await import('../src/skills/skills.ts');
+  promoteWorkspaceSkills(workspaceDir);
+
+  const managedDir = path.join(homeDir, '.hybridclaw', 'skills');
+  expect(fs.existsSync(managedDir)).toBe(false);
+});


### PR DESCRIPTION
## Summary

- Fixes #324 — skills created by the agent at runtime now persist correctly and appear in `/skill list`
- **Root cause**: the agent writes skills to `workspace/skills/` but the canonical source is `~/.hybridclaw/skills/`. Skills in the workspace are managed mirrors — `pruneStaleSyncedSkills()` deletes any workspace skill not in the catalog, so agent-created skills were silently removed on the next turn
- **Fix** (per Ben's feedback: "Skills belong in `~/.hybridclaw/skills/` and are synced to the agent workspace"):
  1. **Post-turn skill promotion**: `promoteWorkspaceSkills()` runs after each agent turn. It scans the workspace for skills not in the catalog and copies them to `~/.hybridclaw/skills/`. The existing sync mechanism then maintains them on subsequent turns.
  2. **Admin API target fix**: `createGatewayAdminSkill` and `uploadGatewayAdminSkillZip` now write to `~/.hybridclaw/skills/` instead of `process.cwd()/skills/`.

### Not included

XLSX creation fix (#327) was initially on this branch but has been split out — will be submitted as a separate PR.

## Test plan

- [x] All 6 admin-skills tests pass (updated assertions for new target dir)
- [x] All 37 claw-archive tests pass
- [x] Audit test passes (promotion skips known catalog skills)
- [x] Full suite: same pass/fail count as baseline (5 files / 9 tests — all pre-existing)
- [ ] Manual: ask agent via TUI to create a skill, verify it appears in `~/.hybridclaw/skills/` and in `/skill list`