### PR TITLE
docs: add Trusted Coworker manifesto + internal roadmap

### DIFF
--- a/docs/content/README.md
+++ b/docs/content/README.md
@@ -49,6 +49,8 @@ doc at once, start from [For Agents](./agents.md).
 
 ## Browse By Section
 
+- [The Trusted Coworker Manifesto](./manifesto.md) — the product principles
+  HybridClaw is built around: what we will and will not ship
 - [Getting Started](./getting-started/README.md) for installation,
   onboarding, provider authentication, and connecting the first transport
 - [Channels](./channels/README.md) for the full supported channel catalog and

--- a/docs/content/README.md
+++ b/docs/content/README.md
@@ -49,8 +49,7 @@ doc at once, start from [For Agents](./agents.md).
 
 ## Browse By Section
 
-- [The Trusted Coworker Manifesto](./manifesto.md) — the product principles
-  HybridClaw is built around: what we will and will not ship
+- [The Trusted Coworker Manifesto](./manifesto.md) — the product principles HybridClaw is built around: what we will and will not ship
 - [Getting Started](./getting-started/README.md) for installation,
   onboarding, provider authentication, and connecting the first transport
 - [Channels](./channels/README.md) for the full supported channel catalog and

--- a/docs/content/internal/roadmap.md
+++ b/docs/content/internal/roadmap.md
@@ -3,7 +3,7 @@ title: Trusted Coworker Roadmap
 description: Internal product roadmap derived from the Trusted Coworker Manifesto. Not linked from the public docs nav.
 ---
 
