### PR TITLE
[codex] Add deployment config schema

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,10 +1,17 @@
 {
-  "version": 21,
+  "version": 22,
   "security": {
     "trustModelAccepted": false,
     "trustModelAcceptedAt": "",
     "trustModelVersion": "",
     "trustModelAcceptedBy": ""
+  },
+  "deployment": {
+    "mode": "local",
+    "public_url": "",
+    "tunnel": {
+      "provider": "manual"
+    }
   },
   "skills": {
     "extraDirs": [],

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -167,6 +167,11 @@ saved revision history directly.
   the auth token can stay empty in config when you store `TWILIO_AUTH_TOKEN`
   in the encrypted runtime secret store or use a SecretRef-backed
   `voice.twilio.authToken`
+- `deployment.mode`, `deployment.public_url`, and `deployment.tunnel.provider`
+  for declaring whether the gateway runs behind a cloud URL or a local tunnel;
+  cloud mode requires `deployment.public_url`, while local mode requires a
+  tunnel provider such as `manual`, `ssh`, `ngrok`, `cloudflare`, or
+  `tailscale`
 - `ops.webApiToken` or `WEB_API_TOKEN` for `/chat`, `/agents`, and `/admin`;
   when unset, localhost browser access stays open without a login prompt
 - `ops.gatewayBaseUrl` plus `ops.gatewayApiToken` or `GATEWAY_API_TOKEN` for

--- a/docs/development/reference/configuration.md
+++ b/docs/development/reference/configuration.md
@@ -133,6 +133,11 @@ leak into the saved revision metadata.
   the auth token can stay empty in config when you store `TWILIO_AUTH_TOKEN`
   in the encrypted runtime secret store or use a SecretRef-backed
   `voice.twilio.authToken`
+- `deployment.mode`, `deployment.public_url`, and `deployment.tunnel.provider`
+  for declaring whether the gateway runs behind a cloud URL or a local tunnel;
+  cloud mode requires `deployment.public_url`, while local mode requires a
+  tunnel provider such as `manual`, `ssh`, `ngrok`, `cloudflare`, or
+  `tailscale`
 - `ops.webApiToken` or `WEB_API_TOKEN` for `/chat`, `/agents`, and `/admin`;
   when unset, localhost browser access stays open without a login prompt
 - `ops.gatewayBaseUrl` plus `ops.gatewayApiToken` or `GATEWAY_API_TOKEN` for

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -242,12 +242,11 @@ export const RUNTIME_DEPLOYMENT_TUNNEL_PROVIDERS = [
 export type RuntimeDeploymentKnownTunnelProvider =
   (typeof RUNTIME_DEPLOYMENT_TUNNEL_PROVIDERS)[number];
 export type RuntimeDeploymentTunnelProvider =
-  | ''
   | RuntimeDeploymentKnownTunnelProvider
   | (string & {});
 
 export interface RuntimeDeploymentTunnelConfig {
-  provider: RuntimeDeploymentTunnelProvider;
+  provider?: RuntimeDeploymentTunnelProvider;
 }
 
 export interface RuntimeDeploymentConfig {
@@ -1711,11 +1710,11 @@ function normalizeDeploymentMode(
 
 function normalizeDeploymentTunnelProvider(
   value: unknown,
-  fallback: RuntimeDeploymentTunnelProvider,
-): RuntimeDeploymentTunnelProvider {
+  fallback: RuntimeDeploymentTunnelProvider | undefined,
+): RuntimeDeploymentTunnelProvider | undefined {
   if (typeof value !== 'string') return fallback;
   const normalized = value.trim().toLowerCase();
-  if (!normalized) return '';
+  if (!normalized) return undefined;
   if (
     (RUNTIME_DEPLOYMENT_TUNNEL_PROVIDERS as readonly string[]).includes(
       normalized,
@@ -1741,15 +1740,14 @@ export function normalizeDeploymentConfig(
 ): RuntimeDeploymentConfig {
   const raw = isRecord(value) ? value : {};
   const rawTunnel = isRecord(raw.tunnel) ? raw.tunnel : {};
+  const tunnelProvider = normalizeDeploymentTunnelProvider(
+    rawTunnel.provider,
+    fallback.tunnel.provider,
+  );
   return {
     mode: normalizeDeploymentMode(raw.mode, fallback.mode),
     public_url: normalizeOptionalBaseUrl(raw.public_url, fallback.public_url),
-    tunnel: {
-      provider: normalizeDeploymentTunnelProvider(
-        rawTunnel.provider,
-        fallback.tunnel.provider,
-      ),
-    },
+    tunnel: tunnelProvider ? { provider: tunnelProvider } : {},
   };
 }
 

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -95,7 +95,7 @@ import {
 import { DEFAULT_RUNTIME_HOME_DIR } from './runtime-paths.js';
 
 export const CONFIG_FILE_NAME = 'config.json';
-export const CONFIG_VERSION = 21;
+export const CONFIG_VERSION = 22;
 export const SECURITY_POLICY_VERSION = '2026-02-28';
 export const DEFAULT_HYBRIDAI_MODEL = 'gpt-5.4-mini';
 const LEGACY_DEFAULT_DB_PATH = 'data/hybridclaw.db';
@@ -231,6 +231,24 @@ export type RuntimeAudioTranscriptionProvider =
   | 'groq'
   | 'deepgram'
   | 'google';
+export type RuntimeDeploymentMode = 'cloud' | 'local';
+export type RuntimeDeploymentTunnelProvider =
+  | ''
+  | 'cloudflare'
+  | 'manual'
+  | 'ngrok'
+  | 'ssh'
+  | 'tailscale';
+
+export interface RuntimeDeploymentTunnelConfig {
+  provider: RuntimeDeploymentTunnelProvider;
+}
+
+export interface RuntimeDeploymentConfig {
+  mode: RuntimeDeploymentMode;
+  public_url: string;
+  tunnel: RuntimeDeploymentTunnelConfig;
+}
 
 export interface RuntimeAudioProviderModelConfig {
   type: 'provider';
@@ -581,6 +599,7 @@ const skillAutonomyRuleIndexes = new WeakMap<
 export interface RuntimeConfig {
   version: number;
   security: RuntimeSecurityConfig;
+  deployment: RuntimeDeploymentConfig;
   agents: AgentsConfig;
   skills: {
     extraDirs: string[];
@@ -949,6 +968,13 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
     trustModelAcceptedAt: '',
     trustModelVersion: '',
     trustModelAcceptedBy: '',
+  },
+  deployment: {
+    mode: 'local',
+    public_url: '',
+    tunnel: {
+      provider: 'manual',
+    },
   },
   agents: {
     defaultAgentId: DEFAULT_AGENT_ID,
@@ -1660,6 +1686,67 @@ function normalizeStringArray(value: unknown, fallback: string[]): string[] {
   }
 
   return fallback;
+}
+
+function normalizeOptionalBaseUrl(value: unknown, fallback: string): string {
+  const candidate = normalizeString(value, fallback, { allowEmpty: true });
+  return candidate ? candidate.replace(/\/+$/, '') : '';
+}
+
+function normalizeDeploymentMode(
+  value: unknown,
+  fallback: RuntimeDeploymentMode,
+): RuntimeDeploymentMode {
+  if (typeof value !== 'string') return fallback;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'cloud' || normalized === 'local') return normalized;
+  return fallback;
+}
+
+function normalizeDeploymentTunnelProvider(
+  value: unknown,
+  fallback: RuntimeDeploymentTunnelProvider,
+): RuntimeDeploymentTunnelProvider {
+  if (typeof value !== 'string') return fallback;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return '';
+  if (
+    normalized === 'cloudflare' ||
+    normalized === 'manual' ||
+    normalized === 'ngrok' ||
+    normalized === 'ssh' ||
+    normalized === 'tailscale'
+  ) {
+    return normalized;
+  }
+  if (normalized === 'cloudflared' || normalized === 'cloudflare-tunnel') {
+    return 'cloudflare';
+  }
+  if (normalized === 'tailscale-funnel' || normalized === 'tailscale-serve') {
+    return 'tailscale';
+  }
+  if (normalized === 'reverse-proxy' || normalized === 'proxy') {
+    return 'manual';
+  }
+  return '';
+}
+
+function normalizeDeploymentConfig(
+  value: unknown,
+  fallback: RuntimeDeploymentConfig,
+): RuntimeDeploymentConfig {
+  const raw = isRecord(value) ? value : {};
+  const rawTunnel = isRecord(raw.tunnel) ? raw.tunnel : {};
+  return {
+    mode: normalizeDeploymentMode(raw.mode, fallback.mode),
+    public_url: normalizeOptionalBaseUrl(raw.public_url, fallback.public_url),
+    tunnel: {
+      provider: normalizeDeploymentTunnelProvider(
+        rawTunnel.provider,
+        fallback.tunnel.provider,
+      ),
+    },
+  };
 }
 
 function normalizeSkillAutonomyLevel(
@@ -4166,6 +4253,7 @@ function normalizeRuntimeConfig(
   const raw = patch ?? {};
 
   const rawSecurity = isRecord(raw.security) ? raw.security : {};
+  const rawDeployment = isRecord(raw.deployment) ? raw.deployment : {};
   const rawAgents = isRecord(raw.agents) ? raw.agents : {};
   const rawSkills = isRecord(raw.skills) ? raw.skills : {};
   const rawPlugins = isRecord(raw.plugins) ? raw.plugins : {};
@@ -4505,6 +4593,10 @@ function normalizeRuntimeConfig(
         { allowEmpty: true },
       ),
     },
+    deployment: normalizeDeploymentConfig(
+      rawDeployment,
+      DEFAULT_RUNTIME_CONFIG.deployment,
+    ),
     agents: normalizeAgentsConfig(rawAgents, DEFAULT_RUNTIME_CONFIG.agents),
     skills: {
       extraDirs: normalizeStringArray(

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -1731,7 +1731,7 @@ function normalizeDeploymentTunnelProvider(
   return '';
 }
 
-function normalizeDeploymentConfig(
+export function normalizeDeploymentConfig(
   value: unknown,
   fallback: RuntimeDeploymentConfig,
 ): RuntimeDeploymentConfig {

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -5943,6 +5943,12 @@ function migrateConfigSchemaOnStartup(): void {
     return;
   }
 
+  if (migrated.deployment.mode === 'cloud' && !migrated.deployment.public_url) {
+    console.warn(
+      '[runtime-config] deployment.mode is "cloud" but deployment.public_url is empty; inbound webhooks and public callbacks may fail until a public URL is configured',
+    );
+  }
+
   try {
     const parsedRecord = parsed as Record<string, unknown>;
     const rawContainer = isRecord(parsedRecord.container)

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -232,13 +232,19 @@ export type RuntimeAudioTranscriptionProvider =
   | 'deepgram'
   | 'google';
 export type RuntimeDeploymentMode = 'cloud' | 'local';
+export const RUNTIME_DEPLOYMENT_TUNNEL_PROVIDERS = [
+  'cloudflare',
+  'manual',
+  'ngrok',
+  'ssh',
+  'tailscale',
+] as const;
+export type RuntimeDeploymentKnownTunnelProvider =
+  (typeof RUNTIME_DEPLOYMENT_TUNNEL_PROVIDERS)[number];
 export type RuntimeDeploymentTunnelProvider =
   | ''
-  | 'cloudflare'
-  | 'manual'
-  | 'ngrok'
-  | 'ssh'
-  | 'tailscale';
+  | RuntimeDeploymentKnownTunnelProvider
+  | (string & {});
 
 export interface RuntimeDeploymentTunnelConfig {
   provider: RuntimeDeploymentTunnelProvider;
@@ -1711,13 +1717,11 @@ function normalizeDeploymentTunnelProvider(
   const normalized = value.trim().toLowerCase();
   if (!normalized) return '';
   if (
-    normalized === 'cloudflare' ||
-    normalized === 'manual' ||
-    normalized === 'ngrok' ||
-    normalized === 'ssh' ||
-    normalized === 'tailscale'
+    (RUNTIME_DEPLOYMENT_TUNNEL_PROVIDERS as readonly string[]).includes(
+      normalized,
+    )
   ) {
-    return normalized;
+    return normalized as RuntimeDeploymentKnownTunnelProvider;
   }
   if (normalized === 'cloudflared' || normalized === 'cloudflare-tunnel') {
     return 'cloudflare';
@@ -1728,7 +1732,7 @@ function normalizeDeploymentTunnelProvider(
   if (normalized === 'reverse-proxy' || normalized === 'proxy') {
     return 'manual';
   }
-  return '';
+  return normalized;
 }
 
 export function normalizeDeploymentConfig(

--- a/src/doctor/checks/config.ts
+++ b/src/doctor/checks/config.ts
@@ -276,18 +276,16 @@ function hasInvalidDeploymentMode(
 
 function hasInvalidDeploymentTunnelProvider(
   rawDeployment: Record<string, unknown> | null,
-  provider: string,
+  provider: string | undefined,
 ): boolean {
   const rawTunnel = rawDeployment?.tunnel;
   if (!rawTunnel || typeof rawTunnel !== 'object' || Array.isArray(rawTunnel)) {
     return false;
   }
   if (!Object.hasOwn(rawTunnel, 'provider')) return false;
-  return (
-    provider !== '' &&
-    !(RUNTIME_DEPLOYMENT_TUNNEL_PROVIDERS as readonly string[]).includes(
-      provider,
-    )
+  if (!provider) return false;
+  return !(RUNTIME_DEPLOYMENT_TUNNEL_PROVIDERS as readonly string[]).includes(
+    provider,
   );
 }
 

--- a/src/doctor/checks/config.ts
+++ b/src/doctor/checks/config.ts
@@ -8,6 +8,7 @@ import {
   getRuntimeConfig,
   getRuntimeDisabledToolNames,
   normalizeDeploymentConfig,
+  RUNTIME_DEPLOYMENT_TUNNEL_PROVIDERS,
   runtimeConfigPath,
   setRuntimeToolEnabled,
   updateRuntimeConfig,
@@ -273,6 +274,23 @@ function hasInvalidDeploymentMode(
   return localFallback.mode !== cloudFallback.mode;
 }
 
+function hasInvalidDeploymentTunnelProvider(
+  rawDeployment: Record<string, unknown> | null,
+  provider: string,
+): boolean {
+  const rawTunnel = rawDeployment?.tunnel;
+  if (!rawTunnel || typeof rawTunnel !== 'object' || Array.isArray(rawTunnel)) {
+    return false;
+  }
+  if (!Object.hasOwn(rawTunnel, 'provider')) return false;
+  return (
+    provider !== '' &&
+    !(RUNTIME_DEPLOYMENT_TUNNEL_PROVIDERS as readonly string[]).includes(
+      provider,
+    )
+  );
+}
+
 function getDeploymentConfigIssues(rawConfig: Record<string, unknown>): {
   missingFields: string[];
   invalidFields: string[];
@@ -289,6 +307,16 @@ function getDeploymentConfigIssues(rawConfig: Record<string, unknown>): {
   const invalidDeploymentMode = hasInvalidDeploymentMode(rawDeployment);
   if (invalidDeploymentMode) {
     invalidFields.push('deployment.mode must be "cloud" or "local"');
+  }
+  if (
+    hasInvalidDeploymentTunnelProvider(
+      rawDeployment,
+      deployment.tunnel.provider,
+    )
+  ) {
+    invalidFields.push(
+      `deployment.tunnel.provider must be one of ${RUNTIME_DEPLOYMENT_TUNNEL_PROVIDERS.join(', ')}`,
+    );
   }
 
   if (!invalidDeploymentMode) {

--- a/src/doctor/checks/config.ts
+++ b/src/doctor/checks/config.ts
@@ -286,15 +286,18 @@ function getDeploymentConfigIssues(rawConfig: Record<string, unknown>): {
     DEFAULT_RUNTIME_CONFIG.deployment,
   );
 
-  if (hasInvalidDeploymentMode(rawDeployment)) {
+  const invalidDeploymentMode = hasInvalidDeploymentMode(rawDeployment);
+  if (invalidDeploymentMode) {
     invalidFields.push('deployment.mode must be "cloud" or "local"');
   }
 
-  if (deployment.mode === 'cloud' && !deployment.public_url) {
-    missingFields.push('deployment.public_url');
-  }
-  if (deployment.mode === 'local' && !deployment.tunnel.provider) {
-    missingFields.push('deployment.tunnel.provider');
+  if (!invalidDeploymentMode) {
+    if (deployment.mode === 'cloud' && !deployment.public_url) {
+      missingFields.push('deployment.public_url');
+    }
+    if (deployment.mode === 'local' && !deployment.tunnel.provider) {
+      missingFields.push('deployment.tunnel.provider');
+    }
   }
   if (deployment.public_url && !isHttpUrl(deployment.public_url)) {
     invalidFields.push('deployment.public_url must be an HTTP(S) URL');

--- a/src/doctor/checks/config.ts
+++ b/src/doctor/checks/config.ts
@@ -3,9 +3,11 @@ import { buildMcpServerNamespaces } from '../../../container/shared/mcp-tool-nam
 import { listKnownToolNames } from '../../agent/tool-summary.js';
 import {
   CONFIG_VERSION,
+  DEFAULT_RUNTIME_CONFIG,
   ensureRuntimeConfigFile,
   getRuntimeConfig,
   getRuntimeDisabledToolNames,
+  normalizeDeploymentConfig,
   runtimeConfigPath,
   setRuntimeToolEnabled,
   updateRuntimeConfig,
@@ -34,8 +36,15 @@ type UsageEntry = UnusedEntry & {
   toolNames: string[];
 };
 
-// Deployment fields were introduced in config v22 and older configs remain valid without them.
-const MIN_DEPLOYMENT_SCHEMA_VERSION = 22;
+const LOCAL_DEPLOYMENT_MODE_FALLBACK = {
+  ...DEFAULT_RUNTIME_CONFIG.deployment,
+  mode: 'local',
+} satisfies typeof DEFAULT_RUNTIME_CONFIG.deployment;
+
+const CLOUD_DEPLOYMENT_MODE_FALLBACK = {
+  ...DEFAULT_RUNTIME_CONFIG.deployment,
+  mode: 'cloud',
+} satisfies typeof DEFAULT_RUNTIME_CONFIG.deployment;
 
 function formatUnusedEntries(entries: readonly UnusedEntry[]): string {
   return entries
@@ -249,27 +258,19 @@ function getRawDeployment(
   return rawDeployment as Record<string, unknown>;
 }
 
-function getRawDeploymentField(
-  rawConfig: Record<string, unknown>,
-  key: string,
-): unknown {
-  const rawDeployment = getRawDeployment(rawConfig);
-  if (!rawDeployment) return undefined;
-  if (!Object.hasOwn(rawDeployment, key)) return undefined;
-  return rawDeployment[key];
-}
-
-function getRawDeploymentTunnelProvider(
-  rawConfig: Record<string, unknown>,
-  fallback: string,
-): string {
-  const rawDeployment = getRawDeployment(rawConfig);
-  const rawTunnel = rawDeployment?.tunnel;
-  if (!rawTunnel || typeof rawTunnel !== 'object' || Array.isArray(rawTunnel)) {
-    return fallback;
-  }
-  const rawProvider = (rawTunnel as Record<string, unknown>).provider;
-  return typeof rawProvider === 'string' ? rawProvider.trim() : fallback;
+function hasInvalidDeploymentMode(
+  rawDeployment: Record<string, unknown> | null,
+): boolean {
+  if (!rawDeployment || !Object.hasOwn(rawDeployment, 'mode')) return false;
+  const localFallback = normalizeDeploymentConfig(
+    rawDeployment,
+    LOCAL_DEPLOYMENT_MODE_FALLBACK,
+  );
+  const cloudFallback = normalizeDeploymentConfig(
+    rawDeployment,
+    CLOUD_DEPLOYMENT_MODE_FALLBACK,
+  );
+  return localFallback.mode !== cloudFallback.mode;
 }
 
 function getDeploymentConfigIssues(rawConfig: Record<string, unknown>): {
@@ -279,39 +280,22 @@ function getDeploymentConfigIssues(rawConfig: Record<string, unknown>): {
   const missingFields: string[] = [];
   const invalidFields: string[] = [];
   const rawDeployment = getRawDeployment(rawConfig);
-  const hasCurrentDeploymentSchema =
-    rawDeployment !== null ||
-    (typeof rawConfig.version === 'number' &&
-      rawConfig.version >= MIN_DEPLOYMENT_SCHEMA_VERSION);
-  const rawMode = getRawDeploymentField(rawConfig, 'mode');
-  const normalizedRawMode =
-    typeof rawMode === 'string' ? rawMode.trim().toLowerCase() : '';
-  const deploymentMode =
-    normalizedRawMode === 'cloud' || normalizedRawMode === 'local'
-      ? normalizedRawMode
-      : 'local';
-  const rawPublicUrl = getRawDeploymentField(rawConfig, 'public_url');
-  const publicUrl = typeof rawPublicUrl === 'string' ? rawPublicUrl.trim() : '';
-  const tunnelProvider = getRawDeploymentTunnelProvider(
-    rawConfig,
-    hasCurrentDeploymentSchema ? '' : 'manual',
+  const deployment = normalizeDeploymentConfig(
+    rawDeployment,
+    DEFAULT_RUNTIME_CONFIG.deployment,
   );
 
-  if (
-    rawMode !== undefined &&
-    normalizedRawMode !== 'cloud' &&
-    normalizedRawMode !== 'local'
-  ) {
+  if (hasInvalidDeploymentMode(rawDeployment)) {
     invalidFields.push('deployment.mode must be "cloud" or "local"');
   }
 
-  if (deploymentMode === 'cloud' && !publicUrl) {
+  if (deployment.mode === 'cloud' && !deployment.public_url) {
     missingFields.push('deployment.public_url');
   }
-  if (deploymentMode === 'local' && !tunnelProvider) {
+  if (deployment.mode === 'local' && !deployment.tunnel.provider) {
     missingFields.push('deployment.tunnel.provider');
   }
-  if (publicUrl && !isHttpUrl(publicUrl)) {
+  if (deployment.public_url && !isHttpUrl(deployment.public_url)) {
     invalidFields.push('deployment.public_url must be an HTTP(S) URL');
   }
 

--- a/src/doctor/checks/config.ts
+++ b/src/doctor/checks/config.ts
@@ -34,7 +34,8 @@ type UsageEntry = UnusedEntry & {
   toolNames: string[];
 };
 
-const DEPLOYMENT_CONFIG_VERSION = 22;
+// Deployment fields were introduced in config v22 and older configs remain valid without them.
+const MIN_DEPLOYMENT_SCHEMA_VERSION = 22;
 
 function formatUnusedEntries(entries: readonly UnusedEntry[]): string {
   return entries
@@ -281,7 +282,7 @@ function getDeploymentConfigIssues(rawConfig: Record<string, unknown>): {
   const hasCurrentDeploymentSchema =
     rawDeployment !== null ||
     (typeof rawConfig.version === 'number' &&
-      rawConfig.version >= DEPLOYMENT_CONFIG_VERSION);
+      rawConfig.version >= MIN_DEPLOYMENT_SCHEMA_VERSION);
   const rawMode = getRawDeploymentField(rawConfig, 'mode');
   const normalizedRawMode =
     typeof rawMode === 'string' ? rawMode.trim().toLowerCase() : '';

--- a/src/doctor/checks/config.ts
+++ b/src/doctor/checks/config.ts
@@ -280,6 +280,7 @@ function getDeploymentConfigIssues(rawConfig: Record<string, unknown>): {
   const missingFields: string[] = [];
   const invalidFields: string[] = [];
   const rawDeployment = getRawDeployment(rawConfig);
+  // Missing deployment fields fall back to defaults so pre-v22 configs do not fail config check.
   const deployment = normalizeDeploymentConfig(
     rawDeployment,
     DEFAULT_RUNTIME_CONFIG.deployment,

--- a/src/doctor/checks/config.ts
+++ b/src/doctor/checks/config.ts
@@ -6,6 +6,7 @@ import {
   ensureRuntimeConfigFile,
   getRuntimeConfig,
   getRuntimeDisabledToolNames,
+  type RuntimeConfig,
   runtimeConfigPath,
   setRuntimeToolEnabled,
   updateRuntimeConfig,
@@ -223,6 +224,67 @@ function buildUnusedMcpServersResult(
   );
 }
 
+function isHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function getRawDeploymentField(
+  rawConfig: Record<string, unknown>,
+  key: string,
+): unknown {
+  const rawDeployment = rawConfig.deployment;
+  if (
+    !rawDeployment ||
+    typeof rawDeployment !== 'object' ||
+    Array.isArray(rawDeployment)
+  ) {
+    return undefined;
+  }
+  if (!Object.hasOwn(rawDeployment, key)) return undefined;
+  return (rawDeployment as Record<string, unknown>)[key];
+}
+
+function getDeploymentConfigIssues(
+  config: RuntimeConfig,
+  rawConfig: Record<string, unknown>,
+): {
+  missingFields: string[];
+  invalidFields: string[];
+} {
+  const missingFields: string[] = [];
+  const invalidFields: string[] = [];
+  const publicUrl = config.deployment.public_url.trim();
+  const tunnelProvider = config.deployment.tunnel.provider.trim();
+  const rawMode = getRawDeploymentField(rawConfig, 'mode');
+  const normalizedRawMode =
+    typeof rawMode === 'string' ? rawMode.trim().toLowerCase() : '';
+
+  if (
+    rawMode !== undefined &&
+    normalizedRawMode !== 'cloud' &&
+    normalizedRawMode !== 'local'
+  ) {
+    invalidFields.push('deployment.mode must be "cloud" or "local"');
+  }
+
+  if (config.deployment.mode === 'cloud' && !publicUrl) {
+    missingFields.push('deployment.public_url');
+  }
+  if (config.deployment.mode === 'local' && !tunnelProvider) {
+    missingFields.push('deployment.tunnel.provider');
+  }
+  if (publicUrl && !isHttpUrl(publicUrl)) {
+    invalidFields.push('deployment.public_url must be an HTTP(S) URL');
+  }
+
+  return { missingFields, invalidFields };
+}
+
 export async function checkConfigFile(): Promise<DiagResult[]> {
   const filePath = runtimeConfigPath();
   const displayPath = shortenHomePath(filePath);
@@ -263,6 +325,7 @@ export async function checkConfigFile(): Promise<DiagResult[]> {
     ];
   }
 
+  const rawConfig = raw as Record<string, unknown>;
   const config = getRuntimeConfig();
   const mode = readUnixMode(filePath);
   const writableByOthers = isGroupOrWorldWritable(mode);
@@ -271,22 +334,25 @@ export async function checkConfigFile(): Promise<DiagResult[]> {
     config.ops.dbPath.trim() ? null : 'ops.dbPath',
     config.container.image.trim() ? null : 'container.image',
   ].filter(Boolean) as string[];
+  const deploymentIssues = getDeploymentConfigIssues(config, rawConfig);
+  missingFields.push(...deploymentIssues.missingFields);
 
-  if (missingFields.length > 0) {
+  if (missingFields.length > 0 || deploymentIssues.invalidFields.length > 0) {
+    const detail = [
+      missingFields.length > 0
+        ? `missing required field${missingFields.length === 1 ? '' : 's'}: ${missingFields.join(', ')}`
+        : null,
+      ...deploymentIssues.invalidFields,
+    ]
+      .filter(Boolean)
+      .join('; ');
     return [
-      makeResult(
-        'config',
-        'Config',
-        'error',
-        `${displayPath} missing required field${missingFields.length === 1 ? '' : 's'}: ${missingFields.join(', ')}`,
-      ),
+      makeResult('config', 'Config', 'error', `${displayPath} ${detail}`),
     ];
   }
 
   const version =
-    typeof (raw as { version?: unknown }).version === 'number'
-      ? (raw as { version: number }).version
-      : null;
+    typeof rawConfig.version === 'number' ? rawConfig.version : null;
   const severity = writableByOthers ? 'warn' : 'ok';
   const message =
     version === CONFIG_VERSION

--- a/src/doctor/checks/config.ts
+++ b/src/doctor/checks/config.ts
@@ -6,7 +6,6 @@ import {
   ensureRuntimeConfigFile,
   getRuntimeConfig,
   getRuntimeDisabledToolNames,
-  type RuntimeConfig,
   runtimeConfigPath,
   setRuntimeToolEnabled,
   updateRuntimeConfig,
@@ -34,6 +33,8 @@ type UnusedEntry = {
 type UsageEntry = UnusedEntry & {
   toolNames: string[];
 };
+
+const DEPLOYMENT_CONFIG_VERSION = 22;
 
 function formatUnusedEntries(entries: readonly UnusedEntry[]): string {
   return entries
@@ -233,51 +234,67 @@ function isHttpUrl(value: string): boolean {
   }
 }
 
-function getRawDeploymentField(
+function getRawDeployment(
   rawConfig: Record<string, unknown>,
-  key: string,
-): unknown {
+): Record<string, unknown> | null {
   const rawDeployment = rawConfig.deployment;
   if (
     !rawDeployment ||
     typeof rawDeployment !== 'object' ||
     Array.isArray(rawDeployment)
   ) {
-    return undefined;
+    return null;
   }
-  if (!Object.hasOwn(rawDeployment, key)) return undefined;
-  return (rawDeployment as Record<string, unknown>)[key];
+  return rawDeployment as Record<string, unknown>;
 }
 
-function getDeploymentConfigIssues(
-  config: RuntimeConfig,
+function getRawDeploymentField(
   rawConfig: Record<string, unknown>,
-): {
+  key: string,
+): unknown {
+  const rawDeployment = getRawDeployment(rawConfig);
+  if (!rawDeployment) return undefined;
+  if (!Object.hasOwn(rawDeployment, key)) return undefined;
+  return rawDeployment[key];
+}
+
+function getRawDeploymentTunnelProvider(
+  rawConfig: Record<string, unknown>,
+  fallback: string,
+): string {
+  const rawDeployment = getRawDeployment(rawConfig);
+  const rawTunnel = rawDeployment?.tunnel;
+  if (!rawTunnel || typeof rawTunnel !== 'object' || Array.isArray(rawTunnel)) {
+    return fallback;
+  }
+  const rawProvider = (rawTunnel as Record<string, unknown>).provider;
+  return typeof rawProvider === 'string' ? rawProvider.trim() : fallback;
+}
+
+function getDeploymentConfigIssues(rawConfig: Record<string, unknown>): {
   missingFields: string[];
   invalidFields: string[];
 } {
   const missingFields: string[] = [];
   const invalidFields: string[] = [];
-  const deployment = (
-    config as {
-      deployment?: Partial<RuntimeConfig['deployment']>;
-    }
-  ).deployment;
-  const deploymentMode =
-    deployment?.mode === 'cloud' || deployment?.mode === 'local'
-      ? deployment.mode
-      : 'local';
-  const publicUrl =
-    typeof deployment?.public_url === 'string'
-      ? deployment.public_url.trim()
-      : '';
-  const tunnelProvider =
-    typeof deployment?.tunnel?.provider === 'string'
-      ? deployment.tunnel.provider.trim()
-      : 'manual';
+  const rawDeployment = getRawDeployment(rawConfig);
+  const hasCurrentDeploymentSchema =
+    rawDeployment !== null ||
+    (typeof rawConfig.version === 'number' &&
+      rawConfig.version >= DEPLOYMENT_CONFIG_VERSION);
   const rawMode = getRawDeploymentField(rawConfig, 'mode');
   const normalizedRawMode =
     typeof rawMode === 'string' ? rawMode.trim().toLowerCase() : '';
+  const deploymentMode =
+    normalizedRawMode === 'cloud' || normalizedRawMode === 'local'
+      ? normalizedRawMode
+      : 'local';
+  const rawPublicUrl = getRawDeploymentField(rawConfig, 'public_url');
+  const publicUrl = typeof rawPublicUrl === 'string' ? rawPublicUrl.trim() : '';
+  const tunnelProvider = getRawDeploymentTunnelProvider(
+    rawConfig,
+    hasCurrentDeploymentSchema ? '' : 'manual',
+  );
 
   if (
     rawMode !== undefined &&
@@ -349,7 +366,7 @@ export async function checkConfigFile(): Promise<DiagResult[]> {
     config.ops.dbPath.trim() ? null : 'ops.dbPath',
     config.container.image.trim() ? null : 'container.image',
   ].filter(Boolean) as string[];
-  const deploymentIssues = getDeploymentConfigIssues(config, rawConfig);
+  const deploymentIssues = getDeploymentConfigIssues(rawConfig);
   missingFields.push(...deploymentIssues.missingFields);
 
   if (missingFields.length > 0 || deploymentIssues.invalidFields.length > 0) {

--- a/src/doctor/checks/config.ts
+++ b/src/doctor/checks/config.ts
@@ -258,8 +258,23 @@ function getDeploymentConfigIssues(
 } {
   const missingFields: string[] = [];
   const invalidFields: string[] = [];
-  const publicUrl = config.deployment.public_url.trim();
-  const tunnelProvider = config.deployment.tunnel.provider.trim();
+  const deployment = (
+    config as {
+      deployment?: Partial<RuntimeConfig['deployment']>;
+    }
+  ).deployment;
+  const deploymentMode =
+    deployment?.mode === 'cloud' || deployment?.mode === 'local'
+      ? deployment.mode
+      : 'local';
+  const publicUrl =
+    typeof deployment?.public_url === 'string'
+      ? deployment.public_url.trim()
+      : '';
+  const tunnelProvider =
+    typeof deployment?.tunnel?.provider === 'string'
+      ? deployment.tunnel.provider.trim()
+      : 'manual';
   const rawMode = getRawDeploymentField(rawConfig, 'mode');
   const normalizedRawMode =
     typeof rawMode === 'string' ? rawMode.trim().toLowerCase() : '';
@@ -272,10 +287,10 @@ function getDeploymentConfigIssues(
     invalidFields.push('deployment.mode must be "cloud" or "local"');
   }
 
-  if (config.deployment.mode === 'cloud' && !publicUrl) {
+  if (deploymentMode === 'cloud' && !publicUrl) {
     missingFields.push('deployment.public_url');
   }
-  if (config.deployment.mode === 'local' && !tunnelProvider) {
+  if (deploymentMode === 'local' && !tunnelProvider) {
     missingFields.push('deployment.tunnel.provider');
   }
   if (publicUrl && !isHttpUrl(publicUrl)) {

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -158,7 +158,9 @@ test('checkConfig warns on unused tools and MCP servers and disables them with f
       'image',
     ],
   }));
+  const actualRuntimeConfig = await import('../src/config/runtime-config.js');
   vi.doMock('../src/config/runtime-config.js', () => ({
+    ...actualRuntimeConfig,
     CONFIG_VERSION: 17,
     ensureRuntimeConfigFile: vi.fn(),
     getRuntimeConfig: () => structuredClone(runtimeConfigState),
@@ -262,7 +264,9 @@ test('checkConfig does not flag a single unused browser subtool when other brows
       'web_extract',
     ],
   }));
+  const actualRuntimeConfig = await import('../src/config/runtime-config.js');
   vi.doMock('../src/config/runtime-config.js', () => ({
+    ...actualRuntimeConfig,
     CONFIG_VERSION: 17,
     ensureRuntimeConfigFile: vi.fn(),
     getRuntimeConfig: () => ({
@@ -314,7 +318,9 @@ test('checkConfig describes a grouped browser warning as a toolset when singular
   vi.doMock('../src/agent/tool-summary.js', () => ({
     listKnownToolNames: () => ['read', 'browser_close', 'browser_navigate'],
   }));
+  const actualRuntimeConfig = await import('../src/config/runtime-config.js');
   vi.doMock('../src/config/runtime-config.js', () => ({
+    ...actualRuntimeConfig,
     CONFIG_VERSION: 17,
     ensureRuntimeConfigFile: vi.fn(),
     getRuntimeConfig: () => ({
@@ -361,7 +367,9 @@ test('checkConfigFile ignores unused tool and MCP hygiene warnings', async () =>
   vi.doMock('../src/agent/tool-summary.js', () => ({
     listKnownToolNames: () => ['read', 'browser_navigate'],
   }));
+  const actualRuntimeConfig = await import('../src/config/runtime-config.js');
   vi.doMock('../src/config/runtime-config.js', () => ({
+    ...actualRuntimeConfig,
     CONFIG_VERSION: 17,
     ensureRuntimeConfigFile: vi.fn(),
     getRuntimeConfig: () => ({

--- a/tests/runtime-config-deployment.test.ts
+++ b/tests/runtime-config-deployment.test.ts
@@ -155,6 +155,34 @@ describe('runtime deployment config', () => {
     );
   });
 
+  it('preserves unknown tunnel providers so validation can report them', async () => {
+    const { runtimeConfig, checkConfigFile } = await importFreshRuntimeConfig();
+    runtimeConfig.updateRuntimeConfig((draft) => {
+      draft.deployment.mode = 'local';
+      draft.deployment.tunnel.provider = 'WireGuard';
+    });
+
+    expect(runtimeConfig.getRuntimeConfig().deployment.tunnel.provider).toBe(
+      'wireguard',
+    );
+    expect(readDiskConfig().deployment).toMatchObject({
+      tunnel: {
+        provider: 'wireguard',
+      },
+    });
+
+    const results = await checkConfigFile();
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.severity).toBe('error');
+    expect(results[0]?.message).toContain(
+      'deployment.tunnel.provider must be one of cloudflare, manual, ngrok, ssh, tailscale',
+    );
+    expect(results[0]?.message).not.toContain(
+      'missing required field: deployment.tunnel.provider',
+    );
+  });
+
   it('persists deployment updates through runtime config revisions', async () => {
     const { runtimeConfig } = await importFreshRuntimeConfig();
 

--- a/tests/runtime-config-deployment.test.ts
+++ b/tests/runtime-config-deployment.test.ts
@@ -34,6 +34,10 @@ function readDiskConfig(): Record<string, unknown> {
   >;
 }
 
+function writeDiskConfig(config: Record<string, unknown>): void {
+  fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+}
+
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hc-deployment-config-'));
   configPath = path.join(tmpDir, 'config.json');
@@ -78,11 +82,16 @@ describe('runtime deployment config', () => {
   });
 
   it('validates cloud mode requires deployment.public_url', async () => {
-    const { runtimeConfig, checkConfigFile } = await importFreshRuntimeConfig();
-    runtimeConfig.updateRuntimeConfig((draft) => {
-      draft.deployment.mode = 'cloud';
-      draft.deployment.public_url = '';
-    });
+    const { checkConfigFile } = await importFreshRuntimeConfig();
+    const config = readDiskConfig();
+    config.deployment = {
+      mode: 'cloud',
+      public_url: '',
+      tunnel: {
+        provider: 'manual',
+      },
+    };
+    writeDiskConfig(config);
 
     const results = await checkConfigFile();
 
@@ -115,13 +124,34 @@ describe('runtime deployment config', () => {
         provider: 'manual',
       },
     };
-    fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+    writeDiskConfig(config);
 
     const results = await checkConfigFile();
 
     expect(results).toHaveLength(1);
     expect(results[0]?.severity).toBe('error');
     expect(results[0]?.message).toContain('deployment.mode');
+  });
+
+  it('validates deployment.public_url protocols from disk', async () => {
+    const { checkConfigFile } = await importFreshRuntimeConfig();
+    const config = readDiskConfig();
+    config.deployment = {
+      mode: 'cloud',
+      public_url: 'ftp://bot.example.com',
+      tunnel: {
+        provider: 'manual',
+      },
+    };
+    writeDiskConfig(config);
+
+    const results = await checkConfigFile();
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.severity).toBe('error');
+    expect(results[0]?.message).toContain(
+      'deployment.public_url must be an HTTP(S) URL',
+    );
   });
 
   it('persists deployment updates through runtime config revisions', async () => {

--- a/tests/runtime-config-deployment.test.ts
+++ b/tests/runtime-config-deployment.test.ts
@@ -1,0 +1,193 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ORIGINAL_DATA_DIR = process.env.HYBRIDCLAW_DATA_DIR;
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_DISABLE_CONFIG_WATCHER =
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
+
+let tmpDir: string;
+let configPath: string;
+
+function restoreEnvVar(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+async function importFreshRuntimeConfig() {
+  vi.resetModules();
+  const runtimeConfig = await import('../src/config/runtime-config.js');
+  const configChecks = await import('../src/doctor/checks/config.js');
+  return { runtimeConfig, checkConfigFile: configChecks.checkConfigFile };
+}
+
+function readDiskConfig(): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(configPath, 'utf-8')) as Record<
+    string,
+    unknown
+  >;
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hc-deployment-config-'));
+  configPath = path.join(tmpDir, 'config.json');
+  process.env.HYBRIDCLAW_DATA_DIR = tmpDir;
+  process.env.HOME = tmpDir;
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
+});
+
+afterEach(() => {
+  vi.resetModules();
+  restoreEnvVar('HYBRIDCLAW_DATA_DIR', ORIGINAL_DATA_DIR);
+  restoreEnvVar('HOME', ORIGINAL_HOME);
+  restoreEnvVar(
+    'HYBRIDCLAW_DISABLE_CONFIG_WATCHER',
+    ORIGINAL_DISABLE_CONFIG_WATCHER,
+  );
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    // best effort
+  }
+});
+
+describe('runtime deployment config', () => {
+  it('seeds local deployment mode with an operator-managed tunnel provider', async () => {
+    const { runtimeConfig } = await importFreshRuntimeConfig();
+
+    expect(runtimeConfig.getRuntimeConfig().deployment).toEqual({
+      mode: 'local',
+      public_url: '',
+      tunnel: {
+        provider: 'manual',
+      },
+    });
+    expect(readDiskConfig().deployment).toEqual({
+      mode: 'local',
+      public_url: '',
+      tunnel: {
+        provider: 'manual',
+      },
+    });
+  });
+
+  it('validates cloud mode requires deployment.public_url', async () => {
+    const { runtimeConfig, checkConfigFile } = await importFreshRuntimeConfig();
+    runtimeConfig.updateRuntimeConfig((draft) => {
+      draft.deployment.mode = 'cloud';
+      draft.deployment.public_url = '';
+    });
+
+    const results = await checkConfigFile();
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.severity).toBe('error');
+    expect(results[0]?.message).toContain('deployment.public_url');
+  });
+
+  it('validates local mode requires deployment.tunnel.provider', async () => {
+    const { runtimeConfig, checkConfigFile } = await importFreshRuntimeConfig();
+    runtimeConfig.updateRuntimeConfig((draft) => {
+      draft.deployment.mode = 'local';
+      draft.deployment.tunnel.provider = '';
+    });
+
+    const results = await checkConfigFile();
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.severity).toBe('error');
+    expect(results[0]?.message).toContain('deployment.tunnel.provider');
+  });
+
+  it('validates deployment.mode values from disk', async () => {
+    const { checkConfigFile } = await importFreshRuntimeConfig();
+    const config = readDiskConfig();
+    config.deployment = {
+      mode: 'managed',
+      public_url: '',
+      tunnel: {
+        provider: 'manual',
+      },
+    };
+    fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+
+    const results = await checkConfigFile();
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.severity).toBe('error');
+    expect(results[0]?.message).toContain('deployment.mode');
+  });
+
+  it('persists deployment updates through runtime config revisions', async () => {
+    const { runtimeConfig } = await importFreshRuntimeConfig();
+
+    runtimeConfig.updateRuntimeConfig(
+      (draft) => {
+        draft.deployment.mode = 'cloud';
+        draft.deployment.public_url = 'https://bot.example.com/';
+        draft.deployment.tunnel.provider = 'cloudflare';
+      },
+      {
+        actor: 'test-user',
+        route: 'test.deployment.update',
+        source: 'internal',
+      },
+    );
+
+    expect(runtimeConfig.getRuntimeConfig().deployment).toEqual({
+      mode: 'cloud',
+      public_url: 'https://bot.example.com',
+      tunnel: {
+        provider: 'cloudflare',
+      },
+    });
+    expect(readDiskConfig().deployment).toEqual({
+      mode: 'cloud',
+      public_url: 'https://bot.example.com',
+      tunnel: {
+        provider: 'cloudflare',
+      },
+    });
+    const revisions = runtimeConfig.listRuntimeConfigRevisions();
+    expect(revisions).toHaveLength(1);
+    expect(revisions[0]).toMatchObject({
+      actor: 'test-user',
+      route: 'test.deployment.update',
+      source: 'internal',
+    });
+    expect(
+      runtimeConfig.getRuntimeConfigRevision(revisions[0]?.id ?? -1)?.content,
+    ).toContain('"deployment"');
+    const revisionId = revisions[0]?.id;
+    if (!revisionId) {
+      throw new Error('Expected deployment config revision id.');
+    }
+
+    const restored = runtimeConfig.restoreRuntimeConfigRevision(revisionId, {
+      actor: 'test-user',
+      route: `test.deployment.rollback#${revisionId}`,
+      source: 'internal',
+    });
+
+    expect(restored.deployment).toEqual({
+      mode: 'local',
+      public_url: '',
+      tunnel: {
+        provider: 'manual',
+      },
+    });
+    expect(readDiskConfig().deployment).toEqual({
+      mode: 'local',
+      public_url: '',
+      tunnel: {
+        provider: 'manual',
+      },
+    });
+  });
+});

--- a/tests/runtime-config-deployment.test.ts
+++ b/tests/runtime-config-deployment.test.ts
@@ -121,7 +121,7 @@ describe('runtime deployment config', () => {
       mode: 'managed',
       public_url: '',
       tunnel: {
-        provider: 'manual',
+        provider: '',
       },
     };
     writeDiskConfig(config);
@@ -131,6 +131,7 @@ describe('runtime deployment config', () => {
     expect(results).toHaveLength(1);
     expect(results[0]?.severity).toBe('error');
     expect(results[0]?.message).toContain('deployment.mode');
+    expect(results[0]?.message).not.toContain('deployment.tunnel.provider');
   });
 
   it('validates deployment.public_url protocols from disk', async () => {

--- a/tests/runtime-config-deployment.test.ts
+++ b/tests/runtime-config-deployment.test.ts
@@ -101,11 +101,16 @@ describe('runtime deployment config', () => {
   });
 
   it('validates local mode requires deployment.tunnel.provider', async () => {
-    const { runtimeConfig, checkConfigFile } = await importFreshRuntimeConfig();
-    runtimeConfig.updateRuntimeConfig((draft) => {
-      draft.deployment.mode = 'local';
-      draft.deployment.tunnel.provider = '';
-    });
+    const { checkConfigFile } = await importFreshRuntimeConfig();
+    const config = readDiskConfig();
+    config.deployment = {
+      mode: 'local',
+      public_url: '',
+      tunnel: {
+        provider: '',
+      },
+    };
+    writeDiskConfig(config);
 
     const results = await checkConfigFile();
 

--- a/tests/runtime-config.migration-logging.test.ts
+++ b/tests/runtime-config.migration-logging.test.ts
@@ -130,6 +130,21 @@ describe('runtime config migration logging', () => {
     ).toBe(true);
   });
 
+  it('warns on startup when cloud deployment is missing a public URL', async () => {
+    const homeDir = makeTempHome();
+    writeRuntimeConfig(homeDir, (config) => {
+      config.deployment.mode = 'cloud';
+      config.deployment.public_url = '';
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await importFreshRuntimeConfig(homeDir);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[runtime-config] deployment.mode is "cloud" but deployment.public_url is empty; inbound webhooks and public callbacks may fail until a public URL is configured',
+    );
+  });
+
   it('normalizes MCP server transport aliases on startup', async () => {
     const homeDir = makeTempHome();
     writeRuntimeConfig(homeDir, (config) => {


### PR DESCRIPTION
## Summary
- Add versioned `deployment` runtime config schema for cloud/local mode, public URL, and tunnel provider.
- Validate deployment mode requirements in `config check`.
- Document the new keys and cover normalization, validation, revision persistence, and rollback.

## Validation
- `./node_modules/.bin/vitest run tests/runtime-config-deployment.test.ts`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`

Closes #566