### PR TITLE
[codex] add GitHub issues skill

### DIFF
--- a/docs/content/guides/bundled-skills.md
+++ b/docs/content/guides/bundled-skills.md
@@ -6,11 +6,11 @@ sidebar_position: 4
 
 # Bundled Skills
 
-HybridClaw currently ships with 35 bundled skills. A few notable categories:
+HybridClaw ships with 37 bundled skills. A few notable categories:
 
 - office workflows: `pdf`, `xlsx`, `docx`, `pptx`, `office-workflows`
 - planning and engineering: `project-manager`, `feature-planning`,
-  `code-review`, `code-simplification`
+  `code-review`, `code-simplification`, `gh-issues`
 - visual explainers and animation: `manim-video`, `excalidraw`
 - platform integrations: `github-pr-workflow`, `notion`, `trello`, `stripe`,
   `wordpress`, `gog`, `google-workspace`, `discord`

--- a/docs/content/guides/skills/README.md
+++ b/docs/content/guides/skills/README.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 # Skills Catalog
 
-HybridClaw ships **37 bundled skills** across nine categories. Each page below
+HybridClaw ships **37 bundled skills** across eight categories. Each page below
 covers every skill in its category with prerequisites, install commands,
 tips & tricks, ready-to-try example prompts, and troubleshooting.
 

--- a/docs/content/guides/skills/README.md
+++ b/docs/content/guides/skills/README.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 # Skills Catalog
 
-HybridClaw ships **35 bundled skills** across nine categories. Each page below
+HybridClaw ships **37 bundled skills** across nine categories. Each page below
 covers every skill in its category with prerequisites, install commands,
 tips & tricks, ready-to-try example prompts, and troubleshooting.
 
@@ -26,12 +26,12 @@ resolution rules and runtime internals see
 | Category | Skills | Page |
 |---|---|---|
 | Office | pdf, xlsx, docx, pptx, office-workflows | [Office Skills](./office.md) |
-| Development | code-review, github-pr-workflow, salesforce, skill-creator | [Development Skills](./development.md) |
+| Development | code-review, gh-issues, github-pr-workflow, salesforce, skill-creator | [Development Skills](./development.md) |
 | Communication | discord, channel-catchup | [Communication Skills](./communication.md) |
 | Apple | apple-calendar, apple-music, apple-passwords | [Apple Skills](./apple.md) |
 | Productivity | feature-planning, project-manager, trello | [Productivity Skills](./productivity.md) |
 | Memory & Knowledge | llm-wiki, notion, obsidian, personality, zettelkasten | [Memory & Knowledge Skills](./memory-knowledge.md) |
-| Publishing | manim-video, wordpress, write-blog-post | [Publishing Skills](./publishing.md) |
+| Publishing | excalidraw, manim-video, wordpress, write-blog-post | [Publishing Skills](./publishing.md) |
 | Integrations & Utilities | 1password, stripe, sokosumi, gog, google-workspace, current-time, hybridclaw-help, iss-position | [Integrations & Utilities](./integrations.md) |
 
 ## Evaluating Example Prompts

--- a/docs/content/guides/skills/development.md
+++ b/docs/content/guides/skills/development.md
@@ -87,8 +87,9 @@ handle CI, and merge safely.
 
 ## gh-issues
 
-Fetch GitHub issues, delegate focused fixes, open pull requests, and follow up
-on actionable PR review comments.
+Process GitHub issues as an automation queue: list and filter issues, confirm
+selected issue numbers, deduplicate `fix/issue-*` work, delegate one focused PR
+per issue, and monitor review feedback on issue-fix PRs.
 
 **Prerequisites** — `git`, `gh` (GitHub CLI, authenticated).
 
@@ -105,6 +106,15 @@ on actionable PR review comments.
 >
 > Use `--fork owner/repo` when branches should be pushed to a fork while PRs
 > target the source repo.
+>
+> Use `--watch --interval 15` for recurring queue follow-up. HybridClaw
+> schedules the next run instead of sleeping in the current turn.
+>
+> Use `--cron --yes` for scheduled runs that process at most one eligible item
+> and exit.
+>
+> Use `--notify-channel <target>` to send the final PR summary to a HybridClaw
+> message target without sending intermediate status chatter.
 
 > 🎯 **Try it yourself**
 >
@@ -115,6 +125,10 @@ on actionable PR review comments.
 > `/gh-issues <your repo> --reviews-only`
 >
 > `/gh-issues <your repo> --fork <your fork> --label help-wanted --limit 1`
+>
+> `/gh-issues <your repo> --watch --interval 15 --label bug --limit 5`
+>
+> `/gh-issues <your repo> --cron --yes --reviews-only`
 >
 > **Conversation flow:**
 >
@@ -127,8 +141,12 @@ on actionable PR review comments.
 - **`gh` not authenticated** — run `gh auth login` or provide `GH_TOKEN`.
 - **Existing branch or PR** — the skill skips issues that already have a
   `fix/issue-*` branch or open PR.
+- **Local checkout missing** — issue listing can run with only `owner/repo`,
+  but processing selected issues needs a matching local git checkout.
 - **Unclear issue** — delegated agents stop and report low confidence instead
   of opening speculative PRs.
+- **Wrong workflow** — use `github-pr-workflow` for current-branch PR work, CI
+  fixes, or a known PR; use `gh-issues` when the entry point is an issue queue.
 
 ---
 

--- a/docs/content/guides/skills/development.md
+++ b/docs/content/guides/skills/development.md
@@ -155,6 +155,13 @@ stored secret `GH_TOKEN` when `gh` is unavailable.
 > Fetches live matching issues and stops after the table or "no matches"
 > response. It must not run processing preflight or delegate work.
 >
+> `/gh-issues <your repo> --label bug --limit 2`
+>
+> Fetches live bug issues, displays whatever currently matches, and asks which
+> issues to process. It is valid for the result count to be lower than the
+> limit; the important checks are that a current-turn GitHub fetch happened and
+> preflight waits for selection.
+>
 > `/gh-issues <your repo> --label enhancement --limit 3`
 >
 > Fetches live enhancement issues and asks for `all`, comma-separated issue

--- a/docs/content/guides/skills/development.md
+++ b/docs/content/guides/skills/development.md
@@ -91,9 +91,14 @@ Process GitHub issues as an automation queue: list and filter issues, confirm
 selected issue numbers, deduplicate `fix/issue-*` work, delegate one focused PR
 per issue, and monitor review feedback on issue-fix PRs.
 
-**Prerequisites** — `git`, `gh` (GitHub CLI, authenticated).
+**Prerequisites** — `git` for processing selected issues. `gh` is preferred for
+GitHub access, but the skill can fall back to the GitHub REST API with
+`GH_TOKEN` when `gh` is unavailable.
 
 > 💡 **Tips & Tricks**
+>
+> Every issue table comes from a live GitHub fetch in the current turn. The
+> skill must not reuse issue lists from memory, transcripts, or earlier prompts.
 >
 > Use `--dry-run` first to inspect the issue set without creating branches or
 > delegations.
@@ -108,7 +113,8 @@ per issue, and monitor review feedback on issue-fix PRs.
 > target the source repo.
 >
 > Use `--watch --interval 15` for recurring queue follow-up. HybridClaw
-> schedules the next run instead of sleeping in the current turn.
+> fetches the first issue list normally, then schedules the next run instead of
+> sleeping in the current turn.
 >
 > Use `--cron --yes` for scheduled runs that process at most one eligible item
 > and exit.
@@ -136,9 +142,39 @@ per issue, and monitor review feedback on issue-fix PRs.
 > `2. Process issues 42 and 48 only`
 > `3. After the PRs are open, run /gh-issues <your repo> --reviews-only`
 
+> **QA prompts**
+>
+> `/gh-issues <your repo>`
+>
+> Lists the latest open issues from GitHub and asks which issue numbers to
+> process. If `<your repo>` is explicit, the skill must not probe the local git
+> checkout before listing issues.
+>
+> `/gh-issues <your repo> --label bug --limit 5 --dry-run`
+>
+> Fetches live matching issues and stops after the table or "no matches"
+> response. It must not run processing preflight or delegate work.
+>
+> `/gh-issues <your repo> --label enhancement --limit 3`
+>
+> Fetches live enhancement issues and asks for `all`, comma-separated issue
+> numbers, or `cancel`. Git preflight happens only after a selection.
+>
+> `/gh-issues <your repo> --watch --interval 15 --label bug --limit 5`
+>
+> Fetches the first issue list normally and asks for selection, then uses
+> HybridClaw scheduling for future `--cron --yes` follow-ups. It must not send a
+> local message as a substitute for scheduling.
+>
+> `/gh-issues <your repo> --reviews-only --yes`
+>
+> Skips issue listing, finds open `fix/issue-*` PRs, gathers review sources, and
+> delegates only actionable review feedback.
+
 **Troubleshooting**
 
-- **`gh` not authenticated** — run `gh auth login` or provide `GH_TOKEN`.
+- **`gh` missing or not authenticated** — install and authenticate `gh`, or
+  provide `GH_TOKEN` so the skill can use the GitHub REST API fallback.
 - **Existing branch or PR** — the skill skips issues that already have a
   `fix/issue-*` branch or open PR.
 - **Local checkout missing** — issue listing can run with only `owner/repo`,
@@ -147,6 +183,10 @@ per issue, and monitor review feedback on issue-fix PRs.
   of opening speculative PRs.
 - **Wrong workflow** — use `github-pr-workflow` for current-branch PR work, CI
   fixes, or a known PR; use `gh-issues` when the entry point is an issue queue.
+- **Feature parity note** — HybridClaw supports the OpenClaw issue queue flow
+  (filters, confirmation, fork mode, dedupe, claims/cursor state, cron/watch,
+  notifications, and review handling) with HybridClaw-native tools instead of
+  OpenClaw config paths or `sessions_spawn`.
 
 ---
 

