### PR TITLE
[codex] Add production Salesforce skill

### DIFF
--- a/skills/salesforce/SKILL.md
+++ b/skills/salesforce/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: salesforce
-description: "Inspect Salesforce objects, fields, relationships, Tooling API metadata, and SOQL rows with a deterministic Python helper. Use when the user asks about Salesforce schema, DDL-like metadata, joins, record lookups, or org structure."
+description: "Read Salesforce leads, contacts, opportunities, inspect schema/SOQL metadata, update opportunity stage/probability, and log calls, emails, or meetings with a deterministic gateway-proxied helper."
 user-invocable: true
 requires:
   bins:
@@ -8,7 +8,7 @@ requires:
 metadata:
   hybridclaw:
     category: development
-    short_description: "Inspect Salesforce schema and SOQL data."
+    short_description: "Salesforce CRM reads and safe writes."
     tags:
       - salesforce
       - soql
@@ -19,7 +19,7 @@ metadata:
 
 # Salesforce
 
-Use this skill for read-only Salesforce exploration from an org you can access with API credentials.
+Use this skill for Salesforce CRM work from an org you can access with stored OAuth credentials.
 
 ## Scope
 
@@ -28,20 +28,26 @@ Use this skill for read-only Salesforce exploration from an org you can access w
 - relationship discovery for lookup, master-detail, and child links
 - SOQL row queries
 - Tooling API metadata queries
+- lead, contact, and opportunity lookup
+- opportunity stage/probability updates
+- activity logging for calls, emails, and meetings on the right CRM record
+- opinionated natural-language commands for common CRM workflows
 - credential setup guidance using HybridClaw stored secrets
 
 ## Default Workflow
 
-1. Start read-only. Do not create, update, delete, or deploy anything unless the user explicitly asks.
+1. Start with read/plan commands. Do not mutate CRM state unless the user explicitly asks.
 2. Run the bundled helper directly via bash in the current session:
    ```bash
    python3 skills/salesforce/scripts/salesforce_query.py ...
    ```
-3. Use `objects` or `describe` before writing SOQL against an unfamiliar object.
-4. Use `relations` when the user asks how objects join or which foreign keys exist.
-5. Use `query` for row reads. Add a SOQL `LIMIT` unless the user explicitly needs a larger fetch.
-6. Use `tooling-query` for metadata objects such as `CustomObject`, `FieldDefinition`, `ApexClass`, and flow metadata.
-7. If login fails, confirm that `SF_FULL_PASSWORD` already includes any required Salesforce security token.
+3. Use `plan` for natural-language requests when you need to inspect the API actions before execution.
+4. Use `run` for supported opinionated workflows, for example "Move the Acme deal to Closed Won and log a call from today".
+5. Use `find leads|contacts|opportunities` for business-row reads before a write target is ambiguous.
+6. Use `objects`, `describe`, or `relations` before writing SOQL against an unfamiliar object.
+7. Use `query` for row reads. Add a SOQL `LIMIT` unless the user explicitly needs a larger fetch.
+8. Use `tooling-query` for metadata objects such as `CustomObject`, `FieldDefinition`, `ApexClass`, and flow metadata.
+9. If login fails, confirm that `SF_FULL_PASSWORD` already includes any required Salesforce security token.
 
 ## Secret Refs
 
@@ -59,9 +65,10 @@ Required stored secrets:
 - `SF_DOMAIN` — `login` for production, `test` for sandbox
 
 The gateway automatically captures the OAuth `access_token` from the login
-response and stores it as `SF_ACCESS_TOKEN` — the token never enters the
-Python process or the agent context. Subsequent API calls reference it via
-`bearerSecretName`.
+response and stores it as `SF_ACCESS_TOKEN`; it also captures
+`instance_url` as `SF_INSTANCE_URL`. The token never enters the Python process
+or the agent context. Subsequent API calls reference it via `bearerSecretName`,
+so the gateway injects the bearer token server-side.
 
 Ask the user to set them once from a local HybridClaw session:
 
@@ -84,6 +91,18 @@ hybridclaw secret set SF_DOMAIN login
 ```
 
 ## Command Contract
+
+Plan a natural-language CRM request without authentication:
+
+```bash
+python3 skills/salesforce/scripts/salesforce_query.py --format json plan "Move the Acme deal to Closed Won and log a call from today"
+```
+
+Execute a supported natural-language CRM request:
+
+```bash
+python3 skills/salesforce/scripts/salesforce_query.py run "Move the Acme deal to Closed Won and log a call from today"
+```
 
 List objects:
 
@@ -115,6 +134,29 @@ Query Tooling API metadata:
 python3 skills/salesforce/scripts/salesforce_query.py tooling-query "SELECT Id, DeveloperName FROM CustomObject LIMIT 20"
 ```
 
+Find CRM records:
+
+```bash
+python3 skills/salesforce/scripts/salesforce_query.py find leads --search Acme
+python3 skills/salesforce/scripts/salesforce_query.py find contacts --search "Jane"
+python3 skills/salesforce/scripts/salesforce_query.py find opportunities --search Acme --open-only
+```
+
+Update an Opportunity:
+
+```bash
+python3 skills/salesforce/scripts/salesforce_query.py update-opportunity "Acme Renewal" --stage "Closed Won"
+python3 skills/salesforce/scripts/salesforce_query.py update-opportunity 006000000000001AAA --stage "Negotiation/Review" --probability 80
+```
+
+Log activities:
+
+```bash
+python3 skills/salesforce/scripts/salesforce_query.py log-activity call "Acme Renewal" --object opportunity --subject "Discovery follow-up" --date today
+python3 skills/salesforce/scripts/salesforce_query.py log-activity email "Jane Rivera" --object contact --subject "Sent pricing notes" --date today
+python3 skills/salesforce/scripts/salesforce_query.py log-activity meeting "BigCo" --object account --subject "Implementation review" --date 2026-05-01 --duration-minutes 45
+```
+
 Emit JSON for downstream tooling:
 
 ```bash
@@ -123,13 +165,26 @@ python3 skills/salesforce/scripts/salesforce_query.py --format json describe Acc
 
 ## Working Rules
 
-- Keep the default posture read-only.
+- Keep the default posture read-first and plan-first.
+- Mutations are limited to Opportunity `StageName`/`Probability` updates and Task/Event creation for calls, emails, or meetings.
+- Use exact Salesforce ids when available. If resolving by name returns multiple matches, stop and ask for the exact record.
 - Never print secrets, dump the full environment, or commit auth profile files.
 - Treat `SF_DOMAIN` as one of: `login` (production) or `test` (sandbox).
 - Prefer `--format json` when another tool or script needs the response.
 - For large tables, narrow the selected columns and use a SOQL `LIMIT` first.
 - The helper strips Salesforce `attributes` objects by default to keep row output compact. Use `--keep-attributes` only when the caller explicitly needs them.
 - If the API route is disabled or insufficient, explain that and fall back to browser or admin guidance instead of guessing.
+- Cost per assistant run is recorded by HybridClaw `UsageTotals` from normal model usage events; helper output includes `costMeasurement.system = "UsageTotals"` so evals can verify the accounting contract.
+
+## Eval Suite
+
+Run the offline natural-language planner scenarios:
+
+```bash
+python3 skills/salesforce/scripts/salesforce_query.py --format json eval-scenarios
+```
+
+The fixture at `evals/scenarios.json` contains 30 scenarios across lead/contact/opportunity reads, Opportunity updates, activity logging, and compound commands.
 
 ## References
 
@@ -142,4 +197,5 @@ Run:
 ```bash
 python3 skills/skill-creator/scripts/quick_validate.py skills/salesforce
 python3 skills/salesforce/scripts/salesforce_query.py --help
+python3 skills/salesforce/scripts/salesforce_query.py --format json eval-scenarios
 ```

--- a/skills/salesforce/SKILL.md
+++ b/skills/salesforce/SKILL.md
@@ -171,6 +171,7 @@ python3 skills/salesforce/scripts/salesforce_query.py --format json describe Acc
 - Never print secrets, dump the full environment, or commit auth profile files.
 - Treat `SF_DOMAIN` as one of: `login` (production) or `test` (sandbox).
 - Prefer `--format json` when another tool or script needs the response.
+- Treat raw `query` and `tooling-query` SOQL as full-credential reads: any caller with gateway access can read arbitrary Salesforce data allowed by the stored OAuth user.
 - For large tables, narrow the selected columns and use a SOQL `LIMIT` first.
 - The helper strips Salesforce `attributes` objects by default to keep row output compact. Use `--keep-attributes` only when the caller explicitly needs them.
 - If the API route is disabled or insufficient, explain that and fall back to browser or admin guidance instead of guessing.

--- a/skills/salesforce/agents/openai.yaml
+++ b/skills/salesforce/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Salesforce"
-  short_description: "Inspect Salesforce schema and SOQL data"
-  default_prompt: "Use $salesforce to inspect Salesforce schema, relationships, and SOQL rows safely."
+  short_description: "Read CRM records, update opportunities, and log activities"
+  default_prompt: "Use $salesforce to read Salesforce leads, contacts, and opportunities; plan supported CRM writes first; then update opportunity stage/probability or log calls, emails, and meetings through the gateway-proxied helper."

--- a/skills/salesforce/evals/scenarios.json
+++ b/skills/salesforce/evals/scenarios.json
@@ -1,0 +1,212 @@
+[
+  {
+    "id": "sf-read-001",
+    "category": "read",
+    "prompt": "Find leads matching Acme",
+    "expected": { "firstAction": "find-records", "recordType": "leads" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-read-002",
+    "category": "read",
+    "prompt": "Show leads for Atlas",
+    "expected": { "firstAction": "find-records", "recordType": "leads" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-read-003",
+    "category": "read",
+    "prompt": "List contacts at Acme",
+    "expected": { "firstAction": "find-records", "recordType": "contacts" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-read-004",
+    "category": "read",
+    "prompt": "Read contacts matching jane@example.com",
+    "expected": { "firstAction": "find-records", "recordType": "contacts" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-read-005",
+    "category": "read",
+    "prompt": "Find opportunities matching Acme",
+    "expected": { "firstAction": "find-records", "recordType": "opportunities" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-read-006",
+    "category": "read",
+    "prompt": "Show open opportunities for Globex",
+    "expected": { "firstAction": "find-records", "recordType": "opportunities" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-read-007",
+    "category": "read",
+    "prompt": "List deals about Renewal",
+    "expected": { "firstAction": "find-records", "recordType": "opportunities" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-read-008",
+    "category": "read",
+    "prompt": "Read opportunities named BigCo",
+    "expected": { "firstAction": "find-records", "recordType": "opportunities" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-read-009",
+    "category": "read",
+    "prompt": "Find contacts for Rivera",
+    "expected": { "firstAction": "find-records", "recordType": "contacts" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-read-010",
+    "category": "read",
+    "prompt": "Show leads about Webinar",
+    "expected": { "firstAction": "find-records", "recordType": "leads" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-update-001",
+    "category": "write-update",
+    "prompt": "Move the Acme deal to Closed Won",
+    "expected": { "firstAction": "update-opportunity", "stage": "Closed Won" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-update-002",
+    "category": "write-update",
+    "prompt": "Move Acme opportunity to Closed Lost",
+    "expected": { "firstAction": "update-opportunity", "stage": "Closed Lost" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-update-003",
+    "category": "write-update",
+    "prompt": "Move the Globex deal to Negotiation/Review with probability 75",
+    "expected": { "firstAction": "update-opportunity", "stage": "Negotiation/Review" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-update-004",
+    "category": "write-update",
+    "prompt": "Move the Renewal opportunity to Proposal/Price Quote with probability 60",
+    "expected": { "firstAction": "update-opportunity", "stage": "Proposal/Price Quote" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-update-005",
+    "category": "write-update",
+    "prompt": "Move the Churn Save deal to Qualification with probability 25",
+    "expected": { "firstAction": "update-opportunity", "stage": "Qualification" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-update-006",
+    "category": "write-update",
+    "prompt": "Move the Summit deal to Needs Analysis with probability 35",
+    "expected": { "firstAction": "update-opportunity", "stage": "Needs Analysis" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-update-007",
+    "category": "write-update",
+    "prompt": "Move the PaperTrail opportunity to Value Proposition with probability 40",
+    "expected": { "firstAction": "update-opportunity", "stage": "Value Proposition" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-update-008",
+    "category": "write-update",
+    "prompt": "Move the Nordic Expansion deal to Prospecting with probability 10",
+    "expected": { "firstAction": "update-opportunity", "stage": "Prospecting" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-update-009",
+    "category": "write-update",
+    "prompt": "Move the Healthcare Pilot opportunity to Id. Decision Makers with probability 50",
+    "expected": { "firstAction": "update-opportunity", "stage": "Id. Decision Makers" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-update-010",
+    "category": "write-update",
+    "prompt": "Move the Migration deal to Perception Analysis with probability 55",
+    "expected": { "firstAction": "update-opportunity", "stage": "Perception Analysis" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-activity-001",
+    "category": "write-activity",
+    "prompt": "Log a call from today on Acme deal",
+    "expected": { "firstAction": "log-activity", "activityType": "call" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-activity-002",
+    "category": "write-activity",
+    "prompt": "Log an email from today for Jane contact",
+    "expected": { "firstAction": "log-activity", "activityType": "email" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-activity-003",
+    "category": "write-activity",
+    "prompt": "Log a meeting on 2026-05-01 for BigCo account",
+    "expected": { "firstAction": "log-activity", "activityType": "meeting" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-activity-004",
+    "category": "write-activity",
+    "prompt": "Log a call from tomorrow for Rivera lead",
+    "expected": { "firstAction": "log-activity", "activityType": "call" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-activity-005",
+    "category": "write-activity",
+    "prompt": "Log an email on 2026-05-03 on Globex opportunity",
+    "expected": { "firstAction": "log-activity", "activityType": "email" },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-compound-001",
+    "category": "compound",
+    "prompt": "Move the Acme deal to Closed Won and log a call from today",
+    "expected": { "firstAction": "update-opportunity", "actionCount": 2 },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-compound-002",
+    "category": "compound",
+    "prompt": "Move the Beta opportunity to Negotiation/Review with probability 80 and log a meeting from tomorrow",
+    "expected": { "firstAction": "update-opportunity", "actionCount": 2 },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-compound-003",
+    "category": "compound",
+    "prompt": "Move the Atlas deal to Closed Lost and log an email from today",
+    "expected": { "firstAction": "update-opportunity", "actionCount": 2 },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-compound-004",
+    "category": "compound",
+    "prompt": "Move the Expansion deal to Proposal/Price Quote with probability 65 and log a call from today",
+    "expected": { "firstAction": "update-opportunity", "actionCount": 2 },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  },
+  {
+    "id": "sf-compound-005",
+    "category": "compound",
+    "prompt": "Move the Strategic Renewal opportunity to Closed Won and log a meeting on 2026-05-07",
+    "expected": { "firstAction": "update-opportunity", "actionCount": 2 },
+    "costMeasurement": { "system": "UsageTotals", "scope": "per run" }
+  }
+]

--- a/skills/salesforce/references/metadata-and-queries.md
+++ b/skills/salesforce/references/metadata-and-queries.md
@@ -1,6 +1,6 @@
 # Salesforce Query Patterns
 
-Use the bundled helper for read-only org inspection:
+Use the bundled helper for CRM reads, safe writes, and org inspection:
 
 ```bash
 python3 skills/salesforce/scripts/salesforce_query.py ...
