### PR TITLE
[codex] Permit secret routes in workspace policy

### DIFF
--- a/src/cli/secret-command.ts
+++ b/src/cli/secret-command.ts
@@ -13,7 +13,9 @@ import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import { agentWorkspaceDir } from '../infra/ipc.js';
 import {
   allowHttpSecretRouteInWorkspacePolicy,
+  captureHttpSecretRoutePolicySnapshot,
   removeHttpSecretRouteFromWorkspacePolicy,
+  restoreHttpSecretRoutePolicySnapshot,
 } from '../policy/secret-route-policy.js';
 import {
   isReservedNonSecretRuntimeName,
@@ -220,36 +222,44 @@ export async function handleSecretCommand(args: string[]): Promise<void> {
       }
       const header = normalizeSecretRouteHeader(rawHeader);
       const prefix = normalizeSecretRoutePrefix(rawAuthPrefix);
-      updateRuntimeConfig(
-        (draft) => {
-          const nextRule: RuntimeHttpRequestAuthRule = {
-            urlPrefix,
-            header,
-            prefix,
-            secret,
-          };
-          draft.tools.httpRequest.authRules =
-            draft.tools.httpRequest.authRules.filter(
-              (rule) =>
-                !(
-                  rule.urlPrefix === urlPrefix &&
-                  rule.header.toLowerCase() === header.toLowerCase()
-                ),
-            );
-          draft.tools.httpRequest.authRules.push(nextRule);
-        },
-        {
-          route: `cli.secret.route.add:${urlPrefix}:${header}`,
-          source: 'internal',
-        },
-      );
+      const policyWorkspacePath = agentWorkspaceDir(DEFAULT_AGENT_ID);
+      const policySnapshot =
+        captureHttpSecretRoutePolicySnapshot(policyWorkspacePath);
       const policyRuleId = allowHttpSecretRouteInWorkspacePolicy({
-        workspacePath: agentWorkspaceDir(DEFAULT_AGENT_ID),
+        workspacePath: policyWorkspacePath,
         urlPrefix,
         header,
         secret,
         agentId: DEFAULT_AGENT_ID,
       });
+      try {
+        updateRuntimeConfig(
+          (draft) => {
+            const nextRule: RuntimeHttpRequestAuthRule = {
+              urlPrefix,
+              header,
+              prefix,
+              secret,
+            };
+            draft.tools.httpRequest.authRules =
+              draft.tools.httpRequest.authRules.filter(
+                (rule) =>
+                  !(
+                    rule.urlPrefix === urlPrefix &&
+                    rule.header.toLowerCase() === header.toLowerCase()
+                  ),
+              );
+            draft.tools.httpRequest.authRules.push(nextRule);
+          },
+          {
+            route: `cli.secret.route.add:${urlPrefix}:${header}`,
+            source: 'internal',
+          },
+        );
+      } catch (error) {
+        restoreHttpSecretRoutePolicySnapshot(policySnapshot);
+        throw error;
+      }
       const authLabel = prefix
         ? `${header}: ${prefix} <secret>`
         : `${header}: <secret>`;
@@ -283,36 +293,43 @@ export async function handleSecretCommand(args: string[]): Promise<void> {
           return true;
         },
       );
