### PR TITLE
[codex] harden mem0 scoped recall and tool validation

### DIFF
--- a/docs/development/extensibility/mem0-memory-plugin.md
+++ b/docs/development/extensibility/mem0-memory-plugin.md
@@ -69,6 +69,8 @@ Useful optional keys:
 - `userId`: override HybridClaw's per-session user id
 - `agentId`: override HybridClaw's active agent id
 - `prefetchRerank`: rerank prompt-time Mem0 searches
+- `readAgentScope`: expand read-side recall to the active agent scope as well as
+  the active user scope
 - `syncTurns`: disable automatic turn mirroring when set to `false`
 - `mirrorNativeMemoryWrites`: disable explicit native-memory mirroring when set
   to `false`
@@ -126,14 +128,18 @@ When enabled with a configured `MEM0_API_KEY`:
    explicit write into Mem0 as a durable conclusion.
 
 Read-side Mem0 recall is scoped to the current HybridClaw user id by default.
-Write-side sync uses the current HybridClaw user id plus the active agent id so
-Mem0 keeps attribution data.
+If `readAgentScope` is enabled, the plugin performs a dual-scope read across
+the active user id or the active agent id. Write-side sync uses the current
+HybridClaw user id plus the active agent id so Mem0 keeps attribution data.
 
 ## Peer Identity
 
-Mem0 recall is scoped to a single HybridClaw user id. Unlike `honcho-memory`,
-the plugin does not model separate user-peer and AI-peer representations. If
-you need distinct peer identities, prefer `honcho-memory`.
+Mem0 recall is user-scoped by default. If you enable `readAgentScope`, Mem0
+uses a dual-scope OR query across the active user id and active agent id,
+because Mem0 stores entity scopes separately. Unlike `honcho-memory`, the
+plugin does not model separate user-peer and AI-peer representations. If you
+need strict peer separation or intersection-style scoping, prefer
+`honcho-memory`.
 
 ## Verification
 
@@ -151,6 +157,8 @@ search results.
 
 - Leave `userId` and `agentId` unset unless you have a deliberate cross-session
   routing plan. The defaults follow HybridClaw's active user and agent scope.
+- Leave `readAgentScope` disabled unless you intentionally want prompt-time
+  recall to include memories addressable through the active agent id.
 - Keep `apiVersion: v2` unless you have a concrete compatibility reason to use
   `v1`; the plugin is tuned around Mem0's newer filtered read path.
 - Use `mem0_profile` first when you want a broad snapshot, and `mem0_search`

--- a/plugins/mem0-memory/hybridclaw.plugin.yaml
+++ b/plugins/mem0-memory/hybridclaw.plugin.yaml
@@ -60,6 +60,9 @@ configSchema:
     includeSearch:
       type: boolean
       default: true
+    readAgentScope:
+      type: boolean
+      default: false
     syncTurns:
       type: boolean
       default: true

