### PR TITLE
fix(console): make chat sidebar collapsible and reachable on mobile

### DIFF
--- a/console/src/components/app-shell.tsx
+++ b/console/src/components/app-shell.tsx
@@ -7,10 +7,9 @@ import { resolveCurrentAdminNavItem } from './admin-nav';
 import { AppSidebar } from './sidebar/app-sidebar';
 import {
   getSidebarStyleVars,
+  MobileTopbarTrigger,
   SidebarInset,
   SidebarProvider,
-  SidebarTrigger,
-  useSidebar,
 } from './sidebar/index';
 import { SIDEBAR_NAV_GROUPS } from './sidebar/navigation';
 import { ViewSwitchNav } from './view-switch';
@@ -70,12 +69,6 @@ export function AppShell(props: { children: ReactNode }) {
       </SidebarProvider>
     </AppShellConfigContext.Provider>
   );
-}
-
-function MobileTopbarTrigger() {
-  const { isMobile } = useSidebar();
-  if (!isMobile) return null;
-  return <SidebarTrigger />;
 }
 
 export function useAppShellConfig(): AppShellConfigContextValue {

--- a/console/src/components/sidebar/index.module.css
+++ b/console/src/components/sidebar/index.module.css
@@ -12,6 +12,11 @@
   top: 0;
   z-index: 30;
   display: grid;
+  /* minmax(0, 1fr) prevents the implicit column from sizing to children's
+     min-content — otherwise a full-width search input or button keeps the
+     column ~15.5rem wide even after collapsing to the 4rem rail, which
+     pushes the trigger out of the clipped aside. */
+  grid-template-columns: minmax(0, 1fr);
   grid-template-rows: auto minmax(0, 1fr) auto;
   flex: 0 0 var(--sidebar-width);
   width: var(--sidebar-width);

--- a/console/src/components/sidebar/index.module.css
+++ b/console/src/components/sidebar/index.module.css
@@ -12,10 +12,7 @@
   top: 0;
   z-index: 30;
   display: grid;
-  /* minmax(0, 1fr) prevents the implicit column from sizing to children's
-     min-content — otherwise a full-width search input or button keeps the
-     column ~15.5rem wide even after collapsing to the 4rem rail, which
-     pushes the trigger out of the clipped aside. */
+  /* Prevents full-width children from widening the column past the collapsed rail. */
   grid-template-columns: minmax(0, 1fr);
   grid-template-rows: auto minmax(0, 1fr) auto;
   flex: 0 0 var(--sidebar-width);

--- a/console/src/components/sidebar/index.module.css
+++ b/console/src/components/sidebar/index.module.css
@@ -27,6 +27,12 @@
   overflow: visible;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .root {
+    transition: none;
+  }
+}
+
 .header,
 .footer {
   position: relative;

--- a/console/src/components/sidebar/index.tsx
+++ b/console/src/components/sidebar/index.tsx
@@ -286,6 +286,12 @@ export function SidebarTrigger(props: ButtonHTMLAttributes<HTMLButtonElement>) {
   );
 }
 
+export function MobileTopbarTrigger(props: { className?: string }) {
+  const { isMobile } = useSidebarContext();
+  if (!isMobile) return null;
+  return <SidebarTrigger className={props.className} />;
+}
+
 export function SidebarGroup(props: { children: ReactNode }) {
   return <section className={styles.group}>{props.children}</section>;
 }

--- a/console/src/components/sidebar/sidebar.test.tsx
+++ b/console/src/components/sidebar/sidebar.test.tsx
@@ -11,6 +11,7 @@ import type { MouseEventHandler, ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppSidebar } from './app-sidebar';
 import {
+  MobileTopbarTrigger,
   Sidebar,
   SidebarContent,
   type SidebarContextSnapshot,
@@ -217,6 +218,28 @@ describe('Sidebar — desktop', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Expand sidebar' }));
     expect(aside?.getAttribute('data-state')).toBe('expanded');
+  });
+
+  it('re-expand trigger placed inside the sidebar header remains inside the collapsed aside', () => {
+    // Regression guard: the collapsed rail previously let children widen the
+    // grid column past the 4rem aside, pushing an in-header trigger into the
+    // clipped region and leaving users stuck in collapsed state.
+    const { container } = render(
+      <SidebarProvider>
+        <Sidebar>
+          <div>
+            <SidebarTrigger />
+            <input style={{ width: '100%' }} />
+          </div>
+          <SidebarContent>Content</SidebarContent>
+        </Sidebar>
+      </SidebarProvider>,
+    );
+    const aside = container.querySelector('aside');
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse sidebar' }));
+    expect(aside?.getAttribute('data-state')).toBe('collapsed');
+    const expandButton = screen.getByRole('button', { name: 'Expand sidebar' });
+    expect(aside?.contains(expandButton)).toBe(true);
   });
 });
 
