### PR TITLE
feat: add Google OAuth HTTP auth routes

### DIFF
--- a/docs/content/getting-started/authentication.md
+++ b/docs/content/getting-started/authentication.md
@@ -167,7 +167,7 @@ hybridclaw secret set <NAME> <VALUE>
 hybridclaw secret show <NAME>
 hybridclaw secret unset <NAME>
 hybridclaw secret route list
-hybridclaw secret route add <url-prefix> <secret-name> [header] [prefix|none]
+hybridclaw secret route add <url-prefix> <secret-name|google-oauth> [header] [prefix|none]
 hybridclaw secret route remove <url-prefix> [header]
 ```
 
@@ -177,7 +177,7 @@ hybridclaw secret route remove <url-prefix> [header]
 /secret show <NAME>
 /secret unset <NAME>
 /secret route list
-/secret route add <url-prefix> <secret-name> [header] [prefix|none]
+/secret route add <url-prefix> <secret-name|google-oauth> [header] [prefix|none]
 /secret route remove <url-prefix> [header]
 ```
 
@@ -192,6 +192,117 @@ hybridclaw secret route remove <url-prefix> [header]
   secret should be sent unchanged
 - you can still reference stored secrets explicitly in prompts with
   `<secret:NAME>` when that workflow is more appropriate than a URL auth rule
