### PR TITLE
[codex] Add mid-run /steer note injection

### DIFF
--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -13,7 +13,7 @@ import {
   runBeforeToolHooks,
 } from './extensions.js';
 import { compactInLoop } from './in-loop-compaction.js';
-import { waitForInput, writeOutput } from './ipc.js';
+import { takePendingSteeringNotes, waitForInput, writeOutput } from './ipc.js';
 import { McpClientManager } from './mcp/client-manager.js';
 import { McpConfigWatcher } from './mcp/config-watcher.js';
 import {
@@ -49,6 +49,12 @@ import {
   advanceStalledTurnCount,
   MAX_STALLED_MODEL_TURNS,
 } from './stalled-turns.js';
+import {
+  appendSteeringCheckpointMessage,
+  appendSteeringNotesToToolMessages,
+  buildSteeringCheckpointPrompt,
+  type QueuedSteeringNote,
+} from './steering.js';
 import {
   collapseSystemMessages,
   mergeSystemMessage,
@@ -405,6 +411,16 @@ function replaceLatestUserPrompt(
   return [...messages, { role: 'user', content: prompt }];
 }
 
+function logQueuedSteeringDelivery(
+  notes: QueuedSteeringNote[],
+  mode: 'fallback' | 'tool',
+): void {
+  if (notes.length === 0) return;
+  console.error(
+    `[steer] injected ${notes.length} queued note${notes.length === 1 ? '' : 's'} via ${mode}`,
+  );
+}
+
 function normalizeRalphMaxExtraIterations(
   value: number | null | undefined,
 ): number {
@@ -530,6 +546,7 @@ interface PreparedToolCallExecution {
 }
 
 interface CompletedToolCallExecution {
+  callId: string;
   toolName: string;
   argsJson: string;
   result: string;
@@ -576,6 +593,17 @@ function appendCompletedToolCall(params: {
     params.completed.argsJson,
     params.completed.result,
     params.completed.isError,
+  );
+}
+
+function retainCompletedAssistantToolCalls(
+  assistantMessage: ChatMessage,
+  completedCallIds: string[],
+): void {
+  if (!assistantMessage.tool_calls?.length) return;
+  const completed = new Set(completedCallIds);
+  assistantMessage.tool_calls = assistantMessage.tool_calls.filter((call) =>
+    completed.has(call.id),
   );
 }
 
@@ -664,6 +692,7 @@ async function executePreparedToolCall(
   );
 
   return {
+    callId: call.id,
     toolName,
     argsJson,
     result,
@@ -885,13 +914,13 @@ async function processRequest(
   const artifacts: ArtifactMetadata[] = [];
   const artifactPaths = new Set<string>();
   const tokenUsage = createTokenUsageStats();
-  const effectiveUserPrompt =
+  let effectiveUserPrompt =
     effectiveUserPromptOverride || latestUserPrompt(messages);
   const ralphMaxExtraIterations = normalizeRalphMaxExtraIterations(
     ralphMaxIterationsOverride,
   );
   const ralphEnabled = ralphMaxExtraIterations !== 0;
-  const ralphSeedPrompt = ralphEnabled ? effectiveUserPrompt : '';
+  let ralphSeedPrompt = ralphEnabled ? effectiveUserPrompt : '';
   const maxStalledTurns = resolveMaxStalledTurns(ralphMaxExtraIterations);
   let ralphExtraIterations = 0;
   let stalledTurns = 0;
@@ -900,7 +929,58 @@ async function processRequest(
   const tokenEstimateCache = createTokenEstimateCache();
   const maxContextGuardRetries = Math.max(0, contextGuard?.maxRetries ?? 3);
 
-  while (stalledTurns < maxStalledTurns) {
+  const updateSteeringState = (nextEffectiveUserPrompt: string): void => {
+    effectiveUserPrompt = nextEffectiveUserPrompt;
+    if (ralphEnabled) {
+      ralphSeedPrompt = effectiveUserPrompt;
+    }
+    stalledTurns = 0;
+  };
+
+  const applyQueuedSteeringFallback = (): boolean => {
+    const notes = takePendingSteeringNotes();
+    if (notes.length === 0) return false;
+    const steeringPrompt = appendSteeringCheckpointMessage({
+      history,
+      notes,
+    });
+    if (!steeringPrompt) return false;
+    logQueuedSteeringDelivery(notes, 'fallback');
+    updateSteeringState(latestUserPrompt(history));
+    return true;
+  };
+
+  const applyQueuedSteeringToRecentToolMessages = (
+    recentToolMessageCount: number,
+  ): boolean => {
+    const notes = takePendingSteeringNotes();
+    if (notes.length === 0) return false;
+    const marker = appendSteeringNotesToToolMessages({
+      history,
+      notes,
+      recentToolMessageCount,
+    });
+    if (!marker) {
+      const steeringPrompt = appendSteeringCheckpointMessage({
+        history,
+        notes,
+      });
+      if (!steeringPrompt) return false;
+      logQueuedSteeringDelivery(notes, 'fallback');
+      updateSteeringState(latestUserPrompt(history));
+      return true;
+    }
+    logQueuedSteeringDelivery(notes, 'tool');
+    const steeringPrompt = buildSteeringCheckpointPrompt(notes);
+    updateSteeringState(
+      steeringPrompt
+        ? `${effectiveUserPrompt}\n\n${steeringPrompt}`.trim()
+        : effectiveUserPrompt,
+    );
+    return true;
+  };
+
+  requestLoop: while (stalledTurns < maxStalledTurns) {
     const guardResult = applyContextGuard({
       history,
       contextWindowTokens: contextWindow,
@@ -1066,6 +1146,7 @@ async function processRequest(
     }
 
     const toolCalls = choice.message.tool_calls || [];
+    const executedToolCallIds: string[] = [];
     const invalidToolCallError = validateStructuredToolCalls(toolCalls);
     if (invalidToolCallError) {
       console.error(
@@ -1130,6 +1211,9 @@ async function processRequest(
       return failed;
     }
     if (toolCalls.length === 0) {
+      if (applyQueuedSteeringFallback()) {
+        continue;
+      }
       if (ralphEnabled) {
         const branchChoice = parseRalphChoice(choice.message.content);
         if (branchChoice === 'STOP') {
@@ -1312,6 +1396,7 @@ async function processRequest(
             if (completed.succeeded) {
               successfulToolCallsThisTurn += 1;
             }
+            executedToolCallIds.push(completed.callId);
             appendCompletedToolCall({
               completed,
               toolsUsed,
@@ -1321,6 +1406,13 @@ async function processRequest(
               artifacts,
               artifactPaths,
             });
+          }
+          if (applyQueuedSteeringToRecentToolMessages(preparedBatch.length)) {
+            retainCompletedAssistantToolCalls(
+              assistantMessage,
+              executedToolCallIds,
+            );
+            continue requestLoop;
           }
           callIndex += preparedBatch.length;
           continue;
@@ -1447,6 +1539,7 @@ async function processRequest(
       if (completed.succeeded) {
         successfulToolCallsThisTurn += 1;
       }
+      executedToolCallIds.push(completed.callId);
       appendCompletedToolCall({
         completed,
         toolsUsed,
@@ -1456,6 +1549,13 @@ async function processRequest(
         artifacts,
         artifactPaths,
       });
+      if (applyQueuedSteeringToRecentToolMessages(1)) {
+        retainCompletedAssistantToolCalls(
+          assistantMessage,
+          executedToolCallIds,
+        );
+        continue requestLoop;
+      }
       callIndex += 1;
     }
     stalledTurns = advanceStalledTurnCount({

--- a/container/src/ipc.ts
+++ b/container/src/ipc.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { IPC_DIR } from './runtime-paths.js';
+import type { QueuedSteeringNote } from './steering.js';
 import type { ContainerInput, ContainerOutput } from './types.js';
 
 const INPUT_PATH = path.join(IPC_DIR, 'input.json');
@@ -36,4 +37,38 @@ export async function waitForInput(
 
 export function writeOutput(output: ContainerOutput): void {
   fs.writeFileSync(OUTPUT_PATH, JSON.stringify(output, null, 2));
+}
+
+export function takePendingSteeringNotes(): QueuedSteeringNote[] {
+  let entries: string[];
+  try {
+    entries = fs
+      .readdirSync(IPC_DIR)
+      .filter((entry) => entry.startsWith('steer-') && entry.endsWith('.json'))
+      .sort((left, right) => left.localeCompare(right));
+  } catch {
+    return [];
+  }
+
+  const notes: QueuedSteeringNote[] = [];
+  for (const entry of entries) {
+    const filePath = path.join(IPC_DIR, entry);
+    try {
+      const raw = fs.readFileSync(filePath, 'utf-8');
+      const parsed = JSON.parse(raw) as Partial<QueuedSteeringNote>;
+      const note = String(parsed.note || '').trim();
+      const createdAt = String(parsed.createdAt || '').trim();
+      if (note && createdAt) {
+        notes.push({ note, createdAt });
+      }
+    } catch {
+      // Ignore malformed steering payloads after removing them below.
+    } finally {
+      try {
+        fs.unlinkSync(filePath);
+      } catch {}
+    }
+  }
+
+  return notes;
 }

--- a/container/src/steering.ts
+++ b/container/src/steering.ts
@@ -1,0 +1,106 @@
+import type { ChatMessage } from './types.js';
+
+export interface QueuedSteeringNote {
+  note: string;
+  createdAt: string;
+}
+
+function normalizeSteeringNoteText(note: string): string {
+  return String(note || '').trim();
+}
+
+function normalizedSteeringNotes(notes: QueuedSteeringNote[]): string[] {
+  return notes
+    .map((entry) => normalizeSteeringNoteText(entry.note))
+    .filter(Boolean);
+}
+
+export function buildSteeringCheckpointPrompt(
+  notes: QueuedSteeringNote[],
+): string {
+  const normalized = normalizedSteeringNotes(notes);
+  if (normalized.length === 0) return '';
+
+  const lines = [
+    'Steering note from the user during the current turn. You reached a safe checkpoint after a tool or model step. Adjust course immediately and continue from the current state instead of restarting.',
+    '',
+    normalized.length === 1 ? 'User note:' : 'User notes:',
+  ];
+
+  if (normalized.length === 1) {
+    lines.push(normalized[0]);
+  } else {
+    for (let index = 0; index < normalized.length; index += 1) {
+      lines.push(`${index + 1}. ${normalized[index]}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export function appendSteeringNotesToToolMessages(params: {
+  history: ChatMessage[];
+  notes: QueuedSteeringNote[];
+  recentToolMessageCount: number;
+}): string | null {
+  const normalized = normalizedSteeringNotes(params.notes);
+  if (normalized.length === 0 || params.recentToolMessageCount <= 0) {
+    return null;
+  }
+
+  let targetIndex = -1;
+  const earliestIndex = Math.max(
+    params.history.length - params.recentToolMessageCount,
+    0,
+  );
+  for (
+    let index = params.history.length - 1;
+    index >= earliestIndex;
+    index -= 1
+  ) {
+    if (params.history[index]?.role === 'tool') {
+      targetIndex = index;
+      break;
+    }
+  }
+  if (targetIndex < 0) return null;
+
+  const lines = ['', '', '[USER STEER (injected mid-run, not tool output):'];
+  if (normalized.length === 1) {
+    lines.push(normalized[0]);
+  } else {
+    for (let index = 0; index < normalized.length; index += 1) {
+      lines.push(`${index + 1}. ${normalized[index]}`);
+    }
+  }
+  lines.push(']');
+  const marker = lines.join('\n');
+
+  const target = params.history[targetIndex];
+  if (typeof target.content === 'string' || target.content == null) {
+    target.content = `${target.content || ''}${marker}`;
+    return marker;
+  }
+
+  target.content = [
+    ...target.content,
+    {
+      type: 'text',
+      text: marker.trimStart(),
+    },
+  ];
+  return marker;
+}
+
+export function appendSteeringCheckpointMessage(params: {
+  history: ChatMessage[];
+  notes: QueuedSteeringNote[];
+}): string | null {
+  const prompt = buildSteeringCheckpointPrompt(params.notes);
+  if (!prompt) return null;
+  params.history.push({
+    role: 'user',
+    content: prompt,
+  });
+  return prompt;
+}

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -87,6 +87,7 @@ const REGISTERED_TEXT_COMMAND_NAMES = new Set([
   'status',
   'memory',
   'show',
+  'steer',
   'approve',
   'usage',
   'export',
@@ -271,6 +272,10 @@ const LOCAL_SESSION_HELP_PRESENTATIONS: Record<
   schedule: {
     command: '/schedule add "<cron>" <prompt>',
     description: 'Add a scheduled task',
+  },
+  steer: {
+    command: '/steer <note>',
+    description: 'Queue a steering note for the active run',
   },
   secret: {
     command: '/secret [list|set|show|unset|route]',
@@ -459,6 +464,9 @@ export function mapCanonicalCommandToGatewayArgs(
 
     case 'show':
       return parts.length > 1 ? ['show', ...parts.slice(1)] : ['show'];
+
+    case 'steer':
+      return parts.length > 1 ? ['steer', ...parts.slice(1)] : ['steer'];
 
     case 'channel-mode':
       return ['channel', 'mode', ...parts.slice(1)];
@@ -691,6 +699,23 @@ function buildSlashCommandCatalogDefinitions(
           kind: 'subcommand',
           name: 'none',
           description: 'Hide thinking and tool activity',
+        },
+      ],
+    },
+    {
+      name: 'steer',
+      description:
+        'Queue a steering note for the active run without interrupting the turn',
+      tuiMenu: {
+        label: '/steer <note>',
+        insertText: '/steer ',
+      },
+      options: [
+        {
+          kind: 'string',
+          name: 'note',
+          description: 'Steering note to inject at the next safe checkpoint',
+          required: true,
         },
       ],
     },
@@ -2671,6 +2696,11 @@ export function parseCanonicalSlashCommandArgs(
         return ['show', subcommand];
       }
       return null;
+    }
+
+    case 'steer': {
+      const note = normalizeStringOption(interaction, 'note', true);
+      return note ? ['steer', note] : null;
     }
 
     case 'approve': {

--- a/src/gateway/gateway-request-runtime.ts
+++ b/src/gateway/gateway-request-runtime.ts
@@ -1,4 +1,5 @@
 import { stopSessionExecution } from '../agent/executor.js';
+import { enqueueSteeringNote } from '../infra/ipc.js';
 
 interface ActiveGatewayRequest {
   controller: AbortController;
@@ -22,6 +23,20 @@ function deleteGatewayRequestEntry(
   if (sessionEntries.size === 0) {
     activeGatewayRequestsBySession.delete(sessionId);
   }
+}
+
+function listExecutionSessionIds(sessionId: string): string[] {
+  const sessionEntries = activeGatewayRequestsBySession.get(sessionId);
+  if (!sessionEntries || sessionEntries.size === 0) return [];
+  return [
+    ...new Set(
+      [...sessionEntries]
+        .map((entry) => entry.executionSessionId)
+        .filter(
+          (value) => typeof value === 'string' && value.trim().length > 0,
+        ),
+    ),
+  ];
 }
 
 export function registerActiveGatewayRequest(params: {
@@ -76,13 +91,25 @@ export function abortActiveGatewayRequests(sessionId: string): number {
   return entries.length;
 }
 
+export function enqueueGatewaySessionSteeringNote(params: {
+  sessionId: string;
+  note: string;
+}): {
+  queued: number;
+  executionSessionIds: string[];
+} {
+  const executionSessionIds = listExecutionSessionIds(params.sessionId);
+  for (const executionSessionId of executionSessionIds) {
+    enqueueSteeringNote(executionSessionId, params.note);
+  }
+  return {
+    queued: executionSessionIds.length,
+    executionSessionIds,
+  };
+}
+
 export function interruptGatewaySessionExecution(sessionId: string): boolean {
-  const sessionEntries = activeGatewayRequestsBySession.get(sessionId);
-  const executionSessionIds = new Set(
-    [...(sessionEntries || [])]
-      .map((entry) => entry.executionSessionId)
-      .filter((value) => typeof value === 'string' && value.trim().length > 0),
-  );
+  const executionSessionIds = new Set(listExecutionSessionIds(sessionId));
   const abortedRequests = abortActiveGatewayRequests(sessionId);
   if (executionSessionIds.size === 0) {
     executionSessionIds.add(sessionId);

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -320,6 +320,7 @@ import {
 import {
   getFullAutoRuntimeState,
   isFullAutoEnabled,
+  noteFullAutoSupervisedIntervention,
   type ProactiveMessagePayload,
   resolveSessionRalphIterations,
 } from './fullauto-runtime.js';
@@ -345,7 +346,10 @@ import {
   tryHandlePluginDefinedGatewayCommand,
 } from './gateway-plugin-service.js';
 import { diagnoseProviderForModels } from './gateway-provider-service.js';
-import { interruptGatewaySessionExecution } from './gateway-request-runtime.js';
+import {
+  enqueueGatewaySessionSteeringNote,
+  interruptGatewaySessionExecution,
+} from './gateway-request-runtime.js';
 import { getGatewayLifecycleStatus } from './gateway-restart.js';
 import { readSessionStatusSnapshot } from './gateway-session-status.js';
 import {
@@ -7611,6 +7615,33 @@ export async function handleGatewayCommand(
           req,
           prompt,
         });
+      }
+
+      case 'steer': {
+        const note = req.args.slice(1).join(' ').trim();
+        if (!note) {
+          return badCommand('Usage', 'Usage: `steer <note>`');
+        }
+
+        const queued = enqueueGatewaySessionSteeringNote({
+          sessionId: req.sessionId,
+          note,
+        });
+        if (queued.queued === 0) {
+          return badCommand(
+            'No Active Run',
+            'No active session run to steer. Send a normal message or start a task first.',
+          );
+        }
+
+        noteFullAutoSupervisedIntervention({
+          session,
+          content: note,
+          source: 'steer',
+        });
+        return plainCommand(
+          `Queued steering note for ${queued.queued === 1 ? 'the active run' : `${queued.queued} active runs`}. It will be delivered at the next tool checkpoint or before the turn finishes.`,
+        );
       }
 
       case 'show': {

--- a/src/infra/ipc.ts
+++ b/src/infra/ipc.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -83,6 +84,26 @@ export function writeInput(
   fs.writeFileSync(inputPath, JSON.stringify(toWrite, null, 2));
   logger.debug({ sessionId, path: inputPath }, 'Wrote IPC input');
   return inputPath;
+}
+
+export function enqueueSteeringNote(sessionId: string, note: string): string {
+  const normalizedNote = String(note || '').trim();
+  if (!normalizedNote) {
+    throw new Error('Steering note must be non-empty.');
+  }
+  ensureSessionDirs(sessionId);
+  const dir = ipcDir(sessionId);
+  const timestamp = String(Date.now()).padStart(13, '0');
+  const finalPath = path.join(dir, `steer-${timestamp}-${randomUUID()}.json`);
+  const tempPath = `${finalPath}.tmp`;
+  const payload = {
+    note: normalizedNote,
+    createdAt: new Date().toISOString(),
+  };
+  fs.writeFileSync(tempPath, JSON.stringify(payload, null, 2));
+  fs.renameSync(tempPath, finalPath);
+  logger.debug({ sessionId, path: finalPath }, 'Queued IPC steering note');
+  return finalPath;
 }
 
 /**

--- a/src/tui-banner.ts
+++ b/src/tui-banner.ts
@@ -101,6 +101,7 @@ const SLASH_COMMANDS = [
   '/show',
   '/skill',
   '/status',
+  '/steer',
   '/stop',
   '/usage',
 ] as const;

--- a/tests/command-registry.test.ts
+++ b/tests/command-registry.test.ts
@@ -755,6 +755,39 @@ test('builds local session help entries from the registry with surface filtering
   );
 });
 
+test('registers steer as a canonical slash/text command and parses its note payload', async () => {
+  const {
+    buildCanonicalSlashCommandDefinitions,
+    buildLocalSessionSlashHelpEntries,
+    isRegisteredTextCommandName,
+    mapCanonicalCommandToGatewayArgs,
+    parseCanonicalSlashCommandArgs,
+  } = await importCommandRegistry();
+
+  expect(isRegisteredTextCommandName('steer')).toBe(true);
+  expect(
+    buildCanonicalSlashCommandDefinitions([]).some(
+      (definition) => definition.name === 'steer',
+    ),
+  ).toBe(true);
+  expect(
+    buildLocalSessionSlashHelpEntries('web').some(
+      (entry) => entry.command === '/steer <note>',
+    ),
+  ).toBe(true);
+  expect(
+    parseCanonicalSlashCommandArgs({
+      commandName: 'steer',
+      getString: (name) =>
+        name === 'note' ? 'Use the smaller diff first.' : null,
+      getSubcommand: () => null,
+    }),
+  ).toEqual(['steer', 'Use the smaller diff first.']);
+  expect(
+    mapCanonicalCommandToGatewayArgs(['steer', 'use', 'smaller', 'diff']),
+  ).toEqual(['steer', 'use', 'smaller', 'diff']);
+});
+
 test('registers policy as a local-only slash command and parses slash args', async () => {
   const {
     buildCanonicalSlashCommandDefinitions,

--- a/tests/container.steering.test.ts
+++ b/tests/container.steering.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  appendSteeringCheckpointMessage,
+  appendSteeringNotesToToolMessages,
+  buildSteeringCheckpointPrompt,
+} from '../container/src/steering.js';
+
+describe('container steering checkpoints', () => {
+  test('builds a single-note steering prompt', () => {
+    expect(
+      buildSteeringCheckpointPrompt([
+        {
+          note: 'Use the smaller diff first.',
+          createdAt: '2026-04-19T10:00:00.000Z',
+        },
+      ]),
+    ).toContain('User note:\nUse the smaller diff first.');
+  });
+
+  test('numbers multiple queued steering notes in order', () => {
+    expect(
+      buildSteeringCheckpointPrompt([
+        {
+          note: 'Finish the refactor before polishing.',
+          createdAt: '2026-04-19T10:00:00.000Z',
+        },
+        {
+          note: 'Skip unrelated README edits.',
+          createdAt: '2026-04-19T10:01:00.000Z',
+        },
+      ]),
+    ).toContain(
+      'User notes:\n1. Finish the refactor before polishing.\n2. Skip unrelated README edits.',
+    );
+  });
+
+  test('appends a user checkpoint message only when notes are present', () => {
+    const history = [{ role: 'assistant' as const, content: 'working' }];
+
+    const prompt = appendSteeringCheckpointMessage({
+      history,
+      notes: [
+        {
+          note: 'Change direction here.',
+          createdAt: '2026-04-19T10:00:00.000Z',
+        },
+      ],
+    });
+
+    expect(prompt).toContain('Change direction here.');
+    expect(history.at(-1)).toEqual({
+      role: 'user',
+      content: expect.stringContaining('Change direction here.'),
+    });
+    expect(
+      appendSteeringCheckpointMessage({
+        history,
+        notes: [],
+      }),
+    ).toBeNull();
+  });
+
+  test('appends queued steering notes to the last recent tool result', () => {
+    const history = [
+      { role: 'assistant' as const, content: null },
+      { role: 'tool' as const, tool_call_id: 'a', content: 'first result' },
+      { role: 'tool' as const, tool_call_id: 'b', content: 'second result' },
+    ];
+
+    const marker = appendSteeringNotesToToolMessages({
+      history,
+      recentToolMessageCount: 2,
+      notes: [
+        {
+          note: 'Use the smaller diff first.',
+          createdAt: '2026-04-19T10:00:00.000Z',
+        },
+      ],
+    });
+
+    expect(marker).toContain('USER STEER');
+    expect(history[1]).toEqual({
+      role: 'tool',
+      tool_call_id: 'a',
+      content: 'first result',
+    });
+    expect(history[2]).toEqual({
+      role: 'tool',
+      tool_call_id: 'b',
+      content: expect.stringContaining('second result'),
+    });
+    expect(history[2]?.content).toContain('Use the smaller diff first.');
+  });
+
+  test('preserves multimodal tool results when steering is appended', () => {
+    const history = [
+      {
+        role: 'tool' as const,
+        tool_call_id: 'a',
+        content: [{ type: 'text' as const, text: 'existing output' }],
+      },
+    ];
+
+    appendSteeringNotesToToolMessages({
+      history,
+      recentToolMessageCount: 1,
+      notes: [
+        {
+          note: 'Change direction here.',
+          createdAt: '2026-04-19T10:00:00.000Z',
+        },
+      ],
+    });
+
+    expect(history[0]?.content).toEqual([
+      { type: 'text', text: 'existing output' },
+      {
+        type: 'text',
+        text: expect.stringContaining('Change direction here.'),
+      },
+    ]);
+  });
+});

--- a/tests/gateway-request-runtime.test.ts
+++ b/tests/gateway-request-runtime.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+const { enqueueSteeringNoteMock, stopSessionExecutionMock } = vi.hoisted(
+  () => ({
+    enqueueSteeringNoteMock: vi.fn(),
+    stopSessionExecutionMock: vi.fn(() => false),
+  }),
+);
+
+vi.mock('../src/infra/ipc.js', () => ({
+  enqueueSteeringNote: enqueueSteeringNoteMock,
+}));
+
+vi.mock('../src/agent/executor.js', () => ({
+  stopSessionExecution: stopSessionExecutionMock,
+}));
+
+afterEach(() => {
+  enqueueSteeringNoteMock.mockReset();
+  stopSessionExecutionMock.mockReset();
+  stopSessionExecutionMock.mockImplementation(() => false);
+  vi.resetModules();
+  vi.restoreAllMocks();
+});
+
+test('queues steering notes against active execution session ids', async () => {
+  const runtime = await import('../src/gateway/gateway-request-runtime.ts');
+  const first = runtime.registerActiveGatewayRequest({
+    sessionId: 'session-steer',
+    executionSessionId: 'exec-a',
+  });
+  const second = runtime.registerActiveGatewayRequest({
+    sessionId: 'session-steer',
+    executionSessionId: 'exec-a',
+  });
+  const third = runtime.registerActiveGatewayRequest({
+    sessionId: 'session-steer',
+    executionSessionId: 'exec-b',
+  });
+
+  try {
+    expect(
+      runtime.enqueueGatewaySessionSteeringNote({
+        sessionId: 'session-steer',
+        note: 'Use the smaller diff first.',
+      }),
+    ).toEqual({
+      queued: 2,
+      executionSessionIds: ['exec-a', 'exec-b'],
+    });
+    expect(enqueueSteeringNoteMock).toHaveBeenCalledTimes(2);
+    expect(enqueueSteeringNoteMock).toHaveBeenNthCalledWith(
+      1,
+      'exec-a',
+      'Use the smaller diff first.',
+    );
+    expect(enqueueSteeringNoteMock).toHaveBeenNthCalledWith(
+      2,
+      'exec-b',
+      'Use the smaller diff first.',
+    );
+  } finally {
+    first.release();
+    second.release();
+    third.release();
+  }
+});
+
+test('returns an empty steering queue result when the session is idle', async () => {
+  const runtime = await import('../src/gateway/gateway-request-runtime.ts');
+
+  expect(
+    runtime.enqueueGatewaySessionSteeringNote({
+      sessionId: 'session-idle',
+      note: 'Try a smaller batch.',
+    }),
+  ).toEqual({
+    queued: 0,
+    executionSessionIds: [],
+  });
+  expect(enqueueSteeringNoteMock).not.toHaveBeenCalled();
+});

--- a/tests/tui-banner.test.ts
+++ b/tests/tui-banner.test.ts
@@ -281,6 +281,7 @@ test('wraps panel rows for very narrow terminals and defaults provider to Hybrid
     '│ /show                      │',
     '│ /skill                     │',
     '│ /status                    │',
+    '│ /steer                     │',
     '│ /stop                      │',
     '│ /usage                     │',
   ]);

--- a/tests/tui-slash-command.test.ts
+++ b/tests/tui-slash-command.test.ts
@@ -113,6 +113,9 @@ test('maps Discord-style slash commands to gateway command args', () => {
     'show',
     'tools',
   ]);
+  expect(
+    mapTuiSlashCommandToGatewayArgs(['steer', 'use', 'smaller', 'diff']),
+  ).toEqual(['steer', 'use', 'smaller', 'diff']);
   expect(mapTuiSlashCommandToGatewayArgs(['channel-mode', 'free'])).toEqual([
     'channel',
     'mode',
@@ -159,12 +162,7 @@ test('maps Discord-style slash commands to gateway command args', () => {
     mapTuiSlashCommandToGatewayArgs(['skill', 'install', 'demo-skill']),
   ).toEqual(['skill', 'install', 'demo-skill']);
   expect(
-    mapTuiSlashCommandToGatewayArgs([
-      'skill',
-      'install',
-      '1password',
-      'brew',
-    ]),
+    mapTuiSlashCommandToGatewayArgs(['skill', 'install', '1password', 'brew']),
   ).toEqual(['skill', 'install', '1password', 'brew']);
   expect(
     mapTuiSlashCommandToGatewayArgs(['skill', 'learn', 'demo-skill']),

--- a/tests/tui-slash-menu.test.ts
+++ b/tests/tui-slash-menu.test.ts
@@ -42,6 +42,7 @@ test('builds canonical, choice-based, and TUI-only slash menu entries', () => {
   expect(labels).toContain('/approve session [approval_id]');
   expect(labels).toContain('/approve all [approval_id]');
   expect(labels).toContain('/fullauto on [prompt]');
+  expect(labels).toContain('/steer <note>');
   expect(labels).toContain('/bot list');
   expect(labels).toContain('/agent install <source>');
   expect(labels).toContain('/plugin install <path|plugin-id|npm-spec>');


### PR DESCRIPTION
## What changed

This adds mid-run \/steer <note> delivery so a user can nudge an active run without interrupting the turn.

The command is now exposed through the gateway and TUI surfaces, queued against the active execution session, and consumed inside the container runtime.

## Behavior

- \/steer <note> queues a note for the currently running execution session.
- During tool execution, queued steer notes are attached to the most recently completed tool result so the model sees them on the next iteration without starting a fresh user turn.
- If the run reaches a no-tool checkpoint before another tool result exists, the note is delivered as a same-turn fallback user checkpoint instead of being dropped.
- For interrupted partial tool batches, completed assistant tool calls are trimmed so the resumed model call remains protocol-valid.

## Why

This is the main coworker-feel upgrade for active runs: direction can change mid-turn without forcing a restart.

I also aligned the primary runtime behavior with the Hermes reference in ~/examples/hermes-agent, which injects steering into the next completed tool result rather than using a synthetic user turn on the normal path.

## Impact

- Users can steer long-running work after a tool boundary.
- Gateway sessions target the active execution session rather than only the user-facing session id.
- TUI help and slash command surfaces now advertise \/steer.

## Validation

- npm run lint
- npm --prefix container run lint
- npm run build
- npx vitest run --configLoader runner --config vitest.unit.config.ts tests/gateway-request-runtime.test.ts tests/command-registry.test.ts tests/tui-slash-command.test.ts tests/tui-banner.test.ts tests/tui-slash-menu.test.ts tests/container.steering.test.ts

## Notes

I did not run the full npm run test:unit suite locally. This machine is on Node v25.9.0, while the checked-in better-sqlite3 native binary in node_modules was built against an older ABI, so broader runtime-config and DB startup paths are unreliable here.