### PR TITLE
[codex] Stack TUI tool activity rows

### DIFF
--- a/src/tui.ts
+++ b/src/tui.ts
@@ -1379,7 +1379,7 @@ function pickOceanActivityVerb(): string {
   return OCEAN_ACTIVITY_VERBS[index] || 'floating';
 }
 
-interface SpinnerToolEntry {
+export interface SpinnerToolEntry {
   name: string;
   preview: string;
   count: number;
@@ -1403,6 +1403,22 @@ export function formatTuiToolActivityLine(params: {
   const body = `  ${frame.emojiColor}${JELLYFISH}${RESET} ${TEAL}${params.toolName}${RESET}${countText}${previewText}`;
   const safeColumns = Math.max(1, params.columns - 1);
   return truncateAnsiTuiEnd(body, safeColumns);
+}
+
+export function formatTuiToolActivityBlock(params: {
+  entries: SpinnerToolEntry[];
+  columns: number;
+  frameIndex?: number;
+}): string[] {
+  return params.entries.map((entry) =>
+    formatTuiToolActivityLine({
+      toolName: entry.name,
+      preview: entry.preview,
+      columns: params.columns,
+      frameIndex: params.frameIndex,
+      count: entry.count,
+    }),
+  );
 }
 
 function spinner(): {
@@ -1430,7 +1446,19 @@ function spinner(): {
   let visibleTextState = createTuiStreamFormatState();
   let visibleTextRows = 0;
   let thinkingPreviewRows = 0;
+  let toolActivityRows = 0;
   const clearLine = () => process.stdout.write('\r\x1b[2K');
+  const clearRows = (rows: number) => {
+    const normalizedRows = Math.max(0, rows);
+    if (normalizedRows <= 0) return;
+    if (!process.stdout.isTTY) return;
+    if (normalizedRows > 1) process.stdout.write(`\x1b[${normalizedRows - 1}A`);
+    for (let row = 0; row < normalizedRows; row += 1) {
+      clearLine();
+      if (row < normalizedRows - 1) process.stdout.write('\n');
+    }
+    if (normalizedRows > 1) process.stdout.write(`\x1b[${normalizedRows - 1}A`);
+  };
   const hideCursor = () => {
     if (cursorHidden || !process.stdout.isTTY) return;
     process.stdout.write(HIDE_CURSOR);
@@ -1441,29 +1469,30 @@ function spinner(): {
     process.stdout.write(SHOW_CURSOR);
     cursorHidden = false;
   };
-  const formatToolLine = (
-    entry: SpinnerToolEntry,
-    frameIdx: number,
-  ): string => {
-    return formatTuiToolActivityLine({
-      toolName: entry.name,
-      preview: entry.preview,
+  const clearToolActivityBlock = () => {
+    if (toolActivityRows > 0) {
+      clearRows(toolActivityRows);
+      toolActivityRows = 0;
+      return;
+    }
+    clearLine();
+  };
+  const repaintToolBlock = (frameIdx: number) => {
+    if (toolEntries.length <= 0) return;
+    clearToolActivityBlock();
+    const lines = formatTuiToolActivityBlock({
+      entries: toolEntries,
       columns: terminalColumns(),
       frameIndex: frameIdx,
-      count: entry.count,
     });
-  };
-  const repaintToolLine = (frameIdx: number) => {
-    const entry = toolEntries.at(-1);
-    if (!entry) return;
-    clearLine();
-    process.stdout.write(`\r${formatToolLine(entry, frameIdx)}`);
+    process.stdout.write(`\r${lines.join('\n')}`);
+    toolActivityRows = lines.length;
   };
   const render = () => {
     if (stopped) return;
     if (hasVisibleText || thinkingPreviewRows > 0) return;
     if (toolEntries.length > 0) {
-      repaintToolLine(i);
+      repaintToolBlock(i);
       i++;
       return;
     }
@@ -1478,7 +1507,7 @@ function spinner(): {
 
   const clearTools = () => {
     if (toolEntries.length <= 0) return;
-    clearLine();
+    clearToolActivityBlock();
     toolEntries.length = 0;
     if (
       !stopped &&
@@ -1551,10 +1580,14 @@ function spinner(): {
         !hasVisibleText &&
         thinkingPreviewRows === 0
       ) {
-        repaintToolLine(i);
+        repaintToolBlock(i);
       }
       if (showActivityPreview && !hasVisibleText && thinkingPreviewRows === 0) {
-        clearLine();
+        if (toolActivityRows > 0) {
+          clearToolActivityBlock();
+        } else {
+          clearLine();
+        }
       }
       showCursor();
     },
@@ -1575,7 +1608,7 @@ function spinner(): {
       }
       if (existingEntry) {
         existingEntry.count += 1;
-        repaintToolLine(i);
+        repaintToolBlock(i);
         return;
       }
       const entry: SpinnerToolEntry = {
@@ -1584,7 +1617,7 @@ function spinner(): {
         count: 1,
       };
       toolEntries.push(entry);
-      repaintToolLine(i);
+      repaintToolBlock(i);
     },
     finishTool: (toolName: string, preview?: string) => {
       if (!showTools) return;
@@ -1603,9 +1636,9 @@ function spinner(): {
         break;
       }
       if (toolEntries.length > 0) {
-        repaintToolLine(i);
+        repaintToolBlock(i);
       } else {
-        clearLine();
+        clearToolActivityBlock();
         if (!stopped && showActivityPreview && thinkingPreviewRows === 0) {
           render();
         }

--- a/tests/tui-format.test.ts
+++ b/tests/tui-format.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest';
 
 import {
   formatTuiTitledCommandBlock,
+  formatTuiToolActivityBlock,
   formatTuiToolActivityLine,
   nextActiveDelegateToolCount,
   parseTuiSectionCards,
@@ -56,6 +57,27 @@ test('tool activity width uses production wide and zero-width handling', () => {
 
   expect(visibleTuiLength(line)).toBeLessThanOrEqual(27);
   expect(stripAnsi(line)).not.toContain('�');
+});
+
+test('tool activity block keeps active tools on separate rows', () => {
+  const lines = formatTuiToolActivityBlock({
+    entries: [
+      {
+        name: 'read',
+        preview: '{"path":"skills/download-platform-invoices/helpers/money"}',
+        count: 1,
+      },
+      { name: 'grep', preview: '{"pattern":"invoice"}', count: 2 },
+    ],
+    columns: 70,
+    frameIndex: 0,
+  }).map(stripAnsi);
+
+  expect(lines).toHaveLength(2);
+  expect(lines[0]).toContain('read');
+  expect(lines[0]).toContain('skills/download-platform-invoices');
+  expect(lines[1]).toContain('grep');
+  expect(lines[1]).toContain('x2');
 });
 
 test('reflows locomo variant tables to the live tui width without splitting rows', () => {


### PR DESCRIPTION
## Summary

- Render active TUI tool activity as a multi-row block instead of replacing the previous tool row.
- Track the rendered tool activity row count so the spinner can clear exactly those rows when tool activity finishes or streamed text starts.
- Add focused formatter coverage for stacked tool rows and repeated tool counts.

## User Impact

Concurrent or sequential tool activity remains visible one entry per row while work is in progress, then the TUI can remove the full activity block cleanly when the final response or streamed text takes over.

## Validation

- `./node_modules/.bin/vitest run tests/tui-format.test.ts`
- `npx biome check src/tui.ts tests/tui-format.test.ts`
- commit hook: Biome checked the staged files