--- a/docs/content/guides/skills/development.md
+++ b/docs/content/guides/skills/development.md
@@ -93,7 +93,7 @@ per issue, and monitor review feedback on issue-fix PRs.
 
 **Prerequisites** — `git` for processing selected issues. `gh` is preferred for
 GitHub access, but the skill can fall back to the GitHub REST API with
-`GH_TOKEN` when `gh` is unavailable.
+stored secret `GH_TOKEN` when `gh` is unavailable.
 
 > 💡 **Tips & Tricks**
 >
@@ -174,7 +174,9 @@ GitHub access, but the skill can fall back to the GitHub REST API with
 **Troubleshooting**
 
 - **`gh` missing or not authenticated** — install and authenticate `gh`, or
-  provide `GH_TOKEN` so the skill can use the GitHub REST API fallback.
+  store `GH_TOKEN` with `/secret set GH_TOKEN <token>` so the skill can call the
+  GitHub REST API through `http_request` with `bearerSecretName: "GH_TOKEN"`.
+  The skill should not use shell environment tokens or authenticated `curl`.
 - **Existing branch or PR** — the skill skips issues that already have a
   `fix/issue-*` branch or open PR.
 - **Local checkout missing** — issue listing can run with only `owner/repo`,

--- a/docs/content/guides/skills/development.md
+++ b/docs/content/guides/skills/development.md
@@ -1,6 +1,6 @@
 ---
 title: Development Skills
-description: Code review, GitHub PR workflows, Salesforce inspection, and skill creation tools.
+description: Code review, GitHub issue automation, PR workflows, Salesforce inspection, and skill creation tools.
 sidebar_position: 3
 ---
 

--- a/docs/content/guides/skills/development.md
+++ b/docs/content/guides/skills/development.md
@@ -85,6 +85,53 @@ handle CI, and merge safely.
 
 ---
 
+## gh-issues
+
+Fetch GitHub issues, delegate focused fixes, open pull requests, and follow up
+on actionable PR review comments.
+
+**Prerequisites** — `git`, `gh` (GitHub CLI, authenticated).
+
+> 💡 **Tips & Tricks**
+>
+> Use `--dry-run` first to inspect the issue set without creating branches or
+> delegations.
+>
+> Add `--label`, `--milestone`, `--assignee`, and `--limit` filters to keep
+> each batch focused.
+>
+> Use `--reviews-only` to address actionable comments on open `fix/issue-*`
+> PRs.
+>
+> Use `--fork owner/repo` when branches should be pushed to a fork while PRs
+> target the source repo.
+
+> 🎯 **Try it yourself**
+>
+> `/gh-issues HybridAIOne/hybridclaw --label bug --limit 3 --dry-run`
+>
+> `/gh-issues HybridAIOne/hybridclaw --label bug --limit 2`
+>
+> `/gh-issues HybridAIOne/hybridclaw --reviews-only`
+>
+> `/gh-issues HybridAIOne/hybridclaw --fork my-user/hybridclaw --label help-wanted --limit 1`
+>
+> **Conversation flow:**
+>
+> `1. /gh-issues HybridAIOne/hybridclaw --label bug --limit 5 --dry-run`
+> `2. Process issues 42 and 48 only`
+> `3. After the PRs are open, run /gh-issues HybridAIOne/hybridclaw --reviews-only`
+
+**Troubleshooting**
+
+- **`gh` not authenticated** — run `gh auth login` or provide `GH_TOKEN`.
+- **Existing branch or PR** — the skill skips issues that already have a
+  `fix/issue-*` branch or open PR.
+- **Unclear issue** — delegated agents stop and report low confidence instead
+  of opening speculative PRs.
+
+---
+
 ## salesforce
 
 Inspect Salesforce objects, fields, relationships, Tooling API metadata, and

--- a/docs/content/guides/skills/development.md
+++ b/docs/content/guides/skills/development.md
@@ -108,19 +108,19 @@ on actionable PR review comments.
 
 > 🎯 **Try it yourself**
 >
-> `/gh-issues HybridAIOne/hybridclaw --label bug --limit 3 --dry-run`
+> `/gh-issues <your repo> --label bug --limit 3 --dry-run`
 >
-> `/gh-issues HybridAIOne/hybridclaw --label bug --limit 2`
+> `/gh-issues <your repo> --label bug --limit 2`
 >
-> `/gh-issues HybridAIOne/hybridclaw --reviews-only`
+> `/gh-issues <your repo> --reviews-only`
 >
-> `/gh-issues HybridAIOne/hybridclaw --fork my-user/hybridclaw --label help-wanted --limit 1`
+> `/gh-issues <your repo> --fork <your fork> --label help-wanted --limit 1`
 >
 > **Conversation flow:**
 >
-> `1. /gh-issues HybridAIOne/hybridclaw --label bug --limit 5 --dry-run`
+> `1. /gh-issues <your repo> --label bug --limit 5 --dry-run`
 > `2. Process issues 42 and 48 only`
-> `3. After the PRs are open, run /gh-issues HybridAIOne/hybridclaw --reviews-only`
+> `3. After the PRs are open, run /gh-issues <your repo> --reviews-only`
 
 **Troubleshooting**
 

--- a/docs/content/guides/skills/publishing.md
+++ b/docs/content/guides/skills/publishing.md
@@ -1,6 +1,6 @@
 ---
 title: Publishing Skills
-description: Manim video creation, WordPress publishing, and blog post writing.
+description: Excalidraw diagrams, Manim video creation, WordPress publishing, and blog post writing.
 sidebar_position: 8
 ---
 

--- a/docs/content/guides/skills/publishing.md
+++ b/docs/content/guides/skills/publishing.md
@@ -56,6 +56,39 @@ math explanations, algorithm walkthroughs, and 3Blue1Brown-style explainers.
 
 ---
 
+## excalidraw
+
+Create and revise editable `.excalidraw` diagrams for architecture diagrams,
+flowcharts, sequence diagrams, concept maps, and hand-drawn explainers.
+
+**Prerequisites** — none.
+
+> 💡 **Tips & Tricks**
+>
+> Use Excalidraw JSON when the user needs an editable diagram instead of a
+> rendered image.
+>
+> Keep labels as bound text elements, not custom properties on shapes.
+>
+> Use short stable ids and readable text sizes so future edits stay simple.
+
+> 🎯 **Try it yourself**
+>
+> `Create an Excalidraw architecture diagram for a gateway, worker queue, database, and admin console`
+>
+> `Revise this .excalidraw file to add a retry path and error queue`
+>
+> `Make a hand-drawn flowchart for the support escalation process`
+
+**Troubleshooting**
+
+- **Diagram will not open** — validate that the file is valid JSON with the
+  standard Excalidraw envelope.
+- **Labels do not appear** — ensure labels are separate `text` elements bound
+  to their shapes.
+
+---
+
 ## wordpress
 
 Draft posts and pages, coordinate wp-admin work, use WP-CLI, inspect themes or

--- a/docs/development/guides/bundled-skills.md
+++ b/docs/development/guides/bundled-skills.md
@@ -6,11 +6,11 @@ sidebar_position: 4
 
 # Bundled Skills
 
-HybridClaw currently ships with 35 bundled skills. A few notable categories:
+HybridClaw ships with 37 bundled skills. A few notable categories:
 
 - office workflows: `pdf`, `xlsx`, `docx`, `pptx`, `office-workflows`
 - planning and engineering: `project-manager`, `feature-planning`,
-  `code-review`, `code-simplification`
+  `code-review`, `code-simplification`, `gh-issues`
 - visual explainers and animation: `manim-video`, `excalidraw`
 - platform integrations: `github-pr-workflow`, `notion`, `trello`, `stripe`,
   `wordpress`, `gog`, `google-workspace`, `discord`

--- a/docs/development/guides/skills/README.md
+++ b/docs/development/guides/skills/README.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 # Skills Catalog
 
-HybridClaw ships **37 bundled skills** across nine categories. Each page below
+HybridClaw ships **37 bundled skills** across eight categories. Each page below
 covers every skill in its category with prerequisites, install commands,
 tips & tricks, ready-to-try example prompts, and troubleshooting.
 

--- a/docs/development/guides/skills/README.md
+++ b/docs/development/guides/skills/README.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 # Skills Catalog
 
-HybridClaw ships **35 bundled skills** across nine categories. Each page below
+HybridClaw ships **37 bundled skills** across nine categories. Each page below
 covers every skill in its category with prerequisites, install commands,
 tips & tricks, ready-to-try example prompts, and troubleshooting.
 
@@ -26,12 +26,12 @@ resolution rules and runtime internals see
 | Category | Skills | Page |
 |---|---|---|
 | Office | pdf, xlsx, docx, pptx, office-workflows | [Office Skills](./office.md) |
-| Development | code-review, github-pr-workflow, salesforce, skill-creator | [Development Skills](./development.md) |
+| Development | code-review, gh-issues, github-pr-workflow, salesforce, skill-creator | [Development Skills](./development.md) |
 | Communication | discord, channel-catchup | [Communication Skills](./communication.md) |
 | Apple | apple-calendar, apple-music, apple-passwords | [Apple Skills](./apple.md) |
 | Productivity | feature-planning, project-manager, trello | [Productivity Skills](./productivity.md) |
 | Memory & Knowledge | llm-wiki, notion, obsidian, personality, zettelkasten | [Memory & Knowledge Skills](./memory-knowledge.md) |
-| Publishing | manim-video, wordpress, write-blog-post | [Publishing Skills](./publishing.md) |
+| Publishing | excalidraw, manim-video, wordpress, write-blog-post | [Publishing Skills](./publishing.md) |
 | Integrations & Utilities | 1password, stripe, sokosumi, gog, google-workspace, current-time, hybridclaw-help, iss-position | [Integrations & Utilities](./integrations.md) |
 
 ## Evaluating Example Prompts

