### PR TITLE
[codex] add ngrok tunnel provider

### DIFF
--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -171,7 +171,8 @@ saved revision history directly.
   for declaring whether the gateway runs behind a cloud URL or a local tunnel;
   cloud mode requires `deployment.public_url`, while local mode requires a
   tunnel provider such as `manual`, `ssh`, `ngrok`, `cloudflare`, or
-  `tailscale`
+  `tailscale`. The built-in ngrok tunnel provider reads `NGROK_AUTHTOKEN` from
+  the encrypted runtime secret store
 - `ops.webApiToken` or `WEB_API_TOKEN` for `/chat`, `/agents`, and `/admin`;
   when unset, localhost browser access stays open without a login prompt
 - `ops.gatewayBaseUrl` plus `ops.gatewayApiToken` or `GATEWAY_API_TOKEN` for

--- a/docs/development/reference/configuration.md
+++ b/docs/development/reference/configuration.md
@@ -137,7 +137,8 @@ leak into the saved revision metadata.
   for declaring whether the gateway runs behind a cloud URL or a local tunnel;
   cloud mode requires `deployment.public_url`, while local mode requires a
   tunnel provider such as `manual`, `ssh`, `ngrok`, `cloudflare`, or
-  `tailscale`
+  `tailscale`. The built-in ngrok tunnel provider reads `NGROK_AUTHTOKEN` from
+  the encrypted runtime secret store
 - `ops.webApiToken` or `WEB_API_TOKEN` for `/chat`, `/agents`, and `/admin`;
   when unset, localhost browser access stays open without a login prompt
 - `ops.gatewayBaseUrl` plus `ops.gatewayApiToken` or `GATEWAY_API_TOKEN` for

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       ],
       "dependencies": {
         "@huggingface/transformers": "3.8.1",
+        "@ngrok/ngrok": "1.5.2",
         "@opentelemetry/api": "1.9.1",
         "@opentelemetry/exporter-trace-otlp-grpc": "0.214.0",
         "@opentelemetry/exporter-trace-otlp-http": "0.214.0",
@@ -2960,6 +2961,235 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@ngrok/ngrok": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok/-/ngrok-1.5.2.tgz",
+      "integrity": "sha512-gN7KKdLTKer+wBSk9s9eDx53MUFdcnXNHsXxiC5sJLLD5HY9JRMSn6UzcCqnk7IgeIgCgw5h1k6YDqhjx6lmtg==",
+      "license": "(MIT OR Apache-2.0)",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@ngrok/ngrok-android-arm64": "1.5.2",
+        "@ngrok/ngrok-darwin-arm64": "1.5.2",
+        "@ngrok/ngrok-darwin-universal": "1.5.2",
+        "@ngrok/ngrok-darwin-x64": "1.5.2",
+        "@ngrok/ngrok-freebsd-x64": "1.5.2",
+        "@ngrok/ngrok-linux-arm-gnueabihf": "1.5.2",
+        "@ngrok/ngrok-linux-arm64-gnu": "1.5.2",
+        "@ngrok/ngrok-linux-arm64-musl": "1.5.2",
+        "@ngrok/ngrok-linux-x64-gnu": "1.5.2",
+        "@ngrok/ngrok-linux-x64-musl": "1.5.2",
+        "@ngrok/ngrok-win32-arm64-msvc": "1.5.2",
+        "@ngrok/ngrok-win32-ia32-msvc": "1.5.2",
+        "@ngrok/ngrok-win32-x64-msvc": "1.5.2"
+      }
+    },
+    "node_modules/@ngrok/ngrok-android-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-android-arm64/-/ngrok-android-arm64-1.5.2.tgz",
+      "integrity": "sha512-v81VbxxAgg2W7jbjhEcn8K9R2aUf0h1AuTx+8tDlw3L4H1YEmbmllIpBAGgMjHRBxLZKOo5GBi0k7oS+VRM5TA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-arm64/-/ngrok-darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-8CVzS9AveYpNhWbydm7cJ6XqmVg29/VRKF15l4kJ2djlNoJxuGSibgM9A627dWRdnJyj5uhmU3VzsgeU8t+/3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-darwin-universal": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-universal/-/ngrok-darwin-universal-1.5.2.tgz",
+      "integrity": "sha512-mEMH1OxN6RxnqRSWb4xY9RqbtdlCpv+WlRKxq4lVy8JVsxEyFNnzVQ0jn+iuiy981jCXjokctzJeGMvECuSQBQ==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-x64/-/ngrok-darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-rGdcADw4NtMSU7SHUTly7uvMVYX6eMeMCppKyL5g3CSlEQntKf3AWs/89ah2TBWJA2WVl0UgGLkXp4xs1tg9eQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-freebsd-x64/-/ngrok-freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-WgY54qUekaUGa5+lFvzYUMjlzf22IEXuZHhxnzJM2/gMqa7gjU8N5W4U8XNDjVW/oz6DekrzIjuoAEPO+2icDg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-arm-gnueabihf": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm-gnueabihf/-/ngrok-linux-arm-gnueabihf-1.5.2.tgz",
+      "integrity": "sha512-azMxr/TGEeFU4JAUbSu5MO2aZEvdq+TzcxiLw6d+yhdEtNAjDW9TOyCczTrIZPOG5fP8G3lcCd8TP7mVIWdOnw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-arm64-gnu": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm64-gnu/-/ngrok-linux-arm64-gnu-1.5.2.tgz",
+      "integrity": "sha512-79eFCxio4rM0ICRBXx/CVvbXDeWk1Jxr7szkezEYWtHaL+gXivrtS1QjtMnJpGY1GJlLTQL+49w2lGydqPOJQA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-arm64-musl": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm64-musl/-/ngrok-linux-arm64-musl-1.5.2.tgz",
+      "integrity": "sha512-ou9Z7iPQJIQ0RX5bdBhb3y7GwYRt+X0G9tenyRzKLXXvs0XfUUcg/23aBP61hmdRvBq7xpliV1PnvEVBgUIYMg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-x64-gnu": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-x64-gnu/-/ngrok-linux-x64-gnu-1.5.2.tgz",
+      "integrity": "sha512-VI1mmtl3Ie5uXTVAR9thPiMNMsCWeqkjBUbHAyk2vZ2OXR4Vs2DGjOPXK+wTl/hjF29FXoxunjhMy6caF9ht0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-x64-musl": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-x64-musl/-/ngrok-linux-x64-musl-1.5.2.tgz",
+      "integrity": "sha512-F4j9EyC/0R3IgYSd+OER4bC8bxuBubvj33e24GvQnRF/IQaKhpybkvQbz54fnvsL7y0j2BB42NAIm2CFtk7tCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-win32-arm64-msvc": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-arm64-msvc/-/ngrok-win32-arm64-msvc-1.5.2.tgz",
+      "integrity": "sha512-0OMXNjWElM1MQX7lMBnpRtafS9+3ybauqGD4m2dZcIm6hFvexsJFwNgx0mCa5aKxe2mQ4zNarEUd+SqG2Aa4/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-win32-ia32-msvc": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-ia32-msvc/-/ngrok-win32-ia32-msvc-1.5.2.tgz",
+      "integrity": "sha512-hdvhnr7Br4XhUblpW67v5XP6FyoQwJ2xSbwas4KW4hZ3F4cw0m6sqXpssRfmqg3/5HJony1H5B2jLi0x4J7uOw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-win32-x64-msvc": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-x64-msvc/-/ngrok-win32-x64-msvc-1.5.2.tgz",
+      "integrity": "sha512-aHuMiRti9Taow9DlYLGVmu9CXtXD/v4CBQWpZlmt7VGuK1KsTWWLaGIBFVp6UXnyW87b0A+KC69Kn/Xjylw+sg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@opentelemetry/api": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,8 @@
     "prepare": "command -v git >/dev/null 2>&1 && test -w .git/config && husky || true"
   },
   "dependencies": {
+    "@huggingface/transformers": "3.8.1",
+    "@ngrok/ngrok": "1.5.2",
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/exporter-trace-otlp-grpc": "0.214.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.214.0",
@@ -88,7 +90,6 @@
     "@opentelemetry/sdk-node": "0.214.0",
     "@opentelemetry/semantic-conventions": "1.40.0",
     "@slack/bolt": "4.7.0",
-    "@huggingface/transformers": "3.8.1",
     "@whiskeysockets/baileys": "7.0.0-rc.9",
     "ajv": "8.18.0",
     "better-sqlite3": "12.8.0",

--- a/package.json
+++ b/package.json
@@ -81,8 +81,6 @@
     "prepare": "command -v git >/dev/null 2>&1 && test -w .git/config && husky || true"
   },
   "dependencies": {
-    "@huggingface/transformers": "3.8.1",
-    "@ngrok/ngrok": "1.5.2",
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/exporter-trace-otlp-grpc": "0.214.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.214.0",
@@ -90,6 +88,8 @@
     "@opentelemetry/sdk-node": "0.214.0",
     "@opentelemetry/semantic-conventions": "1.40.0",
     "@slack/bolt": "4.7.0",
+    "@huggingface/transformers": "3.8.1",
+    "@ngrok/ngrok": "1.5.2",
     "@whiskeysockets/baileys": "7.0.0-rc.9",
     "ajv": "8.18.0",
     "better-sqlite3": "12.8.0",

--- a/src/tunnel/ngrok-tunnel-provider.ts
+++ b/src/tunnel/ngrok-tunnel-provider.ts
@@ -61,10 +61,6 @@ function redactSecret(message: string, secret: string): string {
   return message.split(trimmed).join('<redacted>');
 }
 
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
 export class NgrokTunnelProvider implements TunnelProvider {
   private readonly addr: Config['addr'];
   private readonly domain?: string;
@@ -130,7 +126,7 @@ export class NgrokTunnelProvider implements TunnelProvider {
       this.listener = null;
       this.publicUrl = null;
       throw new Error(
-        `Failed to start ngrok tunnel: ${redactSecret(errorMessage(error), token)}`,
+        `Failed to start ngrok tunnel: ${redactSecret(error instanceof Error ? error.message : String(error), token)}`,
       );
     }
   }

--- a/src/tunnel/ngrok-tunnel-provider.ts
+++ b/src/tunnel/ngrok-tunnel-provider.ts
@@ -1,0 +1,159 @@
+import type { Config } from '@ngrok/ngrok';
+import { readStoredRuntimeSecret } from '../security/runtime-secrets.js';
+import type {
+  TunnelProvider,
+  TunnelStartResult,
+  TunnelStatus,
+} from './tunnel-provider.js';
+
+export const NGROK_AUTHTOKEN_SECRET = 'NGROK_AUTHTOKEN';
+export const DEFAULT_NGROK_TUNNEL_ADDR = 9090;
+
+interface NgrokListener {
+  url(): string | null;
+  close(): Promise<void>;
+}
+
+interface NgrokClient {
+  forward(config: Config | string | number): Promise<NgrokListener>;
+}
+
+export interface NgrokTunnelProviderOptions {
+  addr?: Config['addr'];
+  domain?: string;
+  forwardsTo?: string;
+  metadata?: string;
+  readSecret?: (secretName: string) => string | null;
+  schemes?: string[];
+  tokenSecretName?: string;
+  loadNgrok?: () => Promise<NgrokClient>;
+}
+
+async function loadDefaultNgrok(): Promise<NgrokClient> {
+  return import('@ngrok/ngrok');
+}
+
+function normalizePublicUrl(value: string | null): string {
+  const raw = String(value || '').trim();
+  if (!raw) {
+    throw new Error('ngrok listener did not report a public URL.');
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error(`ngrok listener reported an invalid public URL: ${raw}`);
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(
+      `ngrok listener reported a non-HTTP public URL: ${parsed.protocol}`,
+    );
+  }
+
+  return parsed.toString().replace(/\/$/, '');
+}
+
+function redactSecret(message: string, secret: string): string {
+  const trimmed = secret.trim();
+  if (!trimmed) return message;
+  return message.split(trimmed).join('<redacted>');
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export class NgrokTunnelProvider implements TunnelProvider {
+  private readonly addr: Config['addr'];
+  private readonly domain?: string;
+  private readonly forwardsTo?: string;
+  private readonly metadata?: string;
+  private readonly readSecret: (secretName: string) => string | null;
+  private readonly schemes?: string[];
+  private readonly tokenSecretName: string;
+  private readonly loadNgrok: () => Promise<NgrokClient>;
+  private listener: NgrokListener | null = null;
+  private publicUrl: string | null = null;
+
+  constructor(options: NgrokTunnelProviderOptions = {}) {
+    this.addr = options.addr ?? DEFAULT_NGROK_TUNNEL_ADDR;
+    this.domain = options.domain;
+    this.forwardsTo = options.forwardsTo;
+    this.metadata = options.metadata;
+    this.readSecret = options.readSecret ?? readStoredRuntimeSecret;
+    this.schemes = options.schemes;
+    this.tokenSecretName =
+      options.tokenSecretName?.trim() || NGROK_AUTHTOKEN_SECRET;
+    this.loadNgrok = options.loadNgrok ?? loadDefaultNgrok;
+  }
+
+  async start(): Promise<TunnelStartResult> {
+    if (this.listener && this.publicUrl) {
+      return { public_url: this.publicUrl };
+    }
+
+    const token = this.readSecret(this.tokenSecretName)?.trim() || '';
+    if (!token) {
+      throw new Error(
+        `ngrok auth token is not configured in encrypted runtime secrets. Store it with \`hybridclaw secret set ${this.tokenSecretName} <token>\`.`,
+      );
+    }
+
+    let listener: NgrokListener | null = null;
+    try {
+      const ngrok = await this.loadNgrok();
+      const config: Config = {
+        addr: this.addr,
+        authtoken: token,
+        proto: 'http',
+      };
+      if (this.domain) config.domain = this.domain;
+      if (this.forwardsTo) config.forwards_to = this.forwardsTo;
+      if (this.metadata) config.metadata = this.metadata;
+      if (this.schemes) config.schemes = this.schemes;
+
+      listener = await ngrok.forward(config);
+      const publicUrl = normalizePublicUrl(listener.url());
+      this.listener = listener;
+      this.publicUrl = publicUrl;
+      return { public_url: publicUrl };
+    } catch (error) {
+      if (listener) {
+        try {
+          await listener.close();
+        } catch {
+          // Preserve the original start failure.
+        }
+      }
+      this.listener = null;
+      this.publicUrl = null;
+      throw new Error(
+        `Failed to start ngrok tunnel: ${redactSecret(errorMessage(error), token)}`,
+      );
+    }
+  }
+
+  async stop(): Promise<void> {
+    const listener = this.listener;
+    this.listener = null;
+    this.publicUrl = null;
+    if (listener) {
+      await listener.close();
+    }
+  }
+
+  async status(): Promise<TunnelStatus> {
+    return {
+      running: Boolean(this.listener && this.publicUrl),
+      public_url: this.publicUrl,
+    };
+  }
+}
+
+export function createNgrokTunnelProvider(
+  options: NgrokTunnelProviderOptions = {},
+): TunnelProvider {
+  return new NgrokTunnelProvider(options);
+}

--- a/src/tunnel/ngrok-tunnel-provider.ts
+++ b/src/tunnel/ngrok-tunnel-provider.ts
@@ -136,7 +136,13 @@ export class NgrokTunnelProvider implements TunnelProvider {
     this.listener = null;
     this.publicUrl = null;
     if (listener) {
-      await listener.close();
+      try {
+        await listener.close();
+      } catch {
+        console.warn(
+          '[tunnel] failed to stop ngrok tunnel cleanly; local tunnel state was cleared.',
+        );
+      }
     }
   }
 

--- a/src/tunnel/ngrok-tunnel-provider.ts
+++ b/src/tunnel/ngrok-tunnel-provider.ts
@@ -140,7 +140,7 @@ export class NgrokTunnelProvider implements TunnelProvider {
     }
   }
 
-  async status(): Promise<TunnelStatus> {
+  status(): TunnelStatus {
     return {
       running: Boolean(this.listener && this.publicUrl),
       public_url: this.publicUrl,

--- a/src/tunnel/ngrok-tunnel-provider.ts
+++ b/src/tunnel/ngrok-tunnel-provider.ts
@@ -58,7 +58,7 @@ function normalizePublicUrl(value: string | null): string {
 function redactSecret(message: string, secret: string): string {
   const trimmed = secret.trim();
   if (!trimmed) return message;
-  return message.split(trimmed).join('<redacted>');
+  return message.replaceAll(trimmed, '<redacted>');
 }
 
 export class NgrokTunnelProvider implements TunnelProvider {

--- a/src/tunnel/ngrok-tunnel-provider.ts
+++ b/src/tunnel/ngrok-tunnel-provider.ts
@@ -34,7 +34,7 @@ async function loadDefaultNgrok(): Promise<NgrokClient> {
 }
 
 function normalizePublicUrl(value: string | null): string {
-  const raw = String(value || '').trim();
+  const raw = (value ?? '').trim();
   if (!raw) {
     throw new Error('ngrok listener did not report a public URL.');
   }

--- a/src/tunnel/tunnel-provider.ts
+++ b/src/tunnel/tunnel-provider.ts
@@ -12,5 +12,5 @@ export interface TunnelStatus {
 export interface TunnelProvider {
   start(): Promise<TunnelStartResult>;
   stop(): Promise<void>;
-  status(): Promise<TunnelStatus>;
+  status(): TunnelStatus;
 }

--- a/src/tunnel/tunnel-provider.ts
+++ b/src/tunnel/tunnel-provider.ts
@@ -1,4 +1,6 @@
 export interface TunnelStartResult {
+  // Keep the deployment-facing result shape aligned with runtime config/API
+  // fields instead of returning a bare URL string.
   public_url: string;
 }
 

--- a/src/tunnel/tunnel-provider.ts
+++ b/src/tunnel/tunnel-provider.ts
@@ -1,0 +1,14 @@
+export interface TunnelStartResult {
+  public_url: string;
+}
+
+export interface TunnelStatus {
+  running: boolean;
+  public_url: string | null;
+}
+
+export interface TunnelProvider {
+  start(): Promise<TunnelStartResult>;
+  stop(): Promise<void>;
+  status(): Promise<TunnelStatus>;
+}

--- a/src/tunnel/tunnel-provider.ts
+++ b/src/tunnel/tunnel-provider.ts
@@ -11,6 +11,7 @@ export interface TunnelStatus {
 
 export interface TunnelProvider {
   start(): Promise<TunnelStartResult>;
+  // Stop is best-effort cleanup: provider shutdown failures should not escape.
   stop(): Promise<void>;
   status(): TunnelStatus;
 }

--- a/tests/ngrok-tunnel.live.test.ts
+++ b/tests/ngrok-tunnel.live.test.ts
@@ -102,7 +102,7 @@ liveTest(
       expect(body).toBe(marker);
     } finally {
       if (provider) {
-        await provider.stop().catch(() => {});
+        await provider.stop();
       }
       await closeServer(server).catch(() => {});
       fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/tests/ngrok-tunnel.live.test.ts
+++ b/tests/ngrok-tunnel.live.test.ts
@@ -1,0 +1,116 @@
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import { expect, test, vi } from 'vitest';
+
+const RUN_LIVE = process.env.HYBRIDCLAW_RUN_LIVE_NGROK === '1';
+const SANDBOX_TOKEN =
+  process.env.NGROK_SANDBOX_AUTHTOKEN || process.env.NGROK_AUTHTOKEN || '';
+const liveTest = RUN_LIVE && SANDBOX_TOKEN ? test : test.skip;
+
+const ORIGINAL_DATA_DIR = process.env.HYBRIDCLAW_DATA_DIR;
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_MASTER_KEY = process.env.HYBRIDCLAW_MASTER_KEY;
+
+function restoreEnvVar(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+async function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('Expected TCP server address.'));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+async function closeServer(server: http.Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+async function fetchTextWithRetry(url: string): Promise<string> {
+  let lastError: Error | null = null;
+  for (let attempt = 0; attempt < 12; attempt += 1) {
+    try {
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (response.ok) return await response.text();
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+    }
+    await delay(1_000);
+  }
+  throw lastError || new Error('ngrok tunnel did not return a response.');
+}
+
+liveTest(
+  'forwards public traffic through ngrok using an encrypted sandbox token',
+  async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hc-ngrok-live-'));
+    const marker = `hybridclaw-ngrok-live-${Date.now()}`;
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
+      res.end(marker);
+    });
+    let provider: { stop(): Promise<void> } | null = null;
+
+    try {
+      process.env.HYBRIDCLAW_DATA_DIR = tmpDir;
+      process.env.HOME = tmpDir;
+      process.env.HYBRIDCLAW_MASTER_KEY = 'test-ngrok-live-master-key';
+      vi.resetModules();
+
+      const { saveNamedRuntimeSecrets } = await import(
+        '../src/security/runtime-secrets.js'
+      );
+      saveNamedRuntimeSecrets({ NGROK_AUTHTOKEN: SANDBOX_TOKEN });
+
+      const { NgrokTunnelProvider } = await import(
+        '../src/tunnel/ngrok-tunnel-provider.js'
+      );
+      const port = await listen(server);
+      provider = new NgrokTunnelProvider({
+        addr: `http://127.0.0.1:${port}`,
+        metadata: 'hybridclaw-live-test',
+      });
+
+      const result = await provider.start();
+      expect(result.public_url).toMatch(/^https?:\/\//);
+
+      const body = await fetchTextWithRetry(result.public_url);
+      expect(body).toBe(marker);
+    } finally {
+      if (provider) {
+        await provider.stop().catch(() => {});
+      }
+      await closeServer(server).catch(() => {});
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      restoreEnvVar('HYBRIDCLAW_DATA_DIR', ORIGINAL_DATA_DIR);
+      restoreEnvVar('HOME', ORIGINAL_HOME);
+      restoreEnvVar('HYBRIDCLAW_MASTER_KEY', ORIGINAL_MASTER_KEY);
+      vi.resetModules();
+    }
+  },
+  120_000,
+);

--- a/tests/ngrok-tunnel.test.ts
+++ b/tests/ngrok-tunnel.test.ts
@@ -16,7 +16,7 @@ describe('NgrokTunnelProvider', () => {
         secretName === 'NGROK_AUTHTOKEN' ? ' test-token ' : null,
     });
 
-    await expect(provider.status()).resolves.toEqual({
+    expect(provider.status()).toEqual({
       running: false,
       public_url: null,
     });
@@ -29,14 +29,14 @@ describe('NgrokTunnelProvider', () => {
       authtoken: 'test-token',
       proto: 'http',
     });
-    await expect(provider.status()).resolves.toEqual({
+    expect(provider.status()).toEqual({
       running: true,
       public_url: 'https://abc123.ngrok.app',
     });
 
     await provider.stop();
     expect(close).toHaveBeenCalledTimes(1);
-    await expect(provider.status()).resolves.toEqual({
+    expect(provider.status()).toEqual({
       running: false,
       public_url: null,
     });
@@ -97,7 +97,7 @@ describe('NgrokTunnelProvider', () => {
     expect(thrown?.message).toContain('Failed to start ngrok tunnel');
     expect(thrown?.message).not.toContain('secret-token');
     expect(close).toHaveBeenCalledTimes(1);
-    await expect(provider.status()).resolves.toEqual({
+    expect(provider.status()).toEqual({
       running: false,
       public_url: null,
     });

--- a/tests/ngrok-tunnel.test.ts
+++ b/tests/ngrok-tunnel.test.ts
@@ -75,6 +75,37 @@ describe('NgrokTunnelProvider', () => {
     await provider.stop();
   });
 
+  it('clears local state and warns when stopping fails', async () => {
+    const close = vi.fn(async () => {
+      throw new Error('close failed');
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const forward = vi.fn(async () => ({
+      close,
+      url: () => 'https://stop-failure.ngrok.app',
+    }));
+    const provider = new NgrokTunnelProvider({
+      loadNgrok: async () => ({ forward }),
+      readSecret: () => 'test-token',
+    });
+
+    try {
+      await provider.start();
+      await expect(provider.stop()).resolves.toBeUndefined();
+
+      expect(close).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(
+        '[tunnel] failed to stop ngrok tunnel cleanly; local tunnel state was cleared.',
+      );
+      expect(provider.status()).toEqual({
+        running: false,
+        public_url: null,
+      });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it('closes the listener and redacts the token when startup fails after connecting', async () => {
     const close = vi.fn(async () => {});
     const forward = vi.fn(async () => ({

--- a/tests/ngrok-tunnel.test.ts
+++ b/tests/ngrok-tunnel.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { NgrokTunnelProvider } from '../src/tunnel/ngrok-tunnel-provider.js';
+
+describe('NgrokTunnelProvider', () => {
+  it('opens an ngrok tunnel with the encrypted runtime secret token', async () => {
+    const close = vi.fn(async () => {});
+    const forward = vi.fn(async () => ({
+      close,
+      url: () => 'https://abc123.ngrok.app/',
+    }));
+    const provider = new NgrokTunnelProvider({
+      addr: 9090,
+      loadNgrok: async () => ({ forward }),
+      readSecret: (secretName) =>
+        secretName === 'NGROK_AUTHTOKEN' ? ' test-token ' : null,
+    });
+
+    await expect(provider.status()).resolves.toEqual({
+      running: false,
+      public_url: null,
+    });
+
+    await expect(provider.start()).resolves.toEqual({
+      public_url: 'https://abc123.ngrok.app',
+    });
+    expect(forward).toHaveBeenCalledWith({
+      addr: 9090,
+      authtoken: 'test-token',
+      proto: 'http',
+    });
+    await expect(provider.status()).resolves.toEqual({
+      running: true,
+      public_url: 'https://abc123.ngrok.app',
+    });
+
+    await provider.stop();
+    expect(close).toHaveBeenCalledTimes(1);
+    await expect(provider.status()).resolves.toEqual({
+      running: false,
+      public_url: null,
+    });
+  });
+
+  it('does not load ngrok when the auth token is missing', async () => {
+    const loadNgrok = vi.fn();
+    const provider = new NgrokTunnelProvider({
+      loadNgrok,
+      readSecret: () => null,
+    });
+
+    await expect(provider.start()).rejects.toThrow('NGROK_AUTHTOKEN');
+    expect(loadNgrok).not.toHaveBeenCalled();
+  });
+
+  it('returns the existing tunnel when start is called while running', async () => {
+    const close = vi.fn(async () => {});
+    const forward = vi.fn(async () => ({
+      close,
+      url: () => 'https://stable.ngrok.app',
+    }));
+    const provider = new NgrokTunnelProvider({
+      loadNgrok: async () => ({ forward }),
+      readSecret: () => 'test-token',
+    });
+
+    await expect(provider.start()).resolves.toEqual({
+      public_url: 'https://stable.ngrok.app',
+    });
+    await expect(provider.start()).resolves.toEqual({
+      public_url: 'https://stable.ngrok.app',
+    });
+
+    expect(forward).toHaveBeenCalledTimes(1);
+    await provider.stop();
+  });
+
+  it('closes the listener and redacts the token when startup fails after connecting', async () => {
+    const close = vi.fn(async () => {});
+    const forward = vi.fn(async () => ({
+      close,
+      url: () => null,
+    }));
+    const provider = new NgrokTunnelProvider({
+      loadNgrok: async () => ({ forward }),
+      readSecret: () => 'secret-token',
+    });
+
+    let thrown: Error | null = null;
+    try {
+      await provider.start();
+    } catch (error) {
+      thrown = error instanceof Error ? error : new Error(String(error));
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown?.message).toContain('Failed to start ngrok tunnel');
+    expect(thrown?.message).not.toContain('secret-token');
+    expect(close).toHaveBeenCalledTimes(1);
+    await expect(provider.status()).resolves.toEqual({
+      running: false,
+      public_url: null,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #567.

Adds the foundational tunnel abstraction and an ngrok reference implementation for local deployment mode. The ngrok provider reads `NGROK_AUTHTOKEN` from the encrypted runtime secret store, starts an HTTP tunnel with the official `@ngrok/ngrok` SDK, exposes the public URL through the `TunnelProvider` contract, and cleans up listeners on stop or failed startup.

## Impact

- Adds `TunnelProvider.start()`, `stop()`, and `status()` primitives.
- Adds ngrok tunnel startup with URL normalization and token redaction in errors.
- Documents the `NGROK_AUTHTOKEN` runtime secret.
- Adds mocked unit coverage plus a skipped-by-default live ngrok sandbox test.

## Validation

- `npm run format`
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/ngrok-tunnel.test.ts`
- `npm run typecheck`
- `npm run lint`
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.live.config.ts tests/ngrok-tunnel.live.test.ts` (skipped without live ngrok env)
- `npm run check`
- `git diff --check`
