### PR TITLE
[codex] Classify network errors and auto-route model fallbacks

### DIFF
--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -18,7 +18,10 @@ import { McpClientManager } from './mcp/client-manager.js';
 import { McpConfigWatcher } from './mcp/config-watcher.js';
 import {
   formatModelErrorForLog,
+  classifyModelError,
   isRetryableModelError,
+  RoutedModelError,
+  shouldAutoRouteFromModelError,
   shouldDowngradeStreamToNonStreaming,
 } from './model-retry.js';
 import {
@@ -690,49 +693,28 @@ async function executePreparedToolCall(
   };
 }
 
-async function callHybridAIWithRetry(params: {
-  provider?:
-    | 'hybridai'
-    | 'openai-codex'
-    | 'openrouter'
-    | 'mistral'
-    | 'huggingface'
-    | 'ollama'
-    | 'lmstudio'
-    | 'llamacpp'
-    | 'vllm';
+interface ModelCallTarget {
+  provider: ContainerInput['provider'];
   baseUrl: string;
   apiKey: string;
   model: string;
   chatbotId: string;
   enableRag: boolean;
   requestHeaders?: Record<string, string>;
-  history: ChatMessage[];
-  tools: ToolDefinition[];
-  onTextDelta?: (delta: string) => void;
-  onActivity?: () => void;
   maxTokens?: number;
   isLocal?: boolean;
   contextWindow?: number;
   thinkingFormat?: 'qwen';
+}
+
+async function callSingleModelTargetWithRetry(params: {
+  target: ModelCallTarget;
+  history: ChatMessage[];
+  tools: ToolDefinition[];
+  onTextDelta?: (delta: string) => void;
+  onActivity?: () => void;
 }): Promise<ChatCompletionResponse> {
-  const {
-    provider,
-    baseUrl,
-    apiKey,
-    model,
-    chatbotId,
-    enableRag,
-    requestHeaders,
-    history,
-    tools,
-    onTextDelta,
-    onActivity,
-    maxTokens,
-    isLocal,
-    contextWindow,
-    thinkingFormat,
-  } = params;
+  const { target, history, tools, onTextDelta, onActivity } = params;
   let attempt = 0;
   let delayMs = RETRY_BASE_DELAY_MS;
 
@@ -740,7 +722,7 @@ async function callHybridAIWithRetry(params: {
     attempt += 1;
     const attemptStartedAt = Date.now();
     console.error(
-      `[model] call start provider=${provider || 'hybridai'} model=${model} attempt=${attempt} streaming=${Boolean(onTextDelta)} messages=${history.length} tools=${tools.length}`,
+      `[model] call start provider=${target.provider || 'hybridai'} model=${target.model} attempt=${attempt} streaming=${Boolean(onTextDelta)} messages=${history.length} tools=${tools.length}`,
     );
     await emitRuntimeEvent({ event: 'before_model_call', attempt });
     try {
@@ -748,63 +730,65 @@ async function callHybridAIWithRetry(params: {
       if (onTextDelta) {
         try {
           response = await callRoutedModelStream({
-            provider,
-            baseUrl,
-            apiKey,
-            model,
-            chatbotId,
-            enableRag,
-            requestHeaders,
+            provider: target.provider,
+            baseUrl: target.baseUrl,
+            apiKey: target.apiKey,
+            model: target.model,
+            chatbotId: target.chatbotId,
+            enableRag: target.enableRag,
+            requestHeaders: target.requestHeaders,
             messages: history,
             tools,
             onTextDelta,
             onActivity,
-            maxTokens,
-            isLocal,
-            contextWindow,
-            thinkingFormat,
+            maxTokens: target.maxTokens,
+            isLocal: target.isLocal,
+            contextWindow: target.contextWindow,
+            thinkingFormat: target.thinkingFormat,
           });
         } catch (streamErr) {
           const fallbackEligible = shouldDowngradeStreamToNonStreaming(
-            provider,
+            target.provider,
             streamErr,
           );
-          if (!fallbackEligible) throw streamErr;
+          if (!fallbackEligible || shouldAutoRouteFromModelError(streamErr)) {
+            throw streamErr;
+          }
           response = await callRoutedModel({
-            provider,
-            baseUrl,
-            apiKey,
-            model,
-            chatbotId,
-            enableRag,
-            requestHeaders,
+            provider: target.provider,
+            baseUrl: target.baseUrl,
+            apiKey: target.apiKey,
+            model: target.model,
+            chatbotId: target.chatbotId,
+            enableRag: target.enableRag,
+            requestHeaders: target.requestHeaders,
             messages: history,
             tools,
-            maxTokens,
-            isLocal,
-            contextWindow,
-            thinkingFormat,
+            maxTokens: target.maxTokens,
+            isLocal: target.isLocal,
+            contextWindow: target.contextWindow,
+            thinkingFormat: target.thinkingFormat,
           });
         }
       } else {
         response = await callRoutedModel({
-          provider,
-          baseUrl,
-          apiKey,
-          model,
-          chatbotId,
-          enableRag,
-          requestHeaders,
+          provider: target.provider,
+          baseUrl: target.baseUrl,
+          apiKey: target.apiKey,
+          model: target.model,
+          chatbotId: target.chatbotId,
+          enableRag: target.enableRag,
+          requestHeaders: target.requestHeaders,
           messages: history,
           tools,
-          maxTokens,
-          isLocal,
-          contextWindow,
-          thinkingFormat,
+          maxTokens: target.maxTokens,
+          isLocal: target.isLocal,
+          contextWindow: target.contextWindow,
+          thinkingFormat: target.thinkingFormat,
         });
       }
       console.error(
-        `[model] call success provider=${provider || 'hybridai'} model=${model} attempt=${attempt} durationMs=${Date.now() - attemptStartedAt} toolCalls=${response.choices[0]?.message?.tool_calls?.length || 0}`,
+        `[model] call success provider=${target.provider || 'hybridai'} model=${target.model} attempt=${attempt} durationMs=${Date.now() - attemptStartedAt} toolCalls=${response.choices[0]?.message?.tool_calls?.length || 0}`,
       );
       await emitRuntimeEvent({
         event: 'after_model_call',
@@ -813,7 +797,7 @@ async function callHybridAIWithRetry(params: {
       });
       return response;
     } catch (err) {
-      const formattedError = formatModelErrorForLog(err, baseUrl);
+      const formattedError = formatModelErrorForLog(err, target.baseUrl);
       const retryable =
         RETRY_ENABLED &&
         isRetryableModelError(err) &&
@@ -824,14 +808,74 @@ async function callHybridAIWithRetry(params: {
         retryable,
         error: formattedError,
       });
+      const classification = classifyModelError(err);
       console.error(
-        `[model] call ${retryable ? 'retry' : 'error'} provider=${provider || 'hybridai'} model=${model} attempt=${attempt} durationMs=${Date.now() - attemptStartedAt} retryable=${retryable} error=${formattedError}`,
+        `[model] call ${retryable ? 'retry' : 'error'} provider=${target.provider || 'hybridai'} model=${target.model} attempt=${attempt} durationMs=${Date.now() - attemptStartedAt} retryable=${retryable} class=${classification.kind} error=${formattedError}`,
       );
       if (!retryable) throw err;
       await sleep(delayMs);
       delayMs = Math.min(delayMs * 2, RETRY_MAX_DELAY_MS);
     }
   }
+}
+
+async function callModelWithRetry(params: {
+  primaryTarget: ModelCallTarget;
+  fallbackTargets?: ContainerInput['modelFallbacks'];
+  history: ChatMessage[];
+  tools: ToolDefinition[];
+  onTextDelta?: (delta: string) => void;
+  onActivity?: () => void;
+}): Promise<ChatCompletionResponse> {
+  const {
+    primaryTarget,
+    fallbackTargets,
+    history,
+    tools,
+    onTextDelta,
+    onActivity,
+  } = params;
+  const targets: ModelCallTarget[] = [
+    primaryTarget,
+    ...((fallbackTargets || []) as ModelCallTarget[]),
+  ];
+  const failures: ConstructorParameters<typeof RoutedModelError>[0] = [];
+
+  for (let index = 0; index < targets.length; index += 1) {
+    const target = targets[index];
+    try {
+      return await callSingleModelTargetWithRetry({
+        target,
+        history,
+        tools,
+        onTextDelta,
+        onActivity,
+      });
+    } catch (error) {
+      const classification = classifyModelError(error);
+      failures.push({
+        target: {
+          provider: target.provider,
+          model: target.model,
+          baseUrl: target.baseUrl,
+        },
+        classification,
+        error,
+      });
+
+      const nextTarget = targets[index + 1];
+      const autoRoute = classification.autoRoute && Boolean(nextTarget);
+      console.error(
+        `[model] route ${autoRoute ? 'fallback' : 'stop'} provider=${target.provider || 'hybridai'} model=${target.model} class=${classification.kind}${nextTarget ? ` nextProvider=${nextTarget.provider || 'hybridai'} nextModel=${nextTarget.model}` : ''}`,
+      );
+
+      if (!autoRoute) {
+        throw new RoutedModelError(failures);
+      }
+    }
+  }
+
+  throw new RoutedModelError(failures);
 }
 
 /**
@@ -841,21 +885,12 @@ async function processRequest(
   messages: ChatMessage[],
   apiKey: string,
   baseUrl: string,
-  provider:
-    | 'hybridai'
-    | 'openai-codex'
-    | 'openrouter'
-    | 'mistral'
-    | 'huggingface'
-    | 'ollama'
-    | 'lmstudio'
-    | 'llamacpp'
-    | 'vllm'
-    | undefined,
+  provider: ContainerInput['provider'],
   isLocal: boolean | undefined,
   contextWindow: number | undefined,
   thinkingFormat: 'qwen' | undefined,
   model: string,
+  modelFallbacks: ContainerInput['modelFallbacks'] | undefined,
   chatbotId: string,
   enableRag: boolean,
   requestHeaders: Record<string, string> | undefined,
@@ -995,24 +1030,27 @@ async function processRequest(
       tokenEstimateCache,
     );
 
-    let response: Awaited<ReturnType<typeof callHybridAIWithRetry>>;
+    let response: Awaited<ReturnType<typeof callModelWithRetry>>;
     try {
-      response = await callHybridAIWithRetry({
-        provider,
-        baseUrl,
-        apiKey,
-        model,
-        chatbotId,
-        enableRag,
-        requestHeaders,
+      response = await callModelWithRetry({
+        primaryTarget: {
+          provider,
+          baseUrl,
+          apiKey,
+          model,
+          chatbotId,
+          enableRag,
+          requestHeaders,
+          maxTokens,
+          isLocal,
+          contextWindow,
+          thinkingFormat,
+        },
+        fallbackTargets: modelFallbacks,
         history,
         tools,
         onTextDelta: streamTextDeltas ? emitStreamDelta : undefined,
         onActivity: streamTextDeltas ? emitStreamActivity : undefined,
-        maxTokens,
-        isLocal,
-        contextWindow,
-        thinkingFormat,
       });
     } catch (err) {
       const failed: ContainerOutput = {
@@ -1023,9 +1061,11 @@ async function processRequest(
         toolExecutions,
         tokenUsage: finalizeTokenUsage(tokenUsage),
         error:
-          err instanceof ProviderRequestError
+          err instanceof RoutedModelError
             ? err.message
-            : `API error: ${err instanceof Error ? err.message : String(err)}`,
+            : err instanceof ProviderRequestError
+              ? err.message
+              : `API error: ${err instanceof Error ? err.message : String(err)}`,
       };
       await emitRuntimeEvent({
         event: 'turn_end',
@@ -1611,6 +1651,7 @@ async function main(): Promise<void> {
       firstInput.contextWindow,
       firstInput.thinkingFormat,
       firstInput.model,
+      firstInput.modelFallbacks,
       firstInput.chatbotId,
       firstInput.enableRag,
       storedRequestHeaders,
@@ -1646,6 +1687,7 @@ async function main(): Promise<void> {
         firstInput.contextWindow,
         firstInput.thinkingFormat,
         firstInput.model,
+        firstInput.modelFallbacks,
         firstInput.chatbotId,
         firstInput.enableRag,
         firstInput.requestHeaders,
@@ -1764,6 +1806,7 @@ async function main(): Promise<void> {
       input.contextWindow,
       input.thinkingFormat,
       input.model,
+      input.modelFallbacks,
       input.chatbotId,
       input.enableRag,
       requestHeaders,
@@ -1798,6 +1841,7 @@ async function main(): Promise<void> {
         input.contextWindow,
         input.thinkingFormat,
         input.model,
+        input.modelFallbacks,
         input.chatbotId,
         input.enableRag,
         requestHeaders,

--- a/container/src/model-error-classification.ts
+++ b/container/src/model-error-classification.ts
@@ -1,0 +1,372 @@
+import {
+  isPremiumModelPermissionError,
+  ProviderRequestError,
+  type RuntimeProvider,
+} from './providers/shared.js';
+
+const DNS_CODE_SET = new Set(['EAI_AGAIN', 'ENODATA', 'ENOTFOUND']);
+const TLS_CODE_SET = new Set([
+  'CERT_HAS_EXPIRED',
+  'DEPTH_ZERO_SELF_SIGNED_CERT',
+  'EPROTO',
+  'ERR_SSL_BAD_RECORD_TYPE',
+  'ERR_SSL_WRONG_VERSION_NUMBER',
+  'ERR_TLS_CERT_ALTNAME_INVALID',
+  'SELF_SIGNED_CERT_IN_CHAIN',
+  'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+  'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+]);
+const TIMEOUT_CODE_SET = new Set([
+  'ETIMEDOUT',
+  'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+]);
+const NETWORK_CODE_SET = new Set([
+  'ECONNABORTED',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'EPIPE',
+  'UND_ERR_SOCKET',
+]);
+const PROVIDER_OUTAGE_STATUS_SET = new Set([
+  502, 503, 504, 521, 522, 523, 524, 529,
+]);
+
+const DNS_MESSAGE_RE =
+  /\bdns\b|eai_again|enotfound|getaddrinfo|name resolution|no such host|server misbehaving/i;
+const TLS_MESSAGE_RE =
+  /\btls\b|\bssl\b|certificate|handshake|eproto|wrong version number|x509|unable to verify/i;
+const TIMEOUT_MESSAGE_RE =
+  /\btimeout\b|timed out|deadline exceeded|headers timeout|body timeout/i;
+const NETWORK_MESSAGE_RE =
+  /fetch failed|network error|socket|connection reset|reset by peer|connection refused|broken pipe|host is unreachable|network is unreachable|unexpected eof|terminated|econnreset|econnrefused|ehostunreach|enetunreach|eai_again/i;
+const PROVIDER_OUTAGE_MESSAGE_RE =
+  /overloaded|temporarily unavailable|service unavailable|upstream unavailable|please try again later|response\.failed|response\.incomplete|an error occurred while processing your request|server_error|gateway timeout/i;
+const GENERIC_FETCH_MESSAGE_RE =
+  /^(fetch failed|network error|request failed)$/i;
+
+export type ModelErrorKind =
+  | 'auth'
+  | 'rate_limit'
+  | 'dns'
+  | 'tls'
+  | 'timeout'
+  | 'network'
+  | 'http_5xx'
+  | 'provider_outage'
+  | 'bad_request'
+  | 'unknown';
+
+export interface ModelErrorClassification {
+  kind: ModelErrorKind;
+  retryable: boolean;
+  autoRoute: boolean;
+  status?: number;
+  detail: string;
+}
+
+export interface ModelFailureTarget {
+  provider: RuntimeProvider | undefined;
+  model: string;
+  baseUrl: string;
+}
+
+export interface ModelFailureRecord {
+  target: ModelFailureTarget;
+  classification: ModelErrorClassification;
+  error: unknown;
+}
+
+function providerLabel(provider: RuntimeProvider | undefined): string {
+  switch (provider) {
+    case 'openai-codex':
+      return 'OpenAI Codex';
+    case 'openrouter':
+      return 'OpenRouter';
+    case 'mistral':
+      return 'Mistral';
+    case 'huggingface':
+      return 'HuggingFace';
+    case 'ollama':
+      return 'Ollama';
+    case 'lmstudio':
+      return 'LM Studio';
+    case 'llamacpp':
+      return 'llama.cpp';
+    case 'vllm':
+      return 'vLLM';
+    case 'hybridai':
+    case undefined:
+      return 'HybridAI';
+    default:
+      return String(provider);
+  }
+}
+
+function targetPrefix(target: ModelFailureTarget): string {
+  return `${providerLabel(target.provider)} model \`${target.model}\``;
+}
+
+function normalizeCode(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim().toUpperCase();
+  return trimmed ? trimmed : null;
+}
+
+function collectErrorChain(error: unknown): Array<Record<string, unknown>> {
+  const chain: Array<Record<string, unknown>> = [];
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+
+  while (
+    current &&
+    typeof current === 'object' &&
+    !seen.has(current) &&
+    chain.length < 8
+  ) {
+    seen.add(current);
+    chain.push(current as Record<string, unknown>);
+    current =
+      current instanceof Error
+        ? current.cause
+        : (current as { cause?: unknown }).cause;
+  }
+
+  return chain;
+}
+
+function collectErrorCodes(error: unknown): string[] {
+  const out: string[] = [];
+  for (const item of collectErrorChain(error)) {
+    const code = normalizeCode(item.code);
+    if (code && !out.includes(code)) out.push(code);
+  }
+  return out;
+}
+
+function collectErrorMessages(error: unknown): string[] {
+  const out: string[] = [];
+
+  const add = (value: unknown): void => {
+    if (typeof value !== 'string') return;
+    const trimmed = value.trim();
+    if (!trimmed || out.includes(trimmed)) return;
+    out.push(trimmed);
+  };
+
+  if (error instanceof Error) add(error.message);
+  else add(String(error));
+
+  for (const item of collectErrorChain(error)) {
+    add(item.message);
+  }
+
+  return out;
+}
+
+function stripProviderErrorPrefix(message: string): string {
+  return message.replace(/^Provider API error \d+:\s*/i, '').trim();
+}
+
+function selectPreferredDetail(error: unknown): string {
+  if (error instanceof ProviderRequestError) {
+    return (
+      error.parsedBody?.message?.trim() ||
+      stripProviderErrorPrefix(error.message) ||
+      error.message
+    );
+  }
+
+  const messages = collectErrorMessages(error);
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!GENERIC_FETCH_MESSAGE_RE.test(message)) {
+      return message;
+    }
+  }
+  return messages[0] || String(error);
+}
+
+function hasMatchingCode(
+  codes: readonly string[],
+  candidates: ReadonlySet<string>,
+): boolean {
+  return codes.some((code) => candidates.has(code));
+}
+
+function withKind(
+  kind: ModelErrorKind,
+  detail: string,
+  status?: number,
+): ModelErrorClassification {
+  const retryable =
+    kind === 'rate_limit' ||
+    kind === 'dns' ||
+    kind === 'tls' ||
+    kind === 'timeout' ||
+    kind === 'network' ||
+    kind === 'http_5xx' ||
+    kind === 'provider_outage';
+  const autoRoute =
+    kind === 'dns' ||
+    kind === 'tls' ||
+    kind === 'timeout' ||
+    kind === 'network' ||
+    kind === 'http_5xx' ||
+    kind === 'provider_outage';
+  return {
+    kind,
+    retryable,
+    autoRoute,
+    ...(typeof status === 'number' ? { status } : {}),
+    detail,
+  };
+}
+
+export function classifyModelError(error: unknown): ModelErrorClassification {
+  const detail = selectPreferredDetail(error);
+  const lowerDetail = detail.toLowerCase();
+
+  if (isPremiumModelPermissionError(error)) {
+    return withKind('bad_request', detail, 403);
+  }
+
+  if (error instanceof ProviderRequestError) {
+    const status = error.status;
+    if (status === 401 || status === 403) {
+      return withKind('auth', detail, status);
+    }
+    if (status === 429) {
+      return withKind('rate_limit', detail, status);
+    }
+    if (status === 408) {
+      return withKind('timeout', detail, status);
+    }
+    if (
+      PROVIDER_OUTAGE_STATUS_SET.has(status) ||
+      PROVIDER_OUTAGE_MESSAGE_RE.test(lowerDetail)
+    ) {
+      return withKind('provider_outage', detail, status);
+    }
+    if (status >= 500 && status <= 599) {
+      return withKind('http_5xx', detail, status);
+    }
+    if (status >= 400 && status <= 499) {
+      return withKind('bad_request', detail, status);
+    }
+  }
+
+  const codes = collectErrorCodes(error);
+  const messageBundle = collectErrorMessages(error).join('\n').toLowerCase();
+
+  if (
+    hasMatchingCode(codes, DNS_CODE_SET) ||
+    DNS_MESSAGE_RE.test(messageBundle)
+  ) {
+    return withKind('dns', detail);
+  }
+  if (
+    hasMatchingCode(codes, TLS_CODE_SET) ||
+    TLS_MESSAGE_RE.test(messageBundle)
+  ) {
+    return withKind('tls', detail);
+  }
+  if (
+    hasMatchingCode(codes, TIMEOUT_CODE_SET) ||
+    TIMEOUT_MESSAGE_RE.test(messageBundle)
+  ) {
+    return withKind('timeout', detail);
+  }
+  if (PROVIDER_OUTAGE_MESSAGE_RE.test(messageBundle)) {
+    return withKind('provider_outage', detail);
+  }
+  if (
+    hasMatchingCode(codes, NETWORK_CODE_SET) ||
+    NETWORK_MESSAGE_RE.test(messageBundle)
+  ) {
+    return withKind('network', detail);
+  }
+
+  return withKind('unknown', detail);
+}
+
+export function shouldAutoRouteFromModelError(error: unknown): boolean {
+  return classifyModelError(error).autoRoute;
+}
+
+function extractHostLabel(baseUrl: string): string | null {
+  try {
+    return new URL(baseUrl).host || null;
+  } catch {
+    return null;
+  }
+}
+
+function formatRateLimitOrAuthMessage(record: ModelFailureRecord): string {
+  const prefix = `${targetPrefix(record.target)}: `;
+  if (record.error instanceof ProviderRequestError) {
+    return `${prefix}${record.error.message}`;
+  }
+  const detail =
+    record.error instanceof Error ? record.error.message : String(record.error);
+  return `${prefix}${detail}`;
+}
+
+export function formatModelFailureRecord(record: ModelFailureRecord): string {
+  const label = targetPrefix(record.target);
+  const endpoint = record.target.baseUrl.trim();
+  const host = extractHostLabel(endpoint);
+  const location = endpoint ? ` at \`${endpoint}\`` : '';
+  const statusText =
+    typeof record.classification.status === 'number'
+      ? `HTTP ${record.classification.status} `
+      : '';
+
+  switch (record.classification.kind) {
+    case 'dns':
+      return `${label}: DNS lookup failed for \`${host || endpoint || 'the configured host'}\` (${record.classification.detail}).`;
+    case 'tls':
+      return `${label}: TLS negotiation failed${location} (${record.classification.detail}). Check certificates or the http/https scheme.`;
+    case 'timeout':
+      return `${label}: request timed out${location} (${record.classification.detail}).`;
+    case 'network':
+      return `${label}: network connection failed${location} (${record.classification.detail}).`;
+    case 'provider_outage':
+      return `${label}: provider outage detected${location ? `${location}` : ''} (${statusText}${record.classification.detail}).`;
+    case 'http_5xx':
+      return `${label}: returned ${statusText.trim() || 'an HTTP 5xx response'}${location} (${record.classification.detail}).`;
+    case 'auth':
+    case 'rate_limit':
+    case 'bad_request':
+    case 'unknown':
+      return formatRateLimitOrAuthMessage(record);
+    default:
+      return `${label}: ${record.classification.detail}`;
+  }
+}
+
+export function formatModelFailureSummary(
+  failures: ModelFailureRecord[],
+): string {
+  if (failures.length <= 1) {
+    return failures[0]
+      ? formatModelFailureRecord(failures[0])
+      : 'Model request failed.';
+  }
+  return `All configured model routes failed. ${failures
+    .map((failure) => formatModelFailureRecord(failure))
+    .join(' ')}`;
+}
+
+export class RoutedModelError extends Error {
+  readonly failures: ModelFailureRecord[];
+
+  constructor(failures: ModelFailureRecord[]) {
+    super(formatModelFailureSummary(failures));
+    this.name = 'RoutedModelError';
+    this.failures = failures;
+  }
+}

--- a/container/src/model-retry.ts
+++ b/container/src/model-retry.ts
@@ -5,6 +5,8 @@ import {
   ProviderRequestError,
 } from './providers/shared.js';
 
+const TRANSIENT_NETWORK_ERROR_RE =
+  /fetch failed|network|socket|timeout|timed out|ECONNRESET|ECONNREFUSED|EAI_AGAIN|terminated/i;
 const TRANSIENT_CODEX_STREAM_ERROR_RE =
   /an error occurred while processing your request|request id [0-9a-f-]{8}-[0-9a-f-]{27}|streaming response ended without payload|stream ended without payload|response\.incomplete|response\.failed/i;
 const MAX_ERROR_DETAIL_DEPTH = 3;

--- a/container/src/model-retry.ts
+++ b/container/src/model-retry.ts
@@ -1,11 +1,10 @@
+import { classifyModelError } from './model-error-classification.js';
 import type { RuntimeProvider } from './providers/shared.js';
 import {
   isPremiumModelPermissionError,
   ProviderRequestError,
 } from './providers/shared.js';
 
-const TRANSIENT_NETWORK_ERROR_RE =
-  /fetch failed|network|socket|timeout|timed out|ECONNRESET|ECONNREFUSED|EAI_AGAIN|terminated/i;
 const TRANSIENT_CODEX_STREAM_ERROR_RE =
   /an error occurred while processing your request|request id [0-9a-f-]{8}-[0-9a-f-]{27}|streaming response ended without payload|stream ended without payload|response\.incomplete|response\.failed/i;
 const MAX_ERROR_DETAIL_DEPTH = 3;
@@ -143,6 +142,12 @@ export function formatModelErrorForLog(
   }
 }
 
+export {
+  classifyModelError,
+  RoutedModelError,
+  shouldAutoRouteFromModelError,
+} from './model-error-classification.js';
+
 export function shouldFallbackFromStreamError(error: unknown): boolean {
   if (error instanceof ProviderRequestError) {
     // Keep 429 on retry/backoff path; fallback does not help throttling.
@@ -154,10 +159,8 @@ export function shouldFallbackFromStreamError(error: unknown): boolean {
   if (!message.trim()) return false;
   // Keep 429 on retry/backoff path; fallback does not help throttling.
   if (/429|rate.?limit/i.test(message)) return false;
-  return (
-    TRANSIENT_NETWORK_ERROR_RE.test(message) ||
-    TRANSIENT_CODEX_STREAM_ERROR_RE.test(message)
-  );
+  const classified = classifyModelError(error);
+  return classified.autoRoute || TRANSIENT_CODEX_STREAM_ERROR_RE.test(message);
 }
 
 export function shouldDowngradeStreamToNonStreaming(
@@ -169,12 +172,12 @@ export function shouldDowngradeStreamToNonStreaming(
 }
 
 export function isRetryableModelError(error: unknown): boolean {
-  if (error instanceof ProviderRequestError) {
-    return error.status === 429 || (error.status >= 500 && error.status <= 504);
+  if (error instanceof ProviderRequestError && error.status === 505) {
+    return false;
   }
   const message = error instanceof Error ? error.message : String(error);
   return (
-    TRANSIENT_NETWORK_ERROR_RE.test(message) ||
+    classifyModelError(error).retryable ||
     TRANSIENT_CODEX_STREAM_ERROR_RE.test(message)
   );
 }

--- a/container/src/types.ts
+++ b/container/src/types.ts
@@ -118,6 +118,15 @@ export interface TaskModelPolicy {
     | 'openrouter'
     | 'mistral'
     | 'huggingface'
+    | 'gemini'
+    | 'deepseek'
+    | 'xai'
+    | 'zai'
+    | 'kimi'
+    | 'minimax'
+    | 'dashscope'
+    | 'xiaomi'
+    | 'kilo'
     | 'ollama'
     | 'lmstudio'
     | 'llamacpp'
@@ -192,6 +201,38 @@ export interface WebSearchConfig {
   tavilySearchDepth: 'basic' | 'advanced';
 }
 
+export interface ModelFallbackTarget {
+  model: string;
+  provider?:
+    | 'hybridai'
+    | 'openai-codex'
+    | 'openrouter'
+    | 'mistral'
+    | 'huggingface'
+    | 'gemini'
+    | 'deepseek'
+    | 'xai'
+    | 'zai'
+    | 'kimi'
+    | 'minimax'
+    | 'dashscope'
+    | 'xiaomi'
+    | 'kilo'
+    | 'ollama'
+    | 'lmstudio'
+    | 'llamacpp'
+    | 'vllm';
+  apiKey: string;
+  baseUrl: string;
+  chatbotId: string;
+  enableRag: boolean;
+  requestHeaders?: Record<string, string>;
+  isLocal?: boolean;
+  contextWindow?: number;
+  thinkingFormat?: 'qwen';
+  maxTokens?: number;
+}
+
 export interface ContainerInput {
   sessionId: string;
   messages: ChatMessage[];
@@ -205,6 +246,15 @@ export interface ContainerInput {
     | 'openrouter'
     | 'mistral'
     | 'huggingface'
+    | 'gemini'
+    | 'deepseek'
+    | 'xai'
+    | 'zai'
+    | 'kimi'
+    | 'minimax'
+    | 'dashscope'
+    | 'xiaomi'
+    | 'kilo'
     | 'ollama'
     | 'lmstudio'
     | 'llamacpp'
@@ -216,6 +266,7 @@ export interface ContainerInput {
   gatewayBaseUrl?: string;
   gatewayApiToken?: string;
   model: string;
+  modelFallbacks?: ModelFallbackTarget[];
   ralphMaxIterations?: number | null;
   fullAutoEnabled?: boolean;
   fullAutoNeverApproveTools?: string[];

--- a/src/agents/agent-registry.ts
+++ b/src/agents/agent-registry.ts
@@ -355,6 +355,29 @@ export function resolveAgentModel(
   return normalizeString(agent.model.primary) || undefined;
 }
 
+export function resolveAgentModelFallbacks(
+  agent: AgentConfig | null | undefined,
+  activeModel?: string | null,
+): string[] {
+  if (!agent?.model || typeof agent.model === 'string') return [];
+  const modelConfig = agent.model as Exclude<
+    AgentModelConfig,
+    string | undefined
+  >;
+  const primary = normalizeString(modelConfig.primary);
+  if (!primary) return [];
+  const normalizedActiveModel = normalizeString(activeModel);
+  if (normalizedActiveModel && normalizedActiveModel !== primary) {
+    return [];
+  }
+  const fallbacks = Array.isArray(modelConfig.fallbacks)
+    ? modelConfig.fallbacks
+    : [];
+  return (normalizeOptionalTrimmedUniqueStringArray(fallbacks) || []).filter(
+    (candidate) => candidate !== primary,
+  );
+}
+
 export function resolveAgentWorkspaceId(agentId?: string | null): string {
   const agent = resolveAgentConfig(agentId);
   return normalizeString(agent.workspace) || agent.id;

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -6,6 +6,10 @@ import { type ChildProcess, spawn } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import type { ExecutorRequest } from '../agent/executor-types.js';
+import {
+  resolveAgentConfig,
+  resolveAgentModelFallbacks,
+} from '../agents/agent-registry.js';
 import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import { getBrowserProfileDir } from '../browser/browser-login.js';
 import {
@@ -93,6 +97,65 @@ function resolveExecutorMaxTokens(params: {
     model: params.model,
     discoveredMaxTokens: params.discoveredMaxTokens,
   });
+}
+
+async function resolveModelFallbackTargets(params: {
+  agentId: string;
+  model: string;
+  chatbotId: string;
+  enableRag: boolean;
+}): Promise<ContainerInput['modelFallbacks']> {
+  const fallbackModels = resolveAgentModelFallbacks(
+    resolveAgentConfig(params.agentId),
+    params.model,
+  );
+  if (fallbackModels.length === 0) return undefined;
+
+  const resolvedFallbacks: NonNullable<ContainerInput['modelFallbacks']> = [];
+  const seen = new Set<string>([String(params.model || '').trim()]);
+
+  for (const fallbackModel of fallbackModels) {
+    const normalizedModel = String(fallbackModel || '').trim();
+    if (!normalizedModel || seen.has(normalizedModel)) continue;
+    seen.add(normalizedModel);
+
+    try {
+      const runtime = await resolveModelRuntimeCredentials({
+        model: normalizedModel,
+        chatbotId: params.chatbotId,
+        enableRag: params.enableRag,
+        agentId: params.agentId,
+      });
+      resolvedFallbacks.push({
+        model: normalizedModel,
+        provider: runtime.provider,
+        apiKey: runtime.apiKey,
+        baseUrl: remapHostBaseUrlForContainer(runtime.baseUrl),
+        chatbotId: runtime.chatbotId,
+        enableRag: runtime.enableRag,
+        requestHeaders: runtime.requestHeaders,
+        isLocal: runtime.isLocal,
+        contextWindow: runtime.contextWindow,
+        thinkingFormat: runtime.thinkingFormat,
+        maxTokens: resolveExecutorMaxTokens({
+          model: normalizedModel,
+          discoveredMaxTokens: runtime.maxTokens,
+        }),
+      });
+    } catch (error) {
+      logger.warn(
+        {
+          agentId: params.agentId,
+          primaryModel: params.model,
+          fallbackModel: normalizedModel,
+          err: error,
+        },
+        'Failed to resolve runtime credentials for agent fallback model',
+      );
+    }
+  }
+
+  return resolvedFallbacks.length > 0 ? resolvedFallbacks : undefined;
 }
 
 interface PoolEntry {
@@ -783,6 +846,12 @@ async function runContainerInner(
     enableRag,
     agentId,
   });
+  const modelFallbacks = await resolveModelFallbackTargets({
+    agentId,
+    model,
+    chatbotId: modelRuntime.chatbotId,
+    enableRag: modelRuntime.enableRag,
+  });
   const taskModels = await resolveTaskModelPolicies({
     agentId,
     chatbotId: modelRuntime.chatbotId,
@@ -817,6 +886,7 @@ async function runContainerInner(
     gatewayBaseUrl: remapHostBaseUrlForContainer(GATEWAY_BASE_URL),
     gatewayApiToken: GATEWAY_API_TOKEN || undefined,
     model,
+    modelFallbacks,
     ralphMaxIterations,
     fullAutoEnabled,
     fullAutoNeverApproveTools,
@@ -871,6 +941,7 @@ async function runContainerInner(
     baseUrl: input.baseUrl,
     apiKey: input.apiKey,
     requestHeaders: input.requestHeaders,
+    modelFallbacks: input.modelFallbacks,
     taskModels: input.taskModels,
     workspacePathOverride: params.workspacePathOverride,
     workspaceDisplayRootOverride: params.workspaceDisplayRootOverride,

--- a/src/infra/worker-signature.ts
+++ b/src/infra/worker-signature.ts
@@ -14,12 +14,27 @@ interface WorkerSignatureTaskModel {
   error?: string;
 }
 
+interface WorkerSignatureModelFallback {
+  model: string;
+  provider?: string;
+  apiKey?: string;
+  baseUrl?: string;
+  chatbotId?: string;
+  enableRag?: boolean;
+  requestHeaders?: Record<string, string>;
+  isLocal?: boolean;
+  contextWindow?: number;
+  thinkingFormat?: string;
+  maxTokens?: number;
+}
+
 export interface WorkerSignatureInput {
   agentId: string;
   provider: string | undefined;
   baseUrl: string;
   apiKey: string;
   requestHeaders: Record<string, string> | undefined;
+  modelFallbacks?: WorkerSignatureModelFallback[];
   taskModels?: Partial<Record<TaskModelKey, WorkerSignatureTaskModel>>;
   workspacePathOverride?: string;
   workspaceDisplayRootOverride?: string;
@@ -66,8 +81,35 @@ function normalizeTaskModel(
   };
 }
 
+function normalizeModelFallback(
+  input: WorkerSignatureModelFallback,
+): Record<string, unknown> {
+  return {
+    provider: String(input.provider || '').trim(),
+    baseUrl: String(input.baseUrl || '')
+      .trim()
+      .replace(/\/+$/g, ''),
+    apiKey: String(input.apiKey || ''),
+    chatbotId: String(input.chatbotId || '').trim(),
+    enableRag: input.enableRag === true,
+    requestHeaders: normalizeHeaders(input.requestHeaders),
+    isLocal: input.isLocal === true,
+    contextWindow:
+      typeof input.contextWindow === 'number' ? input.contextWindow : null,
+    thinkingFormat: String(input.thinkingFormat || '').trim(),
+    model: String(input.model || '').trim(),
+    maxTokens:
+      typeof input.maxTokens === 'number' && Number.isFinite(input.maxTokens)
+        ? Math.floor(input.maxTokens)
+        : null,
+  };
+}
+
 export function computeWorkerSignature(input: WorkerSignatureInput): string {
   const normalizedHeaders = normalizeHeaders(input.requestHeaders);
+  const modelFallbacks = Array.isArray(input.modelFallbacks)
+    ? input.modelFallbacks.map((item) => normalizeModelFallback(item))
+    : [];
   const taskModels = Object.fromEntries(
     TASK_MODEL_KEYS.map((key) => [
       key,
@@ -83,6 +125,7 @@ export function computeWorkerSignature(input: WorkerSignatureInput): string {
       .replace(/\/+$/g, ''),
     apiKey: String(input.apiKey || ''),
     requestHeaders: normalizedHeaders,
+    modelFallbacks,
     taskModels,
     workspacePathOverride: String(input.workspacePathOverride || '').trim(),
     workspaceDisplayRootOverride: String(

--- a/src/types/container.ts
+++ b/src/types/container.ts
@@ -49,6 +49,20 @@ export interface WebSearchConfig {
   tavilySearchDepth: 'basic' | 'advanced';
 }
 
+export interface ModelFallbackTarget {
+  model: string;
+  provider?: ProviderKind;
+  apiKey: string;
+  baseUrl: string;
+  chatbotId: string;
+  enableRag: boolean;
+  requestHeaders?: Record<string, string>;
+  isLocal?: boolean;
+  contextWindow?: number;
+  thinkingFormat?: 'qwen';
+  maxTokens?: number;
+}
+
 export interface ContainerInput {
   sessionId: string;
   messages: ChatMessage[];
@@ -64,6 +78,7 @@ export interface ContainerInput {
   gatewayBaseUrl?: string;
   gatewayApiToken?: string;
   model: string;
+  modelFallbacks?: ModelFallbackTarget[];
   ralphMaxIterations?: number | null;
   fullAutoEnabled?: boolean;
   fullAutoNeverApproveTools?: string[];

--- a/tests/agent-model-fallbacks.test.ts
+++ b/tests/agent-model-fallbacks.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from 'vitest';
+import { resolveAgentModelFallbacks } from '../src/agents/agent-registry.ts';
+
+test('resolveAgentModelFallbacks returns normalized fallbacks for the active primary model', () => {
+  const agent = {
+    id: 'research',
+    model: {
+      primary: 'ollama/llama3.2',
+      fallbacks: [
+        ' gpt-5-mini ',
+        'openrouter/anthropic/claude-sonnet-4',
+        'gpt-5-mini',
+        'ollama/llama3.2',
+      ],
+    },
+  } as const;
+
+  expect(resolveAgentModelFallbacks(agent)).toEqual([
+    'gpt-5-mini',
+    'openrouter/anthropic/claude-sonnet-4',
+  ]);
+  expect(resolveAgentModelFallbacks(agent, 'ollama/llama3.2')).toEqual([
+    'gpt-5-mini',
+    'openrouter/anthropic/claude-sonnet-4',
+  ]);
+  expect(
+    resolveAgentModelFallbacks(agent, 'anthropic/claude-3-7-sonnet'),
+  ).toEqual([]);
+  expect(
+    resolveAgentModelFallbacks({
+      id: 'main',
+      model: 'gpt-5-mini',
+    }),
+  ).toEqual([]);
+});

--- a/tests/model-error-classification.test.ts
+++ b/tests/model-error-classification.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from 'vitest';
+import {
+  classifyModelError,
+  formatModelFailureSummary,
+  RoutedModelError,
+} from '../container/src/model-error-classification.js';
+import { shouldAutoRouteFromModelError } from '../container/src/model-retry.js';
+import { ProviderRequestError } from '../container/src/providers/shared.js';
+
+describe('classifyModelError', () => {
+  test('classifies nested DNS transport failures', () => {
+    const error = new Error('fetch failed', {
+      cause: Object.assign(new Error('getaddrinfo ENOTFOUND api.example.com'), {
+        code: 'ENOTFOUND',
+      }),
+    });
+
+    expect(classifyModelError(error)).toMatchObject({
+      kind: 'dns',
+      retryable: true,
+      autoRoute: true,
+      detail: 'getaddrinfo ENOTFOUND api.example.com',
+    });
+  });
+
+  test('classifies TLS transport failures', () => {
+    const error = new Error('fetch failed', {
+      cause: Object.assign(
+        new Error(
+          'certificate has expired or is not yet valid: CERT_HAS_EXPIRED',
+        ),
+        {
+          code: 'CERT_HAS_EXPIRED',
+        },
+      ),
+    });
+
+    expect(classifyModelError(error)).toMatchObject({
+      kind: 'tls',
+      retryable: true,
+      autoRoute: true,
+    });
+  });
+
+  test('distinguishes generic 5xx responses from provider outages', () => {
+    expect(
+      classifyModelError(
+        new ProviderRequestError(
+          500,
+          JSON.stringify({
+            error: { message: 'Internal server error', type: 'server_error' },
+          }),
+        ),
+      ),
+    ).toMatchObject({
+      kind: 'http_5xx',
+      status: 500,
+    });
+
+    expect(
+      classifyModelError(
+        new ProviderRequestError(
+          503,
+          JSON.stringify({
+            error: {
+              message: 'Service temporarily unavailable',
+              type: 'server_error',
+            },
+          }),
+        ),
+      ),
+    ).toMatchObject({
+      kind: 'provider_outage',
+      status: 503,
+    });
+  });
+});
+
+describe('shouldAutoRouteFromModelError', () => {
+  test('allows auto-routing for network and outage classes only', () => {
+    expect(
+      shouldAutoRouteFromModelError(
+        new Error('fetch failed', {
+          cause: Object.assign(
+            new Error('getaddrinfo ENOTFOUND api.example.com'),
+            {
+              code: 'ENOTFOUND',
+            },
+          ),
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldAutoRouteFromModelError(
+        new ProviderRequestError(503, '{"error":"temporarily unavailable"}'),
+      ),
+    ).toBe(true);
+    expect(
+      shouldAutoRouteFromModelError(
+        new ProviderRequestError(400, '{"error":"bad request"}'),
+      ),
+    ).toBe(false);
+    expect(
+      shouldAutoRouteFromModelError(
+        new ProviderRequestError(429, '{"error":"rate limited"}'),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('RoutedModelError', () => {
+  test('summarizes exhausted fallback routes with classified messages', () => {
+    const failures = [
+      {
+        target: {
+          provider: 'openrouter' as const,
+          model: 'openrouter/anthropic/claude-sonnet-4',
+          baseUrl: 'https://openrouter.ai/api/v1',
+        },
+        classification: classifyModelError(
+          new Error('fetch failed', {
+            cause: Object.assign(
+              new Error('getaddrinfo ENOTFOUND openrouter.ai'),
+              {
+                code: 'ENOTFOUND',
+              },
+            ),
+          }),
+        ),
+        error: new Error('fetch failed', {
+          cause: Object.assign(
+            new Error('getaddrinfo ENOTFOUND openrouter.ai'),
+            {
+              code: 'ENOTFOUND',
+            },
+          ),
+        }),
+      },
+      {
+        target: {
+          provider: 'openai-codex' as const,
+          model: 'openai-codex/gpt-5-codex',
+          baseUrl: 'https://api.openai.com/v1',
+        },
+        classification: classifyModelError(
+          new ProviderRequestError(
+            503,
+            '{"error":{"message":"Service temporarily unavailable"}}',
+          ),
+        ),
+        error: new ProviderRequestError(
+          503,
+          '{"error":{"message":"Service temporarily unavailable"}}',
+        ),
+      },
+    ];
+
+    const summary = formatModelFailureSummary(failures);
+    expect(summary).toContain('All configured model routes failed.');
+    expect(summary).toContain('DNS lookup failed');
+    expect(summary).toContain('provider outage detected');
+
+    const error = new RoutedModelError(failures);
+    expect(error.message).toBe(summary);
+  });
+});


### PR DESCRIPTION
## What changed

This teaches the container runtime to classify model transport and upstream failures into actionable categories instead of surfacing a generic fetch/network error.

- add a dedicated model error classifier for DNS, TLS, timeout/network, generic 5xx, and provider-outage failures
- use that classification in the retry and stream-downgrade path so we only retry or route when the failure class warrants it
- route eligible failures to configured agent fallback models by passing resolved fallback targets from the gateway into the container runtime
- preserve provider/model-specific failure summaries when every route is exhausted
- add focused tests for the classifier and agent fallback resolution helper

## Why this changed

The runtime previously relied on coarse regex checks around `fetch failed`-style errors. That made different failure modes look the same to users and prevented the system from making better routing decisions when a provider or network path was temporarily unhealthy.

## Impact

- DNS failures now surface as DNS lookup failures instead of generic fetch errors
- TLS failures now surface with certificate/scheme guidance instead of generic fetch errors
- upstream 5xx and provider-outage failures can auto-route to configured fallback models
- non-routeable failures such as auth, rate-limit, and bad-request errors still stop on the active route and surface directly

## Root cause

Fallback behavior and error reporting were driven by separate coarse heuristics in the container model retry path, and agent `model.fallbacks` were not being resolved into runtime targets for the container execution path.

## Validation

- `npm run format`
- `npm run typecheck`
- `vitest tests/hybridai-retry.test.ts tests/model-error-classification.test.ts tests/agent-model-fallbacks.test.ts`

## Notes

The focused fallback-helper test emits a startup warning from `runtime-config` because the shared `better-sqlite3` build in this environment targets a different Node ABI, but the test itself passes and the new helper coverage does not depend on SQLite.
