### PR TITLE
[codex] Search chat history by title and content

### DIFF
--- a/console/src/api/chat-types.ts
+++ b/console/src/api/chat-types.ts
@@ -1,6 +1,7 @@
 export interface ChatRecentSession {
   sessionId: string;
   title: string;
+  searchSnippet?: string | null;
   lastActive: string;
   messageCount: number;
 }

--- a/console/src/api/chat-types.ts
+++ b/console/src/api/chat-types.ts
@@ -1,6 +1,6 @@
 export interface ChatRecentSession {
   sessionId: string;
-  title: string;
+  title: string | null;
   searchSnippet?: string | null;
   lastActive: string;
   messageCount: number;

--- a/console/src/api/chat.ts
+++ b/console/src/api/chat.ts
@@ -18,12 +18,14 @@ export function fetchChatRecent(
   userId: string,
   channelId = 'web',
   limit = 10,
+  query?: string,
 ): Promise<ChatRecentResponse> {
   const params = new URLSearchParams({
     userId,
     channelId,
     limit: String(limit),
   });
+  if (query) params.set('q', query);
   return requestJson<ChatRecentResponse>(
     `/api/chat/recent?${params.toString()}`,
     { token },

--- a/console/src/lib/chat-ui-config.ts
+++ b/console/src/lib/chat-ui-config.ts
@@ -1,0 +1,8 @@
+import chatUiConfig from '../../../docs/static/chat-ui-config.json';
+
+type ChatUiConfig = {
+  maxRecentSessions: number;
+  maxSearchResults: number;
+};
+
+export const CHAT_UI_CONFIG = chatUiConfig as ChatUiConfig;

--- a/console/src/lib/use-debounced-value.ts
+++ b/console/src/lib/use-debounced-value.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setDebouncedValue(value);
+    }, delayMs);
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [value, delayMs]);
+
+  return debouncedValue;
+}

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -58,6 +58,30 @@
   background: var(--accent-soft);
 }
 
+.sidebarSearchWrap {
+  padding: 2px 0 4px;
+}
+
+.sidebarSearch {
+  width: 100%;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: var(--panel-bg);
+  color: var(--text);
+  font: inherit;
+  padding: 9px 11px;
+}
+
+.sidebarSearch::placeholder {
+  color: var(--muted-foreground);
+}
+
+.sidebarSearch:focus {
+  outline: 2px solid var(--accent-soft);
+  outline-offset: 1px;
+  border-color: var(--ring);
+}
+
 .sidebarLabel {
   margin: 12px 0 4px;
   padding: 0 6px;
@@ -115,6 +139,12 @@
 
 .sessionTime {
   font-size: 0.72rem;
+  color: var(--muted-foreground);
+}
+
+.sidebarStatus {
+  padding: 6px 10px;
+  font-size: 0.82rem;
   color: var(--muted-foreground);
 }
 

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -137,6 +137,14 @@
   text-overflow: ellipsis;
 }
 
