### PR TITLE
[codex] Dedupe tunnel reconnect errors

### DIFF
--- a/console/src/routes/dashboard.test.tsx
+++ b/console/src/routes/dashboard.test.tsx
@@ -193,7 +193,7 @@ describe('DashboardPage', () => {
         }),
       ),
     );
-    reconnectTunnelMock.mockRejectedValue(new Error(message));
+    reconnectTunnelMock.mockRejectedValue(new Error(` ${message} `));
 
     renderDashboardPage();
 

--- a/console/src/routes/dashboard.test.tsx
+++ b/console/src/routes/dashboard.test.tsx
@@ -204,4 +204,32 @@ describe('DashboardPage', () => {
       expect(screen.getAllByText(message)).toHaveLength(1);
     });
   });
+
+  it('shows distinct tunnel and reconnect errors', async () => {
+    const tunnelError =
+      'ngrok auth token is not configured in encrypted runtime secrets.';
+    const reconnectError = 'Failed to start ngrok tunnel.';
+    fetchOverviewMock.mockResolvedValue(
+      makeOverview(
+        makeTunnelStatus({
+          publicUrl: null,
+          state: 'down',
+          health: 'down',
+          lastError: tunnelError,
+          lastCheckedAt: null,
+        }),
+      ),
+    );
+    reconnectTunnelMock.mockRejectedValue(new Error(reconnectError));
+
+    renderDashboardPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Reconnect' }));
+
+    await waitFor(() => {
+      expect(reconnectTunnelMock).toHaveBeenCalledWith('test-token');
+      expect(screen.getByText(tunnelError)).toBeTruthy();
+      expect(screen.getByText(reconnectError)).toBeTruthy();
+    });
+  });
 });

--- a/console/src/routes/dashboard.test.tsx
+++ b/console/src/routes/dashboard.test.tsx
@@ -178,4 +178,30 @@ describe('DashboardPage', () => {
       ).getAttribute('href'),
     ).toBe('https://next.example.test');
   });
+
+  it('does not repeat the same tunnel and reconnect error', async () => {
+    const message =
+      'ngrok auth token is not configured in encrypted runtime secrets. Store it with `hybridclaw secret set NGROK_AUTHTOKEN <token>`.';
+    fetchOverviewMock.mockResolvedValue(
+      makeOverview(
+        makeTunnelStatus({
+          publicUrl: null,
+          state: 'down',
+          health: 'down',
+          lastError: message,
+          lastCheckedAt: null,
+        }),
+      ),
+    );
+    reconnectTunnelMock.mockRejectedValue(new Error(message));
+
+    renderDashboardPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Reconnect' }));
+
+    await waitFor(() => {
+      expect(reconnectTunnelMock).toHaveBeenCalledWith('test-token');
+      expect(screen.getAllByText(message)).toHaveLength(1);
+    });
+  });
 });

--- a/console/src/routes/dashboard.tsx
+++ b/console/src/routes/dashboard.tsx
@@ -83,6 +83,10 @@ function TunnelStatusPanel(props: {
   const publicUrl = tunnel.publicUrl || 'not configured';
   const reconnectDisabled =
     props.reconnectPending || !tunnel.reconnectSupported;
+  const distinctReconnectError =
+    props.reconnectError && props.reconnectError !== tunnel.lastError
+      ? props.reconnectError
+      : null;
 
   return (
     <Panel title="Public tunnel">
@@ -135,8 +139,8 @@ function TunnelStatusPanel(props: {
       {tunnel.lastError ? (
         <p className="supporting-text tunnel-error">{tunnel.lastError}</p>
       ) : null}
-      {props.reconnectError ? (
-        <p className="supporting-text tunnel-error">{props.reconnectError}</p>
+      {distinctReconnectError ? (
+        <p className="supporting-text tunnel-error">{distinctReconnectError}</p>
       ) : null}
     </Panel>
   );

--- a/console/src/routes/dashboard.tsx
+++ b/console/src/routes/dashboard.tsx
@@ -83,8 +83,10 @@ function TunnelStatusPanel(props: {
   const publicUrl = tunnel.publicUrl || 'not configured';
   const reconnectDisabled =
     props.reconnectPending || !tunnel.reconnectSupported;
+  const normalizedTunnelError = tunnel.lastError?.trim() || null;
+  const normalizedReconnectError = props.reconnectError?.trim() || null;
   const distinctReconnectError =
-    props.reconnectError && props.reconnectError !== tunnel.lastError
+    props.reconnectError && normalizedReconnectError !== normalizedTunnelError
       ? props.reconnectError
       : null;
 


### PR DESCRIPTION
## Summary

Fixes duplicate tunnel error text in the console dashboard when a failed reconnect reports the same message that is already persisted as the tunnel `lastError`.

## Root Cause

The public tunnel panel rendered two independent error slots: the persisted tunnel status error and the current reconnect mutation error. When ngrok reconnect failed due to a missing `NGROK_AUTHTOKEN`, both slots contained the same setup message.

## Changes

- Render the reconnect mutation error only when it differs from the persisted tunnel `lastError`.
- Add a dashboard regression test for the ngrok missing-token message so it appears once.

## Validation

- `npm --workspace console run test -- src/routes/dashboard.test.tsx`
- `npm --workspace console run typecheck`