### PR TITLE
feat: add gog Google auth skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## Unreleased
 
+### Added
+
+- **Bundled `gog` Google Workspace skill**: Added API-backed Gmail, Google
+  Calendar, Drive, Contacts, Sheets, and Docs workflows through the `gog` CLI,
+  including the Homebrew install helper and Google OAuth setup via
+  `hybridclaw auth login google`. HybridClaw stores the OAuth client secret
+  and refresh token in encrypted runtime secrets, mints short-lived access
+  tokens on the host, and injects only `GOG_ACCESS_TOKEN` plus `GOG_ACCOUNT`
+  into the agent runtime.
+
+### Changed
+
+- **Google Workspace skill routing prefers `gog` for API access**: The
+  browser-oriented `google-workspace` skill now defers to the bundled `gog`
+  skill when API-backed Gmail, Calendar, Drive, Contacts, Sheets, or Docs
+  access is available.
+
+### Fixed
+
+- **Google Workspace replies preserve user-visible addresses**: Assistant
+  replies and streamed chat text no longer redact ordinary email addresses
+  before they reach the user. Redaction still applies to audit, logging,
+  approval/control previews, and observability paths.
+- **HybridAI streaming avoids duplicate assistant text**: The HybridAI stream
+  adapter now handles chunks that include both cumulative `message.content` and
+  incremental `delta.content` without emitting the same text twice.
+
 ## [0.12.11](https://github.com/HybridAIOne/hybridclaw/tree/v0.12.11)
 
 ### Added

--- a/container/shared/message-tool-channels.d.ts
+++ b/container/shared/message-tool-channels.d.ts
@@ -1,0 +1,29 @@
+export declare const MESSAGE_TOOL_CHANNEL_KINDS: readonly [
+  'discord',
+  'email',
+  'imessage',
+  'msteams',
+  'slack',
+  'telegram',
+  'tui',
+  'whatsapp',
+];
+
+export type MessageToolChannelKind =
+  (typeof MESSAGE_TOOL_CHANNEL_KINDS)[number];
+
+export declare const MESSAGE_TOOL_CHANNEL_LABELS: Readonly<
+  Record<MessageToolChannelKind, string>
+>;
+
+export declare function isMessageToolChannelKind(
+  kind: string,
+): kind is MessageToolChannelKind;
+
+export declare function normalizeMessageToolChannelKinds(
+  kinds: readonly string[] | undefined,
+): MessageToolChannelKind[];
+
+export declare function formatMessageToolChannelList(
+  kinds: readonly string[] | undefined,
+): string;

