### PR TITLE
[codex] improve eval workflows and gateway reload UX

### DIFF
--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -196,13 +196,16 @@ export function fetchOverview(token: string): Promise<AdminOverview> {
   return requestJson<AdminOverview>('/api/admin/overview', { token });
 }
 
-export function restartGateway(
+export function reloadGateway(
   token: string,
 ): Promise<{ status: 'ok'; message: string }> {
-  return requestJson<{ status: 'ok'; message: string }>('/api/admin/restart', {
-    token,
-    method: 'POST',
-  });
+  return requestJson<{ status: 'ok'; message: string }>(
+    '/api/admin/config/reload',
+    {
+      token,
+      method: 'POST',
+    },
+  );
 }
 
 export function startAdminTerminal(

--- a/console/src/routes/gateway.test.tsx
+++ b/console/src/routes/gateway.test.tsx
@@ -1,23 +1,38 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ToastProvider } from '../components/toast';
 
 import { GatewayPage } from './gateway';
 
-const restartGatewayMock = vi.fn();
-const validateTokenMock = vi.fn();
+const reloadGatewayMock = vi.fn();
+const navigateMock = vi.fn();
 const useAuthMock = vi.fn();
 const useLiveEventsMock = vi.fn();
 
 vi.mock('../api/client', () => ({
-  restartGateway: (...args: unknown[]) => restartGatewayMock(...args),
-  validateToken: (...args: unknown[]) => validateTokenMock(...args),
+  reloadGateway: (...args: unknown[]) => reloadGatewayMock(...args),
 }));
 
 vi.mock('../auth', () => ({
   useAuth: () => useAuthMock(),
 }));
+
+vi.mock('@tanstack/react-router', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-router')>(
+    '@tanstack/react-router',
+  );
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
 
 vi.mock('../hooks/use-live-events', () => ({
   useLiveEvents: (...args: unknown[]) => useLiveEventsMock(...args),
@@ -86,15 +101,10 @@ function renderGatewayPage(): void {
   );
 }
 
-async function flushMicrotasks(): Promise<void> {
-  await Promise.resolve();
-  await Promise.resolve();
-}
-
 describe('GatewayPage', () => {
   beforeEach(() => {
-    restartGatewayMock.mockReset();
-    validateTokenMock.mockReset();
+    reloadGatewayMock.mockReset();
+    navigateMock.mockReset();
     useAuthMock.mockReset();
     useLiveEventsMock.mockReset();
 
@@ -111,69 +121,22 @@ describe('GatewayPage', () => {
   });
 
   afterEach(() => {
-    vi.useRealTimers();
     vi.clearAllMocks();
   });
 
-  it('disables restart when the gateway lifecycle does not support it', () => {
-    useAuthMock.mockReturnValue({
-      token: 'test-token',
-      gatewayStatus: makeStatus({
-        lifecycle: {
-          restartSupported: false,
-          restartReason: 'Gateway restart is unavailable in this launch mode.',
-        },
-      }),
-    });
-
-    renderGatewayPage();
-
-    const button = screen.getByRole('button', {
-      name: 'Restart Gateway',
-    }) as HTMLButtonElement;
-    expect(button.disabled).toBe(true);
-    expect(button.className).toContain('danger-button');
-    expect(
-      screen.queryByText('Gateway restart is unavailable in this launch mode.'),
-    ).not.toBeNull();
-  });
-
-  it('shows a restarting spinner until the status poll succeeds', async () => {
-    vi.useFakeTimers();
-    restartGatewayMock.mockResolvedValue({
+  it('opens a reload confirmation dialog and calls the reload endpoint', async () => {
+    reloadGatewayMock.mockResolvedValue({
       status: 'ok',
-      message: 'Gateway restart requested.',
+      message: 'Gateway reloaded.',
     });
-    validateTokenMock.mockResolvedValue(
-      makeStatus({
-        pid: 5678,
-        timestamp: '2026-04-09T12:05:00.000Z',
-      }),
-    );
 
     renderGatewayPage();
-    fireEvent.click(screen.getByRole('button', { name: 'Restart Gateway' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Reload Gateway' }));
     const dialog = screen.getByRole('alertdialog');
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Restart' }));
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(0);
-      await flushMicrotasks();
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Reload' }));
+
+    await waitFor(() => {
+      expect(reloadGatewayMock).toHaveBeenCalledWith('test-token');
     });
-
-    expect(restartGatewayMock).toHaveBeenCalledWith('test-token');
-    expect(
-      screen.queryByRole('button', { name: 'Restarting Gateway' }),
-    ).not.toBeNull();
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1000);
-      await flushMicrotasks();
-    });
-
-    expect(validateTokenMock).toHaveBeenCalledWith('test-token');
-    expect(
-      screen.queryByRole('button', { name: 'Restart Gateway' }),
-    ).not.toBeNull();
-    vi.useRealTimers();
   });
 });

--- a/console/src/routes/gateway.tsx
+++ b/console/src/routes/gateway.tsx
@@ -1,7 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
-import { restartGateway, validateToken } from '../api/client';
+import { useState } from 'react';
+import { reloadGateway } from '../api/client';
 import { useAuth } from '../auth';
 import {
   Dialog,
@@ -19,67 +19,25 @@ import { useLiveEvents } from '../hooks/use-live-events';
 import { getErrorMessage } from '../lib/error-message';
 import { formatDateTime, formatUptime } from '../lib/format';
 
-const GATEWAY_RESTART_POLL_MS = 1000;
-
 export function GatewayPage() {
   const auth = useAuth();
   const toast = useToast();
   const live = useLiveEvents(auth.token);
-  const [polledStatus, setPolledStatus] =
-    useState<typeof auth.gatewayStatus>(null);
-  const [isRestarting, setIsRestarting] = useState(false);
-  const [restartConfirmOpen, setRestartConfirmOpen] = useState(false);
-  const status = live.status || polledStatus || auth.gatewayStatus;
+  const [reloadConfirmOpen, setReloadConfirmOpen] = useState(false);
+  const status = live.status || auth.gatewayStatus;
   const providerEntries = Object.entries(
     status?.providerHealth || status?.localBackends || {},
   );
   const schedulerJobs = status?.scheduler?.jobs || [];
-  const restartMutation = useMutation({
-    mutationFn: () => restartGateway(auth.token),
-    onMutate: () => {
-      setIsRestarting(false);
-      setPolledStatus(null);
-    },
+  const reloadMutation = useMutation({
+    mutationFn: () => reloadGateway(auth.token),
     onSuccess: () => {
-      setIsRestarting(true);
+      toast.success('Gateway reloaded.');
     },
     onError: (error) => {
-      toast.error('Gateway restart failed', getErrorMessage(error));
+      toast.error('Gateway reload failed', getErrorMessage(error));
     },
   });
-
-  useEffect(() => {
-    if (!isRestarting) return;
-
-    let cancelled = false;
-    let timeoutId: number | null = null;
-
-    const schedulePoll = () => {
-      timeoutId = window.setTimeout(() => {
-        void pollStatus();
-      }, GATEWAY_RESTART_POLL_MS);
-    };
-
-    const pollStatus = async () => {
-      try {
-        const nextStatus = await validateToken(auth.token);
-        if (cancelled) return;
-        setPolledStatus(nextStatus);
-        setIsRestarting(false);
-      } catch {
-        if (cancelled) return;
-        schedulePoll();
-      }
-    };
-
-    schedulePoll();
-    return () => {
-      cancelled = true;
-      if (timeoutId !== null) {
-        window.clearTimeout(timeoutId);
-      }
-    };
-  }, [auth.token, isRestarting]);
 
   const navigate = useNavigate();
 
@@ -87,11 +45,7 @@ export function GatewayPage() {
     return <div className="empty-state">Gateway status is unavailable.</div>;
   }
 
-  const restartSupported = Boolean(status.lifecycle?.restartSupported);
-  const restartBusy = restartMutation.isPending || isRestarting;
-  const restartReason =
-    status.lifecycle?.restartReason ||
-    'Gateway restart is unavailable in the current launch mode.';
+  const reloadBusy = reloadMutation.isPending;
   const sandboxWarning =
     status.sandbox?.mode === 'host' ? null : status.sandbox?.warning || null;
   return (
@@ -110,29 +64,23 @@ export function GatewayPage() {
             </div>
             <button
               type="button"
-              className="danger-button"
-              disabled={!restartSupported || restartBusy}
-              onClick={() => setRestartConfirmOpen(true)}
-              title={
-                !restartSupported && !restartBusy ? restartReason : undefined
-              }
-              aria-busy={restartBusy}
+              className="primary-button"
+              disabled={reloadBusy}
+              onClick={() => setReloadConfirmOpen(true)}
+              aria-busy={reloadBusy}
             >
-              {restartBusy ? (
+              {reloadBusy ? (
                 <span className="button-with-spinner">
                   <span aria-hidden="true" className="button-spinner" />
-                  Restarting Gateway
+                  Reloading Gateway
                 </span>
               ) : (
-                'Restart Gateway'
+                'Reload Gateway'
               )}
             </button>
           </div>
         }
       />
-      {!restartSupported ? (
-        <p className="supporting-text">{restartReason}</p>
-      ) : null}
       <div className="metric-grid">
         <MetricCard label="Uptime" value={formatUptime(status.uptime)} />
         <MetricCard label="Sessions" value={String(status.sessions)} />
@@ -259,22 +207,22 @@ export function GatewayPage() {
           )}
         </Panel>
       </div>
-      <Dialog open={restartConfirmOpen} onOpenChange={setRestartConfirmOpen}>
+      <Dialog open={reloadConfirmOpen} onOpenChange={setReloadConfirmOpen}>
         <DialogContent size="sm" role="alertdialog">
           <DialogHeader>
-            <DialogTitle>Restart Gateway?</DialogTitle>
+            <DialogTitle>Reload Gateway?</DialogTitle>
             <DialogDescription>
-              This will interrupt all active sessions. The gateway will be
-              unavailable for a few seconds.
+              This reloads runtime config and refreshes secrets without
+              restarting the workspace container.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
             <DialogClose className="ghost-button">Cancel</DialogClose>
             <DialogClose
-              className="danger-button"
-              onClick={() => restartMutation.mutate()}
+              className="primary-button"
+              onClick={() => reloadMutation.mutate()}
             >
-              Restart
+              Reload
             </DialogClose>
           </DialogFooter>
         </DialogContent>

--- a/docs/content/reference/commands.md
+++ b/docs/content/reference/commands.md
@@ -108,10 +108,12 @@ hybridclaw eval --fresh-agent --omit-prompt=bootstrap inspect eval inspect_evals
   without calling the model, and `run` (default `--live`, `--max 3`) posts
   each prompt to the local OpenAI endpoint and grades the tool trace with
   the same `resolveObservedSkillName` oracle the gateway uses
-- filter `hybridai-skills` runs with `--skill <name>`, `--mode
-  implicit|explicit`, `--kind try-it|conversation`, and `--max N`; results
+- filter `hybridai-skills` runs with `--skill <name>`, `--kind
+  try-it|conversation`, and `--max N`; results
   land at `~/.hybridclaw/data/evals/hybridai-skills/latest-run.json` and
   are also shown via `/eval hybridai-skills results`
+- for `hybridai-skills run`, `--explicit` rewrites each prompt to start with
+  `/<skill>` to force invocation
 - `locomo --mode qa` runs a native HybridClaw QA harness against the official
   LoCoMo conversations, generates answers through the local OpenAI-compatible
   gateway, and scores those answers with LoCoMo-style question metrics

--- a/docs/development/reference/commands.md
+++ b/docs/development/reference/commands.md
@@ -108,10 +108,12 @@ hybridclaw eval --fresh-agent --omit-prompt=bootstrap inspect eval inspect_evals
   without calling the model, and `run` (default `--live`, `--max 3`) posts
   each prompt to the local OpenAI endpoint and grades the tool trace with
   the same `resolveObservedSkillName` oracle the gateway uses
-- filter `hybridai-skills` runs with `--skill <name>`, `--mode
-  implicit|explicit`, `--kind try-it|conversation`, and `--max N`; results
+- filter `hybridai-skills` runs with `--skill <name>`, `--kind
+  try-it|conversation`, and `--max N`; results
   land at `~/.hybridclaw/data/evals/hybridai-skills/latest-run.json` and
   are also shown via `/eval hybridai-skills results`
+- for `hybridai-skills run`, `--explicit` rewrites each prompt to start with
+  `/<skill>` to force invocation
 - `locomo --mode qa` runs a native HybridClaw QA harness against the official
   LoCoMo conversations, generates answers through the local OpenAI-compatible
   gateway, and scores those answers with LoCoMo-style question metrics

--- a/src/evals/eval-command.ts
+++ b/src/evals/eval-command.ts
@@ -16,6 +16,7 @@ import { normalizeMemoryRecallBackend } from '../memory/semantic-recall.js';
 import {
   buildDefaultEvalProfile,
   describeEvalProfile,
+  EVAL_MODEL_PROFILE_MARKER,
   type EvalProfile,
   encodeEvalProfileModel,
   isKnownEvalPromptPart,
@@ -421,10 +422,13 @@ function buildEvalEnvironment(params: {
 }): EvalEnvironment {
   const token = params.webApiToken.trim();
   const baseModel = params.effectiveModel.trim() || 'hybridai/gpt-4.1-mini';
+  const profiledModel = encodeEvalProfileModel(baseModel, params.profile);
   return {
     baseUrl: buildOpenAIBaseUrl(params.gatewayBaseUrl),
     apiKey: token || 'hybridclaw-local',
-    model: encodeEvalProfileModel(baseModel, params.profile),
+    model: profiledModel.includes(EVAL_MODEL_PROFILE_MARKER)
+      ? profiledModel
+      : `${profiledModel}${EVAL_MODEL_PROFILE_MARKER}current-agent`,
     baseModel,
     authMode: token ? 'web-token' : 'loopback',
     profile: params.profile,

--- a/src/evals/hybridai-skills-command.ts
+++ b/src/evals/hybridai-skills-command.ts
@@ -3,10 +3,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { GatewayCommandResult } from '../gateway/gateway-types.js';
 import { resolveInstallPath } from '../infra/install-root.js';
+import { agentWorkspaceDir } from '../infra/ipc.js';
 import { logger } from '../logger.js';
+import { deleteSessionData, isDatabaseInitialized } from '../memory/db.js';
+import { parseSessionKey } from '../session/session-key.js';
 import { resolveObservedSkillName, type Skill } from '../skills/skills.js';
 import type { ToolExecution } from '../types/execution.js';
-import { resetWorkspace } from '../workspace.js';
 import {
   joinSections,
   renderKeyValueSection,
@@ -45,6 +47,7 @@ interface FixtureGradeResult {
   fixture: HybridaiSkillFixture;
   status: 'passed' | 'failed' | 'skipped';
   observedSkill: string | null;
+  artifactsObserved?: boolean;
   toolNames: string[];
   sessionId?: string;
   auditPath?: string;
@@ -83,7 +86,6 @@ interface HybridaiSkillsRunSummary {
   failed?: number;
   skipped?: number;
   filterSkill?: string;
-  filterMode?: HybridaiSkillFixtureMode;
   maxFixtures?: number;
   forceExplicit?: boolean;
   results?: FixtureGradeResult[];
@@ -664,7 +666,6 @@ async function handleRun(params: {
     failed: totals.failed,
     skipped: totals.skipped,
     filterSkill: parsed.skill,
-    filterMode: parsed.mode,
     maxFixtures: parsed.max,
     forceExplicit: parsed.forceExplicit ? true : undefined,
     results: runs[0]?.results ?? [],
@@ -698,7 +699,6 @@ interface ParsedRunFlags {
   dryRun: boolean;
   max?: number;
   skill?: string;
-  mode?: HybridaiSkillFixtureMode;
   kind?: HybridaiSkillFixtureKind;
   forceExplicit?: boolean;
   models: string[];
@@ -764,18 +764,6 @@ function parseRunFlags(args: string[]): ParsedRunFlags {
           return { ...parsed, error: 'Expected a skill name after --skill.' };
         }
         parsed.skill = skill;
-        if (inlineValue === undefined) index += 1;
-        break;
-      }
-      case '--mode': {
-        const mode = String(value).trim().toLowerCase();
-        if (mode !== 'implicit' && mode !== 'explicit') {
-          return {
-            ...parsed,
-            error: 'Invalid --mode (expected `implicit` or `explicit`).',
-          };
-        }
-        parsed.mode = mode;
         if (inlineValue === undefined) index += 1;
         break;
       }
@@ -871,7 +859,6 @@ function filterFixtures(
 ): HybridaiSkillFixture[] {
   return fixtures.filter((fixture) => {
     if (filters.skill && fixture.skill !== filters.skill) return false;
-    if (filters.mode && fixture.mode !== filters.mode) return false;
     if (filters.kind && fixture.kind !== filters.kind) return false;
     return true;
   });
@@ -916,6 +903,7 @@ function evaluateFixtureStatic(
       fixture,
       status: 'failed',
       observedSkill: null,
+      artifactsObserved: false,
       toolNames: [],
       reason: `Expected skill \`${fixture.skill}\` is not installed.`,
       durationMs: 0,
@@ -926,6 +914,7 @@ function evaluateFixtureStatic(
       fixture,
       status: 'passed',
       observedSkill: fixture.skill,
+      artifactsObserved: false,
       toolNames: [],
       reason:
         'explicit prompt references the skill; live run required to verify execution',
@@ -936,6 +925,7 @@ function evaluateFixtureStatic(
     fixture,
     status: 'skipped',
     observedSkill: null,
+    artifactsObserved: false,
     toolNames: [],
     reason: 'dry-run cannot verify implicit skill selection; use --live',
     durationMs: 0,
@@ -952,6 +942,10 @@ interface HybridaiSkillsLiveRunEnvironment {
 interface ExecutedLiveTurn {
   durationMs: number;
   parsed: ParsedChatCompletion;
+  artifactsObserved: boolean;
+  agentId?: string;
+  sessionKey?: string;
+  executionSessionId?: string;
   sessionId?: string;
   auditPath?: string;
   auditTrace: ParsedAuditTrace | null;
@@ -990,6 +984,8 @@ async function runFixtureGroupLive(
       };
   const messages: Array<{ role: 'user' | 'assistant'; content: string }> = [];
   const results: FixtureGradeResult[] = [];
+  const cleanupSessionIdentifiers: string[] = [];
+  let cleanupAgentId = tempAgentId;
 
   try {
     for (const fixture of fixtures) {
@@ -1003,6 +999,10 @@ async function runFixtureGroupLive(
         skills,
         dataDir,
       );
+      cleanupAgentId ||= resolveEvalCleanupAgentId(executed);
+      cleanupSessionIdentifiers.push(
+        ...collectEvalCleanupSessionIdentifiers(executed),
+      );
       results.push(gradeExecutedFixture(fixture, executed, skills));
       messages.push({ role: 'user', content: prompt });
       if (executed.parsed.assistantText) {
@@ -1013,7 +1013,13 @@ async function runFixtureGroupLive(
       }
     }
   } finally {
-    if (tempAgentId) resetWorkspace(tempAgentId);
+    if (tempAgentId) {
+      cleanupTempEvalResources({
+        agentId: cleanupAgentId,
+        dataDir,
+        sessionIdentifiers: cleanupSessionIdentifiers,
+      });
+    }
   }
 
   return results;
@@ -1029,14 +1035,25 @@ async function runFixtureLive(
   const prompt = options.forceExplicit
     ? `/${fixture.skill} ${fixture.prompt}`
     : fixture.prompt;
-  const executed = await executeLiveTurn(
-    [{ role: 'user', content: prompt }],
-    env,
-    env.profile,
-    skills,
-    dataDir,
-  );
-  return gradeExecutedFixture(fixture, executed, skills);
+  let executed: ExecutedLiveTurn | null = null;
+  try {
+    executed = await executeLiveTurn(
+      [{ role: 'user', content: prompt }],
+      env,
+      env.profile,
+      skills,
+      dataDir,
+    );
+    return gradeExecutedFixture(fixture, executed, skills);
+  } finally {
+    if (env.profile.workspaceMode === 'fresh-agent') {
+      cleanupTempEvalResources({
+        agentId: resolveEvalCleanupAgentId(executed),
+        dataDir,
+        sessionIdentifiers: collectEvalCleanupSessionIdentifiers(executed),
+      });
+    }
+  }
 }
 
 async function executeLiveTurn(
@@ -1066,6 +1083,16 @@ async function executeLiveTurn(
     response.headers.get('x-hybridclaw-session-id') || undefined;
   const responseSessionKey =
     response.headers.get('x-hybridclaw-session-key') || undefined;
+  const responseAgentId =
+    response.headers.get('x-hybridclaw-agent-id') ||
+    parseSessionKey(responseSessionKey || responseSessionId || '')?.agentId ||
+    undefined;
+  const executionSessionId =
+    response.headers.get('x-hybridclaw-execution-session-id') || undefined;
+  const artifactsObserved =
+    parseArtifactCountHeader(
+      response.headers.get('x-hybridclaw-artifact-count'),
+    ) > 0;
   const resolvedAudit = resolveAuditTraceForSessionIdentifiers(
     dataDir,
     [responseSessionId, responseSessionKey],
@@ -1077,6 +1104,10 @@ async function executeLiveTurn(
     return {
       durationMs,
       parsed: { toolExecutions: [] },
+      artifactsObserved,
+      agentId: responseAgentId,
+      sessionKey: responseSessionKey,
+      executionSessionId,
       sessionId:
         resolvedAudit?.sessionId ?? responseSessionId ?? responseSessionKey,
       auditPath: resolvedAudit?.auditPath,
@@ -1090,6 +1121,10 @@ async function executeLiveTurn(
   return {
     durationMs,
     parsed: parseChatCompletion(payload),
+    artifactsObserved,
+    agentId: responseAgentId,
+    sessionKey: responseSessionKey,
+    executionSessionId,
     sessionId:
       resolvedAudit?.sessionId ?? responseSessionId ?? responseSessionKey,
     auditPath: resolvedAudit?.auditPath,
@@ -1108,6 +1143,7 @@ function gradeExecutedFixture(
       fixture,
       status: 'failed',
       observedSkill: null,
+      artifactsObserved: executed.artifactsObserved,
       toolNames: [],
       sessionId: executed.sessionId,
       auditPath: executed.auditPath,
@@ -1146,6 +1182,7 @@ function gradeExecutedFixture(
       fixture,
       status: 'passed',
       observedSkill,
+      artifactsObserved: executed.artifactsObserved,
       toolNames,
       sessionId: executed.sessionId,
       auditPath: executed.auditPath,
@@ -1158,6 +1195,7 @@ function gradeExecutedFixture(
     fixture,
     status: 'failed',
     observedSkill,
+    artifactsObserved: executed.artifactsObserved,
     toolNames,
     sessionId: executed.sessionId,
     auditPath: executed.auditPath,
@@ -1239,6 +1277,86 @@ async function safeReadText(response: Response): Promise<string> {
     return await response.text();
   } catch {
     return '';
+  }
+}
+
+function parseArtifactCountHeader(value: string | null): number {
+  const parsed = Number.parseInt(String(value || '').trim(), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+function isTempEvalAgentId(agentId: string | null | undefined): boolean {
+  const normalized = String(agentId || '').trim();
+  return normalized.startsWith('eval-') || normalized.startsWith('eval-conv-');
+}
+
+function resolveEvalCleanupAgentId(
+  executed: ExecutedLiveTurn | null,
+): string | null {
+  const agentId = String(executed?.agentId || '').trim();
+  if (isTempEvalAgentId(agentId)) return agentId;
+  const parsed = parseSessionKey(
+    String(executed?.sessionKey || executed?.sessionId || '').trim(),
+  );
+  return isTempEvalAgentId(parsed?.agentId) ? parsed?.agentId || null : null;
+}
+
+function collectEvalCleanupSessionIdentifiers(
+  executed: ExecutedLiveTurn | null,
+): string[] {
+  if (!executed) return [];
+  return [executed.sessionId, executed.sessionKey, executed.executionSessionId]
+    .map((value) => String(value || '').trim())
+    .filter(Boolean);
+}
+
+function cleanupTempEvalResources(params: {
+  agentId: string | null;
+  dataDir: string;
+  sessionIdentifiers: string[];
+}): void {
+  if (!params.agentId || !isTempEvalAgentId(params.agentId)) return;
+
+  for (const identifier of new Set(params.sessionIdentifiers)) {
+    if (isDatabaseInitialized()) {
+      try {
+        deleteSessionData(identifier);
+      } catch (error) {
+        logger.warn(
+          { sessionId: identifier, error },
+          'Failed to delete eval session data',
+        );
+      }
+    }
+
+    const resolvedAudit = resolveAuditTraceForSession(
+      params.dataDir,
+      identifier,
+      [],
+    );
+    const auditDir = resolvedAudit?.auditPath
+      ? path.dirname(resolvedAudit.auditPath)
+      : path.dirname(resolveAuditWirePath(params.dataDir, identifier));
+    try {
+      fs.rmSync(auditDir, { recursive: true, force: true });
+    } catch (error) {
+      logger.warn(
+        { sessionId: identifier, auditDir, error },
+        'Failed to delete eval audit trail',
+      );
+    }
+  }
+
+  auditWireLookupCache.clear();
+
+  const agentDir = path.dirname(agentWorkspaceDir(params.agentId));
+  try {
+    fs.rmSync(agentDir, { recursive: true, force: true });
+  } catch (error) {
+    logger.warn(
+      { agentId: params.agentId, agentDir, error },
+      'Failed to delete temp eval agent directory',
+    );
   }
 }
 
@@ -1560,7 +1678,6 @@ function renderRunSummary(
   const profile = summary.profile ?? buildDefaultEvalProfile();
   const filterLines: string[] = [];
   if (summary.filterSkill) filterLines.push(`skill=${summary.filterSkill}`);
-  if (summary.filterMode) filterLines.push(`mode=${summary.filterMode}`);
   if (summary.maxFixtures) filterLines.push(`max=${summary.maxFixtures}`);
   if (summary.forceExplicit) filterLines.push('explicit');
   const totals = summarizeHybridaiSkillsRuns(runs);
@@ -1682,9 +1799,7 @@ function renderRunSummary(
                 runs.length > 1
                   ? `${run.model} · ${result.fixture.id}`
                   : result.fixture.id,
-                result.toolNames.length > 0
-                  ? result.toolNames.join(',')
-                  : (result.observedSkill ?? 'ok'),
+                describeResultTrace(result),
               ] as const,
           ),
         )
@@ -1703,22 +1818,36 @@ function renderRunSummary(
 }
 
 function describeFailure(result: FixtureGradeResult): string {
-  const parts: string[] = [];
-  if (result.reason) parts.push(result.reason);
+  const trace = describeResultTrace(result);
   if (
-    result.observedSkill &&
-    result.observedSkill !== result.fixture.skill &&
-    !(result.reason || '').includes(result.observedSkill)
+    !result.reason ||
+    result.reason.trim().toLowerCase() === 'no skill observed in tool trace'
   ) {
-    parts.push(`observed=${result.observedSkill}`);
+    return trace || 'failed';
   }
+  return [result.reason, trace].filter(Boolean).join(' · ');
+}
+
+function describeResultTrace(result: FixtureGradeResult): string {
+  const parts = [
+    `skills=${result.observedSkill || 'None'}`,
+    `artefacts=${result.artifactsObserved ? '✅' : '❌'}`,
+  ];
   if (result.toolNames.length > 0) {
-    parts.push(`tools=${result.toolNames.join(',')}`);
+    parts.push(`tools=${formatToolCallCounts(result.toolNames)}`);
   }
-  if (result.sessionId) {
-    parts.push(`session=${result.sessionId}`);
+  return parts.join(' ');
+}
+
+function formatToolCallCounts(toolNames: string[]): string {
+  const counts = new Map<string, number>();
+  for (const rawName of toolNames) {
+    const name = String(rawName || '').trim() || 'tool';
+    counts.set(name, (counts.get(name) || 0) + 1);
   }
-  return parts.length > 0 ? parts.join(' · ') : 'failed';
+  return Array.from(counts.entries())
+    .map(([name, count]) => `${name} (${count})`)
+    .join(',');
 }
 
 function normalizeModelRuns(
@@ -1763,8 +1892,8 @@ function renderHybridaiSkillsUsage(
     '',
     'Usage:',
     '- `/eval hybridai-skills setup`',
-    '- `/eval hybridai-skills list [--skill <name>] [--mode implicit|explicit] [--kind try-it|conversation] [--max N]`',
-    '- `/eval hybridai-skills run [--dry-run|--live] [--skill <name>] [--mode ...] [--kind ...] [--max N] [--explicit] [--model <name>[,<name>]] [--current-agent|--fresh-agent] [--ablate-system] [--include-prompt=<parts>] [--omit-prompt=<parts>]`',
+    '- `/eval hybridai-skills list [--skill <name>] [--kind try-it|conversation] [--max N]`',
+    '- `/eval hybridai-skills run [--dry-run|--live] [--skill <name>] [--kind try-it|conversation] [--max N] [--explicit] [--model <name>[,<name>]] [--current-agent|--fresh-agent] [--ablate-system] [--include-prompt=<parts>] [--omit-prompt=<parts>]`',
     '- `/eval hybridai-skills results`',
     '',
     'What it does:',

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -28,8 +28,8 @@ import {
   HYBRIDAI_BASE_URL,
   IMESSAGE_WEBHOOK_PATH,
   MSTEAMS_WEBHOOK_PATH,
-  WEB_API_TOKEN,
   refreshRuntimeSecretsFromEnv,
+  WEB_API_TOKEN,
 } from '../config/config.js';
 import type {
   RuntimeConfig,
@@ -38,8 +38,8 @@ import type {
 } from '../config/runtime-config.js';
 import {
   getRuntimeConfig,
-  reloadRuntimeConfig,
   parseSchedulerBoardStatus,
+  reloadRuntimeConfig,
   resolveDefaultAgentId,
 } from '../config/runtime-config.js';
 import { GatewayRequestError } from '../errors/gateway-request-error.js';

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -29,6 +29,7 @@ import {
   IMESSAGE_WEBHOOK_PATH,
   MSTEAMS_WEBHOOK_PATH,
   WEB_API_TOKEN,
+  refreshRuntimeSecretsFromEnv,
 } from '../config/config.js';
 import type {
   RuntimeConfig,
@@ -37,6 +38,7 @@ import type {
 } from '../config/runtime-config.js';
 import {
   getRuntimeConfig,
+  reloadRuntimeConfig,
   parseSchedulerBoardStatus,
   resolveDefaultAgentId,
 } from '../config/runtime-config.js';
@@ -1845,6 +1847,26 @@ function handleApiRestart(res: ServerResponse): void {
   }, 50);
 }
 
+function handleApiConfigReload(res: ServerResponse): void {
+  try {
+    refreshRuntimeSecretsFromEnv();
+    reloadRuntimeConfig('admin-api');
+  } catch (error) {
+    sendJson(res, 500, {
+      error:
+        error instanceof Error
+          ? error.message
+          : 'Gateway reload failed unexpectedly.',
+    });
+    return;
+  }
+
+  sendJson(res, 200, {
+    status: 'ok',
+    message: 'Gateway reloaded.',
+  });
+}
+
 async function handleApiAdminOverview(res: ServerResponse): Promise<void> {
   sendJson(res, 200, await getGatewayAdminOverview());
 }
@@ -3551,6 +3573,11 @@ export function startGatewayHttpServer(): GatewayHttpServer {
           }
           if (pathname === '/api/admin/restart' && method === 'POST') {
             handleApiRestart(res);
+            return;
+          }
+
+          if (pathname === '/api/admin/config/reload' && method === 'POST') {
+            handleApiConfigReload(res);
             return;
           }
           if (pathname === '/api/chat' && method === 'POST') {

--- a/src/gateway/openai-compatible.ts
+++ b/src/gateway/openai-compatible.ts
@@ -221,11 +221,15 @@ function prepareOpenAICompatibleRequest(
 ): {
   responseModel: string;
   cleanupAgentId: string | null;
+  isEvalRequest: boolean;
   requestAgentId: string;
   sessionId: string;
   model: string;
   profile: ReturnType<typeof parseEvalProfileModel>['profile'];
 } {
+  const isEvalRequest =
+    Boolean(input.evalProfile?.trim()) ||
+    input.model.includes(EVAL_MODEL_PROFILE_MARKER);
   const profiledModel = input.evalProfile
     ? input.model.includes(EVAL_MODEL_PROFILE_MARKER)
       ? input.model
@@ -272,6 +276,7 @@ function prepareOpenAICompatibleRequest(
   return {
     responseModel: input.model,
     cleanupAgentId: freshAgentId,
+    isEvalRequest,
     requestAgentId,
     sessionId,
     model,
@@ -291,6 +296,12 @@ function buildGatewayChatRequest(params: {
     sessionId: params.prepared.sessionId,
     ...(params.executionSessionId
       ? { executionSessionId: params.executionSessionId }
+      : {}),
+    ...(params.prepared.isEvalRequest
+      ? {
+          autoApproveTools: true,
+          neverAutoApproveTools: [] as string[],
+        }
       : {}),
     guildId: null,
     channelId: 'openai',
@@ -453,6 +464,12 @@ async function handleOpenAICompatibleNonStreamingChat(
     ...(result.sessionKey
       ? { 'X-HybridClaw-Session-Key': result.sessionKey }
       : {}),
+    ...(chatRequest.executionSessionId
+      ? {
+          'X-HybridClaw-Execution-Session-Id': chatRequest.executionSessionId,
+        }
+      : {}),
+    'X-HybridClaw-Artifact-Count': String(result.artifacts?.length || 0),
   };
   const payload = buildOpenAICompatibleCompletionResponse({
     completionId,

--- a/tests/eval-command.test.ts
+++ b/tests/eval-command.test.ts
@@ -681,7 +681,9 @@ test('starts detached eval runs with injected OpenAI-compatible env', async () =
   expect(options.detached).toBe(true);
   expect(options.env.OPENAI_BASE_URL).toBe('http://127.0.0.1:9090/v1');
   expect(options.env.OPENAI_API_KEY).toBe('hybridclaw-local');
-  expect(options.env.HYBRIDCLAW_EVAL_MODEL).toBe('hybridai/gpt-4.1-mini');
+  expect(options.env.HYBRIDCLAW_EVAL_MODEL).toBe(
+    'hybridai/gpt-4.1-mini__hc_eval=current-agent',
+  );
 
   const evalDir = path.join(dataDir, 'evals');
   const runDirs = fs.readdirSync(evalDir);
@@ -698,7 +700,7 @@ test('starts detached eval runs with injected OpenAI-compatible env', async () =
   expect(meta.pid).toBe(4321);
   expect(meta.authMode).toBe('loopback');
   expect(meta.openaiBaseUrl).toBe('http://127.0.0.1:9090/v1');
-  expect(meta.model).toBe('hybridai/gpt-4.1-mini');
+  expect(meta.model).toBe('hybridai/gpt-4.1-mini__hc_eval=current-agent');
   expect(meta.command).toBe('python -m swebench.harness.run_evaluation');
 });
 

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -1382,6 +1382,8 @@ async function importFreshHealth(options?: {
     restartSupported: true,
     restartReason: null,
   }));
+  const refreshRuntimeSecretsFromEnv = vi.fn();
+  const reloadRuntimeConfig = vi.fn();
 
   vi.doMock('node:http', () => ({
     default: { createServer },
@@ -1399,6 +1401,7 @@ async function importFreshHealth(options?: {
     IMESSAGE_WEBHOOK_PATH: '/api/imessage/webhook',
     MSTEAMS_WEBHOOK_PATH: '/api/msteams/messages',
     WEB_API_TOKEN: options?.webApiToken || '',
+    refreshRuntimeSecretsFromEnv,
     getSandboxAutoDetectionState: vi.fn(() => ({
       runningInsideContainer: options?.runningInsideContainer === true,
       sandboxModeExplicit: false,
@@ -1409,6 +1412,15 @@ async function importFreshHealth(options?: {
       path.join(installRoot, ...segments),
     ),
   }));
+  vi.doMock('../src/config/runtime-config.js', async () => {
+    const actual = await vi.importActual<
+      typeof import('../src/config/runtime-config.js')
+    >('../src/config/runtime-config.js');
+    return {
+      ...actual,
+      reloadRuntimeConfig,
+    };
+  });
   vi.doMock('../src/logger.js', () => ({
     logger: {
       debug: loggerDebug,
@@ -1610,6 +1622,8 @@ async function importFreshHealth(options?: {
     upgradeHandler,
     moveGatewayAdminSchedulerJob,
     requestGatewayRestart,
+    refreshRuntimeSecretsFromEnv,
+    reloadRuntimeConfig,
     createGatewayAdminAgent,
     createGatewayAdminSkill,
     restoreGatewayAdminAgentMarkdownRevision,
@@ -2041,6 +2055,8 @@ describe('gateway HTTP server', () => {
     expect(state.handleGatewayMessage).toHaveBeenCalledWith({
       sessionId: expect.stringMatching(OPENAI_SESSION_ID_RE),
       executionSessionId: expect.stringMatching(OPENAI_EXECUTION_SESSION_ID_RE),
+      autoApproveTools: true,
+      neverAutoApproveTools: [],
       guildId: null,
       channelId: 'openai',
       userId: expect.stringMatching(OPENAI_SESSION_ID_RE),
@@ -2057,6 +2073,10 @@ describe('gateway HTTP server', () => {
     expect(res.getHeader('x-hybridclaw-session-id')).toMatch(
       OPENAI_SESSION_ID_RE,
     );
+    expect(res.getHeader('x-hybridclaw-execution-session-id')).toMatch(
+      OPENAI_EXECUTION_SESSION_ID_RE,
+    );
+    expect(res.getHeader('x-hybridclaw-artifact-count')).toBe('0');
     expect(res.getHeader('x-hybridclaw-agent-id')).toBe('charly');
     expect(res.getHeader('x-hybridclaw-workspace-mode')).toBe('current-agent');
   });
@@ -2071,7 +2091,13 @@ describe('gateway HTTP server', () => {
       assistantMessageId: 12,
       sessionId: 'sess_eval_real_1',
       sessionKey: 'agent:charly:channel:openai:chat:dm:peer:feedfacecafebeef',
-      artifacts: [],
+      artifacts: [
+        {
+          path: '/tmp/report.pdf',
+          filename: 'report.pdf',
+          mimeType: 'application/pdf',
+        },
+      ],
     });
     const req = makeRequest({
       method: 'POST',
@@ -2090,6 +2116,10 @@ describe('gateway HTTP server', () => {
     expect(res.getHeader('x-hybridclaw-session-key')).toBe(
       'agent:charly:channel:openai:chat:dm:peer:feedfacecafebeef',
     );
+    expect(res.getHeader('x-hybridclaw-execution-session-id')).toMatch(
+      OPENAI_EXECUTION_SESSION_ID_RE,
+    );
+    expect(res.getHeader('x-hybridclaw-artifact-count')).toBe('1');
   });
 
   test('routes OpenAI requests with HybridClaw eval-profile header using the plain model name', async () => {
@@ -2113,6 +2143,8 @@ describe('gateway HTTP server', () => {
     expect(state.handleGatewayMessage).toHaveBeenCalledWith({
       sessionId: expect.stringMatching(OPENAI_SESSION_ID_RE),
       executionSessionId: expect.stringMatching(OPENAI_EXECUTION_SESSION_ID_RE),
+      autoApproveTools: true,
+      neverAutoApproveTools: [],
       guildId: null,
       channelId: 'openai',
       userId: expect.stringMatching(OPENAI_SESSION_ID_RE),
@@ -2145,6 +2177,8 @@ describe('gateway HTTP server', () => {
 
     expect(state.handleGatewayMessage).toHaveBeenCalledWith({
       sessionId: expect.stringMatching(OPENAI_SESSION_ID_RE),
+      autoApproveTools: true,
+      neverAutoApproveTools: [],
       guildId: null,
       channelId: 'openai',
       userId: expect.stringMatching(OPENAI_SESSION_ID_RE),
@@ -3967,6 +4001,25 @@ describe('gateway HTTP server', () => {
     expect(res.statusCode).toBe(409);
     expect(JSON.parse(res.body)).toEqual({
       error: 'Gateway restart is unavailable in this launch mode.',
+    });
+  });
+
+  test('reloads gateway config for authorized admin API calls', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/admin/config/reload',
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.refreshRuntimeSecretsFromEnv).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({
+      status: 'ok',
+      message: 'Gateway reloaded.',
     });
   });
 

--- a/tests/hybridai-skills-command.test.ts
+++ b/tests/hybridai-skills-command.test.ts
@@ -267,6 +267,9 @@ describe('handleHybridaiSkillsCommand dispatch', () => {
     const bare = await handleHybridaiSkillsCommand({ dataDir, env });
     expect(bare.kind).toBe('info');
     expect(bare.text).toMatch(/Usage:/);
+    expect(bare.text).toContain(
+      '--kind try-it|conversation] [--max N] [--explicit]',
+    );
     const withHelp = await handleHybridaiSkillsCommand({
       dataDir,
       env,
@@ -290,6 +293,34 @@ describe('live runner grading', () => {
       profile: buildDefaultEvalProfile(),
     };
   }
+
+  test('rejects the removed --mode flag', async () => {
+    const dataDir = makeTempDir();
+    const fixture: HybridaiSkillFixture = {
+      id: 'synthetic:pdf:try-it:mode-removed',
+      docFile: 'synthetic.md',
+      skill: 'pdf',
+      prompt: 'Create a one-page PDF invoice for Acme Corp',
+      mode: 'implicit',
+      kind: 'try-it',
+    };
+    writeHybridaiSkillsFixtures(dataDir, {
+      generatedAt: new Date().toISOString(),
+      docsRoot: '',
+      sourceFiles: ['synthetic.md'],
+      fixtures: [fixture],
+    });
+
+    const result = await handleHybridaiSkillsCommand({
+      dataDir,
+      env: makeEnv(),
+      subcommand: 'run',
+      args: ['--skill', 'pdf', '--mode', 'explicit'],
+    });
+
+    expect(result.kind).toBe('error');
+    expect(result.text).toContain('Unknown flag: `--mode`.');
+  });
 
   test('does not short-circuit on explicit-mode fixtures; empty tool trace fails', async () => {
     const dataDir = makeTempDir();
@@ -338,7 +369,9 @@ describe('live runner grading', () => {
     expect(result.text).toMatch(/Passed\s+0\/1/);
     expect(result.text).toMatch(/Failed\s+1/);
     expect(result.text).toMatch(/synthetic:code-review:try-it:1/);
-    expect(result.text).toMatch(/no skill observed in tool trace/);
+    expect(result.text).toMatch(/skills=None/);
+    expect(result.text).toContain('artefacts=❌');
+    expect(result.text).not.toMatch(/session=/);
   });
 
   test('defaults to fresh-agent per fixture and grades from the audit trace', async () => {
@@ -358,6 +391,8 @@ describe('live runner grading', () => {
       fixtures: [fixture],
     });
     const sessionId = 'sess_pdf_eval_1';
+    const executionSessionId = 'sess_pdf_exec_1';
+    const tempAgentId = 'eval-cleanup-agent-1';
     const auditPath = writeAuditWire(dataDir, sessionId, [
       {
         type: 'session.start',
@@ -384,6 +419,30 @@ describe('live runner grading', () => {
         outcome: 'success',
       },
     ]);
+    const executionAuditPath = writeAuditWire(dataDir, executionSessionId, [
+      {
+        type: 'session.start',
+        cwd: '/tmp/eval-agent/workspace',
+      },
+    ]);
+    const { initDatabase } = await import('../src/memory/db.js');
+    const { memoryService } = await import('../src/memory/memory-service.js');
+    const { agentWorkspaceDir } = await import('../src/infra/ipc.js');
+    initDatabase({ quiet: true });
+    memoryService.getOrCreateSession(sessionId, null, 'openai', tempAgentId);
+    memoryService.getOrCreateSession(
+      executionSessionId,
+      null,
+      'openai',
+      tempAgentId,
+    );
+    const tempAgentWorkspace = agentWorkspaceDir(tempAgentId);
+    fs.mkdirSync(tempAgentWorkspace, { recursive: true });
+    fs.writeFileSync(
+      path.join(tempAgentWorkspace, 'placeholder.txt'),
+      'temp\n',
+      'utf8',
+    );
     const mockFetch = vi.fn(async (_url: string, init?: RequestInit) => {
       const body = JSON.parse(String(init?.body || '{}')) as { model?: string };
       expect(body.model).toContain('__hc_eval=fresh-agent');
@@ -403,6 +462,9 @@ describe('live runner grading', () => {
           headers: {
             'content-type': 'application/json',
             'x-hybridclaw-session-id': sessionId,
+            'x-hybridclaw-execution-session-id': executionSessionId,
+            'x-hybridclaw-agent-id': tempAgentId,
+            'x-hybridclaw-artifact-count': '1',
           },
         },
       );
@@ -420,6 +482,7 @@ describe('live runner grading', () => {
     expect(result.kind).toBe('info');
     expect(result.text).toMatch(/Passed\s+1\/1/);
     expect(result.text).toContain('Profile');
+    expect(result.text).toContain('skills=pdf artefacts=✅ tools=read (1)');
 
     const latestRun = JSON.parse(
       fs.readFileSync(
@@ -435,6 +498,14 @@ describe('live runner grading', () => {
     expect(latestRun.profile.workspaceMode).toBe('fresh-agent');
     expect(latestRun.runs[0]?.results[0]?.sessionId).toBe(sessionId);
     expect(latestRun.runs[0]?.results[0]?.auditPath).toBe(auditPath);
+    expect(memoryService.getSessionById(sessionId)).toBeUndefined();
+    expect(memoryService.getSessionById(executionSessionId)).toBeUndefined();
+    expect(fs.existsSync(tempAgentWorkspace)).toBe(false);
+    expect(fs.existsSync(path.dirname(tempAgentWorkspace))).toBe(false);
+    expect(fs.existsSync(auditPath)).toBe(false);
+    expect(fs.existsSync(path.dirname(auditPath))).toBe(false);
+    expect(fs.existsSync(executionAuditPath)).toBe(false);
+    expect(fs.existsSync(path.dirname(executionAuditPath))).toBe(false);
   });
 
   test('supports suite-local current-agent override after run', async () => {
@@ -637,7 +708,9 @@ describe('live runner grading', () => {
 
     expect(result.kind).toBe('info');
     expect(result.text).toMatch(/Passed\s+0\/1/);
-    expect(result.text).toMatch(/no skill observed in tool trace/);
+    expect(result.text).toMatch(/skills=None/);
+    expect(result.text).toContain('artefacts=❌');
+    expect(result.text).not.toMatch(/session=/);
   });
 
   test('runs conversation fixtures as a chained conversation in one temporary agent workspace', async () => {
@@ -814,5 +887,102 @@ describe('live runner grading', () => {
       'model-a',
       'model-b',
     ]);
+  });
+
+  test('renders tool call counts instead of repeating tool names', async () => {
+    const dataDir = makeTempDir();
+    const fixture: HybridaiSkillFixture = {
+      id: 'synthetic:pdf:try-it:counts',
+      docFile: 'synthetic.md',
+      skill: 'pdf',
+      prompt: 'Create a one-page PDF invoice for Acme Corp',
+      mode: 'implicit',
+      kind: 'try-it',
+    };
+    writeHybridaiSkillsFixtures(dataDir, {
+      generatedAt: new Date().toISOString(),
+      docsRoot: '',
+      sourceFiles: ['synthetic.md'],
+      fixtures: [fixture],
+    });
+    const sessionId = 'sess_pdf_tool_counts_1';
+    writeAuditWire(dataDir, sessionId, [
+      {
+        type: 'tool.call',
+        toolCallId: 'tool-1',
+        toolName: 'write',
+        arguments: { path: 'invoice.md' },
+      },
+      {
+        type: 'tool.result',
+        toolCallId: 'tool-1',
+        toolName: 'write',
+        resultSummary: 'ok',
+        durationMs: 1,
+        isError: false,
+        blocked: false,
+      },
+      {
+        type: 'tool.call',
+        toolCallId: 'tool-2',
+        toolName: 'bash',
+        arguments: { cmd: 'step 1' },
+      },
+      {
+        type: 'tool.result',
+        toolCallId: 'tool-2',
+        toolName: 'bash',
+        resultSummary: 'ok',
+        durationMs: 1,
+        isError: false,
+        blocked: false,
+      },
+      {
+        type: 'tool.call',
+        toolCallId: 'tool-3',
+        toolName: 'bash',
+        arguments: { cmd: 'step 2' },
+      },
+      {
+        type: 'tool.result',
+        toolCallId: 'tool-3',
+        toolName: 'bash',
+        resultSummary: 'ok',
+        durationMs: 1,
+        isError: false,
+        blocked: false,
+      },
+      {
+        type: 'skill.execution',
+        skillName: 'pdf',
+        outcome: 'success',
+      },
+    ]);
+    const mockFetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { role: 'assistant', content: 'Done.' } }],
+        }),
+        {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            'x-hybridclaw-session-id': sessionId,
+          },
+        },
+      );
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const result = await handleHybridaiSkillsCommand({
+      dataDir,
+      env: makeEnv(),
+      subcommand: 'run',
+      args: ['--live', '--max', '1'],
+    });
+
+    expect(result.kind).toBe('info');
+    expect(result.text).toContain('tools=write (1),bash (2)');
+    expect(result.text).not.toContain('tools=write,bash,bash');
   });
 });


### PR DESCRIPTION
## What changed

- replaced the gateway restart action in the console with a config reload flow and updated the client/tests for the new behavior
- expanded `hybridai-skills` eval reporting so results show observed skills, artifact presence, and counted tool-call totals
- removed the `--mode` switch from `hybridai-skills`, updated the help/docs, and locked the new CLI contract in tests
- added temp eval cleanup for fresh-agent runs so transient agent directories, sessions, and audit trails are deleted after grading
- surfaced OpenAI-compatible execution session and artifact-count headers, and made eval-profiled requests auto-approve tools end-to-end

## Why

The eval path was still stopping on approvals in cases that should run unattended, and the `hybridai-skills` output was missing enough trace detail to explain pass/fail behavior quickly. The gateway console also needed a lighter-weight reload path instead of a full restart action.

## Impact

- `/eval` runs can execute without manual approval interruptions
- `hybridai-skills` output is easier to inspect and reason about
- the gateway console can reload config without presenting a restart-oriented UX

## Validation

- `./node_modules/.bin/vitest tests/hybridai-skills-command.test.ts`
- `./node_modules/.bin/vitest tests/eval-command.test.ts tests/gateway-http-server.test.ts`
- `npm run typecheck`
- `./node_modules/.bin/biome check src/evals/eval-command.ts src/evals/hybridai-skills-command.ts src/gateway/openai-compatible.ts tests/eval-command.test.ts tests/gateway-http-server.test.ts tests/hybridai-skills-command.test.ts docs/content/reference/commands.md docs/development/reference/commands.md`

## Notes

- this branch is currently 1 commit behind `main`; I fetched `origin/main` before opening the PR, but did not rebase because the branch stack depends on the existing `hybridai-skills` work in this branch history.
