### PR TITLE
[codex] Add adaptive warm process pool

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,5 @@
 {
-  "version": 25,
+  "version": 26,
   "security": {
     "trustModelAccepted": false,
     "trustModelAcceptedAt": "",
@@ -412,7 +412,15 @@
     "additionalMounts": "",
     "maxOutputBytes": 10485760,
     "maxConcurrent": 5,
-    "persistBashState": true
+    "persistBashState": true,
+    "warmPool": {
+      "enabled": true,
+      "coldStartBudgetMs": 200,
+      "trafficWindowMs": 3600000,
+      "minIdlePerActiveAgent": 1,
+      "maxIdlePerAgent": 2,
+      "memoryPressureRssMb": 2048
+    }
   },
   "mcpServers": {
     "filesystem": {

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -1694,6 +1694,8 @@ async function main(): Promise<void> {
   console.error(
     `[hybridclaw-agent] started, idle timeout ${IDLE_TIMEOUT_MS}ms`,
   );
+  // This marks runtime process readiness only. Request-specific MCP, plugin,
+  // media, and model setup still runs after input and before agent start.
   console.error('[hybridclaw-agent] ready for input');
   process.once('SIGINT', () => {
     void shutdownAgentProcess(0, 'SIGINT');

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -963,6 +963,7 @@ async function processRequest(
     escalationTarget,
   } = params;
   const processStartedAt = Date.now();
+  console.error('[hybridclaw-agent] agent request start');
   await emitRuntimeEvent({
     event: 'before_agent_start',
     messageCount: messages.length,
@@ -1693,6 +1694,7 @@ async function main(): Promise<void> {
   console.error(
     `[hybridclaw-agent] started, idle timeout ${IDLE_TIMEOUT_MS}ms`,
   );
+  console.error('[hybridclaw-agent] ready for input');
   process.once('SIGINT', () => {
     void shutdownAgentProcess(0, 'SIGINT');
   });

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -767,6 +767,7 @@ export const FULLAUTO_STALL_RECOVERY_DELAY_MS = 5_000;
 
 const DOCKER_ENV_PATH = '/.dockerenv';
 let sandboxAutoDetectLogged = '';
+let warmPoolClampWarningSignature = '';
 let sandboxModeOverride: RuntimeConfig['container']['sandboxMode'] | null =
   (() => {
     const raw = String(process.env.HYBRIDCLAW_SANDBOX_MODE_OVERRIDE || '')
@@ -813,6 +814,28 @@ function normalizeConfiguredBaseUrl(
     .trim()
     .replace(/\/+$/, '');
   return trimmed || fallback;
+}
+
+function warnIfWarmPoolMinIdleIsClamped(
+  config: RuntimeConfig['container']['warmPool'],
+): void {
+  if (!config.enabled) return;
+  if (config.minIdlePerActiveAgent <= config.maxIdlePerAgent) {
+    warmPoolClampWarningSignature = '';
+    return;
+  }
+
+  const signature = `${config.minIdlePerActiveAgent}:${config.maxIdlePerAgent}`;
+  if (warmPoolClampWarningSignature === signature) return;
+  warmPoolClampWarningSignature = signature;
+  logger.warn(
+    {
+      requestedMinIdlePerActiveAgent: config.minIdlePerActiveAgent,
+      maxIdlePerAgent: config.maxIdlePerAgent,
+      effectiveMinIdlePerActiveAgent: config.maxIdlePerAgent,
+    },
+    'Warm process pool minIdlePerActiveAgent exceeds maxIdlePerAgent; clamping effective minimum idle workers',
+  );
 }
 
 function applyRuntimeConfig(config: RuntimeConfig): void {
@@ -1059,6 +1082,7 @@ function applyRuntimeConfig(config: RuntimeConfig): void {
   CONTAINER_MAX_OUTPUT_SIZE = config.container.maxOutputBytes;
   MAX_CONCURRENT_CONTAINERS = Math.max(1, config.container.maxConcurrent);
   CONTAINER_PERSIST_BASH_STATE = config.container.persistBashState;
+  warnIfWarmPoolMinIdleIsClamped(config.container.warmPool);
   CONTAINER_WARM_POOL = structuredClone(config.container.warmPool);
   MCP_SERVERS = structuredClone(config.mcpServers || {});
   WEB_SEARCH_PROVIDER = config.web.search.provider;

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -532,6 +532,14 @@ export let ADDITIONAL_MOUNTS = '';
 export let CONTAINER_MAX_OUTPUT_SIZE = 10_485_760;
 export let MAX_CONCURRENT_CONTAINERS = 5;
 export let CONTAINER_PERSIST_BASH_STATE = true;
+export let CONTAINER_WARM_POOL: RuntimeConfig['container']['warmPool'] = {
+  enabled: true,
+  coldStartBudgetMs: 200,
+  trafficWindowMs: 3_600_000,
+  minIdlePerActiveAgent: 1,
+  maxIdlePerAgent: 2,
+  memoryPressureRssMb: 2_048,
+};
 export let MCP_SERVERS: RuntimeConfig['mcpServers'] = {};
 export let WEB_SEARCH_PROVIDER: RuntimeConfig['web']['search']['provider'] =
   'auto';
@@ -1051,6 +1059,7 @@ function applyRuntimeConfig(config: RuntimeConfig): void {
   CONTAINER_MAX_OUTPUT_SIZE = config.container.maxOutputBytes;
   MAX_CONCURRENT_CONTAINERS = Math.max(1, config.container.maxConcurrent);
   CONTAINER_PERSIST_BASH_STATE = config.container.persistBashState;
+  CONTAINER_WARM_POOL = structuredClone(config.container.warmPool);
   MCP_SERVERS = structuredClone(config.mcpServers || {});
   WEB_SEARCH_PROVIDER = config.web.search.provider;
   WEB_SEARCH_FALLBACK_PROVIDERS = [...config.web.search.fallbackProviders];

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -107,7 +107,7 @@ import {
 import { DEFAULT_RUNTIME_HOME_DIR } from './runtime-paths.js';
 
 export const CONFIG_FILE_NAME = 'config.json';
-export const CONFIG_VERSION = 25;
+export const CONFIG_VERSION = 26;
 export const SECURITY_POLICY_VERSION = '2026-02-28';
 export const DEFAULT_HYBRIDAI_MODEL = 'gpt-5.4-mini';
 const LEGACY_DEFAULT_DB_PATH = 'data/hybridclaw.db';
@@ -798,6 +798,14 @@ export interface RuntimeConfig {
     maxOutputBytes: number;
     maxConcurrent: number;
     persistBashState: boolean;
+    warmPool: {
+      enabled: boolean;
+      coldStartBudgetMs: number;
+      trafficWindowMs: number;
+      minIdlePerActiveAgent: number;
+      maxIdlePerAgent: number;
+      memoryPressureRssMb: number;
+    };
   };
   mcpServers: Record<string, McpServerConfig>;
   web: {
@@ -1431,6 +1439,14 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
     maxOutputBytes: 10_485_760,
     maxConcurrent: 5,
     persistBashState: true,
+    warmPool: {
+      enabled: true,
+      coldStartBudgetMs: 200,
+      trafficWindowMs: 3_600_000,
+      minIdlePerActiveAgent: 1,
+      maxIdlePerAgent: 2,
+      memoryPressureRssMb: 2_048,
+    },
   },
   mcpServers: {},
   web: {
@@ -4556,6 +4572,9 @@ function normalizeRuntimeConfig(
     ? rawLocal.healthCheck
     : {};
   const rawContainer = isRecord(raw.container) ? raw.container : {};
+  const rawContainerWarmPool = isRecord(rawContainer.warmPool)
+    ? rawContainer.warmPool
+    : {};
   const rawMcpServers = isRecord(raw.mcpServers) ? raw.mcpServers : {};
   const rawWeb = isRecord(raw.web) ? raw.web : {};
   const rawWebSearch = isRecord(rawWeb.search) ? rawWeb.search : {};
@@ -5517,6 +5536,37 @@ function normalizeRuntimeConfig(
         rawContainer.persistBashState,
         DEFAULT_RUNTIME_CONFIG.container.persistBashState,
       ),
+      warmPool: {
+        enabled: normalizeBoolean(
+          rawContainerWarmPool.enabled,
+          DEFAULT_RUNTIME_CONFIG.container.warmPool.enabled,
+        ),
+        coldStartBudgetMs: normalizeInteger(
+          rawContainerWarmPool.coldStartBudgetMs,
+          DEFAULT_RUNTIME_CONFIG.container.warmPool.coldStartBudgetMs,
+          { min: 1 },
+        ),
+        trafficWindowMs: normalizeInteger(
+          rawContainerWarmPool.trafficWindowMs,
+          DEFAULT_RUNTIME_CONFIG.container.warmPool.trafficWindowMs,
+          { min: 60_000 },
+        ),
+        minIdlePerActiveAgent: normalizeInteger(
+          rawContainerWarmPool.minIdlePerActiveAgent,
+          DEFAULT_RUNTIME_CONFIG.container.warmPool.minIdlePerActiveAgent,
+          { min: 0 },
+        ),
+        maxIdlePerAgent: normalizeInteger(
+          rawContainerWarmPool.maxIdlePerAgent,
+          DEFAULT_RUNTIME_CONFIG.container.warmPool.maxIdlePerAgent,
+          { min: 0 },
+        ),
+        memoryPressureRssMb: normalizeInteger(
+          rawContainerWarmPool.memoryPressureRssMb,
+          DEFAULT_RUNTIME_CONFIG.container.warmPool.memoryPressureRssMb,
+          { min: 0 },
+        ),
+      },
     },
     mcpServers: normalizeMcpServers(rawMcpServers),
     web: {

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -3059,6 +3059,8 @@ function logWarmProcessPoolStartup(config: RuntimeConfig['container']): void {
       coldStartBudgetMs: warmPool.coldStartBudgetMs,
       warmScope:
         'runtime process only; request-specific MCP, plugin, media, and model setup still runs after input',
+      warmFill:
+        'filled after recent traffic for an agent; gateway startup does not pre-spawn workers',
       disableConfig: 'container.warmPool.enabled=false',
     },
     'Warm process pool enabled; idle workers prewarm runtime process startup only',

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -103,6 +103,7 @@ import {
   SLACK_BOT_TOKEN,
   TWILIO_AUTH_TOKEN,
 } from '../config/config.js';
+import type { RuntimeConfig } from '../config/runtime-config.js';
 import { logger } from '../logger.js';
 import {
   deleteQueuedProactiveMessage,
@@ -3046,9 +3047,26 @@ function startOrRestartMemoryConsolidationScheduler(): void {
   scheduleNextMemoryConsolidationRun();
 }
 
+function logWarmProcessPoolStartup(config: RuntimeConfig['container']): void {
+  const warmPool = config.warmPool;
+  if (!warmPool.enabled || warmPool.maxIdlePerAgent <= 0) return;
+  logger.warn(
+    {
+      sandboxMode: config.sandboxMode,
+      minIdlePerActiveAgent: warmPool.minIdlePerActiveAgent,
+      maxIdlePerAgent: warmPool.maxIdlePerAgent,
+      memoryPressureRssMb: warmPool.memoryPressureRssMb,
+      coldStartBudgetMs: warmPool.coldStartBudgetMs,
+      disableConfig: 'container.warmPool.enabled=false',
+    },
+    'Warm process pool enabled; idle agent workers may be spawned after requests',
+  );
+}
+
 async function main(): Promise<void> {
   await initOtel();
   logger.info('Starting HybridClaw gateway');
+  logWarmProcessPoolStartup(getConfigSnapshot().container);
   validateGatewayPromptEnvDefaults();
   initDatabase();
   listAgents();

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -3055,6 +3055,10 @@ function logWarmProcessPoolStartup(config: RuntimeConfig['container']): void {
       sandboxMode: config.sandboxMode,
       minIdlePerActiveAgent: warmPool.minIdlePerActiveAgent,
       maxIdlePerAgent: warmPool.maxIdlePerAgent,
+      effectiveMinIdlePerActiveAgent: Math.min(
+        warmPool.minIdlePerActiveAgent,
+        warmPool.maxIdlePerAgent,
+      ),
       memoryPressureRssMb: warmPool.memoryPressureRssMb,
       coldStartBudgetMs: warmPool.coldStartBudgetMs,
       warmScope:

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -3057,9 +3057,11 @@ function logWarmProcessPoolStartup(config: RuntimeConfig['container']): void {
       maxIdlePerAgent: warmPool.maxIdlePerAgent,
       memoryPressureRssMb: warmPool.memoryPressureRssMb,
       coldStartBudgetMs: warmPool.coldStartBudgetMs,
+      warmScope:
+        'runtime process only; request-specific MCP, plugin, media, and model setup still runs after input',
       disableConfig: 'container.warmPool.enabled=false',
     },
-    'Warm process pool enabled; idle agent workers may be spawned after requests',
+    'Warm process pool enabled; idle workers prewarm runtime process startup only',
   );
 }
 

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -2,7 +2,7 @@
  * Container Runner — manages a pool of persistent containers.
  * Containers stay alive between requests and exit after an idle timeout.
  */
-import { type ChildProcess, spawn, spawnSync } from 'node:child_process';
+import { type ChildProcess, spawn } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import type { ExecutorRequest } from '../agent/executor-types.js';
@@ -156,6 +156,7 @@ const warmPool = new WarmProcessPool<PoolEntry>(
   normalizeWarmProcessPoolRuntimeConfig(CONTAINER_WARM_POOL),
 );
 let containerMemorySample: MemorySample | null = null;
+let containerMemoryRefreshInFlight = false;
 const TOOL_RESULT_RE =
   /^\[tool\]\s+([a-zA-Z0-9_.-]+)\s+result\s+\((\d+)ms\):\s*(.*)$/;
 const TOOL_START_RE = /^\[tool\]\s+([a-zA-Z0-9_.-]+):\s*(.*)$/;
@@ -442,36 +443,53 @@ function parseMemoryBytes(raw: string): number | null {
 
 function readContainerMemoryBytes(
   containerNames: string[],
-): Map<string, number> {
+): Promise<Map<string, number>> {
   const memoryByContainer = new Map<string, number>();
   const uniqueContainerNames = Array.from(new Set(containerNames)).filter(
     (name) => name.length > 0,
   );
-  if (uniqueContainerNames.length === 0) return memoryByContainer;
+  if (uniqueContainerNames.length === 0)
+    return Promise.resolve(memoryByContainer);
 
-  const result = spawnSync(
-    'docker',
-    [
-      'stats',
-      '--no-stream',
-      '--format',
-      '{{.Name}}\t{{.MemUsage}}',
-      ...uniqueContainerNames,
-    ],
-    { encoding: 'utf-8', timeout: 2_000 },
-  );
-  if (result.status !== 0) return memoryByContainer;
-
-  for (const line of String(result.stdout || '').split('\n')) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    const separatorIndex = trimmed.indexOf('\t');
-    if (separatorIndex === -1) continue;
-    const containerName = trimmed.slice(0, separatorIndex).trim();
-    const usage = trimmed.slice(separatorIndex + 1).split('/')[0] || '';
-    memoryByContainer.set(containerName, parseMemoryBytes(usage) || 0);
-  }
-  return memoryByContainer;
+  return new Promise((resolve) => {
+    const proc = spawn(
+      'docker',
+      [
+        'stats',
+        '--no-stream',
+        '--format',
+        '{{.Name}}\t{{.MemUsage}}',
+        ...uniqueContainerNames,
+      ],
+      { stdio: ['ignore', 'pipe', 'ignore'] },
+    );
+    let stdout = '';
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      for (const line of stdout.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        const separatorIndex = trimmed.indexOf('\t');
+        if (separatorIndex === -1) continue;
+        const containerName = trimmed.slice(0, separatorIndex).trim();
+        const usage = trimmed.slice(separatorIndex + 1).split('/')[0] || '';
+        memoryByContainer.set(containerName, parseMemoryBytes(usage) || 0);
+      }
+      resolve(memoryByContainer);
+    };
+    const timer = setTimeout(() => {
+      proc.kill('SIGTERM');
+      finish();
+    }, 2_000);
+    proc.stdout?.on('data', (chunk) => {
+      stdout += chunk.toString('utf-8');
+    });
+    proc.on('error', finish);
+    proc.on('close', finish);
+  });
 }
 
 function getObservedContainerMemoryBytes(): number {
@@ -480,12 +498,16 @@ function getObservedContainerMemoryBytes(): number {
     setCache: (sample) => {
       containerMemorySample = sample;
     },
+    isRefreshInFlight: () => containerMemoryRefreshInFlight,
+    setRefreshInFlight: (value) => {
+      containerMemoryRefreshInFlight = value;
+    },
     activeEntries: Array.from(pool.values()),
     warmEntries: warmPool.values(),
     memoryPressureEnabled: warmPool.memoryPressureEnabled,
     keyForEntry: (entry) => entry.containerName,
-    readTotalBytes: (containerNames) => {
-      const memoryByContainer = readContainerMemoryBytes(containerNames);
+    refreshTotalBytes: async (containerNames) => {
+      const memoryByContainer = await readContainerMemoryBytes(containerNames);
       let total = 0;
       for (const containerName of containerNames) {
         total += memoryByContainer.get(containerName) || 0;
@@ -518,7 +540,6 @@ function claimWarmContainer(params: {
     sessionId: params.sessionId,
     agentId: params.agentId,
     eligibility: params,
-    enforcePressure: enforceWarmContainerPressure,
     logClaim: (entry) =>
       logger.info(
         {
@@ -544,7 +565,6 @@ function maintainWarmContainerPool(params: {
     maxProcessCount: MAX_CONCURRENT_CONTAINERS,
     agentId: params.agentId,
     eligibility: params,
-    enforcePressure: enforceWarmContainerPressure,
     stopEntries: stopWarmEntries,
     spawnWarm: (sessionId, agentId) => {
       getOrSpawnContainer({ sessionId, agentId, warm: true });

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -2,7 +2,7 @@
  * Container Runner — manages a pool of persistent containers.
  * Containers stay alive between requests and exit after an idle timeout.
  */
-import { type ChildProcess, spawn } from 'node:child_process';
+import { type ChildProcess, spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import type { ExecutorRequest } from '../agent/executor-types.js';
@@ -21,6 +21,7 @@ import {
   CONTAINER_NETWORK,
   CONTAINER_PERSIST_BASH_STATE,
   CONTAINER_TIMEOUT,
+  CONTAINER_WARM_POOL,
   CONTEXT_GUARD_COMPACTION_RATIO,
   CONTEXT_GUARD_ENABLED,
   CONTEXT_GUARD_MAX_RETRIES,
@@ -91,6 +92,11 @@ import {
   isThinkingDeltaLine,
   type StreamDebugState,
 } from './stream-debug.js';
+import {
+  normalizeWarmProcessPoolConfig,
+  WarmProcessPool,
+  type WarmProcessPoolEntry,
+} from './warm-process-pool.js';
 import { computeWorkerSignature } from './worker-signature.js';
 
 const IDLE_TIMEOUT_MS = 300_000; // 5 minutes — matches container-side default
@@ -105,11 +111,17 @@ function resolveExecutorMaxTokens(params: {
   });
 }
 
-interface PoolEntry {
+interface PoolEntry extends WarmProcessPoolEntry {
   process: ChildProcess;
   containerName: string;
   sessionId: string;
+  ipcSessionId: string;
+  agentId: string;
   startedAt: number;
+  lastUsedAt: number;
+  warm: boolean;
+  readyForInputAt: number | null;
+  pendingColdStartProbeStartedAt: number | null;
   stderrBuffer: string;
   stderrHistory: string[];
   streamDebug: StreamDebugState;
@@ -129,6 +141,13 @@ interface ContainerPathAliasMount {
 }
 
 const pool = new Map<string, PoolEntry>();
+const warmPool = new WarmProcessPool<PoolEntry>(
+  normalizeWarmProcessPoolConfig({
+    ...CONTAINER_WARM_POOL,
+    memoryPressureRssBytes:
+      CONTAINER_WARM_POOL.memoryPressureRssMb * 1024 * 1024,
+  }),
+);
 const TOOL_RESULT_RE =
   /^\[tool\]\s+([a-zA-Z0-9_.-]+)\s+result\s+\((\d+)ms\):\s*(.*)$/;
 const TOOL_START_RE = /^\[tool\]\s+([a-zA-Z0-9_.-]+):\s*(.*)$/;
@@ -138,6 +157,8 @@ const CONTAINER_APP_NODE_MODULES = '/app/node_modules';
 const CONTAINER_DISCORD_MEDIA_CACHE_ROOT = '/discord-media-cache';
 const CONTAINER_UPLOADED_MEDIA_CACHE_ROOT = '/uploaded-media-cache';
 const AGENT_OUTPUT_TIMEOUT_PREFIX = 'Timeout waiting for agent output after ';
+const AGENT_READY_FOR_INPUT_LINE = '[hybridclaw-agent] ready for input';
+const AGENT_REQUEST_START_LINE = '[hybridclaw-agent] agent request start';
 
 export function collectConfiguredDiscordChannelIds(
   currentChannelId: string,
@@ -365,6 +386,25 @@ export function getActiveContainerSessionIds(): string[] {
   );
 }
 
+export function getWarmContainerColdStartP95Ms(): number | null {
+  return warmPool.coldStartP95Ms();
+}
+
+export function isWarmContainerColdStartWithinBudget(): boolean {
+  return warmPool.isWithinColdStartBudget();
+}
+
+function getTotalContainerProcessCount(): number {
+  return pool.size + warmPool.size;
+}
+
+function removePoolEntry(entry: PoolEntry): void {
+  warmPool.delete(entry.id);
+  for (const [sessionId, active] of pool) {
+    if (active === entry) pool.delete(sessionId);
+  }
+}
+
 export function stopSessionContainer(sessionId: string): boolean {
   const entry = pool.get(sessionId);
   if (!entry) return false;
@@ -373,7 +413,7 @@ export function stopSessionContainer(sessionId: string): boolean {
     'Stopping session container',
   );
   stopContainer(entry.containerName);
-  pool.delete(sessionId);
+  removePoolEntry(entry);
   return true;
 }
 
@@ -382,6 +422,163 @@ function stopContainer(containerName: string): void {
   proc.on('error', (err) => {
     logger.debug({ containerName, err }, 'Failed to stop container');
   });
+}
+
+function stopPoolEntry(entry: PoolEntry): void {
+  stopContainer(entry.containerName);
+}
+
+function stopWarmEntries(entries: PoolEntry[]): void {
+  for (const entry of entries) {
+    logger.info(
+      { agentId: entry.agentId, containerName: entry.containerName },
+      'Evicting warm container',
+    );
+    stopPoolEntry(entry);
+  }
+}
+
+function parseMemoryBytes(raw: string): number | null {
+  const match = raw.trim().match(/^([\d.]+)\s*([kmgt]?i?b)?/i);
+  if (!match) return null;
+  const value = Number(match[1]);
+  if (!Number.isFinite(value)) return null;
+  const unit = (match[2] || 'b').toLowerCase();
+  const multiplier =
+    unit === 'kb' || unit === 'kib'
+      ? 1024
+      : unit === 'mb' || unit === 'mib'
+        ? 1024 ** 2
+        : unit === 'gb' || unit === 'gib'
+          ? 1024 ** 3
+          : unit === 'tb' || unit === 'tib'
+            ? 1024 ** 4
+            : 1;
+  return Math.floor(value * multiplier);
+}
+
+function readContainerMemoryBytes(containerName: string): number {
+  const result = spawnSync(
+    'docker',
+    ['stats', '--no-stream', '--format', '{{.MemUsage}}', containerName],
+    { encoding: 'utf-8', timeout: 2_000 },
+  );
+  if (result.status !== 0) return 0;
+  const usage = String(result.stdout || '').split('/')[0] || '';
+  return parseMemoryBytes(usage) || 0;
+}
+
+function getObservedContainerMemoryBytes(): number {
+  let total = 0;
+  for (const entry of pool.values()) {
+    total += readContainerMemoryBytes(entry.containerName);
+  }
+  for (const entry of warmPool.values()) {
+    total += readContainerMemoryBytes(entry.containerName);
+  }
+  return total;
+}
+
+function enforceWarmContainerPressure(): void {
+  stopWarmEntries(
+    warmPool.evictForPressure({
+      totalProcessCount: getTotalContainerProcessCount(),
+      maxProcessCount: MAX_CONCURRENT_CONTAINERS,
+      rssBytes: getObservedContainerMemoryBytes(),
+    }),
+  );
+}
+
+function markWorkerReadyForInput(entry: PoolEntry): void {
+  entry.readyForInputAt = Date.now();
+}
+
+function markAgentRequestStart(entry: PoolEntry): void {
+  const startedAt = entry.pendingColdStartProbeStartedAt;
+  if (startedAt == null) return;
+  warmPool.recordColdStart(Date.now() - startedAt);
+  entry.pendingColdStartProbeStartedAt = null;
+}
+
+function observeAgentLifecycleLine(entry: PoolEntry, line: string): boolean {
+  if (line === AGENT_READY_FOR_INPUT_LINE) {
+    markWorkerReadyForInput(entry);
+    entry.activity?.notify();
+    return true;
+  }
+  if (line === AGENT_REQUEST_START_LINE) {
+    markAgentRequestStart(entry);
+    entry.activity?.notify();
+    return true;
+  }
+  return false;
+}
+
+function canUseWarmContainerPool(params: {
+  workspacePathOverride?: string;
+  workspaceDisplayRootOverride?: string;
+  bashProxy?: ExecutorRequest['bashProxy'];
+}): boolean {
+  return (
+    warmPool.enabled &&
+    !params.workspacePathOverride?.trim() &&
+    !params.workspaceDisplayRootOverride?.trim() &&
+    !params.bashProxy
+  );
+}
+
+function createWarmSessionId(agentId: string): string {
+  const safeAgent = agentId.replace(/[^a-zA-Z0-9_-]/g, '_');
+  return `warm_${safeAgent}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function claimWarmContainer(params: {
+  sessionId: string;
+  agentId: string;
+  workspacePathOverride?: string;
+  workspaceDisplayRootOverride?: string;
+  bashProxy?: ExecutorRequest['bashProxy'];
+}): PoolEntry | null {
+  if (!canUseWarmContainerPool(params)) return null;
+  enforceWarmContainerPressure();
+  const entry = warmPool.claim(params.agentId);
+  if (!entry) return null;
+  entry.sessionId = params.sessionId;
+  entry.warm = false;
+  entry.lastUsedAt = Date.now();
+  pool.set(params.sessionId, entry);
+  logger.info(
+    {
+      sessionId: params.sessionId,
+      ipcSessionId: entry.ipcSessionId,
+      agentId: params.agentId,
+      containerName: entry.containerName,
+    },
+    'Claimed warm container',
+  );
+  return entry;
+}
+
+function maintainWarmContainerPool(params: {
+  agentId: string;
+  workspacePathOverride?: string;
+  workspaceDisplayRootOverride?: string;
+  bashProxy?: ExecutorRequest['bashProxy'];
+}): void {
+  if (!canUseWarmContainerPool(params)) return;
+  enforceWarmContainerPressure();
+  const targetSize = warmPool.targetIdleForAgent(params.agentId);
+  stopWarmEntries(warmPool.trimAgent(params.agentId, targetSize));
+  while (
+    warmPool.idleCountForAgent(params.agentId) < targetSize &&
+    getTotalContainerProcessCount() < MAX_CONCURRENT_CONTAINERS
+  ) {
+    getOrSpawnContainer({
+      sessionId: createWarmSessionId(params.agentId),
+      agentId: params.agentId,
+      warm: true,
+    });
+  }
 }
 
 function isTimedOutAgentOutput(output: ContainerOutput): boolean {
@@ -503,11 +700,12 @@ function getOrSpawnContainer(
     | 'workspacePathOverride'
     | 'workspaceDisplayRootOverride'
     | 'bashProxy'
-  >,
+  > & { ipcSessionId?: string; warm?: boolean },
 ): PoolEntry {
   const sessionId = params.sessionId;
+  const ipcSessionId = params.ipcSessionId || sessionId;
   const agentId = params.agentId || DEFAULT_AGENT_ID;
-  const existing = pool.get(sessionId);
+  const existing = params.warm ? null : pool.get(sessionId);
   if (
     existing &&
     !existing.process.killed &&
@@ -524,9 +722,9 @@ function getOrSpawnContainer(
     pool.delete(sessionId);
   }
 
-  ensureSessionDirs(sessionId);
+  ensureSessionDirs(ipcSessionId);
   ensureAgentDirs(agentId);
-  const { ipcPath } = getSessionPaths(sessionId, agentId);
+  const { ipcPath } = getSessionPaths(ipcSessionId, agentId);
   const workspacePath = getContainerWorkspacePath({
     sessionId,
     agentId,
@@ -551,7 +749,7 @@ function getOrSpawnContainer(
       'Failed to set permissions on browser profile directory',
     );
   }
-  const containerName = `hybridclaw-${sessionId.replace(/[^a-zA-Z0-9-]/g, '-')}-${Date.now()}`;
+  const containerName = `hybridclaw-${ipcSessionId.replace(/[^a-zA-Z0-9-]/g, '-')}-${Date.now()}`;
 
   const args = [
     'run',
@@ -666,22 +864,38 @@ function getOrSpawnContainer(
 
   args.push(CONTAINER_IMAGE);
 
-  logger.info({ sessionId, containerName }, 'Spawning persistent container');
+  logger.info(
+    { sessionId, ipcSessionId, agentId, containerName, warm: params.warm },
+    'Spawning persistent container',
+  );
 
   const proc = spawn('docker', args, {
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 
   const entry: PoolEntry = {
+    id: ipcSessionId,
     process: proc,
     containerName,
     sessionId,
+    ipcSessionId,
+    agentId,
     startedAt: Date.now(),
+    lastUsedAt: Date.now(),
+    warm: params.warm === true,
+    readyForInputAt: null,
+    pendingColdStartProbeStartedAt: null,
     stderrBuffer: '',
     stderrHistory: [],
     streamDebug: createStreamDebugState(),
     workerSignature: '',
     terminalError: null,
+    isReady() {
+      return entry.readyForInputAt != null;
+    },
+    stop() {
+      stopPoolEntry(entry);
+    },
   };
 
   proc.stderr.on('data', (data) => {
@@ -691,6 +905,7 @@ function getOrSpawnContainer(
     for (const rawLine of lines) {
       const line = rawLine.trim();
       if (!line) continue;
+      if (observeAgentLifecycleLine(entry, line)) continue;
       if (consumeModelResponseDebugFileLine(line)) {
         entry.activity?.notify();
         continue;
@@ -727,7 +942,9 @@ function getOrSpawnContainer(
   proc.on('close', (code, signal) => {
     const tail = entry.stderrBuffer.trim();
     if (tail) {
-      if (consumeModelResponseDebugFileLine(tail)) {
+      if (observeAgentLifecycleLine(entry, tail)) {
+        entry.stderrBuffer = '';
+      } else if (consumeModelResponseDebugFileLine(tail)) {
         entry.activity?.notify();
         entry.stderrBuffer = '';
       } else {
@@ -759,17 +976,21 @@ function getOrSpawnContainer(
     flushCollapsedStreamDebugSummary(entry.streamDebug, (message) => {
       logger.debug({ container: containerName }, message);
     });
-    pool.delete(sessionId);
+    removePoolEntry(entry);
     logger.info({ sessionId, containerName, code, signal }, 'Container exited');
   });
 
   proc.on('error', (err) => {
     entry.terminalError = `Container runtime failed before producing output: ${err instanceof Error ? err.message : String(err)}`;
-    pool.delete(sessionId);
+    removePoolEntry(entry);
     logger.error({ sessionId, containerName, error: err }, 'Container error');
   });
 
-  pool.set(sessionId, entry);
+  if (entry.warm) {
+    warmPool.add(entry);
+  } else {
+    pool.set(sessionId, entry);
+  }
   return entry;
 }
 
@@ -843,19 +1064,32 @@ async function runContainerInner(
     );
     return {};
   });
-  if (pool.size >= MAX_CONCURRENT_CONTAINERS && !pool.has(sessionId)) {
+  enforceWarmContainerPressure();
+  if (
+    getTotalContainerProcessCount() >= MAX_CONCURRENT_CONTAINERS &&
+    !pool.has(sessionId)
+  ) {
+    stopWarmEntries(
+      warmPool.evictForPressure({
+        totalProcessCount: getTotalContainerProcessCount() + 1,
+        maxProcessCount: MAX_CONCURRENT_CONTAINERS,
+        rssBytes: getObservedContainerMemoryBytes(),
+      }),
+    );
+  }
+  if (
+    getTotalContainerProcessCount() >= MAX_CONCURRENT_CONTAINERS &&
+    !pool.has(sessionId)
+  ) {
     return {
       status: 'error',
       result: null,
       toolsUsed: [],
-      error: `Too many active containers (${pool.size}/${MAX_CONCURRENT_CONTAINERS}). Try again later.`,
+      error: `Too many active containers (${getTotalContainerProcessCount()}/${MAX_CONCURRENT_CONTAINERS}). Try again later.`,
     };
   }
 
   const startTime = Date.now();
-
-  cleanupIpc(sessionId);
-  ensureSessionDirs(sessionId);
 
   const input: ContainerInput = {
     sessionId,
@@ -953,7 +1187,7 @@ async function runContainerInner(
       'Worker routing changed; restarting persistent container',
     );
     stopContainer(existingEntry.containerName);
-    pool.delete(sessionId);
+    removePoolEntry(existingEntry);
   }
 
   const isNewContainer =
@@ -963,13 +1197,23 @@ async function runContainerInner(
 
   let entry: PoolEntry;
   try {
-    entry = getOrSpawnContainer({
-      sessionId,
-      agentId,
-      workspacePathOverride: params.workspacePathOverride,
-      workspaceDisplayRootOverride: params.workspaceDisplayRootOverride,
-      bashProxy: params.bashProxy,
-    });
+    entry =
+      (isNewContainer
+        ? claimWarmContainer({
+            sessionId,
+            agentId,
+            workspacePathOverride: params.workspacePathOverride,
+            workspaceDisplayRootOverride: params.workspaceDisplayRootOverride,
+            bashProxy: params.bashProxy,
+          })
+        : null) ||
+      getOrSpawnContainer({
+        sessionId,
+        agentId,
+        workspacePathOverride: params.workspacePathOverride,
+        workspaceDisplayRootOverride: params.workspaceDisplayRootOverride,
+        bashProxy: params.bashProxy,
+      });
   } catch (err) {
     return {
       status: 'error',
@@ -978,6 +1222,8 @@ async function runContainerInner(
       error: `Container spawn error: ${err instanceof Error ? err.message : String(err)}`,
     };
   }
+  cleanupIpc(entry.ipcSessionId);
+  ensureSessionDirs(entry.ipcSessionId);
   const activity = createActivityTracker();
   entry.workerSignature = workerSignature;
   entry.onTextDelta = onTextDelta;
@@ -999,17 +1245,18 @@ async function runContainerInner(
 
   try {
     if (isNewContainer) {
+      entry.pendingColdStartProbeStartedAt = Date.now();
       // First request: send full input (including apiKey) via stdin — no file on disk.
       // Write JSON on a single line followed by newline as delimiter.
       // Do NOT end stdin — closing stdin can cause docker -i to terminate the container.
       entry.process.stdin?.write(`${JSON.stringify(input)}\n`);
     } else {
       // Follow-up requests: write to IPC file, omitting apiKey
-      writeInput(sessionId, input, { omitApiKey: true });
+      writeInput(entry.ipcSessionId, input, { omitApiKey: true });
     }
 
     const output = await readOutput(
-      sessionId,
+      entry.ipcSessionId,
       inactivityTimeoutMs === undefined
         ? CONTAINER_TIMEOUT
         : inactivityTimeoutMs,
@@ -1020,7 +1267,8 @@ async function runContainerInner(
         terminalError: () => entry.terminalError,
       },
     );
-    if (isTimedOutAgentOutput(output)) {
+    const timedOut = isTimedOutAgentOutput(output);
+    if (timedOut) {
       logger.warn(
         { sessionId, containerName: entry.containerName },
         'Agent output timed out; stopping stuck container',
@@ -1047,6 +1295,16 @@ async function runContainerInner(
       };
     }
     const duration = Date.now() - startTime;
+    if (!timedOut) {
+      entry.lastUsedAt = Date.now();
+      warmPool.recordRequest(agentId, duration);
+      maintainWarmContainerPool({
+        agentId,
+        workspacePathOverride: params.workspacePathOverride,
+        workspaceDisplayRootOverride: params.workspaceDisplayRootOverride,
+        bashProxy: params.bashProxy,
+      });
+    }
 
     logger.info(
       {
@@ -1093,6 +1351,13 @@ export function stopAllContainers(): void {
     stopContainer(entry.containerName);
   }
   pool.clear();
+  for (const entry of warmPool.clear()) {
+    logger.info(
+      { agentId: entry.agentId, containerName: entry.containerName },
+      'Stopping warm container (shutdown)',
+    );
+    stopContainer(entry.containerName);
+  }
 }
 
 export class ContainerExecutor {

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -981,6 +981,7 @@ function getOrSpawnContainer(
 
   if (entry.warm) {
     warmPool.add(entry);
+    getObservedContainerMemoryBytes();
   } else {
     pool.set(sessionId, entry);
   }

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -92,14 +92,25 @@ import {
   isThinkingDeltaLine,
   type StreamDebugState,
 } from './stream-debug.js';
+import { WarmProcessPool } from './warm-process-pool.js';
 import {
-  normalizeWarmProcessPoolConfig,
-  WarmProcessPool,
-  type WarmProcessPoolEntry,
-} from './warm-process-pool.js';
+  claimWarmEntry,
+  enforceWarmPoolPressure,
+  getCachedObservedMemoryBytes,
+  getTotalWarmProcessCount,
+  IDLE_TIMEOUT_MS,
+  isTimedOutAgentOutput,
+  type MemorySample,
+  maintainWarmPool,
+  normalizeWarmProcessPoolRuntimeConfig,
+  observeAgentLifecycleLine,
+  rememberStderrLine,
+  removeWarmPoolEntry,
+  stopWarmEntries as stopWarmPoolEntries,
+  summarizeExit,
+  type WarmRunnerEntry,
+} from './warm-runner-utils.js';
 import { computeWorkerSignature } from './worker-signature.js';
-
-const IDLE_TIMEOUT_MS = 300_000; // 5 minutes — matches container-side default
 
 function resolveExecutorMaxTokens(params: {
   model: string;
@@ -111,7 +122,7 @@ function resolveExecutorMaxTokens(params: {
   });
 }
 
-interface PoolEntry extends WarmProcessPoolEntry {
+interface PoolEntry extends WarmRunnerEntry {
   process: ChildProcess;
   containerName: string;
   sessionId: string;
@@ -142,18 +153,9 @@ interface ContainerPathAliasMount {
 
 const pool = new Map<string, PoolEntry>();
 const warmPool = new WarmProcessPool<PoolEntry>(
-  normalizeWarmProcessPoolConfig({
-    ...CONTAINER_WARM_POOL,
-    memoryPressureRssBytes:
-      CONTAINER_WARM_POOL.memoryPressureRssMb * 1024 * 1024,
-  }),
+  normalizeWarmProcessPoolRuntimeConfig(CONTAINER_WARM_POOL),
 );
-const MEMORY_SAMPLE_TTL_MS = 5_000;
-let containerMemorySample: {
-  at: number;
-  containerKey: string;
-  totalBytes: number;
-} | null = null;
+let containerMemorySample: MemorySample | null = null;
 const TOOL_RESULT_RE =
   /^\[tool\]\s+([a-zA-Z0-9_.-]+)\s+result\s+\((\d+)ms\):\s*(.*)$/;
 const TOOL_START_RE = /^\[tool\]\s+([a-zA-Z0-9_.-]+):\s*(.*)$/;
@@ -162,9 +164,6 @@ const CONTAINER_WORKSPACE_ROOT = '/workspace';
 const CONTAINER_APP_NODE_MODULES = '/app/node_modules';
 const CONTAINER_DISCORD_MEDIA_CACHE_ROOT = '/discord-media-cache';
 const CONTAINER_UPLOADED_MEDIA_CACHE_ROOT = '/uploaded-media-cache';
-const AGENT_OUTPUT_TIMEOUT_PREFIX = 'Timeout waiting for agent output after ';
-const AGENT_READY_FOR_INPUT_LINE = '[hybridclaw-agent] ready for input';
-const AGENT_REQUEST_START_LINE = '[hybridclaw-agent] agent request start';
 
 export function collectConfiguredDiscordChannelIds(
   currentChannelId: string,
@@ -194,26 +193,6 @@ export function resolveDiscordMediaCacheHostDir(): string {
 }
 
 const CONTAINER_BROWSER_PROFILE_PATH = '/browser-profiles';
-const STDERR_HISTORY_LIMIT = 20;
-
-function rememberStderrLine(entry: PoolEntry, line: string): void {
-  entry.stderrHistory.push(line);
-  if (entry.stderrHistory.length > STDERR_HISTORY_LIMIT) {
-    entry.stderrHistory.splice(
-      0,
-      entry.stderrHistory.length - STDERR_HISTORY_LIMIT,
-    );
-  }
-}
-
-function summarizeExit(
-  code: number | null,
-  signal: NodeJS.Signals | null,
-): string {
-  if (typeof code === 'number') return `exit code ${code}`;
-  if (signal) return `signal ${signal}`;
-  return 'unknown exit status';
-}
 
 function formatContainerTerminalError(
   entry: PoolEntry,
@@ -401,14 +380,11 @@ export function isWarmContainerColdStartWithinBudget(): boolean {
 }
 
 function getTotalContainerProcessCount(): number {
-  return pool.size + warmPool.size;
+  return getTotalWarmProcessCount(pool, warmPool);
 }
 
 function removePoolEntry(entry: PoolEntry): void {
-  warmPool.delete(entry.id);
-  for (const [sessionId, active] of pool) {
-    if (active === entry) pool.delete(sessionId);
-  }
+  removeWarmPoolEntry(pool, warmPool, entry);
 }
 
 export function stopSessionContainer(sessionId: string): boolean {
@@ -435,13 +411,14 @@ function stopPoolEntry(entry: PoolEntry): void {
 }
 
 function stopWarmEntries(entries: PoolEntry[]): void {
-  for (const entry of entries) {
-    logger.info(
-      { agentId: entry.agentId, containerName: entry.containerName },
-      'Evicting warm container',
-    );
-    stopPoolEntry(entry);
-  }
+  stopWarmPoolEntries(entries, {
+    log: (entry) =>
+      logger.info(
+        { agentId: entry.agentId, containerName: entry.containerName },
+        'Evicting warm container',
+      ),
+    stop: stopPoolEntry,
+  });
 }
 
 function parseMemoryBytes(raw: string): number | null {
@@ -498,86 +475,34 @@ function readContainerMemoryBytes(
 }
 
 function getObservedContainerMemoryBytes(): number {
-  const warmEntries = warmPool.values();
-  if (warmEntries.length === 0 || !warmPool.memoryPressureEnabled) return 0;
-  const containerNames = [
-    ...Array.from(pool.values()).map((entry) => entry.containerName),
-    ...warmEntries.map((entry) => entry.containerName),
-  ];
-  const containerKey = Array.from(new Set(containerNames)).sort().join('\n');
-  const now = Date.now();
-  if (
-    containerMemorySample &&
-    containerMemorySample.containerKey === containerKey &&
-    now - containerMemorySample.at < MEMORY_SAMPLE_TTL_MS
-  ) {
-    return containerMemorySample.totalBytes;
-  }
-
-  const memoryByContainer = readContainerMemoryBytes(containerNames);
-  let total = 0;
-  for (const containerName of containerNames) {
-    total += memoryByContainer.get(containerName) || 0;
-  }
-  containerMemorySample = { at: now, containerKey, totalBytes: total };
-  return total;
+  return getCachedObservedMemoryBytes({
+    cache: containerMemorySample,
+    setCache: (sample) => {
+      containerMemorySample = sample;
+    },
+    activeEntries: Array.from(pool.values()),
+    warmEntries: warmPool.values(),
+    memoryPressureEnabled: warmPool.memoryPressureEnabled,
+    keyForEntry: (entry) => entry.containerName,
+    readTotalBytes: (containerNames) => {
+      const memoryByContainer = readContainerMemoryBytes(containerNames);
+      let total = 0;
+      for (const containerName of containerNames) {
+        total += memoryByContainer.get(containerName) || 0;
+      }
+      return total;
+    },
+  });
 }
 
 function enforceWarmContainerPressure(): void {
-  if (warmPool.size === 0) return;
-  const totalProcessCount = getTotalContainerProcessCount();
-  const overCapacity = totalProcessCount > MAX_CONCURRENT_CONTAINERS;
-  if (!overCapacity && !warmPool.memoryPressureEnabled) return;
-  stopWarmEntries(
-    warmPool.evictForPressure({
-      totalProcessCount,
-      maxProcessCount: MAX_CONCURRENT_CONTAINERS,
-      rssBytes: overCapacity ? undefined : getObservedContainerMemoryBytes(),
-    }),
-  );
-}
-
-function markWorkerReadyForInput(entry: PoolEntry): void {
-  entry.readyForInputAt = Date.now();
-}
-
-function markAgentRequestStart(entry: PoolEntry): void {
-  const startedAt = entry.pendingColdStartProbeStartedAt;
-  if (startedAt == null) return;
-  warmPool.recordColdStart(Date.now() - startedAt);
-  entry.pendingColdStartProbeStartedAt = null;
-}
-
-function observeAgentLifecycleLine(entry: PoolEntry, line: string): boolean {
-  if (line === AGENT_READY_FOR_INPUT_LINE) {
-    markWorkerReadyForInput(entry);
-    entry.activity?.notify();
-    return true;
-  }
-  if (line === AGENT_REQUEST_START_LINE) {
-    markAgentRequestStart(entry);
-    entry.activity?.notify();
-    return true;
-  }
-  return false;
-}
-
-function canUseWarmContainerPool(params: {
-  workspacePathOverride?: string;
-  workspaceDisplayRootOverride?: string;
-  bashProxy?: ExecutorRequest['bashProxy'];
-}): boolean {
-  return (
-    warmPool.enabled &&
-    !params.workspacePathOverride?.trim() &&
-    !params.workspaceDisplayRootOverride?.trim() &&
-    !params.bashProxy
-  );
-}
-
-function createWarmSessionId(agentId: string): string {
-  const safeAgent = agentId.replace(/[^a-zA-Z0-9_-]/g, '_');
-  return `warm_${safeAgent}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  enforceWarmPoolPressure({
+    pool,
+    warmPool,
+    maxProcessCount: MAX_CONCURRENT_CONTAINERS,
+    getObservedMemoryBytes: getObservedContainerMemoryBytes,
+    stopEntries: stopWarmEntries,
+  });
 }
 
 function claimWarmContainer(params: {
@@ -587,24 +512,24 @@ function claimWarmContainer(params: {
   workspaceDisplayRootOverride?: string;
   bashProxy?: ExecutorRequest['bashProxy'];
 }): PoolEntry | null {
-  if (!canUseWarmContainerPool(params)) return null;
-  enforceWarmContainerPressure();
-  const entry = warmPool.claim(params.agentId);
-  if (!entry) return null;
-  entry.sessionId = params.sessionId;
-  entry.warm = false;
-  entry.lastUsedAt = Date.now();
-  pool.set(params.sessionId, entry);
-  logger.info(
-    {
-      sessionId: params.sessionId,
-      ipcSessionId: entry.ipcSessionId,
-      agentId: params.agentId,
-      containerName: entry.containerName,
-    },
-    'Claimed warm container',
-  );
-  return entry;
+  return claimWarmEntry({
+    pool,
+    warmPool,
+    sessionId: params.sessionId,
+    agentId: params.agentId,
+    eligibility: params,
+    enforcePressure: enforceWarmContainerPressure,
+    logClaim: (entry) =>
+      logger.info(
+        {
+          sessionId: params.sessionId,
+          ipcSessionId: entry.ipcSessionId,
+          agentId: params.agentId,
+          containerName: entry.containerName,
+        },
+        'Claimed warm container',
+      ),
+  });
 }
 
 function maintainWarmContainerPool(params: {
@@ -613,28 +538,18 @@ function maintainWarmContainerPool(params: {
   workspaceDisplayRootOverride?: string;
   bashProxy?: ExecutorRequest['bashProxy'];
 }): void {
-  if (!canUseWarmContainerPool(params)) return;
-  enforceWarmContainerPressure();
-  const targetSize = warmPool.targetIdleForAgent(params.agentId);
-  stopWarmEntries(warmPool.trimAgent(params.agentId, targetSize));
-  while (
-    warmPool.idleCountForAgent(params.agentId) < targetSize &&
-    getTotalContainerProcessCount() < MAX_CONCURRENT_CONTAINERS
-  ) {
-    getOrSpawnContainer({
-      sessionId: createWarmSessionId(params.agentId),
-      agentId: params.agentId,
-      warm: true,
-    });
-  }
-}
-
-function isTimedOutAgentOutput(output: ContainerOutput): boolean {
-  return (
-    output.status === 'error' &&
-    typeof output.error === 'string' &&
-    output.error.startsWith(AGENT_OUTPUT_TIMEOUT_PREFIX)
-  );
+  maintainWarmPool({
+    pool,
+    warmPool,
+    maxProcessCount: MAX_CONCURRENT_CONTAINERS,
+    agentId: params.agentId,
+    eligibility: params,
+    enforcePressure: enforceWarmContainerPressure,
+    stopEntries: stopWarmEntries,
+    spawnWarm: (sessionId, agentId) => {
+      getOrSpawnContainer({ sessionId, agentId, warm: true });
+    },
+  });
 }
 
 function isWithinResolvedRoot(candidate: string, root: string): boolean {
@@ -953,7 +868,7 @@ function getOrSpawnContainer(
     for (const rawLine of lines) {
       const line = rawLine.trim();
       if (!line) continue;
-      if (observeAgentLifecycleLine(entry, line)) continue;
+      if (observeAgentLifecycleLine(entry, line, warmPool)) continue;
       if (consumeModelResponseDebugFileLine(line)) {
         entry.activity?.notify();
         continue;
@@ -990,7 +905,7 @@ function getOrSpawnContainer(
   proc.on('close', (code, signal) => {
     const tail = entry.stderrBuffer.trim();
     if (tail) {
-      if (observeAgentLifecycleLine(entry, tail)) {
+      if (observeAgentLifecycleLine(entry, tail, warmPool)) {
         entry.stderrBuffer = '';
       } else if (consumeModelResponseDebugFileLine(tail)) {
         entry.activity?.notify();

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -148,6 +148,12 @@ const warmPool = new WarmProcessPool<PoolEntry>(
       CONTAINER_WARM_POOL.memoryPressureRssMb * 1024 * 1024,
   }),
 );
+const MEMORY_SAMPLE_TTL_MS = 5_000;
+let containerMemorySample: {
+  at: number;
+  containerKey: string;
+  totalBytes: number;
+} | null = null;
 const TOOL_RESULT_RE =
   /^\[tool\]\s+([a-zA-Z0-9_.-]+)\s+result\s+\((\d+)ms\):\s*(.*)$/;
 const TOOL_START_RE = /^\[tool\]\s+([a-zA-Z0-9_.-]+):\s*(.*)$/;
@@ -457,34 +463,76 @@ function parseMemoryBytes(raw: string): number | null {
   return Math.floor(value * multiplier);
 }
 
-function readContainerMemoryBytes(containerName: string): number {
+function readContainerMemoryBytes(
+  containerNames: string[],
+): Map<string, number> {
+  const memoryByContainer = new Map<string, number>();
+  const uniqueContainerNames = Array.from(new Set(containerNames)).filter(
+    (name) => name.length > 0,
+  );
+  if (uniqueContainerNames.length === 0) return memoryByContainer;
+
   const result = spawnSync(
     'docker',
-    ['stats', '--no-stream', '--format', '{{.MemUsage}}', containerName],
+    [
+      'stats',
+      '--no-stream',
+      '--format',
+      '{{.Name}}\t{{.MemUsage}}',
+      ...uniqueContainerNames,
+    ],
     { encoding: 'utf-8', timeout: 2_000 },
   );
-  if (result.status !== 0) return 0;
-  const usage = String(result.stdout || '').split('/')[0] || '';
-  return parseMemoryBytes(usage) || 0;
+  if (result.status !== 0) return memoryByContainer;
+
+  for (const line of String(result.stdout || '').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const separatorIndex = trimmed.indexOf('\t');
+    if (separatorIndex === -1) continue;
+    const containerName = trimmed.slice(0, separatorIndex).trim();
+    const usage = trimmed.slice(separatorIndex + 1).split('/')[0] || '';
+    memoryByContainer.set(containerName, parseMemoryBytes(usage) || 0);
+  }
+  return memoryByContainer;
 }
 
 function getObservedContainerMemoryBytes(): number {
+  const warmEntries = warmPool.values();
+  if (warmEntries.length === 0 || !warmPool.memoryPressureEnabled) return 0;
+  const containerNames = [
+    ...Array.from(pool.values()).map((entry) => entry.containerName),
+    ...warmEntries.map((entry) => entry.containerName),
+  ];
+  const containerKey = Array.from(new Set(containerNames)).sort().join('\n');
+  const now = Date.now();
+  if (
+    containerMemorySample &&
+    containerMemorySample.containerKey === containerKey &&
+    now - containerMemorySample.at < MEMORY_SAMPLE_TTL_MS
+  ) {
+    return containerMemorySample.totalBytes;
+  }
+
+  const memoryByContainer = readContainerMemoryBytes(containerNames);
   let total = 0;
-  for (const entry of pool.values()) {
-    total += readContainerMemoryBytes(entry.containerName);
+  for (const containerName of containerNames) {
+    total += memoryByContainer.get(containerName) || 0;
   }
-  for (const entry of warmPool.values()) {
-    total += readContainerMemoryBytes(entry.containerName);
-  }
+  containerMemorySample = { at: now, containerKey, totalBytes: total };
   return total;
 }
 
 function enforceWarmContainerPressure(): void {
+  if (warmPool.size === 0) return;
+  const totalProcessCount = getTotalContainerProcessCount();
+  const overCapacity = totalProcessCount > MAX_CONCURRENT_CONTAINERS;
+  if (!overCapacity && !warmPool.memoryPressureEnabled) return;
   stopWarmEntries(
     warmPool.evictForPressure({
-      totalProcessCount: getTotalContainerProcessCount(),
+      totalProcessCount,
       maxProcessCount: MAX_CONCURRENT_CONTAINERS,
-      rssBytes: getObservedContainerMemoryBytes(),
+      rssBytes: overCapacity ? undefined : getObservedContainerMemoryBytes(),
     }),
   );
 }
@@ -1073,7 +1121,6 @@ async function runContainerInner(
       warmPool.evictForPressure({
         totalProcessCount: getTotalContainerProcessCount() + 1,
         maxProcessCount: MAX_CONCURRENT_CONTAINERS,
-        rssBytes: getObservedContainerMemoryBytes(),
       }),
     );
   }

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -37,6 +37,7 @@ import {
   HYBRIDAI_MODEL,
   MAX_CONCURRENT_CONTAINERS,
   MCP_SERVERS,
+  onConfigChange,
   PERPLEXITY_API_KEY,
   PROACTIVE_AUTO_RETRY_BASE_DELAY_MS,
   PROACTIVE_AUTO_RETRY_ENABLED,
@@ -421,6 +422,15 @@ function stopWarmEntries(entries: PoolEntry[]): void {
     stop: stopPoolEntry,
   });
 }
+
+onConfigChange((config) => {
+  stopWarmEntries(
+    warmPool.reconfigure(
+      normalizeWarmProcessPoolRuntimeConfig(config.container.warmPool),
+    ),
+  );
+  containerMemorySample = null;
+});
 
 function parseMemoryBytes(raw: string): number | null {
   const match = raw.trim().match(/^([\d.]+)\s*([kmgt]?i?b)?/i);

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -1,4 +1,4 @@
-import { type ChildProcess, spawn, spawnSync } from 'node:child_process';
+import { type ChildProcess, spawn } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -196,6 +196,7 @@ const warmPool = new WarmProcessPool<PoolEntry>(
   normalizeWarmProcessPoolRuntimeConfig(CONTAINER_WARM_POOL),
 );
 let hostMemorySample: MemorySample | null = null;
+let hostMemoryRefreshInFlight = false;
 
 function formatHostAgentTerminalError(
   entry: PoolEntry,
@@ -477,15 +478,42 @@ function stopWarmEntries(entries: PoolEntry[]): void {
   });
 }
 
-function readProcessRssBytes(pid: number | undefined): number {
+async function readProcessRssBytes(pid: number | undefined): Promise<number> {
   if (!pid) return 0;
-  const result = spawnSync('ps', ['-o', 'rss=', '-p', String(pid)], {
-    encoding: 'utf-8',
-    timeout: 2_000,
+  if (process.platform === 'linux') {
+    const status = await fs.promises
+      .readFile(`/proc/${pid}/status`, 'utf-8')
+      .catch(() => '');
+    const match = status.match(/^VmRSS:\s+(\d+)\s+kB$/m);
+    const rssKb = match ? Number(match[1]) : 0;
+    return Number.isFinite(rssKb) ? Math.max(0, Math.floor(rssKb * 1024)) : 0;
+  }
+
+  return new Promise((resolve) => {
+    const proc = spawn('ps', ['-o', 'rss=', '-p', String(pid)], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    let stdout = '';
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      const rssKb = Number(stdout.trim());
+      resolve(
+        Number.isFinite(rssKb) ? Math.max(0, Math.floor(rssKb * 1024)) : 0,
+      );
+    };
+    const timer = setTimeout(() => {
+      proc.kill('SIGTERM');
+      finish();
+    }, 2_000);
+    proc.stdout?.on('data', (chunk) => {
+      stdout += chunk.toString('utf-8');
+    });
+    proc.on('error', finish);
+    proc.on('close', finish);
   });
-  if (result.status !== 0) return 0;
-  const rssKb = Number(String(result.stdout || '').trim());
-  return Number.isFinite(rssKb) ? Math.max(0, Math.floor(rssKb * 1024)) : 0;
 }
 
 function getObservedHostProcessMemoryBytes(): number {
@@ -494,13 +522,21 @@ function getObservedHostProcessMemoryBytes(): number {
     setCache: (sample) => {
       hostMemorySample = sample;
     },
+    isRefreshInFlight: () => hostMemoryRefreshInFlight,
+    setRefreshInFlight: (value) => {
+      hostMemoryRefreshInFlight = value;
+    },
     activeEntries: Array.from(pool.values()),
     warmEntries: warmPool.values(),
     memoryPressureEnabled: warmPool.memoryPressureEnabled,
     keyForEntry: (entry) =>
       typeof entry.process.pid === 'number' ? String(entry.process.pid) : null,
-    readTotalBytes: (pids) =>
-      pids.reduce((sum, pid) => sum + readProcessRssBytes(Number(pid)), 0),
+    refreshTotalBytes: async (pids) => {
+      const rssValues = await Promise.all(
+        pids.map((pid) => readProcessRssBytes(Number(pid))),
+      );
+      return rssValues.reduce((sum, rssBytes) => sum + rssBytes, 0);
+    },
   });
 }
 
@@ -527,7 +563,6 @@ function claimWarmHostProcess(params: {
     sessionId: params.sessionId,
     agentId: params.agentId,
     eligibility: params,
-    enforcePressure: enforceWarmHostPressure,
     logClaim: (entry) =>
       logger.info(
         {
@@ -552,7 +587,6 @@ function maintainWarmHostPool(params: {
     maxProcessCount: MAX_CONCURRENT_CONTAINERS,
     agentId: params.agentId,
     eligibility: params,
-    enforcePressure: enforceWarmHostPressure,
     stopEntries: stopWarmEntries,
     spawnWarm: (sessionId, agentId) => {
       getOrSpawnHostProcess({ sessionId, agentId, warm: true });

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -1,4 +1,4 @@
-import { type ChildProcess, spawn } from 'node:child_process';
+import { type ChildProcess, spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -13,6 +13,7 @@ import {
   CONTAINER_BINDS,
   CONTAINER_PERSIST_BASH_STATE,
   CONTAINER_TIMEOUT,
+  CONTAINER_WARM_POOL,
   CONTEXT_GUARD_COMPACTION_RATIO,
   CONTEXT_GUARD_ENABLED,
   CONTEXT_GUARD_MAX_RETRIES,
@@ -83,6 +84,11 @@ import {
   isThinkingDeltaLine,
   type StreamDebugState,
 } from './stream-debug.js';
+import {
+  normalizeWarmProcessPoolConfig,
+  WarmProcessPool,
+  type WarmProcessPoolEntry,
+} from './warm-process-pool.js';
 import { computeWorkerSignature } from './worker-signature.js';
 
 const IDLE_TIMEOUT_MS = 300_000;
@@ -93,6 +99,8 @@ const TOOL_RESULT_RE =
 const TOOL_START_RE = /^\[tool\]\s+([a-zA-Z0-9_.-]+):\s*(.*)$/;
 const APPROVAL_RE = /^\[approval\]\s+([A-Za-z0-9+/=]+)$/;
 const AGENT_OUTPUT_TIMEOUT_PREFIX = 'Timeout waiting for agent output after ';
+const AGENT_READY_FOR_INPUT_LINE = '[hybridclaw-agent] ready for input';
+const AGENT_REQUEST_START_LINE = '[hybridclaw-agent] agent request start';
 
 function resolveExecutorMaxTokens(params: {
   model: string;
@@ -151,10 +159,16 @@ function resolveHostAgentBrowserBinary(): string | undefined {
   return undefined;
 }
 
-interface PoolEntry {
+interface PoolEntry extends WarmProcessPoolEntry {
   process: ChildProcess;
   sessionId: string;
+  ipcSessionId: string;
+  agentId: string;
   startedAt: number;
+  lastUsedAt: number;
+  warm: boolean;
+  readyForInputAt: number | null;
+  pendingColdStartProbeStartedAt: number | null;
   stderrBuffer: string;
   stderrHistory: string[];
   streamDebug: StreamDebugState;
@@ -169,6 +183,13 @@ interface PoolEntry {
 }
 
 const pool = new Map<string, PoolEntry>();
+const warmPool = new WarmProcessPool<PoolEntry>(
+  normalizeWarmProcessPoolConfig({
+    ...CONTAINER_WARM_POOL,
+    memoryPressureRssBytes:
+      CONTAINER_WARM_POOL.memoryPressureRssMb * 1024 * 1024,
+  }),
+);
 const STDERR_HISTORY_LIMIT = 20;
 
 function rememberStderrLine(entry: PoolEntry, line: string): void {
@@ -238,7 +259,18 @@ async function waitForHostCapacity(
   abortSignal?: AbortSignal,
 ): Promise<'available' | 'aborted' | 'timed_out'> {
   const deadline = Date.now() + HOST_CAPACITY_WAIT_MS;
-  while (pool.size >= MAX_CONCURRENT_CONTAINERS && !pool.has(sessionId)) {
+  while (
+    getTotalHostProcessCount() >= MAX_CONCURRENT_CONTAINERS &&
+    !pool.has(sessionId)
+  ) {
+    stopWarmEntries(
+      warmPool.evictForPressure({
+        totalProcessCount: getTotalHostProcessCount() + 1,
+        maxProcessCount: MAX_CONCURRENT_CONTAINERS,
+        rssBytes: getObservedHostProcessMemoryBytes(),
+      }),
+    );
+    if (getTotalHostProcessCount() < MAX_CONCURRENT_CONTAINERS) break;
     if (abortSignal?.aborted) return 'aborted';
     const remainingMs = deadline - Date.now();
     if (remainingMs <= 0) return 'timed_out';
@@ -269,6 +301,14 @@ export function getActiveHostSessionIds(): string[] {
   return Array.from(pool.keys()).sort((left, right) =>
     left.localeCompare(right),
   );
+}
+
+export function getWarmHostColdStartP95Ms(): number | null {
+  return warmPool.coldStartP95Ms();
+}
+
+export function isWarmHostColdStartWithinBudget(): boolean {
+  return warmPool.isWithinColdStartBudget();
 }
 
 function emitTextDelta(entry: PoolEntry, line: string): void {
@@ -433,6 +473,147 @@ function stopHostProcess(entry: PoolEntry): void {
   }
 }
 
+function getTotalHostProcessCount(): number {
+  return pool.size + warmPool.size;
+}
+
+function removePoolEntry(entry: PoolEntry): void {
+  warmPool.delete(entry.id);
+  for (const [sessionId, active] of pool) {
+    if (active === entry) pool.delete(sessionId);
+  }
+}
+
+function stopWarmEntries(entries: PoolEntry[]): void {
+  for (const entry of entries) {
+    logger.info({ agentId: entry.agentId }, 'Evicting warm host agent process');
+    stopHostProcess(entry);
+  }
+}
+
+function readProcessRssBytes(pid: number | undefined): number {
+  if (!pid) return 0;
+  const result = spawnSync('ps', ['-o', 'rss=', '-p', String(pid)], {
+    encoding: 'utf-8',
+    timeout: 2_000,
+  });
+  if (result.status !== 0) return 0;
+  const rssKb = Number(String(result.stdout || '').trim());
+  return Number.isFinite(rssKb) ? Math.max(0, Math.floor(rssKb * 1024)) : 0;
+}
+
+function getObservedHostProcessMemoryBytes(): number {
+  let total = 0;
+  for (const entry of pool.values()) {
+    total += readProcessRssBytes(entry.process.pid);
+  }
+  for (const entry of warmPool.values()) {
+    total += readProcessRssBytes(entry.process.pid);
+  }
+  return total;
+}
+
+function enforceWarmHostPressure(): void {
+  stopWarmEntries(
+    warmPool.evictForPressure({
+      totalProcessCount: getTotalHostProcessCount(),
+      maxProcessCount: MAX_CONCURRENT_CONTAINERS,
+      rssBytes: getObservedHostProcessMemoryBytes(),
+    }),
+  );
+}
+
+function markWorkerReadyForInput(entry: PoolEntry): void {
+  entry.readyForInputAt = Date.now();
+}
+
+function markAgentRequestStart(entry: PoolEntry): void {
+  const startedAt = entry.pendingColdStartProbeStartedAt;
+  if (startedAt == null) return;
+  warmPool.recordColdStart(Date.now() - startedAt);
+  entry.pendingColdStartProbeStartedAt = null;
+}
+
+function observeAgentLifecycleLine(entry: PoolEntry, line: string): boolean {
+  if (line === AGENT_READY_FOR_INPUT_LINE) {
+    markWorkerReadyForInput(entry);
+    entry.activity?.notify();
+    return true;
+  }
+  if (line === AGENT_REQUEST_START_LINE) {
+    markAgentRequestStart(entry);
+    entry.activity?.notify();
+    return true;
+  }
+  return false;
+}
+
+function canUseWarmHostPool(params: {
+  workspacePathOverride?: string;
+  workspaceDisplayRootOverride?: string;
+  bashProxy?: ExecutorRequest['bashProxy'];
+}): boolean {
+  return (
+    warmPool.enabled &&
+    !params.workspacePathOverride?.trim() &&
+    !params.workspaceDisplayRootOverride?.trim() &&
+    !params.bashProxy
+  );
+}
+
+function createWarmSessionId(agentId: string): string {
+  const safeAgent = agentId.replace(/[^a-zA-Z0-9_-]/g, '_');
+  return `warm_${safeAgent}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function claimWarmHostProcess(params: {
+  sessionId: string;
+  agentId: string;
+  workspacePathOverride?: string;
+  workspaceDisplayRootOverride?: string;
+  bashProxy?: ExecutorRequest['bashProxy'];
+}): PoolEntry | null {
+  if (!canUseWarmHostPool(params)) return null;
+  enforceWarmHostPressure();
+  const entry = warmPool.claim(params.agentId);
+  if (!entry) return null;
+  entry.sessionId = params.sessionId;
+  entry.warm = false;
+  entry.lastUsedAt = Date.now();
+  pool.set(params.sessionId, entry);
+  logger.info(
+    {
+      sessionId: params.sessionId,
+      ipcSessionId: entry.ipcSessionId,
+      agentId: params.agentId,
+    },
+    'Claimed warm host agent process',
+  );
+  return entry;
+}
+
+function maintainWarmHostPool(params: {
+  agentId: string;
+  workspacePathOverride?: string;
+  workspaceDisplayRootOverride?: string;
+  bashProxy?: ExecutorRequest['bashProxy'];
+}): void {
+  if (!canUseWarmHostPool(params)) return;
+  enforceWarmHostPressure();
+  const targetSize = warmPool.targetIdleForAgent(params.agentId);
+  stopWarmEntries(warmPool.trimAgent(params.agentId, targetSize));
+  while (
+    warmPool.idleCountForAgent(params.agentId) < targetSize &&
+    getTotalHostProcessCount() < MAX_CONCURRENT_CONTAINERS
+  ) {
+    getOrSpawnHostProcess({
+      sessionId: createWarmSessionId(params.agentId),
+      agentId: params.agentId,
+      warm: true,
+    });
+  }
+}
+
 function isTimedOutAgentOutput(output: ContainerOutput): boolean {
   return (
     output.status === 'error' &&
@@ -449,11 +630,12 @@ function getOrSpawnHostProcess(
     | 'workspacePathOverride'
     | 'workspaceDisplayRootOverride'
     | 'bashProxy'
-  >,
+  > & { ipcSessionId?: string; warm?: boolean },
 ): PoolEntry {
   const sessionId = params.sessionId;
+  const ipcSessionId = params.ipcSessionId || sessionId;
   const agentId = params.agentId || DEFAULT_AGENT_ID;
-  const existing = pool.get(sessionId);
+  const existing = params.warm ? null : pool.get(sessionId);
   if (
     existing &&
     !existing.process.killed &&
@@ -465,9 +647,9 @@ function getOrSpawnHostProcess(
 
   if (existing) pool.delete(sessionId);
 
-  ensureSessionDirs(sessionId);
+  ensureSessionDirs(ipcSessionId);
   ensureAgentDirs(agentId);
-  const { ipcPath } = getSessionPaths(sessionId, agentId);
+  const { ipcPath } = getSessionPaths(ipcSessionId, agentId);
   const workspacePath = getHostWorkspacePath({
     sessionId,
     agentId,
@@ -527,7 +709,14 @@ function getOrSpawnHostProcess(
   }
 
   logger.info(
-    { sessionId, command: runtime.command, args: runtime.args },
+    {
+      sessionId,
+      ipcSessionId,
+      agentId,
+      command: runtime.command,
+      args: runtime.args,
+      warm: params.warm,
+    },
     'Spawning host agent process',
   );
 
@@ -538,14 +727,27 @@ function getOrSpawnHostProcess(
   });
 
   const entry: PoolEntry = {
+    id: ipcSessionId,
     process: proc,
     sessionId,
+    ipcSessionId,
+    agentId,
     startedAt: Date.now(),
+    lastUsedAt: Date.now(),
+    warm: params.warm === true,
+    readyForInputAt: null,
+    pendingColdStartProbeStartedAt: null,
     stderrBuffer: '',
     stderrHistory: [],
     streamDebug: createStreamDebugState(),
     workerSignature: '',
     terminalError: null,
+    isReady() {
+      return entry.readyForInputAt != null;
+    },
+    stop() {
+      stopHostProcess(entry);
+    },
   };
 
   proc.stderr.on('data', (data) => {
@@ -555,6 +757,7 @@ function getOrSpawnHostProcess(
     for (const rawLine of lines) {
       const line = rawLine.trim();
       if (!line) continue;
+      if (observeAgentLifecycleLine(entry, line)) continue;
       if (consumeModelResponseDebugFileLine(line)) {
         entry.activity?.notify();
         continue;
@@ -594,7 +797,9 @@ function getOrSpawnHostProcess(
   proc.on('close', (code, signal) => {
     const tail = entry.stderrBuffer.trim();
     if (tail) {
-      if (consumeModelResponseDebugFileLine(tail)) {
+      if (observeAgentLifecycleLine(entry, tail)) {
+        entry.stderrBuffer = '';
+      } else if (consumeModelResponseDebugFileLine(tail)) {
         entry.activity?.notify();
         entry.stderrBuffer = '';
       } else {
@@ -626,13 +831,13 @@ function getOrSpawnHostProcess(
     flushCollapsedStreamDebugSummary(entry.streamDebug, (message) => {
       logger.debug({ sessionId }, message);
     });
-    pool.delete(sessionId);
+    removePoolEntry(entry);
     logger.info({ sessionId, code, signal }, 'Host agent process exited');
   });
 
   proc.on('error', (err) => {
     entry.terminalError = `Host agent process failed before producing output: ${err instanceof Error ? err.message : String(err)}`;
-    pool.delete(sessionId);
+    removePoolEntry(entry);
     logger.error({ sessionId, error: err }, 'Host agent process error');
   });
 
@@ -647,7 +852,11 @@ function getOrSpawnHostProcess(
     logger.error({ sessionId, error: err }, 'Host agent stdin error');
   });
 
-  pool.set(sessionId, entry);
+  if (entry.warm) {
+    warmPool.add(entry);
+  } else {
+    pool.set(sessionId, entry);
+  }
   return entry;
 }
 
@@ -659,7 +868,7 @@ export function stopSessionHostProcess(sessionId: string): boolean {
   const entry = pool.get(sessionId);
   if (!entry) return false;
   stopHostProcess(entry);
-  pool.delete(sessionId);
+  removePoolEntry(entry);
   return true;
 }
 
@@ -732,7 +941,11 @@ async function runHostProcessInner(
     return {};
   });
 
-  if (pool.size >= MAX_CONCURRENT_CONTAINERS && !pool.has(sessionId)) {
+  enforceWarmHostPressure();
+  if (
+    getTotalHostProcessCount() >= MAX_CONCURRENT_CONTAINERS &&
+    !pool.has(sessionId)
+  ) {
     const capacityState = await waitForHostCapacity(sessionId, abortSignal);
     if (capacityState === 'aborted') {
       return interruptedHostOutput();
@@ -742,13 +955,12 @@ async function runHostProcessInner(
         status: 'error',
         result: null,
         toolsUsed: [],
-        error: `Too many active host agent processes (${pool.size}/${MAX_CONCURRENT_CONTAINERS}) after waiting ${HOST_CAPACITY_WAIT_MS}ms. Try again later.`,
+        error: `Too many active host agent processes (${getTotalHostProcessCount()}/${MAX_CONCURRENT_CONTAINERS}) after waiting ${HOST_CAPACITY_WAIT_MS}ms. Try again later.`,
       };
     }
   }
 
-  cleanupIpc(sessionId);
-  ensureSessionDirs(sessionId);
+  const startTime = Date.now();
 
   const input: ContainerInput = {
     sessionId,
@@ -840,7 +1052,7 @@ async function runHostProcessInner(
       'Worker routing changed; restarting host agent process',
     );
     stopHostProcess(existingEntry);
-    pool.delete(sessionId);
+    removePoolEntry(existingEntry);
   }
 
   const isNewProcess =
@@ -850,13 +1062,23 @@ async function runHostProcessInner(
 
   let entry: PoolEntry;
   try {
-    entry = getOrSpawnHostProcess({
-      sessionId,
-      agentId,
-      workspacePathOverride: params.workspacePathOverride,
-      workspaceDisplayRootOverride: params.workspaceDisplayRootOverride,
-      bashProxy: params.bashProxy,
-    });
+    entry =
+      (isNewProcess
+        ? claimWarmHostProcess({
+            sessionId,
+            agentId,
+            workspacePathOverride: params.workspacePathOverride,
+            workspaceDisplayRootOverride: params.workspaceDisplayRootOverride,
+            bashProxy: params.bashProxy,
+          })
+        : null) ||
+      getOrSpawnHostProcess({
+        sessionId,
+        agentId,
+        workspacePathOverride: params.workspacePathOverride,
+        workspaceDisplayRootOverride: params.workspaceDisplayRootOverride,
+        bashProxy: params.bashProxy,
+      });
   } catch (err) {
     return {
       status: 'error',
@@ -865,6 +1087,8 @@ async function runHostProcessInner(
       error: `Host agent spawn error: ${err instanceof Error ? err.message : String(err)}`,
     };
   }
+  cleanupIpc(entry.ipcSessionId);
+  ensureSessionDirs(entry.ipcSessionId);
   entry.workerSignature = workerSignature;
 
   const activity = createActivityTracker();
@@ -891,6 +1115,7 @@ async function runHostProcessInner(
       return interruptedHostOutput();
     }
     if (isNewProcess) {
+      entry.pendingColdStartProbeStartedAt = Date.now();
       try {
         entry.process.stdin?.write(`${JSON.stringify(input)}\n`);
       } catch (err) {
@@ -904,11 +1129,11 @@ async function runHostProcessInner(
         throw err;
       }
     } else {
-      writeInput(sessionId, input, { omitApiKey: true });
+      writeInput(entry.ipcSessionId, input, { omitApiKey: true });
     }
 
     const output = await readOutput(
-      sessionId,
+      entry.ipcSessionId,
       inactivityTimeoutMs === undefined
         ? CONTAINER_TIMEOUT
         : inactivityTimeoutMs,
@@ -919,7 +1144,8 @@ async function runHostProcessInner(
         terminalError: () => entry.terminalError,
       },
     );
-    if (isTimedOutAgentOutput(output)) {
+    const timedOut = isTimedOutAgentOutput(output);
+    if (timedOut) {
       logger.warn(
         { sessionId },
         'Agent output timed out; stopping stuck host agent process',
@@ -945,6 +1171,17 @@ async function runHostProcessInner(
         reason: redactCredentialSecrets(output.pendingApproval.reason),
       };
     }
+    const duration = Date.now() - startTime;
+    if (!timedOut) {
+      entry.lastUsedAt = Date.now();
+      warmPool.recordRequest(agentId, duration);
+      maintainWarmHostPool({
+        agentId,
+        workspacePathOverride: params.workspacePathOverride,
+        workspaceDisplayRootOverride: params.workspaceDisplayRootOverride,
+        bashProxy: params.bashProxy,
+      });
+    }
     return output;
   } finally {
     abortSignal?.removeEventListener('abort', onAbort);
@@ -968,6 +1205,10 @@ export function stopAllHostProcesses(): void {
     stopHostProcess(entry);
   }
   pool.clear();
+  for (const entry of warmPool.clear()) {
+    logger.info({ agentId: entry.agentId }, 'Stopping warm host process');
+    stopHostProcess(entry);
+  }
 }
 
 export class HostExecutor {

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -836,6 +836,7 @@ function getOrSpawnHostProcess(
 
   if (entry.warm) {
     warmPool.add(entry);
+    getObservedHostProcessMemoryBytes();
   } else {
     pool.set(sessionId, entry);
   }

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -25,6 +25,7 @@ import {
   HYBRIDAI_MODEL,
   MAX_CONCURRENT_CONTAINERS,
   MCP_SERVERS,
+  onConfigChange,
   PERPLEXITY_API_KEY,
   PROACTIVE_AUTO_RETRY_BASE_DELAY_MS,
   PROACTIVE_AUTO_RETRY_ENABLED,
@@ -477,6 +478,15 @@ function stopWarmEntries(entries: PoolEntry[]): void {
     stop: stopHostProcess,
   });
 }
+
+onConfigChange((config) => {
+  stopWarmEntries(
+    warmPool.reconfigure(
+      normalizeWarmProcessPoolRuntimeConfig(config.container.warmPool),
+    ),
+  );
+  hostMemorySample = null;
+});
 
 async function readProcessRssBytes(pid: number | undefined): Promise<number> {
   if (!pid) return 0;

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -191,6 +191,12 @@ const warmPool = new WarmProcessPool<PoolEntry>(
   }),
 );
 const STDERR_HISTORY_LIMIT = 20;
+const MEMORY_SAMPLE_TTL_MS = 5_000;
+let hostMemorySample: {
+  at: number;
+  processKey: string;
+  totalBytes: number;
+} | null = null;
 
 function rememberStderrLine(entry: PoolEntry, line: string): void {
   entry.stderrHistory.push(line);
@@ -267,7 +273,6 @@ async function waitForHostCapacity(
       warmPool.evictForPressure({
         totalProcessCount: getTotalHostProcessCount() + 1,
         maxProcessCount: MAX_CONCURRENT_CONTAINERS,
-        rssBytes: getObservedHostProcessMemoryBytes(),
       }),
     );
     if (getTotalHostProcessCount() < MAX_CONCURRENT_CONTAINERS) break;
@@ -503,22 +508,40 @@ function readProcessRssBytes(pid: number | undefined): number {
 }
 
 function getObservedHostProcessMemoryBytes(): number {
+  const warmEntries = warmPool.values();
+  if (warmEntries.length === 0 || !warmPool.memoryPressureEnabled) return 0;
+  const pids = [
+    ...Array.from(pool.values()).map((entry) => entry.process.pid),
+    ...warmEntries.map((entry) => entry.process.pid),
+  ].filter((pid): pid is number => typeof pid === 'number');
+  const processKey = Array.from(new Set(pids)).sort().join('\n');
+  const now = Date.now();
+  if (
+    hostMemorySample &&
+    hostMemorySample.processKey === processKey &&
+    now - hostMemorySample.at < MEMORY_SAMPLE_TTL_MS
+  ) {
+    return hostMemorySample.totalBytes;
+  }
+
   let total = 0;
-  for (const entry of pool.values()) {
-    total += readProcessRssBytes(entry.process.pid);
+  for (const pid of pids) {
+    total += readProcessRssBytes(pid);
   }
-  for (const entry of warmPool.values()) {
-    total += readProcessRssBytes(entry.process.pid);
-  }
+  hostMemorySample = { at: now, processKey, totalBytes: total };
   return total;
 }
 
 function enforceWarmHostPressure(): void {
+  if (warmPool.size === 0) return;
+  const totalProcessCount = getTotalHostProcessCount();
+  const overCapacity = totalProcessCount > MAX_CONCURRENT_CONTAINERS;
+  if (!overCapacity && !warmPool.memoryPressureEnabled) return;
   stopWarmEntries(
     warmPool.evictForPressure({
-      totalProcessCount: getTotalHostProcessCount(),
+      totalProcessCount,
       maxProcessCount: MAX_CONCURRENT_CONTAINERS,
-      rssBytes: getObservedHostProcessMemoryBytes(),
+      rssBytes: overCapacity ? undefined : getObservedHostProcessMemoryBytes(),
     }),
   );
 }

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -84,23 +84,32 @@ import {
   isThinkingDeltaLine,
   type StreamDebugState,
 } from './stream-debug.js';
+import { WarmProcessPool } from './warm-process-pool.js';
 import {
-  normalizeWarmProcessPoolConfig,
-  WarmProcessPool,
-  type WarmProcessPoolEntry,
-} from './warm-process-pool.js';
+  claimWarmEntry,
+  enforceWarmPoolPressure,
+  getCachedObservedMemoryBytes,
+  getTotalWarmProcessCount,
+  IDLE_TIMEOUT_MS,
+  isTimedOutAgentOutput,
+  type MemorySample,
+  maintainWarmPool,
+  normalizeWarmProcessPoolRuntimeConfig,
+  observeAgentLifecycleLine,
+  rememberStderrLine,
+  removeWarmPoolEntry,
+  stopWarmEntries as stopWarmPoolEntries,
+  summarizeExit,
+  type WarmRunnerEntry,
+} from './warm-runner-utils.js';
 import { computeWorkerSignature } from './worker-signature.js';
 
-const IDLE_TIMEOUT_MS = 300_000;
 const HOST_CAPACITY_WAIT_MS = 15_000;
 const HOST_CAPACITY_POLL_MS = 100;
 const TOOL_RESULT_RE =
   /^\[tool\]\s+([a-zA-Z0-9_.-]+)\s+result\s+\((\d+)ms\):\s*(.*)$/;
 const TOOL_START_RE = /^\[tool\]\s+([a-zA-Z0-9_.-]+):\s*(.*)$/;
 const APPROVAL_RE = /^\[approval\]\s+([A-Za-z0-9+/=]+)$/;
-const AGENT_OUTPUT_TIMEOUT_PREFIX = 'Timeout waiting for agent output after ';
-const AGENT_READY_FOR_INPUT_LINE = '[hybridclaw-agent] ready for input';
-const AGENT_REQUEST_START_LINE = '[hybridclaw-agent] agent request start';
 
 function resolveExecutorMaxTokens(params: {
   model: string;
@@ -159,7 +168,7 @@ function resolveHostAgentBrowserBinary(): string | undefined {
   return undefined;
 }
 
-interface PoolEntry extends WarmProcessPoolEntry {
+interface PoolEntry extends WarmRunnerEntry {
   process: ChildProcess;
   sessionId: string;
   ipcSessionId: string;
@@ -184,38 +193,9 @@ interface PoolEntry extends WarmProcessPoolEntry {
 
 const pool = new Map<string, PoolEntry>();
 const warmPool = new WarmProcessPool<PoolEntry>(
-  normalizeWarmProcessPoolConfig({
-    ...CONTAINER_WARM_POOL,
-    memoryPressureRssBytes:
-      CONTAINER_WARM_POOL.memoryPressureRssMb * 1024 * 1024,
-  }),
+  normalizeWarmProcessPoolRuntimeConfig(CONTAINER_WARM_POOL),
 );
-const STDERR_HISTORY_LIMIT = 20;
-const MEMORY_SAMPLE_TTL_MS = 5_000;
-let hostMemorySample: {
-  at: number;
-  processKey: string;
-  totalBytes: number;
-} | null = null;
-
-function rememberStderrLine(entry: PoolEntry, line: string): void {
-  entry.stderrHistory.push(line);
-  if (entry.stderrHistory.length > STDERR_HISTORY_LIMIT) {
-    entry.stderrHistory.splice(
-      0,
-      entry.stderrHistory.length - STDERR_HISTORY_LIMIT,
-    );
-  }
-}
-
-function summarizeExit(
-  code: number | null,
-  signal: NodeJS.Signals | null,
-): string {
-  if (typeof code === 'number') return `exit code ${code}`;
-  if (signal) return `signal ${signal}`;
-  return 'unknown exit status';
-}
+let hostMemorySample: MemorySample | null = null;
 
 function formatHostAgentTerminalError(
   entry: PoolEntry,
@@ -479,21 +459,22 @@ function stopHostProcess(entry: PoolEntry): void {
 }
 
 function getTotalHostProcessCount(): number {
-  return pool.size + warmPool.size;
+  return getTotalWarmProcessCount(pool, warmPool);
 }
 
 function removePoolEntry(entry: PoolEntry): void {
-  warmPool.delete(entry.id);
-  for (const [sessionId, active] of pool) {
-    if (active === entry) pool.delete(sessionId);
-  }
+  removeWarmPoolEntry(pool, warmPool, entry);
 }
 
 function stopWarmEntries(entries: PoolEntry[]): void {
-  for (const entry of entries) {
-    logger.info({ agentId: entry.agentId }, 'Evicting warm host agent process');
-    stopHostProcess(entry);
-  }
+  stopWarmPoolEntries(entries, {
+    log: (entry) =>
+      logger.info(
+        { agentId: entry.agentId },
+        'Evicting warm host agent process',
+      ),
+    stop: stopHostProcess,
+  });
 }
 
 function readProcessRssBytes(pid: number | undefined): number {
@@ -508,85 +489,29 @@ function readProcessRssBytes(pid: number | undefined): number {
 }
 
 function getObservedHostProcessMemoryBytes(): number {
-  const warmEntries = warmPool.values();
-  if (warmEntries.length === 0 || !warmPool.memoryPressureEnabled) return 0;
-  const pids = [
-    ...Array.from(pool.values()).map((entry) => entry.process.pid),
-    ...warmEntries.map((entry) => entry.process.pid),
-  ].filter((pid): pid is number => typeof pid === 'number');
-  const processKey = Array.from(new Set(pids)).sort().join('\n');
-  const now = Date.now();
-  if (
-    hostMemorySample &&
-    hostMemorySample.processKey === processKey &&
-    now - hostMemorySample.at < MEMORY_SAMPLE_TTL_MS
-  ) {
-    return hostMemorySample.totalBytes;
-  }
-
-  let total = 0;
-  for (const pid of pids) {
-    total += readProcessRssBytes(pid);
-  }
-  hostMemorySample = { at: now, processKey, totalBytes: total };
-  return total;
+  return getCachedObservedMemoryBytes({
+    cache: hostMemorySample,
+    setCache: (sample) => {
+      hostMemorySample = sample;
+    },
+    activeEntries: Array.from(pool.values()),
+    warmEntries: warmPool.values(),
+    memoryPressureEnabled: warmPool.memoryPressureEnabled,
+    keyForEntry: (entry) =>
+      typeof entry.process.pid === 'number' ? String(entry.process.pid) : null,
+    readTotalBytes: (pids) =>
+      pids.reduce((sum, pid) => sum + readProcessRssBytes(Number(pid)), 0),
+  });
 }
 
 function enforceWarmHostPressure(): void {
-  if (warmPool.size === 0) return;
-  const totalProcessCount = getTotalHostProcessCount();
-  const overCapacity = totalProcessCount > MAX_CONCURRENT_CONTAINERS;
-  if (!overCapacity && !warmPool.memoryPressureEnabled) return;
-  stopWarmEntries(
-    warmPool.evictForPressure({
-      totalProcessCount,
-      maxProcessCount: MAX_CONCURRENT_CONTAINERS,
-      rssBytes: overCapacity ? undefined : getObservedHostProcessMemoryBytes(),
-    }),
-  );
-}
-
-function markWorkerReadyForInput(entry: PoolEntry): void {
-  entry.readyForInputAt = Date.now();
-}
-
-function markAgentRequestStart(entry: PoolEntry): void {
-  const startedAt = entry.pendingColdStartProbeStartedAt;
-  if (startedAt == null) return;
-  warmPool.recordColdStart(Date.now() - startedAt);
-  entry.pendingColdStartProbeStartedAt = null;
-}
-
-function observeAgentLifecycleLine(entry: PoolEntry, line: string): boolean {
-  if (line === AGENT_READY_FOR_INPUT_LINE) {
-    markWorkerReadyForInput(entry);
-    entry.activity?.notify();
-    return true;
-  }
-  if (line === AGENT_REQUEST_START_LINE) {
-    markAgentRequestStart(entry);
-    entry.activity?.notify();
-    return true;
-  }
-  return false;
-}
-
-function canUseWarmHostPool(params: {
-  workspacePathOverride?: string;
-  workspaceDisplayRootOverride?: string;
-  bashProxy?: ExecutorRequest['bashProxy'];
-}): boolean {
-  return (
-    warmPool.enabled &&
-    !params.workspacePathOverride?.trim() &&
-    !params.workspaceDisplayRootOverride?.trim() &&
-    !params.bashProxy
-  );
-}
-
-function createWarmSessionId(agentId: string): string {
-  const safeAgent = agentId.replace(/[^a-zA-Z0-9_-]/g, '_');
-  return `warm_${safeAgent}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  enforceWarmPoolPressure({
+    pool,
+    warmPool,
+    maxProcessCount: MAX_CONCURRENT_CONTAINERS,
+    getObservedMemoryBytes: getObservedHostProcessMemoryBytes,
+    stopEntries: stopWarmEntries,
+  });
 }
 
 function claimWarmHostProcess(params: {
@@ -596,23 +521,23 @@ function claimWarmHostProcess(params: {
   workspaceDisplayRootOverride?: string;
   bashProxy?: ExecutorRequest['bashProxy'];
 }): PoolEntry | null {
-  if (!canUseWarmHostPool(params)) return null;
-  enforceWarmHostPressure();
-  const entry = warmPool.claim(params.agentId);
-  if (!entry) return null;
-  entry.sessionId = params.sessionId;
-  entry.warm = false;
-  entry.lastUsedAt = Date.now();
-  pool.set(params.sessionId, entry);
-  logger.info(
-    {
-      sessionId: params.sessionId,
-      ipcSessionId: entry.ipcSessionId,
-      agentId: params.agentId,
-    },
-    'Claimed warm host agent process',
-  );
-  return entry;
+  return claimWarmEntry({
+    pool,
+    warmPool,
+    sessionId: params.sessionId,
+    agentId: params.agentId,
+    eligibility: params,
+    enforcePressure: enforceWarmHostPressure,
+    logClaim: (entry) =>
+      logger.info(
+        {
+          sessionId: params.sessionId,
+          ipcSessionId: entry.ipcSessionId,
+          agentId: params.agentId,
+        },
+        'Claimed warm host agent process',
+      ),
+  });
 }
 
 function maintainWarmHostPool(params: {
@@ -621,28 +546,18 @@ function maintainWarmHostPool(params: {
   workspaceDisplayRootOverride?: string;
   bashProxy?: ExecutorRequest['bashProxy'];
 }): void {
-  if (!canUseWarmHostPool(params)) return;
-  enforceWarmHostPressure();
-  const targetSize = warmPool.targetIdleForAgent(params.agentId);
-  stopWarmEntries(warmPool.trimAgent(params.agentId, targetSize));
-  while (
-    warmPool.idleCountForAgent(params.agentId) < targetSize &&
-    getTotalHostProcessCount() < MAX_CONCURRENT_CONTAINERS
-  ) {
-    getOrSpawnHostProcess({
-      sessionId: createWarmSessionId(params.agentId),
-      agentId: params.agentId,
-      warm: true,
-    });
-  }
-}
-
-function isTimedOutAgentOutput(output: ContainerOutput): boolean {
-  return (
-    output.status === 'error' &&
-    typeof output.error === 'string' &&
-    output.error.startsWith(AGENT_OUTPUT_TIMEOUT_PREFIX)
-  );
+  maintainWarmPool({
+    pool,
+    warmPool,
+    maxProcessCount: MAX_CONCURRENT_CONTAINERS,
+    agentId: params.agentId,
+    eligibility: params,
+    enforcePressure: enforceWarmHostPressure,
+    stopEntries: stopWarmEntries,
+    spawnWarm: (sessionId, agentId) => {
+      getOrSpawnHostProcess({ sessionId, agentId, warm: true });
+    },
+  });
 }
 
 function getOrSpawnHostProcess(
@@ -780,7 +695,7 @@ function getOrSpawnHostProcess(
     for (const rawLine of lines) {
       const line = rawLine.trim();
       if (!line) continue;
-      if (observeAgentLifecycleLine(entry, line)) continue;
+      if (observeAgentLifecycleLine(entry, line, warmPool)) continue;
       if (consumeModelResponseDebugFileLine(line)) {
         entry.activity?.notify();
         continue;
@@ -820,7 +735,7 @@ function getOrSpawnHostProcess(
   proc.on('close', (code, signal) => {
     const tail = entry.stderrBuffer.trim();
     if (tail) {
-      if (observeAgentLifecycleLine(entry, tail)) {
+      if (observeAgentLifecycleLine(entry, tail, warmPool)) {
         entry.stderrBuffer = '';
       } else if (consumeModelResponseDebugFileLine(tail)) {
         entry.activity?.notify();

--- a/src/infra/warm-process-pool.ts
+++ b/src/infra/warm-process-pool.ts
@@ -121,7 +121,7 @@ export class WarmProcessPool<T extends WarmProcessPoolEntry> {
     for (const entry of this.entries.values()) {
       if (entry.agentId !== agentId) continue;
       if (entry.isReady && !entry.isReady()) continue;
-      if (!claimed || entry.lastUsedAt < claimed.lastUsedAt) claimed = entry;
+      if (!claimed || entry.lastUsedAt > claimed.lastUsedAt) claimed = entry;
     }
     if (!claimed) return null;
     this.entries.delete(claimed.id);

--- a/src/infra/warm-process-pool.ts
+++ b/src/infra/warm-process-pool.ts
@@ -1,0 +1,214 @@
+export interface WarmProcessPoolConfig {
+  enabled: boolean;
+  coldStartBudgetMs: number;
+  trafficWindowMs: number;
+  minIdlePerActiveAgent: number;
+  maxIdlePerAgent: number;
+  memoryPressureRssBytes: number;
+}
+
+export interface WarmProcessPoolEntry {
+  id: string;
+  agentId: string;
+  lastUsedAt: number;
+  isReady?: () => boolean;
+  stop(): void;
+}
+
+interface TrafficSample {
+  at: number;
+  durationMs: number;
+}
+
+const DEFAULT_TRAFFIC_WINDOW_MS = 60 * 60 * 1000;
+
+export function normalizeWarmProcessPoolConfig(
+  raw: Partial<WarmProcessPoolConfig> = {},
+): WarmProcessPoolConfig {
+  const coldStartBudgetMs = normalizeInteger(raw.coldStartBudgetMs, 200, 1);
+  const trafficWindowMs = normalizeInteger(
+    raw.trafficWindowMs,
+    DEFAULT_TRAFFIC_WINDOW_MS,
+    60_000,
+  );
+  const minIdlePerActiveAgent = normalizeInteger(
+    raw.minIdlePerActiveAgent,
+    1,
+    0,
+  );
+  const maxIdlePerAgent = normalizeInteger(raw.maxIdlePerAgent, 2, 0);
+  return {
+    enabled: raw.enabled !== false,
+    coldStartBudgetMs,
+    trafficWindowMs,
+    minIdlePerActiveAgent: Math.min(minIdlePerActiveAgent, maxIdlePerAgent),
+    maxIdlePerAgent,
+    memoryPressureRssBytes: normalizeInteger(raw.memoryPressureRssBytes, 0, 0),
+  };
+}
+
+function normalizeInteger(
+  value: unknown,
+  fallback: number,
+  min: number,
+): number {
+  const numeric = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(numeric)) return fallback;
+  return Math.max(min, Math.floor(numeric));
+}
+
+export class WarmProcessPool<T extends WarmProcessPoolEntry> {
+  private readonly entries = new Map<string, T>();
+  private readonly traffic = new Map<string, TrafficSample[]>();
+  private readonly coldStartSamples: number[] = [];
+
+  constructor(private readonly config: WarmProcessPoolConfig) {}
+
+  get enabled(): boolean {
+    return this.config.enabled && this.config.maxIdlePerAgent > 0;
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  values(): T[] {
+    return Array.from(this.entries.values());
+  }
+
+  add(entry: T): void {
+    if (!this.enabled) {
+      entry.stop();
+      return;
+    }
+    this.entries.set(entry.id, entry);
+  }
+
+  delete(id: string): boolean {
+    return this.entries.delete(id);
+  }
+
+  claim(agentId: string, now = Date.now()): T | null {
+    let claimed: T | null = null;
+    for (const entry of this.entries.values()) {
+      if (entry.agentId !== agentId) continue;
+      if (entry.isReady && !entry.isReady()) continue;
+      if (!claimed || entry.lastUsedAt < claimed.lastUsedAt) claimed = entry;
+    }
+    if (!claimed) return null;
+    this.entries.delete(claimed.id);
+    claimed.lastUsedAt = now;
+    return claimed;
+  }
+
+  recordRequest(agentId: string, durationMs: number, now = Date.now()): void {
+    if (!agentId) return;
+    const samples = this.prune(agentId, now);
+    samples.push({ at: now, durationMs: Math.max(1, Math.floor(durationMs)) });
+    this.traffic.set(agentId, samples);
+  }
+
+  recordColdStart(durationMs: number): void {
+    if (!Number.isFinite(durationMs) || durationMs < 0) return;
+    this.coldStartSamples.push(Math.floor(durationMs));
+    if (this.coldStartSamples.length > 500) {
+      this.coldStartSamples.splice(0, this.coldStartSamples.length - 500);
+    }
+  }
+
+  coldStartP95Ms(): number | null {
+    if (this.coldStartSamples.length === 0) return null;
+    return percentile(this.coldStartSamples, 0.95);
+  }
+
+  isWithinColdStartBudget(): boolean {
+    const p95 = this.coldStartP95Ms();
+    return p95 === null || p95 <= this.config.coldStartBudgetMs;
+  }
+
+  targetIdleForAgent(agentId: string, now = Date.now()): number {
+    if (!this.enabled) return 0;
+    const samples = this.prune(agentId, now);
+    if (samples.length === 0) return 0;
+
+    const requestsPerMinute =
+      samples.length / (this.config.trafficWindowMs / 60_000);
+    const avgExecutionSeconds =
+      samples.reduce((sum, sample) => sum + sample.durationMs, 0) /
+      samples.length /
+      1000;
+    const adaptive = Math.ceil((requestsPerMinute / 60) * avgExecutionSeconds);
+    return Math.min(
+      this.config.maxIdlePerAgent,
+      Math.max(this.config.minIdlePerActiveAgent, adaptive),
+    );
+  }
+
+  idleCountForAgent(agentId: string): number {
+    let count = 0;
+    for (const entry of this.entries.values()) {
+      if (entry.agentId === agentId) count += 1;
+    }
+    return count;
+  }
+
+  trimAgent(agentId: string, targetSize: number): T[] {
+    const candidates = this.values()
+      .filter((entry) => entry.agentId === agentId)
+      .sort((left, right) => left.lastUsedAt - right.lastUsedAt);
+    const evicted: T[] = [];
+    while (candidates.length > targetSize) {
+      const entry = candidates.shift();
+      if (!entry) break;
+      if (this.entries.delete(entry.id)) evicted.push(entry);
+    }
+    return evicted;
+  }
+
+  evictForPressure(params: {
+    totalProcessCount: number;
+    maxProcessCount: number;
+    rssBytes?: number;
+  }): T[] {
+    const memoryPressure =
+      this.config.memoryPressureRssBytes > 0 &&
+      (params.rssBytes || 0) >= this.config.memoryPressureRssBytes;
+    const overCapacity = params.totalProcessCount > params.maxProcessCount;
+    if (!memoryPressure && !overCapacity) return [];
+
+    const evicted: T[] = [];
+    const candidates = this.values().sort(
+      (left, right) => left.lastUsedAt - right.lastUsedAt,
+    );
+    let total = params.totalProcessCount;
+    for (const entry of candidates) {
+      if (!memoryPressure && total <= params.maxProcessCount) break;
+      if (!this.entries.delete(entry.id)) continue;
+      evicted.push(entry);
+      total -= 1;
+    }
+    return evicted;
+  }
+
+  clear(): T[] {
+    const entries = this.values();
+    this.entries.clear();
+    return entries;
+  }
+
+  private prune(agentId: string, now: number): TrafficSample[] {
+    const cutoff = now - this.config.trafficWindowMs;
+    const samples = (this.traffic.get(agentId) || []).filter(
+      (sample) => sample.at >= cutoff,
+    );
+    if (samples.length > 0) this.traffic.set(agentId, samples);
+    else this.traffic.delete(agentId);
+    return samples;
+  }
+}
+
+function percentile(values: number[], ratio: number): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  const index = Math.max(0, Math.ceil(sorted.length * ratio) - 1);
+  return sorted[index] ?? 0;
+}

--- a/src/infra/warm-process-pool.ts
+++ b/src/infra/warm-process-pool.ts
@@ -61,6 +61,8 @@ export class WarmProcessPool<T extends WarmProcessPoolEntry> {
   private readonly entries = new Map<string, T>();
   private readonly traffic = new Map<string, TrafficSample[]>();
   private readonly coldStartSamples: number[] = [];
+  private readonly sortedColdStartSamples: number[] = [];
+  private cachedColdStartP95Ms: number | null = null;
 
   constructor(private readonly config: WarmProcessPoolConfig) {}
 
@@ -114,15 +116,25 @@ export class WarmProcessPool<T extends WarmProcessPoolEntry> {
 
   recordColdStart(durationMs: number): void {
     if (!Number.isFinite(durationMs) || durationMs < 0) return;
-    this.coldStartSamples.push(Math.floor(durationMs));
+    const sample = Math.floor(durationMs);
+    this.coldStartSamples.push(sample);
+    insertSorted(this.sortedColdStartSamples, sample);
     if (this.coldStartSamples.length > 500) {
-      this.coldStartSamples.splice(0, this.coldStartSamples.length - 500);
+      const dropped = this.coldStartSamples.splice(
+        0,
+        this.coldStartSamples.length - 500,
+      );
+      for (const value of dropped)
+        removeSortedValue(this.sortedColdStartSamples, value);
     }
+    this.cachedColdStartP95Ms = percentileSorted(
+      this.sortedColdStartSamples,
+      0.95,
+    );
   }
 
   coldStartP95Ms(): number | null {
-    if (this.coldStartSamples.length === 0) return null;
-    return percentile(this.coldStartSamples, 0.95);
+    return this.cachedColdStartP95Ms;
   }
 
   isWithinColdStartBudget(): boolean {
@@ -211,8 +223,24 @@ export class WarmProcessPool<T extends WarmProcessPoolEntry> {
   }
 }
 
-function percentile(values: number[], ratio: number): number {
-  const sorted = [...values].sort((left, right) => left - right);
+function insertSorted(values: number[], value: number): void {
+  let low = 0;
+  let high = values.length;
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2);
+    if ((values[mid] ?? 0) <= value) low = mid + 1;
+    else high = mid;
+  }
+  values.splice(low, 0, value);
+}
+
+function removeSortedValue(values: number[], value: number): void {
+  const index = values.indexOf(value);
+  if (index !== -1) values.splice(index, 1);
+}
+
+function percentileSorted(sorted: number[], ratio: number): number | null {
+  if (sorted.length === 0) return null;
   const index = Math.max(0, Math.ceil(sorted.length * ratio) - 1);
   return sorted[index] ?? 0;
 }

--- a/src/infra/warm-process-pool.ts
+++ b/src/infra/warm-process-pool.ts
@@ -72,6 +72,10 @@ export class WarmProcessPool<T extends WarmProcessPoolEntry> {
     return this.entries.size;
   }
 
+  get memoryPressureEnabled(): boolean {
+    return this.config.memoryPressureRssBytes > 0;
+  }
+
   values(): T[] {
     return Array.from(this.entries.values());
   }

--- a/src/infra/warm-process-pool.ts
+++ b/src/infra/warm-process-pool.ts
@@ -64,7 +64,7 @@ export class WarmProcessPool<T extends WarmProcessPoolEntry> {
   private readonly sortedColdStartSamples: number[] = [];
   private cachedColdStartP95Ms: number | null = null;
 
-  constructor(private readonly config: WarmProcessPoolConfig) {}
+  constructor(private config: WarmProcessPoolConfig) {}
 
   get enabled(): boolean {
     return this.config.enabled && this.config.maxIdlePerAgent > 0;
@@ -80,6 +80,19 @@ export class WarmProcessPool<T extends WarmProcessPoolEntry> {
 
   values(): T[] {
     return Array.from(this.entries.values());
+  }
+
+  reconfigure(config: WarmProcessPoolConfig): T[] {
+    this.config = config;
+    if (!this.enabled) return this.clear();
+
+    const evicted: T[] = [];
+    const agentIds = new Set<string>();
+    for (const entry of this.entries.values()) agentIds.add(entry.agentId);
+    for (const agentId of agentIds) {
+      evicted.push(...this.trimAgent(agentId, this.config.maxIdlePerAgent));
+    }
+    return evicted;
   }
 
   add(entry: T): void {
@@ -192,16 +205,18 @@ export class WarmProcessPool<T extends WarmProcessPoolEntry> {
     const overCapacity = params.totalProcessCount > params.maxProcessCount;
     if (!memoryPressure && !overCapacity) return [];
 
+    const targetEvictions = Math.max(
+      params.totalProcessCount - params.maxProcessCount,
+      memoryPressure ? 1 : 0,
+    );
     const evicted: T[] = [];
     const candidates = this.values().sort(
       (left, right) => left.lastUsedAt - right.lastUsedAt,
     );
-    let total = params.totalProcessCount;
     for (const entry of candidates) {
-      if (!memoryPressure && total <= params.maxProcessCount) break;
+      if (evicted.length >= targetEvictions) break;
       if (!this.entries.delete(entry.id)) continue;
       evicted.push(entry);
-      total -= 1;
     }
     return evicted;
   }

--- a/src/infra/warm-process-pool.ts
+++ b/src/infra/warm-process-pool.ts
@@ -117,12 +117,20 @@ export class WarmProcessPool<T extends WarmProcessPoolEntry> {
   }
 
   claim(agentId: string, now = Date.now()): T | null {
-    let claimed: T | null = null;
+    let readyClaim: T | null = null;
+    let warmingClaim: T | null = null;
     for (const entry of this.entries.values()) {
       if (entry.agentId !== agentId) continue;
-      if (entry.isReady && !entry.isReady()) continue;
-      if (!claimed || entry.lastUsedAt > claimed.lastUsedAt) claimed = entry;
+      const isReady = !entry.isReady || entry.isReady();
+      if (isReady) {
+        if (!readyClaim || entry.lastUsedAt > readyClaim.lastUsedAt)
+          readyClaim = entry;
+        continue;
+      }
+      if (!warmingClaim || entry.lastUsedAt > warmingClaim.lastUsedAt)
+        warmingClaim = entry;
     }
+    const claimed = readyClaim || warmingClaim;
     if (!claimed) return null;
     this.entries.delete(claimed.id);
     claimed.lastUsedAt = now;

--- a/src/infra/warm-process-pool.ts
+++ b/src/infra/warm-process-pool.ts
@@ -7,6 +7,10 @@ export interface WarmProcessPoolConfig {
   memoryPressureRssBytes: number;
 }
 
+export type WarmProcessPoolConfigInput = Partial<WarmProcessPoolConfig> & {
+  memoryPressureRssMb?: number;
+};
+
 export interface WarmProcessPoolEntry {
   id: string;
   agentId: string;
@@ -23,7 +27,7 @@ interface TrafficSample {
 const DEFAULT_TRAFFIC_WINDOW_MS = 60 * 60 * 1000;
 
 export function normalizeWarmProcessPoolConfig(
-  raw: Partial<WarmProcessPoolConfig> = {},
+  raw: WarmProcessPoolConfigInput = {},
 ): WarmProcessPoolConfig {
   const coldStartBudgetMs = normalizeInteger(raw.coldStartBudgetMs, 200, 1);
   const trafficWindowMs = normalizeInteger(
@@ -37,13 +41,18 @@ export function normalizeWarmProcessPoolConfig(
     0,
   );
   const maxIdlePerAgent = normalizeInteger(raw.maxIdlePerAgent, 2, 0);
+  const memoryPressureRssBytes =
+    raw.memoryPressureRssBytes ??
+    (raw.memoryPressureRssMb == null
+      ? undefined
+      : raw.memoryPressureRssMb * 1024 * 1024);
   return {
     enabled: raw.enabled !== false,
     coldStartBudgetMs,
     trafficWindowMs,
     minIdlePerActiveAgent: Math.min(minIdlePerActiveAgent, maxIdlePerAgent),
     maxIdlePerAgent,
-    memoryPressureRssBytes: normalizeInteger(raw.memoryPressureRssBytes, 0, 0),
+    memoryPressureRssBytes: normalizeInteger(memoryPressureRssBytes, 0, 0),
   };
 }
 

--- a/src/infra/warm-runner-utils.ts
+++ b/src/infra/warm-runner-utils.ts
@@ -170,11 +170,13 @@ export function getCachedObservedMemoryBytes<
 >(params: {
   cache: MemorySample | null;
   setCache: (sample: MemorySample) => void;
+  isRefreshInFlight: () => boolean;
+  setRefreshInFlight: (value: boolean) => void;
   activeEntries: T[];
   warmEntries: T[];
   memoryPressureEnabled: boolean;
   keyForEntry: (entry: T) => string | null;
-  readTotalBytes: (keys: string[]) => number;
+  refreshTotalBytes: (keys: string[]) => Promise<number>;
 }): number {
   if (params.warmEntries.length === 0 || !params.memoryPressureEnabled)
     return 0;
@@ -183,17 +185,26 @@ export function getCachedObservedMemoryBytes<
     .filter((key): key is string => Boolean(key));
   const sampleKey = Array.from(new Set(keys)).sort().join('\n');
   const now = Date.now();
-  if (
-    params.cache &&
-    params.cache.key === sampleKey &&
-    now - params.cache.at < MEMORY_SAMPLE_TTL_MS
-  ) {
-    return params.cache.totalBytes;
+  const currentCache = params.cache?.key === sampleKey ? params.cache : null;
+  if (currentCache && now - currentCache.at < MEMORY_SAMPLE_TTL_MS) {
+    return currentCache.totalBytes;
   }
 
-  const totalBytes = params.readTotalBytes(keys);
-  params.setCache({ at: now, key: sampleKey, totalBytes });
-  return totalBytes;
+  if (!params.isRefreshInFlight()) {
+    params.setRefreshInFlight(true);
+    params
+      .refreshTotalBytes(keys)
+      .then((totalBytes) => {
+        params.setCache({ at: Date.now(), key: sampleKey, totalBytes });
+      })
+      .catch(() => {
+        // Sampling is best-effort; over-capacity eviction does not depend on it.
+      })
+      .finally(() => {
+        params.setRefreshInFlight(false);
+      });
+  }
+  return currentCache ? currentCache.totalBytes : 0;
 }
 
 export function claimWarmEntry<T extends WarmRunnerEntry>(params: {
@@ -202,11 +213,9 @@ export function claimWarmEntry<T extends WarmRunnerEntry>(params: {
   sessionId: string;
   agentId: string;
   eligibility: WarmPoolEligibilityParams;
-  enforcePressure: () => void;
   logClaim: (entry: T) => void;
 }): T | null {
   if (!canUseWarmPool(params.warmPool, params.eligibility)) return null;
-  params.enforcePressure();
   const entry = params.warmPool.claim(params.agentId);
   if (!entry) return null;
   entry.sessionId = params.sessionId;
@@ -223,12 +232,10 @@ export function maintainWarmPool<T extends WarmRunnerEntry>(params: {
   maxProcessCount: number;
   agentId: string;
   eligibility: WarmPoolEligibilityParams;
-  enforcePressure: () => void;
   stopEntries: (entries: T[]) => void;
   spawnWarm: (sessionId: string, agentId: string) => void;
 }): void {
   if (!canUseWarmPool(params.warmPool, params.eligibility)) return;
-  params.enforcePressure();
   const targetSize = params.warmPool.targetIdleForAgent(params.agentId);
   params.stopEntries(params.warmPool.trimAgent(params.agentId, targetSize));
   while (

--- a/src/infra/warm-runner-utils.ts
+++ b/src/infra/warm-runner-utils.ts
@@ -39,10 +39,7 @@ export interface MemorySample {
 export function normalizeWarmProcessPoolRuntimeConfig(
   config: RuntimeConfig['container']['warmPool'],
 ): ReturnType<typeof normalizeWarmProcessPoolConfig> {
-  return normalizeWarmProcessPoolConfig({
-    ...config,
-    memoryPressureRssBytes: config.memoryPressureRssMb * 1024 * 1024,
-  });
+  return normalizeWarmProcessPoolConfig(config);
 }
 
 export function rememberStderrLine(entry: WarmRunnerEntry, line: string): void {

--- a/src/infra/warm-runner-utils.ts
+++ b/src/infra/warm-runner-utils.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import type { RuntimeConfig } from '../config/runtime-config.js';
 import type { ContainerOutput } from '../types/container.js';
 import {
@@ -97,7 +98,7 @@ export function canUseWarmPool(
 
 export function createWarmSessionId(agentId: string): string {
   const safeAgent = agentId.replace(/[^a-zA-Z0-9_-]/g, '_');
-  return `warm_${safeAgent}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  return `warm_${safeAgent}_${Date.now()}_${randomBytes(6).toString('hex')}`;
 }
 
 export function isTimedOutAgentOutput(output: ContainerOutput): boolean {

--- a/src/infra/warm-runner-utils.ts
+++ b/src/infra/warm-runner-utils.ts
@@ -1,0 +1,241 @@
+import type { RuntimeConfig } from '../config/runtime-config.js';
+import type { ContainerOutput } from '../types/container.js';
+import {
+  normalizeWarmProcessPoolConfig,
+  type WarmProcessPool,
+  type WarmProcessPoolEntry,
+} from './warm-process-pool.js';
+
+export const AGENT_OUTPUT_TIMEOUT_PREFIX =
+  'Timeout waiting for agent output after ';
+export const AGENT_READY_FOR_INPUT_LINE = '[hybridclaw-agent] ready for input';
+export const AGENT_REQUEST_START_LINE =
+  '[hybridclaw-agent] agent request start';
+export const IDLE_TIMEOUT_MS = 300_000;
+export const STDERR_HISTORY_LIMIT = 20;
+export const MEMORY_SAMPLE_TTL_MS = 5_000;
+
+export interface WarmRunnerEntry extends WarmProcessPoolEntry {
+  sessionId: string;
+  warm: boolean;
+  readyForInputAt: number | null;
+  pendingColdStartProbeStartedAt: number | null;
+  stderrHistory: string[];
+  activity?: import('./ipc.js').ActivityTracker;
+}
+
+export interface WarmPoolEligibilityParams {
+  workspacePathOverride?: string;
+  workspaceDisplayRootOverride?: string;
+  bashProxy?: unknown;
+}
+
+export interface MemorySample {
+  at: number;
+  key: string;
+  totalBytes: number;
+}
+
+export function normalizeWarmProcessPoolRuntimeConfig(
+  config: RuntimeConfig['container']['warmPool'],
+): ReturnType<typeof normalizeWarmProcessPoolConfig> {
+  return normalizeWarmProcessPoolConfig({
+    ...config,
+    memoryPressureRssBytes: config.memoryPressureRssMb * 1024 * 1024,
+  });
+}
+
+export function rememberStderrLine(entry: WarmRunnerEntry, line: string): void {
+  entry.stderrHistory.push(line);
+  if (entry.stderrHistory.length > STDERR_HISTORY_LIMIT) {
+    entry.stderrHistory.splice(
+      0,
+      entry.stderrHistory.length - STDERR_HISTORY_LIMIT,
+    );
+  }
+}
+
+export function summarizeExit(
+  code: number | null,
+  signal: NodeJS.Signals | null,
+): string {
+  if (typeof code === 'number') return `exit code ${code}`;
+  if (signal) return `signal ${signal}`;
+  return 'unknown exit status';
+}
+
+export function observeAgentLifecycleLine<T extends WarmRunnerEntry>(
+  entry: T,
+  line: string,
+  warmPool: WarmProcessPool<T>,
+): boolean {
+  if (line === AGENT_READY_FOR_INPUT_LINE) {
+    entry.readyForInputAt = Date.now();
+    entry.activity?.notify();
+    return true;
+  }
+  if (line === AGENT_REQUEST_START_LINE) {
+    const startedAt = entry.pendingColdStartProbeStartedAt;
+    if (startedAt != null) {
+      warmPool.recordColdStart(Date.now() - startedAt);
+      entry.pendingColdStartProbeStartedAt = null;
+    }
+    entry.activity?.notify();
+    return true;
+  }
+  return false;
+}
+
+export function canUseWarmPool(
+  warmPool: WarmProcessPool<WarmRunnerEntry>,
+  params: WarmPoolEligibilityParams,
+): boolean {
+  return (
+    warmPool.enabled &&
+    !params.workspacePathOverride?.trim() &&
+    !params.workspaceDisplayRootOverride?.trim() &&
+    !params.bashProxy
+  );
+}
+
+export function createWarmSessionId(agentId: string): string {
+  const safeAgent = agentId.replace(/[^a-zA-Z0-9_-]/g, '_');
+  return `warm_${safeAgent}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function isTimedOutAgentOutput(output: ContainerOutput): boolean {
+  return (
+    output.status === 'error' &&
+    typeof output.error === 'string' &&
+    output.error.startsWith(AGENT_OUTPUT_TIMEOUT_PREFIX)
+  );
+}
+
+export function getTotalWarmProcessCount<T extends WarmRunnerEntry>(
+  pool: Map<string, T>,
+  warmPool: WarmProcessPool<T>,
+): number {
+  return pool.size + warmPool.size;
+}
+
+export function removeWarmPoolEntry<T extends WarmRunnerEntry>(
+  pool: Map<string, T>,
+  warmPool: WarmProcessPool<T>,
+  entry: T,
+): void {
+  warmPool.delete(entry.id);
+  for (const [sessionId, active] of pool) {
+    if (active === entry) pool.delete(sessionId);
+  }
+}
+
+export function stopWarmEntries<T extends WarmRunnerEntry>(
+  entries: T[],
+  params: {
+    log: (entry: T) => void;
+    stop: (entry: T) => void;
+  },
+): void {
+  for (const entry of entries) {
+    params.log(entry);
+    params.stop(entry);
+  }
+}
+
+export function enforceWarmPoolPressure<T extends WarmRunnerEntry>(params: {
+  pool: Map<string, T>;
+  warmPool: WarmProcessPool<T>;
+  maxProcessCount: number;
+  getObservedMemoryBytes: () => number;
+  stopEntries: (entries: T[]) => void;
+}): void {
+  if (params.warmPool.size === 0) return;
+  const totalProcessCount = getTotalWarmProcessCount(
+    params.pool,
+    params.warmPool,
+  );
+  const overCapacity = totalProcessCount > params.maxProcessCount;
+  if (!overCapacity && !params.warmPool.memoryPressureEnabled) return;
+  params.stopEntries(
+    params.warmPool.evictForPressure({
+      totalProcessCount,
+      maxProcessCount: params.maxProcessCount,
+      rssBytes: overCapacity ? undefined : params.getObservedMemoryBytes(),
+    }),
+  );
+}
+
+export function getCachedObservedMemoryBytes<
+  T extends WarmRunnerEntry,
+>(params: {
+  cache: MemorySample | null;
+  setCache: (sample: MemorySample) => void;
+  activeEntries: T[];
+  warmEntries: T[];
+  memoryPressureEnabled: boolean;
+  keyForEntry: (entry: T) => string | null;
+  readTotalBytes: (keys: string[]) => number;
+}): number {
+  if (params.warmEntries.length === 0 || !params.memoryPressureEnabled)
+    return 0;
+  const keys = [...params.activeEntries, ...params.warmEntries]
+    .map((entry) => params.keyForEntry(entry))
+    .filter((key): key is string => Boolean(key));
+  const sampleKey = Array.from(new Set(keys)).sort().join('\n');
+  const now = Date.now();
+  if (
+    params.cache &&
+    params.cache.key === sampleKey &&
+    now - params.cache.at < MEMORY_SAMPLE_TTL_MS
+  ) {
+    return params.cache.totalBytes;
+  }
+
+  const totalBytes = params.readTotalBytes(keys);
+  params.setCache({ at: now, key: sampleKey, totalBytes });
+  return totalBytes;
+}
+
+export function claimWarmEntry<T extends WarmRunnerEntry>(params: {
+  pool: Map<string, T>;
+  warmPool: WarmProcessPool<T>;
+  sessionId: string;
+  agentId: string;
+  eligibility: WarmPoolEligibilityParams;
+  enforcePressure: () => void;
+  logClaim: (entry: T) => void;
+}): T | null {
+  if (!canUseWarmPool(params.warmPool, params.eligibility)) return null;
+  params.enforcePressure();
+  const entry = params.warmPool.claim(params.agentId);
+  if (!entry) return null;
+  entry.sessionId = params.sessionId;
+  entry.warm = false;
+  entry.lastUsedAt = Date.now();
+  params.pool.set(params.sessionId, entry);
+  params.logClaim(entry);
+  return entry;
+}
+
+export function maintainWarmPool<T extends WarmRunnerEntry>(params: {
+  pool: Map<string, T>;
+  warmPool: WarmProcessPool<T>;
+  maxProcessCount: number;
+  agentId: string;
+  eligibility: WarmPoolEligibilityParams;
+  enforcePressure: () => void;
+  stopEntries: (entries: T[]) => void;
+  spawnWarm: (sessionId: string, agentId: string) => void;
+}): void {
+  if (!canUseWarmPool(params.warmPool, params.eligibility)) return;
+  params.enforcePressure();
+  const targetSize = params.warmPool.targetIdleForAgent(params.agentId);
+  params.stopEntries(params.warmPool.trimAgent(params.agentId, targetSize));
+  while (
+    params.warmPool.idleCountForAgent(params.agentId) < targetSize &&
+    getTotalWarmProcessCount(params.pool, params.warmPool) <
+      params.maxProcessCount
+  ) {
+    params.spawnWarm(createWarmSessionId(params.agentId), params.agentId);
+  }
+}

--- a/src/infra/warm-runner-utils.ts
+++ b/src/infra/warm-runner-utils.ts
@@ -202,7 +202,7 @@ export function getCachedObservedMemoryBytes<
         params.setRefreshInFlight(false);
       });
   }
-  return currentCache ? currentCache.totalBytes : 0;
+  return currentCache?.totalBytes ?? params.cache?.totalBytes ?? 0;
 }
 
 export function claimWarmEntry<T extends WarmRunnerEntry>(params: {

--- a/tests/config.version-resolution.test.ts
+++ b/tests/config.version-resolution.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { afterEach, expect, test, vi } from 'vitest';
 
 const originalHome = process.env.HOME;
+const originalDataDir = process.env.HYBRIDCLAW_DATA_DIR;
 const originalDisableWatcher = process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
 const tempHomes: string[] = [];
 
@@ -18,6 +19,11 @@ afterEach(() => {
   } else {
     process.env.HOME = originalHome;
   }
+  if (originalDataDir === undefined) {
+    delete process.env.HYBRIDCLAW_DATA_DIR;
+  } else {
+    process.env.HYBRIDCLAW_DATA_DIR = originalDataDir;
+  }
   if (originalDisableWatcher === undefined) {
     delete process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
   } else {
@@ -28,6 +34,50 @@ afterEach(() => {
     if (!tempHome) continue;
     fs.rmSync(tempHome, { recursive: true, force: true });
   }
+});
+
+test('warns when warm pool min idle is clamped by max idle', async () => {
+  const logger = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  };
+  vi.doMock('../src/logger.js', () => ({ logger }));
+
+  const tempHome = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-config-warm-pool-'),
+  );
+  tempHomes.push(tempHome);
+  vi.stubEnv('HOME', tempHome);
+  vi.stubEnv('HYBRIDCLAW_DATA_DIR', tempHome);
+  vi.stubEnv('HYBRIDCLAW_DISABLE_CONFIG_WATCHER', '1');
+  fs.writeFileSync(
+    path.join(tempHome, 'config.json'),
+    JSON.stringify({
+      container: {
+        warmPool: {
+          enabled: true,
+          minIdlePerActiveAgent: 5,
+          maxIdlePerAgent: 2,
+        },
+      },
+    }),
+    'utf-8',
+  );
+
+  const { CONTAINER_WARM_POOL } = await import('../src/config/config.ts');
+
+  expect(CONTAINER_WARM_POOL.minIdlePerActiveAgent).toBe(5);
+  expect(CONTAINER_WARM_POOL.maxIdlePerAgent).toBe(2);
+  expect(logger.warn).toHaveBeenCalledWith(
+    {
+      requestedMinIdlePerActiveAgent: 5,
+      maxIdlePerAgent: 2,
+      effectiveMinIdlePerActiveAgent: 2,
+    },
+    'Warm process pool minIdlePerActiveAgent exceeds maxIdlePerAgent; clamping effective minimum idle workers',
+  );
 });
 
 test('warns once when all app-version package probes fail', async () => {

--- a/tests/container-runner.redaction.test.ts
+++ b/tests/container-runner.redaction.test.ts
@@ -460,6 +460,127 @@ test('ContainerExecutor stops and respawns a timed out pooled container', async 
   expect(stopCalls).toHaveLength(1);
 });
 
+test('ContainerExecutor claims a warm container for a later session', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+
+  const spawnedRuns: Array<{
+    args: string[];
+    proc: ReturnType<typeof makeFakeChildProcess>;
+  }> = [];
+  const spawn = vi.fn((command: string, args?: string[]) => {
+    const proc = makeFakeChildProcess();
+    if (command === 'docker' && Array.isArray(args) && args[0] === 'run') {
+      spawnedRuns.push({ args: [...args], proc });
+    }
+    return proc as never;
+  });
+  const readOutput = vi.fn(async () => ({
+    status: 'success' as const,
+    result: 'ok',
+    toolsUsed: [],
+    artifacts: [],
+  }));
+  const resolveModelRuntimeCredentials = vi.fn(async () => ({
+    provider: 'hybridai' as const,
+    apiKey: '',
+    baseUrl: 'https://hybridai.one',
+    chatbotId: 'bot-a',
+    enableRag: false,
+    requestHeaders: {},
+    agentId: 'default',
+    isLocal: false,
+    contextWindow: 128_000,
+    thinkingFormat: undefined,
+  }));
+  const loggerInfo = vi.fn();
+
+  vi.doMock('node:child_process', async () => {
+    const actual =
+      await vi.importActual<typeof import('node:child_process')>(
+        'node:child_process',
+      );
+    return {
+      ...actual,
+      spawn,
+    };
+  });
+  vi.doMock('../src/infra/ipc.js', async () => {
+    const actual = await vi.importActual<typeof import('../src/infra/ipc.js')>(
+      '../src/infra/ipc.js',
+    );
+    return {
+      ...actual,
+      readOutput,
+    };
+  });
+  vi.doMock('../src/providers/factory.js', async () => {
+    const actual = await vi.importActual<
+      typeof import('../src/providers/factory.js')
+    >('../src/providers/factory.js');
+    return {
+      ...actual,
+      resolveModelRuntimeCredentials,
+    };
+  });
+  vi.doMock('../src/logger.js', () => ({
+    logger: {
+      debug: vi.fn(),
+      info: loggerInfo,
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  }));
+
+  const { ContainerExecutor } = await import(
+    '../src/infra/container-runner.js'
+  );
+  const executor = new ContainerExecutor();
+
+  await executor.exec({
+    sessionId: 'session-before-warm',
+    messages: [{ role: 'user', content: 'prime warm pool' }],
+    chatbotId: 'bot-a',
+    enableRag: false,
+    model: 'gpt-5',
+    agentId: 'default',
+    channelId: 'tui',
+  });
+  executor.stopSession('session-before-warm');
+
+  const initialWarmRun = spawnedRuns.find(({ args }) => {
+    const nameIndex = args.indexOf('--name');
+    const containerName =
+      nameIndex >= 0 && typeof args[nameIndex + 1] === 'string'
+        ? args[nameIndex + 1]
+        : '';
+    return containerName.startsWith('hybridclaw-warm-');
+  });
+  expect(initialWarmRun).toBeDefined();
+  expect(initialWarmRun?.proc.stdin.write).not.toHaveBeenCalled();
+
+  await executor.exec({
+    sessionId: 'session-claims-warm',
+    messages: [{ role: 'user', content: 'claim warm pool' }],
+    chatbotId: 'bot-a',
+    enableRag: false,
+    model: 'gpt-5',
+    agentId: 'default',
+    channelId: 'tui',
+  });
+
+  expect(loggerInfo).toHaveBeenCalledWith(
+    expect.objectContaining({
+      sessionId: 'session-claims-warm',
+      agentId: 'default',
+      containerName: expect.stringContaining('warm-'),
+    }),
+    'Claimed warm container',
+  );
+  expect(initialWarmRun?.proc.stdin.write).toHaveBeenCalledTimes(1);
+});
+
 test('ContainerExecutor stages the container node_modules symlink before docker launch', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;

--- a/tests/container-runner.redaction.test.ts
+++ b/tests/container-runner.redaction.test.ts
@@ -441,7 +441,7 @@ test('ContainerExecutor stops and respawns a timed out pooled container', async 
 
   expect(secondOutput.status).toBe('success');
   const runCalls = spawn.mock.calls.filter(
-    (call) => Array.isArray(call[1]) && call[1][0] !== 'stop',
+    (call) => Array.isArray(call[1]) && call[1][0] === 'run',
   );
   const activeRunCalls = runCalls.filter((call) => {
     const args = call[1];

--- a/tests/container-runner.redaction.test.ts
+++ b/tests/container-runner.redaction.test.ts
@@ -443,10 +443,20 @@ test('ContainerExecutor stops and respawns a timed out pooled container', async 
   const runCalls = spawn.mock.calls.filter(
     (call) => Array.isArray(call[1]) && call[1][0] !== 'stop',
   );
+  const activeRunCalls = runCalls.filter((call) => {
+    const args = call[1];
+    if (!Array.isArray(args)) return false;
+    const nameIndex = args.indexOf('--name');
+    const containerName =
+      nameIndex >= 0 && typeof args[nameIndex + 1] === 'string'
+        ? args[nameIndex + 1]
+        : '';
+    return !containerName.includes('warm-');
+  });
   const stopCalls = spawn.mock.calls.filter(
     (call) => Array.isArray(call[1]) && call[1][0] === 'stop',
   );
-  expect(runCalls).toHaveLength(2);
+  expect(activeRunCalls).toHaveLength(2);
   expect(stopCalls).toHaveLength(1);
 });
 

--- a/tests/gateway-main.test.ts
+++ b/tests/gateway-main.test.ts
@@ -715,6 +715,8 @@ describe('gateway bootstrap', () => {
         coldStartBudgetMs: 200,
         warmScope:
           'runtime process only; request-specific MCP, plugin, media, and model setup still runs after input',
+        warmFill:
+          'filled after recent traffic for an agent; gateway startup does not pre-spawn workers',
         disableConfig: 'container.warmPool.enabled=false',
       },
       'Warm process pool enabled; idle workers prewarm runtime process startup only',

--- a/tests/gateway-main.test.ts
+++ b/tests/gateway-main.test.ts
@@ -36,6 +36,7 @@ function createGatewayMainTestState(options?: {
   msteamsEnabled?: boolean;
   hasMSTeamsCredentials?: boolean;
   initGatewayServiceImpl?: () => Promise<void>;
+  warmPoolEnabled?: boolean;
 }) {
   return {
     commandHandler: null as null | ((...args: unknown[]) => Promise<void>),
@@ -147,6 +148,17 @@ function createGatewayMainTestState(options?: {
         groupPolicy: 'disabled',
       },
       local: { enabled: false },
+      container: {
+        sandboxMode: 'container',
+        warmPool: {
+          enabled: options?.warmPoolEnabled ?? false,
+          coldStartBudgetMs: 200,
+          trafficWindowMs: 3_600_000,
+          minIdlePerActiveAgent: 1,
+          maxIdlePerAgent: 2,
+          memoryPressureRssMb: 2_048,
+        },
+      },
       memory: {
         consolidationIntervalHours: 0,
         decayRate: 0.25,
@@ -296,6 +308,7 @@ async function importFreshGatewayMain(options?: {
   initGatewayServiceImpl?: () => Promise<void>;
   skipBootstrapHandlerCheck?: boolean;
   dataDir?: string;
+  warmPoolEnabled?: boolean;
   onState?: (state: ReturnType<typeof createGatewayMainTestState>) => void;
 }) {
   vi.resetModules();
@@ -688,6 +701,22 @@ describe('gateway bootstrap', () => {
     expect(state.startScheduler).toHaveBeenCalledTimes(1);
     expect(state.onConfigChange).toHaveBeenCalledTimes(1);
     expect(state.setInterval).toHaveBeenCalled();
+  });
+
+  test('warns on startup when the warm process pool is enabled', async () => {
+    const state = await importFreshGatewayMain({ warmPoolEnabled: true });
+
+    expect(state.loggerWarn).toHaveBeenCalledWith(
+      {
+        sandboxMode: 'container',
+        minIdlePerActiveAgent: 1,
+        maxIdlePerAgent: 2,
+        memoryPressureRssMb: 2_048,
+        coldStartBudgetMs: 200,
+        disableConfig: 'container.warmPool.enabled=false',
+      },
+      'Warm process pool enabled; idle agent workers may be spawned after requests',
+    );
   });
 
   test('runs a missed dream consolidation on startup when nightly scheduling is enabled', async () => {

--- a/tests/gateway-main.test.ts
+++ b/tests/gateway-main.test.ts
@@ -713,9 +713,11 @@ describe('gateway bootstrap', () => {
         maxIdlePerAgent: 2,
         memoryPressureRssMb: 2_048,
         coldStartBudgetMs: 200,
+        warmScope:
+          'runtime process only; request-specific MCP, plugin, media, and model setup still runs after input',
         disableConfig: 'container.warmPool.enabled=false',
       },
-      'Warm process pool enabled; idle agent workers may be spawned after requests',
+      'Warm process pool enabled; idle workers prewarm runtime process startup only',
     );
   });
 

--- a/tests/gateway-main.test.ts
+++ b/tests/gateway-main.test.ts
@@ -711,6 +711,7 @@ describe('gateway bootstrap', () => {
         sandboxMode: 'container',
         minIdlePerActiveAgent: 1,
         maxIdlePerAgent: 2,
+        effectiveMinIdlePerActiveAgent: 1,
         memoryPressureRssMb: 2_048,
         coldStartBudgetMs: 200,
         warmScope:

--- a/tests/host-runner.worker-restart.test.ts
+++ b/tests/host-runner.worker-restart.test.ts
@@ -52,6 +52,20 @@ vi.mock('../src/providers/factory.js', async () => {
   };
 });
 
+vi.mock('../src/config/config.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../src/config/config.js')>(
+      '../src/config/config.js',
+    );
+  return {
+    ...actual,
+    CONTAINER_WARM_POOL: {
+      ...actual.CONTAINER_WARM_POOL,
+      enabled: false,
+    },
+  };
+});
+
 vi.mock('../src/logger.js', () => ({
   logger: {
     debug: vi.fn(),

--- a/tests/session-maintenance.test.ts
+++ b/tests/session-maintenance.test.ts
@@ -53,6 +53,7 @@ vi.mock('../src/config/config.js', () => ({
   SESSION_COMPACTION_SUMMARY_MAX_CHARS: 8_000,
   SESSION_COMPACTION_THRESHOLD: 20,
   SESSION_COMPACTION_TOKEN_BUDGET: 1_000,
+  onConfigChange: vi.fn(() => () => {}),
 }));
 
 vi.mock('../src/infra/ipc.js', () => ({

--- a/tests/session-maintenance.test.ts
+++ b/tests/session-maintenance.test.ts
@@ -35,6 +35,14 @@ vi.mock('../src/agent/prompt-hooks.js', () => ({
 }));
 
 vi.mock('../src/config/config.js', () => ({
+  CONTAINER_WARM_POOL: {
+    coldStartBudgetMs: 10_000,
+    enabled: false,
+    maxIdlePerAgent: 1,
+    memoryPressureRssMb: 0,
+    minIdlePerActiveAgent: 0,
+    trafficWindowMs: 60_000,
+  },
   DATA_DIR: '/tmp/hybridclaw-test-data',
   PRE_COMPACTION_MEMORY_FLUSH_ENABLED: false,
   PRE_COMPACTION_MEMORY_FLUSH_MAX_CHARS: 8_000,

--- a/tests/warm-process-pool.benchmark.test.ts
+++ b/tests/warm-process-pool.benchmark.test.ts
@@ -1,0 +1,163 @@
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, expect, test, vi } from 'vitest';
+
+const ORIGINAL_HOME = process.env.HOME;
+
+function makeTempHome(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'hc-warm-pool-bench-'));
+}
+
+function restoreEnvVar(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+function makeFakeChildProcess(pid: number) {
+  const proc = new EventEmitter() as EventEmitter & {
+    pid: number;
+    stderr: EventEmitter;
+    stdin: EventEmitter & { write: ReturnType<typeof vi.fn> };
+    kill: ReturnType<typeof vi.fn>;
+    killed: boolean;
+    exitCode: number | null;
+  };
+  proc.pid = pid;
+  proc.stderr = new EventEmitter();
+  proc.stdin = Object.assign(new EventEmitter(), {
+    write: vi.fn(() => {
+      proc.stderr.emit(
+        'data',
+        Buffer.from('[hybridclaw-agent] agent request start\n'),
+      );
+      return true;
+    }),
+  });
+  proc.killed = false;
+  proc.exitCode = null;
+  proc.kill = vi.fn(() => {
+    proc.killed = true;
+    return true;
+  });
+  queueMicrotask(() => {
+    proc.stderr.emit(
+      'data',
+      Buffer.from('[hybridclaw-agent] ready for input\n'),
+    );
+  });
+  return proc;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.doUnmock('node:child_process');
+  vi.doUnmock('../src/infra/host-runtime-setup.js');
+  vi.doUnmock('../src/infra/ipc.js');
+  vi.doUnmock('../src/providers/factory.js');
+  vi.doUnmock('../src/logger.js');
+  vi.resetModules();
+  restoreEnvVar('HOME', ORIGINAL_HOME);
+});
+
+test('benchmark keeps p95 cold-start within the warm-process budget on a synthetic host workload', async () => {
+  process.env.HOME = makeTempHome();
+  vi.resetModules();
+
+  let nextPid = 10_000;
+  const spawn = vi.fn(() => {
+    nextPid += 1;
+    return makeFakeChildProcess(nextPid) as never;
+  });
+  const readOutput = vi.fn(async () => ({
+    status: 'success' as const,
+    result: 'ok',
+    toolsUsed: [],
+    artifacts: [],
+  }));
+  const resolveModelRuntimeCredentials = vi.fn(async () => ({
+    provider: 'hybridai' as const,
+    apiKey: '',
+    baseUrl: 'https://hybridai.one',
+    chatbotId: 'bot-a',
+    enableRag: false,
+    requestHeaders: {},
+    agentId: 'default',
+    isLocal: false,
+    contextWindow: 128_000,
+    thinkingFormat: undefined,
+  }));
+
+  vi.doMock('node:child_process', async () => {
+    const actual =
+      await vi.importActual<typeof import('node:child_process')>(
+        'node:child_process',
+      );
+    return {
+      ...actual,
+      spawn,
+    };
+  });
+  vi.doMock('../src/infra/host-runtime-setup.js', () => ({
+    ensureHostRuntimeReady: () => ({
+      command: process.execPath,
+      args: ['/tmp/container/dist/index.js'],
+    }),
+  }));
+  vi.doMock('../src/infra/ipc.js', async () => {
+    const actual = await vi.importActual<typeof import('../src/infra/ipc.js')>(
+      '../src/infra/ipc.js',
+    );
+    return {
+      ...actual,
+      readOutput,
+    };
+  });
+  vi.doMock('../src/providers/factory.js', async () => {
+    const actual = await vi.importActual<
+      typeof import('../src/providers/factory.js')
+    >('../src/providers/factory.js');
+    return {
+      ...actual,
+      resolveModelRuntimeCredentials,
+    };
+  });
+  vi.doMock('../src/logger.js', () => ({
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  }));
+
+  const {
+    HostExecutor,
+    getWarmHostColdStartP95Ms,
+    isWarmHostColdStartWithinBudget,
+  } = await import('../src/infra/host-runner.js');
+  const executor = new HostExecutor();
+
+  for (let index = 0; index < 20; index += 1) {
+    const sessionId = `bench-${index}`;
+    await executor.exec({
+      sessionId,
+      messages: [{ role: 'user', content: 'synthetic warm-pool turn' }],
+      chatbotId: 'bot-a',
+      enableRag: false,
+      model: 'gpt-5',
+      agentId: 'default',
+      channelId: 'benchmark',
+    });
+    executor.stopSession(sessionId);
+    await Promise.resolve();
+  }
+
+  expect(getWarmHostColdStartP95Ms()).not.toBeNull();
+  expect(isWarmHostColdStartWithinBudget()).toBe(true);
+});

--- a/tests/warm-process-pool.benchmark.test.ts
+++ b/tests/warm-process-pool.benchmark.test.ts
@@ -36,11 +36,13 @@ function makeFakeChildProcess(
   proc.stderr = new EventEmitter();
   proc.stdin = Object.assign(new EventEmitter(), {
     write: vi.fn(() => {
-      advanceClock(requestStartDelayMs);
-      proc.stderr.emit(
-        'data',
-        Buffer.from('[hybridclaw-agent] agent request start\n'),
-      );
+      queueMicrotask(() => {
+        advanceClock(requestStartDelayMs);
+        proc.stderr.emit(
+          'data',
+          Buffer.from('[hybridclaw-agent] agent request start\n'),
+        );
+      });
       return true;
     }),
   });
@@ -61,21 +63,26 @@ function makeFakeChildProcess(
 
 async function runSyntheticHostWorkload(requestStartDelayMs: number): Promise<{
   coldStartP95Ms: number | null;
+  coldStartsRecorded: number;
   withinBudget: boolean;
+  warmClaims: number;
 }> {
   process.env.HOME = makeTempHome();
   vi.resetModules();
 
   let now = 1_700_000_000_000;
+  let coldStartsRecorded = 0;
   vi.spyOn(Date, 'now').mockImplementation(() => now);
 
   let nextPid = 10_000;
   const spawn = vi.fn(() => {
     nextPid += 1;
     return makeFakeChildProcess(nextPid, requestStartDelayMs, (durationMs) => {
+      coldStartsRecorded += 1;
       now += durationMs;
     }) as never;
   });
+  const loggerInfo = vi.fn();
   const readOutput = vi.fn(async () => ({
     status: 'success' as const,
     result: 'ok',
@@ -132,7 +139,7 @@ async function runSyntheticHostWorkload(requestStartDelayMs: number): Promise<{
   vi.doMock('../src/logger.js', () => ({
     logger: {
       debug: vi.fn(),
-      info: vi.fn(),
+      info: loggerInfo,
       warn: vi.fn(),
       error: vi.fn(),
     },
@@ -162,7 +169,11 @@ async function runSyntheticHostWorkload(requestStartDelayMs: number): Promise<{
 
   return {
     coldStartP95Ms: getWarmHostColdStartP95Ms(),
+    coldStartsRecorded,
     withinBudget: isWarmHostColdStartWithinBudget(),
+    warmClaims: loggerInfo.mock.calls.filter(
+      (call) => call[1] === 'Claimed warm host agent process',
+    ).length,
   };
 }
 
@@ -181,6 +192,8 @@ test('benchmark keeps p95 cold-start within the warm-process budget on a synthet
   const result = await runSyntheticHostWorkload(50);
 
   expect(result.coldStartP95Ms).toBe(50);
+  expect(result.coldStartsRecorded).toBe(20);
+  expect(result.warmClaims).toBeGreaterThan(0);
   expect(result.withinBudget).toBe(true);
 });
 
@@ -188,5 +201,7 @@ test('benchmark detects p95 cold-start budget violations on a synthetic host wor
   const result = await runSyntheticHostWorkload(250);
 
   expect(result.coldStartP95Ms).toBe(250);
+  expect(result.coldStartsRecorded).toBe(20);
+  expect(result.warmClaims).toBeGreaterThan(0);
   expect(result.withinBudget).toBe(false);
 });

--- a/tests/warm-process-pool.benchmark.test.ts
+++ b/tests/warm-process-pool.benchmark.test.ts
@@ -19,7 +19,11 @@ function restoreEnvVar(name: string, value: string | undefined): void {
   process.env[name] = value;
 }
 
-function makeFakeChildProcess(pid: number) {
+function makeFakeChildProcess(
+  pid: number,
+  requestStartDelayMs: number,
+  advanceClock: (durationMs: number) => void,
+) {
   const proc = new EventEmitter() as EventEmitter & {
     pid: number;
     stderr: EventEmitter;
@@ -32,6 +36,7 @@ function makeFakeChildProcess(pid: number) {
   proc.stderr = new EventEmitter();
   proc.stdin = Object.assign(new EventEmitter(), {
     write: vi.fn(() => {
+      advanceClock(requestStartDelayMs);
       proc.stderr.emit(
         'data',
         Buffer.from('[hybridclaw-agent] agent request start\n'),
@@ -54,25 +59,22 @@ function makeFakeChildProcess(pid: number) {
   return proc;
 }
 
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.doUnmock('node:child_process');
-  vi.doUnmock('../src/infra/host-runtime-setup.js');
-  vi.doUnmock('../src/infra/ipc.js');
-  vi.doUnmock('../src/providers/factory.js');
-  vi.doUnmock('../src/logger.js');
-  vi.resetModules();
-  restoreEnvVar('HOME', ORIGINAL_HOME);
-});
-
-test('benchmark keeps p95 cold-start within the warm-process budget on a synthetic host workload', async () => {
+async function runSyntheticHostWorkload(requestStartDelayMs: number): Promise<{
+  coldStartP95Ms: number | null;
+  withinBudget: boolean;
+}> {
   process.env.HOME = makeTempHome();
   vi.resetModules();
+
+  let now = 1_700_000_000_000;
+  vi.spyOn(Date, 'now').mockImplementation(() => now);
 
   let nextPid = 10_000;
   const spawn = vi.fn(() => {
     nextPid += 1;
-    return makeFakeChildProcess(nextPid) as never;
+    return makeFakeChildProcess(nextPid, requestStartDelayMs, (durationMs) => {
+      now += durationMs;
+    }) as never;
   });
   const readOutput = vi.fn(async () => ({
     status: 'success' as const,
@@ -158,6 +160,33 @@ test('benchmark keeps p95 cold-start within the warm-process budget on a synthet
     await Promise.resolve();
   }
 
-  expect(getWarmHostColdStartP95Ms()).not.toBeNull();
-  expect(isWarmHostColdStartWithinBudget()).toBe(true);
+  return {
+    coldStartP95Ms: getWarmHostColdStartP95Ms(),
+    withinBudget: isWarmHostColdStartWithinBudget(),
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.doUnmock('node:child_process');
+  vi.doUnmock('../src/infra/host-runtime-setup.js');
+  vi.doUnmock('../src/infra/ipc.js');
+  vi.doUnmock('../src/providers/factory.js');
+  vi.doUnmock('../src/logger.js');
+  vi.resetModules();
+  restoreEnvVar('HOME', ORIGINAL_HOME);
+});
+
+test('benchmark keeps p95 cold-start within the warm-process budget on a synthetic host workload', async () => {
+  const result = await runSyntheticHostWorkload(50);
+
+  expect(result.coldStartP95Ms).toBe(50);
+  expect(result.withinBudget).toBe(true);
+});
+
+test('benchmark detects p95 cold-start budget violations on a synthetic host workload', async () => {
+  const result = await runSyntheticHostWorkload(250);
+
+  expect(result.coldStartP95Ms).toBe(250);
+  expect(result.withinBudget).toBe(false);
 });

--- a/tests/warm-process-pool.benchmark.test.ts
+++ b/tests/warm-process-pool.benchmark.test.ts
@@ -21,8 +21,12 @@ function restoreEnvVar(name: string, value: string | undefined): void {
 
 function makeFakeChildProcess(
   pid: number,
+  runtimeStartupDelayMs: number,
   requestStartDelayMs: number,
   advanceClock: (durationMs: number) => void,
+  currentTime: () => number,
+  recordColdStartSample: (durationMs: number) => void,
+  notifyRequestStart: () => void,
 ) {
   const proc = new EventEmitter() as EventEmitter & {
     pid: number;
@@ -34,15 +38,28 @@ function makeFakeChildProcess(
   };
   proc.pid = pid;
   proc.stderr = new EventEmitter();
+  let inputWritten = false;
+  let inputWrittenAt = 0;
+  let readyForInput = false;
+  let requestStarted = false;
+  const maybeStartRequest = () => {
+    if (!inputWritten || !readyForInput || requestStarted) return;
+    requestStarted = true;
+    queueMicrotask(() => {
+      advanceClock(requestStartDelayMs);
+      recordColdStartSample(currentTime() - inputWrittenAt);
+      proc.stderr.emit(
+        'data',
+        Buffer.from('[hybridclaw-agent] agent request start\n'),
+      );
+      notifyRequestStart();
+    });
+  };
   proc.stdin = Object.assign(new EventEmitter(), {
     write: vi.fn(() => {
-      queueMicrotask(() => {
-        advanceClock(requestStartDelayMs);
-        proc.stderr.emit(
-          'data',
-          Buffer.from('[hybridclaw-agent] agent request start\n'),
-        );
-      });
+      inputWritten = true;
+      inputWrittenAt = currentTime();
+      maybeStartRequest();
       return true;
     }),
   });
@@ -53,17 +70,20 @@ function makeFakeChildProcess(
     return true;
   });
   queueMicrotask(() => {
+    advanceClock(runtimeStartupDelayMs);
+    readyForInput = true;
     proc.stderr.emit(
       'data',
       Buffer.from('[hybridclaw-agent] ready for input\n'),
     );
+    maybeStartRequest();
   });
   return proc;
 }
 
 async function runSyntheticHostWorkload(requestStartDelayMs: number): Promise<{
   coldStartP95Ms: number | null;
-  coldStartsRecorded: number;
+  coldStartSamples: number[];
   withinBudget: boolean;
   warmClaims: number;
 }> {
@@ -71,24 +91,44 @@ async function runSyntheticHostWorkload(requestStartDelayMs: number): Promise<{
   vi.resetModules();
 
   let now = 1_700_000_000_000;
-  let coldStartsRecorded = 0;
+  const coldStartSamples: number[] = [];
   vi.spyOn(Date, 'now').mockImplementation(() => now);
+  const pendingRequestStarts: Array<() => void> = [];
+  const waitForRequestStart = () =>
+    new Promise<void>((resolve) => {
+      pendingRequestStarts.push(resolve);
+    });
+  const notifyRequestStart = () => {
+    pendingRequestStarts.shift()?.();
+  };
 
   let nextPid = 10_000;
   const spawn = vi.fn(() => {
     nextPid += 1;
-    return makeFakeChildProcess(nextPid, requestStartDelayMs, (durationMs) => {
-      coldStartsRecorded += 1;
-      now += durationMs;
-    }) as never;
+    return makeFakeChildProcess(
+      nextPid,
+      350,
+      requestStartDelayMs,
+      (durationMs) => {
+        now += durationMs;
+      },
+      () => now,
+      (durationMs) => {
+        coldStartSamples.push(durationMs);
+      },
+      notifyRequestStart,
+    ) as never;
   });
   const loggerInfo = vi.fn();
-  const readOutput = vi.fn(async () => ({
-    status: 'success' as const,
-    result: 'ok',
-    toolsUsed: [],
-    artifacts: [],
-  }));
+  const readOutput = vi.fn(async () => {
+    await waitForRequestStart();
+    return {
+      status: 'success' as const,
+      result: 'ok',
+      toolsUsed: [],
+      artifacts: [],
+    };
+  });
   const resolveModelRuntimeCredentials = vi.fn(async () => ({
     provider: 'hybridai' as const,
     apiKey: '',
@@ -169,7 +209,7 @@ async function runSyntheticHostWorkload(requestStartDelayMs: number): Promise<{
 
   return {
     coldStartP95Ms: getWarmHostColdStartP95Ms(),
-    coldStartsRecorded,
+    coldStartSamples,
     withinBudget: isWarmHostColdStartWithinBudget(),
     warmClaims: loggerInfo.mock.calls.filter(
       (call) => call[1] === 'Claimed warm host agent process',
@@ -192,7 +232,9 @@ test('benchmark keeps p95 cold-start within the warm-process budget on a synthet
   const result = await runSyntheticHostWorkload(50);
 
   expect(result.coldStartP95Ms).toBe(50);
-  expect(result.coldStartsRecorded).toBe(20);
+  expect(result.coldStartSamples).toHaveLength(20);
+  expect(result.coldStartSamples[0]).toBe(350 + 50);
+  expect(result.coldStartSamples.slice(1)).toEqual(Array(19).fill(50));
   expect(result.warmClaims).toBeGreaterThan(0);
   expect(result.withinBudget).toBe(true);
 });
@@ -201,7 +243,9 @@ test('benchmark detects p95 cold-start budget violations on a synthetic host wor
   const result = await runSyntheticHostWorkload(250);
 
   expect(result.coldStartP95Ms).toBe(250);
-  expect(result.coldStartsRecorded).toBe(20);
+  expect(result.coldStartSamples).toHaveLength(20);
+  expect(result.coldStartSamples[0]).toBe(350 + 250);
+  expect(result.coldStartSamples.slice(1)).toEqual(Array(19).fill(250));
   expect(result.warmClaims).toBeGreaterThan(0);
   expect(result.withinBudget).toBe(false);
 });

--- a/tests/warm-process-pool.test.ts
+++ b/tests/warm-process-pool.test.ts
@@ -59,6 +59,70 @@ test('evicts least recently used warm entries under capacity pressure', () => {
   expect(pool.claim('agent_b')).toBe(fresh);
 });
 
+test('evicts the minimum viable warm entries under memory pressure', () => {
+  const pool = new WarmProcessPool(
+    normalizeWarmProcessPoolConfig({
+      maxIdlePerAgent: 3,
+      memoryPressureRssBytes: 1_000,
+    }),
+  );
+  const old = makeEntry('old', 'agent_a', 100);
+  const middle = makeEntry('middle', 'agent_a', 200);
+  const fresh = makeEntry('fresh', 'agent_a', 300);
+  pool.add(old);
+  pool.add(middle);
+  pool.add(fresh);
+
+  const evicted = pool.evictForPressure({
+    totalProcessCount: 3,
+    maxProcessCount: 10,
+    rssBytes: 1_000,
+  });
+
+  expect(evicted).toEqual([old]);
+  expect(pool.idleCountForAgent('agent_a')).toBe(2);
+});
+
+test('applies warm pool config changes to existing entries', () => {
+  const pool = new WarmProcessPool(
+    normalizeWarmProcessPoolConfig({ enabled: true, maxIdlePerAgent: 3 }),
+  );
+  const old = makeEntry('old', 'agent_a', 100);
+  const middle = makeEntry('middle', 'agent_a', 200);
+  const fresh = makeEntry('fresh', 'agent_a', 300);
+  pool.add(old);
+  pool.add(middle);
+  pool.add(fresh);
+
+  expect(
+    pool.reconfigure(
+      normalizeWarmProcessPoolConfig({ enabled: true, maxIdlePerAgent: 1 }),
+    ),
+  ).toEqual([old, middle]);
+  expect(pool.idleCountForAgent('agent_a')).toBe(1);
+
+  expect(
+    pool.reconfigure(
+      normalizeWarmProcessPoolConfig({ enabled: false, maxIdlePerAgent: 1 }),
+    ),
+  ).toEqual([fresh]);
+  expect(pool.size).toBe(0);
+});
+
+test('applies cold-start budget config changes without recreating samples', () => {
+  const pool = new WarmProcessPool(
+    normalizeWarmProcessPoolConfig({ coldStartBudgetMs: 200 }),
+  );
+  pool.recordColdStart(300);
+
+  expect(pool.isWithinColdStartBudget()).toBe(false);
+
+  pool.reconfigure(normalizeWarmProcessPoolConfig({ coldStartBudgetMs: 400 }));
+
+  expect(pool.coldStartP95Ms()).toBe(300);
+  expect(pool.isWithinColdStartBudget()).toBe(true);
+});
+
 test('does not claim a warm entry before the worker is ready', () => {
   const pool = new WarmProcessPool(
     normalizeWarmProcessPoolConfig({ maxIdlePerAgent: 2 }),

--- a/tests/warm-process-pool.test.ts
+++ b/tests/warm-process-pool.test.ts
@@ -90,6 +90,29 @@ test('evicts the minimum viable warm entries under memory pressure', () => {
   expect(pool.idleCountForAgent('agent_a')).toBe(2);
 });
 
+test('claims the freshest ready warm entry before pressure evicts older entries', () => {
+  const pool = new WarmProcessPool(
+    normalizeWarmProcessPoolConfig({ maxIdlePerAgent: 3 }),
+  );
+  const old = makeEntry('old', 'agent_a', 100);
+  const middle = makeEntry('middle', 'agent_a', 200);
+  const fresh = makeEntry('fresh', 'agent_a', 300);
+  pool.add(old);
+  pool.add(middle);
+  pool.add(fresh);
+
+  expect(pool.claim('agent_a', 400)).toBe(fresh);
+  expect(fresh.lastUsedAt).toBe(400);
+
+  const evicted = pool.evictForPressure({
+    totalProcessCount: 3,
+    maxProcessCount: 2,
+  });
+
+  expect(evicted).toEqual([old]);
+  expect(pool.claim('agent_a')).toBe(middle);
+});
+
 test('applies warm pool config changes to existing entries', () => {
   const pool = new WarmProcessPool(
     normalizeWarmProcessPoolConfig({ enabled: true, maxIdlePerAgent: 3 }),

--- a/tests/warm-process-pool.test.ts
+++ b/tests/warm-process-pool.test.ts
@@ -91,3 +91,17 @@ test('reports synthetic p95 cold-start budget compliance', () => {
 
   expect(pool.isWithinColdStartBudget()).toBe(false);
 });
+
+test('keeps cold-start p95 cached while rolling old samples out', () => {
+  const pool = new WarmProcessPool(
+    normalizeWarmProcessPoolConfig({ coldStartBudgetMs: 200 }),
+  );
+
+  pool.recordColdStart(10_000);
+  for (let index = 0; index < 500; index += 1) {
+    pool.recordColdStart(100);
+  }
+
+  expect(pool.coldStartP95Ms()).toBe(100);
+  expect(pool.isWithinColdStartBudget()).toBe(true);
+});

--- a/tests/warm-process-pool.test.ts
+++ b/tests/warm-process-pool.test.ts
@@ -1,0 +1,93 @@
+import { expect, test, vi } from 'vitest';
+import {
+  normalizeWarmProcessPoolConfig,
+  WarmProcessPool,
+  type WarmProcessPoolEntry,
+} from '../src/infra/warm-process-pool.js';
+
+function makeEntry(
+  id: string,
+  agentId: string,
+  lastUsedAt: number,
+): WarmProcessPoolEntry {
+  return {
+    id,
+    agentId,
+    lastUsedAt,
+    stop: vi.fn(),
+  };
+}
+
+test('sizes per-agent warm pools from recent traffic', () => {
+  const pool = new WarmProcessPool(
+    normalizeWarmProcessPoolConfig({
+      trafficWindowMs: 60 * 60 * 1000,
+      minIdlePerActiveAgent: 1,
+      maxIdlePerAgent: 5,
+    }),
+  );
+  const now = 10_000_000;
+
+  for (let index = 0; index < 120; index += 1) {
+    pool.recordRequest('agent_a', 30_000, now - index * 1_000);
+  }
+
+  expect(pool.targetIdleForAgent('agent_a', now)).toBe(1);
+
+  for (let index = 0; index < 600; index += 1) {
+    pool.recordRequest('agent_b', 60_000, now - index * 1_000);
+  }
+
+  expect(pool.targetIdleForAgent('agent_b', now)).toBe(5);
+});
+
+test('evicts least recently used warm entries under capacity pressure', () => {
+  const pool = new WarmProcessPool(
+    normalizeWarmProcessPoolConfig({ maxIdlePerAgent: 3 }),
+  );
+  const old = makeEntry('old', 'agent_a', 100);
+  const fresh = makeEntry('fresh', 'agent_b', 300);
+  pool.add(old);
+  pool.add(fresh);
+
+  const evicted = pool.evictForPressure({
+    totalProcessCount: 3,
+    maxProcessCount: 2,
+  });
+
+  expect(evicted).toEqual([old]);
+  expect(pool.claim('agent_b')).toBe(fresh);
+});
+
+test('does not claim a warm entry before the worker is ready', () => {
+  const pool = new WarmProcessPool(
+    normalizeWarmProcessPoolConfig({ maxIdlePerAgent: 2 }),
+  );
+  let ready = false;
+  const entry = {
+    ...makeEntry('warming', 'agent_a', 100),
+    isReady: () => ready,
+  };
+
+  pool.add(entry);
+
+  expect(pool.claim('agent_a')).toBeNull();
+  ready = true;
+  expect(pool.claim('agent_a')).toBe(entry);
+});
+
+test('reports synthetic p95 cold-start budget compliance', () => {
+  const pool = new WarmProcessPool(
+    normalizeWarmProcessPoolConfig({ coldStartBudgetMs: 200 }),
+  );
+  for (const sample of [75, 90, 100, 120, 150, 180, 190, 195, 198, 200]) {
+    pool.recordColdStart(sample);
+  }
+
+  expect(pool.coldStartP95Ms()).toBe(200);
+  expect(pool.isWithinColdStartBudget()).toBe(true);
+
+  pool.recordColdStart(260);
+
+  expect(pool.isWithinColdStartBudget()).toBe(false);
+});

--- a/tests/warm-process-pool.test.ts
+++ b/tests/warm-process-pool.test.ts
@@ -18,6 +18,13 @@ function makeEntry(
   };
 }
 
+test('normalizes runtime memory pressure from MB to bytes', () => {
+  expect(
+    normalizeWarmProcessPoolConfig({ memoryPressureRssMb: 2 })
+      .memoryPressureRssBytes,
+  ).toBe(2 * 1024 * 1024);
+});
+
 test('sizes per-agent warm pools from recent traffic', () => {
   const pool = new WarmProcessPool(
     normalizeWarmProcessPoolConfig({
@@ -63,7 +70,7 @@ test('evicts the minimum viable warm entries under memory pressure', () => {
   const pool = new WarmProcessPool(
     normalizeWarmProcessPoolConfig({
       maxIdlePerAgent: 3,
-      memoryPressureRssBytes: 1_000,
+      memoryPressureRssMb: 1,
     }),
   );
   const old = makeEntry('old', 'agent_a', 100);
@@ -76,7 +83,7 @@ test('evicts the minimum viable warm entries under memory pressure', () => {
   const evicted = pool.evictForPressure({
     totalProcessCount: 3,
     maxProcessCount: 10,
-    rssBytes: 1_000,
+    rssBytes: 1024 * 1024,
   });
 
   expect(evicted).toEqual([old]);

--- a/tests/warm-process-pool.test.ts
+++ b/tests/warm-process-pool.test.ts
@@ -25,6 +25,15 @@ test('normalizes runtime memory pressure from MB to bytes', () => {
   ).toBe(2 * 1024 * 1024);
 });
 
+test('normalizes min idle workers to the configured max idle workers', () => {
+  expect(
+    normalizeWarmProcessPoolConfig({
+      minIdlePerActiveAgent: 5,
+      maxIdlePerAgent: 2,
+    }).minIdlePerActiveAgent,
+  ).toBe(2);
+});
+
 test('sizes per-agent warm pools from recent traffic', () => {
   const pool = new WarmProcessPool(
     normalizeWarmProcessPoolConfig({

--- a/tests/warm-process-pool.test.ts
+++ b/tests/warm-process-pool.test.ts
@@ -153,21 +153,38 @@ test('applies cold-start budget config changes without recreating samples', () =
   expect(pool.isWithinColdStartBudget()).toBe(true);
 });
 
-test('does not claim a warm entry before the worker is ready', () => {
+test('prefers ready warm entries but falls back to warming entries', () => {
   const pool = new WarmProcessPool(
     normalizeWarmProcessPoolConfig({ maxIdlePerAgent: 2 }),
   );
-  let ready = false;
-  const entry = {
+  const warming = {
     ...makeEntry('warming', 'agent_a', 100),
-    isReady: () => ready,
+    isReady: () => false,
+  };
+  const ready = {
+    ...makeEntry('ready', 'agent_a', 90),
+    isReady: () => true,
   };
 
-  pool.add(entry);
+  pool.add(warming);
+  pool.add(ready);
 
-  expect(pool.claim('agent_a')).toBeNull();
-  ready = true;
-  expect(pool.claim('agent_a')).toBe(entry);
+  expect(pool.claim('agent_a')).toBe(ready);
+  expect(pool.claim('agent_a')).toBe(warming);
+});
+
+test('claims warming entries instead of forcing redundant spawns', () => {
+  const pool = new WarmProcessPool(
+    normalizeWarmProcessPoolConfig({ maxIdlePerAgent: 2 }),
+  );
+  const warming = {
+    ...makeEntry('warming', 'agent_a', 100),
+    isReady: () => false,
+  };
+
+  pool.add(warming);
+
+  expect(pool.claim('agent_a')).toBe(warming);
 });
 
 test('reports synthetic p95 cold-start budget compliance', () => {

--- a/tests/warm-runner-utils.test.ts
+++ b/tests/warm-runner-utils.test.ts
@@ -1,5 +1,10 @@
 import { expect, test, vi } from 'vitest';
-import { createWarmSessionId } from '../src/infra/warm-runner-utils.js';
+import { WarmProcessPool } from '../src/infra/warm-process-pool.js';
+import {
+  claimWarmEntry,
+  createWarmSessionId,
+  type WarmRunnerEntry,
+} from '../src/infra/warm-runner-utils.js';
 
 test('creates warm session IDs with sanitized agents and crypto entropy', () => {
   const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
@@ -11,4 +16,46 @@ test('creates warm session IDs with sanitized agents and crypto entropy', () => 
   expect(first).toMatch(/^warm_agent_a_b_1700000000000_[0-9a-f]{12}$/);
   expect(second).toMatch(/^warm_agent_a_b_1700000000000_[0-9a-f]{12}$/);
   expect(first).not.toBe(second);
+});
+
+test('claims an existing warming entry instead of forcing another spawn', () => {
+  const active = new Map<string, WarmRunnerEntry>();
+  const warmPool = new WarmProcessPool<WarmRunnerEntry>({
+    enabled: true,
+    coldStartBudgetMs: 200,
+    trafficWindowMs: 3_600_000,
+    minIdlePerActiveAgent: 1,
+    maxIdlePerAgent: 2,
+    memoryPressureRssBytes: 0,
+  });
+  const warming: WarmRunnerEntry = {
+    id: 'warm-1',
+    sessionId: 'warm-1',
+    agentId: 'agent_a',
+    lastUsedAt: 100,
+    warm: true,
+    readyForInputAt: null,
+    pendingColdStartProbeStartedAt: null,
+    stderrHistory: [],
+    isReady: () => false,
+    stop: vi.fn(),
+  };
+  const logClaim = vi.fn();
+  warmPool.add(warming);
+
+  const claimed = claimWarmEntry({
+    pool: active,
+    warmPool,
+    sessionId: 'request-1',
+    agentId: 'agent_a',
+    eligibility: {},
+    logClaim,
+  });
+
+  expect(claimed).toBe(warming);
+  expect(warming.sessionId).toBe('request-1');
+  expect(warming.warm).toBe(false);
+  expect(active.get('request-1')).toBe(warming);
+  expect(warmPool.size).toBe(0);
+  expect(logClaim).toHaveBeenCalledWith(warming);
 });

--- a/tests/warm-runner-utils.test.ts
+++ b/tests/warm-runner-utils.test.ts
@@ -1,0 +1,14 @@
+import { expect, test, vi } from 'vitest';
+import { createWarmSessionId } from '../src/infra/warm-runner-utils.js';
+
+test('creates warm session IDs with sanitized agents and crypto entropy', () => {
+  const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+
+  const first = createWarmSessionId('agent/a:b');
+  const second = createWarmSessionId('agent/a:b');
+  nowSpy.mockRestore();
+
+  expect(first).toMatch(/^warm_agent_a_b_1700000000000_[0-9a-f]{12}$/);
+  expect(second).toMatch(/^warm_agent_a_b_1700000000000_[0-9a-f]{12}$/);
+  expect(first).not.toBe(second);
+});

--- a/tests/warm-runner-utils.test.ts
+++ b/tests/warm-runner-utils.test.ts
@@ -3,10 +3,47 @@ import { WarmProcessPool } from '../src/infra/warm-process-pool.js';
 import {
   claimWarmEntry,
   createWarmSessionId,
+  enforceWarmPoolPressure,
   getCachedObservedMemoryBytes,
+  maintainWarmPool,
+  observeAgentLifecycleLine,
   type MemorySample,
   type WarmRunnerEntry,
 } from '../src/infra/warm-runner-utils.js';
+
+function makeWarmPool(config: {
+  enabled?: boolean;
+  minIdlePerActiveAgent?: number;
+  maxIdlePerAgent?: number;
+  memoryPressureRssBytes?: number;
+}): WarmProcessPool<WarmRunnerEntry> {
+  return new WarmProcessPool<WarmRunnerEntry>({
+    enabled: config.enabled ?? true,
+    coldStartBudgetMs: 200,
+    trafficWindowMs: 3_600_000,
+    minIdlePerActiveAgent: config.minIdlePerActiveAgent ?? 1,
+    maxIdlePerAgent: config.maxIdlePerAgent ?? 2,
+    memoryPressureRssBytes: config.memoryPressureRssBytes ?? 0,
+  });
+}
+
+function makeEntry(
+  id: string,
+  agentId = 'agent_a',
+  lastUsedAt = 100,
+): WarmRunnerEntry {
+  return {
+    id,
+    sessionId: id,
+    agentId,
+    lastUsedAt,
+    warm: true,
+    readyForInputAt: null,
+    pendingColdStartProbeStartedAt: null,
+    stderrHistory: [],
+    stop: vi.fn(),
+  };
+}
 
 test('creates warm session IDs with sanitized agents and crypto entropy', () => {
   const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
@@ -22,25 +59,10 @@ test('creates warm session IDs with sanitized agents and crypto entropy', () => 
 
 test('claims an existing warming entry instead of forcing another spawn', () => {
   const active = new Map<string, WarmRunnerEntry>();
-  const warmPool = new WarmProcessPool<WarmRunnerEntry>({
-    enabled: true,
-    coldStartBudgetMs: 200,
-    trafficWindowMs: 3_600_000,
-    minIdlePerActiveAgent: 1,
-    maxIdlePerAgent: 2,
-    memoryPressureRssBytes: 0,
-  });
+  const warmPool = makeWarmPool({});
   const warming: WarmRunnerEntry = {
-    id: 'warm-1',
-    sessionId: 'warm-1',
-    agentId: 'agent_a',
-    lastUsedAt: 100,
-    warm: true,
-    readyForInputAt: null,
-    pendingColdStartProbeStartedAt: null,
-    stderrHistory: [],
+    ...makeEntry('warm-1'),
     isReady: () => false,
-    stop: vi.fn(),
   };
   const logClaim = vi.fn();
   warmPool.add(warming);
@@ -62,6 +84,158 @@ test('claims an existing warming entry instead of forcing another spawn', () => 
   expect(logClaim).toHaveBeenCalledWith(warming);
 });
 
+test('skips warm claim when request eligibility is not pool-safe', () => {
+  const active = new Map<string, WarmRunnerEntry>();
+  const warmPool = makeWarmPool({});
+  const warm = makeEntry('warm-1');
+  warmPool.add(warm);
+
+  const claimed = claimWarmEntry({
+    pool: active,
+    warmPool,
+    sessionId: 'request-1',
+    agentId: 'agent_a',
+    eligibility: { workspacePathOverride: '/custom/workspace' },
+    logClaim: vi.fn(),
+  });
+
+  expect(claimed).toBeNull();
+  expect(active.size).toBe(0);
+  expect(warmPool.size).toBe(1);
+});
+
+test('observes readiness and records cold-start from agent request start', () => {
+  const nowSpy = vi.spyOn(Date, 'now');
+  const warmPool = makeWarmPool({});
+  const entry = makeEntry('warm-1');
+  const notify = vi.fn();
+  entry.activity = { notify } as WarmRunnerEntry['activity'];
+  entry.pendingColdStartProbeStartedAt = 1_000;
+
+  nowSpy.mockReturnValue(1_050);
+  expect(
+    observeAgentLifecycleLine(
+      entry,
+      '[hybridclaw-agent] ready for input',
+      warmPool,
+    ),
+  ).toBe(true);
+  expect(entry.readyForInputAt).toBe(1_050);
+
+  nowSpy.mockReturnValue(1_125);
+  expect(
+    observeAgentLifecycleLine(
+      entry,
+      '[hybridclaw-agent] agent request start',
+      warmPool,
+    ),
+  ).toBe(true);
+  expect(entry.pendingColdStartProbeStartedAt).toBeNull();
+  expect(warmPool.coldStartP95Ms()).toBe(125);
+  expect(notify).toHaveBeenCalledTimes(2);
+  expect(observeAgentLifecycleLine(entry, 'ordinary stderr', warmPool)).toBe(
+    false,
+  );
+
+  nowSpy.mockRestore();
+});
+
+test('enforces memory pressure by stopping selected warm entries', () => {
+  const active = new Map<string, WarmRunnerEntry>();
+  const warmPool = makeWarmPool({ memoryPressureRssBytes: 1_000 });
+  const old = makeEntry('old', 'agent_a', 100);
+  const fresh = makeEntry('fresh', 'agent_a', 200);
+  warmPool.add(old);
+  warmPool.add(fresh);
+  const stopEntries = vi.fn();
+  const getObservedMemoryBytes = vi.fn(() => 1_500);
+
+  enforceWarmPoolPressure({
+    pool: active,
+    warmPool,
+    maxProcessCount: 10,
+    getObservedMemoryBytes,
+    stopEntries,
+  });
+
+  expect(getObservedMemoryBytes).toHaveBeenCalledOnce();
+  expect(stopEntries).toHaveBeenCalledWith([old]);
+  expect(warmPool.size).toBe(1);
+  expect(warmPool.claim('agent_a')).toBe(fresh);
+});
+
+test('enforces process capacity without sampling memory', () => {
+  const active = new Map<string, WarmRunnerEntry>([
+    ['active-1', makeEntry('active-1', 'agent_a', 300)],
+  ]);
+  const warmPool = makeWarmPool({ memoryPressureRssBytes: 1_000 });
+  const warm = makeEntry('warm-1', 'agent_a', 100);
+  warmPool.add(warm);
+  const stopEntries = vi.fn();
+  const getObservedMemoryBytes = vi.fn(() => 0);
+
+  enforceWarmPoolPressure({
+    pool: active,
+    warmPool,
+    maxProcessCount: 1,
+    getObservedMemoryBytes,
+    stopEntries,
+  });
+
+  expect(getObservedMemoryBytes).not.toHaveBeenCalled();
+  expect(stopEntries).toHaveBeenCalledWith([warm]);
+});
+
+test('maintains target warm entries for recent agent traffic', () => {
+  const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+  const active = new Map<string, WarmRunnerEntry>();
+  const warmPool = makeWarmPool({
+    minIdlePerActiveAgent: 1,
+    maxIdlePerAgent: 2,
+  });
+  warmPool.recordRequest('agent_a', 30_000, 1_700_000_000_000);
+  const spawned: string[] = [];
+
+  maintainWarmPool({
+    pool: active,
+    warmPool,
+    maxProcessCount: 3,
+    agentId: 'agent_a',
+    eligibility: {},
+    stopEntries: vi.fn(),
+    spawnWarm: (sessionId, agentId) => {
+      spawned.push(`${agentId}:${sessionId}`);
+      warmPool.add(makeEntry(sessionId, agentId));
+    },
+  });
+
+  expect(spawned).toHaveLength(1);
+  expect(spawned[0]).toMatch(/^agent_a:warm_agent_a_/);
+  expect(warmPool.idleCountForAgent('agent_a')).toBe(1);
+
+  nowSpy.mockRestore();
+});
+
+test('does not maintain warm entries for ineligible requests', () => {
+  const active = new Map<string, WarmRunnerEntry>();
+  const warmPool = makeWarmPool({});
+  warmPool.recordRequest('agent_a', 30_000);
+  const spawnWarm = vi.fn();
+
+  maintainWarmPool({
+    pool: active,
+    warmPool,
+    maxProcessCount: 3,
+    agentId: 'agent_a',
+    eligibility: { bashProxy: { mode: 'docker-exec' } },
+    stopEntries: vi.fn(),
+    spawnWarm,
+  });
+
+  expect(spawnWarm).not.toHaveBeenCalled();
+  expect(warmPool.size).toBe(0);
+});
+
 test('uses the last known memory sample while refreshing a changed pool sample', async () => {
   let cache: MemorySample | null = {
     at: 1_700_000_000_000,
@@ -69,17 +243,8 @@ test('uses the last known memory sample while refreshing a changed pool sample',
     totalBytes: 512,
   };
   let refreshInFlight = false;
-  const entry: WarmRunnerEntry = {
-    id: 'warm-1',
-    sessionId: 'warm-1',
-    agentId: 'agent_a',
-    lastUsedAt: 100,
-    warm: true,
-    readyForInputAt: 1,
-    pendingColdStartProbeStartedAt: null,
-    stderrHistory: [],
-    stop: vi.fn(),
-  };
+  const entry = makeEntry('warm-1');
+  entry.readyForInputAt = 1;
   const refreshTotalBytes = vi.fn(async () => 1024);
 
   const observed = getCachedObservedMemoryBytes({

--- a/tests/warm-runner-utils.test.ts
+++ b/tests/warm-runner-utils.test.ts
@@ -3,6 +3,8 @@ import { WarmProcessPool } from '../src/infra/warm-process-pool.js';
 import {
   claimWarmEntry,
   createWarmSessionId,
+  getCachedObservedMemoryBytes,
+  type MemorySample,
   type WarmRunnerEntry,
 } from '../src/infra/warm-runner-utils.js';
 
@@ -58,4 +60,50 @@ test('claims an existing warming entry instead of forcing another spawn', () => 
   expect(active.get('request-1')).toBe(warming);
   expect(warmPool.size).toBe(0);
   expect(logClaim).toHaveBeenCalledWith(warming);
+});
+
+test('uses the last known memory sample while refreshing a changed pool sample', async () => {
+  let cache: MemorySample | null = {
+    at: 1_700_000_000_000,
+    key: 'old-pid',
+    totalBytes: 512,
+  };
+  let refreshInFlight = false;
+  const entry: WarmRunnerEntry = {
+    id: 'warm-1',
+    sessionId: 'warm-1',
+    agentId: 'agent_a',
+    lastUsedAt: 100,
+    warm: true,
+    readyForInputAt: 1,
+    pendingColdStartProbeStartedAt: null,
+    stderrHistory: [],
+    stop: vi.fn(),
+  };
+  const refreshTotalBytes = vi.fn(async () => 1024);
+
+  const observed = getCachedObservedMemoryBytes({
+    cache,
+    setCache: (sample) => {
+      cache = sample;
+    },
+    isRefreshInFlight: () => refreshInFlight,
+    setRefreshInFlight: (value) => {
+      refreshInFlight = value;
+    },
+    activeEntries: [],
+    warmEntries: [entry],
+    memoryPressureEnabled: true,
+    keyForEntry: (warmEntry) => warmEntry.id,
+    refreshTotalBytes,
+  });
+
+  expect(observed).toBe(512);
+  expect(refreshTotalBytes).toHaveBeenCalledWith(['warm-1']);
+  await new Promise((resolve) => setImmediate(resolve));
+  expect(cache).toMatchObject({
+    key: 'warm-1',
+    totalBytes: 1024,
+  });
+  expect(refreshInFlight).toBe(false);
 });


### PR DESCRIPTION
## Summary

Closes #590.

Adds an adaptive warm process pool so per-agent workers can stay ready between turns and be claimed without paying full process startup cost. The pool sizes idle workers from recent per-agent traffic, evicts least-recently-used warm workers under capacity or memory pressure, and records cold-start p95 against the configurable budget.

## Details

- Adds `container.warmPool` runtime config with a default 200ms cold-start budget and schema version `26`.
- Adds shared warm-pool policy for adaptive sizing, readiness-gated claiming, LRU eviction, and p95 tracking.
- Wires warm workers into both container and host execution paths.
- Adds explicit worker lifecycle markers so budget timing measures from input dispatch to agent request start, not just synchronous process spawn.
- Observes memory pressure from Docker container usage in container mode and child process RSS in host mode.
- Adds a synthetic host-executor benchmark that drives the real runner path and asserts p95 remains within budget.

## Validation

- `./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/container-runner.redaction.test.ts tests/host-runner.redaction.test.ts tests/warm-process-pool.test.ts tests/warm-process-pool.benchmark.test.ts tests/agent-executor.test.ts tests/runtime-config.migration-logging.test.ts`
- `npm run lint`
- `npm --prefix container run build`
- `git diff --check`