### PR TITLE
[codex] Stop TUI session run on ESC

### DIFF
--- a/src/tui-stop.ts
+++ b/src/tui-stop.ts
@@ -1,0 +1,17 @@
+export interface TuiRunStopParams<T> {
+  abortController: AbortController | null;
+  stopRequest: Promise<T> | null;
+  requestStop: () => Promise<T>;
+  clearStopRequest: () => void;
+}
+
+export function stopTuiRun<T>(params: TuiRunStopParams<T>): Promise<T> | null {
+  if (params.stopRequest) return params.stopRequest;
+  if (!params.abortController || params.abortController.signal.aborted) {
+    return null;
+  }
+
+  const stopRequest = params.requestStop().finally(params.clearStopRequest);
+  params.abortController.abort();
+  return stopRequest;
+}

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -108,6 +108,7 @@ import {
   TuiSlashMenuController,
   type TuiSlashMenuPalette,
 } from './tui-slash-menu.js';
+import { stopTuiRun } from './tui-stop.js';
 import {
   appendTerminalRowCount,
   countTerminalRows,
@@ -345,6 +346,7 @@ function formatToolPreview(preview: string | undefined): string {
 }
 
 let activeRunAbortController: AbortController | null = null;
+let activeRunStopInFlight: Promise<GatewayCommandResult> | null = null;
 let proactivePollInFlight = false;
 let delegateStatusRows = 0;
 let delegateStreamActive = false;
@@ -1778,6 +1780,18 @@ async function requestGatewayCommand(
   return result;
 }
 
+function stopActiveRun(): Promise<GatewayCommandResult> | null {
+  activeRunStopInFlight = stopTuiRun({
+    abortController: activeRunAbortController,
+    stopRequest: activeRunStopInFlight,
+    requestStop: () => requestGatewayCommand(['stop']),
+    clearStopRequest: () => {
+      activeRunStopInFlight = null;
+    },
+  });
+  return activeRunStopInFlight;
+}
+
 function collectToolNames(result: GatewayChatResult): string[] {
   const names = new Set<string>();
 
@@ -2004,9 +2018,10 @@ async function syncFullAutoStateFromGateway(
 async function runGatewayCommand(
   args: string[],
   rl: readline.Interface,
+  request: Promise<GatewayCommandResult> = requestGatewayCommand(args),
 ): Promise<void> {
   try {
-    const result = await requestGatewayCommand(args);
+    const result = await request;
     const pendingApproval =
       result.kind === 'info' ? parseTuiApprovalPrompt(result.text || '') : null;
     if (pendingApproval) {
@@ -2353,18 +2368,16 @@ async function handleSlashCommand(
       await runGatewayCommand(['status'], rl);
       return true;
     case 'stop':
-    case 'abort':
-      if (
-        activeRunAbortController &&
-        !activeRunAbortController.signal.aborted
-      ) {
-        activeRunAbortController.abort();
+    case 'abort': {
+      const stopRequest = stopActiveRun();
+      if (stopRequest) {
         printInfo('Stopping current request and disabling full-auto...');
       } else {
         printInfo('No active foreground request. Disabling full-auto...');
       }
-      await runGatewayCommand(['stop'], rl);
+      await runGatewayCommand(['stop'], rl, stopRequest ?? undefined);
       return true;
+    }
     default:
       break;
   }
@@ -2995,9 +3008,18 @@ async function main(): Promise<void> {
   if (process.stdin.isTTY) process.stdin.setRawMode(true);
   process.stdin.on('keypress', (_str, key) => {
     if (key?.name !== 'escape') return;
-    if (!activeRunAbortController || activeRunAbortController.signal.aborted)
-      return;
-    activeRunAbortController.abort();
+    const stopRequest = stopActiveRun();
+    if (!stopRequest) return;
+    void stopRequest
+      .then((result) => {
+        tuiFullAutoState = deriveTuiFullAutoState({
+          current: tuiFullAutoState,
+          args: ['stop'],
+          result,
+        });
+        refreshPrompt(rl);
+      })
+      .catch(() => {});
   });
 
   promptTuiInput(rl);
@@ -3105,6 +3127,7 @@ export async function runTui(options?: Partial<TuiRunOptions>): Promise<void> {
     String(options?.resumeCommand || 'hybridclaw tui --resume').trim() ||
     'hybridclaw tui --resume';
   activeRunAbortController = null;
+  activeRunStopInFlight = null;
   proactivePollInFlight = false;
   tuiFullAutoState = DEFAULT_TUI_FULLAUTO_STATE;
   fullAutoSteeringInFlight = false;

--- a/tests/tui-stop.test.ts
+++ b/tests/tui-stop.test.ts
@@ -1,0 +1,52 @@
+import { expect, test, vi } from 'vitest';
+
+import { stopTuiRun } from '../src/tui-stop.js';
+
+test('stopTuiRun reuses an in-flight stop request after aborting locally', async () => {
+  const abortController = new AbortController();
+  let resolveStop!: (value: string) => void;
+  const requestStop = vi.fn(
+    () =>
+      new Promise<string>((resolve) => {
+        resolveStop = resolve;
+      }),
+  );
+  const clearStopRequest = vi.fn();
+
+  const first = stopTuiRun({
+    abortController,
+    stopRequest: null,
+    requestStop,
+    clearStopRequest,
+  });
+  const second = stopTuiRun({
+    abortController,
+    stopRequest: first,
+    requestStop,
+    clearStopRequest,
+  });
+
+  expect(first).toBeTruthy();
+  expect(second).toBe(first);
+  expect(abortController.signal.aborted).toBe(true);
+  expect(requestStop).toHaveBeenCalledTimes(1);
+
+  resolveStop('stopped');
+  await first;
+  await Promise.resolve();
+  expect(clearStopRequest).toHaveBeenCalledTimes(1);
+});
+
+test('stopTuiRun ignores inactive foreground requests', () => {
+  const requestStop = vi.fn(async () => 'stopped');
+
+  expect(
+    stopTuiRun({
+      abortController: null,
+      stopRequest: null,
+      requestStop,
+      clearStopRequest: () => {},
+    }),
+  ).toBeNull();
+  expect(requestStop).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary

ESC in the TUI now sends the gateway `stop` command for the active session before aborting the foreground fetch. This stops the gateway/container/browser run instead of only making the terminal stop waiting.

The `/stop` and `/abort` handlers share the same in-flight stop request, so pressing ESC and then using `/stop` does not create duplicate gateway stop commands. The shared stop logic lives in a small helper with focused coverage for promise reuse after local abort.

## Root Cause

The previous keypress handler only called `activeRunAbortController.abort()`, which cancelled the TUI client request but did not reliably interrupt the server-side session execution.

## Validation

- `npx biome check --write src/tui.ts src/tui-stop.ts tests/tui-stop.test.ts`
- `npx vitest run tests/tui-stop.test.ts tests/tui-format.test.ts`
- `npm run lint`
- `git diff --check`