### PR TITLE
[codex] docs: add manifesto changelog tags

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,6 +22,13 @@ Describe the change in 2-5 bullets:
 - Closes #
 - Related #
 
+## Manifesto Principle
+
+Which manifesto principle does this serve?
+
+- Principle:
+- Changelog tag added or updated: `Manifesto: Principle <Roman numeral> - <principle title>.`
+
 ## Validation
 
 List the checks you ran and the concrete scenarios you verified.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 
+## Entry Template
+
+Use this shape for shipped feature entries so release, sales, and marketing
+notes can be filtered by manifesto principle:
+
+- **Feature name**: User-facing outcome and why it matters.
+  Manifesto: Principle <Roman numeral> - <principle title>.
+
 ## Unreleased
+
+### Added
+
+- **Manifesto-principle changelog tags**: Feature changelog entries now include
+  a stable manifesto-principle line so release notes, sales briefs, and
+  marketing copy can be traced back to the product principle each feature
+  serves.
+  Manifesto: Principle VII - A coworker you can trust with real responsibility.
 
 ## [0.13.1](https://github.com/HybridAIOne/hybridclaw/tree/v0.13.1) - 2026-04-24
 


### PR DESCRIPTION
## Summary

- Problem: shipped feature notes did not have a stable way to record which Trusted Coworker Manifesto principle they serve.
- Why it matters: sales and marketing need to grep release notes for principle-tagged shipped work without re-deriving the positioning.
- What changed: added a `CHANGELOG.md` entry template, seeded the first manifesto-principle tagged entry, and added the PR-template prompt for future changes.
- What did not change: no runtime, config, or template bootstrap behavior changed.

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Docs
- [ ] Tests
- [ ] Refactor required for the fix
- [x] Tooling or workflow
- [ ] Security hardening

## Linked Context

- Closes #420

## Manifesto Principle

Which manifesto principle does this serve?

- Principle: Principle VII - A coworker you can trust with real responsibility.
- Changelog tag added or updated: `Manifesto: Principle VII - A coworker you can trust with real responsibility.`

## Validation

```bash
npm run format
rg "Manifesto: Principle|Which manifesto principle does this serve" CHANGELOG.md .github/PULL_REQUEST_TEMPLATE.md
git diff --check -- CHANGELOG.md .github/PULL_REQUEST_TEMPLATE.md
```

- Verified manually: changelog template, first tagged entry, and PR prompt are present and grep-friendly.
- Edge cases checked: release tooling references were searched for changelog-heading parsing before adding the template section.
- Skipped checks and why: full test suite skipped because this is a docs/workflow-only change.

## Docs And Config Impact

- [x] README, docs, or examples updated
- [ ] Config or environment behavior changed
- [ ] Templates or workspace bootstrap files changed
- [ ] No docs or config impact

## Risk Notes

- Security-sensitive paths touched? No
- Gateway, audit, approval, or container boundaries touched? No
