### PR TITLE
[codex] Add warehouse SQL skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,8 @@ Once the gateway is running, open HybridClaw locally:
   credentials, supported channels, and per-agent autonomy policy.
 - Bundled skills include API-backed Google Workspace workflows (`gog`, `gws`),
   Salesforce inspection, GitHub issue queue processing (`gh-issues`),
-  brand-voice drafting, and editable Excalidraw diagram creation.
+  natural-language warehouse SQL (`warehouse-sql`), brand-voice drafting, and
+  editable Excalidraw diagram creation.
 - The repo-shipped `brand-voice` plugin can flag, rewrite, or block final
   responses that violate configured voice rules before they reach users.
 - Built-in office skills handle longer PDF creation flows cleanly: the bundled

--- a/docs/content/guides/bundled-skills.md
+++ b/docs/content/guides/bundled-skills.md
@@ -6,11 +6,11 @@ sidebar_position: 4
 
 # Bundled Skills
 
-HybridClaw ships with 37 bundled skills. A few notable categories:
+HybridClaw ships with 38 bundled skills. A few notable categories:
 
 - office workflows: `pdf`, `xlsx`, `docx`, `pptx`, `office-workflows`
 - planning and engineering: `project-manager`, `feature-planning`,
-  `code-review`, `code-simplification`, `gh-issues`
+  `code-review`, `code-simplification`, `gh-issues`, `warehouse-sql`
 - visual explainers and animation: `manim-video`, `excalidraw`
 - platform integrations: `github-pr-workflow`, `notion`, `trello`, `stripe`,
   `wordpress`, `gog`, `google-workspace`, `discord`

--- a/docs/content/guides/skills/README.md
+++ b/docs/content/guides/skills/README.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 # Skills Catalog
 
-HybridClaw ships **37 bundled skills** across eight categories. Each page below
+HybridClaw ships **38 bundled skills** across eight categories. Each page below
 covers every skill in its category with prerequisites, install commands,
 tips & tricks, ready-to-try example prompts, and troubleshooting.
 
@@ -28,7 +28,7 @@ For production package requirements see
 | Category | Skills | Page |
 |---|---|---|
 | Office | pdf, xlsx, docx, pptx, office-workflows | [Office Skills](./office.md) |
-| Development | code-review, gh-issues, github-pr-workflow, salesforce, skill-creator | [Development Skills](./development.md) |
+| Development | code-review, gh-issues, github-pr-workflow, salesforce, skill-creator, warehouse-sql | [Development Skills](./development.md) |
 | Communication | discord, channel-catchup | [Communication Skills](./communication.md) |
 | Apple | apple-calendar, apple-music, apple-passwords | [Apple Skills](./apple.md) |
 | Productivity | feature-planning, project-manager, trello | [Productivity Skills](./productivity.md) |

--- a/docs/content/guides/skills/development.md
+++ b/docs/content/guides/skills/development.md
@@ -250,7 +250,7 @@ SOQL rows with a bundled Python helper. Read-only by default.
 
 ## warehouse-sql
 
-Plan, review, and run read-only natural-language SQL against a customer data
+Review and run read-only natural-language SQL against a customer data
 warehouse with cached schema introspection. SQLite execution is bundled for the
 reproducible TPC-H-style eval suite; Postgres, ClickHouse, BigQuery, and
 Snowflake can run through optional Python drivers or operator-approved
@@ -276,7 +276,7 @@ connector commands.
 
 > 🎯 **Try it yourself**
 >
-> `Plan SQL for the top customers by revenue`
+> `Draft and review SQL for the top customers by revenue`
 >
 > `Review this query before running it: SELECT c_name FROM customer LIMIT 10`
 >
@@ -286,8 +286,8 @@ connector commands.
 
 **Troubleshooting**
 
-- **No deterministic plan matched** — write or ask the model to draft SQL, then
-  pass it through `review` before execution.
+- **SQL review fails** — revise the generated SQL, refresh the schema cache,
+  and pass the revised query through `review` before execution.
 - **Production backend does not execute** — install the relevant Python driver
   or set `HYBRIDCLAW_WAREHOUSE_SQL_<BACKEND>_COMMAND` to a connector command
   that reads SQL on stdin and emits JSON or CSV rows.

--- a/docs/content/guides/skills/development.md
+++ b/docs/content/guides/skills/development.md
@@ -248,6 +248,54 @@ SOQL rows with a bundled Python helper. Read-only by default.
 
 ---
 
+## warehouse-sql
+
+Plan, review, and run read-only natural-language SQL against a customer data
+warehouse with cached schema introspection. SQLite execution is bundled for the
+reproducible TPC-H-style eval suite; Postgres, ClickHouse, BigQuery, and
+Snowflake can run through optional Python drivers or operator-approved
+connector commands.
+
+**Prerequisites**
+
+| Dependency | Purpose | Install |
+|---|---|---|
+| `python3` | Required runtime and SQLite eval execution | System install |
+| Warehouse connector | Production execution through the approved Python driver or connector command | Operator configured |
+
+> 💡 **Tips & Tricks**
+>
+> Start with `schema --refresh` so generated SQL can be checked against cached
+> tables, columns, and keys.
+>
+> Use `review` before `query --execute`; the helper blocks mutating SQL unless
+> an explicit per-skill write grant is provided.
+>
+> Run `schedule-refresh` to register recurring schema-cache refreshes with the
+> HybridClaw gateway scheduler.
+
+> 🎯 **Try it yourself**
+>
+> `Plan SQL for the top customers by revenue`
+>
+> `Review this query before running it: SELECT c_name FROM customer LIMIT 10`
+>
+> `Refresh the schema cache for the analytics warehouse`
+>
+> `Run the TPC-H-style warehouse SQL eval scenarios`
+
+**Troubleshooting**
+
+- **No deterministic plan matched** — write or ask the model to draft SQL, then
+  pass it through `review` before execution.
+- **Production backend does not execute** — install the relevant Python driver
+  or set `HYBRIDCLAW_WAREHOUSE_SQL_<BACKEND>_COMMAND` to a connector command
+  that reads SQL on stdin and emits JSON or CSV rows.
+- **Write blocked** — mutating SQL requires `--allow-write`, `--write-grant`,
+  and a matching `HYBRIDCLAW_WAREHOUSE_SQL_WRITE_GRANT` set by the operator.
+
+---
+
 ## skill-creator
 
 Create and update `SKILL.md`-based skills with strong trigger metadata, lean

--- a/docs/content/guides/skills/development.md
+++ b/docs/content/guides/skills/development.md
@@ -274,6 +274,9 @@ offline SQL-generation coverage, not a TPC-H benchmark run.
 > Use `review` before `query --execute`; the helper blocks mutating SQL unless
 > an explicit per-skill write grant is provided.
 >
+> Pass `--model-review --question "<business question>"` when the helper should
+> invoke HybridClaw's OpenAI-compatible gateway for business-meaning review.
+>
 > Run `schedule-refresh` to register recurring schema-cache refreshes with the
 > HybridClaw gateway scheduler.
 

--- a/docs/content/guides/skills/development.md
+++ b/docs/content/guides/skills/development.md
@@ -256,6 +256,9 @@ reproducible TPC-H-style eval suite; Postgres, ClickHouse, BigQuery, and
 Snowflake can run through optional Python drivers or operator-approved
 connector commands.
 
+The bundled eval fixture is a tiny deterministic TPC-H-style dataset for
+offline SQL-generation coverage, not a TPC-H benchmark run.
+
 **Prerequisites**
 
 | Dependency | Purpose | Install |

--- a/skills/warehouse-sql/SKILL.md
+++ b/skills/warehouse-sql/SKILL.md
@@ -67,6 +67,11 @@ runtime or provide `--backend-command` / `HYBRIDCLAW_WAREHOUSE_SQL_<BACKEND>_COM
 Connector commands read SQL on stdin and emit a JSON row array, `{"rows": [...]}`
 or CSV with headers. Do not invent credentials.
 
+BigQuery schema introspection requires `--bigquery-dataset` or
+`HYBRIDCLAW_WAREHOUSE_SQL_BIGQUERY_DATASET`. Set
+`--bigquery-project` / `HYBRIDCLAW_WAREHOUSE_SQL_BIGQUERY_PROJECT` when the
+dataset is not in the default project.
+
 ## Schema Cache
 
 The helper writes schema cache files outside the repo by default at:
@@ -82,6 +87,10 @@ HybridClaw gateway scheduler:
 ```bash
 python3 skills/warehouse-sql/scripts/warehouse_sql.py --format json schedule-refresh --backend postgres --profile analytics --every "0 */6 * * *"
 ```
+
+Scheduled refreshes default to `last-channel` delivery. Use
+`--delivery-kind channel --delivery-to <channel-id>` only when the target
+channel id is known.
 
 Set `HYBRIDCLAW_GATEWAY_TOKEN` or `GATEWAY_API_TOKEN` in the environment for
 production scheduler registration. `--gateway-token` is supported for tests, but

--- a/skills/warehouse-sql/SKILL.md
+++ b/skills/warehouse-sql/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: warehouse-sql
+description: "Plan, review, and run read-only natural-language SQL against a customer data warehouse with cached schema introspection and explicit write grants."
+user-invocable: true
+requires:
+  bins:
+    - python3
+metadata:
+  hybridclaw:
+    category: development
+    short_description: "Natural-language SQL for warehouses."
+    tags:
+      - sql
+      - warehouse
+      - analytics
+      - postgres
+      - clickhouse
+      - bigquery
+      - snowflake
+---
+
+# Warehouse SQL
+
+Use this skill when the user asks natural-language questions of a data
+warehouse, analytics database, or TPC-H-style reporting dataset.
+
+## Scope
+
+- schema introspection for SQLite eval databases and pluggable Postgres,
+  ClickHouse, BigQuery, and Snowflake backends
+- cached schema summaries with explicit refresh commands for scheduled runs
+- natural-language SQL planning for reproducible TPC-H-style evaluation cases
+- deterministic SQL safety review before execution
+- read-only execution by default
+- write detection and explicit per-skill grant checks before any mutation
+
+## Default Workflow
+
+1. Refresh or read cached schema before planning SQL:
+   ```bash
+   python3 skills/warehouse-sql/scripts/warehouse_sql.py --format json schema --backend sqlite --database ./warehouse.db
+   ```
+2. Plan SQL from the user's question and inspect the generated SQL:
+   ```bash
+   python3 skills/warehouse-sql/scripts/warehouse_sql.py --format json plan "top customers by revenue"
+   ```
+3. Review SQL before execution:
+   ```bash
+   python3 skills/warehouse-sql/scripts/warehouse_sql.py --format json review "SELECT c_name FROM customer LIMIT 10"
+   ```
+4. Return the SQL to the user before execution when the user asks for review,
+   when the query is broad, or when the result could expose sensitive business
+   data.
+5. Execute only after the SQL review passes:
+   ```bash
+   python3 skills/warehouse-sql/scripts/warehouse_sql.py --format json query --backend sqlite --database ./warehouse.db --execute "SELECT c_name FROM customer LIMIT 10"
+   ```
+
+## Backend Contract
+
+Supported backend names:
+
+- `sqlite` — executable through Python stdlib; used by the bundled eval suite
+- `postgres` — `psycopg` / `psycopg2` driver, or a connector command
+- `clickhouse` — `clickhouse-connect` driver, or a connector command
+- `bigquery` — `google-cloud-bigquery` driver, or a connector command
+- `snowflake` — `snowflake-connector-python` driver, or a connector command
+
+For non-SQLite warehouses, install the backend driver package in the skill
+runtime or provide `--backend-command` / `HYBRIDCLAW_WAREHOUSE_SQL_<BACKEND>_COMMAND`.
+Connector commands read SQL on stdin and emit a JSON row array, `{"rows": [...]}`
+or CSV with headers. Do not invent credentials.
+
+## Schema Cache
+
+The helper writes schema cache files outside the repo by default at:
+
+```text
+~/.hybridclaw/warehouse-sql/schema-cache
+```
+
+Use `--cache-dir` for tests or customer-specific workspaces. Use `--refresh` to
+force re-introspection. Use `schedule-refresh` to register the refresh with the
+HybridClaw gateway scheduler:
+
+```bash
+python3 skills/warehouse-sql/scripts/warehouse_sql.py --format json schedule-refresh --backend postgres --profile analytics --every "0 */6 * * *"
+```
+
+## Read/Write Rules
+
+- Default posture is read-only. `SELECT`, `WITH`, and `EXPLAIN` are allowed.
+- Mutating SQL is blocked unless all of these are true:
+  - the user explicitly requested a write
+  - the command includes `--allow-write`
+  - the environment contains `HYBRIDCLAW_WAREHOUSE_SQL_WRITE_GRANT`
+  - `--write-grant` exactly matches that environment value
+- Do not set or reveal the write grant in chat. Treat it like an operator
+  capability, not a user-facing token.
+- Even with a write grant, explain the mutation and ask for confirmation before
+  running it unless the user already gave a concrete write instruction.
+
+## SQL Review Rules
+
+Before execution, check:
+
+- single statement only
+- read-only unless the explicit write grant path is used
+- selected columns are narrow enough for the task
+- `LIMIT` is present for exploratory row reads
+- joins use known keys from the schema cache
+- date and tenant filters are present when the question implies scope
+
+The helper emits a `review` object with safety status and findings. Treat that
+as a deterministic guardrail; still perform model review for business meaning.
+
+## Eval Suite
+
+Run the offline TPC-H-style scenarios:
+
+```bash
+python3 skills/warehouse-sql/scripts/warehouse_sql.py --format json eval-scenarios
+```
+
+The fixture at `evals/tpch_tiny.sql` contains a tiny public-schema-compatible
+dataset using TPC-H-style tables (`customer`, `orders`, `lineitem`, `supplier`,
+`part`, `nation`). The scenario file at `evals/tpch_scenarios.json` verifies
+planning, read-only review, and execution against deterministic answers.
+
+## Validation
+
+Run:
+
+```bash
+python3 skills/skill-creator/scripts/quick_validate.py skills/warehouse-sql
+python3 skills/warehouse-sql/scripts/warehouse_sql.py --help
+python3 skills/warehouse-sql/scripts/warehouse_sql.py --format json eval-scenarios
+```

--- a/skills/warehouse-sql/SKILL.md
+++ b/skills/warehouse-sql/SKILL.md
@@ -87,6 +87,10 @@ HybridClaw gateway scheduler:
 python3 skills/warehouse-sql/scripts/warehouse_sql.py --format json schedule-refresh --backend postgres --profile analytics --every "0 */6 * * *"
 ```
 
+Set `HYBRIDCLAW_GATEWAY_TOKEN` or `GATEWAY_API_TOKEN` in the environment for
+production scheduler registration. `--gateway-token` is supported for tests, but
+tokens passed as CLI arguments can be visible in process listings.
+
 ## Read/Write Rules
 
 - Default posture is read-only. `SELECT`, `WITH`, and `EXPLAIN` are allowed.

--- a/skills/warehouse-sql/SKILL.md
+++ b/skills/warehouse-sql/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: warehouse-sql
-description: "Plan, review, and run read-only natural-language SQL against a customer data warehouse with cached schema introspection and explicit write grants."
+description: "Review and run read-only natural-language SQL against a customer data warehouse with cached schema introspection and explicit write grants."
 user-invocable: true
 requires:
   bins:
@@ -29,29 +29,25 @@ warehouse, analytics database, or TPC-H-style reporting dataset.
 - schema introspection for SQLite eval databases and pluggable Postgres,
   ClickHouse, BigQuery, and Snowflake backends
 - cached schema summaries with explicit refresh commands for scheduled runs
-- natural-language SQL planning for reproducible TPC-H-style evaluation cases
+- reproducible TPC-H-style evaluation cases for generated SQL
 - deterministic SQL safety review before execution
 - read-only execution by default
 - write detection and explicit per-skill grant checks before any mutation
 
 ## Default Workflow
 
-1. Refresh or read cached schema before planning SQL:
+1. Refresh or read cached schema before asking the model to draft SQL:
    ```bash
    python3 skills/warehouse-sql/scripts/warehouse_sql.py --format json schema --backend sqlite --database ./warehouse.db
    ```
-2. Plan SQL from the user's question and inspect the generated SQL:
-   ```bash
-   python3 skills/warehouse-sql/scripts/warehouse_sql.py --format json plan "top customers by revenue"
-   ```
-3. Review SQL before execution:
+2. Have the model draft SQL using the cached schema, then review it before execution:
    ```bash
    python3 skills/warehouse-sql/scripts/warehouse_sql.py --format json review "SELECT c_name FROM customer LIMIT 10"
    ```
-4. Return the SQL to the user before execution when the user asks for review,
+3. Return the SQL to the user before execution when the user asks for review,
    when the query is broad, or when the result could expose sensitive business
    data.
-5. Execute only after the SQL review passes:
+4. Execute only after the SQL review passes:
    ```bash
    python3 skills/warehouse-sql/scripts/warehouse_sql.py --format json query --backend sqlite --database ./warehouse.db --execute "SELECT c_name FROM customer LIMIT 10"
    ```
@@ -61,7 +57,7 @@ warehouse, analytics database, or TPC-H-style reporting dataset.
 Supported backend names:
 
 - `sqlite` — executable through Python stdlib; used by the bundled eval suite
-- `postgres` — `psycopg` / `psycopg2` driver, or a connector command
+- `postgres` — `psycopg` driver, or a connector command
 - `clickhouse` — `clickhouse-connect` driver, or a connector command
 - `bigquery` — `google-cloud-bigquery` driver, or a connector command
 - `snowflake` — `snowflake-connector-python` driver, or a connector command
@@ -129,7 +125,7 @@ python3 skills/warehouse-sql/scripts/warehouse_sql.py --format json eval-scenari
 The fixture at `evals/tpch_tiny.sql` contains a tiny public-schema-compatible
 dataset using TPC-H-style tables (`customer`, `orders`, `lineitem`, `supplier`,
 `part`, `nation`). The scenario file at `evals/tpch_scenarios.json` verifies
-planning, read-only review, and execution against deterministic answers.
+read-only review and execution against deterministic answers.
 
 ## Validation
 

--- a/skills/warehouse-sql/SKILL.md
+++ b/skills/warehouse-sql/SKILL.md
@@ -133,8 +133,10 @@ python3 skills/warehouse-sql/scripts/warehouse_sql.py --format json eval-scenari
 
 The fixture at `evals/tpch_tiny.sql` contains a tiny public-schema-compatible
 dataset using TPC-H-style tables (`customer`, `orders`, `lineitem`, `supplier`,
-`part`, `nation`). The scenario file at `evals/tpch_scenarios.json` verifies
-read-only review and execution against deterministic answers.
+`part`, `nation`). It is an offline deterministic fixture for SQL generation
+coverage, not a TPC-H benchmark run. The scenario file at
+`evals/tpch_scenarios.json` verifies read-only review and execution against
+deterministic answers.
 
 ## Validation
 

--- a/skills/warehouse-sql/SKILL.md
+++ b/skills/warehouse-sql/SKILL.md
@@ -44,6 +44,11 @@ warehouse, analytics database, or TPC-H-style reporting dataset.
    ```bash
    python3 skills/warehouse-sql/scripts/warehouse_sql.py --format json review "SELECT c_name FROM customer LIMIT 10"
    ```
+   To make the helper invoke HybridClaw's OpenAI-compatible gateway for the
+   business-meaning review, pass `--model-review` with the original question:
+   ```bash
+   python3 skills/warehouse-sql/scripts/warehouse_sql.py --format json review --model-review --question "Show the first 10 customers" "SELECT c_name FROM customer LIMIT 10"
+   ```
 3. Return the SQL to the user before execution when the user asks for review,
    when the query is broad, or when the result could expose sensitive business
    data.
@@ -121,7 +126,17 @@ Before execution, check:
 - date and tenant filters are present when the question implies scope
 
 The helper emits a `review` object with safety status and findings. Treat that
-as a deterministic guardrail; still perform model review for business meaning.
+as a deterministic guardrail. Pass `--model-review` on `review` or `query` to
+have the helper invoke the configured OpenAI-compatible model endpoint and add
+that verdict to `review.modelReview`; execution is blocked unless both the
+deterministic guardrail and requested model review pass.
+
+Model review defaults to `HYBRIDCLAW_GATEWAY_URL` / `GATEWAY_BASE_URL` plus
+`/v1/chat/completions`, with authentication from
+`HYBRIDCLAW_WAREHOUSE_SQL_MODEL_REVIEW_TOKEN`, `HYBRIDCLAW_GATEWAY_TOKEN`, or
+`GATEWAY_API_TOKEN`. Use `--model-review-url`, `--model-review-model`,
+`--schema-cache`, and `--question` to make the review explicit in tests or
+operator workflows.
 
 ## Eval Suite
 

