### PR TITLE
docs(roadmap): rename + adopt Agent vs Coworker convention

### DIFF
--- a/docs/content/internal/roadmap.md
+++ b/docs/content/internal/roadmap.md
@@ -11,28 +11,30 @@ description: Internal product roadmap derived from the Trusted Coworker Manifest
 
 The roadmap is anchored in the [Trusted Coworker Manifesto](../manifesto.md). Numbers in *italic* below each feature link the work back to the principle it serves.
 
+> **Naming convention.** Product, manifesto, and marketing surfaces use **Coworker** (*"hire Lena"*). Code, admin UI, CV, scoreboard, types, and APIs use **Agent**. The two refer to the same entity. This roadmap uses *Agent* in technical descriptions and reverts to *Coworker* when paraphrasing the manifesto. See `docs/content/manifesto.md` for the customer-facing voice.
+
 | # | Feature | Description | Priority |
 |---|---------|-------------|----------|
 | 21 | **Business-skill pipeline + first 5 production skills** | Opinionated, ready-on-day-one skills (Salesforce, HubSpot, SAP, GA4, NL→SQL on warehouse) on top of a shared packaging + lifecycle framework. *Principle I — the skills are the product.* | P0 |
-| 1 | **Agent-to-agent messaging** | First-class primitive for one coworker to message, hand off, or escalate to another. Persisted envelopes; intent typed; integrates with the hash-chain audit log. *Principle VI.* | P0 |
+| 1 | **Agent-to-agent messaging** | First-class primitive for one agent to message, hand off, or escalate to another. Persisted envelopes; intent typed; integrates with the hash-chain audit log. *Principle VI.* | P0 |
 | 2 | **Workflow engine — autonomous-by-default with high-stakes escalation** | Declarative YAML workflows. Sequential runner; escalation gates only on high-stakes steps (driven by F8 stakes classifier — **not** approval-by-default). Return-for-revision rewinds. Built on top of #1. *Principles II + VI.* | P0 |
-| 3 | **Coworker scoreboard + auto-`CV.md`** | Per-skill score data model populated from the skill-run event bus. Auto-rendered CV per coworker; admin scoreboard; "best at X" recommendation API. *Principle IV.* | P0 |
+| 3 | **Agent scoreboard + auto-`CV.md`** | Per-skill score data model populated from the skill-run event bus. Auto-rendered CV per agent; admin scoreboard; "best at X" recommendation API. *Principle IV.* | P0 |
 | 4 | **Business-secret masking + demasking** | Extends `confidential-redact.ts` with NDA / client / price / contract classes. Round-trip placeholder scheme; post-LLM rehydrator; mask/demask events on the audit log. *Principle VII.* | P0 |
-| 5 | **Token / money budgets per coworker** | Per-coworker monthly € cap backed by existing `UsageTotals`. Soft-warn at threshold, hard-stop via the policy engine, per-skill sub-limits. *Principle IX.* | P0 |
+| 5 | **Token / money budgets per agent** | Per-agent monthly € cap backed by existing `UsageTotals`. Soft-warn at threshold, hard-stop via the policy engine, per-skill sub-limits. *Principle IX.* | P0 |
 | 6 | **NDA / secret-leak classifier** | Classifier on every prompt and response, fed by the skill-run event bus. Block / warn / log via policy engine; eval suite extends the existing harness. *Principle VII.* | P0 |
