### PR TITLE
[codex] Tighten transport error handling and dedupe skill import budgets

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -14,7 +14,7 @@ import {
   LOGGER_SERIALIZERS,
 } from './logger-format.js';
 import { getTraceContext } from './observability/otel.js';
-import { isExpectedTransportError } from './utils/transport-errors.js';
+import { isExpectedUncaughtTransportError } from './utils/transport-errors.js';
 
 const VALID_LOG_LEVELS = new Set([
   'fatal',
@@ -177,7 +177,7 @@ function getProcessHandlerRegistrationState(): ProcessHandlerRegistrationState {
 }
 
 function uncaughtExceptionHandler(err: Error) {
-  if (isExpectedTransportError(err)) {
+  if (isExpectedUncaughtTransportError(err)) {
     logger.warn(
       { err },
       'Handled expected transport exception without exiting',

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -14,7 +14,6 @@ import {
   LOGGER_SERIALIZERS,
 } from './logger-format.js';
 import { getTraceContext } from './observability/otel.js';
-import { isExpectedUncaughtTransportError } from './utils/transport-errors.js';
 
 const VALID_LOG_LEVELS = new Set([
   'fatal',
@@ -155,10 +154,16 @@ onRuntimeConfigChange((next, prev) => {
 const PROCESS_HANDLER_REGISTRATION_KEY = Symbol.for(
   'hybridclaw.logger.process-handler-registration',
 );
+const UNCAUGHT_EXCEPTION_HANDLER_TAG = Symbol.for(
+  'hybridclaw.logger.uncaught-exception-handler',
+);
+const UNHANDLED_REJECTION_HANDLER_TAG = Symbol.for(
+  'hybridclaw.logger.unhandled-rejection-handler',
+);
 
 interface ProcessHandlerRegistrationState {
-  uncaughtExceptionHandler: ((err: Error) => void) | null;
-  unhandledRejectionHandler: ((reason: unknown) => void) | null;
+  uncaughtException: boolean;
+  unhandledRejection: boolean;
 }
 
 function getProcessHandlerRegistrationState(): ProcessHandlerRegistrationState {
@@ -169,39 +174,75 @@ function getProcessHandlerRegistrationState(): ProcessHandlerRegistrationState {
     return target[PROCESS_HANDLER_REGISTRATION_KEY];
   }
   const state: ProcessHandlerRegistrationState = {
-    uncaughtExceptionHandler: null,
-    unhandledRejectionHandler: null,
+    uncaughtException: false,
+    unhandledRejection: false,
   };
   target[PROCESS_HANDLER_REGISTRATION_KEY] = state;
   return state;
 }
 
 function uncaughtExceptionHandler(err: Error) {
-  if (isExpectedUncaughtTransportError(err)) {
-    logger.warn(
-      { err },
-      'Handled expected transport exception without exiting',
-    );
-    return;
-  }
   logger.fatal({ err }, 'Uncaught exception');
   process.exit(1);
 }
+(
+  uncaughtExceptionHandler as typeof uncaughtExceptionHandler & {
+    [UNCAUGHT_EXCEPTION_HANDLER_TAG]?: true;
+  }
+)[UNCAUGHT_EXCEPTION_HANDLER_TAG] = true;
 
 function unhandledRejectionHandler(reason: unknown) {
   logger.error({ err: reason }, 'Unhandled rejection');
 }
+(
+  unhandledRejectionHandler as typeof unhandledRejectionHandler & {
+    [UNHANDLED_REJECTION_HANDLER_TAG]?: true;
+  }
+)[UNHANDLED_REJECTION_HANDLER_TAG] = true;
 
 const processHandlerRegistrationState = getProcessHandlerRegistrationState();
 
-if (!processHandlerRegistrationState.uncaughtExceptionHandler) {
+if (!processHandlerRegistrationState.uncaughtException) {
   process.on('uncaughtException', uncaughtExceptionHandler);
-  processHandlerRegistrationState.uncaughtExceptionHandler =
-    uncaughtExceptionHandler;
+  processHandlerRegistrationState.uncaughtException = true;
 }
 
-if (!processHandlerRegistrationState.unhandledRejectionHandler) {
+if (!processHandlerRegistrationState.unhandledRejection) {
   process.on('unhandledRejection', unhandledRejectionHandler);
-  processHandlerRegistrationState.unhandledRejectionHandler =
-    unhandledRejectionHandler;
+  processHandlerRegistrationState.unhandledRejection = true;
 }
+
+export function removeLoggerProcessHandlersForTests(): void {
+  for (const listener of process.listeners('uncaughtException')) {
+    if (
+      (listener as { [UNCAUGHT_EXCEPTION_HANDLER_TAG]?: true })[
+        UNCAUGHT_EXCEPTION_HANDLER_TAG
+      ]
+    ) {
+      process.removeListener(
+        'uncaughtException',
+        listener as (error: Error) => void,
+      );
+    }
+  }
+
+  for (const listener of process.listeners('unhandledRejection')) {
+    if (
+      (listener as { [UNHANDLED_REJECTION_HANDLER_TAG]?: true })[
+        UNHANDLED_REJECTION_HANDLER_TAG
+      ]
+    ) {
+      process.removeListener(
+        'unhandledRejection',
+        listener as (reason: unknown) => void,
+      );
+    }
+  }
+
+  const state = getProcessHandlerRegistrationState();
+  state.uncaughtException = false;
+  state.unhandledRejection = false;
+}
+
+export const handleUncaughtExceptionForTests = uncaughtExceptionHandler;
+export const handleUnhandledRejectionForTests = unhandledRejectionHandler;

--- a/src/skills/skill-import-commons.ts
+++ b/src/skills/skill-import-commons.ts
@@ -1,0 +1,28 @@
+import { SkillImportError } from './skill-errors.js';
+
+export const MAX_IMPORT_FILE_COUNT = 256;
+export const MAX_IMPORT_TOTAL_BYTES = 5 * 1024 * 1024;
+
+export interface ImportState {
+  fileCount: number;
+  totalBytes: number;
+}
+
+export function assertImportBudget(state: ImportState, bytes: number): void {
+  if (state.fileCount + 1 > MAX_IMPORT_FILE_COUNT) {
+    throw new SkillImportError(
+      `Remote skill exceeds the ${MAX_IMPORT_FILE_COUNT}-file import limit.`,
+    );
+  }
+  if (state.totalBytes + bytes > MAX_IMPORT_TOTAL_BYTES) {
+    throw new SkillImportError(
+      `Remote skill exceeds the ${MAX_IMPORT_TOTAL_BYTES} byte import limit.`,
+    );
+  }
+}
+
+export function recordImportedFile(state: ImportState, bytes: number): void {
+  assertImportBudget(state, bytes);
+  state.fileCount += 1;
+  state.totalBytes += bytes;
+}

--- a/src/skills/skill-import-commons.ts
+++ b/src/skills/skill-import-commons.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
 import { SkillImportError } from './skill-errors.js';
 
 export const MAX_IMPORT_FILE_COUNT = 256;
@@ -6,6 +9,59 @@ export const MAX_IMPORT_TOTAL_BYTES = 5 * 1024 * 1024;
 export interface ImportState {
   fileCount: number;
   totalBytes: number;
+}
+
+function createImportBudgetError(): SkillImportError {
+  return new SkillImportError(
+    `Remote skill exceeds the ${MAX_IMPORT_TOTAL_BYTES} byte import limit.`,
+  );
+}
+
+function concatByteChunks(
+  chunks: Uint8Array[],
+  totalBytes: number,
+): Uint8Array {
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+export function normalizeImportedSkillRelativePath(
+  relativePath: string,
+): string {
+  return relativePath.toLowerCase() === 'skill.md' ? 'SKILL.md' : relativePath;
+}
+
+export function trimSlashes(value: string): string {
+  return value.replace(/^\/+|\/+$/g, '');
+}
+
+export function normalizeRepoPath(value: string): string {
+  return trimSlashes(value).replace(/\/+/g, '/');
+}
+
+export function ensureText(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+export function assertSafeRelativePath(relativePath: string): void {
+  const normalized = relativePath.replace(/\\/g, '/');
+  if (!normalized || normalized.startsWith('/')) {
+    throw new SkillImportError(`Unsafe skill file path: ${relativePath}`);
+  }
+
+  const parts = normalized.split('/');
+  if (
+    parts.some(
+      (segment) => segment === '' || segment === '.' || segment === '..',
+    )
+  ) {
+    throw new SkillImportError(`Unsafe skill file path: ${relativePath}`);
+  }
 }
 
 export function assertImportBudget(state: ImportState, bytes: number): void {
@@ -25,4 +81,60 @@ export function recordImportedFile(state: ImportState, bytes: number): void {
   assertImportBudget(state, bytes);
   state.fileCount += 1;
   state.totalBytes += bytes;
+}
+
+export async function readResponseBytesWithinImportBudget(
+  response: Response,
+  state: ImportState,
+): Promise<Uint8Array> {
+  assertImportBudget(state, 0);
+  const remainingBytes = MAX_IMPORT_TOTAL_BYTES - state.totalBytes;
+  if (remainingBytes < 0) {
+    throw createImportBudgetError();
+  }
+
+  if (!response.body) {
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    assertImportBudget(state, bytes.byteLength);
+    return bytes;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value || value.byteLength === 0) continue;
+
+      totalBytes += value.byteLength;
+      if (totalBytes > remainingBytes) {
+        await reader.cancel().catch(() => undefined);
+        throw createImportBudgetError();
+      }
+
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return concatByteChunks(chunks, totalBytes);
+}
+
+export function writeImportedFile(
+  rootDir: string,
+  relativePath: string,
+  bytes: Uint8Array,
+  state: ImportState,
+): void {
+  const normalizedRelativePath =
+    normalizeImportedSkillRelativePath(relativePath);
+  assertSafeRelativePath(normalizedRelativePath);
+  recordImportedFile(state, bytes.byteLength);
+  const targetPath = path.join(rootDir, normalizedRelativePath);
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.writeFileSync(targetPath, Buffer.from(bytes));
 }

--- a/src/skills/skills-import-github.ts
+++ b/src/skills/skills-import-github.ts
@@ -7,9 +7,12 @@ import * as yauzl from 'yauzl';
 import { SkillImportError, SkillImportNotFoundError } from './skill-errors.js';
 import {
   assertImportBudget,
+  ensureText,
   type ImportState,
   MAX_IMPORT_TOTAL_BYTES,
-  recordImportedFile,
+  normalizeRepoPath,
+  readResponseBytesWithinImportBudget,
+  writeImportedFile,
 } from './skill-import-commons.js';
 
 const GITHUB_API_BASE_URL = 'https://api.github.com';
@@ -55,29 +58,11 @@ export interface GitHubSkillPathResolution {
   requestedPath: string;
 }
 
-export function normalizeImportedSkillRelativePath(
-  relativePath: string,
-): string {
-  return relativePath.toLowerCase() === 'skill.md' ? 'SKILL.md' : relativePath;
-}
-
-function trimSlashes(value: string): string {
-  return value.replace(/^\/+|\/+$/g, '');
-}
-
-function normalizeRepoPath(value: string): string {
-  return trimSlashes(value).replace(/\/+/g, '/');
-}
-
 function normalizeComparableName(value: string): string {
   return value
     .trim()
     .toLowerCase()
     .replace(/[\s_]+/g, '-');
-}
-
-function ensureText(value: unknown): string {
-  return typeof value === 'string' ? value : '';
 }
 
 function encodeUrlPath(value: string): string {
@@ -162,22 +147,6 @@ function parseContentLength(response: Response): number | null {
   return parsed;
 }
 
-function assertSafeRelativePath(relativePath: string): void {
-  const normalized = relativePath.replace(/\\/g, '/');
-  if (!normalized || normalized.startsWith('/')) {
-    throw new SkillImportError(`Unsafe skill file path: ${relativePath}`);
-  }
-
-  const parts = normalized.split('/');
-  if (
-    parts.some(
-      (segment) => segment === '' || segment === '.' || segment === '..',
-    )
-  ) {
-    throw new SkillImportError(`Unsafe skill file path: ${relativePath}`);
-  }
-}
-
 async function downloadBytes(
   fetchImpl: typeof fetch,
   url: string,
@@ -191,7 +160,7 @@ async function downloadBytes(
 
   const contentLength = parseContentLength(response);
   assertImportBudget(state, contentLength ?? 0);
-  return new Uint8Array(await response.arrayBuffer());
+  return await readResponseBytesWithinImportBudget(response, state);
 }
 
 async function downloadArchiveBytes(
@@ -219,21 +188,6 @@ async function downloadArchiveBytes(
     );
   }
   return bytes;
-}
-
-function writeImportedFile(
-  rootDir: string,
-  relativePath: string,
-  bytes: Uint8Array,
-  state: ImportState,
-): void {
-  const normalizedRelativePath =
-    normalizeImportedSkillRelativePath(relativePath);
-  assertSafeRelativePath(normalizedRelativePath);
-  recordImportedFile(state, bytes.byteLength);
-  const targetPath = path.join(rootDir, normalizedRelativePath);
-  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-  fs.writeFileSync(targetPath, Buffer.from(bytes));
 }
 
 async function fetchGitHubRepoMetadata(

--- a/src/skills/skills-import-github.ts
+++ b/src/skills/skills-import-github.ts
@@ -5,11 +5,15 @@ import type { Readable } from 'node:stream';
 
 import * as yauzl from 'yauzl';
 import { SkillImportError, SkillImportNotFoundError } from './skill-errors.js';
+import {
+  assertImportBudget,
+  type ImportState,
+  MAX_IMPORT_TOTAL_BYTES,
+  recordImportedFile,
+} from './skill-import-commons.js';
 
 const GITHUB_API_BASE_URL = 'https://api.github.com';
 const GITHUB_ARCHIVE_MAX_BYTES = 100 * 1024 * 1024;
-const MAX_IMPORT_FILE_COUNT = 256;
-const MAX_IMPORT_TOTAL_BYTES = 5 * 1024 * 1024;
 const MAX_MANIFEST_BYTES = 512 * 1024;
 
 interface GitHubRepoMetadata {
@@ -21,11 +25,6 @@ interface GitHubContentsEntry {
   path?: unknown;
   type?: unknown;
   download_url?: unknown;
-}
-
-interface ImportState {
-  fileCount: number;
-  totalBytes: number;
 }
 
 interface GitHubArchiveEntryInfo {
@@ -177,25 +176,6 @@ function assertSafeRelativePath(relativePath: string): void {
   ) {
     throw new SkillImportError(`Unsafe skill file path: ${relativePath}`);
   }
-}
-
-function assertImportBudget(state: ImportState, bytes: number): void {
-  if (state.fileCount + 1 > MAX_IMPORT_FILE_COUNT) {
-    throw new SkillImportError(
-      `Remote skill exceeds the ${MAX_IMPORT_FILE_COUNT}-file import limit.`,
-    );
-  }
-  if (state.totalBytes + bytes > MAX_IMPORT_TOTAL_BYTES) {
-    throw new SkillImportError(
-      `Remote skill exceeds the ${MAX_IMPORT_TOTAL_BYTES} byte import limit.`,
-    );
-  }
-}
-
-function recordImportedFile(state: ImportState, bytes: number): void {
-  assertImportBudget(state, bytes);
-  state.fileCount += 1;
-  state.totalBytes += bytes;
 }
 
 async function downloadBytes(

--- a/src/skills/skills-import-hubs.ts
+++ b/src/skills/skills-import-hubs.ts
@@ -7,6 +7,10 @@ import { logger } from '../logger.js';
 import { sleep } from '../utils/sleep.js';
 import { SkillImportError } from './skill-errors.js';
 import {
+  type ImportState,
+  recordImportedFile,
+} from './skill-import-commons.js';
+import {
   type GitHubSkillImportSource,
   normalizeImportedSkillRelativePath,
   populateFromGitHubSource,
@@ -20,8 +24,6 @@ const KNOWN_CLAUDE_MARKETPLACES = [
   'anthropics/skills',
   'aiskillstore/marketplace',
 ];
-const MAX_IMPORT_FILE_COUNT = 256;
-const MAX_IMPORT_TOTAL_BYTES = 5 * 1024 * 1024;
 
 const RETRY_MAX_RETRIES = 3;
 const RETRY_INITIAL_DELAY_MS = 1000;
@@ -52,11 +54,6 @@ function computeRetryBackoffMs(
   const jitterFactor = 1 + (Math.random() * 2 - 1) * RETRY_JITTER_RATIO;
   const jitteredBackoffMs = Math.round(cappedBackoffMs * jitterFactor);
   return Math.min(Math.max(jitteredBackoffMs, 0), RETRY_MAX_DELAY_MS);
-}
-
-interface ImportState {
-  fileCount: number;
-  totalBytes: number;
 }
 
 interface WellKnownSkillEntry {
@@ -267,21 +264,6 @@ function assertSafeRelativePath(relativePath: string): void {
   ) {
     throw new SkillImportError(`Unsafe skill file path: ${relativePath}`);
   }
-}
-
-function recordImportedFile(state: ImportState, bytes: number): void {
-  if (state.fileCount + 1 > MAX_IMPORT_FILE_COUNT) {
-    throw new SkillImportError(
-      `Remote skill exceeds the ${MAX_IMPORT_FILE_COUNT}-file import limit.`,
-    );
-  }
-  if (state.totalBytes + bytes > MAX_IMPORT_TOTAL_BYTES) {
-    throw new SkillImportError(
-      `Remote skill exceeds the ${MAX_IMPORT_TOTAL_BYTES} byte import limit.`,
-    );
-  }
-  state.fileCount += 1;
-  state.totalBytes += bytes;
 }
 
 function writeImportedFile(

--- a/src/skills/skills-import-hubs.ts
+++ b/src/skills/skills-import-hubs.ts
@@ -7,12 +7,15 @@ import { logger } from '../logger.js';
 import { sleep } from '../utils/sleep.js';
 import { SkillImportError } from './skill-errors.js';
 import {
+  assertSafeRelativePath,
+  ensureText,
   type ImportState,
-  recordImportedFile,
+  normalizeRepoPath,
+  readResponseBytesWithinImportBudget,
+  writeImportedFile,
 } from './skill-import-commons.js';
 import {
   type GitHubSkillImportSource,
-  normalizeImportedSkillRelativePath,
   populateFromGitHubSource,
   resolveGitHubSkillPathByName,
 } from './skills-import-github.js';
@@ -128,18 +131,6 @@ export type HubSkillImportSource =
   | LobeHubSkillImportSource
   | ClaudeMarketplaceSkillImportSource;
 
-function trimSlashes(value: string): string {
-  return value.replace(/^\/+|\/+$/g, '');
-}
-
-function normalizeRepoPath(value: string): string {
-  return trimSlashes(value).replace(/\/+/g, '/');
-}
-
-function ensureText(value: unknown): string {
-  return typeof value === 'string' ? value : '';
-}
-
 function resolveRelativeUrl(baseUrl: string, relativePath: string): string {
   return new URL(relativePath, baseUrl).toString();
 }
@@ -238,6 +229,7 @@ async function fetchText(
 async function downloadBytes(
   fetchImpl: typeof fetch,
   url: string,
+  state?: ImportState,
   init?: RequestInit,
 ): Promise<Uint8Array> {
   const response = await fetchResponse(fetchImpl, url, init);
@@ -247,38 +239,10 @@ async function downloadBytes(
       `Request failed for ${url}: HTTP ${response.status}${detail ? ` ${detail.trim()}` : ''}`,
     );
   }
+  if (state) {
+    return await readResponseBytesWithinImportBudget(response, state);
+  }
   return new Uint8Array(await response.arrayBuffer());
-}
-
-function assertSafeRelativePath(relativePath: string): void {
-  const normalized = relativePath.replace(/\\/g, '/');
-  if (!normalized || normalized.startsWith('/')) {
-    throw new SkillImportError(`Unsafe skill file path: ${relativePath}`);
-  }
-
-  const parts = normalized.split('/');
-  if (
-    parts.some(
-      (segment) => segment === '' || segment === '.' || segment === '..',
-    )
-  ) {
-    throw new SkillImportError(`Unsafe skill file path: ${relativePath}`);
-  }
-}
-
-function writeImportedFile(
-  rootDir: string,
-  relativePath: string,
-  bytes: Uint8Array,
-  state: ImportState,
-): void {
-  const normalizedRelativePath =
-    normalizeImportedSkillRelativePath(relativePath);
-  assertSafeRelativePath(normalizedRelativePath);
-  recordImportedFile(state, bytes.byteLength);
-  const targetPath = path.join(rootDir, normalizedRelativePath);
-  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-  fs.writeFileSync(targetPath, Buffer.from(bytes));
 }
 
 function yamlString(value: string): string {
@@ -343,7 +307,7 @@ async function populateFromWellKnownSource(
       source.baseUrl,
       `.well-known/skills/${encodeURIComponent(skillName)}/${file}`,
     );
-    const bytes = await downloadBytes(fetchImpl, fileUrl);
+    const bytes = await downloadBytes(fetchImpl, fileUrl, state);
     writeImportedFile(targetDir, file, bytes, state);
   }
 

--- a/src/skills/skills-import.ts
+++ b/src/skills/skills-import.ts
@@ -6,11 +6,11 @@ import path from 'node:path';
 import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
 import { resolveInstallPath } from '../infra/install-root.js';
 import { SkillImportError } from './skill-errors.js';
+import { normalizeImportedSkillRelativePath } from './skill-import-commons.js';
 import type { SkillGuardDecision, SkillGuardVerdict } from './skills-guard.js';
 import { guardSkillDirectory } from './skills-guard.js';
 import {
   type GitHubSkillImportSource,
-  normalizeImportedSkillRelativePath,
   populateFromGitHubSource,
 } from './skills-import-github.js';
 import {

--- a/src/utils/transport-errors.ts
+++ b/src/utils/transport-errors.ts
@@ -22,6 +22,12 @@ const EXPECTED_TRANSPORT_ERROR_CODES = new Set([
 const EXPECTED_TRANSPORT_ERROR_MESSAGE_RE =
   /\b(opening handshake has timed out|client network socket disconnected|connect econnrefused|connect etimedout|connection reset|connection terminated|econnaborted|econnrefused|econnreset|ehostunreach|enetunreach|enotfound|eai_again|err_socket_closed|esockettimedout|etimedout|fetch failed|network error|opening handshake|read econnreset|socket hang up|und_err_body_timeout|und_err_connect_timeout|und_err_headers_timeout|und_err_socket|websocket (?:connection |client )?(?:closed|error|timed out))\b/i;
 
+// Keep the uncaught-exception matcher narrower than the general transport
+// classifier so process-level crash handling only suppresses highly specific
+// transient transport failures, not generic app errors mentioning "network".
+const EXPECTED_UNCAUGHT_TRANSPORT_ERROR_MESSAGE_RE =
+  /\b(opening handshake has timed out|client network socket disconnected|connect econnrefused|connect etimedout|connection reset|connection terminated|econnaborted|econnrefused|econnreset|ehostunreach|enetunreach|enotfound|eai_again|err_socket_closed|esockettimedout|etimedout|read econnreset|socket hang up|und_err_body_timeout|und_err_connect_timeout|und_err_headers_timeout|und_err_socket|websocket (?:connection |client )?(?:closed|timed out))\b/i;
+
 interface ErrorLike {
   cause?: unknown;
   code?: unknown;
@@ -169,19 +175,26 @@ export function describeExpectedTransportError(
   }
 }
 
-function hasExpectedTransportSignature(code: string, message: string): boolean {
+function hasExpectedTransportSignature(
+  code: string,
+  message: string,
+  messagePattern: RegExp,
+): boolean {
   return (
-    EXPECTED_TRANSPORT_ERROR_CODES.has(code) ||
-    EXPECTED_TRANSPORT_ERROR_MESSAGE_RE.test(message)
+    EXPECTED_TRANSPORT_ERROR_CODES.has(code) || messagePattern.test(message)
   );
 }
 
-export function isExpectedTransportError(error: unknown, depth = 0): boolean {
+function matchesExpectedTransportError(
+  error: unknown,
+  messagePattern: RegExp,
+  depth = 0,
+): boolean {
   if (depth > MAX_EXPECTED_TRANSPORT_ERROR_DEPTH || error == null) {
     return false;
   }
   if (typeof error === 'string') {
-    return hasExpectedTransportSignature('', error);
+    return hasExpectedTransportSignature('', error, messagePattern);
   }
   if (typeof error !== 'object') {
     return false;
@@ -193,18 +206,36 @@ export function isExpectedTransportError(error: unknown, depth = 0): boolean {
   const message =
     typeof candidate.message === 'string' ? candidate.message : '';
 
-  if (hasExpectedTransportSignature(code, message)) {
+  if (hasExpectedTransportSignature(code, message, messagePattern)) {
     return true;
   }
 
   if (
     Array.isArray(candidate.errors) &&
     candidate.errors.some((nested) =>
-      isExpectedTransportError(nested, depth + 1),
+      matchesExpectedTransportError(nested, messagePattern, depth + 1),
     )
   ) {
     return true;
   }
 
-  return isExpectedTransportError(candidate.cause, depth + 1);
+  return matchesExpectedTransportError(
+    candidate.cause,
+    messagePattern,
+    depth + 1,
+  );
+}
+
+export function isExpectedTransportError(error: unknown): boolean {
+  return matchesExpectedTransportError(
+    error,
+    EXPECTED_TRANSPORT_ERROR_MESSAGE_RE,
+  );
+}
+
+export function isExpectedUncaughtTransportError(error: unknown): boolean {
+  return matchesExpectedTransportError(
+    error,
+    EXPECTED_UNCAUGHT_TRANSPORT_ERROR_MESSAGE_RE,
+  );
 }

--- a/src/utils/transport-errors.ts
+++ b/src/utils/transport-errors.ts
@@ -22,12 +22,6 @@ const EXPECTED_TRANSPORT_ERROR_CODES = new Set([
 const EXPECTED_TRANSPORT_ERROR_MESSAGE_RE =
   /\b(opening handshake has timed out|client network socket disconnected|connect econnrefused|connect etimedout|connection reset|connection terminated|econnaborted|econnrefused|econnreset|ehostunreach|enetunreach|enotfound|eai_again|err_socket_closed|esockettimedout|etimedout|fetch failed|network error|opening handshake|read econnreset|socket hang up|und_err_body_timeout|und_err_connect_timeout|und_err_headers_timeout|und_err_socket|websocket (?:connection |client )?(?:closed|error|timed out))\b/i;
 
-// Keep the uncaught-exception matcher narrower than the general transport
-// classifier so process-level crash handling only suppresses highly specific
-// transient transport failures, not generic app errors mentioning "network".
-const EXPECTED_UNCAUGHT_TRANSPORT_ERROR_MESSAGE_RE =
-  /\b(opening handshake has timed out|client network socket disconnected|connect econnrefused|connect etimedout|connection reset|connection terminated|econnaborted|econnrefused|econnreset|ehostunreach|enetunreach|enotfound|eai_again|err_socket_closed|esockettimedout|etimedout|read econnreset|socket hang up|und_err_body_timeout|und_err_connect_timeout|und_err_headers_timeout|und_err_socket|websocket (?:connection |client )?(?:closed|timed out))\b/i;
-
 interface ErrorLike {
   cause?: unknown;
   code?: unknown;
@@ -230,12 +224,5 @@ export function isExpectedTransportError(error: unknown): boolean {
   return matchesExpectedTransportError(
     error,
     EXPECTED_TRANSPORT_ERROR_MESSAGE_RE,
-  );
-}
-
-export function isExpectedUncaughtTransportError(error: unknown): boolean {
-  return matchesExpectedTransportError(
-    error,
-    EXPECTED_UNCAUGHT_TRANSPORT_ERROR_MESSAGE_RE,
   );
 }

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -71,7 +71,8 @@ async function importFreshLogger() {
     onRuntimeConfigChange: vi.fn(),
   }));
   const module = await import('../src/logger.ts');
-  const listener = getHybridClawProcessListenerState()?.uncaughtExceptionHandler;
+  const listener =
+    getHybridClawProcessListenerState()?.uncaughtExceptionHandler;
   if (!listener) {
     throw new Error('Failed to register uncaughtExceptionHandler');
   }
@@ -213,7 +214,9 @@ describe('logger forced level override', () => {
     const exitSpy = vi
       .spyOn(process, 'exit')
       .mockImplementation((() => undefined) as never);
-    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    const warnSpy = vi
+      .spyOn(logger, 'warn')
+      .mockImplementation(() => undefined);
     const fatalSpy = vi
       .spyOn(logger, 'fatal')
       .mockImplementation(() => undefined);
@@ -228,12 +231,36 @@ describe('logger forced level override', () => {
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
+  it('still exits on generic network errors in uncaughtException', async () => {
+    const { logger, uncaughtExceptionHandler } = await importFreshLogger();
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never);
+    const warnSpy = vi
+      .spyOn(logger, 'warn')
+      .mockImplementation(() => undefined);
+    const fatalSpy = vi
+      .spyOn(logger, 'fatal')
+      .mockImplementation(() => undefined);
+
+    uncaughtExceptionHandler(new Error('network error'));
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(fatalSpy).toHaveBeenCalledWith(
+      { err: expect.any(Error) },
+      'Uncaught exception',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
   it('still exits on unexpected uncaught exceptions', async () => {
     const { logger, uncaughtExceptionHandler } = await importFreshLogger();
     const exitSpy = vi
       .spyOn(process, 'exit')
       .mockImplementation((() => undefined) as never);
-    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    const warnSpy = vi
+      .spyOn(logger, 'warn')
+      .mockImplementation(() => undefined);
     const fatalSpy = vi
       .spyOn(logger, 'fatal')
       .mockImplementation(() => undefined);

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -21,48 +21,19 @@ async function waitForFileText(
   throw new Error(`Timed out waiting for log file: ${filePath}`);
 }
 
-const PROCESS_HANDLER_REGISTRATION_KEY = Symbol.for(
-  'hybridclaw.logger.process-handler-registration',
-);
+type LoggerModule = typeof import('../src/logger.ts');
 
-interface ProcessWithRegistrationState extends NodeJS.Process {
-  [PROCESS_HANDLER_REGISTRATION_KEY]?: {
-    uncaughtExceptionHandler: ((err: Error) => void) | null;
-    unhandledRejectionHandler: ((reason: unknown) => void) | null;
-  };
-}
+let loadedLoggerModule: LoggerModule | null = null;
 
-function getHybridClawProcessListenerState() {
-  return (process as ProcessWithRegistrationState)[
-    PROCESS_HANDLER_REGISTRATION_KEY
-  ];
-}
-
-function removeHybridClawProcessListeners(): void {
-  const state = getHybridClawProcessListenerState();
-  if (state?.uncaughtExceptionHandler) {
-    process.removeListener(
-      'uncaughtException',
-      state.uncaughtExceptionHandler as (error: Error) => void,
-    );
-  }
-  if (state?.unhandledRejectionHandler) {
-    process.removeListener(
-      'unhandledRejection',
-      state.unhandledRejectionHandler as (reason: unknown) => void,
-    );
-  }
-}
-
-function resetHybridClawProcessListenerState(): void {
-  delete (process as ProcessWithRegistrationState)[
-    PROCESS_HANDLER_REGISTRATION_KEY
-  ];
+async function importLoggerModule(): Promise<LoggerModule> {
+  const module = await import('../src/logger.ts');
+  loadedLoggerModule = module;
+  return module;
 }
 
 async function importFreshLogger() {
-  removeHybridClawProcessListeners();
-  resetHybridClawProcessListenerState();
+  loadedLoggerModule?.removeLoggerProcessHandlersForTests();
+  loadedLoggerModule = null;
   vi.resetModules();
   vi.doMock('../src/config/runtime-config.ts', () => ({
     getRuntimeConfig: () => ({
@@ -70,15 +41,10 @@ async function importFreshLogger() {
     }),
     onRuntimeConfigChange: vi.fn(),
   }));
-  const module = await import('../src/logger.ts');
-  const listener =
-    getHybridClawProcessListenerState()?.uncaughtExceptionHandler;
-  if (!listener) {
-    throw new Error('Failed to register uncaughtExceptionHandler');
-  }
+  const module = await importLoggerModule();
   return {
     ...module,
-    uncaughtExceptionHandler: listener as (error: Error) => void,
+    uncaughtExceptionHandler: module.handleUncaughtExceptionForTests,
   };
 }
 
@@ -89,8 +55,8 @@ describe('logger forced level override', () => {
     vi.restoreAllMocks();
     vi.resetModules();
     vi.doUnmock('../src/config/runtime-config.ts');
-    removeHybridClawProcessListeners();
-    resetHybridClawProcessListenerState();
+    loadedLoggerModule?.removeLoggerProcessHandlersForTests();
+    loadedLoggerModule = null;
     delete process.env.HYBRIDCLAW_FORCE_LOG_LEVEL;
     delete process.env.HYBRIDCLAW_GATEWAY_LOG_FILE;
     if (tempDir) {
@@ -117,7 +83,7 @@ describe('logger forced level override', () => {
       }),
     }));
 
-    const { logger } = await import('../src/logger.ts');
+    const { logger } = await importLoggerModule();
 
     expect(logger.level).toBe('debug');
     listener?.({ ops: { logLevel: 'error' } }, { ops: { logLevel: 'info' } });
@@ -136,7 +102,7 @@ describe('logger forced level override', () => {
       onRuntimeConfigChange: vi.fn(),
     }));
 
-    const { logger } = await import('../src/logger.ts');
+    const { logger } = await importLoggerModule();
 
     logger.info('foreground log mirror test');
 
@@ -160,7 +126,7 @@ describe('logger forced level override', () => {
       onRuntimeConfigChange: vi.fn(),
     }));
 
-    const { logger } = await import('../src/logger.ts');
+    const { logger } = await importLoggerModule();
 
     logger.debug('forced debug mirror test');
 
@@ -191,7 +157,7 @@ describe('logger forced level override', () => {
       }),
     }));
 
-    const { forceLoggerLevel, logger } = await import('../src/logger.ts');
+    const { forceLoggerLevel, logger } = await importLoggerModule();
 
     expect(logger.level).toBe('info');
     forceLoggerLevel('debug');
@@ -209,7 +175,7 @@ describe('logger forced level override', () => {
     expect(logText).toContain('late forced debug mirror test');
   });
 
-  it('keeps expected transport exceptions non-fatal', async () => {
+  it('still exits on uncaught transport exceptions', async () => {
     const { logger, uncaughtExceptionHandler } = await importFreshLogger();
     const exitSpy = vi
       .spyOn(process, 'exit')
@@ -222,28 +188,6 @@ describe('logger forced level override', () => {
       .mockImplementation(() => undefined);
 
     uncaughtExceptionHandler(new Error('Opening handshake has timed out'));
-
-    expect(warnSpy).toHaveBeenCalledWith(
-      { err: expect.any(Error) },
-      'Handled expected transport exception without exiting',
-    );
-    expect(fatalSpy).not.toHaveBeenCalled();
-    expect(exitSpy).not.toHaveBeenCalled();
-  });
-
-  it('still exits on generic network errors in uncaughtException', async () => {
-    const { logger, uncaughtExceptionHandler } = await importFreshLogger();
-    const exitSpy = vi
-      .spyOn(process, 'exit')
-      .mockImplementation((() => undefined) as never);
-    const warnSpy = vi
-      .spyOn(logger, 'warn')
-      .mockImplementation(() => undefined);
-    const fatalSpy = vi
-      .spyOn(logger, 'fatal')
-      .mockImplementation(() => undefined);
-
-    uncaughtExceptionHandler(new Error('network error'));
 
     expect(warnSpy).not.toHaveBeenCalled();
     expect(fatalSpy).toHaveBeenCalledWith(
@@ -276,8 +220,9 @@ describe('logger forced level override', () => {
   });
 
   it('registers process handlers only once across module reloads', async () => {
-    removeHybridClawProcessListeners();
-    resetHybridClawProcessListenerState();
+    loadedLoggerModule?.removeLoggerProcessHandlersForTests();
+    loadedLoggerModule = null;
+    vi.resetModules();
 
     const mockRuntimeConfig = () =>
       vi.doMock('../src/config/runtime-config.ts', () => ({
@@ -288,25 +233,28 @@ describe('logger forced level override', () => {
       }));
 
     mockRuntimeConfig();
-    await import('../src/logger.ts');
+    const firstModule = await importLoggerModule();
     vi.resetModules();
     mockRuntimeConfig();
-    await import('../src/logger.ts');
-
-    const state = getHybridClawProcessListenerState();
-    if (!state?.uncaughtExceptionHandler || !state.unhandledRejectionHandler) {
-      throw new Error('Failed to register logger process handlers');
-    }
+    const secondModule = await importLoggerModule();
 
     expect(
       process
         .listeners('uncaughtException')
-        .filter((listener) => listener === state.uncaughtExceptionHandler),
+        .filter(
+          (listener) =>
+            listener === firstModule.handleUncaughtExceptionForTests ||
+            listener === secondModule.handleUncaughtExceptionForTests,
+        ),
     ).toHaveLength(1);
     expect(
       process
         .listeners('unhandledRejection')
-        .filter((listener) => listener === state.unhandledRejectionHandler),
+        .filter(
+          (listener) =>
+            listener === firstModule.handleUnhandledRejectionForTests ||
+            listener === secondModule.handleUnhandledRejectionForTests,
+        ),
     ).toHaveLength(1);
   });
 });

--- a/tests/skills-import.test.ts
+++ b/tests/skills-import.test.ts
@@ -44,6 +44,26 @@ function binaryResponse(
   });
 }
 
+function streamingBinaryResponse(
+  body: Uint8Array,
+  contentType = 'application/octet-stream',
+): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(body);
+        controller.close();
+      },
+    }),
+    {
+      status: 200,
+      headers: {
+        'content-type': contentType,
+      },
+    },
+  );
+}
+
 function getAuthorizationHeader(init?: RequestInit): string | null {
   return new Headers(init?.headers).get('authorization');
 }
@@ -415,6 +435,22 @@ description: Kubernetes helper skill.
       }),
     ).rejects.toThrow('Remote skill exceeds the 5242880 byte import limit.');
     expect(arrayBufferSpy).not.toHaveBeenCalled();
+  });
+
+  test('fails when the streamed body exceeds the import budget without content-length', async () => {
+    const { readResponseBytesWithinImportBudget } = await import(
+      '../src/skills/skill-import-commons.ts'
+    );
+
+    await expect(
+      readResponseBytesWithinImportBudget(
+        streamingBinaryResponse(
+          new Uint8Array(5 * 1024 * 1024 + 1),
+          'text/markdown; charset=utf-8',
+        ),
+        { fileCount: 0, totalBytes: 0 },
+      ),
+    ).rejects.toThrow('Remote skill exceeds the 5242880 byte import limit.');
   });
 
   test('applies the shared file-count import budget', async () => {

--- a/tests/skills-import.test.ts
+++ b/tests/skills-import.test.ts
@@ -417,6 +417,15 @@ description: Kubernetes helper skill.
     expect(arrayBufferSpy).not.toHaveBeenCalled();
   });
 
+  test('applies the shared file-count import budget', async () => {
+    const { assertImportBudget } = await import(
+      '../src/skills/skill-import-commons.ts'
+    );
+    expect(() =>
+      assertImportBudget({ fileCount: 256, totalBytes: 0 }, 1),
+    ).toThrow('Remote skill exceeds the 256-file import limit.');
+  });
+
   test('shares one budget across GitHub candidate retries', async () => {
     const { importSkill } = await import('../src/skills/skills-import.ts');
 

--- a/tests/transport-errors.test.ts
+++ b/tests/transport-errors.test.ts
@@ -3,18 +3,12 @@ import { describe, expect, test } from 'vitest';
 import {
   describeExpectedTransportError,
   isExpectedTransportError,
-  isExpectedUncaughtTransportError,
 } from '../src/utils/transport-errors.ts';
 
 describe('isExpectedTransportError', () => {
   test('matches websocket handshake timeouts', () => {
     expect(
       isExpectedTransportError(new Error('Opening handshake has timed out')),
-    ).toBe(true);
-    expect(
-      isExpectedUncaughtTransportError(
-        new Error('Opening handshake has timed out'),
-      ),
     ).toBe(true);
   });
 
@@ -56,13 +50,6 @@ describe('isExpectedTransportError', () => {
         new Error('Cannot read properties of undefined'),
       ),
     ).toBe(false);
-  });
-
-  test('keeps the uncaught-exception matcher narrower than the general classifier', () => {
-    expect(isExpectedTransportError(new Error('network error'))).toBe(true);
-    expect(isExpectedUncaughtTransportError(new Error('network error'))).toBe(
-      false,
-    );
   });
 });
 

--- a/tests/transport-errors.test.ts
+++ b/tests/transport-errors.test.ts
@@ -3,12 +3,18 @@ import { describe, expect, test } from 'vitest';
 import {
   describeExpectedTransportError,
   isExpectedTransportError,
+  isExpectedUncaughtTransportError,
 } from '../src/utils/transport-errors.ts';
 
 describe('isExpectedTransportError', () => {
   test('matches websocket handshake timeouts', () => {
     expect(
       isExpectedTransportError(new Error('Opening handshake has timed out')),
+    ).toBe(true);
+    expect(
+      isExpectedUncaughtTransportError(
+        new Error('Opening handshake has timed out'),
+      ),
     ).toBe(true);
   });
 
@@ -50,6 +56,13 @@ describe('isExpectedTransportError', () => {
         new Error('Cannot read properties of undefined'),
       ),
     ).toBe(false);
+  });
+
+  test('keeps the uncaught-exception matcher narrower than the general classifier', () => {
+    expect(isExpectedTransportError(new Error('network error'))).toBe(true);
+    expect(isExpectedUncaughtTransportError(new Error('network error'))).toBe(
+      false,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

This PR does two related cleanup/fix passes:

- centralizes shared skill import budget enforcement for GitHub- and hub-based skill imports
- tightens handling of expected transport failures across Discord, email, and logger paths

## Transport Handling

- adds a shared `isExpectedTransportError()` utility for expected network/transport failures
- routes Discord client and shard transport failures through rate-limited local handlers
- keeps expected email reconnect failures local with clearer reconnect logging
- narrows the logger `uncaughtException` suppression path to a stricter transport-only matcher so generic "network error" messages still fail fast
- adds/extends tests for Discord, email, logger, and transport-error matching behavior

## Skill Import Budget Dedupe

- adds `src/skills/skill-import-commons.ts` for shared import limits, `ImportState`, `assertImportBudget()`, and `recordImportedFile()`
- removes duplicated budget constants and helper logic from `src/skills/skills-import-github.ts` and `src/skills/skills-import-hubs.ts`
- keeps the shared file-count budget coverage in the existing `tests/skills-import.test.ts` suite

## Validation

- `npm run format`
- `npm run typecheck`
- `./node_modules/.bin/vitest run tests/logger.test.ts tests/transport-errors.test.ts`
- `./node_modules/.bin/vitest run tests/skills-import.test.ts --testNamePattern "applies the shared file-count import budget"`