### PR TITLE
feat: NDA / confidential-info filter + retroactive leak scanner

### DIFF
--- a/.confidential.example.yml
+++ b/.confidential.example.yml
@@ -1,8 +1,11 @@
 # Example .confidential.yml for the HybridClaw NDA / secret-leak filter.
 #
-# Place a copy at ~/.hybridclaw/.confidential.yml (chmod 600) to enable the
-# pre-LLM dehydration filter and to seed the `hybridclaw audit scan-leaks`
-# scanner. The file is git-ignored by default.
+# Place a copy at one of:
+#   - ./.confidential.yml              (project-local, checked first)
+#   - ~/.hybridclaw/.confidential.yml  (user-global fallback)
+# Lock it down with `chmod 600 <file>`. The file is git-ignored by default.
+# Activates the pre-LLM dehydration filter and seeds the
+# `hybridclaw audit scan-leaks` scanner; first file found wins.
 #
 # Sensitivity levels (used for risk scoring): low | medium | high | critical
 # Default = high.

--- a/.confidential.example.yml
+++ b/.confidential.example.yml
@@ -1,0 +1,39 @@
+# Example .confidential.yml for the HybridClaw NDA / secret-leak filter.
+#
+# Place a copy at ~/.hybridclaw/.confidential.yml (chmod 600) to enable the
+# pre-LLM dehydration filter and to seed the `hybridclaw audit scan-leaks`
+# scanner. The file is git-ignored by default.
+#
+# Sensitivity levels (used for risk scoring): low | medium | high | critical
+# Default = high.
+#
+# All literal matches are case-insensitive and respect word boundaries
+# (so "Acme" will not match "AcmeWidget"). Pattern entries take a
+# JavaScript-style regex string.
+
+version: 1
+
+clients:
+  - name: Serviceplan
+    aliases: ["SP", "Serviceplan AG"]
+    sensitivity: high
+  - name: Acme Corp
+    aliases: ["Acme"]
+    sensitivity: medium
+
+projects:
+  - name: Project Falcon
+    sensitivity: critical
+
+people:
+  - name: Jane Doe
+    sensitivity: medium
+
+keywords:
+  - term: "Q4 2026 budget"
+    sensitivity: critical
+
+patterns:
+  - name: internal-doc-id
+    regex: "INT-\\d{6}"
+    sensitivity: high

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ data/
 .env.*.local
 config.json
 config.local.json
+.confidential.yml
 
 # Backups
 *.bak

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -106,8 +106,11 @@ Implementation: [src/session/session-key.ts](./src/session/session-key.ts),
 Optional, opt-in filter that prevents NDA-class business data from leaving the
 host:
 
-- Define rules in `~/.hybridclaw/.confidential.yml` (clients, projects, people,
-  keywords, regex patterns, each tagged with a sensitivity level).
+- Define rules in `.confidential.yml`. The loader checks the current working
+  directory first (`./.confidential.yml`) and then
+  `~/.hybridclaw/.confidential.yml`; first hit wins. The file holds clients,
+  projects, people, keywords, and regex patterns, each tagged with a
+  sensitivity level.
 - Before every prompt is sent to a model, matches are replaced with stable
   placeholders (`«CONF:CLIENT_001»`); the mapping is held in process memory and
   forgotten when the request ends.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -101,6 +101,34 @@ Implementation: [src/session/session-key.ts](./src/session/session-key.ts),
 [src/session/session-routing.ts](./src/session/session-routing.ts),
 [src/memory/db.ts](./src/memory/db.ts)
 
+### 4.1) Confidential-Info Filter (NDA / secret-leak detector)
+
+Optional, opt-in filter that prevents NDA-class business data from leaving the
+host:
+
+- Define rules in `~/.hybridclaw/.confidential.yml` (clients, projects, people,
+  keywords, regex patterns, each tagged with a sensitivity level).
+- Before every prompt is sent to a model, matches are replaced with stable
+  placeholders (`«CONF:CLIENT_001»`); the mapping is held in process memory and
+  forgotten when the request ends.
+- Streaming text deltas and the final response are rehydrated for the user, so
+  the model never sees the original strings but the user sees real names.
+- Disabled via `HYBRIDCLAW_CONFIDENTIAL_DISABLE=1` for debugging or dry-runs.
+
+A retroactive scanner walks existing audit logs to surface possible past leaks
+and assigns a 0-100 risk score:
+
+```bash
+hybridclaw audit scan-leaks                # scan every session
+hybridclaw audit scan-leaks <sessionId>    # scan one session
+hybridclaw audit scan-leaks --json         # machine-readable report
+```
+
+Implementation: [src/security/confidential-rules.ts](./src/security/confidential-rules.ts),
+[src/security/confidential-redact.ts](./src/security/confidential-redact.ts),
+[src/security/confidential-runtime.ts](./src/security/confidential-runtime.ts),
+[src/audit/leak-scanner.ts](./src/audit/leak-scanner.ts).
+
 ### 5) Audit & Tamper Evidence
 
 Security-relevant behavior is written to structured audit logs:

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -2,6 +2,7 @@ import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import { HYBRIDAI_MODEL } from '../config/config.js';
 import { injectPdfContextMessages } from '../media/pdf-context.js';
 import { withSpan } from '../observability/otel.js';
+import { createConfidentialRuntimeContext } from '../security/confidential-runtime.js';
 import type { ContainerOutput } from '../types/container.js';
 import { getExecutor } from './executor.js';
 import type { ExecutorRequest } from './executor-types.js';
@@ -40,10 +41,12 @@ async function runAgentInner(
     workspaceRoot,
     media,
   });
-  return executor.exec({
+  const confidential = createConfidentialRuntimeContext();
+  const dehydratedMessages = confidential.dehydrate(preparedMessages);
+  const output = await executor.exec({
     ...params,
     sessionId,
-    messages: preparedMessages,
+    messages: dehydratedMessages,
     chatbotId,
     model,
     agentId,
@@ -57,5 +60,18 @@ async function runAgentInner(
     channelId,
     media,
     blockedTools,
+    onTextDelta: confidential.wrapDelta(params.onTextDelta),
+    onThinkingDelta: confidential.wrapDelta(params.onThinkingDelta),
   });
+  if (!confidential.enabled) return output;
+  return {
+    ...output,
+    result: output.result
+      ? confidential.rehydrate(output.result)
+      : output.result,
+    error: output.error ? confidential.rehydrate(output.error) : output.error,
+    effectiveUserPrompt: output.effectiveUserPrompt
+      ? confidential.rehydrate(output.effectiveUserPrompt)
+      : output.effectiveUserPrompt,
+  };
 }

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -4,9 +4,29 @@ import { injectPdfContextMessages } from '../media/pdf-context.js';
 import { withSpan } from '../observability/otel.js';
 import { createConfidentialRuntimeContext } from '../security/confidential-runtime.js';
 import type { ContainerOutput } from '../types/container.js';
+import type {
+  PendingApproval,
+  ToolExecution,
+  ToolProgressEvent,
+} from '../types/execution.js';
 import { getExecutor } from './executor.js';
 import type { ExecutorRequest } from './executor-types.js';
 import { mergeBlockedToolNames } from './tool-policy.js';
+
+const TOOL_EXECUTION_REHYDRATE_FIELDS: ReadonlyArray<keyof ToolExecution> = [
+  'arguments',
+  'result',
+  'blockedReason',
+  'approvalIntent',
+  'approvalReason',
+];
+
+const PENDING_APPROVAL_REHYDRATE_FIELDS: ReadonlyArray<keyof PendingApproval> =
+  ['prompt', 'intent', 'reason'];
+
+const TOOL_PROGRESS_REHYDRATE_FIELDS: ReadonlyArray<keyof ToolProgressEvent> = [
+  'preview',
+];
 
 export async function runAgent(
   params: ExecutorRequest,
@@ -62,8 +82,27 @@ async function runAgentInner(
     blockedTools,
     onTextDelta: confidential.wrapDelta(params.onTextDelta),
     onThinkingDelta: confidential.wrapDelta(params.onThinkingDelta),
+    onToolProgress: confidential.wrapEvent(
+      params.onToolProgress,
+      TOOL_PROGRESS_REHYDRATE_FIELDS,
+    ),
+    onApprovalProgress: confidential.wrapEvent(
+      params.onApprovalProgress,
+      PENDING_APPROVAL_REHYDRATE_FIELDS,
+    ),
   });
   if (!confidential.enabled) return output;
+  const rehydratedToolExecutions = output.toolExecutions?.map(
+    (execution) =>
+      confidential.rehydrateFields(
+        execution,
+        TOOL_EXECUTION_REHYDRATE_FIELDS,
+      ) ?? execution,
+  );
+  const rehydratedPendingApproval = confidential.rehydrateFields(
+    output.pendingApproval,
+    PENDING_APPROVAL_REHYDRATE_FIELDS,
+  );
   return {
     ...output,
     result: output.result
@@ -73,5 +112,7 @@ async function runAgentInner(
     effectiveUserPrompt: output.effectiveUserPrompt
       ? confidential.rehydrate(output.effectiveUserPrompt)
       : output.effectiveUserPrompt,
+    toolExecutions: rehydratedToolExecutions ?? output.toolExecutions,
+    pendingApproval: rehydratedPendingApproval ?? output.pendingApproval,
   };
 }

--- a/src/audit/audit-cli.ts
+++ b/src/audit/audit-cli.ts
@@ -69,6 +69,7 @@ Commands:
   search <query> [n]                 Search structured audit events
   approvals [n] [--denied]           Show approval decisions
   verify <sessionId>                 Verify wire hash chain integrity
+  scan-leaks [sessionId] [--json]    Scan audit logs for leaked confidential info
   instructions [--sync] [--approve]  Verify or restore runtime instruction files`);
 }
 
@@ -198,6 +199,12 @@ export async function runAuditCli(rawArgs: string[]): Promise<void> {
 
   if (cmd === 'instructions') {
     runInstructionHashesCommand(args);
+    return;
+  }
+
+  if (cmd === 'scan-leaks') {
+    const { runLeakScanCli } = await import('./leak-scanner-cli.js');
+    await runLeakScanCli(args);
     return;
   }
 

--- a/src/audit/audit-cli.ts
+++ b/src/audit/audit-cli.ts
@@ -69,7 +69,7 @@ Commands:
   search <query> [n]                 Search structured audit events
   approvals [n] [--denied]           Show approval decisions
   verify <sessionId>                 Verify wire hash chain integrity
-  scan-leaks [sessionId] [--json]    Scan audit logs for leaked confidential info
+  scan-leaks [sessionId] [--json]    Scan audit logs for leaked confidential info (rules: ./.confidential.yml then ~/.hybridclaw/.confidential.yml)
   instructions [--sync] [--approve]  Verify or restore runtime instruction files`);
 }
 

--- a/src/audit/audit-cli.ts
+++ b/src/audit/audit-cli.ts
@@ -69,11 +69,14 @@ Commands:
   search <query> [n]                 Search structured audit events
   approvals [n] [--denied]           Show approval decisions
   verify <sessionId>                 Verify wire hash chain integrity
-  scan-leaks [sessionId] [--quiet|--all] [--json]
+  scan-leaks [sessionId] [--quiet|--all] [--level <sev>] [--type <list>] [--json]
                                      Scan audit logs for leaked confidential info. Verbosity:
                                        --quiet  → summary block only
                                        (default) → matched sessions + summary (clean sessions hidden)
                                        --all    → every session, including clean
+                                     Filters (applied after scan):
+                                       --level critical|high|medium|low      keep records at or above this severity
+                                       --type  in,out,tool,url               keep records in any of the listed buckets
                                      Rules loaded from ./.confidential.yml (project-local) or ~/.hybridclaw/.confidential.yml (user-global).
   instructions [--sync] [--approve]  Verify or restore runtime instruction files`);
 }

--- a/src/audit/audit-cli.ts
+++ b/src/audit/audit-cli.ts
@@ -69,7 +69,9 @@ Commands:
   search <query> [n]                 Search structured audit events
   approvals [n] [--denied]           Show approval decisions
   verify <sessionId>                 Verify wire hash chain integrity
-  scan-leaks [sessionId] [--json]    Scan audit logs for leaked confidential info (rules: ./.confidential.yml then ~/.hybridclaw/.confidential.yml)
+  scan-leaks [sessionId] [--all] [--json]
+                                     Scan audit logs for leaked confidential info. Clean sessions are hidden unless --all is passed.
+                                     Rules loaded from ./.confidential.yml (project-local) or ~/.hybridclaw/.confidential.yml (user-global).
   instructions [--sync] [--approve]  Verify or restore runtime instruction files`);
 }
 

--- a/src/audit/audit-cli.ts
+++ b/src/audit/audit-cli.ts
@@ -69,8 +69,11 @@ Commands:
   search <query> [n]                 Search structured audit events
   approvals [n] [--denied]           Show approval decisions
   verify <sessionId>                 Verify wire hash chain integrity
