### PR TITLE
[codex] fix web fetch SSRF guard

### DIFF
--- a/container/src/web-fetch.ts
+++ b/container/src/web-fetch.ts
@@ -3,14 +3,18 @@
  *
  * Ported from OpenClaw's web-fetch but stripped down:
  * - No Firecrawl fallback
- * - No SSRF guard framework (container is sandboxed, basic URL validation suffices)
  * - No external-content wrapping
  * - No config system — sensible hardcoded defaults
  */
 
+import { lookup } from 'node:dns/promises';
+import net from 'node:net';
+
 const DEFAULT_MAX_CHARS = 50_000;
 const MAX_RESPONSE_BYTES = 2_000_000;
 const MAX_REDIRECTS = 5;
+// One timeout budget covers SSRF DNS checks and fetches across the redirect
+// chain, so DNS latency can add up before a response body is read.
 const TIMEOUT_MS = 30_000;
 const CACHE_TTL_MS = 15 * 60_000; // 15 min
 const CACHE_MAX_ENTRIES = 100;
@@ -43,6 +47,8 @@ interface CacheEntry {
   value: WebFetchResult;
   expiresAt: number;
 }
+
+type HostBlockReason = 'private' | 'dns_failure';
 
 const cache = new Map<string, CacheEntry>();
 
