### PR TITLE
ci(release): create GitHub Release only after image & npm publish

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -31,6 +31,7 @@ jobs:
       owner_lc: ${{ steps.check.outputs.owner_lc }}
       sha: ${{ steps.check.outputs.sha }}
       sha_short: ${{ steps.check.outputs.sha_short }}
+      prerelease: ${{ steps.check.outputs.prerelease }}
     steps:
       - name: Resolve target ref
         id: resolve
@@ -82,6 +83,10 @@ jobs:
           if [[ -n "${DOCKERHUB_USERNAME}" && -n "${DOCKERHUB_TOKEN}" ]]; then
             PUBLISH_DOCKERHUB=true
           fi
+          PRERELEASE=false
+          if [[ "${TAG}" == *-* ]]; then
+            PRERELEASE=true
+          fi
           OWNER_LC="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
           SHA="$(git rev-parse HEAD)"
           SHA_SHORT="${SHA::7}"
@@ -90,6 +95,7 @@ jobs:
             echo "tag=${TAG}"
             echo "ref=${{ steps.resolve.outputs.ref }}"
             echo "publish_dockerhub=${PUBLISH_DOCKERHUB}"
+            echo "prerelease=${PRERELEASE}"
             echo "owner_lc=${OWNER_LC}"
             echo "sha=${SHA}"
             echo "sha_short=${SHA_SHORT}"
@@ -122,11 +128,12 @@ jobs:
         shell: bash
         env:
           TAG: ${{ needs.validate.outputs.tag }}
+          PRERELEASE: ${{ needs.validate.outputs.prerelease }}
         run: |
           set -euo pipefail
           DOCKERHUB_IMAGE="hybridaione/hybridclaw-agent"
           TAGS="${DOCKERHUB_IMAGE}:${TAG}"
-          if [[ "${TAG}" != *-* ]]; then
+          if [[ "${PRERELEASE}" != "true" ]]; then
             TAGS="${TAGS}"$'\n'"${DOCKERHUB_IMAGE}:latest"
           fi
           { echo "tags<<EOF"; echo "${TAGS}"; echo "EOF"; } >> "${GITHUB_OUTPUT}"
@@ -193,19 +200,20 @@ jobs:
         shell: bash
         env:
           TAG: ${{ needs.validate.outputs.tag }}
+          PRERELEASE: ${{ needs.validate.outputs.prerelease }}
           PUBLISH_DOCKERHUB: ${{ needs.validate.outputs.publish_dockerhub }}
+          OWNER_LC: ${{ needs.validate.outputs.owner_lc }}
         run: |
           set -euo pipefail
-          OWNER_LC="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
           GHCR_IMAGE="ghcr.io/${OWNER_LC}/hybridclaw-gateway"
           DOCKERHUB_IMAGE="hybridaione/hybridclaw-gateway"
           TAGS="${GHCR_IMAGE}:${TAG}"
-          if [[ "${TAG}" != *-* ]]; then
+          if [[ "${PRERELEASE}" != "true" ]]; then
             TAGS="${TAGS}"$'\n'"${GHCR_IMAGE}:latest"
           fi
           if [[ "${PUBLISH_DOCKERHUB}" == "true" ]]; then
             TAGS="${TAGS}"$'\n'"${DOCKERHUB_IMAGE}:${TAG}"
-            if [[ "${TAG}" != *-* ]]; then
+            if [[ "${PRERELEASE}" != "true" ]]; then
               TAGS="${TAGS}"$'\n'"${DOCKERHUB_IMAGE}:latest"
             fi
           fi
@@ -277,18 +285,70 @@ jobs:
           node-version: 24
           cache: npm
 
+      # Skip the slow install+prepack entirely on retries where a prior run
+      # already reached `npm publish` but a later job failed — otherwise we'd
+      # pay ~30–90s before npm's 403 ended the job.
+      - name: Check if version already published
+        id: preflight
+        shell: bash
+        env:
+          TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          set -euo pipefail
+          NAME="$(jq -r .name package.json)"
+          VERSION="$(jq -r .version package.json)"
+          if npm view "${NAME}@${VERSION}" version >/dev/null 2>&1; then
+            echo "${NAME}@${VERSION} is already published; skipping."
+            echo "skip=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "skip=false" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Install dependencies
+        if: steps.preflight.outputs.skip != 'true'
         run: npm ci
 
       - name: Build and verify pack contents
+        if: steps.preflight.outputs.skip != 'true'
         run: npm run prepack
 
       - name: Publish to npm
