### PR TITLE
feat(agents): add owner, role, and CV to AgentConfig (Foundation F1)

### DIFF
--- a/src/agents/agent-registry.ts
+++ b/src/agents/agent-registry.ts
@@ -27,7 +27,9 @@ import {
   type AgentModelConfig,
   type AgentsConfig,
   buildOptionalAgentPresentation,
+  cloneAgentCv,
   DEFAULT_AGENT_ID,
+  normalizeAgentCv,
 } from './agent-types.js';
 
 const LEGACY_WORKSPACE_DIRS = [
@@ -155,6 +157,9 @@ function normalizeAgent(value: unknown): AgentConfig | null {
   const skills = normalizeOptionalTrimmedUniqueStringArray(
     (value as { skills?: unknown }).skills,
   );
+  const owner = normalizeString((value as { owner?: unknown }).owner);
+  const role = normalizeString((value as { role?: unknown }).role);
+  const cv = normalizeAgentCv((value as { cv?: unknown }).cv);
   return {
     id,
     ...(name ? { name } : {}),
@@ -164,6 +169,9 @@ function normalizeAgent(value: unknown): AgentConfig | null {
     ...(workspace ? { workspace } : {}),
     ...(chatbotId ? { chatbotId } : {}),
     ...(typeof enableRag === 'boolean' ? { enableRag } : {}),
+    ...(owner ? { owner } : {}),
+    ...(role ? { role } : {}),
+    ...(cv ? { cv } : {}),
   };
 }
 
@@ -206,6 +214,7 @@ function applyDefaults(agent: AgentConfig): AgentConfig {
     agent.chatbotId ?? configuredDefaults.chatbotId,
   );
   const enableRag = agent.enableRag ?? configuredDefaults.enableRag;
+  const cv = cloneAgentCv(agent.cv);
   return {
     id: agent.id,
     ...(agent.name ? { name: agent.name } : {}),
@@ -215,6 +224,9 @@ function applyDefaults(agent: AgentConfig): AgentConfig {
     ...(agent.workspace ? { workspace: agent.workspace } : {}),
     ...(chatbotId ? { chatbotId } : {}),
     ...(typeof enableRag === 'boolean' ? { enableRag } : {}),
+    ...(agent.owner ? { owner: agent.owner } : {}),
+    ...(agent.role ? { role: agent.role } : {}),
+    ...(cv ? { cv } : {}),
   };
 }
 
@@ -261,6 +273,9 @@ function syncConfiguredAgentsToDatabase(): void {
     workspace: mainAgent.workspace,
     chatbotId: mainAgent.chatbotId,
     enableRag: mainAgent.enableRag,
+    owner: mainAgent.owner,
+    role: mainAgent.role,
+    cv: cloneAgentCv(mainAgent.cv),
   });
 
   for (const agent of configuredAgents) {
@@ -274,6 +289,9 @@ function syncConfiguredAgentsToDatabase(): void {
       workspace: agent.workspace,
       chatbotId: agent.chatbotId,
       enableRag: agent.enableRag,
+      owner: agent.owner,
+      role: agent.role,
+      cv: cloneAgentCv(agent.cv),
     });
   }
 }

--- a/src/agents/agent-registry.ts
+++ b/src/agents/agent-registry.ts
@@ -175,6 +175,69 @@ function normalizeAgent(value: unknown): AgentConfig | null {
   };
 }
 
+function fingerprintString(value: string | undefined): string {
+  if (!value) return '0:0';
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `${value.length}:${(hash >>> 0).toString(36)}`;
+}
+
+function fingerprintStringArray(values: string[] | undefined): string {
+  return values?.map(fingerprintString).join(',') ?? '';
+}
+
+function fingerprintModel(model: AgentModelConfig | undefined): string {
+  if (!model) return '';
+  if (typeof model === 'string') return `s:${fingerprintString(model)}`;
+  return `o:${fingerprintString(model.primary)}:${fingerprintStringArray(model.fallbacks)}`;
+}
+
+function fingerprintCv(cv: AgentConfig['cv']): string {
+  if (!cv) return '';
+  return [
+    fingerprintString(cv.summary),
+    fingerprintString(cv.background),
+    fingerprintStringArray(cv.capabilities),
+    fingerprintString(cv.asset),
+  ].join(':');
+}
+
+function fingerprintAgent(agent: AgentConfig): string {
+  return [
+    fingerprintString(agent.id),
+    fingerprintString(agent.name),
+    fingerprintString(agent.displayName),
+    fingerprintString(agent.imageAsset),
+    fingerprintModel(agent.model),
+    fingerprintStringArray(agent.skills),
+    fingerprintString(agent.workspace),
+    fingerprintString(agent.chatbotId),
+    typeof agent.enableRag === 'boolean' ? String(agent.enableRag) : '',
+    fingerprintString(agent.owner),
+    fingerprintString(agent.role),
+    fingerprintCv(agent.cv),
+  ].join('|');
+}
+
+function fingerprintAgentsConfig(params: {
+  defaultAgentId: string;
+  defaults: AgentDefaultsConfig;
+  list: AgentConfig[];
+}): string {
+  return [
+    fingerprintString(params.defaultAgentId),
+    fingerprintModel(params.defaults.model),
+    fingerprintString(params.defaults.chatbotId),
+    typeof params.defaults.enableRag === 'boolean'
+      ? String(params.defaults.enableRag)
+      : '',
+    ...params.list.map(fingerprintAgent),
+  ].join('\n');
+}
+
 function normalizeAgentsConfig(config: AgentsConfig | undefined): {
   defaultAgentId: string;
   defaults: AgentDefaultsConfig;
@@ -195,15 +258,16 @@ function normalizeAgentsConfig(config: AgentsConfig | undefined): {
     seen.add(DEFAULT_AGENT_ID);
   }
   const defaultAgentId = normalizeDefaultAgentId(config?.defaultAgentId, seen);
+  const fingerprint = fingerprintAgentsConfig({
+    defaultAgentId,
+    defaults,
+    list,
+  });
   return {
     defaultAgentId,
     defaults,
     list,
-    fingerprint: JSON.stringify({
-      defaultAgentId,
-      defaults,
-      list,
-    }),
+    fingerprint,
   };
 }
 
