### PR TITLE
feat(agent): add agent config command for JSON-based agents

### DIFF
--- a/console/src/api/chat.ts
+++ b/console/src/api/chat.ts
@@ -106,11 +106,15 @@ export function artifactUrl(path: string): string {
   return `/api/artifact?${params.toString()}`;
 }
 
-export async function fetchArtifactBlob(
+export function agentAvatarUrl(imageUrl: string): string {
+  return imageUrl;
+}
+
+async function fetchAuthenticatedBlob(
   token: string,
-  artifactPath: string,
+  url: string,
 ): Promise<Blob> {
-  const response = await fetch(artifactUrl(artifactPath), {
+  const response = await fetch(url, {
     headers: requestHeaders(token),
     cache: 'no-store',
   });
@@ -139,4 +143,18 @@ export async function fetchArtifactBlob(
   }
 
   return response.blob();
+}
+
+export async function fetchArtifactBlob(
+  token: string,
+  artifactPath: string,
+): Promise<Blob> {
+  return fetchAuthenticatedBlob(token, artifactUrl(artifactPath));
+}
+
+export function fetchAgentAvatarBlob(
+  token: string,
+  imageUrl: string,
+): Promise<Blob> {
+  return fetchAuthenticatedBlob(token, agentAvatarUrl(imageUrl));
 }

--- a/console/src/routes/chat/message-block.test.tsx
+++ b/console/src/routes/chat/message-block.test.tsx
@@ -12,9 +12,13 @@ import { MessageBlock } from './message-block';
 
 const fetchArtifactBlobMock =
   vi.fn<(token: string, artifactPath: string) => Promise<Blob>>();
+const fetchAgentAvatarBlobMock =
+  vi.fn<(token: string, imageUrl: string) => Promise<Blob>>();
 const renderMarkdownMock = vi.fn<(content: string) => string>();
 
 vi.mock('../../api/chat', () => ({
+  fetchAgentAvatarBlob: (token: string, imageUrl: string) =>
+    fetchAgentAvatarBlobMock(token, imageUrl),
   fetchArtifactBlob: (token: string, artifactPath: string) =>
     fetchArtifactBlobMock(token, artifactPath),
 }));
@@ -40,6 +44,7 @@ function makeMessage(
 
 describe('MessageBlock artifacts', () => {
   beforeEach(() => {
+    fetchAgentAvatarBlobMock.mockReset();
     fetchArtifactBlobMock.mockReset();
     renderMarkdownMock.mockReset();
     renderMarkdownMock.mockImplementation((content) => `<p>${content}</p>`);
@@ -95,6 +100,45 @@ describe('MessageBlock artifacts', () => {
     );
     expect(
       container.querySelector('[src*="token="], [href*="token="]'),
+    ).toBeNull();
+  });
+
+  it('renders assistant avatars through the authenticated blob helper', async () => {
+    fetchAgentAvatarBlobMock.mockResolvedValue(
+      new Blob(['avatar-bytes'], { type: 'image/jpeg' }),
+    );
+
+    const { container } = render(
+      <MessageBlock
+        message={makeMessage([], {
+          assistantPresentation: {
+            agentId: 'stephan',
+            displayName: 'Stephan',
+            imageUrl: '/api/agent-avatar?agentId=stephan',
+          },
+        })}
+        token="test-token"
+        isStreaming={false}
+        onCopy={vi.fn()}
+        onEdit={vi.fn()}
+        onRegenerate={vi.fn()}
+        onApprovalAction={vi.fn()}
+        approvalBusy={false}
+        branchInfo={null}
+        onBranchNav={vi.fn()}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(fetchAgentAvatarBlobMock).toHaveBeenCalledWith(
+        'test-token',
+        '/api/agent-avatar?agentId=stephan',
+      ),
+    );
+    const avatar = container.querySelector('img');
+    expect(avatar?.getAttribute('src')).toBe('blob:artifact');
+    expect(
+      container.querySelector('img[src="/api/agent-avatar?agentId=stephan"]'),
     ).toBeNull();
   });
 

--- a/console/src/routes/chat/message-block.tsx
+++ b/console/src/routes/chat/message-block.tsx
@@ -6,7 +6,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { fetchArtifactBlob } from '../../api/chat';
+import { fetchAgentAvatarBlob, fetchArtifactBlob } from '../../api/chat';
 import type { ChatArtifact, ChatMessage } from '../../api/chat-types';
 import { Button } from '../../components/button';
 import type { ApprovalAction } from '../../lib/chat-helpers';
@@ -178,6 +178,44 @@ function ArtifactCard(props: { artifact: ChatArtifact; token: string }) {
   );
 }
 
+function useAuthenticatedImageUrl(params: {
+  token: string;
+  imageUrl?: string | null;
+}): string | null {
+  const objectUrlRef = useRef<string | null>(null);
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    const previousUrl = objectUrlRef.current;
+    objectUrlRef.current = null;
+    if (previousUrl) URL.revokeObjectURL(previousUrl);
+    setObjectUrl(null);
+
+    if (!params.imageUrl) return;
+
+    let cancelled = false;
+    void fetchAgentAvatarBlob(params.token, params.imageUrl)
+      .then((blob) => {
+        if (cancelled) return;
+        const nextUrl = URL.createObjectURL(blob);
+        objectUrlRef.current = nextUrl;
+        setObjectUrl(nextUrl);
+      })
+      .catch(() => {
+        if (!cancelled) setObjectUrl(null);
+      });
+
+    return () => {
+      cancelled = true;
+      const nextUrl = objectUrlRef.current;
+      objectUrlRef.current = null;
+      if (nextUrl) URL.revokeObjectURL(nextUrl);
+    };
+  }, [params.imageUrl, params.token]);
+
+  return objectUrl;
+}
+
 export const MessageBlock = memo(function MessageBlock(props: {
   message: ChatUiMessage;
   token: string;
@@ -227,6 +265,12 @@ export const MessageBlock = memo(function MessageBlock(props: {
     isMarkdownMessage,
     props.isStreaming,
   );
+  const presentation = msg.assistantPresentation;
+  const displayName = presentation?.displayName ?? 'Assistant';
+  const avatarUrl = useAuthenticatedImageUrl({
+    token,
+    imageUrl: presentation?.imageUrl,
+  });
 
   if (msg.role === 'thinking') {
     return (
@@ -256,19 +300,12 @@ export const MessageBlock = memo(function MessageBlock(props: {
     msg.role === 'system' && css.bubbleSystem,
   );
 
-  const presentation = msg.assistantPresentation;
-  const displayName = presentation?.displayName ?? 'Assistant';
-
   return (
     <div className={blockClass}>
       {isAssistant ? (
         <div className={css.agentLabel}>
-          {presentation?.imageUrl ? (
-            <img
-              className={css.agentAvatar}
-              src={presentation.imageUrl}
-              alt=""
-            />
+          {avatarUrl ? (
+            <img className={css.agentAvatar} src={avatarUrl} alt="" />
           ) : (
             <span className={css.agentInitial}>
               {displayName.charAt(0).toUpperCase()}

--- a/docs/chat.html
+++ b/docs/chat.html
@@ -1988,7 +1988,8 @@
       const avatar = document.createElement('img');
       avatar.className = 'msg-agent-avatar';
       avatar.alt = displayName;
-      avatar.loading = 'lazy';
+      avatar.loading = 'eager';
+      avatar.decoding = 'async';
 
       await new Promise((resolve) => {
         avatar.addEventListener('load', resolve, { once: true });

--- a/docs/content/extensibility/README.md
+++ b/docs/content/extensibility/README.md
@@ -172,6 +172,7 @@ hybridclaw skill import [--force] [--skip-skill-scan] <source>
 /skill learn <name> [--apply|--reject|--rollback] # TUI/web slash amendment flow
 
 # Agent packages
+hybridclaw agent config <json|--json <json>> [--activate]
 hybridclaw agent export [agent-id] [-o <path>]
 hybridclaw agent inspect <file.claw>
 hybridclaw agent install <file.claw|https://.../*.claw|official:<agent-dir>|github:owner/repo[/<ref>]/<agent-dir>> [--id <id>] [--force] [--skip-skill-scan] [--skip-externals] [--skip-import-errors] [--yes]
@@ -191,3 +192,6 @@ hybridclaw plugin uninstall <plugin-id>
 
 For the `.claw` archive layout and manifest fields, see
 [Agent Packages (`.claw`)](./agent-packages.md).
+For platform-generated agents that only need registry metadata and top-level
+workspace markdown files, use `hybridclaw agent config` with a quoted JSON
+payload instead of generating an archive.

--- a/docs/content/extensibility/agent-packages.md
+++ b/docs/content/extensibility/agent-packages.md
@@ -109,6 +109,11 @@ payload can update only markdown without clearing the model, bot binding, skill
 allowlist, or RAG setting. Passing an empty value for a supported agent field
 clears that field.
 
+When `imageAsset` is an `http`/`https` URL or a local file path, `agent config`
+imports the image into the target workspace `assets/` directory and stores that
+workspace-relative path in the agent registry. Existing workspace-relative
+`imageAsset` paths are preserved as provided.
+
 Use `.claw` archives instead when you need portability, arbitrary workspace
 files, bundled workspace skills, bundled home plugins, or install-time external
 skill imports.
@@ -438,8 +443,9 @@ imports and other external references during install.
 5. registers the agent in the normal agent registry
 6. calls `ensureBootstrapFiles()` to create the workspace and fill missing
    templates
-7. overwrites any provided top-level `.md` files from `markdown` or `files`
-8. writes `agents.defaultAgentId` into runtime config when `--activate` is set
+7. imports `imageAsset` URLs or local file paths into workspace `assets/`
+8. overwrites any provided top-level `.md` files from `markdown` or `files`
+9. writes `agents.defaultAgentId` into runtime config when `--activate` is set
 
 Markdown file names must be top-level `.md` names. Nested paths such as
 `docs/IDENTITY.md`, absolute paths, and traversal segments are rejected. Each

--- a/docs/content/extensibility/agent-packages.md
+++ b/docs/content/extensibility/agent-packages.md
@@ -22,6 +22,7 @@ Use it when you want to:
 
 ```bash
 hybridclaw agent list
+hybridclaw agent config <json|--json <json>> [--activate]
 hybridclaw agent export [agent-id] [-o <path>] [--description <text>] [--author <text>] [--version <value>] [--dry-run] [--skills <ask|active|all|some>] [--skill <name>]... [--plugins <ask|active|all|some>] [--plugin <id>]...
 hybridclaw agent inspect <file.claw>
 hybridclaw agent install <file.claw|https://.../*.claw|official:<agent-dir>|github:owner/repo[/<ref>]/<agent-dir>> [--id <id>] [--force] [--skip-skill-scan] [--skip-externals] [--skip-import-errors] [--yes]
@@ -43,6 +44,9 @@ hybridclaw agent install /tmp/main.claw --id demo-agent
 
 # Install a packaged agent from the official claws repo
 hybridclaw agent install official:charly-neumann-executive-briefing-chief-of-staff --yes
+
+# Configure an agent from a platform-generated JSON payload
+hybridclaw agent config '{"id":"felix","model":"gpt-5.4-mini","markdown":{"IDENTITY.md":"# Felix\n"}}' --activate
 
 # Make one installed agent the default for new requests
 hybridclaw agent activate demo-agent
@@ -75,6 +79,39 @@ hybridclaw agent export main --plugins all
 # Bundle only a named plugin subset
 hybridclaw agent export main --plugins some --plugin demo-plugin --plugin qmd-memory
 ```
+
+## Configuring Agents From JSON
+
+Use `hybridclaw agent config` when another platform already has the agent
+metadata and markdown content as JSON, and you do not need a portable `.claw`
+archive. This is the lightweight provisioning path for generated agents in
+short-lived sandboxes.
+
+The payload may be the agent config object directly:
+
+```bash
+hybridclaw agent config '{"id":"research","name":"Research","model":"gpt-5.4-mini","chatbotId":"bot-123","enableRag":true,"skills":["memory"]}' --activate
+```
+
+Or it may wrap the config in `agent` and include workspace markdown files:
+
+```bash
+hybridclaw agent config --json '{"agent":{"id":"research","model":"gpt-5.4-mini"},"markdown":{"IDENTITY.md":"# Research\n","BOOT.md":"# Boot\n"}}'
+```
+
+`markdown` and `files` are aliases. Each entry overwrites one top-level `.md`
+file in the target agent workspace. This is intended for bootstrap files such
+as `IDENTITY.md`, `SOUL.md`, `BOOT.md`, `AGENTS.md`, `USER.md`, `TOOLS.md`,
+`MEMORY.md`, and `HEARTBEAT.md`.
+
+Omitted agent fields are preserved when the agent already exists, so a later
+payload can update only markdown without clearing the model, bot binding, skill
+allowlist, or RAG setting. Passing an empty value for a supported agent field
+clears that field.
+
+Use `.claw` archives instead when you need portability, arbitrary workspace
+files, bundled workspace skills, bundled home plugins, or install-time external
+skill imports.
 
 ## Installing From GitHub Sources
 
@@ -389,6 +426,24 @@ reuses one readline session for the whole export flow.
 Use `--force` to replace an existing agent workspace or reinstall bundled
 plugins during import. Use `--skip-externals` to skip manifest-declared skill
 imports and other external references during install.
+
+## What `config` Does
+
+`hybridclaw agent config` currently:
+
+1. parses the quoted JSON payload from the positional argument or `--json`
+2. reads agent fields either from the root object or from `agent`
+3. validates markdown file names before mutating the registry
+4. merges omitted fields with the existing registered agent, when present
+5. registers the agent in the normal agent registry
+6. calls `ensureBootstrapFiles()` to create the workspace and fill missing
+   templates
+7. overwrites any provided top-level `.md` files from `markdown` or `files`
+8. writes `agents.defaultAgentId` into runtime config when `--activate` is set
+
+Markdown file names must be top-level `.md` names. Nested paths such as
+`docs/IDENTITY.md`, absolute paths, and traversal segments are rejected. Each
+markdown value must be a string and is limited to 200 KB.
 
 ## What `activate` Does
 

--- a/docs/content/reference/commands.md
+++ b/docs/content/reference/commands.md
@@ -306,10 +306,11 @@ maps to `install`. Local TUI/web sessions also expose `/agent install <source>`
 for the same archive flows against a running gateway.
 
 `agent config` is the JSON provisioning path for generated agents. It upserts
-agent metadata directly and can overwrite top-level workspace markdown files:
+agent metadata directly, can overwrite top-level workspace markdown files, and
+imports `imageAsset` URLs or local file paths into the agent workspace:
 
 ```bash
-hybridclaw agent config '{"id":"felix","model":"gpt-5.4-mini","markdown":{"IDENTITY.md":"# Felix\n"}}' --activate
+hybridclaw agent config '{"id":"felix","model":"gpt-5.4-mini","imageAsset":"https://example.com/felix.jpg","markdown":{"IDENTITY.md":"# Felix\n"}}' --activate
 ```
 
 Use `agent config` for metadata plus bootstrap markdown. Use `agent install`

--- a/docs/content/reference/commands.md
+++ b/docs/content/reference/commands.md
@@ -292,6 +292,7 @@ WhatsApp pairing.
 
 ```bash
 hybridclaw agent list
+hybridclaw agent config <json|--json <json>> [--activate]
 hybridclaw agent export [agent-id] [-o <path>]
 hybridclaw agent inspect <file.claw>
 hybridclaw agent install <file.claw|https://.../*.claw|official:<agent-dir>|github:owner/repo[/<ref>]/<agent-dir>> [--id <id>] [--force] [--skip-skill-scan] [--skip-externals] [--skip-import-errors] [--yes]
@@ -303,6 +304,18 @@ hybridclaw gateway agent [list|switch <id>|create <id>|model [name]]
 aliases remain accepted: `agent pack` maps to `export`, and `agent unpack`
 maps to `install`. Local TUI/web sessions also expose `/agent install <source>`
 for the same archive flows against a running gateway.
+
+`agent config` is the JSON provisioning path for generated agents. It upserts
+agent metadata directly and can overwrite top-level workspace markdown files:
+
+```bash
+hybridclaw agent config '{"id":"felix","model":"gpt-5.4-mini","markdown":{"IDENTITY.md":"# Felix\n"}}' --activate
+```
+
+Use `agent config` for metadata plus bootstrap markdown. Use `agent install`
+when you need a portable `.claw` archive with arbitrary workspace files,
+bundled skills, bundled plugins, or install-time imports.
+
 For archive flags such as `--description`, `--author`, skill/plugin bundling,
 and GitHub install sources, see
 [Agent Packages](../extensibility/agent-packages.md).

--- a/docs/development/extensibility/README.md
+++ b/docs/development/extensibility/README.md
@@ -170,6 +170,7 @@ hybridclaw skill import [--force] [--skip-skill-scan] <source>
 /skill learn <name> [--apply|--reject|--rollback] # TUI/web slash amendment flow
 
 # Agent packages
+hybridclaw agent config <json|--json <json>> [--activate]
 hybridclaw agent export [agent-id] [-o <path>]
 hybridclaw agent inspect <file.claw>
 hybridclaw agent install <file.claw|https://.../*.claw|official:<agent-dir>|github:owner/repo[/<ref>]/<agent-dir>> [--id <id>] [--force] [--skip-skill-scan] [--skip-externals] [--skip-import-errors] [--yes]
@@ -189,3 +190,6 @@ hybridclaw plugin uninstall <plugin-id>
 
 For the `.claw` archive layout and manifest fields, see
 [Agent Packages (`.claw`)](./agent-packages.md).
+For platform-generated agents that only need registry metadata and top-level
+workspace markdown files, use `hybridclaw agent config` with a quoted JSON
+payload instead of generating an archive.

--- a/docs/development/extensibility/agent-packages.md
+++ b/docs/development/extensibility/agent-packages.md
@@ -109,6 +109,11 @@ payload can update only markdown without clearing the model, bot binding, skill
 allowlist, or RAG setting. Passing an empty value for a supported agent field
 clears that field.
 
+When `imageAsset` is an `http`/`https` URL or a local file path, `agent config`
+imports the image into the target workspace `assets/` directory and stores that
+workspace-relative path in the agent registry. Existing workspace-relative
+`imageAsset` paths are preserved as provided.
+
 Use `.claw` archives instead when you need portability, arbitrary workspace
 files, bundled workspace skills, bundled home plugins, or install-time external
 skill imports.
@@ -438,8 +443,9 @@ imports and other external references during install.
 5. registers the agent in the normal agent registry
 6. calls `ensureBootstrapFiles()` to create the workspace and fill missing
    templates
-7. overwrites any provided top-level `.md` files from `markdown` or `files`
-8. writes `agents.defaultAgentId` into runtime config when `--activate` is set
+7. imports `imageAsset` URLs or local file paths into workspace `assets/`
+8. overwrites any provided top-level `.md` files from `markdown` or `files`
+9. writes `agents.defaultAgentId` into runtime config when `--activate` is set
 
 Markdown file names must be top-level `.md` names. Nested paths such as
 `docs/IDENTITY.md`, absolute paths, and traversal segments are rejected. Each

--- a/docs/development/extensibility/agent-packages.md
+++ b/docs/development/extensibility/agent-packages.md
@@ -22,6 +22,7 @@ Use it when you want to:
 
 ```bash
 hybridclaw agent list
+hybridclaw agent config <json|--json <json>> [--activate]
 hybridclaw agent export [agent-id] [-o <path>] [--description <text>] [--author <text>] [--version <value>] [--dry-run] [--skills <ask|active|all|some>] [--skill <name>]... [--plugins <ask|active|all|some>] [--plugin <id>]...
 hybridclaw agent inspect <file.claw>
 hybridclaw agent install <file.claw|https://.../*.claw|official:<agent-dir>|github:owner/repo[/<ref>]/<agent-dir>> [--id <id>] [--force] [--skip-skill-scan] [--skip-externals] [--skip-import-errors] [--yes]
@@ -43,6 +44,9 @@ hybridclaw agent install /tmp/main.claw --id demo-agent
 
 # Install a packaged agent from the official claws repo
 hybridclaw agent install official:charly-neumann-executive-briefing-chief-of-staff --yes
+
+# Configure an agent from a platform-generated JSON payload
+hybridclaw agent config '{"id":"felix","model":"gpt-5.4-mini","markdown":{"IDENTITY.md":"# Felix\n"}}' --activate
 
 # Make one installed agent the default for new requests
 hybridclaw agent activate demo-agent
@@ -75,6 +79,39 @@ hybridclaw agent export main --plugins all
 # Bundle only a named plugin subset
 hybridclaw agent export main --plugins some --plugin demo-plugin --plugin qmd-memory
 ```
+
+## Configuring Agents From JSON
+
+Use `hybridclaw agent config` when another platform already has the agent
+metadata and markdown content as JSON, and you do not need a portable `.claw`
+archive. This is the lightweight provisioning path for generated agents in
+short-lived sandboxes.
+
+The payload may be the agent config object directly:
+
+```bash
+hybridclaw agent config '{"id":"research","name":"Research","model":"gpt-5.4-mini","chatbotId":"bot-123","enableRag":true,"skills":["memory"]}' --activate
+```
+
+Or it may wrap the config in `agent` and include workspace markdown files:
+
+```bash
+hybridclaw agent config --json '{"agent":{"id":"research","model":"gpt-5.4-mini"},"markdown":{"IDENTITY.md":"# Research\n","BOOT.md":"# Boot\n"}}'
+```
+
+`markdown` and `files` are aliases. Each entry overwrites one top-level `.md`
+file in the target agent workspace. This is intended for bootstrap files such
+as `IDENTITY.md`, `SOUL.md`, `BOOT.md`, `AGENTS.md`, `USER.md`, `TOOLS.md`,
+`MEMORY.md`, and `HEARTBEAT.md`.
+
+Omitted agent fields are preserved when the agent already exists, so a later
+payload can update only markdown without clearing the model, bot binding, skill
+allowlist, or RAG setting. Passing an empty value for a supported agent field
+clears that field.
+
+Use `.claw` archives instead when you need portability, arbitrary workspace
+files, bundled workspace skills, bundled home plugins, or install-time external
+skill imports.
 
 ## Installing From GitHub Sources
 
@@ -389,6 +426,24 @@ reuses one readline session for the whole export flow.
 Use `--force` to replace an existing agent workspace or reinstall bundled
 plugins during import. Use `--skip-externals` to skip manifest-declared skill
 imports and other external references during install.
+
+## What `config` Does
+
+`hybridclaw agent config` currently:
+
+1. parses the quoted JSON payload from the positional argument or `--json`
+2. reads agent fields either from the root object or from `agent`
+3. validates markdown file names before mutating the registry
+4. merges omitted fields with the existing registered agent, when present
+5. registers the agent in the normal agent registry
+6. calls `ensureBootstrapFiles()` to create the workspace and fill missing
+   templates
+7. overwrites any provided top-level `.md` files from `markdown` or `files`
+8. writes `agents.defaultAgentId` into runtime config when `--activate` is set
+
+Markdown file names must be top-level `.md` names. Nested paths such as
+`docs/IDENTITY.md`, absolute paths, and traversal segments are rejected. Each
+markdown value must be a string and is limited to 200 KB.
 
 ## What `activate` Does
 

--- a/docs/development/reference/commands.md
+++ b/docs/development/reference/commands.md
@@ -227,6 +227,7 @@ examples and current CLI-only limitations such as WhatsApp pairing.
 
 ```bash
 hybridclaw agent list
+hybridclaw agent config <json|--json <json>> [--activate]
 hybridclaw agent export [agent-id] [-o <path>]
 hybridclaw agent inspect <file.claw>
 hybridclaw agent install <file.claw|https://.../*.claw|official:<agent-dir>|github:owner/repo[/<ref>]/<agent-dir>> [--id <id>] [--force] [--skip-skill-scan] [--skip-externals] [--skip-import-errors] [--yes]
@@ -238,6 +239,18 @@ hybridclaw gateway agent [list|switch <id>|create <id>|model [name]]
 aliases remain accepted: `agent pack` maps to `export`, and `agent unpack`
 maps to `install`. Local TUI/web sessions also expose `/agent install <source>`
 for the same archive flows against a running gateway.
+
+`agent config` is the JSON provisioning path for generated agents. It upserts
+agent metadata directly and can overwrite top-level workspace markdown files:
+
+```bash
+hybridclaw agent config '{"id":"felix","model":"gpt-5.4-mini","markdown":{"IDENTITY.md":"# Felix\n"}}' --activate
+```
+
+Use `agent config` for metadata plus bootstrap markdown. Use `agent install`
+when you need a portable `.claw` archive with arbitrary workspace files,
+bundled skills, bundled plugins, or install-time imports.
+
 For archive flags such as `--description`, `--author`, skill/plugin bundling,
 and GitHub install sources, see
 [Agent Packages](../extensibility/agent-packages.md).

--- a/docs/development/reference/commands.md
+++ b/docs/development/reference/commands.md
@@ -241,10 +241,11 @@ maps to `install`. Local TUI/web sessions also expose `/agent install <source>`
 for the same archive flows against a running gateway.
 
 `agent config` is the JSON provisioning path for generated agents. It upserts
-agent metadata directly and can overwrite top-level workspace markdown files:
+agent metadata directly, can overwrite top-level workspace markdown files, and
+imports `imageAsset` URLs or local file paths into the agent workspace:
 
 ```bash
-hybridclaw agent config '{"id":"felix","model":"gpt-5.4-mini","markdown":{"IDENTITY.md":"# Felix\n"}}' --activate
+hybridclaw agent config '{"id":"felix","model":"gpt-5.4-mini","imageAsset":"https://example.com/felix.jpg","markdown":{"IDENTITY.md":"# Felix\n"}}' --activate
 ```
 
 Use `agent config` for metadata plus bootstrap markdown. Use `agent install`

--- a/src/agents/agent-config-command.ts
+++ b/src/agents/agent-config-command.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { agentWorkspaceDir } from '../infra/ipc.js';
 import { normalizeOptionalTrimmedUniqueStringArray } from '../utils/normalized-strings.js';
@@ -13,6 +14,23 @@ import { activateAgentInRuntimeConfig } from './agent-runtime-config.js';
 import type { AgentConfig, AgentModelConfig } from './agent-types.js';
 
 const MARKDOWN_MAX_BYTES = 200_000;
+const IMAGE_ASSET_MAX_BYTES = 5_000_000;
+const IMAGE_ASSET_DIR = 'assets';
+const IMAGE_EXTENSIONS = new Set([
+  '.gif',
+  '.jpeg',
+  '.jpg',
+  '.png',
+  '.svg',
+  '.webp',
+]);
+const IMAGE_EXTENSION_BY_MIME_TYPE: Record<string, string> = {
+  'image/gif': '.gif',
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/svg+xml': '.svg',
+  'image/webp': '.webp',
+};
 const TOP_LEVEL_MARKDOWN_FILE_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*\.md$/;
 
 export interface ApplyAgentConfigJsonOptions {
@@ -232,6 +250,151 @@ function normalizeTopLevelMarkdownFileName(fileName: string): string {
   return normalized;
 }
 
+function parseImageAssetUrl(value: string): URL | null {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeImageExtension(value: string): string {
+  const ext = path.extname(value).toLowerCase();
+  return IMAGE_EXTENSIONS.has(ext) ? ext : '';
+}
+
+function safeImageAssetFileName(
+  sourceName: string,
+  fallbackExt: string,
+): string {
+  const ext = normalizeImageExtension(sourceName) || fallbackExt;
+  if (!ext) {
+    throw new Error(
+      '`imageAsset` must reference a supported image file: .gif, .jpg, .jpeg, .png, .svg, or .webp.',
+    );
+  }
+  const rawBase = path.basename(sourceName, path.extname(sourceName));
+  const safeBase = rawBase
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/^[._-]+|[._-]+$/g, '')
+    .slice(0, 80);
+  return `${safeBase || 'agent-avatar'}${ext}`;
+}
+
+function writeImportedImageAsset(params: {
+  workspacePath: string;
+  fileName: string;
+  content: Buffer;
+}): string {
+  if (params.content.byteLength > IMAGE_ASSET_MAX_BYTES) {
+    throw new Error(
+      `Image asset "${params.fileName}" exceeds the ${IMAGE_ASSET_MAX_BYTES}-byte limit.`,
+    );
+  }
+  const relativePath = `${IMAGE_ASSET_DIR}/${params.fileName}`;
+  const targetPath = path.join(params.workspacePath, relativePath);
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  const tempPath = `${targetPath}.tmp-${process.pid}-${Date.now().toString(36)}`;
+  fs.writeFileSync(tempPath, params.content);
+  fs.renameSync(tempPath, targetPath);
+  return relativePath;
+}
+
+async function downloadImageAsset(
+  workspacePath: string,
+  url: URL,
+): Promise<string> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download imageAsset from ${url.toString()}: ${response.status} ${response.statusText}`,
+    );
+  }
+  const contentLength = Number(response.headers.get('content-length') || 0);
+  if (contentLength > IMAGE_ASSET_MAX_BYTES) {
+    throw new Error(
+      `Image asset "${url.toString()}" exceeds the ${IMAGE_ASSET_MAX_BYTES}-byte limit.`,
+    );
+  }
+  const contentType =
+    response.headers.get('content-type')?.split(';')[0]?.trim().toLowerCase() ||
+    '';
+  if (contentType && !contentType.startsWith('image/')) {
+    throw new Error('`imageAsset` URL must return an image content type.');
+  }
+  const fallbackExt = IMAGE_EXTENSION_BY_MIME_TYPE[contentType] || '';
+  const sourceName = decodeURIComponent(path.basename(url.pathname) || '');
+  const fileName = safeImageAssetFileName(sourceName, fallbackExt);
+  const content = Buffer.from(await response.arrayBuffer());
+  return writeImportedImageAsset({ workspacePath, fileName, content });
+}
+
+function resolveLocalImageAssetPath(value: string): string | null {
+  try {
+    const url = new URL(value);
+    if (url.protocol === 'file:') return fileURLToPath(url);
+    return null;
+  } catch {
+    // Not a URL; continue with local path checks.
+  }
+  if (
+    path.isAbsolute(value) ||
+    value.startsWith('./') ||
+    value.startsWith('../')
+  ) {
+    return path.resolve(value);
+  }
+  const cwdRelativePath = path.resolve(value);
+  if (fs.existsSync(cwdRelativePath)) return cwdRelativePath;
+  return null;
+}
+
+function copyLocalImageAsset(
+  workspacePath: string,
+  sourcePath: string,
+): string {
+  let stats: fs.Stats;
+  try {
+    stats = fs.statSync(sourcePath);
+  } catch {
+    throw new Error(`Image asset file not found: ${sourcePath}`);
+  }
+  if (!stats.isFile()) {
+    throw new Error(`Image asset is not a file: ${sourcePath}`);
+  }
+  if (stats.size > IMAGE_ASSET_MAX_BYTES) {
+    throw new Error(
+      `Image asset "${sourcePath}" exceeds the ${IMAGE_ASSET_MAX_BYTES}-byte limit.`,
+    );
+  }
+  const workspaceRelative = path.relative(workspacePath, sourcePath);
+  if (
+    workspaceRelative &&
+    !workspaceRelative.startsWith('..') &&
+    !path.isAbsolute(workspaceRelative)
+  ) {
+    return workspaceRelative.split(path.sep).join('/');
+  }
+  const fileName = safeImageAssetFileName(path.basename(sourcePath), '');
+  return writeImportedImageAsset({
+    workspacePath,
+    fileName,
+    content: fs.readFileSync(sourcePath),
+  });
+}
+
+async function importImageAssetIfNeeded(
+  workspacePath: string,
+  imageAsset: string,
+): Promise<string> {
+  const url = parseImageAssetUrl(imageAsset);
+  if (url) return downloadImageAsset(workspacePath, url);
+  const localPath = resolveLocalImageAssetPath(imageAsset);
+  if (localPath) return copyLocalImageAsset(workspacePath, localPath);
+  return imageAsset;
+}
+
 function writeWorkspaceMarkdownFile(
   workspacePath: string,
   fileName: string,
@@ -261,10 +424,10 @@ function normalizeMarkdownEntries(
   });
 }
 
-export function applyAgentConfigJson(
+export async function applyAgentConfigJson(
   rawJson: string,
   options: ApplyAgentConfigJsonOptions = {},
-): ApplyAgentConfigJsonResult {
+): Promise<ApplyAgentConfigJsonResult> {
   const payload = parseAgentConfigJson(rawJson);
   const configInput = resolveAgentConfigInput(payload);
   const id = normalizeOptionalString(configInput.id);
@@ -276,12 +439,20 @@ export function applyAgentConfigJson(
   );
 
   const existing = getStoredAgentConfig(id) ?? getAgentById(id) ?? { id };
-  const saved = upsertRegisteredAgent(
-    applyAgentConfigFieldUpdates(existing, configInput),
-  );
-  ensureBootstrapFiles(saved.id);
-  const workspacePath = path.resolve(agentWorkspaceDir(saved.id));
+  const nextAgent = applyAgentConfigFieldUpdates(existing, configInput);
+  ensureBootstrapFiles(nextAgent.id);
+  const workspacePath = path.resolve(agentWorkspaceDir(nextAgent.id));
   fs.mkdirSync(workspacePath, { recursive: true });
+  if (
+    Object.hasOwn(configInput, 'imageAsset') &&
+    typeof nextAgent.imageAsset === 'string'
+  ) {
+    nextAgent.imageAsset = await importImageAssetIfNeeded(
+      workspacePath,
+      nextAgent.imageAsset,
+    );
+  }
+  const saved = upsertRegisteredAgent(nextAgent);
   const markdownFiles: string[] = [];
   for (const entry of markdownEntries) {
     writeWorkspaceMarkdownFile(workspacePath, entry.fileName, entry.content);

--- a/src/agents/agent-config-command.ts
+++ b/src/agents/agent-config-command.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { updateRuntimeConfig } from '../config/runtime-config.js';
 import { agentWorkspaceDir } from '../infra/ipc.js';
 import { normalizeOptionalTrimmedUniqueStringArray } from '../utils/normalized-strings.js';
 import { ensureBootstrapFiles } from '../workspace.js';
@@ -10,6 +9,7 @@ import {
   getStoredAgentConfig,
   upsertRegisteredAgent,
 } from './agent-registry.js';
+import { activateAgentInRuntimeConfig } from './agent-runtime-config.js';
 import type { AgentConfig, AgentModelConfig } from './agent-types.js';
 
 const MARKDOWN_MAX_BYTES = 200_000;
@@ -36,14 +36,50 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
-function hasOwn(value: Record<string, unknown>, key: string): boolean {
-  return Object.hasOwn(value, key);
-}
-
 function normalizeOptionalString(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
   const normalized = value.trim();
   return normalized || undefined;
+}
+
+function normalizeRequiredStringField(
+  fieldName: string,
+  value: unknown,
+): string {
+  if (typeof value !== 'string') {
+    throw new Error(`\`${fieldName}\` must be a string.`);
+  }
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`Agent config JSON requires a non-empty \`${fieldName}\`.`);
+  }
+  return normalized;
+}
+
+function normalizeOptionalStringField(
+  fieldName: string,
+  value: unknown,
+): string | undefined {
+  if (value === null) return undefined;
+  if (typeof value !== 'string') {
+    throw new Error(`\`${fieldName}\` must be a string or null.`);
+  }
+  const normalized = value.trim();
+  return normalized || undefined;
+}
+
+function normalizeOptionalStringArrayField(
+  fieldName: string,
+  value: unknown,
+): string[] | undefined {
+  if (value === null) return undefined;
+  if (!Array.isArray(value)) {
+    throw new Error(`\`${fieldName}\` must be an array of strings or null.`);
+  }
+  if (value.some((entry) => typeof entry !== 'string')) {
+    throw new Error(`\`${fieldName}\` must be an array of strings or null.`);
+  }
+  return normalizeOptionalTrimmedUniqueStringArray(value);
 }
 
 function normalizeModelConfig(value: unknown): AgentModelConfig | undefined {
@@ -99,52 +135,65 @@ function applyAgentConfigFieldUpdates(
   base: AgentConfig,
   updates: Record<string, unknown>,
 ): AgentConfig {
-  const id = normalizeOptionalString(updates.id) || base.id;
-  if (!id) {
-    throw new Error('Agent config JSON requires a non-empty `id`.');
-  }
+  const id = Object.hasOwn(updates, 'id')
+    ? normalizeRequiredStringField('id', updates.id)
+    : base.id;
 
   const next: AgentConfig = { ...base, id };
-  if (hasOwn(updates, 'name')) {
-    const name = normalizeOptionalString(updates.name);
+  if (Object.hasOwn(updates, 'name')) {
+    const name = normalizeOptionalStringField('name', updates.name);
     if (name) next.name = name;
     else delete next.name;
   }
-  if (hasOwn(updates, 'displayName')) {
-    const displayName = normalizeOptionalString(updates.displayName);
+  if (Object.hasOwn(updates, 'displayName')) {
+    const displayName = normalizeOptionalStringField(
+      'displayName',
+      updates.displayName,
+    );
     if (displayName) next.displayName = displayName;
     else delete next.displayName;
   }
-  if (hasOwn(updates, 'imageAsset')) {
-    const imageAsset = normalizeOptionalString(updates.imageAsset);
+  if (Object.hasOwn(updates, 'imageAsset')) {
+    const imageAsset = normalizeOptionalStringField(
+      'imageAsset',
+      updates.imageAsset,
+    );
     if (imageAsset) next.imageAsset = imageAsset;
     else delete next.imageAsset;
   }
-  if (hasOwn(updates, 'model')) {
+  if (Object.hasOwn(updates, 'model')) {
     const model = normalizeModelConfig(updates.model);
     if (model) next.model = model;
     else delete next.model;
   }
-  if (hasOwn(updates, 'skills')) {
-    const skills = normalizeOptionalTrimmedUniqueStringArray(updates.skills);
+  if (Object.hasOwn(updates, 'skills')) {
+    const skills = normalizeOptionalStringArrayField('skills', updates.skills);
     if (skills !== undefined) next.skills = skills;
     else delete next.skills;
   }
-  if (hasOwn(updates, 'workspace')) {
-    const workspace = normalizeOptionalString(updates.workspace);
+  if (Object.hasOwn(updates, 'workspace')) {
+    const workspace = normalizeOptionalStringField(
+      'workspace',
+      updates.workspace,
+    );
     if (workspace) next.workspace = workspace;
     else delete next.workspace;
   }
-  if (hasOwn(updates, 'chatbotId')) {
-    const chatbotId = normalizeOptionalString(updates.chatbotId);
+  if (Object.hasOwn(updates, 'chatbotId')) {
+    const chatbotId = normalizeOptionalStringField(
+      'chatbotId',
+      updates.chatbotId,
+    );
     if (chatbotId) next.chatbotId = chatbotId;
     else delete next.chatbotId;
   }
-  if (hasOwn(updates, 'enableRag')) {
+  if (Object.hasOwn(updates, 'enableRag')) {
     if (typeof updates.enableRag === 'boolean') {
       next.enableRag = updates.enableRag;
-    } else {
+    } else if (updates.enableRag === null) {
       delete next.enableRag;
+    } else {
+      throw new Error('`enableRag` must be a boolean or null.');
     }
   }
   return next;
@@ -153,16 +202,15 @@ function applyAgentConfigFieldUpdates(
 function resolveMarkdownInput(
   payload: AgentConfigJsonPayload,
 ): Record<string, string> {
-  const markdownMaps = [payload.markdown, payload.files].filter(
-    (entry) => entry !== undefined,
-  );
-  if (markdownMaps.length === 0) return {};
-  if (markdownMaps.length > 1) {
+  if (payload.markdown !== undefined && payload.files !== undefined) {
     throw new Error('Provide either `markdown` or `files`, not both.');
   }
-  const markdown = markdownMaps[0];
+  const markdown = payload.markdown ?? payload.files;
+  if (markdown === undefined) return {};
   if (!isRecord(markdown)) {
-    throw new Error('`markdown`/`files` must be an object of filename to text.');
+    throw new Error(
+      '`markdown`/`files` must be an object of filename to text.',
+    );
   }
   const result: Record<string, string> = {};
   for (const [fileName, content] of Object.entries(markdown)) {
@@ -184,22 +232,14 @@ function normalizeTopLevelMarkdownFileName(fileName: string): string {
   return normalized;
 }
 
-function writeWorkspaceMarkdownFile(params: {
-  workspacePath: string;
-  fileName: string;
-  content: string;
-}): void {
-  const sizeBytes = Buffer.byteLength(params.content, 'utf-8');
-  if (sizeBytes > MARKDOWN_MAX_BYTES) {
-    throw new Error(
-      `Markdown file "${params.fileName}" exceeds the ${MARKDOWN_MAX_BYTES}-byte limit.`,
-    );
-  }
-
-  const filePath = path.join(params.workspacePath, params.fileName);
-  fs.mkdirSync(params.workspacePath, { recursive: true });
+function writeWorkspaceMarkdownFile(
+  workspacePath: string,
+  fileName: string,
+  content: string,
+): void {
+  const filePath = path.join(workspacePath, fileName);
   const tempPath = `${filePath}.tmp-${process.pid}-${Date.now().toString(36)}`;
-  fs.writeFileSync(tempPath, params.content, 'utf-8');
+  fs.writeFileSync(tempPath, content, 'utf-8');
   fs.renameSync(tempPath, filePath);
 }
 
@@ -221,25 +261,6 @@ function normalizeMarkdownEntries(
   });
 }
 
-function activateAgent(agent: AgentConfig): void {
-  updateRuntimeConfig((draft) => {
-    draft.agents ??= {};
-    const nextAgents = Array.isArray(draft.agents.list)
-      ? [...draft.agents.list]
-      : [];
-    const existingIndex = nextAgents.findIndex(
-      (entry) => entry?.id?.trim() === agent.id,
-    );
-    if (existingIndex >= 0) {
-      nextAgents[existingIndex] = agent;
-    } else {
-      nextAgents.push(agent);
-    }
-    draft.agents.list = nextAgents;
-    draft.agents.defaultAgentId = agent.id;
-  });
-}
-
 export function applyAgentConfigJson(
   rawJson: string,
   options: ApplyAgentConfigJsonOptions = {},
@@ -250,7 +271,9 @@ export function applyAgentConfigJson(
   if (!id) {
     throw new Error('Agent config JSON requires a non-empty `id`.');
   }
-  const markdownEntries = normalizeMarkdownEntries(resolveMarkdownInput(payload));
+  const markdownEntries = normalizeMarkdownEntries(
+    resolveMarkdownInput(payload),
+  );
 
   const existing = getStoredAgentConfig(id) ?? getAgentById(id) ?? { id };
   const saved = upsertRegisteredAgent(
@@ -258,23 +281,20 @@ export function applyAgentConfigJson(
   );
   ensureBootstrapFiles(saved.id);
   const workspacePath = path.resolve(agentWorkspaceDir(saved.id));
+  fs.mkdirSync(workspacePath, { recursive: true });
   const markdownFiles: string[] = [];
   for (const entry of markdownEntries) {
-    writeWorkspaceMarkdownFile({
-      workspacePath,
-      fileName: entry.fileName,
-      content: entry.content,
-    });
+    writeWorkspaceMarkdownFile(workspacePath, entry.fileName, entry.content);
     markdownFiles.push(entry.fileName);
   }
-  if (options.activate) {
-    activateAgent(saved);
-  }
+  const runtimeConfigChanged = options.activate
+    ? activateAgentInRuntimeConfig(saved)
+    : false;
 
   return {
     agent: saved,
     workspacePath,
     markdownFiles,
-    runtimeConfigChanged: Boolean(options.activate),
+    runtimeConfigChanged,
   };
 }

--- a/src/agents/agent-config-command.ts
+++ b/src/agents/agent-config-command.ts
@@ -1,0 +1,280 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { updateRuntimeConfig } from '../config/runtime-config.js';
+import { agentWorkspaceDir } from '../infra/ipc.js';
+import { normalizeOptionalTrimmedUniqueStringArray } from '../utils/normalized-strings.js';
+import { ensureBootstrapFiles } from '../workspace.js';
+import {
+  getAgentById,
+  getStoredAgentConfig,
+  upsertRegisteredAgent,
+} from './agent-registry.js';
+import type { AgentConfig, AgentModelConfig } from './agent-types.js';
+
+const MARKDOWN_MAX_BYTES = 200_000;
+const TOP_LEVEL_MARKDOWN_FILE_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*\.md$/;
+
+export interface ApplyAgentConfigJsonOptions {
+  activate?: boolean;
+}
+
+export interface ApplyAgentConfigJsonResult {
+  agent: AgentConfig;
+  workspacePath: string;
+  markdownFiles: string[];
+  runtimeConfigChanged: boolean;
+}
+
+type AgentConfigJsonPayload = Record<string, unknown> & {
+  agent?: unknown;
+  files?: unknown;
+  markdown?: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function hasOwn(value: Record<string, unknown>, key: string): boolean {
+  return Object.hasOwn(value, key);
+}
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim();
+  return normalized || undefined;
+}
+
+function normalizeModelConfig(value: unknown): AgentModelConfig | undefined {
+  if (typeof value === 'string') {
+    const normalized = value.trim();
+    return normalized || undefined;
+  }
+  if (!isRecord(value)) return undefined;
+
+  const primary = normalizeOptionalString(value.primary);
+  if (!primary) return undefined;
+  const seen = new Set<string>([primary]);
+  const fallbacks = Array.isArray(value.fallbacks)
+    ? value.fallbacks
+        .map(normalizeOptionalString)
+        .filter((entry): entry is string => {
+          if (!entry || seen.has(entry)) return false;
+          seen.add(entry);
+          return true;
+        })
+    : [];
+  return fallbacks.length > 0 ? { primary, fallbacks } : { primary };
+}
+
+function parseAgentConfigJson(rawJson: string): AgentConfigJsonPayload {
+  try {
+    const parsed = JSON.parse(rawJson) as unknown;
+    if (!isRecord(parsed)) {
+      throw new Error('Agent config JSON must be an object.');
+    }
+    return parsed;
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error(`Invalid agent config JSON: ${error.message}`);
+    }
+    throw error;
+  }
+}
+
+function resolveAgentConfigInput(
+  payload: AgentConfigJsonPayload,
+): Record<string, unknown> {
+  if (payload.agent !== undefined) {
+    if (!isRecord(payload.agent)) {
+      throw new Error('`agent` must be an object when provided.');
+    }
+    return payload.agent;
+  }
+  return payload;
+}
+
+function applyAgentConfigFieldUpdates(
+  base: AgentConfig,
+  updates: Record<string, unknown>,
+): AgentConfig {
+  const id = normalizeOptionalString(updates.id) || base.id;
+  if (!id) {
+    throw new Error('Agent config JSON requires a non-empty `id`.');
+  }
+
+  const next: AgentConfig = { ...base, id };
+  if (hasOwn(updates, 'name')) {
+    const name = normalizeOptionalString(updates.name);
+    if (name) next.name = name;
+    else delete next.name;
+  }
+  if (hasOwn(updates, 'displayName')) {
+    const displayName = normalizeOptionalString(updates.displayName);
+    if (displayName) next.displayName = displayName;
+    else delete next.displayName;
+  }
+  if (hasOwn(updates, 'imageAsset')) {
+    const imageAsset = normalizeOptionalString(updates.imageAsset);
+    if (imageAsset) next.imageAsset = imageAsset;
+    else delete next.imageAsset;
+  }
+  if (hasOwn(updates, 'model')) {
+    const model = normalizeModelConfig(updates.model);
+    if (model) next.model = model;
+    else delete next.model;
+  }
+  if (hasOwn(updates, 'skills')) {
+    const skills = normalizeOptionalTrimmedUniqueStringArray(updates.skills);
+    if (skills !== undefined) next.skills = skills;
+    else delete next.skills;
+  }
+  if (hasOwn(updates, 'workspace')) {
+    const workspace = normalizeOptionalString(updates.workspace);
+    if (workspace) next.workspace = workspace;
+    else delete next.workspace;
+  }
+  if (hasOwn(updates, 'chatbotId')) {
+    const chatbotId = normalizeOptionalString(updates.chatbotId);
+    if (chatbotId) next.chatbotId = chatbotId;
+    else delete next.chatbotId;
+  }
+  if (hasOwn(updates, 'enableRag')) {
+    if (typeof updates.enableRag === 'boolean') {
+      next.enableRag = updates.enableRag;
+    } else {
+      delete next.enableRag;
+    }
+  }
+  return next;
+}
+
+function resolveMarkdownInput(
+  payload: AgentConfigJsonPayload,
+): Record<string, string> {
+  const markdownMaps = [payload.markdown, payload.files].filter(
+    (entry) => entry !== undefined,
+  );
+  if (markdownMaps.length === 0) return {};
+  if (markdownMaps.length > 1) {
+    throw new Error('Provide either `markdown` or `files`, not both.');
+  }
+  const markdown = markdownMaps[0];
+  if (!isRecord(markdown)) {
+    throw new Error('`markdown`/`files` must be an object of filename to text.');
+  }
+  const result: Record<string, string> = {};
+  for (const [fileName, content] of Object.entries(markdown)) {
+    if (typeof content !== 'string') {
+      throw new Error(`Markdown file "${fileName}" must have string content.`);
+    }
+    result[fileName] = content;
+  }
+  return result;
+}
+
+function normalizeTopLevelMarkdownFileName(fileName: string): string {
+  const normalized = fileName.trim();
+  if (!TOP_LEVEL_MARKDOWN_FILE_RE.test(normalized)) {
+    throw new Error(
+      `Unsupported markdown file "${fileName}". Use a top-level .md filename such as IDENTITY.md.`,
+    );
+  }
+  return normalized;
+}
+
+function writeWorkspaceMarkdownFile(params: {
+  workspacePath: string;
+  fileName: string;
+  content: string;
+}): void {
+  const sizeBytes = Buffer.byteLength(params.content, 'utf-8');
+  if (sizeBytes > MARKDOWN_MAX_BYTES) {
+    throw new Error(
+      `Markdown file "${params.fileName}" exceeds the ${MARKDOWN_MAX_BYTES}-byte limit.`,
+    );
+  }
+
+  const filePath = path.join(params.workspacePath, params.fileName);
+  fs.mkdirSync(params.workspacePath, { recursive: true });
+  const tempPath = `${filePath}.tmp-${process.pid}-${Date.now().toString(36)}`;
+  fs.writeFileSync(tempPath, params.content, 'utf-8');
+  fs.renameSync(tempPath, filePath);
+}
+
+function normalizeMarkdownEntries(
+  markdown: Record<string, string>,
+): Array<{ fileName: string; content: string }> {
+  return Object.entries(markdown).map(([fileName, content]) => {
+    const normalizedFileName = normalizeTopLevelMarkdownFileName(fileName);
+    const sizeBytes = Buffer.byteLength(content, 'utf-8');
+    if (sizeBytes > MARKDOWN_MAX_BYTES) {
+      throw new Error(
+        `Markdown file "${normalizedFileName}" exceeds the ${MARKDOWN_MAX_BYTES}-byte limit.`,
+      );
+    }
+    return {
+      fileName: normalizedFileName,
+      content,
+    };
+  });
+}
+
+function activateAgent(agent: AgentConfig): void {
+  updateRuntimeConfig((draft) => {
+    draft.agents ??= {};
+    const nextAgents = Array.isArray(draft.agents.list)
+      ? [...draft.agents.list]
+      : [];
+    const existingIndex = nextAgents.findIndex(
+      (entry) => entry?.id?.trim() === agent.id,
+    );
+    if (existingIndex >= 0) {
+      nextAgents[existingIndex] = agent;
+    } else {
+      nextAgents.push(agent);
+    }
+    draft.agents.list = nextAgents;
+    draft.agents.defaultAgentId = agent.id;
+  });
+}
+
+export function applyAgentConfigJson(
+  rawJson: string,
+  options: ApplyAgentConfigJsonOptions = {},
+): ApplyAgentConfigJsonResult {
+  const payload = parseAgentConfigJson(rawJson);
+  const configInput = resolveAgentConfigInput(payload);
+  const id = normalizeOptionalString(configInput.id);
+  if (!id) {
+    throw new Error('Agent config JSON requires a non-empty `id`.');
+  }
+  const markdownEntries = normalizeMarkdownEntries(resolveMarkdownInput(payload));
+
+  const existing = getStoredAgentConfig(id) ?? getAgentById(id) ?? { id };
+  const saved = upsertRegisteredAgent(
+    applyAgentConfigFieldUpdates(existing, configInput),
+  );
+  ensureBootstrapFiles(saved.id);
+  const workspacePath = path.resolve(agentWorkspaceDir(saved.id));
+  const markdownFiles: string[] = [];
+  for (const entry of markdownEntries) {
+    writeWorkspaceMarkdownFile({
+      workspacePath,
+      fileName: entry.fileName,
+      content: entry.content,
+    });
+    markdownFiles.push(entry.fileName);
+  }
+  if (options.activate) {
+    activateAgent(saved);
+  }
+
+  return {
+    agent: saved,
+    workspacePath,
+    markdownFiles,
+    runtimeConfigChanged: Boolean(options.activate),
+  };
+}

--- a/src/agents/agent-runtime-config.ts
+++ b/src/agents/agent-runtime-config.ts
@@ -1,0 +1,89 @@
+import {
+  getRuntimeConfig,
+  type RuntimeConfig,
+  updateRuntimeConfig,
+} from '../config/runtime-config.js';
+import type {
+  AgentConfig,
+  AgentModelConfig,
+  AgentsConfig,
+} from './agent-types.js';
+
+function sameStringArray(a?: string[], b?: string[]): boolean {
+  if (a === b) return true;
+  if (!a || !b || a.length !== b.length) return false;
+  return a.every((entry, index) => entry === b[index]);
+}
+
+function sameModelConfig(a?: AgentModelConfig, b?: AgentModelConfig): boolean {
+  if (a === b) return true;
+  if (typeof a === 'string' || typeof b === 'string' || !a || !b) return false;
+  return a.primary === b.primary && sameStringArray(a.fallbacks, b.fallbacks);
+}
+
+function sameAgentConfig(a: AgentConfig | undefined, b: AgentConfig): boolean {
+  return (
+    Boolean(a) &&
+    a?.id === b.id &&
+    a.name === b.name &&
+    a.displayName === b.displayName &&
+    a.imageAsset === b.imageAsset &&
+    sameModelConfig(a.model, b.model) &&
+    sameStringArray(a.skills, b.skills) &&
+    a.workspace === b.workspace &&
+    a.chatbotId === b.chatbotId &&
+    a.enableRag === b.enableRag
+  );
+}
+
+function upsertActivatedAgentInList(
+  agentsList: AgentConfig[] | undefined,
+  agent: AgentConfig,
+): { changed: boolean; list: AgentConfig[] } {
+  const nextAgents = Array.isArray(agentsList) ? [...agentsList] : [];
+  const existingIndex = nextAgents.findIndex(
+    (entry) => entry?.id?.trim() === agent.id,
+  );
+  if (existingIndex >= 0) {
+    if (sameAgentConfig(nextAgents[existingIndex], agent)) {
+      return { changed: false, list: nextAgents };
+    }
+    nextAgents[existingIndex] = agent;
+    return { changed: true, list: nextAgents };
+  }
+  nextAgents.push(agent);
+  return { changed: true, list: nextAgents };
+}
+
+function applyActivatedAgentToRuntimeConfigDraft(
+  draft: Pick<RuntimeConfig, 'agents'>,
+  agent: AgentConfig,
+): boolean {
+  draft.agents ??= {};
+  const listResult = upsertActivatedAgentInList(draft.agents.list, agent);
+  const defaultChanged = draft.agents.defaultAgentId !== agent.id;
+  if (!listResult.changed && !defaultChanged) {
+    return false;
+  }
+  draft.agents.list = listResult.list;
+  draft.agents.defaultAgentId = agent.id;
+  return true;
+}
+
+function activatedAgentWouldChange(
+  agents: AgentsConfig | undefined,
+  agent: AgentConfig,
+): boolean {
+  const listResult = upsertActivatedAgentInList(agents?.list, agent);
+  return listResult.changed || agents?.defaultAgentId !== agent.id;
+}
+
+export function activateAgentInRuntimeConfig(agent: AgentConfig): boolean {
+  if (!activatedAgentWouldChange(getRuntimeConfig().agents, agent)) {
+    return false;
+  }
+  updateRuntimeConfig((draft) => {
+    applyActivatedAgentToRuntimeConfigDraft(draft, agent);
+  });
+  return true;
+}

--- a/src/cli/agent-command.ts
+++ b/src/cli/agent-command.ts
@@ -5,7 +5,6 @@ import {
   ensureRuntimeConfigFile,
   getRuntimeConfig,
   runtimeConfigPath,
-  updateRuntimeConfig,
 } from '../config/runtime-config.js';
 import { normalizeArgs, parseValueFlag } from './common.js';
 import { isHelpRequest, printAgentUsage } from './help.js';
@@ -656,22 +655,10 @@ export async function handleAgentPackageCommand(args: string[]): Promise<void> {
       throw new Error(`Unknown agent: ${targetAgentId}`);
     }
 
-    updateRuntimeConfig((draft) => {
-      draft.agents ??= {};
-      const nextAgents = Array.isArray(draft.agents.list)
-        ? [...draft.agents.list]
-        : [];
-      const existingIndex = nextAgents.findIndex(
-        (entry) => entry?.id?.trim() === agent.id,
-      );
-      if (existingIndex >= 0) {
-        nextAgents[existingIndex] = agent;
-      } else {
-        nextAgents.push(agent);
-      }
-      draft.agents.list = nextAgents;
-      draft.agents.defaultAgentId = agent.id;
-    });
+    const { activateAgentInRuntimeConfig } = await import(
+      '../agents/agent-runtime-config.js'
+    );
+    activateAgentInRuntimeConfig(agent);
     console.log(
       `🎯 Activated agent ${agent.id} as the default at ${runtimeConfigPath()}.`,
     );

--- a/src/cli/agent-command.ts
+++ b/src/cli/agent-command.ts
@@ -147,7 +147,7 @@ export async function handleAgentPackageCommand(args: string[]): Promise<void> {
     const { applyAgentConfigJson } = await import(
       '../agents/agent-config-command.js'
     );
-    const result = applyAgentConfigJson(rawJson, { activate });
+    const result = await applyAgentConfigJson(rawJson, { activate });
     console.log(`Configured agent ${result.agent.id}.`);
     console.log(`Workspace: ${result.workspacePath}`);
     if (result.markdownFiles.length > 0) {

--- a/src/cli/agent-command.ts
+++ b/src/cli/agent-command.ts
@@ -100,6 +100,68 @@ export async function handleAgentPackageCommand(args: string[]): Promise<void> {
     return;
   }
 
+  if (sub === 'config') {
+    let rawJson = '';
+    let activate = false;
+
+    for (let index = 1; index < normalized.length; index += 1) {
+      const arg = normalized[index];
+      if (arg === '--activate') {
+        activate = true;
+        continue;
+      }
+      const jsonFlag = parseValueFlag({
+        arg,
+        args: normalized,
+        index,
+        name: '--json',
+        placeholder: '<json>',
+      });
+      if (jsonFlag) {
+        if (rawJson) {
+          printAgentUsage();
+          throw new Error(
+            'Provide agent config JSON only once for `hybridclaw agent config`.',
+          );
+        }
+        rawJson = jsonFlag.value;
+        index = jsonFlag.nextIndex;
+        continue;
+      }
+      if (!rawJson && !arg.startsWith('--')) {
+        rawJson = arg;
+        continue;
+      }
+      printAgentUsage();
+      throw new Error(
+        `Unexpected argument for \`hybridclaw agent config\`: ${arg}`,
+      );
+    }
+
+    if (!rawJson) {
+      printAgentUsage();
+      throw new Error(
+        'Missing JSON payload for `hybridclaw agent config <json>`.',
+      );
+    }
+
+    const { applyAgentConfigJson } = await import(
+      '../agents/agent-config-command.js'
+    );
+    const result = applyAgentConfigJson(rawJson, { activate });
+    console.log(`Configured agent ${result.agent.id}.`);
+    console.log(`Workspace: ${result.workspacePath}`);
+    if (result.markdownFiles.length > 0) {
+      console.log(`Markdown files written: ${result.markdownFiles.join(', ')}`);
+    }
+    if (result.runtimeConfigChanged) {
+      console.log(
+        `Activated agent ${result.agent.id} as the default at ${runtimeConfigPath()}.`,
+      );
+    }
+    return;
+  }
+
   if (sub === 'inspect') {
     const archivePath = normalized[1];
     if (!archivePath) {
@@ -688,6 +750,6 @@ export async function handleAgentPackageCommand(args: string[]): Promise<void> {
 
   printAgentUsage();
   throw new Error(
-    `Unknown agent subcommand: ${rawSub}. Use \`hybridclaw agent export\`, \`hybridclaw agent inspect\`, \`hybridclaw agent install\`, \`hybridclaw agent activate\`, or \`hybridclaw agent uninstall\`.`,
+    `Unknown agent subcommand: ${rawSub}. Use \`hybridclaw agent list\`, \`hybridclaw agent config\`, \`hybridclaw agent export\`, \`hybridclaw agent inspect\`, \`hybridclaw agent install\`, \`hybridclaw agent activate\`, or \`hybridclaw agent uninstall\`.`,
   );
 }

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -740,6 +740,7 @@ Notes:
   - \`list\` prints registered agents in a script-friendly tab-separated format.
   - \`config\` upserts an agent from a quoted JSON payload. The payload may be an agent object directly, or \`{"agent": {...}, "markdown": {"IDENTITY.md": "..."}}\`.
   - \`config\` writes \`markdown\` or \`files\` entries as top-level \`.md\` files in the agent workspace, overwriting existing files.
+  - \`config\` imports \`imageAsset\` URLs or local file paths into the agent workspace \`assets/\` directory.
   - Use \`--activate\` with \`config\` to make the configured agent the default for new requests.
   - \`export\` exports an agent workspace, bundled workspace skills, and bundled home plugins into a portable \`.claw\` archive.
   - Use \`--description\`, \`--author\`, and \`--version\` to set optional manifest metadata during export.

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -6,7 +6,7 @@ export function printMainUsage(): void {
   console.log(`Usage: hybridclaw <command>
 
   Commands:
-  agent      Export, inspect, install, or uninstall portable agent archives
+  agent      Configure agents or manage portable agent archives
   auth       Unified provider login/logout/status
   config     Show or edit the local runtime config
   secret     Manage encrypted runtime secrets and HTTP auth routes
@@ -729,6 +729,7 @@ export function printAgentUsage(): void {
 
 Commands:
   hybridclaw agent list
+  hybridclaw agent config <json|--json <json>> [--activate]
   hybridclaw agent export [agent-id] [-o <path>] [--description <text>] [--author <text>] [--version <value>] [--dry-run] [--skills <ask|active|all|some>] [--skill <name>]... [--plugins <ask|active|all|some>] [--plugin <id>]...
   hybridclaw agent inspect <file.claw>
   hybridclaw agent install <file.claw|https://.../*.claw|official:<agent-dir>|github:owner/repo/<agent-dir>> [--id <id>] [--force] [--skip-skill-scan] [--skip-externals] [--skip-import-errors] [--yes]
@@ -737,6 +738,9 @@ Commands:
 
 Notes:
   - \`list\` prints registered agents in a script-friendly tab-separated format.
+  - \`config\` upserts an agent from a quoted JSON payload. The payload may be an agent object directly, or \`{"agent": {...}, "markdown": {"IDENTITY.md": "..."}}\`.
+  - \`config\` writes \`markdown\` or \`files\` entries as top-level \`.md\` files in the agent workspace, overwriting existing files.
+  - Use \`--activate\` with \`config\` to make the configured agent the default for new requests.
   - \`export\` exports an agent workspace, bundled workspace skills, and bundled home plugins into a portable \`.claw\` archive.
   - Use \`--description\`, \`--author\`, and \`--version\` to set optional manifest metadata during export.
   - Use \`--dry-run\` to preview the generated manifest path and archive entries without writing a file.

--- a/tests/agent-config-command.test.ts
+++ b/tests/agent-config-command.test.ts
@@ -1,0 +1,98 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { expect, test, vi } from 'vitest';
+import { setupGatewayTest } from './helpers/gateway-test-setup.js';
+
+const { setupHome } = setupGatewayTest({
+  tempHomePrefix: 'hybridclaw-agent-config-command-',
+});
+
+test('agent config command accepts direct JSON and overwrites markdown files', async () => {
+  setupHome();
+
+  const { handleAgentPackageCommand } = await import(
+    '../src/cli/agent-command.ts'
+  );
+  const { getAgentById } = await import('../src/agents/agent-registry.ts');
+  const { getRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  const { agentWorkspaceDir } = await import('../src/infra/ipc.ts');
+  const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  await handleAgentPackageCommand([
+    'config',
+    JSON.stringify({
+      id: 'felix',
+      name: 'Felix',
+      model: 'gpt-5.4-mini',
+      chatbotId: 'bot-felix',
+      enableRag: true,
+      skills: ['memory', 'memory', 'docs'],
+      markdown: {
+        'IDENTITY.md': '# Felix\n',
+        'BOOT.md': '# Boot\n',
+      },
+    }),
+    '--activate',
+  ]);
+
+  const workspacePath = agentWorkspaceDir('felix');
+  expect(getAgentById('felix')).toMatchObject({
+    id: 'felix',
+    name: 'Felix',
+    model: 'gpt-5.4-mini',
+    chatbotId: 'bot-felix',
+    enableRag: true,
+    skills: ['memory', 'docs'],
+  });
+  expect(fs.readFileSync(path.join(workspacePath, 'IDENTITY.md'), 'utf-8')).toBe(
+    '# Felix\n',
+  );
+  expect(fs.readFileSync(path.join(workspacePath, 'BOOT.md'), 'utf-8')).toBe(
+    '# Boot\n',
+  );
+  expect(getRuntimeConfig().agents.defaultAgentId).toBe('felix');
+  expect(logSpy).toHaveBeenCalledWith('Configured agent felix.');
+
+  await handleAgentPackageCommand([
+    'config',
+    '--json',
+    JSON.stringify({
+      id: 'felix',
+      files: {
+        'IDENTITY.md': '# Updated Felix\n',
+      },
+    }),
+  ]);
+
+  expect(getAgentById('felix')?.model).toBe('gpt-5.4-mini');
+  expect(fs.readFileSync(path.join(workspacePath, 'IDENTITY.md'), 'utf-8')).toBe(
+    '# Updated Felix\n',
+  );
+});
+
+test('agent config command rejects nested markdown file paths before upserting', async () => {
+  setupHome();
+
+  const { handleAgentPackageCommand } = await import(
+    '../src/cli/agent-command.ts'
+  );
+  const { getAgentById } = await import('../src/agents/agent-registry.ts');
+
+  await expect(
+    handleAgentPackageCommand([
+      'config',
+      JSON.stringify({
+        id: 'felix',
+        markdown: {
+          'docs/IDENTITY.md': '# Felix\n',
+        },
+      }),
+    ]),
+  ).rejects.toThrow(
+    'Unsupported markdown file "docs/IDENTITY.md". Use a top-level .md filename such as IDENTITY.md.',
+  );
+  expect(getAgentById('felix')).toBeNull();
+});

--- a/tests/agent-config-command.test.ts
+++ b/tests/agent-config-command.test.ts
@@ -15,7 +15,7 @@ test('agent config command accepts direct JSON and overwrites markdown files', a
     '../src/cli/agent-command.ts'
   );
   const { getAgentById } = await import('../src/agents/agent-registry.ts');
-  const { getRuntimeConfig } = await import(
+  const { getRuntimeConfig, runtimeConfigPath } = await import(
     '../src/config/runtime-config.ts'
   );
   const { agentWorkspaceDir } = await import('../src/infra/ipc.ts');
@@ -47,14 +47,28 @@ test('agent config command accepts direct JSON and overwrites markdown files', a
     enableRag: true,
     skills: ['memory', 'docs'],
   });
-  expect(fs.readFileSync(path.join(workspacePath, 'IDENTITY.md'), 'utf-8')).toBe(
-    '# Felix\n',
-  );
+  expect(
+    fs.readFileSync(path.join(workspacePath, 'IDENTITY.md'), 'utf-8'),
+  ).toBe('# Felix\n');
   expect(fs.readFileSync(path.join(workspacePath, 'BOOT.md'), 'utf-8')).toBe(
     '# Boot\n',
   );
   expect(getRuntimeConfig().agents.defaultAgentId).toBe('felix');
   expect(logSpy).toHaveBeenCalledWith('Configured agent felix.');
+  expect(logSpy).toHaveBeenCalledWith(
+    `Activated agent felix as the default at ${runtimeConfigPath()}.`,
+  );
+
+  logSpy.mockClear();
+  await handleAgentPackageCommand([
+    'config',
+    JSON.stringify({ id: 'felix' }),
+    '--activate',
+  ]);
+  expect(logSpy).toHaveBeenCalledWith('Configured agent felix.');
+  expect(logSpy).not.toHaveBeenCalledWith(
+    expect.stringContaining('Activated agent felix'),
+  );
 
   await handleAgentPackageCommand([
     'config',
@@ -68,9 +82,104 @@ test('agent config command accepts direct JSON and overwrites markdown files', a
   ]);
 
   expect(getAgentById('felix')?.model).toBe('gpt-5.4-mini');
-  expect(fs.readFileSync(path.join(workspacePath, 'IDENTITY.md'), 'utf-8')).toBe(
-    '# Updated Felix\n',
+  expect(
+    fs.readFileSync(path.join(workspacePath, 'IDENTITY.md'), 'utf-8'),
+  ).toBe('# Updated Felix\n');
+});
+
+test('agent config command rejects invalid field types without clearing existing values', async () => {
+  setupHome();
+
+  const { handleAgentPackageCommand } = await import(
+    '../src/cli/agent-command.ts'
   );
+  const { getAgentById } = await import('../src/agents/agent-registry.ts');
+  const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  await handleAgentPackageCommand([
+    'config',
+    JSON.stringify({
+      id: 'felix',
+      name: 'Felix',
+      enableRag: true,
+    }),
+  ]);
+
+  await expect(
+    handleAgentPackageCommand([
+      'config',
+      JSON.stringify({
+        id: 'felix',
+        name: 123,
+      }),
+    ]),
+  ).rejects.toThrow('`name` must be a string or null.');
+  expect(getAgentById('felix')).toMatchObject({
+    id: 'felix',
+    name: 'Felix',
+    enableRag: true,
+  });
+
+  await expect(
+    handleAgentPackageCommand([
+      'config',
+      JSON.stringify({
+        id: 'felix',
+        enableRag: 'true',
+      }),
+    ]),
+  ).rejects.toThrow('`enableRag` must be a boolean or null.');
+  expect(getAgentById('felix')).toMatchObject({
+    id: 'felix',
+    name: 'Felix',
+    enableRag: true,
+  });
+
+  logSpy.mockRestore();
+});
+
+test('agent config command rejects duplicate JSON payload inputs', async () => {
+  setupHome();
+
+  const { handleAgentPackageCommand } = await import(
+    '../src/cli/agent-command.ts'
+  );
+
+  await expect(
+    handleAgentPackageCommand([
+      'config',
+      JSON.stringify({ id: 'felix' }),
+      '--json',
+      JSON.stringify({ id: 'felix' }),
+    ]),
+  ).rejects.toThrow(
+    'Provide agent config JSON only once for `hybridclaw agent config`.',
+  );
+});
+
+test('agent config command rejects markdown and files together before upserting', async () => {
+  setupHome();
+
+  const { handleAgentPackageCommand } = await import(
+    '../src/cli/agent-command.ts'
+  );
+  const { getAgentById } = await import('../src/agents/agent-registry.ts');
+
+  await expect(
+    handleAgentPackageCommand([
+      'config',
+      JSON.stringify({
+        id: 'felix',
+        markdown: {
+          'IDENTITY.md': '# Felix\n',
+        },
+        files: {
+          'BOOT.md': '# Boot\n',
+        },
+      }),
+    ]),
+  ).rejects.toThrow('Provide either `markdown` or `files`, not both.');
+  expect(getAgentById('felix')).toBeNull();
 });
 
 test('agent config command rejects nested markdown file paths before upserting', async () => {

--- a/tests/agent-config-command.test.ts
+++ b/tests/agent-config-command.test.ts
@@ -8,6 +8,13 @@ const { setupHome } = setupGatewayTest({
   tempHomePrefix: 'hybridclaw-agent-config-command-',
 });
 
+function bufferToArrayBuffer(buffer: Buffer): ArrayBuffer {
+  return buffer.buffer.slice(
+    buffer.byteOffset,
+    buffer.byteOffset + buffer.byteLength,
+  ) as ArrayBuffer;
+}
+
 test('agent config command accepts direct JSON and overwrites markdown files', async () => {
   setupHome();
 
@@ -85,6 +92,84 @@ test('agent config command accepts direct JSON and overwrites markdown files', a
   expect(
     fs.readFileSync(path.join(workspacePath, 'IDENTITY.md'), 'utf-8'),
   ).toBe('# Updated Felix\n');
+});
+
+test('agent config command imports remote image assets into the workspace', async () => {
+  setupHome();
+
+  const { handleAgentPackageCommand } = await import(
+    '../src/cli/agent-command.ts'
+  );
+  const { getAgentById } = await import('../src/agents/agent-registry.ts');
+  const { agentWorkspaceDir } = await import('../src/infra/ipc.ts');
+  const image = Buffer.from('test-image');
+  const fetchMock = vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === 'content-type' ? 'image/jpeg' : null,
+    },
+    arrayBuffer: async () => bufferToArrayBuffer(image),
+  }));
+  vi.stubGlobal('fetch', fetchMock);
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  await handleAgentPackageCommand([
+    'config',
+    JSON.stringify({
+      id: 'stephan',
+      name: 'Stephan',
+      imageAsset: 'https://example.com/team/stephan-noller.jpg?size=512',
+    }),
+  ]);
+
+  expect(fetchMock).toHaveBeenCalledWith(
+    new URL('https://example.com/team/stephan-noller.jpg?size=512'),
+  );
+  expect(getAgentById('stephan')).toMatchObject({
+    id: 'stephan',
+    imageAsset: 'assets/stephan-noller.jpg',
+  });
+  expect(
+    fs.readFileSync(
+      path.join(agentWorkspaceDir('stephan'), 'assets', 'stephan-noller.jpg'),
+    ),
+  ).toEqual(image);
+});
+
+test('agent config command copies local image assets into the workspace', async () => {
+  const homeDir = setupHome();
+
+  const { handleAgentPackageCommand } = await import(
+    '../src/cli/agent-command.ts'
+  );
+  const { getAgentById } = await import('../src/agents/agent-registry.ts');
+  const { agentWorkspaceDir } = await import('../src/infra/ipc.ts');
+  const image = Buffer.from('local-image');
+  const sourcePath = path.join(homeDir, 'stephan.png');
+  fs.writeFileSync(sourcePath, image);
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  await handleAgentPackageCommand([
+    'config',
+    JSON.stringify({
+      id: 'stephan',
+      name: 'Stephan',
+      imageAsset: sourcePath,
+    }),
+  ]);
+
+  expect(getAgentById('stephan')).toMatchObject({
+    id: 'stephan',
+    imageAsset: 'assets/stephan.png',
+  });
+  expect(
+    fs.readFileSync(
+      path.join(agentWorkspaceDir('stephan'), 'assets', 'stephan.png'),
+    ),
+  ).toEqual(image);
 });
 
 test('agent config command rejects invalid field types without clearing existing values', async () => {


### PR DESCRIPTION
## Summary
- Adds `hybridclaw agent config <json|--json <json>> [--activate]` for creating platform-generated agents directly from a JSON payload — registry metadata plus top-level workspace markdown files — without building a `.claw` archive.
- Wires the new command into the CLI dispatcher and help text.
- Documents the command in the extensibility and command-reference guides.

## Test plan
- [ ] `npm test -- tests/agent-config-command.test.ts`
- [ ] Manual: `hybridclaw agent config '<json>' --activate` creates and activates the agent
- [ ] Manual: `hybridclaw agent config --json '<json>'` form works
- [ ] `hybridclaw agent --help` / `hybridclaw --help` show the new subcommand

🤖 Generated with [Claude Code](https://claude.com/claude-code)