### PR TITLE
[codex] Add ACP IDE integration with MCP passthrough

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "container"
       ],
       "dependencies": {
+        "@agentclientprotocol/sdk": "0.19.0",
         "@huggingface/transformers": "3.8.1",
         "@opentelemetry/api": "1.9.1",
         "@opentelemetry/exporter-trace-otlp-grpc": "0.214.0",
@@ -98,7 +99,7 @@
     },
     "container": {
       "name": "hybridclaw-agent",
-      "version": "0.12.7",
+      "version": "0.12.10",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
         "@mozilla/readability": "0.6.0",
@@ -393,6 +394,15 @@
       },
       "bin": {
         "agent-browser": "bin/agent-browser.js"
+      }
+    },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.19.0.tgz",
+      "integrity": "sha512-U9I8ws9WTOk6jCBAWpXefGSDgVXn14/kV6HFzwWGcstQ02mOQgClMAROHmoIn9GqZbDBDEOkdIbP4P4TEMQdug==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@appium/logger": {
@@ -9218,7 +9228,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9240,7 +9249,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9262,7 +9270,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9284,7 +9291,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9306,7 +9312,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9328,7 +9333,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9350,7 +9354,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9372,7 +9375,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9394,7 +9396,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9416,7 +9417,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9438,7 +9438,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -81,6 +81,8 @@
     "prepare": "command -v git >/dev/null 2>&1 && test -w .git/config && husky || true"
   },
   "dependencies": {
+    "@agentclientprotocol/sdk": "0.19.0",
+    "@huggingface/transformers": "3.8.1",
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/exporter-trace-otlp-grpc": "0.214.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.214.0",
@@ -88,7 +90,6 @@
     "@opentelemetry/sdk-node": "0.214.0",
     "@opentelemetry/semantic-conventions": "1.40.0",
     "@slack/bolt": "4.7.0",
-    "@huggingface/transformers": "3.8.1",
     "@whiskeysockets/baileys": "7.0.0-rc.9",
     "ajv": "8.18.0",
     "better-sqlite3": "12.8.0",

--- a/src/acp/mcp.ts
+++ b/src/acp/mcp.ts
@@ -1,0 +1,66 @@
+import type { McpServer } from '@agentclientprotocol/sdk';
+import type { McpServerConfig } from '../types/models.js';
+
+function headersToRecord(
+  headers: Array<{ name: string; value: string }> | undefined,
+): Record<string, string> | undefined {
+  const mapped = Object.fromEntries(
+    (headers || [])
+      .map((header) => [String(header.name || '').trim(), header.value])
+      .filter(([name]) => name.length > 0),
+  );
+  return Object.keys(mapped).length > 0 ? mapped : undefined;
+}
+
+function envToRecord(
+  env: Array<{ name: string; value: string }> | undefined,
+): Record<string, string> | undefined {
+  const mapped = Object.fromEntries(
+    (env || [])
+      .map((item) => [String(item.name || '').trim(), item.value])
+      .filter(([name]) => name.length > 0),
+  );
+  return Object.keys(mapped).length > 0 ? mapped : undefined;
+}
+
+export function acpMcpServersToConfigMap(
+  mcpServers: McpServer[] | null | undefined,
+): Record<string, McpServerConfig> {
+  const mapped: Record<string, McpServerConfig> = {};
+
+  for (const server of mcpServers || []) {
+    const name = String(server.name || '').trim();
+    if (!name) continue;
+
+    if ('type' in server && server.type === 'http') {
+      mapped[name] = {
+        transport: 'http',
+        url: server.url,
+        ...(headersToRecord(server.headers)
+          ? { headers: headersToRecord(server.headers) }
+          : {}),
+      };
+      continue;
+    }
+
+    if ('type' in server && server.type === 'sse') {
+      mapped[name] = {
+        transport: 'sse',
+        url: server.url,
+        ...(headersToRecord(server.headers)
+          ? { headers: headersToRecord(server.headers) }
+          : {}),
+      };
+      continue;
+    }
+
+    mapped[name] = {
+      transport: 'stdio',
+      command: server.command,
+      args: [...server.args],
+      ...(envToRecord(server.env) ? { env: envToRecord(server.env) } : {}),
+    };
+  }
+
+  return mapped;
+}

--- a/src/acp/prompt.ts
+++ b/src/acp/prompt.ts
@@ -1,0 +1,198 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { AvailableCommand, ContentBlock } from '@agentclientprotocol/sdk';
+import { buildTuiSlashCommandDefinitions } from '../command-registry.js';
+import type { MediaContextItem } from '../types/container.js';
+
+export interface AcpPromptInput {
+  content: string;
+  media: MediaContextItem[];
+}
+
+function deriveFilenameFromUri(uri: string | null | undefined): string | null {
+  const trimmed = String(uri || '').trim();
+  if (!trimmed) return null;
+
+  try {
+    if (trimmed.startsWith('file://')) {
+      const filename = path.basename(fileURLToPath(trimmed));
+      return filename || null;
+    }
+  } catch {
+    // Fall through to generic path parsing.
+  }
+
+  const withoutQuery = trimmed.split('?')[0]?.split('#')[0] || '';
+  const filename = path.basename(withoutQuery);
+  return filename && filename !== '.' && filename !== '/' ? filename : null;
+}
+
+function extensionForMimeType(mimeType: string): string {
+  switch (mimeType.toLowerCase()) {
+    case 'image/jpeg':
+      return 'jpg';
+    case 'image/png':
+      return 'png';
+    case 'image/gif':
+      return 'gif';
+    case 'image/webp':
+      return 'webp';
+    case 'image/svg+xml':
+      return 'svg';
+    case 'audio/mpeg':
+      return 'mp3';
+    case 'audio/wav':
+      return 'wav';
+    default:
+      return 'bin';
+  }
+}
+
+function estimateBase64Size(base64: string): number {
+  const sanitized = base64.replace(/\s+/g, '');
+  if (!sanitized) return 0;
+  const padding = sanitized.endsWith('==')
+    ? 2
+    : sanitized.endsWith('=')
+      ? 1
+      : 0;
+  return Math.max(0, Math.floor((sanitized.length * 3) / 4) - padding);
+}
+
+function buildInlineMediaItem(params: {
+  kind: 'image' | 'audio' | 'resource';
+  index: number;
+  data: string;
+  mimeType: string;
+  uri?: string | null;
+}): MediaContextItem {
+  const dataUrl = `data:${params.mimeType};base64,${params.data}`;
+  const filename =
+    deriveFilenameFromUri(params.uri) ||
+    `${params.kind}-${params.index}.${extensionForMimeType(params.mimeType)}`;
+
+  return {
+    path: null,
+    url: dataUrl,
+    originalUrl: String(params.uri || '').trim() || dataUrl,
+    mimeType: params.mimeType,
+    sizeBytes: estimateBase64Size(params.data),
+    filename,
+  };
+}
+
+function describeResourceLink(
+  block: Extract<ContentBlock, { type: 'resource_link' }>,
+): string {
+  const parts = [block.name.trim()];
+  if (block.uri?.trim()) {
+    parts.push(`(${block.uri.trim()})`);
+  }
+  if (block.description?.trim()) {
+    parts.push(`- ${block.description.trim()}`);
+  }
+  return `[Resource: ${parts.join(' ')}]`;
+}
+
+function describeUnsupportedResource(params: {
+  mimeType?: string | null;
+  uri?: string | null;
+}): string {
+  const parts = ['[Embedded resource'];
+  if (params.mimeType?.trim()) {
+    parts.push(` ${params.mimeType.trim()}`);
+  }
+  if (params.uri?.trim()) {
+    parts.push(` ${params.uri.trim()}`);
+  }
+  parts.push(']');
+  return parts.join('');
+}
+
+export function buildAcpAvailableCommands(): AvailableCommand[] {
+  return buildTuiSlashCommandDefinitions([])
+    .filter(
+      (definition) => definition.name !== 'paste' && definition.name !== 'exit',
+    )
+    .map((definition) => ({
+      name: definition.name,
+      description: definition.description,
+      input: {
+        hint: 'Arguments',
+      },
+    }));
+}
+
+export function convertAcpPromptBlocks(prompt: ContentBlock[]): AcpPromptInput {
+  const textParts: string[] = [];
+  const media: MediaContextItem[] = [];
+
+  for (const [index, block] of prompt.entries()) {
+    switch (block.type) {
+      case 'text':
+        if (block.text) {
+          textParts.push(block.text);
+        }
+        break;
+
+      case 'resource_link':
+        textParts.push(describeResourceLink(block));
+        break;
+
+      case 'image':
+        media.push(
+          buildInlineMediaItem({
+            kind: 'image',
+            index: media.length + 1,
+            data: block.data,
+            mimeType: block.mimeType,
+            uri: block.uri,
+          }),
+        );
+        break;
+
+      case 'audio':
+        textParts.push(
+          `[Audio attachment: ${block.mimeType}${block.annotations?.lastModified ? `, ${block.annotations.lastModified}` : ''}]`,
+        );
+        break;
+
+      case 'resource': {
+        const resource = block.resource;
+        if ('text' in resource) {
+          textParts.push(`[Embedded resource: ${resource.uri}]`);
+          textParts.push(resource.text);
+          break;
+        }
+        if (resource.mimeType?.toLowerCase().startsWith('image/')) {
+          media.push(
+            buildInlineMediaItem({
+              kind: 'resource',
+              index: media.length + 1,
+              data: resource.blob,
+              mimeType: resource.mimeType,
+              uri: resource.uri,
+            }),
+          );
+          break;
+        }
+        textParts.push(
+          describeUnsupportedResource({
+            mimeType: resource.mimeType,
+            uri: resource.uri,
+          }),
+        );
+        break;
+      }
+
+      default:
+        textParts.push(`[Unsupported ACP content block ${index + 1}]`);
+        break;
+    }
+  }
+
+  return {
+    content: textParts.join('\n\n').trim(),
+    media,
+  };
+}

--- a/src/acp/server.ts
+++ b/src/acp/server.ts
@@ -1,0 +1,647 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { Readable, Writable } from 'node:stream';
+import { fileURLToPath } from 'node:url';
+import * as acp from '@agentclientprotocol/sdk';
+import { initAgentRegistry } from '../agents/agent-registry.js';
+import { getRuntimeConfig } from '../config/runtime-config.js';
+import { handleGatewayMessage } from '../gateway/gateway-chat-service.js';
+import { handleGatewayCommand } from '../gateway/gateway-service.js';
+import type { GatewayChatResult } from '../gateway/gateway-types.js';
+import {
+  handleTextChannelApprovalCommand,
+  renderTextChannelCommandResult,
+  resolveTextChannelSlashCommands,
+} from '../gateway/text-channel-commands.js';
+import { logger } from '../logger.js';
+import { initDatabase, isDatabaseInitialized } from '../memory/db.js';
+import type {
+  PendingApproval,
+  ToolExecution,
+  ToolProgressEvent,
+} from '../types/execution.js';
+import type { McpServerConfig } from '../types/models.js';
+import { acpMcpServersToConfigMap } from './mcp.js';
+import { buildAcpAvailableCommands, convertAcpPromptBlocks } from './prompt.js';
+
+interface AcpSessionState {
+  sessionId: string;
+  gatewaySessionId: string;
+  cwd: string;
+  mcpServersOverride: Record<string, McpServerConfig>;
+  activeAbort?: AbortController;
+}
+
+let cachedAcpVersion: string | null = null;
+
+function resolveAcpVersion(): string {
+  if (cachedAcpVersion) return cachedAcpVersion;
+  const envVersion = String(process.env.npm_package_version || '').trim();
+  if (envVersion) {
+    cachedAcpVersion = envVersion;
+    return cachedAcpVersion;
+  }
+
+  try {
+    const packageJsonPath = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      '..',
+      '..',
+      'package.json',
+    );
+    const raw = fs.readFileSync(packageJsonPath, 'utf-8');
+    const parsed = JSON.parse(raw) as { version?: unknown };
+    const version =
+      typeof parsed.version === 'string' ? parsed.version.trim() : '';
+    if (version) {
+      cachedAcpVersion = version;
+      return cachedAcpVersion;
+    }
+  } catch {
+    // Fall back below.
+  }
+
+  cachedAcpVersion = '0.0.0';
+  return cachedAcpVersion;
+}
+
+function buildPermissionOptions(
+  approval: PendingApproval,
+): acp.PermissionOption[] {
+  const options: acp.PermissionOption[] = [
+    {
+      kind: 'allow_once',
+      name: 'Allow once',
+      optionId: 'yes',
+    },
+  ];
+
+  if (approval.allowSession) {
+    options.push({
+      kind: 'allow_always',
+      name: 'Allow for this session',
+      optionId: 'session',
+    });
+  } else if (approval.allowAgent) {
+    options.push({
+      kind: 'allow_always',
+      name: 'Allow for this agent',
+      optionId: 'agent',
+    });
+  } else if (approval.allowAll) {
+    options.push({
+      kind: 'allow_always',
+      name: 'Allow for this workspace',
+      optionId: 'all',
+    });
+  }
+
+  options.push({
+    kind: 'reject_once',
+    name: 'Deny',
+    optionId: 'no',
+  });
+  return options;
+}
+
+function inferToolKind(toolName: string): acp.ToolKind {
+  const normalized = toolName.trim().toLowerCase();
+  if (
+    normalized === 'read' ||
+    normalized === 'glob' ||
+    normalized === 'vision_analyze'
+  ) {
+    return 'read';
+  }
+  if (
+    normalized === 'grep' ||
+    normalized === 'web_search' ||
+    normalized === 'session_search'
+  ) {
+    return 'search';
+  }
+  if (
+    normalized === 'write' ||
+    normalized === 'edit' ||
+    normalized === 'apply_patch'
+  ) {
+    return 'edit';
+  }
+  if (normalized === 'delete') {
+    return 'delete';
+  }
+  if (normalized === 'move') {
+    return 'move';
+  }
+  if (
+    normalized === 'bash' ||
+    normalized.startsWith('browser_') ||
+    normalized === 'http_request'
+  ) {
+    return 'execute';
+  }
+  if (normalized === 'web_fetch' || normalized === 'web_extract') {
+    return 'fetch';
+  }
+  if (normalized === 'delegate' || normalized === 'plan') {
+    return 'think';
+  }
+  return 'other';
+}
+
+function parseToolArguments(argumentsText: string): unknown {
+  const trimmed = argumentsText.trim();
+  if (!trimmed) return undefined;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return trimmed;
+  }
+}
+
+function findApprovalExecution(
+  pendingApproval: PendingApproval,
+  toolExecutions: ToolExecution[] | undefined,
+): ToolExecution | undefined {
+  return toolExecutions?.find(
+    (execution) => execution.approvalRequestId === pendingApproval.approvalId,
+  );
+}
+
+class AcpTurnReporter {
+  private updateQueue: Promise<void> = Promise.resolve();
+  private emittedText = false;
+  private nextToolCallId = 1;
+  private pendingToolCalls = new Map<string, string[]>();
+
+  constructor(
+    private readonly connection: acp.AgentSideConnection,
+    private readonly sessionId: string,
+  ) {}
+
+  get hasEmittedText(): boolean {
+    return this.emittedText;
+  }
+
+  enqueueText(text: string): void {
+    const chunk = text.trim();
+    if (!chunk) return;
+    this.emittedText = true;
+    this.enqueue(async () => {
+      await this.connection.sessionUpdate({
+        sessionId: this.sessionId,
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: {
+            type: 'text',
+            text: text,
+          },
+        },
+      });
+    });
+  }
+
+  enqueueToolProgress(event: ToolProgressEvent): void {
+    const queue = this.pendingToolCalls.get(event.toolName) || [];
+    if (event.phase === 'start') {
+      const toolCallId = `tool-${this.nextToolCallId++}`;
+      queue.push(toolCallId);
+      this.pendingToolCalls.set(event.toolName, queue);
+      this.enqueue(async () => {
+        await this.connection.sessionUpdate({
+          sessionId: this.sessionId,
+          update: {
+            sessionUpdate: 'tool_call',
+            toolCallId,
+            title: event.preview?.trim()
+              ? `${event.toolName}: ${event.preview.trim()}`
+              : event.toolName,
+            kind: inferToolKind(event.toolName),
+            status: 'in_progress',
+            ...(event.preview?.trim()
+              ? { rawInput: { preview: event.preview.trim() } }
+              : {}),
+          },
+        });
+      });
+      return;
+    }
+
+    const toolCallId = queue.shift() || `tool-${this.nextToolCallId++}`;
+    if (queue.length > 0) {
+      this.pendingToolCalls.set(event.toolName, queue);
+    } else {
+      this.pendingToolCalls.delete(event.toolName);
+    }
+    this.enqueue(async () => {
+      await this.connection.sessionUpdate({
+        sessionId: this.sessionId,
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId,
+          status: 'completed',
+          ...(event.preview?.trim()
+            ? {
+                content: [
+                  {
+                    type: 'content',
+                    content: {
+                      type: 'text',
+                      text: event.preview.trim(),
+                    },
+                  },
+                ],
+                rawOutput: {
+                  preview: event.preview.trim(),
+                  durationMs: event.durationMs ?? null,
+                },
+              }
+            : {}),
+        },
+      });
+    });
+  }
+
+  async flush(): Promise<void> {
+    await this.updateQueue;
+  }
+
+  private enqueue(task: () => Promise<void>): void {
+    this.updateQueue = this.updateQueue.then(task).catch((error) => {
+      logger.warn(
+        { err: error, sessionId: this.sessionId },
+        'ACP session update failed',
+      );
+    });
+  }
+}
+
+class HybridClawAcpAgent implements acp.Agent {
+  private readonly sessions = new Map<string, AcpSessionState>();
+
+  constructor(private readonly connection: acp.AgentSideConnection) {
+    this.connection.signal.addEventListener('abort', () => {
+      for (const session of this.sessions.values()) {
+        session.activeAbort?.abort();
+      }
+    });
+  }
+
+  async initialize(): Promise<acp.InitializeResponse> {
+    return {
+      protocolVersion: acp.PROTOCOL_VERSION,
+      agentCapabilities: {
+        loadSession: false,
+        promptCapabilities: {
+          embeddedContext: true,
+          image: true,
+          audio: false,
+        },
+        mcpCapabilities: {
+          http: true,
+          sse: true,
+        },
+      },
+      agentInfo: {
+        name: 'HybridClaw',
+        version: resolveAcpVersion(),
+      },
+    };
+  }
+
+  async newSession(
+    params: acp.NewSessionRequest,
+  ): Promise<acp.NewSessionResponse> {
+    const sessionId = randomUUID();
+    const session: AcpSessionState = {
+      sessionId,
+      gatewaySessionId: sessionId,
+      cwd: path.resolve(params.cwd),
+      mcpServersOverride: acpMcpServersToConfigMap(params.mcpServers),
+    };
+    this.sessions.set(sessionId, session);
+
+    void this.connection
+      .sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: 'available_commands_update',
+          availableCommands: buildAcpAvailableCommands(),
+        },
+      })
+      .catch((error) => {
+        logger.warn(
+          { err: error, sessionId },
+          'Failed to publish ACP command catalog',
+        );
+      });
+
+    return { sessionId };
+  }
+
+  async authenticate(): Promise<acp.AuthenticateResponse> {
+    return {};
+  }
+
+  async prompt(params: acp.PromptRequest): Promise<acp.PromptResponse> {
+    const session = this.sessions.get(params.sessionId);
+    if (!session) {
+      throw new Error(`Unknown ACP session ${params.sessionId}`);
+    }
+
+    session.activeAbort?.abort();
+    const abortController = new AbortController();
+    session.activeAbort = abortController;
+
+    const reporter = new AcpTurnReporter(this.connection, session.sessionId);
+
+    try {
+      const promptInput = convertAcpPromptBlocks(params.prompt);
+      let result = await this.runPromptStep({
+        session,
+        content: promptInput.content,
+        media: promptInput.media,
+        reporter,
+        abortSignal: abortController.signal,
+      });
+
+      while (result.pendingApproval && !abortController.signal.aborted) {
+        await reporter.flush();
+        const permission = await this.requestPermission({
+          session,
+          pendingApproval: result.pendingApproval,
+          toolExecutions: result.toolExecutions,
+        });
+        if (permission === 'cancelled') {
+          return {
+            stopReason: 'cancelled',
+            ...(params.messageId ? { userMessageId: params.messageId } : {}),
+          };
+        }
+
+        result = await this.runApprovalStep({
+          session,
+          action: permission,
+          approvalId: result.pendingApproval.approvalId,
+          reporter,
+          abortSignal: abortController.signal,
+        });
+      }
+
+      await reporter.flush();
+
+      return {
+        stopReason: abortController.signal.aborted ? 'cancelled' : 'end_turn',
+        ...(params.messageId ? { userMessageId: params.messageId } : {}),
+      };
+    } finally {
+      if (session.activeAbort === abortController) {
+        session.activeAbort = undefined;
+      }
+    }
+  }
+
+  async cancel(params: acp.CancelNotification): Promise<void> {
+    this.sessions.get(params.sessionId)?.activeAbort?.abort();
+  }
+
+  async unstable_closeSession(
+    params: acp.CloseSessionRequest,
+  ): Promise<acp.CloseSessionResponse> {
+    this.sessions.get(params.sessionId)?.activeAbort?.abort();
+    this.sessions.delete(params.sessionId);
+    return {};
+  }
+
+  private async runPromptStep(params: {
+    session: AcpSessionState;
+    content: string;
+    media: ReturnType<typeof convertAcpPromptBlocks>['media'];
+    reporter: AcpTurnReporter;
+    abortSignal: AbortSignal;
+  }): Promise<GatewayChatResult> {
+    const slashResult = await this.runSlashCommands({
+      session: params.session,
+      content: params.content,
+    });
+    if (slashResult) {
+      if (slashResult.result?.trim()) {
+        params.reporter.enqueueText(slashResult.result);
+      }
+      await params.reporter.flush();
+      return slashResult;
+    }
+
+    const result = await handleGatewayMessage({
+      sessionId: params.session.gatewaySessionId,
+      guildId: null,
+      channelId: 'cli',
+      userId: `acp:${params.session.sessionId}`,
+      username: 'ACP',
+      content: params.content,
+      media: params.media,
+      workspacePathOverride: params.session.cwd,
+      workspaceDisplayRootOverride: params.session.cwd,
+      mcpServersOverride: params.session.mcpServersOverride,
+      abortSignal: params.abortSignal,
+      source: 'acp',
+      onTextDelta: (delta) => {
+        params.reporter.enqueueText(delta);
+      },
+      onToolProgress: (event) => {
+        params.reporter.enqueueToolProgress(event);
+      },
+    });
+
+    if (result.sessionId?.trim()) {
+      params.session.gatewaySessionId = result.sessionId.trim();
+    }
+    if (params.abortSignal.aborted) {
+      return result;
+    }
+    if (result.status === 'error') {
+      throw new Error(result.error || 'HybridClaw ACP request failed');
+    }
+    if (
+      !result.pendingApproval &&
+      !params.reporter.hasEmittedText &&
+      result.result?.trim()
+    ) {
+      params.reporter.enqueueText(result.result);
+      await params.reporter.flush();
+    }
+    return result;
+  }
+
+  private async runApprovalStep(params: {
+    session: AcpSessionState;
+    action: 'yes' | 'session' | 'agent' | 'all' | 'no';
+    approvalId: string;
+    reporter: AcpTurnReporter;
+    abortSignal: AbortSignal;
+  }): Promise<GatewayChatResult> {
+    const handled = await handleTextChannelApprovalCommand({
+      sessionId: params.session.gatewaySessionId,
+      guildId: null,
+      channelId: 'cli',
+      userId: `acp:${params.session.sessionId}`,
+      username: 'ACP',
+      args: ['approve', params.action, params.approvalId],
+    });
+
+    if (!handled) {
+      throw new Error(
+        'ACP approval bridge did not handle the approval command',
+      );
+    }
+
+    if (handled.sessionId?.trim()) {
+      params.session.gatewaySessionId = handled.sessionId.trim();
+    }
+    if (params.abortSignal.aborted) {
+      return {
+        status: 'success',
+        result: null,
+        toolsUsed: [],
+      };
+    }
+
+    if (handled.text?.trim()) {
+      params.reporter.enqueueText(handled.text);
+      await params.reporter.flush();
+    }
+
+    return {
+      status: 'success',
+      result: handled.text || null,
+      toolsUsed: [],
+      ...(handled.pendingApproval
+        ? { pendingApproval: handled.pendingApproval }
+        : {}),
+      ...(handled.sessionId ? { sessionId: handled.sessionId } : {}),
+    };
+  }
+
+  private async requestPermission(params: {
+    session: AcpSessionState;
+    pendingApproval: PendingApproval;
+    toolExecutions?: ToolExecution[];
+  }): Promise<'yes' | 'session' | 'agent' | 'all' | 'no' | 'cancelled'> {
+    const execution = findApprovalExecution(
+      params.pendingApproval,
+      params.toolExecutions,
+    );
+    const title =
+      execution?.name || params.pendingApproval.intent || 'Pending approval';
+    const permission = await this.connection.requestPermission({
+      sessionId: params.session.sessionId,
+      toolCall: {
+        toolCallId: `approval-${params.pendingApproval.approvalId}`,
+        title,
+        kind: execution ? inferToolKind(execution.name) : 'other',
+        status: 'pending',
+        rawInput: execution?.arguments.trim()
+          ? parseToolArguments(execution.arguments)
+          : {
+              prompt: params.pendingApproval.prompt,
+              intent: params.pendingApproval.intent,
+              reason: params.pendingApproval.reason,
+            },
+      },
+      options: buildPermissionOptions(params.pendingApproval),
+    });
+
+    if (permission.outcome.outcome === 'cancelled') {
+      return 'cancelled';
+    }
+    switch (permission.outcome.optionId) {
+      case 'yes':
+      case 'session':
+      case 'agent':
+      case 'all':
+      case 'no':
+        return permission.outcome.optionId;
+      default:
+        throw new Error(
+          `Unsupported ACP approval option: ${permission.outcome.optionId}`,
+        );
+    }
+  }
+
+  private async runSlashCommands(params: {
+    session: AcpSessionState;
+    content: string;
+  }): Promise<GatewayChatResult | null> {
+    const slashCommands = resolveTextChannelSlashCommands(params.content);
+    if (!slashCommands) return null;
+
+    const textParts: string[] = [];
+    let pendingApproval:
+      | NonNullable<GatewayChatResult['pendingApproval']>
+      | undefined;
+    let sessionId = params.session.gatewaySessionId;
+
+    for (const args of slashCommands) {
+      if ((args[0] || '').trim().toLowerCase() === 'approve') {
+        const handled = await handleTextChannelApprovalCommand({
+          sessionId,
+          guildId: null,
+          channelId: 'cli',
+          userId: `acp:${params.session.sessionId}`,
+          username: 'ACP',
+          args,
+        });
+        if (!handled) continue;
+        sessionId = handled.sessionId || sessionId;
+        if (handled.text?.trim()) {
+          textParts.push(handled.text);
+        }
+        if (handled.pendingApproval) {
+          pendingApproval = handled.pendingApproval;
+        }
+        continue;
+      }
+
+      const commandResult = await handleGatewayCommand({
+        sessionId,
+        guildId: null,
+        channelId: 'cli',
+        args,
+        userId: `acp:${params.session.sessionId}`,
+        username: 'ACP',
+      });
+      sessionId = commandResult.sessionId || sessionId;
+      const rendered = renderTextChannelCommandResult(commandResult).trim();
+      if (rendered) {
+        textParts.push(rendered);
+      }
+    }
+
+    params.session.gatewaySessionId = sessionId;
+    return {
+      status: 'success',
+      result: textParts.join('\n\n').trim() || 'Done.',
+      toolsUsed: [],
+      sessionId,
+      ...(pendingApproval ? { pendingApproval } : {}),
+    };
+  }
+}
+
+export async function runAcpServer(): Promise<void> {
+  if (!isDatabaseInitialized()) {
+    initDatabase({ quiet: true });
+  }
+  initAgentRegistry(getRuntimeConfig().agents);
+
+  const stream = acp.ndJsonStream(
+    Writable.toWeb(process.stdout) as unknown as WritableStream<Uint8Array>,
+    Readable.toWeb(process.stdin) as unknown as ReadableStream<Uint8Array>,
+  );
+  const connection = new acp.AgentSideConnection(
+    (conn) => new HybridClawAcpAgent(conn),
+    stream,
+  );
+  await connection.closed;
+}

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -100,5 +100,6 @@ async function runAgentInner(
     channelId,
     media,
     blockedTools,
+    mcpServersOverride: params.mcpServersOverride,
   });
 }

