### PR TITLE
[codex] Add unified skill-run event bus

### DIFF
--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -1068,6 +1068,15 @@ async function handleGatewayMessageInner(
             toolExecutions,
           }),
           durationMs: Date.now() - startedAt,
+          model,
+          tokenUsage: output.tokenUsage,
+          costUsd: extractUsageCostUsd(output.tokenUsage),
+          coworkerId: agentId,
+          input: storedUserContent,
+          output: {
+            status: output.status,
+            result: output.result,
+          },
           errorDetail: output.error,
         });
       } catch (error) {

--- a/src/skills/skill-run-events.ts
+++ b/src/skills/skill-run-events.ts
@@ -1,0 +1,177 @@
+import { logger } from '../logger.js';
+import { redactSecretsDeep } from '../security/redact.js';
+import type { ToolExecution } from '../types/execution.js';
+import type { TokenUsageStats } from '../types/usage.js';
+import type {
+  SkillErrorCategory,
+  SkillExecutionOutcome,
+} from './adaptive-skills-types.js';
+
+export interface SkillRunTokenEnvelope {
+  prompt: number;
+  completion: number;
+  total: number;
+  modelCalls: number;
+  apiUsageAvailable: boolean;
+  estimatedPrompt: number;
+  estimatedCompletion: number;
+  estimatedTotal: number;
+  apiPrompt: number;
+  apiCompletion: number;
+  apiTotal: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+}
+
+export interface SkillRunBoundedPayload {
+  content: string;
+  truncated: boolean;
+}
+
+export interface SkillRunToolExecutionSummary {
+  name: string;
+  duration_ms: number;
+  is_error: boolean;
+  blocked: boolean;
+  approval_tier?: ToolExecution['approvalTier'];
+  approval_decision?: ToolExecution['approvalDecision'];
+}
+
+export interface SkillRunEvent {
+  type: 'skill_run';
+  skill_id: string;
+  coworker_id: string | null;
+  session_id: string;
+  run_id: string;
+  input: SkillRunBoundedPayload | null;
+  output: SkillRunBoundedPayload | null;
+  model: string | null;
+  tokens: SkillRunTokenEnvelope;
+  latency_ms: number;
+  cost_usd: number;
+  errors: string[];
+  outcome: SkillExecutionOutcome;
+  error_category: SkillErrorCategory | null;
+  error_detail: string | null;
+  tool_executions: SkillRunToolExecutionSummary[];
+}
+
+export type SkillRunSubscriber = (event: SkillRunEvent) => unknown;
+
+const subscribers = new Set<SkillRunSubscriber>();
+const MAX_SKILL_RUN_PAYLOAD_CHARS = 4096;
+
+export function subscribeSkillRunEvents(
+  subscriber: SkillRunSubscriber,
+): () => void {
+  subscribers.add(subscriber);
+  return () => {
+    subscribers.delete(subscriber);
+  };
+}
+
+export function summarizeSkillRunToolExecutions(
+  toolExecutions: ToolExecution[],
+): SkillRunToolExecutionSummary[] {
+  return toolExecutions.map((execution) => {
+    return {
+      name: execution.name,
+      duration_ms: execution.durationMs,
+      is_error: Boolean(execution.isError),
+      blocked: Boolean(execution.blocked),
+      ...(execution.approvalTier
+        ? { approval_tier: execution.approvalTier }
+        : {}),
+      ...(execution.approvalDecision
+        ? { approval_decision: execution.approvalDecision }
+        : {}),
+    };
+  });
+}
+
+function stringifySkillRunPayload(value: unknown): string {
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function buildSkillRunBoundedPayload(
+  value: unknown,
+): SkillRunBoundedPayload | null {
+  if (value == null) return null;
+  const redacted = redactSecretsDeep(value);
+  const content = stringifySkillRunPayload(redacted);
+  if (content.length <= MAX_SKILL_RUN_PAYLOAD_CHARS) {
+    return { content, truncated: false };
+  }
+  return {
+    content: `${content.slice(0, MAX_SKILL_RUN_PAYLOAD_CHARS)}...`,
+    truncated: true,
+  };
+}
+
+export function emitSkillRunEvent(event: SkillRunEvent): void {
+  let subscriberIndex = 0;
+  for (const subscriber of subscribers) {
+    subscriberIndex += 1;
+    try {
+      subscriber(event);
+    } catch (error) {
+      logger.warn(
+        {
+          sessionId: event.session_id,
+          runId: event.run_id,
+          skillId: event.skill_id,
+          subscriberIndex,
+          error,
+        },
+        'Skill run subscriber failed',
+      );
+    }
+  }
+}
+
+function normalizeSkillRunModelCalls(tokenUsage?: TokenUsageStats): number {
+  if (!tokenUsage) return 0;
+  if (tokenUsage.modelCalls >= 1) return tokenUsage.modelCalls;
+  logger.warn(
+    { modelCalls: tokenUsage.modelCalls },
+    'Invalid token usage model call count for skill run event',
+  );
+  return Math.max(0, tokenUsage.modelCalls);
+}
+
+export function buildSkillRunTokens(
+  tokenUsage?: TokenUsageStats,
+): SkillRunTokenEnvelope {
+  const apiUsageAvailable = tokenUsage?.apiUsageAvailable === true;
+  const apiPrompt = tokenUsage?.apiPromptTokens || 0;
+  const apiCompletion = tokenUsage?.apiCompletionTokens || 0;
+  const apiTotal = tokenUsage?.apiTotalTokens || apiPrompt + apiCompletion;
+  const estimatedPrompt = tokenUsage?.estimatedPromptTokens || 0;
+  const estimatedCompletion = tokenUsage?.estimatedCompletionTokens || 0;
+  const estimatedTotal =
+    tokenUsage?.estimatedTotalTokens || estimatedPrompt + estimatedCompletion;
+  return {
+    prompt: apiUsageAvailable ? apiPrompt : estimatedPrompt,
+    completion: apiUsageAvailable ? apiCompletion : estimatedCompletion,
+    total: apiUsageAvailable ? apiTotal : estimatedTotal,
+    modelCalls: normalizeSkillRunModelCalls(tokenUsage),
+    apiUsageAvailable,
+    estimatedPrompt,
+    estimatedCompletion,
+    estimatedTotal,
+    apiPrompt,
+    apiCompletion,
+    apiTotal,
+    ...(tokenUsage?.apiCacheUsageAvailable
+      ? {
+          cacheRead: tokenUsage.apiCacheReadTokens || 0,
+          cacheWrite: tokenUsage.apiCacheWriteTokens || 0,
+        }
+      : {}),
+  };
+}

--- a/src/skills/skills-observation.ts
+++ b/src/skills/skills-observation.ts
@@ -3,10 +3,12 @@ import { getRuntimeConfig } from '../config/runtime-config.js';
 import { logger } from '../logger.js';
 import {
   attachFeedbackToObservation,
+  getSkillObservations,
   incrementAmendmentRunCount,
   recordSkillObservation as insertSkillObservation,
 } from '../memory/db.js';
 import type { ToolExecution } from '../types/execution.js';
+import type { TokenUsageStats } from '../types/usage.js';
 import type {
   AdaptiveSkillsConfig,
   SkillErrorCategory,
@@ -14,18 +16,31 @@ import type {
   SkillFeedbackSentiment,
   SkillObservation,
 } from './adaptive-skills-types.js';
+import {
+  buildSkillRunBoundedPayload,
+  buildSkillRunTokens,
+  emitSkillRunEvent,
+  type SkillRunEvent,
+  subscribeSkillRunEvents,
+  summarizeSkillRunToolExecutions,
+} from './skill-run-events.js';
 import { evaluateAmendment, rollbackAmendment } from './skills-evaluation.js';
 
 let queuedSkillEvaluationWork: Promise<void> = Promise.resolve();
 
+function getToolExecutionErrorDetail(execution: ToolExecution): string | null {
+  return (
+    execution.blockedReason?.trim() ||
+    execution.approvalReason?.trim() ||
+    execution.result?.trim() ||
+    null
+  );
+}
+
 function firstFailedToolDetail(toolExecutions: ToolExecution[]): string | null {
   for (const execution of toolExecutions) {
     if (!execution.isError && !execution.blocked) continue;
-    const detail =
-      execution.blockedReason?.trim() ||
-      execution.approvalReason?.trim() ||
-      execution.result?.trim() ||
-      null;
+    const detail = getToolExecutionErrorDetail(execution);
     if (detail) return detail;
   }
   return null;
@@ -110,49 +125,32 @@ function queueSkillEvaluation(input: {
   queuedSkillEvaluationWork = work.catch(() => {});
 }
 
-export async function waitForQueuedSkillEvaluations(): Promise<void> {
-  await queuedSkillEvaluationWork;
-}
-
-export function recordSkillExecution(input: {
-  skillName: string;
-  sessionId: string;
-  runId: string;
-  toolExecutions: ToolExecution[];
-  outcome: SkillExecutionOutcome;
-  durationMs: number;
-  errorCategory?: SkillErrorCategory | null;
-  errorDetail?: string | null;
-}): SkillObservation | null {
+function recordSkillExecutionObservation(
+  event: SkillRunEvent,
+): SkillObservation | null {
   const config = getRuntimeConfig().adaptiveSkills;
-  const skillName = input.skillName.trim();
-  if (!skillName || !config.observationEnabled) return null;
+  if (!config.observationEnabled) return null;
 
-  const errorCategory =
-    input.errorCategory ??
-    classifyErrorCategory(input.toolExecutions, input.errorDetail);
-  const errorDetail =
-    input.errorDetail?.trim() || firstFailedToolDetail(input.toolExecutions);
   const observation = insertSkillObservation({
-    skillName,
-    sessionId: input.sessionId,
-    runId: input.runId,
-    outcome: input.outcome,
-    errorCategory,
-    errorDetail,
-    toolCallsAttempted: input.toolExecutions.length,
-    toolCallsFailed: input.toolExecutions.filter(
-      (execution) => execution.isError || execution.blocked,
+    skillName: event.skill_id,
+    sessionId: event.session_id,
+    runId: event.run_id,
+    outcome: event.outcome,
+    errorCategory: event.error_category,
+    errorDetail: event.error_detail,
+    toolCallsAttempted: event.tool_executions.length,
+    toolCallsFailed: event.tool_executions.filter(
+      (execution) => execution.is_error || execution.blocked,
     ).length,
-    durationMs: input.durationMs,
+    durationMs: event.latency_ms,
   });
 
   recordAuditEvent({
-    sessionId: input.sessionId,
-    runId: input.runId,
+    sessionId: event.session_id,
+    runId: event.run_id,
     event: {
       type: 'skill.execution',
-      skillName,
+      skillName: event.skill_id,
       outcome: observation.outcome,
       errorCategory: observation.error_category,
       toolCallsAttempted: observation.tool_calls_attempted,
@@ -163,11 +161,99 @@ export function recordSkillExecution(input: {
 
   if (!config.enabled) return observation;
 
-  const applied = incrementAmendmentRunCount(skillName);
+  const applied = incrementAmendmentRunCount(event.skill_id);
   if (!applied) return observation;
 
-  queueSkillEvaluation({ skillName, config });
+  queueSkillEvaluation({ skillName: event.skill_id, config });
   return observation;
+}
+
+export async function waitForQueuedSkillEvaluations(): Promise<void> {
+  await queuedSkillEvaluationWork;
+}
+
+subscribeSkillRunEvents(recordSkillExecutionObservation);
+
+function collectSkillRunErrors(input: {
+  errorDetail?: string | null;
+  toolExecutions: ToolExecution[];
+}): string[] {
+  const errors = new Set<string>();
+  const errorDetail = input.errorDetail?.trim();
+  if (errorDetail) errors.add(errorDetail);
+  for (const execution of input.toolExecutions) {
+    if (!execution.isError && !execution.blocked) continue;
+    const detail = getToolExecutionErrorDetail(execution);
+    if (detail) errors.add(detail);
+  }
+  return [...errors];
+}
+
+function normalizeSkillRunCostUsd(costUsd?: number | null): number {
+  if (costUsd == null) return 0;
+  if (Number.isFinite(costUsd) && costUsd >= 0) return costUsd;
+  logger.warn(
+    { costUsd },
+    'Invalid skill run cost value; recording zero cost in event',
+  );
+  return 0;
+}
+
+export function recordSkillExecution(input: {
+  skillName: string;
+  sessionId: string;
+  runId: string;
+  toolExecutions: ToolExecution[];
+  outcome: SkillExecutionOutcome;
+  durationMs: number;
+  model?: string | null;
+  tokenUsage?: TokenUsageStats;
+  costUsd?: number | null;
+  coworkerId?: string | null;
+  input?: unknown;
+  output?: unknown;
+  errorCategory?: SkillErrorCategory | null;
+  errorDetail?: string | null;
+}): SkillObservation | null {
+  const skillName = input.skillName.trim();
+  if (!skillName) return null;
+
+  const errorCategory =
+    input.errorCategory ??
+    classifyErrorCategory(input.toolExecutions, input.errorDetail);
+  const errorDetail =
+    input.errorDetail?.trim() || firstFailedToolDetail(input.toolExecutions);
+  const event: SkillRunEvent = {
+    type: 'skill_run',
+    skill_id: skillName,
+    coworker_id: input.coworkerId?.trim() || null,
+    session_id: input.sessionId,
+    run_id: input.runId,
+    input: buildSkillRunBoundedPayload(input.input),
+    output: buildSkillRunBoundedPayload(input.output),
+    model: input.model?.trim() || null,
+    tokens: buildSkillRunTokens(input.tokenUsage),
+    latency_ms: input.durationMs,
+    cost_usd: normalizeSkillRunCostUsd(input.costUsd),
+    errors: collectSkillRunErrors({
+      errorDetail,
+      toolExecutions: input.toolExecutions,
+    }),
+    outcome: input.outcome,
+    error_category: errorCategory,
+    error_detail: errorDetail,
+    tool_executions: summarizeSkillRunToolExecutions(input.toolExecutions),
+  };
+
+  emitSkillRunEvent(event);
+  return (
+    getSkillObservations({
+      skillName,
+      sessionId: input.sessionId,
+      runId: input.runId,
+      limit: 1,
+    })[0] ?? null
+  );
 }
 
 export function recordSkillFeedback(input: {

--- a/tests/gateway-service.skill-observation.test.ts
+++ b/tests/gateway-service.skill-observation.test.ts
@@ -25,6 +25,9 @@ test('handleGatewayMessage records observations for implicitly activated single-
   const { updateRuntimeConfig } = await import(
     '../src/config/runtime-config.ts'
   );
+  const { subscribeSkillRunEvents } = await import(
+    '../src/skills/skill-run-events.ts'
+  );
   const { handleGatewayMessage } = await import(
     '../src/gateway/gateway-chat-service.ts'
   );
@@ -32,6 +35,11 @@ test('handleGatewayMessage records observations for implicitly activated single-
   initDatabase({ quiet: true });
   updateRuntimeConfig((draft) => {
     draft.adaptiveSkills.observationEnabled = true;
+  });
+
+  const receivedEvents: unknown[] = [];
+  const unsubscribe = subscribeSkillRunEvents((event) => {
+    receivedEvents.push(event);
   });
 
   runAgentMock.mockResolvedValue({
@@ -48,19 +56,39 @@ test('handleGatewayMessage records observations for implicitly activated single-
         isError: true,
       },
     ],
+    tokenUsage: {
+      modelCalls: 1,
+      apiUsageAvailable: true,
+      apiPromptTokens: 12,
+      apiCompletionTokens: 5,
+      apiTotalTokens: 17,
+      apiCacheUsageAvailable: false,
+      apiCacheReadTokens: 0,
+      apiCacheWriteTokens: 0,
+      estimatedPromptTokens: 10,
+      estimatedCompletionTokens: 4,
+      estimatedTotalTokens: 14,
+      costUsd: 0.00042,
+    },
     error: 'resolved the wrong album',
   });
 
-  const result = await handleGatewayMessage({
-    sessionId: 'session-implicit-apple-music',
-    guildId: null,
-    channelId: 'web',
-    userId: 'user-1',
-    username: 'alice',
-    content: 'Play ... But Seriously by Phil Collins',
-    model: 'test-model',
-    chatbotId: 'bot-1',
-  });
+  let result!: Awaited<ReturnType<typeof handleGatewayMessage>>;
+  try {
+    result = await handleGatewayMessage({
+      sessionId: 'session-implicit-apple-music',
+      guildId: null,
+      channelId: 'web',
+      userId: 'user-1',
+      username: 'alice',
+      content: 'Play ... But Seriously by Phil Collins',
+      model: 'test-model',
+      chatbotId: 'bot-1',
+      agentId: 'coworker-alice',
+    });
+  } finally {
+    unsubscribe();
+  }
 
   expect(result.status).toBe('error');
   expect(getSkillObservationSummary({ skillName: 'apple-music' })).toEqual([
@@ -70,6 +98,33 @@ test('handleGatewayMessage records observations for implicitly activated single-
       failure_count: 1,
       tool_calls_attempted: 1,
       tool_calls_failed: 1,
+    }),
+  ]);
+  expect(receivedEvents).toEqual([
+    expect.objectContaining({
+      type: 'skill_run',
+      skill_id: 'apple-music',
+      coworker_id: 'coworker-alice',
+      session_id: 'session-implicit-apple-music',
+      model: 'test-model',
+      latency_ms: expect.any(Number),
+      cost_usd: 0.00042,
+      errors: ['resolved the wrong album'],
+      tokens: expect.objectContaining({
+        prompt: 12,
+        completion: 5,
+        total: 17,
+        modelCalls: 1,
+        apiUsageAvailable: true,
+      }),
+      input: {
+        content: expect.stringContaining('Phil Collins'),
+        truncated: false,
+      },
+      output: {
+        content: '{"status":"error","result":null}',
+        truncated: false,
+      },
     }),
   ]);
 });

--- a/tests/skills-observation.test.ts
+++ b/tests/skills-observation.test.ts
@@ -109,6 +109,178 @@ test('records skill executions and attaches negative feedback', async () => {
   ]);
 });
 
+test('emits a skill_run event to subscribers for every skill execution', async () => {
+  context = await createAdaptiveSkillsTestContext();
+  const { subscribeSkillRunEvents } = await import(
+    '../src/skills/skill-run-events.ts'
+  );
+  const { recordSkillExecution } = await import(
+    '../src/skills/skills-observation.ts'
+  );
+
+  const events: unknown[] = [];
+  const unsubscribe = subscribeSkillRunEvents((event) => {
+    events.push(event);
+  });
+  try {
+    recordSkillExecution({
+      skillName: context.skillName,
+      sessionId: 'session-event-1',
+      runId: 'run-event-1',
+      toolExecutions: [
+        {
+          name: 'bash',
+          arguments: JSON.stringify({
+            cmd: 'echo hello',
+            apiKey: 'test-key',
+            nested: { token: 'secret-token' },
+          }),
+          result: `${'x'.repeat(320)} secret-token`,
+          durationMs: 11,
+        },
+      ],
+      outcome: 'success',
+      durationMs: 30,
+      model: 'test-model',
+      coworkerId: 'coworker-1',
+      input: {
+        prompt: 'draft the note',
+        apiKey: 'test-key',
+        body: 'i'.repeat(4_500),
+      },
+      output: { text: 'done', token: 'secret-token' },
+      tokenUsage: {
+        modelCalls: 1,
+        apiUsageAvailable: false,
+        apiPromptTokens: 0,
+        apiCompletionTokens: 0,
+        apiTotalTokens: 0,
+        apiCacheUsageAvailable: false,
+        apiCacheReadTokens: 0,
+        apiCacheWriteTokens: 0,
+        estimatedPromptTokens: 9,
+        estimatedCompletionTokens: 3,
+        estimatedTotalTokens: 12,
+      },
+      costUsd: 0.001,
+    });
+
+    recordSkillExecution({
+      skillName: context.skillName,
+      sessionId: 'session-event-2',
+      runId: 'run-event-2',
+      toolExecutions: [],
+      outcome: 'success',
+      durationMs: 40,
+      tokenUsage: {
+        modelCalls: 0,
+        apiUsageAvailable: false,
+        apiPromptTokens: 0,
+        apiCompletionTokens: 0,
+        apiTotalTokens: 0,
+        apiCacheUsageAvailable: false,
+        apiCacheReadTokens: 0,
+        apiCacheWriteTokens: 0,
+        estimatedPromptTokens: 0,
+        estimatedCompletionTokens: 0,
+        estimatedTotalTokens: 0,
+      },
+      costUsd: -1,
+    });
+  } finally {
+    unsubscribe();
+  }
+
+  expect(events).toHaveLength(2);
+  expect(events[0]).toMatchObject({
+    type: 'skill_run',
+    skill_id: context.skillName,
+    coworker_id: 'coworker-1',
+    session_id: 'session-event-1',
+    run_id: 'run-event-1',
+    input: {
+      content: expect.stringContaining('draft the note'),
+      truncated: true,
+    },
+    output: {
+      content: '{"text":"done","token":"***"}',
+      truncated: false,
+    },
+    model: 'test-model',
+    tokens: {
+      prompt: 9,
+      completion: 3,
+      total: 12,
+      modelCalls: 1,
+      apiUsageAvailable: false,
+      estimatedPrompt: 9,
+      estimatedCompletion: 3,
+      estimatedTotal: 12,
+      apiPrompt: 0,
+      apiCompletion: 0,
+      apiTotal: 0,
+    },
+    latency_ms: 30,
+    cost_usd: 0.001,
+    errors: [],
+    tool_executions: [
+      {
+        name: 'bash',
+        duration_ms: 11,
+        is_error: false,
+        blocked: false,
+      },
+    ],
+  });
+  expect(JSON.stringify(events[0])).not.toContain('echo hello');
+  expect(JSON.stringify(events[0])).not.toContain('secret-token');
+  expect(JSON.stringify(events[0])).not.toContain('test-key');
+  expect(
+    (events[0] as { input: { content: string } }).input.content.length,
+  ).toBeLessThanOrEqual(4099);
+  expect(events[1]).toMatchObject({
+    type: 'skill_run',
+    session_id: 'session-event-2',
+    input: null,
+    output: null,
+    tokens: expect.objectContaining({ modelCalls: 0 }),
+    cost_usd: 0,
+  });
+});
+
+test('skill_run subscriber failures do not block observation persistence', async () => {
+  context = await createAdaptiveSkillsTestContext();
+  const { subscribeSkillRunEvents } = await import(
+    '../src/skills/skill-run-events.ts'
+  );
+  const { recordSkillExecution } = await import(
+    '../src/skills/skills-observation.ts'
+  );
+
+  const unsubscribe = subscribeSkillRunEvents(() => {
+    throw new Error('subscriber failed');
+  });
+  try {
+    const observation = recordSkillExecution({
+      skillName: context.skillName,
+      sessionId: 'session-subscriber-failure',
+      runId: 'run-subscriber-failure',
+      toolExecutions: [],
+      outcome: 'success',
+      durationMs: 20,
+    });
+
+    expect(observation).toMatchObject({
+      skill_name: context.skillName,
+      session_id: 'session-subscriber-failure',
+      run_id: 'run-subscriber-failure',
+      outcome: 'success',
+    });
+  } finally {
+    unsubscribe();
+  }
+});
+
 test('classifies timeout and environment-change failures', async () => {
   context = await createAdaptiveSkillsTestContext();
   const { classifyErrorCategory } = await import(


### PR DESCRIPTION
## Summary

Closes #415.

Adds a typed `skill_run` event bus for skill executions and routes the existing adaptive skill observation write through the default subscriber. Gateway skill observations now emit a single bounded/redacted envelope containing input, output, model, token usage, latency, cost, errors, `coworker_id`, and `skill_id` while preserving existing DB/audit behavior.

## #415 Acceptance Criteria

- Single `skill_run` event envelope includes input, output, model, tokens, latency, cost, errors, `coworker_id`, and `skill_id`.
- Pluggable subscribers are exposed through `subscribeSkillRunEvents`.
- Existing post-hoc `SkillObservation` DB/audit write is registered as a subscriber.
- Integration coverage verifies subscribers receive skill-run events and existing observation persistence still works.

## Safety Notes

- Input/output payloads are redacted and capped.
- Tool executions are metadata-only; raw arguments and results are not emitted.
- Subscriber failures are logged and isolated so one subscriber does not block later subscribers.

## Validation

- `./node_modules/.bin/vitest run tests/skills-observation.test.ts tests/gateway-service.skill-observation.test.ts tests/adaptive-skills-integration.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run check`