@@ -46,13 +46,21 @@ hybridclaw secret set SF_DOMAIN login
 Do not include `https://` or `.salesforce.com` in `SF_DOMAIN`.
 
 Configure the helper using the secret refs above. All secrets are resolved
-server-side by the gateway proxy at request time.
+server-side by the gateway proxy at request time. OAuth responses are captured
+into the encrypted runtime secret store, and bearer tokens are injected by the
+gateway on later API calls.
 
 ## Which Command To Use
 
 - `objects`: list available sObjects and filter by search term
 - `describe <Object>`: inspect fields, required flags, reference targets, and child relationships
 - `relations <Object>`: focus on parent lookup/master-detail links plus incoming child relationships
+- `find leads|contacts|opportunities`: search CRM business records
+- `update-opportunity <id-or-name>`: update Opportunity `StageName` and/or `Probability`
+- `log-activity call|email|meeting <target>`: create Task/Event activity records
+- `plan "<request>"`: inspect a supported natural-language CRM workflow without auth
+- `run "<request>"`: execute a supported natural-language CRM workflow
+- `eval-scenarios`: run the offline 30-scenario planner eval suite
 - `query "<SOQL>"`: fetch record rows through the standard query API
 - `tooling-query "<SOQL>"`: query metadata objects through the Tooling API
 
