### PR TITLE
fix(gateway): split liveness from /health and harden Docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,9 @@ ENV HYBRIDCLAW_DATA_DIR=/workspace/.data
 # security trust model in headless mode (e.g. docker run -e HYBRIDCLAW_ACCEPT_TRUST=true).
 RUN mkdir -p /workspace/.data
 
+# Use node:http (not global fetch/undici) and an explicit per-request timeout
+# so a hung server destroys the request instead of leaking the probe process.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD node -e "fetch('http://127.0.0.1:9090/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+  CMD node -e "const r=require('http').get('http://127.0.0.1:9090/livez',{timeout:3000},x=>{x.resume();process.exit(x.statusCode===200?0:1)});r.on('error',()=>process.exit(1));r.on('timeout',()=>{r.destroy();process.exit(1)})"
 
 CMD ["node", "dist/cli.js", "gateway", "start", "--foreground"]

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -3730,17 +3730,45 @@ export function startGatewayHttpServer(): GatewayHttpServer {
     const url = new URL(req.url || '/', 'http://localhost');
     const pathname = url.pathname;
 
+    // Liveness — local-only, no awaits. Used by Docker HEALTHCHECK so a
+    // wedged event loop is detectable without depending on /health, which
+    // fans out to external services and can fail for non-fatal reasons.
+    if (
+      (pathname === '/livez' || pathname === '/healthz') &&
+      method === 'GET'
+    ) {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('ok');
+      return;
+    }
+
     if (pathname === '/health' && method === 'GET') {
-      void getGatewayStatus().then(
-        (status) => sendJson(res, 200, status),
-        (err) => {
-          logger.error({ err }, 'Health check failed');
-          sendJson(res, 503, {
-            status: 'error',
-            error: err instanceof Error ? err.message : String(err),
-          });
-        },
-      );
+      // Outer timeout so a never-settling sub-probe in getGatewayStatus()
+      // can't hold this handler (and the response socket) open indefinitely.
+      const HEALTH_TIMEOUT_MS = 8000;
+      let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+      const timeout = new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(
+          reject,
+          HEALTH_TIMEOUT_MS,
+          new Error(`health check timed out after ${HEALTH_TIMEOUT_MS}ms`),
+        );
+        timeoutHandle.unref();
+      });
+      void Promise.race([getGatewayStatus(), timeout])
+        .finally(() => {
+          if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+        })
+        .then(
+          (s) => sendJson(res, 200, s),
+          (err) => {
+            logger.error({ err }, 'Health check failed');
+            sendJson(res, 503, {
+              status: 'error',
+              error: err instanceof Error ? err.message : String(err),
+            });
+          },
+        );
       return;
     }
 


### PR DESCRIPTION
## Why

`/health` awaits `getGatewayStatus()`, which composes multiple outbound dependency probes via `Promise.allSettled`. If any probe returns a never-settling Promise, the handler hangs indefinitely and holds the response socket open.

There is a path that produces this state. `createOnDemandProbe` in `src/providers/on-demand-probe.ts`:

```ts
let inflight: Promise<T> | null = null;
async function refresh(): Promise<T> {
  try { return await probeFn(); }
  finally { inflight = null; }   // only fires once probeFn settles
}
```

If `probeFn` never settles (a known undici class where `AbortSignal.timeout` can silently fail to fire on a fetch retry under specific upstream half-close conditions), `inflight` is set permanently to a dead Promise. Every later `get()` returns the same dead Promise, and the composing `Promise.allSettled` waits forever.

This PR doesn't fix the on-demand-probe behaviour itself. It ensures the case can't strand the HTTP handler or be misread as "process dead" by the orchestrator.

## Changes

### `src/gateway/gateway-http-server.ts`

- **Add `/livez` (alias `/healthz`).** Local-only, returns `text/plain "ok"` immediately — no awaits, no outbound I/O. This is the right liveness signal for orchestrator probes: failure here genuinely means the HTTP server is wedged, independent of external dependency state. `/ready` and `/readyz` are unchanged and continue to gate startup.
- **Outer timeout on `/health`.** Wraps `getGatewayStatus()` in `Promise.race` with an 8 s budget. Even with a poisoned probe upstream, the handler returns 503 with a timeout error within budget instead of holding the response open indefinitely. Timer is cleared on success.

### `Dockerfile`

- Replace the `HEALTHCHECK` command. The previous form (`node -e "fetch('/health')..."`) had two issues: (1) global `fetch` is undici — the layer that can produce the never-settling-Promise behaviour to begin with — and (2) when the server hung, the spawned Node child held a keep-alive socket open and was killed by Docker's timeout, leaking processes over time. New form uses `require('http').get` with an explicit per-socket `timeout`, destroys the request on timeout, and exits within the 3 s probe budget. Targets `/livez` so the orchestrator's restart decision is decoupled from external dependency state.

## Behaviour after this change

- The orchestrator's healthcheck is no longer affected by the dependency-probe wedge — `/livez` answers immediately even when `/health` is hung.
- Each `/health` request returns within 8 s instead of forever, so external monitoring sees the failure cleanly.
- The Docker healthcheck no longer leaks Node processes when the gateway hangs.

## Not in this PR (tracked separately)

1. **Outer timeout in `createOnDemandProbe.refresh()` itself** — wrap `refresh()` in `Promise.race(probeFn(), timeout(N))` and always null `inflight` on the timeout branch. Eliminates the poisoning class for any caller of the helper.
2. **Background-refresh pattern for the sub-probes feeding `/health`** — a periodic refresher writes to an in-memory snapshot; `/health` reads the snapshot synchronously and returns in <1 ms, never blocking on outbound HTTP.

## Testing

- Built and ran the gateway locally; `GET /livez` → `200 ok`, `GET /healthz` → same. `/health` and `/ready` behave as before.
- Injected a 30 s sleep into one of the on-demand-probe `probeFn`s; `/health` now responds with 503 at 8 s instead of hanging until the request is cancelled.
- `npx tsc --noEmit` clean for the modified files. Two `@ngrok/ngrok` errors on `main` are pre-existing.