### PR TITLE
[codex] Scrub host runtime environment

### DIFF
--- a/container/shared/sensitive-env.d.ts
+++ b/container/shared/sensitive-env.d.ts
@@ -1,0 +1,16 @@
+export interface SensitiveEnvRules {
+  exact: ReadonlySet<string>;
+  prefixes: readonly string[];
+  suffixes: readonly string[];
+}
+
+export declare const SENSITIVE_ENV_RULES: SensitiveEnvRules;
+
+export declare function isSensitiveEnvName(
+  name: string,
+  rules?: SensitiveEnvRules,
+): boolean;
+
+export declare function buildSanitizedEnv(
+  sourceEnv: Record<string, string | undefined>,
+): Record<string, string>;

--- a/container/shared/sensitive-env.js
+++ b/container/shared/sensitive-env.js
@@ -1,0 +1,66 @@
+// container/shared modules are plain JS so both the root TypeScript build and
+// container runtime can import one implementation without widening tsconfig roots.
+export const SENSITIVE_ENV_RULES = {
+  exact: new Set([
+    'ANTHROPIC_API_KEY',
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN',
+    'AWS_SECURITY_TOKEN',
+    'DOCKER_AUTH_CONFIG',
+    'GH_TOKEN',
+    'GIT_ASKPASS',
+    'GITHUB_TOKEN',
+    'GITLAB_TOKEN',
+    'HYBRIDAI_API_KEY',
+    'NPM_CONFIG__AUTH',
+    'NPM_CONFIG__AUTH_TOKEN',
+    'NPM_TOKEN',
+    'NODE_AUTH_TOKEN',
+    'OPENAI_API_KEY',
+    'SSH_AGENT_PID',
+    'SSH_ASKPASS',
+    'SSH_AUTH_SOCK',
+  ]),
+  prefixes: ['AWS_'],
+  // Callers must explicitly re-add any legitimate runtime config that matches
+  // these broad secret-shaped patterns.
+  suffixes: [
+    '_ACCESS_KEY',
+    '_API_KEY',
+    '_AUTH',
+    '_AUTH_CONFIG',
+    '_CREDENTIAL',
+    '_CREDENTIALS',
+    '_PASS',
+    '_PASSWORD',
+    '_PRIVATE_KEY',
+    '_SECRET',
+    '_TOKEN',
+  ],
+};
+
+export function isSensitiveEnvName(name, rules = SENSITIVE_ENV_RULES) {
+  const normalized = String(name || '')
+    .trim()
+    .toUpperCase();
+  if (!normalized) return false;
+  if (rules.exact.has(normalized)) return true;
+  if (rules.prefixes.some((prefix) => normalized.startsWith(prefix))) {
+    return true;
+  }
+  return rules.suffixes.some((suffix) => normalized.endsWith(suffix));
+}
+
+export function buildSanitizedEnv(sourceEnv) {
+  if (!sourceEnv || typeof sourceEnv !== 'object' || Array.isArray(sourceEnv)) {
+    throw new TypeError('buildSanitizedEnv: sourceEnv must be an object');
+  }
+  const env = {};
+  for (const [name, value] of Object.entries(sourceEnv)) {
+    if (typeof value !== 'string') continue;
+    if (isSensitiveEnvName(name)) continue;
+    env[name] = value;
+  }
+  return env;
+}

--- a/container/shared/web-search-config.d.ts
+++ b/container/shared/web-search-config.d.ts
@@ -1,0 +1,22 @@
+export type SearchProviderName =
+  | 'brave'
+  | 'perplexity'
+  | 'tavily'
+  | 'duckduckgo'
+  | 'searxng';
+
+export type SearchProviderMode = SearchProviderName | 'auto';
+
+export interface WebSearchConfig {
+  provider: SearchProviderMode;
+  fallbackProviders: SearchProviderName[];
+  defaultCount: number;
+  cacheTtlMinutes: number;
+  searxngBaseUrl: string;
+  tavilySearchDepth: 'basic' | 'advanced';
+  braveApiKey?: string;
+  perplexityApiKey?: string;
+  tavilyApiKey?: string;
+}
+
+export declare const WEB_SEARCH_PROVIDER_NAMES: SearchProviderName[];

