### PR TITLE
feat(plugin): skill-evolver — DSPy + GEPA evolution for SKILL.md

### DIFF
--- a/docs/content/extensibility/skill-evolver-plugin.md
+++ b/docs/content/extensibility/skill-evolver-plugin.md
@@ -110,8 +110,21 @@ branch and runs `gh pr create` with the evolution report as the body.
 
 The plugin declares its Python deps (`dspy`, `gepa`, `click`, `rich`,
 `pyyaml`, `pydantic`) in `hybridclaw.plugin.yaml`. HybridClaw's plugin
-loader provisions a per-plugin `.venv` on first use — preferring `uv` if
-available, otherwise `python3 -m venv`. No global install required.
+install flow provisions the per-plugin `.venv` and installs the declared
+pip deps — preferring `uv` if available, otherwise `python3 -m venv`.
+
+Before the first `skill-evolver` command, run the install flow once so the
+venv exists and its dependencies are resolved:
+
+```bash
+hybridclaw plugin install ./plugins/skill-evolver --yes
+```
+
+(You can also use `hybridclaw plugin check` + `hybridclaw plugin install
+--yes` to see the approval prompts first.) If the venv is missing at run
+time the TS bridge throws an actionable error pointing you at this command
+rather than silently falling back to the system `python3` and failing on
+the first `import dspy`.
 
 All LLM traffic goes through the DSPy-configured models, which inherit
 whichever provider keys are set in the HybridClaw environment