-      let removed = 0;
-      updateRuntimeConfig(
-        (draft) => {
-          const before = draft.tools.httpRequest.authRules.length;
-          draft.tools.httpRequest.authRules =
-            draft.tools.httpRequest.authRules.filter((rule) => {
-              if (rule.urlPrefix !== urlPrefix) return true;
-              if (
-                header &&
-                rule.header.toLowerCase() !== header.toLowerCase()
-              ) {
-                return true;
-              }
-              return false;
-            });
-          removed = before - draft.tools.httpRequest.authRules.length;
-        },
-        {
-          route: `cli.secret.route.remove:${urlPrefix}:${header || '*'}`,
-          source: 'internal',
-        },
-      );
+      const policyWorkspacePath = agentWorkspaceDir(DEFAULT_AGENT_ID);
+      const policySnapshot =
+        captureHttpSecretRoutePolicySnapshot(policyWorkspacePath);
       for (const rule of currentRules) {
         removeHttpSecretRouteFromWorkspacePolicy({
-          workspacePath: agentWorkspaceDir(DEFAULT_AGENT_ID),
+          workspacePath: policyWorkspacePath,
           urlPrefix,
           header: rule.header,
-          secret: rule.secret,
           agentId: DEFAULT_AGENT_ID,
         });
+      }
+      let removed = 0;
+      try {
+        updateRuntimeConfig(
+          (draft) => {
+            const before = draft.tools.httpRequest.authRules.length;
+            draft.tools.httpRequest.authRules =
+              draft.tools.httpRequest.authRules.filter((rule) => {
+                if (rule.urlPrefix !== urlPrefix) return true;
+                if (
+                  header &&
+                  rule.header.toLowerCase() !== header.toLowerCase()
+                ) {
+                  return true;
+                }
+                return false;
+              });
+            removed = before - draft.tools.httpRequest.authRules.length;
+          },
+          {
+            route: `cli.secret.route.remove:${urlPrefix}:${header || '*'}`,
+            source: 'internal',
+          },
+        );
+      } catch (error) {
+        restoreHttpSecretRoutePolicySnapshot(policySnapshot);
+        throw error;
       }
       console.log(
         removed > 0

--- a/src/cli/secret-command.ts
+++ b/src/cli/secret-command.ts
@@ -9,6 +9,12 @@ import {
   runtimeConfigPath,
   updateRuntimeConfig,
 } from '../config/runtime-config.js';
+import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
+import { agentWorkspaceDir } from '../infra/ipc.js';
+import {
+  allowHttpSecretRouteInWorkspacePolicy,
+  removeHttpSecretRouteFromWorkspacePolicy,
+} from '../policy/secret-route-policy.js';
 import {
   isReservedNonSecretRuntimeName,
   isRuntimeSecretName,
@@ -237,6 +243,13 @@ export async function handleSecretCommand(args: string[]): Promise<void> {
           source: 'internal',
         },
       );
+      const policyRuleId = allowHttpSecretRouteInWorkspacePolicy({
+        workspacePath: agentWorkspaceDir(DEFAULT_AGENT_ID),
+        urlPrefix,
+        header,
+        secret,
+        agentId: DEFAULT_AGENT_ID,
+      });
       const authLabel = prefix
         ? `${header}: ${prefix} <secret>`
         : `${header}: <secret>`;
@@ -244,6 +257,9 @@ export async function handleSecretCommand(args: string[]): Promise<void> {
         `Added secret route for \`${urlPrefix}\` using \`${formatRouteSecretLabel(secret)}\` as \`${authLabel}\`.`,
       );
       console.log(`Updated runtime config at ${runtimeConfigPath()}.`);
+      if (policyRuleId) {
+        console.log(`Allowed this route in secret policy rule \`${policyRuleId}\`.`);
+      }
       return;
     }
 
@@ -258,6 +274,15 @@ export async function handleSecretCommand(args: string[]): Promise<void> {
       }
       const urlPrefix = normalizeUrlPrefix(rawPrefix);
       const header = rawHeader ? normalizeSecretRouteHeader(rawHeader) : '';
+      const currentRules = getRuntimeConfig().tools.httpRequest.authRules.filter(
+        (rule) => {
+          if (rule.urlPrefix !== urlPrefix) return false;
+          if (header && rule.header.toLowerCase() !== header.toLowerCase()) {
+            return false;
+          }
+          return true;
+        },
+      );
       let removed = 0;
       updateRuntimeConfig(
         (draft) => {
@@ -280,6 +305,15 @@ export async function handleSecretCommand(args: string[]): Promise<void> {
           source: 'internal',
         },
       );
+      for (const rule of currentRules) {
+        removeHttpSecretRouteFromWorkspacePolicy({
+          workspacePath: agentWorkspaceDir(DEFAULT_AGENT_ID),
+          urlPrefix,
+          header: rule.header,
+          secret: rule.secret,
+          agentId: DEFAULT_AGENT_ID,
+        });
+      }
       console.log(
         removed > 0
           ? `Removed ${removed} secret route${removed === 1 ? '' : 's'} for \`${urlPrefix}\`.`

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -220,6 +220,10 @@ import {
   updatePolicyRule,
 } from '../policy/policy-store.js';
 import {
+  allowHttpSecretRouteInWorkspacePolicy,
+  removeHttpSecretRouteFromWorkspacePolicy,
+} from '../policy/secret-route-policy.js';
+import {
   discoverCodexModels,
   getDiscoveredCodexModelNames,
 } from '../providers/codex-discovery.js';
@@ -9082,8 +9086,16 @@ export async function handleGatewayCommand(
                         rule.urlPrefix === urlPrefix &&
                         rule.header.toLowerCase() === header.toLowerCase()
                       ),
-                  );
+                );
                 draft.tools.httpRequest.authRules.push(nextRule);
+              });
+              const agentId = resolveSessionAgentId(session);
+              allowHttpSecretRouteInWorkspacePolicy({
+                workspacePath: agentWorkspaceDir(agentId),
+                urlPrefix,
+                header,
+                secret,
+                agentId,
               });
               const authLabel = prefix
                 ? `${header}: ${prefix} <secret>`
@@ -9113,6 +9125,19 @@ export async function handleGatewayCommand(
               const header = rawHeader
                 ? normalizeSecretRouteHeader(rawHeader)
                 : '';
+              const currentRules =
+                getRuntimeConfig().tools.httpRequest.authRules.filter(
+                  (rule) => {
+                    if (rule.urlPrefix !== urlPrefix) return false;
+                    if (
+                      header &&
+                      rule.header.toLowerCase() !== header.toLowerCase()
+                    ) {
+                      return false;
+                    }
+                    return true;
+                  },
+                );
               let removed = 0;
               updateRuntimeConfig((draft) => {
                 const before = draft.tools.httpRequest.authRules.length;
@@ -9126,9 +9151,19 @@ export async function handleGatewayCommand(
                       return true;
                     }
                     return false;
-                  });
+                });
                 removed = before - draft.tools.httpRequest.authRules.length;
               });
