### PR TITLE
[codex] Trajectory capture from event bus

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,5 @@
 {
-  "version": 22,
+  "version": 23,
   "security": {
     "trustModelAccepted": false,
     "trustModelAcceptedAt": "",
@@ -44,6 +44,10 @@
   "adaptiveSkills": {
     "enabled": false,
     "observationEnabled": true,
+    "trajectoryCapture": {
+      "enabledAgentIds": [],
+      "storeDir": ""
+    },
     "inspectionIntervalMs": 3600000,
     "observationRetentionDays": 30,
     "trailingWindowHours": 168,

--- a/docs/content/extensibility/adaptive-skills.md
+++ b/docs/content/extensibility/adaptive-skills.md
@@ -41,7 +41,11 @@ is disabled by default.
     "degradationToolBreakageThreshold": 0.3,
     "autoApplyEnabled": false,
     "evaluationRunsBeforeRollback": 10,
-    "rollbackImprovementThreshold": 0.05
+    "rollbackImprovementThreshold": 0.05,
+    "trajectoryCapture": {
+      "enabledAgentIds": [],
+      "storeDir": ""
+    }
   }
 }
 ```
@@ -57,6 +61,11 @@ Key settings:
 - `trailingWindowHours`: observation lookback used when computing health
 - `autoApplyEnabled`: only applies staged amendments automatically when the
   guard verdict is `safe` with zero findings
+- `trajectoryCapture.enabledAgentIds`: opt-in agent IDs whose full redacted
+  skill-run trajectories are appended to JSONL files
+- `trajectoryCapture.storeDir`: optional trajectory store location; empty uses
+  a `trajectories/` directory beside the runtime database, absolute paths are
+  used as-is, and relative paths resolve under the runtime home directory
 
 Legacy `skillCognee` config input is still normalized into `adaptiveSkills` for
 backward compatibility.

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -142,7 +142,12 @@ saved revision history directly.
 - `proactive.delegation.model` for pinning delegated subagent work to a
   dedicated model while the parent turn keeps its own session or agent model;
   leave it empty to use the parent model
-- `adaptiveSkills.*` for skill observation, amendment staging, and rollback
+- `adaptiveSkills.*` for skill observation, amendment staging, rollback, and
+  opt-in trajectory capture via
+  `adaptiveSkills.trajectoryCapture.enabledAgentIds`; when
+  `adaptiveSkills.trajectoryCapture.storeDir` is empty, trajectories are stored
+  beside the runtime database, absolute paths are used as-is, and relative paths
+  resolve under the runtime home directory
 - `imessage.*` for the dual-backend local or BlueBubbles iMessage transport;
   prefer storing the BlueBubbles password as `IMESSAGE_PASSWORD` in the
   encrypted secret store instead of plaintext config

--- a/docs/development/extensibility/adaptive-skills.md
+++ b/docs/development/extensibility/adaptive-skills.md
@@ -41,7 +41,11 @@ is disabled by default.
     "degradationToolBreakageThreshold": 0.3,
     "autoApplyEnabled": false,
     "evaluationRunsBeforeRollback": 10,
-    "rollbackImprovementThreshold": 0.05
+    "rollbackImprovementThreshold": 0.05,
+    "trajectoryCapture": {
+      "enabledAgentIds": [],
+      "storeDir": ""
+    }
   }
 }
 ```
@@ -57,6 +61,11 @@ Key settings:
 - `trailingWindowHours`: observation lookback used when computing health
 - `autoApplyEnabled`: only applies staged amendments automatically when the
   guard verdict is `safe` with zero findings
+- `trajectoryCapture.enabledAgentIds`: opt-in agent IDs whose full redacted
+  skill-run trajectories are appended to JSONL files
+- `trajectoryCapture.storeDir`: optional trajectory store location; empty uses
+  a `trajectories/` directory beside the runtime database, absolute paths are
+  used as-is, and relative paths resolve under the runtime home directory
 
 Legacy `skillCognee` config input is still normalized into `adaptiveSkills` for
 backward compatibility.

--- a/docs/development/reference/configuration.md
+++ b/docs/development/reference/configuration.md
@@ -116,7 +116,12 @@ leak into the saved revision metadata.
 - `plugins.list[]` for plugin overrides and config; use
   `hybridclaw plugin config <plugin-id> [key] [value|--unset]` for focused
   edits
-- `adaptiveSkills.*` for skill observation, amendment staging, and rollback
+- `adaptiveSkills.*` for skill observation, amendment staging, rollback, and
+  opt-in trajectory capture via
+  `adaptiveSkills.trajectoryCapture.enabledAgentIds`; when
+  `adaptiveSkills.trajectoryCapture.storeDir` is empty, trajectories are stored
+  beside the runtime database, absolute paths are used as-is, and relative paths
+  resolve under the runtime home directory
 - `imessage.*` for the dual-backend local or BlueBubbles iMessage transport;
   prefer storing the BlueBubbles password as `IMESSAGE_PASSWORD` in the
   encrypted secret store instead of plaintext config

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -67,6 +67,7 @@ import {
   normalizeOptionalTrimmedUniqueStringArray,
   normalizeTrimmedStringSet,
 } from '../utils/normalized-strings.js';
+import { expandHomePath } from '../utils/path.js';
 import {
   clearRuntimeAssetRevisions as clearTrackedRuntimeAssetRevisions,
   clearRuntimeConfigRevisions as clearTrackedRuntimeConfigRevisions,
@@ -95,7 +96,7 @@ import {
 import { DEFAULT_RUNTIME_HOME_DIR } from './runtime-paths.js';
 
 export const CONFIG_FILE_NAME = 'config.json';
-export const CONFIG_VERSION = 22;
+export const CONFIG_VERSION = 23;
 export const SECURITY_POLICY_VERSION = '2026-02-28';
 export const DEFAULT_HYBRIDAI_MODEL = 'gpt-5.4-mini';
 const LEGACY_DEFAULT_DB_PATH = 'data/hybridclaw.db';
@@ -1010,6 +1011,10 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
   adaptiveSkills: {
     enabled: false,
     observationEnabled: true,
+    trajectoryCapture: {
+      enabledAgentIds: [],
+      storeDir: '',
+    },
     inspectionIntervalMs: 3_600_000,
     observationRetentionDays: 30,
     trailingWindowHours: 168,
@@ -2227,15 +2232,6 @@ function normalizeCodexModelArray(
 
 function normalizePathForCompare(value: string): string {
   return value.replace(/\\/g, '/').replace(/\/+/g, '/').trim();
-}
-
-function expandHomePath(value: string): string {
-  const normalized = value.trim();
-  if (normalized === '~') return os.homedir();
-  if (normalized.startsWith('~/') || normalized.startsWith('~\\')) {
-    return path.join(os.homedir(), normalized.slice(2));
-  }
-  return normalized;
 }
 
 function isLegacyDefaultDbPath(value: string): boolean {
@@ -4262,6 +4258,9 @@ function normalizeRuntimeConfig(
   const rawAdaptiveSkills = isRecord(raw.adaptiveSkills)
     ? raw.adaptiveSkills
     : {};
+  const rawTrajectoryCapture = isRecord(rawAdaptiveSkills.trajectoryCapture)
+    ? rawAdaptiveSkills.trajectoryCapture
+    : {};
   const rawChannelInstructions = isRecord(raw.channelInstructions)
     ? raw.channelInstructions
     : {};
@@ -4646,6 +4645,18 @@ function normalizeRuntimeConfig(
         rawAdaptiveSkills.observationEnabled,
         DEFAULT_RUNTIME_CONFIG.adaptiveSkills.observationEnabled,
       ),
+      trajectoryCapture: {
+        enabledAgentIds: normalizeStringArray(
+          rawTrajectoryCapture.enabledAgentIds,
+          DEFAULT_RUNTIME_CONFIG.adaptiveSkills.trajectoryCapture
+            .enabledAgentIds,
+        ),
+        storeDir: normalizeString(
+          rawTrajectoryCapture.storeDir,
+          DEFAULT_RUNTIME_CONFIG.adaptiveSkills.trajectoryCapture.storeDir,
+          { allowEmpty: true },
+        ),
+      },
       inspectionIntervalMs: normalizeInteger(
         rawAdaptiveSkills.inspectionIntervalMs,
         DEFAULT_RUNTIME_CONFIG.adaptiveSkills.inspectionIntervalMs,

--- a/src/media/path-utils.ts
+++ b/src/media/path-utils.ts
@@ -1,11 +1,1 @@
-import os from 'node:os';
-import path from 'node:path';
-
-export function expandUserPath(input: string): string {
-  const trimmed = input.trim();
-  if (trimmed === '~') return os.homedir();
-  if (trimmed.startsWith('~/') || trimmed.startsWith('~\\')) {
-    return path.join(os.homedir(), trimmed.slice(2));
-  }
-  return trimmed;
-}
+export { expandHomePath as expandUserPath } from '../utils/path.js';

--- a/src/media/pdf-context.ts
+++ b/src/media/pdf-context.ts
@@ -1,5 +1,4 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -18,6 +17,7 @@ import type {
   ChatMessageContent,
 } from '../types/api.js';
 import type { MediaContextItem } from '../types/container.js';
+import { expandHomePath } from '../utils/path.js';
 import {
   resolveUploadedMediaCacheHostDir,
   UPLOADED_MEDIA_CACHE_ROOT_DISPLAY,
@@ -132,15 +132,6 @@ function cleanCandidate(value: string): string {
 
 function looksLikePdfReference(value: string): boolean {
   return /\.pdf$/i.test(cleanCandidate(value));
-}
-
-function expandUserPath(input: string): string {
-  const trimmed = input.trim();
-  if (trimmed === '~') return os.homedir();
-  if (trimmed.startsWith('~/') || trimmed.startsWith('~\\')) {
-    return path.join(os.homedir(), trimmed.slice(2));
-  }
-  return trimmed;
 }
 
 function escapeXmlAttr(value: string): string {
@@ -325,7 +316,7 @@ async function resolveAllowedHostPdfPath(params: {
   if (displayResolved) {
     resolved = displayResolved;
   } else {
-    const expanded = expandUserPath(candidate);
+    const expanded = expandHomePath(candidate);
     if (!expanded) return null;
 
     const hasPathPrefix =

--- a/src/plugins/plugin-install.ts
+++ b/src/plugins/plugin-install.ts
@@ -11,6 +11,7 @@ import {
 import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
 import { readStoredRuntimeSecret } from '../security/runtime-secrets.js';
 import { hasExecutableCommand } from '../utils/executables.js';
+import { expandHomePath } from '../utils/path.js';
 import {
   allRequiredBinsAvailable,
   checkPluginDependencies,
@@ -203,11 +204,7 @@ function defaultRunCommand({ command, args, cwd }: PluginCommand): void {
 }
 
 function expandUserPath(input: string, cwd: string): string {
-  if (input === '~') return os.homedir();
-  if (input.startsWith('~/')) {
-    return path.join(os.homedir(), input.slice(2));
-  }
-  return path.resolve(cwd, input);
+  return path.resolve(cwd, expandHomePath(input));
 }
 
 function looksLikeLocalPath(input: string): boolean {

--- a/src/security/media-paths.ts
+++ b/src/security/media-paths.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { logger } from '../logger.js';
+import { expandHomePath } from '../utils/path.js';
 import { resolveConfiguredAdditionalMounts } from './mount-config.js';
 import { validateAdditionalMounts } from './mount-security.js';
 
@@ -33,12 +34,7 @@ async function resolveCanonicalPath(filePath: string): Promise<string> {
 }
 
 function expandPathInput(input: string): string {
-  const trimmed = input.trim();
-  if (trimmed === '~') return os.homedir();
-  if (trimmed.startsWith('~/') || trimmed.startsWith('~\\')) {
-    return path.join(os.homedir(), trimmed.slice(2));
-  }
-  return trimmed;
+  return expandHomePath(input);
 }
 
 async function isManagedTempMediaPath(

--- a/src/security/mount-config.ts
+++ b/src/security/mount-config.ts
@@ -1,8 +1,8 @@
-import os from 'node:os';
 import path from 'node:path';
 
 import type { RuntimeConfig } from '../config/runtime-config.js';
 import type { AdditionalMount } from '../types/security.js';
+import { expandHomePath } from '../utils/path.js';
 
 export interface ConfiguredMountParseResult {
   mounts: AdditionalMount[];
@@ -10,13 +10,8 @@ export interface ConfiguredMountParseResult {
 }
 
 function expandUserPath(input: string): string {
-  const trimmed = input.trim();
-  if (!trimmed) return '';
-  if (trimmed === '~') return os.homedir();
-  if (trimmed.startsWith('~/') || trimmed.startsWith('~\\')) {
-    return path.join(os.homedir(), trimmed.slice(2));
-  }
-  return path.resolve(trimmed);
+  const expanded = expandHomePath(input);
+  return expanded ? path.resolve(expanded) : '';
 }
 
 function normalizeMountKey(mount: AdditionalMount): string {

--- a/src/skills/adaptive-skills-types.ts
+++ b/src/skills/adaptive-skills-types.ts
@@ -136,6 +136,10 @@ export interface SkillAmendment {
 export interface AdaptiveSkillsConfig {
   enabled: boolean;
   observationEnabled: boolean;
+  trajectoryCapture: {
+    enabledAgentIds: string[];
+    storeDir: string;
+  };
   inspectionIntervalMs: number;
   observationRetentionDays: number;
   trailingWindowHours: number;

--- a/src/skills/skill-run-events.ts
+++ b/src/skills/skill-run-events.ts
@@ -28,6 +28,15 @@ export interface SkillRunBoundedPayload {
   truncated: boolean;
 }
 
+export interface SkillRunFullPayload {
+  content: string;
+}
+
+export interface SkillRunPayloads {
+  bounded: SkillRunBoundedPayload | null;
+  full: SkillRunFullPayload | null;
+}
+
 export interface SkillRunToolExecutionSummary {
   name: string;
   duration_ms: number;
@@ -35,6 +44,12 @@ export interface SkillRunToolExecutionSummary {
   blocked: boolean;
   approval_tier?: ToolExecution['approvalTier'];
   approval_decision?: ToolExecution['approvalDecision'];
+}
+
+export interface SkillRunToolExecutionFull
+  extends SkillRunToolExecutionSummary {
+  arguments: SkillRunFullPayload;
+  result: SkillRunFullPayload;
 }
 
 export interface SkillRunEvent {
@@ -45,6 +60,8 @@ export interface SkillRunEvent {
   run_id: string;
   input: SkillRunBoundedPayload | null;
   output: SkillRunBoundedPayload | null;
+  input_full: SkillRunFullPayload | null;
+  output_full: SkillRunFullPayload | null;
   model: string | null;
   tokens: SkillRunTokenEnvelope;
   latency_ms: number;
@@ -54,6 +71,7 @@ export interface SkillRunEvent {
   error_category: SkillErrorCategory | null;
   error_detail: string | null;
   tool_executions: SkillRunToolExecutionSummary[];
+  tool_executions_full: SkillRunToolExecutionFull[];
 }
 
 export type SkillRunSubscriber = (event: SkillRunEvent) => unknown;
@@ -70,21 +88,41 @@ export function subscribeSkillRunEvents(
   };
 }
 
+function summarizeSkillRunToolExecution(
+  execution: ToolExecution,
+): SkillRunToolExecutionSummary {
+  return {
+    name: execution.name,
+    duration_ms: execution.durationMs,
+    is_error: Boolean(execution.isError),
+    blocked: Boolean(execution.blocked),
+    ...(execution.approvalTier
+      ? { approval_tier: execution.approvalTier }
+      : {}),
+    ...(execution.approvalDecision
+      ? { approval_decision: execution.approvalDecision }
+      : {}),
+  };
+}
+
 export function summarizeSkillRunToolExecutions(
   toolExecutions: ToolExecution[],
 ): SkillRunToolExecutionSummary[] {
+  return toolExecutions.map(summarizeSkillRunToolExecution);
+}
+
+export function buildSkillRunFullToolExecutions(
+  toolExecutions: ToolExecution[],
+): SkillRunToolExecutionFull[] {
   return toolExecutions.map((execution) => {
     return {
-      name: execution.name,
-      duration_ms: execution.durationMs,
-      is_error: Boolean(execution.isError),
-      blocked: Boolean(execution.blocked),
-      ...(execution.approvalTier
-        ? { approval_tier: execution.approvalTier }
-        : {}),
-      ...(execution.approvalDecision
-        ? { approval_decision: execution.approvalDecision }
-        : {}),
+      ...summarizeSkillRunToolExecution(execution),
+      arguments: {
+        content: stringifyRedactedSkillRunPayload(execution.arguments) ?? '',
+      },
+      result: {
+        content: stringifyRedactedSkillRunPayload(execution.result) ?? '',
+      },
     };
   });
 }
@@ -98,12 +136,14 @@ function stringifySkillRunPayload(value: unknown): string {
   }
 }
 
-export function buildSkillRunBoundedPayload(
-  value: unknown,
-): SkillRunBoundedPayload | null {
+function stringifyRedactedSkillRunPayload(value: unknown): string | null {
   if (value == null) return null;
-  const redacted = redactSecretsDeep(value);
-  const content = stringifySkillRunPayload(redacted);
+  return stringifySkillRunPayload(redactSecretsDeep(value));
+}
+
+function buildBoundedPayloadFromContent(
+  content: string,
+): SkillRunBoundedPayload {
   if (content.length <= MAX_SKILL_RUN_PAYLOAD_CHARS) {
     return { content, truncated: false };
   }
@@ -111,6 +151,29 @@ export function buildSkillRunBoundedPayload(
     content: `${content.slice(0, MAX_SKILL_RUN_PAYLOAD_CHARS)}...`,
     truncated: true,
   };
+}
+
+export function buildSkillRunPayloads(value: unknown): SkillRunPayloads {
+  const content = stringifyRedactedSkillRunPayload(value);
+  if (content == null) return { bounded: null, full: null };
+  return {
+    bounded: buildBoundedPayloadFromContent(content),
+    full: { content },
+  };
+}
+
+export function buildSkillRunBoundedPayload(
+  value: unknown,
+): SkillRunBoundedPayload | null {
+  const content = stringifyRedactedSkillRunPayload(value);
+  if (content == null) return null;
+  return buildBoundedPayloadFromContent(content);
+}
+
+export function buildSkillRunFullPayload(
+  value: unknown,
+): SkillRunFullPayload | null {
+  return buildSkillRunPayloads(value).full;
 }
 
 export function emitSkillRunEvent(event: SkillRunEvent): void {

--- a/src/skills/skill-run-trajectories.ts
+++ b/src/skills/skill-run-trajectories.ts
@@ -1,0 +1,170 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  getRuntimeConfig,
+  type RuntimeConfig,
+} from '../config/runtime-config.js';
+import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+import { logger } from '../logger.js';
+import { expandHomePath } from '../utils/path.js';
+import type { SkillRunEvent } from './skill-run-events.js';
+
+export const SKILL_RUN_TRAJECTORY_SCHEMA_VERSION = 1;
+const SKILL_RUN_TRAJECTORY_DIR_MODE = 0o700;
+let loggedTrajectoryCaptureConfigKey: string | null = null;
+
+export interface SkillRunTrajectoryRecord {
+  schema_version: typeof SKILL_RUN_TRAJECTORY_SCHEMA_VERSION;
+  captured_at: string;
+  date: string;
+  agent_id: string;
+  event: SkillRunEvent;
+}
+
+function safeFilePart(raw: string): string {
+  const normalized = raw.trim().replace(/[^a-zA-Z0-9_-]/g, '_');
+  return normalized || 'unknown';
+}
+
+function resolveTrajectoryStoreDir(config: RuntimeConfig): string {
+  const configured = config.adaptiveSkills.trajectoryCapture.storeDir.trim();
+  if (!configured) {
+    return path.join(path.dirname(config.ops.dbPath), 'trajectories');
+  }
+
+  const expanded = expandHomePath(configured);
+  if (path.isAbsolute(expanded)) return expanded;
+  return path.join(DEFAULT_RUNTIME_HOME_DIR, expanded);
+}
+
+function normalizedTrajectoryCaptureAgentIds(config: RuntimeConfig): string[] {
+  const enabledAgentIds =
+    config.adaptiveSkills.trajectoryCapture.enabledAgentIds;
+  if (enabledAgentIds.length === 0) return [];
+  return enabledAgentIds.map((agentId) => agentId.trim()).filter(Boolean);
+}
+
+function logTrajectoryCaptureEnabledOnce(input: {
+  agentIds: string[];
+  storeDir: string;
+}): void {
+  const configKey = `${input.storeDir}\0${input.agentIds.join('\0')}`;
+  if (loggedTrajectoryCaptureConfigKey === configKey) return;
+  loggedTrajectoryCaptureConfigKey = configKey;
+  logger.info(
+    {
+      agentIds: input.agentIds,
+      storeDir: input.storeDir,
+    },
+    `Trajectory capture enabled for agents: [${input.agentIds.join(', ')}] -> ${
+      input.storeDir
+    }`,
+  );
+}
+
+export function isTrajectoryCaptureEnabledForAgentId(
+  agentId: string | null | undefined,
+  config: RuntimeConfig,
+): agentId is string {
+  const normalizedAgentId = agentId?.trim();
+  if (!normalizedAgentId) return false;
+  const enabledAgentIds =
+    config.adaptiveSkills.trajectoryCapture.enabledAgentIds;
+  if (enabledAgentIds.length === 0) return false;
+  return enabledAgentIds.some((enabledAgentId) => {
+    return enabledAgentId.trim() === normalizedAgentId;
+  });
+}
+
+function isTrajectoryCaptureEnabledForAgent(
+  event: SkillRunEvent,
+  enabledAgentIds: string[],
+): event is SkillRunEvent & { agent_id: string } {
+  const agentId = event.agent_id?.trim();
+  if (!agentId) return false;
+  return enabledAgentIds.includes(agentId);
+}
+
+export function skillRunTrajectoryFilePath(input: {
+  storeDir: string;
+  date: string;
+  agentId: string;
+}): string {
+  return path.join(
+    input.storeDir,
+    input.date,
+    `${safeFilePart(input.agentId)}.jsonl`,
+  );
+}
+
+function ensurePrivateTrajectoryDirectories(input: {
+  storeDir: string;
+  dateDir: string;
+}): void {
+  fs.mkdirSync(input.storeDir, {
+    recursive: true,
+    mode: SKILL_RUN_TRAJECTORY_DIR_MODE,
+  });
+  fs.mkdirSync(input.dateDir, {
+    recursive: true,
+    mode: SKILL_RUN_TRAJECTORY_DIR_MODE,
+  });
+}
+
+export function buildSkillRunTrajectoryRecord(
+  event: SkillRunEvent & { agent_id: string },
+  capturedAt = new Date(),
+): SkillRunTrajectoryRecord {
+  const captured_at = capturedAt.toISOString();
+  return {
+    schema_version: SKILL_RUN_TRAJECTORY_SCHEMA_VERSION,
+    captured_at,
+    date: captured_at.slice(0, 10),
+    agent_id: event.agent_id,
+    event,
+  };
+}
+
+export function recordSkillRunTrajectory(event: SkillRunEvent): void {
+  const config = getRuntimeConfig();
+  const enabledAgentIds = normalizedTrajectoryCaptureAgentIds(config);
+  if (enabledAgentIds.length === 0) {
+    loggedTrajectoryCaptureConfigKey = null;
+    return;
+  }
+
+  const storeDir = resolveTrajectoryStoreDir(config);
+  logTrajectoryCaptureEnabledOnce({
+    agentIds: enabledAgentIds,
+    storeDir,
+  });
+  if (!isTrajectoryCaptureEnabledForAgent(event, enabledAgentIds)) return;
+
+  try {
+    const record = buildSkillRunTrajectoryRecord(event);
+    const filePath = skillRunTrajectoryFilePath({
+      storeDir,
+      date: record.date,
+      agentId: record.agent_id,
+    });
+    ensurePrivateTrajectoryDirectories({
+      storeDir,
+      dateDir: path.dirname(filePath),
+    });
+    fs.appendFileSync(filePath, `${JSON.stringify(record)}\n`, {
+      encoding: 'utf-8',
+      mode: 0o600,
+    });
+  } catch (error) {
+    logger.warn(
+      {
+        sessionId: event.session_id,
+        runId: event.run_id,
+        skillId: event.skill_id,
+        agentId: event.agent_id,
+        error,
+      },
+      'Failed to append skill run trajectory',
+    );
+  }
+}

--- a/src/skills/skills-import.ts
+++ b/src/skills/skills-import.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 
 import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
 import { resolveInstallPath } from '../infra/install-root.js';
+import { expandHomePath } from '../utils/path.js';
 import { SkillImportError } from './skill-errors.js';
 import { normalizeImportedSkillRelativePath } from './skill-import-commons.js';
 import type { SkillGuardDecision, SkillGuardVerdict } from './skills-guard.js';
@@ -157,16 +158,14 @@ function parseLocalSource(input: string): LocalSkillImportSource | null {
 
   const isExplicitLocal =
     trimmed.startsWith('~/') ||
+    trimmed.startsWith('~\\') ||
     trimmed.startsWith('./') ||
     trimmed.startsWith('../') ||
     path.isAbsolute(trimmed);
 
   if (!isExplicitLocal) return null;
 
-  const expanded = trimmed.startsWith('~/')
-    ? path.join(os.homedir(), trimmed.slice(2))
-    : trimmed;
-  const resolved = path.resolve(expanded);
+  const resolved = path.resolve(expandHomePath(trimmed));
 
   return {
     kind: 'local',

--- a/src/skills/skills-observation.ts
+++ b/src/skills/skills-observation.ts
@@ -23,12 +23,19 @@ import {
 } from './agent-scoreboard.js';
 import {
   buildSkillRunBoundedPayload,
+  buildSkillRunFullToolExecutions,
+  buildSkillRunPayloads,
   buildSkillRunTokens,
   emitSkillRunEvent,
   type SkillRunEvent,
+  type SkillRunPayloads,
   subscribeSkillRunEvents,
   summarizeSkillRunToolExecutions,
 } from './skill-run-events.js';
+import {
+  isTrajectoryCaptureEnabledForAgentId,
+  recordSkillRunTrajectory,
+} from './skill-run-trajectories.js';
 import { evaluateAmendment, rollbackAmendment } from './skills-evaluation.js';
 
 let queuedSkillEvaluationWork: Promise<void> = Promise.resolve();
@@ -192,6 +199,7 @@ export async function waitForQueuedSkillEvaluations(): Promise<void> {
 
 subscribeSkillRunEvents(recordSkillExecutionObservation);
 subscribeSkillRunEvents(refreshAgentCvForSkillRun);
+subscribeSkillRunEvents(recordSkillRunTrajectory);
 
 function collectSkillRunErrors(input: {
   errorDetail?: string | null;
@@ -218,6 +226,17 @@ function normalizeSkillRunCostUsd(costUsd?: number | null): number {
   return 0;
 }
 
+function buildSkillRunEventPayloads(
+  value: unknown,
+  includeFull: boolean,
+): SkillRunPayloads {
+  if (includeFull) return buildSkillRunPayloads(value);
+  return {
+    bounded: buildSkillRunBoundedPayload(value),
+    full: null,
+  };
+}
+
 export function recordSkillExecution(input: {
   skillName: string;
   sessionId: string;
@@ -242,14 +261,30 @@ export function recordSkillExecution(input: {
     classifyErrorCategory(input.toolExecutions, input.errorDetail);
   const errorDetail =
     input.errorDetail?.trim() || firstFailedToolDetail(input.toolExecutions);
+  const config = getRuntimeConfig();
+  const agentId = input.agentId?.trim() || null;
+  const includeFullPayloads = isTrajectoryCaptureEnabledForAgentId(
+    agentId,
+    config,
+  );
+  const inputPayloads = buildSkillRunEventPayloads(
+    input.input,
+    includeFullPayloads,
+  );
+  const outputPayloads = buildSkillRunEventPayloads(
+    input.output,
+    includeFullPayloads,
+  );
   const event: SkillRunEvent = {
     type: 'skill_run',
     skill_id: skillName,
-    agent_id: input.agentId?.trim() || null,
+    agent_id: agentId,
     session_id: input.sessionId,
     run_id: input.runId,
-    input: buildSkillRunBoundedPayload(input.input),
-    output: buildSkillRunBoundedPayload(input.output),
+    input: inputPayloads.bounded,
+    output: outputPayloads.bounded,
+    input_full: inputPayloads.full,
+    output_full: outputPayloads.full,
     model: input.model?.trim() || null,
     tokens: buildSkillRunTokens(input.tokenUsage),
     latency_ms: input.durationMs,
@@ -262,6 +297,9 @@ export function recordSkillExecution(input: {
     error_category: errorCategory,
     error_detail: errorDetail,
     tool_executions: summarizeSkillRunToolExecutions(input.toolExecutions),
+    tool_executions_full: includeFullPayloads
+      ? buildSkillRunFullToolExecutions(input.toolExecutions)
+      : [],
   };
 
   emitSkillRunEvent(event);

--- a/src/skills/skills.ts
+++ b/src/skills/skills.ts
@@ -24,6 +24,7 @@ import { withSpanSync } from '../observability/otel.js';
 import type { ToolExecution } from '../types/execution.js';
 import { hasExecutableCommand } from '../utils/executables.js';
 import { normalizeTrimmedUniqueStringArray } from '../utils/normalized-strings.js';
+import { expandHomePath } from '../utils/path.js';
 import { isRecord } from '../utils/type-guards.js';
 import { guardSkillDirectory } from './skills-guard.js';
 
@@ -826,13 +827,8 @@ function asPromptLocation(
 }
 
 function resolveUserPath(raw: string): string {
-  const value = raw.trim();
-  if (!value) return '';
-  if (value === '~') return os.homedir();
-  if (value.startsWith('~/') || value.startsWith('~\\')) {
-    return path.join(os.homedir(), value.slice(2));
-  }
-  return path.resolve(value);
+  const expanded = expandHomePath(raw);
+  return expanded ? path.resolve(expanded) : '';
 }
 
 function resolveBundledSkillsDir(): string | null {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,0 +1,11 @@
+import os from 'node:os';
+import path from 'node:path';
+
+export function expandHomePath(input: string): string {
+  const trimmed = input.trim();
+  if (trimmed === '~') return os.homedir();
+  if (trimmed.startsWith('~/') || trimmed.startsWith('~\\')) {
+    return path.join(os.homedir(), trimmed.slice(2));
+  }
+  return trimmed;
+}

--- a/tests/path-utils.test.ts
+++ b/tests/path-utils.test.ts
@@ -1,0 +1,20 @@
+import os from 'node:os';
+import path from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import { expandHomePath } from '../src/utils/path.ts';
+
+test('expands home-prefixed paths with slash and backslash separators', () => {
+  expect(expandHomePath('~/workspace')).toBe(
+    path.join(os.homedir(), 'workspace'),
+  );
+  expect(expandHomePath('~\\workspace')).toBe(
+    path.join(os.homedir(), 'workspace'),
+  );
+});
+
+test('trims path input and leaves non-home paths unchanged', () => {
+  expect(expandHomePath('  ~  ')).toBe(os.homedir());
+  expect(expandHomePath('  ./relative/path  ')).toBe('./relative/path');
+});

--- a/tests/skills-observation.test.ts
+++ b/tests/skills-observation.test.ts
@@ -494,10 +494,11 @@ test('emits a skill_run event to subscribers for every skill execution', async (
           name: 'bash',
           arguments: JSON.stringify({
             cmd: 'echo hello',
-            apiKey: 'test-key',
-            nested: { token: 'secret-token' },
+            apiKey: 'sk-1234567890abcdefghijklmnop',
+            nested: { token: 'Bearer 1234567890abcdefghijklmnopqrstuv' },
+            body: 'a'.repeat(4_500),
           }),
-          result: `${'x'.repeat(320)} secret-token`,
+          result: `${'x'.repeat(4_500)} OPENAI_API_KEY=sk-1234567890abcdefghijklmnop`,
           durationMs: 11,
         },
       ],
@@ -564,10 +565,12 @@ test('emits a skill_run event to subscribers for every skill execution', async (
       content: expect.stringContaining('draft the note'),
       truncated: true,
     },
+    input_full: null,
     output: {
       content: '{"text":"done","token":"***"}',
       truncated: false,
     },
+    output_full: null,
     model: 'test-model',
     tokens: {
       prompt: 9,
@@ -593,9 +596,14 @@ test('emits a skill_run event to subscribers for every skill execution', async (
         blocked: false,
       },
     ],
+    tool_executions_full: [],
   });
-  expect(JSON.stringify(events[0])).not.toContain('echo hello');
-  expect(JSON.stringify(events[0])).not.toContain('secret-token');
+  expect(JSON.stringify(events[0])).not.toContain(
+    'sk-1234567890abcdefghijklmnop',
+  );
+  expect(JSON.stringify(events[0])).not.toContain(
+    '1234567890abcdefghijklmnopqrstuv',
+  );
   expect(JSON.stringify(events[0])).not.toContain('test-key');
   expect(
     (events[0] as { input: { content: string } }).input.content.length,
@@ -605,9 +613,169 @@ test('emits a skill_run event to subscribers for every skill execution', async (
     session_id: 'session-event-2',
     input: null,
     output: null,
+    input_full: null,
+    output_full: null,
+    tool_executions: [],
+    tool_executions_full: [],
     tokens: expect.objectContaining({ modelCalls: 0 }),
     cost_usd: 0,
   });
+});
+
+test('captures opt-in skill_run trajectories in append-only files keyed by date and agent', async () => {
+  context = await createAdaptiveSkillsTestContext();
+  const storeDir = path.join(context.homeDir, 'trajectory-store');
+  context.runtimeConfigModule.updateRuntimeConfig((draft) => {
+    draft.adaptiveSkills.trajectoryCapture.enabledAgentIds = ['agent-1'];
+    draft.adaptiveSkills.trajectoryCapture.storeDir = storeDir;
+  });
+
+  const { logger } = await import('../src/logger.ts');
+  const { recordSkillExecution } = await import(
+    '../src/skills/skills-observation.ts'
+  );
+  const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+
+  recordSkillExecution({
+    skillName: context.skillName,
+    sessionId: 'session-trajectory-1',
+    runId: 'run-trajectory-1',
+    agentId: 'agent-1',
+    toolExecutions: [
+      {
+        name: 'bash',
+        arguments: JSON.stringify({
+          cmd: 'printf data',
+          apiKey: 'sk-1234567890abcdefghijklmnop',
+          body: 'a'.repeat(4_500),
+        }),
+        result: `${'tool-output-'.repeat(450)} OPENAI_API_KEY=sk-1234567890abcdefghijklmnop`,
+        durationMs: 12,
+      },
+    ],
+    outcome: 'success',
+    durationMs: 25,
+    input: {
+      prompt: 'draft the note',
+      body: 'i'.repeat(4_500),
+      apiKey: 'real-secret-value-1234',
+    },
+    output: { text: 'o'.repeat(4_500), token: 'real-secret-value-5678' },
+  });
+  recordSkillExecution({
+    skillName: context.skillName,
+    sessionId: 'session-trajectory-2',
+    runId: 'run-trajectory-2',
+    agentId: 'agent-1',
+    toolExecutions: [],
+    outcome: 'success',
+    durationMs: 30,
+    input: 'second run',
+    output: 'done',
+  });
+  recordSkillExecution({
+    skillName: context.skillName,
+    sessionId: 'session-trajectory-skipped',
+    runId: 'run-trajectory-skipped',
+    agentId: 'agent-2',
+    toolExecutions: [],
+    outcome: 'success',
+    durationMs: 30,
+    input: 'not opted in',
+    output: 'done',
+  });
+
+  const date = new Date().toISOString().slice(0, 10);
+  const trajectoryPath = path.join(storeDir, date, 'agent-1.jsonl');
+  const trajectoryDateDir = path.dirname(trajectoryPath);
+  const rows = fs
+    .readFileSync(trajectoryPath, 'utf-8')
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+  expect(rows).toHaveLength(2);
+  expect(rows[0]).toMatchObject({
+    schema_version: 1,
+    date,
+    agent_id: 'agent-1',
+    event: {
+      type: 'skill_run',
+      skill_id: context.skillName,
+      agent_id: 'agent-1',
+      session_id: 'session-trajectory-1',
+      run_id: 'run-trajectory-1',
+      input: {
+        truncated: true,
+      },
+      input_full: {
+        content: expect.stringContaining('draft the note'),
+      },
+      output_full: {
+        content: expect.stringContaining('o'.repeat(4_500)),
+      },
+      tool_executions_full: [
+        {
+          name: 'bash',
+          arguments: {
+            content: expect.stringContaining('printf data'),
+          },
+          result: {
+            content: expect.stringContaining('tool-output-'),
+          },
+        },
+      ],
+    },
+  });
+  expect(JSON.stringify(rows[0])).not.toContain('real-secret-value');
+  expect(JSON.stringify(rows[0])).not.toContain(
+    'sk-1234567890abcdefghijklmnop',
+  );
+  expect(
+    (
+      rows[0] as {
+        event: { input_full: { content: string } };
+      }
+    ).event.input_full.content.length,
+  ).toBeGreaterThan(4_500);
+  expect(
+    (
+      rows[0] as {
+        event: {
+          tool_executions_full: Array<{
+            arguments: { content: string };
+            result: { content: string };
+          }>;
+        };
+      }
+    ).event.tool_executions_full[0]?.arguments.content.length,
+  ).toBeGreaterThan(4_500);
+  expect(
+    (
+      rows[0] as {
+        event: {
+          tool_executions_full: Array<{
+            arguments: { content: string };
+            result: { content: string };
+          }>;
+        };
+      }
+    ).event.tool_executions_full[0]?.result.content.length,
+  ).toBeGreaterThan(4_500);
+  expect(infoSpy).toHaveBeenCalledTimes(1);
+  expect(infoSpy).toHaveBeenCalledWith(
+    {
+      agentIds: ['agent-1'],
+      storeDir,
+    },
+    `Trajectory capture enabled for agents: [agent-1] -> ${storeDir}`,
+  );
+  infoSpy.mockRestore();
+  if (process.platform !== 'win32') {
+    expect(fs.statSync(storeDir).mode & 0o777).toBe(0o700);
+    expect(fs.statSync(trajectoryDateDir).mode & 0o777).toBe(0o700);
+  }
+  expect(fs.existsSync(path.join(storeDir, date, 'agent-2.jsonl'))).toBe(false);
 });
 
 test('skill_run subscriber failures do not block observation persistence', async () => {


### PR DESCRIPTION
## Summary

Implements #487 by wiring trajectory capture into the existing F2 `skill_run` event bus.

## What changed

- Keeps bounded, redacted `input` and `output` fields on every `skill_run` event for current subscribers.
- Builds redacted, untruncated `input_full`, `output_full`, and `tool_executions_full` only for agents opted into trajectory capture, avoiding default overhead when no agents are configured.
- Registers a trajectory subscriber that writes opted-in agent runs to append-only JSONL files keyed by date and agent ID.
- Adds `adaptiveSkills.trajectoryCapture.enabledAgentIds` for per-agent opt-in and `adaptiveSkills.trajectoryCapture.storeDir` for store location overrides.
- Resolves empty `storeDir` beside the runtime database, which defaults to `~/.hybridclaw/data/trajectories`; absolute paths are used as-is and relative paths resolve under the runtime home directory.
- Creates trajectory directories with `0o700`, files with `0o600`, and logs the resolved target once when trajectory capture is configured.
- Extracts shared home-path expansion into `src/utils/path.ts` and updates existing call sites to use it.
- Updates config and Adaptive Skills docs, plus focused coverage for opt-in capture, append-only behavior, full I/O, redaction, private directory modes, and path expansion.

## Validation

- `npm run check`
- `npm run typecheck`
- `npm run lint`
- `tests/skills-observation.test.ts` with Node v22.15.1
- `tests/path-utils.test.ts`, `tests/media.path-utils.test.ts`, `tests/mount-config.test.ts` with Node v22.15.1

Closes #487.