### PR TITLE
refactor(gateway): promote /chat to a top-level console SPA route

### DIFF
--- a/console/src/api/chat.ts
+++ b/console/src/api/chat.ts
@@ -11,7 +11,10 @@ import {
   dispatchAuthRequired,
   requestHeaders,
   requestJson,
+  validateToken,
 } from './client';
+
+export { validateToken as fetchAppStatus };
 
 export function fetchChatRecent(
   token: string,

--- a/console/src/components/sidebar/app-sidebar.tsx
+++ b/console/src/components/sidebar/app-sidebar.tsx
@@ -38,11 +38,11 @@ export function AppSidebar(props: {
   onLogout: () => void;
 }) {
   return (
-    <Sidebar collapsible="none">
+    <Sidebar collapsible="icon">
       <SidebarHeader>
         <div className={styles.headerRow}>
           <SidebarBrand />
-          <MobileSidebarTrigger />
+          <SidebarTrigger className={styles.sidebarToggle} />
         </div>
       </SidebarHeader>
       <SidebarContent>
@@ -94,12 +94,6 @@ function SidebarBrand() {
       </div>
     </div>
   );
-}
-
-function MobileSidebarTrigger() {
-  const { isMobile } = useSidebar();
-  if (!isMobile) return null;
-  return <SidebarTrigger className={styles.sidebarToggle} />;
 }
 
 function SidebarNavLink(props: { item: SidebarNavItem }) {

--- a/console/src/components/sidebar/app-sidebar.tsx
+++ b/console/src/components/sidebar/app-sidebar.tsx
@@ -41,7 +41,7 @@ export function AppSidebar(props: {
     <Sidebar collapsible="icon">
       <SidebarHeader>
         <div className={styles.headerRow}>
-          <SidebarBrand />
+          <SidebarBrand subtitle="Admin console" />
           <SidebarTrigger className={styles.sidebarToggle} />
         </div>
       </SidebarHeader>
@@ -80,7 +80,7 @@ export function AppSidebar(props: {
   );
 }
 
-function SidebarBrand() {
+export function SidebarBrand(props: { subtitle?: string }) {
   return (
     <div className={styles.brand}>
       <div className={styles.brandTitle}>
@@ -89,7 +89,9 @@ function SidebarBrand() {
         </span>
         <div className={styles.brandText}>
           <h1>HybridClaw</h1>
-          <span className={styles.eyebrow}>Admin console</span>
+          {props.subtitle ? (
+            <span className={styles.eyebrow}>{props.subtitle}</span>
+          ) : null}
         </div>
       </div>
     </div>
@@ -122,7 +124,7 @@ function SidebarNavLink(props: { item: SidebarNavItem }) {
   );
 }
 
-function SidebarMeta(props: { version?: string }) {
+export function SidebarMeta(props: { version?: string }) {
   if (!props.version) return null;
   return (
     <div className={styles.footerMeta}>

--- a/console/src/components/sidebar/app-sidebar.tsx
+++ b/console/src/components/sidebar/app-sidebar.tsx
@@ -102,6 +102,7 @@ function SidebarNavLink(props: { item: SidebarNavItem }) {
   return (
     <Link
       to={props.item.to}
+      title={props.item.label}
       activeProps={{
         className: cx(styles.menuButton, styles.menuButtonActive),
       }}

--- a/console/src/components/sidebar/index.module.css
+++ b/console/src/components/sidebar/index.module.css
@@ -201,22 +201,21 @@
 
 .brandTitle {
   display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  min-height: 34px;
+  align-items: center;
+  gap: 12px;
+  min-height: 44px;
 }
 
 .brandText {
   display: grid;
-  gap: 1px;
+  gap: 2px;
   min-width: 0;
-  padding-top: 1px;
 }
 
 .brandTitle h1 {
   margin: 0;
-  font-size: 0.9rem;
-  font-weight: 600;
+  font-size: 1.125rem;
+  font-weight: 700;
   letter-spacing: -0.01em;
   line-height: 1.1;
 }

--- a/console/src/components/sidebar/index.module.css
+++ b/console/src/components/sidebar/index.module.css
@@ -327,6 +327,7 @@
 /* Collapsed desktop state — placed after base selectors for specificity */
 
 .root[data-state="collapsed"] {
+  flex: 0 0 var(--sidebar-width-icon);
   width: var(--sidebar-width-icon);
   overflow: hidden;
 }

--- a/console/src/components/sidebar/index.module.css
+++ b/console/src/components/sidebar/index.module.css
@@ -233,8 +233,8 @@
 }
 
 .brandMark {
-  width: 32px;
-  height: 32px;
+  width: 44px;
+  height: 44px;
   border-radius: var(--radius-sm);
   color: var(--accent-foreground);
 }
@@ -248,8 +248,8 @@
 }
 
 .brandMark svg {
-  width: 32px;
-  height: 32px;
+  width: 44px;
+  height: 44px;
 }
 
 .menuIcon svg,

--- a/console/src/components/sidebar/sidebar.test.tsx
+++ b/console/src/components/sidebar/sidebar.test.tsx
@@ -552,7 +552,7 @@ describe('AppSidebar', () => {
     expect(screen.queryByRole('button', { name: 'Forget token' })).toBeNull();
   });
 
-  it('desktop sidebar is always expanded', () => {
+  it('desktop sidebar starts expanded and exposes a collapse trigger', () => {
     const { container } = render(
       <SidebarProvider>
         <AppSidebar
@@ -564,7 +564,9 @@ describe('AppSidebar', () => {
     );
     const aside = container.querySelector('aside');
     expect(aside?.getAttribute('data-state')).toBe('expanded');
-    expect(screen.queryByRole('button', { name: /sidebar$/i })).toBeNull();
+    expect(
+      screen.queryByRole('button', { name: /collapse sidebar/i }),
+    ).not.toBeNull();
   });
 
   it('closes mobile sidebar when a nav link is clicked', () => {

--- a/console/src/components/view-switch.test.tsx
+++ b/console/src/components/view-switch.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ViewSwitchNav } from './view-switch';
+
+const mockRouterState = vi.hoisted(() => ({
+  pathname: '/chat',
+}));
+
+type MockLinkProps = {
+  to: string;
+  className?: string;
+  children: ReactNode;
+};
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ to, className, children }: MockLinkProps) => (
+    <a data-router-link="true" href={to} className={className}>
+      {children}
+    </a>
+  ),
+  useRouterState: (params: {
+    select: (state: { location: { pathname: string } }) => string;
+  }) =>
+    params.select({
+      location: { pathname: mockRouterState.pathname },
+    }),
+}));
+
+describe('ViewSwitchNav', () => {
+  beforeEach(() => {
+    mockRouterState.pathname = '/chat';
+  });
+
+  it('uses client router links only for console routes', () => {
+    mockRouterState.pathname = '/agents';
+
+    render(<ViewSwitchNav />);
+
+    expect(screen.getByRole('link', { name: 'Chat' }).dataset.routerLink).toBe(
+      'true',
+    );
+    expect(screen.getByRole('link', { name: 'Admin' }).dataset.routerLink).toBe(
+      'true',
+    );
+
+    const agentsLink = screen.getByRole('link', { name: 'Agents' });
+    expect(agentsLink.getAttribute('href')).toBe('/agents');
+    expect(agentsLink.dataset.routerLink).toBeUndefined();
+
+    const docsLink = screen.getByRole('link', { name: 'Docs' });
+    expect(docsLink.getAttribute('href')).toBe('/development');
+    expect(docsLink.dataset.routerLink).toBeUndefined();
+  });
+
+  it('marks server-owned links active by pathname', () => {
+    mockRouterState.pathname = '/agents';
+
+    render(<ViewSwitchNav />);
+
+    const agentsLink = screen.getByRole('link', { name: 'Agents' });
+    expect(agentsLink.getAttribute('aria-current')).toBe('page');
+    expect(agentsLink.className).toContain('active');
+  });
+});

--- a/console/src/components/view-switch.tsx
+++ b/console/src/components/view-switch.tsx
@@ -5,11 +5,11 @@ import { Admin, Agents, Chat, Docs, Github } from './icons';
 type ViewSwitchItem = {
   label: string;
   icon: ComponentType;
-} & ({ href: string; external: true } | { to: string; external?: false });
+} & ({ href: string; external?: boolean } | { to: string; external?: false });
 
 const VIEW_SWITCH_ITEMS: ReadonlyArray<ViewSwitchItem> = [
   { to: '/chat', label: 'Chat', icon: Chat },
-  { to: '/agents', label: 'Agents', icon: Agents },
+  { href: '/agents', label: 'Agents', icon: Agents },
   { to: '/admin', label: 'Admin', icon: Admin },
   {
     href: 'https://github.com/HybridAIOne/hybridclaw',
@@ -17,7 +17,7 @@ const VIEW_SWITCH_ITEMS: ReadonlyArray<ViewSwitchItem> = [
     icon: Github,
     external: true,
   },
-  { to: '/development', label: 'Docs', icon: Docs },
+  { href: '/development', label: 'Docs', icon: Docs },
 ];
 
 function isActive(pathname: string, path: string): boolean {
@@ -40,14 +40,18 @@ export function ViewSwitchNav() {
             <span>{item.label}</span>
           </>
         );
-        if (item.external) {
+        if ('href' in item) {
+          const active = !item.external && isActive(pathname, item.href);
           return (
             <a
               key={item.href}
-              className="view-switch-link"
+              className={
+                active ? 'view-switch-link active' : 'view-switch-link'
+              }
               href={item.href}
-              target="_blank"
-              rel="noopener noreferrer"
+              aria-current={active ? 'page' : undefined}
+              target={item.external ? '_blank' : undefined}
+              rel={item.external ? 'noopener noreferrer' : undefined}
             >
               {inner}
             </a>

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -34,16 +34,18 @@
   appearance: none;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   width: 100%;
-  border: 1px solid var(--line-strong);
+  border: none;
   background: transparent;
   color: inherit;
   font: inherit;
-  padding: 10px 12px;
+  font-weight: 500;
+  padding: 8px 6px;
   border-radius: var(--radius-sm);
   cursor: pointer;
   transition: background 0.12s;
+  text-align: left;
 }
 
 .newChatButton:hover {
@@ -51,12 +53,22 @@
 }
 
 .newChatButton > span:first-child {
-  font-size: 1.1rem;
+  font-size: 1.25rem;
   line-height: 1;
+  width: 20px;
+  display: inline-flex;
+  justify-content: center;
+}
+
+.sidebarFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 4px 6px;
 }
 
 .sidebarVersion {
-  padding: 8px 12px;
   font-size: 0.78rem;
   color: var(--muted-foreground);
 }
@@ -204,7 +216,6 @@
   flex-direction: column;
   gap: 12px;
   width: 100%;
-  max-width: 1100px;
 }
 
 .sidebarCollapseButton {

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -60,19 +60,6 @@
   justify-content: center;
 }
 
-.sidebarFooter {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 4px 6px;
-}
-
-.sidebarVersion {
-  font-size: 0.78rem;
-  color: var(--muted-foreground);
-}
-
 .sidebarLabel {
   margin: 12px 0 4px;
   padding: 0 6px;

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -652,9 +652,6 @@
   transition: border-color 0.15s;
 }
 
-.composer:focus-within {
-  border-color: color-mix(in srgb, var(--accent) 55%, var(--line-strong));
-}
 
 .pendingMediaRow {
   display: flex;
@@ -733,11 +730,6 @@
   padding: 6px 0;
 }
 
-.composerInput:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
-  outline-offset: -2px;
-  border-radius: var(--radius-sm);
-}
 
 .composerInput::placeholder {
   color: var(--muted-foreground);
@@ -778,13 +770,14 @@
 
 .sendButton {
   background: transparent;
-  color: var(--primary);
-  border: 1px solid var(--primary);
+  color: var(--muted-foreground);
+  border: 1px solid var(--line-strong);
   font-size: 0.9rem;
 }
 
 .sendButton:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--primary) 10%, transparent);
+  background: var(--muted);
+  color: var(--text);
 }
 
 .sendButton:disabled {

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -423,16 +423,6 @@
   display: flex;
   gap: 4px;
   padding: 0 4px;
-  opacity: 0;
-  transition: opacity 0.15s;
-}
-
-.messageBlock:hover .messageActions {
-  opacity: 1;
-}
-
-.messageBlock:focus-within .messageActions {
-  opacity: 1;
 }
 
 .actionButton {
@@ -594,14 +584,14 @@
 .composer {
   display: flex;
   flex-direction: column;
-  max-width: 860px;
-  margin: 0 auto;
+  max-width: 1100px;
   width: 100%;
+  padding: 12px 16px;
+  gap: 8px;
   border: 1px solid var(--line-strong);
-  border-radius: 24px;
+  border-radius: 16px;
   background: var(--panel-bg);
   box-shadow: var(--shadow-raised);
-  overflow: hidden;
   transition: border-color 0.15s;
 }
 
@@ -658,6 +648,13 @@
   align-items: flex-end;
   gap: 8px;
   padding: 10px 14px;
+}
+
+.composerActions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
 }
 
 .composerInput {

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -14,6 +14,45 @@
   height: 100%;
 }
 
+.chatBrandRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 2px 4px 14px;
+}
+
+.chatBrand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.chatBrandLogo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 46px;
+  height: 46px;
+  flex: 0 0 auto;
+}
+
+.chatBrandLogo svg {
+  width: 46px;
+  height: 46px;
+}
+
+.chatBrandName {
+  font-size: 1.125rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .chatSidebarHeader {
   display: flex;
   align-items: center;
@@ -34,14 +73,14 @@
   appearance: none;
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   width: 100%;
   border: none;
   background: transparent;
   color: inherit;
   font: inherit;
   font-weight: 500;
-  padding: 8px 6px;
+  padding: 18px 8px;
   border-radius: var(--radius-sm);
   cursor: pointer;
   transition: background 0.12s;
@@ -156,7 +195,7 @@
 }
 
 .sidebarSearchWrap {
-  padding: 2px 0 4px;
+  padding: 10px 0 4px;
 }
 
 .sidebarSearch {

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1,85 +1,64 @@
 .chatPage {
-  display: grid;
-  grid-template-columns: 260px 1fr;
+  display: flex;
+  width: 100%;
   height: 100dvh;
   min-height: 0;
   overflow: hidden;
 }
 
-.sidebar {
-  display: flex;
-  flex-direction: column;
+/* The nested SidebarProvider wraps content in a .layout div with
+   min-height: 100vh. Override it so the chat sidebar fits within
+   the chat page's flex layout instead of forcing its own viewport. */
+.chatPage > div {
   min-height: 0;
-  overflow-y: auto;
-  background: var(--sidebar);
-  border-right: 1px solid var(--line);
-  padding: 16px 12px;
-  gap: 8px;
+  height: 100%;
 }
 
-.sidebarHeader {
+.chatSidebarHeader {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 4px 6px 12px;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0 4px;
 }
 
-.sidebarLogo {
-  width: 28px;
-  height: 28px;
-  flex-shrink: 0;
-}
-
-.sidebarBrand {
-  font-size: 1rem;
-  font-weight: 700;
-  color: var(--text);
-  letter-spacing: -0.02em;
+.chatSidebarContent {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 0 4px;
+  overflow: hidden;
 }
 
 .newChatButton {
+  appearance: none;
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 6px;
+  gap: 8px;
   width: 100%;
-  padding: 9px 12px;
-  border-radius: var(--radius-sm);
   border: 1px solid var(--line-strong);
-  background: var(--panel-bg);
-  color: var(--text);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  font-size: 0.875rem;
-  font-weight: 500;
-  transition: background 0.15s;
+  transition: background 0.12s;
 }
 
 .newChatButton:hover {
-  background: var(--accent-soft);
-}
-
-.sidebarSearchWrap {
-  padding: 2px 0 4px;
-}
-
-.sidebarSearch {
-  width: 100%;
-  border: 1px solid var(--line-strong);
-  border-radius: var(--radius-sm);
   background: var(--panel-bg);
-  color: var(--text);
-  font: inherit;
-  padding: 9px 11px;
 }
 
-.sidebarSearch::placeholder {
+.newChatButton > span:first-child {
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.sidebarVersion {
+  padding: 8px 12px;
+  font-size: 0.78rem;
   color: var(--muted-foreground);
-}
-
-.sidebarSearch:focus {
-  outline: 2px solid var(--accent-soft);
-  outline-offset: 1px;
-  border-color: var(--ring);
 }
 
 .sidebarLabel {
@@ -128,18 +107,24 @@
   box-shadow: var(--shadow-raised);
 }
 
+.sessionItemPending {
+  animation: sessionPulse 1s ease-in-out infinite;
+}
+
+@keyframes sessionPulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
 .sessionTitle {
   font-size: 0.875rem;
   font-weight: 500;
   color: var(--text);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.sessionSnippet {
-  font-size: 0.76rem;
-  color: var(--muted-foreground);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -150,25 +135,67 @@
   color: var(--muted-foreground);
 }
 
+.sessionSnippet {
+  font-size: 0.76rem;
+  color: var(--muted-foreground);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sidebarSearchWrap {
+  padding: 2px 0 4px;
+}
+
+.sidebarSearch {
+  width: 100%;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: var(--panel-bg);
+  color: var(--text);
+  font: inherit;
+  padding: 9px 11px;
+}
+
+.sidebarSearch::placeholder {
+  color: var(--muted-foreground);
+}
+
+.sidebarSearch:focus {
+  outline: 2px solid var(--accent-soft);
+  outline-offset: 1px;
+  border-color: var(--ring);
+}
+
 .sidebarStatus {
   padding: 6px 10px;
   font-size: 0.82rem;
   color: var(--muted-foreground);
 }
 
+.chatTopbar {
+  display: flex;
+  justify-content: flex-end;
+  padding: 10px 16px 6px;
+  flex-shrink: 0;
+}
+
 .chatMain {
   display: flex;
   flex-direction: column;
+  flex: 1 1 auto;
   min-height: 0;
+  min-width: 0;
   overflow: hidden;
   position: relative;
+  background: var(--page-bg);
 }
 
 .messageArea {
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
-  padding: 24px 24px 12px;
+  padding: 16px 16px 12px;
   scroll-behavior: smooth;
 }
 
@@ -176,9 +203,12 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
-  max-width: 860px;
-  margin: 0 auto;
   width: 100%;
+  max-width: 1100px;
+}
+
+.sidebarCollapseButton {
+  align-self: center;
 }
 
 .emptyState {
@@ -397,7 +427,10 @@
   transition: opacity 0.15s;
 }
 
-.messageBlock:hover .messageActions,
+.messageBlock:hover .messageActions {
+  opacity: 1;
+}
+
 .messageBlock:focus-within .messageActions {
   opacity: 1;
 }
@@ -429,6 +462,16 @@
   min-height: unset;
   border-radius: 999px;
   font-size: 0.8rem;
+}
+
+.branchButton:hover {
+  background: var(--muted);
+  color: var(--text);
+}
+
+.branchButton:disabled {
+  opacity: 0.4;
+  cursor: default;
 }
 
 .approvalActions {
@@ -619,7 +662,7 @@
 
 .composerInput {
   flex: 1 1 auto;
-  min-height: 24px;
+  min-height: 36px;
   max-height: 180px;
   resize: none;
   border: none;
@@ -627,8 +670,13 @@
   background: transparent;
   color: var(--text);
   font-size: 0.92rem;
+  line-height: 36px;
+  padding: 0;
+}
+
+.composerInput:not(:placeholder-shown) {
   line-height: 1.5;
-  padding: 2px 0;
+  padding: 6px 0;
 }
 
 .composerInput:focus-visible {
@@ -639,12 +687,6 @@
 
 .composerInput::placeholder {
   color: var(--muted-foreground);
-}
-
-.attachButton:focus-visible,
-.sendButton:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
-  outline-offset: 2px;
 }
 
 .attachButton,
@@ -661,6 +703,12 @@
   transition:
     background 0.12s,
     color 0.12s;
+}
+
+.attachButton:focus-visible,
+.sendButton:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
+  outline-offset: 2px;
 }
 
 .attachButton {
@@ -766,45 +814,6 @@
 }
 
 @media (max-width: 900px) {
-  .chatPage {
-    grid-template-columns: 1fr;
-  }
-
-  .sidebar {
-    display: none;
-  }
-
-  .sidebarOpen {
-    display: flex;
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    z-index: 100;
-    width: 280px;
-    max-width: 85vw;
-    animation: slideIn 0.2s ease;
-  }
-
-  .sidebarBackdrop {
-    position: fixed;
-    inset: 0;
-    z-index: 99;
-    background: rgba(0, 0, 0, 0.4);
-    border: none;
-    padding: 0;
-    cursor: default;
-  }
-
-  .mobileHeader {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 12px 16px;
-    border-bottom: 1px solid var(--line);
-    flex-shrink: 0;
-  }
-
   .messageArea {
     padding: 16px 16px 8px;
   }
@@ -842,26 +851,7 @@
     animation: none;
   }
 
-  .sidebarOpen {
+  .sessionItemPending {
     animation: none;
-  }
-}
-
-@media (min-width: 901px) {
-  .mobileHeader {
-    display: none;
-  }
-
-  .sidebarBackdrop {
-    display: none;
-  }
-}
-
-@keyframes slideIn {
-  from {
-    transform: translateX(-100%);
-  }
-  to {
-    transform: translateX(0);
   }
 }

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -592,7 +592,6 @@
 .composer {
   display: flex;
   flex-direction: column;
-  max-width: 1100px;
   width: 100%;
   padding: 12px 16px;
   gap: 8px;

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -14,45 +14,6 @@
   height: 100%;
 }
 
-.chatBrandRow {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 2px 4px 14px;
-}
-
-.chatBrand {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  min-width: 0;
-}
-
-.chatBrandLogo {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 46px;
-  height: 46px;
-  flex: 0 0 auto;
-}
-
-.chatBrandLogo svg {
-  width: 46px;
-  height: 46px;
-}
-
-.chatBrandName {
-  font-size: 1.125rem;
-  font-weight: 700;
-  letter-spacing: -0.01em;
-  color: var(--text);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .chatSidebarHeader {
   display: flex;
   align-items: center;
@@ -227,7 +188,7 @@
 .chatTopbar {
   display: flex;
   justify-content: flex-end;
-  padding: 10px 16px 6px;
+  padding: 24px 24px 0;
   flex-shrink: 0;
 }
 
@@ -246,7 +207,7 @@
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
-  padding: 16px 16px 12px;
+  padding: 16px 24px 12px;
   scroll-behavior: smooth;
 }
 

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -102,9 +102,9 @@
   background: var(--panel-bg);
 }
 
-.sessionItemActive {
-  background: var(--panel-bg);
-  box-shadow: var(--shadow-raised);
+.sessionItemActive .sessionTitle,
+.sessionItemActive .sessionSnippet {
+  color: var(--primary);
 }
 
 .sessionItemPending {

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -738,9 +738,14 @@
 }
 
 .sendButton {
-  background: var(--primary);
-  color: var(--primary-foreground);
+  background: transparent;
+  color: var(--primary);
+  border: 1px solid var(--primary);
   font-size: 0.9rem;
+}
+
+.sendButton:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--primary) 10%, transparent);
 }
 
 .sendButton:disabled {

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -613,7 +613,6 @@
   transition: border-color 0.15s;
 }
 
-
 .pendingMediaRow {
   display: flex;
   flex-wrap: wrap;
@@ -690,7 +689,6 @@
   line-height: 1.5;
   padding: 6px 0;
 }
-
 
 .composerInput::placeholder {
   color: var(--muted-foreground);

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -425,12 +425,20 @@
   padding: 0 4px;
 }
 
-.actionButton {
-  width: 28px;
-  height: 28px;
+.messageActions .actionButton {
+  width: 24px;
+  height: 24px;
   min-height: unset;
-  border-radius: 999px;
+  border-color: transparent;
+  background: transparent;
+  color: var(--muted-foreground);
+  border-radius: var(--radius-sm);
   font-size: 0.82rem;
+}
+
+.messageActions .actionButton:hover {
+  background: var(--muted);
+  color: var(--foreground);
 }
 
 .actionButtonSuccess {

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1,7 +1,7 @@
 .chatPage {
   display: grid;
   grid-template-columns: 260px 1fr;
-  height: 100%;
+  height: 100dvh;
   min-height: 0;
   overflow: hidden;
 }

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -79,6 +79,10 @@ vi.mock('../../components/view-switch', () => ({
   ViewSwitchNav: () => null,
 }));
 
+vi.mock('../../components/theme-toggle', () => ({
+  ThemeToggle: () => null,
+}));
+
 function renderChatPage() {
   const queryClient = new QueryClient({
     defaultOptions: {

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -7,6 +7,7 @@ import {
   waitFor,
   within,
 } from '@testing-library/react';
+import { Suspense } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   BranchResponse,
@@ -15,9 +16,10 @@ import type {
   MediaUploadResponse,
 } from '../../api/chat-types';
 import type { GatewayStatus } from '../../api/types';
+import { SidebarProvider } from '../../components/sidebar/index';
 import { ChatPage } from './chat-page';
 
-const validateTokenMock = vi.fn<(token: string) => Promise<GatewayStatus>>();
+const fetchAppStatusMock = vi.fn<(token: string) => Promise<GatewayStatus>>();
 const fetchChatRecentMock =
   vi.fn<
     (
@@ -47,6 +49,7 @@ const isActiveMock = vi.fn();
 const useChatStreamMock = vi.fn();
 
 vi.mock('../../api/chat', () => ({
+  fetchAppStatus: (token: string) => fetchAppStatusMock(token),
   fetchChatRecent: (
     token: string,
     userId: string,
@@ -64,16 +67,16 @@ vi.mock('../../api/chat', () => ({
   uploadMedia: (token: string, file: File) => uploadMediaMock(token, file),
 }));
 
-vi.mock('../../api/client', () => ({
-  validateToken: (token: string) => validateTokenMock(token),
-}));
-
 vi.mock('../../auth', () => ({
   useAuth: () => useAuthMock(),
 }));
 
 vi.mock('./use-chat-stream', () => ({
   useChatStream: (...args: unknown[]) => useChatStreamMock(...args),
+}));
+
+vi.mock('../../components/view-switch', () => ({
+  ViewSwitchNav: () => null,
 }));
 
 function renderChatPage() {
@@ -86,7 +89,11 @@ function renderChatPage() {
 
   render(
     <QueryClientProvider client={queryClient}>
-      <ChatPage />
+      <SidebarProvider>
+        <Suspense fallback={<div>Loading chat…</div>}>
+          <ChatPage />
+        </Suspense>
+      </SidebarProvider>
     </QueryClientProvider>,
   );
 
@@ -104,7 +111,7 @@ describe('ChatPage', () => {
     localStorage.setItem('hybridclaw_session', 'session-a');
     localStorage.setItem('hybridclaw_user_id', 'web-user-1');
 
-    validateTokenMock.mockReset();
+    fetchAppStatusMock.mockReset();
     fetchChatRecentMock.mockReset();
     fetchChatHistoryMock.mockReset();
     createChatBranchMock.mockReset();
@@ -116,7 +123,7 @@ describe('ChatPage', () => {
     useChatStreamMock.mockReset();
 
     useAuthMock.mockReturnValue({ token: 'test-token' });
-    validateTokenMock.mockResolvedValue({
+    fetchAppStatusMock.mockResolvedValue({
       status: 'ok',
       webAuthConfigured: true,
       version: '0.0.0',
@@ -251,6 +258,55 @@ describe('ChatPage', () => {
       ['test-token', 'session-a'],
       ['test-token', 'session-b'],
     ]);
+  });
+
+  it('assigns branch controls to loaded history and opens sibling branches', async () => {
+    fetchChatHistoryMock.mockImplementation(
+      async (_token, sessionId): Promise<ChatHistoryResponse> => ({
+        sessionId,
+        history: [
+          {
+            id: 42,
+            role: 'assistant',
+            content:
+              sessionId === 'session-b'
+                ? 'Alternate assistant reply'
+                : 'Primary assistant reply',
+          },
+        ],
+        branchFamilies: [
+          {
+            anchorSessionId: 'session-a',
+            anchorMessageId: 42,
+            variants: [
+              { sessionId: 'session-a', messageId: 42 },
+              { sessionId: 'session-b', messageId: 42 },
+            ],
+          },
+        ],
+      }),
+    );
+
+    renderChatPage();
+
+    const initialCounter = await screen.findByText('1/2');
+    const initialActions = initialCounter.parentElement;
+    if (!(initialActions instanceof HTMLElement)) {
+      throw new Error('Missing branch action container');
+    }
+
+    fireEvent.click(
+      within(initialActions).getByRole('button', { name: 'Next branch' }),
+    );
+
+    expect(await screen.findByText('Alternate assistant reply')).not.toBeNull();
+    expect(await screen.findByText('2/2')).not.toBeNull();
+    await waitFor(() =>
+      expect(fetchChatHistoryMock).toHaveBeenCalledWith(
+        'test-token',
+        'session-b',
+      ),
+    );
   });
 
   it('searches conversation titles beyond the default recent list', async () => {
@@ -404,79 +460,6 @@ describe('ChatPage', () => {
     );
   });
 
-  it('assigns branch controls to loaded history and opens sibling branches', async () => {
-    fetchChatHistoryMock.mockImplementation(
-      async (_token, sessionId): Promise<ChatHistoryResponse> => ({
-        sessionId,
-        history: [
-          {
-            id: 42,
-            role: 'assistant',
-            content:
-              sessionId === 'session-b'
-                ? 'Alternate assistant reply'
-                : 'Primary assistant reply',
-          },
-        ],
-        branchFamilies: [
-          {
-            anchorSessionId: 'session-a',
-            anchorMessageId: 42,
-            variants: [
-              { sessionId: 'session-a', messageId: 42 },
-              { sessionId: 'session-b', messageId: 42 },
-            ],
-          },
-        ],
-      }),
-    );
-
-    renderChatPage();
-
-    const initialCounter = await screen.findByText('1/2');
-    const initialActions = initialCounter.parentElement;
-    if (!(initialActions instanceof HTMLElement)) {
-      throw new Error('Missing branch action container');
-    }
-
-    fireEvent.click(
-      within(initialActions).getByRole('button', { name: 'Next branch' }),
-    );
-
-    expect(await screen.findByText('Alternate assistant reply')).not.toBeNull();
-    expect(await screen.findByText('2/2')).not.toBeNull();
-    await waitFor(() =>
-      expect(fetchChatHistoryMock).toHaveBeenCalledWith(
-        'test-token',
-        'session-b',
-      ),
-    );
-  });
-
-  it('keeps a single sidebar tree when the mobile drawer opens', async () => {
-    fetchChatHistoryMock.mockResolvedValue({
-      sessionId: 'session-a',
-      history: [
-        {
-          id: 101,
-          role: 'assistant',
-          content: 'Opened session A',
-        },
-      ],
-    });
-
-    renderChatPage();
-
-    expect(await screen.findByText('Opened session A')).not.toBeNull();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Open sidebar' }));
-
-    expect(screen.getAllByText('Recent')).toHaveLength(1);
-    expect(
-      screen.getByRole('button', { name: 'Close sidebar' }),
-    ).not.toBeNull();
-  });
-
   it('shows an error and keeps edit mode open when the message cannot be branched', async () => {
     fetchChatHistoryMock.mockResolvedValue({
       sessionId: 'session-a',
@@ -511,7 +494,7 @@ describe('ChatPage', () => {
 
   it('surfaces gateway status load failures instead of swallowing them', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    validateTokenMock.mockRejectedValue(new Error('Gateway offline'));
+    fetchAppStatusMock.mockRejectedValue(new Error('Gateway offline'));
     fetchChatHistoryMock.mockResolvedValue({
       sessionId: 'session-a',
       history: [],

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -1,7 +1,16 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+  useTransition,
+} from 'react';
 import {
   createChatBranch,
+  fetchAppStatus,
   fetchChatHistory,
   fetchChatRecent,
   uploadMedia,
@@ -11,8 +20,8 @@ import type {
   ChatMessage,
   MediaItem,
 } from '../../api/chat-types';
-import { validateToken } from '../../api/client';
 import { useAuth } from '../../auth';
+import { ViewSwitchNav } from '../../components/view-switch';
 import {
   type ApprovalAction,
   buildApprovalCommand,
@@ -26,10 +35,10 @@ import {
   storeSessionId,
 } from '../../lib/chat-helpers';
 import { CHAT_UI_CONFIG } from '../../lib/chat-ui-config';
-import { cx } from '../../lib/cx';
+import { getErrorMessage } from '../../lib/error-message';
 import { useDebouncedValue } from '../../lib/use-debounced-value';
 import css from './chat-page.module.css';
-import { ChatSidebar } from './chat-sidebar';
+import { ChatSidebarPanel, ChatSidebarProvider } from './chat-sidebar';
 import type { ChatUiMessage } from './chat-ui-message';
 import { Composer } from './composer';
 import { EditInline, MessageBlock } from './message-block';
@@ -45,6 +54,7 @@ function buildBranchInfoMap(
   branchFamilies: Map<string, BranchVariant[]>,
 ): Map<string, BranchInfo> {
   const map = new Map<string, BranchInfo>();
+  if (branchFamilies.size === 0) return map;
   for (const msg of messages) {
     const key = msg.branchKey;
     if (!key) continue;
@@ -62,28 +72,121 @@ function buildBranchInfoMap(
   return map;
 }
 
+interface ChatState {
+  sessionId: string;
+  messages: ChatUiMessage[];
+  error: string;
+  editingId: string | null;
+  approvalBusy: boolean;
+  branchFamilies: Map<string, BranchVariant[]>;
+}
+
+type ChatAction =
+  | { type: 'SESSION_SWITCH'; sessionId: string }
+  | { type: 'SESSION_ID_UPDATE'; sessionId: string }
+  | {
+      type: 'HISTORY_LOADED';
+      messages: ChatMessage[];
+      branchFamilies: Map<string, BranchVariant[]>;
+      sessionId?: string;
+    }
+  | {
+      type: 'MESSAGES_SET';
+      updater: ChatUiMessage[] | ((prev: ChatUiMessage[]) => ChatUiMessage[]);
+    }
+  | { type: 'ERROR_SET'; error: string }
+  | { type: 'ERROR_CLEAR' }
+  | { type: 'EDIT_START'; id: string }
+  | { type: 'EDIT_CANCEL' }
+  | { type: 'APPROVAL_BUSY_SET'; busy: boolean };
+
+function chatReducer(state: ChatState, action: ChatAction): ChatState {
+  switch (action.type) {
+    case 'SESSION_ID_UPDATE':
+      return { ...state, sessionId: action.sessionId };
+    case 'SESSION_SWITCH':
+      return {
+        ...state,
+        sessionId: action.sessionId,
+        messages: [],
+        error: '',
+        editingId: null,
+        approvalBusy: false,
+        branchFamilies: new Map(),
+      };
+    case 'HISTORY_LOADED':
+      return {
+        ...state,
+        messages: action.messages,
+        branchFamilies: action.branchFamilies,
+        ...(action.sessionId ? { sessionId: action.sessionId } : {}),
+      };
+    case 'MESSAGES_SET': {
+      const messages =
+        typeof action.updater === 'function'
+          ? action.updater(state.messages)
+          : action.updater;
+      return { ...state, messages };
+    }
+    case 'ERROR_SET':
+      return { ...state, error: action.error };
+    case 'ERROR_CLEAR':
+      return { ...state, error: '' };
+    case 'EDIT_START':
+      return { ...state, editingId: action.id };
+    case 'EDIT_CANCEL':
+      return { ...state, editingId: null };
+    case 'APPROVAL_BUSY_SET':
+      return { ...state, approvalBusy: action.busy };
+    default:
+      return state;
+  }
+}
+
 export function ChatPage() {
   const auth = useAuth();
   const queryClient = useQueryClient();
   const userId = useRef(readStoredUserId()).current;
   const defaultAgentIdRef = useRef(DEFAULT_AGENT_ID);
 
-  const [sessionId, setSessionId] = useState<string>(() => {
-    const stored = readStoredSessionId();
-    return stored || generateWebSessionId();
-  });
-  const [messages, setMessages] = useState<ChatUiMessage[]>([]);
-  const [error, setError] = useState('');
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [approvalBusy, setApprovalBusy] = useState(false);
-  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
-  const [sessionSearchQuery, setSessionSearchQuery] = useState('');
-  const [branchFamilies, setBranchFamilies] = useState<
-    Map<string, BranchVariant[]>
-  >(new Map());
-  const [branchInfoMap, setBranchInfoMap] = useState<Map<string, BranchInfo>>(
-    new Map(),
+  const [state, dispatch] = useReducer(
+    chatReducer,
+    undefined,
+    (): ChatState => {
+      const stored = readStoredSessionId();
+      const sessionId =
+        stored ||
+        (() => {
+          const id = generateWebSessionId();
+          storeSessionId(id);
+          return id;
+        })();
+      return {
+        sessionId,
+        messages: [],
+        error: '',
+        editingId: null,
+        approvalBusy: false,
+        branchFamilies: new Map(),
+      };
+    },
   );
+  const {
+    sessionId,
+    messages,
+    error,
+    editingId,
+    approvalBusy,
+    branchFamilies,
+  } = state;
+
+  const [isPending, startTransition] = useTransition();
+  const [sessionSearchQuery, setSessionSearchQuery] = useState('');
+  const debouncedSessionSearchQuery = useDebouncedValue(
+    sessionSearchQuery,
+    160,
+  );
+  const trimmedSessionSearchQuery = debouncedSessionSearchQuery.trim();
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messageAreaRef = useRef<HTMLDivElement>(null);
@@ -94,19 +197,36 @@ export function ChatPage() {
     content: string;
     media: MediaItem[];
   } | null>(null);
-  const debouncedSessionSearchQuery = useDebouncedValue(
-    sessionSearchQuery,
-    160,
-  );
-  const trimmedSessionSearchQuery = debouncedSessionSearchQuery.trim();
 
   const refreshRecent = useCallback(() => {
     void queryClient.invalidateQueries({
       queryKey: ['chat-recent', auth.token, userId],
     });
+    void queryClient.invalidateQueries({
+      queryKey: ['chat-history', auth.token, sessionIdRef.current],
+      refetchType: 'none',
+    });
   }, [queryClient, auth.token, userId]);
 
   const getSessionId = useCallback(() => sessionIdRef.current, []);
+
+  const setMessages = useCallback(
+    (
+      updater: ChatUiMessage[] | ((prev: ChatUiMessage[]) => ChatUiMessage[]),
+    ) => {
+      dispatch({ type: 'MESSAGES_SET', updater });
+    },
+    [],
+  );
+
+  const setSessionId = useCallback((id: string) => {
+    dispatch({ type: 'SESSION_ID_UPDATE', sessionId: id });
+  }, []);
+
+  const setError = useCallback((err: string) => {
+    if (err === '') dispatch({ type: 'ERROR_CLEAR' });
+    else dispatch({ type: 'ERROR_SET', error: err });
+  }, []);
 
   const stream = useChatStream({
     token: auth.token,
@@ -118,7 +238,6 @@ export function ChatPage() {
     refreshRecent,
   });
 
-  // Stable ref for history-load effect to call sendMessage without stale closure
   const sendMessageRef = useRef(stream.sendMessage);
   sendMessageRef.current = stream.sendMessage;
 
@@ -126,24 +245,31 @@ export function ChatPage() {
     storeSessionId(sessionId);
   }, [sessionId]);
 
+  const appStatusQuery = useQuery({
+    queryKey: ['app-status', auth.token],
+    queryFn: () => fetchAppStatus(auth.token),
+    staleTime: Infinity,
+  });
+
   useEffect(() => {
-    void validateToken(auth.token)
-      .then((status) => {
-        if (status.defaultAgentId) {
-          defaultAgentIdRef.current = status.defaultAgentId
-            .trim()
-            .toLowerCase();
-        }
-      })
-      .catch((err) => {
-        console.error('Failed to load gateway status for chat page', err);
-        setError(
-          (prev) =>
-            prev ||
-            'Failed to load the default agent. New chats will use main until gateway status loads.',
-        );
-      });
-  }, [auth.token]);
+    const id = appStatusQuery.data?.defaultAgentId;
+    if (id) {
+      defaultAgentIdRef.current = id.trim().toLowerCase();
+    }
+  }, [appStatusQuery.data?.defaultAgentId]);
+
+  useEffect(() => {
+    if (!appStatusQuery.error) return;
+    console.error(
+      'Failed to load gateway status for chat page',
+      appStatusQuery.error,
+    );
+    dispatch({
+      type: 'ERROR_SET',
+      error:
+        'Failed to load the default agent. New chats will use main until gateway status loads.',
+    });
+  }, [appStatusQuery.error]);
 
   const recentQuery = useQuery({
     queryKey: ['chat-recent', auth.token, userId, trimmedSessionSearchQuery],
@@ -165,17 +291,23 @@ export function ChatPage() {
     queryKey: ['chat-history', auth.token, sessionId],
     queryFn: () => fetchChatHistory(auth.token, sessionId),
     enabled: Boolean(sessionId),
-    staleTime: 45_000,
-    refetchOnWindowFocus: false,
+    staleTime: Infinity,
   });
+
+  // Forward fetch errors inline rather than throwing to the page-level error
+  // boundary — a failed background refetch (invalidated after each stream)
+  // would otherwise tear down ChatPage and lose composer/session state.
+  useEffect(() => {
+    if (!historyQuery.error) return;
+    dispatch({
+      type: 'ERROR_SET',
+      error: getErrorMessage(historyQuery.error),
+    });
+  }, [historyQuery.error]);
 
   useEffect(() => {
     const data = historyQuery.data;
-    if (!sessionId || !data) return;
-
-    if (data.sessionId && data.sessionId !== sessionId) {
-      setSessionId(data.sessionId);
-    }
+    if (!data) return;
 
     const resolvedSessionId = data.sessionId ?? sessionId;
     const loadedBranchFamilies = new Map(
@@ -210,10 +342,13 @@ export function ChatPage() {
           ? (branchKeysByMessageId.get(msg.id) ?? null)
           : null,
     }));
-    setMessages(loaded);
-    setBranchFamilies(loadedBranchFamilies);
-    setBranchInfoMap(buildBranchInfoMap(loaded, loadedBranchFamilies));
-    setError('');
+
+    dispatch({
+      type: 'HISTORY_LOADED',
+      messages: loaded,
+      branchFamilies: loadedBranchFamilies,
+      sessionId: data.sessionId !== sessionId ? data.sessionId : undefined,
+    });
 
     const pending = pendingEditRef.current;
     if (pending) {
@@ -222,14 +357,10 @@ export function ChatPage() {
     }
   }, [historyQuery.data, sessionId]);
 
-  useEffect(() => {
-    if (!historyQuery.error) return;
-    setError(
-      historyQuery.error instanceof Error
-        ? historyQuery.error.message
-        : String(historyQuery.error),
-    );
-  }, [historyQuery.error]);
+  const branchInfoMap = useMemo(
+    () => buildBranchInfoMap(messages, branchFamilies),
+    [messages, branchFamilies],
+  );
 
   const scrollRafRef = useRef(0);
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally re-runs on message changes to auto-scroll
@@ -248,22 +379,16 @@ export function ChatPage() {
     };
   }, []);
 
-  const resetChatState = useCallback(() => {
-    setMessages([]);
-    setBranchFamilies(new Map());
-    setBranchInfoMap(new Map());
-    setError('');
-    setEditingId(null);
-    setMobileSidebarOpen(false);
-  }, []);
-
   const handleEditSave = useCallback(
     async (msg: ChatMessage, newContent: string) => {
       if (!msg.messageId || !msg.sessionId) {
-        setError('This message cannot be edited right now.');
+        dispatch({
+          type: 'ERROR_SET',
+          error: 'This message cannot be edited right now.',
+        });
         return;
       }
-      setEditingId(null);
+      dispatch({ type: 'EDIT_CANCEL' });
       try {
         const branch = await createChatBranch(
           auth.token,
@@ -274,9 +399,14 @@ export function ChatPage() {
           content: newContent,
           media: msg.media ?? [],
         };
-        setSessionId(branch.sessionId);
+        startTransition(() => {
+          dispatch({ type: 'SESSION_SWITCH', sessionId: branch.sessionId });
+        });
       } catch (err) {
-        setError(err instanceof Error ? err.message : String(err));
+        dispatch({
+          type: 'ERROR_SET',
+          error: getErrorMessage(err),
+        });
       }
     },
     [auth.token],
@@ -298,11 +428,11 @@ export function ChatPage() {
     async (action: ApprovalAction, approvalId: string) => {
       const cmd = buildApprovalCommand(action, approvalId);
       if (!cmd) return;
-      setApprovalBusy(true);
+      dispatch({ type: 'APPROVAL_BUSY_SET', busy: true });
       try {
         await stream.sendMessage(cmd, [], { hideUser: true });
       } finally {
-        setApprovalBusy(false);
+        dispatch({ type: 'APPROVAL_BUSY_SET', busy: false });
       }
     },
     [stream.sendMessage],
@@ -319,7 +449,10 @@ export function ChatPage() {
           uploaded.push(r.value.media);
         } else if (r.status === 'rejected') {
           const err = r.reason;
-          setError(err instanceof Error ? err.message : String(err));
+          dispatch({
+            type: 'ERROR_SET',
+            error: getErrorMessage(err),
+          });
         }
       }
       return uploaded;
@@ -329,24 +462,45 @@ export function ChatPage() {
 
   const handleNewChat = useCallback(() => {
     if (stream.isActive()) {
-      setError('Stop the current run before starting a new chat.');
+      dispatch({
+        type: 'ERROR_SET',
+        error: 'Stop the current run before starting a new chat.',
+      });
       return;
     }
-    resetChatState();
-    setSessionId(generateWebSessionId(defaultAgentIdRef.current));
+    dispatch({
+      type: 'SESSION_SWITCH',
+      sessionId: generateWebSessionId(defaultAgentIdRef.current),
+    });
     refreshRecent();
-  }, [stream, resetChatState, refreshRecent]);
+  }, [stream, refreshRecent]);
 
   const handleOpenSession = useCallback(
     (targetId: string) => {
       if (stream.isActive()) {
-        setError('Stop the current run before switching chats.');
+        dispatch({
+          type: 'ERROR_SET',
+          error: 'Stop the current run before switching chats.',
+        });
         return;
       }
-      resetChatState();
-      setSessionId(targetId);
+      startTransition(() => {
+        dispatch({ type: 'SESSION_SWITCH', sessionId: targetId });
+      });
     },
-    [stream, resetChatState],
+    [stream],
+  );
+
+  const handleHoverSession = useCallback(
+    (targetId: string) => {
+      if (targetId === sessionIdRef.current) return;
+      void queryClient.prefetchQuery({
+        queryKey: ['chat-history', auth.token, targetId],
+        queryFn: () => fetchChatHistory(auth.token, targetId),
+        staleTime: 30_000,
+      });
+    },
+    [queryClient, auth.token],
   );
 
   const handleBranchNav = useCallback(
@@ -375,94 +529,77 @@ export function ChatPage() {
     activeSessionId: sessionId,
     onNewChat: handleNewChat,
     onOpenSession: handleOpenSession,
+    onHoverSession: handleHoverSession,
+    isPending,
     searchQuery: sessionSearchQuery,
     onSearchQueryChange: setSessionSearchQuery,
     isLoading: recentQuery.isFetching,
   } as const;
 
   return (
-    <div className={css.chatPage}>
-      {mobileSidebarOpen ? (
-        <button
-          type="button"
-          className={css.sidebarBackdrop}
-          tabIndex={-1}
-          aria-label="Close sidebar"
-          onClick={() => setMobileSidebarOpen(false)}
-        />
-      ) : null}
+    <ChatSidebarProvider>
+      <div className={css.chatPage} aria-busy={isPending}>
+        <ChatSidebarPanel {...sidebarProps} />
 
-      <div className={cx(css.sidebar, mobileSidebarOpen && css.sidebarOpen)}>
-        <ChatSidebar {...sidebarProps} />
-      </div>
-
-      <div className={css.chatMain}>
-        <div className={css.mobileHeader}>
-          <button
-            type="button"
-            className="ghost-button"
-            onClick={() => setMobileSidebarOpen(true)}
-            aria-label="Open sidebar"
-          >
-            ☰
-          </button>
-          <span style={{ fontWeight: 600 }}>HybridClaw</span>
-        </div>
-
-        {isEmpty ? (
-          <div className={css.emptyState}>
-            <h1 className={css.greeting}>
-              Ready to claw through your to-do list?
-            </h1>
+        <div className={css.chatMain}>
+          <div className={css.chatTopbar}>
+            <ViewSwitchNav />
           </div>
-        ) : (
-          <div className={css.messageArea} ref={messageAreaRef}>
-            <div className={css.messageList}>
-              {messages.map((msg) =>
-                editingId === msg.id && msg.role !== 'thinking' ? (
-                  <div key={msg.id} className={css.messageBlock}>
-                    <EditInline
-                      initial={msg.rawContent ?? msg.content}
-                      onSave={(newContent) =>
-                        void handleEditSave(msg, newContent)
-                      }
-                      onCancel={() => setEditingId(null)}
-                    />
-                  </div>
-                ) : (
-                  <MessageBlock
-                    key={msg.id}
-                    message={msg}
-                    token={auth.token}
-                    isStreaming={msg.id === stream.streamingMsgId}
-                    onCopy={copyToClipboard}
-                    onEdit={(m) => setEditingId(m.id)}
-                    onRegenerate={handleRegenerate}
-                    onApprovalAction={handleApprovalAction}
-                    approvalBusy={approvalBusy}
-                    branchInfo={branchInfoMap.get(msg.id) ?? null}
-                    onBranchNav={(dir) => {
-                      if (msg.role === 'thinking') return;
-                      handleBranchNav(msg, dir);
-                    }}
-                  />
-                ),
-              )}
-              <div ref={messagesEndRef} />
+          {isEmpty ? (
+            <div className={css.emptyState}>
+              <h1 className={css.greeting}>
+                Ready to claw through your to-do list?
+              </h1>
             </div>
-          </div>
-        )}
+          ) : (
+            <div className={css.messageArea} ref={messageAreaRef}>
+              <div className={css.messageList}>
+                {messages.map((msg) =>
+                  editingId === msg.id && msg.role !== 'thinking' ? (
+                    <div key={msg.id} className={css.messageBlock}>
+                      <EditInline
+                        initial={msg.rawContent ?? msg.content}
+                        onSave={(newContent) =>
+                          void handleEditSave(msg, newContent)
+                        }
+                        onCancel={() => dispatch({ type: 'EDIT_CANCEL' })}
+                      />
+                    </div>
+                  ) : (
+                    <MessageBlock
+                      key={msg.id}
+                      message={msg}
+                      token={auth.token}
+                      isStreaming={msg.id === stream.streamingMsgId}
+                      onCopy={copyToClipboard}
+                      onEdit={(m) => dispatch({ type: 'EDIT_START', id: m.id })}
+                      onRegenerate={handleRegenerate}
+                      onApprovalAction={handleApprovalAction}
+                      approvalBusy={approvalBusy}
+                      branchInfo={branchInfoMap.get(msg.id) ?? null}
+                      onBranchNav={(dir) => {
+                        if (msg.role === 'thinking') return;
+                        handleBranchNav(msg, dir);
+                      }}
+                    />
+                  ),
+                )}
+                <div ref={messagesEndRef} />
+              </div>
+            </div>
+          )}
 
-        {error ? <div className={css.errorBanner}>{error}</div> : null}
+          {error ? <div className={css.errorBanner}>{error}</div> : null}
 
-        <Composer
-          isStreaming={stream.isStreaming}
-          onSend={(content, media) => void stream.sendMessage(content, media)}
-          onStop={() => void stream.stopRequest()}
-          onUploadFiles={handleUploadFiles}
-          token={auth.token}
-        />
+          <Composer
+            isStreaming={stream.isStreaming}
+            onSend={(content, media) => void stream.sendMessage(content, media)}
+            onStop={() => void stream.stopRequest()}
+            onUploadFiles={handleUploadFiles}
+            token={auth.token}
+          />
+        </div>
       </div>
-    </div>
+    </ChatSidebarProvider>
   );
 }

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -95,7 +95,6 @@ type ChatAction =
       updater: ChatUiMessage[] | ((prev: ChatUiMessage[]) => ChatUiMessage[]);
     }
   | { type: 'ERROR_SET'; error: string }
-  | { type: 'ERROR_CLEAR' }
   | { type: 'EDIT_START'; id: string }
   | { type: 'EDIT_CANCEL' }
   | { type: 'APPROVAL_BUSY_SET'; busy: boolean };
@@ -130,8 +129,6 @@ function chatReducer(state: ChatState, action: ChatAction): ChatState {
     }
     case 'ERROR_SET':
       return { ...state, error: action.error };
-    case 'ERROR_CLEAR':
-      return { ...state, error: '' };
     case 'EDIT_START':
       return { ...state, editingId: action.id };
     case 'EDIT_CANCEL':
@@ -224,8 +221,7 @@ export function ChatPage() {
   }, []);
 
   const setError = useCallback((err: string) => {
-    if (err === '') dispatch({ type: 'ERROR_CLEAR' });
-    else dispatch({ type: 'ERROR_SET', error: err });
+    dispatch({ type: 'ERROR_SET', error: err });
   }, []);
 
   const stream = useChatStream({
@@ -329,11 +325,11 @@ export function ChatPage() {
     let lastUserContent: string | null = null;
     const loaded: ChatMessage[] = history.map((msg) => {
       if (msg.role === 'user') lastUserContent = msg.content;
-      const replayRequest =
+      const replayContent =
         msg.role === 'user'
-          ? { content: msg.content, media: [] }
-          : msg.role === 'assistant' && lastUserContent !== null
-            ? { content: lastUserContent, media: [] }
+          ? msg.content
+          : msg.role === 'assistant'
+            ? lastUserContent
             : null;
       return {
         id: nextMsgId(),
@@ -344,7 +340,10 @@ export function ChatPage() {
         messageId: msg.id ?? null,
         media: [],
         artifacts: [],
-        replayRequest,
+        replayRequest:
+          replayContent !== null
+            ? { content: replayContent, media: [] }
+            : null,
         assistantPresentation: data.assistantPresentation ?? null,
         branchKey:
           msg.id !== undefined && msg.id !== null
@@ -513,6 +512,10 @@ export function ChatPage() {
     [queryClient, auth.token],
   );
 
+  const handleEditOpen = useCallback((m: ChatMessage) => {
+    dispatch({ type: 'EDIT_START', id: m.id });
+  }, []);
+
   const handleBranchNav = useCallback(
     (msg: ChatMessage, direction: -1 | 1) => {
       const key = msg.branchKey;
@@ -582,15 +585,12 @@ export function ChatPage() {
                       token={auth.token}
                       isStreaming={msg.id === stream.streamingMsgId}
                       onCopy={copyToClipboard}
-                      onEdit={(m) => dispatch({ type: 'EDIT_START', id: m.id })}
+                      onEdit={handleEditOpen}
                       onRegenerate={handleRegenerate}
                       onApprovalAction={handleApprovalAction}
                       approvalBusy={approvalBusy}
                       branchInfo={branchInfoMap.get(msg.id) ?? null}
-                      onBranchNav={(dir) => {
-                        if (msg.role === 'thinking') return;
-                        handleBranchNav(msg, dir);
-                      }}
+                      onBranchNav={handleBranchNav}
                     />
                   ),
                 )}

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -325,23 +325,33 @@ export function ChatPage() {
       branchKeysByMessageId.set(currentVariant.messageId, branchKey);
     }
 
-    const loaded: ChatMessage[] = (data.history ?? []).map((msg) => ({
-      id: nextMsgId(),
-      role: msg.role,
-      content: msg.content,
-      rawContent: msg.content,
-      sessionId: resolvedSessionId,
-      messageId: msg.id ?? null,
-      media: [],
-      artifacts: [],
-      replayRequest:
-        msg.role === 'user' ? { content: msg.content, media: [] } : null,
-      assistantPresentation: data.assistantPresentation ?? null,
-      branchKey:
-        msg.id !== undefined && msg.id !== null
-          ? (branchKeysByMessageId.get(msg.id) ?? null)
-          : null,
-    }));
+    const history = data.history ?? [];
+    let lastUserContent: string | null = null;
+    const loaded: ChatMessage[] = history.map((msg) => {
+      if (msg.role === 'user') lastUserContent = msg.content;
+      const replayRequest =
+        msg.role === 'user'
+          ? { content: msg.content, media: [] }
+          : msg.role === 'assistant' && lastUserContent !== null
+            ? { content: lastUserContent, media: [] }
+            : null;
+      return {
+        id: nextMsgId(),
+        role: msg.role,
+        content: msg.content,
+        rawContent: msg.content,
+        sessionId: resolvedSessionId,
+        messageId: msg.id ?? null,
+        media: [],
+        artifacts: [],
+        replayRequest,
+        assistantPresentation: data.assistantPresentation ?? null,
+        branchKey:
+          msg.id !== undefined && msg.id !== null
+            ? (branchKeysByMessageId.get(msg.id) ?? null)
+            : null,
+      };
+    });
 
     dispatch({
       type: 'HISTORY_LOADED',

--- a/console/src/routes/chat/chat-sidebar.tsx
+++ b/console/src/routes/chat/chat-sidebar.tsx
@@ -3,7 +3,6 @@ import type { ChatRecentSession } from '../../api/chat-types';
 import { useAuth } from '../../auth';
 import { HybridClaw } from '../../components/icons';
 import {
-  getSidebarStyleVars,
   Sidebar,
   SidebarContent,
   SidebarFooter,
@@ -11,12 +10,11 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from '../../components/sidebar/index';
+import sidebarStyles from '../../components/sidebar/index.module.css';
 import { ThemeToggle } from '../../components/theme-toggle';
 import { cx } from '../../lib/cx';
 import { formatRelativeTime } from '../../lib/format';
 import css from './chat-page.module.css';
-
-const CHAT_SIDEBAR_STYLE = getSidebarStyleVars('260px', '280px');
 
 export interface ChatSidebarProps {
   sessions: ChatRecentSession[];
@@ -32,7 +30,7 @@ export interface ChatSidebarProps {
 
 export function ChatSidebarProvider(props: { children: ReactNode }) {
   return (
-    <SidebarProvider style={CHAT_SIDEBAR_STYLE} defaultOpen storageKey={false}>
+    <SidebarProvider defaultOpen storageKey={false}>
       {props.children}
     </SidebarProvider>
   );
@@ -44,14 +42,18 @@ export function ChatSidebarPanel(props: ChatSidebarProps) {
   return (
     <Sidebar side="left" collapsible="icon">
       <SidebarHeader>
-        <div className={css.chatBrandRow}>
-          <div className={css.chatBrand}>
-            <span className={css.chatBrandLogo} aria-hidden="true">
-              <HybridClaw />
-            </span>
-            <span className={css.chatBrandName}>HybridClaw</span>
+        <div className={sidebarStyles.headerRow}>
+          <div className={sidebarStyles.brand}>
+            <div className={sidebarStyles.brandTitle}>
+              <span className={sidebarStyles.brandMark} aria-hidden="true">
+                <HybridClaw />
+              </span>
+              <div className={sidebarStyles.brandText}>
+                <h1>HybridClaw</h1>
+              </div>
+            </div>
           </div>
-          <SidebarTrigger className={css.sidebarCollapseButton} />
+          <SidebarTrigger className={sidebarStyles.sidebarToggle} />
         </div>
         <button
           type="button"

--- a/console/src/routes/chat/chat-sidebar.tsx
+++ b/console/src/routes/chat/chat-sidebar.tsx
@@ -1,88 +1,150 @@
+import type { ReactNode } from 'react';
+import { useAuth } from '../../auth';
 import type { ChatRecentSession } from '../../api/chat-types';
+import { HybridClaw } from '../../components/icons';
+import {
+  getSidebarStyleVars,
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarProvider,
+  SidebarTrigger,
+} from '../../components/sidebar/index';
+import sidebarStyles from '../../components/sidebar/index.module.css';
 import { cx } from '../../lib/cx';
 import { formatRelativeTime } from '../../lib/format';
 import css from './chat-page.module.css';
 
-export function ChatSidebar(props: {
+const CHAT_SIDEBAR_STYLE = getSidebarStyleVars('260px', '280px');
+
+export interface ChatSidebarProps {
   sessions: ChatRecentSession[];
   activeSessionId: string;
   onNewChat: () => void;
   onOpenSession: (sessionId: string) => void;
+  onHoverSession?: (sessionId: string) => void;
+  isPending?: boolean;
   searchQuery: string;
   onSearchQueryChange: (value: string) => void;
   isLoading: boolean;
-}) {
-  const trimmedSearch = props.searchQuery.trim();
-  const isSearching = trimmedSearch.length > 0;
+}
 
+export function ChatSidebarProvider(props: { children: ReactNode }) {
   return (
-    <>
-      <div className={css.sidebarHeader}>
-        <img
-          className={css.sidebarLogo}
-          src="/static/hybridclaw-logo.svg"
-          alt="HybridClaw"
-        />
-        <span className={css.sidebarBrand}>HybridClaw</span>
-      </div>
-      <button
-        type="button"
-        className={css.newChatButton}
-        onClick={props.onNewChat}
-      >
-        + New Conversation
-      </button>
-      <div className={css.sidebarSearchWrap}>
-        <input
-          type="search"
-          className={css.sidebarSearch}
-          value={props.searchQuery}
-          onChange={(event) => props.onSearchQueryChange(event.target.value)}
-          placeholder="Search"
-          aria-label="Search conversations"
-        />
-      </div>
-      {props.isLoading && isSearching ? (
-        <div className={css.sidebarStatus}>Searching...</div>
-      ) : props.sessions.length > 0 ? (
-        <>
-          <div className={css.sidebarLabel}>
-            {isSearching ? 'Search Results' : 'Recent'}
+    <SidebarProvider style={CHAT_SIDEBAR_STYLE} defaultOpen storageKey={false}>
+      {props.children}
+    </SidebarProvider>
+  );
+}
+
+export function ChatSidebarPanel(props: ChatSidebarProps) {
+  const auth = useAuth();
+  const isSearching = props.searchQuery.trim().length > 0;
+  return (
+    <Sidebar side="left" collapsible="icon">
+      <SidebarHeader>
+        <div className={sidebarStyles.headerRow}>
+          <div className={sidebarStyles.brand}>
+            <div className={sidebarStyles.brandTitle}>
+              <span className={sidebarStyles.brandMark} aria-hidden="true">
+                <HybridClaw />
+              </span>
+              <div className={sidebarStyles.brandText}>
+                <h1>HybridClaw</h1>
+              </div>
+            </div>
           </div>
-          <ul className={css.sessionList} aria-live="polite">
-            {props.sessions.map((s) => (
-              <li key={s.sessionId}>
-                <button
-                  type="button"
-                  className={cx(
-                    css.sessionItem,
-                    s.sessionId === props.activeSessionId &&
-                      css.sessionItemActive,
-                  )}
-                  aria-current={
-                    s.sessionId === props.activeSessionId ? 'page' : undefined
-                  }
-                  onClick={() => props.onOpenSession(s.sessionId)}
-                >
-                  <span className={css.sessionTitle}>
-                    {s.title || 'Untitled'}
-                  </span>
-                  {s.searchSnippet ? (
-                    <span className={css.sessionSnippet}>
-                      {s.searchSnippet}
-                    </span>
-                  ) : null}
-                  <span className={css.sessionTime}>
-                    {formatRelativeTime(s.lastActive)}
-                  </span>
-                </button>
-              </li>
-            ))}
-          </ul>
-        </>
-      ) : isSearching ? (
-        <div className={css.sidebarStatus}>No matching conversations.</div>
-      ) : null}
-    </>
+          <SidebarTrigger className={css.sidebarCollapseButton} />
+        </div>
+        <button
+          type="button"
+          className={css.newChatButton}
+          onClick={props.onNewChat}
+        >
+          <span aria-hidden="true">+</span>
+          <span>New Conversation</span>
+        </button>
+        <div className={css.sidebarSearchWrap}>
+          <input
+            type="search"
+            className={css.sidebarSearch}
+            value={props.searchQuery}
+            onChange={(event) => props.onSearchQueryChange(event.target.value)}
+            placeholder="Search"
+            aria-label="Search conversations"
+          />
+        </div>
+      </SidebarHeader>
+      <SidebarContent>
+        <ChatSessionList {...props} isSearching={isSearching} />
+      </SidebarContent>
+      <SidebarFooter>
+        {auth.gatewayStatus?.version ? (
+          <div className={css.sidebarVersion}>
+            HybridClaw v.{auth.gatewayStatus.version}
+          </div>
+        ) : null}
+      </SidebarFooter>
+    </Sidebar>
+  );
+}
+
+function ChatSessionList(props: ChatSidebarProps & { isSearching: boolean }) {
+  return (
+    <div className={css.chatSidebarContent}>
+      <div className={css.sidebarLabel}>
+        {props.isSearching ? 'Search Results' : 'Recent Chats'}
+      </div>
+      {renderSessionListBody(props)}
+    </div>
+  );
+}
+
+function renderSessionListBody(
+  props: ChatSidebarProps & { isSearching: boolean },
+) {
+  if (props.isLoading && props.isSearching) {
+    return <div className={css.sidebarStatus}>Searching...</div>;
+  }
+  if (props.sessions.length === 0) {
+    return (
+      <div className={css.sidebarStatus}>
+        {props.isSearching
+          ? 'No matching conversations.'
+          : 'No recent chats yet.'}
+      </div>
+    );
+  }
+  return (
+    <ul className={css.sessionList} aria-live="polite">
+      {props.sessions.map((s) => (
+        <li key={s.sessionId}>
+          <button
+            type="button"
+            className={cx(
+              css.sessionItem,
+              s.sessionId === props.activeSessionId && css.sessionItemActive,
+              s.sessionId === props.activeSessionId &&
+                props.isPending &&
+                css.sessionItemPending,
+            )}
+            aria-current={
+              s.sessionId === props.activeSessionId ? 'page' : undefined
+            }
+            onMouseEnter={() => props.onHoverSession?.(s.sessionId)}
+            onClick={() => props.onOpenSession(s.sessionId)}
+          >
+            <span className={css.sessionTitle}>{s.title || 'Untitled'}</span>
+            {s.searchSnippet ? (
+              <span className={css.sessionSnippet}>{s.searchSnippet}</span>
+            ) : null}
+            <span className={css.sessionTime}>
+              {formatRelativeTime(s.lastActive)}
+            </span>
+          </button>
+        </li>
+      ))}
+    </ul>
   );
 }

--- a/console/src/routes/chat/chat-sidebar.tsx
+++ b/console/src/routes/chat/chat-sidebar.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
-import { useAuth } from '../../auth';
 import type { ChatRecentSession } from '../../api/chat-types';
+import { useAuth } from '../../auth';
 import { HybridClaw } from '../../components/icons';
 import {
   getSidebarStyleVars,
@@ -12,6 +12,7 @@ import {
   SidebarTrigger,
 } from '../../components/sidebar/index';
 import sidebarStyles from '../../components/sidebar/index.module.css';
+import { ThemeToggle } from '../../components/theme-toggle';
 import { cx } from '../../lib/cx';
 import { formatRelativeTime } from '../../lib/format';
 import css from './chat-page.module.css';
@@ -80,11 +81,16 @@ export function ChatSidebarPanel(props: ChatSidebarProps) {
         <ChatSessionList {...props} isSearching={isSearching} />
       </SidebarContent>
       <SidebarFooter>
-        {auth.gatewayStatus?.version ? (
-          <div className={css.sidebarVersion}>
-            HybridClaw v.{auth.gatewayStatus.version}
-          </div>
-        ) : null}
+        <div className={css.sidebarFooter}>
+          {auth.gatewayStatus?.version ? (
+            <span className={css.sidebarVersion}>
+              HybridClaw v.{auth.gatewayStatus.version}
+            </span>
+          ) : (
+            <span />
+          )}
+          <ThemeToggle />
+        </div>
       </SidebarFooter>
     </Sidebar>
   );

--- a/console/src/routes/chat/chat-sidebar.tsx
+++ b/console/src/routes/chat/chat-sidebar.tsx
@@ -11,7 +11,6 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from '../../components/sidebar/index';
-import sidebarStyles from '../../components/sidebar/index.module.css';
 import { ThemeToggle } from '../../components/theme-toggle';
 import { cx } from '../../lib/cx';
 import { formatRelativeTime } from '../../lib/format';
@@ -45,16 +44,12 @@ export function ChatSidebarPanel(props: ChatSidebarProps) {
   return (
     <Sidebar side="left" collapsible="icon">
       <SidebarHeader>
-        <div className={sidebarStyles.headerRow}>
-          <div className={sidebarStyles.brand}>
-            <div className={sidebarStyles.brandTitle}>
-              <span className={sidebarStyles.brandMark} aria-hidden="true">
-                <HybridClaw />
-              </span>
-              <div className={sidebarStyles.brandText}>
-                <h1>HybridClaw</h1>
-              </div>
-            </div>
+        <div className={css.chatBrandRow}>
+          <div className={css.chatBrand}>
+            <span className={css.chatBrandLogo} aria-hidden="true">
+              <HybridClaw />
+            </span>
+            <span className={css.chatBrandName}>HybridClaw</span>
           </div>
           <SidebarTrigger className={css.sidebarCollapseButton} />
         </div>

--- a/console/src/routes/chat/chat-sidebar.tsx
+++ b/console/src/routes/chat/chat-sidebar.tsx
@@ -1,13 +1,14 @@
-import type { ReactNode } from 'react';
 import type { ChatRecentSession } from '../../api/chat-types';
 import { useAuth } from '../../auth';
-import { HybridClaw } from '../../components/icons';
+import {
+  SidebarBrand,
+  SidebarMeta,
+} from '../../components/sidebar/app-sidebar';
 import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
   SidebarHeader,
-  SidebarProvider,
   SidebarTrigger,
 } from '../../components/sidebar/index';
 import sidebarStyles from '../../components/sidebar/index.module.css';
@@ -15,6 +16,8 @@ import { ThemeToggle } from '../../components/theme-toggle';
 import { cx } from '../../lib/cx';
 import { formatRelativeTime } from '../../lib/format';
 import css from './chat-page.module.css';
+
+export { SidebarProvider as ChatSidebarProvider } from '../../components/sidebar/index';
 
 export interface ChatSidebarProps {
   sessions: ChatRecentSession[];
@@ -28,14 +31,6 @@ export interface ChatSidebarProps {
   isLoading: boolean;
 }
 
-export function ChatSidebarProvider(props: { children: ReactNode }) {
-  return (
-    <SidebarProvider defaultOpen storageKey={false}>
-      {props.children}
-    </SidebarProvider>
-  );
-}
-
 export function ChatSidebarPanel(props: ChatSidebarProps) {
   const auth = useAuth();
   const isSearching = props.searchQuery.trim().length > 0;
@@ -43,16 +38,7 @@ export function ChatSidebarPanel(props: ChatSidebarProps) {
     <Sidebar side="left" collapsible="icon">
       <SidebarHeader>
         <div className={sidebarStyles.headerRow}>
-          <div className={sidebarStyles.brand}>
-            <div className={sidebarStyles.brandTitle}>
-              <span className={sidebarStyles.brandMark} aria-hidden="true">
-                <HybridClaw />
-              </span>
-              <div className={sidebarStyles.brandText}>
-                <h1>HybridClaw</h1>
-              </div>
-            </div>
-          </div>
+          <SidebarBrand />
           <SidebarTrigger className={sidebarStyles.sidebarToggle} />
         </div>
         <button
@@ -78,15 +64,9 @@ export function ChatSidebarPanel(props: ChatSidebarProps) {
         <ChatSessionList {...props} isSearching={isSearching} />
       </SidebarContent>
       <SidebarFooter>
-        <div className={css.sidebarFooter}>
-          {auth.gatewayStatus?.version ? (
-            <span className={css.sidebarVersion}>
-              HybridClaw v.{auth.gatewayStatus.version}
-            </span>
-          ) : (
-            <span />
-          )}
-          <ThemeToggle />
+        <div className={sidebarStyles.footerBlock}>
+          <SidebarMeta version={auth.gatewayStatus?.version} />
+          <ThemeToggle labelClassName={sidebarStyles.themeToggleLabel} />
         </div>
       </SidebarFooter>
     </Sidebar>
@@ -99,55 +79,48 @@ function ChatSessionList(props: ChatSidebarProps & { isSearching: boolean }) {
       <div className={css.sidebarLabel}>
         {props.isSearching ? 'Search Results' : 'Recent Chats'}
       </div>
-      {renderSessionListBody(props)}
+      {props.isLoading && props.isSearching ? (
+        <div className={css.sidebarStatus}>Searching...</div>
+      ) : props.sessions.length === 0 ? (
+        <div className={css.sidebarStatus}>
+          {props.isSearching
+            ? 'No matching conversations.'
+            : 'No recent chats yet.'}
+        </div>
+      ) : (
+        <ul className={css.sessionList} aria-live="polite">
+          {props.sessions.map((s) => (
+            <li key={s.sessionId}>
+              <button
+                type="button"
+                className={cx(
+                  css.sessionItem,
+                  s.sessionId === props.activeSessionId &&
+                    css.sessionItemActive,
+                  s.sessionId === props.activeSessionId &&
+                    props.isPending &&
+                    css.sessionItemPending,
+                )}
+                aria-current={
+                  s.sessionId === props.activeSessionId ? 'page' : undefined
+                }
+                onMouseEnter={() => props.onHoverSession?.(s.sessionId)}
+                onClick={() => props.onOpenSession(s.sessionId)}
+              >
+                <span className={css.sessionTitle}>
+                  {s.title || 'Untitled'}
+                </span>
+                {s.searchSnippet ? (
+                  <span className={css.sessionSnippet}>{s.searchSnippet}</span>
+                ) : null}
+                <span className={css.sessionTime}>
+                  {formatRelativeTime(s.lastActive)}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
-  );
-}
-
-function renderSessionListBody(
-  props: ChatSidebarProps & { isSearching: boolean },
-) {
-  if (props.isLoading && props.isSearching) {
-    return <div className={css.sidebarStatus}>Searching...</div>;
-  }
-  if (props.sessions.length === 0) {
-    return (
-      <div className={css.sidebarStatus}>
-        {props.isSearching
-          ? 'No matching conversations.'
-          : 'No recent chats yet.'}
-      </div>
-    );
-  }
-  return (
-    <ul className={css.sessionList} aria-live="polite">
-      {props.sessions.map((s) => (
-        <li key={s.sessionId}>
-          <button
-            type="button"
-            className={cx(
-              css.sessionItem,
-              s.sessionId === props.activeSessionId && css.sessionItemActive,
-              s.sessionId === props.activeSessionId &&
-                props.isPending &&
-                css.sessionItemPending,
-            )}
-            aria-current={
-              s.sessionId === props.activeSessionId ? 'page' : undefined
-            }
-            onMouseEnter={() => props.onHoverSession?.(s.sessionId)}
-            onClick={() => props.onOpenSession(s.sessionId)}
-          >
-            <span className={css.sessionTitle}>{s.title || 'Untitled'}</span>
-            {s.searchSnippet ? (
-              <span className={css.sessionSnippet}>{s.searchSnippet}</span>
-            ) : null}
-            <span className={css.sessionTime}>
-              {formatRelativeTime(s.lastActive)}
-            </span>
-          </button>
-        </li>
-      ))}
-    </ul>
   );
 }

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -227,7 +227,18 @@ export function Composer(props: {
             ) : null}
           </div>
         ) : null}
-        <div className={css.composerRow}>
+        <textarea
+          ref={textareaRef}
+          className={css.composerInput}
+          rows={1}
+          placeholder="Message HybridClaw"
+          disabled={props.isStreaming}
+          onInput={handleInput}
+          onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
+          aria-label="Message input"
+        />
+        <div className={css.composerActions}>
           <button
             type="button"
             className={css.attachButton}
@@ -236,17 +247,6 @@ export function Composer(props: {
           >
             +
           </button>
-          <textarea
-            ref={textareaRef}
-            className={css.composerInput}
-            rows={1}
-            placeholder="Message HybridClaw"
-            disabled={props.isStreaming}
-            onInput={handleInput}
-            onKeyDown={handleKeyDown}
-            onPaste={handlePaste}
-            aria-label="Message input"
-          />
           <button
             type="button"
             className={cx(css.sendButton, props.isStreaming && css.stopping)}

--- a/console/src/routes/chat/message-block.tsx
+++ b/console/src/routes/chat/message-block.tsx
@@ -188,7 +188,7 @@ export const MessageBlock = memo(function MessageBlock(props: {
   onApprovalAction: (action: ApprovalAction, approvalId: string) => void;
   approvalBusy: boolean;
   branchInfo: { current: number; total: number } | null;
-  onBranchNav: (direction: -1 | 1) => void;
+  onBranchNav: (message: ChatMessage, direction: -1 | 1) => void;
 }) {
   const { message: msg, token } = props;
   const [copied, setCopied] = useState(false);
@@ -373,7 +373,7 @@ export const MessageBlock = memo(function MessageBlock(props: {
                 className={css.branchButton}
                 aria-label="Previous branch"
                 disabled={props.branchInfo.current <= 1}
-                onClick={() => props.onBranchNav(-1)}
+                onClick={() => props.onBranchNav(msg, -1)}
               >
                 ‹
               </Button>
@@ -386,7 +386,7 @@ export const MessageBlock = memo(function MessageBlock(props: {
                 className={css.branchButton}
                 aria-label="Next branch"
                 disabled={props.branchInfo.current >= props.branchInfo.total}
-                onClick={() => props.onBranchNav(1)}
+                onClick={() => props.onBranchNav(msg, 1)}
               >
                 ›
               </Button>

--- a/console/src/routes/chat/message-block.tsx
+++ b/console/src/routes/chat/message-block.tsx
@@ -331,6 +331,18 @@ export const MessageBlock = memo(function MessageBlock(props: {
 
       {!props.isStreaming ? (
         <div className={css.messageActions}>
+          {isAssistant && msg.replayRequest ? (
+            <Button
+              variant="ghost"
+              size="icon"
+              className={css.actionButton}
+              title="Regenerate"
+              aria-label="Regenerate response"
+              onClick={() => props.onRegenerate(msg)}
+            >
+              ↻
+            </Button>
+          ) : null}
           <Button
             variant="ghost"
             size="icon"
@@ -351,18 +363,6 @@ export const MessageBlock = memo(function MessageBlock(props: {
               onClick={() => props.onEdit(msg)}
             >
               ✎
-            </Button>
-          ) : null}
-          {isAssistant && msg.replayRequest ? (
-            <Button
-              variant="ghost"
-              size="icon"
-              className={css.actionButton}
-              title="Regenerate"
-              aria-label="Regenerate response"
-              onClick={() => props.onRegenerate(msg)}
-            >
-              ↻
             </Button>
           ) : null}
           {props.branchInfo && props.branchInfo.total > 1 ? (

--- a/console/src/routes/chat/use-chat-stream.ts
+++ b/console/src/routes/chat/use-chat-stream.ts
@@ -8,6 +8,7 @@ import type {
 } from '../../api/chat-types';
 import { buildApprovalSummary, nextMsgId } from '../../lib/chat-helpers';
 import { requestChatStream } from '../../lib/chat-stream';
+import { getErrorMessage } from '../../lib/error-message';
 import type { ChatUiMessage, ThinkingChatMessage } from './chat-ui-message';
 
 interface ActiveRequest {
@@ -25,8 +26,8 @@ interface UseChatStreamOptions {
   userId: string;
   getSessionId: () => string;
   setMessages: React.Dispatch<React.SetStateAction<ChatUiMessage[]>>;
-  setSessionId: React.Dispatch<React.SetStateAction<string>>;
-  setError: React.Dispatch<React.SetStateAction<string>>;
+  setSessionId: (id: string) => void;
+  setError: (err: string) => void;
   refreshRecent: () => void;
 }
 
@@ -241,8 +242,7 @@ export function useChatStream(
         refreshRecent();
       } catch (err) {
         if (req.renderFrame) cancelAnimationFrame(req.renderFrame);
-        const errorText =
-          !req.stopping && err instanceof Error ? err.message : String(err);
+        const errorText = getErrorMessage(err);
         setMessages((prev) => {
           const withoutThinking = prev.filter((m) => m.id !== thinkingId);
           if (req.stopping) return withoutThinking;
@@ -282,9 +282,7 @@ export function useChatStream(
     try {
       await executeCommand(token, req.sessionId, userId, ['stop']);
     } catch (err) {
-      setError(
-        `Failed to stop: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      setError(`Failed to stop: ${getErrorMessage(err)}`);
     } finally {
       req.controller.abort();
     }

--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -2,7 +2,7 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  base: '/admin/',
+  base: '/',
   build: {
     outDir: 'dist',
     emptyOutDir: true,

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -713,18 +713,24 @@ function resolveHybridAILoginUrl(): string | null {
   return `${baseUrl}${HYBRIDAI_LOGIN_PATH}`;
 }
 
+function isConsoleSpaPath(pathname: string): boolean {
+  return (
+    pathname === '/admin' ||
+    pathname.startsWith('/admin/') ||
+    pathname === '/chat' ||
+    pathname.startsWith('/chat/')
+  );
+}
+
 function requiresSessionAuth(pathname: string): boolean {
   if (!getSandboxAutoDetectionState().runningInsideContainer) {
     return false;
   }
 
   return (
-    pathname === '/chat' ||
-    pathname === '/chat.html' ||
     pathname === '/agents' ||
     pathname === '/agents.html' ||
-    pathname === '/admin' ||
-    pathname.startsWith('/admin/')
+    isConsoleSpaPath(pathname)
   );
 }
 
@@ -1180,13 +1186,11 @@ function serveStatic(url: URL, res: ServerResponse): boolean {
   const pathname = url.pathname;
   if (serveDocs(url, res)) return true;
   const filePath = resolveSiteFile(
-    pathname === '/chat'
-      ? '/chat.html'
-      : pathname === '/agents'
-        ? '/agents.html'
-        : pathname === '/about' || pathname === '/about/'
-          ? '/index.html'
-          : pathname,
+    pathname === '/agents'
+      ? '/agents.html'
+      : pathname === '/about' || pathname === '/about/'
+        ? '/index.html'
+        : pathname,
   );
   if (!filePath) return false;
   const ext = path.extname(filePath).toLowerCase();
@@ -1196,15 +1200,10 @@ function serveStatic(url: URL, res: ServerResponse): boolean {
   return true;
 }
 
-function resolveConsoleFile(pathname: string): string | null {
-  const subPath = pathname.replace(/^\/admin/, '') || '/index.html';
-  const directFile = resolveStaticFile(CONSOLE_DIST_DIR, subPath);
-  if (directFile) return directFile;
-  return resolveStaticFile(CONSOLE_DIST_DIR, '/index.html');
-}
-
-function serveConsole(pathname: string, res: ServerResponse): boolean {
-  const filePath = resolveConsoleFile(pathname);
+function serveConsoleFile(
+  filePath: string | null,
+  res: ServerResponse,
+): boolean {
   if (!filePath) return false;
   const ext = path.extname(filePath).toLowerCase();
   const mimeType = SITE_MIME_TYPES[ext] || 'application/octet-stream';
@@ -1216,6 +1215,17 @@ function serveConsole(pathname: string, res: ServerResponse): boolean {
   });
   res.end(fs.readFileSync(filePath));
   return true;
+}
+
+function serveConsoleAsset(pathname: string, res: ServerResponse): boolean {
+  return serveConsoleFile(resolveStaticFile(CONSOLE_DIST_DIR, pathname), res);
+}
+
+function serveConsoleIndex(res: ServerResponse): boolean {
+  return serveConsoleFile(
+    resolveStaticFile(CONSOLE_DIST_DIR, '/index.html'),
+    res,
+  );
 }
 
 async function handleApiChat(
@@ -3734,12 +3744,18 @@ export function startGatewayHttpServer(): GatewayHttpServer {
       return;
     }
 
+    if (pathname.startsWith('/assets/')) {
+      if (serveConsoleAsset(pathname, res)) return;
+      sendText(res, 404, 'Not Found');
+      return;
+    }
+
     if (requiresSessionAuth(pathname) && !ensureSessionAuth(req, res)) {
       return;
     }
 
-    if (pathname.startsWith('/admin')) {
-      if (serveConsole(pathname, res)) return;
+    if (isConsoleSpaPath(pathname)) {
+      if (serveConsoleIndex(res)) return;
       sendText(
         res,
         503,

--- a/tests/npm-install.e2e.test.ts
+++ b/tests/npm-install.e2e.test.ts
@@ -194,13 +194,13 @@ describe.skipIf(!NPM_E2E)('npm install user journey', () => {
     );
   });
 
-  test('/chat serves the chat SPA', async () => {
+  test('/chat serves the console SPA (chat is top-level, not under /admin)', async () => {
     const res = await fetch(`${GATEWAY_URL}/chat`, {
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
     expect(res.status).toBe(200);
     const html = await res.text();
-    expect(html).toContain('<title>HybridClaw Chat</title>');
+    expect(html).toContain('<title>HybridClaw Admin</title>');
   });
 
   test('/admin serves the console (host mode, no container auth)', async () => {


### PR DESCRIPTION
## Summary

- Extract `isConsoleSpaPath()` so `/chat` and `/admin` share one auth gate and one SPA mount point.
- Split the old `serveConsole` / `resolveConsoleFile` into `serveConsoleFile` + `serveConsoleAsset` + `serveConsoleIndex`.
- Add a top-level `/assets/*` route so the console bundle can load its assets from the root instead of `/admin/assets`.
- Flip `console/vite.config.ts` base from `/admin/` to `/` to match.

After this change, `/chat` serves the console SPA instead of the legacy `docs/chat.html`. The legacy file is left on disk for now — a follow-up PR deletes it once nothing references it.

Split out of #323 to keep the routing change reviewable on its own.

## Test plan

- [ ] `/chat` returns 200 with `<title>HybridClaw Admin</title>` (console SPA)
- [ ] `/admin` continues to serve the console SPA
- [ ] `/chat/*` sub-paths fall through to the SPA for client-side routing
- [ ] `/assets/<hashed-name>.js` serves the console's JS bundle
- [ ] Docker-mode session auth still gates `/chat` and `/admin` as before
- [ ] `pnpm test tests/gateway-http-server.test.ts` and `pnpm test tests/npm-install.e2e.test.ts` pass