### PR TITLE
ci: optimize caching and release image promotion flow

### DIFF
--- a/.github/actions/promote-image/action.yml
+++ b/.github/actions/promote-image/action.yml
@@ -1,0 +1,80 @@
+name: Promote Image
+description: Promote a multi-arch source image to one or more target tags.
+
+inputs:
+  source:
+    description: Source image tag to promote from.
+    required: true
+  target-tags:
+    description: Newline-delimited list of target tags.
+    required: true
+  max-attempts-push:
+    description: Poll attempts for push-triggered runs.
+    required: false
+    default: '80'
+  max-attempts-other:
+    description: Poll attempts for non-push runs.
+    required: false
+    default: '1'
+  sleep-seconds:
+    description: Sleep duration between poll attempts.
+    required: false
+    default: '15'
+
+outputs:
+  promoted:
+    description: Whether promotion succeeded.
+    value: ${{ steps.promote.outputs.promoted }}
+
+runs:
+  using: composite
+  steps:
+    - name: Promote image tags
+      id: promote
+      shell: bash
+      env:
+        SOURCE: ${{ inputs.source }}
+        TARGET_TAGS: ${{ inputs.target-tags }}
+        MAX_ATTEMPTS_PUSH: ${{ inputs.max-attempts-push }}
+        MAX_ATTEMPTS_OTHER: ${{ inputs.max-attempts-other }}
+        SLEEP_SECONDS: ${{ inputs.sleep-seconds }}
+      run: |
+        set -euo pipefail
+
+        MAX_ATTEMPTS="${MAX_ATTEMPTS_OTHER}"
+        if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+          MAX_ATTEMPTS="${MAX_ATTEMPTS_PUSH}"
+        fi
+
+        RAW=""
+        for ((_attempt=1; _attempt<=MAX_ATTEMPTS; _attempt++)); do
+          RAW="$(docker buildx imagetools inspect --raw "${SOURCE}" 2>/dev/null || true)"
+          if [[ -n "${RAW}" ]]; then
+            break
+          fi
+          echo "Waiting for source image ${SOURCE}..."
+          sleep "${SLEEP_SECONDS}"
+        done
+
+        if [[ -z "${RAW}" ]]; then
+          echo "Source image not available; falling back to build."
+          echo "promoted=false" >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
+
+        if ! jq -e '
+          (.manifests // [])
+          | map(.platform.architecture)
+          | (index("amd64") and index("arm64"))
+        ' <<< "${RAW}" >/dev/null; then
+          echo "Source image is not multi-arch; falling back to build."
+          echo "promoted=false" >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
+
+        while IFS= read -r tag; do
+          [[ -n "${tag}" ]] || continue
+          docker buildx imagetools create --tag "${tag}" "${SOURCE}"
+        done <<< "${TARGET_TAGS}"
+
+        echo "promoted=true" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/setup-node-workspace/action.yml
+++ b/.github/actions/setup-node-workspace/action.yml
@@ -14,11 +14,15 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         cache: npm
+        cache-dependency-path: |
+          package-lock.json
+          container/package-lock.json
+          console/package-lock.json
 
     - name: Install root dependencies
       shell: bash
-      run: npm ci
+      run: npm ci --no-audit --fund=false
 
     - name: Install container dependencies
       shell: bash
-      run: npm run setup
+      run: npm --prefix container ci --no-audit --fund=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   # Build Docker images (no push) to catch Dockerfile regressions before merge.
   docker-preflight:
-    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     env:
       HAS_HYBRIDAI_API_KEY: ${{ secrets.HYBRIDAI_API_KEY != '' }}
@@ -28,9 +28,11 @@ jobs:
             context: ./container
             file: ./container/Dockerfile
             target: runtime
+            cache_scope: hybridclaw-agent
           - name: gateway
             context: .
             file: ./Dockerfile
+            cache_scope: hybridclaw-gateway
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -47,8 +49,8 @@ jobs:
           push: false
           load: true
           tags: hybridclaw-${{ matrix.name }}:preflight
-          cache-from: type=gha,scope=${{ matrix.name }}-preflight
-          cache-to: type=gha,mode=max,scope=${{ matrix.name }}-preflight
+          cache-from: type=gha,scope=${{ matrix.cache_scope }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.cache_scope }}
 
       - name: Setup Node.js workspace
         uses: ./.github/actions/setup-node-workspace

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,11 +24,11 @@ jobs:
             context: ./container
             file: ./container/Dockerfile
             target: runtime