--- a/docs/development/guides/skills/development.md
+++ b/docs/development/guides/skills/development.md
@@ -87,8 +87,9 @@ handle CI, and merge safely.
 
 ## gh-issues
 
-Fetch GitHub issues, delegate focused fixes, open pull requests, and follow up
-on actionable PR review comments.
+Process GitHub issues as an automation queue: list and filter issues, confirm
+selected issue numbers, deduplicate `fix/issue-*` work, delegate one focused PR
+per issue, and monitor review feedback on issue-fix PRs.
 
 **Prerequisites** — `git`, `gh` (GitHub CLI, authenticated).
 
@@ -105,6 +106,15 @@ on actionable PR review comments.
 >
 > Use `--fork owner/repo` when branches should be pushed to a fork while PRs
 > target the source repo.
+>
+> Use `--watch --interval 15` for recurring queue follow-up. HybridClaw
+> schedules the next run instead of sleeping in the current turn.
+>
+> Use `--cron --yes` for scheduled runs that process at most one eligible item
+> and exit.
+>
+> Use `--notify-channel <target>` to send the final PR summary to a HybridClaw
+> message target without sending intermediate status chatter.
 
 > 🎯 **Try it yourself**
 >
@@ -115,6 +125,10 @@ on actionable PR review comments.
 > `/gh-issues <your repo> --reviews-only`
 >
 > `/gh-issues <your repo> --fork <your fork> --label help-wanted --limit 1`
+>
+> `/gh-issues <your repo> --watch --interval 15 --label bug --limit 5`
+>
+> `/gh-issues <your repo> --cron --yes --reviews-only`
 >
 > **Conversation flow:**
 >
@@ -127,8 +141,12 @@ on actionable PR review comments.
 - **`gh` not authenticated** — run `gh auth login` or provide `GH_TOKEN`.
 - **Existing branch or PR** — the skill skips issues that already have a
   `fix/issue-*` branch or open PR.
+- **Local checkout missing** — issue listing can run with only `owner/repo`,
+  but processing selected issues needs a matching local git checkout.
 - **Unclear issue** — delegated agents stop and report low confidence instead
   of opening speculative PRs.
+- **Wrong workflow** — use `github-pr-workflow` for current-branch PR work, CI
+  fixes, or a known PR; use `gh-issues` when the entry point is an issue queue.
 
 ---
 

--- a/docs/development/guides/skills/development.md
+++ b/docs/development/guides/skills/development.md
@@ -155,6 +155,13 @@ stored secret `GH_TOKEN` when `gh` is unavailable.
 > Fetches live matching issues and stops after the table or "no matches"
 > response. It must not run processing preflight or delegate work.
 >
+> `/gh-issues <your repo> --label bug --limit 2`
+>
+> Fetches live bug issues, displays whatever currently matches, and asks which
+> issues to process. It is valid for the result count to be lower than the
+> limit; the important checks are that a current-turn GitHub fetch happened and
+> preflight waits for selection.
+>
 > `/gh-issues <your repo> --label enhancement --limit 3`
 >
 > Fetches live enhancement issues and asks for `all`, comma-separated issue

--- a/docs/development/guides/skills/development.md
+++ b/docs/development/guides/skills/development.md
@@ -91,9 +91,14 @@ Process GitHub issues as an automation queue: list and filter issues, confirm
 selected issue numbers, deduplicate `fix/issue-*` work, delegate one focused PR
 per issue, and monitor review feedback on issue-fix PRs.
 
-**Prerequisites** — `git`, `gh` (GitHub CLI, authenticated).
+**Prerequisites** — `git` for processing selected issues. `gh` is preferred for
+GitHub access, but the skill can fall back to the GitHub REST API with
+`GH_TOKEN` when `gh` is unavailable.
 
 > 💡 **Tips & Tricks**
+>
+> Every issue table comes from a live GitHub fetch in the current turn. The
+> skill must not reuse issue lists from memory, transcripts, or earlier prompts.
 >
 > Use `--dry-run` first to inspect the issue set without creating branches or
 > delegations.
@@ -108,7 +113,8 @@ per issue, and monitor review feedback on issue-fix PRs.
 > target the source repo.
 >
 > Use `--watch --interval 15` for recurring queue follow-up. HybridClaw
-> schedules the next run instead of sleeping in the current turn.
+> fetches the first issue list normally, then schedules the next run instead of
+> sleeping in the current turn.
 >
 > Use `--cron --yes` for scheduled runs that process at most one eligible item
 > and exit.
@@ -136,9 +142,39 @@ per issue, and monitor review feedback on issue-fix PRs.
 > `2. Process issues 42 and 48 only`
 > `3. After the PRs are open, run /gh-issues <your repo> --reviews-only`
 
+> **QA prompts**
+>
+> `/gh-issues <your repo>`
+>
+> Lists the latest open issues from GitHub and asks which issue numbers to
+> process. If `<your repo>` is explicit, the skill must not probe the local git
+> checkout before listing issues.
+>
+> `/gh-issues <your repo> --label bug --limit 5 --dry-run`
+>
+> Fetches live matching issues and stops after the table or "no matches"
+> response. It must not run processing preflight or delegate work.
+>
+> `/gh-issues <your repo> --label enhancement --limit 3`
+>
+> Fetches live enhancement issues and asks for `all`, comma-separated issue
+> numbers, or `cancel`. Git preflight happens only after a selection.
+>
+> `/gh-issues <your repo> --watch --interval 15 --label bug --limit 5`
+>
+> Fetches the first issue list normally and asks for selection, then uses
+> HybridClaw scheduling for future `--cron --yes` follow-ups. It must not send a
+> local message as a substitute for scheduling.
+>
+> `/gh-issues <your repo> --reviews-only --yes`
+>
+> Skips issue listing, finds open `fix/issue-*` PRs, gathers review sources, and
+> delegates only actionable review feedback.
+
 **Troubleshooting**
 
-- **`gh` not authenticated** — run `gh auth login` or provide `GH_TOKEN`.
+- **`gh` missing or not authenticated** — install and authenticate `gh`, or
+  provide `GH_TOKEN` so the skill can use the GitHub REST API fallback.
 - **Existing branch or PR** — the skill skips issues that already have a
   `fix/issue-*` branch or open PR.
 - **Local checkout missing** — issue listing can run with only `owner/repo`,
@@ -147,6 +183,10 @@ per issue, and monitor review feedback on issue-fix PRs.
   of opening speculative PRs.
 - **Wrong workflow** — use `github-pr-workflow` for current-branch PR work, CI
   fixes, or a known PR; use `gh-issues` when the entry point is an issue queue.
+- **Feature parity note** — HybridClaw supports the OpenClaw issue queue flow
+  (filters, confirmation, fork mode, dedupe, claims/cursor state, cron/watch,
+  notifications, and review handling) with HybridClaw-native tools instead of
+  OpenClaw config paths or `sessions_spawn`.
 
 ---
 

--- a/docs/development/guides/skills/development.md
+++ b/docs/development/guides/skills/development.md
@@ -93,7 +93,7 @@ per issue, and monitor review feedback on issue-fix PRs.
 
 **Prerequisites** — `git` for processing selected issues. `gh` is preferred for
 GitHub access, but the skill can fall back to the GitHub REST API with
-`GH_TOKEN` when `gh` is unavailable.
+stored secret `GH_TOKEN` when `gh` is unavailable.
 
 > 💡 **Tips & Tricks**
 >
@@ -174,7 +174,9 @@ GitHub access, but the skill can fall back to the GitHub REST API with
 **Troubleshooting**
 
 - **`gh` missing or not authenticated** — install and authenticate `gh`, or
-  provide `GH_TOKEN` so the skill can use the GitHub REST API fallback.
+  store `GH_TOKEN` with `/secret set GH_TOKEN <token>` so the skill can call the
+  GitHub REST API through `http_request` with `bearerSecretName: "GH_TOKEN"`.
+  The skill should not use shell environment tokens or authenticated `curl`.
 - **Existing branch or PR** — the skill skips issues that already have a
   `fix/issue-*` branch or open PR.
 - **Local checkout missing** — issue listing can run with only `owner/repo`,

--- a/docs/development/guides/skills/development.md
+++ b/docs/development/guides/skills/development.md
@@ -1,6 +1,6 @@
 ---
 title: Development Skills
-description: Code review, GitHub PR workflows, Salesforce inspection, and skill creation tools.
+description: Code review, GitHub issue automation, PR workflows, Salesforce inspection, and skill creation tools.
 sidebar_position: 3
 ---
 

--- a/docs/development/guides/skills/development.md
+++ b/docs/development/guides/skills/development.md
@@ -85,6 +85,53 @@ handle CI, and merge safely.
 
 ---
 