@@ -278,7 +284,7 @@ async function fetchWithRedirects(
   signal: AbortSignal,
   userAgent: string,
 ): Promise<{ response: Response; finalUrl: string }> {
-  let currentUrl = url;
+  let currentUrl = (await assertFetchUrl(url)).toString();
   for (let i = 0; i <= maxRedirects; i++) {
     const res = await fetch(currentUrl, {
       redirect: 'manual',
@@ -292,13 +298,142 @@ async function fetchWithRedirects(
 
     const location = res.headers.get('location');
     if (location && res.status >= 300 && res.status < 400) {
-      // Resolve relative redirects
-      currentUrl = new URL(location, currentUrl).toString();
+      currentUrl = (
+        await assertFetchUrl(new URL(location, currentUrl))
+      ).toString();
       continue;
     }
     return { response: res, finalUrl: currentUrl };
   }
   throw new Error(`Too many redirects (max ${maxRedirects})`);
+}
+
+function normalizeHostname(hostname: string): string {
+  const normalized = hostname.trim().toLowerCase();
+  if (normalized.startsWith('[') && normalized.endsWith(']')) {
+    return normalized.slice(1, -1);
+  }
+  return normalized;
+}
+
+function isPrivateIpv4(ip: string): boolean {
+  const parts = ip.split('.').map((part) => Number.parseInt(part, 10));
+  if (
+    parts.length !== 4 ||
+    parts.some((part) => Number.isNaN(part) || part < 0 || part > 255)
+  ) {
+    return false;
+  }
+
+  const [a, b] = parts;
+  if (a === 0) return true;
+  if (a === 10 || a === 127) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a >= 224) return true;
+  return false;
+}
+
+function decodeIpv4MappedIpv6Tail(value: string): string | null {
+  if (net.isIP(value) === 4) return value;
+
+  const parts = value.split(':');
+  if (parts.length !== 2) return null;
+
+  const words = parts.map((part) => Number.parseInt(part, 16));
+  if (
+    words.some(
+      (word, index) =>
+        !/^[0-9a-f]{1,4}$/i.test(parts[index] ?? '') ||
+        Number.isNaN(word) ||
+        word < 0 ||
+        word > 0xffff,
+    )
+  ) {
+    return null;
+  }
+
+  return [
+    (words[0] >> 8) & 0xff,
+    words[0] & 0xff,
+    (words[1] >> 8) & 0xff,
+    words[1] & 0xff,
+  ].join('.');
+}
+
+function isPrivateIpv6(ip: string): boolean {
+  const lower = ip.split('%')[0] ?? '';
+  if (lower === '::') return true;
+  if (lower === '::1') return true;
+  if (lower.startsWith('fc') || lower.startsWith('fd')) return true;
+  if (/^fe[89ab]/.test(lower)) return true;
+  if (lower.startsWith('::ffff:')) {
+    const mapped = decodeIpv4MappedIpv6Tail(lower.slice('::ffff:'.length));
+    return mapped ? isPrivateIpv4(mapped) : false;
+  }
+  return false;
+}
+
+function isPrivateIp(ip: string): boolean {
+  const normalized = normalizeHostname(ip);
+  const version = net.isIP(normalized);
+  if (version === 4) return isPrivateIpv4(normalized);
+  if (version === 6) return isPrivateIpv6(normalized);
+  return false;
+}
+
+async function getHostBlockReason(
+  hostname: string,
+): Promise<HostBlockReason | null> {
+  const host = normalizeHostname(hostname);
+  if (!host) return 'private';
+  if (
+    host === 'localhost' ||
+    host.endsWith('.localhost') ||
+    host.endsWith('.local')
+  ) {
+    return 'private';
+  }
+  if (net.isIP(host) > 0) return isPrivateIp(host) ? 'private' : null;
+
+  try {
+    // This pre-connection DNS check blocks obvious private targets, but it is
+    // not a complete DNS rebinding defense. Keep container/network egress
+    // controls in place for defense in depth.
+    const resolved = await lookup(host, { all: true, verbatim: true });
+    if (resolved.length === 0) return 'dns_failure';
+    return resolved.some((entry) => isPrivateIp(entry.address))
+      ? 'private'
+      : null;
+  } catch {
+    return 'dns_failure';
+  }
+}
+
+async function assertFetchUrl(raw: string | URL): Promise<URL> {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = raw instanceof URL ? raw : new URL(raw);
+  } catch {
+    throw new Error('Invalid URL: must be http or https');
+  }
+  if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+    throw new Error('Invalid URL: must be http or https');
+  }
+  const blockReason = await getHostBlockReason(parsedUrl.hostname);
+  if (blockReason === 'dns_failure') {
+    throw new Error(
+      `Web fetch blocked by SSRF guard: DNS lookup failed for host (${parsedUrl.hostname}).`,
+    );
+  }
+  if (blockReason === 'private') {
+    throw new Error(
+      `Web fetch blocked by SSRF guard: private or loopback host (${parsedUrl.hostname}).`,
+    );
+  }
+  return parsedUrl;
 }
 
 function normalizeForDetection(value: string): string {
@@ -406,17 +541,6 @@ export async function webFetch(params: {
     100,
     Math.min(params.maxChars ?? DEFAULT_MAX_CHARS, DEFAULT_MAX_CHARS),
   );
-
-  // Validate URL
-  let parsedUrl: URL;
-  try {
-    parsedUrl = new URL(params.url);
-  } catch {
-    throw new Error('Invalid URL: must be http or https');
-  }
-  if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
-    throw new Error('Invalid URL: must be http or https');
-  }
 
   // Check cache
   const cacheKey =

--- a/tests/unit/web-fetch.test.ts
+++ b/tests/unit/web-fetch.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 afterEach(() => {
   vi.restoreAllMocks();
   vi.resetModules();
+  vi.doUnmock('node:dns/promises');
   vi.unstubAllGlobals();
 });
 
@@ -37,8 +38,10 @@ describe('web fetch Cloudflare challenge retry', () => {
     const { BOT_USER_AGENT, webFetch } = await import(
       '../../container/src/web-fetch.js'
     );
+    // Use a public literal IP so these behavior tests avoid exercising the
+    // SSRF guard's DNS lookup path.
     const result = await webFetch({
-      url: 'https://example.com/cloudflare-challenge-retry',
+      url: 'https://93.184.216.34/cloudflare-challenge-retry',
       extractMode: 'text',
     });
 
@@ -71,13 +74,120 @@ describe('web fetch Cloudflare challenge retry', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const { webFetch } = await import('../../container/src/web-fetch.js');
+    // Use a public literal IP so these behavior tests avoid exercising the
+    // SSRF guard's DNS lookup path.
     const result = await webFetch({
-      url: 'https://example.com/plain-403-no-retry',
+      url: 'https://93.184.216.34/plain-403-no-retry',
       extractMode: 'text',
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(result.status).toBe(403);
     expect(result.escalationHint).toBe('bot_blocked');
+  });
+});
+
+describe('web fetch SSRF guard', () => {
+  it('blocks literal metadata and loopback hosts before fetch', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { webFetch } = await import('../../container/src/web-fetch.js');
+
+    await expect(
+      webFetch({
+        url: 'http://169.254.169.254/latest/meta-data/',
+        extractMode: 'text',
+      }),
+    ).rejects.toThrow(/SSRF guard/);
+    await expect(
+      webFetch({ url: 'http://127.0.0.1:8080/admin', extractMode: 'text' }),
+    ).rejects.toThrow(/SSRF guard/);
+    await expect(
+      webFetch({ url: 'http://[::1]/admin', extractMode: 'text' }),
+    ).rejects.toThrow(/SSRF guard/);
+    await expect(
+      webFetch({ url: 'http://[::]/admin', extractMode: 'text' }),
+    ).rejects.toThrow(/SSRF guard/);
+    await expect(
+      webFetch({ url: 'http://[fc00::1]/admin', extractMode: 'text' }),
+    ).rejects.toThrow(/SSRF guard/);
+    await expect(
+      webFetch({ url: 'http://[fe80::1]/admin', extractMode: 'text' }),
+    ).rejects.toThrow(/SSRF guard/);
+    await expect(
+      webFetch({
+        url: 'http://[::ffff:a9fe:fea9]/latest/meta-data/',
+        extractMode: 'text',
+      }),
+    ).rejects.toThrow(/SSRF guard/);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('blocks hostnames when DNS lookup fails', async () => {
+    const lookupMock = vi.fn(async () => {
+      throw new Error('dns unavailable');
+    });
+    vi.doMock('node:dns/promises', () => ({ lookup: lookupMock }));
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { webFetch } = await import('../../container/src/web-fetch.js');
+
+    await expect(
+      webFetch({
+        url: 'https://unresolvable.example/resource',
+        extractMode: 'text',
+      }),
+    ).rejects.toThrow(/DNS lookup failed/);
+    expect(lookupMock).toHaveBeenCalledWith('unresolvable.example', {
+      all: true,
+      verbatim: true,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('blocks hostnames that resolve to private addresses', async () => {
+    const lookupMock = vi.fn(async () => [{ address: '10.0.0.12', family: 4 }]);
+    vi.doMock('node:dns/promises', () => ({ lookup: lookupMock }));
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { webFetch } = await import('../../container/src/web-fetch.js');
+
+    await expect(
+      webFetch({
+        url: 'https://metadata.internal.example/latest/meta-data/',
+        extractMode: 'text',
+      }),
+    ).rejects.toThrow(/SSRF guard/);
+    expect(lookupMock).toHaveBeenCalledWith('metadata.internal.example', {
+      all: true,
+      verbatim: true,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('blocks redirects to private hosts', async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response('', {
+        status: 302,
+        headers: {
+          Location: 'http://169.254.169.254/latest/meta-data/',
+        },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { webFetch } = await import('../../container/src/web-fetch.js');
+
+    await expect(
+      webFetch({
+        url: 'https://93.184.216.34/redirect-to-metadata',
+        extractMode: 'text',
+      }),
+    ).rejects.toThrow(/SSRF guard/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## What changed

- Added SSRF host validation to container `web_fetch` for initial requests and every redirect target.
- Blocks loopback, link-local metadata, private/reserved IPv4 ranges, IPv6 loopback/link-local/ULA, IPv4-mapped IPv6, `.localhost`, `.local`, and DNS names resolving to private IPs.
- Removed the stale header note implying container sandboxing was sufficient protection.
- Added focused unit tests for direct metadata/loopback URLs, private DNS resolution, and redirect-to-metadata attempts.

## Why

`container/src/web-fetch.ts` previously validated only URL protocol. An agent could fetch cloud metadata endpoints such as `http://169.254.169.254/...` or pivot through redirects to internal services.

## Validation

- `./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/unit/web-fetch.test.ts`
- `npm --prefix container run lint`
- `npm --prefix container run build`
- `npm run lint`