### PR TITLE
[codex] silence agent image apt frontend warnings

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -19,7 +19,7 @@ LABEL org.opencontainers.image.version="${HYBRIDCLAW_VERSION}"
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ripgrep git curl python3 python3-pip poppler-utils qpdf pandoc
 
 RUN --mount=type=cache,target=/root/.cache/pip \
@@ -48,7 +48,7 @@ RUN --mount=type=cache,target=/root/.npm \
     npm ci --omit=dev
 
 # System deps need root; browser installed as node user so /ms-playwright stays owned by node:node
-RUN npx playwright install-deps chromium \
+RUN DEBIAN_FRONTEND=noninteractive npx playwright install-deps chromium \
     && mkdir -p /ms-playwright \
     && chown -R node:node /app /ms-playwright
 USER node
@@ -67,6 +67,6 @@ FROM runtime-lite AS runtime
 USER root
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     libreoffice-calc libreoffice-impress libreoffice-writer
 USER node


### PR DESCRIPTION
## What changed
- set `DEBIAN_FRONTEND=noninteractive` for the agent image apt install layers in `container/Dockerfile`
- set the same environment for `playwright install-deps chromium`, which shells out to apt during the image build

## Why
Release and snapshot container builds were emitting repeated `debconf` frontend fallback warnings while installing LibreOffice and Playwright system packages in non-interactive CI runners. The installs were succeeding, but the logs were noisy and made the real build output harder to read.

## Impact
- container builds keep the same package set and behavior
- GitHub Actions logs for the agent image are quieter and easier to inspect
- remaining LibreOffice `Creating config file ...` lines are expected package-install output

## Root cause
The Dockerfile apt-based install steps, and Playwright's dependency installer, were running on headless CI runners without an explicit non-interactive debconf frontend.

## Validation
- `docker build -f container/Dockerfile --target runtime ./container`
- confirmed the runtime image still builds successfully after the Dockerfile changes
