### PR TITLE
[codex] Implement autonomous workflow engine for #461

### DIFF
--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -39,6 +39,8 @@ import type {
   AdminTerminalStopResponse,
   AdminToolsResponse,
   AdminTunnelStatus,
+  AdminWorkflowRunResponse,
+  AdminWorkflowsResponse,
   AgentListItem,
   AgentListResponse,
   AgentsOverview,
@@ -898,6 +900,52 @@ export function rejectAdaptiveSkillAmendment(
 
 export function fetchTools(token: string): Promise<AdminToolsResponse> {
   return requestJson<AdminToolsResponse>('/api/admin/tools', { token });
+}
+
+export function fetchWorkflows(token: string): Promise<AdminWorkflowsResponse> {
+  return requestJson<AdminWorkflowsResponse>('/api/admin/workflows', { token });
+}
+
+export function startWorkflow(
+  token: string,
+  workflowId: string,
+): Promise<AdminWorkflowRunResponse> {
+  return requestJson<AdminWorkflowRunResponse>('/api/admin/workflows', {
+    token,
+    method: 'POST',
+    body: { workflowId },
+  });
+}
+
+export function approveWorkflow(
+  token: string,
+  runId: string,
+  stepId?: string,
+): Promise<AdminWorkflowRunResponse> {
+  return requestJson<AdminWorkflowRunResponse>(
+    `/api/admin/workflows/runs/${encodeURIComponent(runId)}/approve`,
+    {
+      token,
+      method: 'POST',
+      body: { stepId },
+    },
+  );
+}
+
+export function returnWorkflow(
+  token: string,
+  runId: string,
+  stepId: string,
+  notes: string,
+): Promise<AdminWorkflowRunResponse> {
+  return requestJson<AdminWorkflowRunResponse>(
+    `/api/admin/workflows/runs/${encodeURIComponent(runId)}/return`,
+    {
+      token,
+      method: 'POST',
+      body: { stepId, notes },
+    },
+  );
 }
 
 export function saveSkillEnabled(

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -1320,29 +1320,6 @@ export interface AdminWorkflowRun {
   steps: AdminWorkflowStepRun[];
 }
 
-export interface AdminWorkflowStepView {
-  id: string;
-  ownerCoworkerId: string;
-  action: string;
-  status: string;
-  attempts: number;
-  active: boolean;
-  pendingApproval: boolean;
-  stakes?: string;
-  threshold?: string;
-  revisionCount: number;
-  artifactCount: number;
-}
-
-export interface AdminWorkflowRunView {
-  id: string;
-  workflowId: string;
-  name: string;
-  status: string;
-  currentStepId?: string;
-  steps: AdminWorkflowStepView[];
-}
-
 export interface AdminWorkflowsResponse {
   definitions: AdminWorkflowDefinition[];
   runs: AdminWorkflowRun[];
@@ -1350,8 +1327,6 @@ export interface AdminWorkflowsResponse {
 
 export interface AdminWorkflowRunResponse {
   run: AdminWorkflowRun;
-  view: AdminWorkflowRunView;
-  text: string;
 }
 
 export interface DeleteSessionResult {

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -1282,6 +1282,78 @@ export interface AdminToolsResponse {
   recentExecutions: AdminToolExecution[];
 }
 
+export interface AdminWorkflowDefinition {
+  id: string;
+  name: string;
+  steps: Array<{
+    id: string;
+    owner_coworker_id: string;
+    action: string;
+    stakes_threshold?: 'low' | 'medium' | 'high';
+  }>;
+  transitions: Array<{ from: string; to: string }>;
+}
+
+export interface AdminWorkflowStepRun {
+  step_id: string;
+  owner_coworker_id: string;
+  action: string;
+  status: string;
+  attempts: number;
+  artifacts: unknown[];
+  revisions: unknown[];
+  escalation?: {
+    route: 'none' | 'approval_request';
+    threshold?: 'low' | 'medium' | 'high';
+    stakes?: 'low' | 'medium' | 'high';
+    reasons: string[];
+    approved_at?: string;
+  };
+}
+
+export interface AdminWorkflowRun {
+  id: string;
+  workflow: AdminWorkflowDefinition;
+  status: string;
+  current_step_id?: string;
+  updated_at: string;
+  steps: AdminWorkflowStepRun[];
+}
+
+export interface AdminWorkflowStepView {
+  id: string;
+  ownerCoworkerId: string;
+  action: string;
+  status: string;
+  attempts: number;
+  active: boolean;
+  pendingApproval: boolean;
+  stakes?: string;
+  threshold?: string;
+  revisionCount: number;
+  artifactCount: number;
+}
+
+export interface AdminWorkflowRunView {
+  id: string;
+  workflowId: string;
+  name: string;
+  status: string;
+  currentStepId?: string;
+  steps: AdminWorkflowStepView[];
+}
+
+export interface AdminWorkflowsResponse {
+  definitions: AdminWorkflowDefinition[];
+  runs: AdminWorkflowRun[];
+}
+
+export interface AdminWorkflowRunResponse {
+  run: AdminWorkflowRun;
+  view: AdminWorkflowRunView;
+  text: string;
+}
+
 export interface DeleteSessionResult {
   deleted: boolean;
   sessionId: string;

--- a/console/src/components/sidebar/navigation.ts
+++ b/console/src/components/sidebar/navigation.ts
@@ -42,6 +42,7 @@ export const SIDEBAR_NAV_GROUPS: ReadonlyArray<SidebarNavGroup> = [
       { to: '/admin/approvals', label: 'Approvals', icon: Policy },
       { to: '/admin/audit', label: 'Audit', icon: Audit },
       { to: '/admin/jobs', label: 'Jobs', icon: Jobs },
+      { to: '/admin/workflows', label: 'Workflows', icon: Scheduler },
     ],
   },
   {

--- a/console/src/router.tsx
+++ b/console/src/router.tsx
@@ -24,6 +24,7 @@ import { SessionsPage } from './routes/sessions';
 import { SkillsPage } from './routes/skills';
 import { StatisticsPage } from './routes/statistics';
 import { ToolsPage } from './routes/tools';
+import { WorkflowsPage } from './routes/workflows';
 
 const LazyTerminalPage = lazy(async () => {
   const mod = await import('./routes/terminal');
@@ -149,6 +150,12 @@ const jobsRoute = createRoute({
   component: JobsPage,
 });
 
+const workflowsRoute = createRoute({
+  getParentRoute: () => adminLayoutRoute,
+  path: '/admin/workflows',
+  component: WorkflowsPage,
+});
+
 const mcpRoute = createRoute({
   getParentRoute: () => adminLayoutRoute,
   path: '/admin/mcp',
@@ -207,6 +214,7 @@ const routeTree = rootRoute.addChildren([
     modelsRoute,
     schedulerRoute,
     jobsRoute,
+    workflowsRoute,
     mcpRoute,
     auditRoute,
     skillsRoute,

--- a/console/src/routes/workflows.tsx
+++ b/console/src/routes/workflows.tsx
@@ -1,0 +1,229 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
+import {
+  approveWorkflow,
+  fetchWorkflows,
+  returnWorkflow,
+  startWorkflow,
+} from '../api/client';
+import type { AdminWorkflowRun } from '../api/types';
+import { useAuth } from '../auth';
+import { MetricCard, PageHeader, Panel } from '../components/ui';
+import { formatRelativeTime } from '../lib/format';
+
+function WorkflowRunTimeline(props: { run: AdminWorkflowRun }) {
+  return (
+    <ol className="timeline-list">
+      {props.run.steps.map((step) => (
+        <li
+          className={`timeline-item ${props.run.current_step_id === step.step_id ? 'active' : ''}`}
+          key={step.step_id}
+        >
+          <div>
+            <strong>{step.step_id}</strong>
+            <small>{step.owner_coworker_id}</small>
+          </div>
+          <span className="status-pill">{step.status}</span>
+          <p>{step.action}</p>
+          {step.escalation?.route === 'approval_request' &&
+          !step.escalation.approved_at ? (
+            <small>
+              pending approval - stakes {step.escalation.stakes} / threshold{' '}
+              {step.escalation.threshold}
+            </small>
+          ) : null}
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+export function WorkflowsPage() {
+  const auth = useAuth();
+  const queryClient = useQueryClient();
+  const [selectedRunId, setSelectedRunId] = useState('');
+  const [revisionNotes, setRevisionNotes] = useState('');
+
+  const workflowsQuery = useQuery({
+    queryKey: ['admin-workflows', auth.token],
+    queryFn: () => fetchWorkflows(auth.token),
+  });
+
+  const invalidate = async () => {
+    await queryClient.invalidateQueries({
+      queryKey: ['admin-workflows', auth.token],
+    });
+  };
+
+  const startMutation = useMutation({
+    mutationFn: (workflowId: string) => startWorkflow(auth.token, workflowId),
+    onSuccess: async (result) => {
+      setSelectedRunId(result.run.id);
+      await invalidate();
+    },
+  });
+
+  const approveMutation = useMutation({
+    mutationFn: (run: AdminWorkflowRun) =>
+      approveWorkflow(auth.token, run.id, run.current_step_id),
+    onSuccess: async (result) => {
+      setSelectedRunId(result.run.id);
+      await invalidate();
+    },
+  });
+
+  const returnMutation = useMutation({
+    mutationFn: (run: AdminWorkflowRun) => {
+      const stepId = run.current_step_id || run.steps[0]?.step_id || '';
+      return returnWorkflow(auth.token, run.id, stepId, revisionNotes.trim());
+    },
+    onSuccess: async (result) => {
+      setSelectedRunId(result.run.id);
+      setRevisionNotes('');
+      await invalidate();
+    },
+  });
+
+  const runs = workflowsQuery.data?.runs || [];
+  const selectedRun = useMemo(
+    () =>
+      runs.find((run) => run.id === selectedRunId) ||
+      runs[0] ||
+      null,
+    [runs, selectedRunId],
+  );
+  const activeRuns = runs.filter((run) => run.status !== 'completed').length;
+  const pendingRuns = runs.filter((run) => run.status === 'paused').length;
+
+  return (
+    <div className="page-stack">
+      <PageHeader title="Workflows" />
+
+      <div className="metric-grid">
+        <MetricCard
+          label="Definitions"
+          value={String(workflowsQuery.data?.definitions.length || 0)}
+          detail="loaded templates"
+        />
+        <MetricCard
+          label="Runs"
+          value={String(runs.length)}
+          detail="persisted workflow state"
+        />
+        <MetricCard
+          label="Active"
+          value={String(activeRuns)}
+          detail="running or paused"
+        />
+        <MetricCard
+          label="Pending"
+          value={String(pendingRuns)}
+          detail="approval required"
+        />
+      </div>
+
+      <div className="two-column-grid">
+        <Panel title="Definitions">
+          {workflowsQuery.isLoading ? (
+            <div className="empty-state">Loading workflows...</div>
+          ) : workflowsQuery.data?.definitions.length ? (
+            <div className="stack-list">
+              {workflowsQuery.data.definitions.map((definition) => (
+                <div className="list-row" key={definition.id}>
+                  <div>
+                    <strong>{definition.name}</strong>
+                    <small>
+                      {definition.id} - {definition.steps.length} steps
+                    </small>
+                  </div>
+                  <button
+                    className="primary-button"
+                    disabled={startMutation.isPending}
+                    onClick={() => startMutation.mutate(definition.id)}
+                    type="button"
+                  >
+                    Start
+                  </button>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="empty-state">No workflow definitions loaded.</div>
+          )}
+        </Panel>
+
+        <Panel title="Runs">
+          {runs.length ? (
+            <div className="stack-list">
+              {runs.map((run) => (
+                <button
+                  className="list-row button-row"
+                  key={run.id}
+                  onClick={() => setSelectedRunId(run.id)}
+                  type="button"
+                >
+                  <div>
+                    <strong>{run.workflow.name}</strong>
+                    <small>
+                      {run.id} - {formatRelativeTime(run.updated_at)}
+                    </small>
+                  </div>
+                  <span className="status-pill">{run.status}</span>
+                </button>
+              ))}
+            </div>
+          ) : (
+            <div className="empty-state">No workflow runs yet.</div>
+          )}
+        </Panel>
+      </div>
+
+      <Panel title="Run state">
+        {selectedRun ? (
+          <div className="page-stack">
+            <div className="list-row">
+              <div>
+                <strong>{selectedRun.workflow.name}</strong>
+                <small>
+                  {selectedRun.id}
+                  {selectedRun.current_step_id
+                    ? ` - active: ${selectedRun.current_step_id}`
+                    : ''}
+                </small>
+              </div>
+              <span className="status-pill">{selectedRun.status}</span>
+            </div>
+            <WorkflowRunTimeline run={selectedRun} />
+            <div className="inline-actions">
+              <button
+                className="primary-button"
+                disabled={
+                  selectedRun.status !== 'paused' || approveMutation.isPending
+                }
+                onClick={() => approveMutation.mutate(selectedRun)}
+                type="button"
+              >
+                Approve
+              </button>
+              <input
+                className="compact-search"
+                onChange={(event) => setRevisionNotes(event.target.value)}
+                placeholder="Revision notes"
+                value={revisionNotes}
+              />
+              <button
+                disabled={!revisionNotes.trim() || returnMutation.isPending}
+                onClick={() => returnMutation.mutate(selectedRun)}
+                type="button"
+              >
+                Return
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="empty-state">Select or start a workflow run.</div>
+        )}
+      </Panel>
+    </div>
+  );
+}

--- a/console/src/styles.css
+++ b/console/src/styles.css
@@ -571,6 +571,47 @@ code {
   white-space: nowrap;
 }
 
+.stack-list {
+  display: grid;
+  gap: 10px;
+}
+
+button.list-row {
+  width: 100%;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.inline-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.timeline-list {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.timeline-item {
+  display: grid;
+  gap: 8px;
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--panel-bg);
+}
+
+.timeline-item.active {
+  border-color: var(--accent);
+}
+
 .list-status {
   display: inline-flex;
   align-items: center;

--- a/docs/content/developer-guide/workflows.md
+++ b/docs/content/developer-guide/workflows.md
@@ -58,3 +58,7 @@ The admin console also exposes a Workflows page backed by
 `GET /api/admin/workflows`, with per-run approve and return actions. The
 visualizer shows the active step, owner, status, stakes score, and pending
 escalation state.
+
+Workflow approval prompts expire after 24 hours by default. Operators can tune
+that window with `HYBRIDCLAW_WORKFLOW_APPROVAL_TTL_MS`, expressed in
+milliseconds.

--- a/docs/content/developer-guide/workflows.md
+++ b/docs/content/developer-guide/workflows.md
@@ -1,0 +1,60 @@
+---
+title: Workflow Engine
+description: Declarative YAML workflows with A2A dispatch, F8 stakes escalation, and revision rewinds.
+---
+
+# Workflow Engine
+
+HybridClaw workflows are declarative YAML files that dispatch ordered work to
+coworkers through A2A envelopes. Steps run autonomously by default. A step only
+pauses when it declares `stakes_threshold` and the configured F8 stakes
+classifier scores the step above that bound.
+
+```yaml
+id: brief_build_review
+name: Brief build review
+steps:
+  - id: brief
+    owner_coworker_id: briefing
+    action: Write a concise marketing copy brief from the source context.
+    stakes_threshold: medium
+  - id: build
+    owner_coworker_id: builder
+    action: Build the first marketing copy draft from the approved brief.
+    stakes_threshold: medium
+  - id: review
+    owner_coworker_id: reviewer
+    action: Review the client-facing marketing copy before publication.
+    stakes_threshold: medium
+transitions:
+  - from: brief
+    to: build
+  - from: build
+    to: review
+```
+
+Required fields are `id`, `name`, `steps[].owner_coworker_id`,
+`steps[].action`, and `transitions`. `steps[].stakes_threshold` is optional and
+accepts `low`, `medium`, or `high`.
+
+Starter templates live in `presets/workflows/`:
+
+- `brief-build-review.yaml`
+- `intake-triage-assign.yaml`
+- `draft-legal-publish.yaml`
+
+Runtime state is persisted as workflow revision assets, preserving step
+artifacts across `returnForRevision(runId, stepId, notes)` rewinds. Operators
+can run and resume workflows from the gateway with:
+
+```text
+workflow list
+workflow start <workflow_id> [run_id]
+workflow approve <run_id> [step_id]
+workflow return <run_id> <step_id> <notes>
+```
+
+The admin console also exposes a Workflows page backed by
+`GET /api/admin/workflows`, with per-run approve and return actions. The
+visualizer shows the active step, owner, status, stakes score, and pending
+escalation state.

--- a/docs/content/developer-guide/workflows.md
+++ b/docs/content/developer-guide/workflows.md
@@ -34,8 +34,9 @@ transitions:
 ```
 
 Required fields are `id`, `name`, `steps[].owner_coworker_id`,
-`steps[].action`, and `transitions`. `steps[].stakes_threshold` is optional and
-accepts `low`, `medium`, or `high`.
+`steps[].action`, and `transitions`. Transitions define one linear path through
+the steps; branching and fan-in are rejected. `steps[].stakes_threshold` is
+optional and accepts `low`, `medium`, or `high`.
 
 Starter templates live in `presets/workflows/`:
 

--- a/presets/workflows/brief-build-review.yaml
+++ b/presets/workflows/brief-build-review.yaml
@@ -1,0 +1,20 @@
+id: brief_build_review
+name: Brief build review
+steps:
+  - id: brief
+    owner_coworker_id: briefing@workflow@starter
+    action: Write a concise marketing copy brief from the source context.
+    stakes_threshold: medium
+  - id: build
+    owner_coworker_id: builder@workflow@starter
+    action: Build the first marketing copy draft from the approved brief.
+    stakes_threshold: medium
+  - id: review
+    owner_coworker_id: reviewer@workflow@starter
+    action: Review the client-facing marketing copy before publication.
+    stakes_threshold: medium
+transitions:
+  - from: brief
+    to: build
+  - from: build
+    to: review

--- a/presets/workflows/draft-legal-publish.yaml
+++ b/presets/workflows/draft-legal-publish.yaml
@@ -1,0 +1,20 @@
+id: draft_legal_publish
+name: Draft legal publish
+steps:
+  - id: draft
+    owner_coworker_id: drafter@workflow@starter
+    action: Draft the contract update from the approved source brief.
+    stakes_threshold: medium
+  - id: legal
+    owner_coworker_id: legal@workflow@starter
+    action: Review contract language, liability, and customer commitments.
+    stakes_threshold: medium
+  - id: publish
+    owner_coworker_id: publisher@workflow@starter
+    action: Publish the approved contract update to the customer-facing workspace.
+    stakes_threshold: low
+transitions:
+  - from: draft
+    to: legal
+  - from: legal
+    to: publish

--- a/presets/workflows/intake-triage-assign.yaml
+++ b/presets/workflows/intake-triage-assign.yaml
@@ -1,0 +1,20 @@
+id: intake_triage_assign
+name: Intake triage assign
+steps:
+  - id: intake
+    owner_coworker_id: intake@workflow@starter
+    action: Summarize the support ticket and extract the customer need.
+    stakes_threshold: medium
+  - id: triage
+    owner_coworker_id: triage@workflow@starter
+    action: Classify priority, product area, and any customer-facing risk.
+    stakes_threshold: medium
+  - id: assign
+    owner_coworker_id: support-lead@workflow@starter
+    action: Assign the ticket to the right owner with handoff notes.
+    stakes_threshold: medium
+transitions:
+  - from: intake
+    to: triage
+  - from: triage
+    to: assign

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -99,6 +99,7 @@ const REGISTERED_TEXT_COMMAND_NAMES = new Set([
   'mcp',
   'plugin',
   'voice',
+  'workflow',
   'clear',
   'reset',
   'compact',
@@ -225,6 +226,11 @@ const LOCAL_SESSION_HELP_PRESENTATIONS: Record<
   config: {
     command: '/config [check|reload|set <key> <value>]',
     description: 'Show or update local runtime config',
+  },
+  workflow: {
+    command:
+      '/workflow [list|start <workflow_id>|approve <run_id>|return <run_id> <step_id> <notes>]',
+    description: 'Run and inspect declarative workflows',
   },
   context: {
     command: '/context',

--- a/src/config/runtime-config-revisions.ts
+++ b/src/config/runtime-config-revisions.ts
@@ -23,6 +23,7 @@ export const RUNTIME_REVISION_ASSET_TYPES = [
   'template',
   'a2a',
   'team',
+  'workflow',
 ] as const;
 
 export type RuntimeRevisionAssetType =
@@ -76,6 +77,11 @@ export interface RuntimeConfigRevisionStateMetadata {
   updatedAt: string;
 }
 
+export interface RuntimeConfigRevisionStateEntry
+  extends RuntimeConfigRevisionState {
+  assetPath: string;
+}
+
 export interface RuntimeConfigObservedFile {
   exists: boolean;
   content: string | null;
@@ -125,6 +131,10 @@ interface ConfigRevisionStateMetadataRow {
   route: string;
   source: string;
   updated_at: string;
+}
+
+interface ConfigRevisionStateEntryRow extends ConfigRevisionStateRow {
+  config_path: string;
 }
 
 function resolveActor(actor?: string | null): string {
@@ -685,6 +695,37 @@ export function getRuntimeAssetRevisionState(
       )
       .get(normalizedAssetType, assetPath);
     return row ? mapRevisionStateRow(row) : null;
+  });
+}
+
+export function listRuntimeAssetRevisionStates(
+  assetType: RuntimeRevisionAssetType,
+  pathPrefix?: string,
+): RuntimeConfigRevisionStateEntry[] {
+  const normalizedAssetType = normalizeRevisionAssetType(assetType);
+  const normalizedPrefix = String(pathPrefix || '').trim();
+  return withRevisionDatabase((database) => {
+    const rows = normalizedPrefix
+      ? database
+          .prepare<[string, string], ConfigRevisionStateEntryRow>(
+            `SELECT config_path, current_content, actor, route, source, updated_at
+             FROM config_revision_state
+             WHERE asset_type = ? AND config_path LIKE ?
+             ORDER BY updated_at DESC, config_path ASC`,
+          )
+          .all(normalizedAssetType, `${normalizedPrefix}%`)
+      : database
+          .prepare<[string], ConfigRevisionStateEntryRow>(
+            `SELECT config_path, current_content, actor, route, source, updated_at
+             FROM config_revision_state
+             WHERE asset_type = ?
+             ORDER BY updated_at DESC, config_path ASC`,
+          )
+          .all(normalizedAssetType);
+    return rows.map((row) => ({
+      assetPath: row.config_path,
+      ...mapRevisionStateRow(row),
+    }));
   });
 }
 

--- a/src/config/runtime-config-revisions.ts
+++ b/src/config/runtime-config-revisions.ts
@@ -698,22 +698,27 @@ export function getRuntimeAssetRevisionState(
   });
 }
 
+function escapeSqlLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, (match) => `\\${match}`);
+}
+
 export function listRuntimeAssetRevisionStates(
   assetType: RuntimeRevisionAssetType,
   pathPrefix?: string,
 ): RuntimeConfigRevisionStateEntry[] {
   const normalizedAssetType = normalizeRevisionAssetType(assetType);
   const normalizedPrefix = String(pathPrefix || '').trim();
+  const likePrefix = `${escapeSqlLikePattern(normalizedPrefix)}%`;
   return withRevisionDatabase((database) => {
     const rows = normalizedPrefix
       ? database
-          .prepare<[string, string], ConfigRevisionStateEntryRow>(
+          .prepare<[string, string, string], ConfigRevisionStateEntryRow>(
             `SELECT config_path, current_content, actor, route, source, updated_at
              FROM config_revision_state
-             WHERE asset_type = ? AND config_path LIKE ?
+             WHERE asset_type = ? AND config_path LIKE ? ESCAPE ?
              ORDER BY updated_at DESC, config_path ASC`,
           )
-          .all(normalizedAssetType, `${normalizedPrefix}%`)
+          .all(normalizedAssetType, likePrefix, '\\')
       : database
           .prepare<[string], ConfigRevisionStateEntryRow>(
             `SELECT config_path, current_content, actor, route, source, updated_at

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -3323,6 +3323,12 @@ function sendApiAdminWorkflows(res: ServerResponse): void {
   sendJson(res, 200, getWorkflowAdminSummary());
 }
 
+function sendApiAdminWorkflowError(res: ServerResponse, error: unknown): void {
+  sendJson(res, 400, {
+    error: error instanceof Error ? error.message : String(error),
+  });
+}
+
 async function handleApiAdminWorkflowStart(
   req: IncomingMessage,
   res: ServerResponse,
@@ -3346,9 +3352,7 @@ async function handleApiAdminWorkflowStart(
       text: renderWorkflowRunState(run),
     });
   } catch (error) {
-    sendJson(res, 400, {
-      error: error instanceof Error ? error.message : String(error),
-    });
+    sendApiAdminWorkflowError(res, error);
   }
 }
 
@@ -3371,9 +3375,7 @@ async function handleApiAdminWorkflowApprove(
       text: renderWorkflowRunState(run),
     });
   } catch (error) {
-    sendJson(res, 400, {
-      error: error instanceof Error ? error.message : String(error),
-    });
+    sendApiAdminWorkflowError(res, error);
   }
 }
 
@@ -3406,9 +3408,7 @@ async function handleApiAdminWorkflowReturn(
       text: renderWorkflowRunState(run),
     });
   } catch (error) {
-    sendJson(res, 400, {
-      error: error instanceof Error ? error.message : String(error),
-    });
+    sendApiAdminWorkflowError(res, error);
   }
 }
 

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -91,10 +91,6 @@ import {
 } from '../workflow/service.js';
 import { getWorkflowRunState } from '../workflow/store.js';
 import {
-  buildWorkflowRunView,
-  renderWorkflowRunState,
-} from '../workflow/visualizer.js';
-import {
   AdminTerminalCapacityError,
   type AdminTerminalStartOptions,
   createAdminTerminalManager,
@@ -3312,11 +3308,7 @@ function sendApiAdminWorkflowRun(res: ServerResponse, runId: string): void {
     sendJson(res, 404, { error: `Unknown workflow run: ${runId}` });
     return;
   }
-  sendJson(res, 200, {
-    run,
-    view: buildWorkflowRunView(run),
-    text: renderWorkflowRunState(run),
-  });
+  sendJson(res, 200, { run });
 }
 
 function sendApiAdminWorkflows(res: ServerResponse): void {
@@ -3363,11 +3355,7 @@ async function handleApiAdminWorkflowStart(
       sessionId: `admin:workflow:${workflowId}`,
       userId: resolveApiAdminActor(req),
     });
-    sendJson(res, 201, {
-      run,
-      view: buildWorkflowRunView(run),
-      text: renderWorkflowRunState(run),
-    });
+    sendJson(res, 201, { run });
   } catch (error) {
     sendApiAdminWorkflowError(res, error);
   }
@@ -3386,11 +3374,7 @@ async function handleApiAdminWorkflowApprove(
       actor: resolveApiAdminActor(req),
       sessionId: `admin:workflow:${runId}`,
     });
-    sendJson(res, 200, {
-      run,
-      view: buildWorkflowRunView(run),
-      text: renderWorkflowRunState(run),
-    });
+    sendJson(res, 200, { run });
   } catch (error) {
     sendApiAdminWorkflowError(res, error);
   }
@@ -3419,11 +3403,7 @@ async function handleApiAdminWorkflowReturn(
       actor: resolveApiAdminActor(req),
       sessionId: `admin:workflow:${runId}`,
     });
-    sendJson(res, 200, {
-      run,
-      view: buildWorkflowRunView(run),
-      text: renderWorkflowRunState(run),
-    });
+    sendJson(res, 200, { run });
   } catch (error) {
     sendApiAdminWorkflowError(res, error);
   }

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -3284,9 +3284,25 @@ function handleApiAdminApprovals(res: ServerResponse, url: URL): void {
   );
 }
 
-function handleApiAdminWorkflowRun(res: ServerResponse, url: URL): void {
-  const segments = url.pathname.split('/').filter(Boolean);
-  const runId = segments[4] ? decodeURIComponent(segments[4]) : '';
+function parseApiAdminWorkflowRunPath(pathname: string): {
+  runId: string;
+  action?: 'approve' | 'return';
+} | null {
+  const prefix = '/api/admin/workflows/runs/';
+  if (!pathname.startsWith(prefix)) return null;
+  const segments = pathname.slice(prefix.length).split('/');
+  if (segments.length < 1 || segments.length > 2) return null;
+  const rawAction = segments[1] || '';
+  const action =
+    rawAction === 'approve' || rawAction === 'return' ? rawAction : undefined;
+  if (rawAction && !action) return null;
+  return {
+    runId: decodeURIComponent(segments[0] || ''),
+    ...(action ? { action } : {}),
+  };
+}
+
+function sendApiAdminWorkflowRun(res: ServerResponse, runId: string): void {
   if (!runId) {
     sendJson(res, 400, { error: 'Expected workflow run id.' });
     return;
@@ -3303,108 +3319,97 @@ function handleApiAdminWorkflowRun(res: ServerResponse, url: URL): void {
   });
 }
 
-async function handleApiAdminWorkflows(
+function sendApiAdminWorkflows(res: ServerResponse): void {
+  sendJson(res, 200, getWorkflowAdminSummary());
+}
+
+async function handleApiAdminWorkflowStart(
   req: IncomingMessage,
   res: ServerResponse,
-  url: URL,
 ): Promise<void> {
-  const method = req.method || 'GET';
-  const segments = url.pathname.split('/').filter(Boolean);
-  if (segments.length === 3 && method === 'GET') {
-    sendJson(res, 200, getWorkflowAdminSummary());
+  const body = (await readJsonBody(req)) as ApiAdminWorkflowRequestBody;
+  const workflowId = normalizeOptionalString(body.workflowId);
+  if (!workflowId) {
+    sendJson(res, 400, { error: 'Expected non-empty `workflowId`.' });
     return;
   }
-  if (segments.length === 3 && method === 'POST') {
-    const body = (await readJsonBody(req)) as ApiAdminWorkflowRequestBody;
-    const workflowId = normalizeOptionalString(body.workflowId);
-    if (!workflowId) {
-      sendJson(res, 400, { error: 'Expected non-empty `workflowId`.' });
-      return;
-    }
-    try {
-      const run = await startWorkflowRun({
-        workflowId,
-        runId: normalizeOptionalString(body.runId),
-        sessionId: `admin:workflow:${workflowId}`,
-        userId: 'admin',
-      });
-      sendJson(res, 201, {
-        run,
-        view: buildWorkflowRunView(run),
-        text: renderWorkflowRunState(run),
-      });
-    } catch (error) {
-      sendJson(res, 400, {
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
+  try {
+    const run = await startWorkflowRun({
+      workflowId,
+      runId: normalizeOptionalString(body.runId),
+      sessionId: `admin:workflow:${workflowId}`,
+      userId: 'admin',
+    });
+    sendJson(res, 201, {
+      run,
+      view: buildWorkflowRunView(run),
+      text: renderWorkflowRunState(run),
+    });
+  } catch (error) {
+    sendJson(res, 400, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function handleApiAdminWorkflowApprove(
+  req: IncomingMessage,
+  res: ServerResponse,
+  runId: string,
+): Promise<void> {
+  const body = (await readJsonBody(req)) as ApiAdminWorkflowRequestBody;
+  try {
+    const run = await approveWorkflowRunStep({
+      runId,
+      stepId: normalizeOptionalString(body.stepId),
+      actor: 'admin',
+      sessionId: `admin:workflow:${runId}`,
+    });
+    sendJson(res, 200, {
+      run,
+      view: buildWorkflowRunView(run),
+      text: renderWorkflowRunState(run),
+    });
+  } catch (error) {
+    sendJson(res, 400, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function handleApiAdminWorkflowReturn(
+  req: IncomingMessage,
+  res: ServerResponse,
+  runId: string,
+): Promise<void> {
+  const body = (await readJsonBody(req)) as ApiAdminWorkflowRequestBody;
+  const stepId = normalizeOptionalString(body.stepId);
+  const notes = normalizeOptionalString(body.notes);
+  if (!stepId || !notes) {
+    sendJson(res, 400, {
+      error: 'Expected non-empty `stepId` and `notes`.',
+    });
     return;
   }
-  if (
-    segments.length >= 5 &&
-    segments[2] === 'workflows' &&
-    segments[3] === 'runs'
-  ) {
-    const runId = decodeURIComponent(segments[4] || '');
-    const action = segments[5] || '';
-    if (method === 'GET' && segments.length === 5) {
-      handleApiAdminWorkflowRun(res, url);
-      return;
-    }
-    if (method === 'POST' && action === 'approve') {
-      const body = (await readJsonBody(req)) as ApiAdminWorkflowRequestBody;
-      try {
-        const run = await approveWorkflowRunStep({
-          runId,
-          stepId: normalizeOptionalString(body.stepId),
-          actor: 'admin',
-          sessionId: `admin:workflow:${runId}`,
-        });
-        sendJson(res, 200, {
-          run,
-          view: buildWorkflowRunView(run),
-          text: renderWorkflowRunState(run),
-        });
-      } catch (error) {
-        sendJson(res, 400, {
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-      return;
-    }
-    if (method === 'POST' && action === 'return') {
-      const body = (await readJsonBody(req)) as ApiAdminWorkflowRequestBody;
-      const stepId = normalizeOptionalString(body.stepId);
-      const notes = normalizeOptionalString(body.notes);
-      if (!stepId || !notes) {
-        sendJson(res, 400, {
-          error: 'Expected non-empty `stepId` and `notes`.',
-        });
-        return;
-      }
-      try {
-        const run = await returnWorkflowRunStep({
-          runId,
-          stepId,
-          notes,
-          fromStepId: normalizeOptionalString(body.fromStepId),
-          actor: 'admin',
-          sessionId: `admin:workflow:${runId}`,
-        });
-        sendJson(res, 200, {
-          run,
-          view: buildWorkflowRunView(run),
-          text: renderWorkflowRunState(run),
-        });
-      } catch (error) {
-        sendJson(res, 400, {
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-      return;
-    }
+  try {
+    const run = await returnWorkflowRunStep({
+      runId,
+      stepId,
+      notes,
+      fromStepId: normalizeOptionalString(body.fromStepId),
+      actor: 'admin',
+      sessionId: `admin:workflow:${runId}`,
+    });
+    sendJson(res, 200, {
+      run,
+      view: buildWorkflowRunView(run),
+      text: renderWorkflowRunState(run),
+    });
+  } catch (error) {
+    sendJson(res, 400, {
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
-  sendJson(res, 404, { error: 'Not Found' });
 }
 
 function sendApiAdminPolicyError(res: ServerResponse, error: unknown): void {
@@ -4226,11 +4231,37 @@ export function startGatewayHttpServer(): GatewayHttpServer {
             handleApiAdminApprovals(res, url);
             return;
           }
+          if (pathname === '/api/admin/workflows' && method === 'GET') {
+            sendApiAdminWorkflows(res);
+            return;
+          }
+          if (pathname === '/api/admin/workflows' && method === 'POST') {
+            await handleApiAdminWorkflowStart(req, res);
+            return;
+          }
+          const workflowRunRoute = parseApiAdminWorkflowRunPath(pathname);
           if (
-            pathname === '/api/admin/workflows' ||
-            pathname.startsWith('/api/admin/workflows/')
+            workflowRunRoute &&
+            method === 'GET' &&
+            !workflowRunRoute.action
           ) {
-            await handleApiAdminWorkflows(req, res, url);
+            sendApiAdminWorkflowRun(res, workflowRunRoute.runId);
+            return;
+          }
+          if (workflowRunRoute?.action === 'approve' && method === 'POST') {
+            await handleApiAdminWorkflowApprove(
+              req,
+              res,
+              workflowRunRoute.runId,
+            );
+            return;
+          }
+          if (workflowRunRoute?.action === 'return' && method === 'POST') {
+            await handleApiAdminWorkflowReturn(
+              req,
+              res,
+              workflowRunRoute.runId,
+            );
             return;
           }
           if (

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -3323,6 +3323,23 @@ function sendApiAdminWorkflows(res: ServerResponse): void {
   sendJson(res, 200, getWorkflowAdminSummary());
 }
 
+function resolveApiAdminActor(req: IncomingMessage): string {
+  const sessionUserId = resolveSessionAuthenticatedUserId(req);
+  if (sessionUserId) return sessionUserId;
+
+  const authHeader = req.headers.authorization || '';
+  if (WEB_API_TOKEN && authHeader === `Bearer ${WEB_API_TOKEN}`) {
+    return 'web-api-token';
+  }
+  if (GATEWAY_API_TOKEN && authHeader === `Bearer ${GATEWAY_API_TOKEN}`) {
+    return 'gateway-api-token';
+  }
+  if (hasLocalWebSessionAuth(req)) {
+    return 'local-web-session';
+  }
+  return 'authenticated-admin-api';
+}
+
 function sendApiAdminWorkflowError(res: ServerResponse, error: unknown): void {
   sendJson(res, 400, {
     error: error instanceof Error ? error.message : String(error),
@@ -3344,7 +3361,7 @@ async function handleApiAdminWorkflowStart(
       workflowId,
       runId: normalizeOptionalString(body.runId),
       sessionId: `admin:workflow:${workflowId}`,
-      userId: 'admin',
+      userId: resolveApiAdminActor(req),
     });
     sendJson(res, 201, {
       run,
@@ -3366,7 +3383,7 @@ async function handleApiAdminWorkflowApprove(
     const run = await approveWorkflowRunStep({
       runId,
       stepId: normalizeOptionalString(body.stepId),
-      actor: 'admin',
+      actor: resolveApiAdminActor(req),
       sessionId: `admin:workflow:${runId}`,
     });
     sendJson(res, 200, {
@@ -3399,7 +3416,7 @@ async function handleApiAdminWorkflowReturn(
       stepId,
       notes,
       fromStepId: normalizeOptionalString(body.fromStepId),
-      actor: 'admin',
+      actor: resolveApiAdminActor(req),
       sessionId: `admin:workflow:${runId}`,
     });
     sendJson(res, 200, {

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -84,6 +84,17 @@ import {
   normalizeTrimmedUniqueStringArray,
 } from '../utils/normalized-strings.js';
 import {
+  approveWorkflowRunStep,
+  getWorkflowAdminSummary,
+  returnWorkflowRunStep,
+  startWorkflowRun,
+} from '../workflow/service.js';
+import { getWorkflowRunState } from '../workflow/store.js';
+import {
+  buildWorkflowRunView,
+  renderWorkflowRunState,
+} from '../workflow/visualizer.js';
+import {
   AdminTerminalCapacityError,
   type AdminTerminalStartOptions,
   createAdminTerminalManager,
@@ -272,6 +283,13 @@ type ApiAdminPolicyRequestBody = {
   defaultAction?: unknown;
   presetName?: unknown;
   rule?: unknown;
+};
+type ApiAdminWorkflowRequestBody = {
+  workflowId?: unknown;
+  runId?: unknown;
+  stepId?: unknown;
+  notes?: unknown;
+  fromStepId?: unknown;
 };
 
 function normalizeStringListInput(value: unknown): string[] | undefined {
@@ -3266,6 +3284,129 @@ function handleApiAdminApprovals(res: ServerResponse, url: URL): void {
   );
 }
 
+function handleApiAdminWorkflowRun(res: ServerResponse, url: URL): void {
+  const segments = url.pathname.split('/').filter(Boolean);
+  const runId = segments[4] ? decodeURIComponent(segments[4]) : '';
+  if (!runId) {
+    sendJson(res, 400, { error: 'Expected workflow run id.' });
+    return;
+  }
+  const run = getWorkflowRunState(runId);
+  if (!run) {
+    sendJson(res, 404, { error: `Unknown workflow run: ${runId}` });
+    return;
+  }
+  sendJson(res, 200, {
+    run,
+    view: buildWorkflowRunView(run),
+    text: renderWorkflowRunState(run),
+  });
+}
+
+async function handleApiAdminWorkflows(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL,
+): Promise<void> {
+  const method = req.method || 'GET';
+  const segments = url.pathname.split('/').filter(Boolean);
+  if (segments.length === 3 && method === 'GET') {
+    sendJson(res, 200, getWorkflowAdminSummary());
+    return;
+  }
+  if (segments.length === 3 && method === 'POST') {
+    const body = (await readJsonBody(req)) as ApiAdminWorkflowRequestBody;
+    const workflowId = normalizeOptionalString(body.workflowId);
+    if (!workflowId) {
+      sendJson(res, 400, { error: 'Expected non-empty `workflowId`.' });
+      return;
+    }
+    try {
+      const run = await startWorkflowRun({
+        workflowId,
+        runId: normalizeOptionalString(body.runId),
+        sessionId: `admin:workflow:${workflowId}`,
+        userId: 'admin',
+      });
+      sendJson(res, 201, {
+        run,
+        view: buildWorkflowRunView(run),
+        text: renderWorkflowRunState(run),
+      });
+    } catch (error) {
+      sendJson(res, 400, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    return;
+  }
+  if (
+    segments.length >= 5 &&
+    segments[2] === 'workflows' &&
+    segments[3] === 'runs'
+  ) {
+    const runId = decodeURIComponent(segments[4] || '');
+    const action = segments[5] || '';
+    if (method === 'GET' && segments.length === 5) {
+      handleApiAdminWorkflowRun(res, url);
+      return;
+    }
+    if (method === 'POST' && action === 'approve') {
+      const body = (await readJsonBody(req)) as ApiAdminWorkflowRequestBody;
+      try {
+        const run = await approveWorkflowRunStep({
+          runId,
+          stepId: normalizeOptionalString(body.stepId),
+          actor: 'admin',
+          sessionId: `admin:workflow:${runId}`,
+        });
+        sendJson(res, 200, {
+          run,
+          view: buildWorkflowRunView(run),
+          text: renderWorkflowRunState(run),
+        });
+      } catch (error) {
+        sendJson(res, 400, {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      return;
+    }
+    if (method === 'POST' && action === 'return') {
+      const body = (await readJsonBody(req)) as ApiAdminWorkflowRequestBody;
+      const stepId = normalizeOptionalString(body.stepId);
+      const notes = normalizeOptionalString(body.notes);
+      if (!stepId || !notes) {
+        sendJson(res, 400, {
+          error: 'Expected non-empty `stepId` and `notes`.',
+        });
+        return;
+      }
+      try {
+        const run = await returnWorkflowRunStep({
+          runId,
+          stepId,
+          notes,
+          fromStepId: normalizeOptionalString(body.fromStepId),
+          actor: 'admin',
+          sessionId: `admin:workflow:${runId}`,
+        });
+        sendJson(res, 200, {
+          run,
+          view: buildWorkflowRunView(run),
+          text: renderWorkflowRunState(run),
+        });
+      } catch (error) {
+        sendJson(res, 400, {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      return;
+    }
+  }
+  sendJson(res, 404, { error: 'Not Found' });
+}
+
 function sendApiAdminPolicyError(res: ServerResponse, error: unknown): void {
   const message = error instanceof Error ? error.message : String(error);
   sendJson(res, error instanceof GatewayRequestError ? error.statusCode : 400, {
@@ -4083,6 +4224,13 @@ export function startGatewayHttpServer(): GatewayHttpServer {
           }
           if (pathname === '/api/admin/approvals' && method === 'GET') {
             handleApiAdminApprovals(res, url);
+            return;
+          }
+          if (
+            pathname === '/api/admin/workflows' ||
+            pathname.startsWith('/api/admin/workflows/')
+          ) {
+            await handleApiAdminWorkflows(req, res, url);
             return;
           }
           if (

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -329,6 +329,13 @@ import {
 import { sleep } from '../utils/sleep.js';
 import { formatDurationMs } from '../utils/text-format.js';
 import {
+  approveWorkflowRunStep,
+  getWorkflowAdminSummary,
+  returnWorkflowRunStep,
+  startWorkflowRun,
+} from '../workflow/service.js';
+import { renderWorkflowRunState } from '../workflow/visualizer.js';
+import {
   ensureBootstrapFiles,
   resetWorkspace,
   resolveStartupBootstrapFile,
@@ -456,7 +463,10 @@ import {
   resolveWorkspaceRelativePath,
 } from './gateway-utils.js';
 import { runMemoryConsolidation } from './memory-consolidation-runner.js';
-import { listPendingApprovals } from './pending-approvals.js';
+import {
+  getPendingApproval,
+  listPendingApprovals,
+} from './pending-approvals.js';
 import { isDiscordChannelId } from './proactive-delivery.js';
 import { buildResetConfirmationComponents } from './reset-confirmation.js';
 import {
@@ -7846,6 +7856,140 @@ export async function handleGatewayCommand(
           ({ command, description }) => `\`${command}\`: ${description}`,
         );
         return infoCommand('HybridClaw Commands', help.join('\n'));
+      }
+
+      case 'workflow': {
+        const sub = parseLowerArg(req.args, 1, { defaultValue: 'list' });
+        const workflowCommandResponse = (
+          title: string,
+          runText: string,
+          runId: string,
+        ): GatewayCommandResult => {
+          const pending = getPendingApproval(req.sessionId);
+          if (
+            !pending ||
+            !pending.approvalId.startsWith(`workflow:${runId}:`)
+          ) {
+            return infoCommand(title, runText);
+          }
+          return infoCommand(title, `${runText}\n${pending.prompt}`);
+        };
+
+        if (sub === 'list' || sub === 'status') {
+          const summary = getWorkflowAdminSummary();
+          const lines = [
+            'Definitions:',
+            ...(summary.definitions.length > 0
+              ? summary.definitions.map(
+                  (workflow) =>
+                    `- ${workflow.id} - ${workflow.name} (${workflow.steps.length} steps)`,
+                )
+              : ['- none']),
+            '',
+            'Runs:',
+            ...(summary.runs.length > 0
+              ? summary.runs.slice(0, 10).map((run) => {
+                  const active = run.current_step_id
+                    ? `, active: ${run.current_step_id}`
+                    : '';
+                  return `- ${run.id} - ${run.workflow.name}: ${run.status}${active}`;
+                })
+              : ['- none']),
+          ];
+          return infoCommand('Workflows', lines.join('\n'));
+        }
+
+        if (sub === 'start') {
+          const workflowId = parseIdArg(req.args, 2);
+          if (!workflowId) {
+            return badCommand(
+              'Usage',
+              'Usage: `workflow start <workflow_id> [run_id]`',
+            );
+          }
+          try {
+            const run = await startWorkflowRun({
+              workflowId,
+              runId: parseIdArg(req.args, 3) || undefined,
+              sessionId: req.sessionId,
+              userId: req.userId || undefined,
+            });
+            return workflowCommandResponse(
+              'Workflow Started',
+              renderWorkflowRunState(run),
+              run.id,
+            );
+          } catch (error) {
+            return badCommand(
+              'Workflow Error',
+              error instanceof Error ? error.message : String(error),
+            );
+          }
+        }
+
+        if (sub === 'approve') {
+          const runId = parseIdArg(req.args, 2);
+          if (!runId) {
+            return badCommand(
+              'Usage',
+              'Usage: `workflow approve <run_id> [step_id]`',
+            );
+          }
+          try {
+            const run = await approveWorkflowRunStep({
+              runId,
+              stepId: parseIdArg(req.args, 3) || undefined,
+              actor: req.userId || 'local-user',
+              sessionId: req.sessionId,
+            });
+            return workflowCommandResponse(
+              'Workflow Approved',
+              renderWorkflowRunState(run),
+              run.id,
+            );
+          } catch (error) {
+            return badCommand(
+              'Workflow Error',
+              error instanceof Error ? error.message : String(error),
+            );
+          }
+        }
+
+        if (sub === 'return') {
+          const runId = parseIdArg(req.args, 2);
+          const stepId = parseIdArg(req.args, 3);
+          const notes = req.args.slice(4).join(' ').trim();
+          if (!runId || !stepId || !notes) {
+            return badCommand(
+              'Usage',
+              'Usage: `workflow return <run_id> <step_id> <notes>`',
+            );
+          }
+          try {
+            const run = await returnWorkflowRunStep({
+              runId,
+              stepId,
+              notes,
+              actor: req.userId || 'local-user',
+              sessionId: req.sessionId,
+            });
+            return workflowCommandResponse(
+              'Workflow Returned For Revision',
+              renderWorkflowRunState(run),
+              run.id,
+            );
+          } catch (error) {
+            return badCommand(
+              'Workflow Error',
+              error instanceof Error ? error.message : String(error),
+            );
+          }
+        }
+
+        return badCommand(
+          'Usage',
+          'Usage: `workflow list`, `workflow start <workflow_id> [run_id]`, `workflow approve <run_id> [step_id]`, or `workflow return <run_id> <step_id> <notes>`',
+        );
       }
 
       case 'agent': {

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -7913,7 +7913,7 @@ export async function handleGatewayCommand(
               workflowId,
               runId: parseIdArg(req.args, 3) || undefined,
               sessionId: req.sessionId,
-              userId: req.userId || undefined,
+              userId: req.userId || req.sessionId,
             });
             return workflowCommandResponse(
               'Workflow Started',
@@ -7940,7 +7940,7 @@ export async function handleGatewayCommand(
             const run = await approveWorkflowRunStep({
               runId,
               stepId: parseIdArg(req.args, 3) || undefined,
-              actor: req.userId || 'local-user',
+              actor: req.userId || req.sessionId,
               sessionId: req.sessionId,
             });
             return workflowCommandResponse(
@@ -7971,7 +7971,7 @@ export async function handleGatewayCommand(
               runId,
               stepId,
               notes,
-              actor: req.userId || 'local-user',
+              actor: req.userId || req.sessionId,
               sessionId: req.sessionId,
             });
             return workflowCommandResponse(

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -133,6 +133,7 @@ import {
   normalizeEscalationTarget,
 } from '../types/execution.js';
 import { formatError } from '../utils/text-format.js';
+import { initializeWorkflowRuntime } from '../workflow/service.js';
 import { buildApprovalConfirmationComponents } from './approval-confirmation.js';
 import {
   type ApprovalPresentation,
@@ -3052,6 +3053,7 @@ async function main(): Promise<void> {
   validateGatewayPromptEnvDefaults();
   initDatabase();
   listAgents();
+  initializeWorkflowRuntime();
   await initGatewayService();
   resumeEnabledFullAutoSessions();
   void runManagedMediaCleanup('startup').catch((error) => {

--- a/src/workflow/executor.ts
+++ b/src/workflow/executor.ts
@@ -14,6 +14,7 @@ import type { RuntimeConfigChangeMeta } from '../config/runtime-config-revisions
 import {
   parseWorkflowDefinitionYaml,
   validateWorkflowDefinition,
+  WORKFLOW_STAKES_ORDER,
   type WorkflowDefinition,
   type WorkflowStep,
 } from './schema.js';
@@ -62,12 +63,6 @@ export interface ResumeWorkflowInput {
   actor?: string;
   meta?: RuntimeConfigChangeMeta;
 }
-
-const STAKES_ORDER: Record<StakesLevel, number> = {
-  low: 0,
-  medium: 1,
-  high: 2,
-};
 
 function nowIso(): string {
   return new Date().toISOString();
@@ -204,7 +199,7 @@ function classifyStep(
 }
 
 function exceedsThreshold(score: StakesScore, threshold: StakesLevel): boolean {
-  return STAKES_ORDER[score.level] > STAKES_ORDER[threshold];
+  return WORKFLOW_STAKES_ORDER[score.level] > WORKFLOW_STAKES_ORDER[threshold];
 }
 
 async function defaultDispatchStep(

--- a/src/workflow/executor.ts
+++ b/src/workflow/executor.ts
@@ -415,7 +415,6 @@ async function continueRun(
     }
     run.current_step_id = next;
     markRunUpdated(run);
-    saveWorkflowRunState(run, options.meta);
   }
 
   run.status = 'completed';
@@ -435,7 +434,6 @@ export async function executeWorkflow(
     initiatorCoworkerId: input.initiatorCoworkerId,
   });
   saveWorkflowDefinition(workflow, input.meta);
-  saveWorkflowRunState(run, input.meta);
   return continueRun(run, input);
 }
 

--- a/src/workflow/executor.ts
+++ b/src/workflow/executor.ts
@@ -108,6 +108,22 @@ function nextStepId(
   return outgoing[0]?.to;
 }
 
+function stepIdsFrom(
+  workflow: WorkflowDefinition,
+  stepId: string,
+): Set<string> {
+  const downstream = new Set<string>();
+  let current: string | undefined = stepId;
+  while (current) {
+    if (downstream.has(current)) {
+      throw new Error(`Workflow ${workflow.id} contains a cycle at ${current}`);
+    }
+    downstream.add(current);
+    current = nextStepId(workflow, current);
+  }
+  return downstream;
+}
+
 function makeInitialRun(params: {
   workflow: WorkflowDefinition;
   runId?: string;
@@ -508,9 +524,7 @@ export async function returnForRevision(
     stepId;
   const revision = targetState.revisions.length + 1;
   const createdAt = nowIso();
-  const targetIndex = run.workflow.steps.findIndex(
-    (step) => step.id === stepId,
-  );
+  const downstreamStepIds = stepIdsFrom(run.workflow, stepId);
 
   targetState.revisions.push({
     revision,
@@ -521,10 +535,7 @@ export async function returnForRevision(
     created_at: createdAt,
   });
   for (const stepState of run.steps) {
-    const workflowIndex = run.workflow.steps.findIndex(
-      (step) => step.id === stepState.step_id,
-    );
-    if (workflowIndex >= targetIndex) {
+    if (downstreamStepIds.has(stepState.step_id)) {
       stepState.status =
         stepState.step_id === stepId ? 'pending' : 'revision_requested';
       delete stepState.started_at;

--- a/src/workflow/executor.ts
+++ b/src/workflow/executor.ts
@@ -165,21 +165,14 @@ function findStepState(
   return state;
 }
 
-function workflowAuditContext(run: WorkflowRunState, sessionId?: string) {
-  return {
-    sessionId: sessionId || run.id,
-    runId: makeAuditRunId(`workflow-${run.id}`),
-  };
-}
-
 function recordWorkflowAudit(
   run: WorkflowRunState,
   sessionId: string | undefined,
   payload: AuditEventPayload,
 ): void {
-  const context = workflowAuditContext(run, sessionId);
   recordAuditEvent({
-    ...context,
+    sessionId: sessionId || run.id,
+    runId: makeAuditRunId(`workflow-${run.id}`),
     event: payload,
   });
 }
@@ -249,6 +242,142 @@ function markRunUpdated(run: WorkflowRunState): void {
   run.updated_at = nowIso();
 }
 
+function evaluateStepStakes(
+  run: WorkflowRunState,
+  step: WorkflowStep,
+  classifier: StakesClassifier,
+  sessionId?: string,
+): 'continue' | 'paused' {
+  const stepState = findStepState(run, step.id);
+  if (!step.stakes_threshold || stepState.escalation?.approved_at) {
+    return 'continue';
+  }
+
+  const score = classifyStep(classifier, run.workflow, step);
+  if (exceedsThreshold(score, step.stakes_threshold)) {
+    stepState.status = 'paused';
+    stepState.paused_at = nowIso();
+    stepState.escalation = {
+      route: 'approval_request',
+      threshold: step.stakes_threshold,
+      stakes: score.level,
+      classifier: score.classifier,
+      reasons: score.reasons,
+      requested_at: stepState.paused_at,
+    };
+    run.status = 'paused';
+    run.events.push(
+      event('workflow.step.escalated', {
+        step_id: step.id,
+        stakes: score.level,
+        threshold: step.stakes_threshold,
+        classifier: score.classifier,
+        reasons: score.reasons,
+        message: `Paused ${step.id} for stakes escalation`,
+      }),
+    );
+    recordWorkflowAudit(run, sessionId, {
+      type: 'workflow.escalation',
+      workflowId: run.workflow.id,
+      runId: run.id,
+      stepId: step.id,
+      stakes: score.level,
+      threshold: step.stakes_threshold,
+      route: 'approval_request',
+      classifier: score.classifier,
+      reasons: score.reasons,
+    });
+    markRunUpdated(run);
+    return 'paused';
+  }
+
+  stepState.escalation = {
+    route: 'none',
+    threshold: step.stakes_threshold,
+    stakes: score.level,
+    classifier: score.classifier,
+    reasons: score.reasons,
+  };
+  run.events.push(
+    event('workflow.step.auto_execute', {
+      step_id: step.id,
+      stakes: score.level,
+      threshold: step.stakes_threshold,
+      classifier: score.classifier,
+      reasons: score.reasons,
+    }),
+  );
+  recordWorkflowAudit(run, sessionId, {
+    type: 'workflow.auto_execute',
+    workflowId: run.workflow.id,
+    runId: run.id,
+    stepId: step.id,
+    stakes: score.level,
+    threshold: step.stakes_threshold,
+    classifier: score.classifier,
+    reasons: score.reasons,
+  });
+  return 'continue';
+}
+
+async function dispatchAndRecord(
+  run: WorkflowRunState,
+  step: WorkflowStep,
+  dispatchStep: WorkflowStepDispatcher,
+): Promise<'completed' | 'failed'> {
+  const stepState = findStepState(run, step.id);
+  const startedAt = nowIso();
+  stepState.status = 'running';
+  stepState.started_at = startedAt;
+  stepState.attempts += 1;
+  run.events.push(
+    event('workflow.step.started', {
+      step_id: step.id,
+      owner_coworker_id: step.owner_coworker_id,
+    }),
+  );
+
+  try {
+    const result = await dispatchStep({
+      run,
+      step,
+      sender_coworker_id: senderForStep(run, step.id),
+    });
+    const completedAt = nowIso();
+    stepState.status = 'completed';
+    stepState.completed_at = completedAt;
+    stepState.artifacts.push({
+      revision: stepState.artifacts.length + 1,
+      created_at: completedAt,
+      value: result.artifact ?? result.envelope ?? null,
+    });
+    run.events.push(
+      event('workflow.step.completed', {
+        step_id: step.id,
+        owner_coworker_id: step.owner_coworker_id,
+      }),
+    );
+    markRunUpdated(run);
+    return 'completed';
+  } catch (error) {
+    const failedAt = nowIso();
+    stepState.status = 'failed';
+    stepState.failed_at = failedAt;
+    stepState.error = error instanceof Error ? error.message : String(error);
+    run.status = 'failed';
+    run.failed_at = failedAt;
+    run.error = stepState.error;
+    run.events.push(
+      event('workflow.step.failed', {
+        step_id: step.id,
+        message: stepState.error,
+      }),
+    );
+    markRunUpdated(run);
+    return 'failed';
+  }
+}
+
 async function continueRun(
   run: WorkflowRunState,
   options: {
@@ -265,138 +394,33 @@ async function continueRun(
 
   while (run.current_step_id) {
     const step = findStep(run.workflow, run.current_step_id);
-    const stepState = findStepState(run, step.id);
-
-    if (step.stakes_threshold && !stepState.escalation?.approved_at) {
-      const score = classifyStep(stakesClassifier, run.workflow, step);
-      if (exceedsThreshold(score, step.stakes_threshold)) {
-        stepState.status = 'paused';
-        stepState.paused_at = nowIso();
-        stepState.escalation = {
-          route: 'approval_request',
-          threshold: step.stakes_threshold,
-          stakes: score.level,
-          classifier: score.classifier,
-          reasons: score.reasons,
-          requested_at: stepState.paused_at,
-        };
-        run.status = 'paused';
-        run.events.push(
-          event('workflow.step.escalated', {
-            step_id: step.id,
-            stakes: score.level,
-            threshold: step.stakes_threshold,
-            classifier: score.classifier,
-            reasons: score.reasons,
-            message: `Paused ${step.id} for stakes escalation`,
-          }),
-        );
-        recordWorkflowAudit(run, options.sessionId, {
-          type: 'workflow.escalation',
-          workflowId: run.workflow.id,
-          runId: run.id,
-          stepId: step.id,
-          stakes: score.level,
-          threshold: step.stakes_threshold,
-          route: 'approval_request',
-          classifier: score.classifier,
-          reasons: score.reasons,
-        });
-        markRunUpdated(run);
-        return saveWorkflowRunState(run, options.meta);
-      }
-      stepState.escalation = {
-        route: 'none',
-        threshold: step.stakes_threshold,
-        stakes: score.level,
-        classifier: score.classifier,
-        reasons: score.reasons,
-      };
-      run.events.push(
-        event('workflow.step.auto_execute', {
-          step_id: step.id,
-          stakes: score.level,
-          threshold: step.stakes_threshold,
-          classifier: score.classifier,
-          reasons: score.reasons,
-        }),
-      );
-      recordWorkflowAudit(run, options.sessionId, {
-        type: 'workflow.auto_execute',
-        workflowId: run.workflow.id,
-        runId: run.id,
-        stepId: step.id,
-        stakes: score.level,
-        threshold: step.stakes_threshold,
-        classifier: score.classifier,
-        reasons: score.reasons,
-      });
+    if (
+      evaluateStepStakes(run, step, stakesClassifier, options.sessionId) ===
+      'paused'
+    ) {
+      return saveWorkflowRunState(run, options.meta);
     }
 
-    const startedAt = nowIso();
-    stepState.status = 'running';
-    stepState.started_at = startedAt;
-    stepState.attempts += 1;
-    run.events.push(
-      event('workflow.step.started', {
-        step_id: step.id,
-        owner_coworker_id: step.owner_coworker_id,
-      }),
-    );
+    if ((await dispatchAndRecord(run, step, dispatchStep)) === 'failed') {
+      return saveWorkflowRunState(run, options.meta);
+    }
 
-    try {
-      const result = await dispatchStep({
-        run,
-        step,
-        sender_coworker_id: senderForStep(run, step.id),
-      });
-      const completedAt = nowIso();
-      stepState.status = 'completed';
-      stepState.completed_at = completedAt;
-      stepState.artifacts.push({
-        revision: stepState.artifacts.length + 1,
-        created_at: completedAt,
-        value: result.artifact ?? result.envelope ?? null,
-      });
+    const next = nextStepId(run.workflow, step.id);
+    if (!next) {
+      run.status = 'completed';
+      run.completed_at = nowIso();
+      run.current_step_id = undefined;
       run.events.push(
-        event('workflow.step.completed', {
-          step_id: step.id,
-          owner_coworker_id: step.owner_coworker_id,
-        }),
-      );
-      const next = nextStepId(run.workflow, step.id);
-      if (!next) {
-        run.status = 'completed';
-        run.completed_at = completedAt;
-        run.current_step_id = undefined;
-        run.events.push(
-          event('workflow.run.completed', {
-            message: `Completed workflow ${run.workflow.id}`,
-          }),
-        );
-        markRunUpdated(run);
-        return saveWorkflowRunState(run, options.meta);
-      }
-      run.current_step_id = next;
-      markRunUpdated(run);
-      saveWorkflowRunState(run, options.meta);
-    } catch (error) {
-      const failedAt = nowIso();
-      stepState.status = 'failed';
-      stepState.failed_at = failedAt;
-      stepState.error = error instanceof Error ? error.message : String(error);
-      run.status = 'failed';
-      run.failed_at = failedAt;
-      run.error = stepState.error;
-      run.events.push(
-        event('workflow.step.failed', {
-          step_id: step.id,
-          message: stepState.error,
+        event('workflow.run.completed', {
+          message: `Completed workflow ${run.workflow.id}`,
         }),
       );
       markRunUpdated(run);
       return saveWorkflowRunState(run, options.meta);
     }
+    run.current_step_id = next;
+    markRunUpdated(run);
+    saveWorkflowRunState(run, options.meta);
   }
 
   run.status = 'completed';

--- a/src/workflow/executor.ts
+++ b/src/workflow/executor.ts
@@ -1,0 +1,543 @@
+import { randomUUID } from 'node:crypto';
+import type {
+  StakesClassificationInput,
+  StakesClassifier,
+  StakesLevel,
+  StakesScore,
+} from '../../container/shared/stakes-classifier.js';
+import { type A2AEnvelope, createA2AEnvelope } from '../a2a/envelope.js';
+import { saveA2AEnvelope } from '../a2a/store.js';
+import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
+import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
+import type { AuditEventPayload } from '../audit/audit-trail.js';
+import type { RuntimeConfigChangeMeta } from '../config/runtime-config-revisions.js';
+import {
+  parseWorkflowDefinitionYaml,
+  validateWorkflowDefinition,
+  type WorkflowDefinition,
+  type WorkflowStep,
+} from './schema.js';
+import { createWorkflowStakesClassifier } from './stakes-classifier.js';
+import {
+  getWorkflowRunState,
+  saveWorkflowDefinition,
+  saveWorkflowRunState,
+  type WorkflowRunEvent,
+  type WorkflowRunState,
+  type WorkflowStepRunState,
+} from './store.js';
+
+export interface WorkflowDispatchInput {
+  run: WorkflowRunState;
+  step: WorkflowStep;
+  sender_coworker_id: string;
+}
+
+export interface WorkflowDispatchResult {
+  artifact?: unknown;
+  envelope?: A2AEnvelope;
+}
+
+export type WorkflowStepDispatcher = (
+  input: WorkflowDispatchInput,
+) => Promise<WorkflowDispatchResult> | WorkflowDispatchResult;
+
+export interface ExecuteWorkflowInput {
+  workflow: WorkflowDefinition | string;
+  runId?: string;
+  threadId?: string;
+  initiatorCoworkerId?: string;
+  stakesClassifier?: StakesClassifier;
+  dispatchStep?: WorkflowStepDispatcher;
+  sessionId?: string;
+  actor?: string;
+  meta?: RuntimeConfigChangeMeta;
+}
+
+export interface ResumeWorkflowInput {
+  runId: string;
+  stakesClassifier?: StakesClassifier;
+  dispatchStep?: WorkflowStepDispatcher;
+  sessionId?: string;
+  actor?: string;
+  meta?: RuntimeConfigChangeMeta;
+}
+
+const STAKES_ORDER: Record<StakesLevel, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+};
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function event(
+  type: string,
+  params: Omit<WorkflowRunEvent, 'type' | 'created_at'> = {},
+): WorkflowRunEvent {
+  return {
+    ...params,
+    type,
+    created_at: nowIso(),
+  };
+}
+
+function parseWorkflow(input: WorkflowDefinition | string): WorkflowDefinition {
+  if (typeof input === 'string') return parseWorkflowDefinitionYaml(input);
+  return validateWorkflowDefinition(input);
+}
+
+function firstStepId(workflow: WorkflowDefinition): string {
+  const targets = new Set(
+    workflow.transitions.map((transition) => transition.to),
+  );
+  return (
+    workflow.steps.find((step) => !targets.has(step.id))?.id ||
+    workflow.steps[0]?.id ||
+    ''
+  );
+}
+
+function nextStepId(
+  workflow: WorkflowDefinition,
+  currentStepId: string,
+): string | undefined {
+  const outgoing = workflow.transitions.filter(
+    (transition) => transition.from === currentStepId,
+  );
+  if (outgoing.length > 1) {
+    throw new Error(`Workflow step ${currentStepId} has multiple transitions`);
+  }
+  return outgoing[0]?.to;
+}
+
+function makeInitialRun(params: {
+  workflow: WorkflowDefinition;
+  runId?: string;
+  threadId?: string;
+  initiatorCoworkerId?: string;
+}): WorkflowRunState {
+  const id = params.runId?.trim() || `wf_${randomUUID()}`;
+  const threadId = params.threadId?.trim() || id;
+  const initiator = params.initiatorCoworkerId?.trim() || DEFAULT_AGENT_ID;
+  const createdAt = nowIso();
+  return {
+    version: 1,
+    id,
+    workflow: params.workflow,
+    thread_id: threadId,
+    initiator_coworker_id: initiator,
+    status: 'running',
+    current_step_id: firstStepId(params.workflow),
+    created_at: createdAt,
+    updated_at: createdAt,
+    steps: params.workflow.steps.map((step) => ({
+      step_id: step.id,
+      owner_coworker_id: step.owner_coworker_id,
+      action: step.action,
+      status: 'pending',
+      attempts: 0,
+      artifacts: [],
+      revisions: [],
+    })),
+    events: [
+      event('workflow.run.created', {
+        message: `Started workflow ${params.workflow.id}`,
+      }),
+    ],
+  };
+}
+
+function findStep(workflow: WorkflowDefinition, stepId: string): WorkflowStep {
+  const step = workflow.steps.find((entry) => entry.id === stepId);
+  if (!step) throw new Error(`Unknown workflow step: ${stepId}`);
+  return step;
+}
+
+function findStepState(
+  run: WorkflowRunState,
+  stepId: string,
+): WorkflowStepRunState {
+  const state = run.steps.find((entry) => entry.step_id === stepId);
+  if (!state) throw new Error(`Unknown workflow step state: ${stepId}`);
+  return state;
+}
+
+function workflowAuditContext(run: WorkflowRunState, sessionId?: string) {
+  return {
+    sessionId: sessionId || run.id,
+    runId: makeAuditRunId(`workflow-${run.id}`),
+  };
+}
+
+function recordWorkflowAudit(
+  run: WorkflowRunState,
+  sessionId: string | undefined,
+  payload: AuditEventPayload,
+): void {
+  const context = workflowAuditContext(run, sessionId);
+  recordAuditEvent({
+    ...context,
+    event: payload,
+  });
+}
+
+function classifyStep(
+  classifier: StakesClassifier,
+  workflow: WorkflowDefinition,
+  step: WorkflowStep,
+): StakesScore {
+  const input: StakesClassificationInput = {
+    toolName: 'workflow_step',
+    args: {
+      workflow_id: workflow.id,
+      step_id: step.id,
+      action: step.action,
+      owner_coworker_id: step.owner_coworker_id,
+    },
+    actionKey: `workflow:${workflow.id}:${step.id}`,
+    intent: step.action,
+    reason: 'workflow step dispatch',
+    target: step.action,
+    approvalTier: 'green',
+    pathHints: [],
+    hostHints: [],
+    writeIntent: true,
+    pinned: false,
+  };
+  return classifier.classify(input);
+}
+
+function exceedsThreshold(score: StakesScore, threshold: StakesLevel): boolean {
+  return STAKES_ORDER[score.level] > STAKES_ORDER[threshold];
+}
+
+async function defaultDispatchStep(
+  input: WorkflowDispatchInput,
+): Promise<WorkflowDispatchResult> {
+  const envelope = createA2AEnvelope({
+    sender_agent_id: input.sender_coworker_id,
+    recipient_agent_id: input.step.owner_coworker_id,
+    thread_id: input.run.thread_id,
+    intent: 'handoff',
+    content: input.step.action,
+  });
+  const saved = saveA2AEnvelope(envelope, {
+    route: 'workflow.dispatch',
+    source: input.run.workflow.id,
+  });
+  return {
+    envelope: saved,
+    artifact: {
+      envelope_id: saved.id,
+      recipient_coworker_id: saved.recipient_agent_id,
+    },
+  };
+}
+
+function senderForStep(run: WorkflowRunState, stepId: string): string {
+  const incoming = run.workflow.transitions.find(
+    (transition) => transition.to === stepId,
+  );
+  if (!incoming) return run.initiator_coworker_id;
+  return findStep(run.workflow, incoming.from).owner_coworker_id;
+}
+
+function markRunUpdated(run: WorkflowRunState): void {
+  run.updated_at = nowIso();
+}
+
+async function continueRun(
+  run: WorkflowRunState,
+  options: {
+    stakesClassifier?: StakesClassifier;
+    dispatchStep?: WorkflowStepDispatcher;
+    sessionId?: string;
+    meta?: RuntimeConfigChangeMeta;
+  },
+): Promise<WorkflowRunState> {
+  const dispatchStep = options.dispatchStep || defaultDispatchStep;
+  const stakesClassifier =
+    options.stakesClassifier || createWorkflowStakesClassifier();
+  run.status = 'running';
+
+  while (run.current_step_id) {
+    const step = findStep(run.workflow, run.current_step_id);
+    const stepState = findStepState(run, step.id);
+
+    if (step.stakes_threshold && !stepState.escalation?.approved_at) {
+      const score = classifyStep(stakesClassifier, run.workflow, step);
+      if (exceedsThreshold(score, step.stakes_threshold)) {
+        stepState.status = 'paused';
+        stepState.paused_at = nowIso();
+        stepState.escalation = {
+          route: 'approval_request',
+          threshold: step.stakes_threshold,
+          stakes: score.level,
+          classifier: score.classifier,
+          reasons: score.reasons,
+          requested_at: stepState.paused_at,
+        };
+        run.status = 'paused';
+        run.events.push(
+          event('workflow.step.escalated', {
+            step_id: step.id,
+            stakes: score.level,
+            threshold: step.stakes_threshold,
+            classifier: score.classifier,
+            reasons: score.reasons,
+            message: `Paused ${step.id} for stakes escalation`,
+          }),
+        );
+        recordWorkflowAudit(run, options.sessionId, {
+          type: 'workflow.escalation',
+          workflowId: run.workflow.id,
+          runId: run.id,
+          stepId: step.id,
+          stakes: score.level,
+          threshold: step.stakes_threshold,
+          route: 'approval_request',
+          classifier: score.classifier,
+          reasons: score.reasons,
+        });
+        markRunUpdated(run);
+        return saveWorkflowRunState(run, options.meta);
+      }
+      stepState.escalation = {
+        route: 'none',
+        threshold: step.stakes_threshold,
+        stakes: score.level,
+        classifier: score.classifier,
+        reasons: score.reasons,
+      };
+      run.events.push(
+        event('workflow.step.auto_execute', {
+          step_id: step.id,
+          stakes: score.level,
+          threshold: step.stakes_threshold,
+          classifier: score.classifier,
+          reasons: score.reasons,
+        }),
+      );
+      recordWorkflowAudit(run, options.sessionId, {
+        type: 'workflow.auto_execute',
+        workflowId: run.workflow.id,
+        runId: run.id,
+        stepId: step.id,
+        stakes: score.level,
+        threshold: step.stakes_threshold,
+        classifier: score.classifier,
+        reasons: score.reasons,
+      });
+    }
+
+    const startedAt = nowIso();
+    stepState.status = 'running';
+    stepState.started_at = startedAt;
+    stepState.attempts += 1;
+    run.events.push(
+      event('workflow.step.started', {
+        step_id: step.id,
+        owner_coworker_id: step.owner_coworker_id,
+      }),
+    );
+
+    try {
+      const result = await dispatchStep({
+        run,
+        step,
+        sender_coworker_id: senderForStep(run, step.id),
+      });
+      const completedAt = nowIso();
+      stepState.status = 'completed';
+      stepState.completed_at = completedAt;
+      stepState.artifacts.push({
+        revision: stepState.artifacts.length + 1,
+        created_at: completedAt,
+        value: result.artifact ?? result.envelope ?? null,
+      });
+      run.events.push(
+        event('workflow.step.completed', {
+          step_id: step.id,
+          owner_coworker_id: step.owner_coworker_id,
+        }),
+      );
+      const next = nextStepId(run.workflow, step.id);
+      if (!next) {
+        run.status = 'completed';
+        run.completed_at = completedAt;
+        run.current_step_id = undefined;
+        run.events.push(
+          event('workflow.run.completed', {
+            message: `Completed workflow ${run.workflow.id}`,
+          }),
+        );
+        markRunUpdated(run);
+        return saveWorkflowRunState(run, options.meta);
+      }
+      run.current_step_id = next;
+      markRunUpdated(run);
+      saveWorkflowRunState(run, options.meta);
+    } catch (error) {
+      const failedAt = nowIso();
+      stepState.status = 'failed';
+      stepState.failed_at = failedAt;
+      stepState.error = error instanceof Error ? error.message : String(error);
+      run.status = 'failed';
+      run.failed_at = failedAt;
+      run.error = stepState.error;
+      run.events.push(
+        event('workflow.step.failed', {
+          step_id: step.id,
+          message: stepState.error,
+        }),
+      );
+      markRunUpdated(run);
+      return saveWorkflowRunState(run, options.meta);
+    }
+  }
+
+  run.status = 'completed';
+  run.completed_at = nowIso();
+  markRunUpdated(run);
+  return saveWorkflowRunState(run, options.meta);
+}
+
+export async function executeWorkflow(
+  input: ExecuteWorkflowInput,
+): Promise<WorkflowRunState> {
+  const workflow = parseWorkflow(input.workflow);
+  saveWorkflowDefinition(workflow, input.meta);
+  const run = makeInitialRun({
+    workflow,
+    runId: input.runId,
+    threadId: input.threadId,
+    initiatorCoworkerId: input.initiatorCoworkerId,
+  });
+  saveWorkflowRunState(run, input.meta);
+  return continueRun(run, input);
+}
+
+export async function resumeWorkflowRun(
+  input: ResumeWorkflowInput,
+): Promise<WorkflowRunState> {
+  const run = getWorkflowRunState(input.runId);
+  if (!run) throw new Error(`Unknown workflow run: ${input.runId}`);
+  if (run.status === 'completed') return run;
+  return continueRun(run, input);
+}
+
+export async function approveStep(
+  runId: string,
+  stepId: string,
+  actor: string,
+  options: Omit<ResumeWorkflowInput, 'runId' | 'actor'> = {},
+): Promise<WorkflowRunState> {
+  const run = getWorkflowRunState(runId);
+  if (!run) throw new Error(`Unknown workflow run: ${runId}`);
+  const stepState = findStepState(run, stepId);
+  if (run.status !== 'paused' || run.current_step_id !== stepId) {
+    throw new Error(`Workflow run ${runId} is not paused at step ${stepId}`);
+  }
+  if (stepState.escalation?.route !== 'approval_request') {
+    throw new Error(`Workflow step ${stepId} is not waiting for escalation`);
+  }
+
+  const approvedAt = nowIso();
+  stepState.escalation = {
+    ...stepState.escalation,
+    approved_at: approvedAt,
+    approved_by: actor,
+  };
+  stepState.status = 'pending';
+  run.status = 'running';
+  run.events.push(
+    event('workflow.step.approved', {
+      step_id: stepId,
+      actor,
+    }),
+  );
+  recordWorkflowAudit(run, options.sessionId, {
+    type: 'workflow.escalation.resolved',
+    workflowId: run.workflow.id,
+    runId: run.id,
+    stepId,
+    actor,
+    approved: true,
+  });
+  markRunUpdated(run);
+  saveWorkflowRunState(run, options.meta);
+  return continueRun(run, options);
+}
+
+export async function returnForRevision(
+  runId: string,
+  stepId: string,
+  notes: string,
+  options: Omit<ResumeWorkflowInput, 'runId'> & {
+    fromStepId?: string;
+  } = {},
+): Promise<WorkflowRunState> {
+  const run = getWorkflowRunState(runId);
+  if (!run) throw new Error(`Unknown workflow run: ${runId}`);
+  const targetStep = findStep(run.workflow, stepId);
+  const targetState = findStepState(run, targetStep.id);
+  const fromStepId =
+    options.fromStepId ||
+    run.current_step_id ||
+    run.steps.at(-1)?.step_id ||
+    stepId;
+  const revision = targetState.revisions.length + 1;
+  const createdAt = nowIso();
+
+  targetState.revisions.push({
+    revision,
+    from_step_id: fromStepId,
+    target_step_id: stepId,
+    notes,
+    ...(options.actor ? { actor: options.actor } : {}),
+    created_at: createdAt,
+  });
+  for (const stepState of run.steps) {
+    const workflowIndex = run.workflow.steps.findIndex(
+      (step) => step.id === stepState.step_id,
+    );
+    const targetIndex = run.workflow.steps.findIndex(
+      (step) => step.id === stepId,
+    );
+    if (workflowIndex >= targetIndex) {
+      stepState.status = stepState.step_id === stepId ? 'pending' : 'pending';
+      delete stepState.started_at;
+      delete stepState.completed_at;
+      delete stepState.paused_at;
+      delete stepState.failed_at;
+      delete stepState.error;
+      delete stepState.escalation;
+    }
+  }
+  targetState.status = 'pending';
+  run.status = 'running';
+  run.current_step_id = stepId;
+  run.events.push(
+    event('workflow.step.returned_for_revision', {
+      step_id: stepId,
+      from_step_id: fromStepId,
+      actor: options.actor,
+      notes,
+    }),
+  );
+  recordWorkflowAudit(run, options.sessionId, {
+    type: 'workflow.revision_requested',
+    workflowId: run.workflow.id,
+    runId: run.id,
+    stepId,
+    fromStepId,
+    actor: options.actor || null,
+    notes,
+  });
+  markRunUpdated(run);
+  saveWorkflowRunState(run, options.meta);
+  return continueRun(run, options);
+}

--- a/src/workflow/executor.ts
+++ b/src/workflow/executor.ts
@@ -88,11 +88,11 @@ function firstStepId(workflow: WorkflowDefinition): string {
   const targets = new Set(
     workflow.transitions.map((transition) => transition.to),
   );
-  return (
-    workflow.steps.find((step) => !targets.has(step.id))?.id ||
-    workflow.steps[0]?.id ||
-    ''
-  );
+  const rootStep = workflow.steps.find((step) => !targets.has(step.id));
+  if (!rootStep) {
+    throw new Error(`Workflow ${workflow.id} has no root step`);
+  }
+  return rootStep.id;
 }
 
 function nextStepId(
@@ -428,13 +428,13 @@ export async function executeWorkflow(
   input: ExecuteWorkflowInput,
 ): Promise<WorkflowRunState> {
   const workflow = parseWorkflow(input.workflow);
-  saveWorkflowDefinition(workflow, input.meta);
   const run = makeInitialRun({
     workflow,
     runId: input.runId,
     threadId: input.threadId,
     initiatorCoworkerId: input.initiatorCoworkerId,
   });
+  saveWorkflowDefinition(workflow, input.meta);
   saveWorkflowRunState(run, input.meta);
   return continueRun(run, input);
 }
@@ -527,7 +527,8 @@ export async function returnForRevision(
       (step) => step.id === stepId,
     );
     if (workflowIndex >= targetIndex) {
-      stepState.status = stepState.step_id === stepId ? 'pending' : 'pending';
+      stepState.status =
+        stepState.step_id === stepId ? 'pending' : 'revision_requested';
       delete stepState.started_at;
       delete stepState.completed_at;
       delete stepState.paused_at;

--- a/src/workflow/executor.ts
+++ b/src/workflow/executor.ts
@@ -508,6 +508,9 @@ export async function returnForRevision(
     stepId;
   const revision = targetState.revisions.length + 1;
   const createdAt = nowIso();
+  const targetIndex = run.workflow.steps.findIndex(
+    (step) => step.id === stepId,
+  );
 
   targetState.revisions.push({
     revision,
@@ -521,9 +524,6 @@ export async function returnForRevision(
     const workflowIndex = run.workflow.steps.findIndex(
       (step) => step.id === stepState.step_id,
     );
-    const targetIndex = run.workflow.steps.findIndex(
-      (step) => step.id === stepId,
-    );
     if (workflowIndex >= targetIndex) {
       stepState.status =
         stepState.step_id === stepId ? 'pending' : 'revision_requested';
@@ -535,7 +535,6 @@ export async function returnForRevision(
       delete stepState.escalation;
     }
   }
-  targetState.status = 'pending';
   run.status = 'running';
   run.current_step_id = stepId;
   run.events.push(

--- a/src/workflow/schema.ts
+++ b/src/workflow/schema.ts
@@ -1,0 +1,224 @@
+import { Ajv, type ErrorObject } from 'ajv';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+import type { StakesLevel } from '../../container/shared/stakes-classifier.js';
+import { isRecord } from '../a2a/utils.js';
+
+export const WORKFLOW_STAKES_LEVELS = ['low', 'medium', 'high'] as const;
+
+export interface WorkflowTransition {
+  from: string;
+  to: string;
+}
+
+export interface WorkflowStep {
+  id: string;
+  owner_coworker_id: string;
+  action: string;
+  stakes_threshold?: StakesLevel;
+}
+
+export interface WorkflowDefinition {
+  id: string;
+  name: string;
+  steps: WorkflowStep[];
+  transitions: WorkflowTransition[];
+}
+
+export class WorkflowDefinitionValidationError extends Error {
+  readonly issues: string[];
+
+  constructor(issues: string[]) {
+    super(`Invalid workflow definition: ${issues.join('; ')}`);
+    this.name = 'WorkflowDefinitionValidationError';
+    this.issues = [...issues];
+  }
+}
+
+export const WORKFLOW_DEFINITION_JSON_SCHEMA = {
+  $id: 'https://hybridclaw.dev/schemas/workflow-definition.json',
+  type: 'object',
+  additionalProperties: false,
+  required: ['id', 'name', 'steps', 'transitions'],
+  properties: {
+    id: {
+      type: 'string',
+      minLength: 1,
+      pattern: '^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$',
+    },
+    name: { type: 'string', minLength: 1 },
+    steps: {
+      type: 'array',
+      minItems: 1,
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['id', 'owner_coworker_id', 'action'],
+        properties: {
+          id: {
+            type: 'string',
+            minLength: 1,
+            pattern: '^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$',
+          },
+          owner_coworker_id: { type: 'string', minLength: 1 },
+          action: { type: 'string', minLength: 1 },
+          stakes_threshold: {
+            type: 'string',
+            enum: WORKFLOW_STAKES_LEVELS,
+          },
+        },
+      },
+    },
+    transitions: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['from', 'to'],
+        properties: {
+          from: {
+            type: 'string',
+            minLength: 1,
+            pattern: '^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$',
+          },
+          to: {
+            type: 'string',
+            minLength: 1,
+            pattern: '^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$',
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+const ajv = new Ajv({ allErrors: true });
+const validateWorkflowDefinitionSchema = ajv.compile(
+  WORKFLOW_DEFINITION_JSON_SCHEMA,
+);
+
+function normalizeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function schemaIssue(error: ErrorObject): string {
+  const path = error.instancePath || '/';
+  if (error.keyword === 'additionalProperties') {
+    const additional = String(error.params.additionalProperty || '').trim();
+    return `${path} unexpected field${additional ? `: ${additional}` : ''}`;
+  }
+  return `${path} ${error.message || 'is invalid'}`;
+}
+
+function readStep(value: unknown): unknown {
+  if (!isRecord(value)) return value;
+  const normalizedStep = { ...value };
+  delete normalizedStep.owner_agent_id;
+  const owner =
+    value.owner_coworker_id !== undefined
+      ? value.owner_coworker_id
+      : value.owner_agent_id;
+  return {
+    ...normalizedStep,
+    owner_coworker_id: owner,
+  };
+}
+
+function normalizeDefinition(value: unknown): unknown {
+  if (!isRecord(value)) return value;
+  return {
+    ...value,
+    steps: Array.isArray(value.steps) ? value.steps.map(readStep) : value.steps,
+  };
+}
+
+function validateGraph(definition: WorkflowDefinition): string[] {
+  const issues: string[] = [];
+  const stepIds = new Set<string>();
+  for (const step of definition.steps) {
+    if (stepIds.has(step.id)) {
+      issues.push(`duplicate step id: ${step.id}`);
+      continue;
+    }
+    stepIds.add(step.id);
+  }
+
+  const transitionKeys = new Set<string>();
+  for (const transition of definition.transitions) {
+    if (!stepIds.has(transition.from)) {
+      issues.push(
+        `transition from references unknown step: ${transition.from}`,
+      );
+    }
+    if (!stepIds.has(transition.to)) {
+      issues.push(`transition to references unknown step: ${transition.to}`);
+    }
+    if (transition.from === transition.to) {
+      issues.push(
+        `transition cannot loop to the same step: ${transition.from}`,
+      );
+    }
+    const key = `${transition.from}\0${transition.to}`;
+    if (transitionKeys.has(key)) {
+      issues.push(
+        `duplicate transition: ${transition.from} -> ${transition.to}`,
+      );
+    }
+    transitionKeys.add(key);
+  }
+  return issues;
+}
+
+export function validateWorkflowDefinition(value: unknown): WorkflowDefinition {
+  const normalized = normalizeDefinition(value);
+  const issues: string[] = [];
+  if (!validateWorkflowDefinitionSchema(normalized)) {
+    issues.push(
+      ...(validateWorkflowDefinitionSchema.errors || []).map(schemaIssue),
+    );
+  }
+  if (issues.length > 0) {
+    throw new WorkflowDefinitionValidationError(issues);
+  }
+
+  const record = normalized as WorkflowDefinition;
+  const definition: WorkflowDefinition = {
+    id: normalizeString(record.id),
+    name: normalizeString(record.name),
+    steps: record.steps.map((step) => ({
+      id: normalizeString(step.id),
+      owner_coworker_id: normalizeString(step.owner_coworker_id),
+      action: normalizeString(step.action),
+      ...(step.stakes_threshold
+        ? { stakes_threshold: step.stakes_threshold }
+        : {}),
+    })),
+    transitions: record.transitions.map((transition) => ({
+      from: normalizeString(transition.from),
+      to: normalizeString(transition.to),
+    })),
+  };
+
+  const graphIssues = validateGraph(definition);
+  if (graphIssues.length > 0) {
+    throw new WorkflowDefinitionValidationError(graphIssues);
+  }
+  return definition;
+}
+
+export function parseWorkflowDefinitionYaml(raw: string): WorkflowDefinition {
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(raw);
+  } catch (error) {
+    throw new WorkflowDefinitionValidationError([
+      error instanceof Error ? error.message : 'invalid YAML',
+    ]);
+  }
+  return validateWorkflowDefinition(parsed);
+}
+
+export function serializeWorkflowDefinitionYaml(
+  definition: WorkflowDefinition,
+): string {
+  return stringifyYaml(validateWorkflowDefinition(definition));
+}

--- a/src/workflow/schema.ts
+++ b/src/workflow/schema.ts
@@ -220,5 +220,5 @@ export function parseWorkflowDefinitionYaml(raw: string): WorkflowDefinition {
 export function serializeWorkflowDefinitionYaml(
   definition: WorkflowDefinition,
 ): string {
-  return stringifyYaml(validateWorkflowDefinition(definition));
+  return stringifyYaml(definition);
 }

--- a/src/workflow/schema.ts
+++ b/src/workflow/schema.ts
@@ -4,6 +4,11 @@ import type { StakesLevel } from '../../container/shared/stakes-classifier.js';
 import { isRecord } from '../a2a/utils.js';
 
 export const WORKFLOW_STAKES_LEVELS = ['low', 'medium', 'high'] as const;
+export const WORKFLOW_STAKES_ORDER: Record<StakesLevel, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+};
 
 export interface WorkflowTransition {
   from: string;

--- a/src/workflow/schema.ts
+++ b/src/workflow/schema.ts
@@ -148,6 +148,8 @@ function validateGraph(definition: WorkflowDefinition): string[] {
   }
 
   const transitionKeys = new Set<string>();
+  const outgoing = new Map<string, number>();
+  const incoming = new Map<string, number>();
   for (const transition of definition.transitions) {
     if (!stepIds.has(transition.from)) {
       issues.push(
@@ -169,6 +171,25 @@ function validateGraph(definition: WorkflowDefinition): string[] {
       );
     }
     transitionKeys.add(key);
+    outgoing.set(transition.from, (outgoing.get(transition.from) || 0) + 1);
+    incoming.set(transition.to, (incoming.get(transition.to) || 0) + 1);
+  }
+
+  for (const [stepId, count] of outgoing.entries()) {
+    if (count > 1) {
+      issues.push(`step has multiple outgoing transitions: ${stepId}`);
+    }
+  }
+  for (const [stepId, count] of incoming.entries()) {
+    if (count > 1) {
+      issues.push(`step has multiple incoming transitions: ${stepId}`);
+    }
+  }
+  const roots = definition.steps.filter((step) => !incoming.has(step.id));
+  if (roots.length === 0) {
+    issues.push(`workflow ${definition.id} has no root step`);
+  } else if (roots.length > 1) {
+    issues.push(`workflow ${definition.id} has multiple root steps`);
   }
   return issues;
 }

--- a/src/workflow/schema.ts
+++ b/src/workflow/schema.ts
@@ -150,6 +150,7 @@ function validateGraph(definition: WorkflowDefinition): string[] {
   const transitionKeys = new Set<string>();
   const outgoing = new Map<string, number>();
   const incoming = new Map<string, number>();
+  const nextByStep = new Map<string, string>();
   for (const transition of definition.transitions) {
     if (!stepIds.has(transition.from)) {
       issues.push(
@@ -173,6 +174,9 @@ function validateGraph(definition: WorkflowDefinition): string[] {
     transitionKeys.add(key);
     outgoing.set(transition.from, (outgoing.get(transition.from) || 0) + 1);
     incoming.set(transition.to, (incoming.get(transition.to) || 0) + 1);
+    if (!nextByStep.has(transition.from)) {
+      nextByStep.set(transition.from, transition.to);
+    }
   }
 
   for (const [stepId, count] of outgoing.entries()) {
@@ -190,6 +194,24 @@ function validateGraph(definition: WorkflowDefinition): string[] {
     issues.push(`workflow ${definition.id} has no root step`);
   } else if (roots.length > 1) {
     issues.push(`workflow ${definition.id} has multiple root steps`);
+  } else {
+    const visited = new Set<string>();
+    let current: string | undefined = roots[0]?.id;
+    while (current) {
+      if (visited.has(current)) {
+        issues.push(`workflow ${definition.id} contains a cycle at ${current}`);
+        break;
+      }
+      visited.add(current);
+      current = nextByStep.get(current);
+    }
+    for (const step of definition.steps) {
+      if (!visited.has(step.id)) {
+        issues.push(
+          `workflow ${definition.id} has unreachable step: ${step.id}`,
+        );
+      }
+    }
   }
   return issues;
 }

--- a/src/workflow/service.ts
+++ b/src/workflow/service.ts
@@ -1,0 +1,198 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { rememberPendingApproval } from '../gateway/pending-approvals.js';
+import { approveStep, executeWorkflow, returnForRevision } from './executor.js';
+import { parseWorkflowDefinitionYaml } from './schema.js';
+import {
+  getWorkflowDefinition,
+  getWorkflowRunState,
+  listWorkflowDefinitions,
+  listWorkflowRunStates,
+  saveWorkflowDefinition,
+  type WorkflowRunState,
+} from './store.js';
+
+const WORKFLOW_PRESETS_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'presets',
+  'workflows',
+);
+
+export interface WorkflowRuntimeInitResult {
+  loadedDefinitions: string[];
+}
+
+export interface WorkflowAdminSummary {
+  definitions: ReturnType<typeof listWorkflowDefinitions>;
+  runs: WorkflowRunState[];
+}
+
+function workflowApprovalId(run: WorkflowRunState): string {
+  return `workflow:${run.id}:${run.current_step_id || 'step'}`;
+}
+
+function workflowPendingApprovalPrompt(run: WorkflowRunState): string {
+  const step = run.steps.find((entry) => entry.step_id === run.current_step_id);
+  const reasons = step?.escalation?.reasons || [];
+  return [
+    `Workflow "${run.workflow.name}" paused at step "${run.current_step_id}".`,
+    ...(step
+      ? [`Owner: ${step.owner_coworker_id}`, `Action: ${step.action}`]
+      : []),
+    ...(step?.escalation?.stakes && step.escalation.threshold
+      ? [
+          `Stakes: ${step.escalation.stakes}; threshold: ${step.escalation.threshold}`,
+        ]
+      : []),
+    ...(reasons.length > 0
+      ? [`Classifier reasoning: ${reasons.join('; ')}`]
+      : []),
+    `Approval ID: ${workflowApprovalId(run)}`,
+    'Reply `yes` to resume this workflow step, or `no` to leave it paused.',
+  ].join('\n');
+}
+
+async function rememberWorkflowApproval(params: {
+  run: WorkflowRunState;
+  sessionId?: string;
+  userId?: string;
+}): Promise<void> {
+  if (params.run.status !== 'paused' || !params.run.current_step_id) return;
+  await rememberPendingApproval({
+    sessionId: params.sessionId || `workflow:${params.run.id}`,
+    approvalId: workflowApprovalId(params.run),
+    prompt: workflowPendingApprovalPrompt(params.run),
+    userId: params.userId || 'local-user',
+    expiresAt: Date.now() + 10 * 60_000,
+    commandAction: {
+      approveArgs: [
+        'workflow',
+        'approve',
+        params.run.id,
+        params.run.current_step_id,
+      ],
+      allowSession: false,
+      allowAgent: false,
+      allowAll: false,
+      denyTitle: 'Workflow Paused',
+      denyText: `Workflow \`${params.run.id}\` remains paused at \`${params.run.current_step_id}\`.`,
+    },
+  });
+}
+
+export function initializeWorkflowRuntime(): WorkflowRuntimeInitResult {
+  const loadedDefinitions: string[] = [];
+  if (!fs.existsSync(WORKFLOW_PRESETS_DIR)) {
+    return { loadedDefinitions };
+  }
+
+  for (const entry of fs.readdirSync(WORKFLOW_PRESETS_DIR).sort()) {
+    if (!entry.endsWith('.yaml') && !entry.endsWith('.yml')) continue;
+    const filePath = path.join(WORKFLOW_PRESETS_DIR, entry);
+    const definition = parseWorkflowDefinitionYaml(
+      fs.readFileSync(filePath, 'utf-8'),
+    );
+    saveWorkflowDefinition(definition, {
+      route: 'workflow.runtime.init',
+      source: filePath,
+    });
+    loadedDefinitions.push(definition.id);
+  }
+  return { loadedDefinitions };
+}
+
+export function getWorkflowAdminSummary(): WorkflowAdminSummary {
+  return {
+    definitions: listWorkflowDefinitions(),
+    runs: listWorkflowRunStates(),
+  };
+}
+
+export async function startWorkflowRun(params: {
+  workflowId: string;
+  runId?: string;
+  sessionId?: string;
+  userId?: string;
+}): Promise<WorkflowRunState> {
+  const workflow = getWorkflowDefinition(params.workflowId);
+  if (!workflow) {
+    throw new Error(`Unknown workflow definition: ${params.workflowId}`);
+  }
+  const run = await executeWorkflow({
+    workflow,
+    runId: params.runId,
+    sessionId: params.sessionId,
+    actor: params.userId,
+    meta: {
+      actor: params.userId,
+      route: 'workflow.start',
+      source: params.workflowId,
+    },
+  });
+  await rememberWorkflowApproval({
+    run,
+    sessionId: params.sessionId,
+    userId: params.userId,
+  });
+  return run;
+}
+
+export async function approveWorkflowRunStep(params: {
+  runId: string;
+  stepId?: string;
+  actor: string;
+  sessionId?: string;
+}): Promise<WorkflowRunState> {
+  const current = getWorkflowRunState(params.runId);
+  if (!current) throw new Error(`Unknown workflow run: ${params.runId}`);
+  const stepId = params.stepId || current.current_step_id;
+  if (!stepId) throw new Error(`Workflow run ${params.runId} is not paused.`);
+  const run = await approveStep(params.runId, stepId, params.actor, {
+    sessionId: params.sessionId,
+    meta: {
+      actor: params.actor,
+      route: 'workflow.approve',
+      source: params.runId,
+    },
+  });
+  await rememberWorkflowApproval({
+    run,
+    sessionId: params.sessionId,
+    userId: params.actor,
+  });
+  return run;
+}
+
+export async function returnWorkflowRunStep(params: {
+  runId: string;
+  stepId: string;
+  notes: string;
+  actor: string;
+  fromStepId?: string;
+  sessionId?: string;
+}): Promise<WorkflowRunState> {
+  const run = await returnForRevision(
+    params.runId,
+    params.stepId,
+    params.notes,
+    {
+      actor: params.actor,
+      fromStepId: params.fromStepId,
+      sessionId: params.sessionId,
+      meta: {
+        actor: params.actor,
+        route: 'workflow.return_for_revision',
+        source: params.runId,
+      },
+    },
+  );
+  await rememberWorkflowApproval({
+    run,
+    sessionId: params.sessionId,
+    userId: params.actor,
+  });
+  return run;
+}

--- a/src/workflow/service.ts
+++ b/src/workflow/service.ts
@@ -20,6 +20,8 @@ const WORKFLOW_PRESETS_DIR = path.resolve(
   'presets',
   'workflows',
 );
+const DEFAULT_WORKFLOW_APPROVAL_TTL_MS = 24 * 60 * 60_000;
+const WORKFLOW_APPROVAL_TTL_ENV = 'HYBRIDCLAW_WORKFLOW_APPROVAL_TTL_MS';
 
 export interface WorkflowRuntimeInitResult {
   loadedDefinitions: string[];
@@ -32,6 +34,26 @@ export interface WorkflowAdminSummary {
 
 function workflowApprovalId(run: WorkflowRunState): string {
   return `workflow:${run.id}:${run.current_step_id || 'step'}`;
+}
+
+function workflowApprovalTtlMs(): number {
+  const raw = String(process.env[WORKFLOW_APPROVAL_TTL_ENV] || '').trim();
+  if (!raw) return DEFAULT_WORKFLOW_APPROVAL_TTL_MS;
+  const value = Number(raw);
+  return Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : DEFAULT_WORKFLOW_APPROVAL_TTL_MS;
+}
+
+function requireWorkflowUserId(
+  value: string | undefined,
+  field: string,
+): string {
+  const normalized = String(value || '').trim();
+  if (!normalized) {
+    throw new Error(`Workflow ${field} requires an explicit user id`);
+  }
+  return normalized;
 }
 
 function workflowPendingApprovalPrompt(run: WorkflowRunState): string {
@@ -58,15 +80,16 @@ function workflowPendingApprovalPrompt(run: WorkflowRunState): string {
 async function rememberWorkflowApproval(params: {
   run: WorkflowRunState;
   sessionId?: string;
-  userId?: string;
+  userId: string;
 }): Promise<void> {
   if (params.run.status !== 'paused' || !params.run.current_step_id) return;
+  const userId = requireWorkflowUserId(params.userId, 'approval');
   await rememberPendingApproval({
     sessionId: params.sessionId || `workflow:${params.run.id}`,
     approvalId: workflowApprovalId(params.run),
     prompt: workflowPendingApprovalPrompt(params.run),
-    userId: params.userId || 'local-user',
-    expiresAt: Date.now() + 10 * 60_000,
+    userId,
+    expiresAt: Date.now() + workflowApprovalTtlMs(),
     commandAction: {
       approveArgs: [
         'workflow',
@@ -115,8 +138,9 @@ export async function startWorkflowRun(params: {
   workflowId: string;
   runId?: string;
   sessionId?: string;
-  userId?: string;
+  userId: string;
 }): Promise<WorkflowRunState> {
+  const userId = requireWorkflowUserId(params.userId, 'start');
   const workflow = getWorkflowDefinition(params.workflowId);
   if (!workflow) {
     throw new Error(`Unknown workflow definition: ${params.workflowId}`);
@@ -125,9 +149,9 @@ export async function startWorkflowRun(params: {
     workflow,
     runId: params.runId,
     sessionId: params.sessionId,
-    actor: params.userId,
+    actor: userId,
     meta: {
-      actor: params.userId,
+      actor: userId,
       route: 'workflow.start',
       source: params.workflowId,
     },
@@ -135,7 +159,7 @@ export async function startWorkflowRun(params: {
   await rememberWorkflowApproval({
     run,
     sessionId: params.sessionId,
-    userId: params.userId,
+    userId,
   });
   return run;
 }

--- a/src/workflow/stakes-classifier.ts
+++ b/src/workflow/stakes-classifier.ts
@@ -1,0 +1,125 @@
+import type {
+  StakesClassificationInput,
+  StakesClassifier,
+  StakesLevel,
+  StakesScore,
+  StakesSignal,
+} from '../../container/shared/stakes-classifier.js';
+
+const LEVEL_ORDER: Record<StakesLevel, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+};
+
+const CUSTOMER_FACING_RE =
+  /\b(customer|client|external|public|publish|recipient|subscriber|prospect|lead|buyer)\b/i;
+const SENSITIVE_RE =
+  /\b(secret|token|password|credential|api[_ -]?key|private|nda|contract|legal|billing|payment|refund|charge|production|live)\b/i;
+const IRREVERSIBLE_RE =
+  /\b(delete|destroy|drop|truncate|erase|wipe|terminate|cancel|publish|send|charge|refund|transfer)\b/i;
+
+function maxLevel(...levels: StakesLevel[]): StakesLevel {
+  return levels.reduce<StakesLevel>(
+    (max, level) => (LEVEL_ORDER[level] > LEVEL_ORDER[max] ? level : max),
+    'low',
+  );
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+function signal(
+  name: string,
+  level: StakesLevel,
+  score: number,
+  reason: string,
+): StakesSignal {
+  return { name, level, score: clamp01(score), reason };
+}
+
+export class WorkflowStakesClassifier implements StakesClassifier {
+  classify(input: StakesClassificationInput): StakesScore {
+    const text = [
+      input.toolName,
+      input.actionKey,
+      input.intent,
+      input.reason,
+      input.target,
+      JSON.stringify(input.args),
+    ]
+      .join(' ')
+      .toLowerCase();
+    const signals: StakesSignal[] = [];
+
+    if (input.writeIntent) {
+      signals.push(
+        signal(
+          'workflow-write',
+          'medium',
+          0.2,
+          'workflow step can modify state',
+        ),
+      );
+    }
+    if (CUSTOMER_FACING_RE.test(text)) {
+      signals.push(
+        signal(
+          'customer-facing',
+          input.writeIntent ? 'high' : 'medium',
+          input.writeIntent ? 0.5 : 0.35,
+          'step appears customer-facing or externally visible',
+        ),
+      );
+    }
+    if (SENSITIVE_RE.test(text)) {
+      signals.push(
+        signal(
+          'sensitive-context',
+          'high',
+          0.55,
+          'step mentions sensitive, legal, billing, or production context',
+        ),
+      );
+    }
+    if (IRREVERSIBLE_RE.test(text)) {
+      signals.push(
+        signal(
+          'irreversible',
+          'high',
+          0.65,
+          'step appears irreversible or difficult to roll back',
+        ),
+      );
+    }
+
+    const score = clamp01(
+      0.05 + signals.reduce((total, entry) => total + entry.score, 0),
+    );
+    const level = maxLevel(
+      score >= 0.75 ? 'high' : score >= 0.35 ? 'medium' : 'low',
+      ...signals.map((entry) => entry.level),
+    );
+    const reasons =
+      signals.length > 0
+        ? [...new Set(signals.map((entry) => entry.reason))]
+        : ['no elevated-stakes workflow signals detected'];
+
+    return {
+      level,
+      score,
+      confidence: clamp01(0.65 + Math.min(signals.length, 3) * 0.08),
+      classifier: 'workflow-f8-rules:v1',
+      signals,
+      reasons,
+    };
+  }
+}
+
+export function createWorkflowStakesClassifier(): StakesClassifier {
+  return new WorkflowStakesClassifier();
+}

--- a/src/workflow/stakes-classifier.ts
+++ b/src/workflow/stakes-classifier.ts
@@ -13,6 +13,7 @@ const SENSITIVE_RE =
   /\b(secret|token|password|credential|api[_ -]?key|private|nda|contract|legal|billing|payment|refund|charge|production|live)\b/i;
 const IRREVERSIBLE_RE =
   /\b(delete|destroy|drop|truncate|erase|wipe|terminate|cancel|publish|send|charge|refund|transfer)\b/i;
+const MAX_CLASSIFICATION_CACHE_ENTRIES = 256;
 
 function maxLevel(...levels: StakesLevel[]): StakesLevel {
   return levels.reduce<StakesLevel>(
@@ -39,7 +40,23 @@ function signal(
 }
 
 export class WorkflowStakesClassifier implements StakesClassifier {
+  private readonly cache = new Map<string, StakesScore>();
+
   classify(input: StakesClassificationInput): StakesScore {
+    const cacheKey = [
+      input.actionKey,
+      input.toolName,
+      String(input.args.workflow_id || ''),
+      String(input.args.step_id || ''),
+      String(input.args.owner_coworker_id || ''),
+      input.intent,
+      input.reason,
+      input.target,
+      input.writeIntent ? 'write' : 'read',
+    ].join('\0');
+    const cached = this.cache.get(cacheKey);
+    if (cached) return cached;
+
     const text = [
       input.toolName,
       input.actionKey,
@@ -105,7 +122,7 @@ export class WorkflowStakesClassifier implements StakesClassifier {
         ? [...new Set(signals.map((entry) => entry.reason))]
         : ['no elevated-stakes workflow signals detected'];
 
-    return {
+    const result: StakesScore = {
       level,
       score,
       confidence: clamp01(0.65 + Math.min(signals.length, 3) * 0.08),
@@ -113,6 +130,12 @@ export class WorkflowStakesClassifier implements StakesClassifier {
       signals,
       reasons,
     };
+    this.cache.set(cacheKey, result);
+    if (this.cache.size > MAX_CLASSIFICATION_CACHE_ENTRIES) {
+      const oldestKey = this.cache.keys().next().value;
+      if (oldestKey) this.cache.delete(oldestKey);
+    }
+    return result;
   }
 }
 

--- a/src/workflow/stakes-classifier.ts
+++ b/src/workflow/stakes-classifier.ts
@@ -5,12 +5,7 @@ import type {
   StakesScore,
   StakesSignal,
 } from '../../container/shared/stakes-classifier.js';
-
-const LEVEL_ORDER: Record<StakesLevel, number> = {
-  low: 0,
-  medium: 1,
-  high: 2,
-};
+import { WORKFLOW_STAKES_ORDER } from './schema.js';
 
 const CUSTOMER_FACING_RE =
   /\b(customer|client|external|public|publish|recipient|subscriber|prospect|lead|buyer)\b/i;
@@ -21,7 +16,8 @@ const IRREVERSIBLE_RE =
 
 function maxLevel(...levels: StakesLevel[]): StakesLevel {
   return levels.reduce<StakesLevel>(
-    (max, level) => (LEVEL_ORDER[level] > LEVEL_ORDER[max] ? level : max),
+    (max, level) =>
+      WORKFLOW_STAKES_ORDER[level] > WORKFLOW_STAKES_ORDER[max] ? level : max,
     'low',
   );
 }

--- a/src/workflow/store.ts
+++ b/src/workflow/store.ts
@@ -1,0 +1,402 @@
+import path from 'node:path';
+import { isRecord } from '../a2a/utils.js';
+import {
+  getRuntimeAssetRevisionState,
+  listRuntimeAssetRevisionStates,
+  type RuntimeConfigChangeMeta,
+  syncRuntimeAssetRevisionState,
+} from '../config/runtime-config-revisions.js';
+import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+import {
+  validateWorkflowDefinition,
+  type WorkflowDefinition,
+  WorkflowDefinitionValidationError,
+} from './schema.js';
+
+export type WorkflowRunStatus = 'running' | 'paused' | 'completed' | 'failed';
+export type WorkflowStepRunStatus =
+  | 'pending'
+  | 'running'
+  | 'paused'
+  | 'completed'
+  | 'revision_requested'
+  | 'failed';
+
+export interface WorkflowStepArtifact {
+  revision: number;
+  created_at: string;
+  value: unknown;
+}
+
+export interface WorkflowRevisionRequest {
+  revision: number;
+  from_step_id: string;
+  target_step_id: string;
+  notes: string;
+  actor?: string;
+  created_at: string;
+}
+
+export interface WorkflowStepEscalation {
+  route: 'none' | 'approval_request';
+  threshold?: 'low' | 'medium' | 'high';
+  stakes?: 'low' | 'medium' | 'high';
+  classifier?: string;
+  reasons: string[];
+  requested_at?: string;
+  approved_at?: string;
+  approved_by?: string;
+}
+
+export interface WorkflowStepRunState {
+  step_id: string;
+  owner_coworker_id: string;
+  action: string;
+  status: WorkflowStepRunStatus;
+  attempts: number;
+  artifacts: WorkflowStepArtifact[];
+  revisions: WorkflowRevisionRequest[];
+  started_at?: string;
+  completed_at?: string;
+  paused_at?: string;
+  failed_at?: string;
+  error?: string;
+  escalation?: WorkflowStepEscalation;
+}
+
+export interface WorkflowRunEvent {
+  type: string;
+  step_id?: string;
+  message?: string;
+  created_at: string;
+  [key: string]: unknown;
+}
+
+export interface WorkflowRunState {
+  version: 1;
+  id: string;
+  workflow: WorkflowDefinition;
+  thread_id: string;
+  initiator_coworker_id: string;
+  status: WorkflowRunStatus;
+  current_step_id?: string;
+  created_at: string;
+  updated_at: string;
+  completed_at?: string;
+  failed_at?: string;
+  error?: string;
+  steps: WorkflowStepRunState[];
+  events: WorkflowRunEvent[];
+}
+
+export class WorkflowRunStateError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WorkflowRunStateError';
+  }
+}
+
+function normalizeOpaqueId(value: string, field: string): string {
+  const normalized = value.trim();
+  if (!normalized || /\s/u.test(normalized)) {
+    throw new WorkflowRunStateError(
+      `${field} must be a non-empty id without whitespace`,
+    );
+  }
+  return normalized;
+}
+
+export function workflowRunAssetPath(runId: string): string {
+  return path.join(
+    DEFAULT_RUNTIME_HOME_DIR,
+    'workflows',
+    'runs',
+    `${encodeURIComponent(normalizeOpaqueId(runId, 'runId'))}.json`,
+  );
+}
+
+export function workflowDefinitionAssetPath(workflowId: string): string {
+  return path.join(
+    DEFAULT_RUNTIME_HOME_DIR,
+    'workflows',
+    'definitions',
+    `${encodeURIComponent(normalizeOpaqueId(workflowId, 'workflowId'))}.json`,
+  );
+}
+
+function parseRunState(raw: string, expectedRunId: string): WorkflowRunState {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new WorkflowRunStateError(
+      `workflow run JSON is invalid: ${
+        error instanceof Error ? error.message : 'unknown parse error'
+      }`,
+    );
+  }
+  if (!isRecord(parsed)) {
+    throw new WorkflowRunStateError('workflow run state must be an object');
+  }
+  if (parsed.version !== 1) {
+    throw new WorkflowRunStateError('workflow run state version must be 1');
+  }
+  if (parsed.id !== expectedRunId) {
+    throw new WorkflowRunStateError(
+      `workflow run state is for ${String(parsed.id || '<missing>')}`,
+    );
+  }
+  const workflow = validateWorkflowDefinition(parsed.workflow);
+  const steps = Array.isArray(parsed.steps) ? parsed.steps : [];
+  const events = Array.isArray(parsed.events) ? parsed.events : [];
+  return {
+    version: 1,
+    id: expectedRunId,
+    workflow,
+    thread_id: String(parsed.thread_id || '').trim(),
+    initiator_coworker_id: String(parsed.initiator_coworker_id || '').trim(),
+    status:
+      parsed.status === 'paused' ||
+      parsed.status === 'completed' ||
+      parsed.status === 'failed'
+        ? parsed.status
+        : 'running',
+    ...(typeof parsed.current_step_id === 'string' && parsed.current_step_id
+      ? { current_step_id: parsed.current_step_id }
+      : {}),
+    created_at: String(parsed.created_at || '').trim(),
+    updated_at: String(parsed.updated_at || '').trim(),
+    ...(typeof parsed.completed_at === 'string'
+      ? { completed_at: parsed.completed_at }
+      : {}),
+    ...(typeof parsed.failed_at === 'string'
+      ? { failed_at: parsed.failed_at }
+      : {}),
+    ...(typeof parsed.error === 'string' ? { error: parsed.error } : {}),
+    steps: steps.map(parseStepRunState),
+    events: events.map(parseRunEvent),
+  };
+}
+
+function parseStepRunState(value: unknown): WorkflowStepRunState {
+  if (!isRecord(value)) {
+    throw new WorkflowRunStateError('workflow step run must be an object');
+  }
+  const artifacts = Array.isArray(value.artifacts) ? value.artifacts : [];
+  const revisions = Array.isArray(value.revisions) ? value.revisions : [];
+  return {
+    step_id: String(value.step_id || '').trim(),
+    owner_coworker_id: String(value.owner_coworker_id || '').trim(),
+    action: String(value.action || ''),
+    status: normalizeStepStatus(value.status),
+    attempts: Number.isInteger(value.attempts) ? Number(value.attempts) : 0,
+    artifacts: artifacts.map(parseArtifact),
+    revisions: revisions.map(parseRevisionRequest),
+    ...(typeof value.started_at === 'string'
+      ? { started_at: value.started_at }
+      : {}),
+    ...(typeof value.completed_at === 'string'
+      ? { completed_at: value.completed_at }
+      : {}),
+    ...(typeof value.paused_at === 'string'
+      ? { paused_at: value.paused_at }
+      : {}),
+    ...(typeof value.failed_at === 'string'
+      ? { failed_at: value.failed_at }
+      : {}),
+    ...(typeof value.error === 'string' ? { error: value.error } : {}),
+    ...(isRecord(value.escalation)
+      ? { escalation: parseEscalation(value.escalation) }
+      : {}),
+  };
+}
+
+function normalizeStepStatus(value: unknown): WorkflowStepRunStatus {
+  if (
+    value === 'running' ||
+    value === 'paused' ||
+    value === 'completed' ||
+    value === 'revision_requested' ||
+    value === 'failed'
+  ) {
+    return value;
+  }
+  return 'pending';
+}
+
+function parseArtifact(value: unknown): WorkflowStepArtifact {
+  if (!isRecord(value)) {
+    return {
+      revision: 1,
+      created_at: new Date(0).toISOString(),
+      value,
+    };
+  }
+  return {
+    revision: Number.isInteger(value.revision) ? Number(value.revision) : 1,
+    created_at:
+      typeof value.created_at === 'string'
+        ? value.created_at
+        : new Date(0).toISOString(),
+    value: value.value,
+  };
+}
+
+function parseRevisionRequest(value: unknown): WorkflowRevisionRequest {
+  if (!isRecord(value)) {
+    throw new WorkflowRunStateError(
+      'workflow revision request must be an object',
+    );
+  }
+  return {
+    revision: Number.isInteger(value.revision) ? Number(value.revision) : 1,
+    from_step_id: String(value.from_step_id || '').trim(),
+    target_step_id: String(value.target_step_id || '').trim(),
+    notes: String(value.notes || ''),
+    ...(typeof value.actor === 'string' ? { actor: value.actor } : {}),
+    created_at:
+      typeof value.created_at === 'string'
+        ? value.created_at
+        : new Date(0).toISOString(),
+  };
+}
+
+function parseEscalation(
+  value: Record<string, unknown>,
+): WorkflowStepEscalation {
+  return {
+    route: value.route === 'approval_request' ? 'approval_request' : 'none',
+    ...(value.threshold === 'low' ||
+    value.threshold === 'medium' ||
+    value.threshold === 'high'
+      ? { threshold: value.threshold }
+      : {}),
+    ...(value.stakes === 'low' ||
+    value.stakes === 'medium' ||
+    value.stakes === 'high'
+      ? { stakes: value.stakes }
+      : {}),
+    ...(typeof value.classifier === 'string'
+      ? { classifier: value.classifier }
+      : {}),
+    reasons: Array.isArray(value.reasons)
+      ? value.reasons.map((entry) => String(entry || '')).filter(Boolean)
+      : [],
+    ...(typeof value.requested_at === 'string'
+      ? { requested_at: value.requested_at }
+      : {}),
+    ...(typeof value.approved_at === 'string'
+      ? { approved_at: value.approved_at }
+      : {}),
+    ...(typeof value.approved_by === 'string'
+      ? { approved_by: value.approved_by }
+      : {}),
+  };
+}
+
+function parseRunEvent(value: unknown): WorkflowRunEvent {
+  if (!isRecord(value)) {
+    return {
+      type: 'workflow.event',
+      message: String(value || ''),
+      created_at: new Date(0).toISOString(),
+    };
+  }
+  return {
+    ...value,
+    type: String(value.type || 'workflow.event'),
+    ...(typeof value.step_id === 'string' ? { step_id: value.step_id } : {}),
+    ...(typeof value.message === 'string' ? { message: value.message } : {}),
+    created_at:
+      typeof value.created_at === 'string'
+        ? value.created_at
+        : new Date(0).toISOString(),
+  };
+}
+
+function serializeState(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+export function saveWorkflowDefinition(
+  definition: WorkflowDefinition,
+  meta?: RuntimeConfigChangeMeta,
+): WorkflowDefinition {
+  const normalized = validateWorkflowDefinition(definition);
+  syncRuntimeAssetRevisionState(
+    'workflow',
+    workflowDefinitionAssetPath(normalized.id),
+    meta,
+    {
+      exists: true,
+      content: serializeState(normalized),
+    },
+  );
+  return normalized;
+}
+
+export function getWorkflowDefinition(
+  workflowId: string,
+): WorkflowDefinition | null {
+  const normalizedWorkflowId = normalizeOpaqueId(workflowId, 'workflowId');
+  const state = getRuntimeAssetRevisionState(
+    'workflow',
+    workflowDefinitionAssetPath(normalizedWorkflowId),
+  );
+  if (!state) return null;
+  try {
+    return validateWorkflowDefinition(JSON.parse(state.content) as unknown);
+  } catch (error) {
+    if (error instanceof WorkflowDefinitionValidationError) throw error;
+    throw new WorkflowDefinitionValidationError([
+      error instanceof Error ? error.message : 'invalid workflow JSON',
+    ]);
+  }
+}
+
+export function listWorkflowDefinitions(): WorkflowDefinition[] {
+  return listRuntimeAssetRevisionStates(
+    'workflow',
+    path.join(DEFAULT_RUNTIME_HOME_DIR, 'workflows', 'definitions'),
+  )
+    .map((entry) => validateWorkflowDefinition(JSON.parse(entry.content)))
+    .sort((left, right) => left.id.localeCompare(right.id));
+}
+
+export function saveWorkflowRunState(
+  run: WorkflowRunState,
+  meta?: RuntimeConfigChangeMeta,
+): WorkflowRunState {
+  syncRuntimeAssetRevisionState(
+    'workflow',
+    workflowRunAssetPath(run.id),
+    meta,
+    {
+      exists: true,
+      content: serializeState(run),
+    },
+  );
+  return run;
+}
+
+export function getWorkflowRunState(runId: string): WorkflowRunState | null {
+  const normalizedRunId = normalizeOpaqueId(runId, 'runId');
+  const state = getRuntimeAssetRevisionState(
+    'workflow',
+    workflowRunAssetPath(normalizedRunId),
+  );
+  if (!state) return null;
+  return parseRunState(state.content, normalizedRunId);
+}
+
+export function listWorkflowRunStates(): WorkflowRunState[] {
+  return listRuntimeAssetRevisionStates(
+    'workflow',
+    path.join(DEFAULT_RUNTIME_HOME_DIR, 'workflows', 'runs'),
+  )
+    .map((entry) => {
+      const parsed = JSON.parse(entry.content) as { id?: unknown };
+      return parseRunState(entry.content, String(parsed.id || '').trim());
+    })
+    .sort((left, right) => right.updated_at.localeCompare(left.updated_at));
+}

--- a/src/workflow/store.ts
+++ b/src/workflow/store.ts
@@ -8,6 +8,7 @@ import {
   syncRuntimeAssetRevisionState,
 } from '../config/runtime-config-revisions.js';
 import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+import { logger } from '../logger.js';
 import {
   validateWorkflowDefinition,
   type WorkflowDefinition,
@@ -150,18 +151,14 @@ function parseRunState(raw: string, expectedRunId: string): WorkflowRunState {
   const workflow = validateWorkflowDefinition(parsed.workflow);
   const steps = Array.isArray(parsed.steps) ? parsed.steps : [];
   const events = Array.isArray(parsed.events) ? parsed.events : [];
+  const status = normalizeRunStatus(parsed.status);
   return {
     version: 1,
     id: expectedRunId,
     workflow,
     thread_id: String(parsed.thread_id || '').trim(),
     initiator_coworker_id: String(parsed.initiator_coworker_id || '').trim(),
-    status:
-      parsed.status === 'paused' ||
-      parsed.status === 'completed' ||
-      parsed.status === 'failed'
-        ? parsed.status
-        : 'running',
+    status,
     ...(typeof parsed.current_step_id === 'string' && parsed.current_step_id
       ? { current_step_id: parsed.current_step_id }
       : {}),
@@ -177,6 +174,20 @@ function parseRunState(raw: string, expectedRunId: string): WorkflowRunState {
     steps: steps.map(parseStepRunState),
     events: events.map(parseRunEvent),
   };
+}
+
+function normalizeRunStatus(value: unknown): WorkflowRunStatus {
+  if (
+    value === 'running' ||
+    value === 'paused' ||
+    value === 'completed' ||
+    value === 'failed'
+  ) {
+    return value;
+  }
+  throw new WorkflowRunStateError(
+    `workflow run status is invalid: ${String(value || '<missing>')}`,
+  );
 }
 
 function parseStepRunState(value: unknown): WorkflowStepRunState {
@@ -360,7 +371,20 @@ export function listWorkflowDefinitions(): WorkflowDefinition[] {
     'workflow',
     path.join(DEFAULT_RUNTIME_HOME_DIR, 'workflows', 'definitions'),
   )
-    .map((entry) => validateWorkflowDefinition(JSON.parse(entry.content)))
+    .flatMap((entry) => {
+      try {
+        return [validateWorkflowDefinition(JSON.parse(entry.content))];
+      } catch (error) {
+        logger.warn(
+          {
+            assetPath: entry.assetPath,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          'Skipping invalid workflow definition state',
+        );
+        return [];
+      }
+    })
     .sort((left, right) => left.id.localeCompare(right.id));
 }
 
@@ -395,9 +419,20 @@ export function listWorkflowRunStates(): WorkflowRunState[] {
     'workflow',
     path.join(DEFAULT_RUNTIME_HOME_DIR, 'workflows', 'runs'),
   )
-    .map((entry) => {
-      const parsed = JSON.parse(entry.content) as { id?: unknown };
-      return parseRunState(entry.content, String(parsed.id || '').trim());
+    .flatMap((entry) => {
+      try {
+        const parsed = JSON.parse(entry.content) as { id?: unknown };
+        return [parseRunState(entry.content, String(parsed.id || '').trim())];
+      } catch (error) {
+        logger.warn(
+          {
+            assetPath: entry.assetPath,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          'Skipping invalid workflow run state',
+        );
+        return [];
+      }
     })
     .sort((left, right) => right.updated_at.localeCompare(left.updated_at));
 }

--- a/src/workflow/store.ts
+++ b/src/workflow/store.ts
@@ -105,6 +105,8 @@ export class WorkflowRunStateError extends Error {
   }
 }
 
+let workflowRunStateListCache: WorkflowRunState[] | null = null;
+
 function normalizeOpaqueId(value: string, field: string): string {
   const normalized = value.trim();
   if (!normalized || /\s/u.test(normalized)) {
@@ -436,6 +438,12 @@ export function saveWorkflowRunState(
       content: serializeState(run),
     },
   );
+  if (workflowRunStateListCache) {
+    workflowRunStateListCache = [
+      run,
+      ...workflowRunStateListCache.filter((entry) => entry.id !== run.id),
+    ].sort((left, right) => right.updated_at.localeCompare(left.updated_at));
+  }
   return run;
 }
 
@@ -450,7 +458,8 @@ export function getWorkflowRunState(runId: string): WorkflowRunState | null {
 }
 
 export function listWorkflowRunStates(): WorkflowRunState[] {
-  return listRuntimeAssetRevisionStates(
+  if (workflowRunStateListCache) return [...workflowRunStateListCache];
+  workflowRunStateListCache = listRuntimeAssetRevisionStates(
     'workflow',
     path.join(DEFAULT_RUNTIME_HOME_DIR, 'workflows', 'runs'),
   )
@@ -470,4 +479,5 @@ export function listWorkflowRunStates(): WorkflowRunState[] {
       }
     })
     .sort((left, right) => right.updated_at.localeCompare(left.updated_at));
+  return [...workflowRunStateListCache];
 }

--- a/src/workflow/store.ts
+++ b/src/workflow/store.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import type { StakesLevel } from '../../container/shared/stakes-classifier.js';
 import { isRecord } from '../a2a/utils.js';
 import {
   getRuntimeAssetRevisionState,
@@ -39,8 +40,8 @@ export interface WorkflowRevisionRequest {
 
 export interface WorkflowStepEscalation {
   route: 'none' | 'approval_request';
-  threshold?: 'low' | 'medium' | 'high';
-  stakes?: 'low' | 'medium' | 'high';
+  threshold?: StakesLevel;
+  stakes?: StakesLevel;
   classifier?: string;
   reasons: string[];
   requested_at?: string;

--- a/src/workflow/store.ts
+++ b/src/workflow/store.ts
@@ -70,8 +70,15 @@ export interface WorkflowRunEvent {
   type: string;
   step_id?: string;
   message?: string;
+  owner_coworker_id?: string;
+  stakes?: StakesLevel;
+  threshold?: StakesLevel;
+  classifier?: string;
+  reasons?: string[];
+  actor?: string;
+  from_step_id?: string;
+  notes?: string;
   created_at: string;
-  [key: string]: unknown;
 }
 
 export interface WorkflowRunState {
@@ -314,16 +321,44 @@ function parseRunEvent(value: unknown): WorkflowRunEvent {
       created_at: new Date(0).toISOString(),
     };
   }
-  return {
-    ...value,
+  const event: WorkflowRunEvent = {
     type: String(value.type || 'workflow.event'),
-    ...(typeof value.step_id === 'string' ? { step_id: value.step_id } : {}),
-    ...(typeof value.message === 'string' ? { message: value.message } : {}),
     created_at:
       typeof value.created_at === 'string'
         ? value.created_at
         : new Date(0).toISOString(),
   };
+  if (typeof value.step_id === 'string') event.step_id = value.step_id;
+  if (typeof value.message === 'string') event.message = value.message;
+  if (typeof value.owner_coworker_id === 'string') {
+    event.owner_coworker_id = value.owner_coworker_id;
+  }
+  if (
+    value.stakes === 'low' ||
+    value.stakes === 'medium' ||
+    value.stakes === 'high'
+  ) {
+    event.stakes = value.stakes;
+  }
+  if (
+    value.threshold === 'low' ||
+    value.threshold === 'medium' ||
+    value.threshold === 'high'
+  ) {
+    event.threshold = value.threshold;
+  }
+  if (typeof value.classifier === 'string') event.classifier = value.classifier;
+  if (Array.isArray(value.reasons)) {
+    event.reasons = value.reasons
+      .map((entry) => String(entry || ''))
+      .filter(Boolean);
+  }
+  if (typeof value.actor === 'string') event.actor = value.actor;
+  if (typeof value.from_step_id === 'string') {
+    event.from_step_id = value.from_step_id;
+  }
+  if (typeof value.notes === 'string') event.notes = value.notes;
+  return event;
 }
 
 function serializeState(value: unknown): string {

--- a/src/workflow/visualizer.ts
+++ b/src/workflow/visualizer.ts
@@ -1,0 +1,79 @@
+import { getWorkflowRunState, type WorkflowRunState } from './store.js';
+
+export interface WorkflowRunStepView {
+  id: string;
+  ownerCoworkerId: string;
+  action: string;
+  status: string;
+  attempts: number;
+  active: boolean;
+  pendingApproval: boolean;
+  stakes?: string;
+  threshold?: string;
+  revisionCount: number;
+  artifactCount: number;
+}
+
+export interface WorkflowRunView {
+  id: string;
+  workflowId: string;
+  name: string;
+  status: string;
+  currentStepId?: string;
+  steps: WorkflowRunStepView[];
+}
+
+export function buildWorkflowRunView(run: WorkflowRunState): WorkflowRunView {
+  return {
+    id: run.id,
+    workflowId: run.workflow.id,
+    name: run.workflow.name,
+    status: run.status,
+    ...(run.current_step_id ? { currentStepId: run.current_step_id } : {}),
+    steps: run.steps.map((step) => ({
+      id: step.step_id,
+      ownerCoworkerId: step.owner_coworker_id,
+      action: step.action,
+      status: step.status,
+      attempts: step.attempts,
+      active: run.current_step_id === step.step_id,
+      pendingApproval:
+        step.escalation?.route === 'approval_request' &&
+        !step.escalation.approved_at,
+      ...(step.escalation?.stakes ? { stakes: step.escalation.stakes } : {}),
+      ...(step.escalation?.threshold
+        ? { threshold: step.escalation.threshold }
+        : {}),
+      revisionCount: step.revisions.length,
+      artifactCount: step.artifacts.length,
+    })),
+  };
+}
+
+export function renderWorkflowRunState(run: WorkflowRunState): string {
+  const view = buildWorkflowRunView(run);
+  const lines = [
+    `${view.name} (${view.id})`,
+    `Status: ${view.status}${view.currentStepId ? `, active: ${view.currentStepId}` : ''}`,
+  ];
+  for (const step of view.steps) {
+    const markers = [
+      step.active ? 'active' : '',
+      step.pendingApproval ? 'pending approval' : '',
+      step.stakes && step.threshold
+        ? `stakes ${step.stakes} / threshold ${step.threshold}`
+        : '',
+      step.revisionCount > 0 ? `${step.revisionCount} revision(s)` : '',
+    ].filter(Boolean);
+    lines.push(
+      `- ${step.id}: ${step.status} (${step.ownerCoworkerId})${markers.length > 0 ? ` [${markers.join(', ')}]` : ''}`,
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+export function renderWorkflowRunStateById(runId: string): string {
+  const run = getWorkflowRunState(runId);
+  if (!run) throw new Error(`Unknown workflow run: ${runId}`);
+  return renderWorkflowRunState(run);
+}

--- a/src/workflow/visualizer.ts
+++ b/src/workflow/visualizer.ts
@@ -1,72 +1,24 @@
 import { getWorkflowRunState, type WorkflowRunState } from './store.js';
 
-export interface WorkflowRunStepView {
-  id: string;
-  ownerCoworkerId: string;
-  action: string;
-  status: string;
-  attempts: number;
-  active: boolean;
-  pendingApproval: boolean;
-  stakes?: string;
-  threshold?: string;
-  revisionCount: number;
-  artifactCount: number;
-}
-
-export interface WorkflowRunView {
-  id: string;
-  workflowId: string;
-  name: string;
-  status: string;
-  currentStepId?: string;
-  steps: WorkflowRunStepView[];
-}
-
-export function buildWorkflowRunView(run: WorkflowRunState): WorkflowRunView {
-  return {
-    id: run.id,
-    workflowId: run.workflow.id,
-    name: run.workflow.name,
-    status: run.status,
-    ...(run.current_step_id ? { currentStepId: run.current_step_id } : {}),
-    steps: run.steps.map((step) => ({
-      id: step.step_id,
-      ownerCoworkerId: step.owner_coworker_id,
-      action: step.action,
-      status: step.status,
-      attempts: step.attempts,
-      active: run.current_step_id === step.step_id,
-      pendingApproval:
-        step.escalation?.route === 'approval_request' &&
-        !step.escalation.approved_at,
-      ...(step.escalation?.stakes ? { stakes: step.escalation.stakes } : {}),
-      ...(step.escalation?.threshold
-        ? { threshold: step.escalation.threshold }
-        : {}),
-      revisionCount: step.revisions.length,
-      artifactCount: step.artifacts.length,
-    })),
-  };
-}
-
 export function renderWorkflowRunState(run: WorkflowRunState): string {
-  const view = buildWorkflowRunView(run);
   const lines = [
-    `${view.name} (${view.id})`,
-    `Status: ${view.status}${view.currentStepId ? `, active: ${view.currentStepId}` : ''}`,
+    `${run.workflow.name} (${run.id})`,
+    `Status: ${run.status}${run.current_step_id ? `, active: ${run.current_step_id}` : ''}`,
   ];
-  for (const step of view.steps) {
+  for (const step of run.steps) {
     const markers = [
-      step.active ? 'active' : '',
-      step.pendingApproval ? 'pending approval' : '',
-      step.stakes && step.threshold
-        ? `stakes ${step.stakes} / threshold ${step.threshold}`
+      run.current_step_id === step.step_id ? 'active' : '',
+      step.escalation?.route === 'approval_request' &&
+      !step.escalation.approved_at
+        ? 'pending approval'
         : '',
-      step.revisionCount > 0 ? `${step.revisionCount} revision(s)` : '',
+      step.escalation?.stakes && step.escalation.threshold
+        ? `stakes ${step.escalation.stakes} / threshold ${step.escalation.threshold}`
+        : '',
+      step.revisions.length > 0 ? `${step.revisions.length} revision(s)` : '',
     ].filter(Boolean);
     lines.push(
-      `- ${step.id}: ${step.status} (${step.ownerCoworkerId})${markers.length > 0 ? ` [${markers.join(', ')}]` : ''}`,
+      `- ${step.step_id}: ${step.status} (${step.owner_coworker_id})${markers.length > 0 ? ` [${markers.join(', ')}]` : ''}`,
     );
   }
   return `${lines.join('\n')}\n`;

--- a/tests/runtime-config-revisions.integration.test.ts
+++ b/tests/runtime-config-revisions.integration.test.ts
@@ -266,6 +266,39 @@ describe('runtime config revisions integration', () => {
     }
   });
 
+  it('lists runtime asset states with exact LIKE prefix escaping', async () => {
+    const revisionsMod = await import(
+      '../src/config/runtime-config-revisions.js'
+    );
+    const exactPrefix = path.join(tmpDir, 'workflow_runs', 'wf_');
+    const exactPath = path.join(exactPrefix, 'run.json');
+    const wildcardSiblingPath = path.join(
+      tmpDir,
+      'workflow_runs',
+      'wfA',
+      'run.json',
+    );
+
+    revisionsMod.syncRuntimeAssetRevisionState(
+      'workflow',
+      exactPath,
+      { route: 'test.workflow.exact', source: 'runtime-config-test' },
+      { exists: true, content: 'exact\n' },
+    );
+    revisionsMod.syncRuntimeAssetRevisionState(
+      'workflow',
+      wildcardSiblingPath,
+      { route: 'test.workflow.sibling', source: 'runtime-config-test' },
+      { exists: true, content: 'sibling\n' },
+    );
+
+    expect(
+      revisionsMod
+        .listRuntimeAssetRevisionStates('workflow', exactPrefix)
+        .map((entry) => entry.assetPath),
+    ).toEqual([exactPath]);
+  });
+
   it('migrates legacy config revision rows into typed asset storage', async () => {
     const legacyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hc-cfg-v1-'));
     const legacyDbPath = path.join(legacyDir, 'data', 'config-revisions.db');

--- a/tests/workflow-engine.test.ts
+++ b/tests/workflow-engine.test.ts
@@ -190,6 +190,37 @@ transitions:
     ]);
   });
 
+  test('default workflow stakes classifier caches repeated action classifications', async () => {
+    const { createWorkflowStakesClassifier } = await import(
+      '../src/workflow/stakes-classifier.js'
+    );
+
+    const classifier = createWorkflowStakesClassifier();
+    const input: StakesClassificationInput = {
+      toolName: 'workflow_step',
+      args: {
+        workflow_id: 'cache_test',
+        step_id: 'review',
+        action: 'Review customer-facing copy.',
+        owner_coworker_id: 'reviewer',
+      },
+      actionKey: 'workflow:cache_test:review',
+      intent: 'Review customer-facing copy.',
+      reason: 'workflow step dispatch',
+      target: 'Review customer-facing copy.',
+      approvalTier: 'green',
+      pathHints: [],
+      hostHints: [],
+      writeIntent: true,
+      pinned: false,
+    };
+
+    const first = classifier.classify(input);
+    const second = classifier.classify(input);
+
+    expect(second).toBe(first);
+  });
+
   test('rejects workflows without a root step', async () => {
     await initRuntimeDatabase();
     const { executeWorkflow } = await import('../src/workflow/executor.js');

--- a/tests/workflow-engine.test.ts
+++ b/tests/workflow-engine.test.ts
@@ -102,6 +102,25 @@ transitions:
     to: review
 `),
     ).toThrow('multiple outgoing transitions');
+    expect(() =>
+      parseWorkflowDefinitionYaml(`
+id: disconnected
+name: Disconnected
+steps:
+  - id: brief
+    owner_coworker_id: briefing
+    action: Write the brief.
+  - id: build
+    owner_coworker_id: builder
+    action: Build the draft.
+  - id: review
+    owner_coworker_id: reviewer
+    action: Review the draft.
+transitions:
+  - from: brief
+    to: build
+`),
+    ).toThrow('multiple root steps');
   });
 
   test('runs brief to build autonomously and pauses review when F8 exceeds the threshold', async () => {
@@ -562,6 +581,69 @@ transitions:
 
     expect(paused.status).toBe('paused');
     expect(paused.current_step_id).toBe('build');
+    expect(paused.steps.find((step) => step.step_id === 'build')?.status).toBe(
+      'paused',
+    );
+    expect(paused.steps.find((step) => step.step_id === 'review')?.status).toBe(
+      'revision_requested',
+    );
+  });
+
+  test('returnForRevision follows transitions when step order differs', async () => {
+    await initRuntimeDatabase();
+    const { executeWorkflow, returnForRevision } = await import(
+      '../src/workflow/executor.js'
+    );
+
+    const workflow = {
+      id: 'revision_transition_order_test',
+      name: 'Revision transition order test',
+      steps: [
+        {
+          id: 'review',
+          owner_coworker_id: 'reviewer',
+          action: 'Review the work.',
+        },
+        {
+          id: 'brief',
+          owner_coworker_id: 'briefing',
+          action: 'Brief the work.',
+        },
+        {
+          id: 'build',
+          owner_coworker_id: 'builder',
+          action: 'Build the work.',
+          stakes_threshold: 'medium' as const,
+        },
+      ],
+      transitions: [
+        { from: 'brief', to: 'build' },
+        { from: 'build', to: 'review' },
+      ],
+    };
+
+    const completed = await executeWorkflow({
+      workflow,
+      runId: 'run_revision_transition_order',
+      stakesClassifier: makeClassifier({ build: 'low' }),
+      dispatchStep: ({ step }) => ({ artifact: { stepId: step.id } }),
+    });
+    expect(completed.status).toBe('completed');
+
+    const paused = await returnForRevision(
+      'run_revision_transition_order',
+      'build',
+      'Rework the implementation.',
+      {
+        fromStepId: 'review',
+        stakesClassifier: makeClassifier({ build: 'high' }),
+        dispatchStep: ({ step }) => ({ artifact: { stepId: step.id } }),
+      },
+    );
+
+    expect(paused.steps.find((step) => step.step_id === 'brief')?.status).toBe(
+      'completed',
+    );
     expect(paused.steps.find((step) => step.step_id === 'build')?.status).toBe(
       'paused',
     );

--- a/tests/workflow-engine.test.ts
+++ b/tests/workflow-engine.test.ts
@@ -81,6 +81,27 @@ transitions:
       stakes_threshold: 'medium',
     });
     expect(WORKFLOW_DEFINITION_JSON_SCHEMA.properties.steps).toBeDefined();
+    expect(() =>
+      parseWorkflowDefinitionYaml(`
+id: branching
+name: Branching
+steps:
+  - id: brief
+    owner_coworker_id: briefing
+    action: Write the brief.
+  - id: build
+    owner_coworker_id: builder
+    action: Build the draft.
+  - id: review
+    owner_coworker_id: reviewer
+    action: Review the draft.
+transitions:
+  - from: brief
+    to: build
+  - from: brief
+    to: review
+`),
+    ).toThrow('multiple outgoing transitions');
   });
 
   test('runs brief to build autonomously and pauses review when F8 exceeds the threshold', async () => {
@@ -485,5 +506,67 @@ transitions:
       notes: 'Tighten the source citations.',
       actor: 'reviewer',
     });
+  });
+
+  test('returnForRevision marks downstream steps revision_requested before rerun', async () => {
+    await initRuntimeDatabase();
+    const { executeWorkflow, returnForRevision } = await import(
+      '../src/workflow/executor.js'
+    );
+
+    const workflow = {
+      id: 'revision_pause_test',
+      name: 'Revision pause test',
+      steps: [
+        {
+          id: 'brief',
+          owner_coworker_id: 'briefing',
+          action: 'Brief the work.',
+        },
+        {
+          id: 'build',
+          owner_coworker_id: 'builder',
+          action: 'Build the work.',
+          stakes_threshold: 'medium' as const,
+        },
+        {
+          id: 'review',
+          owner_coworker_id: 'reviewer',
+          action: 'Review the work.',
+        },
+      ],
+      transitions: [
+        { from: 'brief', to: 'build' },
+        { from: 'build', to: 'review' },
+      ],
+    };
+
+    const completed = await executeWorkflow({
+      workflow,
+      runId: 'run_revision_pause',
+      stakesClassifier: makeClassifier({ build: 'low' }),
+      dispatchStep: ({ step }) => ({ artifact: { stepId: step.id } }),
+    });
+    expect(completed.status).toBe('completed');
+
+    const paused = await returnForRevision(
+      'run_revision_pause',
+      'build',
+      'Rework the implementation.',
+      {
+        fromStepId: 'review',
+        stakesClassifier: makeClassifier({ build: 'high' }),
+        dispatchStep: ({ step }) => ({ artifact: { stepId: step.id } }),
+      },
+    );
+
+    expect(paused.status).toBe('paused');
+    expect(paused.current_step_id).toBe('build');
+    expect(paused.steps.find((step) => step.step_id === 'build')?.status).toBe(
+      'paused',
+    );
+    expect(paused.steps.find((step) => step.step_id === 'review')?.status).toBe(
+      'revision_requested',
+    );
   });
 });

--- a/tests/workflow-engine.test.ts
+++ b/tests/workflow-engine.test.ts
@@ -189,6 +189,113 @@ transitions:
     ]);
   });
 
+  test('rejects workflows without a root step', async () => {
+    await initRuntimeDatabase();
+    const { executeWorkflow } = await import('../src/workflow/executor.js');
+
+    await expect(
+      executeWorkflow({
+        workflow: {
+          id: 'cyclic_workflow',
+          name: 'Cyclic workflow',
+          steps: [
+            {
+              id: 'brief',
+              owner_coworker_id: 'briefing',
+              action: 'Brief the work.',
+            },
+            {
+              id: 'build',
+              owner_coworker_id: 'builder',
+              action: 'Build the work.',
+            },
+          ],
+          transitions: [
+            { from: 'brief', to: 'build' },
+            { from: 'build', to: 'brief' },
+          ],
+        },
+      }),
+    ).rejects.toThrow('has no root step');
+  });
+
+  test('workflow list helpers skip invalid persisted entries', async () => {
+    await initRuntimeDatabase();
+    const { syncRuntimeAssetRevisionState } = await import(
+      '../src/config/runtime-config-revisions.js'
+    );
+    const {
+      getWorkflowRunState,
+      listWorkflowDefinitions,
+      listWorkflowRunStates,
+      saveWorkflowDefinition,
+      workflowDefinitionAssetPath,
+      workflowRunAssetPath,
+    } = await import('../src/workflow/store.js');
+    const { executeWorkflow } = await import('../src/workflow/executor.js');
+
+    saveWorkflowDefinition({
+      id: 'valid_definition',
+      name: 'Valid definition',
+      steps: [
+        {
+          id: 'brief',
+          owner_coworker_id: 'briefing',
+          action: 'Brief the work.',
+        },
+      ],
+      transitions: [],
+    });
+    syncRuntimeAssetRevisionState(
+      'workflow',
+      workflowDefinitionAssetPath('bad_definition'),
+      { route: 'test', source: 'workflow-engine.test' },
+      { exists: true, content: '{not-json' },
+    );
+
+    const completed = await executeWorkflow({
+      workflow: {
+        id: 'valid_run_definition',
+        name: 'Valid run definition',
+        steps: [
+          {
+            id: 'brief',
+            owner_coworker_id: 'briefing',
+            action: 'Brief the work.',
+          },
+        ],
+        transitions: [],
+      },
+      runId: 'valid_run',
+      dispatchStep: ({ step }) => ({ artifact: { stepId: step.id } }),
+    });
+    syncRuntimeAssetRevisionState(
+      'workflow',
+      workflowRunAssetPath('bad_status_run'),
+      { route: 'test', source: 'workflow-engine.test' },
+      {
+        exists: true,
+        content: `${JSON.stringify(
+          {
+            ...completed,
+            id: 'bad_status_run',
+            status: 'future_status',
+          },
+          null,
+          2,
+        )}\n`,
+      },
+    );
+
+    expect(() => getWorkflowRunState('bad_status_run')).toThrow(
+      'workflow run status is invalid',
+    );
+    expect(listWorkflowDefinitions().map((definition) => definition.id)).toEqual(
+      ['valid_definition', 'valid_run_definition'],
+    );
+    expect(listWorkflowRunStates().map((run) => run.id)).toEqual(['valid_run']);
+  });
+
   test('service entrypoint registers pending approvals for escalated steps', async () => {
     await initRuntimeDatabase();
     const { getPendingApproval, clearPendingApproval } = await import(

--- a/tests/workflow-engine.test.ts
+++ b/tests/workflow-engine.test.ts
@@ -50,6 +50,7 @@ describe('workflow engine', () => {
 
   afterEach(() => {
     delete process.env.HYBRIDCLAW_DATA_DIR;
+    delete process.env.HYBRIDCLAW_WORKFLOW_APPROVAL_TTL_MS;
     fs.rmSync(runtimeHome, { recursive: true, force: true });
     vi.resetModules();
   });
@@ -286,14 +287,48 @@ transitions:
         )}\n`,
       },
     );
+    syncRuntimeAssetRevisionState(
+      'workflow',
+      workflowRunAssetPath('injected_event_run'),
+      { route: 'test', source: 'workflow-engine.test' },
+      {
+        exists: true,
+        content: `${JSON.stringify(
+          {
+            ...completed,
+            id: 'injected_event_run',
+            events: [
+              {
+                type: 'workflow.custom',
+                actor: 'operator',
+                injected: 'untrusted',
+                created_at: completed.created_at,
+              },
+            ],
+          },
+          null,
+          2,
+        )}\n`,
+      },
+    );
 
     expect(() => getWorkflowRunState('bad_status_run')).toThrow(
       'workflow run status is invalid',
     );
+    const sanitizedRun = getWorkflowRunState('injected_event_run');
+    expect(sanitizedRun?.events[0]).toMatchObject({
+      type: 'workflow.custom',
+      actor: 'operator',
+    });
+    expect(Object.hasOwn(sanitizedRun?.events[0] || {}, 'injected')).toBe(
+      false,
+    );
     expect(listWorkflowDefinitions().map((definition) => definition.id)).toEqual(
       ['valid_definition', 'valid_run_definition'],
     );
-    expect(listWorkflowRunStates().map((run) => run.id)).toEqual(['valid_run']);
+    const runIds = listWorkflowRunStates().map((run) => run.id);
+    expect(runIds).toEqual(expect.arrayContaining(['valid_run']));
+    expect(runIds).not.toContain('bad_status_run');
   });
 
   test('service entrypoint registers pending approvals for escalated steps', async () => {
@@ -304,6 +339,7 @@ transitions:
     const { saveWorkflowDefinition } = await import('../src/workflow/store.js');
     const { startWorkflowRun } = await import('../src/workflow/service.js');
 
+    process.env.HYBRIDCLAW_WORKFLOW_APPROVAL_TTL_MS = '7200000';
     saveWorkflowDefinition({
       id: 'approval_service_test',
       name: 'Approval service test',
@@ -323,7 +359,16 @@ transitions:
       ],
       transitions: [{ from: 'brief', to: 'review' }],
     });
+    await expect(
+      startWorkflowRun({
+        workflowId: 'approval_service_test',
+        runId: 'run_missing_actor',
+        sessionId: 'session-workflow',
+        userId: '',
+      }),
+    ).rejects.toThrow('requires an explicit user id');
 
+    const beforeStart = Date.now();
     const run = await startWorkflowRun({
       workflowId: 'approval_service_test',
       runId: 'run_pending_approval',
@@ -333,7 +378,8 @@ transitions:
 
     expect(run.status).toBe('paused');
     expect(run.current_step_id).toBe('review');
-    expect(getPendingApproval('session-workflow')).toMatchObject({
+    const pending = getPendingApproval('session-workflow');
+    expect(pending).toMatchObject({
       approvalId: 'workflow:run_pending_approval:review',
       userId: 'operator',
       commandAction: {
@@ -345,6 +391,7 @@ transitions:
         ],
       },
     });
+    expect((pending?.expiresAt || 0) - beforeStart).toBeGreaterThan(7_100_000);
 
     await clearPendingApproval('session-workflow');
   });

--- a/tests/workflow-engine.test.ts
+++ b/tests/workflow-engine.test.ts
@@ -1,0 +1,304 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type {
+  StakesClassificationInput,
+  StakesClassifier,
+  StakesScore,
+} from '../container/shared/stakes-classifier.js';
+
+function makeRuntimeHome(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'hc-workflow-'));
+}
+
+function makeScore(level: 'low' | 'medium' | 'high'): StakesScore {
+  return {
+    level,
+    score: level === 'high' ? 0.9 : level === 'medium' ? 0.5 : 0.1,
+    confidence: 0.9,
+    classifier: 'test:f8',
+    signals: [],
+    reasons: [`${level} stakes fixture`],
+  };
+}
+
+function makeClassifier(
+  levelsByStep: Record<string, 'low' | 'medium' | 'high'>,
+): StakesClassifier {
+  return {
+    classify(input: StakesClassificationInput): StakesScore {
+      const stepId = String(input.args.step_id || '');
+      return makeScore(levelsByStep[stepId] || 'low');
+    },
+  };
+}
+
+async function initRuntimeDatabase(): Promise<void> {
+  const { initDatabase } = await import('../src/memory/db.js');
+  initDatabase();
+}
+
+describe('workflow engine', () => {
+  let runtimeHome: string;
+
+  beforeEach(() => {
+    runtimeHome = makeRuntimeHome();
+    process.env.HYBRIDCLAW_DATA_DIR = runtimeHome;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.HYBRIDCLAW_DATA_DIR;
+    fs.rmSync(runtimeHome, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  test('parses YAML definitions with stakes thresholds and validates transitions', async () => {
+    const { parseWorkflowDefinitionYaml, WORKFLOW_DEFINITION_JSON_SCHEMA } =
+      await import('../src/workflow/schema.js');
+
+    const workflow = parseWorkflowDefinitionYaml(`
+id: launch_copy
+name: Launch copy
+steps:
+  - id: brief
+    owner_agent_id: briefing
+    action: Write the brief.
+    stakes_threshold: medium
+  - id: build
+    owner_coworker_id: builder
+    action: Build the copy.
+transitions:
+  - from: brief
+    to: build
+`);
+
+    expect(workflow.steps[0]).toMatchObject({
+      id: 'brief',
+      owner_coworker_id: 'briefing',
+      stakes_threshold: 'medium',
+    });
+    expect(WORKFLOW_DEFINITION_JSON_SCHEMA.properties.steps).toBeDefined();
+  });
+
+  test('runs brief to build autonomously and pauses review when F8 exceeds the threshold', async () => {
+    await initRuntimeDatabase();
+    const { executeWorkflow, approveStep } = await import(
+      '../src/workflow/executor.js'
+    );
+    const { renderWorkflowRunState } = await import(
+      '../src/workflow/visualizer.js'
+    );
+
+    const dispatched: string[] = [];
+    const workflow = `
+id: brief_build_review_test
+name: Brief build review test
+steps:
+  - id: brief
+    owner_coworker_id: briefing
+    action: Write internal brief.
+    stakes_threshold: medium
+  - id: build
+    owner_coworker_id: builder
+    action: Build internal draft.
+    stakes_threshold: medium
+  - id: review
+    owner_coworker_id: reviewer
+    action: Send customer-facing launch copy.
+    stakes_threshold: medium
+transitions:
+  - from: brief
+    to: build
+  - from: build
+    to: review
+`;
+
+    const paused = await executeWorkflow({
+      workflow,
+      runId: 'run_launch_copy',
+      stakesClassifier: makeClassifier({
+        brief: 'low',
+        build: 'medium',
+        review: 'high',
+      }),
+      dispatchStep: ({ step }) => {
+        dispatched.push(step.id);
+        return { artifact: { stepId: step.id } };
+      },
+    });
+
+    expect(paused.status).toBe('paused');
+    expect(paused.current_step_id).toBe('review');
+    expect(dispatched).toEqual(['brief', 'build']);
+    expect(renderWorkflowRunState(paused)).toContain('pending approval');
+
+    const completed = await approveStep('run_launch_copy', 'review', 'lead', {
+      stakesClassifier: makeClassifier({ review: 'high' }),
+      dispatchStep: ({ step }) => {
+        dispatched.push(step.id);
+        return { artifact: { stepId: step.id } };
+      },
+    });
+
+    expect(completed.status).toBe('completed');
+    expect(dispatched).toEqual(['brief', 'build', 'review']);
+    expect(
+      completed.events.some((entry) => entry.type === 'workflow.step.escalated'),
+    ).toBe(true);
+  });
+
+  test('starter-style canonical coworkers dispatch through the default A2A path', async () => {
+    await initRuntimeDatabase();
+    const { executeWorkflow } = await import('../src/workflow/executor.js');
+    const { listA2AThreadEnvelopes } = await import('../src/a2a/store.js');
+
+    const completed = await executeWorkflow({
+      workflow: {
+        id: 'default_dispatch_test',
+        name: 'Default dispatch test',
+        steps: [
+          {
+            id: 'brief',
+            owner_coworker_id: 'briefing@workflow@starter',
+            action: 'Write the internal brief.',
+          },
+          {
+            id: 'build',
+            owner_coworker_id: 'builder@workflow@starter',
+            action: 'Build the internal draft.',
+          },
+        ],
+        transitions: [{ from: 'brief', to: 'build' }],
+      },
+      runId: 'run_default_dispatch',
+      threadId: 'thread_default_dispatch',
+    });
+
+    expect(completed.status).toBe('completed');
+    expect(completed.steps.map((step) => step.status)).toEqual([
+      'completed',
+      'completed',
+    ]);
+    const envelopes = listA2AThreadEnvelopes('thread_default_dispatch');
+    expect(envelopes).toHaveLength(2);
+    expect(envelopes.map((entry) => entry.recipient_agent_id)).toEqual([
+      'briefing@workflow@starter',
+      'builder@workflow@starter',
+    ]);
+  });
+
+  test('service entrypoint registers pending approvals for escalated steps', async () => {
+    await initRuntimeDatabase();
+    const { getPendingApproval, clearPendingApproval } = await import(
+      '../src/gateway/pending-approvals.js'
+    );
+    const { saveWorkflowDefinition } = await import('../src/workflow/store.js');
+    const { startWorkflowRun } = await import('../src/workflow/service.js');
+
+    saveWorkflowDefinition({
+      id: 'approval_service_test',
+      name: 'Approval service test',
+      steps: [
+        {
+          id: 'brief',
+          owner_coworker_id: 'briefing@workflow@starter',
+          action: 'Write the internal brief.',
+          stakes_threshold: 'medium',
+        },
+        {
+          id: 'review',
+          owner_coworker_id: 'reviewer@workflow@starter',
+          action: 'Send customer-facing launch copy.',
+          stakes_threshold: 'medium',
+        },
+      ],
+      transitions: [{ from: 'brief', to: 'review' }],
+    });
+
+    const run = await startWorkflowRun({
+      workflowId: 'approval_service_test',
+      runId: 'run_pending_approval',
+      sessionId: 'session-workflow',
+      userId: 'operator',
+    });
+
+    expect(run.status).toBe('paused');
+    expect(run.current_step_id).toBe('review');
+    expect(getPendingApproval('session-workflow')).toMatchObject({
+      approvalId: 'workflow:run_pending_approval:review',
+      userId: 'operator',
+      commandAction: {
+        approveArgs: [
+          'workflow',
+          'approve',
+          'run_pending_approval',
+          'review',
+        ],
+      },
+    });
+
+    await clearPendingApproval('session-workflow');
+  });
+
+  test('returnForRevision rewinds to a named step and preserves prior artifacts', async () => {
+    await initRuntimeDatabase();
+    const { executeWorkflow, returnForRevision } = await import(
+      '../src/workflow/executor.js'
+    );
+
+    const dispatched: string[] = [];
+    const workflow = {
+      id: 'revision_test',
+      name: 'Revision test',
+      steps: [
+        {
+          id: 'brief',
+          owner_coworker_id: 'briefing',
+          action: 'Brief the work.',
+        },
+        {
+          id: 'build',
+          owner_coworker_id: 'builder',
+          action: 'Build the work.',
+        },
+      ],
+      transitions: [{ from: 'brief', to: 'build' }],
+    };
+
+    const completed = await executeWorkflow({
+      workflow,
+      runId: 'run_revision',
+      dispatchStep: ({ step }) => {
+        dispatched.push(step.id);
+        return { artifact: { pass: dispatched.length, stepId: step.id } };
+      },
+    });
+    expect(completed.status).toBe('completed');
+
+    const revised = await returnForRevision(
+      'run_revision',
+      'brief',
+      'Tighten the source citations.',
+      {
+        fromStepId: 'build',
+        actor: 'reviewer',
+        dispatchStep: ({ step }) => {
+          dispatched.push(step.id);
+          return { artifact: { pass: dispatched.length, stepId: step.id } };
+        },
+      },
+    );
+
+    expect(revised.status).toBe('completed');
+    expect(dispatched).toEqual(['brief', 'build', 'brief', 'build']);
+    const brief = revised.steps.find((step) => step.step_id === 'brief');
+    expect(brief?.artifacts).toHaveLength(2);
+    expect(brief?.revisions[0]).toMatchObject({
+      from_step_id: 'build',
+      notes: 'Tighten the source citations.',
+      actor: 'reviewer',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements #461: the autonomous-by-default workflow engine for brief -> build -> review style coworker flows, with humans only involved when the F8-style stakes classifier crosses a step threshold.

## What changed

- Added declarative workflow schema parsing and validation for YAML definitions, including optional `stakes_threshold` per step.
- Added a sequential workflow runner that dispatches steps through A2A envelopes by default, persists workflow definitions/runs as revision assets, and supports return-for-revision rewinds.
- Added workflow stakes classification and pending-approval integration so high-stakes steps pause through the existing approval surface instead of silently stopping.
- Added operator entry points: `workflow list`, `workflow start`, `workflow approve`, `workflow return`, plus admin HTTP APIs.
- Added an admin Workflows console page showing definitions, live run state, active step, owner, pending approval state, and approve/return controls.
- Added three starter templates: brief/build/review, intake/triage/assign, and draft/legal/publish.
- Added developer docs and targeted workflow engine tests.

## Issue #461 acceptance mapping

- Brief -> build -> review demo: covered by `presets/workflows/brief-build-review.yaml` and workflow tests.
- Autonomous by default: steps dispatch through the default A2A path unless the stakes score exceeds the configured threshold.
- F8 stakes escalation: escalated steps create pending approvals and can be resumed through workflow approval commands or admin UI actions.
- Return for revision: `workflow return` and the executor rewind flow preserve prior artifacts and rerun from the target step.
- Admin visualizer: `/admin/workflows` lists definitions/runs and visualizes active workflow state.

## Validation

- `npm run format`
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/workflow-engine.test.ts`
- `npm run lint`
- `npm run check`
- `npm --workspace console run build`
- `git diff --check`

Closes #461.