### PR TITLE
[codex] add provider fallback routing and credential pools

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,5 @@
 {
-  "version": 21,
+  "version": 22,
   "security": {
     "trustModelAccepted": false,
     "trustModelAcceptedAt": "",
@@ -434,6 +434,10 @@
         "balanced": "gpt-5-mini",
         "noHurry": "gpt-5-nano"
       }
+    },
+    "primaryModel": {
+      "fallbackModels": [],
+      "adaptiveContextTierDowngradeOn429": true
     }
   },
   "heartbeat": {

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -17,6 +17,11 @@ import { waitForInput, writeOutput } from './ipc.js';
 import { McpClientManager } from './mcp/client-manager.js';
 import { McpConfigWatcher } from './mcp/config-watcher.js';
 import {
+  createPrimaryModelRoutingSession,
+  ContextTierDowngradedError,
+  type PrimaryModelRoutingSession,
+} from './model-routing.js';
+import {
   isRetryableModelError,
   shouldDowngradeStreamToNonStreaming,
 } from './model-retry.js';
@@ -138,6 +143,7 @@ let cachedSelectedSkillPath: string | null = null;
 let storedApiKey = '';
 let storedRequestHeaders: Record<string, string> = {};
 let storedTaskModels: ContainerInput['taskModels'];
+let storedModelRouting: ContainerInput['modelRouting'];
 let mcpClientManager: McpClientManager | null = null;
 let mcpConfigWatcher: McpConfigWatcher | null = null;
 let shutdownPromise: Promise<never> | null = null;
@@ -207,6 +213,121 @@ function resolveTaskModelsForRequest(
     return undefined;
   }
   storedTaskModels = cloneTaskModels(merged);
+  return merged;
+}
+
+function cloneModelRouting(
+  modelRouting: ContainerInput['modelRouting'],
+): ContainerInput['modelRouting'] | undefined {
+  if (!modelRouting) return undefined;
+  return {
+    routes: modelRouting.routes.map((route) => ({
+      ...route,
+      requestHeaders: route.requestHeaders ? { ...route.requestHeaders } : undefined,
+      credentialPool: route.credentialPool
+        ? {
+            rotation: route.credentialPool.rotation,
+            entries: route.credentialPool.entries.map((entry) => ({
+              ...entry,
+            })),
+          }
+        : undefined,
+    })),
+    adaptiveContextTierDowngradeOn429:
+      modelRouting.adaptiveContextTierDowngradeOn429,
+  };
+}
+
+function isModelRouteRoutingEqual(
+  left: NonNullable<ContainerInput['modelRouting']>['routes'][number] | undefined,
+  right:
+    | NonNullable<ContainerInput['modelRouting']>['routes'][number]
+    | undefined,
+): boolean {
+  if (!left || !right) return false;
+  if (
+    String(left.provider || '') !== String(right.provider || '') ||
+    normalizeTaskModelBaseUrl(left.baseUrl) !==
+      normalizeTaskModelBaseUrl(right.baseUrl) ||
+    String(left.model || '').trim() !== String(right.model || '').trim() ||
+    String(left.chatbotId || '').trim() !== String(right.chatbotId || '').trim()
+  ) {
+    return false;
+  }
+
+  const leftPool = left.credentialPool;
+  const rightPool = right.credentialPool;
+  if (!leftPool && !rightPool) return true;
+  if (!leftPool || !rightPool) return false;
+  if (leftPool.rotation !== rightPool.rotation) return false;
+  if (leftPool.entries.length !== rightPool.entries.length) return false;
+
+  return leftPool.entries.every((entry, index) => {
+    const candidate = rightPool.entries[index];
+    return (
+      entry.id === candidate?.id &&
+      String(entry.label || '').trim() === String(candidate?.label || '').trim()
+    );
+  });
+}
+
+function resolveModelRoutingForRequest(
+  modelRouting: ContainerInput['modelRouting'],
+): ContainerInput['modelRouting'] | undefined {
+  if (!modelRouting?.routes.length) {
+    storedModelRouting = undefined;
+    return undefined;
+  }
+
+  const mergedRoutes = modelRouting.routes.map((route, routeIndex) => {
+    const storedRoute = storedModelRouting?.routes[routeIndex];
+    const sameRouting = isModelRouteRoutingEqual(route, storedRoute);
+
+    return {
+      ...route,
+      apiKey:
+        String(route.apiKey || '').trim() ||
+        (sameRouting ? String(storedRoute?.apiKey || '').trim() : ''),
+      requestHeaders:
+        route.requestHeaders && Object.keys(route.requestHeaders).length > 0
+          ? { ...route.requestHeaders }
+          : sameRouting && storedRoute?.requestHeaders
+            ? { ...storedRoute.requestHeaders }
+            : undefined,
+      credentialPool: route.credentialPool
+        ? {
+            rotation: route.credentialPool.rotation,
+            entries: route.credentialPool.entries.map((entry) => {
+              const storedEntry =
+                sameRouting &&
+                storedRoute?.credentialPool?.entries.find(
+                  (candidate) => candidate.id === entry.id,
+                );
+              return {
+                ...entry,
+                apiKey:
+                  String(entry.apiKey || '').trim() ||
+                  String(storedEntry?.apiKey || '').trim(),
+              };
+            }),
+          }
+        : sameRouting && storedRoute?.credentialPool
+          ? {
+              rotation: storedRoute.credentialPool.rotation,
+              entries: storedRoute.credentialPool.entries.map((entry) => ({
+                ...entry,
+              })),
+            }
+          : undefined,
+    };
+  });
+
+  const merged = {
+    routes: mergedRoutes,
+    adaptiveContextTierDowngradeOn429:
+      modelRouting.adaptiveContextTierDowngradeOn429,
+  };
+  storedModelRouting = cloneModelRouting(merged);
   return merged;
 }
 
