### PR TITLE
fix(console): keep audit detail panel in view while scrolling

### DIFF
--- a/console/src/routes/audit.tsx
+++ b/console/src/routes/audit.tsx
@@ -122,48 +122,50 @@ export function AuditPage() {
           )}
         </Panel>
 
-        <Panel title="Inspection" accent="warm">
-          {!selectedEntry ? (
-            <div className="empty-state">
-              Select an audit event to inspect it.
-            </div>
-          ) : (
-            <div className="detail-stack">
-              <div className="key-value-grid">
-                <div>
-                  <span>Event type</span>
-                  <strong>{selectedEntry.eventType}</strong>
+        <div className="sticky-detail">
+          <Panel title="Inspection" accent="warm">
+            {!selectedEntry ? (
+              <div className="empty-state">
+                Select an audit event to inspect it.
+              </div>
+            ) : (
+              <div className="detail-stack">
+                <div className="key-value-grid">
+                  <div>
+                    <span>Event type</span>
+                    <strong>{selectedEntry.eventType}</strong>
+                  </div>
+                  <div>
+                    <span>Session</span>
+                    <strong>{selectedEntry.sessionId}</strong>
+                  </div>
+                  <div>
+                    <span>Timestamp</span>
+                    <strong>{formatDateTime(selectedEntry.timestamp)}</strong>
+                  </div>
+                  <div>
+                    <span>Run ID</span>
+                    <strong>{selectedEntry.runId}</strong>
+                  </div>
+                  <div>
+                    <span>Seq</span>
+                    <strong>{selectedEntry.seq}</strong>
+                  </div>
+                  <div>
+                    <span>Parent run</span>
+                    <strong>{selectedEntry.parentRunId || 'none'}</strong>
+                  </div>
                 </div>
-                <div>
-                  <span>Session</span>
-                  <strong>{selectedEntry.sessionId}</strong>
-                </div>
-                <div>
-                  <span>Timestamp</span>
-                  <strong>{formatDateTime(selectedEntry.timestamp)}</strong>
-                </div>
-                <div>
-                  <span>Run ID</span>
-                  <strong>{selectedEntry.runId}</strong>
-                </div>
-                <div>
-                  <span>Seq</span>
-                  <strong>{selectedEntry.seq}</strong>
-                </div>
-                <div>
-                  <span>Parent run</span>
-                  <strong>{selectedEntry.parentRunId || 'none'}</strong>
+                <div className="summary-block">
+                  <span>Payload</span>
+                  <pre className="payload-block">
+                    {prettifyPayload(selectedEntry.payload)}
+                  </pre>
                 </div>
               </div>
-              <div className="summary-block">
-                <span>Payload</span>
-                <pre className="payload-block">
-                  {prettifyPayload(selectedEntry.payload)}
-                </pre>
-              </div>
-            </div>
-          )}
-        </Panel>
+            )}
+          </Panel>
+        </div>
       </div>
     </div>
   );

--- a/console/src/styles.css
+++ b/console/src/styles.css
@@ -468,6 +468,22 @@ code {
   grid-template-columns: minmax(0, 1.1fr) minmax(340px, 0.9fr);
 }
 
+.sticky-detail {
+  position: sticky;
+  top: 16px;
+  align-self: start;
+  max-height: calc(100vh - 32px);
+  overflow-y: auto;
+}
+
+@media (max-width: 1080px) {
+  .sticky-detail {
+    position: static;
+    max-height: none;
+    overflow-y: visible;
+  }
+}
+
 .usage-grid,
 .field-grid,
 .config-grid,


### PR DESCRIPTION
## Summary

- Problem: On `/admin/audit`, the Inspection panel lives in the right column of a two-column grid and scrolls with the page. Clicking an entry lower in the list left the details above the viewport, forcing a scroll up.
- Why it matters: Inspecting audit events is the core workflow of this page; the forced scroll makes quick drill-down painful.
- What changed: Wrapped the Inspection `Panel` in a `sticky-detail` div and added CSS that pins it to `top: 16px` with `align-self: start` plus `max-height: calc(100vh - 32px)` for long payloads on wide screens. Falls back to normal flow on `<=1080px` where the grid stacks.
- What did not change: Filters, entry list rendering, selection logic, and the layout on narrow/mobile viewports.

## Change Type

- [x] Bug fix

## Linked Context

- Closes #
- Related #

## Validation

```bash
npx tsc --noEmit   # (console package) — passed
```

- Verified manually: clicked entries at the bottom of a long audit list in the admin console; the Inspection panel stays pinned to the top of the viewport next to the click, no scroll-up needed.
- Edge cases checked: narrow viewport (<=1080px) stacks as before with static positioning; long payloads scroll internally within the pinned panel.
- Skipped checks and why: no unit test — change is purely CSS-driven layout behavior.

## Docs And Config Impact

- [x] No docs or config impact

## Risk Notes

- Security-sensitive paths touched? `No`
- Gateway, audit, approval, or container boundaries touched? `No` (UI-only change in the audit route)

## Evidence

- [x] Screenshot or recording — manual verification in the admin console

🤖 Generated with [Claude Code](https://claude.com/claude-code)