### PR TITLE
[codex] secure default localhost web auth

### DIFF
--- a/src/gateway/auth-token.ts
+++ b/src/gateway/auth-token.ts
@@ -1,10 +1,12 @@
-import { createHmac, timingSafeEqual } from 'node:crypto';
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
 import fs from 'node:fs';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
 const AUTH_SECRET_FILE = '/run/secrets/hybridclaw_auth_secret';
 export const SESSION_COOKIE_NAME = 'hybridclaw_session';
 export const SESSION_TTL_SECONDS = 24 * 60 * 60;
+export const LOCAL_WEB_SESSION_COOKIE_NAME = 'hybridclaw_local_session';
+export const LOCAL_WEB_SESSION_TTL_SECONDS = 12 * 60 * 60;
 
 export interface VerifiedAuthTokenPayload extends Record<string, unknown> {
   exp: number;
@@ -153,6 +155,8 @@ function requireVerifiedToken(token: string): VerifiedAuthTokenPayload {
   return payload;
 }
 
+const localWebSessionSecret = randomBytes(32).toString('hex');
+
 function signPayload(payload: Record<string, unknown>, secret: string): string {
   const payloadSegment = Buffer.from(JSON.stringify(payload)).toString(
     'base64url',
@@ -200,6 +204,23 @@ function appendSetCookie(res: ServerResponse, cookie: string): void {
   res.setHeader('Set-Cookie', [String(existing), cookie]);
 }
 
+function buildSessionCookieValue(params: {
+  name: string;
+  token: string;
+  ttlSeconds: number;
+  expiresAtSeconds: number;
+  sameSite: 'Lax' | 'Strict';
+}): string {
+  return [
+    `${params.name}=${params.token}`,
+    'Path=/',
+    `Max-Age=${params.ttlSeconds}`,
+    `Expires=${new Date(params.expiresAtSeconds * 1000).toUTCString()}`,
+    'HttpOnly',
+    `SameSite=${params.sameSite}`,
+  ].join('; ');
+}
+
 export function verifyLaunchToken(token: string): VerifiedAuthTokenPayload {
   return requireVerifiedToken(token);
 }
@@ -220,6 +241,41 @@ export function getSessionAuthPayload(
 
 export function hasSessionAuth(req: IncomingMessage): boolean {
   return getSessionAuthPayload(req) !== null;
+}
+
+export function hasLocalWebSessionAuth(req: IncomingMessage): boolean {
+  const token = extractCookieValue(
+    req.headers.cookie,
+    LOCAL_WEB_SESSION_COOKIE_NAME,
+  );
+  if (!token) return false;
+
+  const payload = verifySignedToken(token, localWebSessionSecret);
+  return payload?.typ === 'local-web-session';
+}
+
+export function setLocalWebSessionCookie(res: ServerResponse): void {
+  const issuedAt = Math.floor(Date.now() / 1000);
+  const expiresAt = issuedAt + LOCAL_WEB_SESSION_TTL_SECONDS;
+  const token = signPayload(
+    {
+      exp: expiresAt,
+      iat: issuedAt,
+      typ: 'local-web-session',
+    },
+    localWebSessionSecret,
+  );
+
+  appendSetCookie(
+    res,
+    buildSessionCookieValue({
+      name: LOCAL_WEB_SESSION_COOKIE_NAME,
+      token,
+      ttlSeconds: LOCAL_WEB_SESSION_TTL_SECONDS,
+      expiresAtSeconds: expiresAt,
+      sameSite: 'Strict',
+    }),
+  );
 }
 
 export function setSessionCookie(
@@ -245,13 +301,12 @@ export function setSessionCookie(
 
   appendSetCookie(
     res,
-    [
-      `${SESSION_COOKIE_NAME}=${token}`,
-      'Path=/',
-      `Max-Age=${SESSION_TTL_SECONDS}`,
-      `Expires=${new Date(expiresAt * 1000).toUTCString()}`,
-      'HttpOnly',
-      'SameSite=Lax',
-    ].join('; '),
+    buildSessionCookieValue({
+      name: SESSION_COOKIE_NAME,
+      token,
+      ttlSeconds: SESSION_TTL_SECONDS,
+      expiresAtSeconds: expiresAt,
+      sameSite: 'Lax',
+    }),
   );
 }

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -88,7 +88,9 @@ import {
 import type { AdminTerminalServerMessage } from './admin-terminal-protocol.js';
 import {
   getSessionAuthPayload,
+  hasLocalWebSessionAuth,
   hasSessionAuth,
+  setLocalWebSessionCookie,
   setSessionCookie,
   verifyLaunchToken,
 } from './auth-token.js';
@@ -654,10 +656,93 @@ function hasQueryToken(url: URL): boolean {
   return token === GATEWAY_API_TOKEN;
 }
 
+function isLoopbackSocketAddress(address: string | undefined): boolean {
+  if (!address) return false;
+  if (address === '::1') return true;
+  if (address.startsWith('::ffff:')) {
+    const mappedAddress = address.slice('::ffff:'.length);
+    return (
+      mappedAddress === '127.0.0.1' ||
+      /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(mappedAddress)
+    );
+  }
+  if (address === '127.0.0.1') return true;
+  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(address);
+}
+
+function isLoopbackHost(value: string): boolean {
+  const host = value.trim().toLowerCase();
+  if (!host) return false;
+  if (host === 'localhost') return true;
+  return isLoopbackSocketAddress(host);
+}
+
+function hasForwardingHeaders(req: IncomingMessage): boolean {
+  return (
+    req.headers.forwarded !== undefined ||
+    req.headers['x-forwarded-for'] !== undefined ||
+    req.headers['x-forwarded-host'] !== undefined ||
+    req.headers['x-forwarded-proto'] !== undefined
+  );
+}
+
+function extractHostnameFromHostHeader(
+  value: string | string[] | undefined,
+): string | null {
+  const host = normalizeHeaderValue(value);
+  if (!host) return null;
+  if (host.startsWith('[')) {
+    const endIndex = host.indexOf(']');
+    if (endIndex === -1) return null;
+    return host.slice(1, endIndex).trim().toLowerCase() || null;
+  }
+  const colonIndex = host.indexOf(':');
+  return (colonIndex === -1 ? host : host.slice(0, colonIndex))
+    .trim()
+    .toLowerCase();
+}
+
+function isLocalWebSessionAllowed(req: IncomingMessage): boolean {
+  const requestHost = extractHostnameFromHostHeader(req.headers.host);
+  return (
+    !WEB_API_TOKEN &&
+    isLoopbackHost(HEALTH_HOST) &&
+    isLoopbackSocketAddress(req.socket.remoteAddress) &&
+    !hasForwardingHeaders(req) &&
+    Boolean(requestHost && isLoopbackHost(requestHost))
+  );
+}
+
+function requestUsesHttps(req: IncomingMessage): boolean {
+  const forwardedProto = String(req.headers['x-forwarded-proto'] || '')
+    .split(',')[0]
+    ?.trim()
+    .toLowerCase();
+  if (forwardedProto) return forwardedProto === 'https';
+  return (req.socket as { encrypted?: boolean }).encrypted === true;
+}
+
+function resolveRequestOriginForAuth(req: IncomingMessage): string | null {
+  const host = String(req.headers.host || '').trim();
+  if (!host) return null;
+  const protocol = requestUsesHttps(req) ? 'https' : 'http';
+  return `${protocol}://${host}`;
+}
+
+function hasSameGatewayOrigin(req: IncomingMessage): boolean {
+  const origin = String(req.headers.origin || '').trim();
+  if (!origin) return false;
+  return origin === resolveRequestOriginForAuth(req);
+}
+
 function hasApiAuth(
   req: IncomingMessage,
   url?: URL,
-  opts?: { allowQueryToken?: boolean },
+  opts?: {
+    allowLocalWebSession?: boolean;
+    allowQueryToken?: boolean;
+    requireSameOrigin?: boolean;
+  },
 ): boolean {
   const authHeader = req.headers.authorization || '';
   const gatewayTokenMatch =
@@ -665,6 +750,14 @@ function hasApiAuth(
   if (opts?.allowQueryToken && url && hasQueryToken(url)) return true;
 
   if (WEB_API_TOKEN && authHeader === `Bearer ${WEB_API_TOKEN}`) return true;
+  if (
+    opts?.allowLocalWebSession &&
+    isLocalWebSessionAllowed(req) &&
+    hasLocalWebSessionAuth(req) &&
+    (!opts.requireSameOrigin || hasSameGatewayOrigin(req))
+  ) {
+    return true;
+  }
   return gatewayTokenMatch;
 }
 
@@ -791,13 +884,10 @@ function resolveRequestOrigin(
   const explicitBaseUrl = normalizePublicBaseUrl(bodyBaseUrl);
   if (explicitBaseUrl) return explicitBaseUrl;
 
-  const forwardedProto = String(req.headers['x-forwarded-proto'] || '')
-    .split(',')[0]
-    ?.trim();
   const forwardedHost = String(req.headers['x-forwarded-host'] || '')
     .split(',')[0]
     ?.trim();
-  const proto = forwardedProto || 'http';
+  const proto = requestUsesHttps(req) ? 'https' : 'http';
   const host = forwardedHost || req.headers.host || `127.0.0.1:${HEALTH_PORT}`;
   return `${proto}://${host}`;
 }
@@ -823,6 +913,14 @@ function isConsoleSpaPath(pathname: string): boolean {
     pathname.startsWith('/admin/') ||
     pathname === '/chat' ||
     pathname.startsWith('/chat/')
+  );
+}
+
+function isLocalWebSurfacePath(pathname: string): boolean {
+  return (
+    isConsoleSpaPath(pathname) ||
+    pathname === '/agents' ||
+    pathname === '/agents.html'
   );
 }
 
@@ -1882,7 +1980,7 @@ function handleApiAgentAvatar(
   res: ServerResponse,
   url: URL,
 ): void {
-  if (!hasApiAuth(req, url)) {
+  if (!hasApiAuth(req, url, { allowLocalWebSession: true })) {
     sendJson(res, 401, {
       error: 'Unauthorized. Set `Authorization: Bearer <WEB_API_TOKEN>`.',
     });
@@ -3477,7 +3575,12 @@ function handleApiArtifact(
   res: ServerResponse,
   url: URL,
 ): void {
-  if (!hasApiAuth(req, url, { allowQueryToken: true })) {
+  if (
+    !hasApiAuth(req, url, {
+      allowLocalWebSession: true,
+      allowQueryToken: true,
+    })
+  ) {
     sendJson(res, 401, {
       error:
         'Unauthorized. Set `Authorization: Bearer <WEB_API_TOKEN>` or pass `?token=<WEB_API_TOKEN>`.',
@@ -3723,6 +3826,8 @@ export function startGatewayHttpServer(): GatewayHttpServer {
       if (
         !hasApiAuth(req, url, {
           allowQueryToken: pathname === '/api/events',
+          allowLocalWebSession: true,
+          requireSameOrigin: method !== 'GET',
         })
       ) {
         sendJson(res, 401, {
@@ -4031,6 +4136,20 @@ export function startGatewayHttpServer(): GatewayHttpServer {
       return;
     }
 
+    if (isLocalWebSurfacePath(pathname)) {
+      if (!WEB_API_TOKEN && !isLoopbackHost(HEALTH_HOST)) {
+        sendText(
+          res,
+          401,
+          'Unauthorized. Configure WEB_API_TOKEN before exposing the web console on a non-loopback host.',
+        );
+        return;
+      }
+      if (isLocalWebSessionAllowed(req)) {
+        setLocalWebSessionCookie(res);
+      }
+    }
+
     if (isConsoleSpaPath(pathname)) {
       if (serveConsoleIndex(res)) return;
       sendText(
@@ -4059,8 +4178,23 @@ export function startGatewayHttpServer(): GatewayHttpServer {
     }
 
     const sessionAuthenticated = hasSessionAuth(req);
+    const tokenAuthenticated = hasApiAuth(req, url, {
+      allowQueryToken: false,
+    });
+    if (
+      !sessionAuthenticated &&
+      !tokenAuthenticated &&
+      isLocalWebSessionAllowed(req) &&
+      hasLocalWebSessionAuth(req) &&
+      !hasSameGatewayOrigin(req)
+    ) {
+      writeUpgradeError(socket, 401, 'Unauthorized');
+      return;
+    }
     const requestAuthenticated = hasApiAuth(req, url, {
       allowQueryToken: false,
+      allowLocalWebSession: true,
+      requireSameOrigin: true,
     });
     if (
       !sessionAuthenticated &&

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -376,6 +376,35 @@ function makeResponse() {
   return response;
 }
 
+function getSetCookieHeader(res: ReturnType<typeof makeResponse>): string {
+  const value = res.getHeader('Set-Cookie');
+  if (Array.isArray(value)) return value.join('; ');
+  return String(value || '');
+}
+
+function getCookiePair(setCookie: string, cookieName: string): string {
+  return (
+    setCookie
+      .split(/,\s*|\s*;\s*/)
+      .find((segment) => segment.startsWith(`${cookieName}=`)) || ''
+  );
+}
+
+function issueLocalWebSessionCookie(
+  state: Awaited<ReturnType<typeof importFreshHealth>>,
+): string {
+  const req = makeRequest({
+    url: '/chat',
+    headers: { host: 'localhost:9090' },
+    noAuth: true,
+  });
+  const res = makeResponse();
+
+  state.handler(req as never, res as never);
+
+  return getCookiePair(getSetCookieHeader(res), 'hybridclaw_local_session');
+}
+
 async function settle(): Promise<void> {
   await new Promise((resolve) => setImmediate(resolve));
   await new Promise((resolve) => setImmediate(resolve));
@@ -398,6 +427,7 @@ async function importFreshHealth(options?: {
   dataDir?: string;
   webApiToken?: string;
   gatewayApiToken?: string;
+  healthHost?: string;
   authSecret?: string;
   hybridAiBaseUrl?: string;
   runningInsideContainer?: boolean;
@@ -1459,7 +1489,7 @@ async function importFreshHealth(options?: {
     DATA_DIR: dataDir,
     GATEWAY_API_TOKEN:
       options?.gatewayApiToken ?? DEFAULT_TEST_GATEWAY_API_TOKEN,
-    HEALTH_HOST: '127.0.0.1',
+    HEALTH_HOST: options?.healthHost || '127.0.0.1',
     HEALTH_PORT: 9090,
     HYBRIDAI_BASE_URL: options?.hybridAiBaseUrl || 'https://hybridai.one',
     HYBRIDAI_MODEL: 'gpt-5',
@@ -1816,8 +1846,172 @@ describe('gateway HTTP server', () => {
     expect(res.body).toBe('voice-webhook');
   });
 
-  test('rejects unauthenticated API requests even from loopback addresses', async () => {
+  test('issues a local web-session cookie for loopback console pages when WEB_API_TOKEN is unset', async () => {
     const state = await importFreshHealth();
+    const req = makeRequest({
+      url: '/chat',
+      headers: { host: 'localhost:9090' },
+      noAuth: true,
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(getSetCookieHeader(res)).toContain('hybridclaw_local_session=');
+    expect(getSetCookieHeader(res)).toContain('HttpOnly');
+    expect(getSetCookieHeader(res)).toContain('SameSite=Strict');
+  });
+
+  test('does not issue a local web-session cookie for non-loopback request hosts', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({
+      url: '/chat',
+      headers: { host: 'example.com' },
+      noAuth: true,
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(getSetCookieHeader(res)).toBe('');
+  });
+
+  test('does not issue a local web-session cookie with forwarding headers', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({
+      url: '/chat',
+      headers: { host: 'localhost:9090', 'x-forwarded-for': '203.0.113.10' },
+      noAuth: true,
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(getSetCookieHeader(res)).toBe('');
+  });
+
+  test('rejects unauthenticated console pages when the gateway bind host is not loopback', async () => {
+    const state = await importFreshHealth({ healthHost: '0.0.0.0' });
+    const req = makeRequest({
+      url: '/chat',
+      headers: { host: 'localhost:9090' },
+      noAuth: true,
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toContain('Configure WEB_API_TOKEN');
+    expect(getSetCookieHeader(res)).toBe('');
+  });
+
+  test('rejects API requests from loopback without bearer auth or local web-session cookie', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({
+      url: '/api/status',
+      noAuth: true,
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Unauthorized. Set `Authorization: Bearer <WEB_API_TOKEN>`.',
+    });
+  });
+
+  test('allows API requests with a local web-session cookie when WEB_API_TOKEN is unset', async () => {
+    const state = await importFreshHealth();
+    const cookie = issueLocalWebSessionCookie(state);
+    const req = makeRequest({
+      url: '/api/status',
+      headers: { cookie, host: 'localhost:9090' },
+      noAuth: true,
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual(
+      expect.objectContaining({ status: 'ok' }),
+    );
+  });
+
+  test('rejects local web-session API auth with forwarding headers', async () => {
+    const state = await importFreshHealth();
+    const cookie = issueLocalWebSessionCookie(state);
+    const req = makeRequest({
+      url: '/api/status',
+      headers: {
+        cookie,
+        host: 'localhost:9090',
+        'x-forwarded-for': '203.0.113.10',
+      },
+      noAuth: true,
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Unauthorized. Set `Authorization: Bearer <WEB_API_TOKEN>`.',
+    });
+  });
+
+  test('rejects unsafe local web-session API requests without same-origin headers', async () => {
+    const state = await importFreshHealth();
+    const cookie = issueLocalWebSessionCookie(state);
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/admin/config/reload',
+      headers: { cookie, host: 'localhost:9090' },
+      noAuth: true,
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Unauthorized. Set `Authorization: Bearer <WEB_API_TOKEN>`.',
+    });
+  });
+
+  test('allows unsafe local web-session API requests with a matching origin', async () => {
+    const state = await importFreshHealth();
+    const cookie = issueLocalWebSessionCookie(state);
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/admin/config/reload',
+      headers: {
+        cookie,
+        host: 'localhost:9090',
+        origin: 'http://localhost:9090',
+      },
+      noAuth: true,
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(200);
+    expect(state.reloadRuntimeConfig).toHaveBeenCalledWith('admin-api');
+  });
+
+  test('requires API auth from loopback when WEB_API_TOKEN is configured', async () => {
+    const state = await importFreshHealth({ webApiToken: 'web-token' });
     const req = makeRequest({
       url: '/api/status',
       noAuth: true,
@@ -1852,11 +2046,12 @@ describe('gateway HTTP server', () => {
     });
   });
 
-  test('rejects an empty bearer token when WEB_API_TOKEN is unset', async () => {
+  test('allows an empty bearer token with a local web-session cookie when WEB_API_TOKEN is unset', async () => {
     const state = await importFreshHealth();
+    const cookie = issueLocalWebSessionCookie(state);
     const req = makeRequest({
       url: '/api/status',
-      headers: { authorization: 'Bearer ' },
+      headers: { authorization: 'Bearer ', cookie, host: 'localhost:9090' },
       noAuth: true,
     });
     const res = makeResponse();
@@ -1864,10 +2059,12 @@ describe('gateway HTTP server', () => {
     state.handler(req as never, res as never);
     await waitForResponse(res, (next) => next.writableEnded);
 
-    expect(res.statusCode).toBe(401);
-    expect(JSON.parse(res.body)).toEqual({
-      error: 'Unauthorized. Set `Authorization: Bearer <WEB_API_TOKEN>`.',
-    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual(
+      expect.objectContaining({
+        status: 'ok',
+      }),
+    );
   });
 
   test('rejects unauthorized OpenAI-compatible API requests from non-loopback addresses', async () => {
@@ -5200,6 +5397,71 @@ describe('gateway HTTP server', () => {
         method: 'GET',
         url: '/api/admin/terminal/stream?sessionId=terminal-session-1',
         remoteAddress: '10.0.0.5',
+        noAuth: true,
+      }) as never,
+      socket as never,
+      Buffer.alloc(0) as never,
+    );
+
+    expect(state.handleTerminalUpgrade).not.toHaveBeenCalled();
+    expect(String(socket.write.mock.calls[0]?.[0] || '')).toContain(
+      '401 Unauthorized',
+    );
+  });
+
+  test('allows terminal websocket upgrades with local web-session cookie and matching origin', async () => {
+    const state = await importFreshHealth();
+    const cookie = issueLocalWebSessionCookie(state);
+    const socket = {
+      write: vi.fn(),
+      destroy: vi.fn(),
+    };
+
+    state.upgradeHandler?.(
+      makeRequest({
+        method: 'GET',
+        url: '/api/admin/terminal/stream?sessionId=terminal-session-1',
+        headers: {
+          cookie,
+          host: 'localhost:9090',
+          origin: 'http://localhost:9090',
+        },
+        noAuth: true,
+      }) as never,
+      socket as never,
+      Buffer.alloc(0) as never,
+    );
+
+    expect(state.handleTerminalUpgrade).toHaveBeenCalledWith(
+      expect.anything(),
+      socket,
+      expect.any(Buffer),
+      expect.any(URL),
+      expect.objectContaining({
+        hasSessionAuth: false,
+        hasRequestAuth: true,
+        validateToken: expect.any(Function),
+      }),
+    );
+    expect(socket.write).not.toHaveBeenCalled();
+  });
+
+  test('rejects terminal websocket upgrades with local web-session cookie but no origin', async () => {
+    const state = await importFreshHealth();
+    const cookie = issueLocalWebSessionCookie(state);
+    const socket = {
+      write: vi.fn(),
+      destroy: vi.fn(),
+    };
+
+    state.upgradeHandler?.(
+      makeRequest({
+        method: 'GET',
+        url: '/api/admin/terminal/stream?sessionId=terminal-session-1',
+        headers: {
+          cookie,
+          host: 'localhost:9090',
+        },
         noAuth: true,
       }) as never,
       socket as never,


### PR DESCRIPTION
## Summary

Adds a secure out-of-the-box localhost auth path for the built-in web console and chat surfaces.

- Issues a process-local HttpOnly `hybridclaw_local_session` cookie for loopback `/chat`, `/admin`, and `/agents` page loads when `WEB_API_TOKEN` is unset.
- Requires either bearer auth or that local cookie for `/api/*`, with same-origin checks on unsafe API methods and admin terminal websocket upgrades.
- Rejects unauthenticated web console access when the gateway is bound to a non-loopback host without `WEB_API_TOKEN`.
- Leaves `/v1/*` OpenAI-compatible bearer-token behavior unchanged.

## Root Cause

The gateway generated a local `GATEWAY_API_TOKEN` by default, so the browser SPA could load from `/chat` but then failed when it called `/api/status` without bearer auth. That broke the documented localhost out-of-box flow.

## Validation

- `npx vitest run tests/gateway-http-server.test.ts`
- `npx vitest run tests/gateway-auth-token.test.ts`
- `npm run typecheck`
- `npm run lint`