--- a/skills/warehouse-sql/evals/tpch_eval_planner.py
+++ b/skills/warehouse-sql/evals/tpch_eval_planner.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+DEFAULT_MAX_ROWS = 200
+
+
+def normalize_question(question: str) -> str:
+    return re.sub(r"\s+", " ", question.strip().lower())
+
+
+def extract_customer_name(question: str) -> str | None:
+    match = re.search(r"customer#\d+", question, flags=re.I)
+    return match.group(0) if match else None
+
+
+def plan_eval_sql(question: str, *, limit: int = 10) -> dict[str, Any]:
+    q = normalize_question(question)
+    customer = extract_customer_name(question)
+    capped_limit = max(1, min(limit, DEFAULT_MAX_ROWS))
+    parameters: list[Any] = []
+
+    if "top customer" in q and "revenue" in q:
+        sql = f"""
+SELECT c.c_name, ROUND(SUM(l.l_extendedprice * (1 - l.l_discount)), 2) AS revenue
+FROM customer c
+JOIN orders o ON o.o_custkey = c.c_custkey
+JOIN lineitem l ON l.l_orderkey = o.o_orderkey
+GROUP BY c.c_name
+ORDER BY revenue DESC
+LIMIT {capped_limit}
+""".strip()
+    elif "revenue by nation" in q:
+        sql = f"""
+SELECT n.n_name, ROUND(SUM(l.l_extendedprice * (1 - l.l_discount)), 2) AS revenue
+FROM nation n
+JOIN customer c ON c.c_nationkey = n.n_nationkey
+JOIN orders o ON o.o_custkey = c.c_custkey
+JOIN lineitem l ON l.l_orderkey = o.o_orderkey
+GROUP BY n.n_name
+ORDER BY revenue DESC
+LIMIT {capped_limit}
+""".strip()
+    elif "late shipment" in q:
+        sql = f"""
+SELECT l_orderkey, l_partkey, l_suppkey, l_commitdate, l_receiptdate
+FROM lineitem
+WHERE l_receiptdate > l_commitdate
+ORDER BY l_receiptdate
+LIMIT {capped_limit}
+""".strip()
+    elif "open order" in q and "status" in q:
+        sql = """
+SELECT o_orderstatus, COUNT(*) AS order_count
+FROM orders
+WHERE o_orderstatus = 'O'
+GROUP BY o_orderstatus
+ORDER BY order_count DESC, o_orderstatus
+LIMIT 10
+""".strip()
+    elif customer and "order" in q:
+        parameters = [customer]
+        sql = f"""
+SELECT o.o_orderkey, o.o_orderdate, o.o_orderstatus, o.o_totalprice
+FROM orders o
+JOIN customer c ON c.c_custkey = o.o_custkey
+WHERE c.c_name = ?
+ORDER BY o.o_orderdate
+LIMIT {capped_limit}
+""".strip()
+    elif "discount" in q and "brand" in q:
+        sql = """
+SELECT p.p_brand, ROUND(AVG(l.l_discount), 4) AS avg_discount
+FROM part p
+JOIN lineitem l ON l.l_partkey = p.p_partkey
+GROUP BY p.p_brand
+ORDER BY p.p_brand
+LIMIT 10
+""".strip()
+    elif "supplier" in q and "revenue" in q:
+        sql = f"""
+SELECT s.s_name, ROUND(SUM(l.l_extendedprice * (1 - l.l_discount)), 2) AS revenue
+FROM supplier s
+JOIN lineitem l ON l.l_suppkey = s.s_suppkey
+GROUP BY s.s_name
+ORDER BY revenue DESC
+LIMIT {capped_limit}
+""".strip()
+    elif "customer count" in q and ("segment" in q or "market" in q):
+        sql = """
+SELECT c_mktsegment, COUNT(*) AS customer_count
+FROM customer
+GROUP BY c_mktsegment
+ORDER BY customer_count DESC, c_mktsegment
+LIMIT 10
+""".strip()
+    elif "part" in q and "brand" in q:
+        sql = """
+SELECT p_brand, COUNT(*) AS part_count
+FROM part
+GROUP BY p_brand
+ORDER BY part_count DESC, p_brand
+LIMIT 10
+""".strip()
+    elif "daily" in q and "order" in q:
+        sql = """
+SELECT o_orderdate, ROUND(SUM(o_totalprice), 2) AS order_total
+FROM orders
+GROUP BY o_orderdate
+ORDER BY o_orderdate
+LIMIT 50
+""".strip()
+    elif "revenue" in q and "march" in q and "1995" in q:
+        sql = """
+SELECT ROUND(SUM(l.l_extendedprice * (1 - l.l_discount)), 2) AS revenue
+FROM orders o
+JOIN lineitem l ON l.l_orderkey = o.o_orderkey
+WHERE o.o_orderdate >= '1995-03-01'
+  AND o.o_orderdate < '1995-04-01'
+""".strip()
+    elif "largest order" in q:
+        sql = f"""
+SELECT o_orderkey, o_orderdate, o_totalprice
+FROM orders
+ORDER BY o_totalprice DESC
+LIMIT {capped_limit}
+""".strip()
+    else:
+        raise ValueError(f"No TPC-H eval SQL matched question: {question}")
+
+    return {"sql": sql, "parameters": parameters}

--- a/skills/warehouse-sql/evals/tpch_scenarios.json
+++ b/skills/warehouse-sql/evals/tpch_scenarios.json
@@ -31,7 +31,7 @@
     "id": "orders-for-customer",
     "category": "orders",
     "question": "orders for Customer#000000101",
-    "expectedSqlContains": ["Customer#000000101", "o_orderdate"],
+    "expectedSqlContains": ["WHERE c.c_name = ?", "o_orderdate"],
     "expectedRowCount": 2
   },
   {

--- a/skills/warehouse-sql/evals/tpch_scenarios.json
+++ b/skills/warehouse-sql/evals/tpch_scenarios.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "top-customers-revenue",
+    "category": "revenue",
+    "question": "top customers by revenue",
+    "expectedSqlContains": ["customer", "orders", "lineitem", "revenue"],
+    "expectedFirstValue": "Customer#000000101"
+  },
+  {
+    "id": "revenue-by-nation",
+    "category": "revenue",
+    "question": "revenue by nation",
+    "expectedSqlContains": ["nation", "revenue", "GROUP BY"],
+    "expectedFirstValue": "GERMANY"
+  },
+  {
+    "id": "late-shipments",
+    "category": "operations",
+    "question": "late shipments",
+    "expectedSqlContains": ["l_receiptdate", "l_commitdate"],
+    "expectedRowCount": 3
+  },
+  {
+    "id": "open-orders-status",
+    "category": "orders",
+    "question": "open orders by status",
+    "expectedSqlContains": ["orders", "o_orderstatus", "COUNT"],
+    "expectedFirstValue": "O"
+  },
+  {
+    "id": "orders-for-customer",
+    "category": "orders",
+    "question": "orders for Customer#000000101",
+    "expectedSqlContains": ["Customer#000000101", "o_orderdate"],
+    "expectedRowCount": 2
+  },
+  {
+    "id": "discount-by-brand",
+    "category": "pricing",
+    "question": "average discount by part brand",
+    "expectedSqlContains": ["p_brand", "AVG"],
+    "expectedFirstValue": "Brand#11"
+  },
+  {
+    "id": "supplier-revenue",
+    "category": "supplier",
+    "question": "supplier revenue",
+    "expectedSqlContains": ["supplier", "revenue"],
+    "expectedFirstValue": "Supplier#000000201"
+  },
+  {
+    "id": "customer-count-by-segment",
+    "category": "customers",
+    "question": "customer count by market segment",
+    "expectedSqlContains": ["c_mktsegment", "COUNT"],
+    "expectedRowCount": 3
+  },
+  {
+    "id": "parts-by-brand",
+    "category": "parts",
+    "question": "parts by brand",
+    "expectedSqlContains": ["part", "p_brand", "COUNT"],
+    "expectedFirstValue": "Brand#11"
+  },
+  {
+    "id": "daily-order-totals",
+    "category": "orders",
+    "question": "daily order totals",
+    "expectedSqlContains": ["o_orderdate", "SUM"],
+    "expectedRowCount": 4
+  },
+  {
+    "id": "revenue-in-march",
+    "category": "revenue",
+    "question": "revenue in March 1995",
+    "expectedSqlContains": ["1995-03-01", "1995-04-01", "revenue"],
+    "expectedFirstValue": 2060.0
+  },
+  {
+    "id": "largest-orders",
+    "category": "orders",
+    "question": "largest orders",
+    "expectedSqlContains": ["o_totalprice", "ORDER BY"],
+    "expectedFirstValue": 401
+  }
+]

--- a/skills/warehouse-sql/evals/tpch_tiny.sql
+++ b/skills/warehouse-sql/evals/tpch_tiny.sql
@@ -1,0 +1,80 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE nation (
+  n_nationkey INTEGER PRIMARY KEY,
+  n_name TEXT NOT NULL,
+  n_region TEXT NOT NULL
+);
+
+CREATE TABLE customer (
+  c_custkey INTEGER PRIMARY KEY,
+  c_name TEXT NOT NULL,
+  c_nationkey INTEGER NOT NULL REFERENCES nation(n_nationkey),
+  c_mktsegment TEXT NOT NULL
+);
+
+CREATE TABLE supplier (
+  s_suppkey INTEGER PRIMARY KEY,
+  s_name TEXT NOT NULL,
+  s_nationkey INTEGER NOT NULL REFERENCES nation(n_nationkey)
+);
+
+CREATE TABLE part (
+  p_partkey INTEGER PRIMARY KEY,
+  p_name TEXT NOT NULL,
+  p_brand TEXT NOT NULL,
+  p_type TEXT NOT NULL
+);
+
+CREATE TABLE orders (
+  o_orderkey INTEGER PRIMARY KEY,
+  o_custkey INTEGER NOT NULL REFERENCES customer(c_custkey),
+  o_orderstatus TEXT NOT NULL,
+  o_totalprice REAL NOT NULL,
+  o_orderdate TEXT NOT NULL
+);
+
+CREATE TABLE lineitem (
+  l_orderkey INTEGER NOT NULL REFERENCES orders(o_orderkey),
+  l_partkey INTEGER NOT NULL REFERENCES part(p_partkey),
+  l_suppkey INTEGER NOT NULL REFERENCES supplier(s_suppkey),
+  l_quantity REAL NOT NULL,
+  l_extendedprice REAL NOT NULL,
+  l_discount REAL NOT NULL,
+  l_shipdate TEXT NOT NULL,
+  l_commitdate TEXT NOT NULL,
+  l_receiptdate TEXT NOT NULL
+);
+
+INSERT INTO nation VALUES
+  (1, 'GERMANY', 'EUROPE'),
+  (2, 'FRANCE', 'EUROPE'),
+  (3, 'UNITED STATES', 'AMERICA');
+
+INSERT INTO customer VALUES
+  (101, 'Customer#000000101', 1, 'AUTOMOBILE'),
+  (102, 'Customer#000000102', 2, 'BUILDING'),
+  (103, 'Customer#000000103', 3, 'MACHINERY');
+
+INSERT INTO supplier VALUES
+  (201, 'Supplier#000000201', 1),
+  (202, 'Supplier#000000202', 2),
+  (203, 'Supplier#000000203', 3);
+
+INSERT INTO part VALUES
+  (301, 'green widget', 'Brand#11', 'ECONOMY ANODIZED STEEL'),
+  (302, 'blue bolt', 'Brand#22', 'STANDARD POLISHED COPPER'),
+  (303, 'red gear', 'Brand#11', 'PROMO BRUSHED TIN');
+
+INSERT INTO orders VALUES
+  (401, 101, 'O', 1200.00, '1995-03-10'),
+  (402, 102, 'F', 900.00, '1995-03-12'),
+  (403, 101, 'F', 700.00, '1995-04-01'),
+  (404, 103, 'O', 400.00, '1995-04-20');
+
+INSERT INTO lineitem VALUES
+  (401, 301, 201, 5, 1000.00, 0.05, '1995-03-14', '1995-03-13', '1995-03-16'),
+  (401, 302, 202, 2, 300.00, 0.00, '1995-03-15', '1995-03-17', '1995-03-16'),
+  (402, 302, 202, 4, 900.00, 0.10, '1995-03-20', '1995-03-19', '1995-03-22'),
+  (403, 303, 201, 1, 700.00, 0.00, '1995-04-05', '1995-04-07', '1995-04-06'),
+  (404, 301, 203, 2, 400.00, 0.05, '1995-04-25', '1995-04-24', '1995-04-26');

--- a/skills/warehouse-sql/references/backend-contract.md
+++ b/skills/warehouse-sql/references/backend-contract.md
@@ -19,7 +19,7 @@ optional Python drivers or an operator-provided connector command.
       "columns": [
         {"name": "o_orderkey", "type": "INTEGER", "nullable": false}
       ],