@@ -687,56 +808,38 @@ async function executePreparedToolCall(
 }
 
 async function callHybridAIWithRetry(params: {
-  provider?:
-    | 'hybridai'
-    | 'openai-codex'
-    | 'openrouter'
-    | 'mistral'
-    | 'huggingface'
-    | 'ollama'
-    | 'lmstudio'
-    | 'llamacpp'
-    | 'vllm';
-  baseUrl: string;
-  apiKey: string;
-  model: string;
-  chatbotId: string;
-  enableRag: boolean;
-  requestHeaders?: Record<string, string>;
+  modelRouting: PrimaryModelRoutingSession;
   history: ChatMessage[];
   tools: ToolDefinition[];
   onTextDelta?: (delta: string) => void;
   onActivity?: () => void;
-  maxTokens?: number;
-  isLocal?: boolean;
-  contextWindow?: number;
-  thinkingFormat?: 'qwen';
+  onRouteChange?: () => void;
 }): Promise<ChatCompletionResponse> {
-  const {
-    provider,
-    baseUrl,
-    apiKey,
-    model,
-    chatbotId,
-    enableRag,
-    requestHeaders,
-    history,
-    tools,
-    onTextDelta,
-    onActivity,
-    maxTokens,
-    isLocal,
-    contextWindow,
-    thinkingFormat,
-  } = params;
+  const { modelRouting, history, tools, onTextDelta, onActivity, onRouteChange } =
+    params;
   let attempt = 0;
   let delayMs = RETRY_BASE_DELAY_MS;
 
   while (true) {
+    const activeRoute = modelRouting.current();
+    const {
+      provider,
+      baseUrl,
+      apiKey,
+      model,
+      chatbotId,
+      enableRag,
+      requestHeaders,
+      maxTokens,
+      isLocal,
+      contextWindow,
+      thinkingFormat,
+      credentialLabel,
+    } = activeRoute;
     attempt += 1;
     const attemptStartedAt = Date.now();
     console.error(
-      `[model] call start provider=${provider || 'hybridai'} model=${model} attempt=${attempt} streaming=${Boolean(onTextDelta)} messages=${history.length} tools=${tools.length}`,
+      `[model] call start provider=${provider || 'hybridai'} model=${model} attempt=${attempt} streaming=${Boolean(onTextDelta)} messages=${history.length} tools=${tools.length}${credentialLabel ? ` credential=${credentialLabel}` : ''}`,
     );
     await emitRuntimeEvent({ event: 'before_model_call', attempt });
     try {
@@ -802,6 +905,7 @@ async function callHybridAIWithRetry(params: {
       console.error(
         `[model] call success provider=${provider || 'hybridai'} model=${model} attempt=${attempt} durationMs=${Date.now() - attemptStartedAt} toolCalls=${response.choices[0]?.message?.tool_calls?.length || 0}`,
       );
+      modelRouting.noteSuccess();
       await emitRuntimeEvent({
         event: 'after_model_call',
         attempt,
@@ -813,6 +917,35 @@ async function callHybridAIWithRetry(params: {
         RETRY_ENABLED &&
         isRetryableModelError(err) &&
         attempt < RETRY_MAX_ATTEMPTS;
+      const recovery = modelRouting.recover(err, {
+        canRetrySameRoute: retryable,
+      });
+      if (recovery.type === 'context_downgraded') {
+        console.error(
+          `[model] context tier downgrade provider=${provider || 'hybridai'} model=${model} ${recovery.previousContextWindow}->${recovery.nextContextWindow} reason=${recovery.reason}`,
+        );
+        onRouteChange?.();
+        throw new ContextTierDowngradedError(
+          recovery.previousContextWindow,
+          recovery.nextContextWindow,
+        );
+      }
+      if (recovery.type === 'route_changed') {
+        const nextRoute = modelRouting.current();
+        console.error(
+          `[model] route recovery provider=${provider || 'hybridai'} model=${model} nextProvider=${nextRoute.provider || 'hybridai'} nextModel=${nextRoute.model} reason=${recovery.reason}`,
+        );
+        await emitRuntimeEvent({
+          event: 'model_retry',
+          attempt,
+          retryable: true,
+          error: `Recovered via ${recovery.reason}`,
+        });
+        attempt = 0;
+        delayMs = RETRY_BASE_DELAY_MS;
+        onRouteChange?.();
+        continue;
+      }
       await emitRuntimeEvent({
         event: retryable ? 'model_retry' : 'model_error',
         attempt,
@@ -836,17 +969,7 @@ async function processRequest(
   messages: ChatMessage[],
   apiKey: string,
   baseUrl: string,
-  provider:
-    | 'hybridai'
-    | 'openai-codex'
-    | 'openrouter'
-    | 'mistral'
-    | 'huggingface'
-    | 'ollama'
-    | 'lmstudio'
-    | 'llamacpp'
-    | 'vllm'
-    | undefined,
+  provider: ContainerInput['provider'],
   isLocal: boolean | undefined,
   contextWindow: number | undefined,
   thinkingFormat: 'qwen' | undefined,
@@ -854,6 +977,7 @@ async function processRequest(
   chatbotId: string,
   enableRag: boolean,
   requestHeaders: Record<string, string> | undefined,
+  modelRoutingInput: ContainerInput['modelRouting'] | undefined,
   tools: ToolDefinition[],
   taskModels: ContainerInput['taskModels'] | undefined,
   contextGuard: ContainerInput['contextGuard'] | undefined,
@@ -894,11 +1018,53 @@ async function processRequest(
   let compactionRetries = 0;
   const tokenEstimateCache = createTokenEstimateCache();
   const maxContextGuardRetries = Math.max(0, contextGuard?.maxRetries ?? 3);
+  const primaryModelRouting = createPrimaryModelRoutingSession({
+    sessionId: '',
+    messages: [],
+    chatbotId,
+    enableRag,
+    apiKey,
+    baseUrl,
+    provider,
+    requestHeaders,
+    isLocal,
+    contextWindow,
+    thinkingFormat,
+    model,
+    maxTokens,
+    channelId: '',
+    modelRouting: modelRoutingInput,
+  });
+  const updateActiveModelContext = () => {
+    const activeRoute = primaryModelRouting.current();
+    setModelContext(
+      activeRoute.provider,
+      activeRoute.baseUrl,
+      activeRoute.apiKey,
+      activeRoute.model,
+      activeRoute.chatbotId,
+      activeRoute.requestHeaders,
+      activeRoute.maxTokens,
+    );
+  };
+
+  updateActiveModelContext();
 
   while (stalledTurns < maxStalledTurns) {
+    const activeRoute = primaryModelRouting.current();
+    const activeProvider = activeRoute.provider;
+    const activeBaseUrl = activeRoute.baseUrl;
+    const activeApiKey = activeRoute.apiKey;
+    const activeModel = activeRoute.model;
+    const activeChatbotId = activeRoute.chatbotId;
+    const activeEnableRag = activeRoute.enableRag;
+    const activeRequestHeaders = activeRoute.requestHeaders;
+    const activeIsLocal = activeRoute.isLocal;
+    const activeContextWindow = activeRoute.contextWindow;
+    const activeThinkingFormat = activeRoute.thinkingFormat;
     const guardResult = applyContextGuard({
       history,
-      contextWindowTokens: contextWindow,
+      contextWindowTokens: activeContextWindow,
       config: contextGuard,
       cache: tokenEstimateCache,
     });
@@ -930,7 +1096,7 @@ async function processRequest(
 
       const compacted = await compactInLoop({
         history,
-        contextWindowTokens: contextWindow,
+        contextWindowTokens: activeContextWindow,
         summarize: async (summaryMessages, summaryMaxTokens) => {
           tokenUsage.modelCalls += 1;
           tokenUsage.estimatedPromptTokens +=
@@ -939,15 +1105,15 @@ async function processRequest(
             task: 'compression',
             taskModels,
             fallbackContext: {
-              provider,
-              baseUrl,
-              apiKey,
-              model,
-              chatbotId,
-              requestHeaders,
-              isLocal,
-              contextWindow,
-              thinkingFormat,
+              provider: activeProvider,
+              baseUrl: activeBaseUrl,
+              apiKey: activeApiKey,
+              model: activeModel,
+              chatbotId: activeChatbotId,
+              requestHeaders: activeRequestHeaders,
+              isLocal: activeIsLocal,
+              contextWindow: activeContextWindow,
+              thinkingFormat: activeThinkingFormat,
             },
             messages: summaryMessages,
             maxTokens: summaryMaxTokens,
@@ -993,23 +1159,20 @@ async function processRequest(
     let response: Awaited<ReturnType<typeof callHybridAIWithRetry>>;
     try {
       response = await callHybridAIWithRetry({
-        provider,
-        baseUrl,
-        apiKey,
-        model,
-        chatbotId,
-        enableRag,
-        requestHeaders,
+        modelRouting: primaryModelRouting,
         history,
         tools,
         onTextDelta: streamTextDeltas ? emitStreamDelta : undefined,
         onActivity: streamTextDeltas ? emitStreamActivity : undefined,
-        maxTokens,
-        isLocal,
-        contextWindow,
-        thinkingFormat,
+        onRouteChange: updateActiveModelContext,
       });
     } catch (err) {
+      if (err instanceof ContextTierDowngradedError) {
+        console.error(
+          `[context] adaptive tier downgrade ${err.previousContextWindow}->${err.nextContextWindow} retrying model call`,
+        );
+        continue;
+      }
       const failed: ContainerOutput = {
         status: 'error',
         result: null,
@@ -1030,6 +1193,7 @@ async function processRequest(
       return failed;
     }
 
+    const completedRoute = primaryModelRouting.current();
     accumulateApiUsage(tokenUsage, response);
 
     const choice = response.choices[0];
@@ -1064,7 +1228,7 @@ async function processRequest(
     const invalidToolCallError = validateStructuredToolCalls(toolCalls);
     if (invalidToolCallError) {
       console.error(
-        `[model] invalid structured tool call provider=${provider || 'hybridai'} model=${model} error=${invalidToolCallError}`,
+        `[model] invalid structured tool call provider=${completedRoute.provider || 'hybridai'} model=${completedRoute.model} error=${invalidToolCallError}`,
       );
       const failed: ContainerOutput = {
         status: 'error',
@@ -1099,12 +1263,12 @@ async function processRequest(
       latestVisibleAssistantText = visibleAssistantText;
     }
     if (
-      provider === 'hybridai' &&
+      completedRoute.provider === 'hybridai' &&
       parseRalphChoice(choice.message.content) === null &&
       isHybridAIEmptyVisibleCompletion(response)
     ) {
       console.error(
-        `[model] empty completion provider=hybridai model=${model} debug=${summarizeHybridAICompletionForDebug(response)}`,
+        `[model] empty completion provider=hybridai model=${completedRoute.model} debug=${summarizeHybridAICompletionForDebug(response)}`,
       );
       const failed: ContainerOutput = {
         status: 'error',
@@ -1535,6 +1699,7 @@ async function main(): Promise<void> {
   storedApiKey = firstInput.apiKey;
   storedRequestHeaders = { ...(firstInput.requestHeaders || {}) };
   const firstTaskModels = resolveTaskModelsForRequest(firstInput.taskModels);
+  const firstModelRouting = resolveModelRoutingForRequest(firstInput.modelRouting);
 
   console.error(
     `[hybridclaw-agent] processing first request (${firstInput.messages.length} messages)`,
@@ -1608,6 +1773,7 @@ async function main(): Promise<void> {
       firstInput.chatbotId,
       firstInput.enableRag,
       storedRequestHeaders,
+      firstModelRouting,
       resolveTools(firstInput),
       firstTaskModels,
       firstInput.contextGuard,
@@ -1643,6 +1809,7 @@ async function main(): Promise<void> {
         firstInput.chatbotId,
         firstInput.enableRag,
         firstInput.requestHeaders,
+        firstModelRouting,
         resolveTools(firstInput),
         firstTaskModels,
         firstInput.contextGuard,
@@ -1683,6 +1850,7 @@ async function main(): Promise<void> {
       storedRequestHeaders = { ...input.requestHeaders };
     }
     const taskModels = resolveTaskModelsForRequest(input.taskModels);
+    const modelRouting = resolveModelRoutingForRequest(input.modelRouting);
 
     console.error(
       `[hybridclaw-agent] processing request (${input.messages.length} messages)`,
@@ -1760,6 +1928,7 @@ async function main(): Promise<void> {
       input.chatbotId,
       input.enableRag,
       requestHeaders,
+      modelRouting,
       resolveTools(input),
       taskModels,
       input.contextGuard,
@@ -1794,6 +1963,7 @@ async function main(): Promise<void> {
         input.chatbotId,
         input.enableRag,
         requestHeaders,
+        modelRouting,
         resolveTools(input),
         taskModels,
         input.contextGuard,

--- a/container/src/model-routing.ts
+++ b/container/src/model-routing.ts
@@ -1,0 +1,467 @@
+import {
+  isPremiumModelPermissionError,
+  ProviderRequestError,
+} from './providers/shared.js';
+import type {
+  ContainerInput,
+  ModelRoutingInput,
+  ModelRoutingRouteInput,
+} from './types.js';
+
+const RATE_LIMIT_COOLDOWN_MS = 60 * 60 * 1000;
+const BILLING_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+const AUTH_COOLDOWN_MS = 5 * 60 * 1000;
+const DEFAULT_ERROR_COOLDOWN_MS = 15 * 60 * 1000;
+const MIN_CONTEXT_WINDOW_TOKENS = 4_096;
+const CONTEXT_WINDOW_DOWNGRADE_TIERS = [
+  1_000_000,
+  512_000,
+  256_000,
+  200_000,
+  128_000,
+  64_000,
+  32_000,
+  16_000,
+  8_000,
+  MIN_CONTEXT_WINDOW_TOKENS,
+] as const;
+
+interface CredentialUsageState {
+  requestCount: number;
+  exhaustedUntilMs: number | null;
+}
+
+interface ModelRoutingRouteState extends ModelRoutingRouteInput {
+  currentCredentialId: string | null;
+  retried429: boolean;
+}
+
+export interface ActiveModelRoute extends ModelRoutingRouteInput {
+  credentialId?: string;
+  credentialLabel?: string;
+}
+
+export class ContextTierDowngradedError extends Error {
+  constructor(
+    public readonly previousContextWindow: number,
+    public readonly nextContextWindow: number,
+  ) {
+    super(
+      `Context window downgraded from ${previousContextWindow} to ${nextContextWindow} tokens.`,
+    );
+    this.name = 'ContextTierDowngradedError';
+  }
+}
+
+export type ModelRoutingRecoveryAction =
+  | { type: 'none'; reason: string }
+  | { type: 'route_changed'; reason: string }
+  | {
+      type: 'context_downgraded';
+      reason: string;
+      previousContextWindow: number;
+      nextContextWindow: number;
+    };
+
+const providerCredentialUsageState = new Map<
+  string,
+  Map<string, CredentialUsageState>
+>();
+
+export function clearModelRoutingStateForTests(): void {
+  providerCredentialUsageState.clear();
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return String(baseUrl || '').trim().replace(/\/+$/g, '');
+}
+
+function getProviderPoolStateKey(route: ModelRoutingRouteState): string {
+  return `${route.provider || 'hybridai'}::${normalizeBaseUrl(route.baseUrl)}`;
+}
+
+function getCredentialUsageMap(
+  route: ModelRoutingRouteState,
+): Map<string, CredentialUsageState> {
+  const poolKey = getProviderPoolStateKey(route);
+  let usage = providerCredentialUsageState.get(poolKey);
+  if (!usage) {
+    usage = new Map<string, CredentialUsageState>();
+    providerCredentialUsageState.set(poolKey, usage);
+  }
+  for (const entry of route.credentialPool?.entries || []) {
+    if (!usage.has(entry.id)) {
+      usage.set(entry.id, {
+        requestCount: 0,
+        exhaustedUntilMs: null,
+      });
+    }
+  }
+  return usage;
+}
+
+function getCredentialUsageState(
+  route: ModelRoutingRouteState,
+  credentialId: string,
+): CredentialUsageState {
+  const usage = getCredentialUsageMap(route);
+  let state = usage.get(credentialId);
+  if (!state) {
+    state = {
+      requestCount: 0,
+      exhaustedUntilMs: null,
+    };
+    usage.set(credentialId, state);
+  }
+  return state;
+}
+
+function isCredentialAvailable(
+  route: ModelRoutingRouteState,
+  credentialId: string,
+  now: number = Date.now(),
+): boolean {
+  const state = getCredentialUsageState(route, credentialId);
+  return !state.exhaustedUntilMs || state.exhaustedUntilMs <= now;
+}
+
+function selectLeastUsedCredential(
+  route: ModelRoutingRouteState,
+  excludeCredentialId?: string,
+): { id: string; label: string; apiKey: string } | null {
+  const entries =
+    route.credentialPool?.entries.filter(
+      (entry) =>
+        entry.id !== excludeCredentialId && isCredentialAvailable(route, entry.id),
+    ) || [];
+  if (entries.length === 0) return null;
+
+  return [...entries].sort((left, right) => {
+    const leftState = getCredentialUsageState(route, left.id);
+    const rightState = getCredentialUsageState(route, right.id);
+    if (leftState.requestCount !== rightState.requestCount) {
+      return leftState.requestCount - rightState.requestCount;
+    }
+    const labelCompare = left.label.localeCompare(right.label);
+    if (labelCompare !== 0) return labelCompare;
+    return left.id.localeCompare(right.id);
+  })[0];
+}
+
+function resolveStatusCode(error: unknown): number | null {
+  if (error instanceof ProviderRequestError) return error.status;
+  const message = error instanceof Error ? error.message : String(error);
+  const match = message.match(/\b(401|402|403|404|429|5\d\d)\b/);
+  return match ? Number(match[1]) : null;
+}
+
+function resolveErrorMessage(error: unknown): string {
+  return String(error instanceof Error ? error.message : error || '').trim();
+}
+
+function isAuthFailure(statusCode: number | null, message: string): boolean {
+  return (
+    statusCode === 401 ||
+    /unauthorized|invalid api key|invalid token|authentication failed/i.test(
+      message,
+    )
+  );
+}
+
+function isBillingFailure(statusCode: number | null, message: string): boolean {
+  return (
+    statusCode === 402 ||
+    /billing|quota|credit balance|payment required|insufficient.*quota/i.test(
+      message,
+    )
+  );
+}
+
+function isRateLimitFailure(
+  statusCode: number | null,
+  message: string,
+): boolean {
+  return statusCode === 429 || /rate.?limit|too many requests/i.test(message);
+}
+
+function canFallbackFromError(error: unknown, statusCode: number | null): boolean {
+  if (isPremiumModelPermissionError(error)) return false;
+  if (statusCode !== null) {
+    return statusCode >= 400 && statusCode <= 599;
+  }
+  const message = resolveErrorMessage(error);
+  return /fetch failed|network|socket|timeout|timed out|econnreset|terminated/i.test(
+    message,
+  );
+}
+
+function getCredentialCooldownMs(
+  statusCode: number | null,
+  message: string,
+): number {
+  if (isRateLimitFailure(statusCode, message)) return RATE_LIMIT_COOLDOWN_MS;
+  if (isBillingFailure(statusCode, message)) return BILLING_COOLDOWN_MS;
+  if (isAuthFailure(statusCode, message)) return AUTH_COOLDOWN_MS;
+  return DEFAULT_ERROR_COOLDOWN_MS;
+}
+
+function getNextContextWindowTier(
+  contextWindow: number | undefined,
+): number | null {
+  if (
+    typeof contextWindow !== 'number' ||
+    !Number.isFinite(contextWindow) ||
+    contextWindow <= MIN_CONTEXT_WINDOW_TOKENS
+  ) {
+    return null;
+  }
+
+  for (const tier of CONTEXT_WINDOW_DOWNGRADE_TIERS) {
+    if (tier < contextWindow) return tier;
+  }
+
+  const halved = Math.floor(contextWindow / 2);
+  return halved >= MIN_CONTEXT_WINDOW_TOKENS ? halved : null;
+}
+
+export class PrimaryModelRoutingSession {
+  private readonly routes: ModelRoutingRouteState[];
+  private readonly adaptiveContextTierDowngradeOn429: boolean;
+  private routeIndex = 0;
+
+  constructor(
+    modelRouting: ModelRoutingInput | undefined,
+    fallbackRoute: ModelRoutingRouteInput,
+  ) {
+    const routes = (modelRouting?.routes || [fallbackRoute]).map((route) => ({
+      ...route,
+      baseUrl: normalizeBaseUrl(route.baseUrl),
+      requestHeaders: { ...(route.requestHeaders || {}) },
+      credentialPool: route.credentialPool
+        ? {
+            rotation: route.credentialPool.rotation,
+            entries: route.credentialPool.entries.map((entry) => ({
+              id: entry.id,
+              label: entry.label,
+              apiKey: entry.apiKey,
+            })),
+          }
+        : undefined,
+      currentCredentialId: null,
+      retried429: false,
+    }));
+
+    if (routes.length === 0) {
+      routes.push({
+        ...fallbackRoute,
+        baseUrl: normalizeBaseUrl(fallbackRoute.baseUrl),
+        requestHeaders: { ...(fallbackRoute.requestHeaders || {}) },
+        currentCredentialId: null,
+        retried429: false,
+      });
+    }
+
+    this.routes = routes;
+    this.adaptiveContextTierDowngradeOn429 =
+      modelRouting?.adaptiveContextTierDowngradeOn429 !== false;
+  }
+
+  current(): ActiveModelRoute {
+    const route = this.routes[this.routeIndex];
+    const currentCredentialId = route.currentCredentialId;
+    const currentCredential = route.credentialPool?.entries.find(
+      (entry) => entry.id === currentCredentialId,
+    );
+
+    if (
+      currentCredential &&
+      isCredentialAvailable(route, currentCredential.id)
+    ) {
+      return {
+        ...route,
+        apiKey: currentCredential.apiKey,
+        credentialId: currentCredential.id,
+        credentialLabel: currentCredential.label,
+      };
+    }
+
+    const selectedCredential = selectLeastUsedCredential(route);
+    if (selectedCredential) {
+      route.currentCredentialId = selectedCredential.id;
+      return {
+        ...route,
+        apiKey: selectedCredential.apiKey,
+        credentialId: selectedCredential.id,
+        credentialLabel: selectedCredential.label,
+      };
+    }
+
+    route.currentCredentialId = null;
+    return { ...route };
+  }
+
+  noteSuccess(): void {
+    const route = this.routes[this.routeIndex];
+    const activeRoute = this.current();
+    route.retried429 = false;
+    if (!activeRoute.credentialId) return;
+    const state = getCredentialUsageState(route, activeRoute.credentialId);
+    state.requestCount += 1;
+    state.exhaustedUntilMs = null;
+  }
+
+  recover(
+    error: unknown,
+    opts: { canRetrySameRoute: boolean },
+  ): ModelRoutingRecoveryAction {
+    const route = this.routes[this.routeIndex];
+    const activeRoute = this.current();
+    const statusCode = resolveStatusCode(error);
+    const message = resolveErrorMessage(error);
+
+    if (
+      this.adaptiveContextTierDowngradeOn429 &&
+      isRateLimitFailure(statusCode, message)
+    ) {
+      const nextContextWindow = getNextContextWindowTier(activeRoute.contextWindow);
+      if (
+        nextContextWindow !== null &&
+        typeof activeRoute.contextWindow === 'number'
+      ) {
+        route.contextWindow = nextContextWindow;
+        route.retried429 = false;
+        return {
+          type: 'context_downgraded',
+          reason: 'rate_limit',
+          previousContextWindow: activeRoute.contextWindow,
+          nextContextWindow,
+        };
+      }
+    }
+
+    if (isAuthFailure(statusCode, message)) {
+      if (this.rotateCredential(statusCode, message)) {
+        return {
+          type: 'route_changed',
+          reason: 'credential_auth',
+        };
+      }
+      if (this.advanceRoute()) {
+        return {
+          type: 'route_changed',
+          reason: 'provider_auth',
+        };
+      }
+      return {
+        type: 'none',
+        reason: 'auth_exhausted',
+      };
+    }
+
+    if (isBillingFailure(statusCode, message)) {
+      if (this.rotateCredential(statusCode, message)) {
+        return {
+          type: 'route_changed',
+          reason: 'credential_billing',
+        };
+      }
+      if (this.advanceRoute()) {
+        return {
+          type: 'route_changed',
+          reason: 'provider_billing',
+        };
+      }
+      return {
+        type: 'none',
+        reason: 'billing_exhausted',
+      };
+    }
+
+    if (isRateLimitFailure(statusCode, message)) {
+      if (!route.retried429 && opts.canRetrySameRoute) {
+        route.retried429 = true;
+        return {
+          type: 'none',
+          reason: 'rate_limit_retry',
+        };
+      }
+      if (this.rotateCredential(statusCode, message)) {
+        return {
+          type: 'route_changed',
+          reason: 'credential_rate_limit',
+        };
+      }
+      if (!opts.canRetrySameRoute && this.advanceRoute()) {
+        return {
+          type: 'route_changed',
+          reason: 'provider_rate_limit',
+        };
+      }
+      return {
+        type: 'none',
+        reason: 'rate_limit_exhausted',
+      };
+    }
+
+    if (canFallbackFromError(error, statusCode) && this.advanceRoute()) {
+      return {
+        type: 'route_changed',
+        reason: 'provider_failover',
+      };
+    }
+
+    return {
+      type: 'none',
+      reason: 'no_recovery_path',
+    };
+  }
+
+  private rotateCredential(statusCode: number | null, message: string): boolean {
+    const route = this.routes[this.routeIndex];
+    if ((route.credentialPool?.entries.length || 0) < 2) return false;
+
+    const activeRoute = this.current();
+    if (!activeRoute.credentialId) return false;
+
+    const currentState = getCredentialUsageState(route, activeRoute.credentialId);
+    currentState.exhaustedUntilMs =
+      Date.now() + getCredentialCooldownMs(statusCode, message);
+    route.currentCredentialId = null;
+    route.retried429 = false;
+
+    const nextCredential = selectLeastUsedCredential(
+      route,
+      activeRoute.credentialId,
+    );
+    if (!nextCredential) return false;
+
+    route.currentCredentialId = nextCredential.id;
+    return true;
+  }
+
+  private advanceRoute(): boolean {
+    if (this.routeIndex >= this.routes.length - 1) return false;
+    this.routeIndex += 1;
+    this.routes[this.routeIndex].currentCredentialId = null;
+    this.routes[this.routeIndex].retried429 = false;
+    return true;
+  }
+}
+
+export function createPrimaryModelRoutingSession(
+  input: ContainerInput,
+): PrimaryModelRoutingSession {
+  return new PrimaryModelRoutingSession(input.modelRouting, {
+    provider: input.provider,
+    baseUrl: input.baseUrl,
+    apiKey: input.apiKey,
+    model: input.model,
+    chatbotId: input.chatbotId,
+    enableRag: input.enableRag,
+    requestHeaders: input.requestHeaders,
+    isLocal: input.isLocal,
+    contextWindow: input.contextWindow,
+    thinkingFormat: input.thinkingFormat,
+    maxTokens: input.maxTokens,
+  });
+}

--- a/container/src/types.ts
+++ b/container/src/types.ts
@@ -1,4 +1,5 @@
 import type { McpServerConfig } from './mcp/types.js';
+import type { RuntimeProvider } from './providers/provider-ids.js';
 
 export interface ChatContentTextPart {
   type: 'text';
@@ -112,16 +113,7 @@ export interface PluginRuntimeToolDefinition {
 }
 
 export interface TaskModelPolicy {
-  provider?:
-    | 'hybridai'
-    | 'openai-codex'
-    | 'openrouter'
-    | 'mistral'
-    | 'huggingface'
-    | 'ollama'
-    | 'lmstudio'
-    | 'llamacpp'
-    | 'vllm';
+  provider?: RuntimeProvider;
   baseUrl?: string;
   apiKey?: string;
   requestHeaders?: Record<string, string>;
@@ -192,6 +184,37 @@ export interface WebSearchConfig {
   tavilySearchDepth: 'basic' | 'advanced';
 }
 
+export interface ProviderCredentialPoolEntryInput {
+  id: string;
+  label: string;
+  apiKey: string;
+}
+
+export interface ProviderCredentialPoolInput {
+  rotation: 'least_used';
+  entries: ProviderCredentialPoolEntryInput[];
+}
+
+export interface ModelRoutingRouteInput {
+  provider?: RuntimeProvider;
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+  chatbotId: string;
+  enableRag: boolean;
+  requestHeaders?: Record<string, string>;
+  isLocal?: boolean;
+  contextWindow?: number;
+  thinkingFormat?: 'qwen';
+  maxTokens?: number;
+  credentialPool?: ProviderCredentialPoolInput;
+}
+
+export interface ModelRoutingInput {
+  routes: ModelRoutingRouteInput[];
+  adaptiveContextTierDowngradeOn429?: boolean;
+}
+
 export interface ContainerInput {
   sessionId: string;
   messages: ChatMessage[];
@@ -199,16 +222,7 @@ export interface ContainerInput {
   enableRag: boolean;
   apiKey: string;
   baseUrl: string;
-  provider?:
-    | 'hybridai'
-    | 'openai-codex'
-    | 'openrouter'
-    | 'mistral'
-    | 'huggingface'
-    | 'ollama'
-    | 'lmstudio'
-    | 'llamacpp'
-    | 'vllm';
+  provider?: RuntimeProvider;
   requestHeaders?: Record<string, string>;
   isLocal?: boolean;
   contextWindow?: number;
@@ -234,6 +248,7 @@ export interface ContainerInput {
   taskModels?: TaskModelPolicies;
   contextGuard?: ContextGuardConfig;
   webSearch?: WebSearchConfig;
+  modelRouting?: ModelRoutingInput;
 }
 
 export interface MediaContextItem {

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -84,7 +84,7 @@ import {
 import { DEFAULT_RUNTIME_HOME_DIR } from './runtime-paths.js';
 
 export const CONFIG_FILE_NAME = 'config.json';
-export const CONFIG_VERSION = 21;
+export const CONFIG_VERSION = 22;
 export const SECURITY_POLICY_VERSION = '2026-02-28';
 export const DEFAULT_HYBRIDAI_MODEL = 'gpt-5.4-mini';
 const LEGACY_DEFAULT_DB_PATH = 'data/hybridclaw.db';
@@ -266,6 +266,11 @@ export interface RuntimeRoutingConciergeConfig {
     balanced: string;
     noHurry: string;
   };
+}
+
+export interface RuntimePrimaryModelRoutingConfig {
+  fallbackModels: string[];
+  adaptiveContextTierDowngradeOn429: boolean;
 }
 
 export interface RuntimeDiscordHumanDelayConfig {
@@ -684,6 +689,7 @@ export interface RuntimeConfig {
   };
   routing: {
     concierge: RuntimeRoutingConciergeConfig;
+    primaryModel: RuntimePrimaryModelRoutingConfig;
   };
   heartbeat: {
     enabled: boolean;
@@ -1276,6 +1282,10 @@ const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
         balanced: 'gpt-5-mini',
         noHurry: 'gpt-5-nano',
       },
+    },
+    primaryModel: {
+      fallbackModels: [],
+      adaptiveContextTierDowngradeOn429: true,
     },
   },
   heartbeat: {
@@ -3829,6 +3839,25 @@ function normalizeRoutingConciergeConfig(
   };
 }
 
+function normalizePrimaryModelRoutingConfig(
+  value: unknown,
+  fallback: RuntimePrimaryModelRoutingConfig,
+): RuntimePrimaryModelRoutingConfig {
+  const raw = isRecord(value) ? value : {};
+  return {
+    fallbackModels: normalizeStringArray(
+      raw.fallbackModels ?? raw.fallbacks,
+      fallback.fallbackModels,
+    )
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+    adaptiveContextTierDowngradeOn429: normalizeBoolean(
+      raw.adaptiveContextTierDowngradeOn429 ?? raw.contextTierDowngradeOn429,
+      fallback.adaptiveContextTierDowngradeOn429,
+    ),
+  };
+}
+
 function normalizeTavilySearchDepth(
   value: unknown,
   fallback: 'basic' | 'advanced',
@@ -3935,6 +3964,9 @@ function normalizeRuntimeConfig(
   const rawWebSearch = isRecord(rawWeb.search) ? rawWeb.search : {};
   const rawMedia = isRecord(raw.media) ? raw.media : {};
   const rawRouting = isRecord(raw.routing) ? raw.routing : {};
+  const rawPrimaryModelRouting = isRecord(rawRouting.primaryModel)
+    ? rawRouting.primaryModel
+    : {};
   const rawHeartbeat = isRecord(raw.heartbeat) ? raw.heartbeat : {};
   const rawMemory = isRecord(raw.memory) ? raw.memory : {};
   const rawOps = isRecord(raw.ops) ? raw.ops : {};
@@ -4851,6 +4883,10 @@ function normalizeRuntimeConfig(
       concierge: normalizeRoutingConciergeConfig(
         rawRouting.concierge,
         DEFAULT_RUNTIME_CONFIG.routing.concierge,
+      ),
+      primaryModel: normalizePrimaryModelRoutingConfig(
+        rawPrimaryModelRouting,
+        DEFAULT_RUNTIME_CONFIG.routing.primaryModel,
       ),
     },
     heartbeat: {

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -47,8 +47,7 @@ import {
 import { logger } from '../logger.js';
 import { resolveUploadedMediaCacheHostDir } from '../media/uploaded-media-cache.js';
 import { withSpan } from '../observability/otel.js';
-import { resolveModelRuntimeCredentials } from '../providers/factory.js';
-import { resolveProviderRequestMaxTokens } from '../providers/request-max-tokens.js';
+import { resolvePrimaryModelRoutingPlan } from '../providers/model-routing.js';
 import { resolveTaskModelPolicies } from '../providers/task-routing.js';
 import { resolveConfiguredAdditionalMounts } from '../security/mount-config.js';
 import { validateAdditionalMounts } from '../security/mount-security.js';
@@ -83,16 +82,6 @@ import {
 import { computeWorkerSignature } from './worker-signature.js';
 
 const IDLE_TIMEOUT_MS = 300_000; // 5 minutes — matches container-side default
-
-function resolveExecutorMaxTokens(params: {
-  model: string;
-  discoveredMaxTokens?: number;
-}): number | undefined {
-  return resolveProviderRequestMaxTokens({
-    model: params.model,
-    discoveredMaxTokens: params.discoveredMaxTokens,
-  });
-}
 
 interface PoolEntry {
   process: ChildProcess;
@@ -762,15 +751,16 @@ async function runContainerInner(
     agentId,
     workspacePathOverride: params.workspacePathOverride,
   });
-  const modelRuntime = await resolveModelRuntimeCredentials({
+  const modelRouting = await resolvePrimaryModelRoutingPlan({
     model,
     chatbotId,
     enableRag,
     agentId,
   });
+  const primaryRoute = modelRouting.routes[0];
   const taskModels = await resolveTaskModelPolicies({
     agentId,
-    chatbotId: modelRuntime.chatbotId,
+    chatbotId: primaryRoute.chatbotId,
     sessionModel: model,
   });
   if (pool.size >= MAX_CONCURRENT_CONTAINERS && !pool.has(sessionId)) {
@@ -790,15 +780,15 @@ async function runContainerInner(
   const input: ContainerInput = {
     sessionId,
     messages,
-    chatbotId: modelRuntime.chatbotId,
-    enableRag: modelRuntime.enableRag,
-    apiKey: modelRuntime.apiKey,
-    baseUrl: remapHostBaseUrlForContainer(modelRuntime.baseUrl),
-    provider: modelRuntime.provider,
-    requestHeaders: modelRuntime.requestHeaders,
-    isLocal: modelRuntime.isLocal,
-    contextWindow: modelRuntime.contextWindow,
-    thinkingFormat: modelRuntime.thinkingFormat,
+    chatbotId: primaryRoute.chatbotId,
+    enableRag: primaryRoute.enableRag,
+    apiKey: primaryRoute.apiKey,
+    baseUrl: remapHostBaseUrlForContainer(primaryRoute.baseUrl),
+    provider: primaryRoute.provider,
+    requestHeaders: primaryRoute.requestHeaders,
+    isLocal: primaryRoute.isLocal,
+    contextWindow: primaryRoute.contextWindow,
+    thinkingFormat: primaryRoute.thinkingFormat,
     gatewayBaseUrl: remapHostBaseUrlForContainer(GATEWAY_BASE_URL),
     gatewayApiToken: GATEWAY_API_TOKEN || undefined,
     model,
@@ -807,10 +797,7 @@ async function runContainerInner(
     fullAutoNeverApproveTools,
     skipContainerSystemPrompt,
     streamTextDeltas: Boolean(onTextDelta),
-    maxTokens: resolveExecutorMaxTokens({
-      model,
-      discoveredMaxTokens: modelRuntime.maxTokens,
-    }),
+    maxTokens: primaryRoute.maxTokens,
     channelId,
     configuredDiscordChannels: collectConfiguredDiscordChannelIds(channelId),
     scheduledTasks: scheduledTasks?.map(
@@ -848,6 +835,33 @@ async function runContainerInner(
       searxngBaseUrl: WEB_SEARCH_SEARXNG_BASE_URL,
       tavilySearchDepth: WEB_SEARCH_TAVILY_SEARCH_DEPTH,
     },
+    modelRouting: {
+      routes: modelRouting.routes.map((route) => ({
+        provider: route.provider,
+        baseUrl: remapHostBaseUrlForContainer(route.baseUrl),
+        apiKey: route.apiKey,
+        model: route.model,
+        chatbotId: route.chatbotId,
+        enableRag: route.enableRag,
+        requestHeaders: { ...route.requestHeaders },
+        isLocal: route.isLocal,
+        contextWindow: route.contextWindow,
+        thinkingFormat: route.thinkingFormat,
+        maxTokens: route.maxTokens,
+        credentialPool: route.credentialPool
+          ? {
+              rotation: route.credentialPool.rotation,
+              entries: route.credentialPool.entries.map((entry) => ({
+                id: entry.id,
+                label: entry.label,
+                apiKey: entry.apiKey,
+              })),
+            }
+          : undefined,
+      })),
+      adaptiveContextTierDowngradeOn429:
+        modelRouting.adaptiveContextTierDowngradeOn429,
+    },
   };
   const workerSignature = computeWorkerSignature({
     agentId,
@@ -856,6 +870,7 @@ async function runContainerInner(
     apiKey: input.apiKey,
     requestHeaders: input.requestHeaders,
     taskModels: input.taskModels,
+    modelRouting: input.modelRouting,
     workspacePathOverride: params.workspacePathOverride,
     workspaceDisplayRootOverride: params.workspaceDisplayRootOverride,
     bashProxy: params.bashProxy,

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -34,8 +34,7 @@ import {
 import { logger } from '../logger.js';
 import { resolveUploadedMediaCacheHostDir } from '../media/uploaded-media-cache.js';
 import { withSpan } from '../observability/otel.js';
-import { resolveModelRuntimeCredentials } from '../providers/factory.js';
-import { resolveProviderRequestMaxTokens } from '../providers/request-max-tokens.js';
+import { resolvePrimaryModelRoutingPlan } from '../providers/model-routing.js';
 import { resolveTaskModelPolicies } from '../providers/task-routing.js';
 import { resolveConfiguredAdditionalMounts } from '../security/mount-config.js';
 import { redactSecrets } from '../security/redact.js';
@@ -78,16 +77,6 @@ const TOOL_RESULT_RE =
 const TOOL_START_RE = /^\[tool\]\s+([a-zA-Z0-9_.-]+):\s*(.*)$/;
 const APPROVAL_RE = /^\[approval\]\s+([A-Za-z0-9+/=]+)$/;
 const AGENT_OUTPUT_TIMEOUT_PREFIX = 'Timeout waiting for agent output after ';
-
-function resolveExecutorMaxTokens(params: {
-  model: string;
-  discoveredMaxTokens?: number;
-}): number | undefined {
-  return resolveProviderRequestMaxTokens({
-    model: params.model,
-    discoveredMaxTokens: params.discoveredMaxTokens,
-  });
-}
 
 function buildHostAllowedRoots(extraRoots: string[] = []): string[] {
   const configured = resolveConfiguredAdditionalMounts({
@@ -656,15 +645,16 @@ async function runHostProcessInner(
     agentId,
     workspacePathOverride: params.workspacePathOverride,
   });
-  const modelRuntime = await resolveModelRuntimeCredentials({
+  const modelRouting = await resolvePrimaryModelRoutingPlan({
     model,
     chatbotId,
     enableRag,
     agentId,
   });
+  const primaryRoute = modelRouting.routes[0];
   const taskModels = await resolveTaskModelPolicies({
     agentId,
-    chatbotId: modelRuntime.chatbotId,
+    chatbotId: primaryRoute.chatbotId,
     sessionModel: model,
   });
 
@@ -689,15 +679,15 @@ async function runHostProcessInner(
   const input: ContainerInput = {
     sessionId,
     messages,
-    chatbotId: modelRuntime.chatbotId,
-    enableRag: modelRuntime.enableRag,
-    apiKey: modelRuntime.apiKey,
-    baseUrl: modelRuntime.baseUrl,
-    provider: modelRuntime.provider,
-    requestHeaders: modelRuntime.requestHeaders,
-    isLocal: modelRuntime.isLocal,
-    contextWindow: modelRuntime.contextWindow,
-    thinkingFormat: modelRuntime.thinkingFormat,
+    chatbotId: primaryRoute.chatbotId,
+    enableRag: primaryRoute.enableRag,
+    apiKey: primaryRoute.apiKey,
+    baseUrl: primaryRoute.baseUrl,
+    provider: primaryRoute.provider,
+    requestHeaders: primaryRoute.requestHeaders,
+    isLocal: primaryRoute.isLocal,
+    contextWindow: primaryRoute.contextWindow,
+    thinkingFormat: primaryRoute.thinkingFormat,
     gatewayBaseUrl: GATEWAY_BASE_URL,
     gatewayApiToken: GATEWAY_API_TOKEN || undefined,
     model,
@@ -706,10 +696,7 @@ async function runHostProcessInner(
     fullAutoNeverApproveTools,
     skipContainerSystemPrompt,
     streamTextDeltas: Boolean(onTextDelta),
-    maxTokens: resolveExecutorMaxTokens({
-      model,
-      discoveredMaxTokens: modelRuntime.maxTokens,
-    }),
+    maxTokens: primaryRoute.maxTokens,
     channelId,
     configuredDiscordChannels: collectConfiguredDiscordChannelIds(channelId),
     scheduledTasks: scheduledTasks?.map(
@@ -747,6 +734,33 @@ async function runHostProcessInner(
       searxngBaseUrl: WEB_SEARCH_SEARXNG_BASE_URL,
       tavilySearchDepth: WEB_SEARCH_TAVILY_SEARCH_DEPTH,
     },
+    modelRouting: {
+      routes: modelRouting.routes.map((route) => ({
+        provider: route.provider,
+        baseUrl: route.baseUrl,
+        apiKey: route.apiKey,
+        model: route.model,
+        chatbotId: route.chatbotId,
+        enableRag: route.enableRag,
+        requestHeaders: { ...route.requestHeaders },
+        isLocal: route.isLocal,
+        contextWindow: route.contextWindow,
+        thinkingFormat: route.thinkingFormat,
+        maxTokens: route.maxTokens,
+        credentialPool: route.credentialPool
+          ? {
+              rotation: route.credentialPool.rotation,
+              entries: route.credentialPool.entries.map((entry) => ({
+                id: entry.id,
+                label: entry.label,
+                apiKey: entry.apiKey,
+              })),
+            }
+          : undefined,
+      })),
+      adaptiveContextTierDowngradeOn429:
+        modelRouting.adaptiveContextTierDowngradeOn429,
+    },
   };
   const workerSignature = computeWorkerSignature({
     agentId,
@@ -755,6 +769,7 @@ async function runHostProcessInner(
     apiKey: input.apiKey,
     requestHeaders: input.requestHeaders,
     taskModels: input.taskModels,
+    modelRouting: input.modelRouting,
     workspacePathOverride: params.workspacePathOverride,
     workspaceDisplayRootOverride: params.workspaceDisplayRootOverride,
     bashProxy: params.bashProxy,

--- a/src/infra/ipc.ts
+++ b/src/infra/ipc.ts
@@ -42,6 +42,30 @@ function redactTaskModelSecrets(
   return Object.keys(redacted).length > 0 ? redacted : undefined;
 }
 
+function redactModelRoutingSecrets(
+  modelRouting: ContainerInput['modelRouting'],
+): ContainerInput['modelRouting'] | undefined {
+  if (!modelRouting) return undefined;
+  return {
+    routes: modelRouting.routes.map((route) => ({
+      ...route,
+      apiKey: '',
+      requestHeaders: {},
+      credentialPool: route.credentialPool
+        ? {
+            rotation: route.credentialPool.rotation,
+            entries: route.credentialPool.entries.map((entry) => ({
+              ...entry,
+              apiKey: '',
+            })),
+          }
+        : undefined,
+    })),
+    adaptiveContextTierDowngradeOn429:
+      modelRouting.adaptiveContextTierDowngradeOn429,
+  };
+}
+
 export function agentWorkspaceDir(agentId: string): string {
   return path.join(agentDir(agentId), 'workspace');
 }
@@ -78,6 +102,7 @@ export function writeInput(
         apiKey: '',
         requestHeaders: {},
         taskModels: redactTaskModelSecrets(input.taskModels),
+        modelRouting: redactModelRoutingSecrets(input.modelRouting),
       }
     : input;
   fs.writeFileSync(inputPath, JSON.stringify(toWrite, null, 2));

--- a/src/infra/worker-signature.ts
+++ b/src/infra/worker-signature.ts
@@ -14,6 +14,32 @@ interface WorkerSignatureTaskModel {
   error?: string;
 }
 
+interface WorkerSignatureCredentialPoolEntry {
+  id: string;
+  label: string;
+  apiKey: string;
+}
+
+interface WorkerSignatureCredentialPool {
+  rotation: 'least_used';
+  entries: WorkerSignatureCredentialPoolEntry[];
+}
+
+interface WorkerSignatureModelRoute {
+  provider?: string;
+  baseUrl: string;
+  apiKey: string;
+  requestHeaders?: Record<string, string>;
+  isLocal?: boolean;
+  contextWindow?: number;
+  thinkingFormat?: string;
+  model: string;
+  chatbotId: string;
+  enableRag: boolean;
+  maxTokens?: number;
+  credentialPool?: WorkerSignatureCredentialPool;
+}
+
 export interface WorkerSignatureInput {
   agentId: string;
   provider: string | undefined;
@@ -21,6 +47,10 @@ export interface WorkerSignatureInput {
   apiKey: string;
   requestHeaders: Record<string, string> | undefined;
   taskModels?: Partial<Record<TaskModelKey, WorkerSignatureTaskModel>>;
+  modelRouting?: {
+    routes: WorkerSignatureModelRoute[];
+    adaptiveContextTierDowngradeOn429?: boolean;
+  };
   workspacePathOverride?: string;
   workspaceDisplayRootOverride?: string;
   bashProxy?:
@@ -66,6 +96,42 @@ function normalizeTaskModel(
   };
 }
 
+function normalizeModelRoute(
+  input: WorkerSignatureModelRoute,
+): Record<string, unknown> {
+  return {
+    provider: String(input.provider || '').trim(),
+    baseUrl: String(input.baseUrl || '')
+      .trim()
+      .replace(/\/+$/g, ''),
+    apiKey: String(input.apiKey || ''),
+    requestHeaders: normalizeHeaders(input.requestHeaders),
+    isLocal: input.isLocal === true,
+    contextWindow:
+      typeof input.contextWindow === 'number' ? input.contextWindow : null,
+    thinkingFormat: String(input.thinkingFormat || '').trim(),
+    model: String(input.model || '').trim(),
+    chatbotId: String(input.chatbotId || '').trim(),
+    enableRag: input.enableRag === true,
+    maxTokens:
+      typeof input.maxTokens === 'number' && Number.isFinite(input.maxTokens)
+        ? Math.floor(input.maxTokens)
+        : null,
+    credentialPool: input.credentialPool
+      ? {
+          rotation: input.credentialPool.rotation,
+          entries: input.credentialPool.entries
+            .map((entry) => ({
+              id: String(entry.id || '').trim(),
+              label: String(entry.label || '').trim(),
+              apiKey: String(entry.apiKey || ''),
+            }))
+            .sort((left, right) => left.id.localeCompare(right.id)),
+        }
+      : null,
+  };
+}
+
 export function computeWorkerSignature(input: WorkerSignatureInput): string {
   const normalizedHeaders = normalizeHeaders(input.requestHeaders);
   const taskModels = Object.fromEntries(
@@ -74,6 +140,13 @@ export function computeWorkerSignature(input: WorkerSignatureInput): string {
       normalizeTaskModel(input.taskModels?.[key]),
     ]),
   );
+  const modelRouting = input.modelRouting
+    ? {
+        routes: input.modelRouting.routes.map(normalizeModelRoute),
+        adaptiveContextTierDowngradeOn429:
+          input.modelRouting.adaptiveContextTierDowngradeOn429 === true,
+      }
+    : null;
 
   return JSON.stringify({
     agentId: String(input.agentId || '').trim(),
@@ -84,6 +157,7 @@ export function computeWorkerSignature(input: WorkerSignatureInput): string {
     apiKey: String(input.apiKey || ''),
     requestHeaders: normalizedHeaders,
     taskModels,
+    modelRouting,
     workspacePathOverride: String(input.workspacePathOverride || '').trim(),
     workspaceDisplayRootOverride: String(
       input.workspaceDisplayRootOverride || '',

--- a/src/providers/model-routing.ts
+++ b/src/providers/model-routing.ts
@@ -1,0 +1,258 @@
+import { createHash } from 'node:crypto';
+
+import { MissingRequiredEnvVarError } from '../config/config.js';
+import { getRuntimeConfig } from '../config/runtime-config.js';
+import { logger } from '../logger.js';
+import { readStoredRuntimeSecrets } from '../security/runtime-secrets.js';
+import { resolveModelRuntimeCredentials } from './factory.js';
+import { resolveProviderRequestMaxTokens } from './request-max-tokens.js';
+import type {
+  ResolvedCredentialPool,
+  ResolvedCredentialPoolEntry,
+  ResolvedModelRoutingPlan,
+  ResolvedModelRuntimeRoute,
+  ResolveProviderRuntimeParams,
+  RuntimeProviderId,
+} from './types.js';
+
+const PROVIDER_POOL_SECRET_NAMES: Partial<Record<RuntimeProviderId, string>> = {
+  hybridai: 'HYBRIDAI_API_KEY',
+  openrouter: 'OPENROUTER_API_KEY',
+  mistral: 'MISTRAL_API_KEY',
+  huggingface: 'HF_TOKEN',
+  gemini: 'GEMINI_API_KEY',
+  deepseek: 'DEEPSEEK_API_KEY',
+  xai: 'XAI_API_KEY',
+  zai: 'ZAI_API_KEY',
+  kimi: 'KIMI_API_KEY',
+  minimax: 'MINIMAX_API_KEY',
+  dashscope: 'DASHSCOPE_API_KEY',
+  xiaomi: 'XIAOMI_API_KEY',
+  kilo: 'KILO_API_KEY',
+  vllm: 'VLLM_API_KEY',
+};
+
+type SecretCatalog = Record<string, string | undefined>;
+
+interface DiscoveredSecretValue {
+  label: string;
+  value: string;
+}
+
+function createCredentialEntryId(
+  provider: RuntimeProviderId,
+  value: string,
+): string {
+  return createHash('sha256')
+    .update(`${provider}:${value}`, 'utf-8')
+    .digest('hex')
+    .slice(0, 16);
+}
+
+function normalizePoolListSecretNames(baseName: string): string[] {
+  if (baseName.endsWith('_API_KEY')) {
+    return [baseName.replace(/_API_KEY$/, '_API_KEYS'), `${baseName}_POOL`];
+  }
+  if (baseName.endsWith('_TOKEN')) {
+    return [baseName.replace(/_TOKEN$/, '_TOKENS'), `${baseName}_POOL`];
+  }
+  return [`${baseName}_POOL`];
+}
+
+function parseSecretList(value: string): string[] {
+  return value
+    .split(/[\n,]/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function collectIndexedSecretNames(
+  baseName: string,
+  source: SecretCatalog,
+): string[] {
+  const indexed = Object.keys(source)
+    .filter((key) => new RegExp(`^${baseName}_(\\d+)$`).test(key))
+    .sort((left, right) => {
+      const leftIndex = Number(left.slice(baseName.length + 1));
+      const rightIndex = Number(right.slice(baseName.length + 1));
+      return leftIndex - rightIndex;
+    });
+  return indexed;
+}
+
+function addDiscoveredSecret(
+  collection: DiscoveredSecretValue[],
+  seen: Set<string>,
+  label: string,
+  value: string | undefined,
+): void {
+  const normalized = String(value || '').trim();
+  if (!normalized || seen.has(normalized)) return;
+  seen.add(normalized);
+  collection.push({ label, value: normalized });
+}
+
+function discoverProviderSecretValues(
+  baseName: string,
+): DiscoveredSecretValue[] {
+  const storedSecrets = readStoredRuntimeSecrets();
+  const discovered: DiscoveredSecretValue[] = [];
+  const seen = new Set<string>();
+  const listSecretNames = normalizePoolListSecretNames(baseName);
+
+  addDiscoveredSecret(discovered, seen, baseName, process.env[baseName]);
+  addDiscoveredSecret(discovered, seen, baseName, storedSecrets[baseName]);
+
+  for (const listName of listSecretNames) {
+    const envValues = parseSecretList(process.env[listName] || '');
+    for (const [index, value] of envValues.entries()) {
+      addDiscoveredSecret(discovered, seen, `${listName}[${index + 1}]`, value);
+    }
+
+    const storedValues = parseSecretList(storedSecrets[listName] || '');
+    for (const [index, value] of storedValues.entries()) {
+      addDiscoveredSecret(discovered, seen, `${listName}[${index + 1}]`, value);
+    }
+  }
+
+  for (const indexedName of collectIndexedSecretNames(baseName, process.env)) {
+    addDiscoveredSecret(
+      discovered,
+      seen,
+      indexedName,
+      process.env[indexedName],
+    );
+  }
+  for (const indexedName of collectIndexedSecretNames(
+    baseName,
+    storedSecrets,
+  )) {
+    addDiscoveredSecret(
+      discovered,
+      seen,
+      indexedName,
+      storedSecrets[indexedName],
+    );
+  }
+
+  return discovered;
+}
+
+export function resolveProviderCredentialPool(
+  provider: RuntimeProviderId,
+  primaryApiKey?: string,
+): ResolvedCredentialPool | undefined {
+  const baseSecretName = PROVIDER_POOL_SECRET_NAMES[provider];
+  const seen = new Set<string>();
+  const entries: ResolvedCredentialPoolEntry[] = [];
+
+  const addEntry = (label: string, value: string | undefined) => {
+    const normalized = String(value || '').trim();
+    if (!normalized || seen.has(normalized)) return;
+    seen.add(normalized);
+    entries.push({
+      id: createCredentialEntryId(provider, normalized),
+      label,
+      apiKey: normalized,
+    });
+  };
+
+  addEntry('active', primaryApiKey);
+
+  if (baseSecretName) {
+    for (const discovered of discoverProviderSecretValues(baseSecretName)) {
+      addEntry(discovered.label, discovered.value);
+    }
+  }
+
+  return entries.length > 0
+    ? {
+        rotation: 'least_used',
+        entries,
+      }
+    : undefined;
+}
+
+function normalizeModelRouteChain(
+  primaryModel: string,
+  fallbackModels: string[],
+): string[] {
+  const chain: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of [primaryModel, ...fallbackModels]) {
+    const normalized = String(entry || '').trim();
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    chain.push(normalized);
+  }
+  return chain;
+}
+
+async function resolveRoute(
+  params: ResolveProviderRuntimeParams & { model: string },
+): Promise<ResolvedModelRuntimeRoute> {
+  const resolved = await resolveModelRuntimeCredentials(params);
+  return {
+    ...resolved,
+    model: params.model,
+    maxTokens: resolveProviderRequestMaxTokens({
+      model: params.model,
+      discoveredMaxTokens: resolved.maxTokens,
+    }),
+    credentialPool: resolveProviderCredentialPool(
+      resolved.provider,
+      resolved.apiKey,
+    ),
+  };
+}
+
+export async function resolvePrimaryModelRoutingPlan(
+  params: ResolveProviderRuntimeParams,
+): Promise<ResolvedModelRoutingPlan> {
+  const config = getRuntimeConfig();
+  const primaryModel =
+    String(params.model || config.hybridai.defaultModel).trim() ||
+    config.hybridai.defaultModel;
+  const routeModels = normalizeModelRouteChain(
+    primaryModel,
+    config.routing.primaryModel.fallbackModels,
+  );
+  const routes: ResolvedModelRuntimeRoute[] = [];
+
+  for (const [index, model] of routeModels.entries()) {
+    try {
+      routes.push(
+        await resolveRoute({
+          ...params,
+          model,
+        }),
+      );
+    } catch (error) {
+      if (index === 0 || error instanceof MissingRequiredEnvVarError) {
+        if (index === 0) throw error;
+        logger.warn(
+          {
+            model,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          'Skipping primary-model fallback route because credentials are unavailable',
+        );
+        continue;
+      }
+
+      logger.warn(
+        {
+          model,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        'Skipping primary-model fallback route because it could not be resolved',
+      );
+    }
+  }
+
+  return {
+    routes,
+    adaptiveContextTierDowngradeOn429:
+      config.routing.primaryModel.adaptiveContextTierDowngradeOn429,
+  };
+}

--- a/src/providers/provider-api-key-utils.ts
+++ b/src/providers/provider-api-key-utils.ts
@@ -3,7 +3,10 @@ import {
   MissingRequiredEnvVarError,
   refreshRuntimeSecretsFromEnv,
 } from '../config/config.js';
-import { runtimeSecretsPath } from '../security/runtime-secrets.js';
+import {
+  readStoredRuntimeSecrets,
+  runtimeSecretsPath,
+} from '../security/runtime-secrets.js';
 
 const PROVIDER_API_KEY_REFRESH_DEBOUNCE_MS = 250;
 let lastProviderApiKeyRefreshAt = 0;
@@ -33,6 +36,69 @@ function refreshProviderSecretsIfNeeded(): void {
   lastRuntimeSecretsSignature = readRuntimeSecretsSignature();
 }
 
+function parsePoolSecretList(value: string): string[] {
+  return value
+    .split(/[\n,]/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function getPoolListSecretNames(baseName: string): string[] {
+  if (baseName.endsWith('_API_KEY')) {
+    return [baseName.replace(/_API_KEY$/, '_API_KEYS'), `${baseName}_POOL`];
+  }
+  if (baseName.endsWith('_TOKEN')) {
+    return [baseName.replace(/_TOKEN$/, '_TOKENS'), `${baseName}_POOL`];
+  }
+  return [`${baseName}_POOL`];
+}
+
+function readPooledProviderApiKey(missingEnvVar: string): string {
+  const storedSecrets = readStoredRuntimeSecrets();
+  const directCandidates = [
+    process.env[missingEnvVar],
+    storedSecrets[missingEnvVar],
+  ];
+  for (const candidate of directCandidates) {
+    const normalized = String(candidate || '').trim();
+    if (normalized) return normalized;
+  }
+
+  for (const listSecretName of getPoolListSecretNames(missingEnvVar)) {
+    for (const source of [
+      process.env[listSecretName],
+      storedSecrets[listSecretName],
+    ]) {
+      const first = parsePoolSecretList(String(source || ''))[0];
+      if (first) return first;
+    }
+  }
+
+  const indexedSecretNames = new Set<string>();
+  for (const source of [process.env, storedSecrets]) {
+    for (const key of Object.keys(source)) {
+      if (new RegExp(`^${missingEnvVar}_(\\d+)$`).test(key)) {
+        indexedSecretNames.add(key);
+      }
+    }
+  }
+
+  for (const indexedSecretName of [...indexedSecretNames].sort(
+    (left, right) => {
+      const leftIndex = Number(left.slice(missingEnvVar.length + 1));
+      const rightIndex = Number(right.slice(missingEnvVar.length + 1));
+      return leftIndex - rightIndex;
+    },
+  )) {
+    const normalized = String(
+      process.env[indexedSecretName] || storedSecrets[indexedSecretName] || '',
+    ).trim();
+    if (normalized) return normalized;
+  }
+
+  return '';
+}
+
 export function readProviderApiKey(
   getEnvValues: () => Array<string | undefined>,
   missingEnvVar: string,
@@ -40,7 +106,8 @@ export function readProviderApiKey(
 ): string {
   refreshProviderSecretsIfNeeded();
   const apiKey =
-    getEnvValues().find((value) => typeof value === 'string' && value) || '';
+    getEnvValues().find((value) => typeof value === 'string' && value) ||
+    readPooledProviderApiKey(missingEnvVar);
   const normalized = apiKey.trim();
   if (!normalized && opts?.required !== false) {
     throw new MissingRequiredEnvVarError(missingEnvVar);

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -18,6 +18,29 @@ export interface ResolvedModelRuntimeCredentials {
   thinkingFormat?: LocalThinkingFormat;
 }
 
+export interface ResolvedCredentialPoolEntry {
+  id: string;
+  label: string;
+  apiKey: string;
+}
+
+export interface ResolvedCredentialPool {
+  rotation: 'least_used';
+  entries: ResolvedCredentialPoolEntry[];
+}
+
+export interface ResolvedModelRuntimeRoute
+  extends ResolvedModelRuntimeCredentials {
+  model: string;
+  maxTokens?: number;
+  credentialPool?: ResolvedCredentialPool;
+}
+
+export interface ResolvedModelRoutingPlan {
+  routes: ResolvedModelRuntimeRoute[];
+  adaptiveContextTierDowngradeOn429: boolean;
+}
+
 export interface ResolveProviderRuntimeParams {
   model: string;
   chatbotId?: string;

--- a/src/types/container.ts
+++ b/src/types/container.ts
@@ -49,6 +49,37 @@ export interface WebSearchConfig {
   tavilySearchDepth: 'basic' | 'advanced';
 }
 
+export interface ProviderCredentialPoolEntryInput {
+  id: string;
+  label: string;
+  apiKey: string;
+}
+
+export interface ProviderCredentialPoolInput {
+  rotation: 'least_used';
+  entries: ProviderCredentialPoolEntryInput[];
+}
+
+export interface ModelRoutingRouteInput {
+  provider?: ProviderKind;
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+  chatbotId: string;
+  enableRag: boolean;
+  requestHeaders?: Record<string, string>;
+  isLocal?: boolean;
+  contextWindow?: number;
+  thinkingFormat?: 'qwen';
+  maxTokens?: number;
+  credentialPool?: ProviderCredentialPoolInput;
+}
+
+export interface ModelRoutingInput {
+  routes: ModelRoutingRouteInput[];
+  adaptiveContextTierDowngradeOn429?: boolean;
+}
+
 export interface ContainerInput {
   sessionId: string;
   messages: ChatMessage[];
@@ -82,6 +113,7 @@ export interface ContainerInput {
   taskModels?: TaskModelPolicies;
   contextGuard?: ContextGuardConfig;
   webSearch?: WebSearchConfig;
+  modelRouting?: ModelRoutingInput;
 }
 
 export interface ContainerOutput {

--- a/tests/container.model-routing-state.test.ts
+++ b/tests/container.model-routing-state.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, describe, expect, test } from 'vitest';
+
+import {
+  clearModelRoutingStateForTests,
+  createPrimaryModelRoutingSession,
+} from '../container/src/model-routing.js';
+import { ProviderRequestError } from '../container/src/providers/shared.js';
+
+afterEach(() => {
+  clearModelRoutingStateForTests();
+});
+
+describe('container primary model routing session', () => {
+  test('prefers the least-used credential when a fresh session is created', () => {
+    const firstSession = createPrimaryModelRoutingSession({
+      sessionId: 'session-1',
+      messages: [],
+      chatbotId: 'bot_123',
+      enableRag: false,
+      apiKey: 'fallback-key',
+      baseUrl: 'https://hybridai.one',
+      provider: 'hybridai',
+      requestHeaders: {},
+      model: 'gpt-5-nano',
+      channelId: 'channel-1',
+      modelRouting: {
+        routes: [
+          {
+            provider: 'openrouter',
+            baseUrl: 'https://openrouter.ai/api/v1',
+            apiKey: 'or-active',
+            model: 'openrouter/openai/gpt-5',
+            chatbotId: '',
+            enableRag: false,
+            credentialPool: {
+              rotation: 'least_used',
+              entries: [
+                {
+                  id: 'pool-a',
+                  label: 'primary',
+                  apiKey: 'or-active',
+                },
+                {
+                  id: 'pool-b',
+                  label: 'secondary',
+                  apiKey: 'or-secondary',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    expect(firstSession.current()).toMatchObject({
+      credentialId: 'pool-a',
+      credentialLabel: 'primary',
+      apiKey: 'or-active',
+    });
+
+    firstSession.noteSuccess();
+
+    const secondSession = createPrimaryModelRoutingSession({
+      sessionId: 'session-2',
+      messages: [],
+      chatbotId: 'bot_123',
+      enableRag: false,
+      apiKey: 'fallback-key',
+      baseUrl: 'https://hybridai.one',
+      provider: 'hybridai',
+      requestHeaders: {},
+      model: 'gpt-5-nano',
+      channelId: 'channel-1',
+      modelRouting: {
+        routes: [
+          {
+            provider: 'openrouter',
+            baseUrl: 'https://openrouter.ai/api/v1',
+            apiKey: 'or-active',
+            model: 'openrouter/openai/gpt-5',
+            chatbotId: '',
+            enableRag: false,
+            credentialPool: {
+              rotation: 'least_used',
+              entries: [
+                {
+                  id: 'pool-a',
+                  label: 'primary',
+                  apiKey: 'or-active',
+                },
+                {
+                  id: 'pool-b',
+                  label: 'secondary',
+                  apiKey: 'or-secondary',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    expect(secondSession.current()).toMatchObject({
+      credentialId: 'pool-b',
+      credentialLabel: 'secondary',
+      apiKey: 'or-secondary',
+    });
+  });
+
+  test('rotates credentials on authentication failures before failing over providers', () => {
+    const session = createPrimaryModelRoutingSession({
+      sessionId: 'session-1',
+      messages: [],
+      chatbotId: 'bot_123',
+      enableRag: false,
+      apiKey: 'fallback-key',
+      baseUrl: 'https://hybridai.one',
+      provider: 'hybridai',
+      requestHeaders: {},
+      model: 'gpt-5-nano',
+      channelId: 'channel-1',
+      modelRouting: {
+        routes: [
+          {
+            provider: 'openrouter',
+            baseUrl: 'https://openrouter.ai/api/v1',
+            apiKey: 'or-active',
+            model: 'openrouter/openai/gpt-5',
+            chatbotId: '',
+            enableRag: false,
+            credentialPool: {
+              rotation: 'least_used',
+              entries: [
+                {
+                  id: 'pool-a',
+                  label: 'primary',
+                  apiKey: 'or-active',
+                },
+                {
+                  id: 'pool-b',
+                  label: 'secondary',
+                  apiKey: 'or-secondary',
+                },
+              ],
+            },
+          },
+          {
+            provider: 'mistral',
+            baseUrl: 'https://api.mistral.ai/v1',
+            apiKey: 'mistral-key',
+            model: 'mistral/mistral-large-latest',
+            chatbotId: '',
+            enableRag: false,
+          },
+        ],
+      },
+    });
+
+    expect(
+      session.recover(new ProviderRequestError(401, '{"error":"unauthorized"}'), {
+        canRetrySameRoute: true,
+      }),
+    ).toEqual({
+      type: 'route_changed',
+      reason: 'credential_auth',
+    });
+    expect(session.current()).toMatchObject({
+      provider: 'openrouter',
+      credentialId: 'pool-b',
+      apiKey: 'or-secondary',
+    });
+  });
+
+  test('downgrades the context tier on 429 before trying pool rotation or failover', () => {
+    const session = createPrimaryModelRoutingSession({
+      sessionId: 'session-1',
+      messages: [],
+      chatbotId: 'bot_123',
+      enableRag: false,
+      apiKey: 'fallback-key',
+      baseUrl: 'https://hybridai.one',
+      provider: 'hybridai',
+      requestHeaders: {},
+      model: 'gpt-5-nano',
+      channelId: 'channel-1',
+      contextWindow: 512_000,
+      modelRouting: {
+        routes: [
+          {
+            provider: 'hybridai',
+            baseUrl: 'https://hybridai.one',
+            apiKey: 'hai-active',
+            model: 'gpt-5-nano',
+            chatbotId: 'bot_123',
+            enableRag: false,
+            contextWindow: 512_000,
+          },
+        ],
+        adaptiveContextTierDowngradeOn429: true,
+      },
+    });
+
+    expect(
+      session.recover(new ProviderRequestError(429, '{"error":"rate_limited"}'), {
+        canRetrySameRoute: true,
+      }),
+    ).toEqual({
+      type: 'context_downgraded',
+      reason: 'rate_limit',
+      previousContextWindow: 512_000,
+      nextContextWindow: 256_000,
+    });
+    expect(session.current().contextWindow).toBe(256_000);
+  });
+
+  test('fails over to the next provider after rate-limit retry and pool exhaustion', () => {
+    const session = createPrimaryModelRoutingSession({
+      sessionId: 'session-1',
+      messages: [],
+      chatbotId: 'bot_123',
+      enableRag: false,
+      apiKey: 'fallback-key',
+      baseUrl: 'https://hybridai.one',
+      provider: 'hybridai',
+      requestHeaders: {},
+      model: 'gpt-5-nano',
+      channelId: 'channel-1',
+      contextWindow: 4096,
+      modelRouting: {
+        routes: [
+          {
+            provider: 'openrouter',
+            baseUrl: 'https://openrouter.ai/api/v1',
+            apiKey: 'or-active',
+            model: 'openrouter/openai/gpt-5',
+            chatbotId: '',
+            enableRag: false,
+            contextWindow: 4096,
+            credentialPool: {
+              rotation: 'least_used',
+              entries: [
+                {
+                  id: 'pool-a',
+                  label: 'primary',
+                  apiKey: 'or-active',
+                },
+              ],
+            },
+          },
+          {
+            provider: 'mistral',
+            baseUrl: 'https://api.mistral.ai/v1',
+            apiKey: 'mistral-key',
+            model: 'mistral/mistral-large-latest',
+            chatbotId: '',
+            enableRag: false,
+          },
+        ],
+        adaptiveContextTierDowngradeOn429: true,
+      },
+    });
+
+    expect(
+      session.recover(new ProviderRequestError(429, '{"error":"rate_limited"}'), {
+        canRetrySameRoute: true,
+      }),
+    ).toEqual({
+      type: 'none',
+      reason: 'rate_limit_retry',
+    });
+    expect(session.current()).toMatchObject({
+      provider: 'openrouter',
+      model: 'openrouter/openai/gpt-5',
+    });
+
+    expect(
+      session.recover(new ProviderRequestError(429, '{"error":"rate_limited"}'), {
+        canRetrySameRoute: false,
+      }),
+    ).toEqual({
+      type: 'route_changed',
+      reason: 'provider_rate_limit',
+    });
+    expect(session.current()).toMatchObject({
+      provider: 'mistral',
+      model: 'mistral/mistral-large-latest',
+      apiKey: 'mistral-key',
+    });
+  });
+});

--- a/tests/ipc.test.ts
+++ b/tests/ipc.test.ts
@@ -18,9 +18,28 @@ function restoreEnvVar(name: string, value: string | undefined): void {
   process.env[name] = value;
 }
 
+async function importIpc(homeDir: string) {
+  vi.doMock('../src/agents/agent-registry.js', () => ({
+    resolveAgentWorkspaceId: (agentId: string) => agentId,
+  }));
+  vi.doMock('../src/config/config.js', () => ({
+    CONTAINER_MAX_OUTPUT_SIZE: 1024 * 1024,
+    DATA_DIR: path.join(homeDir, '.hybridclaw', 'data'),
+  }));
+  vi.doMock('../src/logger.js', () => ({
+    logger: {
+      debug: vi.fn(),
+    },
+  }));
+  return import('../src/infra/ipc.ts');
+}
+
 afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
+  vi.doUnmock('../src/agents/agent-registry.js');
+  vi.doUnmock('../src/config/config.js');
+  vi.doUnmock('../src/logger.js');
   vi.resetModules();
   restoreEnvVar('HOME', ORIGINAL_HOME);
 });
@@ -30,7 +49,7 @@ test('writeInput omits auth material from IPC files when requested', async () =>
   process.env.HOME = homeDir;
   vi.resetModules();
 
-  const { ensureSessionDirs, writeInput } = await import('../src/infra/ipc.ts');
+  const { ensureSessionDirs, writeInput } = await importIpc(homeDir);
   const input = {
     sessionId: 'session-1',
     messages: [{ role: 'user', content: 'hello' }],
@@ -59,6 +78,38 @@ test('writeInput omits auth material from IPC files when requested', async () =>
         maxTokens: 123,
       },
     },
+    modelRouting: {
+      routes: [
+        {
+          provider: 'openrouter' as const,
+          baseUrl: 'https://openrouter.ai/api/v1',
+          apiKey: 'route-secret',
+          requestHeaders: {
+            Authorization: 'Bearer route-secret',
+          },
+          model: 'openrouter/openai/gpt-5',
+          chatbotId: '',
+          enableRag: false,
+          maxTokens: 456,
+          credentialPool: {
+            rotation: 'least_used' as const,
+            entries: [
+              {
+                id: 'pool-1',
+                label: 'primary',
+                apiKey: 'pool-secret-1',
+              },
+              {
+                id: 'pool-2',
+                label: 'secondary',
+                apiKey: 'pool-secret-2',
+              },
+            ],
+          },
+        },
+      ],
+      adaptiveContextTierDowngradeOn429: true,
+    },
   };
 
   ensureSessionDirs('session-1');
@@ -81,9 +132,43 @@ test('writeInput omits auth material from IPC files when requested', async () =>
       maxTokens: 123,
     },
   });
+  expect(written.modelRouting).toEqual({
+    routes: [
+      {
+        provider: 'openrouter',
+        baseUrl: 'https://openrouter.ai/api/v1',
+        apiKey: '',
+        requestHeaders: {},
+        model: 'openrouter/openai/gpt-5',
+        chatbotId: '',
+        enableRag: false,
+        maxTokens: 456,
+        credentialPool: {
+          rotation: 'least_used',
+          entries: [
+            {
+              id: 'pool-1',
+              label: 'primary',
+              apiKey: '',
+            },
+            {
+              id: 'pool-2',
+              label: 'secondary',
+              apiKey: '',
+            },
+          ],
+        },
+      },
+    ],
+    adaptiveContextTierDowngradeOn429: true,
+  });
   expect(input.apiKey).toBe('token_secret');
   expect(input.requestHeaders.Authorization).toBe('Bearer token_secret');
   expect(input.taskModels.compression.apiKey).toBe('or-secret');
+  expect(input.modelRouting.routes[0].apiKey).toBe('route-secret');
+  expect(input.modelRouting.routes[0].credentialPool?.entries[0].apiKey).toBe(
+    'pool-secret-1',
+  );
 });
 
 test('readOutput enforces a hard deadline despite repeated activity', async () => {
@@ -93,9 +178,8 @@ test('readOutput enforces a hard deadline despite repeated activity', async () =
   vi.setSystemTime(new Date('2026-03-11T00:00:00Z'));
   vi.resetModules();
 
-  const { ensureSessionDirs, createActivityTracker, readOutput } = await import(
-    '../src/infra/ipc.ts'
-  );
+  const { ensureSessionDirs, createActivityTracker, readOutput } =
+    await importIpc(homeDir);
 
   ensureSessionDirs('session-1');
   const activity = createActivityTracker();
@@ -122,7 +206,7 @@ test('readOutput does not time out when inactivity and wall-clock timeouts are d
   vi.setSystemTime(new Date('2026-03-11T00:00:00Z'));
   vi.resetModules();
 
-  const { ensureSessionDirs, readOutput } = await import('../src/infra/ipc.ts');
+  const { ensureSessionDirs, readOutput } = await importIpc(homeDir);
 
   ensureSessionDirs('session-1');
   const outputPath = path.join(

--- a/tests/provider-api-key-utils.test.ts
+++ b/tests/provider-api-key-utils.test.ts
@@ -1,4 +1,10 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+
+const ORIGINAL_TEST_API_KEYS = process.env.TEST_API_KEYS;
+const ORIGINAL_TEST_API_KEY_1 = process.env.TEST_API_KEY_1;
+const ORIGINAL_TEST_API_KEY_2 = process.env.TEST_API_KEY_2;
 
 async function importFreshUtils() {
   vi.resetModules();
@@ -15,6 +21,11 @@ async function importFreshUtils() {
     refreshRuntimeSecretsFromEnv,
     MissingRequiredEnvVarError,
   }));
+  vi.doMock('../src/security/runtime-secrets.js', () => ({
+    readStoredRuntimeSecrets: () => ({}),
+    runtimeSecretsPath: () =>
+      path.join(os.tmpdir(), 'hybridclaw-test-runtime-secrets.json'),
+  }));
   const utils = await import('../src/providers/provider-api-key-utils.ts');
   return { ...utils, refreshRuntimeSecretsFromEnv, MissingRequiredEnvVarError };
 }
@@ -23,7 +34,23 @@ afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
   vi.doUnmock('../src/config/config.js');
+  vi.doUnmock('../src/security/runtime-secrets.js');
   vi.resetModules();
+  if (ORIGINAL_TEST_API_KEYS === undefined) {
+    delete process.env.TEST_API_KEYS;
+  } else {
+    process.env.TEST_API_KEYS = ORIGINAL_TEST_API_KEYS;
+  }
+  if (ORIGINAL_TEST_API_KEY_1 === undefined) {
+    delete process.env.TEST_API_KEY_1;
+  } else {
+    process.env.TEST_API_KEY_1 = ORIGINAL_TEST_API_KEY_1;
+  }
+  if (ORIGINAL_TEST_API_KEY_2 === undefined) {
+    delete process.env.TEST_API_KEY_2;
+  } else {
+    process.env.TEST_API_KEY_2 = ORIGINAL_TEST_API_KEY_2;
+  }
 });
 
 describe('readProviderApiKey', () => {
@@ -69,5 +96,18 @@ describe('readProviderApiKey', () => {
     expect(() => readProviderApiKey(() => [''], 'TEST_API_KEY')).toThrow(
       MissingRequiredEnvVarError,
     );
+  });
+
+  test('falls back to pooled provider keys when no direct key is present', async () => {
+    process.env.TEST_API_KEYS = ' pooled-one , pooled-two ';
+    process.env.TEST_API_KEY_1 = 'indexed-one';
+    process.env.TEST_API_KEY_2 = 'indexed-two';
+    const { readProviderApiKey } = await importFreshUtils();
+
+    expect(
+      readProviderApiKey(() => [''], 'TEST_API_KEY', {
+        required: false,
+      }),
+    ).toBe('pooled-one');
   });
 });

--- a/tests/providers.model-routing.test.ts
+++ b/tests/providers.model-routing.test.ts
@@ -1,0 +1,273 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+const ORIGINAL_HYBRIDAI_API_KEYS = process.env.HYBRIDAI_API_KEYS;
+const ORIGINAL_OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
+const ORIGINAL_OPENROUTER_API_KEYS = process.env.OPENROUTER_API_KEYS;
+const ORIGINAL_OPENROUTER_API_KEY_2 = process.env.OPENROUTER_API_KEY_2;
+
+function restoreEnvVar(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+async function importFreshModelRouting(params?: {
+  runtimeConfig?: {
+    hybridai?: { defaultModel?: string };
+    routing?: {
+      primaryModel?: {
+        fallbackModels?: string[];
+        adaptiveContextTierDowngradeOn429?: boolean;
+      };
+    };
+  };
+  storedSecrets?: Record<string, string>;
+  resolveModelRuntimeCredentials?: ReturnType<typeof vi.fn>;
+}) {
+  vi.resetModules();
+
+  class MissingRequiredEnvVarError extends Error {
+    envVar: string;
+
+    constructor(envVar: string) {
+      super(`Missing required env var: ${envVar}`);
+      this.name = 'MissingRequiredEnvVarError';
+      this.envVar = envVar;
+    }
+  }
+
+  const loggerWarn = vi.fn();
+  const resolveModelRuntimeCredentials =
+    params?.resolveModelRuntimeCredentials ??
+    vi.fn(async ({ model }: { model: string }) => ({
+      provider: 'hybridai',
+      apiKey: 'hai-key',
+      baseUrl: 'https://hybridai.one',
+      requestHeaders: {},
+      model,
+      chatbotId: 'bot_123',
+      enableRag: false,
+      maxTokens: 4321,
+    }));
+  const resolveProviderRequestMaxTokens = vi.fn(
+    ({
+      discoveredMaxTokens,
+    }: {
+      model: string;
+      discoveredMaxTokens?: number;
+    }) => discoveredMaxTokens,
+  );
+
+  vi.doMock('../src/config/config.js', () => ({
+    MissingRequiredEnvVarError,
+  }));
+  vi.doMock('../src/config/runtime-config.js', () => ({
+    getRuntimeConfig: () => ({
+      hybridai: {
+        defaultModel: 'gpt-5-nano',
+        ...(params?.runtimeConfig?.hybridai || {}),
+      },
+      routing: {
+        primaryModel: {
+          fallbackModels: [],
+          adaptiveContextTierDowngradeOn429: true,
+          ...(params?.runtimeConfig?.routing?.primaryModel || {}),
+        },
+      },
+    }),
+  }));
+  vi.doMock('../src/logger.js', () => ({
+    logger: {
+      warn: loggerWarn,
+    },
+  }));
+  vi.doMock('../src/security/runtime-secrets.js', () => ({
+    readStoredRuntimeSecrets: () => params?.storedSecrets || {},
+  }));
+  vi.doMock('../src/providers/request-max-tokens.js', () => ({
+    resolveProviderRequestMaxTokens,
+  }));
+  vi.doMock('../src/providers/factory.js', () => ({
+    resolveModelRuntimeCredentials,
+  }));
+
+  const modelRouting = await import('../src/providers/model-routing.ts');
+  return {
+    ...modelRouting,
+    MissingRequiredEnvVarError,
+    loggerWarn,
+    resolveModelRuntimeCredentials,
+    resolveProviderRequestMaxTokens,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.doUnmock('../src/config/config.js');
+  vi.doUnmock('../src/config/runtime-config.js');
+  vi.doUnmock('../src/logger.js');
+  vi.doUnmock('../src/security/runtime-secrets.js');
+  vi.doUnmock('../src/providers/request-max-tokens.js');
+  vi.doUnmock('../src/providers/factory.js');
+  vi.resetModules();
+  restoreEnvVar('HYBRIDAI_API_KEYS', ORIGINAL_HYBRIDAI_API_KEYS);
+  restoreEnvVar('OPENROUTER_API_KEY', ORIGINAL_OPENROUTER_API_KEY);
+  restoreEnvVar('OPENROUTER_API_KEYS', ORIGINAL_OPENROUTER_API_KEYS);
+  restoreEnvVar('OPENROUTER_API_KEY_2', ORIGINAL_OPENROUTER_API_KEY_2);
+});
+
+describe('provider model routing', () => {
+  test('discovers pooled provider credentials from env and stored secrets', async () => {
+    process.env.OPENROUTER_API_KEY = 'or-active';
+    process.env.OPENROUTER_API_KEYS = 'or-active, or-pooled-a';
+    process.env.OPENROUTER_API_KEY_2 = 'or-pooled-b';
+    const { resolveProviderCredentialPool } = await importFreshModelRouting({
+      storedSecrets: {
+        OPENROUTER_API_KEY_3: 'or-pooled-c',
+      },
+    });
+
+    expect(
+      resolveProviderCredentialPool('openrouter', 'or-active'),
+    ).toMatchObject({
+      rotation: 'least_used',
+      entries: [
+        {
+          label: 'active',
+          apiKey: 'or-active',
+        },
+        {
+          label: 'OPENROUTER_API_KEYS[2]',
+          apiKey: 'or-pooled-a',
+        },
+        {
+          label: 'OPENROUTER_API_KEY_2',
+          apiKey: 'or-pooled-b',
+        },
+        {
+          label: 'OPENROUTER_API_KEY_3',
+          apiKey: 'or-pooled-c',
+        },
+      ],
+    });
+  });
+
+  test('builds an ordered primary-model route plan and skips unresolved fallbacks', async () => {
+    process.env.HYBRIDAI_API_KEYS = 'hai-pooled-a, hai-pooled-b';
+    process.env.OPENROUTER_API_KEYS = 'or-pooled-a, or-pooled-b';
+    const {
+      MissingRequiredEnvVarError,
+      loggerWarn,
+      resolveModelRuntimeCredentials,
+      resolvePrimaryModelRoutingPlan,
+    } = await importFreshModelRouting({
+      runtimeConfig: {
+        routing: {
+          primaryModel: {
+            fallbackModels: [
+              'openrouter/anthropic/claude-sonnet-4',
+              'mistral/mistral-large-latest',
+            ],
+            adaptiveContextTierDowngradeOn429: false,
+          },
+        },
+      },
+      resolveModelRuntimeCredentials: vi.fn(
+        async ({ model }: { model: string }) => {
+          if (model === 'gpt-5-nano') {
+            return {
+              provider: 'hybridai',
+              apiKey: 'hai-active',
+              baseUrl: 'https://hybridai.one',
+              requestHeaders: {},
+              chatbotId: 'bot_123',
+              enableRag: false,
+              contextWindow: 1_000_000,
+              maxTokens: 8192,
+            };
+          }
+          if (model === 'openrouter/anthropic/claude-sonnet-4') {
+            return {
+              provider: 'openrouter',
+              apiKey: 'or-active',
+              baseUrl: 'https://openrouter.ai/api/v1',
+              requestHeaders: {
+                'HTTP-Referer': 'https://example.com',
+              },
+              chatbotId: '',
+              enableRag: false,
+              contextWindow: 256_000,
+              maxTokens: 4096,
+            };
+          }
+          throw new MissingRequiredEnvVarError('MISTRAL_API_KEY');
+        },
+      ),
+    });
+
+    const plan = await resolvePrimaryModelRoutingPlan({
+      model: 'gpt-5-nano',
+      chatbotId: 'bot_123',
+      enableRag: false,
+      agentId: 'main',
+    });
+
+    expect(resolveModelRuntimeCredentials).toHaveBeenCalledTimes(3);
+    expect(plan.adaptiveContextTierDowngradeOn429).toBe(false);
+    expect(plan.routes.map((route) => route.model)).toEqual([
+      'gpt-5-nano',
+      'openrouter/anthropic/claude-sonnet-4',
+    ]);
+    expect(plan.routes[0]).toMatchObject({
+      provider: 'hybridai',
+      apiKey: 'hai-active',
+      credentialPool: {
+        rotation: 'least_used',
+        entries: [
+          {
+            label: 'active',
+            apiKey: 'hai-active',
+          },
+          {
+            label: 'HYBRIDAI_API_KEYS[1]',
+            apiKey: 'hai-pooled-a',
+          },
+          {
+            label: 'HYBRIDAI_API_KEYS[2]',
+            apiKey: 'hai-pooled-b',
+          },
+        ],
+      },
+    });
+    expect(plan.routes[1]).toMatchObject({
+      provider: 'openrouter',
+      apiKey: 'or-active',
+      credentialPool: {
+        rotation: 'least_used',
+        entries: [
+          {
+            label: 'active',
+            apiKey: 'or-active',
+          },
+          {
+            label: 'OPENROUTER_API_KEYS[1]',
+            apiKey: 'or-pooled-a',
+          },
+          {
+            label: 'OPENROUTER_API_KEYS[2]',
+            apiKey: 'or-pooled-b',
+          },
+        ],
+      },
+    });
+    expect(loggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'mistral/mistral-large-latest',
+        error: 'Missing required env var: MISTRAL_API_KEY',
+      }),
+      'Skipping primary-model fallback route because credentials are unavailable',
+    );
+  });
+});

--- a/tests/worker-signature.test.ts
+++ b/tests/worker-signature.test.ts
@@ -108,3 +108,98 @@ test('computeWorkerSignature changes when auxiliary task routing changes', () =>
     }),
   ).not.toBe(baseline);
 });
+
+test('computeWorkerSignature changes when primary model routing changes', () => {
+  const baseline = computeWorkerSignature({
+    agentId: 'main',
+    provider: 'hybridai',
+    baseUrl: 'https://hybridai.one',
+    apiKey: 'main-secret',
+    requestHeaders: {},
+    modelRouting: {
+      routes: [
+        {
+          provider: 'hybridai',
+          baseUrl: 'https://hybridai.one',
+          apiKey: 'main-secret',
+          requestHeaders: {},
+          model: 'gpt-5-nano',
+          chatbotId: 'bot_123',
+          enableRag: false,
+          maxTokens: 333,
+          credentialPool: {
+            rotation: 'least_used',
+            entries: [
+              {
+                id: 'pool-a',
+                label: 'primary',
+                apiKey: 'secret-a',
+              },
+            ],
+          },
+        },
+      ],
+      adaptiveContextTierDowngradeOn429: true,
+    },
+  });
+
+  expect(
+    computeWorkerSignature({
+      agentId: 'main',
+      provider: 'hybridai',
+      baseUrl: 'https://hybridai.one',
+      apiKey: 'main-secret',
+      requestHeaders: {},
+      modelRouting: {
+        routes: [
+          {
+            provider: 'hybridai',
+            baseUrl: 'https://hybridai.one',
+            apiKey: 'main-secret',
+            requestHeaders: {},
+            model: 'gpt-5-nano',
+            chatbotId: 'bot_123',
+            enableRag: false,
+            maxTokens: 333,
+            credentialPool: {
+              rotation: 'least_used',
+              entries: [
+                {
+                  id: 'pool-b',
+                  label: 'secondary',
+                  apiKey: 'secret-b',
+                },
+              ],
+            },
+          },
+        ],
+        adaptiveContextTierDowngradeOn429: true,
+      },
+    }),
+  ).not.toBe(baseline);
+
+  expect(
+    computeWorkerSignature({
+      agentId: 'main',
+      provider: 'hybridai',
+      baseUrl: 'https://hybridai.one',
+      apiKey: 'main-secret',
+      requestHeaders: {},
+      modelRouting: {
+        routes: [
+          {
+            provider: 'hybridai',
+            baseUrl: 'https://hybridai.one',
+            apiKey: 'main-secret',
+            requestHeaders: {},
+            model: 'gpt-5',
+            chatbotId: 'bot_123',
+            enableRag: false,
+            maxTokens: 333,
+          },
+        ],
+        adaptiveContextTierDowngradeOn429: true,
+      },
+    }),
+  ).not.toBe(baseline);
+});


### PR DESCRIPTION
## What changed

This adds Hermes-style primary model routing for the main session model path.

- add runtime config for ordered primary-model fallbacks and adaptive context-tier downgrade on 429
- resolve an ordered route plan on the host, including per-provider credential pools discovered from env/runtime secrets
- send the full routing plan into the worker/container, while redacting pooled secrets from IPC files on disk
- add container-side recovery logic for least-used credential rotation, 401/402 credential failover, provider/model failover, and context-tier downgrade on 429
- include primary-model routing in worker signatures so persistent workers/containers restart when the fallback chain or pool changes
- add targeted tests for pool discovery, routing-plan assembly, IPC redaction, worker-signature invalidation, and container recovery behavior

## Why

HybridClaw auto-discovers model providers today, but it still executes the primary model path as a single resolved provider credential. That means a transient provider outage, an exhausted key, or a long-context 429 can fail the whole turn even when alternate providers or keys are already configured.

## Impact

Users with multiple provider credentials or fallback models configured can now recover from more provider-side failures automatically without manually switching models.

- 401 and similar auth failures can rotate to another key in the same provider pool
- 402/quota-style failures can move off an exhausted credential
- 429 responses can first downgrade the active context tier, then rotate credentials, then fail over across configured fallback models/providers
- persistent workers pick up routing/pool changes deterministically

## Root cause

The main session model execution path only resolved one provider credential up front and retried that same route. It had no ordered fallback chain, no pooled credential rotation, and no adaptive downgrade for long-context rate-limit scenarios.

## Validation

Passed:

- `npm run typecheck`
- `npm run lint`
- `npm run format`
- `npm exec vitest -- run tests/provider-api-key-utils.test.ts tests/providers.model-routing.test.ts tests/container.model-routing-state.test.ts tests/ipc.test.ts tests/worker-signature.test.ts`

Blocked in this desktop environment:

- broader runner/provider suites currently hit a pre-existing `better-sqlite3` native binary mismatch (`NODE_MODULE_VERSION 127` vs `141`), so they could not be used as final validation here
