### PR TITLE
feat(plugins): first-party otel-tracing plugin for per-turn gen_ai spans

### DIFF
--- a/plugins/otel-tracing/hybridclaw.plugin.yaml
+++ b/plugins/otel-tracing/hybridclaw.plugin.yaml
@@ -1,0 +1,31 @@
+id: otel-tracing
+name: OpenTelemetry Tracing
+version: 0.1.0
+kind: tool
+description: >-
+  Emit OpenTelemetry traces for every agent turn and tool call using
+  gen_ai.* semantic conventions. Reuses the global tracer provider set up
+  by the gateway's built-in OTel SDK (OTEL_ENABLED=true); does not
+  initialise its own exporter. For platform-hosted deployments the plugin
+  only emits identity and usage attributes — message text and tool
+  arguments are never written to spans.
+entrypoint: src/index.js
+requires:
+  env:
+    - OTEL_ENABLED
+configSchema:
+  type: object
+  additionalProperties: false
+  properties:
+    includeToolArguments:
+      type: boolean
+      default: false
+      description: >-
+        Add tool.arguments as a span attribute. Off by default: tool
+        arguments can contain customer data on platform-hosted deployments.
+    includeResultText:
+      type: boolean
+      default: false
+      description: >-
+        Add a truncated prefix of the agent response as a span attribute.
+        Off by default for the same reason as includeToolArguments.

--- a/plugins/otel-tracing/package.json
+++ b/plugins/otel-tracing/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "hybridclaw-plugin-otel-tracing",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Per-turn OpenTelemetry spans with gen_ai.* attributes for HybridClaw agent runs",
+  "engines": {
+    "node": "22.x"
+  },
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.0"
+  }
+}

--- a/plugins/otel-tracing/src/index.js
+++ b/plugins/otel-tracing/src/index.js
@@ -1,0 +1,153 @@
+// Per-turn OpenTelemetry instrumentation for HybridClaw.
+//
+// This plugin piggybacks on the gateway's built-in OTel SDK
+// (src/observability/otel.ts). When OTEL_ENABLED=true the gateway
+// registers a global tracer provider + OTLP exporter; this plugin just
+// subscribes to lifecycle hooks and emits `agent.turn` / `tool.<name>`
+// spans with gen_ai.* attributes through that provider.
+//
+// No message bodies, no tool arguments, and no response text end up on
+// spans by default — on platform-hosted deployments the container runs
+// customer conversations and anything we put on a span leaves our
+// control into whatever OTLP backend the collector forwards to.
+
+import { context, SpanKind, SpanStatusCode, trace } from '@opentelemetry/api';
+
+const TRACER_NAME = 'hybridclaw-agent';
+const TRACER_VERSION = '0.1.0';
+
+const MAX_RESULT_TEXT_CHARS = 256;
+
+export default {
+  id: 'otel-tracing',
+
+  register(api) {
+    if (process.env.OTEL_ENABLED !== 'true') {
+      api.logger.info(
+        'OTEL_ENABLED is not "true"; otel-tracing plugin will no-op',
+      );
+      return;
+    }
+
+    const cfg = api.pluginConfig || {};
+    const includeToolArguments = cfg.includeToolArguments === true;
+    const includeResultText = cfg.includeResultText === true;
+
+    const tracer = trace.getTracer(TRACER_NAME, TRACER_VERSION);
+
+    // sessionId -> { span, context }
+    const activeSpans = new Map();
+
+    api.on('before_agent_start', ({ sessionId, userId, agentId, model }) => {
+      const span = tracer.startSpan('agent.turn', {
+        kind: SpanKind.SERVER,
+        attributes: {
+          'gen_ai.system': 'hybridclaw',
+          'gen_ai.request.model': model || 'unknown',
+          'hybridclaw.session_id': sessionId,
+          'hybridclaw.user_id': userId,
+          'hybridclaw.agent_id': agentId,
+        },
+      });
+      activeSpans.set(sessionId, {
+        span,
+        ctx: trace.setSpan(context.active(), span),
+      });
+    });
+
+    api.on(
+      'after_tool_call',
+      ({ sessionId, toolName, arguments: args, isError }) => {
+        const active = activeSpans.get(sessionId);
+        if (!active) return;
+
+        const toolSpan = tracer.startSpan(
+          `tool.${toolName}`,
+          {
+            kind: SpanKind.INTERNAL,
+            attributes: {
+              'tool.name': toolName,
+              'tool.is_error': Boolean(isError),
+              ...(includeToolArguments && args
+                ? { 'tool.arguments_json': safeStringify(args) }
+                : {}),
+            },
+          },
+          active.ctx,
+        );
+        if (isError) {
+          toolSpan.setStatus({ code: SpanStatusCode.ERROR });
+        } else {
+          toolSpan.setStatus({ code: SpanStatusCode.OK });
+        }
+        toolSpan.end();
+      },
+    );
+
+    api.on('agent_end', (ctx) => {
+      const active = activeSpans.get(ctx.sessionId);
+      if (!active) return;
+
+      const { span } = active;
+      span.setAttribute('gen_ai.response.model', ctx.model || 'unknown');
+      span.setAttribute('hybridclaw.tool_count', ctx.toolNames.length);
+      if (ctx.toolNames.length > 0) {
+        span.setAttribute('hybridclaw.tools', ctx.toolNames.join(','));
+      }
+      if (ctx.durationMs != null) {
+        span.setAttribute('hybridclaw.duration_ms', ctx.durationMs);
+      }
+      if (ctx.tokenUsage) {
+        span.setAttribute(
+          'gen_ai.usage.prompt_tokens',
+          ctx.tokenUsage.promptTokens,
+        );
+        span.setAttribute(
+          'gen_ai.usage.completion_tokens',
+          ctx.tokenUsage.completionTokens,
+        );
+        span.setAttribute(
+          'gen_ai.usage.total_tokens',
+          ctx.tokenUsage.totalTokens,
+        );
+        span.setAttribute(
+          'hybridclaw.model_calls',
+          ctx.tokenUsage.modelCalls,
+        );
+      }
+      if (includeResultText && typeof ctx.resultText === 'string') {
+        span.setAttribute(
+          'gen_ai.response.text_preview',
+          ctx.resultText.slice(0, MAX_RESULT_TEXT_CHARS),
+        );
+      }
+
+      span.setStatus({ code: SpanStatusCode.OK });
+      span.end();
+      activeSpans.delete(ctx.sessionId);
+    });
+
+    api.registerService({
+      id: 'otel-tracing',
+      async stop() {
+        for (const { span } of activeSpans.values()) {
+          span.end();
+        }
+        activeSpans.clear();
+      },
+    });
+
+    api.logger.info(
+      { includeToolArguments, includeResultText },
+      'otel-tracing plugin registered',
+    );
+  },
+};
+
+function safeStringify(value) {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '';
+  }
+}