--- a/plugins/mem0-memory/src/config.js
+++ b/plugins/mem0-memory/src/config.js
@@ -106,6 +106,7 @@ export function resolveMem0PluginConfig(params) {
     prefetchRerank: pluginConfig.prefetchRerank !== false,
     includeProfile: pluginConfig.includeProfile !== false,
     includeSearch: pluginConfig.includeSearch !== false,
+    readAgentScope: pluginConfig.readAgentScope === true,
     syncTurns: pluginConfig.syncTurns !== false,
     mirrorNativeMemoryWrites: pluginConfig.mirrorNativeMemoryWrites !== false,
     prefetchOnSessionStart: pluginConfig.prefetchOnSessionStart !== false,

--- a/plugins/mem0-memory/src/index.js
+++ b/plugins/mem0-memory/src/index.js
@@ -70,7 +70,6 @@ export default {
   register(api) {
     const config = resolveMem0PluginConfig({
       pluginConfig: api.pluginConfig,
-      runtime: api.runtime,
       credentialApiKey: api.getCredential('MEM0_API_KEY'),
     });
     const runtime = new Mem0Runtime(api, config);

--- a/plugins/mem0-memory/src/mem0-client.js
+++ b/plugins/mem0-memory/src/mem0-client.js
@@ -2,6 +2,26 @@ function normalizeString(value) {
   return typeof value === 'string' ? value.trim() : '';
 }
 
+function buildPlatformEntityFilters(config, userId, agentId) {
+  const normalizedUserId = normalizeString(userId);
+  const normalizedAgentId = normalizeString(agentId);
+
+  if (config.readAgentScope && normalizedUserId && normalizedAgentId) {
+    // Mem0 stores entity scopes separately, so dual-scope reads use OR rather
+    // than combining user_id and agent_id in a single AND clause.
+    return {
+      OR: [{ user_id: normalizedUserId }, { agent_id: normalizedAgentId }],
+    };
+  }
+  if (normalizedUserId) {
+    return { AND: [{ user_id: normalizedUserId }] };
+  }
+  if (config.readAgentScope && normalizedAgentId) {
+    return { AND: [{ agent_id: normalizedAgentId }] };
+  }
+  return null;
+}
+
 function buildMissingDependencyError(error) {
   const message =
     error instanceof Error ? error.message : String(error || 'Unknown error');
@@ -32,11 +52,12 @@ async function loadMem0Module() {
   return await mem0ModulePromise;
 }
 
-function buildReadOptions(config, userId, extra = {}) {
+function buildReadOptions(config, userId, agentId, extra = {}) {
   if (config.apiVersion === 'v2') {
+    const filters = buildPlatformEntityFilters(config, userId, agentId);
     return {
       api_version: 'v2',
-      filters: { user_id: userId },
+      ...(filters ? { filters } : {}),
       ...extra,
     };
   }
@@ -118,10 +139,10 @@ export class Mem0PluginClient {
     return await client.ping();
   }
 
-  async getProfile(userId, config = {}) {
+  async getProfile(userId, agentId = '', config = {}) {
     const client = await this.getClient();
     const response = await client.getAll(
-      buildReadOptions(this.config, userId, {
+      buildReadOptions(this.config, userId, agentId, {
         page: 1,
         page_size: config.pageSize || this.config.profileLimit,
       }),
@@ -129,11 +150,11 @@ export class Mem0PluginClient {
     return normalizeMem0Results(response);
   }
 
-  async search(userId, query, config = {}) {
+  async search(userId, agentId, query, config = {}) {
     const client = await this.getClient();
     const response = await client.search(
       query,
-      buildReadOptions(this.config, userId, {
+      buildReadOptions(this.config, userId, agentId, {
         top_k: config.topK || this.config.searchLimit,
         rerank:
           typeof config.rerank === 'boolean'

--- a/plugins/mem0-memory/src/mem0-controls.js
+++ b/plugins/mem0-memory/src/mem0-controls.js
@@ -4,6 +4,26 @@ function normalizeString(value) {
   return String(value || '').trim();
 }
 
+function readRequiredStringArg(args, key, label) {
+  if (typeof args?.[key] !== 'string') {
+    return {
+      ok: false,
+      error: `${label} must be a string.`,
+    };
+  }
+  const normalized = normalizeString(args[key]);
+  if (!normalized) {
+    return {
+      ok: false,
+      error: `${label} is required.`,
+    };
+  }
+  return {
+    ok: true,
+    value: normalized,
+  };
+}
+
 function normalizeToolTopK(value, maximum) {
   if (typeof value !== 'number' || !Number.isFinite(value)) {
     return undefined;
@@ -129,25 +149,30 @@ export class Mem0Controls {
   }
 
   async handleToolSearch(args, context) {
-    const query = normalizeString(args.query);
-    if (!query) {
+    const query = readRequiredStringArg(args, 'query', 'mem0_search.query');
+    if (!query.ok) {
       return JSON.stringify(
         {
           ok: false,
-          error: 'mem0_search requires a query.',
+          error: query.error,
         },
         null,
         2,
       );
     }
-    const result = await this.runtime.search(context.sessionId, '', query, {
-      topK: normalizeToolTopK(args.top_k, this.runtime.config.searchLimit),
-      rerank: typeof args.rerank === 'boolean' ? args.rerank : undefined,
-    });
+    const result = await this.runtime.search(
+      context.sessionId,
+      '',
+      query.value,
+      {
+        topK: normalizeToolTopK(args.top_k, this.runtime.config.searchLimit),
+        rerank: typeof args.rerank === 'boolean' ? args.rerank : undefined,
+      },
+    );
     return JSON.stringify(
       {
         userId: result.userId,
-        query,
+        query: query.value,
         count: result.entries.length,
         results: buildToolMemoryResult(result.entries),
       },
@@ -157,12 +182,16 @@ export class Mem0Controls {
   }
 
   async handleToolConclude(args, context) {
-    const conclusion = normalizeString(args.conclusion);
-    if (!conclusion) {
+    const conclusion = readRequiredStringArg(
+      args,
+      'conclusion',
+      'mem0_conclude.conclusion',
+    );
+    if (!conclusion.ok) {
       return JSON.stringify(
         {
           ok: false,
-          error: 'mem0_conclude requires a conclusion.',
+          error: conclusion.error,
         },
         null,
         2,
@@ -172,14 +201,14 @@ export class Mem0Controls {
       context.sessionId,
       '',
       '',
-      conclusion,
+      conclusion.value,
     );
     return JSON.stringify(
       {
         ok: true,
         userId: result.userId,
         agentId: result.agentId,
-        conclusion,
+        conclusion: conclusion.value,
       },
       null,
       2,

--- a/plugins/mem0-memory/src/mem0-runtime.js
+++ b/plugins/mem0-memory/src/mem0-runtime.js
@@ -16,7 +16,10 @@ function normalizeString(value) {
 function truncateText(value, maxChars) {
   const normalized = normalizeString(value);
   if (normalized.length <= maxChars) return normalized;
-  return `${normalized.slice(0, Math.max(0, maxChars - 1)).trimEnd()}...`;
+  if (maxChars <= 3) {
+    return '.'.repeat(Math.max(0, maxChars));
+  }
+  return `${normalized.slice(0, Math.max(0, maxChars - 3)).trimEnd()}...`;
 }
 
 function buildCompactionConclusion(summary, olderMessages) {
@@ -208,16 +211,17 @@ export class Mem0Runtime {
       return;
     }
     const userId = this.resolveUserId(context.userId, context.sessionId);
-    const prefetch = this.client.getProfile(userId).catch((error) => {
+    const agentId = this.resolveAgentId(context.agentId, context.sessionId);
+    const prefetch = this.client.getProfile(userId, agentId).catch((error) => {
       this.api.logger.debug(
-        { error, sessionId: context.sessionId, userId },
+        { error, sessionId: context.sessionId, userId, agentId },
         'Mem0 session prefetch failed',
       );
       return [];
     });
     this.profilePrefetch.set(context.sessionId, prefetch);
     this.api.logger.debug(
-      { sessionId: context.sessionId, userId },
+      { sessionId: context.sessionId, userId, agentId },
       'Mem0 session prefetch scheduled',
     );
   }
@@ -226,7 +230,7 @@ export class Mem0Runtime {
     const prefetch = this.profilePrefetch.get(context.sessionId);
     this.profilePrefetch.delete(context.sessionId);
     if (prefetch) {
-      await prefetch.catch(() => {});
+      await prefetch;
     }
   }
 
@@ -235,7 +239,7 @@ export class Mem0Runtime {
     this.profilePrefetch.delete(context.previousSessionId);
     this.profilePrefetch.delete(context.sessionId);
     if (previous) {
-      await previous.catch(() => {});
+      await previous;
     }
   }
 
@@ -278,16 +282,17 @@ export class Mem0Runtime {
   async getContextForPrompt(params) {
     if (!this.hasApiKey()) return null;
     const userId = this.resolveUserId(params.userId, params.sessionId);
+    const agentId = this.resolveAgentId(params.agentId, params.sessionId);
     const query = getLatestUserQuery(params.recentMessages);
     const prefetched = this.profilePrefetch.get(params.sessionId);
     if (prefetched) this.profilePrefetch.delete(params.sessionId);
     try {
       const [profileEntries, searchEntries] = await Promise.all([
         this.config.includeProfile
-          ? (prefetched ?? this.client.getProfile(userId))
+          ? (prefetched ?? this.client.getProfile(userId, agentId))
           : Promise.resolve([]),
         this.config.includeSearch && query
-          ? this.client.search(userId, query)
+          ? this.client.search(userId, agentId, query)
           : Promise.resolve([]),
       ]);
       const promptContext = buildPromptContext({
@@ -300,6 +305,7 @@ export class Mem0Runtime {
         {
           query,
           userId,
+          agentId,
           profileCount: profileEntries.length,
           searchCount: searchEntries.length,
         },
@@ -314,6 +320,7 @@ export class Mem0Runtime {
           error,
           host: this.config.host,
           userId,
+          agentId,
           query,
         },
         'Mem0 prompt context fetch failed',
@@ -399,13 +406,15 @@ export class Mem0Runtime {
 
   async fetchProfile(sessionId, inputUserId) {
     const userId = this.resolveUserId(inputUserId, sessionId);
-    const entries = await this.client.getProfile(userId);
+    const agentId = this.resolveAgentId('', sessionId);
+    const entries = await this.client.getProfile(userId, agentId);
     return { userId, entries };
   }
 
   async search(sessionId, inputUserId, query, options = {}) {
     const userId = this.resolveUserId(inputUserId, sessionId);
-    const entries = await this.client.search(userId, query, options);
+    const agentId = this.resolveAgentId('', sessionId);
+    const entries = await this.client.search(userId, agentId, query, options);
     return { userId, entries };
   }
 
@@ -433,6 +442,7 @@ export class Mem0Runtime {
       `API version: ${this.config.apiVersion}`,
       `User scope: ${userId}`,
       `Agent scope: ${agentId}`,
+      `Read agent scope: ${this.config.readAgentScope ? 'enabled' : 'disabled'}`,
       `Search limit: ${this.config.searchLimit}`,
       `Profile limit: ${this.config.profileLimit}`,
       `Sync turns: ${this.config.syncTurns ? 'enabled' : 'disabled'}`,

--- a/tests/mem0-memory-plugin.test.ts
+++ b/tests/mem0-memory-plugin.test.ts
@@ -75,18 +75,30 @@ function installMem0Stub(
       '  }',
       '  async ping() {',
       '    append({ method: "ping" });',
+      '    if (typeof readResponses().pingError === "string") {',
+      '      throw new Error(readResponses().pingError);',
+      '    }',
       '    return { status: "ok", org_id: "org-test", project_id: "proj-test" };',
       '  }',
       '  async getAll(options = {}) {',
       '    append({ method: "getAll", options });',
+      '    if (typeof readResponses().getAllError === "string") {',
+      '      throw new Error(readResponses().getAllError);',
+      '    }',
       '    return readResponses().getAll ?? [];',
       '  }',
       '  async search(query, options = {}) {',
       '    append({ method: "search", query, options });',
+      '    if (typeof readResponses().searchError === "string") {',
+      '      throw new Error(readResponses().searchError);',
+      '    }',
       '    return readResponses().search ?? [];',
       '  }',
       '  async add(messages, options = {}) {',
       '    append({ method: "add", messages, options });',
+      '    if (typeof readResponses().addError === "string") {',
+      '      throw new Error(readResponses().addError);',
+      '    }',
       '    return readResponses().add ?? [];',
       '  }',
       '}',
@@ -126,11 +138,7 @@ test('resolveMem0PluginConfig only accepts MEM0_API_KEY from credentials', async
       apiKey: 'plaintext-config-key',
       host: 'https://api.mem0.ai',
     },
-    runtime: {
-      cwd: '/tmp/hybridclaw',
-    },
     credentialApiKey: 'secret-store-key',
-    processEnvApiKey: 'env-key-should-be-ignored',
   });
 
   expect(config.apiKey).toBe('secret-store-key');
@@ -140,10 +148,6 @@ test('resolveMem0PluginConfig only accepts MEM0_API_KEY from credentials', async
       apiKey: 'plaintext-config-key',
       host: 'https://api.mem0.ai',
     },
-    runtime: {
-      cwd: '/tmp/hybridclaw',
-    },
-    processEnvApiKey: 'env-key-should-be-ignored',
   });
 
   expect(withoutCredential.apiKey).toBe('');
@@ -158,9 +162,6 @@ test('resolveMem0PluginConfig rejects invalid host values', async () => {
     resolveMem0PluginConfig({
       pluginConfig: {
         host: 'not-a-url',
-      },
-      runtime: {
-        cwd: '/tmp/hybridclaw',
       },
     }),
   ).toThrow('mem0-memory plugin config.host must be a valid absolute URL.');
@@ -307,7 +308,7 @@ test('mem0-memory injects prompt context, registers tools, and exposes command h
       method: 'getAll',
       options: expect.objectContaining({
         api_version: 'v2',
-        filters: { user_id: 'user-1' },
+        filters: { AND: [{ user_id: 'user-1' }] },
         page: 1,
         page_size: 2,
       }),
@@ -319,7 +320,7 @@ test('mem0-memory injects prompt context, registers tools, and exposes command h
       query: 'SQLite',
       options: expect.objectContaining({
         api_version: 'v2',
-        filters: { user_id: 'user-1' },
+        filters: { AND: [{ user_id: 'user-1' }] },
         top_k: 2,
         rerank: false,
       }),
@@ -392,6 +393,246 @@ test('mem0_search tool ignores invalid top_k values and clamps oversized request
       }),
     }),
   );
+});
+
+test('mem0 tools reject non-string query and conclusion arguments', async () => {
+  const homeDir = makeTempDir('hybridclaw-mem0-home-');
+  const cwd = makeTempDir('hybridclaw-mem0-project-');
+  const pluginDir = installBundledPlugin(cwd);
+  const logPath = installMem0Stub(pluginDir, {
+    getAll: { results: [] },
+    search: { results: [{ id: 'mem-search-1', memory: 'stored' }] },
+    add: [{ id: 'mem-added-1', memory: 'stored' }],
+  });
+
+  process.env.MEM0_API_KEY = 'mem0-test-key';
+
+  const config = loadRuntimeConfig();
+  config.plugins.list = [
+    {
+      id: 'mem0-memory',
+      enabled: true,
+    },
+  ];
+
+  const { PluginManager } = await import('../src/plugins/plugin-manager.js');
+  const manager = new PluginManager({
+    homeDir,
+    cwd,
+    getRuntimeConfig: () => config,
+  });
+
+  await manager.ensureInitialized();
+
+  const searchResult = await manager.executeTool({
+    toolName: 'mem0_search',
+    args: { query: { text: 'bad' } },
+    sessionId: 'session-1',
+    channelId: 'web',
+  });
+  expect(JSON.parse(searchResult)).toEqual({
+    ok: false,
+    error: 'mem0_search.query must be a string.',
+  });
+
+  const concludeResult = await manager.executeTool({
+    toolName: 'mem0_conclude',
+    args: { conclusion: 42 },
+    sessionId: 'session-1',
+    channelId: 'web',
+  });
+  expect(JSON.parse(concludeResult)).toEqual({
+    ok: false,
+    error: 'mem0_conclude.conclusion must be a string.',
+  });
+
+  const calls = readStubLog(logPath).filter(
+    (entry) => entry.method === 'search' || entry.method === 'add',
+  );
+  expect(calls).toEqual([]);
+});
+
+test('mem0-memory can read across user and agent scopes when readAgentScope is enabled', async () => {
+  const homeDir = makeTempDir('hybridclaw-mem0-home-');
+  const cwd = makeTempDir('hybridclaw-mem0-project-');
+  const pluginDir = installBundledPlugin(cwd);
+  const logPath = installMem0Stub(pluginDir, {
+    getAll: {
+      results: [{ id: 'mem-profile-1', memory: 'Agent-specific preference.' }],
+    },
+    search: {
+      results: [{ id: 'mem-search-1', memory: 'Agent-specific recall.' }],
+    },
+    add: [],
+  });
+
+  process.env.MEM0_API_KEY = 'mem0-test-key';
+
+  const config = loadRuntimeConfig();
+  config.plugins.list = [
+    {
+      id: 'mem0-memory',
+      enabled: true,
+      config: {
+        readAgentScope: true,
+        searchLimit: 2,
+        profileLimit: 2,
+      },
+    },
+  ];
+
+  const { PluginManager } = await import('../src/plugins/plugin-manager.js');
+  const manager = new PluginManager({
+    homeDir,
+    cwd,
+    getRuntimeConfig: () => config,
+  });
+
+  await manager.ensureInitialized();
+
+  const promptContext = await manager.collectPromptContext({
+    sessionId: 'session-1',
+    userId: 'user-1',
+    agentId: 'main',
+    channelId: 'web',
+    recentMessages: [
+      {
+        id: 1,
+        session_id: 'session-1',
+        user_id: 'user-1',
+        username: 'alice',
+        role: 'user',
+        content: 'What do you remember?',
+        created_at: '2026-04-11T10:00:00.000Z',
+      },
+    ],
+  });
+
+  expect(
+    promptContext.some((section) => section.includes('Agent-specific recall.')),
+  ).toBe(true);
+
+  const calls = readStubLog(logPath);
+  expect(calls).toContainEqual(
+    expect.objectContaining({
+      method: 'getAll',
+      options: expect.objectContaining({
+        api_version: 'v2',
+        filters: {
+          OR: [{ user_id: 'user-1' }, { agent_id: 'main' }],
+        },
+        page: 1,
+        page_size: 2,
+      }),
+    }),
+  );
+  expect(calls).toContainEqual(
+    expect.objectContaining({
+      method: 'search',
+      query: 'What do you remember?',
+      options: expect.objectContaining({
+        api_version: 'v2',
+        filters: {
+          OR: [{ user_id: 'user-1' }, { agent_id: 'main' }],
+        },
+        top_k: 2,
+        rerank: true,
+      }),
+    }),
+  );
+});
+
+test('mem0-memory skips empty compaction snapshots and swallows client errors', async () => {
+  const homeDir = makeTempDir('hybridclaw-mem0-home-');
+  const cwd = makeTempDir('hybridclaw-mem0-project-');
+  const pluginDir = installBundledPlugin(cwd);
+  const logPath = installMem0Stub(pluginDir, {
+    getAllError: 'profile unavailable',
+    searchError: 'search unavailable',
+    addError: 'write unavailable',
+  });
+
+  process.env.MEM0_API_KEY = 'mem0-test-key';
+
+  const config = loadRuntimeConfig();
+  config.plugins.list = [
+    {
+      id: 'mem0-memory',
+      enabled: true,
+      config: {
+        searchLimit: 2,
+        profileLimit: 2,
+      },
+    },
+  ];
+
+  const { PluginManager } = await import('../src/plugins/plugin-manager.js');
+  const manager = new PluginManager({
+    homeDir,
+    cwd,
+    getRuntimeConfig: () => config,
+  });
+
+  await manager.ensureInitialized();
+
+  const promptContext = await manager.collectPromptContext({
+    sessionId: 'session-1',
+    userId: 'user-1',
+    agentId: 'main',
+    channelId: 'web',
+    recentMessages: [
+      {
+        id: 1,
+        session_id: 'session-1',
+        user_id: 'user-1',
+        username: 'alice',
+        role: 'user',
+        content: 'What database does this project use?',
+        created_at: '2026-04-11T10:00:00.000Z',
+      },
+    ],
+  });
+  expect(
+    promptContext.some((section) => section.includes('Mem0 memory guide:')),
+  ).toBe(true);
+  expect(
+    promptContext.some((section) => section.includes('Mem0 memory context:')),
+  ).toBe(false);
+
+  await expect(
+    manager.notifyTurnComplete({
+      sessionId: 'session-1',
+      userId: 'user-1',
+      agentId: 'main',
+      workspacePath: cwd,
+      messages: [
+        {
+          id: 1,
+          session_id: 'session-1',
+          user_id: 'user-1',
+          username: 'alice',
+          role: 'user',
+          content: 'Remember this.',
+          created_at: '2026-04-11T10:00:00.000Z',
+        },
+      ],
+    }),
+  ).resolves.toBeUndefined();
+
+  await expect(
+    manager.notifyBeforeCompaction({
+      sessionId: 'session-1',
+      agentId: 'main',
+      channelId: 'web',
+      summary: '',
+      olderMessages: [],
+    }),
+  ).resolves.toBeUndefined();
+
+  const addCalls = readStubLog(logPath).filter(
+    (entry) => entry.method === 'add',
+  );
+  expect(addCalls).toHaveLength(1);
 });
 
 test('mem0-memory syncs turns and mirrors native memory writes', async () => {


### PR DESCRIPTION
## Summary
- add an optional `readAgentScope` setting so Mem0 reads can include the active agent scope as well as the active user scope
- validate `mem0_search` and `mem0_conclude` string inputs earlier and tighten a few small runtime edge cases
- document the new scope behavior and expand regression coverage for error handling and follow-up paths

## Why
This keeps the mem0 follow-up isolated to the branch that already contains the plugin while fixing behavior that was still rough around the edges. Prompt-time recall could not opt into agent-scope reads, malformed tool args reached runtime code too late, and a few error and truncation paths were under-covered.

## Validation
- `./node_modules/.bin/vitest tests/mem0-memory-plugin.test.ts`
