### PR TITLE
[Roadmap 1.1] A2A envelope schema + persistence

### DIFF
--- a/src/a2a/envelope.ts
+++ b/src/a2a/envelope.ts
@@ -1,0 +1,272 @@
+import { randomUUID } from 'node:crypto';
+import { isRecord } from './utils.js';
+
+export const A2A_ENVELOPE_INTENTS = [
+  'chat',
+  'handoff',
+  'escalate',
+  'ack',
+] as const;
+
+export type A2AEnvelopeIntent = (typeof A2A_ENVELOPE_INTENTS)[number];
+export type A2AAgentIdKind = 'local' | 'canonical';
+
+export interface A2AEnvelope {
+  id: string;
+  sender_agent_id: string;
+  recipient_agent_id: string;
+  thread_id: string;
+  parent_message_id?: string;
+  intent: A2AEnvelopeIntent;
+  content: string;
+  created_at: string;
+}
+
+export type CreateA2AEnvelopeInput = Omit<A2AEnvelope, 'id' | 'created_at'> & {
+  id?: string;
+  created_at?: string;
+};
+
+export class A2AEnvelopeValidationError extends Error {
+  readonly issues: string[];
+
+  constructor(issues: string[]) {
+    super(`Invalid A2A envelope: ${issues.join('; ')}`);
+    this.name = 'A2AEnvelopeValidationError';
+    this.issues = [...issues];
+  }
+}
+
+export class A2AEnvelopeDuplicateError extends A2AEnvelopeValidationError {
+  readonly envelopeId: string;
+  readonly threadId: string;
+
+  constructor(envelopeId: string, threadId: string) {
+    const message = `A2A envelope ${envelopeId} already exists in thread ${threadId}.`;
+    super([message]);
+    this.name = 'A2AEnvelopeDuplicateError';
+    this.message = message;
+    this.envelopeId = envelopeId;
+    this.threadId = threadId;
+  }
+}
+
+const A2A_ENVELOPE_FIELDS = new Set([
+  'id',
+  'sender_agent_id',
+  'recipient_agent_id',
+  'thread_id',
+  'parent_message_id',
+  'intent',
+  'content',
+  'created_at',
+]);
+
+const LOCAL_AGENT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const CANONICAL_AGENT_ID_PATTERN =
+  /^[a-z0-9][a-z0-9._-]{0,127}@[a-z0-9][a-z0-9._-]{0,127}@[a-z0-9][a-z0-9._-]{0,127}$/;
+const OPAQUE_ID_DISALLOWED_PATTERN = /[\p{Cc}\s]/u;
+
+function readRequiredTrimmedString(
+  record: Record<string, unknown>,
+  field: keyof A2AEnvelope,
+  issues: string[],
+): string {
+  const value = record[field];
+  if (typeof value !== 'string') {
+    issues.push(`${field} must be a string`);
+    return '';
+  }
+  const normalized = value.trim();
+  if (!normalized) {
+    issues.push(`${field} is required`);
+  }
+  return normalized;
+}
+
+function readOptionalTrimmedString(
+  record: Record<string, unknown>,
+  field: keyof A2AEnvelope,
+  issues: string[],
+): string | undefined {
+  if (!Object.hasOwn(record, field)) return undefined;
+  const value = record[field];
+  if (typeof value !== 'string') {
+    issues.push(`${field} must be a string when provided`);
+    return undefined;
+  }
+  const normalized = value.trim();
+  if (!normalized) {
+    issues.push(`${field} must not be empty when provided`);
+    return undefined;
+  }
+  return normalized;
+}
+
+function readContent(
+  record: Record<string, unknown>,
+  issues: string[],
+): string {
+  const value = record.content;
+  if (typeof value !== 'string') {
+    issues.push('content must be a string');
+    return '';
+  }
+  return value;
+}
+
+export function isA2AEnvelopeIntent(value: string): value is A2AEnvelopeIntent {
+  return A2A_ENVELOPE_INTENTS.includes(value as A2AEnvelopeIntent);
+}
+
+export function classifyA2AAgentId(value: string): A2AAgentIdKind | null {
+  const normalized = value.trim();
+  if (
+    normalized.includes('@') &&
+    CANONICAL_AGENT_ID_PATTERN.test(normalized.toLowerCase())
+  ) {
+    return 'canonical';
+  }
+  if (!normalized.includes('@') && LOCAL_AGENT_ID_PATTERN.test(normalized)) {
+    return 'local';
+  }
+  return null;
+}
+
+function normalizeAgentId(value: string): string {
+  return classifyA2AAgentId(value) === 'canonical'
+    ? value.trim().toLowerCase()
+    : value;
+}
+
+export function isA2AAgentId(value: string): boolean {
+  return classifyA2AAgentId(value) !== null;
+}
+
+export function isA2AOpaqueId(value: string): boolean {
+  const normalized = value.trim();
+  return (
+    normalized.length > 0 && !OPAQUE_ID_DISALLOWED_PATTERN.test(normalized)
+  );
+}
+
+function validateOpaqueId(
+  field: 'id' | 'thread_id' | 'parent_message_id',
+  value: string | undefined,
+  issues: string[],
+): void {
+  if (value === undefined) return;
+  if (!isA2AOpaqueId(value)) {
+    issues.push(`${field} must be a non-empty id without whitespace`);
+  }
+}
+
+function validateAgentId(
+  field: 'sender_agent_id' | 'recipient_agent_id',
+  value: string,
+  issues: string[],
+): void {
+  if (!isA2AAgentId(value)) {
+    issues.push(
+      `${field} must be a local agent id or canonical agent id (agent-slug@user@instance-id)`,
+    );
+  }
+}
+
+function validateCreatedAt(value: string, issues: string[]): void {
+  if (!/^\d{4}-\d{2}-\d{2}T/.test(value) || Number.isNaN(Date.parse(value))) {
+    issues.push('created_at must be an ISO timestamp');
+  }
+}
+
+function validateNoUnknownFields(
+  record: Record<string, unknown>,
+  issues: string[],
+): void {
+  for (const field of Object.keys(record)) {
+    if (!A2A_ENVELOPE_FIELDS.has(field)) {
+      issues.push(`unexpected field: ${field}`);
+    }
+  }
+}
+
+export function validateA2AEnvelope(value: unknown): A2AEnvelope {
+  const issues: string[] = [];
+  if (!isRecord(value)) {
+    throw new A2AEnvelopeValidationError(['envelope must be an object']);
+  }
+
+  validateNoUnknownFields(value, issues);
+
+  const id = readRequiredTrimmedString(value, 'id', issues);
+  const senderAgentId = readRequiredTrimmedString(
+    value,
+    'sender_agent_id',
+    issues,
+  );
+  const recipientAgentId = readRequiredTrimmedString(
+    value,
+    'recipient_agent_id',
+    issues,
+  );
+  const threadId = readRequiredTrimmedString(value, 'thread_id', issues);
+  const parentMessageId = readOptionalTrimmedString(
+    value,
+    'parent_message_id',
+    issues,
+  );
+  const intent = readRequiredTrimmedString(value, 'intent', issues);
+  const content = readContent(value, issues);
+  const createdAt = readRequiredTrimmedString(value, 'created_at', issues);
+  const normalizedSenderAgentId = normalizeAgentId(senderAgentId);
+  const normalizedRecipientAgentId = normalizeAgentId(recipientAgentId);
+
+  validateOpaqueId('id', id, issues);
+  validateOpaqueId('thread_id', threadId, issues);
+  validateOpaqueId('parent_message_id', parentMessageId, issues);
+  validateAgentId('sender_agent_id', normalizedSenderAgentId, issues);
+  validateAgentId('recipient_agent_id', normalizedRecipientAgentId, issues);
+  if (!isA2AEnvelopeIntent(intent)) {
+    issues.push(`intent must be one of: ${A2A_ENVELOPE_INTENTS.join(', ')}`);
+  }
+  validateCreatedAt(createdAt, issues);
+
+  if (issues.length > 0) {
+    throw new A2AEnvelopeValidationError(issues);
+  }
+
+  return {
+    id,
+    sender_agent_id: normalizedSenderAgentId,
+    recipient_agent_id: normalizedRecipientAgentId,
+    thread_id: threadId,
+    ...(parentMessageId ? { parent_message_id: parentMessageId } : {}),
+    intent: intent as A2AEnvelopeIntent,
+    content,
+    created_at: createdAt,
+  };
+}
+
+export function createA2AEnvelope(input: CreateA2AEnvelopeInput): A2AEnvelope {
+  return validateA2AEnvelope({
+    ...input,
+    id: input.id ?? randomUUID(),
+    created_at: input.created_at ?? new Date().toISOString(),
+  });
+}
+
+export function parseA2AEnvelopeJson(raw: string): A2AEnvelope {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new A2AEnvelopeValidationError([
+      error instanceof Error ? error.message : 'invalid JSON',
+    ]);
+  }
+  return validateA2AEnvelope(parsed);
+}
+
+export function serializeA2AEnvelope(envelope: A2AEnvelope): string {
+  return `${JSON.stringify(envelope, null, 2)}\n`;
+}