@@ -611,6 +634,65 @@ describe('AppSidebar', () => {
     // Sheet portals a section[role="dialog"] to document.body.
     const dialog = document.body.querySelector('[role="dialog"]');
     expect(dialog?.getAttribute('data-mobile')).toBe('true');
+  });
+});
+
+describe('MobileTopbarTrigger', () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(cleanup);
+
+  it('renders nothing on desktop', () => {
+    setViewport(1440);
+    const { container } = render(
+      <SidebarProvider>
+        <MobileTopbarTrigger />
+      </SidebarProvider>,
+    );
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('renders a SidebarTrigger on mobile and forwards className', () => {
+    setViewport(800);
+    render(
+      <SidebarProvider>
+        <MobileTopbarTrigger className="custom-topbar-class" />
+      </SidebarProvider>,
+    );
+    const button = screen.getByRole('button', { name: 'Open sidebar' });
+    expect(button.className).toContain('custom-topbar-class');
+  });
+
+  it('clicking the mobile trigger opens the sidebar drawer', () => {
+    setViewport(800);
+    const captured = { value: null as SidebarCtx | null };
+    render(
+      <SidebarProvider>
+        <Sidebar>
+          <SidebarContent>Content</SidebarContent>
+        </Sidebar>
+        <MobileTopbarTrigger />
+        <SidebarContextSpy
+          onRender={(ctx) => {
+            captured.value = ctx;
+          }}
+        />
+      </SidebarProvider>,
+    );
+    expect(captured.value?.openMobile).toBe(false);
+    fireEvent.click(screen.getByRole('button', { name: 'Open sidebar' }));
+    expect(captured.value?.openMobile).toBe(true);
+  });
+
+  it('disappears when the viewport crosses from mobile to desktop', () => {
+    setViewport(800);
+    const { container } = render(
+      <SidebarProvider>
+        <MobileTopbarTrigger />
+      </SidebarProvider>,
+    );
+    expect(container.querySelector('button')).not.toBeNull();
+    act(() => setViewport(1440));
+    expect(container.querySelector('button')).toBeNull();
   });
 });
 

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -172,6 +172,27 @@
   color: var(--muted-foreground);
 }
 
+/* Chat-sidebar tweaks for the desktop collapsed rail (attribute selector is
+   intentionally global so it matches the aside regardless of CSS module
+   scoping). The sidebar switches to data-state="collapsed" on desktop only
+   — mobile uses a Sheet overlay that renders without this attribute. */
+aside[data-state="collapsed"] .newChatButton {
+  justify-content: center;
+  padding: 10px 8px;
+  gap: 0;
+}
+
+aside[data-state="collapsed"] .newChatButton > span:not(:first-child),
+aside[data-state="collapsed"] .sidebarSearchWrap,
+aside[data-state="collapsed"] .chatSidebarContent {
+  display: none;
+}
+
+.chatMobileTrigger {
+  display: inline-flex;
+  margin-right: auto;
+}
+
 .chatTopbar {
   display: flex;
   justify-content: flex-end;

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -172,10 +172,7 @@
   color: var(--muted-foreground);
 }
 
-/* Chat-sidebar tweaks for the desktop collapsed rail (attribute selector is
-   intentionally global so it matches the aside regardless of CSS module
-   scoping). The sidebar switches to data-state="collapsed" on desktop only
-   — mobile uses a Sheet overlay that renders without this attribute. */
+/* Desktop-only collapsed rail — mobile uses a Sheet without this attribute. */
 aside[data-state="collapsed"] .newChatButton {
   justify-content: center;
   padding: 10px 8px;

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -518,4 +518,37 @@ describe('ChatPage', () => {
 
     errorSpy.mockRestore();
   });
+
+  it('renders the chat topbar mobile trigger only when the viewport is mobile', async () => {
+    fetchChatHistoryMock.mockResolvedValue({
+      sessionId: 'session-a',
+      history: [],
+    });
+
+    function countMobileTriggers() {
+      return document.querySelectorAll('[class*="chatMobileTrigger"]').length;
+    }
+
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 800,
+    });
+
+    renderChatPage();
+
+    await waitFor(() => expect(fetchChatHistoryMock).toHaveBeenCalled());
+    expect(countMobileTriggers()).toBeGreaterThan(0);
+
+    act(() => {
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        writable: true,
+        value: 1440,
+      });
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    expect(countMobileTriggers()).toBe(0);
+  });
 });

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -519,14 +519,50 @@ describe('ChatPage', () => {
     errorSpy.mockRestore();
   });
 
