### PR TITLE
[codex] Surface security hook failures

### DIFF
--- a/container/src/extensions.ts
+++ b/container/src/extensions.ts
@@ -107,6 +107,11 @@ function describeError(error: unknown): string {
   return typeof error;
 }
 
+function describeErrorCause(error: unknown): string {
+  if (error instanceof Error && error.cause) return describeError(error.cause);
+  return describeError(error);
+}
+
 function logExtensionFailure(
   extension: string,
   hook: string,
@@ -117,6 +122,12 @@ function logExtensionFailure(
   );
 }
 
+function logHookArgumentParseFailure(hook: string, error: unknown): void {
+  console.error(
+    `[hybridclaw-agent] ${hook} failed to parse tool hook arguments (${describeErrorCause(error)})`,
+  );
+}
+
 function parseArgs(argsJson: string): Record<string, unknown> {
   try {
     const parsed = JSON.parse(argsJson) as unknown;
@@ -124,10 +135,7 @@ function parseArgs(argsJson: string): Record<string, unknown> {
       return {};
     return parsed as Record<string, unknown>;
   } catch (error) {
-    console.error(
-      `[hybridclaw-agent] failed to parse tool hook arguments (${describeError(error)})`,
-    );
-    throw new Error(INVALID_ARGS_MESSAGE);
+    throw new Error(INVALID_ARGS_MESSAGE, { cause: error });
   }
 }
 
@@ -152,7 +160,8 @@ export async function runBeforeToolHooks(
   let args: Record<string, unknown>;
   try {
     args = parseArgs(argsJson);
-  } catch {
+  } catch (error) {
+    logHookArgumentParseFailure('before-tool hook', error);
     await emitRuntimeEvent({
       event: 'before_tool_call',
       toolName,
@@ -206,7 +215,8 @@ export async function runAfterToolHooks(
   let args: Record<string, unknown>;
   try {
     args = parseArgs(argsJson);
-  } catch {
+  } catch (error) {
+    logHookArgumentParseFailure('after-tool hook', error);
     await emitRuntimeEvent({
       event: 'after_tool_call',
       toolName,

--- a/container/src/extensions.ts
+++ b/container/src/extensions.ts
@@ -100,6 +100,8 @@ const securityHookExtension: RuntimeExtension = {
 
 const runtimeExtensions: RuntimeExtension[] = [securityHookExtension];
 
+export const INVALID_ARGS_MESSAGE = 'Invalid tool hook arguments.';
+
 function describeError(error: unknown): string {
   if (error instanceof Error) return error.name;
   return typeof error;
@@ -125,7 +127,7 @@ function parseArgs(argsJson: string): Record<string, unknown> {
     console.error(
       `[hybridclaw-agent] failed to parse tool hook arguments (${describeError(error)})`,
     );
-    throw new Error('Invalid tool hook arguments.');
+    throw new Error(INVALID_ARGS_MESSAGE);
   }
 }
 
@@ -156,9 +158,9 @@ export async function runBeforeToolHooks(
       toolName,
       blocked: true,
       extension: 'runtime',
-      reason: 'Invalid tool hook arguments.',
+      reason: INVALID_ARGS_MESSAGE,
     });
-    return 'Invalid tool hook arguments.';
+    return INVALID_ARGS_MESSAGE;
   }
 
   for (const ext of runtimeExtensions) {
@@ -208,7 +210,7 @@ export async function runAfterToolHooks(
     await emitRuntimeEvent({
       event: 'after_tool_call',
       toolName,
-      hookError: 'Invalid tool hook arguments.',
+      hookError: INVALID_ARGS_MESSAGE,
     });
     return;
   }

--- a/container/src/extensions.ts
+++ b/container/src/extensions.ts
@@ -100,14 +100,32 @@ const securityHookExtension: RuntimeExtension = {
 
 const runtimeExtensions: RuntimeExtension[] = [securityHookExtension];
 
+function describeError(error: unknown): string {
+  if (error instanceof Error) return error.name;
+  return typeof error;
+}
+
+function logExtensionFailure(
+  extension: string,
+  hook: string,
+  error: unknown,
+): void {
+  console.error(
+    `[hybridclaw-agent] runtime extension "${extension}" ${hook} failed (${describeError(error)})`,
+  );
+}
+
 function parseArgs(argsJson: string): Record<string, unknown> {
   try {
     const parsed = JSON.parse(argsJson) as unknown;
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed))
       return {};
     return parsed as Record<string, unknown>;
-  } catch {
-    return {};
+  } catch (error) {
+    console.error(
+      `[hybridclaw-agent] failed to parse tool hook arguments (${describeError(error)})`,
+    );
+    throw new Error('Invalid tool hook arguments.');
   }
 }
 
@@ -118,7 +136,8 @@ export async function emitRuntimeEvent(
     if (!ext.onEvent) continue;
     try {
       await ext.onEvent(payload);
-    } catch {
+    } catch (error) {
+      logExtensionFailure(ext.name, 'onEvent hook', error);
       // Best effort: extension errors should not break request handling.
     }
   }
@@ -128,7 +147,20 @@ export async function runBeforeToolHooks(
   toolName: string,
   argsJson: string,
 ): Promise<string | null> {
-  const args = parseArgs(argsJson);
+  let args: Record<string, unknown>;
+  try {
+    args = parseArgs(argsJson);
+  } catch {
+    await emitRuntimeEvent({
+      event: 'before_tool_call',
+      toolName,
+      blocked: true,
+      extension: 'runtime',
+      reason: 'Invalid tool hook arguments.',
+    });
+    return 'Invalid tool hook arguments.';
+  }
+
   for (const ext of runtimeExtensions) {
     if (!ext.onBeforeToolCall) continue;
     try {
@@ -143,8 +175,17 @@ export async function runBeforeToolHooks(
         });
         return blocked;
       }
-    } catch {
-      // ignore broken extensions
+    } catch (error) {
+      logExtensionFailure(ext.name, 'onBeforeToolCall hook', error);
+      const reason = `Runtime extension "${ext.name}" failed while checking tool permissions.`;
+      await emitRuntimeEvent({
+        event: 'before_tool_call',
+        toolName,
+        blocked: true,
+        extension: ext.name,
+        reason,
+      });
+      return reason;
     }
   }
   await emitRuntimeEvent({
@@ -160,13 +201,25 @@ export async function runAfterToolHooks(
   argsJson: string,
   result: string,
 ): Promise<void> {
-  const args = parseArgs(argsJson);
+  let args: Record<string, unknown>;
+  try {
+    args = parseArgs(argsJson);
+  } catch {
+    await emitRuntimeEvent({
+      event: 'after_tool_call',
+      toolName,
+      hookError: 'Invalid tool hook arguments.',
+    });
+    return;
+  }
+
   for (const ext of runtimeExtensions) {
     if (!ext.onAfterToolCall) continue;
     try {
       await ext.onAfterToolCall(toolName, args, result);
-    } catch {
-      // ignore broken extensions
+    } catch (error) {
+      logExtensionFailure(ext.name, 'onAfterToolCall hook', error);
+      // Best effort: after-tool extension errors should not mask tool results.
     }
   }
   await emitRuntimeEvent({ event: 'after_tool_call', toolName });

--- a/container/src/extensions.ts
+++ b/container/src/extensions.ts
@@ -220,7 +220,7 @@ export async function runAfterToolHooks(
     await emitRuntimeEvent({
       event: 'after_tool_call',
       toolName,
-      hookError: INVALID_ARGS_MESSAGE,
+      reason: INVALID_ARGS_MESSAGE,
     });
     return;
   }

--- a/src/utils/secret-prompt.ts
+++ b/src/utils/secret-prompt.ts
@@ -57,6 +57,16 @@ function shouldUseDedicatedSecretTty(): boolean {
   return process.stdin.listenerCount('data') > 0;
 }
 
+function reportSecretTtyCleanupFailure(
+  target: 'input' | 'output',
+  error: unknown,
+): void {
+  console.error(
+    `[hybridclaw] failed to close dedicated secret TTY ${target} descriptor:`,
+    error,
+  );
+}
+
 function openDedicatedSecretTty(): {
   input: tty.ReadStream;
   output: tty.WriteStream;
@@ -88,12 +98,16 @@ function openDedicatedSecretTty(): {
     if (inputFd !== null) {
       try {
         fs.closeSync(inputFd);
-      } catch {}
+      } catch (error) {
+        reportSecretTtyCleanupFailure('input', error);
+      }
     }
     if (outputFd !== null && outputFd !== inputFd) {
       try {
         fs.closeSync(outputFd);
-      } catch {}
+      } catch (error) {
+        reportSecretTtyCleanupFailure('output', error);
+      }
     }
     return null;
   }

--- a/tests/container.extensions.test.ts
+++ b/tests/container.extensions.test.ts
@@ -88,4 +88,20 @@ describe('container runtime extensions', () => {
       ),
     ).resolves.toBeNull();
   });
+
+  test('fails closed when before-tool hook arguments are malformed', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const { runBeforeToolHooks } = await import(
+      '../container/src/extensions.js'
+    );
+
+    await expect(runBeforeToolHooks('bash', '{bad json')).resolves.toBe(
+      'Invalid tool hook arguments.',
+    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[hybridclaw-agent] failed to parse tool hook arguments (SyntaxError)',
+    );
+  });
 });

--- a/tests/container.extensions.test.ts
+++ b/tests/container.extensions.test.ts
@@ -101,7 +101,7 @@ describe('container runtime extensions', () => {
       INVALID_ARGS_MESSAGE,
     );
     expect(consoleErrorSpy).toHaveBeenCalledWith(
-      '[hybridclaw-agent] failed to parse tool hook arguments (SyntaxError)',
+      '[hybridclaw-agent] before-tool hook failed to parse tool hook arguments (SyntaxError)',
     );
   });
 });

--- a/tests/container.extensions.test.ts
+++ b/tests/container.extensions.test.ts
@@ -93,12 +93,12 @@ describe('container runtime extensions', () => {
     const consoleErrorSpy = vi
       .spyOn(console, 'error')
       .mockImplementation(() => undefined);
-    const { runBeforeToolHooks } = await import(
+    const { INVALID_ARGS_MESSAGE, runBeforeToolHooks } = await import(
       '../container/src/extensions.js'
     );
 
     await expect(runBeforeToolHooks('bash', '{bad json')).resolves.toBe(
-      'Invalid tool hook arguments.',
+      INVALID_ARGS_MESSAGE,
     );
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       '[hybridclaw-agent] failed to parse tool hook arguments (SyntaxError)',


### PR DESCRIPTION
## Summary

This fixes silent failure paths in secret prompt cleanup and container runtime extension hooks.

## Root Cause

Several security-sensitive catch blocks swallowed failures without telemetry. In the container runtime, malformed hook arguments or broken before-tool extensions could quietly bypass approval and blocking checks by returning an empty argument object or ignoring the hook error.

## Changes

- Report dedicated secret TTY descriptor cleanup failures without logging secret input.
- Add container runtime extension failure telemetry that identifies the hook and error type without dumping hook arguments.
- Fail closed when before-tool hook argument parsing fails or a before-tool extension throws.
- Keep non-blocking event and after-tool hooks best-effort, but log failures.
- Add unit coverage for malformed before-tool hook arguments.

## Validation

- `./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/container.extensions.test.ts tests/secret-prompt.test.ts`
- `npm run lint`
- `npm --prefix container run lint`