+## gh-issues
+
+Fetch GitHub issues, delegate focused fixes, open pull requests, and follow up
+on actionable PR review comments.
+
+**Prerequisites** — `git`, `gh` (GitHub CLI, authenticated).
+
+> 💡 **Tips & Tricks**
+>
+> Use `--dry-run` first to inspect the issue set without creating branches or
+> delegations.
+>
+> Add `--label`, `--milestone`, `--assignee`, and `--limit` filters to keep
+> each batch focused.
+>
+> Use `--reviews-only` to address actionable comments on open `fix/issue-*`
+> PRs.
+>
+> Use `--fork owner/repo` when branches should be pushed to a fork while PRs
+> target the source repo.
+
+> 🎯 **Try it yourself**
+>
+> `/gh-issues HybridAIOne/hybridclaw --label bug --limit 3 --dry-run`
+>
+> `/gh-issues HybridAIOne/hybridclaw --label bug --limit 2`
+>
+> `/gh-issues HybridAIOne/hybridclaw --reviews-only`
+>
+> `/gh-issues HybridAIOne/hybridclaw --fork my-user/hybridclaw --label help-wanted --limit 1`
+>
+> **Conversation flow:**
+>
+> `1. /gh-issues HybridAIOne/hybridclaw --label bug --limit 5 --dry-run`
+> `2. Process issues 42 and 48 only`
+> `3. After the PRs are open, run /gh-issues HybridAIOne/hybridclaw --reviews-only`
+
+**Troubleshooting**
+
+- **`gh` not authenticated** — run `gh auth login` or provide `GH_TOKEN`.
+- **Existing branch or PR** — the skill skips issues that already have a
+  `fix/issue-*` branch or open PR.
+- **Unclear issue** — delegated agents stop and report low confidence instead
+  of opening speculative PRs.
+
+---
+
 ## salesforce
 
 Inspect Salesforce objects, fields, relationships, Tooling API metadata, and

--- a/docs/development/guides/skills/development.md
+++ b/docs/development/guides/skills/development.md
@@ -108,19 +108,19 @@ on actionable PR review comments.
 
 > 🎯 **Try it yourself**
 >
-> `/gh-issues HybridAIOne/hybridclaw --label bug --limit 3 --dry-run`
+> `/gh-issues <your repo> --label bug --limit 3 --dry-run`
 >
-> `/gh-issues HybridAIOne/hybridclaw --label bug --limit 2`
+> `/gh-issues <your repo> --label bug --limit 2`
 >
-> `/gh-issues HybridAIOne/hybridclaw --reviews-only`
+> `/gh-issues <your repo> --reviews-only`
 >
-> `/gh-issues HybridAIOne/hybridclaw --fork my-user/hybridclaw --label help-wanted --limit 1`
+> `/gh-issues <your repo> --fork <your fork> --label help-wanted --limit 1`
 >
 > **Conversation flow:**
 >
-> `1. /gh-issues HybridAIOne/hybridclaw --label bug --limit 5 --dry-run`
+> `1. /gh-issues <your repo> --label bug --limit 5 --dry-run`
 > `2. Process issues 42 and 48 only`
-> `3. After the PRs are open, run /gh-issues HybridAIOne/hybridclaw --reviews-only`
+> `3. After the PRs are open, run /gh-issues <your repo> --reviews-only`
 
 **Troubleshooting**
 

--- a/docs/development/guides/skills/publishing.md
+++ b/docs/development/guides/skills/publishing.md
@@ -1,6 +1,6 @@
 ---
 title: Publishing Skills
-description: Manim video creation, WordPress publishing, and blog post writing.
+description: Excalidraw diagrams, Manim video creation, WordPress publishing, and blog post writing.
 sidebar_position: 8
 ---
 

--- a/docs/development/guides/skills/publishing.md
+++ b/docs/development/guides/skills/publishing.md
@@ -56,6 +56,39 @@ math explanations, algorithm walkthroughs, and 3Blue1Brown-style explainers.
 
 ---
 
+## excalidraw
+
+Create and revise editable `.excalidraw` diagrams for architecture diagrams,
+flowcharts, sequence diagrams, concept maps, and hand-drawn explainers.
+
+**Prerequisites** — none.
+
+> 💡 **Tips & Tricks**
+>
+> Use Excalidraw JSON when the user needs an editable diagram instead of a
+> rendered image.
+>
+> Keep labels as bound text elements, not custom properties on shapes.
+>
+> Use short stable ids and readable text sizes so future edits stay simple.
+
+> 🎯 **Try it yourself**
+>
+> `Create an Excalidraw architecture diagram for a gateway, worker queue, database, and admin console`
+>
+> `Revise this .excalidraw file to add a retry path and error queue`
+>
+> `Make a hand-drawn flowchart for the support escalation process`
+
+**Troubleshooting**
+
+- **Diagram will not open** — validate that the file is valid JSON with the
+  standard Excalidraw envelope.
+- **Labels do not appear** — ensure labels are separate `text` elements bound
+  to their shapes.
+
+---
+
 ## wordpress
 
 Draft posts and pages, coordinate wp-admin work, use WP-CLI, inspect themes or

