### PR TITLE
fix(slash): list all providers in /auth status suggestions (#255)

### DIFF
--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -159,6 +159,26 @@ const MODEL_PROVIDER_CHOICES = [
   { name: 'vllm', value: 'vllm' },
 ] satisfies Array<{ name: string; value: string }>;
 
+const AUTH_STATUS_PROVIDERS = [
+  'hybridai',
+  'codex',
+  'openrouter',
+  'mistral',
+  'huggingface',
+  'gemini',
+  'deepseek',
+  'xai',
+  'zai',
+  'kimi',
+  'minimax',
+  'dashscope',
+  'xiaomi',
+  'kilo',
+  'local',
+  'msteams',
+  'slack',
+] as const;
+
 const CONCIERGE_PROFILE_CHOICES = [
   { name: 'asap', value: 'asap' },
   { name: 'balanced', value: 'balanced' },
@@ -1091,15 +1111,17 @@ function buildSlashCommandCatalogDefinitions(
       name: 'auth',
       description: 'Show local provider auth and config status',
       tuiOnly: true,
+      tuiMenuEntries: AUTH_STATUS_PROVIDERS.map((provider) => ({
+        id: `auth.status.${provider}`,
+        label: `/auth status ${provider}`,
+        insertText: `/auth status ${provider}`,
+        description: `Show ${provider} auth status`,
+      })),
       options: [
         {
           kind: 'subcommand',
           name: 'status',
-          description: 'Show local HybridAI auth status',
-          tuiMenu: {
-            label: '/auth status hybridai',
-            insertText: '/auth status hybridai',
-          },
+          description: 'Show auth status for a provider',
           options: [
             {
               kind: 'string',


### PR DESCRIPTION
## Summary
- The `/auth` slash-command menu used to only offer `/auth status hybridai`, even though `auth status` is supported for every provider the runtime knows about.
- Switches `/auth` to `tuiMenuEntries` and generates one entry per supported provider (hybridai, codex, openrouter, mistral, huggingface, gemini, deepseek, xai, zai, kimi, minimax, dashscope, xiaomi, kilo, local, msteams, slack).

Closes #255

## Test plan
- [x] `npx vitest run tests/command-registry.test.ts tests/tui-slash-menu.test.ts tests/tui-slash-command.test.ts`
- [ ] Open TUI, type `/auth` and confirm suggestions list every provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)