### PR TITLE
fix(container): symlink workspace node_modules so ESM skill scripts resolve deps

### DIFF
--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -59,6 +59,14 @@ audit:
 const MAX_FILE_CHARS = 20_000;
 const TEMPLATES_DIR = resolveInstallPath('templates');
 
+/**
+ * Directory (inside the agent container image) where runtime node_modules
+ * are installed. Skill scripts that run from `/workspace/...` need ESM
+ * resolution to walk up into this directory; Node's ESM loader ignores
+ * NODE_PATH, so we symlink `<workspace>/node_modules` at bootstrap time.
+ */
+const CONTAINER_APP_NODE_MODULES = '/app/node_modules';
+
 export interface ContextFile {
   name: string;
   content: string;
@@ -311,6 +319,65 @@ function looksLikeCompletedWorkspace(
 }
 
 /**
+ * Symlink `<wsDir>/node_modules` to the container's `/app/node_modules` so
+ * Node's ESM loader can resolve dependencies from skill scripts that live
+ * under the workspace. Node's ESM resolver walks up the filesystem looking
+ * for `node_modules` and — unlike CommonJS `require()` — ignores `NODE_PATH`,
+ * which is why ESM imports fail even though the deps are installed in
+ * `/app/node_modules`.
+ *
+ * Only creates the symlink when nothing exists at the destination; a
+ * pre-existing `node_modules` (real dir or user-installed symlink) is left
+ * untouched so user-installed deps aren't clobbered. When the source
+ * `/app/node_modules` doesn't exist (e.g. outside the container) this is a
+ * silent no-op.
+ *
+ * Exported for tests.
+ */
+export function ensureWorkspaceNodeModulesLink(
+  wsDir: string,
+  source: string = CONTAINER_APP_NODE_MODULES,
+): void {
+  const target = path.join(wsDir, 'node_modules');
+
+  // `lstat` so we detect a broken symlink at `target` too.
+  try {
+    fs.lstatSync(target);
+    // Something already exists — leave it alone.
+    return;
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err?.code !== 'ENOENT') {
+      logger.warn(
+        { wsDir, target, error },
+        'Failed to inspect workspace node_modules path',
+      );
+      return;
+    }
+  }
+
+  // Only create the link if the source actually exists. Outside the
+  // container (host dev machines, tests) `/app/node_modules` is absent.
+  if (!fs.existsSync(source)) return;
+
+  try {
+    fs.symlinkSync(source, target, 'dir');
+    logger.debug(
+      { wsDir, source, target },
+      'Linked workspace node_modules to container app deps',
+    );
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    // Benign race: another bootstrap pass created it first.
+    if (err?.code === 'EEXIST') return;
+    logger.warn(
+      { wsDir, source, target, error },
+      'Failed to symlink workspace node_modules',
+    );
+  }
+}
+
+/**
  * Ensure workspace has bootstrap files, copying from templates if missing.
  */
 export function ensureBootstrapFiles(
@@ -410,6 +477,8 @@ export function ensureBootstrapFiles(
       );
     }
   }