--- a/skills/gh-issues/SKILL.md
+++ b/skills/gh-issues/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: gh-issues
+description: Fetch GitHub issues, delegate focused fixes, open pull requests, and follow up on actionable PR review comments.
+user-invocable: true
+disable-model-invocation: false
+requires:
+  bins:
+    - gh
+    - git
+metadata:
+  hybridclaw:
+    category: development
+    short_description: "GitHub issue auto-fix workflow."
+    tags:
+      - engineering
+      - github
+      - issues
+      - pull-requests
+      - delegation
+    related_skills:
+      - github-pr-workflow
+      - code-review
+    install:
+      - id: brew
+        kind: brew
+        formula: gh
+        bins:
+          - gh
+        label: "Install GitHub CLI (brew)"
+---
+# GitHub Issues
+
+Use this skill for `/gh-issues` requests that fetch GitHub issues, assign
+focused subagents to implement fixes, open pull requests, or address actionable
+review comments on issue-fix PRs.
+
+## Inputs
+
+Parse the arguments after `/gh-issues`.
+
+Positional:
+
+- `owner/repo`: source repository. If omitted, infer it from
+  `git remote get-url origin`.
+
+Flags:
+
+- `--label <label>`: filter issues by label.
+- `--milestone <milestone>`: filter issues by milestone title.
+- `--assignee <assignee>`: filter by assignee. Use `@me` for the authenticated
+  GitHub user.
+- `--state <open|closed|all>`: default `open`.
+- `--limit <n>`: default `10`.
+- `--fork <owner/repo>`: push branches to a fork while opening PRs against the
+  source repository.
+- `--dry-run`: list matching issues only.
+- `--yes`: process listed issues without asking for another confirmation.
+- `--reviews-only`: skip issue fetching and only handle PR review comments.
+- `--watch <minutes>`: schedule a recurring follow-up instead of sleeping.
+- `--model <model>`: optional model override for delegated tasks.
+
+Derived values:
+
+- `SOURCE_REPO`: issue and PR target repository.
+- `PUSH_REPO`: `--fork` value, otherwise `SOURCE_REPO`.
+- `PUSH_REMOTE`: `fork` when `--fork` is used, otherwise `origin`.
+- `FORK_MODE`: true when `--fork` is used.
+
+If required information is missing, stop with the smallest specific request
+needed to continue.
+
+## Authentication
+
+Prefer GitHub CLI authentication.
+
+```bash
+gh auth status
+```
+
+If that fails and `GH_TOKEN` is set, retry commands with `GH_TOKEN` in the
+environment. If authentication still fails, stop and ask the user to run
+`gh auth login` or provide `GH_TOKEN`.
+
+Do not print tokens, embed tokens in final responses, or store tokens in files.
+
+## Fetch Issues
+
+Use `gh issue list` so pull requests are excluded by default.
+
+```bash
+gh issue list --repo "$SOURCE_REPO" --state open --limit 10 \
+  --json number,title,labels,assignees,url,body
+```
+
+Add optional filters only when present:
+
+- `--label "$LABEL"`
+- `--milestone "$MILESTONE"`
+- `--assignee "$ASSIGNEE"` after resolving `@me` with
+  `gh api user --jq .login`
+
+Display matching issues as a compact markdown table with number, title, labels,
+and assignees. If `--dry-run` is set, stop after the table.
+
+If no issues match, report that directly. Do not delegate an empty batch.
+
+## Confirmation
+
+Unless `--yes` is set, ask which issues to process:
+
+- `all`
+- comma-separated issue numbers
+- `cancel`
+
+After the user chooses, continue only with selected issue numbers.
+
+## Preflight
+
+Run these checks before delegating fixes:
+
+1. Check the working tree.
+
+   ```bash
+   git status --porcelain
+   ```
+
+   If it is dirty, explain that delegated fixes should start from committed
+   state and ask whether to continue. Do not stage or commit unrelated changes.
+
+2. Record the base branch.
+
+   ```bash
+   git rev-parse --abbrev-ref HEAD
+   ```
+
+3. Verify remotes.
+
+   ```bash
+   git ls-remote --exit-code origin HEAD
+   ```
+
+   In fork mode, ensure a `fork` remote exists for `PUSH_REPO`; add it only if
+   missing.
+
+4. Skip issues that already have an open PR from the intended branch.
+
+   ```bash
+   gh pr list --repo "$SOURCE_REPO" --state open \
+     --head "fix/issue-$ISSUE_NUMBER" \
+     --json number,url,headRefName,headRepositoryOwner \
+     --jq ".[] | select(.headRepositoryOwner.login == \"$PUSH_OWNER\")"
+   ```
+
+5. Skip issues whose intended branch already exists in `PUSH_REPO`.
+
+   ```bash
+   gh api "repos/$PUSH_REPO/branches/fix/issue-$ISSUE_NUMBER" --silent
+   ```
+
+Only delegate remaining issues.
+
+## Delegate Fixes
+
+Use the `delegate` tool in `parallel` mode for up to 6 independent issues at a
+time. If there are more than 6 selected issues, process them in batches after
+the previous batch reports back. Do not poll or sleep for delegated completion.
+
+Each delegated task must be self-contained and include:
+
+- source repo, push repo, fork mode, push remote, and base branch
+- issue number, title, URL, labels, assignees, and body
+- expected branch name: `fix/issue-<number>`
+- instruction to open a PR linked to the issue
+- exact output format requested from the subagent
+- model override when `--model` was provided
+
+Use this task shape:
+
+```text
+You are a focused issue-fix subagent. Fix exactly one GitHub issue and open a PR.
+
+Repository: {SOURCE_REPO}
+Push repository: {PUSH_REPO}
+Fork mode: {FORK_MODE}
+Push remote: {PUSH_REMOTE}
+Base branch: {BASE_BRANCH}
+Branch: fix/issue-{NUMBER}
+
+Issue #{NUMBER}: {TITLE}
+URL: {URL}
+Labels: {LABELS}
+Assignees: {ASSIGNEES}
+Body:
+{BODY}
+
+Workflow:
+1. Confirm the issue is actionable. If confidence is below 7/10, stop and
+   report why instead of guessing.
+2. Create branch `fix/issue-{NUMBER}` from `{BASE_BRANCH}`.
+3. Find the smallest relevant code or docs change.
+4. Implement only the issue fix.
+5. Run targeted tests or explain why no targeted test exists.
+6. Stage only your changes and commit with:
+   `fix: {SHORT_DESCRIPTION}`
+
+   Include `Fixes {SOURCE_REPO}#{NUMBER}` in the commit body.
+7. Push to `{PUSH_REMOTE}` and open a pull request against `{SOURCE_REPO}`.
+8. Return: PR URL, files changed, tests run, skipped checks, and any caveats.
+
+Constraints:
+- Do not modify unrelated files.
+- Do not force-push.
+- Do not commit secrets, local config, or personal data.
+- If the working tree contains unrelated changes, leave them untouched.
+```
+
+When delegated results return, present a compact summary table:
+
+| Issue | Status | PR | Notes |
+| --- | --- | --- | --- |
+
+Statuses should be `PR opened`, `Skipped`, `Failed`, or `Needs manual review`.
+
+## Review-Only Mode
+
+When `--reviews-only` is set, find open issue-fix PRs:
+
+```bash
+gh pr list --repo "$SOURCE_REPO" --state open \
+  --json number,title,url,headRefName,body \
+  --jq '.[] | select(.headRefName | startswith("fix/issue-"))'
+```
+
+For each candidate PR, inspect review sources:
+
+```bash
+gh pr view "$PR_NUMBER" --repo "$SOURCE_REPO" \
+  --json number,title,url,body,reviews,comments,reviewDecision
+gh api "repos/$SOURCE_REPO/pulls/$PR_NUMBER/comments"
+```
+
+Treat comments as actionable when they request a concrete change, report a bug,
+identify a failing case, or come from a `CHANGES_REQUESTED` review. Skip pure
+approvals, CI summaries, "LGTM", and comments authored by the bot itself.
+
+Display a table of PRs with actionable comments. Unless `--yes` is set, ask
+which PRs to address.
+
+## Delegate Review Fixes
+
+Use `delegate` in `parallel` mode for up to 6 PRs at a time. Each task must
+include the PR URL, branch, source repo, push repo, and a JSON or markdown list
+of actionable comments with author, body, path, line, and comment URL when
+available.
+
+Use this task shape:
+
+```text
+You are a focused PR review-fix subagent. Address actionable review feedback on
+one pull request.
+
+Repository: {SOURCE_REPO}
+Push repository: {PUSH_REPO}
+Push remote: {PUSH_REMOTE}
+PR #{PR_NUMBER}: {PR_URL}
+Branch: {BRANCH}
+
+Actionable comments:
+{COMMENTS}
+
+Workflow:
+1. Fetch and checkout `{BRANCH}` from `{PUSH_REMOTE}`.
+2. Read every actionable comment and group changes by file.
+3. Implement only the requested review fixes.
+4. Run targeted tests or explain why none apply.
+5. Commit with `fix: address review feedback on PR #{PR_NUMBER}`.
+6. Push the branch.
+7. Reply to addressed comments with a brief summary and commit SHA.
+8. Return: comments addressed, comments skipped, commit SHA, files changed,
+   tests run, and manual follow-ups.
+
+Constraints:
+- Do not force-push.
+- Do not rewrite unrelated PR history.
+- If comments conflict, address the newest concrete request and flag the
+  conflict.
+```
+
+## Watch Mode
+
+If `--watch <minutes>` is set, do not sleep in the active turn. Use the `cron`
+tool to schedule a recurring follow-up prompt that reinvokes this skill with the
+same repository, filters, and `--reviews-only` when appropriate. Include enough
+context in the scheduled prompt to continue safely, but do not include issue
+bodies, review bodies, tokens, or subagent transcripts.
+
+## Safety Rules
+
+- Keep branches scoped to one issue or one PR review batch.
+- Prefer targeted validation over full-suite runs unless the touched area is
+  broad.
+- Never hide skipped checks; include them in the summary.
+- Never weaken repository security policy, approval rules, or CI configuration
+  to make an issue easier to close.
+- If the issue is vague, too large, or not reproducible, report analysis and
+  leave it for manual triage instead of opening a speculative PR.

--- a/skills/gh-issues/SKILL.md
+++ b/skills/gh-issues/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-issues
-description: Fetch GitHub issues, delegate focused fixes, open pull requests, and follow up on actionable PR review comments.
+description: "Process GitHub issues as an automation queue: /gh-issues lists and filters issues, confirms selected issue numbers, deduplicates fix/issue-* work, delegates one focused PR per issue, and can monitor issue-fix PR review feedback. Use this instead of general PR workflow tools only when the entry point is a GitHub issue list or issue-fix queue."
 user-invocable: true
 disable-model-invocation: false
 requires:
@@ -10,7 +10,7 @@ requires:
 metadata:
   hybridclaw:
     category: development
-    short_description: "GitHub issue auto-fix workflow."
+    short_description: "GitHub issue queue automation."
     tags:
       - engineering
       - github
@@ -30,34 +30,44 @@ metadata:
 ---
 # GitHub Issues
 
-Use this skill for `/gh-issues` requests that fetch GitHub issues, assign
-focused subagents to implement fixes, open pull requests, or address actionable
-review comments on issue-fix PRs.
+You are an issue queue orchestrator. Follow the phases in order. Do not run
+processing preflight before the user has selected issues.
 
-## Inputs
+Use this skill for `/gh-issues` requests that start from a GitHub issue list,
+batch issue filters, `fix/issue-*` branch automation, issue-fix PR review
+monitoring, or scheduled issue queue follow-up.
+
+Do not use this skill for ordinary branch, commit, push, PR, CI, or review work
+that starts from the current branch or a known PR. Use a GitHub PR workflow or
+code-review skill for those.
+
+## Phase 1 - Parse Arguments
 
 Parse the arguments after `/gh-issues`.
 
 Positional:
 
 - `owner/repo`: source repository. If omitted, infer it from
-  `git remote get-url origin`.
+  `git remote get-url origin`; if that is unavailable, ask for `owner/repo`.
 
 Flags:
 
-- `--label <label>`: filter issues by label.
-- `--milestone <milestone>`: filter issues by milestone title.
-- `--assignee <assignee>`: filter by assignee. Use `@me` for the authenticated
-  GitHub user.
-- `--state <open|closed|all>`: default `open`.
-- `--limit <n>`: default `10`.
-- `--fork <owner/repo>`: push branches to a fork while opening PRs against the
-  source repository.
-- `--dry-run`: list matching issues only.
-- `--yes`: process listed issues without asking for another confirmation.
-- `--reviews-only`: skip issue fetching and only handle PR review comments.
-- `--watch <minutes>`: schedule a recurring follow-up instead of sleeping.
-- `--model <model>`: optional model override for delegated tasks.
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--label <label>` | none | Filter by label. |
+| `--limit <n>` | `10` | Max issues to fetch per poll. |
+| `--milestone <milestone>` | none | Filter by milestone title. |
+| `--assignee <assignee>` | none | Filter by assignee; resolve `@me` with `gh api user --jq .login`. |
+| `--state <open\|closed\|all>` | `open` | Issue state. |
+| `--fork <owner/repo>` | none | Push branches to a fork while PRs target the source repo. |
+| `--watch` | false | Schedule recurring issue and review follow-up. |
+| `--interval <minutes>` | `5` | Watch interval; only valid with `--watch`. |
+| `--cron` | false | Recurring-run mode: process at most one eligible item and exit. |
+| `--dry-run` | false | Fetch and display issues only. |
+| `--yes` | false | Process listed issues without another confirmation. |
+| `--reviews-only` | false | Skip issue fetching and process issue-fix PR review feedback. |
+| `--model <model>` | none | Optional model override for delegated tasks. |
+| `--notify-channel <target>` | none | Optional HybridClaw message target for final summaries only. |
 
 Derived values:
 
@@ -66,30 +76,30 @@ Derived values:
 - `PUSH_OWNER`: owner portion of `PUSH_REPO`.
 - `PUSH_REMOTE`: `fork` when `--fork` is used, otherwise `origin`.
 - `FORK_MODE`: true when `--fork` is used.
+- `SOURCE_REPO_SLUG`: `SOURCE_REPO` with `/` replaced by `-`.
 
-If required information is missing, stop with the smallest specific request
-needed to continue.
+Mode routing:
 
-## Authentication
+- If `--reviews-only` is set, run authentication, then jump to Phase 6.
+- If `--cron` is set, force `--yes`.
+- If `--watch` is set, use `--interval`, defaulting to 5 minutes.
 
-Prefer GitHub CLI authentication.
+## Phase 2 - Authenticate And Fetch Issues
+
+Prefer GitHub CLI authentication:
 
 ```bash
 gh auth status
 ```
 
-If that fails and `GH_TOKEN` is set, retry commands with `GH_TOKEN` in the
-environment. If authentication still fails, stop and ask the user to run
-`gh auth login` or provide `GH_TOKEN`.
+If that fails and `GH_TOKEN` is set, retry `gh` commands with `GH_TOKEN` in the
+environment. If authentication still fails, ask the user to run `gh auth login`
+or provide `GH_TOKEN`. Never print tokens or put them in git remote URLs.
 