-            scope: agent-main
+            scope: hybridclaw-agent
           - image: hybridclaw-gateway
             context: .
             file: ./Dockerfile
-            scope: gateway-main
+            scope: hybridclaw-gateway
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -43,6 +43,9 @@ jobs:
           IMAGE="ghcr.io/${OWNER_LC}/${{ matrix.image }}"
           TAGS="${IMAGE}:sha-${SHA_SHORT}"$'\n'"${IMAGE}:main"
           { echo "tags<<EOF"; echo "${TAGS}"; echo "EOF"; } >> "${GITHUB_OUTPUT}"
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Setup Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -63,7 +66,7 @@ jobs:
           push: true
           provenance: false
           sbom: false
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -28,6 +28,9 @@ jobs:
       ref: ${{ steps.check.outputs.ref }}
       publish_dockerhub: ${{ steps.check.outputs.publish_dockerhub }}
       labels: ${{ steps.check.outputs.labels }}
+      owner_lc: ${{ steps.check.outputs.owner_lc }}
+      sha: ${{ steps.check.outputs.sha }}
+      sha_short: ${{ steps.check.outputs.sha_short }}
     steps:
       - name: Resolve target ref
         id: resolve
@@ -79,14 +82,20 @@ jobs:
           if [[ -n "${DOCKERHUB_USERNAME}" && -n "${DOCKERHUB_TOKEN}" ]]; then
             PUBLISH_DOCKERHUB=true
           fi
+          OWNER_LC="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          SHA="$(git rev-parse HEAD)"
+          SHA_SHORT="${SHA::7}"
 
           {
             echo "tag=${TAG}"
             echo "ref=${{ steps.resolve.outputs.ref }}"
             echo "publish_dockerhub=${PUBLISH_DOCKERHUB}"
+            echo "owner_lc=${OWNER_LC}"
+            echo "sha=${SHA}"
+            echo "sha_short=${SHA_SHORT}"
             echo "labels<<EOF"
             echo "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}"
-            echo "org.opencontainers.image.revision=${GITHUB_SHA}"
+            echo "org.opencontainers.image.revision=${SHA}"
             echo "org.opencontainers.image.version=${TAG}"
             echo "EOF"
           } >> "${GITHUB_OUTPUT}"
@@ -122,9 +131,6 @@ jobs:
           fi
           { echo "tags<<EOF"; echo "${TAGS}"; echo "EOF"; } >> "${GITHUB_OUTPUT}"
 
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
-
       - name: Setup Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -134,7 +140,70 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME || github.actor }}
+          password: ${{ secrets.GHCR_TOKEN || github.token }}
+
+      - name: Promote agent image from main build
+        id: promote
+        shell: bash
+        env:
+          SOURCE: ghcr.io/${{ needs.validate.outputs.owner_lc }}/hybridclaw-agent:sha-${{ needs.validate.outputs.sha_short }}
+          TARGET_TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+
+          MAX_ATTEMPTS=1
+          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            MAX_ATTEMPTS=80
+          fi
+
+          RAW=""
+          for ((_attempt=1; _attempt<=MAX_ATTEMPTS; _attempt++)); do
+            RAW="$(docker buildx imagetools inspect --raw "${SOURCE}" 2>/dev/null || true)"
+            if [[ -n "${RAW}" ]]; then
+              break
+            fi
+            echo "Waiting for source image ${SOURCE}..."
+            sleep 15
+          done
+
+          if [[ -z "${RAW}" ]]; then
+            echo "Source image not available; falling back to build."
+            echo "promoted=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if ! jq -e '
+            (.manifests // [])
+            | map(.platform.architecture)
+            | (index("amd64") and index("arm64"))
+          ' <<< "${RAW}" >/dev/null; then
+            echo "Source image is not multi-arch; falling back to build."
+            echo "promoted=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          while IFS= read -r tag; do
+            [[ -n "${tag}" ]] || continue
+            docker buildx imagetools create --tag "${tag}" "${SOURCE}"
+          done <<< "${TARGET_TAGS}"
+
+          echo "promoted=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Setup QEMU
+        if: steps.promote.outputs.promoted != 'true'
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
+      - name: Setup Buildx for fallback build
+        if: steps.promote.outputs.promoted != 'true'
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
       - name: Build and push agent image
+        if: steps.promote.outputs.promoted != 'true'
         id: push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
@@ -146,8 +215,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ needs.validate.outputs.labels }}
-          cache-from: type=gha,scope=agent-release
-          cache-to: type=gha,mode=max,scope=agent-release
+          cache-from: type=gha,scope=hybridclaw-agent
+          cache-to: type=gha,mode=max,scope=hybridclaw-agent
 
       - name: Verify published agent tags
         uses: ./.github/actions/verify-published-tags
