### PR TITLE
[codex] Share channel runtime lifecycle boilerplate

### DIFF
--- a/src/channels/channel-runtime-factory.ts
+++ b/src/channels/channel-runtime-factory.ts
@@ -2,39 +2,28 @@ import type { ChannelInfo, ChannelKind } from './channel.js';
 import { registerChannel } from './channel-registry.js';
 
 type MaybePromise<T> = T | Promise<T>;
-type Registration =
-  | string
-  | { id?: string | null; capabilities?: ChannelInfo['capabilities'] }
-  | null
-  | undefined;
-type BaseRuntimeOptions<Args extends unknown[]> = {
+type Registration = string | null | undefined;
+type BaseRuntimeOptions = {
   kind: ChannelKind;
   capabilities: ChannelInfo['capabilities'];
-  cleanup?: (...args: Args) => MaybePromise<void>;
+  cleanup?: () => MaybePromise<void>;
 };
-type RuntimeOptionsWithoutConfig<
-  Handler,
-  Args extends unknown[],
-> = BaseRuntimeOptions<Args> & {
+type RuntimeOptionsWithoutConfig<Handler> = BaseRuntimeOptions & {
   resolveConfig?: undefined;
   resolveRegistration?: () => MaybePromise<Registration>;
   start: (params: { handler: Handler }) => MaybePromise<void>;
 };
-type RuntimeOptionsWithConfig<
-  Handler,
-  Config,
-  Args extends unknown[],
-> = BaseRuntimeOptions<Args> & {
+type RuntimeOptionsWithConfig<Handler, Config> = BaseRuntimeOptions & {
   resolveConfig: () => MaybePromise<Config>;
   resolveRegistration?: (config: Config) => MaybePromise<Registration>;
   start: (params: { handler: Handler; config: Config }) => MaybePromise<void>;
 };
-type RuntimeOptions<Handler, Config, Args extends unknown[]> =
-  | RuntimeOptionsWithoutConfig<Handler, Args>
-  | RuntimeOptionsWithConfig<Handler, Config, Args>;
-type RuntimeLifecycle<Handler, Args extends unknown[]> = {
+type RuntimeOptions<Handler, Config> =
+  | RuntimeOptionsWithoutConfig<Handler>
+  | RuntimeOptionsWithConfig<Handler, Config>;
+type RuntimeLifecycle<Handler> = {
   init: (handler: Handler) => Promise<void>;
-  shutdown: (...args: Args) => Promise<void>;
+  shutdown: () => Promise<void>;
 };
 
 function registerResolvedChannel(
@@ -42,44 +31,32 @@ function registerResolvedChannel(
   capabilities: ChannelInfo['capabilities'],
   registration: Registration,
 ): void {
-  const resolved =
-    typeof registration === 'string' ? { id: registration } : registration;
   registerChannel({
     kind,
-    id: String(resolved?.id || kind).trim() || kind,
-    capabilities: resolved?.capabilities || capabilities,
+    id: String(registration || kind).trim() || kind,
+    capabilities,
   });
 }
 
-function hasResolvedConfig<Handler, Config, Args extends unknown[]>(
-  options: RuntimeOptions<Handler, Config, Args>,
-): options is RuntimeOptionsWithConfig<Handler, Config, Args> {
+function hasResolvedConfig<Handler, Config>(
+  options: RuntimeOptions<Handler, Config>,
+): options is RuntimeOptionsWithConfig<Handler, Config> {
   return typeof options.resolveConfig === 'function';
 }
 
-export function createChannelRuntime<
-  Handler = void,
-  Args extends unknown[] = [],
->(
-  options: RuntimeOptionsWithoutConfig<Handler, Args>,
-): RuntimeLifecycle<Handler, Args>;
-export function createChannelRuntime<
-  Handler,
-  Config,
-  Args extends unknown[] = [],
->(
-  options: RuntimeOptionsWithConfig<Handler, Config, Args>,
-): RuntimeLifecycle<Handler, Args>;
+export function createChannelRuntime<Handler = void>(
+  options: RuntimeOptionsWithoutConfig<Handler>,
+): RuntimeLifecycle<Handler>;
+export function createChannelRuntime<Handler, Config>(
+  options: RuntimeOptionsWithConfig<Handler, Config>,
+): RuntimeLifecycle<Handler>;
 
-export function createChannelRuntime<
-  Handler = void,
-  Config = void,
-  Args extends unknown[] = [],
->(options: RuntimeOptions<Handler, Config, Args>) {
+export function createChannelRuntime<Handler = void, Config = void>(
+  options: RuntimeOptions<Handler, Config>,
+) {
   let initialized = false;
   let initializing: Promise<void> | undefined;
   let generation = 0;
-  let shutdownArgs: Args | undefined;
 
   return {
     init: (handler: Handler): Promise<void> => {
@@ -109,9 +86,7 @@ export function createChannelRuntime<
             await options.start({ handler });
           }
           if (initGeneration !== generation) {
-            if (shutdownArgs) {
-              await options.cleanup?.(...shutdownArgs);
-            }
+            await options.cleanup?.();
             return;
           }
           initialized = true;
@@ -124,11 +99,10 @@ export function createChannelRuntime<
       }
       return initializing;
     },
-    shutdown: async (...args: Args): Promise<void> => {
+    shutdown: async (): Promise<void> => {
       generation += 1;
-      shutdownArgs = args;
       try {
-        await options.cleanup?.(...args);
+        await options.cleanup?.();
       } finally {
         initialized = false;
         initializing = undefined;

--- a/src/channels/channel-runtime-factory.ts
+++ b/src/channels/channel-runtime-factory.ts
@@ -23,16 +23,21 @@ export function createChannelRuntime<
 >(options: RuntimeOptions<Handler, Config, Args>) {
   let initialized = false;
   let initializing: Promise<void> | undefined;
+  let generation = 0;
+  let shutdownArgs: Args | undefined;
 
   return {
     init: (handler: Handler): Promise<void> => {
       if (initialized) return Promise.resolve();
       if (!initializing) {
-        initializing = (async () => {
+        const initGeneration = generation;
+        const initPromise = (async () => {
           const config = await options.resolveConfig?.();
+          if (initGeneration !== generation) return;
           const registration = await options.resolveRegistration?.(
             config as Config,
           );
+          if (initGeneration !== generation) return;
           const resolved =
             typeof registration === 'string'
               ? { id: registration }
@@ -43,14 +48,25 @@ export function createChannelRuntime<
             capabilities: resolved?.capabilities || options.capabilities,
           });
           await options.start({ handler, config: config as Config });
+          if (initGeneration !== generation) {
+            if (shutdownArgs) {
+              await options.cleanup?.(...shutdownArgs);
+            }
+            return;
+          }
           initialized = true;
         })().finally(() => {
-          initializing = undefined;
+          if (initializing === initPromise) {
+            initializing = undefined;
+          }
         });
+        initializing = initPromise;
       }
       return initializing;
     },
     shutdown: async (...args: Args): Promise<void> => {
+      generation += 1;
+      shutdownArgs = args;
       try {
         await options.cleanup?.(...args);
       } finally {

--- a/src/channels/channel-runtime-factory.ts
+++ b/src/channels/channel-runtime-factory.ts
@@ -33,7 +33,7 @@ function registerResolvedChannel(
 ): void {
   registerChannel({
     kind,
-    id: String(registration || kind).trim() || kind,
+    id: registration?.trim() || kind,
     capabilities,
   });
 }

--- a/src/channels/channel-runtime-factory.ts
+++ b/src/channels/channel-runtime-factory.ts
@@ -1,0 +1,62 @@
+import type { ChannelInfo, ChannelKind } from './channel.js';
+import { registerChannel } from './channel-registry.js';
+
+type MaybePromise<T> = T | Promise<T>;
+type Registration =
+  | string
+  | { id?: string | null; capabilities?: ChannelInfo['capabilities'] }
+  | null
+  | undefined;
+type RuntimeOptions<Handler, Config, Args extends unknown[]> = {
+  kind: ChannelKind;
+  capabilities: ChannelInfo['capabilities'];
+  resolveConfig?: () => MaybePromise<Config>;
+  resolveRegistration?: (config: Config) => MaybePromise<Registration>;
+  start: (params: { handler: Handler; config: Config }) => MaybePromise<void>;
+  cleanup?: (...args: Args) => MaybePromise<void>;
+};
+
+export function createChannelRuntime<
+  Handler = void,
+  Config = void,
+  Args extends unknown[] = [],
+>(options: RuntimeOptions<Handler, Config, Args>) {
+  let initialized = false;
+  let initializing: Promise<void> | undefined;
+
+  return {
+    init: (handler: Handler): Promise<void> => {
+      if (initialized) return Promise.resolve();
+      if (!initializing) {
+        initializing = (async () => {
+          const config = await options.resolveConfig?.();
+          const registration = await options.resolveRegistration?.(
+            config as Config,
+          );
+          const resolved =
+            typeof registration === 'string'
+              ? { id: registration }
+              : registration;
+          registerChannel({
+            kind: options.kind,
+            id: String(resolved?.id || options.kind).trim() || options.kind,
+            capabilities: resolved?.capabilities || options.capabilities,
+          });
+          await options.start({ handler, config: config as Config });
+          initialized = true;
+        })().finally(() => {
+          initializing = undefined;
+        });
+      }
+      return initializing;
+    },
+    shutdown: async (...args: Args): Promise<void> => {
+      try {
+        await options.cleanup?.(...args);
+      } finally {
+        initialized = false;
+        initializing = undefined;
+      }
+    },
+  };
+}

--- a/src/channels/channel-runtime-factory.ts
+++ b/src/channels/channel-runtime-factory.ts
@@ -18,7 +18,7 @@ type RuntimeOptionsWithConfig<Handler, Config> = BaseRuntimeOptions & {
   resolveRegistration?: (config: Config) => MaybePromise<Registration>;
   start: (params: { handler: Handler; config: Config }) => MaybePromise<void>;
 };
-type RuntimeOptions<Handler, Config> =
+type RuntimeOptions<Handler, Config = never> =
   | RuntimeOptionsWithoutConfig<Handler>
   | RuntimeOptionsWithConfig<Handler, Config>;
 type RuntimeLifecycle<Handler> = {
@@ -44,69 +44,64 @@ function hasResolvedConfig<Handler, Config>(
   return typeof options.resolveConfig === 'function';
 }
 
-export function createChannelRuntime<Handler = void>(
-  options: RuntimeOptionsWithoutConfig<Handler>,
-): RuntimeLifecycle<Handler>;
-export function createChannelRuntime<Handler, Config>(
-  options: RuntimeOptionsWithConfig<Handler, Config>,
-): RuntimeLifecycle<Handler>;
+export function createChannelRuntime<Handler = void>() {
+  return <Config = never>(
+    options: RuntimeOptions<Handler, Config>,
+  ): RuntimeLifecycle<Handler> => {
+    let initialized = false;
+    let initializing: Promise<void> | undefined;
+    let generation = 0;
 
-export function createChannelRuntime<Handler = void, Config = void>(
-  options: RuntimeOptions<Handler, Config>,
-) {
-  let initialized = false;
-  let initializing: Promise<void> | undefined;
-  let generation = 0;
-
-  return {
-    init: (handler: Handler): Promise<void> => {
-      if (initialized) return Promise.resolve();
-      if (!initializing) {
-        const initGeneration = generation;
-        const initPromise = (async () => {
-          if (hasResolvedConfig(options)) {
-            const config = await options.resolveConfig();
-            if (initGeneration !== generation) return;
-            const registration = await options.resolveRegistration?.(config);
-            if (initGeneration !== generation) return;
-            registerResolvedChannel(
-              options.kind,
-              options.capabilities,
-              registration,
-            );
-            await options.start({ handler, config });
-          } else {
-            const registration = await options.resolveRegistration?.();
-            if (initGeneration !== generation) return;
-            registerResolvedChannel(
-              options.kind,
-              options.capabilities,
-              registration,
-            );
-            await options.start({ handler });
-          }
-          if (initGeneration !== generation) {
-            await options.cleanup?.();
-            return;
-          }
-          initialized = true;
-        })().finally(() => {
-          if (initializing === initPromise) {
-            initializing = undefined;
-          }
-        });
-        initializing = initPromise;
-      }
-      return initializing;
-    },
-    shutdown: async (): Promise<void> => {
-      generation += 1;
-      try {
-        await options.cleanup?.();
-      } finally {
-        initialized = false;
-        initializing = undefined;
-      }
-    },
+    return {
+      init: (handler: Handler): Promise<void> => {
+        if (initialized) return Promise.resolve();
+        if (!initializing) {
+          const initGeneration = generation;
+          const initPromise = (async () => {
+            if (hasResolvedConfig(options)) {
+              const config = await options.resolveConfig();
+              if (initGeneration !== generation) return;
+              const registration = await options.resolveRegistration?.(config);
+              if (initGeneration !== generation) return;
+              registerResolvedChannel(
+                options.kind,
+                options.capabilities,
+                registration,
+              );
+              await options.start({ handler, config });
+            } else {
+              const registration = await options.resolveRegistration?.();
+              if (initGeneration !== generation) return;
+              registerResolvedChannel(
+                options.kind,
+                options.capabilities,
+                registration,
+              );
+              await options.start({ handler });
+            }
+            if (initGeneration !== generation) {
+              await options.cleanup?.();
+              return;
+            }
+            initialized = true;
+          })().finally(() => {
+            if (initializing === initPromise) {
+              initializing = undefined;
+            }
+          });
+          initializing = initPromise;
+        }
+        return initializing;
+      },
+      shutdown: async (): Promise<void> => {
+        generation += 1;
+        try {
+          await options.cleanup?.();
+        } finally {
+          initialized = false;
+          initializing = undefined;
+        }
+      },
+    };
   };
 }

--- a/src/channels/channel-runtime-factory.ts
+++ b/src/channels/channel-runtime-factory.ts
@@ -44,6 +44,12 @@ function hasResolvedConfig<Handler, Config>(
   return typeof options.resolveConfig === 'function';
 }
 
+// Keep this helper scoped to runtimes that only need init dedupe,
+// registerChannel(), and a no-arg shutdown cleanup. Current intentional
+// opt-outs:
+// - Discord owns client login/readiness and returns a live Client from init.
+// - Telegram caches resolved bot identity/config state alongside its poll task.
+// - Voice supports drain-aware shutdown and websocket availability transitions.
 export function createChannelRuntime<Handler = void>() {
   return <Config = never>(
     options: RuntimeOptions<Handler, Config>,

--- a/src/channels/channel-runtime-factory.ts
+++ b/src/channels/channel-runtime-factory.ts
@@ -7,14 +7,69 @@ type Registration =
   | { id?: string | null; capabilities?: ChannelInfo['capabilities'] }
   | null
   | undefined;
-type RuntimeOptions<Handler, Config, Args extends unknown[]> = {
+type BaseRuntimeOptions<Args extends unknown[]> = {
   kind: ChannelKind;
   capabilities: ChannelInfo['capabilities'];
-  resolveConfig?: () => MaybePromise<Config>;
-  resolveRegistration?: (config: Config) => MaybePromise<Registration>;
-  start: (params: { handler: Handler; config: Config }) => MaybePromise<void>;
   cleanup?: (...args: Args) => MaybePromise<void>;
 };
+type RuntimeOptionsWithoutConfig<
+  Handler,
+  Args extends unknown[],
+> = BaseRuntimeOptions<Args> & {
+  resolveConfig?: undefined;
+  resolveRegistration?: () => MaybePromise<Registration>;
+  start: (params: { handler: Handler }) => MaybePromise<void>;
+};
+type RuntimeOptionsWithConfig<
+  Handler,
+  Config,
+  Args extends unknown[],
+> = BaseRuntimeOptions<Args> & {
+  resolveConfig: () => MaybePromise<Config>;
+  resolveRegistration?: (config: Config) => MaybePromise<Registration>;
+  start: (params: { handler: Handler; config: Config }) => MaybePromise<void>;
+};
+type RuntimeOptions<Handler, Config, Args extends unknown[]> =
+  | RuntimeOptionsWithoutConfig<Handler, Args>
+  | RuntimeOptionsWithConfig<Handler, Config, Args>;
+type RuntimeLifecycle<Handler, Args extends unknown[]> = {
+  init: (handler: Handler) => Promise<void>;
+  shutdown: (...args: Args) => Promise<void>;
+};
+
+function registerResolvedChannel(
+  kind: ChannelKind,
+  capabilities: ChannelInfo['capabilities'],
+  registration: Registration,
+): void {
+  const resolved =
+    typeof registration === 'string' ? { id: registration } : registration;
+  registerChannel({
+    kind,
+    id: String(resolved?.id || kind).trim() || kind,
+    capabilities: resolved?.capabilities || capabilities,
+  });
+}
+
+function hasResolvedConfig<Handler, Config, Args extends unknown[]>(
+  options: RuntimeOptions<Handler, Config, Args>,
+): options is RuntimeOptionsWithConfig<Handler, Config, Args> {
+  return typeof options.resolveConfig === 'function';
+}
+
+export function createChannelRuntime<
+  Handler = void,
+  Args extends unknown[] = [],
+>(
+  options: RuntimeOptionsWithoutConfig<Handler, Args>,
+): RuntimeLifecycle<Handler, Args>;
+export function createChannelRuntime<
+  Handler,
+  Config,
+  Args extends unknown[] = [],
+>(
+  options: RuntimeOptionsWithConfig<Handler, Config, Args>,
+): RuntimeLifecycle<Handler, Args>;
 
 export function createChannelRuntime<
   Handler = void,
@@ -32,22 +87,27 @@ export function createChannelRuntime<
       if (!initializing) {
         const initGeneration = generation;
         const initPromise = (async () => {
-          const config = await options.resolveConfig?.();
-          if (initGeneration !== generation) return;
-          const registration = await options.resolveRegistration?.(
-            config as Config,
-          );
-          if (initGeneration !== generation) return;
-          const resolved =
-            typeof registration === 'string'
-              ? { id: registration }
-              : registration;
-          registerChannel({
-            kind: options.kind,
-            id: String(resolved?.id || options.kind).trim() || options.kind,
-            capabilities: resolved?.capabilities || options.capabilities,
-          });
-          await options.start({ handler, config: config as Config });
+          if (hasResolvedConfig(options)) {
+            const config = await options.resolveConfig();
+            if (initGeneration !== generation) return;
+            const registration = await options.resolveRegistration?.(config);
+            if (initGeneration !== generation) return;
+            registerResolvedChannel(
+              options.kind,
+              options.capabilities,
+              registration,
+            );
+            await options.start({ handler, config });
+          } else {
+            const registration = await options.resolveRegistration?.();
+            if (initGeneration !== generation) return;
+            registerResolvedChannel(
+              options.kind,
+              options.capabilities,
+              registration,
+            );
+            await options.start({ handler });
+          }
           if (initGeneration !== generation) {
             if (shutdownArgs) {
               await options.cleanup?.(...shutdownArgs);

--- a/src/channels/discord/runtime.ts
+++ b/src/channels/discord/runtime.ts
@@ -1249,7 +1249,6 @@ export async function initDiscord(
     id: 'discord',
     capabilities: DISCORD_CAPABILITIES,
   });
-
   interface QueuedConversationMessage {
     msg: DiscordMessage;
     content: string;
@@ -2541,7 +2540,11 @@ export async function initDiscord(
 
     if (!shouldHandleFreeModeMessage(msg, behavior, content)) {
       logger.debug(
-        { channelId: msg.channelId, messageId: msg.id, userId: msg.author.id },
+        {
+          channelId: msg.channelId,
+          messageId: msg.id,
+          userId: msg.author.id,
+        },
         'Skipping Discord free-mode message by relevance/mention gate',
       );
       return;

--- a/src/channels/email/runtime.ts
+++ b/src/channels/email/runtime.ts
@@ -4,7 +4,7 @@ import { EMAIL_PASSWORD, getConfigSnapshot } from '../../config/config.js';
 import { logger } from '../../logger.js';
 import type { MediaContextItem } from '../../types/container.js';
 import { EMAIL_CAPABILITIES } from '../channel.js';
-import { registerChannel } from '../channel-registry.js';
+import { createChannelRuntime } from '../channel-runtime-factory.js';
 import { createEmailConnectionManager } from './connection.js';
 import { type EmailSendParams, sendEmail } from './delivery.js';
 import { cleanupEmailInboundMedia, processInboundEmail } from './inbound.js';
@@ -56,17 +56,6 @@ export interface EmailTextSendOptions {
   inReplyTo?: string | null;
   references?: string[] | null;
   metadata?: EmailDeliveryMetadata | null;
-}
-
-export interface EmailRuntime {
-  initEmail: (messageHandler: EmailMessageHandler) => Promise<void>;
-  sendToEmail: (
-    to: string,
-    text: string,
-    options?: EmailTextSendOptions,
-  ) => Promise<void>;
-  sendEmailAttachmentTo: (params: EmailAttachmentSendParams) => Promise<void>;
-  shutdownEmail: () => Promise<void>;
 }
 
 function createEmailShutdownAbortError(): Error {
@@ -154,7 +143,7 @@ function resolveRuntimeConfig(): {
   };
 }
 
-export function createEmailRuntime(): EmailRuntime {
+export function createEmailRuntime() {
   type ResolvedRuntimeConfig = ReturnType<typeof resolveRuntimeConfig>;
 
   let connectionManager: ReturnType<
@@ -164,7 +153,6 @@ export function createEmailRuntime(): EmailRuntime {
   let runtimeConfig: ResolvedRuntimeConfig | null = null;
   let transport: Transporter | null = null;
   let threadTracker: ReturnType<typeof createThreadTracker> | null = null;
-  let runtimeInitialized = false;
   const inFlightControllers = new Set<AbortController>();
 
   const ensureRuntimeActive = (): void => {
@@ -359,21 +347,36 @@ export function createEmailRuntime(): EmailRuntime {
     );
     return connectionManager;
   };
+  const runtimeLifecycle = createChannelRuntime<
+    EmailMessageHandler,
+    ResolvedRuntimeConfig
+  >({
+    kind: 'email',
+    capabilities: EMAIL_CAPABILITIES,
+    resolveConfig: () => {
+      ensureRuntimeActive();
+      return ensureRuntimeConfig();
+    },
+    resolveRegistration: (config) => config.address,
+    start: async ({ handler }) => {
+      await ensureTransport();
+      await ensureConnectionManager(handler).start();
+    },
+    cleanup: async () => {
+      shuttingDown = true;
+      abortInFlightHandlers();
+      await connectionManager?.stop();
+      await transport?.close();
+      connectionManager = null;
+      runtimeConfig = null;
+      transport = null;
+      threadTracker?.clear();
+      threadTracker = null;
+    },
+  });
 
   return {
-    async initEmail(messageHandler: EmailMessageHandler): Promise<void> {
-      ensureRuntimeActive();
-      if (runtimeInitialized) return;
-      runtimeInitialized = true;
-      const config = ensureRuntimeConfig();
-      registerChannel({
-        kind: 'email',
-        id: config.address,
-        capabilities: EMAIL_CAPABILITIES,
-      });
-      await ensureTransport();
-      await ensureConnectionManager(messageHandler).start();
-    },
+    initEmail: runtimeLifecycle.init,
     async sendToEmail(
       to: string,
       text: string,
@@ -386,47 +389,29 @@ export function createEmailRuntime(): EmailRuntime {
     ): Promise<void> {
       await sendAttachmentToAddress(params);
     },
-    async shutdownEmail(): Promise<void> {
-      shuttingDown = true;
-      abortInFlightHandlers();
-      await connectionManager?.stop();
-      await transport?.close();
-      connectionManager = null;
-      runtimeConfig = null;
-      transport = null;
-      threadTracker?.clear();
-      threadTracker = null;
-      runtimeInitialized = false;
-    },
+    shutdownEmail: runtimeLifecycle.shutdown,
   };
 }
 
-let defaultRuntime: EmailRuntime | null = null;
+let defaultRuntime: ReturnType<typeof createEmailRuntime> | null = null;
 
-function ensureDefaultRuntime(): EmailRuntime {
+function ensureDefaultRuntime(): ReturnType<typeof createEmailRuntime> {
   defaultRuntime ??= createEmailRuntime();
   return defaultRuntime;
 }
 
-export async function initEmail(
-  messageHandler: EmailMessageHandler,
-): Promise<void> {
-  await ensureDefaultRuntime().initEmail(messageHandler);
-}
+export const initEmail = (messageHandler: EmailMessageHandler): Promise<void> =>
+  ensureDefaultRuntime().initEmail(messageHandler);
 
-export async function sendToEmail(
+export const sendToEmail = (
   to: string,
   text: string,
   options?: EmailTextSendOptions,
-): Promise<void> {
-  await ensureDefaultRuntime().sendToEmail(to, text, options);
-}
+): Promise<void> => ensureDefaultRuntime().sendToEmail(to, text, options);
 
-export async function sendEmailAttachmentTo(
+export const sendEmailAttachmentTo = (
   params: EmailAttachmentSendParams,
-): Promise<void> {
-  await ensureDefaultRuntime().sendEmailAttachmentTo(params);
-}
+): Promise<void> => ensureDefaultRuntime().sendEmailAttachmentTo(params);
 
 export async function shutdownEmail(): Promise<void> {
   const runtime = defaultRuntime;

--- a/src/channels/email/runtime.ts
+++ b/src/channels/email/runtime.ts
@@ -347,10 +347,7 @@ export function createEmailRuntime() {
     );
     return connectionManager;
   };
-  const runtimeLifecycle = createChannelRuntime<
-    EmailMessageHandler,
-    ResolvedRuntimeConfig
-  >({
+  const runtimeLifecycle = createChannelRuntime<EmailMessageHandler>()({
     kind: 'email',
     capabilities: EMAIL_CAPABILITIES,
     resolveConfig: () => {
@@ -358,9 +355,12 @@ export function createEmailRuntime() {
       return ensureRuntimeConfig();
     },
     resolveRegistration: (config) => config.address,
-    start: async ({ handler }) => {
+    start: async (params: {
+      config: ResolvedRuntimeConfig;
+      handler: EmailMessageHandler;
+    }) => {
       await ensureTransport();
-      await ensureConnectionManager(handler).start();
+      await ensureConnectionManager(params.handler).start();
     },
     cleanup: async () => {
       shuttingDown = true;

--- a/src/channels/imessage/runtime.ts
+++ b/src/channels/imessage/runtime.ts
@@ -176,7 +176,7 @@ export function createIMessageRuntime() {
       },
     );
   };
-  const runtimeLifecycle = createChannelRuntime<IMessageMessageHandler>({
+  const runtimeLifecycle = createChannelRuntime<IMessageMessageHandler>()({
     kind: 'imessage',
     capabilities: IMESSAGE_CAPABILITIES,
     start: async ({ handler }) => {

--- a/src/channels/imessage/runtime.ts
+++ b/src/channels/imessage/runtime.ts
@@ -5,7 +5,7 @@ import { logger } from '../../logger.js';
 import { memoryService } from '../../memory/memory-service.js';
 import { parseSessionKey } from '../../session/session-key.js';
 import { IMESSAGE_CAPABILITIES } from '../channel.js';
-import { registerChannel } from '../channel-registry.js';
+import { createChannelRuntime } from '../channel-runtime-factory.js';
 import type { IMessageMediaSendParams } from './backend.js';
 import { createBlueBubblesIMessageBackend } from './backend-bluebubbles.js';
 import { createLocalIMessageBackend } from './backend-local.js';
@@ -20,17 +20,6 @@ import {
   type IMessageLocalSelfChatMetadata,
 } from './self-chat-guard.js';
 import type { IMessageMessageHandler, IMessageReplyFn } from './types.js';
-
-export interface IMessageRuntime {
-  initIMessage: (messageHandler: IMessageMessageHandler) => Promise<void>;
-  sendToIMessageChat: (target: string, text: string) => Promise<void>;
-  sendIMessageMediaToChat: (params: IMessageMediaSendParams) => Promise<void>;
-  handleIMessageWebhook: (
-    req: IncomingMessage,
-    res: ServerResponse,
-  ) => Promise<boolean>;
-  shutdownIMessage: () => Promise<void>;
-}
 
 const SELF_CHAT_REPLY_PREFIX_RE = /^\[[^\]]+\](?:\s|$)/i;
 const IMESSAGE_NOOP_ABORT_SIGNAL = new AbortController().signal;
@@ -64,7 +53,7 @@ function formatSelfChatReply(content: string, sessionId: string): string {
   return trimmed ? `${prefix} ${trimmed}` : prefix;
 }
 
-export function createIMessageRuntime(): IMessageRuntime {
+export function createIMessageRuntime() {
   let backend:
     | ReturnType<typeof createLocalIMessageBackend>
     | ReturnType<typeof createBlueBubblesIMessageBackend>
@@ -73,7 +62,6 @@ export function createIMessageRuntime(): IMessageRuntime {
     null;
   let selfChatGuard: ReturnType<typeof createIMessageSelfChatGuard> | null =
     null;
-  let runtimeInitialized = false;
 
   const readLocalSelfChatMetadata = (
     message: IMessageInboundBatch,
@@ -188,24 +176,30 @@ export function createIMessageRuntime(): IMessageRuntime {
       },
     );
   };
-
-  const runtime: IMessageRuntime = {
-    async initIMessage(messageHandler: IMessageMessageHandler): Promise<void> {
-      if (runtimeInitialized) return;
-      runtimeInitialized = true;
+  const runtimeLifecycle = createChannelRuntime<IMessageMessageHandler>({
+    kind: 'imessage',
+    capabilities: IMESSAGE_CAPABILITIES,
+    start: async ({ handler }) => {
       selfChatGuard = createIMessageSelfChatGuard({
         resolveReplyPrefix: resolveSelfChatReplyPrefix,
       });
       inboundDebouncer = createIMessageDebouncer(async (batch) => {
-        await dispatchInboundBatch(batch, messageHandler);
+        await dispatchInboundBatch(batch, handler);
       });
-      registerChannel({
-        kind: 'imessage',
-        id: 'imessage',
-        capabilities: IMESSAGE_CAPABILITIES,
-      });
-      await ensureBackend(messageHandler).start();
+      await ensureBackend(handler).start();
     },
+    cleanup: async () => {
+      await inboundDebouncer?.flushAll();
+      await backend?.shutdown();
+      inboundDebouncer = null;
+      selfChatGuard?.clear();
+      selfChatGuard = null;
+      backend = null;
+    },
+  });
+
+  const runtime = {
+    initIMessage: runtimeLifecycle.init,
     async sendToIMessageChat(target: string, text: string): Promise<void> {
       const refs = await ensureBackend().sendText(target, text);
       selfChatGuard?.rememberOutbound(refs);
@@ -232,15 +226,7 @@ export function createIMessageRuntime(): IMessageRuntime {
       }
       return await activeBackend.handleWebhook(req, res);
     },
-    async shutdownIMessage(): Promise<void> {
-      await inboundDebouncer?.flushAll();
-      await backend?.shutdown();
-      inboundDebouncer = null;
-      selfChatGuard?.clear();
-      selfChatGuard = null;
-      backend = null;
-      runtimeInitialized = false;
-    },
+    shutdownIMessage: runtimeLifecycle.shutdown,
   };
 
   return runtime;

--- a/src/channels/slack/runtime.ts
+++ b/src/channels/slack/runtime.ts
@@ -1035,7 +1035,7 @@ async function startSlackRuntime(handler: {
 const slackRuntime = createChannelRuntime<{
   commandHandler: SlackCommandHandler;
   messageHandler: SlackMessageHandler;
-}>({
+}>()({
   kind: 'slack',
   capabilities: SLACK_CAPABILITIES,
   start: async ({ handler }) => {

--- a/src/channels/slack/runtime.ts
+++ b/src/channels/slack/runtime.ts
@@ -569,12 +569,10 @@ async function postSlackText(target: string, text: string): Promise<void> {
   if (!parsedTarget) {
     throw new Error(`Invalid Slack target: ${target}`);
   }
-  if (!app) {
-    throw new Error('Slack runtime is not initialized.');
-  }
+  const activeApp = ensureSlackRuntimeInitialized();
 
   for (const chunk of prepareSlackTextChunks(text)) {
-    await app.client.chat.postMessage({
+    await activeApp.client.chat.postMessage({
       channel: parsedTarget.channelId,
       text: chunk,
       mrkdwn: true,
@@ -593,9 +591,7 @@ async function postSlackFile(params: {
   if (!parsedTarget) {
     throw new Error(`Invalid Slack target: ${params.target}`);
   }
-  if (!app) {
-    throw new Error('Slack runtime is not initialized.');
-  }
+  const activeApp = ensureSlackRuntimeInitialized();
 
   const filename =
     trimValue(params.filename) || path.basename(path.resolve(params.filePath));
@@ -609,7 +605,7 @@ async function postSlackFile(params: {
     ...(parsedTarget.threadTs ? { thread_ts: parsedTarget.threadTs } : {}),
   };
 
-  await app.client.files.uploadV2(uploadParams as SlackUploadFileArgs);
+  await activeApp.client.files.uploadV2(uploadParams as SlackUploadFileArgs);
 }
 
 async function updateSlackApprovalMessage(params: {
@@ -631,6 +627,13 @@ async function updateSlackApprovalMessage(params: {
       params.statusText,
     ),
   });
+}
+
+function ensureSlackRuntimeInitialized(): App {
+  if (!app) {
+    throw new Error('Slack runtime is not initialized.');
+  }
+  return app;
 }
 
 export async function sendSlackApprovalNotification(params: {
@@ -1067,6 +1070,7 @@ export async function sendToSlackTarget(
   target: string,
   text: string,
 ): Promise<void> {
+  ensureSlackRuntimeInitialized();
   await postSlackText(target, text);
 }
 
@@ -1076,6 +1080,7 @@ export async function sendSlackFileToTarget(params: {
   filename?: string | null;
   caption?: string | null;
 }): Promise<void> {
+  ensureSlackRuntimeInitialized();
   await postSlackFile(params);
 }
 

--- a/src/channels/slack/runtime.ts
+++ b/src/channels/slack/runtime.ts
@@ -23,7 +23,7 @@ import { buildSessionKey } from '../../session/session-key.js';
 import type { MediaContextItem } from '../../types/container.js';
 import { normalizeTrimmedString as trimValue } from '../../utils/normalized-strings.js';
 import { SLACK_CAPABILITIES } from '../channel.js';
-import { registerChannel } from '../channel-registry.js';
+import { createChannelRuntime } from '../channel-runtime-factory.js';
 import {
   buildSlackApprovalBlocks,
   buildSlackResolvedApprovalBlocks,
@@ -149,8 +149,6 @@ interface SlackStatusController {
 }
 
 let app: App | null = null;
-let runtimeInitialized = false;
-let runtimeInitializationPromise: Promise<void> | null = null;
 let botUserId = '';
 const activeSlackSessions = new Map<string, ActiveSlackSession>();
 const activeThreadKeys = new Set<string>();
@@ -773,20 +771,10 @@ async function handleIncomingSlackEvent(
   }
 }
 
-export async function initSlack(
-  messageHandler: SlackMessageHandler,
-  commandHandler: SlackCommandHandler,
-): Promise<void> {
-  if (runtimeInitialized) return;
-  if (runtimeInitializationPromise) {
-    return runtimeInitializationPromise;
-  }
-  registerChannel({
-    kind: 'slack',
-    id: 'slack',
-    capabilities: SLACK_CAPABILITIES,
-  });
-
+async function startSlackRuntime(handler: {
+  commandHandler: SlackCommandHandler;
+  messageHandler: SlackMessageHandler;
+}): Promise<void> {
   if (!SLACK_ENABLED) {
     throw new Error('Slack runtime is disabled.');
   }
@@ -803,272 +791,276 @@ export async function initSlack(
     socketMode: true,
     logLevel: LogLevel.WARN,
   });
-  runtimeInitializationPromise = (async () => {
-    app = nextApp;
-    try {
-      const auth = await nextApp.client.auth.test();
-      botUserId = trimValue(
-        typeof auth.user_id === 'string' ? auth.user_id : undefined,
-      );
-      if (!botUserId) {
-        throw new Error('Slack auth.test did not return a bot user id.');
-      }
+  app = nextApp;
+  try {
+    const auth = await nextApp.client.auth.test();
+    botUserId = trimValue(
+      typeof auth.user_id === 'string' ? auth.user_id : undefined,
+    );
+    if (!botUserId) {
+      throw new Error('Slack auth.test did not return a bot user id.');
+    }
 
-      nextApp.event('message', async ({ event }) => {
-        await handleIncomingSlackEvent(event as unknown, messageHandler);
-      });
-      nextApp.event('app_mention', async ({ event }) => {
-        await handleIncomingSlackEvent(event as unknown, messageHandler);
-      });
-      for (const commandName of getSlackNativeSlashCommandNames()) {
-        nextApp.command(
-          `/${commandName}`,
-          async ({ ack, command, respond }) => {
-            await ack();
+    nextApp.event('message', async ({ event }) => {
+      await handleIncomingSlackEvent(event as unknown, handler.messageHandler);
+    });
+    nextApp.event('app_mention', async ({ event }) => {
+      await handleIncomingSlackEvent(event as unknown, handler.messageHandler);
+    });
+    for (const commandName of getSlackNativeSlashCommandNames()) {
+      nextApp.command(`/${commandName}`, async ({ ack, command, respond }) => {
+        await ack();
 
-            const routing = buildSlackNativeCommandRouting(
-              command as SlackSlashCommandPayload,
-            );
-            if (!routing) {
-              const fallbackTarget = normalizeSlackChannelId(command.channel_id)
-                ? buildSlackChannelTarget(String(command.channel_id))
-                : null;
-              await respondToSlackSlashCommand(
-                respond,
-                fallbackTarget,
-                'This Slack command is not available in this conversation.',
-              ).catch(() => undefined);
-              return;
-            }
-
-            const args = resolveSlackNativeSlashCommandArgs({
-              commandName,
-              text: command.text,
-            });
-            if (!args || args.length === 0) {
-              await respondToSlackSlashCommand(
-                respond,
-                routing.target,
-                'Unsupported slash command.',
-              );
-              return;
-            }
-
-            rememberActiveSlackSession(routing.sessionId, {
-              target: routing.target,
-              channelId: routing.channelId,
-              isDm: routing.isDm,
-              threadTs: null,
-            });
-
-            try {
-              const username = await resolveSlackDisplayName(routing.userId);
-              const reply: SlackCommandReplyFn = async (content) => {
-                await respondToSlackSlashCommand(
-                  respond,
-                  routing.target,
-                  content,
-                );
-              };
-              for (const commandArgs of args) {
-                await commandHandler(
-                  routing.sessionId,
-                  routing.guildId,
-                  routing.target,
-                  routing.userId,
-                  username,
-                  commandArgs,
-                  reply,
-                );
-              }
-            } catch (error) {
-              logger.error(
-                {
-                  error,
-                  channelId: routing.channelId,
-                  userId: routing.userId,
-                  command: commandName,
-                },
-                'Slack slash command failed',
-              );
-              await respondToSlackSlashCommand(
-                respond,
-                routing.target,
-                formatSlackMrkdwn(
-                  `**Gateway Error:** ${error instanceof Error ? error.message : String(error)}`,
-                ),
-              ).catch(() => undefined);
-            }
-          },
+        const routing = buildSlackNativeCommandRouting(
+          command as SlackSlashCommandPayload,
         );
-      }
-      nextApp.action(
-        /^approve:(yes|session|agent|all|no)$/,
-        async (payload) => {
-          await payload.ack();
-          const action =
-            payload.action && typeof payload.action === 'object'
-              ? payload.action
-              : {};
-          const parsed = parseSlackApprovalAction(
-            trimValue(
-              'action_id' in action && typeof action.action_id === 'string'
-                ? action.action_id
-                : '',
-            ),
-            trimValue(
-              'value' in action && typeof action.value === 'string'
-                ? action.value
-                : '',
-            ),
+        if (!routing) {
+          const fallbackTarget = normalizeSlackChannelId(command.channel_id)
+            ? buildSlackChannelTarget(String(command.channel_id))
+            : null;
+          await respondToSlackSlashCommand(
+            respond,
+            fallbackTarget,
+            'This Slack command is not available in this conversation.',
+          ).catch(() => undefined);
+          return;
+        }
+
+        const args = resolveSlackNativeSlashCommandArgs({
+          commandName,
+          text: command.text,
+        });
+        if (!args || args.length === 0) {
+          await respondToSlackSlashCommand(
+            respond,
+            routing.target,
+            'Unsupported slash command.',
           );
-          if (!parsed) {
-            return;
-          }
+          return;
+        }
 
-          const body =
-            payload.body && typeof payload.body === 'object'
-              ? payload.body
-              : {};
-          const user =
-            'user' in body && body.user && typeof body.user === 'object'
-              ? body.user
-              : {};
-          const channel =
-            'channel' in body &&
-            body.channel &&
-            typeof body.channel === 'object'
-              ? body.channel
-              : {};
-          const message =
-            'message' in body &&
-            body.message &&
-            typeof body.message === 'object'
-              ? body.message
-              : {};
-          const userId = trimValue('id' in user ? String(user.id || '') : '');
-          const channelId = trimValue(
-            'id' in channel ? String(channel.id || '') : '',
-          );
+        rememberActiveSlackSession(routing.sessionId, {
+          target: routing.target,
+          channelId: routing.channelId,
+          isDm: routing.isDm,
+          threadTs: null,
+        });
 
-          const pending = claimPendingApprovalByApprovalId({
-            approvalId: parsed.approvalId,
-            userId,
-          });
-          if (pending.status === 'not_found') {
-            if (channelId && userId) {
-              await app?.client.chat.postEphemeral({
-                channel: channelId,
-                user: userId,
-                text: 'This approval has expired or was already handled.',
-              });
-            }
-            return;
-          }
-          if (pending.status === 'unauthorized') {
-            if (channelId && userId) {
-              await app?.client.chat.postEphemeral({
-                channel: channelId,
-                user: userId,
-                text: 'Only the requesting user can respond.',
-              });
-            }
-            return;
-          }
-          if (pending.status === 'already_handled') {
-            if (channelId && userId) {
-              await app?.client.chat.postEphemeral({
-                channel: channelId,
-                user: userId,
-                text: 'This approval has already been handled.',
-              });
-            }
-            return;
-          }
-
-          const approvalTarget = extractSlackActionTarget(
-            body as {
-              channel?: { id?: string };
-              container?: { thread_ts?: string };
-              message?: { thread_ts?: string };
-            },
-          );
-          const promptText =
-            trimValue(
-              'text' in message && typeof message.text === 'string'
-                ? message.text
-                : '',
-            ) || 'Approval required.';
-
-          try {
-            const username = await resolveSlackDisplayName(userId);
-            await commandHandler(
-              pending.sessionId,
-              null,
-              approvalTarget || buildSlackChannelTarget(channelId),
-              userId,
+        try {
+          const username = await resolveSlackDisplayName(routing.userId);
+          const reply: SlackCommandReplyFn = async (content) => {
+            await respondToSlackSlashCommand(respond, routing.target, content);
+          };
+          for (const commandArgs of args) {
+            await handler.commandHandler(
+              routing.sessionId,
+              routing.guildId,
+              routing.target,
+              routing.userId,
               username,
-              ['approve', parsed.action, parsed.approvalId],
-              async (content) => {
-                if (!approvalTarget) {
-                  throw new Error(
-                    'Slack approval action is missing a reply target.',
-                  );
-                }
-                await postSlackText(approvalTarget, content);
-              },
+              commandArgs,
+              reply,
             );
-            const messageTs = trimValue(
-              'ts' in message ? String(message.ts || '') : '',
-            );
-            if (channelId && messageTs) {
-              await updateSlackApprovalMessage({
-                channelId,
-                messageTs,
-                promptText,
-                statusText: buildSlackApprovalDecisionText(
-                  parsed.action,
-                  username,
-                ),
-              });
-            }
-          } catch (error) {
-            rollbackPendingApprovalClaim({
-              sessionId: pending.sessionId,
-              approvalId: parsed.approvalId,
-            });
-            logger.error(
-              { error, channelId, userId, approvalId: parsed.approvalId },
-              'Slack approval button failed',
-            );
-            if (approvalTarget) {
-              await postSlackText(
-                approvalTarget,
-                formatSlackMrkdwn(
-                  `**Gateway Error:** ${error instanceof Error ? error.message : String(error)}`,
-                ),
-              ).catch(() => {});
-            }
           }
+        } catch (error) {
+          logger.error(
+            {
+              error,
+              channelId: routing.channelId,
+              userId: routing.userId,
+              command: commandName,
+            },
+            'Slack slash command failed',
+          );
+          await respondToSlackSlashCommand(
+            respond,
+            routing.target,
+            formatSlackMrkdwn(
+              `**Gateway Error:** ${error instanceof Error ? error.message : String(error)}`,
+            ),
+          ).catch(() => undefined);
+        }
+      });
+    }
+    nextApp.action(/^approve:(yes|session|agent|all|no)$/, async (payload) => {
+      await payload.ack();
+      const action =
+        payload.action && typeof payload.action === 'object'
+          ? payload.action
+          : {};
+      const parsed = parseSlackApprovalAction(
+        trimValue(
+          'action_id' in action && typeof action.action_id === 'string'
+            ? action.action_id
+            : '',
+        ),
+        trimValue(
+          'value' in action && typeof action.value === 'string'
+            ? action.value
+            : '',
+        ),
+      );
+      if (!parsed) {
+        return;
+      }
+
+      const body =
+        payload.body && typeof payload.body === 'object' ? payload.body : {};
+      const user =
+        'user' in body && body.user && typeof body.user === 'object'
+          ? body.user
+          : {};
+      const channel =
+        'channel' in body && body.channel && typeof body.channel === 'object'
+          ? body.channel
+          : {};
+      const message =
+        'message' in body && body.message && typeof body.message === 'object'
+          ? body.message
+          : {};
+      const userId = trimValue('id' in user ? String(user.id || '') : '');
+      const channelId = trimValue(
+        'id' in channel ? String(channel.id || '') : '',
+      );
+
+      const pending = claimPendingApprovalByApprovalId({
+        approvalId: parsed.approvalId,
+        userId,
+      });
+      if (pending.status === 'not_found') {
+        if (channelId && userId) {
+          await app?.client.chat.postEphemeral({
+            channel: channelId,
+            user: userId,
+            text: 'This approval has expired or was already handled.',
+          });
+        }
+        return;
+      }
+      if (pending.status === 'unauthorized') {
+        if (channelId && userId) {
+          await app?.client.chat.postEphemeral({
+            channel: channelId,
+            user: userId,
+            text: 'Only the requesting user can respond.',
+          });
+        }
+        return;
+      }
+      if (pending.status === 'already_handled') {
+        if (channelId && userId) {
+          await app?.client.chat.postEphemeral({
+            channel: channelId,
+            user: userId,
+            text: 'This approval has already been handled.',
+          });
+        }
+        return;
+      }
+
+      const approvalTarget = extractSlackActionTarget(
+        body as {
+          channel?: { id?: string };
+          container?: { thread_ts?: string };
+          message?: { thread_ts?: string };
         },
       );
+      const promptText =
+        trimValue(
+          'text' in message && typeof message.text === 'string'
+            ? message.text
+            : '',
+        ) || 'Approval required.';
 
-      await nextApp.start();
-      runtimeInitialized = true;
-    } catch (error) {
-      if (app === nextApp) {
-        app = null;
+      try {
+        const username = await resolveSlackDisplayName(userId);
+        await handler.commandHandler(
+          pending.sessionId,
+          null,
+          approvalTarget || buildSlackChannelTarget(channelId),
+          userId,
+          username,
+          ['approve', parsed.action, parsed.approvalId],
+          async (content) => {
+            if (!approvalTarget) {
+              throw new Error(
+                'Slack approval action is missing a reply target.',
+              );
+            }
+            await postSlackText(approvalTarget, content);
+          },
+        );
+        const messageTs = trimValue(
+          'ts' in message ? String(message.ts || '') : '',
+        );
+        if (channelId && messageTs) {
+          await updateSlackApprovalMessage({
+            channelId,
+            messageTs,
+            promptText,
+            statusText: buildSlackApprovalDecisionText(parsed.action, username),
+          });
+        }
+      } catch (error) {
+        rollbackPendingApprovalClaim({
+          sessionId: pending.sessionId,
+          approvalId: parsed.approvalId,
+        });
+        logger.error(
+          { error, channelId, userId, approvalId: parsed.approvalId },
+          'Slack approval button failed',
+        );
+        if (approvalTarget) {
+          await postSlackText(
+            approvalTarget,
+            formatSlackMrkdwn(
+              `**Gateway Error:** ${error instanceof Error ? error.message : String(error)}`,
+            ),
+          ).catch(() => {});
+        }
       }
-      botUserId = '';
-      runtimeInitialized = false;
-      await nextApp.stop?.().catch(() => undefined);
-      throw error;
-    } finally {
-      runtimeInitializationPromise = null;
-    }
-  })();
+    });
 
-  return runtimeInitializationPromise;
+    await nextApp.start();
+  } catch (error) {
+    if (app === nextApp) {
+      app = null;
+    }
+    botUserId = '';
+    await nextApp.stop?.().catch(() => undefined);
+    throw error;
+  }
+}
+
+const slackRuntime = createChannelRuntime<{
+  commandHandler: SlackCommandHandler;
+  messageHandler: SlackMessageHandler;
+}>({
+  kind: 'slack',
+  capabilities: SLACK_CAPABILITIES,
+  start: async ({ handler }) => {
+    await startSlackRuntime(handler);
+  },
+  cleanup: async () => {
+    activeSlackSessions.clear();
+    activeThreadKeys.clear();
+    seenEventKeys.clear();
+    userDisplayNameCache.clear();
+    botUserId = '';
+    const activeApp = app;
+    app = null;
+    await activeApp?.stop();
+  },
+});
+
+export async function initSlack(
+  messageHandler: SlackMessageHandler,
+  commandHandler: SlackCommandHandler,
+): Promise<void> {
+  await slackRuntime.init({
+    commandHandler,
+    messageHandler,
+  });
 }
 
 export async function sendToSlackTarget(
@@ -1122,14 +1114,5 @@ export async function sendToActiveSlackSession(
 }
 
 export async function shutdownSlack(): Promise<void> {
-  activeSlackSessions.clear();
-  activeThreadKeys.clear();
-  seenEventKeys.clear();
-  userDisplayNameCache.clear();
-  botUserId = '';
-  const activeApp = app;
-  app = null;
-  runtimeInitialized = false;
-  runtimeInitializationPromise = null;
-  await activeApp?.stop();
+  await slackRuntime.shutdown();
 }

--- a/src/channels/voice/runtime.ts
+++ b/src/channels/voice/runtime.ts
@@ -61,7 +61,6 @@ const DUPLICATE_TWILIO_REQUEST_HEADER = 'i-twilio-idempotency-token';
 const PREINIT_MAX_CONCURRENT_CALLS = 1;
 
 const replayProtector = new ReplayProtector(REPLAY_TTL_MS);
-let runtimeInitialized = false;
 let draining = false;
 let voiceMessageHandler: VoiceMessageHandler | null = null;
 let missingTwilioAuthTokenLogged = false;
@@ -96,6 +95,7 @@ const WebSocketServerCtor = (
   }
 ).WebSocketServer;
 let websocketServer = new WebSocketServerCtor({ noServer: true });
+let runtimeInitialized = false;
 
 function isVoiceRuntimeAvailable(): boolean {
   return runtimeInitialized && !draining && voiceMessageHandler !== null;
@@ -586,7 +586,6 @@ function handleWebSocketConnection(ws: WebSocket, remoteIp: string): void {
     logger.debug({ error, callSid, remoteIp }, 'Voice relay websocket error');
   });
 }
-
 export async function initVoice(
   messageHandler: VoiceMessageHandler,
 ): Promise<void> {

--- a/src/channels/whatsapp/runtime.ts
+++ b/src/channels/whatsapp/runtime.ts
@@ -3,7 +3,7 @@ import { getConfigSnapshot } from '../../config/config.js';
 import { logger } from '../../logger.js';
 import type { MediaContextItem } from '../../types/container.js';
 import { WHATSAPP_CAPABILITIES } from '../channel.js';
-import { registerChannel } from '../channel-registry.js';
+import { createChannelRuntime } from '../channel-runtime-factory.js';
 import {
   createWhatsAppConnectionManager,
   type WhatsAppConnectionManager,
@@ -58,13 +58,6 @@ export interface WhatsAppMediaSendParams {
   caption?: string;
 }
 
-export interface WhatsAppRuntime {
-  initWhatsApp: (messageHandler: WhatsAppMessageHandler) => Promise<void>;
-  sendToWhatsAppChat: (jid: string, text: string) => Promise<void>;
-  sendWhatsAppMediaToChat: (params: WhatsAppMediaSendParams) => Promise<void>;
-  shutdownWhatsApp: () => Promise<void>;
-}
-
 const SELF_CHAT_REPLY_PREFIX = '[hybridclaw]';
 const APPEND_RECENT_GRACE_MS = 60_000;
 const SELF_CHAT_REPLY_PREFIX_RE = new RegExp(
@@ -110,13 +103,12 @@ function buildReactionCleanupTargets(
   return targets;
 }
 
-export function createWhatsAppRuntime(): WhatsAppRuntime {
+export function createWhatsAppRuntime() {
   let connectionManager: WhatsAppConnectionManager | null = null;
   let inboundDebouncer: ReturnType<typeof createWhatsAppDebouncer> | null =
     null;
   let selfEchoCache: ReturnType<typeof createWhatsAppSelfEchoCache> | null =
     null;
-  let runtimeInitialized = false;
 
   const sendTextToChat = async (jid: string, text: string): Promise<void> => {
     const manager = ensureConnectionManager();
@@ -332,17 +324,28 @@ export function createWhatsAppRuntime(): WhatsAppRuntime {
 
     await dispatchInboundBatch(batch, messageHandler);
   };
-
-  return {
-    async initWhatsApp(messageHandler: WhatsAppMessageHandler): Promise<void> {
-      if (runtimeInitialized) return;
-      runtimeInitialized = true;
+  const runtimeLifecycle = createChannelRuntime<WhatsAppMessageHandler>({
+    kind: 'whatsapp',
+    capabilities: WHATSAPP_CAPABILITIES,
+    start: async ({ handler }) => {
       selfEchoCache = createWhatsAppSelfEchoCache();
       inboundDebouncer = createWhatsAppDebouncer(async (batch) => {
-        await dispatchInboundBatch(batch, messageHandler);
+        await dispatchInboundBatch(batch, handler);
       });
-      await ensureConnectionManager(messageHandler).start();
+      await ensureConnectionManager(handler).start();
     },
+    cleanup: async () => {
+      await inboundDebouncer?.flushAll();
+      await connectionManager?.stop();
+      selfEchoCache?.clear();
+      inboundDebouncer = null;
+      connectionManager = null;
+      selfEchoCache = null;
+    },
+  });
+
+  return {
+    initWhatsApp: runtimeLifecycle.init,
     async sendToWhatsAppChat(jid: string, text: string): Promise<void> {
       await sendTextToChat(jid, text);
     },
@@ -351,48 +354,27 @@ export function createWhatsAppRuntime(): WhatsAppRuntime {
     ): Promise<void> {
       await sendMediaToChat(params);
     },
-    async shutdownWhatsApp(): Promise<void> {
-      await inboundDebouncer?.flushAll();
-      await connectionManager?.stop();
-      selfEchoCache?.clear();
-      inboundDebouncer = null;
-      connectionManager = null;
-      selfEchoCache = null;
-      runtimeInitialized = false;
-    },
+    shutdownWhatsApp: runtimeLifecycle.shutdown,
   };
 }
 
-let defaultRuntime: WhatsAppRuntime | null = null;
+let defaultRuntime: ReturnType<typeof createWhatsAppRuntime> | null = null;
 
-function ensureDefaultRuntime(): WhatsAppRuntime {
+function ensureDefaultRuntime(): ReturnType<typeof createWhatsAppRuntime> {
   defaultRuntime ??= createWhatsAppRuntime();
   return defaultRuntime;
 }
 
-export async function initWhatsApp(
+export const initWhatsApp = (
   messageHandler: WhatsAppMessageHandler,
-): Promise<void> {
-  registerChannel({
-    kind: 'whatsapp',
-    id: 'whatsapp',
-    capabilities: WHATSAPP_CAPABILITIES,
-  });
-  await ensureDefaultRuntime().initWhatsApp(messageHandler);
-}
+): Promise<void> => ensureDefaultRuntime().initWhatsApp(messageHandler);
 
-export async function sendToWhatsAppChat(
-  jid: string,
-  text: string,
-): Promise<void> {
-  await ensureDefaultRuntime().sendToWhatsAppChat(jid, text);
-}
+export const sendToWhatsAppChat = (jid: string, text: string): Promise<void> =>
+  ensureDefaultRuntime().sendToWhatsAppChat(jid, text);
 
-export async function sendWhatsAppMediaToChat(
+export const sendWhatsAppMediaToChat = (
   params: WhatsAppMediaSendParams,
-): Promise<void> {
-  await ensureDefaultRuntime().sendWhatsAppMediaToChat(params);
-}
+): Promise<void> => ensureDefaultRuntime().sendWhatsAppMediaToChat(params);
 
 export async function shutdownWhatsApp(): Promise<void> {
   const runtime = defaultRuntime;

--- a/src/channels/whatsapp/runtime.ts
+++ b/src/channels/whatsapp/runtime.ts
@@ -324,7 +324,7 @@ export function createWhatsAppRuntime() {
 
     await dispatchInboundBatch(batch, messageHandler);
   };
-  const runtimeLifecycle = createChannelRuntime<WhatsAppMessageHandler>({
+  const runtimeLifecycle = createChannelRuntime<WhatsAppMessageHandler>()({
     kind: 'whatsapp',
     capabilities: WHATSAPP_CAPABILITIES,
     start: async ({ handler }) => {

--- a/tests/channel-runtime-factory.test.ts
+++ b/tests/channel-runtime-factory.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function importFreshRuntimeFactory() {
+  vi.resetModules();
+  const registerChannel = vi.fn();
+  vi.doMock('../src/channels/channel-registry.js', () => ({
+    registerChannel,
+  }));
+
+  const channelModule = await import('../src/channels/channel.js');
+  const runtimeFactoryModule = await import(
+    '../src/channels/channel-runtime-factory.js'
+  );
+
+  return {
+    ...channelModule,
+    ...runtimeFactoryModule,
+    registerChannel,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.doUnmock('../src/channels/channel-registry.js');
+  vi.resetModules();
+});
+
+test('shutdown invalidates init before runtime side effects begin', async () => {
+  const { EMAIL_CAPABILITIES, createChannelRuntime, registerChannel } =
+    await importFreshRuntimeFactory();
+  const resolveConfigGate = createDeferred<void>();
+  const start = vi.fn(async () => {});
+
+  const runtime = createChannelRuntime<void, void>({
+    kind: 'email',
+    capabilities: EMAIL_CAPABILITIES,
+    resolveConfig: async () => {
+      await resolveConfigGate.promise;
+    },
+    start,
+  });
+
+  const initPromise = runtime.init(undefined);
+  await runtime.shutdown();
+  resolveConfigGate.resolve();
+  await initPromise;
+
+  expect(registerChannel).not.toHaveBeenCalled();
+  expect(start).not.toHaveBeenCalled();
+});
+
+test('shutdown prevents a late init completion from sticking', async () => {
+  const { EMAIL_CAPABILITIES, createChannelRuntime, registerChannel } =
+    await importFreshRuntimeFactory();
+  const startEntered = createDeferred<void>();
+  const releaseFirstStart = createDeferred<void>();
+  const cleanup = vi.fn(async () => {});
+  const start = vi.fn(async () => {});
+  start.mockImplementationOnce(async () => {
+    startEntered.resolve();
+    await releaseFirstStart.promise;
+  });
+
+  const runtime = createChannelRuntime<void, void>({
+    kind: 'email',
+    capabilities: EMAIL_CAPABILITIES,
+    start,
+    cleanup,
+  });
+
+  const firstInit = runtime.init(undefined);
+  await startEntered.promise;
+  await runtime.shutdown();
+  releaseFirstStart.resolve();
+  await firstInit;
+  await runtime.init(undefined);
+
+  expect(start).toHaveBeenCalledTimes(2);
+  expect(cleanup).toHaveBeenCalledTimes(2);
+  expect(registerChannel).toHaveBeenCalledTimes(2);
+});

--- a/tests/channel-runtime-factory.test.ts
+++ b/tests/channel-runtime-factory.test.ts
@@ -39,14 +39,18 @@ test('shutdown invalidates init before runtime side effects begin', async () => 
   const { EMAIL_CAPABILITIES, createChannelRuntime, registerChannel } =
     await importFreshRuntimeFactory();
   const resolveConfigGate = createDeferred<void>();
-  const start = vi.fn(async () => {});
+  const start = vi.fn(async ({ config }: { config: { address: string } }) => {
+    expect(config.address).toBe('ops@example.com');
+  });
 
-  const runtime = createChannelRuntime<void>({
+  const runtime = createChannelRuntime<void>()({
     kind: 'email',
     capabilities: EMAIL_CAPABILITIES,
     resolveConfig: async () => {
       await resolveConfigGate.promise;
+      return { address: 'ops@example.com' };
     },
+    resolveRegistration: (config) => config.address,
     start,
   });
 
@@ -71,7 +75,7 @@ test('shutdown prevents a late init completion from sticking', async () => {
     await releaseFirstStart.promise;
   });
 
-  const runtime = createChannelRuntime<void>({
+  const runtime = createChannelRuntime<void>()({
     kind: 'email',
     capabilities: EMAIL_CAPABILITIES,
     start,

--- a/tests/channel-runtime-factory.test.ts
+++ b/tests/channel-runtime-factory.test.ts
@@ -41,7 +41,7 @@ test('shutdown invalidates init before runtime side effects begin', async () => 
   const resolveConfigGate = createDeferred<void>();
   const start = vi.fn(async () => {});
 
-  const runtime = createChannelRuntime<void, void>({
+  const runtime = createChannelRuntime<void>({
     kind: 'email',
     capabilities: EMAIL_CAPABILITIES,
     resolveConfig: async () => {
@@ -71,7 +71,7 @@ test('shutdown prevents a late init completion from sticking', async () => {
     await releaseFirstStart.promise;
   });
 
-  const runtime = createChannelRuntime<void, void>({
+  const runtime = createChannelRuntime<void>({
     kind: 'email',
     capabilities: EMAIL_CAPABILITIES,
     start,

--- a/tests/slack.runtime.test.ts
+++ b/tests/slack.runtime.test.ts
@@ -253,6 +253,15 @@ describe('slack runtime', () => {
     });
   });
 
+  test('rejects text sends before Slack init', async () => {
+    const state = await importFreshSlackRuntime();
+
+    await expect(
+      state.runtime.sendToSlackTarget('slack:C1234567890', 'hello'),
+    ).rejects.toThrow('Slack runtime is not initialized.');
+    expect(state.postMessage).not.toHaveBeenCalled();
+  });
+
   test('formats Slack file captions before upload', async () => {
     const state = await importFreshSlackRuntime();
     const filePath = makeTempFile('report.txt', 'hello slack');
@@ -274,6 +283,19 @@ describe('slack runtime', () => {
         thread_ts: '1710000000.123456',
       }),
     );
+  });
+
+  test('rejects file sends before Slack init', async () => {
+    const state = await importFreshSlackRuntime();
+    const filePath = makeTempFile('report.txt', 'hello slack');
+
+    await expect(
+      state.runtime.sendSlackFileToTarget({
+        target: 'slack:C1234567890',
+        filePath,
+      }),
+    ).rejects.toThrow('Slack runtime is not initialized.');
+    expect(state.uploadV2).not.toHaveBeenCalled();
   });
 
   test('sends Slack approval prompts through the named helper', async () => {


### PR DESCRIPTION
## Summary
- add a compact `channel-runtime-factory` helper for shared init and shutdown wiring
- move the repeated lifecycle boilerplate out of the email, iMessage, Slack, and WhatsApp runtimes
- keep the overall touched runtime/helper footprint LOC-neutral while preserving the existing channel-specific behavior

## Why
Several channel runtimes repeated the same `runtimeInitialized` guard, `registerChannel()` setup, and shutdown cleanup shape. This extracts the stable lifecycle path into one helper so the repeated channel code stays smaller and easier to keep in sync.

## Impact
This reduces repeated runtime lifecycle code without changing the channel-facing behavior. The staged diff is balanced at 417 insertions and 417 deletions.

## Validation
- `npm run format`
- `npm run typecheck`
- `npx vitest tests/slack.runtime.test.ts tests/imessage.runtime.test.ts tests/whatsapp.runtime.test.ts tests/email.channel.test.ts`

## Notes
- The email test suite still emits the existing `chmod ~/.hybridclaw` EPERM warning and `better-sqlite3` ABI warning during startup reload, but the tests pass.