-  scan-leaks [sessionId] [--all] [--json]
-                                     Scan audit logs for leaked confidential info. Clean sessions are hidden unless --all is passed.
+  scan-leaks [sessionId] [--quiet|--all] [--json]
+                                     Scan audit logs for leaked confidential info. Verbosity:
+                                       --quiet  → summary block only
+                                       (default) → matched sessions + summary (clean sessions hidden)
+                                       --all    → every session, including clean
                                      Rules loaded from ./.confidential.yml (project-local) or ~/.hybridclaw/.confidential.yml (user-global).
   instructions [--sync] [--approve]  Verify or restore runtime instruction files`);
 }

--- a/src/audit/leak-scanner-cli.ts
+++ b/src/audit/leak-scanner-cli.ts
@@ -1,13 +1,16 @@
+import type { ConfidentialFinding } from '../security/confidential-redact.js';
 import { loadConfidentialRules } from '../security/confidential-rules.js';
 import {
   type LeakScanReport,
   scanAllAuditSessionsForLeaks,
   scanAuditSessionForLeaks,
+  summarizeLeakReports,
 } from './leak-scanner.js';
 
 const ANSI_RED = '\x1b[31m';
 const ANSI_YELLOW = '\x1b[33m';
 const ANSI_GREEN = '\x1b[32m';
+const ANSI_BOLD = '\x1b[1m';
 const ANSI_RESET = '\x1b[0m';
 
 function color(text: string, code: string): string {
@@ -20,12 +23,26 @@ function severityColor(severity: LeakScanReport['severity']): string {
   return ANSI_GREEN;
 }
 
+function highlightExcerpt(excerpt: string): string {
+  if (!process.stdout.isTTY) return excerpt;
+  // The scanner wraps each match in »…« — swap those for ANSI bold red so
+  // the matched span pops in a terminal but the raw text still reads.
+  return excerpt.replace(
+    /»([^«]+)«/g,
+    `${ANSI_BOLD}${ANSI_RED}$1${ANSI_RESET}`,
+  );
+}
+
 function summarizeReport(report: LeakScanReport): string {
   const tag = color(
     report.severity.toUpperCase().padEnd(8),
     severityColor(report.severity),
   );
-  return `${tag} session=${report.sessionId} score=${report.score}/100 matches=${report.totalMatches} records=${report.matchedRecords.length}/${report.recordsScanned}`;
+  const skipped =
+    report.recordsSkippedByType > 0
+      ? ` skipped=${report.recordsSkippedByType}`
+      : '';
+  return `${tag} session=${report.sessionId} score=${report.score}/100 matches=${report.totalMatches} records=${report.matchedRecords.length}/${report.recordsScanned}${skipped}`;
 }
 
 function printReportDetail(report: LeakScanReport): void {
@@ -36,7 +53,7 @@ function printReportDetail(report: LeakScanReport): void {
   }
   if (report.matchedRecords.length === 0) {
     if (report.recordsScanned === 0) {
-      console.log('  (no audit records found)');
+      console.log('  (no prompt-bearing audit records found)');
     } else {
       console.log('  (no confidential matches)');
     }
@@ -54,9 +71,32 @@ function printReportDetail(report: LeakScanReport): void {
     );
     for (const finding of record.findings) {
       console.log(
-        `    - [${finding.sensitivity}] ${finding.kind}:${finding.label} ×${finding.matches}  ${finding.excerpt}`,
+        `    - [${finding.sensitivity}] ${finding.kind}:${finding.label} ×${finding.matches}  ${highlightExcerpt(finding.excerpt)}`,
       );
     }
+  }
+}
+
+function printSummaryFooter(reports: LeakScanReport[]): void {
+  const summary = summarizeLeakReports(reports);
+  const order: ConfidentialFinding['sensitivity'][] = [
+    'critical',
+    'high',
+    'medium',
+    'low',
+  ];
+  console.log('');
+  console.log(
+    color('Summary', ANSI_BOLD) +
+      ` — ${summary.affectedSessions}/${summary.totalSessions} session${summary.totalSessions === 1 ? '' : 's'} affected, ${summary.totalMatches} match${summary.totalMatches === 1 ? '' : 'es'} total`,
+  );
+  for (const severity of order) {
+    const count = summary.bySeverity[severity];
+    const label = color(
+      severity.toUpperCase().padEnd(8),
+      severityColor(severity),
+    );
+    console.log(`  ${label} ${count} session${count === 1 ? '' : 's'}`);
   }
 }
 
@@ -89,6 +129,7 @@ export async function runLeakScanCli(args: string[]): Promise<void> {
       sessionId: report.sessionId,
       filePath: report.filePath,
       recordsScanned: report.recordsScanned,
+      recordsSkippedByType: report.recordsSkippedByType,
       matchedRecords: report.matchedRecords,
       totalMatches: report.totalMatches,
       score: report.score,
@@ -98,7 +139,11 @@ export async function runLeakScanCli(args: string[]): Promise<void> {
     }));
     console.log(
       JSON.stringify(
-        { rulesLoaded: ruleSet.rules.length, reports: serialized },
+        {
+          rulesLoaded: ruleSet.rules.length,
+          summary: summarizeLeakReports(reports),
+          reports: serialized,
+        },
         null,
         2,
       ),
@@ -124,6 +169,8 @@ export async function runLeakScanCli(args: string[]): Promise<void> {
     if (report.totalMatches > 0) leaksFound = true;
     printReportDetail(report);
   }
+
+  printSummaryFooter(reports);
 
   if (leaksFound) {
     process.exitCode = 2;

--- a/src/audit/leak-scanner-cli.ts
+++ b/src/audit/leak-scanner-cli.ts
@@ -70,7 +70,7 @@ export async function runLeakScanCli(args: string[]): Promise<void> {
     const message =
       ruleSet.sourcePath != null
         ? `No usable rules found in ${ruleSet.sourcePath}.`
-        : 'No .confidential.yml found. Create ~/.hybridclaw/.confidential.yml to enable leak scanning.';
+        : 'No .confidential.yml found. Create ./.confidential.yml (project-local) or ~/.hybridclaw/.confidential.yml (user-global) to enable leak scanning.';
     if (useJson) {
       console.log(JSON.stringify({ ok: false, reason: message }, null, 2));
     } else {

--- a/src/audit/leak-scanner-cli.ts
+++ b/src/audit/leak-scanner-cli.ts
@@ -102,6 +102,8 @@ function printReportDetail(report: LeakScanReport): void {
   }
 }
 
+const SUMMARY_RULE = '*'.repeat(60);
+
 function printSummaryFooter(reports: LeakScanReport[]): void {
   const summary = summarizeLeakReports(reports);
   const sevOrder: ConfidentialFinding['sensitivity'][] = [
@@ -111,33 +113,41 @@ function printSummaryFooter(reports: LeakScanReport[]): void {
     'low',
   ];
   const dirOrder: PromptDirection[] = ['in', 'out', 'tool'];
+  // ASCII rule + asterisks survive copy/paste into Slack, email, PR
+  // comments and pagers that strip ANSI styling.
   console.log('');
+  console.log(SUMMARY_RULE);
+  console.log('***                     SUMMARY                          ***');
+  console.log(SUMMARY_RULE);
   console.log(
-    `${color('Summary', ANSI_BOLD)} — ${summary.affectedSessions}/${summary.totalSessions} session${summary.totalSessions === 1 ? '' : 's'} affected, ${summary.totalMatches} match${summary.totalMatches === 1 ? '' : 'es'} total`,
+    `${summary.affectedSessions}/${summary.totalSessions} session${summary.totalSessions === 1 ? '' : 's'} affected, ${summary.totalMatches} match${summary.totalMatches === 1 ? '' : 'es'} total`,
   );
-  console.log('  By session severity:');
+  console.log('');
+  console.log('By session severity:');
   for (const severity of sevOrder) {
     const count = summary.bySeverity[severity];
     const label = color(
       severity.toUpperCase().padEnd(8),
       severityColor(severity),
     );
-    console.log(`    ${label} ${count} session${count === 1 ? '' : 's'}`);
+    console.log(`  ${label} ${count} session${count === 1 ? '' : 's'}`);
   }
-  console.log('  By prompt direction:');
+  console.log('');
+  console.log('By prompt direction:');
   for (const dir of dirOrder) {
     const totals = summary.byDirection[dir];
     const label = DIRECTION_LABEL[dir].padEnd(13);
     console.log(
-      `    ${label} ${totals.matches} match${totals.matches === 1 ? '' : 'es'} in ${totals.records} record${totals.records === 1 ? '' : 's'}`,
+      `  ${label} ${totals.matches} match${totals.matches === 1 ? '' : 'es'} in ${totals.records} record${totals.records === 1 ? '' : 's'}`,
     );
   }
   if (summary.byDirection.other.matches > 0) {
     const totals = summary.byDirection.other;
     console.log(
-      `    other         ${totals.matches} match${totals.matches === 1 ? '' : 'es'} in ${totals.records} record${totals.records === 1 ? '' : 's'}`,
+      `  other         ${totals.matches} match${totals.matches === 1 ? '' : 'es'} in ${totals.records} record${totals.records === 1 ? '' : 's'}`,
     );
   }
+  console.log(SUMMARY_RULE);
 }
 
 export async function runLeakScanCli(args: string[]): Promise<void> {

--- a/src/audit/leak-scanner-cli.ts
+++ b/src/audit/leak-scanner-cli.ts
@@ -7,7 +7,7 @@ import type { ConfidentialFinding } from '../security/confidential-redact.js';
 import { loadConfidentialRules } from '../security/confidential-rules.js';
 import {
   type LeakScanReport,
-  type PromptDirection,
+  type PromptCategory,
   scanAllAuditSessionsForLeaks,
   scanAuditSessionForLeaks,
   summarizeLeakReports,
@@ -52,10 +52,11 @@ function formatTimestamp(iso: string): string {
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
 }
 
-const DIRECTION_LABEL: Record<PromptDirection, string> = {
+const CATEGORY_LABEL: Record<PromptCategory, string> = {
   in: 'in   (→ LLM)',
   out: 'out  (← LLM)',
   tool: 'tool (I/O)',
+  url: 'url  (URLs)',
 };
 
 function summarizeReport(report: LeakScanReport): string {
@@ -128,10 +129,12 @@ function printRunHeader(
   scope: string,
 ): void {
   printBanner('Audit Leak Scanner');
-  console.log(
-    `Rules: ${rulesLoaded} from ${rulesPath ?? 'embedded'}    Scope: ${scope}`,
-  );
-  console.log('');
+  console.log(`Rules: ${rulesLoaded} from ${rulesPath ?? 'embedded'}`);
+  console.log(`Scope: ${scope}`);
+}
+
+function pluralize(value: number, singular: string, plural: string): string {
+  return `${value} ${value === 1 ? singular : plural}`;
 }
 
 function printSummaryFooter(reports: LeakScanReport[]): void {
@@ -142,13 +145,13 @@ function printSummaryFooter(reports: LeakScanReport[]): void {
     'medium',
     'low',
   ];
-  const dirOrder: PromptDirection[] = ['in', 'out', 'tool'];
-  // ASCII rule + asterisks survive copy/paste into Slack, email, PR
-  // comments and pagers that strip ANSI styling.
+  const catOrder: PromptCategory[] = ['in', 'out', 'tool', 'url'];
+  // No second banner — the AUDIT LEAK SCANNER block at the top already
+  // brackets the report. Keep blocks visually separated by single blank
+  // lines and close with one rule for copy-paste delimiting.
   console.log('');
-  printBanner('Summary');
   console.log(
-    `${summary.affectedSessions}/${summary.totalSessions} session${summary.totalSessions === 1 ? '' : 's'} affected, ${summary.totalMatches} match${summary.totalMatches === 1 ? '' : 'es'} total`,
+    `${summary.affectedSessions}/${summary.totalSessions} ${summary.totalSessions === 1 ? 'session' : 'sessions'} affected, ${pluralize(summary.totalMatches, 'match', 'matches')} total`,
   );
   console.log('');
   console.log('By session severity:');
@@ -158,21 +161,15 @@ function printSummaryFooter(reports: LeakScanReport[]): void {
       severity.toUpperCase().padEnd(8),
       severityColor(severity),
     );
-    console.log(`  ${label} ${count} session${count === 1 ? '' : 's'}`);
+    console.log(`  ${label} ${pluralize(count, 'session', 'sessions')}`);
   }
   console.log('');
-  console.log('By prompt direction:');
-  for (const dir of dirOrder) {
-    const totals = summary.byDirection[dir];
-    const label = DIRECTION_LABEL[dir].padEnd(13);
+  console.log('By type:');
+  for (const cat of catOrder) {
+    const totals = summary.byCategory[cat];
+    const label = CATEGORY_LABEL[cat].padEnd(13);
     console.log(
-      `  ${label} ${totals.matches} match${totals.matches === 1 ? '' : 'es'} in ${totals.records} record${totals.records === 1 ? '' : 's'}`,
-    );
-  }
-  if (summary.byDirection.other.matches > 0) {
-    const totals = summary.byDirection.other;
-    console.log(
-      `  other         ${totals.matches} match${totals.matches === 1 ? '' : 'es'} in ${totals.records} record${totals.records === 1 ? '' : 's'}`,
+      `  ${label} ${pluralize(totals.matches, 'match', 'matches')} in ${pluralize(totals.records, 'record', 'records')} in ${pluralize(totals.sessions, 'session', 'sessions')}`,
     );
   }
   console.log(SUMMARY_RULE);
@@ -254,6 +251,7 @@ export async function runLeakScanCli(args: string[]): Promise<void> {
   const leaksFound = reports.some((report) => report.totalMatches > 0);
 
   if (effectiveVerbosity !== 'quiet') {
+    console.log('');
     let cleanHidden = 0;
     for (const report of reports) {
       // `standard` suppresses sessions with zero matches — most workspaces

--- a/src/audit/leak-scanner-cli.ts
+++ b/src/audit/leak-scanner-cli.ts
@@ -1,0 +1,131 @@
+import { loadConfidentialRules } from '../security/confidential-rules.js';
+import {
+  type LeakScanReport,
+  scanAllAuditSessionsForLeaks,
+  scanAuditSessionForLeaks,
+} from './leak-scanner.js';
+
+const ANSI_RED = '\x1b[31m';
+const ANSI_YELLOW = '\x1b[33m';
+const ANSI_GREEN = '\x1b[32m';
+const ANSI_RESET = '\x1b[0m';
+
+function color(text: string, code: string): string {
+  return process.stdout.isTTY ? `${code}${text}${ANSI_RESET}` : text;
+}
+
+function severityColor(severity: LeakScanReport['severity']): string {
+  if (severity === 'critical' || severity === 'high') return ANSI_RED;
+  if (severity === 'medium') return ANSI_YELLOW;
+  return ANSI_GREEN;
+}
+
+function summarizeReport(report: LeakScanReport): string {
+  const tag = color(
+    report.severity.toUpperCase().padEnd(8),
+    severityColor(report.severity),
+  );
+  return `${tag} session=${report.sessionId} score=${report.score}/100 matches=${report.totalMatches} records=${report.matchedRecords.length}/${report.recordsScanned}`;
+}
+
+function printReportDetail(report: LeakScanReport): void {
+  if (report.errors.length > 0) {
+    for (const error of report.errors) {
+      console.log(`  ! ${error}`);
+    }
+  }
+  if (report.matchedRecords.length === 0) {
+    if (report.recordsScanned === 0) {
+      console.log('  (no audit records found)');
+    } else {
+      console.log('  (no confidential matches)');
+    }
+    return;
+  }
+
+  for (const record of report.matchedRecords) {
+    const sevTag = color(
+      record.severity.toUpperCase(),
+      severityColor(record.severity),
+    );
+    const placeholder = record.hadPlaceholder ? ' (post-dehydrate)' : '';
+    console.log(
+      `  #${record.seq} ${record.timestamp} ${record.eventType} ${sevTag} score=${record.score}${placeholder}`,
+    );
+    for (const finding of record.findings) {
+      console.log(
+        `    - [${finding.sensitivity}] ${finding.kind}:${finding.label} ×${finding.matches}  ${finding.excerpt}`,
+      );
+    }
+  }
+}
+
+export async function runLeakScanCli(args: string[]): Promise<void> {
+  const useJson = args.includes('--json');
+  const positional = args.filter((arg) => !arg.startsWith('--'));
+  const sessionId = positional[0];
+
+  const ruleSet = loadConfidentialRules();
+  if (ruleSet.rules.length === 0) {
+    const message =
+      ruleSet.sourcePath != null
+        ? `No usable rules found in ${ruleSet.sourcePath}.`
+        : 'No .confidential.yml found. Create ~/.hybridclaw/.confidential.yml to enable leak scanning.';
+    if (useJson) {
+      console.log(JSON.stringify({ ok: false, reason: message }, null, 2));
+    } else {
+      console.log(message);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  const reports = sessionId
+    ? [scanAuditSessionForLeaks(sessionId, ruleSet)]
+    : scanAllAuditSessionsForLeaks(ruleSet);
+
+  if (useJson) {
+    const serialized = reports.map((report) => ({
+      sessionId: report.sessionId,
+      filePath: report.filePath,
+      recordsScanned: report.recordsScanned,
+      matchedRecords: report.matchedRecords,
+      totalMatches: report.totalMatches,
+      score: report.score,
+      rawScore: report.rawScore,
+      severity: report.severity,
+      errors: report.errors,
+    }));
+    console.log(
+      JSON.stringify(
+        { rulesLoaded: ruleSet.rules.length, reports: serialized },
+        null,
+        2,
+      ),
+    );
+    if (reports.some((report) => report.totalMatches > 0)) {
+      process.exitCode = 2;
+    }
+    return;
+  }
+
+  console.log(
+    `Scanning audit logs (${ruleSet.rules.length} rule${ruleSet.rules.length === 1 ? '' : 's'} from ${ruleSet.sourcePath ?? 'embedded'})`,
+  );
+
+  if (reports.length === 0) {
+    console.log('No audit sessions found.');
+    return;
+  }
+
+  let leaksFound = false;
+  for (const report of reports) {
+    console.log(summarizeReport(report));
+    if (report.totalMatches > 0) leaksFound = true;
+    printReportDetail(report);
+  }
+
+  if (leaksFound) {
+    process.exitCode = 2;
+  }
+}

--- a/src/audit/leak-scanner-cli.ts
+++ b/src/audit/leak-scanner-cli.ts
@@ -6,12 +6,124 @@ import {
 import type { ConfidentialFinding } from '../security/confidential-redact.js';
 import { loadConfidentialRules } from '../security/confidential-rules.js';
 import {
+  applyLeakReportFilter,
   type LeakScanReport,
   type PromptCategory,
+  SEVERITY_LEVELS,
   scanAllAuditSessionsForLeaks,
   scanAuditSessionForLeaks,
   summarizeLeakReports,
 } from './leak-scanner.js';
+
+const VALID_CATEGORIES: ReadonlySet<PromptCategory> = new Set([
+  'in',
+  'out',
+  'tool',
+  'url',
+]);
+
+interface ParsedScanFlags {
+  remaining: string[];
+  level: ConfidentialFinding['sensitivity'] | null;
+  categories: Set<PromptCategory> | null;
+  error: string | null;
+}
+
+function parseValueFlag(
+  args: string[],
+  index: number,
+  name: string,
+): { value: string | null; consumed: number } {
+  const arg = args[index];
+  const eqIdx = arg.indexOf('=');
+  if (eqIdx >= 0) {
+    return { value: arg.slice(eqIdx + 1), consumed: 1 };
+  }
+  if (arg === name) {
+    const next = args[index + 1];
+    if (next == null || next.startsWith('--')) {
+      return { value: null, consumed: 1 };
+    }
+    return { value: next, consumed: 2 };
+  }
+  return { value: null, consumed: 0 };
+}
+
+function parseScanFlags(args: string[]): ParsedScanFlags {
+  let level: ConfidentialFinding['sensitivity'] | null = null;
+  let categories: Set<PromptCategory> | null = null;
+  const remaining: string[] = [];
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+    if (arg === '--level' || arg.startsWith('--level=')) {
+      const { value, consumed } = parseValueFlag(args, i, '--level');
+      if (!value) {
+        return {
+          remaining,
+          level,
+          categories,
+          error: '--level requires a value (critical, high, medium, low)',
+        };
+      }
+      const normalized = value.trim().toLowerCase();
+      if (
+        !SEVERITY_LEVELS.includes(
+          normalized as ConfidentialFinding['sensitivity'],
+        )
+      ) {
+        return {
+          remaining,
+          level,
+          categories,
+          error: `--level must be one of ${SEVERITY_LEVELS.join(', ')} (got "${value}")`,
+        };
+      }
+      level = normalized as ConfidentialFinding['sensitivity'];
+      i += consumed;
+      continue;
+    }
+    if (arg === '--type' || arg.startsWith('--type=')) {
+      const { value, consumed } = parseValueFlag(args, i, '--type');
+      if (!value) {
+        return {
+          remaining,
+          level,
+          categories,
+          error: '--type requires a value (in,out,tool,url)',
+        };
+      }
+      const next = new Set<PromptCategory>();
+      for (const raw of value.split(',')) {
+        const normalized = raw.trim().toLowerCase();
+        if (!normalized) continue;
+        if (!VALID_CATEGORIES.has(normalized as PromptCategory)) {
+          return {
+            remaining,
+            level,
+            categories,
+            error: `--type values must be one of in, out, tool, url (got "${raw}")`,
+          };
+        }
+        next.add(normalized as PromptCategory);
+      }
+      if (next.size === 0) {
+        return {
+          remaining,
+          level,
+          categories,
+          error: '--type requires at least one category',
+        };
+      }
+      categories = next;
+      i += consumed;
+      continue;
+    }
+    remaining.push(arg);
+    i += 1;
+  }
+  return { remaining, level, categories, error: null };
+}
 
 const ANSI_RED = '\x1b[31m';
 const ANSI_YELLOW = '\x1b[33m';
@@ -127,10 +239,12 @@ function printRunHeader(
   rulesLoaded: number,
   rulesPath: string | null,
   scope: string,
+  filters: string | null,
 ): void {
   printBanner('Audit Leak Scanner');
   console.log(`Rules: ${rulesLoaded} from ${rulesPath ?? 'embedded'}`);
   console.log(`Scope: ${scope}`);
+  if (filters) console.log(`Filter: ${filters}`);
 }
 
 function pluralize(value: number, singular: string, plural: string): string {
@@ -178,8 +292,14 @@ function printSummaryFooter(reports: LeakScanReport[]): void {
 export async function runLeakScanCli(args: string[]): Promise<void> {
   const useJson = args.includes('--json');
   const verbosity: OutputVerbosity = parseOutputVerbosity(args);
-  const remaining = stripVerbosityFlags(args);
-  const positional = remaining.filter((arg) => !arg.startsWith('--'));
+  const afterVerbosity = stripVerbosityFlags(args);
+  const flags = parseScanFlags(afterVerbosity);
+  if (flags.error) {
+    console.error(flags.error);
+    process.exitCode = 1;
+    return;
+  }
+  const positional = flags.remaining.filter((arg) => !arg.startsWith('--'));
   const sessionId = positional[0];
   // Asking for one specific session implies "show me everything about it",
   // including clean and the per-session detail block.
@@ -201,9 +321,16 @@ export async function runLeakScanCli(args: string[]): Promise<void> {
     return;
   }
 
-  const reports = sessionId
+  const rawReports = sessionId
     ? [scanAuditSessionForLeaks(sessionId, ruleSet)]
     : scanAllAuditSessionsForLeaks(ruleSet);
+  const reports =
+    flags.level || flags.categories
+      ? applyLeakReportFilter(rawReports, {
+          minSeverity: flags.level ?? undefined,
+          categories: flags.categories ?? undefined,
+        })
+      : rawReports;
 
   if (useJson) {
     const serialized = reports.map((report) => ({
@@ -235,12 +362,18 @@ export async function runLeakScanCli(args: string[]): Promise<void> {
     return;
   }
 
+  const filterParts: string[] = [];
+  if (flags.level) filterParts.push(`level≥${flags.level}`);
+  if (flags.categories) {
+    filterParts.push(`type=${[...flags.categories].sort().join(',')}`);
+  }
   printRunHeader(
     ruleSet.rules.length,
     ruleSet.sourcePath,
     sessionId
       ? `session ${sessionId}`
       : `${reports.length} session${reports.length === 1 ? '' : 's'}`,
+    filterParts.length > 0 ? filterParts.join('  ') : null,
   );
 
   if (reports.length === 0) {

--- a/src/audit/leak-scanner-cli.ts
+++ b/src/audit/leak-scanner-cli.ts
@@ -1,7 +1,11 @@
+import {
+  type OutputVerbosity,
+  parseOutputVerbosity,
+  stripVerbosityFlags,
+} from '../cli/verbosity.js';
 import type { ConfidentialFinding } from '../security/confidential-redact.js';
 import { loadConfidentialRules } from '../security/confidential-rules.js';
 import {
-  directionForEventType,
   type LeakScanReport,
   type PromptDirection,
   scanAllAuditSessionsForLeaks,
@@ -87,22 +91,48 @@ function printReportDetail(report: LeakScanReport): void {
       severityColor(record.severity),
     );
     const placeholder = record.hadPlaceholder ? ' (post-dehydrate)' : '';
-    const direction = directionForEventType(record.eventType);
-    const dirTag = direction ? ` [${direction}]` : '';
+    // Direction is redundant on the record header — the event type
+    // (`tool.result`, `turn.start`, …) already implies it. The summary
+    // footer aggregates by direction where the rollup actually helps.
     console.log(
-      `  #${record.seq} ${formatTimestamp(record.timestamp)} ${record.eventType}${dirTag} ${sevTag} score=${record.score}${placeholder}`,
+      `  #${record.seq} ${formatTimestamp(record.timestamp)} ${record.eventType} ${sevTag} score=${record.score}${placeholder}`,
     );
     for (const finding of record.findings) {
-      // Print match=... explicitly so it stays visible when ANSI styling is
-      // stripped (e.g. when copying terminal output or piping through less).
+      // Severity is shown on the record header above. Match text is shown
+      // verbatim in the excerpt wrapped in »…« (and ANSI-bold-red on TTY),
+      // so an explicit `match="..."` would just repeat it.
+      const sevHint =
+        finding.sensitivity !== record.severity
+          ? `[${finding.sensitivity}] `
+          : '';
       console.log(
-        `    - [${finding.sensitivity}] ${finding.kind}:${finding.label} ×${finding.matches} match="${finding.match}"  ${highlightExcerpt(finding.excerpt)}`,
+        `    - ${sevHint}${finding.kind}:${finding.label} ×${finding.matches}  ${highlightExcerpt(finding.excerpt)}`,
       );
     }
   }
 }
 
 const SUMMARY_RULE = '*'.repeat(60);
+
+function printBanner(title: string): void {
+  console.log(SUMMARY_RULE);
+  const inner = title.toUpperCase();
+  const padded = inner.padStart((54 + inner.length) / 2).padEnd(54);
+  console.log(`***${padded}***`);
+  console.log(SUMMARY_RULE);
+}
+
+function printRunHeader(
+  rulesLoaded: number,
+  rulesPath: string | null,
+  scope: string,
+): void {
+  printBanner('Audit Leak Scanner');
+  console.log(
+    `Rules: ${rulesLoaded} from ${rulesPath ?? 'embedded'}    Scope: ${scope}`,
+  );
+  console.log('');
+}
 
 function printSummaryFooter(reports: LeakScanReport[]): void {
   const summary = summarizeLeakReports(reports);
@@ -116,9 +146,7 @@ function printSummaryFooter(reports: LeakScanReport[]): void {
   // ASCII rule + asterisks survive copy/paste into Slack, email, PR
   // comments and pagers that strip ANSI styling.
   console.log('');
-  console.log(SUMMARY_RULE);
-  console.log('***                     SUMMARY                          ***');
-  console.log(SUMMARY_RULE);
+  printBanner('Summary');
   console.log(
     `${summary.affectedSessions}/${summary.totalSessions} session${summary.totalSessions === 1 ? '' : 's'} affected, ${summary.totalMatches} match${summary.totalMatches === 1 ? '' : 'es'} total`,
   );
@@ -152,9 +180,14 @@ function printSummaryFooter(reports: LeakScanReport[]): void {
 
 export async function runLeakScanCli(args: string[]): Promise<void> {
   const useJson = args.includes('--json');
-  const showAll = args.includes('--all');
-  const positional = args.filter((arg) => !arg.startsWith('--'));
+  const verbosity: OutputVerbosity = parseOutputVerbosity(args);
+  const remaining = stripVerbosityFlags(args);
+  const positional = remaining.filter((arg) => !arg.startsWith('--'));
   const sessionId = positional[0];
+  // Asking for one specific session implies "show me everything about it",
+  // including clean and the per-session detail block.
+  const effectiveVerbosity: OutputVerbosity =
+    sessionId && verbosity === 'standard' ? 'all' : verbosity;
 
   const ruleSet = loadConfidentialRules();
   if (ruleSet.rules.length === 0) {
@@ -205,8 +238,12 @@ export async function runLeakScanCli(args: string[]): Promise<void> {
     return;
   }
 
-  console.log(
-    `Scanning audit logs (${ruleSet.rules.length} rule${ruleSet.rules.length === 1 ? '' : 's'} from ${ruleSet.sourcePath ?? 'embedded'})`,
+  printRunHeader(
+    ruleSet.rules.length,
+    ruleSet.sourcePath,
+    sessionId
+      ? `session ${sessionId}`
+      : `${reports.length} session${reports.length === 1 ? '' : 's'}`,
   );
 
   if (reports.length === 0) {
@@ -214,30 +251,31 @@ export async function runLeakScanCli(args: string[]): Promise<void> {
     return;
   }
 
-  let leaksFound = false;
-  let cleanHidden = 0;
-  for (const report of reports) {
-    if (report.totalMatches > 0) leaksFound = true;
-    // By default, suppress sessions with zero matches — most workspaces
-    // have many short clean sessions and the noise drowns the signal.
-    // `--all` (or asking for one specific session) restores them.
-    if (
-      report.totalMatches === 0 &&
-      report.errors.length === 0 &&
-      !showAll &&
-      !sessionId
-    ) {
-      cleanHidden += 1;
-      continue;
-    }
-    console.log(summarizeReport(report));
-    printReportDetail(report);
-  }
+  const leaksFound = reports.some((report) => report.totalMatches > 0);
 
-  if (cleanHidden > 0) {
-    console.log(
-      `(${cleanHidden} clean session${cleanHidden === 1 ? '' : 's'} hidden — pass --all to show)`,
-    );
+  if (effectiveVerbosity !== 'quiet') {
+    let cleanHidden = 0;
+    for (const report of reports) {
+      // `standard` suppresses sessions with zero matches — most workspaces
+      // have many short clean sessions and the noise drowns the signal.
+      // `all` restores them.
+      if (
+        effectiveVerbosity === 'standard' &&
+        report.totalMatches === 0 &&
+        report.errors.length === 0
+      ) {
+        cleanHidden += 1;
+        continue;
+      }
+      console.log(summarizeReport(report));
+      printReportDetail(report);
+    }
+
+    if (cleanHidden > 0) {
+      console.log(
+        `(${cleanHidden} clean session${cleanHidden === 1 ? '' : 's'} hidden — pass --all to show)`,
+      );
+    }
   }
 
   printSummaryFooter(reports);

--- a/src/audit/leak-scanner-cli.ts
+++ b/src/audit/leak-scanner-cli.ts
@@ -1,7 +1,9 @@
 import type { ConfidentialFinding } from '../security/confidential-redact.js';
 import { loadConfidentialRules } from '../security/confidential-rules.js';
 import {
+  directionForEventType,
   type LeakScanReport,
+  type PromptDirection,
   scanAllAuditSessionsForLeaks,
   scanAuditSessionForLeaks,
   summarizeLeakReports,
@@ -32,6 +34,25 @@ function highlightExcerpt(excerpt: string): string {
     `${ANSI_BOLD}${ANSI_RED}$1${ANSI_RESET}`,
   );
 }
+
+/**
+ * Format an ISO timestamp as `YYYY-MM-DD HH:MM:SS` (drop millis + `Z`).
+ * Seconds are precise enough for human review and the result lines up in
+ * fixed-width columns.
+ */
+function formatTimestamp(iso: string): string {
+  if (!iso) return '';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  const pad = (value: number): string => String(value).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+}
+
+const DIRECTION_LABEL: Record<PromptDirection, string> = {
+  in: 'in   (→ LLM)',
+  out: 'out  (← LLM)',
+  tool: 'tool (I/O)',
+};
 
 function summarizeReport(report: LeakScanReport): string {
   const tag = color(
@@ -66,12 +87,16 @@ function printReportDetail(report: LeakScanReport): void {
       severityColor(record.severity),
     );
     const placeholder = record.hadPlaceholder ? ' (post-dehydrate)' : '';
+    const direction = directionForEventType(record.eventType);
+    const dirTag = direction ? ` [${direction}]` : '';
     console.log(
-      `  #${record.seq} ${record.timestamp} ${record.eventType} ${sevTag} score=${record.score}${placeholder}`,
+      `  #${record.seq} ${formatTimestamp(record.timestamp)} ${record.eventType}${dirTag} ${sevTag} score=${record.score}${placeholder}`,
     );
     for (const finding of record.findings) {
+      // Print match=... explicitly so it stays visible when ANSI styling is
+      // stripped (e.g. when copying terminal output or piping through less).
       console.log(
-        `    - [${finding.sensitivity}] ${finding.kind}:${finding.label} ×${finding.matches}  ${highlightExcerpt(finding.excerpt)}`,
+        `    - [${finding.sensitivity}] ${finding.kind}:${finding.label} ×${finding.matches} match="${finding.match}"  ${highlightExcerpt(finding.excerpt)}`,
       );
     }
   }
@@ -79,24 +104,39 @@ function printReportDetail(report: LeakScanReport): void {
 
 function printSummaryFooter(reports: LeakScanReport[]): void {
   const summary = summarizeLeakReports(reports);
-  const order: ConfidentialFinding['sensitivity'][] = [
+  const sevOrder: ConfidentialFinding['sensitivity'][] = [
     'critical',
     'high',
     'medium',
     'low',
   ];
+  const dirOrder: PromptDirection[] = ['in', 'out', 'tool'];
   console.log('');
   console.log(
-    color('Summary', ANSI_BOLD) +
-      ` — ${summary.affectedSessions}/${summary.totalSessions} session${summary.totalSessions === 1 ? '' : 's'} affected, ${summary.totalMatches} match${summary.totalMatches === 1 ? '' : 'es'} total`,
+    `${color('Summary', ANSI_BOLD)} — ${summary.affectedSessions}/${summary.totalSessions} session${summary.totalSessions === 1 ? '' : 's'} affected, ${summary.totalMatches} match${summary.totalMatches === 1 ? '' : 'es'} total`,
   );
-  for (const severity of order) {
+  console.log('  By session severity:');
+  for (const severity of sevOrder) {
     const count = summary.bySeverity[severity];
     const label = color(
       severity.toUpperCase().padEnd(8),
       severityColor(severity),
     );
-    console.log(`  ${label} ${count} session${count === 1 ? '' : 's'}`);
+    console.log(`    ${label} ${count} session${count === 1 ? '' : 's'}`);
+  }
+  console.log('  By prompt direction:');
+  for (const dir of dirOrder) {
+    const totals = summary.byDirection[dir];
+    const label = DIRECTION_LABEL[dir].padEnd(13);
+    console.log(
+      `    ${label} ${totals.matches} match${totals.matches === 1 ? '' : 'es'} in ${totals.records} record${totals.records === 1 ? '' : 's'}`,
+    );
+  }
+  if (summary.byDirection.other.matches > 0) {
+    const totals = summary.byDirection.other;
+    console.log(
+      `    other         ${totals.matches} match${totals.matches === 1 ? '' : 'es'} in ${totals.records} record${totals.records === 1 ? '' : 's'}`,
+    );
   }
 }
 

--- a/src/audit/leak-scanner-cli.ts
+++ b/src/audit/leak-scanner-cli.ts
@@ -4,9 +4,11 @@ import {
   stripVerbosityFlags,
 } from '../cli/verbosity.js';
 import type { ConfidentialFinding } from '../security/confidential-redact.js';
+import type { ConfidentialKind } from '../security/confidential-rules.js';
 import { loadConfidentialRules } from '../security/confidential-rules.js';
 import {
   applyLeakReportFilter,
+  KIND_KEYS,
   type LeakScanReport,
   type PromptCategory,
   SEVERITY_LEVELS,
@@ -171,6 +173,14 @@ const CATEGORY_LABEL: Record<PromptCategory, string> = {
   url: 'url  (URLs)',
 };
 
+const KIND_LABEL: Record<ConfidentialKind, string> = {
+  client: 'client ',
+  project: 'project',
+  person: 'person ',
+  keyword: 'keyword',
+  pattern: 'pattern',
+};
+
 function summarizeReport(report: LeakScanReport): string {
   const tag = color(
     report.severity.toUpperCase().padEnd(8),
@@ -241,7 +251,7 @@ function printRunHeader(
   scope: string,
   filters: string | null,
 ): void {
-  printBanner('Audit Leak Scanner');
+  printBanner('Leak Scanner');
   console.log(`Rules: ${rulesLoaded} from ${rulesPath ?? 'embedded'}`);
   console.log(`Scope: ${scope}`);
   if (filters) console.log(`Filter: ${filters}`);
@@ -284,6 +294,15 @@ function printSummaryFooter(reports: LeakScanReport[]): void {
     const label = CATEGORY_LABEL[cat].padEnd(13);
     console.log(
       `  ${label} ${pluralize(totals.matches, 'match', 'matches')} in ${pluralize(totals.records, 'record', 'records')} in ${pluralize(totals.sessions, 'session', 'sessions')}`,
+    );
+  }
+  console.log('');
+  console.log('By rule kind:');
+  for (const kind of KIND_KEYS) {
+    const totals = summary.byKind[kind];
+    if (totals.matches === 0) continue;
+    console.log(
+      `  ${KIND_LABEL[kind]} ${pluralize(totals.matches, 'match', 'matches')} (${pluralize(totals.distinctLabels, 'rule', 'rules')}) in ${pluralize(totals.sessions, 'session', 'sessions')}`,
     );
   }
   console.log(SUMMARY_RULE);

--- a/src/audit/leak-scanner-cli.ts
+++ b/src/audit/leak-scanner-cli.ts
@@ -102,6 +102,7 @@ function printSummaryFooter(reports: LeakScanReport[]): void {
 
 export async function runLeakScanCli(args: string[]): Promise<void> {
   const useJson = args.includes('--json');
+  const showAll = args.includes('--all');
   const positional = args.filter((arg) => !arg.startsWith('--'));
   const sessionId = positional[0];
 
@@ -164,10 +165,29 @@ export async function runLeakScanCli(args: string[]): Promise<void> {
   }
 
   let leaksFound = false;
+  let cleanHidden = 0;
   for (const report of reports) {
-    console.log(summarizeReport(report));
     if (report.totalMatches > 0) leaksFound = true;
+    // By default, suppress sessions with zero matches — most workspaces
+    // have many short clean sessions and the noise drowns the signal.
+    // `--all` (or asking for one specific session) restores them.
+    if (
+      report.totalMatches === 0 &&
+      report.errors.length === 0 &&
+      !showAll &&
+      !sessionId
+    ) {
+      cleanHidden += 1;
+      continue;
+    }
+    console.log(summarizeReport(report));
     printReportDetail(report);
+  }
+
+  if (cleanHidden > 0) {
+    console.log(
+      `(${cleanHidden} clean session${cleanHidden === 1 ? '' : 's'} hidden — pass --all to show)`,
+    );
   }
 
   printSummaryFooter(reports);

--- a/src/audit/leak-scanner.ts
+++ b/src/audit/leak-scanner.ts
@@ -14,20 +14,28 @@ const WIRE_FILE_NAME = 'wire.jsonl';
 const PLACEHOLDER_RE = /«CONF:[A-Z0-9_-]+»/;
 
 /**
- * Direction of the text relative to the LLM:
+ * Where the leaking text lives relative to the LLM. Used to bucket the
+ * summary so reviewers can tell at a glance whether their leaks are user
+ * input, model output, tool I/O, or URL-shaped strings (which are easy
+ * to fix by sanitising the URL builder).
+ *
  *  - `in`   → user input that travels TO the LLM
  *  - `out`  → text the LLM emitted (or a system prompt sent on its behalf)
  *  - `tool` → tool I/O (call args + tool results, including skill steps)
+ *  - `url`  → match falls inside a URL/markdown link, regardless of event
  *
- * Tool I/O is its own bucket rather than being lumped under in/out because
- * it is the most common leak surface (tool results from web fetches,
- * memory lookups, etc. often carry confidential strings) and because the
- * mitigation differs (tighter tool-result redaction vs. user-prompt
- * coaching).
+ * URL is its own bucket because URLs are the most common leak surface in
+ * tool output (search results, fetched pages) and the cheapest mitigation
+ * is "redact URL paths" rather than "rewrite the prompt".
  */
-export type PromptDirection = 'in' | 'out' | 'tool';
+export type PromptCategory = 'in' | 'out' | 'tool' | 'url';
 
-const EVENT_TYPE_DIRECTIONS: Record<string, PromptDirection> = {
+/**
+ * @deprecated kept as an alias during migration; prefer {@link PromptCategory}.
+ */
+export type PromptDirection = PromptCategory;
+
+const EVENT_TYPE_DIRECTIONS: Record<string, Exclude<PromptCategory, 'url'>> = {
   'turn.start': 'in',
   prompt: 'in',
   message: 'in',
@@ -40,6 +48,44 @@ const EVENT_TYPE_DIRECTIONS: Record<string, PromptDirection> = {
   'skill.execution': 'tool',
   'skill.inspection': 'tool',
 };
+
+/**
+ * Per event type, the set of fields whose values carry actual prompt
+ * content. Only these fields are scanned, which avoids false positives
+ * from metadata fields like `provider`, `toolName`, `username`, etc.
+ *
+ * For `arguments` (a nested object on `tool.call`), we recurse into all
+ * string values within — the schema is open-ended.
+ */
+const PROMPT_TEXT_FIELDS_BY_TYPE: Record<string, ReadonlyArray<string>> = {
+  'turn.start': ['userInput', 'rawUserInput', 'content', 'text'],
+  'turn.end': ['text', 'output', 'result', 'summary', 'response', 'content'],
+  'tool.call': ['arguments'],
+  'tool.result': [
+    'resultSummary',
+    'output',
+    'result',
+    'content',
+    'summary',
+    'text',
+  ],
+  'approval.request': ['description', 'reason'],
+  prompt: ['content', 'text', 'system', 'systemPrompt'],
+  message: ['content', 'text'],
+  text: ['text', 'content'],
+  thinking: ['text', 'content'],
+  'skill.execution': ['prompt', 'result', 'output', 'text'],
+  'skill.inspection': ['prompt', 'result', 'output', 'text'],
+};
+
+/**
+ * Detects URLs and markdown link targets in scanned text. Catches:
+ *  - bare URLs:                 `https://example.com/path?q=1`
+ *  - markdown relative links:   `[label](/path/to/thing#anchor)`
+ *  - markdown absolute links:   `[label](https://example.com)`
+ */
+const URL_SPAN_RE =
+  /(?:https?:\/\/[^\s<>"'`]+|\]\(([^)]+)\)|\((\/[^()\s]+)\))/g;
 
 /**
  * Event types whose payload contains text that travels to or from the LLM,
@@ -56,8 +102,30 @@ export const PROMPT_BEARING_EVENT_TYPES: ReadonlySet<string> = new Set(
 
 export function directionForEventType(
   eventType: string,
-): PromptDirection | null {
+): Exclude<PromptCategory, 'url'> | null {
   return EVENT_TYPE_DIRECTIONS[eventType] ?? null;
+}
+
+function findUrlSpans(text: string): { start: number; end: number }[] {
+  const spans: { start: number; end: number }[] = [];
+  URL_SPAN_RE.lastIndex = 0;
+  let match: RegExpExecArray | null = URL_SPAN_RE.exec(text);
+  while (match) {
+    spans.push({ start: match.index, end: match.index + match[0].length });
+    if (URL_SPAN_RE.lastIndex === match.index) URL_SPAN_RE.lastIndex += 1;
+    match = URL_SPAN_RE.exec(text);
+  }
+  return spans;
+}
+
+function indexFallsInsideAnySpan(
+  index: number,
+  spans: { start: number; end: number }[],
+): boolean {
+  for (const span of spans) {
+    if (index >= span.start && index < span.end) return true;
+  }
+  return false;
 }
 
 function resolveScanEventTypes(): ReadonlySet<string> {
@@ -83,6 +151,8 @@ export interface LeakScanRecord {
   severity: ConfidentialFinding['sensitivity'];
   /** True when the source text already contained a confidential placeholder (i.e. dehydration had run). */
   hadPlaceholder: boolean;
+  /** Bucket for the summary footer: in/out/tool by event direction, or url when the match falls inside a URL/markdown link. */
+  category: PromptCategory;
 }
 
 export interface LeakScanReport {
@@ -150,6 +220,19 @@ function collectStringValues(value: unknown, into: string[]): void {
   }
 }
 
+function collectPromptText(
+  event: Record<string, unknown>,
+  fields: ReadonlyArray<string>,
+): string[] {
+  const out: string[] = [];
+  for (const field of fields) {
+    if (field in event) {
+      collectStringValues(event[field], out);
+    }
+  }
+  return out;
+}
+
 interface WireRecord {
   seq?: number;
   timestamp?: string;
@@ -171,17 +254,58 @@ function parseWireLine(line: string): WireRecord | null {
 function scanRecordForLeaks(
   record: WireRecord,
   ruleSet: ConfidentialRuleSet,
-): { result: ConfidentialScanResult; hadPlaceholder: boolean } | null {
+): {
+  result: ConfidentialScanResult;
+  hadPlaceholder: boolean;
+  combinedText: string;
+} | null {
   const event = record.event;
   if (!event || typeof event !== 'object') return null;
-  const strings: string[] = [];
-  collectStringValues(event, strings);
+  const eventType = typeof event.type === 'string' ? event.type : '';
+  const fields = PROMPT_TEXT_FIELDS_BY_TYPE[eventType];
+  // Unknown event types fall back to the field whitelist union, which
+  // catches the common content-bearing field names without dragging in
+  // metadata like `provider`, `username`, `toolName`.
+  const fallbackFields = [
+    'content',
+    'text',
+    'output',
+    'result',
+    'summary',
+    'description',
+    'reason',
+    'prompt',
+    'userInput',
+    'rawUserInput',
+  ];
+  const strings = collectPromptText(
+    event as Record<string, unknown>,
+    fields ?? fallbackFields,
+  );
   if (strings.length === 0) return null;
-  const combined = strings.join('\n');
-  const hadPlaceholder = PLACEHOLDER_RE.test(combined);
-  const result = scanForLeaks(combined, ruleSet);
+  const combinedText = strings.join('\n');
+  const hadPlaceholder = PLACEHOLDER_RE.test(combinedText);
+  const result = scanForLeaks(combinedText, ruleSet);
   if (result.totalMatches === 0) return null;
-  return { result, hadPlaceholder };
+  return { result, hadPlaceholder, combinedText };
+}
+
+function categoryForRecord(
+  eventType: string,
+  combinedText: string,
+  findings: ConfidentialFinding[],
+): PromptCategory {
+  const urlSpans = findUrlSpans(combinedText);
+  if (urlSpans.length > 0) {
+    for (const finding of findings) {
+      if (!finding.match) continue;
+      const idx = combinedText.indexOf(finding.match);
+      if (idx >= 0 && indexFallsInsideAnySpan(idx, urlSpans)) {
+        return 'url';
+      }
+    }
+  }
+  return directionForEventType(eventType) ?? 'tool';
 }
 
 function listAuditSessionIds(auditRoot: string): string[] {
@@ -294,6 +418,11 @@ export function scanAuditSessionForLeaks(
       score: scan.result.score,
       severity: scan.result.severity,
       hadPlaceholder: scan.hadPlaceholder,
+      category: categoryForRecord(
+        eventType,
+        scan.combinedText,
+        scan.result.findings,
+      ),
     });
     totalMatches += scan.result.totalMatches;
     aggregateRaw += scan.result.rawScore;
@@ -328,18 +457,27 @@ export function scanAllAuditSessionsForLeaks(
   );
 }
 
-export interface DirectionTotals {
-  /** Number of matched audit records bucketed in this direction. */
+export interface CategoryTotals {
+  /** Number of matched audit records bucketed in this category. */
   records: number;
   /** Sum of matches inside those records. */
   matches: number;
+  /** Number of distinct sessions in which this category appeared. */
+  sessions: number;
 }
+
+const CATEGORY_KEYS: ReadonlyArray<PromptCategory> = [
+  'in',
+  'out',
+  'tool',
+  'url',
+];
 
 export function summarizeLeakReports(reports: LeakScanReport[]): {
   bySeverity: Record<ConfidentialFinding['sensitivity'], number>;
-  byDirection: Record<PromptDirection, DirectionTotals> & {
-    other: DirectionTotals;
-  };
+  byCategory: Record<PromptCategory, CategoryTotals>;
+  /** @deprecated alias for {@link byCategory}; remove after callers migrate. */
+  byDirection: Record<PromptCategory, CategoryTotals>;
   totalMatches: number;
   totalSessions: number;
   affectedSessions: number;
@@ -350,13 +488,17 @@ export function summarizeLeakReports(reports: LeakScanReport[]): {
     medium: 0,
     low: 0,
   };
-  const byDirection: Record<PromptDirection, DirectionTotals> & {
-    other: DirectionTotals;
-  } = {
-    in: { records: 0, matches: 0 },
-    out: { records: 0, matches: 0 },
-    tool: { records: 0, matches: 0 },
-    other: { records: 0, matches: 0 },
+  const byCategory: Record<PromptCategory, CategoryTotals> = {
+    in: { records: 0, matches: 0, sessions: 0 },
+    out: { records: 0, matches: 0, sessions: 0 },
+    tool: { records: 0, matches: 0, sessions: 0 },
+    url: { records: 0, matches: 0, sessions: 0 },
+  };
+  const sessionsSeenByCategory: Record<PromptCategory, Set<string>> = {
+    in: new Set(),
+    out: new Set(),
+    tool: new Set(),
+    url: new Set(),
   };
   let totalMatches = 0;
   let affectedSessions = 0;
@@ -367,14 +509,19 @@ export function summarizeLeakReports(reports: LeakScanReport[]): {
       bySeverity[report.severity] += 1;
     }
     for (const record of report.matchedRecords) {
-      const bucket = directionForEventType(record.eventType) ?? 'other';
-      byDirection[bucket].records += 1;
-      byDirection[bucket].matches += record.totalMatches;
+      const bucket = record.category;
+      byCategory[bucket].records += 1;
+      byCategory[bucket].matches += record.totalMatches;
+      sessionsSeenByCategory[bucket].add(report.sessionId);
     }
+  }
+  for (const key of CATEGORY_KEYS) {
+    byCategory[key].sessions = sessionsSeenByCategory[key].size;
   }
   return {
     bySeverity,
-    byDirection,
+    byCategory,
+    byDirection: byCategory,
     totalMatches,
     totalSessions: reports.length,
     affectedSessions,

--- a/src/audit/leak-scanner.ts
+++ b/src/audit/leak-scanner.ts
@@ -7,7 +7,10 @@ import {
   type ConfidentialScanResult,
   scanForLeaks,
 } from '../security/confidential-redact.js';
-import type { ConfidentialRuleSet } from '../security/confidential-rules.js';
+import type {
+  ConfidentialKind,
+  ConfidentialRuleSet,
+} from '../security/confidential-rules.js';
 
 const AUDIT_DIR_NAME = 'audit';
 const WIRE_FILE_NAME = 'wire.jsonl';
@@ -523,6 +526,17 @@ export interface CategoryTotals {
   sessions: number;
 }
 
+export interface KindTotals {
+  /** Sum of finding.matches across all findings of this kind. */
+  matches: number;
+  /** Number of records that contain at least one finding of this kind. */
+  records: number;
+  /** Number of distinct sessions in which this kind appeared. */
+  sessions: number;
+  /** Number of distinct rule labels (e.g. distinct client names) hit. */
+  distinctLabels: number;
+}
+
 const CATEGORY_KEYS: ReadonlyArray<PromptCategory> = [
   'in',
   'out',
@@ -530,9 +544,18 @@ const CATEGORY_KEYS: ReadonlyArray<PromptCategory> = [
   'url',
 ];
 
+export const KIND_KEYS: ReadonlyArray<ConfidentialKind> = [
+  'client',
+  'project',
+  'person',
+  'keyword',
+  'pattern',
+];
+
 export function summarizeLeakReports(reports: LeakScanReport[]): {
   bySeverity: Record<ConfidentialFinding['sensitivity'], number>;
   byCategory: Record<PromptCategory, CategoryTotals>;
+  byKind: Record<ConfidentialKind, KindTotals>;
   /** @deprecated alias for {@link byCategory}; remove after callers migrate. */
   byDirection: Record<PromptCategory, CategoryTotals>;
   totalMatches: number;
@@ -557,6 +580,27 @@ export function summarizeLeakReports(reports: LeakScanReport[]): {
     tool: new Set(),
     url: new Set(),
   };
+  const byKind: Record<ConfidentialKind, KindTotals> = {
+    client: { matches: 0, records: 0, sessions: 0, distinctLabels: 0 },
+    project: { matches: 0, records: 0, sessions: 0, distinctLabels: 0 },
+    person: { matches: 0, records: 0, sessions: 0, distinctLabels: 0 },
+    keyword: { matches: 0, records: 0, sessions: 0, distinctLabels: 0 },
+    pattern: { matches: 0, records: 0, sessions: 0, distinctLabels: 0 },
+  };
+  const sessionsSeenByKind: Record<ConfidentialKind, Set<string>> = {
+    client: new Set(),
+    project: new Set(),
+    person: new Set(),
+    keyword: new Set(),
+    pattern: new Set(),
+  };
+  const labelsSeenByKind: Record<ConfidentialKind, Set<string>> = {
+    client: new Set(),
+    project: new Set(),
+    person: new Set(),
+    keyword: new Set(),
+    pattern: new Set(),
+  };
   let totalMatches = 0;
   let affectedSessions = 0;
   for (const report of reports) {
@@ -570,14 +614,34 @@ export function summarizeLeakReports(reports: LeakScanReport[]): {
       byCategory[bucket].records += 1;
       byCategory[bucket].matches += record.totalMatches;
       sessionsSeenByCategory[bucket].add(report.sessionId);
+
+      const kindsInRecord = new Set<ConfidentialKind>();
+      for (const finding of record.findings) {
+        const kind = finding.kind as ConfidentialKind;
+        byKind[kind].matches += finding.matches;
+        kindsInRecord.add(kind);
+        sessionsSeenByKind[kind].add(report.sessionId);
+        labelsSeenByKind[kind].add(finding.label);
+      }
+      // A record contributes to byKind[k].records once per distinct
+      // kind it touches, regardless of how many findings of that kind
+      // it carries.
+      for (const kind of kindsInRecord) {
+        byKind[kind].records += 1;
+      }
     }
   }
   for (const key of CATEGORY_KEYS) {
     byCategory[key].sessions = sessionsSeenByCategory[key].size;
   }
+  for (const key of KIND_KEYS) {
+    byKind[key].sessions = sessionsSeenByKind[key].size;
+    byKind[key].distinctLabels = labelsSeenByKind[key].size;
+  }
   return {
     bySeverity,
     byCategory,
+    byKind,
     byDirection: byCategory,
     totalMatches,
     totalSessions: reports.length,

--- a/src/audit/leak-scanner.ts
+++ b/src/audit/leak-scanner.ts
@@ -13,6 +13,39 @@ const AUDIT_DIR_NAME = 'audit';
 const WIRE_FILE_NAME = 'wire.jsonl';
 const PLACEHOLDER_RE = /«CONF:[A-Z0-9_-]+»/;
 
+/**
+ * Event types whose payload contains text that travels to or from the LLM,
+ * and is therefore worth scanning for confidential-info leaks.
+ *
+ * Telemetry/lifecycle/auth events are intentionally excluded — e.g.
+ * `model.usage` payloads contain provider names like "HybridAI" as field
+ * values, which would generate noisy false positives against a rule that
+ * names HybridAI as a confidential client.
+ */
+export const PROMPT_BEARING_EVENT_TYPES: ReadonlySet<string> = new Set([
+  'turn.start',
+  'turn.end',
+  'tool.call',
+  'tool.result',
+  'approval.request',
+  'prompt',
+  'message',
+  'text',
+  'thinking',
+  'skill.execution',
+  'skill.inspection',
+]);
+
+function resolveScanEventTypes(): ReadonlySet<string> {
+  const override = (process.env.HYBRIDCLAW_LEAK_SCAN_EVENT_TYPES || '').trim();
+  if (!override) return PROMPT_BEARING_EVENT_TYPES;
+  const types = override
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  return types.length > 0 ? new Set(types) : PROMPT_BEARING_EVENT_TYPES;
+}
+
 export interface LeakScanRecord {
   seq: number;
   timestamp: string;
@@ -32,6 +65,8 @@ export interface LeakScanReport {
   sessionId: string;
   filePath: string;
   recordsScanned: number;
+  /** Number of records skipped because their event.type is not prompt-bearing. */
+  recordsSkippedByType: number;
   matchedRecords: LeakScanRecord[];
   totalMatches: number;
   /** sum of per-record raw scores, capped at 1000 then normalized to 0-100 */
@@ -39,6 +74,11 @@ export interface LeakScanReport {
   score: number;
   severity: ConfidentialFinding['sensitivity'];
   errors: string[];
+}
+
+export interface LeakScanOptions {
+  /** Override the default {@link PROMPT_BEARING_EVENT_TYPES} whitelist. */
+  scanEventTypes?: ReadonlySet<string>;
 }
 
 const SEVERITY_RANK: Record<ConfidentialFinding['sensitivity'], number> = {
@@ -150,7 +190,9 @@ export function scanAuditSessionForLeaks(
   sessionId: string,
   ruleSet: ConfidentialRuleSet,
   dataDir: string = DATA_DIR,
+  options: LeakScanOptions = {},
 ): LeakScanReport {
+  const scanTypes = options.scanEventTypes ?? resolveScanEventTypes();
   const safeId = sessionId.trim().replace(/[^a-zA-Z0-9_-]/g, '_') || 'session';
   const filePath = path.join(dataDir, AUDIT_DIR_NAME, safeId, WIRE_FILE_NAME);
   const errors: string[] = [];
@@ -160,6 +202,7 @@ export function scanAuditSessionForLeaks(
       sessionId,
       filePath,
       recordsScanned: 0,
+      recordsSkippedByType: 0,
       matchedRecords: [],
       totalMatches: 0,
       rawScore: 0,
@@ -177,6 +220,7 @@ export function scanAuditSessionForLeaks(
       sessionId,
       filePath,
       recordsScanned: 0,
+      recordsSkippedByType: 0,
       matchedRecords: [],
       totalMatches: 0,
       rawScore: 0,
@@ -195,6 +239,7 @@ export function scanAuditSessionForLeaks(
 
   const matched: LeakScanRecord[] = [];
   let recordsScanned = 0;
+  let recordsSkippedByType = 0;
   let totalMatches = 0;
   let aggregateRaw = 0;
   let severity: ConfidentialFinding['sensitivity'] = 'low';
@@ -202,6 +247,12 @@ export function scanAuditSessionForLeaks(
   for (let i = 0; i < lines.length; i++) {
     const parsed = parseWireLine(lines[i]);
     if (!parsed || !parsed.event) continue;
+    const eventType =
+      typeof parsed.event?.type === 'string' ? parsed.event.type : 'unknown';
+    if (!scanTypes.has(eventType)) {
+      recordsSkippedByType += 1;
+      continue;
+    }
     recordsScanned += 1;
     const scan = scanRecordForLeaks(parsed, ruleSet);
     if (!scan) continue;
@@ -212,8 +263,7 @@ export function scanAuditSessionForLeaks(
       runId: typeof parsed.runId === 'string' ? parsed.runId : '',
       parentRunId:
         typeof parsed.parentRunId === 'string' ? parsed.parentRunId : undefined,
-      eventType:
-        typeof parsed.event?.type === 'string' ? parsed.event.type : 'unknown',
+      eventType,
       findings: scan.result.findings,
       totalMatches: scan.result.totalMatches,
       rawScore: scan.result.rawScore,
@@ -231,6 +281,7 @@ export function scanAuditSessionForLeaks(
     sessionId,
     filePath,
     recordsScanned,
+    recordsSkippedByType,
     matchedRecords: matched,
     totalMatches,
     rawScore: aggregate.rawScore,
@@ -246,8 +297,38 @@ export function scanAuditSessionForLeaks(
 export function scanAllAuditSessionsForLeaks(
   ruleSet: ConfidentialRuleSet,
   dataDir: string = DATA_DIR,
+  options: LeakScanOptions = {},
 ): LeakScanReport[] {
   return listAuditedSessions(dataDir).map(({ sessionId }) =>
-    scanAuditSessionForLeaks(sessionId, ruleSet, dataDir),
+    scanAuditSessionForLeaks(sessionId, ruleSet, dataDir, options),
   );
+}
+
+export function summarizeLeakReports(reports: LeakScanReport[]): {
+  bySeverity: Record<ConfidentialFinding['sensitivity'], number>;
+  totalMatches: number;
+  totalSessions: number;
+  affectedSessions: number;
+} {
+  const bySeverity: Record<ConfidentialFinding['sensitivity'], number> = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+  };
+  let totalMatches = 0;
+  let affectedSessions = 0;
+  for (const report of reports) {
+    totalMatches += report.totalMatches;
+    if (report.totalMatches > 0) {
+      affectedSessions += 1;
+      bySeverity[report.severity] += 1;
+    }
+  }
+  return {
+    bySeverity,
+    totalMatches,
+    totalSessions: reports.length,
+    affectedSessions,
+  };
 }

--- a/src/audit/leak-scanner.ts
+++ b/src/audit/leak-scanner.ts
@@ -1,0 +1,253 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { DATA_DIR } from '../config/config.js';
+import {
+  type ConfidentialFinding,
+  type ConfidentialScanResult,
+  scanForLeaks,
+} from '../security/confidential-redact.js';
+import type { ConfidentialRuleSet } from '../security/confidential-rules.js';
+
+const AUDIT_DIR_NAME = 'audit';
+const WIRE_FILE_NAME = 'wire.jsonl';
+const PLACEHOLDER_RE = /«CONF:[A-Z0-9_-]+»/;
+
+export interface LeakScanRecord {
+  seq: number;
+  timestamp: string;
+  runId: string;
+  parentRunId?: string;
+  eventType: string;
+  findings: ConfidentialFinding[];
+  totalMatches: number;
+  rawScore: number;
+  score: number;
+  severity: ConfidentialFinding['sensitivity'];
+  /** True when the source text already contained a confidential placeholder (i.e. dehydration had run). */
+  hadPlaceholder: boolean;
+}
+
+export interface LeakScanReport {
+  sessionId: string;
+  filePath: string;
+  recordsScanned: number;
+  matchedRecords: LeakScanRecord[];
+  totalMatches: number;
+  /** sum of per-record raw scores, capped at 1000 then normalized to 0-100 */
+  rawScore: number;
+  score: number;
+  severity: ConfidentialFinding['sensitivity'];
+  errors: string[];
+}
+
+const SEVERITY_RANK: Record<ConfidentialFinding['sensitivity'], number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+  critical: 3,
+};
+
+function rankSeverity(
+  current: ConfidentialFinding['sensitivity'],
+  next: ConfidentialFinding['sensitivity'],
+): ConfidentialFinding['sensitivity'] {
+  return SEVERITY_RANK[next] > SEVERITY_RANK[current] ? next : current;
+}
+
+function bucketScore(rawScore: number): {
+  rawScore: number;
+  score: number;
+  severity: ConfidentialFinding['sensitivity'];
+} {
+  const capped = Math.min(rawScore, 1000);
+  const score = Math.round((capped / 1000) * 100);
+  let severity: ConfidentialFinding['sensitivity'] = 'low';
+  if (capped >= 100) severity = 'critical';
+  else if (capped >= 30) severity = 'high';
+  else if (capped >= 10) severity = 'medium';
+  return { rawScore: capped, score, severity };
+}
+
+function collectStringValues(value: unknown, into: string[]): void {
+  if (value == null) return;
+  if (typeof value === 'string') {
+    if (value) into.push(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) collectStringValues(entry, into);
+    return;
+  }
+  if (typeof value === 'object') {
+    for (const entry of Object.values(value as Record<string, unknown>)) {
+      collectStringValues(entry, into);
+    }
+  }
+}
+
+interface WireRecord {
+  seq?: number;
+  timestamp?: string;
+  runId?: string;
+  parentRunId?: string;
+  event?: { type?: string; [key: string]: unknown };
+}
+
+function parseWireLine(line: string): WireRecord | null {
+  try {
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    if (!parsed || typeof parsed !== 'object') return null;
+    return parsed as WireRecord;
+  } catch {
+    return null;
+  }
+}
+
+function scanRecordForLeaks(
+  record: WireRecord,
+  ruleSet: ConfidentialRuleSet,
+): { result: ConfidentialScanResult; hadPlaceholder: boolean } | null {
+  const event = record.event;
+  if (!event || typeof event !== 'object') return null;
+  const strings: string[] = [];
+  collectStringValues(event, strings);
+  if (strings.length === 0) return null;
+  const combined = strings.join('\n');
+  const hadPlaceholder = PLACEHOLDER_RE.test(combined);
+  const result = scanForLeaks(combined, ruleSet);
+  if (result.totalMatches === 0) return null;
+  return { result, hadPlaceholder };
+}
+
+function listAuditSessionIds(auditRoot: string): string[] {
+  if (!fs.existsSync(auditRoot)) return [];
+  try {
+    const entries = fs.readdirSync(auditRoot, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .filter((name) =>
+        fs.existsSync(path.join(auditRoot, name, WIRE_FILE_NAME)),
+      )
+      .sort((a, b) => a.localeCompare(b));
+  } catch {
+    return [];
+  }
+}
+
+export function listAuditedSessions(
+  dataDir: string = DATA_DIR,
+): { sessionId: string; filePath: string }[] {
+  const auditRoot = path.join(dataDir, AUDIT_DIR_NAME);
+  return listAuditSessionIds(auditRoot).map((sessionId) => ({
+    sessionId,
+    filePath: path.join(auditRoot, sessionId, WIRE_FILE_NAME),
+  }));
+}
+
+export function scanAuditSessionForLeaks(
+  sessionId: string,
+  ruleSet: ConfidentialRuleSet,
+  dataDir: string = DATA_DIR,
+): LeakScanReport {
+  const safeId = sessionId.trim().replace(/[^a-zA-Z0-9_-]/g, '_') || 'session';
+  const filePath = path.join(dataDir, AUDIT_DIR_NAME, safeId, WIRE_FILE_NAME);
+  const errors: string[] = [];
+
+  if (!fs.existsSync(filePath)) {
+    return {
+      sessionId,
+      filePath,
+      recordsScanned: 0,
+      matchedRecords: [],
+      totalMatches: 0,
+      rawScore: 0,
+      score: 0,
+      severity: 'low',
+      errors: [`wire log not found: ${filePath}`],
+    };
+  }
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf-8');
+  } catch (error) {
+    return {
+      sessionId,
+      filePath,
+      recordsScanned: 0,
+      matchedRecords: [],
+      totalMatches: 0,
+      rawScore: 0,
+      score: 0,
+      severity: 'low',
+      errors: [
+        `failed to read wire log: ${error instanceof Error ? error.message : String(error)}`,
+      ],
+    };
+  }
+
+  const lines = raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const matched: LeakScanRecord[] = [];
+  let recordsScanned = 0;
+  let totalMatches = 0;
+  let aggregateRaw = 0;
+  let severity: ConfidentialFinding['sensitivity'] = 'low';
+
+  for (let i = 0; i < lines.length; i++) {
+    const parsed = parseWireLine(lines[i]);
+    if (!parsed || !parsed.event) continue;
+    recordsScanned += 1;
+    const scan = scanRecordForLeaks(parsed, ruleSet);
+    if (!scan) continue;
+
+    matched.push({
+      seq: typeof parsed.seq === 'number' ? parsed.seq : i,
+      timestamp: typeof parsed.timestamp === 'string' ? parsed.timestamp : '',
+      runId: typeof parsed.runId === 'string' ? parsed.runId : '',
+      parentRunId:
+        typeof parsed.parentRunId === 'string' ? parsed.parentRunId : undefined,
+      eventType:
+        typeof parsed.event?.type === 'string' ? parsed.event.type : 'unknown',
+      findings: scan.result.findings,
+      totalMatches: scan.result.totalMatches,
+      rawScore: scan.result.rawScore,
+      score: scan.result.score,
+      severity: scan.result.severity,
+      hadPlaceholder: scan.hadPlaceholder,
+    });
+    totalMatches += scan.result.totalMatches;
+    aggregateRaw += scan.result.rawScore;
+    severity = rankSeverity(severity, scan.result.severity);
+  }
+
+  const aggregate = bucketScore(aggregateRaw);
+  return {
+    sessionId,
+    filePath,
+    recordsScanned,
+    matchedRecords: matched,
+    totalMatches,
+    rawScore: aggregate.rawScore,
+    score: aggregate.score,
+    severity:
+      SEVERITY_RANK[aggregate.severity] > SEVERITY_RANK[severity]
+        ? aggregate.severity
+        : severity,
+    errors,
+  };
+}
+
+export function scanAllAuditSessionsForLeaks(
+  ruleSet: ConfidentialRuleSet,
+  dataDir: string = DATA_DIR,
+): LeakScanReport[] {
+  return listAuditedSessions(dataDir).map(({ sessionId }) =>
+    scanAuditSessionForLeaks(sessionId, ruleSet, dataDir),
+  );
+}

--- a/src/audit/leak-scanner.ts
+++ b/src/audit/leak-scanner.ts
@@ -14,6 +14,34 @@ const WIRE_FILE_NAME = 'wire.jsonl';
 const PLACEHOLDER_RE = /«CONF:[A-Z0-9_-]+»/;
 
 /**
+ * Direction of the text relative to the LLM:
+ *  - `in`   → user input that travels TO the LLM
+ *  - `out`  → text the LLM emitted (or a system prompt sent on its behalf)
+ *  - `tool` → tool I/O (call args + tool results, including skill steps)
+ *
+ * Tool I/O is its own bucket rather than being lumped under in/out because
+ * it is the most common leak surface (tool results from web fetches,
+ * memory lookups, etc. often carry confidential strings) and because the
+ * mitigation differs (tighter tool-result redaction vs. user-prompt
+ * coaching).
+ */
+export type PromptDirection = 'in' | 'out' | 'tool';
+
+const EVENT_TYPE_DIRECTIONS: Record<string, PromptDirection> = {
+  'turn.start': 'in',
+  prompt: 'in',
+  message: 'in',
+  'turn.end': 'out',
+  text: 'out',
+  thinking: 'out',
+  'approval.request': 'out',
+  'tool.call': 'tool',
+  'tool.result': 'tool',
+  'skill.execution': 'tool',
+  'skill.inspection': 'tool',
+};
+
+/**
  * Event types whose payload contains text that travels to or from the LLM,
  * and is therefore worth scanning for confidential-info leaks.
  *
@@ -22,19 +50,15 @@ const PLACEHOLDER_RE = /«CONF:[A-Z0-9_-]+»/;
  * values, which would generate noisy false positives against a rule that
  * names HybridAI as a confidential client.
  */
-export const PROMPT_BEARING_EVENT_TYPES: ReadonlySet<string> = new Set([
-  'turn.start',
-  'turn.end',
-  'tool.call',
-  'tool.result',
-  'approval.request',
-  'prompt',
-  'message',
-  'text',
-  'thinking',
-  'skill.execution',
-  'skill.inspection',
-]);
+export const PROMPT_BEARING_EVENT_TYPES: ReadonlySet<string> = new Set(
+  Object.keys(EVENT_TYPE_DIRECTIONS),
+);
+
+export function directionForEventType(
+  eventType: string,
+): PromptDirection | null {
+  return EVENT_TYPE_DIRECTIONS[eventType] ?? null;
+}
 
 function resolveScanEventTypes(): ReadonlySet<string> {
   const override = (process.env.HYBRIDCLAW_LEAK_SCAN_EVENT_TYPES || '').trim();
@@ -304,8 +328,18 @@ export function scanAllAuditSessionsForLeaks(
   );
 }
 
+export interface DirectionTotals {
+  /** Number of matched audit records bucketed in this direction. */
+  records: number;
+  /** Sum of matches inside those records. */
+  matches: number;
+}
+
 export function summarizeLeakReports(reports: LeakScanReport[]): {
   bySeverity: Record<ConfidentialFinding['sensitivity'], number>;
+  byDirection: Record<PromptDirection, DirectionTotals> & {
+    other: DirectionTotals;
+  };
   totalMatches: number;
   totalSessions: number;
   affectedSessions: number;
@@ -316,6 +350,14 @@ export function summarizeLeakReports(reports: LeakScanReport[]): {
     medium: 0,
     low: 0,
   };
+  const byDirection: Record<PromptDirection, DirectionTotals> & {
+    other: DirectionTotals;
+  } = {
+    in: { records: 0, matches: 0 },
+    out: { records: 0, matches: 0 },
+    tool: { records: 0, matches: 0 },
+    other: { records: 0, matches: 0 },
+  };
   let totalMatches = 0;
   let affectedSessions = 0;
   for (const report of reports) {
@@ -324,9 +366,15 @@ export function summarizeLeakReports(reports: LeakScanReport[]): {
       affectedSessions += 1;
       bySeverity[report.severity] += 1;
     }
+    for (const record of report.matchedRecords) {
+      const bucket = directionForEventType(record.eventType) ?? 'other';
+      byDirection[bucket].records += 1;
+      byDirection[bucket].matches += record.totalMatches;
+    }
   }
   return {
     bySeverity,
+    byDirection,
     totalMatches,
     totalSessions: reports.length,
     affectedSessions,

--- a/src/audit/leak-scanner.ts
+++ b/src/audit/leak-scanner.ts
@@ -182,6 +182,63 @@ const SEVERITY_RANK: Record<ConfidentialFinding['sensitivity'], number> = {
   critical: 3,
 };
 
+export const SEVERITY_LEVELS: ReadonlyArray<
+  ConfidentialFinding['sensitivity']
+> = ['low', 'medium', 'high', 'critical'];
+
+export interface LeakReportFilter {
+  /** Floor severity — keep only records whose severity is at or above this. */
+  minSeverity?: ConfidentialFinding['sensitivity'];
+  /** Allow-list of categories — keep only records bucketed in one of these. */
+  categories?: ReadonlySet<PromptCategory>;
+}
+
+/**
+ * Apply post-scan filters to reports without re-scanning the wire log.
+ * Records that fail the filter are removed; per-session totals (matches,
+ * raw score, score, severity) are recomputed against the surviving set.
+ */
+export function applyLeakReportFilter(
+  reports: LeakScanReport[],
+  filter: LeakReportFilter,
+): LeakScanReport[] {
+  const minRank = filter.minSeverity ? SEVERITY_RANK[filter.minSeverity] : null;
+  const categories = filter.categories;
+  if (minRank == null && !categories) return reports;
+
+  return reports.map((report) => {
+    const survivors = report.matchedRecords.filter((record) => {
+      if (minRank != null && SEVERITY_RANK[record.severity] < minRank) {
+        return false;
+      }
+      if (categories && !categories.has(record.category)) return false;
+      return true;
+    });
+    if (survivors.length === report.matchedRecords.length) return report;
+
+    let totalMatches = 0;
+    let aggregateRaw = 0;
+    let severity: ConfidentialFinding['sensitivity'] = 'low';
+    for (const record of survivors) {
+      totalMatches += record.totalMatches;
+      aggregateRaw += record.rawScore;
+      severity = rankSeverity(severity, record.severity);
+    }
+    const aggregate = bucketScore(aggregateRaw);
+    return {
+      ...report,
+      matchedRecords: survivors,
+      totalMatches,
+      rawScore: aggregate.rawScore,
+      score: aggregate.score,
+      severity:
+        SEVERITY_RANK[aggregate.severity] > SEVERITY_RANK[severity]
+          ? aggregate.severity
+          : severity,
+    };
+  });
+}
+
 function rankSeverity(
   current: ConfidentialFinding['sensitivity'],
   next: ConfidentialFinding['sensitivity'],

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -537,7 +537,7 @@ Commands:
   search <query> [n]                 Search structured audit events
   approvals [n] [--denied]           Show approval decisions
   verify <sessionId>                 Verify wire hash chain integrity
-  scan-leaks [sessionId] [--json]    Scan audit logs against ~/.hybridclaw/.confidential.yml for confidential-info leaks
+  scan-leaks [sessionId] [--json]    Scan audit logs for confidential-info leaks (rules from ./.confidential.yml or ~/.hybridclaw/.confidential.yml)
   instructions [--sync] [--approve]  Verify or restore runtime instruction files`);
 }
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -537,7 +537,9 @@ Commands:
   search <query> [n]                 Search structured audit events
   approvals [n] [--denied]           Show approval decisions
   verify <sessionId>                 Verify wire hash chain integrity
-  scan-leaks [sessionId] [--json]    Scan audit logs for confidential-info leaks (rules from ./.confidential.yml or ~/.hybridclaw/.confidential.yml)
+  scan-leaks [sessionId] [--all] [--json]
+                                     Scan audit logs for confidential-info leaks. Clean sessions hidden unless --all.
+                                     Rules from ./.confidential.yml (project-local) or ~/.hybridclaw/.confidential.yml (user-global).
   instructions [--sync] [--approve]  Verify or restore runtime instruction files`);
 }
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -537,6 +537,7 @@ Commands:
   search <query> [n]                 Search structured audit events
   approvals [n] [--denied]           Show approval decisions
   verify <sessionId>                 Verify wire hash chain integrity
+  scan-leaks [sessionId] [--json]    Scan audit logs against ~/.hybridclaw/.confidential.yml for confidential-info leaks
   instructions [--sync] [--approve]  Verify or restore runtime instruction files`);
 }
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -537,8 +537,10 @@ Commands:
   search <query> [n]                 Search structured audit events
   approvals [n] [--denied]           Show approval decisions
   verify <sessionId>                 Verify wire hash chain integrity
-  scan-leaks [sessionId] [--all] [--json]
-                                     Scan audit logs for confidential-info leaks. Clean sessions hidden unless --all.
+  scan-leaks [sessionId] [--quiet|--all] [--level <sev>] [--type <list>] [--json]
+                                     Scan audit logs for confidential-info leaks. Verbosity: --quiet | (default) | --all.
+                                     Filters: --level critical|high|medium|low (≥ floor),
+                                              --type in,out,tool,url (allowlist).
                                      Rules from ./.confidential.yml (project-local) or ~/.hybridclaw/.confidential.yml (user-global).
   instructions [--sync] [--approve]  Verify or restore runtime instruction files`);
 }

--- a/src/cli/verbosity.ts
+++ b/src/cli/verbosity.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared verbosity convention for hybridclaw subcommands.
+ *
+ * Three levels, named so that defaults sit in the middle and each end is
+ * a single explicit flag:
+ *
+ *   --quiet  / -q  → minimal output (totals/summary only)
+ *   (default)      → standard       (matched/relevant items + summary)
+ *   --all          → extended       (every item, including clean/skipped)
+ *
+ * `-v`/`--verbose` is intentionally NOT used here — `-v` is reserved at
+ * the top level (`hybridclaw -v` prints the version). `--all` reads more
+ * naturally for "show me everything" anyway.
+ *
+ * Usage in a subcommand:
+ *
+ *   const verbosity = parseOutputVerbosity(args);
+ *   const remaining = stripVerbosityFlags(args);
+ *
+ * Pass `verbosity` to your renderer; use `remaining` for further parsing.
+ */
+
+export type OutputVerbosity = 'quiet' | 'standard' | 'all';
+
+const QUIET_FLAGS = new Set(['--quiet', '-q']);
+const ALL_FLAGS = new Set(['--all']);
+
+export function parseOutputVerbosity(
+  args: ReadonlyArray<string>,
+): OutputVerbosity {
+  let level: OutputVerbosity = 'standard';
+  for (const arg of args) {
+    if (QUIET_FLAGS.has(arg)) level = 'quiet';
+    else if (ALL_FLAGS.has(arg)) level = 'all';
+  }
+  return level;
+}
+
+export function stripVerbosityFlags(args: ReadonlyArray<string>): string[] {
+  return args.filter((arg) => !QUIET_FLAGS.has(arg) && !ALL_FLAGS.has(arg));
+}
+
+/**
+ * Standard one-line help fragment subcommands can splice into their
+ * usage text so the convention is uniform across the CLI.
+ */
+export const VERBOSITY_HELP_LINE =
+  '--quiet | --all                    Verbosity: quiet = summary only, default = relevant items + summary, all = include clean/skipped items';

--- a/src/security/confidential-redact.ts
+++ b/src/security/confidential-redact.ts
@@ -1,0 +1,244 @@
+import type {
+  ConfidentialRule,
+  ConfidentialRuleSet,
+  ConfidentialSensitivity,
+} from './confidential-rules.js';
+
+const PLACEHOLDER_PREFIX = '«CONF:';
+const PLACEHOLDER_SUFFIX = '»';
+const PLACEHOLDER_RE = /«CONF:([A-Z0-9_-]+)»/g;
+
+const SENSITIVITY_WEIGHTS: Record<ConfidentialSensitivity, number> = {
+  low: 3,
+  medium: 10,
+  high: 30,
+  critical: 100,
+};
+
+const SCORE_BUCKETS: ReadonlyArray<{
+  min: number;
+  level: ConfidentialSensitivity;
+}> = [
+  { min: 100, level: 'critical' },
+  { min: 30, level: 'high' },
+  { min: 10, level: 'medium' },
+  { min: 0, level: 'low' },
+];
+
+const MAX_SCORE = 1000;
+
+export interface ConfidentialPlaceholderMap {
+  /** placeholder token → original text (case as it appeared in source) */
+  byPlaceholder: Map<string, string>;
+  /** rule id → placeholder token */
+  byRuleId: Map<string, string>;
+}
+
+export interface DehydrateResult {
+  text: string;
+  mappings: ConfidentialPlaceholderMap;
+  hits: number;
+}
+
+export interface ConfidentialFinding {
+  ruleId: string;
+  kind: ConfidentialRule['kind'];
+  label: string;
+  sensitivity: ConfidentialSensitivity;
+  matches: number;
+  /** A short text excerpt around the first match, redacted. */
+  excerpt: string;
+}
+
+export interface ConfidentialScanResult {
+  findings: ConfidentialFinding[];
+  totalMatches: number;
+  /** raw weighted score (sum of sensitivity weights × matches), capped at {@link MAX_SCORE}. */
+  rawScore: number;
+  /** 0–100 normalized score for dashboards. */
+  score: number;
+  severity: ConfidentialSensitivity;
+}
+
+export function createPlaceholderMap(): ConfidentialPlaceholderMap {
+  return { byPlaceholder: new Map(), byRuleId: new Map() };
+}
+
+function escapeForRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function literalRegex(rule: ConfidentialRule): RegExp | null {
+  const variants = [rule.literal, ...(rule.literalAliases || [])].filter(
+    (entry): entry is string => Boolean(entry),
+  );
+  if (variants.length === 0) return null;
+  variants.sort((a, b) => b.length - a.length);
+  const pattern = variants.map(escapeForRegex).join('|');
+  const flags = rule.caseInsensitive ? 'giu' : 'gu';
+  return new RegExp(
+    `(?<![\\p{L}\\p{N}_])(${pattern})(?![\\p{L}\\p{N}_])`,
+    flags,
+  );
+}
+
+function ruleRegex(rule: ConfidentialRule): RegExp | null {
+  if (rule.regex) {
+    return new RegExp(rule.regex.source, rule.caseInsensitive ? 'gi' : 'g');
+  }
+  return literalRegex(rule);
+}
+
+function placeholderForRule(
+  rule: ConfidentialRule,
+  mappings: ConfidentialPlaceholderMap,
+): string {
+  const existing = mappings.byRuleId.get(rule.id);
+  if (existing) return existing;
+  const token = `${PLACEHOLDER_PREFIX}${rule.id.toUpperCase()}${PLACEHOLDER_SUFFIX}`;
+  mappings.byRuleId.set(rule.id, token);
+  return token;
+}
+
+export function dehydrateConfidential(
+  text: string,
+  ruleSet: ConfidentialRuleSet,
+  initialMappings?: ConfidentialPlaceholderMap,
+): DehydrateResult {
+  const mappings = initialMappings || createPlaceholderMap();
+  if (!text || ruleSet.rules.length === 0) {
+    return { text: text || '', mappings, hits: 0 };
+  }
+
+  let next = text;
+  let hits = 0;
+
+  for (const rule of ruleSet.rules) {
+    const regex = ruleRegex(rule);
+    if (!regex) continue;
+    const placeholder = placeholderForRule(rule, mappings);
+
+    next = next.replace(regex, (match) => {
+      hits += 1;
+      if (!mappings.byPlaceholder.has(placeholder)) {
+        mappings.byPlaceholder.set(placeholder, match);
+      }
+      return placeholder;
+    });
+  }
+
+  return { text: next, mappings, hits };
+}
+
+export function rehydrateConfidential(
+  text: string,
+  mappings: ConfidentialPlaceholderMap,
+): string {
+  if (!text || mappings.byPlaceholder.size === 0) return text;
+  return text.replace(PLACEHOLDER_RE, (match) => {
+    const original = mappings.byPlaceholder.get(match);
+    return original ?? match;
+  });
+}
+
+function buildExcerpt(
+  source: string,
+  matchIndex: number,
+  matchLength: number,
+  width = 60,
+): string {
+  if (matchIndex < 0) return '';
+  const start = Math.max(0, matchIndex - width);
+  const end = Math.min(source.length, matchIndex + matchLength + width);
+  const before = source.slice(start, matchIndex);
+  const after = source.slice(matchIndex + matchLength, end);
+  const prefix = start > 0 ? '...' : '';
+  const suffix = end < source.length ? '...' : '';
+  return `${prefix}${before}***${after}${suffix}`.replace(/\s+/g, ' ').trim();
+}
+
+export function scanForLeaks(
+  text: string,
+  ruleSet: ConfidentialRuleSet,
+): ConfidentialScanResult {
+  const findings: ConfidentialFinding[] = [];
+  if (!text || ruleSet.rules.length === 0) {
+    return {
+      findings,
+      totalMatches: 0,
+      rawScore: 0,
+      score: 0,
+      severity: 'low',
+    };
+  }
+
+  let totalMatches = 0;
+  let rawScore = 0;
+
+  for (const rule of ruleSet.rules) {
+    const regex = ruleRegex(rule);
+    if (!regex) continue;
+    let matches = 0;
+    let firstIndex = -1;
+    let firstLength = 0;
+    let result: RegExpExecArray | null = regex.exec(text);
+    while (result) {
+      matches += 1;
+      if (firstIndex === -1) {
+        firstIndex = result.index;
+        firstLength = result[0].length;
+      }
+      if (regex.lastIndex === result.index) regex.lastIndex += 1;
+      result = regex.exec(text);
+    }
+    if (matches === 0) continue;
+    totalMatches += matches;
+    rawScore += SENSITIVITY_WEIGHTS[rule.sensitivity] * matches;
+    findings.push({
+      ruleId: rule.id,
+      kind: rule.kind,
+      label: rule.label,
+      sensitivity: rule.sensitivity,
+      matches,
+      excerpt: buildExcerpt(text, firstIndex, firstLength),
+    });
+  }
+
+  const cappedRaw = Math.min(rawScore, MAX_SCORE);
+  const score = Math.round((cappedRaw / MAX_SCORE) * 100);
+  const severity =
+    SCORE_BUCKETS.find((bucket) => cappedRaw >= bucket.min)?.level || 'low';
+
+  findings.sort((a, b) => {
+    const sevDiff =
+      SENSITIVITY_WEIGHTS[b.sensitivity] - SENSITIVITY_WEIGHTS[a.sensitivity];
+    if (sevDiff !== 0) return sevDiff;
+    if (b.matches !== a.matches) return b.matches - a.matches;
+    return a.label.localeCompare(b.label);
+  });
+
+  return {
+    findings,
+    totalMatches,
+    rawScore: cappedRaw,
+    score,
+    severity,
+  };
+}
+
+export function mergePlaceholderMaps(
+  base: ConfidentialPlaceholderMap,
+  next: ConfidentialPlaceholderMap,
+): ConfidentialPlaceholderMap {
+  for (const [token, original] of next.byPlaceholder) {
+    if (!base.byPlaceholder.has(token)) {
+      base.byPlaceholder.set(token, original);
+    }
+  }
+  for (const [ruleId, token] of next.byRuleId) {
+    if (!base.byRuleId.has(ruleId)) {
+      base.byRuleId.set(ruleId, token);
+    }
+  }
+  return base;
+}

--- a/src/security/confidential-redact.ts
+++ b/src/security/confidential-redact.ts
@@ -46,8 +46,13 @@ export interface ConfidentialFinding {
   label: string;
   sensitivity: ConfidentialSensitivity;
   matches: number;
-  /** A short text excerpt around the first match, redacted. */
+  /**
+   * A short text excerpt around the first match, with the matched span
+   * shown verbatim (so a reviewer can decide whether it is a real leak).
+   */
   excerpt: string;
+  /** The exact substring that matched the rule, in its original casing. */
+  match: string;
 }
 
 export interface ConfidentialScanResult {
@@ -151,10 +156,13 @@ function buildExcerpt(
   const start = Math.max(0, matchIndex - width);
   const end = Math.min(source.length, matchIndex + matchLength + width);
   const before = source.slice(start, matchIndex);
+  const match = source.slice(matchIndex, matchIndex + matchLength);
   const after = source.slice(matchIndex + matchLength, end);
   const prefix = start > 0 ? '...' : '';
   const suffix = end < source.length ? '...' : '';
-  return `${prefix}${before}***${after}${suffix}`.replace(/\s+/g, ' ').trim();
+  return `${prefix}${before}»${match}«${after}${suffix}`
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
 export function scanForLeaks(
@@ -181,12 +189,14 @@ export function scanForLeaks(
     let matches = 0;
     let firstIndex = -1;
     let firstLength = 0;
+    let firstMatchText = '';
     let result: RegExpExecArray | null = regex.exec(text);
     while (result) {
       matches += 1;
       if (firstIndex === -1) {
         firstIndex = result.index;
         firstLength = result[0].length;
+        firstMatchText = result[0];
       }
       if (regex.lastIndex === result.index) regex.lastIndex += 1;
       result = regex.exec(text);
@@ -201,6 +211,7 @@ export function scanForLeaks(
       sensitivity: rule.sensitivity,
       matches,
       excerpt: buildExcerpt(text, firstIndex, firstLength),
+      match: firstMatchText,
     });
   }
 

--- a/src/security/confidential-rules.ts
+++ b/src/security/confidential-rules.ts
@@ -183,6 +183,11 @@ export function parseConfidentialYaml(
   return { rules: parseRuleSet(raw), sourcePath };
 }
 
+/**
+ * Search order, first hit wins:
+ *   1. ./.confidential.yml (project-local, e.g. per-workspace overrides)
+ *   2. ~/.hybridclaw/.confidential.yml (user-global default)
+ */
 export function defaultConfidentialConfigPaths(
   cwd: string = process.cwd(),
 ): string[] {

--- a/src/security/confidential-rules.ts
+++ b/src/security/confidential-rules.ts
@@ -1,0 +1,218 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { parse as parseYaml } from 'yaml';
+
+import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+
+export const CONFIDENTIAL_CONFIG_FILE = '.confidential.yml';
+
+export type ConfidentialSensitivity = 'low' | 'medium' | 'high' | 'critical';
+
+export type ConfidentialKind =
+  | 'client'
+  | 'project'
+  | 'person'
+  | 'keyword'
+  | 'pattern';
+
+export interface ConfidentialRule {
+  id: string;
+  kind: ConfidentialKind;
+  label: string;
+  sensitivity: ConfidentialSensitivity;
+  literal?: string;
+  literalAliases?: string[];
+  regex?: RegExp;
+  regexSource?: string;
+  caseInsensitive: boolean;
+}
+
+export interface ConfidentialRuleSet {
+  rules: ConfidentialRule[];
+  sourcePath: string | null;
+}
+
+interface RawEntry {
+  name?: unknown;
+  label?: unknown;
+  aliases?: unknown;
+  sensitivity?: unknown;
+  case_insensitive?: unknown;
+  caseInsensitive?: unknown;
+  term?: unknown;
+  regex?: unknown;
+}
+
+interface RawConfig {
+  version?: unknown;
+  clients?: unknown;
+  projects?: unknown;
+  people?: unknown;
+  keywords?: unknown;
+  patterns?: unknown;
+}
+
+const DEFAULT_SENSITIVITY: ConfidentialSensitivity = 'high';
+const VALID_SENSITIVITIES: ReadonlySet<string> = new Set([
+  'low',
+  'medium',
+  'high',
+  'critical',
+]);
+
+function normalizeSensitivity(raw: unknown): ConfidentialSensitivity {
+  if (typeof raw !== 'string') return DEFAULT_SENSITIVITY;
+  const value = raw.trim().toLowerCase();
+  return VALID_SENSITIVITIES.has(value)
+    ? (value as ConfidentialSensitivity)
+    : DEFAULT_SENSITIVITY;
+}
+
+function asEntries(raw: unknown): RawEntry[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (entry): entry is RawEntry =>
+      entry != null && typeof entry === 'object' && !Array.isArray(entry),
+  );
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function asAliasList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const entry of value) {
+    const normalized = asNonEmptyString(entry);
+    if (!normalized) continue;
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(normalized);
+  }
+  return result;
+}
+
+function buildLiteralRule(
+  kind: ConfidentialKind,
+  entry: RawEntry,
+  index: number,
+): ConfidentialRule | null {
+  const primary =
+    asNonEmptyString(entry.name) ||
+    asNonEmptyString(entry.label) ||
+    asNonEmptyString(entry.term);
+  if (!primary) return null;
+  const aliases = asAliasList(entry.aliases);
+  return {
+    id: `${kind}_${String(index + 1).padStart(3, '0')}`,
+    kind,
+    label: primary,
+    sensitivity: normalizeSensitivity(entry.sensitivity),
+    literal: primary,
+    literalAliases: aliases,
+    caseInsensitive: true,
+  };
+}
+
+function buildPatternRule(
+  entry: RawEntry,
+  index: number,
+): ConfidentialRule | null {
+  const label =
+    asNonEmptyString(entry.name) || asNonEmptyString(entry.label) || null;
+  const regexSource = asNonEmptyString(entry.regex);
+  if (!label || !regexSource) return null;
+  const caseInsensitive =
+    entry.case_insensitive === true || entry.caseInsensitive === true;
+  let regex: RegExp;
+  try {
+    regex = new RegExp(regexSource, caseInsensitive ? 'gi' : 'g');
+  } catch {
+    return null;
+  }
+  return {
+    id: `pattern_${String(index + 1).padStart(3, '0')}`,
+    kind: 'pattern',
+    label,
+    sensitivity: normalizeSensitivity(entry.sensitivity),
+    regex,
+    regexSource,
+    caseInsensitive,
+  };
+}
+
+function parseRuleSet(raw: RawConfig): ConfidentialRule[] {
+  const rules: ConfidentialRule[] = [];
+
+  const literalGroups: Array<[ConfidentialKind, unknown]> = [
+    ['client', raw.clients],
+    ['project', raw.projects],
+    ['person', raw.people],
+    ['keyword', raw.keywords],
+  ];
+
+  for (const [kind, entries] of literalGroups) {
+    asEntries(entries).forEach((entry, index) => {
+      const rule = buildLiteralRule(kind, entry, index);
+      if (rule) rules.push(rule);
+    });
+  }
+
+  asEntries(raw.patterns).forEach((entry, index) => {
+    const rule = buildPatternRule(entry, index);
+    if (rule) rules.push(rule);
+  });
+
+  return rules;
+}
+
+export function parseConfidentialYaml(
+  source: string,
+  sourcePath: string | null = null,
+): ConfidentialRuleSet {
+  const data = parseYaml(source) as unknown;
+  const raw =
+    data && typeof data === 'object' && !Array.isArray(data)
+      ? (data as RawConfig)
+      : {};
+  return { rules: parseRuleSet(raw), sourcePath };
+}
+
+export function defaultConfidentialConfigPaths(
+  cwd: string = process.cwd(),
+): string[] {
+  return [
+    path.join(cwd, CONFIDENTIAL_CONFIG_FILE),
+    path.join(DEFAULT_RUNTIME_HOME_DIR, CONFIDENTIAL_CONFIG_FILE),
+  ];
+}
+
+export function loadConfidentialRules(
+  searchPaths?: string[],
+): ConfidentialRuleSet {
+  const candidates = searchPaths?.length
+    ? searchPaths
+    : defaultConfidentialConfigPaths();
+  for (const candidate of candidates) {
+    if (!candidate || !fs.existsSync(candidate)) continue;
+    try {
+      const raw = fs.readFileSync(candidate, 'utf-8');
+      return parseConfidentialYaml(raw, candidate);
+    } catch (error) {
+      console.warn(
+        `[confidential] failed to load ${candidate}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return { rules: [], sourcePath: candidate };
+    }
+  }
+  return { rules: [], sourcePath: null };
+}
+
+export function ruleHasContent(ruleSet: ConfidentialRuleSet): boolean {
+  return ruleSet.rules.length > 0;
+}

--- a/src/security/confidential-runtime.ts
+++ b/src/security/confidential-runtime.ts
@@ -35,9 +35,16 @@ export function isConfidentialRedactionEnabled(): boolean {
   return getConfidentialRuleSet().rules.length > 0;
 }
 
+export interface DehydrateMessageToolCall {
+  id?: string;
+  type?: string;
+  function?: { name?: string; arguments?: unknown };
+}
+
 export interface DehydrateMessageContent {
   role?: string;
   content: unknown;
+  tool_calls?: DehydrateMessageToolCall[];
 }
 
 function dehydrateText(
@@ -49,19 +56,18 @@ function dehydrateText(
   return dehydrateConfidential(text, ruleSet, mappings).text;
 }
 
-function dehydrateContent<T extends DehydrateMessageContent>(
-  message: T,
+function dehydrateContentField(
+  content: unknown,
   mappings: ConfidentialPlaceholderMap,
   ruleSet: ConfidentialRuleSet,
-): T {
-  if (typeof message.content === 'string') {
-    const dehydrated = dehydrateText(message.content, mappings, ruleSet);
-    if (dehydrated === message.content) return message;
-    return { ...message, content: dehydrated };
+): { content: unknown; mutated: boolean } {
+  if (typeof content === 'string') {
+    const dehydrated = dehydrateText(content, mappings, ruleSet);
+    return { content: dehydrated, mutated: dehydrated !== content };
   }
-  if (Array.isArray(message.content)) {
+  if (Array.isArray(content)) {
     let mutated = false;
-    const next = message.content.map((part) => {
+    const next = content.map((part) => {
       if (
         part &&
         typeof part === 'object' &&
@@ -77,10 +83,72 @@ function dehydrateContent<T extends DehydrateMessageContent>(
       }
       return part;
     });
-    if (!mutated) return message;
-    return { ...message, content: next as unknown as T['content'] };
+    return { content: mutated ? next : content, mutated };
   }
-  return message;
+  return { content, mutated: false };
+}
+
+/**
+ * Tool call arguments are stored as a JSON string. We dehydrate that
+ * string directly — confidential placeholders use Unicode brackets
+ * (`«CONF:…»`) that are valid inside JSON strings, so the result stays
+ * parseable. `tool_calls[].function.arguments` would otherwise leak the
+ * original term back to the model on every subsequent turn.
+ */
+function dehydrateToolCalls(
+  toolCalls: DehydrateMessageToolCall[],
+  mappings: ConfidentialPlaceholderMap,
+  ruleSet: ConfidentialRuleSet,
+): { toolCalls: DehydrateMessageToolCall[]; mutated: boolean } {
+  let mutated = false;
+  const next = toolCalls.map((call) => {
+    const args = call.function?.arguments;
+    if (typeof args !== 'string' || args.length === 0) return call;
+    const dehydrated = dehydrateText(args, mappings, ruleSet);
+    if (dehydrated === args) return call;
+    mutated = true;
+    return {
+      ...call,
+      function: {
+        ...(call.function ?? {}),
+        arguments: dehydrated,
+      },
+    };
+  });
+  return { toolCalls: mutated ? next : toolCalls, mutated };
+}
+
+function dehydrateContent<T extends DehydrateMessageContent>(
+  message: T,
+  mappings: ConfidentialPlaceholderMap,
+  ruleSet: ConfidentialRuleSet,
+): T {
+  const contentResult = dehydrateContentField(
+    message.content,
+    mappings,
+    ruleSet,
+  );
+  let toolCallsResult: {
+    toolCalls: DehydrateMessageToolCall[];
+    mutated: boolean;
+  } = {
+    toolCalls: message.tool_calls ?? [],
+    mutated: false,
+  };
+  if (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) {
+    toolCallsResult = dehydrateToolCalls(message.tool_calls, mappings, ruleSet);
+  }
+
+  if (!contentResult.mutated && !toolCallsResult.mutated) return message;
+  const next: T = { ...message };
+  if (contentResult.mutated) {
+    (next as { content: unknown }).content = contentResult.content;
+  }
+  if (toolCallsResult.mutated) {
+    (next as { tool_calls?: DehydrateMessageToolCall[] }).tool_calls =
+      toolCallsResult.toolCalls;
+  }
+  return next;
 }
 
 export interface ConfidentialRuntimeContext {
@@ -129,6 +197,53 @@ function rehydrateStringField<T extends object>(
   };
 }
 
+/**
+ * Maximum number of trailing characters we keep in the streaming buffer
+ * waiting for a placeholder to close. Placeholders are at most ~20 chars
+ * (`«CONF:` + ID + `»`); 64 leaves slack for compound IDs while bounding
+ * how much of the live stream we delay.
+ *
+ * If the orphan tail exceeds this length without a closing `»`, it
+ * cannot be a placeholder — we flush it as-is so the user does not lose
+ * legitimate text that happens to start with `«`.
+ */
+const STREAM_PLACEHOLDER_LOOKAHEAD = 64;
+
+function makeStreamingDeltaWrapper(
+  callback: (delta: string) => void,
+  mappings: ConfidentialPlaceholderMap,
+): (delta: string) => void {
+  // A placeholder may straddle two delta chunks — e.g. one delta ends
+  // with `«CONF:CLIENT_` and the next begins with `001»`. If we
+  // rehydrated each delta independently the user would see broken
+  // halves. We hold back any characters from the latest unmatched `«`
+  // so the placeholder is only emitted once it is whole.
+  let pending = '';
+  return (delta: string) => {
+    pending += delta;
+    const lastOpen = pending.lastIndexOf('«');
+    let flushUpTo: number;
+    if (lastOpen === -1) {
+      flushUpTo = pending.length;
+    } else {
+      const closeAfter = pending.indexOf('»', lastOpen);
+      if (closeAfter !== -1) {
+        flushUpTo = pending.length;
+      } else if (pending.length - lastOpen > STREAM_PLACEHOLDER_LOOKAHEAD) {
+        // Tail is too long to still be a placeholder — release it so the
+        // user does not stall on an orphan `«` in legitimate prose.
+        flushUpTo = pending.length;
+      } else {
+        flushUpTo = lastOpen;
+      }
+    }
+    if (flushUpTo === 0) return;
+    const ready = pending.slice(0, flushUpTo);
+    pending = pending.slice(flushUpTo);
+    callback(rehydrateConfidential(ready, mappings));
+  };
+}
+
 export function createConfidentialRuntimeContext(): ConfidentialRuntimeContext {
   if (!isConfidentialRedactionEnabled()) {
     return NOOP_CONTEXT;
@@ -168,9 +283,7 @@ export function createConfidentialRuntimeContext(): ConfidentialRuntimeContext {
     },
     wrapDelta(callback) {
       if (!callback) return callback;
-      return (delta: string) => {
-        callback(rehydrateConfidential(delta, mappings));
-      };
+      return makeStreamingDeltaWrapper(callback, mappings);
     },
     rehydrateFields,
     wrapEvent(callback, fields) {

--- a/src/security/confidential-runtime.ts
+++ b/src/security/confidential-runtime.ts
@@ -1,0 +1,133 @@
+import {
+  type ConfidentialPlaceholderMap,
+  createPlaceholderMap,
+  dehydrateConfidential,
+  rehydrateConfidential,
+} from './confidential-redact.js';
+import {
+  type ConfidentialRuleSet,
+  loadConfidentialRules,
+} from './confidential-rules.js';
+
+let cachedRuleSet: ConfidentialRuleSet | null = null;
+
+export function getConfidentialRuleSet(): ConfidentialRuleSet {
+  cachedRuleSet ??= loadConfidentialRules();
+  return cachedRuleSet;
+}
+
+export function resetConfidentialRuleSetCache(): void {
+  cachedRuleSet = null;
+}
+
+/**
+ * Test seam: inject a rule set without touching the filesystem.
+ * Pass `null` to fall back to the regular loader.
+ */
+export function setConfidentialRuleSetForTesting(
+  ruleSet: ConfidentialRuleSet | null,
+): void {
+  cachedRuleSet = ruleSet;
+}
+
+export function isConfidentialRedactionEnabled(): boolean {
+  if (process.env.HYBRIDCLAW_CONFIDENTIAL_DISABLE === '1') return false;
+  return getConfidentialRuleSet().rules.length > 0;
+}
+
+export interface DehydrateMessageContent {
+  role?: string;
+  content: unknown;
+}
+
+function dehydrateText(
+  text: string,
+  mappings: ConfidentialPlaceholderMap,
+  ruleSet: ConfidentialRuleSet,
+): string {
+  if (!text) return text;
+  return dehydrateConfidential(text, ruleSet, mappings).text;
+}
+
+function dehydrateContent<T extends DehydrateMessageContent>(
+  message: T,
+  mappings: ConfidentialPlaceholderMap,
+  ruleSet: ConfidentialRuleSet,
+): T {
+  if (typeof message.content === 'string') {
+    const dehydrated = dehydrateText(message.content, mappings, ruleSet);
+    if (dehydrated === message.content) return message;
+    return { ...message, content: dehydrated };
+  }
+  if (Array.isArray(message.content)) {
+    let mutated = false;
+    const next = message.content.map((part) => {
+      if (
+        part &&
+        typeof part === 'object' &&
+        'text' in part &&
+        typeof (part as { text?: unknown }).text === 'string'
+      ) {
+        const original = (part as { text: string }).text;
+        const dehydrated = dehydrateText(original, mappings, ruleSet);
+        if (dehydrated !== original) {
+          mutated = true;
+          return { ...part, text: dehydrated };
+        }
+      }
+      return part;
+    });
+    if (!mutated) return message;
+    return { ...message, content: next as unknown as T['content'] };
+  }
+  return message;
+}
+
+export interface ConfidentialRuntimeContext {
+  enabled: boolean;
+  ruleSet: ConfidentialRuleSet;
+  mappings: ConfidentialPlaceholderMap;
+  dehydrate<T extends DehydrateMessageContent>(messages: T[]): T[];
+  rehydrate(text: string | null | undefined): string;
+  wrapDelta(
+    callback: ((delta: string) => void) | undefined,
+  ): ((delta: string) => void) | undefined;
+}
+
+const NOOP_CONTEXT: ConfidentialRuntimeContext = {
+  enabled: false,
+  ruleSet: { rules: [], sourcePath: null },
+  mappings: createPlaceholderMap(),
+  dehydrate: (messages) => messages,
+  rehydrate: (text) => text || '',
+  wrapDelta: (callback) => callback,
+};
+
+export function createConfidentialRuntimeContext(): ConfidentialRuntimeContext {
+  if (!isConfidentialRedactionEnabled()) {
+    return NOOP_CONTEXT;
+  }
+  const ruleSet = getConfidentialRuleSet();
+  const mappings = createPlaceholderMap();
+
+  return {
+    enabled: true,
+    ruleSet,
+    mappings,
+    dehydrate(messages) {
+      return messages.map((message) =>
+        dehydrateContent(message, mappings, ruleSet),
+      );
+    },
+    rehydrate(text) {
+      if (!text) return text || '';
+      return rehydrateConfidential(text, mappings);
+    },
+    wrapDelta(callback) {
+      if (!callback) return callback;
+      return (delta: string) => {
+        callback(rehydrateConfidential(delta, mappings));
+      };
+    },
+  };
+}

--- a/src/security/confidential-runtime.ts
+++ b/src/security/confidential-runtime.ts
@@ -92,6 +92,16 @@ export interface ConfidentialRuntimeContext {
   wrapDelta(
     callback: ((delta: string) => void) | undefined,
   ): ((delta: string) => void) | undefined;
+  /** Rehydrate every listed string field on an object (shallow). */
+  rehydrateFields<T extends object>(
+    value: T | null | undefined,
+    fields: ReadonlyArray<keyof T>,
+  ): T | null | undefined;
+  /** Map a callback that receives an object, rehydrating string fields by name. */
+  wrapEvent<T extends object>(
+    callback: ((event: T) => void) | undefined,
+    fields: ReadonlyArray<keyof T>,
+  ): ((event: T) => void) | undefined;
 }
 
 const NOOP_CONTEXT: ConfidentialRuntimeContext = {
@@ -101,7 +111,23 @@ const NOOP_CONTEXT: ConfidentialRuntimeContext = {
   dehydrate: (messages) => messages,
   rehydrate: (text) => text || '',
   wrapDelta: (callback) => callback,
+  rehydrateFields: (value) => value,
+  wrapEvent: (callback) => callback,
 };
+
+function rehydrateStringField<T extends object>(
+  source: T,
+  key: keyof T,
+  mappings: ConfidentialPlaceholderMap,
+): { value: T[keyof T]; mutated: boolean } {
+  const raw = source[key];
+  if (typeof raw !== 'string') return { value: raw, mutated: false };
+  const next = rehydrateConfidential(raw, mappings);
+  return {
+    value: next as T[keyof T],
+    mutated: next !== raw,
+  };
+}
 
 export function createConfidentialRuntimeContext(): ConfidentialRuntimeContext {
   if (!isConfidentialRedactionEnabled()) {
@@ -109,6 +135,23 @@ export function createConfidentialRuntimeContext(): ConfidentialRuntimeContext {
   }
   const ruleSet = getConfidentialRuleSet();
   const mappings = createPlaceholderMap();
+
+  function rehydrateFields<T extends object>(
+    value: T | null | undefined,
+    fields: ReadonlyArray<keyof T>,
+  ): T | null | undefined {
+    if (!value) return value;
+    let mutated = false;
+    const next = { ...value } as T;
+    for (const field of fields) {
+      const result = rehydrateStringField(value, field, mappings);
+      if (result.mutated) {
+        next[field] = result.value;
+        mutated = true;
+      }
+    }
+    return mutated ? next : value;
+  }
 
   return {
     enabled: true,
@@ -127,6 +170,14 @@ export function createConfidentialRuntimeContext(): ConfidentialRuntimeContext {
       if (!callback) return callback;
       return (delta: string) => {
         callback(rehydrateConfidential(delta, mappings));
+      };
+    },
+    rehydrateFields,
+    wrapEvent(callback, fields) {
+      if (!callback) return callback;
+      return (event) => {
+        const next = rehydrateFields(event, fields);
+        callback((next ?? event) as Parameters<typeof callback>[0]);
       };
     },
   };

--- a/tests/cli-verbosity.test.ts
+++ b/tests/cli-verbosity.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  parseOutputVerbosity,
+  stripVerbosityFlags,
+} from '../src/cli/verbosity.js';
+
+describe('parseOutputVerbosity', () => {
+  test('defaults to standard when no flag is passed', () => {
+    expect(parseOutputVerbosity([])).toBe('standard');
+    expect(parseOutputVerbosity(['some-id', '--json'])).toBe('standard');
+  });
+
+  test('returns quiet for --quiet or -q', () => {
+    expect(parseOutputVerbosity(['--quiet'])).toBe('quiet');
+    expect(parseOutputVerbosity(['-q'])).toBe('quiet');
+  });
+
+  test('returns all for --all', () => {
+    expect(parseOutputVerbosity(['--all'])).toBe('all');
+  });
+
+  test('last verbosity flag wins when multiple are passed', () => {
+    expect(parseOutputVerbosity(['--quiet', '--all'])).toBe('all');
+    expect(parseOutputVerbosity(['--all', '-q'])).toBe('quiet');
+  });
+});
+
+describe('stripVerbosityFlags', () => {
+  test('removes --quiet, -q, and --all but preserves everything else', () => {
+    expect(
+      stripVerbosityFlags(['session-1', '--quiet', '--json', '-q', '--all']),
+    ).toEqual(['session-1', '--json']);
+  });
+
+  test('returns the same args when no verbosity flag present', () => {
+    expect(stripVerbosityFlags(['session-1', '--json'])).toEqual([
+      'session-1',
+      '--json',
+    ]);
+  });
+});

--- a/tests/confidential-leak-scanner.test.ts
+++ b/tests/confidential-leak-scanner.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
 import {
+  directionForEventType,
   listAuditedSessions,
   PROMPT_BEARING_EVENT_TYPES,
   scanAllAuditSessionsForLeaks,
@@ -266,6 +267,62 @@ describe('audit log leak scanner', () => {
     expect(summary.bySeverity.high).toBe(1);
     expect(summary.bySeverity.medium).toBe(0);
     expect(summary.bySeverity.low).toBe(0);
+    // Empty matchedRecords on all inputs → direction buckets stay zero.
+    expect(summary.byDirection.in.matches).toBe(0);
+    expect(summary.byDirection.out.matches).toBe(0);
+    expect(summary.byDirection.tool.matches).toBe(0);
+  });
+
+  test('directionForEventType classifies the canonical event types', () => {
+    expect(directionForEventType('turn.start')).toBe('in');
+    expect(directionForEventType('prompt')).toBe('in');
+    expect(directionForEventType('message')).toBe('in');
+    expect(directionForEventType('turn.end')).toBe('out');
+    expect(directionForEventType('text')).toBe('out');
+    expect(directionForEventType('thinking')).toBe('out');
+    expect(directionForEventType('approval.request')).toBe('out');
+    expect(directionForEventType('tool.call')).toBe('tool');
+    expect(directionForEventType('tool.result')).toBe('tool');
+    expect(directionForEventType('skill.execution')).toBe('tool');
+    expect(directionForEventType('model.usage')).toBeNull();
+    expect(directionForEventType('unknown.weird')).toBeNull();
+  });
+
+  test('summarizeLeakReports splits matched records by direction', () => {
+    writeWireLines('directional', [
+      {
+        version: '2.0',
+        seq: 1,
+        timestamp: '2025-01-01T00:00:00.001Z',
+        runId: 'run_1',
+        sessionId: 'directional',
+        event: { type: 'turn.start', content: 'About Serviceplan' },
+      },
+      {
+        version: '2.0',
+        seq: 2,
+        timestamp: '2025-01-01T00:00:00.002Z',
+        runId: 'run_1',
+        sessionId: 'directional',
+        event: { type: 'turn.end', content: 'Reply about Project Falcon' },
+      },
+      {
+        version: '2.0',
+        seq: 3,
+        timestamp: '2025-01-01T00:00:00.003Z',
+        runId: 'run_1',
+        sessionId: 'directional',
+        event: { type: 'tool.result', summary: 'Project Falcon launched' },
+      },
+    ]);
+    const reports = [scanAuditSessionForLeaks('directional', RULES, tempDir)];
+    const summary = summarizeLeakReports(reports);
+    expect(summary.byDirection.in.records).toBe(1);
+    expect(summary.byDirection.out.records).toBe(1);
+    expect(summary.byDirection.tool.records).toBe(1);
+    expect(summary.byDirection.in.matches).toBeGreaterThanOrEqual(1);
+    expect(summary.byDirection.out.matches).toBeGreaterThanOrEqual(1);
+    expect(summary.byDirection.tool.matches).toBeGreaterThanOrEqual(1);
   });
 
   test('scanAllAuditSessionsForLeaks scans every session', () => {

--- a/tests/confidential-leak-scanner.test.ts
+++ b/tests/confidential-leak-scanner.test.ts
@@ -331,6 +331,54 @@ describe('audit log leak scanner', () => {
     expect(summary.byCategory.tool.sessions).toBe(1);
   });
 
+  test('summarizeLeakReports buckets matches by rule kind', () => {
+    const richRules = parseConfidentialYaml(`
+clients:
+  - name: Serviceplan
+    sensitivity: high
+projects:
+  - name: Project Falcon
+    sensitivity: critical
+people:
+  - name: Jane Doe
+    sensitivity: medium
+keywords:
+  - term: Q4 2026 budget
+    sensitivity: critical
+patterns:
+  - name: internal-doc
+    regex: "INT-\\\\d{6}"
+    sensitivity: high
+`);
+    writeWireLines('kinds', [
+      {
+        version: '2.0',
+        seq: 1,
+        timestamp: '2025-01-01T00:00:00.001Z',
+        runId: 'run_1',
+        sessionId: 'kinds',
+        event: {
+          type: 'turn.start',
+          userInput:
+            'Brief from Serviceplan about Project Falcon, Q4 2026 budget for Jane Doe, doc INT-123456',
+        },
+      },
+    ]);
+    const reports = [scanAuditSessionForLeaks('kinds', richRules, tempDir)];
+    const summary = summarizeLeakReports(reports);
+    expect(summary.byKind.client.matches).toBe(1);
+    expect(summary.byKind.project.matches).toBe(1);
+    expect(summary.byKind.person.matches).toBe(1);
+    expect(summary.byKind.keyword.matches).toBe(1);
+    expect(summary.byKind.pattern.matches).toBe(1);
+    // All five kinds touched the same single record / session.
+    expect(summary.byKind.client.records).toBe(1);
+    expect(summary.byKind.client.sessions).toBe(1);
+    // distinctLabels counts unique rule labels per kind.
+    expect(summary.byKind.client.distinctLabels).toBe(1);
+    expect(summary.byKind.pattern.distinctLabels).toBe(1);
+  });
+
   test('classifies matches inside URLs into the url bucket', () => {
     writeWireLines('urls', [
       {

--- a/tests/confidential-leak-scanner.test.ts
+++ b/tests/confidential-leak-scanner.test.ts
@@ -142,7 +142,9 @@ describe('audit log leak scanner', () => {
   test('listAuditedSessions discovers all sessions', () => {
     writeWireLines('alpha', []);
     writeWireLines('beta', []);
-    const sessions = listAuditedSessions(tempDir).map((entry) => entry.sessionId);
+    const sessions = listAuditedSessions(tempDir).map(
+      (entry) => entry.sessionId,
+    );
     expect(sessions).toEqual(['alpha', 'beta']);
   });
 

--- a/tests/confidential-leak-scanner.test.ts
+++ b/tests/confidential-leak-scanner.test.ts
@@ -317,12 +317,83 @@ describe('audit log leak scanner', () => {
     ]);
     const reports = [scanAuditSessionForLeaks('directional', RULES, tempDir)];
     const summary = summarizeLeakReports(reports);
-    expect(summary.byDirection.in.records).toBe(1);
-    expect(summary.byDirection.out.records).toBe(1);
-    expect(summary.byDirection.tool.records).toBe(1);
-    expect(summary.byDirection.in.matches).toBeGreaterThanOrEqual(1);
-    expect(summary.byDirection.out.matches).toBeGreaterThanOrEqual(1);
-    expect(summary.byDirection.tool.matches).toBeGreaterThanOrEqual(1);
+    expect(summary.byCategory.in.records).toBe(1);
+    expect(summary.byCategory.out.records).toBe(1);
+    expect(summary.byCategory.tool.records).toBe(1);
+    expect(summary.byCategory.in.matches).toBeGreaterThanOrEqual(1);
+    expect(summary.byCategory.out.matches).toBeGreaterThanOrEqual(1);
+    expect(summary.byCategory.tool.matches).toBeGreaterThanOrEqual(1);
+    // All three records came from the same session — the per-bucket
+    // session count should report 1 (deduped), not 3.
+    expect(summary.byCategory.in.sessions).toBe(1);
+    expect(summary.byCategory.out.sessions).toBe(1);
+    expect(summary.byCategory.tool.sessions).toBe(1);
+  });
+
+  test('classifies matches inside URLs into the url bucket', () => {
+    writeWireLines('urls', [
+      {
+        version: '2.0',
+        seq: 1,
+        timestamp: '2025-01-01T00:00:00.001Z',
+        runId: 'run_1',
+        sessionId: 'urls',
+        event: {
+          type: 'tool.result',
+          resultSummary:
+            'Found article at https://news.example.com/Serviceplan/2026',
+        },
+      },
+      {
+        version: '2.0',
+        seq: 2,
+        timestamp: '2025-01-01T00:00:00.002Z',
+        runId: 'run_1',
+        sessionId: 'urls',
+        event: {
+          type: 'tool.result',
+          resultSummary:
+            'See [Spendenseite](/unterstuetzung#Serviceplan) for details',
+        },
+      },
+      {
+        version: '2.0',
+        seq: 3,
+        timestamp: '2025-01-01T00:00:00.003Z',
+        runId: 'run_1',
+        sessionId: 'urls',
+        event: { type: 'turn.start', userInput: 'Tell me about Serviceplan' },
+      },
+    ]);
+    const reports = [scanAuditSessionForLeaks('urls', RULES, tempDir)];
+    const summary = summarizeLeakReports(reports);
+    // Two URL-bucketed records (https + markdown), one prose record.
+    expect(summary.byCategory.url.records).toBe(2);
+    expect(summary.byCategory.in.records).toBe(1);
+    expect(summary.byCategory.tool.records).toBe(0);
+  });
+
+  test('only scans whitelisted fields per event type — ignores metadata fields', () => {
+    writeWireLines('targeted', [
+      {
+        version: '2.0',
+        seq: 1,
+        timestamp: '2025-01-01T00:00:00.001Z',
+        runId: 'run_1',
+        sessionId: 'targeted',
+        // `provider` and `model` are metadata; only `userInput` should be
+        // scanned for turn.start. A confidential value placed in `provider`
+        // must NOT be flagged.
+        event: {
+          type: 'turn.start',
+          provider: 'Serviceplan',
+          model: 'gpt-5.1',
+          userInput: 'all clear here',
+        },
+      },
+    ]);
+    const report = scanAuditSessionForLeaks('targeted', RULES, tempDir);
+    expect(report.totalMatches).toBe(0);
   });
 
   test('scanAllAuditSessionsForLeaks scans every session', () => {

--- a/tests/confidential-leak-scanner.test.ts
+++ b/tests/confidential-leak-scanner.test.ts
@@ -1,0 +1,180 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import {
+  listAuditedSessions,
+  scanAllAuditSessionsForLeaks,
+  scanAuditSessionForLeaks,
+} from '../src/audit/leak-scanner.js';
+import { parseConfidentialYaml } from '../src/security/confidential-rules.js';
+
+let tempDir: string;
+
+const RULES = parseConfidentialYaml(`
+clients:
+  - name: Serviceplan
+    sensitivity: high
+projects:
+  - name: Project Falcon
+    sensitivity: critical
+`);
+
+function writeWireLines(sessionId: string, records: object[]): string {
+  const sessionDir = path.join(tempDir, 'audit', sessionId);
+  fs.mkdirSync(sessionDir, { recursive: true });
+  const filePath = path.join(sessionDir, 'wire.jsonl');
+  fs.writeFileSync(
+    filePath,
+    `${records.map((record) => JSON.stringify(record)).join('\n')}\n`,
+    'utf-8',
+  );
+  return filePath;
+}
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hc-leak-scan-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('audit log leak scanner', () => {
+  test('flags records whose event payload contains confidential terms', () => {
+    writeWireLines('session_a', [
+      {
+        type: 'metadata',
+        protocolVersion: '2.0',
+        sessionId: 'session_a',
+        createdAt: '2025-01-01T00:00:00.000Z',
+      },
+      {
+        version: '2.0',
+        seq: 1,
+        timestamp: '2025-01-01T00:00:00.001Z',
+        runId: 'run_1',
+        sessionId: 'session_a',
+        event: {
+          type: 'user.message',
+          content: 'Serviceplan brief about Project Falcon',
+        },
+      },
+      {
+        version: '2.0',
+        seq: 2,
+        timestamp: '2025-01-01T00:00:00.002Z',
+        runId: 'run_1',
+        sessionId: 'session_a',
+        event: {
+          type: 'tool.result',
+          toolName: 'noop',
+          isError: false,
+          summary: 'no client info here',
+        },
+      },
+    ]);
+
+    const report = scanAuditSessionForLeaks('session_a', RULES, tempDir);
+    expect(report.recordsScanned).toBe(2);
+    expect(report.matchedRecords).toHaveLength(1);
+    expect(report.matchedRecords[0].eventType).toBe('user.message');
+    expect(report.totalMatches).toBeGreaterThanOrEqual(2);
+    expect(report.score).toBeGreaterThan(0);
+    expect(['high', 'critical']).toContain(report.severity);
+  });
+
+  test('returns zero matches when audit log is clean', () => {
+    writeWireLines('clean', [
+      {
+        type: 'metadata',
+        protocolVersion: '2.0',
+        sessionId: 'clean',
+        createdAt: '2025-01-01T00:00:00.000Z',
+      },
+      {
+        version: '2.0',
+        seq: 1,
+        timestamp: '2025-01-01T00:00:00.001Z',
+        runId: 'run_1',
+        sessionId: 'clean',
+        event: { type: 'user.message', content: 'Just a hello.' },
+      },
+    ]);
+    const report = scanAuditSessionForLeaks('clean', RULES, tempDir);
+    expect(report.totalMatches).toBe(0);
+    expect(report.matchedRecords).toEqual([]);
+    expect(report.score).toBe(0);
+    expect(report.severity).toBe('low');
+  });
+
+  test('hadPlaceholder flag is true when text already dehydrated', () => {
+    writeWireLines('placeholders', [
+      {
+        type: 'metadata',
+        protocolVersion: '2.0',
+        sessionId: 'placeholders',
+        createdAt: '2025-01-01T00:00:00.000Z',
+      },
+      {
+        version: '2.0',
+        seq: 1,
+        timestamp: '2025-01-01T00:00:00.001Z',
+        runId: 'run_1',
+        sessionId: 'placeholders',
+        event: {
+          type: 'user.message',
+          content: 'Brief from «CONF:CLIENT_001» mentioning Project Falcon.',
+        },
+      },
+    ]);
+    const report = scanAuditSessionForLeaks('placeholders', RULES, tempDir);
+    expect(report.matchedRecords[0].hadPlaceholder).toBe(true);
+  });
+
+  test('returns errors when wire file is missing', () => {
+    const report = scanAuditSessionForLeaks('does_not_exist', RULES, tempDir);
+    expect(report.errors[0]).toMatch(/wire log not found/);
+    expect(report.recordsScanned).toBe(0);
+  });
+
+  test('listAuditedSessions discovers all sessions', () => {
+    writeWireLines('alpha', []);
+    writeWireLines('beta', []);
+    const sessions = listAuditedSessions(tempDir).map((entry) => entry.sessionId);
+    expect(sessions).toEqual(['alpha', 'beta']);
+  });
+
+  test('scanAllAuditSessionsForLeaks scans every session', () => {
+    writeWireLines('alpha', [
+      {
+        version: '2.0',
+        seq: 1,
+        timestamp: '2025-01-01T00:00:00.001Z',
+        runId: 'run_1',
+        sessionId: 'alpha',
+        event: { type: 'user.message', content: 'Project Falcon update' },
+      },
+    ]);
+    writeWireLines('beta', [
+      {
+        version: '2.0',
+        seq: 1,
+        timestamp: '2025-01-01T00:00:00.001Z',
+        runId: 'run_1',
+        sessionId: 'beta',
+        event: { type: 'user.message', content: 'Hello world' },
+      },
+    ]);
+    const reports = scanAllAuditSessionsForLeaks(RULES, tempDir);
+    expect(reports.map((report) => report.sessionId)).toEqual([
+      'alpha',
+      'beta',
+    ]);
+    const alpha = reports.find((report) => report.sessionId === 'alpha');
+    expect(alpha?.totalMatches).toBe(1);
+    const beta = reports.find((report) => report.sessionId === 'beta');
+    expect(beta?.totalMatches).toBe(0);
+  });
+});

--- a/tests/confidential-leak-scanner.test.ts
+++ b/tests/confidential-leak-scanner.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
 import {
+  applyLeakReportFilter,
   directionForEventType,
   listAuditedSessions,
   PROMPT_BEARING_EVENT_TYPES,
@@ -371,6 +372,122 @@ describe('audit log leak scanner', () => {
     expect(summary.byCategory.url.records).toBe(2);
     expect(summary.byCategory.in.records).toBe(1);
     expect(summary.byCategory.tool.records).toBe(0);
+  });
+
+  test('applyLeakReportFilter drops records below the severity floor', () => {
+    writeWireLines('mixed_sev', [
+      // Project Falcon = critical
+      {
+        version: '2.0',
+        seq: 1,
+        timestamp: '2025-01-01T00:00:00.001Z',
+        runId: 'run_1',
+        sessionId: 'mixed_sev',
+        event: { type: 'turn.start', userInput: 'About Project Falcon' },
+      },
+      // Serviceplan = high
+      {
+        version: '2.0',
+        seq: 2,
+        timestamp: '2025-01-01T00:00:00.002Z',
+        runId: 'run_1',
+        sessionId: 'mixed_sev',
+        event: { type: 'turn.start', userInput: 'and Serviceplan too' },
+      },
+    ]);
+    const reports = [scanAuditSessionForLeaks('mixed_sev', RULES, tempDir)];
+    expect(reports[0].matchedRecords).toHaveLength(2);
+
+    const critOnly = applyLeakReportFilter(reports, {
+      minSeverity: 'critical',
+    });
+    expect(critOnly[0].matchedRecords).toHaveLength(1);
+    expect(critOnly[0].matchedRecords[0].severity).toBe('critical');
+    expect(critOnly[0].totalMatches).toBe(1);
+
+    const highAndUp = applyLeakReportFilter(reports, { minSeverity: 'high' });
+    expect(highAndUp[0].matchedRecords).toHaveLength(2);
+
+    const mediumAndUp = applyLeakReportFilter(reports, {
+      minSeverity: 'medium',
+    });
+    expect(mediumAndUp[0].matchedRecords).toHaveLength(2);
+  });
+
+  test('applyLeakReportFilter drops records outside the category allowlist', () => {
+    writeWireLines('mixed_cat', [
+      {
+        version: '2.0',
+        seq: 1,
+        timestamp: '2025-01-01T00:00:00.001Z',
+        runId: 'run_1',
+        sessionId: 'mixed_cat',
+        event: { type: 'turn.start', userInput: 'About Project Falcon' },
+      },
+      {
+        version: '2.0',
+        seq: 2,
+        timestamp: '2025-01-01T00:00:00.002Z',
+        runId: 'run_1',
+        sessionId: 'mixed_cat',
+        // Use Serviceplan in the URL so the literal match falls inside
+        // the URL span (URLs can't contain spaces, so multi-word rules
+        // like "Project Falcon" never bucket as URL on their own).
+        event: {
+          type: 'tool.result',
+          resultSummary: 'See https://news.example.com/Serviceplan/',
+        },
+      },
+    ]);
+    const reports = [scanAuditSessionForLeaks('mixed_cat', RULES, tempDir)];
+    expect(reports[0].matchedRecords).toHaveLength(2);
+
+    const inOnly = applyLeakReportFilter(reports, {
+      categories: new Set(['in']),
+    });
+    expect(inOnly[0].matchedRecords).toHaveLength(1);
+    expect(inOnly[0].matchedRecords[0].category).toBe('in');
+
+    const urlOnly = applyLeakReportFilter(reports, {
+      categories: new Set(['url']),
+    });
+    expect(urlOnly[0].matchedRecords).toHaveLength(1);
+    expect(urlOnly[0].matchedRecords[0].category).toBe('url');
+
+    const inAndUrl = applyLeakReportFilter(reports, {
+      categories: new Set(['in', 'url']),
+    });
+    expect(inAndUrl[0].matchedRecords).toHaveLength(2);
+  });
+
+  test('applyLeakReportFilter recomputes per-session totals after filtering', () => {
+    writeWireLines('totals', [
+      {
+        version: '2.0',
+        seq: 1,
+        timestamp: '2025-01-01T00:00:00.001Z',
+        runId: 'run_1',
+        sessionId: 'totals',
+        event: { type: 'turn.start', userInput: 'About Project Falcon' },
+      },
+      {
+        version: '2.0',
+        seq: 2,
+        timestamp: '2025-01-01T00:00:00.002Z',
+        runId: 'run_1',
+        sessionId: 'totals',
+        event: { type: 'turn.start', userInput: 'and Serviceplan too' },
+      },
+    ]);
+    const reports = [scanAuditSessionForLeaks('totals', RULES, tempDir)];
+    const before = reports[0];
+    const after = applyLeakReportFilter(reports, {
+      minSeverity: 'critical',
+    })[0];
+
+    expect(after.totalMatches).toBeLessThan(before.totalMatches);
+    expect(after.rawScore).toBeLessThan(before.rawScore);
+    expect(after.severity).toBe('critical');
   });
 
   test('only scans whitelisted fields per event type — ignores metadata fields', () => {

--- a/tests/confidential-leak-scanner.test.ts
+++ b/tests/confidential-leak-scanner.test.ts
@@ -5,8 +5,10 @@ import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
 import {
   listAuditedSessions,
+  PROMPT_BEARING_EVENT_TYPES,
   scanAllAuditSessionsForLeaks,
   scanAuditSessionForLeaks,
+  summarizeLeakReports,
 } from '../src/audit/leak-scanner.js';
 import { parseConfidentialYaml } from '../src/security/confidential-rules.js';
 
@@ -57,7 +59,7 @@ describe('audit log leak scanner', () => {
         runId: 'run_1',
         sessionId: 'session_a',
         event: {
-          type: 'user.message',
+          type: 'turn.start',
           content: 'Serviceplan brief about Project Falcon',
         },
       },
@@ -79,7 +81,7 @@ describe('audit log leak scanner', () => {
     const report = scanAuditSessionForLeaks('session_a', RULES, tempDir);
     expect(report.recordsScanned).toBe(2);
     expect(report.matchedRecords).toHaveLength(1);
-    expect(report.matchedRecords[0].eventType).toBe('user.message');
+    expect(report.matchedRecords[0].eventType).toBe('turn.start');
     expect(report.totalMatches).toBeGreaterThanOrEqual(2);
     expect(report.score).toBeGreaterThan(0);
     expect(['high', 'critical']).toContain(report.severity);
@@ -99,7 +101,7 @@ describe('audit log leak scanner', () => {
         timestamp: '2025-01-01T00:00:00.001Z',
         runId: 'run_1',
         sessionId: 'clean',
-        event: { type: 'user.message', content: 'Just a hello.' },
+        event: { type: 'turn.start', content: 'Just a hello.' },
       },
     ]);
     const report = scanAuditSessionForLeaks('clean', RULES, tempDir);
@@ -124,7 +126,7 @@ describe('audit log leak scanner', () => {
         runId: 'run_1',
         sessionId: 'placeholders',
         event: {
-          type: 'user.message',
+          type: 'turn.start',
           content: 'Brief from «CONF:CLIENT_001» mentioning Project Falcon.',
         },
       },
@@ -148,6 +150,124 @@ describe('audit log leak scanner', () => {
     expect(sessions).toEqual(['alpha', 'beta']);
   });
 
+  test('skips telemetry/lifecycle event types and counts them as skipped', () => {
+    writeWireLines('mixed', [
+      {
+        version: '2.0',
+        seq: 1,
+        timestamp: '2025-01-01T00:00:00.001Z',
+        runId: 'run_1',
+        sessionId: 'mixed',
+        // model.usage payloads contain provider names ("HybridAI"); we must
+        // not flag them as confidential leaks, otherwise every turn shows
+        // a false positive against a HybridAI rule.
+        event: {
+          type: 'model.usage',
+          provider: 'Serviceplan',
+          model: 'gpt-5.1',
+        },
+      },
+      {
+        version: '2.0',
+        seq: 2,
+        timestamp: '2025-01-01T00:00:00.002Z',
+        runId: 'run_1',
+        sessionId: 'mixed',
+        event: { type: 'session.start', userId: 'Serviceplan' },
+      },
+      {
+        version: '2.0',
+        seq: 3,
+        timestamp: '2025-01-01T00:00:00.003Z',
+        runId: 'run_1',
+        sessionId: 'mixed',
+        event: { type: 'turn.start', content: 'About Serviceplan today' },
+      },
+    ]);
+    const report = scanAuditSessionForLeaks('mixed', RULES, tempDir);
+    expect(report.recordsScanned).toBe(1);
+    expect(report.recordsSkippedByType).toBe(2);
+    expect(report.matchedRecords).toHaveLength(1);
+    expect(report.matchedRecords[0].eventType).toBe('turn.start');
+  });
+
+  test('PROMPT_BEARING_EVENT_TYPES contains the expected canonical types', () => {
+    expect(PROMPT_BEARING_EVENT_TYPES.has('turn.start')).toBe(true);
+    expect(PROMPT_BEARING_EVENT_TYPES.has('turn.end')).toBe(true);
+    expect(PROMPT_BEARING_EVENT_TYPES.has('tool.call')).toBe(true);
+    expect(PROMPT_BEARING_EVENT_TYPES.has('tool.result')).toBe(true);
+    expect(PROMPT_BEARING_EVENT_TYPES.has('approval.request')).toBe(true);
+    expect(PROMPT_BEARING_EVENT_TYPES.has('model.usage')).toBe(false);
+    expect(PROMPT_BEARING_EVENT_TYPES.has('session.start')).toBe(false);
+    expect(PROMPT_BEARING_EVENT_TYPES.has('authorization.check')).toBe(false);
+  });
+
+  test('caller can override scanEventTypes', () => {
+    writeWireLines('override', [
+      {
+        version: '2.0',
+        seq: 1,
+        timestamp: '2025-01-01T00:00:00.001Z',
+        runId: 'run_1',
+        sessionId: 'override',
+        event: { type: 'custom.weird', text: 'Project Falcon hidden' },
+      },
+    ]);
+    const report = scanAuditSessionForLeaks('override', RULES, tempDir, {
+      scanEventTypes: new Set(['custom.weird']),
+    });
+    expect(report.matchedRecords).toHaveLength(1);
+  });
+
+  test('summarizeLeakReports buckets by session severity', () => {
+    const reports = [
+      {
+        sessionId: 'a',
+        filePath: 'a',
+        recordsScanned: 1,
+        recordsSkippedByType: 0,
+        matchedRecords: [],
+        totalMatches: 5,
+        rawScore: 200,
+        score: 20,
+        severity: 'critical' as const,
+        errors: [],
+      },
+      {
+        sessionId: 'b',
+        filePath: 'b',
+        recordsScanned: 1,
+        recordsSkippedByType: 0,
+        matchedRecords: [],
+        totalMatches: 2,
+        rawScore: 50,
+        score: 5,
+        severity: 'high' as const,
+        errors: [],
+      },
+      {
+        sessionId: 'c',
+        filePath: 'c',
+        recordsScanned: 1,
+        recordsSkippedByType: 0,
+        matchedRecords: [],
+        totalMatches: 0,
+        rawScore: 0,
+        score: 0,
+        severity: 'low' as const,
+        errors: [],
+      },
+    ];
+    const summary = summarizeLeakReports(reports);
+    expect(summary.totalSessions).toBe(3);
+    expect(summary.affectedSessions).toBe(2);
+    expect(summary.totalMatches).toBe(7);
+    expect(summary.bySeverity.critical).toBe(1);
+    expect(summary.bySeverity.high).toBe(1);
+    expect(summary.bySeverity.medium).toBe(0);
+    expect(summary.bySeverity.low).toBe(0);
+  });
+
   test('scanAllAuditSessionsForLeaks scans every session', () => {
     writeWireLines('alpha', [
       {
@@ -156,7 +276,7 @@ describe('audit log leak scanner', () => {
         timestamp: '2025-01-01T00:00:00.001Z',
         runId: 'run_1',
         sessionId: 'alpha',
-        event: { type: 'user.message', content: 'Project Falcon update' },
+        event: { type: 'turn.start', content: 'Project Falcon update' },
       },
     ]);
     writeWireLines('beta', [
@@ -166,7 +286,7 @@ describe('audit log leak scanner', () => {
         timestamp: '2025-01-01T00:00:00.001Z',
         runId: 'run_1',
         sessionId: 'beta',
-        event: { type: 'user.message', content: 'Hello world' },
+        event: { type: 'turn.start', content: 'Hello world' },
       },
     ]);
     const reports = scanAllAuditSessionsForLeaks(RULES, tempDir);

--- a/tests/confidential-redact.test.ts
+++ b/tests/confidential-redact.test.ts
@@ -153,12 +153,22 @@ describe('scanForLeaks', () => {
     expect(result.severity).toBe('critical');
   });
 
-  test('excerpt is short and includes redaction marker', () => {
+  test('excerpt shows the matched span verbatim, wrapped in »…« markers', () => {
     const result = scanForLeaks('Notes: Serviceplan brief follows.', ruleSet);
     const finding = result.findings.find(
       (entry) => entry.label === 'Serviceplan',
     );
-    expect(finding?.excerpt).toContain('***');
+    expect(finding?.match).toBe('Serviceplan');
+    expect(finding?.excerpt).toContain('»Serviceplan«');
+    expect(finding?.excerpt).not.toContain('***');
     expect(finding?.excerpt.length).toBeLessThan(180);
+  });
+
+  test('match field carries the original casing of the first hit', () => {
+    const result = scanForLeaks('SERVICEPLAN told us.', ruleSet);
+    const finding = result.findings.find(
+      (entry) => entry.label === 'Serviceplan',
+    );
+    expect(finding?.match).toBe('SERVICEPLAN');
   });
 });

--- a/tests/confidential-redact.test.ts
+++ b/tests/confidential-redact.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  createPlaceholderMap,
+  dehydrateConfidential,
+  rehydrateConfidential,
+  scanForLeaks,
+} from '../src/security/confidential-redact.js';
+import { parseConfidentialYaml } from '../src/security/confidential-rules.js';
+
+const RULES_YAML = `
+version: 1
+clients:
+  - name: Serviceplan
+    aliases: [SP, "Serviceplan AG"]
+    sensitivity: high
+  - name: Acme
+    sensitivity: medium
+projects:
+  - name: Project Falcon
+    sensitivity: critical
+people:
+  - name: Jane Doe
+    sensitivity: medium
+keywords:
+  - term: "Q4 2026 budget"
+    sensitivity: critical
+patterns:
+  - name: internal-doc
+    regex: "INT-\\\\d{6}"
+    sensitivity: high
+`;
+
+const ruleSet = parseConfidentialYaml(RULES_YAML, 'memory:test');
+
+describe('confidential rules loader', () => {
+  test('parses literal entries and patterns', () => {
+    const labels = ruleSet.rules.map((rule) => rule.label).sort();
+    expect(labels).toContain('Serviceplan');
+    expect(labels).toContain('Acme');
+    expect(labels).toContain('Project Falcon');
+    expect(labels).toContain('Jane Doe');
+    expect(labels).toContain('Q4 2026 budget');
+    expect(labels).toContain('internal-doc');
+  });
+
+  test('aliases are tracked alongside primary literal', () => {
+    const sp = ruleSet.rules.find((rule) => rule.label === 'Serviceplan');
+    expect(sp?.literalAliases).toEqual(['SP', 'Serviceplan AG']);
+  });
+
+  test('returns empty rule set when YAML is empty', () => {
+    expect(parseConfidentialYaml('').rules).toEqual([]);
+  });
+});
+
+describe('dehydrate / rehydrate', () => {
+  test('replaces literal hits with stable placeholders', () => {
+    const text =
+      'Serviceplan briefed us on Project Falcon. SP wants the Q4 2026 budget by Friday.';
+    const { text: dehydrated, mappings, hits } = dehydrateConfidential(
+      text,
+      ruleSet,
+    );
+    expect(hits).toBeGreaterThanOrEqual(4);
+    expect(dehydrated).not.toMatch(/Serviceplan/);
+    expect(dehydrated).not.toMatch(/Project Falcon/);
+    expect(dehydrated).not.toMatch(/Q4 2026 budget/);
+
+    const rehydrated = rehydrateConfidential(dehydrated, mappings);
+    // Aliases collapse to the primary spelling on rehydrate (last-write-wins
+    // through the placeholder); the canonical name remains intact.
+    expect(rehydrated).toContain('Serviceplan');
+    expect(rehydrated).toContain('Project Falcon');
+    expect(rehydrated).toContain('Q4 2026 budget');
+  });
+
+  test('placeholders are stable across calls when reusing mappings', () => {
+    const mappings = createPlaceholderMap();
+    const first = dehydrateConfidential('Serviceplan again', ruleSet, mappings);
+    const second = dehydrateConfidential('Serviceplan again', ruleSet, mappings);
+    expect(first.text).toBe(second.text);
+  });
+
+  test('regex patterns are matched and rehydrated', () => {
+    const text = 'See doc INT-123456 attached.';
+    const { text: dehydrated, mappings, hits } = dehydrateConfidential(
+      text,
+      ruleSet,
+    );
+    expect(hits).toBe(1);
+    expect(dehydrated).not.toContain('INT-123456');
+    expect(rehydrateConfidential(dehydrated, mappings)).toContain('INT-123456');
+  });
+
+  test('case-insensitive literal matching', () => {
+    const { hits } = dehydrateConfidential('SERVICEPLAN told ACME', ruleSet);
+    expect(hits).toBe(2);
+  });
+
+  test('no-op when rule set is empty', () => {
+    const empty = parseConfidentialYaml('');
+    const { text, hits } = dehydrateConfidential('Hello Serviceplan', empty);
+    expect(text).toBe('Hello Serviceplan');
+    expect(hits).toBe(0);
+  });
+
+  test('rehydrate with unknown placeholder is left intact', () => {
+    const out = rehydrateConfidential('See «CONF:UNKNOWN_001» here.', createPlaceholderMap());
+    expect(out).toBe('See «CONF:UNKNOWN_001» here.');
+  });
+});
+
+describe('scanForLeaks', () => {
+  test('flags multiple sensitivities and produces a non-zero score', () => {
+    const text =
+      'Serviceplan brief: Project Falcon launches Q4 2026 budget review with INT-654321.';
+    const result = scanForLeaks(text, ruleSet);
+    expect(result.totalMatches).toBeGreaterThanOrEqual(4);
+    expect(result.score).toBeGreaterThan(0);
+    expect(['high', 'critical']).toContain(result.severity);
+    const labels = result.findings.map((finding) => finding.label);
+    expect(labels).toContain('Project Falcon');
+    expect(labels).toContain('Q4 2026 budget');
+    expect(labels).toContain('Serviceplan');
+    // Findings sorted critical/high first.
+    expect(result.findings[0]?.sensitivity).toBe('critical');
+  });
+
+  test('returns zero score for clean text', () => {
+    const result = scanForLeaks('All quiet here.', ruleSet);
+    expect(result.totalMatches).toBe(0);
+    expect(result.score).toBe(0);
+    expect(result.severity).toBe('low');
+  });
+
+  test('caps raw score at 1000', () => {
+    const text = Array(50).fill('Project Falcon').join(' ');
+    const result = scanForLeaks(text, ruleSet);
+    expect(result.rawScore).toBeLessThanOrEqual(1000);
+    expect(result.score).toBe(100);
+    expect(result.severity).toBe('critical');
+  });
+
+  test('excerpt is short and includes redaction marker', () => {
+    const result = scanForLeaks('Notes: Serviceplan brief follows.', ruleSet);
+    const finding = result.findings.find(
+      (entry) => entry.label === 'Serviceplan',
+    );
+    expect(finding?.excerpt).toContain('***');
+    expect(finding?.excerpt.length).toBeLessThan(180);
+  });
+});

--- a/tests/confidential-redact.test.ts
+++ b/tests/confidential-redact.test.ts
@@ -69,8 +69,10 @@ describe('dehydrate / rehydrate', () => {
     expect(dehydrated).not.toMatch(/Q4 2026 budget/);
 
     const rehydrated = rehydrateConfidential(dehydrated, mappings);
-    // Aliases collapse to the primary spelling on rehydrate (last-write-wins
-    // through the placeholder); the canonical name remains intact.
+    // All variants of a rule (primary + aliases) share one placeholder, and
+    // the placeholder maps to the FIRST spelling that matched (first-write-
+    // wins). Here "Serviceplan" appears before "SP", so both rehydrate to
+    // "Serviceplan".
     expect(rehydrated).toContain('Serviceplan');
     expect(rehydrated).toContain('Project Falcon');
     expect(rehydrated).toContain('Q4 2026 budget');

--- a/tests/confidential-redact.test.ts
+++ b/tests/confidential-redact.test.ts
@@ -58,10 +58,11 @@ describe('dehydrate / rehydrate', () => {
   test('replaces literal hits with stable placeholders', () => {
     const text =
       'Serviceplan briefed us on Project Falcon. SP wants the Q4 2026 budget by Friday.';
-    const { text: dehydrated, mappings, hits } = dehydrateConfidential(
-      text,
-      ruleSet,
-    );
+    const {
+      text: dehydrated,
+      mappings,
+      hits,
+    } = dehydrateConfidential(text, ruleSet);
     expect(hits).toBeGreaterThanOrEqual(4);
     expect(dehydrated).not.toMatch(/Serviceplan/);
     expect(dehydrated).not.toMatch(/Project Falcon/);
@@ -78,16 +79,21 @@ describe('dehydrate / rehydrate', () => {
   test('placeholders are stable across calls when reusing mappings', () => {
     const mappings = createPlaceholderMap();
     const first = dehydrateConfidential('Serviceplan again', ruleSet, mappings);
-    const second = dehydrateConfidential('Serviceplan again', ruleSet, mappings);
+    const second = dehydrateConfidential(
+      'Serviceplan again',
+      ruleSet,
+      mappings,
+    );
     expect(first.text).toBe(second.text);
   });
 
   test('regex patterns are matched and rehydrated', () => {
     const text = 'See doc INT-123456 attached.';
-    const { text: dehydrated, mappings, hits } = dehydrateConfidential(
-      text,
-      ruleSet,
-    );
+    const {
+      text: dehydrated,
+      mappings,
+      hits,
+    } = dehydrateConfidential(text, ruleSet);
     expect(hits).toBe(1);
     expect(dehydrated).not.toContain('INT-123456');
     expect(rehydrateConfidential(dehydrated, mappings)).toContain('INT-123456');
@@ -106,7 +112,10 @@ describe('dehydrate / rehydrate', () => {
   });
 
   test('rehydrate with unknown placeholder is left intact', () => {
-    const out = rehydrateConfidential('See «CONF:UNKNOWN_001» here.', createPlaceholderMap());
+    const out = rehydrateConfidential(
+      'See «CONF:UNKNOWN_001» here.',
+      createPlaceholderMap(),
+    );
     expect(out).toBe('See «CONF:UNKNOWN_001» here.');
   });
 });

--- a/tests/confidential-runtime.test.ts
+++ b/tests/confidential-runtime.test.ts
@@ -62,4 +62,38 @@ describe('confidential runtime context', () => {
     wrapped?.('Replying about «CONF:CLIENT_001»');
     expect(seen[0]).toBe('Replying about Serviceplan');
   });
+
+  test('rehydrateFields restores listed string fields and leaves others alone', () => {
+    setConfidentialRuleSetForTesting(RULES);
+    const ctx = createConfidentialRuntimeContext();
+    ctx.dehydrate([{ role: 'user', content: 'About Serviceplan' }]);
+
+    const execution = {
+      name: 'noop',
+      arguments: 'See «CONF:CLIENT_001»',
+      result: 'Reply: «CONF:CLIENT_001»',
+      durationMs: 4,
+    };
+    const next = ctx.rehydrateFields(execution, [
+      'arguments',
+      'result',
+    ] as const);
+    expect(next?.arguments).toBe('See Serviceplan');
+    expect(next?.result).toBe('Reply: Serviceplan');
+    expect(next?.durationMs).toBe(4);
+  });
+
+  test('wrapEvent rehydrates listed string fields on each event', () => {
+    setConfidentialRuleSetForTesting(RULES);
+    const ctx = createConfidentialRuntimeContext();
+    ctx.dehydrate([{ role: 'user', content: 'About Serviceplan' }]);
+
+    const seen: { preview?: string }[] = [];
+    const wrapped = ctx.wrapEvent(
+      (event: { preview?: string }) => seen.push(event),
+      ['preview'] as const,
+    );
+    wrapped?.({ preview: 'tool starting on «CONF:CLIENT_001»' });
+    expect(seen[0]?.preview).toBe('tool starting on Serviceplan');
+  });
 });

--- a/tests/confidential-runtime.test.ts
+++ b/tests/confidential-runtime.test.ts
@@ -1,11 +1,10 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
-
+import { parseConfidentialYaml } from '../src/security/confidential-rules.js';
 import {
   createConfidentialRuntimeContext,
   resetConfidentialRuleSetCache,
   setConfidentialRuleSetForTesting,
 } from '../src/security/confidential-runtime.js';
-import { parseConfidentialYaml } from '../src/security/confidential-rules.js';
 
 const RULES = parseConfidentialYaml(
   `clients:\n  - name: Serviceplan\n    sensitivity: high\n`,

--- a/tests/confidential-runtime.test.ts
+++ b/tests/confidential-runtime.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  createConfidentialRuntimeContext,
+  resetConfidentialRuleSetCache,
+  setConfidentialRuleSetForTesting,
+} from '../src/security/confidential-runtime.js';
+import { parseConfidentialYaml } from '../src/security/confidential-rules.js';
+
+const RULES = parseConfidentialYaml(
+  `clients:\n  - name: Serviceplan\n    sensitivity: high\n`,
+);
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  resetConfidentialRuleSetCache();
+});
+
+describe('confidential runtime context', () => {
+  test('returns no-op context when no rules exist', () => {
+    setConfidentialRuleSetForTesting({ rules: [], sourcePath: null });
+    const ctx = createConfidentialRuntimeContext();
+    expect(ctx.enabled).toBe(false);
+    const messages = [{ role: 'user', content: 'hello Serviceplan' }];
+    expect(ctx.dehydrate(messages)).toEqual(messages);
+    expect(ctx.rehydrate('hello «CONF:CLIENT_001»')).toBe(
+      'hello «CONF:CLIENT_001»',
+    );
+  });
+
+  test('dehydrates and rehydrates round-trip when rules are present', () => {
+    setConfidentialRuleSetForTesting(RULES);
+
+    const ctx = createConfidentialRuntimeContext();
+    expect(ctx.enabled).toBe(true);
+
+    const messages = [
+      { role: 'system', content: 'You are an assistant.' },
+      { role: 'user', content: 'Briefing for Serviceplan today.' },
+    ];
+    const dehydrated = ctx.dehydrate(messages);
+    expect(dehydrated[1].content).not.toContain('Serviceplan');
+    expect(typeof dehydrated[1].content).toBe('string');
+    expect(ctx.rehydrate(dehydrated[1].content as string)).toContain(
+      'Serviceplan',
+    );
+  });
+
+  test('honours HYBRIDCLAW_CONFIDENTIAL_DISABLE override', () => {
+    setConfidentialRuleSetForTesting(RULES);
+    vi.stubEnv('HYBRIDCLAW_CONFIDENTIAL_DISABLE', '1');
+    const ctx = createConfidentialRuntimeContext();
+    expect(ctx.enabled).toBe(false);
+  });
+
+  test('wrapDelta rehydrates streamed text', () => {
+    setConfidentialRuleSetForTesting(RULES);
+    const ctx = createConfidentialRuntimeContext();
+    ctx.dehydrate([{ role: 'user', content: 'About Serviceplan' }]);
+
+    const seen: string[] = [];
+    const wrapped = ctx.wrapDelta((delta: string) => seen.push(delta));
+    wrapped?.('Replying about «CONF:CLIENT_001»');
+    expect(seen[0]).toBe('Replying about Serviceplan');
+  });
+});

--- a/tests/confidential-runtime.test.ts
+++ b/tests/confidential-runtime.test.ts
@@ -96,4 +96,98 @@ describe('confidential runtime context', () => {
     wrapped?.({ preview: 'tool starting on «CONF:CLIENT_001»' });
     expect(seen[0]?.preview).toBe('tool starting on Serviceplan');
   });
+
+  test('dehydrates assistant tool_calls[].function.arguments JSON', () => {
+    setConfidentialRuleSetForTesting(RULES);
+    const ctx = createConfidentialRuntimeContext();
+    const messages = [
+      { role: 'user', content: 'search Serviceplan' },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: {
+              name: 'web_search',
+              arguments: JSON.stringify({ query: 'Serviceplan' }),
+            },
+          },
+        ],
+      },
+    ];
+    const dehydrated = ctx.dehydrate(messages);
+    const toolCallArgs = (
+      dehydrated[1] as {
+        tool_calls: { function: { arguments: string } }[];
+      }
+    ).tool_calls[0].function.arguments;
+    expect(toolCallArgs).not.toContain('Serviceplan');
+    // Result is still parseable JSON with the placeholder substituted.
+    const parsed = JSON.parse(toolCallArgs);
+    expect(parsed.query).toMatch(/^«CONF:/);
+    // The user's content was dehydrated to the same placeholder so the
+    // model sees a consistent term throughout the conversation history.
+    const userContent = (dehydrated[0] as { content: string }).content;
+    expect(userContent).toContain(parsed.query);
+  });
+
+  test('messages with tool_calls but no confidential matches are passed through', () => {
+    setConfidentialRuleSetForTesting(RULES);
+    const ctx = createConfidentialRuntimeContext();
+    const messages = [
+      {
+        role: 'assistant',
+        content: 'all good',
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: {
+              name: 'noop',
+              arguments: '{"q":"hello world"}',
+            },
+          },
+        ],
+      },
+    ];
+    const dehydrated = ctx.dehydrate(messages);
+    expect(dehydrated[0]).toBe(messages[0]);
+  });
+
+  test('wrapDelta buffers placeholders split across delta boundaries', () => {
+    setConfidentialRuleSetForTesting(RULES);
+    const ctx = createConfidentialRuntimeContext();
+    ctx.dehydrate([{ role: 'user', content: 'About Serviceplan' }]);
+
+    const seen: string[] = [];
+    const wrapped = ctx.wrapDelta((delta: string) => seen.push(delta));
+    // The placeholder «CONF:CLIENT_001» is split across three chunks.
+    wrapped?.('Replying about ');
+    wrapped?.('«CONF:CLIENT_');
+    wrapped?.('001» now');
+    const joined = seen.join('');
+    expect(joined).toContain('Replying about Serviceplan');
+    // None of the individual chunks emitted a broken half.
+    for (const chunk of seen) {
+      expect(chunk).not.toMatch(/«CONF:[A-Z0-9_-]*$/);
+      expect(chunk).not.toMatch(/^[A-Z0-9_-]*»/);
+    }
+  });
+
+  test('wrapDelta releases orphan « after lookahead window expires', () => {
+    setConfidentialRuleSetForTesting(RULES);
+    const ctx = createConfidentialRuntimeContext();
+    const seen: string[] = [];
+    const wrapped = ctx.wrapDelta((delta: string) => seen.push(delta));
+    // 80 chars of plain text after the «, well past the 64-char
+    // lookahead, with no closing » — the tail must be flushed so the
+    // user does not stall on a legitimate `«` in prose.
+    wrapped?.('quote «');
+    wrapped?.('a'.repeat(80));
+    const joined = seen.join('');
+    expect(joined).toContain('«');
+    expect(joined.length).toBeGreaterThan(40);
+  });
 });


### PR DESCRIPTION
> Supersedes #405 (auto-closed when the branch was renamed from
> `claude/hopeful-fermat-758cd4` to `feat/nda-leak-detector`). All commits
> are identical; the original Copilot review thread on #405 is addressed in
> commit `91780cc3` and is still visible there for reference.

## Summary

- **Problem:** HybridClaw had no way to keep NDA-class business data (client names, project codenames, internal IDs) out of LLM prompts, and no way to inspect existing audit logs for past leaks. Roadmap item #6.
- **Why it matters:** Backs Manifesto Principle V (*"under NDA from minute one"*). Without it, an agency operator using HybridClaw on a Serviceplan briefing has no technical guarantee that Serviceplan's client names won't leak to a third-party model provider.
- **What changed:** Adds an opt-in pre-LLM dehydration filter (placeholders + rehydration) wired into `runAgent`, plus a `hybridclaw audit scan-leaks` command that walks existing `wire.jsonl` audit logs and produces per-session findings with a 0-100 risk score.
- **What did not change:** Existing credential redaction (`src/security/redact.ts`), audit hash chain, approval policy, mount allowlists, or any provider/executor wiring. Feature is a no-op until a `.confidential.yml` is created.

## Change Type

- [x] Feature
- [x] Security hardening
- [x] Tests
- [x] Docs

## Linked Context

- Implements roadmap item #6: *"NDA / secret-leak detector across all prompts"* (~/examples/trusted-coworker-roadmap.md)
- Pairs with roadmap item #4 (business-secret masking + demasking) — same placeholder format, same ruleset
- Inspired by picoclaw `pkg/config/security.go` + `.security.yml` (config-driven sensitive-data filter)
- Closes #405 (review feedback addressed; this PR is the live thread)

## Validation

```bash
npm run typecheck     # clean
npm run check         # biome clean
npx vitest run tests/confidential-redact.test.ts \
               tests/confidential-leak-scanner.test.ts \
               tests/confidential-runtime.test.ts \
               tests/agent-executor.test.ts
# 26/26 passing
```

- Verified manually:
  - Round-trip dehydrate → rehydrate preserves user-facing content (literal, alias, regex matches)
  - `scan-leaks` returns non-zero score for matched audit records, zero for clean ones
  - `hadPlaceholder` flag correctly distinguishes pre/post-dehydrate content in audit logs
  - `HYBRIDCLAW_CONFIDENTIAL_DISABLE=1` correctly forces the runtime no-op path
  - Tool-progress events, `pendingApproval`, and `toolExecutions[]` strings all rehydrate before reaching the user (regression caught by reviewer on #405)
- Edge cases checked: empty rule set (no-op), unknown placeholder in rehydrate (left intact), score capping at 1000, case-insensitive literal matching, word-boundary protection (`Acme` won't match `AcmeWidget`)
- Skipped checks: full `npm run test:unit` has 10 unrelated pre-existing failures (browser bin env var, plugin-singleton timeout, eval-command flake, host-runner respawn) that reproduce identically on `main` without these changes — confirmed via `git stash && vitest run …`

## Docs And Config Impact

- [x] README, docs, or examples updated — new section *4.1) Confidential-Info Filter* in `SECURITY.md`, `audit scan-leaks` added to `printAuditUsage()`
- [x] Config or environment behavior changed — new optional file (search order: `./.confidential.yml` → `~/.hybridclaw/.confidential.yml`, first hit wins), new env var `HYBRIDCLAW_CONFIDENTIAL_DISABLE`
- [ ] Templates or workspace bootstrap files changed
- [ ] No docs or config impact

`.confidential.example.yml` added at the repo root for users to copy. `.gitignore` excludes `.confidential.yml`. No `templates/` files touched.

## Risk Notes

- Security-sensitive paths touched? **Yes** — `src/security/` (new modules) and `src/agent/agent.ts` (wire-up). `src/audit/` extended with read-only scanner.
- Gateway, audit, approval, or container boundaries touched? **Audit** read-only (new scanner reads existing `wire.jsonl`); **agent** modified to wrap exec call.
- Failure mode: if the YAML loader fails, it logs a warning and returns an empty rule set — runtime falls back to the no-op context. If neither config file exists, the entire feature compiles to a single map+identity-callback chain via the no-op fast path in `createConfidentialRuntimeContext`.
- Failure mode tested: empty/missing config, malformed YAML (covered by `parseConfidentialYaml('')` test), missing wire log file (returns errors array, not a throw).

## Evidence

- New test coverage: 25 tests across 3 files
  - `tests/confidential-redact.test.ts` — rule parsing, dehydrate/rehydrate, scoring, severity sort
  - `tests/confidential-leak-scanner.test.ts` — wire.jsonl walking, multi-session aggregation, missing-file errors, post-dehydration detection
  - `tests/confidential-runtime.test.ts` — opt-in/disable, message dehydration, streaming delta rehydration, tool-surface field rehydration, event wrapping

### Architecture

```
.confidential.yml (./ or ~/.hybridclaw/)
        │
        ▼
confidential-rules.ts  ──►  confidential-redact.ts  ──►  confidential-runtime.ts
   (loader, types)        (dehydrate/rehydrate/scan)      (cached + opt-in ctx)
                                       │                          │
                                       ▼                          ▼
                          audit/leak-scanner.ts          agent/agent.ts (runAgent)
                                       │                          │
                                       ▼                          ▼
                       hybridclaw audit scan-leaks       Pre-LLM dehydration +
                                                          response rehydration
                                                          (text + tool surfaces)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)