### PR TITLE
feat: add bundled xlsx creation script

### DIFF
--- a/skills/xlsx/SKILL.md
+++ b/skills/xlsx/SKILL.md
@@ -23,7 +23,7 @@ Use this skill whenever the user asks to create, inspect, analyze, or edit an `.
 
 ## Default Workflow
 
-1. Use a workspace CommonJS `.cjs` script with `require("xlsx-populate")` for workbook creation and structural edits.
+1. For creation tasks, use `skills/xlsx/scripts/create_xlsx.cjs` to create a new workbook from headers/rows or JSON data. Fall back to a workspace `.cjs` script only when the bundled script cannot handle the requirement.
 2. Use `skills/xlsx/scripts/import_delimited.cjs` for messy CSV or TSV inputs when it saves time, then polish the workbook with `xlsx-populate`.
 3. Do table reshaping in plain JavaScript, then write the final workbook with `xlsx-populate`.
 4. After meaningful formula edits, run LibreOffice-backed recalculation when `soffice` is available so cached values and error checks are current.
@@ -40,6 +40,7 @@ Use this skill whenever the user asks to create, inspect, analyze, or edit an `.
 - Preserve existing worksheets, named ranges, freeze panes, filters, and formats unless the user asked for a redesign.
 - Prefer `.xlsx` as the final deliverable. Only fall back to CSV/TSV if the user explicitly wants a flat export.
 - Use number formats, explicit column widths, alignment, and header styling for user-facing workbooks.
+- For creation tasks ("make a spreadsheet", "create an xlsx"), always use `skills/xlsx/scripts/create_xlsx.cjs` first. Only write a custom workspace script if the user's requirements exceed what the bundled script supports.
 - Treat `skills/` as bundled tooling. Do not write generated task scripts under `skills/xlsx/` or `skills/office/` for normal workbook jobs.
 - Put new helper scripts in workspace `scripts/` or the workspace root, then run them from there. Use `skills/xlsx/scripts/...` and `skills/office/...` only as shipped helper commands.
 
@@ -50,6 +51,7 @@ Use this skill whenever the user asks to create, inspect, analyze, or edit an `.
 ## Useful Commands
 
 ```bash
+node skills/xlsx/scripts/create_xlsx.cjs output.xlsx --headers "Name,Age,City" --rows "Alice,30,NYC;Bob,25,LA" --json
 node skills/xlsx/scripts/recalc.cjs workbook.xlsx --json
 node skills/xlsx/scripts/import_delimited.cjs raw.csv cleaned.xlsx --json
 ```
@@ -86,6 +88,30 @@ async function main() {
 
 main();
 ```
+
+## Create a New Workbook
+
+Use `skills/xlsx/scripts/create_xlsx.cjs` to create a professionally styled `.xlsx` from scratch. This is the preferred method for creation tasks.
+
+### With headers and rows
+
+```bash
+node skills/xlsx/scripts/create_xlsx.cjs output.xlsx --headers "Name,Age,City" --rows "Alice,30,NYC;Bob,25,LA" --json
+```
+
+### With JSON data
+
+```bash
+node skills/xlsx/scripts/create_xlsx.cjs output.xlsx --json-data '[{"Name":"Alice","Age":30},{"Name":"Bob","Age":25}]' --json
+```
+
+### With formulas
+
+```bash
+node skills/xlsx/scripts/create_xlsx.cjs output.xlsx --headers "Revenue,Cost,Profit" --rows "120000,45000,=A2-B2" --sheet-name "Summary" --json
+```
+
+The script applies professional styling automatically: bold headers with fill color, freeze panes at row 2, auto-filter, and auto-sized column widths. Numbers are auto-detected and written as numbers, not strings. Values starting with `=` are written as formulas.
 
 ## CSV / TSV Import
 

--- a/skills/xlsx/SKILL.md
+++ b/skills/xlsx/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: xlsx
-description: Inspect, create, clean, analyze, and format `.xlsx` workbooks and tabular data with Node.js and XlsxPopulate.
+description: Create, edit, inspect, and analyze `.xlsx` spreadsheets and Excel workbooks. Use this skill whenever the user asks to make a spreadsheet, generate an Excel file, create a table as xlsx, import CSV/TSV to xlsx, or work with any `.xlsx` file.
 user-invocable: true
 disable-model-invocation: false
 requires:
@@ -9,11 +9,14 @@ requires:
 metadata:
   hybridclaw:
     category: office
-    short_description: "XLSX editing and analysis."
+    short_description: "Create and edit Excel spreadsheets (.xlsx)."
     tags:
       - office
       - spreadsheet
       - xlsx
