### PR TITLE
fix(honcho-memory): await in-flight prefetch in getContextForPrompt

### DIFF
--- a/plugins/honcho-memory/src/honcho-runtime.js
+++ b/plugins/honcho-memory/src/honcho-runtime.js
@@ -310,6 +310,12 @@ export class HonchoRuntime {
 
     const contextEntry = this.contextPrefetch.get(params.sessionId);
     const dialecticEntry = this.dialecticPrefetch.get(params.sessionId);
+    if (contextEntry?.status === 'pending' && contextEntry.promise) {
+      await contextEntry.promise;
+    }
+    if (dialecticEntry?.status === 'pending' && dialecticEntry.promise) {
+      await dialecticEntry.promise;
+    }
     let payload =
       contextEntry?.status === 'fulfilled' ? contextEntry.value : null;
     const dialectic =
@@ -613,9 +619,10 @@ export class HonchoRuntime {
     const entry = {
       status: 'pending',
       value: null,
+      promise: null,
     };
     this.contextPrefetch.set(sessionContext.platformSessionId, entry);
-    void (async () => {
+    entry.promise = (async () => {
       try {
         const payload = await this.fetchPromptContextPayload(sessionContext);
         entry.status = 'fulfilled';
@@ -638,9 +645,10 @@ export class HonchoRuntime {
     const entry = {
       status: 'pending',
       value: '',
+      promise: null,
     };
     this.dialecticPrefetch.set(sessionContext.platformSessionId, entry);
-    void (async () => {
+    entry.promise = (async () => {
       try {
         const value = await this.client.chatWithPeer({
           peerId: sessionContext.agentPeerId,


### PR DESCRIPTION
## Summary
- Fix flaky CI failure in `tests/honcho-memory-plugin.test.ts:1507` (`expected 4 to be 2`) that blocked main after #392.
- `notifySessionStart` → `onSessionStart` → `schedulePrefetch` kicks off background fetches but returns before the responses land. The test's `waitFor(contextRequests.length >= 2)` only confirms the stub received the requests, not that the client resolved them, so the prefetch entry could still be `pending` when `collectPromptContext` ran. `getContextForPrompt` only consumed `fulfilled` entries and fell through to a fresh fetch — producing 2 extra context requests.
- Attach the in-flight promise to each prefetch entry and `await` it in `getContextForPrompt` when still pending, so the cached payload is reused once the response resolves.

## Test plan
- [x] `npx vitest run --config vitest.unit.config.ts tests/honcho-memory-plugin.test.ts` (18/18 pass)
- [x] `npx vitest run --config vitest.unit.config.ts tests/plugin-manager.test.ts tests/gateway-service.plugins.test.ts` (all pass)
- [x] `npm run lint` clean
- [x] `npx biome check plugins/honcho-memory/src/honcho-runtime.js` clean
- [ ] Re-run CI "Unit tests with coverage" on PR