### PR TITLE
fix: bootstrap Docker workspaces correctly

### DIFF
--- a/container/src/tools.ts
+++ b/container/src/tools.ts
@@ -3201,7 +3201,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
     type: 'function',
     function: {
       name: 'bash',
-      description: `Run a shell command and return stdout/stderr. The shell starts in the workspace root; use relative workspace paths instead of literal ${WORKSPACE_ROOT_DISPLAY} paths. Use bash for absolute paths outside the workspace, and prefer /tmp for temporary scratch files. Do not use for file creation or file editing; use write/edit tools for file authoring.`,
+      description: `Run a shell command and return stdout/stderr. The shell starts in the workspace root; use relative workspace paths instead of literal ${WORKSPACE_ROOT_DISPLAY} paths. Use bash for absolute paths outside the workspace, and prefer /tmp only for temporary scratch files. Final user-visible outputs should be written to workspace-relative paths so they persist and can be attached. Do not use for file creation or file editing; use write/edit tools for file authoring.`,
       parameters: {
         type: 'object',
         properties: {

--- a/skills/pdf/SKILL.md
+++ b/skills/pdf/SKILL.md
@@ -51,7 +51,8 @@ If the user asks for one of those, state that it is outside the bundled Node wor
 - For PDFs outside the workspace, keep the original absolute path when invoking the Node scripts from `bash`.
 - For folder discovery outside the workspace, use `bash` with `find`. Do not use `glob`, ad-hoc Python file discovery, or browser tools.
 - Use a **linear** workflow. Stop as soon as one step succeeds.
-- Use `/tmp` for temporary output when page images are needed.
+- Use workspace-relative output paths for final PDFs you expect HybridClaw to keep, return, or attach.
+- Use `/tmp` only for temporary output when page images or other scratch intermediates are needed.
 - For ordinary extraction tasks, do not probe `pdfinfo`, `pdftotext`, `pdftoppm`, `mdls`, `strings`, `qlmanage`, or browser tools.
 - Before filling any form, read [forms.md](./forms.md).
 - For advanced bundled JS patterns, read [reference.md](./reference.md).
@@ -112,6 +113,8 @@ node skills/pdf/scripts/create_pdf.mjs output.pdf --text "Line 1\nLine 2" --font
 For creation tasks ("make a PDF", "create a PDF with X"), always use this bundled
 script or the recipe from [reference.md](./reference.md). Never call `drawText()`
 without passing an embedded `font` — omitting it produces a blank/corrupt page.
+Use a workspace-relative `output.pdf` path for the final deliverable. Reserve
+`/tmp/...` paths for scratch files that do not need to persist after the run.
 
 ### Text Extraction
 

--- a/src/agent/prompt-hooks.ts
+++ b/src/agent/prompt-hooks.ts
@@ -325,9 +325,10 @@ function buildSafetyHook(context: PromptHookContext): string {
       ? 'Files tools (`read`, `write`, `edit`, `delete`, `glob`, `grep`) operate relative to the workspace directory shown in Runtime Metadata. Use `bash` for absolute paths outside the workspace.'
       : 'Files tools (`read`, `write`, `edit`, `delete`, `glob`, `grep`) are workspace-bound, but configured container bind mounts can make selected host paths available through those tools. Prefer file tools when a bound path resolves; otherwise use `bash` for absolute paths outside the workspace.',
     CONTAINER_SANDBOX_MODE === 'host'
-      ? 'For `bash`, the working directory is the workspace root. Use relative paths from the workspace, prefer `/tmp` for temporary artifacts, and use the workspace path shown in Runtime Metadata when an absolute path is required.'
-      : 'For `bash`, the working directory is the workspace root. Use relative workspace paths instead of literal `/workspace/...` paths, and prefer `/tmp` for temporary artifacts.',
+      ? 'For `bash`, the working directory is the workspace root. Use relative paths from the workspace, prefer `/tmp` only for temporary scratch artifacts, and use the workspace path shown in Runtime Metadata when an absolute path is required.'
+      : 'For `bash`, the working directory is the workspace root. Use relative workspace paths instead of literal `/workspace/...` paths, and prefer `/tmp` only for temporary scratch artifacts.',
     'Treat `skills/` as bundled tooling, not as a scratch/output directory. Use it to read or run shipped helpers, but write new task files to workspace `scripts/` or the workspace root.',
+    'For final user-visible deliverables such as PDFs, images, documents, slides, spreadsheets, or reports, write the final file to a workspace-relative path, not `/tmp`, unless the user explicitly asks for a temporary-only location.',
     'After file changes, run commands only when asked; otherwise explicitly offer to run them immediately.',
     'Only skip file creation when the user explicitly asks for snippet-only or explanation-only output.',
     'Never write plain text placeholder content to binary office files such as `.docx`, `.xlsx`, `.pptx`, or `.pdf`. If generation fails, report the error instead of creating a fake file.',

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -61,6 +61,7 @@ import type {
 } from '../types/execution.js';
 import type { ScheduledTaskInput } from '../types/scheduler.js';
 import type { AdditionalMount } from '../types/security.js';
+import { ensureWorkspaceNodeModulesLink } from '../workspace.js';
 import {
   agentWorkspaceDir,
   cleanupIpc,
@@ -121,6 +122,7 @@ const TOOL_RESULT_RE =
 const TOOL_START_RE = /^\[tool\]\s+([a-zA-Z0-9_.-]+):\s*(.*)$/;
 const APPROVAL_RE = /^\[approval\]\s+([A-Za-z0-9+/=]+)$/;
 const CONTAINER_WORKSPACE_ROOT = '/workspace';
+const CONTAINER_APP_NODE_MODULES = '/app/node_modules';
 const CONTAINER_DISCORD_MEDIA_CACHE_ROOT = '/discord-media-cache';
 const CONTAINER_UPLOADED_MEDIA_CACHE_ROOT = '/uploaded-media-cache';
 const AGENT_OUTPUT_TIMEOUT_PREFIX = 'Timeout waiting for agent output after ';
@@ -483,6 +485,11 @@ function getOrSpawnContainer(
     sessionId,
     agentId,
     workspacePathOverride: params.workspacePathOverride,
+  });
+  fs.mkdirSync(workspacePath, { recursive: true });
+  ensureWorkspaceNodeModulesLink(workspacePath, CONTAINER_APP_NODE_MODULES, {
+    allowMissingSource: true,
+    replaceExistingSymlink: true,
   });
   const mediaCacheHostPath = resolveDiscordMediaCacheHostDir();
   fs.mkdirSync(mediaCacheHostPath, { recursive: true });

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -82,7 +82,7 @@ export interface ResetWorkspaceResult {
   removed: boolean;
 }
 
-interface WorkspaceNodeModulesLinkOptions {
+export interface WorkspaceNodeModulesLinkOptions {
   allowMissingSource?: boolean;
   replaceExistingSymlink?: boolean;
 }

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -82,6 +82,11 @@ export interface ResetWorkspaceResult {
   removed: boolean;
 }
 
+interface WorkspaceNodeModulesLinkOptions {
+  allowMissingSource?: boolean;
+  replaceExistingSymlink?: boolean;
+}
+
 interface WorkspaceOnboardingState {
   version: typeof WORKSPACE_STATE_VERSION;
   bootstrapSeededAt?: string;
@@ -327,24 +332,40 @@ function looksLikeCompletedWorkspace(
  * `/app/node_modules`.
  *
  * Only creates the symlink when nothing exists at the destination; a
- * pre-existing `node_modules` (real dir or user-installed symlink) is left
- * untouched so user-installed deps aren't clobbered. When the source
- * `/app/node_modules` doesn't exist (e.g. outside the container) this is a
- * silent no-op.
+ * pre-existing `node_modules` directory is left untouched so user-installed
+ * deps aren't clobbered. Callers can opt into replacing an existing symlink
+ * when they need to repair a stale runtime link before launching Docker.
+ *
+ * When the source `/app/node_modules` doesn't exist (e.g. outside the
+ * container) this is normally a silent no-op. Docker launch paths can opt into
+ * creating the symlink anyway so the bind-mounted workspace is already correct
+ * when the container starts.
  *
  * Exported for tests.
  */
 export function ensureWorkspaceNodeModulesLink(
   wsDir: string,
   source: string = CONTAINER_APP_NODE_MODULES,
+  options: WorkspaceNodeModulesLinkOptions = {},
 ): void {
   const target = path.join(wsDir, 'node_modules');
+  const resolvedSource = path.resolve(source);
+  let replaceExistingSymlink = false;
 
   // `lstat` so we detect a broken symlink at `target` too.
   try {
-    fs.lstatSync(target);
-    // Something already exists — leave it alone.
-    return;
+    const stat = fs.lstatSync(target);
+    if (!stat.isSymbolicLink()) {
+      // A real directory/file already exists — leave it alone.
+      return;
+    }
+
+    if (!options.replaceExistingSymlink) return;
+
+    const existingTarget = fs.readlinkSync(target);
+    const resolvedExisting = path.resolve(path.dirname(target), existingTarget);
+    if (resolvedExisting === resolvedSource) return;
+    replaceExistingSymlink = true;
   } catch (error) {
     const err = error as NodeJS.ErrnoException;
     if (err?.code !== 'ENOENT') {
@@ -356,11 +377,14 @@ export function ensureWorkspaceNodeModulesLink(
     }
   }
 
-  // Only create the link if the source actually exists. Outside the
-  // container (host dev machines, tests) `/app/node_modules` is absent.
-  if (!fs.existsSync(source)) return;
+  // Only create the link if the source actually exists unless the caller is
+  // deliberately staging a dangling container-path symlink before `docker run`.
+  if (!fs.existsSync(source) && !options.allowMissingSource) return;
 
   try {
+    if (replaceExistingSymlink) {
+      fs.rmSync(target, { recursive: true, force: true });
+    }
     fs.symlinkSync(source, target, 'dir');
     logger.debug(
       { wsDir, source, target },

--- a/tests/container-runner.redaction.test.ts
+++ b/tests/container-runner.redaction.test.ts
@@ -339,6 +339,104 @@ test('ContainerExecutor stops and respawns a timed out pooled container', async 
   expect(stopCalls).toHaveLength(1);
 });
 
+test('ContainerExecutor stages the container node_modules symlink before docker launch', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+
+  const spawn = vi.fn(() => makeFakeChildProcess() as never);
+  const readOutput = vi.fn(async () => ({
+    status: 'success' as const,
+    result: 'ok',
+    toolsUsed: [],
+    artifacts: [],
+  }));
+  const resolveModelRuntimeCredentials = vi.fn(async () => ({
+    provider: 'hybridai' as const,
+    apiKey: '',
+    baseUrl: 'https://hybridai.one',
+    chatbotId: 'bot-a',
+    enableRag: false,
+    requestHeaders: {},
+    agentId: 'default',
+    isLocal: false,
+    contextWindow: 128_000,
+    thinkingFormat: undefined,
+  }));
+
+  vi.doMock('node:child_process', async () => {
+    const actual =
+      await vi.importActual<typeof import('node:child_process')>(
+        'node:child_process',
+      );
+    return {
+      ...actual,
+      spawn,
+    };
+  });
+  vi.doMock('../src/infra/ipc.js', async () => {
+    const actual = await vi.importActual<typeof import('../src/infra/ipc.js')>(
+      '../src/infra/ipc.js',
+    );
+    return {
+      ...actual,
+      readOutput,
+    };
+  });
+  vi.doMock('../src/providers/factory.js', async () => {
+    const actual = await vi.importActual<
+      typeof import('../src/providers/factory.js')
+    >('../src/providers/factory.js');
+    return {
+      ...actual,
+      resolveModelRuntimeCredentials,
+    };
+  });
+  vi.doMock('../src/logger.js', () => ({
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  }));
+
+  const { getSessionPaths } = await import('../src/infra/ipc.js');
+  const { workspacePath } = getSessionPaths('session-node-link', 'default');
+  fs.mkdirSync(workspacePath, { recursive: true });
+  fs.symlinkSync(
+    '/Users/example/project/node_modules',
+    path.join(workspacePath, 'node_modules'),
+    'dir',
+  );
+
+  const { ContainerExecutor } = await import(
+    '../src/infra/container-runner.js'
+  );
+  const executor = new ContainerExecutor();
+
+  await executor.exec({
+    sessionId: 'session-node-link',
+    messages: [{ role: 'user', content: 'hello' }],
+    chatbotId: 'bot-a',
+    enableRag: false,
+    model: 'gpt-5',
+    agentId: 'default',
+    channelId: 'tui',
+  });
+
+  expect(fs.readlinkSync(path.join(workspacePath, 'node_modules'))).toBe(
+    '/app/node_modules',
+  );
+  expect(
+    spawn.mock.calls.some(
+      (call) =>
+        Array.isArray(call[1]) &&
+        call[1].includes(`${workspacePath}:/workspace:rw`),
+    ),
+  ).toBe(true);
+});
+
 test('ContainerExecutor disables internal text streaming when no text callback is provided', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;

--- a/tests/prompt-hooks.tool-summary.test.ts
+++ b/tests/prompt-hooks.tool-summary.test.ts
@@ -148,6 +148,9 @@ test('buildSystemPromptFromHooks adds mandatory routing instructions for availab
     'For deliverable-generation tasks such as presentations, slide decks, spreadsheets, documents, PDFs, reports, or images, assume the created asset should be attached in the final reply unless the user explicitly says not to send the file.',
   );
   expect(prompt).toContain(
+    'For final user-visible deliverables such as PDFs, images, documents, slides, spreadsheets, or reports, write the final file to a workspace-relative path, not `/tmp`, unless the user explicitly asks for a temporary-only location.',
+  );
+  expect(prompt).toContain(
     'If you created or updated the requested deliverable successfully, prefer posting the asset immediately over replying with a path plus "if you want, I can upload it."',
   );
   expect(prompt).toContain(

--- a/tests/workspace-bootstrap.test.ts
+++ b/tests/workspace-bootstrap.test.ts
@@ -327,6 +327,48 @@ describe('workspace bootstrap lifecycle', () => {
     expect(fs.existsSync(path.join(wsDir, 'node_modules'))).toBe(false);
   });
 
+  test('can stage a dangling container node_modules symlink before docker launch', async () => {
+    const homeDir = makeTempDir('hybridclaw-home-');
+    const unrelatedCwd = makeTempDir('hybridclaw-cwd-');
+    vi.stubEnv('HOME', homeDir);
+    process.chdir(unrelatedCwd);
+
+    const workspace = await import('../src/workspace.js');
+
+    const wsDir = makeTempDir('hybridclaw-ws-');
+
+    workspace.ensureWorkspaceNodeModulesLink(wsDir, '/app/node_modules', {
+      allowMissingSource: true,
+    });
+
+    const linkPath = path.join(wsDir, 'node_modules');
+    const stat = fs.lstatSync(linkPath);
+    expect(stat.isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(linkPath)).toBe('/app/node_modules');
+  });
+
+  test('can replace a stale workspace node_modules symlink before docker launch', async () => {
+    const homeDir = makeTempDir('hybridclaw-home-');
+    const unrelatedCwd = makeTempDir('hybridclaw-cwd-');
+    vi.stubEnv('HOME', homeDir);
+    process.chdir(unrelatedCwd);
+
+    const workspace = await import('../src/workspace.js');
+
+    const wsDir = makeTempDir('hybridclaw-ws-');
+    const linkPath = path.join(wsDir, 'node_modules');
+    fs.symlinkSync('/Users/example/project/node_modules', linkPath, 'dir');
+
+    workspace.ensureWorkspaceNodeModulesLink(wsDir, '/app/node_modules', {
+      allowMissingSource: true,
+      replaceExistingSymlink: true,
+    });
+
+    const stat = fs.lstatSync(linkPath);
+    expect(stat.isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(linkPath)).toBe('/app/node_modules');
+  });
+
   test('keeps a package-provided custom BOOTSTRAP.md on fresh install', async () => {
     const homeDir = makeTempDir('hybridclaw-home-');
     const unrelatedCwd = makeTempDir('hybridclaw-cwd-');


### PR DESCRIPTION
## Summary
- repair Docker workspace bootstrapping before container launch so /workspace/node_modules always points at /app/node_modules
- update prompt and tool guidance so final user-visible deliverables are written to workspace-relative paths instead of /tmp
- add regression coverage for stale node_modules symlinks and the new workspace-output guidance

## Validation
- npm run lint
- ./node_modules/.bin/vitest run tests/prompt-hooks.tool-summary.test.ts tests/workspace-bootstrap.test.ts tests/container-runner.redaction.test.ts tests/pdf-skill-node.test.ts