@@ -214,7 +278,6 @@ function applyDefaults(agent: AgentConfig): AgentConfig {
     agent.chatbotId ?? configuredDefaults.chatbotId,
   );
   const enableRag = agent.enableRag ?? configuredDefaults.enableRag;
-  const cv = cloneAgentCv(agent.cv);
   return {
     id: agent.id,
     ...(agent.name ? { name: agent.name } : {}),
@@ -226,7 +289,7 @@ function applyDefaults(agent: AgentConfig): AgentConfig {
     ...(typeof enableRag === 'boolean' ? { enableRag } : {}),
     ...(agent.owner ? { owner: agent.owner } : {}),
     ...(agent.role ? { role: agent.role } : {}),
-    ...(cv ? { cv } : {}),
+    ...(agent.cv ? { cv: agent.cv } : {}),
   };
 }
 
@@ -259,24 +322,13 @@ function rebuildRegistryFromDatabase(): void {
 function syncConfiguredAgentsToDatabase(): void {
   const mainAgent = configuredAgents.find(
     (entry) => entry.id === DEFAULT_AGENT_ID,
-  ) ?? {
-    id: DEFAULT_AGENT_ID,
-    name: 'Main Agent',
-  };
-  dbUpsertAgent({
-    id: DEFAULT_AGENT_ID,
-    name: mainAgent.name || 'Main Agent',
-    displayName: mainAgent.displayName,
-    imageAsset: mainAgent.imageAsset,
-    model: cloneModelConfig(mainAgent.model),
-    skills: mainAgent.skills,
-    workspace: mainAgent.workspace,
-    chatbotId: mainAgent.chatbotId,
-    enableRag: mainAgent.enableRag,
-    owner: mainAgent.owner,
-    role: mainAgent.role,
-    cv: cloneAgentCv(mainAgent.cv),
-  });
+  );
+  if (!mainAgent) {
+    dbUpsertAgent({
+      id: DEFAULT_AGENT_ID,
+      name: 'Main Agent',
+    });
+  }
 
   for (const agent of configuredAgents) {
     dbUpsertAgent({

--- a/src/agents/agent-runtime-config.ts
+++ b/src/agents/agent-runtime-config.ts
@@ -8,6 +8,7 @@ import type {
   AgentModelConfig,
   AgentsConfig,
 } from './agent-types.js';
+import { agentCvEquals } from './agent-types.js';
 
 function sameStringArray(a?: string[], b?: string[]): boolean {
   if (a === b) return true;
@@ -32,7 +33,10 @@ function sameAgentConfig(a: AgentConfig | undefined, b: AgentConfig): boolean {
     sameStringArray(a.skills, b.skills) &&
     a.workspace === b.workspace &&
     a.chatbotId === b.chatbotId &&
-    a.enableRag === b.enableRag
+    a.enableRag === b.enableRag &&
+    a.owner === b.owner &&
+    a.role === b.role &&
+    agentCvEquals(a.cv, b.cv)
   );
 }
 

--- a/src/agents/agent-types.ts
+++ b/src/agents/agent-types.ts
@@ -7,6 +7,13 @@ export type AgentModelConfig =
       fallbacks?: string[];
     };
 
+export interface AgentCv {
+  summary?: string;
+  background?: string;
+  capabilities?: string[];
+  asset?: string;
+}
+
 export interface AgentConfig {
   id: string;
   name?: string;
@@ -17,6 +24,9 @@ export interface AgentConfig {
   workspace?: string;
   chatbotId?: string;
   enableRag?: boolean;
+  owner?: string;
+  role?: string;
+  cv?: AgentCv;
 }
 
 export interface AgentDefaultsConfig {
@@ -39,4 +49,66 @@ export function buildOptionalAgentPresentation(
     ...(displayName ? { displayName } : {}),
     ...(imageAsset ? { imageAsset } : {}),
   };
+}
+
+export function normalizeAgentCv(value: unknown): AgentCv | undefined {
+  if (typeof value === 'string') {
+    const asset = value.trim();
+    return asset ? { asset } : undefined;
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  const raw = value as {
+    summary?: unknown;
+    background?: unknown;
+    capabilities?: unknown;
+    asset?: unknown;
+  };
+  const summary = typeof raw.summary === 'string' ? raw.summary.trim() : '';
+  const background =
+    typeof raw.background === 'string' ? raw.background.trim() : '';
+  const asset = typeof raw.asset === 'string' ? raw.asset.trim() : '';
+  const capabilities = Array.isArray(raw.capabilities)
+    ? Array.from(
+        new Set(
+          raw.capabilities
+            .filter((entry): entry is string => typeof entry === 'string')
+            .map((entry) => entry.trim())
+            .filter(Boolean),
+        ),
+      )
+    : [];
+  const cv: AgentCv = {
+    ...(summary ? { summary } : {}),
+    ...(background ? { background } : {}),
+    ...(capabilities.length > 0 ? { capabilities } : {}),
+    ...(asset ? { asset } : {}),
+  };
+  return Object.keys(cv).length > 0 ? cv : undefined;
+}
+
+export function cloneAgentCv(value: AgentCv | undefined): AgentCv | undefined {
+  if (!value) return undefined;
+  const cv: AgentCv = {
+    ...(value.summary ? { summary: value.summary } : {}),
+    ...(value.background ? { background: value.background } : {}),
+    ...(value.capabilities && value.capabilities.length > 0
+      ? { capabilities: [...value.capabilities] }
+      : {}),
+    ...(value.asset ? { asset: value.asset } : {}),
+  };
+  return Object.keys(cv).length > 0 ? cv : undefined;
+}
+
+export function agentCvEquals(a?: AgentCv, b?: AgentCv): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  if (a.summary !== b.summary) return false;
+  if (a.background !== b.background) return false;
+  if (a.asset !== b.asset) return false;
+  const aCaps = a.capabilities ?? [];
+  const bCaps = b.capabilities ?? [];
+  if (aCaps.length !== bCaps.length) return false;
+  return aCaps.every((entry, index) => entry === bCaps[index]);
 }

--- a/src/agents/agent-types.ts
+++ b/src/agents/agent-types.ts
@@ -1,3 +1,8 @@
+import {
+  normalizeTrimmedString,
+  normalizeTrimmedUniqueStringArray,
+} from '../utils/normalized-strings.js';
+
 export const DEFAULT_AGENT_ID = 'main';
 
 export type AgentModelConfig =
@@ -53,7 +58,7 @@ export function buildOptionalAgentPresentation(
 
 export function normalizeAgentCv(value: unknown): AgentCv | undefined {
   if (typeof value === 'string') {
-    const asset = value.trim();
+    const asset = normalizeTrimmedString(value);
     return asset ? { asset } : undefined;
   }
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -65,19 +70,11 @@ export function normalizeAgentCv(value: unknown): AgentCv | undefined {
     capabilities?: unknown;
     asset?: unknown;
   };
-  const summary = typeof raw.summary === 'string' ? raw.summary.trim() : '';
-  const background =
-    typeof raw.background === 'string' ? raw.background.trim() : '';
-  const asset = typeof raw.asset === 'string' ? raw.asset.trim() : '';
+  const summary = normalizeTrimmedString(raw.summary);
+  const background = normalizeTrimmedString(raw.background);
+  const asset = normalizeTrimmedString(raw.asset);
   const capabilities = Array.isArray(raw.capabilities)
-    ? Array.from(
-        new Set(
-          raw.capabilities
-            .filter((entry): entry is string => typeof entry === 'string')
-            .map((entry) => entry.trim())
-            .filter(Boolean),
-        ),
-      )
+    ? normalizeTrimmedUniqueStringArray(raw.capabilities)
     : [];
   const cv: AgentCv = {
     ...(summary ? { summary } : {}),

--- a/src/agents/agent-types.ts
+++ b/src/agents/agent-types.ts
@@ -87,15 +87,10 @@ export function normalizeAgentCv(value: unknown): AgentCv | undefined {
 
 export function cloneAgentCv(value: AgentCv | undefined): AgentCv | undefined {
   if (!value) return undefined;
-  const cv: AgentCv = {
-    ...(value.summary ? { summary: value.summary } : {}),
-    ...(value.background ? { background: value.background } : {}),
-    ...(value.capabilities && value.capabilities.length > 0
-      ? { capabilities: [...value.capabilities] }
-      : {}),
-    ...(value.asset ? { asset: value.asset } : {}),
+  return {
+    ...value,
+    ...(value.capabilities ? { capabilities: [...value.capabilities] } : {}),
   };
-  return Object.keys(cv).length > 0 ? cv : undefined;
 }
 
 export function agentCvEquals(a?: AgentCv, b?: AgentCv): boolean {

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -11,7 +11,9 @@ import {
   type AgentModelConfig,
   type AgentsConfig,
   buildOptionalAgentPresentation,
+  cloneAgentCv,
   DEFAULT_AGENT_ID,
+  normalizeAgentCv,
 } from '../agents/agent-types.js';
 import type { SkillConfigChannelKind } from '../channels/channel.js';
 import { normalizeSkillConfigChannelKind } from '../channels/channel-registry.js';
@@ -1811,6 +1813,15 @@ function normalizeAgentConfig(
     : fallback?.skills
       ? [...fallback.skills]
       : undefined;
+  const owner = normalizeString(value.owner, fallback?.owner ?? '', {
+    allowEmpty: true,
+  });
+  const role = normalizeString(value.role, fallback?.role ?? '', {
+    allowEmpty: true,
+  });
+  const cv = Object.hasOwn(value, 'cv')
+    ? normalizeAgentCv(value.cv)
+    : cloneAgentCv(fallback?.cv);
   return {
     id,
     ...(name ? { name } : {}),
@@ -1820,6 +1831,9 @@ function normalizeAgentConfig(
     ...(workspace ? { workspace } : {}),
     ...(chatbotId ? { chatbotId } : {}),
     ...(typeof enableRag === 'boolean' ? { enableRag } : {}),
+    ...(owner ? { owner } : {}),
+    ...(role ? { role } : {}),
+    ...(cv ? { cv } : {}),
   };
 }
 

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -1931,8 +1931,7 @@ function serializeAgentSkillsConfig(skills?: string[]): string | null {
 }
 
 function serializeAgentCv(cv: AgentCv | undefined): string | null {
-  const normalized = normalizeAgentCv(cv);
-  return normalized ? JSON.stringify(normalized) : null;
+  return cv ? JSON.stringify(cv) : null;
 }
 
 function parseAgentCv(rawCv: string | null): AgentCv | undefined {
@@ -1943,7 +1942,7 @@ function parseAgentCv(rawCv: string | null): AgentCv | undefined {
     return normalizeAgentCv(JSON.parse(normalized));
   } catch {
     logger.warn(
-      { rawCvLength: normalized.length },
+      { cvLength: normalized.length },
       'Failed to parse persisted agent CV configuration',
     );
     return undefined;

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -2,7 +2,11 @@ import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import Database from 'better-sqlite3';
-import type { AgentConfig, AgentModelConfig } from '../agents/agent-types.js';
+import type {
+  AgentConfig,
+  AgentCv,
+  AgentModelConfig,
+} from '../agents/agent-types.js';
 import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import type { WireRecord } from '../audit/audit-trail.js';
 import { DB_PATH } from '../config/config.js';
@@ -106,7 +110,7 @@ import {
 let db: Database.Database;
 let databaseInitialized = false;
 
-export const DATABASE_SCHEMA_VERSION = 20;
+export const DATABASE_SCHEMA_VERSION = 21;
 const STRUCTURED_AUDIT_SESSION_LIMIT = 10_000;
 const RECENT_CHAT_MESSAGE_SEARCH_TABLE = 'recent_chat_message_search';
 const RECENT_CHAT_MESSAGE_SEARCH_INSERT_TRIGGER =
@@ -148,6 +152,9 @@ type AgentRow = {
   chatbot_id: string | null;
   enable_rag: number | null;
   workspace: string | null;
+  owner: string | null;
+  role: string | null;
+  cv: string | null;
   created_at: string;
   updated_at: string;
 };
@@ -1729,6 +1736,39 @@ function migrateV20(
   recordMigration(database, 20, 'Persist assistant message agent identity');
 }
 
+function migrateV21(
+  database: Database.Database,
+  opts?: InitDatabaseOptions,
+): void {
+  const quiet = opts?.quiet === true;
+  addColumnIfMissing({
+    database,
+    table: 'agents',
+    column: 'owner',
+    ddl: 'owner TEXT',
+    quiet,
+  });
+  addColumnIfMissing({
+    database,
+    table: 'agents',
+    column: 'role',
+    ddl: 'role TEXT',
+    quiet,
+  });
+  addColumnIfMissing({
+    database,
+    table: 'agents',
+    column: 'cv',
+    ddl: 'cv TEXT',
+    quiet,
+  });
+  recordMigration(
+    database,
+    21,
+    'Persist agent owner, role, and CV profile for stable coworker identity',
+  );
+}
+
 function runMigrations(
   database: Database.Database,
   opts?: InitDatabaseOptions,
@@ -1770,6 +1810,7 @@ function runMigrations(
   if (currentVersion < 18) migrateV18(database, opts);
   if (currentVersion < 19) migrateV19(database);
   if (currentVersion < 20) migrateV20(database, opts);
+  if (currentVersion < 21) migrateV21(database, opts);
 
   setSchemaVersion(database, DATABASE_SCHEMA_VERSION);
   if (!quiet && currentVersion < DATABASE_SCHEMA_VERSION) {
@@ -1889,6 +1930,69 @@ function serializeAgentSkillsConfig(skills?: string[]): string | null {
   return JSON.stringify(normalizeTrimmedUniqueStringArray(skills));
 }
 
+function serializeAgentCv(cv: AgentCv | undefined): string | null {
+  if (!cv) return null;
+  const summary = cv.summary?.trim() || '';
+  const background = cv.background?.trim() || '';
+  const asset = cv.asset?.trim() || '';
+  const capabilities = Array.isArray(cv.capabilities)
+    ? normalizeTrimmedUniqueStringArray(cv.capabilities)
+    : [];
+  const payload: AgentCv = {
+    ...(summary ? { summary } : {}),
+    ...(background ? { background } : {}),
+    ...(capabilities.length > 0 ? { capabilities } : {}),
+    ...(asset ? { asset } : {}),
+  };
+  return Object.keys(payload).length > 0 ? JSON.stringify(payload) : null;
+}
+
+function parseAgentCv(rawCv: string | null): AgentCv | undefined {
+  const normalized = rawCv?.trim() || '';
+  if (!normalized) return undefined;
+
+  try {
+    const parsed = JSON.parse(normalized) as unknown;
+    if (typeof parsed === 'string') {
+      const asset = parsed.trim();
+      return asset ? { asset } : undefined;
+    }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return undefined;
+    }
+    const raw = parsed as {
+      summary?: unknown;
+      background?: unknown;
+      capabilities?: unknown;
+      asset?: unknown;
+    };
+    const summary = typeof raw.summary === 'string' ? raw.summary.trim() : '';
+    const background =
+      typeof raw.background === 'string' ? raw.background.trim() : '';
+    const asset = typeof raw.asset === 'string' ? raw.asset.trim() : '';
+    const capabilities = Array.isArray(raw.capabilities)
+      ? normalizeTrimmedUniqueStringArray(
+          raw.capabilities.filter(
+            (entry): entry is string => typeof entry === 'string',
+          ),
+        )
+      : [];
+    const cv: AgentCv = {
+      ...(summary ? { summary } : {}),
+      ...(background ? { background } : {}),
+      ...(capabilities.length > 0 ? { capabilities } : {}),
+      ...(asset ? { asset } : {}),
+    };
+    return Object.keys(cv).length > 0 ? cv : undefined;
+  } catch {
+    logger.warn(
+      { rawCv: normalized },
+      'Failed to parse persisted agent CV configuration',
+    );
+    return undefined;
+  }
+}
+
 function mapAgentRow(row: AgentRow): AgentConfig {
   const name = row.name?.trim() || '';
   const displayName = row.display_name?.trim() || '';
@@ -1897,6 +2001,9 @@ function mapAgentRow(row: AgentRow): AgentConfig {
   const skills = parseAgentSkillsConfig(row.skills);
   const chatbotId = row.chatbot_id?.trim() || '';
   const workspace = row.workspace?.trim() || '';
+  const owner = row.owner?.trim() || '';
+  const role = row.role?.trim() || '';
+  const cv = parseAgentCv(row.cv);
   return {
     id: row.id,
     ...(name ? { name } : {}),
@@ -1909,15 +2016,21 @@ function mapAgentRow(row: AgentRow): AgentConfig {
     ...(typeof row.enable_rag === 'number'
       ? { enableRag: row.enable_rag !== 0 }
       : {}),
+    ...(owner ? { owner } : {}),
+    ...(role ? { role } : {}),
+    ...(cv ? { cv } : {}),
   };
 }
+
+const AGENT_SELECT_COLUMNS =
+  'id, name, display_name, image_asset, model, skills, chatbot_id, enable_rag, workspace, owner, role, cv, created_at, updated_at';
 
 export function getAgentById(agentId: string): AgentConfig | null {
   const normalizedAgentId = agentId.trim();
   if (!normalizedAgentId) return null;
   const row = queryOne<AgentRow, [string]>(
     db,
-    `SELECT id, name, display_name, image_asset, model, skills, chatbot_id, enable_rag, workspace, created_at, updated_at
+    `SELECT ${AGENT_SELECT_COLUMNS}
      FROM agents
      WHERE id = ?`,
     normalizedAgentId,
@@ -1928,7 +2041,7 @@ export function getAgentById(agentId: string): AgentConfig | null {
 export function listAgents(): AgentConfig[] {
   const rows = queryAll<AgentRow, [string]>(
     db,
-    `SELECT id, name, display_name, image_asset, model, skills, chatbot_id, enable_rag, workspace, created_at, updated_at
+    `SELECT ${AGENT_SELECT_COLUMNS}
      FROM agents
      ORDER BY CASE WHEN id = ? THEN 0 ELSE 1 END, id ASC`,
     DEFAULT_AGENT_ID,
@@ -1948,6 +2061,9 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
   const normalizedSkills = serializeAgentSkillsConfig(agent.skills);
   const normalizedChatbotId = agent.chatbotId?.trim() || null;
   const normalizedWorkspace = agent.workspace?.trim() || null;
+  const normalizedOwner = agent.owner?.trim() || null;
+  const normalizedRole = agent.role?.trim() || null;
+  const normalizedCv = serializeAgentCv(agent.cv);
   const enableRag =
     typeof agent.enableRag === 'boolean' ? (agent.enableRag ? 1 : 0) : null;
   db.prepare(
@@ -1961,9 +2077,12 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
        chatbot_id,
        enable_rag,
        workspace,
+       owner,
+       role,
+       cv,
        created_at,
        updated_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
      ON CONFLICT(id) DO UPDATE SET
        name = excluded.name,
        display_name = excluded.display_name,
@@ -1973,6 +2092,9 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
        chatbot_id = excluded.chatbot_id,
        enable_rag = excluded.enable_rag,
        workspace = excluded.workspace,
+       owner = excluded.owner,
+       role = excluded.role,
+       cv = excluded.cv,
        updated_at = datetime('now')`,
   ).run(
     normalizedId,
@@ -1984,6 +2106,9 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
     normalizedChatbotId,
     enableRag,
     normalizedWorkspace,
+    normalizedOwner,
+    normalizedRole,
+    normalizedCv,
   );
   const storedAgent = getAgentById(normalizedId);
   if (!storedAgent) {

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -7,7 +7,7 @@ import type {
   AgentCv,
   AgentModelConfig,
 } from '../agents/agent-types.js';
-import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
+import { DEFAULT_AGENT_ID, normalizeAgentCv } from '../agents/agent-types.js';
 import type { WireRecord } from '../audit/audit-trail.js';
 import { DB_PATH } from '../config/config.js';
 import {
@@ -1931,20 +1931,8 @@ function serializeAgentSkillsConfig(skills?: string[]): string | null {
 }
 
 function serializeAgentCv(cv: AgentCv | undefined): string | null {
-  if (!cv) return null;
-  const summary = cv.summary?.trim() || '';
-  const background = cv.background?.trim() || '';
-  const asset = cv.asset?.trim() || '';
-  const capabilities = Array.isArray(cv.capabilities)
-    ? normalizeTrimmedUniqueStringArray(cv.capabilities)
-    : [];
-  const payload: AgentCv = {
-    ...(summary ? { summary } : {}),
-    ...(background ? { background } : {}),
-    ...(capabilities.length > 0 ? { capabilities } : {}),
-    ...(asset ? { asset } : {}),
-  };
-  return Object.keys(payload).length > 0 ? JSON.stringify(payload) : null;
+  const normalized = normalizeAgentCv(cv);
+  return normalized ? JSON.stringify(normalized) : null;
 }
 
 function parseAgentCv(rawCv: string | null): AgentCv | undefined {
@@ -1952,41 +1940,10 @@ function parseAgentCv(rawCv: string | null): AgentCv | undefined {
   if (!normalized) return undefined;
 
   try {
-    const parsed = JSON.parse(normalized) as unknown;
-    if (typeof parsed === 'string') {
-      const asset = parsed.trim();
-      return asset ? { asset } : undefined;
-    }
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      return undefined;
-    }
-    const raw = parsed as {
-      summary?: unknown;
-      background?: unknown;
-      capabilities?: unknown;
-      asset?: unknown;
-    };
-    const summary = typeof raw.summary === 'string' ? raw.summary.trim() : '';
-    const background =
-      typeof raw.background === 'string' ? raw.background.trim() : '';
-    const asset = typeof raw.asset === 'string' ? raw.asset.trim() : '';
-    const capabilities = Array.isArray(raw.capabilities)
-      ? normalizeTrimmedUniqueStringArray(
-          raw.capabilities.filter(
-            (entry): entry is string => typeof entry === 'string',
-          ),
-        )
-      : [];
-    const cv: AgentCv = {
-      ...(summary ? { summary } : {}),
-      ...(background ? { background } : {}),
-      ...(capabilities.length > 0 ? { capabilities } : {}),
-      ...(asset ? { asset } : {}),
-    };
-    return Object.keys(cv).length > 0 ? cv : undefined;
+    return normalizeAgentCv(JSON.parse(normalized));
   } catch {
     logger.warn(
-      { rawCv: normalized },
+      { rawCvLength: normalized.length },
       'Failed to parse persisted agent CV configuration',
     );
     return undefined;

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -422,6 +422,59 @@ test('warns and ignores malformed persisted agent skill allowlists', async () =>
   );
 });
 
+test('warns without logging malformed persisted agent CV payloads', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+
+  const warnMock = vi.fn();
+  vi.doMock('../src/logger.js', () => ({
+    logger: {
+      warn: warnMock,
+      info: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+      trace: vi.fn(),
+      child: vi.fn(() => ({
+        warn: warnMock,
+        info: vi.fn(),
+        debug: vi.fn(),
+        error: vi.fn(),
+        fatal: vi.fn(),
+        trace: vi.fn(),
+      })),
+    },
+  }));
+
+  const dbPath = path.join(homeDir, 'data', 'hybridclaw.db');
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { getAgentById } = await import('../src/agents/agent-registry.ts');
+
+  initDatabase({ quiet: true, dbPath });
+  const rawCv = '{"summary":"Benedikt lives at Example Street"';
+  const rawDb = new Database(dbPath);
+  rawDb
+    .prepare(
+      `INSERT INTO agents (id, name, cv, created_at, updated_at)
+       VALUES (?, ?, ?, datetime('now'), datetime('now'))`,
+    )
+    .run('researcher', 'Researcher Agent', rawCv);
+  rawDb.close();
+
+  const agent = getAgentById('researcher');
+  expect(agent).toMatchObject({
+    id: 'researcher',
+    name: 'Researcher Agent',
+  });
+  expect(agent?.cv).toBeUndefined();
+  expect(warnMock).toHaveBeenCalledWith(
+    { cvLength: rawCv.length },
+    'Failed to parse persisted agent CV configuration',
+  );
+  expect(JSON.stringify(warnMock.mock.calls)).not.toContain('Benedikt');
+});
+
 test('initAgentRegistry migrates the first legacy workspace to main', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -212,6 +212,165 @@ test('agent skill allowlists persist through runtime config normalization and th
   expect(getAgentById('silent')?.skills).toEqual([]);
 });
 
+test('agent owner, role, and CV persist through runtime config and registry', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { updateRuntimeConfig, getRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  const { getAgentById, initAgentRegistry, resolveAgentConfig } = await import(
+    '../src/agents/agent-registry.ts'
+  );
+
+  initDatabase({ quiet: true });
+  updateRuntimeConfig((draft) => {
+    draft.agents.list = [
+      {
+        id: 'main',
+        name: 'Main Agent',
+      },
+      {
+        id: 'charly',
+        name: 'Charly',
+        owner: '  benedikt  ',
+        role: ' Researcher ',
+        cv: {
+          summary: '  Senior coworker  ',
+          capabilities: [' research ', 'writing', 'research'],
+          asset: 'agents/charly/CV.md',
+        },
+      },
+    ];
+  });
+
+  // Runtime config normalization should trim strings and dedupe capability list.
+  const persistedConfig = getRuntimeConfig().agents.list?.find(
+    (entry) => entry.id === 'charly',
+  );
+  expect(persistedConfig?.owner).toBe('benedikt');
+  expect(persistedConfig?.role).toBe('Researcher');
+  expect(persistedConfig?.cv).toEqual({
+    summary: 'Senior coworker',
+    capabilities: ['research', 'writing'],
+    asset: 'agents/charly/CV.md',
+  });
+
+  initAgentRegistry({
+    list: [
+      {
+        id: 'main',
+        name: 'Main Agent',
+      },
+      {
+        id: 'charly',
+        name: 'Charly',
+        owner: 'benedikt',
+        role: 'Researcher',
+        cv: {
+          summary: 'Senior coworker',
+          capabilities: ['research', 'writing'],
+          asset: 'agents/charly/CV.md',
+        },
+      },
+    ],
+  });
+
+  const resolved = resolveAgentConfig('charly');
+  expect(resolved.owner).toBe('benedikt');
+  expect(resolved.role).toBe('Researcher');
+  expect(resolved.cv).toEqual({
+    summary: 'Senior coworker',
+    capabilities: ['research', 'writing'],
+    asset: 'agents/charly/CV.md',
+  });
+
+  // Round-trip through SQLite confirms persistence.
+  const stored = getAgentById('charly');
+  expect(stored?.owner).toBe('benedikt');
+  expect(stored?.role).toBe('Researcher');
+  expect(stored?.cv).toEqual({
+    summary: 'Senior coworker',
+    capabilities: ['research', 'writing'],
+    asset: 'agents/charly/CV.md',
+  });
+});
+
+test('legacy agents without owner/role/cv load cleanly after migration v21', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+
+  const dbPath = path.join(homeDir, 'data', 'hybridclaw.db');
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+
+  const legacyDb = new Database(dbPath);
+  legacyDb.exec(`
+    CREATE TABLE agents (
+      id TEXT PRIMARY KEY,
+      name TEXT,
+      display_name TEXT,
+      image_asset TEXT,
+      model TEXT,
+      skills TEXT,
+      chatbot_id TEXT,
+      enable_rag INTEGER DEFAULT 1,
+      workspace TEXT,
+      created_at TEXT DEFAULT (datetime('now')),
+      updated_at TEXT DEFAULT (datetime('now'))
+    );
+  `);
+  legacyDb
+    .prepare(
+      `INSERT INTO agents (id, name, display_name)
+       VALUES (?, ?, ?)`,
+    )
+    .run('charly', 'Charly', 'Charly the Coworker');
+  legacyDb.pragma('user_version = 20');
+  legacyDb.close();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  initDatabase({ quiet: true, dbPath });
+
+  const migratedDb = new Database(dbPath, { readonly: true });
+  const columns = migratedDb.pragma('table_info(agents)') as Array<{
+    name: string;
+  }>;
+  expect(columns.some((column) => column.name === 'owner')).toBe(true);
+  expect(columns.some((column) => column.name === 'role')).toBe(true);
+  expect(columns.some((column) => column.name === 'cv')).toBe(true);
+
+  const userVersion = migratedDb.pragma('user_version', { simple: true });
+  expect(userVersion).toBeGreaterThanOrEqual(21);
+
+  const charly = migratedDb
+    .prepare('SELECT id, name, owner, role, cv FROM agents WHERE id = ?')
+    .get('charly') as {
+    id: string;
+    name: string;
+    owner: string | null;
+    role: string | null;
+    cv: string | null;
+  };
+  expect(charly).toMatchObject({
+    id: 'charly',
+    name: 'Charly',
+    owner: null,
+    role: null,
+    cv: null,
+  });
+  migratedDb.close();
+
+  const { getAgentById } = await import('../src/agents/agent-registry.ts');
+  expect(getAgentById('charly')).toMatchObject({
+    id: 'charly',
+    name: 'Charly',
+    displayName: 'Charly the Coworker',
+  });
+});
+
 test('warns and ignores malformed persisted agent skill allowlists', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;

--- a/tests/agent-types.test.ts
+++ b/tests/agent-types.test.ts
@@ -49,7 +49,9 @@ test('normalizeAgentCv returns undefined for non-object, empty, or noise input',
   expect(normalizeAgentCv(null)).toBeUndefined();
   expect(normalizeAgentCv(['array'])).toBeUndefined();
   expect(normalizeAgentCv({})).toBeUndefined();
-  expect(normalizeAgentCv({ summary: '   ', capabilities: [] })).toBeUndefined();
+  expect(
+    normalizeAgentCv({ summary: '   ', capabilities: [] }),
+  ).toBeUndefined();
 });
 
 test('cloneAgentCv produces an independent copy', () => {
@@ -78,8 +80,6 @@ test('agentCvEquals compares structurally', () => {
       { summary: 'a', capabilities: ['y', 'x'] },
     ),
   ).toBe(false);
-  expect(
-    agentCvEquals({ summary: 'a' }, { summary: 'b' }),
-  ).toBe(false);
+  expect(agentCvEquals({ summary: 'a' }, { summary: 'b' })).toBe(false);
   expect(agentCvEquals({ summary: 'a' }, undefined)).toBe(false);
 });

--- a/tests/agent-types.test.ts
+++ b/tests/agent-types.test.ts
@@ -1,6 +1,11 @@
 import { expect, test } from 'vitest';
 
-import { buildOptionalAgentPresentation } from '../src/agents/agent-types.js';
+import {
+  agentCvEquals,
+  buildOptionalAgentPresentation,
+  cloneAgentCv,
+  normalizeAgentCv,
+} from '../src/agents/agent-types.js';
 
 test('buildOptionalAgentPresentation includes only populated presentation fields', () => {
   expect(
@@ -15,4 +20,66 @@ test('buildOptionalAgentPresentation includes only populated presentation fields
   ).toEqual({
     imageAsset: 'avatars/charly.png',
   });
+});
+
+test('normalizeAgentCv accepts a string asset pointer', () => {
+  expect(normalizeAgentCv('agents/charly/CV.md')).toEqual({
+    asset: 'agents/charly/CV.md',
+  });
+  expect(normalizeAgentCv('   ')).toBeUndefined();
+});
+
+test('normalizeAgentCv trims fields, dedupes capabilities, and drops empties', () => {
+  expect(
+    normalizeAgentCv({
+      summary: '  Senior researcher  ',
+      background: '',
+      capabilities: [' research ', 'writing', 'research', '', 7],
+      asset: ' agents/charly/CV.md ',
+    }),
+  ).toEqual({
+    summary: 'Senior researcher',
+    capabilities: ['research', 'writing'],
+    asset: 'agents/charly/CV.md',
+  });
+});
+
+test('normalizeAgentCv returns undefined for non-object, empty, or noise input', () => {
+  expect(normalizeAgentCv(undefined)).toBeUndefined();
+  expect(normalizeAgentCv(null)).toBeUndefined();
+  expect(normalizeAgentCv(['array'])).toBeUndefined();
+  expect(normalizeAgentCv({})).toBeUndefined();
+  expect(normalizeAgentCv({ summary: '   ', capabilities: [] })).toBeUndefined();
+});
+
+test('cloneAgentCv produces an independent copy', () => {
+  const original = {
+    summary: 'Senior',
+    capabilities: ['a', 'b'],
+    asset: 'CV.md',
+  };
+  const copy = cloneAgentCv(original);
+  expect(copy).toEqual(original);
+  copy?.capabilities?.push('c');
+  expect(original.capabilities).toEqual(['a', 'b']);
+});
+
+test('agentCvEquals compares structurally', () => {
+  expect(agentCvEquals(undefined, undefined)).toBe(true);
+  expect(
+    agentCvEquals(
+      { summary: 'a', capabilities: ['x', 'y'] },
+      { summary: 'a', capabilities: ['x', 'y'] },
+    ),
+  ).toBe(true);
+  expect(
+    agentCvEquals(
+      { summary: 'a', capabilities: ['x', 'y'] },
+      { summary: 'a', capabilities: ['y', 'x'] },
+    ),
+  ).toBe(false);
+  expect(
+    agentCvEquals({ summary: 'a' }, { summary: 'b' }),
+  ).toBe(false);
+  expect(agentCvEquals({ summary: 'a' }, undefined)).toBe(false);
 });


### PR DESCRIPTION
## Summary

- **Problem:** \`AgentConfig\` lacked owner, role, and a structured CV — Foundation F1 of the Trusted Coworker roadmap (#414) blocks downstream items 1.x (sender/recipient identity), 3.x (CV.md & scoreboard), 5.x (per-coworker budgets), and #11 (working hours).
- **Why it matters:** Manifesto Principle I — \"a coworker is a person, not a prompt.\" Stable identity needs to live in the schema, not in a per-session prompt template.
- **What changed:** Extended \`AgentConfig\` with \`owner\`, \`role\`, and a structured \`cv\` (\`summary\`, \`background\`, \`capabilities\`, \`asset\`); added migration v21 + persistence; wired normalization through runtime-config and the agent registry; added unit and migration tests.
- **What did not change:** No behavioral change to existing fields. The new fields are optional — legacy rows and configs load cleanly with NULL/undefined values. Out of scope: \`.claw\` archive manifest, agent-config-command JSON setters (separate follow-ups; both can opt in once a consumer needs them).

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Docs
- [x] Tests
- [ ] Refactor required for the fix
- [ ] Tooling or workflow
- [ ] Security hardening

## Linked Context

- Closes #414
- Related: roadmap items 1.x, 3.x, 5.x, #11

## Validation

\`\`\`bash
npm run typecheck                  # passes
npm run lint                       # passes
npm run check                      # passes (after npm run format)
npx vitest run tests/agent-types.test.ts tests/agent-registry.test.ts                      # 14 pass
npx vitest run tests/agent-config-command.test.ts tests/gateway-agent-cards.test.ts \\
              tests/gateway-service.agent-install.test.ts tests/gateway-service.agent-markdown.test.ts \\
              tests/agent-side-effects.test.ts                                              # 29 pass
npx vitest run tests/memory-service.test.ts tests/doctor.test.ts                            # 78 pass
npx vitest run --config vitest.integration.config.ts tests/database-session.integration.test.ts  # 14 pass
\`\`\`

- Verified manually:
  - Schema round-trip: a config with owner/role/cv flows through \`updateRuntimeConfig\` → \`initAgentRegistry\` → SQLite → \`getAgentById\` and comes back identical, with capabilities trimmed/deduped and empty CV objects collapsed to \`undefined\`.
  - Migration: a legacy v20 database (agents table without the new columns) opens, gets the three new columns added via \`addColumnIfMissing\`, advances \`user_version\` to ≥21, and existing rows load with \`null\` for the new fields.
  - Equality: \`sameAgentConfig\` now considers owner/role/cv, so unchanged drafts no longer churn writes.
- Edge cases checked: malformed JSON in the \`cv\` column warns and is dropped (mirrors the skills allowlist behavior); CV input as a bare string is treated as an asset pointer; arrays/null/non-objects normalize to \`undefined\`.
- Skipped checks and why: \`npm run test:e2e\` and \`test:live\` — not applicable to a schema/persistence change.

## Docs And Config Impact

- [ ] README, docs, or examples updated
- [ ] Config or environment behavior changed
- [ ] Templates or workspace bootstrap files changed
- [x] No docs or config impact

\`templates/\` was not touched; \`src/workspace.ts\` is unchanged.

## Risk Notes

- Security-sensitive paths touched? **No**
- Gateway, audit, approval, or container boundaries touched? **No**
- Risk class: medium (\`src/memory/db.ts\` — schema migration). The migration is additive (\`addColumnIfMissing\`), idempotent on re-run, and forward-compatible — older binaries reading a v21 database will still see all v20 columns.

## Evidence

- [ ] Failing output before and passing output after
- [ ] Screenshot or recording
- [ ] Log snippet
- [x] New or updated test coverage

New tests:

- [tests/agent-types.test.ts](tests/agent-types.test.ts) — \`normalizeAgentCv\` (string asset, structured object, trimming/dedup, empty/noise input), \`cloneAgentCv\` independence, \`agentCvEquals\` structural compare.
- [tests/agent-registry.test.ts](tests/agent-registry.test.ts) — owner/role/cv survive runtime-config normalization, registry resolution, and SQLite round-trip; legacy v20 database migrates cleanly to v21 with NULL values for the new columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)