-Do not print tokens, embed tokens in final responses, or store tokens in files.
-
-## Fetch Issues
-
-Use `gh issue list` so pull requests are excluded by default.
+When not in `--reviews-only`, fetch issues with `gh issue list`:
 
 ```bash
-gh issue list --repo "$SOURCE_REPO" --state open --limit 10 \
+gh issue list --repo "$SOURCE_REPO" --state "$STATE" --limit "$LIMIT" \
   --json number,title,labels,assignees,url,body
 ```
 
@@ -97,53 +107,82 @@ Add optional filters only when present:
 
 - `--label "$LABEL"`
 - `--milestone "$MILESTONE"`
-- `--assignee "$ASSIGNEE"` after resolving `@me` with
-  `gh api user --jq .login`
+- `--assignee "$ASSIGNEE"` after resolving `@me`
 
-Display matching issues as a compact markdown table with number, title, labels,
-and assignees. If `--dry-run` is set, stop after the table.
+`gh issue list` excludes pull requests. If another API path is used, exclude
+items that contain a `pull_request` field.
 
-If no issues match, report that directly. Do not delegate an empty batch.
+If watch context includes `PROCESSED_ISSUES`, filter those issue numbers out.
+If no issues match, report that directly and, in watch mode, continue to Phase 6
+to check review feedback.
 
-## Confirmation
+Extract for each issue: number, title, body, label names, assignees, URL.
 
-Unless `--yes` is set, ask which issues to process:
+## Phase 3 - Present And Confirm
 
-- `all`
-- comma-separated issue numbers
-- `cancel`
+Display a compact table:
 
-After the user chooses, continue only with selected issue numbers.
+| # | Title | Labels | Assignees |
+| --- | --- | --- | --- |
 
-## Preflight
+If fork mode is active, also say that branches will be pushed to `PUSH_REPO`
+and PRs will target `SOURCE_REPO`.
 
-Run these checks before delegating fixes:
+If `--dry-run` is set, stop after the table. Do not run preflight.
 
-1. Check the working tree.
+If `--yes` is set, process every listed issue and proceed to Phase 4.
+
+Otherwise ask:
+
+> Which issues should I process: `all`, a comma-separated list of issue numbers,
+> or `cancel`?
+
+Wait for the user response. Continue only with selected issue numbers.
+
+Watch behavior: ask on the first interactive poll unless `--yes` is set. For
+subsequent scheduled runs, auto-process eligible issues with `--yes`.
+
+## Phase 4 - Issue Processing Preflight
+
+Run this phase only after selected issue numbers are known. These checks are for
+delegating fixes, not for issue listing.
+
+1. Resolve the local checkout.
+
+   Use the current directory if it is a git repo whose `origin` matches
+   `SOURCE_REPO`. If the current directory is not a matching checkout, ask the
+   user for the local checkout path before processing. Issue listing does not
+   require a local checkout, but fixing issues does.
+
+2. Check the working tree.
 
    ```bash
    git status --porcelain
    ```
 
-   If it is dirty, explain that delegated fixes should start from committed
-   state and ask whether to continue. Do not stage or commit unrelated changes.
+   If output is non-empty, explain that delegated fixes should start from a
+   committed state and ask whether to continue. Never stage or commit unrelated
+   changes.
 
-2. Record the base branch.
+3. Record the base branch.
 
    ```bash
    git rev-parse --abbrev-ref HEAD
    ```
 
-3. Verify remotes.
+   Store as `BASE_BRANCH`.
+
+4. Verify remotes.
 
    ```bash
    git ls-remote --exit-code origin HEAD
    ```
 
-   In fork mode, ensure a `fork` remote exists for `PUSH_REPO`; add it only if
-   missing.
+   In fork mode, verify a `fork` remote exists for `PUSH_REPO`; add it only if
+   missing, and use the normal GitHub remote URL. Do not write tokens into git
+   config.
 
-4. Skip issues that already have an open PR from the intended branch.
+5. Skip issues that already have open PRs from the intended branch owner.
 
    ```bash
    gh pr list --repo "$SOURCE_REPO" --state open \
@@ -152,31 +191,49 @@ Run these checks before delegating fixes:
      --jq ".[] | select(.headRepositoryOwner.login == \"$PUSH_OWNER\")"
    ```
 
-5. Skip issues whose intended branch already exists in `PUSH_REPO`.
+6. Skip issues whose intended branch exists in `PUSH_REPO`.
 
    ```bash
    BRANCH_REF="fix%2Fissue-$ISSUE_NUMBER"
    gh api "repos/$PUSH_REPO/branches/$BRANCH_REF" --silent
    ```
 
-Only delegate remaining issues.
+7. Track claims for cron/watch dedupe when durable state storage is available.
 
-## Delegate Fixes
+   Use `$HYBRIDCLAW_STATE_DIR/gh-issues` when that variable is set, otherwise
+   `$HOME/.hybridclaw/data/gh-issues`. Create the directory if needed. Store
+   claims in `claims.json`, creating it as `{}` if missing. Remove claims older
+   than 2 hours. For each remaining issue, skip if key
+   `SOURCE_REPO#ISSUE_NUMBER` is claimed. Never write claim or cursor files into
+   the target repository checkout.
 
-Use the `delegate` tool in `parallel` mode for up to 6 independent issues at a
-time. If there are more than 6 selected issues, process them in batches after
-the previous batch reports back. Do not poll or sleep for delegated completion.
+If all selected issues are skipped, report why and, in watch mode, continue to
+Phase 6.
 
-Each delegated task must be self-contained and include:
+## Phase 5 - Delegate Issue Fixes
 
-- source repo, push repo, fork mode, push remote, and base branch
-- issue number, title, URL, labels, assignees, and body
-- expected branch name: `fix/issue-<number>`
-- instruction to open a PR linked to the issue
-- exact output format requested from the subagent
-- model override when `--model` was provided
+Before each delegate call, write or refresh the claim for that issue when the
+claims file is available. Include enough context for the delegated task to work
+without reading this orchestration transcript.
 
-Use this task shape:
+Cron mode:
+
+- Use `cursor-SOURCE_REPO_SLUG.json` in the same HybridClaw state directory as
+  the claims file.
+- Create it as `{"last_processed":null,"in_progress":null}` if missing.
+- Select one eligible issue only: not claimed, no open PR, no branch, and after
+  `last_processed` when possible. Wrap to the first eligible issue if needed.
+- Mark `in_progress`, delegate one issue, report the spawn, and exit. Do not
+  wait for results.
+
+Normal mode:
+
+- Use `delegate` in `parallel` mode for up to 6 independent issues at a time.
+- If more than 6 issues are selected, process the next batch after the previous
+  batch reports back.
+- Do not sleep or busy-wait.
+
+Delegate task shape:
 
 ```text
 You are a focused issue-fix subagent. Fix exactly one GitHub issue and open a PR.
@@ -187,6 +244,7 @@ Fork mode: {FORK_MODE}
 Push remote: {PUSH_REMOTE}
 Base branch: {BASE_BRANCH}
 Branch: fix/issue-{NUMBER}
+Notification target: {NOTIFY_CHANNEL}
 
 Issue #{NUMBER}: {TITLE}
 URL: {URL}
@@ -207,25 +265,49 @@ Workflow:
 
    Include `Fixes {SOURCE_REPO}#{NUMBER}` in the commit body.
 7. Push to `{PUSH_REMOTE}` and open a pull request against `{SOURCE_REPO}`.
-8. Return: PR URL, files changed, tests run, skipped checks, and any caveats.
+8. If a notification target is present, send only the final PR summary to that
+   target with the message tool; do not send status chatter.
+9. Return: PR URL, files changed, tests run, skipped checks, and caveats.
 
 Constraints:
 - Do not modify unrelated files.
 - Do not force-push.
 - Do not commit secrets, local config, or personal data.
 - If the working tree contains unrelated changes, leave them untouched.
+- If the issue is vague, too large, or not reproducible, return analysis and
+  mark it for manual triage instead of opening a speculative PR.
 ```
 
-When delegated results return, present a compact summary table:
+Result collection:
+
+- In cron mode, skip collection because the orchestrator exits after spawning.
+- In normal mode, collect delegate results and present:
 
 | Issue | Status | PR | Notes |
 | --- | --- | --- | --- |
 
-Statuses should be `PR opened`, `Skipped`, `Failed`, or `Needs manual review`.
+Statuses: `PR opened`, `Skipped`, `Failed`, `Timed out`, `Needs manual review`.
 
-## Review-Only Mode
+Store opened PRs as `OPEN_PRS` with PR number, branch, URL, and issue number for
+Phase 6.
 
-When `--reviews-only` is set, find open issue-fix PRs:
+If `--notify-channel` is set, send a final summary only after the batch
+finishes. Do not include issue bodies, review bodies, tokens, or transcripts.
+
+## Phase 6 - PR Review Handler
+
+This phase monitors open issue-fix PRs for actionable review feedback.
+
+It runs:
+
+- after Phase 5 results, for PRs just opened
+- when `--reviews-only` is set
+- during watch or cron review runs
+
+Discover PRs:
+
+- If `OPEN_PRS` exists from Phase 5, inspect those first.
+- Otherwise list open PRs whose head branch starts with `fix/issue-`:
 
 ```bash
 gh pr list --repo "$SOURCE_REPO" --state open \
@@ -233,29 +315,67 @@ gh pr list --repo "$SOURCE_REPO" --state open \
   --jq '.[] | select(.headRefName | startswith("fix/issue-"))'
 ```
 
-For each candidate PR, inspect review sources:
+Fetch review sources for each candidate:
 
 ```bash
 gh pr view "$PR_NUMBER" --repo "$SOURCE_REPO" \
   --json number,title,url,body,reviews,comments,reviewDecision
 gh api "repos/$SOURCE_REPO/pulls/$PR_NUMBER/comments"
