### PR TITLE
feat: NDA / confidential-info filter + retroactive leak scanner

### DIFF
--- a/.confidential.example.yml
+++ b/.confidential.example.yml
@@ -1,8 +1,11 @@
 # Example .confidential.yml for the HybridClaw NDA / secret-leak filter.
 #
-# Place a copy at ~/.hybridclaw/.confidential.yml (chmod 600) to enable the
-# pre-LLM dehydration filter and to seed the `hybridclaw audit scan-leaks`
-# scanner. The file is git-ignored by default.
+# Place a copy at one of:
+#   - ./.confidential.yml              (project-local, checked first)
+#   - ~/.hybridclaw/.confidential.yml  (user-global fallback)
+# Lock it down with `chmod 600 <file>`. The file is git-ignored by default.
+# Activates the pre-LLM dehydration filter and seeds the
+# `hybridclaw audit scan-leaks` scanner; first file found wins.
 #
 # Sensitivity levels (used for risk scoring): low | medium | high | critical
 # Default = high.

--- a/.confidential.example.yml
+++ b/.confidential.example.yml
@@ -1,0 +1,39 @@
+# Example .confidential.yml for the HybridClaw NDA / secret-leak filter.
+#
+# Place a copy at ~/.hybridclaw/.confidential.yml (chmod 600) to enable the
+# pre-LLM dehydration filter and to seed the `hybridclaw audit scan-leaks`
+# scanner. The file is git-ignored by default.
+#
+# Sensitivity levels (used for risk scoring): low | medium | high | critical
+# Default = high.
+#
+# All literal matches are case-insensitive and respect word boundaries
+# (so "Acme" will not match "AcmeWidget"). Pattern entries take a
+# JavaScript-style regex string.
+
+version: 1
+
+clients:
+  - name: Serviceplan
+    aliases: ["SP", "Serviceplan AG"]
+    sensitivity: high
+  - name: Acme Corp
+    aliases: ["Acme"]
+    sensitivity: medium
+
+projects:
+  - name: Project Falcon
+    sensitivity: critical
+
+people:
+  - name: Jane Doe
+    sensitivity: medium
+
+keywords:
+  - term: "Q4 2026 budget"
+    sensitivity: critical
+
+patterns:
+  - name: internal-doc-id
+    regex: "INT-\\d{6}"
+    sensitivity: high

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ data/
 .env.*.local
 config.json
 config.local.json
+.confidential.yml
 
 # Backups
 *.bak

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -106,8 +106,11 @@ Implementation: [src/session/session-key.ts](./src/session/session-key.ts),
 Optional, opt-in filter that prevents NDA-class business data from leaving the
 host:
 
-- Define rules in `~/.hybridclaw/.confidential.yml` (clients, projects, people,
-  keywords, regex patterns, each tagged with a sensitivity level).
+- Define rules in `.confidential.yml`. The loader checks the current working
+  directory first (`./.confidential.yml`) and then
+  `~/.hybridclaw/.confidential.yml`; first hit wins. The file holds clients,
+  projects, people, keywords, and regex patterns, each tagged with a
+  sensitivity level.
 - Before every prompt is sent to a model, matches are replaced with stable
   placeholders (`«CONF:CLIENT_001»`); the mapping is held in process memory and
   forgotten when the request ends.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -101,6 +101,34 @@ Implementation: [src/session/session-key.ts](./src/session/session-key.ts),
 [src/session/session-routing.ts](./src/session/session-routing.ts),
 [src/memory/db.ts](./src/memory/db.ts)
 
+### 4.1) Confidential-Info Filter (NDA / secret-leak detector)
+
+Optional, opt-in filter that prevents NDA-class business data from leaving the
+host:
+
+- Define rules in `~/.hybridclaw/.confidential.yml` (clients, projects, people,
+  keywords, regex patterns, each tagged with a sensitivity level).
+- Before every prompt is sent to a model, matches are replaced with stable
+  placeholders (`«CONF:CLIENT_001»`); the mapping is held in process memory and
+  forgotten when the request ends.
+- Streaming text deltas and the final response are rehydrated for the user, so
+  the model never sees the original strings but the user sees real names.
+- Disabled via `HYBRIDCLAW_CONFIDENTIAL_DISABLE=1` for debugging or dry-runs.
+
+A retroactive scanner walks existing audit logs to surface possible past leaks
+and assigns a 0-100 risk score:
+
+```bash
+hybridclaw audit scan-leaks                # scan every session
+hybridclaw audit scan-leaks <sessionId>    # scan one session
+hybridclaw audit scan-leaks --json         # machine-readable report
+```
+
+Implementation: [src/security/confidential-rules.ts](./src/security/confidential-rules.ts),
+[src/security/confidential-redact.ts](./src/security/confidential-redact.ts),
+[src/security/confidential-runtime.ts](./src/security/confidential-runtime.ts),
+[src/audit/leak-scanner.ts](./src/audit/leak-scanner.ts).
+
 ### 5) Audit & Tamper Evidence
 
 Security-relevant behavior is written to structured audit logs:

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -2,6 +2,7 @@ import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import { HYBRIDAI_MODEL } from '../config/config.js';
 import { injectPdfContextMessages } from '../media/pdf-context.js';
 import { withSpan } from '../observability/otel.js';
+import { createConfidentialRuntimeContext } from '../security/confidential-runtime.js';
 import type { ContainerOutput } from '../types/container.js';
 import { getExecutor } from './executor.js';
 import type { ExecutorRequest } from './executor-types.js';
@@ -40,10 +41,12 @@ async function runAgentInner(
     workspaceRoot,
     media,
   });
-  return executor.exec({
+  const confidential = createConfidentialRuntimeContext();
+  const dehydratedMessages = confidential.dehydrate(preparedMessages);
+  const output = await executor.exec({
     ...params,
     sessionId,
-    messages: preparedMessages,
+    messages: dehydratedMessages,
     chatbotId,
     model,
     agentId,
@@ -57,5 +60,18 @@ async function runAgentInner(
     channelId,
     media,
     blockedTools,
+    onTextDelta: confidential.wrapDelta(params.onTextDelta),
+    onThinkingDelta: confidential.wrapDelta(params.onThinkingDelta),
   });
+  if (!confidential.enabled) return output;
+  return {
+    ...output,
+    result: output.result
+      ? confidential.rehydrate(output.result)
+      : output.result,
+    error: output.error ? confidential.rehydrate(output.error) : output.error,
+    effectiveUserPrompt: output.effectiveUserPrompt
+      ? confidential.rehydrate(output.effectiveUserPrompt)
+      : output.effectiveUserPrompt,
+  };
 }

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -4,9 +4,29 @@ import { injectPdfContextMessages } from '../media/pdf-context.js';
 import { withSpan } from '../observability/otel.js';
 import { createConfidentialRuntimeContext } from '../security/confidential-runtime.js';
 import type { ContainerOutput } from '../types/container.js';
+import type {
+  PendingApproval,
+  ToolExecution,
+  ToolProgressEvent,
+} from '../types/execution.js';
 import { getExecutor } from './executor.js';
 import type { ExecutorRequest } from './executor-types.js';
 import { mergeBlockedToolNames } from './tool-policy.js';
+
+const TOOL_EXECUTION_REHYDRATE_FIELDS: ReadonlyArray<keyof ToolExecution> = [
+  'arguments',
+  'result',
+  'blockedReason',
+  'approvalIntent',
+  'approvalReason',
+];
+
+const PENDING_APPROVAL_REHYDRATE_FIELDS: ReadonlyArray<keyof PendingApproval> =
+  ['prompt', 'intent', 'reason'];
+
+const TOOL_PROGRESS_REHYDRATE_FIELDS: ReadonlyArray<keyof ToolProgressEvent> = [
+  'preview',
+];
 
 export async function runAgent(
   params: ExecutorRequest,
@@ -62,8 +82,27 @@ async function runAgentInner(
     blockedTools,
     onTextDelta: confidential.wrapDelta(params.onTextDelta),
     onThinkingDelta: confidential.wrapDelta(params.onThinkingDelta),
+    onToolProgress: confidential.wrapEvent(
+      params.onToolProgress,
+      TOOL_PROGRESS_REHYDRATE_FIELDS,
+    ),
+    onApprovalProgress: confidential.wrapEvent(
+      params.onApprovalProgress,
+      PENDING_APPROVAL_REHYDRATE_FIELDS,
+    ),
   });
   if (!confidential.enabled) return output;
+  const rehydratedToolExecutions = output.toolExecutions?.map(
+    (execution) =>
+      confidential.rehydrateFields(
+        execution,
+        TOOL_EXECUTION_REHYDRATE_FIELDS,
+      ) ?? execution,
+  );
+  const rehydratedPendingApproval = confidential.rehydrateFields(
+    output.pendingApproval,
+    PENDING_APPROVAL_REHYDRATE_FIELDS,
+  );
   return {
     ...output,
     result: output.result
@@ -73,5 +112,7 @@ async function runAgentInner(
     effectiveUserPrompt: output.effectiveUserPrompt
       ? confidential.rehydrate(output.effectiveUserPrompt)
       : output.effectiveUserPrompt,
+    toolExecutions: rehydratedToolExecutions ?? output.toolExecutions,
+    pendingApproval: rehydratedPendingApproval ?? output.pendingApproval,
   };
 }

--- a/src/audit/audit-cli.ts
+++ b/src/audit/audit-cli.ts
@@ -69,6 +69,7 @@ Commands:
   search <query> [n]                 Search structured audit events
   approvals [n] [--denied]           Show approval decisions
   verify <sessionId>                 Verify wire hash chain integrity
+  scan-leaks [sessionId] [--json]    Scan audit logs for leaked confidential info
   instructions [--sync] [--approve]  Verify or restore runtime instruction files`);
 }
 
@@ -198,6 +199,12 @@ export async function runAuditCli(rawArgs: string[]): Promise<void> {
 
   if (cmd === 'instructions') {
     runInstructionHashesCommand(args);
+    return;
+  }
+
+  if (cmd === 'scan-leaks') {
+    const { runLeakScanCli } = await import('./leak-scanner-cli.js');
+    await runLeakScanCli(args);
     return;
   }
 

--- a/src/audit/audit-cli.ts
+++ b/src/audit/audit-cli.ts
@@ -69,7 +69,7 @@ Commands:
   search <query> [n]                 Search structured audit events
   approvals [n] [--denied]           Show approval decisions
   verify <sessionId>                 Verify wire hash chain integrity
-  scan-leaks [sessionId] [--json]    Scan audit logs for leaked confidential info
+  scan-leaks [sessionId] [--json]    Scan audit logs for leaked confidential info (rules: ./.confidential.yml then ~/.hybridclaw/.confidential.yml)
   instructions [--sync] [--approve]  Verify or restore runtime instruction files`);
 }
 

