### PR TITLE
[codex] Share provider discovery error helpers

### DIFF
--- a/src/providers/discovery-error-utils.ts
+++ b/src/providers/discovery-error-utils.ts
@@ -1,0 +1,52 @@
+export interface DiscoveryError {
+  httpStatus?: number;
+  message: string;
+}
+
+export function formatDiscoveryDuration(ms: number): string {
+  return ms % 1000 === 0 ? `${ms / 1000}s` : `${ms}ms`;
+}
+
+export function isTimeoutError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const message = error.message.toLowerCase();
+  const name = error.name.toLowerCase();
+  const code = (error as Error & { code?: unknown }).code;
+  return (
+    name === 'timeouterror' ||
+    code === 23 ||
+    code === 'TIMEOUT_ERR' ||
+    /timed out|timeout|aborted due to timeout/.test(message)
+  );
+}
+
+export function formatDiscoveryFailure(params: {
+  error: unknown;
+  url: string;
+  timeoutMs: number;
+}): DiscoveryError {
+  const httpStatus = (params.error as { httpStatus?: number } | null)
+    ?.httpStatus;
+  if (typeof httpStatus === 'number') {
+    return {
+      httpStatus,
+      message: `HTTP ${httpStatus} from ${params.url}`,
+    };
+  }
+
+  if (isTimeoutError(params.error)) {
+    return {
+      message: `Timed out after ${formatDiscoveryDuration(
+        params.timeoutMs,
+      )} while fetching ${params.url}.`,
+    };
+  }
+
+  const rawMessage =
+    params.error instanceof Error && params.error.message.trim()
+      ? params.error.message.trim()
+      : String(params.error);
+  return {
+    message: `Failed to fetch ${params.url}: ${rawMessage}`,
+  };
+}

--- a/src/providers/openai-compat-discovery.ts
+++ b/src/providers/openai-compat-discovery.ts
@@ -10,6 +10,10 @@ import {
   ZAI_ENABLED,
 } from '../config/config.js';
 import { logger } from '../logger.js';
+import {
+  type DiscoveryError,
+  formatDiscoveryFailure,
+} from './discovery-error-utils.js';
 import { getDiscoveredHuggingFaceModelNames } from './huggingface-discovery.js';
 import { getDiscoveredMistralModelNames } from './mistral-discovery.js';
 import {
@@ -85,11 +89,6 @@ function prefixModelId(prefix: string, id: string): string {
   return `${prefix}${id}`;
 }
 
-export interface DiscoveryError {
-  httpStatus?: number;
-  message: string;
-}
-
 export interface OpenAICompatDiscoveryStore {
   discoverModels: (opts?: { force?: boolean }) => Promise<string[]>;
   getModelNames: () => string[];
@@ -109,49 +108,6 @@ const buildEmptyOpenAICompatDiscoveryState =
     discoveredModelNames: [],
     pricingByModel: new Map(),
   });
