### PR TITLE
foundation: autonomy/stakes/escalation metadata plumbing (F8 substrate)

### DIFF
--- a/container/src/approval-policy.ts
+++ b/container/src/approval-policy.ts
@@ -32,6 +32,13 @@ export {
 } from '../shared/network-policy.js';
 
 export type ApprovalTier = 'green' | 'yellow' | 'red';
+export type AutonomyLevel = 'autonomous' | 'supervised' | 'manual';
+export type StakesLevel = 'low' | 'medium' | 'high';
+export type EscalationRoute =
+  | 'none'
+  | 'implicit_notice'
+  | 'approval_request'
+  | 'policy_denial';
 
 export type ApprovalDecision =
   | 'auto'
@@ -53,6 +60,11 @@ export interface ApprovalPolicyRule {
 
 export interface ApprovalPolicyConfig {
   pinnedRed: ApprovalPolicyRule[];
+  autonomy: {
+    defaultLevel: AutonomyLevel;
+    tools: Record<string, AutonomyLevel>;
+    actions: Record<string, AutonomyLevel>;
+  };
   networkDefault: NetworkPolicyAction;
   networkRules: NetworkRule[];
   networkPresets: string[];
@@ -67,6 +79,7 @@ export interface ApprovalPolicyConfig {
 
 interface ClassifiedAction {
   tier: ApprovalTier;
+  stakes?: StakesLevel;
   actionKey: string;
   intent: string;
   consequenceIfDenied: string;
@@ -105,6 +118,9 @@ export interface ApprovalPrelude {
 export interface ToolApprovalEvaluation {
   baseTier: ApprovalTier;
   tier: ApprovalTier;
+  autonomyLevel: AutonomyLevel;
+  stakes: StakesLevel;
+  escalationRoute: EscalationRoute;
   decision: ApprovalDecision;
   actionKey: string;
   fingerprint: string;
@@ -169,6 +185,11 @@ export const DEFAULT_POLICY: ApprovalPolicyConfig = {
     { paths: ['~/.ssh/**', '/etc/**', '.env*'] },
     { tools: ['force_push'] },
   ],
+  autonomy: {
+    defaultLevel: 'autonomous',
+    tools: {},
+    actions: {},
+  },
   networkDefault: DEFAULT_NETWORK_DEFAULT,
   networkRules: DEFAULT_NETWORK_RULES,
   networkPresets: [],
@@ -235,6 +256,22 @@ function stableHash(input: string): string {
   return createHash('sha256').update(input).digest('hex').slice(0, 16);
 }
 
+function stakesForTier(tier: ApprovalTier): StakesLevel {
+  if (tier === 'red') return 'high';
+  if (tier === 'yellow') return 'medium';
+  return 'low';
+}
+
+function escalationRouteForDecision(
+  decision: ApprovalDecision,
+  tier: ApprovalTier,
+): EscalationRoute {
+  if (decision === 'denied') return 'policy_denial';
+  if (decision === 'required') return 'approval_request';
+  if (tier === 'yellow' && decision === 'implicit') return 'implicit_notice';
+  return 'none';
+}
+
 function parseJsonObject(raw: string): Record<string, unknown> {
   try {
     const parsed = JSON.parse(raw) as unknown;
@@ -276,6 +313,28 @@ function normalizeStringList(raw: unknown): string[] {
       .filter(Boolean);
   }
   return [];
+}
+
+function normalizeAutonomyLevel(raw: unknown): AutonomyLevel | null {
+  const value = String(raw || '')
+    .trim()
+    .toLowerCase();
+  if (value === 'autonomous' || value === 'supervised' || value === 'manual') {
+    return value;
+  }
+  return null;
+}
+
+function normalizeAutonomyMap(raw: unknown): Record<string, AutonomyLevel> {
+  const record = asRecord(raw);
+  const out: Record<string, AutonomyLevel> = {};
+  for (const [rawKey, rawValue] of Object.entries(record)) {
+    const key = rawKey.trim().toLowerCase();
+    const level = normalizeAutonomyLevel(rawValue);
+    if (!key || !level) continue;
+    out[key] = level;
+  }
+  return out;
 }
 
 function normalizeApprovalRule(raw: unknown): ApprovalPolicyRule | null {
@@ -335,6 +394,7 @@ function matchesPathPattern(candidatePath: string, pattern: string): boolean {
 export function parsePolicyYaml(raw: string): Partial<ApprovalPolicyConfig> {
   const document = asRecord(YAML.parse(raw) as unknown);
   const approval = asRecord(document.approval);
+  const autonomy = asRecord(document.autonomy);
   const audit = asRecord(document.audit);
   const pinnedRed = Array.isArray(approval.pinned_red)
     ? approval.pinned_red
@@ -345,6 +405,13 @@ export function parsePolicyYaml(raw: string): Partial<ApprovalPolicyConfig> {
 
   return {
     ...(pinnedRed.length > 0 ? { pinnedRed } : {}),
+    autonomy: {
+      defaultLevel:
+        normalizeAutonomyLevel(autonomy.default) ||
+        DEFAULT_POLICY.autonomy.defaultLevel,
+      tools: normalizeAutonomyMap(autonomy.tools),
+      actions: normalizeAutonomyMap(autonomy.actions),
+    },
     networkDefault: networkState.defaultAction,
     networkRules: networkState.rules.map((rule) => ({
       ...rule,
@@ -403,6 +470,21 @@ export function loadPolicyFromDisk(policyPath: string): ApprovalPolicyConfig {
       Array.isArray(filePolicy.pinnedRed) && filePolicy.pinnedRed.length > 0
         ? filePolicy.pinnedRed
         : DEFAULT_POLICY.pinnedRed,
+    autonomy: {
+      defaultLevel:
+        normalizeAutonomyLevel(filePolicy.autonomy?.defaultLevel) ||
+        DEFAULT_POLICY.autonomy.defaultLevel,
+      tools:
+        filePolicy.autonomy?.tools &&
+        typeof filePolicy.autonomy.tools === 'object'
+          ? { ...filePolicy.autonomy.tools }
+          : {},
+      actions:
+        filePolicy.autonomy?.actions &&
+        typeof filePolicy.autonomy.actions === 'object'
+          ? { ...filePolicy.autonomy.actions }
+          : {},
+    },
     networkDefault:
       filePolicy.networkDefault === 'allow' ||
       filePolicy.networkDefault === 'deny'
@@ -1205,8 +1287,18 @@ export class TrustedCoworkerApprovalRuntime {
       pathHints: classified.pathHints,
       args,
     });
-    const baseTier: ApprovalTier =
+    const autonomyLevel = this.resolveAutonomyLevel({
+      toolName: params.toolName,
+      actionKey: classified.actionKey,
+    });
+    let baseTier: ApprovalTier =
       pinnedByPolicy || classified.tier === 'red' ? 'red' : classified.tier;
+    if (autonomyLevel === 'manual' && baseTier !== 'red') {
+      baseTier = 'red';
+    } else if (autonomyLevel === 'supervised' && baseTier === 'green') {
+      baseTier = 'yellow';
+    }
+    const stakes = classified.stakes || stakesForTier(baseTier);
 
     let tier: ApprovalTier = baseTier;
     let decision: ApprovalDecision = 'auto';
@@ -1216,6 +1308,9 @@ export class TrustedCoworkerApprovalRuntime {
         return {
           baseTier,
           tier: 'red',
+          autonomyLevel,
+          stakes: 'high',
+          escalationRoute: 'policy_denial',
           decision: 'denied',
           actionKey: classified.actionKey,
           fingerprint,
@@ -1273,6 +1368,9 @@ export class TrustedCoworkerApprovalRuntime {
           return {
             baseTier,
             tier: 'red',
+            autonomyLevel,
+            stakes,
+            escalationRoute: 'policy_denial',
             decision: 'denied',
             actionKey: classified.actionKey,
             fingerprint,
@@ -1299,6 +1397,9 @@ export class TrustedCoworkerApprovalRuntime {
         return {
           baseTier,
           tier: 'red',
+          autonomyLevel,
+          stakes,
+          escalationRoute: 'approval_request',
           decision: 'required',
           actionKey: classified.actionKey,
           fingerprint,
@@ -1341,6 +1442,9 @@ export class TrustedCoworkerApprovalRuntime {
     return {
       baseTier,
       tier,
+      autonomyLevel,
+      stakes,
+      escalationRoute: escalationRouteForDecision(decision, tier),
       decision,
       actionKey: classified.actionKey,
       fingerprint,
@@ -1462,6 +1566,19 @@ export class TrustedCoworkerApprovalRuntime {
 
   private bumpCount(map: Map<string, number>, key: string): void {
     map.set(key, (map.get(key) || 0) + 1);
+  }
+
+  private resolveAutonomyLevel(params: {
+    toolName: string;
+    actionKey: string;
+  }): AutonomyLevel {
+    const toolName = params.toolName.trim().toLowerCase();
+    const actionKey = params.actionKey.trim().toLowerCase();
+    return (
+      this.loadedPolicy.autonomy.actions[actionKey] ||
+      this.loadedPolicy.autonomy.tools[toolName] ||
+      this.loadedPolicy.autonomy.defaultLevel
+    );
   }
 
   private classifyNetworkTargets(params: {

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -673,6 +673,12 @@ async function executePreparedToolCall(
   const isError = runtimeResult.isError;
   const executionBlockedReason =
     blockedReason || (loopGuard.stuck ? loopGuard.message : null);
+  const approvalDecision = executionBlockedReason
+    ? 'denied'
+    : approval.decision;
+  const escalationRoute = executionBlockedReason
+    ? 'policy_denial'
+    : approval.escalationRoute;
   const succeeded = !isError;
 
   if (succeeded) {
@@ -703,7 +709,10 @@ async function executePreparedToolCall(
       blockedReason: executionBlockedReason || undefined,
       approvalTier: approval.tier,
       approvalBaseTier: approval.baseTier,
-      approvalDecision: executionBlockedReason ? 'denied' : approval.decision,
+      autonomyLevel: approval.autonomyLevel,
+      stakes: approval.stakes,
+      escalationRoute,
+      approvalDecision,
       approvalActionKey: approval.actionKey,
       approvalReason: approval.reason,
       approvalRequestId: approval.requestId,
@@ -1464,6 +1473,9 @@ async function processRequest(
           blockedReason: approval.reason,
           approvalTier: approval.tier,
           approvalBaseTier: approval.baseTier,
+          autonomyLevel: approval.autonomyLevel,
+          stakes: approval.stakes,
+          escalationRoute: approval.escalationRoute,
           approvalDecision: approval.decision,
           approvalActionKey: approval.actionKey,
           approvalIntent: approval.intent,
@@ -1505,6 +1517,9 @@ async function processRequest(
           blockedReason: approval.reason,
           approvalTier: approval.tier,
           approvalBaseTier: approval.baseTier,
+          autonomyLevel: approval.autonomyLevel,
+          stakes: approval.stakes,
+          escalationRoute: approval.escalationRoute,
           approvalDecision: approval.decision,
           approvalActionKey: approval.actionKey,
           approvalIntent: approval.intent,

--- a/container/src/types.ts
+++ b/container/src/types.ts
@@ -263,6 +263,13 @@ export interface ToolExecution {
   blockedReason?: string;
   approvalTier?: 'green' | 'yellow' | 'red';
   approvalBaseTier?: 'green' | 'yellow' | 'red';
+  autonomyLevel?: 'autonomous' | 'supervised' | 'manual';
+  stakes?: 'low' | 'medium' | 'high';
+  escalationRoute?:
+    | 'none'
+    | 'implicit_notice'
+    | 'approval_request'
+    | 'policy_denial';
   approvalDecision?:
     | 'auto'
     | 'implicit'

--- a/src/audit/audit-events.ts
+++ b/src/audit/audit-events.ts
@@ -41,6 +41,23 @@ function summarizeToolResult(text: string): string {
   return truncateAuditText(text, 280);
 }
 
+type ApprovalTier = NonNullable<ToolExecution['approvalTier']>;
+type ApprovalDecision = NonNullable<ToolExecution['approvalDecision']>;
+type EscalationRoute = NonNullable<ToolExecution['escalationRoute']>;
+
+function resolveAutonomyEscalationRoute(params: {
+  decision: ApprovalDecision;
+  tier: ApprovalTier;
+  blocked: boolean;
+}): EscalationRoute {
+  if (params.blocked || params.decision === 'denied') return 'policy_denial';
+  if (params.decision === 'required') return 'approval_request';
+  if (params.tier === 'yellow' && params.decision === 'implicit') {
+    return 'implicit_notice';
+  }
+  return 'none';
+}
+
 const SENSITIVE_ARG_KEY_RE =
   /(pass(word)?|secret|token|api[_-]?key|authorization|cookie|credential|session)/i;
 
@@ -75,6 +92,23 @@ export function emitToolExecutionAuditEvents(input: {
   const { sessionId, runId, toolExecutions } = input;
   toolExecutions.forEach((execution, index) => {
     const toolCallId = `${runId}:tool:${index + 1}`;
+    const effectiveTier = execution.approvalTier || 'green';
+    const effectiveBaseTier =
+      execution.approvalBaseTier || execution.approvalTier || 'green';
+    const effectiveDecision = execution.approvalDecision || 'auto';
+    const effectiveEscalationRoute =
+      execution.escalationRoute ||
+      resolveAutonomyEscalationRoute({
+        decision: effectiveDecision,
+        tier: effectiveTier,
+        blocked: Boolean(execution.blocked),
+      });
+    const effectiveReason =
+      execution.approvalReason ||
+      execution.blockedReason ||
+      (effectiveDecision === 'auto'
+        ? 'allowed'
+        : `approval:${effectiveDecision}`);
     const argumentsObject = parseJsonObject(execution.arguments || '{}');
     const auditArguments = sanitizeAuditArguments(
       execution.name,
@@ -100,12 +134,24 @@ export function emitToolExecutionAuditEvents(input: {
         action: `tool:${execution.name}`,
         resource: 'container.sandbox',
         allowed: !execution.blocked,
-        reason:
-          execution.blockedReason ||
-          execution.approvalReason ||
-          (execution.approvalDecision
-            ? `approval:${execution.approvalDecision}`
-            : 'allowed'),
+        reason: effectiveReason,
+      },
+    });
+
+    recordAuditEvent({
+      sessionId,
+      runId,
+      event: {
+        type: 'autonomy.decision',
+        toolCallId,
+        action: execution.approvalActionKey || `tool:${execution.name}`,
+        autonomyLevel: execution.autonomyLevel || 'autonomous',
+        stakes: execution.stakes || 'low',
+        escalationRoute: effectiveEscalationRoute,
+        approvalTier: effectiveTier,
+        approvalBaseTier: effectiveBaseTier,
+        approvalDecision: effectiveDecision,
+        reason: effectiveReason,
       },
     });
 

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -76,6 +76,13 @@ export interface GatewayChatResult {
     blockedReason?: string;
     approvalTier?: 'green' | 'yellow' | 'red';
     approvalBaseTier?: 'green' | 'yellow' | 'red';
+    autonomyLevel?: 'autonomous' | 'supervised' | 'manual';
+    stakes?: 'low' | 'medium' | 'high';
+    escalationRoute?:
+      | 'none'
+      | 'implicit_notice'
+      | 'approval_request'
+      | 'policy_denial';
     approvalDecision?:
       | 'auto'
       | 'implicit'

--- a/src/types/execution.ts
+++ b/src/types/execution.ts
@@ -31,6 +31,13 @@ export interface ToolExecution {
   blockedReason?: string;
   approvalTier?: 'green' | 'yellow' | 'red';
   approvalBaseTier?: 'green' | 'yellow' | 'red';
+  autonomyLevel?: 'autonomous' | 'supervised' | 'manual';
+  stakes?: 'low' | 'medium' | 'high';
+  escalationRoute?:
+    | 'none'
+    | 'implicit_notice'
+    | 'approval_request'
+    | 'policy_denial';
   approvalDecision?:
     | 'auto'
     | 'implicit'

--- a/tests/approval-policy.test.ts
+++ b/tests/approval-policy.test.ts
@@ -72,6 +72,23 @@ network:
     ]);
   });
 
+  test('parsePolicyYaml reads autonomy defaults and scoped overrides', () => {
+    const parsed = parsePolicyYaml(`
+autonomy:
+  default: supervised
+  tools:
+    read: manual
+  actions:
+    bash:install-deps: autonomous
+`);
+
+    expect(parsed.autonomy).toEqual({
+      defaultLevel: 'supervised',
+      tools: { read: 'manual' },
+      actions: { 'bash:install-deps': 'autonomous' },
+    });
+  });
+
   test('yellow actions promote to green after successful repeat', () => {
     const runtime = new TrustedCoworkerApprovalRuntime(
       '/tmp/hybridclaw-missing-policy.yaml',
@@ -93,6 +110,44 @@ network:
       latestUserPrompt: 'Install dependencies',
     });
     expect(second.tier).toBe('green');
+  });
+
+  test('autonomy metadata is emitted for default low-stakes read actions', () => {
+    const runtime = new TrustedCoworkerApprovalRuntime(
+      '/tmp/hybridclaw-missing-policy.yaml',
+    );
+
+    const evaluation = runtime.evaluateToolCall({
+      toolName: 'read',
+      argsJson: JSON.stringify({ path: 'README.md' }),
+      latestUserPrompt: 'Read the README',
+    });
+
+    expect(evaluation.autonomyLevel).toBe('autonomous');
+    expect(evaluation.stakes).toBe('low');
+    expect(evaluation.escalationRoute).toBe('none');
+  });
+
+  test('manual autonomy override escalates an otherwise read-only tool', () => {
+    const policyPath = writeTempPolicy(`
+autonomy:
+  tools:
+    read: manual
+`);
+    const runtime = new TrustedCoworkerApprovalRuntime(policyPath);
+
+    const evaluation = runtime.evaluateToolCall({
+      toolName: 'read',
+      argsJson: JSON.stringify({ path: 'README.md' }),
+      latestUserPrompt: 'Read the README',
+    });
+
+    expect(evaluation.autonomyLevel).toBe('manual');
+    expect(evaluation.baseTier).toBe('red');
+    expect(evaluation.stakes).toBe('high');
+    expect(evaluation.decision).toBe('required');
+    expect(evaluation.escalationRoute).toBe('approval_request');
+    expect(evaluation.requestId).toBeTruthy();
   });
 
   test('pip install is classified as dependency installation', () => {

--- a/tests/audit-events.test.ts
+++ b/tests/audit-events.test.ts
@@ -60,9 +60,19 @@ test('does not emit approval events for auto-approved read-only tools', async ()
   const events = getRecentStructuredAuditForSession('session-auto-read', 10);
   expect(events.map((event) => event.event_type)).toEqual([
     'tool.result',
+    'autonomy.decision',
     'authorization.check',
     'tool.call',
   ]);
+  expect(JSON.parse(events[1].payload)).toEqual(
+    expect.objectContaining({
+      type: 'autonomy.decision',
+      autonomyLevel: 'autonomous',
+      stakes: 'low',
+      escalationRoute: 'none',
+      approvalDecision: 'auto',
+    }),
+  );
 });
 
 test('emits approval request and response events for pending red actions', async () => {
@@ -93,6 +103,9 @@ test('emits approval request and response events for pending red actions', async
         blockedReason: 'this command may change local state',
         approvalTier: 'red',
         approvalBaseTier: 'red',
+        autonomyLevel: 'autonomous',
+        stakes: 'high',
+        escalationRoute: 'approval_request',
         approvalDecision: 'required',
         approvalActionKey: 'bash:other',
         approvalReason: 'this command may change local state',
@@ -106,7 +119,59 @@ test('emits approval request and response events for pending red actions', async
     'tool.result',
     'approval.response',
     'approval.request',
+    'autonomy.decision',
     'authorization.check',
     'tool.call',
   ]);
+});
+
+test('autonomy audit falls back to internally consistent approval metadata', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+
+  const { initDatabase, getRecentStructuredAuditForSession } = await import(
+    '../src/memory/db.ts'
+  );
+  const { emitToolExecutionAuditEvents } = await import(
+    '../src/audit/audit-events.ts'
+  );
+
+  initDatabase({ quiet: true });
+  emitToolExecutionAuditEvents({
+    sessionId: 'session-autonomy-fallback',
+    runId: 'run-autonomy-fallback',
+    toolExecutions: [
+      {
+        name: 'bash',
+        arguments: '{"command":"touch out.txt"}',
+        result: 'blocked',
+        durationMs: 4,
+        blocked: true,
+        blockedReason: 'blocked by security hook',
+        approvalTier: 'yellow',
+        approvalDecision: 'denied',
+      },
+    ],
+  });
+
+  const events = getRecentStructuredAuditForSession(
+    'session-autonomy-fallback',
+    10,
+  );
+  const autonomyEvent = events.find(
+    (event) => event.event_type === 'autonomy.decision',
+  );
+  expect(autonomyEvent).toBeDefined();
+  const autonomy = JSON.parse(autonomyEvent?.payload || '{}');
+  expect(autonomy).toEqual(
+    expect.objectContaining({
+      type: 'autonomy.decision',
+      escalationRoute: 'policy_denial',
+      approvalTier: 'yellow',
+      approvalBaseTier: 'yellow',
+      approvalDecision: 'denied',
+      reason: 'blocked by security hook',
+    }),
+  );
 });


### PR DESCRIPTION
## Scope

Relates to #599 as an F8 substrate patch. This PR does not close #599; the F8 parent should stay open while the child issues are implemented next. It does not fully implement every child issue; it lays the common metadata and audit plumbing that the child issues can build on.

## What changed

- Added autonomy policy metadata to the approval runtime, using the current internal levels `autonomous`, `supervised`, and `manual`.
- Added low/medium/high stakes metadata derived from the existing green/yellow/red classification tier.
- Added explicit escalation route metadata: `none`, `implicit_notice`, `approval_request`, and `policy_denial`.
- Propagated autonomy, stakes, and escalation metadata through container tool execution records and gateway execution types.
- Added structured `autonomy.decision` audit entries for every tool execution.

## What this delivers for F8

- A durable place for autonomy/stakes/escalation decisions to be represented at runtime.
- Audit visibility for autonomy decisions independent of approval request/response events.
- A conservative policy hook that can escalate behavior without weakening pinned-red actions, network denials, approval queue limits, or existing trust-store behavior.

## Not included

- Closing #599.
- Full #585 semantics for `full-autonomous`, `low-stakes-autonomous`, and `confirm-each` per `(coworker, skill)` pair.
- UI/API management flows for per-skill autonomy settings.
- Closing the child issues #585 through #589.

## Validation

- `./node_modules/.bin/vitest run tests/approval-policy.test.ts tests/audit-events.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format`
- `npm --prefix container run lint`
- `npm run build`

## Risk notes

This touches medium/high-risk approval and audit surfaces. The patch is scoped to metadata plumbing, explicit escalation controls, and audit emission; it does not weaken existing enforcement boundaries.