-      "primaryKeys": ["o_orderkey"],
+      "primaryKeys": [],
       "foreignKeys": [
         {
           "columns": ["o_custkey"],
@@ -44,8 +44,11 @@ The command emits backend-specific introspection SQL for:
 
 - table and view discovery
 - column names/types/nullability
-- primary keys where the backend exposes them through information schema
 - foreign keys where the backend exposes them through information schema
+
+`primaryKeys` is always present in the cache shape, but may be empty for
+non-SQLite backends. Consumers should not require primary-key metadata for
+warehouse backends.
 
 ## Connector Command Protocol
 

--- a/skills/warehouse-sql/references/backend-contract.md
+++ b/skills/warehouse-sql/references/backend-contract.md
@@ -1,0 +1,61 @@
+# Warehouse SQL Backend Contract
+
+The `warehouse-sql` helper owns schema-cache format, SQL safety review, evals,
+and execution dispatch. SQLite uses Python stdlib. Production warehouses use
+optional Python drivers or an operator-provided connector command.
+
+## Cache Shape
+
+```json
+{
+  "cacheVersion": 1,
+  "backend": "postgres",
+  "profile": "analytics",
+  "refreshedAt": "2026-04-29T10:30:00Z",
+  "tables": [
+    {
+      "name": "orders",
+      "schema": "public",
+      "columns": [
+        {"name": "o_orderkey", "type": "INTEGER", "nullable": false}
+      ],
+      "primaryKeys": ["o_orderkey"],
+      "foreignKeys": [
+        {
+          "columns": ["o_custkey"],
+          "referencesTable": "customer",
+          "referencesColumns": ["c_custkey"]
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Introspection Queries
+
+Use:
+
+```bash
+python3 skills/warehouse-sql/scripts/warehouse_sql.py --format json backend-contract --backend postgres
+```
+
+The command emits backend-specific introspection SQL for:
+
+- table and view discovery
+- column names/types/nullability
+- primary keys where the backend exposes them through information schema
+- foreign keys where the backend exposes them through information schema
+
+## Connector Command Protocol
+
+Set `HYBRIDCLAW_WAREHOUSE_SQL_<BACKEND>_COMMAND` or pass `--backend-command`.
+The command receives SQL on stdin and in `WAREHOUSE_SQL_QUERY`, then emits one
+of:
+
+- a JSON row array
+- an object with `rows: [...]`
+- CSV with headers
+
+This lets operators route execution through existing secret stores and network
+policy without exposing credentials to the agent context.

--- a/skills/warehouse-sql/scripts/warehouse_sql.py
+++ b/skills/warehouse-sql/scripts/warehouse_sql.py
@@ -628,7 +628,7 @@ def write_private_json(path: Path, payload: dict[str, Any]) -> None:
     fd = os.open(tmp_path, flags, 0o600)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            json.dump(payload, handle, indent=2, sort_keys=True)
+            json.dump(payload, handle, separators=(",", ":"), sort_keys=True)
             handle.write("\n")
         os.chmod(tmp_path, 0o600)
         os.replace(tmp_path, path)

--- a/skills/warehouse-sql/scripts/warehouse_sql.py
+++ b/skills/warehouse-sql/scripts/warehouse_sql.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import hmac
 import hashlib
 import io
 import json
@@ -33,6 +34,15 @@ DEFAULT_CACHE_TTL_SECONDS = 6 * 60 * 60
 DEFAULT_MAX_ROWS = 200
 WRITE_GRANT_ENV = "HYBRIDCLAW_WAREHOUSE_SQL_WRITE_GRANT"
 DEFAULT_GATEWAY_URL = "http://127.0.0.1:9090"
+CONNECTOR_ENV_PASSTHROUGH = {
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "PATH",
+    "REQUESTS_CA_BUNDLE",
+    "SSL_CERT_FILE",
+    "TMPDIR",
+}
 
 SKILL_DIR = Path(__file__).resolve().parent.parent
 EVAL_SCENARIOS_PATH = SKILL_DIR / "evals" / "tpch_scenarios.json"
@@ -173,6 +183,12 @@ class ReviewResult:
     requires_write_grant: bool
 
 
+@dataclass
+class SqlPlan:
+    sql: str
+    parameters: list[Any]
+
+
 def utc_now() -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
 
@@ -232,6 +248,29 @@ def resolve_backend_command(args: argparse.Namespace) -> str:
     return os.environ.get(backend_command_env_name(args.backend), "").strip()
 
 
+def connector_command_env(args: argparse.Namespace, sql: str) -> dict[str, str]:
+    backend_prefix = f"HYBRIDCLAW_WAREHOUSE_SQL_{args.backend.upper().replace('-', '_')}_"
+    env: dict[str, str] = {}
+    for name in CONNECTOR_ENV_PASSTHROUGH:
+        value = os.environ.get(name)
+        if value is not None:
+            env[name] = value
+    for name, value in os.environ.items():
+        if not name.startswith(backend_prefix):
+            continue
+        if name in {WRITE_GRANT_ENV, backend_command_env_name(args.backend)}:
+            continue
+        env[name] = value
+    env.update(
+        {
+            "WAREHOUSE_SQL_BACKEND": args.backend,
+            "WAREHOUSE_SQL_PROFILE": str(getattr(args, "profile", "default") or "default"),
+            "WAREHOUSE_SQL_QUERY": sql,
+        }
+    )
+    return env
+
+
 def parse_rows_payload(raw: str) -> list[dict[str, Any]]:
     text = raw.strip()
     if not text:
@@ -259,12 +298,7 @@ def run_backend_command(args: argparse.Namespace, sql: str) -> list[dict[str, An
         raise WarehouseSqlError(
             f"{args.backend} requires {backend_command_env_name(args.backend)} or --backend-command, or an installed Python driver with the required environment."
         )
-    env = {
-        **os.environ,
-        "WAREHOUSE_SQL_BACKEND": args.backend,
-        "WAREHOUSE_SQL_PROFILE": str(getattr(args, "profile", "default") or "default"),
-        "WAREHOUSE_SQL_QUERY": sql,
-    }
+    env = connector_command_env(args, sql)
     try:
         result = subprocess.run(
             shlex.split(command),
@@ -574,6 +608,30 @@ def quote_identifier(identifier: str) -> str:
     return '"' + identifier.replace('"', '""') + '"'
 
 
+def write_private_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f".{path.name}.tmp-{os.getpid()}-{int(time.time() * 1000)}")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    fd = os.open(tmp_path, flags, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, path)
+        os.chmod(path, 0o600)
+    except Exception:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        raise
+
+
 def load_or_refresh_schema(args: argparse.Namespace) -> dict[str, Any]:
     ensure_backend(args.backend)
     cache_dir = Path(args.cache_dir).expanduser() if args.cache_dir else default_cache_dir()
@@ -602,7 +660,7 @@ def load_or_refresh_schema(args: argparse.Namespace) -> dict[str, Any]:
         payload["introspection"] = BACKEND_INTROSPECTION_SQL[args.backend]
         payload["adapter"] = "command" if resolve_backend_command(args) else "python-driver"
 
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_private_json(path, payload)
     payload["cache"] = {
         "status": "refresh" if args.refresh else "miss",
         "path": str(path),
@@ -651,6 +709,12 @@ def first_keyword(statement: str) -> str:
     return match.group(0).lower() if match else ""
 
 
+def write_grant_matches(write_grant: str | None, expected_grant: str) -> bool:
+    if not write_grant or not expected_grant:
+        return False
+    return hmac.compare_digest(write_grant, expected_grant)
+
+
 def review_sql(
     sql: str,
     *,
@@ -692,10 +756,10 @@ def review_sql(
             findings.append(f"Write SQL requires {WRITE_GRANT_ENV} to be set.")
         if not write_grant:
             findings.append("Write SQL requires --write-grant.")
-        elif expected_grant and write_grant != expected_grant:
+        elif expected_grant and not write_grant_matches(write_grant, expected_grant):
             findings.append("Provided write grant does not match the per-skill grant.")
 
-    status = "pass" if (read_only or (requires_write_grant and allow_write and write_grant and write_grant == os.environ.get(WRITE_GRANT_ENV, ""))) and len(statements) == 1 else "block"
+    status = "pass" if (read_only or (requires_write_grant and allow_write and write_grant_matches(write_grant, os.environ.get(WRITE_GRANT_ENV, "")))) and len(statements) == 1 else "block"
     return ReviewResult(
         status=status,
         read_only=read_only,
@@ -744,6 +808,7 @@ def plan_sql(question: str, *, limit: int = 10) -> dict[str, Any]:
     q = normalize_question(question)
     customer = extract_customer_name(question)
     capped_limit = max(1, min(limit, DEFAULT_MAX_ROWS))
+    parameters: list[Any] = []
 
     if "top customer" in q and "revenue" in q:
         sql = f"""
@@ -784,11 +849,12 @@ ORDER BY order_count DESC, o_orderstatus
 LIMIT 10
 """.strip()
     elif customer and "order" in q:
+        parameters = [customer]
         sql = f"""
 SELECT o.o_orderkey, o.o_orderdate, o.o_orderstatus, o.o_totalprice
 FROM orders o
 JOIN customer c ON c.c_custkey = o.o_custkey
-WHERE c.c_name = '{escape_sql_literal(customer)}'
+WHERE c.c_name = ?
 ORDER BY o.o_orderdate
 LIMIT {capped_limit}
 """.strip()
@@ -860,13 +926,10 @@ LIMIT {capped_limit}
         "question": question,
         "dialect": "ansi-sql",
         "sql": sql,
+        "parameters": parameters,
         "review": review["review"],
         "schemaAssumption": "TPC-H-style customer/orders/lineitem/supplier/part/nation schema",
     }
-
-
-def escape_sql_literal(value: str) -> str:
-    return value.replace("'", "''")
 
 
 def execute_sqlite_query(
@@ -874,6 +937,7 @@ def execute_sqlite_query(
     sql: str,
     *,
     max_rows: int,
+    parameters: list[Any] | None = None,
     allow_write: bool = False,
     write_grant: str | None = None,
 ) -> dict[str, Any]:
@@ -881,7 +945,7 @@ def execute_sqlite_query(
     if result.status != "pass":
         raise WarehouseSqlError("SQL review blocked execution: " + "; ".join(result.findings))
     with connect_sqlite(database) as conn:
-        cursor = conn.execute(sql)
+        cursor = conn.execute(sql, parameters or [])
         if not result.read_only:
             conn.commit()
             return {
@@ -964,7 +1028,12 @@ def run_eval_scenarios() -> dict[str, Any]:
                 for expected in scenario.get("expectedSqlContains", []):
                     if str(expected).lower() not in sql.lower():
                         case_result["findings"].append(f"SQL missing expected token: {expected}")
-                query_result = execute_sqlite_query(database, sql, max_rows=DEFAULT_MAX_ROWS)
+                query_result = execute_sqlite_query(
+                    database,
+                    sql,
+                    max_rows=DEFAULT_MAX_ROWS,
+                    parameters=plan.get("parameters", []),
+                )
                 if "expectedRowCount" in scenario and query_result["rowCount"] != scenario["expectedRowCount"]:
                     case_result["findings"].append(
                         f"row count {query_result['rowCount']} != {scenario['expectedRowCount']}"
@@ -1165,10 +1234,14 @@ def handle_query(args: argparse.Namespace) -> Any:
         }
         return payload
     if args.backend == "sqlite":
+        parameters = json.loads(args.params) if args.params else []
+        if not isinstance(parameters, list):
+            raise WarehouseSqlError("--params must be a JSON array.")
         result = execute_sqlite_query(
             args.database,
             args.sql,
             max_rows=args.max_rows,
+            parameters=parameters,
             allow_write=args.allow_write,
             write_grant=args.write_grant,
         )
@@ -1250,6 +1323,7 @@ def build_parser() -> argparse.ArgumentParser:
     query.add_argument("--profile", default="default")
     query.add_argument("--backend-command", help="Executable connector command that reads SQL on stdin and emits JSON/CSV rows.")
     query.add_argument("--timeout-seconds", type=int, default=60)
+    query.add_argument("--params", help="JSON array of SQLite parameters for positional placeholders.")
     query.add_argument("--allow-write", action="store_true")
     query.add_argument("--write-grant")
     query.add_argument("sql")

--- a/skills/warehouse-sql/scripts/warehouse_sql.py
+++ b/skills/warehouse-sql/scripts/warehouse_sql.py
@@ -414,11 +414,13 @@ def run_backend_sql(args: argparse.Namespace, sql: str) -> list[dict[str, Any]]:
 
 
 def row_text(row: dict[str, Any], *keys: str) -> str:
-    lower = {str(key).lower(): value for key, value in row.items()}
     for key in keys:
         value = row.get(key)
-        if value is None:
-            value = lower.get(key.lower())
+        if value is not None:
+            return str(value)
+    lower = {str(key).lower(): value for key, value in row.items()}
+    for key in keys:
+        value = lower.get(key.lower())
         if value is not None:
             return str(value)
     return ""
@@ -524,6 +526,10 @@ def sqlite_schema(database: str) -> dict[str, Any]:
         ).fetchall()
         for table_row in table_rows:
             table_name = table_row["name"]
+            table_info_rows = [
+                dict(row)
+                for row in conn.execute(f"PRAGMA table_info({quote_identifier(table_name)})")
+            ]
             columns = [
                 {
                     "name": row["name"],
@@ -532,14 +538,11 @@ def sqlite_schema(database: str) -> dict[str, Any]:
                     "default": row["dflt_value"],
                     "ordinal": row["cid"] + 1,
                 }
-                for row in conn.execute(f"PRAGMA table_info({quote_identifier(table_name)})")
+                for row in table_info_rows
             ]
             primary_keys = [
                 column["name"]
-                for column in sorted(
-                    [dict(row) for row in conn.execute(f"PRAGMA table_info({quote_identifier(table_name)})")],
-                    key=lambda row: row["pk"],
-                )
+                for column in sorted(table_info_rows, key=lambda row: row["pk"])
                 if column["pk"]
             ]
             foreign_keys = [

--- a/skills/warehouse-sql/scripts/warehouse_sql.py
+++ b/skills/warehouse-sql/scripts/warehouse_sql.py
@@ -1,0 +1,1277 @@
+#!/usr/bin/env python3
+# ruff: noqa: INP001
+"""Natural-language warehouse SQL helper.
+
+The helper owns deterministic planning for the bundled TPC-H-style eval suite,
+schema-cache management, SQL safety review, and SQLite execution for
+reproducible tests. Production warehouses should execute through an operator
+approved CLI, MCP server, or gateway integration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+import os
+import re
+import shlex
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib import error, request
+
+CACHE_VERSION = 1
+DEFAULT_CACHE_TTL_SECONDS = 6 * 60 * 60
+DEFAULT_MAX_ROWS = 200
+WRITE_GRANT_ENV = "HYBRIDCLAW_WAREHOUSE_SQL_WRITE_GRANT"
+DEFAULT_GATEWAY_URL = "http://127.0.0.1:9090"
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+EVAL_SCENARIOS_PATH = SKILL_DIR / "evals" / "tpch_scenarios.json"
+TPC_H_FIXTURE_PATH = SKILL_DIR / "evals" / "tpch_tiny.sql"
+
+BACKENDS = {"sqlite", "postgres", "clickhouse", "bigquery", "snowflake"}
+READ_ONLY_STARTERS = {"select", "with", "explain"}
+MUTATING_KEYWORDS = {
+    "alter",
+    "attach",
+    "call",
+    "copy",
+    "create",
+    "delete",
+    "detach",
+    "drop",
+    "execute",
+    "grant",
+    "insert",
+    "load",
+    "merge",
+    "put",
+    "remove",
+    "replace",
+    "revoke",
+    "truncate",
+    "update",
+    "vacuum",
+}
+
+BACKEND_INTROSPECTION_SQL: dict[str, dict[str, str]] = {
+    "postgres": {
+        "tables": """
+SELECT table_schema, table_name, table_type
+FROM information_schema.tables
+WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
+ORDER BY table_schema, table_name;
+""".strip(),
+        "columns": """
+SELECT table_schema, table_name, column_name, data_type, is_nullable, ordinal_position
+FROM information_schema.columns
+WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
+ORDER BY table_schema, table_name, ordinal_position;
+""".strip(),
+        "foreignKeys": """
+SELECT tc.table_schema, tc.table_name, kcu.column_name,
+       ccu.table_schema AS references_schema,
+       ccu.table_name AS references_table,
+       ccu.column_name AS references_column
+FROM information_schema.table_constraints tc
+JOIN information_schema.key_column_usage kcu
+  ON tc.constraint_name = kcu.constraint_name
+ AND tc.table_schema = kcu.table_schema
+JOIN information_schema.constraint_column_usage ccu
+  ON ccu.constraint_name = tc.constraint_name
+ AND ccu.table_schema = tc.table_schema
+WHERE tc.constraint_type = 'FOREIGN KEY'
+ORDER BY tc.table_schema, tc.table_name, kcu.ordinal_position;
+""".strip(),
+    },
+    "clickhouse": {
+        "tables": """
+SELECT database AS table_schema, name AS table_name, engine AS table_type
+FROM system.tables
+WHERE database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')
+ORDER BY database, name;
+""".strip(),
+        "columns": """
+SELECT database AS table_schema, table AS table_name, name AS column_name,
+       type AS data_type, position AS ordinal_position
+FROM system.columns
+WHERE database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')
+ORDER BY database, table, position;
+""".strip(),
+        "foreignKeys": "ClickHouse does not expose relational foreign keys in system tables.",
+    },
+    "bigquery": {
+        "tables": """
+SELECT table_catalog, table_schema, table_name, table_type
+FROM `<project>.<dataset>.INFORMATION_SCHEMA.TABLES`
+ORDER BY table_schema, table_name;
+""".strip(),
+        "columns": """
+SELECT table_schema, table_name, column_name, data_type, is_nullable, ordinal_position
+FROM `<project>.<dataset>.INFORMATION_SCHEMA.COLUMNS`
+ORDER BY table_schema, table_name, ordinal_position;
+""".strip(),
+        "foreignKeys": "BigQuery key constraints are dataset-specific; inspect INFORMATION_SCHEMA.TABLE_CONSTRAINTS when enabled.",
+    },
+    "snowflake": {
+        "tables": """
+SELECT table_schema, table_name, table_type
+FROM information_schema.tables
+WHERE table_schema <> 'INFORMATION_SCHEMA'
+ORDER BY table_schema, table_name;
+""".strip(),
+        "columns": """
+SELECT table_schema, table_name, column_name, data_type, is_nullable, ordinal_position
+FROM information_schema.columns
+WHERE table_schema <> 'INFORMATION_SCHEMA'
+ORDER BY table_schema, table_name, ordinal_position;
+""".strip(),
+        "foreignKeys": """
+SELECT fk_tco.table_schema, fk_tco.table_name, fk_col.column_name,
+       pk_tco.table_schema AS references_schema,
+       pk_tco.table_name AS references_table,
+       pk_col.column_name AS references_column
+FROM information_schema.referential_constraints rco
+JOIN information_schema.table_constraints fk_tco
+  ON rco.constraint_name = fk_tco.constraint_name
+ AND rco.constraint_schema = fk_tco.table_schema
+JOIN information_schema.table_constraints pk_tco
+  ON rco.unique_constraint_name = pk_tco.constraint_name
+ AND rco.unique_constraint_schema = pk_tco.table_schema
+JOIN information_schema.key_column_usage fk_col
+  ON fk_col.constraint_name = fk_tco.constraint_name
+ AND fk_col.constraint_schema = fk_tco.table_schema
+JOIN information_schema.key_column_usage pk_col
+  ON pk_col.constraint_name = pk_tco.constraint_name
+ AND pk_col.constraint_schema = pk_tco.table_schema
+ AND pk_col.ordinal_position = fk_col.ordinal_position
+ORDER BY fk_tco.table_schema, fk_tco.table_name, fk_col.ordinal_position;
+""".strip(),
+    },
+}
+
+
+class WarehouseSqlError(RuntimeError):
+    """Raised for user-facing helper failures."""
+
+
+@dataclass
+class ReviewResult:
+    status: str
+    read_only: bool
+    statements: list[str]
+    findings: list[str]
+    requires_write_grant: bool
+
+
+def utc_now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def default_cache_dir() -> Path:
+    return Path.home() / ".hybridclaw" / "warehouse-sql" / "schema-cache"
+
+
+def stable_cache_key(backend: str, profile: str, database: str | None) -> str:
+    raw = json.dumps(
+        {"backend": backend, "profile": profile, "database": database or ""},
+        sort_keys=True,
+    )
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
+
+
+def cache_path(cache_dir: Path, backend: str, profile: str, database: str | None) -> Path:
+    return cache_dir / f"{backend}-{profile}-{stable_cache_key(backend, profile, database)}.json"
+
+
+def emit(payload: Any, fmt: str) -> None:
+    if fmt == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    if isinstance(payload, str):
+        print(payload)
+        return
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def ensure_backend(backend: str) -> None:
+    if backend not in BACKENDS:
+        raise WarehouseSqlError(
+            f"unsupported backend '{backend}'. Choose one of: {', '.join(sorted(BACKENDS))}"
+        )
+
+
+def connect_sqlite(database: str | None) -> sqlite3.Connection:
+    if not database:
+        raise WarehouseSqlError("--database is required for sqlite commands")
+    path = Path(database).expanduser()
+    if not path.exists():
+        raise WarehouseSqlError(f"sqlite database not found: {path}")
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def backend_command_env_name(backend: str) -> str:
+    return f"HYBRIDCLAW_WAREHOUSE_SQL_{backend.upper().replace('-', '_')}_COMMAND"
+
+
+def resolve_backend_command(args: argparse.Namespace) -> str:
+    explicit = str(getattr(args, "backend_command", "") or "").strip()
+    if explicit:
+        return explicit
+    return os.environ.get(backend_command_env_name(args.backend), "").strip()
+
+
+def parse_rows_payload(raw: str) -> list[dict[str, Any]]:
+    text = raw.strip()
+    if not text:
+        return []
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        reader = csv.DictReader(io.StringIO(text))
+        return [dict(row) for row in reader]
+
+    if isinstance(parsed, list):
+        return [row for row in parsed if isinstance(row, dict)]
+    if isinstance(parsed, dict):
+        rows = parsed.get("rows")
+        if isinstance(rows, list):
+            return [row for row in rows if isinstance(row, dict)]
+        if isinstance(parsed.get("data"), list):
+            return [row for row in parsed["data"] if isinstance(row, dict)]
+    raise WarehouseSqlError("Backend command must emit a JSON row array, {'rows': [...]}, or CSV with headers.")
+
+
+def run_backend_command(args: argparse.Namespace, sql: str) -> list[dict[str, Any]]:
+    command = resolve_backend_command(args)
+    if not command:
+        raise WarehouseSqlError(
+            f"{args.backend} requires {backend_command_env_name(args.backend)} or --backend-command, or an installed Python driver with the required environment."
+        )
+    env = {
+        **os.environ,
+        "WAREHOUSE_SQL_BACKEND": args.backend,
+        "WAREHOUSE_SQL_PROFILE": str(getattr(args, "profile", "default") or "default"),
+        "WAREHOUSE_SQL_QUERY": sql,
+    }
+    try:
+        result = subprocess.run(
+            shlex.split(command),
+            input=sql,
+            text=True,
+            capture_output=True,
+            check=False,
+            env=env,
+            timeout=max(1, int(getattr(args, "timeout_seconds", 60) or 60)),
+        )
+    except FileNotFoundError as exc:
+        raise WarehouseSqlError(f"Backend command not found: {command}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise WarehouseSqlError(f"Backend command timed out after {exc.timeout}s.") from exc
+
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise WarehouseSqlError(f"Backend command failed: {detail}")
+    return parse_rows_payload(result.stdout)
+
+
+def run_postgres_driver(args: argparse.Namespace, sql: str) -> list[dict[str, Any]]:
+    dsn = os.environ.get("HYBRIDCLAW_WAREHOUSE_SQL_POSTGRES_DSN", "").strip()
+    if not dsn:
+        raise WarehouseSqlError("Postgres requires HYBRIDCLAW_WAREHOUSE_SQL_POSTGRES_DSN or a backend command.")
+    try:
+        import psycopg  # type: ignore
+        from psycopg.rows import dict_row  # type: ignore
+
+        with psycopg.connect(dsn, row_factory=dict_row) as conn:
+            with conn.cursor() as cur:
+                cur.execute(sql)
+                if cur.description is None:
+                    conn.commit()
+                    return [{"affected_rows": cur.rowcount}]
+                return [dict(row) for row in cur.fetchall()]
+    except ImportError:
+        try:
+            import psycopg2  # type: ignore
+            import psycopg2.extras  # type: ignore
+        except ImportError as exc:
+            raise WarehouseSqlError("Postgres driver not installed. Install psycopg/psycopg2 or configure a backend command.") from exc
+
+        with psycopg2.connect(dsn) as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+                cur.execute(sql)
+                if cur.description is None:
+                    conn.commit()
+                    return [{"affected_rows": cur.rowcount}]
+                return [dict(row) for row in cur.fetchall()]
+
+
+def run_clickhouse_driver(args: argparse.Namespace, sql: str) -> list[dict[str, Any]]:
+    try:
+        import clickhouse_connect  # type: ignore
+    except ImportError as exc:
+        raise WarehouseSqlError("ClickHouse driver not installed. Install clickhouse-connect or configure a backend command.") from exc
+
+    client = clickhouse_connect.get_client(
+        host=os.environ.get("HYBRIDCLAW_WAREHOUSE_SQL_CLICKHOUSE_HOST", "localhost"),
+        port=int(os.environ.get("HYBRIDCLAW_WAREHOUSE_SQL_CLICKHOUSE_PORT", "8123")),
+        username=os.environ.get("HYBRIDCLAW_WAREHOUSE_SQL_CLICKHOUSE_USER", "default"),
+        password=os.environ.get("HYBRIDCLAW_WAREHOUSE_SQL_CLICKHOUSE_PASSWORD", ""),
+        database=os.environ.get("HYBRIDCLAW_WAREHOUSE_SQL_CLICKHOUSE_DATABASE", "default"),
+        secure=os.environ.get("HYBRIDCLAW_WAREHOUSE_SQL_CLICKHOUSE_SECURE", "").lower() in {"1", "true", "yes"},
+    )
+    result = client.query(sql)
+    return [dict(zip(result.column_names, row)) for row in result.result_rows]
+
+
+def run_bigquery_driver(args: argparse.Namespace, sql: str) -> list[dict[str, Any]]:
+    try:
+        from google.cloud import bigquery  # type: ignore
+    except ImportError as exc:
+        raise WarehouseSqlError("BigQuery driver not installed. Install google-cloud-bigquery or configure a backend command.") from exc
+
+    project = os.environ.get("HYBRIDCLAW_WAREHOUSE_SQL_BIGQUERY_PROJECT", "").strip() or None
+    client = bigquery.Client(project=project)
+    return [dict(row.items()) for row in client.query(sql).result()]
+
+
+def run_snowflake_driver(args: argparse.Namespace, sql: str) -> list[dict[str, Any]]:
+    try:
+        import snowflake.connector  # type: ignore
+    except ImportError as exc:
+        raise WarehouseSqlError("Snowflake driver not installed. Install snowflake-connector-python or configure a backend command.") from exc
+
+    required = {
+        "account": "HYBRIDCLAW_WAREHOUSE_SQL_SNOWFLAKE_ACCOUNT",
+        "user": "HYBRIDCLAW_WAREHOUSE_SQL_SNOWFLAKE_USER",
+        "password": "HYBRIDCLAW_WAREHOUSE_SQL_SNOWFLAKE_PASSWORD",
+    }
+    kwargs: dict[str, str] = {}
+    for key, env_name in required.items():
+        value = os.environ.get(env_name, "").strip()
+        if not value:
+            raise WarehouseSqlError(f"Snowflake requires {env_name} or a backend command.")
+        kwargs[key] = value
+    for key, env_name in {
+        "warehouse": "HYBRIDCLAW_WAREHOUSE_SQL_SNOWFLAKE_WAREHOUSE",
+        "database": "HYBRIDCLAW_WAREHOUSE_SQL_SNOWFLAKE_DATABASE",
+        "schema": "HYBRIDCLAW_WAREHOUSE_SQL_SNOWFLAKE_SCHEMA",
+        "role": "HYBRIDCLAW_WAREHOUSE_SQL_SNOWFLAKE_ROLE",
+    }.items():
+        value = os.environ.get(env_name, "").strip()
+        if value:
+            kwargs[key] = value
+
+    conn = snowflake.connector.connect(**kwargs)
+    try:
+        cur = conn.cursor(snowflake.connector.DictCursor)
+        try:
+            cur.execute(sql)
+            rows = cur.fetchall() if cur.description else [{"affected_rows": cur.rowcount}]
+            return [dict(row) for row in rows]
+        finally:
+            cur.close()
+    finally:
+        conn.close()
+
+
+def run_backend_sql(args: argparse.Namespace, sql: str) -> list[dict[str, Any]]:
+    command = resolve_backend_command(args)
+    if command:
+        return run_backend_command(args, sql)
+    if args.backend == "postgres":
+        return run_postgres_driver(args, sql)
+    if args.backend == "clickhouse":
+        return run_clickhouse_driver(args, sql)
+    if args.backend == "bigquery":
+        return run_bigquery_driver(args, sql)
+    if args.backend == "snowflake":
+        return run_snowflake_driver(args, sql)
+    raise WarehouseSqlError(f"No executable adapter for backend '{args.backend}'.")
+
+
+def row_text(row: dict[str, Any], *keys: str) -> str:
+    lower = {str(key).lower(): value for key, value in row.items()}
+    for key in keys:
+        value = row.get(key)
+        if value is None:
+            value = lower.get(key.lower())
+        if value is not None:
+            return str(value)
+    return ""
+
+
+def row_bool(row: dict[str, Any], key: str, fallback: bool = True) -> bool:
+    raw = row_text(row, key)
+    if not raw:
+        return fallback
+    return raw.strip().lower() not in {"no", "false", "0", "n"}
+
+
+def row_int(row: dict[str, Any], key: str, fallback: int = 0) -> int:
+    raw = row_text(row, key)
+    try:
+        return int(float(raw))
+    except (TypeError, ValueError):
+        return fallback
+
+
+def normalize_backend_schema(args: argparse.Namespace) -> dict[str, Any]:
+    table_rows = run_backend_sql(args, BACKEND_INTROSPECTION_SQL[args.backend]["tables"])
+    column_rows = run_backend_sql(args, BACKEND_INTROSPECTION_SQL[args.backend]["columns"])
+    fk_sql = BACKEND_INTROSPECTION_SQL[args.backend]["foreignKeys"]
+    fk_rows = [] if "\n" not in fk_sql and "SELECT" not in fk_sql.upper() else run_backend_sql(args, fk_sql)
+
+    tables: dict[tuple[str, str], dict[str, Any]] = {}
+    for row in table_rows:
+        schema = row_text(row, "table_schema", "database", "schema") or "default"
+        name = row_text(row, "table_name", "name")
+        if not name:
+            continue
+        tables[(schema, name)] = {
+            "name": name,
+            "schema": schema,
+            "type": row_text(row, "table_type", "engine", "type") or "table",
+            "columns": [],
+            "primaryKeys": [],
+            "foreignKeys": [],
+        }
+
+    for row in column_rows:
+        schema = row_text(row, "table_schema", "database", "schema") or "default"
+        table = row_text(row, "table_name", "table")
+        column = row_text(row, "column_name", "name")
+        if not table or not column:
+            continue
+        entry = tables.setdefault(
+            (schema, table),
+            {
+                "name": table,
+                "schema": schema,
+                "type": "table",
+                "columns": [],
+                "primaryKeys": [],
+                "foreignKeys": [],
+            },
+        )
+        entry["columns"].append(
+            {
+                "name": column,
+                "type": row_text(row, "data_type", "type") or "UNKNOWN",
+                "nullable": row_bool(row, "is_nullable", True),
+                "ordinal": row_int(row, "ordinal_position", len(entry["columns"]) + 1),
+            }
+        )
+
+    for row in fk_rows:
+        schema = row_text(row, "table_schema", "database", "schema") or "default"
+        table = row_text(row, "table_name", "table")
+        column = row_text(row, "column_name", "name")
+        ref_table = row_text(row, "references_table", "foreign_table_name")
+        ref_column = row_text(row, "references_column", "foreign_column_name")
+        if not table or not column or not ref_table:
+            continue
+        entry = tables.setdefault(
+            (schema, table),
+            {
+                "name": table,
+                "schema": schema,
+                "type": "table",
+                "columns": [],
+                "primaryKeys": [],
+                "foreignKeys": [],
+            },
+        )
+        entry["foreignKeys"].append(
+            {
+                "columns": [column],
+                "referencesTable": ref_table,
+                "referencesColumns": [ref_column] if ref_column else [],
+            }
+        )
+
+    return {
+        "cacheVersion": CACHE_VERSION,
+        "backend": args.backend,
+        "profile": args.profile,
+        "refreshedAt": utc_now(),
+        "tables": sorted(tables.values(), key=lambda table: (table["schema"], table["name"])),
+    }
+
+
+def sqlite_schema(database: str) -> dict[str, Any]:
+    with connect_sqlite(database) as conn:
+        tables = []
+        table_rows = conn.execute(
+            """
+            SELECT name, type, sql
+            FROM sqlite_master
+            WHERE type IN ('table', 'view')
+              AND name NOT LIKE 'sqlite_%'
+            ORDER BY name
+            """
+        ).fetchall()
+        for table_row in table_rows:
+            table_name = table_row["name"]
+            columns = [
+                {
+                    "name": row["name"],
+                    "type": row["type"] or "UNKNOWN",
+                    "nullable": not bool(row["notnull"]),
+                    "default": row["dflt_value"],
+                    "ordinal": row["cid"] + 1,
+                }
+                for row in conn.execute(f"PRAGMA table_info({quote_identifier(table_name)})")
+            ]
+            primary_keys = [
+                column["name"]
+                for column in sorted(
+                    [dict(row) for row in conn.execute(f"PRAGMA table_info({quote_identifier(table_name)})")],
+                    key=lambda row: row["pk"],
+                )
+                if column["pk"]
+            ]
+            foreign_keys = [
+                {
+                    "columns": [row["from"]],
+                    "referencesTable": row["table"],
+                    "referencesColumns": [row["to"]],
+                }
+                for row in conn.execute(f"PRAGMA foreign_key_list({quote_identifier(table_name)})")
+            ]
+            tables.append(
+                {
+                    "name": table_name,
+                    "schema": "main",
+                    "type": table_row["type"],
+                    "columns": columns,
+                    "primaryKeys": primary_keys,
+                    "foreignKeys": foreign_keys,
+                }
+            )
+    return {
+        "cacheVersion": CACHE_VERSION,
+        "backend": "sqlite",
+        "profile": "default",
+        "source": str(Path(database).expanduser()),
+        "refreshedAt": utc_now(),
+        "tables": tables,
+    }
+
+
+def quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def load_or_refresh_schema(args: argparse.Namespace) -> dict[str, Any]:
+    ensure_backend(args.backend)
+    cache_dir = Path(args.cache_dir).expanduser() if args.cache_dir else default_cache_dir()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    path = cache_path(cache_dir, args.backend, args.profile, args.database)
+    ttl_seconds = max(0, int(args.cache_ttl_seconds))
+    now = time.time()
+
+    if path.exists() and not args.refresh:
+        age_seconds = now - path.stat().st_mtime
+        if ttl_seconds == 0 or age_seconds <= ttl_seconds:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            payload["cache"] = {
+                "status": "hit",
+                "path": str(path),
+                "ageSeconds": int(age_seconds),
+                "ttlSeconds": ttl_seconds,
+            }
+            return payload
+
+    if args.backend == "sqlite":
+        payload = sqlite_schema(args.database)
+        payload["profile"] = args.profile
+    else:
+        payload = normalize_backend_schema(args)
+        payload["introspection"] = BACKEND_INTROSPECTION_SQL[args.backend]
+        payload["adapter"] = "command" if resolve_backend_command(args) else "python-driver"
+
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    payload["cache"] = {
+        "status": "refresh" if args.refresh else "miss",
+        "path": str(path),
+        "ageSeconds": 0,
+        "ttlSeconds": ttl_seconds,
+    }
+    return payload
+
+
+def strip_sql_comments(sql: str) -> str:
+    without_block = re.sub(r"/\*.*?\*/", " ", sql, flags=re.S)
+    return "\n".join(line.split("--", 1)[0] for line in without_block.splitlines())
+
+
+def split_sql_statements(sql: str) -> list[str]:
+    statements: list[str] = []
+    current: list[str] = []
+    quote: str | None = None
+    index = 0
+    while index < len(sql):
+        char = sql[index]
+        current.append(char)
+        if quote:
+            if char == quote:
+                if index + 1 < len(sql) and sql[index + 1] == quote:
+                    current.append(sql[index + 1])
+                    index += 1
+                else:
+                    quote = None
+        elif char in {"'", '"'}:
+            quote = char
+        elif char == ";":
+            statement = "".join(current).strip().rstrip(";").strip()
+            if statement:
+                statements.append(statement)
+            current = []
+        index += 1
+    tail = "".join(current).strip()
+    if tail:
+        statements.append(tail)
+    return statements
+
+
+def first_keyword(statement: str) -> str:
+    match = re.search(r"[A-Za-z_][A-Za-z0-9_]*", statement)
+    return match.group(0).lower() if match else ""
+
+
+def review_sql(
+    sql: str,
+    *,
+    allow_write: bool = False,
+    write_grant: str | None = None,
+) -> ReviewResult:
+    cleaned = strip_sql_comments(sql)
+    statements = split_sql_statements(cleaned)
+    findings: list[str] = []
+
+    if not statements:
+        findings.append("SQL is empty after removing comments.")
+
+    if len(statements) > 1:
+        findings.append("SQL must contain exactly one statement.")
+
+    lowered = f" {cleaned.lower()} "
+    keyword_hits = sorted(
+        keyword
+        for keyword in MUTATING_KEYWORDS
+        if re.search(rf"\b{re.escape(keyword)}\b", lowered)
+    )
+    starter = first_keyword(statements[0]) if statements else ""
+    read_only = bool(statements) and starter in READ_ONLY_STARTERS and not keyword_hits
+    requires_write_grant = not read_only
+
+    if keyword_hits:
+        findings.append(f"Mutating or privileged keyword(s) found: {', '.join(keyword_hits)}.")
+    if statements and starter not in READ_ONLY_STARTERS:
+        findings.append(f"Statement starts with '{starter or 'unknown'}', not a read-only SQL verb.")
+    if read_only and " limit " not in lowered and starter != "explain":
+        findings.append("Exploratory read does not include LIMIT; add one unless an aggregate query requires all rows.")
+
+    if requires_write_grant:
+        expected_grant = os.environ.get(WRITE_GRANT_ENV, "")
+        if not allow_write:
+            findings.append("Write SQL requires --allow-write.")
+        if not expected_grant:
+            findings.append(f"Write SQL requires {WRITE_GRANT_ENV} to be set.")
+        if not write_grant:
+            findings.append("Write SQL requires --write-grant.")
+        elif expected_grant and write_grant != expected_grant:
+            findings.append("Provided write grant does not match the per-skill grant.")
+
+    status = "pass" if (read_only or (requires_write_grant and allow_write and write_grant and write_grant == os.environ.get(WRITE_GRANT_ENV, ""))) and len(statements) == 1 else "block"
+    return ReviewResult(
+        status=status,
+        read_only=read_only,
+        statements=statements,
+        findings=findings,
+        requires_write_grant=requires_write_grant,
+    )
+
+
+def review_payload(sql: str, args: argparse.Namespace) -> dict[str, Any]:
+    result = review_sql(
+        sql,
+        allow_write=getattr(args, "allow_write", False),
+        write_grant=getattr(args, "write_grant", None),
+    )
+    return {
+        "sql": sql.strip(),
+        "review": {
+            "status": result.status,
+            "readOnly": result.read_only,
+            "statementCount": len(result.statements),
+            "requiresWriteGrant": result.requires_write_grant,
+            "findings": result.findings,
+            "modelReview": {
+                "required": True,
+                "instructions": [
+                    "Check that the SQL answers the user's business question.",
+                    "Confirm joins and filters against the schema cache.",
+                    "Return SQL before execution when the user asked to review it or scope is broad.",
+                ],
+            },
+        },
+    }
+
+
+def normalize_question(question: str) -> str:
+    return re.sub(r"\s+", " ", question.strip().lower())
+
+
+def extract_customer_name(question: str) -> str | None:
+    match = re.search(r"customer#\d+", question, flags=re.I)
+    return match.group(0) if match else None
+
+
+def plan_sql(question: str, *, limit: int = 10) -> dict[str, Any]:
+    q = normalize_question(question)
+    customer = extract_customer_name(question)
+    capped_limit = max(1, min(limit, DEFAULT_MAX_ROWS))
+
+    if "top customer" in q and "revenue" in q:
+        sql = f"""
+SELECT c.c_name, ROUND(SUM(l.l_extendedprice * (1 - l.l_discount)), 2) AS revenue
+FROM customer c
+JOIN orders o ON o.o_custkey = c.c_custkey
+JOIN lineitem l ON l.l_orderkey = o.o_orderkey
+GROUP BY c.c_name
+ORDER BY revenue DESC
+LIMIT {capped_limit}
+""".strip()
+    elif "revenue by nation" in q:
+        sql = f"""
+SELECT n.n_name, ROUND(SUM(l.l_extendedprice * (1 - l.l_discount)), 2) AS revenue
+FROM nation n
+JOIN customer c ON c.c_nationkey = n.n_nationkey
+JOIN orders o ON o.o_custkey = c.c_custkey
+JOIN lineitem l ON l.l_orderkey = o.o_orderkey
+GROUP BY n.n_name
+ORDER BY revenue DESC
+LIMIT {capped_limit}
+""".strip()
+    elif "late shipment" in q:
+        sql = f"""
+SELECT l_orderkey, l_partkey, l_suppkey, l_commitdate, l_receiptdate
+FROM lineitem
+WHERE l_receiptdate > l_commitdate
+ORDER BY l_receiptdate
+LIMIT {capped_limit}
+""".strip()
+    elif "open order" in q and "status" in q:
+        sql = """
+SELECT o_orderstatus, COUNT(*) AS order_count
+FROM orders
+WHERE o_orderstatus = 'O'
+GROUP BY o_orderstatus
+ORDER BY order_count DESC, o_orderstatus
+LIMIT 10
+""".strip()
+    elif customer and "order" in q:
+        sql = f"""
+SELECT o.o_orderkey, o.o_orderdate, o.o_orderstatus, o.o_totalprice
+FROM orders o
+JOIN customer c ON c.c_custkey = o.o_custkey
+WHERE c.c_name = '{escape_sql_literal(customer)}'
+ORDER BY o.o_orderdate
+LIMIT {capped_limit}
+""".strip()
+    elif "discount" in q and "brand" in q:
+        sql = """
+SELECT p.p_brand, ROUND(AVG(l.l_discount), 4) AS avg_discount
+FROM part p
+JOIN lineitem l ON l.l_partkey = p.p_partkey
+GROUP BY p.p_brand
+ORDER BY p.p_brand
+LIMIT 10
+""".strip()
+    elif "supplier" in q and "revenue" in q:
+        sql = f"""
+SELECT s.s_name, ROUND(SUM(l.l_extendedprice * (1 - l.l_discount)), 2) AS revenue
+FROM supplier s
+JOIN lineitem l ON l.l_suppkey = s.s_suppkey
+GROUP BY s.s_name
+ORDER BY revenue DESC
+LIMIT {capped_limit}
+""".strip()
+    elif "customer count" in q and ("segment" in q or "market" in q):
+        sql = """
+SELECT c_mktsegment, COUNT(*) AS customer_count
+FROM customer
+GROUP BY c_mktsegment
+ORDER BY customer_count DESC, c_mktsegment
+LIMIT 10
+""".strip()
+    elif "part" in q and "brand" in q:
+        sql = """
+SELECT p_brand, COUNT(*) AS part_count
+FROM part
+GROUP BY p_brand
+ORDER BY part_count DESC, p_brand
+LIMIT 10
+""".strip()
+    elif "daily" in q and "order" in q:
+        sql = """
+SELECT o_orderdate, ROUND(SUM(o_totalprice), 2) AS order_total
+FROM orders
+GROUP BY o_orderdate
+ORDER BY o_orderdate
+LIMIT 50
+""".strip()
+    elif "revenue" in q and "march" in q and "1995" in q:
+        sql = """
+SELECT ROUND(SUM(l.l_extendedprice * (1 - l.l_discount)), 2) AS revenue
+FROM orders o
+JOIN lineitem l ON l.l_orderkey = o.o_orderkey
+WHERE o.o_orderdate >= '1995-03-01'
+  AND o.o_orderdate < '1995-04-01'
+""".strip()
+    elif "largest order" in q:
+        sql = f"""
+SELECT o_orderkey, o_orderdate, o_totalprice
+FROM orders
+ORDER BY o_totalprice DESC
+LIMIT {capped_limit}
+""".strip()
+    else:
+        raise WarehouseSqlError(
+            "No deterministic TPC-H-style plan matched this question. Use review/query with model-authored SQL."
+        )
+
+    review = review_payload(sql, argparse.Namespace(allow_write=False, write_grant=None))
+    return {
+        "command": "plan",
+        "question": question,
+        "dialect": "ansi-sql",
+        "sql": sql,
+        "review": review["review"],
+        "schemaAssumption": "TPC-H-style customer/orders/lineitem/supplier/part/nation schema",
+    }
+
+
+def escape_sql_literal(value: str) -> str:
+    return value.replace("'", "''")
+
+
+def execute_sqlite_query(
+    database: str,
+    sql: str,
+    *,
+    max_rows: int,
+    allow_write: bool = False,
+    write_grant: str | None = None,
+) -> dict[str, Any]:
+    result = review_sql(sql, allow_write=allow_write, write_grant=write_grant)
+    if result.status != "pass":
+        raise WarehouseSqlError("SQL review blocked execution: " + "; ".join(result.findings))
+    with connect_sqlite(database) as conn:
+        cursor = conn.execute(sql)
+        if not result.read_only:
+            conn.commit()
+            return {
+                "columns": [],
+                "rows": [],
+                "rowCount": 0,
+                "affectedRows": cursor.rowcount,
+                "truncated": False,
+                "maxRows": max_rows,
+            }
+        rows = cursor.fetchmany(max_rows + 1)
+        columns = list(rows[0].keys()) if rows else []
+        truncated = len(rows) > max_rows
+        rows = rows[:max_rows]
+        return {
+            "columns": columns,
+            "rows": [dict(row) for row in rows],
+            "rowCount": len(rows),
+            "truncated": truncated,
+            "maxRows": max_rows,
+        }
+
+
+def execute_backend_query(args: argparse.Namespace, sql: str) -> dict[str, Any]:
+    rows = run_backend_sql(args, sql)
+    max_rows = max(1, int(args.max_rows))
+    truncated = len(rows) > max_rows
+    rows = rows[:max_rows]
+    columns = list(rows[0].keys()) if rows else []
+    return {
+        "columns": columns,
+        "rows": rows,
+        "rowCount": len(rows),
+        "truncated": truncated,
+        "maxRows": max_rows,
+    }
+
+
+def create_eval_database() -> str:
+    handle = tempfile.NamedTemporaryFile(prefix="warehouse-sql-tpch-", suffix=".db", delete=False)
+    handle.close()
+    fixture = TPC_H_FIXTURE_PATH.read_text(encoding="utf-8")
+    with sqlite3.connect(handle.name) as conn:
+        conn.executescript(fixture)
+    return handle.name
+
+
+def load_scenarios() -> list[dict[str, Any]]:
+    return json.loads(EVAL_SCENARIOS_PATH.read_text(encoding="utf-8"))
+
+
+def first_cell(rows: list[dict[str, Any]]) -> Any:
+    if not rows:
+        return None
+    first_row = rows[0]
+    if not first_row:
+        return None
+    return next(iter(first_row.values()))
+
+
+def run_eval_scenarios() -> dict[str, Any]:
+    database = create_eval_database()
+    scenarios = load_scenarios()
+    results = []
+    category_counts: dict[str, int] = {}
+    failed = 0
+    try:
+        for scenario in scenarios:
+            category = str(scenario.get("category", "uncategorized"))
+            category_counts[category] = category_counts.get(category, 0) + 1
+            case_result: dict[str, Any] = {
+                "id": scenario["id"],
+                "category": category,
+                "status": "pass",
+                "findings": [],
+            }
+            try:
+                plan = plan_sql(str(scenario["question"]))
+                sql = plan["sql"]
+                for expected in scenario.get("expectedSqlContains", []):
+                    if str(expected).lower() not in sql.lower():
+                        case_result["findings"].append(f"SQL missing expected token: {expected}")
+                query_result = execute_sqlite_query(database, sql, max_rows=DEFAULT_MAX_ROWS)
+                if "expectedRowCount" in scenario and query_result["rowCount"] != scenario["expectedRowCount"]:
+                    case_result["findings"].append(
+                        f"row count {query_result['rowCount']} != {scenario['expectedRowCount']}"
+                    )
+                if "expectedFirstValue" in scenario:
+                    actual = first_cell(query_result["rows"])
+                    expected = scenario["expectedFirstValue"]
+                    if actual != expected:
+                        case_result["findings"].append(f"first value {actual!r} != {expected!r}")
+                if case_result["findings"]:
+                    case_result["status"] = "fail"
+                    failed += 1
+            except Exception as exc:  # noqa: BLE001 - surface per-scenario failure
+                case_result["status"] = "fail"
+                case_result["findings"].append(str(exc))
+                failed += 1
+            results.append(case_result)
+    finally:
+        try:
+            Path(database).unlink()
+        except OSError:
+            pass
+
+    return {
+        "command": "eval-scenarios",
+        "dataset": "TPC-H-style tiny fixture",
+        "scenarioCount": len(scenarios),
+        "failed": failed,
+        "categories": category_counts,
+        "results": results,
+    }
+
+
+def handle_schema(args: argparse.Namespace) -> Any:
+    return load_or_refresh_schema(args)
+
+
+def handle_backend_contract(args: argparse.Namespace) -> Any:
+    ensure_backend(args.backend)
+    if args.backend == "sqlite":
+        return {
+            "backend": "sqlite",
+            "execution": "python-stdlib sqlite3",
+            "introspection": {
+                "tables": "sqlite_master WHERE type IN ('table', 'view')",
+                "columns": "PRAGMA table_info(<table>)",
+                "foreignKeys": "PRAGMA foreign_key_list(<table>)",
+            },
+        }
+    return {
+        "backend": args.backend,
+        "execution": "operator-approved connector required",
+        "introspection": BACKEND_INTROSPECTION_SQL[args.backend],
+    }
+
+
+def handle_schedule_command(args: argparse.Namespace) -> Any:
+    ensure_backend(args.backend)
+    command = [
+        "python3",
+        "skills/warehouse-sql/scripts/warehouse_sql.py",
+        "--format",
+        "json",
+        "schema",
+        "--backend",
+        args.backend,
+        "--profile",
+        args.profile,
+        "--refresh",
+    ]
+    if args.database:
+        command.extend(["--database", args.database])
+    return {
+        "schedule": args.every,
+        "command": " ".join(command),
+        "hybridclawExample": f"hybridclaw schedule create --cron '{args.every}' -- {' '.join(command)}",
+    }
+
+
+def resolve_gateway_url(args: argparse.Namespace) -> str:
+    return (
+        str(getattr(args, "gateway_url", "") or "").strip()
+        or os.environ.get("HYBRIDCLAW_GATEWAY_URL", "").strip()
+        or os.environ.get("GATEWAY_BASE_URL", "").strip()
+        or DEFAULT_GATEWAY_URL
+    )
+
+
+def resolve_gateway_token(args: argparse.Namespace) -> str:
+    return (
+        str(getattr(args, "gateway_token", "") or "").strip()
+        or os.environ.get("HYBRIDCLAW_GATEWAY_TOKEN", "").strip()
+        or os.environ.get("GATEWAY_API_TOKEN", "").strip()
+        or ""
+    )
+
+
+def build_refresh_command(args: argparse.Namespace) -> list[str]:
+    command = [
+        "python3",
+        "skills/warehouse-sql/scripts/warehouse_sql.py",
+        "--format",
+        "json",
+        "schema",
+        "--backend",
+        args.backend,
+        "--profile",
+        args.profile,
+        "--refresh",
+    ]
+    if args.database:
+        command.extend(["--database", args.database])
+    if getattr(args, "cache_dir", None):
+        command.extend(["--cache-dir", args.cache_dir])
+    if getattr(args, "backend_command", None):
+        command.extend(["--backend-command", args.backend_command])
+    return command
+
+
+def scheduler_job_payload(args: argparse.Namespace) -> dict[str, Any]:
+    ensure_backend(args.backend)
+    job_id = (
+        str(getattr(args, "job_id", "") or "").strip()
+        or f"warehouse-sql-schema-{args.backend}-{args.profile}".replace("_", "-")
+    )
+    command = build_refresh_command(args)
+    message = "Refresh the warehouse SQL schema cache by running this exact command and report success or failure:\n\n```bash\n" + " ".join(shlex.quote(part) for part in command) + "\n```"
+    return {
+        "id": job_id,
+        "name": f"Warehouse SQL schema refresh ({args.backend}/{args.profile})",
+        "description": "Refresh cached warehouse schema introspection for the warehouse-sql skill.",
+        "enabled": True,
+        "agentId": args.agent_id,
+        "boardStatus": "backlog",
+        "schedule": {
+            "kind": "cron",
+            "expr": args.every,
+            "tz": args.time_zone,
+        },
+        "action": {
+            "kind": "agent_turn",
+            "message": message,
+        },
+        "delivery": {
+            "kind": "channel",
+            "to": args.delivery_channel,
+        },
+    }
+
+
+def handle_schedule_refresh(args: argparse.Namespace) -> Any:
+    job = scheduler_job_payload(args)
+    if args.dry_run:
+        return {"status": "dry-run", "job": job}
+
+    gateway_url = resolve_gateway_url(args).rstrip("/")
+    token = resolve_gateway_token(args)
+    payload = json.dumps({"job": job}).encode("utf-8")
+    req = request.Request(
+        f"{gateway_url}/api/admin/scheduler",
+        data=payload,
+        method="PUT",
+        headers={"Content-Type": "application/json"},
+    )
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with request.urlopen(req, timeout=max(1, int(args.timeout_seconds))) as response:
+            raw = response.read().decode("utf-8")
+            body = json.loads(raw) if raw.strip() else {}
+    except error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise WarehouseSqlError(f"Gateway scheduler registration failed ({exc.code}): {detail}") from exc
+    except error.URLError as exc:
+        raise WarehouseSqlError(f"Gateway scheduler registration failed: {exc.reason}") from exc
+    return {
+        "status": "registered",
+        "gatewayUrl": gateway_url,
+        "jobId": job["id"],
+        "job": job,
+        "scheduler": body,
+    }
+
+
+def handle_query(args: argparse.Namespace) -> Any:
+    ensure_backend(args.backend)
+    payload = review_payload(args.sql, args)
+    if not args.execute:
+        payload["execution"] = {
+            "status": "not-run",
+            "reason": "query defaults to review-only; pass --execute after review",
+        }
+        return payload
+    if payload["review"]["status"] != "pass":
+        payload["execution"] = {
+            "status": "blocked",
+            "reason": "; ".join(payload["review"]["findings"]),
+        }
+        return payload
+    if args.backend == "sqlite":
+        result = execute_sqlite_query(
+            args.database,
+            args.sql,
+            max_rows=args.max_rows,
+            allow_write=args.allow_write,
+            write_grant=args.write_grant,
+        )
+        adapter = "python-stdlib sqlite3"
+    else:
+        result = execute_backend_query(args, args.sql)
+        adapter = "command" if resolve_backend_command(args) else "python-driver"
+    payload["execution"] = {
+        "status": "ran",
+        "backend": args.backend,
+        "adapter": adapter,
+        **result,
+    }
+    return payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Natural-language warehouse SQL planner, schema cache, safety review, and eval helper."
+    )
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    schema = subparsers.add_parser("schema", help="Read or refresh cached schema introspection.")
+    schema.add_argument("--backend", choices=sorted(BACKENDS), required=True)
+    schema.add_argument("--database", help="SQLite database path for sqlite backend.")
+    schema.add_argument("--profile", default="default", help="Logical warehouse profile name.")
+    schema.add_argument("--cache-dir", help="Schema cache directory.")
+    schema.add_argument("--cache-ttl-seconds", type=int, default=DEFAULT_CACHE_TTL_SECONDS)
+    schema.add_argument("--backend-command", help="Executable connector command that reads SQL on stdin and emits JSON/CSV rows.")
+    schema.add_argument("--timeout-seconds", type=int, default=60)
+    schema.add_argument("--refresh", action="store_true", help="Force a schema refresh.")
+    schema.set_defaults(func=handle_schema)
+
+    contract = subparsers.add_parser("backend-contract", help="Emit backend introspection contract.")
+    contract.add_argument("--backend", choices=sorted(BACKENDS), required=True)
+    contract.set_defaults(func=handle_backend_contract)
+
+    schedule = subparsers.add_parser("schedule-command", help="Emit a scheduled schema refresh command.")
+    schedule.add_argument("--backend", choices=sorted(BACKENDS), required=True)
+    schedule.add_argument("--database", help="SQLite database path for sqlite backend.")
+    schedule.add_argument("--profile", default="default")
+    schedule.add_argument("--every", default="0 */6 * * *", help="Cron expression.")
+    schedule.set_defaults(func=handle_schedule_command)
+
+    schedule_refresh = subparsers.add_parser("schedule-refresh", help="Register a gateway scheduler job that refreshes schema cache.")
+    schedule_refresh.add_argument("--backend", choices=sorted(BACKENDS), required=True)
+    schedule_refresh.add_argument("--database", help="SQLite database path for sqlite backend.")
+    schedule_refresh.add_argument("--profile", default="default")
+    schedule_refresh.add_argument("--cache-dir", help="Schema cache directory.")
+    schedule_refresh.add_argument("--backend-command", help="Executable connector command that reads SQL on stdin and emits JSON/CSV rows.")
+    schedule_refresh.add_argument("--every", default="0 */6 * * *", help="Cron expression.")
+    schedule_refresh.add_argument("--time-zone", default="UTC")
+    schedule_refresh.add_argument("--job-id")
+    schedule_refresh.add_argument("--agent-id", default="main")
+    schedule_refresh.add_argument("--delivery-channel", default="scheduler")
+    schedule_refresh.add_argument("--gateway-url")
+    schedule_refresh.add_argument("--gateway-token")
+    schedule_refresh.add_argument("--timeout-seconds", type=int, default=30)
+    schedule_refresh.add_argument("--dry-run", action="store_true")
+    schedule_refresh.set_defaults(func=handle_schedule_refresh)
+
+    plan = subparsers.add_parser("plan", help="Plan SQL for a natural-language TPC-H-style question.")
+    plan.add_argument("question")
+    plan.add_argument("--limit", type=int, default=10)
+    plan.set_defaults(func=lambda args: plan_sql(args.question, limit=args.limit))
+
+    review = subparsers.add_parser("review", help="Review SQL safety without execution.")
+    review.add_argument("sql")
+    review.add_argument("--allow-write", action="store_true")
+    review.add_argument("--write-grant")
+    review.set_defaults(func=lambda args: review_payload(args.sql, args))
+
+    query = subparsers.add_parser("query", help="Review SQL and optionally execute it.")
+    query.add_argument("--backend", choices=sorted(BACKENDS), required=True)
+    query.add_argument("--database", help="SQLite database path for sqlite backend.")
+    query.add_argument("--execute", action="store_true")
+    query.add_argument("--max-rows", type=int, default=DEFAULT_MAX_ROWS)
+    query.add_argument("--profile", default="default")
+    query.add_argument("--backend-command", help="Executable connector command that reads SQL on stdin and emits JSON/CSV rows.")
+    query.add_argument("--timeout-seconds", type=int, default=60)
+    query.add_argument("--allow-write", action="store_true")
+    query.add_argument("--write-grant")
+    query.add_argument("sql")
+    query.set_defaults(func=handle_query)
+
+    evals = subparsers.add_parser("eval-scenarios", help="Run bundled TPC-H-style eval scenarios.")
+    evals.set_defaults(func=lambda _args: run_eval_scenarios())
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        payload = args.func(args)
+        emit(payload, args.format)
+        return 0
+    except WarehouseSqlError as exc:
+        emit({"error": str(exc)}, args.format)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/warehouse-sql/scripts/warehouse_sql.py
+++ b/skills/warehouse-sql/scripts/warehouse_sql.py
@@ -439,6 +439,17 @@ def row_int(row: dict[str, Any], key: str, fallback: int = 0) -> int:
         return fallback
 
 
+def make_table_entry(schema: str, name: str, table_type: str = "table") -> dict[str, Any]:
+    return {
+        "name": name,
+        "schema": schema,
+        "type": table_type,
+        "columns": [],
+        "primaryKeys": [],
+        "foreignKeys": [],
+    }
+
+
 def normalize_backend_schema(args: argparse.Namespace) -> dict[str, Any]:
     table_rows = run_backend_sql(args, BACKEND_INTROSPECTION_SQL[args.backend]["tables"])
     column_rows = run_backend_sql(args, BACKEND_INTROSPECTION_SQL[args.backend]["columns"])
@@ -451,14 +462,11 @@ def normalize_backend_schema(args: argparse.Namespace) -> dict[str, Any]:
         name = row_text(row, "table_name", "name")
         if not name:
             continue
-        tables[(schema, name)] = {
-            "name": name,
-            "schema": schema,
-            "type": row_text(row, "table_type", "engine", "type") or "table",
-            "columns": [],
-            "primaryKeys": [],
-            "foreignKeys": [],
-        }
+        tables[(schema, name)] = make_table_entry(
+            schema,
+            name,
+            row_text(row, "table_type", "engine", "type") or "table",
+        )
 
     for row in column_rows:
         schema = row_text(row, "table_schema", "database", "schema") or "default"
@@ -466,17 +474,7 @@ def normalize_backend_schema(args: argparse.Namespace) -> dict[str, Any]:
         column = row_text(row, "column_name", "name")
         if not table or not column:
             continue
-        entry = tables.setdefault(
-            (schema, table),
-            {
-                "name": table,
-                "schema": schema,
-                "type": "table",
-                "columns": [],
-                "primaryKeys": [],
-                "foreignKeys": [],
-            },
-        )
+        entry = tables.setdefault((schema, table), make_table_entry(schema, table))
         entry["columns"].append(
             {
                 "name": column,
@@ -494,17 +492,7 @@ def normalize_backend_schema(args: argparse.Namespace) -> dict[str, Any]:
         ref_column = row_text(row, "references_column", "foreign_column_name")
         if not table or not column or not ref_table:
             continue
-        entry = tables.setdefault(
-            (schema, table),
-            {
-                "name": table,
-                "schema": schema,
-                "type": "table",
-                "columns": [],
-                "primaryKeys": [],
-                "foreignKeys": [],
-            },
-        )
+        entry = tables.setdefault((schema, table), make_table_entry(schema, table))
         entry["foreignKeys"].append(
             {
                 "columns": [column],

--- a/skills/warehouse-sql/scripts/warehouse_sql.py
+++ b/skills/warehouse-sql/scripts/warehouse_sql.py
@@ -2,10 +2,8 @@
 # ruff: noqa: INP001
 """Natural-language warehouse SQL helper.
 
-The helper owns deterministic planning for the bundled TPC-H-style eval suite,
-schema-cache management, SQL safety review, and SQLite execution for
-reproducible tests. Production warehouses should execute through an operator
-approved CLI, MCP server, or gateway integration.
+The helper owns schema-cache management, SQL safety review, warehouse execution,
+scheduler registration, and the bundled TPC-H-style eval runner.
 """
 
 from __future__ import annotations
@@ -73,7 +71,7 @@ MUTATING_KEYWORDS = {
     "vacuum",
 }
 
-BACKEND_INTROSPECTION_SQL: dict[str, dict[str, str]] = {
+BACKEND_INTROSPECTION_SQL: dict[str, dict[str, str | None]] = {
     "postgres": {
         "tables": """
 SELECT table_schema, table_name, table_type
@@ -117,7 +115,7 @@ FROM system.columns
 WHERE database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')
 ORDER BY database, table, position;
 """.strip(),
-        "foreignKeys": "ClickHouse does not expose relational foreign keys in system tables.",
+        "foreignKeys": None,
     },
     "bigquery": {
         "tables": """
@@ -130,7 +128,7 @@ SELECT table_schema, table_name, column_name, data_type, is_nullable, ordinal_po
 FROM `<project>.<dataset>.INFORMATION_SCHEMA.COLUMNS`
 ORDER BY table_schema, table_name, ordinal_position;
 """.strip(),
-        "foreignKeys": "BigQuery key constraints are dataset-specific; inspect INFORMATION_SCHEMA.TABLE_CONSTRAINTS when enabled.",
+        "foreignKeys": None,
     },
     "snowflake": {
         "tables": """
@@ -181,12 +179,6 @@ class ReviewResult:
     statements: list[str]
     findings: list[str]
     requires_write_grant: bool
-
-
-@dataclass
-class SqlPlan:
-    sql: str
-    parameters: list[Any]
 
 
 def utc_now() -> str:
@@ -287,8 +279,6 @@ def parse_rows_payload(raw: str) -> list[dict[str, Any]]:
         rows = parsed.get("rows")
         if isinstance(rows, list):
             return [row for row in rows if isinstance(row, dict)]
-        if isinstance(parsed.get("data"), list):
-            return [row for row in parsed["data"] if isinstance(row, dict)]
     raise WarehouseSqlError("Backend command must emit a JSON row array, {'rows': [...]}, or CSV with headers.")
 
 
@@ -327,28 +317,16 @@ def run_postgres_driver(args: argparse.Namespace, sql: str) -> list[dict[str, An
     try:
         import psycopg  # type: ignore
         from psycopg.rows import dict_row  # type: ignore
+    except ImportError as exc:
+        raise WarehouseSqlError("Postgres driver not installed. Install psycopg or configure a backend command.") from exc
 
-        with psycopg.connect(dsn, row_factory=dict_row) as conn:
-            with conn.cursor() as cur:
-                cur.execute(sql)
-                if cur.description is None:
-                    conn.commit()
-                    return [{"affected_rows": cur.rowcount}]
-                return [dict(row) for row in cur.fetchall()]
-    except ImportError:
-        try:
-            import psycopg2  # type: ignore
-            import psycopg2.extras  # type: ignore
-        except ImportError as exc:
-            raise WarehouseSqlError("Postgres driver not installed. Install psycopg/psycopg2 or configure a backend command.") from exc
-
-        with psycopg2.connect(dsn) as conn:
-            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
-                cur.execute(sql)
-                if cur.description is None:
-                    conn.commit()
-                    return [{"affected_rows": cur.rowcount}]
-                return [dict(row) for row in cur.fetchall()]
+    with psycopg.connect(dsn, row_factory=dict_row) as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+            if cur.description is None:
+                conn.commit()
+                return [{"affected_rows": cur.rowcount}]
+            return [dict(row) for row in cur.fetchall()]
 
 
 def run_clickhouse_driver(args: argparse.Namespace, sql: str) -> list[dict[str, Any]]:
@@ -465,7 +443,7 @@ def normalize_backend_schema(args: argparse.Namespace) -> dict[str, Any]:
     table_rows = run_backend_sql(args, BACKEND_INTROSPECTION_SQL[args.backend]["tables"])
     column_rows = run_backend_sql(args, BACKEND_INTROSPECTION_SQL[args.backend]["columns"])
     fk_sql = BACKEND_INTROSPECTION_SQL[args.backend]["foreignKeys"]
-    fk_rows = [] if "\n" not in fk_sql and "SELECT" not in fk_sql.upper() else run_backend_sql(args, fk_sql)
+    fk_rows = run_backend_sql(args, fk_sql) if fk_sql is not None else []
 
     tables: dict[tuple[str, str], dict[str, Any]] = {}
     for row in table_rows:
@@ -759,7 +737,13 @@ def review_sql(
         elif expected_grant and not write_grant_matches(write_grant, expected_grant):
             findings.append("Provided write grant does not match the per-skill grant.")
 
-    status = "pass" if (read_only or (requires_write_grant and allow_write and write_grant_matches(write_grant, os.environ.get(WRITE_GRANT_ENV, "")))) and len(statements) == 1 else "block"
+    write_approved = (
+        requires_write_grant
+        and allow_write
+        and write_grant_matches(write_grant, os.environ.get(WRITE_GRANT_ENV, ""))
+    )
+    single_statement = len(statements) == 1
+    status = "pass" if (read_only or write_approved) and single_statement else "block"
     return ReviewResult(
         status=status,
         read_only=read_only,
@@ -792,143 +776,6 @@ def review_payload(sql: str, args: argparse.Namespace) -> dict[str, Any]:
                 ],
             },
         },
-    }
-
-
-def normalize_question(question: str) -> str:
-    return re.sub(r"\s+", " ", question.strip().lower())
-
-
-def extract_customer_name(question: str) -> str | None:
-    match = re.search(r"customer#\d+", question, flags=re.I)
-    return match.group(0) if match else None
-
-
-def plan_sql(question: str, *, limit: int = 10) -> dict[str, Any]:
-    q = normalize_question(question)
-    customer = extract_customer_name(question)
-    capped_limit = max(1, min(limit, DEFAULT_MAX_ROWS))
-    parameters: list[Any] = []
-
-    if "top customer" in q and "revenue" in q:
-        sql = f"""
-SELECT c.c_name, ROUND(SUM(l.l_extendedprice * (1 - l.l_discount)), 2) AS revenue
-FROM customer c
-JOIN orders o ON o.o_custkey = c.c_custkey
-JOIN lineitem l ON l.l_orderkey = o.o_orderkey
-GROUP BY c.c_name
-ORDER BY revenue DESC
-LIMIT {capped_limit}
-""".strip()
-    elif "revenue by nation" in q:
-        sql = f"""
-SELECT n.n_name, ROUND(SUM(l.l_extendedprice * (1 - l.l_discount)), 2) AS revenue
-FROM nation n
-JOIN customer c ON c.c_nationkey = n.n_nationkey
-JOIN orders o ON o.o_custkey = c.c_custkey
-JOIN lineitem l ON l.l_orderkey = o.o_orderkey
-GROUP BY n.n_name
-ORDER BY revenue DESC
-LIMIT {capped_limit}
-""".strip()
-    elif "late shipment" in q:
-        sql = f"""
-SELECT l_orderkey, l_partkey, l_suppkey, l_commitdate, l_receiptdate
-FROM lineitem
-WHERE l_receiptdate > l_commitdate
-ORDER BY l_receiptdate
-LIMIT {capped_limit}
-""".strip()
-    elif "open order" in q and "status" in q:
-        sql = """
-SELECT o_orderstatus, COUNT(*) AS order_count
-FROM orders
-WHERE o_orderstatus = 'O'
-GROUP BY o_orderstatus
-ORDER BY order_count DESC, o_orderstatus
-LIMIT 10
-""".strip()
-    elif customer and "order" in q:
-        parameters = [customer]
-        sql = f"""
-SELECT o.o_orderkey, o.o_orderdate, o.o_orderstatus, o.o_totalprice
-FROM orders o
-JOIN customer c ON c.c_custkey = o.o_custkey
-WHERE c.c_name = ?
-ORDER BY o.o_orderdate
-LIMIT {capped_limit}
-""".strip()
-    elif "discount" in q and "brand" in q:
-        sql = """
-SELECT p.p_brand, ROUND(AVG(l.l_discount), 4) AS avg_discount
-FROM part p
-JOIN lineitem l ON l.l_partkey = p.p_partkey
-GROUP BY p.p_brand
-ORDER BY p.p_brand
-LIMIT 10
-""".strip()
-    elif "supplier" in q and "revenue" in q:
-        sql = f"""
-SELECT s.s_name, ROUND(SUM(l.l_extendedprice * (1 - l.l_discount)), 2) AS revenue
-FROM supplier s
-JOIN lineitem l ON l.l_suppkey = s.s_suppkey
-GROUP BY s.s_name
-ORDER BY revenue DESC
-LIMIT {capped_limit}
-""".strip()
-    elif "customer count" in q and ("segment" in q or "market" in q):
-        sql = """
-SELECT c_mktsegment, COUNT(*) AS customer_count
-FROM customer
-GROUP BY c_mktsegment
-ORDER BY customer_count DESC, c_mktsegment
-LIMIT 10
-""".strip()
-    elif "part" in q and "brand" in q:
-        sql = """
-SELECT p_brand, COUNT(*) AS part_count
-FROM part
-GROUP BY p_brand
-ORDER BY part_count DESC, p_brand
-LIMIT 10
-""".strip()
-    elif "daily" in q and "order" in q:
-        sql = """
-SELECT o_orderdate, ROUND(SUM(o_totalprice), 2) AS order_total
-FROM orders
-GROUP BY o_orderdate
-ORDER BY o_orderdate
-LIMIT 50
-""".strip()
-    elif "revenue" in q and "march" in q and "1995" in q:
-        sql = """
-SELECT ROUND(SUM(l.l_extendedprice * (1 - l.l_discount)), 2) AS revenue
-FROM orders o
-JOIN lineitem l ON l.l_orderkey = o.o_orderkey
-WHERE o.o_orderdate >= '1995-03-01'
-  AND o.o_orderdate < '1995-04-01'
-""".strip()
-    elif "largest order" in q:
-        sql = f"""
-SELECT o_orderkey, o_orderdate, o_totalprice
-FROM orders
-ORDER BY o_totalprice DESC
-LIMIT {capped_limit}
-""".strip()
-    else:
-        raise WarehouseSqlError(
-            "No deterministic TPC-H-style plan matched this question. Use review/query with model-authored SQL."
-        )
-
-    review = review_payload(sql, argparse.Namespace(allow_write=False, write_grant=None))
-    return {
-        "command": "plan",
-        "question": question,
-        "dialect": "ansi-sql",
-        "sql": sql,
-        "parameters": parameters,
-        "review": review["review"],
-        "schemaAssumption": "TPC-H-style customer/orders/lineitem/supplier/part/nation schema",
     }
 
 
@@ -997,6 +844,19 @@ def load_scenarios() -> list[dict[str, Any]]:
     return json.loads(EVAL_SCENARIOS_PATH.read_text(encoding="utf-8"))
 
 
+def plan_eval_sql(question: str) -> dict[str, Any]:
+    sys.path.insert(0, str(SKILL_DIR / "evals"))
+    try:
+        from tpch_eval_planner import plan_eval_sql as eval_planner  # type: ignore
+
+        return eval_planner(question)
+    finally:
+        try:
+            sys.path.remove(str(SKILL_DIR / "evals"))
+        except ValueError:
+            pass
+
+
 def first_cell(rows: list[dict[str, Any]]) -> Any:
     if not rows:
         return None
@@ -1023,7 +883,7 @@ def run_eval_scenarios() -> dict[str, Any]:
                 "findings": [],
             }
             try:
-                plan = plan_sql(str(scenario["question"]))
+                plan = plan_eval_sql(str(scenario["question"]))
                 sql = plan["sql"]
                 for expected in scenario.get("expectedSqlContains", []):
                     if str(expected).lower() not in sql.lower():
@@ -1087,29 +947,6 @@ def handle_backend_contract(args: argparse.Namespace) -> Any:
         "backend": args.backend,
         "execution": "operator-approved connector required",
         "introspection": BACKEND_INTROSPECTION_SQL[args.backend],
-    }
-
-
-def handle_schedule_command(args: argparse.Namespace) -> Any:
-    ensure_backend(args.backend)
-    command = [
-        "python3",
-        "skills/warehouse-sql/scripts/warehouse_sql.py",
-        "--format",
-        "json",
-        "schema",
-        "--backend",
-        args.backend,
-        "--profile",
-        args.profile,
-        "--refresh",
-    ]
-    if args.database:
-        command.extend(["--database", args.database])
-    return {
-        "schedule": args.every,
-        "command": " ".join(command),
-        "hybridclawExample": f"hybridclaw schedule create --cron '{args.every}' -- {' '.join(command)}",
     }
 
 
@@ -1260,7 +1097,7 @@ def handle_query(args: argparse.Namespace) -> Any:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Natural-language warehouse SQL planner, schema cache, safety review, and eval helper."
+        description="Warehouse SQL schema cache, safety review, execution, scheduler, and eval helper."
     )
     parser.add_argument("--format", choices=["text", "json"], default="text")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -1280,13 +1117,6 @@ def build_parser() -> argparse.ArgumentParser:
     contract.add_argument("--backend", choices=sorted(BACKENDS), required=True)
     contract.set_defaults(func=handle_backend_contract)
 
-    schedule = subparsers.add_parser("schedule-command", help="Emit a scheduled schema refresh command.")
-    schedule.add_argument("--backend", choices=sorted(BACKENDS), required=True)
-    schedule.add_argument("--database", help="SQLite database path for sqlite backend.")
-    schedule.add_argument("--profile", default="default")
-    schedule.add_argument("--every", default="0 */6 * * *", help="Cron expression.")
-    schedule.set_defaults(func=handle_schedule_command)
-
     schedule_refresh = subparsers.add_parser("schedule-refresh", help="Register a gateway scheduler job that refreshes schema cache.")
     schedule_refresh.add_argument("--backend", choices=sorted(BACKENDS), required=True)
     schedule_refresh.add_argument("--database", help="SQLite database path for sqlite backend.")
@@ -1303,11 +1133,6 @@ def build_parser() -> argparse.ArgumentParser:
     schedule_refresh.add_argument("--timeout-seconds", type=int, default=30)
     schedule_refresh.add_argument("--dry-run", action="store_true")
     schedule_refresh.set_defaults(func=handle_schedule_refresh)
-
-    plan = subparsers.add_parser("plan", help="Plan SQL for a natural-language TPC-H-style question.")
-    plan.add_argument("question")
-    plan.add_argument("--limit", type=int, default=10)
-    plan.set_defaults(func=lambda args: plan_sql(args.question, limit=args.limit))
 
     review = subparsers.add_parser("review", help="Review SQL safety without execution.")
     review.add_argument("sql")

--- a/skills/warehouse-sql/scripts/warehouse_sql.py
+++ b/skills/warehouse-sql/scripts/warehouse_sql.py
@@ -274,12 +274,19 @@ def parse_rows_payload(raw: str) -> list[dict[str, Any]]:
         return [dict(row) for row in reader]
 
     if isinstance(parsed, list):
-        return [row for row in parsed if isinstance(row, dict)]
+        return validate_row_objects(parsed)
     if isinstance(parsed, dict):
         rows = parsed.get("rows")
         if isinstance(rows, list):
-            return [row for row in rows if isinstance(row, dict)]
+            return validate_row_objects(rows)
     raise WarehouseSqlError("Backend command must emit a JSON row array, {'rows': [...]}, or CSV with headers.")
+
+
+def validate_row_objects(rows: list[Any]) -> list[dict[str, Any]]:
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise WarehouseSqlError(f"Backend command row {index} must be a JSON object.")
+    return rows
 
 
 def run_backend_command(args: argparse.Namespace, sql: str) -> list[dict[str, Any]]:
@@ -452,10 +459,47 @@ def make_table_entry(schema: str, name: str, table_type: str = "table") -> dict[
     }
 
 
+def bigquery_qualified_information_schema(args: argparse.Namespace, table: str) -> str:
+    project = (
+        str(getattr(args, "bigquery_project", "") or "").strip()
+        or os.environ.get("HYBRIDCLAW_WAREHOUSE_SQL_BIGQUERY_PROJECT", "").strip()
+    )
+    dataset = (
+        str(getattr(args, "bigquery_dataset", "") or "").strip()
+        or os.environ.get("HYBRIDCLAW_WAREHOUSE_SQL_BIGQUERY_DATASET", "").strip()
+    )
+    if not dataset:
+        raise WarehouseSqlError(
+            "BigQuery schema introspection requires --bigquery-dataset or HYBRIDCLAW_WAREHOUSE_SQL_BIGQUERY_DATASET."
+        )
+    qualifier = f"{project}.{dataset}" if project else dataset
+    if not re.fullmatch(r"[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_]+)?", qualifier):
+        raise WarehouseSqlError(
+            "BigQuery project/dataset contains unsupported characters for INFORMATION_SCHEMA SQL."
+        )
+    return f"`{qualifier}.INFORMATION_SCHEMA.{table}`"
+
+
+def backend_introspection_sql(args: argparse.Namespace, key: str) -> str | None:
+    sql = BACKEND_INTROSPECTION_SQL[args.backend][key]
+    if args.backend == "bigquery" and sql is not None:
+        table = "TABLES" if key == "tables" else "COLUMNS"
+        placeholder = f"`<project>.<dataset>.INFORMATION_SCHEMA.{table}`"
+        return sql.replace(
+            placeholder,
+            bigquery_qualified_information_schema(args, table),
+        )
+    return sql
+
+
 def normalize_backend_schema(args: argparse.Namespace) -> dict[str, Any]:
-    table_rows = run_backend_sql(args, BACKEND_INTROSPECTION_SQL[args.backend]["tables"])
-    column_rows = run_backend_sql(args, BACKEND_INTROSPECTION_SQL[args.backend]["columns"])
-    fk_sql = BACKEND_INTROSPECTION_SQL[args.backend]["foreignKeys"]
+    tables_sql = backend_introspection_sql(args, "tables")
+    columns_sql = backend_introspection_sql(args, "columns")
+    if tables_sql is None or columns_sql is None:
+        raise WarehouseSqlError(f"{args.backend} does not define required table/column introspection SQL.")
+    table_rows = run_backend_sql(args, tables_sql)
+    column_rows = run_backend_sql(args, columns_sql)
+    fk_sql = backend_introspection_sql(args, "foreignKeys")
     fk_rows = run_backend_sql(args, fk_sql) if fk_sql is not None else []
 
     tables: dict[tuple[str, str], dict[str, Any]] = {}
@@ -610,24 +654,30 @@ def load_or_refresh_schema(args: argparse.Namespace) -> dict[str, Any]:
     now = time.time()
 
     if path.exists() and not args.refresh:
-        age_seconds = now - path.stat().st_mtime
-        if ttl_seconds == 0 or age_seconds <= ttl_seconds:
-            payload = json.loads(path.read_text(encoding="utf-8"))
-            if payload.get("cacheVersion") == CACHE_VERSION:
-                payload["cache"] = {
-                    "status": "hit",
-                    "path": str(path),
-                    "ageSeconds": int(age_seconds),
-                    "ttlSeconds": ttl_seconds,
-                }
-                return payload
+        try:
+            age_seconds = now - path.stat().st_mtime
+            if ttl_seconds == 0 or age_seconds <= ttl_seconds:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+                if payload.get("cacheVersion") == CACHE_VERSION:
+                    payload["cache"] = {
+                        "status": "hit",
+                        "path": str(path),
+                        "ageSeconds": int(age_seconds),
+                        "ttlSeconds": ttl_seconds,
+                    }
+                    return payload
+        except (OSError, json.JSONDecodeError):
+            pass
 
     if args.backend == "sqlite":
         payload = sqlite_schema(args.database)
         payload["profile"] = args.profile
     else:
         payload = normalize_backend_schema(args)
-        payload["introspection"] = BACKEND_INTROSPECTION_SQL[args.backend]
+        payload["introspection"] = {
+            key: backend_introspection_sql(args, key)
+            for key in ("tables", "columns", "foreignKeys")
+        }
         payload["adapter"] = "command" if resolve_backend_command(args) else "python-driver"
 
     write_private_json(path, payload)
@@ -707,15 +757,25 @@ def review_sql(
         for keyword in MUTATING_KEYWORDS
         if re.search(rf"\b{re.escape(keyword)}\b", lowered)
     )
+    write_through_select = bool(
+        re.search(r"\bselect\b[\s\S]*\binto\b", cleaned, re.IGNORECASE)
+    )
     starter = first_keyword(statements[0]) if statements else ""
-    read_only = bool(statements) and starter in READ_ONLY_STARTERS and not keyword_hits
+    read_only = (
+        bool(statements)
+        and starter in READ_ONLY_STARTERS
+        and not keyword_hits
+        and not write_through_select
+    )
     requires_write_grant = not read_only
 
     if keyword_hits:
         findings.append(f"Mutating or privileged keyword(s) found: {', '.join(keyword_hits)}.")
+    if write_through_select:
+        findings.append("SELECT INTO requires the write-grant path.")
     if statements and starter not in READ_ONLY_STARTERS:
         findings.append(f"Statement starts with '{starter or 'unknown'}', not a read-only SQL verb.")
-    if read_only and " limit " not in lowered and starter != "explain":
+    if read_only and not re.search(r"\blimit\b", cleaned, re.IGNORECASE) and starter != "explain":
         findings.append("Exploratory read does not include LIMIT; add one unless an aggregate query requires all rows.")
 
     if requires_write_grant:
@@ -988,7 +1048,33 @@ def build_refresh_command(args: argparse.Namespace) -> list[str]:
         command.extend(["--cache-dir", args.cache_dir])
     if getattr(args, "backend_command", None):
         command.extend(["--backend-command", args.backend_command])
+    if getattr(args, "bigquery_project", None):
+        command.extend(["--bigquery-project", args.bigquery_project])
+    if getattr(args, "bigquery_dataset", None):
+        command.extend(["--bigquery-dataset", args.bigquery_dataset])
     return command
+
+
+def scheduler_delivery_payload(args: argparse.Namespace) -> dict[str, Any]:
+    delivery_kind = str(getattr(args, "delivery_kind", "") or "last-channel")
+    if delivery_kind == "last-channel":
+        return {"kind": "last-channel"}
+    if delivery_kind == "channel":
+        delivery_to = str(getattr(args, "delivery_to", "") or "").strip()
+        if not delivery_to:
+            raise WarehouseSqlError("Channel delivery requires --delivery-to.")
+        return {
+            "kind": "channel",
+            "channel": args.delivery_channel,
+            "to": delivery_to,
+        }
+    webhook_url = str(getattr(args, "delivery_webhook_url", "") or "").strip()
+    if not webhook_url:
+        raise WarehouseSqlError("Webhook delivery requires --delivery-webhook-url.")
+    return {
+        "kind": "webhook",
+        "webhookUrl": webhook_url,
+    }
 
 
 def scheduler_job_payload(args: argparse.Namespace) -> dict[str, Any]:
@@ -1015,10 +1101,7 @@ def scheduler_job_payload(args: argparse.Namespace) -> dict[str, Any]:
             "kind": "agent_turn",
             "message": message,
         },
-        "delivery": {
-            "kind": "channel",
-            "to": args.delivery_channel,
-        },
+        "delivery": scheduler_delivery_payload(args),
     }
 
 
@@ -1114,6 +1197,8 @@ def build_parser() -> argparse.ArgumentParser:
     schema.add_argument("--cache-dir", help="Schema cache directory.")
     schema.add_argument("--cache-ttl-seconds", type=int, default=DEFAULT_CACHE_TTL_SECONDS)
     schema.add_argument("--backend-command", help="Executable connector command that reads SQL on stdin and emits JSON/CSV rows.")
+    schema.add_argument("--bigquery-project", help="BigQuery project for INFORMATION_SCHEMA introspection.")
+    schema.add_argument("--bigquery-dataset", help="BigQuery dataset for INFORMATION_SCHEMA introspection.")
     schema.add_argument("--timeout-seconds", type=int, default=60)
     schema.add_argument("--refresh", action="store_true", help="Force a schema refresh.")
     schema.set_defaults(func=handle_schema)
@@ -1128,11 +1213,20 @@ def build_parser() -> argparse.ArgumentParser:
     schedule_refresh.add_argument("--profile", default="default")
     schedule_refresh.add_argument("--cache-dir", help="Schema cache directory.")
     schedule_refresh.add_argument("--backend-command", help="Executable connector command that reads SQL on stdin and emits JSON/CSV rows.")
+    schedule_refresh.add_argument("--bigquery-project", help="BigQuery project for INFORMATION_SCHEMA introspection.")
+    schedule_refresh.add_argument("--bigquery-dataset", help="BigQuery dataset for INFORMATION_SCHEMA introspection.")
     schedule_refresh.add_argument("--every", default="0 */6 * * *", help="Cron expression.")
     schedule_refresh.add_argument("--time-zone", default="UTC")
     schedule_refresh.add_argument("--job-id")
     schedule_refresh.add_argument("--agent-id", default="main")
-    schedule_refresh.add_argument("--delivery-channel", default="scheduler")
+    schedule_refresh.add_argument(
+        "--delivery-kind",
+        choices=["last-channel", "channel", "webhook"],
+        default="last-channel",
+    )
+    schedule_refresh.add_argument("--delivery-channel", default="discord", help="Channel kind for channel deliveries.")
+    schedule_refresh.add_argument("--delivery-to", help="Destination/channel id for channel deliveries.")
+    schedule_refresh.add_argument("--delivery-webhook-url", help="Webhook URL for webhook deliveries.")
     schedule_refresh.add_argument("--gateway-url")
     schedule_refresh.add_argument("--gateway-token")
     schedule_refresh.add_argument("--timeout-seconds", type=int, default=30)

--- a/skills/warehouse-sql/scripts/warehouse_sql.py
+++ b/skills/warehouse-sql/scripts/warehouse_sql.py
@@ -32,6 +32,7 @@ DEFAULT_CACHE_TTL_SECONDS = 6 * 60 * 60
 DEFAULT_MAX_ROWS = 200
 WRITE_GRANT_ENV = "HYBRIDCLAW_WAREHOUSE_SQL_WRITE_GRANT"
 DEFAULT_GATEWAY_URL = "http://127.0.0.1:9090"
+DEFAULT_MODEL_REVIEW_MODEL = "gpt-5"
 CONNECTOR_ENV_PASSTHROUGH = {
     "HOME",
     "LANG",
@@ -735,6 +736,24 @@ def write_grant_matches(write_grant: str | None, expected_grant: str) -> bool:
     return hmac.compare_digest(write_grant, expected_grant)
 
 
+def resolve_gateway_url(args: argparse.Namespace) -> str:
+    return (
+        str(getattr(args, "gateway_url", "") or "").strip()
+        or os.environ.get("HYBRIDCLAW_GATEWAY_URL", "").strip()
+        or os.environ.get("GATEWAY_BASE_URL", "").strip()
+        or DEFAULT_GATEWAY_URL
+    )
+
+
+def resolve_gateway_token(args: argparse.Namespace) -> str:
+    return (
+        str(getattr(args, "gateway_token", "") or "").strip()
+        or os.environ.get("HYBRIDCLAW_GATEWAY_TOKEN", "").strip()
+        or os.environ.get("GATEWAY_API_TOKEN", "").strip()
+        or ""
+    )
+
+
 def review_sql(
     sql: str,
     *,
@@ -805,24 +824,182 @@ def review_sql(
     )
 
 
-def review_payload_from_result(sql: str, result: ReviewResult) -> dict[str, Any]:
+def default_model_review_payload() -> dict[str, Any]:
+    return {
+        "enabled": False,
+        "status": "not-run",
+        "instructions": [
+            "Check that the SQL answers the user's business question.",
+            "Confirm joins and filters against the schema cache.",
+            "Return SQL before execution when the user asked to review it or scope is broad.",
+        ],
+    }
+
+
+def review_payload_from_result(
+    sql: str,
+    result: ReviewResult,
+    model_review: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    findings = list(result.findings)
+    status = result.status
+    if model_review and model_review.get("status") != "pass":
+        status = "block"
+        findings.append("Model review blocked execution.")
     return {
         "sql": sql.strip(),
         "review": {
+            "status": status,
+            "readOnly": result.read_only,
+            "statementCount": len(result.statements),
+            "requiresWriteGrant": result.requires_write_grant,
+            "findings": findings,
+            "modelReview": model_review or default_model_review_payload(),
+        },
+    }
+
+
+def resolve_model_review_url(args: argparse.Namespace) -> str:
+    explicit = str(getattr(args, "model_review_url", "") or "").strip()
+    if explicit:
+        return explicit
+    env_url = os.environ.get("HYBRIDCLAW_WAREHOUSE_SQL_MODEL_REVIEW_URL", "").strip()
+    if env_url:
+        return env_url
+    return f"{resolve_gateway_url(args).rstrip('/')}/v1/chat/completions"
+
+
+def resolve_model_review_token(args: argparse.Namespace) -> str:
+    return (
+        os.environ.get("HYBRIDCLAW_WAREHOUSE_SQL_MODEL_REVIEW_TOKEN", "").strip()
+        or resolve_gateway_token(args)
+    )
+
+
+def resolve_model_review_model(args: argparse.Namespace) -> str:
+    return (
+        str(getattr(args, "model_review_model", "") or "").strip()
+        or os.environ.get("HYBRIDCLAW_WAREHOUSE_SQL_MODEL_REVIEW_MODEL", "").strip()
+        or DEFAULT_MODEL_REVIEW_MODEL
+    )
+
+
+def model_review_schema_context(args: argparse.Namespace) -> str:
+    path_raw = str(getattr(args, "schema_cache", "") or "").strip()
+    if not path_raw:
+        return ""
+    path = Path(path_raw).expanduser()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise WarehouseSqlError(f"Model review schema cache could not be read: {path}") from exc
+    return text[:20000]
+
+
+def parse_model_review_content(content: str) -> dict[str, Any]:
+    stripped = content.strip()
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        start = stripped.find("{")
+        end = stripped.rfind("}")
+        if start < 0 or end <= start:
+            raise WarehouseSqlError("Model review response was not JSON.")
+        try:
+            parsed = json.loads(stripped[start : end + 1])
+        except json.JSONDecodeError as exc:
+            raise WarehouseSqlError("Model review response was not valid JSON.") from exc
+    if not isinstance(parsed, dict):
+        raise WarehouseSqlError("Model review response must be a JSON object.")
+    status = str(parsed.get("status", "")).strip().lower()
+    if status not in {"pass", "block"}:
+        raise WarehouseSqlError("Model review response status must be 'pass' or 'block'.")
+    findings_raw = parsed.get("findings", [])
+    if not isinstance(findings_raw, list):
+        raise WarehouseSqlError("Model review response findings must be a JSON array.")
+    return {
+        "status": status,
+        "summary": str(parsed.get("summary", "") or "").strip(),
+        "findings": [str(item) for item in findings_raw],
+    }
+
+
+def run_model_review(
+    sql: str,
+    args: argparse.Namespace,
+    result: ReviewResult,
+) -> dict[str, Any]:
+    url = resolve_model_review_url(args)
+    model = resolve_model_review_model(args)
+    question = str(getattr(args, "question", "") or "").strip()
+    schema_context = model_review_schema_context(args)
+    prompt = {
+        "question": question,
+        "sql": sql.strip(),
+        "deterministicReview": {
             "status": result.status,
             "readOnly": result.read_only,
             "statementCount": len(result.statements),
             "requiresWriteGrant": result.requires_write_grant,
             "findings": result.findings,
-            "modelReview": {
-                "required": True,
-                "instructions": [
-                    "Check that the SQL answers the user's business question.",
-                    "Confirm joins and filters against the schema cache.",
-                    "Return SQL before execution when the user asked to review it or scope is broad.",
-                ],
-            },
         },
+        "schemaCache": schema_context,
+    }
+    body = json.dumps(
+        {
+            "model": model,
+            "stream": False,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": (
+                        "You review warehouse SQL for business meaning and schema fit. "
+                        "Return only JSON with status 'pass' or 'block', summary, and findings array. "
+                        "Block SQL that does not answer the question, references absent schema, "
+                        "uses unsafe scope, or should be shown to the user before execution."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": json.dumps(prompt, sort_keys=True),
+                },
+            ],
+        }
+    ).encode("utf-8")
+    req = request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    token = resolve_model_review_token(args)
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        timeout_seconds = max(1, int(getattr(args, "model_review_timeout_seconds", 60)))
+        with request.urlopen(req, timeout=timeout_seconds) as response:
+            raw = response.read().decode("utf-8")
+    except error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise WarehouseSqlError(f"Model review failed ({exc.code}): {detail}") from exc
+    except error.URLError as exc:
+        raise WarehouseSqlError(f"Model review failed: {exc.reason}") from exc
+
+    try:
+        payload = json.loads(raw)
+        content = payload["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError, json.JSONDecodeError) as exc:
+        raise WarehouseSqlError("Model review response did not match OpenAI-compatible chat completion shape.") from exc
+    if not isinstance(content, str):
+        raise WarehouseSqlError("Model review response content must be a string.")
+    parsed = parse_model_review_content(content)
+    return {
+        "enabled": True,
+        "provider": "openai-compatible",
+        "model": model,
+        "status": parsed["status"],
+        "summary": parsed["summary"],
+        "findings": parsed["findings"],
     }
 
 
@@ -832,7 +1009,37 @@ def review_payload(sql: str, args: argparse.Namespace) -> dict[str, Any]:
         allow_write=getattr(args, "allow_write", False),
         write_grant=getattr(args, "write_grant", None),
     )
-    return review_payload_from_result(sql, result)
+    model_review = (
+        run_model_review(sql, args, result)
+        if getattr(args, "model_review", False)
+        else None
+    )
+    return review_payload_from_result(sql, result, model_review)
+
+
+def add_model_review_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--model-review",
+        action="store_true",
+        help="Invoke the OpenAI-compatible gateway for model review.",
+    )
+    parser.add_argument(
+        "--model-review-url",
+        help="OpenAI-compatible chat completions URL for model review.",
+    )
+    parser.add_argument(
+        "--model-review-model",
+        help=f"Model id for model review (default: {DEFAULT_MODEL_REVIEW_MODEL}).",
+    )
+    parser.add_argument("--model-review-timeout-seconds", type=int, default=60)
+    parser.add_argument(
+        "--question",
+        help="Natural-language business question the SQL should answer.",
+    )
+    parser.add_argument(
+        "--schema-cache",
+        help="Schema cache JSON file to include in model review context.",
+    )
 
 
 def execute_sqlite_query(
@@ -1011,24 +1218,6 @@ def handle_backend_contract(args: argparse.Namespace) -> Any:
     }
 
 
-def resolve_gateway_url(args: argparse.Namespace) -> str:
-    return (
-        str(getattr(args, "gateway_url", "") or "").strip()
-        or os.environ.get("HYBRIDCLAW_GATEWAY_URL", "").strip()
-        or os.environ.get("GATEWAY_BASE_URL", "").strip()
-        or DEFAULT_GATEWAY_URL
-    )
-
-
-def resolve_gateway_token(args: argparse.Namespace) -> str:
-    return (
-        str(getattr(args, "gateway_token", "") or "").strip()
-        or os.environ.get("HYBRIDCLAW_GATEWAY_TOKEN", "").strip()
-        or os.environ.get("GATEWAY_API_TOKEN", "").strip()
-        or ""
-    )
-
-
 def build_refresh_command(args: argparse.Namespace) -> list[str]:
     command = [
         "python3",
@@ -1146,7 +1335,10 @@ def handle_query(args: argparse.Namespace) -> Any:
         allow_write=args.allow_write,
         write_grant=args.write_grant,
     )
-    payload = review_payload_from_result(args.sql, review_result)
+    model_review = (
+        run_model_review(args.sql, args, review_result) if args.model_review else None
+    )
+    payload = review_payload_from_result(args.sql, review_result, model_review)
     if not args.execute:
         payload["execution"] = {
             "status": "not-run",
@@ -1237,6 +1429,7 @@ def build_parser() -> argparse.ArgumentParser:
     review.add_argument("sql")
     review.add_argument("--allow-write", action="store_true")
     review.add_argument("--write-grant")
+    add_model_review_arguments(review)
     review.set_defaults(func=lambda args: review_payload(args.sql, args))
 
     query = subparsers.add_parser("query", help="Review SQL and optionally execute it.")
@@ -1250,6 +1443,7 @@ def build_parser() -> argparse.ArgumentParser:
     query.add_argument("--params", help="JSON array of SQLite parameters for positional placeholders.")
     query.add_argument("--allow-write", action="store_true")
     query.add_argument("--write-grant")
+    add_model_review_arguments(query)
     query.add_argument("sql")
     query.set_defaults(func=handle_query)
 

--- a/skills/warehouse-sql/scripts/warehouse_sql.py
+++ b/skills/warehouse-sql/scripts/warehouse_sql.py
@@ -610,13 +610,14 @@ def load_or_refresh_schema(args: argparse.Namespace) -> dict[str, Any]:
         age_seconds = now - path.stat().st_mtime
         if ttl_seconds == 0 or age_seconds <= ttl_seconds:
             payload = json.loads(path.read_text(encoding="utf-8"))
-            payload["cache"] = {
-                "status": "hit",
-                "path": str(path),
-                "ageSeconds": int(age_seconds),
-                "ttlSeconds": ttl_seconds,
-            }
-            return payload
+            if payload.get("cacheVersion") == CACHE_VERSION:
+                payload["cache"] = {
+                    "status": "hit",
+                    "path": str(path),
+                    "ageSeconds": int(age_seconds),
+                    "ttlSeconds": ttl_seconds,
+                }
+                return payload
 
     if args.backend == "sqlite":
         payload = sqlite_schema(args.database)
@@ -741,12 +742,7 @@ def review_sql(
     )
 
 
-def review_payload(sql: str, args: argparse.Namespace) -> dict[str, Any]:
-    result = review_sql(
-        sql,
-        allow_write=getattr(args, "allow_write", False),
-        write_grant=getattr(args, "write_grant", None),
-    )
+def review_payload_from_result(sql: str, result: ReviewResult) -> dict[str, Any]:
     return {
         "sql": sql.strip(),
         "review": {
@@ -767,6 +763,15 @@ def review_payload(sql: str, args: argparse.Namespace) -> dict[str, Any]:
     }
 
 
+def review_payload(sql: str, args: argparse.Namespace) -> dict[str, Any]:
+    result = review_sql(
+        sql,
+        allow_write=getattr(args, "allow_write", False),
+        write_grant=getattr(args, "write_grant", None),
+    )
+    return review_payload_from_result(sql, result)
+
+
 def execute_sqlite_query(
     database: str,
     sql: str,
@@ -775,8 +780,13 @@ def execute_sqlite_query(
     parameters: list[Any] | None = None,
     allow_write: bool = False,
     write_grant: str | None = None,
+    review_result: ReviewResult | None = None,
 ) -> dict[str, Any]:
-    result = review_sql(sql, allow_write=allow_write, write_grant=write_grant)
+    result = review_result or review_sql(
+        sql,
+        allow_write=allow_write,
+        write_grant=write_grant,
+    )
     if result.status != "pass":
         raise WarehouseSqlError("SQL review blocked execution: " + "; ".join(result.findings))
     with connect_sqlite(database) as conn:
@@ -1045,7 +1055,12 @@ def handle_schedule_refresh(args: argparse.Namespace) -> Any:
 
 def handle_query(args: argparse.Namespace) -> Any:
     ensure_backend(args.backend)
-    payload = review_payload(args.sql, args)
+    review_result = review_sql(
+        args.sql,
+        allow_write=args.allow_write,
+        write_grant=args.write_grant,
+    )
+    payload = review_payload_from_result(args.sql, review_result)
     if not args.execute:
         payload["execution"] = {
             "status": "not-run",
@@ -1067,8 +1082,7 @@ def handle_query(args: argparse.Namespace) -> Any:
             args.sql,
             max_rows=args.max_rows,
             parameters=parameters,
-            allow_write=args.allow_write,
-            write_grant=args.write_grant,
+            review_result=review_result,
         )
         adapter = "python-stdlib sqlite3"
     else:

--- a/tests/fixtures/warehouse_backend_stub.py
+++ b/tests/fixtures/warehouse_backend_stub.py
@@ -3,11 +3,22 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
+
+WRITE_GRANT_ENV = "HYBRIDCLAW_WAREHOUSE_SQL_WRITE_GRANT"
 
 sql = sys.stdin.read().lower()
 
-if "information_schema.tables" in sql:
+if "env_check" in sql:
+    rows = [
+        {
+            "has_write_grant": WRITE_GRANT_ENV in os.environ,
+            "backend": os.environ.get("WAREHOUSE_SQL_BACKEND"),
+            "profile": os.environ.get("WAREHOUSE_SQL_PROFILE"),
+        }
+    ]
+elif "information_schema.tables" in sql:
     rows = [
         {
             "table_schema": "public",

--- a/tests/fixtures/warehouse_backend_stub.py
+++ b/tests/fixtures/warehouse_backend_stub.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# ruff: noqa: INP001
+from __future__ import annotations
+
+import json
+import sys
+
+sql = sys.stdin.read().lower()
+
+if "information_schema.tables" in sql:
+    rows = [
+        {
+            "table_schema": "public",
+            "table_name": "customer",
+            "table_type": "BASE TABLE",
+        },
+        {
+            "table_schema": "public",
+            "table_name": "orders",
+            "table_type": "BASE TABLE",
+        },
+    ]
+elif "information_schema.columns" in sql:
+    rows = [
+        {
+            "table_schema": "public",
+            "table_name": "customer",
+            "column_name": "c_custkey",
+            "data_type": "integer",
+            "is_nullable": "NO",
+            "ordinal_position": 1,
+        },
+        {
+            "table_schema": "public",
+            "table_name": "customer",
+            "column_name": "c_name",
+            "data_type": "text",
+            "is_nullable": "NO",
+            "ordinal_position": 2,
+        },
+        {
+            "table_schema": "public",
+            "table_name": "orders",
+            "column_name": "o_orderkey",
+            "data_type": "integer",
+            "is_nullable": "NO",
+            "ordinal_position": 1,
+        },
+        {
+            "table_schema": "public",
+            "table_name": "orders",
+            "column_name": "o_custkey",
+            "data_type": "integer",
+            "is_nullable": "NO",
+            "ordinal_position": 2,
+        },
+    ]
+elif "constraint_type = 'foreign key'" in sql:
+    rows = [
+        {
+            "table_schema": "public",
+            "table_name": "orders",
+            "column_name": "o_custkey",
+            "references_schema": "public",
+            "references_table": "customer",
+            "references_column": "c_custkey",
+        }
+    ]
+else:
+    rows = [{"c_name": "Customer#000000101", "revenue": 1650.0}]
+
+print(json.dumps(rows))

--- a/tests/fixtures/warehouse_backend_stub.py
+++ b/tests/fixtures/warehouse_backend_stub.py
@@ -18,6 +18,8 @@ if "env_check" in sql:
             "profile": os.environ.get("WAREHOUSE_SQL_PROFILE"),
         }
     ]
+elif "bad_rows" in sql:
+    rows = [["not", "an", "object"]]
 elif "information_schema.tables" in sql:
     rows = [
         {

--- a/tests/warehouse-sql-skill.test.ts
+++ b/tests/warehouse-sql-skill.test.ts
@@ -4,7 +4,7 @@ import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
-import { expect, test } from 'vitest';
+import { afterEach, expect, test } from 'vitest';
 
 const helperPath = path.join(
   process.cwd(),
@@ -26,6 +26,20 @@ const backendStubPath = path.join(
   'fixtures',
   'warehouse_backend_stub.py',
 );
+const tempDirs = new Set<string>();
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs.clear();
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.add(dir);
+  return dir;
+}
 
 function runHelper(args: string[], env: NodeJS.ProcessEnv = {}) {
   return spawnSync('python3', [helperPath, ...args], {
@@ -34,14 +48,40 @@ function runHelper(args: string[], env: NodeJS.ProcessEnv = {}) {
   });
 }
 
-function runHelperAsync(args: string[], env: NodeJS.ProcessEnv = {}) {
+function runHelperAsync(
+  args: string[],
+  env: NodeJS.ProcessEnv = {},
+  timeoutMs = 10_000,
+) {
   return new Promise<{ status: number | null; stdout: string; stderr: string }>(
-    (resolve) => {
+    (resolve, reject) => {
       const child = spawn('python3', [helperPath, ...args], {
         env: { ...process.env, ...env },
       });
       let stdout = '';
       let stderr = '';
+      let settled = false;
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      const finishResolve = (status: number | null) => {
+        if (settled) return;
+        settled = true;
+        if (timeout) clearTimeout(timeout);
+        resolve({ status, stdout, stderr });
+      };
+      const finishReject = (error: Error) => {
+        if (settled) return;
+        settled = true;
+        if (timeout) clearTimeout(timeout);
+        reject(error);
+      };
+      timeout = setTimeout(() => {
+        child.kill();
+        finishReject(
+          new Error(
+            `Timed out after ${timeoutMs}ms waiting for warehouse SQL helper`,
+          ),
+        );
+      }, timeoutMs);
       child.stdout.setEncoding('utf8');
       child.stderr.setEncoding('utf8');
       child.stdout.on('data', (chunk) => {
@@ -50,15 +90,18 @@ function runHelperAsync(args: string[], env: NodeJS.ProcessEnv = {}) {
       child.stderr.on('data', (chunk) => {
         stderr += chunk;
       });
+      child.on('error', (error) => {
+        finishReject(error);
+      });
       child.on('close', (status) => {
-        resolve({ status, stdout, stderr });
+        finishResolve(status);
       });
     },
   );
 }
 
 function createFixtureDb(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'warehouse-sql-test-'));
+  const dir = makeTempDir('warehouse-sql-test-');
   const dbPath = path.join(dir, 'tpch.db');
   const db = new Database(dbPath);
   try {
@@ -83,9 +126,7 @@ test('warehouse SQL helper --help exits cleanly', () => {
 
 test('warehouse SQL helper caches SQLite schema introspection', () => {
   const dbPath = createFixtureDb();
-  const cacheDir = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'warehouse-sql-cache-'),
-  );
+  const cacheDir = makeTempDir('warehouse-sql-cache-');
 
   const first = runHelper([
     '--format',
@@ -146,12 +187,26 @@ test('warehouse SQL helper caches SQLite schema introspection', () => {
   const versionMismatchPayload = JSON.parse(versionMismatch.stdout);
   expect(versionMismatchPayload.cache.status).toBe('miss');
   expect(versionMismatchPayload.cacheVersion).toBe(firstPayload.cacheVersion);
+
+  fs.writeFileSync(secondPayload.cache.path, '{');
+  const corruptCache = runHelper([
+    '--format',
+    'json',
+    'schema',
+    '--backend',
+    'sqlite',
+    '--database',
+    dbPath,
+    '--cache-dir',
+    cacheDir,
+  ]);
+  expect(corruptCache.status).toBe(0);
+  const corruptCachePayload = JSON.parse(corruptCache.stdout);
+  expect(corruptCachePayload.cache.status).toBe('miss');
 });
 
 test('warehouse SQL helper refreshes and executes non-SQLite backends through connector commands', () => {
-  const cacheDir = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'warehouse-sql-cache-'),
-  );
+  const cacheDir = makeTempDir('warehouse-sql-cache-');
   const backendCommand = `python3 ${backendStubPath}`;
 
   const schema = runHelper([
@@ -243,6 +298,51 @@ test('warehouse SQL helper refreshes and executes non-SQLite backends through co
       profile: 'analytics',
     },
   ]);
+
+  const badRows = runHelper([
+    '--format',
+    'json',
+    'query',
+    '--backend',
+    'postgres',
+    '--profile',
+    'analytics',
+    '--backend-command',
+    backendCommand,
+    '--execute',
+    'SELECT bad_rows LIMIT 1',
+  ]);
+  expect(badRows.status).toBe(2);
+  const badRowsPayload = JSON.parse(badRows.stdout);
+  expect(badRowsPayload.error).toContain('row 0');
+});
+
+test('warehouse SQL helper renders BigQuery introspection from explicit dataset config', () => {
+  const cacheDir = makeTempDir('warehouse-sql-cache-');
+  const schema = runHelper([
+    '--format',
+    'json',
+    'schema',
+    '--backend',
+    'bigquery',
+    '--profile',
+    'analytics',
+    '--backend-command',
+    `python3 ${backendStubPath}`,
+    '--bigquery-project',
+    'example-project',
+    '--bigquery-dataset',
+    'analytics',
+    '--cache-dir',
+    cacheDir,
+    '--refresh',
+  ]);
+
+  expect(schema.status).toBe(0);
+  const payload = JSON.parse(schema.stdout);
+  expect(payload.introspection.tables).toContain(
+    '`example-project.analytics.INFORMATION_SCHEMA.TABLES`',
+  );
 });
 
 test('warehouse SQL helper blocks writes unless the per-skill grant matches', () => {
@@ -279,6 +379,31 @@ test('warehouse SQL helper blocks writes unless the per-skill grant matches', ()
   const allowedPayload = JSON.parse(allowed.stdout);
   expect(allowedPayload.review.status).toBe('pass');
   expect(allowedPayload.review.readOnly).toBe(false);
+
+  const selectInto = runHelper([
+    '--format',
+    'json',
+    'review',
+    'SELECT * INTO copied_customer FROM customer LIMIT 1',
+  ]);
+  expect(selectInto.status).toBe(0);
+  const selectIntoPayload = JSON.parse(selectInto.stdout);
+  expect(selectIntoPayload.review.status).toBe('block');
+  expect(selectIntoPayload.review.findings).toEqual(
+    expect.arrayContaining([expect.stringContaining('SELECT INTO')]),
+  );
+
+  const limitNewline = runHelper([
+    '--format',
+    'json',
+    'review',
+    'SELECT c_name FROM customer LIMIT\n1',
+  ]);
+  expect(limitNewline.status).toBe(0);
+  const limitNewlinePayload = JSON.parse(limitNewline.stdout);
+  expect(limitNewlinePayload.review.findings).not.toEqual(
+    expect.arrayContaining([expect.stringContaining('does not include LIMIT')]),
+  );
 });
 
 test('warehouse SQL helper honors write grants during SQLite execution', () => {
@@ -464,6 +589,9 @@ test('warehouse SQL helper registers scheduled schema refresh jobs through the g
         kind: 'agent_turn',
         message: expect.stringContaining('--refresh'),
       }),
+      delivery: {
+        kind: 'last-channel',
+      },
     }),
   );
 });

--- a/tests/warehouse-sql-skill.test.ts
+++ b/tests/warehouse-sql-skill.test.ts
@@ -121,6 +121,31 @@ test('warehouse SQL helper caches SQLite schema introspection', () => {
   const secondPayload = JSON.parse(second.stdout);
   expect(secondPayload.cache.status).toBe('hit');
   expect(secondPayload.cache.path).toBe(firstPayload.cache.path);
+
+  const stalePayload = JSON.parse(
+    fs.readFileSync(secondPayload.cache.path, 'utf-8'),
+  );
+  stalePayload.cacheVersion = 0;
+  fs.writeFileSync(
+    secondPayload.cache.path,
+    `${JSON.stringify(stalePayload, null, 2)}\n`,
+  );
+
+  const versionMismatch = runHelper([
+    '--format',
+    'json',
+    'schema',
+    '--backend',
+    'sqlite',
+    '--database',
+    dbPath,
+    '--cache-dir',
+    cacheDir,
+  ]);
+  expect(versionMismatch.status).toBe(0);
+  const versionMismatchPayload = JSON.parse(versionMismatch.stdout);
+  expect(versionMismatchPayload.cache.status).toBe('miss');
+  expect(versionMismatchPayload.cacheVersion).toBe(firstPayload.cacheVersion);
 });
 
 test('warehouse SQL helper refreshes and executes non-SQLite backends through connector commands', () => {

--- a/tests/warehouse-sql-skill.test.ts
+++ b/tests/warehouse-sql-skill.test.ts
@@ -73,45 +73,12 @@ test('warehouse SQL helper --help exits cleanly', () => {
   const result = runHelper(['--help']);
 
   expect(result.status).toBe(0);
-  expect(result.stdout).toContain('Natural-language warehouse SQL');
+  expect(result.stdout).toContain('Warehouse SQL schema cache');
   expect(result.stdout).toContain('schema');
   expect(result.stdout).toContain('review');
   expect(result.stdout).toContain('query');
   expect(result.stdout).toContain('eval-scenarios');
-});
-
-test('warehouse SQL helper plans and reviews read-only SQL', () => {
-  const result = runHelper([
-    '--format',
-    'json',
-    'plan',
-    'top customers by revenue',
-  ]);
-
-  expect(result.status).toBe(0);
-  const payload = JSON.parse(result.stdout);
-  expect(payload.command).toBe('plan');
-  expect(payload.sql).toContain('JOIN lineitem');
-  expect(payload.sql).toContain('revenue');
-  expect(payload.parameters).toEqual([]);
-  expect(payload.review.status).toBe('pass');
-  expect(payload.review.readOnly).toBe(true);
-  expect(payload.review.modelReview.required).toBe(true);
-});
-
-test('warehouse SQL helper emits parameters for planned customer filters', () => {
-  const result = runHelper([
-    '--format',
-    'json',
-    'plan',
-    'orders for Customer#000000101',
-  ]);
-
-  expect(result.status).toBe(0);
-  const payload = JSON.parse(result.stdout);
-  expect(payload.sql).toContain('WHERE c.c_name = ?');
-  expect(payload.sql).not.toContain('Customer#000000101');
-  expect(payload.parameters).toEqual(['Customer#000000101']);
+  expect(result.stdout).not.toContain(' plan ');
 });
 
 test('warehouse SQL helper caches SQLite schema introspection', () => {
@@ -384,7 +351,7 @@ test('warehouse SQL helper eval suite covers TPC-H-style scenarios', () => {
   });
 });
 
-test('warehouse SQL helper emits backend contracts and schedule refresh commands', () => {
+test('warehouse SQL helper emits backend contracts', () => {
   const contract = runHelper([
     '--format',
     'json',
@@ -397,24 +364,6 @@ test('warehouse SQL helper emits backend contracts and schedule refresh commands
   expect(contractPayload.execution).toContain('operator-approved');
   expect(contractPayload.introspection.tables).toContain(
     'information_schema.tables',
-  );
-
-  const schedule = runHelper([
-    '--format',
-    'json',
-    'schedule-command',
-    '--backend',
-    'postgres',
-    '--profile',
-    'analytics',
-    '--every',
-    '0 */6 * * *',
-  ]);
-  expect(schedule.status).toBe(0);
-  const schedulePayload = JSON.parse(schedule.stdout);
-  expect(schedulePayload.command).toContain('--refresh');
-  expect(schedulePayload.hybridclawExample).toContain(
-    'hybridclaw schedule create',
   );
 });
 

--- a/tests/warehouse-sql-skill.test.ts
+++ b/tests/warehouse-sql-skill.test.ts
@@ -93,9 +93,25 @@ test('warehouse SQL helper plans and reviews read-only SQL', () => {
   expect(payload.command).toBe('plan');
   expect(payload.sql).toContain('JOIN lineitem');
   expect(payload.sql).toContain('revenue');
+  expect(payload.parameters).toEqual([]);
   expect(payload.review.status).toBe('pass');
   expect(payload.review.readOnly).toBe(true);
   expect(payload.review.modelReview.required).toBe(true);
+});
+
+test('warehouse SQL helper emits parameters for planned customer filters', () => {
+  const result = runHelper([
+    '--format',
+    'json',
+    'plan',
+    'orders for Customer#000000101',
+  ]);
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.sql).toContain('WHERE c.c_name = ?');
+  expect(payload.sql).not.toContain('Customer#000000101');
+  expect(payload.parameters).toEqual(['Customer#000000101']);
 });
 
 test('warehouse SQL helper caches SQLite schema introspection', () => {
@@ -118,6 +134,7 @@ test('warehouse SQL helper caches SQLite schema introspection', () => {
   expect(first.status).toBe(0);
   const firstPayload = JSON.parse(first.stdout);
   expect(firstPayload.cache.status).toBe('miss');
+  expect(fs.statSync(firstPayload.cache.path).mode & 0o777).toBe(0o600);
   expect(
     firstPayload.tables.map((table: { name: string }) => table.name),
   ).toContain('lineitem');
@@ -204,6 +221,35 @@ test('warehouse SQL helper refreshes and executes non-SQLite backends through co
   expect(queryPayload.execution.backend).toBe('postgres');
   expect(queryPayload.execution.rows).toEqual([
     { c_name: 'Customer#000000101', revenue: 1650 },
+  ]);
+
+  const envCheck = runHelper(
+    [
+      '--format',
+      'json',
+      'query',
+      '--backend',
+      'postgres',
+      '--profile',
+      'analytics',
+      '--backend-command',
+      backendCommand,
+      '--execute',
+      'SELECT env_check LIMIT 1',
+    ],
+    {
+      HYBRIDCLAW_WAREHOUSE_SQL_WRITE_GRANT: 'secret-grant',
+      HYBRIDCLAW_WAREHOUSE_SQL_POSTGRES_PASSWORD: 'backend-secret',
+    },
+  );
+  expect(envCheck.status).toBe(0);
+  const envPayload = JSON.parse(envCheck.stdout);
+  expect(envPayload.execution.rows).toEqual([
+    {
+      backend: 'postgres',
+      has_write_grant: false,
+      profile: 'analytics',
+    },
   ]);
 });
 
@@ -307,7 +353,9 @@ test('warehouse SQL helper executes reviewed SQLite queries only when requested'
     '--database',
     dbPath,
     '--execute',
-    'SELECT c_name FROM customer ORDER BY c_name LIMIT 1',
+    '--params',
+    '["Customer#000000101"]',
+    'SELECT c_name FROM customer WHERE c_name = ? LIMIT 1',
   ]);
   expect(executed.status).toBe(0);
   const executedPayload = JSON.parse(executed.stdout);

--- a/tests/warehouse-sql-skill.test.ts
+++ b/tests/warehouse-sql-skill.test.ts
@@ -406,6 +406,106 @@ test('warehouse SQL helper blocks writes unless the per-skill grant matches', ()
   );
 });
 
+test('warehouse SQL helper invokes model review through an OpenAI-compatible endpoint', async () => {
+  const received = await new Promise<{
+    body: string;
+    authorization: string | undefined;
+    result: { status: number | null; stdout: string; stderr: string };
+    url: string | undefined;
+  }>((resolve, reject) => {
+    let requestBody = '';
+    let authorization: string | undefined;
+    let url: string | undefined;
+    const server = http.createServer((req, res) => {
+      let body = '';
+      authorization = req.headers.authorization;
+      url = req.url;
+      req.setEncoding('utf8');
+      req.on('data', (chunk) => {
+        body += chunk;
+      });
+      req.on('end', () => {
+        requestBody = body;
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  content: JSON.stringify({
+                    status: 'pass',
+                    summary: 'SQL answers the customer lookup question.',
+                    findings: [],
+                  }),
+                },
+              },
+            ],
+          }),
+        );
+      });
+    });
+    server.listen(0, '127.0.0.1', async () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('Expected TCP test server address.'));
+        return;
+      }
+      try {
+        const result = await runHelperAsync(
+          [
+            '--format',
+            'json',
+            'review',
+            '--model-review',
+            '--model-review-url',
+            `http://127.0.0.1:${address.port}/v1/chat/completions`,
+            '--model-review-model',
+            'test-model',
+            '--question',
+            'Which customer is first alphabetically?',
+            'SELECT c_name FROM customer ORDER BY c_name LIMIT 1',
+          ],
+          { HYBRIDCLAW_WAREHOUSE_SQL_MODEL_REVIEW_TOKEN: 'model-token' },
+        );
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve({
+            body: requestBody,
+            authorization,
+            result,
+            url,
+          });
+        });
+      } catch (error) {
+        server.close(() => {
+          reject(error);
+        });
+      }
+    });
+  });
+
+  expect(received.result.status).toBe(0);
+  expect(received.url).toBe('/v1/chat/completions');
+  expect(received.authorization).toBe('Bearer model-token');
+  const requestPayload = JSON.parse(received.body);
+  expect(requestPayload.model).toBe('test-model');
+  expect(requestPayload.messages[1].content).toContain(
+    'Which customer is first alphabetically?',
+  );
+  const payload = JSON.parse(received.result.stdout);
+  expect(payload.review.status).toBe('pass');
+  expect(payload.review.modelReview).toMatchObject({
+    enabled: true,
+    model: 'test-model',
+    provider: 'openai-compatible',
+    status: 'pass',
+    summary: 'SQL answers the customer lookup question.',
+  });
+});
+
 test('warehouse SQL helper honors write grants during SQLite execution', () => {
   const dbPath = createFixtureDb();
   const result = runHelper(

--- a/tests/warehouse-sql-skill.test.ts
+++ b/tests/warehouse-sql-skill.test.ts
@@ -1,0 +1,447 @@
+import { spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { expect, test } from 'vitest';
+
+const helperPath = path.join(
+  process.cwd(),
+  'skills',
+  'warehouse-sql',
+  'scripts',
+  'warehouse_sql.py',
+);
+const fixturePath = path.join(
+  process.cwd(),
+  'skills',
+  'warehouse-sql',
+  'evals',
+  'tpch_tiny.sql',
+);
+const backendStubPath = path.join(
+  process.cwd(),
+  'tests',
+  'fixtures',
+  'warehouse_backend_stub.py',
+);
+
+function runHelper(args: string[], env: NodeJS.ProcessEnv = {}) {
+  return spawnSync('python3', [helperPath, ...args], {
+    encoding: 'utf-8',
+    env: { ...process.env, ...env },
+  });
+}
+
+function runHelperAsync(args: string[], env: NodeJS.ProcessEnv = {}) {
+  return new Promise<{ status: number | null; stdout: string; stderr: string }>(
+    (resolve) => {
+      const child = spawn('python3', [helperPath, ...args], {
+        env: { ...process.env, ...env },
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.setEncoding('utf8');
+      child.stderr.setEncoding('utf8');
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk;
+      });
+      child.stderr.on('data', (chunk) => {
+        stderr += chunk;
+      });
+      child.on('close', (status) => {
+        resolve({ status, stdout, stderr });
+      });
+    },
+  );
+}
+
+function createFixtureDb(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'warehouse-sql-test-'));
+  const dbPath = path.join(dir, 'tpch.db');
+  const db = new Database(dbPath);
+  try {
+    db.exec(fs.readFileSync(fixturePath, 'utf-8'));
+  } finally {
+    db.close();
+  }
+  return dbPath;
+}
+
+test('warehouse SQL helper --help exits cleanly', () => {
+  const result = runHelper(['--help']);
+
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain('Natural-language warehouse SQL');
+  expect(result.stdout).toContain('schema');
+  expect(result.stdout).toContain('review');
+  expect(result.stdout).toContain('query');
+  expect(result.stdout).toContain('eval-scenarios');
+});
+
+test('warehouse SQL helper plans and reviews read-only SQL', () => {
+  const result = runHelper([
+    '--format',
+    'json',
+    'plan',
+    'top customers by revenue',
+  ]);
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.command).toBe('plan');
+  expect(payload.sql).toContain('JOIN lineitem');
+  expect(payload.sql).toContain('revenue');
+  expect(payload.review.status).toBe('pass');
+  expect(payload.review.readOnly).toBe(true);
+  expect(payload.review.modelReview.required).toBe(true);
+});
+
+test('warehouse SQL helper caches SQLite schema introspection', () => {
+  const dbPath = createFixtureDb();
+  const cacheDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'warehouse-sql-cache-'),
+  );
+
+  const first = runHelper([
+    '--format',
+    'json',
+    'schema',
+    '--backend',
+    'sqlite',
+    '--database',
+    dbPath,
+    '--cache-dir',
+    cacheDir,
+  ]);
+  expect(first.status).toBe(0);
+  const firstPayload = JSON.parse(first.stdout);
+  expect(firstPayload.cache.status).toBe('miss');
+  expect(
+    firstPayload.tables.map((table: { name: string }) => table.name),
+  ).toContain('lineitem');
+
+  const second = runHelper([
+    '--format',
+    'json',
+    'schema',
+    '--backend',
+    'sqlite',
+    '--database',
+    dbPath,
+    '--cache-dir',
+    cacheDir,
+  ]);
+  expect(second.status).toBe(0);
+  const secondPayload = JSON.parse(second.stdout);
+  expect(secondPayload.cache.status).toBe('hit');
+  expect(secondPayload.cache.path).toBe(firstPayload.cache.path);
+});
+
+test('warehouse SQL helper refreshes and executes non-SQLite backends through connector commands', () => {
+  const cacheDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'warehouse-sql-cache-'),
+  );
+  const backendCommand = `python3 ${backendStubPath}`;
+
+  const schema = runHelper([
+    '--format',
+    'json',
+    'schema',
+    '--backend',
+    'postgres',
+    '--profile',
+    'analytics',
+    '--backend-command',
+    backendCommand,
+    '--cache-dir',
+    cacheDir,
+    '--refresh',
+  ]);
+  expect(schema.status).toBe(0);
+  const schemaPayload = JSON.parse(schema.stdout);
+  expect(schemaPayload.backend).toBe('postgres');
+  expect(schemaPayload.adapter).toBe('command');
+  expect(schemaPayload.tables).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: 'customer',
+        schema: 'public',
+        columns: expect.arrayContaining([
+          expect.objectContaining({ name: 'c_name', type: 'text' }),
+        ]),
+      }),
+      expect.objectContaining({
+        name: 'orders',
+        foreignKeys: [
+          {
+            columns: ['o_custkey'],
+            referencesColumns: ['c_custkey'],
+            referencesTable: 'customer',
+          },
+        ],
+      }),
+    ]),
+  );
+
+  const query = runHelper([
+    '--format',
+    'json',
+    'query',
+    '--backend',
+    'postgres',
+    '--profile',
+    'analytics',
+    '--backend-command',
+    backendCommand,
+    '--execute',
+    'SELECT c_name FROM customer LIMIT 1',
+  ]);
+  expect(query.status).toBe(0);
+  const queryPayload = JSON.parse(query.stdout);
+  expect(queryPayload.execution.status).toBe('ran');
+  expect(queryPayload.execution.backend).toBe('postgres');
+  expect(queryPayload.execution.rows).toEqual([
+    { c_name: 'Customer#000000101', revenue: 1650 },
+  ]);
+});
+
+test('warehouse SQL helper blocks writes unless the per-skill grant matches', () => {
+  const blocked = runHelper([
+    '--format',
+    'json',
+    'review',
+    "UPDATE customer SET c_name = 'x'",
+  ]);
+  expect(blocked.status).toBe(0);
+  const blockedPayload = JSON.parse(blocked.stdout);
+  expect(blockedPayload.review.status).toBe('block');
+  expect(blockedPayload.review.requiresWriteGrant).toBe(true);
+  expect(blockedPayload.review.findings).toEqual(
+    expect.arrayContaining([
+      expect.stringContaining('Mutating or privileged keyword'),
+      expect.stringContaining('--allow-write'),
+    ]),
+  );
+
+  const allowed = runHelper(
+    [
+      '--format',
+      'json',
+      'review',
+      '--allow-write',
+      '--write-grant',
+      'test-grant',
+      "UPDATE customer SET c_name = 'x'",
+    ],
+    { HYBRIDCLAW_WAREHOUSE_SQL_WRITE_GRANT: 'test-grant' },
+  );
+  expect(allowed.status).toBe(0);
+  const allowedPayload = JSON.parse(allowed.stdout);
+  expect(allowedPayload.review.status).toBe('pass');
+  expect(allowedPayload.review.readOnly).toBe(false);
+});
+
+test('warehouse SQL helper honors write grants during SQLite execution', () => {
+  const dbPath = createFixtureDb();
+  const result = runHelper(
+    [
+      '--format',
+      'json',
+      'query',
+      '--backend',
+      'sqlite',
+      '--database',
+      dbPath,
+      '--execute',
+      '--allow-write',
+      '--write-grant',
+      'test-grant',
+      "UPDATE customer SET c_name = 'Updated Customer' WHERE c_custkey = 101",
+    ],
+    { HYBRIDCLAW_WAREHOUSE_SQL_WRITE_GRANT: 'test-grant' },
+  );
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.execution.status).toBe('ran');
+  expect(payload.execution.affectedRows).toBe(1);
+
+  const db = new Database(dbPath);
+  try {
+    expect(
+      db
+        .prepare('SELECT c_name FROM customer WHERE c_custkey = 101')
+        .pluck()
+        .get(),
+    ).toBe('Updated Customer');
+  } finally {
+    db.close();
+  }
+});
+
+test('warehouse SQL helper executes reviewed SQLite queries only when requested', () => {
+  const dbPath = createFixtureDb();
+
+  const reviewOnly = runHelper([
+    '--format',
+    'json',
+    'query',
+    '--backend',
+    'sqlite',
+    '--database',
+    dbPath,
+    'SELECT c_name FROM customer ORDER BY c_name LIMIT 1',
+  ]);
+  expect(reviewOnly.status).toBe(0);
+  const reviewPayload = JSON.parse(reviewOnly.stdout);
+  expect(reviewPayload.execution.status).toBe('not-run');
+
+  const executed = runHelper([
+    '--format',
+    'json',
+    'query',
+    '--backend',
+    'sqlite',
+    '--database',
+    dbPath,
+    '--execute',
+    'SELECT c_name FROM customer ORDER BY c_name LIMIT 1',
+  ]);
+  expect(executed.status).toBe(0);
+  const executedPayload = JSON.parse(executed.stdout);
+  expect(executedPayload.execution.status).toBe('ran');
+  expect(executedPayload.execution.rows).toEqual([
+    { c_name: 'Customer#000000101' },
+  ]);
+});
+
+test('warehouse SQL helper eval suite covers TPC-H-style scenarios', () => {
+  const result = runHelper(['--format', 'json', 'eval-scenarios']);
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.dataset).toBe('TPC-H-style tiny fixture');
+  expect(payload.scenarioCount).toBe(12);
+  expect(payload.failed).toBe(0);
+  expect(payload.categories).toMatchObject({
+    customers: 1,
+    operations: 1,
+    orders: 4,
+    parts: 1,
+    pricing: 1,
+    revenue: 3,
+    supplier: 1,
+  });
+});
+
+test('warehouse SQL helper emits backend contracts and schedule refresh commands', () => {
+  const contract = runHelper([
+    '--format',
+    'json',
+    'backend-contract',
+    '--backend',
+    'postgres',
+  ]);
+  expect(contract.status).toBe(0);
+  const contractPayload = JSON.parse(contract.stdout);
+  expect(contractPayload.execution).toContain('operator-approved');
+  expect(contractPayload.introspection.tables).toContain(
+    'information_schema.tables',
+  );
+
+  const schedule = runHelper([
+    '--format',
+    'json',
+    'schedule-command',
+    '--backend',
+    'postgres',
+    '--profile',
+    'analytics',
+    '--every',
+    '0 */6 * * *',
+  ]);
+  expect(schedule.status).toBe(0);
+  const schedulePayload = JSON.parse(schedule.stdout);
+  expect(schedulePayload.command).toContain('--refresh');
+  expect(schedulePayload.hybridclawExample).toContain(
+    'hybridclaw schedule create',
+  );
+});
+
+test('warehouse SQL helper registers scheduled schema refresh jobs through the gateway admin API', async () => {
+  const received = await new Promise<{
+    body: string;
+    authorization: string | undefined;
+    url: string | undefined;
+  }>((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      let body = '';
+      req.setEncoding('utf8');
+      req.on('data', (chunk) => {
+        body += chunk;
+      });
+      req.on('end', () => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ jobs: [] }));
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve({
+            body,
+            authorization: req.headers.authorization,
+            url: req.url,
+          });
+        });
+      });
+    });
+    server.listen(0, '127.0.0.1', async () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('Expected TCP test server address.'));
+        return;
+      }
+      const result = await runHelperAsync([
+        '--format',
+        'json',
+        'schedule-refresh',
+        '--backend',
+        'postgres',
+        '--profile',
+        'analytics',
+        '--backend-command',
+        `python3 ${backendStubPath}`,
+        '--every',
+        '0 */6 * * *',
+        '--gateway-url',
+        `http://127.0.0.1:${address.port}`,
+        '--gateway-token',
+        'test-token',
+      ]);
+      if (result.status !== 0) {
+        reject(new Error(result.stderr || result.stdout));
+      }
+    });
+  });
+
+  expect(received.url).toBe('/api/admin/scheduler');
+  expect(received.authorization).toBe('Bearer test-token');
+  const payload = JSON.parse(received.body);
+  expect(payload.job).toEqual(
+    expect.objectContaining({
+      id: 'warehouse-sql-schema-postgres-analytics',
+      enabled: true,
+      schedule: expect.objectContaining({
+        kind: 'cron',
+        expr: '0 */6 * * *',
+      }),
+      action: expect.objectContaining({
+        kind: 'agent_turn',
+        message: expect.stringContaining('--refresh'),
+      }),
+    }),
+  );
+});