+      - excel
+      - table
+      - csv
     related_skills:
       - docx
 ---

--- a/skills/xlsx/scripts/create_xlsx.cjs
+++ b/skills/xlsx/scripts/create_xlsx.cjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const XlsxPopulate = require('xlsx-populate');
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  if (args.length < 1) {
+    throw new Error(
+      'Usage: node skills/xlsx/scripts/create_xlsx.cjs <output_path> --headers "A,B,C" --rows "1,2,3;4,5,6" [--sheet-name "Sheet1"] [--json-data \'[{"A":1}]\'] [--json]',
+    );
+  }
+
+  const options = {
+    outputPath: '',
+    headers: null,
+    rows: null,
+    jsonData: null,
+    sheetName: 'Sheet1',
+    asJson: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--json') {
+      options.asJson = true;
+      continue;
+    }
+    if (arg === '--headers' && args[index + 1]) {
+      options.headers = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--rows' && args[index + 1]) {
+      options.rows = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--json-data' && args[index + 1]) {
+      options.jsonData = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--sheet-name' && args[index + 1]) {
+      options.sheetName = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (!options.outputPath && !arg.startsWith('--')) {
+      options.outputPath = path.resolve(arg);
+    }
+  }
+
+  if (!options.outputPath) {
+    throw new Error('Output path is required.');
+  }
+
+  if (!options.headers && !options.jsonData) {
+    throw new Error(
+      'Either --headers (with optional --rows) or --json-data is required.',
+    );
+  }
+
+  return options;
+}
+
+function parseValue(value) {
+  const trimmed = String(value ?? '').trim();
+  if (!trimmed) return '';
+
+  const normalized = trimmed.replace(/,/g, '');
+  if (/^-?\d+(\.\d+)?$/.test(normalized)) {
+    return normalized.includes('.')
+      ? Number.parseFloat(normalized)
+      : Number.parseInt(normalized, 10);
+  }
+
+  return trimmed;
+}
+
+function normalizeSheetName(name) {
+  const cleaned = String(name || 'Sheet1')
+    .replace(/[\\/*?:[\]]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return cleaned.slice(0, 31) || 'Sheet1';
+}
+
+function formatHeaderRange(range) {
+  range.style({
+    bold: true,
+    horizontalAlignment: 'center',
+    fill: 'D9EAF7',
+  });
+}
+
+function setColumnWidths(worksheet, rowCount, columnCount) {
+  for (let columnIndex = 1; columnIndex <= columnCount; columnIndex += 1) {
+    let maxLength = 10;
+    for (let rowIndex = 1; rowIndex <= rowCount; rowIndex += 1) {
+      const cell = worksheet.cell(rowIndex, columnIndex);
+      const raw = cell.formula() || cell.value();
+      const text = raw == null ? '' : String(raw);
+      maxLength = Math.max(maxLength, Math.min(40, text.length + 2));
+    }
+    worksheet.column(columnIndex).width(maxLength);
+  }
+}
+
+function setCellValue(cell, value) {
+  const strValue = String(value ?? '').trim();
+  if (strValue.startsWith('=')) {
+    cell.formula(strValue.slice(1));
+    return;
+  }
+  const parsed = parseValue(value);
+  cell.value(parsed);
+}
+
+function emit(payload, asJson) {
+  if (asJson) {
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    return;
+  }
+  if (payload.success) {
+    process.stdout.write(`${payload.output_path}\n`);
+    return;
+  }
+  process.stdout.write(`${payload.error || 'Creation failed.'}\n`);
+}
+
+async function main() {
+  let options;
+  try {
+    options = parseArgs(process.argv);
+  } catch (error) {
+    emit(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      true,
+    );
+    return 1;
+  }
+
+  let headers = [];
+  let dataRows = [];
+
+  if (options.jsonData) {
+    let parsed;
+    try {
+      parsed = JSON.parse(options.jsonData);
+    } catch (error) {
+      emit(
+        {
+          success: false,
+          error: `Invalid JSON data: ${error instanceof Error ? error.message : String(error)}`,
+        },
+        options.asJson,
+      );
+      return 1;
+    }
+
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+      emit(
+        {
+          success: false,
+          error: 'JSON data must be a non-empty array of objects.',
+        },
+        options.asJson,
+      );
+      return 1;
+    }
+
+    const keySet = new Set();
+    for (const obj of parsed) {
+      if (obj && typeof obj === 'object') {
+        for (const key of Object.keys(obj)) {
+          keySet.add(key);
+        }
+      }
+    }
+    headers = [...keySet];
+    dataRows = parsed.map((obj) => headers.map((key) => obj[key] ?? ''));
+  } else {
+    headers = options.headers.split(',').map((h) => h.trim());
+    if (options.rows) {
+      dataRows = options.rows.split(';').map((row) => row.split(','));
+    }
+  }
+
+  const workbook = await XlsxPopulate.fromBlankAsync();
+  const worksheet = workbook.sheet(0);
+  worksheet.name(normalizeSheetName(options.sheetName));
+
+  const columnCount = headers.length;
+
+  // Write headers
+  for (let colIdx = 0; colIdx < headers.length; colIdx += 1) {
+    worksheet.cell(1, colIdx + 1).value(headers[colIdx]);
+  }
+
+  formatHeaderRange(worksheet.range(1, 1, 1, Math.max(1, columnCount)));
+  worksheet.freezePanes('A2');
+  worksheet.autoFilter(worksheet.range(1, 1, 1, Math.max(1, columnCount)));
+
+  // Write data rows
+  for (let rowIdx = 0; rowIdx < dataRows.length; rowIdx += 1) {
+    const row = dataRows[rowIdx];
+    for (let colIdx = 0; colIdx < row.length; colIdx += 1) {
+      setCellValue(worksheet.cell(rowIdx + 2, colIdx + 1), row[colIdx]);
+    }
+  }
+
+  const totalRows = 1 + dataRows.length;
+  setColumnWidths(worksheet, totalRows, Math.max(1, columnCount));
+
+  fs.mkdirSync(path.dirname(options.outputPath), { recursive: true });
+  await workbook.toFileAsync(options.outputPath);
+
+  emit(
+    {
+      success: true,
+      sheet_name: normalizeSheetName(options.sheetName),
+      row_count: dataRows.length,
+      column_count: columnCount,
+      output_path: options.outputPath,
+    },
+    options.asJson,
+  );
+  return 0;
+}
+
+main().then(
+  (code) => {
+    process.exitCode = code;
+  },
+  (error) => {
+    emit(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      true,
+    );
+    process.exitCode = 1;
+  },
+);

--- a/tests/xlsx-skill-node.test.ts
+++ b/tests/xlsx-skill-node.test.ts
@@ -2,7 +2,7 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import XlsxPopulate from 'xlsx-populate';
 import { useTempDir } from './test-utils.ts';
 
@@ -65,4 +65,158 @@ test('xlsx import script converts delimited input into a formatted workbook', as
   expect(sheet.cell('A1').style('bold')).toBe(true);
   expect(sheet.column('A').width()).toBeGreaterThanOrEqual(10);
   expect(sheet.autoFilter()).toBeTruthy();
+});
+
+describe('xlsx create script', () => {
+  test('creates a workbook from headers and rows', async () => {
+    const dir = makeTempDir();
+    const outputPath = path.join(dir, 'created.xlsx');
+
+    const result = runNodeScript([
+      'skills/xlsx/scripts/create_xlsx.cjs',
+      outputPath,
+      '--headers',
+      'Name,Age,City',
+      '--rows',
+      'Alice,30,NYC;Bob,25,LA',
+      '--json',
+    ]);
+
+    const payload = JSON.parse(result.stdout);
+    expect(payload).toMatchObject({
+      success: true,
+      sheet_name: 'Sheet1',
+      row_count: 2,
+      column_count: 3,
+      output_path: outputPath,
+    });
+    expect(fs.existsSync(outputPath)).toBe(true);
+
+    const workbook = await XlsxPopulate.fromFileAsync(outputPath);
+    const sheet = workbook.sheet('Sheet1');
+
+    expect(sheet.cell('A1').value()).toBe('Name');
+    expect(sheet.cell('B1').value()).toBe('Age');
+    expect(sheet.cell('C1').value()).toBe('City');
+    expect(sheet.cell('A2').value()).toBe('Alice');
+    expect(sheet.cell('B2').value()).toBe(30);
+    expect(sheet.cell('C2').value()).toBe('NYC');
+    expect(sheet.cell('A3').value()).toBe('Bob');
+    expect(sheet.cell('B3').value()).toBe(25);
+
+    // Professional styling checks
+    expect(sheet.cell('A1').style('bold')).toBe(true);
+    expect(sheet.cell('A1').style('fill').color).toMatchObject({
+      rgb: 'D9EAF7',
+    });
+    expect(sheet.column('A').width()).toBeGreaterThanOrEqual(10);
+    expect(sheet.autoFilter()).toBeTruthy();
+  });
+
+  test('creates a workbook from JSON data', async () => {
+    const dir = makeTempDir();
+    const outputPath = path.join(dir, 'json-created.xlsx');
+
+    const jsonData = JSON.stringify([
+      { Name: 'Alice', Age: 30, City: 'NYC' },
+      { Name: 'Bob', Age: 25, City: 'LA' },
+    ]);
+
+    const result = runNodeScript([
+      'skills/xlsx/scripts/create_xlsx.cjs',
+      outputPath,
+      '--json-data',
+      jsonData,
+      '--json',
+    ]);
+
+    const payload = JSON.parse(result.stdout);
+    expect(payload).toMatchObject({
+      success: true,
+      row_count: 2,
+      column_count: 3,
+    });
+
+    const workbook = await XlsxPopulate.fromFileAsync(outputPath);
+    const sheet = workbook.sheet(0);
+
+    // Headers inferred from JSON keys
+    expect(sheet.cell('A1').value()).toBe('Name');
+    expect(sheet.cell('B1').value()).toBe('Age');
+    expect(sheet.cell('C1').value()).toBe('City');
+
+    // Data values
+    expect(sheet.cell('A2').value()).toBe('Alice');
+    expect(sheet.cell('B2').value()).toBe(30);
+    expect(sheet.cell('C2').value()).toBe('NYC');
+    expect(sheet.cell('A1').style('bold')).toBe(true);
+  });
+
+  test('preserves formulas in cell values', async () => {
+    const dir = makeTempDir();
+    const outputPath = path.join(dir, 'formulas.xlsx');
+
+    runNodeScript([
+      'skills/xlsx/scripts/create_xlsx.cjs',
+      outputPath,
+      '--headers',
+      'Revenue,Cost,Profit',
+      '--rows',
+      '120000,45000,=A2-B2',
+      '--json',
+    ]);
+
+    const workbook = await XlsxPopulate.fromFileAsync(outputPath);
+    const sheet = workbook.sheet(0);
+
+    expect(sheet.cell('A2').value()).toBe(120000);
+    expect(sheet.cell('B2').value()).toBe(45000);
+    expect(sheet.cell('C2').formula()).toBe('A2-B2');
+  });
+
+  test('applies custom sheet name', async () => {
+    const dir = makeTempDir();
+    const outputPath = path.join(dir, 'named.xlsx');
+
+    runNodeScript([
+      'skills/xlsx/scripts/create_xlsx.cjs',
+      outputPath,
+      '--headers',
+      'A,B',
+      '--rows',
+      '1,2',
+      '--sheet-name',
+      'Summary',
+      '--json',
+    ]);
+
+    const workbook = await XlsxPopulate.fromFileAsync(outputPath);
+    expect(workbook.sheet('Summary')).toBeTruthy();
+    expect(workbook.sheet('Summary').cell('A1').value()).toBe('A');
+  });
+
+  test('auto-detects numeric values', async () => {
+    const dir = makeTempDir();
+    const outputPath = path.join(dir, 'numbers.xlsx');
+
+    runNodeScript([
+      'skills/xlsx/scripts/create_xlsx.cjs',
+      outputPath,
+      '--headers',
+      'Int,Float,Text',
+      '--rows',
+      '42,3.14,hello',
+      '--json',
+    ]);
+
+    const workbook = await XlsxPopulate.fromFileAsync(outputPath);
+    const sheet = workbook.sheet(0);
+
+    expect(sheet.cell('A2').value()).toBe(42);
+    expect(typeof sheet.cell('A2').value()).toBe('number');
+    expect(sheet.cell('B2').value()).toBe(3.14);
+    expect(typeof sheet.cell('B2').value()).toBe('number');
+    expect(sheet.cell('C2').value()).toBe('hello');
+    expect(typeof sheet.cell('C2').value()).toBe('string');
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes #327 — XLSX generation no longer fails silently
- Same pattern as the PDF creation fix in PR #322: added a bundled `create_xlsx.cjs` script with proper `xlsx-populate` usage so the agent uses a known-working path instead of improvising
- Supports `--headers`/`--rows` and `--json-data` input modes, with number auto-detection, formula preservation, and professional styling (bold headers with fill, freeze panes, auto-filter, auto-width columns)
- Updated `SKILL.md` with creation workflow docs and enforcement rule

## Test plan

- [x] 5 new tests: basic creation, JSON data, formulas, custom sheet name, number auto-detection
- [x] All 6 xlsx tests pass (1 existing + 5 new)
- [x] Full suite: same pass/fail count as baseline
- [ ] Manual: ask agent to create a spreadsheet, verify output is valid xlsx