### PR TITLE
[codex] Add asset revision rollback

### DIFF
--- a/src/config/runtime-config-revisions.ts
+++ b/src/config/runtime-config-revisions.ts
@@ -12,7 +12,18 @@ const CONFIG_REVISION_DB_PATH = path.join(
   'config-revisions.db',
 );
 
-const REVISION_SCHEMA_VERSION = 1;
+const REVISION_SCHEMA_VERSION = 2;
+
+export const RUNTIME_REVISION_ASSET_TYPES = [
+  'config',
+  'skill',
+  'knowledge',
+  'cv',
+  'classifier',
+] as const;
+
+export type RuntimeRevisionAssetType =
+  (typeof RUNTIME_REVISION_ASSET_TYPES)[number];
 
 export interface RuntimeConfigChangeMeta {
   actor?: string | null;
@@ -22,6 +33,7 @@ export interface RuntimeConfigChangeMeta {
 
 export interface RuntimeConfigRevisionSummary {
   id: number;
+  assetType: RuntimeRevisionAssetType;
   actor: string;
   route: string;
   source: string;
@@ -58,6 +70,7 @@ export interface RuntimeConfigObservedFile {
 
 interface ConfigRevisionRow {
   id: number;
+  asset_type: string;
   actor: string;
   route: string;
   source: string;
@@ -70,6 +83,7 @@ interface ConfigRevisionRow {
 
 interface ConfigRevisionSummaryRow {
   id: number;
+  asset_type: string;
   actor: string;
   route: string;
   source: string;
@@ -169,6 +183,67 @@ function computeMd5(content: string): string {
   return createHash('md5').update(content).digest('hex');
 }
 
+function isRuntimeRevisionAssetType(
+  value: string,
+): value is RuntimeRevisionAssetType {
+  return RUNTIME_REVISION_ASSET_TYPES.includes(
+    value as RuntimeRevisionAssetType,
+  );
+}
+
+function normalizeRevisionAssetType(
+  assetType: string,
+): RuntimeRevisionAssetType {
+  if (isRuntimeRevisionAssetType(assetType)) return assetType;
+  throw new Error(`Unsupported revision asset type: ${assetType}`);
+}
+
+function migrateRevisionDatabase(database: Database.Database): void {
+  const currentVersion = Number(
+    database.pragma('user_version', { simple: true }) || 0,
+  );
+  if (currentVersion >= REVISION_SCHEMA_VERSION) return;
+
+  const revisionColumns = database
+    .prepare(`PRAGMA table_info(config_revisions)`)
+    .all() as Array<{ name: string }>;
+  if (!revisionColumns.some((column) => column.name === 'asset_type')) {
+    database.exec(`
+      ALTER TABLE config_revisions
+        ADD COLUMN asset_type TEXT NOT NULL DEFAULT 'config';
+    `);
+  }
+
+  const stateColumns = database
+    .prepare(`PRAGMA table_info(config_revision_state)`)
+    .all() as Array<{ name: string }>;
+  if (!stateColumns.some((column) => column.name === 'asset_type')) {
+    database.exec(`
+      ALTER TABLE config_revision_state RENAME TO config_revision_state_v1;
+      CREATE TABLE config_revision_state (
+        asset_type TEXT NOT NULL DEFAULT 'config',
+        config_path TEXT NOT NULL,
+        current_md5 TEXT NOT NULL,
+        current_content TEXT NOT NULL,
+        actor TEXT NOT NULL,
+        route TEXT NOT NULL,
+        source TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (asset_type, config_path)
+      );
+      INSERT INTO config_revision_state (
+        asset_type, config_path, current_md5, current_content, actor, route, source, updated_at
+      )
+      SELECT
+        'config', config_path, current_md5, current_content, actor, route, source, updated_at
+      FROM config_revision_state_v1;
+      DROP TABLE config_revision_state_v1;
+    `);
+  }
+
+  database.pragma(`user_version = ${REVISION_SCHEMA_VERSION}`);
+}
+
 function withRevisionDatabase<T>(fn: (database: Database.Database) => T): T {
   fs.mkdirSync(path.dirname(CONFIG_REVISION_DB_PATH), { recursive: true });
   const database = new Database(CONFIG_REVISION_DB_PATH);
@@ -178,6 +253,7 @@ function withRevisionDatabase<T>(fn: (database: Database.Database) => T): T {
     database.exec(`
       CREATE TABLE IF NOT EXISTS config_revisions (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
+        asset_type TEXT NOT NULL DEFAULT 'config',
         config_path TEXT NOT NULL,
         actor TEXT NOT NULL,
         route TEXT NOT NULL,
@@ -188,24 +264,25 @@ function withRevisionDatabase<T>(fn: (database: Database.Database) => T): T {
         replaced_by_md5 TEXT,
         created_at TEXT NOT NULL
       );
-      CREATE INDEX IF NOT EXISTS idx_config_revisions_path_id
-        ON config_revisions(config_path, id DESC);
       CREATE TABLE IF NOT EXISTS config_revision_state (
-        config_path TEXT PRIMARY KEY,
+        asset_type TEXT NOT NULL DEFAULT 'config',
+        config_path TEXT NOT NULL,
         current_md5 TEXT NOT NULL,
         current_content TEXT NOT NULL,
         actor TEXT NOT NULL,
         route TEXT NOT NULL,
         source TEXT NOT NULL,
-        updated_at TEXT NOT NULL
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (asset_type, config_path)
       );
     `);
-    const currentVersion = Number(
-      database.pragma('user_version', { simple: true }) || 0,
-    );
-    if (currentVersion < REVISION_SCHEMA_VERSION) {
-      database.pragma(`user_version = ${REVISION_SCHEMA_VERSION}`);
-    }
+    migrateRevisionDatabase(database);
+    database.exec(`
+      CREATE INDEX IF NOT EXISTS idx_config_revisions_asset_path_id
+        ON config_revisions(asset_type, config_path, id DESC);
+      CREATE INDEX IF NOT EXISTS idx_config_revisions_path_id
+        ON config_revisions(config_path, id DESC);
+    `);
     return fn(database);
   } finally {
     database.close();
@@ -215,6 +292,7 @@ function withRevisionDatabase<T>(fn: (database: Database.Database) => T): T {
 function mapRevisionRow(row: ConfigRevisionRow): RuntimeConfigRevision {
   return {
     id: row.id,
+    assetType: normalizeRevisionAssetType(row.asset_type || 'config'),
     actor: row.actor,
     route: row.route,
     source: row.source,
@@ -231,6 +309,7 @@ function mapRevisionSummaryRow(
 ): RuntimeConfigRevisionSummary {
   return {
     id: row.id,
+    assetType: normalizeRevisionAssetType(row.asset_type || 'config'),
     actor: row.actor,
     route: row.route,
     source: row.source,
@@ -273,6 +352,21 @@ export function syncRuntimeConfigRevisionState(
   meta?: RuntimeConfigChangeMeta,
   observedFile?: RuntimeConfigObservedFile,
 ): { changed: boolean; previousMd5: string | null; currentMd5: string | null } {
+  return syncRuntimeAssetRevisionState(
+    'config',
+    configPath,
+    meta,
+    observedFile,
+  );
+}
+
+export function syncRuntimeAssetRevisionState(
+  assetType: RuntimeRevisionAssetType,
+  assetPath: string,
+  meta?: RuntimeConfigChangeMeta,
+  observedFile?: RuntimeConfigObservedFile,
+): { changed: boolean; previousMd5: string | null; currentMd5: string | null } {
+  const normalizedAssetType = normalizeRevisionAssetType(assetType);
   const normalizedMeta = normalizeChangeMeta(meta);
   const timestamp = new Date().toISOString();
 
@@ -280,14 +374,14 @@ export function syncRuntimeConfigRevisionState(
     return database
       .transaction(() => {
         const state = database
-          .prepare<[string], ConfigRevisionTrackedStateRow>(
+          .prepare<[string, string], ConfigRevisionTrackedStateRow>(
             `SELECT current_md5, current_content
              FROM config_revision_state
-             WHERE config_path = ?`,
+             WHERE asset_type = ? AND config_path = ?`,
           )
-          .get(configPath);
+          .get(normalizedAssetType, assetPath);
 
-        const fileExists = observedFile?.exists ?? fs.existsSync(configPath);
+        const fileExists = observedFile?.exists ?? fs.existsSync(assetPath);
         if (!fileExists) {
           if (!state) {
             return {
@@ -300,11 +394,12 @@ export function syncRuntimeConfigRevisionState(
           database
             .prepare(
               `INSERT INTO config_revisions (
-                 config_path, actor, route, source, md5, byte_length, content, replaced_by_md5, created_at
-               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+                 asset_type, config_path, actor, route, source, md5, byte_length, content, replaced_by_md5, created_at
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
             )
             .run(
-              configPath,
+              normalizedAssetType,
+              assetPath,
               normalizedMeta.actor,
               normalizedMeta.route,
               normalizedMeta.source,
@@ -315,8 +410,10 @@ export function syncRuntimeConfigRevisionState(
               timestamp,
             );
           database
-            .prepare(`DELETE FROM config_revision_state WHERE config_path = ?`)
-            .run(configPath);
+            .prepare(
+              `DELETE FROM config_revision_state WHERE asset_type = ? AND config_path = ?`,
+            )
+            .run(normalizedAssetType, assetPath);
           return {
             changed: true,
             previousMd5: state.current_md5,
@@ -325,17 +422,18 @@ export function syncRuntimeConfigRevisionState(
         }
 
         const content =
-          observedFile?.content ?? fs.readFileSync(configPath, 'utf-8');
+          observedFile?.content ?? fs.readFileSync(assetPath, 'utf-8');
         const md5 = observedFile?.md5 ?? computeMd5(content);
         if (!state) {
           database
             .prepare(
               `INSERT INTO config_revision_state (
-                 config_path, current_md5, current_content, actor, route, source, updated_at
-               ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+                 asset_type, config_path, current_md5, current_content, actor, route, source, updated_at
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
             )
             .run(
-              configPath,
+              normalizedAssetType,
+              assetPath,
               md5,
               content,
               normalizedMeta.actor,
@@ -361,11 +459,12 @@ export function syncRuntimeConfigRevisionState(
         database
           .prepare(
             `INSERT INTO config_revisions (
-               config_path, actor, route, source, md5, byte_length, content, replaced_by_md5, created_at
-             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+               asset_type, config_path, actor, route, source, md5, byte_length, content, replaced_by_md5, created_at
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
           )
           .run(
-            configPath,
+            normalizedAssetType,
+            assetPath,
             normalizedMeta.actor,
             normalizedMeta.route,
             normalizedMeta.source,
@@ -379,7 +478,7 @@ export function syncRuntimeConfigRevisionState(
           .prepare(
             `UPDATE config_revision_state
              SET current_md5 = ?, current_content = ?, actor = ?, route = ?, source = ?, updated_at = ?
-             WHERE config_path = ?`,
+             WHERE asset_type = ? AND config_path = ?`,
           )
           .run(
             md5,
@@ -388,7 +487,8 @@ export function syncRuntimeConfigRevisionState(
             normalizedMeta.route,
             normalizedMeta.source,
             timestamp,
-            configPath,
+            normalizedAssetType,
+            assetPath,
           );
         return {
           changed: true,
@@ -403,15 +503,23 @@ export function syncRuntimeConfigRevisionState(
 export function listRuntimeConfigRevisions(
   configPath: string,
 ): RuntimeConfigRevisionSummary[] {
+  return listRuntimeAssetRevisions('config', configPath);
+}
+
+export function listRuntimeAssetRevisions(
+  assetType: RuntimeRevisionAssetType,
+  assetPath: string,
+): RuntimeConfigRevisionSummary[] {
+  const normalizedAssetType = normalizeRevisionAssetType(assetType);
   return withRevisionDatabase((database) =>
     database
-      .prepare<[string], ConfigRevisionSummaryRow>(
-        `SELECT id, actor, route, source, md5, byte_length, created_at, replaced_by_md5
+      .prepare<[string, string], ConfigRevisionSummaryRow>(
+        `SELECT id, asset_type, actor, route, source, md5, byte_length, created_at, replaced_by_md5
          FROM config_revisions
-         WHERE config_path = ?
+         WHERE asset_type = ? AND config_path = ?
          ORDER BY id DESC`,
       )
-      .all(configPath)
+      .all(normalizedAssetType, assetPath)
       .map((row) => mapRevisionSummaryRow(row)),
   );
 }
@@ -420,14 +528,23 @@ export function getRuntimeConfigRevision(
   configPath: string,
   revisionId: number,
 ): RuntimeConfigRevision | null {
+  return getRuntimeAssetRevision('config', configPath, revisionId);
+}
+
+export function getRuntimeAssetRevision(
+  assetType: RuntimeRevisionAssetType,
+  assetPath: string,
+  revisionId: number,
+): RuntimeConfigRevision | null {
+  const normalizedAssetType = normalizeRevisionAssetType(assetType);
   return withRevisionDatabase((database) => {
     const row = database
-      .prepare<[string, number], ConfigRevisionRow>(
-        `SELECT id, actor, route, source, md5, byte_length, content, created_at, replaced_by_md5
+      .prepare<[string, string, number], ConfigRevisionRow>(
+        `SELECT id, asset_type, actor, route, source, md5, byte_length, content, created_at, replaced_by_md5
          FROM config_revisions
-         WHERE config_path = ? AND id = ?`,
+         WHERE asset_type = ? AND config_path = ? AND id = ?`,
       )
-      .get(configPath, revisionId);
+      .get(normalizedAssetType, assetPath, revisionId);
     return row ? mapRevisionRow(row) : null;
   });
 }
@@ -435,14 +552,22 @@ export function getRuntimeConfigRevision(
 export function getRuntimeConfigRevisionState(
   configPath: string,
 ): RuntimeConfigRevisionState | null {
+  return getRuntimeAssetRevisionState('config', configPath);
+}
+
+export function getRuntimeAssetRevisionState(
+  assetType: RuntimeRevisionAssetType,
+  assetPath: string,
+): RuntimeConfigRevisionState | null {
+  const normalizedAssetType = normalizeRevisionAssetType(assetType);
   return withRevisionDatabase((database) => {
     const row = database
-      .prepare<[string], ConfigRevisionStateRow>(
+      .prepare<[string, string], ConfigRevisionStateRow>(
         `SELECT current_content, actor, route, source, updated_at
          FROM config_revision_state
-         WHERE config_path = ?`,
+         WHERE asset_type = ? AND config_path = ?`,
       )
-      .get(configPath);
+      .get(normalizedAssetType, assetPath);
     return row ? mapRevisionStateRow(row) : null;
   });
 }
@@ -450,14 +575,22 @@ export function getRuntimeConfigRevisionState(
 export function getRuntimeConfigRevisionStateMetadata(
   configPath: string,
 ): RuntimeConfigRevisionStateMetadata | null {
+  return getRuntimeAssetRevisionStateMetadata('config', configPath);
+}
+
+export function getRuntimeAssetRevisionStateMetadata(
+  assetType: RuntimeRevisionAssetType,
+  assetPath: string,
+): RuntimeConfigRevisionStateMetadata | null {
+  const normalizedAssetType = normalizeRevisionAssetType(assetType);
   return withRevisionDatabase((database) => {
     const row = database
-      .prepare<[string], ConfigRevisionStateMetadataRow>(
+      .prepare<[string, string], ConfigRevisionStateMetadataRow>(
         `SELECT actor, route, source, updated_at
          FROM config_revision_state
-         WHERE config_path = ?`,
+         WHERE asset_type = ? AND config_path = ?`,
       )
-      .get(configPath);
+      .get(normalizedAssetType, assetPath);
     return row ? mapRevisionStateMetadataRow(row) : null;
   });
 }
@@ -466,21 +599,69 @@ export function deleteRuntimeConfigRevision(
   configPath: string,
   revisionId: number,
 ): boolean {
+  return deleteRuntimeAssetRevision('config', configPath, revisionId);
+}
+
+export function deleteRuntimeAssetRevision(
+  assetType: RuntimeRevisionAssetType,
+  assetPath: string,
+  revisionId: number,
+): boolean {
+  const normalizedAssetType = normalizeRevisionAssetType(assetType);
   return withRevisionDatabase((database) => {
     const result = database
-      .prepare<[string, number]>(
-        `DELETE FROM config_revisions WHERE config_path = ? AND id = ?`,
+      .prepare<[string, string, number]>(
+        `DELETE FROM config_revisions
+         WHERE asset_type = ? AND config_path = ? AND id = ?`,
       )
-      .run(configPath, revisionId);
+      .run(normalizedAssetType, assetPath, revisionId);
     return result.changes > 0;
   });
 }
 
 export function clearRuntimeConfigRevisions(configPath: string): number {
+  return clearRuntimeAssetRevisions('config', configPath);
+}
+
+export function clearRuntimeAssetRevisions(
+  assetType: RuntimeRevisionAssetType,
+  assetPath: string,
+): number {
+  const normalizedAssetType = normalizeRevisionAssetType(assetType);
   return withRevisionDatabase((database) => {
     const result = database
-      .prepare<[string]>(`DELETE FROM config_revisions WHERE config_path = ?`)
-      .run(configPath);
+      .prepare<[string, string]>(
+        `DELETE FROM config_revisions
+         WHERE asset_type = ? AND config_path = ?`,
+      )
+      .run(normalizedAssetType, assetPath);
     return result.changes;
   });
+}
+
+export function restoreRuntimeAssetRevision(
+  assetType: RuntimeRevisionAssetType,
+  assetPath: string,
+  revisionId: number,
+  meta?: RuntimeConfigChangeMeta,
+): string {
+  const revision = getRuntimeAssetRevision(assetType, assetPath, revisionId);
+  if (!revision) {
+    throw new Error(
+      `${assetType} revision ${revisionId} was not found for ${assetPath}.`,
+    );
+  }
+
+  fs.mkdirSync(path.dirname(assetPath), { recursive: true });
+  const tmpPath = `${assetPath}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(tmpPath, revision.content, {
+    encoding: 'utf-8',
+    mode: 0o600,
+  });
+  fs.renameSync(tmpPath, assetPath);
+  syncRuntimeAssetRevisionState(assetType, assetPath, meta, {
+    exists: true,
+    content: revision.content,
+  });
+  return revision.content;
 }

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -68,11 +68,17 @@ import {
   normalizeTrimmedStringSet,
 } from '../utils/normalized-strings.js';
 import {
+  clearRuntimeAssetRevisions as clearTrackedRuntimeAssetRevisions,
   clearRuntimeConfigRevisions as clearTrackedRuntimeConfigRevisions,
+  deleteRuntimeAssetRevision as deleteTrackedRuntimeAssetRevision,
   deleteRuntimeConfigRevision as deleteTrackedRuntimeConfigRevision,
+  getRuntimeAssetRevision as getTrackedRuntimeAssetRevision,
+  getRuntimeAssetRevisionState as getTrackedRuntimeAssetRevisionState,
+  getRuntimeAssetRevisionStateMetadata as getTrackedRuntimeAssetRevisionStateMetadata,
   getRuntimeConfigRevision as getTrackedRuntimeConfigRevision,
   getRuntimeConfigRevisionState as getTrackedRuntimeConfigRevisionState,
   getRuntimeConfigRevisionStateMetadata as getTrackedRuntimeConfigRevisionStateMetadata,
+  listRuntimeAssetRevisions as listTrackedRuntimeAssetRevisions,
   listRuntimeConfigRevisions as listTrackedRuntimeConfigRevisions,
   type RuntimeConfigChangeMeta,
   type RuntimeConfigObservedFile,
@@ -80,8 +86,11 @@ import {
   type RuntimeConfigRevisionState,
   type RuntimeConfigRevisionStateMetadata,
   type RuntimeConfigRevisionSummary,
+  type RuntimeRevisionAssetType,
+  restoreRuntimeAssetRevision as restoreTrackedRuntimeAssetRevision,
   runtimeConfigRevisionStorePath,
   syncRuntimeConfigRevisionState,
+  syncRuntimeAssetRevisionState as syncTrackedRuntimeAssetRevisionState,
 } from './runtime-config-revisions.js';
 import { DEFAULT_RUNTIME_HOME_DIR } from './runtime-paths.js';
 
@@ -5838,6 +5847,7 @@ export type {
   RuntimeConfigRevisionState,
   RuntimeConfigRevisionStateMetadata,
   RuntimeConfigRevisionSummary,
+  RuntimeRevisionAssetType,
 };
 
 export function saveRuntimeConfig(
@@ -5962,26 +5972,84 @@ export function listRuntimeConfigRevisions(): RuntimeConfigRevisionSummary[] {
   return listTrackedRuntimeConfigRevisions(CONFIG_PATH);
 }
 
+export function listRuntimeAssetRevisions(
+  assetType: RuntimeRevisionAssetType,
+  assetPath: string,
+): RuntimeConfigRevisionSummary[] {
+  return listTrackedRuntimeAssetRevisions(assetType, assetPath);
+}
+
 export function getRuntimeConfigRevision(
   revisionId: number,
 ): RuntimeConfigRevision | null {
   return getTrackedRuntimeConfigRevision(CONFIG_PATH, revisionId);
 }
 
+export function getRuntimeAssetRevision(
+  assetType: RuntimeRevisionAssetType,
+  assetPath: string,
+  revisionId: number,
+): RuntimeConfigRevision | null {
+  return getTrackedRuntimeAssetRevision(assetType, assetPath, revisionId);
+}
+
 export function getLastKnownGoodRuntimeConfigState(): RuntimeConfigRevisionState | null {
   return getTrackedRuntimeConfigRevisionState(CONFIG_PATH);
+}
+
+export function getLastKnownGoodRuntimeAssetState(
+  assetType: RuntimeRevisionAssetType,
+  assetPath: string,
+): RuntimeConfigRevisionState | null {
+  return getTrackedRuntimeAssetRevisionState(assetType, assetPath);
 }
 
 export function getLastKnownGoodRuntimeConfigMetadata(): RuntimeConfigRevisionStateMetadata | null {
   return getTrackedRuntimeConfigRevisionStateMetadata(CONFIG_PATH);
 }
 
+export function getLastKnownGoodRuntimeAssetMetadata(
+  assetType: RuntimeRevisionAssetType,
+  assetPath: string,
+): RuntimeConfigRevisionStateMetadata | null {
+  return getTrackedRuntimeAssetRevisionStateMetadata(assetType, assetPath);
+}
+
 export function deleteRuntimeConfigRevision(revisionId: number): boolean {
   return deleteTrackedRuntimeConfigRevision(CONFIG_PATH, revisionId);
 }
 
+export function deleteRuntimeAssetRevision(
+  assetType: RuntimeRevisionAssetType,
+  assetPath: string,
+  revisionId: number,
+): boolean {
+  return deleteTrackedRuntimeAssetRevision(assetType, assetPath, revisionId);
+}
+
 export function clearRuntimeConfigRevisions(): number {
   return clearTrackedRuntimeConfigRevisions(CONFIG_PATH);
+}
+
+export function clearRuntimeAssetRevisions(
+  assetType: RuntimeRevisionAssetType,
+  assetPath: string,
+): number {
+  return clearTrackedRuntimeAssetRevisions(assetType, assetPath);
+}
+
+export function syncRuntimeAssetRevisionState(
+  assetType: RuntimeRevisionAssetType,
+  assetPath: string,
+  meta?: RuntimeConfigChangeMeta,
+  observedFile?: RuntimeConfigObservedFile,
+): { changed: boolean; previousMd5: string | null; currentMd5: string | null } {
+  return syncTrackedRuntimeAssetRevisionState(
+    assetType,
+    assetPath,
+    meta,
+    observedFile,
+  );
 }
 
 export function restoreRuntimeConfigRevision(
@@ -6031,6 +6099,52 @@ export function restoreLastKnownGoodRuntimeConfig(
   }
 
   return saveRuntimeConfigSource(parsed as Record<string, unknown>, meta);
+}
+
+export function restoreRuntimeAssetRevision(
+  assetType: RuntimeRevisionAssetType,
+  assetPath: string,
+  revisionId: number,
+  meta?: RuntimeConfigChangeMeta,
+): string {
+  return restoreTrackedRuntimeAssetRevision(
+    assetType,
+    assetPath,
+    revisionId,
+    meta,
+  );
+}
+
+export function restoreRuntimeSkillRevision(
+  assetPath: string,
+  revisionId: number,
+  meta?: RuntimeConfigChangeMeta,
+): string {
+  return restoreRuntimeAssetRevision('skill', assetPath, revisionId, meta);
+}
+
+export function restoreRuntimeKnowledgeRevision(
+  assetPath: string,
+  revisionId: number,
+  meta?: RuntimeConfigChangeMeta,
+): string {
+  return restoreRuntimeAssetRevision('knowledge', assetPath, revisionId, meta);
+}
+
+export function restoreRuntimeCvRevision(
+  assetPath: string,
+  revisionId: number,
+  meta?: RuntimeConfigChangeMeta,
+): string {
+  return restoreRuntimeAssetRevision('cv', assetPath, revisionId, meta);
+}
+
+export function restoreRuntimeClassifierRevision(
+  assetPath: string,
+  revisionId: number,
+  meta?: RuntimeConfigChangeMeta,
+): string {
+  return restoreRuntimeAssetRevision('classifier', assetPath, revisionId, meta);
 }
 
 export function runtimeConfigRevisionPath(): string {

--- a/tests/runtime-config-revisions.integration.test.ts
+++ b/tests/runtime-config-revisions.integration.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
+import Database from 'better-sqlite3';
 import {
   afterAll,
   afterEach,
@@ -181,5 +182,181 @@ describe('runtime config revisions integration', () => {
     expect(cleared).toBeGreaterThan(0);
     expect(configMod.listRuntimeConfigRevisions()).toHaveLength(0);
     expect(fs.existsSync(configMod.runtimeConfigRevisionPath())).toBe(true);
+  });
+
+  it('migrates the revision store for typed runtime assets', () => {
+    const database = new Database(configMod.runtimeConfigRevisionPath(), {
+      readonly: true,
+    });
+    try {
+      const revisionColumns = database
+        .prepare(`PRAGMA table_info(config_revisions)`)
+        .all() as Array<{ name: string }>;
+      const stateColumns = database
+        .prepare(`PRAGMA table_info(config_revision_state)`)
+        .all() as Array<{ name: string; pk: number }>;
+
+      expect(
+        revisionColumns.some((column) => column.name === 'asset_type'),
+      ).toBe(true);
+      expect(stateColumns.some((column) => column.name === 'asset_type')).toBe(
+        true,
+      );
+      expect(
+        stateColumns.find((column) => column.name === 'asset_type')?.pk,
+      ).toBe(1);
+      expect(
+        stateColumns.find((column) => column.name === 'config_path')?.pk,
+      ).toBe(2);
+      expect(database.pragma('user_version', { simple: true })).toBe(2);
+    } finally {
+      database.close();
+    }
+  });
+
+  it('migrates legacy config revision rows into typed asset storage', async () => {
+    const legacyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hc-cfg-v1-'));
+    const legacyDbPath = path.join(legacyDir, 'data', 'config-revisions.db');
+    const legacyConfigPath = path.join(legacyDir, 'config.json');
+    fs.mkdirSync(path.dirname(legacyDbPath), { recursive: true });
+    const database = new Database(legacyDbPath);
+    try {
+      database.exec(`
+        CREATE TABLE config_revisions (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          config_path TEXT NOT NULL,
+          actor TEXT NOT NULL,
+          route TEXT NOT NULL,
+          source TEXT NOT NULL,
+          md5 TEXT NOT NULL,
+          byte_length INTEGER NOT NULL,
+          content TEXT NOT NULL,
+          replaced_by_md5 TEXT,
+          created_at TEXT NOT NULL
+        );
+        CREATE TABLE config_revision_state (
+          config_path TEXT PRIMARY KEY,
+          current_md5 TEXT NOT NULL,
+          current_content TEXT NOT NULL,
+          actor TEXT NOT NULL,
+          route TEXT NOT NULL,
+          source TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        );
+        PRAGMA user_version = 1;
+      `);
+      database
+        .prepare(
+          `INSERT INTO config_revisions (
+            config_path, actor, route, source, md5, byte_length, content, replaced_by_md5, created_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          legacyConfigPath,
+          'legacy-user',
+          'legacy.update',
+          'internal',
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          13,
+          '{"version":1}',
+          null,
+          '2026-04-27T00:00:00.000Z',
+        );
+      database
+        .prepare(
+          `INSERT INTO config_revision_state (
+            config_path, current_md5, current_content, actor, route, source, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          legacyConfigPath,
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          '{"version":2}',
+          'legacy-user',
+          'legacy.state',
+          'internal',
+          '2026-04-27T00:01:00.000Z',
+        );
+    } finally {
+      database.close();
+    }
+
+    process.env.HYBRIDCLAW_DATA_DIR = legacyDir;
+    process.env.HOME = legacyDir;
+    vi.resetModules();
+    const revisionsMod = await import(
+      '../src/config/runtime-config-revisions.js'
+    );
+
+    const revisions = revisionsMod.listRuntimeConfigRevisions(legacyConfigPath);
+    expect(revisions).toHaveLength(1);
+    expect(revisions[0]).toMatchObject({
+      assetType: 'config',
+      actor: 'legacy-user',
+      route: 'legacy.update',
+    });
+    expect(
+      revisionsMod.getRuntimeConfigRevisionState(legacyConfigPath)?.content,
+    ).toBe('{"version":2}');
+
+    const skillPath = path.join(legacyDir, 'skills', 'demo', 'SKILL.md');
+    fs.mkdirSync(path.dirname(skillPath), { recursive: true });
+    fs.writeFileSync(skillPath, 'first\n', 'utf-8');
+    revisionsMod.syncRuntimeAssetRevisionState('skill', skillPath);
+    fs.writeFileSync(skillPath, 'second\n', 'utf-8');
+    revisionsMod.syncRuntimeAssetRevisionState('skill', skillPath);
+    expect(
+      revisionsMod.listRuntimeAssetRevisions('skill', skillPath),
+    ).toHaveLength(1);
+  });
+
+  it.each([
+    ['skill', 'skills/research/SKILL.md'],
+    ['knowledge', 'knowledge/sales/index.md'],
+    ['cv', 'agents/charly/CV.md'],
+    ['classifier', 'classifiers/nda/weights.json'],
+  ] as const)('restores %s runtime asset revisions', (assetType, relativePath) => {
+    const restoreRevision = {
+      skill: configMod.restoreRuntimeSkillRevision,
+      knowledge: configMod.restoreRuntimeKnowledgeRevision,
+      cv: configMod.restoreRuntimeCvRevision,
+      classifier: configMod.restoreRuntimeClassifierRevision,
+    }[assetType];
+    const assetPath = path.join(tmpDir, relativePath);
+    fs.mkdirSync(path.dirname(assetPath), { recursive: true });
+    fs.writeFileSync(assetPath, `${assetType}: first\n`, 'utf-8');
+
+    configMod.syncRuntimeAssetRevisionState(assetType, assetPath, {
+      actor: 'asset-test',
+      route: `test.${assetType}.seed`,
+      source: 'internal',
+    });
+
+    fs.writeFileSync(assetPath, `${assetType}: second\n`, 'utf-8');
+    configMod.syncRuntimeAssetRevisionState(assetType, assetPath, {
+      actor: 'asset-test',
+      route: `test.${assetType}.update`,
+      source: 'internal',
+    });
+
+    const revisions = configMod.listRuntimeAssetRevisions(assetType, assetPath);
+    expect(revisions).toHaveLength(1);
+    expect(revisions[0]).toMatchObject({
+      assetType,
+      route: `test.${assetType}.update`,
+    });
+
+    const restoredContent = restoreRevision(assetPath, revisions[0].id, {
+      actor: 'asset-test',
+      route: `test.${assetType}.rollback`,
+      source: 'internal',
+    });
+
+    expect(restoredContent).toBe(`${assetType}: first\n`);
+    expect(fs.readFileSync(assetPath, 'utf-8')).toBe(`${assetType}: first\n`);
+    expect(
+      configMod.getLastKnownGoodRuntimeAssetState(assetType, assetPath)
+        ?.content,
+    ).toBe(`${assetType}: first\n`);
   });
 });


### PR DESCRIPTION
## Summary

Extends the runtime config revision store into a typed runtime asset revision store for skills, knowledge bases, CV files, and classifier weights while preserving the existing config revision API.

## Changes

- Adds asset_type storage and a v2 SQLite migration for existing config revision databases.
- Adds generic asset revision APIs for sync/list/get/delete/clear/restore.
- Adds explicit rollback helpers for skill, knowledge, CV, and classifier assets.
- Covers per-asset rollback and legacy v1 migration behavior in the runtime config revision integration suite.

## Validation

- ./node_modules/.bin/vitest run --configLoader runner --config vitest.integration.config.ts tests/runtime-config-revisions.integration.test.ts
- npm run typecheck
- npm run lint
- npm run check