--- a/container/shared/web-search-config.js
+++ b/container/shared/web-search-config.js
@@ -1,0 +1,7 @@
+export const WEB_SEARCH_PROVIDER_NAMES = [
+  'brave',
+  'perplexity',
+  'tavily',
+  'duckduckgo',
+  'searxng',
+];

--- a/container/src/tools.ts
+++ b/container/src/tools.ts
@@ -7,6 +7,7 @@ import {
   formatMessageToolChannelList,
   normalizeMessageToolChannelKinds,
 } from '../shared/message-tool-channels.js';
+import { buildSanitizedEnv } from '../shared/sensitive-env.js';
 import {
   currentDateStampInTimezone,
   readUserTimezoneFile,
@@ -397,14 +398,12 @@ function runHostBash(
   args: string[],
   timeoutMs: number,
 ): SpawnSyncReturns<string> {
-  const cleanEnv = { ...process.env };
-  delete cleanEnv.HYBRIDAI_API_KEY;
   return spawnSync('bash', args, {
     timeout: timeoutMs,
     encoding: 'utf-8',
     cwd: WORKSPACE_ROOT,
     maxBuffer: BASH_EXEC_MAX_BUFFER_BYTES,
-    env: cleanEnv,
+    env: buildSanitizedEnv(process.env),
   });
 }
 
@@ -771,13 +770,33 @@ export function setMediaContext(media?: MediaContextItem[]): void {
   currentMediaContext = Array.isArray(media) ? media : [];
 }
 
+function hasWebSearchProviderKeys(config?: WebSearchRuntimeConfig): boolean {
+  return Boolean(
+    config?.braveApiKey || config?.perplexityApiKey || config?.tavilyApiKey,
+  );
+}
+
 export function setWebSearchConfig(config?: WebSearchRuntimeConfig): void {
-  currentWebSearchConfig = config
-    ? {
-        ...config,
-        fallbackProviders: [...config.fallbackProviders],
-      }
-    : undefined;
+  const previous = currentWebSearchConfig;
+  if (!config) {
+    if (hasWebSearchProviderKeys(previous)) {
+      console.warn(
+        '[web-search] runtime config cleared; provider API keys supplied through runtime config will be unavailable until a new config arrives.',
+      );
+    }
+    currentWebSearchConfig = undefined;
+    return;
+  }
+
+  currentWebSearchConfig = {
+    ...config,
+    fallbackProviders: [...config.fallbackProviders],
+    // Follow-up IPC files redact provider keys, so keep the first in-memory
+    // values until this long-lived agent process restarts.
+    braveApiKey: config.braveApiKey ?? previous?.braveApiKey,
+    perplexityApiKey: config.perplexityApiKey ?? previous?.perplexityApiKey,
+    tavilyApiKey: config.tavilyApiKey ?? previous?.tavilyApiKey,
+  };
 }
 
 export function setMcpClientManager(manager: McpClientManager | null): void {

--- a/container/src/types.ts
+++ b/container/src/types.ts
@@ -2,6 +2,7 @@ import type {
   StakesScore as CanonicalStakesScore,
   StakesSignal as CanonicalStakesSignal,
 } from '../shared/stakes-classifier.js';
+import type { WebSearchConfig } from '../shared/web-search-config.js';
 import type { McpServerConfig } from './mcp/types.js';
 
 export interface ChatContentTextPart {
@@ -177,26 +178,7 @@ export interface ScheduledTaskInput {
   createdAt: string;
 }
 
-export interface WebSearchConfig {
-  provider:
-    | 'auto'
-    | 'brave'
-    | 'perplexity'
-    | 'tavily'
-    | 'duckduckgo'
-    | 'searxng';
-  fallbackProviders: (
-    | 'brave'
-    | 'perplexity'
-    | 'tavily'
-    | 'duckduckgo'
-    | 'searxng'
-  )[];
-  defaultCount: number;
-  cacheTtlMinutes: number;
-  searxngBaseUrl: string;
-  tavilySearchDepth: 'basic' | 'advanced';
-}
+export type { WebSearchConfig } from '../shared/web-search-config.js';
 
 export interface ContainerInput {
   sessionId: string;

--- a/container/src/web-search.ts
+++ b/container/src/web-search.ts
@@ -1,3 +1,9 @@
+import type {
+  SearchProviderMode,
+  SearchProviderName,
+  WebSearchConfig,
+} from '../shared/web-search-config.js';
+
 const DEFAULT_COUNT = 5;
 const MIN_COUNT = 1;
 const MAX_COUNT = 10;
@@ -58,14 +64,12 @@ const BRAVE_LANGUAGE_ALIASES: Record<string, string> = {
   'zh-tw': 'zh-hant',
 };
 
-export type SearchProviderName =
-  | 'brave'
-  | 'perplexity'
-  | 'tavily'
-  | 'duckduckgo'
-  | 'searxng';
+export type {
+  SearchProviderMode,
+  SearchProviderName,
+  WebSearchConfig,
+} from '../shared/web-search-config.js';
 
-export type SearchProviderMode = SearchProviderName | 'auto';
 export type SearchFreshness = 'day' | 'week' | 'month' | 'year';
 
 export interface SearchProvider {
@@ -84,26 +88,7 @@ export interface SearchResult {
   age?: string;
 }
 
-export interface WebSearchConfig {
-  provider: SearchProviderMode;
-  fallbackProviders: SearchProviderName[];
-  defaultCount: number;
-  cacheTtlMinutes: number;
-  searxngBaseUrl: string;
-  tavilySearchDepth: 'basic' | 'advanced';
-  braveApiKey?: string;
-  perplexityApiKey?: string;
-  tavilyApiKey?: string;
-}
-
-export interface WebSearchRuntimeConfig {
-  provider: SearchProviderMode;
-  fallbackProviders: SearchProviderName[];
-  defaultCount: number;
-  cacheTtlMinutes: number;
-  searxngBaseUrl: string;
-  tavilySearchDepth: 'basic' | 'advanced';
-}
+export type WebSearchRuntimeConfig = WebSearchConfig;
 
 export interface WebSearchParams {
   query: string;
@@ -404,6 +389,15 @@ export function getWebSearchConfigFromEnv(
               ? 'basic'
               : 'advanced',
         }
+      : {}),
+    ...(override?.braveApiKey != null
+      ? { braveApiKey: String(override.braveApiKey || '').trim() }
+      : {}),
+    ...(override?.perplexityApiKey != null
+      ? { perplexityApiKey: String(override.perplexityApiKey || '').trim() }
+      : {}),
+    ...(override?.tavilyApiKey != null
+      ? { tavilyApiKey: String(override.tavilyApiKey || '').trim() }
       : {}),
   };
 }

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -624,15 +624,6 @@ function getOrSpawnContainer(
     'HYBRIDCLAW_AGENT_SANDBOX_MODE=container',
   ];
 
-  for (const [name, value] of [
-    ['BRAVE_API_KEY', BRAVE_API_KEY],
-    ['PERPLEXITY_API_KEY', PERPLEXITY_API_KEY],
-    ['TAVILY_API_KEY', TAVILY_API_KEY],
-  ] as const) {
-    if (!value) continue;
-    args.push('-e', `${name}=${value}`);
-  }
-
   // Run as host user so bind-mount file ownership matches
   const hostUid = process.getuid?.();
   const hostGid = process.getgid?.();
@@ -930,6 +921,9 @@ async function runContainerInner(
       cacheTtlMinutes: WEB_SEARCH_CACHE_TTL_MINUTES,
       searxngBaseUrl: WEB_SEARCH_SEARXNG_BASE_URL,
       tavilySearchDepth: WEB_SEARCH_TAVILY_SEARCH_DEPTH,
+      braveApiKey: BRAVE_API_KEY,
+      perplexityApiKey: PERPLEXITY_API_KEY,
+      tavilyApiKey: TAVILY_API_KEY,
     },
     persistBashState: CONTAINER_PERSIST_BASH_STATE,
     escalationTarget,

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -2,6 +2,7 @@ import { type ChildProcess, spawn } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { buildSanitizedEnv } from '../../container/shared/sensitive-env.js';
 import type { ExecutorRequest } from '../agent/executor-types.js';
 import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import { resolveGoogleWorkspaceRuntimeEnv } from '../auth/google-auth.js';
@@ -488,7 +489,7 @@ function getOrSpawnHostProcess(
   }
   const agentBrowserBin = resolveHostAgentBrowserBinary();
   const env: NodeJS.ProcessEnv = {
-    ...process.env,
+    ...buildSanitizedEnv(process.env),
     HYBRIDCLAW_AGENT_SANDBOX_MODE: 'host',
     HYBRIDAI_BASE_URL,
     HYBRIDAI_MODEL,
@@ -507,9 +508,6 @@ function getOrSpawnHostProcess(
     ),
     HYBRIDCLAW_WEB_SEARCH_TAVILY_SEARCH_DEPTH: WEB_SEARCH_TAVILY_SEARCH_DEPTH,
     SEARXNG_BASE_URL: WEB_SEARCH_SEARXNG_BASE_URL,
-    BRAVE_API_KEY,
-    PERPLEXITY_API_KEY,
-    TAVILY_API_KEY,
     HYBRIDCLAW_AGENT_ID: agentId,
     HYBRIDCLAW_AGENT_WORKSPACE_ROOT: workspacePath,
     HYBRIDCLAW_AGENT_WORKSPACE_DISPLAY_ROOT:
@@ -816,6 +814,9 @@ async function runHostProcessInner(
       cacheTtlMinutes: WEB_SEARCH_CACHE_TTL_MINUTES,
       searxngBaseUrl: WEB_SEARCH_SEARXNG_BASE_URL,
       tavilySearchDepth: WEB_SEARCH_TAVILY_SEARCH_DEPTH,
+      braveApiKey: BRAVE_API_KEY,
+      perplexityApiKey: PERPLEXITY_API_KEY,
+      tavilyApiKey: TAVILY_API_KEY,
     },
     persistBashState: CONTAINER_PERSIST_BASH_STATE,
     escalationTarget,

--- a/src/infra/ipc.ts
+++ b/src/infra/ipc.ts
@@ -42,6 +42,18 @@ function redactTaskModelSecrets(
   return Object.keys(redacted).length > 0 ? redacted : undefined;
 }
 
+function redactWebSearchSecrets(
+  webSearch: ContainerInput['webSearch'],
+): ContainerInput['webSearch'] | undefined {
+  if (!webSearch) return undefined;
+  return {
+    ...webSearch,
+    braveApiKey: undefined,
+    perplexityApiKey: undefined,
+    tavilyApiKey: undefined,
+  };
+}
+
 export function agentWorkspaceDir(agentId: string): string {
   return path.join(agentDir(agentId), 'workspace');
 }
@@ -79,6 +91,7 @@ export function writeInput(
         apiKey: '',
         requestHeaders: {},
         taskModels: redactTaskModelSecrets(input.taskModels),
+        webSearch: redactWebSearchSecrets(input.webSearch),
       }
     : input;
   fs.writeFileSync(inputPath, JSON.stringify(toWrite, null, 2), {

--- a/src/types/container.ts
+++ b/src/types/container.ts
@@ -1,3 +1,4 @@
+import type { WebSearchConfig } from '../../container/shared/web-search-config.js';
 import type { ChatMessage } from './api.js';
 import type {
   ArtifactMetadata,
@@ -29,26 +30,7 @@ export interface MediaContextItem {
   filename: string;
 }
 
-export interface WebSearchConfig {
-  provider:
-    | 'auto'
-    | 'brave'
-    | 'perplexity'
-    | 'tavily'
-    | 'duckduckgo'
-    | 'searxng';
-  fallbackProviders: (
-    | 'brave'
-    | 'perplexity'
-    | 'tavily'
-    | 'duckduckgo'
-    | 'searxng'
-  )[];
-  defaultCount: number;
-  cacheTtlMinutes: number;
-  searxngBaseUrl: string;
-  tavilySearchDepth: 'basic' | 'advanced';
-}
+export type { WebSearchConfig } from '../../container/shared/web-search-config.js';
 
 export interface ContainerInput {
   sessionId: string;

--- a/tests/container.bash-tool.test.ts
+++ b/tests/container.bash-tool.test.ts
@@ -88,6 +88,30 @@ describe.sequential('container bash tool persistence', () => {
     expect(result).toBe('persisted');
   });
 
+  test('does not expose ambient credential variables to host bash calls', async () => {
+    vi.stubEnv('OPENAI_API_KEY', 'openai-secret');
+    vi.stubEnv('ANTHROPIC_API_KEY', 'anthropic-secret');
+    vi.stubEnv('AWS_ACCESS_KEY_ID', 'aws-access-key');
+    vi.stubEnv('AWS_SECRET_ACCESS_KEY', 'aws-secret-key');
+    vi.stubEnv('AWS_SESSION_TOKEN', 'aws-session-token');
+    vi.stubEnv('GITHUB_TOKEN', 'github-token');
+    vi.stubEnv('BRAVE_API_KEY', 'brave-secret');
+    vi.stubEnv('HYBRIDCLAW_TEST_VISIBLE', 'visible');
+
+    const { executeTool } = await createBashTestRuntime({
+      sessionId: `bash-session-sanitized-env-${Date.now()}`,
+    });
+
+    const result = await executeTool(
+      'bash',
+      bashCommand(
+        'printf "%s|%s|%s|%s|%s|%s|%s|%s" "$OPENAI_API_KEY" "$ANTHROPIC_API_KEY" "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY" "$AWS_SESSION_TOKEN" "$GITHUB_TOKEN" "$BRAVE_API_KEY" "$HYBRIDCLAW_TEST_VISIBLE"',
+      ),
+    );
+
+    expect(result).toBe('|||||||visible');
+  });
+
   test('persists aliases across bash calls', async () => {
     const { executeTool } = await createBashTestRuntime({
       sessionId: `bash-session-alias-${Date.now()}`,

--- a/tests/container.web-search-config.test.ts
+++ b/tests/container.web-search-config.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+test('setWebSearchConfig warns before clearing runtime-only provider keys', async () => {
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const { setWebSearchConfig } = await import('../container/src/tools.js');
+
+  setWebSearchConfig({
+    provider: 'auto',
+    fallbackProviders: [],
+    defaultCount: 5,
+    cacheTtlMinutes: 5,
+    searxngBaseUrl: '',
+    tavilySearchDepth: 'advanced',
+    braveApiKey: 'brave-secret',
+  });
+  setWebSearchConfig(undefined);
+
+  expect(warn).toHaveBeenCalledWith(
+    '[web-search] runtime config cleared; provider API keys supplied through runtime config will be unavailable until a new config arrives.',
+  );
+});

--- a/tests/host-runner.redaction.test.ts
+++ b/tests/host-runner.redaction.test.ts
@@ -50,6 +50,7 @@ afterEach(() => {
   vi.doUnmock('../src/infra/ipc.js');
   vi.doUnmock('../src/providers/factory.js');
   vi.doUnmock('../src/logger.js');
+  vi.unstubAllEnvs();
   vi.resetModules();
   restoreEnvVar('HOME', ORIGINAL_HOME);
 });
@@ -434,6 +435,126 @@ test('HostExecutor exposes the uploaded media cache root to host agent processes
   expect(JSON.parse(spawnEnv?.HYBRIDCLAW_AGENT_ALLOWED_ROOTS || '[]')).toEqual(
     expect.arrayContaining([os.homedir(), process.cwd(), os.tmpdir()]),
   );
+});
+
+test('HostExecutor strips ambient credentials from host agent process env', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.stubEnv('OPENAI_API_KEY', 'openai-secret');
+  vi.stubEnv('ANTHROPIC_API_KEY', 'anthropic-secret');
+  vi.stubEnv('AWS_ACCESS_KEY_ID', 'aws-access-key');
+  vi.stubEnv('AWS_SECRET_ACCESS_KEY', 'aws-secret-key');
+  vi.stubEnv('AWS_SESSION_TOKEN', 'aws-session-token');
+  vi.stubEnv('GITHUB_TOKEN', 'github-token');
+  vi.stubEnv('GH_TOKEN', 'gh-token');
+  vi.stubEnv('CUSTOM_SERVICE_API_KEY', 'custom-service-key');
+  vi.stubEnv('CUSTOM_PASSWORD', 'custom-password');
+  vi.stubEnv('SSH_AUTH_SOCK', '/tmp/ssh-agent.sock');
+  vi.stubEnv('BRAVE_API_KEY', 'brave-secret');
+  vi.stubEnv('PERPLEXITY_API_KEY', 'perplexity-secret');
+  vi.stubEnv('TAVILY_API_KEY', 'tavily-secret');
+  vi.stubEnv('HYBRIDCLAW_TEST_VISIBLE', 'visible');
+  vi.resetModules();
+
+  const proc = makeFakeChildProcess();
+  const spawn = vi.fn(() => proc as never);
+  const readOutput = vi.fn(async () => ({
+    status: 'success' as const,
+    result: 'ok',
+    toolsUsed: [],
+    artifacts: [],
+  }));
+  const resolveModelRuntimeCredentials = vi.fn(async () => ({
+    provider: 'hybridai' as const,
+    apiKey: '',
+    baseUrl: 'https://hybridai.one',
+    chatbotId: 'bot-a',
+    enableRag: false,
+    requestHeaders: {},
+    agentId: 'default',
+    isLocal: false,
+    contextWindow: 128_000,
+    thinkingFormat: undefined,
+  }));
+
+  vi.doMock('node:child_process', async () => {
+    const actual =
+      await vi.importActual<typeof import('node:child_process')>(
+        'node:child_process',
+      );
+    return {
+      ...actual,
+      spawn,
+    };
+  });
+  vi.doMock('../src/infra/ipc.js', async () => {
+    const actual = await vi.importActual<typeof import('../src/infra/ipc.js')>(
+      '../src/infra/ipc.js',
+    );
+    return {
+      ...actual,
+      readOutput,
+    };
+  });
+  vi.doMock('../src/providers/factory.js', async () => {
+    const actual = await vi.importActual<
+      typeof import('../src/providers/factory.js')
+    >('../src/providers/factory.js');
+    return {
+      ...actual,
+      resolveModelRuntimeCredentials,
+    };
+  });
+  vi.doMock('../src/logger.js', () => ({
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  }));
+  mockHostRuntimeReady();
+
+  const { HostExecutor } = await import('../src/infra/host-runner.js');
+  const executor = new HostExecutor();
+
+  await executor.exec({
+    sessionId: 'session-sanitized-env',
+    messages: [{ role: 'user', content: 'hello' }],
+    chatbotId: 'bot-a',
+    enableRag: false,
+    model: 'gpt-5',
+    agentId: 'default',
+    channelId: 'web',
+  });
+
+  const spawnEnv = spawn.mock.calls[0]?.[2]?.env as
+    | NodeJS.ProcessEnv
+    | undefined;
+  expect(spawnEnv?.HYBRIDCLAW_AGENT_SANDBOX_MODE).toBe('host');
+  expect(spawnEnv?.HYBRIDCLAW_TEST_VISIBLE).toBe('visible');
+  expect(spawnEnv?.OPENAI_API_KEY).toBeUndefined();
+  expect(spawnEnv?.ANTHROPIC_API_KEY).toBeUndefined();
+  expect(spawnEnv?.AWS_ACCESS_KEY_ID).toBeUndefined();
+  expect(spawnEnv?.AWS_SECRET_ACCESS_KEY).toBeUndefined();
+  expect(spawnEnv?.AWS_SESSION_TOKEN).toBeUndefined();
+  expect(spawnEnv?.GITHUB_TOKEN).toBeUndefined();
+  expect(spawnEnv?.GH_TOKEN).toBeUndefined();
+  expect(spawnEnv?.CUSTOM_SERVICE_API_KEY).toBeUndefined();
+  expect(spawnEnv?.CUSTOM_PASSWORD).toBeUndefined();
+  expect(spawnEnv?.SSH_AUTH_SOCK).toBeUndefined();
+  expect(spawnEnv?.BRAVE_API_KEY).toBeUndefined();
+  expect(spawnEnv?.PERPLEXITY_API_KEY).toBeUndefined();
+  expect(spawnEnv?.TAVILY_API_KEY).toBeUndefined();
+
+  const firstInput = JSON.parse(
+    String(proc.stdin.write.mock.calls[0]?.[0] || '').trim(),
+  ) as { webSearch?: Record<string, unknown> };
+  expect(firstInput.webSearch).toMatchObject({
+    braveApiKey: 'brave-secret',
+    perplexityApiKey: 'perplexity-secret',
+    tavilyApiKey: 'tavily-secret',
+  });
 });
 
 test('HostExecutor disables internal text streaming when no text callback is provided', async () => {

--- a/tests/ipc.test.ts
+++ b/tests/ipc.test.ts
@@ -64,6 +64,17 @@ test('writeInput omits auth material from IPC files when requested', async () =>
         maxTokens: 123,
       },
     },
+    webSearch: {
+      provider: 'auto' as const,
+      fallbackProviders: ['brave' as const],
+      defaultCount: 5,
+      cacheTtlMinutes: 5,
+      searxngBaseUrl: '',
+      tavilySearchDepth: 'advanced' as const,
+      braveApiKey: 'brave-secret',
+      perplexityApiKey: 'perplexity-secret',
+      tavilyApiKey: 'tavily-secret',
+    },
   };
 
   ensureSessionDirs('session-1');
@@ -91,9 +102,18 @@ test('writeInput omits auth material from IPC files when requested', async () =>
       maxTokens: 123,
     },
   });
+  expect(written.webSearch).toEqual({
+    provider: 'auto',
+    fallbackProviders: ['brave'],
+    defaultCount: 5,
+    cacheTtlMinutes: 5,
+    searxngBaseUrl: '',
+    tavilySearchDepth: 'advanced',
+  });
   expect(input.apiKey).toBe('token_secret');
   expect(input.requestHeaders.Authorization).toBe('Bearer token_secret');
   expect(input.taskModels.compression.apiKey).toBe('or-secret');
+  expect(input.webSearch.braveApiKey).toBe('brave-secret');
 });
 
 test('readOutput enforces a hard deadline despite repeated activity', async () => {

--- a/tests/sensitive-env.test.ts
+++ b/tests/sensitive-env.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from 'vitest';
+
+import {
+  buildSanitizedEnv,
+  isSensitiveEnvName,
+} from '../container/shared/sensitive-env.js';
+
+test('buildSanitizedEnv rejects invalid source environments', () => {
+  expect(() =>
+    buildSanitizedEnv(null as unknown as Record<string, string | undefined>),
+  ).toThrow(TypeError);
+  expect(() =>
+    buildSanitizedEnv(
+      undefined as unknown as Record<string, string | undefined>,
+    ),
+  ).toThrow('buildSanitizedEnv: sourceEnv must be an object');
+});
+
+test('buildSanitizedEnv strips exact and pattern-matched credential names', () => {
+  const sanitized = buildSanitizedEnv({
+    ANTHROPIC_API_KEY: 'anthropic-secret',
+    OPENAI_API_KEY: 'openai-secret',
+    AWS_REGION: 'us-east-1',
+    GITHUB_TOKEN: 'github-secret',
+    HYBRIDCLAW_TEST_VISIBLE: 'visible',
+  });
+
+  expect(sanitized).toEqual({
+    HYBRIDCLAW_TEST_VISIBLE: 'visible',
+  });
+  expect(isSensitiveEnvName('OPENAI_API_KEY')).toBe(true);
+  expect(isSensitiveEnvName('ANTHROPIC_API_KEY')).toBe(true);
+});

--- a/tests/unit/web-search.test.ts
+++ b/tests/unit/web-search.test.ts
@@ -107,6 +107,9 @@ describe('provider chain', () => {
       cacheTtlMinutes: 9,
       searxngBaseUrl: 'https://search.example.com',
       tavilySearchDepth: 'basic',
+      braveApiKey: 'brave-override',
+      perplexityApiKey: 'perplexity-override',
+      tavilyApiKey: 'tavily-override',
     });
 
     expect(config.provider).toBe('auto');
@@ -115,6 +118,9 @@ describe('provider chain', () => {
     expect(config.cacheTtlMinutes).toBe(9);
     expect(config.searxngBaseUrl).toBe('https://search.example.com');
     expect(config.tavilySearchDepth).toBe('basic');
+    expect(config.braveApiKey).toBe('brave-override');
+    expect(config.perplexityApiKey).toBe('perplexity-override');
+    expect(config.tavilyApiKey).toBe('tavily-override');
   });
 });
 


### PR DESCRIPTION
## Summary

- scrub ambient credential-like variables from host agent process environments
- keep web-search provider keys out of process env by passing them through runtime config instead
- redact web-search keys from subsequent IPC input files and prevent host bash calls from inheriting common credential variables

## Why

The host runtime was spawned from the broad parent environment, so LLM-controlled host processes could inherit unrelated credentials such as OpenAI, Anthropic, AWS, and GitHub tokens. This changes the default to deny common secret env patterns while preserving explicit runtime config needed by the agent.

## Validation

- `npm run format`
- `biome check --write` on touched container/test files
- `vitest run tests/host-runner.redaction.test.ts tests/ipc.test.ts tests/unit/web-search.test.ts tests/container.bash-tool.test.ts`
- `npm run typecheck`
- `npm --prefix container run lint`
- `npm run lint`
- `npm run build`
- `git diff --check`