@@ -100,6 +108,18 @@ Emit JSON:
 python3 skills/salesforce/scripts/salesforce_query.py --format json query "SELECT Id, Name FROM Account LIMIT 5"
 ```
 
+Move a deal and log a call:
+
+```bash
+python3 skills/salesforce/scripts/salesforce_query.py run "Move the Acme deal to Closed Won and log a call from today"
+```
+
+Log an activity directly:
+
+```bash
+python3 skills/salesforce/scripts/salesforce_query.py log-activity call "Acme Renewal" --object opportunity --subject "Discovery follow-up" --date today
+```
+
 ## Query Hygiene
 
 - Start with explicit column lists. Avoid `SELECT *` style thinking; SOQL does not support it anyway.
@@ -107,3 +127,5 @@ python3 skills/salesforce/scripts/salesforce_query.py --format json query "SELEC
 - Prefer `describe` before building joins against unfamiliar objects.
 - Use `tooling-query` for metadata records, not business rows.
 - Keep `--keep-attributes` off unless you explicitly need Salesforce record type metadata in the response.
+- Resolve write targets by Salesforce id when possible. Name resolution fails closed on ambiguity.
+- Cost per assistant run is measured by HybridClaw `UsageTotals`; helper payloads include a `costMeasurement` block that names that accounting source.

--- a/skills/salesforce/scripts/salesforce_query.py
+++ b/skills/salesforce/scripts/salesforce_query.py
@@ -27,6 +27,7 @@ DEFAULT_FIELD_LIMIT = 80
 DEFAULT_OBJECT_LIMIT = 200
 DEFAULT_SEARCH_LIMIT = 10
 DEFAULT_MEETING_MINUTES = 30
+GATEWAY_TIMEOUT_BUFFER_S = 5
 
 SF_ACCESS_TOKEN_SECRET = "SF_ACCESS_TOKEN"
 SF_INSTANCE_URL_SECRET = "SF_INSTANCE_URL"
@@ -239,7 +240,9 @@ def gateway_request(
         proxy_url, data=encoded, method="POST", headers=proxy_headers,
     )
     try:
-        with request.urlopen(req, timeout=gw.timeout_ms / 1000 + 5) as resp:
+        with request.urlopen(
+            req, timeout=gw.timeout_ms / 1000 + GATEWAY_TIMEOUT_BUFFER_S
+        ) as resp:
             raw = resp.read().decode("utf-8")
     except error.HTTPError as exc:
         detail = exc.read().decode("utf-8", errors="replace").strip()
@@ -553,15 +556,18 @@ def find_single_record(
     ]
     if is_salesforce_id(cleaned):
         where = f"Id = '{escape_soql_literal(cleaned)}'"
+        order_clause = ""
         limit = 1
     else:
         exact = escape_soql_literal(cleaned)
-        where = f"Name = '{exact}'"
-        limit = 2
+        like = escape_soql_like_literal(cleaned)
+        where = f"(Name = '{exact}' OR Name LIKE '%{like}%')"
+        order_clause = " ORDER BY LastModifiedDate DESC"
+        limit = 6
 
     soql = (
         f"SELECT {', '.join(select_fields)} FROM {sobject} "
-        f"WHERE {where} LIMIT {limit}"
+        f"WHERE {where}{order_clause} LIMIT {limit}"
     )
     payload = run_query(
         session,
@@ -573,32 +579,18 @@ def find_single_record(
     records = payload.get("records", [])
     if isinstance(records, list) and len(records) == 1 and is_mapping(records[0]):
         return records[0]
-    if isinstance(records, list) and len(records) > 1:
-        names = ", ".join(
-            str(record.get("Name", record.get("Id")))
-            for record in records
-            if is_mapping(record)
-        )
-        raise SalesforceError(f"Ambiguous {sobject} target {cleaned!r}: {names}")
-
     if is_salesforce_id(cleaned):
         raise SalesforceError(f"No {sobject} found for id {cleaned!r}")
-
-    like = escape_soql_like_literal(cleaned)
-    soql = (
-        f"SELECT {', '.join(select_fields)} FROM {sobject} "
-        f"WHERE Name LIKE '%{like}%' ORDER BY LastModifiedDate DESC LIMIT 6"
-    )
-    payload = run_query(
-        session,
-        soql=soql,
-        tooling=False,
-        max_records=6,
-        keep_attributes=False,
-    )
-    records = payload.get("records", [])
-    if isinstance(records, list) and len(records) == 1 and is_mapping(records[0]):
-        return records[0]
+    if isinstance(records, list):
+        exact_records = [
+            record
+            for record in records
+            if is_mapping(record) and record.get("Name") == cleaned
+        ]
+        if len(exact_records) == 1:
+            return exact_records[0]
+        if len(exact_records) > 1:
+            records = exact_records
     if not records:
         raise SalesforceError(f"No {sobject} found matching {cleaned!r}")
     names = ", ".join(
@@ -624,6 +616,8 @@ def strip_attributes(value: Any) -> Any:
 def list_objects(
     session: SalesforceSession, *, search: str, custom_only: bool, limit: int
 ) -> dict[str, Any]:
+    # Salesforce /sobjects has no server-side search/filter parameter, so this
+    # endpoint fetches the full object catalog before applying local filters.
     payload = session.get_json(session.data_path("/sobjects"))
     objects = payload.get("sobjects", []) if is_mapping(payload) else []
     if not isinstance(objects, list):

--- a/skills/salesforce/scripts/salesforce_query.py
+++ b/skills/salesforce/scripts/salesforce_query.py
@@ -124,11 +124,15 @@ class SalesforceSession:
         *,
         json_payload: dict[str, Any] | None = None,
     ) -> Any:
-        url = (
-            path_or_url
-            if path_or_url.startswith("http://") or path_or_url.startswith("https://")
-            else f"<secret:{SF_INSTANCE_URL_SECRET}>{path_or_url}"
-        )
+        parsed = parse.urlparse(path_or_url)
+        if parsed.scheme or parsed.netloc:
+            if parsed.scheme != "https" or not parsed.hostname:
+                raise ConfigError("Salesforce API URL must be an absolute HTTPS URL.")
+            url = path_or_url
+        else:
+            if not path_or_url.startswith("/"):
+                raise ConfigError("Salesforce API path must start with '/'.")
+            url = f"<secret:{SF_INSTANCE_URL_SECRET}>{path_or_url}"
         return gateway_request(
             self.gateway,
             url=url,
@@ -503,6 +507,8 @@ def parse_activity_date(value: str | None) -> str:
 def meeting_times(activity_date: str, duration_minutes: int) -> tuple[str, str]:
     duration = max(1, duration_minutes)
     start_date = date.fromisoformat(activity_date)
+    # Salesforce Event requires a timestamp; NL activity logging only captures a date,
+    # so default date-only meetings to 09:00 UTC until the command accepts a time zone.
     start = datetime.combine(start_date, time(hour=9), tzinfo=timezone.utc)
     end = start + timedelta(minutes=duration)
     return (
@@ -1171,7 +1177,7 @@ def run_planned_actions(
             results=[],
         )
     results: list[dict[str, Any]] = []
-    resolved_records: dict[str, dict[str, Any]] = {}
+    last_updated_opportunity_id = ""
     for action in plan["actions"]:
         if action["action"] == "find-records":
             results.append(
@@ -1194,12 +1200,12 @@ def run_planned_actions(
             results.append(result)
             target = result.get("target")
             if is_mapping(target):
-                resolved_records[action["opportunity"]] = target
+                last_updated_opportunity_id = str(target.get("id") or "").strip()
         elif action["action"] == "log-activity":
             target = action["target"]
             target_object = action["targetObject"]
-            if target in resolved_records and target_object == "Opportunity":
-                target = str(resolved_records[target].get("id") or target)
+            if last_updated_opportunity_id and target_object == "Opportunity":
+                target = last_updated_opportunity_id
             results.append(
                 log_activity(
                     session,
@@ -1517,10 +1523,11 @@ def _add_common_args(
 ) -> None:
     """Register shared flags on *parser*.
 
+    Shared flags are registered once on the root parser and again on each
+    subparser so commands accept them before or after the subcommand.
     When *with_defaults* is ``False`` the arguments use
     ``argparse.SUPPRESS`` so the subparser does not override a value
-    already set by the main parser.  This lets flags like ``--format``
-    work in any position on the command line.
+    already set by the main parser.
     """
     _sup = argparse.SUPPRESS
 

--- a/skills/salesforce/scripts/salesforce_query.py
+++ b/skills/salesforce/scripts/salesforce_query.py
@@ -958,7 +958,7 @@ def build_activity_payload(
     activity_date: str,
     notes: str,
     duration_minutes: int,
-) -> tuple[str, dict[str, Any]]:
+) -> tuple[str, str, dict[str, Any]]:
     normalized_type = normalize_activity_type(activity_type)
     link_field = record_link_field(target_sobject)
     clean_subject = clean_phrase(subject)
@@ -980,7 +980,7 @@ def build_activity_payload(
         }
         if notes.strip():
             payload["Description"] = notes.strip()
-        return "Task", payload
+        return "Task", normalized_type, payload
 
     start, end = meeting_times(activity_date, duration_minutes)
     event_subject = (
@@ -996,7 +996,7 @@ def build_activity_payload(
     }
     if notes.strip():
         payload["Description"] = notes.strip()
-    return "Event", payload
+    return "Event", normalized_type, payload
 
 
 def log_activity(
@@ -1020,7 +1020,7 @@ def log_activity(
     target_id = str(record.get("Id") or "").strip()
     if not target_id:
         raise SalesforceError("Resolved activity target did not include Id.")
-    activity_sobject, fields = build_activity_payload(
+    activity_sobject, normalized_activity_type, fields = build_activity_payload(
         activity_type=activity_type,
         target_sobject=target_sobject,
         target_id=target_id,
@@ -1039,7 +1039,7 @@ def log_activity(
         "log-activity",
         apiVersion=session.api_version,
         dryRun=dry_run,
-        activityType=normalize_activity_type(activity_type),
+        activityType=normalized_activity_type,
         activityObject=activity_sobject,
         targetObject=target_sobject,
         target=record_identity(record),
@@ -1300,6 +1300,33 @@ def format_table(headers: list[str], rows: list[list[Any]]) -> str:
     return "\n".join(lines)
 
 
+def _child_relationship_rows(payload: dict[str, Any]) -> list[list[Any]]:
+    return [
+        [
+            rel.get("childSObject"),
+            rel.get("field"),
+            rel.get("relationshipName"),
+            rel.get("cascadeDelete"),
+        ]
+        for rel in payload.get("childRelationships", [])
+    ]
+
+
+def _columns_from_records(records: Any) -> list[str]:
+    columns: list[str] = []
+    if not isinstance(records, list):
+        return columns
+    seen: set[str] = set()
+    for record in records:
+        if not is_mapping(record):
+            continue
+        for key in record.keys():
+            if key not in seen:
+                seen.add(key)
+                columns.append(key)
+    return columns
+
+
 def render_text(payload: dict[str, Any]) -> str:
     command = payload.get("command")
     if command == "objects":
@@ -1338,15 +1365,7 @@ def render_text(payload: dict[str, Any]) -> str:
             ]
             for field in payload.get("fields", [])
         ]
-        child_rows = [
-            [
-                rel.get("childSObject"),
-                rel.get("field"),
-                rel.get("relationshipName"),
-                rel.get("cascadeDelete"),
-            ]
-            for rel in payload.get("childRelationships", [])
-        ]
+        child_rows = _child_relationship_rows(payload)
         lines = [
             f"Object: {obj.get('name')} ({obj.get('label')})",
             f"API version: {payload.get('apiVersion')}",
@@ -1385,15 +1404,7 @@ def render_text(payload: dict[str, Any]) -> str:
             ]
             for rel in payload.get("parentRelations", [])
         ]
-        child_rows = [
-            [
-                rel.get("childSObject"),
-                rel.get("field"),
-                rel.get("relationshipName"),
-                rel.get("cascadeDelete"),
-            ]
-            for rel in payload.get("childRelationships", [])
-        ]
+        child_rows = _child_relationship_rows(payload)
         return "\n".join(
             [
                 f"Object: {obj.get('name')} ({obj.get('label')})",
@@ -1418,16 +1429,7 @@ def render_text(payload: dict[str, Any]) -> str:
 
     if command in {"query", "tooling-query"}:
         records = payload.get("records", [])
-        columns: list[str] = []
-        if isinstance(records, list):
-            seen: set[str] = set()
-            for record in records:
-                if not is_mapping(record):
-                    continue
-                for key in record.keys():
-                    if key not in seen:
-                        seen.add(key)
-                        columns.append(key)
+        columns = _columns_from_records(records)
         rows = [
             [record.get(column) if is_mapping(record) else record for column in columns]
             for record in records
@@ -1451,16 +1453,7 @@ def render_text(payload: dict[str, Any]) -> str:
 
     if command == "find":
         records = payload.get("records", [])
-        columns: list[str] = []
-        if isinstance(records, list):
-            seen: set[str] = set()
-            for record in records:
-                if not is_mapping(record):
-                    continue
-                for key in record.keys():
-                    if key not in seen:
-                        seen.add(key)
-                        columns.append(key)
+        columns = _columns_from_records(records)
         rows = [
             [record.get(column) if is_mapping(record) else record for column in columns]
             for record in records

--- a/skills/salesforce/scripts/salesforce_query.py
+++ b/skills/salesforce/scripts/salesforce_query.py
@@ -371,7 +371,15 @@ def resolve_latest_api_version(gw: GatewayConfig) -> str:
     if not isinstance(versions, list) or not versions:
         raise SalesforceError("Salesforce did not return any API versions")
 
-    def version_key(item: Any) -> tuple[int, ...]:
+    valid_versions = [
+        item
+        for item in versions
+        if is_mapping(item) and str(item.get("version", "")).strip()
+    ]
+    if not valid_versions:
+        raise SalesforceError("Salesforce returned an invalid API version payload")
+
+    def version_key(item: dict[str, Any]) -> tuple[int, ...]:
         raw_version = str(item.get("version", "")).strip()
         parts = []
         for chunk in raw_version.split("."):
@@ -380,10 +388,8 @@ def resolve_latest_api_version(gw: GatewayConfig) -> str:
             parts.append(int(chunk))
         return tuple(parts)
 
-    latest = max(versions, key=version_key)
+    latest = max(valid_versions, key=version_key)
     version = str(latest.get("version", "")).strip()
-    if not version:
-        raise SalesforceError("Salesforce returned an invalid API version payload")
     return version
 
 
@@ -1161,6 +1167,45 @@ def plan_natural_language(statement: str) -> dict[str, Any]:
     )
 
 
+def require_action_fields(action: dict[str, Any], required: list[str]) -> None:
+    missing = [field for field in required if field not in action]
+    if missing:
+        action_name = action.get("action", "<missing>")
+        raise ConfigError(
+            f"Planned Salesforce action {action_name!r} is missing: "
+            f"{', '.join(missing)}."
+        )
+
+
+def validate_planned_actions(plan: dict[str, Any]) -> list[dict[str, Any]]:
+    actions = plan.get("actions")
+    if not isinstance(actions, list):
+        raise ConfigError("Salesforce plan did not include an actions list.")
+    validated: list[dict[str, Any]] = []
+    required_by_action = {
+        "find-records": ["recordType", "search", "limit", "openOnly"],
+        "update-opportunity": ["opportunity", "stage", "probability"],
+        "log-activity": [
+            "activityType",
+            "target",
+            "targetObject",
+            "subject",
+            "date",
+            "notes",
+        ],
+    }
+    for action in actions:
+        if not is_mapping(action):
+            raise ConfigError("Salesforce plan included a non-object action.")
+        action_name = action.get("action")
+        required = required_by_action.get(str(action_name))
+        if required is None:
+            raise ConfigError(f"Unsupported planned Salesforce action: {action_name!r}.")
+        require_action_fields(action, ["action", *required])
+        validated.append(action)
+    return validated
+
+
 def run_planned_actions(
     session: SalesforceSession,
     *,
@@ -1168,17 +1213,18 @@ def run_planned_actions(
     dry_run: bool,
 ) -> dict[str, Any]:
     plan = plan_natural_language(statement)
+    actions = validate_planned_actions(plan)
     if dry_run:
         return command_payload(
             "run",
             dryRun=True,
-            statement=plan["statement"],
-            actions=plan["actions"],
+            statement=plan.get("statement", statement),
+            actions=actions,
             results=[],
         )
     results: list[dict[str, Any]] = []
     last_updated_opportunity_id = ""
-    for action in plan["actions"]:
+    for action in actions:
         if action["action"] == "find-records":
             results.append(
                 find_records(
@@ -1222,8 +1268,8 @@ def run_planned_actions(
     return command_payload(
         "run",
         dryRun=False,
-        statement=plan["statement"],
-        actions=plan["actions"],
+        statement=plan.get("statement", statement),
+        actions=actions,
         results=results,
     )
 
@@ -1808,7 +1854,7 @@ def main() -> int:
                 statement=args.statement,
                 dry_run=False,
             )
-        else:
+        elif args.command == "tooling-query":
             payload = run_query(
                 session,
                 soql=args.soql,
@@ -1816,6 +1862,8 @@ def main() -> int:
                 max_records=args.max_records,
                 keep_attributes=args.keep_attributes,
             )
+        else:
+            raise AssertionError(f"Unreachable: {args.command}")
     except (ConfigError, SalesforceError, GatewayError) as exc:
         payload = {"status": "error", "message": str(exc)}
         if args.format == "json":

--- a/skills/salesforce/scripts/salesforce_query.py
+++ b/skills/salesforce/scripts/salesforce_query.py
@@ -405,6 +405,10 @@ def escape_soql_literal(value: str) -> str:
     return value.replace("\\", "\\\\").replace("'", "\\'")
 
 
+def escape_soql_like_literal(value: str) -> str:
+    return escape_soql_literal(value).replace("%", "\\%").replace("_", "\\_")
+
+
 def is_salesforce_id(value: str) -> bool:
     return bool(SALESFORCE_ID_RE.fullmatch(value.strip()))
 
@@ -425,7 +429,7 @@ def normalize_stage_name(value: str) -> str:
         "closed won": "Closed Won",
         "closed lost": "Closed Lost",
     }
-    return known.get(normalized.lower(), normalized.title())
+    return known.get(normalized.lower(), normalized)
 
 
 def normalize_probability(value: int | None) -> int | None:
@@ -568,7 +572,7 @@ def find_single_record(
     if is_salesforce_id(cleaned):
         raise SalesforceError(f"No {sobject} found for id {cleaned!r}")
 
-    like = escape_soql_literal(cleaned)
+    like = escape_soql_like_literal(cleaned)
     soql = (
         f"SELECT {', '.join(select_fields)} FROM {sobject} "
         f"WHERE Name LIKE '%{like}%' ORDER BY LastModifiedDate DESC LIMIT 6"
@@ -830,7 +834,7 @@ def find_records(
     where_parts: list[str] = []
     cleaned_search = search.strip()
     if cleaned_search:
-        needle = escape_soql_literal(cleaned_search)
+        needle = escape_soql_like_literal(cleaned_search)
         where_parts.append(
             "("
             + " OR ".join(

--- a/skills/salesforce/scripts/salesforce_query.py
+++ b/skills/salesforce/scripts/salesforce_query.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # ruff: noqa: INP001
-"""Read-only Salesforce schema and query helper.
+"""Salesforce CRM schema, query, and operation helper.
 
 All HTTP traffic is routed through the HybridClaw gateway proxy at
 ``/api/http/request`` so that stored secrets (``<secret:NAME>`` placeholders)
@@ -12,8 +12,11 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta, timezone
+from pathlib import Path
 from typing import Any
 from urllib import error, parse, request
 
@@ -22,11 +25,69 @@ DEFAULT_TIMEOUT_MS = DEFAULT_TIMEOUT * 1000
 DEFAULT_MAX_RECORDS = 200
 DEFAULT_FIELD_LIMIT = 80
 DEFAULT_OBJECT_LIMIT = 200
+DEFAULT_SEARCH_LIMIT = 10
+DEFAULT_MEETING_MINUTES = 30
 
 SF_ACCESS_TOKEN_SECRET = "SF_ACCESS_TOKEN"
 SF_INSTANCE_URL_SECRET = "SF_INSTANCE_URL"
 
 DEFAULT_GATEWAY_URL = "http://127.0.0.1:9090"
+EVAL_SCENARIOS_PATH = (
+    Path(__file__).resolve().parent.parent / "evals" / "scenarios.json"
+)
+SALESFORCE_ID_RE = re.compile(r"^[A-Za-z0-9]{15}(?:[A-Za-z0-9]{3})?$")
+
+ACTIVITY_OBJECT_ALIASES = {
+    "account": "Account",
+    "accounts": "Account",
+    "contact": "Contact",
+    "contacts": "Contact",
+    "lead": "Lead",
+    "leads": "Lead",
+    "opportunity": "Opportunity",
+    "opportunities": "Opportunity",
+    "deal": "Opportunity",
+    "deals": "Opportunity",
+}
+
+ACTIVITY_ID_PREFIXES = {
+    "001": "Account",
+    "003": "Contact",
+    "006": "Opportunity",
+    "00Q": "Lead",
+}
+
+SEARCH_CONFIG = {
+    "leads": {
+        "sobject": "Lead",
+        "fields": ["Id", "Name", "Company", "Status", "Owner.Name"],
+        "search_fields": ["Name", "Company", "Email"],
+    },
+    "contacts": {
+        "sobject": "Contact",
+        "fields": ["Id", "Name", "Email", "Account.Name", "Title"],
+        "search_fields": ["Name", "Email", "Account.Name"],
+    },
+    "opportunities": {
+        "sobject": "Opportunity",
+        "fields": [
+            "Id",
+            "Name",
+            "StageName",
+            "Probability",
+            "Amount",
+            "CloseDate",
+            "Account.Name",
+            "IsClosed",
+        ],
+        "search_fields": ["Name", "Account.Name"],
+    },
+}
+
+DEFAULT_STAGE_PROBABILITIES = {
+    "closed won": 100,
+    "closed lost": 0,
+}
 
 
 class ConfigError(RuntimeError):
@@ -56,7 +117,13 @@ class SalesforceSession:
     def data_path(self, suffix: str) -> str:
         return f"/services/data/v{self.api_version}{suffix}"
 
-    def get_json(self, path_or_url: str) -> Any:
+    def request_json(
+        self,
+        method: str,
+        path_or_url: str,
+        *,
+        json_payload: dict[str, Any] | None = None,
+    ) -> Any:
         url = (
             path_or_url
             if path_or_url.startswith("http://") or path_or_url.startswith("https://")
@@ -65,14 +132,40 @@ class SalesforceSession:
         return gateway_request(
             self.gateway,
             url=url,
-            method="GET",
+            method=method,
             bearer_secret=SF_ACCESS_TOKEN_SECRET,
+            json_payload=json_payload,
             replace_placeholders=True,
         )
+
+    def get_json(self, path_or_url: str) -> Any:
+        return self.request_json("GET", path_or_url)
+
+    def patch_json(self, path_or_url: str, payload: dict[str, Any]) -> Any:
+        return self.request_json("PATCH", path_or_url, json_payload=payload)
+
+    def post_json(self, path_or_url: str, payload: dict[str, Any]) -> Any:
+        return self.request_json("POST", path_or_url, json_payload=payload)
 
 
 def is_mapping(value: Any) -> bool:
     return isinstance(value, dict)
+
+
+def usage_totals_measurement() -> dict[str, Any]:
+    return {
+        "system": "UsageTotals",
+        "source": "HybridClaw usage_events",
+        "scope": "per assistant run/session",
+        "fields": [
+            "total_input_tokens",
+            "total_output_tokens",
+            "total_tokens",
+            "total_cost_usd",
+            "call_count",
+            "total_tool_calls",
+        ],
+    }
 
 
 def resolve_gateway_url() -> str:
@@ -291,8 +384,213 @@ def resolve_latest_api_version(gw: GatewayConfig) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Salesforce operations (unchanged logic, now using gateway proxy)
+# Salesforce operation helpers
 # ---------------------------------------------------------------------------
+
+
+def command_payload(command: str, **fields: Any) -> dict[str, Any]:
+    return {
+        "status": "success",
+        "command": command,
+        "costMeasurement": usage_totals_measurement(),
+        **fields,
+    }
+
+
+def ensure_positive_limit(value: int, default: int) -> int:
+    return value if isinstance(value, int) and value >= 0 else default
+
+
+def escape_soql_literal(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
+def is_salesforce_id(value: str) -> bool:
+    return bool(SALESFORCE_ID_RE.fullmatch(value.strip()))
+
+
+def normalize_stage_name(value: str) -> str:
+    normalized = re.sub(r"\s+", " ", value.strip())
+    if not normalized:
+        raise ConfigError("Opportunity stage is required.")
+    known = {
+        "prospecting": "Prospecting",
+        "qualification": "Qualification",
+        "needs analysis": "Needs Analysis",
+        "value proposition": "Value Proposition",
+        "id. decision makers": "Id. Decision Makers",
+        "perception analysis": "Perception Analysis",
+        "proposal/price quote": "Proposal/Price Quote",
+        "negotiation/review": "Negotiation/Review",
+        "closed won": "Closed Won",
+        "closed lost": "Closed Lost",
+    }
+    return known.get(normalized.lower(), normalized.title())
+
+
+def normalize_probability(value: int | None) -> int | None:
+    if value is None:
+        return None
+    if value < 0 or value > 100:
+        raise ConfigError("Opportunity probability must be between 0 and 100.")
+    return value
+
+
+def default_probability_for_stage(stage_name: str) -> int | None:
+    return DEFAULT_STAGE_PROBABILITIES.get(stage_name.lower())
+
+
+def normalize_activity_type(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized not in {"call", "email", "meeting"}:
+        raise ConfigError("Activity type must be call, email, or meeting.")
+    return normalized
+
+
+def normalize_record_type(value: str) -> str:
+    normalized = value.strip().lower().replace("-", "_")
+    if normalized in {"opportunity", "deal", "deals"}:
+        normalized = "opportunities"
+    elif normalized == "contact":
+        normalized = "contacts"
+    elif normalized == "lead":
+        normalized = "leads"
+    if normalized not in SEARCH_CONFIG:
+        raise ConfigError("Record type must be leads, contacts, or opportunities.")
+    return normalized
+
+
+def normalize_target_object(value: str) -> str:
+    normalized = value.strip().lower()
+    if not normalized:
+        raise ConfigError("Target object is required.")
+    resolved = ACTIVITY_OBJECT_ALIASES.get(normalized)
+    if not resolved:
+        raise ConfigError(
+            "Target object must be account, contact, lead, or opportunity."
+        )
+    return resolved
+
+
+def infer_object_from_salesforce_id(value: str) -> str | None:
+    if not is_salesforce_id(value):
+        return None
+    return ACTIVITY_ID_PREFIXES.get(value[:3])
+
+
+def clean_phrase(value: str) -> str:
+    return re.sub(r"\s+", " ", value.strip(" .,'\"")).strip()
+
+
+def parse_activity_date(value: str | None) -> str:
+    if value is None or not value.strip() or value.strip().lower() == "today":
+        return date.today().isoformat()
+    normalized = value.strip().lower()
+    if normalized == "tomorrow":
+        return (date.today() + timedelta(days=1)).isoformat()
+    try:
+        return date.fromisoformat(normalized).isoformat()
+    except ValueError as exc:
+        raise ConfigError(
+            "Activity date must be today, tomorrow, or YYYY-MM-DD."
+        ) from exc
+
+
+def meeting_times(activity_date: str, duration_minutes: int) -> tuple[str, str]:
+    duration = max(1, duration_minutes)
+    start_date = date.fromisoformat(activity_date)
+    start = datetime.combine(start_date, time(hour=9), tzinfo=timezone.utc)
+    end = start + timedelta(minutes=duration)
+    return (
+        start.isoformat().replace("+00:00", "Z"),
+        end.isoformat().replace("+00:00", "Z"),
+    )
+
+
+def record_identity(record: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": record.get("Id"),
+        "name": record.get("Name"),
+    }
+
+
+def record_link_field(sobject: str) -> str:
+    if sobject in {"Lead", "Contact"}:
+        return "WhoId"
+    return "WhatId"
+
+
+def find_single_record(
+    session: SalesforceSession,
+    *,
+    sobject: str,
+    identifier: str,
+    fields: list[str],
+) -> dict[str, Any]:
+    cleaned = identifier.strip()
+    if not cleaned:
+        raise ConfigError("A record id or name is required.")
+    select_fields = [
+        "Id",
+        "Name",
+        *[field for field in fields if field not in {"Id", "Name"}],
+    ]
+    if is_salesforce_id(cleaned):
+        where = f"Id = '{escape_soql_literal(cleaned)}'"
+        limit = 1
+    else:
+        exact = escape_soql_literal(cleaned)
+        where = f"Name = '{exact}'"
+        limit = 2
+
+    soql = (
+        f"SELECT {', '.join(select_fields)} FROM {sobject} "
+        f"WHERE {where} LIMIT {limit}"
+    )
+    payload = run_query(
+        session,
+        soql=soql,
+        tooling=False,
+        max_records=limit,
+        keep_attributes=False,
+    )
+    records = payload.get("records", [])
+    if isinstance(records, list) and len(records) == 1 and is_mapping(records[0]):
+        return records[0]
+    if isinstance(records, list) and len(records) > 1:
+        names = ", ".join(
+            str(record.get("Name", record.get("Id")))
+            for record in records
+            if is_mapping(record)
+        )
+        raise SalesforceError(f"Ambiguous {sobject} target {cleaned!r}: {names}")
+
+    if is_salesforce_id(cleaned):
+        raise SalesforceError(f"No {sobject} found for id {cleaned!r}")
+
+    like = escape_soql_literal(cleaned)
+    soql = (
+        f"SELECT {', '.join(select_fields)} FROM {sobject} "
+        f"WHERE Name LIKE '%{like}%' ORDER BY LastModifiedDate DESC LIMIT 6"
+    )
+    payload = run_query(
+        session,
+        soql=soql,
+        tooling=False,
+        max_records=6,
+        keep_attributes=False,
+    )
+    records = payload.get("records", [])
+    if isinstance(records, list) and len(records) == 1 and is_mapping(records[0]):
+        return records[0]
+    if not records:
+        raise SalesforceError(f"No {sobject} found matching {cleaned!r}")
+    names = ", ".join(
+        str(record.get("Name", record.get("Id")))
+        for record in records
+        if is_mapping(record)
+    )
+    raise SalesforceError(f"Ambiguous {sobject} target {cleaned!r}: {names}")
 
 
 def strip_attributes(value: Any) -> Any:
@@ -343,15 +641,14 @@ def list_objects(
     filtered.sort(key=lambda item: (item["name"] or "", item["label"] or ""))
     total = len(filtered)
     shown = filtered[:limit] if limit > 0 else filtered
-    return {
-        "status": "success",
-        "command": "objects",
-        "apiVersion": session.api_version,
-        "count": len(shown),
-        "totalMatched": total,
-        "truncated": limit > 0 and total > len(shown),
-        "objects": shown,
-    }
+    return command_payload(
+        "objects",
+        apiVersion=session.api_version,
+        count=len(shown),
+        totalMatched=total,
+        truncated=limit > 0 and total > len(shown),
+        objects=shown,
+    )
 
 
 def describe_object(
@@ -408,11 +705,10 @@ def describe_object(
     )
 
     shown_fields = fields[:field_limit] if field_limit > 0 else fields
-    return {
-        "status": "success",
-        "command": "describe",
-        "apiVersion": session.api_version,
-        "object": {
+    return command_payload(
+        "describe",
+        apiVersion=session.api_version,
+        object={
             "name": str(payload.get("name", "")).strip(),
             "label": str(payload.get("label", "")).strip(),
             "labelPlural": str(payload.get("labelPlural", "")).strip(),
@@ -426,13 +722,13 @@ def describe_object(
             "replicateable": bool(payload.get("replicateable")),
             "retrieveable": bool(payload.get("retrieveable")),
         },
-        "fieldCount": len(fields),
-        "fieldsShown": len(shown_fields),
-        "fieldsTruncated": field_limit > 0 and len(fields) > len(shown_fields),
-        "fields": shown_fields,
-        "childRelationshipCount": len(child_relationships),
-        "childRelationships": child_relationships,
-    }
+        fieldCount=len(fields),
+        fieldsShown=len(shown_fields),
+        fieldsTruncated=field_limit > 0 and len(fields) > len(shown_fields),
+        fields=shown_fields,
+        childRelationshipCount=len(child_relationships),
+        childRelationships=child_relationships,
+    )
 
 
 def relations_object(session: SalesforceSession, *, sobject: str) -> dict[str, Any]:
@@ -451,14 +747,13 @@ def relations_object(session: SalesforceSession, *, sobject: str) -> dict[str, A
         if isinstance(field, dict) and field.get("referenceTo")
     ]
 
-    return {
-        "status": "success",
-        "command": "relations",
-        "apiVersion": session.api_version,
-        "object": described.get("object"),
-        "parentRelations": parent_relations,
-        "childRelationships": child_relationships,
-    }
+    return command_payload(
+        "relations",
+        apiVersion=session.api_version,
+        object=described.get("object"),
+        parentRelations=parent_relations,
+        childRelationships=child_relationships,
+    )
 
 
 def run_query(
@@ -487,17 +782,16 @@ def run_query(
             clean = record if keep_attributes else strip_attributes(record)
             records.append(clean)
             if max_records > 0 and len(records) >= max_records:
-                return {
-                    "status": "success",
-                    "command": "tooling-query" if tooling else "query",
-                    "apiVersion": session.api_version,
-                    "soql": soql,
-                    "count": len(records),
-                    "totalSize": total_size,
-                    "done": False,
-                    "truncated": True,
-                    "records": records,
-                }
+                return command_payload(
+                    "tooling-query" if tooling else "query",
+                    apiVersion=session.api_version,
+                    soql=soql,
+                    count=len(records),
+                    totalSize=total_size,
+                    done=False,
+                    truncated=True,
+                    records=records,
+                )
 
         done = bool(current_payload.get("done", False))
         next_url = current_payload.get("nextRecordsUrl")
@@ -507,17 +801,463 @@ def run_query(
         if not is_mapping(current_payload):
             raise SalesforceError("Unexpected paginated query response")
 
-    return {
-        "status": "success",
-        "command": "tooling-query" if tooling else "query",
-        "apiVersion": session.api_version,
-        "soql": soql,
-        "count": len(records),
-        "totalSize": total_size,
-        "done": done,
-        "truncated": False,
-        "records": records,
+    return command_payload(
+        "tooling-query" if tooling else "query",
+        apiVersion=session.api_version,
+        soql=soql,
+        count=len(records),
+        totalSize=total_size,
+        done=done,
+        truncated=False,
+        records=records,
+    )
+
+
+def find_records(
+    session: SalesforceSession,
+    *,
+    record_type: str,
+    search: str,
+    limit: int,
+    open_only: bool,
+) -> dict[str, Any]:
+    normalized_type = normalize_record_type(record_type)
+    config = SEARCH_CONFIG[normalized_type]
+    sobject = str(config["sobject"])
+    fields = list(config["fields"])
+    search_fields = list(config["search_fields"])
+    bounded_limit = ensure_positive_limit(limit, DEFAULT_SEARCH_LIMIT)
+    where_parts: list[str] = []
+    cleaned_search = search.strip()
+    if cleaned_search:
+        needle = escape_soql_literal(cleaned_search)
+        where_parts.append(
+            "("
+            + " OR ".join(
+                f"{field} LIKE '%{needle}%'" for field in search_fields
+            )
+            + ")"
+        )
+    if normalized_type == "opportunities" and open_only:
+        where_parts.append("IsClosed = false")
+    where_clause = f" WHERE {' AND '.join(where_parts)}" if where_parts else ""
+    limit_clause = f" LIMIT {bounded_limit}" if bounded_limit > 0 else ""
+    soql = (
+        f"SELECT {', '.join(fields)} FROM {sobject}{where_clause} "
+        f"ORDER BY LastModifiedDate DESC{limit_clause}"
+    )
+    query_payload = run_query(
+        session,
+        soql=soql,
+        tooling=False,
+        max_records=bounded_limit,
+        keep_attributes=False,
+    )
+    return command_payload(
+        "find",
+        apiVersion=session.api_version,
+        recordType=normalized_type,
+        sobject=sobject,
+        search=cleaned_search,
+        openOnly=open_only,
+        soql=soql,
+        count=query_payload.get("count", 0),
+        totalSize=query_payload.get("totalSize", 0),
+        truncated=query_payload.get("truncated", False),
+        records=query_payload.get("records", []),
+    )
+
+
+def update_opportunity(
+    session: SalesforceSession,
+    *,
+    identifier: str,
+    stage: str | None,
+    probability: int | None,
+    dry_run: bool,
+) -> dict[str, Any]:
+    updates: dict[str, Any] = {}
+    stage_name = normalize_stage_name(stage) if stage else None
+    if stage_name:
+        updates["StageName"] = stage_name
+        default_probability = default_probability_for_stage(stage_name)
+        if probability is None and default_probability is not None:
+            probability = default_probability
+    normalized_probability = normalize_probability(probability)
+    if normalized_probability is not None:
+        updates["Probability"] = normalized_probability
+    if not updates:
+        raise ConfigError("Provide --stage, --probability, or both.")
+
+    target = find_single_record(
+        session,
+        sobject="Opportunity",
+        identifier=identifier,
+        fields=["Id", "Name", "StageName", "Probability"],
+    )
+    target_id = str(target.get("Id") or "").strip()
+    if not target_id:
+        raise SalesforceError("Resolved Opportunity target did not include Id.")
+    if not dry_run:
+        session.patch_json(
+            session.data_path(f"/sobjects/Opportunity/{parse.quote(target_id)}"),
+            updates,
+        )
+
+    return command_payload(
+        "update-opportunity",
+        apiVersion=session.api_version,
+        dryRun=dry_run,
+        target=record_identity(target),
+        previous={
+            "StageName": target.get("StageName"),
+            "Probability": target.get("Probability"),
+        },
+        update=updates,
+    )
+
+
+def resolve_activity_target(
+    session: SalesforceSession,
+    *,
+    target: str,
+    target_object: str | None,
+) -> tuple[str, dict[str, Any]]:
+    inferred_object = infer_object_from_salesforce_id(target)
+    sobject = (
+        normalize_target_object(target_object) if target_object else inferred_object
+    )
+    if not sobject:
+        sobject = "Opportunity"
+    fields = ["Id", "Name"]
+    if sobject == "Opportunity":
+        fields.extend(["StageName", "Probability"])
+    if sobject == "Contact":
+        fields.extend(["Email", "Account.Name"])
+    if sobject == "Lead":
+        fields.extend(["Company", "Status"])
+    record = find_single_record(
+        session,
+        sobject=sobject,
+        identifier=target,
+        fields=fields,
+    )
+    return sobject, record
+
+
+def build_activity_payload(
+    *,
+    activity_type: str,
+    target_sobject: str,
+    target_id: str,
+    subject: str,
+    activity_date: str,
+    notes: str,
+    duration_minutes: int,
+) -> tuple[str, dict[str, Any]]:
+    normalized_type = normalize_activity_type(activity_type)
+    link_field = record_link_field(target_sobject)
+    clean_subject = clean_phrase(subject)
+    if not clean_subject:
+        clean_subject = normalized_type.title()
+    if normalized_type in {"call", "email"}:
+        prefix = "Call" if normalized_type == "call" else "Email"
+        task_subject = (
+            clean_subject
+            if clean_subject.lower().startswith(prefix.lower())
+            else f"{prefix}: {clean_subject}"
+        )
+        payload: dict[str, Any] = {
+            "Subject": task_subject,
+            "Status": "Completed",
+            "Priority": "Normal",
+            "ActivityDate": activity_date,
+            link_field: target_id,
+        }
+        if notes.strip():
+            payload["Description"] = notes.strip()
+        return "Task", payload
+
+    start, end = meeting_times(activity_date, duration_minutes)
+    event_subject = (
+        clean_subject
+        if clean_subject.lower().startswith("meeting")
+        else f"Meeting: {clean_subject}"
+    )
+    payload = {
+        "Subject": event_subject,
+        "StartDateTime": start,
+        "EndDateTime": end,
+        link_field: target_id,
     }
+    if notes.strip():
+        payload["Description"] = notes.strip()
+    return "Event", payload
+
+
+def log_activity(
+    session: SalesforceSession,
+    *,
+    activity_type: str,
+    target: str,
+    target_object: str | None,
+    subject: str,
+    activity_date: str | None,
+    notes: str,
+    duration_minutes: int,
+    dry_run: bool,
+) -> dict[str, Any]:
+    resolved_date = parse_activity_date(activity_date)
+    target_sobject, record = resolve_activity_target(
+        session,
+        target=target,
+        target_object=target_object,
+    )
+    target_id = str(record.get("Id") or "").strip()
+    if not target_id:
+        raise SalesforceError("Resolved activity target did not include Id.")
+    activity_sobject, fields = build_activity_payload(
+        activity_type=activity_type,
+        target_sobject=target_sobject,
+        target_id=target_id,
+        subject=subject,
+        activity_date=resolved_date,
+        notes=notes,
+        duration_minutes=duration_minutes,
+    )
+    created: Any = {}
+    if not dry_run:
+        created = session.post_json(
+            session.data_path(f"/sobjects/{activity_sobject}"),
+            fields,
+        )
+    return command_payload(
+        "log-activity",
+        apiVersion=session.api_version,
+        dryRun=dry_run,
+        activityType=normalize_activity_type(activity_type),
+        activityObject=activity_sobject,
+        targetObject=target_sobject,
+        target=record_identity(record),
+        fields=fields,
+        created=created if is_mapping(created) else {},
+    )
+
+
+def _extract_probability(text: str) -> int | None:
+    match = re.search(r"\bprob(?:ability)?(?:\s+to)?\s+(\d{1,3})%?", text, re.I)
+    if not match:
+        return None
+    return normalize_probability(int(match.group(1)))
+
+
+def _strip_probability_phrase(value: str) -> str:
+    return re.sub(
+        r"\s+(?:with\s+)?prob(?:ability)?(?:\s+to)?\s+\d{1,3}%?",
+        "",
+        value,
+        flags=re.I,
+    ).strip()
+
+
+def plan_natural_language(statement: str) -> dict[str, Any]:
+    text = clean_phrase(statement)
+    if not text:
+        raise ConfigError("Natural-language command is required.")
+    lower = text.lower()
+    actions: list[dict[str, Any]] = []
+
+    read_match = re.search(
+        r"\b(?:find|show|list|read)\s+(open\s+)?"
+        r"(leads?|contacts?|opportunit(?:y|ies)|deals?)"
+        r"(?:\s+(?:matching|for|named|at|about)\s+(.+))?$",
+        text,
+        re.I,
+    )
+    if read_match:
+        record_type = normalize_record_type(read_match.group(2))
+        actions.append(
+            {
+                "action": "find-records",
+                "recordType": record_type,
+                "search": clean_phrase(read_match.group(3) or ""),
+                "openOnly": bool(read_match.group(1)),
+                "limit": DEFAULT_SEARCH_LIMIT,
+            }
+        )
+
+    move_match = re.search(
+        r"\bmove\s+(?:the\s+)?(.+?)\s+(?:deal|opportunity)\s+to\s+"
+        r"(.+?)(?=(?:\s+and\s+log|\s+with\s+prob|\s*,|$))",
+        text,
+        re.I,
+    )
+    moved_opportunity = ""
+    if move_match:
+        moved_opportunity = clean_phrase(move_match.group(1))
+        stage = normalize_stage_name(_strip_probability_phrase(move_match.group(2)))
+        probability = _extract_probability(text)
+        if probability is None:
+            probability = default_probability_for_stage(stage)
+        actions.append(
+            {
+                "action": "update-opportunity",
+                "opportunity": moved_opportunity,
+                "stage": stage,
+                "probability": probability,
+            }
+        )
+
+    activity_match = re.search(
+        r"\blog\s+(?:an?\s+)?(call|email|meeting)"
+        r"(?:\s+(?:from|for|on)\s+(today|tomorrow|\d{4}-\d{2}-\d{2}))?"
+        r"(?:\s+(?:on|to|for)\s+(?:the\s+)?(.+?)\s+"
+        r"(account|contact|lead|deal|opportunity))?(?:$|[,.])",
+        text,
+        re.I,
+    )
+    if activity_match:
+        target = clean_phrase(activity_match.group(3) or moved_opportunity)
+        target_object = activity_match.group(4) or (
+            "opportunity" if moved_opportunity else None
+        )
+        if not target:
+            raise ConfigError("Activity command needs a target record.")
+        activity_type = normalize_activity_type(activity_match.group(1))
+        actions.append(
+            {
+                "action": "log-activity",
+                "activityType": activity_type,
+                "target": target,
+                "targetObject": normalize_target_object(target_object)
+                if target_object
+                else "Opportunity",
+                "date": activity_match.group(2) or "today",
+                "subject": f"{activity_type.title()} for {target}",
+                "notes": text,
+            }
+        )
+
+    if not actions:
+        raise ConfigError(
+            "Could not map the request to a supported Salesforce operation."
+        )
+
+    return command_payload(
+        "plan",
+        statement=text,
+        actions=actions,
+        actionCount=len(actions),
+    )
+
+
+def run_planned_actions(
+    session: SalesforceSession,
+    *,
+    statement: str,
+    dry_run: bool,
+) -> dict[str, Any]:
+    plan = plan_natural_language(statement)
+    if dry_run:
+        return command_payload(
+            "run",
+            dryRun=True,
+            statement=plan["statement"],
+            actions=plan["actions"],
+            results=[],
+        )
+    results: list[dict[str, Any]] = []
+    resolved_records: dict[str, dict[str, Any]] = {}
+    for action in plan["actions"]:
+        if action["action"] == "find-records":
+            results.append(
+                find_records(
+                    session,
+                    record_type=action["recordType"],
+                    search=action["search"],
+                    limit=action["limit"],
+                    open_only=action["openOnly"],
+                )
+            )
+        elif action["action"] == "update-opportunity":
+            result = update_opportunity(
+                session,
+                identifier=action["opportunity"],
+                stage=action["stage"],
+                probability=action["probability"],
+                dry_run=False,
+            )
+            results.append(result)
+            target = result.get("target")
+            if is_mapping(target):
+                resolved_records[action["opportunity"]] = target
+        elif action["action"] == "log-activity":
+            target = action["target"]
+            target_object = action["targetObject"]
+            if target in resolved_records and target_object == "Opportunity":
+                target = str(resolved_records[target].get("id") or target)
+            results.append(
+                log_activity(
+                    session,
+                    activity_type=action["activityType"],
+                    target=target,
+                    target_object=target_object,
+                    subject=action["subject"],
+                    activity_date=action["date"],
+                    notes=action["notes"],
+                    duration_minutes=DEFAULT_MEETING_MINUTES,
+                    dry_run=False,
+                )
+            )
+    return command_payload(
+        "run",
+        dryRun=False,
+        statement=plan["statement"],
+        actions=plan["actions"],
+        results=results,
+    )
+
+
+def evaluate_scenarios() -> dict[str, Any]:
+    raw = json.loads(EVAL_SCENARIOS_PATH.read_text("utf-8"))
+    if not isinstance(raw, list):
+        raise ConfigError("Salesforce eval scenarios must be a JSON array.")
+    failures: list[dict[str, Any]] = []
+    categories: dict[str, int] = {}
+    for scenario in raw:
+        if not is_mapping(scenario):
+            failures.append({"id": None, "error": "Scenario is not an object"})
+            continue
+        scenario_id = str(scenario.get("id") or "")
+        prompt = str(scenario.get("prompt") or "")
+        expected = scenario.get("expected") if is_mapping(scenario.get("expected")) else {}
+        category = str(scenario.get("category") or "uncategorized")
+        categories[category] = categories.get(category, 0) + 1
+        try:
+            plan = plan_natural_language(prompt)
+            actions = plan.get("actions", [])
+            first_action = actions[0] if isinstance(actions, list) and actions else {}
+            expected_action = expected.get("firstAction") if is_mapping(expected) else None
+            if expected_action and first_action.get("action") != expected_action:
+                failures.append(
+                    {
+                        "id": scenario_id,
+                        "error": (
+                            f"Expected {expected_action}, got "
+                            f"{first_action.get('action')}"
+                        ),
+                    }
+                )
+        except Exception as exc:  # noqa: BLE001 - CLI eval reports all failures
+            failures.append({"id": scenario_id, "error": str(exc)})
+    return command_payload(
+        "eval-scenarios",
+        scenarioCount=len(raw),
+        passed=len(raw) - len(failures),
+        failed=len(failures),
+        categories=categories,
+        failures=failures,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -705,6 +1445,61 @@ def render_text(payload: dict[str, Any]) -> str:
         )
         return "\n".join(lines)
 
+    if command == "find":
+        records = payload.get("records", [])
+        columns: list[str] = []
+        if isinstance(records, list):
+            seen: set[str] = set()
+            for record in records:
+                if not is_mapping(record):
+                    continue
+                for key in record.keys():
+                    if key not in seen:
+                        seen.add(key)
+                        columns.append(key)
+        rows = [
+            [record.get(column) if is_mapping(record) else record for column in columns]
+            for record in records
+        ]
+        return "\n".join(
+            [
+                f"Record type: {payload.get('recordType')}",
+                f"Rows returned: {payload.get('count')} of {payload.get('totalSize')}",
+                f"SOQL: {payload.get('soql')}",
+                "",
+                format_table(columns, rows) if columns else "No rows returned.",
+            ]
+        )
+
+    if command == "update-opportunity":
+        target = payload.get("target", {})
+        return "\n".join(
+            [
+                "Opportunity update prepared." if payload.get("dryRun") else "Opportunity updated.",
+                f"Target: {target.get('name')} ({target.get('id')})"
+                if is_mapping(target)
+                else "Target: unknown",
+                f"Update: {json.dumps(payload.get('update', {}), ensure_ascii=True)}",
+                "Dry run: yes" if payload.get("dryRun") else "Dry run: no",
+            ]
+        )
+
+    if command == "log-activity":
+        target = payload.get("target", {})
+        return "\n".join(
+            [
+                "Activity prepared." if payload.get("dryRun") else "Activity logged.",
+                f"Activity object: {payload.get('activityObject')}",
+                f"Target: {target.get('name')} ({target.get('id')})"
+                if is_mapping(target)
+                else "Target: unknown",
+                "Dry run: yes" if payload.get("dryRun") else "Dry run: no",
+            ]
+        )
+
+    if command in {"plan", "run", "eval-scenarios"}:
+        return json.dumps(payload, ensure_ascii=True, indent=2)
+
     return json.dumps(payload, ensure_ascii=True, indent=2)
 
 
@@ -769,11 +1564,31 @@ def _add_common_args(
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Read-only Salesforce schema and query helper"
+        description="Salesforce CRM schema, query, and operation helper"
     )
     _add_common_args(parser, with_defaults=True)
 
     subparsers = parser.add_subparsers(dest="command", required=True)
+
+    plan_parser = subparsers.add_parser(
+        "plan", help="Map a natural-language Salesforce request to API actions"
+    )
+    _add_common_args(plan_parser, with_defaults=False)
+    plan_parser.add_argument("statement", help="Natural-language request to plan")
+
+    run_parser = subparsers.add_parser(
+        "run", help="Execute an opinionated natural-language Salesforce request"
+    )
+    _add_common_args(run_parser, with_defaults=False)
+    run_parser.add_argument("statement", help="Natural-language request to execute")
+    run_parser.add_argument(
+        "--dry-run", action="store_true", help="Plan without calling Salesforce"
+    )
+
+    eval_parser = subparsers.add_parser(
+        "eval-scenarios", help="Run the offline Salesforce NL planner eval suite"
+    )
+    _add_common_args(eval_parser, with_defaults=False)
 
     objects_parser = subparsers.add_parser("objects", help="List available sObjects")
     _add_common_args(objects_parser, with_defaults=False)
@@ -806,6 +1621,75 @@ def build_parser() -> argparse.ArgumentParser:
     _add_common_args(relations_parser, with_defaults=False)
     relations_parser.add_argument("sobject", help="Salesforce object API name")
 
+    find_parser = subparsers.add_parser(
+        "find", help="Find leads, contacts, or opportunities by name or account"
+    )
+    _add_common_args(find_parser, with_defaults=False)
+    find_parser.add_argument(
+        "record_type",
+        choices=("leads", "contacts", "opportunities"),
+        help="CRM record collection to search",
+    )
+    find_parser.add_argument("--search", default="", help="Search text")
+    find_parser.add_argument(
+        "--open-only",
+        action="store_true",
+        help="Only return open opportunities",
+    )
+    find_parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_SEARCH_LIMIT,
+        help=f"Maximum records to return (default: {DEFAULT_SEARCH_LIMIT}, 0 for all)",
+    )
+
+    update_parser = subparsers.add_parser(
+        "update-opportunity",
+        help="Update an Opportunity stage and/or probability",
+    )
+    _add_common_args(update_parser, with_defaults=False)
+    update_parser.add_argument("identifier", help="Opportunity id or exact name")
+    update_parser.add_argument("--stage", default=None, help="New StageName")
+    update_parser.add_argument(
+        "--probability",
+        type=int,
+        default=None,
+        help="New Probability percentage, 0-100",
+    )
+    update_parser.add_argument(
+        "--dry-run", action="store_true", help="Resolve the target but skip PATCH"
+    )
+
+    activity_parser = subparsers.add_parser(
+        "log-activity", help="Log a call, email, or meeting on a CRM record"
+    )
+    _add_common_args(activity_parser, with_defaults=False)
+    activity_parser.add_argument(
+        "activity_type", choices=("call", "email", "meeting")
+    )
+    activity_parser.add_argument("target", help="Target record id or name")
+    activity_parser.add_argument(
+        "--object",
+        dest="target_object",
+        default=None,
+        choices=("account", "contact", "lead", "opportunity"),
+        help="Target object type; defaults to Opportunity unless id prefix is known",
+    )
+    activity_parser.add_argument("--subject", default="", help="Activity subject")
+    activity_parser.add_argument(
+        "--date", default="today", help="Activity date: today, tomorrow, or YYYY-MM-DD"
+    )
+    activity_parser.add_argument("--notes", default="", help="Activity notes")
+    activity_parser.add_argument(
+        "--duration-minutes",
+        type=int,
+        default=DEFAULT_MEETING_MINUTES,
+        help=f"Meeting duration in minutes (default: {DEFAULT_MEETING_MINUTES})",
+    )
+    activity_parser.add_argument(
+        "--dry-run", action="store_true", help="Resolve the target but skip create"
+    )
+
     query_parser = subparsers.add_parser("query", help="Run a SOQL row query")
     _add_common_args(query_parser, with_defaults=False)
     query_parser.add_argument("soql", help="SOQL statement to execute")
@@ -836,6 +1720,24 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
+        if args.command == "plan":
+            emit(plan_natural_language(args.statement), args.format)
+            return 0
+        if args.command == "eval-scenarios":
+            payload = evaluate_scenarios()
+            emit(payload, args.format)
+            return 0 if payload.get("failed") == 0 else 1
+        if args.command == "run" and args.dry_run:
+            emit(
+                run_planned_actions(
+                    SalesforceSession(api_version="dry-run", gateway=GatewayConfig("", "", 0)),
+                    statement=args.statement,
+                    dry_run=True,
+                ),
+                args.format,
+            )
+            return 0
+
         gw = GatewayConfig(
             base_url=args.gateway_url,
             api_token=args.gateway_token,
@@ -860,6 +1762,34 @@ def main() -> int:
             )
         elif args.command == "relations":
             payload = relations_object(session, sobject=args.sobject)
+        elif args.command == "find":
+            payload = find_records(
+                session,
+                record_type=args.record_type,
+                search=args.search,
+                limit=args.limit,
+                open_only=args.open_only,
+            )
+        elif args.command == "update-opportunity":
+            payload = update_opportunity(
+                session,
+                identifier=args.identifier,
+                stage=args.stage,
+                probability=args.probability,
+                dry_run=args.dry_run,
+            )
+        elif args.command == "log-activity":
+            payload = log_activity(
+                session,
+                activity_type=args.activity_type,
+                target=args.target,
+                target_object=args.target_object,
+                subject=args.subject,
+                activity_date=args.date,
+                notes=args.notes,
+                duration_minutes=args.duration_minutes,
+                dry_run=args.dry_run,
+            )
         elif args.command == "query":
             payload = run_query(
                 session,
@@ -867,6 +1797,12 @@ def main() -> int:
                 tooling=False,
                 max_records=args.max_records,
                 keep_attributes=args.keep_attributes,
+            )
+        elif args.command == "run":
+            payload = run_planned_actions(
+                session,
+                statement=args.statement,
+                dry_run=False,
             )
         else:
             payload = run_query(

--- a/src/gateway/gateway-http-proxy.ts
+++ b/src/gateway/gateway-http-proxy.ts
@@ -306,6 +306,7 @@ function replaceSecretPlaceholders(value: unknown): unknown {
 }
 
 const BOUND_DOMAIN_SUFFIX = '_BOUND_DOMAIN';
+const UNBOUND_OAUTH_CAPTURE_JSON_PATHS = new Set(['instance_url']);
 
 /**
  * Return the exact lowercase hostname for domain binding.
@@ -394,11 +395,11 @@ function extractBindingDomainFromResponse(
  * fields into the secret store and return the mapping.  The original
  * response body is **never** forwarded to the caller.
  *
- * For every captured secret that looks like a token (contains "token" in the
- * jsonPath), a domain binding is stored so that `bearerSecretName` only works
- * against the resource host. OAuth APIs such as Salesforce issue tokens from a
- * login host but return an `instance_url` resource host; bind to that resource
- * host when present and fall back to the OAuth endpoint hostname otherwise.
+ * Captured OAuth secrets are bound by default so that `bearerSecretName` only
+ * works against the resource host. OAuth APIs such as Salesforce issue tokens
+ * from a login host but return an `instance_url` resource host; bind to that
+ * resource host when present and fall back to the OAuth endpoint hostname
+ * otherwise. Non-token metadata captures must be explicitly exempted.
  */
 function captureOAuthResponse(
   responseJson: unknown,
@@ -421,9 +422,9 @@ function captureOAuthResponse(
       secrets[rule.secretName] = value.trim();
       captured[rule.jsonPath] = rule.secretName;
 
-      // Bind token secrets to the OAuth endpoint's domain so they
-      // cannot be exfiltrated to an attacker-controlled URL.
-      if (rule.jsonPath.includes('token')) {
+      // Bind captured OAuth secrets by default so future token field names such
+      // as "access" or "bearer" cannot silently become cross-host credentials.
+      if (!UNBOUND_OAUTH_CAPTURE_JSON_PATHS.has(rule.jsonPath)) {
         secrets[`${rule.secretName}${BOUND_DOMAIN_SUFFIX}`] = baseDomain;
       }
     }

--- a/src/gateway/gateway-http-proxy.ts
+++ b/src/gateway/gateway-http-proxy.ts
@@ -369,15 +369,36 @@ function normalizeCaptureResponseFields(
   return rules;
 }
 
+function extractBindingDomainFromResponse(
+  responseJson: Record<string, unknown>,
+  requestUrl: URL,
+): string {
+  const instanceUrl = responseJson.instance_url;
+  if (typeof instanceUrl !== 'string' || !instanceUrl.trim()) {
+    return extractBaseDomain(requestUrl.hostname);
+  }
+  try {
+    const parsed = new URL(instanceUrl);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return extractBaseDomain(requestUrl.hostname);
+    }
+    return extractBaseDomain(parsed.hostname);
+  } catch {
+    return extractBaseDomain(requestUrl.hostname);
+  }
+}
+
 /**
  * Auto-detect an OAuth2 token response (RFC 6749 S5.1) by checking for
  * `access_token` in the JSON body.  When detected, capture all matching
  * fields into the secret store and return the mapping.  The original
  * response body is **never** forwarded to the caller.
  *
- * For every captured secret that looks like a token (contains "token" in
- * the jsonPath), a domain binding is stored so that `bearerSecretName`
- * only works against the same domain the token was issued from.
+ * For every captured secret that looks like a token (contains "token" in the
+ * jsonPath), a domain binding is stored so that `bearerSecretName` only works
+ * against the resource host. OAuth APIs such as Salesforce issue tokens from a
+ * login host but return an `instance_url` resource host; bind to that resource
+ * host when present and fall back to the OAuth endpoint hostname otherwise.
  */
 function captureOAuthResponse(
   responseJson: unknown,
@@ -390,7 +411,7 @@ function captureOAuthResponse(
     return null;
   }
 
-  const baseDomain = extractBaseDomain(requestUrl.hostname);
+  const baseDomain = extractBindingDomainFromResponse(obj, requestUrl);
   const secrets: Record<string, string> = {};
   const captured: Record<string, string> = {};
 

--- a/tests/fixtures/salesforce_helper_assertions.py
+++ b/tests/fixtures/salesforce_helper_assertions.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Fixture assertions for tests/salesforce-skill.test.ts."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sys
+from urllib import parse
+from typing import Any
+
+
+def load_helper(path: str) -> Any:
+    helper_path = pathlib.Path(path)
+    spec = importlib.util.spec_from_file_location("salesforce_query", helper_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load helper from {helper_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def print_json(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload))
+
+
+def normalize_and_escape(module: Any) -> None:
+    print_json(
+        {
+            "standardStage": module.normalize_stage_name("closed won"),
+            "customStage": module.normalize_stage_name("legal review - phase_2"),
+            "literal": module.escape_soql_literal("Acme_50%'s"),
+            "likeLiteral": module.escape_soql_like_literal("Acme_50%'s"),
+        }
+    )
+
+
+def request_and_reuse(module: Any) -> None:
+    gateway_calls: list[dict[str, Any]] = []
+
+    def fake_gateway_request(gateway: Any, **kwargs: Any) -> dict[str, bool]:
+        gateway_calls.append(kwargs)
+        return {"ok": True}
+
+    module.gateway_request = fake_gateway_request
+    gateway = module.GatewayConfig(
+        base_url="http://127.0.0.1:9090",
+        api_token="test-token",
+        timeout_ms=1000,
+    )
+    session = module.SalesforceSession(api_version="61.0", gateway=gateway)
+    session.request_json("GET", "/services/data/v61.0/query")
+    session.request_json(
+        "GET", "https://example.my.salesforce.com/services/data/v61.0/query"
+    )
+
+    errors: list[str] = []
+    for bad in ["http://stubs", "services/data/v61.0/query"]:
+        try:
+            session.request_json("GET", bad)
+        except module.ConfigError:
+            errors.append(bad)
+
+    captured_targets: list[str] = []
+
+    class DummySession:
+        api_version = "61.0"
+
+    module.plan_natural_language = lambda statement: {
+        "statement": statement,
+        "actions": [
+            {
+                "action": "update-opportunity",
+                "opportunity": "Acme",
+                "stage": "Closed Won",
+                "probability": 100,
+            },
+            {
+                "action": "log-activity",
+                "activityType": "call",
+                "target": " acme ",
+                "targetObject": "Opportunity",
+                "subject": "Call for Acme",
+                "date": "today",
+                "notes": statement,
+            },
+        ],
+    }
+    module.update_opportunity = lambda *args, **kwargs: {
+        "target": {"id": "006000000000001AAA", "name": "Acme"}
+    }
+
+    def fake_log_activity(*args: Any, **kwargs: Any) -> dict[str, str]:
+        captured_targets.append(kwargs["target"])
+        return {"target": kwargs["target"]}
+
+    module.log_activity = fake_log_activity
+    module.run_planned_actions(DummySession(), statement="move and log", dry_run=False)
+    print_json(
+        {
+            "urls": [call["url"] for call in gateway_calls],
+            "errors": errors,
+            "capturedTargets": captured_targets,
+        }
+    )
+
+
+def validate_plan_and_versions(module: Any) -> None:
+    gateway_payloads: list[Any] = []
+
+    def fake_gateway_request(gateway: Any, **kwargs: Any) -> Any:
+        return gateway_payloads.pop(0)
+
+    module.gateway_request = fake_gateway_request
+    gateway = module.GatewayConfig(
+        base_url="http://127.0.0.1:9090",
+        api_token="test-token",
+        timeout_ms=1000,
+    )
+    gateway_payloads.append(
+        ["not-an-object", {"version": "60.0"}, 7, {"version": "61.0"}]
+    )
+    latest = module.resolve_latest_api_version(gateway)
+
+    gateway_payloads.append(["bad", {"label": "missing version"}])
+    invalid_version_error = ""
+    try:
+        module.resolve_latest_api_version(gateway)
+    except module.SalesforceError as exc:
+        invalid_version_error = str(exc)
+
+    writes: list[dict[str, Any]] = []
+
+    class DummySession:
+        api_version = "61.0"
+
+    module.plan_natural_language = lambda statement: {
+        "statement": statement,
+        "actions": [
+            {
+                "action": "update-opportunity",
+                "opportunity": "Acme",
+                "stage": "Closed Won",
+                "probability": 100,
+            },
+            {
+                "action": "find-records",
+                "recordType": "leads",
+                "search": "Acme",
+                "limit": 10,
+            },
+        ],
+    }
+
+    def fake_update(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        writes.append(kwargs)
+        return {"target": {"id": "006000000000001AAA", "name": "Acme"}}
+
+    module.update_opportunity = fake_update
+    plan_error = ""
+    try:
+        module.run_planned_actions(DummySession(), statement="bad plan", dry_run=False)
+    except module.ConfigError as exc:
+        plan_error = str(exc)
+
+    print_json(
+        {
+            "latest": latest,
+            "invalidVersionError": invalid_version_error,
+            "planError": plan_error,
+            "writeCount": len(writes),
+        }
+    )
+
+
+class FakeSession:
+    api_version = "61.0"
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.queries: list[str] = []
+
+    def data_path(self, suffix: str) -> str:
+        return "/services/data/v61.0" + suffix
+
+    def get_json(self, path: str) -> dict[str, Any]:
+        assert path.startswith("/services/data/v61.0/query?")
+        self.queries.append(path)
+        return {
+            "totalSize": 1,
+            "done": True,
+            "records": [
+                {
+                    "Id": "006000000000001AAA",
+                    "Name": "Acme Renewal",
+                    "StageName": "Proposal/Price Quote",
+                    "Probability": 60,
+                }
+            ],
+        }
+
+    def patch_json(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append({"method": "PATCH", "path": path, "payload": payload})
+        return {}
+
+    def post_json(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append({"method": "POST", "path": path, "payload": payload})
+        return {"id": "00T000000000001AAA", "success": True}
+
+
+def write_payloads(module: Any) -> None:
+    session = FakeSession()
+    update = module.update_opportunity(
+        session,
+        identifier="Acme Renewal",
+        stage="Closed Won",
+        probability=None,
+        dry_run=False,
+    )
+    activity = module.log_activity(
+        session,
+        activity_type="call",
+        target="006000000000001AAA",
+        target_object="opportunity",
+        subject="Discovery follow-up",
+        activity_date="today",
+        notes="Spoke with the champion.",
+        duration_minutes=30,
+        dry_run=False,
+    )
+    print_json(
+        {
+            "update": update,
+            "activity": activity,
+            "calls": session.calls,
+            "queryCount": len(session.queries),
+        }
+    )
+
+
+def single_query_fuzzy_resolution(module: Any) -> None:
+    class QuerySession:
+        api_version = "61.0"
+
+        def __init__(self) -> None:
+            self.queries: list[str] = []
+            self.soql: list[str] = []
+
+        def data_path(self, suffix: str) -> str:
+            return "/services/data/v61.0" + suffix
+
+        def get_json(self, path: str) -> dict[str, Any]:
+            self.queries.append(path)
+            self.soql.append(parse.parse_qs(parse.urlparse(path).query)["q"][0])
+            return {
+                "totalSize": 1,
+                "done": True,
+                "records": [
+                    {
+                        "Id": "006000000000001AAA",
+                        "Name": "Acme Renewal",
+                    }
+                ],
+            }
+
+    session = QuerySession()
+    record = module.find_single_record(
+        session,
+        sobject="Opportunity",
+        identifier="Acme Ren",
+        fields=["StageName", "Probability"],
+    )
+    print_json(
+        {
+            "record": record,
+            "queryCount": len(session.queries),
+            "query": session.soql[0],
+        }
+    )
+
+
+def route_check(module: Any) -> None:
+    assert callable(module.gateway_request)
+    assert not hasattr(module, "request_json")
+    assert not hasattr(module, "read_stored_secret")
+    assert not hasattr(module, "resolve_secret_input")
+    assert not hasattr(module, "normalize_stored_secret_output")
+    assert not hasattr(module, "AuthConfig")
+    assert not hasattr(module, "store_secret")
+    print_json({"ok": True})
+
+
+def secret_scan(path: str) -> None:
+    content = pathlib.Path(path).read_text()
+    assert "secret show" not in content, "Script must not read secrets via CLI"
+    assert "secret set" not in content, (
+        "Script must not write secrets via CLI - use captureResponseSecrets"
+    )
+    assert "subprocess" not in content, "Script must not shell out to manage secrets"
+    assert "captureResponseSecrets" not in content, (
+        "Script must not reference captureResponseSecrets directly"
+    )
+    print("ok")
+
+
+CASES = {
+    "normalize-and-escape": normalize_and_escape,
+    "request-and-reuse": request_and_reuse,
+    "validate-plan-and-versions": validate_plan_and_versions,
+    "write-payloads": write_payloads,
+    "single-query-fuzzy-resolution": single_query_fuzzy_resolution,
+    "route-check": route_check,
+}
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(
+            "usage: salesforce_helper_assertions.py HELPER_PATH CASE",
+            file=sys.stderr,
+        )
+        return 2
+
+    helper_path, case = sys.argv[1], sys.argv[2]
+    if case == "secret-scan":
+        secret_scan(helper_path)
+        return 0
+
+    assertion = CASES.get(case)
+    if assertion is None:
+        print(f"unknown case: {case}", file=sys.stderr)
+        return 2
+    assertion(load_helper(helper_path))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -7402,6 +7402,125 @@ describe('gateway HTTP server', () => {
     });
   });
 
+  test('binds captured OAuth bearer tokens to response instance_url host', async () => {
+    const homeDir = makeTempDocsRoot('hybridclaw-http-oauth-');
+    process.env.HOME = homeDir;
+    writeRuntimeConfig(homeDir);
+
+    const { saveNamedRuntimeSecrets } = await import(
+      '../src/security/runtime-secrets.ts'
+    );
+    saveNamedRuntimeSecrets({
+      SF_DOMAIN: 'login',
+      SF_FULL_CLIENTID: 'client-id',
+      SF_FULL_SECRET: 'client-secret',
+      SF_FULL_USERNAME: 'user@example.com',
+      SF_FULL_PASSWORD: 'password-plus-token',
+    });
+
+    vi.doMock('node:dns/promises', () => ({
+      lookup: vi.fn(async () => [{ address: '93.184.216.34', family: 4 }]),
+    }));
+    const state = await importFreshHealth({ gatewayApiToken: 'gateway-token' });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: 'salesforce-access-token',
+            instance_url: 'https://acme.my.salesforce.com',
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ totalSize: 0, done: true, records: [] }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        ),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const authReq = makeRequest({
+      method: 'POST',
+      url: '/api/http/request',
+      headers: { authorization: 'Bearer gateway-token' },
+      body: {
+        url: 'https://<secret:SF_DOMAIN>.salesforce.com/services/oauth2/token',
+        method: 'POST',
+        body: 'grant_type=password&client_id=<secret:SF_FULL_CLIENTID>&client_secret=<secret:SF_FULL_SECRET>&username=<secret:SF_FULL_USERNAME>&password=<secret:SF_FULL_PASSWORD>',
+        captureResponseFields: [
+          { jsonPath: 'access_token', secretName: 'SF_ACCESS_TOKEN' },
+          { jsonPath: 'instance_url', secretName: 'SF_INSTANCE_URL' },
+        ],
+      },
+    });
+    const authRes = makeResponse();
+
+    state.handler(authReq as never, authRes as never);
+    await settle();
+
+    expect(authRes.statusCode).toBe(200);
+    expect(JSON.parse(authRes.body)).toEqual({
+      ok: true,
+      status: 200,
+      captured: {
+        access_token: 'SF_ACCESS_TOKEN',
+        instance_url: 'SF_INSTANCE_URL',
+      },
+    });
+
+    const apiReq = makeRequest({
+      method: 'POST',
+      url: '/api/http/request',
+      headers: { authorization: 'Bearer gateway-token' },
+      body: {
+        url: 'https://acme.my.salesforce.com/services/data/v61.0/query?q=SELECT+Id+FROM+Opportunity+LIMIT+1',
+        bearerSecretName: 'SF_ACCESS_TOKEN',
+      },
+    });
+    const apiRes = makeResponse();
+
+    state.handler(apiReq as never, apiRes as never);
+    await settle();
+
+    expect(apiRes.statusCode).toBe(200);
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      expect.any(URL),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer salesforce-access-token',
+        }),
+      }),
+    );
+
+    const blockedReq = makeRequest({
+      method: 'POST',
+      url: '/api/http/request',
+      headers: { authorization: 'Bearer gateway-token' },
+      body: {
+        url: 'https://evil.example.com/steal',
+        bearerSecretName: 'SF_ACCESS_TOKEN',
+      },
+    });
+    const blockedRes = makeResponse();
+
+    state.handler(blockedReq as never, blockedRes as never);
+    await settle();
+
+    expect(blockedRes.statusCode).toBe(403);
+    expect(JSON.parse(blockedRes.body).error).toContain(
+      'request to evil.example.com is blocked',
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   test('blocks outbound http_request redirects to avoid SSRF bypasses', async () => {
     vi.doMock('node:dns/promises', () => ({
       lookup: vi.fn(async () => [{ address: '104.21.30.182', family: 4 }]),

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -7408,7 +7408,7 @@ describe('gateway HTTP server', () => {
     process.env.HOME = homeDir;
     writeRuntimeConfig(homeDir);
 
-    const { saveNamedRuntimeSecrets } = await import(
+    const { readStoredRuntimeSecret, saveNamedRuntimeSecrets } = await import(
       '../src/security/runtime-secrets.ts'
     );
     saveNamedRuntimeSecrets({
@@ -7429,6 +7429,7 @@ describe('gateway HTTP server', () => {
         new Response(
           JSON.stringify({
             access_token: 'salesforce-access-token',
+            bearer: 'salesforce-bearer-token',
             instance_url: 'https://acme.my.salesforce.com',
           }),
           {
@@ -7458,6 +7459,7 @@ describe('gateway HTTP server', () => {
         body: 'grant_type=password&client_id=<secret:SF_FULL_CLIENTID>&client_secret=<secret:SF_FULL_SECRET>&username=<secret:SF_FULL_USERNAME>&password=<secret:SF_FULL_PASSWORD>',
         captureResponseFields: [
           { jsonPath: 'access_token', secretName: 'SF_ACCESS_TOKEN' },
+          { jsonPath: 'bearer', secretName: 'SF_BEARER' },
           { jsonPath: 'instance_url', secretName: 'SF_INSTANCE_URL' },
         ],
       },
@@ -7473,9 +7475,17 @@ describe('gateway HTTP server', () => {
       status: 200,
       captured: {
         access_token: 'SF_ACCESS_TOKEN',
+        bearer: 'SF_BEARER',
         instance_url: 'SF_INSTANCE_URL',
       },
     });
+    expect(readStoredRuntimeSecret('SF_ACCESS_TOKEN_BOUND_DOMAIN')).toBe(
+      'acme.my.salesforce.com',
+    );
+    expect(readStoredRuntimeSecret('SF_BEARER_BOUND_DOMAIN')).toBe(
+      'acme.my.salesforce.com',
+    );
+    expect(readStoredRuntimeSecret('SF_INSTANCE_URL_BOUND_DOMAIN')).toBeNull();
 
     const apiReq = makeRequest({
       method: 'POST',

--- a/tests/salesforce-skill.test.ts
+++ b/tests/salesforce-skill.test.ts
@@ -67,6 +67,40 @@ test('salesforce helper plans compound natural-language workflows offline', () =
   ]);
 });
 
+test('salesforce helper preserves custom stage names and escapes SOQL LIKE wildcards', () => {
+  const result = spawnSync(
+    'python3',
+    [
+      '-c',
+      [
+        'import importlib.util, json, pathlib, sys',
+        'helper_path = pathlib.Path(sys.argv[1])',
+        'spec = importlib.util.spec_from_file_location("salesforce_query", helper_path)',
+        'module = importlib.util.module_from_spec(spec)',
+        'sys.modules[spec.name] = module',
+        'spec.loader.exec_module(module)',
+        'print(json.dumps({',
+        '    "standardStage": module.normalize_stage_name("closed won"),',
+        '    "customStage": module.normalize_stage_name("legal review - phase_2"),',
+        '    "literal": module.escape_soql_literal("Acme_50%\'s"),',
+        '    "likeLiteral": module.escape_soql_like_literal("Acme_50%\'s"),',
+        '}))',
+      ].join('\n'),
+      helperPath,
+    ],
+    { encoding: 'utf-8' },
+  );
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload).toEqual({
+    standardStage: 'Closed Won',
+    customStage: 'legal review - phase_2',
+    literal: "Acme_50%\\'s",
+    likeLiteral: "Acme\\_50\\%\\'s",
+  });
+});
+
 test('salesforce helper eval suite covers 30 read and write scenarios', () => {
   const scenarios = JSON.parse(
     fs.readFileSync(scenariosPath, 'utf-8'),

--- a/tests/salesforce-skill.test.ts
+++ b/tests/salesforce-skill.test.ts
@@ -101,6 +101,73 @@ test('salesforce helper preserves custom stage names and escapes SOQL LIKE wildc
   });
 });
 
+test('salesforce helper validates Salesforce request URLs and reuses resolved opportunity ids', () => {
+  const result = spawnSync(
+    'python3',
+    [
+      '-c',
+      [
+        'import importlib.util, json, pathlib, sys',
+        'helper_path = pathlib.Path(sys.argv[1])',
+        'spec = importlib.util.spec_from_file_location("salesforce_query", helper_path)',
+        'module = importlib.util.module_from_spec(spec)',
+        'sys.modules[spec.name] = module',
+        'spec.loader.exec_module(module)',
+        'gateway_calls = []',
+        'def fake_gateway_request(gateway, **kwargs):',
+        '    gateway_calls.append(kwargs)',
+        '    return {"ok": True}',
+        'module.gateway_request = fake_gateway_request',
+        'gateway = module.GatewayConfig(base_url="http://127.0.0.1:9090", api_token="test-token", timeout_ms=1000)',
+        'session = module.SalesforceSession(api_version="61.0", gateway=gateway)',
+        'session.request_json("GET", "/services/data/v61.0/query")',
+        'session.request_json("GET", "https://example.my.salesforce.com/services/data/v61.0/query")',
+        'errors = []',
+        'for bad in ["http://stubs", "services/data/v61.0/query"]:',
+        '    try:',
+        '        session.request_json("GET", bad)',
+        '    except module.ConfigError:',
+        '        errors.append(bad)',
+        'captured_targets = []',
+        'class DummySession:',
+        '    api_version = "61.0"',
+        'module.plan_natural_language = lambda statement: {',
+        '    "statement": statement,',
+        '    "actions": [',
+        '        {"action": "update-opportunity", "opportunity": "Acme", "stage": "Closed Won", "probability": 100},',
+        '        {"action": "log-activity", "activityType": "call", "target": " acme ", "targetObject": "Opportunity", "subject": "Call for Acme", "date": "today", "notes": statement},',
+        '    ],',
+        '}',
+        'module.update_opportunity = lambda *args, **kwargs: {"target": {"id": "006000000000001AAA", "name": "Acme"}}',
+        'def fake_log_activity(*args, **kwargs):',
+        '    captured_targets.append(kwargs["target"])',
+        '    return {"target": kwargs["target"]}',
+        'module.log_activity = fake_log_activity',
+        'module.run_planned_actions(DummySession(), statement="move and log", dry_run=False)',
+        'print(json.dumps({',
+        '    "urls": [call["url"] for call in gateway_calls],',
+        '    "errors": errors,',
+        '    "capturedTargets": captured_targets,',
+        '}))',
+      ].join('\n'),
+      helperPath,
+    ],
+    { encoding: 'utf-8' },
+  );
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.urls).toEqual([
+    '<secret:SF_INSTANCE_URL>/services/data/v61.0/query',
+    'https://example.my.salesforce.com/services/data/v61.0/query',
+  ]);
+  expect(payload.errors).toEqual([
+    'http://stubs',
+    'services/data/v61.0/query',
+  ]);
+  expect(payload.capturedTargets).toEqual(['006000000000001AAA']);
+});
+
 test('salesforce helper eval suite covers 30 read and write scenarios', () => {
   const scenarios = JSON.parse(
     fs.readFileSync(scenariosPath, 'utf-8'),

--- a/tests/salesforce-skill.test.ts
+++ b/tests/salesforce-skill.test.ts
@@ -168,6 +168,70 @@ test('salesforce helper validates Salesforce request URLs and reuses resolved op
   expect(payload.capturedTargets).toEqual(['006000000000001AAA']);
 });
 
+test('salesforce helper validates planned actions before writes and ignores malformed API versions', () => {
+  const result = spawnSync(
+    'python3',
+    [
+      '-c',
+      [
+        'import importlib.util, json, pathlib, sys',
+        'helper_path = pathlib.Path(sys.argv[1])',
+        'spec = importlib.util.spec_from_file_location("salesforce_query", helper_path)',
+        'module = importlib.util.module_from_spec(spec)',
+        'sys.modules[spec.name] = module',
+        'spec.loader.exec_module(module)',
+        'gateway_payloads = []',
+        'def fake_gateway_request(gateway, **kwargs):',
+        '    return gateway_payloads.pop(0)',
+        'module.gateway_request = fake_gateway_request',
+        'gateway = module.GatewayConfig(base_url="http://127.0.0.1:9090", api_token="test-token", timeout_ms=1000)',
+        'gateway_payloads.append(["not-an-object", {"version": "60.0"}, 7, {"version": "61.0"}])',
+        'latest = module.resolve_latest_api_version(gateway)',
+        'gateway_payloads.append(["bad", {"label": "missing version"}])',
+        'invalid_version_error = ""',
+        'try:',
+        '    module.resolve_latest_api_version(gateway)',
+        'except module.SalesforceError as exc:',
+        '    invalid_version_error = str(exc)',
+        'writes = []',
+        'class DummySession:',
+        '    api_version = "61.0"',
+        'module.plan_natural_language = lambda statement: {',
+        '    "statement": statement,',
+        '    "actions": [',
+        '        {"action": "update-opportunity", "opportunity": "Acme", "stage": "Closed Won", "probability": 100},',
+        '        {"action": "find-records", "recordType": "leads", "search": "Acme", "limit": 10},',
+        '    ],',
+        '}',
+        'def fake_update(*args, **kwargs):',
+        '    writes.append(kwargs)',
+        '    return {"target": {"id": "006000000000001AAA", "name": "Acme"}}',
+        'module.update_opportunity = fake_update',
+        'plan_error = ""',
+        'try:',
+        '    module.run_planned_actions(DummySession(), statement="bad plan", dry_run=False)',
+        'except module.ConfigError as exc:',
+        '    plan_error = str(exc)',
+        'print(json.dumps({',
+        '    "latest": latest,',
+        '    "invalidVersionError": invalid_version_error,',
+        '    "planError": plan_error,',
+        '    "writeCount": len(writes),',
+        '}))',
+      ].join('\n'),
+      helperPath,
+    ],
+    { encoding: 'utf-8' },
+  );
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.latest).toBe('61.0');
+  expect(payload.invalidVersionError).toContain('invalid API version payload');
+  expect(payload.planError).toContain("missing: openOnly");
+  expect(payload.writeCount).toBe(0);
+});
+
 test('salesforce helper eval suite covers 30 read and write scenarios', () => {
   const scenarios = JSON.parse(
     fs.readFileSync(scenariosPath, 'utf-8'),

--- a/tests/salesforce-skill.test.ts
+++ b/tests/salesforce-skill.test.ts
@@ -18,6 +18,18 @@ const scenariosPath = path.join(
   'evals',
   'scenarios.json',
 );
+const assertionsPath = path.join(
+  process.cwd(),
+  'tests',
+  'fixtures',
+  'salesforce_helper_assertions.py',
+);
+
+function runAssertion(caseName: string) {
+  return spawnSync('python3', [assertionsPath, helperPath, caseName], {
+    encoding: 'utf-8',
+  });
+}
 
 test('salesforce helper --help exits cleanly', () => {
   const result = spawnSync('python3', [helperPath, '--help'], {
@@ -68,28 +80,7 @@ test('salesforce helper plans compound natural-language workflows offline', () =
 });
 
 test('salesforce helper preserves custom stage names and escapes SOQL LIKE wildcards', () => {
-  const result = spawnSync(
-    'python3',
-    [
-      '-c',
-      [
-        'import importlib.util, json, pathlib, sys',
-        'helper_path = pathlib.Path(sys.argv[1])',
-        'spec = importlib.util.spec_from_file_location("salesforce_query", helper_path)',
-        'module = importlib.util.module_from_spec(spec)',
-        'sys.modules[spec.name] = module',
-        'spec.loader.exec_module(module)',
-        'print(json.dumps({',
-        '    "standardStage": module.normalize_stage_name("closed won"),',
-        '    "customStage": module.normalize_stage_name("legal review - phase_2"),',
-        '    "literal": module.escape_soql_literal("Acme_50%\'s"),',
-        '    "likeLiteral": module.escape_soql_like_literal("Acme_50%\'s"),',
-        '}))',
-      ].join('\n'),
-      helperPath,
-    ],
-    { encoding: 'utf-8' },
-  );
+  const result = runAssertion('normalize-and-escape');
 
   expect(result.status).toBe(0);
   const payload = JSON.parse(result.stdout);
@@ -102,58 +93,7 @@ test('salesforce helper preserves custom stage names and escapes SOQL LIKE wildc
 });
 
 test('salesforce helper validates Salesforce request URLs and reuses resolved opportunity ids', () => {
-  const result = spawnSync(
-    'python3',
-    [
-      '-c',
-      [
-        'import importlib.util, json, pathlib, sys',
-        'helper_path = pathlib.Path(sys.argv[1])',
-        'spec = importlib.util.spec_from_file_location("salesforce_query", helper_path)',
-        'module = importlib.util.module_from_spec(spec)',
-        'sys.modules[spec.name] = module',
-        'spec.loader.exec_module(module)',
-        'gateway_calls = []',
-        'def fake_gateway_request(gateway, **kwargs):',
-        '    gateway_calls.append(kwargs)',
-        '    return {"ok": True}',
-        'module.gateway_request = fake_gateway_request',
-        'gateway = module.GatewayConfig(base_url="http://127.0.0.1:9090", api_token="test-token", timeout_ms=1000)',
-        'session = module.SalesforceSession(api_version="61.0", gateway=gateway)',
-        'session.request_json("GET", "/services/data/v61.0/query")',
-        'session.request_json("GET", "https://example.my.salesforce.com/services/data/v61.0/query")',
-        'errors = []',
-        'for bad in ["http://stubs", "services/data/v61.0/query"]:',
-        '    try:',
-        '        session.request_json("GET", bad)',
-        '    except module.ConfigError:',
-        '        errors.append(bad)',
-        'captured_targets = []',
-        'class DummySession:',
-        '    api_version = "61.0"',
-        'module.plan_natural_language = lambda statement: {',
-        '    "statement": statement,',
-        '    "actions": [',
-        '        {"action": "update-opportunity", "opportunity": "Acme", "stage": "Closed Won", "probability": 100},',
-        '        {"action": "log-activity", "activityType": "call", "target": " acme ", "targetObject": "Opportunity", "subject": "Call for Acme", "date": "today", "notes": statement},',
-        '    ],',
-        '}',
-        'module.update_opportunity = lambda *args, **kwargs: {"target": {"id": "006000000000001AAA", "name": "Acme"}}',
-        'def fake_log_activity(*args, **kwargs):',
-        '    captured_targets.append(kwargs["target"])',
-        '    return {"target": kwargs["target"]}',
-        'module.log_activity = fake_log_activity',
-        'module.run_planned_actions(DummySession(), statement="move and log", dry_run=False)',
-        'print(json.dumps({',
-        '    "urls": [call["url"] for call in gateway_calls],',
-        '    "errors": errors,',
-        '    "capturedTargets": captured_targets,',
-        '}))',
-      ].join('\n'),
-      helperPath,
-    ],
-    { encoding: 'utf-8' },
-  );
+  const result = runAssertion('request-and-reuse');
 
   expect(result.status).toBe(0);
   const payload = JSON.parse(result.stdout);
@@ -169,60 +109,7 @@ test('salesforce helper validates Salesforce request URLs and reuses resolved op
 });
 
 test('salesforce helper validates planned actions before writes and ignores malformed API versions', () => {
-  const result = spawnSync(
-    'python3',
-    [
-      '-c',
-      [
-        'import importlib.util, json, pathlib, sys',
-        'helper_path = pathlib.Path(sys.argv[1])',
-        'spec = importlib.util.spec_from_file_location("salesforce_query", helper_path)',
-        'module = importlib.util.module_from_spec(spec)',
-        'sys.modules[spec.name] = module',
-        'spec.loader.exec_module(module)',
-        'gateway_payloads = []',
-        'def fake_gateway_request(gateway, **kwargs):',
-        '    return gateway_payloads.pop(0)',
-        'module.gateway_request = fake_gateway_request',
-        'gateway = module.GatewayConfig(base_url="http://127.0.0.1:9090", api_token="test-token", timeout_ms=1000)',
-        'gateway_payloads.append(["not-an-object", {"version": "60.0"}, 7, {"version": "61.0"}])',
-        'latest = module.resolve_latest_api_version(gateway)',
-        'gateway_payloads.append(["bad", {"label": "missing version"}])',
-        'invalid_version_error = ""',
-        'try:',
-        '    module.resolve_latest_api_version(gateway)',
-        'except module.SalesforceError as exc:',
-        '    invalid_version_error = str(exc)',
-        'writes = []',
-        'class DummySession:',
-        '    api_version = "61.0"',
-        'module.plan_natural_language = lambda statement: {',
-        '    "statement": statement,',
-        '    "actions": [',
-        '        {"action": "update-opportunity", "opportunity": "Acme", "stage": "Closed Won", "probability": 100},',
-        '        {"action": "find-records", "recordType": "leads", "search": "Acme", "limit": 10},',
-        '    ],',
-        '}',
-        'def fake_update(*args, **kwargs):',
-        '    writes.append(kwargs)',
-        '    return {"target": {"id": "006000000000001AAA", "name": "Acme"}}',
-        'module.update_opportunity = fake_update',
-        'plan_error = ""',
-        'try:',
-        '    module.run_planned_actions(DummySession(), statement="bad plan", dry_run=False)',
-        'except module.ConfigError as exc:',
-        '    plan_error = str(exc)',
-        'print(json.dumps({',
-        '    "latest": latest,',
-        '    "invalidVersionError": invalid_version_error,',
-        '    "planError": plan_error,',
-        '    "writeCount": len(writes),',
-        '}))',
-      ].join('\n'),
-      helperPath,
-    ],
-    { encoding: 'utf-8' },
-  );
+  const result = runAssertion('validate-plan-and-versions');
 
   expect(result.status).toBe(0);
   const payload = JSON.parse(result.stdout);
@@ -270,66 +157,7 @@ test('salesforce helper eval suite covers 30 read and write scenarios', () => {
 });
 
 test('salesforce helper builds gateway-backed opportunity update and activity writes', () => {
-  const result = spawnSync(
-    'python3',
-    [
-      '-c',
-      [
-        'import importlib.util, json, pathlib, sys',
-        'helper_path = pathlib.Path(sys.argv[1])',
-        'spec = importlib.util.spec_from_file_location("salesforce_query", helper_path)',
-        'module = importlib.util.module_from_spec(spec)',
-        'sys.modules[spec.name] = module',
-        'spec.loader.exec_module(module)',
-        'class FakeSession:',
-        '    api_version = "61.0"',
-        '    def __init__(self):',
-        '        self.calls = []',
-        '    def data_path(self, suffix):',
-        '        return "/services/data/v61.0" + suffix',
-        '    def get_json(self, path):',
-        '        assert path.startswith("/services/data/v61.0/query?")',
-        '        return {',
-        '            "totalSize": 1,',
-        '            "done": True,',
-        '            "records": [{',
-        '                "Id": "006000000000001AAA",',
-        '                "Name": "Acme Renewal",',
-        '                "StageName": "Proposal/Price Quote",',
-        '                "Probability": 60,',
-        '            }],',
-        '        }',
-        '    def patch_json(self, path, payload):',
-        '        self.calls.append({"method": "PATCH", "path": path, "payload": payload})',
-        '        return {}',
-        '    def post_json(self, path, payload):',
-        '        self.calls.append({"method": "POST", "path": path, "payload": payload})',
-        '        return {"id": "00T000000000001AAA", "success": True}',
-        'session = FakeSession()',
-        'update = module.update_opportunity(',
-        '    session,',
-        '    identifier="Acme Renewal",',
-        '    stage="Closed Won",',
-        '    probability=None,',
-        '    dry_run=False,',
-        ')',
-        'activity = module.log_activity(',
-        '    session,',
-        '    activity_type="call",',
-        '    target="006000000000001AAA",',
-        '    target_object="opportunity",',
-        '    subject="Discovery follow-up",',
-        '    activity_date="today",',
-        '    notes="Spoke with the champion.",',
-        '    duration_minutes=30,',
-        '    dry_run=False,',
-        ')',
-        'print(json.dumps({"update": update, "activity": activity, "calls": session.calls}))',
-      ].join('\n'),
-      helperPath,
-    ],
-    { encoding: 'utf-8' },
-  );
+  const result = runAssertion('write-payloads');
 
   expect(result.status).toBe(0);
   const payload = JSON.parse(result.stdout);
@@ -356,38 +184,27 @@ test('salesforce helper builds gateway-backed opportunity update and activity wr
       path: '/services/data/v61.0/sobjects/Task',
     }),
   ]);
+  expect(payload.queryCount).toBe(2);
+});
+
+test('salesforce helper resolves fuzzy record names with one SOQL query', () => {
+  const result = runAssertion('single-query-fuzzy-resolution');
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.record).toEqual(
+    expect.objectContaining({
+      Id: '006000000000001AAA',
+      Name: 'Acme Renewal',
+    }),
+  );
+  expect(payload.queryCount).toBe(1);
+  expect(payload.query).toContain("Name = 'Acme Ren'");
+  expect(payload.query).toContain("Name LIKE '%Acme Ren%'");
 });
 
 test('salesforce helper routes all requests through gateway proxy', () => {
-  const result = spawnSync(
-    'python3',
-    [
-      '-c',
-      [
-        'import importlib.util, json, pathlib, sys',
-        'helper_path = pathlib.Path(sys.argv[1])',
-        'spec = importlib.util.spec_from_file_location("salesforce_query", helper_path)',
-        'module = importlib.util.module_from_spec(spec)',
-        'sys.modules[spec.name] = module',
-        'spec.loader.exec_module(module)',
-        '# Verify gateway_request exists and is the HTTP layer',
-        'assert callable(module.gateway_request)',
-        '# Verify no direct urllib request_json function exists',
-        'assert not hasattr(module, "request_json")',
-        '# Verify no secret resolution functions exist',
-        'assert not hasattr(module, "read_stored_secret")',
-        'assert not hasattr(module, "resolve_secret_input")',
-        'assert not hasattr(module, "normalize_stored_secret_output")',
-        '# Verify no AuthConfig (secrets are never loaded into the script)',
-        'assert not hasattr(module, "AuthConfig")',
-        '# Verify no store_secret function (token captured gateway-side)',
-        'assert not hasattr(module, "store_secret")',
-        'print(json.dumps({"ok": True}))',
-      ].join('\n'),
-      helperPath,
-    ],
-    { encoding: 'utf-8' },
-  );
+  const result = runAssertion('route-check');
 
   expect(result.status).toBe(0);
   const payload = JSON.parse(result.stdout.trim());
@@ -395,31 +212,7 @@ test('salesforce helper routes all requests through gateway proxy', () => {
 });
 
 test('salesforce helper never touches secrets directly', () => {
-  const result = spawnSync(
-    'python3',
-    [
-      '-c',
-      [
-        'import pathlib, sys',
-        'content = pathlib.Path(sys.argv[1]).read_text()',
-        'assert "secret show" not in content, (',
-        '    "Script must not read secrets via CLI"',
-        ')',
-        'assert "secret set" not in content, (',
-        '    "Script must not write secrets via CLI — use captureResponseSecrets"',
-        ')',
-        'assert "subprocess" not in content, (',
-        '    "Script must not shell out to manage secrets"',
-        ')',
-        'assert "captureResponseSecrets" not in content, (',
-        '    "Script must not reference captureResponseSecrets directly"',
-        ')',
-        'print("ok")',
-      ].join('\n'),
-      helperPath,
-    ],
-    { encoding: 'utf-8' },
-  );
+  const result = runAssertion('secret-scan');
 
   expect(result.status).toBe(0);
   expect(result.stdout.trim()).toBe('ok');

--- a/tests/salesforce-skill.test.ts
+++ b/tests/salesforce-skill.test.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 
 import { expect, test } from 'vitest';
@@ -10,6 +11,13 @@ const helperPath = path.join(
   'scripts',
   'salesforce_query.py',
 );
+const scenariosPath = path.join(
+  process.cwd(),
+  'skills',
+  'salesforce',
+  'evals',
+  'scenarios.json',
+);
 
 test('salesforce helper --help exits cleanly', () => {
   const result = spawnSync('python3', [helperPath, '--help'], {
@@ -17,11 +25,172 @@ test('salesforce helper --help exits cleanly', () => {
   });
 
   expect(result.status).toBe(0);
-  expect(result.stdout).toContain(
-    'Read-only Salesforce schema and query helper',
-  );
+  expect(result.stdout).toContain('Salesforce CRM schema');
   expect(result.stdout).toContain('--gateway-url');
   expect(result.stdout).toContain('--gateway-token');
+  expect(result.stdout).toContain('update-opportunity');
+  expect(result.stdout).toContain('log-activity');
+  expect(result.stdout).toContain('eval-scenarios');
+});
+
+test('salesforce helper plans compound natural-language workflows offline', () => {
+  const result = spawnSync(
+    'python3',
+    [
+      helperPath,
+      '--format',
+      'json',
+      'plan',
+      'Move the Acme deal to Closed Won and log a call from today',
+    ],
+    { encoding: 'utf-8' },
+  );
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.command).toBe('plan');
+  expect(payload.costMeasurement.system).toBe('UsageTotals');
+  expect(payload.actions).toEqual([
+    expect.objectContaining({
+      action: 'update-opportunity',
+      opportunity: 'Acme',
+      stage: 'Closed Won',
+      probability: 100,
+    }),
+    expect.objectContaining({
+      action: 'log-activity',
+      activityType: 'call',
+      target: 'Acme',
+      targetObject: 'Opportunity',
+      date: 'today',
+    }),
+  ]);
+});
+
+test('salesforce helper eval suite covers 30 read and write scenarios', () => {
+  const scenarios = JSON.parse(
+    fs.readFileSync(scenariosPath, 'utf-8'),
+  ) as Array<{
+    category?: string;
+    costMeasurement?: { system?: string };
+  }>;
+  const categories = new Set(scenarios.map((scenario) => scenario.category));
+
+  expect(scenarios).toHaveLength(30);
+  expect(categories).toEqual(
+    new Set(['read', 'write-update', 'write-activity', 'compound']),
+  );
+  expect(
+    scenarios.every(
+      (scenario) => scenario.costMeasurement?.system === 'UsageTotals',
+    ),
+  ).toBe(true);
+
+  const result = spawnSync(
+    'python3',
+    [helperPath, '--format', 'json', 'eval-scenarios'],
+    { encoding: 'utf-8' },
+  );
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.scenarioCount).toBe(30);
+  expect(payload.failed).toBe(0);
+  expect(payload.categories).toMatchObject({
+    read: 10,
+    'write-update': 10,
+    'write-activity': 5,
+    compound: 5,
+  });
+});
+
+test('salesforce helper builds gateway-backed opportunity update and activity writes', () => {
+  const result = spawnSync(
+    'python3',
+    [
+      '-c',
+      [
+        'import importlib.util, json, pathlib, sys',
+        'helper_path = pathlib.Path(sys.argv[1])',
+        'spec = importlib.util.spec_from_file_location("salesforce_query", helper_path)',
+        'module = importlib.util.module_from_spec(spec)',
+        'sys.modules[spec.name] = module',
+        'spec.loader.exec_module(module)',
+        'class FakeSession:',
+        '    api_version = "61.0"',
+        '    def __init__(self):',
+        '        self.calls = []',
+        '    def data_path(self, suffix):',
+        '        return "/services/data/v61.0" + suffix',
+        '    def get_json(self, path):',
+        '        assert path.startswith("/services/data/v61.0/query?")',
+        '        return {',
+        '            "totalSize": 1,',
+        '            "done": True,',
+        '            "records": [{',
+        '                "Id": "006000000000001AAA",',
+        '                "Name": "Acme Renewal",',
+        '                "StageName": "Proposal/Price Quote",',
+        '                "Probability": 60,',
+        '            }],',
+        '        }',
+        '    def patch_json(self, path, payload):',
+        '        self.calls.append({"method": "PATCH", "path": path, "payload": payload})',
+        '        return {}',
+        '    def post_json(self, path, payload):',
+        '        self.calls.append({"method": "POST", "path": path, "payload": payload})',
+        '        return {"id": "00T000000000001AAA", "success": True}',
+        'session = FakeSession()',
+        'update = module.update_opportunity(',
+        '    session,',
+        '    identifier="Acme Renewal",',
+        '    stage="Closed Won",',
+        '    probability=None,',
+        '    dry_run=False,',
+        ')',
+        'activity = module.log_activity(',
+        '    session,',
+        '    activity_type="call",',
+        '    target="006000000000001AAA",',
+        '    target_object="opportunity",',
+        '    subject="Discovery follow-up",',
+        '    activity_date="today",',
+        '    notes="Spoke with the champion.",',
+        '    duration_minutes=30,',
+        '    dry_run=False,',
+        ')',
+        'print(json.dumps({"update": update, "activity": activity, "calls": session.calls}))',
+      ].join('\n'),
+      helperPath,
+    ],
+    { encoding: 'utf-8' },
+  );
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.update.update).toEqual({
+    StageName: 'Closed Won',
+    Probability: 100,
+  });
+  expect(payload.activity.activityObject).toBe('Task');
+  expect(payload.activity.fields).toEqual(
+    expect.objectContaining({
+      Subject: 'Call: Discovery follow-up',
+      Status: 'Completed',
+      Priority: 'Normal',
+      WhatId: '006000000000001AAA',
+    }),
+  );
+  expect(payload.calls).toEqual([
+    expect.objectContaining({
+      method: 'PATCH',
+      path: '/services/data/v61.0/sobjects/Opportunity/006000000000001AAA',
+    }),
+    expect.objectContaining({
+      method: 'POST',
+      path: '/services/data/v61.0/sobjects/Task',
+    }),
+  ]);
 });
 
 test('salesforce helper routes all requests through gateway proxy', () => {


### PR DESCRIPTION
## Summary
- expands the Salesforce bundled skill from read-only inspection into CRM reads, Opportunity stage/probability updates, and Task/Event activity logging
- adds deterministic natural-language planning/execution for workflows like "Move the Acme deal to Closed Won and log a call from today"
- adds a 30-scenario offline eval fixture covering read, write-update, write-activity, and compound paths
- updates gateway OAuth token binding so captured Salesforce tokens bind to the returned `instance_url` host while remaining blocked from unrelated hosts

## Acceptance Criteria
- OAuth token capture and storage stay gateway-side via `<secret:...>` placeholders, `captureResponseFields`, and `bearerSecretName`; tokens are not returned to the helper/model
- lead/contact/opportunity read paths are available through `find`
- Opportunity `StageName` and `Probability` writes are available through `update-opportunity` and NL `run`
- call/email/meeting logging creates `Task` or `Event` records on the resolved CRM target
- cost-per-run accounting is documented and emitted as `UsageTotals` metadata in helper/eval payloads

Closes #580.

## Validation
- `npm run format`
- `python3 skills/skill-creator/scripts/quick_validate.py skills/salesforce`
- `python3 skills/salesforce/scripts/salesforce_query.py --format json eval-scenarios`
- `python3 -c "import pathlib; p=pathlib.Path('skills/salesforce/scripts/salesforce_query.py'); compile(p.read_text(), str(p), 'exec')"`
- `/Users/bkoehler/src/hybridclaw/node_modules/.bin/vitest tests/salesforce-skill.test.ts`
- `/Users/bkoehler/src/hybridclaw/node_modules/.bin/vitest tests/gateway-http-server.test.ts -t "binds captured OAuth bearer tokens to response instance_url host"`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --check`

Note: the focused gateway test passes but logs an existing shared `better-sqlite3` Node ABI warning during mocked runtime-config startup.
