### PR TITLE
[Foundation F6.3] Tunnel health check + auto-reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+
+- **Tunnel health checks**: The built-in ngrok tunnel provider health-checks
+  active tunnels on a configurable interval, records tunnel up/down audit
+  events, and reconnects failed tunnels with capped exponential backoff.
+
 ## [0.14.0](https://github.com/HybridAIOne/hybridclaw/tree/v0.14.0) - 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -138,8 +138,9 @@ Once the gateway is running, open HybridClaw locally:
 - `proactive.delegation.model` can pin delegated work to a different model
   from the parent turn; `/status` shows delegate token totals and local-token
   share when that split is configured.
-- `deployment.mode`, `deployment.public_url`, and `deployment.tunnel.provider`
-  describe local/cloud exposure. The built-in ngrok tunnel provider reads
+- `deployment.mode`, `deployment.public_url`, `deployment.tunnel.provider`, and
+  `deployment.tunnel.health_check_interval_ms` describe local/cloud exposure
+  and tunnel health cadence. The built-in ngrok tunnel provider reads
   `NGROK_AUTHTOKEN` from the encrypted runtime secret store.
 - `container.persistBashState` controls whether bash tool calls share shell
   state (`cd`, exported env vars, aliases) across turns in the same active

--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,5 @@
 {
-  "version": 23,
+  "version": 24,
   "security": {
     "trustModelAccepted": false,
     "trustModelAcceptedAt": "",
@@ -10,7 +10,8 @@
     "mode": "local",
     "public_url": "",
     "tunnel": {
-      "provider": "manual"
+      "provider": "manual",
+      "health_check_interval_ms": 30000
     }
   },
   "skills": {

--- a/docs/content/guides/remote-access.md
+++ b/docs/content/guides/remote-access.md
@@ -122,6 +122,7 @@ Runtime config can record the intended exposure mode and tunnel provider:
 ```bash
 hybridclaw config set deployment.mode local
 hybridclaw config set deployment.tunnel.provider ngrok
+hybridclaw config set deployment.tunnel.health_check_interval_ms 30000
 hybridclaw secret set NGROK_AUTHTOKEN "replace-with-your-ngrok-token"
 ```
 
@@ -129,7 +130,8 @@ The deployment keys make local, cloud, and tunnel-backed setups explicit in
 operator state. Manual SSH and Tailscale setups can use `manual`, `ssh`, or
 `tailscale` as the provider value. The built-in ngrok provider reads
 `NGROK_AUTHTOKEN` from encrypted runtime secrets when it is used by a gateway
-deployment flow.
+deployment flow, checks active tunnels every 30 seconds by default, and
+reconnects failed tunnels with capped backoff.
 
 ## macOS: Persistent SSH Tunnel Via LaunchAgent
 

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -178,16 +178,9 @@ saved revision history directly.
   the auth token can stay empty in config when you store `TWILIO_AUTH_TOKEN`
   in the encrypted runtime secret store or use a SecretRef-backed
   `voice.twilio.authToken`
-- `deployment.mode`, `deployment.public_url`, `deployment.tunnel.provider`, and
-  `deployment.tunnel.health_check_interval_ms` for declaring whether the
-  gateway runs behind a cloud URL or a local tunnel; cloud mode requires
-  `deployment.public_url`, while local mode requires a tunnel provider such as
-  `manual`, `ssh`, `ngrok`, `cloudflare`, or `tailscale`. The built-in ngrok
-  tunnel provider reads `NGROK_AUTHTOKEN` from the encrypted runtime secret
-  store and health-checks active tunnels every 30 seconds by default. Tunnel
-  health checks call the public tunnel URL, so they consume provider request
-  quota and generate traffic visible to the tunnel provider edge; increase the
-  interval when that cost matters
+- `deployment.mode`, `deployment.public_url`, `deployment.tunnel.provider`, and `deployment.tunnel.health_check_interval_ms` declare whether the gateway runs behind a cloud URL or a local tunnel; cloud mode requires `deployment.public_url`, while local mode requires a tunnel provider such as `manual`, `ssh`, `ngrok`, `cloudflare`, or `tailscale`
+- The built-in ngrok tunnel provider reads `NGROK_AUTHTOKEN` from the encrypted runtime secret store and health-checks active tunnels every 30 seconds by default
+- Tunnel health checks call the public tunnel URL, so they consume provider request quota and generate traffic visible to the tunnel provider edge; increase the interval when that cost matters
 - `HYBRIDCLAW_CONFIDENTIAL_DISABLE=1` disables confidential-info redaction for
   local debugging. Leave it unset in normal operation so `.confidential.yml`
   rules can redact NDA-class matches before prompts are sent to models

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -176,12 +176,13 @@ saved revision history directly.
   the auth token can stay empty in config when you store `TWILIO_AUTH_TOKEN`
   in the encrypted runtime secret store or use a SecretRef-backed
   `voice.twilio.authToken`
-- `deployment.mode`, `deployment.public_url`, and `deployment.tunnel.provider`
-  for declaring whether the gateway runs behind a cloud URL or a local tunnel;
-  cloud mode requires `deployment.public_url`, while local mode requires a
-  tunnel provider such as `manual`, `ssh`, `ngrok`, `cloudflare`, or
-  `tailscale`. The built-in ngrok tunnel provider reads `NGROK_AUTHTOKEN` from
-  the encrypted runtime secret store
+- `deployment.mode`, `deployment.public_url`, `deployment.tunnel.provider`, and
+  `deployment.tunnel.health_check_interval_ms` for declaring whether the
+  gateway runs behind a cloud URL or a local tunnel; cloud mode requires
+  `deployment.public_url`, while local mode requires a tunnel provider such as
+  `manual`, `ssh`, `ngrok`, `cloudflare`, or `tailscale`. The built-in ngrok
+  tunnel provider reads `NGROK_AUTHTOKEN` from the encrypted runtime secret
+  store and health-checks active tunnels every 30 seconds by default
 - `HYBRIDCLAW_CONFIDENTIAL_DISABLE=1` disables confidential-info redaction for
   local debugging. Leave it unset in normal operation so `.confidential.yml`
   rules can redact NDA-class matches before prompts are sent to models

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -184,7 +184,10 @@ saved revision history directly.
   `deployment.public_url`, while local mode requires a tunnel provider such as
   `manual`, `ssh`, `ngrok`, `cloudflare`, or `tailscale`. The built-in ngrok
   tunnel provider reads `NGROK_AUTHTOKEN` from the encrypted runtime secret
-  store and health-checks active tunnels every 30 seconds by default
+  store and health-checks active tunnels every 30 seconds by default. Tunnel
+  health checks call the public tunnel URL, so they consume provider request
+  quota and generate traffic visible to the tunnel provider edge; increase the
+  interval when that cost matters
 - `HYBRIDCLAW_CONFIDENTIAL_DISABLE=1` disables confidential-info redaction for
   local debugging. Leave it unset in normal operation so `.confidential.yml`
   rules can redact NDA-class matches before prompts are sent to models

--- a/docs/development/guides/remote-access.md
+++ b/docs/development/guides/remote-access.md
@@ -122,6 +122,7 @@ Runtime config can record the intended exposure mode and tunnel provider:
 ```bash
 hybridclaw config set deployment.mode local
 hybridclaw config set deployment.tunnel.provider ngrok
+hybridclaw config set deployment.tunnel.health_check_interval_ms 30000
 hybridclaw secret set NGROK_AUTHTOKEN "replace-with-your-ngrok-token"
 ```
 
@@ -129,7 +130,8 @@ The deployment keys make local, cloud, and tunnel-backed setups explicit in
 operator state. Manual SSH and Tailscale setups can use `manual`, `ssh`, or
 `tailscale` as the provider value. The built-in ngrok provider reads
 `NGROK_AUTHTOKEN` from encrypted runtime secrets when it is used by a gateway
-deployment flow.
+deployment flow, checks active tunnels every 30 seconds by default, and
+reconnects failed tunnels with capped backoff.
 
 ## macOS: Persistent SSH Tunnel Via LaunchAgent
 

--- a/docs/development/reference/configuration.md
+++ b/docs/development/reference/configuration.md
@@ -144,16 +144,9 @@ leak into the saved revision metadata.
   the auth token can stay empty in config when you store `TWILIO_AUTH_TOKEN`
   in the encrypted runtime secret store or use a SecretRef-backed
   `voice.twilio.authToken`
-- `deployment.mode`, `deployment.public_url`, `deployment.tunnel.provider`, and
-  `deployment.tunnel.health_check_interval_ms` for declaring whether the
-  gateway runs behind a cloud URL or a local tunnel; cloud mode requires
-  `deployment.public_url`, while local mode requires a tunnel provider such as
-  `manual`, `ssh`, `ngrok`, `cloudflare`, or `tailscale`. The built-in ngrok
-  tunnel provider reads `NGROK_AUTHTOKEN` from the encrypted runtime secret
-  store and health-checks active tunnels every 30 seconds by default. Tunnel
-  health checks call the public tunnel URL, so they consume provider request
-  quota and generate traffic visible to the tunnel provider edge; increase the
-  interval when that cost matters
+- `deployment.mode`, `deployment.public_url`, `deployment.tunnel.provider`, and `deployment.tunnel.health_check_interval_ms` declare whether the gateway runs behind a cloud URL or a local tunnel; cloud mode requires `deployment.public_url`, while local mode requires a tunnel provider such as `manual`, `ssh`, `ngrok`, `cloudflare`, or `tailscale`
+- The built-in ngrok tunnel provider reads `NGROK_AUTHTOKEN` from the encrypted runtime secret store and health-checks active tunnels every 30 seconds by default
+- Tunnel health checks call the public tunnel URL, so they consume provider request quota and generate traffic visible to the tunnel provider edge; increase the interval when that cost matters
 - `HYBRIDCLAW_CONFIDENTIAL_DISABLE=1` disables confidential-info redaction for
   local debugging. Leave it unset in normal operation so `.confidential.yml`
   rules can redact NDA-class matches before prompts are sent to models

--- a/docs/development/reference/configuration.md
+++ b/docs/development/reference/configuration.md
@@ -150,7 +150,10 @@ leak into the saved revision metadata.
   `deployment.public_url`, while local mode requires a tunnel provider such as
   `manual`, `ssh`, `ngrok`, `cloudflare`, or `tailscale`. The built-in ngrok
   tunnel provider reads `NGROK_AUTHTOKEN` from the encrypted runtime secret
-  store and health-checks active tunnels every 30 seconds by default
+  store and health-checks active tunnels every 30 seconds by default. Tunnel
+  health checks call the public tunnel URL, so they consume provider request
+  quota and generate traffic visible to the tunnel provider edge; increase the
+  interval when that cost matters
 - `HYBRIDCLAW_CONFIDENTIAL_DISABLE=1` disables confidential-info redaction for
   local debugging. Leave it unset in normal operation so `.confidential.yml`
   rules can redact NDA-class matches before prompts are sent to models

--- a/docs/development/reference/configuration.md
+++ b/docs/development/reference/configuration.md
@@ -142,12 +142,13 @@ leak into the saved revision metadata.
   the auth token can stay empty in config when you store `TWILIO_AUTH_TOKEN`
   in the encrypted runtime secret store or use a SecretRef-backed
   `voice.twilio.authToken`
-- `deployment.mode`, `deployment.public_url`, and `deployment.tunnel.provider`
-  for declaring whether the gateway runs behind a cloud URL or a local tunnel;
-  cloud mode requires `deployment.public_url`, while local mode requires a
-  tunnel provider such as `manual`, `ssh`, `ngrok`, `cloudflare`, or
-  `tailscale`. The built-in ngrok tunnel provider reads `NGROK_AUTHTOKEN` from
-  the encrypted runtime secret store
+- `deployment.mode`, `deployment.public_url`, `deployment.tunnel.provider`, and
+  `deployment.tunnel.health_check_interval_ms` for declaring whether the
+  gateway runs behind a cloud URL or a local tunnel; cloud mode requires
+  `deployment.public_url`, while local mode requires a tunnel provider such as
+  `manual`, `ssh`, `ngrok`, `cloudflare`, or `tailscale`. The built-in ngrok
+  tunnel provider reads `NGROK_AUTHTOKEN` from the encrypted runtime secret
+  store and health-checks active tunnels every 30 seconds by default
 - `HYBRIDCLAW_CONFIDENTIAL_DISABLE=1` disables confidential-info redaction for
   local debugging. Leave it unset in normal operation so `.confidential.yml`
   rules can redact NDA-class matches before prompts are sent to models

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -68,6 +68,7 @@ import {
   type SessionDmScope,
 } from '../session/session-routing.js';
 import type { AdaptiveSkillsConfig } from '../skills/adaptive-skills-types.js';
+import { DEFAULT_TUNNEL_HEALTH_CHECK_INTERVAL_MS } from '../tunnel/tunnel-provider.js';
 import type { AnthropicMethod, McpServerConfig } from '../types/models.js';
 import {
   normalizeOptionalTrimmedUniqueStringArray,
@@ -102,7 +103,7 @@ import {
 import { DEFAULT_RUNTIME_HOME_DIR } from './runtime-paths.js';
 
 export const CONFIG_FILE_NAME = 'config.json';
-export const CONFIG_VERSION = 23;
+export const CONFIG_VERSION = 24;
 export const SECURITY_POLICY_VERSION = '2026-02-28';
 export const DEFAULT_HYBRIDAI_MODEL = 'gpt-5.4-mini';
 const LEGACY_DEFAULT_DB_PATH = 'data/hybridclaw.db';
@@ -254,6 +255,7 @@ export type RuntimeDeploymentTunnelProvider =
 
 export interface RuntimeDeploymentTunnelConfig {
   provider?: RuntimeDeploymentTunnelProvider;
+  health_check_interval_ms: number;
 }
 
 export interface RuntimeDeploymentConfig {
@@ -1014,6 +1016,7 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
     public_url: '',
     tunnel: {
       provider: 'manual',
+      health_check_interval_ms: DEFAULT_TUNNEL_HEALTH_CHECK_INTERVAL_MS,
     },
   },
   agents: {
@@ -1787,7 +1790,14 @@ export function normalizeDeploymentConfig(
   return {
     mode: normalizeDeploymentMode(raw.mode, fallback.mode),
     public_url: normalizeOptionalBaseUrl(raw.public_url, fallback.public_url),
-    tunnel: tunnelProvider ? { provider: tunnelProvider } : {},
+    tunnel: {
+      ...(tunnelProvider ? { provider: tunnelProvider } : {}),
+      health_check_interval_ms: normalizeInteger(
+        rawTunnel.health_check_interval_ms,
+        fallback.tunnel.health_check_interval_ms,
+        { min: 1 },
+      ),
+    },
   };
 }
 

--- a/src/tunnel/ngrok-tunnel-provider.ts
+++ b/src/tunnel/ngrok-tunnel-provider.ts
@@ -20,6 +20,7 @@ import {
 export const NGROK_AUTHTOKEN_SECRET = 'NGROK_AUTHTOKEN';
 export const DEFAULT_NGROK_TUNNEL_ADDR = 9090;
 const DEFAULT_NGROK_HEALTH_CHECK_PATH = '/health';
+const RECONNECT_JITTER_RATIO = 0.1;
 const TUNNEL_AUDIT_SESSION_ID = 'system:tunnel';
 
 interface NgrokListener {
@@ -121,6 +122,12 @@ function errorMessage(error: unknown): string {
 
 function makeTunnelAuditRunId(): string {
   return `tunnel_${randomUUID()}`;
+}
+
+function jitterReconnectDelayMs(delayMs: number): number {
+  const factor =
+    1 - RECONNECT_JITTER_RATIO + Math.random() * RECONNECT_JITTER_RATIO * 2;
+  return Math.max(1, Math.round(delayMs * factor));
 }
 
 export class NgrokTunnelProvider implements TunnelProvider {
@@ -515,10 +522,11 @@ export class NgrokTunnelProvider implements TunnelProvider {
 
   private scheduleReconnect(message: string): void {
     const attempt = this.reconnectAttempt + 1;
-    const delayMs = Math.min(
+    const baseDelayMs = Math.min(
       this.reconnectMaxBackoffMs,
       this.reconnectInitialBackoffMs * 2 ** Math.max(0, attempt - 1),
     );
+    const delayMs = jitterReconnectDelayMs(baseDelayMs);
     const nextReconnectAt = new Date(Date.now() + delayMs).toISOString();
     this.updateStatus({
       lastError: message,

--- a/src/tunnel/ngrok-tunnel-provider.ts
+++ b/src/tunnel/ngrok-tunnel-provider.ts
@@ -1,18 +1,20 @@
 import { randomUUID } from 'node:crypto';
 
 import type { Config } from '@ngrok/ngrok';
+import {
+  recordAuditEvent as defaultRecordAuditEvent,
+  type RecordAuditEventInput,
+} from '../audit/audit-events.js';
 import { readStoredRuntimeSecret } from '../security/runtime-secrets.js';
-import type {
-  TunnelProvider,
-  TunnelStartResult,
-  TunnelState,
-  TunnelStatus,
-} from './tunnel-provider.js';
 import {
   DEFAULT_TUNNEL_HEALTH_CHECK_INTERVAL_MS as DEFAULT_HEALTH_INTERVAL_MS,
   DEFAULT_TUNNEL_HEALTH_CHECK_TIMEOUT_MS as DEFAULT_HEALTH_TIMEOUT_MS,
   DEFAULT_TUNNEL_RECONNECT_INITIAL_BACKOFF_MS as DEFAULT_RECONNECT_INITIAL_BACKOFF_MS,
   DEFAULT_TUNNEL_RECONNECT_MAX_BACKOFF_MS as DEFAULT_RECONNECT_MAX_BACKOFF_MS,
+  type TunnelProvider,
+  type TunnelStartResult,
+  type TunnelState,
+  type TunnelStatus,
 } from './tunnel-provider.js';
 
 export const NGROK_AUTHTOKEN_SECRET = 'NGROK_AUTHTOKEN';
@@ -34,15 +36,9 @@ type TunnelHealthFetch = (
   input: string | URL,
   init?: { method?: string; signal?: AbortSignal },
 ) => Promise<Pick<Response, 'ok' | 'status'>>;
-interface TunnelAuditRecord {
-  sessionId: string;
-  runId: string;
-  event: {
-    type: string;
-    [key: string]: unknown;
-  };
-}
-type TunnelAuditRecorder = (input: TunnelAuditRecord) => void | Promise<void>;
+type TunnelAuditRecorder = (
+  input: RecordAuditEventInput,
+) => void | Promise<void>;
 
 export interface NgrokTunnelProviderOptions {
   addr?: Config['addr'];
@@ -109,14 +105,7 @@ function normalizeHealthCheckPath(value: unknown): string {
 }
 
 function unrefTimer(timer: TunnelTimer): void {
-  if (
-    typeof timer === 'object' &&
-    timer &&
-    'unref' in timer &&
-    typeof timer.unref === 'function'
-  ) {
-    timer.unref();
-  }
+  timer.unref();
 }
 
 function errorMessage(error: unknown): string {
@@ -124,14 +113,7 @@ function errorMessage(error: unknown): string {
 }
 
 function makeTunnelAuditRunId(): string {
-  return `tunnel_${Date.now()}_${randomUUID().slice(0, 8)}`;
-}
-
-async function recordDefaultTunnelAudit(
-  input: TunnelAuditRecord,
-): Promise<void> {
-  const { recordAuditEvent } = await import('../audit/audit-events.js');
-  recordAuditEvent(input);
+  return `tunnel_${randomUUID()}`;
 }
 
 export class NgrokTunnelProvider implements TunnelProvider {
@@ -161,6 +143,7 @@ export class NgrokTunnelProvider implements TunnelProvider {
   private reconnectAttempt = 0;
   private reconnectTimer: TunnelTimer | null = null;
   private state: TunnelState = 'down';
+  private statusVersion = 0;
 
   constructor(options: NgrokTunnelProviderOptions = {}) {
     this.addr = options.addr ?? DEFAULT_NGROK_TUNNEL_ADDR;
@@ -193,7 +176,7 @@ export class NgrokTunnelProvider implements TunnelProvider {
     this.recordAuditEvent =
       options.recordAuditEvent === false
         ? null
-        : (options.recordAuditEvent ?? recordDefaultTunnelAudit);
+        : (options.recordAuditEvent ?? defaultRecordAuditEvent);
     this.schemes = options.schemes;
     this.tokenSecretName =
       options.tokenSecretName?.trim() || NGROK_AUTHTOKEN_SECRET;
@@ -318,25 +301,46 @@ export class NgrokTunnelProvider implements TunnelProvider {
     reconnectAttempt?: number;
     state?: TunnelState;
   }): void {
-    const before = JSON.stringify(this.status());
+    const previousVersion = this.statusVersion;
+    let changed = false;
     if ('lastCheckedAt' in update) {
-      this.lastCheckedAt = update.lastCheckedAt ?? null;
+      const next = update.lastCheckedAt ?? null;
+      if (this.lastCheckedAt !== next) {
+        this.lastCheckedAt = next;
+        changed = true;
+      }
     }
     if ('lastError' in update) {
-      this.lastError = update.lastError ?? null;
+      const next = update.lastError ?? null;
+      if (this.lastError !== next) {
+        this.lastError = next;
+        changed = true;
+      }
     }
     if ('nextReconnectAt' in update) {
-      this.nextReconnectAt = update.nextReconnectAt ?? null;
+      const next = update.nextReconnectAt ?? null;
+      if (this.nextReconnectAt !== next) {
+        this.nextReconnectAt = next;
+        changed = true;
+      }
     }
     if ('reconnectAttempt' in update) {
-      this.reconnectAttempt = Math.max(0, update.reconnectAttempt ?? 0);
+      const next = Math.max(0, update.reconnectAttempt ?? 0);
+      if (this.reconnectAttempt !== next) {
+        this.reconnectAttempt = next;
+        changed = true;
+      }
     }
-    if (update.state) {
+    if (update.state && this.state !== update.state) {
       this.state = update.state;
+      changed = true;
     }
 
-    const after = JSON.stringify(this.status());
-    if (before !== after) {
+    if (changed) {
+      this.statusVersion += 1;
+    }
+
+    if (this.statusVersion !== previousVersion) {
       this.publishStatusChange();
     }
   }

--- a/src/tunnel/ngrok-tunnel-provider.ts
+++ b/src/tunnel/ngrok-tunnel-provider.ts
@@ -158,6 +158,7 @@ export class NgrokTunnelProvider implements TunnelProvider {
   private reconnectTimer: TunnelTimer | null = null;
   private state: TunnelState = 'down';
   private statusVersion = 0;
+  private tunnelRunId: string | null = null;
 
   constructor(options: NgrokTunnelProviderOptions = {}) {
     this.addr = options.addr ?? DEFAULT_NGROK_TUNNEL_ADDR;
@@ -281,7 +282,7 @@ export class NgrokTunnelProvider implements TunnelProvider {
   async stop(): Promise<void> {
     this.clearTimer('healthTimer');
     this.clearTimer('reconnectTimer');
-    const { listener, publicUrl } = this.clearActiveTunnel({
+    const { listener, publicUrl, tunnelRunId } = this.clearActiveTunnel({
       lastCheckedAt: null,
       lastError: null,
       nextReconnectAt: null,
@@ -292,6 +293,7 @@ export class NgrokTunnelProvider implements TunnelProvider {
       await this.recordTunnelAudit('tunnel.down', {
         publicUrl,
         reason: 'stopped',
+        runId: tunnelRunId,
       });
     }
     if (listener) {
@@ -374,8 +376,10 @@ export class NgrokTunnelProvider implements TunnelProvider {
     reason: string,
   ): Promise<void> {
     const wasRunning = Boolean(this.listener && this.publicUrl);
+    const tunnelRunId = this.tunnelRunId ?? makeTunnelAuditRunId();
     this.listener = listener;
     this.publicUrl = publicUrl;
+    this.tunnelRunId = tunnelRunId;
     this.updateStatus({
       lastError: null,
       nextReconnectAt: null,
@@ -383,7 +387,11 @@ export class NgrokTunnelProvider implements TunnelProvider {
       state: 'up',
     });
     if (!wasRunning) {
-      await this.recordTunnelAudit('tunnel.up', { publicUrl, reason });
+      await this.recordTunnelAudit('tunnel.up', {
+        publicUrl,
+        reason,
+        runId: tunnelRunId,
+      });
     }
   }
 
@@ -393,7 +401,7 @@ export class NgrokTunnelProvider implements TunnelProvider {
     publicUrl: string;
     reason: string;
   }): Promise<void> {
-    this.clearActiveTunnel({
+    const { tunnelRunId } = this.clearActiveTunnel({
       lastCheckedAt: params.lastCheckedAt ?? null,
       lastError: params.message,
       state: 'reconnecting',
@@ -402,6 +410,7 @@ export class NgrokTunnelProvider implements TunnelProvider {
       error: params.message,
       publicUrl: params.publicUrl,
       reason: params.reason,
+      runId: tunnelRunId,
     });
   }
 
@@ -411,12 +420,13 @@ export class NgrokTunnelProvider implements TunnelProvider {
       error?: string;
       publicUrl?: string;
       reason: string;
+      runId?: string | null;
     },
   ): Promise<void> {
     try {
       await this.recordAuditEvent({
         sessionId: this.auditSessionId,
-        runId: makeTunnelAuditRunId(),
+        runId: details.runId ?? makeTunnelAuditRunId(),
         event: {
           type,
           provider: 'ngrok',
@@ -436,13 +446,16 @@ export class NgrokTunnelProvider implements TunnelProvider {
   private clearActiveTunnel(update: TunnelStatusUpdate): {
     listener: NgrokListener | null;
     publicUrl: string | null;
+    tunnelRunId: string | null;
   } {
     const listener = this.listener;
     const publicUrl = this.publicUrl;
+    const tunnelRunId = this.tunnelRunId;
     this.listener = null;
     this.publicUrl = null;
+    this.tunnelRunId = null;
     this.updateStatus(update);
-    return { listener, publicUrl };
+    return { listener, publicUrl, tunnelRunId };
   }
 
   private clearTimer(name: 'healthTimer' | 'reconnectTimer'): void {

--- a/src/tunnel/ngrok-tunnel-provider.ts
+++ b/src/tunnel/ngrok-tunnel-provider.ts
@@ -39,6 +39,13 @@ type TunnelHealthFetch = (
 type TunnelAuditRecorder = (
   input: RecordAuditEventInput,
 ) => void | Promise<void>;
+type TunnelStatusUpdate = {
+  lastCheckedAt?: string | null;
+  lastError?: string | null;
+  nextReconnectAt?: string | null;
+  reconnectAttempt?: number;
+  state?: TunnelState;
+};
 
 export interface NgrokTunnelProviderOptions {
   addr?: Config['addr'];
@@ -188,8 +195,8 @@ export class NgrokTunnelProvider implements TunnelProvider {
       return { public_url: this.publicUrl };
     }
 
-    this.clearHealthTimer();
-    this.clearReconnectTimer();
+    this.clearTimer('healthTimer');
+    this.clearTimer('reconnectTimer');
     this.updateStatus({
       lastCheckedAt: null,
       lastError: null,
@@ -204,9 +211,7 @@ export class NgrokTunnelProvider implements TunnelProvider {
       this.scheduleHealthCheck();
       return { public_url: publicUrl };
     } catch (error) {
-      this.listener = null;
-      this.publicUrl = null;
-      this.updateStatus({
+      this.clearActiveTunnel({
         lastError: errorMessage(error),
         nextReconnectAt: null,
         reconnectAttempt: 0,
@@ -258,13 +263,9 @@ export class NgrokTunnelProvider implements TunnelProvider {
   }
 
   async stop(): Promise<void> {
-    this.clearHealthTimer();
-    this.clearReconnectTimer();
-    const listener = this.listener;
-    const publicUrl = this.publicUrl;
-    this.listener = null;
-    this.publicUrl = null;
-    this.updateStatus({
+    this.clearTimer('healthTimer');
+    this.clearTimer('reconnectTimer');
+    const { listener, publicUrl } = this.clearActiveTunnel({
       lastCheckedAt: null,
       lastError: null,
       nextReconnectAt: null,
@@ -294,13 +295,7 @@ export class NgrokTunnelProvider implements TunnelProvider {
     };
   }
 
-  private updateStatus(update: {
-    lastCheckedAt?: string | null;
-    lastError?: string | null;
-    nextReconnectAt?: string | null;
-    reconnectAttempt?: number;
-    state?: TunnelState;
-  }): void {
+  private updateStatus(update: TunnelStatusUpdate): void {
     const previousVersion = this.statusVersion;
     let changed = false;
     if ('lastCheckedAt' in update) {
@@ -352,7 +347,7 @@ export class NgrokTunnelProvider implements TunnelProvider {
     } catch (error) {
       console.warn(
         '[tunnel] status change handler failed.',
-        error instanceof Error ? error.message : String(error),
+        errorMessage(error),
       );
     }
   }
@@ -382,9 +377,7 @@ export class NgrokTunnelProvider implements TunnelProvider {
     publicUrl: string;
     reason: string;
   }): Promise<void> {
-    this.listener = null;
-    this.publicUrl = null;
-    this.updateStatus({
+    this.clearActiveTunnel({
       lastCheckedAt: params.lastCheckedAt ?? null,
       lastError: params.message,
       state: 'reconnecting',
@@ -420,25 +413,32 @@ export class NgrokTunnelProvider implements TunnelProvider {
     } catch (error) {
       console.warn(
         '[tunnel] failed to record tunnel audit event.',
-        error instanceof Error ? error.message : String(error),
+        errorMessage(error),
       );
     }
   }
 
-  private clearHealthTimer(): void {
-    if (!this.healthTimer) return;
-    clearTimeout(this.healthTimer);
-    this.healthTimer = null;
+  private clearActiveTunnel(update: TunnelStatusUpdate): {
+    listener: NgrokListener | null;
+    publicUrl: string | null;
+  } {
+    const listener = this.listener;
+    const publicUrl = this.publicUrl;
+    this.listener = null;
+    this.publicUrl = null;
+    this.updateStatus(update);
+    return { listener, publicUrl };
   }
 
-  private clearReconnectTimer(): void {
-    if (!this.reconnectTimer) return;
-    clearTimeout(this.reconnectTimer);
-    this.reconnectTimer = null;
+  private clearTimer(name: 'healthTimer' | 'reconnectTimer'): void {
+    const timer = this[name];
+    if (!timer) return;
+    clearTimeout(timer);
+    this[name] = null;
   }
 
   private scheduleHealthCheck(): void {
-    this.clearHealthTimer();
+    this.clearTimer('healthTimer');
     if (!this.listener || !this.publicUrl) return;
     this.healthTimer = setTimeout(() => {
       this.healthTimer = null;
@@ -518,7 +518,7 @@ export class NgrokTunnelProvider implements TunnelProvider {
       reconnectAttempt: attempt,
       state: 'reconnecting',
     });
-    this.clearReconnectTimer();
+    this.clearTimer('reconnectTimer');
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
       void this.reconnect();

--- a/src/tunnel/ngrok-tunnel-provider.ts
+++ b/src/tunnel/ngrok-tunnel-provider.ts
@@ -180,6 +180,11 @@ export class NgrokTunnelProvider implements TunnelProvider {
       options.reconnectMaxBackoffMs,
       DEFAULT_RECONNECT_MAX_BACKOFF_MS,
     );
+    if (this.reconnectInitialBackoffMs > this.reconnectMaxBackoffMs) {
+      throw new Error(
+        `reconnectInitialBackoffMs (${this.reconnectInitialBackoffMs}) must be less than or equal to reconnectMaxBackoffMs (${this.reconnectMaxBackoffMs}).`,
+      );
+    }
     this.recordAuditEvent =
       options.recordAuditEvent === false
         ? null
@@ -195,6 +200,8 @@ export class NgrokTunnelProvider implements TunnelProvider {
       return { public_url: this.publicUrl };
     }
 
+    const startReason =
+      this.state === 'reconnecting' ? 'manual_reconnect' : 'started';
     this.clearTimer('healthTimer');
     this.clearTimer('reconnectTimer');
     this.updateStatus({
@@ -207,15 +214,20 @@ export class NgrokTunnelProvider implements TunnelProvider {
 
     try {
       const { listener, publicUrl } = await this.openTunnel();
-      await this.markTunnelUp(listener, publicUrl, 'started');
+      await this.markTunnelUp(listener, publicUrl, startReason);
       this.scheduleHealthCheck();
       return { public_url: publicUrl };
     } catch (error) {
+      const message = errorMessage(error);
       this.clearActiveTunnel({
-        lastError: errorMessage(error),
+        lastError: message,
         nextReconnectAt: null,
         reconnectAttempt: 0,
         state: 'down',
+      });
+      await this.recordTunnelAudit('tunnel.start_failed', {
+        error: message,
+        reason: startReason,
       });
       throw error;
     }
@@ -390,10 +402,10 @@ export class NgrokTunnelProvider implements TunnelProvider {
   }
 
   private async recordTunnelAudit(
-    type: 'tunnel.up' | 'tunnel.down',
+    type: 'tunnel.up' | 'tunnel.down' | 'tunnel.start_failed',
     details: {
       error?: string;
-      publicUrl: string;
+      publicUrl?: string;
       reason: string;
     },
   ): Promise<void> {
@@ -405,8 +417,8 @@ export class NgrokTunnelProvider implements TunnelProvider {
         event: {
           type,
           provider: 'ngrok',
-          public_url: details.publicUrl,
           reason: details.reason,
+          ...(details.publicUrl ? { public_url: details.publicUrl } : {}),
           ...(details.error ? { error: details.error } : {}),
         },
       });

--- a/src/tunnel/ngrok-tunnel-provider.ts
+++ b/src/tunnel/ngrok-tunnel-provider.ts
@@ -1,8 +1,7 @@
-import { randomUUID } from 'node:crypto';
-
 import type { Config } from '@ngrok/ngrok';
 import {
   recordAuditEvent as defaultRecordAuditEvent,
+  makeAuditRunId,
   type RecordAuditEventInput,
 } from '../audit/audit-events.js';
 import { readStoredRuntimeSecret } from '../security/runtime-secrets.js';
@@ -118,10 +117,6 @@ function unrefTimer(timer: TunnelTimer): void {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
-}
-
-function makeTunnelAuditRunId(): string {
-  return `tunnel_${randomUUID()}`;
 }
 
 function jitterReconnectDelayMs(delayMs: number): number {
@@ -376,7 +371,7 @@ export class NgrokTunnelProvider implements TunnelProvider {
     reason: string,
   ): Promise<void> {
     const wasRunning = Boolean(this.listener && this.publicUrl);
-    const tunnelRunId = this.tunnelRunId ?? makeTunnelAuditRunId();
+    const tunnelRunId = this.tunnelRunId ?? makeAuditRunId('tunnel');
     this.listener = listener;
     this.publicUrl = publicUrl;
     this.tunnelRunId = tunnelRunId;
@@ -426,7 +421,7 @@ export class NgrokTunnelProvider implements TunnelProvider {
     try {
       await this.recordAuditEvent({
         sessionId: this.auditSessionId,
-        runId: details.runId ?? makeTunnelAuditRunId(),
+        runId: details.runId ?? makeAuditRunId('tunnel'),
         event: {
           type,
           provider: 'ngrok',

--- a/src/tunnel/ngrok-tunnel-provider.ts
+++ b/src/tunnel/ngrok-tunnel-provider.ts
@@ -61,7 +61,7 @@ export interface NgrokTunnelProviderOptions {
   readSecret?: (secretName: string) => string | null;
   reconnectInitialBackoffMs?: number;
   reconnectMaxBackoffMs?: number;
-  recordAuditEvent?: TunnelAuditRecorder | false;
+  recordAuditEvent?: TunnelAuditRecorder;
   schemes?: string[];
   tokenSecretName?: string;
   loadNgrok?: () => Promise<NgrokClient>;
@@ -137,7 +137,7 @@ export class NgrokTunnelProvider implements TunnelProvider {
   private readonly readSecret: (secretName: string) => string | null;
   private readonly reconnectInitialBackoffMs: number;
   private readonly reconnectMaxBackoffMs: number;
-  private readonly recordAuditEvent: TunnelAuditRecorder | null;
+  private readonly recordAuditEvent: TunnelAuditRecorder;
   private readonly schemes?: string[];
   private readonly tokenSecretName: string;
   private readonly loadNgrok: () => Promise<NgrokClient>;
@@ -185,10 +185,7 @@ export class NgrokTunnelProvider implements TunnelProvider {
         `reconnectInitialBackoffMs (${this.reconnectInitialBackoffMs}) must be less than or equal to reconnectMaxBackoffMs (${this.reconnectMaxBackoffMs}).`,
       );
     }
-    this.recordAuditEvent =
-      options.recordAuditEvent === false
-        ? null
-        : (options.recordAuditEvent ?? defaultRecordAuditEvent);
+    this.recordAuditEvent = options.recordAuditEvent ?? defaultRecordAuditEvent;
     this.schemes = options.schemes;
     this.tokenSecretName =
       options.tokenSecretName?.trim() || NGROK_AUTHTOKEN_SECRET;
@@ -409,7 +406,6 @@ export class NgrokTunnelProvider implements TunnelProvider {
       reason: string;
     },
   ): Promise<void> {
-    if (!this.recordAuditEvent) return;
     try {
       await this.recordAuditEvent({
         sessionId: this.auditSessionId,

--- a/src/tunnel/ngrok-tunnel-provider.ts
+++ b/src/tunnel/ngrok-tunnel-provider.ts
@@ -1,13 +1,24 @@
+import { randomUUID } from 'node:crypto';
+
 import type { Config } from '@ngrok/ngrok';
 import { readStoredRuntimeSecret } from '../security/runtime-secrets.js';
 import type {
   TunnelProvider,
   TunnelStartResult,
+  TunnelState,
   TunnelStatus,
+} from './tunnel-provider.js';
+import {
+  DEFAULT_TUNNEL_HEALTH_CHECK_INTERVAL_MS as DEFAULT_HEALTH_INTERVAL_MS,
+  DEFAULT_TUNNEL_HEALTH_CHECK_TIMEOUT_MS as DEFAULT_HEALTH_TIMEOUT_MS,
+  DEFAULT_TUNNEL_RECONNECT_INITIAL_BACKOFF_MS as DEFAULT_RECONNECT_INITIAL_BACKOFF_MS,
+  DEFAULT_TUNNEL_RECONNECT_MAX_BACKOFF_MS as DEFAULT_RECONNECT_MAX_BACKOFF_MS,
 } from './tunnel-provider.js';
 
 export const NGROK_AUTHTOKEN_SECRET = 'NGROK_AUTHTOKEN';
 export const DEFAULT_NGROK_TUNNEL_ADDR = 9090;
+const DEFAULT_NGROK_HEALTH_CHECK_PATH = '/health';
+const TUNNEL_AUDIT_SESSION_ID = 'system:tunnel';
 
 interface NgrokListener {
   url(): string | null;
@@ -18,12 +29,36 @@ interface NgrokClient {
   forward(config: Config | string | number): Promise<NgrokListener>;
 }
 
+type TunnelTimer = ReturnType<typeof setTimeout>;
+type TunnelHealthFetch = (
+  input: string | URL,
+  init?: { method?: string; signal?: AbortSignal },
+) => Promise<Pick<Response, 'ok' | 'status'>>;
+interface TunnelAuditRecord {
+  sessionId: string;
+  runId: string;
+  event: {
+    type: string;
+    [key: string]: unknown;
+  };
+}
+type TunnelAuditRecorder = (input: TunnelAuditRecord) => void | Promise<void>;
+
 export interface NgrokTunnelProviderOptions {
   addr?: Config['addr'];
+  auditSessionId?: string;
   domain?: string;
+  fetch?: TunnelHealthFetch;
   forwardsTo?: string;
+  healthCheckIntervalMs?: number;
+  healthCheckPath?: string;
+  healthCheckTimeoutMs?: number;
   metadata?: string;
+  onStatusChange?: (status: TunnelStatus) => void;
   readSecret?: (secretName: string) => string | null;
+  reconnectInitialBackoffMs?: number;
+  reconnectMaxBackoffMs?: number;
+  recordAuditEvent?: TunnelAuditRecorder | false;
   schemes?: string[];
   tokenSecretName?: string;
   loadNgrok?: () => Promise<NgrokClient>;
@@ -61,24 +96,104 @@ function redactSecret(message: string, secret: string): string {
   return message.replaceAll(trimmed, '<redacted>');
 }
 
+function normalizeDurationMs(value: unknown, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  return Math.max(1, Math.trunc(value));
+}
+
+function normalizeHealthCheckPath(value: unknown): string {
+  if (typeof value !== 'string') return DEFAULT_NGROK_HEALTH_CHECK_PATH;
+  const trimmed = value.trim();
+  if (!trimmed) return DEFAULT_NGROK_HEALTH_CHECK_PATH;
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+}
+
+function unrefTimer(timer: TunnelTimer): void {
+  if (
+    typeof timer === 'object' &&
+    timer &&
+    'unref' in timer &&
+    typeof timer.unref === 'function'
+  ) {
+    timer.unref();
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function makeTunnelAuditRunId(): string {
+  return `tunnel_${Date.now()}_${randomUUID().slice(0, 8)}`;
+}
+
+async function recordDefaultTunnelAudit(
+  input: TunnelAuditRecord,
+): Promise<void> {
+  const { recordAuditEvent } = await import('../audit/audit-events.js');
+  recordAuditEvent(input);
+}
+
 export class NgrokTunnelProvider implements TunnelProvider {
   private readonly addr: Config['addr'];
+  private readonly auditSessionId: string;
   private readonly domain?: string;
+  private readonly fetch: TunnelHealthFetch;
   private readonly forwardsTo?: string;
+  private readonly healthCheckIntervalMs: number;
+  private readonly healthCheckPath: string;
+  private readonly healthCheckTimeoutMs: number;
   private readonly metadata?: string;
+  private readonly onStatusChange?: (status: TunnelStatus) => void;
   private readonly readSecret: (secretName: string) => string | null;
+  private readonly reconnectInitialBackoffMs: number;
+  private readonly reconnectMaxBackoffMs: number;
+  private readonly recordAuditEvent: TunnelAuditRecorder | null;
   private readonly schemes?: string[];
   private readonly tokenSecretName: string;
   private readonly loadNgrok: () => Promise<NgrokClient>;
+  private healthTimer: TunnelTimer | null = null;
   private listener: NgrokListener | null = null;
+  private lastCheckedAt: string | null = null;
+  private lastError: string | null = null;
+  private nextReconnectAt: string | null = null;
   private publicUrl: string | null = null;
+  private reconnectAttempt = 0;
+  private reconnectTimer: TunnelTimer | null = null;
+  private state: TunnelState = 'down';
 
   constructor(options: NgrokTunnelProviderOptions = {}) {
     this.addr = options.addr ?? DEFAULT_NGROK_TUNNEL_ADDR;
+    this.auditSessionId =
+      options.auditSessionId?.trim() || TUNNEL_AUDIT_SESSION_ID;
     this.domain = options.domain;
+    this.fetch =
+      options.fetch ?? ((input, init) => globalThis.fetch(input, init));
     this.forwardsTo = options.forwardsTo;
+    this.healthCheckIntervalMs = normalizeDurationMs(
+      options.healthCheckIntervalMs,
+      DEFAULT_HEALTH_INTERVAL_MS,
+    );
+    this.healthCheckPath = normalizeHealthCheckPath(options.healthCheckPath);
+    this.healthCheckTimeoutMs = normalizeDurationMs(
+      options.healthCheckTimeoutMs,
+      DEFAULT_HEALTH_TIMEOUT_MS,
+    );
     this.metadata = options.metadata;
+    this.onStatusChange = options.onStatusChange;
     this.readSecret = options.readSecret ?? readStoredRuntimeSecret;
+    this.reconnectInitialBackoffMs = normalizeDurationMs(
+      options.reconnectInitialBackoffMs,
+      DEFAULT_RECONNECT_INITIAL_BACKOFF_MS,
+    );
+    this.reconnectMaxBackoffMs = normalizeDurationMs(
+      options.reconnectMaxBackoffMs,
+      DEFAULT_RECONNECT_MAX_BACKOFF_MS,
+    );
+    this.recordAuditEvent =
+      options.recordAuditEvent === false
+        ? null
+        : (options.recordAuditEvent ?? recordDefaultTunnelAudit);
     this.schemes = options.schemes;
     this.tokenSecretName =
       options.tokenSecretName?.trim() || NGROK_AUTHTOKEN_SECRET;
@@ -90,6 +205,38 @@ export class NgrokTunnelProvider implements TunnelProvider {
       return { public_url: this.publicUrl };
     }
 
+    this.clearHealthTimer();
+    this.clearReconnectTimer();
+    this.updateStatus({
+      lastCheckedAt: null,
+      lastError: null,
+      nextReconnectAt: null,
+      reconnectAttempt: 0,
+      state: 'starting',
+    });
+
+    try {
+      const { listener, publicUrl } = await this.openTunnel();
+      await this.markTunnelUp(listener, publicUrl, 'started');
+      this.scheduleHealthCheck();
+      return { public_url: publicUrl };
+    } catch (error) {
+      this.listener = null;
+      this.publicUrl = null;
+      this.updateStatus({
+        lastError: errorMessage(error),
+        nextReconnectAt: null,
+        reconnectAttempt: 0,
+        state: 'down',
+      });
+      throw error;
+    }
+  }
+
+  private async openTunnel(): Promise<{
+    listener: NgrokListener;
+    publicUrl: string;
+  }> {
     const token = this.readSecret(this.tokenSecretName)?.trim() || '';
     if (!token) {
       throw new Error(
@@ -112,9 +259,7 @@ export class NgrokTunnelProvider implements TunnelProvider {
 
       listener = await ngrok.forward(config);
       const publicUrl = normalizePublicUrl(listener.url());
-      this.listener = listener;
-      this.publicUrl = publicUrl;
-      return { public_url: publicUrl };
+      return { listener, publicUrl };
     } catch (error) {
       if (listener) {
         try {
@@ -123,26 +268,34 @@ export class NgrokTunnelProvider implements TunnelProvider {
           // Preserve the original start failure.
         }
       }
-      this.listener = null;
-      this.publicUrl = null;
       throw new Error(
-        `Failed to start ngrok tunnel: ${redactSecret(error instanceof Error ? error.message : String(error), token)}`,
+        `Failed to start ngrok tunnel: ${redactSecret(errorMessage(error), token)}`,
       );
     }
   }
 
   async stop(): Promise<void> {
+    this.clearHealthTimer();
+    this.clearReconnectTimer();
     const listener = this.listener;
+    const publicUrl = this.publicUrl;
     this.listener = null;
     this.publicUrl = null;
+    this.updateStatus({
+      lastCheckedAt: null,
+      lastError: null,
+      nextReconnectAt: null,
+      reconnectAttempt: 0,
+      state: 'down',
+    });
+    if (publicUrl) {
+      await this.recordTunnelAudit('tunnel.down', {
+        publicUrl,
+        reason: 'stopped',
+      });
+    }
     if (listener) {
-      try {
-        await listener.close();
-      } catch {
-        console.warn(
-          '[tunnel] failed to stop ngrok tunnel cleanly; local tunnel state was cleared.',
-        );
-      }
+      await this.closeListener(listener);
     }
   }
 
@@ -150,7 +303,245 @@ export class NgrokTunnelProvider implements TunnelProvider {
     return {
       running: Boolean(this.listener && this.publicUrl),
       public_url: this.publicUrl,
+      state: this.state,
+      last_error: this.lastError,
+      last_checked_at: this.lastCheckedAt,
+      next_reconnect_at: this.nextReconnectAt,
+      reconnect_attempt: this.reconnectAttempt,
     };
+  }
+
+  private updateStatus(update: {
+    lastCheckedAt?: string | null;
+    lastError?: string | null;
+    nextReconnectAt?: string | null;
+    reconnectAttempt?: number;
+    state?: TunnelState;
+  }): void {
+    const before = JSON.stringify(this.status());
+    if ('lastCheckedAt' in update) {
+      this.lastCheckedAt = update.lastCheckedAt ?? null;
+    }
+    if ('lastError' in update) {
+      this.lastError = update.lastError ?? null;
+    }
+    if ('nextReconnectAt' in update) {
+      this.nextReconnectAt = update.nextReconnectAt ?? null;
+    }
+    if ('reconnectAttempt' in update) {
+      this.reconnectAttempt = Math.max(0, update.reconnectAttempt ?? 0);
+    }
+    if (update.state) {
+      this.state = update.state;
+    }
+
+    const after = JSON.stringify(this.status());
+    if (before !== after) {
+      this.publishStatusChange();
+    }
+  }
+
+  private publishStatusChange(): void {
+    if (!this.onStatusChange) return;
+    try {
+      this.onStatusChange(this.status());
+    } catch (error) {
+      console.warn(
+        '[tunnel] status change handler failed.',
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  private async markTunnelUp(
+    listener: NgrokListener,
+    publicUrl: string,
+    reason: string,
+  ): Promise<void> {
+    const wasRunning = Boolean(this.listener && this.publicUrl);
+    this.listener = listener;
+    this.publicUrl = publicUrl;
+    this.updateStatus({
+      lastError: null,
+      nextReconnectAt: null,
+      reconnectAttempt: 0,
+      state: 'up',
+    });
+    if (!wasRunning) {
+      await this.recordTunnelAudit('tunnel.up', { publicUrl, reason });
+    }
+  }
+
+  private async markTunnelDown(params: {
+    lastCheckedAt?: string;
+    message: string;
+    publicUrl: string;
+    reason: string;
+  }): Promise<void> {
+    this.listener = null;
+    this.publicUrl = null;
+    this.updateStatus({
+      lastCheckedAt: params.lastCheckedAt ?? null,
+      lastError: params.message,
+      state: 'reconnecting',
+    });
+    await this.recordTunnelAudit('tunnel.down', {
+      error: params.message,
+      publicUrl: params.publicUrl,
+      reason: params.reason,
+    });
+  }
+
+  private async recordTunnelAudit(
+    type: 'tunnel.up' | 'tunnel.down',
+    details: {
+      error?: string;
+      publicUrl: string;
+      reason: string;
+    },
+  ): Promise<void> {
+    if (!this.recordAuditEvent) return;
+    try {
+      await this.recordAuditEvent({
+        sessionId: this.auditSessionId,
+        runId: makeTunnelAuditRunId(),
+        event: {
+          type,
+          provider: 'ngrok',
+          public_url: details.publicUrl,
+          reason: details.reason,
+          ...(details.error ? { error: details.error } : {}),
+        },
+      });
+    } catch (error) {
+      console.warn(
+        '[tunnel] failed to record tunnel audit event.',
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  private clearHealthTimer(): void {
+    if (!this.healthTimer) return;
+    clearTimeout(this.healthTimer);
+    this.healthTimer = null;
+  }
+
+  private clearReconnectTimer(): void {
+    if (!this.reconnectTimer) return;
+    clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = null;
+  }
+
+  private scheduleHealthCheck(): void {
+    this.clearHealthTimer();
+    if (!this.listener || !this.publicUrl) return;
+    this.healthTimer = setTimeout(() => {
+      this.healthTimer = null;
+      void this.runHealthCheck();
+    }, this.healthCheckIntervalMs);
+    unrefTimer(this.healthTimer);
+  }
+
+  private async runHealthCheck(): Promise<void> {
+    const listener = this.listener;
+    const publicUrl = this.publicUrl;
+    if (!listener || !publicUrl || this.state !== 'up') return;
+
+    const checkedAt = new Date().toISOString();
+    try {
+      await this.checkTunnelHealth(publicUrl);
+      if (this.listener !== listener || this.publicUrl !== publicUrl) return;
+      this.updateStatus({
+        lastCheckedAt: checkedAt,
+        lastError: null,
+        reconnectAttempt: 0,
+        state: 'up',
+      });
+      this.scheduleHealthCheck();
+    } catch (error) {
+      if (this.listener !== listener || this.publicUrl !== publicUrl) return;
+      const message = errorMessage(error);
+      await this.markTunnelDown({
+        lastCheckedAt: checkedAt,
+        message,
+        publicUrl,
+        reason: 'health_check_failed',
+      });
+      await this.closeListener(listener);
+      this.scheduleReconnect(message);
+    }
+  }
+
+  private async checkTunnelHealth(publicUrl: string): Promise<void> {
+    const healthUrl = new URL(this.healthCheckPath, `${publicUrl}/`).toString();
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(),
+      this.healthCheckTimeoutMs,
+    );
+    unrefTimer(timeout);
+    try {
+      const response = await this.fetch(healthUrl, {
+        method: 'GET',
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`tunnel health check returned HTTP ${response.status}`);
+      }
+    } catch (error) {
+      if (controller.signal.aborted) {
+        throw new Error(
+          `tunnel health check timed out after ${this.healthCheckTimeoutMs}ms`,
+        );
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private scheduleReconnect(message: string): void {
+    const attempt = this.reconnectAttempt + 1;
+    const delayMs = Math.min(
+      this.reconnectMaxBackoffMs,
+      this.reconnectInitialBackoffMs * 2 ** Math.max(0, attempt - 1),
+    );
+    const nextReconnectAt = new Date(Date.now() + delayMs).toISOString();
+    this.updateStatus({
+      lastError: message,
+      nextReconnectAt,
+      reconnectAttempt: attempt,
+      state: 'reconnecting',
+    });
+    this.clearReconnectTimer();
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      void this.reconnect();
+    }, delayMs);
+    unrefTimer(this.reconnectTimer);
+  }
+
+  private async reconnect(): Promise<void> {
+    if (this.state !== 'reconnecting' || this.listener || this.publicUrl)
+      return;
+    try {
+      const { listener, publicUrl } = await this.openTunnel();
+      await this.markTunnelUp(listener, publicUrl, 'reconnected');
+      this.scheduleHealthCheck();
+    } catch (error) {
+      this.scheduleReconnect(errorMessage(error));
+    }
+  }
+
+  private async closeListener(listener: NgrokListener): Promise<void> {
+    try {
+      await listener.close();
+    } catch {
+      console.warn(
+        '[tunnel] failed to stop ngrok tunnel cleanly; local tunnel state was cleared.',
+      );
+    }
   }
 }
 

--- a/src/tunnel/tunnel-provider.ts
+++ b/src/tunnel/tunnel-provider.ts
@@ -4,9 +4,21 @@ export interface TunnelStartResult {
   public_url: string;
 }
 
+export const DEFAULT_TUNNEL_HEALTH_CHECK_INTERVAL_MS = 30_000;
+export const DEFAULT_TUNNEL_HEALTH_CHECK_TIMEOUT_MS = 5_000;
+export const DEFAULT_TUNNEL_RECONNECT_INITIAL_BACKOFF_MS = 1_000;
+export const DEFAULT_TUNNEL_RECONNECT_MAX_BACKOFF_MS = 30_000;
+
+export type TunnelState = 'down' | 'starting' | 'up' | 'reconnecting';
+
 export interface TunnelStatus {
   running: boolean;
   public_url: string | null;
+  state: TunnelState;
+  last_error: string | null;
+  last_checked_at: string | null;
+  next_reconnect_at: string | null;
+  reconnect_attempt: number;
 }
 
 export interface TunnelProvider {

--- a/tests/ngrok-tunnel.test.ts
+++ b/tests/ngrok-tunnel.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { NgrokTunnelProvider } from '../src/tunnel/ngrok-tunnel-provider.js';
+import type { TunnelStatus } from '../src/tunnel/tunnel-provider.js';
+
+const DOWN_STATUS: TunnelStatus = {
+  running: false,
+  public_url: null,
+  state: 'down',
+  last_error: null,
+  last_checked_at: null,
+  next_reconnect_at: null,
+  reconnect_attempt: 0,
+};
 
 describe('NgrokTunnelProvider', () => {
   it('opens an ngrok tunnel with the encrypted runtime secret token', async () => {
@@ -9,17 +20,16 @@ describe('NgrokTunnelProvider', () => {
       close,
       url: () => 'https://abc123.ngrok.app/',
     }));
+    const recordAuditEvent = vi.fn();
     const provider = new NgrokTunnelProvider({
       addr: 9090,
       loadNgrok: async () => ({ forward }),
+      recordAuditEvent,
       readSecret: (secretName) =>
         secretName === 'NGROK_AUTHTOKEN' ? ' test-token ' : null,
     });
 
-    expect(provider.status()).toEqual({
-      running: false,
-      public_url: null,
-    });
+    expect(provider.status()).toEqual(DOWN_STATUS);
 
     await expect(provider.start()).resolves.toEqual({
       public_url: 'https://abc123.ngrok.app',
@@ -32,25 +42,56 @@ describe('NgrokTunnelProvider', () => {
     expect(provider.status()).toEqual({
       running: true,
       public_url: 'https://abc123.ngrok.app',
+      state: 'up',
+      last_error: null,
+      last_checked_at: null,
+      next_reconnect_at: null,
+      reconnect_attempt: 0,
     });
+    expect(recordAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'system:tunnel',
+        event: {
+          type: 'tunnel.up',
+          provider: 'ngrok',
+          public_url: 'https://abc123.ngrok.app',
+          reason: 'started',
+        },
+      }),
+    );
 
     await provider.stop();
     expect(close).toHaveBeenCalledTimes(1);
-    expect(provider.status()).toEqual({
-      running: false,
-      public_url: null,
-    });
+    expect(provider.status()).toEqual(DOWN_STATUS);
+    expect(recordAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'system:tunnel',
+        event: {
+          type: 'tunnel.down',
+          provider: 'ngrok',
+          public_url: 'https://abc123.ngrok.app',
+          reason: 'stopped',
+        },
+      }),
+    );
   });
 
   it('does not load ngrok when the auth token is missing', async () => {
     const loadNgrok = vi.fn();
     const provider = new NgrokTunnelProvider({
       loadNgrok,
+      recordAuditEvent: vi.fn(),
       readSecret: () => null,
     });
 
     await expect(provider.start()).rejects.toThrow('NGROK_AUTHTOKEN');
     expect(loadNgrok).not.toHaveBeenCalled();
+    expect(provider.status()).toMatchObject({
+      running: false,
+      public_url: null,
+      state: 'down',
+    });
+    expect(provider.status().last_error).toContain('NGROK_AUTHTOKEN');
   });
 
   it('returns the existing tunnel when start is called while running', async () => {
@@ -61,6 +102,7 @@ describe('NgrokTunnelProvider', () => {
     }));
     const provider = new NgrokTunnelProvider({
       loadNgrok: async () => ({ forward }),
+      recordAuditEvent: vi.fn(),
       readSecret: () => 'test-token',
     });
 
@@ -86,6 +128,7 @@ describe('NgrokTunnelProvider', () => {
     }));
     const provider = new NgrokTunnelProvider({
       loadNgrok: async () => ({ forward }),
+      recordAuditEvent: vi.fn(),
       readSecret: () => 'test-token',
     });
 
@@ -97,10 +140,7 @@ describe('NgrokTunnelProvider', () => {
       expect(warn).toHaveBeenCalledWith(
         '[tunnel] failed to stop ngrok tunnel cleanly; local tunnel state was cleared.',
       );
-      expect(provider.status()).toEqual({
-        running: false,
-        public_url: null,
-      });
+      expect(provider.status()).toEqual(DOWN_STATUS);
     } finally {
       warn.mockRestore();
     }
@@ -114,6 +154,7 @@ describe('NgrokTunnelProvider', () => {
     }));
     const provider = new NgrokTunnelProvider({
       loadNgrok: async () => ({ forward }),
+      recordAuditEvent: vi.fn(),
       readSecret: () => 'secret-token',
     });
 
@@ -128,9 +169,130 @@ describe('NgrokTunnelProvider', () => {
     expect(thrown?.message).toContain('Failed to start ngrok tunnel');
     expect(thrown?.message).not.toContain('secret-token');
     expect(close).toHaveBeenCalledTimes(1);
-    expect(provider.status()).toEqual({
+    expect(provider.status()).toMatchObject({
       running: false,
       public_url: null,
+      state: 'down',
     });
+    expect(provider.status().last_error).toContain(
+      'Failed to start ngrok tunnel',
+    );
+  });
+
+  it('health-checks the active tunnel at the configured interval', async () => {
+    vi.useFakeTimers();
+    try {
+      const close = vi.fn(async () => {});
+      const forward = vi.fn(async () => ({
+        close,
+        url: () => 'https://health.ngrok.app',
+      }));
+      const fetch = vi.fn(async () => ({ ok: true, status: 200 }));
+      const statusChanges: TunnelStatus[] = [];
+      const provider = new NgrokTunnelProvider({
+        fetch,
+        healthCheckIntervalMs: 250,
+        loadNgrok: async () => ({ forward }),
+        onStatusChange: (status) => statusChanges.push(status),
+        recordAuditEvent: vi.fn(),
+        readSecret: () => 'test-token',
+      });
+
+      await provider.start();
+      await vi.advanceTimersByTimeAsync(249);
+      expect(fetch).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(fetch).toHaveBeenCalledWith('https://health.ngrok.app/health', {
+        method: 'GET',
+        signal: expect.any(AbortSignal),
+      });
+      expect(provider.status()).toMatchObject({
+        running: true,
+        public_url: 'https://health.ngrok.app',
+        state: 'up',
+        last_error: null,
+      });
+      expect(provider.status().last_checked_at).toEqual(expect.any(String));
+      expect(statusChanges.map((status) => status.state)).toContain('up');
+
+      await provider.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reconnects with capped backoff when a health check fails', async () => {
+    vi.useFakeTimers();
+    try {
+      const firstClose = vi.fn(async () => {});
+      const secondClose = vi.fn(async () => {});
+      const forward = vi
+        .fn()
+        .mockResolvedValueOnce({
+          close: firstClose,
+          url: () => 'https://first.ngrok.app',
+        })
+        .mockRejectedValueOnce(new Error('temporary ngrok failure'))
+        .mockResolvedValueOnce({
+          close: secondClose,
+          url: () => 'https://second.ngrok.app',
+        });
+      const fetch = vi.fn(async () => ({ ok: false, status: 503 }));
+      const recordAuditEvent = vi.fn();
+      const provider = new NgrokTunnelProvider({
+        fetch,
+        healthCheckIntervalMs: 100,
+        loadNgrok: async () => ({ forward }),
+        reconnectInitialBackoffMs: 50,
+        reconnectMaxBackoffMs: 75,
+        recordAuditEvent,
+        readSecret: () => 'test-token',
+      });
+
+      await provider.start();
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(firstClose).toHaveBeenCalledTimes(1);
+      expect(provider.status()).toMatchObject({
+        running: false,
+        public_url: null,
+        state: 'reconnecting',
+        last_error: 'tunnel health check returned HTTP 503',
+        reconnect_attempt: 1,
+      });
+      expect(provider.status().next_reconnect_at).toEqual(expect.any(String));
+      expect(
+        recordAuditEvent.mock.calls.map((call) => call[0].event.type),
+      ).toEqual(['tunnel.up', 'tunnel.down']);
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(forward).toHaveBeenCalledTimes(2);
+      expect(provider.status()).toMatchObject({
+        running: false,
+        state: 'reconnecting',
+        reconnect_attempt: 2,
+      });
+
+      await vi.advanceTimersByTimeAsync(74);
+      expect(forward).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(forward).toHaveBeenCalledTimes(3);
+      expect(provider.status()).toMatchObject({
+        running: true,
+        public_url: 'https://second.ngrok.app',
+        state: 'up',
+        last_error: null,
+        reconnect_attempt: 0,
+      });
+      expect(
+        recordAuditEvent.mock.calls.map((call) => call[0].event.type),
+      ).toEqual(['tunnel.up', 'tunnel.down', 'tunnel.up']);
+
+      await provider.stop();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/ngrok-tunnel.test.ts
+++ b/tests/ngrok-tunnel.test.ts
@@ -71,6 +71,7 @@ describe('NgrokTunnelProvider', () => {
         },
       }),
     );
+    const upRunId = recordAuditEvent.mock.calls[0]?.[0].runId;
 
     await provider.stop();
     expect(close).toHaveBeenCalledTimes(1);
@@ -86,6 +87,7 @@ describe('NgrokTunnelProvider', () => {
         },
       }),
     );
+    expect(recordAuditEvent.mock.calls[1]?.[0].runId).toBe(upRunId);
   });
 
   it('does not load ngrok when the auth token is missing', async () => {
@@ -303,6 +305,9 @@ describe('NgrokTunnelProvider', () => {
       expect(
         recordAuditEvent.mock.calls.map((call) => call[0].event.type),
       ).toEqual(['tunnel.up', 'tunnel.down']);
+      expect(recordAuditEvent.mock.calls[1]?.[0].runId).toBe(
+        recordAuditEvent.mock.calls[0]?.[0].runId,
+      );
 
       await vi.advanceTimersByTimeAsync(50);
       expect(forward).toHaveBeenCalledTimes(2);
@@ -327,6 +332,9 @@ describe('NgrokTunnelProvider', () => {
       expect(
         recordAuditEvent.mock.calls.map((call) => call[0].event.type),
       ).toEqual(['tunnel.up', 'tunnel.down', 'tunnel.up']);
+      expect(recordAuditEvent.mock.calls[2]?.[0].runId).not.toBe(
+        recordAuditEvent.mock.calls[0]?.[0].runId,
+      );
 
       await provider.stop();
     } finally {

--- a/tests/ngrok-tunnel.test.ts
+++ b/tests/ngrok-tunnel.test.ts
@@ -261,6 +261,7 @@ describe('NgrokTunnelProvider', () => {
 
   it('reconnects with capped backoff when a health check fails', async () => {
     vi.useFakeTimers();
+    const random = vi.spyOn(Math, 'random').mockReturnValue(0.5);
     try {
       const firstClose = vi.fn(async () => {});
       const secondClose = vi.fn(async () => {});
@@ -329,6 +330,59 @@ describe('NgrokTunnelProvider', () => {
 
       await provider.stop();
     } finally {
+      random.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('jitters reconnect backoff to avoid synchronized retries', async () => {
+    vi.useFakeTimers();
+    const random = vi.spyOn(Math, 'random').mockReturnValue(1);
+    try {
+      const firstClose = vi.fn(async () => {});
+      const secondClose = vi.fn(async () => {});
+      const forward = vi
+        .fn()
+        .mockResolvedValueOnce({
+          close: firstClose,
+          url: () => 'https://first.ngrok.app',
+        })
+        .mockResolvedValueOnce({
+          close: secondClose,
+          url: () => 'https://jitter.ngrok.app',
+        });
+      const fetch = vi.fn(async () => ({ ok: false, status: 503 }));
+      const provider = new NgrokTunnelProvider({
+        fetch,
+        healthCheckIntervalMs: 100,
+        loadNgrok: async () => ({ forward }),
+        reconnectInitialBackoffMs: 50,
+        reconnectMaxBackoffMs: 500,
+        recordAuditEvent: vi.fn(),
+        readSecret: () => 'test-token',
+      });
+
+      await provider.start();
+      await vi.advanceTimersByTimeAsync(100);
+      expect(provider.status()).toMatchObject({
+        state: 'reconnecting',
+        reconnect_attempt: 1,
+      });
+
+      await vi.advanceTimersByTimeAsync(54);
+      expect(forward).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(forward).toHaveBeenCalledTimes(2);
+      expect(provider.status()).toMatchObject({
+        running: true,
+        public_url: 'https://jitter.ngrok.app',
+        state: 'up',
+      });
+
+      await provider.stop();
+    } finally {
+      random.mockRestore();
       vi.useRealTimers();
     }
   });

--- a/tests/ngrok-tunnel.test.ts
+++ b/tests/ngrok-tunnel.test.ts
@@ -14,6 +14,18 @@ const DOWN_STATUS: TunnelStatus = {
 };
 
 describe('NgrokTunnelProvider', () => {
+  it('rejects reconnect backoff configs whose initial delay exceeds the cap', () => {
+    expect(
+      () =>
+        new NgrokTunnelProvider({
+          reconnectInitialBackoffMs: 60_000,
+          reconnectMaxBackoffMs: 1_000,
+        }),
+    ).toThrow(
+      'reconnectInitialBackoffMs (60000) must be less than or equal to reconnectMaxBackoffMs (1000).',
+    );
+  });
+
   it('opens an ngrok tunnel with the encrypted runtime secret token', async () => {
     const close = vi.fn(async () => {});
     const forward = vi.fn(async () => ({
@@ -78,9 +90,10 @@ describe('NgrokTunnelProvider', () => {
 
   it('does not load ngrok when the auth token is missing', async () => {
     const loadNgrok = vi.fn();
+    const recordAuditEvent = vi.fn();
     const provider = new NgrokTunnelProvider({
       loadNgrok,
-      recordAuditEvent: vi.fn(),
+      recordAuditEvent,
       readSecret: () => null,
     });
 
@@ -92,6 +105,17 @@ describe('NgrokTunnelProvider', () => {
       state: 'down',
     });
     expect(provider.status().last_error).toContain('NGROK_AUTHTOKEN');
+    expect(recordAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: {
+          type: 'tunnel.start_failed',
+          provider: 'ngrok',
+          reason: 'started',
+          error:
+            'ngrok auth token is not configured in encrypted runtime secrets. Store it with `hybridclaw secret set NGROK_AUTHTOKEN <token>`.',
+        },
+      }),
+    );
   });
 
   it('returns the existing tunnel when start is called while running', async () => {
@@ -152,9 +176,10 @@ describe('NgrokTunnelProvider', () => {
       close,
       url: () => null,
     }));
+    const recordAuditEvent = vi.fn();
     const provider = new NgrokTunnelProvider({
       loadNgrok: async () => ({ forward }),
-      recordAuditEvent: vi.fn(),
+      recordAuditEvent,
       readSecret: () => 'secret-token',
     });
 
@@ -176,6 +201,18 @@ describe('NgrokTunnelProvider', () => {
     });
     expect(provider.status().last_error).toContain(
       'Failed to start ngrok tunnel',
+    );
+    expect(recordAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          type: 'tunnel.start_failed',
+          provider: 'ngrok',
+          reason: 'started',
+        }),
+      }),
+    );
+    expect(JSON.stringify(recordAuditEvent.mock.calls)).not.toContain(
+      'secret-token',
     );
   });
 
@@ -289,6 +326,67 @@ describe('NgrokTunnelProvider', () => {
       expect(
         recordAuditEvent.mock.calls.map((call) => call[0].event.type),
       ).toEqual(['tunnel.up', 'tunnel.down', 'tunnel.up']);
+
+      await provider.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('lets a manual start replace a pending reconnect attempt', async () => {
+    vi.useFakeTimers();
+    try {
+      const firstClose = vi.fn(async () => {});
+      const secondClose = vi.fn(async () => {});
+      const forward = vi
+        .fn()
+        .mockResolvedValueOnce({
+          close: firstClose,
+          url: () => 'https://first.ngrok.app',
+        })
+        .mockResolvedValueOnce({
+          close: secondClose,
+          url: () => 'https://manual.ngrok.app',
+        });
+      const fetch = vi.fn(async () => ({ ok: false, status: 503 }));
+      const recordAuditEvent = vi.fn();
+      const provider = new NgrokTunnelProvider({
+        fetch,
+        healthCheckIntervalMs: 100,
+        loadNgrok: async () => ({ forward }),
+        reconnectInitialBackoffMs: 1_000,
+        reconnectMaxBackoffMs: 1_000,
+        recordAuditEvent,
+        readSecret: () => 'test-token',
+      });
+
+      await provider.start();
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(provider.status()).toMatchObject({
+        running: false,
+        state: 'reconnecting',
+        reconnect_attempt: 1,
+      });
+
+      await expect(provider.start()).resolves.toEqual({
+        public_url: 'https://manual.ngrok.app',
+      });
+      expect(forward).toHaveBeenCalledTimes(2);
+      expect(provider.status()).toMatchObject({
+        running: true,
+        public_url: 'https://manual.ngrok.app',
+        state: 'up',
+        reconnect_attempt: 0,
+      });
+      expect(recordAuditEvent.mock.calls[2]?.[0].event).toMatchObject({
+        type: 'tunnel.up',
+        reason: 'manual_reconnect',
+        public_url: 'https://manual.ngrok.app',
+      });
+
+      await vi.advanceTimersByTimeAsync(999);
+      expect(forward).toHaveBeenCalledTimes(2);
 
       await provider.stop();
     } finally {

--- a/tests/runtime-config-deployment.test.ts
+++ b/tests/runtime-config-deployment.test.ts
@@ -70,6 +70,7 @@ describe('runtime deployment config', () => {
       public_url: '',
       tunnel: {
         provider: 'manual',
+        health_check_interval_ms: 30000,
       },
     });
     expect(readDiskConfig().deployment).toEqual({
@@ -77,6 +78,7 @@ describe('runtime deployment config', () => {
       public_url: '',
       tunnel: {
         provider: 'manual',
+        health_check_interval_ms: 30000,
       },
     });
   });
@@ -173,6 +175,7 @@ describe('runtime deployment config', () => {
     expect(readDiskConfig().deployment).toMatchObject({
       tunnel: {
         provider: 'wireguard',
+        health_check_interval_ms: 30000,
       },
     });
 
@@ -196,6 +199,7 @@ describe('runtime deployment config', () => {
         draft.deployment.mode = 'cloud';
         draft.deployment.public_url = 'https://bot.example.com/';
         draft.deployment.tunnel.provider = 'cloudflare';
+        draft.deployment.tunnel.health_check_interval_ms = 45000;
       },
       {
         actor: 'test-user',
@@ -209,6 +213,7 @@ describe('runtime deployment config', () => {
       public_url: 'https://bot.example.com',
       tunnel: {
         provider: 'cloudflare',
+        health_check_interval_ms: 45000,
       },
     });
     expect(readDiskConfig().deployment).toEqual({
@@ -216,6 +221,7 @@ describe('runtime deployment config', () => {
       public_url: 'https://bot.example.com',
       tunnel: {
         provider: 'cloudflare',
+        health_check_interval_ms: 45000,
       },
     });
     const revisions = runtimeConfig.listRuntimeConfigRevisions();
@@ -244,6 +250,7 @@ describe('runtime deployment config', () => {
       public_url: '',
       tunnel: {
         provider: 'manual',
+        health_check_interval_ms: 30000,
       },
     });
     expect(readDiskConfig().deployment).toEqual({
@@ -251,6 +258,7 @@ describe('runtime deployment config', () => {
       public_url: '',
       tunnel: {
         provider: 'manual',
+        health_check_interval_ms: 30000,
       },
     });
   });


### PR DESCRIPTION
## Summary

Closes #568.

Implements tunnel health monitoring for the built-in ngrok tunnel provider:

- health-checks the active tunnel at a configurable interval, defaulting to 30s
- exposes tunnel state transitions through `status()` and `onStatusChange`
- reconnects failed tunnels with capped exponential backoff
- records structured `tunnel.up` and `tunnel.down` audit events
- documents `deployment.tunnel.health_check_interval_ms` and updates the config example/changelog

## Acceptance Criteria

- [x] Health check at configurable interval (default 30s).
- [x] On failure: reconnect with capped backoff; surface state changes.
- [x] Audit-log entry per tunnel up/down.

## Validation

- `/Users/bkoehler/src/hybridclaw-electron-mac/desktop/build/runtime-bin/node ./node_modules/vitest/vitest.mjs run --configLoader runner --config vitest.unit.config.ts tests/ngrok-tunnel.test.ts tests/runtime-config-deployment.test.ts`
- `/Users/bkoehler/src/hybridclaw-electron-mac/desktop/build/runtime-bin/node ./node_modules/typescript/bin/tsc --noEmit --noUnusedLocals --noUnusedParameters`
- `/Users/bkoehler/src/hybridclaw/node_modules/.bin/biome check --write src`
- `/Users/bkoehler/src/hybridclaw/node_modules/.bin/biome check src`