--- a/container/shared/message-tool-channels.js
+++ b/container/shared/message-tool-channels.js
@@ -1,0 +1,47 @@
+export const MESSAGE_TOOL_CHANNEL_KINDS = [
+  'discord',
+  'email',
+  'imessage',
+  'msteams',
+  'slack',
+  'telegram',
+  'tui',
+  'whatsapp',
+];
+
+export const MESSAGE_TOOL_CHANNEL_LABELS = Object.freeze({
+  discord: 'Discord',
+  email: 'email',
+  imessage: 'iMessage',
+  msteams: 'Microsoft Teams',
+  slack: 'Slack',
+  telegram: 'Telegram',
+  tui: 'local TUI',
+  whatsapp: 'WhatsApp',
+});
+
+const MESSAGE_TOOL_CHANNEL_KIND_SET = new Set(MESSAGE_TOOL_CHANNEL_KINDS);
+
+export function isMessageToolChannelKind(kind) {
+  return MESSAGE_TOOL_CHANNEL_KIND_SET.has(String(kind || '').toLowerCase());
+}
+
+export function normalizeMessageToolChannelKinds(kinds) {
+  if (!Array.isArray(kinds)) return [];
+  const normalized = new Set();
+  for (const kind of kinds) {
+    const candidate = String(kind || '')
+      .trim()
+      .toLowerCase();
+    if (isMessageToolChannelKind(candidate)) normalized.add(candidate);
+  }
+  return [...normalized].sort();
+}
+
+export function formatMessageToolChannelList(kinds) {
+  const labels = normalizeMessageToolChannelKinds(kinds).map(
+    (kind) => MESSAGE_TOOL_CHANNEL_LABELS[kind],
+  );
+  if (labels.length === 0) return 'none';
+  return labels.join(', ');
+}

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -134,6 +134,15 @@ const DEFAULT_RALPH_MAX_EXTRA_ITERATIONS = Number.isFinite(
     ? -1
     : Math.max(0, Math.min(64, RAW_DEFAULT_RALPH_MAX_EXTRA_ITERATIONS))
   : 0;
+
+function applyRuntimeEnv(runtimeEnv: ContainerInput['runtimeEnv']): void {
+  for (const [name, value] of Object.entries(runtimeEnv || {})) {
+    if (!/^[A-Z][A-Z0-9_]{0,127}$/.test(name)) continue;
+    if (typeof value !== 'string' || !value.trim()) continue;
+    process.env[name] = value;
+  }
+}
+
 const approvalRuntime = new TrustedCoworkerApprovalRuntime();
 let cachedSelectedSkillPath: string | null = null;
 
@@ -1540,11 +1549,7 @@ async function main(): Promise<void> {
   // First request arrives via stdin (contains apiKey — never written to disk)
   const stdinData = await readStdinLine();
   const firstInput: ContainerInput = JSON.parse(stdinData);
-  for (const [name, value] of Object.entries(firstInput.runtimeEnv || {})) {
-    if (!/^[A-Z][A-Z0-9_]{0,127}$/.test(name)) continue;
-    if (typeof value !== 'string' || !value.trim()) continue;
-    process.env[name] = value;
-  }
+  applyRuntimeEnv(firstInput.runtimeEnv);
   storedApiKey = firstInput.apiKey;
   storedRequestHeaders = { ...(firstInput.requestHeaders || {}) };
   const firstTaskModels = resolveTaskModelsForRequest(firstInput.taskModels);
@@ -1685,6 +1690,8 @@ async function main(): Promise<void> {
       await shutdownAgentProcess(0, 'idle timeout');
       return;
     }
+
+    applyRuntimeEnv(input.runtimeEnv);
 
     // Use stored apiKey — IPC file no longer contains it
     const apiKey = input.apiKey || storedApiKey;

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -1514,7 +1514,10 @@ function resolveTools(input: ContainerInput): ToolDefinition[] {
       ...tool,
       function: {
         ...tool.function,
-        description: getMessageToolDescription(input.channelId),
+        description: getMessageToolDescription(
+          input.channelId,
+          input.activeMessageChannels,
+        ),
       },
     };
   });

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -1537,6 +1537,11 @@ async function main(): Promise<void> {
   // First request arrives via stdin (contains apiKey — never written to disk)
   const stdinData = await readStdinLine();
   const firstInput: ContainerInput = JSON.parse(stdinData);
+  for (const [name, value] of Object.entries(firstInput.runtimeEnv || {})) {
+    if (!/^[A-Z][A-Z0-9_]{0,127}$/.test(name)) continue;
+    if (typeof value !== 'string' || !value.trim()) continue;
+    process.env[name] = value;
+  }
   storedApiKey = firstInput.apiKey;
   storedRequestHeaders = { ...(firstInput.requestHeaders || {}) };
   const firstTaskModels = resolveTaskModelsForRequest(firstInput.taskModels);

--- a/container/src/providers/hybridai.ts
+++ b/container/src/providers/hybridai.ts
@@ -214,13 +214,17 @@ export async function callHybridAIProviderStream(
       const message = choice.message;
       if (typeof message.role === 'string' && message.role) role = message.role;
       if (typeof message.content === 'string') {
-        usedMessageContent = true;
         const nextContent = message.content;
-        const delta = nextContent.startsWith(textContent)
-          ? nextContent.slice(textContent.length)
-          : nextContent;
-        textContent = nextContent;
-        if (delta) args.onTextDelta(delta);
+        const messageDelta = nextContent
+          ? nextContent.startsWith(textContent)
+            ? nextContent.slice(textContent.length)
+            : nextContent
+          : '';
+        if (messageDelta) {
+          textContent = nextContent;
+          usedMessageContent = true;
+          args.onTextDelta(messageDelta);
+        }
       }
       if (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) {
         toolCalls.length = 0;

--- a/container/src/providers/hybridai.ts
+++ b/container/src/providers/hybridai.ts
@@ -209,10 +209,12 @@ export async function callHybridAIProviderStream(
       : undefined;
     if (!choice) return;
 
+    let usedMessageContent = false;
     if (choice.message) {
       const message = choice.message;
       if (typeof message.role === 'string' && message.role) role = message.role;
       if (typeof message.content === 'string') {
+        usedMessageContent = true;
         const nextContent = message.content;
         const delta = nextContent.startsWith(textContent)
           ? nextContent.slice(textContent.length)
@@ -238,7 +240,11 @@ export async function callHybridAIProviderStream(
     if (choice.delta) {
       const delta = choice.delta;
       if (typeof delta.role === 'string' && delta.role) role = delta.role;
-      if (typeof delta.content === 'string' && delta.content) {
+      if (
+        !usedMessageContent &&
+        typeof delta.content === 'string' &&
+        delta.content
+      ) {
         textContent += delta.content;
         args.onTextDelta(delta.content);
       }

--- a/container/src/tools.ts
+++ b/container/src/tools.ts
@@ -176,7 +176,17 @@ function parseStructuredToolOutput(
 const MESSAGE_TOOL_ACTION_LIST =
   'read, member-info, channel-info, send, react, quote-reply, edit, delete, pin, unpin, thread-create, thread-reply';
 const MESSAGE_TOOL_DESCRIPTION_BASE =
-  'Send messages and uploads across supported channels (Discord, current Microsoft Teams chat, WhatsApp, email, local TUI), plus read Discord channel history, read ingested email thread history, and look up member info on Discord. Use this when asked to send/post/DM/notify someone, post a local file/image, read Discord messages or ingested email threads, or look up Discord users.';
+  'Send or read messages on active communication channels.';
+const MESSAGE_TOOL_CHANNEL_LABELS: Record<string, string> = {
+  discord: 'Discord',
+  email: 'email',
+  imessage: 'iMessage',
+  msteams: 'Microsoft Teams',
+  slack: 'Slack',
+  telegram: 'Telegram',
+  tui: 'local TUI',
+  whatsapp: 'WhatsApp',
+};
 let gatewayConfiguredChannels: string[] = [];
 const DISCORD_SNOWFLAKE_RE = /^\d{16,22}$/;
 const TEAMS_SESSION_ID_RE = /^teams:/i;
@@ -603,13 +613,46 @@ function resolveGatewayMessageSendChannelFallback(): string {
   );
 }
 
-export function getMessageToolDescription(channelId?: string): string {
+function normalizeActiveMessageChannels(
+  activeMessageChannels?: string[],
+): string[] {
+  if (!Array.isArray(activeMessageChannels)) return [];
+  const normalized = new Set<string>();
+  for (const channel of activeMessageChannels) {
+    const candidate = String(channel || '')
+      .trim()
+      .toLowerCase();
+    if (MESSAGE_TOOL_CHANNEL_LABELS[candidate]) normalized.add(candidate);
+  }
+  return [...normalized].sort();
+}
+
+function formatActiveMessageChannels(activeMessageChannels?: string[]): string {
+  const channels = normalizeActiveMessageChannels(activeMessageChannels);
+  if (channels.length === 0) return 'none';
+  return channels
+    .map((channel) => MESSAGE_TOOL_CHANNEL_LABELS[channel])
+    .join(', ');
+}
+
+export function getMessageToolDescription(
+  channelId?: string,
+  activeMessageChannels?: string[],
+): string {
   const explicitChannelId = normalizeDiscordMessageTarget(channelId);
   const activeChannelId =
     explicitChannelId && DISCORD_SNOWFLAKE_RE.test(explicitChannelId)
       ? explicitChannelId
       : resolveGatewayDiscordChannelFallback();
   const activeTeamsChannelId = resolveGatewayMSTeamsChannelFallback();
+  let activeChannels = normalizeActiveMessageChannels(activeMessageChannels);
+  if (activeMessageChannels === undefined) {
+    const inferredChannels = new Set(activeChannels);
+    if (activeChannelId) inferredChannels.add('discord');
+    if (activeTeamsChannelId) inferredChannels.add('msteams');
+    activeChannels = [...inferredChannels].sort();
+  }
+  const activeChannelList = formatActiveMessageChannels(activeChannels);
   const configuredChannels = normalizeConfiguredChannelList(
     gatewayConfiguredChannels,
   );
@@ -621,16 +664,19 @@ export function getMessageToolDescription(channelId?: string): string {
       otherChannels.length > 0
         ? ` Other configured channels: ${otherChannels.map((id) => `${id} (${MESSAGE_TOOL_ACTION_LIST})`).join(', ')}.`
         : '';
-    return `${MESSAGE_TOOL_DESCRIPTION_BASE} Current Discord channel (${activeChannelId}) supports: ${MESSAGE_TOOL_ACTION_LIST}. Omit channelId/to to target the current Discord channel for read/channel-info/send.${withOthers}`;
+    return `${MESSAGE_TOOL_DESCRIPTION_BASE} Active channels: ${activeChannelList}. Current Discord channel (${activeChannelId}) supports: ${MESSAGE_TOOL_ACTION_LIST}. Omit channelId/to to target the current Discord channel for read/channel-info/send.${withOthers}`;
   }
   if (activeTeamsChannelId) {
-    return `${MESSAGE_TOOL_DESCRIPTION_BASE} Current Teams conversation (${activeTeamsChannelId}) supports: send. Omit channelId/to to target the current Teams conversation for send, including local file uploads. Discord-only actions such as read/member-info/channel-info still require explicit Discord targets.`;
+    return `${MESSAGE_TOOL_DESCRIPTION_BASE} Active channels: ${activeChannelList}. Current Teams conversation (${activeTeamsChannelId}) supports: send. Omit channelId/to to target the current Teams conversation for send, including local file uploads.`;
+  }
+  if (activeChannels.length === 0) {
+    return `${MESSAGE_TOOL_DESCRIPTION_BASE} Active channels: none.`;
   }
   const withOthers =
     configuredChannels.length > 0
       ? ` Configured channels: ${configuredChannels.map((id) => `${id} (${MESSAGE_TOOL_ACTION_LIST})`).join(', ')}.`
       : '';
-  return `${MESSAGE_TOOL_DESCRIPTION_BASE} Supports actions: ${MESSAGE_TOOL_ACTION_LIST}.${withOthers}`;
+  return `${MESSAGE_TOOL_DESCRIPTION_BASE} Active channels: ${activeChannelList}. Supports actions: ${MESSAGE_TOOL_ACTION_LIST}.${withOthers}`;
 }
 
 function cloneTaskModelPolicies(
@@ -3457,17 +3503,17 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
           channelId: {
             type: 'string',
             description:
-              'Send target or Discord channel selector. For `send`, accepts Discord ids/mentions/#channel, email addresses, WhatsApp JIDs or phone numbers, and local channel ids like `tui`. For Discord-only actions, use a Discord channel id/mention/#channel.',
+              'Message target or channel selector for send/read actions.',
           },
           guildId: {
             type: 'string',
             description:
-              'Discord guild id (required for member-info; optional for Discord channel-name sends).',
+              'Server or workspace id for channel/member lookups when required.',
           },
           userId: {
             type: 'string',
             description:
-              'Discord user id (required for member-info; optional requester id for send allowlist checks).',
+              'User id for member lookups or send allowlist checks when required.',
           },
           memberId: {
             type: 'string',
@@ -3476,17 +3522,17 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
           username: {
             type: 'string',
             description:
-              'Discord username/display name/@handle to resolve for member-info, or as DM target for send when channelId/to/target is omitted.',
+              'Username, display name, or handle to resolve for member lookups or user-targeted sends.',
           },
           user: {
             type: 'string',
             description:
-              'Alias for username/userId in member-info; for send, used as DM target when channelId/to/target is omitted.',
+              'Alias for username/userId in member lookups or user-targeted sends.',
           },
           resolveAmbiguous: {
             type: 'string',
             description:
-              'Ambiguity policy for Discord name lookups. For action="member-info", user-target sends, and channel-name targets: "error" (default) returns an error/candidates, "best" auto-picks the top score.',
+              'Ambiguity policy for name lookups. "error" returns an error/candidates; "best" auto-picks the top score.',
             enum: ['error', 'best'],
           },
           limit: {
@@ -3512,7 +3558,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
           subject: {
             type: 'string',
             description:
-              'Optional email subject override for action="send" when channelId/to targets an email address. If omitted, email can still use an inline `[Subject: ...]` prefix in content.',
+              'Optional subject override for action="send" when supported by the active channel.',
           },
           cc: {
             type: ['string', 'array'],
@@ -3520,7 +3566,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
               type: 'string',
             },
             description:
-              'Optional email CC recipient or list of recipients for action="send" when channelId/to targets an email address.',
+              'Optional copied recipient or list of recipients for action="send" when supported by the active channel.',
           },
           bcc: {
             type: ['string', 'array'],
@@ -3528,12 +3574,12 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
               type: 'string',
             },
             description:
-              'Optional email BCC recipient or list of recipients for action="send" when channelId/to targets an email address.',
+              'Optional blind-copied recipient or list of recipients for action="send" when supported by the active channel.',
           },
           inReplyTo: {
             type: 'string',
             description:
-              'Optional email Message-ID for the parent message being replied to on action="send" when channelId/to targets an email address. Use the latest message in the thread.',
+              'Optional parent message id for threaded replies when supported by the active channel.',
           },
           references: {
             type: ['string', 'array'],
@@ -3541,22 +3587,20 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
               type: 'string',
             },
             description:
-              'Optional ordered email Message-ID chain for the References header on action="send" when channelId/to targets an email address. End the list with the same parent message used for inReplyTo.',
+              'Optional ordered parent message id chain for threaded replies when supported by the active channel.',
           },
           filePath: {
             type: 'string',
             description:
-              'Optional local file to upload for action="send". Discord, the current Teams conversation, WhatsApp, and email support filePath; local queued sends do not. Use a workspace-relative path or an absolute /discord-media-cache path.',
+              'Optional local file to upload for action="send" when supported by the active channel. Use a workspace-relative path or an absolute managed media path.',
           },
           attachmentPath: {
             type: 'string',
-            description:
-              'Alias for filePath in action="send". Use for local Discord uploads.',
+            description: 'Alias for filePath in action="send".',
           },
           mediaPath: {
             type: 'string',
-            description:
-              'Alias for filePath in action="send". Use for local Discord uploads.',
+            description: 'Alias for filePath in action="send".',
           },
           imagePath: {
             type: 'string',
@@ -3574,7 +3618,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
               type: 'object',
             },
             description:
-              'Optional Discord components payload for action="send" (buttons/selects/action rows). Supported only for Discord sends, not Teams/WhatsApp/email/local sends.',
+              'Optional interactive components payload for action="send" when supported by the active channel.',
           },
           text: {
             type: 'string',
@@ -3592,12 +3636,12 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
           contextChannelId: {
             type: 'string',
             description:
-              'Context Discord channel id used to infer guild for Discord user-target sends.',
+              'Context channel id used to infer routing for user-targeted sends.',
           },
           messageId: {
             type: 'string',
             description:
-              'Discord message id for actions: react, quote-reply, edit, delete, pin, unpin, thread-create.',
+              'Message id for actions: react, quote-reply, edit, delete, pin, unpin, thread-create.',
           },
           emoji: {
             type: 'string',
@@ -3614,13 +3658,11 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
           },
           target: {
             type: 'string',
-            description:
-              'Target user or channel. For `send`, accepts Discord channel IDs, user IDs, @usernames, #channel-name, email addresses, WhatsApp JIDs or phone numbers, or local channel ids like `tui`.',
+            description: 'Target user or channel for action="send".',
           },
           to: {
             type: 'string',
-            description:
-              'Target user or channel. For `send`, accepts Discord channel IDs, user IDs, @usernames, #channel-name, email addresses, WhatsApp JIDs or phone numbers, or local channel ids like `tui`.',
+            description: 'Target user or channel for action="send".',
           },
         },
         required: ['action'],

--- a/container/src/tools.ts
+++ b/container/src/tools.ts
@@ -4,6 +4,10 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import {
+  formatMessageToolChannelList,
+  normalizeMessageToolChannelKinds,
+} from '../shared/message-tool-channels.js';
+import {
   currentDateStampInTimezone,
   readUserTimezoneFile,
 } from '../shared/workspace-time.js';
@@ -177,16 +181,6 @@ const MESSAGE_TOOL_ACTION_LIST =
   'read, member-info, channel-info, send, react, quote-reply, edit, delete, pin, unpin, thread-create, thread-reply';
 const MESSAGE_TOOL_DESCRIPTION_BASE =
   'Send or read messages on active communication channels.';
-const MESSAGE_TOOL_CHANNEL_LABELS: Record<string, string> = {
-  discord: 'Discord',
-  email: 'email',
-  imessage: 'iMessage',
-  msteams: 'Microsoft Teams',
-  slack: 'Slack',
-  telegram: 'Telegram',
-  tui: 'local TUI',
-  whatsapp: 'WhatsApp',
-};
 let gatewayConfiguredChannels: string[] = [];
 const DISCORD_SNOWFLAKE_RE = /^\d{16,22}$/;
 const TEAMS_SESSION_ID_RE = /^teams:/i;
@@ -613,28 +607,6 @@ function resolveGatewayMessageSendChannelFallback(): string {
   );
 }
 
-function normalizeActiveMessageChannels(
-  activeMessageChannels?: string[],
-): string[] {
-  if (!Array.isArray(activeMessageChannels)) return [];
-  const normalized = new Set<string>();
-  for (const channel of activeMessageChannels) {
-    const candidate = String(channel || '')
-      .trim()
-      .toLowerCase();
-    if (MESSAGE_TOOL_CHANNEL_LABELS[candidate]) normalized.add(candidate);
-  }
-  return [...normalized].sort();
-}
-
-function formatActiveMessageChannels(activeMessageChannels?: string[]): string {
-  const channels = normalizeActiveMessageChannels(activeMessageChannels);
-  if (channels.length === 0) return 'none';
-  return channels
-    .map((channel) => MESSAGE_TOOL_CHANNEL_LABELS[channel])
-    .join(', ');
-}
-
 export function getMessageToolDescription(
   channelId?: string,
   activeMessageChannels?: string[],
@@ -645,14 +617,14 @@ export function getMessageToolDescription(
       ? explicitChannelId
       : resolveGatewayDiscordChannelFallback();
   const activeTeamsChannelId = resolveGatewayMSTeamsChannelFallback();
-  let activeChannels = normalizeActiveMessageChannels(activeMessageChannels);
+  let activeChannels = normalizeMessageToolChannelKinds(activeMessageChannels);
   if (activeMessageChannels === undefined) {
     const inferredChannels = new Set(activeChannels);
     if (activeChannelId) inferredChannels.add('discord');
     if (activeTeamsChannelId) inferredChannels.add('msteams');
     activeChannels = [...inferredChannels].sort();
   }
-  const activeChannelList = formatActiveMessageChannels(activeChannels);
+  const activeChannelList = formatMessageToolChannelList(activeChannels);
   const configuredChannels = normalizeConfiguredChannelList(
     gatewayConfiguredChannels,
   );

--- a/container/src/types.ts
+++ b/container/src/types.ts
@@ -224,6 +224,7 @@ export interface ContainerInput {
   maxTokens?: number;
   channelId: string;
   configuredDiscordChannels?: string[];
+  activeMessageChannels?: string[];
   scheduledTasks?: ScheduledTaskInput[];
   allowedTools?: string[];
   blockedTools?: string[];

--- a/container/src/types.ts
+++ b/container/src/types.ts
@@ -235,6 +235,7 @@ export interface ContainerInput {
   contextGuard?: ContextGuardConfig;
   webSearch?: WebSearchConfig;
   persistBashState?: boolean;
+  runtimeEnv?: Record<string, string>;
 }
 
 export interface MediaContextItem {

--- a/docs/content/getting-started/authentication.md
+++ b/docs/content/getting-started/authentication.md
@@ -96,7 +96,15 @@ hybridclaw auth whatsapp reset
 - `hybridclaw auth login google` stores a Google OAuth desktop client id,
   client secret, account, and refresh token for API access through the bundled
   `gog` skill. Create the desktop OAuth client in Google Cloud Console, then
-  pass its **Client ID** and **Client secret** to the command above.
+  pass its **Client ID** and **Client secret** to the command above. The
+  command prints a Google authorization URL and waits for the local OAuth
+  callback; approve the requested scopes in the browser to store the refresh
+  token.
+- Google API access through `gog` also requires the relevant Google Cloud APIs
+  to be enabled in the same project, for example Gmail API, Google Calendar
+  API, Google Drive API, Google Docs API, Google Sheets API, and People API.
+  If the OAuth app is in testing mode, add your Google account as a test user
+  before authorizing.
 - The local backend model id is optional. If omitted, HybridClaw enables the
   backend and you can pick a model later with `/model list <backend>`.
 - Interactive onboarding can skip remote provider auth entirely when you plan

--- a/docs/content/getting-started/authentication.md
+++ b/docs/content/getting-started/authentication.md
@@ -32,6 +32,7 @@ hybridclaw auth login kilo anthropic/claude-sonnet-4.6 --api-key ...
 hybridclaw auth login local lmstudio --base-url http://127.0.0.1:1234
 hybridclaw auth login local ollama llama3.2
 hybridclaw auth login local vllm mistralai/Mistral-7B-Instruct-v0.3 --base-url http://127.0.0.1:8000 --api-key secret
+hybridclaw auth login google --client-id 000000000000-example.apps.googleusercontent.com --client-secret GOCSPX-example --account you@example.com
 hybridclaw auth login msteams --app-id 00000000-0000-0000-0000-000000000000 --tenant-id 11111111-1111-1111-1111-111111111111 --app-password secret
 hybridclaw auth login slack --bot-token xoxb-... --app-token xapp-...
 hybridclaw auth status hybridai
@@ -49,6 +50,7 @@ hybridclaw auth status dashscope
 hybridclaw auth status xiaomi
 hybridclaw auth status kilo
 hybridclaw auth status local
+hybridclaw auth status google
 hybridclaw auth status msteams
 hybridclaw auth status slack
 hybridclaw auth logout hybridai
@@ -66,6 +68,7 @@ hybridclaw auth logout dashscope
 hybridclaw auth logout xiaomi
 hybridclaw auth logout kilo
 hybridclaw auth logout local
+hybridclaw auth logout google
 hybridclaw auth logout msteams
 hybridclaw auth logout slack
 hybridclaw auth whatsapp reset
@@ -90,6 +93,10 @@ hybridclaw auth whatsapp reset
   `XIAOMI_API_KEY`, `KILO_API_KEY`), or prompt interactively.
 - `hybridclaw auth login local` configures Ollama, LM Studio, llama.cpp, or
   vLLM in `~/.hybridclaw/config.json`.
+- `hybridclaw auth login google` stores a Google OAuth desktop client id,
+  client secret, account, and refresh token for API access through the bundled
+  `gog` skill. Create the desktop OAuth client in Google Cloud Console, then
+  pass its **Client ID** and **Client secret** to the command above.
 - The local backend model id is optional. If omitted, HybridClaw enables the
   backend and you can pick a model later with `/model list <backend>`.
 - Interactive onboarding can skip remote provider auth entirely when you plan
@@ -110,6 +117,8 @@ hybridclaw auth whatsapp reset
   the active account id, and the token expiry timestamp.
 - `hybridclaw auth logout local` disables configured local backends and clears
   any saved vLLM API key.
+- `hybridclaw auth logout google` clears the stored Google OAuth material used
+  to mint short-lived `gog` access tokens.
 - `hybridclaw auth logout msteams` clears the stored Teams app password and
   disables the Teams integration in config.
 - `hybridclaw auth logout slack` clears both stored Slack tokens and disables
@@ -163,9 +172,9 @@ hybridclaw secret route remove <url-prefix> [header]
 
 - `~/.hybridclaw/credentials.json` stores HybridAI, OpenRouter, Mistral,
   Hugging Face, Gemini, DeepSeek, xAI, Z.AI, Kimi, MiniMax, DashScope,
-  Xiaomi, Kilo Code, Discord, Slack, Telegram, email, Teams, BlueBubbles
-  iMessage, vLLM, web/gateway auth tokens, related runtime secrets, and named
-  `/secret set` values in encrypted form
+  Xiaomi, Kilo Code, Google OAuth for `gog`, Discord, Slack, Telegram, email,
+  Teams, BlueBubbles iMessage, vLLM, web/gateway auth tokens, related runtime
+  secrets, and named `/secret set` values in encrypted form
 - `~/.hybridclaw/credentials.master.key`, `HYBRIDCLAW_MASTER_KEY`, or
   `/run/secrets/hybridclaw_master_key` supplies the master key used to decrypt
   runtime secrets

--- a/docs/content/guides/bundled-skills.md
+++ b/docs/content/guides/bundled-skills.md
@@ -6,14 +6,14 @@ sidebar_position: 4
 
 # Bundled Skills
 
-HybridClaw currently ships with 34 bundled skills. A few notable categories:
+HybridClaw currently ships with 35 bundled skills. A few notable categories:
 
 - office workflows: `pdf`, `xlsx`, `docx`, `pptx`, `office-workflows`
 - planning and engineering: `project-manager`, `feature-planning`,
   `code-review`, `code-simplification`
 - visual explainers and animation: `manim-video`, `excalidraw`
 - platform integrations: `github-pr-workflow`, `notion`, `trello`, `stripe`,
-  `wordpress`, `google-workspace`, `discord`
+  `wordpress`, `gog`, `google-workspace`, `discord`
 - knowledge workflows: `llm-wiki`, `obsidian`, `zettelkasten`
 - personal and Apple workflows: `apple-calendar`, `apple-passwords`,
   `apple-music`

--- a/docs/content/guides/skills/README.md
+++ b/docs/content/guides/skills/README.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 # Skills Catalog
 
-HybridClaw ships **34 bundled skills** across nine categories. Each page below
+HybridClaw ships **35 bundled skills** across nine categories. Each page below
 covers every skill in its category with prerequisites, install commands,
 tips & tricks, ready-to-try example prompts, and troubleshooting.
 
@@ -32,7 +32,7 @@ resolution rules and runtime internals see
 | Productivity | feature-planning, project-manager, trello | [Productivity Skills](./productivity.md) |
 | Memory & Knowledge | llm-wiki, notion, obsidian, personality, zettelkasten | [Memory & Knowledge Skills](./memory-knowledge.md) |
 | Publishing | manim-video, wordpress, write-blog-post | [Publishing Skills](./publishing.md) |
-| Integrations & Utilities | 1password, stripe, sokosumi, google-workspace, current-time, hybridclaw-help, iss-position | [Integrations & Utilities](./integrations.md) |
+| Integrations & Utilities | 1password, stripe, sokosumi, gog, google-workspace, current-time, hybridclaw-help, iss-position | [Integrations & Utilities](./integrations.md) |
 
 ## Evaluating Example Prompts
 

--- a/docs/content/guides/skills/integrations.md
+++ b/docs/content/guides/skills/integrations.md
@@ -142,12 +142,46 @@ Set `SOKOSUMI_API_KEY` as an environment variable or provide when prompted.
 Work with Gmail, Calendar, Drive, Docs, and Sheets via browser automation or
 APIs.
 
-**Prerequisites** — a Google account. For browser automation, run
-`hybridclaw browser login` once to set up a persistent browser profile.
+**Prerequisites** — a Google account.
+
+For browser automation, run `hybridclaw browser login` once to set up a
+persistent browser profile.
+
+For API access through the bundled `gog` skill:
+
+1. Open [Google Cloud Console Credentials](https://console.cloud.google.com/apis/credentials).
+2. Select or create a project.
+3. Open **OAuth consent screen** and finish the required app setup. If the app
+   is in testing mode, add your Google account as a test user.
+4. Open **Library** and enable the APIs you need, such as Gmail API, Google
+   Calendar API, Google Drive API, Google Docs API, Google Sheets API, and
+   People API.
+5. Open **Credentials**.
+6. Click **Create credentials**.
+7. Choose **OAuth client ID**.
+8. Choose application type **Desktop app**.
+9. Name it, for example `HybridClaw local auth`.
+10. Click **Create**.
+11. Copy the generated **Client ID** and **Client secret**.
+12. Save them in HybridClaw:
+
+```bash
+hybridclaw auth login google --client-id "<client-id>" --client-secret "<client-secret>" --account you@example.com
+```
+
+13. Install the `gog` dependency:
+
+```bash
+hybridclaw skill install gog brew
+```
+
+Use **OAuth client ID**, not **API key** or **Service account**, for normal
+personal Gmail, Calendar, Drive, Docs, and Sheets access.
 
 > 💡 **Tips & Tricks**
 >
-> The skill prefers browser automation over API calls — no OAuth setup needed for basic operations.
+> Browser automation does not need OAuth setup. API access through `gog` needs
+> the Google OAuth client setup above.
 >
 > If a Google login page appears, it directs you to run `hybridclaw browser login` rather than entering credentials.
 >

--- a/docs/content/guides/skills/integrations.md
+++ b/docs/content/guides/skills/integrations.md
@@ -137,6 +137,76 @@ Set `SOKOSUMI_API_KEY` as an environment variable or provide when prompted.
 
 ---
 
+## gog
+
+Use the `gog` CLI for API-backed Google Workspace access: Gmail, Google
+Calendar, Drive, Contacts, Sheets, and Docs.
+
+**Prerequisites** — a Google account, a Google Cloud OAuth desktop client, and
+the APIs you plan to use enabled in that Google Cloud project.
+
+**Install and authorize**
+
+1. Open [Google Cloud Console Credentials](https://console.cloud.google.com/apis/credentials).
+2. Select or create the project you want HybridClaw to use.
+3. Open **OAuth consent screen** and finish the required app setup. If the app
+   is in testing mode, add your Google account as a test user.
+4. Open **Library** and enable the APIs you need, such as Gmail API, Google
+   Calendar API, Google Drive API, Google Docs API, Google Sheets API, and
+   People API.
+5. Open **Credentials**.
+6. Click **Create credentials**.
+7. Choose **OAuth client ID**.
+8. Choose application type **Desktop app**.
+9. Name it, for example `HybridClaw local auth`.
+10. Click **Create**.
+11. Copy the generated **Client ID** and **Client secret**.
+12. Install the `gog` CLI dependency:
+
+```bash
+hybridclaw skill install gog brew
+```
+
+13. Store the OAuth material in HybridClaw and complete the consent link:
+
+```bash
+hybridclaw auth login google --client-id "<client-id>" --client-secret "<client-secret>" --account you@example.com
+hybridclaw auth status google
+```
+
+Use **OAuth client ID**, not **API key** or **Service account**, for normal
+personal Gmail, Calendar, Drive, Docs, and Sheets access.
+
+HybridClaw stores the OAuth client secret and refresh token in encrypted
+runtime secrets. At run time it mints a short-lived access token on the host
+and injects only `GOG_ACCESS_TOKEN` plus `GOG_ACCOUNT` into the agent runtime.
+
+> 💡 **Tips & Tricks**
+>
+> Prefer `gog` for direct API-backed Gmail, Calendar, Drive, Contacts, Sheets,
+> and Docs tasks.
+>
+> Use `gog <command> --help` to inspect the current flags for a subcommand.
+>
+> For scripting, prefer `--json` and `--no-input`.
+>
+> For Google Calendar invites, use `--attendees a@b.com,c@d.com` and
+> `--send-updates all` when guests should receive email notifications.
+>
+> Always confirm before sending emails or creating calendar events.
+
+> 🎯 **Try it yourself**
+>
+> `Use gog to list all Google Calendar events tomorrow`
+>
+> `Create a Google Calendar meeting "Product Sync" next Tuesday from 10:00 to 10:30 and invite alex@example.com`
+>
+> `Search Gmail for unread messages from finance@example.com from the last 7 days`
+>
+> `Export the Google Doc with id DOC_ID as text and summarize it`
+
+---
+
 ## google-workspace
 
 Work with Gmail, Calendar, Drive, Docs, and Sheets via browser automation or
@@ -147,7 +217,11 @@ APIs.
 For browser automation, run `hybridclaw browser login` once to set up a
 persistent browser profile.
 
-For API access through the bundled `gog` skill:
+For API access, prefer the bundled [`gog`](#gog) skill when it is installed and
+authenticated. It provides CLI-backed access to Gmail, Google Calendar, Drive,
+Contacts, Sheets, and Docs from both host and container sessions.
+
+If you need to set up `gog` access:
 
 1. Open [Google Cloud Console Credentials](https://console.cloud.google.com/apis/credentials).
 2. Select or create a project.

--- a/docs/development/getting-started/authentication.md
+++ b/docs/development/getting-started/authentication.md
@@ -87,7 +87,15 @@ hybridclaw auth whatsapp reset
 - `hybridclaw auth login google` stores a Google OAuth desktop client id,
   client secret, account, and refresh token for API access through the bundled
   `gog` skill. Create the desktop OAuth client in Google Cloud Console, then
-  pass its **Client ID** and **Client secret** to the command above.
+  pass its **Client ID** and **Client secret** to the command above. The
+  command prints a Google authorization URL and waits for the local OAuth
+  callback; approve the requested scopes in the browser to store the refresh
+  token.
+- Google API access through `gog` also requires the relevant Google Cloud APIs
+  to be enabled in the same project, for example Gmail API, Google Calendar
+  API, Google Drive API, Google Docs API, Google Sheets API, and People API.
+  If the OAuth app is in testing mode, add your Google account as a test user
+  before authorizing.
 - The local backend model id is optional. If omitted, HybridClaw enables the
   backend and you can pick a model later with `/model list <backend>`.
 - Interactive onboarding can skip remote provider auth entirely when you plan

--- a/docs/development/getting-started/authentication.md
+++ b/docs/development/getting-started/authentication.md
@@ -26,6 +26,7 @@ hybridclaw auth login xiaomi mimo-v2-pro --api-key ...
 hybridclaw auth login kilo anthropic/claude-sonnet-4.6 --api-key ...
 hybridclaw auth login local lmstudio --base-url http://127.0.0.1:1234
 hybridclaw auth login local ollama llama3.2
+hybridclaw auth login google --client-id 000000000000-example.apps.googleusercontent.com --client-secret GOCSPX-example --account you@example.com
 hybridclaw auth login msteams --app-id 00000000-0000-0000-0000-000000000000 --tenant-id 11111111-1111-1111-1111-111111111111 --app-password secret
 hybridclaw auth status hybridai
 hybridclaw auth status codex
@@ -42,6 +43,7 @@ hybridclaw auth status dashscope
 hybridclaw auth status xiaomi
 hybridclaw auth status kilo
 hybridclaw auth status local
+hybridclaw auth status google
 hybridclaw auth status msteams
 hybridclaw auth logout hybridai
 hybridclaw auth logout codex
@@ -58,6 +60,7 @@ hybridclaw auth logout dashscope
 hybridclaw auth logout xiaomi
 hybridclaw auth logout kilo
 hybridclaw auth logout local
+hybridclaw auth logout google
 hybridclaw auth logout msteams
 hybridclaw auth whatsapp reset
 ```
@@ -81,6 +84,10 @@ hybridclaw auth whatsapp reset
   `XIAOMI_API_KEY`, `KILO_API_KEY`), or prompt interactively.
 - `hybridclaw auth login local` configures Ollama, LM Studio, llama.cpp, or
   vLLM in `~/.hybridclaw/config.json`.
+- `hybridclaw auth login google` stores a Google OAuth desktop client id,
+  client secret, account, and refresh token for API access through the bundled
+  `gog` skill. Create the desktop OAuth client in Google Cloud Console, then
+  pass its **Client ID** and **Client secret** to the command above.
 - The local backend model id is optional. If omitted, HybridClaw enables the
   backend and you can pick a model later with `/model list <backend>`.
 - Interactive onboarding can skip remote provider auth entirely when you plan
@@ -96,6 +103,8 @@ hybridclaw auth whatsapp reset
   the credentials file path or any partial secret value.
 - `hybridclaw auth logout local` disables configured local backends and clears
   any saved vLLM API key.
+- `hybridclaw auth logout google` clears the stored Google OAuth material used
+  to mint short-lived `gog` access tokens.
 - `hybridclaw auth logout msteams` clears the stored Teams app password and
   disables the Teams integration in config.
 - `hybridclaw auth whatsapp reset` clears linked WhatsApp Web auth without
@@ -113,8 +122,9 @@ hybridclaw auth whatsapp reset
 
 - `~/.hybridclaw/credentials.json` stores HybridAI, OpenRouter, Mistral,
   Hugging Face, Gemini, DeepSeek, xAI, Z.AI, Kimi, MiniMax, DashScope,
-  Xiaomi, Kilo Code, Discord, email, Teams, BlueBubbles iMessage, related
-  runtime secrets, and named `/secret set` values in encrypted form
+  Xiaomi, Kilo Code, Google OAuth for `gog`, Discord, email, Teams,
+  BlueBubbles iMessage, related runtime secrets, and named `/secret set` values
+  in encrypted form
 - `~/.hybridclaw/credentials.master.key`, `HYBRIDCLAW_MASTER_KEY`, or
   `/run/secrets/hybridclaw_master_key` supplies the master key used to decrypt
   runtime secrets

--- a/docs/development/guides/bundled-skills.md
+++ b/docs/development/guides/bundled-skills.md
@@ -6,14 +6,14 @@ sidebar_position: 4
 
 # Bundled Skills
 
-HybridClaw currently ships with 34 bundled skills. A few notable categories:
+HybridClaw currently ships with 35 bundled skills. A few notable categories:
 
 - office workflows: `pdf`, `xlsx`, `docx`, `pptx`, `office-workflows`
 - planning and engineering: `project-manager`, `feature-planning`,
   `code-review`, `code-simplification`
 - visual explainers and animation: `manim-video`, `excalidraw`
 - platform integrations: `github-pr-workflow`, `notion`, `trello`, `stripe`,
-  `wordpress`, `google-workspace`, `discord`
+  `wordpress`, `gog`, `google-workspace`, `discord`
 - knowledge workflows: `llm-wiki`, `obsidian`, `zettelkasten`
 - personal and Apple workflows: `apple-calendar`, `apple-passwords`,
   `apple-music`

--- a/docs/development/guides/skills/README.md
+++ b/docs/development/guides/skills/README.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 # Skills Catalog
 
-HybridClaw ships **34 bundled skills** across nine categories. Each page below
+HybridClaw ships **35 bundled skills** across nine categories. Each page below
 covers every skill in its category with prerequisites, install commands,
 tips & tricks, ready-to-try example prompts, and troubleshooting.
 
@@ -32,7 +32,7 @@ resolution rules and runtime internals see
 | Productivity | feature-planning, project-manager, trello | [Productivity Skills](./productivity.md) |
 | Memory & Knowledge | llm-wiki, notion, obsidian, personality, zettelkasten | [Memory & Knowledge Skills](./memory-knowledge.md) |
 | Publishing | manim-video, wordpress, write-blog-post | [Publishing Skills](./publishing.md) |
-| Integrations & Utilities | 1password, stripe, sokosumi, google-workspace, current-time, hybridclaw-help, iss-position | [Integrations & Utilities](./integrations.md) |
+| Integrations & Utilities | 1password, stripe, sokosumi, gog, google-workspace, current-time, hybridclaw-help, iss-position | [Integrations & Utilities](./integrations.md) |
 
 ## Evaluating Example Prompts
 

--- a/docs/development/guides/skills/integrations.md
+++ b/docs/development/guides/skills/integrations.md
@@ -142,12 +142,46 @@ Set `SOKOSUMI_API_KEY` as an environment variable or provide when prompted.
 Work with Gmail, Calendar, Drive, Docs, and Sheets via browser automation or
 APIs.
 
-**Prerequisites** — a Google account. For browser automation, run
-`hybridclaw browser login` once to set up a persistent browser profile.
+**Prerequisites** — a Google account.
+
+For browser automation, run `hybridclaw browser login` once to set up a
+persistent browser profile.
+
+For API access through the bundled `gog` skill:
+
+1. Open [Google Cloud Console Credentials](https://console.cloud.google.com/apis/credentials).
+2. Select or create a project.
+3. Open **OAuth consent screen** and finish the required app setup. If the app
+   is in testing mode, add your Google account as a test user.
+4. Open **Library** and enable the APIs you need, such as Gmail API, Google
+   Calendar API, Google Drive API, Google Docs API, Google Sheets API, and
+   People API.
+5. Open **Credentials**.
+6. Click **Create credentials**.
+7. Choose **OAuth client ID**.
+8. Choose application type **Desktop app**.
+9. Name it, for example `HybridClaw local auth`.
+10. Click **Create**.
+11. Copy the generated **Client ID** and **Client secret**.
+12. Save them in HybridClaw:
+
+```bash
+hybridclaw auth login google --client-id "<client-id>" --client-secret "<client-secret>" --account you@example.com
+```
+
+13. Install the `gog` dependency:
+
+```bash
+hybridclaw skill install gog brew
+```
+
+Use **OAuth client ID**, not **API key** or **Service account**, for normal
+personal Gmail, Calendar, Drive, Docs, and Sheets access.
 
 > 💡 **Tips & Tricks**
 >
-> The skill prefers browser automation over API calls — no OAuth setup needed for basic operations.
+> Browser automation does not need OAuth setup. API access through `gog` needs
+> the Google OAuth client setup above.
 >
 > If a Google login page appears, it directs you to run `hybridclaw browser login` rather than entering credentials.
 >

--- a/docs/development/guides/skills/integrations.md
+++ b/docs/development/guides/skills/integrations.md
@@ -137,6 +137,76 @@ Set `SOKOSUMI_API_KEY` as an environment variable or provide when prompted.
 
 ---
 
+## gog
+
+Use the `gog` CLI for API-backed Google Workspace access: Gmail, Google
+Calendar, Drive, Contacts, Sheets, and Docs.
+
+**Prerequisites** — a Google account, a Google Cloud OAuth desktop client, and
+the APIs you plan to use enabled in that Google Cloud project.
+
+**Install and authorize**
+
+1. Open [Google Cloud Console Credentials](https://console.cloud.google.com/apis/credentials).
+2. Select or create the project you want HybridClaw to use.
+3. Open **OAuth consent screen** and finish the required app setup. If the app
+   is in testing mode, add your Google account as a test user.
+4. Open **Library** and enable the APIs you need, such as Gmail API, Google
+   Calendar API, Google Drive API, Google Docs API, Google Sheets API, and
+   People API.
+5. Open **Credentials**.
+6. Click **Create credentials**.
+7. Choose **OAuth client ID**.
+8. Choose application type **Desktop app**.
+9. Name it, for example `HybridClaw local auth`.
+10. Click **Create**.
+11. Copy the generated **Client ID** and **Client secret**.
+12. Install the `gog` CLI dependency:
+
+```bash
+hybridclaw skill install gog brew
+```
+
+13. Store the OAuth material in HybridClaw and complete the consent link:
+
+```bash
+hybridclaw auth login google --client-id "<client-id>" --client-secret "<client-secret>" --account you@example.com
+hybridclaw auth status google
+```
+
+Use **OAuth client ID**, not **API key** or **Service account**, for normal
+personal Gmail, Calendar, Drive, Docs, and Sheets access.
+
+HybridClaw stores the OAuth client secret and refresh token in encrypted
+runtime secrets. At run time it mints a short-lived access token on the host
+and injects only `GOG_ACCESS_TOKEN` plus `GOG_ACCOUNT` into the agent runtime.
+
+> 💡 **Tips & Tricks**
+>
+> Prefer `gog` for direct API-backed Gmail, Calendar, Drive, Contacts, Sheets,
+> and Docs tasks.
+>
+> Use `gog <command> --help` to inspect the current flags for a subcommand.
+>
+> For scripting, prefer `--json` and `--no-input`.
+>
+> For Google Calendar invites, use `--attendees a@b.com,c@d.com` and
+> `--send-updates all` when guests should receive email notifications.
+>
+> Always confirm before sending emails or creating calendar events.
+
+> 🎯 **Try it yourself**
+>
+> `Use gog to list all Google Calendar events tomorrow`
+>
+> `Create a Google Calendar meeting "Product Sync" next Tuesday from 10:00 to 10:30 and invite alex@example.com`
+>
+> `Search Gmail for unread messages from finance@example.com from the last 7 days`
+>
+> `Export the Google Doc with id DOC_ID as text and summarize it`
+
+---
+
 ## google-workspace
 
 Work with Gmail, Calendar, Drive, Docs, and Sheets via browser automation or
@@ -147,7 +217,11 @@ APIs.
 For browser automation, run `hybridclaw browser login` once to set up a
 persistent browser profile.
 
-For API access through the bundled `gog` skill:
+For API access, prefer the bundled [`gog`](#gog) skill when it is installed and
+authenticated. It provides CLI-backed access to Gmail, Google Calendar, Drive,
+Contacts, Sheets, and Docs from both host and container sessions.
+
+If you need to set up `gog` access:
 
 1. Open [Google Cloud Console Credentials](https://console.cloud.google.com/apis/credentials).
 2. Select or create a project.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1431,7 +1431,7 @@
     </div>
     <div class="feature-card">
       <h3 style="color: var(--accent-1);">Skills Engine</h3>
-      <p>HybridClaw ships with 34 bundled skills, including the <code>manim-video</code> animation workflow and the <code>excalidraw</code> diagramming workflow, category-aware catalog and admin authoring flows, and OpenClaw/CLAUDE-compatible <code>SKILL.md</code> discovery with prompt embedding modes (<code>always</code>/<code>summary</code>/<code>hidden</code>), eligibility checks, and trust-aware security scanning. Community imports support packaged <code>official/&lt;skill&gt;</code> skills, <code>skills-sh</code>, <code>clawhub</code>, <code>lobehub</code>, <code>claude-marketplace</code>, <code>well-known</code>, and explicit GitHub repo/path sources via <code>hybridclaw skill import</code> or <code>/skill import</code>.</p>
+      <p>HybridClaw ships with 35 bundled skills, including the <code>gog</code> Google Workspace CLI workflow, the <code>manim-video</code> animation workflow, and the <code>excalidraw</code> diagramming workflow, category-aware catalog and admin authoring flows, and OpenClaw/CLAUDE-compatible <code>SKILL.md</code> discovery with prompt embedding modes (<code>always</code>/<code>summary</code>/<code>hidden</code>), eligibility checks, and trust-aware security scanning. Community imports support packaged <code>official/&lt;skill&gt;</code> skills, <code>skills-sh</code>, <code>clawhub</code>, <code>lobehub</code>, <code>claude-marketplace</code>, <code>well-known</code>, and explicit GitHub repo/path sources via <code>hybridclaw skill import</code> or <code>/skill import</code>.</p>
     </div>
     <div class="feature-card">
       <h3 style="color: var(--accent-1);">Agent Packaging</h3>

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gog
-description: Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs.
+description: Google Workspace CLI for Gmail, Google Calendar, Drive, Contacts, Sheets, and Docs.
 user-invocable: true
 requires:
   bins:

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gog
-description: Use the gog CLI for Google Workspace workflows across Gmail, Calendar, Drive, Contacts, Sheets, and Docs.
+description: Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs.
 user-invocable: true
 requires:
   bins:

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -62,7 +62,8 @@ Use the minimum scopes needed for the task. Keep OAuth client secrets outside th
 3. The runtime normally provides `GOG_ACCOUNT`; pass `--account you@example.com` only when the user has explicitly configured multiple accounts.
 4. Prefer read/list/search commands first, then propose write operations.
 5. Require explicit confirmation before sending email, creating drafts that may be sent, creating or updating calendar events, changing Sheets values, or modifying Drive/Docs resources.
-6. For scripting and follow-up parsing, prefer `--json` and `--no-input` when the subcommand supports them.
+6. For scripting and follow-up parsing, prefer `--json`, `--results-only`, and `--no-input` when the subcommand supports them.
+7. Do not pipe `gog ... --json` into `python3 - <<'PY'`; the heredoc becomes Python's stdin, so `json.load(sys.stdin)` will not receive the `gog` output. Use a temp JSON file or call `gog` from Python with `subprocess.check_output`.
 
 ## Gmail
 
@@ -132,6 +133,25 @@ List events:
 
 ```bash
 gog calendar events <calendarId> --from <iso> --to <iso>
+```
+
+For broad user requests like "my calendar", "my Google Calendar", or "all my meetings", omit `<calendarId>` first so `gog` searches all available calendars. Use `primary` only when the user explicitly asks for the primary calendar or after confirming that primary is the right scope.
+
+```bash
+gog calendar events --from <iso> --to <iso> --json --results-only --no-input
+```
+
+When filtering JSON results, either write JSON to a temp file:
+
+```bash
+gog calendar events --from <iso> --to <iso> --json --results-only --no-input > /tmp/gog-events.json
+python3 -c 'import json,re; items=json.load(open("/tmp/gog-events.json")); rx=re.compile("festival", re.I); print(json.dumps([e for e in items if rx.search(str(e.get("summary","")) + " " + str(e.get("description","")))], ensure_ascii=False, indent=2))'
+```
+
+Or call `gog` from Python:
+
+```bash
+python3 -c 'import json,re,subprocess; out=subprocess.check_output(["gog","calendar","events","--from","<iso>","--to","<iso>","--json","--results-only","--no-input"], text=True); items=json.loads(out); rx=re.compile("festival", re.I); print(json.dumps([e for e in items if rx.search(str(e.get("summary","")) + " " + str(e.get("description","")))], ensure_ascii=False, indent=2))'
 ```
 
 Create an event:

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gog
-description: Google Workspace CLI for Gmail, Google Calendar events, meetings, schedules, availability, Drive, Contacts, Sheets, and Docs.
+description: Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs
 user-invocable: true
 requires:
   bins:
@@ -34,24 +34,19 @@ Use `gog` for Gmail/Calendar/Drive/Contacts/Sheets/Docs. Requires OAuth setup.
 
 ```bash
 hybridclaw skill install gog brew
-```
-
-```bash
 hybridclaw auth login google --client-id <id> --client-secret <secret> --account you@gmail.com
 hybridclaw auth status google
 ```
 
 HybridClaw stores the Google OAuth client secret and refresh token in encrypted runtime secrets, mints a short-lived access token on the host, and injects only `GOG_ACCESS_TOKEN` plus `GOG_ACCOUNT` into the agent runtime for `gog`.
 
-If the user already has a refresh token, they can store it directly:
-
-```bash
-hybridclaw auth login google --client-id <id> --client-secret <secret> --account you@gmail.com --refresh-token <token>
-```
-
 ## Common commands
 
-- Help about a gog command: `gog <service> <command> --help`
+`gog` support the commands: calendar, chat, contacts, docs, drive, forms, gmail, groups, people,
+slides, tasks, sheets
+
+- Help about a gog command: `gog <command> --help`
+
 - Gmail search: `gog gmail search 'newer_than:7d' --max 10`
 - Gmail messages search (per email, ignores threading): `gog gmail messages search "in:inbox from:ryanair.com" --max 20 --account you@example.com`
 - Gmail send (plain): `gog gmail send --to a@b.com --subject "Hi" --body "Hello"`

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gog
-description: Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs
+description: Google Workspace CLI for Gmail, Google Calendar events, meetings, schedules, availability, Drive, Contacts, Sheets, and Docs
 user-invocable: true
 requires:
   bins:
@@ -42,7 +42,7 @@ HybridClaw stores the Google OAuth client secret and refresh token in encrypted 
 
 ## Common commands
 
-`gog` support the commands: calendar, chat, contacts, docs, drive, forms, gmail, groups, people,
+`gog` supports the commands: calendar, chat, contacts, docs, drive, forms, gmail, groups, people,
 slides, tasks, sheets
 
 - Help about a gog command: `gog <command> --help`
@@ -59,6 +59,7 @@ slides, tasks, sheets
 - Calendar search events: `gog calendar search <calendarId> "Meeting" --from <iso> --to <iso> --max 10`
 - Calendar list events: `gog calendar events <calendarId> --from <iso> --to <iso>`
 - Calendar create event: `gog calendar create <calendarId> --summary "Title" --from <iso> --to <iso>`
+- Calendar create with attendees: `gog calendar create <calendarId> --summary "Title" --from <iso> --to <iso> --attendees a@b.com,c@d.com --send-updates all`
 - Calendar create with color: `gog calendar create <calendarId> --summary "Title" --from <iso> --to <iso> --event-color 7`
 - Calendar update event: `gog calendar update <calendarId> <eventId> --summary "New Title" --event-color 4`
 - Calendar show colors: `gog calendar colors`
@@ -122,6 +123,8 @@ Email Formatting
 
 ## Notes
 - For scripting, prefer `--json` plus `--no-input`.
+- When the user asks for calendar events without naming a calendar ID, `gog` searches all available calendars.
+- Do not pipe `gog ... --json` through ad hoc Python filters unless the JSON shape has been inspected first.
 - Sheets values can be passed via `--values-json` (recommended) or as inline rows.
 - Docs supports export/cat/copy. In-place edits require a Docs API client (not in gog).
 - Confirm before sending mail or creating events.

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gog
-description: Google Workspace CLI for Gmail, Google Calendar, Drive, Contacts, Sheets, and Docs.
+description: Google Workspace CLI for Gmail, Google Calendar events, meetings, schedules, availability, Drive, Contacts, Sheets, and Docs.
 user-invocable: true
 requires:
   bins:

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -28,17 +28,13 @@ metadata:
 ---
 # gog
 
-Use this skill when the user wants deterministic Google Workspace automation through `gog` instead of browser automation. `gog` covers Gmail, Calendar, Drive, Contacts, Sheets, and Docs, and requires OAuth setup before use.
+Use `gog` for Gmail/Calendar/Drive/Contacts/Sheets/Docs. Requires OAuth setup.
 
-## Setup
-
-If `gog` is missing, tell the user to run:
+## Setup (once)
 
 ```bash
 hybridclaw skill install gog brew
 ```
-
-Then complete HybridClaw Google OAuth setup once from the host:
 
 ```bash
 hybridclaw auth login google --client-id <id> --client-secret <secret> --account you@gmail.com
@@ -53,210 +49,85 @@ If the user already has a refresh token, they can store it directly:
 hybridclaw auth login google --client-id <id> --client-secret <secret> --account you@gmail.com --refresh-token <token>
 ```
 
-Use the minimum scopes needed for the task. Keep OAuth client secrets outside the repo and outside version control.
-
-## Default Workflow
-
-1. Check availability with `gog --help` or the specific subcommand help.
-2. Check auth state with `hybridclaw auth status google` before assuming an account exists.
-3. The runtime normally provides `GOG_ACCOUNT`; pass `--account you@example.com` only when the user has explicitly configured multiple accounts.
-4. Prefer read/list/search commands first, then propose write operations.
-5. Require explicit confirmation before sending email, creating drafts that may be sent, creating or updating calendar events, changing Sheets values, or modifying Drive/Docs resources.
-6. For scripting and follow-up parsing, prefer `--json`, `--results-only`, and `--no-input` when the subcommand supports them.
-7. Do not pipe `gog ... --json` into `python3 - <<'PY'`; the heredoc becomes Python's stdin, so `json.load(sys.stdin)` will not receive the `gog` output. Use a temp JSON file or call `gog` from Python with `subprocess.check_output`.
-
-## Gmail
-
-Search threads:
-
-```bash
-gog gmail search 'newer_than:7d' --max 10
-```
-
-Search individual messages, ignoring thread grouping:
-
-```bash
-gog gmail messages search "in:inbox from:example.com" --max 20 --account you@example.com
-```
-
-Send a plain text email:
-
-```bash
-gog gmail send --to recipient@example.com --subject "Hi" --body "Hello"
-```
-
-Send a multi-paragraph email from a file:
-
-```bash
-gog gmail send --to recipient@example.com --subject "Hi" --body-file ./message.txt
-```
-
-Send a multi-paragraph email from stdin:
-
-```bash
-gog gmail send --to recipient@example.com --subject "Hi" --body-file - <<'EOF'
-Hi Name,
-
-Thanks for meeting today. Next steps:
-- Item one
-- Item two
-
-Best regards,
-Your Name
-EOF
-```
-
-Create and send drafts:
-
-```bash
-gog gmail drafts create --to recipient@example.com --subject "Hi" --body-file ./message.txt
-gog gmail drafts send <draftId>
-```
-
-Reply to a message:
-
-```bash
-gog gmail send --to recipient@example.com --subject "Re: Hi" --body "Reply" --reply-to-message-id <messageId>
-```
-
-HTML email is available when rich formatting is necessary:
-
-```bash
-gog gmail send --to recipient@example.com --subject "Update" --body-html "<p>Hi Name,</p><p>Thanks for meeting today.</p>"
-```
-
-Prefer plain text unless the user asks for formatting. `--body` does not unescape `\n`; use `--body-file` for line breaks and multi-paragraph messages.
-
-## Calendar
-
-List events:
-
-```bash
-gog calendar events <calendarId> --from <iso> --to <iso>
-```
-
-For broad user requests like "my calendar", "my Google Calendar", or "all my meetings", omit `<calendarId>` first so `gog` searches all available calendars. Use `primary` only when the user explicitly asks for the primary calendar or after confirming that primary is the right scope.
-
-```bash
-gog calendar events --from <iso> --to <iso> --json --results-only --no-input
-```
-
-When filtering JSON results, either write JSON to a temp file:
-
-```bash
-gog calendar events --from <iso> --to <iso> --json --results-only --no-input > /tmp/gog-events.json
-python3 -c 'import json,re; items=json.load(open("/tmp/gog-events.json")); rx=re.compile("festival", re.I); print(json.dumps([e for e in items if rx.search(str(e.get("summary","")) + " " + str(e.get("description","")))], ensure_ascii=False, indent=2))'
-```
-
-Or call `gog` from Python:
-
-```bash
-python3 -c 'import json,re,subprocess; out=subprocess.check_output(["gog","calendar","events","--from","<iso>","--to","<iso>","--json","--results-only","--no-input"], text=True); items=json.loads(out); rx=re.compile("festival", re.I); print(json.dumps([e for e in items if rx.search(str(e.get("summary","")) + " " + str(e.get("description","")))], ensure_ascii=False, indent=2))'
-```
-
-Create an event:
-
-```bash
-gog calendar create <calendarId> --summary "Title" --from <iso> --to <iso>
-```
-
-Create or update events with a Google Calendar color:
-
-```bash
-gog calendar create <calendarId> --summary "Title" --from <iso> --to <iso> --event-color 7
-gog calendar update <calendarId> <eventId> --summary "New Title" --event-color 4
-```
-
-Show available event colors:
-
-```bash
-gog calendar colors
-```
-
-Known event color IDs:
-
-| ID | Color |
-|----|-------|
-| 1 | `#a4bdfc` |
-| 2 | `#7ae7bf` |
-| 3 | `#dbadff` |
-| 4 | `#ff887c` |
-| 5 | `#fbd75b` |
-| 6 | `#ffb878` |
-| 7 | `#46d6db` |
-| 8 | `#e1e1e1` |
-| 9 | `#5484ed` |
-| 10 | `#51b749` |
-| 11 | `#dc2127` |
-
-## Drive And Contacts
-
-Search Drive:
-
-```bash
-gog drive search "query" --max 10
-```
-
-List contacts:
-
-```bash
-gog contacts list --max 20
-```
-
-## Sheets
-
-Read values:
-
-```bash
-gog sheets get <sheetId> "Tab!A1:D10" --json
-```
-
-Update values:
-
-```bash
-gog sheets update <sheetId> "Tab!A1:B2" --values-json '[["A","B"],["1","2"]]' --input USER_ENTERED
-```
-
-Append values:
-
-```bash
-gog sheets append <sheetId> "Tab!A:C" --values-json '[["x","y","z"]]' --insert INSERT_ROWS
-```
-
-Clear values:
-
-```bash
-gog sheets clear <sheetId> "Tab!A2:Z"
-```
-
-Inspect spreadsheet metadata:
-
-```bash
-gog sheets metadata <sheetId> --json
-```
-
-Use `--values-json` for reliable structured input. Confirm the target sheet, tab, and range before writes.
-
-## Docs
-
-Export a document:
-
-```bash
-gog docs export <docId> --format txt --out /tmp/doc.txt
-```
-
-Print document text:
-
-```bash
-gog docs cat <docId>
-```
-
-`gog` supports Docs export, cat, and copy workflows. In-place Docs edits require a Docs API client or browser automation.
-
-## Rules
-
-- Never ask the user to paste Google passwords, refresh tokens, or OAuth client secrets into chat.
-- Never commit OAuth client files, downloaded document exports, or generated email bodies that contain private data unless the user explicitly asks and the path is appropriate.
-- Confirm before sending email, sending a draft, creating or updating calendar events, changing Sheets values, or modifying Drive/Docs resources.
-- State the account and target resource before write operations.
-- Prefer `gog gmail messages search` when the user needs every email returned separately; `gog gmail search` returns one row per thread.
+## Common commands
+
+- Help about a gog command: `gog <service> <command> --help`
+- Gmail search: `gog gmail search 'newer_than:7d' --max 10`
+- Gmail messages search (per email, ignores threading): `gog gmail messages search "in:inbox from:ryanair.com" --max 20 --account you@example.com`
+- Gmail send (plain): `gog gmail send --to a@b.com --subject "Hi" --body "Hello"`
+- Gmail send (multi-line): `gog gmail send --to a@b.com --subject "Hi" --body-file ./message.txt`
+- Gmail send (stdin): `gog gmail send --to a@b.com --subject "Hi" --body-file -`
+- Gmail send (HTML): `gog gmail send --to a@b.com --subject "Hi" --body-html "<p>Hello</p>"`
+- Gmail draft: `gog gmail drafts create --to a@b.com --subject "Hi" --body-file ./message.txt`
+- Gmail send draft: `gog gmail drafts send <draftId>`
+- Gmail reply: `gog gmail send --to a@b.com --subject "Re: Hi" --body "Reply" --reply-to-message-id <msgId>`
+- Calendar search events: `gog calendar search <calendarId> "Meeting" --from <iso> --to <iso> --max 10`
+- Calendar list events: `gog calendar events <calendarId> --from <iso> --to <iso>`
+- Calendar create event: `gog calendar create <calendarId> --summary "Title" --from <iso> --to <iso>`
+- Calendar create with color: `gog calendar create <calendarId> --summary "Title" --from <iso> --to <iso> --event-color 7`
+- Calendar update event: `gog calendar update <calendarId> <eventId> --summary "New Title" --event-color 4`
+- Calendar show colors: `gog calendar colors`
+- Drive search: `gog drive search "query" --max 10`
+- Contacts: `gog contacts list --max 20`
+- Sheets get: `gog sheets get <sheetId> "Tab!A1:D10" --json`
+- Sheets update: `gog sheets update <sheetId> "Tab!A1:B2" --values-json '[["A","B"],["1","2"]]' --input USER_ENTERED`
+- Sheets append: `gog sheets append <sheetId> "Tab!A:C" --values-json '[["x","y","z"]]' --insert INSERT_ROWS`
+- Sheets clear: `gog sheets clear <sheetId> "Tab!A2:Z"`
+- Sheets metadata: `gog sheets metadata <sheetId> --json`
+- Docs export: `gog docs export <docId> --format txt --out /tmp/doc.txt`
+- Docs cat: `gog docs cat <docId>`
+
+## Calendar Colors
+
+- Use `gog calendar colors` to see all available event colors (IDs 1-11)
+- Add colors to events with `--event-color <id>` flag
+- Event color IDs (from `gog calendar colors` output):
+  - 1: #a4bdfc
+  - 2: #7ae7bf
+  - 3: #dbadff
+  - 4: #ff887c
+  - 5: #fbd75b
+  - 6: #ffb878
+  - 7: #46d6db
+  - 8: #e1e1e1
+  - 9: #5484ed
+  - 10: #51b749
+  - 11: #dc2127
+
+Email Formatting
+
+- Prefer plain text. Use `--body-file` for multi-paragraph messages (or `--body-file -` for stdin).
+- Same `--body-file` pattern works for drafts and replies.
+- `--body` does not unescape `\n`. If you need inline newlines, use a heredoc or `$'Line 1\n\nLine 2'`.
+- Use `--body-html` only when you need rich formatting.
+- HTML tags: `<p>` for paragraphs, `<br>` for line breaks, `<strong>` for bold, `<em>` for italic, `<a href="url">` for links, `<ul>`/`<li>` for lists.
+- Example (plain text via stdin):
+
+  ```bash
+  gog gmail send --to recipient@example.com \
+    --subject "Meeting Follow-up" \
+    --body-file - <<'EOF'
+  Hi Name,
+
+  Thanks for meeting today. Next steps:
+  - Item one
+  - Item two
+
+  Best regards,
+  Your Name
+  EOF
+  ```
+
+- Example (HTML list):
+  ```bash
+  gog gmail send --to recipient@example.com \
+    --subject "Meeting Follow-up" \
+    --body-html "<p>Hi Name,</p><p>Thanks for meeting today. Here are the next steps:</p><ul><li>Item one</li><li>Item two</li></ul><p>Best regards,<br>Your Name</p>"
+  ```
+
+## Notes
+- For scripting, prefer `--json` plus `--no-input`.
+- Sheets values can be passed via `--values-json` (recommended) or as inline rows.
+- Docs supports export/cat/copy. In-place edits require a Docs API client (not in gog).
+- Confirm before sending mail or creating events.
+- `gog gmail search` returns one row per thread; use `gog gmail messages search` when you need every individual email returned separately.

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: gog
+description: Use the gog CLI for Google Workspace workflows across Gmail, Calendar, Drive, Contacts, Sheets, and Docs.
+user-invocable: true
+requires:
+  bins:
+    - gog
+metadata:
+  hybridclaw:
+    category: productivity
+    short_description: "Google Workspace via gog CLI."
+    tags:
+      - google
+      - workspace
+      - gmail
+      - calendar
+      - drive
+      - sheets
+      - docs
+    related_skills:
+      - google-workspace
+    install:
+      - id: brew
+        kind: brew
+        formula: steipete/tap/gogcli
+        bins: ["gog"]
+        label: Install gog CLI (brew)
+---
+# gog
+
+Use this skill when the user wants deterministic Google Workspace automation through `gog` instead of browser automation. `gog` covers Gmail, Calendar, Drive, Contacts, Sheets, and Docs, and requires OAuth setup before use.
+
+## Setup
+
+If `gog` is missing, tell the user to run:
+
+```bash
+hybridclaw skill install gog brew
+```
+
+Then complete HybridClaw Google OAuth setup once from the host:
+
+```bash
+hybridclaw auth login google --client-id <id> --client-secret <secret> --account you@gmail.com
+hybridclaw auth status google
+```
+
+HybridClaw stores the Google OAuth client secret and refresh token in encrypted runtime secrets, mints a short-lived access token on the host, and injects only `GOG_ACCESS_TOKEN` plus `GOG_ACCOUNT` into the agent runtime for `gog`.
+
+If the user already has a refresh token, they can store it directly:
+
+```bash
+hybridclaw auth login google --client-id <id> --client-secret <secret> --account you@gmail.com --refresh-token <token>
+```
+
+Use the minimum scopes needed for the task. Keep OAuth client secrets outside the repo and outside version control.
+
+## Default Workflow
+
+1. Check availability with `gog --help` or the specific subcommand help.
+2. Check auth state with `hybridclaw auth status google` before assuming an account exists.
+3. The runtime normally provides `GOG_ACCOUNT`; pass `--account you@example.com` only when the user has explicitly configured multiple accounts.
+4. Prefer read/list/search commands first, then propose write operations.
+5. Require explicit confirmation before sending email, creating drafts that may be sent, creating or updating calendar events, changing Sheets values, or modifying Drive/Docs resources.
+6. For scripting and follow-up parsing, prefer `--json` and `--no-input` when the subcommand supports them.
+
+## Gmail
+
+Search threads:
+
+```bash
+gog gmail search 'newer_than:7d' --max 10
+```
+
+Search individual messages, ignoring thread grouping:
+
+```bash
+gog gmail messages search "in:inbox from:example.com" --max 20 --account you@example.com
+```
+
+Send a plain text email:
+
+```bash
+gog gmail send --to recipient@example.com --subject "Hi" --body "Hello"
+```
+
+Send a multi-paragraph email from a file:
+
+```bash
+gog gmail send --to recipient@example.com --subject "Hi" --body-file ./message.txt
+```
+
+Send a multi-paragraph email from stdin:
+
+```bash
+gog gmail send --to recipient@example.com --subject "Hi" --body-file - <<'EOF'
+Hi Name,
+
+Thanks for meeting today. Next steps:
+- Item one
+- Item two
+
+Best regards,
+Your Name
+EOF
+```
+
+Create and send drafts:
+
+```bash
+gog gmail drafts create --to recipient@example.com --subject "Hi" --body-file ./message.txt
+gog gmail drafts send <draftId>
+```
+
+Reply to a message:
+
+```bash
+gog gmail send --to recipient@example.com --subject "Re: Hi" --body "Reply" --reply-to-message-id <messageId>
+```
+
+HTML email is available when rich formatting is necessary:
+
+```bash
+gog gmail send --to recipient@example.com --subject "Update" --body-html "<p>Hi Name,</p><p>Thanks for meeting today.</p>"
+```
+
+Prefer plain text unless the user asks for formatting. `--body` does not unescape `\n`; use `--body-file` for line breaks and multi-paragraph messages.
+
+## Calendar
+
+List events:
+
+```bash
+gog calendar events <calendarId> --from <iso> --to <iso>
+```
+
+Create an event:
+
+```bash
+gog calendar create <calendarId> --summary "Title" --from <iso> --to <iso>
+```
+
+Create or update events with a Google Calendar color:
+
+```bash
+gog calendar create <calendarId> --summary "Title" --from <iso> --to <iso> --event-color 7
+gog calendar update <calendarId> <eventId> --summary "New Title" --event-color 4
+```
+
+Show available event colors:
+
+```bash
+gog calendar colors
+```
+
+Known event color IDs:
+
+| ID | Color |
+|----|-------|
+| 1 | `#a4bdfc` |
+| 2 | `#7ae7bf` |
+| 3 | `#dbadff` |
+| 4 | `#ff887c` |
+| 5 | `#fbd75b` |
+| 6 | `#ffb878` |
+| 7 | `#46d6db` |
+| 8 | `#e1e1e1` |
+| 9 | `#5484ed` |
+| 10 | `#51b749` |
+| 11 | `#dc2127` |
+
+## Drive And Contacts
+
+Search Drive:
+
+```bash
+gog drive search "query" --max 10
+```
+
+List contacts:
+
+```bash
+gog contacts list --max 20
+```
+
+## Sheets
+
+Read values:
+
+```bash
+gog sheets get <sheetId> "Tab!A1:D10" --json
+```
+
+Update values:
+
+```bash
+gog sheets update <sheetId> "Tab!A1:B2" --values-json '[["A","B"],["1","2"]]' --input USER_ENTERED
+```
+
+Append values:
+
+```bash
+gog sheets append <sheetId> "Tab!A:C" --values-json '[["x","y","z"]]' --insert INSERT_ROWS
+```
+
+Clear values:
+
+```bash
+gog sheets clear <sheetId> "Tab!A2:Z"
+```
+
+Inspect spreadsheet metadata:
+
+```bash
+gog sheets metadata <sheetId> --json
+```
+
+Use `--values-json` for reliable structured input. Confirm the target sheet, tab, and range before writes.
+
+## Docs
+
+Export a document:
+
+```bash
+gog docs export <docId> --format txt --out /tmp/doc.txt
+```
+
+Print document text:
+
+```bash
+gog docs cat <docId>
+```
+
+`gog` supports Docs export, cat, and copy workflows. In-place Docs edits require a Docs API client or browser automation.
+
+## Rules
+
+- Never ask the user to paste Google passwords, refresh tokens, or OAuth client secrets into chat.
+- Never commit OAuth client files, downloaded document exports, or generated email bodies that contain private data unless the user explicitly asks and the path is appropriate.
+- Confirm before sending email, sending a draft, creating or updating calendar events, changing Sheets values, or modifying Drive/Docs resources.
+- State the account and target resource before write operations.
+- Prefer `gog gmail messages search` when the user needs every email returned separately; `gog gmail search` returns one row per thread.

--- a/skills/google-workspace/SKILL.md
+++ b/skills/google-workspace/SKILL.md
@@ -31,10 +31,10 @@ For API-backed Google Workspace access, prefer the bundled `gog` skill when avai
 
 ## Default Strategy
 
-1. For email-only tasks, prefer the optional `himalaya` community skill if it is installed, or the existing email channel when that is simpler.
-2. For Calendar, Drive, Docs, or Sheets tasks, **default to browser automation** using the persistent browser profile. Do not ask which method to use — just try the browser first.
-3. If the browser hits a login page, tell the user to run `hybridclaw browser login` to sign in once, then retry. Do not ask for credentials in chat.
-4. Only fall back to API-based access if the user explicitly requests it or browser automation is unavailable.
+1. For API-backed Gmail, Calendar, Drive, Contacts, Sheets, or Docs tasks, prefer the bundled `gog` skill when it is installed and authenticated.
+2. For email-only tasks where `gog` is unavailable, prefer the optional `himalaya` community skill if it is installed, or the existing email channel when that is simpler.
+3. Use browser automation only when `gog` is unavailable, the user explicitly asks for browser-based work, or the task needs visual inspection in the Google web UI.
+4. If the browser hits a login page, tell the user to run `hybridclaw browser login` to sign in once, then retry. Do not ask for credentials in chat.
 
 ## Proactive Behavior
 

--- a/skills/google-workspace/SKILL.md
+++ b/skills/google-workspace/SKILL.md
@@ -19,6 +19,8 @@ metadata:
 
 Use this skill for Google Workspace workflows that go beyond HybridClaw's built-in email and Discord channels.
 
+For API-backed Google Workspace access, prefer the bundled `gog` skill when available.
+
 ## Scope
 
 - Gmail searches and draft/send workflows

--- a/skills/google-workspace/SKILL.md
+++ b/skills/google-workspace/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: google-workspace
-description: Work with Gmail, Calendar, Drive, Docs, and Sheets via browser automation or APIs.
+description: Work with Gmail, Calendar, Drive, Docs, and Sheets via browser automation or APIs
 user-invocable: true
 metadata:
   hybridclaw:
     category: productivity
-    short_description: "Gmail, Drive, Docs, and Sheets."
+    short_description: "Browser-based Gmail, Drive, Docs, and Sheets."
     tags:
       - google
       - workspace

--- a/src/agent/prompt-hooks.ts
+++ b/src/agent/prompt-hooks.ts
@@ -4,6 +4,12 @@ import {
   getChannelByContextId,
   normalizeChannelKind,
 } from '../channels/channel-registry.js';
+import {
+  collectActiveMessageToolChannelKinds,
+  describeMessageToolChannelActions,
+  formatMessageToolChannelList,
+  type MessageToolChannelKind,
+} from '../channels/message-tool-advertising.js';
 import { resolveChannelMessageToolHints } from '../channels/prompt-adapters.js';
 import {
   APP_VERSION,
@@ -281,6 +287,78 @@ function buildSessionContextHook(context: PromptHookContext): string {
   return buildSessionContextPrompt(sessionContext);
 }
 
+function buildMessageToolPromptLines(
+  activeChannels: readonly MessageToolChannelKind[],
+  channelMessageToolHints: readonly string[],
+): string[] {
+  const lines = [
+    `Use the \`message\` tool for sending or reading messages on active communication channels: ${formatMessageToolChannelList(activeChannels)}.`,
+  ];
+
+  const channelActionLines = describeMessageToolChannelActions(activeChannels);
+  if (channelActionLines.length > 0) {
+    lines.push(...channelActionLines);
+    lines.push(
+      'For `message` sends, include target as `channelId` (aliases: `to`, `target`) and text as `content` (aliases: `message`, `text`).',
+      `If \`message\` with \`action="send"\` already delivered the final user-visible reply, respond with ONLY: ${MESSAGE_SEND_SILENT_REPLY_TOKEN}`,
+    );
+  } else {
+    lines.push('No active communication channels are registered right now.');
+  }
+
+  if (channelMessageToolHints.length > 0) {
+    lines.push('', '### Message Tool Hints', ...channelMessageToolHints);
+  }
+
+  const examples: string[] = [];
+  if (activeChannels.includes('discord')) {
+    examples.push(
+      'Example: "What did Bob say in #general?" -> `message` {"action":"read","channelId":"<discord-channel-id>","limit":50}',
+      'Example: "Send a message to #general saying hello" -> `message` {"action":"send","channelId":"<discord-channel-id>","content":"hello"}',
+    );
+  }
+  if (activeChannels.includes('msteams')) {
+    examples.push(
+      'Example: "Post this file in the current Teams chat" -> `message` {"action":"send","filePath":"path/in/workspace"}',
+    );
+  }
+  if (activeChannels.includes('slack')) {
+    examples.push(
+      'Example: "Read the current Slack thread" -> `message` {"action":"read","channelId":"slack:current","limit":50}',
+    );
+  }
+  if (activeChannels.includes('telegram')) {
+    examples.push(
+      'Example: "Send this to Telegram" -> `message` {"action":"send","to":"telegram:<chatId>","content":"message text"}',
+    );
+  }
+  if (activeChannels.includes('whatsapp')) {
+    examples.push(
+      'Example: "Send this to WhatsApp" -> `message` {"action":"send","to":"whatsapp:<phone-or-jid>","content":"message text"}',
+    );
+  }
+  if (activeChannels.includes('email')) {
+    examples.push(
+      'Example: "Email ops@example.com that the deployment is complete" -> `message` {"action":"send","to":"ops@example.com","content":"[Subject: Deployment complete]\\n\\nDeployment is complete."}',
+    );
+  }
+  if (activeChannels.includes('imessage')) {
+    examples.push(
+      'Example: "Send this by iMessage" -> `message` {"action":"send","to":"+15551234567","content":"message text"}',
+    );
+  }
+  if (activeChannels.includes('tui')) {
+    examples.push(
+      'Example: "Post this to the local TUI" -> `message` {"action":"send","to":"tui","content":"message text"}',
+    );
+  }
+  if (examples.length > 0) {
+    lines.push('', '### Message Tool Examples', ...examples);
+  }
+
+  return lines;
+}
+
 function readSecurityPromptGuardrails(): string {
   return readRuntimeInstructionFile('SECURITY.md');
 }
@@ -301,6 +379,11 @@ function buildSafetyHook(context: PromptHookContext): string {
       guildId: context.runtimeInfo?.guildId,
     },
   });
+  const activeMessageChannels = collectActiveMessageToolChannelKinds();
+  const messageToolPromptLines = buildMessageToolPromptLines(
+    activeMessageChannels,
+    channelMessageToolHints,
+  );
 
   const lines = [
     '## Runtime Safety Guardrails',
@@ -338,16 +421,9 @@ function buildSafetyHook(context: PromptHookContext): string {
     'After file changes, run commands only when asked; otherwise explicitly offer to run them immediately.',
     'Only skip file creation when the user explicitly asks for snippet-only or explanation-only output.',
     'Never write plain text placeholder content to binary office files such as `.docx`, `.xlsx`, `.pptx`, or `.pdf`. If generation fails, report the error instead of creating a fake file.',
-    'If the current turn already includes an attachment, local file path, `MediaItems`, injected `<file>` content, or `[PDFContext]`, use that artifact first. Do not start with `message` reads, `glob`, `find`, workspace-wide discovery, or skill reads unless the user explicitly asked for history or folder discovery.',
+    'If the current turn already includes an attachment, local file path, `MediaItems`, injected `<file>` content, or `[PDFContext]`, use that artifact first.',
     'For fresh deliverable-generation tasks from a folder of source files, use the primary source inputs directly and create a new output. Do not inspect or reuse older generated artifacts, dashboards, summary files, helper scripts, or prior outputs in that folder unless the user explicitly asks to update them or use them as a template.',
-    'When Discord context is needed, use the `message` tool actions (`read`, `member-info`, `channel-info`, `send`) instead of guessing channel members.',
-    'For questions like "what did X say", "who said", or channel recap requests, call `message` with `action="read"` first before answering.',
-    'For channel catch-up or recap requests with partial scope, infer a reasonable recent scope from available context, do a best-effort read first, and note assumptions after the summary instead of blocking on a clarification.',
-    'For ingested email conversations, `message` with `action="read"` can inspect stored thread history for the current email session or an explicit email address target. It does not query arbitrary mailbox-wide unseen mail.',
-    'For send intents like "send message", "post in", "DM", "tell X", "notify X", or "message X", call `message` with `action="send"`.',
-    'For `message` with `action="send"`, include target as `channelId` (aliases: `to`, `target`) and text as `content` (aliases: `message`, `text`). `send` supports Discord targets, Telegram `telegram:<chatId>` targets, the current Teams conversation, WhatsApp JIDs/phone numbers, email addresses, and local channels like `tui`.',
-    'For local Discord, the current Teams conversation, WhatsApp, or email uploads, call `message` with `action="send"` and `filePath` pointing to a file in the current workspace or `/discord-media-cache`.',
-    'If you already created a file earlier in this session and the user asks to post/upload/send it here, reuse that existing `filePath` with `message action="send"` instead of replying with the path alone.',
+    ...messageToolPromptLines,
     'When the user asks you to create or generate a file and return/upload/post it, include the file immediately in the final delivery. Do not ask a follow-up question offering to upload it later.',
     'For deliverable-generation tasks such as presentations, slide decks, spreadsheets, documents, PDFs, reports, or images, assume the created asset should be attached in the final reply unless the user explicitly says not to send the file.',
     'If you created or updated the requested deliverable successfully, prefer posting the asset immediately over replying with a path plus "if you want, I can upload it."',
@@ -358,59 +434,12 @@ function buildSafetyHook(context: PromptHookContext): string {
     'For reminder scheduling via `cron`, set `prompt` as a clear instruction for the future model run (for example: "Reply exactly with: TIMER IS OVER!").',
     'For relative one-shot reminders, prefer `cron` with `at_seconds` (seconds from now) over computing absolute timestamps yourself.',
     'For absolute one-shot reminders via `cron` `at`, emit an offset-bearing ISO-8601 timestamp that mirrors the user timezone shown in current context (for example `2026-04-10T09:00:00+02:00`), not a `Z` timestamp unless the user explicitly asked for UTC.',
-    `If \`message\` with \`action="send"\` already delivered the final user-visible reply, respond with ONLY: ${MESSAGE_SEND_SILENT_REPLY_TOKEN}`,
-    ...(channelMessageToolHints.length > 0
-      ? ['', '### Message Tool Hints', ...channelMessageToolHints]
-      : []),
     '',
-    '### Message Tool Few-Shot Examples',
-    'Example 1',
-    'User: "Send a message to #general saying hello"',
-    'Tool call: `message` {"action":"send","channelId":"#general","content":"hello"}',
-    `Assistant final text: "${MESSAGE_SEND_SILENT_REPLY_TOKEN}"`,
-    '',
-    'Example 2',
-    'User: "DM @alice about the deploy"',
-    'Tool call 1: `message` {"action":"member-info","guildId":"<guild-id>","user":"@alice"}',
-    'Tool call 2: `message` {"action":"send","to":"<alice-user-or-dm-channel-id>","content":"Deploy finished. Please verify."}',
-    `Assistant final text: "${MESSAGE_SEND_SILENT_REPLY_TOKEN}"`,
-    '',
-    'Example 3',
-    'User: "Post `invoices/dashboard.html.png` here on Discord"',
-    'Tool call: `message` {"action":"send","filePath":"invoices/dashboard.html.png"}',
-    `Assistant final text: "${MESSAGE_SEND_SILENT_REPLY_TOKEN}"`,
-    '',
-    'Example 4',
-    'User: "Post `.browser-artifacts/hybridclaw-homepage.png` here in Teams"',
-    'Tool call: `message` {"action":"send","filePath":".browser-artifacts/hybridclaw-homepage.png"}',
-    `Assistant final text: "${MESSAGE_SEND_SILENT_REPLY_TOKEN}"`,
-    '',
-    'Example 5',
-    'Earlier in this session you created `.browser-artifacts/hybridclaw-homepage.png`.',
-    'User: "Post screenshot here"',
-    'Tool call: `message` {"action":"send","filePath":".browser-artifacts/hybridclaw-homepage.png"}',
-    `Assistant final text: "${MESSAGE_SEND_SILENT_REPLY_TOKEN}"`,
-    '',
-    'Example 6',
-    'User: "What did Bob say?"',
-    'Tool call: `message` {"action":"read","channelId":"<current-or-target-channel-id>","limit":50}',
-    'Then answer from fetched messages; do not guess.',
-    '',
-    'Example 7',
+    '### Attachment Example',
     'User: "Pull the key fields from this attached invoice PDF."',
     'Current-turn context already includes a local PDF path or injected `<file>` block.',
-    'Action: use that attachment content directly; do not call `message` `read`, `glob`, `find`, or read `skills/pdf/SKILL.md` first.',
+    'Action: use that attachment content directly and answer from the extracted text.',
     'Then answer with the extracted invoice fields.',
-    '',
-    'Example 8',
-    'User: "Send this to WhatsApp +491701234567: landed safely"',
-    'Tool call: `message` {"action":"send","to":"+491701234567","content":"landed safely"}',
-    `Assistant final text: "${MESSAGE_SEND_SILENT_REPLY_TOKEN}"`,
-    '',
-    'Example 9',
-    'User: "Email ops@example.com that the deployment is complete"',
-    'Tool call: `message` {"action":"send","to":"ops@example.com","content":"[Subject: Deployment complete]\\n\\nDeployment is complete."}',
-    `Assistant final text: "${MESSAGE_SEND_SILENT_REPLY_TOKEN}"`,
     '',
     '### Cron reminder few-shot examples',
     'Example 1',

--- a/src/auth/google-auth.ts
+++ b/src/auth/google-auth.ts
@@ -1,0 +1,430 @@
+import { randomBytes } from 'node:crypto';
+import http from 'node:http';
+
+import {
+  readStoredRuntimeSecret,
+  runtimeSecretsPath,
+  saveNamedRuntimeSecrets,
+} from '../security/runtime-secrets.js';
+
+const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const LOOPBACK_HOST = '127.0.0.1';
+const DEFAULT_CALLBACK_TIMEOUT_MS = 5 * 60 * 1000;
+
+export const GOOGLE_ACCOUNT_SECRET = 'GOOGLE_ACCOUNT';
+export const GOOGLE_OAUTH_CLIENT_ID_SECRET = 'GOOGLE_OAUTH_CLIENT_ID';
+export const GOOGLE_OAUTH_CLIENT_SECRET_SECRET = 'GOOGLE_OAUTH_CLIENT_SECRET';
+export const GOOGLE_OAUTH_REFRESH_TOKEN_SECRET = 'GOOGLE_OAUTH_REFRESH_TOKEN';
+export const GOOGLE_OAUTH_SCOPES_SECRET = 'GOOGLE_OAUTH_SCOPES';
+
+export const DEFAULT_GOOGLE_OAUTH_SCOPES = [
+  'https://www.googleapis.com/auth/gmail.modify',
+  'https://www.googleapis.com/auth/gmail.settings.basic',
+  'https://www.googleapis.com/auth/calendar',
+  'https://www.googleapis.com/auth/drive',
+  'https://www.googleapis.com/auth/documents',
+  'https://www.googleapis.com/auth/spreadsheets',
+  'https://www.googleapis.com/auth/contacts',
+  'https://www.googleapis.com/auth/contacts.other.readonly',
+  'https://www.googleapis.com/auth/directory.readonly',
+];
+
+export interface GoogleStoredAuth {
+  account: string;
+  clientId: string;
+  clientSecret: string;
+  refreshToken: string;
+  scopes: string[];
+}
+
+export interface GoogleLoginInput {
+  account: string;
+  clientId: string;
+  clientSecret: string;
+  scopes: string[];
+  refreshToken?: string;
+  redirectPort?: number;
+  callbackTimeoutMs?: number;
+}
+
+export interface GoogleLoginResult {
+  account: string;
+  scopes: string[];
+  secretsPath: string;
+  usedProvidedRefreshToken: boolean;
+}
+
+interface GoogleTokenResponse {
+  access_token?: unknown;
+  expires_in?: unknown;
+  refresh_token?: unknown;
+  token_type?: unknown;
+  error?: unknown;
+  error_description?: unknown;
+}
+
+let cachedGogAccessToken: {
+  accessToken: string;
+  account: string;
+  expiresAtMs: number;
+} | null = null;
+
+function normalizeScopes(scopes: string[]): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const scope of scopes) {
+    const trimmed = String(scope || '').trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+  return normalized;
+}
+
+export function parseGoogleScopes(raw?: string): string[] {
+  const value = String(raw || '').trim();
+  if (!value) return [...DEFAULT_GOOGLE_OAUTH_SCOPES];
+  return normalizeScopes(value.split(/[,\s]+/));
+}
+
+function readSecretOrEnv(name: string): string {
+  return (
+    String(process.env[name] || '').trim() ||
+    readStoredRuntimeSecret(name) ||
+    ''
+  );
+}
+
+export function readStoredGoogleAuth(): GoogleStoredAuth | null {
+  const account = readSecretOrEnv(GOOGLE_ACCOUNT_SECRET);
+  const clientId = readSecretOrEnv(GOOGLE_OAUTH_CLIENT_ID_SECRET);
+  const clientSecret = readSecretOrEnv(GOOGLE_OAUTH_CLIENT_SECRET_SECRET);
+  const refreshToken = readSecretOrEnv(GOOGLE_OAUTH_REFRESH_TOKEN_SECRET);
+  const scopes = parseGoogleScopes(readSecretOrEnv(GOOGLE_OAUTH_SCOPES_SECRET));
+  if (!clientId || !clientSecret || !refreshToken) return null;
+  return {
+    account,
+    clientId,
+    clientSecret,
+    refreshToken,
+    scopes,
+  };
+}
+
+function makeState(): string {
+  return randomBytes(24).toString('base64url');
+}
+
+function buildAuthorizeUrl(input: {
+  clientId: string;
+  redirectUri: string;
+  state: string;
+  scopes: string[];
+}): string {
+  const query = new URLSearchParams({
+    client_id: input.clientId,
+    redirect_uri: input.redirectUri,
+    response_type: 'code',
+    scope: input.scopes.join(' '),
+    access_type: 'offline',
+    prompt: 'consent',
+    include_granted_scopes: 'false',
+    state: input.state,
+  });
+  return `${GOOGLE_AUTH_URL}?${query.toString()}`;
+}
+
+function formatTokenError(payload: GoogleTokenResponse): string {
+  const error = typeof payload.error === 'string' ? payload.error : 'unknown';
+  const description =
+    typeof payload.error_description === 'string'
+      ? payload.error_description
+      : '';
+  return description ? `${error}: ${description}` : error;
+}
+
+async function postGoogleToken(
+  params: URLSearchParams,
+): Promise<GoogleTokenResponse> {
+  const response = await fetch(GOOGLE_TOKEN_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: params,
+  });
+  const payload = (await response
+    .json()
+    .catch(() => ({}))) as GoogleTokenResponse;
+  if (!response.ok) {
+    throw new Error(
+      `Google OAuth token request failed: ${formatTokenError(payload)}`,
+    );
+  }
+  return payload;
+}
+
+async function exchangeAuthorizationCode(input: {
+  clientId: string;
+  clientSecret: string;
+  code: string;
+  redirectUri: string;
+}): Promise<{ refreshToken: string }> {
+  const payload = await postGoogleToken(
+    new URLSearchParams({
+      client_id: input.clientId,
+      client_secret: input.clientSecret,
+      code: input.code,
+      redirect_uri: input.redirectUri,
+      grant_type: 'authorization_code',
+    }),
+  );
+  if (
+    typeof payload.refresh_token !== 'string' ||
+    !payload.refresh_token.trim()
+  ) {
+    throw new Error(
+      'Google OAuth response did not include a refresh token. Re-run with consent enabled or revoke the old grant and try again.',
+    );
+  }
+  return { refreshToken: payload.refresh_token.trim() };
+}
+
+async function waitForAuthorizationCode(input: {
+  clientId: string;
+  scopes: string[];
+  redirectPort?: number;
+  timeoutMs?: number;
+}): Promise<{ code: string; redirectUri: string; authorizeUrl: string }> {
+  const state = makeState();
+  const timeoutMs = input.timeoutMs || DEFAULT_CALLBACK_TIMEOUT_MS;
+
+  return await new Promise((resolve, reject) => {
+    let settled = false;
+    const server = http.createServer((req, res) => {
+      try {
+        const requestUrl = new URL(req.url || '/', `http://${LOOPBACK_HOST}`);
+        if (requestUrl.pathname !== '/oauth2/callback') {
+          res.writeHead(404, { 'Content-Type': 'text/plain' });
+          res.end('Not found');
+          return;
+        }
+
+        const returnedState = requestUrl.searchParams.get('state') || '';
+        if (returnedState !== state) {
+          res.writeHead(400, { 'Content-Type': 'text/plain' });
+          res.end('Invalid OAuth state. Return to HybridClaw and retry.');
+          throw new Error('Google OAuth callback state did not match.');
+        }
+
+        const error = requestUrl.searchParams.get('error');
+        if (error) {
+          res.writeHead(400, { 'Content-Type': 'text/plain' });
+          res.end('Google authorization was rejected.');
+          throw new Error(`Google OAuth authorization failed: ${error}`);
+        }
+
+        const code = requestUrl.searchParams.get('code') || '';
+        if (!code) {
+          res.writeHead(400, { 'Content-Type': 'text/plain' });
+          res.end('Missing OAuth authorization code.');
+          throw new Error('Google OAuth callback did not include a code.');
+        }
+
+        const address = server.address();
+        const port = typeof address === 'object' && address ? address.port : 0;
+        const redirectUri = `http://${LOOPBACK_HOST}:${port}/oauth2/callback`;
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end(
+          'Google authorization complete. You can close this browser tab.',
+        );
+        settled = true;
+        server.close();
+        resolve({
+          code,
+          redirectUri,
+          authorizeUrl: buildAuthorizeUrl({
+            clientId: input.clientId,
+            redirectUri,
+            state,
+            scopes: input.scopes,
+          }),
+        });
+      } catch (error) {
+        settled = true;
+        server.close();
+        reject(error);
+      }
+    });
+
+    server.once('error', (error) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    });
+
+    server.listen(input.redirectPort || 0, LOOPBACK_HOST, () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      const redirectUri = `http://${LOOPBACK_HOST}:${port}/oauth2/callback`;
+      const authorizeUrl = buildAuthorizeUrl({
+        clientId: input.clientId,
+        redirectUri,
+        state,
+        scopes: input.scopes,
+      });
+      console.log('Open this Google authorization URL in your browser:');
+      console.log(authorizeUrl);
+      console.log(`Waiting for OAuth callback on ${redirectUri} ...`);
+    });
+
+    setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      server.close();
+      reject(new Error('Timed out waiting for Google OAuth callback.'));
+    }, timeoutMs).unref();
+  });
+}
+
+export async function loginGoogle(
+  input: GoogleLoginInput,
+): Promise<GoogleLoginResult> {
+  const scopes = normalizeScopes(input.scopes);
+  if (!input.account.trim())
+    throw new Error('Google account email is required.');
+  if (!input.clientId.trim())
+    throw new Error('Google OAuth client id is required.');
+  if (!input.clientSecret.trim()) {
+    throw new Error('Google OAuth client secret is required.');
+  }
+  if (scopes.length === 0)
+    throw new Error('At least one Google OAuth scope is required.');
+
+  let refreshToken = input.refreshToken?.trim() || '';
+  if (!refreshToken) {
+    const authorization = await waitForAuthorizationCode({
+      clientId: input.clientId,
+      scopes,
+      redirectPort: input.redirectPort,
+      timeoutMs: input.callbackTimeoutMs,
+    });
+    const exchanged = await exchangeAuthorizationCode({
+      clientId: input.clientId,
+      clientSecret: input.clientSecret,
+      code: authorization.code,
+      redirectUri: authorization.redirectUri,
+    });
+    refreshToken = exchanged.refreshToken;
+  }
+
+  const secretsPath = saveNamedRuntimeSecrets({
+    [GOOGLE_ACCOUNT_SECRET]: input.account,
+    [GOOGLE_OAUTH_CLIENT_ID_SECRET]: input.clientId,
+    [GOOGLE_OAUTH_CLIENT_SECRET_SECRET]: input.clientSecret,
+    [GOOGLE_OAUTH_REFRESH_TOKEN_SECRET]: refreshToken,
+    [GOOGLE_OAUTH_SCOPES_SECRET]: scopes.join(' '),
+  });
+  cachedGogAccessToken = null;
+
+  return {
+    account: input.account,
+    scopes,
+    secretsPath,
+    usedProvidedRefreshToken: Boolean(input.refreshToken?.trim()),
+  };
+}
+
+export function clearGoogleAuth(): string {
+  cachedGogAccessToken = null;
+  return saveNamedRuntimeSecrets({
+    [GOOGLE_ACCOUNT_SECRET]: null,
+    [GOOGLE_OAUTH_CLIENT_ID_SECRET]: null,
+    [GOOGLE_OAUTH_CLIENT_SECRET_SECRET]: null,
+    [GOOGLE_OAUTH_REFRESH_TOKEN_SECRET]: null,
+    [GOOGLE_OAUTH_SCOPES_SECRET]: null,
+  });
+}
+
+export function getGoogleAuthStatus(): {
+  authenticated: boolean;
+  account: string;
+  scopes: string[];
+  path: string;
+} {
+  const stored = readStoredGoogleAuth();
+  return {
+    authenticated: Boolean(stored),
+    account: stored?.account || readSecretOrEnv(GOOGLE_ACCOUNT_SECRET),
+    scopes:
+      stored?.scopes ||
+      parseGoogleScopes(readSecretOrEnv(GOOGLE_OAUTH_SCOPES_SECRET)),
+    path: runtimeSecretsPath(),
+  };
+}
+
+export async function mintGoogleAccessToken(): Promise<{
+  accessToken: string;
+  expiresIn: number | null;
+  account: string;
+} | null> {
+  const stored = readStoredGoogleAuth();
+  if (!stored) return null;
+  const now = Date.now();
+  if (cachedGogAccessToken && cachedGogAccessToken.expiresAtMs - now > 60_000) {
+    return {
+      accessToken: cachedGogAccessToken.accessToken,
+      expiresIn: Math.max(
+        0,
+        Math.floor((cachedGogAccessToken.expiresAtMs - now) / 1000),
+      ),
+      account: cachedGogAccessToken.account,
+    };
+  }
+  const payload = await postGoogleToken(
+    new URLSearchParams({
+      client_id: stored.clientId,
+      client_secret: stored.clientSecret,
+      refresh_token: stored.refreshToken,
+      grant_type: 'refresh_token',
+    }),
+  );
+  if (
+    typeof payload.access_token !== 'string' ||
+    !payload.access_token.trim()
+  ) {
+    throw new Error(
+      'Google OAuth token response did not include an access token.',
+    );
+  }
+  const accessToken = payload.access_token.trim();
+  const expiresIn =
+    typeof payload.expires_in === 'number' ? payload.expires_in : null;
+  cachedGogAccessToken = {
+    accessToken,
+    account: stored.account,
+    expiresAtMs: now + Math.max(60, expiresIn || 3600) * 1000,
+  };
+  return { accessToken, expiresIn, account: stored.account };
+}
+
+export async function resolveGogRuntimeEnv(): Promise<Record<string, string>> {
+  const existingAccessToken = String(process.env.GOG_ACCESS_TOKEN || '').trim();
+  const existingAccount =
+    String(process.env.GOG_ACCOUNT || '').trim() ||
+    readSecretOrEnv(GOOGLE_ACCOUNT_SECRET);
+  if (existingAccessToken) {
+    return {
+      GOG_ACCESS_TOKEN: existingAccessToken,
+      ...(existingAccount ? { GOG_ACCOUNT: existingAccount } : {}),
+    };
+  }
+
+  const minted = await mintGoogleAccessToken();
+  if (!minted) return {};
+  return {
+    GOG_ACCESS_TOKEN: minted.accessToken,
+    ...(minted.account ? { GOG_ACCOUNT: minted.account } : {}),
+  };
+}

--- a/src/auth/google-auth.ts
+++ b/src/auth/google-auth.ts
@@ -45,7 +45,6 @@ export interface GoogleLoginInput {
   scopes: string[];
   refreshToken?: string;
   redirectPort?: number;
-  callbackTimeoutMs?: number;
 }
 
 export interface GoogleLoginResult {
@@ -64,6 +63,8 @@ interface GoogleTokenResponse {
   error_description?: unknown;
 }
 
+// HybridClaw currently stores one Google account per runtime secret store. Keep
+// this cache single-account unless Google auth grows an explicit account key.
 let cachedGogAccessToken: {
   accessToken: string;
   account: string;
@@ -196,7 +197,7 @@ async function waitForAuthorizationCode(input: {
   scopes: string[];
   redirectPort?: number;
   timeoutMs?: number;
-}): Promise<{ code: string; redirectUri: string; authorizeUrl: string }> {
+}): Promise<{ code: string; redirectUri: string }> {
   const state = makeState();
   const timeoutMs = input.timeoutMs || DEFAULT_CALLBACK_TIMEOUT_MS;
 
@@ -244,12 +245,6 @@ async function waitForAuthorizationCode(input: {
         resolve({
           code,
           redirectUri,
-          authorizeUrl: buildAuthorizeUrl({
-            clientId: input.clientId,
-            redirectUri,
-            state,
-            scopes: input.scopes,
-          }),
         });
       } catch (error) {
         settled = true;
@@ -308,7 +303,6 @@ export async function loginGoogle(
       clientId: input.clientId,
       scopes,
       redirectPort: input.redirectPort,
-      timeoutMs: input.callbackTimeoutMs,
     });
     const exchanged = await exchangeAuthorizationCode({
       clientId: input.clientId,

--- a/src/channels/message-tool-advertising.ts
+++ b/src/channels/message-tool-advertising.ts
@@ -1,0 +1,93 @@
+import type { ChannelKind } from './channel.js';
+import { listChannels } from './channel-registry.js';
+
+export const MESSAGE_TOOL_CHANNEL_KINDS = [
+  'discord',
+  'email',
+  'imessage',
+  'msteams',
+  'slack',
+  'telegram',
+  'tui',
+  'whatsapp',
+] as const satisfies readonly ChannelKind[];
+
+export type MessageToolChannelKind =
+  (typeof MESSAGE_TOOL_CHANNEL_KINDS)[number];
+
+const MESSAGE_TOOL_CHANNEL_KIND_SET = new Set<ChannelKind>(
+  MESSAGE_TOOL_CHANNEL_KINDS,
+);
+
+const MESSAGE_TOOL_CHANNEL_LABELS: Record<MessageToolChannelKind, string> = {
+  discord: 'Discord',
+  email: 'email',
+  imessage: 'iMessage',
+  msteams: 'Microsoft Teams',
+  slack: 'Slack',
+  telegram: 'Telegram',
+  tui: 'local TUI',
+  whatsapp: 'WhatsApp',
+};
+
+const MESSAGE_TOOL_CHANNEL_ACTIONS: Record<MessageToolChannelKind, string> = {
+  discord:
+    'Discord: send/read messages, upload files, inspect members/channels, react, edit, pin, and manage threads.',
+  email: 'Email: send email and read ingested email thread history.',
+  imessage: 'iMessage: send messages to explicit iMessage handles.',
+  msteams:
+    'Microsoft Teams: send/read known Teams conversations, upload files, and inspect members/channels.',
+  slack:
+    'Slack: send/read known Slack conversations, upload files, and inspect members/channels.',
+  telegram:
+    'Telegram: send messages and uploads to explicit Telegram chat or topic targets.',
+  tui: 'Local TUI: queue messages for local TUI delivery.',
+  whatsapp:
+    'WhatsApp: send messages and uploads to explicit WhatsApp JIDs or phone numbers.',
+};
+
+function isMessageToolChannelKind(
+  kind: ChannelKind | string,
+): kind is MessageToolChannelKind {
+  return MESSAGE_TOOL_CHANNEL_KIND_SET.has(kind as ChannelKind);
+}
+
+export function normalizeMessageToolChannelKinds(
+  kinds: readonly string[] | undefined,
+): MessageToolChannelKind[] {
+  if (!Array.isArray(kinds)) return [];
+  const normalized = new Set<MessageToolChannelKind>();
+  for (const kind of kinds) {
+    const candidate = String(kind || '')
+      .trim()
+      .toLowerCase();
+    if (isMessageToolChannelKind(candidate)) {
+      normalized.add(candidate);
+    }
+  }
+  return [...normalized].sort();
+}
+
+export function collectActiveMessageToolChannelKinds(): MessageToolChannelKind[] {
+  return normalizeMessageToolChannelKinds(
+    listChannels().map((channel) => channel.kind),
+  );
+}
+
+export function formatMessageToolChannelList(
+  kinds: readonly string[] | undefined,
+): string {
+  const labels = normalizeMessageToolChannelKinds(kinds).map(
+    (kind) => MESSAGE_TOOL_CHANNEL_LABELS[kind],
+  );
+  if (labels.length === 0) return 'none';
+  return labels.join(', ');
+}
+
+export function describeMessageToolChannelActions(
+  kinds: readonly string[] | undefined,
+): string[] {
+  return normalizeMessageToolChannelKinds(kinds).map(
+    (kind) => `- ${MESSAGE_TOOL_CHANNEL_ACTIONS[kind]}`,
+  );
+}

--- a/src/channels/message-tool-advertising.ts
+++ b/src/channels/message-tool-advertising.ts
@@ -1,33 +1,16 @@
-import type { ChannelKind } from './channel.js';
+import {
+  formatMessageToolChannelList,
+  MESSAGE_TOOL_CHANNEL_KINDS,
+  type MessageToolChannelKind,
+  normalizeMessageToolChannelKinds,
+} from '../../container/shared/message-tool-channels.js';
 import { listChannels } from './channel-registry.js';
 
-export const MESSAGE_TOOL_CHANNEL_KINDS = [
-  'discord',
-  'email',
-  'imessage',
-  'msteams',
-  'slack',
-  'telegram',
-  'tui',
-  'whatsapp',
-] as const satisfies readonly ChannelKind[];
-
-export type MessageToolChannelKind =
-  (typeof MESSAGE_TOOL_CHANNEL_KINDS)[number];
-
-const MESSAGE_TOOL_CHANNEL_KIND_SET = new Set<ChannelKind>(
+export type { MessageToolChannelKind };
+export {
+  formatMessageToolChannelList,
   MESSAGE_TOOL_CHANNEL_KINDS,
-);
-
-const MESSAGE_TOOL_CHANNEL_LABELS: Record<MessageToolChannelKind, string> = {
-  discord: 'Discord',
-  email: 'email',
-  imessage: 'iMessage',
-  msteams: 'Microsoft Teams',
-  slack: 'Slack',
-  telegram: 'Telegram',
-  tui: 'local TUI',
-  whatsapp: 'WhatsApp',
+  normalizeMessageToolChannelKinds,
 };
 
 const MESSAGE_TOOL_CHANNEL_ACTIONS: Record<MessageToolChannelKind, string> = {
@@ -46,42 +29,10 @@ const MESSAGE_TOOL_CHANNEL_ACTIONS: Record<MessageToolChannelKind, string> = {
     'WhatsApp: send messages and uploads to explicit WhatsApp JIDs or phone numbers.',
 };
 
-function isMessageToolChannelKind(
-  kind: ChannelKind | string,
-): kind is MessageToolChannelKind {
-  return MESSAGE_TOOL_CHANNEL_KIND_SET.has(kind as ChannelKind);
-}
-
-export function normalizeMessageToolChannelKinds(
-  kinds: readonly string[] | undefined,
-): MessageToolChannelKind[] {
-  if (!Array.isArray(kinds)) return [];
-  const normalized = new Set<MessageToolChannelKind>();
-  for (const kind of kinds) {
-    const candidate = String(kind || '')
-      .trim()
-      .toLowerCase();
-    if (isMessageToolChannelKind(candidate)) {
-      normalized.add(candidate);
-    }
-  }
-  return [...normalized].sort();
-}
-
 export function collectActiveMessageToolChannelKinds(): MessageToolChannelKind[] {
   return normalizeMessageToolChannelKinds(
     listChannels().map((channel) => channel.kind),
   );
-}
-
-export function formatMessageToolChannelList(
-  kinds: readonly string[] | undefined,
-): string {
-  const labels = normalizeMessageToolChannelKinds(kinds).map(
-    (kind) => MESSAGE_TOOL_CHANNEL_LABELS[kind],
-  );
-  if (labels.length === 0) return 'none';
-  return labels.join(', ');
 }
 
 export function describeMessageToolChannelActions(

--- a/src/cli/auth-command.ts
+++ b/src/cli/auth-command.ts
@@ -848,76 +848,35 @@ function isLocalProviderModel(modelName: string): boolean {
   return /^(ollama|lmstudio|llamacpp|vllm)\//i.test(modelName.trim());
 }
 
-function printOpenRouterStatus(): void {
+type ApiKeyProviderConfigKey =
+  | 'openrouter'
+  | 'mistral'
+  | 'huggingface'
+  | 'gemini'
+  | 'deepseek'
+  | 'xai'
+  | 'zai'
+  | 'kimi'
+  | 'minimax'
+  | 'dashscope'
+  | 'xiaomi'
+  | 'kilo';
+
+function printApiKeyProviderStatus(options: {
+  providerLabel?: string;
+  configKey: ApiKeyProviderConfigKey;
+  secretKey: string;
+  envVarNames: string[];
+  showProviderLabel?: boolean;
+  catalog?: string;
+}): void {
   ensureRuntimeConfigFile();
   const config = getRuntimeConfig();
-  const storedApiKey = readStoredRuntimeSecret('OPENROUTER_API_KEY');
-  const envApiKey = process.env.OPENROUTER_API_KEY?.trim() || '';
-  const source = envApiKey
-    ? storedApiKey && envApiKey === storedApiKey
-      ? 'runtime-secrets'
-      : 'env'
-    : storedApiKey
-      ? 'runtime-secrets'
-      : null;
-  const apiKey = envApiKey || storedApiKey || '';
-
-  console.log(`Path: ${runtimeSecretsPath()}`);
-  console.log(`Authenticated: ${apiKey ? 'yes' : 'no'}`);
-  if (source) {
-    console.log(`Source: ${source}`);
-  }
-  if (apiKey) {
-    console.log(`API key: ${CONFIGURED_SECRET_STATUS}`);
-  }
-  console.log(`Config: ${runtimeConfigPath()}`);
-  console.log(`Enabled: ${config.openrouter.enabled ? 'yes' : 'no'}`);
-  console.log(`Base URL: ${config.openrouter.baseUrl}`);
-  console.log(
-    `Default model: ${formatModelForDisplay(config.hybridai.defaultModel)}`,
-  );
-  console.log('Catalog: auto-discovered');
-}
-
-function printMistralStatus(): void {
-  ensureRuntimeConfigFile();
-  const config = getRuntimeConfig();
-  const storedApiKey = readStoredRuntimeSecret('MISTRAL_API_KEY');
-  const envApiKey = process.env.MISTRAL_API_KEY?.trim() || '';
-  const source = envApiKey
-    ? storedApiKey && envApiKey === storedApiKey
-      ? 'runtime-secrets'
-      : 'env'
-    : storedApiKey
-      ? 'runtime-secrets'
-      : null;
-  const apiKey = envApiKey || storedApiKey || '';
-
-  console.log(`Path: ${runtimeSecretsPath()}`);
-  console.log(`Authenticated: ${apiKey ? 'yes' : 'no'}`);
-  if (source) {
-    console.log(`Source: ${source}`);
-  }
-  if (apiKey) {
-    console.log(`API key: ${CONFIGURED_SECRET_STATUS}`);
-  }
-  console.log(`Config: ${runtimeConfigPath()}`);
-  console.log(`Enabled: ${config.mistral.enabled ? 'yes' : 'no'}`);
-  console.log(`Base URL: ${config.mistral.baseUrl}`);
-  console.log(
-    `Default model: ${formatModelForDisplay(config.hybridai.defaultModel)}`,
-  );
-  console.log('Catalog: auto-discovered');
-}
-
-function printHuggingFaceStatus(): void {
-  ensureRuntimeConfigFile();
-  const config = getRuntimeConfig();
-  const storedApiKey = readStoredRuntimeSecret('HF_TOKEN');
+  const storedApiKey = readStoredRuntimeSecret(options.secretKey);
   const envApiKey =
-    process.env.HF_TOKEN?.trim() ||
-    process.env.HUGGINGFACE_API_KEY?.trim() ||
-    '';
+    options.envVarNames
+      .map((name) => process.env[name]?.trim())
+      .find((value) => value) || '';
   const source = envApiKey
     ? storedApiKey && envApiKey === storedApiKey
       ? 'runtime-secrets'
@@ -927,6 +886,9 @@ function printHuggingFaceStatus(): void {
       : null;
   const apiKey = envApiKey || storedApiKey || '';
 
+  if (options.showProviderLabel && options.providerLabel) {
+    console.log(`Provider: ${options.providerLabel}`);
+  }
   console.log(`Path: ${runtimeSecretsPath()}`);
   console.log(`Authenticated: ${apiKey ? 'yes' : 'no'}`);
   if (source) {
@@ -936,12 +898,14 @@ function printHuggingFaceStatus(): void {
     console.log(`API key: ${CONFIGURED_SECRET_STATUS}`);
   }
   console.log(`Config: ${runtimeConfigPath()}`);
-  console.log(`Enabled: ${config.huggingface.enabled ? 'yes' : 'no'}`);
-  console.log(`Base URL: ${config.huggingface.baseUrl}`);
+  console.log(`Enabled: ${config[options.configKey].enabled ? 'yes' : 'no'}`);
+  console.log(`Base URL: ${config[options.configKey].baseUrl}`);
   console.log(
     `Default model: ${formatModelForDisplay(config.hybridai.defaultModel)}`,
   );
-  console.log('Catalog: auto-discovered');
+  if (options.catalog) {
+    console.log(`Catalog: ${options.catalog}`);
+  }
 }
 
 function clearOpenRouterCredentials(): void {
@@ -996,6 +960,12 @@ function parseGoogleLoginArgs(args: string[]): {
   scopes?: string;
   redirectPort?: number;
 } {
+  type GoogleStringFlagKey =
+    | 'account'
+    | 'clientId'
+    | 'clientSecret'
+    | 'refreshToken'
+    | 'scopes';
   const parsed: {
     account?: string;
     clientId?: string;
@@ -1004,74 +974,46 @@ function parseGoogleLoginArgs(args: string[]): {
     scopes?: string;
     redirectPort?: number;
   } = {};
+  const stringFlags: Array<{
+    key: GoogleStringFlagKey;
+    name: string;
+    placeholder: string;
+  }> = [
+    { key: 'account', name: '--account', placeholder: '<email>' },
+    { key: 'clientId', name: '--client-id', placeholder: '<id>' },
+    {
+      key: 'clientSecret',
+      name: '--client-secret',
+      placeholder: '<secret>',
+    },
+    {
+      key: 'refreshToken',
+      name: '--refresh-token',
+      placeholder: '<token>',
+    },
+    { key: 'scopes', name: '--scopes', placeholder: '<scopes>' },
+  ];
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index] || '';
-    const accountFlag = parseValueFlag({
-      arg,
-      args,
-      index,
-      name: '--account',
-      placeholder: '<email>',
-      allowEmptyEquals: true,
-    });
-    if (accountFlag) {
-      parsed.account = accountFlag.value || undefined;
-      index = accountFlag.nextIndex;
-      continue;
+    let matchedStringFlag = false;
+    for (const flag of stringFlags) {
+      const parsedFlag = parseValueFlag({
+        arg,
+        args,
+        index,
+        name: flag.name,
+        placeholder: flag.placeholder,
+        allowEmptyEquals: true,
+      });
+      if (!parsedFlag) continue;
+      parsed[flag.key] = parsedFlag.value || undefined;
+      index = parsedFlag.nextIndex;
+      matchedStringFlag = true;
+      break;
     }
-    const clientIdFlag = parseValueFlag({
-      arg,
-      args,
-      index,
-      name: '--client-id',
-      placeholder: '<id>',
-      allowEmptyEquals: true,
-    });
-    if (clientIdFlag) {
-      parsed.clientId = clientIdFlag.value || undefined;
-      index = clientIdFlag.nextIndex;
-      continue;
-    }
-    const clientSecretFlag = parseValueFlag({
-      arg,
-      args,
-      index,
-      name: '--client-secret',
-      placeholder: '<secret>',
-      allowEmptyEquals: true,
-    });
-    if (clientSecretFlag) {
-      parsed.clientSecret = clientSecretFlag.value || undefined;
-      index = clientSecretFlag.nextIndex;
-      continue;
-    }
-    const refreshTokenFlag = parseValueFlag({
-      arg,
-      args,
-      index,
-      name: '--refresh-token',
-      placeholder: '<token>',
-      allowEmptyEquals: true,
-    });
-    if (refreshTokenFlag) {
-      parsed.refreshToken = refreshTokenFlag.value || undefined;
-      index = refreshTokenFlag.nextIndex;
-      continue;
-    }
-    const scopesFlag = parseValueFlag({
-      arg,
-      args,
-      index,
-      name: '--scopes',
-      placeholder: '<scopes>',
-      allowEmptyEquals: true,
-    });
-    if (scopesFlag) {
-      parsed.scopes = scopesFlag.value || undefined;
-      index = scopesFlag.nextIndex;
-      continue;
-    }
+    if (matchedStringFlag) continue;
+
     const redirectPortFlag = parseValueFlag({
       arg,
       args,
@@ -1121,12 +1063,10 @@ async function resolveInteractiveGoogleLogin(params: {
     );
   }
 
-  const createPromptInterface = () =>
-    readline.createInterface({
-      input: process.stdin,
-      output: process.stdout,
-    });
-  let rl = createPromptInterface();
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
 
   try {
     const account = await promptWithDefault({
@@ -1139,13 +1079,12 @@ async function resolveInteractiveGoogleLogin(params: {
       question: 'Google OAuth desktop client id',
       defaultValue: params.clientId || undefined,
     });
-    rl.close();
-    const clientSecret =
-      params.clientSecret ||
-      (await promptForSecretInput({
-        prompt: 'Google OAuth desktop client secret: ',
-      }));
-    rl = createPromptInterface();
+    const clientSecret = await promptWithDefault({
+      rl,
+      question: 'Google OAuth desktop client secret',
+      defaultValue: params.clientSecret || undefined,
+      secret: true,
+    });
     return {
       account,
       clientId,
@@ -1203,52 +1142,6 @@ async function configureGoogleAuth(args: string[]): Promise<void> {
   );
   console.log(
     'Agent containers will receive a fresh short-lived GOG_ACCESS_TOKEN for gog.',
-  );
-}
-
-function printGenericProviderStatus(
-  providerLabel: string,
-  configKey:
-    | 'gemini'
-    | 'deepseek'
-    | 'xai'
-    | 'zai'
-    | 'kimi'
-    | 'minimax'
-    | 'dashscope'
-    | 'xiaomi'
-    | 'kilo',
-  secretKey: string,
-  envVarNames: string[],
-): void {
-  ensureRuntimeConfigFile();
-  const config = getRuntimeConfig();
-  const storedApiKey = readStoredRuntimeSecret(secretKey);
-  const envApiKey =
-    envVarNames.map((name) => process.env[name]?.trim()).find((v) => v) || '';
-  const source = envApiKey
-    ? storedApiKey && envApiKey === storedApiKey
-      ? 'runtime-secrets'
-      : 'env'
-    : storedApiKey
-      ? 'runtime-secrets'
-      : null;
-  const apiKey = envApiKey || storedApiKey || '';
-
-  console.log(`Provider: ${providerLabel}`);
-  console.log(`Path: ${runtimeSecretsPath()}`);
-  console.log(`Authenticated: ${apiKey ? 'yes' : 'no'}`);
-  if (source) {
-    console.log(`Source: ${source}`);
-  }
-  if (apiKey) {
-    console.log(`API key: ${CONFIGURED_SECRET_STATUS}`);
-  }
-  console.log(`Config: ${runtimeConfigPath()}`);
-  console.log(`Enabled: ${config[configKey].enabled ? 'yes' : 'no'}`);
-  console.log(`Base URL: ${config[configKey].baseUrl}`);
-  console.log(
-    `Default model: ${formatModelForDisplay(config.hybridai.defaultModel)}`,
   );
 }
 
@@ -1891,7 +1784,12 @@ async function dispatchProviderAction(
   }
   if (provider === 'openrouter') {
     if (action === 'status') {
-      printOpenRouterStatus();
+      printApiKeyProviderStatus({
+        configKey: 'openrouter',
+        secretKey: 'OPENROUTER_API_KEY',
+        envVarNames: ['OPENROUTER_API_KEY'],
+        catalog: 'auto-discovered',
+      });
       return;
     }
     clearOpenRouterCredentials();
@@ -1899,7 +1797,12 @@ async function dispatchProviderAction(
   }
   if (provider === 'mistral') {
     if (action === 'status') {
-      printMistralStatus();
+      printApiKeyProviderStatus({
+        configKey: 'mistral',
+        secretKey: 'MISTRAL_API_KEY',
+        envVarNames: ['MISTRAL_API_KEY'],
+        catalog: 'auto-discovered',
+      });
       return;
     }
     clearMistralCredentials();
@@ -1907,7 +1810,12 @@ async function dispatchProviderAction(
   }
   if (provider === 'huggingface') {
     if (action === 'status') {
-      printHuggingFaceStatus();
+      printApiKeyProviderStatus({
+        configKey: 'huggingface',
+        secretKey: 'HF_TOKEN',
+        envVarNames: ['HF_TOKEN', 'HUGGINGFACE_API_KEY'],
+        catalog: 'auto-discovered',
+      });
       return;
     }
     clearHuggingFaceCredentials();
@@ -1924,12 +1832,13 @@ async function dispatchProviderAction(
   const genericDef = findGenericProviderDef(provider);
   if (genericDef) {
     if (action === 'status') {
-      printGenericProviderStatus(
-        genericDef.label,
-        genericDef.id,
-        genericDef.secretKey,
-        genericDef.envVarNames,
-      );
+      printApiKeyProviderStatus({
+        providerLabel: genericDef.label,
+        configKey: genericDef.id,
+        secretKey: genericDef.secretKey,
+        envVarNames: genericDef.envVarNames,
+        showProviderLabel: true,
+      });
       return;
     }
     clearGenericProviderCredentials(

--- a/src/cli/auth-command.ts
+++ b/src/cli/auth-command.ts
@@ -1,5 +1,15 @@
 import readline from 'node:readline/promises';
-
+import {
+  clearGoogleAuth,
+  DEFAULT_GOOGLE_OAUTH_SCOPES,
+  GOOGLE_ACCOUNT_SECRET,
+  GOOGLE_OAUTH_CLIENT_ID_SECRET,
+  GOOGLE_OAUTH_CLIENT_SECRET_SECRET,
+  GOOGLE_OAUTH_REFRESH_TOKEN_SECRET,
+  getGoogleAuthStatus,
+  loginGoogle,
+  parseGoogleScopes,
+} from '../auth/google-auth.js';
 import {
   ensureRuntimeConfigFile,
   getRuntimeConfig,
@@ -27,6 +37,7 @@ import {
   isHelpRequest,
   printAuthUsage,
   printCodexUsage,
+  printGoogleUsage,
   printHuggingFaceUsage,
   printHybridAIUsage,
   printLocalUsage,
@@ -713,6 +724,7 @@ type UnifiedProvider =
   | 'openrouter'
   | 'mistral'
   | 'huggingface'
+  | 'google'
   | 'gemini'
   | 'deepseek'
   | 'xai'
@@ -757,6 +769,9 @@ function normalizeUnifiedProvider(
   ) {
     return 'huggingface';
   }
+  if (normalized === 'google' || normalized === 'gog') {
+    return 'google';
+  }
   // Check data-driven generic providers by id or alias.
   for (const def of GENERIC_PROVIDER_AUTH_DEFS) {
     if (normalized === def.id || def.aliases.includes(normalized)) {
@@ -799,7 +814,7 @@ function parseUnifiedProviderArgs(args: string[]): {
     const provider = normalizeUnifiedProvider(rawProvider);
     if (!provider) {
       throw new Error(
-        `Unknown provider "${rawProvider}". Use \`hybridai\`, \`codex\`, \`openrouter\`, \`mistral\`, \`huggingface\`, \`gemini\`, \`deepseek\`, \`xai\`, \`zai\`, \`kimi\`, \`minimax\`, \`dashscope\`, \`xiaomi\`, \`kilo\`, \`local\`, \`msteams\`, or \`slack\`.`,
+        `Unknown provider "${rawProvider}". Use \`hybridai\`, \`codex\`, \`openrouter\`, \`mistral\`, \`huggingface\`, \`google\`, \`gemini\`, \`deepseek\`, \`xai\`, \`zai\`, \`kimi\`, \`minimax\`, \`dashscope\`, \`xiaomi\`, \`kilo\`, \`local\`, \`msteams\`, or \`slack\`.`,
       );
     }
     return {
@@ -813,7 +828,7 @@ function parseUnifiedProviderArgs(args: string[]): {
     const provider = normalizeUnifiedProvider(rawProvider);
     if (!provider) {
       throw new Error(
-        `Unknown provider "${rawProvider}". Use \`hybridai\`, \`codex\`, \`openrouter\`, \`mistral\`, \`huggingface\`, \`gemini\`, \`deepseek\`, \`xai\`, \`zai\`, \`kimi\`, \`minimax\`, \`dashscope\`, \`xiaomi\`, \`kilo\`, \`local\`, \`msteams\`, or \`slack\`.`,
+        `Unknown provider "${rawProvider}". Use \`hybridai\`, \`codex\`, \`openrouter\`, \`mistral\`, \`huggingface\`, \`google\`, \`gemini\`, \`deepseek\`, \`xai\`, \`zai\`, \`kimi\`, \`minimax\`, \`dashscope\`, \`xiaomi\`, \`kilo\`, \`local\`, \`msteams\`, or \`slack\`.`,
       );
     }
     return {
@@ -950,6 +965,244 @@ function clearHuggingFaceCredentials(): void {
   console.log(`Cleared Hugging Face credentials in ${filePath}.`);
   console.log(
     'If HF_TOKEN is still exported in your shell, unset it separately.',
+  );
+}
+
+function printGoogleStatus(): void {
+  const status = getGoogleAuthStatus();
+  console.log(`Path: ${status.path}`);
+  console.log(`Authenticated: ${status.authenticated ? 'yes' : 'no'}`);
+  if (status.authenticated) {
+    console.log('Source: runtime-secrets');
+    console.log(`Account: ${status.account || '(not set)'}`);
+    console.log('Refresh token: configured');
+    console.log('Client secret: configured');
+    console.log(`Scopes: ${status.scopes.join(' ')}`);
+    console.log('gog mode: direct access token');
+  }
+}
+
+function clearGoogleCredentials(): void {
+  const filePath = clearGoogleAuth();
+  console.log(`Cleared Google OAuth credentials from ${filePath}.`);
+  console.log('gog containers will no longer receive GOG_ACCESS_TOKEN.');
+}
+
+function parseGoogleLoginArgs(args: string[]): {
+  account?: string;
+  clientId?: string;
+  clientSecret?: string;
+  refreshToken?: string;
+  scopes?: string;
+  redirectPort?: number;
+} {
+  const parsed: {
+    account?: string;
+    clientId?: string;
+    clientSecret?: string;
+    refreshToken?: string;
+    scopes?: string;
+    redirectPort?: number;
+  } = {};
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index] || '';
+    const accountFlag = parseValueFlag({
+      arg,
+      args,
+      index,
+      name: '--account',
+      placeholder: '<email>',
+      allowEmptyEquals: true,
+    });
+    if (accountFlag) {
+      parsed.account = accountFlag.value || undefined;
+      index = accountFlag.nextIndex;
+      continue;
+    }
+    const clientIdFlag = parseValueFlag({
+      arg,
+      args,
+      index,
+      name: '--client-id',
+      placeholder: '<id>',
+      allowEmptyEquals: true,
+    });
+    if (clientIdFlag) {
+      parsed.clientId = clientIdFlag.value || undefined;
+      index = clientIdFlag.nextIndex;
+      continue;
+    }
+    const clientSecretFlag = parseValueFlag({
+      arg,
+      args,
+      index,
+      name: '--client-secret',
+      placeholder: '<secret>',
+      allowEmptyEquals: true,
+    });
+    if (clientSecretFlag) {
+      parsed.clientSecret = clientSecretFlag.value || undefined;
+      index = clientSecretFlag.nextIndex;
+      continue;
+    }
+    const refreshTokenFlag = parseValueFlag({
+      arg,
+      args,
+      index,
+      name: '--refresh-token',
+      placeholder: '<token>',
+      allowEmptyEquals: true,
+    });
+    if (refreshTokenFlag) {
+      parsed.refreshToken = refreshTokenFlag.value || undefined;
+      index = refreshTokenFlag.nextIndex;
+      continue;
+    }
+    const scopesFlag = parseValueFlag({
+      arg,
+      args,
+      index,
+      name: '--scopes',
+      placeholder: '<scopes>',
+      allowEmptyEquals: true,
+    });
+    if (scopesFlag) {
+      parsed.scopes = scopesFlag.value || undefined;
+      index = scopesFlag.nextIndex;
+      continue;
+    }
+    const redirectPortFlag = parseValueFlag({
+      arg,
+      args,
+      index,
+      name: '--redirect-port',
+      placeholder: '<port>',
+      allowEmptyEquals: true,
+    });
+    if (redirectPortFlag) {
+      const port = Number.parseInt(redirectPortFlag.value, 10);
+      if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+        throw new Error(
+          'Google OAuth redirect port must be between 1 and 65535.',
+        );
+      }
+      parsed.redirectPort = port;
+      index = redirectPortFlag.nextIndex;
+      continue;
+    }
+    if (arg.startsWith('-')) {
+      throw new Error(`Unknown flag: ${arg}`);
+    }
+    throw new Error(
+      `Unexpected argument: ${arg}. Use \`hybridclaw auth login google --help\`.`,
+    );
+  }
+
+  return parsed;
+}
+
+async function resolveInteractiveGoogleLogin(params: {
+  account: string;
+  clientId: string;
+  clientSecret: string;
+}): Promise<{
+  account: string;
+  clientId: string;
+  clientSecret: string;
+}> {
+  if (params.account && params.clientId && params.clientSecret) {
+    return params;
+  }
+
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new Error(
+      'Missing Google OAuth credentials. Pass `--client-id <id>`, `--client-secret <secret>`, and `--account <email>`, or run this command in an interactive terminal.',
+    );
+  }
+
+  const createPromptInterface = () =>
+    readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+  let rl = createPromptInterface();
+
+  try {
+    const account = await promptWithDefault({
+      rl,
+      question: 'Google account email',
+      defaultValue: params.account || undefined,
+    });
+    const clientId = await promptWithDefault({
+      rl,
+      question: 'Google OAuth desktop client id',
+      defaultValue: params.clientId || undefined,
+    });
+    rl.close();
+    const clientSecret =
+      params.clientSecret ||
+      (await promptForSecretInput({
+        prompt: 'Google OAuth desktop client secret: ',
+      }));
+    rl = createPromptInterface();
+    return {
+      account,
+      clientId,
+      clientSecret,
+    };
+  } finally {
+    rl.close();
+  }
+}
+
+async function configureGoogleAuth(args: string[]): Promise<void> {
+  const parsed = parseGoogleLoginArgs(args);
+  const resolved = await resolveInteractiveGoogleLogin({
+    account:
+      parsed.account ||
+      process.env[GOOGLE_ACCOUNT_SECRET]?.trim() ||
+      readStoredRuntimeSecret(GOOGLE_ACCOUNT_SECRET) ||
+      '',
+    clientId:
+      parsed.clientId ||
+      process.env[GOOGLE_OAUTH_CLIENT_ID_SECRET]?.trim() ||
+      readStoredRuntimeSecret(GOOGLE_OAUTH_CLIENT_ID_SECRET) ||
+      '',
+    clientSecret:
+      parsed.clientSecret ||
+      process.env[GOOGLE_OAUTH_CLIENT_SECRET_SECRET]?.trim() ||
+      readStoredRuntimeSecret(GOOGLE_OAUTH_CLIENT_SECRET_SECRET) ||
+      '',
+  });
+  const scopes = parseGoogleScopes(
+    parsed.scopes ||
+      process.env.GOOGLE_OAUTH_SCOPES?.trim() ||
+      readStoredRuntimeSecret('GOOGLE_OAUTH_SCOPES') ||
+      DEFAULT_GOOGLE_OAUTH_SCOPES.join(' '),
+  );
+  const result = await loginGoogle({
+    account: resolved.account,
+    clientId: resolved.clientId,
+    clientSecret: resolved.clientSecret,
+    refreshToken:
+      parsed.refreshToken ||
+      process.env[GOOGLE_OAUTH_REFRESH_TOKEN_SECRET]?.trim() ||
+      undefined,
+    scopes,
+    redirectPort: parsed.redirectPort,
+  });
+
+  console.log(`Saved Google OAuth credentials to ${result.secretsPath}.`);
+  console.log(`Account: ${result.account}`);
+  console.log(`Scopes: ${result.scopes.join(' ')}`);
+  console.log(
+    result.usedProvidedRefreshToken
+      ? 'Stored provided refresh token.'
+      : 'Completed browser authorization and stored refresh token.',
+  );
+  console.log(
+    'Agent containers will receive a fresh short-lived GOG_ACCESS_TOKEN for gog.',
   );
 }
 
@@ -1234,6 +1487,10 @@ function printUnifiedProviderUsage(provider: UnifiedProvider): void {
     printHuggingFaceUsage();
     return;
   }
+  if (provider === 'google') {
+    printGoogleUsage();
+    return;
+  }
   if (findGenericProviderDef(provider)) {
     console.log(
       `Usage: hybridclaw auth login ${provider} [--api-key <key>] [--base-url <url>] [--model <model>] [--no-default]`,
@@ -1488,7 +1745,7 @@ async function handleAuthLoginCommand(normalizedArgs: string[]): Promise<void> {
   const parsed = parseUnifiedProviderArgs(normalizedArgs);
   if (!parsed.provider) {
     throw new Error(
-      `Unknown auth login provider "${normalizedArgs[0]}". Use \`hybridai\`, \`codex\`, \`openrouter\`, \`mistral\`, \`huggingface\`, \`gemini\`, \`deepseek\`, \`xai\`, \`zai\`, \`kimi\`, \`minimax\`, \`dashscope\`, \`xiaomi\`, \`kilo\`, \`local\`, \`msteams\`, or \`slack\`.`,
+      `Unknown auth login provider "${normalizedArgs[0]}". Use \`hybridai\`, \`codex\`, \`openrouter\`, \`mistral\`, \`huggingface\`, \`google\`, \`gemini\`, \`deepseek\`, \`xai\`, \`zai\`, \`kimi\`, \`minimax\`, \`dashscope\`, \`xiaomi\`, \`kilo\`, \`local\`, \`msteams\`, or \`slack\`.`,
     );
   }
   if (isHelpRequest(parsed.remaining)) {
@@ -1514,6 +1771,10 @@ async function handleAuthLoginCommand(normalizedArgs: string[]): Promise<void> {
   }
   if (parsed.provider === 'huggingface') {
     await configureHuggingFace(parsed.remaining);
+    return;
+  }
+  if (parsed.provider === 'google') {
+    await configureGoogleAuth(parsed.remaining);
     return;
   }
   const genericLoginDef = findGenericProviderDef(parsed.provider);
@@ -1652,6 +1913,14 @@ async function dispatchProviderAction(
     clearHuggingFaceCredentials();
     return;
   }
+  if (provider === 'google') {
+    if (action === 'status') {
+      printGoogleStatus();
+      return;
+    }
+    clearGoogleCredentials();
+    return;
+  }
   const genericDef = findGenericProviderDef(provider);
   if (genericDef) {
     if (action === 'status') {
@@ -1706,7 +1975,7 @@ async function handleProviderActionCommand(
   const parsed = parseUnifiedProviderArgs(normalizedArgs);
   if (!parsed.provider) {
     throw new Error(
-      `Unknown ${action} provider "${normalizedArgs[0]}". Use \`hybridai\`, \`codex\`, \`openrouter\`, \`mistral\`, \`huggingface\`, \`gemini\`, \`deepseek\`, \`xai\`, \`zai\`, \`kimi\`, \`minimax\`, \`dashscope\`, \`xiaomi\`, \`kilo\`, \`local\`, \`msteams\`, or \`slack\`.`,
+      `Unknown ${action} provider "${normalizedArgs[0]}". Use \`hybridai\`, \`codex\`, \`openrouter\`, \`mistral\`, \`huggingface\`, \`google\`, \`gemini\`, \`deepseek\`, \`xai\`, \`zai\`, \`kimi\`, \`minimax\`, \`dashscope\`, \`xiaomi\`, \`kilo\`, \`local\`, \`msteams\`, or \`slack\`.`,
     );
   }
   if (parsed.remaining.length > 0) {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -204,9 +204,9 @@ export function printAuthUsage(): void {
 
 Commands:
   hybridclaw auth login
-  hybridclaw auth login <hybridai|codex|openrouter|mistral|huggingface|local|msteams|slack> ...
-  hybridclaw auth status <hybridai|codex|openrouter|mistral|huggingface|local|msteams|slack>
-  hybridclaw auth logout <hybridai|codex|openrouter|mistral|huggingface|local|msteams|slack>
+  hybridclaw auth login <hybridai|codex|openrouter|mistral|huggingface|google|local|msteams|slack> ...
+  hybridclaw auth status <hybridai|codex|openrouter|mistral|huggingface|google|local|msteams|slack>
+  hybridclaw auth logout <hybridai|codex|openrouter|mistral|huggingface|google|local|msteams|slack>
   hybridclaw auth whatsapp reset
 
 Examples:
@@ -217,6 +217,7 @@ Examples:
   hybridclaw auth login openrouter anthropic/claude-sonnet-4 --api-key sk-or-...
   hybridclaw auth login mistral mistral-large-latest --api-key mistral_...
   hybridclaw auth login huggingface meta-llama/Llama-3.1-8B-Instruct --api-key hf_...
+  hybridclaw auth login google --client-id ... --client-secret ... --account you@gmail.com
   hybridclaw auth login local lmstudio --base-url http://127.0.0.1:1234
   hybridclaw auth login local ollama llama3.2
   hybridclaw auth login local llamacpp Meta-Llama-3-8B-Instruct --base-url http://127.0.0.1:8081
@@ -226,11 +227,13 @@ Examples:
   hybridclaw auth status openrouter
   hybridclaw auth status mistral
   hybridclaw auth status huggingface
+  hybridclaw auth status google
   hybridclaw auth status msteams
   hybridclaw auth status slack
   hybridclaw auth logout codex
   hybridclaw auth logout mistral
   hybridclaw auth logout huggingface
+  hybridclaw auth logout google
   hybridclaw auth logout msteams
   hybridclaw auth logout slack
 
@@ -245,6 +248,29 @@ Notes:
   - \`auth login huggingface\` prompts for the token when \`--api-key\` and \`HF_TOKEN\` are both absent.
   - \`auth login msteams\` prompts for the app id, app password, and optional tenant id when the terminal is interactive.
   - \`auth login slack\` prompts for the bot token and app token when the terminal is interactive.`);
+}
+
+export function printGoogleUsage(): void {
+  console.log(`Usage: hybridclaw auth login google [options]
+
+Options:
+  --client-id <id>          Google OAuth desktop client id
+  --client-secret <secret>  Google OAuth desktop client secret
+  --account <email>         Google account used by gog
+  --scopes <scopes>         Space- or comma-separated OAuth scopes
+  --refresh-token <token>   Store an existing refresh token instead of opening the browser flow
+  --redirect-port <port>    Fixed localhost callback port (optional)
+
+Examples:
+  hybridclaw auth login google --client-id ... --client-secret ... --account you@gmail.com
+  hybridclaw auth login google --client-id ... --client-secret ... --account you@gmail.com --scopes "https://www.googleapis.com/auth/gmail.modify https://www.googleapis.com/auth/calendar"
+  hybridclaw auth status google
+  hybridclaw auth logout google
+
+Notes:
+  - The Google refresh token and client secret are stored in encrypted runtime secrets.
+  - Agent containers receive only a short-lived \`GOG_ACCESS_TOKEN\` minted by the host.
+  - Use a Google OAuth desktop client with an authorized redirect URI matching the printed localhost callback URL.`);
 }
 
 export function printChannelsUsage(): void {

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -7,6 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { ExecutorRequest } from '../agent/executor-types.js';
 import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
+import { resolveGogRuntimeEnv } from '../auth/google-auth.js';
 import { getBrowserProfileDir } from '../browser/browser-login.js';
 import {
   ADDITIONAL_MOUNTS,
@@ -788,6 +789,13 @@ async function runContainerInner(
     chatbotId: modelRuntime.chatbotId,
     sessionModel: model,
   });
+  const runtimeEnv = await resolveGogRuntimeEnv().catch((error) => {
+    logger.warn(
+      { error },
+      'Failed to mint Google access token for gog runtime environment',
+    );
+    return {};
+  });
   if (pool.size >= MAX_CONCURRENT_CONTAINERS && !pool.has(sessionId)) {
     return {
       status: 'error',
@@ -848,6 +856,7 @@ async function runContainerInner(
     pluginTools,
     mcpServers: MCP_SERVERS,
     taskModels,
+    runtimeEnv,
     contextGuard: {
       enabled: CONTEXT_GUARD_ENABLED,
       perResultShare: CONTEXT_GUARD_PER_RESULT_SHARE,

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -7,7 +7,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { ExecutorRequest } from '../agent/executor-types.js';
 import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
-import { resolveGogRuntimeEnv } from '../auth/google-auth.js';
+import {
+  readStoredGoogleAuth,
+  resolveGogRuntimeEnv,
+} from '../auth/google-auth.js';
 import { getBrowserProfileDir } from '../browser/browser-login.js';
 import { collectActiveMessageToolChannelKinds } from '../channels/message-tool-advertising.js';
 import {
@@ -55,7 +58,7 @@ import { resolveProviderRequestMaxTokens } from '../providers/request-max-tokens
 import { resolveTaskModelPolicies } from '../providers/task-routing.js';
 import { resolveConfiguredAdditionalMounts } from '../security/mount-config.js';
 import { validateAdditionalMounts } from '../security/mount-security.js';
-import { redactSecrets } from '../security/redact.js';
+import { redactCredentialSecrets } from '../security/redact.js';
 import type { ContainerInput, ContainerOutput } from '../types/container.js';
 import type {
   ArtifactMetadata,
@@ -225,7 +228,7 @@ function emitTextDelta(entry: PoolEntry, line: string): void {
 
   try {
     if (!delta) return;
-    callback(delta);
+    callback(redactCredentialSecrets(delta));
   } catch (err) {
     logger.debug(
       { sessionId: entry.sessionId, err },
@@ -246,7 +249,7 @@ function emitToolProgress(entry: PoolEntry, line: string): void {
         toolName: resultMatch[1],
         phase: 'finish',
         durationMs: parseInt(resultMatch[2], 10),
-        preview: redactSecrets(resultMatch[3]),
+        preview: redactCredentialSecrets(resultMatch[3]),
       });
     } catch (err) {
       logger.debug(
@@ -264,7 +267,7 @@ function emitToolProgress(entry: PoolEntry, line: string): void {
         sessionId: entry.sessionId,
         toolName: startMatch[1],
         phase: 'start',
-        preview: redactSecrets(startMatch[2]),
+        preview: redactCredentialSecrets(startMatch[2]),
       });
     } catch (err) {
       logger.debug(
@@ -293,9 +296,9 @@ function parseApprovalProgress(line: string): PendingApproval | null {
     }
     return {
       approvalId: parsed.approvalId,
-      prompt: redactSecrets(parsed.prompt),
-      intent: redactSecrets(parsed.intent),
-      reason: redactSecrets(parsed.reason),
+      prompt: redactCredentialSecrets(parsed.prompt),
+      intent: redactCredentialSecrets(parsed.intent),
+      reason: redactCredentialSecrets(parsed.reason),
       allowSession: parsed.allowSession === true,
       allowAgent: parsed.allowAgent === true,
       allowAll: parsed.allowAll === true,
@@ -790,13 +793,15 @@ async function runContainerInner(
     chatbotId: modelRuntime.chatbotId,
     sessionModel: model,
   });
-  const runtimeEnv = await resolveGogRuntimeEnv().catch((error) => {
-    logger.warn(
-      { error },
-      'Failed to mint Google access token for gog runtime environment',
-    );
-    return {};
-  });
+  const runtimeEnv = readStoredGoogleAuth()
+    ? await resolveGogRuntimeEnv().catch((error) => {
+        logger.warn(
+          { error },
+          'Failed to mint Google access token for gog runtime environment',
+        );
+        return {};
+      })
+    : {};
   if (pool.size >= MAX_CONCURRENT_CONTAINERS && !pool.has(sessionId)) {
     return {
       status: 'error',
@@ -978,12 +983,18 @@ async function runContainerInner(
       workspacePath,
       params.workspaceDisplayRootOverride,
     );
+    if (typeof output.result === 'string') {
+      output.result = redactCredentialSecrets(output.result);
+    }
+    if (typeof output.error === 'string') {
+      output.error = redactCredentialSecrets(output.error);
+    }
     if (output.pendingApproval) {
       output.pendingApproval = {
         ...output.pendingApproval,
-        prompt: redactSecrets(output.pendingApproval.prompt),
-        intent: redactSecrets(output.pendingApproval.intent),
-        reason: redactSecrets(output.pendingApproval.reason),
+        prompt: redactCredentialSecrets(output.pendingApproval.prompt),
+        intent: redactCredentialSecrets(output.pendingApproval.intent),
+        reason: redactCredentialSecrets(output.pendingApproval.reason),
       };
     }
     const duration = Date.now() - startTime;

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -9,6 +9,7 @@ import type { ExecutorRequest } from '../agent/executor-types.js';
 import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import { resolveGogRuntimeEnv } from '../auth/google-auth.js';
 import { getBrowserProfileDir } from '../browser/browser-login.js';
+import { collectActiveMessageToolChannelKinds } from '../channels/message-tool-advertising.js';
 import {
   ADDITIONAL_MOUNTS,
   CONTAINER_BINDS,
@@ -836,6 +837,7 @@ async function runContainerInner(
     }),
     channelId,
     configuredDiscordChannels: collectConfiguredDiscordChannelIds(channelId),
+    activeMessageChannels: collectActiveMessageToolChannelKinds(),
     scheduledTasks: scheduledTasks?.map(
       (task): ScheduledTaskInput => ({
         id: task.id,

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -225,7 +225,7 @@ function emitTextDelta(entry: PoolEntry, line: string): void {
 
   try {
     if (!delta) return;
-    callback(redactSecrets(delta));
+    callback(delta);
   } catch (err) {
     logger.debug(
       { sessionId: entry.sessionId, err },
@@ -978,10 +978,6 @@ async function runContainerInner(
       workspacePath,
       params.workspaceDisplayRootOverride,
     );
-    if (typeof output.result === 'string')
-      output.result = redactSecrets(output.result);
-    if (typeof output.error === 'string')
-      output.error = redactSecrets(output.error);
     if (output.pendingApproval) {
       output.pendingApproval = {
         ...output.pendingApproval,

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import type { ExecutorRequest } from '../agent/executor-types.js';
 import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import { resolveGogRuntimeEnv } from '../auth/google-auth.js';
+import { collectActiveMessageToolChannelKinds } from '../channels/message-tool-advertising.js';
 import {
   ADDITIONAL_MOUNTS,
   CONTAINER_BINDS,
@@ -721,6 +722,7 @@ async function runHostProcessInner(
     }),
     channelId,
     configuredDiscordChannels: collectConfiguredDiscordChannelIds(channelId),
+    activeMessageChannels: collectActiveMessageToolChannelKinds(),
     scheduledTasks: scheduledTasks?.map(
       (task): ScheduledTaskInput => ({
         id: task.id,

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -265,7 +265,7 @@ function emitTextDelta(entry: PoolEntry, line: string): void {
   if (delta == null) return;
 
   try {
-    if (delta) callback(redactSecrets(delta));
+    if (delta) callback(delta);
   } catch (err) {
     logger.debug(
       { sessionId: entry.sessionId, err },
@@ -869,10 +869,6 @@ async function runHostProcessInner(
       workspacePath,
       params.workspaceDisplayRootOverride,
     );
-    if (typeof output.result === 'string')
-      output.result = redactSecrets(output.result);
-    if (typeof output.error === 'string')
-      output.error = redactSecrets(output.error);
     if (output.pendingApproval) {
       output.pendingApproval = {
         ...output.pendingApproval,

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -4,7 +4,10 @@ import os from 'node:os';
 import path from 'node:path';
 import type { ExecutorRequest } from '../agent/executor-types.js';
 import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
-import { resolveGogRuntimeEnv } from '../auth/google-auth.js';
+import {
+  readStoredGoogleAuth,
+  resolveGogRuntimeEnv,
+} from '../auth/google-auth.js';
 import { collectActiveMessageToolChannelKinds } from '../channels/message-tool-advertising.js';
 import {
   ADDITIONAL_MOUNTS,
@@ -41,7 +44,7 @@ import { resolveModelRuntimeCredentials } from '../providers/factory.js';
 import { resolveProviderRequestMaxTokens } from '../providers/request-max-tokens.js';
 import { resolveTaskModelPolicies } from '../providers/task-routing.js';
 import { resolveConfiguredAdditionalMounts } from '../security/mount-config.js';
-import { redactSecrets } from '../security/redact.js';
+import { redactCredentialSecrets } from '../security/redact.js';
 import type { ContainerInput, ContainerOutput } from '../types/container.js';
 import type { PendingApproval, ToolProgressEvent } from '../types/execution.js';
 import type { ScheduledTaskInput } from '../types/scheduler.js';
@@ -265,7 +268,7 @@ function emitTextDelta(entry: PoolEntry, line: string): void {
   if (delta == null) return;
 
   try {
-    if (delta) callback(delta);
+    if (delta) callback(redactCredentialSecrets(delta));
   } catch (err) {
     logger.debug(
       { sessionId: entry.sessionId, err },
@@ -286,7 +289,7 @@ function emitToolProgress(entry: PoolEntry, line: string): void {
         toolName: resultMatch[1],
         phase: 'finish',
         durationMs: parseInt(resultMatch[2], 10),
-        preview: redactSecrets(resultMatch[3]),
+        preview: redactCredentialSecrets(resultMatch[3]),
       });
     } catch (err) {
       logger.debug(
@@ -304,7 +307,7 @@ function emitToolProgress(entry: PoolEntry, line: string): void {
       sessionId: entry.sessionId,
       toolName: startMatch[1],
       phase: 'start',
-      preview: redactSecrets(startMatch[2]),
+      preview: redactCredentialSecrets(startMatch[2]),
     });
   } catch (err) {
     logger.debug(
@@ -332,9 +335,9 @@ function parseApprovalProgress(line: string): PendingApproval | null {
     }
     return {
       approvalId: parsed.approvalId,
-      prompt: redactSecrets(parsed.prompt),
-      intent: redactSecrets(parsed.intent),
-      reason: redactSecrets(parsed.reason),
+      prompt: redactCredentialSecrets(parsed.prompt),
+      intent: redactCredentialSecrets(parsed.intent),
+      reason: redactCredentialSecrets(parsed.reason),
       allowSession: parsed.allowSession === true,
       allowAgent: parsed.allowAgent === true,
       allowAll: parsed.allowAll === true,
@@ -670,13 +673,15 @@ async function runHostProcessInner(
     chatbotId: modelRuntime.chatbotId,
     sessionModel: model,
   });
-  const runtimeEnv = await resolveGogRuntimeEnv().catch((error) => {
-    logger.warn(
-      { error },
-      'Failed to mint Google access token for gog runtime environment',
-    );
-    return {};
-  });
+  const runtimeEnv = readStoredGoogleAuth()
+    ? await resolveGogRuntimeEnv().catch((error) => {
+        logger.warn(
+          { error },
+          'Failed to mint Google access token for gog runtime environment',
+        );
+        return {};
+      })
+    : {};
 
   if (pool.size >= MAX_CONCURRENT_CONTAINERS && !pool.has(sessionId)) {
     const capacityState = await waitForHostCapacity(sessionId, abortSignal);
@@ -869,12 +874,18 @@ async function runHostProcessInner(
       workspacePath,
       params.workspaceDisplayRootOverride,
     );
+    if (typeof output.result === 'string') {
+      output.result = redactCredentialSecrets(output.result);
+    }
+    if (typeof output.error === 'string') {
+      output.error = redactCredentialSecrets(output.error);
+    }
     if (output.pendingApproval) {
       output.pendingApproval = {
         ...output.pendingApproval,
-        prompt: redactSecrets(output.pendingApproval.prompt),
-        intent: redactSecrets(output.pendingApproval.intent),
-        reason: redactSecrets(output.pendingApproval.reason),
+        prompt: redactCredentialSecrets(output.pendingApproval.prompt),
+        intent: redactCredentialSecrets(output.pendingApproval.intent),
+        reason: redactCredentialSecrets(output.pendingApproval.reason),
       };
     }
     return output;

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import type { ExecutorRequest } from '../agent/executor-types.js';
 import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
+import { resolveGogRuntimeEnv } from '../auth/google-auth.js';
 import {
   ADDITIONAL_MOUNTS,
   CONTAINER_BINDS,
@@ -668,6 +669,13 @@ async function runHostProcessInner(
     chatbotId: modelRuntime.chatbotId,
     sessionModel: model,
   });
+  const runtimeEnv = await resolveGogRuntimeEnv().catch((error) => {
+    logger.warn(
+      { error },
+      'Failed to mint Google access token for gog runtime environment',
+    );
+    return {};
+  });
 
   if (pool.size >= MAX_CONCURRENT_CONTAINERS && !pool.has(sessionId)) {
     const capacityState = await waitForHostCapacity(sessionId, abortSignal);
@@ -733,6 +741,7 @@ async function runHostProcessInner(
     pluginTools,
     mcpServers: MCP_SERVERS,
     taskModels,
+    runtimeEnv,
     contextGuard: {
       enabled: CONTEXT_GUARD_ENABLED,
       perResultShare: CONTEXT_GUARD_PER_RESULT_SHARE,

--- a/src/infra/ipc.ts
+++ b/src/infra/ipc.ts
@@ -63,7 +63,8 @@ export function ensureAgentDirs(agentId: string): void {
 /**
  * Write input for the container agent.
  * When omitApiKey is set, auth material is excluded from the file on disk
- * (the agent already has it in memory from the initial stdin payload).
+ * (the agent already has it in memory from the initial stdin payload). Runtime
+ * env is preserved so short-lived host-minted tokens can refresh per request.
  */
 export function writeInput(
   sessionId: string,
@@ -78,10 +79,11 @@ export function writeInput(
         apiKey: '',
         requestHeaders: {},
         taskModels: redactTaskModelSecrets(input.taskModels),
-        runtimeEnv: {},
       }
     : input;
-  fs.writeFileSync(inputPath, JSON.stringify(toWrite, null, 2));
+  fs.writeFileSync(inputPath, JSON.stringify(toWrite, null, 2), {
+    mode: 0o600,
+  });
   logger.debug({ sessionId, path: inputPath }, 'Wrote IPC input');
   return inputPath;
 }

--- a/src/infra/ipc.ts
+++ b/src/infra/ipc.ts
@@ -78,6 +78,7 @@ export function writeInput(
         apiKey: '',
         requestHeaders: {},
         taskModels: redactTaskModelSecrets(input.taskModels),
+        runtimeEnv: {},
       }
     : input;
   fs.writeFileSync(inputPath, JSON.stringify(toWrite, null, 2));

--- a/src/security/redact.ts
+++ b/src/security/redact.ts
@@ -180,7 +180,7 @@ const ENV_SECRET_ASSIGNMENT_RE =
 const OBJECT_SECRET_KEY_RE =
   /(?:api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret|webhook[_-]?secret|auth(?:orization)?|token|secret|password|private[_-]?key)/i;
 
-export const SECRET_REDACTION_PATTERNS: readonly SecretRedactionPattern[] =
+export const CREDENTIAL_REDACTION_PATTERNS: readonly SecretRedactionPattern[] =
   Object.freeze([
     {
       match:
@@ -259,6 +259,11 @@ export const SECRET_REDACTION_PATTERNS: readonly SecretRedactionPattern[] =
       match: /\b(SG\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})\b/g,
       replace: (_match: string, token: string) => maskSecret(token),
     },
+  ]);
+
+export const SECRET_REDACTION_PATTERNS: readonly SecretRedactionPattern[] =
+  Object.freeze([
+    ...CREDENTIAL_REDACTION_PATTERNS,
     {
       match: /\b([A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,})\b/gi,
       replace: replaceEmail,
@@ -295,6 +300,16 @@ export const SECRET_REDACTION_PATTERNS: readonly SecretRedactionPattern[] =
       replace: replaceCreditCard,
     },
   ]);
+
+export function redactCredentialSecrets(text: string): string {
+  if (!text || !isRedactionEnabled()) return text;
+
+  let next = text;
+  for (const pattern of CREDENTIAL_REDACTION_PATTERNS) {
+    next = next.replace(pattern.match, pattern.replace as never);
+  }
+  return next;
+}
 
 export function redactSecrets(text: string): string {
   if (!text || !isRedactionEnabled()) return text;

--- a/src/types/container.ts
+++ b/src/types/container.ts
@@ -83,6 +83,7 @@ export interface ContainerInput {
   contextGuard?: ContextGuardConfig;
   webSearch?: WebSearchConfig;
   persistBashState?: boolean;
+  runtimeEnv?: Record<string, string>;
 }
 
 export interface ContainerOutput {

--- a/src/types/container.ts
+++ b/src/types/container.ts
@@ -72,6 +72,7 @@ export interface ContainerInput {
   maxTokens?: number;
   channelId: string;
   configuredDiscordChannels?: string[];
+  activeMessageChannels?: string[];
   scheduledTasks?: ScheduledTaskInput[];
   allowedTools?: string[];
   blockedTools?: string[];

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -541,6 +541,7 @@ async function importFreshCli(options?: {
     };
   });
   const saveRuntimeSecrets = vi.fn(() => '/tmp/credentials.json');
+  const saveNamedRuntimeSecrets = vi.fn(() => '/tmp/credentials.json');
   const readStoredRuntimeSecret = vi.fn(() => null);
   const readStoredRuntimeSecrets = vi.fn(() => ({}));
   const loadSkillCatalog = vi.fn(() => [
@@ -1209,6 +1210,7 @@ async function importFreshCli(options?: {
     readStoredRuntimeSecret,
     readStoredRuntimeSecrets,
     runtimeSecretsPath: vi.fn(() => '/tmp/credentials.json'),
+    saveNamedRuntimeSecrets,
     saveRuntimeSecrets,
   }));
   vi.doMock('../src/tui.ts', () => {
@@ -1312,6 +1314,7 @@ async function importFreshCli(options?: {
     readStoredRuntimeSecret,
     readStoredRuntimeSecrets,
     saveRuntimeSecrets,
+    saveNamedRuntimeSecrets,
     ensureRuntimeConfigFile,
     clearRuntimeConfigRevisions,
     deleteRuntimeConfigRevision,
@@ -3717,6 +3720,57 @@ describe('CLI hybridai commands', () => {
     expect(loginCodexInteractive).toHaveBeenCalledWith({
       method: 'browser-pkce',
     });
+  });
+
+  it('prompts once for interactive Google OAuth login values', async () => {
+    const originalStdinTty = process.stdin.isTTY;
+    const originalStdoutTty = process.stdout.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+
+    try {
+      const { cli, readlineCreateInterface, readlineQuestion, readlineClose } =
+        await importFreshCli({
+          promptResponses: [
+            'you@example.com',
+            'desktop-client-id',
+            'desktop-client-secret',
+          ],
+        });
+
+      await cli.main([
+        'auth',
+        'login',
+        'google',
+        '--refresh-token',
+        'refresh-token',
+      ]);
+
+      expect(readlineCreateInterface).toHaveBeenCalledTimes(1);
+      expect(readlineQuestion).toHaveBeenCalledWith('Google account email: ');
+      expect(readlineQuestion).toHaveBeenCalledWith(
+        'Google OAuth desktop client id: ',
+      );
+      expect(readlineQuestion).toHaveBeenCalledWith(
+        '🔒 Paste Google OAuth desktop client secret: ',
+      );
+      expect(readlineClose).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: originalStdinTty,
+        configurable: true,
+      });
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: originalStdoutTty,
+        configurable: true,
+      });
+    }
   });
 
   it('rejects conflicting codex login flags', async () => {

--- a/tests/container-runner.redaction.test.ts
+++ b/tests/container-runner.redaction.test.ts
@@ -50,7 +50,7 @@ afterEach(() => {
   restoreEnvVar('HOME', ORIGINAL_HOME);
 });
 
-test('ContainerExecutor redacts result and error strings from agent output', async () => {
+test('ContainerExecutor preserves user-visible result and error strings from agent output', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;
   vi.resetModules();
@@ -58,10 +58,10 @@ test('ContainerExecutor redacts result and error strings from agent output', asy
   const spawn = vi.fn(() => makeFakeChildProcess() as never);
   const readOutput = vi.fn(async () => ({
     status: 'error' as const,
-    result: 'OPENAI_API_KEY=sk-1234567890abcdefghijklmnop',
+    result: 'Invited max.noller@hybridai.one and stephan.noller@hybridai.one.',
     toolsUsed: [],
     artifacts: [],
-    error: 'Authorization: Bearer 1234567890abcdefghijklmnopqrstuv',
+    error: 'Could not notify max.noller@hybridai.one.',
   }));
   const resolveModelRuntimeCredentials = vi.fn(async () => ({
     provider: 'hybridai' as const,
@@ -127,8 +127,99 @@ test('ContainerExecutor redacts result and error strings from agent output', asy
     channelId: 'tui',
   });
 
-  expect(output.result).toBe('OPENAI_API_KEY=sk-123...mnop');
-  expect(output.error).toBe('Authorization: Bearer 123456...stuv');
+  expect(output.result).toBe(
+    'Invited max.noller@hybridai.one and stephan.noller@hybridai.one.',
+  );
+  expect(output.error).toBe('Could not notify max.noller@hybridai.one.');
+});
+
+test('ContainerExecutor preserves user-visible streamed text deltas', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+
+  const proc = makeFakeChildProcess();
+  const spawn = vi.fn(() => proc as never);
+  const readOutput = vi.fn(async () => {
+    const delta = Buffer.from(
+      'Invited max.noller@hybridai.one.',
+      'utf-8',
+    ).toString('base64');
+    proc.stderr.emit('data', Buffer.from(`[stream] ${delta}\n`));
+    return {
+      status: 'success' as const,
+      result: 'ok',
+      toolsUsed: [],
+      artifacts: [],
+    };
+  });
+  const resolveModelRuntimeCredentials = vi.fn(async () => ({
+    provider: 'hybridai' as const,
+    apiKey: '',
+    baseUrl: 'https://hybridai.one',
+    chatbotId: 'bot-a',
+    enableRag: false,
+    requestHeaders: {},
+    agentId: 'default',
+    isLocal: false,
+    contextWindow: 128_000,
+    thinkingFormat: undefined,
+  }));
+
+  vi.doMock('node:child_process', async () => {
+    const actual =
+      await vi.importActual<typeof import('node:child_process')>(
+        'node:child_process',
+      );
+    return {
+      ...actual,
+      spawn,
+    };
+  });
+  vi.doMock('../src/infra/ipc.js', async () => {
+    const actual = await vi.importActual<typeof import('../src/infra/ipc.js')>(
+      '../src/infra/ipc.js',
+    );
+    return {
+      ...actual,
+      readOutput,
+    };
+  });
+  vi.doMock('../src/providers/factory.js', async () => {
+    const actual = await vi.importActual<
+      typeof import('../src/providers/factory.js')
+    >('../src/providers/factory.js');
+    return {
+      ...actual,
+      resolveModelRuntimeCredentials,
+    };
+  });
+  vi.doMock('../src/logger.js', () => ({
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  }));
+
+  const { ContainerExecutor } = await import(
+    '../src/infra/container-runner.js'
+  );
+  const executor = new ContainerExecutor();
+  const deltas: string[] = [];
+  await executor.exec({
+    sessionId: 'session-stream-visible',
+    messages: [{ role: 'user', content: 'hello' }],
+    chatbotId: 'bot-a',
+    enableRag: false,
+    model: 'gpt-5',
+    agentId: 'default',
+    channelId: 'tui',
+    onTextDelta: (delta) => deltas.push(delta),
+  });
+
+  expect(deltas).toEqual(['Invited max.noller@hybridai.one.']);
 });
 
 test('ContainerExecutor preserves approval ids while redacting approval text fields', async () => {

--- a/tests/container-runner.redaction.test.ts
+++ b/tests/container-runner.redaction.test.ts
@@ -58,10 +58,12 @@ test('ContainerExecutor preserves user-visible result and error strings from age
   const spawn = vi.fn(() => makeFakeChildProcess() as never);
   const readOutput = vi.fn(async () => ({
     status: 'error' as const,
-    result: 'Invited max.noller@hybridai.one and stephan.noller@hybridai.one.',
+    result:
+      'Invited max.noller@hybridai.one and used OPENAI_API_KEY=sk-1234567890abcdefghijklmnop.',
     toolsUsed: [],
     artifacts: [],
-    error: 'Could not notify max.noller@hybridai.one.',
+    error:
+      'Could not notify stephan.noller@hybridai.one with Authorization: Bearer 1234567890abcdefghijklmnopqrstuv',
   }));
   const resolveModelRuntimeCredentials = vi.fn(async () => ({
     provider: 'hybridai' as const,
@@ -128,12 +130,14 @@ test('ContainerExecutor preserves user-visible result and error strings from age
   });
 
   expect(output.result).toBe(
-    'Invited max.noller@hybridai.one and stephan.noller@hybridai.one.',
+    'Invited max.noller@hybridai.one and used OPENAI_API_KEY=sk-123...mnop.',
   );
-  expect(output.error).toBe('Could not notify max.noller@hybridai.one.');
+  expect(output.error).toBe(
+    'Could not notify stephan.noller@hybridai.one with Authorization: Bearer 123456...stuv',
+  );
 });
 
-test('ContainerExecutor preserves user-visible streamed text deltas', async () => {
+test('ContainerExecutor preserves user-visible streamed text and tool progress while redacting credentials', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;
   vi.resetModules();
@@ -142,10 +146,16 @@ test('ContainerExecutor preserves user-visible streamed text deltas', async () =
   const spawn = vi.fn(() => proc as never);
   const readOutput = vi.fn(async () => {
     const delta = Buffer.from(
-      'Invited max.noller@hybridai.one.',
+      'Invited max.noller@hybridai.one with token sk-1234567890abcdefghijklmnop.',
       'utf-8',
     ).toString('base64');
     proc.stderr.emit('data', Buffer.from(`[stream] ${delta}\n`));
+    proc.stderr.emit(
+      'data',
+      Buffer.from(
+        '[tool] bash result (12ms): emailed user@example.com with OPENAI_API_KEY=sk-1234567890abcdefghijklmnop\n',
+      ),
+    );
     return {
       status: 'success' as const,
       result: 'ok',
@@ -208,6 +218,7 @@ test('ContainerExecutor preserves user-visible streamed text deltas', async () =
   );
   const executor = new ContainerExecutor();
   const deltas: string[] = [];
+  const toolEvents: Array<{ preview?: string }> = [];
   await executor.exec({
     sessionId: 'session-stream-visible',
     messages: [{ role: 'user', content: 'hello' }],
@@ -217,12 +228,18 @@ test('ContainerExecutor preserves user-visible streamed text deltas', async () =
     agentId: 'default',
     channelId: 'tui',
     onTextDelta: (delta) => deltas.push(delta),
+    onToolProgress: (event) => toolEvents.push(event),
   });
 
-  expect(deltas).toEqual(['Invited max.noller@hybridai.one.']);
+  expect(deltas).toEqual([
+    'Invited max.noller@hybridai.one with token sk-123...mnop.',
+  ]);
+  expect(toolEvents[0]?.preview).toBe(
+    'emailed user@example.com with OPENAI_API_KEY=sk-123...mnop',
+  );
 });
 
-test('ContainerExecutor preserves approval ids while redacting approval text fields', async () => {
+test('ContainerExecutor preserves user-visible approval details while redacting credentials', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;
   vi.resetModules();
@@ -236,7 +253,7 @@ test('ContainerExecutor preserves approval ids while redacting approval text fie
     pendingApproval: {
       approvalId: '089 4233232',
       prompt:
-        'I need your approval before I call +49 170 3330160 and contact user@example.com.',
+        'I need your approval before I call +49 170 3330160, contact user@example.com, and use OPENAI_API_KEY=sk-1234567890abcdefghijklmnop.',
       intent: 'contact +49 170 3330160',
       reason: 'notify user@example.com',
       allowSession: true,
@@ -310,10 +327,13 @@ test('ContainerExecutor preserves approval ids while redacting approval text fie
   });
 
   expect(output.pendingApproval?.approvalId).toBe('089 4233232');
-  expect(output.pendingApproval?.prompt).toContain('***PHONE_REDACTED***');
-  expect(output.pendingApproval?.prompt).toContain('***EMAIL_REDACTED***');
-  expect(output.pendingApproval?.intent).toContain('***PHONE_REDACTED***');
-  expect(output.pendingApproval?.reason).toContain('***EMAIL_REDACTED***');
+  expect(output.pendingApproval?.prompt).toContain('+49 170 3330160');
+  expect(output.pendingApproval?.prompt).toContain('user@example.com');
+  expect(output.pendingApproval?.prompt).toContain(
+    'OPENAI_API_KEY=sk-123...mnop',
+  );
+  expect(output.pendingApproval?.intent).toContain('+49 170 3330160');
+  expect(output.pendingApproval?.reason).toContain('user@example.com');
 });
 
 test('ContainerExecutor stops and respawns a timed out pooled container', async () => {

--- a/tests/container.message-tool-normalization.test.ts
+++ b/tests/container.message-tool-normalization.test.ts
@@ -6,6 +6,7 @@ import {
   getMessageToolDescription,
   setGatewayContext,
   setSessionContext,
+  TOOL_DEFINITIONS,
 } from '../container/src/tools.js';
 
 const CHANNEL_ID = '1475079601968648386';
@@ -320,18 +321,32 @@ describe.sequential('container message tool normalization', () => {
     expect(payload.filePath).toBe('package.json');
   });
 
-  test('message tool description does not treat WhatsApp chat as a Discord channel', () => {
+  test('message tool description does not advertise inactive WhatsApp', () => {
     setGatewayContext(
       'http://gateway.local',
       'token',
       '491234567890@s.whatsapp.net',
     );
 
-    const description = getMessageToolDescription();
+    const description = getMessageToolDescription(undefined, []);
     expect(description).not.toContain('491234567890@s.whatsapp.net');
-    expect(description).toContain('Supports actions:');
-    expect(description).toContain('WhatsApp');
-    expect(description).toContain('ingested email thread history');
+    expect(description).toContain('Active channels: none.');
+    expect(description).not.toContain('WhatsApp');
+    expect(description).not.toContain('ingested email thread history');
+  });
+
+  test('message tool schema keeps channel descriptions generic', () => {
+    const messageTool = TOOL_DEFINITIONS.find(
+      (tool) => tool.function.name === 'message',
+    );
+    const schemaText = JSON.stringify(messageTool?.function ?? {});
+
+    expect(schemaText).toContain(
+      'Message target or channel selector for send/read actions.',
+    );
+    expect(schemaText).not.toContain('WhatsApp JIDs');
+    expect(schemaText).not.toContain('email addresses');
+    expect(schemaText).not.toContain('Discord-only');
   });
 
   test('message tool description advertises current Teams send support', () => {
@@ -342,10 +357,11 @@ describe.sequential('container message tool normalization', () => {
     );
     setSessionContext('teams:dm:user-aad-id');
 
-    const description = getMessageToolDescription();
+    const description = getMessageToolDescription(undefined, ['msteams']);
     expect(description).toContain(
       'Current Teams conversation (a:teams-current-conversation) supports: send.',
     );
+    expect(description).toContain('Active channels: Microsoft Teams.');
     expect(description).toContain('current Teams conversation for send');
   });
 
@@ -356,8 +372,9 @@ describe.sequential('container message tool normalization', () => {
       otherChannelId,
     ]);
 
-    const description = getMessageToolDescription(CHANNEL_ID);
+    const description = getMessageToolDescription(CHANNEL_ID, ['discord']);
     expect(description).toContain(`Current Discord channel (${CHANNEL_ID})`);
+    expect(description).toContain('Active channels: Discord.');
     expect(description).toContain(
       `Other configured channels: ${otherChannelId} (`,
     );

--- a/tests/host-runner.redaction.test.ts
+++ b/tests/host-runner.redaction.test.ts
@@ -63,7 +63,7 @@ function mockHostRuntimeReady(): void {
   }));
 }
 
-test('HostExecutor redacts result and error strings from agent output', async () => {
+test('HostExecutor preserves user-visible result and error strings from agent output', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;
   vi.resetModules();
@@ -71,10 +71,10 @@ test('HostExecutor redacts result and error strings from agent output', async ()
   const spawn = vi.fn(() => makeFakeChildProcess() as never);
   const readOutput = vi.fn(async () => ({
     status: 'error' as const,
-    result: 'OPENAI_API_KEY=sk-1234567890abcdefghijklmnop',
+    result: 'Invited max.noller@hybridai.one and stephan.noller@hybridai.one.',
     toolsUsed: [],
     artifacts: [],
-    error: 'Authorization: Bearer 1234567890abcdefghijklmnopqrstuv',
+    error: 'Could not notify max.noller@hybridai.one.',
   }));
   const resolveModelRuntimeCredentials = vi.fn(async () => ({
     provider: 'hybridai' as const,
@@ -139,8 +139,98 @@ test('HostExecutor redacts result and error strings from agent output', async ()
     channelId: 'tui',
   });
 
-  expect(output.result).toBe('OPENAI_API_KEY=sk-123...mnop');
-  expect(output.error).toBe('Authorization: Bearer 123456...stuv');
+  expect(output.result).toBe(
+    'Invited max.noller@hybridai.one and stephan.noller@hybridai.one.',
+  );
+  expect(output.error).toBe('Could not notify max.noller@hybridai.one.');
+});
+
+test('HostExecutor preserves user-visible streamed text deltas', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+
+  const proc = makeFakeChildProcess();
+  const spawn = vi.fn(() => proc as never);
+  const readOutput = vi.fn(async () => {
+    const delta = Buffer.from(
+      'Invited max.noller@hybridai.one.',
+      'utf-8',
+    ).toString('base64');
+    proc.stderr.emit('data', Buffer.from(`[stream] ${delta}\n`));
+    return {
+      status: 'success' as const,
+      result: 'ok',
+      toolsUsed: [],
+      artifacts: [],
+    };
+  });
+  const resolveModelRuntimeCredentials = vi.fn(async () => ({
+    provider: 'hybridai' as const,
+    apiKey: '',
+    baseUrl: 'https://hybridai.one',
+    chatbotId: 'bot-a',
+    enableRag: false,
+    requestHeaders: {},
+    agentId: 'default',
+    isLocal: false,
+    contextWindow: 128_000,
+    thinkingFormat: undefined,
+  }));
+
+  vi.doMock('node:child_process', async () => {
+    const actual =
+      await vi.importActual<typeof import('node:child_process')>(
+        'node:child_process',
+      );
+    return {
+      ...actual,
+      spawn,
+    };
+  });
+  vi.doMock('../src/infra/ipc.js', async () => {
+    const actual = await vi.importActual<typeof import('../src/infra/ipc.js')>(
+      '../src/infra/ipc.js',
+    );
+    return {
+      ...actual,
+      readOutput,
+    };
+  });
+  vi.doMock('../src/providers/factory.js', async () => {
+    const actual = await vi.importActual<
+      typeof import('../src/providers/factory.js')
+    >('../src/providers/factory.js');
+    return {
+      ...actual,
+      resolveModelRuntimeCredentials,
+    };
+  });
+  vi.doMock('../src/logger.js', () => ({
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  }));
+  mockHostRuntimeReady();
+
+  const { HostExecutor } = await import('../src/infra/host-runner.js');
+  const executor = new HostExecutor();
+  const deltas: string[] = [];
+  await executor.exec({
+    sessionId: 'session-stream-visible',
+    messages: [{ role: 'user', content: 'hello' }],
+    chatbotId: 'bot-a',
+    enableRag: false,
+    model: 'gpt-5',
+    agentId: 'default',
+    channelId: 'tui',
+    onTextDelta: (delta) => deltas.push(delta),
+  });
+
+  expect(deltas).toEqual(['Invited max.noller@hybridai.one.']);
 });
 
 test('HostExecutor preserves approval ids while redacting approval text fields', async () => {

--- a/tests/host-runner.redaction.test.ts
+++ b/tests/host-runner.redaction.test.ts
@@ -71,10 +71,12 @@ test('HostExecutor preserves user-visible result and error strings from agent ou
   const spawn = vi.fn(() => makeFakeChildProcess() as never);
   const readOutput = vi.fn(async () => ({
     status: 'error' as const,
-    result: 'Invited max.noller@hybridai.one and stephan.noller@hybridai.one.',
+    result:
+      'Invited max.noller@hybridai.one and used OPENAI_API_KEY=sk-1234567890abcdefghijklmnop.',
     toolsUsed: [],
     artifacts: [],
-    error: 'Could not notify max.noller@hybridai.one.',
+    error:
+      'Could not notify stephan.noller@hybridai.one with Authorization: Bearer 1234567890abcdefghijklmnopqrstuv',
   }));
   const resolveModelRuntimeCredentials = vi.fn(async () => ({
     provider: 'hybridai' as const,
@@ -140,12 +142,14 @@ test('HostExecutor preserves user-visible result and error strings from agent ou
   });
 
   expect(output.result).toBe(
-    'Invited max.noller@hybridai.one and stephan.noller@hybridai.one.',
+    'Invited max.noller@hybridai.one and used OPENAI_API_KEY=sk-123...mnop.',
   );
-  expect(output.error).toBe('Could not notify max.noller@hybridai.one.');
+  expect(output.error).toBe(
+    'Could not notify stephan.noller@hybridai.one with Authorization: Bearer 123456...stuv',
+  );
 });
 
-test('HostExecutor preserves user-visible streamed text deltas', async () => {
+test('HostExecutor preserves user-visible streamed text and tool progress while redacting credentials', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;
   vi.resetModules();
@@ -154,10 +158,16 @@ test('HostExecutor preserves user-visible streamed text deltas', async () => {
   const spawn = vi.fn(() => proc as never);
   const readOutput = vi.fn(async () => {
     const delta = Buffer.from(
-      'Invited max.noller@hybridai.one.',
+      'Invited max.noller@hybridai.one with token sk-1234567890abcdefghijklmnop.',
       'utf-8',
     ).toString('base64');
     proc.stderr.emit('data', Buffer.from(`[stream] ${delta}\n`));
+    proc.stderr.emit(
+      'data',
+      Buffer.from(
+        '[tool] bash result (12ms): emailed user@example.com with OPENAI_API_KEY=sk-1234567890abcdefghijklmnop\n',
+      ),
+    );
     return {
       status: 'success' as const,
       result: 'ok',
@@ -219,6 +229,7 @@ test('HostExecutor preserves user-visible streamed text deltas', async () => {
   const { HostExecutor } = await import('../src/infra/host-runner.js');
   const executor = new HostExecutor();
   const deltas: string[] = [];
+  const toolEvents: Array<{ preview?: string }> = [];
   await executor.exec({
     sessionId: 'session-stream-visible',
     messages: [{ role: 'user', content: 'hello' }],
@@ -228,12 +239,18 @@ test('HostExecutor preserves user-visible streamed text deltas', async () => {
     agentId: 'default',
     channelId: 'tui',
     onTextDelta: (delta) => deltas.push(delta),
+    onToolProgress: (event) => toolEvents.push(event),
   });
 
-  expect(deltas).toEqual(['Invited max.noller@hybridai.one.']);
+  expect(deltas).toEqual([
+    'Invited max.noller@hybridai.one with token sk-123...mnop.',
+  ]);
+  expect(toolEvents[0]?.preview).toBe(
+    'emailed user@example.com with OPENAI_API_KEY=sk-123...mnop',
+  );
 });
 
-test('HostExecutor preserves approval ids while redacting approval text fields', async () => {
+test('HostExecutor preserves user-visible approval details while redacting credentials', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;
   vi.resetModules();
@@ -247,7 +264,7 @@ test('HostExecutor preserves approval ids while redacting approval text fields',
     pendingApproval: {
       approvalId: '089 4233232',
       prompt:
-        'I need your approval before I call +49 170 3330160 and contact user@example.com.',
+        'I need your approval before I call +49 170 3330160, contact user@example.com, and use OPENAI_API_KEY=sk-1234567890abcdefghijklmnop.',
       intent: 'contact +49 170 3330160',
       reason: 'notify user@example.com',
       allowSession: true,
@@ -320,10 +337,13 @@ test('HostExecutor preserves approval ids while redacting approval text fields',
   });
 
   expect(output.pendingApproval?.approvalId).toBe('089 4233232');
-  expect(output.pendingApproval?.prompt).toContain('***PHONE_REDACTED***');
-  expect(output.pendingApproval?.prompt).toContain('***EMAIL_REDACTED***');
-  expect(output.pendingApproval?.intent).toContain('***PHONE_REDACTED***');
-  expect(output.pendingApproval?.reason).toContain('***EMAIL_REDACTED***');
+  expect(output.pendingApproval?.prompt).toContain('+49 170 3330160');
+  expect(output.pendingApproval?.prompt).toContain('user@example.com');
+  expect(output.pendingApproval?.prompt).toContain(
+    'OPENAI_API_KEY=sk-123...mnop',
+  );
+  expect(output.pendingApproval?.intent).toContain('+49 170 3330160');
+  expect(output.pendingApproval?.reason).toContain('user@example.com');
 });
 
 test('HostExecutor exposes the uploaded media cache root to host agent processes', async () => {

--- a/tests/hybridai-client.test.ts
+++ b/tests/hybridai-client.test.ts
@@ -231,6 +231,33 @@ test('callRoutedModelStream forwards stream and max_tokens', async () => {
   expect(fetchMock).toHaveBeenCalledTimes(1);
 });
 
+test('callRoutedModelStream does not duplicate HybridAI chunks with message and delta content', async () => {
+  const deltas: string[] = [];
+  const fetchMock = vi.fn(async () =>
+    makeEventStreamResponse([
+      'data: {"id":"resp_stream","model":"gpt-5-nano","choices":[{"message":{"role":"assistant","content":"Hello"},"delta":{"role":"assistant","content":"Hello"}}]}\n\n',
+      'data: {"id":"resp_stream","model":"gpt-5-nano","choices":[{"message":{"role":"assistant","content":"Hello world"},"delta":{"content":" world"},"finish_reason":"stop"}]}\n\n',
+      'data: [DONE]\n\n',
+    ]),
+  );
+  vi.stubGlobal('fetch', fetchMock);
+
+  const result = await callRoutedModelStream({
+    provider: 'hybridai',
+    baseUrl: 'https://hybridai.one',
+    apiKey: 'test-key',
+    model: 'gpt-5-nano',
+    chatbotId: 'bot_1',
+    enableRag: true,
+    messages: [{ role: 'user', content: 'hello' }],
+    tools: [],
+    onTextDelta: (delta) => deltas.push(delta),
+  });
+
+  expect(deltas).toEqual(['Hello', ' world']);
+  expect(result.choices[0]?.message.content).toBe('Hello world');
+});
+
 test('callRoutedModelStream parses Codex SSE text deltas and tool calls', async () => {
   const deltas: string[] = [];
   const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {

--- a/tests/hybridai-client.test.ts
+++ b/tests/hybridai-client.test.ts
@@ -258,6 +258,32 @@ test('callRoutedModelStream does not duplicate HybridAI chunks with message and 
   expect(result.choices[0]?.message.content).toBe('Hello world');
 });
 
+test('callRoutedModelStream preserves delta content when message content is empty', async () => {
+  const deltas: string[] = [];
+  const fetchMock = vi.fn(async () =>
+    makeEventStreamResponse([
+      'data: {"id":"resp_stream","model":"gpt-5-nano","choices":[{"message":{"role":"assistant","content":""},"delta":{"role":"assistant","content":"Hello"}}]}\n\n',
+      'data: [DONE]\n\n',
+    ]),
+  );
+  vi.stubGlobal('fetch', fetchMock);
+
+  const result = await callRoutedModelStream({
+    provider: 'hybridai',
+    baseUrl: 'https://hybridai.one',
+    apiKey: 'test-key',
+    model: 'gpt-5-nano',
+    chatbotId: 'bot_1',
+    enableRag: true,
+    messages: [{ role: 'user', content: 'hello' }],
+    tools: [],
+    onTextDelta: (delta) => deltas.push(delta),
+  });
+
+  expect(deltas).toEqual(['Hello']);
+  expect(result.choices[0]?.message.content).toBe('Hello');
+});
+
 test('callRoutedModelStream parses Codex SSE text deltas and tool calls', async () => {
   const deltas: string[] = [];
   const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {

--- a/tests/ipc.test.ts
+++ b/tests/ipc.test.ts
@@ -46,6 +46,10 @@ test('writeInput omits auth material from IPC files when requested', async () =>
     },
     model: 'openai-codex/gpt-5-codex',
     channelId: 'channel-1',
+    runtimeEnv: {
+      GOG_ACCESS_TOKEN: 'short-lived-access-token',
+      GOG_ACCOUNT: 'user@example.com',
+    },
     taskModels: {
       compression: {
         provider: 'openrouter' as const,
@@ -70,6 +74,10 @@ test('writeInput omits auth material from IPC files when requested', async () =>
 
   expect(written.apiKey).toBe('');
   expect(written.requestHeaders).toEqual({});
+  expect(written.runtimeEnv).toEqual({
+    GOG_ACCESS_TOKEN: 'short-lived-access-token',
+    GOG_ACCOUNT: 'user@example.com',
+  });
   expect(written.taskModels).toEqual({
     compression: {
       provider: 'openrouter',

--- a/tests/prompt-hooks.tool-summary.test.ts
+++ b/tests/prompt-hooks.tool-summary.test.ts
@@ -6,7 +6,10 @@ import {
 } from '../src/agent/prompt-hooks.js';
 import { buildToolsSummary } from '../src/agent/tool-summary.js';
 import { EMAIL_CAPABILITIES } from '../src/channels/channel.js';
-import { registerChannel } from '../src/channels/channel-registry.js';
+import {
+  registerChannel,
+  unregisterChannel,
+} from '../src/channels/channel-registry.js';
 import * as runtimeConfig from '../src/config/runtime-config.js';
 import * as providerFactory from '../src/providers/factory.js';
 import type { Skill } from '../src/skills/skills.js';
@@ -136,13 +139,10 @@ test('buildSystemPromptFromHooks adds mandatory routing instructions for availab
     'For fresh deliverable-generation tasks from a folder of source files, use the primary source inputs directly and create a new output.',
   );
   expect(prompt).toContain(
-    'For channel catch-up or recap requests with partial scope, infer a reasonable recent scope from available context, do a best-effort read first, and note assumptions after the summary instead of blocking on a clarification.',
+    'Use the `message` tool for sending or reading messages on active communication channels: none.',
   );
   expect(prompt).toContain(
-    'For local Discord, the current Teams conversation, WhatsApp, or email uploads, call `message` with `action="send"` and `filePath` pointing to a file in the current workspace or `/discord-media-cache`.',
-  );
-  expect(prompt).toContain(
-    'If you already created a file earlier in this session and the user asks to post/upload/send it here, reuse that existing `filePath` with `message action="send"` instead of replying with the path alone.',
+    'No active communication channels are registered right now.',
   );
   expect(prompt).toContain(
     'When the user asks you to create or generate a file and return/upload/post it, include the file immediately in the final delivery. Do not ask a follow-up question offering to upload it later.',
@@ -174,22 +174,8 @@ test('buildSystemPromptFromHooks adds mandatory routing instructions for availab
   expect(prompt).toContain(
     'Never write plain text placeholder content to binary office files such as `.docx`, `.xlsx`, `.pptx`, or `.pdf`. If generation fails, report the error instead of creating a fake file.',
   );
-  expect(prompt).toContain(
-    'User: "Post `invoices/dashboard.html.png` here on Discord"',
-  );
-  expect(prompt).toContain(
-    'Tool call: `message` {"action":"send","filePath":"invoices/dashboard.html.png"}',
-  );
-  expect(prompt).toContain(
-    'User: "Post `.browser-artifacts/hybridclaw-homepage.png` here in Teams"',
-  );
-  expect(prompt).toContain(
-    'Earlier in this session you created `.browser-artifacts/hybridclaw-homepage.png`.',
-  );
-  expect(prompt).toContain('User: "Post screenshot here"');
-  expect(prompt).toContain(
-    'User: "Send this to WhatsApp +491701234567: landed safely"',
-  );
+  expect(prompt).not.toContain('Send this to WhatsApp');
+  expect(prompt).not.toContain('Post this file in the current Teams chat');
   expect(prompt).toContain(
     'Tool call: `cron` {"action":"add","at":"2026-04-10T09:00:00+02:00","prompt":"Reply with: submit report"}',
   );
@@ -197,7 +183,7 @@ test('buildSystemPromptFromHooks adds mandatory routing instructions for availab
     'User: "Pull the key fields from this attached invoice PDF."',
   );
   expect(prompt).toContain(
-    'Action: use that attachment content directly; do not call `message` `read`, `glob`, `find`, or read `skills/pdf/SKILL.md` first.',
+    'Action: use that attachment content directly and answer from the extracted text.',
   );
   expect(prompt).toContain(
     'Use `http_request` for direct API calls that need a specific method, headers, JSON body, or secret-backed auth injection. Prefer it over `bash` + `curl` for HTTP APIs.',
@@ -369,23 +355,32 @@ test('buildSystemPromptFromHooks includes email signature guidance for email con
     capabilities: EMAIL_CAPABILITIES,
   });
 
-  const prompt = buildSystemPromptFromHooks({
-    agentId: 'test-agent',
-    skills: [],
-    runtimeInfo: {
-      channelType: 'email',
-      channelId: 'peer@example.com',
-    },
-  });
+  try {
+    const prompt = buildSystemPromptFromHooks({
+      agentId: 'test-agent',
+      skills: [],
+      runtimeInfo: {
+        channelType: 'email',
+        channelId: 'peer@example.com',
+      },
+    });
 
-  expect(prompt).toContain('Current email peer: `peer@example.com`');
-  expect(prompt).toContain(
-    'append a polished corporate signature block derived from the identity details already loaded from `IDENTITY.md`',
-  );
-  expect(prompt).toContain('do not use emoji or mascot-style sign-offs');
-  expect(prompt).toContain(
-    'make a reasonable best-effort assumption, do the useful work first, and mention the assumption after the answer',
-  );
+    expect(prompt).toContain('Current email peer: `peer@example.com`');
+    expect(prompt).toContain(
+      'Use the `message` tool for sending or reading messages on active communication channels: email.',
+    );
+    expect(prompt).toContain('Email: send email and read ingested email');
+    expect(prompt).not.toContain('WhatsApp: send messages');
+    expect(prompt).toContain(
+      'append a polished corporate signature block derived from the identity details already loaded from `IDENTITY.md`',
+    );
+    expect(prompt).toContain('do not use emoji or mascot-style sign-offs');
+    expect(prompt).toContain(
+      'make a reasonable best-effort assumption, do the useful work first, and mention the assumption after the answer',
+    );
+  } finally {
+    unregisterChannel('email');
+  }
 });
 
 test('buildSystemPromptFromHooks includes spoken-output guidance for voice context without channel registration', () => {

--- a/tests/redact.test.ts
+++ b/tests/redact.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, expect, test, vi } from 'vitest';
 
 import {
+  redactCredentialSecrets,
   redactHighEntropyStrings,
   redactSecrets,
   redactSecretsDeep,
@@ -166,6 +167,17 @@ test('redacts pii while preserving the GitHub noreply allowlist', () => {
   );
   expect(redactSecrets('Number: 1234567890123456')).toBe(
     'Number: 1234567890123456',
+  );
+});
+
+test('redacts credential secrets without masking user-visible contact details', () => {
+  expect(
+    redactCredentialSecrets(
+      'Invite user@example.com with OPENAI_API_KEY=sk-1234567890abcdefghijklmnop',
+    ),
+  ).toBe('Invite user@example.com with OPENAI_API_KEY=sk-123...mnop');
+  expect(redactCredentialSecrets('Call +49 170 3330160')).toBe(
+    'Call +49 170 3330160',
   );
 });
 

--- a/tests/skill-resolution.integration.test.ts
+++ b/tests/skill-resolution.integration.test.ts
@@ -109,6 +109,12 @@ describe('skill resolution integration', () => {
     expect(gogSkill?.description).toContain('Google Calendar');
     expect(gogSkill?.description).toContain('events');
     expect(gogSkill?.description).toContain('meetings');
+    const gogSkillBody = fs.readFileSync(
+      path.resolve('skills/gog/SKILL.md'),
+      'utf-8',
+    );
+    expect(gogSkillBody).toContain('searches all available calendars');
+    expect(gogSkillBody).toContain('Do not pipe `gog ... --json`');
     expect(googleWorkspaceSkill).toContain(
       'API-backed Google Workspace access',
     );

--- a/tests/skill-resolution.integration.test.ts
+++ b/tests/skill-resolution.integration.test.ts
@@ -98,7 +98,7 @@ describe('skill resolution integration', () => {
     expect(pdfSkill?.description).toContain('invoice/document parsing');
   });
 
-  it('advertises gog for Google Calendar API-backed Workspace access', () => {
+  it('advertises gog for Google Calendar event access', () => {
     const catalog = skillsMod.loadSkillCatalog();
     const gogSkill = catalog.find((skill) => skill.name === 'gog');
     const googleWorkspaceSkill = fs.readFileSync(
@@ -107,6 +107,8 @@ describe('skill resolution integration', () => {
     );
 
     expect(gogSkill?.description).toContain('Google Calendar');
+    expect(gogSkill?.description).toContain('events');
+    expect(gogSkill?.description).toContain('meetings');
     expect(googleWorkspaceSkill).toContain(
       'API-backed Google Workspace access',
     );

--- a/tests/skill-resolution.integration.test.ts
+++ b/tests/skill-resolution.integration.test.ts
@@ -98,6 +98,20 @@ describe('skill resolution integration', () => {
     expect(pdfSkill?.description).toContain('invoice/document parsing');
   });
 
+  it('advertises gog for Google Calendar API-backed Workspace access', () => {
+    const catalog = skillsMod.loadSkillCatalog();
+    const gogSkill = catalog.find((skill) => skill.name === 'gog');
+    const googleWorkspaceSkill = fs.readFileSync(
+      path.resolve('skills/google-workspace/SKILL.md'),
+      'utf-8',
+    );
+
+    expect(gogSkill?.description).toContain('Google Calendar');
+    expect(googleWorkspaceSkill).toContain(
+      'API-backed Google Workspace access',
+    );
+  });
+
   it('SKILL.md with valid frontmatter parses correctly (name, description, category, tags)', () => {
     const extraDir = path.join(tmpDir, 'extra-skills');
     writeSkill(


### PR DESCRIPTION
## Summary
- add a bundled `gog` skill for deterministic Google Workspace CLI workflows
- add `hybridclaw auth login|status|logout google` to store Google OAuth material in encrypted runtime secrets
- mint short-lived Google access tokens host-side and pass only `GOG_ACCESS_TOKEN` / `GOG_ACCOUNT` into agent runtimes

## Validation
- `npm run format`
- `npm --prefix container run lint`
- `npm run typecheck`