--- a/src/agent/executor-types.ts
+++ b/src/agent/executor-types.ts
@@ -5,6 +5,7 @@ import type {
   PluginRuntimeToolDefinition,
   ToolProgressEvent,
 } from '../types/execution.js';
+import type { McpServerConfig } from '../types/models.js';
 import type { ScheduledTask } from '../types/scheduler.js';
 
 export interface ExecutorRequest {
@@ -35,6 +36,7 @@ export interface ExecutorRequest {
   scheduledTasks?: ScheduledTask[];
   allowedTools?: string[];
   blockedTools?: string[];
+  mcpServersOverride?: Record<string, McpServerConfig>;
   onTextDelta?: (delta: string) => void;
   onToolProgress?: (event: ToolProgressEvent) => void;
   onApprovalProgress?: (approval: PendingApproval) => void;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url';
 import { makeLazyApi, normalizeArgs } from './cli/common.js';
 import {
   isHelpRequest,
+  printAcpUsage,
   printAuditUsage,
   printBrowserUsage,
   printDeprecatedProviderAliasWarning,
@@ -1504,6 +1505,16 @@ export async function main(
     case 'gateway':
       await handleGatewayCommand(subargs);
       break;
+    case 'acp': {
+      if (isHelpRequest(subargs)) {
+        printAcpUsage();
+        break;
+      }
+      process.env.HYBRIDCLAW_STDIO_PROTOCOL = 'acp';
+      const { runAcpServer } = await import('./acp/server.js');
+      await runAcpServer();
+      break;
+    }
     case '__gateway-restart-helper': {
       const payload = String(subargs[0] || '').trim();
       if (!payload) {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -12,6 +12,7 @@ export function printMainUsage(): void {
   secret     Manage encrypted runtime secrets and HTTP auth routes
   policy     Manage workspace HTTP/network access rules
   gateway    Manage core runtime (start/stop/status) or run gateway commands
+  acp        Run the ACP stdio bridge for VS Code, Zed, and JetBrains
   eval       Run local eval recipes or launch detached benchmark commands
   tui        Start terminal adapter (starts gateway automatically when needed)
   onboarding Run interactive auth + trust-model onboarding
@@ -46,6 +47,18 @@ Commands:
   hybridclaw gateway show [all|thinking|tools|none]
   hybridclaw gateway reset [yes|no]
   hybridclaw gateway <discord-style command ...>`);
+}
+
+export function printAcpUsage(): void {
+  console.log(`Usage: hybridclaw acp
+
+Runs HybridClaw as an Agent Client Protocol (ACP) stdio server for local IDEs.
+
+Notes:
+  - Intended for ACP-compatible editors such as VS Code, Zed, and JetBrains.
+  - Stdout is reserved for ACP traffic; normal logs are redirected to stderr.
+  - Editor-provided MCP servers are passed through per ACP session.
+  - Local slash commands remain available, including /mcp, /model, /status, /auth, and /config.`);
 }
 
 export function printEvalUsage(): void {
@@ -716,6 +729,7 @@ Topics:
   agent       Help for portable agent archive commands
   auth        Help for unified provider login/logout/status
   gateway     Help for gateway lifecycle and passthrough commands
+  acp         Help for ACP editor integration
   eval        Help for local eval recipes and benchmark runs
   tui         Help for terminal client
   onboarding  Help for onboarding flow
@@ -789,6 +803,9 @@ export async function printHelpTopic(topic: string): Promise<boolean> {
       return true;
     case 'gateway':
       printGatewayUsage();
+      return true;
+    case 'acp':
+      printAcpUsage();
       return true;
     case 'eval':
       printEvalUsage();

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -65,6 +65,7 @@ import {
   normalizeOptionalTrimmedUniqueStringArray,
   normalizeTrimmedStringSet,
 } from '../utils/normalized-strings.js';
+import { emitRuntimeWarning } from '../utils/stdio-warning.js';
 import {
   clearRuntimeConfigRevisions as clearTrackedRuntimeConfigRevisions,
   deleteRuntimeConfigRevision as deleteTrackedRuntimeConfigRevision,
@@ -1459,7 +1460,7 @@ function disableWatcher(reason: string): void {
     clearTimeout(watcherStableTimer);
     watcherStableTimer = null;
   }
-  console.warn(`[runtime-config] watcher disabled: ${reason}`);
+  emitRuntimeWarning(`[runtime-config] watcher disabled: ${reason}`);
 }
 
 function shouldRetryWatcherError(err: unknown): boolean {
@@ -1566,7 +1567,7 @@ function normalizeSkillChannelDisabled(
   for (const [key, rawDisabled] of Object.entries(rawChannelDisabled)) {
     const channelKind = normalizeSkillConfigChannelKind(key);
     if (!channelKind) {
-      console.warn(
+      emitRuntimeWarning(
         `[runtime-config] ignored unknown skills.channelDisabled key: ${key}`,
       );
       continue;
@@ -3316,7 +3317,7 @@ function migrateProviderBaseUrl(params: {
   nextDefault: string;
 }): string {
   if (params.retired.has(params.baseUrl)) {
-    console.warn(
+    emitRuntimeWarning(
       `[runtime-config] migrating ${params.provider} baseUrl ${params.baseUrl} -> ${params.nextDefault}`,
     );
     return params.nextDefault;
@@ -5289,7 +5290,7 @@ function applyConfig(next: RuntimeConfig): void {
     try {
       listener(cloneConfig(currentConfig), cloneConfig(prev));
     } catch (err) {
-      console.warn(
+      emitRuntimeWarning(
         `[runtime-config] listener failed: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
@@ -5334,7 +5335,7 @@ function reloadFromDisk(trigger: string): void {
       path: CONFIG_PATH,
       message: err instanceof Error ? err.message : String(err),
     };
-    console.warn(
+    emitRuntimeWarning(
       `[runtime-config] reload failed (${trigger}): ${err instanceof Error ? err.message : String(err)}`,
     );
   }
@@ -5356,7 +5357,7 @@ function scheduleWatcherRestart(reason: string): void {
     watcherStableTimer = null;
   }
   if (watcherRetryAttempt >= WATCHER_RETRY_MAX_ATTEMPTS) {
-    console.warn(
+    emitRuntimeWarning(
       `[runtime-config] watcher disabled after ${WATCHER_RETRY_MAX_ATTEMPTS} retries (${reason})`,
     );
     return;
@@ -5367,7 +5368,7 @@ function scheduleWatcherRestart(reason: string): void {
     WATCHER_RETRY_BASE_DELAY_MS * 2 ** (watcherRetryAttempt - 1),
     WATCHER_RETRY_MAX_DELAY_MS,
   );
-  console.warn(
+  emitRuntimeWarning(
     `[runtime-config] watcher restart in ${delay}ms (attempt ${watcherRetryAttempt}/${WATCHER_RETRY_MAX_ATTEMPTS})`,
   );
   watcherRestartTimer = startDetachedTimer(() => {
@@ -5424,7 +5425,7 @@ function startWatcher(): void {
         disableWatcher(reason);
         return;
       }
-      console.warn(`[runtime-config] watcher error: ${reason}`);
+      emitRuntimeWarning(`[runtime-config] watcher error: ${reason}`);
       scheduleWatcherRestart(`watcher error: ${reason}`);
     });
   } catch (err) {
@@ -5433,7 +5434,7 @@ function startWatcher(): void {
       disableWatcher(reason);
       return;
     }
-    console.warn(`[runtime-config] watcher setup failed: ${reason}`);
+    emitRuntimeWarning(`[runtime-config] watcher setup failed: ${reason}`);
     scheduleWatcherRestart(`watcher setup failed: ${reason}`);
   }
 }
@@ -5460,14 +5461,14 @@ function migrateConfigSchemaOnStartup(): void {
     raw = fs.readFileSync(CONFIG_PATH, 'utf-8');
     parsed = JSON.parse(raw) as unknown;
   } catch (err) {
-    console.warn(
+    emitRuntimeWarning(
       `[runtime-config] schema migration skipped (invalid JSON): ${err instanceof Error ? err.message : String(err)}`,
     );
     return;
   }
 
   if (!isRecord(parsed)) {
-    console.warn(
+    emitRuntimeWarning(
       '[runtime-config] schema migration skipped: config.json is not an object',
     );
     return;
@@ -5479,7 +5480,7 @@ function migrateConfigSchemaOnStartup(): void {
   try {
     migrated = normalizeRuntimeConfig(parseConfigPatch(parsed));
   } catch (err) {
-    console.warn(
+    emitRuntimeWarning(
       `[runtime-config] schema migration skipped: ${err instanceof Error ? err.message : String(err)}`,
     );
     return;
@@ -5513,7 +5514,7 @@ function migrateConfigSchemaOnStartup(): void {
       );
     }
   } catch (err) {
-    console.warn(
+    emitRuntimeWarning(
       `[runtime-config] schema migration failed: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
@@ -5696,7 +5697,7 @@ export function updateRuntimeConfig(
       source: 'external',
     });
   } catch (err) {
-    console.warn(
+    emitRuntimeWarning(
       `[runtime-config] update using in-memory config after reload failure: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
@@ -5718,7 +5719,7 @@ export function setRuntimeConfigSecretInput(
     });
     baseSource = currentConfigSource;
   } catch (err) {
-    console.warn(
+    emitRuntimeWarning(
       `[runtime-config] secret input update using in-memory config after reload failure: ${err instanceof Error ? err.message : String(err)}`,
     );
   }

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -897,6 +897,7 @@ async function handleGatewayMessageInner(
       agentId,
       workspacePathOverride: req.workspacePathOverride,
       workspaceDisplayRootOverride: req.workspaceDisplayRootOverride,
+      mcpServersOverride: req.mcpServersOverride,
       skipContainerSystemPrompt: req.promptMode === 'none',
       maxTokens: req.maxTokens,
       maxWallClockMs: req.maxWallClockMs,

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -156,6 +156,7 @@ export interface GatewayChatRequest {
   neverAutoApproveTools?: string[];
   workspacePathOverride?: string;
   workspaceDisplayRootOverride?: string;
+  mcpServersOverride?: Record<string, McpServerConfig>;
   maxTokens?: number;
   maxWallClockMs?: number | null;
   inactivityTimeoutMs?: number | null;

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -72,6 +72,7 @@ import {
   readOutput,
   writeInput,
 } from './ipc.js';
+import { mergeSessionMcpServers } from './mcp-server-config.js';
 import {
   consumeCollapsedStreamDebugLine,
   createStreamDebugState,
@@ -800,6 +801,10 @@ async function runContainerInner(
 
   cleanupIpc(sessionId);
   ensureSessionDirs(sessionId);
+  const mcpServers = mergeSessionMcpServers(
+    MCP_SERVERS,
+    params.mcpServersOverride,
+  );
 
   const input: ContainerInput = {
     sessionId,
@@ -845,7 +850,7 @@ async function runContainerInner(
     media,
     audioTranscriptsPrepended,
     pluginTools,
-    mcpServers: MCP_SERVERS,
+    mcpServers,
     taskModels,
     contextGuard: {
       enabled: CONTEXT_GUARD_ENABLED,
@@ -870,6 +875,7 @@ async function runContainerInner(
     apiKey: input.apiKey,
     requestHeaders: input.requestHeaders,
     taskModels: input.taskModels,
+    mcpServers,
     workspacePathOverride: params.workspacePathOverride,
     workspaceDisplayRootOverride: params.workspaceDisplayRootOverride,
     bashProxy: params.bashProxy,

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -60,6 +60,7 @@ import {
   readOutput,
   writeInput,
 } from './ipc.js';
+import { mergeSessionMcpServers } from './mcp-server-config.js';
 import {
   consumeCollapsedStreamDebugLine,
   createStreamDebugState,
@@ -685,6 +686,10 @@ async function runHostProcessInner(
 
   cleanupIpc(sessionId);
   ensureSessionDirs(sessionId);
+  const mcpServers = mergeSessionMcpServers(
+    MCP_SERVERS,
+    params.mcpServersOverride,
+  );
 
   const input: ContainerInput = {
     sessionId,
@@ -730,7 +735,7 @@ async function runHostProcessInner(
     media,
     audioTranscriptsPrepended,
     pluginTools,
-    mcpServers: MCP_SERVERS,
+    mcpServers,
     taskModels,
     contextGuard: {
       enabled: CONTEXT_GUARD_ENABLED,
@@ -755,6 +760,7 @@ async function runHostProcessInner(
     apiKey: input.apiKey,
     requestHeaders: input.requestHeaders,
     taskModels: input.taskModels,
+    mcpServers,
     workspacePathOverride: params.workspacePathOverride,
     workspaceDisplayRootOverride: params.workspaceDisplayRootOverride,
     bashProxy: params.bashProxy,

--- a/src/infra/mcp-server-config.ts
+++ b/src/infra/mcp-server-config.ts
@@ -1,0 +1,72 @@
+import type { McpServerConfig } from '../types/models.js';
+
+function cloneStringArray(values?: string[]): string[] | undefined {
+  return Array.isArray(values) ? [...values] : undefined;
+}
+
+function cloneStringRecord(
+  values?: Record<string, string>,
+): Record<string, string> | undefined {
+  return values ? { ...values } : undefined;
+}
+
+export function cloneMcpServerConfig(config: McpServerConfig): McpServerConfig {
+  return {
+    transport: config.transport,
+    ...(typeof config.command === 'string' ? { command: config.command } : {}),
+    ...(Array.isArray(config.args)
+      ? { args: cloneStringArray(config.args) }
+      : {}),
+    ...(config.env ? { env: cloneStringRecord(config.env) } : {}),
+    ...(typeof config.cwd === 'string' ? { cwd: config.cwd } : {}),
+    ...(typeof config.url === 'string' ? { url: config.url } : {}),
+    ...(config.headers ? { headers: cloneStringRecord(config.headers) } : {}),
+    ...(typeof config.enabled === 'boolean' ? { enabled: config.enabled } : {}),
+  };
+}
+
+export function mergeSessionMcpServers(
+  configuredServers: Record<string, McpServerConfig> | undefined,
+  sessionOverride: Record<string, McpServerConfig> | undefined,
+): Record<string, McpServerConfig> {
+  const merged: Record<string, McpServerConfig> = {};
+
+  for (const [name, config] of Object.entries(configuredServers || {})) {
+    merged[name] = cloneMcpServerConfig(config);
+  }
+
+  for (const [name, config] of Object.entries(sessionOverride || {})) {
+    merged[name] = cloneMcpServerConfig(config);
+  }
+
+  return merged;
+}
+
+function normalizeRecord(
+  values?: Record<string, string>,
+): Array<[string, string]> {
+  return Object.entries(values || {})
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => [key, value]);
+}
+
+export function normalizeMcpServersForSignature(
+  mcpServers?: Record<string, McpServerConfig>,
+): Array<[string, Record<string, unknown>]> {
+  return Object.entries(mcpServers || {})
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, config]) => [
+      name,
+      {
+        transport: config.transport,
+        command: String(config.command || '').trim(),
+        args: Array.isArray(config.args) ? [...config.args] : [],
+        env: normalizeRecord(config.env),
+        cwd: String(config.cwd || '').trim(),
+        url: String(config.url || '').trim(),
+        headers: normalizeRecord(config.headers),
+        enabled:
+          typeof config.enabled === 'boolean' ? config.enabled : undefined,
+      },
+    ]);
+}

--- a/src/infra/worker-signature.ts
+++ b/src/infra/worker-signature.ts
@@ -1,4 +1,9 @@
-import { TASK_MODEL_KEYS, type TaskModelKey } from '../types/models.js';
+import {
+  type McpServerConfig,
+  TASK_MODEL_KEYS,
+  type TaskModelKey,
+} from '../types/models.js';
+import { normalizeMcpServersForSignature } from './mcp-server-config.js';
 
 interface WorkerSignatureTaskModel {
   provider?: string;
@@ -21,6 +26,7 @@ export interface WorkerSignatureInput {
   apiKey: string;
   requestHeaders: Record<string, string> | undefined;
   taskModels?: Partial<Record<TaskModelKey, WorkerSignatureTaskModel>>;
+  mcpServers?: Record<string, McpServerConfig>;
   workspacePathOverride?: string;
   workspaceDisplayRootOverride?: string;
   bashProxy?:
@@ -84,6 +90,7 @@ export function computeWorkerSignature(input: WorkerSignatureInput): string {
     apiKey: String(input.apiKey || ''),
     requestHeaders: normalizedHeaders,
     taskModels,
+    mcpServers: normalizeMcpServersForSignature(input.mcpServers),
     workspacePathOverride: String(input.workspacePathOverride || '').trim(),
     workspaceDisplayRootOverride: String(
       input.workspaceDisplayRootOverride || '',

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -40,6 +40,9 @@ const initialLevel = forcedLevel || getRuntimeConfig().ops.logLevel;
 const gatewayLogFile = String(
   process.env.HYBRIDCLAW_GATEWAY_LOG_FILE || '',
 ).trim();
+const stdioProtocol = String(process.env.HYBRIDCLAW_STDIO_PROTOCOL || '')
+  .trim()
+  .toLowerCase();
 
 function createPrettyDestination(
   prettyOptions: typeof LOGGER_PRETTY_OPTIONS,
@@ -85,7 +88,10 @@ function createLogger() {
   const streams: Array<{ level: 'trace'; stream: NodeJS.WritableStream }> = [
     {
       level: 'trace',
-      stream: createPrettyDestination(LOGGER_PRETTY_OPTIONS, process.stdout),
+      stream: createPrettyDestination(
+        LOGGER_PRETTY_OPTIONS,
+        stdioProtocol === 'acp' ? process.stderr : process.stdout,
+      ),
     },
   ];
 

--- a/src/security/runtime-secrets.ts
+++ b/src/security/runtime-secrets.ts
@@ -8,6 +8,7 @@ import {
 import fs from 'node:fs';
 import path from 'node:path';
 import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+import { emitRuntimeWarning } from '../utils/stdio-warning.js';
 import { migrateLegacySecretFile } from './runtime-secrets-migration.js';
 
 const RUNTIME_SECRETS_FILE = 'credentials.json';
@@ -166,7 +167,7 @@ function ensureExistingRuntimeHomePermissions(): void {
   try {
     fs.chmodSync(DEFAULT_RUNTIME_HOME_DIR, RUNTIME_HOME_MODE);
   } catch (error) {
-    console.warn(
+    emitRuntimeWarning(
       `[runtime-secrets] failed to set permissions on ${DEFAULT_RUNTIME_HOME_DIR}: ${error instanceof Error ? error.message : String(error)}`,
     );
   } finally {
@@ -182,7 +183,7 @@ function ensureRuntimeHomeDir(): void {
   try {
     fs.chmodSync(DEFAULT_RUNTIME_HOME_DIR, RUNTIME_HOME_MODE);
   } catch (error) {
-    console.warn(
+    emitRuntimeWarning(
       `[runtime-secrets] failed to set permissions on ${DEFAULT_RUNTIME_HOME_DIR}: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
@@ -222,7 +223,7 @@ function readMasterKeyFile(filePath: string): Buffer | null {
     const raw = fs.readFileSync(filePath, 'utf-8');
     return parseMasterKey(raw);
   } catch (error) {
-    console.warn(
+    emitRuntimeWarning(
       `[runtime-secrets] failed to load master key from ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
     );
     return null;
@@ -380,7 +381,7 @@ function decryptEncryptedSecretStore(
       decryptFailures += 1;
       lastDecryptError =
         error instanceof Error ? error : new Error(String(error));
-      console.warn(
+      emitRuntimeWarning(
         `[runtime-secrets] failed to decrypt stored ${secretKey}: ${lastDecryptError.message}`,
       );
       continue;
@@ -522,7 +523,7 @@ class SecretStore {
             status: 'encrypted',
           });
         } catch (error) {
-          console.warn(
+          emitRuntimeWarning(
             `[runtime-secrets] failed to decrypt ${this.filePath}: ${error instanceof Error ? error.message : String(error)}`,
           );
           return cacheSecretStoreRead({
@@ -550,7 +551,7 @@ class SecretStore {
         status: 'invalid',
       });
     } catch (err) {
-      console.warn(
+      emitRuntimeWarning(
         `[runtime-secrets] failed to read ${this.filePath}: ${err instanceof Error ? err.message : String(err)}`,
       );
       return cacheSecretStoreRead({
@@ -597,7 +598,7 @@ class SecretStore {
         };
       },
       onValidatedBackupRemovalError: (error) => {
-        console.warn(
+        emitRuntimeWarning(
           `[runtime-secrets] failed to remove validated legacy backup ${legacyPath}: ${error instanceof Error ? error.message : String(error)}`,
         );
       },
@@ -668,7 +669,7 @@ function readLegacyEnvSecrets(cwd: string = process.cwd()): RuntimeSecrets {
   try {
     return parseEnvStyleSecrets(fs.readFileSync(envPath, 'utf-8'));
   } catch (err) {
-    console.warn(
+    emitRuntimeWarning(
       `[runtime-secrets] failed to read ${envPath}: ${err instanceof Error ? err.message : String(err)}`,
     );
     return {};
@@ -721,7 +722,7 @@ export function migrateLegacyRuntimeSecretsFile(): boolean {
     store.migrateLegacyPlaintextFile(plaintextSecrets);
     return true;
   } catch (err) {
-    console.warn(
+    emitRuntimeWarning(
       `[runtime-secrets] failed to migrate legacy plaintext credentials at ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
     );
     return false;
@@ -754,7 +755,7 @@ export function loadRuntimeSecrets(cwd: string = process.cwd()): void {
     try {
       store.writeAll({ ...secrets, ...migratedSecrets });
     } catch (err) {
-      console.warn(
+      emitRuntimeWarning(
         `[runtime-secrets] failed to migrate legacy .env secrets to ${destination}: ${err instanceof Error ? err.message : String(err)}`,
       );
     }

--- a/src/utils/stdio-warning.ts
+++ b/src/utils/stdio-warning.ts
@@ -1,0 +1,15 @@
+function isAcpStdioProtocol(): boolean {
+  return (
+    String(process.env.HYBRIDCLAW_STDIO_PROTOCOL || '')
+      .trim()
+      .toLowerCase() === 'acp'
+  );
+}
+
+export function emitRuntimeWarning(message: string): void {
+  if (isAcpStdioProtocol()) {
+    process.stderr.write(`${message}\n`);
+    return;
+  }
+  console.warn(message);
+}

--- a/tests/acp-mcp.test.ts
+++ b/tests/acp-mcp.test.ts
@@ -1,0 +1,87 @@
+import { expect, test } from 'vitest';
+
+import { acpMcpServersToConfigMap } from '../src/acp/mcp.js';
+import { mergeSessionMcpServers } from '../src/infra/mcp-server-config.js';
+
+test('acpMcpServersToConfigMap converts stdio and remote MCP servers', () => {
+  const servers = acpMcpServersToConfigMap([
+    {
+      name: 'filesystem',
+      command: 'npx',
+      args: ['-y', '@modelcontextprotocol/server-filesystem', '/workspace'],
+      env: [{ name: 'DEBUG', value: '1' }],
+    },
+    {
+      type: 'http',
+      name: 'github',
+      url: 'https://example.com/mcp',
+      headers: [{ name: 'Authorization', value: 'Bearer test' }],
+    },
+    {
+      type: 'sse',
+      name: 'slack',
+      url: 'https://example.com/sse',
+      headers: [],
+    },
+  ]);
+
+  expect(servers).toEqual({
+    filesystem: {
+      transport: 'stdio',
+      command: 'npx',
+      args: ['-y', '@modelcontextprotocol/server-filesystem', '/workspace'],
+      env: { DEBUG: '1' },
+    },
+    github: {
+      transport: 'http',
+      url: 'https://example.com/mcp',
+      headers: { Authorization: 'Bearer test' },
+    },
+    slack: {
+      transport: 'sse',
+      url: 'https://example.com/sse',
+    },
+  });
+});
+
+test('mergeSessionMcpServers overlays runtime MCP config with ACP session overrides', () => {
+  const merged = mergeSessionMcpServers(
+    {
+      filesystem: {
+        transport: 'stdio',
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-filesystem', '/workspace'],
+      },
+      github: {
+        transport: 'http',
+        url: 'https://runtime.example/mcp',
+      },
+    },
+    {
+      github: {
+        transport: 'http',
+        url: 'https://editor.example/mcp',
+      },
+      slack: {
+        transport: 'sse',
+        url: 'https://editor.example/sse',
+      },
+    },
+  );
+
+  expect(merged).toEqual({
+    filesystem: {
+      transport: 'stdio',
+      command: 'npx',
+      args: ['-y', '@modelcontextprotocol/server-filesystem', '/workspace'],
+    },
+    github: {
+      transport: 'http',
+      url: 'https://editor.example/mcp',
+    },
+    slack: {
+      transport: 'sse',
+      url: 'https://editor.example/sse',
+    },
+  });
+});

--- a/tests/acp-prompt.test.ts
+++ b/tests/acp-prompt.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from 'vitest';
+
+import {
+  buildAcpAvailableCommands,
+  convertAcpPromptBlocks,
+} from '../src/acp/prompt.js';
+
+test('convertAcpPromptBlocks lifts inline images and embedded text resources', () => {
+  const prompt = convertAcpPromptBlocks([
+    {
+      type: 'text',
+      text: 'Inspect the current workspace.',
+    },
+    {
+      type: 'image',
+      mimeType: 'image/png',
+      data: 'aGVsbG8=',
+      uri: 'file:///tmp/screenshot.png',
+    },
+    {
+      type: 'resource',
+      resource: {
+        uri: 'file:///tmp/README.md',
+        text: '# README',
+        mimeType: 'text/markdown',
+      },
+    },
+    {
+      type: 'resource_link',
+      name: 'package.json',
+      uri: 'file:///tmp/package.json',
+      mimeType: 'application/json',
+    },
+  ]);
+
+  expect(prompt.content).toContain('Inspect the current workspace.');
+  expect(prompt.content).toContain(
+    '[Embedded resource: file:///tmp/README.md]',
+  );
+  expect(prompt.content).toContain('# README');
+  expect(prompt.content).toContain(
+    '[Resource: package.json (file:///tmp/package.json)]',
+  );
+  expect(prompt.media).toEqual([
+    expect.objectContaining({
+      filename: 'screenshot.png',
+      mimeType: 'image/png',
+      url: expect.stringMatching(/^data:image\/png;base64,/),
+      originalUrl: 'file:///tmp/screenshot.png',
+    }),
+  ]);
+});
+
+test('buildAcpAvailableCommands exposes local slash commands and excludes tui-only ones', () => {
+  const commands = buildAcpAvailableCommands();
+
+  expect(commands).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ name: 'mcp' }),
+      expect.objectContaining({ name: 'model' }),
+      expect.objectContaining({ name: 'status' }),
+      expect.objectContaining({ name: 'auth' }),
+    ]),
+  );
+  expect(commands.some((command) => command.name === 'paste')).toBe(false);
+  expect(commands.some((command) => command.name === 'exit')).toBe(false);
+});

--- a/tests/gateway-chat-service.acp.test.ts
+++ b/tests/gateway-chat-service.acp.test.ts
@@ -1,0 +1,67 @@
+import { expect, test, vi } from 'vitest';
+import { setupGatewayTest } from './helpers/gateway-test-setup.js';
+
+const { runAgentMock } = vi.hoisted(() => ({
+  runAgentMock: vi.fn(),
+}));
+
+vi.mock('../src/agent/agent.js', () => ({
+  runAgent: runAgentMock,
+}));
+
+const { setupHome } = setupGatewayTest({
+  tempHomePrefix: 'hybridclaw-gateway-acp-',
+  cleanup: () => {
+    runAgentMock.mockReset();
+  },
+});
+
+test('handleGatewayMessage forwards ACP workspace and MCP overrides to runAgent', async () => {
+  setupHome();
+
+  runAgentMock.mockResolvedValue({
+    status: 'success',
+    result: 'ok',
+    toolsUsed: [],
+    toolExecutions: [],
+  });
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayMessage } = await import(
+    '../src/gateway/gateway-chat-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+
+  await handleGatewayMessage({
+    sessionId: 'acp-session',
+    guildId: null,
+    channelId: 'cli',
+    userId: 'acp:user',
+    username: 'ACP',
+    source: 'acp',
+    content: 'List configured MCP servers.',
+    chatbotId: 'bot-1',
+    workspacePathOverride: '/tmp/acp-workspace',
+    workspaceDisplayRootOverride: '/tmp/acp-workspace',
+    mcpServersOverride: {
+      github: {
+        transport: 'http',
+        url: 'https://editor.example/mcp',
+      },
+    },
+  });
+
+  expect(runAgentMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      workspacePathOverride: '/tmp/acp-workspace',
+      workspaceDisplayRootOverride: '/tmp/acp-workspace',
+      mcpServersOverride: {
+        github: {
+          transport: 'http',
+          url: 'https://editor.example/mcp',
+        },
+      },
+    }),
+  );
+});

--- a/tests/worker-signature.test.ts
+++ b/tests/worker-signature.test.ts
@@ -108,3 +108,37 @@ test('computeWorkerSignature changes when auxiliary task routing changes', () =>
     }),
   ).not.toBe(baseline);
 });
+
+test('computeWorkerSignature changes when session MCP routing changes', () => {
+  const baseline = computeWorkerSignature({
+    agentId: 'main',
+    provider: 'hybridai',
+    baseUrl: 'https://hybridai.one',
+    apiKey: 'main-secret',
+    requestHeaders: {},
+    mcpServers: {
+      filesystem: {
+        transport: 'stdio',
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-filesystem', '/workspace'],
+      },
+    },
+  });
+
+  expect(
+    computeWorkerSignature({
+      agentId: 'main',
+      provider: 'hybridai',
+      baseUrl: 'https://hybridai.one',
+      apiKey: 'main-secret',
+      requestHeaders: {},
+      mcpServers: {
+        filesystem: {
+          transport: 'stdio',
+          command: 'npx',
+          args: ['-y', '@modelcontextprotocol/server-filesystem', '/tmp'],
+        },
+      },
+    }),
+  ).not.toBe(baseline);
+});


### PR DESCRIPTION
## Summary
Adds Agent Client Protocol integration for IDEs by introducing a `hybridclaw acp` stdio server and wiring editor-provided MCP servers through the existing gateway and runner paths.

## What Changed
- add an ACP bridge for VS Code, Zed, and JetBrains with session lifecycle, prompt handling, cancellation, slash command support, and approval passthrough
- convert ACP prompt content blocks into HybridClaw prompt/media input and stream text/tool progress back as ACP events
- thread per-session MCP server overrides through gateway, executor, host runner, container runner, and worker signatures
- move ACP-mode logs and startup warnings off stdout so the stdio protocol stays clean
- add targeted ACP and worker-signature tests

## Validation
- `npm run typecheck`
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/acp-prompt.test.ts tests/acp-mcp.test.ts tests/gateway-chat-service.acp.test.ts tests/worker-signature.test.ts`
- `./node_modules/.bin/tsx src/cli.ts help acp` with stdout/stderr split to confirm help text stays on stdout and runtime warnings go to stderr

## Notes
- ACP `loadSession` / resume is not implemented yet
- ACP multi-root `additionalDirectories` handling is not implemented yet
- editor MCP config is applied per ACP session and overrides runtime-config MCP servers for that session