--- a/src/a2a/identity.ts
+++ b/src/a2a/identity.ts
@@ -1,0 +1,105 @@
+import { createHash } from 'node:crypto';
+import os from 'node:os';
+
+import { findAgentConfig, listAgents } from '../agents/agent-registry.js';
+import { type AgentConfig, DEFAULT_AGENT_ID } from '../agents/agent-types.js';
+import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+import {
+  type A2AEnvelope,
+  A2AEnvelopeValidationError,
+  classifyA2AAgentId,
+  validateA2AEnvelope,
+} from './envelope.js';
+
+const CANONICAL_COMPONENT_PATTERN = /^[a-z0-9][a-z0-9._-]{0,127}$/;
+let cachedInstanceId: string | undefined;
+
+function canonicalComponent(value: string, fallback: string): string {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/@.*$/u, '')
+    .replace(/[^a-z0-9._-]+/gu, '-')
+    .replace(/^[._-]+|[._-]+$/gu, '')
+    .slice(0, 128);
+  if (normalized && CANONICAL_COMPONENT_PATTERN.test(normalized)) {
+    return normalized;
+  }
+  return fallback;
+}
+
+function readEnvInstanceId(): string {
+  return canonicalComponent(process.env.HYBRIDCLAW_INSTANCE_ID || '', '');
+}
+
+function findLocalAgent(agentId: string): AgentConfig {
+  const exact = findAgentConfig(agentId);
+  if (exact) return exact;
+
+  const normalized = agentId.toLowerCase();
+  const matches = listAgents().filter(
+    (agent) => agent.id.toLowerCase() === normalized,
+  );
+  if (matches.length === 1 && matches[0]) return matches[0];
+  if (matches.length > 1) {
+    throw new A2AEnvelopeValidationError([
+      `local agent id ${agentId} is ambiguous`,
+    ]);
+  }
+  throw new A2AEnvelopeValidationError([
+    `local agent id ${agentId} does not match a registered agent`,
+  ]);
+}
+
+export function resolveLocalA2AInstanceId(): string {
+  if (cachedInstanceId) return cachedInstanceId;
+
+  const envInstanceId = readEnvInstanceId();
+  if (envInstanceId) {
+    cachedInstanceId = envInstanceId;
+    return envInstanceId;
+  }
+
+  const digest = createHash('sha256')
+    .update(os.hostname(), 'utf-8')
+    .update('\0')
+    .update(DEFAULT_RUNTIME_HOME_DIR, 'utf-8')
+    .digest('hex')
+    .slice(0, 12);
+  cachedInstanceId = `local-${digest}`;
+  return cachedInstanceId;
+}
+
+export function resolveA2AAgentId(agentId: string): string {
+  const normalized = agentId.trim();
+  const kind = classifyA2AAgentId(normalized);
+  if (kind === 'canonical') return normalized.toLowerCase();
+  if (kind !== 'local') {
+    throw new A2AEnvelopeValidationError([
+      'agent id must be a local agent id or canonical agent id (agent-slug@user@instance-id)',
+    ]);
+  }
+
+  const agent = findLocalAgent(normalized);
+  const agentSlug = canonicalComponent(agent.id, DEFAULT_AGENT_ID);
+  const userSlug = canonicalComponent(
+    agent.owner ||
+      process.env.HYBRIDCLAW_USER_ID ||
+      process.env.USER ||
+      process.env.LOGNAME ||
+      '',
+    'local',
+  );
+  return `${agentSlug}@${userSlug}@${resolveLocalA2AInstanceId()}`;
+}
+
+export function resolveA2AEnvelopeAgentIds(envelope: unknown): A2AEnvelope {
+  const normalizedEnvelope = validateA2AEnvelope(envelope);
+  return {
+    ...normalizedEnvelope,
+    sender_agent_id: resolveA2AAgentId(normalizedEnvelope.sender_agent_id),
+    recipient_agent_id: resolveA2AAgentId(
+      normalizedEnvelope.recipient_agent_id,
+    ),
+  };
+}