### PR DESCRIPTION
## Summary

Implements #584 by adding a bundled `warehouse-sql` skill for natural-language SQL over customer data warehouses.

## What changed

- Added a `warehouse-sql` bundled skill with read-first workflow, SQL review rules, schema cache guidance, write-grant policy, and validation commands.
- Added `warehouse_sql.py`, a deterministic helper that supports cached schema introspection, scheduled schema refresh registration through the gateway scheduler, read-only SQL review by default, explicit per-skill write grant checks before mutations, SQLite execution for reproducible evals, and pluggable Postgres, ClickHouse, BigQuery, and Snowflake execution via optional Python drivers or operator-provided connector commands.
- Added a tiny TPC-H-style fixture and 12 offline eval scenarios.
- Added Vitest coverage for schema caching, non-SQLite command-backed adapters, scheduler registration, SQL review, write-grant execution, and eval results.
- Updated the bundled skill catalog and README references.

## Issue #584 acceptance criteria

- Schema introspection cached and refreshable on a schedule: implemented via schema cache files and `schedule-refresh` gateway scheduler registration.
- Read-only by default; writes require explicit per-skill grant: implemented in deterministic SQL review and execution paths.
- SQL output reviewed before execution: helper emits a review object and defaults `query` to review-only unless `--execute` is passed.
- Eval suite using a public TPC-H-style dataset: added tiny TPC-H-style schema fixture plus deterministic eval scenarios.
- Pluggable backend: supports SQLite plus Postgres, ClickHouse, BigQuery, and Snowflake through drivers or connector command protocol.

## Validation

- `python3 skills/skill-creator/scripts/quick_validate.py skills/warehouse-sql`
- `python3 skills/warehouse-sql/scripts/warehouse_sql.py --format json eval-scenarios`
- `npx vitest run tests/warehouse-sql-skill.test.ts`
- `npm run lint`
