### PR TITLE
[codex] Add monthly coworker spend rollup

### DIFF
--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -802,6 +802,7 @@ export interface AgentCard {
   effectiveModels: string[];
   lastActive: string | null;
   status: 'active' | 'idle' | 'stopped' | 'unused';
+  monthlySpend: number;
 }
 
 export interface AgentSessionCard {

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -802,7 +802,7 @@ export interface AgentCard {
   effectiveModels: string[];
   lastActive: string | null;
   status: 'active' | 'idle' | 'stopped' | 'unused';
-  monthlySpend: number;
+  monthlySpendUsd: number;
 }
 
 export interface AgentSessionCard {

--- a/src/gateway/gateway-agent-cards.ts
+++ b/src/gateway/gateway-agent-cards.ts
@@ -414,6 +414,7 @@ export function mapLogicalAgentCard(params: {
   agent: AgentConfig;
   sessions: GatewaySessionCard[];
   usage?: GatewaySessionUsageSummary;
+  monthlyUsage?: Pick<GatewaySessionUsageSummary, 'total_cost_usd'>;
 }): GatewayLogicalAgentCard {
   const resolved = resolveAgentConfig(params.agent.id);
   const sessions = [...params.sessions].sort((left, right) => {
@@ -445,6 +446,7 @@ export function mapLogicalAgentCard(params: {
     inputTokens: usage?.total_input_tokens || 0,
     outputTokens: usage?.total_output_tokens || 0,
     costUsd: usage?.total_cost_usd || 0,
+    monthlySpend: params.monthlyUsage?.total_cost_usd || 0,
     messageCount: sessions.reduce(
       (sum, session) => sum + Number(session.messageCount || 0),
       0,

--- a/src/gateway/gateway-agent-cards.ts
+++ b/src/gateway/gateway-agent-cards.ts
@@ -414,7 +414,7 @@ export function mapLogicalAgentCard(params: {
   agent: AgentConfig;
   sessions: GatewaySessionCard[];
   usage?: GatewaySessionUsageSummary;
-  monthlyUsage?: Pick<GatewaySessionUsageSummary, 'total_cost_usd'>;
+  monthlySpendUsd?: number;
 }): GatewayLogicalAgentCard {
   const resolved = resolveAgentConfig(params.agent.id);
   const sessions = [...params.sessions].sort((left, right) => {
@@ -446,7 +446,7 @@ export function mapLogicalAgentCard(params: {
     inputTokens: usage?.total_input_tokens || 0,
     outputTokens: usage?.total_output_tokens || 0,
     costUsd: usage?.total_cost_usd || 0,
-    monthlySpendUsd: params.monthlyUsage?.total_cost_usd || 0,
+    monthlySpendUsd: params.monthlySpendUsd || 0,
     messageCount: sessions.reduce(
       (sum, session) => sum + Number(session.messageCount || 0),
       0,

--- a/src/gateway/gateway-agent-cards.ts
+++ b/src/gateway/gateway-agent-cards.ts
@@ -446,7 +446,7 @@ export function mapLogicalAgentCard(params: {
     inputTokens: usage?.total_input_tokens || 0,
     outputTokens: usage?.total_output_tokens || 0,
     costUsd: usage?.total_cost_usd || 0,
-    monthlySpend: params.monthlyUsage?.total_cost_usd || 0,
+    monthlySpendUsd: params.monthlyUsage?.total_cost_usd || 0,
     messageCount: sessions.reduce(
       (sum, session) => sum + Number(session.messageCount || 0),
       0,

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -175,6 +175,7 @@ import {
   listStatsByChannel,
   listStructuredAuditEntries,
   listUsageByAgent,
+  listUsageByAgentRollups,
   listUsageByModel,
   listUsageBySession,
   listUsageDailyBreakdown,
@@ -4254,14 +4255,7 @@ export async function getGatewayAgents(): Promise<GatewayAgentsResponse> {
   const status = await getGatewayStatus();
   const activeSessionIds = new Set(getActiveExecutorSessionIds());
   const usageByAgent = new Map(
-    listUsageByAgent({ window: 'all' }).map(
-      (row) => [row.agent_id, row] as const,
-    ),
-  );
-  const monthlyUsageByAgent = new Map(
-    listUsageByAgent({ window: 'monthly' }).map(
-      (row) => [row.agent_id, row] as const,
-    ),
+    listUsageByAgentRollups().map((row) => [row.agent_id, row] as const),
   );
   const usageBySession = new Map(
     listUsageBySession({ window: 'all' }).map(
@@ -4299,14 +4293,15 @@ export async function getGatewayAgents(): Promise<GatewayAgentsResponse> {
     sessionsByAgent.set(session.agentId, existing);
   }
   const agents = agentIds
-    .map((agentId) =>
-      mapLogicalAgentCard({
+    .map((agentId) => {
+      const usage = usageByAgent.get(agentId);
+      return mapLogicalAgentCard({
         agent: getAgentById(agentId) ?? resolveAgentConfig(agentId),
         sessions: sessionsByAgent.get(agentId) ?? [],
-        usage: usageByAgent.get(agentId),
-        monthlyUsage: monthlyUsageByAgent.get(agentId),
-      }),
-    )
+        usage,
+        monthlySpendUsd: usage?.monthly_cost_usd,
+      });
+    })
     .sort((left, right) => {
       const rank = { active: 0, idle: 1, stopped: 2, unused: 3 } as const;
       const byStatus = rank[left.status] - rank[right.status];

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -4258,6 +4258,11 @@ export async function getGatewayAgents(): Promise<GatewayAgentsResponse> {
       (row) => [row.agent_id, row] as const,
     ),
   );
+  const monthlyUsageByAgent = new Map(
+    listUsageByAgent({ window: 'monthly' }).map(
+      (row) => [row.agent_id, row] as const,
+    ),
+  );
   const usageBySession = new Map(
     listUsageBySession({ window: 'all' }).map(
       (row) => [row.session_id, row] as const,
@@ -4299,6 +4304,7 @@ export async function getGatewayAgents(): Promise<GatewayAgentsResponse> {
         agent: getAgentById(agentId) ?? resolveAgentConfig(agentId),
         sessions: sessionsByAgent.get(agentId) ?? [],
         usage: usageByAgent.get(agentId),
+        monthlyUsage: monthlyUsageByAgent.get(agentId),
       }),
     )
     .sort((left, right) => {

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -716,7 +716,7 @@ export interface GatewayLogicalAgentCard {
   inputTokens: number;
   outputTokens: number;
   costUsd: number;
-  monthlySpend: number;
+  monthlySpendUsd: number;
   messageCount: number;
   toolCalls: number;
   recentSessionId: string | null;

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -716,6 +716,7 @@ export interface GatewayLogicalAgentCard {
   inputTokens: number;
   outputTokens: number;
   costUsd: number;
+  monthlySpend: number;
   messageCount: number;
   toolCalls: number;
   recentSessionId: string | null;

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -2984,6 +2984,14 @@ export function getUsageTotals(params?: {
   };
 }
 
+export function monthlySpend(coworkerId: string): number {
+  const agentId = coworkerId.trim();
+  if (!agentId) {
+    throw new Error('Coworker id is required.');
+  }
+  return getUsageTotals({ agentId, window: 'monthly' }).total_cost_usd;
+}
+
 export function getSessionUsageTotals(sessionId: string): UsageTotals {
   return getSessionUsageTotalsSince(sessionId, null);
 }

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -2984,10 +2984,10 @@ export function getUsageTotals(params?: {
   };
 }
 
-export function monthlySpend(coworkerId: string): number {
-  const agentId = coworkerId.trim();
+export function monthlySpendUsd(agentId: string): number {
+  agentId = agentId.trim();
   if (!agentId) {
-    throw new Error('Coworker id is required.');
+    throw new Error('Agent id is required.');
   }
   return getUsageTotals({ agentId, window: 'monthly' }).total_cost_usd;
 }

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -88,6 +88,7 @@ import type {
 } from '../types/session.js';
 import type {
   UsageAgentAggregate,
+  UsageAgentRollup,
   UsageDailyAggregate,
   UsageModelAggregate,
   UsageSessionAggregate,
@@ -3354,6 +3355,40 @@ export function listUsageByAgent(params?: {
     total_output_tokens: normalizeUsageNumber(row.total_output_tokens),
     total_tokens: normalizeUsageNumber(row.total_tokens),
     total_cost_usd: normalizeUsageCost(row.total_cost_usd),
+    call_count: normalizeUsageNumber(row.call_count),
+    total_tool_calls: normalizeUsageNumber(row.total_tool_calls),
+  }));
+}
+
+export function listUsageByAgentRollups(): UsageAgentRollup[] {
+  const rows = queryAll<UsageAgentRollup>(
+    db,
+    `SELECT
+       agent_id,
+       COALESCE(SUM(input_tokens), 0) AS total_input_tokens,
+       COALESCE(SUM(output_tokens), 0) AS total_output_tokens,
+       COALESCE(SUM(total_tokens), 0) AS total_tokens,
+       COALESCE(SUM(cost_usd), 0.0) AS total_cost_usd,
+       COALESCE(SUM(
+         CASE
+           WHEN timestamp >= datetime('now', 'start of month') THEN cost_usd
+           ELSE 0
+         END
+       ), 0.0) AS monthly_cost_usd,
+       COUNT(*) AS call_count,
+       COALESCE(SUM(tool_calls), 0) AS total_tool_calls
+     FROM usage_events
+     GROUP BY agent_id
+     ORDER BY total_cost_usd DESC, total_tokens DESC, call_count DESC`,
+  );
+
+  return rows.map((row) => ({
+    agent_id: row.agent_id,
+    total_input_tokens: normalizeUsageNumber(row.total_input_tokens),
+    total_output_tokens: normalizeUsageNumber(row.total_output_tokens),
+    total_tokens: normalizeUsageNumber(row.total_tokens),
+    total_cost_usd: normalizeUsageCost(row.total_cost_usd),
+    monthly_cost_usd: normalizeUsageCost(row.monthly_cost_usd),
     call_count: normalizeUsageNumber(row.call_count),
     total_tool_calls: normalizeUsageNumber(row.total_tool_calls),
   }));

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -15,6 +15,7 @@ import {
   resolveDefaultAgentId,
 } from '../config/runtime-config.js';
 import { logger } from '../logger.js';
+import { MODEL_METADATA_USD_TO_EUR } from '../providers/model-metadata.js';
 import {
   buildRecentChatSearchMatchQuery,
   MAX_RECENT_CHAT_SESSION_LIMIT,
@@ -2991,6 +2992,10 @@ export function monthlySpendUsd(agentId: string): number {
     throw new Error('Agent id is required.');
   }
   return getUsageTotals({ agentId, window: 'monthly' }).total_cost_usd;
+}
+
+export function monthlySpendEur(agentId: string): number {
+  return monthlySpendUsd(agentId) / MODEL_METADATA_USD_TO_EUR.usdPerEur;
 }
 
 export function getSessionUsageTotals(sessionId: string): UsageTotals {

--- a/src/providers/model-metadata.ts
+++ b/src/providers/model-metadata.ts
@@ -19,6 +19,12 @@ const MODEL_METADATA_SOURCES = {
   anthropicModels: 'https://docs.claude.com/claude/docs/models-overview',
 };
 
+export const MODEL_METADATA_USD_TO_EUR = {
+  rateDate: '2026-04-24',
+  usdPerEur: 1.1712,
+  source: 'https://www.ecb.europa.eu/stats/eurofxref',
+} as const;
+
 const STATIC_MODEL_METADATA_ALIASES: Record<string, string> = {
   'claude-haiku-4.5': 'claude-haiku-4-5',
   'claude-opus-4.1': 'claude-opus-4-1',

--- a/src/types/usage.ts
+++ b/src/types/usage.ts
@@ -55,6 +55,10 @@ export interface UsageAgentAggregate {
   total_tool_calls: number;
 }
 
+export interface UsageAgentRollup extends UsageAgentAggregate {
+  monthly_cost_usd: number;
+}
+
 export interface UsageSessionAggregate {
   session_id: string;
   total_input_tokens: number;

--- a/tests/gateway-agent-cards.test.ts
+++ b/tests/gateway-agent-cards.test.ts
@@ -124,9 +124,7 @@ describe('mapLogicalAgentCard', () => {
         total_cost_usd: 1.25,
         total_tool_calls: 7,
       },
-      monthlyUsage: {
-        total_cost_usd: 0.42,
-      },
+      monthlySpendUsd: 0.42,
     });
 
     expect(card).toMatchObject({

--- a/tests/gateway-agent-cards.test.ts
+++ b/tests/gateway-agent-cards.test.ts
@@ -124,6 +124,9 @@ describe('mapLogicalAgentCard', () => {
         total_cost_usd: 1.25,
         total_tool_calls: 7,
       },
+      monthlyUsage: {
+        total_cost_usd: 0.42,
+      },
     });
 
     expect(card).toMatchObject({
@@ -140,6 +143,7 @@ describe('mapLogicalAgentCard', () => {
       inputTokens: 200,
       outputTokens: 50,
       costUsd: 1.25,
+      monthlySpend: 0.42,
       messageCount: 10,
       toolCalls: 7,
       recentSessionId: 'dm:1',

--- a/tests/gateway-agent-cards.test.ts
+++ b/tests/gateway-agent-cards.test.ts
@@ -143,7 +143,7 @@ describe('mapLogicalAgentCard', () => {
       inputTokens: 200,
       outputTokens: 50,
       costUsd: 1.25,
-      monthlySpend: 0.42,
+      monthlySpendUsd: 0.42,
       messageCount: 10,
       toolCalls: 7,
       recentSessionId: 'dm:1',

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -887,6 +887,7 @@ async function importFreshHealth(options?: {
         inputTokens: 10,
         outputTokens: 5,
         costUsd: 0.01,
+        monthlySpend: 0.01,
         messageCount: 2,
         toolCalls: 1,
         recentSessionId: DEFAULT_WEB_SESSION_ID,
@@ -4934,6 +4935,7 @@ describe('gateway HTTP server', () => {
         {
           id: 'main',
           sessionCount: 1,
+          monthlySpend: 0.01,
           status: 'active',
         },
       ],

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -887,7 +887,7 @@ async function importFreshHealth(options?: {
         inputTokens: 10,
         outputTokens: 5,
         costUsd: 0.01,
-        monthlySpend: 0.01,
+        monthlySpendUsd: 0.01,
         messageCount: 2,
         toolCalls: 1,
         recentSessionId: DEFAULT_WEB_SESSION_ID,
@@ -4935,7 +4935,7 @@ describe('gateway HTTP server', () => {
         {
           id: 'main',
           sessionCount: 1,
-          monthlySpend: 0.01,
+          monthlySpendUsd: 0.01,
           status: 'active',
         },
       ],

--- a/tests/memory-service.test.ts
+++ b/tests/memory-service.test.ts
@@ -27,6 +27,7 @@ import {
   listUsageByAgent,
   listUsageByModel,
   listUsageDailyBreakdown,
+  monthlySpend,
   queryKnowledgeGraph,
   recallSemanticMemories,
   recordUsageEvent,
@@ -2091,6 +2092,10 @@ describe.sequential('usage aggregation DB', () => {
   test('records usage events and returns daily/monthly + by-model aggregates', () => {
     const dbPath = createTempDbPath();
     initDatabase({ quiet: true, dbPath });
+    const now = new Date();
+    const previousMonth = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 15, 12),
+    );
 
     recordUsageEvent({
       sessionId: 's-a',
@@ -2122,6 +2127,16 @@ describe.sequential('usage aggregation DB', () => {
       toolCalls: 0,
       costUsd: 0.0013,
     });
+    recordUsageEvent({
+      sessionId: 's-old',
+      agentId: 'agent-a',
+      model: 'gpt-5-nano',
+      inputTokens: 1_000,
+      outputTokens: 1_000,
+      totalTokens: 2_000,
+      costUsd: 9,
+      timestamp: previousMonth.toISOString(),
+    });
 
     const agentDaily = getUsageTotals({
       agentId: 'agent-a',
@@ -2130,6 +2145,9 @@ describe.sequential('usage aggregation DB', () => {
     expect(agentDaily.call_count).toBe(2);
     expect(agentDaily.total_tokens).toBe(800);
     expect(agentDaily.total_cost_usd).toBeCloseTo(0.0049, 6);
+    expect(monthlySpend(' agent-a ')).toBeCloseTo(0.0049, 6);
+    expect(monthlySpend('agent-b')).toBeCloseTo(0.0013, 6);
+    expect(() => monthlySpend('')).toThrow('Coworker id is required.');
 
     const monthlyByModel = listUsageByModel({
       window: 'monthly',

--- a/tests/memory-service.test.ts
+++ b/tests/memory-service.test.ts
@@ -25,6 +25,7 @@ import {
   initDatabase,
   listMemoryValues,
   listUsageByAgent,
+  listUsageByAgentRollups,
   listUsageByModel,
   listUsageDailyBreakdown,
   monthlySpendUsd,
@@ -2162,6 +2163,12 @@ describe.sequential('usage aggregation DB', () => {
     expect(dailyByAgent.length).toBe(2);
     expect(dailyByAgent[0]?.agent_id).toBe('agent-a');
     expect(dailyByAgent[0]?.total_tokens).toBe(800);
+
+    const agentRollups = listUsageByAgentRollups();
+    expect(agentRollups.length).toBe(2);
+    expect(agentRollups[0]?.agent_id).toBe('agent-a');
+    expect(agentRollups[0]?.total_cost_usd).toBeCloseTo(9.0049, 6);
+    expect(agentRollups[0]?.monthly_cost_usd).toBeCloseTo(0.0049, 6);
 
     const dailyBreakdown = listUsageDailyBreakdown({ days: 7 });
     expect(dailyBreakdown.length).toBe(1);

--- a/tests/memory-service.test.ts
+++ b/tests/memory-service.test.ts
@@ -28,6 +28,7 @@ import {
   listUsageByAgentRollups,
   listUsageByModel,
   listUsageDailyBreakdown,
+  monthlySpendEur,
   monthlySpendUsd,
   queryKnowledgeGraph,
   recallSemanticMemories,
@@ -41,6 +42,7 @@ import {
   type MemoryBackend,
   MemoryService,
 } from '../src/memory/memory-service.js';
+import { MODEL_METADATA_USD_TO_EUR } from '../src/providers/model-metadata.js';
 import { normalizeRecentChatSearchQuery } from '../src/session/recent-chat-search.js';
 import {
   KnowledgeEntityType,
@@ -2147,6 +2149,10 @@ describe.sequential('usage aggregation DB', () => {
     expect(agentDaily.total_tokens).toBe(800);
     expect(agentDaily.total_cost_usd).toBeCloseTo(0.0049, 6);
     expect(monthlySpendUsd(' agent-a ')).toBeCloseTo(0.0049, 6);
+    expect(monthlySpendEur(' agent-a ')).toBeCloseTo(
+      0.0049 / MODEL_METADATA_USD_TO_EUR.usdPerEur,
+      6,
+    );
     expect(monthlySpendUsd('agent-b')).toBeCloseTo(0.0013, 6);
     expect(() => monthlySpendUsd('')).toThrow('Agent id is required.');
 

--- a/tests/memory-service.test.ts
+++ b/tests/memory-service.test.ts
@@ -27,7 +27,7 @@ import {
   listUsageByAgent,
   listUsageByModel,
   listUsageDailyBreakdown,
-  monthlySpend,
+  monthlySpendUsd,
   queryKnowledgeGraph,
   recallSemanticMemories,
   recordUsageEvent,
@@ -2145,9 +2145,9 @@ describe.sequential('usage aggregation DB', () => {
     expect(agentDaily.call_count).toBe(2);
     expect(agentDaily.total_tokens).toBe(800);
     expect(agentDaily.total_cost_usd).toBeCloseTo(0.0049, 6);
-    expect(monthlySpend(' agent-a ')).toBeCloseTo(0.0049, 6);
-    expect(monthlySpend('agent-b')).toBeCloseTo(0.0013, 6);
-    expect(() => monthlySpend('')).toThrow('Coworker id is required.');
+    expect(monthlySpendUsd(' agent-a ')).toBeCloseTo(0.0049, 6);
+    expect(monthlySpendUsd('agent-b')).toBeCloseTo(0.0013, 6);
+    expect(() => monthlySpendUsd('')).toThrow('Agent id is required.');
 
     const monthlyByModel = listUsageByModel({
       window: 'monthly',

--- a/tests/usage-monthly-spend.integration.test.ts
+++ b/tests/usage-monthly-spend.integration.test.ts
@@ -7,7 +7,7 @@ import {
   getUsageTotals,
   initDatabase,
   listUsageByAgent,
-  monthlySpend,
+  monthlySpendUsd,
   recordUsageEvent,
 } from '../src/memory/db.js';
 
@@ -23,7 +23,7 @@ function previousMonthIso(): string {
   ).toISOString();
 }
 
-test('monthlySpend matches the monthly UsageTotals rollup per coworker', () => {
+test('monthlySpendUsd matches the monthly UsageTotals rollup per agent', () => {
   initDatabase({ quiet: true, dbPath: createTempDbPath() });
 
   recordUsageEvent({
@@ -71,7 +71,7 @@ test('monthlySpend matches the monthly UsageTotals rollup per coworker', () => {
   );
 
   expect(alphaTotals.total_cost_usd).toBeCloseTo(0.35, 6);
-  expect(monthlySpend('alpha')).toBeCloseTo(alphaTotals.total_cost_usd, 6);
+  expect(monthlySpendUsd('alpha')).toBeCloseTo(alphaTotals.total_cost_usd, 6);
   expect(monthlyRows.get('alpha')?.total_cost_usd).toBeCloseTo(0.35, 6);
   expect(monthlyRows.get('beta')?.total_cost_usd).toBeCloseTo(0.04, 6);
 });

--- a/tests/usage-monthly-spend.integration.test.ts
+++ b/tests/usage-monthly-spend.integration.test.ts
@@ -6,7 +6,7 @@ import { expect, test } from 'vitest';
 import {
   getUsageTotals,
   initDatabase,
-  listUsageByAgent,
+  listUsageByAgentRollups,
   monthlySpendUsd,
   recordUsageEvent,
 } from '../src/memory/db.js';
@@ -64,14 +64,13 @@ test('monthlySpendUsd matches the monthly UsageTotals rollup per agent', () => {
     agentId: 'alpha',
     window: 'monthly',
   });
-  const monthlyRows = new Map(
-    listUsageByAgent({ window: 'monthly' }).map(
-      (row) => [row.agent_id, row] as const,
-    ),
+  const rollups = new Map(
+    listUsageByAgentRollups().map((row) => [row.agent_id, row] as const),
   );
 
   expect(alphaTotals.total_cost_usd).toBeCloseTo(0.35, 6);
   expect(monthlySpendUsd('alpha')).toBeCloseTo(alphaTotals.total_cost_usd, 6);
-  expect(monthlyRows.get('alpha')?.total_cost_usd).toBeCloseTo(0.35, 6);
-  expect(monthlyRows.get('beta')?.total_cost_usd).toBeCloseTo(0.04, 6);
+  expect(rollups.get('alpha')?.total_cost_usd).toBeCloseTo(10.35, 6);
+  expect(rollups.get('alpha')?.monthly_cost_usd).toBeCloseTo(0.35, 6);
+  expect(rollups.get('beta')?.monthly_cost_usd).toBeCloseTo(0.04, 6);
 });

--- a/tests/usage-monthly-spend.integration.test.ts
+++ b/tests/usage-monthly-spend.integration.test.ts
@@ -7,9 +7,11 @@ import {
   getUsageTotals,
   initDatabase,
   listUsageByAgentRollups,
+  monthlySpendEur,
   monthlySpendUsd,
   recordUsageEvent,
 } from '../src/memory/db.js';
+import { MODEL_METADATA_USD_TO_EUR } from '../src/providers/model-metadata.js';
 
 function createTempDbPath(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-usage-'));
@@ -70,6 +72,10 @@ test('monthlySpendUsd matches the monthly UsageTotals rollup per agent', () => {
 
   expect(alphaTotals.total_cost_usd).toBeCloseTo(0.35, 6);
   expect(monthlySpendUsd('alpha')).toBeCloseTo(alphaTotals.total_cost_usd, 6);
+  expect(monthlySpendEur('alpha')).toBeCloseTo(
+    alphaTotals.total_cost_usd / MODEL_METADATA_USD_TO_EUR.usdPerEur,
+    6,
+  );
   expect(rollups.get('alpha')?.total_cost_usd).toBeCloseTo(10.35, 6);
   expect(rollups.get('alpha')?.monthly_cost_usd).toBeCloseTo(0.35, 6);
   expect(rollups.get('beta')?.monthly_cost_usd).toBeCloseTo(0.04, 6);

--- a/tests/usage-monthly-spend.integration.test.ts
+++ b/tests/usage-monthly-spend.integration.test.ts
@@ -1,0 +1,77 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { expect, test } from 'vitest';
+
+import {
+  getUsageTotals,
+  initDatabase,
+  listUsageByAgent,
+  monthlySpend,
+  recordUsageEvent,
+} from '../src/memory/db.js';
+
+function createTempDbPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-usage-'));
+  return path.join(dir, 'test.db');
+}
+
+function previousMonthIso(): string {
+  const now = new Date();
+  return new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 15, 12),
+  ).toISOString();
+}
+
+test('monthlySpend matches the monthly UsageTotals rollup per coworker', () => {
+  initDatabase({ quiet: true, dbPath: createTempDbPath() });
+
+  recordUsageEvent({
+    sessionId: 'session-alpha-1',
+    agentId: 'alpha',
+    model: 'gpt-5-mini',
+    inputTokens: 100,
+    outputTokens: 40,
+    costUsd: 0.25,
+  });
+  recordUsageEvent({
+    sessionId: 'session-alpha-2',
+    agentId: 'alpha',
+    model: 'gpt-5-mini',
+    inputTokens: 80,
+    outputTokens: 20,
+    costUsd: 0.1,
+  });
+  recordUsageEvent({
+    sessionId: 'session-beta-1',
+    agentId: 'beta',
+    model: 'gpt-5-nano',
+    inputTokens: 50,
+    outputTokens: 10,
+    costUsd: 0.04,
+  });
+  recordUsageEvent({
+    sessionId: 'session-alpha-old',
+    agentId: 'alpha',
+    model: 'gpt-5-mini',
+    inputTokens: 1_000,
+    outputTokens: 1_000,
+    costUsd: 10,
+    timestamp: previousMonthIso(),
+  });
+
+  const alphaTotals = getUsageTotals({
+    agentId: 'alpha',
+    window: 'monthly',
+  });
+  const monthlyRows = new Map(
+    listUsageByAgent({ window: 'monthly' }).map(
+      (row) => [row.agent_id, row] as const,
+    ),
+  );
+
+  expect(alphaTotals.total_cost_usd).toBeCloseTo(0.35, 6);
+  expect(monthlySpend('alpha')).toBeCloseTo(alphaTotals.total_cost_usd, 6);
+  expect(monthlyRows.get('alpha')?.total_cost_usd).toBeCloseTo(0.35, 6);
+  expect(monthlyRows.get('beta')?.total_cost_usd).toBeCloseTo(0.04, 6);
+});


### PR DESCRIPTION
## Summary
- Add `monthlySpendUsd(agentId)` backed by existing monthly `UsageTotals` / `cost_usd` accounting.
- Add `monthlySpendEur(agentId)` as the canonical EUR wrapper using `MODEL_METADATA_USD_TO_EUR.usdPerEur`.
- Surface per-agent monthly USD spend on the `/api/agents` rollup response.
- Cover the rollup with unit and integration tests.

Closes #448.

## Currency note
The persisted usage ledger remains USD (`cost_usd`, `costUsd`, `remaining_usd`). `monthlySpendEur(agentId)` converts that canonical USD monthly total through the shared model metadata USD/EUR rate so downstream budget work has a single EUR helper.

## Validation
- `./node_modules/.bin/biome check --write src/providers/model-metadata.ts src/memory/db.ts tests/memory-service.test.ts tests/usage-monthly-spend.integration.test.ts`
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/memory-service.test.ts tests/gateway-agent-cards.test.ts tests/gateway-http-server.test.ts`
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.integration.config.ts tests/usage-monthly-spend.integration.test.ts`
- `npm run typecheck`
- `npm run lint`
- `git rebase origin/main`