### PR TITLE
[codex] Decouple gateway health from provider probes

### DIFF
--- a/src/doctor/checks/providers.ts
+++ b/src/doctor/checks/providers.ts
@@ -5,6 +5,7 @@ import {
 import { getCodexAuthStatus } from '../../auth/codex-auth.js';
 import { getRuntimeConfig } from '../../config/runtime-config.js';
 import { resolveModelProvider } from '../../providers/factory.js';
+import { dedupeStrings } from '../../utils/normalized-strings.js';
 import {
   type ProviderProbeResult,
   probeAnthropic,
@@ -33,18 +34,6 @@ interface ProviderPlan {
   configuredModelCount: number;
   probe: (() => Promise<ProviderProbeResult>) | null;
   inactiveMessage?: string;
-}
-
-function dedupeStrings(values: string[]): string[] {
-  const seen = new Set<string>();
-  const deduped: string[] = [];
-  for (const rawValue of values) {
-    const value = String(rawValue || '').trim();
-    if (!value || seen.has(value)) continue;
-    seen.add(value);
-    deduped.push(value);
-  }
-  return deduped;
 }
 
 async function readDiscoveredModelNamesSafely(): Promise<{

--- a/src/gateway/gateway-agent-cards.ts
+++ b/src/gateway/gateway-agent-cards.ts
@@ -21,6 +21,7 @@ import {
 } from '../session/session-preview.js';
 import type { StructuredAuditEntry } from '../types/audit.js';
 import type { Session, StoredMessage } from '../types/session.js';
+import { dedupeStrings } from '../utils/normalized-strings.js';
 import { isFullAutoEnabled } from './fullauto-runtime.js';
 import { formatRelativeTimeFromMs, parseTimestamp } from './gateway-time.js';
 import type {
@@ -396,18 +397,6 @@ function getLogicalAgentStatus(
   if (sessions.some((session) => session.status === 'active')) return 'active';
   if (sessions.some((session) => session.status === 'idle')) return 'idle';
   return 'stopped';
-}
-
-function dedupeStrings(values: string[]): string[] {
-  const seen = new Set<string>();
-  const deduped: string[] = [];
-  for (const rawValue of values) {
-    const value = String(rawValue || '').trim();
-    if (!value || seen.has(value)) continue;
-    seen.add(value);
-    deduped.push(value);
-  }
-  return deduped;
 }
 
 export function mapLogicalAgentCard(params: {

--- a/src/gateway/gateway-health-service.ts
+++ b/src/gateway/gateway-health-service.ts
@@ -1,0 +1,116 @@
+import { getHybridAIAuthStatus } from '../auth/hybridai-auth.js';
+import { getDiscoveredHybridAIModelNames } from '../providers/hybridai-discovery.js';
+import {
+  type HybridAIHealthResult,
+  hybridAIProbe,
+} from '../providers/hybridai-health.js';
+import { localBackendsProbe } from '../providers/local-health.js';
+import type {
+  HealthCheckResult,
+  LocalBackendType,
+} from '../providers/local-types.js';
+import type { GatewayProviderHealthEntry } from './gateway-types.js';
+
+const GATEWAY_STATUS_PROVIDER_PROBE_TIMEOUT_MS = 750;
+
+export interface GatewayHealthOptions {
+  refreshProviderHealth?: boolean;
+  providerProbeTimeoutMs?: number;
+}
+
+function providerProbeTimeoutMs(options: GatewayHealthOptions): number {
+  const value = options.providerProbeTimeoutMs;
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : GATEWAY_STATUS_PROVIDER_PROBE_TIMEOUT_MS;
+}
+
+function dedupeStrings(values: string[]): string[] {
+  return [...new Set(values.filter((value) => value.trim().length > 0))];
+}
+
+async function withProbeDeadline<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  fallback: () => T,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<T>((resolve) => {
+    timeout = setTimeout(() => resolve(fallback()), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function fallbackLocalBackendsHealth(): Map<
+  LocalBackendType,
+  HealthCheckResult
+> {
+  return localBackendsProbe.peek() ?? new Map();
+}
+
+function fallbackHybridAIHealth(): HybridAIHealthResult {
+  const cached = hybridAIProbe.peek();
+  if (cached) return cached;
+  return {
+    reachable: false,
+    error: getHybridAIAuthStatus().authenticated
+      ? 'probe pending'
+      : 'API key missing',
+    latencyMs: 0,
+  };
+}
+
+export function resolveGatewayLocalBackendsHealth(
+  options: GatewayHealthOptions = {},
+): Promise<Map<LocalBackendType, HealthCheckResult>> {
+  if (options.refreshProviderHealth === false) {
+    return Promise.resolve(fallbackLocalBackendsHealth());
+  }
+  return withProbeDeadline(
+    localBackendsProbe.get(),
+    providerProbeTimeoutMs(options),
+    fallbackLocalBackendsHealth,
+  );
+}
+
+export function resolveGatewayHybridAIHealth(
+  options: GatewayHealthOptions = {},
+): Promise<HybridAIHealthResult> {
+  if (options.refreshProviderHealth === false) {
+    return Promise.resolve(fallbackHybridAIHealth());
+  }
+  return withProbeDeadline(
+    hybridAIProbe.get(),
+    providerProbeTimeoutMs(options),
+    fallbackHybridAIHealth,
+  );
+}
+
+export function invalidateGatewayProviderHealth(): void {
+  localBackendsProbe.invalidate();
+  hybridAIProbe.invalidate();
+}
+
+export function buildGatewayHybridAIProviderEntry(
+  probe: HybridAIHealthResult,
+): GatewayProviderHealthEntry {
+  const discoveredModelCount = dedupeStrings(
+    getDiscoveredHybridAIModelNames(),
+  ).length;
+
+  return {
+    kind: 'remote',
+    reachable: probe.reachable,
+    ...(probe.error ? { error: probe.error } : {}),
+    latencyMs: probe.latencyMs,
+    modelCount: probe.modelCount ?? discoveredModelCount,
+    detail: probe.reachable
+      ? `${probe.latencyMs}ms`
+      : probe.error || 'unreachable',
+  };
+}

--- a/src/gateway/gateway-health-service.ts
+++ b/src/gateway/gateway-health-service.ts
@@ -1,4 +1,3 @@
-import { getHybridAIAuthStatus } from '../auth/hybridai-auth.js';
 import { getDiscoveredHybridAIModelNames } from '../providers/hybridai-discovery.js';
 import {
   type HybridAIHealthResult,
@@ -48,9 +47,7 @@ function fallbackHybridAIHealth(): HybridAIHealthResult {
   if (cached) return cached;
   return {
     reachable: false,
-    error: getHybridAIAuthStatus().authenticated
-      ? 'probe pending'
-      : 'API key missing',
+    error: 'unavailable',
     latencyMs: 0,
   };
 }

--- a/src/gateway/gateway-health-service.ts
+++ b/src/gateway/gateway-health-service.ts
@@ -1,0 +1,114 @@
+import { getHybridAIAuthStatus } from '../auth/hybridai-auth.js';
+import { getDiscoveredHybridAIModelNames } from '../providers/hybridai-discovery.js';
+import {
+  type HybridAIHealthResult,
+  hybridAIProbe,
+} from '../providers/hybridai-health.js';
+import { localBackendsProbe } from '../providers/local-health.js';
+import type {
+  HealthCheckResult,
+  LocalBackendType,
+} from '../providers/local-types.js';
+import type { GatewayProviderHealthEntry } from './gateway-types.js';
+
+const GATEWAY_STATUS_PROVIDER_PROBE_TIMEOUT_MS = 750;
+
+export interface GatewayHealthOptions {
+  refreshProviderHealth?: boolean;
+  providerProbeTimeoutMs?: number;
+}
+
+function providerProbeTimeoutMs(options: GatewayHealthOptions): number {
+  const timeoutMs = options.providerProbeTimeoutMs ?? 0;
+  return timeoutMs > 0 ? timeoutMs : GATEWAY_STATUS_PROVIDER_PROBE_TIMEOUT_MS;
+}
+
+function dedupeStrings(values: string[]): string[] {
+  return [...new Set(values.filter((value) => value.trim().length > 0))];
+}
+
+async function withProbeDeadline<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  fallback: () => T,
+): Promise<T> {
+  let timeout!: ReturnType<typeof setTimeout>;
+  const timeoutPromise = new Promise<T>((resolve) => {
+    timeout = setTimeout(() => resolve(fallback()), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function fallbackLocalBackendsHealth(): Map<
+  LocalBackendType,
+  HealthCheckResult
+> {
+  return localBackendsProbe.peek() ?? new Map();
+}
+
+function fallbackHybridAIHealth(): HybridAIHealthResult {
+  const cached = hybridAIProbe.peek();
+  if (cached) return cached;
+  return {
+    reachable: false,
+    error: getHybridAIAuthStatus().authenticated
+      ? 'probe pending'
+      : 'API key missing',
+    latencyMs: 0,
+  };
+}
+
+export function resolveGatewayLocalBackendsHealth(
+  options: GatewayHealthOptions = {},
+): Promise<Map<LocalBackendType, HealthCheckResult>> {
+  if (options.refreshProviderHealth === false) {
+    return Promise.resolve(fallbackLocalBackendsHealth());
+  }
+  return withProbeDeadline(
+    localBackendsProbe.get(),
+    providerProbeTimeoutMs(options),
+    fallbackLocalBackendsHealth,
+  );
+}
+
+export function resolveGatewayHybridAIHealth(
+  options: GatewayHealthOptions = {},
+): Promise<HybridAIHealthResult> {
+  if (options.refreshProviderHealth === false) {
+    return Promise.resolve(fallbackHybridAIHealth());
+  }
+  return withProbeDeadline(
+    hybridAIProbe.get(),
+    providerProbeTimeoutMs(options),
+    fallbackHybridAIHealth,
+  );
+}
+
+export function invalidateGatewayProviderHealth(): void {
+  localBackendsProbe.invalidate();
+  hybridAIProbe.invalidate();
+}
+
+export function buildGatewayHybridAIProviderEntry(
+  probe: HybridAIHealthResult,
+): GatewayProviderHealthEntry {
+  const discoveredModelCount = dedupeStrings(
+    getDiscoveredHybridAIModelNames(),
+  ).length;
+
+  return {
+    kind: 'remote',
+    reachable: probe.reachable,
+    ...(probe.error ? { error: probe.error } : {}),
+    latencyMs: probe.latencyMs,
+    modelCount: probe.modelCount ?? discoveredModelCount,
+    detail: probe.reachable
+      ? `${probe.latencyMs}ms`
+      : probe.error || 'unreachable',
+  };
+}

--- a/src/gateway/gateway-health-service.ts
+++ b/src/gateway/gateway-health-service.ts
@@ -15,12 +15,6 @@ const GATEWAY_STATUS_PROVIDER_PROBE_TIMEOUT_MS = 750;
 
 export interface GatewayHealthOptions {
   refreshProviderHealth?: boolean;
-  providerProbeTimeoutMs?: number;
-}
-
-function providerProbeTimeoutMs(options: GatewayHealthOptions): number {
-  const timeoutMs = options.providerProbeTimeoutMs ?? 0;
-  return timeoutMs > 0 ? timeoutMs : GATEWAY_STATUS_PROVIDER_PROBE_TIMEOUT_MS;
 }
 
 function dedupeStrings(values: string[]): string[] {
@@ -71,7 +65,7 @@ export function resolveGatewayLocalBackendsHealth(
   }
   return withProbeDeadline(
     localBackendsProbe.get(),
-    providerProbeTimeoutMs(options),
+    GATEWAY_STATUS_PROVIDER_PROBE_TIMEOUT_MS,
     fallbackLocalBackendsHealth,
   );
 }
@@ -84,7 +78,7 @@ export function resolveGatewayHybridAIHealth(
   }
   return withProbeDeadline(
     hybridAIProbe.get(),
-    providerProbeTimeoutMs(options),
+    GATEWAY_STATUS_PROVIDER_PROBE_TIMEOUT_MS,
     fallbackHybridAIHealth,
   );
 }

--- a/src/gateway/gateway-health-service.ts
+++ b/src/gateway/gateway-health-service.ts
@@ -9,16 +9,13 @@ import type {
   HealthCheckResult,
   LocalBackendType,
 } from '../providers/local-types.js';
+import { dedupeStrings } from '../utils/normalized-strings.js';
 import type { GatewayProviderHealthEntry } from './gateway-types.js';
 
 const GATEWAY_STATUS_PROVIDER_PROBE_TIMEOUT_MS = 750;
 
 export interface GatewayHealthOptions {
   refreshProviderHealth?: boolean;
-}
-
-function dedupeStrings(values: string[]): string[] {
-  return [...new Set(values.filter((value) => value.trim().length > 0))];
 }
 
 async function withProbeDeadline<T>(

--- a/src/gateway/gateway-health-service.ts
+++ b/src/gateway/gateway-health-service.ts
@@ -27,9 +27,10 @@ async function withProbeDeadline<T>(
   const timeoutPromise = new Promise<T>((resolve) => {
     timeout = setTimeout(() => resolve(fallback()), timeoutMs);
   });
+  const probePromise = promise.catch(() => fallback());
 
   try {
-    return await Promise.race([promise, timeoutPromise]);
+    return await Promise.race([probePromise, timeoutPromise]);
   } finally {
     clearTimeout(timeout);
   }

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -3731,7 +3731,7 @@ export function startGatewayHttpServer(): GatewayHttpServer {
     const pathname = url.pathname;
 
     if (pathname === '/health' && method === 'GET') {
-      void getGatewayStatus().then(
+      void getGatewayStatus({ refreshProviderHealth: false }).then(
         (status) => sendJson(res, 200, status),
         (err) => {
           logger.error({ err }, 'Health check failed');

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -225,13 +225,7 @@ import {
   fetchHybridAIBots,
   HybridAIBotFetchError,
 } from '../providers/hybridai-bots.js';
-import { getDiscoveredHybridAIModelNames } from '../providers/hybridai-discovery.js';
-import {
-  type HybridAIHealthResult,
-  hybridAIProbe,
-} from '../providers/hybridai-health.js';
 import { getLocalModelInfo } from '../providers/local-discovery.js';
-import { localBackendsProbe } from '../providers/local-health.js';
 import {
   discoverMistralModels,
   getDiscoveredMistralModelNames,
@@ -364,6 +358,13 @@ import {
   formatCompactNumber,
   formatRalphIterations,
 } from './gateway-formatting.js';
+import {
+  buildGatewayHybridAIProviderEntry,
+  type GatewayHealthOptions,
+  invalidateGatewayProviderHealth,
+  resolveGatewayHybridAIHealth,
+  resolveGatewayLocalBackendsHealth,
+} from './gateway-health-service.js';
 import { GATEWAY_LOG_REQUESTS_ENV } from './gateway-lifecycle.js';
 import { tryEnsurePluginManagerInitializedForGateway } from './gateway-plugin-runtime.js';
 import {
@@ -1592,29 +1593,12 @@ function getAdminChannelDisabledSkills(
   );
 }
 
-function buildHybridAIProviderEntry(
-  probe: HybridAIHealthResult,
-): GatewayProviderHealthEntry {
-  const discoveredModelCount = dedupeStrings(
-    getDiscoveredHybridAIModelNames(),
-  ).length;
-
-  return {
-    kind: 'remote',
-    reachable: probe.reachable,
-    ...(probe.error ? { error: probe.error } : {}),
-    latencyMs: probe.latencyMs,
-    modelCount: probe.modelCount ?? discoveredModelCount,
-    detail: probe.reachable
-      ? `${probe.latencyMs}ms`
-      : probe.error || 'unreachable',
-  };
-}
+export type GatewayStatusOptions = GatewayHealthOptions;
 
 function buildGatewayProviderHealth(params: {
   localBackends: GatewayStatus['localBackends'];
   codex: ReturnType<typeof getCodexAuthStatus>;
-  hybridaiHealth: HybridAIHealthResult;
+  hybridaiHealth: GatewayProviderHealthEntry;
 }): NonNullable<GatewayStatus['providerHealth']> {
   const runtimeConfig = getRuntimeConfig();
   const anthropicStatus = getAnthropicAuthStatus();
@@ -1623,7 +1607,7 @@ function buildGatewayProviderHealth(params: {
     runtimeConfig.anthropic.method,
   );
   const providerHealth: NonNullable<GatewayStatus['providerHealth']> = {
-    hybridai: buildHybridAIProviderEntry(params.hybridaiHealth),
+    hybridai: params.hybridaiHealth,
     codex: {
       kind: 'remote',
       reachable: params.codex.authenticated && !params.codex.reloginRequired,
@@ -1719,8 +1703,7 @@ async function getGatewayStatusForModelSubcommand(
   if (subcommand === 'list' || subcommand === 'info') {
     // These commands are expected to reflect the current live provider state,
     // not a recently cached health snapshot.
-    localBackendsProbe.invalidate();
-    hybridAIProbe.invalidate();
+    invalidateGatewayProviderHealth();
   }
   return await getGatewayStatus();
 }
@@ -3703,15 +3686,18 @@ export function buildTokenUsageAuditPayload(
   };
 }
 
-export async function getGatewayStatus(): Promise<GatewayStatus> {
+export async function getGatewayStatus(
+  options: GatewayStatusOptions = {},
+): Promise<GatewayStatus> {
   const codex = getCodexAuthStatus();
   const hybridai = getHybridAIAuthStatus();
+  const refreshProviderHealth = options.refreshProviderHealth ?? true;
   const [localBackendsResult, hybridaiResult, whatsappAuthResult] =
     await Promise.allSettled([
-      localBackendsProbe.get(),
-      hybridAIProbe.get(),
+      resolveGatewayLocalBackendsHealth(options),
+      resolveGatewayHybridAIHealth(options),
       getWhatsAppAuthStatus(),
-      codex.authenticated && !codex.reloginRequired
+      refreshProviderHealth && codex.authenticated && !codex.reloginRequired
         ? discoverCodexModels()
         : Promise.resolve([]),
     ]);
@@ -3721,10 +3707,15 @@ export async function getGatewayStatus(): Promise<GatewayStatus> {
     localBackendsResult.status === 'fulfilled'
       ? localBackendsResult.value
       : new Map();
-  const hybridaiHealth: HybridAIHealthResult =
+  const hybridaiHealth = buildGatewayHybridAIProviderEntry(
     hybridaiResult.status === 'fulfilled'
       ? hybridaiResult.value
-      : { reachable: false, error: 'probe failed', latencyMs: 0 };
+      : {
+          reachable: false,
+          error: 'probe failed',
+          latencyMs: 0,
+        },
+  );
   const whatsappAuth =
     whatsappAuthResult.status === 'fulfilled'
       ? whatsappAuthResult.value

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -225,13 +225,7 @@ import {
   fetchHybridAIBots,
   HybridAIBotFetchError,
 } from '../providers/hybridai-bots.js';
-import { getDiscoveredHybridAIModelNames } from '../providers/hybridai-discovery.js';
-import {
-  type HybridAIHealthResult,
-  hybridAIProbe,
-} from '../providers/hybridai-health.js';
 import { getLocalModelInfo } from '../providers/local-discovery.js';
-import { localBackendsProbe } from '../providers/local-health.js';
 import {
   discoverMistralModels,
   getDiscoveredMistralModelNames,
@@ -364,6 +358,13 @@ import {
   formatCompactNumber,
   formatRalphIterations,
 } from './gateway-formatting.js';
+import {
+  buildGatewayHybridAIProviderEntry,
+  type GatewayHealthOptions,
+  invalidateGatewayProviderHealth,
+  resolveGatewayHybridAIHealth,
+  resolveGatewayLocalBackendsHealth,
+} from './gateway-health-service.js';
 import { GATEWAY_LOG_REQUESTS_ENV } from './gateway-lifecycle.js';
 import { tryEnsurePluginManagerInitializedForGateway } from './gateway-plugin-runtime.js';
 import {
@@ -1592,29 +1593,12 @@ function getAdminChannelDisabledSkills(
   );
 }
 
-function buildHybridAIProviderEntry(
-  probe: HybridAIHealthResult,
-): GatewayProviderHealthEntry {
-  const discoveredModelCount = dedupeStrings(
-    getDiscoveredHybridAIModelNames(),
-  ).length;
-
-  return {
-    kind: 'remote',
-    reachable: probe.reachable,
-    ...(probe.error ? { error: probe.error } : {}),
-    latencyMs: probe.latencyMs,
-    modelCount: probe.modelCount ?? discoveredModelCount,
-    detail: probe.reachable
-      ? `${probe.latencyMs}ms`
-      : probe.error || 'unreachable',
-  };
-}
+export type GatewayStatusOptions = GatewayHealthOptions;
 
 function buildGatewayProviderHealth(params: {
   localBackends: GatewayStatus['localBackends'];
   codex: ReturnType<typeof getCodexAuthStatus>;
-  hybridaiHealth: HybridAIHealthResult;
+  hybridaiHealth: GatewayProviderHealthEntry;
 }): NonNullable<GatewayStatus['providerHealth']> {
   const runtimeConfig = getRuntimeConfig();
   const anthropicStatus = getAnthropicAuthStatus();
@@ -1623,7 +1607,7 @@ function buildGatewayProviderHealth(params: {
     runtimeConfig.anthropic.method,
   );
   const providerHealth: NonNullable<GatewayStatus['providerHealth']> = {
-    hybridai: buildHybridAIProviderEntry(params.hybridaiHealth),
+    hybridai: params.hybridaiHealth,
     codex: {
       kind: 'remote',
       reachable: params.codex.authenticated && !params.codex.reloginRequired,
@@ -1719,8 +1703,7 @@ async function getGatewayStatusForModelSubcommand(
   if (subcommand === 'list' || subcommand === 'info') {
     // These commands are expected to reflect the current live provider state,
     // not a recently cached health snapshot.
-    localBackendsProbe.invalidate();
-    hybridAIProbe.invalidate();
+    invalidateGatewayProviderHealth();
   }
   return await getGatewayStatus();
 }
@@ -3703,15 +3686,22 @@ export function buildTokenUsageAuditPayload(
   };
 }
 
-export async function getGatewayStatus(): Promise<GatewayStatus> {
+export async function getGatewayStatus(
+  options: GatewayStatusOptions = {},
+): Promise<GatewayStatus> {
   const codex = getCodexAuthStatus();
   const hybridai = getHybridAIAuthStatus();
+  const refreshProviderHealth = options.refreshProviderHealth ?? true;
+  const providerHealthOptions = {
+    refreshProviderHealth,
+    providerProbeTimeoutMs: options.providerProbeTimeoutMs,
+  };
   const [localBackendsResult, hybridaiResult, whatsappAuthResult] =
     await Promise.allSettled([
-      localBackendsProbe.get(),
-      hybridAIProbe.get(),
+      resolveGatewayLocalBackendsHealth(providerHealthOptions),
+      resolveGatewayHybridAIHealth(providerHealthOptions),
       getWhatsAppAuthStatus(),
-      codex.authenticated && !codex.reloginRequired
+      refreshProviderHealth && codex.authenticated && !codex.reloginRequired
         ? discoverCodexModels()
         : Promise.resolve([]),
     ]);
@@ -3721,10 +3711,15 @@ export async function getGatewayStatus(): Promise<GatewayStatus> {
     localBackendsResult.status === 'fulfilled'
       ? localBackendsResult.value
       : new Map();
-  const hybridaiHealth: HybridAIHealthResult =
+  const hybridaiHealth = buildGatewayHybridAIProviderEntry(
     hybridaiResult.status === 'fulfilled'
       ? hybridaiResult.value
-      : { reachable: false, error: 'probe failed', latencyMs: 0 };
+      : {
+          reachable: false,
+          error: 'probe failed',
+          latencyMs: 0,
+        },
+  );
   const whatsappAuth =
     whatsappAuthResult.status === 'fulfilled'
       ? whatsappAuthResult.value

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -318,7 +318,10 @@ import type {
 } from '../types/side-effects.js';
 import type { TokenUsageStats } from '../types/usage.js';
 import { isApprovalHistoryMessage } from '../utils/approval-text.js';
-import { normalizeOptionalTrimmedUniqueStringArray } from '../utils/normalized-strings.js';
+import {
+  dedupeStrings,
+  normalizeOptionalTrimmedUniqueStringArray,
+} from '../utils/normalized-strings.js';
 import { sleep } from '../utils/sleep.js';
 import { formatDurationMs } from '../utils/text-format.js';
 import {
@@ -1561,18 +1564,6 @@ function getGatewayAdminAgentMarkdownRevisionRecord(params: {
     throw new Error(`Revision "${revisionId}" was not found.`);
   }
   return record;
-}
-
-function dedupeStrings(values: string[]): string[] {
-  const seen = new Set<string>();
-  const deduped: string[] = [];
-  for (const rawValue of values) {
-    const value = String(rawValue || '').trim();
-    if (!value || seen.has(value)) continue;
-    seen.add(value);
-    deduped.push(value);
-  }
-  return deduped;
 }
 
 function getAdminChannelDisabledSkills(

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -3686,6 +3686,8 @@ export async function getGatewayStatus(
       resolveGatewayLocalBackendsHealth(options),
       resolveGatewayHybridAIHealth(options),
       getWhatsAppAuthStatus(),
+      // Warm the Codex model cache for provider counts; the status payload
+      // reads discovered names after all probes settle.
       refreshProviderHealth && codex.authenticated && !codex.reloginRequired
         ? discoverCodexModels()
         : Promise.resolve([]),

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -3681,17 +3681,27 @@ export async function getGatewayStatus(
   const codex = getCodexAuthStatus();
   const hybridai = getHybridAIAuthStatus();
   const refreshProviderHealth = options.refreshProviderHealth ?? true;
-  const [localBackendsResult, hybridaiResult, whatsappAuthResult] =
-    await Promise.allSettled([
-      resolveGatewayLocalBackendsHealth(options),
-      resolveGatewayHybridAIHealth(options),
-      getWhatsAppAuthStatus(),
-      // Warm the Codex model cache for provider counts; the status payload
-      // reads discovered names after all probes settle.
-      refreshProviderHealth && codex.authenticated && !codex.reloginRequired
-        ? discoverCodexModels()
-        : Promise.resolve([]),
-    ]);
+  const [
+    localBackendsResult,
+    hybridaiResult,
+    whatsappAuthResult,
+    codexDiscoveryResult,
+  ] = await Promise.allSettled([
+    resolveGatewayLocalBackendsHealth(options),
+    resolveGatewayHybridAIHealth(options),
+    getWhatsAppAuthStatus(),
+    // Warm the Codex model cache for provider counts; the status payload
+    // reads discovered names after all probes settle.
+    refreshProviderHealth && codex.authenticated && !codex.reloginRequired
+      ? discoverCodexModels()
+      : Promise.resolve([]),
+  ]);
+  if (codexDiscoveryResult.status === 'rejected') {
+    logger.debug(
+      { err: codexDiscoveryResult.reason },
+      'Codex model cache warmup failed during gateway status',
+    );
+  }
   const runtimeConfig = getRuntimeConfig();
   const storedSecrets = readStoredRuntimeSecrets();
   const localBackendsMap =

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -1593,8 +1593,6 @@ function getAdminChannelDisabledSkills(
   );
 }
 
-export type GatewayStatusOptions = GatewayHealthOptions;
-
 function buildGatewayProviderHealth(params: {
   localBackends: GatewayStatus['localBackends'];
   codex: ReturnType<typeof getCodexAuthStatus>;
@@ -3687,7 +3685,7 @@ export function buildTokenUsageAuditPayload(
 }
 
 export async function getGatewayStatus(
-  options: GatewayStatusOptions = {},
+  options: GatewayHealthOptions = {},
 ): Promise<GatewayStatus> {
   const codex = getCodexAuthStatus();
   const hybridai = getHybridAIAuthStatus();

--- a/src/utils/normalized-strings.ts
+++ b/src/utils/normalized-strings.ts
@@ -20,6 +20,20 @@ export function normalizeTrimmedStringArray(
     .filter(Boolean);
 }
 
+export function dedupeStrings(
+  values: readonly unknown[] | undefined,
+): string[] {
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (const rawValue of values ?? []) {
+    const value = String(rawValue || '').trim();
+    if (!value || seen.has(value)) continue;
+    seen.add(value);
+    deduped.push(value);
+  }
+  return deduped;
+}
+
 export function normalizeTrimmedUniqueStringArray(
   values: readonly unknown[] | undefined,
 ): string[] {

--- a/tests/gateway-health-service.test.ts
+++ b/tests/gateway-health-service.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+const ORIGINAL_HYBRIDAI_API_KEY = process.env.HYBRIDAI_API_KEY;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.doUnmock('../src/providers/hybridai-discovery.js');
+  vi.doUnmock('../src/providers/hybridai-health.js');
+  vi.doUnmock('../src/providers/local-health.js');
+  vi.resetModules();
+  if (ORIGINAL_HYBRIDAI_API_KEY === undefined) {
+    delete process.env.HYBRIDAI_API_KEY;
+  } else {
+    process.env.HYBRIDAI_API_KEY = ORIGINAL_HYBRIDAI_API_KEY;
+  }
+});
+
+test('resolveGatewayHybridAIHealth uses a generic uncached fallback', async () => {
+  process.env.HYBRIDAI_API_KEY = 'hai-test-gateway-health';
+  const get = vi.fn(async () => ({
+    reachable: true,
+    latencyMs: 10,
+  }));
+  vi.doMock('../src/providers/hybridai-discovery.js', () => ({
+    getDiscoveredHybridAIModelNames: vi.fn(() => []),
+  }));
+  vi.doMock('../src/providers/hybridai-health.js', () => ({
+    hybridAIProbe: {
+      get,
+      peek: vi.fn(() => null),
+      invalidate: vi.fn(),
+    },
+  }));
+  vi.doMock('../src/providers/local-health.js', () => ({
+    localBackendsProbe: {
+      get: vi.fn(async () => new Map()),
+      peek: vi.fn(() => new Map()),
+      invalidate: vi.fn(),
+    },
+  }));
+
+  const { resolveGatewayHybridAIHealth } = await import(
+    '../src/gateway/gateway-health-service.js'
+  );
+
+  await expect(
+    resolveGatewayHybridAIHealth({ refreshProviderHealth: false }),
+  ).resolves.toEqual({
+    reachable: false,
+    error: 'unavailable',
+    latencyMs: 0,
+  });
+  expect(get).not.toHaveBeenCalled();
+});

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -1837,6 +1837,9 @@ describe('gateway HTTP server', () => {
     await vi.waitFor(() => expect(res.statusCode).toBe(200));
 
     expect(state.listenArgs).toEqual({ host: '127.0.0.1', port: 9090 });
+    expect(state.getGatewayStatus).toHaveBeenCalledWith({
+      refreshProviderHealth: false,
+    });
     expect(JSON.parse(res.body)).toEqual({ status: 'ok', sessions: 2 });
   });
 

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -131,6 +131,52 @@ function mockHealthProbes(options?: {
   }));
 }
 
+test('getGatewayStatus uses cached HybridAI health when probe exceeds deadline', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  process.env.HYBRIDAI_API_KEY = 'hai-test-gateway-status-timeout';
+  writeRuntimeConfig(homeDir);
+  vi.resetModules();
+
+  const hybridAIGet = vi.fn(() => new Promise<never>(() => {}));
+  vi.doMock('../src/providers/hybridai-health.js', () => ({
+    hybridAIProbe: {
+      get: hybridAIGet,
+      peek: vi.fn(() => ({
+        reachable: true,
+        latencyMs: 42,
+        modelCount: 7,
+      })),
+      invalidate: vi.fn(),
+    },
+  }));
+  vi.doMock('../src/providers/local-health.js', () => ({
+    localBackendsProbe: {
+      get: vi.fn(async () => new Map()),
+      peek: vi.fn(() => new Map()),
+      invalidate: vi.fn(),
+    },
+    checkConnection: vi.fn(),
+    checkModelConnection: vi.fn(),
+    checkAllBackends: vi.fn(async () => new Map()),
+  }));
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { getGatewayStatus } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+  initDatabase({ quiet: true });
+
+  const status = await getGatewayStatus({ providerProbeTimeoutMs: 1 });
+
+  expect(hybridAIGet).toHaveBeenCalledTimes(1);
+  expect(status.providerHealth?.hybridai).toMatchObject({
+    reachable: true,
+    latencyMs: 42,
+    modelCount: 7,
+  });
+});
+
 test('getGatewayStatus includes Codex auth state', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -57,6 +57,7 @@ function makeJwt(payload: Record<string, unknown>): string {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.useRealTimers();
   vi.unstubAllGlobals();
   vi.doUnmock('../src/logger.js');
   vi.doUnmock('../src/plugins/plugin-manager.js');
@@ -177,6 +178,54 @@ test('getGatewayStatus uses cached HybridAI health when probe exceeds deadline',
     reachable: true,
     latencyMs: 42,
     modelCount: 7,
+  });
+});
+
+test('getGatewayStatus uses cached HybridAI health when probe rejects', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  process.env.HYBRIDAI_API_KEY = 'hai-test-gateway-status-reject';
+  writeRuntimeConfig(homeDir);
+  vi.resetModules();
+
+  const hybridAIGet = vi.fn(async () => {
+    throw new Error('probe failed');
+  });
+  vi.doMock('../src/providers/hybridai-health.js', () => ({
+    hybridAIProbe: {
+      get: hybridAIGet,
+      peek: vi.fn(() => ({
+        reachable: true,
+        latencyMs: 39,
+        modelCount: 6,
+      })),
+      invalidate: vi.fn(),
+    },
+  }));
+  vi.doMock('../src/providers/local-health.js', () => ({
+    localBackendsProbe: {
+      get: vi.fn(async () => new Map()),
+      peek: vi.fn(() => new Map()),
+      invalidate: vi.fn(),
+    },
+    checkConnection: vi.fn(),
+    checkModelConnection: vi.fn(),
+    checkAllBackends: vi.fn(async () => new Map()),
+  }));
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { getGatewayStatus } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+  initDatabase({ quiet: true });
+
+  const status = await getGatewayStatus();
+
+  expect(hybridAIGet).toHaveBeenCalledTimes(1);
+  expect(status.providerHealth?.hybridai).toMatchObject({
+    reachable: true,
+    latencyMs: 39,
+    modelCount: 6,
   });
 });
 

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -167,7 +167,10 @@ test('getGatewayStatus uses cached HybridAI health when probe exceeds deadline',
   );
   initDatabase({ quiet: true });
 
-  const status = await getGatewayStatus({ providerProbeTimeoutMs: 1 });
+  vi.useFakeTimers();
+  const statusPromise = getGatewayStatus();
+  await vi.advanceTimersByTimeAsync(750);
+  const status = await statusPromise;
 
   expect(hybridAIGet).toHaveBeenCalledTimes(1);
   expect(status.providerHealth?.hybridai).toMatchObject({

--- a/tests/normalized-strings.test.ts
+++ b/tests/normalized-strings.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'vitest';
+import { dedupeStrings } from '../src/utils/normalized-strings.js';
+
+test('dedupeStrings trims before deduping and drops blank entries', () => {
+  expect(dedupeStrings([' foo', 'foo', '', '  ', 'bar ', 'bar'])).toEqual([
+    'foo',
+    'bar',
+  ]);
+});
+
+test('dedupeStrings preserves legacy value coercion', () => {
+  expect(dedupeStrings(['0', 0, false, 'false', true])).toEqual([
+    '0',
+    'false',
+    'true',
+  ]);
+});


### PR DESCRIPTION
## Summary

Decouples the gateway `/health` response from live provider probes so transient HybridAI bot-management outages do not cause Docker liveness checks to hang or fail.

## Changes

- Added `gateway-health-service` to own provider health probe deadline/fallback behavior.
- Made `/health` call `getGatewayStatus({ refreshProviderHealth: false })` so liveness uses cached provider health and skips external refreshes.
- Kept richer status paths able to refresh provider health, with a short deadline and cached fallback for slow HybridAI/local backend probes.
- Added regression coverage for cached HybridAI fallback and the HTTP health endpoint behavior.

## Root Cause

`/health` used the full `getGatewayStatus()` path, which refreshed HybridAI bot-management health. During hybridai.one deploys, `/api/v1/bot-management/bots` can return 502 or time out, making the gateway health check slow or unavailable and causing Docker to mark the instance unhealthy.

## Validation

- `./node_modules/.bin/tsc --noEmit`
- `npx biome check src/gateway/gateway-service.ts src/gateway/gateway-http-server.ts src/gateway/gateway-health-service.ts tests/gateway-status.test.ts tests/gateway-http-server.test.ts`
- `npx vitest run tests/gateway-status.test.ts tests/gateway-http-server.test.ts tests/hybridai-health.test.ts`