-
-function formatDuration(ms: number): string {
-  return ms % 1000 === 0 ? `${ms / 1000}s` : `${ms}ms`;
-}
-
-function isTimeoutError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  const message = error.message.toLowerCase();
-  const name = error.name.toLowerCase();
-  const code = (error as Error & { code?: unknown }).code;
-  return (
-    name === 'timeouterror' ||
-    code === 23 ||
-    code === 'TIMEOUT_ERR' ||
-    /timed out|timeout|aborted due to timeout/.test(message)
-  );
-}
-
-function formatDiscoveryFailure(error: unknown, url: string): DiscoveryError {
-  const httpStatus = (error as { httpStatus?: number } | null)?.httpStatus;
-  if (typeof httpStatus === 'number') {
-    return {
-      httpStatus,
-      message: `HTTP ${httpStatus} from ${url}`,
-    };
-  }
-
-  if (isTimeoutError(error)) {
-    return {
-      message: `Timed out after ${formatDuration(
-        OPENAI_COMPAT_DISCOVERY_TIMEOUT_MS,
-      )} while fetching ${url}.`,
-    };
-  }
-
-  const rawMessage =
-    error instanceof Error && error.message.trim()
-      ? error.message.trim()
-      : String(error);
-  return {
-    message: `Failed to fetch ${url}: ${rawMessage}`,
-  };
-}
 
 export function createOpenAICompatDiscoveryStore(
   def: OpenAICompatRemoteProviderDef,
@@ -239,10 +195,11 @@ export function createOpenAICompatDiscoveryStore(
     const state = await discoveryStore.discover(() => fetchModels(apiKey), {
       force: opts?.force,
       onError: (err, staleState) => {
-        const discoveryError = formatDiscoveryFailure(
-          err,
-          resolveDiscoveryUrl(),
-        );
+        const discoveryError = formatDiscoveryFailure({
+          error: err,
+          url: resolveDiscoveryUrl(),
+          timeoutMs: OPENAI_COMPAT_DISCOVERY_TIMEOUT_MS,
+        });
         lastError = discoveryError;
         const httpStatus = discoveryError.httpStatus;
         if (httpStatus === 404 || httpStatus === 405) {

--- a/tests/discovery-error-utils.test.ts
+++ b/tests/discovery-error-utils.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  formatDiscoveryDuration,
+  formatDiscoveryFailure,
+  isTimeoutError,
+} from '../src/providers/discovery-error-utils.js';
+
+describe('provider discovery error utils', () => {
+  test('formats discovery durations compactly', () => {
+    expect(formatDiscoveryDuration(5_000)).toBe('5s');
+    expect(formatDiscoveryDuration(5_250)).toBe('5250ms');
+  });
+
+  test('detects timeout-shaped errors from fetch runtimes', () => {
+    const timeout = new DOMException(
+      'The operation was aborted due to timeout',
+      'TimeoutError',
+    );
+    expect(isTimeoutError(timeout)).toBe(true);
+    expect(isTimeoutError(new Error('request timed out'))).toBe(true);
+    expect(isTimeoutError(new Error('fetch failed'))).toBe(false);
+  });
+
+  test('formats HTTP, timeout, and generic discovery failures', () => {
+    const httpError = new Error('HTTP 404') as Error & { httpStatus?: number };
+    httpError.httpStatus = 404;
+    expect(
+      formatDiscoveryFailure({
+        error: httpError,
+        url: 'https://example.test/models',
+        timeoutMs: 5_000,
+      }),
+    ).toEqual({
+      httpStatus: 404,
+      message: 'HTTP 404 from https://example.test/models',
+    });
+
+    expect(
+      formatDiscoveryFailure({
+        error: new DOMException('timeout', 'TimeoutError'),
+        url: 'https://example.test/models',
+        timeoutMs: 5_000,
+      }),
+    ).toEqual({
+      message: 'Timed out after 5s while fetching https://example.test/models.',
+    });
+
+    expect(
+      formatDiscoveryFailure({
+        error: new Error('connection refused'),
+        url: 'https://example.test/models',
+        timeoutMs: 5_000,
+      }),
+    ).toEqual({
+      message:
+        'Failed to fetch https://example.test/models: connection refused',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Move OpenAI-compatible discovery timeout/error formatting into `src/providers/discovery-error-utils.ts`.
- Reuse the shared helper from `openai-compat-discovery.ts` instead of keeping local copies of `isTimeoutError`, duration formatting, and discovery failure formatting.
- Add focused unit coverage for HTTP, timeout, and generic discovery failure formatting.

## Validation

- `PATH="/Users/bkoehler/Library/Application Support/Herd/config/nvm/versions/node/v22.15.1/bin:$PATH" ./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/discovery-error-utils.test.ts tests/openai-compat-discovery.test.ts`
- `PATH="/Users/bkoehler/Library/Application Support/Herd/config/nvm/versions/node/v22.15.1/bin:$PATH" "/Users/bkoehler/Library/Application Support/Herd/config/nvm/versions/node/v22.15.1/bin/node" "/Users/bkoehler/Library/Application Support/Herd/config/nvm/versions/node/v22.15.1/lib/node_modules/npm/bin/npm-cli.js" run typecheck`

Risk note: behavior should be unchanged; existing timeout text and HTTP status handling are preserved, but now live in the shared provider discovery helper.