### PR TITLE
fix(web-chat): refocus input after bot response (#226)

### DIFF
--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -69,6 +69,14 @@ export function Composer(props: {
     };
   }, []);
 
+  const wasStreamingRef = useRef(props.isStreaming);
+  useEffect(() => {
+    if (wasStreamingRef.current && !props.isStreaming) {
+      textareaRef.current?.focus();
+    }
+    wasStreamingRef.current = props.isStreaming;
+  }, [props.isStreaming]);
+
   const resize = () => {
     const ta = textareaRef.current;
     if (!ta) return;

--- a/docs/chat.html
+++ b/docs/chat.html
@@ -3814,6 +3814,9 @@
         if (requestState.assistantBlock?.isConnected) {
           renderMessageActions(requestState.assistantBlock);
         }
+        if (!activeChatRequest && !messageEl.disabled) {
+          messageEl.focus();
+        }
       }
 
       return null;


### PR DESCRIPTION
## Summary
- After the assistant's response completes (or errors out), automatically return keyboard focus to the message textarea so the user can keep typing without clicking back into the input.

Closes #226

## Test plan
- [ ] Open the docs web chat, send a message, and confirm the textarea regains focus when the response finishes
- [ ] Confirm the stop-button flow (cancel in-flight request) also restores focus once the request resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)