### PR TITLE
[codex] fix result-only web chat slash streams

### DIFF
--- a/console/src/api/chat-types.ts
+++ b/console/src/api/chat-types.ts
@@ -14,6 +14,8 @@ export interface ChatHistoryMessage {
   role: 'user' | 'assistant' | 'system';
   content: string;
   id?: number | string | null;
+  agent_id?: string | null;
+  assistantPresentation?: AssistantPresentation | null;
 }
 
 export interface AssistantPresentation {
@@ -88,6 +90,7 @@ export interface ChatStreamResult {
   userMessageId?: number | string | null;
   assistantMessageId?: number | string | null;
   result?: string;
+  assistantPresentation?: AssistantPresentation | null;
   artifacts?: ChatArtifact[];
   toolsUsed?: string[];
 }

--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -34,6 +34,8 @@ import type {
   AdminTerminalStartResponse,
   AdminTerminalStopResponse,
   AdminToolsResponse,
+  AgentListItem,
+  AgentListResponse,
   AgentsOverview,
   AgentsOverviewResponse,
   DeleteSessionResult,
@@ -248,6 +250,13 @@ export function adminTerminalSocketUrl(
 
 export function fetchAgentsOverview(token: string): Promise<AgentsOverview> {
   return requestJson<AgentsOverviewResponse>('/api/agents', { token });
+}
+
+export async function fetchAgentList(token: string): Promise<AgentListItem[]> {
+  const payload = await requestJson<AgentListResponse>('/api/agents/list', {
+    token,
+  });
+  return payload.agents;
 }
 
 export async function fetchAdminAgents(token: string): Promise<AdminAgent[]> {

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -778,6 +778,15 @@ export type AgentsOverview = Pick<
   'agents' | 'sessions'
 >;
 
+export interface AgentListItem {
+  id: string;
+  name: string | null;
+}
+
+export interface AgentListResponse {
+  agents: AgentListItem[];
+}
+
 export interface JobAgent {
   id: string;
   name: string | null;

--- a/console/src/routes/chat/agent-switch-select.tsx
+++ b/console/src/routes/chat/agent-switch-select.tsx
@@ -14,22 +14,24 @@ export function AgentSwitchSelect(props: {
   if (props.agents.length === 0) return null;
 
   return (
-    <select
-      className={css.agentSelect}
-      value={props.selectedAgentId}
-      disabled={props.disabled}
-      aria-label="Switch agent"
-      onChange={(event) => {
-        const nextAgentId = event.target.value;
-        if (!nextAgentId || nextAgentId === props.selectedAgentId) return;
-        props.onSwitch(nextAgentId);
-      }}
-    >
-      {props.agents.map((agent) => (
-        <option key={agent.id} value={agent.id}>
-          {agent.name?.trim() || agent.id}
-        </option>
-      ))}
-    </select>
+    <span className={css.agentSelectWrap}>
+      <select
+        className={css.agentSelect}
+        value={props.selectedAgentId}
+        disabled={props.disabled}
+        aria-label="Switch agent"
+        onChange={(event) => {
+          const nextAgentId = event.target.value;
+          if (!nextAgentId || nextAgentId === props.selectedAgentId) return;
+          props.onSwitch(nextAgentId);
+        }}
+      >
+        {props.agents.map((agent) => (
+          <option key={agent.id} value={agent.id}>
+            {agent.name?.trim() || agent.id}
+          </option>
+        ))}
+      </select>
+    </span>
   );
 }

--- a/console/src/routes/chat/agent-switch-select.tsx
+++ b/console/src/routes/chat/agent-switch-select.tsx
@@ -1,0 +1,35 @@
+import css from './chat-page.module.css';
+
+export interface AgentSwitchOption {
+  id: string;
+  name?: string | null;
+}
+
+export function AgentSwitchSelect(props: {
+  agents: AgentSwitchOption[];
+  selectedAgentId: string;
+  disabled?: boolean;
+  onSwitch: (agentId: string) => void;
+}) {
+  if (props.agents.length === 0) return null;
+
+  return (
+    <select
+      className={css.agentSelect}
+      value={props.selectedAgentId}
+      disabled={props.disabled}
+      aria-label="Switch agent"
+      onChange={(event) => {
+        const nextAgentId = event.target.value;
+        if (!nextAgentId || nextAgentId === props.selectedAgentId) return;
+        props.onSwitch(nextAgentId);
+      }}
+    >
+      {props.agents.map((agent) => (
+        <option key={agent.id} value={agent.id}>
+          {agent.name?.trim() || agent.id}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/console/src/routes/chat/chat-history-query.test.ts
+++ b/console/src/routes/chat/chat-history-query.test.ts
@@ -87,25 +87,41 @@ describe('buildChatHistoryUiData', () => {
     expect(ui.messages[0]?.sessionId).toBe('session-canonical');
   });
 
-  it('passes assistantPresentation through to every message', () => {
+  it('uses per-message assistantPresentation instead of session-level presentation', () => {
     const raw: ChatHistoryResponse = {
       sessionId: 'session-a',
       history: [
         { id: 1, role: 'user', content: 'hi' },
         { id: 2, role: 'assistant', content: 'hello' },
+        {
+          id: 3,
+          role: 'assistant',
+          content: 'charly hello',
+          assistantPresentation: {
+            agentId: 'charly',
+            displayName: 'Charly',
+            imageUrl: null,
+          },
+        },
       ],
       assistantPresentation: {
-        agentId: 'main',
-        displayName: 'Main Agent',
+        agentId: 'charly',
+        displayName: 'Charly',
         imageUrl: null,
       },
     };
 
     const ui = buildChatHistoryUiData(raw, 'session-a');
 
-    for (const msg of ui.messages) {
-      expect(msg.assistantPresentation?.agentId).toBe('main');
-      expect(msg.assistantPresentation?.displayName).toBe('Main Agent');
-    }
+    const mainAssistant = ui.messages.find((m) => m.content === 'hello');
+    const charlyAssistant = ui.messages.find(
+      (m) => m.content === 'charly hello',
+    );
+
+    expect(mainAssistant?.assistantPresentation).toBeNull();
+    expect(charlyAssistant?.assistantPresentation).toMatchObject({
+      agentId: 'charly',
+      displayName: 'Charly',
+    });
   });
 });

--- a/console/src/routes/chat/chat-history-query.ts
+++ b/console/src/routes/chat/chat-history-query.ts
@@ -58,7 +58,7 @@ export function buildChatHistoryUiData(
       artifacts: [],
       replayRequest:
         replayContent !== null ? { content: replayContent, media: [] } : null,
-      assistantPresentation: raw.assistantPresentation ?? null,
+      assistantPresentation: msg.assistantPresentation ?? null,
       branchKey:
         msg.id !== undefined && msg.id !== null
           ? (branchKeysByMessageId.get(msg.id) ?? null)

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -774,7 +774,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
   background: transparent;
   color: inherit;
   font: inherit;
-  font-size: 0.86rem;
+  font-size: 0.78rem;
   font-weight: 500;
   line-height: 36px;
   padding: 0 42px 0 20px;

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -264,30 +264,30 @@ aside[data-state="collapsed"] .chatSidebarContent {
 .agentLabel {
   display: flex;
   align-items: center;
-  gap: 6px;
-  font-size: 0.75rem;
+  gap: 8px;
+  font-size: 0.82rem;
   font-weight: 600;
   color: var(--muted-foreground);
   padding: 0 4px;
 }
 
 .agentAvatar {
-  width: 20px;
-  height: 20px;
+  width: 28px;
+  height: 28px;
   border-radius: 999px;
   object-fit: cover;
 }
 
 .agentInitial {
-  width: 20px;
-  height: 20px;
+  width: 28px;
+  height: 28px;
   border-radius: 999px;
   background: var(--primary);
   color: var(--primary-foreground);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.65rem;
+  font-size: 0.8rem;
   font-weight: 700;
 }
 

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -676,6 +676,13 @@ aside[data-state="collapsed"] .chatSidebarContent {
   gap: 8px;
 }
 
+.composerLeftActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
 .composerInput {
   flex: 1 1 auto;
   min-height: 36px;
@@ -730,6 +737,28 @@ aside[data-state="collapsed"] .chatSidebarContent {
 .attachButton:hover {
   background: var(--muted);
   color: var(--text);
+}
+
+.agentSelect {
+  max-width: 160px;
+  height: 32px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-bg);
+  color: var(--muted-foreground);
+  font: inherit;
+  font-size: 0.82rem;
+  padding: 0 24px 0 8px;
+}
+
+.agentSelect:hover:not(:disabled),
+.agentSelect:focus {
+  color: var(--text);
+  border-color: var(--line-strong);
+}
+
+.agentSelect:disabled {
+  opacity: 0.55;
 }
 
 .sendButton {

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -739,26 +739,57 @@ aside[data-state="collapsed"] .chatSidebarContent {
   color: var(--text);
 }
 
+.agentSelectWrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  max-width: 170px;
+}
+
+.agentSelectWrap::after {
+  content: "";
+  position: absolute;
+  right: 1px;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  color: var(--muted-foreground);
+  pointer-events: none;
+  transform: translateY(-2px) rotate(45deg);
+}
+
 .agentSelect {
-  max-width: 160px;
+  max-width: 170px;
   height: 32px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  background: var(--panel-bg);
+  border: none;
+  appearance: none;
+  background: transparent;
   color: var(--muted-foreground);
   font: inherit;
-  font-size: 0.82rem;
-  padding: 0 24px 0 8px;
+  font-size: 0.95rem;
+  line-height: 32px;
+  padding: 0 18px 0 0;
+  outline: none;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .agentSelect:hover:not(:disabled),
 .agentSelect:focus {
   color: var(--text);
-  border-color: var(--line-strong);
+}
+
+.agentSelectWrap:has(.agentSelect:hover:not(:disabled))::after,
+.agentSelectWrap:has(.agentSelect:focus)::after {
+  color: var(--text);
 }
 
 .agentSelect:disabled {
   opacity: 0.55;
+  cursor: default;
 }
 
 .sendButton {

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -745,7 +745,12 @@ aside[data-state="collapsed"] .chatSidebarContent {
   align-items: center;
   height: 36px;
   max-width: 160px;
+  border-radius: 999px;
   color: var(--muted-foreground);
+  padding: 0 10px;
+  transition:
+    background 0.12s,
+    color 0.12s;
 }
 
 .agentSelectWrap::after {
@@ -761,7 +766,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
 }
 
 .agentSelect {
-  max-width: 160px;
+  max-width: 140px;
   height: 36px;
   border: none;
   appearance: none;
@@ -786,6 +791,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
 
 .agentSelectWrap:has(.agentSelect:hover:not(:disabled)),
 .agentSelectWrap:has(.agentSelect:focus) {
+  background: var(--muted);
   color: var(--text);
 }
 

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -450,7 +450,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
   border-color: transparent;
   background: transparent;
   color: var(--muted-foreground);
-  border-radius: var(--radius-sm);
+  border-radius: 999px;
   font-size: 0.82rem;
 }
 

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1,5 +1,5 @@
 .chatPage {
-  --chat-hover-bg: color-mix(in srgb, var(--muted) 86%, var(--background) 14%);
+  --chat-hover-bg: color-mix(in srgb, var(--muted) 94%, var(--foreground) 6%);
 
   display: flex;
   width: 100%;

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -679,7 +679,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
 .composerLeftActions {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
   min-width: 0;
 }
 
@@ -743,33 +743,35 @@ aside[data-state="collapsed"] .chatSidebarContent {
   position: relative;
   display: inline-flex;
   align-items: center;
-  max-width: 170px;
+  height: 36px;
+  max-width: 160px;
+  color: var(--muted-foreground);
 }
 
 .agentSelectWrap::after {
   content: "";
   position: absolute;
-  right: 1px;
-  width: 8px;
-  height: 8px;
-  border-right: 2px solid currentColor;
-  border-bottom: 2px solid currentColor;
-  color: var(--muted-foreground);
+  right: 0;
+  width: 7px;
+  height: 7px;
+  border-right: 1.7px solid currentColor;
+  border-bottom: 1.7px solid currentColor;
   pointer-events: none;
-  transform: translateY(-2px) rotate(45deg);
+  transform: translateY(-3px) rotate(45deg);
 }
 
 .agentSelect {
-  max-width: 170px;
-  height: 32px;
+  max-width: 160px;
+  height: 36px;
   border: none;
   appearance: none;
   background: transparent;
-  color: var(--muted-foreground);
+  color: inherit;
   font: inherit;
-  font-size: 0.95rem;
-  line-height: 32px;
-  padding: 0 18px 0 0;
+  font-size: 0.86rem;
+  font-weight: 500;
+  line-height: 36px;
+  padding: 0 20px 0 0;
   outline: none;
   cursor: pointer;
   overflow: hidden;
@@ -782,8 +784,8 @@ aside[data-state="collapsed"] .chatSidebarContent {
   color: var(--text);
 }
 
-.agentSelectWrap:has(.agentSelect:hover:not(:disabled))::after,
-.agentSelectWrap:has(.agentSelect:focus)::after {
+.agentSelectWrap:has(.agentSelect:hover:not(:disabled)),
+.agentSelectWrap:has(.agentSelect:focus) {
   color: var(--text);
 }
 

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -454,7 +454,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
   font-size: 0.82rem;
 }
 
-.messageActions .actionButton:hover {
+.messageActions .actionButton:hover:not(:disabled):not([data-disabled]) {
   background: var(--chat-hover-bg);
   color: var(--foreground);
 }
@@ -480,7 +480,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
   font-size: 0.8rem;
 }
 
-.branchButton:hover {
+.branchButton:hover:not(:disabled):not([data-disabled]) {
   background: var(--chat-hover-bg);
   color: var(--text);
 }

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1,5 +1,5 @@
 .chatPage {
-  --chat-hover-bg: color-mix(in srgb, var(--muted) 78%, var(--foreground) 6%);
+  --chat-hover-bg: color-mix(in srgb, var(--muted) 86%, var(--background) 14%);
 
   display: flex;
   width: 100%;
@@ -746,10 +746,9 @@ aside[data-state="collapsed"] .chatSidebarContent {
   display: inline-flex;
   align-items: center;
   height: 36px;
-  max-width: 160px;
+  max-width: 180px;
   border-radius: 999px;
   color: var(--muted-foreground);
-  padding: 0 10px;
   transition:
     background 0.12s,
     color 0.12s;
@@ -758,7 +757,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
 .agentSelectWrap::after {
   content: "";
   position: absolute;
-  right: 0;
+  right: 16px;
   width: 7px;
   height: 7px;
   border-right: 1.7px solid currentColor;
@@ -768,7 +767,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
 }
 
 .agentSelect {
-  max-width: 140px;
+  max-width: 180px;
   height: 36px;
   border: none;
   appearance: none;
@@ -778,7 +777,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
   font-size: 0.86rem;
   font-weight: 500;
   line-height: 36px;
-  padding: 0 20px 0 0;
+  padding: 0 42px 0 20px;
   outline: none;
   cursor: pointer;
   overflow: hidden;

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -272,22 +272,22 @@ aside[data-state="collapsed"] .chatSidebarContent {
 }
 
 .agentAvatar {
-  width: 28px;
-  height: 28px;
+  width: 32px;
+  height: 32px;
   border-radius: 999px;
   object-fit: cover;
 }
 
 .agentInitial {
-  width: 28px;
-  height: 28px;
+  width: 32px;
+  height: 32px;
   border-radius: 999px;
   background: var(--primary);
   color: var(--primary-foreground);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.8rem;
+  font-size: 0.86rem;
   font-weight: 700;
 }
 

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1,4 +1,6 @@
 .chatPage {
+  --chat-hover-bg: color-mix(in srgb, var(--muted) 78%, var(--foreground) 6%);
+
   display: flex;
   width: 100%;
   height: 100dvh;
@@ -49,7 +51,7 @@
 }
 
 .newChatButton:hover {
-  background: var(--panel-bg);
+  background: var(--chat-hover-bg);
 }
 
 .newChatButton > span:first-child {
@@ -98,7 +100,7 @@
 }
 
 .sessionItem:hover {
-  background: var(--panel-bg);
+  background: var(--chat-hover-bg);
 }
 
 .sessionItemActive .sessionTitle,
@@ -453,7 +455,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
 }
 
 .messageActions .actionButton:hover {
-  background: var(--muted);
+  background: var(--chat-hover-bg);
   color: var(--foreground);
 }
 
@@ -479,7 +481,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
 }
 
 .branchButton:hover {
-  background: var(--muted);
+  background: var(--chat-hover-bg);
   color: var(--text);
 }
 
@@ -735,7 +737,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
 }
 
 .attachButton:hover {
-  background: var(--muted);
+  background: var(--chat-hover-bg);
   color: var(--text);
 }
 
@@ -791,7 +793,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
 
 .agentSelectWrap:has(.agentSelect:hover:not(:disabled)),
 .agentSelectWrap:has(.agentSelect:focus) {
-  background: var(--muted);
+  background: var(--chat-hover-bg);
   color: var(--text);
 }
 
@@ -808,7 +810,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
 }
 
 .sendButton:hover:not(:disabled) {
-  background: var(--muted);
+  background: var(--chat-hover-bg);
   color: var(--text);
 }
 
@@ -848,7 +850,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
 
 .suggestionItem:hover,
 .suggestionItemActive {
-  background: var(--muted);
+  background: var(--chat-hover-bg);
 }
 
 .suggestionLabel {

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -23,7 +23,7 @@ import type {
   ChatRecentResponse,
   MediaUploadResponse,
 } from '../../api/chat-types';
-import type { GatewayStatus } from '../../api/types';
+import type { AgentsOverview, GatewayStatus } from '../../api/types';
 import { SidebarProvider } from '../../components/sidebar/index';
 import { ChatPage } from './chat-page';
 
@@ -50,6 +50,8 @@ const createChatBranchMock =
   >();
 const uploadMediaMock =
   vi.fn<(token: string, file: File) => Promise<MediaUploadResponse>>();
+const fetchAgentsOverviewMock =
+  vi.fn<(token: string) => Promise<AgentsOverview>>();
 const useAuthMock = vi.fn();
 const sendMessageMock = vi.fn();
 const stopRequestMock = vi.fn();
@@ -73,6 +75,10 @@ vi.mock('../../api/chat', () => ({
     beforeMessageId: number | string,
   ) => createChatBranchMock(token, sessionId, beforeMessageId),
   uploadMedia: (token: string, file: File) => uploadMediaMock(token, file),
+}));
+
+vi.mock('../../api/client', () => ({
+  fetchAgentsOverview: (token: string) => fetchAgentsOverviewMock(token),
 }));
 
 vi.mock('../../auth', () => ({
@@ -135,6 +141,7 @@ describe('ChatPage', () => {
     fetchChatHistoryMock.mockReset();
     createChatBranchMock.mockReset();
     uploadMediaMock.mockReset();
+    fetchAgentsOverviewMock.mockReset();
     useAuthMock.mockReset();
     sendMessageMock.mockReset();
     stopRequestMock.mockReset();
@@ -183,6 +190,43 @@ describe('ChatPage', () => {
             ],
       }),
     );
+    fetchAgentsOverviewMock.mockResolvedValue({
+      agents: [
+        {
+          id: 'main',
+          name: 'Assistant',
+          model: 'gpt-5',
+          chatbotId: null,
+          enableRag: null,
+          workspace: null,
+          workspacePath: '/tmp/main',
+          sessionCount: 1,
+          activeSessions: 0,
+          idleSessions: 1,
+          stoppedSessions: 0,
+          effectiveModels: ['gpt-5'],
+          lastActive: null,
+          status: 'idle',
+        },
+        {
+          id: 'charly',
+          name: 'Charly',
+          model: 'gpt-5',
+          chatbotId: null,
+          enableRag: null,
+          workspace: null,
+          workspacePath: '/tmp/charly',
+          sessionCount: 0,
+          activeSessions: 0,
+          idleSessions: 0,
+          stoppedSessions: 0,
+          effectiveModels: ['gpt-5'],
+          lastActive: null,
+          status: 'unused',
+        },
+      ],
+      sessions: [],
+    });
     isActiveMock.mockReturnValue(false);
     useChatStreamMock.mockReturnValue({
       sendMessage: sendMessageMock,
@@ -238,6 +282,29 @@ describe('ChatPage', () => {
         'test-token',
         'session-b',
       ),
+    );
+  });
+
+  it('switches agents from the composer dropdown using the slash command path', async () => {
+    fetchChatHistoryMock.mockResolvedValue({
+      sessionId: 'session-a',
+      history: [{ id: 101, role: 'assistant', content: 'Opened session A' }],
+    });
+    sendMessageMock.mockResolvedValue(true);
+
+    renderChatPage();
+
+    expect(await screen.findByText('Opened session A')).not.toBeNull();
+    await waitFor(() => expect(fetchAgentsOverviewMock).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText('Switch agent'), {
+      target: { value: 'charly' },
+    });
+
+    await waitFor(() =>
+      expect(sendMessageMock).toHaveBeenCalledWith('/agent switch charly', [], {
+        hideUser: true,
+      }),
     );
   });
 

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -23,7 +23,7 @@ import type {
   ChatRecentResponse,
   MediaUploadResponse,
 } from '../../api/chat-types';
-import type { AgentsOverview, GatewayStatus } from '../../api/types';
+import type { AgentListItem, GatewayStatus } from '../../api/types';
 import { SidebarProvider } from '../../components/sidebar/index';
 import { ChatPage } from './chat-page';
 
@@ -50,8 +50,7 @@ const createChatBranchMock =
   >();
 const uploadMediaMock =
   vi.fn<(token: string, file: File) => Promise<MediaUploadResponse>>();
-const fetchAgentsOverviewMock =
-  vi.fn<(token: string) => Promise<AgentsOverview>>();
+const fetchAgentListMock = vi.fn<(token: string) => Promise<AgentListItem[]>>();
 const useAuthMock = vi.fn();
 const sendMessageMock = vi.fn();
 const stopRequestMock = vi.fn();
@@ -78,7 +77,7 @@ vi.mock('../../api/chat', () => ({
 }));
 
 vi.mock('../../api/client', () => ({
-  fetchAgentsOverview: (token: string) => fetchAgentsOverviewMock(token),
+  fetchAgentList: (token: string) => fetchAgentListMock(token),
 }));
 
 vi.mock('../../auth', () => ({
@@ -141,7 +140,7 @@ describe('ChatPage', () => {
     fetchChatHistoryMock.mockReset();
     createChatBranchMock.mockReset();
     uploadMediaMock.mockReset();
-    fetchAgentsOverviewMock.mockReset();
+    fetchAgentListMock.mockReset();
     useAuthMock.mockReset();
     sendMessageMock.mockReset();
     stopRequestMock.mockReset();
@@ -190,43 +189,10 @@ describe('ChatPage', () => {
             ],
       }),
     );
-    fetchAgentsOverviewMock.mockResolvedValue({
-      agents: [
-        {
-          id: 'main',
-          name: 'Assistant',
-          model: 'gpt-5',
-          chatbotId: null,
-          enableRag: null,
-          workspace: null,
-          workspacePath: '/tmp/main',
-          sessionCount: 1,
-          activeSessions: 0,
-          idleSessions: 1,
-          stoppedSessions: 0,
-          effectiveModels: ['gpt-5'],
-          lastActive: null,
-          status: 'idle',
-        },
-        {
-          id: 'charly',
-          name: 'Charly',
-          model: 'gpt-5',
-          chatbotId: null,
-          enableRag: null,
-          workspace: null,
-          workspacePath: '/tmp/charly',
-          sessionCount: 0,
-          activeSessions: 0,
-          idleSessions: 0,
-          stoppedSessions: 0,
-          effectiveModels: ['gpt-5'],
-          lastActive: null,
-          status: 'unused',
-        },
-      ],
-      sessions: [],
-    });
+    fetchAgentListMock.mockResolvedValue([
+      { id: 'main', name: 'Assistant' },
+      { id: 'charly', name: 'Charly' },
+    ]);
     isActiveMock.mockReturnValue(false);
     useChatStreamMock.mockReturnValue({
       sendMessage: sendMessageMock,
@@ -295,7 +261,7 @@ describe('ChatPage', () => {
     renderChatPage();
 
     expect(await screen.findByText('Opened session A')).not.toBeNull();
-    await waitFor(() => expect(fetchAgentsOverviewMock).toHaveBeenCalled());
+    await waitFor(() => expect(fetchAgentListMock).toHaveBeenCalled());
 
     fireEvent.change(screen.getByLabelText('Switch agent'), {
       target: { value: 'charly' },

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -335,6 +335,7 @@ export function ChatPage() {
 
   const handleAgentSwitch = useCallback(
     async (agentId: string) => {
+      if (!agentId || /\s/.test(agentId)) return;
       ensureSessionForSend();
       const accepted = await stream.sendMessage(
         `/agent switch ${agentId}`,

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -11,6 +11,7 @@ import type {
   ChatMessage,
   MediaItem,
 } from '../../api/chat-types';
+import { fetchAgentsOverview } from '../../api/client';
 import { useAuth } from '../../auth';
 import { MobileTopbarTrigger } from '../../components/sidebar/index';
 import { ViewSwitchNav } from '../../components/view-switch';
@@ -77,6 +78,9 @@ export function ChatPage() {
   const [error, setError] = useState('');
   const [editingId, setEditingId] = useState<string | null>(null);
   const [approvalBusy, setApprovalBusy] = useState(false);
+  const [selectedAgentId, setSelectedAgentId] = useState(
+    defaultAgentIdRef.current,
+  );
 
   const [sessionSearchQuery, setSessionSearchQuery] = useState('');
   const debouncedSessionSearchQuery = useDebouncedValue(
@@ -124,10 +128,20 @@ export function ChatPage() {
     staleTime: Infinity,
   });
 
+  const agentsQuery = useQuery({
+    queryKey: ['agents-overview', auth.token],
+    queryFn: () => fetchAgentsOverview(auth.token),
+    staleTime: 30_000,
+  });
+
   useEffect(() => {
     const id = appStatusQuery.data?.defaultAgentId;
     if (id) {
-      defaultAgentIdRef.current = id.trim().toLowerCase();
+      const normalized = id.trim().toLowerCase();
+      defaultAgentIdRef.current = normalized;
+      setSelectedAgentId((current) =>
+        !current || current === DEFAULT_AGENT_ID ? normalized : current,
+      );
     }
   }, [appStatusQuery.data?.defaultAgentId]);
 
@@ -157,6 +171,24 @@ export function ChatPage() {
     staleTime: 10_000,
   });
   const recentSessions = recentQuery.data?.sessions ?? [];
+  const agentOptions = useMemo(
+    () =>
+      (agentsQuery.data?.agents ?? []).map((agent) => ({
+        id: agent.id,
+        name: agent.name,
+      })),
+    [agentsQuery.data?.agents],
+  );
+
+  useEffect(() => {
+    if (!sessionId) return;
+    const currentSession = agentsQuery.data?.sessions.find(
+      (entry) => entry.sessionId === sessionId,
+    );
+    if (currentSession?.agentId) {
+      setSelectedAgentId(currentSession.agentId);
+    }
+  }, [agentsQuery.data?.sessions, sessionId]);
 
   const historyQuery = useQuery({
     queryKey: chatHistoryQueryKey(auth.token, sessionId),
@@ -301,6 +333,26 @@ export function ChatPage() {
     [ensureSessionForSend, stream.sendMessage],
   );
 
+  const handleAgentSwitch = useCallback(
+    async (agentId: string) => {
+      ensureSessionForSend();
+      const accepted = await stream.sendMessage(
+        `/agent switch ${agentId}`,
+        [],
+        {
+          hideUser: true,
+        },
+      );
+      if (accepted) {
+        setSelectedAgentId(agentId);
+        void queryClient.invalidateQueries({
+          queryKey: ['agents-overview', auth.token],
+        });
+      }
+    },
+    [ensureSessionForSend, stream.sendMessage, queryClient, auth.token],
+  );
+
   const handleOpenSession = useCallback(
     (targetId: string) => {
       if (stream.isActive()) {
@@ -421,6 +473,9 @@ export function ChatPage() {
             onStop={() => void stream.stopRequest()}
             onUploadFiles={handleUploadFiles}
             token={auth.token}
+            agents={agentOptions}
+            selectedAgentId={selectedAgentId}
+            onAgentSwitch={(agentId) => void handleAgentSwitch(agentId)}
           />
         </div>
       </div>

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -11,7 +11,7 @@ import type {
   ChatMessage,
   MediaItem,
 } from '../../api/chat-types';
-import { fetchAgentsOverview } from '../../api/client';
+import { fetchAgentList } from '../../api/client';
 import { useAuth } from '../../auth';
 import { MobileTopbarTrigger } from '../../components/sidebar/index';
 import { ViewSwitchNav } from '../../components/view-switch';
@@ -129,8 +129,8 @@ export function ChatPage() {
   });
 
   const agentsQuery = useQuery({
-    queryKey: ['agents-overview', auth.token],
-    queryFn: () => fetchAgentsOverview(auth.token),
+    queryKey: ['agents-list', auth.token],
+    queryFn: () => fetchAgentList(auth.token),
     staleTime: 30_000,
   });
 
@@ -173,22 +173,12 @@ export function ChatPage() {
   const recentSessions = recentQuery.data?.sessions ?? [];
   const agentOptions = useMemo(
     () =>
-      (agentsQuery.data?.agents ?? []).map((agent) => ({
+      (agentsQuery.data ?? []).map((agent) => ({
         id: agent.id,
         name: agent.name,
       })),
-    [agentsQuery.data?.agents],
+    [agentsQuery.data],
   );
-
-  useEffect(() => {
-    if (!sessionId) return;
-    const currentSession = agentsQuery.data?.sessions.find(
-      (entry) => entry.sessionId === sessionId,
-    );
-    if (currentSession?.agentId) {
-      setSelectedAgentId(currentSession.agentId);
-    }
-  }, [agentsQuery.data?.sessions, sessionId]);
 
   const historyQuery = useQuery({
     queryKey: chatHistoryQueryKey(auth.token, sessionId),
@@ -346,12 +336,9 @@ export function ChatPage() {
       );
       if (accepted) {
         setSelectedAgentId(agentId);
-        void queryClient.invalidateQueries({
-          queryKey: ['agents-overview', auth.token],
-        });
       }
     },
-    [ensureSessionForSend, stream.sendMessage, queryClient, auth.token],
+    [ensureSessionForSend, stream.sendMessage],
   );
 
   const handleOpenSession = useCallback(

--- a/console/src/routes/chat/composer.test.tsx
+++ b/console/src/routes/chat/composer.test.tsx
@@ -42,4 +42,30 @@ describe('Composer', () => {
       ),
     );
   });
+
+  it('renders a compact agent switcher beside the attach button', () => {
+    const onAgentSwitch = vi.fn();
+
+    render(
+      <Composer
+        isStreaming={false}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        onUploadFiles={vi.fn<(_: File[]) => Promise<MediaItem[]>>()}
+        token="test-token"
+        agents={[
+          { id: 'main', name: 'Assistant' },
+          { id: 'charly', name: 'Charly' },
+        ]}
+        selectedAgentId="main"
+        onAgentSwitch={onAgentSwitch}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Switch agent'), {
+      target: { value: 'charly' },
+    });
+
+    expect(onAgentSwitch).toHaveBeenCalledWith('charly');
+  });
 });

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -11,6 +11,10 @@ import { fetchChatCommands } from '../../api/chat';
 import type { ChatCommandSuggestion, MediaItem } from '../../api/chat-types';
 import { extractClipboardFiles } from '../../lib/chat-helpers';
 import { cx } from '../../lib/cx';
+import {
+  type AgentSwitchOption,
+  AgentSwitchSelect,
+} from './agent-switch-select';
 import css from './chat-page.module.css';
 
 function SlashSuggestions(props: {
@@ -52,6 +56,9 @@ export function Composer(props: {
   onStop: () => void;
   onUploadFiles: (files: File[]) => Promise<MediaItem[]>;
   token: string;
+  agents?: AgentSwitchOption[];
+  selectedAgentId?: string;
+  onAgentSwitch?: (agentId: string) => void;
 }) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -198,6 +205,9 @@ export function Composer(props: {
     setPendingMedia((prev) => prev.filter((_, i) => i !== index));
   };
 
+  const agentOptions = props.agents ?? [];
+  const selectedAgentId = props.selectedAgentId ?? '';
+
   return (
     <div className={css.composerWrapper}>
       <div className={css.composer} style={{ position: 'relative' }}>
@@ -239,14 +249,22 @@ export function Composer(props: {
           aria-label="Message input"
         />
         <div className={css.composerActions}>
-          <button
-            type="button"
-            className={css.attachButton}
-            onClick={() => fileInputRef.current?.click()}
-            aria-label="Attach files"
-          >
-            +
-          </button>
+          <div className={css.composerLeftActions}>
+            <button
+              type="button"
+              className={css.attachButton}
+              onClick={() => fileInputRef.current?.click()}
+              aria-label="Attach files"
+            >
+              +
+            </button>
+            <AgentSwitchSelect
+              agents={agentOptions}
+              selectedAgentId={selectedAgentId}
+              disabled={props.isStreaming}
+              onSwitch={(agentId) => props.onAgentSwitch?.(agentId)}
+            />
+          </div>
           <button
             type="button"
             className={cx(css.sendButton, props.isStreaming && css.stopping)}

--- a/console/src/routes/chat/use-chat-stream.test.ts
+++ b/console/src/routes/chat/use-chat-stream.test.ts
@@ -284,6 +284,56 @@ describe('useChatStream', () => {
     });
   });
 
+  it('replaces thinking with an assistant message for result-only slash command streams', async () => {
+    const harness = makeHarness();
+
+    requestChatStreamMock.mockResolvedValue({
+      status: 'success',
+      sessionId: SESSION_ID,
+      userMessageId: 'server-user-1',
+      assistantMessageId: null,
+      result: 'Session agent set to `research` (model: `gpt-5`).',
+      toolsUsed: [],
+    });
+
+    const { result } = renderHook(
+      () =>
+        useChatStream({
+          token: TOKEN,
+          userId: 'web-user-1',
+          getSessionId: () => SESSION_ID,
+          setError: harness.setError,
+          refreshRecent: vi.fn(),
+          onSessionIdCorrection: harness.correctionMock,
+        }),
+      { wrapper: harness.wrapper },
+    );
+
+    await act(async () => {
+      await result.current.sendMessage('/agent switch research', []);
+    });
+
+    expect(harness.messages).toHaveLength(2);
+    expect(
+      harness.messages.find((msg) => msg.role === 'thinking'),
+    ).toBeUndefined();
+    expect(harness.messages[0]).toMatchObject({
+      role: 'user',
+      content: '/agent switch research',
+      messageId: 'server-user-1',
+    });
+    expect(harness.messages[1]).toMatchObject({
+      id: 'msg-3',
+      role: 'assistant',
+      content: 'Session agent set to `research` (model: `gpt-5`).',
+      messageId: null,
+      replayRequest: {
+        content: '/agent switch research',
+        media: [],
+      },
+    });
+  });
+
   it('removes the thinking placeholder and appends one system error on stream failure', async () => {
     const harness = makeHarness();
 

--- a/console/src/routes/chat/use-chat-stream.test.ts
+++ b/console/src/routes/chat/use-chat-stream.test.ts
@@ -187,6 +187,11 @@ describe('useChatStream', () => {
           userMessageId: 'server-user-2',
           assistantMessageId: 'assistant-2',
           result: 'Answer',
+          assistantPresentation: {
+            agentId: 'charly',
+            displayName: 'Charly',
+            imageUrl: null,
+          },
         };
       },
     );
@@ -225,6 +230,10 @@ describe('useChatStream', () => {
     expect(assistant).toMatchObject({
       content: 'Answer',
       messageId: 'assistant-2',
+      assistantPresentation: {
+        agentId: 'charly',
+        displayName: 'Charly',
+      },
       replayRequest: {
         content: 'repeat this',
         media: [],

--- a/console/src/routes/chat/use-chat-stream.ts
+++ b/console/src/routes/chat/use-chat-stream.ts
@@ -244,23 +244,33 @@ export function useChatStream(
         const finalText = result.result ?? req.assistantText ?? '';
         const finalApproval = req.pendingApproval;
         const finalArtifacts = result.artifacts ?? [];
+        const buildFinalizedMessage = (
+          id: string,
+          sessionId: string,
+          base?: ChatUiMessage,
+        ): ChatUiMessage => ({
+          ...base,
+          id,
+          role: finalApproval ? 'approval' : 'assistant',
+          content: finalText,
+          sessionId,
+          messageId: result.assistantMessageId ?? null,
+          artifacts: finalArtifacts,
+          assistantPresentation: result.assistantPresentation ?? null,
+          pendingApproval: finalApproval,
+          replayRequest: { content, media },
+        });
 
         setMessages((prev) => {
           const withoutThinking = prev.filter((m) => m.id !== thinkingId);
           const hasAssistant = withoutThinking.some((m) => m.id === streamId);
           const finalizeMessage = (m: ChatUiMessage): ChatUiMessage => {
             if (m.id === streamId) {
-              return {
-                ...m,
-                role: finalApproval ? 'approval' : 'assistant',
-                content: finalText,
-                sessionId: result.sessionId ?? m.sessionId,
-                messageId: result.assistantMessageId ?? null,
-                artifacts: finalArtifacts,
-                assistantPresentation: result.assistantPresentation ?? null,
-                pendingApproval: finalApproval,
-                replayRequest: { content, media },
-              };
+              return buildFinalizedMessage(
+                streamId,
+                result.sessionId ?? m.sessionId,
+                m,
+              );
             }
             if (userMsgId && m.id === userMsgId && m.role === 'user') {
               return {
@@ -277,17 +287,7 @@ export function useChatStream(
 
           return [
             ...finalized,
-            {
-              id: streamId,
-              role: finalApproval ? 'approval' : 'assistant',
-              content: finalText,
-              sessionId: result.sessionId ?? req.sessionId,
-              messageId: result.assistantMessageId ?? null,
-              artifacts: finalArtifacts,
-              assistantPresentation: result.assistantPresentation ?? null,
-              pendingApproval: finalApproval,
-              replayRequest: { content, media },
-            },
+            buildFinalizedMessage(streamId, result.sessionId ?? req.sessionId),
           ];
         });
 

--- a/console/src/routes/chat/use-chat-stream.ts
+++ b/console/src/routes/chat/use-chat-stream.ts
@@ -245,30 +245,49 @@ export function useChatStream(
         const finalApproval = req.pendingApproval;
         const finalArtifacts = result.artifacts ?? [];
 
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.id === streamId
-              ? {
-                  ...m,
-                  role: finalApproval ? 'approval' : 'assistant',
-                  content: finalText,
-                  messageId: result.assistantMessageId ?? null,
-                  artifacts: finalArtifacts,
-                  pendingApproval: finalApproval,
-                  replayRequest: { content, media },
-                }
-              : userMsgId &&
-                  m.id === userMsgId &&
-                  m.role === 'user' &&
-                  !m.messageId
-                ? {
-                    ...m,
-                    messageId: result.userMessageId ?? null,
-                    sessionId: result.sessionId ?? m.sessionId,
-                  }
-                : m,
-          ),
-        );
+        setMessages((prev) => {
+          const withoutThinking = prev.filter((m) => m.id !== thinkingId);
+          const hasAssistant = withoutThinking.some((m) => m.id === streamId);
+          const finalizeMessage = (m: ChatUiMessage): ChatUiMessage => {
+            if (m.id === streamId) {
+              return {
+                ...m,
+                role: finalApproval ? 'approval' : 'assistant',
+                content: finalText,
+                sessionId: result.sessionId ?? m.sessionId,
+                messageId: result.assistantMessageId ?? null,
+                artifacts: finalArtifacts,
+                pendingApproval: finalApproval,
+                replayRequest: { content, media },
+              };
+            }
+            if (userMsgId && m.id === userMsgId && m.role === 'user') {
+              return {
+                ...m,
+                messageId: m.messageId ?? result.userMessageId ?? null,
+                sessionId: result.sessionId ?? m.sessionId,
+              };
+            }
+            return m;
+          };
+
+          const finalized = withoutThinking.map(finalizeMessage);
+          if (hasAssistant) return finalized;
+
+          return [
+            ...finalized,
+            {
+              id: streamId,
+              role: finalApproval ? 'approval' : 'assistant',
+              content: finalText,
+              sessionId: result.sessionId ?? req.sessionId,
+              messageId: result.assistantMessageId ?? null,
+              artifacts: finalArtifacts,
+              pendingApproval: finalApproval,
+              replayRequest: { content, media },
+            },
+          ];
+        });
 
         refreshRecent();
       } catch (err) {

--- a/console/src/routes/chat/use-chat-stream.ts
+++ b/console/src/routes/chat/use-chat-stream.ts
@@ -257,6 +257,7 @@ export function useChatStream(
                 sessionId: result.sessionId ?? m.sessionId,
                 messageId: result.assistantMessageId ?? null,
                 artifacts: finalArtifacts,
+                assistantPresentation: result.assistantPresentation ?? null,
                 pendingApproval: finalApproval,
                 replayRequest: { content, media },
               };
@@ -283,6 +284,7 @@ export function useChatStream(
               sessionId: result.sessionId ?? req.sessionId,
               messageId: result.assistantMessageId ?? null,
               artifacts: finalArtifacts,
+              assistantPresentation: result.assistantPresentation ?? null,
               pendingApproval: finalApproval,
               replayRequest: { content, media },
             },

--- a/docs/chat.html
+++ b/docs/chat.html
@@ -1637,7 +1637,6 @@
     let activeChatRequest = null;
     let activeConcurrentBtwRequest = null;
     let activeEditState = null;
-    let activeAssistantPresentation = null;
     let slashSuggestionsVersion = 0;
     let slashFetchBackoffUntil = 0;
     let slashDebounceTimer = 0;
@@ -3205,10 +3204,7 @@
       let artifactsBlock = null;
       if (role === 'assistant') {
         item.classList.add('markdown');
-        appendAssistantPresentation(
-          item,
-          options.assistantPresentation || activeAssistantPresentation,
-        );
+        appendAssistantPresentation(item, options.assistantPresentation);
         contentEl = document.createElement('div');
         contentEl.className = 'msg-content';
         contentEl.innerHTML = renderMarkdown(content || '');
@@ -3710,7 +3706,6 @@
       const preservePendingBootstrap = options.preservePendingBootstrap === true;
       const bootstrapAttempt = Number(options.bootstrapAttempt) || 0;
       activeEditState = null;
-      activeAssistantPresentation = null;
       savePrefs();
       setError('');
       pruneBranchStateForSession(activeSessionId);
@@ -3731,8 +3726,7 @@
           activeSessionId = nextSessionId;
           savePrefs();
         }
-        activeAssistantPresentation = normalizeAssistantPresentation(payload.assistantPresentation);
-        const restoredAgentId = normalizeAgentId(activeAssistantPresentation?.agentId);
+        const restoredAgentId = resolveWebSessionAgentId(activeSessionId);
         if (
           initialStoredRestorePending &&
           requestedSessionId &&
@@ -3788,7 +3782,7 @@
               sessionId: activeSessionId,
               messageId,
               replayRequest: lastUserPrompt,
-              assistantPresentation: activeAssistantPresentation,
+              assistantPresentation: normalizeAssistantPresentation(msg.assistantPresentation),
             });
             continue;
           }

--- a/src/doctor/checks/resource-hygiene.ts
+++ b/src/doctor/checks/resource-hygiene.ts
@@ -232,6 +232,9 @@ function loadSessionSnapshotFromDatabase(): SessionDatabaseSnapshot {
           WHERE COALESCE(message_count, 0) = 0`,
       )
       .all() as Array<{ id: string; last_active: string }>;
+    // Candidate selection is intentionally broader than the token regex used
+    // for agent-wide cleanup so stale session-scoped rows are still pruned
+    // without treating names like "evaluation-helper" as disposable agents.
     const ephemeralEvalRows = db
       .prepare(
         `SELECT id, agent_id, channel_id, last_active

--- a/src/doctor/checks/resource-hygiene.ts
+++ b/src/doctor/checks/resource-hygiene.ts
@@ -42,6 +42,7 @@ const PROMPT_DUMP_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 const SESSION_COMPACTION_IDLE_MAX_AGE_MS = 6 * 60 * 60 * 1000;
 const EMPTY_SESSION_MAX_AGE_MS = 48 * 60 * 60 * 1000;
 const MANAGED_TEMP_MEDIA_DIR_PREFIXES = ['hybridclaw-wa-', 'hybridclaw-slack-'];
+const EPHEMERAL_EVAL_SESSION_RE = /(?:^|[-_/])(?:eval|locomo)(?:[-_/]|$)/i;
 
 interface CleanupCandidate {
   path: string;
@@ -73,10 +74,16 @@ interface EmptySessionSnapshot {
   lastActiveMs: number | null;
 }
 
+interface EphemeralEvalSessionSnapshot extends EmptySessionSnapshot {
+  agentId: string;
+  channelId: string;
+}
+
 interface SessionDatabaseSnapshot {
   currentSessions: SessionSnapshot[];
   allSessionKeys: Set<string>;
   emptySessions: EmptySessionSnapshot[];
+  ephemeralEvalSessions: EphemeralEvalSessionSnapshot[];
 }
 
 interface ExportCandidateShell {
@@ -173,6 +180,12 @@ function openReadonlyDatabase(): Database.Database {
   });
 }
 
+function openWritableDatabase(): Database.Database {
+  return new Database(DB_PATH, {
+    fileMustExist: true,
+  });
+}
+
 const ALLOWED_PRAGMA_TABLES = new Set(['sessions']);
 
 function databaseHasColumn(
@@ -219,6 +232,23 @@ function loadSessionSnapshotFromDatabase(): SessionDatabaseSnapshot {
           WHERE COALESCE(message_count, 0) = 0`,
       )
       .all() as Array<{ id: string; last_active: string }>;
+    const ephemeralEvalRows = db
+      .prepare(
+        `SELECT id, agent_id, channel_id, last_active
+           FROM sessions
+          WHERE lower(COALESCE(agent_id, '')) LIKE '%eval%'
+             OR lower(COALESCE(agent_id, '')) LIKE '%locomo%'
+             OR lower(id) LIKE '%eval%'
+             OR lower(id) LIKE '%locomo%'
+             OR lower(channel_id) LIKE '%eval%'
+             OR lower(channel_id) LIKE '%locomo%'`,
+      )
+      .all() as Array<{
+      id: string;
+      agent_id: string;
+      channel_id: string;
+      last_active: string;
+    }>;
 
     return {
       currentSessions: currentSessionRows.map((row) => {
@@ -246,6 +276,16 @@ function loadSessionSnapshotFromDatabase(): SessionDatabaseSnapshot {
           lastActiveMs: Number.isFinite(lastActiveMs) ? lastActiveMs : null,
         };
       }),
+      ephemeralEvalSessions: ephemeralEvalRows.map((row) => {
+        const lastActiveMs = Date.parse(row.last_active);
+        return {
+          id: row.id,
+          agentId: row.agent_id,
+          channelId: row.channel_id,
+          lastActive: row.last_active,
+          lastActiveMs: Number.isFinite(lastActiveMs) ? lastActiveMs : null,
+        };
+      }),
     };
   } finally {
     db.close();
@@ -257,6 +297,90 @@ function readDirEntries(dirPath: string): fs.Dirent[] {
     return fs.readdirSync(dirPath, { withFileTypes: true });
   } catch {
     return [];
+  }
+}
+
+function listEphemeralEvalDirectoryCandidates(
+  nowMs = Date.now(),
+): CleanupCandidate[] {
+  const candidates: CleanupCandidate[] = [];
+  for (const rootPath of [
+    path.join(DATA_DIR, 'sessions'),
+    path.join(DATA_DIR, 'audit'),
+  ]) {
+    for (const entry of readDirEntries(rootPath)) {
+      if (!EPHEMERAL_EVAL_SESSION_RE.test(entry.name)) continue;
+      const entryPath = path.join(rootPath, entry.name);
+      let stat: fs.Stats;
+      try {
+        stat = fs.statSync(entryPath);
+      } catch {
+        continue;
+      }
+      const ageMs = Math.max(0, nowMs - stat.mtimeMs);
+      if (ageMs < EMPTY_SESSION_MAX_AGE_MS) continue;
+      candidates.push({
+        path: entryPath,
+        displayPath: shortenHomePath(entryPath),
+        sizeBytes: stat.isDirectory() ? readDirSize(entryPath) : stat.size,
+        ageMs,
+      });
+    }
+  }
+  return candidates;
+}
+
+function deleteEphemeralEvalSessionData(
+  sessions: EphemeralEvalSessionSnapshot[],
+): number {
+  if (sessions.length === 0) return 0;
+  const db = openWritableDatabase();
+  try {
+    const transaction = db.transaction(
+      (rows: EphemeralEvalSessionSnapshot[]) => {
+        const deleteBySessionId = [
+          'approvals',
+          'audit_events',
+          'audit_log',
+          'messages',
+          'request_log',
+          'semantic_memories',
+          'skill_observations',
+          'tasks',
+          'usage_events',
+        ].map((tableName) =>
+          db.prepare(`DELETE FROM ${tableName} WHERE session_id = ?`),
+        );
+        const deleteBranches = db.prepare(
+          'DELETE FROM session_branches WHERE session_id = ? OR parent_session_id = ?',
+        );
+        const deleteSession = db.prepare('DELETE FROM sessions WHERE id = ?');
+        const deleteCanonicalByAgent = db.prepare(
+          'DELETE FROM canonical_sessions WHERE agent_id = ? OR canonical_id = ? OR canonical_id = ?',
+        );
+        const deleteMessagesByAgent = db.prepare(
+          'DELETE FROM messages WHERE agent_id = ?',
+        );
+        let deleted = 0;
+        for (const session of rows) {
+          for (const statement of deleteBySessionId) {
+            statement.run(session.id);
+          }
+          deleteBranches.run(session.id, session.id);
+          deleteCanonicalByAgent.run(
+            session.agentId,
+            session.agentId,
+            session.id,
+          );
+          deleteMessagesByAgent.run(session.agentId);
+          deleted += deleteSession.run(session.id).changes;
+        }
+        return deleted;
+      },
+    );
+    return transaction(sessions);
+  } finally {
+    db.close();
   }
 }
 
@@ -943,6 +1067,92 @@ export async function checkEmptySessions(
   ];
 }
 
+export async function checkEphemeralEvalArtifacts(
+  ctx: HygieneRunContext = new HygieneRunContext(),
+): Promise<DiagResult[]> {
+  let snapshot: SessionDatabaseSnapshot;
+  try {
+    snapshot = ctx.getSnapshot();
+  } catch (error) {
+    return [
+      makeResult(
+        'database',
+        'Ephemeral eval artifacts',
+        'error',
+        `Cannot inspect eval sessions without ${shortenHomePath(DB_PATH)} (${toErrorMessage(error)})`,
+      ),
+    ];
+  }
+
+  const nowMs = Date.now();
+  const staleSessions = snapshot.ephemeralEvalSessions.filter(
+    (session) =>
+      session.lastActiveMs != null &&
+      nowMs - session.lastActiveMs >= EMPTY_SESSION_MAX_AGE_MS,
+  );
+  const directoryCandidates = listEphemeralEvalDirectoryCandidates(nowMs);
+
+  if (staleSessions.length === 0 && directoryCandidates.length === 0) {
+    return [
+      makeResult(
+        'database',
+        'Ephemeral eval artifacts',
+        'ok',
+        `No eval/locomo sessions or directories older than ${formatAge(EMPTY_SESSION_MAX_AGE_MS)}`,
+      ),
+    ];
+  }
+
+  const oldestSession =
+    staleSessions.reduce<EphemeralEvalSessionSnapshot | null>(
+      (oldest, session) => {
+        if (session.lastActiveMs == null) return oldest;
+        if (
+          oldest == null ||
+          oldest.lastActiveMs == null ||
+          session.lastActiveMs < oldest.lastActiveMs
+        ) {
+          return session;
+        }
+        return oldest;
+      },
+      null,
+    );
+  const oldestDirectoryAgeMs =
+    directoryCandidates.length > 0 ? maxCandidateAgeMs(directoryCandidates) : 0;
+  const oldestAgeMs = Math.max(
+    oldestSession?.lastActiveMs != null
+      ? Math.max(0, nowMs - oldestSession.lastActiveMs)
+      : 0,
+    oldestDirectoryAgeMs,
+  );
+
+  return [
+    makeResult(
+      'database',
+      'Ephemeral eval artifacts',
+      'warn',
+      [
+        `${staleSessions.length} stale eval/locomo ${pluralize(staleSessions.length, 'session', 'sessions')}`,
+        `${directoryCandidates.length} matching ${pluralize(directoryCandidates.length, 'directory', 'directories')}`,
+        oldestAgeMs > 0 ? `oldest ${formatAge(oldestAgeMs)}` : null,
+      ]
+        .filter((part): part is string => Boolean(part))
+        .join(', '),
+      {
+        summary: `Delete ${staleSessions.length} eval/locomo ${pluralize(staleSessions.length, 'session', 'sessions')} and ${directoryCandidates.length} matching ${pluralize(directoryCandidates.length, 'directory', 'directories')}`,
+        requiresApproval: false,
+        apply: async () => {
+          deleteEphemeralEvalSessionData(staleSessions);
+          for (const candidate of directoryCandidates) {
+            removeCleanupPath(candidate.path);
+          }
+        },
+      },
+    ),
+  ];
+}
+
 export function resourceHygieneDoctorChecks(): DoctorCheck[] {
   const ctx = new HygieneRunContext();
   return [
@@ -980,6 +1190,11 @@ export function resourceHygieneDoctorChecks(): DoctorCheck[] {
       category: 'database',
       label: 'Empty sessions',
       run: () => checkEmptySessions(ctx),
+    },
+    {
+      category: 'database',
+      label: 'Ephemeral eval artifacts',
+      run: () => checkEphemeralEvalArtifacts(ctx),
     },
   ];
 }

--- a/src/doctor/checks/resource-hygiene.ts
+++ b/src/doctor/checks/resource-hygiene.ts
@@ -336,34 +336,34 @@ function deleteEphemeralEvalSessionData(
   if (sessions.length === 0) return 0;
   const db = openWritableDatabase();
   try {
+    const deleteBySessionId = [
+      'approvals',
+      'audit_events',
+      'audit_log',
+      'messages',
+      'request_log',
+      'semantic_memories',
+      'skill_observations',
+      'tasks',
+      'usage_events',
+    ].map((tableName) =>
+      db.prepare(`DELETE FROM ${tableName} WHERE session_id = ?`),
+    );
+    const deleteBranches = db.prepare(
+      'DELETE FROM session_branches WHERE session_id = ? OR parent_session_id = ?',
+    );
+    const deleteSession = db.prepare('DELETE FROM sessions WHERE id = ?');
+    const deleteCanonicalById = db.prepare(
+      'DELETE FROM canonical_sessions WHERE canonical_id = ?',
+    );
+    const deleteCanonicalByAgent = db.prepare(
+      'DELETE FROM canonical_sessions WHERE agent_id = ?',
+    );
+    const deleteMessagesByAgent = db.prepare(
+      'DELETE FROM messages WHERE agent_id = ?',
+    );
     const transaction = db.transaction(
       (rows: EphemeralEvalSessionSnapshot[]) => {
-        const deleteBySessionId = [
-          'approvals',
-          'audit_events',
-          'audit_log',
-          'messages',
-          'request_log',
-          'semantic_memories',
-          'skill_observations',
-          'tasks',
-          'usage_events',
-        ].map((tableName) =>
-          db.prepare(`DELETE FROM ${tableName} WHERE session_id = ?`),
-        );
-        const deleteBranches = db.prepare(
-          'DELETE FROM session_branches WHERE session_id = ? OR parent_session_id = ?',
-        );
-        const deleteSession = db.prepare('DELETE FROM sessions WHERE id = ?');
-        const deleteCanonicalById = db.prepare(
-          'DELETE FROM canonical_sessions WHERE canonical_id = ?',
-        );
-        const deleteCanonicalByAgent = db.prepare(
-          'DELETE FROM canonical_sessions WHERE agent_id = ?',
-        );
-        const deleteMessagesByAgent = db.prepare(
-          'DELETE FROM messages WHERE agent_id = ?',
-        );
         const ephemeralAgentIds = new Set<string>();
         let deleted = 0;
         for (const session of rows) {

--- a/src/doctor/checks/resource-hygiene.ts
+++ b/src/doctor/checks/resource-hygiene.ts
@@ -75,7 +75,7 @@ interface EmptySessionSnapshot {
 }
 
 interface EphemeralEvalSessionSnapshot extends EmptySessionSnapshot {
-  agentId: string;
+  agentId: string | null;
   channelId: string;
 }
 
@@ -245,7 +245,7 @@ function loadSessionSnapshotFromDatabase(): SessionDatabaseSnapshot {
       )
       .all() as Array<{
       id: string;
-      agent_id: string;
+      agent_id: string | null;
       channel_id: string;
       last_active: string;
     }>;
@@ -355,25 +355,34 @@ function deleteEphemeralEvalSessionData(
           'DELETE FROM session_branches WHERE session_id = ? OR parent_session_id = ?',
         );
         const deleteSession = db.prepare('DELETE FROM sessions WHERE id = ?');
+        const deleteCanonicalById = db.prepare(
+          'DELETE FROM canonical_sessions WHERE canonical_id = ?',
+        );
         const deleteCanonicalByAgent = db.prepare(
-          'DELETE FROM canonical_sessions WHERE agent_id = ? OR canonical_id = ? OR canonical_id = ?',
+          'DELETE FROM canonical_sessions WHERE agent_id = ?',
         );
         const deleteMessagesByAgent = db.prepare(
           'DELETE FROM messages WHERE agent_id = ?',
         );
+        const ephemeralAgentIds = new Set<string>();
         let deleted = 0;
         for (const session of rows) {
           for (const statement of deleteBySessionId) {
             statement.run(session.id);
           }
           deleteBranches.run(session.id, session.id);
-          deleteCanonicalByAgent.run(
-            session.agentId,
-            session.agentId,
-            session.id,
-          );
-          deleteMessagesByAgent.run(session.agentId);
+          deleteCanonicalById.run(session.id);
+          if (
+            session.agentId &&
+            EPHEMERAL_EVAL_SESSION_RE.test(session.agentId)
+          ) {
+            ephemeralAgentIds.add(session.agentId);
+          }
           deleted += deleteSession.run(session.id).changes;
+        }
+        for (const agentId of ephemeralAgentIds) {
+          deleteCanonicalByAgent.run(agentId);
+          deleteMessagesByAgent.run(agentId);
         }
         return deleted;
       },

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -100,7 +100,7 @@ import {
   extractUsageCostUsd,
   formatCanonicalContextPrompt,
   formatPluginPromptContext,
-  getGatewayAssistantPresentationForAgent,
+  getGatewayAssistantPresentationForMessageAgent,
   isGatewayRequestLoggingEnabled,
   isVersionOnlyQuestion,
   maybeRecordGatewayRequestLog,
@@ -124,12 +124,6 @@ import {
 } from './show-mode.js';
 
 const MAX_HISTORY_MESSAGES = 40;
-
-function getAssistantPresentationForResult(agentId: string) {
-  return agentId === DEFAULT_AGENT_ID
-    ? undefined
-    : getGatewayAssistantPresentationForAgent(agentId);
-}
 
 function readGatewayPromptModeDefault(): PromptMode | undefined {
   const raw = String(process.env[GATEWAY_SYSTEM_PROMPT_MODE_ENV] || '')
@@ -533,7 +527,8 @@ async function handleGatewayMessageInner(
             })
           : undefined,
       toolsUsed: [],
-      assistantPresentation: getAssistantPresentationForResult(agentId),
+      assistantPresentation:
+        getGatewayAssistantPresentationForMessageAgent(agentId),
       userMessageId: storedTurn.userMessageId,
       assistantMessageId: storedTurn.assistantMessageId,
     });
@@ -694,7 +689,8 @@ async function handleGatewayMessageInner(
       agentId,
       model,
       provider,
-      assistantPresentation: getAssistantPresentationForResult(agentId),
+      assistantPresentation:
+        getGatewayAssistantPresentationForMessageAgent(agentId),
       userMessageId: storedTurn.userMessageId,
       assistantMessageId: storedTurn.assistantMessageId,
     };
@@ -1352,7 +1348,8 @@ async function handleGatewayMessageInner(
       pendingApproval: output.pendingApproval,
       tokenUsage: output.tokenUsage,
       effectiveUserPrompt: output.effectiveUserPrompt,
-      assistantPresentation: getAssistantPresentationForResult(agentId),
+      assistantPresentation:
+        getGatewayAssistantPresentationForMessageAgent(agentId),
       userMessageId: storedTurn.userMessageId,
       assistantMessageId: storedTurn.assistantMessageId,
     };

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -100,6 +100,7 @@ import {
   extractUsageCostUsd,
   formatCanonicalContextPrompt,
   formatPluginPromptContext,
+  getGatewayAssistantPresentationForAgent,
   isGatewayRequestLoggingEnabled,
   isVersionOnlyQuestion,
   maybeRecordGatewayRequestLog,
@@ -123,6 +124,12 @@ import {
 } from './show-mode.js';
 
 const MAX_HISTORY_MESSAGES = 40;
+
+function getAssistantPresentationForResult(agentId: string) {
+  return agentId === DEFAULT_AGENT_ID
+    ? undefined
+    : getGatewayAssistantPresentationForAgent(agentId);
+}
 
 function readGatewayPromptModeDefault(): PromptMode | undefined {
   const raw = String(process.env[GATEWAY_SYSTEM_PROMPT_MODE_ENV] || '')
@@ -526,6 +533,7 @@ async function handleGatewayMessageInner(
             })
           : undefined,
       toolsUsed: [],
+      assistantPresentation: getAssistantPresentationForResult(agentId),
       userMessageId: storedTurn.userMessageId,
       assistantMessageId: storedTurn.assistantMessageId,
     });
@@ -686,6 +694,7 @@ async function handleGatewayMessageInner(
       agentId,
       model,
       provider,
+      assistantPresentation: getAssistantPresentationForResult(agentId),
       userMessageId: storedTurn.userMessageId,
       assistantMessageId: storedTurn.assistantMessageId,
     };
@@ -1343,6 +1352,7 @@ async function handleGatewayMessageInner(
       pendingApproval: output.pendingApproval,
       tokenUsage: output.tokenUsage,
       effectiveUserPrompt: output.effectiveUserPrompt,
+      assistantPresentation: getAssistantPresentationForResult(agentId),
       userMessageId: storedTurn.userMessageId,
       assistantMessageId: storedTurn.assistantMessageId,
     };

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -147,6 +147,7 @@ import {
   getGatewayAdminSessions,
   getGatewayAdminSkills,
   getGatewayAdminTools,
+  getGatewayAgentList,
   getGatewayAgents,
   getGatewayBootstrapAutostartState,
   getGatewayHistory,
@@ -1873,6 +1874,10 @@ function handleApiChatCommands(res: ServerResponse, url: URL): void {
 
 async function handleApiAgents(res: ServerResponse): Promise<void> {
   sendJson(res, 200, await getGatewayAgents());
+}
+
+function handleApiAgentList(res: ServerResponse): void {
+  sendJson(res, 200, getGatewayAgentList());
 }
 
 function handleApiAdminJobsContext(res: ServerResponse): void {
@@ -3643,6 +3648,10 @@ export function startGatewayHttpServer(): GatewayHttpServer {
           }
           if (pathname === '/api/agents' && method === 'GET') {
             await handleApiAgents(res);
+            return;
+          }
+          if (pathname === '/api/agents/list' && method === 'GET') {
+            handleApiAgentList(res);
             return;
           }
           if (pathname === '/api/proactive/pull' && method === 'GET') {

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -148,7 +148,6 @@ import {
   getGatewayAdminSkills,
   getGatewayAdminTools,
   getGatewayAgents,
-  getGatewayAssistantPresentationForSession,
   getGatewayBootstrapAutostartState,
   getGatewayHistory,
   getGatewayHistorySummary,
@@ -1766,7 +1765,6 @@ async function handleApiHistory(res: ServerResponse, url: URL): Promise<void> {
     sessionKey: historyPage.sessionKey || undefined,
     mainSessionKey: historyPage.mainSessionKey || undefined,
     history: historyPage.history,
-    assistantPresentation: getGatewayAssistantPresentationForSession(sessionId),
     bootstrapAutostart,
     ...(historyPage.branchFamilies.length > 0
       ? { branchFamilies: historyPage.branchFamilies }

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -407,6 +407,7 @@ import {
   type GatewayAdminToolCatalogEntry,
   type GatewayAdminToolsResponse,
   type GatewayAdminUsageSummary,
+  type GatewayAgentListResponse,
   type GatewayAgentsResponse,
   type GatewayAssistantPresentation,
   type GatewayChatRequest,
@@ -6016,6 +6017,15 @@ export function getGatewayHistory(
     mainSessionKey: page.mainSessionKey,
     history,
     branchFamilies: page.branchFamilies,
+  };
+}
+
+export function getGatewayAgentList(): GatewayAgentListResponse {
+  return {
+    agents: listAgents().map((agent) => ({
+      id: agent.id,
+      name: agent.name || null,
+    })),
   };
 }
 

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -2647,7 +2647,7 @@ export function getGatewayAssistantPresentationForSession(
   );
 }
 
-function getGatewayAssistantPresentationForMessageAgent(
+export function getGatewayAssistantPresentationForMessageAgent(
   agentId?: string | null,
 ): GatewayAssistantPresentation | undefined {
   const normalizedAgentId = String(agentId || '').trim();

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -2638,15 +2638,6 @@ export function getGatewayAssistantPresentationForAgent(
   };
 }
 
-export function getGatewayAssistantPresentationForSession(
-  sessionId: string,
-): GatewayAssistantPresentation {
-  const session = memoryService.getSessionById(sessionId);
-  return getGatewayAssistantPresentationForAgent(
-    session ? resolveSessionAgentId(session) : DEFAULT_AGENT_ID,
-  );
-}
-
 export function getGatewayAssistantPresentationForMessageAgent(
   agentId?: string | null,
 ): GatewayAssistantPresentation | undefined {

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -2647,6 +2647,16 @@ export function getGatewayAssistantPresentationForSession(
   );
 }
 
+function getGatewayAssistantPresentationForMessageAgent(
+  agentId?: string | null,
+): GatewayAssistantPresentation | undefined {
+  const normalizedAgentId = String(agentId || '').trim();
+  if (!normalizedAgentId || normalizedAgentId === DEFAULT_AGENT_ID) {
+    return undefined;
+  }
+  return getGatewayAssistantPresentationForAgent(normalizedAgentId);
+}
+
 export function extractUsageCostUsd(tokenUsage?: TokenUsageStats): number {
   if (!tokenUsage) return 0;
   const costCarrier = tokenUsage as unknown as Record<string, unknown>;
@@ -3168,6 +3178,7 @@ export function recordSuccessfulTurn(opts: {
             username: null,
             role: 'assistant',
             content: opts.resultText,
+            agentId: opts.agentId,
           }),
         }
       : memoryService.storeTurn({
@@ -3180,6 +3191,7 @@ export function recordSuccessfulTurn(opts: {
           assistant: {
             userId: 'assistant',
             username: null,
+            agentId: opts.agentId,
             content: opts.resultText,
           },
         });
@@ -5892,6 +5904,7 @@ export async function ensureGatewayBootstrapAutostart(params: {
       username: null,
       role: 'assistant',
       content: resultText,
+      agentId: resolved.agentId,
     });
     appendSessionTranscript(resolved.agentId, {
       sessionId: session.id,
@@ -5994,12 +6007,13 @@ export function getGatewayHistory(
     .map((message) => {
       if (message.role !== 'assistant') return message;
       const content = stripSilentToken(message.content);
-      return content === message.content
-        ? message
-        : {
-            ...message,
-            content,
-          };
+      const assistantPresentation =
+        getGatewayAssistantPresentationForMessageAgent(message.agent_id);
+      return {
+        ...message,
+        ...(content === message.content ? {} : { content }),
+        ...(assistantPresentation ? { assistantPresentation } : {}),
+      };
     })
     .filter((message) => message.content.trim().length > 0)
     .reverse();
@@ -6959,6 +6973,7 @@ async function publishDelegationCompletion(params: {
     username: null,
     role: 'assistant',
     content: forLLM,
+    agentId,
   });
   appendSessionTranscript(agentId, {
     sessionId: parentSessionId,

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -6000,9 +6000,12 @@ export function getGatewayHistory(
       const content = stripSilentToken(message.content);
       const assistantPresentation =
         getGatewayAssistantPresentationForMessageAgent(message.agent_id);
+      if (content === message.content && !assistantPresentation) {
+        return message;
+      }
       return {
         ...message,
-        ...(content === message.content ? {} : { content }),
+        ...(content !== message.content ? { content } : {}),
         ...(assistantPresentation ? { assistantPresentation } : {}),
       };
     })

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -53,6 +53,7 @@ export interface GatewayChatResult {
   pluginsUsed?: string[];
   skillUsed?: string;
   agentId?: string;
+  assistantPresentation?: GatewayAssistantPresentation;
   model?: string;
   provider?: string;
   memoryCitations?: MemoryCitation[];
@@ -231,8 +232,10 @@ export interface GatewayHistoryMessage {
   user_id: string;
   username: string | null;
   role: string;
+  agent_id?: string | null;
   content: string;
   created_at: string;
+  assistantPresentation?: GatewayAssistantPresentation;
 }
 
 export interface GatewayHistoryToolBreakdownEntry {

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -680,6 +680,15 @@ export interface GatewayAgentsResponse {
   sessions: GatewaySessionCard[];
 }
 
+export interface GatewayAgentListItem {
+  id: string;
+  name: string | null;
+}
+
+export interface GatewayAgentListResponse {
+  agents: GatewayAgentListItem[];
+}
+
 export interface GatewayAdminJobAgent {
   id: string;
   name: string | null;

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -281,7 +281,6 @@ export interface GatewayHistoryResponse {
   sessionKey?: string;
   mainSessionKey?: string;
   history: GatewayHistoryMessage[];
-  assistantPresentation?: GatewayAssistantPresentation;
   bootstrapAutostart?: {
     status: 'idle' | 'starting' | 'completed';
     fileName: 'BOOTSTRAP.md' | 'OPENING.md';

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -2486,6 +2486,42 @@ async function startIMessageIntegration(): Promise<boolean> {
   return true;
 }
 
+const SHUTDOWN_STEP_TIMEOUT_MS = 5_000;
+
+async function runShutdownStep(
+  step: string,
+  run: () => Promise<void> | void,
+  timeoutMs = SHUTDOWN_STEP_TIMEOUT_MS,
+): Promise<void> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const operation = Promise.resolve()
+    .then(run)
+    .then(
+      () => ({ status: 'done' as const }),
+      (error) => ({ status: 'error' as const, error }),
+    );
+  const timeout = new Promise<{ status: 'timeout' }>((resolve) => {
+    timeoutHandle = setTimeout(() => resolve({ status: 'timeout' }), timeoutMs);
+  });
+
+  try {
+    const result = await Promise.race([operation, timeout]);
+    if (result.status === 'error') {
+      logger.debug(
+        { error: result.error, step },
+        'Gateway shutdown step failed',
+      );
+    } else if (result.status === 'timeout') {
+      logger.warn(
+        { step, timeoutMs },
+        'Gateway shutdown step timed out; continuing',
+      );
+    }
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+  }
+}
+
 function setupShutdown(broadcastShutdown: () => void): void {
   let shuttingDown = false;
   const shutdown = async (opts?: { drain?: boolean }) => {
@@ -2496,39 +2532,18 @@ function setupShutdown(broadcastShutdown: () => void): void {
       detachConfigListener();
       detachConfigListener = null;
     }
-    await setDiscordMaintenancePresence().catch((error) => {
-      logger.debug(
-        { error },
-        'Failed to set Discord maintenance presence during shutdown',
-      );
-    });
-    await shutdownEmail().catch((error) => {
-      logger.debug({ error }, 'Failed to stop email runtime during shutdown');
-    });
-    await shutdownSlack().catch((error) => {
-      logger.debug({ error }, 'Failed to stop Slack runtime during shutdown');
-    });
-    await shutdownTelegram().catch((error) => {
-      logger.debug(
-        { error },
-        'Failed to stop Telegram runtime during shutdown',
-      );
-    });
-    await shutdownWhatsApp().catch((error) => {
-      logger.debug(
-        { error },
-        'Failed to stop WhatsApp runtime during shutdown',
-      );
-    });
-    await shutdownVoice({ drain: opts?.drain }).catch((error) => {
-      logger.debug({ error }, 'Failed to stop Voice runtime during shutdown');
-    });
-    await shutdownIMessage().catch((error) => {
-      logger.debug(
-        { error },
-        'Failed to stop iMessage runtime during shutdown',
-      );
-    });
+    await runShutdownStep(
+      'set Discord maintenance presence',
+      setDiscordMaintenancePresence,
+    );
+    await runShutdownStep('stop email runtime', shutdownEmail);
+    await runShutdownStep('stop Slack runtime', shutdownSlack);
+    await runShutdownStep('stop Telegram runtime', shutdownTelegram);
+    await runShutdownStep('stop WhatsApp runtime', shutdownWhatsApp);
+    await runShutdownStep('stop Voice runtime', () =>
+      shutdownVoice({ drain: opts?.drain }),
+    );
+    await runShutdownStep('stop iMessage runtime', shutdownIMessage);
     if (opts?.drain) {
       broadcastShutdown();
       stopAllExecutions();
@@ -2541,21 +2556,19 @@ function setupShutdown(broadcastShutdown: () => void): void {
         );
       }
     }
-    await runManagedMediaCleanup('shutdown');
+    await runShutdownStep('run managed media cleanup', () =>
+      runManagedMediaCleanup('shutdown'),
+    );
     stopHeartbeat();
     stopObservabilityIngest();
     stopDiscoveryLoop();
     if (!opts?.drain) {
       stopAllExecutions();
     }
-    await stopGatewayPlugins().catch((error) => {
-      logger.debug({ error }, 'Failed to stop plugins during shutdown');
-    });
+    await runShutdownStep('stop gateway plugins', stopGatewayPlugins);
     stopScheduler();
     stopMemoryConsolidationScheduler();
-    await shutdownOtel().catch((error) => {
-      logger.debug({ error }, 'Failed to shut down OTel during shutdown');
-    });
+    await runShutdownStep('shut down OTel', shutdownOtel);
     if (proactiveFlushTimer) {
       clearInterval(proactiveFlushTimer);
       proactiveFlushTimer = null;

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -106,7 +106,7 @@ import {
 let db: Database.Database;
 let databaseInitialized = false;
 
-export const DATABASE_SCHEMA_VERSION = 19;
+export const DATABASE_SCHEMA_VERSION = 20;
 const STRUCTURED_AUDIT_SESSION_LIMIT = 10_000;
 const RECENT_CHAT_MESSAGE_SEARCH_TABLE = 'recent_chat_message_search';
 const RECENT_CHAT_MESSAGE_SEARCH_INSERT_TRIGGER =
@@ -160,6 +160,7 @@ interface ConversationHistoryPageRow {
   user_id: string | null;
   username: string | null;
   role: string | null;
+  agent_id: string | null;
   content: string | null;
   created_at: string | null;
 }
@@ -473,6 +474,7 @@ function migrateV1(database: Database.Database): void {
       user_id TEXT NOT NULL,
       username TEXT,
       role TEXT NOT NULL,
+      agent_id TEXT,
       content TEXT NOT NULL,
       created_at TEXT DEFAULT (datetime('now'))
     );
@@ -1713,6 +1715,20 @@ function migrateV19(database: Database.Database): void {
   );
 }
 
+function migrateV20(
+  database: Database.Database,
+  opts?: InitDatabaseOptions,
+): void {
+  addColumnIfMissing({
+    database,
+    table: 'messages',
+    column: 'agent_id',
+    ddl: 'agent_id TEXT',
+    quiet: opts?.quiet === true,
+  });
+  recordMigration(database, 20, 'Persist assistant message agent identity');
+}
+
 function runMigrations(
   database: Database.Database,
   opts?: InitDatabaseOptions,
@@ -1753,6 +1769,7 @@ function runMigrations(
   if (currentVersion < 17) migrateV17(database, opts);
   if (currentVersion < 18) migrateV18(database, opts);
   if (currentVersion < 19) migrateV19(database);
+  if (currentVersion < 20) migrateV20(database, opts);
 
   setSchemaVersion(database, DATABASE_SCHEMA_VERSION);
   if (!quiet && currentVersion < DATABASE_SCHEMA_VERSION) {
@@ -3959,8 +3976,8 @@ export function forkSessionBranch(
     ).run(nextSessionId, sourceSession.id, beforeMessageId, copiedMessageCount);
     copySessionKvStore(sourceSession.id, nextSessionId);
     db.prepare(
-      `INSERT INTO messages (session_id, user_id, username, role, content, created_at)
-       SELECT ?, user_id, username, role, content, created_at
+      `INSERT INTO messages (session_id, user_id, username, role, agent_id, content, created_at)
+       SELECT ?, user_id, username, role, agent_id, content, created_at
        FROM messages
        WHERE session_id = ?
          AND id < ?
@@ -4546,13 +4563,15 @@ export function storeMessage(
   username: string | null,
   role: string,
   content: string,
+  agentId?: string | null,
 ): number {
   const resolvedSessionId = resolveSessionIdCompat(sessionId);
+  const normalizedAgentId = agentId?.trim() || null;
   const result = db
     .prepare(
-      'INSERT INTO messages (session_id, user_id, username, role, content) VALUES (?, ?, ?, ?, ?)',
+      'INSERT INTO messages (session_id, user_id, username, role, agent_id, content) VALUES (?, ?, ?, ?, ?, ?)',
     )
-    .run(resolvedSessionId, userId, username, role, content);
+    .run(resolvedSessionId, userId, username, role, normalizedAgentId, content);
 
   db.prepare(
     "UPDATE sessions SET message_count = message_count + 1, last_active = datetime('now') WHERE id = ?",
@@ -4698,6 +4717,7 @@ export function getConversationHistoryPage(
          m.user_id,
          m.username,
          m.role,
+         m.agent_id,
          m.content,
          m.created_at
        FROM sessions s
@@ -4744,6 +4764,7 @@ export function getConversationHistoryPage(
       user_id: row.user_id,
       username: row.username,
       role: row.role,
+      agent_id: row.agent_id,
       content: row.content,
       created_at: row.created_at,
     });

--- a/src/memory/memory-service.ts
+++ b/src/memory/memory-service.ts
@@ -171,6 +171,7 @@ export interface MemoryBackend {
     username: string | null,
     role: string,
     content: string,
+    agentId?: string | null,
   ) => number;
   storeSemanticMemory: (params: {
     sessionId: string;
@@ -241,6 +242,7 @@ export interface StoreTurnParams {
   assistant: {
     userId?: string;
     username?: string | null;
+    agentId?: string | null;
     content: string;
   };
 }
@@ -721,6 +723,7 @@ export class MemoryService {
     username: string | null;
     role: string;
     content: string;
+    agentId?: string | null;
   }): number {
     return this.backend.storeMessage(
       params.sessionId,
@@ -728,6 +731,7 @@ export class MemoryService {
       params.username,
       params.role,
       params.content,
+      params.agentId,
     );
   }
 
@@ -775,6 +779,7 @@ export class MemoryService {
       username: params.assistant.username || null,
       role: 'assistant',
       content: params.assistant.content,
+      agentId: params.assistant.agentId,
     });
 
     const interactionText = this.normalizeSemanticContent(

--- a/src/scheduler/heartbeat.ts
+++ b/src/scheduler/heartbeat.ts
@@ -339,6 +339,7 @@ export function startHeartbeat(
         assistant: {
           userId: 'assistant',
           username: null,
+          agentId: resolvedAgentId,
           content: result,
         },
       });

--- a/src/scheduler/scheduled-task-runner.ts
+++ b/src/scheduler/scheduled-task-runner.ts
@@ -173,6 +173,7 @@ export async function runIsolatedScheduledTask(params: {
         assistant: {
           userId: 'assistant',
           username: null,
+          agentId,
           content: output.result,
         },
       });

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -34,6 +34,7 @@ export interface StoredMessage {
   username: string | null;
   role: string;
   content: string;
+  agent_id?: string | null;
   created_at: string;
 }
 

--- a/tests/doctor.resource-hygiene.test.ts
+++ b/tests/doctor.resource-hygiene.test.ts
@@ -204,3 +204,85 @@ test('session compaction backlog fix compacts oversized idle sessions and report
     }),
   );
 });
+
+test('ephemeral eval artifact check removes stale eval sessions and directories', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+
+  const { initDatabase, getOrCreateSession } = await import(
+    '../src/memory/db.ts'
+  );
+  const { DATA_DIR, DB_PATH } = await import('../src/config/config.ts');
+
+  initDatabase({ quiet: true });
+  const staleSession = getOrCreateSession(
+    'agent_eval-stale_channel_openai_chat_dm_peer_1',
+    null,
+    'openai_chat_dm_peer',
+    'eval-stale',
+  );
+  const recentSession = getOrCreateSession(
+    'agent_eval-recent_channel_openai_chat_dm_peer_1',
+    null,
+    'openai_chat_dm_peer',
+    'eval-recent',
+  );
+  const db = new Database(DB_PATH);
+  db.prepare(
+    'UPDATE sessions SET message_count = ?, last_active = ? WHERE id = ?',
+  ).run(2, '2026-04-01T00:00:00.000Z', staleSession.id);
+  db.prepare(
+    'UPDATE sessions SET message_count = ?, last_active = ? WHERE id = ?',
+  ).run(2, new Date().toISOString(), recentSession.id);
+  db.prepare(
+    'INSERT INTO messages (session_id, user_id, username, role, content, agent_id) VALUES (?, ?, ?, ?, ?, ?)',
+  ).run(staleSession.id, 'user', 'User', 'assistant', 'stale', 'eval-stale');
+  db.close();
+
+  const staleSessionDir = path.join(DATA_DIR, 'sessions', staleSession.id);
+  const staleAuditDir = path.join(DATA_DIR, 'audit', staleSession.id);
+  const recentSessionDir = path.join(DATA_DIR, 'sessions', recentSession.id);
+  fs.mkdirSync(staleSessionDir, { recursive: true });
+  fs.mkdirSync(staleAuditDir, { recursive: true });
+  fs.mkdirSync(recentSessionDir, { recursive: true });
+  fs.writeFileSync(path.join(staleSessionDir, 'turn.jsonl'), 'stale');
+  fs.writeFileSync(path.join(staleAuditDir, 'wire.jsonl'), 'stale');
+  fs.writeFileSync(path.join(recentSessionDir, 'turn.jsonl'), 'recent');
+  setOldMtime(staleSessionDir, 3 * 24 * 60 * 60 * 1000);
+  setOldMtime(staleAuditDir, 3 * 24 * 60 * 60 * 1000);
+
+  const { checkEphemeralEvalArtifacts } = await import(
+    '../src/doctor/checks/resource-hygiene.ts'
+  );
+
+  const [result] = await checkEphemeralEvalArtifacts();
+
+  expect(result).toMatchObject({
+    label: 'Ephemeral eval artifacts',
+    severity: 'warn',
+  });
+  expect(result.message).toContain('1 stale eval/locomo session');
+  expect(result.message).toContain('2 matching directories');
+
+  await result.fix?.apply();
+
+  const verifyDb = new Database(DB_PATH);
+  const staleRow = verifyDb
+    .prepare('SELECT id FROM sessions WHERE id = ?')
+    .get(staleSession.id);
+  const recentRow = verifyDb
+    .prepare('SELECT id FROM sessions WHERE id = ?')
+    .get(recentSession.id);
+  const staleMessage = verifyDb
+    .prepare('SELECT id FROM messages WHERE session_id = ?')
+    .get(staleSession.id);
+  verifyDb.close();
+
+  expect(staleRow).toBeUndefined();
+  expect(staleMessage).toBeUndefined();
+  expect(recentRow).toEqual({ id: recentSession.id });
+  expect(fs.existsSync(staleSessionDir)).toBe(false);
+  expect(fs.existsSync(staleAuditDir)).toBe(false);
+  expect(fs.existsSync(recentSessionDir)).toBe(true);
+});

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -495,11 +495,6 @@ async function importFreshHealth(options?: {
       deletedCount: 1,
     },
   }));
-  const getGatewayAssistantPresentationForSession = vi.fn(() => ({
-    agentId: 'charly',
-    displayName: 'Charly',
-    imageUrl: '/api/agent-avatar?agentId=charly',
-  }));
   const getGatewayBootstrapAutostartState = vi.fn(() => null);
   const ensureGatewayBootstrapAutostart = vi.fn(async () => {});
   const getAgentById = vi.fn((agentId: string) =>
@@ -1490,7 +1485,6 @@ async function importFreshHealth(options?: {
     getGatewayAdminSessions,
     getGatewayAdminSkills,
     getGatewayAdminTools,
-    getGatewayAssistantPresentationForSession,
     getGatewayBootstrapAutostartState,
     getGatewayHistory,
     getGatewayRecentChatSessions,
@@ -1586,7 +1580,6 @@ async function importFreshHealth(options?: {
     listenArgs,
     getGatewayStatus,
     ensureGatewayBootstrapAutostart,
-    getGatewayAssistantPresentationForSession,
     getGatewayBootstrapAutostartState,
     getGatewayHistory,
     getGatewayRecentChatSessions,
@@ -3415,11 +3408,6 @@ describe('gateway HTTP server', () => {
       sessionId: 's1',
       sessionKey: undefined,
       mainSessionKey: undefined,
-      assistantPresentation: {
-        agentId: 'charly',
-        displayName: 'Charly',
-        imageUrl: '/api/agent-avatar?agentId=charly',
-      },
       bootstrapAutostart: null,
       history: [
         { role: 'user', content: 'hello' },

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -881,6 +881,9 @@ async function importFreshHealth(options?: {
       },
     ],
   }));
+  const getGatewayAgentList = vi.fn(() => ({
+    agents: [{ id: 'main', name: 'Main Agent' }],
+  }));
   const getGatewayAdminModels = vi.fn(async () => ({
     defaultModel: 'gpt-5',
     providerStatus: {},
@@ -1464,6 +1467,7 @@ async function importFreshHealth(options?: {
     deleteGatewayAdminSession,
     ensureGatewayBootstrapAutostart,
     GatewayRequestError,
+    getGatewayAgentList,
     getGatewayAgents,
     getGatewayAdminAgents,
     getGatewayAdminAgentMarkdownFile,
@@ -1580,6 +1584,7 @@ async function importFreshHealth(options?: {
     listenArgs,
     getGatewayStatus,
     ensureGatewayBootstrapAutostart,
+    getGatewayAgentList,
     getGatewayBootstrapAutostartState,
     getGatewayHistory,
     getGatewayRecentChatSessions,
@@ -4702,6 +4707,22 @@ describe('gateway HTTP server', () => {
           fullAutoEnabled: true,
         },
       ],
+    });
+  });
+
+  test('returns lightweight agent list for authorized API requests', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({ url: '/api/agents/list' });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.getGatewayAgentList).toHaveBeenCalledTimes(1);
+    expect(state.getGatewayAgents).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({
+      agents: [{ id: 'main', name: 'Main Agent' }],
     });
   });
 

--- a/tests/gateway-main.test.ts
+++ b/tests/gateway-main.test.ts
@@ -205,6 +205,7 @@ function createGatewayMainTestState(options?: {
     shutdownEmail: vi.fn(async () => {}),
     shutdownSlack: vi.fn(async () => {}),
     shutdownTelegram: vi.fn(async () => {}),
+    shutdownWhatsApp: vi.fn(async () => {}),
     memoryServiceConsolidate: vi.fn(() => ({
       memoriesDecayed: 0,
       dailyFilesCompiled: 0,
@@ -239,6 +240,7 @@ function createGatewayMainTestState(options?: {
     resolveAgentWorkspaceId: vi.fn((agentId: string) => agentId),
     rewriteUserMentionsForMessage: vi.fn(async (text: string) => text),
     runManagedMediaCleanup: vi.fn(async () => {}),
+    setDiscordMaintenancePresence: vi.fn(async () => {}),
     executeWorkflow: vi.fn(async () => {}),
     setInterval: vi.fn(() => ({ timer: true })),
     setTimeout: vi.fn(() => ({ timer: true })),
@@ -404,7 +406,7 @@ async function importFreshGatewayMain(options?: {
     initDiscord: state.initDiscord,
     sendToChannel: vi.fn(),
     shutdownDiscord: state.shutdownDiscord,
-    setDiscordMaintenancePresence: vi.fn(async () => {}),
+    setDiscordMaintenancePresence: state.setDiscordMaintenancePresence,
   }));
   vi.doMock('../src/channels/msteams/attachments.js', () => ({
     buildTeamsArtifactAttachments: state.buildTeamsArtifactAttachments,
@@ -449,7 +451,7 @@ async function importFreshGatewayMain(options?: {
     initWhatsApp: state.initWhatsApp,
     sendToWhatsAppChat: vi.fn(async () => {}),
     sendWhatsAppMediaToChat: vi.fn(async () => {}),
-    shutdownWhatsApp: vi.fn(async () => {}),
+    shutdownWhatsApp: state.shutdownWhatsApp,
   }));
   vi.doMock('../src/channels/whatsapp/auth.js', () => ({
     WhatsAppAuthLockError: MockWhatsAppAuthLockError,
@@ -2380,6 +2382,45 @@ describe('gateway bootstrap', () => {
     expect(
       state.startGatewayHttpServer.mock.results[0]?.value.broadcastShutdown,
     ).toHaveBeenCalledTimes(1);
+  });
+
+  test('shutdown continues when a cleanup step never resolves', async () => {
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never);
+    const state = await importFreshGatewayMain({
+      onState: (nextState) => {
+        nextState.setDiscordMaintenancePresence.mockImplementation(
+          () => new Promise<void>(() => undefined),
+        );
+        nextState.setTimeout.mockImplementation((callback: () => void) => {
+          callback();
+          return { timer: true };
+        });
+      },
+    });
+    const sigintHandler = state.processOn.mock.calls.find(
+      ([event]) => event === 'SIGINT',
+    )?.[1] as (() => void) | undefined;
+
+    expect(sigintHandler).toBeTypeOf('function');
+
+    sigintHandler?.();
+    await settle();
+    await settle();
+
+    expect(state.loggerWarn).toHaveBeenCalledWith(
+      {
+        step: 'set Discord maintenance presence',
+        timeoutMs: 5_000,
+      },
+      'Gateway shutdown step timed out; continuing',
+    );
+    expect(state.shutdownEmail).toHaveBeenCalledTimes(1);
+    expect(state.shutdownSlack).toHaveBeenCalledTimes(1);
+    expect(state.shutdownTelegram).toHaveBeenCalledTimes(1);
+    expect(state.shutdownWhatsApp).toHaveBeenCalledTimes(1);
+    expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
   test('keeps voice stopped on config change until shared Twilio auth token refresh completes', async () => {

--- a/tests/gateway-service.media-history.test.ts
+++ b/tests/gateway-service.media-history.test.ts
@@ -128,6 +128,60 @@ test('getGatewayHistory omits silent message-send placeholders', async () => {
   ]);
 });
 
+test('getGatewayHistory returns assistant presentation per stored message agent', async () => {
+  setupHome();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { getGatewayHistory } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+
+  initDatabase({ quiet: true });
+
+  const sessionId = 'web:agent-history';
+  memoryService.getOrCreateSession(sessionId, null, 'web');
+  memoryService.storeMessage({
+    sessionId,
+    userId: 'assistant',
+    username: null,
+    role: 'assistant',
+    content: 'Main answer',
+    agentId: 'main',
+  });
+  memoryService.storeMessage({
+    sessionId,
+    userId: 'assistant',
+    username: null,
+    role: 'assistant',
+    content: 'Charly answer',
+    agentId: 'charly',
+  });
+
+  const history = getGatewayHistory(sessionId, 10).history;
+
+  const mainAnswer = history.find(
+    (message) => message.content === 'Main answer',
+  );
+  const charlyAnswer = history.find(
+    (message) => message.content === 'Charly answer',
+  );
+
+  expect(mainAnswer).toMatchObject({
+    role: 'assistant',
+    agent_id: 'main',
+  });
+  expect(mainAnswer?.assistantPresentation).toBeUndefined();
+  expect(charlyAnswer).toMatchObject({
+    role: 'assistant',
+    agent_id: 'charly',
+    assistantPresentation: {
+      agentId: 'charly',
+      displayName: 'charly',
+    },
+  });
+});
+
 test('getGatewayHistory omits stored approval request messages', async () => {
   setupHome();
 

--- a/tests/memory-service.test.ts
+++ b/tests/memory-service.test.ts
@@ -568,11 +568,17 @@ describe.sequential('schema migrations', () => {
         "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
       )
       .get('request_log') as { sql: string | null } | undefined;
+    const messageColumns = inspect
+      .prepare('PRAGMA table_info(messages)')
+      .all() as Array<{ name: string }>;
     inspect.close();
 
     expect(String(journalMode).toLowerCase()).toBe('wal');
     expect(Number(schemaVersion)).toBe(DATABASE_SCHEMA_VERSION);
     expect(hasRequestLog?.name).toBe('request_log');
+    expect(messageColumns.some((column) => column.name === 'agent_id')).toBe(
+      true,
+    );
     expect(requestLogSql?.sql?.toLowerCase()).not.toContain(
       "created_at text default (datetime('now'))",
     );
@@ -691,6 +697,29 @@ describe.sequential('schema migrations', () => {
     inspect.close();
 
     expect(getAnyChatbotId()).toBe('bot-newer');
+  });
+
+  test('storeMessage persists assistant agent identity', () => {
+    const dbPath = createTempDbPath();
+    initDatabase({ quiet: true, dbPath });
+
+    getOrCreateSession('session-agent-message', null, 'web');
+    storeMessage(
+      'session-agent-message',
+      'assistant',
+      null,
+      'assistant',
+      'Charly answer',
+      'charly',
+    );
+
+    const inspect = new Database(dbPath, { readonly: true });
+    const stored = inspect
+      .prepare('SELECT agent_id FROM messages WHERE session_id = ?')
+      .get('session-agent-message') as { agent_id: string | null } | undefined;
+    inspect.close();
+
+    expect(stored?.agent_id).toBe('charly');
   });
 
   test('getRecentSessionsForUser returns recent web sessions scoped to the user', () => {


### PR DESCRIPTION
## Summary

Fixes the web `/chat` rendering path for slash commands that complete with only a final stream result event, plus several adjacent reliability and observability changes that surfaced while testing the fix end-to-end.

## Root Cause

The gateway streaming `/api/chat` path short-circuits recognized slash commands into a single `type: "result"` NDJSON event. The console stream hook only finalized an assistant message if one had already been created by a prior text delta, so result-only slash commands could leave the thinking placeholder visible and hide the command response.

## Changes

### Console — slash result rendering (the headline fix)
- Finalize result-only chat streams by removing the thinking placeholder and appending the assistant or approval message when no streamed message exists yet.
- Preserve existing streamed-delta behavior for normal assistant responses.
- Use per-message `assistantPresentation` instead of session-level so a switched agent's message renders with its own avatar/name.
- Add an agent switch dropdown next to the composer attach button (issues `/agent switch <id>` with `hideUser: true`).
- Regression tests: result-only slash command stream (`/agent switch research`); composer dropdown invokes callback; chat-page wires agent switching; chat history uses per-message presentation.

### Gateway + memory — per-message agent identity
- Persist `messages.agent_id` (schema migration + backfill in `db.ts`).
- Plumb `agentId` through `storeMessage` / `storeTurn` and into scheduler/heartbeat assistant outputs.
- Surface per-message `assistantPresentation` in chat results and history responses.

### Ops — shutdown-step timeouts
- `gateway.ts` adds a `runShutdownStep(name, fn, timeoutMs)` wrapper applied to each step of the shutdown pipeline. Shipping in this PR because the result-only stream investigation surfaced gateway shutdowns hanging on a single misbehaving subsystem (websocket teardown, channel adapter close), which made the new chat-stream regression tests flaky and made `gw restart` unreliable. The wrapper logs and continues past a stuck step instead of blocking the whole shutdown.
- Test: `tests/gateway-main.test.ts` covers the shutdown-timeout behavior and exercises the wrapped pipeline.

### Doctor — eval/locomo cleanup
- `resource-hygiene.ts` adds an "Ephemeral eval artifacts" check + fix that cleans up stale eval/locomo sessions and their on-disk session/audit directories.
- Per-session deletes scope to `session_id` (no agent-wide message wipes for sessions that merely have an eval-shaped channel/id). Agent-wide cleanup runs only when the `agent_id` itself matches the eval pattern.
- `EphemeralEvalSessionSnapshot.agentId` typed as `string | null` to match the schema (`sessions.agent_id` is nullable).
- Test: `tests/doctor.resource-hygiene.test.ts` covers the new check and fix.

## Validation

- `./node_modules/.bin/biome check --write console/src/routes/chat/use-chat-stream.ts console/src/routes/chat/use-chat-stream.test.ts src/doctor/checks/resource-hygiene.ts`
- `npm --workspace console run test -- src/routes/chat/use-chat-stream.test.ts`
- `npm --workspace console run typecheck`
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/doctor.resource-hygiene.test.ts tests/memory-service.test.ts tests/gateway-main.test.ts tests/gateway-http-server.test.ts`
- `git diff --check`