### PR TITLE
[codex] Persist team structure revisions

### DIFF
--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -33,6 +33,8 @@ import type {
   AdminSession,
   AdminSkillsResponse,
   AdminStatisticsResponse,
+  AdminTeamStructureResponse,
+  AdminTeamStructureRevisionResponse,
   AdminTerminalStartResponse,
   AdminTerminalStopResponse,
   AdminToolsResponse,
@@ -295,6 +297,37 @@ export async function fetchAdminAgents(token: string): Promise<AdminAgent[]> {
     token,
   });
   return payload.agents;
+}
+
+export function fetchAdminTeamStructure(
+  token: string,
+): Promise<AdminTeamStructureResponse> {
+  return requestJson<AdminTeamStructureResponse>('/api/admin/team-structure', {
+    token,
+  });
+}
+
+export function fetchAdminTeamStructureRevision(
+  token: string,
+  revisionId: number,
+): Promise<AdminTeamStructureRevisionResponse> {
+  return requestJson<AdminTeamStructureRevisionResponse>(
+    `/api/admin/team-structure/revisions/${encodeURIComponent(String(revisionId))}`,
+    { token },
+  );
+}
+
+export function restoreAdminTeamStructureRevision(
+  token: string,
+  revisionId: number,
+): Promise<AdminTeamStructureResponse> {
+  return requestJson<AdminTeamStructureResponse>(
+    `/api/admin/team-structure/revisions/${encodeURIComponent(String(revisionId))}/restore`,
+    {
+      token,
+      method: 'POST',
+    },
+  );
 }
 
 export function fetchAdminAgentMarkdownFile(

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -838,12 +838,7 @@ export interface AdminTeamStructureResponse {
 }
 
 export interface AdminTeamStructureRevisionResponse {
-  revision: AdminTeamStructureRevision & {
-    content: string;
-    snapshot: AdminTeamStructureSnapshot;
-    nextContent: string | null;
-    nextSnapshot: AdminTeamStructureSnapshot | null;
-  };
+  revision: AdminTeamStructureRevision;
 }
 
 export interface AdminAgentMarkdownFileResponse {

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -776,6 +776,10 @@ export interface AdminAgent {
   skills: string[] | null;
   chatbotId: string | null;
   enableRag: boolean | null;
+  role: string | null;
+  reportsTo: string | null;
+  delegatesTo: string[] | null;
+  peers: string[] | null;
   workspace: string | null;
   workspacePath: string;
   markdownFiles: AdminAgentMarkdownFile[];
@@ -783,6 +787,63 @@ export interface AdminAgent {
 
 export interface AdminAgentsResponse {
   agents: AdminAgent[];
+}
+
+export interface AdminTeamStructureEntry {
+  id: string;
+  role?: string;
+  reportsTo?: string;
+  delegatesTo?: string[];
+  peers?: string[];
+}
+
+export interface AdminTeamStructureSnapshot {
+  version: 1;
+  agents: AdminTeamStructureEntry[];
+}
+
+export interface AdminTeamStructureFieldDiff {
+  field: 'role' | 'reportsTo' | 'delegatesTo' | 'peers';
+  before: string | string[] | null;
+  after: string | string[] | null;
+}
+
+export interface AdminTeamStructureAgentDiff {
+  agentId: string;
+  fields: AdminTeamStructureFieldDiff[];
+}
+
+export interface AdminTeamStructureDiff {
+  added: AdminTeamStructureEntry[];
+  removed: AdminTeamStructureEntry[];
+  changed: AdminTeamStructureAgentDiff[];
+}
+
+export interface AdminTeamStructureRevision {
+  id: number;
+  createdAt: string;
+  actor: string;
+  route: string;
+  source: string;
+  md5: string;
+  sizeBytes: number;
+  replacedByMd5: string | null;
+  changeCount: number;
+  diff: AdminTeamStructureDiff;
+}
+
+export interface AdminTeamStructureResponse {
+  snapshot: AdminTeamStructureSnapshot;
+  revisions: AdminTeamStructureRevision[];
+}
+
+export interface AdminTeamStructureRevisionResponse {
+  revision: AdminTeamStructureRevision & {
+    content: string;
+    snapshot: AdminTeamStructureSnapshot;
+    nextContent: string | null;
+    nextSnapshot: AdminTeamStructureSnapshot | null;
+  };
 }
 
 export interface AdminAgentMarkdownFileResponse {

--- a/console/src/routes/agents.test.tsx
+++ b/console/src/routes/agents.test.tsx
@@ -24,6 +24,9 @@ const fetchAdminAgentMarkdownRevisionMock =
       params: { agentId: string; fileName: string; revisionId: string },
     ) => Promise<AdminAgentMarkdownRevisionResponse>
   >();
+const fetchAdminTeamStructureMock = vi.fn();
+const fetchAdminTeamStructureRevisionMock = vi.fn();
+const restoreAdminTeamStructureRevisionMock = vi.fn();
 const restoreAdminAgentMarkdownRevisionMock = vi.fn();
 const saveAdminAgentMarkdownFileMock = vi.fn();
 const useAuthMock = vi.fn();
@@ -38,10 +41,16 @@ vi.mock('../api/client', () => ({
     token: string,
     params: { agentId: string; fileName: string; revisionId: string },
   ) => fetchAdminAgentMarkdownRevisionMock(token, params),
+  fetchAdminTeamStructure: (token: string) =>
+    fetchAdminTeamStructureMock(token),
+  fetchAdminTeamStructureRevision: (token: string, revisionId: number) =>
+    fetchAdminTeamStructureRevisionMock(token, revisionId),
   restoreAdminAgentMarkdownRevision: (
     token: string,
     params: { agentId: string; fileName: string; revisionId: string },
   ) => restoreAdminAgentMarkdownRevisionMock(token, params),
+  restoreAdminTeamStructureRevision: (token: string, revisionId: number) =>
+    restoreAdminTeamStructureRevisionMock(token, revisionId),
   saveAdminAgentMarkdownFile: (
     token: string,
     params: { agentId: string; fileName: string; content: string },
@@ -60,6 +69,10 @@ function makeAgent(overrides: Partial<AdminAgent>): AdminAgent {
     skills: null,
     chatbotId: null,
     enableRag: true,
+    role: null,
+    reportsTo: null,
+    delegatesTo: null,
+    peers: null,
     workspace: null,
     workspacePath: '/tmp/main/workspace',
     markdownFiles: [
@@ -136,11 +149,18 @@ describe('AgentFilesPage', () => {
     fetchAdminAgentsMock.mockReset();
     fetchAdminAgentMarkdownFileMock.mockReset();
     fetchAdminAgentMarkdownRevisionMock.mockReset();
+    fetchAdminTeamStructureMock.mockReset();
+    fetchAdminTeamStructureRevisionMock.mockReset();
+    restoreAdminTeamStructureRevisionMock.mockReset();
     restoreAdminAgentMarkdownRevisionMock.mockReset();
     saveAdminAgentMarkdownFileMock.mockReset();
     useAuthMock.mockReset();
     useAuthMock.mockReturnValue({
       token: 'test-token',
+    });
+    fetchAdminTeamStructureMock.mockResolvedValue({
+      snapshot: { version: 1, agents: [{ id: 'main' }] },
+      revisions: [],
     });
   });
 

--- a/console/src/routes/agents.tsx
+++ b/console/src/routes/agents.tsx
@@ -4,10 +4,17 @@ import {
   fetchAdminAgentMarkdownFile,
   fetchAdminAgentMarkdownRevision,
   fetchAdminAgents,
+  fetchAdminTeamStructure,
+  fetchAdminTeamStructureRevision,
   restoreAdminAgentMarkdownRevision,
+  restoreAdminTeamStructureRevision,
   saveAdminAgentMarkdownFile,
 } from '../api/client';
-import type { AdminAgent } from '../api/types';
+import type {
+  AdminAgent,
+  AdminTeamStructureDiff,
+  AdminTeamStructureFieldDiff,
+} from '../api/types';
 import { useAuth } from '../auth';
 import { useToast } from '../components/toast';
 import { Panel } from '../components/ui';
@@ -31,6 +38,31 @@ function getSelectedDocumentKey(
   return `${agentId}:${fileName}`;
 }
 
+function formatTeamFieldValue(
+  value: AdminTeamStructureFieldDiff['before'],
+): string {
+  if (Array.isArray(value)) return value.length > 0 ? value.join(', ') : 'none';
+  return value || 'none';
+}
+
+function formatTeamDiff(diff: AdminTeamStructureDiff): string {
+  const lines: string[] = [];
+  for (const agent of diff.added) {
+    lines.push(`+ ${agent.id}`);
+  }
+  for (const agent of diff.removed) {
+    lines.push(`- ${agent.id}`);
+  }
+  for (const agent of diff.changed) {
+    for (const field of agent.fields) {
+      lines.push(
+        `~ ${agent.agentId}.${field.field}: ${formatTeamFieldValue(field.before)} -> ${formatTeamFieldValue(field.after)}`,
+      );
+    }
+  }
+  return lines.length > 0 ? lines.join('\n') : 'No field changes recorded.';
+}
+
 export function AgentFilesPage() {
   const auth = useAuth();
   const queryClient = useQueryClient();
@@ -45,6 +77,9 @@ export function AgentFilesPage() {
   const [selectedRevisionId, setSelectedRevisionId] = useState<string | null>(
     null,
   );
+  const [selectedTeamRevisionId, setSelectedTeamRevisionId] = useState<
+    number | null
+  >(null);
   const [draftContent, setDraftContent] = useState('');
   const hydratedDocumentKeyRef = useRef<string | null>(null);
   const hydratedContentRef = useRef('');
@@ -132,6 +167,24 @@ export function AgentFilesPage() {
     enabled: Boolean(
       selectedAgent?.id && selectedFileName && selectedRevisionId,
     ),
+    refetchOnWindowFocus: false,
+  });
+
+  const teamQuery = useQuery({
+    queryKey: ['admin-team-structure', auth.token],
+    queryFn: () => fetchAdminTeamStructure(auth.token),
+    refetchOnWindowFocus: false,
+  });
+
+  const teamRevisionQuery = useQuery({
+    queryKey: [
+      'admin-team-structure-revision',
+      auth.token,
+      selectedTeamRevisionId || 0,
+    ],
+    queryFn: () =>
+      fetchAdminTeamStructureRevision(auth.token, selectedTeamRevisionId || 0),
+    enabled: Boolean(selectedTeamRevisionId),
     refetchOnWindowFocus: false,
   });
 
@@ -228,6 +281,29 @@ export function AgentFilesPage() {
     },
     onError: (error) => {
       toast.error('Restore failed', getErrorMessage(error));
+    },
+  });
+
+  const restoreTeamMutation = useMutation({
+    mutationFn: async () => {
+      if (!selectedTeamRevisionId) {
+        throw new Error('Select a team revision to restore first.');
+      }
+      return restoreAdminTeamStructureRevision(
+        auth.token,
+        selectedTeamRevisionId,
+      );
+    },
+    onSuccess: (payload) => {
+      queryClient.setQueryData(['admin-team-structure', auth.token], payload);
+      void queryClient.invalidateQueries({
+        queryKey: ['admin-agents', auth.token],
+      });
+      setSelectedTeamRevisionId(null);
+      toast.success('Restored team structure from revision history.');
+    },
+    onError: (error) => {
+      toast.error('Team restore failed', getErrorMessage(error));
     },
   });
 
@@ -442,6 +518,104 @@ export function AgentFilesPage() {
                             }
                           >
                             Copy to Editor
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </Panel>
+                </div>
+
+                <div className="two-column-grid">
+                  <Panel
+                    title="Team Revisions"
+                    subtitle={`${teamQuery.data?.revisions.length || 0} saved revision${teamQuery.data?.revisions.length === 1 ? '' : 's'}`}
+                  >
+                    {teamQuery.isLoading ? (
+                      <div className="empty-state">
+                        Loading team revisions...
+                      </div>
+                    ) : !teamQuery.data?.revisions.length ? (
+                      <div className="empty-state">
+                        Team revisions appear here after org-chart changes.
+                      </div>
+                    ) : (
+                      <div className="list-stack selectable-list">
+                        {teamQuery.data.revisions.map((revision) => (
+                          <button
+                            key={revision.id}
+                            className={
+                              revision.id === selectedTeamRevisionId
+                                ? 'selectable-row active'
+                                : 'selectable-row'
+                            }
+                            type="button"
+                            onClick={() =>
+                              setSelectedTeamRevisionId(revision.id)
+                            }
+                          >
+                            <div>
+                              <strong>
+                                #{revision.id} ·{' '}
+                                {formatDateTime(revision.createdAt)}
+                              </strong>
+                              <small>
+                                {formatRelativeTime(revision.createdAt)} ·{' '}
+                                {revision.changeCount} change
+                                {revision.changeCount === 1 ? '' : 's'} ·{' '}
+                                {revision.route}
+                              </small>
+                            </div>
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </Panel>
+
+                  <Panel title="Team Diff" accent="warm">
+                    {!selectedTeamRevisionId ? (
+                      <div className="empty-state">
+                        Select a team revision to inspect its diff.
+                      </div>
+                    ) : teamRevisionQuery.isLoading ? (
+                      <div className="empty-state">
+                        Loading team revision...
+                      </div>
+                    ) : !teamRevisionQuery.data ? (
+                      <div className="empty-state">
+                        Team revision details are unavailable.
+                      </div>
+                    ) : (
+                      <div className="detail-stack">
+                        <div className="summary-block">
+                          <span>
+                            Revision #{teamRevisionQuery.data.revision.id}
+                          </span>
+                          <p>
+                            {teamRevisionQuery.data.revision.md5.slice(0, 16)} ·{' '}
+                            {teamRevisionQuery.data.revision.source}
+                          </p>
+                        </div>
+                        <label className="field textarea-field">
+                          <span>Diff</span>
+                          <textarea
+                            className="code-editor"
+                            rows={10}
+                            readOnly
+                            value={formatTeamDiff(
+                              teamRevisionQuery.data.revision.diff,
+                            )}
+                          />
+                        </label>
+                        <div className="button-row">
+                          <button
+                            className="primary-button"
+                            type="button"
+                            disabled={restoreTeamMutation.isPending}
+                            onClick={() => restoreTeamMutation.mutate()}
+                          >
+                            {restoreTeamMutation.isPending
+                              ? 'Restoring...'
+                              : 'Restore Team'}
                           </button>
                         </div>
                       </div>

--- a/docs/content/channels/admin-console.md
+++ b/docs/content/channels/admin-console.md
@@ -35,6 +35,9 @@ and delete the current workspace network policy rules for a selected agent.
   runtime workspace
 - `/admin/agents` shows saved revisions for those markdown files and can
   restore an earlier version without opening the workspace directory manually
+- `/admin/agents` also shows org-chart/team-structure revisions, per-revision
+  diffs, and a restore action for rolling back role, reporting, delegation, and
+  peer relationships
 - `/admin/approvals` shows unresolved approval prompts across sessions and the
   selected agent workspace's current `policy.yaml` network rules in one place
 - `/admin/approvals` can add, edit, and delete network rules without switching
@@ -70,6 +73,7 @@ scoped to the built-in allowlist and is not a general workspace file browser.
 - you want to verify saved settings without editing `config.json` directly
 - you want to update an agent's workspace instructions from the browser
 - you want revision history before restoring an earlier agent prompt file
+- you want to inspect or roll back agent org-chart changes from the browser
 - you want to inspect pending approvals and compare them with the declarative
   network policy without switching to `/chat` or opening the workspace files
 - you want to add, edit, or remove network policy rules from the browser

--- a/docs/content/channels/admin-console.md
+++ b/docs/content/channels/admin-console.md
@@ -35,9 +35,7 @@ and delete the current workspace network policy rules for a selected agent.
   runtime workspace
 - `/admin/agents` shows saved revisions for those markdown files and can
   restore an earlier version without opening the workspace directory manually
-- `/admin/agents` also shows org-chart/team-structure revisions, per-revision
-  diffs, and a restore action for rolling back role, reporting, delegation, and
-  peer relationships
+- `/admin/agents` also shows org-chart/team-structure revisions, per-revision diffs, and a restore action for rolling back role, reporting, delegation, and peer relationships
 - `/admin/approvals` shows unresolved approval prompts across sessions and the
   selected agent workspace's current `policy.yaml` network rules in one place
 - `/admin/approvals` can add, edit, and delete network rules without switching

--- a/src/agents/agent-registry.ts
+++ b/src/agents/agent-registry.ts
@@ -9,10 +9,12 @@ import {
 import { getRuntimeConfig } from '../config/runtime-config.js';
 import { logger } from '../logger.js';
 import {
-  deleteAgent as dbDeleteAgent,
+  deleteAgentWithTeamRevision as dbDeleteAgentWithTeamRevision,
   getAgentById as dbGetAgentById,
   listAgents as dbListAgents,
-  upsertAgent as dbUpsertAgent,
+  replaceAgentOrgChart as dbReplaceAgentOrgChart,
+  upsertAgentsWithTeamRevision as dbUpsertAgentsWithTeamRevision,
+  upsertAgentWithTeamRevision as dbUpsertAgentWithTeamRevision,
   isDatabaseInitialized,
 } from '../memory/db.js';
 import type { Session } from '../types/session.js';
@@ -34,6 +36,13 @@ import {
   resolveSnakeCamelAlias,
   validateAgentOrgChart,
 } from './agent-types.js';
+import {
+  type AgentTeamStructureRevision,
+  type AgentTeamStructureRevisionSummary,
+  getAgentTeamStructureRevision,
+  listAgentTeamStructureRevisions,
+  syncAgentTeamStructureRevisionState,
+} from './team-structure-revisions.js';
 
 const LEGACY_WORKSPACE_DIRS = [
   'default',
@@ -353,37 +362,65 @@ function rebuildRegistryFromDatabase(options?: { validate?: boolean }): void {
   }
 }
 
+function configuredAgentForDatabase(agent: AgentConfig): AgentConfig {
+  return {
+    id: agent.id,
+    name: agent.name,
+    displayName: agent.displayName,
+    imageAsset: agent.imageAsset,
+    model: cloneModelConfig(agent.model),
+    skills: agent.skills,
+    workspace: agent.workspace,
+    chatbotId: agent.chatbotId,
+    enableRag: agent.enableRag,
+    owner: agent.owner,
+    role: agent.role,
+    reportsTo: agent.reportsTo,
+    delegatesTo: agent.delegatesTo,
+    peers: agent.peers,
+    cv: cloneAgentCv(agent.cv),
+    escalationTarget: agent.escalationTarget,
+  };
+}
+
 function syncConfiguredAgentsToDatabase(): void {
+  const currentAgents = dbListAgents();
+  syncAgentTeamStructureRevisionState(currentAgents, {
+    route: 'agents.team.before_config_sync',
+    source: 'agent-registry',
+  });
+
   const mainAgent = configuredAgents.find(
     (entry) => entry.id === DEFAULT_AGENT_ID,
   );
+  const agentsToUpsert: AgentConfig[] = [];
+  const finalAgentsById = new Map(
+    currentAgents.map((agent) => [agent.id, agent] as const),
+  );
   if (!mainAgent) {
-    dbUpsertAgent({
+    const defaultMainAgent = {
       id: DEFAULT_AGENT_ID,
       name: 'Main Agent',
-    });
+    };
+    agentsToUpsert.push(defaultMainAgent);
+    finalAgentsById.set(DEFAULT_AGENT_ID, defaultMainAgent);
   }
 
   for (const agent of configuredAgents) {
-    dbUpsertAgent({
-      id: agent.id,
-      name: agent.name,
-      displayName: agent.displayName,
-      imageAsset: agent.imageAsset,
-      model: cloneModelConfig(agent.model),
-      skills: agent.skills,
-      workspace: agent.workspace,
-      chatbotId: agent.chatbotId,
-      enableRag: agent.enableRag,
-      owner: agent.owner,
-      role: agent.role,
-      reportsTo: agent.reportsTo,
-      delegatesTo: agent.delegatesTo,
-      peers: agent.peers,
-      cv: cloneAgentCv(agent.cv),
-      escalationTarget: agent.escalationTarget,
-    });
+    const nextAgent = configuredAgentForDatabase(agent);
+    agentsToUpsert.push(nextAgent);
+    finalAgentsById.set(nextAgent.id, nextAgent);
   }
+  const finalAgents = Array.from(finalAgentsById.values());
+  validateAgentOrgChart(finalAgents);
+  dbUpsertAgentsWithTeamRevision({
+    agents: agentsToUpsert,
+    finalAgents,
+    meta: {
+      route: 'agents.team.config_sync',
+      source: 'agent-registry',
+    },
+  });
 }
 
 function safeWorkspaceName(rawName: string): string {
@@ -571,6 +608,17 @@ function collectAgentDeletionBlockers(agentId: string): string[] {
   return blockers.sort();
 }
 
+function currentTeamStructureAgents(): AgentConfig[] {
+  return Array.from(registry.values()).map((agent) => applyDefaults(agent));
+}
+
+function syncCurrentTeamStructureRevisionState(route: string): void {
+  syncAgentTeamStructureRevisionState(currentTeamStructureAgents(), {
+    route,
+    source: 'agent-registry',
+  });
+}
+
 export function upsertRegisteredAgent(agent: AgentConfig): AgentConfig {
   if (!isDatabaseInitialized()) {
     throw new Error('Database is not initialized.');
@@ -589,7 +637,15 @@ export function upsertRegisteredAgent(agent: AgentConfig): AgentConfig {
     });
   }
   validateAgentOrgChart(Array.from(nextAgentsById.values()));
-  dbUpsertAgent(normalized);
+  syncCurrentTeamStructureRevisionState('agents.team.before_upsert');
+  dbUpsertAgentWithTeamRevision({
+    agent: normalized,
+    finalAgents: Array.from(nextAgentsById.values()),
+    meta: {
+      route: `agents.team.upsert#${normalized.id}`,
+      source: 'agent-registry',
+    },
+  });
   rebuildRegistryFromDatabase({ validate: false });
   registryInitialized = true;
   registryDbBacked = true;
@@ -610,11 +666,62 @@ export function deleteRegisteredAgent(agentId: string): boolean {
       `Cannot delete agent "${normalizedId}" because it is still referenced by: ${blockers.join(', ')}.`,
     );
   }
-  const deleted = dbDeleteAgent(normalizedId);
+  const finalAgents = Array.from(registry.values()).filter(
+    (agent) => agent.id !== normalizedId,
+  );
+  syncCurrentTeamStructureRevisionState('agents.team.before_delete');
+  const deleted = dbDeleteAgentWithTeamRevision({
+    agentId: normalizedId,
+    finalAgents,
+    meta: {
+      route: `agents.team.delete#${normalizedId}`,
+      source: 'agent-registry',
+    },
+  });
   rebuildRegistryFromDatabase();
   registryInitialized = true;
   registryDbBacked = true;
   return deleted;
+}
+
+export function listRegisteredAgentTeamStructureRevisions(): AgentTeamStructureRevisionSummary[] {
+  ensureRegistryCurrent();
+  return listAgentTeamStructureRevisions(currentTeamStructureAgents());
+}
+
+export function getRegisteredAgentTeamStructureRevision(
+  revisionId: number,
+): AgentTeamStructureRevision {
+  ensureRegistryCurrent();
+  return getAgentTeamStructureRevision(
+    revisionId,
+    currentTeamStructureAgents(),
+  );
+}
+
+export function restoreRegisteredAgentTeamStructureRevision(
+  revisionId: number,
+): AgentTeamStructureRevision {
+  if (!isDatabaseInitialized()) {
+    throw new Error('Database is not initialized.');
+  }
+  ensureRegistryCurrent();
+  const revision = getAgentTeamStructureRevision(
+    revisionId,
+    currentTeamStructureAgents(),
+  );
+  syncCurrentTeamStructureRevisionState('agents.team.before_restore');
+  dbReplaceAgentOrgChart(revision.snapshot.agents, {
+    route: `agents.team.restore#${revisionId}`,
+    source: 'agent-registry',
+  });
+  rebuildRegistryFromDatabase();
+  registryInitialized = true;
+  registryDbBacked = true;
+  return getAgentTeamStructureRevision(
+    revisionId,
+    currentTeamStructureAgents(),
+  );
 }
 
 export function migrateWorkspaceDirs(): void {

--- a/src/agents/agent-registry.ts
+++ b/src/agents/agent-registry.ts
@@ -41,7 +41,6 @@ import {
   type AgentTeamStructureRevisionSummary,
   getAgentTeamStructureRevision,
   listAgentTeamStructureRevisions,
-  syncAgentTeamStructureRevisionState,
 } from './team-structure-revisions.js';
 
 const LEGACY_WORKSPACE_DIRS = [
@@ -385,11 +384,6 @@ function configuredAgentForDatabase(agent: AgentConfig): AgentConfig {
 
 function syncConfiguredAgentsToDatabase(): void {
   const currentAgents = dbListAgents();
-  syncAgentTeamStructureRevisionState(currentAgents, {
-    route: 'agents.team.before_config_sync',
-    source: 'agent-registry',
-  });
-
   const mainAgent = configuredAgents.find(
     (entry) => entry.id === DEFAULT_AGENT_ID,
   );
@@ -612,13 +606,6 @@ function currentTeamStructureAgents(): AgentConfig[] {
   return Array.from(registry.values()).map((agent) => applyDefaults(agent));
 }
 
-function syncCurrentTeamStructureRevisionState(route: string): void {
-  syncAgentTeamStructureRevisionState(currentTeamStructureAgents(), {
-    route,
-    source: 'agent-registry',
-  });
-}
-
 export function upsertRegisteredAgent(agent: AgentConfig): AgentConfig {
   if (!isDatabaseInitialized()) {
     throw new Error('Database is not initialized.');
@@ -637,7 +624,6 @@ export function upsertRegisteredAgent(agent: AgentConfig): AgentConfig {
     });
   }
   validateAgentOrgChart(Array.from(nextAgentsById.values()));
-  syncCurrentTeamStructureRevisionState('agents.team.before_upsert');
   dbUpsertAgentWithTeamRevision({
     agent: normalized,
     finalAgents: Array.from(nextAgentsById.values()),
@@ -669,7 +655,6 @@ export function deleteRegisteredAgent(agentId: string): boolean {
   const finalAgents = Array.from(registry.values()).filter(
     (agent) => agent.id !== normalizedId,
   );
-  syncCurrentTeamStructureRevisionState('agents.team.before_delete');
   const deleted = dbDeleteAgentWithTeamRevision({
     agentId: normalizedId,
     finalAgents,
@@ -710,7 +695,6 @@ export function restoreRegisteredAgentTeamStructureRevision(
     revisionId,
     currentTeamStructureAgents(),
   );
-  syncCurrentTeamStructureRevisionState('agents.team.before_restore');
   dbReplaceAgentOrgChart(revision.snapshot.agents, {
     route: `agents.team.restore#${revisionId}`,
     source: 'agent-registry',

--- a/src/agents/team-structure-revisions.ts
+++ b/src/agents/team-structure-revisions.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto';
 import path from 'node:path';
 
 import {
@@ -10,6 +9,7 @@ import {
   syncRuntimeAssetRevisionState,
 } from '../config/runtime-config-revisions.js';
 import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+import { md5Hex } from '../utils/hash.js';
 import type { AgentConfig } from './agent-types.js';
 import {
   type AgentTeamStructureDiff,
@@ -31,16 +31,14 @@ export interface AgentTeamStructureRevision
   snapshot: AgentTeamStructureSnapshot;
 }
 
+const AGENT_TEAM_STRUCTURE_ASSET_PATH = path.join(
+  DEFAULT_RUNTIME_HOME_DIR,
+  'agents',
+  'team-structure.json',
+);
+
 export function agentTeamStructureAssetPath(): string {
-  return path.join(DEFAULT_RUNTIME_HOME_DIR, 'agents', 'team-structure.json');
-}
-
-function md5(content: string): string {
-  return createHash('md5').update(content).digest('hex');
-}
-
-function currentTeamStructureContent(agents: AgentConfig[]): string {
-  return serializeAgentTeamStructure(agents);
+  return AGENT_TEAM_STRUCTURE_ASSET_PATH;
 }
 
 function revisionNextContent(params: {
@@ -50,7 +48,7 @@ function revisionNextContent(params: {
 }): string | null {
   if (!params.revision.replacedByMd5) return null;
   // Runtime revisions link forward by storing the MD5 of the content that replaced this revision.
-  if (md5(params.currentContent) === params.revision.replacedByMd5) {
+  if (md5Hex(params.currentContent) === params.revision.replacedByMd5) {
     return params.currentContent;
   }
   const nextRevision = params.revisions.find(
@@ -59,7 +57,7 @@ function revisionNextContent(params: {
   if (!nextRevision) return null;
   const record = getRuntimeAssetRevision(
     'team',
-    agentTeamStructureAssetPath(),
+    AGENT_TEAM_STRUCTURE_ASSET_PATH,
     nextRevision.id,
   );
   return record?.content ?? null;
@@ -72,7 +70,7 @@ function summarizeRevision(params: {
 }): AgentTeamStructureRevisionSummary {
   const record = getRuntimeAssetRevision(
     'team',
-    agentTeamStructureAssetPath(),
+    AGENT_TEAM_STRUCTURE_ASSET_PATH,
     params.revision.id,
   );
   if (!record) {
@@ -97,10 +95,10 @@ export function syncAgentTeamStructureRevisionState(
   agents: AgentConfig[],
   meta?: RuntimeConfigChangeMeta,
 ): { changed: boolean; previousMd5: string | null; currentMd5: string | null } {
-  const content = currentTeamStructureContent(agents);
+  const content = serializeAgentTeamStructure(agents);
   return syncRuntimeAssetRevisionState(
     'team',
-    agentTeamStructureAssetPath(),
+    AGENT_TEAM_STRUCTURE_ASSET_PATH,
     meta,
     {
       exists: true,
@@ -114,11 +112,11 @@ export function listAgentTeamStructureRevisions(
 ): AgentTeamStructureRevisionSummary[] {
   const revisions = listRuntimeAssetRevisions(
     'team',
-    agentTeamStructureAssetPath(),
+    AGENT_TEAM_STRUCTURE_ASSET_PATH,
   );
   const currentContent =
-    getRuntimeAssetRevisionState('team', agentTeamStructureAssetPath())
-      ?.content ?? currentTeamStructureContent(currentAgents);
+    getRuntimeAssetRevisionState('team', AGENT_TEAM_STRUCTURE_ASSET_PATH)
+      ?.content ?? serializeAgentTeamStructure(currentAgents);
   return revisions.map((revision) =>
     summarizeRevision({ revision, revisions, currentContent }),
   );
@@ -130,7 +128,7 @@ export function getAgentTeamStructureRevision(
 ): AgentTeamStructureRevision {
   const revisions = listRuntimeAssetRevisions(
     'team',
-    agentTeamStructureAssetPath(),
+    AGENT_TEAM_STRUCTURE_ASSET_PATH,
   );
   const summary = revisions.find((revision) => revision.id === revisionId);
   if (!summary) {
@@ -138,15 +136,15 @@ export function getAgentTeamStructureRevision(
   }
   const record = getRuntimeAssetRevision(
     'team',
-    agentTeamStructureAssetPath(),
+    AGENT_TEAM_STRUCTURE_ASSET_PATH,
     revisionId,
   );
   if (!record) {
     throw new Error(`Team structure revision ${revisionId} was not found.`);
   }
   const currentContent =
-    getRuntimeAssetRevisionState('team', agentTeamStructureAssetPath())
-      ?.content ?? currentTeamStructureContent(currentAgents);
+    getRuntimeAssetRevisionState('team', AGENT_TEAM_STRUCTURE_ASSET_PATH)
+      ?.content ?? serializeAgentTeamStructure(currentAgents);
   const nextContent = revisionNextContent({
     revision: summary,
     revisions,

--- a/src/agents/team-structure-revisions.ts
+++ b/src/agents/team-structure-revisions.ts
@@ -18,7 +18,6 @@ import {
   diffAgentTeamStructureSnapshots,
   parseAgentTeamStructureSnapshot,
   serializeAgentTeamStructure,
-  serializeAgentTeamStructureSnapshot,
 } from './team-structure.js';
 
 export interface AgentTeamStructureRevisionSummary
@@ -29,10 +28,7 @@ export interface AgentTeamStructureRevisionSummary
 
 export interface AgentTeamStructureRevision
   extends AgentTeamStructureRevisionSummary {
-  content: string;
   snapshot: AgentTeamStructureSnapshot;
-  nextContent: string | null;
-  nextSnapshot: AgentTeamStructureSnapshot | null;
 }
 
 export function agentTeamStructureAssetPath(): string {
@@ -165,17 +161,9 @@ export function getAgentTeamStructureRevision(
     nextSnapshot ?? snapshot,
   );
   return {
-    ...record,
+    ...summary,
     diff,
     changeCount: agentTeamStructureDiffCount(diff),
     snapshot,
-    nextContent,
-    nextSnapshot,
   };
-}
-
-export function serializeAgentTeamStructureForRevision(
-  snapshot: AgentTeamStructureSnapshot,
-): string {
-  return serializeAgentTeamStructureSnapshot(snapshot);
 }

--- a/src/agents/team-structure-revisions.ts
+++ b/src/agents/team-structure-revisions.ts
@@ -1,0 +1,180 @@
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+
+import {
+  getRuntimeAssetRevision,
+  getRuntimeAssetRevisionState,
+  listRuntimeAssetRevisions,
+  type RuntimeConfigChangeMeta,
+  type RuntimeConfigRevisionSummary,
+  syncRuntimeAssetRevisionState,
+} from '../config/runtime-config-revisions.js';
+import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+import type { AgentConfig } from './agent-types.js';
+import {
+  type AgentTeamStructureDiff,
+  type AgentTeamStructureSnapshot,
+  agentTeamStructureDiffCount,
+  diffAgentTeamStructureSnapshots,
+  parseAgentTeamStructureSnapshot,
+  serializeAgentTeamStructure,
+  serializeAgentTeamStructureSnapshot,
+} from './team-structure.js';
+
+export interface AgentTeamStructureRevisionSummary
+  extends RuntimeConfigRevisionSummary {
+  diff: AgentTeamStructureDiff;
+  changeCount: number;
+}
+
+export interface AgentTeamStructureRevision
+  extends AgentTeamStructureRevisionSummary {
+  content: string;
+  snapshot: AgentTeamStructureSnapshot;
+  nextContent: string | null;
+  nextSnapshot: AgentTeamStructureSnapshot | null;
+}
+
+export function agentTeamStructureAssetPath(): string {
+  return path.join(DEFAULT_RUNTIME_HOME_DIR, 'agents', 'team-structure.json');
+}
+
+function md5(content: string): string {
+  return createHash('md5').update(content).digest('hex');
+}
+
+function currentTeamStructureContent(agents: AgentConfig[]): string {
+  return serializeAgentTeamStructure(agents);
+}
+
+function revisionNextContent(params: {
+  revision: RuntimeConfigRevisionSummary;
+  revisions: RuntimeConfigRevisionSummary[];
+  currentContent: string;
+}): string | null {
+  if (!params.revision.replacedByMd5) return null;
+  if (md5(params.currentContent) === params.revision.replacedByMd5) {
+    return params.currentContent;
+  }
+  const nextRevision = params.revisions.find(
+    (candidate) => candidate.md5 === params.revision.replacedByMd5,
+  );
+  if (!nextRevision) return null;
+  const record = getRuntimeAssetRevision(
+    'team',
+    agentTeamStructureAssetPath(),
+    nextRevision.id,
+  );
+  return record?.content ?? null;
+}
+
+function summarizeRevision(params: {
+  revision: RuntimeConfigRevisionSummary;
+  revisions: RuntimeConfigRevisionSummary[];
+  currentContent: string;
+}): AgentTeamStructureRevisionSummary {
+  const record = getRuntimeAssetRevision(
+    'team',
+    agentTeamStructureAssetPath(),
+    params.revision.id,
+  );
+  if (!record) {
+    throw new Error(
+      `Team structure revision ${params.revision.id} was not found.`,
+    );
+  }
+  const snapshot = parseAgentTeamStructureSnapshot(record.content);
+  const nextContent = revisionNextContent(params);
+  const nextSnapshot = nextContent
+    ? parseAgentTeamStructureSnapshot(nextContent)
+    : snapshot;
+  const diff = diffAgentTeamStructureSnapshots(snapshot, nextSnapshot);
+  return {
+    ...params.revision,
+    diff,
+    changeCount: agentTeamStructureDiffCount(diff),
+  };
+}
+
+export function syncAgentTeamStructureRevisionState(
+  agents: AgentConfig[],
+  meta?: RuntimeConfigChangeMeta,
+): { changed: boolean; previousMd5: string | null; currentMd5: string | null } {
+  const content = currentTeamStructureContent(agents);
+  return syncRuntimeAssetRevisionState(
+    'team',
+    agentTeamStructureAssetPath(),
+    meta,
+    {
+      exists: true,
+      content,
+    },
+  );
+}
+
+export function listAgentTeamStructureRevisions(
+  currentAgents: AgentConfig[],
+): AgentTeamStructureRevisionSummary[] {
+  const revisions = listRuntimeAssetRevisions(
+    'team',
+    agentTeamStructureAssetPath(),
+  );
+  const currentContent =
+    getRuntimeAssetRevisionState('team', agentTeamStructureAssetPath())
+      ?.content ?? currentTeamStructureContent(currentAgents);
+  return revisions.map((revision) =>
+    summarizeRevision({ revision, revisions, currentContent }),
+  );
+}
+
+export function getAgentTeamStructureRevision(
+  revisionId: number,
+  currentAgents: AgentConfig[],
+): AgentTeamStructureRevision {
+  const revisions = listRuntimeAssetRevisions(
+    'team',
+    agentTeamStructureAssetPath(),
+  );
+  const summary = revisions.find((revision) => revision.id === revisionId);
+  if (!summary) {
+    throw new Error(`Team structure revision ${revisionId} was not found.`);
+  }
+  const record = getRuntimeAssetRevision(
+    'team',
+    agentTeamStructureAssetPath(),
+    revisionId,
+  );
+  if (!record) {
+    throw new Error(`Team structure revision ${revisionId} was not found.`);
+  }
+  const currentContent =
+    getRuntimeAssetRevisionState('team', agentTeamStructureAssetPath())
+      ?.content ?? currentTeamStructureContent(currentAgents);
+  const nextContent = revisionNextContent({
+    revision: summary,
+    revisions,
+    currentContent,
+  });
+  const snapshot = parseAgentTeamStructureSnapshot(record.content);
+  const nextSnapshot = nextContent
+    ? parseAgentTeamStructureSnapshot(nextContent)
+    : null;
+  const diff = diffAgentTeamStructureSnapshots(
+    snapshot,
+    nextSnapshot ?? snapshot,
+  );
+  return {
+    ...record,
+    diff,
+    changeCount: agentTeamStructureDiffCount(diff),
+    snapshot,
+    nextContent,
+    nextSnapshot,
+  };
+}
+
+export function serializeAgentTeamStructureForRevision(
+  snapshot: AgentTeamStructureSnapshot,
+): string {
+  return serializeAgentTeamStructureSnapshot(snapshot);
+}

--- a/src/agents/team-structure-revisions.ts
+++ b/src/agents/team-structure-revisions.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 
 import {
+  getRuntimeAssetRevisionDetailHistory,
   listRuntimeAssetRevisionHistory,
   type RuntimeConfigChangeMeta,
   type RuntimeConfigRevision,
@@ -78,7 +79,7 @@ export function syncAgentTeamStructureRevisionState(
   agents: AgentConfig[],
   meta?: RuntimeConfigChangeMeta,
 ): { changed: boolean; previousMd5: string | null; currentMd5: string | null } {
-  const content = serializeAgentTeamStructure(agents);
+  const content = serializeAgentTeamStructure(agents, { validate: false });
   return syncRuntimeAssetRevisionState(
     'team',
     AGENT_TEAM_STRUCTURE_ASSET_PATH,
@@ -98,7 +99,8 @@ export function listAgentTeamStructureRevisions(
     AGENT_TEAM_STRUCTURE_ASSET_PATH,
   );
   const currentContent =
-    history.state?.content ?? serializeAgentTeamStructure(currentAgents);
+    history.state?.content ??
+    serializeAgentTeamStructure(currentAgents, { validate: false });
   return history.revisions.map((revision) =>
     summarizeRevision({
       revision,
@@ -112,23 +114,22 @@ export function getAgentTeamStructureRevision(
   revisionId: number,
   currentAgents: AgentConfig[],
 ): AgentTeamStructureRevision {
-  const history = listRuntimeAssetRevisionHistory(
+  const history = getRuntimeAssetRevisionDetailHistory(
     'team',
     AGENT_TEAM_STRUCTURE_ASSET_PATH,
+    revisionId,
   );
-  const revision = history.revisions.find(
-    (candidate) => candidate.id === revisionId,
-  );
+  const revision = history.revision;
   if (!revision) {
     throw new Error(`Team structure revision ${revisionId} was not found.`);
   }
   const currentContent =
-    history.state?.content ?? serializeAgentTeamStructure(currentAgents);
-  const nextContent = revisionNextContent({
-    revision,
-    revisions: history.revisions,
-    currentContent,
-  });
+    history.state?.content ??
+    serializeAgentTeamStructure(currentAgents, { validate: false });
+  const nextContent =
+    revision.replacedByMd5 && md5Hex(currentContent) === revision.replacedByMd5
+      ? currentContent
+      : history.nextRevision?.content;
   const snapshot = parseAgentTeamStructureSnapshot(revision.content);
   const nextSnapshot = nextContent
     ? parseAgentTeamStructureSnapshot(nextContent)

--- a/src/agents/team-structure-revisions.ts
+++ b/src/agents/team-structure-revisions.ts
@@ -1,10 +1,9 @@
 import path from 'node:path';
 
 import {
-  getRuntimeAssetRevision,
-  getRuntimeAssetRevisionState,
-  listRuntimeAssetRevisions,
+  listRuntimeAssetRevisionHistory,
   type RuntimeConfigChangeMeta,
+  type RuntimeConfigRevision,
   type RuntimeConfigRevisionSummary,
   syncRuntimeAssetRevisionState,
 } from '../config/runtime-config-revisions.js';
@@ -42,8 +41,8 @@ export function agentTeamStructureAssetPath(): string {
 }
 
 function revisionNextContent(params: {
-  revision: RuntimeConfigRevisionSummary;
-  revisions: RuntimeConfigRevisionSummary[];
+  revision: RuntimeConfigRevision;
+  revisions: RuntimeConfigRevision[];
   currentContent: string;
 }): string | null {
   if (!params.revision.replacedByMd5) return null;
@@ -54,31 +53,15 @@ function revisionNextContent(params: {
   const nextRevision = params.revisions.find(
     (candidate) => candidate.md5 === params.revision.replacedByMd5,
   );
-  if (!nextRevision) return null;
-  const record = getRuntimeAssetRevision(
-    'team',
-    AGENT_TEAM_STRUCTURE_ASSET_PATH,
-    nextRevision.id,
-  );
-  return record?.content ?? null;
+  return nextRevision?.content ?? null;
 }
 
 function summarizeRevision(params: {
-  revision: RuntimeConfigRevisionSummary;
-  revisions: RuntimeConfigRevisionSummary[];
+  revision: RuntimeConfigRevision;
+  revisions: RuntimeConfigRevision[];
   currentContent: string;
 }): AgentTeamStructureRevisionSummary {
-  const record = getRuntimeAssetRevision(
-    'team',
-    AGENT_TEAM_STRUCTURE_ASSET_PATH,
-    params.revision.id,
-  );
-  if (!record) {
-    throw new Error(
-      `Team structure revision ${params.revision.id} was not found.`,
-    );
-  }
-  const snapshot = parseAgentTeamStructureSnapshot(record.content);
+  const snapshot = parseAgentTeamStructureSnapshot(params.revision.content);
   const nextContent = revisionNextContent(params);
   const nextSnapshot = nextContent
     ? parseAgentTeamStructureSnapshot(nextContent)
@@ -110,15 +93,18 @@ export function syncAgentTeamStructureRevisionState(
 export function listAgentTeamStructureRevisions(
   currentAgents: AgentConfig[],
 ): AgentTeamStructureRevisionSummary[] {
-  const revisions = listRuntimeAssetRevisions(
+  const history = listRuntimeAssetRevisionHistory(
     'team',
     AGENT_TEAM_STRUCTURE_ASSET_PATH,
   );
   const currentContent =
-    getRuntimeAssetRevisionState('team', AGENT_TEAM_STRUCTURE_ASSET_PATH)
-      ?.content ?? serializeAgentTeamStructure(currentAgents);
-  return revisions.map((revision) =>
-    summarizeRevision({ revision, revisions, currentContent }),
+    history.state?.content ?? serializeAgentTeamStructure(currentAgents);
+  return history.revisions.map((revision) =>
+    summarizeRevision({
+      revision,
+      revisions: history.revisions,
+      currentContent,
+    }),
   );
 }
 
@@ -126,31 +112,24 @@ export function getAgentTeamStructureRevision(
   revisionId: number,
   currentAgents: AgentConfig[],
 ): AgentTeamStructureRevision {
-  const revisions = listRuntimeAssetRevisions(
+  const history = listRuntimeAssetRevisionHistory(
     'team',
     AGENT_TEAM_STRUCTURE_ASSET_PATH,
   );
-  const summary = revisions.find((revision) => revision.id === revisionId);
-  if (!summary) {
-    throw new Error(`Team structure revision ${revisionId} was not found.`);
-  }
-  const record = getRuntimeAssetRevision(
-    'team',
-    AGENT_TEAM_STRUCTURE_ASSET_PATH,
-    revisionId,
+  const revision = history.revisions.find(
+    (candidate) => candidate.id === revisionId,
   );
-  if (!record) {
+  if (!revision) {
     throw new Error(`Team structure revision ${revisionId} was not found.`);
   }
   const currentContent =
-    getRuntimeAssetRevisionState('team', AGENT_TEAM_STRUCTURE_ASSET_PATH)
-      ?.content ?? serializeAgentTeamStructure(currentAgents);
+    history.state?.content ?? serializeAgentTeamStructure(currentAgents);
   const nextContent = revisionNextContent({
-    revision: summary,
-    revisions,
+    revision,
+    revisions: history.revisions,
     currentContent,
   });
-  const snapshot = parseAgentTeamStructureSnapshot(record.content);
+  const snapshot = parseAgentTeamStructureSnapshot(revision.content);
   const nextSnapshot = nextContent
     ? parseAgentTeamStructureSnapshot(nextContent)
     : null;
@@ -158,6 +137,7 @@ export function getAgentTeamStructureRevision(
     snapshot,
     nextSnapshot ?? snapshot,
   );
+  const { content: _content, ...summary } = revision;
   return {
     ...summary,
     diff,

--- a/src/agents/team-structure-revisions.ts
+++ b/src/agents/team-structure-revisions.ts
@@ -53,6 +53,7 @@ function revisionNextContent(params: {
   currentContent: string;
 }): string | null {
   if (!params.revision.replacedByMd5) return null;
+  // Runtime revisions link forward by storing the MD5 of the content that replaced this revision.
   if (md5(params.currentContent) === params.revision.replacedByMd5) {
     return params.currentContent;
   }

--- a/src/agents/team-structure.ts
+++ b/src/agents/team-structure.ts
@@ -1,0 +1,243 @@
+import type { AgentConfig } from './agent-types.js';
+import { validateAgentOrgChart } from './agent-types.js';
+
+export const AGENT_TEAM_STRUCTURE_VERSION = 1;
+
+export type AgentTeamStructureField =
+  | 'role'
+  | 'reportsTo'
+  | 'delegatesTo'
+  | 'peers';
+
+export interface AgentTeamStructureEntry {
+  id: string;
+  role?: string;
+  reportsTo?: string;
+  delegatesTo?: string[];
+  peers?: string[];
+}
+
+export interface AgentTeamStructureSnapshot {
+  version: typeof AGENT_TEAM_STRUCTURE_VERSION;
+  agents: AgentTeamStructureEntry[];
+}
+
+export interface AgentTeamStructureFieldDiff {
+  field: AgentTeamStructureField;
+  before: string | string[] | null;
+  after: string | string[] | null;
+}
+
+export interface AgentTeamStructureAgentDiff {
+  agentId: string;
+  fields: AgentTeamStructureFieldDiff[];
+}
+
+export interface AgentTeamStructureDiff {
+  added: AgentTeamStructureEntry[];
+  removed: AgentTeamStructureEntry[];
+  changed: AgentTeamStructureAgentDiff[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const entry of value) {
+    const normalizedEntry = normalizeString(entry);
+    if (!normalizedEntry || seen.has(normalizedEntry)) continue;
+    seen.add(normalizedEntry);
+    normalized.push(normalizedEntry);
+  }
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeTeamEntry(value: unknown): AgentTeamStructureEntry | null {
+  if (!isRecord(value)) return null;
+  const id = normalizeString(value.id);
+  if (!id) return null;
+  const role = normalizeString(value.role);
+  const reportsTo = normalizeString(value.reportsTo);
+  const delegatesTo = normalizeStringArray(value.delegatesTo);
+  const peers = normalizeStringArray(value.peers);
+  return {
+    id,
+    ...(role ? { role } : {}),
+    ...(reportsTo ? { reportsTo } : {}),
+    ...(delegatesTo ? { delegatesTo } : {}),
+    ...(peers ? { peers } : {}),
+  };
+}
+
+function toAgentConfig(entry: AgentTeamStructureEntry): AgentConfig {
+  return {
+    id: entry.id,
+    ...(entry.role ? { role: entry.role } : {}),
+    ...(entry.reportsTo ? { reportsTo: entry.reportsTo } : {}),
+    ...(entry.delegatesTo ? { delegatesTo: [...entry.delegatesTo] } : {}),
+    ...(entry.peers ? { peers: [...entry.peers] } : {}),
+  };
+}
+
+function snapshotEntry(agent: AgentConfig): AgentTeamStructureEntry {
+  const role = normalizeString(agent.role);
+  const reportsTo = normalizeString(agent.reportsTo);
+  const delegatesTo = normalizeStringArray(agent.delegatesTo);
+  const peers = normalizeStringArray(agent.peers);
+  return {
+    id: agent.id.trim(),
+    ...(role ? { role } : {}),
+    ...(reportsTo ? { reportsTo } : {}),
+    ...(delegatesTo ? { delegatesTo } : {}),
+    ...(peers ? { peers } : {}),
+  };
+}
+
+export function buildAgentTeamStructureSnapshot(
+  agents: AgentConfig[],
+): AgentTeamStructureSnapshot {
+  const seen = new Set<string>();
+  const entries: AgentTeamStructureEntry[] = [];
+  for (const agent of agents) {
+    const id = agent.id.trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    entries.push(snapshotEntry(agent));
+  }
+  entries.sort((left, right) => left.id.localeCompare(right.id));
+  validateAgentOrgChart(entries.map(toAgentConfig));
+  return {
+    version: AGENT_TEAM_STRUCTURE_VERSION,
+    agents: entries,
+  };
+}
+
+export function parseAgentTeamStructureSnapshot(
+  raw: string,
+): AgentTeamStructureSnapshot {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch (error) {
+    throw new Error(
+      `Team structure revision is not valid JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  if (!isRecord(parsed)) {
+    throw new Error('Team structure revision must be a JSON object.');
+  }
+  if (parsed.version !== AGENT_TEAM_STRUCTURE_VERSION) {
+    throw new Error(
+      `Team structure revision version must be ${AGENT_TEAM_STRUCTURE_VERSION}.`,
+    );
+  }
+  if (!Array.isArray(parsed.agents)) {
+    throw new Error('Team structure revision must include an agents array.');
+  }
+
+  const seen = new Set<string>();
+  const agents: AgentTeamStructureEntry[] = [];
+  for (const entry of parsed.agents) {
+    const normalized = normalizeTeamEntry(entry);
+    if (!normalized) {
+      throw new Error('Team structure revision contains an invalid agent.');
+    }
+    if (seen.has(normalized.id)) {
+      throw new Error(
+        `Team structure revision contains duplicate agent "${normalized.id}".`,
+      );
+    }
+    seen.add(normalized.id);
+    agents.push(normalized);
+  }
+  agents.sort((left, right) => left.id.localeCompare(right.id));
+  validateAgentOrgChart(agents.map(toAgentConfig));
+  return {
+    version: AGENT_TEAM_STRUCTURE_VERSION,
+    agents,
+  };
+}
+
+export function serializeAgentTeamStructureSnapshot(
+  snapshot: AgentTeamStructureSnapshot,
+): string {
+  return `${JSON.stringify(snapshot, null, 2)}\n`;
+}
+
+export function serializeAgentTeamStructure(agents: AgentConfig[]): string {
+  return serializeAgentTeamStructureSnapshot(
+    buildAgentTeamStructureSnapshot(agents),
+  );
+}
+
+function valuesEqual(
+  left: string | string[] | null,
+  right: string | string[] | null,
+): boolean {
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right)) return false;
+    return left.length === right.length && left.every((v, i) => v === right[i]);
+  }
+  return left === right;
+}
+
+function getFieldValue(
+  entry: AgentTeamStructureEntry,
+  field: AgentTeamStructureField,
+): string | string[] | null {
+  const value = entry[field];
+  if (Array.isArray(value)) return [...value];
+  return value || null;
+}
+
+export function diffAgentTeamStructureSnapshots(
+  before: AgentTeamStructureSnapshot,
+  after: AgentTeamStructureSnapshot,
+): AgentTeamStructureDiff {
+  const beforeById = new Map(before.agents.map((agent) => [agent.id, agent]));
+  const afterById = new Map(after.agents.map((agent) => [agent.id, agent]));
+  const fields: AgentTeamStructureField[] = [
+    'role',
+    'reportsTo',
+    'delegatesTo',
+    'peers',
+  ];
+  const changed: AgentTeamStructureAgentDiff[] = [];
+
+  for (const [agentId, beforeAgent] of beforeById) {
+    const afterAgent = afterById.get(agentId);
+    if (!afterAgent) continue;
+    const fieldDiffs = fields
+      .map((field) => ({
+        field,
+        before: getFieldValue(beforeAgent, field),
+        after: getFieldValue(afterAgent, field),
+      }))
+      .filter((diff) => !valuesEqual(diff.before, diff.after));
+    if (fieldDiffs.length > 0) {
+      changed.push({ agentId, fields: fieldDiffs });
+    }
+  }
+
+  return {
+    added: after.agents.filter((agent) => !beforeById.has(agent.id)),
+    removed: before.agents.filter((agent) => !afterById.has(agent.id)),
+    changed,
+  };
+}
+
+export function agentTeamStructureDiffCount(
+  diff: AgentTeamStructureDiff,
+): number {
+  return diff.added.length + diff.removed.length + diff.changed.length;
+}

--- a/src/agents/team-structure.ts
+++ b/src/agents/team-structure.ts
@@ -1,3 +1,4 @@
+import { isRecord } from '../utils/type-guards.js';
 import type { AgentConfig } from './agent-types.js';
 import { validateAgentOrgChart } from './agent-types.js';
 
@@ -37,10 +38,6 @@ export interface AgentTeamStructureDiff {
   added: AgentTeamStructureEntry[];
   removed: AgentTeamStructureEntry[];
   changed: AgentTeamStructureAgentDiff[];
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
 function normalizeString(value: unknown): string {

--- a/src/agents/team-structure.ts
+++ b/src/agents/team-structure.ts
@@ -1,3 +1,4 @@
+import { normalizeOptionalTrimmedUniqueStringArray } from '../utils/normalized-strings.js';
 import { isRecord } from '../utils/type-guards.js';
 import type { AgentConfig } from './agent-types.js';
 import { validateAgentOrgChart } from './agent-types.js';
@@ -44,27 +45,16 @@ function normalizeString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
 }
 
-function normalizeStringArray(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) return undefined;
-  const seen = new Set<string>();
-  const normalized: string[] = [];
-  for (const entry of value) {
-    const normalizedEntry = normalizeString(entry);
-    if (!normalizedEntry || seen.has(normalizedEntry)) continue;
-    seen.add(normalizedEntry);
-    normalized.push(normalizedEntry);
-  }
-  return normalized.length > 0 ? normalized : undefined;
-}
-
 function normalizeTeamEntry(value: unknown): AgentTeamStructureEntry | null {
   if (!isRecord(value)) return null;
   const id = normalizeString(value.id);
   if (!id) return null;
   const role = normalizeString(value.role);
   const reportsTo = normalizeString(value.reportsTo);
-  const delegatesTo = normalizeStringArray(value.delegatesTo);
-  const peers = normalizeStringArray(value.peers);
+  const delegatesTo = normalizeOptionalTrimmedUniqueStringArray(
+    value.delegatesTo,
+  );
+  const peers = normalizeOptionalTrimmedUniqueStringArray(value.peers);
   return {
     id,
     ...(role ? { role } : {}),
@@ -87,8 +77,10 @@ function toAgentConfig(entry: AgentTeamStructureEntry): AgentConfig {
 function snapshotEntry(agent: AgentConfig): AgentTeamStructureEntry {
   const role = normalizeString(agent.role);
   const reportsTo = normalizeString(agent.reportsTo);
-  const delegatesTo = normalizeStringArray(agent.delegatesTo);
-  const peers = normalizeStringArray(agent.peers);
+  const delegatesTo = normalizeOptionalTrimmedUniqueStringArray(
+    agent.delegatesTo,
+  );
+  const peers = normalizeOptionalTrimmedUniqueStringArray(agent.peers);
   return {
     id: agent.id.trim(),
     ...(role ? { role } : {}),

--- a/src/agents/team-structure.ts
+++ b/src/agents/team-structure.ts
@@ -41,6 +41,10 @@ export interface AgentTeamStructureDiff {
   changed: AgentTeamStructureAgentDiff[];
 }
 
+export interface AgentTeamStructureSnapshotOptions {
+  validate?: boolean;
+}
+
 function normalizeString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
 }
@@ -92,6 +96,7 @@ function snapshotEntry(agent: AgentConfig): AgentTeamStructureEntry {
 
 export function buildAgentTeamStructureSnapshot(
   agents: AgentConfig[],
+  options?: AgentTeamStructureSnapshotOptions,
 ): AgentTeamStructureSnapshot {
   const seen = new Set<string>();
   const entries: AgentTeamStructureEntry[] = [];
@@ -102,7 +107,9 @@ export function buildAgentTeamStructureSnapshot(
     entries.push(snapshotEntry(agent));
   }
   entries.sort((left, right) => left.id.localeCompare(right.id));
-  validateAgentOrgChart(entries.map(toAgentConfig));
+  if (options?.validate !== false) {
+    validateAgentOrgChart(entries.map(toAgentConfig));
+  }
   return {
     version: AGENT_TEAM_STRUCTURE_VERSION,
     agents: entries,
@@ -163,9 +170,12 @@ export function serializeAgentTeamStructureSnapshot(
   return `${JSON.stringify(snapshot, null, 2)}\n`;
 }
 
-export function serializeAgentTeamStructure(agents: AgentConfig[]): string {
+export function serializeAgentTeamStructure(
+  agents: AgentConfig[],
+  options?: AgentTeamStructureSnapshotOptions,
+): string {
   return serializeAgentTeamStructureSnapshot(
-    buildAgentTeamStructureSnapshot(agents),
+    buildAgentTeamStructureSnapshot(agents, options),
   );
 }
 

--- a/src/config/runtime-config-revisions.ts
+++ b/src/config/runtime-config-revisions.ts
@@ -54,6 +54,12 @@ export interface RuntimeConfigRevisionHistory {
   state: RuntimeConfigRevisionState | null;
 }
 
+export interface RuntimeConfigRevisionDetailHistory {
+  revision: RuntimeConfigRevision | null;
+  nextRevision: RuntimeConfigRevision | null;
+  state: RuntimeConfigRevisionState | null;
+}
+
 export interface RuntimeConfigRevisionState {
   actor: string;
   route: string;
@@ -590,6 +596,45 @@ export function listRuntimeAssetRevisionHistory(
     return {
       revisions,
       state: state ? mapRevisionStateRow(state) : null,
+    };
+  });
+}
+
+export function getRuntimeAssetRevisionDetailHistory(
+  assetType: RuntimeRevisionAssetType,
+  assetPath: string,
+  revisionId: number,
+): RuntimeConfigRevisionDetailHistory {
+  const normalizedAssetType = normalizeRevisionAssetType(assetType);
+  return withRevisionDatabase((database) => {
+    const revisionRow = database
+      .prepare<[string, string, number], ConfigRevisionRow>(
+        `SELECT id, asset_type, actor, route, source, md5, byte_length, content, created_at, replaced_by_md5
+         FROM config_revisions
+         WHERE asset_type = ? AND config_path = ? AND id = ?`,
+      )
+      .get(normalizedAssetType, assetPath, revisionId);
+    const revision = revisionRow ? mapRevisionRow(revisionRow) : null;
+    const stateRow = database
+      .prepare<[string, string], ConfigRevisionStateRow>(
+        `SELECT current_content, actor, route, source, updated_at
+         FROM config_revision_state
+         WHERE asset_type = ? AND config_path = ?`,
+      )
+      .get(normalizedAssetType, assetPath);
+    const nextRevisionRow = revision?.replacedByMd5
+      ? database
+          .prepare<[string, string, string], ConfigRevisionRow>(
+            `SELECT id, asset_type, actor, route, source, md5, byte_length, content, created_at, replaced_by_md5
+             FROM config_revisions
+             WHERE asset_type = ? AND config_path = ? AND md5 = ?`,
+          )
+          .get(normalizedAssetType, assetPath, revision.replacedByMd5)
+      : null;
+    return {
+      revision,
+      nextRevision: nextRevisionRow ? mapRevisionRow(nextRevisionRow) : null,
+      state: stateRow ? mapRevisionStateRow(stateRow) : null,
     };
   });
 }

--- a/src/config/runtime-config-revisions.ts
+++ b/src/config/runtime-config-revisions.ts
@@ -1,9 +1,9 @@
-import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 
+import { md5Hex } from '../utils/hash.js';
 import { DEFAULT_RUNTIME_HOME_DIR } from './runtime-paths.js';
 
 const CONFIG_REVISION_DB_PATH = path.join(
@@ -179,10 +179,6 @@ function normalizeChangeMeta(
     route: explicitRoute || detectedRoute || 'runtime-config.unspecified',
     source: String(meta?.source || '').trim() || 'internal',
   };
-}
-
-function computeMd5(content: string): string {
-  return createHash('md5').update(content).digest('hex');
 }
 
 function quoteSqlIdentifier(value: string): string {
@@ -466,7 +462,7 @@ export function syncRuntimeAssetRevisionStateInOpenDatabase(
   }
 
   const content = observedFile?.content ?? fs.readFileSync(assetPath, 'utf-8');
-  const md5 = observedFile?.md5 ?? computeMd5(content);
+  const md5 = observedFile?.md5 ?? md5Hex(content);
   if (!state) {
     database
       .prepare(

--- a/src/config/runtime-config-revisions.ts
+++ b/src/config/runtime-config-revisions.ts
@@ -49,6 +49,11 @@ export interface RuntimeConfigRevision extends RuntimeConfigRevisionSummary {
   content: string;
 }
 
+export interface RuntimeConfigRevisionHistory {
+  revisions: RuntimeConfigRevision[];
+  state: RuntimeConfigRevisionState | null;
+}
+
 export interface RuntimeConfigRevisionState {
   actor: string;
   route: string;
@@ -558,6 +563,35 @@ export function listRuntimeAssetRevisions(
       .all(normalizedAssetType, assetPath)
       .map((row) => mapRevisionSummaryRow(row)),
   );
+}
+
+export function listRuntimeAssetRevisionHistory(
+  assetType: RuntimeRevisionAssetType,
+  assetPath: string,
+): RuntimeConfigRevisionHistory {
+  const normalizedAssetType = normalizeRevisionAssetType(assetType);
+  return withRevisionDatabase((database) => {
+    const revisions = database
+      .prepare<[string, string], ConfigRevisionRow>(
+        `SELECT id, asset_type, actor, route, source, md5, byte_length, content, created_at, replaced_by_md5
+         FROM config_revisions
+         WHERE asset_type = ? AND config_path = ?
+         ORDER BY id DESC`,
+      )
+      .all(normalizedAssetType, assetPath)
+      .map((row) => mapRevisionRow(row));
+    const state = database
+      .prepare<[string, string], ConfigRevisionStateRow>(
+        `SELECT current_content, actor, route, source, updated_at
+         FROM config_revision_state
+         WHERE asset_type = ? AND config_path = ?`,
+      )
+      .get(normalizedAssetType, assetPath);
+    return {
+      revisions,
+      state: state ? mapRevisionStateRow(state) : null,
+    };
+  });
 }
 
 export function getRuntimeConfigRevision(

--- a/src/config/runtime-config-revisions.ts
+++ b/src/config/runtime-config-revisions.ts
@@ -21,6 +21,7 @@ export const RUNTIME_REVISION_ASSET_TYPES = [
   'cv',
   'classifier',
   'a2a',
+  'team',
 ] as const;
 
 export type RuntimeRevisionAssetType =
@@ -182,6 +183,16 @@ function normalizeChangeMeta(
 
 function computeMd5(content: string): string {
   return createHash('md5').update(content).digest('hex');
+}
+
+function quoteSqlIdentifier(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function revisionTableName(tableName: string, schemaName?: string): string {
+  return schemaName
+    ? `${quoteSqlIdentifier(schemaName)}.${quoteSqlIdentifier(tableName)}`
+    : tableName;
 }
 
 function isRuntimeRevisionAssetType(
@@ -374,131 +385,159 @@ export function syncRuntimeAssetRevisionState(
   return withRevisionDatabase((database) => {
     return database
       .transaction(() => {
-        const state = database
-          .prepare<[string, string], ConfigRevisionTrackedStateRow>(
-            `SELECT current_md5, current_content
-             FROM config_revision_state
-             WHERE asset_type = ? AND config_path = ?`,
-          )
-          .get(normalizedAssetType, assetPath);
-
-        const fileExists = observedFile?.exists ?? fs.existsSync(assetPath);
-        if (!fileExists) {
-          if (!state) {
-            return {
-              changed: false,
-              previousMd5: null,
-              currentMd5: null,
-            };
-          }
-
-          database
-            .prepare(
-              `INSERT INTO config_revisions (
-                 asset_type, config_path, actor, route, source, md5, byte_length, content, replaced_by_md5, created_at
-               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-            )
-            .run(
-              normalizedAssetType,
-              assetPath,
-              normalizedMeta.actor,
-              normalizedMeta.route,
-              normalizedMeta.source,
-              state.current_md5,
-              Buffer.byteLength(state.current_content, 'utf-8'),
-              state.current_content,
-              null,
-              timestamp,
-            );
-          database
-            .prepare(
-              `DELETE FROM config_revision_state WHERE asset_type = ? AND config_path = ?`,
-            )
-            .run(normalizedAssetType, assetPath);
-          return {
-            changed: true,
-            previousMd5: state.current_md5,
-            currentMd5: null,
-          };
-        }
-
-        const content =
-          observedFile?.content ?? fs.readFileSync(assetPath, 'utf-8');
-        const md5 = observedFile?.md5 ?? computeMd5(content);
-        if (!state) {
-          database
-            .prepare(
-              `INSERT INTO config_revision_state (
-                 asset_type, config_path, current_md5, current_content, actor, route, source, updated_at
-               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-            )
-            .run(
-              normalizedAssetType,
-              assetPath,
-              md5,
-              content,
-              normalizedMeta.actor,
-              normalizedMeta.route,
-              normalizedMeta.source,
-              timestamp,
-            );
-          return {
-            changed: false,
-            previousMd5: null,
-            currentMd5: md5,
-          };
-        }
-
-        if (state.current_md5 === md5) {
-          return {
-            changed: false,
-            previousMd5: state.current_md5,
-            currentMd5: md5,
-          };
-        }
-
-        database
-          .prepare(
-            `INSERT INTO config_revisions (
-               asset_type, config_path, actor, route, source, md5, byte_length, content, replaced_by_md5, created_at
-             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-          )
-          .run(
-            normalizedAssetType,
-            assetPath,
-            normalizedMeta.actor,
-            normalizedMeta.route,
-            normalizedMeta.source,
-            state.current_md5,
-            Buffer.byteLength(state.current_content, 'utf-8'),
-            state.current_content,
-            md5,
-            timestamp,
-          );
-        database
-          .prepare(
-            `UPDATE config_revision_state
-             SET current_md5 = ?, current_content = ?, actor = ?, route = ?, source = ?, updated_at = ?
-             WHERE asset_type = ? AND config_path = ?`,
-          )
-          .run(
-            md5,
-            content,
-            normalizedMeta.actor,
-            normalizedMeta.route,
-            normalizedMeta.source,
-            timestamp,
-            normalizedAssetType,
-            assetPath,
-          );
-        return {
-          changed: true,
-          previousMd5: state.current_md5,
-          currentMd5: md5,
-        };
+        return syncRuntimeAssetRevisionStateInOpenDatabase(
+          database,
+          normalizedAssetType,
+          assetPath,
+          normalizedMeta,
+          observedFile,
+          timestamp,
+        );
       })
       .immediate();
   });
+}
+
+export function syncRuntimeAssetRevisionStateInOpenDatabase(
+  database: Database.Database,
+  assetType: RuntimeRevisionAssetType,
+  assetPath: string,
+  meta?: RuntimeConfigChangeMeta,
+  observedFile?: RuntimeConfigObservedFile,
+  timestamp = new Date().toISOString(),
+  options?: { schemaName?: string },
+): { changed: boolean; previousMd5: string | null; currentMd5: string | null } {
+  const normalizedAssetType = normalizeRevisionAssetType(assetType);
+  const normalizedMeta = normalizeChangeMeta(meta);
+  const revisionStateTable = revisionTableName(
+    'config_revision_state',
+    options?.schemaName,
+  );
+  const revisionsTable = revisionTableName(
+    'config_revisions',
+    options?.schemaName,
+  );
+  const state = database
+    .prepare<[string, string], ConfigRevisionTrackedStateRow>(
+      `SELECT current_md5, current_content
+       FROM ${revisionStateTable}
+       WHERE asset_type = ? AND config_path = ?`,
+    )
+    .get(normalizedAssetType, assetPath);
+
+  const fileExists = observedFile?.exists ?? fs.existsSync(assetPath);
+  if (!fileExists) {
+    if (!state) {
+      return {
+        changed: false,
+        previousMd5: null,
+        currentMd5: null,
+      };
+    }
+
+    database
+      .prepare(
+        `INSERT INTO ${revisionsTable} (
+           asset_type, config_path, actor, route, source, md5, byte_length, content, replaced_by_md5, created_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        normalizedAssetType,
+        assetPath,
+        normalizedMeta.actor,
+        normalizedMeta.route,
+        normalizedMeta.source,
+        state.current_md5,
+        Buffer.byteLength(state.current_content, 'utf-8'),
+        state.current_content,
+        null,
+        timestamp,
+      );
+    database
+      .prepare(
+        `DELETE FROM ${revisionStateTable} WHERE asset_type = ? AND config_path = ?`,
+      )
+      .run(normalizedAssetType, assetPath);
+    return {
+      changed: true,
+      previousMd5: state.current_md5,
+      currentMd5: null,
+    };
+  }
+
+  const content = observedFile?.content ?? fs.readFileSync(assetPath, 'utf-8');
+  const md5 = observedFile?.md5 ?? computeMd5(content);
+  if (!state) {
+    database
+      .prepare(
+        `INSERT INTO ${revisionStateTable} (
+           asset_type, config_path, current_md5, current_content, actor, route, source, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        normalizedAssetType,
+        assetPath,
+        md5,
+        content,
+        normalizedMeta.actor,
+        normalizedMeta.route,
+        normalizedMeta.source,
+        timestamp,
+      );
+    return {
+      changed: false,
+      previousMd5: null,
+      currentMd5: md5,
+    };
+  }
+
+  if (state.current_md5 === md5) {
+    return {
+      changed: false,
+      previousMd5: state.current_md5,
+      currentMd5: md5,
+    };
+  }
+
+  database
+    .prepare(
+      `INSERT INTO ${revisionsTable} (
+         asset_type, config_path, actor, route, source, md5, byte_length, content, replaced_by_md5, created_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      normalizedAssetType,
+      assetPath,
+      normalizedMeta.actor,
+      normalizedMeta.route,
+      normalizedMeta.source,
+      state.current_md5,
+      Buffer.byteLength(state.current_content, 'utf-8'),
+      state.current_content,
+      md5,
+      timestamp,
+    );
+  database
+    .prepare(
+      `UPDATE ${revisionStateTable}
+       SET current_md5 = ?, current_content = ?, actor = ?, route = ?, source = ?, updated_at = ?
+       WHERE asset_type = ? AND config_path = ?`,
+    )
+    .run(
+      md5,
+      content,
+      normalizedMeta.actor,
+      normalizedMeta.route,
+      normalizedMeta.source,
+      timestamp,
+      normalizedAssetType,
+      assetPath,
+    );
+  return {
+    changed: true,
+    previousMd5: state.current_md5,
+    currentMd5: md5,
+  };
 }
 
 export function listRuntimeConfigRevisions(

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -6648,6 +6648,14 @@ export function restoreRuntimeClassifierRevision(
   return restoreRuntimeAssetRevision('classifier', assetPath, revisionId, meta);
 }
 
+export function restoreRuntimeTeamRevision(
+  assetPath: string,
+  revisionId: number,
+  meta?: RuntimeConfigChangeMeta,
+): string {
+  return restoreRuntimeAssetRevision('team', assetPath, revisionId, meta);
+}
+
 export function runtimeConfigRevisionPath(): string {
   return runtimeConfigRevisionStorePath();
 }

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -157,6 +157,8 @@ import {
   getGatewayAdminSessions,
   getGatewayAdminSkills,
   getGatewayAdminStatistics,
+  getGatewayAdminTeamStructure,
+  getGatewayAdminTeamStructureRevision,
   getGatewayAdminTools,
   getGatewayAgentList,
   getGatewayAgents,
@@ -171,6 +173,7 @@ import {
   removeGatewayAdminChannel,
   removeGatewayAdminMcpServer,
   restoreGatewayAdminAgentMarkdownRevision,
+  restoreGatewayAdminTeamStructureRevision,
   saveGatewayAdminAgentMarkdownFile,
   saveGatewayAdminConfig,
   saveGatewayAdminModels,
@@ -2773,6 +2776,49 @@ async function handleApiAdminAgents(
   }
 }
 
+async function handleApiAdminTeamStructure(
+  res: ServerResponse,
+  method: string,
+  url: URL,
+): Promise<void> {
+  const segments = url.pathname.split('/').filter(Boolean);
+  if (segments.length === 3) {
+    if (method === 'GET') {
+      sendJson(res, 200, getGatewayAdminTeamStructure());
+      return;
+    }
+    sendMethodNotAllowed(res);
+    return;
+  }
+
+  const revisionId =
+    segments.length >= 5 && segments[3] === 'revisions'
+      ? parsePositiveInteger(decodeApiPathSegment(segments[4] || ''))
+      : null;
+  if (!revisionId) {
+    sendJson(res, 404, { error: 'Not Found' });
+    return;
+  }
+
+  try {
+    if (segments.length === 5 && method === 'GET') {
+      sendJson(res, 200, getGatewayAdminTeamStructureRevision(revisionId));
+      return;
+    }
+    if (
+      segments.length === 6 &&
+      segments[5] === 'restore' &&
+      method === 'POST'
+    ) {
+      sendJson(res, 200, restoreGatewayAdminTeamStructureRevision(revisionId));
+      return;
+    }
+    sendMethodNotAllowed(res);
+  } catch (error) {
+    sendApiAdminAgentError(res, error);
+  }
+}
+
 function handleApiAdminSessions(res: ServerResponse): void {
   sendJson(res, 200, { sessions: getGatewayAdminSessions() });
 }
@@ -3934,6 +3980,13 @@ export function startGatewayHttpServer(): GatewayHttpServer {
           }
           if (pathname === '/api/admin/statistics' && method === 'GET') {
             handleApiAdminStatistics(res, url);
+            return;
+          }
+          if (
+            pathname === '/api/admin/team-structure' ||
+            pathname.startsWith('/api/admin/team-structure/')
+          ) {
+            await handleApiAdminTeamStructure(res, method, url);
             return;
           }
           if (

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -2455,7 +2455,8 @@ function sendApiAdminAgentError(res: ServerResponse, error: unknown): void {
   const message = error instanceof Error ? error.message : String(error);
   const isKnownNotFoundMessage =
     /^Agent ["`].+["`] was not found\.$/.test(message) ||
-    /^Revision ["`].+["`] was not found\.$/.test(message);
+    /^Revision ["`].+["`] was not found\.$/.test(message) ||
+    /^Team structure revision \d+ was not found\.$/.test(message);
   const status =
     error instanceof GatewayRequestError
       ? error.statusCode

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -4094,13 +4094,7 @@ export function getGatewayAdminTeamStructureRevision(
 ): GatewayAdminTeamStructureRevisionResponse {
   const revision = getRegisteredAgentTeamStructureRevision(revisionId);
   return {
-    revision: {
-      ...mapGatewayAdminTeamStructureRevision(revision),
-      content: revision.content,
-      snapshot: revision.snapshot,
-      nextContent: revision.nextContent,
-      nextSnapshot: revision.nextSnapshot,
-    },
+    revision: mapGatewayAdminTeamStructureRevision(revision),
   };
 }
 

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -35,15 +35,19 @@ import {
   deleteRegisteredAgent,
   findAgentConfig,
   getAgentById,
+  getRegisteredAgentTeamStructureRevision,
   getStoredAgentConfig,
   listAgents,
+  listRegisteredAgentTeamStructureRevisions,
   resolveAgentConfig,
   resolveAgentForRequest,
   resolveAgentModel,
+  restoreRegisteredAgentTeamStructureRevision,
   upsertRegisteredAgent,
 } from '../agents/agent-registry.js';
 import { type AgentConfig, DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import { safeExtractZip } from '../agents/claw-security.js';
+import { buildAgentTeamStructureSnapshot } from '../agents/team-structure.js';
 import {
   emitToolExecutionAuditEvents,
   makeAuditRunId,
@@ -421,6 +425,9 @@ import {
   type GatewayAdminStatisticsChannelRow,
   type GatewayAdminStatisticsResponse,
   type GatewayAdminStatisticsTrendDay,
+  type GatewayAdminTeamStructureResponse,
+  type GatewayAdminTeamStructureRevision,
+  type GatewayAdminTeamStructureRevisionResponse,
   type GatewayAdminToolCatalogEntry,
   type GatewayAdminToolsResponse,
   type GatewayAdminUsageSummary,
@@ -4052,6 +4059,56 @@ export function getGatewayAdminAgents(): GatewayAdminAgentsResponse {
       });
     }),
   };
+}
+
+function mapGatewayAdminTeamStructureRevision(
+  revision: ReturnType<
+    typeof listRegisteredAgentTeamStructureRevisions
+  >[number],
+): GatewayAdminTeamStructureRevision {
+  return {
+    id: revision.id,
+    createdAt: revision.createdAt,
+    actor: revision.actor,
+    route: revision.route,
+    source: revision.source,
+    md5: revision.md5,
+    sizeBytes: revision.byteLength,
+    replacedByMd5: revision.replacedByMd5,
+    changeCount: revision.changeCount,
+    diff: revision.diff,
+  };
+}
+
+export function getGatewayAdminTeamStructure(): GatewayAdminTeamStructureResponse {
+  return {
+    snapshot: buildAgentTeamStructureSnapshot(listAgents()),
+    revisions: listRegisteredAgentTeamStructureRevisions().map(
+      mapGatewayAdminTeamStructureRevision,
+    ),
+  };
+}
+
+export function getGatewayAdminTeamStructureRevision(
+  revisionId: number,
+): GatewayAdminTeamStructureRevisionResponse {
+  const revision = getRegisteredAgentTeamStructureRevision(revisionId);
+  return {
+    revision: {
+      ...mapGatewayAdminTeamStructureRevision(revision),
+      content: revision.content,
+      snapshot: revision.snapshot,
+      nextContent: revision.nextContent,
+      nextSnapshot: revision.nextSnapshot,
+    },
+  };
+}
+
+export function restoreGatewayAdminTeamStructureRevision(
+  revisionId: number,
+): GatewayAdminTeamStructureResponse {
+  restoreRegisteredAgentTeamStructureRevision(revisionId);
+  return getGatewayAdminTeamStructure();
 }
 
 export function getGatewayAdminAgentMarkdownFile(

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -1,5 +1,9 @@
 import type { BaseMessageOptions } from 'discord.js';
 import type { PromptMode, PromptPartName } from '../agent/prompt-hooks.js';
+import type {
+  AgentTeamStructureDiff,
+  AgentTeamStructureSnapshot,
+} from '../agents/team-structure.js';
 import type { SkillConfigChannelKind } from '../channels/channel.js';
 import type {
   MSTeamsReplyStyle,
@@ -877,6 +881,33 @@ export interface GatewayAdminAgent {
 
 export interface GatewayAdminAgentsResponse {
   agents: GatewayAdminAgent[];
+}
+
+export interface GatewayAdminTeamStructureRevision {
+  id: number;
+  createdAt: string;
+  actor: string;
+  route: string;
+  source: string;
+  md5: string;
+  sizeBytes: number;
+  replacedByMd5: string | null;
+  changeCount: number;
+  diff: AgentTeamStructureDiff;
+}
+
+export interface GatewayAdminTeamStructureResponse {
+  snapshot: AgentTeamStructureSnapshot;
+  revisions: GatewayAdminTeamStructureRevision[];
+}
+
+export interface GatewayAdminTeamStructureRevisionResponse {
+  revision: GatewayAdminTeamStructureRevision & {
+    content: string;
+    snapshot: AgentTeamStructureSnapshot;
+    nextContent: string | null;
+    nextSnapshot: AgentTeamStructureSnapshot | null;
+  };
 }
 
 export interface GatewayAdminAgentMarkdownFileResponse {

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -902,12 +902,7 @@ export interface GatewayAdminTeamStructureResponse {
 }
 
 export interface GatewayAdminTeamStructureRevisionResponse {
-  revision: GatewayAdminTeamStructureRevision & {
-    content: string;
-    snapshot: AgentTeamStructureSnapshot;
-    nextContent: string | null;
-    nextSnapshot: AgentTeamStructureSnapshot | null;
-  };
+  revision: GatewayAdminTeamStructureRevision;
 }
 
 export interface GatewayAdminAgentMarkdownFileResponse {

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -2315,7 +2315,7 @@ function syncAttachedTeamRevisionState(
     meta,
     {
       exists: true,
-      content: serializeAgentTeamStructure(agents),
+      content: serializeAgentTeamStructure(agents, { validate: false }),
     },
     new Date().toISOString(),
     {

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -11,13 +11,24 @@ import {
   DEFAULT_AGENT_ID,
   normalizeAgentCv,
   normalizeAgentEscalationTarget,
+  validateAgentOrgChart,
 } from '../agents/agent-types.js';
+import {
+  type AgentTeamStructureEntry,
+  serializeAgentTeamStructure,
+} from '../agents/team-structure.js';
+import { agentTeamStructureAssetPath } from '../agents/team-structure-revisions.js';
 import type { WireRecord } from '../audit/audit-trail.js';
 import { DB_PATH } from '../config/config.js';
 import {
   getRuntimeConfig,
   resolveDefaultAgentId,
 } from '../config/runtime-config.js';
+import {
+  type RuntimeConfigChangeMeta,
+  runtimeConfigRevisionStorePath,
+  syncRuntimeAssetRevisionStateInOpenDatabase,
+} from '../config/runtime-config-revisions.js';
 import { logger } from '../logger.js';
 import { MODEL_METADATA_USD_TO_EUR } from '../providers/model-metadata.js';
 import {
@@ -2278,6 +2289,52 @@ function serializeAgentStringArray(
   return JSON.stringify(normalizeTrimmedUniqueStringArray(values));
 }
 
+const RUNTIME_REVISION_ATTACHMENT = 'runtime_revisions';
+
+function isRuntimeRevisionDatabaseAttached(): boolean {
+  return (
+    db.prepare('PRAGMA database_list').all() as Array<{ name: string }>
+  ).some((entry) => entry.name === RUNTIME_REVISION_ATTACHMENT);
+}
+
+function withRuntimeRevisionDatabaseAttached<T>(fn: () => T): T {
+  const alreadyAttached = isRuntimeRevisionDatabaseAttached();
+  if (!alreadyAttached) {
+    const revisionDbPath = runtimeConfigRevisionStorePath();
+    fs.mkdirSync(path.dirname(revisionDbPath), { recursive: true });
+    db.prepare(`ATTACH DATABASE ? AS ${RUNTIME_REVISION_ATTACHMENT}`).run(
+      revisionDbPath,
+    );
+  }
+  try {
+    return fn();
+  } finally {
+    if (!alreadyAttached) {
+      db.exec(`DETACH DATABASE ${RUNTIME_REVISION_ATTACHMENT}`);
+    }
+  }
+}
+
+function syncAttachedTeamRevisionState(
+  agents: AgentConfig[],
+  meta: RuntimeConfigChangeMeta,
+): void {
+  syncRuntimeAssetRevisionStateInOpenDatabase(
+    db,
+    'team',
+    agentTeamStructureAssetPath(),
+    meta,
+    {
+      exists: true,
+      content: serializeAgentTeamStructure(agents),
+    },
+    new Date().toISOString(),
+    {
+      schemaName: RUNTIME_REVISION_ATTACHMENT,
+    },
+  );
+}
+
 function parseAgentStringArray(
   rawValues: string | null,
   fieldName: string,
@@ -2486,6 +2543,120 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
   return storedAgent;
 }
 
+export function upsertAgentWithTeamRevision(params: {
+  agent: AgentConfig;
+  finalAgents: AgentConfig[];
+  meta: RuntimeConfigChangeMeta;
+}): AgentConfig {
+  return withRuntimeRevisionDatabaseAttached(() => {
+    const upsert = db.transaction(() => {
+      const stored = upsertAgent(params.agent);
+      syncAttachedTeamRevisionState(params.finalAgents, params.meta);
+      return stored;
+    });
+    return upsert();
+  });
+}
+
+export function upsertAgentsWithTeamRevision(params: {
+  agents: AgentConfig[];
+  finalAgents: AgentConfig[];
+  meta: RuntimeConfigChangeMeta;
+}): AgentConfig[] {
+  return withRuntimeRevisionDatabaseAttached(() => {
+    const upsert = db.transaction(() => {
+      for (const agent of params.agents) {
+        upsertAgent(agent);
+      }
+      syncAttachedTeamRevisionState(params.finalAgents, params.meta);
+      return listAgents();
+    });
+    return upsert();
+  });
+}
+
+export function replaceAgentOrgChart(
+  entries: AgentTeamStructureEntry[],
+  revisionMeta?: RuntimeConfigChangeMeta,
+): AgentConfig[] {
+  const currentAgents = listAgents();
+  const entriesById = new Map<string, AgentTeamStructureEntry>();
+  for (const entry of entries) {
+    const id = entry.id.trim();
+    if (!id) {
+      throw new Error('Team structure agent id is required.');
+    }
+    if (entriesById.has(id)) {
+      throw new Error(
+        `Team structure revision contains duplicate agent "${id}".`,
+      );
+    }
+    entriesById.set(id, entry);
+  }
+
+  const nextAgentsById = new Map<string, AgentConfig>();
+  for (const agent of currentAgents) {
+    const entry = entriesById.get(agent.id);
+    nextAgentsById.set(agent.id, {
+      ...agent,
+      role: entry?.role,
+      reportsTo: entry?.reportsTo,
+      delegatesTo: entry?.delegatesTo ? [...entry.delegatesTo] : undefined,
+      peers: entry?.peers ? [...entry.peers] : undefined,
+    });
+  }
+  for (const entry of entries) {
+    if (nextAgentsById.has(entry.id)) continue;
+    nextAgentsById.set(entry.id, {
+      id: entry.id,
+      role: entry.role,
+      reportsTo: entry.reportsTo,
+      delegatesTo: entry.delegatesTo ? [...entry.delegatesTo] : undefined,
+      peers: entry.peers ? [...entry.peers] : undefined,
+    });
+  }
+  const nextAgents = Array.from(nextAgentsById.values());
+  validateAgentOrgChart(nextAgents);
+
+  const updateOrgChart = db.transaction(() => {
+    const statement = db.prepare(
+      `INSERT INTO agents (
+         id,
+         role,
+         reports_to,
+         delegates_to,
+         peers,
+         created_at,
+         updated_at
+       ) VALUES (?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+       ON CONFLICT(id) DO UPDATE SET
+         role = excluded.role,
+         reports_to = excluded.reports_to,
+         delegates_to = excluded.delegates_to,
+         peers = excluded.peers,
+         updated_at = datetime('now')`,
+    );
+    for (const agent of nextAgents) {
+      statement.run(
+        agent.id,
+        agent.role?.trim() || null,
+        agent.reportsTo?.trim() || null,
+        serializeAgentStringArray(agent.delegatesTo),
+        serializeAgentStringArray(agent.peers),
+      );
+    }
+    if (revisionMeta) {
+      syncAttachedTeamRevisionState(nextAgents, revisionMeta);
+    }
+  });
+  if (revisionMeta) {
+    withRuntimeRevisionDatabaseAttached(() => updateOrgChart());
+  } else {
+    updateOrgChart();
+  }
+  return listAgents();
+}
+
 export function deleteAgent(agentId: string): boolean {
   const normalizedAgentId = agentId.trim();
   if (!normalizedAgentId || normalizedAgentId === DEFAULT_AGENT_ID) {
@@ -2495,6 +2666,23 @@ export function deleteAgent(agentId: string): boolean {
     db.prepare('DELETE FROM agents WHERE id = ?').run(normalizedAgentId)
       .changes > 0
   );
+}
+
+export function deleteAgentWithTeamRevision(params: {
+  agentId: string;
+  finalAgents: AgentConfig[];
+  meta: RuntimeConfigChangeMeta;
+}): boolean {
+  return withRuntimeRevisionDatabaseAttached(() => {
+    const deleteWithRevision = db.transaction(() => {
+      const deleted = deleteAgent(params.agentId);
+      if (deleted) {
+        syncAttachedTeamRevisionState(params.finalAgents, params.meta);
+      }
+      return deleted;
+    });
+    return deleteWithRevision();
+  });
 }
 
 type MemoryKvRow = Omit<StructuredMemoryEntry, 'value'> & {

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -2610,30 +2610,27 @@ export function replaceAgentOrgChart(
       syncAttachedTeamRevisionState(currentAgents, revisionMeta);
     }
     const statement = db.prepare(
-      `INSERT INTO agents (
-         id,
-         role,
-         reports_to,
-         delegates_to,
-         peers,
-         created_at,
-         updated_at
-       ) VALUES (?, ?, ?, ?, ?, datetime('now'), datetime('now'))
-       ON CONFLICT(id) DO UPDATE SET
-         role = excluded.role,
-         reports_to = excluded.reports_to,
-         delegates_to = excluded.delegates_to,
-         peers = excluded.peers,
-         updated_at = datetime('now')`,
+      `UPDATE agents
+       SET role = ?,
+           reports_to = ?,
+           delegates_to = ?,
+           peers = ?,
+           updated_at = datetime('now')
+       WHERE id = ?`,
     );
     for (const agent of nextAgents) {
-      statement.run(
-        agent.id,
+      const result = statement.run(
         agent.role?.trim() || null,
         agent.reportsTo?.trim() || null,
         serializeAgentStringArray(agent.delegatesTo),
         serializeAgentStringArray(agent.peers),
+        agent.id,
       );
+      if (result.changes !== 1) {
+        throw new Error(
+          `Cannot restore team structure because agent "${agent.id}" does not exist.`,
+        );
+      }
     }
     if (revisionMeta) {
       syncAttachedTeamRevisionState(nextAgents, revisionMeta);

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -2580,6 +2580,7 @@ export function replaceAgentOrgChart(
   revisionMeta?: RuntimeConfigChangeMeta,
 ): AgentConfig[] {
   const currentAgents = listAgents();
+  const currentAgentIds = new Set(currentAgents.map((agent) => agent.id));
   const entriesById = new Map<string, AgentTeamStructureEntry>();
   for (const entry of entries) {
     const id = entry.id.trim();
@@ -2589,6 +2590,11 @@ export function replaceAgentOrgChart(
     if (entriesById.has(id)) {
       throw new Error(
         `Team structure revision contains duplicate agent "${id}".`,
+      );
+    }
+    if (!currentAgentIds.has(id)) {
+      throw new Error(
+        `Cannot restore team structure because agent "${id}" does not exist.`,
       );
     }
     entriesById.set(id, entry);
@@ -2603,16 +2609,6 @@ export function replaceAgentOrgChart(
       reportsTo: entry?.reportsTo,
       delegatesTo: entry?.delegatesTo ? [...entry.delegatesTo] : undefined,
       peers: entry?.peers ? [...entry.peers] : undefined,
-    });
-  }
-  for (const entry of entries) {
-    if (nextAgentsById.has(entry.id)) continue;
-    nextAgentsById.set(entry.id, {
-      id: entry.id,
-      role: entry.role,
-      reportsTo: entry.reportsTo,
-      delegatesTo: entry.delegatesTo ? [...entry.delegatesTo] : undefined,
-      peers: entry.peers ? [...entry.peers] : undefined,
     });
   }
   const nextAgents = Array.from(nextAgentsById.values());

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -2291,27 +2291,16 @@ function serializeAgentStringArray(
 
 const RUNTIME_REVISION_ATTACHMENT = 'runtime_revisions';
 
-function isRuntimeRevisionDatabaseAttached(): boolean {
-  return (
-    db.prepare('PRAGMA database_list').all() as Array<{ name: string }>
-  ).some((entry) => entry.name === RUNTIME_REVISION_ATTACHMENT);
-}
-
 function withRuntimeRevisionDatabaseAttached<T>(fn: () => T): T {
-  const alreadyAttached = isRuntimeRevisionDatabaseAttached();
-  if (!alreadyAttached) {
-    const revisionDbPath = runtimeConfigRevisionStorePath();
-    fs.mkdirSync(path.dirname(revisionDbPath), { recursive: true });
-    db.prepare(`ATTACH DATABASE ? AS ${RUNTIME_REVISION_ATTACHMENT}`).run(
-      revisionDbPath,
-    );
-  }
+  const revisionDbPath = runtimeConfigRevisionStorePath();
+  fs.mkdirSync(path.dirname(revisionDbPath), { recursive: true });
+  db.prepare(`ATTACH DATABASE ? AS ${RUNTIME_REVISION_ATTACHMENT}`).run(
+    revisionDbPath,
+  );
   try {
     return fn();
   } finally {
-    if (!alreadyAttached) {
-      db.exec(`DETACH DATABASE ${RUNTIME_REVISION_ATTACHMENT}`);
-    }
+    db.exec(`DETACH DATABASE ${RUNTIME_REVISION_ATTACHMENT}`);
   }
 }
 
@@ -2550,6 +2539,7 @@ export function upsertAgentWithTeamRevision(params: {
 }): AgentConfig {
   return withRuntimeRevisionDatabaseAttached(() => {
     const upsert = db.transaction(() => {
+      syncAttachedTeamRevisionState(listAgents(), params.meta);
       const stored = upsertAgent(params.agent);
       syncAttachedTeamRevisionState(params.finalAgents, params.meta);
       return stored;
@@ -2565,6 +2555,7 @@ export function upsertAgentsWithTeamRevision(params: {
 }): AgentConfig[] {
   return withRuntimeRevisionDatabaseAttached(() => {
     const upsert = db.transaction(() => {
+      syncAttachedTeamRevisionState(listAgents(), params.meta);
       for (const agent of params.agents) {
         upsertAgent(agent);
       }
@@ -2615,6 +2606,9 @@ export function replaceAgentOrgChart(
   validateAgentOrgChart(nextAgents);
 
   const updateOrgChart = db.transaction(() => {
+    if (revisionMeta) {
+      syncAttachedTeamRevisionState(currentAgents, revisionMeta);
+    }
     const statement = db.prepare(
       `INSERT INTO agents (
          id,
@@ -2671,6 +2665,7 @@ export function deleteAgentWithTeamRevision(params: {
 }): boolean {
   return withRuntimeRevisionDatabaseAttached(() => {
     const deleteWithRevision = db.transaction(() => {
+      syncAttachedTeamRevisionState(listAgents(), params.meta);
       const deleted = deleteAgent(params.agentId);
       if (deleted) {
         syncAttachedTeamRevisionState(params.finalAgents, params.meta);

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,0 +1,5 @@
+import { createHash } from 'node:crypto';
+
+export function md5Hex(content: string): string {
+  return createHash('md5').update(content).digest('hex');
+}

--- a/tests/agent-team-structure-revisions.test.ts
+++ b/tests/agent-team-structure-revisions.test.ts
@@ -1,0 +1,218 @@
+import Database from 'better-sqlite3';
+import { expect, test, vi } from 'vitest';
+import { setupGatewayTest } from './helpers/gateway-test-setup.js';
+
+const { setupHome } = setupGatewayTest({
+  tempHomePrefix: 'hybridclaw-team-structure-revisions-',
+});
+
+async function configureAgent(payload: Record<string, unknown>): Promise<void> {
+  const { handleAgentPackageCommand } = await import(
+    '../src/cli/agent-command.ts'
+  );
+  await handleAgentPackageCommand(['config', JSON.stringify(payload)]);
+}
+
+test('org-chart changes create F4 team revisions with visible diffs', async () => {
+  setupHome();
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  await configureAgent({
+    id: 'support',
+    role: 'Support Lead',
+    reports_to: 'main',
+  });
+  await configureAgent({
+    id: 'support',
+    role: 'Support Manager',
+    reports_to: 'main',
+  });
+
+  const { getGatewayAdminTeamStructure } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+  const team = getGatewayAdminTeamStructure();
+
+  expect(team.revisions.length).toBeGreaterThanOrEqual(2);
+  expect(team.revisions[0]).toMatchObject({
+    changeCount: 1,
+    diff: {
+      changed: [
+        {
+          agentId: 'support',
+          fields: [
+            {
+              field: 'role',
+              before: 'Support Lead',
+              after: 'Support Manager',
+            },
+          ],
+        },
+      ],
+    },
+  });
+});
+
+test('team rollback restores the previous org chart atomically', async () => {
+  setupHome();
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  await configureAgent({
+    id: 'support',
+    role: 'Support Lead',
+    reports_to: 'main',
+  });
+  await configureAgent({
+    id: 'support',
+    role: 'Support Manager',
+    reports_to: 'main',
+  });
+  await configureAgent({
+    id: 'triage',
+    role: 'Triage Specialist',
+    reports_to: 'support',
+  });
+
+  const {
+    getGatewayAdminTeamStructure,
+    restoreGatewayAdminTeamStructureRevision,
+  } = await import('../src/gateway/gateway-service.ts');
+  const { getAgentById } = await import('../src/agents/agent-registry.ts');
+  const revision = getGatewayAdminTeamStructure().revisions.find((entry) =>
+    entry.diff.changed.some((change) => change.agentId === 'support'),
+  );
+  if (!revision) {
+    throw new Error('Expected support org-chart revision.');
+  }
+
+  restoreGatewayAdminTeamStructureRevision(revision.id);
+
+  expect(getAgentById('support')).toMatchObject({
+    role: 'Support Lead',
+    reportsTo: 'main',
+  });
+  expect(getAgentById('triage')?.role).toBeUndefined();
+  expect(getAgentById('triage')?.reportsTo).toBeUndefined();
+});
+
+test('team rollback rejects missing revisions before mutating agents', async () => {
+  setupHome();
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  await configureAgent({
+    id: 'support',
+    role: 'Support Manager',
+    reports_to: 'main',
+  });
+
+  const { restoreGatewayAdminTeamStructureRevision } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+  const { getAgentById } = await import('../src/agents/agent-registry.ts');
+
+  expect(() => restoreGatewayAdminTeamStructureRevision(999)).toThrow(
+    'Team structure revision 999 was not found.',
+  );
+  expect(getAgentById('support')).toMatchObject({
+    role: 'Support Manager',
+    reportsTo: 'main',
+  });
+});
+
+test('runtime config org-chart sync creates team revisions', async () => {
+  setupHome();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { updateRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  const { listAgents } = await import('../src/agents/agent-registry.ts');
+  const { getGatewayAdminTeamStructure } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  updateRuntimeConfig((draft) => {
+    draft.agents.list = [
+      { id: 'main', name: 'Main Agent' },
+      { id: 'support', role: 'Support Lead', reportsTo: 'main' },
+    ];
+  });
+  expect(listAgents().find((agent) => agent.id === 'support')?.role).toBe(
+    'Support Lead',
+  );
+
+  updateRuntimeConfig((draft) => {
+    draft.agents.list = [
+      { id: 'main', name: 'Main Agent' },
+      { id: 'support', role: 'Support Manager', reportsTo: 'main' },
+    ];
+  });
+  expect(listAgents().find((agent) => agent.id === 'support')?.role).toBe(
+    'Support Manager',
+  );
+
+  expect(getGatewayAdminTeamStructure().revisions[0]).toMatchObject({
+    diff: {
+      changed: [
+        {
+          agentId: 'support',
+          fields: [
+            {
+              field: 'role',
+              before: 'Support Lead',
+              after: 'Support Manager',
+            },
+          ],
+        },
+      ],
+    },
+  });
+});
+
+test('atomic team rollback leaves agents unchanged when F4 sync fails', async () => {
+  setupHome();
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  await configureAgent({
+    id: 'support',
+    role: 'Support Manager',
+    reports_to: 'main',
+  });
+
+  const { replaceAgentOrgChart } = await import('../src/memory/db.ts');
+  const { getAgentById } = await import('../src/agents/agent-registry.ts');
+  const { runtimeConfigRevisionStorePath, syncRuntimeAssetRevisionState } =
+    await import('../src/config/runtime-config-revisions.ts');
+  const { agentTeamStructureAssetPath } = await import(
+    '../src/agents/team-structure-revisions.ts'
+  );
+
+  syncRuntimeAssetRevisionState('team', agentTeamStructureAssetPath(), {
+    route: 'test.seed',
+    source: 'test',
+  });
+  const revisionDb = new Database(runtimeConfigRevisionStorePath());
+  try {
+    revisionDb.exec('DROP TABLE config_revision_state');
+  } finally {
+    revisionDb.close();
+  }
+
+  expect(() =>
+    replaceAgentOrgChart(
+      [
+        { id: 'main' },
+        { id: 'support', role: 'Support Lead', reportsTo: 'main' },
+      ],
+      {
+        route: 'test.atomic_failure',
+        source: 'test',
+      },
+    ),
+  ).toThrow();
+  expect(getAgentById('support')).toMatchObject({
+    role: 'Support Manager',
+    reportsTo: 'main',
+  });
+});

--- a/tests/agent-team-structure-revisions.test.ts
+++ b/tests/agent-team-structure-revisions.test.ts
@@ -119,6 +119,41 @@ test('team rollback rejects missing revisions before mutating agents', async () 
   });
 });
 
+test('team rollback rejects deleted agents before mutating agents', async () => {
+  setupHome();
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  await configureAgent({
+    id: 'support',
+    role: 'Support Lead',
+    reports_to: 'main',
+  });
+  await configureAgent({
+    id: 'support',
+    role: 'Support Manager',
+    reports_to: 'main',
+  });
+
+  const {
+    getGatewayAdminTeamStructure,
+    restoreGatewayAdminTeamStructureRevision,
+  } = await import('../src/gateway/gateway-service.ts');
+  const { getAgentById } = await import('../src/agents/agent-registry.ts');
+  const { deleteAgent } = await import('../src/memory/db.ts');
+  const revision = getGatewayAdminTeamStructure().revisions.find((entry) =>
+    entry.diff.changed.some((change) => change.agentId === 'support'),
+  );
+  if (!revision) {
+    throw new Error('Expected support org-chart revision.');
+  }
+
+  expect(deleteAgent('support')).toBe(true);
+  expect(() => restoreGatewayAdminTeamStructureRevision(revision.id)).toThrow(
+    'Cannot restore team structure because agent "support" does not exist.',
+  );
+  expect(getAgentById('support')).toBeNull();
+});
+
 test('runtime config org-chart sync creates team revisions', async () => {
   setupHome();
 

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -1099,6 +1099,32 @@ async function importFreshHealth(options?: {
       },
     }),
   );
+  const getGatewayAdminTeamStructure = vi.fn(() => ({
+    revisions: [],
+  }));
+  const getGatewayAdminTeamStructureRevision = vi.fn((revisionId: number) => ({
+    revision: {
+      id: revisionId,
+      author: 'test',
+      updatedAt: new Date(0).toISOString(),
+      changeCount: 0,
+      diff: { added: [], removed: [], changed: [] },
+      snapshot: { version: 1, agents: [] },
+    },
+  }));
+  const restoreGatewayAdminTeamStructureRevision = vi.fn(
+    (revisionId: number) => ({
+      revision: {
+        id: revisionId,
+        author: 'test',
+        updatedAt: new Date(0).toISOString(),
+        changeCount: 0,
+        diff: { added: [], removed: [], changed: [] },
+        snapshot: { version: 1, agents: [] },
+      },
+      agents: [],
+    }),
+  );
   const getGatewayAdminSessions = vi.fn(() => []);
   const getGatewayAdminScheduler = vi.fn(() => ({
     jobs: [],
@@ -1595,6 +1621,8 @@ async function importFreshHealth(options?: {
     getGatewayAdminAudit,
     getGatewayAdminChannels,
     getGatewayAdminConfig,
+    getGatewayAdminTeamStructure,
+    getGatewayAdminTeamStructureRevision,
     applyGatewayAdminPolicyPreset,
     deleteGatewayAdminPolicyRule,
     deleteGatewayAdminEmailMessage,
@@ -1623,6 +1651,7 @@ async function importFreshHealth(options?: {
     removeGatewayAdminChannel,
     removeGatewayAdminMcpServer,
     restoreGatewayAdminAgentMarkdownRevision,
+    restoreGatewayAdminTeamStructureRevision,
     saveGatewayAdminConfig,
     saveGatewayAdminAgentMarkdownFile,
     saveGatewayAdminPolicyDefault,
@@ -1724,6 +1753,8 @@ async function importFreshHealth(options?: {
     getGatewayAdminAgents,
     getGatewayAdminAgentMarkdownFile,
     getGatewayAdminAgentMarkdownRevision,
+    getGatewayAdminTeamStructure,
+    getGatewayAdminTeamStructureRevision,
     getGatewayAdminApprovals,
     saveGatewayAdminPolicyDefault,
     applyGatewayAdminPolicyPreset,
@@ -1751,6 +1782,7 @@ async function importFreshHealth(options?: {
     createGatewayAdminAgent,
     createGatewayAdminSkill,
     restoreGatewayAdminAgentMarkdownRevision,
+    restoreGatewayAdminTeamStructureRevision,
     updateGatewayAdminAgent,
     saveGatewayAdminAgentMarkdownFile,
     deleteGatewayAdminAgent,
@@ -5021,6 +5053,25 @@ describe('gateway HTTP server', () => {
     expect(res.statusCode).toBe(404);
     expect(JSON.parse(res.body)).toEqual({
       error: 'Revision "missing-rev" was not found.',
+    });
+  });
+
+  test('returns 404 for known admin team structure revision not-found errors', async () => {
+    const state = await importFreshHealth();
+    state.getGatewayAdminTeamStructureRevision.mockImplementationOnce(() => {
+      throw new Error('Team structure revision 999 was not found.');
+    });
+    const req = makeRequest({
+      url: '/api/admin/team-structure/revisions/999',
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Team structure revision 999 was not found.',
     });
   });
 

--- a/tests/runtime-config-revisions.integration.test.ts
+++ b/tests/runtime-config-revisions.integration.test.ts
@@ -367,12 +367,14 @@ describe('runtime config revisions integration', () => {
     ['knowledge', 'knowledge/sales/index.md'],
     ['cv', 'agents/charly/CV.md'],
     ['classifier', 'classifiers/nda/weights.json'],
+    ['team', 'agents/team-structure.json'],
   ] as const)('restores %s runtime asset revisions', (assetType, relativePath) => {
     const restoreRevision = {
       skill: configMod.restoreRuntimeSkillRevision,
       knowledge: configMod.restoreRuntimeKnowledgeRevision,
       cv: configMod.restoreRuntimeCvRevision,
       classifier: configMod.restoreRuntimeClassifierRevision,
+      team: configMod.restoreRuntimeTeamRevision,
     }[assetType];
     const assetPath = path.join(tmpDir, relativePath);
     fs.mkdirSync(path.dirname(assetPath), { recursive: true });


### PR DESCRIPTION
## Summary

Closes #595.

This implements persisted agent team/org-chart structures through the F4 runtime revision store. Team structures now serialize role, reporting, delegation, and peer relationships as deterministic `team` revision snapshots with per-revision diffs for the admin surface.

## What Changed

- Added `team` as a runtime revision asset type.
- Added team structure snapshot, parse, serialize, and diff helpers.
- Recorded team revisions for agent upsert, delete, config sync, and rollback paths.
- Made agent org-chart rollback update the agent DB and F4 revision DB in one SQLite transaction by attaching the revision DB to the agent DB transaction.
- Added admin API endpoints for team structure revision listing, detail, diff, and restore.
- Added `/admin/agents` UI for team revisions and rollback.
- Documented the admin console team revision surface.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run check`
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/agent-team-structure-revisions.test.ts`
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.integration.config.ts tests/runtime-config-revisions.integration.test.ts`
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/agent-registry.test.ts tests/agent-config-command.test.ts`
- `npm --workspace console run test -- agents.test.tsx`

## Risk Notes

Rollback is intentionally scoped to org-chart fields only: role, reportsTo, delegatesTo, and peers. It preserves non-team agent fields such as model, workspace, skills, CV, and presentation metadata.