--- a/src/audit/leak-scanner-cli.ts
+++ b/src/audit/leak-scanner-cli.ts
@@ -70,7 +70,7 @@ export async function runLeakScanCli(args: string[]): Promise<void> {
     const message =
       ruleSet.sourcePath != null
         ? `No usable rules found in ${ruleSet.sourcePath}.`
-        : 'No .confidential.yml found. Create ~/.hybridclaw/.confidential.yml to enable leak scanning.';
+        : 'No .confidential.yml found. Create ./.confidential.yml (project-local) or ~/.hybridclaw/.confidential.yml (user-global) to enable leak scanning.';
     if (useJson) {
       console.log(JSON.stringify({ ok: false, reason: message }, null, 2));
     } else {

--- a/src/audit/leak-scanner-cli.ts
+++ b/src/audit/leak-scanner-cli.ts
@@ -1,0 +1,131 @@
+import { loadConfidentialRules } from '../security/confidential-rules.js';
+import {
+  type LeakScanReport,
+  scanAllAuditSessionsForLeaks,
+  scanAuditSessionForLeaks,
+} from './leak-scanner.js';
+
+const ANSI_RED = '\x1b[31m';
+const ANSI_YELLOW = '\x1b[33m';
+const ANSI_GREEN = '\x1b[32m';
+const ANSI_RESET = '\x1b[0m';
+
+function color(text: string, code: string): string {
+  return process.stdout.isTTY ? `${code}${text}${ANSI_RESET}` : text;
+}
+
+function severityColor(severity: LeakScanReport['severity']): string {
+  if (severity === 'critical' || severity === 'high') return ANSI_RED;
+  if (severity === 'medium') return ANSI_YELLOW;
+  return ANSI_GREEN;
+}
+
+function summarizeReport(report: LeakScanReport): string {
+  const tag = color(
+    report.severity.toUpperCase().padEnd(8),
+    severityColor(report.severity),
+  );
+  return `${tag} session=${report.sessionId} score=${report.score}/100 matches=${report.totalMatches} records=${report.matchedRecords.length}/${report.recordsScanned}`;
+}
+
+function printReportDetail(report: LeakScanReport): void {
+  if (report.errors.length > 0) {
+    for (const error of report.errors) {
+      console.log(`  ! ${error}`);
+    }
+  }
+  if (report.matchedRecords.length === 0) {
+    if (report.recordsScanned === 0) {
+      console.log('  (no audit records found)');
+    } else {
+      console.log('  (no confidential matches)');
+    }
+    return;
+  }
+
+  for (const record of report.matchedRecords) {
+    const sevTag = color(
+      record.severity.toUpperCase(),
+      severityColor(record.severity),
+    );
+    const placeholder = record.hadPlaceholder ? ' (post-dehydrate)' : '';
+    console.log(
+      `  #${record.seq} ${record.timestamp} ${record.eventType} ${sevTag} score=${record.score}${placeholder}`,
+    );
+    for (const finding of record.findings) {
+      console.log(
+        `    - [${finding.sensitivity}] ${finding.kind}:${finding.label} ×${finding.matches}  ${finding.excerpt}`,
+      );
+    }
+  }
+}
+
+export async function runLeakScanCli(args: string[]): Promise<void> {
+  const useJson = args.includes('--json');
+  const positional = args.filter((arg) => !arg.startsWith('--'));
+  const sessionId = positional[0];
+
+  const ruleSet = loadConfidentialRules();
+  if (ruleSet.rules.length === 0) {
+    const message =
+      ruleSet.sourcePath != null
+        ? `No usable rules found in ${ruleSet.sourcePath}.`
+        : 'No .confidential.yml found. Create ~/.hybridclaw/.confidential.yml to enable leak scanning.';
+    if (useJson) {
+      console.log(JSON.stringify({ ok: false, reason: message }, null, 2));
+    } else {
+      console.log(message);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  const reports = sessionId
+    ? [scanAuditSessionForLeaks(sessionId, ruleSet)]
+    : scanAllAuditSessionsForLeaks(ruleSet);
+
+  if (useJson) {
+    const serialized = reports.map((report) => ({
+      sessionId: report.sessionId,
+      filePath: report.filePath,
+      recordsScanned: report.recordsScanned,
+      matchedRecords: report.matchedRecords,
+      totalMatches: report.totalMatches,
+      score: report.score,
+      rawScore: report.rawScore,
+      severity: report.severity,
+      errors: report.errors,
+    }));
+    console.log(
+      JSON.stringify(
+        { rulesLoaded: ruleSet.rules.length, reports: serialized },
+        null,
+        2,
+      ),
+    );
+    if (reports.some((report) => report.totalMatches > 0)) {
+      process.exitCode = 2;
+    }
+    return;
+  }
+
+  console.log(
+    `Scanning audit logs (${ruleSet.rules.length} rule${ruleSet.rules.length === 1 ? '' : 's'} from ${ruleSet.sourcePath ?? 'embedded'})`,
+  );
+
+  if (reports.length === 0) {
+    console.log('No audit sessions found.');
+    return;
+  }
+
+  let leaksFound = false;
+  for (const report of reports) {
+    console.log(summarizeReport(report));
+    if (report.totalMatches > 0) leaksFound = true;
+    printReportDetail(report);
+  }
+
+  if (leaksFound) {
+    process.exitCode = 2;
+  }
+}

--- a/src/audit/leak-scanner.ts
+++ b/src/audit/leak-scanner.ts
@@ -1,0 +1,253 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { DATA_DIR } from '../config/config.js';
+import {
+  type ConfidentialFinding,
+  type ConfidentialScanResult,
+  scanForLeaks,
+} from '../security/confidential-redact.js';
+import type { ConfidentialRuleSet } from '../security/confidential-rules.js';
+
+const AUDIT_DIR_NAME = 'audit';
+const WIRE_FILE_NAME = 'wire.jsonl';
+const PLACEHOLDER_RE = /«CONF:[A-Z0-9_-]+»/;
+
+export interface LeakScanRecord {
+  seq: number;
+  timestamp: string;
+  runId: string;
+  parentRunId?: string;
+  eventType: string;
+  findings: ConfidentialFinding[];
+  totalMatches: number;
+  rawScore: number;
+  score: number;
+  severity: ConfidentialFinding['sensitivity'];
+  /** True when the source text already contained a confidential placeholder (i.e. dehydration had run). */
+  hadPlaceholder: boolean;
+}
+
+export interface LeakScanReport {
+  sessionId: string;
+  filePath: string;
+  recordsScanned: number;
+  matchedRecords: LeakScanRecord[];
+  totalMatches: number;
+  /** sum of per-record raw scores, capped at 1000 then normalized to 0-100 */
+  rawScore: number;
+  score: number;
+  severity: ConfidentialFinding['sensitivity'];
+  errors: string[];
+}
+
+const SEVERITY_RANK: Record<ConfidentialFinding['sensitivity'], number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+  critical: 3,
+};
+
+function rankSeverity(
+  current: ConfidentialFinding['sensitivity'],
+  next: ConfidentialFinding['sensitivity'],
+): ConfidentialFinding['sensitivity'] {
+  return SEVERITY_RANK[next] > SEVERITY_RANK[current] ? next : current;
+}
+
+function bucketScore(rawScore: number): {
+  rawScore: number;
+  score: number;
+  severity: ConfidentialFinding['sensitivity'];
+} {
+  const capped = Math.min(rawScore, 1000);
+  const score = Math.round((capped / 1000) * 100);
+  let severity: ConfidentialFinding['sensitivity'] = 'low';
+  if (capped >= 100) severity = 'critical';
+  else if (capped >= 30) severity = 'high';
+  else if (capped >= 10) severity = 'medium';
+  return { rawScore: capped, score, severity };
+}
+
+function collectStringValues(value: unknown, into: string[]): void {
+  if (value == null) return;
+  if (typeof value === 'string') {
+    if (value) into.push(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) collectStringValues(entry, into);
+    return;
+  }
+  if (typeof value === 'object') {
+    for (const entry of Object.values(value as Record<string, unknown>)) {
+      collectStringValues(entry, into);
+    }
+  }
+}
+
+interface WireRecord {
+  seq?: number;
+  timestamp?: string;
+  runId?: string;
+  parentRunId?: string;
+  event?: { type?: string; [key: string]: unknown };
+}
+
+function parseWireLine(line: string): WireRecord | null {
+  try {
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    if (!parsed || typeof parsed !== 'object') return null;
+    return parsed as WireRecord;
+  } catch {
+    return null;
+  }
+}
+
+function scanRecordForLeaks(
+  record: WireRecord,
+  ruleSet: ConfidentialRuleSet,
+): { result: ConfidentialScanResult; hadPlaceholder: boolean } | null {
+  const event = record.event;
+  if (!event || typeof event !== 'object') return null;
+  const strings: string[] = [];
+  collectStringValues(event, strings);
+  if (strings.length === 0) return null;
+  const combined = strings.join('\n');
+  const hadPlaceholder = PLACEHOLDER_RE.test(combined);
+  const result = scanForLeaks(combined, ruleSet);
+  if (result.totalMatches === 0) return null;
+  return { result, hadPlaceholder };
+}
+
+function listAuditSessionIds(auditRoot: string): string[] {
+  if (!fs.existsSync(auditRoot)) return [];
+  try {
+    const entries = fs.readdirSync(auditRoot, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .filter((name) =>
+        fs.existsSync(path.join(auditRoot, name, WIRE_FILE_NAME)),
+      )
+      .sort((a, b) => a.localeCompare(b));
+  } catch {
+    return [];
+  }
+}
+
+export function listAuditedSessions(
+  dataDir: string = DATA_DIR,
+): { sessionId: string; filePath: string }[] {
+  const auditRoot = path.join(dataDir, AUDIT_DIR_NAME);
+  return listAuditSessionIds(auditRoot).map((sessionId) => ({
+    sessionId,
+    filePath: path.join(auditRoot, sessionId, WIRE_FILE_NAME),
+  }));
+}
+
+export function scanAuditSessionForLeaks(
+  sessionId: string,
+  ruleSet: ConfidentialRuleSet,
+  dataDir: string = DATA_DIR,
+): LeakScanReport {
+  const safeId = sessionId.trim().replace(/[^a-zA-Z0-9_-]/g, '_') || 'session';
+  const filePath = path.join(dataDir, AUDIT_DIR_NAME, safeId, WIRE_FILE_NAME);
+  const errors: string[] = [];
+
+  if (!fs.existsSync(filePath)) {
+    return {
+      sessionId,
+      filePath,
+      recordsScanned: 0,
+      matchedRecords: [],
+      totalMatches: 0,
+      rawScore: 0,
+      score: 0,
+      severity: 'low',
+      errors: [`wire log not found: ${filePath}`],
+    };
+  }
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf-8');
+  } catch (error) {
+    return {
+      sessionId,
+      filePath,
+      recordsScanned: 0,
+      matchedRecords: [],
+      totalMatches: 0,
+      rawScore: 0,
+      score: 0,
+      severity: 'low',
+      errors: [
+        `failed to read wire log: ${error instanceof Error ? error.message : String(error)}`,
+      ],
+    };
+  }
+
+  const lines = raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const matched: LeakScanRecord[] = [];
+  let recordsScanned = 0;
+  let totalMatches = 0;
+  let aggregateRaw = 0;
+  let severity: ConfidentialFinding['sensitivity'] = 'low';
+
+  for (let i = 0; i < lines.length; i++) {
+    const parsed = parseWireLine(lines[i]);
+    if (!parsed || !parsed.event) continue;
+    recordsScanned += 1;
+    const scan = scanRecordForLeaks(parsed, ruleSet);
+    if (!scan) continue;
+
+    matched.push({
+      seq: typeof parsed.seq === 'number' ? parsed.seq : i,
+      timestamp: typeof parsed.timestamp === 'string' ? parsed.timestamp : '',
+      runId: typeof parsed.runId === 'string' ? parsed.runId : '',
+      parentRunId:
+        typeof parsed.parentRunId === 'string' ? parsed.parentRunId : undefined,
+      eventType:
+        typeof parsed.event?.type === 'string' ? parsed.event.type : 'unknown',
+      findings: scan.result.findings,
+      totalMatches: scan.result.totalMatches,
+      rawScore: scan.result.rawScore,
+      score: scan.result.score,
+      severity: scan.result.severity,
+      hadPlaceholder: scan.hadPlaceholder,
+    });
+    totalMatches += scan.result.totalMatches;
+    aggregateRaw += scan.result.rawScore;
+    severity = rankSeverity(severity, scan.result.severity);
+  }
+
+  const aggregate = bucketScore(aggregateRaw);
+  return {
+    sessionId,
+    filePath,
+    recordsScanned,
+    matchedRecords: matched,
+    totalMatches,
+    rawScore: aggregate.rawScore,
+    score: aggregate.score,
+    severity:
+      SEVERITY_RANK[aggregate.severity] > SEVERITY_RANK[severity]
+        ? aggregate.severity
+        : severity,
+    errors,
+  };
+}
+
+export function scanAllAuditSessionsForLeaks(
+  ruleSet: ConfidentialRuleSet,
+  dataDir: string = DATA_DIR,
+): LeakScanReport[] {
+  return listAuditedSessions(dataDir).map(({ sessionId }) =>
+    scanAuditSessionForLeaks(sessionId, ruleSet, dataDir),
+  );
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -537,7 +537,7 @@ Commands:
   search <query> [n]                 Search structured audit events
   approvals [n] [--denied]           Show approval decisions
   verify <sessionId>                 Verify wire hash chain integrity
-  scan-leaks [sessionId] [--json]    Scan audit logs against ~/.hybridclaw/.confidential.yml for confidential-info leaks
+  scan-leaks [sessionId] [--json]    Scan audit logs for confidential-info leaks (rules from ./.confidential.yml or ~/.hybridclaw/.confidential.yml)
   instructions [--sync] [--approve]  Verify or restore runtime instruction files`);
 }
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -537,6 +537,7 @@ Commands:
   search <query> [n]                 Search structured audit events
   approvals [n] [--denied]           Show approval decisions
   verify <sessionId>                 Verify wire hash chain integrity
+  scan-leaks [sessionId] [--json]    Scan audit logs against ~/.hybridclaw/.confidential.yml for confidential-info leaks
   instructions [--sync] [--approve]  Verify or restore runtime instruction files`);
 }
 

--- a/src/security/confidential-redact.ts
+++ b/src/security/confidential-redact.ts
@@ -1,0 +1,244 @@
+import type {
+  ConfidentialRule,
+  ConfidentialRuleSet,
+  ConfidentialSensitivity,
+} from './confidential-rules.js';
+
+const PLACEHOLDER_PREFIX = '«CONF:';
+const PLACEHOLDER_SUFFIX = '»';
+const PLACEHOLDER_RE = /«CONF:([A-Z0-9_-]+)»/g;
+
+const SENSITIVITY_WEIGHTS: Record<ConfidentialSensitivity, number> = {
+  low: 3,
+  medium: 10,
+  high: 30,
+  critical: 100,
+};
+
+const SCORE_BUCKETS: ReadonlyArray<{
+  min: number;
+  level: ConfidentialSensitivity;
+}> = [
+  { min: 100, level: 'critical' },
+  { min: 30, level: 'high' },
+  { min: 10, level: 'medium' },
+  { min: 0, level: 'low' },
+];
+
+const MAX_SCORE = 1000;
+
+export interface ConfidentialPlaceholderMap {
+  /** placeholder token → original text (case as it appeared in source) */
+  byPlaceholder: Map<string, string>;
+  /** rule id → placeholder token */
+  byRuleId: Map<string, string>;
+}
+
+export interface DehydrateResult {
+  text: string;
+  mappings: ConfidentialPlaceholderMap;
+  hits: number;
+}
+
+export interface ConfidentialFinding {
+  ruleId: string;
+  kind: ConfidentialRule['kind'];
+  label: string;
+  sensitivity: ConfidentialSensitivity;
+  matches: number;
+  /** A short text excerpt around the first match, redacted. */
+  excerpt: string;
+}
+
+export interface ConfidentialScanResult {
+  findings: ConfidentialFinding[];
+  totalMatches: number;
+  /** raw weighted score (sum of sensitivity weights × matches), capped at {@link MAX_SCORE}. */
+  rawScore: number;
+  /** 0–100 normalized score for dashboards. */
+  score: number;
+  severity: ConfidentialSensitivity;
+}
+
+export function createPlaceholderMap(): ConfidentialPlaceholderMap {
+  return { byPlaceholder: new Map(), byRuleId: new Map() };
+}
+
+function escapeForRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function literalRegex(rule: ConfidentialRule): RegExp | null {
+  const variants = [rule.literal, ...(rule.literalAliases || [])].filter(
+    (entry): entry is string => Boolean(entry),
+  );
+  if (variants.length === 0) return null;
+  variants.sort((a, b) => b.length - a.length);
+  const pattern = variants.map(escapeForRegex).join('|');
+  const flags = rule.caseInsensitive ? 'giu' : 'gu';
+  return new RegExp(
+    `(?<![\\p{L}\\p{N}_])(${pattern})(?![\\p{L}\\p{N}_])`,
+    flags,
+  );
+}
+
+function ruleRegex(rule: ConfidentialRule): RegExp | null {
+  if (rule.regex) {
+    return new RegExp(rule.regex.source, rule.caseInsensitive ? 'gi' : 'g');
+  }
+  return literalRegex(rule);
+}
+
+function placeholderForRule(
+  rule: ConfidentialRule,
+  mappings: ConfidentialPlaceholderMap,
+): string {
+  const existing = mappings.byRuleId.get(rule.id);
+  if (existing) return existing;
+  const token = `${PLACEHOLDER_PREFIX}${rule.id.toUpperCase()}${PLACEHOLDER_SUFFIX}`;
+  mappings.byRuleId.set(rule.id, token);
+  return token;
+}
+
+export function dehydrateConfidential(
+  text: string,
+  ruleSet: ConfidentialRuleSet,
+  initialMappings?: ConfidentialPlaceholderMap,
+): DehydrateResult {
+  const mappings = initialMappings || createPlaceholderMap();
+  if (!text || ruleSet.rules.length === 0) {
+    return { text: text || '', mappings, hits: 0 };
+  }
+
+  let next = text;
+  let hits = 0;
+
+  for (const rule of ruleSet.rules) {
+    const regex = ruleRegex(rule);
+    if (!regex) continue;
+    const placeholder = placeholderForRule(rule, mappings);
+
+    next = next.replace(regex, (match) => {
+      hits += 1;
+      if (!mappings.byPlaceholder.has(placeholder)) {
+        mappings.byPlaceholder.set(placeholder, match);
+      }
+      return placeholder;
+    });
+  }
+
+  return { text: next, mappings, hits };
+}
+
+export function rehydrateConfidential(
+  text: string,
+  mappings: ConfidentialPlaceholderMap,
+): string {
+  if (!text || mappings.byPlaceholder.size === 0) return text;
+  return text.replace(PLACEHOLDER_RE, (match) => {
+    const original = mappings.byPlaceholder.get(match);
+    return original ?? match;
+  });
+}
+
+function buildExcerpt(
+  source: string,
+  matchIndex: number,
+  matchLength: number,
+  width = 60,
+): string {
+  if (matchIndex < 0) return '';
+  const start = Math.max(0, matchIndex - width);
+  const end = Math.min(source.length, matchIndex + matchLength + width);
+  const before = source.slice(start, matchIndex);
+  const after = source.slice(matchIndex + matchLength, end);
+  const prefix = start > 0 ? '...' : '';
+  const suffix = end < source.length ? '...' : '';
+  return `${prefix}${before}***${after}${suffix}`.replace(/\s+/g, ' ').trim();
+}
+
+export function scanForLeaks(
+  text: string,
+  ruleSet: ConfidentialRuleSet,
+): ConfidentialScanResult {
+  const findings: ConfidentialFinding[] = [];
+  if (!text || ruleSet.rules.length === 0) {
+    return {
+      findings,
+      totalMatches: 0,
+      rawScore: 0,
+      score: 0,
+      severity: 'low',
+    };
+  }
+
+  let totalMatches = 0;
+  let rawScore = 0;
+
+  for (const rule of ruleSet.rules) {
+    const regex = ruleRegex(rule);
+    if (!regex) continue;
+    let matches = 0;
+    let firstIndex = -1;
+    let firstLength = 0;
+    let result: RegExpExecArray | null = regex.exec(text);
+    while (result) {
+      matches += 1;
+      if (firstIndex === -1) {
+        firstIndex = result.index;
+        firstLength = result[0].length;
+      }
+      if (regex.lastIndex === result.index) regex.lastIndex += 1;
+      result = regex.exec(text);
+    }
+    if (matches === 0) continue;
+    totalMatches += matches;
+    rawScore += SENSITIVITY_WEIGHTS[rule.sensitivity] * matches;
+    findings.push({
+      ruleId: rule.id,
+      kind: rule.kind,
+      label: rule.label,
+      sensitivity: rule.sensitivity,
+      matches,
+      excerpt: buildExcerpt(text, firstIndex, firstLength),
+    });
+  }
+
+  const cappedRaw = Math.min(rawScore, MAX_SCORE);
+  const score = Math.round((cappedRaw / MAX_SCORE) * 100);
+  const severity =
+    SCORE_BUCKETS.find((bucket) => cappedRaw >= bucket.min)?.level || 'low';
+
+  findings.sort((a, b) => {
+    const sevDiff =
+      SENSITIVITY_WEIGHTS[b.sensitivity] - SENSITIVITY_WEIGHTS[a.sensitivity];
+    if (sevDiff !== 0) return sevDiff;
+    if (b.matches !== a.matches) return b.matches - a.matches;
+    return a.label.localeCompare(b.label);
+  });
+
+  return {
+    findings,
+    totalMatches,
+    rawScore: cappedRaw,
+    score,
+    severity,
+  };
+}
+
+export function mergePlaceholderMaps(
+  base: ConfidentialPlaceholderMap,
+  next: ConfidentialPlaceholderMap,
+): ConfidentialPlaceholderMap {
+  for (const [token, original] of next.byPlaceholder) {
+    if (!base.byPlaceholder.has(token)) {
+      base.byPlaceholder.set(token, original);
+    }
+  }
+  for (const [ruleId, token] of next.byRuleId) {
+    if (!base.byRuleId.has(ruleId)) {
+      base.byRuleId.set(ruleId, token);
+    }
+  }
+  return base;
+}

--- a/src/security/confidential-rules.ts
+++ b/src/security/confidential-rules.ts
@@ -183,6 +183,11 @@ export function parseConfidentialYaml(
   return { rules: parseRuleSet(raw), sourcePath };
 }
 
+/**
+ * Search order, first hit wins:
+ *   1. ./.confidential.yml (project-local, e.g. per-workspace overrides)
+ *   2. ~/.hybridclaw/.confidential.yml (user-global default)
+ */
 export function defaultConfidentialConfigPaths(
   cwd: string = process.cwd(),
 ): string[] {

--- a/src/security/confidential-rules.ts
+++ b/src/security/confidential-rules.ts
@@ -1,0 +1,218 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { parse as parseYaml } from 'yaml';
+
+import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+
+export const CONFIDENTIAL_CONFIG_FILE = '.confidential.yml';
+
+export type ConfidentialSensitivity = 'low' | 'medium' | 'high' | 'critical';
+
+export type ConfidentialKind =
+  | 'client'
+  | 'project'
+  | 'person'
+  | 'keyword'
+  | 'pattern';
+
+export interface ConfidentialRule {
+  id: string;
+  kind: ConfidentialKind;
+  label: string;
+  sensitivity: ConfidentialSensitivity;
+  literal?: string;
+  literalAliases?: string[];
+  regex?: RegExp;
+  regexSource?: string;
+  caseInsensitive: boolean;
+}
+
+export interface ConfidentialRuleSet {
+  rules: ConfidentialRule[];
+  sourcePath: string | null;
+}
+
+interface RawEntry {
+  name?: unknown;
+  label?: unknown;
+  aliases?: unknown;
+  sensitivity?: unknown;
+  case_insensitive?: unknown;
+  caseInsensitive?: unknown;
+  term?: unknown;
+  regex?: unknown;
+}
+
+interface RawConfig {
+  version?: unknown;
+  clients?: unknown;
+  projects?: unknown;
+  people?: unknown;
+  keywords?: unknown;
+  patterns?: unknown;
+}
+
+const DEFAULT_SENSITIVITY: ConfidentialSensitivity = 'high';
+const VALID_SENSITIVITIES: ReadonlySet<string> = new Set([
+  'low',
+  'medium',
+  'high',
+  'critical',
+]);
+
+function normalizeSensitivity(raw: unknown): ConfidentialSensitivity {
+  if (typeof raw !== 'string') return DEFAULT_SENSITIVITY;
+  const value = raw.trim().toLowerCase();
+  return VALID_SENSITIVITIES.has(value)
+    ? (value as ConfidentialSensitivity)
+    : DEFAULT_SENSITIVITY;
+}
+
+function asEntries(raw: unknown): RawEntry[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (entry): entry is RawEntry =>
+      entry != null && typeof entry === 'object' && !Array.isArray(entry),
+  );
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function asAliasList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const entry of value) {
+    const normalized = asNonEmptyString(entry);
+    if (!normalized) continue;
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(normalized);
+  }
+  return result;
+}
+
+function buildLiteralRule(
+  kind: ConfidentialKind,
+  entry: RawEntry,
+  index: number,
+): ConfidentialRule | null {
+  const primary =
+    asNonEmptyString(entry.name) ||
+    asNonEmptyString(entry.label) ||
+    asNonEmptyString(entry.term);
+  if (!primary) return null;
+  const aliases = asAliasList(entry.aliases);
+  return {
+    id: `${kind}_${String(index + 1).padStart(3, '0')}`,
+    kind,
+    label: primary,
+    sensitivity: normalizeSensitivity(entry.sensitivity),
+    literal: primary,
+    literalAliases: aliases,
+    caseInsensitive: true,
+  };
+}
+
+function buildPatternRule(
+  entry: RawEntry,
+  index: number,
+): ConfidentialRule | null {
+  const label =
+    asNonEmptyString(entry.name) || asNonEmptyString(entry.label) || null;
+  const regexSource = asNonEmptyString(entry.regex);
+  if (!label || !regexSource) return null;
+  const caseInsensitive =
+    entry.case_insensitive === true || entry.caseInsensitive === true;
+  let regex: RegExp;
+  try {
+    regex = new RegExp(regexSource, caseInsensitive ? 'gi' : 'g');
+  } catch {
+    return null;
+  }
+  return {
+    id: `pattern_${String(index + 1).padStart(3, '0')}`,
+    kind: 'pattern',
+    label,
+    sensitivity: normalizeSensitivity(entry.sensitivity),
+    regex,
+    regexSource,
+    caseInsensitive,
+  };
+}
+
+function parseRuleSet(raw: RawConfig): ConfidentialRule[] {
+  const rules: ConfidentialRule[] = [];
+
+  const literalGroups: Array<[ConfidentialKind, unknown]> = [
+    ['client', raw.clients],
+    ['project', raw.projects],
+    ['person', raw.people],
+    ['keyword', raw.keywords],
+  ];
+
+  for (const [kind, entries] of literalGroups) {
+    asEntries(entries).forEach((entry, index) => {
+      const rule = buildLiteralRule(kind, entry, index);
+      if (rule) rules.push(rule);
+    });
+  }
+
+  asEntries(raw.patterns).forEach((entry, index) => {
+    const rule = buildPatternRule(entry, index);
+    if (rule) rules.push(rule);
+  });
+
+  return rules;
+}
+
+export function parseConfidentialYaml(
+  source: string,
+  sourcePath: string | null = null,
+): ConfidentialRuleSet {
+  const data = parseYaml(source) as unknown;
+  const raw =
+    data && typeof data === 'object' && !Array.isArray(data)
+      ? (data as RawConfig)
+      : {};
+  return { rules: parseRuleSet(raw), sourcePath };
+}
+
+export function defaultConfidentialConfigPaths(
+  cwd: string = process.cwd(),
+): string[] {
+  return [
+    path.join(cwd, CONFIDENTIAL_CONFIG_FILE),
+    path.join(DEFAULT_RUNTIME_HOME_DIR, CONFIDENTIAL_CONFIG_FILE),
+  ];
+}
+
+export function loadConfidentialRules(
+  searchPaths?: string[],
+): ConfidentialRuleSet {
+  const candidates = searchPaths?.length
+    ? searchPaths
+    : defaultConfidentialConfigPaths();
+  for (const candidate of candidates) {
+    if (!candidate || !fs.existsSync(candidate)) continue;
+    try {
+      const raw = fs.readFileSync(candidate, 'utf-8');
+      return parseConfidentialYaml(raw, candidate);
+    } catch (error) {
+      console.warn(
+        `[confidential] failed to load ${candidate}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return { rules: [], sourcePath: candidate };
+    }
+  }
+  return { rules: [], sourcePath: null };
+}
+
+export function ruleHasContent(ruleSet: ConfidentialRuleSet): boolean {
+  return ruleSet.rules.length > 0;
+}

--- a/src/security/confidential-runtime.ts
+++ b/src/security/confidential-runtime.ts
@@ -1,0 +1,133 @@
+import {
+  type ConfidentialPlaceholderMap,
+  createPlaceholderMap,
+  dehydrateConfidential,
+  rehydrateConfidential,
+} from './confidential-redact.js';
+import {
+  type ConfidentialRuleSet,
+  loadConfidentialRules,
+} from './confidential-rules.js';
+
+let cachedRuleSet: ConfidentialRuleSet | null = null;
+
+export function getConfidentialRuleSet(): ConfidentialRuleSet {
+  cachedRuleSet ??= loadConfidentialRules();
+  return cachedRuleSet;
+}
+
+export function resetConfidentialRuleSetCache(): void {
+  cachedRuleSet = null;
+}
+
+/**
+ * Test seam: inject a rule set without touching the filesystem.
+ * Pass `null` to fall back to the regular loader.
+ */
+export function setConfidentialRuleSetForTesting(
+  ruleSet: ConfidentialRuleSet | null,
+): void {
+  cachedRuleSet = ruleSet;
+}
+
+export function isConfidentialRedactionEnabled(): boolean {
+  if (process.env.HYBRIDCLAW_CONFIDENTIAL_DISABLE === '1') return false;
+  return getConfidentialRuleSet().rules.length > 0;
+}
+
+export interface DehydrateMessageContent {
+  role?: string;
+  content: unknown;
+}
+
+function dehydrateText(
+  text: string,
+  mappings: ConfidentialPlaceholderMap,
+  ruleSet: ConfidentialRuleSet,
+): string {
+  if (!text) return text;
+  return dehydrateConfidential(text, ruleSet, mappings).text;
+}
+
+function dehydrateContent<T extends DehydrateMessageContent>(
+  message: T,
+  mappings: ConfidentialPlaceholderMap,
+  ruleSet: ConfidentialRuleSet,
+): T {
+  if (typeof message.content === 'string') {
+    const dehydrated = dehydrateText(message.content, mappings, ruleSet);
+    if (dehydrated === message.content) return message;
+    return { ...message, content: dehydrated };
+  }
+  if (Array.isArray(message.content)) {
+    let mutated = false;
+    const next = message.content.map((part) => {
+      if (
+        part &&
+        typeof part === 'object' &&
+        'text' in part &&
+        typeof (part as { text?: unknown }).text === 'string'
+      ) {
+        const original = (part as { text: string }).text;
+        const dehydrated = dehydrateText(original, mappings, ruleSet);
+        if (dehydrated !== original) {
+          mutated = true;
+          return { ...part, text: dehydrated };
+        }
+      }
+      return part;
+    });
+    if (!mutated) return message;
+    return { ...message, content: next as unknown as T['content'] };
+  }
+  return message;
+}
+
+export interface ConfidentialRuntimeContext {
+  enabled: boolean;
+  ruleSet: ConfidentialRuleSet;
+  mappings: ConfidentialPlaceholderMap;
+  dehydrate<T extends DehydrateMessageContent>(messages: T[]): T[];
+  rehydrate(text: string | null | undefined): string;
+  wrapDelta(
+    callback: ((delta: string) => void) | undefined,
+  ): ((delta: string) => void) | undefined;
+}
+
+const NOOP_CONTEXT: ConfidentialRuntimeContext = {
+  enabled: false,
+  ruleSet: { rules: [], sourcePath: null },
+  mappings: createPlaceholderMap(),
+  dehydrate: (messages) => messages,
+  rehydrate: (text) => text || '',
+  wrapDelta: (callback) => callback,
+};
+
+export function createConfidentialRuntimeContext(): ConfidentialRuntimeContext {
+  if (!isConfidentialRedactionEnabled()) {
+    return NOOP_CONTEXT;
+  }
+  const ruleSet = getConfidentialRuleSet();
+  const mappings = createPlaceholderMap();
+
+  return {
+    enabled: true,
+    ruleSet,
+    mappings,
+    dehydrate(messages) {
+      return messages.map((message) =>
+        dehydrateContent(message, mappings, ruleSet),
+      );
+    },
+    rehydrate(text) {
+      if (!text) return text || '';
+      return rehydrateConfidential(text, mappings);
+    },
+    wrapDelta(callback) {
+      if (!callback) return callback;
+      return (delta: string) => {
+        callback(rehydrateConfidential(delta, mappings));
+      };
+    },
+  };
+}

--- a/src/security/confidential-runtime.ts
+++ b/src/security/confidential-runtime.ts
@@ -92,6 +92,16 @@ export interface ConfidentialRuntimeContext {
   wrapDelta(
     callback: ((delta: string) => void) | undefined,
   ): ((delta: string) => void) | undefined;
+  /** Rehydrate every listed string field on an object (shallow). */
+  rehydrateFields<T extends object>(
+    value: T | null | undefined,
+    fields: ReadonlyArray<keyof T>,
+  ): T | null | undefined;
+  /** Map a callback that receives an object, rehydrating string fields by name. */
+  wrapEvent<T extends object>(
+    callback: ((event: T) => void) | undefined,
+    fields: ReadonlyArray<keyof T>,
+  ): ((event: T) => void) | undefined;
 }
 
 const NOOP_CONTEXT: ConfidentialRuntimeContext = {
@@ -101,7 +111,23 @@ const NOOP_CONTEXT: ConfidentialRuntimeContext = {
   dehydrate: (messages) => messages,
   rehydrate: (text) => text || '',
   wrapDelta: (callback) => callback,
+  rehydrateFields: (value) => value,
+  wrapEvent: (callback) => callback,
 };
+
+function rehydrateStringField<T extends object>(
+  source: T,
+  key: keyof T,
+  mappings: ConfidentialPlaceholderMap,
+): { value: T[keyof T]; mutated: boolean } {
+  const raw = source[key];
+  if (typeof raw !== 'string') return { value: raw, mutated: false };
+  const next = rehydrateConfidential(raw, mappings);
+  return {
+    value: next as T[keyof T],
+    mutated: next !== raw,
+  };
+}
 
 export function createConfidentialRuntimeContext(): ConfidentialRuntimeContext {
   if (!isConfidentialRedactionEnabled()) {
@@ -109,6 +135,23 @@ export function createConfidentialRuntimeContext(): ConfidentialRuntimeContext {
   }
   const ruleSet = getConfidentialRuleSet();
   const mappings = createPlaceholderMap();
+
+  function rehydrateFields<T extends object>(
+    value: T | null | undefined,
+    fields: ReadonlyArray<keyof T>,
+  ): T | null | undefined {
+    if (!value) return value;
+    let mutated = false;
+    const next = { ...value } as T;
+    for (const field of fields) {
+      const result = rehydrateStringField(value, field, mappings);
+      if (result.mutated) {
+        next[field] = result.value;
+        mutated = true;
+      }
+    }
+    return mutated ? next : value;
+  }
 
   return {
     enabled: true,
@@ -127,6 +170,14 @@ export function createConfidentialRuntimeContext(): ConfidentialRuntimeContext {
       if (!callback) return callback;
       return (delta: string) => {
         callback(rehydrateConfidential(delta, mappings));
+      };
+    },
+    rehydrateFields,
+    wrapEvent(callback, fields) {
+      if (!callback) return callback;
+      return (event) => {
+        const next = rehydrateFields(event, fields);
+        callback((next ?? event) as Parameters<typeof callback>[0]);
       };
     },
   };

--- a/tests/confidential-leak-scanner.test.ts
+++ b/tests/confidential-leak-scanner.test.ts
@@ -142,7 +142,9 @@ describe('audit log leak scanner', () => {
   test('listAuditedSessions discovers all sessions', () => {
     writeWireLines('alpha', []);
     writeWireLines('beta', []);
-    const sessions = listAuditedSessions(tempDir).map((entry) => entry.sessionId);
+    const sessions = listAuditedSessions(tempDir).map(
+      (entry) => entry.sessionId,
+    );
     expect(sessions).toEqual(['alpha', 'beta']);
   });
 

--- a/tests/confidential-leak-scanner.test.ts
+++ b/tests/confidential-leak-scanner.test.ts
@@ -1,0 +1,180 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import {
+  listAuditedSessions,
+  scanAllAuditSessionsForLeaks,
+  scanAuditSessionForLeaks,
+} from '../src/audit/leak-scanner.js';
+import { parseConfidentialYaml } from '../src/security/confidential-rules.js';
+
+let tempDir: string;
+
+const RULES = parseConfidentialYaml(`
+clients:
+  - name: Serviceplan
+    sensitivity: high
+projects:
+  - name: Project Falcon
+    sensitivity: critical
+`);
+
+function writeWireLines(sessionId: string, records: object[]): string {
+  const sessionDir = path.join(tempDir, 'audit', sessionId);
+  fs.mkdirSync(sessionDir, { recursive: true });
+  const filePath = path.join(sessionDir, 'wire.jsonl');
+  fs.writeFileSync(
+    filePath,
+    `${records.map((record) => JSON.stringify(record)).join('\n')}\n`,
+    'utf-8',
+  );
+  return filePath;
+}
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hc-leak-scan-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('audit log leak scanner', () => {
+  test('flags records whose event payload contains confidential terms', () => {
+    writeWireLines('session_a', [
+      {
+        type: 'metadata',
+        protocolVersion: '2.0',
+        sessionId: 'session_a',
+        createdAt: '2025-01-01T00:00:00.000Z',
+      },
+      {
+        version: '2.0',
+        seq: 1,
+        timestamp: '2025-01-01T00:00:00.001Z',
+        runId: 'run_1',
+        sessionId: 'session_a',
+        event: {
+          type: 'user.message',
+          content: 'Serviceplan brief about Project Falcon',
+        },
+      },
+      {
+        version: '2.0',
+        seq: 2,
+        timestamp: '2025-01-01T00:00:00.002Z',
+        runId: 'run_1',
+        sessionId: 'session_a',
+        event: {
+          type: 'tool.result',
+          toolName: 'noop',
+          isError: false,
+          summary: 'no client info here',
+        },
+      },
+    ]);
+
+    const report = scanAuditSessionForLeaks('session_a', RULES, tempDir);
+    expect(report.recordsScanned).toBe(2);
+    expect(report.matchedRecords).toHaveLength(1);
+    expect(report.matchedRecords[0].eventType).toBe('user.message');
+    expect(report.totalMatches).toBeGreaterThanOrEqual(2);
+    expect(report.score).toBeGreaterThan(0);
+    expect(['high', 'critical']).toContain(report.severity);
+  });
+
+  test('returns zero matches when audit log is clean', () => {
+    writeWireLines('clean', [
+      {
+        type: 'metadata',
+        protocolVersion: '2.0',
+        sessionId: 'clean',
+        createdAt: '2025-01-01T00:00:00.000Z',
+      },
+      {
+        version: '2.0',
+        seq: 1,
+        timestamp: '2025-01-01T00:00:00.001Z',
+        runId: 'run_1',
+        sessionId: 'clean',
+        event: { type: 'user.message', content: 'Just a hello.' },
+      },
+    ]);
+    const report = scanAuditSessionForLeaks('clean', RULES, tempDir);
+    expect(report.totalMatches).toBe(0);
+    expect(report.matchedRecords).toEqual([]);
+    expect(report.score).toBe(0);
+    expect(report.severity).toBe('low');
+  });
+
+  test('hadPlaceholder flag is true when text already dehydrated', () => {
+    writeWireLines('placeholders', [
+      {
+        type: 'metadata',
+        protocolVersion: '2.0',
+        sessionId: 'placeholders',
+        createdAt: '2025-01-01T00:00:00.000Z',
+      },
+      {
+        version: '2.0',
+        seq: 1,
+        timestamp: '2025-01-01T00:00:00.001Z',
+        runId: 'run_1',
+        sessionId: 'placeholders',
+        event: {
+          type: 'user.message',
+          content: 'Brief from «CONF:CLIENT_001» mentioning Project Falcon.',
+        },
+      },
+    ]);
+    const report = scanAuditSessionForLeaks('placeholders', RULES, tempDir);
+    expect(report.matchedRecords[0].hadPlaceholder).toBe(true);
+  });
+
+  test('returns errors when wire file is missing', () => {
+    const report = scanAuditSessionForLeaks('does_not_exist', RULES, tempDir);
+    expect(report.errors[0]).toMatch(/wire log not found/);
+    expect(report.recordsScanned).toBe(0);
+  });
+
+  test('listAuditedSessions discovers all sessions', () => {
+    writeWireLines('alpha', []);
+    writeWireLines('beta', []);
+    const sessions = listAuditedSessions(tempDir).map((entry) => entry.sessionId);
+    expect(sessions).toEqual(['alpha', 'beta']);
+  });
+
+  test('scanAllAuditSessionsForLeaks scans every session', () => {
+    writeWireLines('alpha', [
+      {
+        version: '2.0',
+        seq: 1,
+        timestamp: '2025-01-01T00:00:00.001Z',
+        runId: 'run_1',
+        sessionId: 'alpha',
+        event: { type: 'user.message', content: 'Project Falcon update' },
+      },
+    ]);
+    writeWireLines('beta', [
+      {
+        version: '2.0',
+        seq: 1,
+        timestamp: '2025-01-01T00:00:00.001Z',
+        runId: 'run_1',
+        sessionId: 'beta',
+        event: { type: 'user.message', content: 'Hello world' },
+      },
+    ]);
+    const reports = scanAllAuditSessionsForLeaks(RULES, tempDir);
+    expect(reports.map((report) => report.sessionId)).toEqual([
+      'alpha',
+      'beta',
+    ]);
+    const alpha = reports.find((report) => report.sessionId === 'alpha');
+    expect(alpha?.totalMatches).toBe(1);
+    const beta = reports.find((report) => report.sessionId === 'beta');
+    expect(beta?.totalMatches).toBe(0);
+  });
+});

--- a/tests/confidential-redact.test.ts
+++ b/tests/confidential-redact.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  createPlaceholderMap,
+  dehydrateConfidential,
+  rehydrateConfidential,
+  scanForLeaks,
+} from '../src/security/confidential-redact.js';
+import { parseConfidentialYaml } from '../src/security/confidential-rules.js';
+
+const RULES_YAML = `
+version: 1
+clients:
+  - name: Serviceplan
+    aliases: [SP, "Serviceplan AG"]
+    sensitivity: high
+  - name: Acme
+    sensitivity: medium
+projects:
+  - name: Project Falcon
+    sensitivity: critical
+people:
+  - name: Jane Doe
+    sensitivity: medium
+keywords:
+  - term: "Q4 2026 budget"
+    sensitivity: critical
+patterns:
+  - name: internal-doc
+    regex: "INT-\\\\d{6}"
+    sensitivity: high
+`;
+
+const ruleSet = parseConfidentialYaml(RULES_YAML, 'memory:test');
+
+describe('confidential rules loader', () => {
+  test('parses literal entries and patterns', () => {
+    const labels = ruleSet.rules.map((rule) => rule.label).sort();
+    expect(labels).toContain('Serviceplan');
+    expect(labels).toContain('Acme');
+    expect(labels).toContain('Project Falcon');
+    expect(labels).toContain('Jane Doe');
+    expect(labels).toContain('Q4 2026 budget');
+    expect(labels).toContain('internal-doc');
+  });
+
+  test('aliases are tracked alongside primary literal', () => {
+    const sp = ruleSet.rules.find((rule) => rule.label === 'Serviceplan');
+    expect(sp?.literalAliases).toEqual(['SP', 'Serviceplan AG']);
+  });
+
+  test('returns empty rule set when YAML is empty', () => {
+    expect(parseConfidentialYaml('').rules).toEqual([]);
+  });
+});
+
+describe('dehydrate / rehydrate', () => {
+  test('replaces literal hits with stable placeholders', () => {
+    const text =
+      'Serviceplan briefed us on Project Falcon. SP wants the Q4 2026 budget by Friday.';
+    const { text: dehydrated, mappings, hits } = dehydrateConfidential(
+      text,
+      ruleSet,
+    );
+    expect(hits).toBeGreaterThanOrEqual(4);
+    expect(dehydrated).not.toMatch(/Serviceplan/);
+    expect(dehydrated).not.toMatch(/Project Falcon/);
+    expect(dehydrated).not.toMatch(/Q4 2026 budget/);
+
+    const rehydrated = rehydrateConfidential(dehydrated, mappings);
+    // Aliases collapse to the primary spelling on rehydrate (last-write-wins
+    // through the placeholder); the canonical name remains intact.
+    expect(rehydrated).toContain('Serviceplan');
+    expect(rehydrated).toContain('Project Falcon');
+    expect(rehydrated).toContain('Q4 2026 budget');
+  });
+
+  test('placeholders are stable across calls when reusing mappings', () => {
+    const mappings = createPlaceholderMap();
+    const first = dehydrateConfidential('Serviceplan again', ruleSet, mappings);
+    const second = dehydrateConfidential('Serviceplan again', ruleSet, mappings);
+    expect(first.text).toBe(second.text);
+  });
+
+  test('regex patterns are matched and rehydrated', () => {
+    const text = 'See doc INT-123456 attached.';
+    const { text: dehydrated, mappings, hits } = dehydrateConfidential(
+      text,
+      ruleSet,
+    );
+    expect(hits).toBe(1);
+    expect(dehydrated).not.toContain('INT-123456');
+    expect(rehydrateConfidential(dehydrated, mappings)).toContain('INT-123456');
+  });
+
+  test('case-insensitive literal matching', () => {
+    const { hits } = dehydrateConfidential('SERVICEPLAN told ACME', ruleSet);
+    expect(hits).toBe(2);
+  });
+
+  test('no-op when rule set is empty', () => {
+    const empty = parseConfidentialYaml('');
+    const { text, hits } = dehydrateConfidential('Hello Serviceplan', empty);
+    expect(text).toBe('Hello Serviceplan');
+    expect(hits).toBe(0);
+  });
+
+  test('rehydrate with unknown placeholder is left intact', () => {
+    const out = rehydrateConfidential('See «CONF:UNKNOWN_001» here.', createPlaceholderMap());
+    expect(out).toBe('See «CONF:UNKNOWN_001» here.');
+  });
+});
+
+describe('scanForLeaks', () => {
+  test('flags multiple sensitivities and produces a non-zero score', () => {
+    const text =
+      'Serviceplan brief: Project Falcon launches Q4 2026 budget review with INT-654321.';
+    const result = scanForLeaks(text, ruleSet);
+    expect(result.totalMatches).toBeGreaterThanOrEqual(4);
+    expect(result.score).toBeGreaterThan(0);
+    expect(['high', 'critical']).toContain(result.severity);
+    const labels = result.findings.map((finding) => finding.label);
+    expect(labels).toContain('Project Falcon');
+    expect(labels).toContain('Q4 2026 budget');
+    expect(labels).toContain('Serviceplan');
+    // Findings sorted critical/high first.
+    expect(result.findings[0]?.sensitivity).toBe('critical');
+  });
+
+  test('returns zero score for clean text', () => {
+    const result = scanForLeaks('All quiet here.', ruleSet);
+    expect(result.totalMatches).toBe(0);
+    expect(result.score).toBe(0);
+    expect(result.severity).toBe('low');
+  });
+
+  test('caps raw score at 1000', () => {
+    const text = Array(50).fill('Project Falcon').join(' ');
+    const result = scanForLeaks(text, ruleSet);
+    expect(result.rawScore).toBeLessThanOrEqual(1000);
+    expect(result.score).toBe(100);
+    expect(result.severity).toBe('critical');
+  });
+
+  test('excerpt is short and includes redaction marker', () => {
+    const result = scanForLeaks('Notes: Serviceplan brief follows.', ruleSet);
+    const finding = result.findings.find(
+      (entry) => entry.label === 'Serviceplan',
+    );
+    expect(finding?.excerpt).toContain('***');
+    expect(finding?.excerpt.length).toBeLessThan(180);
+  });
+});

--- a/tests/confidential-redact.test.ts
+++ b/tests/confidential-redact.test.ts
@@ -69,8 +69,10 @@ describe('dehydrate / rehydrate', () => {
     expect(dehydrated).not.toMatch(/Q4 2026 budget/);
 
     const rehydrated = rehydrateConfidential(dehydrated, mappings);
-    // Aliases collapse to the primary spelling on rehydrate (last-write-wins
-    // through the placeholder); the canonical name remains intact.
+    // All variants of a rule (primary + aliases) share one placeholder, and
+    // the placeholder maps to the FIRST spelling that matched (first-write-
+    // wins). Here "Serviceplan" appears before "SP", so both rehydrate to
+    // "Serviceplan".
     expect(rehydrated).toContain('Serviceplan');
     expect(rehydrated).toContain('Project Falcon');
     expect(rehydrated).toContain('Q4 2026 budget');

--- a/tests/confidential-redact.test.ts
+++ b/tests/confidential-redact.test.ts
@@ -58,10 +58,11 @@ describe('dehydrate / rehydrate', () => {
   test('replaces literal hits with stable placeholders', () => {
     const text =
       'Serviceplan briefed us on Project Falcon. SP wants the Q4 2026 budget by Friday.';
-    const { text: dehydrated, mappings, hits } = dehydrateConfidential(
-      text,
-      ruleSet,
-    );
+    const {
+      text: dehydrated,
+      mappings,
+      hits,
+    } = dehydrateConfidential(text, ruleSet);
     expect(hits).toBeGreaterThanOrEqual(4);
     expect(dehydrated).not.toMatch(/Serviceplan/);
     expect(dehydrated).not.toMatch(/Project Falcon/);
@@ -78,16 +79,21 @@ describe('dehydrate / rehydrate', () => {
   test('placeholders are stable across calls when reusing mappings', () => {
     const mappings = createPlaceholderMap();
     const first = dehydrateConfidential('Serviceplan again', ruleSet, mappings);
-    const second = dehydrateConfidential('Serviceplan again', ruleSet, mappings);
+    const second = dehydrateConfidential(
+      'Serviceplan again',
+      ruleSet,
+      mappings,
+    );
     expect(first.text).toBe(second.text);
   });
 
   test('regex patterns are matched and rehydrated', () => {
     const text = 'See doc INT-123456 attached.';
-    const { text: dehydrated, mappings, hits } = dehydrateConfidential(
-      text,
-      ruleSet,
-    );
+    const {
+      text: dehydrated,
+      mappings,
+      hits,
+    } = dehydrateConfidential(text, ruleSet);
     expect(hits).toBe(1);
     expect(dehydrated).not.toContain('INT-123456');
     expect(rehydrateConfidential(dehydrated, mappings)).toContain('INT-123456');
@@ -106,7 +112,10 @@ describe('dehydrate / rehydrate', () => {
   });
 
   test('rehydrate with unknown placeholder is left intact', () => {
-    const out = rehydrateConfidential('See «CONF:UNKNOWN_001» here.', createPlaceholderMap());
+    const out = rehydrateConfidential(
+      'See «CONF:UNKNOWN_001» here.',
+      createPlaceholderMap(),
+    );
     expect(out).toBe('See «CONF:UNKNOWN_001» here.');
   });
 });

--- a/tests/confidential-runtime.test.ts
+++ b/tests/confidential-runtime.test.ts
@@ -62,4 +62,38 @@ describe('confidential runtime context', () => {
     wrapped?.('Replying about «CONF:CLIENT_001»');
     expect(seen[0]).toBe('Replying about Serviceplan');
   });
+
+  test('rehydrateFields restores listed string fields and leaves others alone', () => {
+    setConfidentialRuleSetForTesting(RULES);
+    const ctx = createConfidentialRuntimeContext();
+    ctx.dehydrate([{ role: 'user', content: 'About Serviceplan' }]);
+
+    const execution = {
+      name: 'noop',
+      arguments: 'See «CONF:CLIENT_001»',
+      result: 'Reply: «CONF:CLIENT_001»',
+      durationMs: 4,
+    };
+    const next = ctx.rehydrateFields(execution, [
+      'arguments',
+      'result',
+    ] as const);
+    expect(next?.arguments).toBe('See Serviceplan');
+    expect(next?.result).toBe('Reply: Serviceplan');
+    expect(next?.durationMs).toBe(4);
+  });
+
+  test('wrapEvent rehydrates listed string fields on each event', () => {
+    setConfidentialRuleSetForTesting(RULES);
+    const ctx = createConfidentialRuntimeContext();
+    ctx.dehydrate([{ role: 'user', content: 'About Serviceplan' }]);
+
+    const seen: { preview?: string }[] = [];
+    const wrapped = ctx.wrapEvent(
+      (event: { preview?: string }) => seen.push(event),
+      ['preview'] as const,
+    );
+    wrapped?.({ preview: 'tool starting on «CONF:CLIENT_001»' });
+    expect(seen[0]?.preview).toBe('tool starting on Serviceplan');
+  });
 });

--- a/tests/confidential-runtime.test.ts
+++ b/tests/confidential-runtime.test.ts
@@ -1,11 +1,10 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
-
+import { parseConfidentialYaml } from '../src/security/confidential-rules.js';
 import {
   createConfidentialRuntimeContext,
   resetConfidentialRuleSetCache,
   setConfidentialRuleSetForTesting,
 } from '../src/security/confidential-runtime.js';
-import { parseConfidentialYaml } from '../src/security/confidential-rules.js';
 
 const RULES = parseConfidentialYaml(
   `clients:\n  - name: Serviceplan\n    sensitivity: high\n`,

--- a/tests/confidential-runtime.test.ts
+++ b/tests/confidential-runtime.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  createConfidentialRuntimeContext,
+  resetConfidentialRuleSetCache,
+  setConfidentialRuleSetForTesting,
+} from '../src/security/confidential-runtime.js';
+import { parseConfidentialYaml } from '../src/security/confidential-rules.js';
+
+const RULES = parseConfidentialYaml(
+  `clients:\n  - name: Serviceplan\n    sensitivity: high\n`,
+);
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  resetConfidentialRuleSetCache();
+});
+
+describe('confidential runtime context', () => {
+  test('returns no-op context when no rules exist', () => {
+    setConfidentialRuleSetForTesting({ rules: [], sourcePath: null });
+    const ctx = createConfidentialRuntimeContext();
+    expect(ctx.enabled).toBe(false);
+    const messages = [{ role: 'user', content: 'hello Serviceplan' }];
+    expect(ctx.dehydrate(messages)).toEqual(messages);
+    expect(ctx.rehydrate('hello «CONF:CLIENT_001»')).toBe(
+      'hello «CONF:CLIENT_001»',
+    );
+  });
+
+  test('dehydrates and rehydrates round-trip when rules are present', () => {
+    setConfidentialRuleSetForTesting(RULES);
+
+    const ctx = createConfidentialRuntimeContext();
+    expect(ctx.enabled).toBe(true);
+
+    const messages = [
+      { role: 'system', content: 'You are an assistant.' },
+      { role: 'user', content: 'Briefing for Serviceplan today.' },
+    ];
+    const dehydrated = ctx.dehydrate(messages);
+    expect(dehydrated[1].content).not.toContain('Serviceplan');
+    expect(typeof dehydrated[1].content).toBe('string');
+    expect(ctx.rehydrate(dehydrated[1].content as string)).toContain(
+      'Serviceplan',
+    );
+  });
+
+  test('honours HYBRIDCLAW_CONFIDENTIAL_DISABLE override', () => {
+    setConfidentialRuleSetForTesting(RULES);
+    vi.stubEnv('HYBRIDCLAW_CONFIDENTIAL_DISABLE', '1');
+    const ctx = createConfidentialRuntimeContext();
+    expect(ctx.enabled).toBe(false);
+  });
+
+  test('wrapDelta rehydrates streamed text', () => {
+    setConfidentialRuleSetForTesting(RULES);
+    const ctx = createConfidentialRuntimeContext();
+    ctx.dehydrate([{ role: 'user', content: 'About Serviceplan' }]);
+
+    const seen: string[] = [];
+    const wrapped = ctx.wrapDelta((delta: string) => seen.push(delta));
+    wrapped?.('Replying about «CONF:CLIENT_001»');
+    expect(seen[0]).toBe('Replying about Serviceplan');
+  });
+});


### PR DESCRIPTION
## Summary

- **Problem:** HybridClaw had no way to keep NDA-class business data (client names, project codenames, internal IDs) out of LLM prompts, and no way to inspect existing audit logs for past leaks. Roadmap item #6.
- **Why it matters:** Backs Manifesto Principle V (*"under NDA from minute one"*). Without it, an agency operator using HybridClaw on a Serviceplan briefing has no technical guarantee that Serviceplan's client names won't leak to a third-party model provider.
- **What changed:** Adds an opt-in pre-LLM dehydration filter (placeholders + rehydration) wired into `runAgent`, plus a `hybridclaw audit scan-leaks` command that walks existing `wire.jsonl` audit logs and produces per-session findings with a 0-100 risk score.
- **What did not change:** Existing credential redaction (`src/security/redact.ts`), audit hash chain, approval policy, mount allowlists, or any provider/executor wiring. Feature is a no-op until `~/.hybridclaw/.confidential.yml` is created.

## Change Type

- [x] Feature
- [x] Security hardening
- [x] Tests
- [x] Docs

## Linked Context

- Implements roadmap item #6: *"NDA / secret-leak detector across all prompts"* (~/examples/trusted-coworker-roadmap.md)
- Pairs with roadmap item #4 (business-secret masking + demasking) — same placeholder format, same ruleset
- Inspired by picoclaw `pkg/config/security.go` + `.security.yml` (config-driven sensitive-data filter)

## Validation

```bash
npm run typecheck     # clean
npm run check         # biome clean
npx vitest run tests/confidential-redact.test.ts \
               tests/confidential-leak-scanner.test.ts \
               tests/confidential-runtime.test.ts
# 23/23 passing
```

- Verified manually:
  - Round-trip dehydrate → rehydrate preserves user-facing content (literal, alias, regex matches)
  - `scan-leaks` returns non-zero score for matched audit records, zero for clean ones
  - `hadPlaceholder` flag correctly distinguishes pre/post-dehydrate content in audit logs
  - `HYBRIDCLAW_CONFIDENTIAL_DISABLE=1` correctly forces the runtime no-op path
- Edge cases checked: empty rule set (no-op), unknown placeholder in rehydrate (left intact), score capping at 1000, case-insensitive literal matching, word-boundary protection (`Acme` won't match `AcmeWidget`)
- Skipped checks: full `npm run test:unit` has 10 unrelated pre-existing failures (browser bin env var, plugin-singleton timeout, eval-command flake, host-runner respawn) that reproduce identically on `main` without these changes — confirmed via `git stash && vitest run …`

## Docs And Config Impact

- [x] README, docs, or examples updated — new section *4.1) Confidential-Info Filter* in `SECURITY.md`, `audit scan-leaks` added to `printAuditUsage()`
- [x] Config or environment behavior changed — new optional file `~/.hybridclaw/.confidential.yml`, new env var `HYBRIDCLAW_CONFIDENTIAL_DISABLE`
- [ ] Templates or workspace bootstrap files changed
- [ ] No docs or config impact

`.confidential.example.yml` added at the repo root for users to copy. `.gitignore` excludes `.confidential.yml`. No `templates/` files touched.

## Risk Notes

- Security-sensitive paths touched? **Yes** — `src/security/` (new modules) and `src/agent/agent.ts` (wire-up). `src/audit/` extended with read-only scanner.
- Gateway, audit, approval, or container boundaries touched? **Audit** read-only (new scanner reads existing `wire.jsonl`); **agent** modified to wrap exec call.
- Failure mode: if the YAML loader fails, it logs a warning and returns an empty rule set — runtime falls back to the no-op context. If `.confidential.yml` is absent, the entire feature compiles to a single map+identity-callback chain (zero allocations on the hot path is not claimed; verified via the no-op fast path in `createConfidentialRuntimeContext`).
- Failure mode tested: empty/missing config, malformed YAML (covered by `parseConfidentialYaml('')` test), missing wire log file (returns errors array, not a throw).

## Evidence

- New test coverage: 23 tests across 3 files
  - `tests/confidential-redact.test.ts` — rule parsing, dehydrate/rehydrate, scoring, severity sort
  - `tests/confidential-leak-scanner.test.ts` — wire.jsonl walking, multi-session aggregation, missing-file errors, post-dehydration detection
  - `tests/confidential-runtime.test.ts` — opt-in/disable, message dehydration, streaming delta rehydration

### Architecture

```
~/.hybridclaw/.confidential.yml
        │
        ▼
confidential-rules.ts  ──►  confidential-redact.ts  ──►  confidential-runtime.ts
   (loader, types)        (dehydrate/rehydrate/scan)      (cached + opt-in ctx)
                                       │                          │
                                       ▼                          ▼
                          audit/leak-scanner.ts          agent/agent.ts (runAgent)
                                       │                          │
                                       ▼                          ▼
                       hybridclaw audit scan-leaks       Pre-LLM dehydration +
                                                          response rehydration
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)