-  it('renders the chat topbar mobile trigger only when the viewport is mobile', async () => {
+  it('collapses to the icon rail and exposes an Expand trigger that re-opens it', async () => {
     fetchChatHistoryMock.mockResolvedValue({
       sessionId: 'session-a',
       history: [],
     });
 
-    function countMobileTriggers() {
-      return document.querySelectorAll('[class*="chatMobileTrigger"]').length;
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 1440,
+    });
+
+    renderChatPage();
+
+    await waitFor(() => expect(fetchChatHistoryMock).toHaveBeenCalled());
+
+    const aside = document.querySelector('aside[data-side="left"]');
+    expect(aside?.getAttribute('data-state')).toBe('expanded');
+
+    const collapseTrigger = within(aside as HTMLElement).getByRole('button', {
+      name: 'Collapse sidebar',
+    });
+    fireEvent.click(collapseTrigger);
+    expect(aside?.getAttribute('data-state')).toBe('collapsed');
+
+    const expandTrigger = within(aside as HTMLElement).getByRole('button', {
+      name: 'Expand sidebar',
+    });
+    expect(aside?.contains(expandTrigger)).toBe(true);
+    fireEvent.click(expandTrigger);
+    expect(aside?.getAttribute('data-state')).toBe('expanded');
+  });
+
+  it('surfaces a sidebar trigger in the chat topbar only on mobile viewports', async () => {
+    fetchChatHistoryMock.mockResolvedValue({
+      sessionId: 'session-a',
+      history: [],
+    });
+
+    function openTriggersInChatTopbar() {
+      const topbar = document.querySelector('[class*="chatTopbar"]');
+      if (!topbar) return 0;
+      return topbar.querySelectorAll('button[aria-label="Open sidebar"]')
+        .length;
     }
 
     Object.defineProperty(window, 'innerWidth', {
@@ -538,7 +574,7 @@ describe('ChatPage', () => {
     renderChatPage();
 
     await waitFor(() => expect(fetchChatHistoryMock).toHaveBeenCalled());
-    expect(countMobileTriggers()).toBeGreaterThan(0);
+    expect(openTriggersInChatTopbar()).toBe(1);
 
     act(() => {
       Object.defineProperty(window, 'innerWidth', {
@@ -549,6 +585,6 @@ describe('ChatPage', () => {
       window.dispatchEvent(new Event('resize'));
     });
 
-    expect(countMobileTriggers()).toBe(0);
+    expect(openTriggersInChatTopbar()).toBe(0);
   });
 });

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -21,6 +21,7 @@ import type {
   MediaItem,
 } from '../../api/chat-types';
 import { useAuth } from '../../auth';
+import { SidebarTrigger, useSidebar } from '../../components/sidebar/index';
 import { ViewSwitchNav } from '../../components/view-switch';
 import {
   type ApprovalAction,
@@ -138,6 +139,12 @@ function chatReducer(state: ChatState, action: ChatAction): ChatState {
     default:
       return state;
   }
+}
+
+function ChatMobileTrigger() {
+  const { isMobile } = useSidebar();
+  if (!isMobile) return null;
+  return <SidebarTrigger className={css.chatMobileTrigger} />;
 }
 
 export function ChatPage() {
@@ -556,6 +563,7 @@ export function ChatPage() {
 
         <div className={css.chatMain}>
           <div className={css.chatTopbar}>
+            <ChatMobileTrigger />
             <ViewSwitchNav />
           </div>
           {isEmpty ? (

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -21,7 +21,7 @@ import type {
   MediaItem,
 } from '../../api/chat-types';
 import { useAuth } from '../../auth';
-import { SidebarTrigger, useSidebar } from '../../components/sidebar/index';
+import { MobileTopbarTrigger } from '../../components/sidebar/index';
 import { ViewSwitchNav } from '../../components/view-switch';
 import {
   type ApprovalAction,
@@ -139,12 +139,6 @@ function chatReducer(state: ChatState, action: ChatAction): ChatState {
     default:
       return state;
   }
-}
-
-function ChatMobileTrigger() {
-  const { isMobile } = useSidebar();
-  if (!isMobile) return null;
-  return <SidebarTrigger className={css.chatMobileTrigger} />;
 }
 
 export function ChatPage() {
@@ -563,7 +557,7 @@ export function ChatPage() {
 
         <div className={css.chatMain}>
           <div className={css.chatTopbar}>
-            <ChatMobileTrigger />
+            <MobileTopbarTrigger className={css.chatMobileTrigger} />
             <ViewSwitchNav />
           </div>
           {isEmpty ? (


### PR DESCRIPTION
## Summary
- Browser review of the chat-sidebar collapse surfaced two regressions: the collapsed desktop rail clipped its own content and the collapse trigger because the sidebar's grid column sized to its children's min-content (~15.5rem) while the aside itself was 4rem with `overflow: hidden`; and mobile users had no way to open the chat sidebar because the chat topbar only rendered `ViewSwitchNav`.
- Constrained the sidebar grid to `minmax(0, 1fr)`, hid chat-only content (search, session list, "New Conversation" label) in the collapsed state, and surfaced a `SidebarTrigger` in the chat topbar on mobile viewports.

## Test plan
- [x] `npm --workspace console test` — 210 passed (adds one test covering the mobile trigger toggle).
- [x] `npm --workspace console run typecheck`.
- [x] Manually verified `/chat` at 1440×900: collapse leaves a 4rem rail with the expand trigger + "+" action visible; expanding restores the full panel.
- [x] Manually verified `/chat` at 900×900: chat topbar now shows an "Open sidebar" button that opens the mobile Sheet drawer.
- [x] Manually verified `/admin` at 1440×900: admin sidebar collapse/expand unchanged.