+gh api "repos/$SOURCE_REPO/issues/$PR_NUMBER/comments"
 ```
 
-Treat comments as actionable when they request a concrete change, report a bug,
-identify a failing case, or come from a `CHANGES_REQUESTED` review. Skip pure
-approvals, CI summaries, "LGTM", and comments authored by the bot itself.
+Also inspect the PR body for embedded review content such as
+`<!-- greptile_comment -->` or structured sections from review bots.
 
-Display a table of PRs with actionable comments. Unless `--yes` is set, ask
-which PRs to address.
+Determine the bot username with:
 
-## Delegate Review Fixes
+```bash
+gh api user --jq .login
+```
 
-Use `delegate` in `parallel` mode for up to 6 PRs at a time. Each task must
-include the PR URL, branch, source repo, push repo, and a JSON or markdown list
-of actionable comments with author, body, path, line, and comment URL when
-available.
+Exclude comments authored by that user and comments already answered with
+addressed-style replies.
 
-Use this task shape:
+Actionable feedback includes:
+
+- `CHANGES_REQUESTED` reviews
+- comments asking for concrete changes, tests, error handling, or edge cases
+- comments saying a change will fail, break, or cause an error
+- inline comments identifying code defects
+- embedded review sections that flag critical issues, expected failures,
+  low-confidence concerns, or specific changes needed
+
+Not actionable:
+
+- approvals, LGTM, thanks, or pure acknowledgements
+- CI summaries without a requested change
+- bot-generated summaries with no concrete request
+- stale comments already addressed
+
+Build `ACTIONABLE_COMMENTS` with source, author, body, path, line, diff hunk,
+comment ID, and URL when available.
+
+If no actionable comments are found, report that and stop unless watch mode
+needs scheduling.
+
+Display a table:
+
+| PR | Branch | Actionable Comments | Sources |
+| --- | --- | --- | --- |
+
+Unless `--yes`, `--cron`, or a subsequent scheduled watch run is active, ask
+which PRs to address: `all`, comma-separated PR numbers, or `skip`.
+
+Cron review mode:
+
+- Process at most one PR with actionable comments.
+- Delegate one review-fix task and exit without waiting.
+
+Normal review mode:
+
+- Use `delegate` in `parallel` mode for up to 6 PRs at a time.
+
+Review delegate task shape:
 
 ```text
 You are a focused PR review-fix subagent. Address actionable review feedback on
@@ -273,36 +393,65 @@ Actionable comments:
 Workflow:
 1. Fetch and checkout `{BRANCH}` from `{PUSH_REMOTE}`.
 2. Read every actionable comment and group changes by file.
-3. Implement only the requested review fixes.
+3. Implement only requested review fixes.
 4. Run targeted tests or explain why none apply.
 5. Commit with `fix: address review feedback on PR #{PR_NUMBER}`.
 6. Push the branch.
-7. Reply to addressed comments with a brief summary and commit SHA.
+7. Reply to addressed comments with a brief summary and commit SHA. For
+   unresolved or contradictory comments, reply with the reason and mark manual
+   follow-up.
 8. Return: comments addressed, comments skipped, commit SHA, files changed,
    tests run, and manual follow-ups.
 
 Constraints:
 - Do not force-push.
 - Do not rewrite unrelated PR history.
+- Do not change files unrelated to the actionable comments.
 - If comments conflict, address the newest concrete request and flag the
   conflict.
 ```
 
+After review delegates finish, present:
+
+| PR | Comments Addressed | Comments Skipped | Commit | Status |
+| --- | --- | --- | --- | --- |
+
+Track addressed comment IDs in `ADDRESSED_COMMENTS` for watch context.
+
 ## Watch Mode
 
-If `--watch <minutes>` is set, do not sleep in the active turn. Use the `cron`
-tool to schedule a recurring follow-up prompt that reinvokes this skill with the
-same repository, filters, and `--reviews-only` when appropriate. Include enough
-context in the scheduled prompt to continue safely, but do not include issue
-bodies, review bodies, tokens, or subagent transcripts.
+HybridClaw must not sleep in the active turn. If `--watch` is set, use `cron`
+to schedule a recurring follow-up prompt using the same repository and filters.
+
+The scheduled prompt must include:
+
+- `SOURCE_REPO`, `PUSH_REPO`, `FORK_MODE`, `PUSH_REMOTE`
+- filters: label, milestone, assignee, state, limit
+- `--cron --yes`
+- `--reviews-only` when the run should only monitor review feedback
+- compact state: `PROCESSED_ISSUES`, `ADDRESSED_COMMENTS`, `OPEN_PRS`,
+  cumulative one-line results, and `BASE_BRANCH` when known
+
+The scheduled prompt must not include:
+
+- issue bodies
+- review bodies
+- tokens
+- subagent transcripts
+- raw command output containing secrets
+
+If a watch run finds no issue work, still run Phase 6. If no issue or review
+work exists, report "No eligible issue or review work found" and let the next
+scheduled run handle future polling.
 
 ## Safety Rules
 
 - Keep branches scoped to one issue or one PR review batch.
 - Prefer targeted validation over full-suite runs unless the touched area is
   broad.
-- Never hide skipped checks; include them in the summary.
-- Never weaken repository security policy, approval rules, or CI configuration
-  to make an issue easier to close.
+- Never hide skipped checks; include them in summaries.
+- Never weaken repository security policy, approval rules, branch protection, or
+  CI configuration to make an issue easier to close.
+- Do not print or store tokens. Do not put tokens into git remotes.
 - If the issue is vague, too large, or not reproducible, report analysis and
   leave it for manual triage instead of opening a speculative PR.

--- a/skills/gh-issues/SKILL.md
+++ b/skills/gh-issues/SKILL.md
@@ -109,15 +109,12 @@ If `gh` exists, prefer GitHub CLI authentication:
 gh auth status
 ```
 
-If that fails and `GH_TOKEN` is set, retry `gh` commands with `GH_TOKEN` in the
-environment.
-
-If `gh` is unavailable or authentication fails, use the GitHub REST API fallback
-with a token. Prefer the `http_request` tool when available using a stored
-`GH_TOKEN` secret. Otherwise use `curl` with `GH_TOKEN` from the environment.
-If neither `gh` auth nor an API token is available, ask the user to install and
-authenticate `gh`, or provide `GH_TOKEN`. Never print tokens or put them in git
-remote URLs.
+If `gh` is unavailable or authentication fails, use the GitHub REST API through
+the `http_request` tool with `bearerSecretName: "GH_TOKEN"`. The gateway resolves
+`GH_TOKEN` from the encrypted secret store; do not ask the shell for `GH_TOKEN`,
+do not echo tokens, and do not use `curl` for authenticated GitHub API calls. If
+neither `gh` auth nor stored secret `GH_TOKEN` works, ask the user to run
+`gh auth login` or store a GitHub token with `/secret set GH_TOKEN <token>`.
 
 When not in `--reviews-only`, fetch issues with a current-turn GitHub data call.
 Primary `gh` path:
@@ -133,19 +130,25 @@ Add optional filters only when present:
 - `--milestone "$MILESTONE"`
 - `--assignee "$ASSIGNEE"` after resolving `@me`
 
-API fallback path:
+API fallback path with `gh` still available:
 
 ```bash
 gh api "repos/$SOURCE_REPO/issues" \
   -f state="$STATE" -f per_page="$LIMIT"
 ```
 
-Or, without `gh`:
+API fallback path without `gh`: call `http_request` with
+`bearerSecretName: "GH_TOKEN"` and the GitHub URL. Example request shape:
 
-```bash
-curl -sS -H "Authorization: Bearer $GH_TOKEN" \
-  -H "Accept: application/vnd.github+json" \
-  "https://api.github.com/repos/$SOURCE_REPO/issues?state=$STATE&per_page=$LIMIT"
+```json
+{
+  "method": "GET",
+  "url": "https://api.github.com/repos/{SOURCE_REPO}/issues?state={STATE}&per_page={LIMIT}",
+  "bearerSecretName": "GH_TOKEN",
+  "headers": {
+    "Accept": "application/vnd.github+json"
+  }
+}
 ```
 
 Add API query parameters only when present:
@@ -244,12 +247,18 @@ delegating fixes, not for issue listing.
      --jq ".[] | select(.headRepositoryOwner.login == \"$PUSH_OWNER\")"
    ```
 
-   If `gh` is unavailable, use the GitHub REST API:
+   If `gh` is unavailable, use `http_request` with
+   `bearerSecretName: "GH_TOKEN"`:
 
-   ```bash
-   curl -sS -H "Authorization: Bearer $GH_TOKEN" \
-     -H "Accept: application/vnd.github+json" \
-     "https://api.github.com/repos/$SOURCE_REPO/pulls?head=$PUSH_OWNER:fix/issue-$ISSUE_NUMBER&state=open&per_page=1"
+   ```json
+   {
+     "method": "GET",
+     "url": "https://api.github.com/repos/{SOURCE_REPO}/pulls?head={PUSH_OWNER}:fix/issue-{ISSUE_NUMBER}&state=open&per_page=1",
+     "bearerSecretName": "GH_TOKEN",
+     "headers": {
+       "Accept": "application/vnd.github+json"
+     }
+   }
    ```
 
 6. Skip issues whose intended branch exists in `PUSH_REPO`.
@@ -259,8 +268,9 @@ delegating fixes, not for issue listing.
    gh api "repos/$PUSH_REPO/branches/$BRANCH_REF" --silent
    ```
 
-   If `gh` is unavailable, use `GET /repos/$PUSH_REPO/branches/fix%2Fissue-N`
-   through the GitHub REST API.
+   If `gh` is unavailable, use `http_request` with
+   `bearerSecretName: "GH_TOKEN"` against:
+   `https://api.github.com/repos/{PUSH_REPO}/branches/fix%2Fissue-N`.
 
 7. Track claims for cron/watch dedupe when durable state storage is available.
 

