### PR TITLE
fix: enable /dream memory consolidation for cloud sessions

### DIFF
--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -8508,12 +8508,6 @@ export async function handleGatewayCommand(
       }
 
       case 'dream': {
-        if (!isLocalSession(req)) {
-          return badCommand(
-            'Dream Restricted',
-            '`dream` consolidates local workspace memory and is only available from local TUI/web sessions.',
-          );
-        }
 
         const sub = (req.args[1] || '').trim().toLowerCase();
         const currentConfig = getRuntimeConfig();

--- a/tests/gateway-service.dream-command.test.ts
+++ b/tests/gateway-service.dream-command.test.ts
@@ -100,7 +100,7 @@ test('dream command reports consolidation failures', async () => {
   expect(result.text).toContain('disk busy');
 });
 
-test('dream command is restricted to local TUI/web sessions', async () => {
+test('dream command works for remote sessions', async () => {
   setupHome();
 
   const { initDatabase } = await import('../src/memory/db.ts');
@@ -111,10 +111,16 @@ test('dream command is restricted to local TUI/web sessions', async () => {
 
   initDatabase({ quiet: true });
 
-  const consolidateSpy = vi.spyOn(
-    memoryService,
-    'consolidateMemoriesWithCleanup',
-  );
+  const consolidateSpy = vi
+    .spyOn(memoryService, 'consolidateMemoriesWithCleanup')
+    .mockResolvedValue({
+      memoriesDecayed: 0,
+      dailyFilesCompiled: 0,
+      workspacesUpdated: 0,
+      modelCleanups: 0,
+      fallbacksUsed: 0,
+      durationMs: 10,
+    });
 
   const result = await handleGatewayCommand({
     sessionId: 'session-dream-remote',
@@ -123,10 +129,9 @@ test('dream command is restricted to local TUI/web sessions', async () => {
     args: ['dream', 'now'],
   });
 
-  expect(consolidateSpy).not.toHaveBeenCalled();
-  expect(result.kind).toBe('error');
-  expect(result.title).toBe('Dream Restricted');
-  expect(result.text).toContain('only available from local TUI/web sessions');
+  expect(consolidateSpy).toHaveBeenCalled();
+  expect(result.kind).toBe('info');
+  expect(result.title).toBe('Memory Consolidated');
 });
 
 test('dream command reports scheduler status by default', async () => {


### PR DESCRIPTION
## Summary

- Fixes #325 — memory writes silently fail in cloud agent
- Removes the `isLocalSession()` gate on `/dream` that blocked memory consolidation for non-local sessions (Discord, cloud web, etc.)
- **Root cause**: this restriction was added as a GitHub Copilot automated review suggestion during PR #239, flagging dream as "a local, disk-mutating operation." But cloud instances now have persistent workspace storage (`HYBRIDCLAW_DATA_DIR=/workspace/.data` with bind mount), making dream safe and necessary
- **Impact**: without this fix, daily memory notes (`memory/YYYY-MM-DD.md`) accumulate but never consolidate into `MEMORY.md`. Users checking `MEMORY.md` see nothing — the primary symptom Stephan reported

## Test plan

- [x] Updated test: "dream command works for remote sessions" verifies consolidation runs for Discord-like sessions
- [x] All 5 dream command tests pass
- [x] Full suite: 322 files / 2595 tests — 0 failures
- [ ] Manual: run `/dream now` from a Discord session, verify it consolidates daily notes into MEMORY.md