### PR TITLE
[codex] Add per-skill agent autonomy config

### DIFF
--- a/container/src/approval-policy.ts
+++ b/container/src/approval-policy.ts
@@ -32,7 +32,10 @@ export {
 } from '../shared/network-policy.js';
 
 export type ApprovalTier = 'green' | 'yellow' | 'red';
-export type AutonomyLevel = 'autonomous' | 'supervised' | 'manual';
+export type AutonomyLevel =
+  | 'full-autonomous'
+  | 'low-stakes-autonomous'
+  | 'confirm-each';
 export type StakesLevel = 'low' | 'medium' | 'high';
 export type EscalationRoute =
   | 'none'
@@ -186,7 +189,7 @@ export const DEFAULT_POLICY: ApprovalPolicyConfig = {
     { tools: ['force_push'] },
   ],
   autonomy: {
-    defaultLevel: 'autonomous',
+    defaultLevel: 'full-autonomous',
     tools: {},
     actions: {},
   },
@@ -319,7 +322,11 @@ function normalizeAutonomyLevel(raw: unknown): AutonomyLevel | null {
   const value = String(raw || '')
     .trim()
     .toLowerCase();
-  if (value === 'autonomous' || value === 'supervised' || value === 'manual') {
+  if (
+    value === 'full-autonomous' ||
+    value === 'low-stakes-autonomous' ||
+    value === 'confirm-each'
+  ) {
     return value;
   }
   return null;
@@ -1293,9 +1300,12 @@ export class TrustedCoworkerApprovalRuntime {
     });
     let baseTier: ApprovalTier =
       pinnedByPolicy || classified.tier === 'red' ? 'red' : classified.tier;
-    if (autonomyLevel === 'manual' && baseTier !== 'red') {
+    if (autonomyLevel === 'confirm-each' && baseTier !== 'red') {
       baseTier = 'red';
-    } else if (autonomyLevel === 'supervised' && baseTier === 'green') {
+    } else if (
+      autonomyLevel === 'low-stakes-autonomous' &&
+      baseTier === 'green'
+    ) {
       baseTier = 'yellow';
     }
     const stakes = classified.stakes || stakesForTier(baseTier);

--- a/container/src/types.ts
+++ b/container/src/types.ts
@@ -263,7 +263,7 @@ export interface ToolExecution {
   blockedReason?: string;
   approvalTier?: 'green' | 'yellow' | 'red';
   approvalBaseTier?: 'green' | 'yellow' | 'red';
-  autonomyLevel?: 'autonomous' | 'supervised' | 'manual';
+  autonomyLevel?: 'full-autonomous' | 'low-stakes-autonomous' | 'confirm-each';
   stakes?: 'low' | 'medium' | 'high';
   escalationRoute?:
     | 'none'

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -135,10 +135,7 @@ saved revision history directly.
 - `channelInstructions.*` for transport-specific prompt guidance injected into
   the runtime prompt; `channelInstructions.voice` is the right place for
   spoken-style rules such as "no markdown" or "keep replies short"
-- `skills.disabled` and `skills.channelDisabled.*` for skill availability;
-  `skills.autonomy.defaultLevel` and `skills.autonomy.rules[]` declare the
-  permitted autonomy level for each coworker/skill pair (`full-autonomous`,
-  `low-stakes-autonomous`, or `confirm-each`)
+- `skills.disabled` and `skills.channelDisabled.*` for skill availability; `skills.autonomy.defaultLevel` and `skills.autonomy.rules[]` declare the permitted autonomy level for each coworker/skill pair (`full-autonomous`, `low-stakes-autonomous`, or `confirm-each`)
 - `plugins.list[]` for plugin overrides and config; use
   `hybridclaw plugin config <plugin-id> [key] [value|--unset]` for focused
   edits

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -135,7 +135,7 @@ saved revision history directly.
 - `channelInstructions.*` for transport-specific prompt guidance injected into
   the runtime prompt; `channelInstructions.voice` is the right place for
   spoken-style rules such as "no markdown" or "keep replies short"
-- `skills.disabled` and `skills.channelDisabled.*` for skill availability; `skills.autonomy.defaultLevel` and `skills.autonomy.rules[]` declare the permitted autonomy level for each coworker/skill pair (`full-autonomous`, `low-stakes-autonomous`, or `confirm-each`)
+- `skills.disabled` and `skills.channelDisabled.*` for skill availability; `skills.autonomy.defaultLevel` and `skills.autonomy.rules[]` declare the permitted autonomy level for each agent/skill pair (`full-autonomous`, `low-stakes-autonomous`, or `confirm-each`)
 - `plugins.list[]` for plugin overrides and config; use
   `hybridclaw plugin config <plugin-id> [key] [value|--unset]` for focused
   edits

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -135,7 +135,10 @@ saved revision history directly.
 - `channelInstructions.*` for transport-specific prompt guidance injected into
   the runtime prompt; `channelInstructions.voice` is the right place for
   spoken-style rules such as "no markdown" or "keep replies short"
-- `skills.disabled` and `skills.channelDisabled.*` for skill availability
+- `skills.disabled` and `skills.channelDisabled.*` for skill availability;
+  `skills.autonomy.defaultLevel` and `skills.autonomy.rules[]` declare the
+  permitted autonomy level for each coworker/skill pair (`full-autonomous`,
+  `low-stakes-autonomous`, or `confirm-each`)
 - `plugins.list[]` for plugin overrides and config; use
   `hybridclaw plugin config <plugin-id> [key] [value|--unset]` for focused
   edits

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -135,7 +135,7 @@ saved revision history directly.
 - `channelInstructions.*` for transport-specific prompt guidance injected into
   the runtime prompt; `channelInstructions.voice` is the right place for
   spoken-style rules such as "no markdown" or "keep replies short"
-- `skills.disabled` and `skills.channelDisabled.*` for skill availability; `skills.autonomy.defaultLevel` and `skills.autonomy.rules[]` declare the permitted autonomy level for each agent/skill pair (`full-autonomous`, `low-stakes-autonomous`, or `confirm-each`) for upcoming default-action runtime enforcement
+- `skills.disabled` and `skills.channelDisabled.*` for skill availability; `skills.autonomy.defaultLevel` and `skills.autonomy.rules[]` declare the permitted autonomy level for each agent/skill pair (`full-autonomous`, `low-stakes-autonomous`, or `confirm-each`) for upcoming default-action runtime enforcement; the shipped default is the conservative global `confirm-each`, not a per-skill-class default table
 - `plugins.list[]` for plugin overrides and config; use
   `hybridclaw plugin config <plugin-id> [key] [value|--unset]` for focused
   edits

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -135,7 +135,7 @@ saved revision history directly.
 - `channelInstructions.*` for transport-specific prompt guidance injected into
   the runtime prompt; `channelInstructions.voice` is the right place for
   spoken-style rules such as "no markdown" or "keep replies short"
-- `skills.disabled` and `skills.channelDisabled.*` for skill availability; `skills.autonomy.defaultLevel` and `skills.autonomy.rules[]` declare the permitted autonomy level for each agent/skill pair (`full-autonomous`, `low-stakes-autonomous`, or `confirm-each`)
+- `skills.disabled` and `skills.channelDisabled.*` for skill availability; `skills.autonomy.defaultLevel` and `skills.autonomy.rules[]` declare the permitted autonomy level for each agent/skill pair (`full-autonomous`, `low-stakes-autonomous`, or `confirm-each`) for upcoming default-action runtime enforcement
 - `plugins.list[]` for plugin overrides and config; use
   `hybridclaw plugin config <plugin-id> [key] [value|--unset]` for focused
   edits

--- a/docs/development/reference/configuration.md
+++ b/docs/development/reference/configuration.md
@@ -112,7 +112,7 @@ leak into the saved revision metadata.
 - `channelInstructions.*` for transport-specific prompt guidance injected into
   the runtime prompt; `channelInstructions.voice` is the right place for
   spoken-style rules such as "no markdown" or "keep replies short"
-- `skills.disabled` and `skills.channelDisabled.*` for skill availability; `skills.autonomy.defaultLevel` and `skills.autonomy.rules[]` declare the permitted autonomy level for each agent/skill pair (`full-autonomous`, `low-stakes-autonomous`, or `confirm-each`) for upcoming default-action runtime enforcement
+- `skills.disabled` and `skills.channelDisabled.*` for skill availability; `skills.autonomy.defaultLevel` and `skills.autonomy.rules[]` declare the permitted autonomy level for each agent/skill pair (`full-autonomous`, `low-stakes-autonomous`, or `confirm-each`) for upcoming default-action runtime enforcement; the shipped default is the conservative global `confirm-each`, not a per-skill-class default table
 - `plugins.list[]` for plugin overrides and config; use
   `hybridclaw plugin config <plugin-id> [key] [value|--unset]` for focused
   edits

--- a/docs/development/reference/configuration.md
+++ b/docs/development/reference/configuration.md
@@ -112,7 +112,7 @@ leak into the saved revision metadata.
 - `channelInstructions.*` for transport-specific prompt guidance injected into
   the runtime prompt; `channelInstructions.voice` is the right place for
   spoken-style rules such as "no markdown" or "keep replies short"
-- `skills.disabled` and `skills.channelDisabled.*` for skill availability; `skills.autonomy.defaultLevel` and `skills.autonomy.rules[]` declare the permitted autonomy level for each coworker/skill pair (`full-autonomous`, `low-stakes-autonomous`, or `confirm-each`)
+- `skills.disabled` and `skills.channelDisabled.*` for skill availability; `skills.autonomy.defaultLevel` and `skills.autonomy.rules[]` declare the permitted autonomy level for each agent/skill pair (`full-autonomous`, `low-stakes-autonomous`, or `confirm-each`)
 - `plugins.list[]` for plugin overrides and config; use
   `hybridclaw plugin config <plugin-id> [key] [value|--unset]` for focused
   edits

--- a/docs/development/reference/configuration.md
+++ b/docs/development/reference/configuration.md
@@ -112,7 +112,10 @@ leak into the saved revision metadata.
 - `channelInstructions.*` for transport-specific prompt guidance injected into
   the runtime prompt; `channelInstructions.voice` is the right place for
   spoken-style rules such as "no markdown" or "keep replies short"
-- `skills.disabled` and `skills.channelDisabled.*` for skill availability
+- `skills.disabled` and `skills.channelDisabled.*` for skill availability;
+  `skills.autonomy.defaultLevel` and `skills.autonomy.rules[]` declare the
+  permitted autonomy level for each coworker/skill pair (`full-autonomous`,
+  `low-stakes-autonomous`, or `confirm-each`)
 - `plugins.list[]` for plugin overrides and config; use
   `hybridclaw plugin config <plugin-id> [key] [value|--unset]` for focused
   edits

--- a/docs/development/reference/configuration.md
+++ b/docs/development/reference/configuration.md
@@ -112,7 +112,7 @@ leak into the saved revision metadata.
 - `channelInstructions.*` for transport-specific prompt guidance injected into
   the runtime prompt; `channelInstructions.voice` is the right place for
   spoken-style rules such as "no markdown" or "keep replies short"
-- `skills.disabled` and `skills.channelDisabled.*` for skill availability; `skills.autonomy.defaultLevel` and `skills.autonomy.rules[]` declare the permitted autonomy level for each agent/skill pair (`full-autonomous`, `low-stakes-autonomous`, or `confirm-each`)
+- `skills.disabled` and `skills.channelDisabled.*` for skill availability; `skills.autonomy.defaultLevel` and `skills.autonomy.rules[]` declare the permitted autonomy level for each agent/skill pair (`full-autonomous`, `low-stakes-autonomous`, or `confirm-each`) for upcoming default-action runtime enforcement
 - `plugins.list[]` for plugin overrides and config; use
   `hybridclaw plugin config <plugin-id> [key] [value|--unset]` for focused
   edits

--- a/docs/development/reference/configuration.md
+++ b/docs/development/reference/configuration.md
@@ -112,10 +112,7 @@ leak into the saved revision metadata.
 - `channelInstructions.*` for transport-specific prompt guidance injected into
   the runtime prompt; `channelInstructions.voice` is the right place for
   spoken-style rules such as "no markdown" or "keep replies short"
-- `skills.disabled` and `skills.channelDisabled.*` for skill availability;
-  `skills.autonomy.defaultLevel` and `skills.autonomy.rules[]` declare the
-  permitted autonomy level for each coworker/skill pair (`full-autonomous`,
-  `low-stakes-autonomous`, or `confirm-each`)
+- `skills.disabled` and `skills.channelDisabled.*` for skill availability; `skills.autonomy.defaultLevel` and `skills.autonomy.rules[]` declare the permitted autonomy level for each coworker/skill pair (`full-autonomous`, `low-stakes-autonomous`, or `confirm-each`)
 - `plugins.list[]` for plugin overrides and config; use
   `hybridclaw plugin config <plugin-id> [key] [value|--unset]` for focused
   edits

--- a/src/audit/audit-events.ts
+++ b/src/audit/audit-events.ts
@@ -145,7 +145,7 @@ export function emitToolExecutionAuditEvents(input: {
         type: 'autonomy.decision',
         toolCallId,
         action: execution.approvalActionKey || `tool:${execution.name}`,
-        autonomyLevel: execution.autonomyLevel || 'autonomous',
+        autonomyLevel: execution.autonomyLevel || 'full-autonomous',
         stakes: execution.stakes || 'low',
         escalationRoute: effectiveEscalationRoute,
         approvalTier: effectiveTier,

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -1695,6 +1695,15 @@ function normalizeSkillAutonomyConfig(
       continue;
     }
     const level = normalizeSkillAutonomyLevel(item.level, defaultLevel);
+    if (
+      typeof item.level === 'string' &&
+      item.level.trim() &&
+      level !== item.level.trim().toLowerCase()
+    ) {
+      console.warn(
+        `[runtime-config] invalid skills.autonomy level "${item.level.trim()}" for agentId "${agentId}" and skillName "${skillName}"; using default "${defaultLevel}"`,
+      );
+    }
     rulesByKey.set(JSON.stringify([agentId, skillName]), {
       agentId,
       skillName,

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -5912,12 +5912,10 @@ export function resolveSkillAutonomyLevel(
   const normalizedSkillName = normalizeString(skillName, '', {
     allowEmpty: false,
   });
-  const defaultLevel =
-    config.skills.autonomy?.defaultLevel ??
-    DEFAULT_RUNTIME_CONFIG.skills.autonomy.defaultLevel;
+  const defaultLevel = config.skills.autonomy.defaultLevel;
   if (!normalizedAgentId || !normalizedSkillName) return defaultLevel;
 
-  const rule = config.skills.autonomy?.rules.find(
+  const rule = config.skills.autonomy.rules.find(
     (entry) =>
       entry.agentId === normalizedAgentId &&
       entry.skillName === normalizedSkillName,

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -5926,7 +5926,11 @@ export function resolveSkillAutonomyLevel(
   skillName: string,
 ): SkillAutonomyLevel {
   const defaultLevel = config.skills.autonomy.defaultLevel;
-  if (!agentId || !skillName) return defaultLevel;
+  if (!agentId || !skillName) {
+    throw new Error(
+      'resolveSkillAutonomyLevel requires non-empty agentId and skillName.',
+    );
+  }
 
   const rule = config.skills.autonomy.rules.find(
     (entry) => entry.agentId === agentId && entry.skillName === skillName,

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -1685,7 +1685,7 @@ function normalizeSkillAutonomyConfig(
     });
     if (!coworkerId || !skillName) continue;
     const level = normalizeSkillAutonomyLevel(item.level, defaultLevel);
-    rulesByKey.set(`${coworkerId}\0${skillName}`, {
+    rulesByKey.set(JSON.stringify([coworkerId, skillName]), {
       coworkerId,
       skillName,
       level,

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -568,6 +568,16 @@ export interface RuntimeSkillAutonomyConfig {
   rules: RuntimeSkillAutonomyRule[];
 }
 
+type RuntimeSkillAutonomyRuleIndex = Map<
+  string,
+  Map<string, SkillAutonomyLevel>
+>;
+
+const skillAutonomyRuleIndexes = new WeakMap<
+  RuntimeSkillAutonomyConfig,
+  RuntimeSkillAutonomyRuleIndex
+>();
+
 export interface RuntimeConfig {
   version: number;
   security: RuntimeSecurityConfig;
@@ -1718,6 +1728,25 @@ function normalizeSkillAutonomyConfig(
       return byAgent || a.skillName.localeCompare(b.skillName);
     }),
   };
+}
+
+function getSkillAutonomyRuleIndex(
+  autonomy: RuntimeSkillAutonomyConfig,
+): RuntimeSkillAutonomyRuleIndex {
+  const cached = skillAutonomyRuleIndexes.get(autonomy);
+  if (cached) return cached;
+
+  const index: RuntimeSkillAutonomyRuleIndex = new Map();
+  for (const rule of autonomy.rules) {
+    let skillRules = index.get(rule.agentId);
+    if (!skillRules) {
+      skillRules = new Map<string, SkillAutonomyLevel>();
+      index.set(rule.agentId, skillRules);
+    }
+    skillRules.set(rule.skillName, rule.level);
+  }
+  skillAutonomyRuleIndexes.set(autonomy, index);
+  return index;
 }
 
 function normalizeSkillChannelDisabled(
@@ -5932,10 +5961,11 @@ export function resolveSkillAutonomyLevel(
     );
   }
 
-  const rule = config.skills.autonomy.rules.find(
-    (entry) => entry.agentId === agentId && entry.skillName === skillName,
+  return (
+    getSkillAutonomyRuleIndex(config.skills.autonomy)
+      .get(agentId)
+      ?.get(skillName) ?? defaultLevel
   );
-  return rule?.level ?? defaultLevel;
 }
 
 export function isContainerSandboxModeExplicit(): boolean {

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -187,6 +187,12 @@ export type SchedulerScheduleKind = 'at' | 'every' | 'cron' | 'one_shot';
 export type SchedulerActionKind = 'agent_turn' | 'system_event';
 export type SchedulerDeliveryKind = 'channel' | 'last-channel' | 'webhook';
 export const DEFAULT_ONE_SHOT_MAX_RETRIES = 3;
+export const SKILL_AUTONOMY_LEVELS = [
+  'full-autonomous',
+  'low-stakes-autonomous',
+  'confirm-each',
+] as const;
+export type SkillAutonomyLevel = (typeof SKILL_AUTONOMY_LEVELS)[number];
 export const SCHEDULER_BOARD_STATUSES = [
   'backlog',
   'in_progress',
@@ -551,6 +557,17 @@ export interface RuntimeHttpRequestToolConfig {
   authRules: RuntimeHttpRequestAuthRule[];
 }
 
+export interface RuntimeSkillAutonomyRule {
+  coworkerId: string;
+  skillName: string;
+  level: SkillAutonomyLevel;
+}
+
+export interface RuntimeSkillAutonomyConfig {
+  defaultLevel: SkillAutonomyLevel;
+  rules: RuntimeSkillAutonomyRule[];
+}
+
 export interface RuntimeConfig {
   version: number;
   security: RuntimeSecurityConfig;
@@ -559,6 +576,7 @@ export interface RuntimeConfig {
     extraDirs: string[];
     disabled: string[];
     channelDisabled?: Partial<Record<SkillConfigChannelKind, string[]>>;
+    autonomy: RuntimeSkillAutonomyConfig;
   };
   tools: {
     disabled: string[];
@@ -931,6 +949,10 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
     extraDirs: [],
     disabled: [],
     channelDisabled: {},
+    autonomy: {
+      defaultLevel: 'confirm-each',
+      rules: [],
+    },
   },
   tools: {
     disabled: [],
@@ -1628,6 +1650,55 @@ function normalizeStringArray(value: unknown, fallback: string[]): string[] {
   }
 
   return fallback;
+}
+
+function normalizeSkillAutonomyLevel(
+  value: unknown,
+  fallback: SkillAutonomyLevel,
+): SkillAutonomyLevel {
+  const normalized = normalizeString(value, fallback, {
+    allowEmpty: false,
+  }).toLowerCase();
+  return SKILL_AUTONOMY_LEVELS.includes(normalized as SkillAutonomyLevel)
+    ? (normalized as SkillAutonomyLevel)
+    : fallback;
+}
+
+function normalizeSkillAutonomyConfig(
+  value: unknown,
+  fallback: RuntimeSkillAutonomyConfig,
+): RuntimeSkillAutonomyConfig {
+  const raw = isRecord(value) ? value : {};
+  const defaultLevel = normalizeSkillAutonomyLevel(
+    raw.defaultLevel,
+    fallback.defaultLevel,
+  );
+  const rulesByKey = new Map<string, RuntimeSkillAutonomyRule>();
+  const rawRules = Array.isArray(raw.rules) ? raw.rules : [];
+  for (const item of rawRules) {
+    if (!isRecord(item)) continue;
+    const coworkerId = normalizeString(item.coworkerId, '', {
+      allowEmpty: false,
+    });
+    const skillName = normalizeString(item.skillName, '', {
+      allowEmpty: false,
+    });
+    if (!coworkerId || !skillName) continue;
+    const level = normalizeSkillAutonomyLevel(item.level, defaultLevel);
+    rulesByKey.set(`${coworkerId}\0${skillName}`, {
+      coworkerId,
+      skillName,
+      level,
+    });
+  }
+
+  return {
+    defaultLevel,
+    rules: [...rulesByKey.values()].sort((a, b) => {
+      const byCoworker = a.coworkerId.localeCompare(b.coworkerId);
+      return byCoworker || a.skillName.localeCompare(b.skillName);
+    }),
+  };
 }
 
 function normalizeSkillChannelDisabled(
@@ -4397,6 +4468,10 @@ function normalizeRuntimeConfig(
         DEFAULT_RUNTIME_CONFIG.skills.disabled,
       ),
       channelDisabled: normalizeSkillChannelDisabled(rawSkills.channelDisabled),
+      autonomy: normalizeSkillAutonomyConfig(
+        rawSkills.autonomy,
+        DEFAULT_RUNTIME_CONFIG.skills.autonomy,
+      ),
     },
     tools: {
       disabled: normalizeStringArray(
@@ -5824,6 +5899,30 @@ export function resolveDefaultAgentId(
       }) === configured,
   );
   return hasConfiguredAgent ? configured : DEFAULT_AGENT_ID;
+}
+
+export function resolveSkillAutonomyLevel(
+  config: Pick<RuntimeConfig, 'skills'> = currentConfig,
+  coworkerId: string,
+  skillName: string,
+): SkillAutonomyLevel {
+  const normalizedCoworkerId = normalizeString(coworkerId, '', {
+    allowEmpty: false,
+  });
+  const normalizedSkillName = normalizeString(skillName, '', {
+    allowEmpty: false,
+  });
+  const defaultLevel =
+    config.skills.autonomy?.defaultLevel ??
+    DEFAULT_RUNTIME_CONFIG.skills.autonomy.defaultLevel;
+  if (!normalizedCoworkerId || !normalizedSkillName) return defaultLevel;
+
+  const rule = config.skills.autonomy?.rules.find(
+    (entry) =>
+      entry.coworkerId === normalizedCoworkerId &&
+      entry.skillName === normalizedSkillName,
+  );
+  return rule?.level ?? defaultLevel;
 }
 
 export function isContainerSandboxModeExplicit(): boolean {

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -558,7 +558,7 @@ export interface RuntimeHttpRequestToolConfig {
 }
 
 export interface RuntimeSkillAutonomyRule {
-  coworkerId: string;
+  agentId: string;
   skillName: string;
   level: SkillAutonomyLevel;
 }
@@ -1677,16 +1677,16 @@ function normalizeSkillAutonomyConfig(
   const rawRules = Array.isArray(raw.rules) ? raw.rules : [];
   for (const item of rawRules) {
     if (!isRecord(item)) continue;
-    const coworkerId = normalizeString(item.coworkerId, '', {
+    const agentId = normalizeString(item.agentId, '', {
       allowEmpty: false,
     });
     const skillName = normalizeString(item.skillName, '', {
       allowEmpty: false,
     });
-    if (!coworkerId || !skillName) continue;
+    if (!agentId || !skillName) continue;
     const level = normalizeSkillAutonomyLevel(item.level, defaultLevel);
-    rulesByKey.set(JSON.stringify([coworkerId, skillName]), {
-      coworkerId,
+    rulesByKey.set(JSON.stringify([agentId, skillName]), {
+      agentId,
       skillName,
       level,
     });
@@ -1695,8 +1695,8 @@ function normalizeSkillAutonomyConfig(
   return {
     defaultLevel,
     rules: [...rulesByKey.values()].sort((a, b) => {
-      const byCoworker = a.coworkerId.localeCompare(b.coworkerId);
-      return byCoworker || a.skillName.localeCompare(b.skillName);
+      const byAgent = a.agentId.localeCompare(b.agentId);
+      return byAgent || a.skillName.localeCompare(b.skillName);
     }),
   };
 }
@@ -5903,10 +5903,10 @@ export function resolveDefaultAgentId(
 
 export function resolveSkillAutonomyLevel(
   config: Pick<RuntimeConfig, 'skills'> = currentConfig,
-  coworkerId: string,
+  agentId: string,
   skillName: string,
 ): SkillAutonomyLevel {
-  const normalizedCoworkerId = normalizeString(coworkerId, '', {
+  const normalizedAgentId = normalizeString(agentId, '', {
     allowEmpty: false,
   });
   const normalizedSkillName = normalizeString(skillName, '', {
@@ -5915,11 +5915,11 @@ export function resolveSkillAutonomyLevel(
   const defaultLevel =
     config.skills.autonomy?.defaultLevel ??
     DEFAULT_RUNTIME_CONFIG.skills.autonomy.defaultLevel;
-  if (!normalizedCoworkerId || !normalizedSkillName) return defaultLevel;
+  if (!normalizedAgentId || !normalizedSkillName) return defaultLevel;
 
   const rule = config.skills.autonomy?.rules.find(
     (entry) =>
-      entry.coworkerId === normalizedCoworkerId &&
+      entry.agentId === normalizedAgentId &&
       entry.skillName === normalizedSkillName,
   );
   return rule?.level ?? defaultLevel;

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -1676,14 +1676,24 @@ function normalizeSkillAutonomyConfig(
   const rulesByKey = new Map<string, RuntimeSkillAutonomyRule>();
   const rawRules = Array.isArray(raw.rules) ? raw.rules : [];
   for (const item of rawRules) {
-    if (!isRecord(item)) continue;
+    if (!isRecord(item)) {
+      console.warn(
+        '[runtime-config] skipping skills.autonomy rule: expected an object',
+      );
+      continue;
+    }
     const agentId = normalizeString(item.agentId, '', {
       allowEmpty: false,
     });
     const skillName = normalizeString(item.skillName, '', {
       allowEmpty: false,
     });
-    if (!agentId || !skillName) continue;
+    if (!agentId || !skillName) {
+      console.warn(
+        '[runtime-config] skipping skills.autonomy rule with empty agentId or skillName',
+      );
+      continue;
+    }
     const level = normalizeSkillAutonomyLevel(item.level, defaultLevel);
     rulesByKey.set(JSON.stringify([agentId, skillName]), {
       agentId,

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -5906,19 +5906,11 @@ export function resolveSkillAutonomyLevel(
   agentId: string,
   skillName: string,
 ): SkillAutonomyLevel {
-  const normalizedAgentId = normalizeString(agentId, '', {
-    allowEmpty: false,
-  });
-  const normalizedSkillName = normalizeString(skillName, '', {
-    allowEmpty: false,
-  });
   const defaultLevel = config.skills.autonomy.defaultLevel;
-  if (!normalizedAgentId || !normalizedSkillName) return defaultLevel;
+  if (!agentId || !skillName) return defaultLevel;
 
   const rule = config.skills.autonomy.rules.find(
-    (entry) =>
-      entry.agentId === normalizedAgentId &&
-      entry.skillName === normalizedSkillName,
+    (entry) => entry.agentId === agentId && entry.skillName === skillName,
   );
   return rule?.level ?? defaultLevel;
 }

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -76,7 +76,10 @@ export interface GatewayChatResult {
     blockedReason?: string;
     approvalTier?: 'green' | 'yellow' | 'red';
     approvalBaseTier?: 'green' | 'yellow' | 'red';
-    autonomyLevel?: 'autonomous' | 'supervised' | 'manual';
+    autonomyLevel?:
+      | 'full-autonomous'
+      | 'low-stakes-autonomous'
+      | 'confirm-each';
     stakes?: 'low' | 'medium' | 'high';
     escalationRoute?:
       | 'none'

--- a/src/types/execution.ts
+++ b/src/types/execution.ts
@@ -31,7 +31,7 @@ export interface ToolExecution {
   blockedReason?: string;
   approvalTier?: 'green' | 'yellow' | 'red';
   approvalBaseTier?: 'green' | 'yellow' | 'red';
-  autonomyLevel?: 'autonomous' | 'supervised' | 'manual';
+  autonomyLevel?: 'full-autonomous' | 'low-stakes-autonomous' | 'confirm-each';
   stakes?: 'low' | 'medium' | 'high';
   escalationRoute?:
     | 'none'

--- a/tests/approval-policy.test.ts
+++ b/tests/approval-policy.test.ts
@@ -75,17 +75,17 @@ network:
   test('parsePolicyYaml reads autonomy defaults and scoped overrides', () => {
     const parsed = parsePolicyYaml(`
 autonomy:
-  default: supervised
+  default: low-stakes-autonomous
   tools:
-    read: manual
+    read: confirm-each
   actions:
-    bash:install-deps: autonomous
+    bash:install-deps: full-autonomous
 `);
 
     expect(parsed.autonomy).toEqual({
-      defaultLevel: 'supervised',
-      tools: { read: 'manual' },
-      actions: { 'bash:install-deps': 'autonomous' },
+      defaultLevel: 'low-stakes-autonomous',
+      tools: { read: 'confirm-each' },
+      actions: { 'bash:install-deps': 'full-autonomous' },
     });
   });
 
@@ -123,16 +123,16 @@ autonomy:
       latestUserPrompt: 'Read the README',
     });
 
-    expect(evaluation.autonomyLevel).toBe('autonomous');
+    expect(evaluation.autonomyLevel).toBe('full-autonomous');
     expect(evaluation.stakes).toBe('low');
     expect(evaluation.escalationRoute).toBe('none');
   });
 
-  test('manual autonomy override escalates an otherwise read-only tool', () => {
+  test('confirm-each autonomy override escalates an otherwise read-only tool', () => {
     const policyPath = writeTempPolicy(`
 autonomy:
   tools:
-    read: manual
+    read: confirm-each
 `);
     const runtime = new TrustedCoworkerApprovalRuntime(policyPath);
 
@@ -142,7 +142,7 @@ autonomy:
       latestUserPrompt: 'Read the README',
     });
 
-    expect(evaluation.autonomyLevel).toBe('manual');
+    expect(evaluation.autonomyLevel).toBe('confirm-each');
     expect(evaluation.baseTier).toBe('red');
     expect(evaluation.stakes).toBe('high');
     expect(evaluation.decision).toBe('required');

--- a/tests/audit-events.test.ts
+++ b/tests/audit-events.test.ts
@@ -67,7 +67,7 @@ test('does not emit approval events for auto-approved read-only tools', async ()
   expect(JSON.parse(events[1].payload)).toEqual(
     expect.objectContaining({
       type: 'autonomy.decision',
-      autonomyLevel: 'autonomous',
+      autonomyLevel: 'full-autonomous',
       stakes: 'low',
       escalationRoute: 'none',
       approvalDecision: 'auto',
@@ -103,7 +103,7 @@ test('emits approval request and response events for pending red actions', async
         blockedReason: 'this command may change local state',
         approvalTier: 'red',
         approvalBaseTier: 'red',
-        autonomyLevel: 'autonomous',
+        autonomyLevel: 'full-autonomous',
         stakes: 'high',
         escalationRoute: 'approval_request',
         approvalDecision: 'required',

--- a/tests/config-reload.integration.test.ts
+++ b/tests/config-reload.integration.test.ts
@@ -211,7 +211,7 @@ describe('config reload integration', () => {
         },
       ],
     });
-    expect(configMod.resolveSkillAutonomyLevel(cfg, ' writer ', ' docs ')).toBe(
+    expect(configMod.resolveSkillAutonomyLevel(cfg, 'writer', 'docs')).toBe(
       'full-autonomous',
     );
     expect(configMod.resolveSkillAutonomyLevel(cfg, 'writer', 'missing')).toBe(

--- a/tests/config-reload.integration.test.ts
+++ b/tests/config-reload.integration.test.ts
@@ -219,6 +219,36 @@ describe('config reload integration', () => {
     );
   });
 
+  it('keeps autonomy rules distinct when ids contain null bytes', () => {
+    writeConfig({
+      skills: {
+        autonomy: {
+          rules: [
+            {
+              coworkerId: 'team\u0000alpha',
+              skillName: 'docs',
+              level: 'full-autonomous',
+            },
+            {
+              coworkerId: 'team',
+              skillName: 'alpha\u0000docs',
+              level: 'low-stakes-autonomous',
+            },
+          ],
+        },
+      },
+    });
+
+    const cfg = configMod.reloadRuntimeConfig('test');
+
+    expect(
+      configMod.resolveSkillAutonomyLevel(cfg, 'team\u0000alpha', 'docs'),
+    ).toBe('full-autonomous');
+    expect(
+      configMod.resolveSkillAutonomyLevel(cfg, 'team', 'alpha\u0000docs'),
+    ).toBe('low-stakes-autonomous');
+  });
+
   it('nested config updates do not clobber sibling keys', () => {
     configMod.ensureRuntimeConfigFile();
 

--- a/tests/config-reload.integration.test.ts
+++ b/tests/config-reload.integration.test.ts
@@ -158,6 +158,67 @@ describe('config reload integration', () => {
     expect(cfg.container.persistBashState).toBe(false);
   });
 
+  it('normalizes per-coworker skill autonomy rules', () => {
+    writeConfig({
+      skills: {
+        autonomy: {
+          defaultLevel: 'low-stakes-autonomous',
+          rules: [
+            {
+              coworkerId: ' writer ',
+              skillName: ' docs ',
+              level: 'full-autonomous',
+            },
+            {
+              coworkerId: 'writer',
+              skillName: 'email',
+              level: 'confirm-each',
+            },
+            {
+              coworkerId: '',
+              skillName: 'ignored',
+              level: 'full-autonomous',
+            },
+            {
+              coworkerId: 'writer',
+              skillName: 'bad-level',
+              level: 'unsupported',
+            },
+          ],
+        },
+      },
+    });
+
+    const cfg = configMod.reloadRuntimeConfig('test');
+
+    expect(cfg.skills.autonomy).toEqual({
+      defaultLevel: 'low-stakes-autonomous',
+      rules: [
+        {
+          coworkerId: 'writer',
+          skillName: 'bad-level',
+          level: 'low-stakes-autonomous',
+        },
+        {
+          coworkerId: 'writer',
+          skillName: 'docs',
+          level: 'full-autonomous',
+        },
+        {
+          coworkerId: 'writer',
+          skillName: 'email',
+          level: 'confirm-each',
+        },
+      ],
+    });
+    expect(configMod.resolveSkillAutonomyLevel(cfg, ' writer ', ' docs ')).toBe(
+      'full-autonomous',
+    );
+    expect(configMod.resolveSkillAutonomyLevel(cfg, 'writer', 'missing')).toBe(
+      'low-stakes-autonomous',
+    );
+  });
+
   it('nested config updates do not clobber sibling keys', () => {
     configMod.ensureRuntimeConfigFile();
 

--- a/tests/config-reload.integration.test.ts
+++ b/tests/config-reload.integration.test.ts
@@ -158,29 +158,29 @@ describe('config reload integration', () => {
     expect(cfg.container.persistBashState).toBe(false);
   });
 
-  it('normalizes per-coworker skill autonomy rules', () => {
+  it('normalizes per-agent skill autonomy rules', () => {
     writeConfig({
       skills: {
         autonomy: {
           defaultLevel: 'low-stakes-autonomous',
           rules: [
             {
-              coworkerId: ' writer ',
+              agentId: ' writer ',
               skillName: ' docs ',
               level: 'full-autonomous',
             },
             {
-              coworkerId: 'writer',
+              agentId: 'writer',
               skillName: 'email',
               level: 'confirm-each',
             },
             {
-              coworkerId: '',
+              agentId: '',
               skillName: 'ignored',
               level: 'full-autonomous',
             },
             {
-              coworkerId: 'writer',
+              agentId: 'writer',
               skillName: 'bad-level',
               level: 'unsupported',
             },
@@ -195,17 +195,17 @@ describe('config reload integration', () => {
       defaultLevel: 'low-stakes-autonomous',
       rules: [
         {
-          coworkerId: 'writer',
+          agentId: 'writer',
           skillName: 'bad-level',
           level: 'low-stakes-autonomous',
         },
         {
-          coworkerId: 'writer',
+          agentId: 'writer',
           skillName: 'docs',
           level: 'full-autonomous',
         },
         {
-          coworkerId: 'writer',
+          agentId: 'writer',
           skillName: 'email',
           level: 'confirm-each',
         },
@@ -225,12 +225,12 @@ describe('config reload integration', () => {
         autonomy: {
           rules: [
             {
-              coworkerId: 'team\u0000alpha',
+              agentId: 'team\u0000alpha',
               skillName: 'docs',
               level: 'full-autonomous',
             },
             {
-              coworkerId: 'team',
+              agentId: 'team',
               skillName: 'alpha\u0000docs',
               level: 'low-stakes-autonomous',
             },

--- a/tests/config-reload.integration.test.ts
+++ b/tests/config-reload.integration.test.ts
@@ -159,11 +159,13 @@ describe('config reload integration', () => {
   });
 
   it('normalizes per-agent skill autonomy rules', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     writeConfig({
       skills: {
         autonomy: {
           defaultLevel: 'low-stakes-autonomous',
           rules: [
+            'not-a-rule',
             {
               agentId: ' writer ',
               skillName: ' docs ',
@@ -217,6 +219,13 @@ describe('config reload integration', () => {
     expect(configMod.resolveSkillAutonomyLevel(cfg, 'writer', 'missing')).toBe(
       'low-stakes-autonomous',
     );
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[runtime-config] skipping skills.autonomy rule: expected an object',
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[runtime-config] skipping skills.autonomy rule with empty agentId or skillName',
+    );
+    warnSpy.mockRestore();
   });
 
   it('keeps autonomy rules distinct when ids contain null bytes', () => {

--- a/tests/config-reload.integration.test.ts
+++ b/tests/config-reload.integration.test.ts
@@ -225,6 +225,9 @@ describe('config reload integration', () => {
     expect(warnSpy).toHaveBeenCalledWith(
       '[runtime-config] skipping skills.autonomy rule with empty agentId or skillName',
     );
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[runtime-config] invalid skills.autonomy level "unsupported" for agentId "writer" and skillName "bad-level"; using default "low-stakes-autonomous"',
+    );
     warnSpy.mockRestore();
   });
 

--- a/tests/config-reload.integration.test.ts
+++ b/tests/config-reload.integration.test.ts
@@ -219,6 +219,14 @@ describe('config reload integration', () => {
     expect(configMod.resolveSkillAutonomyLevel(cfg, 'writer', 'missing')).toBe(
       'low-stakes-autonomous',
     );
+    expect(() => configMod.resolveSkillAutonomyLevel(cfg, '', 'docs')).toThrow(
+      'resolveSkillAutonomyLevel requires non-empty agentId and skillName.',
+    );
+    expect(() =>
+      configMod.resolveSkillAutonomyLevel(cfg, 'writer', ''),
+    ).toThrow(
+      'resolveSkillAutonomyLevel requires non-empty agentId and skillName.',
+    );
     expect(warnSpy).toHaveBeenCalledWith(
       '[runtime-config] skipping skills.autonomy rule: expected an object',
     );

--- a/tests/runtime-config-revisions.integration.test.ts
+++ b/tests/runtime-config-revisions.integration.test.ts
@@ -184,6 +184,58 @@ describe('runtime config revisions integration', () => {
     expect(fs.existsSync(configMod.runtimeConfigRevisionPath())).toBe(true);
   });
 
+  it('restores versioned skill autonomy changes through config revisions', () => {
+    configMod.ensureRuntimeConfigFile();
+
+    configMod.updateRuntimeConfig((draft) => {
+      draft.skills.autonomy = {
+        defaultLevel: 'confirm-each',
+        rules: [
+          {
+            coworkerId: 'writer',
+            skillName: 'docs',
+            level: 'full-autonomous',
+          },
+        ],
+      };
+    });
+    configMod.updateRuntimeConfig((draft) => {
+      draft.skills.autonomy = {
+        defaultLevel: 'low-stakes-autonomous',
+        rules: [],
+      };
+    });
+
+    const revisions = configMod.listRuntimeConfigRevisions();
+    const autonomyRevision = revisions.find((revision) =>
+      configMod
+        .getRuntimeConfigRevision(revision.id)
+        ?.content.includes('"skillName": "docs"'),
+    );
+    expect(autonomyRevision).toBeTruthy();
+    if (!autonomyRevision) {
+      throw new Error('Expected a revision containing the autonomy rule.');
+    }
+
+    const restored = configMod.restoreRuntimeConfigRevision(
+      autonomyRevision.id,
+    );
+
+    expect(restored.skills.autonomy).toEqual({
+      defaultLevel: 'confirm-each',
+      rules: [
+        {
+          coworkerId: 'writer',
+          skillName: 'docs',
+          level: 'full-autonomous',
+        },
+      ],
+    });
+    expect(
+      configMod.resolveSkillAutonomyLevel(restored, 'writer', 'docs'),
+    ).toBe('full-autonomous');
+  });
+
   it('migrates the revision store for typed runtime assets', () => {
     const database = new Database(configMod.runtimeConfigRevisionPath(), {
       readonly: true,

--- a/tests/runtime-config-revisions.integration.test.ts
+++ b/tests/runtime-config-revisions.integration.test.ts
@@ -192,7 +192,7 @@ describe('runtime config revisions integration', () => {
         defaultLevel: 'confirm-each',
         rules: [
           {
-            coworkerId: 'writer',
+            agentId: 'writer',
             skillName: 'docs',
             level: 'full-autonomous',
           },
@@ -225,7 +225,7 @@ describe('runtime config revisions integration', () => {
       defaultLevel: 'confirm-each',
       rules: [
         {
-          coworkerId: 'writer',
+          agentId: 'writer',
           skillName: 'docs',
           level: 'full-autonomous',
         },


### PR DESCRIPTION
## Summary

Implements #585 by adding a versioned runtime config schema for per-agent / per-skill autonomy levels. This PR is schema and resolver groundwork only; runtime enforcement of these levels is expected in the F8.4 default-action runtime work.

## Changes

- Adds `skills.autonomy.defaultLevel` and `skills.autonomy.rules[]` to runtime config.
- Supports `full-autonomous`, `low-stakes-autonomous`, and `confirm-each` levels with a secure `confirm-each` config default.
- Uses a deliberately minimal default model: one conservative global default plus explicit agent/skill overrides, not a per-skill-class default table.
- Adds normalization, deterministic rule ordering, and `resolveSkillAutonomyLevel(...)` for future consumers.
- Aligns the existing approval-policy autonomy metadata vocabulary to the same F8.1 level names.
- Documents the new config keys in both reference docs, including that enforcement is upcoming.

## Validation

- `npm run test:integration -- tests/config-reload.integration.test.ts tests/runtime-config-revisions.integration.test.ts`
- `./node_modules/.bin/vitest run tests/approval-policy.test.ts tests/audit-events.test.ts`
- `npm run format`
- `npm run typecheck`
- `npm --prefix container run lint`
- `npm run lint`
- `git diff --check`

Closes #585.