### PR TITLE
[codex] Add webhook outbound adapter

### DIFF
--- a/src/a2a/envelope.ts
+++ b/src/a2a/envelope.ts
@@ -27,6 +27,13 @@ export type CreateA2AEnvelopeInput = Omit<A2AEnvelope, 'id' | 'created_at'> & {
   created_at?: string;
 };
 
+export interface A2AEnvelopeAuditSummary {
+  messageId: string | null;
+  threadId: string | null;
+  senderAgentId: string | null;
+  recipientAgentId: string | null;
+}
+
 export class A2AEnvelopeValidationError extends Error {
   readonly issues: string[];
 
@@ -269,4 +276,15 @@ export function parseA2AEnvelopeJson(raw: string): A2AEnvelope {
 
 export function serializeA2AEnvelope(envelope: A2AEnvelope): string {
   return `${JSON.stringify(envelope, null, 2)}\n`;
+}
+
+export function summarizeA2AEnvelopeForAudit(
+  envelope: A2AEnvelope,
+): A2AEnvelopeAuditSummary {
+  return {
+    messageId: envelope.id,
+    threadId: envelope.thread_id,
+    senderAgentId: envelope.sender_agent_id,
+    recipientAgentId: envelope.recipient_agent_id,
+  };
 }

--- a/src/a2a/peer-descriptor.ts
+++ b/src/a2a/peer-descriptor.ts
@@ -1,3 +1,5 @@
+import { isIP } from 'node:net';
+
 import type { SecretRef } from '../security/secret-refs.js';
 import { parseSecretInput } from '../security/secret-refs.js';
 import {
@@ -21,6 +23,9 @@ const WEBHOOK_ALLOWED_FIELDS = new Set([
   'url',
   'secretRef',
   'secret_ref',
+  'signatureHeader',
+  'signature_header',
+  'version',
 ]);
 
 export interface InternalPeerDescriptor {
@@ -37,6 +42,8 @@ export interface WebhookPeerDescriptor {
   transport: 'webhook';
   url: string;
   secretRef: SecretRef;
+  signatureHeader?: string;
+  version?: string;
 }
 
 export interface UnknownPeerDescriptor {
@@ -108,6 +115,25 @@ function readOptionalStringAlias(
   return normalized;
 }
 
+function readOptionalString(
+  record: Record<string, unknown>,
+  field: string,
+  issues: string[],
+): string | undefined {
+  if (!Object.hasOwn(record, field)) return undefined;
+  const value = record[field];
+  if (typeof value !== 'string') {
+    issues.push(`${field} must be a string when provided`);
+    return undefined;
+  }
+  const normalized = value.trim();
+  if (!normalized) {
+    issues.push(`${field} must not be empty when provided`);
+    return undefined;
+  }
+  return normalized;
+}
+
 function validateAllowedFields(
   record: Record<string, unknown>,
   allowedFields: ReadonlySet<string>,
@@ -134,6 +160,57 @@ function readHttpUrl(
     }
   } catch {
     issues.push(`${field} must be a valid URL`);
+  }
+  return value;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/^\[(.*)\]$/, '$1');
+  if (normalized === 'localhost' || normalized === '::1') return true;
+  if (isIP(normalized) !== 4) return false;
+  const [firstOctet] = normalized.split('.');
+  return firstOctet === '127';
+}
+
+function readWebhookUrl(
+  record: Record<string, unknown>,
+  field: string,
+  issues: string[],
+): string {
+  const value = readRequiredString(record[field], field, issues);
+  if (!value) return '';
+  try {
+    const url = new URL(value);
+    if (
+      url.protocol !== 'https:' &&
+      !(url.protocol === 'http:' && isLoopbackHostname(url.hostname))
+    ) {
+      issues.push(`${field} must use https unless targeting loopback`);
+    }
+  } catch {
+    issues.push(`${field} must be a valid URL`);
+  }
+  return value;
+}
+
+function readHttpHeaderName(
+  record: Record<string, unknown>,
+  camelKey: string,
+  snakeKey: string,
+  field: string,
+  issues: string[],
+): string | undefined {
+  const value = readOptionalStringAlias(
+    record,
+    camelKey,
+    snakeKey,
+    field,
+    issues,
+  );
+  if (!value) return undefined;
+  if (!/^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/.test(value)) {
+    issues.push(`${field} must be a valid HTTP header name`);
+    return undefined;
   }
   return value;
 }
@@ -224,11 +301,22 @@ export function normalizePeerDescriptor(value: unknown): PeerDescriptor {
 
   if (transport === 'webhook') {
     validateAllowedFields(value, WEBHOOK_ALLOWED_FIELDS, issues);
-    const url = readHttpUrl(value, 'url', issues);
+    const url = readWebhookUrl(value, 'url', issues);
     const secretRef = normalizeWebhookSecretRef(
       readAlias(value, 'secretRef', 'secret_ref'),
       issues,
     );
+    const signatureHeader = readHttpHeaderName(
+      value,
+      'signatureHeader',
+      'signature_header',
+      'signatureHeader',
+      issues,
+    );
+    const version = readOptionalString(value, 'version', issues);
+    if (version && version !== '1') {
+      issues.push('version must be 1 when provided');
+    }
     if (issues.length > 0 || !secretRef) {
       throw new PeerDescriptorValidationError(issues);
     }
@@ -236,6 +324,8 @@ export function normalizePeerDescriptor(value: unknown): PeerDescriptor {
       transport: 'webhook',
       url,
       secretRef,
+      ...(signatureHeader ? { signatureHeader } : {}),
+      ...(version ? { version } : {}),
     };
   }
 

--- a/src/a2a/transport-registry.ts
+++ b/src/a2a/transport-registry.ts
@@ -6,17 +6,33 @@ import {
   emitInteractionNeededEvent,
 } from '../gateway/interactive-escalation.js';
 import type { EscalationTarget } from '../types/execution.js';
-import { type A2AEnvelope, validateA2AEnvelope } from './envelope.js';
+import {
+  type A2AEnvelope,
+  type A2AEnvelopeAuditSummary,
+  summarizeA2AEnvelopeForAudit,
+  validateA2AEnvelope,
+} from './envelope.js';
 import {
   type A2APeerTransport,
   normalizePeerDescriptor,
   type PeerDescriptor,
 } from './peer-descriptor.js';
 import { A2A_TRANSPORT_PATTERN, normalizeTransportString } from './utils.js';
+import { webhookOutboundAdapter } from './webhook-outbound.js';
+
+export interface TransportAdapterContext {
+  sessionId?: string;
+  runId?: string;
+  escalationTarget?: EscalationTarget;
+}
 
 export interface TransportAdapter<WirePayload = unknown> {
   readonly transport: A2APeerTransport;
-  encode(envelope: A2AEnvelope, descriptor?: PeerDescriptor): WirePayload;
+  encode(
+    envelope: A2AEnvelope,
+    descriptor?: PeerDescriptor,
+    context?: TransportAdapterContext,
+  ): WirePayload;
   decode(payload: WirePayload, descriptor?: PeerDescriptor): A2AEnvelope;
 }
 
@@ -80,6 +96,7 @@ export const internalTransportAdapter: TransportAdapter<A2AEnvelope> = {
 export function createDefaultTransportRegistry(): TransportRegistry {
   const registry = new TransportRegistry();
   registry.register(internalTransportAdapter);
+  registry.register(webhookOutboundAdapter);
   return registry;
 }
 
@@ -93,23 +110,9 @@ export interface TransportEscalationAuditInput {
   escalationTarget?: EscalationTarget;
 }
 
-function summarizeEnvelopeForAudit(envelope: A2AEnvelope): {
-  messageId: string | null;
-  threadId: string | null;
-  senderAgentId: string | null;
-  recipientAgentId: string | null;
-} {
-  return {
-    messageId: envelope.id,
-    threadId: envelope.thread_id,
-    senderAgentId: envelope.sender_agent_id,
-    recipientAgentId: envelope.recipient_agent_id,
-  };
-}
-
 function transportEscalationPrompt(params: {
   transport: string;
-  summary: ReturnType<typeof summarizeEnvelopeForAudit>;
+  summary: A2AEnvelopeAuditSummary;
 }): string {
   return [
     `A2A transport escalation: no adapter is registered for "${params.transport}".`,
@@ -129,7 +132,7 @@ function transportEscalationPrompt(params: {
 
 function createTransportEscalationSession(input: {
   transport: string;
-  summary: ReturnType<typeof summarizeEnvelopeForAudit>;
+  summary: A2AEnvelopeAuditSummary;
   escalationTarget?: EscalationTarget;
   runId: string;
   sessionId: string;
@@ -172,15 +175,13 @@ function encodeCompositeKeyPart(
   return Buffer.from(raw).toString('base64url');
 }
 
-function makeEscalationSessionId(
-  summary: ReturnType<typeof summarizeEnvelopeForAudit>,
-): string {
+function makeEscalationSessionId(summary: A2AEnvelopeAuditSummary): string {
   return `a2a:${encodeCompositeKeyPart(summary.threadId, 'sendMessage')}`;
 }
 
 function makeEscalationApprovalId(
   transport: string,
-  summary: ReturnType<typeof summarizeEnvelopeForAudit>,
+  summary: A2AEnvelopeAuditSummary,
 ): string {
   return [
     'a2a-transport',
@@ -192,7 +193,7 @@ function makeEscalationApprovalId(
 export function recordTransportEscalationAudit(
   input: TransportEscalationAuditInput,
 ): void {
-  const summary = summarizeEnvelopeForAudit(input.envelope);
+  const summary = summarizeA2AEnvelopeForAudit(input.envelope);
   const sessionId = input.sessionId || makeEscalationSessionId(summary);
   const approvalId = makeEscalationApprovalId(input.transport, summary);
   const runId = input.runId || makeAuditRunId('a2a-transport');
@@ -277,8 +278,10 @@ export function encodeForRegisteredTransport(params: {
     return validateA2AEnvelope(adapter.encode(normalizedEnvelope, descriptor));
   }
 
-  // R1.10 opens the encoder seam; follow-up transport work owns delivery.
-  // The runtime persists the canonical envelope until a sender consumes this payload.
-  adapter.encode(normalizedEnvelope, descriptor);
+  adapter.encode(normalizedEnvelope, descriptor, {
+    sessionId: params.sessionId,
+    runId: params.runId,
+    escalationTarget: params.escalationTarget,
+  });
   return normalizedEnvelope;
 }

--- a/src/a2a/webhook-outbound.ts
+++ b/src/a2a/webhook-outbound.ts
@@ -1,0 +1,725 @@
+import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
+import path from 'node:path';
+
+import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
+import {
+  listRuntimeAssetRevisionStates,
+  syncRuntimeAssetRevisionState,
+} from '../config/runtime-config-revisions.js';
+import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+import {
+  createSuspendedSession,
+  emitInteractionNeededEvent,
+} from '../gateway/interactive-escalation.js';
+import { logger } from '../logger.js';
+import {
+  resolveSecretInputUnsafe,
+  type SecretRef,
+} from '../security/secret-refs.js';
+import type { EscalationTarget } from '../types/execution.js';
+import {
+  type A2AEnvelope,
+  summarizeA2AEnvelopeForAudit,
+  validateA2AEnvelope,
+} from './envelope.js';
+import type { WebhookPeerDescriptor } from './peer-descriptor.js';
+import type {
+  TransportAdapter,
+  TransportAdapterContext,
+} from './transport-registry.js';
+
+export const WEBHOOK_SIGNATURE_HEADER = 'X-HybridClaw-Signature';
+export const WEBHOOK_BODY_VERSION = '1';
+export const WEBHOOK_REPLAY_WINDOW_MS = 5 * 60_000;
+export const WEBHOOK_RETRY_BASE_DELAY_MS = 1_000;
+export const WEBHOOK_RETRY_MAX_DELAY_MS = 5 * 60_000;
+export const WEBHOOK_RETRY_MAX_ATTEMPTS = 8;
+export const WEBHOOK_OUTBOX_CONCURRENCY = 4;
+export const WEBHOOK_OUTBOX_DRAIN_INTERVAL_MS = 5_000;
+const WEBHOOK_OUTBOX_SCHEMA_VERSION = 1;
+const WEBHOOK_OUTBOX_ASSET_PREFIX = path.join(
+  DEFAULT_RUNTIME_HOME_DIR,
+  'a2a',
+  'outbox',
+  'webhook',
+);
+
+export type WebhookOutboxStatus = 'pending' | 'delivered' | 'failed';
+
+export interface WebhookOutboxItem {
+  schemaVersion: typeof WEBHOOK_OUTBOX_SCHEMA_VERSION;
+  id: string;
+  status: WebhookOutboxStatus;
+  envelope: A2AEnvelope;
+  url: string;
+  secretRef: SecretRef;
+  signatureHeader: string;
+  version: string;
+  attempts: number;
+  maxAttempts: number;
+  nextAttemptAt: string;
+  createdAt: string;
+  updatedAt: string;
+  sessionId?: string;
+  runId?: string;
+  escalationTarget?: EscalationTarget;
+  lastAttemptAt?: string;
+  deliveredAt?: string;
+  failedAt?: string;
+  lastError?: string;
+  lastStatusCode?: number;
+}
+
+export interface WebhookOutboundAdapterOptions {
+  autoProcess?: boolean;
+  maxAttempts?: number;
+}
+
+export interface WebhookOutboxProcessOptions {
+  fetchImpl?: typeof fetch;
+  now?: () => Date;
+  random?: () => number;
+  maxAttempts?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  jitterRatio?: number;
+  concurrency?: number;
+}
+
+export interface WebhookOutboxProcessResult {
+  processed: number;
+  delivered: number;
+  retried: number;
+  failed: number;
+}
+
+let webhookOutboxProcessorTimer: ReturnType<typeof setInterval> | null = null;
+let webhookOutboxProcessorRunning = false;
+
+export interface WebhookSignatureVerificationInput {
+  header: string | null | undefined;
+  body: string;
+  secret: string;
+  nowMs?: number;
+  replayWindowMs?: number;
+}
+
+function outboxAssetPath(id: string): string {
+  return path.join(WEBHOOK_OUTBOX_ASSET_PREFIX, `${id}.json`);
+}
+
+function nowIso(now: Date): string {
+  return now.toISOString();
+}
+
+function stableJson(value: unknown): string {
+  if (value === null) return 'null';
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? String(value) : 'null';
+  }
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableJson(entry ?? null)).join(',')}]`;
+  }
+  if (typeof value !== 'object') return 'null';
+
+  const record = value as Record<string, unknown>;
+  const parts = Object.keys(record)
+    .filter((key) => record[key] !== undefined)
+    .sort((left, right) => (left < right ? -1 : left > right ? 1 : 0))
+    .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`);
+  return `{${parts.join(',')}}`;
+}
+
+export function canonicalWebhookBody(
+  envelope: A2AEnvelope,
+  version = WEBHOOK_BODY_VERSION,
+): string {
+  const canonicalEnvelope = validateA2AEnvelope(envelope);
+  return stableJson({
+    ...canonicalEnvelope,
+    version,
+  });
+}
+
+export function signWebhookBody(input: {
+  body: string;
+  secret: string;
+  timestampSeconds?: number;
+}): string {
+  const timestamp = Math.trunc(input.timestampSeconds ?? Date.now() / 1000);
+  const signature = createHmac('sha256', input.secret)
+    .update(`${timestamp}.${input.body}`)
+    .digest('hex');
+  return `t=${timestamp}, v1=${signature}`;
+}
+
+function parseSignatureHeader(
+  header: string | null | undefined,
+): { timestamp: number; signature: string } | null {
+  if (!header) return null;
+  const segments = header.split(',').map((segment) => segment.trim());
+  const values = new Map<string, string>();
+  for (const segment of segments) {
+    const separator = segment.indexOf('=');
+    if (separator <= 0) continue;
+    values.set(segment.slice(0, separator), segment.slice(separator + 1));
+  }
+  const timestamp = Number(values.get('t'));
+  const signature = values.get('v1') || '';
+  if (!Number.isSafeInteger(timestamp) || timestamp <= 0) return null;
+  if (!/^[a-f0-9]{64}$/i.test(signature)) return null;
+  return { timestamp, signature: signature.toLowerCase() };
+}
+
+export function verifyWebhookSignature(
+  input: WebhookSignatureVerificationInput,
+): boolean {
+  const parsed = parseSignatureHeader(input.header);
+  if (!parsed || !input.secret) return false;
+  const now = Math.trunc((input.nowMs ?? Date.now()) / 1000);
+  const replayWindowSeconds = Math.max(
+    0,
+    Math.trunc((input.replayWindowMs ?? WEBHOOK_REPLAY_WINDOW_MS) / 1000),
+  );
+  if (Math.abs(now - parsed.timestamp) > replayWindowSeconds) return false;
+
+  const expected = signWebhookBody({
+    body: input.body,
+    secret: input.secret,
+    timestampSeconds: parsed.timestamp,
+  })
+    .split('v1=')[1]
+    ?.toLowerCase();
+  if (!expected) return false;
+
+  const expectedBuffer = Buffer.from(expected, 'hex');
+  const actualBuffer = Buffer.from(parsed.signature, 'hex');
+  return (
+    expectedBuffer.length === actualBuffer.length &&
+    timingSafeEqual(expectedBuffer, actualBuffer)
+  );
+}
+
+function parseOutboxItem(raw: string): WebhookOutboxItem | null {
+  try {
+    const parsed = JSON.parse(raw) as WebhookOutboxItem;
+    if (parsed.schemaVersion !== WEBHOOK_OUTBOX_SCHEMA_VERSION) return null;
+    validateA2AEnvelope(parsed.envelope);
+    if (
+      parsed.status !== 'pending' &&
+      parsed.status !== 'delivered' &&
+      parsed.status !== 'failed'
+    ) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function persistOutboxItem(item: WebhookOutboxItem): void {
+  syncRuntimeAssetRevisionState(
+    'a2a',
+    outboxAssetPath(item.id),
+    {
+      route: 'a2a.webhook.outbox',
+      source: 'a2a-webhook',
+    },
+    {
+      exists: true,
+      content: JSON.stringify(item),
+    },
+  );
+}
+
+export function listWebhookOutboxItems(): WebhookOutboxItem[] {
+  return listRuntimeAssetRevisionStates('a2a', {
+    assetPathPrefix: WEBHOOK_OUTBOX_ASSET_PREFIX,
+  })
+    .map((state) => parseOutboxItem(state.content))
+    .filter((item): item is WebhookOutboxItem => item !== null)
+    .sort((left, right) => {
+      const nextAttemptOrder = left.nextAttemptAt.localeCompare(
+        right.nextAttemptAt,
+      );
+      if (nextAttemptOrder !== 0) return nextAttemptOrder;
+      return left.id.localeCompare(right.id);
+    });
+}
+
+function auditSecretEscape(params: {
+  sessionId: string;
+  runId: string;
+  ref: SecretRef;
+  url: string;
+  reason: string;
+}): void {
+  recordAuditEvent({
+    sessionId: params.sessionId,
+    runId: params.runId,
+    event: {
+      type: 'secret.unsafe_escape',
+      skill: 'a2a.webhook',
+      secretRef: params.ref,
+      sinkKind: 'http',
+      host: new URL(params.url).host,
+      selector: null,
+      reason: params.reason,
+    },
+  });
+}
+
+function resolveWebhookSecret(item: WebhookOutboxItem): string {
+  const secret = resolveSecretInputUnsafe(item.secretRef, {
+    path: 'a2a.webhook.secretRef',
+    required: true,
+    reason: 'sign outbound webhook envelope',
+    audit: (handle, reason) =>
+      auditSecretEscape({
+        sessionId: resolveItemSessionId(item),
+        runId: item.runId || makeAuditRunId('a2a-webhook-secret'),
+        ref: handle.ref,
+        url: item.url,
+        reason,
+      }),
+  });
+  if (!secret) {
+    throw new Error(
+      `a2a.webhook.secretRef resolved to an empty secret for ${item.secretRef.source}:${item.secretRef.id}`,
+    );
+  }
+  return secret;
+}
+
+function makeOutboxItem(
+  envelope: A2AEnvelope,
+  descriptor: WebhookPeerDescriptor,
+  context?: TransportAdapterContext,
+  opts?: WebhookOutboundAdapterOptions,
+): WebhookOutboxItem {
+  const createdAt = new Date();
+  const createdAtIso = nowIso(createdAt);
+  return {
+    schemaVersion: WEBHOOK_OUTBOX_SCHEMA_VERSION,
+    id: randomUUID(),
+    status: 'pending',
+    envelope: validateA2AEnvelope(envelope),
+    url: descriptor.url,
+    secretRef: descriptor.secretRef,
+    signatureHeader: descriptor.signatureHeader || WEBHOOK_SIGNATURE_HEADER,
+    version: descriptor.version || WEBHOOK_BODY_VERSION,
+    attempts: 0,
+    maxAttempts: normalizePositiveInteger(
+      opts?.maxAttempts,
+      WEBHOOK_RETRY_MAX_ATTEMPTS,
+    ),
+    nextAttemptAt: createdAtIso,
+    createdAt: createdAtIso,
+    updatedAt: createdAtIso,
+    sessionId: context?.sessionId,
+    runId: context?.runId,
+    escalationTarget: context?.escalationTarget,
+  };
+}
+
+function normalizePositiveInteger(
+  value: number | undefined,
+  fallback: number,
+): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(1, Math.trunc(value as number));
+}
+
+export function enqueueWebhookEnvelope(
+  envelope: A2AEnvelope,
+  descriptor: WebhookPeerDescriptor,
+  context?: TransportAdapterContext,
+  opts?: WebhookOutboundAdapterOptions,
+): WebhookOutboxItem {
+  const item = makeOutboxItem(envelope, descriptor, context, opts);
+  persistOutboxItem(item);
+  return item;
+}
+
+function webhookSessionId(item: WebhookOutboxItem): string {
+  return `a2a:webhook:${item.envelope.thread_id}`;
+}
+
+function resolveItemSessionId(item: WebhookOutboxItem): string {
+  return item.sessionId || webhookSessionId(item);
+}
+
+function resolveItemRunId(item: WebhookOutboxItem, prefix: string): string {
+  return item.runId || makeAuditRunId(prefix);
+}
+
+function recordWebhookAudit(
+  item: WebhookOutboxItem,
+  event: Record<string, unknown> & { type: string },
+): void {
+  recordAuditEvent({
+    sessionId: resolveItemSessionId(item),
+    runId: resolveItemRunId(item, 'a2a-webhook'),
+    event,
+  });
+}
+
+function createWebhookEscalation(
+  item: WebhookOutboxItem,
+  reason: string,
+): void {
+  const sessionId = resolveItemSessionId(item);
+  const runId = resolveItemRunId(item, 'a2a-webhook');
+  const approvalId = `a2a-webhook-${item.envelope.id}`;
+  const session = createSuspendedSession({
+    sessionId,
+    approvalId,
+    prompt: [
+      'A2A webhook delivery failed.',
+      `URL: ${item.url}`,
+      `Message: ${item.envelope.id}`,
+      `Reason: ${reason}`,
+      'Reply `approved` after fixing the endpoint, or `declined` to cancel this delivery.',
+    ].join('\n'),
+    userId: item.escalationTarget?.recipient || 'operator',
+    modality: 'push',
+    expectedReturnKinds: ['approved', 'declined', 'timeout'],
+    frameSnapshot: {
+      url: 'hybridclaw://a2a/webhook-outbox',
+      title: 'A2A webhook delivery failed',
+    },
+    context: {
+      host: 'a2a.webhook',
+      pageTitle: 'Webhook delivery failure',
+    },
+    skillId: 'a2a.webhook-outbound',
+    escalationTarget: item.escalationTarget,
+  });
+  emitInteractionNeededEvent({ session, runId });
+}
+
+function failWebhookItem(
+  item: WebhookOutboxItem,
+  now: Date,
+  reason: string,
+  statusCode?: number,
+): WebhookOutboxItem {
+  const failed: WebhookOutboxItem = {
+    ...item,
+    status: 'failed',
+    attempts: item.attempts + 1,
+    updatedAt: nowIso(now),
+    lastAttemptAt: nowIso(now),
+    failedAt: nowIso(now),
+    lastError: reason,
+    ...(statusCode ? { lastStatusCode: statusCode } : {}),
+  };
+  persistOutboxItem(failed);
+  recordWebhookAudit(failed, {
+    type: 'a2a.webhook.delivery_failed',
+    reason,
+    statusCode: statusCode ?? null,
+    envelope: summarizeA2AEnvelopeForAudit(failed.envelope),
+    url: failed.url,
+  });
+  recordWebhookAudit(failed, {
+    type: 'escalation.decision',
+    action: 'a2a.webhook:deliver',
+    proposedAction: 'deliver A2A envelope via webhook transport',
+    escalationRoute: 'approval_request',
+    target: failed.escalationTarget || null,
+    stakes: 'high',
+    classifier: 'a2a.webhook-outbound',
+    classifierReasoning: [reason],
+    approvalDecision: 'required',
+    reason,
+    envelope: summarizeA2AEnvelopeForAudit(failed.envelope),
+  });
+  createWebhookEscalation(failed, reason);
+  return failed;
+}
+
+function retryWebhookItem(
+  item: WebhookOutboxItem,
+  now: Date,
+  reason: string,
+  options: Required<
+    Pick<
+      WebhookOutboxProcessOptions,
+      'baseDelayMs' | 'maxDelayMs' | 'jitterRatio' | 'random'
+    >
+  >,
+  statusCode?: number,
+): WebhookOutboxItem {
+  const attempts = item.attempts + 1;
+  const exponentialDelay = Math.min(
+    options.maxDelayMs,
+    options.baseDelayMs * 2 ** Math.max(0, attempts - 1),
+  );
+  const jitter = exponentialDelay * options.jitterRatio * options.random();
+  const delayMs = Math.max(0, Math.trunc(exponentialDelay + jitter));
+  const retry: WebhookOutboxItem = {
+    ...item,
+    attempts,
+    updatedAt: nowIso(now),
+    lastAttemptAt: nowIso(now),
+    lastError: reason,
+    nextAttemptAt: nowIso(new Date(now.getTime() + delayMs)),
+    ...(statusCode ? { lastStatusCode: statusCode } : {}),
+  };
+  persistOutboxItem(retry);
+  recordWebhookAudit(retry, {
+    type: 'a2a.webhook.delivery_retry',
+    reason,
+    attempts,
+    nextAttemptAt: retry.nextAttemptAt,
+    statusCode: statusCode ?? null,
+    envelope: summarizeA2AEnvelopeForAudit(retry.envelope),
+    url: retry.url,
+  });
+  return retry;
+}
+
+async function deliverWebhookItem(
+  item: WebhookOutboxItem,
+  opts: WebhookOutboxProcessOptions,
+): Promise<'delivered' | 'retried' | 'failed'> {
+  const now = opts.now?.() ?? new Date();
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const attemptNumber = item.attempts + 1;
+  const retryOptions = normalizeRetryOptions(opts);
+  const maxAttempts = normalizePositiveInteger(
+    opts.maxAttempts,
+    item.maxAttempts,
+  );
+  let body: string;
+  let signature: string;
+
+  try {
+    body = canonicalWebhookBody(item.envelope, item.version);
+    const secret = resolveWebhookSecret(item);
+    signature = signWebhookBody({
+      body,
+      secret,
+      timestampSeconds: Math.trunc(now.getTime() / 1000),
+    });
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    failWebhookItem(item, now, reason);
+    return 'failed';
+  }
+
+  let response: Response;
+  try {
+    response = await fetchImpl(item.url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        [item.signatureHeader]: signature,
+      },
+      body,
+    });
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    if (attemptNumber >= maxAttempts) {
+      failWebhookItem(item, now, reason);
+      return 'failed';
+    }
+    retryWebhookItem(item, now, reason, retryOptions);
+    return 'retried';
+  }
+
+  if (response.status >= 200 && response.status < 300) {
+    const delivered: WebhookOutboxItem = {
+      ...item,
+      status: 'delivered',
+      attempts: attemptNumber,
+      updatedAt: nowIso(now),
+      lastAttemptAt: nowIso(now),
+      deliveredAt: nowIso(now),
+      lastStatusCode: response.status,
+      lastError: undefined,
+    };
+    persistOutboxItem(delivered);
+    recordWebhookAudit(delivered, {
+      type: 'a2a.webhook.delivered',
+      statusCode: response.status,
+      attempts: attemptNumber,
+      envelope: summarizeA2AEnvelopeForAudit(delivered.envelope),
+      url: delivered.url,
+    });
+    return 'delivered';
+  }
+
+  const reason = `HTTP ${response.status}`;
+  if (response.status >= 400 && response.status < 500) {
+    failWebhookItem(item, now, reason, response.status);
+    return 'failed';
+  }
+
+  if (attemptNumber >= maxAttempts) {
+    failWebhookItem(item, now, reason, response.status);
+    return 'failed';
+  }
+  retryWebhookItem(item, now, reason, retryOptions, response.status);
+  return 'retried';
+}
+
+function normalizeRetryOptions(
+  opts: WebhookOutboxProcessOptions,
+): Required<
+  Pick<
+    WebhookOutboxProcessOptions,
+    'baseDelayMs' | 'maxDelayMs' | 'jitterRatio' | 'random'
+  >
+> {
+  return {
+    baseDelayMs: normalizePositiveInteger(
+      opts.baseDelayMs,
+      WEBHOOK_RETRY_BASE_DELAY_MS,
+    ),
+    maxDelayMs: normalizePositiveInteger(
+      opts.maxDelayMs,
+      WEBHOOK_RETRY_MAX_DELAY_MS,
+    ),
+    jitterRatio: Math.max(0, opts.jitterRatio ?? 0.2),
+    random: opts.random ?? Math.random,
+  };
+}
+
+export async function processWebhookOutbox(
+  opts: WebhookOutboxProcessOptions = {},
+): Promise<WebhookOutboxProcessResult> {
+  const now = opts.now?.() ?? new Date();
+  const concurrency = normalizePositiveInteger(
+    opts.concurrency,
+    WEBHOOK_OUTBOX_CONCURRENCY,
+  );
+  const due = listWebhookOutboxItems().filter(
+    (item) =>
+      item.status === 'pending' &&
+      Date.parse(item.nextAttemptAt) <= now.getTime(),
+  );
+  const result: WebhookOutboxProcessResult = {
+    processed: 0,
+    delivered: 0,
+    retried: 0,
+    failed: 0,
+  };
+
+  for (let index = 0; index < due.length; index += concurrency) {
+    const batch = due.slice(index, index + concurrency);
+    result.processed += batch.length;
+    const outcomes = await Promise.allSettled(
+      batch.map((item) => deliverWebhookItem(item, opts)),
+    );
+    for (const outcome of outcomes) {
+      if (outcome.status === 'fulfilled') {
+        result[outcome.value] += 1;
+      } else {
+        result.failed += 1;
+        logger.warn(
+          { err: outcome.reason },
+          'A2A webhook outbox delivery rejected unexpectedly',
+        );
+      }
+    }
+  }
+
+  return result;
+}
+
+async function drainWebhookOutbox(
+  source: 'startup' | 'interval',
+): Promise<void> {
+  if (webhookOutboxProcessorRunning) {
+    logger.debug(
+      { source },
+      'A2A webhook outbox drain skipped because a previous drain is still running',
+    );
+    return;
+  }
+
+  webhookOutboxProcessorRunning = true;
+  try {
+    const result = await processWebhookOutbox();
+    if (result.processed > 0) {
+      logger.info({ source, ...result }, 'A2A webhook outbox drained');
+    }
+  } catch (error) {
+    logger.warn({ source, error }, 'A2A webhook outbox drain failed');
+  } finally {
+    webhookOutboxProcessorRunning = false;
+  }
+}
+
+export function startWebhookOutboxProcessor(
+  intervalMs = WEBHOOK_OUTBOX_DRAIN_INTERVAL_MS,
+): void {
+  stopWebhookOutboxProcessor();
+  const normalizedIntervalMs = normalizePositiveInteger(
+    intervalMs,
+    WEBHOOK_OUTBOX_DRAIN_INTERVAL_MS,
+  );
+  void drainWebhookOutbox('startup');
+  webhookOutboxProcessorTimer = setInterval(() => {
+    void drainWebhookOutbox('interval');
+  }, normalizedIntervalMs);
+  logger.info(
+    { intervalMs: normalizedIntervalMs },
+    'A2A webhook outbox processor started',
+  );
+}
+
+export function stopWebhookOutboxProcessor(): void {
+  if (webhookOutboxProcessorTimer) {
+    clearInterval(webhookOutboxProcessorTimer);
+    webhookOutboxProcessorTimer = null;
+    logger.info('A2A webhook outbox processor stopped');
+  }
+  webhookOutboxProcessorRunning = false;
+}
+
+export class WebhookOutboundAdapter
+  implements TransportAdapter<WebhookOutboxItem>
+{
+  readonly transport = 'webhook' as const;
+
+  constructor(private readonly opts: WebhookOutboundAdapterOptions = {}) {}
+
+  encode(
+    envelope: A2AEnvelope,
+    descriptor?: WebhookPeerDescriptor,
+    context?: TransportAdapterContext,
+  ): WebhookOutboxItem {
+    if (!descriptor || descriptor.transport !== 'webhook') {
+      const receivedTransport = descriptor?.transport ?? 'undefined';
+      throw new Error(
+        `WebhookOutboundAdapter requires a webhook descriptor; received "${receivedTransport}".`,
+      );
+    }
+    const item = enqueueWebhookEnvelope(
+      envelope,
+      descriptor,
+      context,
+      this.opts,
+    );
+    if (this.opts.autoProcess !== false) {
+      void processWebhookOutbox().catch((error) => {
+        logger.warn({ err: error }, 'Failed to process A2A webhook outbox');
+      });
+    }
+    return item;
+  }
+
+  decode(): A2AEnvelope {
+    throw new Error(
+      'Webhook outbound adapter does not decode inbound payloads.',
+    );
+  }
+}
+
+export const webhookOutboundAdapter = new WebhookOutboundAdapter();

--- a/src/config/runtime-config-revisions.ts
+++ b/src/config/runtime-config-revisions.ts
@@ -709,19 +709,34 @@ export function getRuntimeAssetRevisionState(
 
 export function listRuntimeAssetRevisionStates(
   assetType: RuntimeRevisionAssetType,
+  opts?: { assetPathPrefix?: string },
 ): RuntimeAssetRevisionState[] {
   const normalizedAssetType = normalizeRevisionAssetType(assetType);
-  return withRevisionDatabase((database) =>
-    database
-      .prepare<[string], ConfigRevisionAssetStateRow>(
-        `SELECT config_path, current_content, actor, route, source, updated_at
+  const assetPathPrefix = opts?.assetPathPrefix;
+  return withRevisionDatabase((database) => {
+    const baseQuery = `SELECT config_path, current_content, actor, route, source, updated_at
          FROM config_revision_state
-         WHERE asset_type = ?
+         WHERE asset_type = ?`;
+    if (assetPathPrefix) {
+      return database
+        .prepare<[string, string, string], ConfigRevisionAssetStateRow>(
+          `${baseQuery}
+           AND config_path >= ?
+           AND config_path < ?
+           ORDER BY config_path ASC`,
+        )
+        .all(normalizedAssetType, assetPathPrefix, `${assetPathPrefix}\uffff`)
+        .map((row) => mapRevisionAssetStateRow(row));
+    }
+
+    return database
+      .prepare<[string], ConfigRevisionAssetStateRow>(
+        `${baseQuery}
          ORDER BY config_path ASC`,
       )
       .all(normalizedAssetType)
-      .map((row) => mapRevisionAssetStateRow(row)),
-  );
+      .map((row) => mapRevisionAssetStateRow(row));
+  });
 }
 
 export function getRuntimeConfigRevisionStateMetadata(

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -2,6 +2,10 @@ import fs from 'node:fs';
 import { AttachmentBuilder } from 'discord.js';
 import { resolveEffectiveTimezone } from '../../container/shared/workspace-time.js';
 import {
+  startWebhookOutboxProcessor,
+  stopWebhookOutboxProcessor,
+} from '../a2a/webhook-outbound.js';
+import {
   getActiveExecutorCount,
   stopAllExecutions,
 } from '../agent/executor.js';
@@ -2805,6 +2809,7 @@ function setupShutdown(broadcastShutdown: () => void): void {
       runManagedMediaCleanup('shutdown'),
     );
     stopHeartbeat();
+    stopWebhookOutboxProcessor();
     stopObservabilityIngest();
     await stopTokenUsageBuffer().catch((error) => {
       logger.debug({ error }, 'Failed to drain token usage buffer at shutdown');
@@ -3049,6 +3054,7 @@ async function main(): Promise<void> {
   const imessageActive = await startIMessageIntegration();
 
   startOrRestartHeartbeat();
+  startWebhookOutboxProcessor();
   startObservabilityIngest();
   startTokenUsageBuffer();
   startDiscoveryLoop();

--- a/tests/a2a-transport-registry.test.ts
+++ b/tests/a2a-transport-registry.test.ts
@@ -11,6 +11,7 @@ import {
   internalTransportAdapter,
   type TransportAdapter,
 } from '../src/a2a/transport-registry.ts';
+import { webhookOutboundAdapter } from '../src/a2a/webhook-outbound.ts';
 
 describe('A2A transport adapter registry', () => {
   test('resolves the default internal adapter and preserves envelope shape', () => {
@@ -39,7 +40,7 @@ describe('A2A transport adapter registry', () => {
     expect(adapter?.decode(envelope)).toEqual(envelope);
   });
 
-  test('falls through when a transport has no registered adapter', () => {
+  test('falls through when a non-webhook transport has no registered adapter', () => {
     const registry = createDefaultTransportRegistry();
 
     const unregisteredKnown = registry.resolve({
@@ -58,7 +59,7 @@ describe('A2A transport adapter registry', () => {
       transport: 'smtp',
       raw: { transport: 'smtp' },
     });
-    expect(registry.resolveByTransport('webhook')).toBeNull();
+    expect(registry.resolveByTransport('webhook')).toBe(webhookOutboundAdapter);
   });
 
   test('rejects malformed peer descriptors before adapter resolution', () => {
@@ -102,6 +103,20 @@ describe('A2A transport adapter registry', () => {
         url: 'https://hooks.example.com/a2a',
       }),
     ).toThrow('secretRef is required');
+    expect(() =>
+      normalizePeerDescriptor({
+        transport: 'webhook',
+        url: 'http://hooks.example.com/a2a',
+        secretRef: { source: 'env', id: 'A2A_WEBHOOK_SECRET' },
+      }),
+    ).toThrow('url must use https unless targeting loopback');
+    expect(() =>
+      normalizePeerDescriptor({
+        transport: 'webhook',
+        url: 'http://128.0.0.1/a2a',
+        secretRef: { source: 'env', id: 'A2A_WEBHOOK_SECRET' },
+      }),
+    ).toThrow('url must use https unless targeting loopback');
   });
 
   test('preserves raw fields for unknown transports', () => {
@@ -123,14 +138,29 @@ describe('A2A transport adapter registry', () => {
     expect(
       normalizePeerDescriptor({
         transport: 'webhook',
-        url: 'https://hooks.example.com/a2a',
+        url: 'http://127.0.0.1:8787/a2a',
         secret_ref: { source: 'env', id: 'A2A_WEBHOOK_SECRET' },
+        signature_header: 'X-Custom-Signature',
+        version: '1',
       }),
     ).toEqual({
       transport: 'webhook',
-      url: 'https://hooks.example.com/a2a',
+      url: 'http://127.0.0.1:8787/a2a',
       secretRef: { source: 'env', id: 'A2A_WEBHOOK_SECRET' },
+      signatureHeader: 'X-Custom-Signature',
+      version: '1',
     });
+  });
+
+  test('rejects unsupported webhook body versions', () => {
+    expect(() =>
+      normalizePeerDescriptor({
+        transport: 'webhook',
+        url: 'https://hooks.example.com/a2a',
+        secretRef: { source: 'env', id: 'A2A_WEBHOOK_SECRET' },
+        version: '2026-05-01',
+      }),
+    ).toThrow(/version must be 1/);
   });
 
   test('normalizes registered adapter transport keys', () => {

--- a/tests/a2a-webhook-outbound.integration.test.ts
+++ b/tests/a2a-webhook-outbound.integration.test.ts
@@ -1,0 +1,140 @@
+import http from 'node:http';
+
+import { describe, expect, test } from 'vitest';
+
+import {
+  sampleA2AWebhookEnvelope,
+  setupA2AWebhookTestEnv,
+} from './helpers/a2a-webhook-fixtures.ts';
+
+setupA2AWebhookTestEnv('hc-a2a-webhook-int-');
+
+function readRequestBody(request: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    request.on('data', (chunk: Buffer | string) => {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    });
+    request.on('error', reject);
+    request.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+  });
+}
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('receiver did not bind to a TCP port'));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+function closeServer(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+describe('A2A webhook outbound integration', () => {
+  test('stub receiver rejects old signatures after rotation and accepts new envelopes', async () => {
+    const { initDatabase } = await import('../src/memory/db.ts');
+    const runtime = await import('../src/a2a/runtime.ts');
+    const transport = await import('../src/a2a/transport-registry.ts');
+    const webhook = await import('../src/a2a/webhook-outbound.ts');
+    const secrets = await import('../src/security/runtime-secrets.ts');
+
+    initDatabase({ quiet: true });
+    const registry = new transport.TransportRegistry();
+    registry.register(
+      new webhook.WebhookOutboundAdapter({ autoProcess: false }),
+    );
+    let receiverSecret = 'old-secret';
+    const received: Array<{
+      id: string;
+      body: string;
+      signature: string;
+      accepted: boolean;
+    }> = [];
+    const server = http.createServer(async (request, response) => {
+      const body = await readRequestBody(request);
+      const signature = String(
+        request.headers[webhook.WEBHOOK_SIGNATURE_HEADER.toLowerCase()] || '',
+      );
+      const accepted = webhook.verifyWebhookSignature({
+        header: signature,
+        body,
+        secret: receiverSecret,
+      });
+      const parsed = JSON.parse(body) as { id?: string };
+      received.push({
+        id: parsed.id || '',
+        body,
+        signature,
+        accepted,
+      });
+      response.writeHead(accepted ? 202 : 401);
+      response.end();
+    });
+    const port = await listen(server);
+    const peerDescriptor = {
+      transport: 'webhook',
+      url: `http://127.0.0.1:${port}/a2a`,
+      secretRef: { source: 'store', id: 'A2A_WEBHOOK_SECRET' },
+    } as const;
+
+    try {
+      secrets.saveNamedRuntimeSecrets({ A2A_WEBHOOK_SECRET: 'old-secret' });
+      runtime.sendMessage(sampleA2AWebhookEnvelope('msg-old-secret'), {
+        peerDescriptor,
+        transportRegistry: registry,
+      });
+
+      await expect(webhook.processWebhookOutbox()).resolves.toMatchObject({
+        processed: 1,
+        delivered: 1,
+      });
+      expect(received[0]).toMatchObject({
+        id: 'msg-old-secret',
+        accepted: true,
+      });
+
+      receiverSecret = 'new-secret';
+      secrets.saveNamedRuntimeSecrets({ A2A_WEBHOOK_SECRET: 'new-secret' });
+
+      const oldReplay = await fetch(peerDescriptor.url, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          [webhook.WEBHOOK_SIGNATURE_HEADER]: received[0]?.signature || '',
+        },
+        body: received[0]?.body || '',
+      });
+      expect(oldReplay.status).toBe(401);
+      expect(received[1]).toMatchObject({
+        id: 'msg-old-secret',
+        accepted: false,
+      });
+
+      runtime.sendMessage(sampleA2AWebhookEnvelope('msg-new-secret'), {
+        peerDescriptor,
+        transportRegistry: registry,
+      });
+
+      await expect(webhook.processWebhookOutbox()).resolves.toMatchObject({
+        processed: 1,
+        delivered: 1,
+      });
+      expect(received[2]).toMatchObject({
+        id: 'msg-new-secret',
+        accepted: true,
+      });
+    } finally {
+      await closeServer(server);
+    }
+  });
+});

--- a/tests/a2a-webhook-outbound.test.ts
+++ b/tests/a2a-webhook-outbound.test.ts
@@ -1,0 +1,401 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import {
+  sampleA2AWebhookEnvelope,
+  setupA2AWebhookTestEnv,
+} from './helpers/a2a-webhook-fixtures.ts';
+
+setupA2AWebhookTestEnv('hc-a2a-webhook-');
+
+describe('A2A webhook outbound adapter', () => {
+  test('queues webhook envelopes and delivers a signed canonical body', async () => {
+    const { initDatabase } = await import('../src/memory/db.ts');
+    const runtime = await import('../src/a2a/runtime.ts');
+    const transport = await import('../src/a2a/transport-registry.ts');
+    const webhook = await import('../src/a2a/webhook-outbound.ts');
+    const secrets = await import('../src/security/runtime-secrets.ts');
+
+    initDatabase({ quiet: true });
+    secrets.saveNamedRuntimeSecrets({ A2A_WEBHOOK_SECRET: 'old-secret' });
+
+    const registry = new transport.TransportRegistry();
+    registry.register(
+      new webhook.WebhookOutboundAdapter({ autoProcess: false }),
+    );
+
+    runtime.sendMessage(sampleA2AWebhookEnvelope('msg-webhook-1'), {
+      peerDescriptor: {
+        transport: 'webhook',
+        url: 'https://hooks.example.com/a2a',
+        secretRef: { source: 'store', id: 'A2A_WEBHOOK_SECRET' },
+      },
+      transportRegistry: registry,
+      sessionId: 'session-webhook',
+      auditRunId: 'run-webhook',
+    });
+
+    expect(webhook.listWebhookOutboxItems()).toHaveLength(1);
+
+    const receivedBodies: string[] = [];
+    const receivedHeaders: string[] = [];
+    const fetchImpl = vi.fn(
+      async (_url: RequestInfo | URL, init?: RequestInit) => {
+        const body = String(init?.body || '');
+        const headers = init?.headers as Record<string, string>;
+        const signature = headers[webhook.WEBHOOK_SIGNATURE_HEADER];
+
+        receivedBodies.push(body);
+        receivedHeaders.push(signature);
+        return new Response('', { status: 200 });
+      },
+    );
+
+    await expect(
+      webhook.processWebhookOutbox({
+        fetchImpl,
+        now: () => new Date('2030-01-01T00:00:00.000Z'),
+        jitterRatio: 0,
+      }),
+    ).resolves.toEqual({
+      processed: 1,
+      delivered: 1,
+      retried: 0,
+      failed: 0,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://hooks.example.com/a2a',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'content-type': 'application/json',
+          [webhook.WEBHOOK_SIGNATURE_HEADER]: expect.stringMatching(
+            /^t=\d+, v1=[a-f0-9]{64}$/,
+          ),
+        }),
+      }),
+    );
+    expect(JSON.parse(receivedBodies[0] || '{}')).toEqual({
+      content: 'Webhook payload msg-webhook-1',
+      created_at: '2026-05-01T10:00:00.000Z',
+      id: 'msg-webhook-1',
+      intent: 'chat',
+      recipient_agent_id: 'remote@team@peer-instance',
+      sender_agent_id: 'main',
+      thread_id: 'thread-webhook',
+      version: '1',
+    });
+    expect(receivedBodies[0]).toBe(
+      '{"content":"Webhook payload msg-webhook-1","created_at":"2026-05-01T10:00:00.000Z","id":"msg-webhook-1","intent":"chat","recipient_agent_id":"remote@team@peer-instance","sender_agent_id":"main","thread_id":"thread-webhook","version":"1"}',
+    );
+    expect(
+      webhook.verifyWebhookSignature({
+        header: receivedHeaders[0],
+        body: receivedBodies[0] || '',
+        secret: 'old-secret',
+        nowMs: Date.parse('2030-01-01T00:00:00.000Z'),
+      }),
+    ).toBe(true);
+    const staleSignature = webhook.signWebhookBody({
+      body: receivedBodies[0] || '',
+      secret: 'old-secret',
+      timestampSeconds: 1_000,
+    });
+    expect(
+      webhook.verifyWebhookSignature({
+        header: staleSignature,
+        body: receivedBodies[0] || '',
+        secret: 'old-secret',
+        nowMs: Date.parse('2030-01-01T00:00:00.000Z'),
+      }),
+    ).toBe(false);
+    expect(
+      webhook.verifyWebhookSignature({
+        header: staleSignature,
+        body: receivedBodies[0] || '',
+        secret: 'old-secret',
+        nowMs: Date.parse('2030-01-01T00:00:00.000Z'),
+        replayWindowMs: Number.MAX_SAFE_INTEGER,
+      }),
+    ).toBe(true);
+    expect(webhook.listWebhookOutboxItems()[0]).toMatchObject({
+      status: 'delivered',
+      attempts: 1,
+      lastStatusCode: 200,
+    });
+    expect(receivedHeaders).toHaveLength(1);
+  });
+
+  test('fails and escalates when the webhook secret cannot be resolved', async () => {
+    const { initDatabase, getRecentStructuredAuditForSession } = await import(
+      '../src/memory/db.ts'
+    );
+    const escalation = await import('../src/gateway/interactive-escalation.ts');
+    const runtime = await import('../src/a2a/runtime.ts');
+    const transport = await import('../src/a2a/transport-registry.ts');
+    const webhook = await import('../src/a2a/webhook-outbound.ts');
+
+    initDatabase({ quiet: true });
+    const registry = new transport.TransportRegistry();
+    registry.register(
+      new webhook.WebhookOutboundAdapter({ autoProcess: false }),
+    );
+
+    runtime.sendMessage(sampleA2AWebhookEnvelope('msg-missing-secret'), {
+      peerDescriptor: {
+        transport: 'webhook',
+        url: 'https://hooks.example.com/missing-secret',
+        secretRef: { source: 'store', id: 'MISSING_WEBHOOK_SECRET' },
+      },
+      transportRegistry: registry,
+      sessionId: 'session-webhook-missing-secret',
+      auditRunId: 'run-webhook-missing-secret',
+      escalationTarget: {
+        channel: 'slack:COPS',
+        recipient: 'ops-lead',
+      },
+    });
+
+    await expect(
+      webhook.processWebhookOutbox({
+        fetchImpl: vi.fn(),
+        now: () => new Date('2030-01-01T00:00:00.000Z'),
+      }),
+    ).resolves.toMatchObject({ processed: 1, failed: 1 });
+
+    expect(
+      webhook
+        .listWebhookOutboxItems()
+        .find((item) => item.envelope.id === 'msg-missing-secret'),
+    ).toMatchObject({
+      status: 'failed',
+      attempts: 1,
+      lastError:
+        'a2a.webhook.secretRef references stored secret MISSING_WEBHOOK_SECRET but it is not set',
+    });
+    expect(
+      getRecentStructuredAuditForSession(
+        'session-webhook-missing-secret',
+        10,
+      ).map((event) => event.event_type),
+    ).toContain('a2a.webhook.delivery_failed');
+    expect(
+      escalation.getSuspendedSession('session-webhook-missing-secret'),
+    ).toMatchObject({
+      approvalId: 'a2a-webhook-msg-missing-secret',
+      status: 'pending',
+    });
+  });
+
+  test('processes due webhook deliveries with bounded concurrency', async () => {
+    const { initDatabase } = await import('../src/memory/db.ts');
+    const runtime = await import('../src/a2a/runtime.ts');
+    const transport = await import('../src/a2a/transport-registry.ts');
+    const webhook = await import('../src/a2a/webhook-outbound.ts');
+    const secrets = await import('../src/security/runtime-secrets.ts');
+
+    initDatabase({ quiet: true });
+    secrets.saveNamedRuntimeSecrets({
+      A2A_WEBHOOK_SECRET: 'concurrent-secret',
+    });
+    const registry = new transport.TransportRegistry();
+    registry.register(
+      new webhook.WebhookOutboundAdapter({ autoProcess: false }),
+    );
+
+    for (const id of ['msg-c1', 'msg-c2', 'msg-c3', 'msg-c4']) {
+      runtime.sendMessage(sampleA2AWebhookEnvelope(id), {
+        peerDescriptor: {
+          transport: 'webhook',
+          url: `https://hooks.example.com/${id}`,
+          secretRef: { source: 'store', id: 'A2A_WEBHOOK_SECRET' },
+        },
+        transportRegistry: registry,
+      });
+    }
+
+    let active = 0;
+    let maxActive = 0;
+    const fetchImpl = vi.fn(async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active -= 1;
+      return new Response('', { status: 200 });
+    });
+
+    await expect(
+      webhook.processWebhookOutbox({
+        fetchImpl,
+        concurrency: 2,
+      }),
+    ).resolves.toMatchObject({
+      processed: 4,
+      delivered: 4,
+    });
+    expect(maxActive).toBe(2);
+  });
+
+  test('processor startup sweep drains retried items without another send', async () => {
+    vi.useFakeTimers({ now: new Date('2030-01-01T00:00:00.000Z') });
+    const { initDatabase } = await import('../src/memory/db.ts');
+    const runtime = await import('../src/a2a/runtime.ts');
+    const transport = await import('../src/a2a/transport-registry.ts');
+    const webhook = await import('../src/a2a/webhook-outbound.ts');
+    const secrets = await import('../src/security/runtime-secrets.ts');
+
+    initDatabase({ quiet: true });
+    secrets.saveNamedRuntimeSecrets({ A2A_WEBHOOK_SECRET: 'startup-secret' });
+    const registry = new transport.TransportRegistry();
+    registry.register(
+      new webhook.WebhookOutboundAdapter({ autoProcess: false }),
+    );
+    runtime.sendMessage(sampleA2AWebhookEnvelope('msg-startup-sweep'), {
+      peerDescriptor: {
+        transport: 'webhook',
+        url: 'https://hooks.example.com/startup-sweep',
+        secretRef: { source: 'store', id: 'A2A_WEBHOOK_SECRET' },
+      },
+      transportRegistry: registry,
+    });
+
+    await expect(
+      webhook.processWebhookOutbox({
+        fetchImpl: vi.fn().mockResolvedValue(new Response('', { status: 503 })),
+        now: () => new Date(),
+        jitterRatio: 0,
+      }),
+    ).resolves.toMatchObject({ processed: 1, retried: 1 });
+
+    vi.setSystemTime(new Date('2030-01-01T00:00:02.000Z'));
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(new Response('', { status: 202 }));
+    vi.stubGlobal('fetch', fetchImpl);
+    try {
+      webhook.startWebhookOutboxProcessor(1_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    } finally {
+      webhook.stopWebhookOutboxProcessor();
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(
+      webhook
+        .listWebhookOutboxItems()
+        .find((item) => item.envelope.id === 'msg-startup-sweep'),
+    ).toMatchObject({
+      status: 'delivered',
+      attempts: 2,
+    });
+  });
+
+  test('retries transient failures and fails fast on 4xx responses', async () => {
+    const { initDatabase, getRecentStructuredAuditForSession } = await import(
+      '../src/memory/db.ts'
+    );
+    const escalation = await import('../src/gateway/interactive-escalation.ts');
+    const runtime = await import('../src/a2a/runtime.ts');
+    const transport = await import('../src/a2a/transport-registry.ts');
+    const webhook = await import('../src/a2a/webhook-outbound.ts');
+    const secrets = await import('../src/security/runtime-secrets.ts');
+
+    initDatabase({ quiet: true });
+    secrets.saveNamedRuntimeSecrets({ A2A_WEBHOOK_SECRET: 'retry-secret' });
+
+    const registry = new transport.TransportRegistry();
+    registry.register(
+      new webhook.WebhookOutboundAdapter({
+        autoProcess: false,
+        maxAttempts: 2,
+      }),
+    );
+
+    runtime.sendMessage(sampleA2AWebhookEnvelope('msg-retry'), {
+      peerDescriptor: {
+        transport: 'webhook',
+        url: 'https://hooks.example.com/retry',
+        secretRef: { source: 'store', id: 'A2A_WEBHOOK_SECRET' },
+      },
+      transportRegistry: registry,
+      sessionId: 'session-webhook-retry',
+      auditRunId: 'run-webhook-retry',
+    });
+
+    const retryFetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('', { status: 503 }))
+      .mockResolvedValueOnce(new Response('', { status: 202 }));
+    await expect(
+      webhook.processWebhookOutbox({
+        fetchImpl: retryFetch,
+        now: () => new Date('2030-01-01T00:00:00.000Z'),
+        jitterRatio: 0,
+      }),
+    ).resolves.toMatchObject({ processed: 1, retried: 1 });
+    expect(webhook.listWebhookOutboxItems()[0]).toMatchObject({
+      status: 'pending',
+      attempts: 1,
+      lastStatusCode: 503,
+      nextAttemptAt: '2030-01-01T00:00:01.000Z',
+    });
+
+    await expect(
+      webhook.processWebhookOutbox({
+        fetchImpl: retryFetch,
+        now: () => new Date('2030-01-01T00:00:01.000Z'),
+        jitterRatio: 0,
+      }),
+    ).resolves.toMatchObject({ processed: 1, delivered: 1 });
+
+    runtime.sendMessage(sampleA2AWebhookEnvelope('msg-fail-fast'), {
+      peerDescriptor: {
+        transport: 'webhook',
+        url: 'https://hooks.example.com/fail-fast',
+        secretRef: { source: 'store', id: 'A2A_WEBHOOK_SECRET' },
+      },
+      transportRegistry: registry,
+      sessionId: 'session-webhook-fail',
+      auditRunId: 'run-webhook-fail',
+      escalationTarget: {
+        channel: 'slack:COPS',
+        recipient: 'ops-lead',
+      },
+    });
+
+    await expect(
+      webhook.processWebhookOutbox({
+        fetchImpl: vi.fn().mockResolvedValue(new Response('', { status: 401 })),
+        now: () => new Date('2030-01-01T00:00:02.000Z'),
+      }),
+    ).resolves.toMatchObject({ processed: 1, failed: 1 });
+
+    expect(
+      webhook
+        .listWebhookOutboxItems()
+        .find((item) => item.envelope.id === 'msg-fail-fast'),
+    ).toMatchObject({
+      status: 'failed',
+      attempts: 1,
+      lastStatusCode: 401,
+    });
+    expect(
+      getRecentStructuredAuditForSession('session-webhook-fail', 10).map(
+        (event) => event.event_type,
+      ),
+    ).toContain('a2a.webhook.delivery_failed');
+    expect(
+      escalation.getSuspendedSession('session-webhook-fail'),
+    ).toMatchObject({
+      approvalId: 'a2a-webhook-msg-fail-fast',
+      status: 'pending',
+      escalationTarget: {
+        channel: 'slack:COPS',
+        recipient: 'ops-lead',
+      },
+    });
+  });
+});

--- a/tests/gateway-main.test.ts
+++ b/tests/gateway-main.test.ts
@@ -278,6 +278,8 @@ function createGatewayMainTestState(options?: {
       setReady: vi.fn(),
     })),
     startHeartbeat: vi.fn(),
+    startWebhookOutboxProcessor: vi.fn(),
+    stopWebhookOutboxProcessor: vi.fn(),
     startDiscoveryLoop: vi.fn(),
     hybridAIProbeGet: vi.fn(async () => ({})),
     localBackendsProbeGet: vi.fn(async () => new Map()),
@@ -577,6 +579,10 @@ async function importFreshGatewayMain(options?: {
     startHeartbeat: state.startHeartbeat,
     stopHeartbeat: vi.fn(),
   }));
+  vi.doMock('../src/a2a/webhook-outbound.js', () => ({
+    startWebhookOutboxProcessor: state.startWebhookOutboxProcessor,
+    stopWebhookOutboxProcessor: state.stopWebhookOutboxProcessor,
+  }));
   vi.doMock('../src/scheduler/scheduler.js', () => ({
     rearmScheduler: state.rearmScheduler,
     startScheduler: state.startScheduler,
@@ -666,6 +672,7 @@ useCleanMocks({
     '../src/memory/db.js',
     '../src/memory/memory-service.js',
     '../src/agents/agent-registry.js',
+    '../src/a2a/webhook-outbound.js',
     '../src/providers/local-discovery.js',
     '../src/providers/local-health.js',
     '../src/scheduler/heartbeat.js',
@@ -696,6 +703,7 @@ describe('gateway bootstrap', () => {
       1_000,
       expect.any(Function),
     );
+    expect(state.startWebhookOutboxProcessor).toHaveBeenCalledTimes(1);
     expect(state.startDiscoveryLoop).toHaveBeenCalledTimes(1);
     expect(state.startObservabilityIngest).toHaveBeenCalledTimes(1);
     expect(state.startScheduler).toHaveBeenCalledTimes(1);

--- a/tests/helpers/a2a-webhook-fixtures.ts
+++ b/tests/helpers/a2a-webhook-fixtures.ts
@@ -1,0 +1,48 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, vi } from 'vitest';
+
+function restoreEnvVar(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+export function setupA2AWebhookTestEnv(tempHomePrefix: string): void {
+  const originalDataDir = process.env.HYBRIDCLAW_DATA_DIR;
+  const originalHome = process.env.HOME;
+  let tmpDir = '';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), tempHomePrefix));
+    process.env.HYBRIDCLAW_DATA_DIR = tmpDir;
+    process.env.HOME = tmpDir;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreEnvVar('HYBRIDCLAW_DATA_DIR', originalDataDir);
+    restoreEnvVar('HOME', originalHome);
+    vi.resetModules();
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = '';
+    }
+  });
+}
+
+export function sampleA2AWebhookEnvelope(id: string) {
+  return {
+    id,
+    sender_agent_id: 'main',
+    recipient_agent_id: 'remote@team@peer-instance',
+    thread_id: 'thread-webhook',
+    intent: 'chat',
+    content: `Webhook payload ${id}`,
+    created_at: '2026-05-01T10:00:00.000Z',
+  };
+}


### PR DESCRIPTION
## Summary

Implements the Roadmap 1.13 webhook outbound adapter for #768.

- Registers `WebhookOutboundAdapter` under the existing A2A transport registry as `transport: "webhook"`.
- Extends webhook peer descriptors with `url`, `secretRef`, `signatureHeader?`, and `version?`.
- Adds canonical JSON webhook bodies, HMAC-SHA256 signatures, replay-window verification, durable outbox persistence, exponential retry with jitter, fail-fast 4xx handling, and audit/escalation on terminal failure.
- Adds unit coverage plus an integration test with a real stub HTTP receiver that verifies signatures and rejects old envelopes after secret rotation.

Closes #768.

## Validation

- `npx biome check --write src/a2a/peer-descriptor.ts src/a2a/transport-registry.ts src/a2a/webhook-outbound.ts tests/a2a-transport-registry.test.ts tests/a2a-webhook-outbound.test.ts tests/a2a-webhook-outbound.integration.test.ts`
- `npx vitest run tests/a2a-transport-registry.test.ts tests/a2a-webhook-outbound.test.ts`
- `npx vitest run --config vitest.integration.config.ts tests/a2a-webhook-outbound.integration.test.ts tests/a2a-runtime.integration.test.ts`
- `npm run typecheck`