+              const agentId = resolveSessionAgentId(session);
+              for (const rule of currentRules) {
+                removeHttpSecretRouteFromWorkspacePolicy({
+                  workspacePath: agentWorkspaceDir(agentId),
+                  urlPrefix,
+                  header: rule.header,
+                  secret: rule.secret,
+                  agentId,
+                });
+              }
               return plainCommand(
                 removed > 0
                   ? `Removed ${removed} secret route${removed === 1 ? '' : 's'} for \`${urlPrefix}\`.`

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -221,7 +221,9 @@ import {
 } from '../policy/policy-store.js';
 import {
   allowHttpSecretRouteInWorkspacePolicy,
+  captureHttpSecretRoutePolicySnapshot,
   removeHttpSecretRouteFromWorkspacePolicy,
+  restoreHttpSecretRoutePolicySnapshot,
 } from '../policy/secret-route-policy.js';
 import {
   discoverCodexModels,
@@ -9072,31 +9074,39 @@ export async function handleGatewayCommand(
               }
               const header = normalizeSecretRouteHeader(rawHeader);
               const prefix = normalizeSecretRoutePrefix(rawAuthPrefix);
-              updateRuntimeConfig((draft) => {
-                const nextRule: RuntimeHttpRequestAuthRule = {
-                  urlPrefix,
-                  header,
-                  prefix,
-                  secret,
-                };
-                draft.tools.httpRequest.authRules =
-                  draft.tools.httpRequest.authRules.filter(
-                    (rule) =>
-                      !(
-                        rule.urlPrefix === urlPrefix &&
-                        rule.header.toLowerCase() === header.toLowerCase()
-                      ),
-                );
-                draft.tools.httpRequest.authRules.push(nextRule);
-              });
               const agentId = resolveSessionAgentId(session);
+              const policyWorkspacePath = agentWorkspaceDir(agentId);
+              const policySnapshot =
+                captureHttpSecretRoutePolicySnapshot(policyWorkspacePath);
               allowHttpSecretRouteInWorkspacePolicy({
-                workspacePath: agentWorkspaceDir(agentId),
+                workspacePath: policyWorkspacePath,
                 urlPrefix,
                 header,
                 secret,
                 agentId,
               });
+              try {
+                updateRuntimeConfig((draft) => {
+                  const nextRule: RuntimeHttpRequestAuthRule = {
+                    urlPrefix,
+                    header,
+                    prefix,
+                    secret,
+                  };
+                  draft.tools.httpRequest.authRules =
+                    draft.tools.httpRequest.authRules.filter(
+                      (rule) =>
+                        !(
+                          rule.urlPrefix === urlPrefix &&
+                          rule.header.toLowerCase() === header.toLowerCase()
+                        ),
+                    );
+                  draft.tools.httpRequest.authRules.push(nextRule);
+                });
+              } catch (error) {
+                restoreHttpSecretRoutePolicySnapshot(policySnapshot);
+                throw error;
+              }
               const authLabel = prefix
                 ? `${header}: ${prefix} <secret>`
                 : `${header}: <secret>`;
@@ -9138,31 +9148,38 @@ export async function handleGatewayCommand(
                     return true;
                   },
                 );
-              let removed = 0;
-              updateRuntimeConfig((draft) => {
-                const before = draft.tools.httpRequest.authRules.length;
-                draft.tools.httpRequest.authRules =
-                  draft.tools.httpRequest.authRules.filter((rule) => {
-                    if (rule.urlPrefix !== urlPrefix) return true;
-                    if (
-                      header &&
-                      rule.header.toLowerCase() !== header.toLowerCase()
-                    ) {
-                      return true;
-                    }
-                    return false;
-                });
-                removed = before - draft.tools.httpRequest.authRules.length;
-              });
               const agentId = resolveSessionAgentId(session);
+              const policyWorkspacePath = agentWorkspaceDir(agentId);
+              const policySnapshot =
+                captureHttpSecretRoutePolicySnapshot(policyWorkspacePath);
               for (const rule of currentRules) {
                 removeHttpSecretRouteFromWorkspacePolicy({
-                  workspacePath: agentWorkspaceDir(agentId),
+                  workspacePath: policyWorkspacePath,
                   urlPrefix,
                   header: rule.header,
-                  secret: rule.secret,
                   agentId,
                 });
+              }
+              let removed = 0;
+              try {
+                updateRuntimeConfig((draft) => {
+                  const before = draft.tools.httpRequest.authRules.length;
+                  draft.tools.httpRequest.authRules =
+                    draft.tools.httpRequest.authRules.filter((rule) => {
+                      if (rule.urlPrefix !== urlPrefix) return true;
+                      if (
+                        header &&
+                        rule.header.toLowerCase() !== header.toLowerCase()
+                      ) {
+                        return true;
+                      }
+                      return false;
+                    });
+                  removed = before - draft.tools.httpRequest.authRules.length;
+                });
+              } catch (error) {
+                restoreHttpSecretRoutePolicySnapshot(policySnapshot);
+                throw error;
               }
               return plainCommand(
                 removed > 0

--- a/src/policy/secret-route-policy.ts
+++ b/src/policy/secret-route-policy.ts
@@ -19,6 +19,12 @@ type SecretRoutePolicyTarget = {
   secretId: string;
 };
 
+export type SecretRoutePolicySnapshot = {
+  policyPath: string;
+  exists: boolean;
+  content: string | null;
+};
+
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -42,6 +48,33 @@ function writeRawPolicyObject(
 ): void {
   fs.mkdirSync(path.dirname(policyPath), { recursive: true });
   fs.writeFileSync(policyPath, YAML.stringify(document), 'utf-8');
+}
+
+export function captureHttpSecretRoutePolicySnapshot(workspacePath: string): SecretRoutePolicySnapshot {
+  const policyPath = resolveWorkspacePolicyPath(workspacePath);
+  if (!fs.existsSync(policyPath)) {
+    return {
+      policyPath,
+      exists: false,
+      content: null,
+    };
+  }
+  return {
+    policyPath,
+    exists: true,
+    content: fs.readFileSync(policyPath, 'utf-8'),
+  };
+}
+
+export function restoreHttpSecretRoutePolicySnapshot(snapshot: SecretRoutePolicySnapshot): void {
+  if (!snapshot.exists) {
+    if (fs.existsSync(snapshot.policyPath)) {
+      fs.unlinkSync(snapshot.policyPath);
+    }
+    return;
+  }
+  fs.mkdirSync(path.dirname(snapshot.policyPath), { recursive: true });
+  fs.writeFileSync(snapshot.policyPath, snapshot.content || '', 'utf-8');
 }
 
 function routePolicyTarget(
@@ -111,6 +144,26 @@ function secretRouteRule(params: {
   };
 }
 
+function isManagedSecretRouteRuleForRoute(
+  rule: unknown,
+  params: {
+    agentId: string;
+    host: string;
+    header: string;
+  },
+): boolean {
+  const record = asRecord(rule);
+  if (record[MANAGED_BY_SECRET_ROUTE_FIELD] !== true) return false;
+  const when = asRecord(record.when);
+  return (
+    when.predicate === 'secret_resolve_allowed' &&
+    when.sink === 'http' &&
+    when.host === params.host &&
+    when.selector === params.header &&
+    when.agent === params.agentId
+  );
+}
+
 export function allowHttpSecretRouteInWorkspacePolicy(params: {
   workspacePath: string;
   urlPrefix: string;
@@ -133,9 +186,13 @@ export function allowHttpSecretRouteInWorkspacePolicy(params: {
     header: params.header,
     target,
   });
-  const nextRuleId = String(nextRule.id);
   const nextRules = rules.filter(
-    (rule) => asRecord(rule).id !== nextRuleId,
+    (rule) =>
+      !isManagedSecretRouteRuleForRoute(rule, {
+        agentId,
+        host,
+        header: params.header,
+      }),
   );
   nextRules.push(nextRule);
   document.secret = {
@@ -143,32 +200,29 @@ export function allowHttpSecretRouteInWorkspacePolicy(params: {
     rules: nextRules,
   };
   writeRawPolicyObject(policyPath, document);
-  return nextRuleId;
+  return String(nextRule.id);
 }
 
 export function removeHttpSecretRouteFromWorkspacePolicy(params: {
   workspacePath: string;
   urlPrefix: string;
   header: string;
-  secret: RuntimeHttpRequestAuthRuleSecret;
   agentId?: string;
 }): boolean {
-  const target = routePolicyTarget(params.secret);
-  if (!target) return false;
-
   const host = new URL(params.urlPrefix).hostname;
   const agentId = params.agentId || DEFAULT_AGENT_ID;
   const policyPath = resolveWorkspacePolicyPath(params.workspacePath);
   const document = readRawPolicyObject(policyPath);
   const secret = asRecord(document.secret);
   const rules = Array.isArray(secret.rules) ? [...secret.rules] : [];
-  const ruleId = secretRouteRuleId({
-    agentId,
-    host,
-    header: params.header,
-    target,
-  });
-  const nextRules = rules.filter((rule) => asRecord(rule).id !== ruleId);
+  const nextRules = rules.filter(
+    (rule) =>
+      !isManagedSecretRouteRuleForRoute(rule, {
+        agentId,
+        host,
+        header: params.header,
+      }),
+  );
   if (nextRules.length === rules.length) return false;
   document.secret = {
     ...secret,

--- a/src/policy/secret-route-policy.ts
+++ b/src/policy/secret-route-policy.ts
@@ -1,0 +1,179 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import YAML from 'yaml';
+import {
+  isGoogleOAuthSecretRef,
+  type RuntimeHttpRequestAuthRuleSecret,
+} from '../config/runtime-config.js';
+import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
+import type { SecretRef } from '../security/secret-refs.js';
+import { resolveWorkspacePolicyPath } from './policy-store.js';
+
+const GOOGLE_WORKSPACE_CLI_TOKEN_SECRET = 'GOOGLE_WORKSPACE_CLI_TOKEN';
+const MANAGED_BY_SECRET_ROUTE_FIELD = 'managed_by_secret_route';
+
+type SecretRoutePolicyTarget = {
+  secretSource: 'env' | 'store';
+  secretId: string;
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function readRawPolicyObject(policyPath: string): Record<string, unknown> {
+  if (!fs.existsSync(policyPath)) return {};
+  const raw = fs.readFileSync(policyPath, 'utf-8');
+  const parsed = YAML.parse(raw) as unknown;
+  if (!parsed) return {};
+  if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`Policy file must contain a YAML mapping: ${policyPath}`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function writeRawPolicyObject(
+  policyPath: string,
+  document: Record<string, unknown>,
+): void {
+  fs.mkdirSync(path.dirname(policyPath), { recursive: true });
+  fs.writeFileSync(policyPath, YAML.stringify(document), 'utf-8');
+}
+
+function routePolicyTarget(
+  secret: RuntimeHttpRequestAuthRuleSecret,
+): SecretRoutePolicyTarget | null {
+  if (isGoogleOAuthSecretRef(secret)) {
+    return {
+      secretSource: 'env',
+      secretId: GOOGLE_WORKSPACE_CLI_TOKEN_SECRET,
+    };
+  }
+  if (
+    secret &&
+    typeof secret === 'object' &&
+    !Array.isArray(secret) &&
+    (secret as SecretRef).source === 'store' &&
+    typeof (secret as SecretRef).id === 'string'
+  ) {
+    return {
+      secretSource: 'store',
+      secretId: (secret as SecretRef).id,
+    };
+  }
+  return null;
+}
+
+function secretRouteRuleId(params: {
+  agentId: string;
+  host: string;
+  header: string;
+  target: SecretRoutePolicyTarget;
+}): string {
+  const hash = createHash('sha256')
+    .update(
+      [
+        params.agentId,
+        params.host.toLowerCase(),
+        params.header.toLowerCase(),
+        params.target.secretSource,
+        params.target.secretId,
+      ].join('\0'),
+    )
+    .digest('hex')
+    .slice(0, 16);
+  return `allow-http-secret-route-${hash}`;
+}
+
+function secretRouteRule(params: {
+  agentId: string;
+  host: string;
+  header: string;
+  target: SecretRoutePolicyTarget;
+}): Record<string, unknown> {
+  return {
+    id: secretRouteRuleId(params),
+    [MANAGED_BY_SECRET_ROUTE_FIELD]: true,
+    when: {
+      predicate: 'secret_resolve_allowed',
+      id: params.target.secretId,
+      source: params.target.secretSource,
+      sink: 'http',
+      host: params.host,
+      selector: params.header,
+      agent: params.agentId,
+    },
+    action: 'allow',
+  };
+}
+
+export function allowHttpSecretRouteInWorkspacePolicy(params: {
+  workspacePath: string;
+  urlPrefix: string;
+  header: string;
+  secret: RuntimeHttpRequestAuthRuleSecret;
+  agentId?: string;
+}): string | null {
+  const target = routePolicyTarget(params.secret);
+  if (!target) return null;
+
+  const host = new URL(params.urlPrefix).hostname;
+  const agentId = params.agentId || DEFAULT_AGENT_ID;
+  const policyPath = resolveWorkspacePolicyPath(params.workspacePath);
+  const document = readRawPolicyObject(policyPath);
+  const secret = asRecord(document.secret);
+  const rules = Array.isArray(secret.rules) ? [...secret.rules] : [];
+  const nextRule = secretRouteRule({
+    agentId,
+    host,
+    header: params.header,
+    target,
+  });
+  const nextRuleId = String(nextRule.id);
+  const nextRules = rules.filter(
+    (rule) => asRecord(rule).id !== nextRuleId,
+  );
+  nextRules.push(nextRule);
+  document.secret = {
+    ...secret,
+    rules: nextRules,
+  };
+  writeRawPolicyObject(policyPath, document);
+  return nextRuleId;
+}
+
+export function removeHttpSecretRouteFromWorkspacePolicy(params: {
+  workspacePath: string;
+  urlPrefix: string;
+  header: string;
+  secret: RuntimeHttpRequestAuthRuleSecret;
+  agentId?: string;
+}): boolean {
+  const target = routePolicyTarget(params.secret);
+  if (!target) return false;
+
+  const host = new URL(params.urlPrefix).hostname;
+  const agentId = params.agentId || DEFAULT_AGENT_ID;
+  const policyPath = resolveWorkspacePolicyPath(params.workspacePath);
+  const document = readRawPolicyObject(policyPath);
+  const secret = asRecord(document.secret);
+  const rules = Array.isArray(secret.rules) ? [...secret.rules] : [];
+  const ruleId = secretRouteRuleId({
+    agentId,
+    host,
+    header: params.header,
+    target,
+  });
+  const nextRules = rules.filter((rule) => asRecord(rule).id !== ruleId);
+  if (nextRules.length === rules.length) return false;
+  document.secret = {
+    ...secret,
+    rules: nextRules,
+  };
+  writeRawPolicyObject(policyPath, document);
+  return true;
+}

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -45,19 +45,23 @@ function writeRuntimeConfig(
 function readMainAgentPolicy(homeDir: string): Record<string, unknown> {
   return YAML.parse(
     fs.readFileSync(
-      path.join(
-        homeDir,
-        '.hybridclaw',
-        'data',
-        'agents',
-        'main',
-        'workspace',
-        '.hybridclaw',
-        'policy.yaml',
-      ),
+      mainAgentPolicyPath(homeDir),
       'utf-8',
     ),
   ) as Record<string, unknown>;
+}
+
+function mainAgentPolicyPath(homeDir: string): string {
+  return path.join(
+    homeDir,
+    '.hybridclaw',
+    'data',
+    'agents',
+    'main',
+    'workspace',
+    '.hybridclaw',
+    'policy.yaml',
+  );
 }
 
 function restoreEnvVar(name: string, value: string | undefined): void {
@@ -1511,6 +1515,42 @@ test('secret route add normalizes URL prefixes before saving auth rules', async 
       ],
     },
   });
+});
+
+test('secret route add does not leave runtime config changed when policy is invalid', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+  writeRuntimeConfig(homeDir);
+  const policyPath = mainAgentPolicyPath(homeDir);
+  fs.mkdirSync(path.dirname(policyPath), { recursive: true });
+  fs.writeFileSync(policyPath, 'secret:\n  rules: [\n', 'utf-8');
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+
+  const result = await handleGatewayCommand({
+    sessionId: 'session-secret-route-invalid-policy',
+    guildId: null,
+    channelId: 'tui',
+    args: [
+      'secret',
+      'route',
+      'add',
+      'https://hybridai.one/v1/',
+      'NEW_HAI_API_KEY',
+    ],
+  });
+
+  expect(result.kind).toBe('error');
+  const storedConfig = JSON.parse(
+    fs.readFileSync(path.join(homeDir, '.hybridclaw', 'config.json'), 'utf-8'),
+  ) as RuntimeConfig;
+  expect(storedConfig.tools.httpRequest.authRules).toEqual([]);
 });
 
 test('secret route add accepts Google OAuth runtime provider routes', async () => {

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { afterEach, expect, test, vi } from 'vitest';
+import YAML from 'yaml';
 import type { RuntimeConfig } from '../src/config/runtime-config.js';
 
 const ORIGINAL_HOME = process.env.HOME;
@@ -39,6 +40,24 @@ function writeRuntimeConfig(
   mutator?.(config);
   fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
   fs.chmodSync(configPath, 0o600);
+}
+
+function readMainAgentPolicy(homeDir: string): Record<string, unknown> {
+  return YAML.parse(
+    fs.readFileSync(
+      path.join(
+        homeDir,
+        '.hybridclaw',
+        'data',
+        'agents',
+        'main',
+        'workspace',
+        '.hybridclaw',
+        'policy.yaml',
+      ),
+      'utf-8',
+    ),
+  ) as Record<string, unknown>;
 }
 
 function restoreEnvVar(name: string, value: string | undefined): void {
@@ -1408,6 +1427,24 @@ test('secret commands manage encrypted secrets and HTTP auth routes', async () =
       },
     },
   ]);
+  expect(readMainAgentPolicy(homeDir)).toMatchObject({
+    secret: {
+      rules: [
+        {
+          when: {
+            predicate: 'secret_resolve_allowed',
+            id: 'NEW_HAI_API_KEY',
+            source: 'store',
+            sink: 'http',
+            host: 'hybridai.one',
+            selector: 'Authorization',
+            agent: 'main',
+          },
+          action: 'allow',
+        },
+      ],
+    },
+  });
 });
 
 test('secret route add normalizes URL prefixes before saving auth rules', async () => {
@@ -1456,6 +1493,24 @@ test('secret route add normalizes URL prefixes before saving auth rules', async 
       },
     },
   ]);
+  expect(readMainAgentPolicy(homeDir)).toMatchObject({
+    secret: {
+      rules: [
+        {
+          when: {
+            predicate: 'secret_resolve_allowed',
+            id: 'NEW_HAI_API_KEY',
+            source: 'store',
+            sink: 'http',
+            host: 'hybridai.one',
+            selector: 'Authorization',
+            agent: 'main',
+          },
+          action: 'allow',
+        },
+      ],
+    },
+  });
 });
 
 test('secret route add accepts Google OAuth runtime provider routes', async () => {
@@ -1497,6 +1552,24 @@ test('secret route add accepts Google OAuth runtime provider routes', async () =
       },
     },
   ]);