--- a/src/a2a/store.ts
+++ b/src/a2a/store.ts
@@ -1,0 +1,196 @@
+import path from 'node:path';
+import {
+  getRuntimeAssetRevisionState,
+  type RuntimeConfigChangeMeta,
+  syncRuntimeAssetRevisionState,
+} from '../config/runtime-config-revisions.js';
+import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+import {
+  type A2AEnvelope,
+  A2AEnvelopeDuplicateError,
+  A2AEnvelopeValidationError,
+  isA2AOpaqueId,
+  validateA2AEnvelope,
+} from './envelope.js';
+import { resolveA2AEnvelopeAgentIds } from './identity.js';
+import { isRecord } from './utils.js';
+
+const A2A_THREAD_STATE_VERSION = 1;
+
+interface A2AThreadState {
+  version: typeof A2A_THREAD_STATE_VERSION;
+  thread_id: string;
+  envelopes: A2AEnvelope[];
+}
+
+function normalizeOpaqueId(value: string, field: string): string {
+  const normalized = value.trim();
+  if (!isA2AOpaqueId(normalized)) {
+    throw new A2AEnvelopeValidationError([
+      `${field} must be a non-empty id without whitespace`,
+    ]);
+  }
+  return normalized;
+}
+
+function normalizeThreadId(threadId: string): string {
+  return normalizeOpaqueId(threadId, 'thread_id');
+}
+
+function normalizeEnvelopeId(envelopeId: string): string {
+  return normalizeOpaqueId(envelopeId, 'id');
+}
+
+export function a2aThreadAssetPath(threadId: string): string {
+  const normalizedThreadId = normalizeThreadId(threadId);
+  return path.join(
+    DEFAULT_RUNTIME_HOME_DIR,
+    'a2a',
+    'threads',
+    `${encodeURIComponent(normalizedThreadId)}.json`,
+  );
+}
+
+function emptyThreadState(threadId: string): A2AThreadState {
+  return {
+    version: A2A_THREAD_STATE_VERSION,
+    thread_id: threadId,
+    envelopes: [],
+  };
+}
+
+function parsePersistedThreadState(
+  raw: string,
+  expectedThreadId: string,
+): A2AThreadState {
+  const issues: string[] = [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new A2AEnvelopeValidationError([
+      `thread state JSON is invalid: ${
+        error instanceof Error ? error.message : 'unknown parse error'
+      }`,
+    ]);
+  }
+
+  if (!isRecord(parsed)) {
+    throw new A2AEnvelopeValidationError([
+      'thread state must be a JSON object',
+    ]);
+  }
+
+  if (parsed.version !== A2A_THREAD_STATE_VERSION) {
+    issues.push(`thread state version must be ${A2A_THREAD_STATE_VERSION}`);
+  }
+
+  const threadId =
+    typeof parsed.thread_id === 'string' ? parsed.thread_id.trim() : '';
+  if (threadId !== expectedThreadId) {
+    issues.push(`thread state is for ${threadId || '<missing>'}`);
+  }
+
+  const rawEnvelopes = parsed.envelopes;
+  if (!Array.isArray(rawEnvelopes)) {
+    issues.push('thread state envelopes must be an array');
+  }
+
+  const envelopes: A2AEnvelope[] = [];
+  const seenEnvelopeIds = new Set<string>();
+  if (Array.isArray(rawEnvelopes)) {
+    rawEnvelopes.forEach((entry, index) => {
+      try {
+        const envelope = validateA2AEnvelope(entry);
+        if (envelope.thread_id !== expectedThreadId) {
+          issues.push(`envelopes[${index}] belongs to ${envelope.thread_id}`);
+        }
+        if (seenEnvelopeIds.has(envelope.id)) {
+          issues.push(`duplicate envelope id: ${envelope.id}`);
+        }
+        seenEnvelopeIds.add(envelope.id);
+        envelopes.push(envelope);
+      } catch (error) {
+        if (error instanceof A2AEnvelopeValidationError) {
+          issues.push(
+            ...error.issues.map((issue) => `envelopes[${index}]: ${issue}`),
+          );
+          return;
+        }
+        issues.push(
+          `envelopes[${index}]: ${
+            error instanceof Error ? error.message : 'invalid envelope'
+          }`,
+        );
+      }
+    });
+  }
+
+  if (issues.length > 0) {
+    throw new A2AEnvelopeValidationError(issues);
+  }
+
+  return {
+    version: A2A_THREAD_STATE_VERSION,
+    thread_id: expectedThreadId,
+    envelopes,
+  };
+}
+
+function readThreadState(threadId: string): A2AThreadState {
+  const normalizedThreadId = normalizeThreadId(threadId);
+  const state = getRuntimeAssetRevisionState(
+    'a2a',
+    a2aThreadAssetPath(normalizedThreadId),
+  );
+  if (!state) return emptyThreadState(normalizedThreadId);
+  return parsePersistedThreadState(state.content, normalizedThreadId);
+}
+
+function serializeThreadState(state: A2AThreadState): string {
+  return `${JSON.stringify(state, null, 2)}\n`;
+}
+
+export function listA2AThreadEnvelopes(threadId: string): A2AEnvelope[] {
+  return readThreadState(threadId).envelopes;
+}
+
+export function getA2AEnvelope(
+  threadId: string,
+  envelopeId: string,
+): A2AEnvelope | null {
+  const normalizedEnvelopeId = normalizeEnvelopeId(envelopeId);
+  const envelope = readThreadState(threadId).envelopes.find(
+    (entry) => entry.id === normalizedEnvelopeId,
+  );
+  return envelope ?? null;
+}
+
+export function saveA2AEnvelope(
+  envelope: unknown,
+  meta?: RuntimeConfigChangeMeta,
+): A2AEnvelope {
+  const normalizedEnvelope = resolveA2AEnvelopeAgentIds(envelope);
+  const state = readThreadState(normalizedEnvelope.thread_id);
+  if (state.envelopes.some((entry) => entry.id === normalizedEnvelope.id)) {
+    throw new A2AEnvelopeDuplicateError(
+      normalizedEnvelope.id,
+      normalizedEnvelope.thread_id,
+    );
+  }
+
+  const nextState: A2AThreadState = {
+    ...state,
+    envelopes: [...state.envelopes, normalizedEnvelope],
+  };
+  syncRuntimeAssetRevisionState(
+    'a2a',
+    a2aThreadAssetPath(normalizedEnvelope.thread_id),
+    meta,
+    {
+      exists: true,
+      content: serializeThreadState(nextState),
+    },
+  );
+  return normalizedEnvelope;
+}