--- a/skills/gh-issues/SKILL.md
+++ b/skills/gh-issues/SKILL.md
@@ -63,6 +63,7 @@ Derived values:
 
 - `SOURCE_REPO`: issue and PR target repository.
 - `PUSH_REPO`: `--fork` value, otherwise `SOURCE_REPO`.
+- `PUSH_OWNER`: owner portion of `PUSH_REPO`.
 - `PUSH_REMOTE`: `fork` when `--fork` is used, otherwise `origin`.
 - `FORK_MODE`: true when `--fork` is used.
 
@@ -154,7 +155,8 @@ Run these checks before delegating fixes:
 5. Skip issues whose intended branch already exists in `PUSH_REPO`.
 
    ```bash
-   gh api "repos/$PUSH_REPO/branches/fix/issue-$ISSUE_NUMBER" --silent
+   BRANCH_REF="fix%2Fissue-$ISSUE_NUMBER"
+   gh api "repos/$PUSH_REPO/branches/$BRANCH_REF" --silent
    ```
 
 Only delegate remaining issues.

--- a/skills/gh-issues/SKILL.md
+++ b/skills/gh-issues/SKILL.md
@@ -5,7 +5,6 @@ user-invocable: true
 disable-model-invocation: false
 requires:
   bins:
-    - gh
     - git
 metadata:
   hybridclaw:
@@ -33,6 +32,13 @@ metadata:
 You are an issue queue orchestrator. Follow the phases in order. Do not run
 processing preflight before the user has selected issues.
 
+Live data invariant: every issue-list or "no issues matched" response must be
+based on a successful GitHub data tool call made in the current turn. Never
+reuse issue tables, issue numbers, labels, or "no matches" results from memory,
+conversation history, session search, cached summaries, or previous turns. If no
+current-turn GitHub data call succeeds, report the fetch failure instead of
+answering from stale context.
+
 Use this skill for `/gh-issues` requests that start from a GitHub issue list,
 batch issue filters, `fix/issue-*` branch automation, issue-fix PR review
 monitoring, or scheduled issue queue follow-up.
@@ -49,6 +55,9 @@ Positional:
 
 - `owner/repo`: source repository. If omitted, infer it from
   `git remote get-url origin`; if that is unavailable, ask for `owner/repo`.
+  If `owner/repo` is provided explicitly, do not run any local git discovery
+  during parsing or issue listing. Local checkout checks belong only to Phase 4
+  after issue selection.
 
 Flags:
 
@@ -60,7 +69,7 @@ Flags:
 | `--assignee <assignee>` | none | Filter by assignee; resolve `@me` with `gh api user --jq .login`. |
 | `--state <open\|closed\|all>` | `open` | Issue state. |
 | `--fork <owner/repo>` | none | Push branches to a fork while PRs target the source repo. |
-| `--watch` | false | Schedule recurring issue and review follow-up. |
+| `--watch` | false | Fetch the issue list normally, then schedule recurring issue and review follow-up after the first confirmed run. |
 | `--interval <minutes>` | `5` | Watch interval; only valid with `--watch`. |
 | `--cron` | false | Recurring-run mode: process at most one eligible item and exit. |
 | `--dry-run` | false | Fetch and display issues only. |
@@ -82,21 +91,36 @@ Mode routing:
 
 - If `--reviews-only` is set, run authentication, then jump to Phase 6.
 - If `--cron` is set, force `--yes`.
-- If `--watch` is set, use `--interval`, defaulting to 5 minutes.
+- If `--watch` is set, use `--interval`, defaulting to 5 minutes. Do not skip
+  issue fetching or confirmation. The first watch turn follows Phases 2 and 3
+  like a normal run.
 
 ## Phase 2 - Authenticate And Fetch Issues
 
-Prefer GitHub CLI authentication:
+GitHub CLI is preferred but optional. First check whether it exists:
+
+```bash
+command -v gh
+```
+
+If `gh` exists, prefer GitHub CLI authentication:
 
 ```bash
 gh auth status
 ```
 
 If that fails and `GH_TOKEN` is set, retry `gh` commands with `GH_TOKEN` in the
-environment. If authentication still fails, ask the user to run `gh auth login`
-or provide `GH_TOKEN`. Never print tokens or put them in git remote URLs.
+environment.
 
-When not in `--reviews-only`, fetch issues with `gh issue list`:
+If `gh` is unavailable or authentication fails, use the GitHub REST API fallback
+with a token. Prefer the `http_request` tool when available using a stored
+`GH_TOKEN` secret. Otherwise use `curl` with `GH_TOKEN` from the environment.
+If neither `gh` auth nor an API token is available, ask the user to install and
+authenticate `gh`, or provide `GH_TOKEN`. Never print tokens or put them in git
+remote URLs.
+
+When not in `--reviews-only`, fetch issues with a current-turn GitHub data call.
+Primary `gh` path:
 
 ```bash
 gh issue list --repo "$SOURCE_REPO" --state "$STATE" --limit "$LIMIT" \
@@ -109,8 +133,35 @@ Add optional filters only when present:
 - `--milestone "$MILESTONE"`
 - `--assignee "$ASSIGNEE"` after resolving `@me`
 
-`gh issue list` excludes pull requests. If another API path is used, exclude
-items that contain a `pull_request` field.
+API fallback path:
+
+```bash
+gh api "repos/$SOURCE_REPO/issues" \
+  -f state="$STATE" -f per_page="$LIMIT"
+```
+
+Or, without `gh`:
+
+```bash
+curl -sS -H "Authorization: Bearer $GH_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/$SOURCE_REPO/issues?state=$STATE&per_page=$LIMIT"
+```
+
+Add API query parameters only when present:
+
+- `labels=$LABEL`
+- `assignee=$ASSIGNEE` after resolving `@me` through `GET /user`
+- `milestone=$MILESTONE_NUMBER`; if the user supplied a title, first list
+  milestones and match the title to a number
+
+`gh issue list` excludes pull requests. API issue endpoints include pull
+requests, so exclude any item with a `pull_request` field.
+
+Hard failure rule: if the current turn did not execute a successful `gh issue
+list`, GitHub Issues API, or equivalent `http_request` call, do not display an
+issue table and do not say no issues matched. Report that live issue fetch did
+not complete.
 
 If watch context includes `PROCESSED_ISSUES`, filter those issue numbers out.
 If no issues match, report that directly and, in watch mode, continue to Phase 6
@@ -139,8 +190,10 @@ Otherwise ask:
 
 Wait for the user response. Continue only with selected issue numbers.
 
-Watch behavior: ask on the first interactive poll unless `--yes` is set. For
-subsequent scheduled runs, auto-process eligible issues with `--yes`.
+Watch behavior: ask on the first interactive poll unless `--yes` is set. Do not
+schedule watch follow-up from a parse-only turn. After the user confirms issues
+or after a `--yes` run completes, schedule the next run in Watch Mode.
+Subsequent scheduled runs use `--cron --yes`.
 
 ## Phase 4 - Issue Processing Preflight
 
@@ -191,12 +244,23 @@ delegating fixes, not for issue listing.
      --jq ".[] | select(.headRepositoryOwner.login == \"$PUSH_OWNER\")"
    ```
 
+   If `gh` is unavailable, use the GitHub REST API:
+
+   ```bash
+   curl -sS -H "Authorization: Bearer $GH_TOKEN" \
+     -H "Accept: application/vnd.github+json" \
+     "https://api.github.com/repos/$SOURCE_REPO/pulls?head=$PUSH_OWNER:fix/issue-$ISSUE_NUMBER&state=open&per_page=1"
+   ```
+
 6. Skip issues whose intended branch exists in `PUSH_REPO`.
 
    ```bash
    BRANCH_REF="fix%2Fissue-$ISSUE_NUMBER"
    gh api "repos/$PUSH_REPO/branches/$BRANCH_REF" --silent
    ```
+
+   If `gh` is unavailable, use `GET /repos/$PUSH_REPO/branches/fix%2Fissue-N`
+   through the GitHub REST API.
 
 7. Track claims for cron/watch dedupe when durable state storage is available.
 
@@ -422,6 +486,15 @@ Track addressed comment IDs in `ADDRESSED_COMMENTS` for watch context.
 
 HybridClaw must not sleep in the active turn. If `--watch` is set, use `cron`
 to schedule a recurring follow-up prompt using the same repository and filters.
+
+The initial `--watch` invocation is not a parse-only request. It must fetch the
+current issue list first, present the table, and either ask for selected issue
+numbers or honor `--yes`. Only schedule the recurring follow-up after that first
+selection/processing path has run.
+
+Use the `cron` tool for scheduled follow-up. Do not send a local `message` as a
+substitute for scheduling. If `cron` is unavailable or scheduling fails, report
+that watch scheduling failed.
 
 The scheduled prompt must include:
 


### PR DESCRIPTION
## Summary

Adds a bundled `gh-issues` skill modeled after the OpenClaw workflow, adapted for HybridClaw conventions.

## Changes

- Adds `/gh-issues` as a user-invocable development skill.
- Documents GitHub issue fetching, duplicate branch/PR preflight checks, delegated issue-fix tasks, review-only handling, and watch scheduling through `cron`.
- Declares `gh` and `git` requirements plus a Homebrew install option for GitHub CLI.

## Validation

- `npm run format` completed with no changes.
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/skills.invocation.test.ts` passed.
- Parsed the new skill frontmatter with Ruby/Psych successfully.

## Notes

The Vitest run emitted a startup warning because the reused main-checkout `better-sqlite3` native module was built for a different Node ABI than the active Node runtime, but the targeted invocation suite passed.