+  expect(readMainAgentPolicy(homeDir)).toMatchObject({
+    secret: {
+      rules: [
+        {
+          when: {
+            predicate: 'secret_resolve_allowed',
+            id: 'GOOGLE_WORKSPACE_CLI_TOKEN',
+            source: 'env',
+            sink: 'http',
+            host: 'analyticsadmin.googleapis.com',
+            selector: 'Authorization',
+            agent: 'main',
+          },
+          action: 'allow',
+        },
+      ],
+    },
+  });
 });
 
 test('secret route add rejects Google OAuth runtime provider routes outside googleapis', async () => {

--- a/tests/local-cli.test.ts
+++ b/tests/local-cli.test.ts
@@ -60,19 +60,23 @@ function readRuntimeConfig(homeDir: string): RuntimeConfig {
 function readMainAgentPolicy(homeDir: string): Record<string, unknown> {
   return YAML.parse(
     fs.readFileSync(
-      path.join(
-        homeDir,
-        '.hybridclaw',
-        'data',
-        'agents',
-        'main',
-        'workspace',
-        '.hybridclaw',
-        'policy.yaml',
-      ),
+      mainAgentPolicyPath(homeDir),
       'utf-8',
     ),
   ) as Record<string, unknown>;
+}
+
+function mainAgentPolicyPath(homeDir: string): string {
+  return path.join(
+    homeDir,
+    '.hybridclaw',
+    'data',
+    'agents',
+    'main',
+    'workspace',
+    '.hybridclaw',
+    'policy.yaml',
+  );
 }
 
 async function readRuntimeSecrets(
@@ -339,6 +343,117 @@ test('secret route add and remove update store-backed auth rules', async () => {
       rules: [],
     },
   });
+});
+
+test('secret route add replaces stale managed policy rules for the route', async () => {
+  const homeDir = makeTempHome();
+  const cli = await importFreshCli(homeDir);
+
+  await cli.main([
+    'secret',
+    'route',
+    'add',
+    'https://api.example.com/v1',
+    'SF_FULL_SECRET',
+    'X-API-Key',
+    'none',
+  ]);
+  await cli.main([
+    'secret',
+    'route',
+    'add',
+    'https://api.example.com/v1',
+    'SF_FULL_OTHER_SECRET',
+    'X-API-Key',
+    'none',
+  ]);
+
+  const config = readRuntimeConfig(homeDir);
+  expect(config.tools.httpRequest.authRules).toEqual([
+    {
+      urlPrefix: 'https://api.example.com/v1/',
+      header: 'X-API-Key',
+      prefix: '',
+      secret: { source: 'store', id: 'SF_FULL_OTHER_SECRET' },
+    },
+  ]);
+  const policy = readMainAgentPolicy(homeDir);
+  expect(policy).toMatchObject({
+    secret: {
+      rules: [
+        {
+          when: {
+            predicate: 'secret_resolve_allowed',
+            id: 'SF_FULL_OTHER_SECRET',
+            source: 'store',
+            sink: 'http',
+            host: 'api.example.com',
+            selector: 'X-API-Key',
+            agent: 'main',
+          },
+          action: 'allow',
+        },
+      ],
+    },
+  });
+  expect(JSON.stringify(policy)).not.toContain('SF_FULL_SECRET');
+});
+
+test('secret route add fails before runtime config changes when policy is invalid', async () => {
+  const homeDir = makeTempHome();
+  const cli = await importFreshCli(homeDir);
+  const policyPath = mainAgentPolicyPath(homeDir);
+  fs.mkdirSync(path.dirname(policyPath), { recursive: true });
+  fs.writeFileSync(policyPath, 'secret:\n  rules: [\n', 'utf-8');
+
+  await expect(
+    cli.main([
+      'secret',
+      'route',
+      'add',
+      'https://api.example.com/v1',
+      'SF_FULL_SECRET',
+      'X-API-Key',
+      'none',
+    ]),
+  ).rejects.toThrow();
+
+  expect(readRuntimeConfig(homeDir).tools.httpRequest.authRules).toEqual([]);
+});
+
+test('secret route remove fails before runtime config changes when policy is invalid', async () => {
+  const homeDir = makeTempHome();
+  const cli = await importFreshCli(homeDir);
+
+  await cli.main([
+    'secret',
+    'route',
+    'add',
+    'https://api.example.com/v1',
+    'SF_FULL_SECRET',
+    'X-API-Key',
+    'none',
+  ]);
+  fs.writeFileSync(mainAgentPolicyPath(homeDir), 'secret:\n  rules: [\n', 'utf-8');
+
+  await expect(
+    cli.main([
+      'secret',
+      'route',
+      'remove',
+      'https://api.example.com/v1',
+      'X-API-Key',
+    ]),
+  ).rejects.toThrow();
+
+  expect(readRuntimeConfig(homeDir).tools.httpRequest.authRules).toEqual([
+    {
+      urlPrefix: 'https://api.example.com/v1/',
+      header: 'X-API-Key',
+      prefix: '',
+      secret: { source: 'store', id: 'SF_FULL_SECRET' },
+    },
+  ]);
 });
 
 test('secret route add supports Google OAuth runtime auth rules', async () => {

--- a/tests/local-cli.test.ts
+++ b/tests/local-cli.test.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { afterEach, expect, test, vi } from 'vitest';
+import YAML from 'yaml';
 
 import type { RuntimeConfig } from '../src/config/runtime-config.js';
 
@@ -54,6 +55,24 @@ function readRuntimeConfig(homeDir: string): RuntimeConfig {
   return JSON.parse(
     fs.readFileSync(path.join(homeDir, '.hybridclaw', 'config.json'), 'utf-8'),
   ) as RuntimeConfig;
+}
+
+function readMainAgentPolicy(homeDir: string): Record<string, unknown> {
+  return YAML.parse(
+    fs.readFileSync(
+      path.join(
+        homeDir,
+        '.hybridclaw',
+        'data',
+        'agents',
+        'main',
+        'workspace',
+        '.hybridclaw',
+        'policy.yaml',
+      ),
+      'utf-8',
+    ),
+  ) as Record<string, unknown>;
 }
 
 async function readRuntimeSecrets(
@@ -286,6 +305,24 @@ test('secret route add and remove update store-backed auth rules', async () => {
       secret: { source: 'store', id: 'SF_FULL_SECRET' },
     },
   ]);
+  expect(readMainAgentPolicy(homeDir)).toMatchObject({
+    secret: {
+      rules: [
+        {
+          when: {
+            predicate: 'secret_resolve_allowed',
+            id: 'SF_FULL_SECRET',
+            source: 'store',
+            sink: 'http',
+            host: 'api.example.com',
+            selector: 'X-API-Key',
+            agent: 'main',
+          },
+          action: 'allow',
+        },
+      ],
+    },
+  });
 
   await cli.main([
     'secret',
@@ -297,6 +334,11 @@ test('secret route add and remove update store-backed auth rules', async () => {
 
   config = readRuntimeConfig(homeDir);
   expect(config.tools.httpRequest.authRules).toEqual([]);
+  expect(readMainAgentPolicy(homeDir)).toMatchObject({
+    secret: {
+      rules: [],
+    },
+  });
 });
 
 test('secret route add supports Google OAuth runtime auth rules', async () => {
@@ -320,6 +362,24 @@ test('secret route add supports Google OAuth runtime auth rules', async () => {
       secret: { source: 'google-oauth' },
     },
   ]);
+  expect(readMainAgentPolicy(homeDir)).toMatchObject({
+    secret: {
+      rules: [
+        {
+          when: {
+            predicate: 'secret_resolve_allowed',
+            id: 'GOOGLE_WORKSPACE_CLI_TOKEN',
+            source: 'env',
+            sink: 'http',
+            host: 'analyticsdata.googleapis.com',
+            selector: 'Authorization',
+            agent: 'main',
+          },
+          action: 'allow',
+        },
+      ],
+    },
+  });
 });
 
 test('secret route add rejects Google OAuth routes for non-Google APIs', async () => {


### PR DESCRIPTION
## Summary

Adds automatic workspace secret-policy grants when HTTP secret routes are configured. A route such as:

```bash
hybridclaw secret route add https://googleads.googleapis.com/ GOOGLEADS_DEVELOPER_TOKEN developer-token none
```

now writes the matching runtime auth rule and a scoped `secret_resolve_allowed` policy rule for the route host, header, secret source, and agent. Google OAuth HTTP routes also grant the existing `GOOGLE_WORKSPACE_CLI_TOKEN` env-backed token for Google API hosts.

## Why

The runtime config could inject HTTP auth headers, but the secret policy still denied resolving the configured secret. That made route setup feel incomplete: users had to know to edit `.hybridclaw/policy.yaml` separately after adding a route.

## Details

- Adds a managed policy helper for secret-route grants.
- Wires CLI `/secret route add/remove` and gateway command handling to create/remove managed policy rules.
- Keeps the runtime route prefix as the URL-level boundary while the policy grant remains scoped to the exact secret, host, header, and agent.
- Adds coverage for store-backed routes, route removal cleanup, normalized URL prefixes, and Google OAuth routes.

## Validation

- `npx biome check --write src/cli/secret-command.ts src/gateway/gateway-service.ts src/policy/secret-route-policy.ts tests/local-cli.test.ts tests/gateway-status.test.ts`
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/local-cli.test.ts tests/gateway-status.test.ts`