@@ -187,9 +256,6 @@ jobs:
           fi
           { echo "tags<<EOF"; echo "${TAGS}"; echo "EOF"; } >> "${GITHUB_OUTPUT}"
 
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
-
       - name: Setup Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -207,7 +273,63 @@ jobs:
           username: ${{ secrets.GHCR_USERNAME || github.actor }}
           password: ${{ secrets.GHCR_TOKEN || github.token }}
 
+      - name: Promote gateway image from main build
+        id: promote
+        shell: bash
+        env:
+          SOURCE: ghcr.io/${{ needs.validate.outputs.owner_lc }}/hybridclaw-gateway:sha-${{ needs.validate.outputs.sha_short }}
+          TARGET_TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+
+          MAX_ATTEMPTS=1
+          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            MAX_ATTEMPTS=80
+          fi
+
+          RAW=""
+          for ((_attempt=1; _attempt<=MAX_ATTEMPTS; _attempt++)); do
+            RAW="$(docker buildx imagetools inspect --raw "${SOURCE}" 2>/dev/null || true)"
+            if [[ -n "${RAW}" ]]; then
+              break
+            fi
+            echo "Waiting for source image ${SOURCE}..."
+            sleep 15
+          done
+
+          if [[ -z "${RAW}" ]]; then
+            echo "Source image not available; falling back to build."
+            echo "promoted=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if ! jq -e '
+            (.manifests // [])
+            | map(.platform.architecture)
+            | (index("amd64") and index("arm64"))
+          ' <<< "${RAW}" >/dev/null; then
+            echo "Source image is not multi-arch; falling back to build."
+            echo "promoted=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          while IFS= read -r tag; do
+            [[ -n "${tag}" ]] || continue
+            docker buildx imagetools create --tag "${tag}" "${SOURCE}"
+          done <<< "${TARGET_TAGS}"
+
+          echo "promoted=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Setup QEMU
+        if: steps.promote.outputs.promoted != 'true'
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
+      - name: Setup Buildx for fallback build
+        if: steps.promote.outputs.promoted != 'true'
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
       - name: Build and push gateway image
+        if: steps.promote.outputs.promoted != 'true'
         id: push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
@@ -219,8 +341,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ needs.validate.outputs.labels }}
-          cache-from: type=gha,scope=gateway-release
-          cache-to: type=gha,mode=max,scope=gateway-release
+          cache-from: type=gha,scope=hybridclaw-gateway
+          cache-to: type=gha,mode=max,scope=hybridclaw-gateway
 
       - name: Verify published gateway tags
         uses: ./.github/actions/verify-published-tags

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -131,6 +131,9 @@ jobs:
           fi
           { echo "tags<<EOF"; echo "${TAGS}"; echo "EOF"; } >> "${GITHUB_OUTPUT}"
 
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
       - name: Setup Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -149,58 +152,10 @@ jobs:
 
       - name: Promote agent image from main build
         id: promote