+        if: steps.preflight.outputs.skip != 'true'
+        shell: bash
+        env:
+          PRERELEASE: ${{ needs.validate.outputs.prerelease }}
         run: |
-          VERSION="$(node -p "require('./package.json').version")"
-          if [[ "$VERSION" == *-* ]]; then
+          set -euo pipefail
+          if [[ "${PRERELEASE}" == "true" ]]; then
             NPM_TAG="next"
           else
             NPM_TAG="latest"
           fi
-          npm publish --access public --tag "$NPM_TAG" --provenance
+          npm publish --access public --tag "${NPM_TAG}" --provenance
+
+  # Consumers (e.g. the chat repo's image resolver) treat the GitHub Release
+  # as the authoritative "image is pullable" signal; gate creation on all
+  # publish jobs succeeding.
+  create-release:
+    needs: [validate, publish-agent, publish-gateway, publish-npm]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ needs.validate.outputs.tag }}
+          PRERELEASE: ${{ needs.validate.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+          if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; skipping creation."
+            exit 0
+          fi
+          flags=(--title "$TAG" --verify-tag --generate-notes)
+          if [[ "$PRERELEASE" == "true" ]]; then
+            flags+=(--prerelease)
+          fi
+          gh release create "$TAG" --repo "$REPO" "${flags[@]}"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -334,14 +334,16 @@ jobs:
 
   # Consumers (e.g. the chat repo's image resolver) treat the GitHub Release
   # as the authoritative "image is pullable" signal; gate creation on all
-  # publish jobs succeeding.
+  # publish jobs succeeding. Created as a draft so the maintainer's curated
+  # notes (AGENTS.md §7.6 step 8) are never overwritten by auto-generated ones
+  # — the maintainer edits and publishes the draft manually.
   create-release:
     needs: [validate, publish-agent, publish-gateway, publish-npm]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - name: Create GitHub Release
+      - name: Create GitHub Release draft
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -355,7 +357,7 @@ jobs:
             echo "Release $TAG already exists; skipping creation."
             exit 0
           fi
-          flags=(--title "$TAG" --generate-notes)
+          flags=(--draft --title "$TAG" --generate-notes)
           if [[ "$VERIFY_TAG" == "true" ]]; then
             flags+=(--verify-tag)
           else

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -32,6 +32,7 @@ jobs:
       sha: ${{ steps.check.outputs.sha }}
       sha_short: ${{ steps.check.outputs.sha_short }}
       prerelease: ${{ steps.check.outputs.prerelease }}
+      verify_tag: ${{ steps.check.outputs.verify_tag }}
     steps:
       - name: Resolve target ref
         id: resolve
@@ -90,12 +91,17 @@ jobs:
           OWNER_LC="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
           SHA="$(git rev-parse HEAD)"
           SHA_SHORT="${SHA::7}"
+          VERIFY_TAG=true
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && -z "${INPUT_VERSION}" ]]; then
+            VERIFY_TAG=false
+          fi
 
           {
             echo "tag=${TAG}"
-            echo "ref=${{ steps.resolve.outputs.ref }}"
+            echo "ref=${SHA}"
             echo "publish_dockerhub=${PUBLISH_DOCKERHUB}"
             echo "prerelease=${PRERELEASE}"
+            echo "verify_tag=${VERIFY_TAG}"
             echo "owner_lc=${OWNER_LC}"
             echo "sha=${SHA}"
             echo "sha_short=${SHA_SHORT}"
@@ -341,13 +347,20 @@ jobs:
           REPO: ${{ github.repository }}
           TAG: ${{ needs.validate.outputs.tag }}
           PRERELEASE: ${{ needs.validate.outputs.prerelease }}
+          SHA: ${{ needs.validate.outputs.sha }}
+          VERIFY_TAG: ${{ needs.validate.outputs.verify_tag }}
         run: |
           set -euo pipefail
           if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
             echo "Release $TAG already exists; skipping creation."
             exit 0
           fi
-          flags=(--title "$TAG" --verify-tag --generate-notes)
+          flags=(--title "$TAG" --generate-notes)
+          if [[ "$VERIFY_TAG" == "true" ]]; then
+            flags+=(--verify-tag)
+          else
+            flags+=(--target "$SHA")
+          fi
           if [[ "$PRERELEASE" == "true" ]]; then
             flags+=(--prerelease)
           fi

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -32,7 +32,6 @@ jobs:
       sha: ${{ steps.check.outputs.sha }}
       sha_short: ${{ steps.check.outputs.sha_short }}
       prerelease: ${{ steps.check.outputs.prerelease }}
-      verify_tag: ${{ steps.check.outputs.verify_tag }}
     steps:
       - name: Resolve target ref
         id: resolve
@@ -91,17 +90,11 @@ jobs:
           OWNER_LC="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
           SHA="$(git rev-parse HEAD)"
           SHA_SHORT="${SHA::7}"
-          VERIFY_TAG=true
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && -z "${INPUT_VERSION}" ]]; then
-            VERIFY_TAG=false
-          fi
 
           {
             echo "tag=${TAG}"
-            echo "ref=${SHA}"
             echo "publish_dockerhub=${PUBLISH_DOCKERHUB}"
             echo "prerelease=${PRERELEASE}"
-            echo "verify_tag=${VERIFY_TAG}"
             echo "owner_lc=${OWNER_LC}"
             echo "sha=${SHA}"
             echo "sha_short=${SHA_SHORT}"
@@ -127,7 +120,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: ${{ needs.validate.outputs.ref }}
+          ref: ${{ needs.validate.outputs.sha }}
 
       - name: Resolve agent image tags
         id: meta
@@ -199,7 +192,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: ${{ needs.validate.outputs.ref }}
+          ref: ${{ needs.validate.outputs.sha }}
 
       - name: Resolve gateway image tags
         id: meta
@@ -281,7 +274,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: ${{ needs.validate.outputs.ref }}
+          ref: ${{ needs.validate.outputs.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -350,19 +343,16 @@ jobs:
           TAG: ${{ needs.validate.outputs.tag }}
           PRERELEASE: ${{ needs.validate.outputs.prerelease }}
           SHA: ${{ needs.validate.outputs.sha }}
-          VERIFY_TAG: ${{ needs.validate.outputs.verify_tag }}
         run: |
           set -euo pipefail
           if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
             echo "Release $TAG already exists; skipping creation."
             exit 0
           fi
-          flags=(--draft --title "$TAG" --generate-notes)
-          if [[ "$VERIFY_TAG" == "true" ]]; then
-            flags+=(--verify-tag)
-          else
-            flags+=(--target "$SHA")
-          fi
+          # --target pins the Release to the resolved SHA and also creates the
+          # tag on workflow_dispatch paths where only HEAD (not a tag ref) was
+          # pushed. On tag-push paths the existing tag ref wins regardless.
+          flags=(--draft --title "$TAG" --target "$SHA" --generate-notes)
           if [[ "$PRERELEASE" == "true" ]]; then
             flags+=(--prerelease)
           fi


### PR DESCRIPTION
## Summary

Gates GitHub Release creation on successful image + npm publishes, so the Release always corresponds to a pullable version — and creates it as a **draft** so the maintainer's curated release notes (AGENTS.md §7.6 step 8) are never overwritten by auto-generated ones.

### Changes

- New `create-release` job with `needs: [validate, publish-agent, publish-gateway, publish-npm]` that calls `gh release create --draft --verify-tag --generate-notes`. Idempotent: skips if the Release already exists (backwards-compatible with the current UI-first flow). Scoped `contents: write` on this job only; workflow default stays `contents: read`.
- `validate` now emits `prerelease` as a boolean output; `create-release` consumes it via a bash array (safe under `set -u`).
- `publish-npm` preflights `npm view "$NAME@$VERSION" version` and exits 0 if already published, so re-runs after a downstream failure don't 403.

### Operator change

- Today: create Release in UI → tag push triggers workflow → Release already exists when consumers look.
- New (recommended): `git tag vX.Y.Z && git push origin vX.Y.Z` → workflow publishes everything, then creates a **draft** Release with auto-generated notes. Maintainer edits the draft to the AGENTS.md §7.6 curated format (Highlights / Changed / Fixed / Contributors / Full Changelog) and publishes it. Consumers only ever see a published Release whose artifacts are ready.
- Backwards compatible: the UI-first flow still works; `create-release` sees the existing Release (including drafts) and skips.

## Test plan

- [x] YAML parses; `needs` graph is acyclic; `validate` outputs include `prerelease`.
- [x] Bash array `"${flags[@]}"` is safe with empty arrays on bash 5 (GitHub runners).
- [ ] Dry-run via a test tag on a fork: verify the draft Release is created only after all publish jobs succeed, that editing + publishing the draft works, and that re-running against an existing (draft or published) Release no-ops.