### PR TITLE
refactor(chat): adopt shared Button in message actions and approvals

### DIFF
--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -364,25 +364,11 @@
 }
 
 .actionButton {
-  display: flex;
-  align-items: center;
-  justify-content: center;
   width: 28px;
   height: 28px;
-  border: none;
+  min-height: unset;
   border-radius: 999px;
-  background: transparent;
-  color: var(--muted-foreground);
-  cursor: pointer;
   font-size: 0.82rem;
-  transition:
-    background 0.12s,
-    color 0.12s;
-}
-
-.actionButton:hover {
-  background: var(--muted);
-  color: var(--text);
 }
 
 .actionButtonSuccess {
@@ -399,27 +385,11 @@
 }
 
 .branchButton {
-  display: flex;
-  align-items: center;
-  justify-content: center;
   width: 22px;
   height: 22px;
-  border: none;
+  min-height: unset;
   border-radius: 999px;
-  background: transparent;
-  color: var(--muted-foreground);
-  cursor: pointer;
   font-size: 0.8rem;
-}
-
-.branchButton:hover {
-  background: var(--muted);
-  color: var(--text);
-}
-
-.branchButton:disabled {
-  opacity: 0.4;
-  cursor: default;
 }
 
 .approvalActions {
@@ -430,39 +400,9 @@
 }
 
 .approvalAllow {
-  padding: 6px 12px;
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--success-border);
+  border-color: var(--success-border);
   background: var(--success-soft);
   color: var(--success);
-  cursor: pointer;
-  font-size: 0.82rem;
-  font-weight: 500;
-}
-
-.approvalAllow:hover {
-  opacity: 0.85;
-}
-
-.approvalDeny {
-  padding: 6px 12px;
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--danger-border);
-  background: var(--danger-soft);
-  color: var(--danger);
-  cursor: pointer;
-  font-size: 0.82rem;
-  font-weight: 500;
-}
-
-.approvalDeny:hover {
-  opacity: 0.85;
-}
-
-.approvalAllow:disabled,
-.approvalDeny:disabled {
-  opacity: 0.5;
-  cursor: default;
 }
 
 .artifactCard {

--- a/console/src/routes/chat/message-block.tsx
+++ b/console/src/routes/chat/message-block.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react';
 import { fetchArtifactBlob } from '../../api/chat';
 import type { ChatArtifact, ChatMessage } from '../../api/chat-types';
+import { Button } from '../../components/button';
 import type { ApprovalAction } from '../../lib/chat-helpers';
 import { cx } from '../../lib/cx';
 import { renderMarkdown } from '../../lib/markdown';
@@ -291,9 +292,10 @@ export const MessageBlock = memo(function MessageBlock(props: {
         {isApproval && msg.pendingApproval ? (
           <div className={css.approvalActions}>
             {APPROVAL_BUTTONS.map((btn) => (
-              <button
+              <Button
                 key={btn.action}
-                type="button"
+                variant="outline"
+                size="sm"
                 className={css.approvalAllow}
                 disabled={props.approvalBusy}
                 onClick={() =>
@@ -304,11 +306,11 @@ export const MessageBlock = memo(function MessageBlock(props: {
                 }
               >
                 {btn.label}
-              </button>
+              </Button>
             ))}
-            <button
-              type="button"
-              className={css.approvalDeny}
+            <Button
+              variant="danger"
+              size="sm"
               disabled={props.approvalBusy}
               onClick={() =>
                 props.onApprovalAction(
@@ -318,7 +320,7 @@ export const MessageBlock = memo(function MessageBlock(props: {
               }
             >
               Deny
-            </button>
+            </Button>
           </div>
         ) : null}
       </div>
@@ -329,55 +331,60 @@ export const MessageBlock = memo(function MessageBlock(props: {
 
       {!props.isStreaming ? (
         <div className={css.messageActions}>
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="icon"
             className={cx(css.actionButton, copied && css.actionButtonSuccess)}
             title="Copy"
             onClick={handleCopy}
           >
             {copied ? '✓' : '⧉'}
-          </button>
+          </Button>
           {isUser ? (
-            <button
-              type="button"
+            <Button
+              variant="ghost"
+              size="icon"
               className={css.actionButton}
               title="Edit"
               onClick={() => props.onEdit(msg)}
             >
               ✎
-            </button>
+            </Button>
           ) : null}
           {isAssistant && msg.replayRequest ? (
-            <button
-              type="button"
+            <Button
+              variant="ghost"
+              size="icon"
               className={css.actionButton}
               title="Regenerate"
               onClick={() => props.onRegenerate(msg)}
             >
               ↻
-            </button>
+            </Button>
           ) : null}
           {props.branchInfo && props.branchInfo.total > 1 ? (
             <div className={css.branchSwitcher}>
-              <button
-                type="button"
+              <Button
+                variant="ghost"
+                size="icon"
                 className={css.branchButton}
                 disabled={props.branchInfo.current <= 1}
                 onClick={() => props.onBranchNav(-1)}
               >
                 ‹
-              </button>
+              </Button>
               <span>
                 {props.branchInfo.current}/{props.branchInfo.total}
               </span>
-              <button
-                type="button"
+              <Button
+                variant="ghost"
+                size="icon"
                 className={css.branchButton}
                 disabled={props.branchInfo.current >= props.branchInfo.total}
                 onClick={() => props.onBranchNav(1)}
               >
                 ›
-              </button>
+              </Button>
             </div>
           ) : null}
         </div>
@@ -402,17 +409,15 @@ export function EditInline(props: {
         autoFocus
       />
       <div className={css.editButtons}>
-        <button
-          type="button"
-          className="primary-button"
+        <Button
           onClick={() => props.onSave(value.trim())}
           disabled={!value.trim()}
         >
           Save
-        </button>
-        <button type="button" className="ghost-button" onClick={props.onCancel}>
+        </Button>
+        <Button variant="ghost" onClick={props.onCancel}>
           Cancel
-        </button>
+        </Button>
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
Extracted from #323 as PR E1. Stacked on #358 (base branch: \`extract-shared-button-icons\`) because it consumes the shared \`<Button>\` component.

- Replaces raw \`<button>\` elements in \`MessageBlock\` / \`EditInline\` with \`<Button>\` (variant + size props)
- Drops CSS that Button now owns: default border/background/cursor/hover for action/branch/approval buttons
- \`.approvalDeny\` removed entirely — Deny uses \`variant=\"danger\"\` directly

Mapping:
- Message actions (copy/edit/regenerate) → \`variant=\"ghost\" size=\"icon\"\`
- Branch nav → \`variant=\"ghost\" size=\"icon\"\`
- Approval Allow* → \`variant=\"outline\" size=\"sm\"\` + color-only override via \`.approvalAllow\`
- Approval Deny → \`variant=\"danger\" size=\"sm\"\`
- Edit Save → default \`<Button>\`, Cancel → \`variant=\"ghost\"\`

This PR does **not** add aria-labels — those are in #359 (chat a11y) so they merge cleanly without overlap.

## Review order
Merge #358 first, then retarget this PR to \`main\`. Opening as draft until that happens.

## Test plan
- [x] \`vitest run\` — 205/205 console tests pass
- [x] \`tsc --noEmit\` clean
- [ ] Load a chat session, hover a message — copy/edit/regenerate buttons render with correct ghost styling
- [ ] Approval dialog — Allow row buttons are green outline; Deny is red
- [ ] Edit a message — Save/Cancel render with default/ghost variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)