-        shell: bash
-        env:
-          SOURCE: ghcr.io/${{ needs.validate.outputs.owner_lc }}/hybridclaw-agent:sha-${{ needs.validate.outputs.sha_short }}
-          TARGET_TAGS: ${{ steps.meta.outputs.tags }}
-        run: |
-          set -euo pipefail
-
-          MAX_ATTEMPTS=1
-          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
-            MAX_ATTEMPTS=80
-          fi
-
-          RAW=""
-          for ((_attempt=1; _attempt<=MAX_ATTEMPTS; _attempt++)); do
-            RAW="$(docker buildx imagetools inspect --raw "${SOURCE}" 2>/dev/null || true)"
-            if [[ -n "${RAW}" ]]; then
-              break
-            fi
-            echo "Waiting for source image ${SOURCE}..."
-            sleep 15
-          done
-
-          if [[ -z "${RAW}" ]]; then
-            echo "Source image not available; falling back to build."
-            echo "promoted=false" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          if ! jq -e '
-            (.manifests // [])
-            | map(.platform.architecture)
-            | (index("amd64") and index("arm64"))
-          ' <<< "${RAW}" >/dev/null; then
-            echo "Source image is not multi-arch; falling back to build."
-            echo "promoted=false" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          while IFS= read -r tag; do
-            [[ -n "${tag}" ]] || continue
-            docker buildx imagetools create --tag "${tag}" "${SOURCE}"
-          done <<< "${TARGET_TAGS}"
-
-          echo "promoted=true" >> "${GITHUB_OUTPUT}"
-
-      - name: Setup QEMU
-        if: steps.promote.outputs.promoted != 'true'
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
-
-      - name: Setup Buildx for fallback build
-        if: steps.promote.outputs.promoted != 'true'
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: ./.github/actions/promote-image
+        with:
+          source: ghcr.io/${{ needs.validate.outputs.owner_lc }}/hybridclaw-agent:sha-${{ needs.validate.outputs.sha_short }}
+          target-tags: ${{ steps.meta.outputs.tags }}
 
       - name: Build and push agent image
         if: steps.promote.outputs.promoted != 'true'
@@ -256,6 +211,9 @@ jobs:
           fi
           { echo "tags<<EOF"; echo "${TAGS}"; echo "EOF"; } >> "${GITHUB_OUTPUT}"
 
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
       - name: Setup Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -275,58 +233,10 @@ jobs:
 
       - name: Promote gateway image from main build
         id: promote
-        shell: bash
-        env:
-          SOURCE: ghcr.io/${{ needs.validate.outputs.owner_lc }}/hybridclaw-gateway:sha-${{ needs.validate.outputs.sha_short }}
-          TARGET_TAGS: ${{ steps.meta.outputs.tags }}
-        run: |
-          set -euo pipefail
-
-          MAX_ATTEMPTS=1
-          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
-            MAX_ATTEMPTS=80
-          fi
-
-          RAW=""
-          for ((_attempt=1; _attempt<=MAX_ATTEMPTS; _attempt++)); do
-            RAW="$(docker buildx imagetools inspect --raw "${SOURCE}" 2>/dev/null || true)"
-            if [[ -n "${RAW}" ]]; then
-              break
-            fi
-            echo "Waiting for source image ${SOURCE}..."
-            sleep 15
-          done
-
-          if [[ -z "${RAW}" ]]; then
-            echo "Source image not available; falling back to build."
-            echo "promoted=false" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          if ! jq -e '
-            (.manifests // [])
-            | map(.platform.architecture)
-            | (index("amd64") and index("arm64"))
-          ' <<< "${RAW}" >/dev/null; then
-            echo "Source image is not multi-arch; falling back to build."
-            echo "promoted=false" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          while IFS= read -r tag; do
-            [[ -n "${tag}" ]] || continue
-            docker buildx imagetools create --tag "${tag}" "${SOURCE}"
-          done <<< "${TARGET_TAGS}"
-
-          echo "promoted=true" >> "${GITHUB_OUTPUT}"
-
-      - name: Setup QEMU
-        if: steps.promote.outputs.promoted != 'true'
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
-
-      - name: Setup Buildx for fallback build
-        if: steps.promote.outputs.promoted != 'true'
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: ./.github/actions/promote-image
+        with:
+          source: ghcr.io/${{ needs.validate.outputs.owner_lc }}/hybridclaw-gateway:sha-${{ needs.validate.outputs.sha_short }}
+          target-tags: ${{ steps.meta.outputs.tags }}
 
       - name: Build and push gateway image
         if: steps.promote.outputs.promoted != 'true'


### PR DESCRIPTION
## Summary
- run `docker-preflight` only on PRs to remove duplicate main branch image builds
- unify Docker cache scopes across CI, main image builds, and release fallback builds
- publish multi-arch images (`amd64`,`arm64`) on main Docker builds so release can promote tags instead of rebuilding
- add release-time image promotion from `sha-*` tags with fallback builds if promotion source is unavailable
- tighten workspace dependency cache configuration and use explicit container `npm ci`

## Validation
- `npm run format`
- YAML parse check for modified workflow/action files