-> **Internal document.** This page is intentionally not linked from the docs sidebar or the public website. It exists in the repo as the source of truth for roadmap planning and is referenced from GitHub issue bodies. Tracked in the umbrella issue [HybridAIOne/hybridclaw#466](https://github.com/HybridAIOne/hybridclaw/issues/466).
+> **Internal document.** This page is intentionally excluded from the docs sidebar, navigation, and search — but it remains web-accessible by direct URL, which is how GitHub issue bodies reference it. Source of truth for roadmap planning. Tracked in the umbrella issue [HybridAIOne/hybridclaw#466](https://github.com/HybridAIOne/hybridclaw/issues/466).
 
 # Trusted Coworker Roadmap
 

--- a/docs/content/internal/roadmap.md
+++ b/docs/content/internal/roadmap.md
@@ -1,0 +1,95 @@
+---
+title: Trusted Coworker Roadmap
+description: Internal product roadmap derived from the Trusted Coworker Manifesto. Not linked from the public docs nav.
+---
+
+> **Internal document.** This page is intentionally not linked from the docs sidebar or the public website. It exists in the repo as the source of truth for roadmap planning and is referenced from GitHub issue bodies. Tracked in the umbrella issue [HybridAIOne/hybridclaw#466](https://github.com/HybridAIOne/hybridclaw/issues/466).
+
+# Trusted Coworker Roadmap
+
+20 features grouped into three priority tiers. **P0** = Very High Priority (launch package). **P1** = High Priority (depth). **P2** = Priority (breadth). Sequencing within a tier is driven by technical dependencies.
+
+| # | Feature | Description | Priority |
+|---|---------|-------------|----------|
+| 1 | **Agent-to-agent messaging** | First-class primitive for one coworker to message, hand off, or escalate to another. Persisted envelopes; intent typed; integrates with the hash-chain audit log. | P0 |
+| 2 | **Workflow engine — A→B→C with approval gates** | Declarative YAML workflows. Sequential runner, pause/resume on approval, return-for-revision rewinds. Built on top of #1. | P0 |
+| 3 | **Coworker scoreboard + auto-`CV.md`** | Per-skill score data model populated from the skill-run event bus. Auto-rendered CV per coworker; admin scoreboard; "best at X" recommendation API. | P0 |
+| 4 | **Business-secret masking + demasking** | Extends `confidential-redact.ts` with NDA / client / price / contract classes. Round-trip placeholder scheme; post-LLM rehydrator; mask/demask events on the audit log. | P0 |
+| 5 | **Token / money budgets per coworker** | Per-coworker monthly € cap backed by existing `UsageTotals`. Soft-warn at threshold, hard-stop via the policy engine, per-skill sub-limits. | P0 |
+| 6 | **NDA / secret-leak classifier** | Classifier on every prompt and response, fed by the skill-run event bus. Block / warn / log via policy engine; eval suite extends the existing harness. | P0 |
+| 7 | **Shared enterprise memory** | RAG over team docs / CRM / wiki, available in self-hosted HC. Pluggable vector store, per-coworker source scoping, retrieval-quality eval suite. | P1 |
+| 8 | **Brand-voice + output classifier** | Per-tenant voice profile (do / don't, tone, banned phrases). Pre-ship classifier on responses; block / rewrite via policy engine. | P1 |
+| 9 | **Hierarchical swarm — HC1 delegates to HC2** | Cross-instance delegation. Signed delegation tokens, transport over HTTP, audit-log linking across instances. | P1 |
+| 10 | **Auto fine-tuning on real tasks** | Trajectory capture → PII scrub → per-customer training data → fine-tuning pipeline → tuned-model registry with eval gate before promotion. | P1 |
+| 11 | **Coworker working hours + escalation** | Schedule on `AgentConfig` (timezone, weekly hours). Out-of-hours dispatcher decides queue / page / escalate per configured rules. | P1 |
+| 12 | **Mobile-first admin (iOS / Android wrapper)** | Responsive admin pages, mobile-friendly approval flow, push notifications, native wrappers via Capacitor or React Native. | P1 |
+| 13 | **Per-client cost & audit reports** | Client tagging on activity, per-client cost rollup extending #5, per-client audit-log filter, branded PDF export. | P1 |
+| 14 | **SSO + RBAC** | OAuth2 / OIDC framework with Okta, Google Workspace, Microsoft Entra providers. Role + permission model; per-coworker access policies for human users. | P1 |
+| 15 | **Coworker handoff with context transfer** | Extends the `handoff` intent from #1 to carry a context bundle (thread refs, brief, client tags). Recipient absorbs context before resuming. | P2 |
+| 16 | **Skill A/B testing + canary deployments** | Variant routing by deterministic hash, per-variant metrics from the event bus, statistical comparison, promotion gate via the eval harness. | P2 |
+| 17 | **Coworker references / portfolio export** | Anonymized portfolio bundle (work samples + scores). Export and import flows so a coworker template can be instantiated on a fresh instance. | P2 |
+| 18 | **Voice / outbound phone channel** | Twilio Programmable Voice for outbound dial. Existing TTS plus STT for callee responses; call-flow primitive; transcript on the audit log. | P2 |
+| 19 | **Calendar / meeting presence** | Bot joins Zoom / Meet, real-time STT, live notes, post-meeting summary, action-item dispatch via #1 to other coworkers. | P2 |
+| 20 | **Right-to-be-forgotten / GDPR data export** | Identifier registry, cascading data discovery, audited deletion, machine + human readable export. Hash-chain entry of the deletion preserved. | P2 |
+
+---
+
+## Foundations
+
+Cross-cutting work that several roadmap items depend on. Decomposed under the `foundation` label rather than belonging to any single feature.
+
+- **F1** — Extend `AgentConfig` with `owner` / `role` / `cv` fields and persistence. Required by #1, #3, #5, #11.
+- **F2** — Unified skill-run event bus (streaming, not post-hoc). Required by #3, #5, #6, #10, #16.
+- **F3** — Generalize the network-only policy engine into a "predicate → action" engine. Used by #4, #5, #6, #8, #11, #14.
+- **F4** — Versioning + rollback for skills, knowledge, CVs, and classifier weights. Extends `runtime-config-revisions`. Required by Principle VII.
+- **F5** — Model pricing & capability matrix on top of `model-catalog`. Required by #5 cost compute and future routing.
+
+## Cross-cutting additions
+
+Engineering hygiene that ships alongside P0:
+
+- **A1** — End-to-end smoke scenario exercising #1 + #2 + #3 + #4 + #5 + #6 in one run.
+- **A2** — `CHANGELOG.md` with manifesto-principle tags per entry.
+- **A3** — Test-fixtures library (coworkers, clients, threads, secrets).
+- **A4** — CI cost-regression gate against the eval suite.
+- **A5** — Threat-model document for any feature touching secrets or keys.
+
+---
+
+## How to read this
+
+**P0 (#1–6)** is the launch package. Read it as the smallest set of features that makes the manifesto demonstrable end-to-end:
+
+- #1 + #2 implement Principle IV (coworkers in teams).
+- #3 implements Principle I (person, not prompt).
+- #4 + #6 implement Principle V (NDA from minute one).
+- #5 implements Principle IX (thinks before spending).
+- F1 + F2 + F3 are prerequisites for the above.
+
+**P1 (#7–14)** is depth work. Each item compounds with one or more P0 features:
+
+- Shared memory (#7) and auto fine-tuning (#10) close the data flywheel — both feed back into the skill scoreboard (#3) and the leak classifier (#6).
+- Hierarchical swarm (#9) extends the A2A primitive (#1) across host instances.
+- Working hours (#11), per-client reports (#13), and SSO/RBAC (#14) are operational table stakes once a fleet is in use.
+- Mobile admin (#12) is the surface for Principle III on a phone.
+
+**P2 (#15–20)** is breadth. Each item is independently shippable but most depend on at least one P1 item:
+
+- Handoff context transfer (#15) makes #1 + #2 feel finished.
+- A/B testing (#16) compounds with #10.
+- Voice (#18) and calendar (#19) are channel expansions on top of the existing channel layer.
+- RTBF (#20) is the GDPR baseline; mostly implementation work on top of the audit log.
+
+## Sequencing rules
+
+- **Foundations first.** F1, F2, F3 unblock the majority of P0 children. F4 and F5 unblock specific items but are not on the critical path for the launch demo (A1).
+- **A2A before workflow.** #1 must ship at least to 1.2 (send/receive runtime API) before #2.2 (sequential runner) becomes useful.
+- **Trajectory capture starts early.** 10.1 (trajectory collection) should land alongside F2, well before the rest of #10 — the data is the asset.
+- **Leak classifier needs a dataset.** 6.1 (classifier dataset) gates 6.2 / 6.3; budget for labeling time.
+- **Avoid net-new channels until P0 ships.** New channel work (#18, #19) is deferred to P2 even where infrastructure exists.
+
+## Out of scope
+
+- Net-new chat channels beyond what already ships in `src/channels/`.
+- Generic "more skills" — skills ship through the opinionated business-skill pipeline (Salesforce, HubSpot, SAP, GA4, NL→SQL), not as a feature-count metric.
+- Anything that requires the end user to open the desktop app (Principle II).

--- a/docs/content/manifesto.md
+++ b/docs/content/manifesto.md
@@ -1,0 +1,59 @@
+---
+title: The Trusted Coworker Manifesto
+description: The product principles HybridClaw is built around — what we will and will not ship.
+sidebar_position: 2
+---
+
+# The Trusted Coworker Manifesto
+
+*HybridClaw is not an AI assistant. It is the coworker your team trusts with keys, clients, and calendar.*
+
+That belief steers every line of code we write — and every line we refuse to write.
+
+---
+
+### I. A coworker is a person, not a prompt
+Our coworkers ship with a name, a face, a voice, and a `CV.md`. They have skill scores, a track record, references. You don't *configure* them — you onboard them, evaluate them, promote them, retire them.
+**We will never ship a generic chatbot panel.** If a user can't picture saying *"Lena, take care of this,"* we haven't done our job.
+
+### II. A coworker lives where work happens
+Email. Web chat. Slack. Teams. WhatsApp. The phone. Your CRM. We meet your team in the tools they already pay for — never the other way around.
+
+Apps are for the *operator*, not the user: one-click deployment, one place to manage the fleet. It's how you hire your coworker — not where you talk to them.
+**We will never make end users open our app to talk to their coworker.**
+
+### III. A coworker is hired, not installed
+Sixty seconds, from a browser, from anywhere. The central admin is remote-first: fleet dashboard, kanban board, channel wiring, evals — reachable from a phone on the train.
+**We will not ship features that require a terminal to operate.**
+
+### IV. Coworkers work in teams
+Real work is collaborative. Coworkers delegate, hand off, escalate, ask for help. Agent-to-agent communication is a first-class primitive, not a hack on top.
+**We will not optimize for the lone-agent scenario at the cost of the team scenario.**
+
+### V. A trusted coworker never holds your keys
+Credentials are encrypted at rest. The model only ever sees a placeholder; the host injects real tokens at request time, then forgets them. PII and business secrets are masked on the way in and validated on the way out — your coworker is under NDA from minute one.
+**We will never ship a feature that requires the model to see a real secret.** Convenience is not a justification.
+
+### VI. A trusted coworker shows their work
+Every action is appended to a hash-chain audit log. *"What did Lena do this week?"* gets an answer your auditor, your client, and your accountant will accept.
+**We will not add features that bypass the audit log to look faster.**
+
+### VII. A trusted coworker is undoable
+Configs, agent files, skills, knowledge — all versioned. Rollback is one click. The cost of a bad change is a click, not a week.
+**We will not ship state-mutating features without a rollback path.**
+
+### VIII. A trusted coworker doesn't break overnight
+When a new model ships, we re-run your tuned skills and knowledge against your real workflows. Regressions land in our dashboard, not your client's inbox.
+**We will not let provider churn become customer churn.**
+
+### IX. A coworker thinks before they spend
+Concierge routing picks the model by urgency and complexity — not by default. Sensitive work stays local. Premium reasoning happens only when the work is worth it.
+**We will not bill our customers for thinking harder than the task required.**
+
+### X. A coworker actually does the work
+Opinionated, ready-on-day-one skills for the systems your business runs on: Salesforce, HubSpot, SAP, GA4, plus natural-language SQL on your warehouse. Not a "build your own" toolkit.
+**We will not ship a runtime and call it a coworker.** The skills are the product.
+
+---
+
+*All of the Claw. None of the chaos.*

--- a/docs/static/docs.js
+++ b/docs/static/docs.js
@@ -36,7 +36,10 @@ const LEGACY_DOC_PREFIX_REWRITES = [
 export const DEVELOPMENT_DOCS_SECTIONS = [
   {
     title: 'Overview',
-    pages: [{ title: 'HybridClaw Docs', path: 'README.md' }],
+    pages: [
+      { title: 'HybridClaw Docs', path: 'README.md' },
+      { title: 'The Trusted Coworker Manifesto', path: 'manifesto.md' },
+    ],
   },
   {
     title: 'Getting Started',


### PR DESCRIPTION
## Summary

- Adds `docs/content/manifesto.md` — the Trusted Coworker product principles (10 numbered principles, also linked from the Overview section of the docs sidebar)
- Adds `docs/content/internal/roadmap.md` — the 20-feature internal roadmap, technical phrasing only. **Intentionally not wired into the docs nav, sidebar, or search** — present in the repo for issue cross-references and team planning, web-accessible by URL only
- Updates `docs/content/README.md` to surface the manifesto in "Browse By Section"
- Updates `docs/static/docs.js` to add the manifesto as a sidebar entry under Overview

## Context

These docs are the source-of-truth for the roadmap tracked in [#466](https://github.com/HybridAIOne/hybridclaw/issues/466) — an umbrella issue covering 20 parents, 116 children, 5 foundations, and 5 cross-cutting tasks (141 issues + umbrella). Issue bodies cross-link to the roadmap file in this branch.

Priority labels added to the repo at the same time: `roadmap`, `foundation`, `priority/P0` (Very High Priority), `priority/P1` (High Priority), `priority/P2` (Priority).

## Test plan

- [ ] Confirm manifesto renders correctly in the docs UI under Overview
- [ ] Confirm `docs/content/internal/roadmap.md` does NOT appear in the sidebar or search
- [ ] Confirm the roadmap is still fetchable by direct URL (intended — it's the link target from issue bodies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)