### PR TITLE
[codex] Fix HybridAI model prefix warning

### DIFF
--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -248,6 +248,7 @@ import {
   formatModelCountSuffix,
   formatModelForDisplay,
   HYBRIDAI_MODEL_PREFIX,
+  NON_HYBRID_PROVIDER_PREFIXES,
   normalizeHybridAIModelForRuntime,
   stripHybridAIModelPrefix,
 } from '../providers/model-names.js';
@@ -4980,26 +4981,22 @@ export async function getGatewayAdminTools(): Promise<GatewayAdminToolsResponse>
   };
 }
 
+function resolveKnownNonHybridProviderKey(
+  prefix: string,
+): GatewayModelProviderKey {
+  const normalized = prefix.replace(/\/+$/g, '');
+  if (normalized === 'openai-codex') return 'codex';
+  return normalized as GatewayModelProviderKey;
+}
+
 const MODEL_PROVIDER_KEY_BY_PREFIX: Array<[string, GatewayModelProviderKey]> = [
   [HYBRIDAI_MODEL_PREFIX, 'hybridai'],
-  ['openai-codex/', 'codex'],
-  ['anthropic/', 'anthropic'],
-  ['openrouter/', 'openrouter'],
-  ['mistral/', 'mistral'],
-  ['huggingface/', 'huggingface'],
-  ['gemini/', 'gemini'],
-  ['deepseek/', 'deepseek'],
-  ['xai/', 'xai'],
-  ['zai/', 'zai'],
-  ['kimi/', 'kimi'],
-  ['minimax/', 'minimax'],
-  ['dashscope/', 'dashscope'],
-  ['xiaomi/', 'xiaomi'],
-  ['kilo/', 'kilo'],
-  ['ollama/', 'ollama'],
-  ['lmstudio/', 'lmstudio'],
-  ['llamacpp/', 'llamacpp'],
-  ['vllm/', 'vllm'],
+  ...NON_HYBRID_PROVIDER_PREFIXES.map(
+    (prefix): [string, GatewayModelProviderKey] => [
+      prefix,
+      resolveKnownNonHybridProviderKey(prefix),
+    ],
+  ),
 ];
 
 // Bare slugs (no `provider/` prefix) are HybridAI passthroughs by gateway

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -247,6 +247,7 @@ import {
   formatHybridAIModelForCatalog,
   formatModelCountSuffix,
   formatModelForDisplay,
+  HYBRIDAI_MODEL_PREFIX,
   normalizeHybridAIModelForRuntime,
   stripHybridAIModelPrefix,
 } from '../providers/model-names.js';
@@ -4980,6 +4981,7 @@ export async function getGatewayAdminTools(): Promise<GatewayAdminToolsResponse>
 }
 
 const MODEL_PROVIDER_KEY_BY_PREFIX: Array<[string, GatewayModelProviderKey]> = [
+  [HYBRIDAI_MODEL_PREFIX, 'hybridai'],
   ['openai-codex/', 'codex'],
   ['anthropic/', 'anthropic'],
   ['openrouter/', 'openrouter'],

--- a/src/providers/model-names.ts
+++ b/src/providers/model-names.ts
@@ -2,6 +2,7 @@ import {
   formatHybridAIModelForCatalog,
   HYBRIDAI_MODEL_PREFIX,
   hasKnownNonHybridProviderPrefix,
+  NON_HYBRID_PROVIDER_PREFIXES,
   normalizeHybridAIModelForRuntime,
   stripHybridAIModelPrefix,
   stripProviderPrefix,
@@ -11,6 +12,7 @@ import { pluralize } from '../utils/text-format.js';
 export {
   formatHybridAIModelForCatalog,
   HYBRIDAI_MODEL_PREFIX,
+  NON_HYBRID_PROVIDER_PREFIXES,
   normalizeHybridAIModelForRuntime,
   stripHybridAIModelPrefix,
   stripProviderPrefix,

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -679,13 +679,7 @@ test('getGatewayAdminModels treats hybridai-prefixed models as HybridAI without 
 
   const warnMock = vi.fn();
   vi.doMock('../src/logger.js', () => ({
-    logger: {
-      debug: vi.fn(),
-      info: vi.fn(),
-      warn: warnMock,
-      error: vi.fn(),
-      fatal: vi.fn(),
-    },
+    logger: { warn: warnMock },
   }));
   vi.doMock('../src/providers/model-catalog.js', async () => {
     const actual = await vi.importActual<

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -671,6 +671,53 @@ test('getGatewayAdminModels tags each row with its providerHealth key', async ()
   expect(byId['ollama/llama-3.1']).toBe('ollama');
 });
 
+test('getGatewayAdminModels treats hybridai-prefixed models as HybridAI without warning', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+  mockHealthProbes();
+
+  const warnMock = vi.fn();
+  vi.doMock('../src/logger.js', () => ({
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: warnMock,
+      error: vi.fn(),
+      fatal: vi.fn(),
+    },
+  }));
+  vi.doMock('../src/providers/model-catalog.js', async () => {
+    const actual = await vi.importActual<
+      typeof import('../src/providers/model-catalog.js')
+    >('../src/providers/model-catalog.js');
+    return {
+      ...actual,
+      refreshAvailableModelCatalogs: vi.fn(async () => {}),
+      getAvailableModelList: vi.fn(() => [
+        'hybridai/o1-preview',
+        'hybridai/o3-mini',
+      ]),
+    };
+  });
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { getGatewayAdminModels } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  const result = await getGatewayAdminModels();
+
+  const byId = Object.fromEntries(result.models.map((m) => [m.id, m.provider]));
+  expect(byId['hybridai/o1-preview']).toBe('hybridai');
+  expect(byId['hybridai/o3-mini']).toBe('hybridai');
+  expect(warnMock).not.toHaveBeenCalledWith(
+    expect.anything(),
+    'Unknown provider prefix in model id; defaulting to hybridai',
+  );
+});
+
 test('getGatewayAdminModels populates context windows from provider discovery', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;


### PR DESCRIPTION
## Summary

- Recognize `hybridai/` as an explicit HybridAI provider prefix in the gateway admin model provider resolver.
- Add a regression test for `hybridai/o1-preview` and `hybridai/o3-mini` catalog rows so opening the `/chat` model dropdown does not emit the unknown-prefix warning.

## Root Cause

The admin models path treated bare model slugs as HybridAI, but only listed non-HybridAI provider prefixes in `MODEL_PROVIDER_KEY_BY_PREFIX`. Display/catalog rows with `hybridai/...` therefore fell through to the unknown slash-prefixed warning path even though they are valid HybridAI IDs.

## Validation

- `./node_modules/.bin/vitest --run tests/gateway-status.test.ts -t "hybridai-prefixed models"`
- `npm run typecheck`
- `npm run lint`
- `npm run check`