### PR DESCRIPTION
## Summary
- Promotes the OTLP agent-run tracing pattern from `docs/content/extensibility/otel-plugin.md` into a bundled first-party plugin at `plugins/otel-tracing/`.
- Reuses the global tracer provider registered by the gateway's built-in OTel SDK (`src/observability/otel.ts`) — just subscribes to `before_agent_start` / `after_tool_call` / `agent_end` hooks and calls `trace.getTracer(...)`. No double exporter init, no extra OTel deps beyond `@opentelemetry/api`.
- Emits `agent.turn` root spans with `gen_ai.usage.*` attributes and `tool.<name>` children per tool call. Spans carry session/user/agent/bot identity via `hybridclaw.*` + `tenant.id`/`bot.id` (the latter flow in via `OTEL_RESOURCE_ATTRIBUTES` set by the provisioner).

## Data hygiene
Message bodies, tool arguments, and response text are **off by default**. Two opt-in config flags exist for self-hosters who accept the tradeoff:
- `includeToolArguments` — emits `tool.arguments_json` on each tool span
- `includeResultText` — emits a 256-char `gen_ai.response.text_preview`

On platform-hosted deployments these stay disabled — the container runs customer conversations and span attributes leave our control into whatever OTLP backend the collector forwards to.

## Companion PRs
- Infra: attaches the otel-collector to the `sandbox-containers` network so hosted bots can reach it.
- Chat: passes `OTEL_ENABLED`, `OTEL_EXPORTER_OTLP_ENDPOINT`, and per-tenant `OTEL_RESOURCE_ATTRIBUTES` to the hosted HybridClaw sandbox at provisioning time.

All three need to land for the end-to-end telemetry path to work, but each is independently inert without the others (empty endpoint / closed network / plugin gets OTEL_ENABLED=false and no-ops).

## Test plan
- [ ] Locally: `OTEL_ENABLED=true OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf hybridclaw gateway`, send a message, confirm one `agent.turn` span with `gen_ai.usage.*` and a child `tool.*` span per tool.
- [ ] Confirm default run: no `tool.arguments_json`, no `gen_ai.response.text_preview`.
- [ ] Flip both config flags on a throwaway instance: confirm attributes appear.
- [ ] With `OTEL_ENABLED` unset: `/plugin list` shows the plugin loaded but `register` logs the no-op message and no spans are emitted.