-| 7 | **Shared enterprise memory** | RAG over team docs / CRM / wiki, available in self-hosted HC. Pluggable vector store, per-coworker source scoping, retrieval-quality eval suite. *Principle I.* | P1 |
+| 7 | **Shared enterprise memory** | RAG over team docs / CRM / wiki, available in self-hosted HC. Pluggable vector store, per-agent source scoping, retrieval-quality eval suite. *Principle I.* | P1 |
 | 8 | **Brand-voice + output classifier** | Per-tenant voice profile (do / don't, tone, banned phrases). Pre-ship classifier on responses; block / rewrite via policy engine. *Principle VII.* | P1 |
 | 9 | **Hierarchical swarm — HC1 delegates to HC2** | Cross-instance delegation. Signed delegation tokens, transport over HTTP, audit-log linking across instances. *Principle VI.* | P1 |
 | 10 | **Auto fine-tuning on real tasks** | Trajectory capture → PII scrub → per-customer training data → fine-tuning pipeline → tuned-model registry with eval gate before promotion. *Principle VIII.* | P1 |
 | 11 | **Operator notification windows + escalation routing** | *Reframed under v3 Principle III.* The coworker is always on; this issue covers per-operator notification preferences (when to page vs. queue for the morning summary) and escalation routing through F8. | P2 |
 | 12 | **Mobile-first admin (iOS / Android wrapper)** | Responsive admin pages, mobile-friendly approval flow, push notifications, native wrappers via Capacitor or React Native. *Principle X.* | P1 |
 | 13 | **Per-client cost & audit reports** | Client tagging on activity, per-client cost rollup extending #5, per-client audit-log filter, branded PDF export. *Principle VII.* | P1 |
-| 14 | **SSO + RBAC** | OAuth2 / OIDC framework with Okta, Google Workspace, Microsoft Entra providers. Role + permission model; per-coworker access policies for human users. *Principle VII.* | P1 |
-| 15 | **Coworker handoff with context transfer** | Extends the `handoff` intent from #1 to carry a context bundle (thread refs, brief, client tags). Recipient absorbs context before resuming. *Principle VI.* | P2 |
+| 14 | **SSO + RBAC** | OAuth2 / OIDC framework with Okta, Google Workspace, Microsoft Entra providers. Role + permission model; per-agent access policies for human users. *Principle VII.* | P1 |
+| 15 | **Agent handoff with context transfer** | Extends the `handoff` intent from #1 to carry a context bundle (thread refs, brief, client tags). Recipient absorbs context before resuming. *Principle VI.* | P2 |
 | 16 | **Skill A/B testing + canary deployments** | Variant routing by deterministic hash, per-variant metrics from the event bus, statistical comparison, promotion gate via the eval harness. *Principle VIII.* | P2 |
-| 17 | **Coworker references / portfolio export** | Anonymized portfolio bundle (work samples + scores). Export and import flows so a coworker template can be instantiated on a fresh instance. *Principle IV.* | P2 |
+| 17 | **Agent references / portfolio export** | Anonymized portfolio bundle (work samples + scores). Export and import flows so an agent template can be instantiated on a fresh instance. *Principle IV.* | P2 |
 | 18 | **Voice / outbound phone channel** | Twilio Programmable Voice for outbound dial. Existing TTS plus STT for callee responses; call-flow primitive; transcript on the audit log. *Principle V.* | P2 |
-| 19 | **Calendar / meeting presence** | Bot joins Zoom / Meet, real-time STT, live notes, post-meeting summary, action-item dispatch via #1 to other coworkers. *Principle V.* | P2 |
+| 19 | **Calendar / meeting presence** | Bot joins Zoom / Meet, real-time STT, live notes, post-meeting summary, action-item dispatch via #1 to other agents. *Principle V.* | P2 |
 | 20 | **Right-to-be-forgotten / GDPR data export** | Identifier registry, cascading data discovery, audited deletion, machine + human readable export. Hash-chain entry of the deletion preserved. *Principle VII.* | P2 |
 
 ---
@@ -48,9 +50,9 @@ Cross-cutting work that several roadmap items depend on. Decomposed under the `f
 - **F5** — Model pricing & capability matrix on top of `model-catalog`. Required by #5 cost compute and future routing.
 - **F6** — Deployment-mode + public-URL abstraction. Cloud installs declare an external URL; local installs run a tunnel (ngrok / Cloudflare / Tailscale). Required by #9, #18, #19, and the launch smoke scenario A1 in local mode.
 - **F7** — Global identity primitives. Canonical user IDs (`username@authority`, default authority `hybridai`) and canonical agent IDs (`agent-slug@user@instance-id`), plus a resolver and TOFU trust model. Required by #1 envelope addressing, #9 cross-instance delegation, #14 SSO federation, #15 handoff, #17 portfolio refs.
-- **F8** — Autonomy + escalation policy framework. Per-coworker / per-skill autonomy levels, stakes classifier, escalation routing, default-action runtime that inverts approval-by-default. **Required by Principle II** and reframes the default behaviour of #2.
-- **F9** — Always-on runtime guarantees. Warm process pool, per-coworker liveness probe, auto-restart with backoff, fleet red/green dashboard. **Required by Principle III** ("doesn't clock out") — without it the principle is aspirational.
-- **F10** — Coworker org-chart / team primitive. Roles, reporting lines, escalation chains as first-class data — not derived from message graphs. Required by F8 escalation routing and #15 handoff context.
+- **F8** — Autonomy + escalation policy framework. Per-agent / per-skill autonomy levels, stakes classifier, escalation routing, default-action runtime that inverts approval-by-default. **Required by Principle II** and reframes the default behaviour of #2.
+- **F9** — Always-on runtime guarantees. Warm process pool, per-agent liveness probe, auto-restart with backoff, fleet red/green dashboard. **Required by Principle III** ("doesn't clock out") — without it the principle is aspirational.
+- **F10** — Agent org-chart / team primitive. Roles, reporting lines, escalation chains as first-class data — not derived from message graphs. Required by F8 escalation routing and #15 handoff context.
 
 ## Cross-cutting additions
 
@@ -58,7 +60,7 @@ Engineering hygiene that ships alongside P0:
 
 - **A1** — End-to-end smoke scenario exercising #1 + #2 + #3 + #4 + #5 + #6 in one run.
 - **A2** — `CHANGELOG.md` with manifesto-principle tags per entry.
-- **A3** — Test-fixtures library (coworkers, clients, threads, secrets).
+- **A3** — Test-fixtures library (agents, clients, threads, secrets).
 - **A4** — CI cost-regression gate against the eval suite.
 - **A5** — Threat-model document for any feature touching secrets or keys.
 

--- a/docs/content/internal/roadmap.md
+++ b/docs/content/internal/roadmap.md
@@ -1,11 +1,11 @@
 ---
-title: Trusted Coworker Roadmap
+title: Agent, That Really Works — Roadmap
 description: Internal product roadmap derived from the Trusted Coworker Manifesto. Not linked from the public docs nav.
 ---
 
 > **Internal document.** This page is intentionally excluded from the docs sidebar, navigation, and search — but it remains web-accessible by direct URL, which is how GitHub issue bodies reference it. Source of truth for roadmap planning. Tracked in the umbrella issue [HybridAIOne/hybridclaw#466](https://github.com/HybridAIOne/hybridclaw/issues/466).
 
-# Trusted Coworker Roadmap
+# Agent, That Really Works — Roadmap
 
 21 features grouped into three priority tiers. **P0** = Very High Priority (launch package). **P1** = High Priority (depth). **P2** = Priority (breadth). Sequencing within a tier is driven by technical dependencies.
 


### PR DESCRIPTION
## Summary

Two changes to [docs/content/internal/roadmap.md](docs/content/internal/roadmap.md):

1. **Adopt the team's naming convention.** Marketing/manifesto/customer-facing surfaces use **Coworker**. Code, admin UI, CV, scoreboard, types, and APIs use **Agent**. Same entity, two voices.
2. **Rename the doc** to *"Agent, That Really Works — Roadmap"* — echoes Manifesto Principle I (the agent does the work, skills are the product) and aligns with the new convention.

## Where Coworker is preserved

- `docs/content/manifesto.md` — untouched (customer-facing voice)
- Anywhere the roadmap text is paraphrasing a manifesto principle ("a coworker doesn't clock out", "coworkers in teams")
- Doc references to the *Trusted Coworker Manifesto* (the manifesto's own title)

## Where Agent is now used

- Feature names + descriptions (Roadmap 3 "Agent scoreboard + auto-CV.md", #5, #15, #17)
- Foundation descriptions (F8 per-agent autonomy, F9 per-agent liveness, F10 agent org-chart)
- Configuration scopes (per-agent monthly cap, per-agent source scoping, per-agent access policies)
- Test fixtures, recommendation surfaces, etc.

## Out of band on the issue tracker (separate from this PR)

- 8 issue titles renamed: #462, #438, #464, #471, #585, #558, #560, #601
- ~20 issue bodies updated via surgical text replacement (sed-based, only matching technical phrasings)
- Umbrella [#466](https://github.com/HybridAIOne/hybridclaw/issues/466) retitled to *"Agent, That Really Works — Roadmap (tracking issue, P0 launch package)"* with the same convention note inline

## Test plan

- [ ] Confirm the renamed roadmap renders correctly (frontmatter + h1) at the URL
- [ ] Confirm umbrella #466 displays the new title and convention note
- [ ] Spot-check 1-2 renamed issues (e.g. #462, #585) to confirm titles + bodies are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)