### PR TITLE
[codex] Add agent collaboration tools and named destinations

### DIFF
--- a/container/src/tools.ts
+++ b/container/src/tools.ts
@@ -960,6 +960,18 @@ function resolveGatewayPluginToolUrl(): string | null {
   return `${base}/api/plugin/tool`;
 }
 
+function resolveGatewayAgentsUrl(): string | null {
+  const base = gatewayBaseUrl.replace(/\/+$/, '');
+  if (!base) return null;
+  return `${base}/api/agents`;
+}
+
+function resolveGatewayAgentChatUrl(): string | null {
+  const base = gatewayBaseUrl.replace(/\/+$/, '');
+  if (!base) return null;
+  return `${base}/api/agents/chat`;
+}
+
 function resolveGatewayHttpRequestUrl(): string | null {
   const base = gatewayBaseUrl.replace(/\/+$/, '');
   if (!base) return null;
@@ -1047,6 +1059,171 @@ async function callGatewayMessageAction(
 
   if (parsed) return JSON.stringify(parsed, null, 2);
   return rawText || JSON.stringify({ ok: true }, null, 2);
+}
+
+async function callGatewayAgentsList(): Promise<string> {
+  const url = resolveGatewayAgentsUrl();
+  if (!url) {
+    return failTool(
+      'Error: list_agents is unavailable because gatewayBaseUrl is not configured.',
+    );
+  }
+
+  const headers: Record<string, string> = {};
+  if (gatewayApiToken) {
+    headers.Authorization = `Bearer ${gatewayApiToken}`;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'GET',
+      headers,
+    });
+  } catch (err) {
+    return failTool(
+      `Error: list_agents request failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
+  const rawText = await response.text();
+  let parsed: Record<string, unknown> | null = null;
+  try {
+    const maybe = JSON.parse(rawText) as unknown;
+    if (maybe && typeof maybe === 'object' && !Array.isArray(maybe)) {
+      parsed = maybe as Record<string, unknown>;
+    }
+  } catch {
+    parsed = null;
+  }
+
+  if (!response.ok) {
+    return failTool(
+      JSON.stringify(
+        {
+          ok: false,
+          status: response.status,
+          error:
+            (parsed && typeof parsed.error === 'string' && parsed.error) ||
+            rawText ||
+            `HTTP ${response.status}`,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+
+  const rawAgents = Array.isArray(parsed?.agents) ? parsed.agents : [];
+  const agents = rawAgents
+    .filter(
+      (entry): entry is Record<string, unknown> =>
+        Boolean(entry) && typeof entry === 'object' && !Array.isArray(entry),
+    )
+    .map((entry) => ({
+      id: typeof entry.id === 'string' ? entry.id : '',
+      name: typeof entry.name === 'string' ? entry.name : null,
+      model: typeof entry.model === 'string' ? entry.model : null,
+      status: typeof entry.status === 'string' ? entry.status : null,
+      workspacePath:
+        typeof entry.workspacePath === 'string' ? entry.workspacePath : null,
+      sessionCount:
+        typeof entry.sessionCount === 'number' &&
+        Number.isFinite(entry.sessionCount)
+          ? entry.sessionCount
+          : 0,
+      activeSessions:
+        typeof entry.activeSessions === 'number' &&
+        Number.isFinite(entry.activeSessions)
+          ? entry.activeSessions
+          : 0,
+    }))
+    .filter((entry) => entry.id);
+
+  return JSON.stringify(
+    {
+      success: true,
+      count: agents.length,
+      agents,
+    },
+    null,
+    2,
+  );
+}
+
+async function callGatewayAgentChat(
+  payload: Record<string, unknown>,
+): Promise<string> {
+  const url = resolveGatewayAgentChatUrl();
+  if (!url) {
+    return failTool(
+      'Error: chat_with_agent is unavailable because gatewayBaseUrl is not configured.',
+    );
+  }
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (gatewayApiToken) {
+    headers.Authorization = `Bearer ${gatewayApiToken}`;
+  }
+
+  const requestPayload = { ...payload };
+  if (
+    currentSessionId &&
+    typeof requestPayload.currentSessionId !== 'string' &&
+    !Array.isArray(requestPayload.currentSessionId)
+  ) {
+    requestPayload.currentSessionId = currentSessionId;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(requestPayload),
+    });
+  } catch (err) {
+    return failTool(
+      `Error: chat_with_agent request failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
+  const rawText = await response.text();
+  let parsed: Record<string, unknown> | null = null;
+  try {
+    const maybe = JSON.parse(rawText) as unknown;
+    if (maybe && typeof maybe === 'object' && !Array.isArray(maybe)) {
+      parsed = maybe as Record<string, unknown>;
+    }
+  } catch {
+    parsed = null;
+  }
+
+  if (!response.ok) {
+    return failTool(
+      JSON.stringify(
+        {
+          ok: false,
+          status: response.status,
+          error:
+            (parsed && typeof parsed.error === 'string' && parsed.error) ||
+            rawText ||
+            `HTTP ${response.status}`,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+
+  if (parsed) return JSON.stringify(parsed, null, 2);
+  return rawText || JSON.stringify({ success: true }, null, 2);
 }
 
 async function callGatewayPluginTool(
@@ -2157,7 +2334,7 @@ async function executeToolInternal(
   }
   const args =
     parsedArgs && typeof parsedArgs === 'object'
-      ? (parsedArgs as Record<string, any>)
+      ? (parsedArgs as Record<string, unknown>)
       : {};
   const auxiliaryRuntimeContext = captureAuxiliaryRuntimeContext();
 
@@ -2396,6 +2573,43 @@ async function executeToolInternal(
         command: args.command,
         timeoutMs,
       });
+    }
+
+    case 'list_agents': {
+      return await callGatewayAgentsList();
+    }
+
+    case 'chat_with_agent': {
+      const toAgent =
+        readStringValue(args.to_agent) ||
+        readStringValue(args.toAgent) ||
+        readStringValue(args.agentId);
+      if (!toAgent) {
+        return failTool('Error: to_agent is required for chat_with_agent.');
+      }
+      const text =
+        readStringValue(args.text) ||
+        readStringValue(args.prompt) ||
+        readStringValue(args.message);
+      if (!text) {
+        return failTool('Error: text is required for chat_with_agent.');
+      }
+
+      const payload: Record<string, unknown> = {
+        toAgent,
+        text,
+      };
+      const sessionId =
+        readStringValue(args.session_id) || readStringValue(args.sessionId);
+      const destination =
+        readStringValue(args.destination) || readStringValue(args.route);
+      const timeoutSeconds = readPositiveNumberValue(
+        args.timeout_seconds ?? args.timeoutSeconds,
+      );
+      if (sessionId) payload.sessionId = sessionId;
+      if (destination) payload.destination = destination;
+      if (timeoutSeconds != null) payload.timeoutSeconds = timeoutSeconds;
+      return await callGatewayAgentChat(payload);
     }
 
     case 'memory': {
@@ -3903,6 +4117,86 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
     },
   },
   ...BROWSER_TOOL_DEFINITIONS,
+  {
+    type: 'function',
+    function: {
+      name: 'list_agents',
+      description:
+        'List the configured HybridClaw agents available for collaboration. Use this before handing work to a named agent so you can target a real agent id instead of guessing.',
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: [],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'chat_with_agent',
+      description:
+        'Send a focused foreground handoff to another configured HybridClaw agent and wait for its reply. Use `to_agent` with an id returned by `list_agents`. Optional `destination` creates or reuses a named route between the current agent and the target agent. Reuse `session_id` to continue the same inter-agent conversation.',
+      parameters: {
+        type: 'object',
+        properties: {
+          to_agent: {
+            type: 'string',
+            description:
+              'Target agent id from `list_agents` (required). Alias: `toAgent`.',
+          },
+          toAgent: {
+            type: 'string',
+            description: 'Alias of `to_agent`.',
+          },
+          agentId: {
+            type: 'string',
+            description: 'Secondary alias of `to_agent`.',
+          },
+          text: {
+            type: 'string',
+            description:
+              'Self-contained request for the target agent. Alias: `prompt` or `message`.',
+          },
+          prompt: {
+            type: 'string',
+            description: 'Alias of `text`.',
+          },
+          message: {
+            type: 'string',
+            description: 'Alias of `text`.',
+          },
+          session_id: {
+            type: 'string',
+            description:
+              'Optional existing inter-agent session key to continue. Alias: `sessionId`.',
+          },
+          sessionId: {
+            type: 'string',
+            description: 'Alias of `session_id`.',
+          },
+          destination: {
+            type: 'string',
+            description:
+              'Optional named destination for the route between the current agent and the target agent. Defaults to `default` when omitted. Alias: `route`.',
+          },
+          route: {
+            type: 'string',
+            description: 'Alias of `destination`.',
+          },
+          timeout_seconds: {
+            type: 'number',
+            description:
+              'Optional wall-clock timeout in seconds for the target agent turn (5-900). Alias: `timeoutSeconds`.',
+          },
+          timeoutSeconds: {
+            type: 'number',
+            description: 'Alias of `timeout_seconds`.',
+          },
+        },
+        required: [],
+      },
+    },
+  },
   {
     type: 'function',
     function: {

--- a/src/agent/prompt-hooks.ts
+++ b/src/agent/prompt-hooks.ts
@@ -479,6 +479,7 @@ function buildProactivityHook(context: PromptHookContext): string {
     '',
     '## Subagent Delegation Playbook',
     'Use `delegate` to offload narrow, self-contained subtasks to subagents.',
+    'Use `list_agents` to discover named agents and `chat_with_agent` when a configured agent should handle or review work directly.',
     '',
     '### When to use `delegate`',
     '- Reasoning-heavy subtasks (debugging, code review, research synthesis).',

--- a/src/agent/tool-summary.ts
+++ b/src/agent/tool-summary.ts
@@ -46,6 +46,10 @@ const TOOL_GROUPS: ToolGroup[] = [
     tools: ['message'],
   },
   {
+    label: 'Agent Collaboration',
+    tools: ['list_agents', 'chat_with_agent'],
+  },
+  {
     label: 'Scheduling',
     tools: ['cron'],
   },

--- a/src/gateway/agent-collaboration.ts
+++ b/src/gateway/agent-collaboration.ts
@@ -1,0 +1,73 @@
+import { buildSessionKey } from '../session/session-key.js';
+
+export const DEFAULT_AGENT_COLLABORATION_DESTINATION = 'default';
+const MAX_AGENT_COLLABORATION_DESTINATION_LENGTH = 64;
+
+function normalizeAgentCollaborationString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export function parseAgentCollaborationDestination(value: unknown): string {
+  const normalized = normalizeAgentCollaborationString(value);
+  if (!normalized) return DEFAULT_AGENT_COLLABORATION_DESTINATION;
+  if (normalized.length > MAX_AGENT_COLLABORATION_DESTINATION_LENGTH) {
+    throw new Error(
+      `Agent collaboration destination must be ${MAX_AGENT_COLLABORATION_DESTINATION_LENGTH} characters or fewer.`,
+    );
+  }
+  return normalized;
+}
+
+export function buildAgentCollaborationSessionKey(params: {
+  sourceAgentId: string;
+  targetAgentId: string;
+  destination: string;
+  sessionId?: string | null;
+}): string {
+  const explicitSessionId = normalizeAgentCollaborationString(params.sessionId);
+  if (explicitSessionId) return explicitSessionId;
+  return buildSessionKey(
+    params.targetAgentId,
+    'agent',
+    'dm',
+    params.sourceAgentId,
+    {
+      subagentId: params.destination,
+    },
+  );
+}
+
+function sanitizeChannelSegment(value: string): string {
+  const normalized = normalizeAgentCollaborationString(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return normalized || DEFAULT_AGENT_COLLABORATION_DESTINATION;
+}
+
+export function buildAgentCollaborationChannelId(params: {
+  sourceAgentId: string;
+  destination: string;
+}): string {
+  return `agent:${sanitizeChannelSegment(params.sourceAgentId)}:${sanitizeChannelSegment(params.destination)}`;
+}
+
+export function formatAgentCollaborationPrompt(params: {
+  sourceAgentId: string;
+  targetAgentId: string;
+  destination: string;
+  text: string;
+}): string {
+  return [
+    '# Agent Handoff',
+    `- Source agent: \`${params.sourceAgentId}\``,
+    `- Target agent: \`${params.targetAgentId}\``,
+    `- Destination: \`${params.destination}\``,
+    '- This is an internal agent-to-agent collaboration request, not a direct user message.',
+    '- Reply to the requesting agent with the concrete result it needs.',
+    '',
+    '## Request',
+    params.text.trim(),
+  ].join('\n');
+}

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -4,6 +4,7 @@ import { buildConversationContext } from '../agent/conversation.js';
 import { processSideEffects } from '../agent/side-effects.js';
 import { isSilentReply } from '../agent/silent-reply.js';
 import {
+  findAgentConfig,
   resolveAgentConfig,
   resolveAgentForRequest,
   resolveAgentModel,
@@ -36,6 +37,7 @@ import {
   getTasksForSession,
   logAudit,
   recordUsageEvent,
+  resolveSessionIdCompat,
 } from '../memory/db.js';
 import {
   type BuildMemoryPromptResult,
@@ -61,6 +63,12 @@ import {
 import type { PendingApproval, ToolProgressEvent } from '../types/execution.js';
 import type { CanonicalSessionContext } from '../types/session.js';
 import { ensureBootstrapFiles } from '../workspace.js';
+import {
+  buildAgentCollaborationChannelId,
+  buildAgentCollaborationSessionKey,
+  formatAgentCollaborationPrompt,
+  parseAgentCollaborationDestination,
+} from './agent-collaboration.js';
 import { buildConciergeChoiceComponents } from './concierge-choice.js';
 import {
   buildConciergeExecutionNotice,
@@ -105,7 +113,12 @@ import {
   resolveSessionAutoResetPolicy,
   shouldForceNewTuiSession,
 } from './gateway-service.js';
-import type { GatewayChatRequest, GatewayChatResult } from './gateway-types.js';
+import type {
+  GatewayAgentCollaborationRequest,
+  GatewayAgentCollaborationResult,
+  GatewayChatRequest,
+  GatewayChatResult,
+} from './gateway-types.js';
 import { firstNumber } from './gateway-utils.js';
 import {
   normalizeSessionShowMode,
@@ -127,6 +140,110 @@ export async function handleGatewayMessage(
     },
     async () => handleGatewayMessageInner(req),
   );
+}
+
+export async function handleAgentCollaborationChatRequest(
+  req: GatewayAgentCollaborationRequest,
+): Promise<GatewayAgentCollaborationResult> {
+  const currentSessionId = String(req.currentSessionId || '').trim();
+  if (!currentSessionId) {
+    throw new Error('Current sessionId is required for agent collaboration.');
+  }
+
+  const sourceSession = memoryService.getSessionById(
+    resolveSessionIdCompat(currentSessionId),
+  );
+  if (!sourceSession) {
+    throw new Error(
+      `Agent collaboration source session was not found: ${currentSessionId}`,
+    );
+  }
+
+  const sourceAgentId = sourceSession.agent_id?.trim() || DEFAULT_AGENT_ID;
+  const targetAgentId = String(req.toAgent || '').trim();
+  if (!targetAgentId) {
+    throw new Error('Target agent id is required.');
+  }
+  if (targetAgentId === sourceAgentId) {
+    throw new Error('Target agent must differ from the current agent.');
+  }
+
+  const targetAgent = findAgentConfig(targetAgentId);
+  if (!targetAgent) {
+    throw new Error(`Agent "${targetAgentId}" was not found.`);
+  }
+
+  const text = String(req.text || '').trim();
+  if (!text) {
+    throw new Error('Agent collaboration text is required.');
+  }
+
+  const destination = parseAgentCollaborationDestination(req.destination);
+  const requestedSessionId = String(req.sessionId || '').trim();
+  if (requestedSessionId) {
+    const existing = memoryService.getSessionById(
+      resolveSessionIdCompat(requestedSessionId),
+    );
+    if (existing) {
+      const existingAgentId = existing.agent_id?.trim() || DEFAULT_AGENT_ID;
+      if (existingAgentId !== targetAgent.id) {
+        throw new Error(
+          `Session "${requestedSessionId}" belongs to agent "${existingAgentId}", not "${targetAgent.id}".`,
+        );
+      }
+    }
+  }
+
+  const collaborationSessionId = buildAgentCollaborationSessionKey({
+    sourceAgentId,
+    targetAgentId: targetAgent.id,
+    destination,
+    sessionId: requestedSessionId || undefined,
+  });
+  const channelId = buildAgentCollaborationChannelId({
+    sourceAgentId,
+    destination,
+  });
+  const rawTimeoutSeconds =
+    typeof req.timeoutSeconds === 'number' &&
+    Number.isFinite(req.timeoutSeconds)
+      ? Math.floor(req.timeoutSeconds)
+      : 300;
+  const timeoutSeconds = Math.max(5, Math.min(rawTimeoutSeconds, 900));
+
+  const result = await handleGatewayMessage({
+    sessionId: collaborationSessionId,
+    sessionMode: 'resume',
+    guildId: null,
+    channelId,
+    userId: `agent:${sourceAgentId}`,
+    username: sourceAgentId,
+    content: formatAgentCollaborationPrompt({
+      sourceAgentId,
+      targetAgentId: targetAgent.id,
+      destination,
+      text,
+    }),
+    agentId: targetAgent.id,
+    maxWallClockMs: timeoutSeconds * 1000,
+    source: 'agent',
+  });
+
+  return {
+    status: result.status,
+    route: {
+      sourceAgentId,
+      targetAgentId: targetAgent.id,
+      destination,
+      sessionId: collaborationSessionId,
+      executionSessionId: result.sessionId || collaborationSessionId,
+      channelId,
+    },
+    result: result.result,
+    toolsUsed: result.toolsUsed,
+    artifacts: result.artifacts,
+    ...(result.error ? { error: result.error } : {}),
+  };
 }
 
 async function handleGatewayMessageInner(

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -99,7 +99,10 @@ import {
   normalizeSilentMessageSendReply,
 } from './chat-result.js';
 import { serveDocs } from './docs.js';
-import { handleGatewayMessage } from './gateway-chat-service.js';
+import {
+  handleAgentCollaborationChatRequest,
+  handleGatewayMessage,
+} from './gateway-chat-service.js';
 import { handleApiHttpRequest } from './gateway-http-proxy.js';
 import {
   parsePositiveInteger,
@@ -243,6 +246,14 @@ const ALLOWED_MEDIA_UPLOAD_MIME_TYPES = new Set([
 
 type ApiChatRequestBody = GatewayChatRequestBody & { stream?: boolean };
 type ApiChatBranchRequestBody = Partial<GatewayChatBranchRequestBody>;
+type ApiAgentCollaborationChatRequestBody = {
+  currentSessionId?: unknown;
+  toAgent?: unknown;
+  text?: unknown;
+  sessionId?: unknown;
+  destination?: unknown;
+  timeoutSeconds?: unknown;
+};
 type ApiMessageActionRequestBody = Partial<DiscordToolActionRequest>;
 type ApiAdminTerminalRequestBody = {
   cols?: number;
@@ -1857,6 +1868,63 @@ function handleApiChatCommands(res: ServerResponse, url: URL): void {
 
 async function handleApiAgents(res: ServerResponse): Promise<void> {
   sendJson(res, 200, await getGatewayAgents());
+}
+
+async function handleApiAgentCollaborationChat(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  const body = (await readJsonBody(
+    req,
+  )) as ApiAgentCollaborationChatRequestBody;
+  const currentSessionId = normalizeOptionalString(body.currentSessionId);
+  const toAgent = normalizeOptionalString(body.toAgent);
+  const text = normalizeOptionalString(body.text);
+  const sessionId = normalizeOptionalString(body.sessionId);
+  const destination = normalizeOptionalString(body.destination);
+  const timeoutSeconds =
+    typeof body.timeoutSeconds === 'number' &&
+    Number.isFinite(body.timeoutSeconds)
+      ? body.timeoutSeconds
+      : undefined;
+
+  if (!currentSessionId) {
+    sendJson(res, 400, {
+      error: 'Missing `currentSessionId` in request body.',
+    });
+    return;
+  }
+  if (!toAgent) {
+    sendJson(res, 400, { error: 'Missing `toAgent` in request body.' });
+    return;
+  }
+  if (!text) {
+    sendJson(res, 400, { error: 'Missing `text` in request body.' });
+    return;
+  }
+
+  try {
+    const result = await handleAgentCollaborationChatRequest({
+      currentSessionId,
+      toAgent,
+      text,
+      ...(sessionId ? { sessionId } : {}),
+      ...(destination ? { destination } : {}),
+      ...(typeof timeoutSeconds === 'number' ? { timeoutSeconds } : {}),
+    });
+    sendJson(res, result.status === 'success' ? 200 : 500, result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    sendJson(
+      res,
+      /not found|required|must differ|belongs to agent|characters or fewer/i.test(
+        message,
+      )
+        ? 400
+        : 500,
+      { error: message },
+    );
+  }
 }
 
 function handleApiAdminJobsContext(res: ServerResponse): void {
@@ -3622,6 +3690,10 @@ export function startGatewayHttpServer(): GatewayHttpServer {
           }
           if (pathname === '/api/agents' && method === 'GET') {
             await handleApiAgents(res);
+            return;
+          }
+          if (pathname === '/api/agents/chat' && method === 'POST') {
+            await handleApiAgentCollaborationChat(req, res);
             return;
           }
           if (pathname === '/api/proactive/pull' && method === 'GET') {

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -191,6 +191,31 @@ export interface GatewayChatRequest {
   source?: string;
 }
 
+export interface GatewayAgentCollaborationRequest {
+  currentSessionId: string;
+  toAgent: string;
+  text: string;
+  sessionId?: string | null;
+  destination?: string | null;
+  timeoutSeconds?: number | null;
+}
+
+export interface GatewayAgentCollaborationResult {
+  status: 'success' | 'error';
+  route: {
+    sourceAgentId: string;
+    targetAgentId: string;
+    destination: string;
+    sessionId: string;
+    executionSessionId: string;
+    channelId: string;
+  } | null;
+  result: string | null;
+  toolsUsed: string[];
+  artifacts?: ArtifactMetadata[];
+  error?: string;
+}
+
 export interface GatewayMediaUploadResult {
   media: GatewayMediaItem;
 }

--- a/tests/container.agent-collaboration-tool.test.ts
+++ b/tests/container.agent-collaboration-tool.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  executeTool,
+  setGatewayContext,
+  setSessionContext,
+} from '../container/src/tools.js';
+
+function mockFetchJson(responsePayload: Record<string, unknown>) {
+  const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => ({
+    ok: true,
+    status: 200,
+    text: async () => JSON.stringify(responsePayload),
+  }));
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+describe.sequential('container agent collaboration tools', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    setSessionContext('');
+    setGatewayContext('', '', '');
+  });
+
+  test('list_agents reads the gateway agent catalog and returns a simplified result', async () => {
+    const fetchMock = mockFetchJson({
+      agents: [
+        {
+          id: 'research',
+          name: 'Research Agent',
+          model: 'openai-codex/gpt-5.4-mini',
+          status: 'idle',
+          workspacePath: '/tmp/research',
+          sessionCount: 2,
+          activeSessions: 1,
+        },
+      ],
+    });
+    setGatewayContext('http://gateway.local', 'token', 'web');
+
+    const result = await executeTool('list_agents', JSON.stringify({}));
+    const parsed = JSON.parse(result) as {
+      success: boolean;
+      count: number;
+      agents: Array<{ id: string; name: string | null }>;
+    };
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.count).toBe(1);
+    expect(parsed.agents[0]).toMatchObject({
+      id: 'research',
+      name: 'Research Agent',
+    });
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+      'http://gateway.local/api/agents',
+    );
+    expect(
+      (fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.method,
+    ).toBe('GET');
+  });
+
+  test('chat_with_agent posts the current session and named destination to the gateway', async () => {
+    const fetchMock = mockFetchJson({
+      status: 'success',
+      route: {
+        sourceAgentId: 'main',
+        targetAgentId: 'research',
+        destination: 'planner',
+        sessionId:
+          'agent:research:channel:agent:chat:dm:peer:main:subagent:planner',
+        executionSessionId: 'session-123',
+        channelId: 'agent:main:planner',
+      },
+      result: 'Research summary',
+      toolsUsed: ['web_search'],
+    });
+    setGatewayContext('http://gateway.local', 'token', 'web');
+    setSessionContext('session-current');
+
+    const result = await executeTool(
+      'chat_with_agent',
+      JSON.stringify({
+        toAgent: 'research',
+        prompt: 'Review the rollout plan.',
+        destination: 'planner',
+        timeoutSeconds: 42,
+      }),
+    );
+
+    expect(result).toContain('"status": "success"');
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+      'http://gateway.local/api/agents/chat',
+    );
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const payload = JSON.parse(String(init.body || '{}')) as Record<
+      string,
+      unknown
+    >;
+    expect(payload).toMatchObject({
+      currentSessionId: 'session-current',
+      toAgent: 'research',
+      text: 'Review the rollout plan.',
+      destination: 'planner',
+      timeoutSeconds: 42,
+    });
+  });
+});

--- a/tests/gateway-service.agent-collaboration.test.ts
+++ b/tests/gateway-service.agent-collaboration.test.ts
@@ -1,0 +1,175 @@
+import { expect, test, vi } from 'vitest';
+import { setupGatewayTest } from './helpers/gateway-test-setup.js';
+
+const { runAgentMock } = vi.hoisted(() => ({
+  runAgentMock: vi.fn(),
+}));
+
+vi.mock('../src/agent/agent.js', () => ({
+  runAgent: runAgentMock,
+}));
+
+const { setupHome } = setupGatewayTest({
+  tempHomePrefix: 'hybridclaw-gateway-agent-collab-',
+  cleanup: () => {
+    runAgentMock.mockReset();
+  },
+});
+
+async function configureAgents(): Promise<void> {
+  const runtimeConfigModule = await import('../src/config/runtime-config.ts');
+  const nextConfig = structuredClone(runtimeConfigModule.getRuntimeConfig());
+  nextConfig.agents = {
+    defaultAgentId: 'main',
+    defaults: {
+      model: 'openai-codex/gpt-5.4-mini',
+    },
+    list: [
+      {
+        id: 'main',
+        name: 'Main Agent',
+        model: 'openai-codex/gpt-5.4-mini',
+      },
+      {
+        id: 'research',
+        name: 'Research Agent',
+        model: 'openai-codex/gpt-5.4-mini',
+      },
+      {
+        id: 'writer',
+        name: 'Writer Agent',
+        model: 'openai-codex/gpt-5.4-mini',
+      },
+    ],
+  };
+  runtimeConfigModule.saveRuntimeConfig(nextConfig);
+}
+
+test('routes agent collaboration through a named destination session key', async () => {
+  setupHome();
+
+  runAgentMock.mockResolvedValue({
+    status: 'success',
+    result: 'ready',
+    toolsUsed: [],
+    toolExecutions: [],
+  });
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayMessage, handleAgentCollaborationChatRequest } =
+    await import('../src/gateway/gateway-chat-service.ts');
+  const { parseSessionKey } = await import('../src/session/session-key.ts');
+
+  initDatabase({ quiet: true });
+  await configureAgents();
+
+  await handleGatewayMessage({
+    sessionId: 'source-agent-session',
+    guildId: null,
+    channelId: 'web',
+    userId: 'user-1',
+    username: 'user',
+    content: 'kick off',
+    agentId: 'main',
+    model: 'openai-codex/gpt-5.4-mini',
+    chatbotId: 'bot-main',
+  });
+
+  runAgentMock.mockClear();
+  runAgentMock.mockResolvedValue({
+    status: 'success',
+    result: 'Research summary',
+    toolsUsed: ['web_search'],
+    toolExecutions: [],
+  });
+
+  const result = await handleAgentCollaborationChatRequest({
+    currentSessionId: 'source-agent-session',
+    toAgent: 'research',
+    text: 'Review the rollout plan and flag gaps.',
+    destination: 'planner',
+  });
+
+  expect(result.status).toBe('success');
+  expect(result.result).toBe('Research summary');
+  expect(result.route).toMatchObject({
+    sourceAgentId: 'main',
+    targetAgentId: 'research',
+    destination: 'planner',
+    channelId: 'agent:main:planner',
+  });
+
+  const parsedKey = parseSessionKey(result.route?.sessionId || '');
+  expect(parsedKey).toMatchObject({
+    agentId: 'research',
+    channelKind: 'agent',
+    chatType: 'dm',
+    peerId: 'main',
+    subagentId: 'planner',
+  });
+
+  const request = runAgentMock.mock.calls[0]?.[0] as
+    | {
+        agentId?: string;
+        channelId?: string;
+        messages?: Array<{ role: string; content: string }>;
+      }
+    | undefined;
+  const userMessage = request?.messages?.at(-1);
+
+  expect(request?.agentId).toBe('research');
+  expect(request?.channelId).toBe('agent:main:planner');
+  expect(userMessage?.role).toBe('user');
+  expect(userMessage?.content).toContain('# Agent Handoff');
+  expect(userMessage?.content).toContain('Source agent: `main`');
+  expect(userMessage?.content).toContain('Destination: `planner`');
+  expect(userMessage?.content).toContain(
+    'Review the rollout plan and flag gaps.',
+  );
+});
+
+test('rejects reusing an agent collaboration session with a different target agent', async () => {
+  setupHome();
+
+  runAgentMock.mockResolvedValue({
+    status: 'success',
+    result: 'ready',
+    toolsUsed: [],
+    toolExecutions: [],
+  });
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayMessage, handleAgentCollaborationChatRequest } =
+    await import('../src/gateway/gateway-chat-service.ts');
+
+  initDatabase({ quiet: true });
+  await configureAgents();
+
+  await handleGatewayMessage({
+    sessionId: 'source-agent-session',
+    guildId: null,
+    channelId: 'web',
+    userId: 'user-1',
+    username: 'user',
+    content: 'kick off',
+    agentId: 'main',
+    model: 'openai-codex/gpt-5.4-mini',
+    chatbotId: 'bot-main',
+  });
+
+  const firstResult = await handleAgentCollaborationChatRequest({
+    currentSessionId: 'source-agent-session',
+    toAgent: 'research',
+    text: 'Review the first draft.',
+    destination: 'planner',
+  });
+
+  await expect(
+    handleAgentCollaborationChatRequest({
+      currentSessionId: 'source-agent-session',
+      toAgent: 'writer',
+      text: 'Now rewrite it.',
+      sessionId: firstResult.route?.sessionId || '',
+    }),
+  ).rejects.toThrow(/belongs to agent "research"/i);
+});


### PR DESCRIPTION
## Summary
- add `list_agents` and `chat_with_agent` so one agent can hand work off to another through the gateway
- route handoffs through named destinations with target-agent validation and reusable collaboration session keys
- cover the gateway path and container tool shims with focused collaboration tests

## Validation
- `biome check --write` on the touched files
- `npm_config_cache=/tmp/.npm-cache npx -y node@22 node_modules/typescript/bin/tsc --noEmit`
- targeted collaboration/container vitest coverage passed earlier under the Node 22 shim; a later rerun from the detached worktree hit the known `better-sqlite3` ABI mismatch because the shared install was built for the host Node 25 runtime