### PR TITLE
[codex] fix npm trusted publishing auth regression

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -250,7 +250,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 22
+          # npm trusted publishing requires npm 11+, which GitHub-hosted Node 24
+          # provides out of the box on the release runner image.
+          node-version: 24
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
## What changed
Restore the `publish-npm` job in `publish-release.yml` to Node 24 and keep the npm cache configuration.

## Why it changed
The release workflow was switched to npm trusted publishing via OIDC, which depends on npm 11+ for the publish path used in GitHub Actions. A later workflow change moved the publish job to Node 22 on GitHub-hosted runners, which ran npm 10.9.7 and caused `npm publish --provenance` to fail with `ENEEDAUTH`.

## Impact
Tagged releases should authenticate with npm trusted publishing again without reintroducing a long-lived npm token.

## Root cause
`v0.12.5` published successfully on Node 24 / npm 11.11.0. `v0.12.6` ran on Node 22.22.2 / npm 10.9.7 and failed in the `Publish to npm` step with `npm error code ENEEDAUTH`.

## Validation
- `git diff --check`
- Reviewed the workflow diff to confirm only the `publish-npm` runtime changed

## Not run
- No local GitHub Actions workflow linter is configured in this repo
- Full end-to-end release workflow execution was not replayed locally
