### PR TITLE
[codex] Add config get command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1336,7 +1336,7 @@ async function handleConfigCommand(args: string[]): Promise<void> {
     return;
   }
   if (sub === 'get') {
-    const key = String(normalized[1] || '').trim();
+    const key = (normalized[1] || '').trim();
     if (!key) {
       throw new Error('Usage: `hybridclaw config get <key>`');
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,6 +45,7 @@ import {
   updateRuntimeConfig,
 } from './config/runtime-config.js';
 import {
+  getRuntimeConfigValueAtPath,
   parseRuntimeConfigCommandValue,
   setRuntimeConfigValueAtPath,
 } from './config/runtime-config-edit.js';
@@ -1215,6 +1216,10 @@ async function handleEvalCommand(args: string[]): Promise<void> {
 }
 
 async function handleConfigCommand(args: string[]): Promise<void> {
+  function formatRuntimeConfigValue(value: unknown): string {
+    return JSON.stringify(value, null, 2) ?? String(value);
+  }
+
   function parseRevisionId(raw: string): number {
     const parsed = Number.parseInt(raw, 10);
     if (!Number.isFinite(parsed) || parsed <= 0) {
@@ -1333,9 +1338,20 @@ async function handleConfigCommand(args: string[]): Promise<void> {
     await runRuntimeConfigFileCheck();
     return;
   }
+  if (sub === 'get') {
+    const key = String(normalized[1] || '').trim();
+    if (!key) {
+      throw new Error('Usage: `hybridclaw config get <key>`');
+    }
+    const value = getRuntimeConfigValueAtPath(getRuntimeConfig(), key);
+    console.log(`Active config: ${runtimeConfigPath()}`);
+    console.log(`Key: ${key}`);
+    console.log(formatRuntimeConfigValue(value));
+    return;
+  }
   if (sub !== 'set') {
     throw new Error(
-      'Unknown config subcommand. Use `hybridclaw config`, `hybridclaw config check`, `hybridclaw config reload`, `hybridclaw config set <key> <value>`, or `hybridclaw config revisions`.',
+      'Unknown config subcommand. Use `hybridclaw config`, `hybridclaw config check`, `hybridclaw config reload`, `hybridclaw config get <key>`, `hybridclaw config set <key> <value>`, or `hybridclaw config revisions`.',
     );
   }
 
@@ -1343,7 +1359,7 @@ async function handleConfigCommand(args: string[]): Promise<void> {
   const rawValue = normalized.slice(2).join(' ').trim();
   if (!key || !rawValue) {
     throw new Error(
-      'Usage: `hybridclaw config`, `hybridclaw config check`, `hybridclaw config reload`, `hybridclaw config set <key> <value>`, or `hybridclaw config revisions`',
+      'Usage: `hybridclaw config`, `hybridclaw config check`, `hybridclaw config reload`, `hybridclaw config get <key>`, `hybridclaw config set <key> <value>`, or `hybridclaw config revisions`',
     );
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,6 +45,7 @@ import {
   updateRuntimeConfig,
 } from './config/runtime-config.js';
 import {
+  formatRuntimeConfigValue,
   getRuntimeConfigValueAtPath,
   parseRuntimeConfigCommandValue,
   setRuntimeConfigValueAtPath,
@@ -1216,10 +1217,6 @@ async function handleEvalCommand(args: string[]): Promise<void> {
 }
 
 async function handleConfigCommand(args: string[]): Promise<void> {
-  function formatRuntimeConfigValue(value: unknown): string {
-    return JSON.stringify(value, null, 2) ?? String(value);
-  }
-
   function parseRevisionId(raw: string): number {
     const parsed = Number.parseInt(raw, 10);
     if (!Number.isFinite(parsed) || parsed <= 0) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1337,7 +1337,7 @@ async function handleConfigCommand(args: string[]): Promise<void> {
   }
   if (sub === 'get') {
     const key = (normalized[1] || '').trim();
-    if (!key) {
+    if (!key || normalized.length > 2) {
       throw new Error('Usage: `hybridclaw config get <key>`');
     }
     const value = getRuntimeConfigValueAtPath(getRuntimeConfig(), key);

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -136,7 +136,7 @@ Interactive slash commands inside TUI:
   /compact
   /concierge [info|on|off|model [name]|profile <asap|balanced|no_hurry> [model]]
   /eval [list|env|<suite>|<command...>]
-  /config   /config check   /config reload   /config set <key> <value>   /config revisions
+  /config   /config check   /config reload   /config get <key>   /config set <key> <value>   /config revisions
   /exit
   /export session [sessionId]   /export trace [sessionId|all]
   /fullauto [status|off|on [prompt]|prompt]
@@ -683,12 +683,13 @@ Notes:
 }
 
 export function printConfigUsage(): void {
-  console.log(`Usage: hybridclaw config [check|reload|set <key> <value>]
+  console.log(`Usage: hybridclaw config [check|reload|get <key>|set <key> <value>]
 
 Commands:
   hybridclaw config
   hybridclaw config check
   hybridclaw config reload
+  hybridclaw config get <key>
   hybridclaw config set <key> <value>
   hybridclaw config revisions [list|rollback <id>|delete <id>|clear]
 
@@ -696,6 +697,7 @@ Examples:
   hybridclaw config
   hybridclaw config check
   hybridclaw config reload
+  hybridclaw config get hybridai.maxTokens
   hybridclaw config set hybridai.maxTokens 8192
   hybridclaw config revisions
   hybridclaw config revisions rollback 12
@@ -706,6 +708,7 @@ Notes:
   - \`config\` prints the current runtime config from ${runtimeConfigPath()}.
   - \`check\` validates only the runtime config file itself.
   - \`reload\` forces an immediate in-process hot reload from disk, then runs a config check.
+  - \`get\` prints one existing dotted key path from the current runtime config.
   - \`set\` only updates existing dotted key paths; it does not create new keys, then immediately runs a config check.
   - \`revisions\` lists saved config snapshots, including the actor and route that caused each tracked change.
   - Values are parsed as JSON when possible, otherwise they are stored as plain strings.`);

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -223,7 +223,7 @@ const LOCAL_SESSION_HELP_PRESENTATIONS: Record<
     description: 'Configure concierge routing',
   },
   config: {
-    command: '/config [check|reload|set <key> <value>]',
+    command: '/config [check|reload|get <key>|set <key> <value>]',
     description: 'Show or update local runtime config',
   },
   context: {
@@ -539,6 +539,10 @@ export function mapCanonicalCommandToGatewayArgs(
       if (!sub) return ['config'];
       if (sub === 'check') return ['config', 'check'];
       if (sub === 'reload') return ['config', 'reload'];
+      if (sub === 'get') {
+        const key = (parts[2] || '').trim();
+        return key ? ['config', 'get', key] : ['config', 'get'];
+      }
       if (sub === 'set') {
         const key = (parts[2] || '').trim();
         const value = parts.slice(3).join(' ').trim();
@@ -1170,9 +1174,19 @@ function buildSlashCommandCatalogDefinitions(
     {
       name: 'config',
       description:
-        'Show, validate, reload, or set the local runtime config file',
+        'Show, validate, reload, get, or set the local runtime config file',
       tuiOnly: true,
+      tuiMenu: {
+        label: '/config [check|reload|get|set] [key] [value]',
+        insertText: '/config ',
+      },
       tuiMenuEntries: [
+        {
+          id: 'config.get',
+          label: '/config get <key>',
+          insertText: '/config get ',
+          description: 'Show one runtime config value',
+        },
         {
           id: 'config.set',
           label: '/config set <key> <value>',
@@ -1200,6 +1214,7 @@ function buildSlashCommandCatalogDefinitions(
           choices: [
             { name: 'check', value: 'check' },
             { name: 'reload', value: 'reload' },
+            { name: 'get', value: 'get' },
             { name: 'set', value: 'set' },
           ],
         },
@@ -2689,6 +2704,7 @@ export function parseCanonicalSlashCommandArgs(
       if (!action && !key && !value) return ['config'];
       if (action === 'check' && !key && !value) return ['config', 'check'];
       if (action === 'reload' && !key && !value) return ['config', 'reload'];
+      if (action === 'get' && key && !value) return ['config', 'get', key];
       if (action !== 'set' || !key || !value) return null;
       return ['config', 'set', key, value];
     }

--- a/src/config/runtime-config-edit.ts
+++ b/src/config/runtime-config-edit.ts
@@ -61,3 +61,20 @@ export function setRuntimeConfigValueAtPath(
   }
   current[leaf] = value;
 }
+
+export function getRuntimeConfigValueAtPath(
+  config: RuntimeConfig,
+  keyPath: string,
+): unknown {
+  const segments = splitRuntimeConfigPath(keyPath);
+  let current: unknown = config;
+
+  for (const segment of segments) {
+    if (!isConfigObject(current) || !Object.hasOwn(current, segment)) {
+      throw new Error(`Config key \`${keyPath}\` was not found.`);
+    }
+    current = current[segment];
+  }
+
+  return current;
+}

--- a/src/config/runtime-config-edit.ts
+++ b/src/config/runtime-config-edit.ts
@@ -78,3 +78,7 @@ export function getRuntimeConfigValueAtPath(
 
   return current;
 }
+
+export function formatRuntimeConfigValue(value: unknown): string {
+  return JSON.stringify(value, null, 2) ?? String(value);
+}

--- a/src/config/runtime-config-edit.ts
+++ b/src/config/runtime-config-edit.ts
@@ -80,5 +80,5 @@ export function getRuntimeConfigValueAtPath(
 }
 
 export function formatRuntimeConfigValue(value: unknown): string {
-  return JSON.stringify(value, null, 2) ?? String(value);
+  return JSON.stringify(value, null, 2);
 }

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -135,6 +135,7 @@ import {
   updateRuntimeConfig,
 } from '../config/runtime-config.js';
 import {
+  getRuntimeConfigValueAtPath,
   parseRuntimeConfigCommandValue,
   setRuntimeConfigValueAtPath,
 } from '../config/runtime-config-edit.js';
@@ -7787,6 +7788,10 @@ export async function handleGatewayCommand(
     return JSON.stringify(config, null, 2);
   }
 
+  function formatRuntimeConfigValue(value: unknown): string {
+    return JSON.stringify(value, null, 2) ?? String(value);
+  }
+
   async function runRuntimeConfigCheck(): Promise<{
     severity: 'ok' | 'warn' | 'error';
     text: string;
@@ -9232,13 +9237,37 @@ export async function handleGatewayCommand(
           }
         }
 
+        if (sub === 'get') {
+          const key = parseIdArg(req.args, 2);
+          if (!key || req.args.length > 3) {
+            return badCommand('Usage', 'Usage: `config get <key>`');
+          }
+          try {
+            const value = getRuntimeConfigValueAtPath(getRuntimeConfig(), key);
+            return infoCommand(
+              'Runtime Config Value',
+              [
+                `Path: ${runtimeConfigPath()}`,
+                `Key: ${key}`,
+                'Value:',
+                formatRuntimeConfigValue(value),
+              ].join('\n'),
+            );
+          } catch (error) {
+            return badCommand(
+              'Config Read Failed',
+              error instanceof Error ? error.message : String(error),
+            );
+          }
+        }
+
         if (sub === 'set') {
           const key = parseIdArg(req.args, 2);
           const rawValue = req.args.slice(3).join(' ').trim();
           if (!key || !rawValue) {
             return badCommand(
               'Usage',
-              'Usage: `config`, `config check`, `config reload`, or `config set <key> <value>`',
+              'Usage: `config`, `config check`, `config reload`, `config get <key>`, or `config set <key> <value>`',
             );
           }
           try {
@@ -9275,7 +9304,7 @@ export async function handleGatewayCommand(
 
         return badCommand(
           'Usage',
-          'Usage: `config`, `config check`, `config reload`, or `config set <key> <value>`',
+          'Usage: `config`, `config check`, `config reload`, `config get <key>`, or `config set <key> <value>`',
         );
       }
 

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -135,6 +135,7 @@ import {
   updateRuntimeConfig,
 } from '../config/runtime-config.js';
 import {
+  formatRuntimeConfigValue,
   getRuntimeConfigValueAtPath,
   parseRuntimeConfigCommandValue,
   setRuntimeConfigValueAtPath,
@@ -7786,10 +7787,6 @@ export async function handleGatewayCommand(
 
   function formatRuntimeConfigJson(config: RuntimeConfig): string {
     return JSON.stringify(config, null, 2);
-  }
-
-  function formatRuntimeConfigValue(value: unknown): string {
-    return JSON.stringify(value, null, 2) ?? String(value);
   }
 
   async function runRuntimeConfigCheck(): Promise<{

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -3562,6 +3562,14 @@ describe('CLI hybridai commands', () => {
     expect(logSpy).toHaveBeenCalledWith('4096');
   });
 
+  it('rejects extra arguments for config get', async () => {
+    const { cli } = await importFreshCli();
+
+    await expect(
+      cli.main(['config', 'get', 'hybridai.maxTokens', 'typo']),
+    ).rejects.toThrow('Usage: `hybridclaw config get <key>`');
+  });
+
   it('reloads runtime config from disk through the top-level config command', async () => {
     const { cli, reloadRuntimeConfig, runDoctorCli } = await importFreshCli();
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -3551,6 +3551,17 @@ describe('CLI hybridai commands', () => {
     expect(process.exitCode).toBe(0);
   });
 
+  it('prints a single runtime config value from the top-level config command', async () => {
+    const { cli, runtimeConfigPath } = await importFreshCli();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await cli.main(['config', 'get', 'hybridai.maxTokens']);
+
+    expect(logSpy).toHaveBeenCalledWith(`Active config: ${runtimeConfigPath()}`);
+    expect(logSpy).toHaveBeenCalledWith('Key: hybridai.maxTokens');
+    expect(logSpy).toHaveBeenCalledWith('4096');
+  });
+
   it('reloads runtime config from disk through the top-level config command', async () => {
     const { cli, reloadRuntimeConfig, runDoctorCli } = await importFreshCli();
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});

--- a/tests/command-registry.test.ts
+++ b/tests/command-registry.test.ts
@@ -329,6 +329,18 @@ test('registers config as a local slash/text command', async () => {
       commandName: 'config',
       getString: (name) =>
         name === 'action'
+          ? 'get'
+          : name === 'key'
+            ? 'hybridai.maxTokens'
+            : null,
+      getSubcommand: () => null,
+    }),
+  ).toEqual(['config', 'get', 'hybridai.maxTokens']);
+  expect(
+    parseCanonicalSlashCommandArgs({
+      commandName: 'config',
+      getString: (name) =>
+        name === 'action'
           ? 'set'
           : name === 'key'
             ? 'hybridai.maxTokens'
@@ -347,6 +359,9 @@ test('registers config as a local slash/text command', async () => {
     'config',
     'reload',
   ]);
+  expect(
+    mapCanonicalCommandToGatewayArgs(['config', 'get', 'hybridai.maxTokens']),
+  ).toEqual(['config', 'get', 'hybridai.maxTokens']);
   expect(
     mapCanonicalCommandToGatewayArgs([
       'config',
@@ -725,7 +740,7 @@ test('builds local session help entries from the registry with surface filtering
         command: '/auth status <provider>',
       }),
       expect.objectContaining({
-        command: '/config [check|reload|set <key> <value>]',
+        command: '/config [check|reload|get <key>|set <key> <value>]',
       }),
       expect.objectContaining({
         command: '/paste',
@@ -741,7 +756,7 @@ test('builds local session help entries from the registry with surface filtering
         command: '/auth status <provider>',
       }),
       expect.objectContaining({
-        command: '/config [check|reload|set <key> <value>]',
+        command: '/config [check|reload|get <key>|set <key> <value>]',
       }),
     ]),
   );

--- a/tests/gateway-service.plugins.test.ts
+++ b/tests/gateway-service.plugins.test.ts
@@ -1351,7 +1351,7 @@ test('handleGatewayCommand help continues without plugins when plugin manager in
     '`/auth status <provider>`: Show local provider auth and config status',
   );
   expect(result.text).toContain(
-    '`/config [check|reload|set <key> <value>]`: Show or update local runtime config',
+    '`/config [check|reload|get <key>|set <key> <value>]`: Show or update local runtime config',
   );
   expect(result.text).not.toContain(
     '`plugin config <plugin-id> [key] [value|--unset]`',
@@ -1359,6 +1359,7 @@ test('handleGatewayCommand help continues without plugins when plugin manager in
   expect(result.text).not.toContain('`plugin enable <plugin-id>`');
   expect(result.text).not.toContain('`config check`');
   expect(result.text).not.toContain('`config reload`');
+  expect(result.text).not.toContain('`config get <key>`');
   expect(result.text).not.toContain('`config set <key> <value>`');
   expect(result.text).not.toContain('`/exit`');
   expect(result.text).not.toContain('`/paste`');

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -1481,6 +1481,38 @@ test('config check validates the local runtime config', async () => {
   expect(result.text).toContain('0 errors');
 });
 
+test('config get shows one local runtime config value', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+  writeRuntimeConfig(homeDir, (config) => {
+    config.hybridai.maxTokens = 4096;
+  });
+
+  const configPath = path.join(homeDir, '.hybridclaw', 'config.json');
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  const result = await handleGatewayCommand({
+    sessionId: 'session-config-get',
+    guildId: null,
+    channelId: 'web',
+    args: ['config', 'get', 'hybridai.maxTokens'],
+  });
+
+  expect(result.kind).toBe('info');
+  if (result.kind !== 'info') {
+    throw new Error(`Unexpected result kind: ${result.kind}`);
+  }
+  expect(result.title).toBe('Runtime Config Value');
+  expect(result.text).toContain(`Path: ${configPath}`);
+  expect(result.text).toContain('Key: hybridai.maxTokens');
+  expect(result.text).toContain('Value:\n4096');
+});
+
 test('config reload hot-reloads the local runtime config from disk', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;

--- a/tests/tui-slash-command.test.ts
+++ b/tests/tui-slash-command.test.ts
@@ -74,6 +74,9 @@ test('maps Discord-style slash commands to gateway command args', () => {
     'reload',
   ]);
   expect(
+    mapTuiSlashCommandToGatewayArgs(['config', 'get', 'hybridai.maxTokens']),
+  ).toEqual(['config', 'get', 'hybridai.maxTokens']);
+  expect(
     mapTuiSlashCommandToGatewayArgs([
       'secret',
       'set',

--- a/tests/tui-slash-menu.test.ts
+++ b/tests/tui-slash-menu.test.ts
@@ -29,13 +29,14 @@ test('builds canonical, choice-based, and TUI-only slash menu entries', () => {
   expect(labels).toContain('/secret set <name> <value>');
   expect(labels).toContain('/voice <info|call>');
   expect(labels).toContain('/voice call <e164-number>');
-  expect(labels).toContain('/config [check|reload|set] [key] [value]');
+  expect(labels).toContain('/config [check|reload|get|set] [key] [value]');
   expect(labels).toContain('/config check');
   expect(labels).toContain('/config reload');
+  expect(labels).toContain('/config get <key>');
   expect(labels).toContain('/config set <key> <value>');
   expect(
     labels.filter(
-      (label) => label === '/config [check|reload|set] [key] [value]',
+      (label) => label === '/config [check|reload|get|set] [key] [value]',
     ),
   ).toHaveLength(1);
   expect(labels).toContain('/approve yes [approval_id]');
@@ -145,7 +146,9 @@ test('root entries with subcommands include arg hints in labels', () => {
 
   // Commands with string options show formatted option suffixes.
   const configEntry = rootEntries.find((entry) => entry.id === 'config');
-  expect(configEntry?.label).toBe('/config [check|reload|set] [key] [value]');
+  expect(configEntry?.label).toBe(
+    '/config [check|reload|get|set] [key] [value]',
+  );
 
   // Commands with no options or subcommands have plain labels.
   const statusEntry = rootEntries.find((entry) => entry.id === 'status');


### PR DESCRIPTION
## Summary

Adds a read-only `config get <key>` command for inspecting one existing dotted runtime config value without printing the full config file.

## Changes

- Add a shared runtime config dotted-path getter that reuses the same path validation rules as `config set`.
- Wire `hybridclaw config get <key>` into the local CLI.
- Wire `/config get <key>` through local gateway/TUI command handling and slash command registry metadata.
- Update config help/menu text and focused tests.

## Validation

- `npx vitest run tests/cli.test.ts tests/gateway-status.test.ts tests/tui-slash-command.test.ts tests/tui-slash-menu.test.ts tests/command-registry.test.ts tests/gateway-service.plugins.test.ts`
- `npm run typecheck`
- `npm run format`
- `git diff --check`