+
+## Google OAuth For Direct Google APIs
+
+Use the `google-oauth` route provider when an agent should call Google APIs
+through `http_request` without seeing or handling an access token. This is the
+right setup for APIs such as Google Analytics Admin, Google Analytics Data,
+Google Ads, or other `*.googleapis.com` endpoints that are not covered by a
+bundled skill command.
+
+The route provider uses the same encrypted Google OAuth material created by
+`hybridclaw auth login google`. At request time the gateway mints a
+short-lived access token on the host and injects it into matching
+`http_request` calls. The token is only injectable into `googleapis.com` or
+`*.googleapis.com` requests.
+
+### 1. Create A Google OAuth Client
+
+1. Open [Google Cloud Console Credentials](https://console.cloud.google.com/apis/credentials).
+2. Select or create a project dedicated to HybridClaw Google API access.
+3. Open **OAuth consent screen** and finish the required app setup; if the app is in testing mode, add your Google account as a test user.
+4. Open **Library** and enable every API you plan to call from this project; for GA4 reporting, enable Google Analytics Admin API and Google Analytics Data API.
+5. Open **Credentials**.
+6. Click **Create credentials**.
+7. Choose **OAuth client ID**.
+8. Choose application type **Desktop app**.
+9. Copy the generated **Client ID** and **Client secret**.
+
+Use an OAuth desktop client, not an API key. A service account can work for
+some Google APIs, but it is a different setup and is not what
+`google-oauth` routes use.
+
+### 2. Authorize The Required Scopes
+
+Run `auth login google` with the scopes needed by the APIs you will call. For
+GA4 read-only reporting:
+
+```bash
+hybridclaw auth login google \
+  --client-id "<client-id>" \
+  --client-secret "<client-secret>" \
+  --account you@example.com \
+  --scopes "https://www.googleapis.com/auth/analytics.readonly"
+```
+
+If the same Google OAuth credential should also keep powering `gog` or `gws`,
+include the Workspace scopes you need in the same `--scopes` value. Treat
+`--scopes` as the complete grant you want stored for this Google login.
+
+Check the stored account and scopes:
+
+```bash
+hybridclaw auth status google
+```
+
+### 3. Add URL Auth Routes
+
+Add one route per Google API family, using narrow URL prefixes:
+
+```bash
+hybridclaw secret route add https://analyticsadmin.googleapis.com/ google-oauth Authorization Bearer
+hybridclaw secret route add https://analyticsdata.googleapis.com/ google-oauth Authorization Bearer
+```
+
+The equivalent local TUI/web commands are:
+
+```text
+/secret route add https://analyticsadmin.googleapis.com/ google-oauth Authorization Bearer
+/secret route add https://analyticsdata.googleapis.com/ google-oauth Authorization Bearer
+```
+
+List routes:
+
+```bash
+hybridclaw secret route list
+```
+
+Routes are stored in `~/.hybridclaw/config.json` as:
+
+```json
+{
+  "urlPrefix": "https://analyticsdata.googleapis.com/",
+  "header": "Authorization",
+  "prefix": "Bearer",
+  "secret": { "source": "google-oauth" }
+}
+```
+
+### 4. Prompt The Agent
+
+After the routes exist, prompts do not need `bearerSecretName` or
+`Authorization` headers. Ask the agent to use `http_request` and call only the
+Google API URLs:
+
+```text
+Get my GA4 report with http_request.
+
+Use these APIs only:
+- GET https://analyticsadmin.googleapis.com/v1alpha/accountSummaries?pageSize=200
+- POST https://analyticsdata.googleapis.com/v1beta/properties/PROPERTY_ID:runReport
+
+Do not use bash, gcloud, ADC, gog, or gws.
+Do not read or print any token.
+The configured Google OAuth auth routes should attach Authorization.
+```
+
+### Troubleshooting
+
+- `SERVICE_DISABLED`: enable the named Google API in the same Google Cloud project that owns the OAuth client, then wait a few minutes and retry.
+- `PERMISSION_DENIED` for a GA4 property: grant the authorized Google account Viewer or Analyst access to that GA4 property.
+- `insufficient authentication scopes`: rerun `hybridclaw auth login google` with all required scopes.
+- `401 Unauthorized`: rerun `hybridclaw auth login google`; the stored refresh token may have been revoked or the OAuth client may have changed.
 
 ## Where Credentials Live
 

--- a/docs/content/guides/skills/integrations.md
+++ b/docs/content/guides/skills/integrations.md
@@ -177,6 +177,11 @@ hybridclaw auth status google
 Use **OAuth client ID**, not **API key** or **Service account**, for normal
 personal Gmail, Calendar, Drive, Docs, and Sheets access.
 
+For Google APIs that are not exposed by `gog` commands, such as Google
+Analytics Admin, Google Analytics Data, or Google Ads, configure direct
+`http_request` auth routes with the same OAuth login. See
+[Google OAuth For Direct Google APIs](../../getting-started/authentication.md#google-oauth-for-direct-google-apis).
+
 HybridClaw stores the OAuth client secret and refresh token in encrypted
 runtime secrets. At run time it mints a short-lived access token on the host
 and injects only Google Workspace CLI access-token environment variables plus

--- a/docs/content/reference/commands.md
+++ b/docs/content/reference/commands.md
@@ -257,7 +257,7 @@ hybridclaw secret set <name> <value>
 hybridclaw secret show <name>
 hybridclaw secret unset <name>
 hybridclaw secret route list
-hybridclaw secret route add <url-prefix> <secret-name> [header] [prefix|none]
+hybridclaw secret route add <url-prefix> <secret-name|google-oauth> [header] [prefix|none]
 hybridclaw secret route remove <url-prefix> [header]
 ```
 
@@ -267,7 +267,7 @@ hybridclaw secret route remove <url-prefix> [header]
 /secret show <name>
 /secret unset <name>
 /secret route list
-/secret route add <url-prefix> <secret-name> [header] [prefix|none]
+/secret route add <url-prefix> <secret-name|google-oauth> [header] [prefix|none]
 /secret route remove <url-prefix> [header]
 ```
 
@@ -282,6 +282,9 @@ hybridclaw secret route remove <url-prefix> [header]
 - `/secret route add` manages `tools.httpRequest.authRules[]`, which lets the
   gateway inject the real auth header for matching `http_request` tool calls
 - use `prefix` for `Bearer <secret>` or `none` for raw header injection
+- use `google-oauth` as the secret name for direct Google API routes after
+  `hybridclaw auth login google`; see
+  [Google OAuth For Direct Google APIs](../getting-started/authentication.md#google-oauth-for-direct-google-apis)
 
 ## Channels
 

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -268,7 +268,7 @@ hybridclaw secret set <NAME> <VALUE>
 hybridclaw secret show <NAME>
 hybridclaw secret unset <NAME>
 hybridclaw secret route list
-hybridclaw secret route add <url-prefix> <secret-name> [header] [prefix|none]
+hybridclaw secret route add <url-prefix> <secret-name|google-oauth> [header] [prefix|none]
 hybridclaw secret route remove <url-prefix> [header]
 ```
 
@@ -278,7 +278,7 @@ hybridclaw secret route remove <url-prefix> [header]
 /secret show <NAME>
 /secret unset <NAME>
 /secret route list
-/secret route add <url-prefix> <secret-name> [header] [prefix|none]
+/secret route add <url-prefix> <secret-name|google-oauth> [header] [prefix|none]
 /secret route remove <url-prefix> [header]
 ```
 
@@ -287,6 +287,7 @@ hybridclaw secret route remove <url-prefix> [header]
   store
 - `/secret route ...` is a convenience surface for editing
   `tools.httpRequest.authRules[]` without hand-editing `config.json`
+- `secret: { "source": "google-oauth" }` routes mint and inject the Google OAuth access token from `hybridclaw auth login google` for matching `*.googleapis.com` requests
 
 Codex OAuth sessions are stored separately in `~/.hybridclaw/codex-auth.json`.
 Trust-model acceptance is persisted in `config.json` under `security.*` and is

--- a/docs/content/reference/faq.md
+++ b/docs/content/reference/faq.md
@@ -30,8 +30,11 @@ compatibility import of supported secrets.
 
 Store the key once with `/secret set <NAME> <VALUE>`, then either:
 
-- configure a URL auth rule with `/secret route add <url-prefix> <secret-name> [header] [prefix|none]`
+- configure a URL auth rule with `/secret route add <url-prefix> <secret-name|google-oauth> [header] [prefix|none]`
 - reference it explicitly in a prompt with `<secret:NAME>`
+
+For direct Google APIs, run `hybridclaw auth login google` and use
+`google-oauth` in the route instead of storing a static token.
 
 HybridClaw routes the actual request through the gateway-side `http_request`
 path, injects the real header at send time, and persists redacted tool-call

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -743,7 +743,7 @@ Commands:
   hybridclaw secret show <name>
   hybridclaw secret unset <name>
   hybridclaw secret route list
-  hybridclaw secret route add <url-prefix> <secret-name> [header] [prefix|none]
+  hybridclaw secret route add <url-prefix> <secret-name|google-oauth> [header] [prefix|none]
   hybridclaw secret route remove <url-prefix> [header]
 
 Examples:
@@ -752,12 +752,13 @@ Examples:
   hybridclaw secret show SF_FULL_USERNAME
   hybridclaw secret unset SF_FULL_USERNAME
   hybridclaw secret route add https://staging.hybridai.one/api/v1/ STAGING_HYBRIDAI_API_KEY X-API-Key none
+  hybridclaw secret route add https://analyticsdata.googleapis.com/ google-oauth Authorization Bearer
 
 Notes:
   - \`secret\` reads and writes the encrypted store at ${runtimeSecretsPath()}.
   - Secret names must use uppercase letters, digits, and underscores.
   - \`show\` reports whether a secret is stored; it never outputs decrypted values. Secrets are only resolved gateway-side via \`<secret:NAME>\` placeholders or auth rules.
-  - \`route add\` writes \`tools.httpRequest.authRules[]\` in ${runtimeConfigPath()} with a store-backed secret ref.
+  - \`route add\` writes \`tools.httpRequest.authRules[]\` in ${runtimeConfigPath()} with a store-backed secret ref or the Google OAuth runtime token provider.
   - Use \`prefix\` for \`Bearer <secret>\` or \`none\` for raw header injection.`);
 }
 

--- a/src/cli/secret-command.ts
+++ b/src/cli/secret-command.ts
@@ -1,6 +1,11 @@
 import {
   getRuntimeConfig,
+  isGoogleApisUrlPrefix,
+  isGoogleOAuthSecretRef,
+  isGoogleOAuthSpecifier,
+  makeGoogleOAuthSecretRef,
   type RuntimeHttpRequestAuthRule,
+  type RuntimeHttpRequestAuthRuleSecret,
   runtimeConfigPath,
   updateRuntimeConfig,
 } from '../config/runtime-config.js';
@@ -57,6 +62,25 @@ function normalizeSecretRoutePrefix(raw: string | undefined): string {
   return normalized;
 }
 
+function normalizeSecretRouteSecret(
+  raw: string,
+): RuntimeHttpRequestAuthRuleSecret {
+  const value = String(raw || '').trim();
+  if (isGoogleOAuthSpecifier(value)) {
+    return makeGoogleOAuthSecretRef();
+  }
+  assertSecretName(value);
+  return { source: 'store', id: value };
+}
+
+function formatRouteSecretLabel(
+  secret: RuntimeHttpRequestAuthRuleSecret,
+): string {
+  if (typeof secret === 'string') return secret;
+  if (isGoogleOAuthSecretRef(secret)) return 'google-oauth';
+  return `${secret.source}:${secret.id}`;
+}
+
 function formatHttpRequestAuthRule(
   rule: RuntimeHttpRequestAuthRule,
   index: number,
@@ -64,9 +88,11 @@ function formatHttpRequestAuthRule(
   const parsedSecret =
     typeof rule.secret === 'string'
       ? rule.secret
-      : typeof rule.secret.id === 'string'
-        ? `${rule.secret.source}:${rule.secret.id}`
-        : '<invalid>';
+      : isGoogleOAuthSecretRef(rule.secret)
+        ? 'google-oauth'
+        : typeof rule.secret.id === 'string'
+          ? `${rule.secret.source}:${rule.secret.id}`
+          : '<invalid>';
   const prefix = rule.prefix ? ` ${rule.prefix}` : '';
   return `${index + 1}. ${rule.urlPrefix} -> ${rule.header}:${prefix} ${parsedSecret}`.trim();
 }
@@ -176,11 +202,16 @@ export async function handleSecretCommand(args: string[]): Promise<void> {
       if (!rawPrefix || !secretName) {
         printSecretUsage();
         throw new Error(
-          'Usage: `hybridclaw secret route add <url-prefix> <secret-name> [header] [prefix|none]`',
+          'Usage: `hybridclaw secret route add <url-prefix> <secret-name|google-oauth> [header] [prefix|none]`',
         );
       }
-      assertSecretName(secretName);
+      const secret = normalizeSecretRouteSecret(secretName);
       const urlPrefix = normalizeUrlPrefix(rawPrefix);
+      if (isGoogleOAuthSecretRef(secret) && !isGoogleApisUrlPrefix(urlPrefix)) {
+        throw new Error(
+          '`google-oauth` routes can only target googleapis.com or *.googleapis.com URL prefixes.',
+        );
+      }
       const header = normalizeSecretRouteHeader(rawHeader);
       const prefix = normalizeSecretRoutePrefix(rawAuthPrefix);
       updateRuntimeConfig(
@@ -189,7 +220,7 @@ export async function handleSecretCommand(args: string[]): Promise<void> {
             urlPrefix,
             header,
             prefix,
-            secret: { source: 'store', id: secretName },
+            secret,
           };
           draft.tools.httpRequest.authRules =
             draft.tools.httpRequest.authRules.filter(
@@ -210,7 +241,7 @@ export async function handleSecretCommand(args: string[]): Promise<void> {
         ? `${header}: ${prefix} <secret>`
         : `${header}: <secret>`;
       console.log(
-        `Added secret route for \`${urlPrefix}\` using \`${secretName}\` as \`${authLabel}\`.`,
+        `Added secret route for \`${urlPrefix}\` using \`${formatRouteSecretLabel(secret)}\` as \`${authLabel}\`.`,
       );
       console.log(`Updated runtime config at ${runtimeConfigPath()}.`);
       return;
@@ -262,7 +293,7 @@ export async function handleSecretCommand(args: string[]): Promise<void> {
 
     printSecretUsage();
     throw new Error(
-      'Usage: `hybridclaw secret route list`, `hybridclaw secret route add <url-prefix> <secret-name> [header] [prefix|none]`, or `hybridclaw secret route remove <url-prefix> [header]`',
+      'Usage: `hybridclaw secret route list`, `hybridclaw secret route add <url-prefix> <secret-name|google-oauth> [header] [prefix|none]`, or `hybridclaw secret route remove <url-prefix> [header]`',
     );
   }
 

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -1447,9 +1447,10 @@ function buildSlashCommandCatalogDefinitions(
         },
         {
           id: 'secret.route.add',
-          label: '/secret route add <url-prefix> <secret-name>',
+          label: '/secret route add <url-prefix> <secret-name|google-oauth>',
           insertText: '/secret route add ',
-          description: 'Auto-attach a stored secret to matching HTTP requests',
+          description:
+            'Auto-attach a stored secret or Google OAuth token to matching HTTP requests',
         },
       ],
       options: [

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -586,15 +586,56 @@ export interface RuntimePluginsConfig {
   list: RuntimePluginConfigEntry[];
 }
 
+export interface RuntimeHttpRequestGoogleOAuthSecretRef {
+  source: 'google-oauth';
+}
+
+export type RuntimeHttpRequestAuthRuleSecret =
+  | SecretInput
+  | RuntimeHttpRequestGoogleOAuthSecretRef;
+
 export interface RuntimeHttpRequestAuthRule {
   urlPrefix: string;
   header: string;
   prefix: string;
-  secret: SecretInput;
+  secret: RuntimeHttpRequestAuthRuleSecret;
 }
 
 export interface RuntimeHttpRequestToolConfig {
   authRules: RuntimeHttpRequestAuthRule[];
+}
+
+export function makeGoogleOAuthSecretRef(): RuntimeHttpRequestGoogleOAuthSecretRef {
+  return { source: 'google-oauth' };
+}
+
+export function isGoogleOAuthSpecifier(value: string): boolean {
+  const normalized = String(value || '')
+    .trim()
+    .toLowerCase();
+  return (
+    normalized === 'google-oauth' || normalized === 'google-oauth:workspace'
+  );
+}
+
+export function isGoogleOAuthSecretRef(
+  value: unknown,
+): value is RuntimeHttpRequestGoogleOAuthSecretRef {
+  return (
+    isRecord(value) &&
+    value.source === 'google-oauth' &&
+    (value.id === undefined || value.id === 'workspace')
+  );
+}
+
+export function isGoogleApisUrlPrefix(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    const host = parsed.hostname.trim().toLowerCase();
+    return host === 'googleapis.com' || host.endsWith('.googleapis.com');
+  } catch {
+    return false;
+  }
 }
 
 export interface RuntimeSkillAutonomyRule {
@@ -4203,14 +4244,18 @@ function normalizeHttpHeaderName(
 function normalizeHttpRequestAuthRuleSecret(
   value: unknown,
   path: string,
-): SecretInput {
+): RuntimeHttpRequestAuthRuleSecret {
+  if (isGoogleOAuthSecretRef(value)) {
+    return makeGoogleOAuthSecretRef();
+  }
+
   const parsed = parseSecretInput(value);
   if (parsed.kind === 'invalid') {
     throw new Error(`${path} ${parsed.reason}`);
   }
   if (parsed.kind === 'plain') {
     throw new Error(
-      `${path} must use an env/store secret reference such as \`{ "source": "store", "id": "SECRET_NAME" }\` or \`\${ENV_VAR}\``,
+      `${path} must use an env/store secret reference such as \`{ "source": "store", "id": "SECRET_NAME" }\`, \`\${ENV_VAR}\`, or \`{ "source": "google-oauth" }\``,
     );
   }
   return cloneConfig(parsed.ref);

--- a/src/gateway/coworker-liveness.ts
+++ b/src/gateway/coworker-liveness.ts
@@ -155,7 +155,7 @@ function buildRecentSkillRunCheck(
     return {
       ok: false,
       code: 'no_skill_runs_observed',
-      detail: 'no skill execution observations found for this coworker',
+      detail: 'no skill execution observations found for this agent',
       observedAt: null,
       skillName: null,
       outcome: null,
@@ -496,7 +496,7 @@ export function formatCoworkerLivenessPage(
   probe: GatewayCoworkerLivenessProbe,
 ): string {
   return [
-    `Coworker liveness ${probe.state.toUpperCase()}: ${probe.agentId}`,
+    `Agent liveness ${probe.state.toUpperCase()}: ${probe.agentId}`,
     `Reasons: ${probe.reasonCodes.join(', ')}`,
     `Process: ${probe.process.code} - ${probe.process.detail}`,
     `Skill: ${probe.recentSkillRun.code} - ${probe.recentSkillRun.detail}`,

--- a/src/gateway/gateway-http-proxy.ts
+++ b/src/gateway/gateway-http-proxy.ts
@@ -10,8 +10,15 @@ import { lookup } from 'node:dns/promises';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import net from 'node:net';
 
-import type { RuntimeConfig } from '../config/runtime-config.js';
-import { getRuntimeConfig } from '../config/runtime-config.js';
+import { resolveGoogleWorkspaceRuntimeEnv } from '../auth/google-auth.js';
+import type {
+  RuntimeConfig,
+  RuntimeHttpRequestGoogleOAuthSecretRef,
+} from '../config/runtime-config.js';
+import {
+  getRuntimeConfig,
+  isGoogleOAuthSecretRef,
+} from '../config/runtime-config.js';
 import { GatewayRequestError } from '../errors/gateway-request-error.js';
 import { logger } from '../logger.js';
 import {
@@ -50,6 +57,8 @@ const HTTP_REQUEST_MAX_RESPONSE_BYTES = 1_000_000;
 const HTTP_REQUEST_SECRET_PLACEHOLDER_RE = /<secret:([A-Z][A-Z0-9_]{0,127})>/g;
 const REDIRECT_RESPONSE_STATUS_MIN = 300;
 const REDIRECT_RESPONSE_STATUS_MAX = 399;
+const GOOGLE_WORKSPACE_CLI_TOKEN_SECRET = 'GOOGLE_WORKSPACE_CLI_TOKEN';
+const GOG_ACCESS_TOKEN_SECRET = 'GOG_ACCESS_TOKEN';
 
 type CaptureFieldRule = { jsonPath: string; secretName: string };
 
@@ -295,12 +304,88 @@ function withAuthPrefix(secret: string, prefix: string): string {
   return prefix ? `${prefix} ${secret}` : secret;
 }
 
-function resolveStoredSecretOrThrow(
+function isGoogleWorkspaceRuntimeTokenName(secretName: string): boolean {
+  return (
+    secretName === GOOGLE_WORKSPACE_CLI_TOKEN_SECRET ||
+    secretName === GOG_ACCESS_TOKEN_SECRET
+  );
+}
+
+function isGoogleApisHost(host?: string): boolean {
+  const normalized = normalizeSecretString(host).toLowerCase();
+  return (
+    normalized === 'googleapis.com' || normalized.endsWith('.googleapis.com')
+  );
+}
+
+function isGoogleOAuthHttpAuthRuleSecret(
+  value: unknown,
+): value is RuntimeHttpRequestGoogleOAuthSecretRef {
+  return isGoogleOAuthSecretRef(value);
+}
+
+async function resolveGoogleOAuthTokenOrThrow(
   secretName: string,
   context: SecretResolveContext,
-): string {
+): Promise<string> {
+  if (!isGoogleApisHost(context.host)) {
+    throw new GatewayRequestError(
+      403,
+      `${secretName} can only be injected into googleapis.com requests.`,
+    );
+  }
+
+  assertSecretResolveAllowed({
+    sessionId: context.sessionId,
+    agentId: context.agentId,
+    skillName: context.skillName,
+    secretSource: 'env',
+    secretId: secretName,
+    sinkKind: 'http',
+    host: context.host,
+    selector: context.selector,
+  });
+
+  const runtimeEnv = await resolveGoogleWorkspaceRuntimeEnv();
+  const token = normalizeSecretString(runtimeEnv[secretName]);
+  if (!token) {
+    throw new GatewayRequestError(
+      400,
+      `${secretName} is not available. Run \`hybridclaw auth login google\` and start a fresh agent runtime.`,
+    );
+  }
+
+  const auditContext = {
+    sessionId: context.sessionId,
+    skillName: context.skillName,
+    secretSource: 'env' as const,
+    secretId: secretName,
+    sinkKind: 'http' as const,
+    host: context.host,
+    selector: context.selector,
+  };
+  recordSecretResolved(auditContext);
+  recordSecretUnsafeEscaped({
+    ...auditContext,
+    reason: `inject ${secretName} into http sink`,
+  });
+  rememberResolvedSecretForLeakScan({
+    sessionId: normalizeSecretSessionId(context.sessionId),
+    secretId: secretName,
+    value: token,
+  });
+  return token;
+}
+
+async function resolveHttpSecretOrThrow(
+  secretName: string,
+  context: SecretResolveContext,
+): Promise<string> {
   if (!isRuntimeSecretName(secretName)) {
     throw new GatewayRequestError(400, `Invalid secret name: ${secretName}`);
+  }
+  if (isGoogleWorkspaceRuntimeTokenName(secretName)) {
+    return await resolveGoogleOAuthTokenOrThrow(secretName, context);
   }
   return resolveStoredSecretForInjection({
     secretName,
@@ -313,39 +398,48 @@ function resolveStoredSecretOrThrow(
   });
 }
 
-function replaceSecretPlaceholdersInString(
+async function replaceSecretPlaceholdersInString(
   value: string,
   context: SecretResolveContext,
-): string {
-  return value.replace(
-    HTTP_REQUEST_SECRET_PLACEHOLDER_RE,
-    (_match, secretName) =>
-      resolveStoredSecretOrThrow(secretName, {
-        ...context,
-        selector: context.selector || '<secret-placeholder>',
-      }),
-  );
+): Promise<string> {
+  let next = '';
+  let lastIndex = 0;
+  for (const match of value.matchAll(HTTP_REQUEST_SECRET_PLACEHOLDER_RE)) {
+    const matchIndex = match.index ?? 0;
+    next += value.slice(lastIndex, matchIndex);
+    next += await resolveHttpSecretOrThrow(match[1] || '', {
+      ...context,
+      selector: context.selector || '<secret-placeholder>',
+    });
+    lastIndex = matchIndex + match[0].length;
+  }
+  next += value.slice(lastIndex);
+  return next;
 }
 
-function replaceSecretPlaceholders(
+async function replaceSecretPlaceholders(
   value: unknown,
   context: SecretResolveContext,
-): unknown {
+): Promise<unknown> {
   if (typeof value === 'string') {
-    return replaceSecretPlaceholdersInString(value, context);
+    return await replaceSecretPlaceholdersInString(value, context);
   }
   if (Array.isArray(value)) {
-    return value.map((entry) => replaceSecretPlaceholders(entry, context));
+    return await Promise.all(
+      value.map((entry) => replaceSecretPlaceholders(entry, context)),
+    );
   }
   if (value && typeof value === 'object') {
     return Object.fromEntries(
-      Object.entries(value).map(([key, entry]) => [
-        key,
-        replaceSecretPlaceholders(entry, {
-          ...context,
-          selector: context.selector || `json.${key}`,
-        }),
-      ]),
+      await Promise.all(
+        Object.entries(value).map(async ([key, entry]) => [
+          key,
+          await replaceSecretPlaceholders(entry, {
+            ...context,
+            selector: context.selector || `json.${key}`,
+          }),
+        ]),
+      ),
     );
   }
   return value;
@@ -484,11 +578,11 @@ function captureOAuthResponse(
   return captured;
 }
 
-function resolveHttpRequestRuleAssignments(
+async function resolveHttpRequestRuleAssignments(
   url: string,
   config: RuntimeConfig,
   context: SecretResolveContext,
-): Array<{ header: string; value: string }> {
+): Promise<Array<{ header: string; value: string }>> {
   const matching = config.tools.httpRequest.authRules
     .map((rule, index) => ({ rule, index }))
     .filter(({ rule }) => url.startsWith(rule.urlPrefix))
@@ -502,7 +596,7 @@ function resolveHttpRequestRuleAssignments(
   for (const { rule, index } of matching) {
     const key = rule.header.toLowerCase();
     if (assignments.has(key)) continue;
-    const secret = resolveHttpRuleSecret(
+    const secret = await resolveHttpRuleSecret(
       rule.secret,
       {
         ...context,
@@ -517,13 +611,26 @@ function resolveHttpRequestRuleAssignments(
   return Array.from(assignments.values());
 }
 
-function resolveHttpRuleSecret(
+async function resolveHttpRuleSecret(
   value: unknown,
   context: SecretResolveContext,
   path: string,
   headerName: string,
   prefix: string,
-): { header: string; value: string } {
+): Promise<{ header: string; value: string }> {
+  if (isGoogleOAuthHttpAuthRuleSecret(value)) {
+    return {
+      header: headerName,
+      value: withAuthPrefix(
+        await resolveGoogleOAuthTokenOrThrow(
+          GOOGLE_WORKSPACE_CLI_TOKEN_SECRET,
+          context,
+        ),
+        prefix,
+      ),
+    };
+  }
+
   const handle = resolveSecretHandleInput(value, {
     path,
     required: true,
@@ -617,7 +724,7 @@ export async function handleApiHttpRequest(
       ? []
       : (normalizeCaptureResponseFields(body.captureResponseFields) ?? []);
   const rawUrl = replacePlaceholders
-    ? replaceSecretPlaceholdersInString(String(body.url || ''), {
+    ? await replaceSecretPlaceholdersInString(String(body.url || ''), {
         ...baseSecretContext,
         selector: 'url',
       })
@@ -636,7 +743,7 @@ export async function handleApiHttpRequest(
   const config = getRuntimeConfig();
 
   const headers = normalizeHttpRequestHeaders(body.headers);
-  for (const assignment of resolveHttpRequestRuleAssignments(
+  for (const assignment of await resolveHttpRequestRuleAssignments(
     url.toString(),
     config,
     secretContext,
@@ -654,7 +761,7 @@ export async function handleApiHttpRequest(
       headers,
       'Authorization',
       withAuthPrefix(
-        resolveStoredSecretOrThrow(bearerSecretName, {
+        await resolveHttpSecretOrThrow(bearerSecretName, {
           ...secretContext,
           selector: 'Authorization',
         }),
@@ -671,7 +778,7 @@ export async function handleApiHttpRequest(
       headers,
       secretHeader.name,
       withAuthPrefix(
-        resolveStoredSecretOrThrow(secretHeader.secretName, {
+        await resolveHttpSecretOrThrow(secretHeader.secretName, {
           ...secretContext,
           selector: secretHeader.name,
         }),
@@ -682,7 +789,7 @@ export async function handleApiHttpRequest(
 
   if (replacePlaceholders) {
     for (const [key, value] of Object.entries(headers)) {
-      headers[key] = replaceSecretPlaceholdersInString(value, {
+      headers[key] = await replaceSecretPlaceholdersInString(value, {
         ...secretContext,
         selector: key,
       });
@@ -692,7 +799,7 @@ export async function handleApiHttpRequest(
   let payloadBody: string | undefined;
   if (body.json !== undefined) {
     const jsonValue = replacePlaceholders
-      ? replaceSecretPlaceholders(body.json, {
+      ? await replaceSecretPlaceholders(body.json, {
           ...secretContext,
           selector: 'json',
         })
@@ -705,7 +812,7 @@ export async function handleApiHttpRequest(
     }
   } else if (typeof body.body === 'string') {
     payloadBody = replacePlaceholders
-      ? replaceSecretPlaceholdersInString(body.body, {
+      ? await replaceSecretPlaceholdersInString(body.body, {
           ...secretContext,
           selector: 'body',
         })

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -125,8 +125,13 @@ import {
 } from '../config/config.js';
 import {
   getRuntimeConfig,
+  isGoogleApisUrlPrefix,
+  isGoogleOAuthSecretRef,
+  isGoogleOAuthSpecifier,
+  makeGoogleOAuthSecretRef,
   type RuntimeConfig,
   type RuntimeHttpRequestAuthRule,
+  type RuntimeHttpRequestAuthRuleSecret,
   reloadRuntimeConfig,
   resolveDefaultAgentId,
   runtimeConfigPath,
@@ -3409,6 +3414,35 @@ function normalizeSecretRoutePrefix(raw: string | undefined): string {
   return normalized;
 }
 
+function normalizeSecretRouteSecret(
+  raw: string,
+): RuntimeHttpRequestAuthRuleSecret {
+  const value = String(raw || '').trim();
+  if (isGoogleOAuthSpecifier(value)) {
+    return makeGoogleOAuthSecretRef();
+  }
+  return { source: 'store', id: value };
+}
+
+function isStoreSecretRouteSecret(
+  secret: RuntimeHttpRequestAuthRuleSecret,
+): secret is { source: 'store'; id: string } {
+  return (
+    typeof secret === 'object' &&
+    secret !== null &&
+    !Array.isArray(secret) &&
+    secret.source === 'store'
+  );
+}
+
+function formatRouteSecretLabel(
+  secret: RuntimeHttpRequestAuthRuleSecret,
+): string {
+  if (typeof secret === 'string') return secret;
+  if (isGoogleOAuthSecretRef(secret)) return 'google-oauth';
+  return `${secret.source}:${secret.id}`;
+}
+
 function isLoopbackHostname(hostname: string): boolean {
   const normalized = String(hostname || '')
     .trim()
@@ -3469,9 +3503,11 @@ function formatHttpRequestAuthRule(
   const parsedSecret =
     typeof rule.secret === 'string'
       ? rule.secret
-      : typeof rule.secret.id === 'string'
-        ? `${rule.secret.source}:${rule.secret.id}`
-        : '<invalid>';
+      : isGoogleOAuthSecretRef(rule.secret)
+        ? 'google-oauth'
+        : typeof rule.secret.id === 'string'
+          ? `${rule.secret.source}:${rule.secret.id}`
+          : '<invalid>';
   const prefix = rule.prefix ? ` ${rule.prefix}` : '';
   return `${index + 1}. ${rule.urlPrefix} -> ${rule.header}:${prefix} ${parsedSecret}`.trim();
 }
@@ -8997,23 +9033,39 @@ export async function handleGatewayCommand(
             if (!rawPrefix || !secretName) {
               return badCommand(
                 'Usage',
-                'Usage: `secret route add <url-prefix> <secret-name> [header] [prefix|none]`',
+                'Usage: `secret route add <url-prefix> <secret-name|google-oauth> [header] [prefix|none]`',
               );
             }
-            if (!isRuntimeSecretName(secretName)) {
+            const secret = normalizeSecretRouteSecret(secretName);
+            if (
+              isStoreSecretRouteSecret(secret) &&
+              !isRuntimeSecretName(secret.id)
+            ) {
               return badCommand(
                 'Invalid Secret Name',
                 'Secret names must use uppercase letters, digits, and underscores only.',
               );
             }
-            if (isReservedNonSecretRuntimeName(secretName)) {
+            if (
+              isStoreSecretRouteSecret(secret) &&
+              isReservedNonSecretRuntimeName(secret.id)
+            ) {
               return badCommand(
                 'Reserved Non-Secret Name',
-                `\`${secretName}\` is a normal runtime config key and cannot be used as an encrypted secret route target.`,
+                `\`${secret.id}\` is a normal runtime config key and cannot be used as an encrypted secret route target.`,
               );
             }
             try {
               const urlPrefix = normalizeUrlPrefix(rawPrefix);
+              if (
+                isGoogleOAuthSecretRef(secret) &&
+                !isGoogleApisUrlPrefix(urlPrefix)
+              ) {
+                return badCommand(
+                  'Invalid Google OAuth Route',
+                  '`google-oauth` routes can only target googleapis.com or *.googleapis.com URL prefixes.',
+                );
+              }
               const header = normalizeSecretRouteHeader(rawHeader);
               const prefix = normalizeSecretRoutePrefix(rawAuthPrefix);
               updateRuntimeConfig((draft) => {
@@ -9021,7 +9073,7 @@ export async function handleGatewayCommand(
                   urlPrefix,
                   header,
                   prefix,
-                  secret: { source: 'store', id: secretName },
+                  secret,
                 };
                 draft.tools.httpRequest.authRules =
                   draft.tools.httpRequest.authRules.filter(
@@ -9037,7 +9089,7 @@ export async function handleGatewayCommand(
                 ? `${header}: ${prefix} <secret>`
                 : `${header}: <secret>`;
               return plainCommand(
-                `Added secret route for \`${urlPrefix}\` using \`${secretName}\` as \`${authLabel}\`.`,
+                `Added secret route for \`${urlPrefix}\` using \`${formatRouteSecretLabel(secret)}\` as \`${authLabel}\`.`,
               );
             } catch (error) {
               return badCommand(
@@ -9092,7 +9144,7 @@ export async function handleGatewayCommand(
 
           return badCommand(
             'Usage',
-            'Usage: `secret route list`, `secret route add <url-prefix> <secret-name> [header] [prefix|none]`, or `secret route remove <url-prefix> [header]`',
+            'Usage: `secret route list`, `secret route add <url-prefix> <secret-name|google-oauth> [header] [prefix|none]`, or `secret route remove <url-prefix> [header]`',
           );
         }
 
@@ -9999,7 +10051,7 @@ export async function handleGatewayCommand(
           `⚙️ Runtime: ${status.sandbox?.mode || 'container'} · RAG: ${session.enable_rag ? 'on' : 'off'} · Ralph: ${formatRalphIterations(resolveSessionRalphIterations(session))} · Show: ${showMode}`,
           `🤖 Full-auto: ${fullAutoLabel}`,
           `👥 Activation: ${resolveActivationModeLabel()} · 🪢 Queue: ${queueLabel} · 📬 Proactive queued: ${proactiveQueued}`,
-          `🩺 Coworkers: ${coworkerHealthLabel}`,
+          `🩺 Agents: ${coworkerHealthLabel}`,
           ...coworkerHealthLines,
         ];
         return infoCommand('Status', lines.join('\n'));

--- a/src/scheduler/heartbeat.ts
+++ b/src/scheduler/heartbeat.ts
@@ -120,14 +120,14 @@ function startCoworkerLivenessPaging(
 
   livenessPagingTimer = setInterval(async () => {
     if (livenessPagingRunning) {
-      logger.debug('Coworker liveness paging skipped — previous still running');
+      logger.debug('Agent liveness paging skipped — previous still running');
       return;
     }
     livenessPagingRunning = true;
     try {
       await pageRedCoworkerLivenessTransitions(onMessage);
     } catch (error) {
-      logger.warn({ error }, 'Coworker liveness paging failed');
+      logger.warn({ error }, 'Agent liveness paging failed');
     } finally {
       livenessPagingRunning = false;
     }
@@ -148,7 +148,7 @@ export function startHeartbeat(
 
   if (!HEARTBEAT_ENABLED) {
     logger.info(
-      'Heartbeat disabled via HEARTBEAT_ENABLED=false; coworker liveness paging remains active',
+      'Heartbeat disabled via HEARTBEAT_ENABLED=false; agent liveness paging remains active',
     );
     return;
   }
@@ -499,11 +499,11 @@ export function stopHeartbeat(): void {
   if (livenessPagingTimer) {
     clearInterval(livenessPagingTimer);
     livenessPagingTimer = null;
-    logger.info('Coworker liveness paging stopped');
+    logger.info('Agent liveness paging stopped');
   }
   heartbeatRunning = false;
   livenessPagingRunning = false;
-  // In-process edge state is intentionally cleared so a still-red coworker
+  // In-process edge state is intentionally cleared so a still-red agent
   // pages again after gateway restart or scheduler restart.
   lastPagedLivenessStateByAgent.clear();
 }

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -1382,6 +1382,7 @@ function pickOceanActivityVerb(): string {
 interface SpinnerToolEntry {
   name: string;
   preview: string;
+  count: number;
 }
 
 export function formatTuiToolActivityLine(params: {
@@ -1389,6 +1390,7 @@ export function formatTuiToolActivityLine(params: {
   preview?: string;
   columns: number;
   frameIndex?: number;
+  count?: number;
 }): string {
   const frameIndex = Math.max(0, params.frameIndex || 0);
   const frame =
@@ -1396,7 +1398,9 @@ export function formatTuiToolActivityLine(params: {
   const previewText = params.preview
     ? ` ${MUTED}${params.preview}${RESET}`
     : '';
-  const body = `  ${frame.emojiColor}${JELLYFISH}${RESET} ${TEAL}${params.toolName}${RESET}${previewText}`;
+  const count = Math.max(1, params.count || 1);
+  const countText = count > 1 ? ` ${MUTED}x${count}${RESET}` : '';
+  const body = `  ${frame.emojiColor}${JELLYFISH}${RESET} ${TEAL}${params.toolName}${RESET}${countText}${previewText}`;
   const safeColumns = Math.max(1, params.columns - 1);
   return truncateAnsiTuiEnd(body, safeColumns);
 }
@@ -1404,7 +1408,7 @@ export function formatTuiToolActivityLine(params: {
 function spinner(): {
   stop: () => void;
   addTool: (toolName: string, preview?: string) => void;
-  finishTool: (toolName: string) => void;
+  finishTool: (toolName: string, preview?: string) => void;
   addVisibleTextDelta: (delta: string) => void;
   flushVisibleText: () => void;
   clearVisibleText: () => void;
@@ -1446,6 +1450,7 @@ function spinner(): {
       preview: entry.preview,
       columns: terminalColumns(),
       frameIndex: frameIdx,
+      count: entry.count,
     });
   };
   const repaintToolLine = (frameIdx: number) => {
@@ -1558,22 +1563,44 @@ function spinner(): {
       if (hasVisibleText) return;
       clearThinkingPreview();
       clearLine();
+      const normalizedPreview = preview || '';
+      let existingEntry: SpinnerToolEntry | undefined;
+      for (let idx = toolEntries.length - 1; idx >= 0; idx -= 1) {
+        const entry = toolEntries[idx];
+        if (entry.name !== toolName || entry.preview !== normalizedPreview) {
+          continue;
+        }
+        existingEntry = entry;
+        break;
+      }
+      if (existingEntry) {
+        existingEntry.count += 1;
+        repaintToolLine(i);
+        return;
+      }
       const entry: SpinnerToolEntry = {
         name: toolName,
-        preview: preview || '',
+        preview: normalizedPreview,
+        count: 1,
       };
       toolEntries.push(entry);
       repaintToolLine(i);
     },
-    finishTool: (toolName: string) => {
+    finishTool: (toolName: string, preview?: string) => {
       if (!showTools) return;
       if (hasVisibleText) return;
+      const normalizedPreview = preview || '';
       for (let idx = toolEntries.length - 1; idx >= 0; idx -= 1) {
         const entry = toolEntries[idx];
-        if (entry && entry.name === toolName) {
-          toolEntries.splice(idx, 1);
-          break;
+        if (entry.name !== toolName || entry.preview !== normalizedPreview) {
+          continue;
         }
+        if (entry.count > 1) {
+          entry.count -= 1;
+        } else {
+          toolEntries.splice(idx, 1);
+        }
+        break;
       }
       if (toolEntries.length > 0) {
         repaintToolLine(i);
@@ -2341,6 +2368,10 @@ async function processMessage(
     const request = buildGatewayChatRequest(content, queuedMedia);
     const streamState = createTuiThinkingStreamState();
     const streamedToolNames = new Set<string>();
+    const activeDisplayedToolStartCounts = new Map<string, number>();
+    const hiddenDuplicateToolCounts = new Map<string, number>();
+    const makeToolDisplayKey = (toolName: string, preview: string): string =>
+      `${toolName}\0${preview}`;
     let sawStreamEvent = false;
     let sawVisibleTextDelta = false;
     let activeDelegateToolCount = 0;
@@ -2400,12 +2431,47 @@ async function processMessage(
             event,
           );
           if (event.phase === 'finish') {
-            s.finishTool(event.toolName);
+            const previewText = formatToolPreview(event.preview);
+            const displayKey = makeToolDisplayKey(event.toolName, previewText);
+            const hiddenCount = hiddenDuplicateToolCounts.get(displayKey) || 0;
+            if (hiddenCount > 0) {
+              if (hiddenCount === 1) {
+                hiddenDuplicateToolCounts.delete(displayKey);
+              } else {
+                hiddenDuplicateToolCounts.set(displayKey, hiddenCount - 1);
+              }
+              return;
+            }
+            s.finishTool(event.toolName, previewText || undefined);
+            const activeDisplayCount =
+              activeDisplayedToolStartCounts.get(displayKey) || 0;
+            if (activeDisplayCount <= 1) {
+              activeDisplayedToolStartCounts.delete(displayKey);
+            } else {
+              activeDisplayedToolStartCounts.set(
+                displayKey,
+                activeDisplayCount - 1,
+              );
+            }
             return;
           }
           if (event.phase !== 'start') return;
           const previewText = formatToolPreview(event.preview);
+          const displayKey = makeToolDisplayKey(event.toolName, previewText);
           streamedToolNames.add(event.toolName);
+          const activeDisplayCount =
+            activeDisplayedToolStartCounts.get(displayKey) || 0;
+          if (activeDisplayCount > 0) {
+            hiddenDuplicateToolCounts.set(
+              displayKey,
+              (hiddenDuplicateToolCounts.get(displayKey) || 0) + 1,
+            );
+            return;
+          }
+          activeDisplayedToolStartCounts.set(
+            displayKey,
+            activeDisplayCount + 1,
+          );
           s.addTool(event.toolName, previewText || undefined);
         },
         abortController.signal,

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -1883,6 +1883,7 @@ useCleanMocks({
     '../src/gateway/media-upload-quota.ts',
     '../src/plugins/plugin-manager.js',
     '../src/gateway/gateway-restart.js',
+    '../src/auth/google-auth.js',
   ],
   suspendedSessions: [],
 });
@@ -8051,6 +8052,335 @@ describe('gateway HTTP server', () => {
       body: JSON.stringify({ ok: true, id: 'completion-1' }),
       json: { ok: true, id: 'completion-1' },
     });
+  });
+
+  test('allows Google OAuth runtime token placeholders for googleapis http requests', async () => {
+    const homeDir = makeTempDocsRoot('hybridclaw-http-google-');
+    process.env.HOME = homeDir;
+    writeRuntimeConfig(homeDir);
+    writeAllowAllSecretPolicy(homeDir);
+
+    vi.doMock('../src/auth/google-auth.js', () => ({
+      resolveGoogleWorkspaceRuntimeEnv: vi.fn(async () => ({
+        GOOGLE_WORKSPACE_CLI_TOKEN: 'minted-google-access-token',
+        GOG_ACCESS_TOKEN: 'minted-google-access-token',
+        GOG_ACCOUNT: 'user@example.com',
+      })),
+    }));
+    vi.doMock('node:dns/promises', () => ({
+      lookup: vi.fn(async () => [{ address: '142.250.185.234', family: 4 }]),
+    }));
+    const state = await importFreshHealth({
+      dataDir: path.join(homeDir, '.hybridclaw', 'data'),
+      gatewayApiToken: 'gateway-token',
+    });
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      url: 'https://analyticsdata.googleapis.com/v1beta/properties/123:runReport',
+      headers: new Headers({ 'content-type': 'application/json' }),
+      arrayBuffer: async () =>
+        Buffer.from(JSON.stringify({ rows: [], rowCount: 0 })),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/http/request',
+      headers: { authorization: 'Bearer gateway-token' },
+      body: {
+        url: 'https://analyticsdata.googleapis.com/v1beta/properties/123:runReport',
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer <secret:GOOGLE_WORKSPACE_CLI_TOKEN>',
+        },
+        json: {
+          dateRanges: [{ startDate: '30daysAgo', endDate: 'yesterday' }],
+          metrics: [{ name: 'activeUsers' }],
+        },
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer minted-google-access-token',
+          'Content-Type': 'application/json',
+        }),
+      }),
+    );
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).json).toEqual({ rows: [], rowCount: 0 });
+  });
+
+  test('allows Google OAuth runtime tokens through URL auth routes', async () => {
+    const homeDir = makeTempDocsRoot('hybridclaw-http-google-route-');
+    process.env.HOME = homeDir;
+    writeRuntimeConfig(homeDir, (config) => {
+      const tools = config.tools as Record<string, unknown>;
+      tools.httpRequest = {
+        authRules: [
+          {
+            urlPrefix: 'https://analyticsdata.googleapis.com/',
+            header: 'Authorization',
+            prefix: 'Bearer',
+            secret: { source: 'google-oauth' },
+          },
+        ],
+      };
+    });
+    writeAllowAllSecretPolicy(homeDir);
+
+    vi.doMock('../src/auth/google-auth.js', () => ({
+      resolveGoogleWorkspaceRuntimeEnv: vi.fn(async () => ({
+        GOOGLE_WORKSPACE_CLI_TOKEN: 'minted-google-access-token',
+        GOG_ACCESS_TOKEN: 'minted-google-access-token',
+        GOG_ACCOUNT: 'user@example.com',
+      })),
+    }));
+    vi.doMock('node:dns/promises', () => ({
+      lookup: vi.fn(async () => [{ address: '142.250.185.234', family: 4 }]),
+    }));
+    const state = await importFreshHealth({
+      dataDir: path.join(homeDir, '.hybridclaw', 'data'),
+      gatewayApiToken: 'gateway-token',
+    });
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      url: 'https://analyticsdata.googleapis.com/v1beta/properties/123:runReport',
+      headers: new Headers({ 'content-type': 'application/json' }),
+      arrayBuffer: async () =>
+        Buffer.from(JSON.stringify({ rows: [], rowCount: 0 })),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/http/request',
+      headers: { authorization: 'Bearer gateway-token' },
+      body: {
+        url: 'https://analyticsdata.googleapis.com/v1beta/properties/123:runReport',
+        method: 'POST',
+        json: {
+          dateRanges: [{ startDate: '30daysAgo', endDate: 'yesterday' }],
+          metrics: [{ name: 'activeUsers' }],
+        },
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer minted-google-access-token',
+          'Content-Type': 'application/json',
+        }),
+      }),
+    );
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).json).toEqual({ rows: [], rowCount: 0 });
+  });
+
+  test('honors secret resolution policy for Google OAuth runtime token injection', async () => {
+    const homeDir = makeTempDocsRoot('hybridclaw-http-google-policy-');
+    process.env.HOME = homeDir;
+    writeRuntimeConfig(homeDir);
+
+    const resolveGoogleWorkspaceRuntimeEnv = vi.fn(async () => ({
+      GOOGLE_WORKSPACE_CLI_TOKEN: 'minted-google-access-token',
+    }));
+    vi.doMock('../src/auth/google-auth.js', () => ({
+      resolveGoogleWorkspaceRuntimeEnv,
+    }));
+    vi.doMock('node:dns/promises', () => ({
+      lookup: vi.fn(async () => [{ address: '142.250.185.234', family: 4 }]),
+    }));
+    const state = await importFreshHealth({
+      dataDir: path.join(homeDir, '.hybridclaw', 'data'),
+      gatewayApiToken: 'gateway-token',
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/http/request',
+      headers: { authorization: 'Bearer gateway-token' },
+      body: {
+        url: 'https://analyticsdata.googleapis.com/v1beta/properties/123:runReport',
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer <secret:GOOGLE_WORKSPACE_CLI_TOKEN>',
+        },
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toBe(
+      'Secret env:GOOGLE_WORKSPACE_CLI_TOKEN is blocked by secret resolution policy.',
+    );
+    expect(resolveGoogleWorkspaceRuntimeEnv).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('honors secret resolution policy for Google OAuth URL auth routes', async () => {
+    const homeDir = makeTempDocsRoot('hybridclaw-http-google-route-policy-');
+    process.env.HOME = homeDir;
+    writeRuntimeConfig(homeDir, (config) => {
+      const tools = config.tools as Record<string, unknown>;
+      tools.httpRequest = {
+        authRules: [
+          {
+            urlPrefix: 'https://analyticsdata.googleapis.com/',
+            header: 'Authorization',
+            prefix: 'Bearer',
+            secret: { source: 'google-oauth' },
+          },
+        ],
+      };
+    });
+
+    const resolveGoogleWorkspaceRuntimeEnv = vi.fn(async () => ({
+      GOOGLE_WORKSPACE_CLI_TOKEN: 'minted-google-access-token',
+    }));
+    vi.doMock('../src/auth/google-auth.js', () => ({
+      resolveGoogleWorkspaceRuntimeEnv,
+    }));
+    vi.doMock('node:dns/promises', () => ({
+      lookup: vi.fn(async () => [{ address: '142.250.185.234', family: 4 }]),
+    }));
+    const state = await importFreshHealth({
+      dataDir: path.join(homeDir, '.hybridclaw', 'data'),
+      gatewayApiToken: 'gateway-token',
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/http/request',
+      headers: { authorization: 'Bearer gateway-token' },
+      body: {
+        url: 'https://analyticsdata.googleapis.com/v1beta/properties/123:runReport',
+        method: 'POST',
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toBe(
+      'Secret env:GOOGLE_WORKSPACE_CLI_TOKEN is blocked by secret resolution policy.',
+    );
+    expect(resolveGoogleWorkspaceRuntimeEnv).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('does not substitute a different Google OAuth runtime token name', async () => {
+    const homeDir = makeTempDocsRoot('hybridclaw-http-google-exact-token-');
+    process.env.HOME = homeDir;
+    writeRuntimeConfig(homeDir);
+    writeAllowAllSecretPolicy(homeDir);
+
+    const resolveGoogleWorkspaceRuntimeEnv = vi.fn(async () => ({
+      GOOGLE_WORKSPACE_CLI_TOKEN: 'minted-google-access-token',
+    }));
+    vi.doMock('../src/auth/google-auth.js', () => ({
+      resolveGoogleWorkspaceRuntimeEnv,
+    }));
+    vi.doMock('node:dns/promises', () => ({
+      lookup: vi.fn(async () => [{ address: '142.250.185.234', family: 4 }]),
+    }));
+    const state = await importFreshHealth({
+      dataDir: path.join(homeDir, '.hybridclaw', 'data'),
+      gatewayApiToken: 'gateway-token',
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/http/request',
+      headers: { authorization: 'Bearer gateway-token' },
+      body: {
+        url: 'https://analyticsdata.googleapis.com/v1beta/properties/123:runReport',
+        headers: {
+          Authorization: 'Bearer <secret:GOG_ACCESS_TOKEN>',
+        },
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toContain(
+      'GOG_ACCESS_TOKEN is not available',
+    );
+    expect(resolveGoogleWorkspaceRuntimeEnv).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('blocks Google OAuth runtime token placeholders for non-Google hosts', async () => {
+    const homeDir = makeTempDocsRoot('hybridclaw-http-google-block-');
+    process.env.HOME = homeDir;
+    writeRuntimeConfig(homeDir);
+
+    vi.doMock('../src/auth/google-auth.js', () => ({
+      resolveGoogleWorkspaceRuntimeEnv: vi.fn(async () => ({
+        GOOGLE_WORKSPACE_CLI_TOKEN: 'minted-google-access-token',
+      })),
+    }));
+    vi.doMock('node:dns/promises', () => ({
+      lookup: vi.fn(async () => [{ address: '93.184.216.34', family: 4 }]),
+    }));
+    const state = await importFreshHealth({
+      dataDir: path.join(homeDir, '.hybridclaw', 'data'),
+      gatewayApiToken: 'gateway-token',
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/http/request',
+      headers: { authorization: 'Bearer gateway-token' },
+      body: {
+        url: 'https://example.com/steal',
+        headers: {
+          Authorization: 'Bearer <secret:GOG_ACCESS_TOKEN>',
+        },
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toContain(
+      'GOG_ACCESS_TOKEN can only be injected into googleapis.com requests',
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test('binds captured OAuth bearer tokens to response instance_url host', async () => {

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -1458,6 +1458,86 @@ test('secret route add normalizes URL prefixes before saving auth rules', async 
   ]);
 });
 
+test('secret route add accepts Google OAuth runtime provider routes', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+  writeRuntimeConfig(homeDir);
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+
+  await handleGatewayCommand({
+    sessionId: 'session-secret-route-google-oauth',
+    guildId: null,
+    channelId: 'tui',
+    args: [
+      'secret',
+      'route',
+      'add',
+      'https://analyticsadmin.googleapis.com/v1alpha',
+      'google-oauth',
+    ],
+  });
+
+  const storedConfig = JSON.parse(
+    fs.readFileSync(path.join(homeDir, '.hybridclaw', 'config.json'), 'utf-8'),
+  ) as RuntimeConfig;
+  expect(storedConfig.tools.httpRequest.authRules).toEqual([
+    {
+      urlPrefix: 'https://analyticsadmin.googleapis.com/v1alpha/',
+      header: 'Authorization',
+      prefix: 'Bearer',
+      secret: {
+        source: 'google-oauth',
+      },
+    },
+  ]);
+});
+
+test('secret route add rejects Google OAuth runtime provider routes outside googleapis', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+  writeRuntimeConfig(homeDir);
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+
+  const result = await handleGatewayCommand({
+    sessionId: 'session-secret-route-google-oauth-invalid',
+    guildId: null,
+    channelId: 'tui',
+    args: [
+      'secret',
+      'route',
+      'add',
+      'https://api.example.com/v1',
+      'google-oauth',
+    ],
+  });
+
+  expect(result.kind).toBe('error');
+  if (result.kind !== 'error') {
+    throw new Error(`Unexpected result kind: ${result.kind}`);
+  }
+  expect(result.title).toBe('Invalid Google OAuth Route');
+  expect(result.text).toContain('googleapis.com');
+
+  const storedConfig = JSON.parse(
+    fs.readFileSync(path.join(homeDir, '.hybridclaw', 'config.json'), 'utf-8'),
+  ) as RuntimeConfig;
+  expect(storedConfig.tools.httpRequest.authRules).toEqual([]);
+});
+
 test('config shows the local runtime config', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;

--- a/tests/heartbeat.test.ts
+++ b/tests/heartbeat.test.ts
@@ -29,7 +29,7 @@ const mocks = vi.hoisted(() => ({
   recordAuditEvent: vi.fn(),
   formatCoworkerLivenessPage: vi.fn(
     (probe: { agentId: string; state: string }) =>
-      `Coworker liveness ${probe.state}: ${probe.agentId}`,
+      `Agent liveness ${probe.state}: ${probe.agentId}`,
   ),
   getCoworkerLivenessSummary: vi.fn(() => ({ probes: [] })),
   heartbeatEnabled: true,
@@ -195,7 +195,7 @@ test('delivers substantive heartbeat messages', async () => {
   expect(mocks.maybeCompactSession).toHaveBeenCalledTimes(1);
 });
 
-test('pages red coworker liveness transitions through heartbeat delivery', async () => {
+test('pages red agent liveness transitions through heartbeat delivery', async () => {
   vi.useFakeTimers();
   mocks.runAgent.mockResolvedValue({
     status: 'success',
@@ -223,10 +223,10 @@ test('pages red coworker liveness transitions through heartbeat delivery', async
   stopHeartbeat();
 
   expect(onMessage).toHaveBeenCalledTimes(1);
-  expect(onMessage).toHaveBeenCalledWith('Coworker liveness red: ops');
+  expect(onMessage).toHaveBeenCalledWith('Agent liveness red: ops');
 });
 
-test('pages red coworker liveness when heartbeat agent is disabled', async () => {
+test('pages red agent liveness when heartbeat agent is disabled', async () => {
   vi.useFakeTimers();
   mocks.heartbeatEnabled = false;
   mocks.getCoworkerLivenessSummary.mockReturnValue({
@@ -251,5 +251,5 @@ test('pages red coworker liveness when heartbeat agent is disabled', async () =>
 
   expect(mocks.runAgent).not.toHaveBeenCalled();
   expect(onMessage).toHaveBeenCalledTimes(1);
-  expect(onMessage).toHaveBeenCalledWith('Coworker liveness red: ops');
+  expect(onMessage).toHaveBeenCalledWith('Agent liveness red: ops');
 });

--- a/tests/local-cli.test.ts
+++ b/tests/local-cli.test.ts
@@ -299,6 +299,46 @@ test('secret route add and remove update store-backed auth rules', async () => {
   expect(config.tools.httpRequest.authRules).toEqual([]);
 });
 
+test('secret route add supports Google OAuth runtime auth rules', async () => {
+  const homeDir = makeTempHome();
+  const cli = await importFreshCli(homeDir);
+
+  await cli.main([
+    'secret',
+    'route',
+    'add',
+    'https://analyticsdata.googleapis.com/v1beta',
+    'google-oauth',
+  ]);
+
+  const config = readRuntimeConfig(homeDir);
+  expect(config.tools.httpRequest.authRules).toEqual([
+    {
+      urlPrefix: 'https://analyticsdata.googleapis.com/v1beta/',
+      header: 'Authorization',
+      prefix: 'Bearer',
+      secret: { source: 'google-oauth' },
+    },
+  ]);
+});
+
+test('secret route add rejects Google OAuth routes for non-Google APIs', async () => {
+  const homeDir = makeTempHome();
+  const cli = await importFreshCli(homeDir);
+
+  await expect(
+    cli.main([
+      'secret',
+      'route',
+      'add',
+      'https://api.example.com/v1',
+      'google-oauth',
+    ]),
+  ).rejects.toThrow(/googleapis\.com/);
+
+  expect(readRuntimeConfig(homeDir).tools.httpRequest.authRules).toEqual([]);
+});
+
 test('top-level help hides deprecated alias commands', async () => {
   const homeDir = makeTempHome();
   const cli = await importFreshCli(homeDir);


### PR DESCRIPTION
## Summary
- add host-side Google OAuth support for http_request auth routes, including google-oauth route configuration and guarded direct Google API token injection
- document Google Analytics setup with Google OAuth routes, required scopes, and troubleshooting
- rename user-facing coworker liveness copy to agent liveness and reduce repeated TUI tool activity noise

## Validation
- npm run lint
- npm run build
- vitest gateway-http-server Google OAuth coverage
- vitest local CLI secret route add coverage
- vitest gateway status secret route add coverage
- focused heartbeat/liveness Vitest coverage

## Notes
- No gateway restart or stop commands were run.