### PR TITLE
[codex] fix pdf layout and artifact path remapping

### DIFF
--- a/skills/pdf/SKILL.md
+++ b/skills/pdf/SKILL.md
@@ -113,6 +113,8 @@ node skills/pdf/scripts/create_pdf.mjs output.pdf --text "Line 1\nLine 2" --font
 For creation tasks ("make a PDF", "create a PDF with X"), always use this bundled
 script or the recipe from [reference.md](./reference.md). Never call `drawText()`
 without passing an embedded `font` — omitting it produces a blank/corrupt page.
+The bundled script wraps long lines, respects explicit `\n` line breaks, and
+adds pages automatically when content exceeds the first page.
 Use a workspace-relative `output.pdf` path for the final deliverable. Reserve
 `/tmp/...` paths for scratch files that do not need to persist after the run.
 

--- a/skills/pdf/scripts/create_pdf.mjs
+++ b/skills/pdf/scripts/create_pdf.mjs
@@ -67,6 +67,84 @@ function resolveStandardFont(name) {
   return fontMap[normalized] || StandardFonts.Helvetica;
 }
 
+function normalizeTextBreaks(value) {
+  return String(value || '')
+    .replace(/\\r\\n/g, '\n')
+    .replace(/\\n/g, '\n')
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n');
+}
+
+function computeLineHeight(font, fontSize, multiplier) {
+  return Math.max(
+    font.heightAtSize(fontSize, { descender: true }) * multiplier,
+    fontSize * multiplier,
+  );
+}
+
+function splitLongToken(token, font, fontSize, maxWidth) {
+  const pieces = [];
+  let current = '';
+
+  for (const character of Array.from(token)) {
+    const next = `${current}${character}`;
+    if (current && font.widthOfTextAtSize(next, fontSize) > maxWidth) {
+      pieces.push(current);
+      current = character;
+      continue;
+    }
+    current = next;
+  }
+
+  if (current) {
+    pieces.push(current);
+  }
+
+  return pieces;
+}
+
+// Wrap text ourselves so the vertical cursor tracks the actual rendered lines.
+function buildWrappedLines(text, font, fontSize, maxWidth) {
+  const wrappedLines = [];
+  const normalizedText = normalizeTextBreaks(text);
+
+  for (const rawLine of normalizedText.split('\n')) {
+    if (!rawLine.trim()) {
+      wrappedLines.push('');
+      continue;
+    }
+
+    const words = rawLine.trim().split(/\s+/).filter(Boolean);
+    let currentLine = '';
+
+    for (const word of words) {
+      const segments =
+        font.widthOfTextAtSize(word, fontSize) > maxWidth
+          ? splitLongToken(word, font, fontSize, maxWidth)
+          : [word];
+
+      for (const segment of segments) {
+        const candidate = currentLine ? `${currentLine} ${segment}` : segment;
+        if (font.widthOfTextAtSize(candidate, fontSize) <= maxWidth) {
+          currentLine = candidate;
+          continue;
+        }
+
+        if (currentLine) {
+          wrappedLines.push(currentLine);
+        }
+        currentLine = segment;
+      }
+    }
+
+    if (currentLine) {
+      wrappedLines.push(currentLine);
+    }
+  }
+
+  return wrappedLines;
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   if (!args.outputPath || (!args.text && !args.title)) {
@@ -80,41 +158,65 @@ async function main() {
   const pdfDoc = await PDFDocument.create();
   const font = await pdfDoc.embedFont(resolveStandardFont(args.fontName));
   const boldFont = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
-  const page = pdfDoc.addPage();
-  const { width, height } = page.getSize();
+  const firstPage = pdfDoc.addPage();
+  const { width, height } = firstPage.getSize();
   const margin = 50;
+  const maxWidth = width - margin * 2;
+  let page = firstPage;
   let y = height - margin;
+
+  const startNewPage = () => {
+    page = pdfDoc.addPage([width, height]);
+    y = height - margin;
+  };
+
+  const drawWrappedBlock = (lines, fontRef, fontSize, lineHeight) => {
+    let drewText = false;
+    for (const line of lines) {
+      if (y - fontSize < margin) {
+        startNewPage();
+      }
+
+      if (line) {
+        page.drawText(line, {
+          x: margin,
+          y: y - fontSize,
+          size: fontSize,
+          font: fontRef,
+          color: rgb(0, 0, 0),
+        });
+        drewText = true;
+      }
+
+      y -= lineHeight;
+    }
+
+    return drewText;
+  };
 
   if (args.title) {
     const titleSize = Math.min(args.fontSize * 1.5, 48);
-    page.drawText(args.title, {
-      x: margin,
-      y: y - titleSize,
-      size: titleSize,
-      font: boldFont,
-      color: rgb(0, 0, 0),
-      maxWidth: width - margin * 2,
-    });
-    y -= titleSize + 30;
+    const titleLineHeight = computeLineHeight(boldFont, titleSize, 1.15);
+    const titleLines = buildWrappedLines(
+      args.title,
+      boldFont,
+      titleSize,
+      maxWidth,
+    );
+    if (drawWrappedBlock(titleLines, boldFont, titleSize, titleLineHeight)) {
+      y -= Math.max(18, titleLineHeight * 0.45);
+    }
   }
 
   if (args.text) {
-    const lines = args.text.split('\\n');
-    const lineHeight = args.fontSize * 1.4;
-    for (const line of lines) {
-      if (y - args.fontSize < margin) {
-        break;
-      }
-      page.drawText(line, {
-        x: margin,
-        y: y - args.fontSize,
-        size: args.fontSize,
-        font,
-        color: rgb(0, 0, 0),
-        maxWidth: width - margin * 2,
-      });
-      y -= lineHeight;
-    }
+    const bodyLineHeight = computeLineHeight(font, args.fontSize, 1.35);
+    const bodyLines = buildWrappedLines(
+      args.text,
+      font,
+      args.fontSize,
+      maxWidth,
+    );
+    drawWrappedBlock(bodyLines, font, args.fontSize, bodyLineHeight);
   }
 
   fs.writeFileSync(args.outputPath, await pdfDoc.save());

--- a/skills/pdf/scripts/create_pdf.mjs
+++ b/skills/pdf/scripts/create_pdf.mjs
@@ -28,9 +28,14 @@ function parseArgs(argv) {
       continue;
     }
     if (value === '--font-size') {
-      const parsed = Number.parseInt(argv[index + 1] || '', 10);
+      const rawFontSize = argv[index + 1] || '';
+      const parsed = Number.parseInt(rawFontSize, 10);
       if (Number.isFinite(parsed) && parsed > 0) {
         args.fontSize = parsed;
+      } else {
+        console.warn(
+          `Ignoring invalid --font-size "${rawFontSize}" and keeping ${args.fontSize}.`,
+        );
       }
       index += 1;
       continue;
@@ -64,12 +69,16 @@ function resolveStandardFont(name) {
     timesitalic: StandardFonts.TimesRomanItalic,
     timesbolditalic: StandardFonts.TimesRomanBoldItalic,
   };
-  return fontMap[normalized] || StandardFonts.Helvetica;
+  const resolvedFont = fontMap[normalized];
+  if (resolvedFont) {
+    return resolvedFont;
+  }
+  console.warn(`Unknown --font "${name}". Falling back to Helvetica.`);
+  return StandardFonts.Helvetica;
 }
 
 function normalizeTextBreaks(value) {
   return String(value || '')
-    .replace(/\\r\\n/g, '\n')
     .replace(/\\n/g, '\n')
     .replace(/\r\n/g, '\n')
     .replace(/\r/g, '\n');
@@ -86,7 +95,7 @@ function splitLongToken(token, font, fontSize, maxWidth) {
   const pieces = [];
   let current = '';
 
-  for (const character of Array.from(token)) {
+  for (const character of token) {
     const next = `${current}${character}`;
     if (current && font.widthOfTextAtSize(next, fontSize) > maxWidth) {
       pieces.push(current);
@@ -114,7 +123,7 @@ function buildWrappedLines(text, font, fontSize, maxWidth) {
       continue;
     }
 
-    const words = rawLine.trim().split(/\s+/).filter(Boolean);
+    const words = rawLine.trim().split(/\s+/);
     let currentLine = '';
 
     for (const word of words) {
@@ -123,8 +132,13 @@ function buildWrappedLines(text, font, fontSize, maxWidth) {
           ? splitLongToken(word, font, fontSize, maxWidth)
           : [word];
 
-      for (const segment of segments) {
-        const candidate = currentLine ? `${currentLine} ${segment}` : segment;
+      for (const [segmentIndex, segment] of segments.entries()) {
+        const joinsExistingWord = segmentIndex > 0;
+        const candidate = currentLine
+          ? joinsExistingWord
+            ? `${currentLine}${segment}`
+            : `${currentLine} ${segment}`
+          : segment;
         if (font.widthOfTextAtSize(candidate, fontSize) <= maxWidth) {
           currentLine = candidate;
           continue;
@@ -165,6 +179,7 @@ async function main() {
   let page = firstPage;
   let y = height - margin;
 
+  // These helpers mutate the current page/cursor state in outer scope.
   const startNewPage = () => {
     page = pdfDoc.addPage([width, height]);
     y = height - margin;

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -374,14 +374,16 @@ function resolveArtifactHostPath(
 
   if (path.posix.isAbsolute(normalized)) {
     const cleanAbs = path.posix.normalize(normalized);
-    const allowedRoots = new Set([CONTAINER_WORKSPACE_ROOT, displayRoot]);
-    let matchedRoot: string | null = null;
-    for (const root of allowedRoots) {
-      if (cleanAbs === root || cleanAbs.startsWith(`${root}/`)) {
-        matchedRoot = root;
-        break;
-      }
-    }
+    const allowedRoots =
+      displayRoot === CONTAINER_WORKSPACE_ROOT
+        ? [CONTAINER_WORKSPACE_ROOT]
+        : [CONTAINER_WORKSPACE_ROOT, displayRoot].sort(
+            (left, right) => right.length - left.length,
+          );
+    const matchedRoot =
+      allowedRoots.find(
+        (root) => cleanAbs === root || cleanAbs.startsWith(`${root}/`),
+      ) ?? null;
     if (!matchedRoot) {
       return null;
     }

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -362,23 +362,30 @@ function isTimedOutAgentOutput(output: ContainerOutput): boolean {
 function resolveArtifactHostPath(
   rawPath: string,
   workspacePath: string,
+  workspaceDisplayRoot = CONTAINER_WORKSPACE_ROOT,
 ): string | null {
   const input = String(rawPath || '').trim();
   if (!input) return null;
   const normalized = input.replace(/\\/g, '/');
   const workspaceRoot = path.resolve(workspacePath);
+  const displayRoot = path.posix.normalize(
+    String(workspaceDisplayRoot || '').trim() || CONTAINER_WORKSPACE_ROOT,
+  );
 
   if (path.posix.isAbsolute(normalized)) {
     const cleanAbs = path.posix.normalize(normalized);
-    if (
-      cleanAbs !== CONTAINER_WORKSPACE_ROOT &&
-      !cleanAbs.startsWith(`${CONTAINER_WORKSPACE_ROOT}/`)
-    ) {
+    const allowedRoots = new Set([CONTAINER_WORKSPACE_ROOT, displayRoot]);
+    let matchedRoot: string | null = null;
+    for (const root of allowedRoots) {
+      if (cleanAbs === root || cleanAbs.startsWith(`${root}/`)) {
+        matchedRoot = root;
+        break;
+      }
+    }
+    if (!matchedRoot) {
       return null;
     }
-    const rel = cleanAbs
-      .slice(CONTAINER_WORKSPACE_ROOT.length)
-      .replace(/^\/+/, '');
+    const rel = cleanAbs.slice(matchedRoot.length).replace(/^\/+/, '');
     const resolved = path.resolve(workspaceRoot, rel);
     if (
       resolved === workspaceRoot ||
@@ -404,6 +411,7 @@ function resolveArtifactHostPath(
 export function remapOutputArtifacts(
   output: ContainerOutput,
   workspacePath: string,
+  workspaceDisplayRoot?: string,
 ): void {
   if (!Array.isArray(output.artifacts) || output.artifacts.length === 0) return;
   const mapped: ArtifactMetadata[] = [];
@@ -412,6 +420,7 @@ export function remapOutputArtifacts(
     const hostPath = resolveArtifactHostPath(
       String(raw.path || ''),
       workspacePath,
+      workspaceDisplayRoot,
     );
     if (!hostPath) continue;
     const filename =
@@ -946,7 +955,11 @@ async function runContainerInner(
       );
       stopSessionContainer(sessionId);
     }
-    remapOutputArtifacts(output, workspacePath);
+    remapOutputArtifacts(
+      output,
+      workspacePath,
+      params.workspaceDisplayRootOverride,
+    );
     if (typeof output.result === 'string')
       output.result = redactSecrets(output.result);
     if (typeof output.error === 'string')

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -851,7 +851,11 @@ async function runHostProcessInner(
       );
       stopSessionHostProcess(sessionId);
     }
-    remapOutputArtifacts(output, workspacePath);
+    remapOutputArtifacts(
+      output,
+      workspacePath,
+      params.workspaceDisplayRootOverride,
+    );
     if (typeof output.result === 'string')
       output.result = redactSecrets(output.result);
     if (typeof output.error === 'string')

--- a/tests/container-runner.artifacts.test.ts
+++ b/tests/container-runner.artifacts.test.ts
@@ -38,3 +38,35 @@ test('remaps artifact paths that use a custom workspace display root', () => {
     fs.rmSync(workspacePath, { recursive: true, force: true });
   }
 });
+
+test('prefers the longest matching workspace display root when remapping', () => {
+  const workspacePath = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-artifact-remap-'),
+  );
+  try {
+    const output: ContainerOutput = {
+      status: 'success',
+      result: 'ok',
+      toolsUsed: [],
+      artifacts: [
+        {
+          path: '/workspace/sub/output.pdf',
+          filename: 'output.pdf',
+          mimeType: 'application/pdf',
+        },
+      ],
+    };
+
+    remapOutputArtifacts(output, workspacePath, '/workspace/sub');
+
+    expect(output.artifacts).toEqual([
+      {
+        path: path.join(workspacePath, 'output.pdf'),
+        filename: 'output.pdf',
+        mimeType: 'application/pdf',
+      },
+    ]);
+  } finally {
+    fs.rmSync(workspacePath, { recursive: true, force: true });
+  }
+});

--- a/tests/container-runner.artifacts.test.ts
+++ b/tests/container-runner.artifacts.test.ts
@@ -1,0 +1,40 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import { remapOutputArtifacts } from '../src/infra/container-runner.js';
+import type { ContainerOutput } from '../src/types/container.js';
+
+test('remaps artifact paths that use a custom workspace display root', () => {
+  const workspacePath = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-artifact-remap-'),
+  );
+  try {
+    const output: ContainerOutput = {
+      status: 'success',
+      result: 'ok',
+      toolsUsed: [],
+      artifacts: [
+        {
+          path: '/app/output.pdf',
+          filename: 'output.pdf',
+          mimeType: 'application/pdf',
+        },
+      ],
+    };
+
+    remapOutputArtifacts(output, workspacePath, '/app');
+
+    expect(output.artifacts).toEqual([
+      {
+        path: path.join(workspacePath, 'output.pdf'),
+        filename: 'output.pdf',
+        mimeType: 'application/pdf',
+      },
+    ]);
+  } finally {
+    fs.rmSync(workspacePath, { recursive: true, force: true });
+  }
+});

--- a/tests/pdf-skill-node.test.ts
+++ b/tests/pdf-skill-node.test.ts
@@ -91,6 +91,22 @@ async function readPageTextItems(outputPath, pageNumber = 1) {
     .filter(Boolean);
 }
 
+function groupItemsByLine(items, tolerance = 0.75) {
+  const positioned = [...items].sort((left, right) => right.y - left.y);
+  const lines = [];
+
+  for (const item of positioned) {
+    const previous = lines.at(-1);
+    if (!previous || Math.abs(previous.y - item.y) > tolerance) {
+      lines.push({ y: item.y, items: [item] });
+      continue;
+    }
+    previous.items.push(item);
+  }
+
+  return lines;
+}
+
 afterEach(() => {
   while (tempDirs.length > 0) {
     fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
@@ -136,10 +152,31 @@ describe('PDF skill Node scripts', () => {
     ]);
 
     const items = await readPageTextItems(outputPdf);
-    expect(items.length).toBeGreaterThan(8);
-    for (let index = 1; index < items.length; index += 1) {
-      expect(items[index].y).toBeLessThan(items[index - 1].y);
+    const lines = groupItemsByLine(items);
+    expect(lines.length).toBeGreaterThan(8);
+    for (let index = 1; index < lines.length; index += 1) {
+      expect(lines[index].y).toBeLessThan(lines[index - 1].y);
     }
+  });
+
+  test('wraps overlong single tokens without inserting spaces between segments', async () => {
+    const dir = makeTempDir();
+    const outputPdf = path.join(dir, 'long-token.pdf');
+    const longToken = 'a'.repeat(160);
+
+    runNodeScript([
+      'skills/pdf/scripts/create_pdf.mjs',
+      outputPdf,
+      '--font-size',
+      '24',
+      '--text',
+      longToken,
+    ]);
+
+    const items = await readPageTextItems(outputPdf);
+    const combinedText = items.map((item) => item.text).join('');
+    expect(combinedText).toContain(longToken);
+    expect(combinedText).not.toContain(' ');
   });
 
   test('adds new pages when wrapped body text exceeds the first page', async () => {

--- a/tests/pdf-skill-node.test.ts
+++ b/tests/pdf-skill-node.test.ts
@@ -6,6 +6,8 @@ import path from 'node:path';
 import { PDFDocument } from 'pdf-lib';
 import { afterEach, describe, expect, test } from 'vitest';
 
+import { openPdfDocument } from '../skills/pdf/scripts/_pdf_runtime.mjs';
+
 const repoRoot = process.cwd();
 const tempDirs = [];
 
@@ -70,6 +72,25 @@ async function createPlainPdf(outputPath) {
   fs.writeFileSync(outputPath, await pdfDoc.save());
 }
 
+async function readPageTextItems(outputPath, pageNumber = 1) {
+  const pdf = await openPdfDocument(outputPath);
+  const page = await pdf.getPage(pageNumber);
+  const textContent = await page.getTextContent();
+
+  return textContent.items
+    .map((item) => {
+      if (!('str' in item)) return null;
+      const text = String(item.str || '').trim();
+      if (!text) return null;
+      const transform = Array.isArray(item.transform) ? item.transform : [];
+      return {
+        text,
+        y: Number(transform[5] || 0),
+      };
+    })
+    .filter(Boolean);
+}
+
 afterEach(() => {
   while (tempDirs.length > 0) {
     fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
@@ -93,6 +114,57 @@ describe('PDF skill docs', () => {
 });
 
 describe('PDF skill Node scripts', () => {
+  test('wraps escaped newline paragraphs without overlapping later baselines', async () => {
+    const dir = makeTempDir();
+    const outputPdf = path.join(dir, 'wrapped.pdf');
+
+    runNodeScript([
+      'skills/pdf/scripts/create_pdf.mjs',
+      outputPdf,
+      '--title',
+      'Lorem Ipsum',
+      '--font-size',
+      '24',
+      '--text',
+      [
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+        'Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+        'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+        'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
+        'Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+      ].join('\\n'),
+    ]);
+
+    const items = await readPageTextItems(outputPdf);
+    expect(items.length).toBeGreaterThan(8);
+    for (let index = 1; index < items.length; index += 1) {
+      expect(items[index].y).toBeLessThan(items[index - 1].y);
+    }
+  });
+
+  test('adds new pages when wrapped body text exceeds the first page', async () => {
+    const dir = makeTempDir();
+    const outputPdf = path.join(dir, 'multi-page.pdf');
+
+    runNodeScript([
+      'skills/pdf/scripts/create_pdf.mjs',
+      outputPdf,
+      '--title',
+      'Long Document',
+      '--font-size',
+      '24',
+      '--text',
+      new Array(80)
+        .fill(
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+        )
+        .join('\\n'),
+    ]);
+
+    const generated = await PDFDocument.load(fs.readFileSync(outputPdf));
+    expect(generated.getPageCount()).toBeGreaterThan(1);
+  });
+
   test('supports the fillable-form workflow end to end', async () => {
     const dir = makeTempDir();
     const inputPdf = path.join(dir, 'fillable.pdf');


### PR DESCRIPTION
## What changed
- rewrote `skills/pdf/scripts/create_pdf.mjs` to wrap text explicitly with font metrics instead of relying on `drawText(..., maxWidth)` while advancing the cursor by one logical line
- normalized both literal `\n` sequences and actual newlines before layout
- added automatic page creation when wrapped body text exceeds the current page
- added regression tests for newline-heavy wrapped paragraphs and multi-page overflow
- documented the new wrapping and page-break behavior in the PDF skill docs
- updated artifact remapping in the host and container runners to respect custom workspace display roots such as `/app`, not just `/workspace`
- added a regression test for artifact remapping when the runtime reports `/app/output.pdf`

## Why
There were two related user-facing failures:

1. The `/pdf` skill could produce overlapping lines because `pdf-lib` was wrapping long text internally, but the script only moved the vertical cursor once per input line. That let later `drawText()` calls start inside already-rendered wrapped text.
2. Cloud-sandbox artifact downloads could fail even when the file existed in the workspace, because artifact remapping only recognized absolute workspace paths under `/workspace`. In environments that reported artifact paths under `/app`, the host-side remap could not resolve the file back to the real workspace path.

## Impact
- PDFs created through `/pdf` now preserve line breaks, use consistent line height, and continue onto new pages instead of overlapping or truncating long body text.
- Workspace artifacts reported from custom display roots can now be remapped back to the correct host path, which fixes download/attachment handling for those environments.

## Validation
- `./node_modules/.bin/vitest run tests/pdf-skill-node.test.ts tests/pdf-context.test.ts`
- `./node_modules/.bin/vitest run tests/container-runner.artifacts.test.ts`
- `npm run typecheck`
- `npx biome check skills/pdf/scripts/create_pdf.mjs tests/pdf-skill-node.test.ts skills/pdf/SKILL.md`
