### PR TITLE
[codex] Keep IMAP transport timeouts local

### DIFF
--- a/src/channels/email/connection.ts
+++ b/src/channels/email/connection.ts
@@ -188,7 +188,24 @@ export function createEmailConnectionManager(
     const activeClient = client;
     client = null;
     if (!activeClient) return;
-    activeClient.removeAllListeners();
+    activeClient.removeAllListeners('close');
+    activeClient.removeAllListeners('error');
+    activeClient.on('error', (error) => {
+      if (isExpectedTransportError(error)) {
+        childLogger.debug(
+          {
+            code: getEmailConnectionErrorCode(error) || undefined,
+            host: config.imapHost,
+          },
+          `${describeExpectedTransportError(error, 'Email IMAP', config.imapHost)} Ignoring error from closing client.`,
+        );
+        return;
+      }
+      childLogger.warn(
+        { error, host: config.imapHost },
+        'Email IMAP client emitted an error while closing',
+      );
+    });
     await activeClient.logout().catch((error) => {
       if (
         error &&

--- a/src/utils/transport-errors.ts
+++ b/src/utils/transport-errors.ts
@@ -9,6 +9,7 @@ const EXPECTED_TRANSPORT_ERROR_CODES = new Set([
   'ENOTFOUND',
   'ERR_SOCKET_CLOSED',
   'ESOCKETTIMEDOUT',
+  'ETIMEOUT',
   'ETIMEDOUT',
   'UND_ERR_BODY_TIMEOUT',
   'UND_ERR_CONNECT_TIMEOUT',
@@ -17,7 +18,7 @@ const EXPECTED_TRANSPORT_ERROR_CODES = new Set([
 ]);
 
 const EXPECTED_TRANSPORT_ERROR_MESSAGE_RE =
-  /\b(opening handshake has timed out|client network socket disconnected|connect econnrefused|connect etimedout|connection reset|connection terminated|econnaborted|econnrefused|econnreset|ehostunreach|enetunreach|enotfound|eai_again|err_socket_closed|esockettimedout|etimedout|fetch failed|network error|opening handshake|read econnreset|socket hang up|und_err_body_timeout|und_err_connect_timeout|und_err_headers_timeout|und_err_socket|websocket (?:connection |client )?(?:closed|error|timed out))\b/i;
+  /\b(opening handshake has timed out|client network socket disconnected|connect econnrefused|connect etimedout|connection reset|connection terminated|econnaborted|econnrefused|econnreset|ehostunreach|enetunreach|enotfound|eai_again|err_socket_closed|esockettimedout|etimeout|etimedout|fetch failed|network error|opening handshake|read econnreset|socket hang up|socket timeout|und_err_body_timeout|und_err_connect_timeout|und_err_headers_timeout|und_err_socket|websocket (?:connection |client )?(?:closed|error|timed out))\b/i;
 
 interface ErrorLike {
   cause?: unknown;
@@ -140,6 +141,7 @@ export function describeExpectedTransportError(
         ? `${subject} DNS lookup for ${host} is temporarily unavailable.`
         : `${subject} DNS lookup is temporarily unavailable.`;
     case 'ETIMEDOUT':
+    case 'ETIMEOUT':
     case 'ESOCKETTIMEDOUT':
     case 'UND_ERR_CONNECT_TIMEOUT':
     case 'UND_ERR_HEADERS_TIMEOUT':

--- a/tests/email.connection.test.ts
+++ b/tests/email.connection.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events';
 import fs from 'node:fs';
 import path from 'node:path';
 import { describe, expect, test, vi } from 'vitest';
@@ -24,7 +25,7 @@ const makeTempDir = useTempDir();
 useCleanMocks({
   restoreAllMocks: true,
   resetModules: true,
-  unmock: ['imapflow', '../src/config/config.js'],
+  unmock: ['imapflow', '../src/config/config.js', '../src/logger.ts'],
 });
 
 describe('email connection manager', () => {
@@ -273,6 +274,104 @@ describe('email connection manager', () => {
         host: 'mx.hybridclaw.io',
       },
       'Email IMAP DNS lookup failed for mx.hybridclaw.io. Retrying connection in 1s.',
+    );
+  });
+
+  test('keeps IMAP shutdown socket errors local after scheduling reconnect', async () => {
+    const dataDir = makeTempDir('hybridclaw-email-connection-');
+    const childLogger = {
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+    const clients: Array<{
+      emit: (eventName: string, error: unknown) => boolean;
+      listenerCount: (eventName: string) => number;
+    }> = [];
+    const timeoutError = Object.assign(new Error('Socket timeout'), {
+      code: 'ETIMEOUT',
+    });
+    const resetError = Object.assign(new Error('read ECONNRESET'), {
+      code: 'ECONNRESET',
+      errno: -54,
+      syscall: 'read',
+    });
+
+    vi.doMock('../src/config/config.js', () => ({
+      DATA_DIR: dataDir,
+    }));
+    vi.doMock('../src/logger.ts', () => ({
+      logger: {
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+        child: vi.fn(() => childLogger),
+      },
+    }));
+    vi.doMock('imapflow', () => ({
+      ImapFlow: class extends EventEmitter {
+        mailbox = {
+          path: 'INBOX',
+          uidNext: 1,
+          uidValidity: 1n,
+        };
+        constructor() {
+          super();
+          clients.push(this);
+        }
+        connect = vi.fn(async () => {});
+        logout = vi.fn(async () => {});
+        getMailboxLock = vi.fn(async (folder: string) => {
+          this.mailbox = {
+            path: folder,
+            uidNext: 1,
+            uidValidity: 1n,
+          };
+          return {
+            release: vi.fn(),
+          };
+        });
+        search = vi.fn(async () => []);
+        fetch = vi.fn(async function* () {});
+        messageFlagsAdd = vi.fn(async () => true);
+      },
+    }));
+
+    const { createEmailConnectionManager } = await import(
+      '../src/channels/email/connection.js'
+    );
+    const manager = createEmailConnectionManager(
+      BASE_EMAIL_CONFIG,
+      'secret',
+      async () => {},
+    );
+
+    await manager.start();
+    expect(clients).toHaveLength(1);
+
+    const imapClient = clients[0];
+    imapClient.emit('error', timeoutError);
+
+    expect(() => imapClient.emit('error', resetError)).not.toThrow();
+    expect(imapClient.listenerCount('error')).toBe(1);
+    await manager.stop();
+
+    expect(childLogger.error).not.toHaveBeenCalled();
+    expect(childLogger.warn).toHaveBeenCalledWith(
+      {
+        delayMs: 1_000,
+        reason: 'client-error',
+        code: 'ETIMEOUT',
+        host: 'imap.example.com',
+      },
+      'Email IMAP connection to imap.example.com timed out. Retrying connection in 1s.',
+    );
+    expect(childLogger.debug).toHaveBeenCalledWith(
+      {
+        code: 'ECONNRESET',
+        host: 'imap.example.com',
+      },
+      'Email IMAP connection to imap.example.com was reset. Ignoring error from closing client.',
     );
   });
 

--- a/tests/transport-errors.test.ts
+++ b/tests/transport-errors.test.ts
@@ -19,6 +19,16 @@ describe('isExpectedTransportError', () => {
     expect(isExpectedTransportError(error)).toBe(true);
   });
 
+  test('matches IMAP socket timeout errors', () => {
+    const error = Object.assign(new Error('Socket timeout'), {
+      code: 'ETIMEOUT',
+    });
+    expect(isExpectedTransportError(error)).toBe(true);
+    expect(describeExpectedTransportError(error, 'Email IMAP')).toBe(
+      'Email IMAP connection timed out.',
+    );
+  });
+
   test('matches nested transport causes', () => {
     const error = new Error('Discord shard error', {
       cause: new Error('socket hang up'),


### PR DESCRIPTION
## Summary

- Classify ImapFlow `ETIMEOUT` / `Socket timeout` failures as expected transient transport errors.
- Keep an IMAP client `error` listener attached while a failed client is being closed, so follow-on socket resets during logout stay local to the email channel.
- Add regression coverage for the timeout/reconnect path and the shutdown `ECONNRESET` race.

## Root Cause

The email connection manager removed every IMAP listener before calling `logout()` on a failed client. If the same underlying TLS socket emitted another `error` during that shutdown window, Node treated it as an uncaught EventEmitter error and the gateway process-level handler exited the process.

## Validation

- `./node_modules/.bin/vitest run tests/email.connection.test.ts tests/transport-errors.test.ts`
- commit hook: Biome checked the staged files