+
+  ensureWorkspaceNodeModulesLink(wsDir);
 
   return {
     workspacePath: wsDir,

--- a/tests/workspace-bootstrap.test.ts
+++ b/tests/workspace-bootstrap.test.ts
@@ -246,6 +246,87 @@ describe('workspace bootstrap lifecycle', () => {
     expect(state.onboardingCompletedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
   });
 
+  test('symlinks workspace node_modules to the container app deps when absent', async () => {
+    const homeDir = makeTempDir('hybridclaw-home-');
+    const unrelatedCwd = makeTempDir('hybridclaw-cwd-');
+    vi.stubEnv('HOME', homeDir);
+    process.chdir(unrelatedCwd);
+
+    const workspace = await import('../src/workspace.js');
+
+    const wsDir = makeTempDir('hybridclaw-ws-');
+    const appNodeModules = makeTempDir('hybridclaw-app-node_modules-');
+    fs.mkdirSync(path.join(appNodeModules, 'pdf-lib'), { recursive: true });
+    fs.writeFileSync(
+      path.join(appNodeModules, 'pdf-lib', 'package.json'),
+      JSON.stringify({ name: 'pdf-lib', version: '0.0.0-test' }),
+      'utf-8',
+    );
+
+    workspace.ensureWorkspaceNodeModulesLink(wsDir, appNodeModules);
+
+    const linkPath = path.join(wsDir, 'node_modules');
+    const stat = fs.lstatSync(linkPath);
+    expect(stat.isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(linkPath)).toBe(appNodeModules);
+    // Sanity: the symlink resolves to the fake dep we staged.
+    expect(fs.existsSync(path.join(linkPath, 'pdf-lib', 'package.json'))).toBe(
+      true,
+    );
+  });
+
+  test('leaves a pre-existing workspace node_modules directory untouched', async () => {
+    const homeDir = makeTempDir('hybridclaw-home-');
+    const unrelatedCwd = makeTempDir('hybridclaw-cwd-');
+    vi.stubEnv('HOME', homeDir);
+    process.chdir(unrelatedCwd);
+
+    const workspace = await import('../src/workspace.js');
+
+    const wsDir = makeTempDir('hybridclaw-ws-');
+    const appNodeModules = makeTempDir('hybridclaw-app-node_modules-');
+    fs.mkdirSync(path.join(appNodeModules, 'pdf-lib'), { recursive: true });
+
+    // User-installed deps already present in the workspace.
+    const userNodeModules = path.join(wsDir, 'node_modules');
+    fs.mkdirSync(path.join(userNodeModules, 'left-pad'), { recursive: true });
+    fs.writeFileSync(
+      path.join(userNodeModules, 'left-pad', 'package.json'),
+      JSON.stringify({ name: 'left-pad', version: '1.0.0' }),
+      'utf-8',
+    );
+
+    workspace.ensureWorkspaceNodeModulesLink(wsDir, appNodeModules);
+
+    const stat = fs.lstatSync(userNodeModules);
+    expect(stat.isDirectory()).toBe(true);
+    expect(stat.isSymbolicLink()).toBe(false);
+    expect(
+      fs.existsSync(path.join(userNodeModules, 'left-pad', 'package.json')),
+    ).toBe(true);
+    // App deps must NOT have leaked into the user's workspace.
+    expect(fs.existsSync(path.join(userNodeModules, 'pdf-lib'))).toBe(false);
+  });
+
+  test('is a no-op when the container app node_modules source is absent', async () => {
+    const homeDir = makeTempDir('hybridclaw-home-');
+    const unrelatedCwd = makeTempDir('hybridclaw-cwd-');
+    vi.stubEnv('HOME', homeDir);
+    process.chdir(unrelatedCwd);
+
+    const workspace = await import('../src/workspace.js');
+
+    const wsDir = makeTempDir('hybridclaw-ws-');
+    const missingSource = path.join(
+      makeTempDir('hybridclaw-app-'),
+      'does-not-exist',
+    );
+
+    workspace.ensureWorkspaceNodeModulesLink(wsDir, missingSource);
+
+    expect(fs.existsSync(path.join(wsDir, 'node_modules'))).toBe(false);
+  });
+
   test('keeps a package-provided custom BOOTSTRAP.md on fresh install', async () => {
     const homeDir = makeTempDir('hybridclaw-home-');
     const unrelatedCwd = makeTempDir('hybridclaw-cwd-');


### PR DESCRIPTION
## Summary

- Bootstrap now symlinks `<workspace>/node_modules` → `/app/node_modules` so Node's ESM loader can resolve deps from skill scripts under `/workspace`.
- Only creates the link when nothing exists at the target; pre-existing user dirs are left alone.
- No-op on hosts where `/app/node_modules` doesn't exist (dev machines, CI).

## Why

The agent container installs its runtime deps (e.g. `pdf-lib`) at `/app/node_modules` and sets `NODE_PATH=/usr/local/lib/node_modules:/app/node_modules`. That works for CJS `require()` — but Node's **ESM** loader ignores `NODE_PATH` and instead walks up from the importing file looking for a `node_modules` directory. A skill script at `/workspace/skills/pdf/scripts/create_pdf.mjs` doing `import { PDFDocument } from 'pdf-lib'` therefore fails with `ERR_MODULE_NOT_FOUND`, even though the package is right there.

Reproduced inside a running agent container:

```
$ cd /workspace && node skills/pdf/scripts/create_pdf.mjs --text hi --output /tmp/x.pdf
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'pdf-lib' imported from /workspace/skills/pdf/scripts/create_pdf.mjs

$ node -e 'console.log(require.resolve("pdf-lib"))'
/app/node_modules/pdf-lib/cjs/index.js   # CJS path works via NODE_PATH
```

Symlinking at the workspace root is the standard trick for this asymmetry and fixes both ESM and CJS uniformly without duplicating `node_modules`.

## Scope

This is a tactical fix. The proper long-term solution is per-skill dependency declarations (OpenClaw-style `SKILL.md` manifests with an installer + load-time eligibility filter); that's tracked separately and is a larger architectural change.

## Test plan

- [x] `tests/workspace-bootstrap.test.ts` — three new tests: creates-when-absent, leaves-existing-dir-untouched, no-op-when-source-missing (11/11 pass locally)
- [ ] CI green
- [ ] Manual: run a `.mjs` skill script (e.g. `/pdf`) in a fresh agent container and confirm the import resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)