### PR TITLE
[codex] fix gateway restart shutdown hang

### DIFF
--- a/src/channels/whatsapp/connection.ts
+++ b/src/channels/whatsapp/connection.ts
@@ -343,10 +343,13 @@ async function waitForPendingCredsSave(
   target: WhatsAppLogger,
   pendingSave: Promise<void>,
 ): Promise<void> {
-  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  let timeoutHandle!: ReturnType<typeof setTimeout>;
   try {
     const outcome = await Promise.race([
-      pendingSave.then(() => 'saved' as const),
+      pendingSave.then(
+        () => 'done' as const,
+        () => 'done' as const,
+      ),
       new Promise<'timeout'>((resolve) => {
         timeoutHandle = setTimeout(
           () => resolve('timeout'),
@@ -360,7 +363,7 @@ async function waitForPendingCredsSave(
       );
     }
   } finally {
-    if (timeoutHandle) clearTimeout(timeoutHandle);
+    clearTimeout(timeoutHandle);
   }
 }
 
@@ -651,7 +654,7 @@ export function createWhatsAppConnectionManager(params?: {
       }
       await waitForPendingCredsSave(
         childLogger,
-        credsSaveQueue.catch(() => undefined),
+        credsSaveQueue,
       );
       releaseAuthLock?.();
       releaseAuthLock = null;

--- a/src/channels/whatsapp/connection.ts
+++ b/src/channels/whatsapp/connection.ts
@@ -652,10 +652,7 @@ export function createWhatsAppConnectionManager(params?: {
           childLogger.debug({ error }, 'WhatsApp socket shutdown raised');
         }
       }
-      await waitForPendingCredsSave(
-        childLogger,
-        credsSaveQueue,
-      );
+      await waitForPendingCredsSave(childLogger, credsSaveQueue);
       releaseAuthLock?.();
       releaseAuthLock = null;
       rejectWaiters(new Error('WhatsApp runtime stopped'));

--- a/src/channels/whatsapp/connection.ts
+++ b/src/channels/whatsapp/connection.ts
@@ -37,6 +37,7 @@ const EXPECTED_TRANSPORT_DEBUG_WINDOW_MS = 60_000;
 const EXPECTED_TRANSPORT_DEBUG_LIMIT = 3;
 const EXPECTED_TRANSPORT_DEBUG_COOLDOWN_MS = 1_000;
 const KEEPALIVE_ERROR_SUPPRESS_MS = 30_000;
+const STOP_CREDS_SAVE_TIMEOUT_MS = 2_000;
 
 type WhatsAppLogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error';
 
@@ -338,6 +339,31 @@ export interface WhatsAppConnectionManager {
   rememberSentMessage: WhatsAppMessageStore['rememberSentMessage'];
 }
 
+async function waitForPendingCredsSave(
+  target: WhatsAppLogger,
+  pendingSave: Promise<void>,
+): Promise<void> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  try {
+    const outcome = await Promise.race([
+      pendingSave.then(() => 'saved' as const),
+      new Promise<'timeout'>((resolve) => {
+        timeoutHandle = setTimeout(
+          () => resolve('timeout'),
+          STOP_CREDS_SAVE_TIMEOUT_MS,
+        );
+      }),
+    ]);
+    if (outcome === 'timeout') {
+      target.warn(
+        `Timed out waiting ${STOP_CREDS_SAVE_TIMEOUT_MS}ms for WhatsApp credential save during shutdown; continuing.`,
+      );
+    }
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+  }
+}
+
 export function createWhatsAppConnectionManager(params?: {
   onSocketCreated?: (socket: WASocket) => void;
 }): WhatsAppConnectionManager {
@@ -623,7 +649,10 @@ export function createWhatsAppConnectionManager(params?: {
           childLogger.debug({ error }, 'WhatsApp socket shutdown raised');
         }
       }
-      await credsSaveQueue.catch(() => undefined);
+      await waitForPendingCredsSave(
+        childLogger,
+        credsSaveQueue.catch(() => undefined),
+      );
       releaseAuthLock?.();
       releaseAuthLock = null;
       rejectWaiters(new Error('WhatsApp runtime stopped'));

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -2528,6 +2528,7 @@ function setupShutdown(broadcastShutdown: () => void): void {
     });
     if (opts?.drain) {
       broadcastShutdown();
+      stopAllExecutions();
       const DRAIN_TIMEOUT_MS = 15_000;
       const DRAIN_POLL_MS = 250;
       const deadline = Date.now() + DRAIN_TIMEOUT_MS;
@@ -2541,7 +2542,9 @@ function setupShutdown(broadcastShutdown: () => void): void {
     stopHeartbeat();
     stopObservabilityIngest();
     stopDiscoveryLoop();
-    stopAllExecutions();
+    if (!opts?.drain) {
+      stopAllExecutions();
+    }
     await stopGatewayPlugins().catch((error) => {
       logger.debug({ error }, 'Failed to stop plugins during shutdown');
     });

--- a/tests/gateway-main.test.ts
+++ b/tests/gateway-main.test.ts
@@ -162,6 +162,7 @@ function createGatewayMainTestState(options?: {
       providerHealth: {},
       localBackends: {},
     })),
+    getActiveExecutorCount: vi.fn(() => 0),
     getWorkflowByCompanionTaskId: vi.fn(() => null),
     handleGatewayCommand: vi.fn(async ({ args }: { args: string[] }) => {
       if (args[0] === 'info') {
@@ -199,6 +200,7 @@ function createGatewayMainTestState(options?: {
     loggerFatal: vi.fn(),
     loggerInfo: vi.fn(),
     loggerWarn: vi.fn(),
+    shutdownDiscord: vi.fn(async () => {}),
     shutdownEmail: vi.fn(async () => {}),
     shutdownSlack: vi.fn(async () => {}),
     shutdownTelegram: vi.fn(async () => {}),
@@ -367,6 +369,7 @@ async function importFreshGatewayMain(options?: {
   vi.stubGlobal('clearTimeout', vi.fn());
 
   vi.doMock('../src/agent/executor.js', () => ({
+    getActiveExecutorCount: state.getActiveExecutorCount,
     stopAllExecutions: vi.fn(),
   }));
   vi.doMock('../src/agent/proactive-policy.js', () => ({
@@ -399,6 +402,7 @@ async function importFreshGatewayMain(options?: {
   vi.doMock('../src/channels/discord/runtime.js', () => ({
     initDiscord: state.initDiscord,
     sendToChannel: vi.fn(),
+    shutdownDiscord: state.shutdownDiscord,
     setDiscordMaintenancePresence: vi.fn(async () => {}),
   }));
   vi.doMock('../src/channels/msteams/attachments.js', () => ({
@@ -2347,6 +2351,33 @@ describe('gateway bootstrap', () => {
         replyStyle: 'top-level',
       }),
     );
+  });
+
+  test('SIGTERM shutdown stops executors before draining', async () => {
+    const state = await importFreshGatewayMain({
+      onState: (nextState) => {
+        nextState.getActiveExecutorCount.mockReturnValueOnce(1);
+        nextState.getActiveExecutorCount.mockReturnValue(0);
+      },
+    });
+    const sigtermHandler = state.processOn.mock.calls.find(
+      ([event]) => event === 'SIGTERM',
+    )?.[1] as (() => void) | undefined;
+    const executorModule = await import('../src/agent/executor.js');
+    const stopAllExecutionsMock = vi.mocked(executorModule.stopAllExecutions);
+
+    expect(sigtermHandler).toBeTypeOf('function');
+
+    sigtermHandler?.();
+    await settle();
+
+    expect(stopAllExecutionsMock).toHaveBeenCalledTimes(1);
+    expect(stopAllExecutionsMock.mock.invocationCallOrder[0]).toBeLessThan(
+      state.getActiveExecutorCount.mock.invocationCallOrder[0] ?? Infinity,
+    );
+    expect(
+      state.startGatewayHttpServer.mock.results[0]?.value.broadcastShutdown,
+    ).toHaveBeenCalledTimes(1);
   });
 
   test('keeps voice stopped on config change until shared Twilio auth token refresh completes', async () => {

--- a/tests/whatsapp.connection.test.ts
+++ b/tests/whatsapp.connection.test.ts
@@ -576,3 +576,33 @@ test('serializes WhatsApp credential saves on rapid creds.update events', async 
   await manager.stop();
   expect(maxConcurrentSaves).toBe(1);
 });
+
+test('stop continues after timing out on a stuck WhatsApp credential save', async () => {
+  vi.useFakeTimers();
+  const {
+    createWhatsAppConnectionManager,
+    releaseAuthLock,
+    saveCredsMock,
+    sockets,
+    whatsappLogger,
+  } = await importFreshConnectionModule();
+  const pendingSave = createDeferred<void>();
+  saveCredsMock.mockImplementation(() => pendingSave.promise);
+
+  const manager = createWhatsAppConnectionManager();
+  await manager.start();
+
+  const credsHandlers = sockets[0]?.evHandlers.get('creds.update');
+  expect(credsHandlers).toHaveLength(1);
+  credsHandlers?.[0]?.({});
+  await flushMicrotasks();
+
+  const stopPromise = manager.stop();
+  await vi.advanceTimersByTimeAsync(2_000);
+  await stopPromise;
+
+  expect(releaseAuthLock).toHaveBeenCalledTimes(1);
+  expect(whatsappLogger.warn).toHaveBeenCalledWith(
+    'Timed out waiting 2000ms for WhatsApp credential save during shutdown; continuing.',
+  );
+});


### PR DESCRIPTION
## What changed

This fixes two shutdown paths that could make `hybridclaw gateway restart --sandbox host` hang until the CLI fell back to `SIGKILL`.

- Bound the WhatsApp shutdown wait for pending credential writes so a stuck `saveCreds()` cannot block gateway exit forever.
- Changed gateway SIGTERM shutdown ordering so pooled host executors are stopped before the drain loop, which prevents idle cached agent processes from keeping the gateway alive during restart.
- Added a targeted WhatsApp regression test for the stuck credential-save case.

## Why it changed

Gateway restart was timing out even after the HTTP server had begun graceful shutdown.

There were two separate contributors:

1. The WhatsApp connection manager waited indefinitely for `credsSaveQueue` during shutdown.
2. The gateway drain loop waited on `getActiveExecutorCount()`, which includes pooled host executors that remain alive for reuse and are not themselves active work.

Together these could keep the old gateway process alive longer than the CLIs 10 second stop timeout.

## Impact

- Repeated `hybridclaw gateway restart --debug --sandbox host` runs stop cleanly instead of frequently requiring `SIGKILL`.
- Shutdown is more predictable when WhatsApp is enabled and when a recent host executor is still warm in the pool.

## Validation

- `./node_modules/.bin/vitest run tests/whatsapp.connection.test.ts`
- Real restart verification in host sandbox mode against the live runtime:
  - confirmed an older pre-fix process still timed out
  - confirmed subsequent post-fix gateway instances shut down cleanly on repeated restarts
