### PR TITLE
docs: manifesto v3 + roadmap refresh (skills #21, F6-F10, reframes)

### DIFF
--- a/docs/content/internal/roadmap.md
+++ b/docs/content/internal/roadmap.md
@@ -7,30 +7,33 @@ description: Internal product roadmap derived from the Trusted Coworker Manifest
 
 # Trusted Coworker Roadmap
 
-20 features grouped into three priority tiers. **P0** = Very High Priority (launch package). **P1** = High Priority (depth). **P2** = Priority (breadth). Sequencing within a tier is driven by technical dependencies.
+21 features grouped into three priority tiers. **P0** = Very High Priority (launch package). **P1** = High Priority (depth). **P2** = Priority (breadth). Sequencing within a tier is driven by technical dependencies.
+
+The roadmap is anchored in the [Trusted Coworker Manifesto](../manifesto.md). Numbers in *italic* below each feature link the work back to the principle it serves.
 
 | # | Feature | Description | Priority |
 |---|---------|-------------|----------|
-| 1 | **Agent-to-agent messaging** | First-class primitive for one coworker to message, hand off, or escalate to another. Persisted envelopes; intent typed; integrates with the hash-chain audit log. | P0 |
-| 2 | **Workflow engine — A→B→C with approval gates** | Declarative YAML workflows. Sequential runner, pause/resume on approval, return-for-revision rewinds. Built on top of #1. | P0 |
-| 3 | **Coworker scoreboard + auto-`CV.md`** | Per-skill score data model populated from the skill-run event bus. Auto-rendered CV per coworker; admin scoreboard; "best at X" recommendation API. | P0 |
-| 4 | **Business-secret masking + demasking** | Extends `confidential-redact.ts` with NDA / client / price / contract classes. Round-trip placeholder scheme; post-LLM rehydrator; mask/demask events on the audit log. | P0 |
-| 5 | **Token / money budgets per coworker** | Per-coworker monthly € cap backed by existing `UsageTotals`. Soft-warn at threshold, hard-stop via the policy engine, per-skill sub-limits. | P0 |
-| 6 | **NDA / secret-leak classifier** | Classifier on every prompt and response, fed by the skill-run event bus. Block / warn / log via policy engine; eval suite extends the existing harness. | P0 |
-| 7 | **Shared enterprise memory** | RAG over team docs / CRM / wiki, available in self-hosted HC. Pluggable vector store, per-coworker source scoping, retrieval-quality eval suite. | P1 |
-| 8 | **Brand-voice + output classifier** | Per-tenant voice profile (do / don't, tone, banned phrases). Pre-ship classifier on responses; block / rewrite via policy engine. | P1 |
-| 9 | **Hierarchical swarm — HC1 delegates to HC2** | Cross-instance delegation. Signed delegation tokens, transport over HTTP, audit-log linking across instances. | P1 |
-| 10 | **Auto fine-tuning on real tasks** | Trajectory capture → PII scrub → per-customer training data → fine-tuning pipeline → tuned-model registry with eval gate before promotion. | P1 |
-| 11 | **Coworker working hours + escalation** | Schedule on `AgentConfig` (timezone, weekly hours). Out-of-hours dispatcher decides queue / page / escalate per configured rules. | P1 |
-| 12 | **Mobile-first admin (iOS / Android wrapper)** | Responsive admin pages, mobile-friendly approval flow, push notifications, native wrappers via Capacitor or React Native. | P1 |
-| 13 | **Per-client cost & audit reports** | Client tagging on activity, per-client cost rollup extending #5, per-client audit-log filter, branded PDF export. | P1 |
-| 14 | **SSO + RBAC** | OAuth2 / OIDC framework with Okta, Google Workspace, Microsoft Entra providers. Role + permission model; per-coworker access policies for human users. | P1 |
-| 15 | **Coworker handoff with context transfer** | Extends the `handoff` intent from #1 to carry a context bundle (thread refs, brief, client tags). Recipient absorbs context before resuming. | P2 |
-| 16 | **Skill A/B testing + canary deployments** | Variant routing by deterministic hash, per-variant metrics from the event bus, statistical comparison, promotion gate via the eval harness. | P2 |
-| 17 | **Coworker references / portfolio export** | Anonymized portfolio bundle (work samples + scores). Export and import flows so a coworker template can be instantiated on a fresh instance. | P2 |
-| 18 | **Voice / outbound phone channel** | Twilio Programmable Voice for outbound dial. Existing TTS plus STT for callee responses; call-flow primitive; transcript on the audit log. | P2 |
-| 19 | **Calendar / meeting presence** | Bot joins Zoom / Meet, real-time STT, live notes, post-meeting summary, action-item dispatch via #1 to other coworkers. | P2 |
-| 20 | **Right-to-be-forgotten / GDPR data export** | Identifier registry, cascading data discovery, audited deletion, machine + human readable export. Hash-chain entry of the deletion preserved. | P2 |
+| 21 | **Business-skill pipeline + first 5 production skills** | Opinionated, ready-on-day-one skills (Salesforce, HubSpot, SAP, GA4, NL→SQL on warehouse) on top of a shared packaging + lifecycle framework. *Principle I — the skills are the product.* | P0 |
+| 1 | **Agent-to-agent messaging** | First-class primitive for one coworker to message, hand off, or escalate to another. Persisted envelopes; intent typed; integrates with the hash-chain audit log. *Principle VI.* | P0 |
+| 2 | **Workflow engine — autonomous-by-default with high-stakes escalation** | Declarative YAML workflows. Sequential runner; escalation gates only on high-stakes steps (driven by F8 stakes classifier — **not** approval-by-default). Return-for-revision rewinds. Built on top of #1. *Principles II + VI.* | P0 |
+| 3 | **Coworker scoreboard + auto-`CV.md`** | Per-skill score data model populated from the skill-run event bus. Auto-rendered CV per coworker; admin scoreboard; "best at X" recommendation API. *Principle IV.* | P0 |
+| 4 | **Business-secret masking + demasking** | Extends `confidential-redact.ts` with NDA / client / price / contract classes. Round-trip placeholder scheme; post-LLM rehydrator; mask/demask events on the audit log. *Principle VII.* | P0 |
+| 5 | **Token / money budgets per coworker** | Per-coworker monthly € cap backed by existing `UsageTotals`. Soft-warn at threshold, hard-stop via the policy engine, per-skill sub-limits. *Principle IX.* | P0 |
+| 6 | **NDA / secret-leak classifier** | Classifier on every prompt and response, fed by the skill-run event bus. Block / warn / log via policy engine; eval suite extends the existing harness. *Principle VII.* | P0 |
+| 7 | **Shared enterprise memory** | RAG over team docs / CRM / wiki, available in self-hosted HC. Pluggable vector store, per-coworker source scoping, retrieval-quality eval suite. *Principle I.* | P1 |
+| 8 | **Brand-voice + output classifier** | Per-tenant voice profile (do / don't, tone, banned phrases). Pre-ship classifier on responses; block / rewrite via policy engine. *Principle VII.* | P1 |
+| 9 | **Hierarchical swarm — HC1 delegates to HC2** | Cross-instance delegation. Signed delegation tokens, transport over HTTP, audit-log linking across instances. *Principle VI.* | P1 |
+| 10 | **Auto fine-tuning on real tasks** | Trajectory capture → PII scrub → per-customer training data → fine-tuning pipeline → tuned-model registry with eval gate before promotion. *Principle VIII.* | P1 |
+| 11 | **Operator notification windows + escalation routing** | *Reframed under v3 Principle III.* The coworker is always on; this issue covers per-operator notification preferences (when to page vs. queue for the morning summary) and escalation routing through F8. | P2 |
+| 12 | **Mobile-first admin (iOS / Android wrapper)** | Responsive admin pages, mobile-friendly approval flow, push notifications, native wrappers via Capacitor or React Native. *Principle X.* | P1 |
+| 13 | **Per-client cost & audit reports** | Client tagging on activity, per-client cost rollup extending #5, per-client audit-log filter, branded PDF export. *Principle VII.* | P1 |
+| 14 | **SSO + RBAC** | OAuth2 / OIDC framework with Okta, Google Workspace, Microsoft Entra providers. Role + permission model; per-coworker access policies for human users. *Principle VII.* | P1 |
+| 15 | **Coworker handoff with context transfer** | Extends the `handoff` intent from #1 to carry a context bundle (thread refs, brief, client tags). Recipient absorbs context before resuming. *Principle VI.* | P2 |
+| 16 | **Skill A/B testing + canary deployments** | Variant routing by deterministic hash, per-variant metrics from the event bus, statistical comparison, promotion gate via the eval harness. *Principle VIII.* | P2 |
+| 17 | **Coworker references / portfolio export** | Anonymized portfolio bundle (work samples + scores). Export and import flows so a coworker template can be instantiated on a fresh instance. *Principle IV.* | P2 |
+| 18 | **Voice / outbound phone channel** | Twilio Programmable Voice for outbound dial. Existing TTS plus STT for callee responses; call-flow primitive; transcript on the audit log. *Principle V.* | P2 |
+| 19 | **Calendar / meeting presence** | Bot joins Zoom / Meet, real-time STT, live notes, post-meeting summary, action-item dispatch via #1 to other coworkers. *Principle V.* | P2 |
+| 20 | **Right-to-be-forgotten / GDPR data export** | Identifier registry, cascading data discovery, audited deletion, machine + human readable export. Hash-chain entry of the deletion preserved. *Principle VII.* | P2 |
 
 ---
 
@@ -38,11 +41,16 @@ description: Internal product roadmap derived from the Trusted Coworker Manifest
 
 Cross-cutting work that several roadmap items depend on. Decomposed under the `foundation` label rather than belonging to any single feature.
 
-- **F1** — Extend `AgentConfig` with `owner` / `role` / `cv` fields and persistence. Required by #1, #3, #5, #11.
-- **F2** — Unified skill-run event bus (streaming, not post-hoc). Required by #3, #5, #6, #10, #16.
-- **F3** — Generalize the network-only policy engine into a "predicate → action" engine. Used by #4, #5, #6, #8, #11, #14.
+- **F1** — Extend `AgentConfig` with `owner` / `role` / `cv` fields and persistence. `owner` is a typed reference to a canonical user (see F7). Required by #1, #3, #5, #11, #21.
+- **F2** — Unified skill-run event bus (streaming, not post-hoc). Required by #3, #5, #6, #10, #16, F8.
+- **F3** — Generalize the network-only policy engine into a "predicate → action" engine. Used by #4, #5, #6, #8, #14, F8.
 - **F4** — Versioning + rollback for skills, knowledge, CVs, and classifier weights. Extends `runtime-config-revisions`. Required by Principle VII.
 - **F5** — Model pricing & capability matrix on top of `model-catalog`. Required by #5 cost compute and future routing.
+- **F6** — Deployment-mode + public-URL abstraction. Cloud installs declare an external URL; local installs run a tunnel (ngrok / Cloudflare / Tailscale). Required by #9, #18, #19, and the launch smoke scenario A1 in local mode.
+- **F7** — Global identity primitives. Canonical user IDs (`username@authority`, default authority `hybridai`) and canonical agent IDs (`agent-slug@user@instance-id`), plus a resolver and TOFU trust model. Required by #1 envelope addressing, #9 cross-instance delegation, #14 SSO federation, #15 handoff, #17 portfolio refs.
+- **F8** — Autonomy + escalation policy framework. Per-coworker / per-skill autonomy levels, stakes classifier, escalation routing, default-action runtime that inverts approval-by-default. **Required by Principle II** and reframes the default behaviour of #2.
+- **F9** — Always-on runtime guarantees. Warm process pool, per-coworker liveness probe, auto-restart with backoff, fleet red/green dashboard. **Required by Principle III** ("doesn't clock out") — without it the principle is aspirational.
+- **F10** — Coworker org-chart / team primitive. Roles, reporting lines, escalation chains as first-class data — not derived from message graphs. Required by F8 escalation routing and #15 handoff context.
 
 ## Cross-cutting additions
 
@@ -58,23 +66,27 @@ Engineering hygiene that ships alongside P0:
 
 ## How to read this
 
-**P0 (#1–6)** is the launch package. Read it as the smallest set of features that makes the manifesto demonstrable end-to-end:
+**P0 (#21 + #1–6)** is the launch package. Read it as the smallest set of features that makes the manifesto demonstrable end-to-end:
 
-- #1 + #2 implement Principle IV (coworkers in teams).
-- #3 implements Principle I (person, not prompt).
-- #4 + #6 implement Principle V (NDA from minute one).
-- #5 implements Principle IX (thinks before spending).
+- **#21** implements Principle I — *the skills are the product*. Without shippable skills, everything else is a runtime, not a coworker.
+- F8 + #2 implement Principle II — autonomy by default, escalate on stakes.
+- F9 implements Principle III — always on, no warm-up.
+- #3 + F10 implement Principle IV — colleague with a CV; org chart not flat list.
+- #1 + #2 + F10 implement Principle VI — coworkers in teams.
+- #4 + #6 + F4 implement Principle VII — trust + audit + reversibility.
+- #5 implements Principle IX — thinks before spending.
 - F1 + F2 + F3 are prerequisites for the above.
 
-**P1 (#7–14)** is depth work. Each item compounds with one or more P0 features:
+**P1 (#7–10, #12–14)** is depth work. Each item compounds with one or more P0 features:
 
 - Shared memory (#7) and auto fine-tuning (#10) close the data flywheel — both feed back into the skill scoreboard (#3) and the leak classifier (#6).
-- Hierarchical swarm (#9) extends the A2A primitive (#1) across host instances.
-- Working hours (#11), per-client reports (#13), and SSO/RBAC (#14) are operational table stakes once a fleet is in use.
-- Mobile admin (#12) is the surface for Principle III on a phone.
+- Hierarchical swarm (#9) extends the A2A primitive (#1) across host instances; depends on F6 + F7.
+- Per-client reports (#13) and SSO/RBAC (#14) are operational table stakes once a fleet is in use.
+- Mobile admin (#12) is the surface for Principle X on a phone.
 
-**P2 (#15–20)** is breadth. Each item is independently shippable but most depend on at least one P1 item:
+**P2 (#11, #15–20)** is breadth. Each item is independently shippable but most depend on at least one P1 item:
 
+- Operator notification windows (#11) was reframed away from "agent goes offline" semantics; demoted from P1 → P2.
 - Handoff context transfer (#15) makes #1 + #2 feel finished.
 - A/B testing (#16) compounds with #10.
 - Voice (#18) and calendar (#19) are channel expansions on top of the existing channel layer.
@@ -82,8 +94,10 @@ Engineering hygiene that ships alongside P0:
 
 ## Sequencing rules
 
-- **Foundations first.** F1, F2, F3 unblock the majority of P0 children. F4 and F5 unblock specific items but are not on the critical path for the launch demo (A1).
+- **Foundations first.** F1, F2, F3 unblock the majority of P0 children. F4 and F5 unblock specific items. F6 and F7 are critical-path the moment any cross-instance work or local-install demo is involved. F8, F9, F10 are needed as soon as the launch demo (A1) tries to honour Principles II / III / VI.
+- **Skills early.** #21.1 (skill packaging framework) should land before any of #21.2-#21.6 (the five production skills). Without the framework each skill reinvents lifecycle + permissioning.
 - **A2A before workflow.** #1 must ship at least to 1.2 (send/receive runtime API) before #2.2 (sequential runner) becomes useful.
+- **F8 alongside #2.** #2.3 (gating semantics) should not land before F8.4 (default-action runtime) — otherwise #2 hard-codes approval-by-default and has to be refactored.
 - **Trajectory capture starts early.** 10.1 (trajectory collection) should land alongside F2, well before the rest of #10 — the data is the asset.
 - **Leak classifier needs a dataset.** 6.1 (classifier dataset) gates 6.2 / 6.3; budget for labeling time.
 - **Avoid net-new channels until P0 ships.** New channel work (#18, #19) is deferred to P2 even where infrastructure exists.
@@ -91,5 +105,6 @@ Engineering hygiene that ships alongside P0:
 ## Out of scope
 
 - Net-new chat channels beyond what already ships in `src/channels/`.
-- Generic "more skills" — skills ship through the opinionated business-skill pipeline (Salesforce, HubSpot, SAP, GA4, NL→SQL), not as a feature-count metric.
-- Anything that requires the end user to open the desktop app (Principle II).
+- Generic "more skills" beyond the production-grade five in #21 — additional skills are folded into the same pipeline, not added as feature-count items.
+- Anything that requires the end user to open the desktop app (Principle V).
+- Per-coworker "away" / clock-out semantics — explicitly anti-Principle III.

--- a/docs/content/manifesto.md
+++ b/docs/content/manifesto.md
@@ -4,56 +4,76 @@ description: The product principles HybridClaw is built around — what we will 
 sidebar_position: 2
 ---
 
-# The Trusted Coworker Manifesto
+# HybridClaw: The AI Coworker Who's Already On It
 
-*HybridClaw is not an AI assistant. It is the coworker your team trusts with keys, clients, and calendar.*
+*HybridClaw is not an AI assistant framework. It's an open-source agent harness for shipping coworkers that do the work. Reliably. Fast. At a level your team will trust with clients.*
 
-That belief steers every line of code we write — and every line we refuse to write.
+Every line of code in this project serves that belief.
 
 ---
 
-### I. A coworker is a person, not a prompt
-Our coworkers ship with a name, a face, a voice, and a `CV.md`. They have skill scores, a track record, references. You don't *configure* them — you onboard them, evaluate them, promote them, retire them.
-**We will never ship a generic chatbot panel.** If a user can't picture saying *"Lena, take care of this,"* we haven't done our job.
+### I. A coworker actually does the work
 
-### II. A coworker lives where work happens
-Email. Web chat. Slack. Teams. WhatsApp. The phone. Your CRM. We meet your team in the tools they already pay for — never the other way around.
+Opinionated, ready-on-day-one skills for the tools your work runs on. A CRM, a Shopify store, an ad platform, a video pipeline, a data warehouse. Your coworker closes the ticket before your team reads it.
 
-Apps are for the *operator*, not the user: one-click deployment, one place to manage the fleet. It's how you hire your coworker — not where you talk to them.
-**We will never make end users open our app to talk to their coworker.**
+**A runtime is not a coworker.** The skills are the product.
 
-### III. A coworker is hired, not installed
-Sixty seconds, from a browser, from anywhere. The central admin is remote-first: fleet dashboard, kanban board, channel wiring, evals — reachable from a phone on the train.
-**We will not ship features that require a terminal to operate.**
+### II. A coworker acts first, asks later
 
-### IV. Coworkers work in teams
-Real work is collaborative. Coworkers delegate, hand off, escalate, ask for help. Agent-to-agent communication is a first-class primitive, not a hack on top.
-**We will not optimize for the lone-agent scenario at the cost of the team scenario.**
+The default is action, not a menu. Your coworker reads the brief, picks the best path, executes, and reports back. It escalates when stakes are high. Not when the answer is obvious.
 
-### V. A trusted coworker never holds your keys
-Credentials are encrypted at rest. The model only ever sees a placeholder; the host injects real tokens at request time, then forgets them. PII and business secrets are masked on the way in and validated on the way out — your coworker is under NDA from minute one.
-**We will never ship a feature that requires the model to see a real secret.** Convenience is not a justification.
+**A coworker that turns simple tasks into conversations is not a coworker.** It's a form.
 
-### VI. A trusted coworker shows their work
-Every action is appended to a hash-chain audit log. *"What did Lena do this week?"* gets an answer your auditor, your client, and your accountant will accept.
-**We will not add features that bypass the audit log to look faster.**
+### III. A coworker doesn't clock out
 
-### VII. A trusted coworker is undoable
-Configs, agent files, skills, knowledge — all versioned. Rollback is one click. The cost of a bad change is a click, not a week.
-**We will not ship state-mutating features without a rollback path.**
+3 AM on a Sunday. August. The holiday your team booked six months ago. Your coworker is still there. Same level. Same attention to detail. No sick days, no ramp-up, no two-week notice.
 
-### VIII. A trusted coworker doesn't break overnight
-When a new model ships, we re-run your tuned skills and knowledge against your real workflows. Regressions land in our dashboard, not your client's inbox.
-**We will not let provider churn become customer churn.**
+**A coworker should never need to be "woken up" or warmed up.**
+
+### IV. A coworker is a colleague, not a chatbot
+
+A HybridClaw coworker ships with a name, a face, a voice, and a CV. Skill scores, a track record, references. You don't *configure* it. You onboard it, evaluate it, promote it, retire it. It fills a seat on your org chart, not a panel on your screen.
+
+**If a user can't picture saying *"Lena, handle this,"* the job isn't done.**
+
+### V. A coworker lives where work happens
+
+Email. Slack. Teams. WhatsApp. The phone. Your CRM. The coworker meets your team in the tools they already use. Never the other way around.
+
+The app is for the *operator*, not the end user. One-click deployment. One place to manage the fleet.
+
+**End users should never have to open an app to talk to their coworker.**
+
+### VI. Coworkers work in teams
+
+Real work is collaborative. A coworker delegates to specialists, escalates to leads, reports to managers. Think org charts, not pipelines. Structured teams with roles, hierarchies, and handoffs. Agent-to-agent communication is a first-class primitive, not a hack on top.
+
+**The lone-agent scenario is not the design target.** The team scenario is.
+
+### VII. A coworker you can trust with real responsibility
+
+Credentials are encrypted at rest. The model never sees a real secret. Every action lands in a hash-chain audit log your auditor will accept. Configs, skills, and knowledge are versioned. Rollback is one click. Your coworker is under NDA from minute one.
+
+**Auditability and reversibility are never traded for speed.** Trust is what turns a demo into a deployment.
+
+### VIII. A coworker doesn't break overnight
+
+When a new model ships, your coworker re-runs its tuned skills and knowledge against your real workflows. Regressions surface in the dashboard, not your client's inbox.
+
+**Provider churn does not become customer churn.**
 
 ### IX. A coworker thinks before they spend
-Concierge routing picks the model by urgency and complexity — not by default. Sensitive work stays local. Premium reasoning happens only when the work is worth it.
-**We will not bill our customers for thinking harder than the task required.**
 
-### X. A coworker actually does the work
-Opinionated, ready-on-day-one skills for the systems your business runs on: Salesforce, HubSpot, SAP, GA4, plus natural-language SQL on your warehouse. Not a "build your own" toolkit.
-**We will not ship a runtime and call it a coworker.** The skills are the product.
+Concierge routing picks the model by urgency and complexity. Not by default. Premium reasoning happens only when the work is worth it. The result: output that rivals your best people, at a fraction of the cost.
+
+**No one gets billed for thinking harder than the task required.**
+
+### X. A coworker is hired in sixty seconds
+
+From a browser, from anywhere. Fleet dashboard, kanban board, channel wiring, evals. All reachable from a phone on the train.
+
+**No feature should require a terminal to operate.**
 
 ---
 
-*All of the Claw. None of the chaos.*
+*All of the Claw. None of the overhead.*


### PR DESCRIPTION
## Summary

Updates the docs to manifesto v3 and refreshes the internal roadmap to match. The manifesto's two new principles (II "acts first, asks later" and III "doesn't clock out") plus the promotion of Principle I ("skills are the product") create real gaps in the existing roadmap; this PR fills them.

## What changed in the docs

- [docs/content/manifesto.md](docs/content/manifesto.md): replaced v1 body with v3 (10 principles, reordered + 2 new). Frontmatter preserved.
- [docs/content/internal/roadmap.md](docs/content/internal/roadmap.md): adds Roadmap 21 (Skills pipeline), 5 new foundations (F6 deployment, F7 identity, F8 autonomy, F9 always-on, F10 org-chart), per-row principle annotations, and reframes #11 (working hours → operator notification windows, P1 → P2). Reorients #2 from approval-by-default to autonomous-by-default with high-stakes escalation.

## What changed on the issue tracker (separate from this PR)

- 23 new issues filed: 4 new parents (#598 Skills, #599 F8, #600 F9, #601 F10) plus 19 children (#579–#597).
- Reframe comment posted on [#554 (#11 working hours)](https://github.com/HybridAIOne/hybridclaw/issues/554) — proposes rename + demote P1 → P2.
- Reorientation comment posted on [#461 (#2 workflow)](https://github.com/HybridAIOne/hybridclaw/issues/461) — proposes default-action via F8.
- Umbrella [#466](https://github.com/HybridAIOne/hybridclaw/issues/466) updated with the new structure (skills, F6-F10, principle-coverage map, totals).

## Manifesto v3 → roadmap mapping

| Principle | Roadmap items |
|---|---|
| I — Actually does the work (skills) | #598 (Skills pipeline) · #550 (Shared memory) |
| II — Acts first, asks later | #599 (F8 Autonomy) · #461 (Workflow reoriented) |
| III — Doesn't clock out | #600 (F9 Always-on) · #554 (reframed) |
| IV — Colleague, not chatbot | #462 (Scoreboard + CV) · #560 (Portfolio export) |
| V — Lives where work happens | existing channel layer · #561 #562 |
| VI — Coworkers in teams (org charts) | #460 #461 · #601 (F10) · #552 #558 |
| VII — Trust with real responsibility | #463 #465 #417 (F4) · #551 #556 #557 #563 |
| VIII — Doesn't break overnight | #553 #559 |
| IX — Thinks before spending | #464 |
| X — Hired in 60 seconds | #555 |

## Test plan

- [ ] Confirm updated manifesto renders correctly under Overview in the docs UI
- [ ] Confirm `docs/content/internal/roadmap.md` is still excluded from sidebar/search and only reachable by direct URL
- [ ] Confirm umbrella [#466](https://github.com/HybridAIOne/hybridclaw/issues/466) shows the new principle-coverage table and totals

🤖 Generated with [Claude Code](https://claude.com/claude-code)