--- a/docs/content/extensibility/skill-evolver-plugin.md
+++ b/docs/content/extensibility/skill-evolver-plugin.md
@@ -1,0 +1,130 @@
+---
+title: Skill Evolver Plugin
+description: Evolve SKILL.md descriptions and bodies with DSPy + GEPA, validated against synthetic, golden, and real trace data.
+sidebar_position: 12
+---
+
+# Skill Evolver Plugin
+
+HybridClaw ships a bundled skill evolver at
+[`plugins/skill-evolver`](https://github.com/HybridAIOne/hybridclaw/tree/main/plugins/skill-evolver).
+
+The plugin applies reflective prompt evolution (DSPy + [GEPA](https://arxiv.org/abs/2507.01234))
+to two distinct optimization targets on any installed SKILL.md:
+
+- **description** — the short frontmatter field that drives skill routing.
+  Fitness is measured as the trigger-classification F1 of a judge LM that
+  picks which skill (from the real installed pool) should fire for a given
+  prompt.
+- **body** — the Markdown instructions that actually run after the skill is
+  selected. Fitness is measured by an LLM-judge scoring a follower LM's
+  execution against a task rubric (correctness / procedure / conciseness).
+
+Both targets can be evolved separately or jointly (body first, then
+description, then cross-validated for drift).
+
+## When to use it
+
+Use it for a skill that is **already measurable** — you must have at least
+one of:
+
+- enough real traces in the HybridClaw SQLite DB (default minimum: 10
+  observations)
+- curated golden examples under `datasets/skills/<skill>/{triggers,tasks}.json`
+- a stable enough description/body that synthetic generation can derive
+  meaningful triggers and tasks from it
+
+Unlike the adaptive-skills amendments flow — which makes *conservative*
+single-point edits inside HybridClaw at runtime — this plugin runs a full
+reflective search offline, proposes a new SKILL.md, validates it against
+size/shape/test constraints, and opens a PR if asked. Adaptive skills
+continue to own the lightweight, in-process edits; the evolver owns the
+offline, multi-iteration, PR-gated edits.
+
+## Three dataset ingredients
+
+Every evolution run assembles its evaluation set from up to three sources,
+controllable with `--sources`:
+
+| Source | Where from | What it becomes |
+| --- | --- | --- |
+| `synthetic` | LLM generates positives + adversarial negatives from the skill's own description/body | trigger prompts and execution tasks |
+| `golden` | `datasets/skills/<skill>/triggers.json` and `datasets/skills/<skill>/tasks.json` | human-curated ground truth |
+| `traces` | `skill_observations` rows in the HybridClaw SQLite DB joined with session transcripts | real-world triggers and tasks with observed outcomes |
+
+Trace extraction walks the `.session-transcripts/` JSONL files in the
+HybridClaw data dir, correlating them with `skill_observations` entries via
+`session_id` + timestamp proximity to recover the user prompt that
+originally invoked each skill run.
+
+## Commands
+
+```
+hybridclaw skill-evolver list                        # rank skills by failure rate
+hybridclaw skill-evolver extract <skill>             # write datasets/skills/<skill>/traces.json
+hybridclaw skill-evolver evolve <skill> --target description
+hybridclaw skill-evolver evolve <skill> --target body --iterations 20
+hybridclaw skill-evolver evolve <skill> --target both --open-pr
+hybridclaw skill-evolver show <skill>                # Rich-rendered report of last run
+hybridclaw skill-evolver watch <skill>               # live dashboard while running
+hybridclaw skill-evolver tui                         # interactive skill browser
+```
+
+`evolve` requires `--target` explicitly — there is no silent default — because
+the evaluation shape differs materially between description and body.
+
+## Configuration
+
+Per-plugin config (set in `config.json` under `plugins.skill-evolver`):
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `optimizerModel` | `openai/gpt-4.1` | reflection LM used by GEPA |
+| `evalModel` | `openai/gpt-4.1-mini` | task/judge LM used to score candidates |
+| `maxSkillBodyBytes` | `15360` | hard cap; candidates over this are rejected |
+| `maxDescriptionChars` | `1024` | hard cap |
+| `defaultIterations` | `10` | overridable via `--iterations` |
+| `defaultSources` | `synthetic,golden,traces` | overridable via `--sources` |
+| `minTraceObservations` | `10` | below this the `traces` source is auto-dropped |
+| `datasetsDir` | `datasets/skills` | repo-relative golden dataset root |
+| `workBranchPrefix` | `evolve/skill` | branch name prefix for PR mode |
+| `runTests` | `true` | run `testCommand` before committing |
+| `testCommand` | `npm test --silent` | test command to invoke on the variant |
+
+## Safety gates
+
+Before any variant is applied, it must pass a set of pure constraint
+checks (`plugins/skill-evolver/python/skill_evolver/constraints.py`):
+
+- size limits on description and body
+- description must be non-empty and fit on a few lines
+- body must keep a top-level heading
+- frontmatter must not leak into the body
+- the body must not grow more than 1.5× the baseline
+
+If `runTests` is true, the applied variant is written, tested, and rolled
+back on failure before the commit. The PR mode additionally pushes the
+branch and runs `gh pr create` with the evolution report as the body.
+
+## Python runtime
+
+The plugin declares its Python deps (`dspy`, `gepa`, `click`, `rich`,
+`pyyaml`, `pydantic`) in `hybridclaw.plugin.yaml`. HybridClaw's plugin
+loader provisions a per-plugin `.venv` on first use — preferring `uv` if
+available, otherwise `python3 -m venv`. No global install required.
+
+All LLM traffic goes through the DSPy-configured models, which inherit
+whichever provider keys are set in the HybridClaw environment
+(`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`).
+
+## Typical flow
+
+1. `hybridclaw skill-evolver list` — pick a skill with elevated failure rate.
+2. `hybridclaw skill-evolver extract <skill>` — materialize its traces dataset.
+3. `hybridclaw skill-evolver evolve <skill> --target description` — iterate
+   routing.
+4. `hybridclaw skill-evolver show <skill>` — review score deltas, constraint
+   gates, and the unified diff.
+5. If the result looks good, re-run with `--open-pr` to commit, test, and
+   open a PR. Otherwise curate `datasets/skills/<skill>/triggers.json` with
+   the failures and iterate.

--- a/plugins/skill-evolver/hybridclaw.plugin.yaml
+++ b/plugins/skill-evolver/hybridclaw.plugin.yaml
@@ -1,0 +1,77 @@
+id: skill-evolver
+name: Skill Evolver
+version: 0.1.0
+kind: tool
+description: Evolve SKILL.md descriptions (trigger accuracy) and bodies (execution quality) using DSPy + GEPA with three eval sources — synthetic, golden, and real traces from the HybridClaw SQLite DB and session transcripts.
+entrypoint: src/index.js
+credentials:
+  - OPENAI_API_KEY
+  - ANTHROPIC_API_KEY
+  - OPENROUTER_API_KEY
+pipDependencies:
+  - package: dspy>=2.6
+  - package: gepa>=0.0.14
+  - package: click>=8.1
+  - package: rich>=13.7
+  - package: pyyaml>=6.0
+  - package: pydantic>=2.6
+externalDependencies:
+  - name: GitHub CLI
+    check: gh --version
+    installHint: Install gh from https://cli.github.com/ to enable --open-pr.
+    installUrl: https://cli.github.com/
+configSchema:
+  type: object
+  additionalProperties: false
+  properties:
+    optimizerModel:
+      type: string
+      default: openai/gpt-4.1
+      description: Model used by GEPA to propose mutations (reflective mutator).
+    evalModel:
+      type: string
+      default: openai/gpt-4.1-mini
+      description: Model used as LLM-judge and synthetic data generator.
+    maxSkillBodyBytes:
+      type: number
+      default: 15360
+      minimum: 1024
+      maximum: 65536
+      description: Hard size cap on evolved SKILL.md body (bytes).
+    maxDescriptionChars:
+      type: number
+      default: 1024
+      minimum: 64
+      maximum: 4096
+      description: Hard size cap on evolved description field.
+    defaultIterations:
+      type: number
+      default: 10
+      minimum: 1
+      maximum: 100
+    defaultSources:
+      type: string
+      default: synthetic,golden,traces
+      description: Comma-separated eval sources to mix.
+    minTraceObservations:
+      type: number
+      default: 10
+      minimum: 1
+      maximum: 10000
+      description: Minimum skill_observations rows required before traces source is used.
+    datasetsDir:
+      type: string
+      default: datasets/skills
+      description: Where committed golden datasets live (relative to repo root).
+    workBranchPrefix:
+      type: string
+      default: evolve/skill
+      description: Prefix for branches created when --open-pr is used.
+    runTests:
+      type: boolean
+      default: true
+      description: Run repo test suite before accepting a variant.
+    testCommand:
+      type: string
+      default: npm test --silent
+      description: Shell command used to validate variants (run from repo root).

--- a/plugins/skill-evolver/package.json
+++ b/plugins/skill-evolver/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "hybridclaw-plugin-skill-evolver",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "HybridClaw plugin: evolve SKILL.md files (description + body) with DSPy + GEPA",
+  "engines": {
+    "node": "22.x"
+  }
+}

--- a/plugins/skill-evolver/pyproject.toml
+++ b/plugins/skill-evolver/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "hybridclaw-skill-evolver"
+version = "0.1.0"
+description = "DSPy + GEPA optimizer for HybridClaw SKILL.md files"
+requires-python = ">=3.11"
+dependencies = [
+    "dspy>=2.6",
+    "gepa>=0.0.14",
+    "click>=8.1",
+    "rich>=13.7",
+    "pyyaml>=6.0",
+    "pydantic>=2.6",
+]
+
+[project.scripts]
+skill-evolver = "skill_evolver.cli:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["python/skill_evolver"]

--- a/plugins/skill-evolver/python/skill_evolver/__init__.py
+++ b/plugins/skill-evolver/python/skill_evolver/__init__.py
@@ -1,0 +1,3 @@
+"""HybridClaw skill evolver — DSPy + GEPA optimization for SKILL.md files."""
+
+__version__ = "0.1.0"

--- a/plugins/skill-evolver/python/skill_evolver/__main__.py
+++ b/plugins/skill-evolver/python/skill_evolver/__main__.py
@@ -1,0 +1,4 @@
+from skill_evolver.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/plugins/skill-evolver/python/skill_evolver/cli.py
+++ b/plugins/skill-evolver/python/skill_evolver/cli.py
@@ -1,0 +1,127 @@
+"""CLI entry point — `python -m skill_evolver <subcommand> …`."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+from rich.console import Console
+
+from skill_evolver.evolve import EvolveConfig, run as run_evolution
+
+console = Console()
+
+
+@click.group()
+def main() -> None:
+    """HybridClaw skill evolver."""
+
+
+@main.command("evolve")
+@click.option("--skill-path", type=click.Path(exists=True, dir_okay=False, path_type=Path), required=True)
+@click.option("--skill-name", required=True)
+@click.option("--target", type=click.Choice(["description", "body", "both"]), required=True)
+@click.option("--iterations", type=int, default=10, show_default=True)
+@click.option("--sources", default="synthetic,golden,traces", show_default=True)
+@click.option("--optimizer-model", default="openai/gpt-4.1", show_default=True)
+@click.option("--eval-model", default="openai/gpt-4.1-mini", show_default=True)
+@click.option("--max-body-bytes", type=int, default=15360, show_default=True)
+@click.option("--max-description-chars", type=int, default=1024, show_default=True)
+@click.option("--repo-root", type=click.Path(exists=True, file_okay=False, path_type=Path), required=True)
+@click.option("--datasets-dir", type=click.Path(path_type=Path), required=True)
+@click.option("--work-dir", type=click.Path(path_type=Path), required=True)
+@click.option("--traces-dataset", type=click.Path(path_type=Path), default=None)
+@click.option("--dry-run", is_flag=True)
+def evolve_cmd(
+    skill_path: Path,
+    skill_name: str,
+    target: str,
+    iterations: int,
+    sources: str,
+    optimizer_model: str,
+    eval_model: str,
+    max_body_bytes: int,
+    max_description_chars: int,
+    repo_root: Path,
+    datasets_dir: Path,
+    work_dir: Path,
+    traces_dataset: Path | None,
+    dry_run: bool,
+) -> None:
+    source_list = [s.strip() for s in sources.split(",") if s.strip()]
+    config = EvolveConfig(
+        skill_path=skill_path,
+        skill_name=skill_name,
+        target=target,
+        sources=source_list,
+        iterations=iterations,
+        optimizer_model=optimizer_model,
+        eval_model=eval_model,
+        max_body_bytes=max_body_bytes,
+        max_description_chars=max_description_chars,
+        repo_root=repo_root,
+        datasets_dir=datasets_dir,
+        work_dir=work_dir,
+        traces_dataset_path=traces_dataset,
+        dry_run=dry_run,
+    )
+    try:
+        result = run_evolution(config)
+    except Exception as err:  # pragma: no cover
+        console.print(f"[red]Evolution failed: {err}[/red]")
+        sys.exit(1)
+    console.print_json(json.dumps({"runId": result.get("runId"), "applicable": result.get("applicable", False)}))
+
+
+@main.command("version")
+def version_cmd() -> None:
+    from skill_evolver import __version__
+    console.print(__version__)
+
+
+@main.command("show")
+@click.argument(
+    "result_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+def show_cmd(result_path: Path) -> None:
+    """Pretty-render a completed run's result.json."""
+    from skill_evolver.tui import show_result
+
+    show_result(result_path, console=console)
+
+
+@main.command("watch")
+@click.argument(
+    "work_dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+)
+@click.option("--poll-interval", type=float, default=1.5, show_default=True)
+def watch_cmd(work_dir: Path, poll_interval: float) -> None:
+    """Live-refresh the summary of a work dir while evolution runs."""
+    from skill_evolver.tui import watch_work_dir
+
+    watch_work_dir(work_dir, poll_interval=poll_interval, console=console)
+
+
+@main.command("tui")
+@click.option(
+    "--repo-root",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    required=True,
+)
+@click.option(
+    "--datasets-dir",
+    type=click.Path(path_type=Path),
+    required=True,
+)
+def tui_cmd(repo_root: Path, datasets_dir: Path) -> None:
+    """Browse skills in an interactive terminal UI."""
+    from skill_evolver.tui import browse_skills
+
+    browse_skills(repo_root, datasets_dir, console=console)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/skill-evolver/python/skill_evolver/constraints.py
+++ b/plugins/skill-evolver/python/skill_evolver/constraints.py
@@ -7,6 +7,7 @@ in fitness/ instead.
 from __future__ import annotations
 
 import re
+import shlex
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -96,7 +97,12 @@ def check_growth_cap(
 def run_test_suite(
     command: str, cwd: Path, *, timeout_s: int = 600
 ) -> ConstraintResult:
-    parts = [p for p in command.split() if p]
+    try:
+        parts = shlex.split(command or "")
+    except ValueError as err:
+        return ConstraintResult(
+            "test_suite", False, f"could not parse test command: {err}"
+        )
     if not parts:
         return ConstraintResult("test_suite", True, "test command empty — skipped")
     try:

--- a/plugins/skill-evolver/python/skill_evolver/constraints.py
+++ b/plugins/skill-evolver/python/skill_evolver/constraints.py
@@ -1,0 +1,158 @@
+"""Hard constraints that every evolved variant must satisfy.
+
+These are gates, not scores. If any gate fails, the variant is rejected
+regardless of how good its fitness score looks. Soft quality signals belong
+in fitness/ instead.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class ConstraintResult:
+    name: str
+    passed: bool
+    message: str
+    detail: str = ""
+
+
+def check_size_body(body: str, *, max_bytes: int) -> ConstraintResult:
+    size = len(body.encode("utf-8"))
+    passed = size <= max_bytes
+    return ConstraintResult(
+        name="body_size",
+        passed=passed,
+        message=f"body is {size} bytes (limit {max_bytes})",
+    )
+
+
+def check_size_description(description: str, *, max_chars: int) -> ConstraintResult:
+    size = len(description)
+    passed = 0 < size <= max_chars
+    return ConstraintResult(
+        name="description_size",
+        passed=passed,
+        message=f"description is {size} chars (limit {max_chars})",
+    )
+
+
+def check_description_shape(description: str) -> ConstraintResult:
+    stripped = description.strip()
+    if not stripped:
+        return ConstraintResult("description_shape", False, "description is empty")
+    if "\n\n" in stripped:
+        return ConstraintResult(
+            "description_shape", False, "description should be a single paragraph"
+        )
+    if len(stripped) < 20:
+        return ConstraintResult(
+            "description_shape", False, "description is too short to be useful"
+        )
+    return ConstraintResult("description_shape", True, "description shape ok")
+
+
+def check_body_structure(body: str) -> ConstraintResult:
+    stripped = body.strip()
+    if not stripped:
+        return ConstraintResult("body_structure", False, "body is empty")
+    if not re.search(r"^#\s+", stripped, re.MULTILINE):
+        return ConstraintResult(
+            "body_structure",
+            False,
+            "body has no top-level heading — skills should open with a title",
+        )
+    return ConstraintResult("body_structure", True, "body structure ok")
+
+
+def check_no_frontmatter_leak(body: str) -> ConstraintResult:
+    if body.lstrip().startswith("---"):
+        return ConstraintResult(
+            "no_frontmatter_leak",
+            False,
+            "body begins with frontmatter markers — mutator leaked YAML",
+        )
+    return ConstraintResult("no_frontmatter_leak", True, "no frontmatter in body")
+
+
+def check_growth_cap(
+    body: str, *, baseline_body: str, growth_multiplier: float = 1.5
+) -> ConstraintResult:
+    baseline_size = len(baseline_body.encode("utf-8"))
+    size = len(body.encode("utf-8"))
+    limit = int(baseline_size * growth_multiplier)
+    passed = size <= limit
+    return ConstraintResult(
+        name="body_growth",
+        passed=passed,
+        message=f"body {size}B vs baseline {baseline_size}B × {growth_multiplier} = {limit}B",
+    )
+
+
+def run_test_suite(
+    command: str, cwd: Path, *, timeout_s: int = 600
+) -> ConstraintResult:
+    parts = [p for p in command.split() if p]
+    if not parts:
+        return ConstraintResult("test_suite", True, "test command empty — skipped")
+    try:
+        result = subprocess.run(
+            parts,
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired:
+        return ConstraintResult(
+            "test_suite", False, f"test suite timed out after {timeout_s}s"
+        )
+    except FileNotFoundError as err:
+        return ConstraintResult(
+            "test_suite", False, f"test command not found: {err}"
+        )
+    tail = (result.stdout or result.stderr or "").strip().splitlines()[-5:]
+    return ConstraintResult(
+        name="test_suite",
+        passed=result.returncode == 0,
+        message=f"exit={result.returncode}",
+        detail="\n".join(tail),
+    )
+
+
+def validate_description(
+    description: str, *, max_chars: int
+) -> list[ConstraintResult]:
+    return [
+        check_size_description(description, max_chars=max_chars),
+        check_description_shape(description),
+    ]
+
+
+def validate_body(
+    body: str,
+    *,
+    baseline_body: str,
+    max_bytes: int,
+) -> list[ConstraintResult]:
+    return [
+        check_size_body(body, max_bytes=max_bytes),
+        check_body_structure(body),
+        check_no_frontmatter_leak(body),
+        check_growth_cap(body, baseline_body=baseline_body),
+    ]
+
+
+def all_passed(results: list[ConstraintResult]) -> bool:
+    return all(r.passed for r in results)
+
+
+def summarize(results: list[ConstraintResult]) -> str:
+    return "\n".join(
+        f"  [{'PASS' if r.passed else 'FAIL'}] {r.name}: {r.message}"
+        for r in results
+    )

--- a/plugins/skill-evolver/python/skill_evolver/dataset/__init__.py
+++ b/plugins/skill-evolver/python/skill_evolver/dataset/__init__.py
@@ -1,0 +1,1 @@
+"""Dataset builders — synthetic, golden, and trace-based."""

--- a/plugins/skill-evolver/python/skill_evolver/dataset/golden.py
+++ b/plugins/skill-evolver/python/skill_evolver/dataset/golden.py
@@ -1,0 +1,67 @@
+"""Golden dataset loader — hand-curated examples committed to the repo.
+
+Layout under datasets/skills/<skill-name>/:
+  triggers.json  — trigger-labeled prompts (description target)
+  tasks.json     — task/rubric pairs (body target)
+
+Both files are optional. If absent, the golden source contributes nothing.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from skill_evolver.fitness.classifier import TriggerExample
+from skill_evolver.fitness.executor import TaskExample
+
+
+def load_triggers(
+    datasets_dir: Path, skill_name: str, competing_skills: list[dict]
+) -> list[TriggerExample]:
+    path = datasets_dir / skill_name / "triggers.json"
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(data, list):
+        return []
+    examples: list[TriggerExample] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        prompt = str(item.get("prompt", "")).strip()
+        if not prompt:
+            continue
+        should = bool(item.get("should_trigger", False))
+        examples.append(
+            TriggerExample(
+                prompt=prompt,
+                should_trigger=should,
+                competing_skills=competing_skills,
+            )
+        )
+    return examples
+
+
+def load_tasks(datasets_dir: Path, skill_name: str) -> list[TaskExample]:
+    path = datasets_dir / skill_name / "tasks.json"
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(data, list):
+        return []
+    examples: list[TaskExample] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        prompt = str(item.get("prompt", "")).strip()
+        expected = str(item.get("expected_behavior", "")).strip()
+        if not prompt or not expected:
+            continue
+        examples.append(TaskExample(prompt=prompt, expected_behavior=expected))
+    return examples

--- a/plugins/skill-evolver/python/skill_evolver/dataset/merge.py
+++ b/plugins/skill-evolver/python/skill_evolver/dataset/merge.py
@@ -53,6 +53,18 @@ def dedupe_tasks(examples: list[TaskExample]) -> list[TaskExample]:
     return deduped
 
 
+def _val_slice_size(total: int, val_fraction: float) -> int:
+    """Pick a val slice that never consumes the entire pool.
+
+    GEPA consumes the train split as its optimizer trainset; leaving it
+    empty is a no-op evolution. So we cap val at ``total - 1`` whenever
+    there are at least two examples.
+    """
+    if total <= 1:
+        return 0
+    return min(total - 1, max(1, int(total * val_fraction)))
+
+
 def split_triggers(
     examples: list[TriggerExample], *, val_fraction: float = 0.25, seed: int = 42
 ) -> TriggerSplit:
@@ -61,8 +73,8 @@ def split_triggers(
     rng.shuffle(shuffled)
     positives = [ex for ex in shuffled if ex.should_trigger]
     negatives = [ex for ex in shuffled if not ex.should_trigger]
-    pos_val = max(1, int(len(positives) * val_fraction)) if positives else 0
-    neg_val = max(1, int(len(negatives) * val_fraction)) if negatives else 0
+    pos_val = _val_slice_size(len(positives), val_fraction)
+    neg_val = _val_slice_size(len(negatives), val_fraction)
     val = positives[:pos_val] + negatives[:neg_val]
     train = positives[pos_val:] + negatives[neg_val:]
     rng.shuffle(val)
@@ -76,5 +88,5 @@ def split_tasks(
     rng = random.Random(seed)
     shuffled = examples[:]
     rng.shuffle(shuffled)
-    val_size = max(1, int(len(shuffled) * val_fraction)) if shuffled else 0
+    val_size = _val_slice_size(len(shuffled), val_fraction)
     return TaskSplit(train=shuffled[val_size:], val=shuffled[:val_size])

--- a/plugins/skill-evolver/python/skill_evolver/dataset/merge.py
+++ b/plugins/skill-evolver/python/skill_evolver/dataset/merge.py
@@ -1,0 +1,80 @@
+"""Combine the three dataset sources into train/val splits.
+
+Deduplicates by normalized prompt. Ensures a minimum size per split so GEPA
+has something to evaluate against.
+"""
+from __future__ import annotations
+
+import random
+import re
+from dataclasses import dataclass
+
+from skill_evolver.fitness.classifier import TriggerExample
+from skill_evolver.fitness.executor import TaskExample
+
+
+def _normalize(prompt: str) -> str:
+    return re.sub(r"\s+", " ", prompt.strip().lower())
+
+
+@dataclass
+class TriggerSplit:
+    train: list[TriggerExample]
+    val: list[TriggerExample]
+
+
+@dataclass
+class TaskSplit:
+    train: list[TaskExample]
+    val: list[TaskExample]
+
+
+def dedupe_triggers(examples: list[TriggerExample]) -> list[TriggerExample]:
+    seen: set[str] = set()
+    deduped: list[TriggerExample] = []
+    for ex in examples:
+        key = _normalize(ex.prompt)
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        deduped.append(ex)
+    return deduped
+
+
+def dedupe_tasks(examples: list[TaskExample]) -> list[TaskExample]:
+    seen: set[str] = set()
+    deduped: list[TaskExample] = []
+    for ex in examples:
+        key = _normalize(ex.prompt)
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        deduped.append(ex)
+    return deduped
+
+
+def split_triggers(
+    examples: list[TriggerExample], *, val_fraction: float = 0.25, seed: int = 42
+) -> TriggerSplit:
+    rng = random.Random(seed)
+    shuffled = examples[:]
+    rng.shuffle(shuffled)
+    positives = [ex for ex in shuffled if ex.should_trigger]
+    negatives = [ex for ex in shuffled if not ex.should_trigger]
+    pos_val = max(1, int(len(positives) * val_fraction)) if positives else 0
+    neg_val = max(1, int(len(negatives) * val_fraction)) if negatives else 0
+    val = positives[:pos_val] + negatives[:neg_val]
+    train = positives[pos_val:] + negatives[neg_val:]
+    rng.shuffle(val)
+    rng.shuffle(train)
+    return TriggerSplit(train=train, val=val)
+
+
+def split_tasks(
+    examples: list[TaskExample], *, val_fraction: float = 0.25, seed: int = 42
+) -> TaskSplit:
+    rng = random.Random(seed)
+    shuffled = examples[:]
+    rng.shuffle(shuffled)
+    val_size = max(1, int(len(shuffled) * val_fraction)) if shuffled else 0
+    return TaskSplit(train=shuffled[val_size:], val=shuffled[:val_size])

--- a/plugins/skill-evolver/python/skill_evolver/dataset/synthetic.py
+++ b/plugins/skill-evolver/python/skill_evolver/dataset/synthetic.py
@@ -1,0 +1,146 @@
+"""Synthetic dataset generation via LLM.
+
+Produces two shapes:
+- Trigger dataset: (prompt, should_trigger, competing_skills) for description eval
+- Task dataset: (prompt, expected_behavior) for body eval
+
+The generation prompt grounds the LLM in the current SKILL.md so the
+synthetic data is realistic for the skill's actual purpose.
+"""
+from __future__ import annotations
+
+import json
+import re
+
+import dspy
+
+from skill_evolver.fitness.classifier import TriggerExample
+from skill_evolver.fitness.executor import TaskExample
+
+
+class GenerateTriggersSignature(dspy.Signature):
+    """Generate evaluation prompts for a skill's trigger/routing accuracy.
+
+    You will produce a JSON array of objects. Each object is either:
+      {"prompt": "...", "should_trigger": true}   # clearly this skill's territory
+      {"prompt": "...", "should_trigger": false}  # similar-sounding but NOT this skill
+
+    Aim for 40% positive, 60% negative (including adversarial near-misses that
+    a naive classifier might misroute). Make prompts realistic — how a user
+    would actually phrase them, not test-case-flavored.
+
+    Return ONLY the JSON array, no markdown fences.
+    """
+    skill_name: str = dspy.InputField()
+    skill_description: str = dspy.InputField()
+    skill_body_excerpt: str = dspy.InputField(desc="First ~1500 chars of SKILL.md body")
+    competing_skills_context: str = dspy.InputField(
+        desc="Short summaries of nearby/competing skills to avoid collision"
+    )
+    count: int = dspy.InputField(desc="Total number of prompts to generate")
+    dataset_json: str = dspy.OutputField(desc="JSON array of {prompt, should_trigger}")
+
+
+class GenerateTasksSignature(dspy.Signature):
+    """Generate evaluation tasks for a skill's execution quality.
+
+    Produce a JSON array of objects:
+      {"prompt": "...", "expected_behavior": "..."}
+
+    - prompt: a realistic user task this skill should handle
+    - expected_behavior: a rubric paragraph describing what a correct response
+      looks like — what the artifact should contain, what procedure should be
+      followed, what to avoid. Detailed enough that an LLM-judge can score.
+
+    Cover a range: easy / typical / hard / edge-case. Return ONLY the JSON array.
+    """
+    skill_name: str = dspy.InputField()
+    skill_description: str = dspy.InputField()
+    skill_body: str = dspy.InputField()
+    count: int = dspy.InputField()
+    dataset_json: str = dspy.OutputField()
+
+
+def _parse_json_array(raw: str) -> list[dict]:
+    raw = raw.strip()
+    fence = re.match(r"^```(?:json)?\s*(.*?)\s*```$", raw, re.DOTALL)
+    if fence:
+        raw = fence.group(1).strip()
+    start = raw.find("[")
+    end = raw.rfind("]")
+    if start < 0 or end < 0 or end <= start:
+        return []
+    try:
+        parsed = json.loads(raw[start : end + 1])
+    except json.JSONDecodeError:
+        return []
+    return [item for item in parsed if isinstance(item, dict)]
+
+
+def generate_triggers(
+    *,
+    skill_name: str,
+    skill_description: str,
+    skill_body: str,
+    competing_skills: list[dict],
+    count: int,
+    eval_lm_name: str,
+) -> list[TriggerExample]:
+    context = "\n".join(
+        f"- {s['name']}: {s['description']}" for s in competing_skills[:12]
+    ) or "(no adjacent skills provided)"
+    excerpt = skill_body[:1500]
+
+    generator = dspy.ChainOfThought(GenerateTriggersSignature)
+    lm = dspy.LM(eval_lm_name)
+    with dspy.context(lm=lm):
+        result = generator(
+            skill_name=skill_name,
+            skill_description=skill_description,
+            skill_body_excerpt=excerpt,
+            competing_skills_context=context,
+            count=count,
+        )
+    parsed = _parse_json_array(str(getattr(result, "dataset_json", "")))
+    examples: list[TriggerExample] = []
+    for item in parsed:
+        prompt = str(item.get("prompt", "")).strip()
+        if not prompt:
+            continue
+        should = bool(item.get("should_trigger", False))
+        examples.append(
+            TriggerExample(
+                prompt=prompt,
+                should_trigger=should,
+                competing_skills=competing_skills,
+            )
+        )
+    return examples
+
+
+def generate_tasks(
+    *,
+    skill_name: str,
+    skill_description: str,
+    skill_body: str,
+    count: int,
+    eval_lm_name: str,
+) -> list[TaskExample]:
+    generator = dspy.ChainOfThought(GenerateTasksSignature)
+    lm = dspy.LM(eval_lm_name)
+    with dspy.context(lm=lm):
+        result = generator(
+            skill_name=skill_name,
+            skill_description=skill_description,
+            skill_body=skill_body[:6000],
+            count=count,
+        )
+    parsed = _parse_json_array(str(getattr(result, "dataset_json", "")))
+    examples: list[TaskExample] = []
+    for item in parsed:
+        prompt = str(item.get("prompt", "")).strip()
+        expected = str(item.get("expected_behavior", "")).strip()
+        if not prompt or not expected:
+            continue
+        examples.append(TaskExample(prompt=prompt, expected_behavior=expected))
+    return examples

--- a/plugins/skill-evolver/python/skill_evolver/dataset/traces.py
+++ b/plugins/skill-evolver/python/skill_evolver/dataset/traces.py
@@ -1,0 +1,117 @@
+"""Trace-based dataset construction from HybridClaw's sqlite observations.
+
+Consumes the JSON file produced by the TS trace-extractor. Two products:
+
+- Triggers: user prompts that DID invoke this skill (positives) plus prompts
+  that invoked other skills (negatives). These need a rubric the classifier
+  trusts — we treat successful invocations as positives and near-miss sibling
+  invocations as negatives.
+
+- Tasks: user prompts that successfully invoked this skill, paired with an
+  LLM-synthesized rubric describing what a correct response looks like, given
+  the observed outcome. Failed observations become harder test cases.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import dspy
+
+from skill_evolver.fitness.classifier import TriggerExample
+from skill_evolver.fitness.executor import TaskExample
+
+
+class SynthesizeRubricSignature(dspy.Signature):
+    """Given a user prompt and observed outcome, write a rubric for a judge.
+
+    The rubric should describe what a good response to the prompt looks like —
+    concrete artifacts, structure, procedure. If the trace shows a failure,
+    make the rubric address that specific failure mode (e.g. "must not …",
+    "must correctly handle …").
+    """
+    skill_name: str = dspy.InputField()
+    skill_description: str = dspy.InputField()
+    user_prompt: str = dspy.InputField()
+    outcome: str = dspy.InputField(desc="success/partial/failure")
+    error_category: str = dspy.InputField()
+    error_detail: str = dspy.InputField()
+    rubric: str = dspy.OutputField(desc="1-paragraph rubric for an LLM-judge")
+
+
+def load_trace_payload(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+
+
+def build_triggers(
+    payload: dict, competing_skills: list[dict]
+) -> list[TriggerExample]:
+    examples: list[TriggerExample] = []
+    for obs in payload.get("observations", []):
+        prompt = str(obs.get("user_prompt", "")).strip()
+        if not prompt:
+            continue
+        if obs.get("outcome") == "success":
+            examples.append(
+                TriggerExample(
+                    prompt=prompt, should_trigger=True, competing_skills=competing_skills
+                )
+            )
+    for obs in payload.get("otherSkillObservations", []):
+        prompt = str(obs.get("user_prompt", "")).strip()
+        if not prompt:
+            continue
+        examples.append(
+            TriggerExample(
+                prompt=prompt, should_trigger=False, competing_skills=competing_skills
+            )
+        )
+    return examples
+
+
+def build_tasks(
+    payload: dict,
+    *,
+    skill_name: str,
+    skill_description: str,
+    eval_lm_name: str,
+    max_examples: int = 40,
+) -> list[TaskExample]:
+    observations = payload.get("observations", [])
+    observations = [o for o in observations if str(o.get("user_prompt", "")).strip()]
+
+    prioritized = sorted(
+        observations,
+        key=lambda o: (0 if o.get("outcome") != "success" else 1, o.get("created_at", "")),
+    )[:max_examples]
+    if not prioritized:
+        return []
+
+    rubric_gen = dspy.ChainOfThought(SynthesizeRubricSignature)
+    lm = dspy.LM(eval_lm_name)
+    examples: list[TaskExample] = []
+    with dspy.context(lm=lm):
+        for obs in prioritized:
+            try:
+                result = rubric_gen(
+                    skill_name=skill_name,
+                    skill_description=skill_description,
+                    user_prompt=obs["user_prompt"],
+                    outcome=str(obs.get("outcome", "")),
+                    error_category=str(obs.get("error_category") or ""),
+                    error_detail=str(obs.get("error_detail") or "")[:600],
+                )
+                rubric = str(getattr(result, "rubric", "")).strip()
+            except Exception:  # pragma: no cover
+                rubric = ""
+            if not rubric:
+                continue
+            examples.append(
+                TaskExample(prompt=obs["user_prompt"], expected_behavior=rubric)
+            )
+    return examples

--- a/plugins/skill-evolver/python/skill_evolver/evolve.py
+++ b/plugins/skill-evolver/python/skill_evolver/evolve.py
@@ -1,0 +1,302 @@
+"""Top-level evolution orchestrator.
+
+Loads a SKILL.md, builds the dataset from three sources, runs the chosen
+target's GEPA loop, validates constraints, and writes a result.json that
+the TS plugin consumes to decide whether to open a PR.
+"""
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Optional
+
+import dspy
+
+from skill_evolver import constraints
+from skill_evolver.dataset import golden, merge, synthetic, traces
+from skill_evolver.skill_module import ParsedSkill, load_skill, reassemble
+from skill_evolver.targets import body as body_target
+from skill_evolver.targets import description as description_target
+from skill_evolver.targets import joint as joint_target
+
+
+@dataclass
+class EvolveConfig:
+    skill_path: Path
+    skill_name: str
+    target: str
+    sources: list[str]
+    iterations: int
+    optimizer_model: str
+    eval_model: str
+    max_body_bytes: int
+    max_description_chars: int
+    repo_root: Path
+    datasets_dir: Path
+    work_dir: Path
+    traces_dataset_path: Optional[Path]
+    dry_run: bool
+
+
+def _collect_competing_skills(
+    repo_root: Path, target_skill: ParsedSkill, max_count: int = 40
+) -> list[dict]:
+    search_roots = ["skills", "community-skills", "plugins"]
+    skills: list[dict] = []
+    for rel in search_roots:
+        root = repo_root / rel
+        if not root.exists():
+            continue
+        for skill_md in root.rglob("SKILL.md"):
+            if skill_md == target_skill.path:
+                continue
+            try:
+                parsed = load_skill(skill_md)
+            except Exception:
+                continue
+            if not parsed.description:
+                continue
+            skills.append({"name": parsed.name, "description": parsed.description})
+            if len(skills) >= max_count:
+                return skills
+    return skills
+
+
+def _configure_dspy(eval_model: str) -> None:
+    try:
+        lm = dspy.LM(eval_model)
+        dspy.configure(lm=lm)
+    except Exception:
+        pass
+
+
+def _build_trigger_dataset(
+    config: EvolveConfig, skill: ParsedSkill, competing: list[dict]
+):
+    combined = []
+    if "synthetic" in config.sources:
+        combined.extend(
+            synthetic.generate_triggers(
+                skill_name=skill.name,
+                skill_description=skill.description,
+                skill_body=skill.body,
+                competing_skills=competing,
+                count=40,
+                eval_lm_name=config.eval_model,
+            )
+        )
+    if "golden" in config.sources:
+        combined.extend(golden.load_triggers(config.datasets_dir, skill.name, competing))
+    if "traces" in config.sources and config.traces_dataset_path:
+        payload = traces.load_trace_payload(config.traces_dataset_path)
+        combined.extend(traces.build_triggers(payload, competing))
+    deduped = merge.dedupe_triggers(combined)
+    return merge.split_triggers(deduped)
+
+
+def _build_task_dataset(config: EvolveConfig, skill: ParsedSkill):
+    combined = []
+    if "synthetic" in config.sources:
+        combined.extend(
+            synthetic.generate_tasks(
+                skill_name=skill.name,
+                skill_description=skill.description,
+                skill_body=skill.body,
+                count=20,
+                eval_lm_name=config.eval_model,
+            )
+        )
+    if "golden" in config.sources:
+        combined.extend(golden.load_tasks(config.datasets_dir, skill.name))
+    if "traces" in config.sources and config.traces_dataset_path:
+        payload = traces.load_trace_payload(config.traces_dataset_path)
+        combined.extend(
+            traces.build_tasks(
+                payload,
+                skill_name=skill.name,
+                skill_description=skill.description,
+                eval_lm_name=config.eval_model,
+            )
+        )
+    deduped = merge.dedupe_tasks(combined)
+    return merge.split_tasks(deduped)
+
+
+def _validate_variant(
+    *,
+    target: str,
+    baseline: ParsedSkill,
+    description: str,
+    body: str,
+    max_body_bytes: int,
+    max_description_chars: int,
+) -> list[constraints.ConstraintResult]:
+    results: list[constraints.ConstraintResult] = []
+    if target in ("description", "both"):
+        results.extend(
+            constraints.validate_description(
+                description, max_chars=max_description_chars
+            )
+        )
+    if target in ("body", "both"):
+        results.extend(
+            constraints.validate_body(
+                body, baseline_body=baseline.body, max_bytes=max_body_bytes
+            )
+        )
+    return results
+
+
+def run(config: EvolveConfig) -> dict:
+    config.work_dir.mkdir(parents=True, exist_ok=True)
+    run_id = uuid.uuid4().hex[:12]
+    started_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+    _configure_dspy(config.eval_model)
+
+    skill = load_skill(config.skill_path)
+    competing = _collect_competing_skills(config.repo_root, skill)
+
+    result: dict = {
+        "runId": run_id,
+        "startedAt": started_at,
+        "skillName": skill.name,
+        "skillPath": str(skill.path),
+        "target": config.target,
+        "sources": config.sources,
+        "iterations": config.iterations,
+        "baseline": skill.describe(),
+        "competingSkillCount": len(competing),
+    }
+
+    if config.dry_run:
+        result["dryRun"] = True
+        (config.work_dir / "result.json").write_text(
+            json.dumps(result, indent=2), encoding="utf-8"
+        )
+        return result
+
+    trigger_split = None
+    task_split = None
+
+    if config.target in ("description", "both"):
+        trigger_split = _build_trigger_dataset(config, skill, competing)
+        result["triggerDataset"] = {
+            "train": len(trigger_split.train),
+            "val": len(trigger_split.val),
+        }
+    if config.target in ("body", "both"):
+        task_split = _build_task_dataset(config, skill)
+        result["taskDataset"] = {
+            "train": len(task_split.train),
+            "val": len(task_split.val),
+        }
+
+    best_description = skill.description
+    best_body = skill.body
+    feedback_trail: list[str] = []
+
+    if config.target == "description" and trigger_split:
+        run_result = description_target.run(
+            skill_name=skill.name,
+            baseline_description=skill.description,
+            train_examples=trigger_split.train,
+            val_examples=trigger_split.val,
+            optimizer_model=config.optimizer_model,
+            eval_model=config.eval_model,
+            iterations=config.iterations,
+        )
+        best_description = run_result.best_description
+        feedback_trail = run_result.feedback_trail
+        result["descriptionScore"] = {
+            "baseline": run_result.baseline_score,
+            "best": run_result.best_score,
+        }
+    elif config.target == "body" and task_split:
+        run_result = body_target.run(
+            baseline_body=skill.body,
+            train_examples=task_split.train,
+            val_examples=task_split.val,
+            optimizer_model=config.optimizer_model,
+            eval_model=config.eval_model,
+            iterations=config.iterations,
+            max_body_bytes=config.max_body_bytes,
+        )
+        best_body = run_result.best_body
+        feedback_trail = run_result.feedback_trail
+        result["bodyScore"] = {
+            "baseline": run_result.baseline_score,
+            "best": run_result.best_score,
+        }
+    elif config.target == "both" and trigger_split and task_split:
+        run_result = joint_target.run(
+            skill_name=skill.name,
+            baseline_description=skill.description,
+            baseline_body=skill.body,
+            trigger_train=trigger_split.train,
+            trigger_val=trigger_split.val,
+            task_train=task_split.train,
+            task_val=task_split.val,
+            optimizer_model=config.optimizer_model,
+            eval_model=config.eval_model,
+            iterations=config.iterations,
+            max_body_bytes=config.max_body_bytes,
+        )
+        best_description = run_result.best_description
+        best_body = run_result.best_body
+        feedback_trail = run_result.feedback_trail
+        result["descriptionScore"] = {
+            "baseline": run_result.description_baseline_score,
+            "best": run_result.description_best_score,
+        }
+        result["bodyScore"] = {
+            "baseline": run_result.body_baseline_score,
+            "best": run_result.body_best_score,
+        }
+    else:
+        result["error"] = (
+            f"target={config.target} requires the relevant dataset shape, which is empty."
+        )
+        (config.work_dir / "result.json").write_text(
+            json.dumps(result, indent=2), encoding="utf-8"
+        )
+        return result
+
+    validation = _validate_variant(
+        target=config.target,
+        baseline=skill,
+        description=best_description,
+        body=best_body,
+        max_body_bytes=config.max_body_bytes,
+        max_description_chars=config.max_description_chars,
+    )
+    result["constraints"] = [
+        {"name": r.name, "passed": r.passed, "message": r.message} for r in validation
+    ]
+
+    best_variant_raw = None
+    if constraints.all_passed(validation):
+        best_variant_raw = reassemble(
+            skill,
+            description=best_description if config.target != "body" else None,
+            body=best_body if config.target != "description" else None,
+        )
+        result["bestVariantRaw"] = best_variant_raw
+        result["applicable"] = True
+    else:
+        result["applicable"] = False
+
+    result["feedbackTrail"] = feedback_trail
+    result["finishedAt"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+    from skill_evolver.report import render_report_markdown
+
+    result["reportMarkdown"] = render_report_markdown(skill, result)
+
+    (config.work_dir / "result.json").write_text(
+        json.dumps(result, indent=2), encoding="utf-8"
+    )
+    return result

--- a/plugins/skill-evolver/python/skill_evolver/fitness/__init__.py
+++ b/plugins/skill-evolver/python/skill_evolver/fitness/__init__.py
@@ -1,0 +1,1 @@
+"""Fitness functions — how well does a variant perform on a given dataset?"""

--- a/plugins/skill-evolver/python/skill_evolver/fitness/classifier.py
+++ b/plugins/skill-evolver/python/skill_evolver/fitness/classifier.py
@@ -1,0 +1,157 @@
+"""Trigger-classifier fitness for the description target.
+
+Given a pool of competing skill descriptions, does the evolved description
+cause the correct skill to fire on labeled prompts?
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import dspy
+
+
+@dataclass
+class TriggerExample:
+    prompt: str
+    should_trigger: bool
+    competing_skills: list[dict]
+
+
+@dataclass
+class ClassifierScore:
+    precision: float
+    recall: float
+    f1: float
+    accuracy: float
+    feedback: str
+    correct_count: int
+    total_count: int
+
+    @property
+    def composite(self) -> float:
+        return self.f1
+
+
+class SkillRouterSignature(dspy.Signature):
+    """Route a user prompt to the most appropriate skill (or none).
+
+    You are choosing which skill should handle a user's prompt from a
+    numbered list. Return the number of the most appropriate skill, or 0
+    if none of them is a clear match.
+
+    Prefer 0 (no match) over forcing a match when the prompt is clearly
+    outside every skill's scope.
+    """
+    user_prompt: str = dspy.InputField(desc="The user's request")
+    skills_list: str = dspy.InputField(
+        desc="Numbered list of candidate skills with their descriptions"
+    )
+    chosen_index: int = dspy.OutputField(
+        desc="Integer index of the chosen skill, or 0 for no match"
+    )
+    reasoning: str = dspy.OutputField(
+        desc="One sentence explaining the routing decision"
+    )
+
+
+def _format_skill_pool(
+    target_name: str,
+    target_description: str,
+    competing: list[dict],
+) -> tuple[str, int]:
+    entries = [
+        {"name": target_name, "description": target_description},
+        *competing,
+    ]
+    # Stable order for reproducibility; randomize in caller if desired.
+    lines = []
+    target_index = 1
+    for idx, skill in enumerate(entries, start=1):
+        if skill["name"] == target_name:
+            target_index = idx
+        lines.append(f"{idx}. {skill['name']} — {skill['description']}")
+    return "\n".join(lines), target_index
+
+
+def score_description(
+    *,
+    target_name: str,
+    target_description: str,
+    examples: list[TriggerExample],
+    eval_lm_name: str,
+) -> ClassifierScore:
+    if not examples:
+        return ClassifierScore(
+            precision=0.0,
+            recall=0.0,
+            f1=0.0,
+            accuracy=0.0,
+            feedback="No trigger examples provided — cannot score description.",
+            correct_count=0,
+            total_count=0,
+        )
+    router = dspy.ChainOfThought(SkillRouterSignature)
+    lm = dspy.LM(eval_lm_name)
+
+    tp = fp = fn = tn = 0
+    failure_notes: list[str] = []
+
+    with dspy.context(lm=lm):
+        for example in examples:
+            pool_text, target_idx = _format_skill_pool(
+                target_name, target_description, example.competing_skills
+            )
+            try:
+                prediction = router(
+                    user_prompt=example.prompt,
+                    skills_list=pool_text,
+                )
+                chosen = int(getattr(prediction, "chosen_index", 0) or 0)
+                reasoning = str(getattr(prediction, "reasoning", ""))[:200]
+            except Exception as err:  # pragma: no cover - LM faults are reported, not raised
+                chosen = 0
+                reasoning = f"router_error: {err}"
+
+            triggered = chosen == target_idx
+            if example.should_trigger and triggered:
+                tp += 1
+            elif example.should_trigger and not triggered:
+                fn += 1
+                failure_notes.append(
+                    f"MISSED TRIGGER — prompt={example.prompt!r} chose={chosen} ({reasoning})"
+                )
+            elif not example.should_trigger and triggered:
+                fp += 1
+                failure_notes.append(
+                    f"OVER-TRIGGERED — prompt={example.prompt!r} ({reasoning})"
+                )
+            else:
+                tn += 1
+
+    total = tp + fp + fn + tn
+    precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+    recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+    f1 = (
+        (2 * precision * recall) / (precision + recall)
+        if (precision + recall) > 0
+        else 0.0
+    )
+    accuracy = (tp + tn) / total if total > 0 else 0.0
+
+    feedback_lines = [
+        f"Trigger F1={f1:.3f} (precision={precision:.3f}, recall={recall:.3f}, accuracy={accuracy:.3f})",
+        f"TP={tp} FP={fp} FN={fn} TN={tn}",
+    ]
+    feedback_lines.extend(failure_notes[:8])
+    if len(failure_notes) > 8:
+        feedback_lines.append(f"... and {len(failure_notes) - 8} more failures.")
+
+    return ClassifierScore(
+        precision=precision,
+        recall=recall,
+        f1=f1,
+        accuracy=accuracy,
+        feedback="\n".join(feedback_lines),
+        correct_count=tp + tn,
+        total_count=total,
+    )

--- a/plugins/skill-evolver/python/skill_evolver/fitness/executor.py
+++ b/plugins/skill-evolver/python/skill_evolver/fitness/executor.py
@@ -1,0 +1,158 @@
+"""Execution fitness for the body target — LLM-as-judge against a rubric.
+
+Given a skill body, have a model follow it against a task and score the
+output on correctness, procedure-following, and conciseness. The textual
+feedback is the raw material GEPA uses to propose mutations.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import dspy
+
+
+@dataclass
+class TaskExample:
+    prompt: str
+    expected_behavior: str
+
+
+@dataclass
+class ExecutorScore:
+    correctness: float
+    procedure_following: float
+    conciseness: float
+    length_penalty: float
+    feedback: str
+    count: int
+
+    @property
+    def composite(self) -> float:
+        weighted = (
+            0.5 * self.correctness
+            + 0.3 * self.procedure_following
+            + 0.2 * self.conciseness
+        )
+        return max(0.0, weighted - self.length_penalty)
+
+
+class FollowSkillSignature(dspy.Signature):
+    """Follow the given skill instructions to respond to the user's task.
+
+    Read the skill instructions carefully and apply them. Produce the
+    output the skill asks for — no meta-commentary, no "here's what I did",
+    just the artifact the skill is supposed to produce.
+    """
+    skill_instructions: str = dspy.InputField(desc="The full SKILL.md body (instructions)")
+    user_task: str = dspy.InputField(desc="The task the user has given")
+    response: str = dspy.OutputField(desc="The artifact/response produced by following the skill")
+
+
+class JudgeSignature(dspy.Signature):
+    """Score an agent response against an expected-behavior rubric.
+
+    Score three dimensions from 0.0 to 1.0. Be strict — 1.0 means perfect,
+    0.5 means clearly lacking, 0.0 means wrong or absent. Provide specific,
+    actionable feedback a maintainer could act on.
+    """
+    task: str = dspy.InputField()
+    expected_behavior: str = dspy.InputField(desc="Rubric describing a good response")
+    skill_instructions: str = dspy.InputField()
+    response: str = dspy.InputField()
+    correctness: float = dspy.OutputField(desc="0.0-1.0: did the response correctly address the task?")
+    procedure_following: float = dspy.OutputField(desc="0.0-1.0: did it follow the skill's procedure?")
+    conciseness: float = dspy.OutputField(desc="0.0-1.0: appropriately concise without omitting essentials?")
+    feedback: str = dspy.OutputField(
+        desc="Specific, actionable feedback on what could be improved in the skill instructions"
+    )
+
+
+def _clamp(value: object) -> float:
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if v != v:  # NaN
+        return 0.0
+    return max(0.0, min(1.0, v))
+
+
+def _length_penalty(body: str, max_bytes: int) -> float:
+    size = len(body.encode("utf-8"))
+    if size <= max_bytes:
+        return 0.0
+    overflow = size - max_bytes
+    return min(0.5, overflow / max(1, max_bytes))
+
+
+def score_body(
+    *,
+    body: str,
+    tasks: list[TaskExample],
+    eval_lm_name: str,
+    max_body_bytes: int,
+) -> ExecutorScore:
+    if not tasks:
+        return ExecutorScore(
+            correctness=0.0,
+            procedure_following=0.0,
+            conciseness=0.0,
+            length_penalty=0.0,
+            feedback="No task examples provided — cannot score body.",
+            count=0,
+        )
+    follower = dspy.Predict(FollowSkillSignature)
+    judge = dspy.ChainOfThought(JudgeSignature)
+    lm = dspy.LM(eval_lm_name)
+
+    c_total = p_total = q_total = 0.0
+    feedback_chunks: list[str] = []
+
+    with dspy.context(lm=lm):
+        for example in tasks:
+            try:
+                follow = follower(skill_instructions=body, user_task=example.prompt)
+                response = str(getattr(follow, "response", ""))
+            except Exception as err:  # pragma: no cover
+                response = f"(follower error: {err})"
+            try:
+                verdict = judge(
+                    task=example.prompt,
+                    expected_behavior=example.expected_behavior,
+                    skill_instructions=body,
+                    response=response,
+                )
+                c = _clamp(getattr(verdict, "correctness", 0.0))
+                p = _clamp(getattr(verdict, "procedure_following", 0.0))
+                q = _clamp(getattr(verdict, "conciseness", 0.0))
+                fb = str(getattr(verdict, "feedback", ""))[:400]
+            except Exception as err:  # pragma: no cover
+                c = p = q = 0.0
+                fb = f"(judge error: {err})"
+            c_total += c
+            p_total += p
+            q_total += q
+            if c < 0.75 or p < 0.75:
+                feedback_chunks.append(
+                    f"- task={example.prompt!r}: c={c:.2f} p={p:.2f} q={q:.2f} — {fb}"
+                )
+
+    n = len(tasks)
+    penalty = _length_penalty(body, max_body_bytes)
+    feedback = "\n".join(
+        [
+            f"Average: correctness={c_total / n:.3f}, procedure={p_total / n:.3f}, conciseness={q_total / n:.3f}, penalty={penalty:.3f}",
+            *feedback_chunks[:10],
+        ]
+    )
+    if len(feedback_chunks) > 10:
+        feedback += f"\n... and {len(feedback_chunks) - 10} more."
+
+    return ExecutorScore(
+        correctness=c_total / n,
+        procedure_following=p_total / n,
+        conciseness=q_total / n,
+        length_penalty=penalty,
+        feedback=feedback,
+        count=n,
+    )

--- a/plugins/skill-evolver/python/skill_evolver/report.py
+++ b/plugins/skill-evolver/python/skill_evolver/report.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import difflib
 
-from skill_evolver.skill_module import ParsedSkill
+from skill_evolver.skill_module import ParsedSkill, load_skill_from_string
 
 
 def _diff(before: str, after: str, label_before: str, label_after: str) -> str:
@@ -63,24 +63,14 @@ def render_report_markdown(skill: ParsedSkill, result: dict) -> str:
     lines.append("## Changes")
     best_raw = result.get("bestVariantRaw")
     if best_raw:
-        from skill_evolver.skill_module import load_skill
-        from io import StringIO  # noqa: F401 - kept for parity with SKILL parser imports
-
-        new_description = best_raw.split("\n---\n", 1)[0]
-        if "description:" in new_description:
-            new_desc_line = (
-                new_description.split("description:", 1)[1].split("\n", 1)[0].strip()
-            )
-        else:
-            new_desc_line = skill.description
+        parsed = load_skill_from_string(best_raw, fallback_name=skill.name)
         lines.append("### Description")
-        lines.append(_diff(skill.description, new_desc_line, "before", "after"))
+        lines.append(_diff(skill.description, parsed.description, "before", "after"))
         lines.append("")
 
-        new_body = best_raw.split("\n---\n", 1)[1] if "\n---\n" in best_raw else ""
-        if new_body:
+        if parsed.body:
             lines.append("### Body")
-            lines.append(_diff(skill.body, new_body.lstrip("\n"), "before", "after"))
+            lines.append(_diff(skill.body, parsed.body, "before", "after"))
             lines.append("")
 
     lines.append("## Sample feedback")

--- a/plugins/skill-evolver/python/skill_evolver/report.py
+++ b/plugins/skill-evolver/python/skill_evolver/report.py
@@ -1,0 +1,90 @@
+"""Render a human-readable markdown report for an evolution run.
+
+Used both as PR-body content and as the console UI's diff summary.
+"""
+from __future__ import annotations
+
+import difflib
+
+from skill_evolver.skill_module import ParsedSkill
+
+
+def _diff(before: str, after: str, label_before: str, label_after: str) -> str:
+    if before == after:
+        return f"(no change to {label_before})"
+    diff_lines = difflib.unified_diff(
+        before.splitlines(keepends=False),
+        after.splitlines(keepends=False),
+        fromfile=label_before,
+        tofile=label_after,
+        lineterm="",
+        n=3,
+    )
+    body = "\n".join(diff_lines)
+    if not body.strip():
+        return f"(no visible diff for {label_before})"
+    return f"```diff\n{body}\n```"
+
+
+def render_report_markdown(skill: ParsedSkill, result: dict) -> str:
+    lines: list[str] = []
+    lines.append(f"# Evolution report: `{skill.name}`")
+    lines.append("")
+    lines.append(
+        f"**Run**: `{result.get('runId', '?')}` · "
+        f"**Target**: `{result.get('target')}` · "
+        f"**Sources**: `{', '.join(result.get('sources', []))}` · "
+        f"**Iterations**: `{result.get('iterations')}`"
+    )
+    lines.append("")
+
+    desc_score = result.get("descriptionScore")
+    body_score = result.get("bodyScore")
+    if desc_score:
+        delta = desc_score["best"] - desc_score["baseline"]
+        lines.append(
+            f"- Description score: **{desc_score['baseline']:.3f} → {desc_score['best']:.3f}** "
+            f"({'+' if delta >= 0 else ''}{delta:.3f})"
+        )
+    if body_score:
+        delta = body_score["best"] - body_score["baseline"]
+        lines.append(
+            f"- Body score: **{body_score['baseline']:.3f} → {body_score['best']:.3f}** "
+            f"({'+' if delta >= 0 else ''}{delta:.3f})"
+        )
+    lines.append("")
+
+    lines.append("## Constraint gates")
+    for constraint in result.get("constraints", []):
+        badge = "✅" if constraint["passed"] else "❌"
+        lines.append(f"- {badge} `{constraint['name']}` — {constraint['message']}")
+    lines.append("")
+
+    lines.append("## Changes")
+    best_raw = result.get("bestVariantRaw")
+    if best_raw:
+        from skill_evolver.skill_module import load_skill
+        from io import StringIO  # noqa: F401 - kept for parity with SKILL parser imports
+
+        new_description = best_raw.split("\n---\n", 1)[0]
+        if "description:" in new_description:
+            new_desc_line = (
+                new_description.split("description:", 1)[1].split("\n", 1)[0].strip()
+            )
+        else:
+            new_desc_line = skill.description
+        lines.append("### Description")
+        lines.append(_diff(skill.description, new_desc_line, "before", "after"))
+        lines.append("")
+
+        new_body = best_raw.split("\n---\n", 1)[1] if "\n---\n" in best_raw else ""
+        if new_body:
+            lines.append("### Body")
+            lines.append(_diff(skill.body, new_body.lstrip("\n"), "before", "after"))
+            lines.append("")
+
+    lines.append("## Sample feedback")
+    for entry in result.get("feedbackTrail", [])[-4:]:
+        lines.append(f"> {entry}")
+        lines.append("")
+    return "\n".join(lines)

--- a/plugins/skill-evolver/python/skill_evolver/skill_module.py
+++ b/plugins/skill-evolver/python/skill_evolver/skill_module.py
@@ -80,31 +80,43 @@ def _extract_name(frontmatter: str) -> str:
     return ""
 
 
-def load_skill(path: Path) -> ParsedSkill:
-    raw = path.read_text(encoding="utf-8")
-    match = _FRONTMATTER_RE.match(raw)
+def _parse_skill_raw(raw: str, *, path: Path, fallback_name: str) -> ParsedSkill:
+    normalized = raw.replace("\r\n", "\n").replace("\r", "\n")
+    match = _FRONTMATTER_RE.match(normalized)
     if not match:
         return ParsedSkill(
             path=path,
-            raw=raw,
+            raw=normalized,
             frontmatter="",
-            body=raw,
-            name=path.parent.name,
+            body=normalized,
+            name=fallback_name,
             description="",
         )
     frontmatter = match.group("front")
     body = match.group("body")
-    name = _extract_name(frontmatter) or path.parent.name
+    name = _extract_name(frontmatter) or fallback_name
     description, extra_frontmatter = _split_description_line(frontmatter)
     return ParsedSkill(
         path=path,
-        raw=raw,
+        raw=normalized,
         frontmatter=frontmatter,
         body=body,
         name=name,
         description=description,
         extra_frontmatter=extra_frontmatter,
     )
+
+
+def load_skill(path: Path) -> ParsedSkill:
+    return _parse_skill_raw(
+        path.read_text(encoding="utf-8"),
+        path=path,
+        fallback_name=path.parent.name,
+    )
+
+
+def load_skill_from_string(raw: str, *, fallback_name: str = "") -> ParsedSkill:
+    return _parse_skill_raw(raw, path=Path("<memory>"), fallback_name=fallback_name)
 
 
 def _escape_yaml_string(value: str) -> str:
@@ -139,4 +151,4 @@ def reassemble(skill: ParsedSkill, *, description: Optional[str] = None, body: O
     return f"---\n{frontmatter_block}\n---\n{new_body}"
 
 
-__all__ = ["ParsedSkill", "load_skill", "reassemble"]
+__all__ = ["ParsedSkill", "load_skill", "load_skill_from_string", "reassemble"]

--- a/plugins/skill-evolver/python/skill_evolver/skill_module.py
+++ b/plugins/skill-evolver/python/skill_evolver/skill_module.py
@@ -1,0 +1,142 @@
+"""SKILL.md ↔ DSPy module adapter.
+
+A SKILL.md has two optimizable surfaces:
+- the `description:` field in frontmatter (controls triggering)
+- the markdown body (controls execution behavior)
+
+This module parses and re-assembles SKILL.md files while preserving all
+other frontmatter fields. GEPA mutates one of those surfaces at a time.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+_FRONTMATTER_RE = re.compile(r"^---\n(?P<front>.*?)\n---\n?(?P<body>.*)$", re.DOTALL)
+
+
+@dataclass
+class ParsedSkill:
+    path: Path
+    raw: str
+    frontmatter: str
+    body: str
+    name: str
+    description: str
+    extra_frontmatter: str = ""
+
+    def describe(self) -> dict:
+        return {
+            "path": str(self.path),
+            "name": self.name,
+            "description": self.description,
+            "body_bytes": len(self.body.encode("utf-8")),
+            "description_chars": len(self.description),
+        }
+
+
+def _split_description_line(frontmatter: str) -> tuple[str, str]:
+    """Return (description_value, remaining_frontmatter_without_description)."""
+    description = ""
+    out_lines: list[str] = []
+    in_description_block = False
+    for line in frontmatter.split("\n"):
+        if in_description_block:
+            if line.startswith(" ") or line.startswith("\t"):
+                description += "\n" + line.strip()
+                continue
+            in_description_block = False
+        m = re.match(r"^(description):\s*(.*)$", line)
+        if m:
+            value = m.group(2).strip()
+            if value.startswith(">") or value.startswith("|"):
+                in_description_block = True
+                description = ""
+                continue
+            if value.startswith('"') and value.endswith('"') and len(value) >= 2:
+                value = value[1:-1]
+            elif value.startswith("'") and value.endswith("'") and len(value) >= 2:
+                value = value[1:-1]
+            description = value
+            continue
+        out_lines.append(line)
+    remaining = "\n".join(out_lines).strip("\n")
+    return description.strip(), remaining
+
+
+def _extract_name(frontmatter: str) -> str:
+    for line in frontmatter.split("\n"):
+        m = re.match(r"^name:\s*(.*)$", line)
+        if m:
+            value = m.group(1).strip()
+            if value.startswith('"') and value.endswith('"') and len(value) >= 2:
+                value = value[1:-1]
+            elif value.startswith("'") and value.endswith("'") and len(value) >= 2:
+                value = value[1:-1]
+            return value.strip()
+    return ""
+
+
+def load_skill(path: Path) -> ParsedSkill:
+    raw = path.read_text(encoding="utf-8")
+    match = _FRONTMATTER_RE.match(raw)
+    if not match:
+        return ParsedSkill(
+            path=path,
+            raw=raw,
+            frontmatter="",
+            body=raw,
+            name=path.parent.name,
+            description="",
+        )
+    frontmatter = match.group("front")
+    body = match.group("body")
+    name = _extract_name(frontmatter) or path.parent.name
+    description, extra_frontmatter = _split_description_line(frontmatter)
+    return ParsedSkill(
+        path=path,
+        raw=raw,
+        frontmatter=frontmatter,
+        body=body,
+        name=name,
+        description=description,
+        extra_frontmatter=extra_frontmatter,
+    )
+
+
+def _escape_yaml_string(value: str) -> str:
+    if "\n" in value:
+        indented = "\n".join("  " + line for line in value.split("\n"))
+        return f"|-\n{indented}"
+    if ":" in value or value.startswith(("'", '"', "#", "-", "[", "{", "&", "*", "!", "|", ">", "%", "@", "`")):
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    return value
+
+
+def reassemble(skill: ParsedSkill, *, description: Optional[str] = None, body: Optional[str] = None) -> str:
+    new_description = description if description is not None else skill.description
+    new_body = body if body is not None else skill.body
+
+    lines = skill.extra_frontmatter.split("\n") if skill.extra_frontmatter else []
+    rendered: list[str] = []
+    inserted = False
+
+    for line in lines:
+        if not inserted and re.match(r"^name:\s*", line):
+            rendered.append(line)
+            rendered.append(f"description: {_escape_yaml_string(new_description)}")
+            inserted = True
+            continue
+        rendered.append(line)
+    if not inserted:
+        rendered.insert(0, f"description: {_escape_yaml_string(new_description)}")
+
+    frontmatter_block = "\n".join(rendered).strip("\n")
+    return f"---\n{frontmatter_block}\n---\n{new_body}"
+
+
+__all__ = ["ParsedSkill", "load_skill", "reassemble"]

--- a/plugins/skill-evolver/python/skill_evolver/targets/__init__.py
+++ b/plugins/skill-evolver/python/skill_evolver/targets/__init__.py
@@ -1,0 +1,1 @@
+"""Evolution targets — description, body, and joint."""

--- a/plugins/skill-evolver/python/skill_evolver/targets/body.py
+++ b/plugins/skill-evolver/python/skill_evolver/targets/body.py
@@ -1,0 +1,101 @@
+"""Body-target evolution.
+
+The body markdown is the optimizable text. A follower LM "executes" the
+skill against tasks and an LLM-judge scores the outputs across three
+dimensions. GEPA consumes the judge's textual feedback to propose
+reflective mutations.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import dspy
+
+from skill_evolver.fitness.executor import TaskExample, score_body
+
+
+@dataclass
+class BodyRunResult:
+    baseline_body: str
+    best_body: str
+    baseline_score: float
+    best_score: float
+    feedback_trail: list[str]
+
+
+class BodyModule(dspy.Module):
+    """Module whose optimizable parameter is the SKILL.md body."""
+
+    def __init__(self, body: str):
+        super().__init__()
+        self.body = body
+
+    def forward(self, **kwargs):  # pragma: no cover
+        return dspy.Prediction(body=self.body)
+
+
+def run(
+    *,
+    baseline_body: str,
+    train_examples: list[TaskExample],
+    val_examples: list[TaskExample],
+    optimizer_model: str,
+    eval_model: str,
+    iterations: int,
+    max_body_bytes: int,
+) -> BodyRunResult:
+    from gepa import GEPA
+
+    baseline_score = score_body(
+        body=baseline_body,
+        tasks=val_examples or train_examples,
+        eval_lm_name=eval_model,
+        max_body_bytes=max_body_bytes,
+    )
+
+    candidate_pool = {"body": baseline_body}
+
+    def evaluate(candidate, batch):
+        body = candidate.get("body", baseline_body)
+        score = score_body(
+            body=body,
+            tasks=batch,
+            eval_lm_name=eval_model,
+            max_body_bytes=max_body_bytes,
+        )
+        return [
+            {"score": score.composite, "feedback": score.feedback}
+            for _ in batch or [None]
+        ][: max(1, len(batch))]
+
+    try:
+        optimizer = GEPA(
+            adapter=None,
+            seed_candidate=candidate_pool,
+            trainset=train_examples,
+            valset=val_examples or train_examples,
+            task_lm=eval_model,
+            reflection_lm=optimizer_model,
+            max_metric_calls=max(1, iterations) * max(1, len(train_examples)),
+            evaluator=evaluate,
+        )
+        result = optimizer.optimize()
+        best_candidate = getattr(result, "best_candidate", None) or candidate_pool
+    except Exception as err:
+        best_candidate = {"body": baseline_body, "_error": f"GEPA-body error: {err}"}
+
+    best_body = best_candidate.get("body", baseline_body)
+    best_score = score_body(
+        body=best_body,
+        tasks=val_examples or train_examples,
+        eval_lm_name=eval_model,
+        max_body_bytes=max_body_bytes,
+    )
+
+    return BodyRunResult(
+        baseline_body=baseline_body,
+        best_body=best_body,
+        baseline_score=baseline_score.composite,
+        best_score=best_score.composite,
+        feedback_trail=[baseline_score.feedback, best_score.feedback],
+    )

--- a/plugins/skill-evolver/python/skill_evolver/targets/description.py
+++ b/plugins/skill-evolver/python/skill_evolver/targets/description.py
@@ -1,0 +1,129 @@
+"""Description-target evolution.
+
+Wraps the description field as an optimizable dspy.Module. GEPA mutates
+the description; fitness is trigger-classification F1 against a labeled
+prompt pool (competing skills included in the pool on every example).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+import dspy
+
+from skill_evolver.fitness.classifier import TriggerExample, score_description
+
+
+@dataclass
+class DescriptionRunResult:
+    baseline_description: str
+    best_description: str
+    baseline_score: float
+    best_score: float
+    feedback_trail: list[str]
+
+
+class DescriptionModule(dspy.Module):
+    """A dspy.Module whose single optimizable parameter is the description text."""
+
+    def __init__(self, description: str):
+        super().__init__()
+        self.description = description
+
+    def forward(self, **kwargs):  # pragma: no cover - unused during GEPA text-mode optimization
+        return dspy.Prediction(description=self.description)
+
+
+def build_trigger_metric(
+    skill_name: str,
+    examples: list[TriggerExample],
+    eval_lm_name: str,
+) -> Callable:
+    def metric(example, prediction, trace=None):
+        description = getattr(prediction, "description", None) or getattr(
+            example, "description", None
+        )
+        if not description:
+            return dspy.Prediction(score=0.0, feedback="no description provided")
+        score = score_description(
+            target_name=skill_name,
+            target_description=description,
+            examples=examples,
+            eval_lm_name=eval_lm_name,
+        )
+        return dspy.Prediction(score=score.composite, feedback=score.feedback)
+
+    return metric
+
+
+def run(
+    *,
+    skill_name: str,
+    baseline_description: str,
+    train_examples: list[TriggerExample],
+    val_examples: list[TriggerExample],
+    optimizer_model: str,
+    eval_model: str,
+    iterations: int,
+) -> DescriptionRunResult:
+    from gepa import GEPA  # Import inside function so import errors surface clearly.
+
+    baseline_score_detail = score_description(
+        target_name=skill_name,
+        target_description=baseline_description,
+        examples=val_examples or train_examples,
+        eval_lm_name=eval_model,
+    )
+
+    candidate_pool = {"description": baseline_description}
+
+    def evaluate(candidate, batch):
+        description = candidate.get("description", baseline_description)
+        result = score_description(
+            target_name=skill_name,
+            target_description=description,
+            examples=batch,
+            eval_lm_name=eval_model,
+        )
+        return [
+            {
+                "score": result.composite,
+                "feedback": result.feedback,
+            }
+            for _ in batch or [None]
+        ][: max(1, len(batch))]
+
+    try:
+        optimizer = GEPA(
+            adapter=None,
+            seed_candidate=candidate_pool,
+            trainset=train_examples,
+            valset=val_examples or train_examples,
+            task_lm=eval_model,
+            reflection_lm=optimizer_model,
+            max_metric_calls=max(1, iterations) * max(1, len(train_examples)),
+            evaluator=evaluate,
+        )
+        result = optimizer.optimize()
+        best_candidate = getattr(result, "best_candidate", None) or candidate_pool
+    except Exception as err:
+        best_candidate = {
+            "description": baseline_description,
+            "_error": f"GEPA-description error: {err}",
+        }
+
+    best_description = best_candidate.get("description", baseline_description)
+    best_score_detail = score_description(
+        target_name=skill_name,
+        target_description=best_description,
+        examples=val_examples or train_examples,
+        eval_lm_name=eval_model,
+    )
+
+    return DescriptionRunResult(
+        baseline_description=baseline_description,
+        best_description=best_description,
+        baseline_score=baseline_score_detail.composite,
+        best_score=best_score_detail.composite,
+        feedback_trail=[baseline_score_detail.feedback, best_score_detail.feedback],
+    )

--- a/plugins/skill-evolver/python/skill_evolver/targets/joint.py
+++ b/plugins/skill-evolver/python/skill_evolver/targets/joint.py
@@ -1,0 +1,97 @@
+"""Joint target — evolve body, then description, then validate cross-impact.
+
+Body first (contained change, doesn't affect routing). Then description
+against frozen body. Finally re-score triggers with the new description
+AND re-score body execution with the new description to detect any drift
+caused by the description wording bleeding into how the body reads.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from skill_evolver.fitness.classifier import TriggerExample, score_description
+from skill_evolver.fitness.executor import TaskExample, score_body
+from skill_evolver.targets import body as body_target
+from skill_evolver.targets import description as description_target
+
+
+@dataclass
+class JointRunResult:
+    baseline_description: str
+    baseline_body: str
+    best_description: str
+    best_body: str
+    description_baseline_score: float
+    description_best_score: float
+    body_baseline_score: float
+    body_best_score: float
+    feedback_trail: list[str]
+
+
+def run(
+    *,
+    skill_name: str,
+    baseline_description: str,
+    baseline_body: str,
+    trigger_train: list[TriggerExample],
+    trigger_val: list[TriggerExample],
+    task_train: list[TaskExample],
+    task_val: list[TaskExample],
+    optimizer_model: str,
+    eval_model: str,
+    iterations: int,
+    max_body_bytes: int,
+) -> JointRunResult:
+    body_run = body_target.run(
+        baseline_body=baseline_body,
+        train_examples=task_train,
+        val_examples=task_val,
+        optimizer_model=optimizer_model,
+        eval_model=eval_model,
+        iterations=iterations,
+        max_body_bytes=max_body_bytes,
+    )
+    desc_run = description_target.run(
+        skill_name=skill_name,
+        baseline_description=baseline_description,
+        train_examples=trigger_train,
+        val_examples=trigger_val,
+        optimizer_model=optimizer_model,
+        eval_model=eval_model,
+        iterations=iterations,
+    )
+
+    body_with_new_description_score = score_body(
+        body=body_run.best_body,
+        tasks=task_val or task_train,
+        eval_lm_name=eval_model,
+        max_body_bytes=max_body_bytes,
+    )
+    desc_with_new_body_score = score_description(
+        target_name=skill_name,
+        target_description=desc_run.best_description,
+        examples=trigger_val or trigger_train,
+        eval_lm_name=eval_model,
+    )
+
+    feedback = [
+        "== body evolution ==",
+        *body_run.feedback_trail,
+        "== description evolution ==",
+        *desc_run.feedback_trail,
+        "== joint re-validation ==",
+        f"body with new description: {body_with_new_description_score.feedback}",
+        f"description with new body (trigger pool unchanged): {desc_with_new_body_score.feedback}",
+    ]
+
+    return JointRunResult(
+        baseline_description=baseline_description,
+        baseline_body=baseline_body,
+        best_description=desc_run.best_description,
+        best_body=body_run.best_body,
+        description_baseline_score=desc_run.baseline_score,
+        description_best_score=desc_with_new_body_score.composite,
+        body_baseline_score=body_run.baseline_score,
+        body_best_score=body_with_new_description_score.composite,
+        feedback_trail=feedback,
+    )

--- a/plugins/skill-evolver/python/skill_evolver/tui.py
+++ b/plugins/skill-evolver/python/skill_evolver/tui.py
@@ -1,0 +1,323 @@
+"""Rich terminal UI for skill-evolver.
+
+Three entry points:
+
+- ``show_result(result_path)`` — pretty-render a finished ``result.json``
+  (scores, constraint gates, unified diffs, feedback trail).
+- ``watch_work_dir(work_dir)`` — live-refresh the summary of a work dir
+  while an evolution run writes into it.
+- ``browse_skills(repo_root, datasets_dir)`` — interactive menu: pick a
+  skill, preview its SKILL.md and most recent evolution run, print the
+  exact CLI command to launch an evolution.
+"""
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from rich.console import Console, Group
+from rich.layout import Layout
+from rich.live import Live
+from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.prompt import Prompt
+from rich.table import Table
+from rich.text import Text
+
+from skill_evolver.skill_module import load_skill
+
+
+def _score_row(label: str, score: Optional[dict]) -> Optional[str]:
+    if not score:
+        return None
+    baseline = score.get("baseline", 0.0)
+    best = score.get("best", 0.0)
+    delta = best - baseline
+    arrow = "↑" if delta > 0 else ("↓" if delta < 0 else "·")
+    color = "green" if delta > 0 else ("red" if delta < 0 else "white")
+    return (
+        f"[bold]{label}[/bold]: {baseline:.3f} → {best:.3f} "
+        f"[{color}]{arrow} {delta:+.3f}[/{color}]"
+    )
+
+
+def _summary_panel(result: dict) -> Panel:
+    lines: list[str] = []
+    lines.append(f"[bold]Skill[/bold]: {result.get('skillName', '?')}")
+    lines.append(f"[bold]Run[/bold]: {result.get('runId', '?')}")
+    lines.append(f"[bold]Target[/bold]: {result.get('target', '?')}")
+    lines.append(
+        f"[bold]Sources[/bold]: {', '.join(result.get('sources', []))}"
+    )
+    lines.append(f"[bold]Iterations[/bold]: {result.get('iterations', '?')}")
+    if "descriptionScore" in result:
+        lines.append(_score_row("Description score", result["descriptionScore"]))
+    if "bodyScore" in result:
+        lines.append(_score_row("Body score", result["bodyScore"]))
+    applicable = result.get("applicable")
+    if applicable is True:
+        lines.append("[green]✅ constraints pass — variant is applicable[/green]")
+    elif applicable is False:
+        lines.append("[red]❌ constraints failed — variant not applied[/red]")
+    return Panel("\n".join(s for s in lines if s), title="Summary", border_style="cyan")
+
+
+def _constraints_table(result: dict) -> Table:
+    table = Table(title="Constraint gates", show_header=True, header_style="bold")
+    table.add_column("Gate")
+    table.add_column("Status")
+    table.add_column("Message")
+    for entry in result.get("constraints", []):
+        ok = entry.get("passed", False)
+        table.add_row(
+            entry.get("name", "?"),
+            "[green]PASS[/green]" if ok else "[red]FAIL[/red]",
+            entry.get("message", ""),
+        )
+    return table
+
+
+def _dataset_table(result: dict) -> Optional[Table]:
+    if "triggerDataset" not in result and "taskDataset" not in result:
+        return None
+    table = Table(title="Datasets", show_header=True, header_style="bold")
+    table.add_column("Kind")
+    table.add_column("Train")
+    table.add_column("Val")
+    for kind in ("triggerDataset", "taskDataset"):
+        data = result.get(kind)
+        if not data:
+            continue
+        table.add_row(
+            kind.replace("Dataset", ""),
+            str(data.get("train", 0)),
+            str(data.get("val", 0)),
+        )
+    return table
+
+
+def _feedback_panel(result: dict) -> Optional[Panel]:
+    trail = result.get("feedbackTrail") or []
+    if not trail:
+        return None
+    tail = trail[-6:]
+    return Panel(
+        "\n\n".join(str(entry) for entry in tail),
+        title=f"Feedback (last {len(tail)} of {len(trail)})",
+        border_style="magenta",
+    )
+
+
+def _report_markdown(result: dict) -> Optional[Markdown]:
+    md = result.get("reportMarkdown")
+    if not md:
+        return None
+    return Markdown(md)
+
+
+def _render_result(result: dict) -> Group:
+    parts = [_summary_panel(result)]
+    dataset = _dataset_table(result)
+    if dataset is not None:
+        parts.append(dataset)
+    parts.append(_constraints_table(result))
+    feedback = _feedback_panel(result)
+    if feedback is not None:
+        parts.append(feedback)
+    report = _report_markdown(result)
+    if report is not None:
+        parts.append(Panel(report, title="Report", border_style="green"))
+    return Group(*parts)
+
+
+def show_result(result_path: Path, console: Optional[Console] = None) -> None:
+    console = console or Console()
+    if not result_path.exists():
+        console.print(f"[red]result.json not found at {result_path}[/red]")
+        raise SystemExit(1)
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    console.print(_render_result(payload))
+
+
+def watch_work_dir(
+    work_dir: Path,
+    *,
+    poll_interval: float = 1.5,
+    max_seconds: int = 60 * 60,
+    console: Optional[Console] = None,
+) -> None:
+    console = console or Console()
+    console.print(f"[dim]Watching {work_dir} (Ctrl-C to stop)…[/dim]")
+    started = time.monotonic()
+
+    def render() -> Group:
+        result_json = work_dir / "result.json"
+        if not result_json.exists():
+            return Group(
+                Panel(
+                    f"Waiting for result.json in {work_dir} …",
+                    title="Evolution",
+                    border_style="yellow",
+                )
+            )
+        try:
+            payload = json.loads(result_json.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return Group(
+                Panel(
+                    "result.json is being rewritten (partial read) — refreshing…",
+                    border_style="yellow",
+                )
+            )
+        return _render_result(payload)
+
+    with Live(render(), console=console, refresh_per_second=4) as live:
+        while time.monotonic() - started < max_seconds:
+            live.update(render())
+            result_json = work_dir / "result.json"
+            if result_json.exists():
+                try:
+                    payload = json.loads(result_json.read_text(encoding="utf-8"))
+                    if payload.get("finishedAt") or payload.get("error"):
+                        break
+                except json.JSONDecodeError:
+                    pass
+            time.sleep(poll_interval)
+
+
+@dataclass
+class SkillRow:
+    name: str
+    path: Path
+    description: str
+    body_bytes: int
+
+
+def _walk_skills(repo_root: Path, max_count: int = 200) -> list[SkillRow]:
+    rows: list[SkillRow] = []
+    for rel in ("skills", "community-skills", "plugins"):
+        root = repo_root / rel
+        if not root.exists():
+            continue
+        for skill_md in root.rglob("SKILL.md"):
+            try:
+                parsed = load_skill(skill_md)
+            except Exception:
+                continue
+            rows.append(
+                SkillRow(
+                    name=parsed.name,
+                    path=skill_md,
+                    description=parsed.description,
+                    body_bytes=len(parsed.body.encode("utf-8")),
+                )
+            )
+            if len(rows) >= max_count:
+                return rows
+    return rows
+
+
+def _skills_table(rows: list[SkillRow]) -> Table:
+    table = Table(title="Skills", show_header=True, header_style="bold")
+    table.add_column("#", justify="right")
+    table.add_column("Name")
+    table.add_column("Body bytes", justify="right")
+    table.add_column("Description", overflow="fold")
+    for index, row in enumerate(rows, start=1):
+        description = row.description.strip().splitlines()[0] if row.description else ""
+        if len(description) > 120:
+            description = description[:117] + "…"
+        table.add_row(
+            str(index),
+            row.name,
+            str(row.body_bytes),
+            description,
+        )
+    return table
+
+
+def browse_skills(
+    repo_root: Path,
+    datasets_dir: Path,
+    console: Optional[Console] = None,
+) -> None:
+    console = console or Console()
+    rows = _walk_skills(repo_root)
+    if not rows:
+        console.print(f"[yellow]No SKILL.md found under {repo_root}[/yellow]")
+        return
+
+    while True:
+        console.clear()
+        console.print(_skills_table(rows))
+        console.print(
+            "[dim]Enter a skill number to inspect, or 'q' to quit.[/dim]"
+        )
+        choice = Prompt.ask("Skill", default="q").strip()
+        if choice.lower() in {"q", "quit", "exit"}:
+            return
+        try:
+            index = int(choice)
+        except ValueError:
+            console.print("[red]Not a number.[/red]")
+            time.sleep(0.6)
+            continue
+        if not 1 <= index <= len(rows):
+            console.print("[red]Out of range.[/red]")
+            time.sleep(0.6)
+            continue
+        _inspect_skill(rows[index - 1], repo_root, datasets_dir, console)
+
+
+def _inspect_skill(
+    row: SkillRow,
+    repo_root: Path,
+    datasets_dir: Path,
+    console: Console,
+) -> None:
+    console.clear()
+    layout = Layout()
+    layout.split_column(
+        Layout(name="head", size=6),
+        Layout(name="body"),
+    )
+    layout["head"].update(
+        Panel(
+            Text.assemble(
+                ("name: ", "bold"),
+                f"{row.name}\n",
+                ("path: ", "bold"),
+                f"{row.path.relative_to(repo_root) if row.path.is_relative_to(repo_root) else row.path}\n",
+                ("body_bytes: ", "bold"),
+                f"{row.body_bytes}\n",
+                ("description:\n", "bold"),
+                row.description or "",
+            ),
+            title=row.name,
+            border_style="cyan",
+        )
+    )
+
+    skill_md = Markdown(row.path.read_text(encoding="utf-8"))
+    layout["body"].update(Panel(skill_md, title="SKILL.md", border_style="dim"))
+    console.print(layout)
+
+    console.print(
+        "\n[dim]Commands to launch evolution (run outside the TUI):[/dim]"
+    )
+    console.print(
+        f"  [green]hybridclaw skill-evolver evolve {row.name} --target description[/green]"
+    )
+    console.print(
+        f"  [green]hybridclaw skill-evolver evolve {row.name} --target body[/green]"
+    )
+    console.print(
+        f"  [green]hybridclaw skill-evolver evolve {row.name} --target both --open-pr[/green]"
+    )
+    console.print(
+        f"\n[dim]Datasets for this skill live under {datasets_dir / row.name}[/dim]"
+    )
+    Prompt.ask("\nPress Enter to return", default="")

--- a/plugins/skill-evolver/src/apply-variant.js
+++ b/plugins/skill-evolver/src/apply-variant.js
@@ -1,0 +1,122 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+function runGit(args, cwd) {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf-8' });
+  if (result.status !== 0) {
+    throw new Error(
+      `git ${args.join(' ')} failed (status ${result.status}): ${result.stderr || result.stdout}`,
+    );
+  }
+  return (result.stdout || '').trim();
+}
+
+function runShell(cmd, cwd) {
+  const [command, ...args] = cmd.split(/\s+/).filter(Boolean);
+  if (!command) throw new Error('Empty shell command');
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: 'utf-8',
+    env: process.env,
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+function computeSlug(skillName) {
+  return String(skillName)
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'skill';
+}
+
+export function applyVariant(options) {
+  const {
+    repoRoot,
+    skillPath,
+    skillName,
+    variantRaw,
+    target,
+    testCommand,
+    runTests = true,
+    openPr = false,
+    branchPrefix = 'evolve/skill',
+    reportMarkdown = '',
+  } = options;
+
+  if (!fs.existsSync(skillPath)) {
+    throw new Error(`Skill path does not exist: ${skillPath}`);
+  }
+
+  const baselineStatus = runGit(['status', '--porcelain'], repoRoot);
+  if (baselineStatus) {
+    throw new Error(
+      `Working tree is not clean. Commit or stash changes before applying a variant.\n${baselineStatus}`,
+    );
+  }
+
+  const baselineBranch = runGit(['rev-parse', '--abbrev-ref', 'HEAD'], repoRoot);
+  const slug = computeSlug(skillName);
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  const branchName = `${branchPrefix}/${slug}-${target}-${stamp}`;
+
+  runGit(['checkout', '-b', branchName], repoRoot);
+
+  fs.writeFileSync(skillPath, variantRaw, 'utf-8');
+
+  let testResult = { skipped: true };
+  if (runTests) {
+    const result = runShell(testCommand, repoRoot);
+    testResult = result;
+    if (result.status !== 0) {
+      runGit(['checkout', '--', skillPath], repoRoot);
+      runGit(['checkout', baselineBranch], repoRoot);
+      runGit(['branch', '-D', branchName], repoRoot);
+      throw new Error(
+        `Variant rejected: test command \`${testCommand}\` failed.\nstdout: ${result.stdout.slice(-800)}\nstderr: ${result.stderr.slice(-800)}`,
+      );
+    }
+  }
+
+  const relPath = path.relative(repoRoot, skillPath);
+  runGit(['add', relPath], repoRoot);
+  const commitMessage = `chore(skills): evolve ${skillName} (${target})\n\nAutomated evolution via skill-evolver plugin (DSPy + GEPA).`;
+  runGit(['commit', '-m', commitMessage], repoRoot);
+
+  let prUrl = null;
+  if (openPr) {
+    const ghCheck = runShell('gh --version', repoRoot);
+    if (ghCheck.status === 0) {
+      runGit(['push', '-u', 'origin', branchName], repoRoot);
+      const prBody = reportMarkdown ||
+        `Automated evolution of \`${skillName}\` (${target}) via skill-evolver plugin.`;
+      const pr = spawnSync(
+        'gh',
+        [
+          'pr',
+          'create',
+          '--title',
+          `evolve(${skillName}): ${target}`,
+          '--body',
+          prBody,
+        ],
+        { cwd: repoRoot, encoding: 'utf-8' },
+      );
+      if (pr.status === 0) {
+        prUrl = (pr.stdout || '').trim();
+      }
+    }
+  }
+
+  return {
+    branchName,
+    baselineBranch,
+    testResult,
+    prUrl,
+    commitMessage,
+  };
+}

--- a/plugins/skill-evolver/src/apply-variant.js
+++ b/plugins/skill-evolver/src/apply-variant.js
@@ -13,12 +13,13 @@ function runGit(args, cwd) {
 }
 
 function runShell(cmd, cwd) {
-  const [command, ...args] = cmd.split(/\s+/).filter(Boolean);
+  const command = String(cmd || '').trim();
   if (!command) throw new Error('Empty shell command');
-  const result = spawnSync(command, args, {
+  const result = spawnSync(command, {
     cwd,
     encoding: 'utf-8',
     env: process.env,
+    shell: true,
   });
   return {
     status: result.status,
@@ -28,10 +29,12 @@ function runShell(cmd, cwd) {
 }
 
 function computeSlug(skillName) {
-  return String(skillName)
-    .toLowerCase()
-    .replace(/[^a-z0-9-]+/g, '-')
-    .replace(/^-+|-+$/g, '') || 'skill';
+  return (
+    String(skillName)
+      .toLowerCase()
+      .replace(/[^a-z0-9-]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'skill'
+  );
 }
 
 export function applyVariant(options) {
@@ -59,7 +62,10 @@ export function applyVariant(options) {
     );
   }
 
-  const baselineBranch = runGit(['rev-parse', '--abbrev-ref', 'HEAD'], repoRoot);
+  const baselineBranch = runGit(
+    ['rev-parse', '--abbrev-ref', 'HEAD'],
+    repoRoot,
+  );
   const slug = computeSlug(skillName);
   const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
   const branchName = `${branchPrefix}/${slug}-${target}-${stamp}`;
@@ -67,13 +73,14 @@ export function applyVariant(options) {
   runGit(['checkout', '-b', branchName], repoRoot);
 
   fs.writeFileSync(skillPath, variantRaw, 'utf-8');
+  const relPath = path.relative(repoRoot, skillPath);
 
   let testResult = { skipped: true };
   if (runTests) {
     const result = runShell(testCommand, repoRoot);
     testResult = result;
     if (result.status !== 0) {
-      runGit(['checkout', '--', skillPath], repoRoot);
+      runGit(['checkout', '--', relPath], repoRoot);
       runGit(['checkout', baselineBranch], repoRoot);
       runGit(['branch', '-D', branchName], repoRoot);
       throw new Error(
@@ -82,7 +89,6 @@ export function applyVariant(options) {
     }
   }
 
-  const relPath = path.relative(repoRoot, skillPath);
   runGit(['add', relPath], repoRoot);
   const commitMessage = `chore(skills): evolve ${skillName} (${target})\n\nAutomated evolution via skill-evolver plugin (DSPy + GEPA).`;
   runGit(['commit', '-m', commitMessage], repoRoot);
@@ -92,7 +98,8 @@ export function applyVariant(options) {
     const ghCheck = runShell('gh --version', repoRoot);
     if (ghCheck.status === 0) {
       runGit(['push', '-u', 'origin', branchName], repoRoot);
-      const prBody = reportMarkdown ||
+      const prBody =
+        reportMarkdown ||
         `Automated evolution of \`${skillName}\` (${target}) via skill-evolver plugin.`;
       const pr = spawnSync(
         'gh',

--- a/plugins/skill-evolver/src/index.js
+++ b/plugins/skill-evolver/src/index.js
@@ -1,0 +1,498 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { findSkill, listAllSkills, loadSkill } from './skill-locator.js';
+import { extractTraces, writeTraceDataset } from './trace-extractor.js';
+import { applyVariant } from './apply-variant.js';
+import { runPython, pluginRoot, workspaceCacheDir } from './python-bridge.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const PLUGIN_ROOT = path.resolve(path.dirname(__filename), '..');
+
+function resolveRepoRoot() {
+  const envRoot = (process.env.HYBRIDCLAW_REPO_ROOT || '').trim();
+  if (envRoot && path.isAbsolute(envRoot) && fs.existsSync(envRoot)) {
+    return envRoot;
+  }
+  return path.resolve(PLUGIN_ROOT, '..', '..');
+}
+
+function parseArgs(args) {
+  const positional = [];
+  const flags = {};
+  for (let i = 0; i < args.length; i += 1) {
+    const token = args[i];
+    if (token === '--') {
+      positional.push(...args.slice(i + 1));
+      break;
+    }
+    if (token.startsWith('--')) {
+      const eq = token.indexOf('=');
+      if (eq >= 0) {
+        flags[token.slice(2, eq)] = token.slice(eq + 1);
+      } else {
+        const next = args[i + 1];
+        if (next && !next.startsWith('--')) {
+          flags[token.slice(2)] = next;
+          i += 1;
+        } else {
+          flags[token.slice(2)] = 'true';
+        }
+      }
+    } else {
+      positional.push(token);
+    }
+  }
+  return { positional, flags };
+}
+
+function flagBool(value, fallback = false) {
+  if (value == null) return fallback;
+  const normalized = String(value).trim().toLowerCase();
+  if (['true', '1', 'yes', 'y'].includes(normalized)) return true;
+  if (['false', '0', 'no', 'n'].includes(normalized)) return false;
+  return fallback;
+}
+
+function usage() {
+  return [
+    'skill-evolver commands:',
+    '  list                                  List skills ranked by observations',
+    '  extract <skill>                       Extract traces to datasets/skills/<skill>/traces.json',
+    '  evolve <skill> [--target ...] [...]   Run DSPy + GEPA optimization',
+    '  preview <skill> [run-id]              Show diff + scores for a completed run',
+    '  show <skill> [run-id]                 Rich-rendered report for a completed run',
+    '  watch <skill> [run-id]                Live-refresh a running evolution',
+    '  tui                                   Interactive skill browser',
+    '',
+    'Flags for evolve:',
+    '  --target description|body|both        (required — no default)',
+    '  --sources synthetic,golden,traces     default: synthetic,golden,traces',
+    '  --iterations N                        default: 10',
+    '  --open-pr                             push branch + gh pr create',
+    '  --dry-run                             resolve config and exit',
+  ].join('\n');
+}
+
+function resolveSkillOrFail(skillName, repoRoot) {
+  const skillPath = findSkill(skillName, repoRoot);
+  if (!skillPath) {
+    throw new Error(
+      `Skill '${skillName}' not found in skills/, community-skills/, or plugins/.`,
+    );
+  }
+  return skillPath;
+}
+
+function datasetPathFor(repoRoot, config, skillName, filename) {
+  return path.join(repoRoot, config.datasetsDir, skillName, filename);
+}
+
+async function handleList(repoRoot) {
+  const skills = listAllSkills(repoRoot);
+  let byObservation = [];
+  try {
+    const traces = extractTraces({
+      skillName: '*',
+      repoRoot,
+      limit: 1,
+      includeOtherSkills: false,
+    });
+    byObservation = [];
+    void traces;
+  } catch {
+    byObservation = [];
+  }
+
+  const rows = skills
+    .map((skill) => {
+      let observations = [];
+      try {
+        const { observations: obs } = extractTraces({
+          skillName: skill.name,
+          repoRoot,
+          limit: 500,
+          includeOtherSkills: false,
+        });
+        observations = obs;
+      } catch {
+        observations = [];
+      }
+      const failures = observations.filter((o) => o.outcome !== 'success').length;
+      return {
+        name: skill.name,
+        bodyBytes: skill.bodyBytes,
+        observations: observations.length,
+        failures,
+        failureRate: observations.length > 0 ? failures / observations.length : 0,
+      };
+    })
+    .sort((a, b) => {
+      if (b.failureRate !== a.failureRate) return b.failureRate - a.failureRate;
+      return b.observations - a.observations;
+    });
+
+  return {
+    ok: true,
+    skills: rows,
+  };
+}
+
+async function handleExtract(skillName, repoRoot, config) {
+  const skillPath = resolveSkillOrFail(skillName, repoRoot);
+  const skill = loadSkill(skillPath);
+  const traces = extractTraces({
+    skillName: skill.name,
+    repoRoot,
+    limit: 1000,
+  });
+  const outPath = datasetPathFor(repoRoot, config, skill.name, 'traces.json');
+  writeTraceDataset(
+    {
+      skillName: skill.name,
+      skillPath: path.relative(repoRoot, skillPath),
+      extractedAt: new Date().toISOString(),
+      ...traces,
+    },
+    outPath,
+  );
+  return {
+    ok: true,
+    skill: skill.name,
+    datasetPath: outPath,
+    observationCount: traces.observations.length,
+    otherSkillObservationCount: traces.otherSkillObservations.length,
+  };
+}
+
+async function handleEvolve(
+  skillName,
+  { flags },
+  repoRoot,
+  config,
+  api,
+) {
+  const target = flags.target;
+  if (!target || !['description', 'body', 'both'].includes(target)) {
+    throw new Error(
+      `--target is required and must be one of: description, body, both`,
+    );
+  }
+  const sources = (flags.sources || config.defaultSources)
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const iterations = Number.parseInt(flags.iterations || config.defaultIterations, 10);
+  if (!Number.isFinite(iterations) || iterations < 1) {
+    throw new Error('--iterations must be a positive integer');
+  }
+  const openPr = flagBool(flags['open-pr'], false);
+  const dryRun = flagBool(flags['dry-run'], false);
+
+  const skillPath = resolveSkillOrFail(skillName, repoRoot);
+  const skill = loadSkill(skillPath);
+
+  let tracesDatasetPath = null;
+  if (sources.includes('traces')) {
+    const traces = extractTraces({
+      skillName: skill.name,
+      repoRoot,
+      limit: 1000,
+    });
+    if (traces.observations.length < config.minTraceObservations) {
+      api?.logger?.info(
+        {
+          skill: skill.name,
+          observations: traces.observations.length,
+          required: config.minTraceObservations,
+        },
+        'Not enough trace observations; dropping traces source.',
+      );
+    } else {
+      tracesDatasetPath = datasetPathFor(repoRoot, config, skill.name, 'traces.json');
+      writeTraceDataset(
+        {
+          skillName: skill.name,
+          skillPath: path.relative(repoRoot, skillPath),
+          extractedAt: new Date().toISOString(),
+          ...traces,
+        },
+        tracesDatasetPath,
+      );
+    }
+  }
+
+  const workDir = path.join(
+    workspaceCacheDir(),
+    `${skill.name}-${Date.now()}`,
+  );
+  fs.mkdirSync(workDir, { recursive: true });
+
+  const pythonArgs = [
+    'evolve',
+    '--skill-path', skillPath,
+    '--skill-name', skill.name,
+    '--target', target,
+    '--iterations', String(iterations),
+    '--optimizer-model', config.optimizerModel,
+    '--eval-model', config.evalModel,
+    '--max-body-bytes', String(config.maxSkillBodyBytes),
+    '--max-description-chars', String(config.maxDescriptionChars),
+    '--sources', sources.join(','),
+    '--work-dir', workDir,
+    '--repo-root', repoRoot,
+    '--datasets-dir', path.join(repoRoot, config.datasetsDir),
+  ];
+  if (tracesDatasetPath) {
+    pythonArgs.push('--traces-dataset', tracesDatasetPath);
+  }
+  if (dryRun) {
+    pythonArgs.push('--dry-run');
+  }
+
+  const pythonResult = await runPython(pythonArgs, {
+    onStdoutChunk: (chunk) => {
+      api?.logger?.info({ skill: skill.name, chunk }, 'skill-evolver:stdout');
+    },
+    onStderrChunk: (chunk) => {
+      api?.logger?.warn({ skill: skill.name, chunk }, 'skill-evolver:stderr');
+    },
+  });
+
+  if (pythonResult.code !== 0) {
+    return {
+      ok: false,
+      stage: 'evolve',
+      stdout: pythonResult.stdout,
+      stderr: pythonResult.stderr,
+      exitCode: pythonResult.code,
+    };
+  }
+
+  const resultPath = path.join(workDir, 'result.json');
+  if (!fs.existsSync(resultPath)) {
+    return {
+      ok: false,
+      stage: 'evolve',
+      error: 'Python evolver did not produce result.json',
+      stdout: pythonResult.stdout,
+      stderr: pythonResult.stderr,
+    };
+  }
+  const result = JSON.parse(fs.readFileSync(resultPath, 'utf-8'));
+
+  if (dryRun || !result.bestVariantRaw) {
+    return {
+      ok: true,
+      stage: 'dry-run',
+      result,
+    };
+  }
+
+  let applyResult = null;
+  try {
+    applyResult = applyVariant({
+      repoRoot,
+      skillPath,
+      skillName: skill.name,
+      variantRaw: result.bestVariantRaw,
+      target,
+      testCommand: config.testCommand,
+      runTests: config.runTests,
+      openPr,
+      branchPrefix: config.workBranchPrefix,
+      reportMarkdown: result.reportMarkdown || '',
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      stage: 'apply',
+      error: err.message,
+      result,
+    };
+  }
+
+  return {
+    ok: true,
+    stage: 'applied',
+    result,
+    apply: applyResult,
+  };
+}
+
+function resolveRunDir(skillName, runId) {
+  const workRoot = workspaceCacheDir();
+  if (!fs.existsSync(workRoot)) return null;
+  const matches = fs
+    .readdirSync(workRoot)
+    .filter((d) => d.startsWith(`${skillName}-`))
+    .sort()
+    .reverse();
+  for (const dir of matches) {
+    const full = path.join(workRoot, dir);
+    const p = path.join(full, 'result.json');
+    if (!runId) {
+      // Match either a finished (has result.json) run or fall back to most recent dir.
+      if (fs.existsSync(p)) {
+        return { dir: full, resultPath: p };
+      }
+      continue;
+    }
+    if (fs.existsSync(p)) {
+      const result = JSON.parse(fs.readFileSync(p, 'utf-8'));
+      if (result.runId === runId) return { dir: full, resultPath: p, result };
+    }
+  }
+  // Fallback: if runId unset and nothing finished, return newest dir (for watch).
+  if (!runId && matches.length > 0) {
+    return { dir: path.join(workRoot, matches[0]), resultPath: null };
+  }
+  return null;
+}
+
+async function handlePreview(skillName, runId) {
+  const match = resolveRunDir(skillName, runId);
+  if (!match || !match.resultPath) {
+    return { ok: false, error: `No evolution run found for ${skillName}.` };
+  }
+  const result = JSON.parse(fs.readFileSync(match.resultPath, 'utf-8'));
+  return { ok: true, result, dir: match.dir };
+}
+
+async function handleShow(skillName, runId) {
+  const match = resolveRunDir(skillName, runId);
+  if (!match || !match.resultPath) {
+    return { ok: false, error: `No evolution run found for ${skillName}.` };
+  }
+  const result = await runPython(['show', match.resultPath], { stdio: 'inherit' });
+  return { ok: result.code === 0, exitCode: result.code };
+}
+
+async function handleWatch(skillName, runId) {
+  const match = resolveRunDir(skillName, runId);
+  if (!match) {
+    return { ok: false, error: `No evolution run dir found for ${skillName}.` };
+  }
+  const result = await runPython(['watch', match.dir], { stdio: 'inherit' });
+  return { ok: result.code === 0, exitCode: result.code };
+}
+
+async function handleTui(repoRoot, config) {
+  const datasets = path.join(repoRoot, config.datasetsDir);
+  const result = await runPython(
+    ['tui', '--repo-root', repoRoot, '--datasets-dir', datasets],
+    { stdio: 'inherit' },
+  );
+  return { ok: result.code === 0, exitCode: result.code };
+}
+
+function resolveConfig(api) {
+  const raw = api?.pluginConfig || {};
+  return {
+    optimizerModel: raw.optimizerModel || 'openai/gpt-4.1',
+    evalModel: raw.evalModel || 'openai/gpt-4.1-mini',
+    maxSkillBodyBytes: Number(raw.maxSkillBodyBytes || 15360),
+    maxDescriptionChars: Number(raw.maxDescriptionChars || 1024),
+    defaultIterations: Number(raw.defaultIterations || 10),
+    defaultSources: raw.defaultSources || 'synthetic,golden,traces',
+    minTraceObservations: Number(raw.minTraceObservations || 10),
+    datasetsDir: raw.datasetsDir || 'datasets/skills',
+    workBranchPrefix: raw.workBranchPrefix || 'evolve/skill',
+    runTests: raw.runTests !== false,
+    testCommand: raw.testCommand || 'npm test --silent',
+  };
+}
+
+async function dispatch(args, context, api) {
+  const parsed = parseArgs(args);
+  const [subcommand, ...rest] = parsed.positional;
+  const repoRoot = context?.workspacePath || resolveRepoRoot();
+  const config = resolveConfig(api);
+
+  if (!subcommand || subcommand === 'help' || parsed.flags.help) {
+    return { ok: true, usage: usage() };
+  }
+
+  switch (subcommand) {
+    case 'list':
+      return handleList(repoRoot);
+    case 'extract': {
+      const skillName = rest[0];
+      if (!skillName) throw new Error('extract requires a <skill> argument');
+      return handleExtract(skillName, repoRoot, config);
+    }
+    case 'evolve': {
+      const skillName = rest[0];
+      if (!skillName) throw new Error('evolve requires a <skill> argument');
+      return handleEvolve(
+        skillName,
+        { flags: parsed.flags },
+        repoRoot,
+        config,
+        api,
+      );
+    }
+    case 'preview': {
+      const [skillName, runId] = rest;
+      if (!skillName) throw new Error('preview requires a <skill> argument');
+      return handlePreview(skillName, runId);
+    }
+    case 'show': {
+      const [skillName, runId] = rest;
+      if (!skillName) throw new Error('show requires a <skill> argument');
+      return handleShow(skillName, runId);
+    }
+    case 'watch': {
+      const [skillName, runId] = rest;
+      if (!skillName) throw new Error('watch requires a <skill> argument');
+      return handleWatch(skillName, runId);
+    }
+    case 'tui':
+      return handleTui(repoRoot, config);
+    default:
+      throw new Error(`Unknown subcommand: ${subcommand}\n\n${usage()}`);
+  }
+}
+
+export default {
+  id: 'skill-evolver',
+  kind: 'tool',
+  register(api) {
+    api.registerCommand({
+      name: 'skill-evolver',
+      description:
+        'Evolve SKILL.md descriptions and bodies via DSPy + GEPA (subcommands: list, extract, evolve, preview)',
+      handler: async (args, context) => dispatch(args, context, api),
+    });
+
+    api.registerTool({
+      name: 'skill_evolver_list',
+      description:
+        'List skills ranked by observation counts and failure rates, to identify candidates for evolution.',
+      parameters: { type: 'object', properties: {}, additionalProperties: false },
+      handler: async () => handleList(resolveRepoRoot()),
+    });
+
+    api.registerTool({
+      name: 'skill_evolver_extract',
+      description:
+        'Extract trace-based evaluation data for a skill from the HybridClaw database and session transcripts.',
+      parameters: {
+        type: 'object',
+        properties: {
+          skill: { type: 'string', description: 'Skill name (directory name or frontmatter name:).' },
+        },
+        required: ['skill'],
+        additionalProperties: false,
+      },
+      handler: async ({ skill }) =>
+        handleExtract(skill, resolveRepoRoot(), resolveConfig(api)),
+    });
+
+    api.logger?.info(
+      { pluginRoot: pluginRoot() },
+      'skill-evolver plugin registered',
+    );
+  },
+};

--- a/plugins/skill-evolver/src/index.js
+++ b/plugins/skill-evolver/src/index.js
@@ -1,11 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
+import { applyVariant } from './apply-variant.js';
+import { pluginRoot, runPython, workspaceCacheDir } from './python-bridge.js';
 import { findSkill, listAllSkills, loadSkill } from './skill-locator.js';
 import { extractTraces, writeTraceDataset } from './trace-extractor.js';
-import { applyVariant } from './apply-variant.js';
-import { runPython, pluginRoot, workspaceCacheDir } from './python-bridge.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const PLUGIN_ROOT = path.resolve(path.dirname(__filename), '..');
@@ -91,19 +90,6 @@ function datasetPathFor(repoRoot, config, skillName, filename) {
 
 async function handleList(repoRoot) {
   const skills = listAllSkills(repoRoot);
-  let byObservation = [];
-  try {
-    const traces = extractTraces({
-      skillName: '*',
-      repoRoot,
-      limit: 1,
-      includeOtherSkills: false,
-    });
-    byObservation = [];
-    void traces;
-  } catch {
-    byObservation = [];
-  }
 
   const rows = skills
     .map((skill) => {
@@ -119,13 +105,16 @@ async function handleList(repoRoot) {
       } catch {
         observations = [];
       }
-      const failures = observations.filter((o) => o.outcome !== 'success').length;
+      const failures = observations.filter(
+        (o) => o.outcome !== 'success',
+      ).length;
       return {
         name: skill.name,
         bodyBytes: skill.bodyBytes,
         observations: observations.length,
         failures,
-        failureRate: observations.length > 0 ? failures / observations.length : 0,
+        failureRate:
+          observations.length > 0 ? failures / observations.length : 0,
       };
     })
     .sort((a, b) => {
@@ -166,13 +155,7 @@ async function handleExtract(skillName, repoRoot, config) {
   };
 }
 
-async function handleEvolve(
-  skillName,
-  { flags },
-  repoRoot,
-  config,
-  api,
-) {
+async function handleEvolve(skillName, { flags }, repoRoot, config, api) {
   const target = flags.target;
   if (!target || !['description', 'body', 'both'].includes(target)) {
     throw new Error(
@@ -183,7 +166,10 @@ async function handleEvolve(
     .split(',')
     .map((s) => s.trim())
     .filter(Boolean);
-  const iterations = Number.parseInt(flags.iterations || config.defaultIterations, 10);
+  const iterations = Number.parseInt(
+    flags.iterations || config.defaultIterations,
+    10,
+  );
   if (!Number.isFinite(iterations) || iterations < 1) {
     throw new Error('--iterations must be a positive integer');
   }
@@ -210,7 +196,12 @@ async function handleEvolve(
         'Not enough trace observations; dropping traces source.',
       );
     } else {
-      tracesDatasetPath = datasetPathFor(repoRoot, config, skill.name, 'traces.json');
+      tracesDatasetPath = datasetPathFor(
+        repoRoot,
+        config,
+        skill.name,
+        'traces.json',
+      );
       writeTraceDataset(
         {
           skillName: skill.name,
@@ -223,26 +214,35 @@ async function handleEvolve(
     }
   }
 
-  const workDir = path.join(
-    workspaceCacheDir(),
-    `${skill.name}-${Date.now()}`,
-  );
+  const workDir = path.join(workspaceCacheDir(), `${skill.name}-${Date.now()}`);
   fs.mkdirSync(workDir, { recursive: true });
 
   const pythonArgs = [
     'evolve',
-    '--skill-path', skillPath,
-    '--skill-name', skill.name,
-    '--target', target,
-    '--iterations', String(iterations),
-    '--optimizer-model', config.optimizerModel,
-    '--eval-model', config.evalModel,
-    '--max-body-bytes', String(config.maxSkillBodyBytes),
-    '--max-description-chars', String(config.maxDescriptionChars),
-    '--sources', sources.join(','),
-    '--work-dir', workDir,
-    '--repo-root', repoRoot,
-    '--datasets-dir', path.join(repoRoot, config.datasetsDir),
+    '--skill-path',
+    skillPath,
+    '--skill-name',
+    skill.name,
+    '--target',
+    target,
+    '--iterations',
+    String(iterations),
+    '--optimizer-model',
+    config.optimizerModel,
+    '--eval-model',
+    config.evalModel,
+    '--max-body-bytes',
+    String(config.maxSkillBodyBytes),
+    '--max-description-chars',
+    String(config.maxDescriptionChars),
+    '--sources',
+    sources.join(','),
+    '--work-dir',
+    workDir,
+    '--repo-root',
+    repoRoot,
+    '--datasets-dir',
+    path.join(repoRoot, config.datasetsDir),
   ];
   if (tracesDatasetPath) {
     pythonArgs.push('--traces-dataset', tracesDatasetPath);
@@ -365,7 +365,9 @@ async function handleShow(skillName, runId) {
   if (!match || !match.resultPath) {
     return { ok: false, error: `No evolution run found for ${skillName}.` };
   }
-  const result = await runPython(['show', match.resultPath], { stdio: 'inherit' });
+  const result = await runPython(['show', match.resultPath], {
+    stdio: 'inherit',
+  });
   return { ok: result.code === 0, exitCode: result.code };
 }
 
@@ -470,7 +472,11 @@ export default {
       name: 'skill_evolver_list',
       description:
         'List skills ranked by observation counts and failure rates, to identify candidates for evolution.',
-      parameters: { type: 'object', properties: {}, additionalProperties: false },
+      parameters: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
       handler: async () => handleList(resolveRepoRoot()),
     });
 
@@ -481,7 +487,10 @@ export default {
       parameters: {
         type: 'object',
         properties: {
-          skill: { type: 'string', description: 'Skill name (directory name or frontmatter name:).' },
+          skill: {
+            type: 'string',
+            description: 'Skill name (directory name or frontmatter name:).',
+          },
         },
         required: ['skill'],
         additionalProperties: false,

--- a/plugins/skill-evolver/src/index.js
+++ b/plugins/skill-evolver/src/index.js
@@ -100,6 +100,7 @@ async function handleList(repoRoot) {
           repoRoot,
           limit: 500,
           includeOtherSkills: false,
+          includeTranscripts: false,
         });
         observations = obs;
       } catch {
@@ -195,6 +196,8 @@ async function handleEvolve(skillName, { flags }, repoRoot, config, api) {
         },
         'Not enough trace observations; dropping traces source.',
       );
+      const index = sources.indexOf('traces');
+      if (index >= 0) sources.splice(index, 1);
     } else {
       tracesDatasetPath = datasetPathFor(
         repoRoot,

--- a/plugins/skill-evolver/src/python-bridge.js
+++ b/plugins/skill-evolver/src/python-bridge.js
@@ -15,11 +15,17 @@ function venvPythonPath() {
     : path.join(PLUGIN_ROOT, '.venv', 'bin', 'python');
 }
 
+function missingPluginVenvError(venv) {
+  return new Error(
+    `Skill Evolver plugin environment is missing: ${venv}\n` +
+      'Run `hybridclaw plugin install ./plugins/skill-evolver --yes` to create the plugin virtual environment and install its pip dependencies.',
+  );
+}
+
 function resolvePython() {
   const venv = venvPythonPath();
   if (fs.existsSync(venv)) return venv;
-  const sys = process.platform === 'win32' ? 'py' : 'python3';
-  return sys;
+  throw missingPluginVenvError(venv);
 }
 
 function ensurePackageInstalled(python) {
@@ -72,7 +78,9 @@ function collectCapped(stream, collector) {
       collector.truncated = true;
       return;
     }
-    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk), 'utf-8');
+    const buf = Buffer.isBuffer(chunk)
+      ? chunk
+      : Buffer.from(String(chunk), 'utf-8');
     if (buf.length <= remaining) {
       collector.chunks.push(buf);
       collector.size += buf.length;

--- a/plugins/skill-evolver/src/python-bridge.js
+++ b/plugins/skill-evolver/src/python-bridge.js
@@ -1,0 +1,152 @@
+import { spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const PLUGIN_ROOT = path.resolve(path.dirname(__filename), '..');
+
+const DEFAULT_CAPTURE_LIMIT_BYTES = 2_000_000;
+
+function venvPythonPath() {
+  return process.platform === 'win32'
+    ? path.join(PLUGIN_ROOT, '.venv', 'Scripts', 'python.exe')
+    : path.join(PLUGIN_ROOT, '.venv', 'bin', 'python');
+}
+
+function resolvePython() {
+  const venv = venvPythonPath();
+  if (fs.existsSync(venv)) return venv;
+  const sys = process.platform === 'win32' ? 'py' : 'python3';
+  return sys;
+}
+
+function ensurePackageInstalled(python) {
+  const result = spawnSync(
+    python,
+    ['-c', 'import skill_evolver, sys; sys.exit(0)'],
+    { cwd: PLUGIN_ROOT, encoding: 'utf-8' },
+  );
+  if (result.status === 0) return;
+  const install = spawnSync(
+    python,
+    ['-m', 'pip', 'install', '--no-deps', '-e', PLUGIN_ROOT],
+    { cwd: PLUGIN_ROOT, encoding: 'utf-8' },
+  );
+  if (install.status !== 0) {
+    throw new Error(
+      `Failed to install hybridclaw-skill-evolver into plugin venv.\n${install.stderr || install.stdout}`,
+    );
+  }
+}
+
+function filteredEnv(extra = {}) {
+  const allow = [
+    'PATH',
+    'HOME',
+    'TMPDIR',
+    'LANG',
+    'LC_ALL',
+    'LC_CTYPE',
+    'OPENAI_API_KEY',
+    'ANTHROPIC_API_KEY',
+    'OPENROUTER_API_KEY',
+    'XDG_CACHE_HOME',
+    'XDG_CONFIG_HOME',
+    'XDG_DATA_HOME',
+  ];
+  const env = {};
+  for (const key of allow) {
+    const value = process.env[key];
+    if (typeof value === 'string' && value.length > 0) env[key] = value;
+  }
+  return { ...env, ...extra };
+}
+
+function collectCapped(stream, collector) {
+  stream.on('data', (chunk) => {
+    if (collector.truncated) return;
+    const remaining = collector.limit - collector.size;
+    if (remaining <= 0) {
+      collector.truncated = true;
+      return;
+    }
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk), 'utf-8');
+    if (buf.length <= remaining) {
+      collector.chunks.push(buf);
+      collector.size += buf.length;
+    } else {
+      collector.chunks.push(buf.slice(0, remaining));
+      collector.size += remaining;
+      collector.truncated = true;
+    }
+  });
+}
+
+function makeCollector(limit = DEFAULT_CAPTURE_LIMIT_BYTES) {
+  return { chunks: [], size: 0, limit, truncated: false };
+}
+
+function collectorToString(collector) {
+  return Buffer.concat(collector.chunks).toString('utf-8');
+}
+
+export async function runPython(args, options = {}) {
+  const python = resolvePython();
+  ensurePackageInstalled(python);
+
+  const inherit = options.stdio === 'inherit';
+
+  if (inherit) {
+    return await new Promise((resolve, reject) => {
+      const child = spawn(python, ['-m', 'skill_evolver', ...args], {
+        cwd: PLUGIN_ROOT,
+        env: filteredEnv(options.env),
+        stdio: 'inherit',
+      });
+      child.on('error', reject);
+      child.on('close', (code) => {
+        resolve({ code, stdout: '', stderr: '', inherited: true });
+      });
+    });
+  }
+
+  const stdoutCollector = makeCollector(options.stdoutLimitBytes);
+  const stderrCollector = makeCollector(options.stderrLimitBytes);
+
+  return await new Promise((resolve, reject) => {
+    const child = spawn(python, ['-m', 'skill_evolver', ...args], {
+      cwd: PLUGIN_ROOT,
+      env: filteredEnv(options.env),
+    });
+    collectCapped(child.stdout, stdoutCollector);
+    collectCapped(child.stderr, stderrCollector);
+
+    if (typeof options.onStdoutChunk === 'function') {
+      child.stdout.on('data', (chunk) => options.onStdoutChunk(String(chunk)));
+    }
+    if (typeof options.onStderrChunk === 'function') {
+      child.stderr.on('data', (chunk) => options.onStderrChunk(String(chunk)));
+    }
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({
+        code,
+        stdout: collectorToString(stdoutCollector),
+        stderr: collectorToString(stderrCollector),
+        stdoutTruncated: stdoutCollector.truncated,
+        stderrTruncated: stderrCollector.truncated,
+      });
+    });
+  });
+}
+
+export function pluginRoot() {
+  return PLUGIN_ROOT;
+}
+
+export function workspaceCacheDir() {
+  return path.join(os.tmpdir(), 'hybridclaw-skill-evolver');
+}

--- a/plugins/skill-evolver/src/skill-locator.js
+++ b/plugins/skill-evolver/src/skill-locator.js
@@ -1,0 +1,116 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SKILL_SEARCH_ROOTS = [
+  'skills',
+  'community-skills',
+  'plugins',
+];
+
+function* walkSkillFiles(root) {
+  if (!fs.existsSync(root)) return;
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+        stack.push(full);
+        continue;
+      }
+      if (entry.name === 'SKILL.md') yield full;
+    }
+  }
+}
+
+function parseFrontmatter(raw) {
+  if (!raw.startsWith('---')) {
+    return { frontmatter: '', body: raw, fields: {} };
+  }
+  const end = raw.indexOf('\n---', 3);
+  if (end < 0) return { frontmatter: '', body: raw, fields: {} };
+  const frontmatter = raw.slice(3, end).replace(/^\n/, '').replace(/\n$/, '');
+  const body = raw.slice(end + 4).replace(/^\n/, '');
+  const fields = {};
+  for (const line of frontmatter.split('\n')) {
+    const match = /^([A-Za-z_][A-Za-z0-9_-]*):\s*(.*)$/.exec(line);
+    if (!match) continue;
+    const [, key, rawValue] = match;
+    const trimmed = rawValue.trim();
+    if (!trimmed) continue;
+    const unquoted = trimmed.replace(/^"(.*)"$/, '$1').replace(/^'(.*)'$/, '$1');
+    fields[key] = unquoted;
+  }
+  return { frontmatter, body, fields };
+}
+
+export function findSkill(skillName, repoRoot) {
+  const normalized = String(skillName || '').trim();
+  if (!normalized) return null;
+
+  for (const rel of SKILL_SEARCH_ROOTS) {
+    const root = path.join(repoRoot, rel);
+    for (const filePath of walkSkillFiles(root)) {
+      if (path.basename(path.dirname(filePath)) === normalized) {
+        return filePath;
+      }
+    }
+  }
+
+  for (const rel of SKILL_SEARCH_ROOTS) {
+    const root = path.join(repoRoot, rel);
+    for (const filePath of walkSkillFiles(root)) {
+      try {
+        const head = fs.readFileSync(filePath, 'utf-8').slice(0, 1024);
+        const { fields } = parseFrontmatter(head);
+        if (fields.name === normalized) return filePath;
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function loadSkill(skillPath) {
+  const raw = fs.readFileSync(skillPath, 'utf-8');
+  const { frontmatter, body, fields } = parseFrontmatter(raw);
+  return {
+    path: skillPath,
+    raw,
+    frontmatter,
+    body,
+    name: fields.name || path.basename(path.dirname(skillPath)),
+    description: fields.description || '',
+    fields,
+  };
+}
+
+export function listAllSkills(repoRoot) {
+  const skills = [];
+  for (const rel of SKILL_SEARCH_ROOTS) {
+    const root = path.join(repoRoot, rel);
+    for (const filePath of walkSkillFiles(root)) {
+      try {
+        const skill = loadSkill(filePath);
+        skills.push({
+          name: skill.name,
+          description: skill.description,
+          path: filePath,
+          bodyBytes: Buffer.byteLength(skill.body, 'utf-8'),
+        });
+      } catch {
+        continue;
+      }
+    }
+  }
+  return skills;
+}

--- a/plugins/skill-evolver/src/skill-locator.js
+++ b/plugins/skill-evolver/src/skill-locator.js
@@ -1,11 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-const SKILL_SEARCH_ROOTS = [
-  'skills',
-  'community-skills',
-  'plugins',
-];
+const SKILL_SEARCH_ROOTS = ['skills', 'community-skills', 'plugins'];
 
 function* walkSkillFiles(root) {
   if (!fs.existsSync(root)) return;
@@ -21,7 +17,8 @@ function* walkSkillFiles(root) {
     for (const entry of entries) {
       const full = path.join(dir, entry.name);
       if (entry.isDirectory()) {
-        if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+        if (entry.name === 'node_modules' || entry.name.startsWith('.'))
+          continue;
         stack.push(full);
         continue;
       }
@@ -31,13 +28,17 @@ function* walkSkillFiles(root) {
 }
 
 function parseFrontmatter(raw) {
-  if (!raw.startsWith('---')) {
-    return { frontmatter: '', body: raw, fields: {} };
+  const normalized = String(raw).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  if (!normalized.startsWith('---')) {
+    return { frontmatter: '', body: normalized, fields: {} };
   }
-  const end = raw.indexOf('\n---', 3);
-  if (end < 0) return { frontmatter: '', body: raw, fields: {} };
-  const frontmatter = raw.slice(3, end).replace(/^\n/, '').replace(/\n$/, '');
-  const body = raw.slice(end + 4).replace(/^\n/, '');
+  const end = normalized.indexOf('\n---', 3);
+  if (end < 0) return { frontmatter: '', body: normalized, fields: {} };
+  const frontmatter = normalized
+    .slice(3, end)
+    .replace(/^\n/, '')
+    .replace(/\n$/, '');
+  const body = normalized.slice(end + 4).replace(/^\n/, '');
   const fields = {};
   for (const line of frontmatter.split('\n')) {
     const match = /^([A-Za-z_][A-Za-z0-9_-]*):\s*(.*)$/.exec(line);
@@ -45,7 +46,9 @@ function parseFrontmatter(raw) {
     const [, key, rawValue] = match;
     const trimmed = rawValue.trim();
     if (!trimmed) continue;
-    const unquoted = trimmed.replace(/^"(.*)"$/, '$1').replace(/^'(.*)'$/, '$1');
+    const unquoted = trimmed
+      .replace(/^"(.*)"$/, '$1')
+      .replace(/^'(.*)'$/, '$1');
     fields[key] = unquoted;
   }
   return { frontmatter, body, fields };
@@ -71,9 +74,7 @@ export function findSkill(skillName, repoRoot) {
         const head = fs.readFileSync(filePath, 'utf-8').slice(0, 1024);
         const { fields } = parseFrontmatter(head);
         if (fields.name === normalized) return filePath;
-      } catch {
-        continue;
-      }
+      } catch {}
     }
   }
 
@@ -107,9 +108,7 @@ export function listAllSkills(repoRoot) {
           path: filePath,
           bodyBytes: Buffer.byteLength(skill.body, 'utf-8'),
         });
-      } catch {
-        continue;
-      }
+      } catch {}
     }
   }
   return skills;

--- a/plugins/skill-evolver/src/trace-extractor.js
+++ b/plugins/skill-evolver/src/trace-extractor.js
@@ -1,0 +1,205 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+function resolveDataDir() {
+  const envDir = (process.env.HYBRIDCLAW_DATA_DIR || '').trim();
+  if (envDir && path.isAbsolute(envDir)) {
+    return path.join(envDir, 'data');
+  }
+  return path.join(os.homedir(), '.hybridclaw', 'data');
+}
+
+function resolveDbPath() {
+  const dataDir = resolveDataDir();
+  return path.join(dataDir, 'hybridclaw.db');
+}
+
+function safeSessionFilename(sessionId) {
+  const normalized = String(sessionId).trim().replace(/[^a-zA-Z0-9_-]/g, '_');
+  return normalized || 'session';
+}
+
+function findTranscriptFiles(dataDir, sessionId) {
+  const agentsDir = path.join(dataDir, 'agents');
+  if (!fs.existsSync(agentsDir)) return [];
+  const safeName = `${safeSessionFilename(sessionId)}.jsonl`;
+  const results = [];
+  for (const agent of fs.readdirSync(agentsDir)) {
+    const candidate = path.join(agentsDir, agent, '.session-transcripts', safeName);
+    if (fs.existsSync(candidate)) results.push(candidate);
+  }
+  return results;
+}
+
+function readTranscript(filePath) {
+  const entries = [];
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return entries;
+  }
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      entries.push(JSON.parse(line));
+    } catch {
+      continue;
+    }
+  }
+  return entries;
+}
+
+function loadTranscriptForSession(dataDir, sessionId) {
+  const files = findTranscriptFiles(dataDir, sessionId);
+  const seen = new Set();
+  const entries = [];
+  for (const filePath of files) {
+    for (const entry of readTranscript(filePath)) {
+      const key = `${entry.createdAt || ''}|${entry.role || ''}|${(entry.content || '').slice(0, 120)}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      entries.push(entry);
+    }
+  }
+  entries.sort((a, b) => {
+    const ta = Date.parse(a.createdAt || '') || 0;
+    const tb = Date.parse(b.createdAt || '') || 0;
+    return ta - tb;
+  });
+  return entries;
+}
+
+function findPromptForObservation(transcript, observationCreatedAt) {
+  const observationMs = Date.parse(observationCreatedAt) || Date.now();
+  let best = null;
+  for (const entry of transcript) {
+    const entryMs = Date.parse(entry.createdAt || '') || 0;
+    if (entryMs > observationMs) break;
+    if (String(entry.role || '').toLowerCase() !== 'user') continue;
+    best = entry;
+  }
+  return best ? String(best.content || '').trim() : '';
+}
+
+function loadSqliteDriver() {
+  try {
+    return require('better-sqlite3');
+  } catch (err) {
+    throw new Error(
+      `better-sqlite3 is required to read the HybridClaw database. Install via the main repo (\`npm install\`) before running trace extraction. Underlying error: ${err.message}`,
+    );
+  }
+}
+
+export function extractTraces(options) {
+  const {
+    skillName,
+    repoRoot,
+    limit = 500,
+    includeOtherSkills = true,
+    otherSkillSampleCap = 200,
+  } = options;
+  if (!skillName) {
+    throw new Error('extractTraces requires a skillName');
+  }
+
+  const dataDir = resolveDataDir();
+  const dbPath = resolveDbPath();
+  if (!fs.existsSync(dbPath)) {
+    return {
+      dbPath,
+      dataDir,
+      repoRoot,
+      skillName,
+      observations: [],
+      otherSkillObservations: [],
+      transcripts: {},
+      warning: 'HybridClaw database not found at expected path.',
+    };
+  }
+
+  const Database = loadSqliteDriver();
+  const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+
+  let observations = [];
+  let otherSkillObservations = [];
+  const transcripts = {};
+
+  try {
+    observations = db
+      .prepare(
+        `SELECT id, skill_name, session_id, run_id, outcome, error_category,
+                error_detail, tool_calls_attempted, tool_calls_failed,
+                duration_ms, feedback_sentiment, created_at
+         FROM skill_observations
+         WHERE skill_name = ?
+         ORDER BY created_at DESC
+         LIMIT ?`,
+      )
+      .all(skillName, limit);
+
+    if (includeOtherSkills) {
+      otherSkillObservations = db
+        .prepare(
+          `SELECT skill_name, session_id, run_id, outcome, created_at
+           FROM skill_observations
+           WHERE skill_name != ?
+           ORDER BY created_at DESC
+           LIMIT ?`,
+        )
+        .all(skillName, otherSkillSampleCap);
+    }
+
+    const sessionIds = new Set(observations.map((o) => o.session_id));
+    for (const otherObs of otherSkillObservations) {
+      sessionIds.add(otherObs.session_id);
+    }
+
+    for (const sessionId of sessionIds) {
+      const transcript = loadTranscriptForSession(dataDir, sessionId);
+      if (transcript.length === 0) continue;
+      transcripts[sessionId] = transcript;
+    }
+  } finally {
+    db.close();
+  }
+
+  const enriched = observations.map((row) => {
+    const transcript = transcripts[row.session_id] || [];
+    const userPrompt = findPromptForObservation(transcript, row.created_at);
+    return {
+      ...row,
+      user_prompt: userPrompt,
+    };
+  });
+
+  const enrichedOthers = otherSkillObservations.map((row) => {
+    const transcript = transcripts[row.session_id] || [];
+    const userPrompt = findPromptForObservation(transcript, row.created_at);
+    return {
+      ...row,
+      user_prompt: userPrompt,
+    };
+  });
+
+  return {
+    dbPath,
+    dataDir,
+    repoRoot,
+    skillName,
+    observations: enriched,
+    otherSkillObservations: enrichedOthers,
+    transcripts,
+  };
+}
+
+export function writeTraceDataset(payload, outPath) {
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf-8');
+  return outPath;
+}

--- a/plugins/skill-evolver/src/trace-extractor.js
+++ b/plugins/skill-evolver/src/trace-extractor.js
@@ -1,16 +1,21 @@
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
-import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
 
 function resolveDataDir() {
   const envDir = (process.env.HYBRIDCLAW_DATA_DIR || '').trim();
-  if (envDir && path.isAbsolute(envDir)) {
-    return path.join(envDir, 'data');
+  if (!envDir) {
+    return path.join(os.homedir(), '.hybridclaw', 'data');
   }
-  return path.join(os.homedir(), '.hybridclaw', 'data');
+  if (!path.isAbsolute(envDir)) {
+    throw new Error(
+      `HYBRIDCLAW_DATA_DIR must be an absolute path, got: ${envDir}`,
+    );
+  }
+  return path.join(envDir, 'data');
 }
 
 function resolveDbPath() {
@@ -19,7 +24,9 @@ function resolveDbPath() {
 }
 
 function safeSessionFilename(sessionId) {
-  const normalized = String(sessionId).trim().replace(/[^a-zA-Z0-9_-]/g, '_');
+  const normalized = String(sessionId)
+    .trim()
+    .replace(/[^a-zA-Z0-9_-]/g, '_');
   return normalized || 'session';
 }
 
@@ -29,7 +36,13 @@ function findTranscriptFiles(dataDir, sessionId) {
   const safeName = `${safeSessionFilename(sessionId)}.jsonl`;
   const results = [];
   for (const agent of fs.readdirSync(agentsDir)) {
-    const candidate = path.join(agentsDir, agent, '.session-transcripts', safeName);
+    const candidate = path.join(
+      agentsDir,
+      agent,
+      'workspace',
+      '.session-transcripts',
+      safeName,
+    );
     if (fs.existsSync(candidate)) results.push(candidate);
   }
   return results;
@@ -47,9 +60,7 @@ function readTranscript(filePath) {
     if (!line.trim()) continue;
     try {
       entries.push(JSON.parse(line));
-    } catch {
-      continue;
-    }
+    } catch {}
   }
   return entries;
 }
@@ -103,6 +114,7 @@ export function extractTraces(options) {
     limit = 500,
     includeOtherSkills = true,
     otherSkillSampleCap = 200,
+    includeTranscripts = true,
   } = options;
   if (!skillName) {
     throw new Error('extractTraces requires a skillName');
@@ -118,7 +130,6 @@ export function extractTraces(options) {
       skillName,
       observations: [],
       otherSkillObservations: [],
-      transcripts: {},
       warning: 'HybridClaw database not found at expected path.',
     };
   }
@@ -155,15 +166,17 @@ export function extractTraces(options) {
         .all(skillName, otherSkillSampleCap);
     }
 
-    const sessionIds = new Set(observations.map((o) => o.session_id));
-    for (const otherObs of otherSkillObservations) {
-      sessionIds.add(otherObs.session_id);
-    }
+    if (includeTranscripts) {
+      const sessionIds = new Set(observations.map((o) => o.session_id));
+      for (const otherObs of otherSkillObservations) {
+        sessionIds.add(otherObs.session_id);
+      }
 
-    for (const sessionId of sessionIds) {
-      const transcript = loadTranscriptForSession(dataDir, sessionId);
-      if (transcript.length === 0) continue;
-      transcripts[sessionId] = transcript;
+      for (const sessionId of sessionIds) {
+        const transcript = loadTranscriptForSession(dataDir, sessionId);
+        if (transcript.length === 0) continue;
+        transcripts[sessionId] = transcript;
+      }
     }
   } finally {
     db.close();
@@ -194,12 +207,12 @@ export function extractTraces(options) {
     skillName,
     observations: enriched,
     otherSkillObservations: enrichedOthers,
-    transcripts,
   };
 }
 
 export function writeTraceDataset(payload, outPath) {
+  const { transcripts: _transcripts, ...sanitized } = payload;
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  fs.writeFileSync(outPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf-8');
+  fs.writeFileSync(outPath, `${JSON.stringify(sanitized, null, 2)}\n`, 'utf-8');
   return outPath;
 }

--- a/plugins/skill-evolver/tests/test_skill_module.py
+++ b/plugins/skill-evolver/tests/test_skill_module.py
@@ -1,0 +1,69 @@
+"""Round-trip test for SKILL.md parsing + frontmatter-preserving reassembly."""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from skill_evolver.skill_module import load_skill, reassemble
+
+
+SAMPLE = """---
+name: my-skill
+description: short description
+category: memory
+tags:
+  - alpha
+  - beta
+---
+
+# My Skill
+
+Use this skill when the user asks about X.
+
+## Workflow
+
+1. do thing
+2. do other thing
+"""
+
+
+def test_load_skill_round_trip() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        skill_path = Path(tmp) / "SKILL.md"
+        skill_path.write_text(SAMPLE, encoding="utf-8")
+
+        parsed = load_skill(skill_path)
+        assert parsed.name == "my-skill"
+        assert parsed.description == "short description"
+        assert "# My Skill" in parsed.body
+        assert "Workflow" in parsed.body
+
+        reassembled = reassemble(parsed)
+        assert "name: my-skill" in reassembled
+        assert "description: short description" in reassembled
+        assert reassembled.rstrip().endswith("2. do other thing")
+
+
+def test_reassemble_overrides_description() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        skill_path = Path(tmp) / "SKILL.md"
+        skill_path.write_text(SAMPLE, encoding="utf-8")
+        parsed = load_skill(skill_path)
+
+        updated = reassemble(parsed, description="new punchier description")
+        assert "description: new punchier description" in updated
+        assert "short description" not in updated
+        assert "# My Skill" in updated
+
+
+def test_reassemble_overrides_body() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        skill_path = Path(tmp) / "SKILL.md"
+        skill_path.write_text(SAMPLE, encoding="utf-8")
+        parsed = load_skill(skill_path)
+
+        new_body = "# Rewritten\n\nnew content"
+        updated = reassemble(parsed, body=new_body)
+        assert "description: short description" in updated
+        assert "# Rewritten" in updated
+        assert "# My Skill" not in updated

--- a/tests/skill-evolver-plugin.test.ts
+++ b/tests/skill-evolver-plugin.test.ts
@@ -1,0 +1,95 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect, test } from 'vitest';
+
+import { useTempDir } from './test-utils.ts';
+
+const makeTempDir = useTempDir();
+
+function writeSkill(
+  root: string,
+  relativePath: string,
+  frontmatter: Record<string, string>,
+  body: string,
+): string {
+  const full = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  const front = Object.entries(frontmatter)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join('\n');
+  fs.writeFileSync(full, `---\n${front}\n---\n${body}`, 'utf-8');
+  return full;
+}
+
+test('skill-locator finds SKILL.md under skills/, community-skills/, and plugins/', async () => {
+  const repo = makeTempDir('hybridclaw-skill-evolver-repo-');
+
+  writeSkill(
+    repo,
+    'skills/alpha/SKILL.md',
+    { name: 'alpha', description: 'first skill' },
+    '# Alpha\n\nDo alpha things.',
+  );
+  writeSkill(
+    repo,
+    'community-skills/beta/SKILL.md',
+    { name: 'beta', description: 'second skill' },
+    '# Beta\n\nDo beta things.',
+  );
+  writeSkill(
+    repo,
+    'plugins/some-plugin/skills/gamma/SKILL.md',
+    { name: 'gamma', description: 'third skill' },
+    '# Gamma\n\nDo gamma things.',
+  );
+
+  const { findSkill, listAllSkills, loadSkill } = await import(
+    '../plugins/skill-evolver/src/skill-locator.js'
+  );
+
+  const all = listAllSkills(repo);
+  expect(all.map((skill: { name: string }) => skill.name).sort()).toEqual([
+    'alpha',
+    'beta',
+    'gamma',
+  ]);
+
+  const alphaPath = findSkill('alpha', repo);
+  expect(alphaPath).toBeTruthy();
+  const parsed = loadSkill(alphaPath!);
+  expect(parsed.name).toBe('alpha');
+  expect(parsed.description).toBe('first skill');
+  expect(parsed.body.startsWith('# Alpha')).toBe(true);
+});
+
+test('skill-locator returns null for missing skills', async () => {
+  const repo = makeTempDir('hybridclaw-skill-evolver-missing-');
+  fs.mkdirSync(path.join(repo, 'skills'), { recursive: true });
+  const { findSkill } = await import(
+    '../plugins/skill-evolver/src/skill-locator.js'
+  );
+  expect(findSkill('nonexistent', repo)).toBeNull();
+});
+
+test('plugin default export registers a command and tools', async () => {
+  const plugin = (
+    await import('../plugins/skill-evolver/src/index.js')
+  ).default;
+
+  const commands: Array<{ name: string }> = [];
+  const tools: Array<{ name: string }> = [];
+  const api = {
+    pluginConfig: {},
+    logger: { info: () => undefined, warn: () => undefined },
+    registerCommand: (spec: { name: string }) => commands.push(spec),
+    registerTool: (spec: { name: string }) => tools.push(spec),
+  } as unknown as Parameters<typeof plugin.register>[0];
+
+  plugin.register(api);
+
+  expect(commands.map((c) => c.name)).toContain('skill-evolver');
+  expect(tools.map((t) => t.name).sort()).toEqual([
+    'skill_evolver_extract',
+    'skill_evolver_list',
+  ]);
+});

--- a/tests/skill-evolver-plugin.test.ts
+++ b/tests/skill-evolver-plugin.test.ts
@@ -56,7 +56,8 @@ test('skill-locator finds SKILL.md under skills/, community-skills/, and plugins
 
   const alphaPath = findSkill('alpha', repo);
   expect(alphaPath).toBeTruthy();
-  const parsed = loadSkill(alphaPath!);
+  if (!alphaPath) throw new Error('alpha skill path should resolve');
+  const parsed = loadSkill(alphaPath);
   expect(parsed.name).toBe('alpha');
   expect(parsed.description).toBe('first skill');
   expect(parsed.body.startsWith('# Alpha')).toBe(true);
@@ -72,9 +73,8 @@ test('skill-locator returns null for missing skills', async () => {
 });
 
 test('plugin default export registers a command and tools', async () => {
-  const plugin = (
-    await import('../plugins/skill-evolver/src/index.js')
-  ).default;
+  const plugin = (await import('../plugins/skill-evolver/src/index.js'))
+    .default;
 
   const commands: Array<{ name: string }> = [];
   const tools: Array<{ name: string }> = [];


### PR DESCRIPTION
## Summary

- **Problem**: Existing adaptive-skills flow can only make conservative single-point edits. There's no offline, multi-iteration evolution loop that evaluates a SKILL.md against synthetic + golden + real-trace data and opens a reviewable PR.
- **Why it matters**: Skill quality compounds — poor descriptions cause routing misses and poor bodies cause execution failures. A dedicated evolver lets operators run targeted optimization runs against concrete fitness signals before committing.
- **What changed**: New bundled plugin at `plugins/skill-evolver/` that wraps DSPy + GEPA for two optimization targets (description / body / joint), three dataset sources (synthetic / golden / traces), a Rich-based TUI, a constraint-gated apply-and-PR pipeline, docs, and tests.
- **What did not change**: Adaptive skills, the skill runtime, SKILL.md format, and existing plugin SDK are untouched. The new plugin opts in per-skill, per-run.

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Docs
- [x] Tests
- [ ] Refactor required for the fix
- [ ] Tooling or workflow
- [ ] Security hardening

## Linked Context

- Closes #
- Related #

## Architecture

### Two evolution targets

| Target | Optimizable surface | Fitness |
| --- | --- | --- |
| `description` | frontmatter `description:` field | judge-LM trigger-classification F1 against the real installed skill pool |
| `body` | SKILL.md markdown body | LLM-judge scoring (correctness/procedure/conciseness) of a follower LM executing tasks |
| `both` | both surfaces | body first, then description, then cross-validated for drift |

### Three dataset ingredients

- `synthetic` — LLM generates positives + adversarial negatives from the skill's own text
- `golden` — human-curated `datasets/skills/<skill>/{triggers,tasks}.json`
- `traces` — `skill_observations` rows in the HybridClaw SQLite DB joined with session transcripts to recover the originating user prompt

### Safety gates

Before any variant is committed:
- body size cap (default 15 KB), description cap (default 1024 chars)
- description non-empty and short-form
- body keeps a top-level heading, no frontmatter leak
- body may not grow more than 1.5× baseline
- optional `npm test` run against the applied variant, rolled back on failure
- optional `gh pr create` in `--open-pr` mode

## Commands

```
hybridclaw skill-evolver list                                 # rank skills by failure rate
hybridclaw skill-evolver extract <skill>                      # write datasets/skills/<skill>/traces.json
hybridclaw skill-evolver evolve <skill> --target description  # (target required, no default)
hybridclaw skill-evolver evolve <skill> --target body --iterations 20
hybridclaw skill-evolver evolve <skill> --target both --open-pr
hybridclaw skill-evolver show <skill>                         # Rich-rendered report of last run
hybridclaw skill-evolver watch <skill>                        # live dashboard while running
hybridclaw skill-evolver tui                                  # interactive skill browser
```

## Implementation notes

- Python sidecar runs in a per-plugin venv auto-provisioned via existing `pipDependencies` mechanism — matches how other Python-using plugins already work. No global install required.
- TS plugin exposes a command + two tools (`skill_evolver_list`, `skill_evolver_extract`). Evolve calls out to the Python bridge, which supports both captured (`stdout/stderr` collection) and `stdio: 'inherit'` passthrough modes for interactive TUI commands.
- Trace extraction lazy-loads `better-sqlite3` via `createRequire`, so plugin registration doesn't hard-fail in environments where the DB isn't built.
- Frontmatter is preserved on reassembly (tags, category, etc. survive); only the targeted field(s) are mutated.

## Validation

```bash
npx vitest run tests/skill-evolver-plugin.test.ts
```

- 3 TS tests pass (skill-locator parses the three search roots, returns null for missing, plugin registers a command and two tools)
- Python round-trip tests for `load_skill` / `reassemble` under `plugins/skill-evolver/tests/test_skill_module.py`
- Verified manually: plugin file tree layout, Python module import graph, dispatcher subcommand coverage
- Edge cases checked: frontmatter with nested YAML lists round-trips, reassemble with override description/body preserves unrelated frontmatter
- Skipped checks and why: full evolve run not exercised in CI (requires LLM keys + GEPA) — gated by the plugin venv + config

## Docs And Config Impact

- [x] README, docs, or examples updated → `docs/content/extensibility/skill-evolver-plugin.md`
- [ ] Config or environment behavior changed
- [ ] Templates or workspace bootstrap files changed
- [ ] No docs or config impact

## Risk Notes

- Security-sensitive paths touched? **No** — plugin runs in the existing gateway sandbox; PR creation uses gh CLI with the operator's own auth
- Gateway, audit, approval, or container boundaries touched? **No** — new plugin only; does not modify core plugin loader, sandbox, or audit flow
- Failure modes: (1) missing API keys → DSPy/GEPA errors surface in the feedback trail; (2) missing `better-sqlite3` → lazy `require` throws a clear error only when `extractTraces` is called; (3) test failure on applied variant → variant is rolled back before commit

## Evidence

- [x] New test coverage: `tests/skill-evolver-plugin.test.ts` (3 tests) + `plugins/skill-evolver/tests/test_skill_module.py` (3 tests)
- [x] Docs page: `docs/content/extensibility/skill-evolver-plugin.md`