+.sessionSnippet {
+  font-size: 0.76rem;
+  color: var(--muted-foreground);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .sessionTime {
   font-size: 0.72rem;
   color: var(--muted-foreground);

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -1,12 +1,13 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
+  act,
   fireEvent,
   render,
   screen,
   waitFor,
   within,
 } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   BranchResponse,
   ChatHistoryResponse,
@@ -93,6 +94,10 @@ function renderChatPage() {
 }
 
 describe('ChatPage', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   beforeEach(() => {
     window.HTMLElement.prototype.scrollIntoView = vi.fn();
     localStorage.clear();
@@ -299,6 +304,103 @@ describe('ChatPage', () => {
         'test-token',
         'session-search',
       ),
+    );
+  });
+
+  it('renders title-only search matches without a snippet', async () => {
+    fetchChatHistoryMock.mockImplementation(
+      async (_token, sessionId): Promise<ChatHistoryResponse> => ({
+        sessionId,
+        history: [
+          {
+            id: sessionId === 'session-title-only' ? 401 : 101,
+            role: 'assistant',
+            content:
+              sessionId === 'session-title-only'
+                ? 'Opened title-only deployment thread'
+                : 'Opened session A',
+          },
+        ],
+      }),
+    );
+    fetchChatRecentMock.mockImplementation(
+      async (_token, _userId, _channelId, _limit, query) => ({
+        sessions: query
+          ? [
+              {
+                sessionId: 'session-title-only',
+                title: 'Deployment checklist',
+                lastActive: '2026-04-13T09:30:00.000Z',
+                messageCount: 1,
+              },
+            ]
+          : [
+              {
+                sessionId: 'session-a',
+                title: 'Session A',
+                lastActive: '2026-04-14T10:00:00.000Z',
+                messageCount: 2,
+              },
+            ],
+      }),
+    );
+
+    renderChatPage();
+
+    expect(await screen.findByText('Opened session A')).not.toBeNull();
+
+    fireEvent.change(screen.getByLabelText('Search conversations'), {
+      target: { value: 'deploy' },
+    });
+
+    expect(await screen.findByText('Deployment checklist')).not.toBeNull();
+    expect(
+      screen.queryByText('...deployment rollback steps from yesterday...'),
+    ).toBeNull();
+  });
+
+  it('debounces recent-session searches while typing', async () => {
+    fetchChatHistoryMock.mockResolvedValue({
+      sessionId: 'session-a',
+      history: [
+        {
+          id: 101,
+          role: 'assistant',
+          content: 'Opened session A',
+        },
+      ],
+    });
+
+    renderChatPage();
+
+    expect(await screen.findByText('Opened session A')).not.toBeNull();
+    expect(fetchChatRecentMock).toHaveBeenCalledTimes(1);
+
+    vi.useFakeTimers();
+    const searchInput = screen.getByLabelText('Search conversations');
+    for (const value of ['d', 'de', 'dep', 'depl', 'deplo', 'deploy']) {
+      fireEvent.change(searchInput, { target: { value } });
+    }
+
+    expect(fetchChatRecentMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(159);
+    });
+    expect(fetchChatRecentMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+    vi.useRealTimers();
+
+    await waitFor(() => expect(fetchChatRecentMock).toHaveBeenCalledTimes(2));
+    expect(fetchChatRecentMock).toHaveBeenLastCalledWith(
+      'test-token',
+      'web-user-1',
+      'web',
+      50,
+      'deploy',
     );
   });
 

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -18,7 +18,15 @@ import { ChatPage } from './chat-page';
 
 const validateTokenMock = vi.fn<(token: string) => Promise<GatewayStatus>>();
 const fetchChatRecentMock =
-  vi.fn<(token: string, userId: string) => Promise<ChatRecentResponse>>();
+  vi.fn<
+    (
+      token: string,
+      userId: string,
+      channelId?: string,
+      limit?: number,
+      query?: string,
+    ) => Promise<ChatRecentResponse>
+  >();
 const fetchChatHistoryMock =
   vi.fn<(token: string, sessionId: string) => Promise<ChatHistoryResponse>>();
 const createChatBranchMock =
@@ -38,8 +46,13 @@ const isActiveMock = vi.fn();
 const useChatStreamMock = vi.fn();
 
 vi.mock('../../api/chat', () => ({
-  fetchChatRecent: (token: string, userId: string) =>
-    fetchChatRecentMock(token, userId),
+  fetchChatRecent: (
+    token: string,
+    userId: string,
+    channelId?: string,
+    limit?: number,
+    query?: string,
+  ) => fetchChatRecentMock(token, userId, channelId, limit, query),
   fetchChatHistory: (token: string, sessionId: string) =>
     fetchChatHistoryMock(token, sessionId),
   createChatBranch: (
@@ -111,22 +124,33 @@ describe('ChatPage', () => {
       ragDefault: false,
       timestamp: '2026-04-14T10:00:00.000Z',
     });
-    fetchChatRecentMock.mockResolvedValue({
-      sessions: [
-        {
-          sessionId: 'session-a',
-          title: 'Session A',
-          lastActive: '2026-04-14T10:00:00.000Z',
-          messageCount: 2,
-        },
-        {
-          sessionId: 'session-b',
-          title: 'Session B',
-          lastActive: '2026-04-14T09:30:00.000Z',
-          messageCount: 3,
-        },
-      ],
-    });
+    fetchChatRecentMock.mockImplementation(
+      async (_token, _userId, _channelId, _limit, query) => ({
+        sessions: query
+          ? [
+              {
+                sessionId: 'session-search',
+                title: 'Deployment checklist',
+                lastActive: '2026-04-13T09:30:00.000Z',
+                messageCount: 4,
+              },
+            ]
+          : [
+              {
+                sessionId: 'session-a',
+                title: 'Session A',
+                lastActive: '2026-04-14T10:00:00.000Z',
+                messageCount: 2,
+              },
+              {
+                sessionId: 'session-b',
+                title: 'Session B',
+                lastActive: '2026-04-14T09:30:00.000Z',
+                messageCount: 3,
+              },
+            ],
+      }),
+    );
     isActiveMock.mockReturnValue(false);
     useChatStreamMock.mockReturnValue({
       sendMessage: sendMessageMock,
@@ -221,6 +245,57 @@ describe('ChatPage', () => {
       ['test-token', 'session-a'],
       ['test-token', 'session-b'],
     ]);
+  });
+
+  it('searches conversation titles beyond the default recent list', async () => {
+    fetchChatHistoryMock.mockImplementation(
+      async (_token, sessionId): Promise<ChatHistoryResponse> => ({
+        sessionId,
+        history: [
+          {
+            id: sessionId === 'session-search' ? 301 : 101,
+            role: 'assistant',
+            content:
+              sessionId === 'session-search'
+                ? 'Opened deployment thread'
+                : 'Opened session A',
+          },
+        ],
+      }),
+    );
+
+    renderChatPage();
+
+    expect(await screen.findByText('Opened session A')).not.toBeNull();
+
+    fireEvent.change(screen.getByLabelText('Search conversations by title'), {
+      target: { value: 'deploy' },
+    });
+
+    expect(await screen.findByText('Deployment checklist')).not.toBeNull();
+    await waitFor(() =>
+      expect(fetchChatRecentMock).toHaveBeenCalledWith(
+        'test-token',
+        'web-user-1',
+        'web',
+        50,
+        'deploy',
+      ),
+    );
+
+    fireEvent.click(
+      screen
+        .getByText('Deployment checklist')
+        .closest('button') as HTMLButtonElement,
+    );
+
+    expect(await screen.findByText('Opened deployment thread')).not.toBeNull();
+    await waitFor(() =>
+      expect(fetchChatHistoryMock).toHaveBeenCalledWith(
+        'test-token',
+        'session-search',
+      ),
+    );
   });
 
   it('assigns branch controls to loaded history and opens sibling branches', async () => {

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -131,6 +131,7 @@ describe('ChatPage', () => {
               {
                 sessionId: 'session-search',
                 title: 'Deployment checklist',
+                searchSnippet: '...deployment rollback steps from yesterday...',
                 lastActive: '2026-04-13T09:30:00.000Z',
                 messageCount: 4,
               },
@@ -268,11 +269,14 @@ describe('ChatPage', () => {
 
     expect(await screen.findByText('Opened session A')).not.toBeNull();
 
-    fireEvent.change(screen.getByLabelText('Search conversations by title'), {
+    fireEvent.change(screen.getByLabelText('Search conversations'), {
       target: { value: 'deploy' },
     });
 
     expect(await screen.findByText('Deployment checklist')).not.toBeNull();
+    expect(
+      await screen.findByText('...deployment rollback steps from yesterday...'),
+    ).not.toBeNull();
     await waitFor(() =>
       expect(fetchChatRecentMock).toHaveBeenCalledWith(
         'test-token',

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -25,7 +25,9 @@ import {
   readStoredUserId,
   storeSessionId,
 } from '../../lib/chat-helpers';
+import { CHAT_UI_CONFIG } from '../../lib/chat-ui-config';
 import { cx } from '../../lib/cx';
+import { useDebouncedValue } from '../../lib/use-debounced-value';
 import css from './chat-page.module.css';
 import { ChatSidebar } from './chat-sidebar';
 import type { ChatUiMessage } from './chat-ui-message';
@@ -92,7 +94,11 @@ export function ChatPage() {
     content: string;
     media: MediaItem[];
   } | null>(null);
-  const trimmedSessionSearchQuery = sessionSearchQuery.trim();
+  const debouncedSessionSearchQuery = useDebouncedValue(
+    sessionSearchQuery,
+    160,
+  );
+  const trimmedSessionSearchQuery = debouncedSessionSearchQuery.trim();
 
   const refreshRecent = useCallback(() => {
     void queryClient.invalidateQueries({
@@ -146,7 +152,9 @@ export function ChatPage() {
         auth.token,
         userId,
         'web',
-        trimmedSessionSearchQuery ? 50 : 10,
+        trimmedSessionSearchQuery
+          ? CHAT_UI_CONFIG.maxSearchResults
+          : CHAT_UI_CONFIG.maxRecentSessions,
         trimmedSessionSearchQuery || undefined,
       ),
     staleTime: 10_000,

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -75,6 +75,7 @@ export function ChatPage() {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [approvalBusy, setApprovalBusy] = useState(false);
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  const [sessionSearchQuery, setSessionSearchQuery] = useState('');
   const [branchFamilies, setBranchFamilies] = useState<
     Map<string, BranchVariant[]>
   >(new Map());
@@ -91,6 +92,7 @@ export function ChatPage() {
     content: string;
     media: MediaItem[];
   } | null>(null);
+  const trimmedSessionSearchQuery = sessionSearchQuery.trim();
 
   const refreshRecent = useCallback(() => {
     void queryClient.invalidateQueries({
@@ -138,8 +140,15 @@ export function ChatPage() {
   }, [auth.token]);
 
   const recentQuery = useQuery({
-    queryKey: ['chat-recent', auth.token, userId],
-    queryFn: () => fetchChatRecent(auth.token, userId),
+    queryKey: ['chat-recent', auth.token, userId, trimmedSessionSearchQuery],
+    queryFn: () =>
+      fetchChatRecent(
+        auth.token,
+        userId,
+        'web',
+        trimmedSessionSearchQuery ? 50 : 10,
+        trimmedSessionSearchQuery || undefined,
+      ),
     staleTime: 10_000,
   });
   const recentSessions = recentQuery.data?.sessions ?? [];
@@ -358,6 +367,9 @@ export function ChatPage() {
     activeSessionId: sessionId,
     onNewChat: handleNewChat,
     onOpenSession: handleOpenSession,
+    searchQuery: sessionSearchQuery,
+    onSearchQueryChange: setSessionSearchQuery,
+    isLoading: recentQuery.isFetching,
   } as const;
 
   return (

--- a/console/src/routes/chat/chat-sidebar.tsx
+++ b/console/src/routes/chat/chat-sidebar.tsx
@@ -38,16 +38,16 @@ export function ChatSidebar(props: {
           className={css.sidebarSearch}
           value={props.searchQuery}
           onChange={(event) => props.onSearchQueryChange(event.target.value)}
-          placeholder="Search titles"
-          aria-label="Search conversations by title"
+          placeholder="Search"
+          aria-label="Search conversations"
         />
       </div>
       {props.isLoading && isSearching ? (
-        <div className={css.sidebarStatus}>Searching titles...</div>
+        <div className={css.sidebarStatus}>Searching...</div>
       ) : props.sessions.length > 0 ? (
         <>
           <div className={css.sidebarLabel}>
-            {isSearching ? 'Matches' : 'Recent'}
+            {isSearching ? 'Search Results' : 'Recent'}
           </div>
           <ul className={css.sessionList} aria-live="polite">
             {props.sessions.map((s) => (
@@ -67,6 +67,11 @@ export function ChatSidebar(props: {
                   <span className={css.sessionTitle}>
                     {s.title || 'Untitled'}
                   </span>
+                  {s.searchSnippet ? (
+                    <span className={css.sessionSnippet}>
+                      {s.searchSnippet}
+                    </span>
+                  ) : null}
                   <span className={css.sessionTime}>
                     {formatRelativeTime(s.lastActive)}
                   </span>
@@ -76,7 +81,7 @@ export function ChatSidebar(props: {
           </ul>
         </>
       ) : isSearching ? (
-        <div className={css.sidebarStatus}>No conversation titles match.</div>
+        <div className={css.sidebarStatus}>No matching conversations.</div>
       ) : null}
     </>
   );

--- a/console/src/routes/chat/chat-sidebar.tsx
+++ b/console/src/routes/chat/chat-sidebar.tsx
@@ -8,7 +8,13 @@ export function ChatSidebar(props: {
   activeSessionId: string;
   onNewChat: () => void;
   onOpenSession: (sessionId: string) => void;
+  searchQuery: string;
+  onSearchQueryChange: (value: string) => void;
+  isLoading: boolean;
 }) {
+  const trimmedSearch = props.searchQuery.trim();
+  const isSearching = trimmedSearch.length > 0;
+
   return (
     <>
       <div className={css.sidebarHeader}>
@@ -26,9 +32,23 @@ export function ChatSidebar(props: {
       >
         + New Conversation
       </button>
-      {props.sessions.length > 0 ? (
+      <div className={css.sidebarSearchWrap}>
+        <input
+          type="search"
+          className={css.sidebarSearch}
+          value={props.searchQuery}
+          onChange={(event) => props.onSearchQueryChange(event.target.value)}
+          placeholder="Search titles"
+          aria-label="Search conversations by title"
+        />
+      </div>
+      {props.isLoading && isSearching ? (
+        <div className={css.sidebarStatus}>Searching titles...</div>
+      ) : props.sessions.length > 0 ? (
         <>
-          <div className={css.sidebarLabel}>Recent</div>
+          <div className={css.sidebarLabel}>
+            {isSearching ? 'Matches' : 'Recent'}
+          </div>
           <ul className={css.sessionList} aria-live="polite">
             {props.sessions.map((s) => (
               <li key={s.sessionId}>
@@ -55,6 +75,8 @@ export function ChatSidebar(props: {
             ))}
           </ul>
         </>
+      ) : isSearching ? (
+        <div className={css.sidebarStatus}>No conversation titles match.</div>
       ) : null}
     </>
   );

--- a/docs/chat.html
+++ b/docs/chat.html
@@ -1439,8 +1439,7 @@
 
     const urlParams = new URLSearchParams(window.location.search);
     const queryToken = urlParams.get('token') || '';
-    const MAX_RECENT_SESSIONS = 10;
-    const MAX_SEARCH_RESULTS = 50;
+    const CHAT_UI_CONFIG_URL = '/static/chat-ui-config.json';
     const SEND_ICON = `
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <path d="M12 19V5"></path>
@@ -1540,6 +1539,20 @@
       };
     }
 
+    async function loadChatUiConfig() {
+      if (!chatUiConfigPromise) {
+        chatUiConfigPromise = fetch(CHAT_UI_CONFIG_URL, {
+          cache: 'no-store',
+        }).then(async (response) => {
+          if (!response.ok) {
+            throw new Error(`Failed to load chat UI config (${response.status})`);
+          }
+          return response.json();
+        });
+      }
+      return chatUiConfigPromise;
+    }
+
     const initialStoredSessionId = localStorage.getItem('hybridclaw_session');
     let activeSessionId = resolveStoredSessionId(initialStoredSessionId, {
       allowGenerate: false,
@@ -1558,6 +1571,7 @@
     let recentSessions = [];
     let recentSearchQuery = '';
     let recentSearchTimer = 0;
+    let chatUiConfigPromise = null;
     const apiToken = queryToken || localStorage.getItem('hybridclaw_token') || '';
     let pendingMedia = [];
     let pendingUploadCount = 0;
@@ -2191,11 +2205,16 @@
 
     async function refreshRecentSessions() {
       try {
+        const chatUiConfig = await loadChatUiConfig();
         const trimmedQuery = String(recentSearchQuery || '').trim();
         const params = new URLSearchParams({
           userId: activeUserId,
           channelId: 'web',
-          limit: String(trimmedQuery ? MAX_SEARCH_RESULTS : MAX_RECENT_SESSIONS),
+          limit: String(
+            trimmedQuery
+              ? chatUiConfig.maxSearchResults
+              : chatUiConfig.maxRecentSessions,
+          ),
         });
         if (trimmedQuery) {
           params.set('q', trimmedQuery);

--- a/docs/chat.html
+++ b/docs/chat.html
@@ -163,6 +163,34 @@
       min-height: 0;
     }
 
+    .sidebar-search-wrap {
+      display: grid;
+      gap: 6px;
+      margin-top: 4px;
+    }
+
+    .sidebar-search {
+      width: 100%;
+      border: 1px solid #d9e0ea;
+      border-radius: 12px;
+      background: rgba(255, 255, 255, 0.82);
+      color: #374151;
+      font: inherit;
+      font-size: 14px;
+      padding: 10px 12px;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .sidebar-search::placeholder {
+      color: #8b98ab;
+    }
+
+    .sidebar-search:focus {
+      outline: none;
+      border-color: #a8b8d8;
+      box-shadow: 0 0 0 3px rgba(134, 159, 210, 0.18);
+    }
+
     .sidebar-section-title {
       padding: 4px 2px 0;
       font-size: 11px;
@@ -248,6 +276,14 @@
       white-space: nowrap;
     }
 
+    .chat-session-snippet {
+      font-size: 12px;
+      color: #6f7a8c;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
     .sidebar-empty {
       padding: 2px 2px 0;
       font-size: 13px;
@@ -267,6 +303,10 @@
     }
 
     .layout.is-sidebar-collapsed .sidebar-session-list-wrap {
+      display: none;
+    }
+
+    .layout.is-sidebar-collapsed .sidebar-search-wrap {
       display: none;
     }
 
@@ -1270,6 +1310,15 @@
         <span class="new-chat-icon">+</span>
         <span class="new-chat-label">New Conversation</span>
       </button>
+      <div class="sidebar-search-wrap">
+        <input
+          id="recentSearch"
+          type="search"
+          class="sidebar-search"
+          placeholder="Search"
+          aria-label="Search conversations"
+        >
+      </div>
       <section class="sidebar-session-list-wrap" aria-labelledby="recentChatsLabel">
         <div id="recentChatsLabel" class="sidebar-section-title">Recent chats</div>
         <div id="recentSessions" class="sidebar-nav" aria-live="polite"></div>
@@ -1379,6 +1428,8 @@
     const messageEl = document.getElementById('message');
     const messagesEl = document.getElementById('messages');
     const recentSessionsEl = document.getElementById('recentSessions');
+    const recentSearchEl = document.getElementById('recentSearch');
+    const recentChatsLabelEl = document.getElementById('recentChatsLabel');
     const errorEl = document.getElementById('error');
     const sendEl = document.getElementById('send');
     const attachEl = document.getElementById('attach');
@@ -1389,6 +1440,7 @@
     const urlParams = new URLSearchParams(window.location.search);
     const queryToken = urlParams.get('token') || '';
     const MAX_RECENT_SESSIONS = 10;
+    const MAX_SEARCH_RESULTS = 50;
     const SEND_ICON = `
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <path d="M12 19V5"></path>
@@ -1476,11 +1528,13 @@
       const sessionId = String(entry?.sessionId || '').trim();
       if (!sessionId) return null;
       const title = String(entry?.title || '').trim() || 'Untitled chat';
+      const searchSnippet = String(entry?.searchSnippet || '').trim();
       const lastActive = String(entry?.lastActive || '').trim();
       const messageCount = Number(entry?.messageCount);
       return {
         sessionId,
         title,
+        searchSnippet,
         lastActive,
         messageCount: Number.isFinite(messageCount) ? messageCount : 0,
       };
@@ -1502,6 +1556,8 @@
       lastSessionNumber = activeSessionNumber;
     }
     let recentSessions = [];
+    let recentSearchQuery = '';
+    let recentSearchTimer = 0;
     const apiToken = queryToken || localStorage.getItem('hybridclaw_token') || '';
     let pendingMedia = [];
     let pendingUploadCount = 0;
@@ -2084,11 +2140,18 @@
 
     function renderRecentSessions() {
       if (!recentSessionsEl) return;
+      if (recentChatsLabelEl) {
+        recentChatsLabelEl.textContent = recentSearchQuery
+          ? 'Search results'
+          : 'Recent chats';
+      }
       recentSessionsEl.innerHTML = '';
       if (recentSessions.length === 0) {
         const empty = document.createElement('div');
         empty.className = 'sidebar-empty';
-        empty.textContent = 'No recent chats yet.';
+        empty.textContent = recentSearchQuery
+          ? 'No matching chats.'
+          : 'No recent chats yet.';
         recentSessionsEl.appendChild(empty);
         return;
       }
@@ -2106,6 +2169,13 @@
         title.textContent = session.title || 'Untitled chat';
         copy.appendChild(title);
 
+        if (session.searchSnippet) {
+          const snippet = document.createElement('span');
+          snippet.className = 'chat-session-snippet';
+          snippet.textContent = session.searchSnippet;
+          copy.appendChild(snippet);
+        }
+
         const meta = document.createElement('span');
         meta.className = 'chat-session-meta';
         meta.textContent = formatRelativeTime(session.lastActive);
@@ -2121,11 +2191,15 @@
 
     async function refreshRecentSessions() {
       try {
+        const trimmedQuery = String(recentSearchQuery || '').trim();
         const params = new URLSearchParams({
           userId: activeUserId,
           channelId: 'web',
-          limit: String(MAX_RECENT_SESSIONS),
+          limit: String(trimmedQuery ? MAX_SEARCH_RESULTS : MAX_RECENT_SESSIONS),
         });
+        if (trimmedQuery) {
+          params.set('q', trimmedQuery);
+        }
         const payload = await requestJson(`/api/chat/recent?${params.toString()}`, {
           method: 'GET',
           headers: apiHeaders(),
@@ -2139,6 +2213,16 @@
         recentSessions = [];
       }
       renderRecentSessions();
+    }
+
+    function scheduleRefreshRecentSessions() {
+      if (recentSearchTimer) {
+        window.clearTimeout(recentSearchTimer);
+      }
+      recentSearchTimer = window.setTimeout(() => {
+        recentSearchTimer = 0;
+        void refreshRecentSessions();
+      }, 160);
     }
 
     function autoResizeTextarea() {
@@ -3983,6 +4067,12 @@
     attachmentInputEl.addEventListener('change', () => {
       void uploadSelectedFiles(attachmentInputEl.files);
     });
+    if (recentSearchEl) {
+      recentSearchEl.addEventListener('input', (event) => {
+        recentSearchQuery = String(event.target?.value || '').trim();
+        scheduleRefreshRecentSessions();
+      });
+    }
     document.getElementById('newChat').addEventListener('click', newChat);
     const sidebarToggleBtn = document.getElementById('sidebarToggle');
     const mobileSidebarMedia = window.matchMedia('(max-width: 900px)');

--- a/docs/static/chat-ui-config.json
+++ b/docs/static/chat-ui-config.json
@@ -1,0 +1,4 @@
+{
+  "maxRecentSessions": 10,
+  "maxSearchResults": 50
+}

--- a/src/agents/agent-registry.ts
+++ b/src/agents/agent-registry.ts
@@ -16,7 +16,11 @@ import {
   isDatabaseInitialized,
 } from '../memory/db.js';
 import type { Session } from '../types/session.js';
-import { normalizeOptionalTrimmedUniqueStringArray } from '../utils/normalized-strings.js';
+import {
+  normalizeNullableTrimmedString as normalizeNullableString,
+  normalizeOptionalTrimmedUniqueStringArray,
+  normalizeTrimmedString as normalizeString,
+} from '../utils/normalized-strings.js';
 import {
   type AgentConfig,
   type AgentDefaultsConfig,
@@ -57,15 +61,6 @@ function resetRegistryState(): void {
 }
 
 resetRegistryState();
-
-function normalizeString(value: unknown): string {
-  return typeof value === 'string' ? value.trim() : '';
-}
-
-function normalizeNullableString(value: unknown): string | null {
-  if (typeof value !== 'string') return null;
-  return value.trim();
-}
 
 function cloneModelConfig(
   value: AgentModelConfig | undefined,

--- a/src/auth/codex-auth.ts
+++ b/src/auth/codex-auth.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 import readline from 'node:readline/promises';
 import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
 import { CODEX_DEFAULT_BASE_URL } from '../providers/codex-constants.js';
+import { normalizeTrimmedString as normalizeString } from '../utils/normalized-strings.js';
 import { sleep } from '../utils/sleep.js';
 
 export const CODEX_AUTH_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
@@ -136,10 +137,6 @@ export class CodexAuthError extends Error {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function normalizeString(value: unknown): string {
-  return typeof value === 'string' ? value.trim() : '';
 }
 
 function normalizeTimestamp(value: unknown): number {

--- a/src/channels/discord/prompt-adapter.ts
+++ b/src/channels/discord/prompt-adapter.ts
@@ -1,8 +1,5 @@
+import { normalizeTrimmedString as trimValue } from '../../utils/normalized-strings.js';
 import type { ChannelAgentPromptAdapter } from '../prompt-adapters.js';
-
-function trimValue(value: string | null | undefined): string {
-  return String(value || '').trim();
-}
 
 export const discordAgentPromptAdapter: ChannelAgentPromptAdapter = {
   messageToolHints: ({ runtimeInfo }) => {

--- a/src/channels/email/metadata.ts
+++ b/src/channels/email/metadata.ts
@@ -1,4 +1,5 @@
 import type { TokenUsageStats } from '../../types/usage.js';
+import { normalizeNullableTrimmedString as trimString } from '../../utils/normalized-strings.js';
 
 export type EmailDeliveryTokenSource = 'api' | 'estimated';
 
@@ -21,11 +22,6 @@ const EMAIL_METADATA_HEADERS = {
   totalTokens: 'X-HybridClaw-Total-Tokens',
   tokenSource: 'X-HybridClaw-Token-Source',
 } as const;
-
-function trimString(value: unknown): string | null {
-  const trimmed = typeof value === 'string' ? value.trim() : '';
-  return trimmed || null;
-}
 
 function normalizeTokenCount(value: unknown): number | null {
   if (typeof value === 'number' && Number.isFinite(value)) {

--- a/src/channels/email/prompt-adapter.ts
+++ b/src/channels/email/prompt-adapter.ts
@@ -1,8 +1,5 @@
+import { normalizeTrimmedString as trimValue } from '../../utils/normalized-strings.js';
 import type { ChannelAgentPromptAdapter } from '../prompt-adapters.js';
-
-function trimValue(value: string | null | undefined): string {
-  return String(value || '').trim();
-}
 
 export const emailAgentPromptAdapter: ChannelAgentPromptAdapter = {
   messageToolHints: ({ runtimeInfo }) => {

--- a/src/channels/imessage/prompt-adapter.ts
+++ b/src/channels/imessage/prompt-adapter.ts
@@ -1,9 +1,6 @@
+import { normalizeTrimmedString as trimValue } from '../../utils/normalized-strings.js';
 import type { ChannelAgentPromptAdapter } from '../prompt-adapters.js';
 import { isIMessageGroupHandle, parseIMessageChannelId } from './handle.js';
-
-function trimValue(value: string | null | undefined): string {
-  return String(value || '').trim();
-}
 
 export const imessageAgentPromptAdapter: ChannelAgentPromptAdapter = {
   messageToolHints: ({ runtimeInfo }) => {

--- a/src/channels/msteams/prompt-adapter.ts
+++ b/src/channels/msteams/prompt-adapter.ts
@@ -1,8 +1,5 @@
+import { normalizeTrimmedString as trimValue } from '../../utils/normalized-strings.js';
 import type { ChannelAgentPromptAdapter } from '../prompt-adapters.js';
-
-function trimValue(value: string | null | undefined): string {
-  return String(value || '').trim();
-}
 
 export const msteamsAgentPromptAdapter: ChannelAgentPromptAdapter = {
   messageToolHints: ({ runtimeInfo }) => {

--- a/src/channels/msteams/utils.ts
+++ b/src/channels/msteams/utils.ts
@@ -1,16 +1,18 @@
+import {
+  normalizeNullableTrimmedString,
+  normalizeTrimmedString as normalizeValue,
+} from '../../utils/normalized-strings.js';
+
 export const MSTEAMS_CONVERSATION_REFERENCE_KEY =
   'msteams:conversation-reference';
-
-export function normalizeValue(value: string | null | undefined): string {
-  return String(value || '').trim();
-}
+export { normalizeValue };
 
 export function normalizeOptionalValue(value: unknown): string | null {
   const normalized =
     typeof value === 'string' || typeof value === 'number'
       ? normalizeValue(String(value))
       : '';
-  return normalized || null;
+  return normalizeNullableTrimmedString(normalized);
 }
 
 export function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/channels/prompt-adapters.ts
+++ b/src/channels/prompt-adapters.ts
@@ -1,3 +1,4 @@
+import { normalizeTrimmedString as normalizeValue } from '../utils/normalized-strings.js';
 import type { ChannelInfo } from './channel.js';
 import {
   getChannel,
@@ -24,10 +25,6 @@ export type ChannelAgentPromptAdapter = {
     runtimeInfo?: ChannelPromptRuntimeInfo;
   }) => string[];
 };
-
-function normalizeValue(value: string | null | undefined): string {
-  return String(value || '').trim();
-}
 
 function resolveRuntimeChannel(
   runtimeInfo?: ChannelPromptRuntimeInfo,

--- a/src/channels/telegram/prompt-adapter.ts
+++ b/src/channels/telegram/prompt-adapter.ts
@@ -1,9 +1,6 @@
+import { normalizeTrimmedString as trimValue } from '../../utils/normalized-strings.js';
 import type { ChannelAgentPromptAdapter } from '../prompt-adapters.js';
 import { resolveTelegramTargetChatType } from './target.js';
-
-function trimValue(value: string | null | undefined): string {
-  return String(value || '').trim();
-}
 
 export const telegramAgentPromptAdapter: ChannelAgentPromptAdapter = {
   messageToolHints: ({ runtimeInfo }) => {

--- a/src/channels/whatsapp/message-store.ts
+++ b/src/channels/whatsapp/message-store.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import { proto, type WAMessageKey } from '@whiskeysockets/baileys';
 import { logger } from '../../logger.js';
+import { normalizeTrimmedString as normalizeString } from '../../utils/normalized-strings.js';
 import { WHATSAPP_AUTH_DIR } from './auth.js';
 
 const MESSAGE_STORE_FILE = 'message-store.json';
@@ -33,10 +34,6 @@ export interface WhatsAppMessageStore {
     message: proto.IWebMessageInfo | null | undefined,
   ) => Promise<void>;
   clear: () => Promise<void>;
-}
-
-function normalizeString(value: unknown): string {
-  return typeof value === 'string' ? value.trim() : '';
 }
 
 function buildLookupKey(params: {

--- a/src/channels/whatsapp/prompt-adapter.ts
+++ b/src/channels/whatsapp/prompt-adapter.ts
@@ -1,9 +1,6 @@
+import { normalizeTrimmedString as trimValue } from '../../utils/normalized-strings.js';
 import type { ChannelAgentPromptAdapter } from '../prompt-adapters.js';
 import { isGroupJid } from './phone.js';
-
-function trimValue(value: string | null | undefined): string {
-  return String(value || '').trim();
-}
 
 export const whatsappAgentPromptAdapter: ChannelAgentPromptAdapter = {
   messageToolHints: ({ runtimeInfo }) => {

--- a/src/evals/eval-profile.ts
+++ b/src/evals/eval-profile.ts
@@ -3,6 +3,7 @@ import {
   type PromptPartName,
 } from '../agent/prompt-hooks.js';
 import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
+import { normalizeTrimmedString as normalizeString } from '../utils/normalized-strings.js';
 
 export type EvalWorkspaceMode = 'current-agent' | 'fresh-agent';
 
@@ -18,10 +19,6 @@ export const EVAL_MODEL_PROFILE_MARKER = '__hc_eval=';
 
 const KNOWN_FLAGS = new Set(['current-agent', 'fresh-agent', 'ablate-system']);
 const KNOWN_PROMPT_PARTS = new Set<PromptPartName>(PROMPT_PART_NAMES);
-
-function normalizeString(value: string | null | undefined): string {
-  return String(value || '').trim();
-}
 
 function normalizeAgentId(agentId: string | null | undefined): string {
   return normalizeString(agentId);

--- a/src/gateway/auth-token.ts
+++ b/src/gateway/auth-token.ts
@@ -204,15 +204,22 @@ export function verifyLaunchToken(token: string): VerifiedAuthTokenPayload {
   return requireVerifiedToken(token);
 }
 
-export function hasSessionAuth(req: IncomingMessage): boolean {
+export function getSessionAuthPayload(
+  req: IncomingMessage,
+): VerifiedAuthTokenPayload | null {
   const token = extractCookieValue(req.headers.cookie, SESSION_COOKIE_NAME);
-  if (!token) return false;
+  if (!token) return null;
 
   try {
-    return requireVerifiedToken(token).typ === 'session';
+    const payload = requireVerifiedToken(token);
+    return payload.typ === 'session' ? payload : null;
   } catch {
-    return false;
+    return null;
   }
+}
+
+export function hasSessionAuth(req: IncomingMessage): boolean {
+  return getSessionAuthPayload(req) !== null;
 }
 
 export function setSessionCookie(

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -1750,6 +1750,7 @@ function handleApiChatRecent(res: ServerResponse, url: URL): void {
     return;
   }
   const channelId = (url.searchParams.get('channelId') || 'web').trim();
+  const query = (url.searchParams.get('q') || '').trim();
   const parsedLimit = parseInt(url.searchParams.get('limit') || '10', 10);
   const limit = Number.isNaN(parsedLimit) ? 10 : parsedLimit;
   sendJson(res, 200, {
@@ -1757,6 +1758,7 @@ function handleApiChatRecent(res: ServerResponse, url: URL): void {
       userId,
       channelId,
       limit,
+      query,
     }),
   });
 }

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -1794,14 +1794,7 @@ function handleApiChatRecent(
   url: URL,
 ): void {
   const channelId = (url.searchParams.get('channelId') || 'web').trim();
-  const sessionUserId = resolveSessionAuthenticatedUserId(req);
   const query = normalizeRecentChatSearchQuery(url.searchParams.get('q'));
-  if (query && channelId.toLowerCase() === 'web' && !sessionUserId) {
-    sendJson(res, 401, {
-      error: 'Web chat search requires a signed session.',
-    });
-    return;
-  }
   const userId = resolveGatewayRequestUserId({
     req,
     channelId,

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -1758,7 +1758,7 @@ function handleApiChatRecent(res: ServerResponse, url: URL): void {
       userId,
       channelId,
       limit,
-      query,
+      ...(query ? { query } : {}),
     }),
   });
 }

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -58,6 +58,10 @@ import { memoryService } from '../memory/memory-service.js';
 import { listLoadedPluginCommands } from '../plugins/plugin-manager.js';
 import { isPluginInboundWebhookPath } from '../plugins/plugin-webhooks.js';
 import {
+  normalizeRecentChatSearchQuery,
+  normalizeRecentChatSessionLimit,
+} from '../session/recent-chat-search.js';
+import {
   buildSessionKey,
   classifySessionKeyShape,
 } from '../session/session-key.js';
@@ -67,7 +71,10 @@ import {
 } from '../tui-slash-menu.js';
 import type { MediaContextItem } from '../types/container.js';
 import type { PendingApproval, ToolProgressEvent } from '../types/execution.js';
-import { normalizeTrimmedUniqueStringArray } from '../utils/normalized-strings.js';
+import {
+  normalizeOptionalTrimmedString as normalizeOptionalString,
+  normalizeTrimmedUniqueStringArray,
+} from '../utils/normalized-strings.js';
 import {
   AdminTerminalCapacityError,
   type AdminTerminalStartOptions,
@@ -75,6 +82,7 @@ import {
 } from './admin-terminal.js';
 import type { AdminTerminalServerMessage } from './admin-terminal-protocol.js';
 import {
+  getSessionAuthPayload,
   hasSessionAuth,
   setSessionCookie,
   verifyLaunchToken,
@@ -323,11 +331,6 @@ type ApiPluginToolRequestBody = {
   sessionId?: unknown;
   channelId?: unknown;
 };
-
-function normalizeOptionalString(value: unknown): string | undefined {
-  const normalized = typeof value === 'string' ? value.trim() : '';
-  return normalized || undefined;
-}
 
 function parseApiAdminPolicyIndex(value: unknown): number {
   const parsed = parsePositiveInteger(value);
@@ -743,6 +746,35 @@ function ensureSessionAuth(req: IncomingMessage, res: ServerResponse): boolean {
 
   sendRedirect(res, 302, loginUrl);
   return false;
+}
+
+function resolveSessionAuthenticatedUserId(
+  req: IncomingMessage,
+): string | undefined {
+  const payload = getSessionAuthPayload(req);
+  return normalizeOptionalString(payload?.sub);
+}
+
+function resolveGatewayRequestUserId(params: {
+  req: IncomingMessage;
+  channelId?: string | null;
+  requestedUserId?: string | null;
+  fallbackUserId?: string | null;
+}): string | undefined {
+  const channelId = String(params.channelId || '')
+    .trim()
+    .toLowerCase();
+  if (channelId === 'web') {
+    return (
+      resolveSessionAuthenticatedUserId(params.req) ||
+      normalizeOptionalString(params.requestedUserId) ||
+      normalizeOptionalString(params.fallbackUserId)
+    );
+  }
+  return (
+    normalizeOptionalString(params.requestedUserId) ||
+    normalizeOptionalString(params.fallbackUserId)
+  );
 }
 
 function isWithinRoot(candidate: string, root: string): boolean {
@@ -1210,6 +1242,7 @@ async function handleApiChat(
     sendJson(res, 400, { error: 'Malformed canonical `sessionId`.' });
     return;
   }
+  const channelId = body.channelId || 'web';
   const chatRequest: GatewayChatRequest = {
     sessionId,
     sessionMode:
@@ -1217,8 +1250,14 @@ async function handleApiChat(
         ? body.sessionMode
         : undefined,
     guildId: body.guildId ?? null,
-    channelId: body.channelId || 'web',
-    userId: normalizeOptionalString(body.userId) || sessionId,
+    channelId,
+    userId:
+      resolveGatewayRequestUserId({
+        req,
+        channelId,
+        requestedUserId: normalizeOptionalString(body.userId),
+        fallbackUserId: sessionId,
+      }) || sessionId,
     username: body.username ?? 'web',
     content,
     ...(media.length > 0 ? { media } : {}),
@@ -1548,7 +1587,13 @@ async function handleApiCommand(
     guildId: body.guildId ?? null,
     channelId: body.channelId || 'web',
     args,
-    userId: normalizeOptionalString(body.userId) || sessionId,
+    userId:
+      resolveGatewayRequestUserId({
+        req,
+        channelId: body.channelId || 'web',
+        requestedUserId: normalizeOptionalString(body.userId),
+        fallbackUserId: sessionId,
+      }) || sessionId,
     username: body.username ?? null,
   };
   const result = await handleGatewayCommand(commandRequest);
@@ -1743,16 +1788,33 @@ function handleApiAgentAvatar(
   });
 }
 
-function handleApiChatRecent(res: ServerResponse, url: URL): void {
-  const userId = (url.searchParams.get('userId') || '').trim();
+function handleApiChatRecent(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL,
+): void {
+  const channelId = (url.searchParams.get('channelId') || 'web').trim();
+  const sessionUserId = resolveSessionAuthenticatedUserId(req);
+  const query = normalizeRecentChatSearchQuery(url.searchParams.get('q'));
+  if (query && channelId.toLowerCase() === 'web' && !sessionUserId) {
+    sendJson(res, 401, {
+      error: 'Web chat search requires a signed session.',
+    });
+    return;
+  }
+  const userId = resolveGatewayRequestUserId({
+    req,
+    channelId,
+    requestedUserId: url.searchParams.get('userId'),
+  });
   if (!userId) {
     sendJson(res, 400, { error: 'Missing `userId` query parameter.' });
     return;
   }
-  const channelId = (url.searchParams.get('channelId') || 'web').trim();
-  const query = (url.searchParams.get('q') || '').trim();
   const parsedLimit = parseInt(url.searchParams.get('limit') || '10', 10);
-  const limit = Number.isNaN(parsedLimit) ? 10 : parsedLimit;
+  const limit = normalizeRecentChatSessionLimit(
+    Number.isNaN(parsedLimit) ? undefined : parsedLimit,
+  );
   sendJson(res, 200, {
     sessions: getGatewayRecentChatSessions({
       userId,
@@ -3322,6 +3384,9 @@ export function startGatewayHttpServer(): GatewayHttpServer {
             /</g,
             '\\u003c',
           );
+          const escapedUserId = JSON.stringify(
+            normalizeOptionalString(payload.sub) || '',
+          ).replace(/</g, '\\u003c');
           res.writeHead(200, {
             'Content-Type': 'text/html; charset=utf-8',
             'Cache-Control': 'no-store',
@@ -3332,6 +3397,7 @@ export function startGatewayHttpServer(): GatewayHttpServer {
           res.end(
             `<!DOCTYPE html><html><body><script>` +
               `localStorage.setItem('hybridclaw_token',${escaped});` +
+              `if (${escapedUserId}) localStorage.setItem('hybridclaw_user_id',${escapedUserId});` +
               `window.location.replace(${escapedRedirect});` +
               `</script></body></html>`,
           );
@@ -3554,7 +3620,7 @@ export function startGatewayHttpServer(): GatewayHttpServer {
             return;
           }
           if (pathname === '/api/chat/recent' && method === 'GET') {
-            handleApiChatRecent(res, url);
+            handleApiChatRecent(req, res, url);
             return;
           }
           if (pathname === '/api/chat/commands' && method === 'GET') {

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -5852,11 +5852,13 @@ export function getGatewayRecentChatSessions(params: {
   userId: string;
   channelId?: string | null;
   limit?: number;
+  query?: string | null;
 }): GatewayRecentChatSession[] {
   return getRecentSessionsForUser({
     userId: params.userId,
     channelId: params.channelId || 'web',
     limit: params.limit,
+    query: params.query,
   });
 }
 

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -295,6 +295,7 @@ export interface GatewayChatBranchResponse {
 export interface GatewayRecentChatSession {
   sessionId: string;
   title: string | null;
+  searchSnippet?: string | null;
   lastActive: string;
   messageCount: number;
 }

--- a/src/gateway/openai-compatible-request.ts
+++ b/src/gateway/openai-compatible-request.ts
@@ -3,6 +3,7 @@ import type { IncomingMessage } from 'node:http';
 import net from 'node:net';
 import type { ChatMessage, ToolCall } from '../types/api.js';
 import type { MediaContextItem } from '../types/container.js';
+import { normalizeOptionalTrimmedString as normalizeOptionalString } from '../utils/normalized-strings.js';
 import type {
   OpenAICompatibleToolChoice,
   OpenAICompatibleToolDefinition,
@@ -90,11 +91,6 @@ export class OpenAICompatibleRequestError extends Error {
     this.param = options?.param;
     this.code = options?.code;
   }
-}
-
-function normalizeOptionalString(value: unknown): string | undefined {
-  const normalized = typeof value === 'string' ? value.trim() : '';
-  return normalized || undefined;
 }
 
 async function readRequestBody(req: IncomingMessage): Promise<Buffer> {

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -4125,14 +4125,72 @@ interface RecentSessionBoundaryRow {
   last_role: string | null;
 }
 
+const RECENT_SESSION_BOUNDARY_BATCH_SIZE = 400;
+
+function getRecentSessionBoundaryRows(
+  sessionIds: string[],
+  userId: string,
+): RecentSessionBoundaryRow[] {
+  const rows: RecentSessionBoundaryRow[] = [];
+
+  for (
+    let index = 0;
+    index < sessionIds.length;
+    index += RECENT_SESSION_BOUNDARY_BATCH_SIZE
+  ) {
+    const batch = sessionIds.slice(
+      index,
+      index + RECENT_SESSION_BOUNDARY_BATCH_SIZE,
+    );
+    const placeholders = batch.map(() => '?').join(', ');
+    rows.push(
+      ...queryAll<RecentSessionBoundaryRow>(
+        db,
+        `WITH ranked AS (
+           SELECT
+             session_id,
+             role,
+             content,
+             CASE WHEN role = 'user' AND user_id = ? THEN 1 ELSE 0 END AS is_target_user,
+             ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY id ASC) AS rn_first,
+             ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY id DESC) AS rn_last,
+             ROW_NUMBER() OVER (
+               PARTITION BY session_id, CASE WHEN role = 'user' AND user_id = ? THEN 1 ELSE 0 END
+               ORDER BY id ASC
+             ) AS rn_target_group
+           FROM messages
+           WHERE session_id IN (${placeholders})
+         )
+         SELECT
+           session_id,
+           MAX(CASE WHEN is_target_user = 1 AND rn_target_group = 1 THEN content END) AS first_user_content,
+           MAX(CASE WHEN rn_first = 1 THEN content END) AS first_content,
+           MAX(CASE WHEN rn_last = 1 THEN content END) AS last_content,
+           MAX(CASE WHEN rn_last = 1 THEN role END) AS last_role
+         FROM ranked
+         GROUP BY session_id`,
+        userId,
+        userId,
+        ...batch,
+      ),
+    );
+  }
+
+  return rows;
+}
+
 export function getRecentSessionsForUser(params: {
   userId: string;
   channelId?: string | null;
   limit?: number;
+  query?: string | null;
 }): RecentUserSessionSummary[] {
   const userId = params.userId.trim();
   if (!userId) return [];
   const channelId = String(params.channelId || '').trim();
+  const titleQuery = String(params.query || '')
+    .trim()
+    .toLowerCase();
   const limit =
     typeof params.limit === 'number' && Number.isFinite(params.limit)
       ? Math.max(1, Math.floor(params.limit))
@@ -4160,53 +4218,26 @@ export function getRecentSessionsForUser(params: {
         userId,
       );
 
-  const targetRows = rows
-    .sort((left, right) => {
-      const rightTimestamp = parseTimestamp(right.last_active);
-      const leftTimestamp = parseTimestamp(left.last_active);
-      if (rightTimestamp !== leftTimestamp) {
-        return rightTimestamp - leftTimestamp;
-      }
-      return right.id.localeCompare(left.id);
-    })
-    .slice(0, limit);
+  const sortedRows = rows.sort((left, right) => {
+    const rightTimestamp = parseTimestamp(right.last_active);
+    const leftTimestamp = parseTimestamp(left.last_active);
+    if (rightTimestamp !== leftTimestamp) {
+      return rightTimestamp - leftTimestamp;
+    }
+    return right.id.localeCompare(left.id);
+  });
+  const targetRows = titleQuery ? sortedRows : sortedRows.slice(0, limit);
   if (targetRows.length === 0) return [];
 
-  const placeholders = targetRows.map(() => '?').join(', ');
-  const boundaryRows = queryAll<RecentSessionBoundaryRow>(
-    db,
-    `WITH ranked AS (
-       SELECT
-         session_id,
-         role,
-         content,
-         CASE WHEN role = 'user' AND user_id = ? THEN 1 ELSE 0 END AS is_target_user,
-         ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY id ASC) AS rn_first,
-         ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY id DESC) AS rn_last,
-         ROW_NUMBER() OVER (
-           PARTITION BY session_id, CASE WHEN role = 'user' AND user_id = ? THEN 1 ELSE 0 END
-           ORDER BY id ASC
-         ) AS rn_target_group
-       FROM messages
-       WHERE session_id IN (${placeholders})
-     )
-     SELECT
-       session_id,
-       MAX(CASE WHEN is_target_user = 1 AND rn_target_group = 1 THEN content END) AS first_user_content,
-       MAX(CASE WHEN rn_first = 1 THEN content END) AS first_content,
-       MAX(CASE WHEN rn_last = 1 THEN content END) AS last_content,
-       MAX(CASE WHEN rn_last = 1 THEN role END) AS last_role
-     FROM ranked
-     GROUP BY session_id`,
+  const boundaryRows = getRecentSessionBoundaryRows(
+    targetRows.map((row) => row.id),
     userId,
-    userId,
-    ...targetRows.map((row) => row.id),
   );
   const boundariesBySessionId = new Map(
     boundaryRows.map((row) => [row.session_id, row] as const),
   );
 
-  return targetRows.map((row) => {
+  const sessions = targetRows.map((row) => {
     const boundary = boundariesBySessionId.get(row.id);
     const firstMessage =
       boundary?.first_user_content || boundary?.first_content || null;
@@ -4232,6 +4263,15 @@ export function getRecentSessionsForUser(params: {
       }),
     };
   });
+
+  if (!titleQuery) return sessions;
+  return sessions
+    .filter((session) =>
+      String(session.title || '')
+        .toLowerCase()
+        .includes(titleQuery),
+    )
+    .slice(0, limit);
 }
 
 export function getFullAutoSessionCount(): number {

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -4328,10 +4328,9 @@ export function getRecentSessionsForUser(params: {
       lastActive: row.last_active,
       messageCount: normalizeUsageNumber(row.message_count),
       title,
-      searchSnippet:
-        rawSearchSnippet && !String(title || '').includes(rawSearchSnippet)
-          ? rawSearchSnippet
-          : null,
+      ...(rawSearchSnippet && !String(title || '').includes(rawSearchSnippet)
+        ? { searchSnippet: rawSearchSnippet }
+        : {}),
     };
   });
 

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -12,6 +12,12 @@ import {
 } from '../config/runtime-config.js';
 import { logger } from '../logger.js';
 import {
+  buildRecentChatSearchMatchQuery,
+  MAX_RECENT_CHAT_SESSION_LIMIT,
+  normalizeRecentChatSearchQuery,
+  normalizeRecentChatSessionLimit,
+} from '../session/recent-chat-search.js';
+import {
   buildSessionKey,
   classifySessionKeyShape,
   inspectSessionKeyMigration,
@@ -23,6 +29,7 @@ import {
   buildSessionBoundaryPreview,
   buildSessionSearchSnippet,
   RECENT_CHAT_SESSION_TITLE_MAX_LENGTH,
+  shouldIncludeSessionSearchSnippet,
 } from '../session/session-preview.js';
 import {
   evaluateSessionExpiry,
@@ -99,8 +106,15 @@ import {
 let db: Database.Database;
 let databaseInitialized = false;
 
-export const DATABASE_SCHEMA_VERSION = 18;
+export const DATABASE_SCHEMA_VERSION = 19;
 const STRUCTURED_AUDIT_SESSION_LIMIT = 10_000;
+const RECENT_CHAT_MESSAGE_SEARCH_TABLE = 'recent_chat_message_search';
+const RECENT_CHAT_MESSAGE_SEARCH_INSERT_TRIGGER =
+  'messages_recent_chat_search_ai';
+const RECENT_CHAT_MESSAGE_SEARCH_DELETE_TRIGGER =
+  'messages_recent_chat_search_ad';
+const RECENT_CHAT_MESSAGE_SEARCH_UPDATE_TRIGGER =
+  'messages_recent_chat_search_au';
 const STRUCTURED_AUDIT_SELECT_COLUMNS = [
   'id',
   'session_id',
@@ -257,6 +271,73 @@ function ensureSessionBranchesTable(database: Database.Database): void {
     );
     CREATE INDEX IF NOT EXISTS idx_session_branches_parent
       ON session_branches(parent_session_id, parent_message_id);
+  `);
+}
+
+function ensureRecentChatMessageSearchIndex(database: Database.Database): void {
+  if (!tableExists(database, 'messages')) {
+    return;
+  }
+
+  const needsBackfill = !tableExists(
+    database,
+    RECENT_CHAT_MESSAGE_SEARCH_TABLE,
+  );
+
+  try {
+    database.exec(`
+      CREATE VIRTUAL TABLE IF NOT EXISTS ${RECENT_CHAT_MESSAGE_SEARCH_TABLE}
+      USING fts5(
+        session_id UNINDEXED,
+        content,
+        tokenize='unicode61 remove_diacritics 2'
+      );
+
+      CREATE TRIGGER IF NOT EXISTS ${RECENT_CHAT_MESSAGE_SEARCH_INSERT_TRIGGER}
+      AFTER INSERT ON messages
+      BEGIN
+        INSERT INTO ${RECENT_CHAT_MESSAGE_SEARCH_TABLE} (
+          rowid,
+          session_id,
+          content
+        )
+        VALUES (new.id, new.session_id, new.content);
+      END;
+
+      CREATE TRIGGER IF NOT EXISTS ${RECENT_CHAT_MESSAGE_SEARCH_DELETE_TRIGGER}
+      AFTER DELETE ON messages
+      BEGIN
+        DELETE FROM ${RECENT_CHAT_MESSAGE_SEARCH_TABLE}
+        WHERE rowid = old.id;
+      END;
+
+      CREATE TRIGGER IF NOT EXISTS ${RECENT_CHAT_MESSAGE_SEARCH_UPDATE_TRIGGER}
+      AFTER UPDATE ON messages
+      BEGIN
+        DELETE FROM ${RECENT_CHAT_MESSAGE_SEARCH_TABLE}
+        WHERE rowid = old.id;
+        INSERT INTO ${RECENT_CHAT_MESSAGE_SEARCH_TABLE} (
+          rowid,
+          session_id,
+          content
+        )
+        VALUES (new.id, new.session_id, new.content);
+      END;
+    `);
+  } catch (error) {
+    throw new Error(
+      `Recent chat content search requires SQLite FTS5 support: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (!needsBackfill) {
+    return;
+  }
+
+  database.exec(`
+    INSERT INTO ${RECENT_CHAT_MESSAGE_SEARCH_TABLE} (rowid, session_id, content)
+    SELECT id, session_id, content
+    FROM messages;
   `);
 }
 
@@ -1623,6 +1704,15 @@ function migrateV18(
   recordMigration(database, 18, 'Persist per-agent skill allowlists');
 }
 
+function migrateV19(database: Database.Database): void {
+  ensureRecentChatMessageSearchIndex(database);
+  recordMigration(
+    database,
+    19,
+    'Index recent chat content search with SQLite FTS5',
+  );
+}
+
 function runMigrations(
   database: Database.Database,
   opts?: InitDatabaseOptions,
@@ -1662,6 +1752,7 @@ function runMigrations(
   if (currentVersion < 16) migrateV16(database);
   if (currentVersion < 17) migrateV17(database, opts);
   if (currentVersion < 18) migrateV18(database, opts);
+  if (currentVersion < 19) migrateV19(database);
 
   setSchemaVersion(database, DATABASE_SCHEMA_VERSION);
   if (!quiet && currentVersion < DATABASE_SCHEMA_VERSION) {
@@ -4134,11 +4225,11 @@ interface RecentSessionContentMatchRow {
 
 const RECENT_SESSION_BOUNDARY_BATCH_SIZE = 400;
 
-function getRecentSessionBoundaryRows(
+function batchQueryAllBySessionIds<Row>(
   sessionIds: string[],
-  userId: string,
-): RecentSessionBoundaryRow[] {
-  const rows: RecentSessionBoundaryRow[] = [];
+  queryBatch: (batch: string[], placeholders: string) => Row[],
+): Row[] {
+  const rows: Row[] = [];
 
   for (
     let index = 0;
@@ -4150,83 +4241,79 @@ function getRecentSessionBoundaryRows(
       index + RECENT_SESSION_BOUNDARY_BATCH_SIZE,
     );
     const placeholders = batch.map(() => '?').join(', ');
-    rows.push(
-      ...queryAll<RecentSessionBoundaryRow>(
-        db,
-        `WITH ranked AS (
-           SELECT
-             session_id,
-             role,
-             content,
-             CASE WHEN role = 'user' AND user_id = ? THEN 1 ELSE 0 END AS is_target_user,
-             ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY id ASC) AS rn_first,
-             ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY id DESC) AS rn_last,
-             ROW_NUMBER() OVER (
-               PARTITION BY session_id, CASE WHEN role = 'user' AND user_id = ? THEN 1 ELSE 0 END
-               ORDER BY id ASC
-             ) AS rn_target_group
-           FROM messages
-           WHERE session_id IN (${placeholders})
-         )
-         SELECT
-           session_id,
-           MAX(CASE WHEN is_target_user = 1 AND rn_target_group = 1 THEN content END) AS first_user_content,
-           MAX(CASE WHEN rn_first = 1 THEN content END) AS first_content,
-           MAX(CASE WHEN rn_last = 1 THEN content END) AS last_content,
-           MAX(CASE WHEN rn_last = 1 THEN role END) AS last_role
-         FROM ranked
-         GROUP BY session_id`,
-        userId,
-        userId,
-        ...batch,
-      ),
-    );
+    rows.push(...queryBatch(batch, placeholders));
   }
 
   return rows;
 }
 
+function getRecentSessionBoundaryRows(
+  sessionIds: string[],
+  userId: string,
+): RecentSessionBoundaryRow[] {
+  return batchQueryAllBySessionIds(sessionIds, (batch, placeholders) =>
+    queryAll<RecentSessionBoundaryRow>(
+      db,
+      `WITH ranked AS (
+         SELECT
+           session_id,
+           role,
+           content,
+           CASE WHEN role = 'user' AND user_id = ? THEN 1 ELSE 0 END AS is_target_user,
+           ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY id ASC) AS rn_first,
+           ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY id DESC) AS rn_last,
+           ROW_NUMBER() OVER (
+             PARTITION BY session_id, CASE WHEN role = 'user' AND user_id = ? THEN 1 ELSE 0 END
+             ORDER BY id ASC
+           ) AS rn_target_group
+         FROM messages
+         WHERE session_id IN (${placeholders})
+       )
+       SELECT
+         session_id,
+         MAX(CASE WHEN is_target_user = 1 AND rn_target_group = 1 THEN content END) AS first_user_content,
+         MAX(CASE WHEN rn_first = 1 THEN content END) AS first_content,
+         MAX(CASE WHEN rn_last = 1 THEN content END) AS last_content,
+         MAX(CASE WHEN rn_last = 1 THEN role END) AS last_role
+       FROM ranked
+       GROUP BY session_id`,
+      userId,
+      userId,
+      ...batch,
+    ),
+  );
+}
+
 function getRecentSessionContentMatches(
   sessionIds: string[],
-  query: string,
+  normalizedQuery: string,
 ): Map<string, string> {
-  const normalizedQuery = query.trim().toLowerCase();
-  if (!normalizedQuery || sessionIds.length === 0) {
+  const matchQuery = buildRecentChatSearchMatchQuery(normalizedQuery);
+  if (!normalizedQuery || !matchQuery || sessionIds.length === 0) {
     return new Map();
   }
 
-  const rows: RecentSessionContentMatchRow[] = [];
-
-  for (
-    let index = 0;
-    index < sessionIds.length;
-    index += RECENT_SESSION_BOUNDARY_BATCH_SIZE
-  ) {
-    const batch = sessionIds.slice(
-      index,
-      index + RECENT_SESSION_BOUNDARY_BATCH_SIZE,
-    );
-    const placeholders = batch.map(() => '?').join(', ');
-    rows.push(
-      ...queryAll<RecentSessionContentMatchRow>(
-        db,
-        `WITH ranked_matches AS (
+  const rows = batchQueryAllBySessionIds(sessionIds, (batch, placeholders) =>
+    queryAll<RecentSessionContentMatchRow>(
+      db,
+      `WITH ranked_matches AS (
            SELECT
              session_id,
              content,
-             ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY id DESC) AS rn
-           FROM messages
-           WHERE session_id IN (${placeholders})
+             ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY rowid DESC) AS rn
+           FROM ${RECENT_CHAT_MESSAGE_SEARCH_TABLE}
+           WHERE ${RECENT_CHAT_MESSAGE_SEARCH_TABLE} MATCH ?
+             AND session_id IN (${placeholders})
              AND instr(lower(content), ?) > 0
          )
          SELECT session_id, content
          FROM ranked_matches
          WHERE rn = 1`,
-        ...batch,
-        normalizedQuery,
-      ),
-    );
-  }
+      matchQuery,
+      ...batch,
+      normalizedQuery,
+    ),
+  );
 
   return new Map(
     rows
@@ -4244,13 +4331,10 @@ export function getRecentSessionsForUser(params: {
   const userId = params.userId.trim();
   if (!userId) return [];
   const channelId = String(params.channelId || '').trim();
-  const searchQuery = String(params.query || '')
-    .trim()
-    .toLowerCase();
-  const limit =
-    typeof params.limit === 'number' && Number.isFinite(params.limit)
-      ? Math.max(1, Math.floor(params.limit))
-      : 10;
+  const searchQuery = normalizeRecentChatSearchQuery(
+    params.query,
+  ).toLowerCase();
+  const limit = normalizeRecentChatSessionLimit(params.limit);
 
   const rows = channelId
     ? queryAll<RecentUserSessionRow, [string, string]>(
@@ -4282,7 +4366,9 @@ export function getRecentSessionsForUser(params: {
     }
     return right.id.localeCompare(left.id);
   });
-  const targetRows = searchQuery ? sortedRows : sortedRows.slice(0, limit);
+  const targetRows = searchQuery
+    ? sortedRows.slice(0, MAX_RECENT_CHAT_SESSION_LIMIT)
+    : sortedRows.slice(0, limit);
   if (targetRows.length === 0) return [];
 
   const boundaryRows = getRecentSessionBoundaryRows(
@@ -4328,7 +4414,7 @@ export function getRecentSessionsForUser(params: {
       lastActive: row.last_active,
       messageCount: normalizeUsageNumber(row.message_count),
       title,
-      ...(rawSearchSnippet && !String(title || '').includes(rawSearchSnippet)
+      ...(shouldIncludeSessionSearchSnippet(title, rawSearchSnippet)
         ? { searchSnippet: rawSearchSnippet }
         : {}),
     };

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -21,6 +21,7 @@ import {
 } from '../session/session-key.js';
 import {
   buildSessionBoundaryPreview,
+  buildSessionSearchSnippet,
   RECENT_CHAT_SESSION_TITLE_MAX_LENGTH,
 } from '../session/session-preview.js';
 import {
@@ -4110,6 +4111,7 @@ export interface RecentUserSessionSummary {
   lastActive: string;
   messageCount: number;
   title: string | null;
+  searchSnippet?: string | null;
 }
 
 type RecentUserSessionRow = Pick<
@@ -4123,6 +4125,11 @@ interface RecentSessionBoundaryRow {
   first_content: string | null;
   last_content: string | null;
   last_role: string | null;
+}
+
+interface RecentSessionContentMatchRow {
+  session_id: string;
+  content: string | null;
 }
 
 const RECENT_SESSION_BOUNDARY_BATCH_SIZE = 400;
@@ -4179,6 +4186,55 @@ function getRecentSessionBoundaryRows(
   return rows;
 }
 
+function getRecentSessionContentMatches(
+  sessionIds: string[],
+  query: string,
+): Map<string, string> {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery || sessionIds.length === 0) {
+    return new Map();
+  }
+
+  const rows: RecentSessionContentMatchRow[] = [];
+
+  for (
+    let index = 0;
+    index < sessionIds.length;
+    index += RECENT_SESSION_BOUNDARY_BATCH_SIZE
+  ) {
+    const batch = sessionIds.slice(
+      index,
+      index + RECENT_SESSION_BOUNDARY_BATCH_SIZE,
+    );
+    const placeholders = batch.map(() => '?').join(', ');
+    rows.push(
+      ...queryAll<RecentSessionContentMatchRow>(
+        db,
+        `WITH ranked_matches AS (
+           SELECT
+             session_id,
+             content,
+             ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY id DESC) AS rn
+           FROM messages
+           WHERE session_id IN (${placeholders})
+             AND instr(lower(content), ?) > 0
+         )
+         SELECT session_id, content
+         FROM ranked_matches
+         WHERE rn = 1`,
+        ...batch,
+        normalizedQuery,
+      ),
+    );
+  }
+
+  return new Map(
+    rows
+      .filter((row) => row.session_id && row.content)
+      .map((row) => [row.session_id, row.content as string] as const),
+  );
+}
+
 export function getRecentSessionsForUser(params: {
   userId: string;
   channelId?: string | null;
@@ -4188,7 +4244,7 @@ export function getRecentSessionsForUser(params: {
   const userId = params.userId.trim();
   if (!userId) return [];
   const channelId = String(params.channelId || '').trim();
-  const titleQuery = String(params.query || '')
+  const searchQuery = String(params.query || '')
     .trim()
     .toLowerCase();
   const limit =
@@ -4226,12 +4282,16 @@ export function getRecentSessionsForUser(params: {
     }
     return right.id.localeCompare(left.id);
   });
-  const targetRows = titleQuery ? sortedRows : sortedRows.slice(0, limit);
+  const targetRows = searchQuery ? sortedRows : sortedRows.slice(0, limit);
   if (targetRows.length === 0) return [];
 
   const boundaryRows = getRecentSessionBoundaryRows(
     targetRows.map((row) => row.id),
     userId,
+  );
+  const contentMatchesBySessionId = getRecentSessionContentMatches(
+    targetRows.map((row) => row.id),
+    searchQuery,
   );
   const boundariesBySessionId = new Map(
     boundaryRows.map((row) => [row.session_id, row] as const),
@@ -4251,26 +4311,38 @@ export function getRecentSessionsForUser(params: {
       boundary?.last_content && !shouldHideApprovalPrompt
         ? boundary.last_content
         : null;
+    const title = buildSessionBoundaryPreview({
+      firstMessage,
+      lastMessage,
+      maxLength: RECENT_CHAT_SESSION_TITLE_MAX_LENGTH,
+    });
+    const rawSearchSnippet = searchQuery
+      ? buildSessionSearchSnippet(
+          contentMatchesBySessionId.get(row.id) || null,
+          searchQuery,
+        )
+      : null;
 
     return {
       sessionId: row.id,
       lastActive: row.last_active,
       messageCount: normalizeUsageNumber(row.message_count),
-      title: buildSessionBoundaryPreview({
-        firstMessage,
-        lastMessage,
-        maxLength: RECENT_CHAT_SESSION_TITLE_MAX_LENGTH,
-      }),
+      title,
+      searchSnippet:
+        rawSearchSnippet && !String(title || '').includes(rawSearchSnippet)
+          ? rawSearchSnippet
+          : null,
     };
   });
 
-  if (!titleQuery) return sessions;
+  if (!searchQuery) return sessions;
   return sessions
-    .filter((session) =>
-      String(session.title || '')
+    .filter((session) => {
+      const titleMatches = String(session.title || '')
         .toLowerCase()
-        .includes(titleQuery),
-    )
+        .includes(searchQuery);
+      return titleMatches || Boolean(session.searchSnippet);
+    })
     .slice(0, limit);
 }
 

--- a/src/plugins/plugin-dependencies.ts
+++ b/src/plugins/plugin-dependencies.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { hasExecutableCommand } from '../utils/executables.js';
+import { normalizeNullableTrimmedString as normalizePackageSpec } from '../utils/normalized-strings.js';
 import type {
   PluginExternalDependency,
   PluginManifest,
@@ -67,11 +68,6 @@ export interface PluginDependencyCheckReport {
   nodeDependencies: PluginPackageStatus[];
   pipDependencies: PluginPackageStatus[];
   externalDependencies: PluginExternalDependencyStatus[];
-}
-
-function normalizePackageSpec(value: unknown): string | null {
-  const normalized = typeof value === 'string' ? value.trim() : '';
-  return normalized ? normalized : null;
 }
 
 function extractCheckPackageName(spec: string): string {

--- a/src/session/recent-chat-search.ts
+++ b/src/session/recent-chat-search.ts
@@ -1,0 +1,29 @@
+export const DEFAULT_RECENT_CHAT_SESSION_LIMIT = 10;
+export const MAX_RECENT_CHAT_SESSION_LIMIT = 200;
+export const MAX_RECENT_CHAT_QUERY_LENGTH = 200;
+const RECENT_CHAT_SEARCH_TERM_PATTERN = /[\p{L}\p{N}]+/gu;
+const MAX_RECENT_CHAT_SEARCH_TERMS = 12;
+
+export function normalizeRecentChatSessionLimit(limit?: number | null): number {
+  const normalized =
+    typeof limit === 'number' && Number.isFinite(limit)
+      ? Math.floor(limit)
+      : DEFAULT_RECENT_CHAT_SESSION_LIMIT;
+  return Math.max(1, Math.min(normalized, MAX_RECENT_CHAT_SESSION_LIMIT));
+}
+
+export function normalizeRecentChatSearchQuery(query?: string | null): string {
+  return String(query || '')
+    .trim()
+    .slice(0, MAX_RECENT_CHAT_QUERY_LENGTH);
+}
+
+export function buildRecentChatSearchMatchQuery(
+  normalizedQuery: string,
+): string {
+  const terms =
+    normalizedQuery
+      .match(RECENT_CHAT_SEARCH_TERM_PATTERN)
+      ?.slice(0, MAX_RECENT_CHAT_SEARCH_TERMS) || [];
+  return terms.map((term) => `${term}*`).join(' AND ');
+}

--- a/src/session/session-preview.ts
+++ b/src/session/session-preview.ts
@@ -39,6 +39,45 @@ export function buildSessionBoundaryPreview(params: {
   return single ? `"${single}"` : null;
 }
 
+export function buildSessionSearchSnippet(
+  raw: string | null | undefined,
+  query: string | null | undefined,
+  maxLength = 120,
+): string | null {
+  const compact = String(raw || '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!compact) return null;
+
+  const normalizedQuery = String(query || '')
+    .trim()
+    .toLowerCase();
+  if (!normalizedQuery) {
+    return trimSessionPreviewText(compact, maxLength);
+  }
+
+  const matchIndex = compact.toLowerCase().indexOf(normalizedQuery);
+  if (matchIndex < 0) {
+    return trimSessionPreviewText(compact, maxLength);
+  }
+
+  const surroundingChars = Math.max(
+    18,
+    Math.floor((maxLength - normalizedQuery.length) / 2),
+  );
+  const start = Math.max(0, matchIndex - surroundingChars);
+  const end = Math.min(
+    compact.length,
+    matchIndex + normalizedQuery.length + surroundingChars,
+  );
+
+  let snippet = compact.slice(start, end).trim();
+  if (!snippet) return null;
+  if (start > 0) snippet = `...${snippet}`;
+  if (end < compact.length) snippet = `${snippet}...`;
+  return snippet;
+}
+
 export function buildSessionConversationPreview(
   messages: Array<Pick<StoredMessage, 'role' | 'content'>>,
   maxLength = 140,

--- a/src/session/session-preview.ts
+++ b/src/session/session-preview.ts
@@ -75,7 +75,32 @@ export function buildSessionSearchSnippet(
   if (!snippet) return null;
   if (start > 0) snippet = `...${snippet}`;
   if (end < compact.length) snippet = `${snippet}...`;
-  return snippet;
+  return trimSessionPreviewText(snippet, maxLength);
+}
+
+function normalizeSessionPreviewComparisonText(
+  raw: string | null | undefined,
+): string {
+  return String(raw || '')
+    .replace(/^\.\.\./, '')
+    .replace(/\.\.\.$/, '')
+    .replace(/"/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+export function shouldIncludeSessionSearchSnippet(
+  title: string | null | undefined,
+  snippet: string | null | undefined,
+): boolean {
+  const normalizedSnippet = normalizeSessionPreviewComparisonText(snippet);
+  if (!normalizedSnippet) return false;
+
+  const normalizedTitle = normalizeSessionPreviewComparisonText(title);
+  if (!normalizedTitle) return true;
+
+  return !normalizedTitle.includes(normalizedSnippet);
 }
 
 export function buildSessionConversationPreview(

--- a/src/utils/normalized-strings.ts
+++ b/src/utils/normalized-strings.ts
@@ -2,6 +2,16 @@ export function normalizeTrimmedString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
 }
 
+export function normalizeOptionalTrimmedString(
+  value: unknown,
+): string | undefined {
+  return normalizeTrimmedString(value) || undefined;
+}
+
+export function normalizeNullableTrimmedString(value: unknown): string | null {
+  return normalizeTrimmedString(value) || null;
+}
+
 export function normalizeTrimmedStringArray(
   values: readonly unknown[] | undefined,
 ): string[] {

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -886,6 +886,13 @@ test('checkSkills warns on enabled caution skills and disables them with fix', a
 
 test('checkSkills warns on enabled skills unused in the last 30 days', async () => {
   const disabledSkills = new Set<string>();
+  const now = Date.now();
+  const freshObservedAt = new Date(
+    now - 10 * 24 * 60 * 60 * 1000,
+  ).toISOString();
+  const staleObservedAt = new Date(
+    now - 90 * 24 * 60 * 60 * 1000,
+  ).toISOString();
 
   vi.doMock('../src/config/runtime-config.js', () => ({
     getRuntimeConfig: () => ({
@@ -939,7 +946,7 @@ test('checkSkills warns on enabled skills unused in the last 30 days', async () 
         positive_feedback_count: 0,
         negative_feedback_count: 0,
         error_clusters: [],
-        last_observed_at: '2026-03-20T10:00:00.000Z',
+        last_observed_at: freshObservedAt,
       },
       {
         skill_name: 'stale-skill',
@@ -953,7 +960,7 @@ test('checkSkills warns on enabled skills unused in the last 30 days', async () 
         positive_feedback_count: 0,
         negative_feedback_count: 0,
         error_clusters: [],
-        last_observed_at: '2026-01-20T10:00:00.000Z',
+        last_observed_at: staleObservedAt,
       },
     ],
   }));

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -3198,7 +3198,9 @@ describe('gateway HTTP server', () => {
     expect(res.headers['Content-Type']).toBe('text/html; charset=utf-8');
     expect(res.body).toContain('localStorage.setItem');
     expect(res.body).toContain('hybridclaw_token');
+    expect(res.body).toContain('hybridclaw_user_id');
     expect(res.body).toContain('my-web-token');
+    expect(res.body).toContain('user-1');
     expect(res.body).toContain('window.location.replace("/admin")');
     // Session cookie should still be set
     expect(res.headers['Set-Cookie']).toEqual(
@@ -3746,6 +3748,100 @@ describe('gateway HTTP server', () => {
   });
 
   test('passes chat title search queries through to recent session lookup', async () => {
+    const authSecret = 'health-secret';
+    const sessionToken = signAuthPayload(
+      {
+        exp: Math.floor(Date.now() / 1000) + 60,
+        iat: Math.floor(Date.now() / 1000),
+        sub: 'user-1',
+        typ: 'session',
+      },
+      authSecret,
+    );
+    const state = await importFreshHealth({ authSecret });
+    const req = makeRequest({
+      url: '/api/chat/recent?userId=web-user-a&channelId=web&limit=25&q=deploy',
+      headers: {
+        cookie: `hybridclaw_session=${sessionToken}`,
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(state.getGatewayRecentChatSessions).toHaveBeenCalledWith({
+      userId: 'user-1',
+      channelId: 'web',
+      limit: 25,
+      query: 'deploy',
+    });
+  });
+
+  test('uses the signed session subject for web chat history search', async () => {
+    const authSecret = 'health-secret';
+    const sessionToken = signAuthPayload(
+      {
+        exp: Math.floor(Date.now() / 1000) + 60,
+        iat: Math.floor(Date.now() / 1000),
+        sub: 'user-1',
+        typ: 'session',
+      },
+      authSecret,
+    );
+    const state = await importFreshHealth({ authSecret });
+    const req = makeRequest({
+      url: '/api/chat/recent?channelId=web&limit=25&q=deploy',
+      headers: {
+        cookie: `hybridclaw_session=${sessionToken}`,
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(state.getGatewayRecentChatSessions).toHaveBeenCalledWith({
+      userId: 'user-1',
+      channelId: 'web',
+      limit: 25,
+      query: 'deploy',
+    });
+  });
+
+  test('caps recent chat search limit and query length before lookup', async () => {
+    const authSecret = 'health-secret';
+    const sessionToken = signAuthPayload(
+      {
+        exp: Math.floor(Date.now() / 1000) + 60,
+        iat: Math.floor(Date.now() / 1000),
+        sub: 'user-1',
+        typ: 'session',
+      },
+      authSecret,
+    );
+    const state = await importFreshHealth({ authSecret });
+    const longQuery = 'd'.repeat(250);
+    const req = makeRequest({
+      url: `/api/chat/recent?userId=web-user-a&channelId=web&limit=9999&q=${longQuery}`,
+      headers: {
+        cookie: `hybridclaw_session=${sessionToken}`,
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(state.getGatewayRecentChatSessions).toHaveBeenCalledWith({
+      userId: 'user-1',
+      channelId: 'web',
+      limit: 200,
+      query: 'd'.repeat(200),
+    });
+  });
+
+  test('rejects web chat search without a signed session', async () => {
     const state = await importFreshHealth();
     const req = makeRequest({
       url: '/api/chat/recent?userId=web-user-a&channelId=web&limit=25&q=deploy',
@@ -3755,11 +3851,10 @@ describe('gateway HTTP server', () => {
     state.handler(req as never, res as never);
     await waitForResponse(res, (next) => next.writableEnded);
 
-    expect(state.getGatewayRecentChatSessions).toHaveBeenCalledWith({
-      userId: 'web-user-a',
-      channelId: 'web',
-      limit: 25,
-      query: 'deploy',
+    expect(state.getGatewayRecentChatSessions).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Web chat search requires a signed session.',
     });
   });
 
@@ -5523,6 +5618,53 @@ describe('gateway HTTP server', () => {
     });
   });
 
+  test('uses the signed session subject for web chat requests', async () => {
+    const authSecret = 'health-secret';
+    const sessionToken = signAuthPayload(
+      {
+        exp: Math.floor(Date.now() / 1000) + 60,
+        iat: Math.floor(Date.now() / 1000),
+        sub: 'user-1',
+        typ: 'session',
+      },
+      authSecret,
+    );
+    const state = await importFreshHealth({ authSecret });
+    state.handleGatewayCommand.mockResolvedValueOnce({
+      kind: 'info',
+      title: 'Runtime Status',
+      text: 'All systems nominal.',
+      sessionId: 'session-web-slash',
+    });
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/chat',
+      headers: {
+        cookie: `hybridclaw_session=${sessionToken}`,
+      },
+      body: {
+        sessionId: 'session-web-slash',
+        channelId: 'web',
+        userId: 'other-user',
+        username: 'web',
+        content: '/status',
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(state.handleGatewayCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-web-slash',
+        channelId: 'web',
+        args: ['status'],
+        userId: 'user-1',
+      }),
+    );
+  });
+
   test('lists slash command suggestions for the web chat UI', async () => {
     const state = await importFreshHealth();
     const req = makeRequest({
@@ -6214,6 +6356,52 @@ describe('gateway HTTP server', () => {
     expect(JSON.parse(res.body)).toEqual({
       error: 'Malformed canonical `sessionId`.',
     });
+  });
+
+  test('uses the signed session subject for /api/command web requests', async () => {
+    const authSecret = 'health-secret';
+    const sessionToken = signAuthPayload(
+      {
+        exp: Math.floor(Date.now() / 1000) + 60,
+        iat: Math.floor(Date.now() / 1000),
+        sub: 'user-1',
+        typ: 'session',
+      },
+      authSecret,
+    );
+    const state = await importFreshHealth({ authSecret });
+    state.handleGatewayCommand.mockResolvedValueOnce({
+      kind: 'plain',
+      text: 'ok',
+      sessionId: 'session-web-command',
+    });
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/command',
+      headers: {
+        cookie: `hybridclaw_session=${sessionToken}`,
+      },
+      body: {
+        sessionId: 'session-web-command',
+        channelId: 'web',
+        userId: 'other-user',
+        username: 'web',
+        args: ['help'],
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.handleGatewayCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-web-command',
+        channelId: 'web',
+        args: ['help'],
+        userId: 'user-1',
+      }),
+    );
   });
 
   test('returns 400 for malformed json request bodies', async () => {

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -3745,6 +3745,24 @@ describe('gateway HTTP server', () => {
     });
   });
 
+  test('passes chat title search queries through to recent session lookup', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({
+      url: '/api/chat/recent?userId=web-user-a&channelId=web&limit=25&q=deploy',
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(state.getGatewayRecentChatSessions).toHaveBeenCalledWith({
+      userId: 'web-user-a',
+      channelId: 'web',
+      limit: 25,
+      query: 'deploy',
+    });
+  });
+
   test('rejects history requests without an explicit session id', async () => {
     const state = await importFreshHealth();
     const req = makeRequest({ url: '/api/history?limit=2' });

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -3841,21 +3841,26 @@ describe('gateway HTTP server', () => {
     });
   });
 
-  test('rejects web chat search without a signed session', async () => {
-    const state = await importFreshHealth();
+  test('accepts web chat search with request auth and explicit user id', async () => {
+    const state = await importFreshHealth({ webApiToken: 'web-token' });
     const req = makeRequest({
       url: '/api/chat/recent?userId=web-user-a&channelId=web&limit=25&q=deploy',
+      headers: {
+        authorization: 'Bearer web-token',
+      },
     });
     const res = makeResponse();
 
     state.handler(req as never, res as never);
     await waitForResponse(res, (next) => next.writableEnded);
 
-    expect(state.getGatewayRecentChatSessions).not.toHaveBeenCalled();
-    expect(res.statusCode).toBe(401);
-    expect(JSON.parse(res.body)).toEqual({
-      error: 'Web chat search requires a signed session.',
+    expect(state.getGatewayRecentChatSessions).toHaveBeenCalledWith({
+      userId: 'web-user-a',
+      channelId: 'web',
+      limit: 25,
+      query: 'deploy',
     });
+    expect(res.statusCode).toBe(200);
   });
 
   test('rejects history requests without an explicit session id', async () => {

--- a/tests/memory-service.test.ts
+++ b/tests/memory-service.test.ts
@@ -945,6 +945,69 @@ describe.sequential('schema migrations', () => {
     ]);
   });
 
+  test('getRecentSessionsForUser matches content outside the derived title', () => {
+    const dbPath = createTempDbPath();
+    initDatabase({ quiet: true, dbPath });
+
+    getOrCreateSession('web-session-content-match', null, 'web');
+
+    const inspect = new Database(dbPath);
+    const insertMessage = inspect.prepare(
+      'INSERT INTO messages (session_id, user_id, username, role, content, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+    );
+    const updateSession = inspect.prepare(
+      'UPDATE sessions SET message_count = ?, last_active = ? WHERE id = ?',
+    );
+
+    insertMessage.run(
+      'web-session-content-match',
+      'web-user-a',
+      'web',
+      'user',
+      'Discuss the release checklist',
+      '2026-03-24T11:00:00.000Z',
+    );
+    insertMessage.run(
+      'web-session-content-match',
+      'assistant',
+      null,
+      'assistant',
+      'Deployment rollback steps are documented here.',
+      '2026-03-24T11:01:00.000Z',
+    );
+    insertMessage.run(
+      'web-session-content-match',
+      'web-user-a',
+      'web',
+      'user',
+      'Thanks, that helps.',
+      '2026-03-24T11:02:00.000Z',
+    );
+    updateSession.run(
+      3,
+      '2026-03-24T11:02:00.000Z',
+      'web-session-content-match',
+    );
+    inspect.close();
+
+    expect(
+      getRecentSessionsForUser({
+        userId: 'web-user-a',
+        channelId: 'web',
+        limit: 10,
+        query: 'deploy',
+      }),
+    ).toEqual([
+      {
+        sessionId: 'web-session-content-match',
+        lastActive: '2026-03-24T11:02:00.000Z',
+        messageCount: 3,
+        searchSnippet: 'Deployment rollback steps are documented here.',
+        title: '"Discuss the release checklist" ... "Thanks, that helps."',
+      },
+    ]);
+  });
+
   test('forkSessionBranch copies the prefix into a new sibling session', () => {
     const dbPath = createTempDbPath();
     initDatabase({ quiet: true, dbPath });

--- a/tests/memory-service.test.ts
+++ b/tests/memory-service.test.ts
@@ -928,14 +928,14 @@ describe.sequential('schema migrations', () => {
     updateSession.run(1, '2026-03-24T10:00:00.000Z', 'web-session-3');
     inspect.close();
 
-    expect(
-      getRecentSessionsForUser({
-        userId: 'web-user-a',
-        channelId: 'web',
-        limit: 1,
-        query: 'deploy',
-      }),
-    ).toEqual([
+    const sessions = getRecentSessionsForUser({
+      userId: 'web-user-a',
+      channelId: 'web',
+      limit: 1,
+      query: 'deploy',
+    });
+
+    expect(sessions).toEqual([
       {
         sessionId: 'web-session-2',
         lastActive: '2026-03-24T09:00:00.000Z',
@@ -943,6 +943,7 @@ describe.sequential('schema migrations', () => {
         title: '"Review deployment rollback plan"',
       },
     ]);
+    expect(sessions[0]).not.toHaveProperty('searchSnippet');
   });
 
   test('getRecentSessionsForUser matches content outside the derived title', () => {
@@ -1006,6 +1007,197 @@ describe.sequential('schema migrations', () => {
         title: '"Discuss the release checklist" ... "Thanks, that helps."',
       },
     ]);
+  });
+
+  test('getRecentSessionsForUser suppresses duplicated search snippets when the title already shows the match', () => {
+    const dbPath = createTempDbPath();
+    initDatabase({ quiet: true, dbPath });
+
+    getOrCreateSession('web-session-duplicate-snippet', null, 'web');
+
+    const inspect = new Database(dbPath);
+    const insertMessage = inspect.prepare(
+      'INSERT INTO messages (session_id, user_id, username, role, content, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+    );
+    const updateSession = inspect.prepare(
+      'UPDATE sessions SET message_count = ?, last_active = ? WHERE id = ?',
+    );
+    const longContent =
+      'Deployment rollback planning notes stay visible in the title while additional context continues here so the snippet builder adds trailing ellipsis for search results.';
+
+    insertMessage.run(
+      'web-session-duplicate-snippet',
+      'web-user-a',
+      'web',
+      'user',
+      longContent,
+      '2026-03-24T11:05:00.000Z',
+    );
+    updateSession.run(
+      1,
+      '2026-03-24T11:05:00.000Z',
+      'web-session-duplicate-snippet',
+    );
+    inspect.close();
+
+    const sessions = getRecentSessionsForUser({
+      userId: 'web-user-a',
+      channelId: 'web',
+      limit: 10,
+      query: 'deploy',
+    });
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      sessionId: 'web-session-duplicate-snippet',
+      lastActive: '2026-03-24T11:05:00.000Z',
+      messageCount: 1,
+    });
+    expect(sessions[0]?.title).toContain(
+      'Deployment rollback planning notes stay visible in the title',
+    );
+    expect(sessions[0]).not.toHaveProperty('searchSnippet');
+  });
+
+  test('getRecentSessionsForUser backfills the message search index on schema upgrade', () => {
+    const dbPath = createTempDbPath();
+    initDatabase({ quiet: true, dbPath });
+
+    getOrCreateSession('web-session-upgrade-search', null, 'web');
+    storeMessage(
+      'web-session-upgrade-search',
+      'web-user-a',
+      'web',
+      'user',
+      'Discuss the release checklist',
+    );
+    storeMessage(
+      'web-session-upgrade-search',
+      'assistant',
+      null,
+      'assistant',
+      'Deployment rollback steps are documented here.',
+    );
+
+    const inspect = new Database(dbPath);
+    inspect.exec(`
+      DROP TRIGGER IF EXISTS messages_recent_chat_search_ai;
+      DROP TRIGGER IF EXISTS messages_recent_chat_search_ad;
+      DROP TRIGGER IF EXISTS messages_recent_chat_search_au;
+      DROP TABLE IF EXISTS recent_chat_message_search;
+      PRAGMA user_version = 18;
+    `);
+    inspect.close();
+
+    initDatabase({ quiet: true, dbPath });
+
+    expect(
+      getRecentSessionsForUser({
+        userId: 'web-user-a',
+        channelId: 'web',
+        limit: 10,
+        query: 'deploy',
+      }),
+    ).toEqual([
+      {
+        sessionId: 'web-session-upgrade-search',
+        lastActive: expect.any(String),
+        messageCount: 2,
+        title:
+          '"Discuss the release checklist" ... "Deployment rollback steps are documented here."',
+      },
+    ]);
+  });
+
+  test('getRecentSessionsForUser truncates long search queries before content matching', () => {
+    const dbPath = createTempDbPath();
+    initDatabase({ quiet: true, dbPath });
+
+    getOrCreateSession('web-session-long-query', null, 'web');
+
+    const inspect = new Database(dbPath);
+    const insertMessage = inspect.prepare(
+      'INSERT INTO messages (session_id, user_id, username, role, content, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+    );
+    const updateSession = inspect.prepare(
+      'UPDATE sessions SET message_count = ?, last_active = ? WHERE id = ?',
+    );
+    const longContent = 'a'.repeat(210);
+
+    insertMessage.run(
+      'web-session-long-query',
+      'web-user-a',
+      'web',
+      'user',
+      'Keep this title unrelated',
+      '2026-03-24T11:10:00.000Z',
+    );
+    insertMessage.run(
+      'web-session-long-query',
+      'assistant',
+      null,
+      'assistant',
+      longContent,
+      '2026-03-24T11:11:00.000Z',
+    );
+    updateSession.run(2, '2026-03-24T11:11:00.000Z', 'web-session-long-query');
+    inspect.close();
+
+    const sessions = getRecentSessionsForUser({
+      userId: 'web-user-a',
+      channelId: 'web',
+      limit: 10,
+      query: 'a'.repeat(250),
+    });
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      sessionId: 'web-session-long-query',
+      lastActive: '2026-03-24T11:11:00.000Z',
+      messageCount: 2,
+      searchSnippet: longContent,
+    });
+    expect(sessions[0]?.title).toContain('Keep this title unrelated');
+  });
+
+  test('getRecentSessionsForUser only scans the capped recent search window', () => {
+    const dbPath = createTempDbPath();
+    initDatabase({ quiet: true, dbPath });
+
+    const inspect = new Database(dbPath);
+    const insertMessage = inspect.prepare(
+      'INSERT INTO messages (session_id, user_id, username, role, content, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+    );
+    const updateSession = inspect.prepare(
+      'UPDATE sessions SET message_count = ?, last_active = ? WHERE id = ?',
+    );
+
+    for (let index = 0; index < 201; index += 1) {
+      const sessionId = `web-session-cap-${String(index + 1).padStart(3, '0')}`;
+      getOrCreateSession(sessionId, null, 'web');
+      const timestamp = new Date(
+        Date.UTC(2026, 2, 24, 0, index, 0),
+      ).toISOString();
+      insertMessage.run(
+        sessionId,
+        'web-user-a',
+        'web',
+        'user',
+        index === 0 ? 'This old session mentions deploy' : 'General note',
+        timestamp,
+      );
+      updateSession.run(1, timestamp, sessionId);
+    }
+    inspect.close();
+
+    expect(
+      getRecentSessionsForUser({
+        userId: 'web-user-a',
+        channelId: 'web',
+        limit: 9999,
+        query: 'deploy',
+      }),
+    ).toEqual([]);
   });
 
   test('forkSessionBranch copies the prefix into a new sibling session', () => {

--- a/tests/memory-service.test.ts
+++ b/tests/memory-service.test.ts
@@ -37,6 +37,7 @@ import {
   type MemoryBackend,
   MemoryService,
 } from '../src/memory/memory-service.js';
+import { normalizeRecentChatSearchQuery } from '../src/session/recent-chat-search.js';
 import {
   KnowledgeEntityType,
   KnowledgeRelationType,
@@ -1109,55 +1110,12 @@ describe.sequential('schema migrations', () => {
     ]);
   });
 
-  test('getRecentSessionsForUser truncates long search queries before content matching', () => {
-    const dbPath = createTempDbPath();
-    initDatabase({ quiet: true, dbPath });
+  test('normalizeRecentChatSearchQuery truncates long search queries', () => {
+    const rawQuery = 'alpha beta '.repeat(25).trimEnd();
+    const normalizedQuery = normalizeRecentChatSearchQuery(rawQuery);
 
-    getOrCreateSession('web-session-long-query', null, 'web');
-
-    const inspect = new Database(dbPath);
-    const insertMessage = inspect.prepare(
-      'INSERT INTO messages (session_id, user_id, username, role, content, created_at) VALUES (?, ?, ?, ?, ?, ?)',
-    );
-    const updateSession = inspect.prepare(
-      'UPDATE sessions SET message_count = ?, last_active = ? WHERE id = ?',
-    );
-    const longContent = 'a'.repeat(210);
-
-    insertMessage.run(
-      'web-session-long-query',
-      'web-user-a',
-      'web',
-      'user',
-      'Keep this title unrelated',
-      '2026-03-24T11:10:00.000Z',
-    );
-    insertMessage.run(
-      'web-session-long-query',
-      'assistant',
-      null,
-      'assistant',
-      longContent,
-      '2026-03-24T11:11:00.000Z',
-    );
-    updateSession.run(2, '2026-03-24T11:11:00.000Z', 'web-session-long-query');
-    inspect.close();
-
-    const sessions = getRecentSessionsForUser({
-      userId: 'web-user-a',
-      channelId: 'web',
-      limit: 10,
-      query: 'a'.repeat(250),
-    });
-
-    expect(sessions).toHaveLength(1);
-    expect(sessions[0]).toMatchObject({
-      sessionId: 'web-session-long-query',
-      lastActive: '2026-03-24T11:11:00.000Z',
-      messageCount: 2,
-      searchSnippet: longContent,
-    });
-    expect(sessions[0]?.title).toContain('Keep this title unrelated');
+    expect(normalizedQuery).toHaveLength(200);
+    expect(normalizedQuery).toBe(rawQuery.trim().slice(0, 200));
   });
 
   test('getRecentSessionsForUser only scans the capped recent search window', () => {

--- a/tests/memory-service.test.ts
+++ b/tests/memory-service.test.ts
@@ -881,6 +881,70 @@ describe.sequential('schema migrations', () => {
     ]);
   });
 
+  test('getRecentSessionsForUser searches titles before applying the result limit', () => {
+    const dbPath = createTempDbPath();
+    initDatabase({ quiet: true, dbPath });
+
+    getOrCreateSession('web-session-1', null, 'web');
+    getOrCreateSession('web-session-2', null, 'web');
+    getOrCreateSession('web-session-3', null, 'web');
+
+    const inspect = new Database(dbPath);
+    const insertMessage = inspect.prepare(
+      'INSERT INTO messages (session_id, user_id, username, role, content, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+    );
+    const updateSession = inspect.prepare(
+      'UPDATE sessions SET message_count = ?, last_active = ? WHERE id = ?',
+    );
+
+    insertMessage.run(
+      'web-session-1',
+      'web-user-a',
+      'web',
+      'user',
+      'Draft the deployment checklist',
+      '2026-03-24T08:00:00.000Z',
+    );
+    updateSession.run(1, '2026-03-24T08:00:00.000Z', 'web-session-1');
+
+    insertMessage.run(
+      'web-session-2',
+      'web-user-a',
+      'web',
+      'user',
+      'Review deployment rollback plan',
+      '2026-03-24T09:00:00.000Z',
+    );
+    updateSession.run(1, '2026-03-24T09:00:00.000Z', 'web-session-2');
+
+    insertMessage.run(
+      'web-session-3',
+      'web-user-a',
+      'web',
+      'user',
+      'Brainstorm launch copy',
+      '2026-03-24T10:00:00.000Z',
+    );
+    updateSession.run(1, '2026-03-24T10:00:00.000Z', 'web-session-3');
+    inspect.close();
+
+    expect(
+      getRecentSessionsForUser({
+        userId: 'web-user-a',
+        channelId: 'web',
+        limit: 1,
+        query: 'deploy',
+      }),
+    ).toEqual([
+      {
+        sessionId: 'web-session-2',
+        lastActive: '2026-03-24T09:00:00.000Z',
+        messageCount: 1,
+        title: '"Review deployment rollback plan"',
+      },
+    ]);
+  });
+
   test('forkSessionBranch copies the prefix into a new sibling session', () => {
     const dbPath = createTempDbPath();
     initDatabase({ quiet: true, dbPath });

--- a/tests/session-preview.test.ts
+++ b/tests/session-preview.test.ts
@@ -3,6 +3,8 @@ import { expect, test } from 'vitest';
 import {
   buildSessionBoundaryPreview,
   buildSessionConversationPreview,
+  buildSessionSearchSnippet,
+  shouldIncludeSessionSearchSnippet,
   trimSessionPreviewText,
 } from '../src/session/session-preview.ts';
 
@@ -32,6 +34,26 @@ test('buildSessionBoundaryPreview collapses identical first and last snippets', 
       lastMessage: 'Same boundary message',
     }),
   ).toBe('"Same boundary message"');
+});
+
+test('shouldIncludeSessionSearchSnippet ignores edge ellipses when the title already shows the text', () => {
+  expect(
+    shouldIncludeSessionSearchSnippet(
+      '"Review deployment rollback planning notes"',
+      '...deployment rollback planning notes...',
+    ),
+  ).toBe(false);
+});
+
+test('buildSessionSearchSnippet clamps the final decorated snippet to maxLength', () => {
+  const snippet = buildSessionSearchSnippet(
+    'Intro words before deployment rollback guidance with extra trailing context that pushes the decorated snippet over the requested limit.',
+    'deployment rollback guidance',
+    28,
+  );
+
+  expect(snippet).not.toBeNull();
+  expect(snippet?.length).toBeLessThanOrEqual(28);
 });
 
 test('buildSessionConversationPreview returns the latest user and assistant snippets', () => {


### PR DESCRIPTION
## Summary
- add a `Search` field to the chat sidebar used by `docs/chat.html`
- search recent chat history by both derived conversation title and message content via `/api/chat/recent?q=...`
- show content-match snippets in results and keep the console chat sidebar behavior aligned
- preserve the non-search response shape and fix the related CI regressions

## Testing
- `npm run typecheck`
- `npm run lint`
- `vitest` for `console/src/routes/chat/chat-page.test.tsx`
- targeted `vitest` for `tests/gateway-http-server.test.ts`
- targeted `vitest` for `tests/doctor.test.ts`

## Notes
- `tests/memory-service.test.ts` was added and updated for the new search behavior, but that full file still depends on a local `better-sqlite3` build that matches the repo's Node 22 environment.