### PR TITLE
fix: improve mobile chat layout and handoff

### DIFF
--- a/console/src/api/chat-types.ts
+++ b/console/src/api/chat-types.ts
@@ -10,6 +10,12 @@ export interface ChatRecentResponse {
   sessions: ChatRecentSession[];
 }
 
+export interface ChatMobileQrResponse {
+  launchUrl: string;
+  expiresAt: string;
+  qrSvg: string;
+}
+
 export interface ChatHistoryMessage {
   role: 'user' | 'assistant' | 'system';
   content: string;

--- a/console/src/api/chat.ts
+++ b/console/src/api/chat.ts
@@ -2,6 +2,7 @@ import type {
   BranchResponse,
   ChatCommandsResponse,
   ChatHistoryResponse,
+  ChatMobileQrResponse,
   ChatRecentResponse,
   CommandResponse,
   MediaUploadResponse,
@@ -57,6 +58,17 @@ export function fetchChatCommands(
     ? `/api/chat/commands?q=${encodeURIComponent(query)}`
     : '/api/chat/commands';
   return requestJson<ChatCommandsResponse>(url, { token });
+}
+
+export function createChatMobileQr(
+  token: string,
+  payload: { userId: string; sessionId: string; baseUrl?: string },
+): Promise<ChatMobileQrResponse> {
+  return requestJson<ChatMobileQrResponse>('/api/chat/mobile-qr', {
+    token,
+    method: 'POST',
+    body: payload,
+  });
 }
 
 export function createChatBranch(

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -3,7 +3,8 @@
 
   display: flex;
   width: 100%;
-  height: 100dvh;
+  max-width: 100vw;
+  height: var(--chat-visual-viewport-height, 100dvh);
   min-height: 0;
   overflow: hidden;
 }
@@ -14,6 +15,22 @@
 .chatPage > div {
   min-height: 0;
   height: 100%;
+}
+
+:global(.layout):has(.chatPage) {
+  width: 100%;
+  max-width: 100vw;
+  min-height: 0;
+  height: var(--chat-visual-viewport-height, 100dvh);
+  overflow: hidden;
+}
+
+:global(html:has(.chatPage)),
+:global(body:has(.chatPage)),
+:global(#root:has(.chatPage)) {
+  width: 100%;
+  max-width: 100vw;
+  overflow-x: hidden;
 }
 
 .chatSidebarHeader {
@@ -103,11 +120,6 @@
   background: var(--chat-hover-bg);
 }
 
-.sessionItemActive .sessionTitle,
-.sessionItemActive .sessionSnippet {
-  color: var(--primary);
-}
-
 .sessionItemPending {
   animation: sessionPulse 1s ease-in-out infinite;
 }
@@ -142,6 +154,11 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.sessionItemActive .sessionTitle,
+.sessionItemActive .sessionSnippet {
+  color: var(--primary);
 }
 
 .sidebarSearchWrap {
@@ -194,15 +211,127 @@ aside[data-state="collapsed"] .chatSidebarContent {
 
 .chatTopbar {
   display: flex;
+  gap: 10px;
+  align-items: center;
   justify-content: flex-end;
   padding: 24px 24px 0;
   flex-shrink: 0;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.mobileQrButton {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-bg);
+  color: var(--muted-foreground);
+  cursor: pointer;
+}
+
+.mobileQrButton:hover {
+  color: var(--primary);
+  border-color: color-mix(in srgb, var(--primary) 42%, var(--line));
+}
+
+.mobileQrButton:disabled {
+  opacity: 0.55;
+  cursor: wait;
+}
+
+.mobileQrIcon {
+  display: grid;
+  grid-template-columns: repeat(2, 7px);
+  grid-template-rows: repeat(2, 7px);
+  gap: 3px;
+}
+
+.mobileQrIcon span {
+  border: 2px solid currentColor;
+  border-radius: 2px;
+}
+
+.mobileQrOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+  background: color-mix(in srgb, #020617 45%, transparent);
+}
+
+.mobileQrDialog {
+  width: min(360px, 100%);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--panel-bg);
+  box-shadow: 0 18px 55px rgb(15 23 42 / 22%);
+  padding: 18px;
+}
+
+.mobileQrHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.mobileQrHeader h2 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 650;
+}
+
+.mobileQrClose {
+  appearance: none;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  font: inherit;
+  line-height: 1;
+}
+
+.mobileQrImage {
+  display: flex;
+  justify-content: center;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: #fff;
+}
+
+.mobileQrImage img {
+  width: min(260px, 100%);
+  height: auto;
+}
+
+.mobileQrLink {
+  display: block;
+  margin-top: 12px;
+  color: var(--primary);
+  font-size: 0.86rem;
+  text-align: center;
+  word-break: break-word;
 }
 
 .chatMain {
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
+  height: 100%;
   min-height: 0;
   min-width: 0;
   overflow: hidden;
@@ -213,7 +342,9 @@ aside[data-state="collapsed"] .chatSidebarContent {
 .messageArea {
   flex: 1 1 auto;
   min-height: 0;
+  min-width: 0;
   overflow-y: auto;
+  overflow-x: hidden;
   padding: 16px 24px 12px;
   scroll-behavior: smooth;
 }
@@ -223,6 +354,8 @@ aside[data-state="collapsed"] .chatSidebarContent {
   flex-direction: column;
   gap: 12px;
   width: 100%;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .sidebarCollapseButton {
@@ -252,6 +385,9 @@ aside[data-state="collapsed"] .chatSidebarContent {
   display: flex;
   flex-direction: column;
   gap: 6px;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .messageBlockUser {
@@ -297,6 +433,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
   padding: 10px 14px;
   border-radius: 14px;
   max-width: 85%;
+  min-width: 0;
   word-wrap: break-word;
   overflow-wrap: break-word;
   line-height: 1.55;
@@ -328,6 +465,9 @@ aside[data-state="collapsed"] .chatSidebarContent {
 
 .markdownContent {
   line-height: 1.6;
+  max-width: 100%;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .markdownContent h1,
@@ -604,13 +744,19 @@ aside[data-state="collapsed"] .chatSidebarContent {
 
 .composerWrapper {
   flex-shrink: 0;
+  margin-top: auto;
   padding: 0 24px 20px;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .composer {
   display: flex;
   flex-direction: column;
   width: 100%;
+  min-width: 0;
+  max-width: 100%;
   padding: 12px 16px;
   gap: 8px;
   border: 1px solid var(--line-strong);
@@ -899,12 +1045,63 @@ aside[data-state="collapsed"] .chatSidebarContent {
 }
 
 @media (max-width: 900px) {
+  .chatPage {
+    position: fixed;
+    inset: 0;
+    width: 100vw;
+    max-width: 100vw;
+  }
+
+  .chatPage,
+  .chatPage * {
+    max-width: 100vw;
+  }
+
+  .chatPage {
+    height: var(--chat-visual-viewport-height, 100svh);
+  }
+
+  .chatMain {
+    flex: 0 0 100vw;
+    width: 100vw;
+    max-width: 100vw;
+  }
+
+  .chatTopbar {
+    width: 100vw;
+    padding: 8px 16px 0;
+  }
+
   .messageArea {
-    padding: 16px 16px 8px;
+    width: 100vw;
+    max-width: 100vw;
+    padding: 16px 16px calc(var(--chat-composer-height, 150px) + 12px);
+  }
+
+  .messageList,
+  .messageBlock {
+    width: 100%;
+    max-width: 100%;
+    overflow-x: clip;
+  }
+
+  .bubble {
+    max-width: min(95%, calc(100vw - 32px));
+  }
+
+  .bubbleUser,
+  .bubbleAssistant {
+    max-width: min(95%, calc(100vw - 32px));
   }
 
   .composerWrapper {
-    padding: 0 16px 12px;
+    position: fixed;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 45;
+    padding: 0 16px;
+    background: var(--page-bg);
   }
 
   .slashSuggestions {
@@ -919,11 +1116,11 @@ aside[data-state="collapsed"] .chatSidebarContent {
   }
 
   .messageArea {
-    padding: 12px 8px 8px;
+    padding: 12px 8px calc(var(--chat-composer-height, 150px) + 12px);
   }
 
   .composerWrapper {
-    padding: 0 8px 8px;
+    padding: 0 12px;
   }
 
   .emptyState h1 {

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -20,6 +20,7 @@ vi.mock('@tanstack/react-router', async () => {
 import type {
   BranchResponse,
   ChatHistoryResponse,
+  ChatMobileQrResponse,
   ChatRecentResponse,
   MediaUploadResponse,
 } from '../../api/chat-types';
@@ -40,6 +41,13 @@ const fetchChatRecentMock =
   >();
 const fetchChatHistoryMock =
   vi.fn<(token: string, sessionId: string) => Promise<ChatHistoryResponse>>();
+const createChatMobileQrMock =
+  vi.fn<
+    (
+      token: string,
+      payload: { userId: string; sessionId: string; baseUrl?: string },
+    ) => Promise<ChatMobileQrResponse>
+  >();
 const createChatBranchMock =
   vi.fn<
     (
@@ -68,6 +76,10 @@ vi.mock('../../api/chat', () => ({
   ) => fetchChatRecentMock(token, userId, channelId, limit, query),
   fetchChatHistory: (token: string, sessionId: string) =>
     fetchChatHistoryMock(token, sessionId),
+  createChatMobileQr: (
+    token: string,
+    payload: { userId: string; sessionId: string; baseUrl?: string },
+  ) => createChatMobileQrMock(token, payload),
   createChatBranch: (
     token: string,
     sessionId: string,
@@ -138,6 +150,7 @@ describe('ChatPage', () => {
     fetchAppStatusMock.mockReset();
     fetchChatRecentMock.mockReset();
     fetchChatHistoryMock.mockReset();
+    createChatMobileQrMock.mockReset();
     createChatBranchMock.mockReset();
     uploadMediaMock.mockReset();
     fetchAgentListMock.mockReset();
@@ -193,6 +206,11 @@ describe('ChatPage', () => {
       { id: 'main', name: 'Assistant' },
       { id: 'charly', name: 'Charly' },
     ]);
+    createChatMobileQrMock.mockResolvedValue({
+      launchUrl: 'https://example.test/chat/continue?token=test-token',
+      expiresAt: '2026-04-14T10:10:00.000Z',
+      qrSvg: '<svg viewBox="0 0 1 1"></svg>',
+    });
     isActiveMock.mockReturnValue(false);
     useChatStreamMock.mockReturnValue({
       sendMessage: sendMessageMock,
@@ -712,5 +730,58 @@ describe('ChatPage', () => {
     });
 
     expect(openTriggersInChatTopbar()).toBe(0);
+  });
+
+  it('refreshes recent sessions when the mobile sidebar opens', async () => {
+    fetchChatHistoryMock.mockResolvedValue({
+      sessionId: 'session-a',
+      history: [],
+    });
+
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 800,
+    });
+
+    renderChatPage();
+
+    await waitFor(() => expect(fetchChatRecentMock).toHaveBeenCalledTimes(1));
+
+    const topbar = document.querySelector('[class*="chatTopbar"]');
+    if (!(topbar instanceof HTMLElement)) {
+      throw new Error('Missing chat topbar');
+    }
+
+    fireEvent.click(
+      within(topbar).getByRole('button', { name: 'Open sidebar' }),
+    );
+
+    await waitFor(() => expect(fetchChatRecentMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('creates a mobile handoff QR code for the active chat session', async () => {
+    fetchChatHistoryMock.mockResolvedValue({
+      sessionId: 'session-a',
+      history: [{ id: 101, role: 'assistant', content: 'Opened session A' }],
+    });
+
+    renderChatPage();
+
+    expect(await screen.findByText('Opened session A')).not.toBeNull();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Show mobile QR code' }),
+    );
+
+    await waitFor(() =>
+      expect(createChatMobileQrMock).toHaveBeenCalledWith('test-token', {
+        userId: 'web-user-1',
+        sessionId: 'session-a',
+        baseUrl: 'http://localhost:3000',
+      }),
+    );
+    expect(await screen.findByText('Open on mobile')).not.toBeNull();
+    expect(screen.getByText('Open link')).not.toBeNull();
   });
 });

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -783,5 +783,14 @@ describe('ChatPage', () => {
     );
     expect(await screen.findByText('Open on mobile')).not.toBeNull();
     expect(screen.getByText('Open link')).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Close mobile QR code' })).toBe(
+      document.activeElement,
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    await waitFor(() =>
+      expect(screen.queryByText('Open on mobile')).toBeNull(),
+    );
   });
 });

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -2,6 +2,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   createChatBranch,
+  createChatMobileQr,
   fetchAppStatus,
   fetchChatRecent,
   uploadMedia,
@@ -9,6 +10,7 @@ import {
 import type {
   BranchVariant,
   ChatMessage,
+  ChatMobileQrResponse,
   MediaItem,
 } from '../../api/chat-types';
 import { fetchAgentList } from '../../api/client';
@@ -78,6 +80,8 @@ export function ChatPage() {
   const [error, setError] = useState('');
   const [editingId, setEditingId] = useState<string | null>(null);
   const [approvalBusy, setApprovalBusy] = useState(false);
+  const [mobileQr, setMobileQr] = useState<ChatMobileQrResponse | null>(null);
+  const [mobileQrBusy, setMobileQrBusy] = useState(false);
   const [selectedAgentId, setSelectedAgentId] = useState(
     defaultAgentIdRef.current,
   );
@@ -91,6 +95,40 @@ export function ChatPage() {
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messageAreaRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const setVisualViewportHeight = () => {
+      const height = window.visualViewport?.height ?? window.innerHeight;
+      if (!Number.isFinite(height) || height <= 0) return;
+      document.documentElement.style.setProperty(
+        '--chat-visual-viewport-height',
+        `${Math.round(height)}px`,
+      );
+      document.scrollingElement?.scrollTo({ left: 0 });
+      document.body.scrollLeft = 0;
+      document.documentElement.scrollLeft = 0;
+    };
+    setVisualViewportHeight();
+    window.addEventListener('resize', setVisualViewportHeight);
+    window.addEventListener('orientationchange', setVisualViewportHeight);
+    window.visualViewport?.addEventListener('resize', setVisualViewportHeight);
+    window.visualViewport?.addEventListener('scroll', setVisualViewportHeight);
+    return () => {
+      window.removeEventListener('resize', setVisualViewportHeight);
+      window.removeEventListener('orientationchange', setVisualViewportHeight);
+      window.visualViewport?.removeEventListener(
+        'resize',
+        setVisualViewportHeight,
+      );
+      window.visualViewport?.removeEventListener(
+        'scroll',
+        setVisualViewportHeight,
+      );
+      document.documentElement.style.removeProperty(
+        '--chat-visual-viewport-height',
+      );
+    };
+  }, []);
 
   const getDefaultAgentId = useCallback(() => defaultAgentIdRef.current, []);
   const {
@@ -364,6 +402,34 @@ export function ChatPage() {
     [queryClient, auth.token, getSessionId],
   );
 
+  const handleRefreshRecent = useCallback(() => {
+    void queryClient.invalidateQueries({
+      queryKey: ['chat-recent', auth.token, userId, trimmedSessionSearchQuery],
+    });
+  }, [queryClient, auth.token, userId, trimmedSessionSearchQuery]);
+
+  const handleOpenMobileQr = useCallback(async () => {
+    const activeSessionId = getSessionId();
+    if (!activeSessionId) {
+      setError('Open or send a chat before creating a mobile QR code.');
+      return;
+    }
+    setMobileQrBusy(true);
+    try {
+      setMobileQr(
+        await createChatMobileQr(auth.token, {
+          userId,
+          sessionId: activeSessionId,
+          baseUrl: window.location.origin,
+        }),
+      );
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setMobileQrBusy(false);
+    }
+  }, [auth.token, getSessionId, userId]);
+
   const handleEditOpen = useCallback((m: ChatMessage) => {
     setEditingId(m.id);
   }, []);
@@ -400,6 +466,7 @@ export function ChatPage() {
     searchQuery: sessionSearchQuery,
     onSearchQueryChange: setSessionSearchQuery,
     isLoading: recentQuery.isFetching,
+    onRefreshRecent: handleRefreshRecent,
   } as const;
 
   return (
@@ -410,8 +477,54 @@ export function ChatPage() {
         <div className={css.chatMain}>
           <div className={css.chatTopbar}>
             <MobileTopbarTrigger className={css.chatMobileTrigger} />
+            <button
+              type="button"
+              className={css.mobileQrButton}
+              onClick={() => void handleOpenMobileQr()}
+              disabled={mobileQrBusy}
+              aria-label="Show mobile QR code"
+              title="Show mobile QR code"
+            >
+              <span aria-hidden="true" className={css.mobileQrIcon}>
+                <span />
+                <span />
+                <span />
+                <span />
+              </span>
+            </button>
             <ViewSwitchNav />
           </div>
+          {mobileQr ? (
+            <div className={css.mobileQrOverlay}>
+              <div
+                className={css.mobileQrDialog}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="mobile-qr-title"
+              >
+                <div className={css.mobileQrHeader}>
+                  <h2 id="mobile-qr-title">Open on mobile</h2>
+                  <button
+                    type="button"
+                    className={css.mobileQrClose}
+                    onClick={() => setMobileQr(null)}
+                    aria-label="Close mobile QR code"
+                  >
+                    x
+                  </button>
+                </div>
+                <div className={css.mobileQrImage}>
+                  <img
+                    src={`data:image/svg+xml;charset=utf-8,${encodeURIComponent(mobileQr.qrSvg)}`}
+                    alt="Mobile session QR code"
+                  />
+                </div>
+                <a className={css.mobileQrLink} href={mobileQr.launchUrl}>
+                  Open link
+                </a>
+              </div>
+            </div>
+          ) : null}
           {isEmpty ? (
             <div className={css.emptyState}>
               <h1 className={css.greeting}>

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -95,6 +95,8 @@ export function ChatPage() {
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messageAreaRef = useRef<HTMLDivElement>(null);
+  const mobileQrDialogRef = useRef<HTMLDivElement>(null);
+  const mobileQrCloseRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     const setVisualViewportHeight = () => {
@@ -236,6 +238,49 @@ export function ChatPage() {
     if (!historyQuery.error) return;
     setError(getErrorMessage(historyQuery.error));
   }, [historyQuery.error]);
+
+  useEffect(() => {
+    if (!mobileQr) return;
+    const previousOverflow = document.body.style.overflow;
+    const previousActiveElement = document.activeElement;
+    document.body.style.overflow = 'hidden';
+    mobileQrCloseRef.current?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setMobileQr(null);
+        return;
+      }
+      if (event.key !== 'Tab') return;
+
+      const focusable = Array.from(
+        mobileQrDialogRef.current?.querySelectorAll<HTMLElement>(
+          'a[href], button:not(:disabled)',
+        ) ?? [],
+      );
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last?.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first?.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = previousOverflow;
+      if (previousActiveElement instanceof HTMLElement) {
+        previousActiveElement.focus();
+      }
+    };
+  }, [mobileQr]);
 
   // Server may resolve to a canonical branch id; keep the URL in sync.
   useEffect(() => {
@@ -497,6 +542,7 @@ export function ChatPage() {
           {mobileQr ? (
             <div className={css.mobileQrOverlay}>
               <div
+                ref={mobileQrDialogRef}
                 className={css.mobileQrDialog}
                 role="dialog"
                 aria-modal="true"
@@ -505,6 +551,7 @@ export function ChatPage() {
                 <div className={css.mobileQrHeader}>
                   <h2 id="mobile-qr-title">Open on mobile</h2>
                   <button
+                    ref={mobileQrCloseRef}
                     type="button"
                     className={css.mobileQrClose}
                     onClick={() => setMobileQr(null)}

--- a/console/src/routes/chat/chat-sidebar.tsx
+++ b/console/src/routes/chat/chat-sidebar.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import type { ChatRecentSession } from '../../api/chat-types';
 import { useAuth } from '../../auth';
 import {
@@ -10,6 +11,7 @@ import {
   SidebarFooter,
   SidebarHeader,
   SidebarTrigger,
+  useSidebar,
 } from '../../components/sidebar/index';
 import sidebarStyles from '../../components/sidebar/index.module.css';
 import { ThemeToggle } from '../../components/theme-toggle';
@@ -29,11 +31,19 @@ export interface ChatSidebarProps {
   searchQuery: string;
   onSearchQueryChange: (value: string) => void;
   isLoading: boolean;
+  onRefreshRecent?: () => void;
 }
 
 export function ChatSidebarPanel(props: ChatSidebarProps) {
   const auth = useAuth();
+  const sidebar = useSidebar();
   const isSearching = props.searchQuery.trim().length > 0;
+
+  useEffect(() => {
+    if (!sidebar.openMobile) return;
+    props.onRefreshRecent?.();
+  }, [props.onRefreshRecent, sidebar.openMobile]);
+
   return (
     <Sidebar side="left" collapsible="icon">
       <SidebarHeader>

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -62,6 +62,7 @@ export function Composer(props: {
 }) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const [pendingMedia, setPendingMedia] = useState<MediaItem[]>([]);
   const [uploading, setUploading] = useState(0);
   const [suggestions, setSuggestions] = useState<ChatCommandSuggestion[]>([]);
@@ -73,6 +74,34 @@ export function Composer(props: {
   useEffect(() => {
     return () => {
       if (suggestTimerRef.current) clearTimeout(suggestTimerRef.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    const wrapper = wrapperRef.current;
+    if (!wrapper) return;
+
+    const updateComposerHeight = () => {
+      const height = wrapper.getBoundingClientRect().height;
+      if (!Number.isFinite(height) || height <= 0) return;
+      document.documentElement.style.setProperty(
+        '--chat-composer-height',
+        `${Math.ceil(height)}px`,
+      );
+    };
+
+    updateComposerHeight();
+    const observer =
+      typeof ResizeObserver === 'undefined'
+        ? null
+        : new ResizeObserver(updateComposerHeight);
+    observer?.observe(wrapper);
+    window.addEventListener('resize', updateComposerHeight);
+
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener('resize', updateComposerHeight);
+      document.documentElement.style.removeProperty('--chat-composer-height');
     };
   }, []);
 
@@ -209,7 +238,7 @@ export function Composer(props: {
   const selectedAgentId = props.selectedAgentId ?? '';
 
   return (
-    <div className={css.composerWrapper}>
+    <div className={css.composerWrapper} ref={wrapperRef}>
       <div className={css.composer} style={{ position: 'relative' }}>
         {showSuggestions ? (
           <SlashSuggestions

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -186,6 +186,7 @@ import {
   handleOpenAICompatibleChatCompletions,
   handleOpenAICompatibleModelList,
 } from './openai-compatible.js';
+import { renderQrSvg } from './qr-svg.js';
 import {
   handleTextChannelApprovalCommand,
   renderTextChannelCommandResult,
@@ -333,6 +334,18 @@ type ApiPluginToolRequestBody = {
   sessionId?: unknown;
   channelId?: unknown;
 };
+
+type ApiChatMobileQrRequestBody = {
+  userId?: unknown;
+  sessionId?: unknown;
+  baseUrl?: unknown;
+};
+
+const MOBILE_LAUNCH_TTL_MS = 10 * 60 * 1000;
+const mobileLaunchTokens = new Map<
+  string,
+  { userId: string; sessionId: string; expiresAt: number }
+>();
 
 function parseApiAdminPolicyIndex(value: unknown): number {
   const parsed = parsePositiveInteger(value);
@@ -710,6 +723,87 @@ function sendRedirect(
     Location: location,
   });
   res.end();
+}
+
+function escapeInlineScriptValue(value: string): string {
+  return JSON.stringify(value).replace(/</g, '\\u003c');
+}
+
+function cleanupExpiredMobileLaunchTokens(now = Date.now()): void {
+  for (const [token, entry] of mobileLaunchTokens) {
+    if (entry.expiresAt <= now) mobileLaunchTokens.delete(token);
+  }
+}
+
+function createMobileLaunchToken(params: {
+  userId: string;
+  sessionId: string;
+}): string {
+  cleanupExpiredMobileLaunchTokens();
+  const token = randomUUID();
+  mobileLaunchTokens.set(token, {
+    userId: params.userId,
+    sessionId: params.sessionId,
+    expiresAt: Date.now() + MOBILE_LAUNCH_TTL_MS,
+  });
+  return token;
+}
+
+function resolveMobileLaunchToken(token: string):
+  | {
+      userId: string;
+      sessionId: string;
+    }
+  | undefined {
+  cleanupExpiredMobileLaunchTokens();
+  const entry = mobileLaunchTokens.get(token.trim());
+  if (!entry) return undefined;
+  return {
+    userId: entry.userId,
+    sessionId: entry.sessionId,
+  };
+}
+
+function normalizePublicBaseUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return undefined;
+    }
+    return url.origin;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveRequestOrigin(
+  req: IncomingMessage,
+  bodyBaseUrl?: unknown,
+): string {
+  const explicitBaseUrl = normalizePublicBaseUrl(bodyBaseUrl);
+  if (explicitBaseUrl) return explicitBaseUrl;
+
+  const forwardedProto = String(req.headers['x-forwarded-proto'] || '')
+    .split(',')[0]
+    ?.trim();
+  const forwardedHost = String(req.headers['x-forwarded-host'] || '')
+    .split(',')[0]
+    ?.trim();
+  const proto = forwardedProto || 'http';
+  const host = forwardedHost || req.headers.host || `127.0.0.1:${HEALTH_PORT}`;
+  return `${proto}://${host}`;
+}
+
+function buildMobileLaunchUrl(params: {
+  origin: string;
+  token: string;
+}): string {
+  const url = new URL('/chat/continue', params.origin);
+  url.searchParams.set('token', params.token);
+  return url.toString();
 }
 
 function resolveHybridAILoginUrl(): string | null {
@@ -1816,6 +1910,9 @@ function handleApiChatRecent(
 ): void {
   const channelId = (url.searchParams.get('channelId') || 'web').trim();
   const query = normalizeRecentChatSearchQuery(url.searchParams.get('q'));
+  const hasWebSessionUser =
+    channelId.toLowerCase() === 'web' &&
+    Boolean(resolveSessionAuthenticatedUserId(req));
   const userId = resolveGatewayRequestUserId({
     req,
     channelId,
@@ -1835,8 +1932,71 @@ function handleApiChatRecent(
       channelId,
       limit,
       ...(query ? { query } : {}),
+      ...(channelId.toLowerCase() === 'web' && !hasWebSessionUser
+        ? { fallbackToChannelRecent: true }
+        : {}),
     }),
   });
+}
+
+async function handleApiChatMobileQr(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  const body = (await readJsonBody(req)) as ApiChatMobileQrRequestBody;
+  const userId = normalizeOptionalString(body.userId);
+  const sessionId = normalizeOptionalString(body.sessionId);
+  if (!userId) {
+    sendJson(res, 400, { error: 'Missing `userId` in request body.' });
+    return;
+  }
+  if (!sessionId) {
+    sendJson(res, 400, { error: 'Missing `sessionId` in request body.' });
+    return;
+  }
+  if (isMalformedCanonicalSessionId(sessionId)) {
+    sendJson(res, 400, { error: 'Malformed canonical `sessionId`.' });
+    return;
+  }
+
+  const token = createMobileLaunchToken({ userId, sessionId });
+  const launchUrl = buildMobileLaunchUrl({
+    origin: resolveRequestOrigin(req, body.baseUrl),
+    token,
+  });
+  sendJson(res, 200, {
+    launchUrl,
+    expiresAt: new Date(Date.now() + MOBILE_LAUNCH_TTL_MS).toISOString(),
+    qrSvg: renderQrSvg(launchUrl),
+  });
+}
+
+function handleChatMobileContinue(res: ServerResponse, url: URL): void {
+  const token = normalizeOptionalString(url.searchParams.get('token'));
+  const launch = token ? resolveMobileLaunchToken(token) : undefined;
+  if (!launch) {
+    sendText(res, 401, 'Mobile launch QR code is invalid or expired.');
+    return;
+  }
+
+  const escapedUserId = escapeInlineScriptValue(launch.userId);
+  const escapedSessionId = escapeInlineScriptValue(launch.sessionId);
+  const escapedRedirect = escapeInlineScriptValue(
+    `/chat/${encodeURIComponent(launch.sessionId)}`,
+  );
+  res.writeHead(200, {
+    'Content-Type': 'text/html; charset=utf-8',
+    'Cache-Control': 'no-store',
+    'Content-Security-Policy': "default-src 'none'; script-src 'unsafe-inline'",
+    'X-Content-Type-Options': 'nosniff',
+  });
+  res.end(
+    `<!DOCTYPE html><html><body><script>` +
+      `localStorage.setItem('hybridclaw_user_id',${escapedUserId});` +
+      `localStorage.setItem('hybridclaw_session',${escapedSessionId});` +
+      `window.location.replace(${escapedRedirect});` +
+      `</script></body></html>`,
+  );
 }
 
 let cachedSlashMenuEntries: ReturnType<typeof buildTuiSlashMenuEntries> | null =
@@ -3399,6 +3559,15 @@ export function startGatewayHttpServer(): GatewayHttpServer {
       return;
     }
 
+    if (pathname === '/chat/continue') {
+      if (method !== 'GET') {
+        sendJson(res, 405, { error: 'Method Not Allowed' });
+        return;
+      }
+      handleChatMobileContinue(res, url);
+      return;
+    }
+
     if (pathname === '/auth/callback') {
       if (method !== 'GET') {
         sendJson(res, 405, { error: 'Method Not Allowed' });
@@ -3689,6 +3858,10 @@ export function startGatewayHttpServer(): GatewayHttpServer {
           }
           if (pathname === '/api/chat/recent' && method === 'GET') {
             handleApiChatRecent(req, res, url);
+            return;
+          }
+          if (pathname === '/api/chat/mobile-qr' && method === 'POST') {
+            await handleApiChatMobileQr(req, res);
             return;
           }
           if (pathname === '/api/chat/commands' && method === 'GET') {

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -342,10 +342,13 @@ type ApiChatMobileQrRequestBody = {
 };
 
 const MOBILE_LAUNCH_TTL_MS = 10 * 60 * 1000;
-const mobileLaunchTokens = new Map<
-  string,
-  { userId: string; sessionId: string; expiresAt: number }
->();
+const MOBILE_LAUNCH_TOKEN_MAX_ENTRIES = 10_000;
+type MobileLaunchTokenEntry = {
+  userId: string;
+  sessionId: string;
+  expiresAt: number;
+};
+const mobileLaunchTokens = new Map<string, MobileLaunchTokenEntry>();
 
 function parseApiAdminPolicyIndex(value: unknown): number {
   const parsed = parsePositiveInteger(value);
@@ -735,11 +738,20 @@ function cleanupExpiredMobileLaunchTokens(now = Date.now()): void {
   }
 }
 
+function evictOldestMobileLaunchTokens(): void {
+  while (mobileLaunchTokens.size >= MOBILE_LAUNCH_TOKEN_MAX_ENTRIES) {
+    const oldestToken = mobileLaunchTokens.keys().next().value;
+    if (!oldestToken) return;
+    mobileLaunchTokens.delete(oldestToken);
+  }
+}
+
 function createMobileLaunchToken(params: {
   userId: string;
   sessionId: string;
 }): string {
   cleanupExpiredMobileLaunchTokens();
+  evictOldestMobileLaunchTokens();
   const token = randomUUID();
   mobileLaunchTokens.set(token, {
     userId: params.userId,
@@ -756,8 +768,14 @@ function resolveMobileLaunchToken(token: string):
     }
   | undefined {
   cleanupExpiredMobileLaunchTokens();
-  const entry = mobileLaunchTokens.get(token.trim());
+  const normalizedToken = token.trim();
+  const entry = mobileLaunchTokens.get(normalizedToken);
   if (!entry) return undefined;
+  if (entry.expiresAt <= Date.now()) {
+    mobileLaunchTokens.delete(normalizedToken);
+    return undefined;
+  }
+  mobileLaunchTokens.delete(normalizedToken);
   return {
     userId: entry.userId,
     sessionId: entry.sessionId,

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -3569,14 +3569,6 @@ export function startGatewayHttpServer(): GatewayHttpServer {
       return;
     }
 
-    if (pathname === '/chat.html') {
-      // Preserve the query string so legacy `/chat.html?token=…` launch
-      // links keep handing the token off to the React console, which reads
-      // it from `window.location.search` (see `readStoredToken`).
-      sendRedirect(res, 301, `/chat${url.search}`);
-      return;
-    }
-
     if (pathname === '/chat/continue') {
       if (method !== 'GET') {
         sendJson(res, 405, { error: 'Method Not Allowed' });

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -155,6 +155,7 @@ import {
   getMemoryValue,
   getQueuedProactiveMessageCount,
   getRecentMessages,
+  getRecentSessionsForChannel,
   getRecentSessionsForUser,
   getRecentStructuredAuditForSession,
   getSessionBoundaryMessagesBySessionIds,
@@ -6054,13 +6055,31 @@ export function getGatewayRecentChatSessions(params: {
   channelId?: string | null;
   limit?: number;
   query?: string | null;
+  fallbackToChannelRecent?: boolean;
 }): GatewayRecentChatSession[] {
-  return getRecentSessionsForUser({
+  const sessions = getRecentSessionsForUser({
     userId: params.userId,
     channelId: params.channelId || 'web',
     limit: params.limit,
     query: params.query,
   });
+  if (!params.fallbackToChannelRecent) {
+    return sessions;
+  }
+  const channelSessions = getRecentSessionsForChannel({
+    channelId: params.channelId || 'web',
+    limit: params.limit,
+    query: params.query,
+  });
+  const merged = new Map<string, GatewayRecentChatSession>();
+  for (const session of [...channelSessions, ...sessions]) {
+    merged.set(session.sessionId, session);
+  }
+  return [...merged.values()]
+    .sort(
+      (a, b) => Date.parse(b.lastActive || '') - Date.parse(a.lastActive || ''),
+    )
+    .slice(0, params.limit ?? 20);
 }
 
 function resolveHistorySummarySinceMs(

--- a/src/gateway/qr-svg.ts
+++ b/src/gateway/qr-svg.ts
@@ -1,0 +1,48 @@
+import { createRequire } from 'node:module';
+
+interface QRCodeInstance {
+  addData(input: string): void;
+  make(): void;
+  getModuleCount(): number;
+  isDark(row: number, col: number): boolean;
+}
+
+type QRCodeConstructor = new (
+  typeNumber: number,
+  errorCorrectionLevel: number,
+) => QRCodeInstance;
+
+const require = createRequire(import.meta.url);
+const QRCode = require('qrcode-terminal/vendor/QRCode') as QRCodeConstructor;
+const QRErrorCorrectLevel =
+  require('qrcode-terminal/vendor/QRCode/QRErrorCorrectLevel') as { M: number };
+
+export function renderQrSvg(input: string): string {
+  const qr = new QRCode(-1, QRErrorCorrectLevel.M);
+  qr.addData(input);
+  qr.make();
+
+  const moduleCount = qr.getModuleCount();
+  const quietZone = 4;
+  const cellSize = 8;
+  const size = (moduleCount + quietZone * 2) * cellSize;
+  const rects: string[] = [];
+
+  for (let row = 0; row < moduleCount; row += 1) {
+    for (let col = 0; col < moduleCount; col += 1) {
+      if (!qr.isDark(row, col)) continue;
+      rects.push(
+        `<rect x="${(col + quietZone) * cellSize}" y="${(row + quietZone) * cellSize}" width="${cellSize}" height="${cellSize}"/>`,
+      );
+    }
+  }
+
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${size} ${size}" role="img" aria-label="Mobile session QR code">`,
+    '<rect width="100%" height="100%" fill="#fff"/>',
+    '<g fill="#111827">',
+    rects.join(''),
+    '</g>',
+    '</svg>',
+  ].join('');
+}

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -4266,7 +4266,7 @@ function batchQueryAllBySessionIds<Row>(
 
 function getRecentSessionBoundaryRows(
   sessionIds: string[],
-  userId: string,
+  userId: string | null,
 ): RecentSessionBoundaryRow[] {
   return batchQueryAllBySessionIds(sessionIds, (batch, placeholders) =>
     queryAll<RecentSessionBoundaryRow>(
@@ -4276,11 +4276,11 @@ function getRecentSessionBoundaryRows(
            session_id,
            role,
            content,
-           CASE WHEN role = 'user' AND user_id = ? THEN 1 ELSE 0 END AS is_target_user,
+           CASE WHEN role = 'user' AND (? IS NULL OR user_id = ?) THEN 1 ELSE 0 END AS is_target_user,
            ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY id ASC) AS rn_first,
            ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY id DESC) AS rn_last,
            ROW_NUMBER() OVER (
-             PARTITION BY session_id, CASE WHEN role = 'user' AND user_id = ? THEN 1 ELSE 0 END
+             PARTITION BY session_id, CASE WHEN role = 'user' AND (? IS NULL OR user_id = ?) THEN 1 ELSE 0 END
              ORDER BY id ASC
            ) AS rn_target_group
          FROM messages
@@ -4294,6 +4294,8 @@ function getRecentSessionBoundaryRows(
          MAX(CASE WHEN rn_last = 1 THEN role END) AS last_role
        FROM ranked
        GROUP BY session_id`,
+      userId,
+      userId,
       userId,
       userId,
       ...batch,
@@ -4339,6 +4341,86 @@ function getRecentSessionContentMatches(
   );
 }
 
+function buildRecentSessionSummaries(params: {
+  rows: RecentUserSessionRow[];
+  boundaryUserId: string | null;
+  searchQuery: string;
+  limit: number;
+}): RecentUserSessionSummary[] {
+  const sortedRows = params.rows.sort((left, right) => {
+    const rightTimestamp = parseTimestamp(right.last_active);
+    const leftTimestamp = parseTimestamp(left.last_active);
+    if (rightTimestamp !== leftTimestamp) {
+      return rightTimestamp - leftTimestamp;
+    }
+    return right.id.localeCompare(left.id);
+  });
+  const targetRows = params.searchQuery
+    ? sortedRows.slice(0, MAX_RECENT_CHAT_SESSION_LIMIT)
+    : sortedRows.slice(0, params.limit);
+  if (targetRows.length === 0) return [];
+
+  const sessionIds = targetRows.map((row) => row.id);
+  const boundaryRows = getRecentSessionBoundaryRows(
+    sessionIds,
+    params.boundaryUserId,
+  );
+  const contentMatchesBySessionId = getRecentSessionContentMatches(
+    sessionIds,
+    params.searchQuery,
+  );
+  const boundariesBySessionId = new Map(
+    boundaryRows.map((row) => [row.session_id, row] as const),
+  );
+
+  const sessions = targetRows.map((row) => {
+    const boundary = boundariesBySessionId.get(row.id);
+    const firstMessage =
+      boundary?.first_user_content || boundary?.first_content || null;
+    const shouldHideApprovalPrompt =
+      boundary?.last_role === 'assistant' &&
+      Boolean(
+        boundary?.last_content &&
+          isApprovalHistoryMessage(boundary.last_content),
+      );
+    const lastMessage =
+      boundary?.last_content && !shouldHideApprovalPrompt
+        ? boundary.last_content
+        : null;
+    const title = buildSessionBoundaryPreview({
+      firstMessage,
+      lastMessage,
+      maxLength: RECENT_CHAT_SESSION_TITLE_MAX_LENGTH,
+    });
+    const rawSearchSnippet = params.searchQuery
+      ? buildSessionSearchSnippet(
+          contentMatchesBySessionId.get(row.id) || null,
+          params.searchQuery,
+        )
+      : null;
+
+    return {
+      sessionId: row.id,
+      lastActive: row.last_active,
+      messageCount: normalizeUsageNumber(row.message_count),
+      title,
+      ...(shouldIncludeSessionSearchSnippet(title, rawSearchSnippet)
+        ? { searchSnippet: rawSearchSnippet }
+        : {}),
+    };
+  });
+
+  if (!params.searchQuery) return sessions;
+  return sessions
+    .filter((session) => {
+      const titleMatches = String(session.title || '')
+        .toLowerCase()
+        .includes(params.searchQuery);
+      return titleMatches || Boolean(session.searchSnippet);
+    })
+    .slice(0, params.limit);
+}
+
 export function getRecentSessionsForUser(params: {
   userId: string;
   channelId?: string | null;
@@ -4375,77 +4457,42 @@ export function getRecentSessionsForUser(params: {
         userId,
       );
 
-  const sortedRows = rows.sort((left, right) => {
-    const rightTimestamp = parseTimestamp(right.last_active);
-    const leftTimestamp = parseTimestamp(left.last_active);
-    if (rightTimestamp !== leftTimestamp) {
-      return rightTimestamp - leftTimestamp;
-    }
-    return right.id.localeCompare(left.id);
-  });
-  const targetRows = searchQuery
-    ? sortedRows.slice(0, MAX_RECENT_CHAT_SESSION_LIMIT)
-    : sortedRows.slice(0, limit);
-  if (targetRows.length === 0) return [];
-
-  const boundaryRows = getRecentSessionBoundaryRows(
-    targetRows.map((row) => row.id),
-    userId,
-  );
-  const contentMatchesBySessionId = getRecentSessionContentMatches(
-    targetRows.map((row) => row.id),
+  return buildRecentSessionSummaries({
+    rows,
+    boundaryUserId: userId,
     searchQuery,
-  );
-  const boundariesBySessionId = new Map(
-    boundaryRows.map((row) => [row.session_id, row] as const),
-  );
-
-  const sessions = targetRows.map((row) => {
-    const boundary = boundariesBySessionId.get(row.id);
-    const firstMessage =
-      boundary?.first_user_content || boundary?.first_content || null;
-    const shouldHideApprovalPrompt =
-      boundary?.last_role === 'assistant' &&
-      Boolean(
-        boundary?.last_content &&
-          isApprovalHistoryMessage(boundary.last_content),
-      );
-    const lastMessage =
-      boundary?.last_content && !shouldHideApprovalPrompt
-        ? boundary.last_content
-        : null;
-    const title = buildSessionBoundaryPreview({
-      firstMessage,
-      lastMessage,
-      maxLength: RECENT_CHAT_SESSION_TITLE_MAX_LENGTH,
-    });
-    const rawSearchSnippet = searchQuery
-      ? buildSessionSearchSnippet(
-          contentMatchesBySessionId.get(row.id) || null,
-          searchQuery,
-        )
-      : null;
-
-    return {
-      sessionId: row.id,
-      lastActive: row.last_active,
-      messageCount: normalizeUsageNumber(row.message_count),
-      title,
-      ...(shouldIncludeSessionSearchSnippet(title, rawSearchSnippet)
-        ? { searchSnippet: rawSearchSnippet }
-        : {}),
-    };
+    limit,
   });
+}
 
-  if (!searchQuery) return sessions;
-  return sessions
-    .filter((session) => {
-      const titleMatches = String(session.title || '')
-        .toLowerCase()
-        .includes(searchQuery);
-      return titleMatches || Boolean(session.searchSnippet);
-    })
-    .slice(0, limit);
+export function getRecentSessionsForChannel(params: {
+  channelId: string;
+  limit?: number;
+  query?: string | null;
+}): RecentUserSessionSummary[] {
+  const channelId = params.channelId.trim();
+  if (!channelId) return [];
+  const searchQuery = normalizeRecentChatSearchQuery(
+    params.query,
+  ).toLowerCase();
+  const limit = normalizeRecentChatSessionLimit(params.limit);
+
+  const rows = queryAll<RecentUserSessionRow, [string]>(
+    db,
+    `SELECT DISTINCT s.id, s.last_active, s.message_count
+       FROM sessions s
+       INNER JOIN messages m
+         ON m.session_id = s.id
+      WHERE s.channel_id = ?`,
+    channelId,
+  );
+
+  return buildRecentSessionSummaries({
+    rows,
+    boundaryUserId: null,
+    searchQuery,
+    limit,
+  });
 }
 
 export function getFullAutoSessionCount(): number {

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -4347,7 +4347,7 @@ function buildRecentSessionSummaries(params: {
   searchQuery: string;
   limit: number;
 }): RecentUserSessionSummary[] {
-  const sortedRows = params.rows.sort((left, right) => {
+  const sortedRows = [...params.rows].sort((left, right) => {
     const rightTimestamp = parseTimestamp(right.last_active);
     const leftTimestamp = parseTimestamp(left.last_active);
     if (rightTimestamp !== leftTimestamp) {
@@ -4476,15 +4476,22 @@ export function getRecentSessionsForChannel(params: {
     params.query,
   ).toLowerCase();
   const limit = normalizeRecentChatSessionLimit(params.limit);
+  const sqlLimit = searchQuery ? MAX_RECENT_CHAT_SESSION_LIMIT : limit;
 
-  const rows = queryAll<RecentUserSessionRow, [string]>(
+  const rows = queryAll<RecentUserSessionRow, [string, number]>(
     db,
-    `SELECT DISTINCT s.id, s.last_active, s.message_count
+    `SELECT s.id, s.last_active, s.message_count
        FROM sessions s
-       INNER JOIN messages m
-         ON m.session_id = s.id
-      WHERE s.channel_id = ?`,
+      WHERE s.channel_id = ?
+        AND EXISTS (
+          SELECT 1
+            FROM messages m
+           WHERE m.session_id = s.id
+        )
+      ORDER BY s.last_active DESC
+      LIMIT ?`,
     channelId,
+    sqlLimit,
   );
 
   return buildRecentSessionSummaries({

--- a/tests/gateway-docker.e2e.test.ts
+++ b/tests/gateway-docker.e2e.test.ts
@@ -223,17 +223,6 @@ describe.skipIf(!DOCKER_E2E)('gateway Docker image', () => {
     expect(res.headers.get('location')).toMatch(/login/);
   });
 
-  // ── Legacy route redirects ──────────────────────────────────────────
-
-  test('/chat.html 301-redirects to the React /chat console', async () => {
-    const res = await fetch(`${GATEWAY_URL}/chat.html`, {
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-      redirect: 'manual',
-    });
-    expect(res.status).toBe(301);
-    expect(res.headers.get('location')).toBe('/chat');
-  });
-
   test('/development redirects to /docs', async () => {
     const res = await fetch(`${GATEWAY_URL}/development`, {
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -3057,33 +3057,6 @@ describe('gateway HTTP server', () => {
     }
   });
 
-  test('301-redirects the legacy /chat.html URL to /chat', async () => {
-    const state = await importFreshHealth();
-
-    const req = makeRequest({ url: '/chat.html' });
-    const res = makeResponse();
-
-    state.handler(req as never, res as never);
-
-    expect(res.statusCode).toBe(301);
-    expect(res.headers.Location).toBe('/chat');
-    expect(res.headers['Cache-Control']).toBe('no-store');
-  });
-
-  test('preserves the query string when redirecting /chat.html?token=… to /chat', async () => {
-    const state = await importFreshHealth();
-
-    const req = makeRequest({
-      url: '/chat.html?token=launch-xyz&next=%2Fadmin',
-    });
-    const res = makeResponse();
-
-    state.handler(req as never, res as never);
-
-    expect(res.statusCode).toBe(301);
-    expect(res.headers.Location).toBe('/chat?token=launch-xyz&next=%2Fadmin');
-  });
-
   test('serves /chat, /agents, and /admin without a session cookie outside Docker', async () => {
     const state = await importFreshHealth();
 

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -3770,6 +3770,7 @@ describe('gateway HTTP server', () => {
       userId: 'web-user-a',
       channelId: 'web',
       limit: 10,
+      fallbackToChannelRecent: true,
     });
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body)).toEqual({
@@ -3902,6 +3903,7 @@ describe('gateway HTTP server', () => {
       channelId: 'web',
       limit: 25,
       query: 'deploy',
+      fallbackToChannelRecent: true,
     });
     expect(res.statusCode).toBe(200);
   });

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -3908,6 +3908,127 @@ describe('gateway HTTP server', () => {
     expect(res.statusCode).toBe(200);
   });
 
+  test('requires API auth for mobile chat QR handoff creation', async () => {
+    const state = await importFreshHealth({ webApiToken: 'web-token' });
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/chat/mobile-qr',
+      remoteAddress: '203.0.113.10',
+      body: {
+        userId: 'web-user-a',
+        sessionId: 'agent:main:channel:web:chat:dm:peer:1234567890abcdef',
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Unauthorized. Set `Authorization: Bearer <WEB_API_TOKEN>`.',
+    });
+  });
+
+  test('creates and redeems mobile chat QR handoffs once', async () => {
+    const state = await importFreshHealth({ webApiToken: 'web-token' });
+    const sessionId = 'agent:main:channel:web:chat:dm:peer:1234567890abcdef';
+    const createReq = makeRequest({
+      method: 'POST',
+      url: '/api/chat/mobile-qr',
+      headers: {
+        authorization: 'Bearer web-token',
+      },
+      body: {
+        userId: 'web-user-a',
+        sessionId,
+        baseUrl: 'https://example.test/chat',
+      },
+    });
+    const createRes = makeResponse();
+
+    state.handler(createReq as never, createRes as never);
+    await waitForResponse(createRes, (next) => next.writableEnded);
+
+    expect(createRes.statusCode).toBe(200);
+    const payload = JSON.parse(createRes.body) as {
+      launchUrl: string;
+      expiresAt: string;
+      qrSvg: string;
+    };
+    expect(payload.launchUrl).toMatch(
+      /^https:\/\/example\.test\/chat\/continue\?token=/,
+    );
+    expect(payload.expiresAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(payload.qrSvg).toContain('<svg');
+
+    const continueUrl = new URL(payload.launchUrl);
+    const continueReq = makeRequest({
+      url: `${continueUrl.pathname}${continueUrl.search}`,
+    });
+    const continueRes = makeResponse();
+
+    state.handler(continueReq as never, continueRes as never);
+    await waitForResponse(continueRes, (next) => next.writableEnded);
+
+    expect(continueRes.statusCode).toBe(200);
+    expect(continueRes.body).toContain(
+      `localStorage.setItem('hybridclaw_user_id',"web-user-a");`,
+    );
+    expect(continueRes.body).toContain(
+      `localStorage.setItem('hybridclaw_session',"${sessionId}");`,
+    );
+    expect(continueRes.body).toContain(
+      `window.location.replace("/chat/${encodeURIComponent(sessionId)}");`,
+    );
+
+    const replayRes = makeResponse();
+    state.handler(continueReq as never, replayRes as never);
+    await waitForResponse(replayRes, (next) => next.writableEnded);
+
+    expect(replayRes.statusCode).toBe(401);
+    expect(replayRes.body).toBe('Mobile launch QR code is invalid or expired.');
+  });
+
+  test('rejects expired mobile chat QR handoff tokens', async () => {
+    const dateNow = vi.spyOn(Date, 'now');
+    dateNow.mockReturnValue(new Date('2026-04-26T12:00:00.000Z').getTime());
+    try {
+      const state = await importFreshHealth();
+      const createReq = makeRequest({
+        method: 'POST',
+        url: '/api/chat/mobile-qr',
+        body: {
+          userId: 'web-user-a',
+          sessionId: 'agent:main:channel:web:chat:dm:peer:1234567890abcdef',
+          baseUrl: 'https://example.test',
+        },
+      });
+      const createRes = makeResponse();
+
+      state.handler(createReq as never, createRes as never);
+      await waitForResponse(createRes, (next) => next.writableEnded);
+
+      const payload = JSON.parse(createRes.body) as { launchUrl: string };
+      dateNow.mockReturnValue(new Date('2026-04-26T12:10:00.001Z').getTime());
+
+      const continueUrl = new URL(payload.launchUrl);
+      const continueReq = makeRequest({
+        url: `${continueUrl.pathname}${continueUrl.search}`,
+      });
+      const continueRes = makeResponse();
+      state.handler(continueReq as never, continueRes as never);
+      await waitForResponse(continueRes, (next) => next.writableEnded);
+
+      expect(continueRes.statusCode).toBe(401);
+      expect(continueRes.body).toBe(
+        'Mobile launch QR code is invalid or expired.',
+      );
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
   test('rejects history requests without an explicit session id', async () => {
     const state = await importFreshHealth();
     const req = makeRequest({ url: '/api/history?limit=2' });

--- a/tests/memory-service.test.ts
+++ b/tests/memory-service.test.ts
@@ -17,6 +17,7 @@ import {
   getCanonicalContext,
   getMemoryValue,
   getOrCreateSession,
+  getRecentSessionsForChannel,
   getRecentSessionsForUser,
   getSessionById,
   getUsageTotals,
@@ -803,6 +804,72 @@ describe.sequential('schema migrations', () => {
         lastActive: '2026-03-24T09:01:00.000Z',
         messageCount: 2,
         title: '"First web question from user A" ... "Assistant reply A1"',
+      },
+    ]);
+  });
+
+  test('getRecentSessionsForChannel returns recent web sessions across browser users', () => {
+    const dbPath = createTempDbPath();
+    initDatabase({ quiet: true, dbPath });
+
+    getOrCreateSession('web-session-1', null, 'web');
+    getOrCreateSession('web-session-2', null, 'web');
+    getOrCreateSession('discord-session', null, 'discord:123');
+
+    const inspect = new Database(dbPath);
+    const insertMessage = inspect.prepare(
+      'INSERT INTO messages (session_id, user_id, username, role, content, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+    );
+    insertMessage.run(
+      'web-session-1',
+      'web-user-a',
+      'web',
+      'user',
+      'First browser question',
+      '2026-03-24T09:00:00.000Z',
+    );
+    insertMessage.run(
+      'web-session-2',
+      'web-user-b',
+      'web',
+      'user',
+      'Second browser question',
+      '2026-03-24T10:00:00.000Z',
+    );
+    insertMessage.run(
+      'discord-session',
+      'web-user-a',
+      'web',
+      'user',
+      'Discord message should be ignored',
+      '2026-03-24T11:00:00.000Z',
+    );
+
+    const updateSession = inspect.prepare(
+      'UPDATE sessions SET message_count = ?, last_active = ? WHERE id = ?',
+    );
+    updateSession.run(1, '2026-03-24T09:00:00.000Z', 'web-session-1');
+    updateSession.run(1, '2026-03-24T10:00:00.000Z', 'web-session-2');
+    updateSession.run(1, '2026-03-24T11:00:00.000Z', 'discord-session');
+    inspect.close();
+
+    expect(
+      getRecentSessionsForChannel({
+        channelId: 'web',
+        limit: 10,
+      }),
+    ).toEqual([
+      {
+        sessionId: 'web-session-2',
+        lastActive: '2026-03-24T10:00:00.000Z',
+        messageCount: 1,
+        title: '"Second browser question"',
+      },
+      {
+        sessionId: 'web-session-1',
+        lastActive: '2026-03-24T09:00:00.000Z',
+        messageCount: 1,
+        title: '"First browser question"',
       },
     ]);
   });

--- a/tests/npm-install.e2e.test.ts
+++ b/tests/npm-install.e2e.test.ts
@@ -203,15 +203,6 @@ describe.skipIf(!NPM_E2E)('npm install user journey', () => {
     expect(html).toContain('<title>HybridClaw Admin</title>');
   });
 
-  test('/chat.html 301-redirects to the React /chat console', async () => {
-    const res = await fetch(`${GATEWAY_URL}/chat.html`, {
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-      redirect: 'manual',
-    });
-    expect(res.status).toBe(301);
-    expect(res.headers.get('location')).toBe('/chat');
-  });
-
   test('/admin serves the console (host mode, no container auth)', async () => {
     const res = await fetch(`${GATEWAY_URL}/admin`, {
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),


### PR DESCRIPTION
## Summary
- Tighten mobile chat layout so the surface stays within the phone viewport and the composer stays fixed to the bottom.
- Refresh and merge recent web conversations for unsigned mobile web access.
- Add a short-lived QR mobile handoff flow that opens the same user/session on a phone.

## Validation
- `npm --workspace console run test -- chat-page`
- `npm --workspace console run build`
- `npm run typecheck`
- `npm run build`
- `npx vitest run --configLoader runner --config vitest.unit.config.ts tests/memory-service.test.ts tests/gateway-http-server.test.ts`