--- a/src/a2a/utils.ts
+++ b/src/a2a/utils.ts
@@ -1,0 +1,3 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/config/runtime-config-revisions.ts
+++ b/src/config/runtime-config-revisions.ts
@@ -20,6 +20,7 @@ export const RUNTIME_REVISION_ASSET_TYPES = [
   'knowledge',
   'cv',
   'classifier',
+  'a2a',
 ] as const;
 
 export type RuntimeRevisionAssetType =

--- a/tests/a2a-envelope.test.ts
+++ b/tests/a2a-envelope.test.ts
@@ -1,0 +1,277 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  type A2AEnvelopeDuplicateError,
+  A2AEnvelopeValidationError,
+  classifyA2AAgentId,
+  createA2AEnvelope,
+  validateA2AEnvelope,
+} from '../src/a2a/envelope.ts';
+
+const ORIGINAL_DATA_DIR = process.env.HYBRIDCLAW_DATA_DIR;
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_INSTANCE_ID = process.env.HYBRIDCLAW_INSTANCE_ID;
+
+let tmpDir: string;
+
+function restoreEnvVar(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hc-a2a-envelope-'));
+  process.env.HYBRIDCLAW_DATA_DIR = tmpDir;
+  process.env.HOME = tmpDir;
+  process.env.HYBRIDCLAW_INSTANCE_ID = 'local-dev';
+  vi.resetModules();
+});
+
+afterEach(() => {
+  restoreEnvVar('HYBRIDCLAW_DATA_DIR', ORIGINAL_DATA_DIR);
+  restoreEnvVar('HOME', ORIGINAL_HOME);
+  restoreEnvVar('HYBRIDCLAW_INSTANCE_ID', ORIGINAL_INSTANCE_ID);
+  vi.resetModules();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('A2A envelope schema', () => {
+  test('validates and normalizes local and canonical agent ids', () => {
+    const envelope = validateA2AEnvelope({
+      id: ' msg-1 ',
+      sender_agent_id: ' researcher ',
+      recipient_agent_id: 'Charly@Benedikt@Local-Dev',
+      thread_id: ' thread-1 ',
+      parent_message_id: ' msg-0 ',
+      intent: 'handoff',
+      content: 'Please take the client brief from here.',
+      created_at: '2026-04-28T10:00:00.000Z',
+    });
+
+    expect(envelope).toEqual({
+      id: 'msg-1',
+      sender_agent_id: 'researcher',
+      recipient_agent_id: 'charly@benedikt@local-dev',
+      thread_id: 'thread-1',
+      parent_message_id: 'msg-0',
+      intent: 'handoff',
+      content: 'Please take the client brief from here.',
+      created_at: '2026-04-28T10:00:00.000Z',
+    });
+    expect(classifyA2AAgentId('researcher')).toBe('local');
+    expect(classifyA2AAgentId('charly@benedikt@local-dev')).toBe('canonical');
+    expect(classifyA2AAgentId('Charly@Benedikt@Local-Dev')).toBe('canonical');
+  });
+
+  test('rejects malformed envelopes', () => {
+    expect(() =>
+      validateA2AEnvelope({
+        id: 'bad id',
+        sender_agent_id: 'agent@too@many@segments',
+        recipient_agent_id: 'writer one',
+        thread_id: 'thread-1',
+        intent: 'notify',
+        content: ['not', 'text'],
+        created_at: 'not-a-date',
+        extra: true,
+      }),
+    ).toThrow(A2AEnvelopeValidationError);
+
+    try {
+      validateA2AEnvelope({
+        id: 'bad id',
+        sender_agent_id: 'agent@too@many@segments',
+        recipient_agent_id: 'writer one',
+        thread_id: 'thread-1',
+        intent: 'notify',
+        content: ['not', 'text'],
+        created_at: 'not-a-date',
+        extra: true,
+      });
+    } catch (error) {
+      expect(error).toBeInstanceOf(A2AEnvelopeValidationError);
+      expect((error as A2AEnvelopeValidationError).issues).toEqual(
+        expect.arrayContaining([
+          'unexpected field: extra',
+          'id must be a non-empty id without whitespace',
+          'sender_agent_id must be a local agent id or canonical agent id (agent-slug@user@instance-id)',
+          'recipient_agent_id must be a local agent id or canonical agent id (agent-slug@user@instance-id)',
+          'intent must be one of: chat, handoff, escalate, ack',
+          'content must be a string',
+          'created_at must be an ISO timestamp',
+        ]),
+      );
+      return;
+    }
+
+    throw new Error('Expected validation to fail.');
+  });
+
+  test('creates envelopes with generated ids and timestamps', () => {
+    const envelope = createA2AEnvelope({
+      sender_agent_id: 'main',
+      recipient_agent_id: 'writer',
+      thread_id: 'thread-1',
+      intent: 'chat',
+      content: 'Draft the outline.',
+    });
+
+    expect(envelope.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+    expect(Date.parse(envelope.created_at)).not.toBeNaN();
+  });
+});
+
+describe('A2A envelope persistence', () => {
+  test('round-trips envelopes through the revisioned runtime store', async () => {
+    const runtimeConfig = await import('../src/config/runtime-config.ts');
+    const store = await import('../src/a2a/store.ts');
+    const revisions = await import('../src/config/runtime-config-revisions.ts');
+
+    runtimeConfig.updateRuntimeConfig((draft) => {
+      draft.agents.list = [
+        { id: 'main', owner: 'benedikt' },
+        { id: 'writer', owner: 'sam' },
+      ];
+    });
+
+    const first = validateA2AEnvelope({
+      id: 'msg-1',
+      sender_agent_id: 'Main',
+      recipient_agent_id: 'writer@benedikt@local-dev',
+      thread_id: 'thread-1',
+      intent: 'chat',
+      content: 'Can you draft this?',
+      created_at: '2026-04-28T10:00:00.000Z',
+    });
+    const second = validateA2AEnvelope({
+      id: 'msg-2',
+      sender_agent_id: 'writer@benedikt@local-dev',
+      recipient_agent_id: 'main',
+      thread_id: 'thread-1',
+      parent_message_id: 'msg-1',
+      intent: 'ack',
+      content: '',
+      created_at: '2026-04-28T10:01:00.000Z',
+    });
+
+    const resolvedFirst = {
+      ...first,
+      sender_agent_id: 'main@benedikt@local-dev',
+    };
+    const resolvedSecond = {
+      ...second,
+      recipient_agent_id: 'main@benedikt@local-dev',
+    };
+
+    expect(store.listA2AThreadEnvelopes('thread-1')).toEqual([]);
+    expect(
+      store.saveA2AEnvelope(first, {
+        actor: 'test',
+        route: 'test.a2a.first',
+        source: 'internal',
+      }),
+    ).toEqual(resolvedFirst);
+    expect(store.getA2AEnvelope('thread-1', 'msg-1')).toEqual(resolvedFirst);
+
+    store.saveA2AEnvelope(second, {
+      actor: 'test',
+      route: 'test.a2a.second',
+      source: 'internal',
+    });
+
+    expect(store.listA2AThreadEnvelopes('thread-1')).toEqual([
+      resolvedFirst,
+      resolvedSecond,
+    ]);
+
+    const assetPath = store.a2aThreadAssetPath('thread-1');
+    expect(assetPath).toBe(
+      path.join(tmpDir, 'a2a', 'threads', 'thread-1.json'),
+    );
+    const state = revisions.getRuntimeAssetRevisionState('a2a', assetPath);
+    expect(JSON.parse(state?.content ?? '{}')).toMatchObject({
+      version: 1,
+      thread_id: 'thread-1',
+      envelopes: [resolvedFirst, resolvedSecond],
+    });
+
+    const revisionSummaries = revisions.listRuntimeAssetRevisions(
+      'a2a',
+      assetPath,
+    );
+    expect(revisionSummaries).toHaveLength(1);
+    expect(revisionSummaries[0]).toMatchObject({
+      assetType: 'a2a',
+      route: 'test.a2a.second',
+    });
+    const revision = revisions.getRuntimeAssetRevision(
+      'a2a',
+      assetPath,
+      revisionSummaries[0]?.id ?? -1,
+    );
+    expect(JSON.parse(revision?.content ?? '{}')).toMatchObject({
+      version: 1,
+      thread_id: 'thread-1',
+      envelopes: [resolvedFirst],
+    });
+  });
+
+  test('rejects unknown local agent ids without default-agent fallback', async () => {
+    const store = await import('../src/a2a/store.ts');
+    const envelopeMod = await import('../src/a2a/envelope.ts');
+    const envelope = envelopeMod.validateA2AEnvelope({
+      id: 'msg-1',
+      sender_agent_id: 'researcher',
+      recipient_agent_id: 'main',
+      thread_id: 'thread-1',
+      intent: 'chat',
+      content: 'Can you see this?',
+      created_at: '2026-04-28T10:00:00.000Z',
+    });
+
+    expect(() => store.saveA2AEnvelope(envelope)).toThrow(
+      envelopeMod.A2AEnvelopeValidationError,
+    );
+    expect(() => store.saveA2AEnvelope(envelope)).toThrow(
+      'local agent id researcher does not match a registered agent',
+    );
+  });
+
+  test('rejects duplicate envelope ids in a thread', async () => {
+    const store = await import('../src/a2a/store.ts');
+    const envelopeMod = await import('../src/a2a/envelope.ts');
+    const envelope = envelopeMod.validateA2AEnvelope({
+      id: 'msg-1',
+      sender_agent_id: 'main',
+      recipient_agent_id: 'main',
+      thread_id: 'thread-1',
+      intent: 'chat',
+      content: 'First copy.',
+      created_at: '2026-04-28T10:00:00.000Z',
+    });
+
+    store.saveA2AEnvelope(envelope);
+
+    expect(() => store.saveA2AEnvelope(envelope)).toThrow(
+      envelopeMod.A2AEnvelopeDuplicateError,
+    );
+    try {
+      store.saveA2AEnvelope(envelope);
+    } catch (error) {
+      expect(error).toBeInstanceOf(envelopeMod.A2AEnvelopeValidationError);
+      expect(error).toBeInstanceOf(envelopeMod.A2AEnvelopeDuplicateError);
+      expect((error as A2AEnvelopeDuplicateError).envelopeId).toBe('msg-1');
+      expect((error as A2AEnvelopeDuplicateError).threadId).toBe('thread-1');
+      return;
+    }
+    throw new Error('Expected duplicate envelope save to fail.');
+  });
+});


### PR DESCRIPTION
Closes #424.

## Summary
- Defines a strict A2A envelope schema with `id`, `sender_agent_id`, `recipient_agent_id`, `thread_id`, optional `parent_message_id`, typed `intent`, `content`, and `created_at`.
- Adds A2A thread persistence on top of the existing config-revisioned runtime asset store using a new `a2a` asset type.
- Resolves local short-form agent IDs to canonical `agent-slug@user@instance-id` IDs while preserving already canonical IDs.
- Adds unit coverage for schema validation, canonical/local agent ID handling, persistence round-trip, revision history, and duplicate envelope protection.

## Issue Context
Issue #424 asks for the message envelope and persistence layer for agent-to-agent communication under the coworker team roadmap. A later dependency update requires `sender_agent_id` and `recipient_agent_id` to accept both local short-form IDs and fully-qualified canonical agent IDs.

## Validation
- `vitest run --configLoader runner --config vitest.unit.config.ts tests/a2a-envelope.test.ts`
- `tsc --noEmit --noUnusedLocals --noUnusedParameters`
- `biome check src/a2a src/config/runtime-config-revisions.ts tests/a2a-envelope.test.ts`
- `git diff --check`
