### PR TITLE
[codex] handle transient transport errors locally

### DIFF
--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -17,6 +17,7 @@ import { waitForInput, writeOutput } from './ipc.js';
 import { McpClientManager } from './mcp/client-manager.js';
 import { McpConfigWatcher } from './mcp/config-watcher.js';
 import {
+  formatModelErrorForLog,
   isRetryableModelError,
   shouldDowngradeStreamToNonStreaming,
 } from './model-retry.js';
@@ -809,6 +810,7 @@ async function callHybridAIWithRetry(params: {
       });
       return response;
     } catch (err) {
+      const formattedError = formatModelErrorForLog(err, baseUrl);
       const retryable =
         RETRY_ENABLED &&
         isRetryableModelError(err) &&
@@ -817,10 +819,10 @@ async function callHybridAIWithRetry(params: {
         event: retryable ? 'model_retry' : 'model_error',
         attempt,
         retryable,
-        error: err instanceof Error ? err.message : String(err),
+        error: formattedError,
       });
       console.error(
-        `[model] call ${retryable ? 'retry' : 'error'} provider=${provider || 'hybridai'} model=${model} attempt=${attempt} durationMs=${Date.now() - attemptStartedAt} retryable=${retryable} error=${err instanceof Error ? err.message : String(err)}`,
+        `[model] call ${retryable ? 'retry' : 'error'} provider=${provider || 'hybridai'} model=${model} attempt=${attempt} durationMs=${Date.now() - attemptStartedAt} retryable=${retryable} error=${formattedError}`,
       );
       if (!retryable) throw err;
       await sleep(delayMs);

--- a/container/src/model-retry.ts
+++ b/container/src/model-retry.ts
@@ -42,11 +42,11 @@ function getOwnErrorDetails(error: unknown): ErrorDetails {
 
   const candidate = error as ErrorLike;
   return {
-    code: typeof candidate.code === 'string' ? candidate.code.toUpperCase() : '',
+    code:
+      typeof candidate.code === 'string' ? candidate.code.toUpperCase() : '',
     host:
       typeof candidate.hostname === 'string' ? candidate.hostname.trim() : '',
-    message:
-      typeof candidate.message === 'string' ? candidate.message : '',
+    message: typeof candidate.message === 'string' ? candidate.message : '',
   };
 }
 
@@ -111,9 +111,7 @@ export function formatModelErrorForLog(
 
   switch (code) {
     case 'ENOTFOUND':
-      return host
-        ? `DNS lookup failed for ${host}`
-        : 'DNS lookup failed';
+      return host ? `DNS lookup failed for ${host}` : 'DNS lookup failed';
     case 'EAI_AGAIN':
       return host
         ? `DNS lookup for ${host} is temporarily unavailable`

--- a/container/src/model-retry.ts
+++ b/container/src/model-retry.ts
@@ -8,6 +8,142 @@ const TRANSIENT_NETWORK_ERROR_RE =
   /fetch failed|network|socket|timeout|timed out|ECONNRESET|ECONNREFUSED|EAI_AGAIN|terminated/i;
 const TRANSIENT_CODEX_STREAM_ERROR_RE =
   /an error occurred while processing your request|request id [0-9a-f-]{8}-[0-9a-f-]{27}|streaming response ended without payload|stream ended without payload|response\.incomplete|response\.failed/i;
+const MAX_ERROR_DETAIL_DEPTH = 3;
+
+interface ErrorLike {
+  cause?: unknown;
+  code?: unknown;
+  errors?: unknown;
+  hostname?: unknown;
+  message?: unknown;
+}
+
+interface ErrorDetails {
+  code: string;
+  host: string;
+  message: string;
+}
+
+function getOwnErrorDetails(error: unknown): ErrorDetails {
+  if (typeof error === 'string') {
+    return {
+      code: '',
+      host: '',
+      message: error,
+    };
+  }
+  if (!error || typeof error !== 'object') {
+    return {
+      code: '',
+      host: '',
+      message: '',
+    };
+  }
+
+  const candidate = error as ErrorLike;
+  return {
+    code: typeof candidate.code === 'string' ? candidate.code.toUpperCase() : '',
+    host:
+      typeof candidate.hostname === 'string' ? candidate.hostname.trim() : '',
+    message:
+      typeof candidate.message === 'string' ? candidate.message : '',
+  };
+}
+
+function findErrorDetails(error: unknown, depth = 0): ErrorDetails {
+  if (depth > MAX_ERROR_DETAIL_DEPTH || error == null) {
+    return {
+      code: '',
+      host: '',
+      message: '',
+    };
+  }
+
+  const details = getOwnErrorDetails(error);
+  if (details.code || details.host) {
+    return details;
+  }
+
+  if (error && typeof error === 'object') {
+    const candidate = error as ErrorLike;
+    if (Array.isArray(candidate.errors)) {
+      for (const nested of candidate.errors) {
+        const nestedDetails = findErrorDetails(nested, depth + 1);
+        if (nestedDetails.code || nestedDetails.host || nestedDetails.message) {
+          return nestedDetails;
+        }
+      }
+    }
+
+    const causeDetails = findErrorDetails(candidate.cause, depth + 1);
+    if (causeDetails.code || causeDetails.host || causeDetails.message) {
+      return causeDetails;
+    }
+  }
+
+  return details;
+}
+
+function resolveHost(baseUrl?: string): string {
+  try {
+    return baseUrl ? new URL(baseUrl).hostname || '' : '';
+  } catch {
+    return '';
+  }
+}
+
+function formatConnectionTarget(host: string): string {
+  return host ? `connection to ${host}` : 'connection';
+}
+
+export function formatModelErrorForLog(
+  error: unknown,
+  baseUrl?: string,
+): string {
+  if (error instanceof ProviderRequestError) {
+    return error.message;
+  }
+
+  const details = findErrorDetails(error);
+  const code = details.code;
+  const host = details.host || resolveHost(baseUrl);
+  const message = details.message || String(error);
+
+  switch (code) {
+    case 'ENOTFOUND':
+      return host
+        ? `DNS lookup failed for ${host}`
+        : 'DNS lookup failed';
+    case 'EAI_AGAIN':
+      return host
+        ? `DNS lookup for ${host} is temporarily unavailable`
+        : 'DNS lookup is temporarily unavailable';
+    case 'ETIMEDOUT':
+    case 'ESOCKETTIMEDOUT':
+    case 'UND_ERR_CONNECT_TIMEOUT':
+    case 'UND_ERR_HEADERS_TIMEOUT':
+    case 'UND_ERR_BODY_TIMEOUT':
+      return `${formatConnectionTarget(host)} timed out`;
+    case 'ECONNREFUSED':
+      return `${formatConnectionTarget(host)} was refused`;
+    case 'ECONNRESET':
+      return `${formatConnectionTarget(host)} was reset`;
+    case 'EHOSTUNREACH':
+    case 'ENETUNREACH':
+      return host ? `Host ${host} is unreachable` : 'Network is unreachable';
+    case 'ERR_SOCKET_CLOSED':
+    case 'UND_ERR_SOCKET':
+    case 'EPIPE':
+      return 'Socket closed unexpectedly';
+    default:
+      if (TRANSIENT_NETWORK_ERROR_RE.test(message)) {
+        return host
+          ? `Model API at ${host} is temporarily unavailable`
+          : 'Model API is temporarily unavailable';
+      }
+      return message;
+  }
+}
 
 export function shouldFallbackFromStreamError(error: unknown): boolean {
   if (error instanceof ProviderRequestError) {

--- a/src/audit/observability-ingest.ts
+++ b/src/audit/observability-ingest.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto';
 import os from 'node:os';
-
+import { SlidingWindowRateLimiter } from '../channels/discord/rate-limiter.js';
 import {
   APP_VERSION,
   HYBRIDAI_API_KEY,
@@ -26,11 +26,17 @@ import {
   setObservabilityOffset,
 } from '../memory/db.js';
 import type { StructuredAuditEntry } from '../types/audit.js';
+import {
+  describeExpectedTransportError,
+  isExpectedTransportError,
+} from '../utils/transport-errors.js';
 
 const PLATFORM_MAX_EVENTS = 1_000;
 const PLATFORM_MAX_PAYLOAD_BYTES = 2_000_000;
 const FETCH_LIMIT_FACTOR = 4;
 const TOKEN_ADMIN_PATH = '/api/v1/agent-observability/ingest-token:ensure';
+const OBSERVABILITY_TRANSIENT_WARN_WINDOW_MS = 60_000;
+const OBSERVABILITY_TRANSIENT_WARN_LIMIT = 1;
 
 interface ResolvedIngestConfig {
   enabled: boolean;
@@ -123,6 +129,9 @@ const ingestState: ObservabilityIngestState = {
 let timer: ReturnType<typeof setInterval> | null = null;
 let flushInProgress = false;
 let flushGeneration = 0;
+const transientObservabilityWarnLimiter = new SlidingWindowRateLimiter(
+  OBSERVABILITY_TRANSIENT_WARN_WINDOW_MS,
+);
 
 function clampInteger(value: number, min: number, max: number): number {
   if (!Number.isFinite(value)) return min;
@@ -700,6 +709,14 @@ async function postBatch(
   };
 }
 
+function resolveObservabilityHost(ingestUrl: string): string {
+  try {
+    return new URL(ingestUrl).hostname || '';
+  } catch {
+    return '';
+  }
+}
+
 function isPauseStatus(statusCode: number): boolean {
   return (
     statusCode === 400 ||
@@ -749,6 +766,7 @@ async function flushObservability(reason: string): Promise<void> {
     let activeToken = initialToken.token;
 
     const streamKey = buildStreamKey(config);
+    const observabilityHost = resolveObservabilityHost(config.ingestUrl);
     ingestState.streamKey = streamKey;
     let cursor = getObservabilityOffset(streamKey);
     ingestState.lastCursor = cursor;
@@ -816,17 +834,40 @@ async function flushObservability(reason: string): Promise<void> {
       if (!result.ok) {
         ingestState.lastFailureAt = new Date().toISOString();
         ingestState.lastError = result.errorText;
-        logger.warn(
-          {
-            reason,
-            streamKey,
-            statusCode: result.statusCode || undefined,
-            error: result.errorText,
-            cursor,
-            batchEvents: batch.eventCount,
-          },
-          'Observability ingest push failed',
-        );
+        if (
+          result.statusCode === 0 &&
+          isExpectedTransportError(result.errorText)
+        ) {
+          const transientMessage = `${describeExpectedTransportError(result.errorText, 'Observability ingest', observabilityHost)} Events will be retried automatically.`;
+          if (
+            transientObservabilityWarnLimiter.check(
+              `${streamKey}:${transientMessage}`,
+              OBSERVABILITY_TRANSIENT_WARN_LIMIT,
+            ).allowed
+          ) {
+            logger.warn(
+              {
+                reason,
+                streamKey,
+                cursor,
+                batchEvents: batch.eventCount,
+              },
+              transientMessage,
+            );
+          }
+        } else {
+          logger.warn(
+            {
+              reason,
+              streamKey,
+              statusCode: result.statusCode || undefined,
+              error: result.errorText,
+              cursor,
+              batchEvents: batch.eventCount,
+            },
+            'Observability ingest push failed',
+          );
+        }
         if (isPauseStatus(result.statusCode)) {
           ingestState.paused = true;
           ingestState.reason = `paused after status ${result.statusCode}`;

--- a/src/channels/discord/reactions.ts
+++ b/src/channels/discord/reactions.ts
@@ -2,6 +2,7 @@ import type { Message as DiscordMessage } from 'discord.js';
 
 import { logger } from '../../logger.js';
 import { sleep } from '../../utils/sleep.js';
+import { logDiscordApiError } from './transport-errors.js';
 
 export type LifecyclePhase =
   | 'queued'
@@ -172,15 +173,17 @@ export class LifecycleReactionController {
       );
       this.lastReactionAt = Date.now();
     } catch (error) {
-      logger.debug(
-        {
-          error,
+      logDiscordApiError({
+        error,
+        expectedAction: 'Lifecycle reaction was not added.',
+        unexpectedMessage: 'Failed to add lifecycle reaction',
+        metadata: {
           channelId: this.message.channelId,
           messageId: this.message.id,
           emoji,
         },
-        'Failed to add lifecycle reaction',
-      );
+        level: 'debug',
+      });
     }
   }
 
@@ -194,15 +197,17 @@ export class LifecycleReactionController {
       );
       this.lastReactionAt = Date.now();
     } catch (error) {
-      logger.debug(
-        {
-          error,
+      logDiscordApiError({
+        error,
+        expectedAction: 'Lifecycle reaction was not removed.',
+        unexpectedMessage: 'Failed to remove lifecycle reaction',
+        metadata: {
           channelId: this.message.channelId,
           messageId: this.message.id,
           emoji,
         },
-        'Failed to remove lifecycle reaction',
-      );
+        level: 'debug',
+      });
     }
   }
 }

--- a/src/channels/discord/runtime.ts
+++ b/src/channels/discord/runtime.ts
@@ -133,7 +133,10 @@ import {
   createDiscordToolActionRunner,
   type DiscordToolActionRequest,
 } from './tool-actions.js';
-import { attachDiscordTransportErrorHandlers } from './transport-errors.js';
+import {
+  attachDiscordTransportErrorHandlers,
+  logDiscordApiError,
+} from './transport-errors.js';
 import { createTypingController } from './typing.js';
 
 export type ReplyFn = (
@@ -1077,7 +1080,11 @@ async function ensureSlashCommands(): Promise<void> {
       'Successfully registered slash commands',
     );
   } catch (error) {
-    logger.warn({ error }, 'Failed to register global slash commands');
+    logDiscordApiError({
+      error,
+      expectedAction: 'Global slash commands were not registered.',
+      unexpectedMessage: 'Failed to register global slash commands',
+    });
   }
 
   await Promise.allSettled(
@@ -1101,10 +1108,12 @@ async function ensureSlashCommands(): Promise<void> {
           'Successfully cleaned up guild slash commands',
         );
       } catch (error) {
-        logger.warn(
-          { error, guildId: guild.id },
-          'Failed to clean up Discord guild slash commands',
-        );
+        logDiscordApiError({
+          error,
+          expectedAction: 'Guild slash commands were not cleaned up.',
+          unexpectedMessage: 'Failed to clean up Discord guild slash commands',
+          metadata: { guildId: guild.id },
+        });
       }
     }),
   );

--- a/src/channels/discord/runtime.ts
+++ b/src/channels/discord/runtime.ts
@@ -133,6 +133,7 @@ import {
   createDiscordToolActionRunner,
   type DiscordToolActionRequest,
 } from './tool-actions.js';
+import { attachDiscordTransportErrorHandlers } from './transport-errors.js';
 import { createTypingController } from './typing.js';
 
 export type ReplyFn = (
@@ -1539,6 +1540,7 @@ export async function initDiscord(
       Partials.User,
     ],
   });
+  attachDiscordTransportErrorHandlers(client);
 
   client.on('presenceUpdate', (_oldPresence, nextPresence) => {
     const userId = nextPresence.userId || nextPresence.user?.id;
@@ -1552,13 +1554,6 @@ export async function initDiscord(
         details: activity.details || null,
       })),
     });
-  });
-
-  client.on('error', (error) => {
-    logger.error(
-      { error },
-      'Discord client error (will reconnect automatically)',
-    );
   });
 
   client.on('clientReady', () => {

--- a/src/channels/discord/stream.ts
+++ b/src/channels/discord/stream.ts
@@ -8,6 +8,7 @@ import { chunkMessage } from '../../memory/chunk.js';
 import { sleep } from '../../utils/sleep.js';
 import { getHumanDelayMs, type HumanDelayConfig } from './human-delay.js';
 import { withDiscordRetry } from './retry.js';
+import { logDiscordApiError } from './transport-errors.js';
 
 interface DiscordSendChannel {
   send: (payload: {
@@ -138,7 +139,11 @@ export class DiscordStreamManager {
 
   private enqueue(task: () => Promise<void>): Promise<void> {
     this.opQueue = this.opQueue.then(task).catch((error) => {
-      logger.warn({ error }, 'Discord stream operation failed');
+      logDiscordApiError({
+        error,
+        expectedAction: 'Response message was not delivered.',
+        unexpectedMessage: 'Discord stream operation failed',
+      });
     });
     return this.opQueue;
   }

--- a/src/channels/discord/transport-errors.ts
+++ b/src/channels/discord/transport-errors.ts
@@ -2,21 +2,42 @@ import type { Client } from 'discord.js';
 
 import { logger } from '../../logger.js';
 import { isExpectedTransportError } from '../../utils/transport-errors.js';
+import { SlidingWindowRateLimiter } from './rate-limiter.js';
 
-function logDiscordTransportError(
+const EXPECTED_TRANSPORT_WARN_WINDOW_MS = 60_000;
+const EXPECTED_TRANSPORT_WARN_LIMIT = 5;
+
+function createDiscordTransportErrorLogger(): (
   error: unknown,
   message: string,
   metadata?: Record<string, unknown>,
-): void {
-  const bindings = metadata ? { ...metadata, error } : { error };
-  if (isExpectedTransportError(error)) {
-    logger.warn(bindings, message);
-    return;
-  }
-  logger.error(bindings, message);
+) => void {
+  const expectedTransportWarnLimiter = new SlidingWindowRateLimiter(
+    EXPECTED_TRANSPORT_WARN_WINDOW_MS,
+  );
+
+  return (error, message, metadata) => {
+    const bindings = metadata ? { ...metadata, err: error } : { err: error };
+    if (isExpectedTransportError(error)) {
+      // Rate-limit by error path, not shard id, so reconnect storms across
+      // shards still collapse to a few warnings per minute.
+      if (
+        expectedTransportWarnLimiter.check(
+          message,
+          EXPECTED_TRANSPORT_WARN_LIMIT,
+        ).allowed
+      ) {
+        logger.warn(bindings, message);
+      }
+      return;
+    }
+    logger.error(bindings, message);
+  };
 }
 
 export function attachDiscordTransportErrorHandlers(client: Client): void {
+  const logDiscordTransportError = createDiscordTransportErrorLogger();
+
   client.on('error', (error) => {
     logDiscordTransportError(
       error,

--- a/src/channels/discord/transport-errors.ts
+++ b/src/channels/discord/transport-errors.ts
@@ -1,0 +1,34 @@
+import type { Client } from 'discord.js';
+
+import { logger } from '../../logger.js';
+import { isExpectedTransportError } from '../../utils/transport-errors.js';
+
+function logDiscordTransportError(
+  error: unknown,
+  message: string,
+  metadata?: Record<string, unknown>,
+): void {
+  const bindings = metadata ? { ...metadata, error } : { error };
+  if (isExpectedTransportError(error)) {
+    logger.warn(bindings, message);
+    return;
+  }
+  logger.error(bindings, message);
+}
+
+export function attachDiscordTransportErrorHandlers(client: Client): void {
+  client.on('error', (error) => {
+    logDiscordTransportError(
+      error,
+      'Discord client transport error (will reconnect automatically)',
+    );
+  });
+
+  client.on('shardError', (error, shardId) => {
+    logDiscordTransportError(
+      error,
+      'Discord shard transport error (will reconnect automatically)',
+      { shardId },
+    );
+  });
+}

--- a/src/channels/discord/transport-errors.ts
+++ b/src/channels/discord/transport-errors.ts
@@ -9,29 +9,30 @@ const EXPECTED_TRANSPORT_WARN_LIMIT = 5;
 
 function createDiscordTransportErrorLogger(): (
   error: unknown,
-  message: string,
+  expectedMessage: string,
+  unexpectedMessage: string,
   metadata?: Record<string, unknown>,
 ) => void {
   const expectedTransportWarnLimiter = new SlidingWindowRateLimiter(
     EXPECTED_TRANSPORT_WARN_WINDOW_MS,
   );
 
-  return (error, message, metadata) => {
+  return (error, expectedMessage, unexpectedMessage, metadata) => {
     const bindings = metadata ? { ...metadata, err: error } : { err: error };
     if (isExpectedTransportError(error)) {
       // Rate-limit by error path, not shard id, so reconnect storms across
       // shards still collapse to a few warnings per minute.
       if (
         expectedTransportWarnLimiter.check(
-          message,
+          expectedMessage,
           EXPECTED_TRANSPORT_WARN_LIMIT,
         ).allowed
       ) {
-        logger.warn(bindings, message);
+        logger.warn(bindings, expectedMessage);
       }
       return;
     }
-    logger.error(bindings, message);
+    logger.error(bindings, unexpectedMessage);
   };
 }
 
@@ -42,6 +43,7 @@ export function attachDiscordTransportErrorHandlers(client: Client): void {
     logDiscordTransportError(
       error,
       'Discord client transport error (will reconnect automatically)',
+      'Unexpected Discord client error (reconnect may not recover automatically)',
     );
   });
 
@@ -49,6 +51,7 @@ export function attachDiscordTransportErrorHandlers(client: Client): void {
     logDiscordTransportError(
       error,
       'Discord shard transport error (will reconnect automatically)',
+      'Unexpected Discord shard error (reconnect may not recover automatically)',
       { shardId },
     );
   });

--- a/src/channels/discord/transport-errors.ts
+++ b/src/channels/discord/transport-errors.ts
@@ -1,11 +1,34 @@
 import type { Client } from 'discord.js';
 
 import { logger } from '../../logger.js';
-import { isExpectedTransportError } from '../../utils/transport-errors.js';
+import {
+  describeExpectedTransportError,
+  isExpectedTransportError,
+} from '../../utils/transport-errors.js';
 import { SlidingWindowRateLimiter } from './rate-limiter.js';
 
 const EXPECTED_TRANSPORT_WARN_WINDOW_MS = 60_000;
-const EXPECTED_TRANSPORT_WARN_LIMIT = 5;
+const EXPECTED_TRANSPORT_WARN_LIMIT = 2;
+const EXPECTED_API_WARN_WINDOW_MS = 60_000;
+const EXPECTED_API_WARN_LIMIT = 5;
+
+const expectedApiWarnLimiter = new SlidingWindowRateLimiter(
+  EXPECTED_API_WARN_WINDOW_MS,
+);
+
+type DiscordLogLevel = 'debug' | 'warn';
+
+function logAtLevel(
+  level: DiscordLogLevel,
+  bindings: Record<string, unknown>,
+  message: string,
+): void {
+  if (level === 'debug') {
+    logger.debug(bindings, message);
+    return;
+  }
+  logger.warn(bindings, message);
+}
 
 function createDiscordTransportErrorLogger(): (
   error: unknown,
@@ -34,6 +57,43 @@ function createDiscordTransportErrorLogger(): (
     }
     logger.error(bindings, unexpectedMessage);
   };
+}
+
+export function logDiscordApiError(params: {
+  error: unknown;
+  expectedAction: string;
+  unexpectedMessage: string;
+  metadata?: Record<string, unknown>;
+  level?: DiscordLogLevel;
+}): void {
+  const level = params.level ?? 'warn';
+  if (isExpectedTransportError(params.error)) {
+    if (
+      level === 'warn' &&
+      !expectedApiWarnLimiter.check(
+        params.expectedAction,
+        EXPECTED_API_WARN_LIMIT,
+      ).allowed
+    ) {
+      return;
+    }
+
+    logAtLevel(
+      level,
+      params.metadata ?? {},
+      `${describeExpectedTransportError(params.error, 'Discord API', 'discord.com')} ${params.expectedAction}`,
+    );
+    return;
+  }
+
+  const bindings = params.metadata
+    ? { ...params.metadata, err: params.error }
+    : { err: params.error };
+  if (level === 'debug') {
+    logger.debug(bindings, params.unexpectedMessage);
+    return;
+  }
+  logger.warn(bindings, params.unexpectedMessage);
 }
 
 export function attachDiscordTransportErrorHandlers(client: Client): void {

--- a/src/channels/discord/typing.ts
+++ b/src/channels/discord/typing.ts
@@ -1,6 +1,6 @@
 import type { Message as DiscordMessage } from 'discord.js';
 
-import { logger } from '../../logger.js';
+import { logDiscordApiError } from './transport-errors.js';
 
 export type DiscordTypingPhase =
   | 'received'
@@ -69,10 +69,13 @@ export function createTypingController(
     try {
       await message.channel.sendTyping();
     } catch (error) {
-      logger.debug(
-        { error, channelId: message.channelId },
-        'Failed to send typing indicator',
-      );
+      logDiscordApiError({
+        error,
+        expectedAction: 'Typing indicator was not sent.',
+        unexpectedMessage: 'Failed to send typing indicator',
+        metadata: { channelId: message.channelId },
+        level: 'debug',
+      });
     }
   };
 

--- a/src/channels/email/connection.ts
+++ b/src/channels/email/connection.ts
@@ -4,6 +4,7 @@ import { ImapFlow } from 'imapflow';
 import { DATA_DIR } from '../../config/config.js';
 import type { RuntimeEmailConfig } from '../../config/runtime-config.js';
 import { logger } from '../../logger.js';
+import { isExpectedTransportError } from '../../utils/transport-errors.js';
 
 const INITIAL_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 60_000;
@@ -24,6 +25,12 @@ export interface EmailConnectionManager {
 interface PersistedFolderCursorState {
   uidValidity: string | null;
   lastProcessedUid: number;
+}
+
+interface EmailConnectionErrorLike {
+  code?: unknown;
+  hostname?: unknown;
+  message?: unknown;
 }
 
 function resolveFolders(folders: string[]): string[] {
@@ -70,6 +77,54 @@ function normalizeUidValidity(
 function normalizeLastProcessedUid(value: unknown): number {
   const normalized = Math.max(0, Math.trunc(Number(value) || 0));
   return Number.isFinite(normalized) ? normalized : 0;
+}
+
+function getEmailConnectionErrorCode(error: unknown): string {
+  if (!error || typeof error !== 'object') {
+    return '';
+  }
+  const code = (error as EmailConnectionErrorLike).code;
+  return typeof code === 'string' ? code.toUpperCase() : '';
+}
+
+function getEmailConnectionErrorHost(
+  error: unknown,
+  fallbackHost: string,
+): string {
+  if (error && typeof error === 'object') {
+    const hostname = (error as EmailConnectionErrorLike).hostname;
+    if (typeof hostname === 'string' && hostname.trim()) {
+      return hostname.trim();
+    }
+  }
+  return fallbackHost;
+}
+
+function formatReconnectDelay(delayMs: number): string {
+  return `${Math.max(1, Math.ceil(delayMs / 1_000))}s`;
+}
+
+function describeExpectedEmailTransportError(
+  error: unknown,
+  fallbackHost: string,
+): string {
+  const host = getEmailConnectionErrorHost(error, fallbackHost);
+  switch (getEmailConnectionErrorCode(error)) {
+    case 'ENOTFOUND':
+      return `Email IMAP DNS lookup failed for ${host}.`;
+    case 'ETIMEDOUT':
+    case 'ESOCKETTIMEDOUT':
+      return `Email IMAP connection to ${host} timed out.`;
+    case 'ECONNREFUSED':
+      return `Email IMAP connection to ${host} was refused.`;
+    case 'ECONNRESET':
+      return `Email IMAP connection to ${host} was reset.`;
+    case 'EHOSTUNREACH':
+    case 'ENETUNREACH':
+      return `Email IMAP host ${host} is unreachable.`;
+    default:
+      return `Email IMAP connection to ${host} is temporarily unavailable.`;
+  }
 }
 
 async function loadPersistedFolderCursorState(
@@ -181,10 +236,40 @@ export function createEmailConnectionManager(
 
     const delayMs = reconnectDelayMs;
     reconnectDelayMs = Math.min(reconnectDelayMs * 2, MAX_RECONNECT_DELAY_MS);
-    childLogger.warn({ delayMs, reason, error }, 'Email reconnect scheduled');
+    if (error && isExpectedTransportError(error)) {
+      childLogger.warn(
+        {
+          delayMs,
+          reason,
+          code: getEmailConnectionErrorCode(error) || undefined,
+          host: getEmailConnectionErrorHost(error, config.imapHost),
+        },
+        `${describeExpectedEmailTransportError(error, config.imapHost)} Retrying connection in ${formatReconnectDelay(delayMs)}.`,
+      );
+    } else if (error) {
+      childLogger.error(
+        { err: error, delayMs, reason },
+        `Email IMAP reconnect scheduled in ${formatReconnectDelay(delayMs)}.`,
+      );
+    } else if (reason === 'client-closed') {
+      childLogger.warn(
+        { delayMs, reason, host: config.imapHost },
+        `Email IMAP connection closed. Retrying connection in ${formatReconnectDelay(delayMs)}.`,
+      );
+    } else if (reason === 'missing-client') {
+      childLogger.warn(
+        { delayMs, reason, host: config.imapHost },
+        `Email IMAP client is unavailable. Retrying connection in ${formatReconnectDelay(delayMs)}.`,
+      );
+    } else {
+      childLogger.warn(
+        { delayMs, reason, host: config.imapHost },
+        `Email IMAP reconnect scheduled in ${formatReconnectDelay(delayMs)}.`,
+      );
+    }
     reconnectTimer = setTimeout(() => {
       reconnectTimer = null;
-      void connect();
+      void connect().catch(() => {});
     }, delayMs);
   };
 
@@ -373,7 +458,7 @@ export function createEmailConnectionManager(
           user: config.address,
           pass: password,
         },
-        logger: childLogger,
+        logger: false,
       });
 
       nextClient.on('close', () => {
@@ -398,7 +483,9 @@ export function createEmailConnectionManager(
     })()
       .catch((error) => {
         scheduleReconnect('connect-error', error);
-        throw error;
+        if (!isExpectedTransportError(error)) {
+          throw error;
+        }
       })
       .finally(() => {
         connectingPromise = null;

--- a/src/channels/email/connection.ts
+++ b/src/channels/email/connection.ts
@@ -4,7 +4,10 @@ import { ImapFlow } from 'imapflow';
 import { DATA_DIR } from '../../config/config.js';
 import type { RuntimeEmailConfig } from '../../config/runtime-config.js';
 import { logger } from '../../logger.js';
-import { isExpectedTransportError } from '../../utils/transport-errors.js';
+import {
+  describeExpectedTransportError,
+  isExpectedTransportError,
+} from '../../utils/transport-errors.js';
 
 const INITIAL_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 60_000;
@@ -29,8 +32,6 @@ interface PersistedFolderCursorState {
 
 interface EmailConnectionErrorLike {
   code?: unknown;
-  hostname?: unknown;
-  message?: unknown;
 }
 
 function resolveFolders(folders: string[]): string[] {
@@ -87,44 +88,8 @@ function getEmailConnectionErrorCode(error: unknown): string {
   return typeof code === 'string' ? code.toUpperCase() : '';
 }
 
-function getEmailConnectionErrorHost(
-  error: unknown,
-  fallbackHost: string,
-): string {
-  if (error && typeof error === 'object') {
-    const hostname = (error as EmailConnectionErrorLike).hostname;
-    if (typeof hostname === 'string' && hostname.trim()) {
-      return hostname.trim();
-    }
-  }
-  return fallbackHost;
-}
-
 function formatReconnectDelay(delayMs: number): string {
   return `${Math.max(1, Math.ceil(delayMs / 1_000))}s`;
-}
-
-function describeExpectedEmailTransportError(
-  error: unknown,
-  fallbackHost: string,
-): string {
-  const host = getEmailConnectionErrorHost(error, fallbackHost);
-  switch (getEmailConnectionErrorCode(error)) {
-    case 'ENOTFOUND':
-      return `Email IMAP DNS lookup failed for ${host}.`;
-    case 'ETIMEDOUT':
-    case 'ESOCKETTIMEDOUT':
-      return `Email IMAP connection to ${host} timed out.`;
-    case 'ECONNREFUSED':
-      return `Email IMAP connection to ${host} was refused.`;
-    case 'ECONNRESET':
-      return `Email IMAP connection to ${host} was reset.`;
-    case 'EHOSTUNREACH':
-    case 'ENETUNREACH':
-      return `Email IMAP host ${host} is unreachable.`;
-    default:
-      return `Email IMAP connection to ${host} is temporarily unavailable.`;
-  }
 }
 
 async function loadPersistedFolderCursorState(
@@ -225,6 +190,14 @@ export function createEmailConnectionManager(
     if (!activeClient) return;
     activeClient.removeAllListeners();
     await activeClient.logout().catch((error) => {
+      if (
+        error &&
+        typeof error === 'object' &&
+        String((error as EmailConnectionErrorLike).code || '') ===
+          'NoConnection'
+      ) {
+        return;
+      }
       childLogger.debug({ error }, 'Email IMAP logout failed');
     });
   };
@@ -242,9 +215,9 @@ export function createEmailConnectionManager(
           delayMs,
           reason,
           code: getEmailConnectionErrorCode(error) || undefined,
-          host: getEmailConnectionErrorHost(error, config.imapHost),
+          host: config.imapHost,
         },
-        `${describeExpectedEmailTransportError(error, config.imapHost)} Retrying connection in ${formatReconnectDelay(delayMs)}.`,
+        `${describeExpectedTransportError(error, 'Email IMAP', config.imapHost)} Retrying connection in ${formatReconnectDelay(delayMs)}.`,
       );
     } else if (error) {
       childLogger.error(

--- a/src/channels/whatsapp/connection.ts
+++ b/src/channels/whatsapp/connection.ts
@@ -90,6 +90,16 @@ function shouldSuppressKeepAliveError(nowMs = Date.now()): boolean {
   return nowMs - lastExpectedTransportAt < KEEPALIVE_ERROR_SUPPRESS_MS;
 }
 
+function resolveWhatsAppLogMessage(payload: unknown, message?: string): string {
+  if (typeof message === 'string' && message.trim().length > 0) {
+    return message;
+  }
+  if (typeof payload === 'string' && payload.trim().length > 0) {
+    return payload;
+  }
+  return '';
+}
+
 function extractTransportSignal(payload: unknown, message?: string): unknown {
   if (payload && typeof payload === 'object') {
     if ('error' in payload) {
@@ -224,25 +234,26 @@ function emitWhatsAppLog(
   payload: unknown,
   message?: string,
 ): void {
+  const resolvedMessage = resolveWhatsAppLogMessage(payload, message);
   const transportSignal = extractTransportSignal(payload, message);
   if (
-    message === 'connection errored' &&
+    resolvedMessage === 'connection errored' &&
     isExpectedTransportError(transportSignal)
   ) {
     noteExpectedTransportActivity();
     return;
   }
   if (
-    message === 'error in sending keep alive' &&
+    resolvedMessage === 'error in sending keep alive' &&
     shouldSuppressKeepAliveError()
   ) {
     return;
   }
   if (
     shouldSuppressKeepAliveError() &&
-    (message === 'Buffer timeout reached, auto-flushing' ||
-      message === 'Flushing event buffer' ||
-      message === 'Event buffer activated')
+    (resolvedMessage === 'Buffer timeout reached, auto-flushing' ||
+      resolvedMessage === 'Flushing event buffer' ||
+      resolvedMessage === 'Event buffer activated')
   ) {
     return;
   }

--- a/src/channels/whatsapp/connection.ts
+++ b/src/channels/whatsapp/connection.ts
@@ -9,6 +9,11 @@ import qrcode from 'qrcode-terminal';
 import { APP_VERSION } from '../../config/config.js';
 import { logger } from '../../logger.js';
 import { sleep } from '../../utils/sleep.js';
+import {
+  describeExpectedTransportError,
+  isExpectedTransportError,
+} from '../../utils/transport-errors.js';
+import { SlidingWindowRateLimiter } from '../discord/rate-limiter.js';
 import { acquireWhatsAppAuthLock, loadWhatsAppAuthState } from './auth.js';
 import {
   createWhatsAppMessageStore,
@@ -27,6 +32,11 @@ const WHATSAPP_BROWSER_IDENTITY = [
   'Gateway',
   APP_VERSION,
 ] as const;
+const WHATSAPP_TRANSPORT_HOST = 'web.whatsapp.com';
+const EXPECTED_TRANSPORT_DEBUG_WINDOW_MS = 60_000;
+const EXPECTED_TRANSPORT_DEBUG_LIMIT = 3;
+const EXPECTED_TRANSPORT_DEBUG_COOLDOWN_MS = 1_000;
+const KEEPALIVE_ERROR_SUPPRESS_MS = 30_000;
 
 type WhatsAppLogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error';
 
@@ -55,6 +65,11 @@ interface EventEmitterWithInternals extends EventEmitterLike {
   [WHATSAPP_ERROR_SINK_ATTACHED]?: boolean;
 }
 
+const expectedTransportDebugLimiter = new SlidingWindowRateLimiter(
+  EXPECTED_TRANSPORT_DEBUG_WINDOW_MS,
+);
+let lastExpectedTransportAt = 0;
+
 function isEventEmitterLike(value: unknown): value is EventEmitterLike {
   return (
     typeof value === 'object' &&
@@ -63,17 +78,87 @@ function isEventEmitterLike(value: unknown): value is EventEmitterLike {
   );
 }
 
+function formatReconnectDelay(delayMs: number): string {
+  return `${Math.max(1, Math.ceil(delayMs / 1_000))}s`;
+}
+
+function noteExpectedTransportActivity(nowMs = Date.now()): void {
+  lastExpectedTransportAt = nowMs;
+}
+
+function shouldSuppressKeepAliveError(nowMs = Date.now()): boolean {
+  return nowMs - lastExpectedTransportAt < KEEPALIVE_ERROR_SUPPRESS_MS;
+}
+
+function extractTransportSignal(payload: unknown, message?: string): unknown {
+  if (payload && typeof payload === 'object') {
+    if ('error' in payload) {
+      return (payload as { error?: unknown }).error;
+    }
+    if (typeof (payload as { trace?: unknown }).trace === 'string') {
+      return (payload as { trace: string }).trace;
+    }
+  }
+  if (typeof payload === 'string' && payload.trim().length > 0) {
+    return payload;
+  }
+  return message || null;
+}
+
+function logExpectedWhatsAppTransport(
+  target: WhatsAppLogger,
+  error: unknown,
+  key: string,
+  nextAction: string,
+  level: 'debug' | 'warn',
+): void {
+  noteExpectedTransportActivity();
+  if (
+    level === 'debug' &&
+    (!expectedTransportDebugLimiter.shouldNotify(
+      key,
+      EXPECTED_TRANSPORT_DEBUG_COOLDOWN_MS,
+    ) ||
+      !expectedTransportDebugLimiter.check(key, EXPECTED_TRANSPORT_DEBUG_LIMIT)
+        .allowed)
+  ) {
+    return;
+  }
+
+  const message = `${describeExpectedTransportError(
+    error,
+    'WhatsApp WebSocket',
+    WHATSAPP_TRANSPORT_HOST,
+  )} ${nextAction}`;
+  if (level === 'debug') {
+    target.debug(message);
+    return;
+  }
+  target.warn(message);
+}
+
 function attachWhatsAppEmitterErrorSink(
   target: WhatsAppLogger,
   emitter: unknown,
-  message: string,
+  key: string,
+  unexpectedMessage: string,
 ): void {
   if (!isEventEmitterLike(emitter)) return;
   const candidate = emitter as EventEmitterWithInternals;
   if (candidate[WHATSAPP_ERROR_SINK_ATTACHED]) return;
   candidate[WHATSAPP_ERROR_SINK_ATTACHED] = true;
   candidate.on('error', (error: unknown) => {
-    logWhatsAppMessage(target, 'warn', message, { error });
+    if (isExpectedTransportError(error)) {
+      logExpectedWhatsAppTransport(
+        target,
+        error,
+        key,
+        'Reconnect will be retried automatically.',
+        'debug',
+      );
+      return;
+    }
+    logWhatsAppMessage(target, 'warn', unexpectedMessage, { error });
   });
 }
 
@@ -83,7 +168,12 @@ function attachWhatsAppTransportErrorSinks(
 ): void {
   if (!isEventEmitterLike(transport)) return;
 
-  attachWhatsAppEmitterErrorSink(target, transport, 'WhatsApp websocket error');
+  attachWhatsAppEmitterErrorSink(
+    target,
+    transport,
+    'whatsapp-websocket',
+    'Unexpected WhatsApp websocket error',
+  );
 
   // Baileys still exposes the underlying ws EventEmitter on `ws.socket` in
   // this runtime surface. Keep an explicit sink here so a raw transport error
@@ -93,7 +183,8 @@ function attachWhatsAppTransportErrorSinks(
   attachWhatsAppEmitterErrorSink(
     target,
     rawSocket,
-    'WhatsApp raw websocket error',
+    'whatsapp-websocket',
+    'Unexpected WhatsApp raw websocket error',
   );
 
   const request = isEventEmitterLike(rawSocket)
@@ -102,7 +193,8 @@ function attachWhatsAppTransportErrorSinks(
   attachWhatsAppEmitterErrorSink(
     target,
     request,
-    'WhatsApp websocket request error',
+    'whatsapp-websocket',
+    'Unexpected WhatsApp websocket request error',
   );
 
   const tcpSocket = isEventEmitterLike(rawSocket)
@@ -111,7 +203,8 @@ function attachWhatsAppTransportErrorSinks(
   attachWhatsAppEmitterErrorSink(
     target,
     tcpSocket,
-    'WhatsApp websocket tcp error',
+    'whatsapp-websocket',
+    'Unexpected WhatsApp websocket tcp error',
   );
 }
 
@@ -131,6 +224,29 @@ function emitWhatsAppLog(
   payload: unknown,
   message?: string,
 ): void {
+  const transportSignal = extractTransportSignal(payload, message);
+  if (
+    message === 'connection errored' &&
+    isExpectedTransportError(transportSignal)
+  ) {
+    noteExpectedTransportActivity();
+    return;
+  }
+  if (
+    message === 'error in sending keep alive' &&
+    shouldSuppressKeepAliveError()
+  ) {
+    return;
+  }
+  if (
+    shouldSuppressKeepAliveError() &&
+    (message === 'Buffer timeout reached, auto-flushing' ||
+      message === 'Flushing event buffer' ||
+      message === 'Event buffer activated')
+  ) {
+    return;
+  }
+
   if (isVerboseWhatsAppLogging(target)) {
     if (message === undefined) {
       target[level](payload);
@@ -244,14 +360,32 @@ export function createWhatsAppConnectionManager(params?: {
     }
   };
 
-  const scheduleReconnect = (reason: string): void => {
+  const scheduleReconnect = (reason: string, error?: unknown): void => {
     if (stopped || reconnectTimer) return;
     const delayMs = reconnectDelayMs;
     reconnectDelayMs = Math.min(reconnectDelayMs * 2, MAX_RECONNECT_DELAY_MS);
-    logWhatsAppMessage(childLogger, 'warn', 'WhatsApp reconnect scheduled', {
-      delayMs,
-      reason,
-    });
+    if (error && isExpectedTransportError(error)) {
+      logExpectedWhatsAppTransport(
+        childLogger,
+        error,
+        `whatsapp-reconnect:${reason}`,
+        `Retrying connection in ${formatReconnectDelay(delayMs)}.`,
+        'warn',
+      );
+    } else if (
+      reason === 'connection-close' ||
+      reason === 'status:408' ||
+      reason === 'status:428'
+    ) {
+      childLogger.warn(
+        `WhatsApp connection was lost. Retrying connection in ${formatReconnectDelay(delayMs)}.`,
+      );
+    } else {
+      logWhatsAppMessage(childLogger, 'warn', 'WhatsApp reconnect scheduled', {
+        delayMs,
+        reason,
+      });
+    }
     reconnectTimer = setTimeout(() => {
       reconnectTimer = null;
       void connect().catch(() => undefined);
@@ -331,13 +465,17 @@ export function createWhatsAppConnectionManager(params?: {
       );
     })()
       .catch((error) => {
-        logWhatsAppMessage(
-          childLogger,
-          'error',
-          'WhatsApp connection attempt failed',
-          { error },
-        );
-        scheduleReconnect('connect-error');
+        if (isExpectedTransportError(error)) {
+          scheduleReconnect('connect-error', error);
+        } else {
+          logWhatsAppMessage(
+            childLogger,
+            'error',
+            'WhatsApp connection attempt failed',
+            { error },
+          );
+          scheduleReconnect('connect-error');
+        }
         throw error;
       })
       .finally(() => {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -150,12 +150,31 @@ onRuntimeConfigChange((next, prev) => {
   }
 });
 
-// Use a module-level symbol so the same named handler can be detected across
-// re-imports that occur in tests (vi.resetModules + dynamic import). Without
-// this guard, every reimport of this module appends a fresh listener to the
-// process, quickly exceeding the default MaxListeners limit of 10.
-const UNCAUGHT_EXCEPTION_TAG = '__hybridclaw_uncaughtException__';
-const UNHANDLED_REJECTION_TAG = '__hybridclaw_unhandledRejection__';
+// Keep registration state on `process` so module reloads in tests
+// (vi.resetModules + dynamic import) do not append duplicate listeners.
+const PROCESS_HANDLER_REGISTRATION_KEY = Symbol.for(
+  'hybridclaw.logger.process-handler-registration',
+);
+
+interface ProcessHandlerRegistrationState {
+  uncaughtExceptionHandler: ((err: Error) => void) | null;
+  unhandledRejectionHandler: ((reason: unknown) => void) | null;
+}
+
+function getProcessHandlerRegistrationState(): ProcessHandlerRegistrationState {
+  const target = process as NodeJS.Process & {
+    [PROCESS_HANDLER_REGISTRATION_KEY]?: ProcessHandlerRegistrationState;
+  };
+  if (target[PROCESS_HANDLER_REGISTRATION_KEY]) {
+    return target[PROCESS_HANDLER_REGISTRATION_KEY];
+  }
+  const state: ProcessHandlerRegistrationState = {
+    uncaughtExceptionHandler: null,
+    unhandledRejectionHandler: null,
+  };
+  target[PROCESS_HANDLER_REGISTRATION_KEY] = state;
+  return state;
+}
 
 function uncaughtExceptionHandler(err: Error) {
   if (isExpectedTransportError(err)) {
@@ -173,30 +192,16 @@ function unhandledRejectionHandler(reason: unknown) {
   logger.error({ err: reason }, 'Unhandled rejection');
 }
 
-// Tag the handlers so we can detect whether they are already registered.
-(uncaughtExceptionHandler as unknown as Record<string, boolean>)[
-  UNCAUGHT_EXCEPTION_TAG
-] = true;
-(unhandledRejectionHandler as unknown as Record<string, boolean>)[
-  UNHANDLED_REJECTION_TAG
-] = true;
+const processHandlerRegistrationState = getProcessHandlerRegistrationState();
 
-if (
-  !process
-    .listeners('uncaughtException')
-    .some(
-      (l) => (l as unknown as Record<string, boolean>)[UNCAUGHT_EXCEPTION_TAG],
-    )
-) {
+if (!processHandlerRegistrationState.uncaughtExceptionHandler) {
   process.on('uncaughtException', uncaughtExceptionHandler);
+  processHandlerRegistrationState.uncaughtExceptionHandler =
+    uncaughtExceptionHandler;
 }
 
-if (
-  !process
-    .listeners('unhandledRejection')
-    .some(
-      (l) => (l as unknown as Record<string, boolean>)[UNHANDLED_REJECTION_TAG],
-    )
-) {
+if (!processHandlerRegistrationState.unhandledRejectionHandler) {
   process.on('unhandledRejection', unhandledRejectionHandler);
+  processHandlerRegistrationState.unhandledRejectionHandler =
+    unhandledRejectionHandler;
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -14,6 +14,7 @@ import {
   LOGGER_SERIALIZERS,
 } from './logger-format.js';
 import { getTraceContext } from './observability/otel.js';
+import { isExpectedTransportError } from './utils/transport-errors.js';
 
 const VALID_LOG_LEVELS = new Set([
   'fatal',
@@ -157,6 +158,13 @@ const UNCAUGHT_EXCEPTION_TAG = '__hybridclaw_uncaughtException__';
 const UNHANDLED_REJECTION_TAG = '__hybridclaw_unhandledRejection__';
 
 function uncaughtExceptionHandler(err: Error) {
+  if (isExpectedTransportError(err)) {
+    logger.warn(
+      { err },
+      'Handled expected transport exception without exiting',
+    );
+    return;
+  }
   logger.fatal({ err }, 'Uncaught exception');
   process.exit(1);
 }

--- a/src/utils/transport-errors.ts
+++ b/src/utils/transport-errors.ts
@@ -1,0 +1,81 @@
+const EXPECTED_TRANSPORT_ERROR_CODES = new Set([
+  'ECONNABORTED',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EHOSTUNREACH',
+  'EPIPE',
+  'EAI_AGAIN',
+  'ENETUNREACH',
+  'ENOTFOUND',
+  'ERR_SOCKET_CLOSED',
+  'ESOCKETTIMEDOUT',
+  'ETIMEDOUT',
+  'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_SOCKET',
+]);
+
+const EXPECTED_TRANSPORT_ERROR_MESSAGE_RE =
+  /\b(opening handshake has timed out|client network socket disconnected|connect econnrefused|connect etimedout|connection reset|connection terminated|econnaborted|econnrefused|econnreset|ehostunreach|enetunreach|enotfound|eai_again|err_socket_closed|esockettimedout|etimedout|fetch failed|network error|opening handshake|read econnreset|socket hang up|und_err_body_timeout|und_err_connect_timeout|und_err_headers_timeout|und_err_socket|websocket (?:connection |client )?(?:closed|error|timed out))\b/i;
+
+interface ErrorLike {
+  cause?: unknown;
+  code?: unknown;
+  error?: unknown;
+  errors?: unknown;
+  message?: unknown;
+}
+
+function hasExpectedTransportSignature(code: string, message: string): boolean {
+  return (
+    EXPECTED_TRANSPORT_ERROR_CODES.has(code) ||
+    EXPECTED_TRANSPORT_ERROR_MESSAGE_RE.test(message)
+  );
+}
+
+export function isExpectedTransportError(error: unknown): boolean {
+  const stack: unknown[] = [error];
+  const visited = new Set<unknown>();
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current === undefined || current === null || visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+
+    if (typeof current === 'string') {
+      if (hasExpectedTransportSignature('', current)) {
+        return true;
+      }
+      continue;
+    }
+
+    if (typeof current !== 'object') {
+      continue;
+    }
+
+    const candidate = current as ErrorLike;
+    const code =
+      typeof candidate.code === 'string' ? candidate.code.toUpperCase() : '';
+    const message =
+      typeof candidate.message === 'string' ? candidate.message : '';
+
+    if (hasExpectedTransportSignature(code, message)) {
+      return true;
+    }
+
+    if (Array.isArray(candidate.errors)) {
+      stack.push(...candidate.errors);
+    }
+    if (candidate.error !== undefined) {
+      stack.push(candidate.error);
+    }
+    if (candidate.cause !== undefined) {
+      stack.push(candidate.cause);
+    }
+  }
+
+  return false;
+}

--- a/src/utils/transport-errors.ts
+++ b/src/utils/transport-errors.ts
@@ -16,16 +16,21 @@ const EXPECTED_TRANSPORT_ERROR_CODES = new Set([
   'UND_ERR_SOCKET',
 ]);
 
+// Keep code strings here even when they also exist in the Set above. Some
+// libraries only surface transport failures in `message`, not `code`, and they
+// often embed the code inside longer text such as "connect ECONNREFUSED".
 const EXPECTED_TRANSPORT_ERROR_MESSAGE_RE =
   /\b(opening handshake has timed out|client network socket disconnected|connect econnrefused|connect etimedout|connection reset|connection terminated|econnaborted|econnrefused|econnreset|ehostunreach|enetunreach|enotfound|eai_again|err_socket_closed|esockettimedout|etimedout|fetch failed|network error|opening handshake|read econnreset|socket hang up|und_err_body_timeout|und_err_connect_timeout|und_err_headers_timeout|und_err_socket|websocket (?:connection |client )?(?:closed|error|timed out))\b/i;
 
 interface ErrorLike {
   cause?: unknown;
   code?: unknown;
-  error?: unknown;
+  // Keep the standard AggregateError shape, but avoid speculative wrappers.
   errors?: unknown;
   message?: unknown;
 }
+
+const MAX_EXPECTED_TRANSPORT_ERROR_DEPTH = 3;
 
 function hasExpectedTransportSignature(code: string, message: string): boolean {
   return (
@@ -34,48 +39,35 @@ function hasExpectedTransportSignature(code: string, message: string): boolean {
   );
 }
 
-export function isExpectedTransportError(error: unknown): boolean {
-  const stack: unknown[] = [error];
-  const visited = new Set<unknown>();
-
-  while (stack.length > 0) {
-    const current = stack.pop();
-    if (current === undefined || current === null || visited.has(current)) {
-      continue;
-    }
-    visited.add(current);
-
-    if (typeof current === 'string') {
-      if (hasExpectedTransportSignature('', current)) {
-        return true;
-      }
-      continue;
-    }
-
-    if (typeof current !== 'object') {
-      continue;
-    }
-
-    const candidate = current as ErrorLike;
-    const code =
-      typeof candidate.code === 'string' ? candidate.code.toUpperCase() : '';
-    const message =
-      typeof candidate.message === 'string' ? candidate.message : '';
-
-    if (hasExpectedTransportSignature(code, message)) {
-      return true;
-    }
-
-    if (Array.isArray(candidate.errors)) {
-      stack.push(...candidate.errors);
-    }
-    if (candidate.error !== undefined) {
-      stack.push(candidate.error);
-    }
-    if (candidate.cause !== undefined) {
-      stack.push(candidate.cause);
-    }
+export function isExpectedTransportError(error: unknown, depth = 0): boolean {
+  if (depth > MAX_EXPECTED_TRANSPORT_ERROR_DEPTH || error == null) {
+    return false;
+  }
+  if (typeof error === 'string') {
+    return hasExpectedTransportSignature('', error);
+  }
+  if (typeof error !== 'object') {
+    return false;
   }
 
-  return false;
+  const candidate = error as ErrorLike;
+  const code =
+    typeof candidate.code === 'string' ? candidate.code.toUpperCase() : '';
+  const message =
+    typeof candidate.message === 'string' ? candidate.message : '';
+
+  if (hasExpectedTransportSignature(code, message)) {
+    return true;
+  }
+
+  if (
+    Array.isArray(candidate.errors) &&
+    candidate.errors.some((nested) =>
+      isExpectedTransportError(nested, depth + 1),
+    )
+  ) {
+    return true;
+  }
+
+  return isExpectedTransportError(candidate.cause, depth + 1);
 }

--- a/src/utils/transport-errors.ts
+++ b/src/utils/transport-errors.ts
@@ -25,12 +25,149 @@ const EXPECTED_TRANSPORT_ERROR_MESSAGE_RE =
 interface ErrorLike {
   cause?: unknown;
   code?: unknown;
+  hostname?: unknown;
   // Keep the standard AggregateError shape, but avoid speculative wrappers.
   errors?: unknown;
   message?: unknown;
 }
 
 const MAX_EXPECTED_TRANSPORT_ERROR_DEPTH = 3;
+
+interface TransportErrorDetails {
+  code: string;
+  host: string;
+  message: string;
+}
+
+function getOwnTransportErrorDetails(error: unknown): TransportErrorDetails {
+  if (typeof error === 'string') {
+    return {
+      code: '',
+      host: '',
+      message: error,
+    };
+  }
+  if (!error || typeof error !== 'object') {
+    return {
+      code: '',
+      host: '',
+      message: '',
+    };
+  }
+
+  const candidate = error as ErrorLike;
+  return {
+    code:
+      typeof candidate.code === 'string' ? candidate.code.toUpperCase() : '',
+    host:
+      typeof candidate.hostname === 'string' ? candidate.hostname.trim() : '',
+    message: typeof candidate.message === 'string' ? candidate.message : '',
+  };
+}
+
+function findTransportErrorDetails(
+  error: unknown,
+  depth = 0,
+): TransportErrorDetails {
+  if (depth > MAX_EXPECTED_TRANSPORT_ERROR_DEPTH || error == null) {
+    return {
+      code: '',
+      host: '',
+      message: '',
+    };
+  }
+
+  const details = getOwnTransportErrorDetails(error);
+  if (details.code || details.host) {
+    return details;
+  }
+
+  if (error && typeof error === 'object') {
+    const candidate = error as ErrorLike;
+    if (Array.isArray(candidate.errors)) {
+      for (const nested of candidate.errors) {
+        const nestedDetails = findTransportErrorDetails(nested, depth + 1);
+        if (nestedDetails.code || nestedDetails.host || nestedDetails.message) {
+          return nestedDetails;
+        }
+      }
+    }
+
+    const causeDetails = findTransportErrorDetails(candidate.cause, depth + 1);
+    if (causeDetails.code || causeDetails.host || causeDetails.message) {
+      return causeDetails;
+    }
+  }
+
+  return details;
+}
+
+function getTransportErrorCode(error: unknown): string {
+  return findTransportErrorDetails(error).code;
+}
+
+function getTransportErrorHost(
+  error: unknown,
+  fallbackHost?: string | null,
+): string {
+  const host = findTransportErrorDetails(error).host;
+  return host || String(fallbackHost || '').trim();
+}
+
+function hasMeaningfulHost(host: string): boolean {
+  return host.length > 0;
+}
+
+function formatTransportEndpoint(subject: string, host: string): string {
+  if (hasMeaningfulHost(host)) {
+    return `${subject} connection to ${host}`;
+  }
+  return `${subject} connection`;
+}
+
+export function describeExpectedTransportError(
+  error: unknown,
+  subject: string,
+  fallbackHost?: string | null,
+): string {
+  const code = getTransportErrorCode(error);
+  const host = getTransportErrorHost(error, fallbackHost);
+
+  switch (code) {
+    case 'ENOTFOUND':
+      return hasMeaningfulHost(host)
+        ? `${subject} DNS lookup failed for ${host}.`
+        : `${subject} DNS lookup failed.`;
+    case 'EAI_AGAIN':
+      return hasMeaningfulHost(host)
+        ? `${subject} DNS lookup for ${host} is temporarily unavailable.`
+        : `${subject} DNS lookup is temporarily unavailable.`;
+    case 'ETIMEDOUT':
+    case 'ESOCKETTIMEDOUT':
+    case 'UND_ERR_CONNECT_TIMEOUT':
+    case 'UND_ERR_HEADERS_TIMEOUT':
+    case 'UND_ERR_BODY_TIMEOUT':
+      return `${formatTransportEndpoint(subject, host)} timed out.`;
+    case 'ECONNREFUSED':
+      return `${formatTransportEndpoint(subject, host)} was refused.`;
+    case 'ECONNRESET':
+      return `${formatTransportEndpoint(subject, host)} was reset.`;
+    case 'EHOSTUNREACH':
+    case 'ENETUNREACH':
+      return hasMeaningfulHost(host)
+        ? `${subject} host ${host} is unreachable.`
+        : `${subject} network is unreachable.`;
+    case 'ERR_SOCKET_CLOSED':
+    case 'UND_ERR_SOCKET':
+    case 'EPIPE':
+      return `${subject} socket closed unexpectedly.`;
+    default:
+      if (hasMeaningfulHost(host)) {
+        return `${subject} is temporarily unavailable at ${host}.`;
+      }
+      return `${subject} is temporarily unavailable.`;
+  }
+}
 
 function hasExpectedTransportSignature(code: string, message: string): boolean {
   return (

--- a/tests/discord.error-handler.test.ts
+++ b/tests/discord.error-handler.test.ts
@@ -24,6 +24,7 @@ class FakeDiscordClient extends EventEmitter {}
 afterEach(() => {
   loggerMocks.error.mockReset();
   loggerMocks.warn.mockReset();
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -49,11 +50,11 @@ describe('Discord client transport error handlers', () => {
     ).not.toThrow();
 
     expect(loggerMocks.warn).toHaveBeenCalledWith(
-      { error: expect.any(Error) },
+      { err: expect.any(Error) },
       'Discord client transport error (will reconnect automatically)',
     );
     expect(loggerMocks.warn).toHaveBeenCalledWith(
-      { error: expect.any(Error), shardId: 7 },
+      { err: expect.any(Error), shardId: 7 },
       'Discord shard transport error (will reconnect automatically)',
     );
   });
@@ -68,8 +69,27 @@ describe('Discord client transport error handlers', () => {
     ).not.toThrow();
 
     expect(loggerMocks.error).toHaveBeenCalledWith(
-      { error: expect.any(Error) },
+      { err: expect.any(Error) },
       'Discord client transport error (will reconnect automatically)',
     );
+  });
+
+  test('rate-limits repeated expected transport warnings and resumes later', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-19T17:00:00Z'));
+
+    const client = new FakeDiscordClient() as unknown as Client;
+    attachDiscordTransportErrorHandlers(client);
+
+    for (let attempt = 0; attempt < 8; attempt += 1) {
+      client.emit('error', new Error('socket hang up'));
+    }
+
+    expect(loggerMocks.warn).toHaveBeenCalledTimes(5);
+
+    vi.setSystemTime(new Date('2026-04-19T17:01:01Z'));
+    client.emit('error', new Error('socket hang up'));
+
+    expect(loggerMocks.warn).toHaveBeenCalledTimes(6);
   });
 });

--- a/tests/discord.error-handler.test.ts
+++ b/tests/discord.error-handler.test.ts
@@ -70,7 +70,7 @@ describe('Discord client transport error handlers', () => {
 
     expect(loggerMocks.error).toHaveBeenCalledWith(
       { err: expect.any(Error) },
-      'Discord client transport error (will reconnect automatically)',
+      'Unexpected Discord client error (reconnect may not recover automatically)',
     );
   });
 

--- a/tests/discord.error-handler.test.ts
+++ b/tests/discord.error-handler.test.ts
@@ -3,6 +3,7 @@ import type { Client } from 'discord.js';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 const loggerMocks = vi.hoisted(() => ({
+  debug: vi.fn(),
   error: vi.fn(),
   warn: vi.fn(),
 }));
@@ -11,7 +12,10 @@ vi.mock('../src/logger.ts', () => ({
   logger: loggerMocks,
 }));
 
-import { attachDiscordTransportErrorHandlers } from '../src/channels/discord/transport-errors.ts';
+import {
+  attachDiscordTransportErrorHandlers,
+  logDiscordApiError,
+} from '../src/channels/discord/transport-errors.ts';
 
 /**
  * Regression tests for transport errors bubbling out of Discord websocket
@@ -22,6 +26,7 @@ import { attachDiscordTransportErrorHandlers } from '../src/channels/discord/tra
 class FakeDiscordClient extends EventEmitter {}
 
 afterEach(() => {
+  loggerMocks.debug.mockReset();
   loggerMocks.error.mockReset();
   loggerMocks.warn.mockReset();
   vi.useRealTimers();
@@ -85,11 +90,31 @@ describe('Discord client transport error handlers', () => {
       client.emit('error', new Error('socket hang up'));
     }
 
-    expect(loggerMocks.warn).toHaveBeenCalledTimes(5);
+    expect(loggerMocks.warn).toHaveBeenCalledTimes(2);
 
     vi.setSystemTime(new Date('2026-04-19T17:01:01Z'));
     client.emit('error', new Error('socket hang up'));
 
-    expect(loggerMocks.warn).toHaveBeenCalledTimes(6);
+    expect(loggerMocks.warn).toHaveBeenCalledTimes(3);
+  });
+
+  test('formats expected Discord API failures with user-readable wording', () => {
+    logDiscordApiError({
+      error: Object.assign(new Error('lookup failed'), {
+        code: 'ENOTFOUND',
+        hostname: 'discord.com',
+      }),
+      expectedAction: 'Typing indicator was not sent.',
+      unexpectedMessage: 'Failed to send typing indicator',
+      metadata: { channelId: '123' },
+      level: 'debug',
+    });
+
+    expect(loggerMocks.warn).not.toHaveBeenCalled();
+    expect(loggerMocks.error).not.toHaveBeenCalled();
+    expect(loggerMocks.debug).toHaveBeenCalledWith(
+      { channelId: '123' },
+      'Discord API DNS lookup failed for discord.com. Typing indicator was not sent.',
+    );
   });
 });

--- a/tests/discord.error-handler.test.ts
+++ b/tests/discord.error-handler.test.ts
@@ -51,7 +51,11 @@ describe('Discord client transport error handlers', () => {
       client.emit('error', new Error('Opening handshake has timed out')),
     ).not.toThrow();
     expect(() =>
-      client.emit('shardError', new Error('Opening handshake has timed out'), 7),
+      client.emit(
+        'shardError',
+        new Error('Opening handshake has timed out'),
+        7,
+      ),
     ).not.toThrow();
 
     expect(loggerMocks.warn).toHaveBeenCalledWith(

--- a/tests/discord.error-handler.test.ts
+++ b/tests/discord.error-handler.test.ts
@@ -1,17 +1,33 @@
 import { EventEmitter } from 'node:events';
-import { describe, expect, test, vi } from 'vitest';
+import type { Client } from 'discord.js';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+const loggerMocks = vi.hoisted(() => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock('../src/logger.ts', () => ({
+  logger: loggerMocks,
+}));
+
+import { attachDiscordTransportErrorHandlers } from '../src/channels/discord/transport-errors.ts';
 
 /**
- * Regression test for gateway crash caused by unhandled Discord client 'error'
- * events. Without an error listener, Node's EventEmitter throws 'error' events
- * as uncaught exceptions — which hit our process.on('uncaughtException') handler
- * in logger.ts and call process.exit(1).
- *
- * The fix adds `client.on('error', ...)` in initDiscord() so transient
- * WebSocket errors (e.g. "Opening handshake has timed out") are logged
- * instead of crashing the gateway.
+ * Regression tests for transport errors bubbling out of Discord websocket
+ * setup/reconnect paths. These failures are expected during normal network
+ * churn and must be handled locally instead of surfacing as fatal process
+ * exceptions.
  */
-describe('Discord client error handler', () => {
+class FakeDiscordClient extends EventEmitter {}
+
+afterEach(() => {
+  loggerMocks.error.mockReset();
+  loggerMocks.warn.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe('Discord client transport error handlers', () => {
   test('EventEmitter without error listener throws on error event', () => {
     const emitter = new EventEmitter();
     // Without a listener, emitting 'error' throws
@@ -20,18 +36,40 @@ describe('Discord client error handler', () => {
     );
   });
 
-  test('EventEmitter with error listener does not throw', () => {
-    const emitter = new EventEmitter();
-    const errorHandler = vi.fn();
-    emitter.on('error', errorHandler);
+  test('expected Discord transport errors are handled locally', () => {
+    const client = new FakeDiscordClient() as unknown as Client;
 
-    // With a listener, emitting 'error' is handled gracefully
+    attachDiscordTransportErrorHandlers(client);
+
     expect(() =>
-      emitter.emit('error', new Error('Opening handshake has timed out')),
+      client.emit('error', new Error('Opening handshake has timed out')),
     ).not.toThrow();
-    expect(errorHandler).toHaveBeenCalledOnce();
-    expect(errorHandler.mock.calls[0][0].message).toBe(
-      'Opening handshake has timed out',
+    expect(() =>
+      client.emit('shardError', new Error('Opening handshake has timed out'), 7),
+    ).not.toThrow();
+
+    expect(loggerMocks.warn).toHaveBeenCalledWith(
+      { error: expect.any(Error) },
+      'Discord client transport error (will reconnect automatically)',
+    );
+    expect(loggerMocks.warn).toHaveBeenCalledWith(
+      { error: expect.any(Error), shardId: 7 },
+      'Discord shard transport error (will reconnect automatically)',
+    );
+  });
+
+  test('unexpected Discord client errors stay at error level', () => {
+    const client = new FakeDiscordClient() as unknown as Client;
+
+    attachDiscordTransportErrorHandlers(client);
+
+    expect(() =>
+      client.emit('error', new Error('Discord parser exploded')),
+    ).not.toThrow();
+
+    expect(loggerMocks.error).toHaveBeenCalledWith(
+      { error: expect.any(Error) },
+      'Discord client transport error (will reconnect automatically)',
     );
   });
 });

--- a/tests/email.connection.test.ts
+++ b/tests/email.connection.test.ts
@@ -209,4 +209,124 @@ describe('email connection manager', () => {
       uid: true,
     });
   });
+
+  test('keeps expected DNS failures local and logs a readable reconnect warning', async () => {
+    const dataDir = makeTempDir('hybridclaw-email-connection-');
+    const childLogger = {
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+    const connectError = Object.assign(
+      new Error('getaddrinfo ENOTFOUND mx.hybridclaw.io'),
+      {
+        code: 'ENOTFOUND',
+        hostname: 'mx.hybridclaw.io',
+        syscall: 'getaddrinfo',
+      },
+    );
+
+    vi.doMock('../src/config/config.js', () => ({
+      DATA_DIR: dataDir,
+    }));
+    vi.doMock('../src/logger.ts', () => ({
+      logger: {
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+        child: vi.fn(() => childLogger),
+      },
+    }));
+    vi.doMock('imapflow', () => ({
+      ImapFlow: class {
+        connect = vi.fn(async () => {
+          throw connectError;
+        });
+        logout = vi.fn(async () => {});
+        close = vi.fn(() => {});
+        removeAllListeners = vi.fn(() => {});
+        on = vi.fn(() => this);
+      },
+    }));
+
+    const { createEmailConnectionManager } = await import(
+      '../src/channels/email/connection.js'
+    );
+    const manager = createEmailConnectionManager(
+      {
+        ...BASE_EMAIL_CONFIG,
+        imapHost: 'mx.hybridclaw.io',
+      },
+      'secret',
+      async () => {},
+    );
+
+    await expect(manager.start()).resolves.toBeUndefined();
+    await manager.stop();
+
+    expect(childLogger.error).not.toHaveBeenCalled();
+    expect(childLogger.warn).toHaveBeenCalledWith(
+      {
+        delayMs: 1_000,
+        reason: 'connect-error',
+        code: 'ENOTFOUND',
+        host: 'mx.hybridclaw.io',
+      },
+      'Email IMAP DNS lookup failed for mx.hybridclaw.io. Retrying connection in 1s.',
+    );
+  });
+
+  test('still rejects unexpected connect failures on initial start', async () => {
+    const dataDir = makeTempDir('hybridclaw-email-connection-');
+    const childLogger = {
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+    const connectError = new Error('Authentication failed');
+
+    vi.doMock('../src/config/config.js', () => ({
+      DATA_DIR: dataDir,
+    }));
+    vi.doMock('../src/logger.ts', () => ({
+      logger: {
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+        child: vi.fn(() => childLogger),
+      },
+    }));
+    vi.doMock('imapflow', () => ({
+      ImapFlow: class {
+        connect = vi.fn(async () => {
+          throw connectError;
+        });
+        logout = vi.fn(async () => {});
+        close = vi.fn(() => {});
+        removeAllListeners = vi.fn(() => {});
+        on = vi.fn(() => this);
+      },
+    }));
+
+    const { createEmailConnectionManager } = await import(
+      '../src/channels/email/connection.js'
+    );
+    const manager = createEmailConnectionManager(
+      BASE_EMAIL_CONFIG,
+      'secret',
+      async () => {},
+    );
+
+    await expect(manager.start()).rejects.toThrow('Authentication failed');
+    await manager.stop();
+
+    expect(childLogger.error).toHaveBeenCalledWith(
+      {
+        err: connectError,
+        delayMs: 1_000,
+        reason: 'connect-error',
+      },
+      'Email IMAP reconnect scheduled in 1s.',
+    );
+  });
 });

--- a/tests/hybridai-retry.test.ts
+++ b/tests/hybridai-retry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import {
+  formatModelErrorForLog,
   isRetryableModelError,
   shouldDowngradeStreamToNonStreaming,
   shouldFallbackFromStreamError,
@@ -155,5 +156,29 @@ describe('isRetryableModelError', () => {
 
   test('does not retry unrelated generic errors', () => {
     expect(isRetryableModelError(new Error('validation failed'))).toBe(false);
+  });
+});
+
+describe('formatModelErrorForLog', () => {
+  test('uses nested transport causes to describe fetch failures', () => {
+    const error = new Error('fetch failed', {
+      cause: Object.assign(new Error('getaddrinfo ENOTFOUND api.hybridai.one'), {
+        code: 'ENOTFOUND',
+        hostname: 'api.hybridai.one',
+      }),
+    });
+
+    expect(formatModelErrorForLog(error, 'https://api.hybridai.one/v1/chat')).toBe(
+      'DNS lookup failed for api.hybridai.one',
+    );
+  });
+
+  test('falls back to the model API host for generic network failures', () => {
+    expect(
+      formatModelErrorForLog(
+        new Error('fetch failed'),
+        'https://api.hybridai.one/v1/chat',
+      ),
+    ).toBe('Model API at api.hybridai.one is temporarily unavailable');
   });
 });

--- a/tests/hybridai-retry.test.ts
+++ b/tests/hybridai-retry.test.ts
@@ -162,15 +162,18 @@ describe('isRetryableModelError', () => {
 describe('formatModelErrorForLog', () => {
   test('uses nested transport causes to describe fetch failures', () => {
     const error = new Error('fetch failed', {
-      cause: Object.assign(new Error('getaddrinfo ENOTFOUND api.hybridai.one'), {
-        code: 'ENOTFOUND',
-        hostname: 'api.hybridai.one',
-      }),
+      cause: Object.assign(
+        new Error('getaddrinfo ENOTFOUND api.hybridai.one'),
+        {
+          code: 'ENOTFOUND',
+          hostname: 'api.hybridai.one',
+        },
+      ),
     });
 
-    expect(formatModelErrorForLog(error, 'https://api.hybridai.one/v1/chat')).toBe(
-      'DNS lookup failed for api.hybridai.one',
-    );
+    expect(
+      formatModelErrorForLog(error, 'https://api.hybridai.one/v1/chat'),
+    ).toBe('DNS lookup failed for api.hybridai.one');
   });
 
   test('falls back to the model API host for generic network failures', () => {

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -21,16 +21,48 @@ async function waitForFileText(
   throw new Error(`Timed out waiting for log file: ${filePath}`);
 }
 
-function removeHybridClawProcessListeners(event: 'uncaughtException'): void {
-  for (const listener of process.listeners(event)) {
-    if (listener.name === 'uncaughtExceptionHandler') {
-      process.removeListener(event, listener);
-    }
+const PROCESS_HANDLER_REGISTRATION_KEY = Symbol.for(
+  'hybridclaw.logger.process-handler-registration',
+);
+
+interface ProcessWithRegistrationState extends NodeJS.Process {
+  [PROCESS_HANDLER_REGISTRATION_KEY]?: {
+    uncaughtExceptionHandler: ((err: Error) => void) | null;
+    unhandledRejectionHandler: ((reason: unknown) => void) | null;
+  };
+}
+
+function getHybridClawProcessListenerState() {
+  return (process as ProcessWithRegistrationState)[
+    PROCESS_HANDLER_REGISTRATION_KEY
+  ];
+}
+
+function removeHybridClawProcessListeners(): void {
+  const state = getHybridClawProcessListenerState();
+  if (state?.uncaughtExceptionHandler) {
+    process.removeListener(
+      'uncaughtException',
+      state.uncaughtExceptionHandler as (error: Error) => void,
+    );
+  }
+  if (state?.unhandledRejectionHandler) {
+    process.removeListener(
+      'unhandledRejection',
+      state.unhandledRejectionHandler as (reason: unknown) => void,
+    );
   }
 }
 
+function resetHybridClawProcessListenerState(): void {
+  delete (process as ProcessWithRegistrationState)[
+    PROCESS_HANDLER_REGISTRATION_KEY
+  ];
+}
+
 async function importFreshLogger() {
-  removeHybridClawProcessListeners('uncaughtException');
+  removeHybridClawProcessListeners();
+  resetHybridClawProcessListenerState();
   vi.resetModules();
   vi.doMock('../src/config/runtime-config.ts', () => ({
     getRuntimeConfig: () => ({
@@ -39,9 +71,7 @@ async function importFreshLogger() {
     onRuntimeConfigChange: vi.fn(),
   }));
   const module = await import('../src/logger.ts');
-  const listener = process
-    .listeners('uncaughtException')
-    .find((candidate) => candidate.name === 'uncaughtExceptionHandler');
+  const listener = getHybridClawProcessListenerState()?.uncaughtExceptionHandler;
   if (!listener) {
     throw new Error('Failed to register uncaughtExceptionHandler');
   }
@@ -58,7 +88,8 @@ describe('logger forced level override', () => {
     vi.restoreAllMocks();
     vi.resetModules();
     vi.doUnmock('../src/config/runtime-config.ts');
-    removeHybridClawProcessListeners('uncaughtException');
+    removeHybridClawProcessListeners();
+    resetHybridClawProcessListenerState();
     delete process.env.HYBRIDCLAW_FORCE_LOG_LEVEL;
     delete process.env.HYBRIDCLAW_GATEWAY_LOG_FILE;
     if (tempDir) {
@@ -215,5 +246,40 @@ describe('logger forced level override', () => {
       'Uncaught exception',
     );
     expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('registers process handlers only once across module reloads', async () => {
+    removeHybridClawProcessListeners();
+    resetHybridClawProcessListenerState();
+
+    const mockRuntimeConfig = () =>
+      vi.doMock('../src/config/runtime-config.ts', () => ({
+        getRuntimeConfig: () => ({
+          ops: { logLevel: 'info' },
+        }),
+        onRuntimeConfigChange: vi.fn(),
+      }));
+
+    mockRuntimeConfig();
+    await import('../src/logger.ts');
+    vi.resetModules();
+    mockRuntimeConfig();
+    await import('../src/logger.ts');
+
+    const state = getHybridClawProcessListenerState();
+    if (!state?.uncaughtExceptionHandler || !state.unhandledRejectionHandler) {
+      throw new Error('Failed to register logger process handlers');
+    }
+
+    expect(
+      process
+        .listeners('uncaughtException')
+        .filter((listener) => listener === state.uncaughtExceptionHandler),
+    ).toHaveLength(1);
+    expect(
+      process
+        .listeners('unhandledRejection')
+        .filter((listener) => listener === state.unhandledRejectionHandler),
+    ).toHaveLength(1);
   });
 });

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -21,6 +21,36 @@ async function waitForFileText(
   throw new Error(`Timed out waiting for log file: ${filePath}`);
 }
 
+function removeHybridClawProcessListeners(event: 'uncaughtException'): void {
+  for (const listener of process.listeners(event)) {
+    if (listener.name === 'uncaughtExceptionHandler') {
+      process.removeListener(event, listener);
+    }
+  }
+}
+
+async function importFreshLogger() {
+  removeHybridClawProcessListeners('uncaughtException');
+  vi.resetModules();
+  vi.doMock('../src/config/runtime-config.ts', () => ({
+    getRuntimeConfig: () => ({
+      ops: { logLevel: 'info' },
+    }),
+    onRuntimeConfigChange: vi.fn(),
+  }));
+  const module = await import('../src/logger.ts');
+  const listener = process
+    .listeners('uncaughtException')
+    .find((candidate) => candidate.name === 'uncaughtExceptionHandler');
+  if (!listener) {
+    throw new Error('Failed to register uncaughtExceptionHandler');
+  }
+  return {
+    ...module,
+    uncaughtExceptionHandler: listener as (error: Error) => void,
+  };
+}
+
 describe('logger forced level override', () => {
   let tempDir: string | null = null;
 
@@ -28,6 +58,7 @@ describe('logger forced level override', () => {
     vi.restoreAllMocks();
     vi.resetModules();
     vi.doUnmock('../src/config/runtime-config.ts');
+    removeHybridClawProcessListeners('uncaughtException');
     delete process.env.HYBRIDCLAW_FORCE_LOG_LEVEL;
     delete process.env.HYBRIDCLAW_GATEWAY_LOG_FILE;
     if (tempDir) {
@@ -144,5 +175,45 @@ describe('logger forced level override', () => {
     );
 
     expect(logText).toContain('late forced debug mirror test');
+  });
+
+  it('keeps expected transport exceptions non-fatal', async () => {
+    const { logger, uncaughtExceptionHandler } = await importFreshLogger();
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never);
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    const fatalSpy = vi
+      .spyOn(logger, 'fatal')
+      .mockImplementation(() => undefined);
+
+    uncaughtExceptionHandler(new Error('Opening handshake has timed out'));
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      { err: expect.any(Error) },
+      'Handled expected transport exception without exiting',
+    );
+    expect(fatalSpy).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('still exits on unexpected uncaught exceptions', async () => {
+    const { logger, uncaughtExceptionHandler } = await importFreshLogger();
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never);
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    const fatalSpy = vi
+      .spyOn(logger, 'fatal')
+      .mockImplementation(() => undefined);
+
+    uncaughtExceptionHandler(new Error('Invariant violation'));
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(fatalSpy).toHaveBeenCalledWith(
+      { err: expect.any(Error) },
+      'Uncaught exception',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 });

--- a/tests/observability-ingest.test.ts
+++ b/tests/observability-ingest.test.ts
@@ -299,3 +299,116 @@ test('observability ingest restart dispatches a new startup flush without waitin
 
   stopObservabilityIngest();
 });
+
+test('observability ingest rate-limits repeated transient outage warnings', async () => {
+  vi.useFakeTimers();
+  vi.resetModules();
+  setupHome({ HYBRIDAI_API_KEY: 'test-key' });
+
+  const loggerMock = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  };
+  vi.doMock('../src/logger.ts', () => ({
+    logger: loggerMock,
+  }));
+
+  try {
+    const { getRuntimeConfig, saveRuntimeConfig } = await import(
+      '../src/config/runtime-config.ts'
+    );
+    const runtimeConfig = getRuntimeConfig();
+    saveRuntimeConfig({
+      ...runtimeConfig,
+      hybridai: {
+        ...runtimeConfig.hybridai,
+        defaultChatbotId: 'bot-default',
+      },
+      observability: {
+        ...runtimeConfig.observability,
+        enabled: true,
+        botId: 'bot-observability',
+        agentId: 'agent-observability',
+        flushIntervalMs: 10_000,
+        batchMaxEvents: 10,
+      },
+    });
+
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, _init?: RequestInit) => {
+        const url =
+          typeof input === 'string'
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        if (url.endsWith('/api/v1/agent-observability/ingest-token:ensure')) {
+          return new Response(
+            JSON.stringify({
+              success: true,
+              created: true,
+              token: 'ingest-token',
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+        if (url.endsWith('/api/v1/agent-observability/events:batch')) {
+          throw new Error('fetch failed');
+        }
+        throw new Error(`Unexpected fetch URL: ${url}`);
+      },
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { initDatabase } = await import('../src/memory/db.ts');
+    const { recordAuditEvent } = await import('../src/audit/audit-events.ts');
+    const { startObservabilityIngest, stopObservabilityIngest } = await import(
+      '../src/audit/observability-ingest.ts'
+    );
+
+    initDatabase({ quiet: true });
+    recordAuditEvent({
+      sessionId: 'session-observability-rate-limit',
+      runId: 'run-observability-rate-limit',
+      event: {
+        type: 'bot.set',
+        source: 'command',
+        requestedBot: 'Research Bot',
+        previousBotId: null,
+        resolvedBotId: 'bot-research',
+        changed: true,
+        previousModel: 'gpt-5-nano',
+        syncedModel: 'gpt-4o-mini',
+        userId: 'user-1',
+        username: 'alice',
+      },
+    });
+
+    startObservabilityIngest();
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(5);
+    });
+
+    const transientWarnCalls = loggerMock.warn.mock.calls.filter(
+      ([, message]) =>
+        message ===
+        'Observability ingest is temporarily unavailable at hybridai.one. Events will be retried automatically.',
+    );
+    expect(transientWarnCalls).toHaveLength(1);
+
+    stopObservabilityIngest();
+  } finally {
+    vi.doUnmock('../src/logger.ts');
+    vi.useRealTimers();
+    vi.resetModules();
+  }
+});

--- a/tests/transport-errors.test.ts
+++ b/tests/transport-errors.test.ts
@@ -23,6 +23,24 @@ describe('isExpectedTransportError', () => {
     expect(isExpectedTransportError(error)).toBe(true);
   });
 
+  test('matches deeply nested transport causes', () => {
+    const error = new Error('Discord shard error', {
+      cause: new Error('Gateway reconnect failed', {
+        cause: Object.assign(new Error('connect failed'), {
+          code: 'ECONNRESET',
+        }),
+      }),
+    });
+    expect(isExpectedTransportError(error)).toBe(true);
+  });
+
+  test('matches transport errors nested inside errors arrays', () => {
+    const error = {
+      errors: [new Error('validation failed'), new Error('socket hang up')],
+    };
+    expect(isExpectedTransportError(error)).toBe(true);
+  });
+
   test('ignores unrelated application errors', () => {
     expect(
       isExpectedTransportError(new Error("Cannot read properties of undefined")),

--- a/tests/transport-errors.test.ts
+++ b/tests/transport-errors.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'vitest';
 
-import { isExpectedTransportError } from '../src/utils/transport-errors.ts';
+import {
+  describeExpectedTransportError,
+  isExpectedTransportError,
+} from '../src/utils/transport-errors.ts';
 
 describe('isExpectedTransportError', () => {
   test('matches websocket handshake timeouts', () => {
@@ -45,5 +48,30 @@ describe('isExpectedTransportError', () => {
     expect(
       isExpectedTransportError(new Error("Cannot read properties of undefined")),
     ).toBe(false);
+  });
+});
+
+describe('describeExpectedTransportError', () => {
+  test('uses nested cause codes and hosts when the top-level error is generic', () => {
+    const error = new Error('fetch failed', {
+      cause: Object.assign(new Error('getaddrinfo ENOTFOUND discord.com'), {
+        code: 'ENOTFOUND',
+        hostname: 'discord.com',
+      }),
+    });
+
+    expect(describeExpectedTransportError(error, 'Discord API')).toBe(
+      'Discord API DNS lookup failed for discord.com.',
+    );
+  });
+
+  test('falls back to the provided host for generic transient fetch failures', () => {
+    expect(
+      describeExpectedTransportError(
+        new Error('fetch failed'),
+        'Observability ingest',
+        'hybridai.one',
+      ),
+    ).toBe('Observability ingest is temporarily unavailable at hybridai.one.');
   });
 });

--- a/tests/transport-errors.test.ts
+++ b/tests/transport-errors.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest';
+
+import { isExpectedTransportError } from '../src/utils/transport-errors.ts';
+
+describe('isExpectedTransportError', () => {
+  test('matches websocket handshake timeouts', () => {
+    expect(
+      isExpectedTransportError(new Error('Opening handshake has timed out')),
+    ).toBe(true);
+  });
+
+  test('matches known transport error codes', () => {
+    const error = Object.assign(new Error('connect failed'), {
+      code: 'ETIMEDOUT',
+    });
+    expect(isExpectedTransportError(error)).toBe(true);
+  });
+
+  test('matches nested transport causes', () => {
+    const error = new Error('Discord shard error', {
+      cause: new Error('socket hang up'),
+    });
+    expect(isExpectedTransportError(error)).toBe(true);
+  });
+
+  test('ignores unrelated application errors', () => {
+    expect(
+      isExpectedTransportError(new Error("Cannot read properties of undefined")),
+    ).toBe(false);
+  });
+});

--- a/tests/transport-errors.test.ts
+++ b/tests/transport-errors.test.ts
@@ -46,7 +46,9 @@ describe('isExpectedTransportError', () => {
 
   test('ignores unrelated application errors', () => {
     expect(
-      isExpectedTransportError(new Error("Cannot read properties of undefined")),
+      isExpectedTransportError(
+        new Error('Cannot read properties of undefined'),
+      ),
     ).toBe(false);
   });
 });

--- a/tests/whatsapp.connection.test.ts
+++ b/tests/whatsapp.connection.test.ts
@@ -30,7 +30,11 @@ async function importFreshConnectionModule(options?: {
     config: {
       browser?: unknown[];
       getMessage?: (key: unknown) => Promise<unknown>;
-      logger: { info: (obj: unknown, msg?: string) => void };
+      logger: {
+        debug: (obj: unknown, msg?: string) => void;
+        info: (obj: unknown, msg?: string) => void;
+        warn: (obj: unknown, msg?: string) => void;
+      };
     };
     evHandlers: Map<string, Array<(payload: unknown) => void>>;
     wsHandlers: Map<string, Array<(payload: unknown) => void>>;
@@ -396,9 +400,9 @@ test('suppresses buffer flush noise while WhatsApp is offline', async () => {
     }),
   );
 
-  sockets[0]?.config.logger.warn({}, 'Buffer timeout reached, auto-flushing');
+  sockets[0]?.config.logger.warn('Buffer timeout reached, auto-flushing');
   sockets[0]?.config.logger.debug({ bufferCount: 1 }, 'Flushing event buffer');
-  sockets[0]?.config.logger.debug({}, 'Event buffer activated');
+  sockets[0]?.config.logger.debug('Event buffer activated');
 
   expect(whatsappLogger.warn).not.toHaveBeenCalledWith(
     'Buffer timeout reached, auto-flushing',
@@ -407,10 +411,7 @@ test('suppresses buffer flush noise while WhatsApp is offline', async () => {
     { bufferCount: 1 },
     'Flushing event buffer',
   );
-  expect(whatsappLogger.debug).not.toHaveBeenCalledWith(
-    {},
-    'Event buffer activated',
-  );
+  expect(whatsappLogger.debug).not.toHaveBeenCalledWith('Event buffer activated');
 
   await manager.stop();
 });

--- a/tests/whatsapp.connection.test.ts
+++ b/tests/whatsapp.connection.test.ts
@@ -275,7 +275,10 @@ test('waitForSocket does not revive the manager after stop during implicit start
 
 test('transport-level WhatsApp emitters are handled without throwing', async () => {
   const { createWhatsAppConnectionManager, sockets, whatsappLogger } =
-    await importFreshConnectionModule();
+    await importFreshConnectionModule({
+      logLevel: 'debug',
+      rootLevel: 'debug',
+    });
 
   const manager = createWhatsAppConnectionManager();
   await manager.start();
@@ -286,13 +289,130 @@ test('transport-level WhatsApp emitters are handled without throwing', async () 
   expect(() =>
     transport?.rawSocketEmitter.emit(
       'error',
-      new Error('Opening handshake has timed out'),
+      Object.assign(new Error('getaddrinfo ENOTFOUND web.whatsapp.com'), {
+        code: 'ENOTFOUND',
+        hostname: 'web.whatsapp.com',
+      }),
     ),
   ).not.toThrow();
 
-  expect(whatsappLogger.warn).toHaveBeenCalledWith(
-    'WhatsApp raw websocket error',
+  expect(whatsappLogger.debug).toHaveBeenCalledWith(
+    'WhatsApp WebSocket DNS lookup failed for web.whatsapp.com. Reconnect will be retried automatically.',
   );
+});
+
+test('rate-limits repeated expected WhatsApp transport sink logs', async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-20T08:00:00Z'));
+
+  const { createWhatsAppConnectionManager, sockets, whatsappLogger } =
+    await importFreshConnectionModule({
+      logLevel: 'debug',
+      rootLevel: 'debug',
+    });
+
+  const manager = createWhatsAppConnectionManager();
+  await manager.start();
+
+  const transport = sockets[0];
+  expect(transport).toBeDefined();
+
+  for (let attempt = 0; attempt < 6; attempt += 1) {
+    transport?.rawSocketEmitter.emit(
+      'error',
+      Object.assign(new Error('getaddrinfo ENOTFOUND web.whatsapp.com'), {
+        code: 'ENOTFOUND',
+        hostname: 'web.whatsapp.com',
+      }),
+    );
+  }
+
+  expect(
+    whatsappLogger.debug.mock.calls.filter(
+      ([message]) =>
+        message ===
+        'WhatsApp WebSocket DNS lookup failed for web.whatsapp.com. Reconnect will be retried automatically.',
+    ),
+  ).toHaveLength(1);
+
+  vi.setSystemTime(new Date('2026-04-20T08:01:01Z'));
+  transport?.rawSocketEmitter.emit(
+    'error',
+    Object.assign(new Error('getaddrinfo ENOTFOUND web.whatsapp.com'), {
+      code: 'ENOTFOUND',
+      hostname: 'web.whatsapp.com',
+    }),
+  );
+
+  expect(
+    whatsappLogger.debug.mock.calls.filter(
+      ([message]) =>
+        message ===
+        'WhatsApp WebSocket DNS lookup failed for web.whatsapp.com. Reconnect will be retried automatically.',
+    ),
+  ).toHaveLength(2);
+});
+
+test('reconnect warnings use human-readable wording for lost connections', async () => {
+  const { createWhatsAppConnectionManager, sockets, whatsappLogger } =
+    await importFreshConnectionModule();
+
+  const manager = createWhatsAppConnectionManager();
+  await manager.start();
+
+  const updateHandlers = sockets[0]?.evHandlers.get('connection.update');
+  expect(updateHandlers).toHaveLength(1);
+
+  updateHandlers?.[0]?.({
+    connection: 'close',
+    lastDisconnect: {
+      error: { output: { statusCode: 408 } },
+      date: new Date(),
+    },
+  });
+
+  expect(whatsappLogger.warn).toHaveBeenCalledWith(
+    'WhatsApp connection was lost. Retrying connection in 1s.',
+  );
+
+  await manager.stop();
+});
+
+test('suppresses buffer flush noise while WhatsApp is offline', async () => {
+  const { createWhatsAppConnectionManager, sockets, whatsappLogger } =
+    await importFreshConnectionModule({
+      logLevel: 'debug',
+      rootLevel: 'debug',
+    });
+
+  const manager = createWhatsAppConnectionManager();
+  await manager.start();
+
+  sockets[0]?.rawSocketEmitter.emit(
+    'error',
+    Object.assign(new Error('getaddrinfo ENOTFOUND web.whatsapp.com'), {
+      code: 'ENOTFOUND',
+      hostname: 'web.whatsapp.com',
+    }),
+  );
+
+  sockets[0]?.config.logger.warn({}, 'Buffer timeout reached, auto-flushing');
+  sockets[0]?.config.logger.debug({ bufferCount: 1 }, 'Flushing event buffer');
+  sockets[0]?.config.logger.debug({}, 'Event buffer activated');
+
+  expect(whatsappLogger.warn).not.toHaveBeenCalledWith(
+    'Buffer timeout reached, auto-flushing',
+  );
+  expect(whatsappLogger.debug).not.toHaveBeenCalledWith(
+    { bufferCount: 1 },
+    'Flushing event buffer',
+  );
+  expect(whatsappLogger.debug).not.toHaveBeenCalledWith(
+    {},
+    'Event buffer activated',
+  );
+
+  await manager.stop();
 });
 
 test('info-level WhatsApp logs omit structured metadata', async () => {

--- a/tests/whatsapp.connection.test.ts
+++ b/tests/whatsapp.connection.test.ts
@@ -411,7 +411,9 @@ test('suppresses buffer flush noise while WhatsApp is offline', async () => {
     { bufferCount: 1 },
     'Flushing event buffer',
   );
-  expect(whatsappLogger.debug).not.toHaveBeenCalledWith('Event buffer activated');
+  expect(whatsappLogger.debug).not.toHaveBeenCalledWith(
+    'Event buffer activated',
+  );
 
   await manager.stop();
 });


### PR DESCRIPTION
## Summary
- add a shared classifier for expected websocket and network transport failures
- add explicit local handlers for both Discord client `error` and Discord `shardError` transport events so reconnect churn is logged instead of bubbling
- keep expected transport exceptions out of the fatal `uncaughtException` exit path and add regression coverage

## Root cause
Normal transport failures such as `Opening handshake has timed out` could escape local handling and reach the global uncaught-exception path, which treated them as process-fatal and exited the gateway. This fix also closes the gap where Discord shard-level transport failures were not handled explicitly.

## Impact
The gateway stays up through transient websocket and network issues while still logging unexpected failures at error or fatal severity.

## Validation
- `npm run format`
- `npm run typecheck`
- `../../node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/transport-errors.test.ts tests/discord.error-handler.test.ts tests/logger.test.ts`
