### PR TITLE
[codex] Normalize OpenRouter fallback model hints

### DIFF
--- a/src/providers/auxiliary.ts
+++ b/src/providers/auxiliary.ts
@@ -314,12 +314,13 @@ function buildOpenRouterFallbackModel(modelHint?: string): string | undefined {
     return resolveDefaultAuxiliaryModelForProvider('openrouter');
   }
 
-  const providerPrefix = detectRuntimeProviderPrefix(trimmed);
-  if (providerPrefix === 'openrouter') return trimmed;
+  const upstreamHint = stripHybridAIModelPrefix(trimmed);
+  const providerPrefix = detectRuntimeProviderPrefix(upstreamHint);
+  if (providerPrefix === 'openrouter') return upstreamHint;
   if (providerPrefix === 'anthropic') {
     return normalizeAuxiliaryProviderModel({
       provider: 'openrouter',
-      model: trimmed,
+      model: upstreamHint,
     });
   }
   if (providerPrefix) {
@@ -327,7 +328,7 @@ function buildOpenRouterFallbackModel(modelHint?: string): string | undefined {
   }
   return normalizeAuxiliaryProviderModel({
     provider: 'openrouter',
-    model: trimmed,
+    model: upstreamHint,
   });
 }
 

--- a/tests/providers.auxiliary.test.ts
+++ b/tests/providers.auxiliary.test.ts
@@ -258,6 +258,80 @@ test('host auxiliary caller strips the HybridAI display prefix from request mode
   });
 });
 
+test('host auxiliary caller supports HybridAI-routed vendor model hints', async () => {
+  const resolveTaskModelPolicy = vi.fn(async () => undefined);
+  const resolveModelRuntimeCredentials = vi.fn(async () => ({
+    provider: 'hybridai' as const,
+    apiKey: 'hybridai-key',
+    baseUrl: 'https://hybridai.one',
+    chatbotId: 'bot_123',
+    enableRag: false,
+    requestHeaders: {},
+    agentId: 'main',
+    isLocal: false,
+    contextWindow: 200_000,
+    maxTokens: 2048,
+    thinkingFormat: undefined,
+  }));
+  setupProviderMocks({
+    resolveTaskModelPolicy,
+    resolveModelRuntimeCredentials,
+  });
+
+  const fetchMock = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input).toBe('https://hybridai.one/v1/chat/completions');
+      const body = JSON.parse(String(init?.body || '{}')) as Record<
+        string,
+        unknown
+      >;
+      expect(body).toMatchObject({
+        model: 'anthropic/claude-haiku-4-5',
+        chatbot_id: 'bot_123',
+        enable_rag: false,
+      });
+      return new Response(
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                role: 'assistant',
+                content: 'HybridAI vendor model response.',
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    },
+  );
+  vi.stubGlobal('fetch', fetchMock);
+
+  const { callAuxiliaryModel } = await import('../src/providers/auxiliary.js');
+  const result = await callAuxiliaryModel({
+    task: 'compression',
+    agentId: 'main',
+    fallbackModel: 'hybridai/anthropic/claude-haiku-4-5',
+    fallbackChatbotId: 'bot_123',
+    messages: [{ role: 'user', content: 'Summarize this.' }],
+  });
+
+  expect(result).toEqual({
+    provider: 'hybridai',
+    model: 'hybridai/anthropic/claude-haiku-4-5',
+    content: 'HybridAI vendor model response.',
+  });
+  expect(resolveModelRuntimeCredentials).toHaveBeenCalledWith({
+    model: 'hybridai/anthropic/claude-haiku-4-5',
+    chatbotId: 'bot_123',
+    enableRag: false,
+    agentId: 'main',
+  });
+});
+
 test('host auxiliary caller streams Codex responses for auxiliary tasks', async () => {
   const resolveTaskModelPolicy = vi.fn(async () => undefined);
   const resolveModelRuntimeCredentials = vi.fn(async () => ({
@@ -637,4 +711,73 @@ test('host auxiliary caller falls back to openrouter when task resolution fails'
     }),
     'Auxiliary provider resolution failed; using OpenRouter fallback',
   );
+});
+
+test('host auxiliary caller strips HybridAI prefix from OpenRouter fallback hints', async () => {
+  const resolveTaskModelPolicy = vi.fn(async () => ({
+    model: 'hybridai/anthropic/claude-haiku-4-5',
+    error: 'HybridAI provider is unavailable.',
+  }));
+  const resolveModelRuntimeCredentials = vi.fn(async () => ({
+    provider: 'openrouter' as const,
+    apiKey: 'openrouter-key',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    chatbotId: '',
+    enableRag: false,
+    requestHeaders: {},
+    agentId: 'main',
+    isLocal: false,
+    contextWindow: 200_000,
+    thinkingFormat: undefined,
+  }));
+  setupProviderMocks({
+    resolveTaskModelPolicy,
+    resolveModelRuntimeCredentials,
+  });
+  vi.doMock('../src/logger.js', () => ({
+    logger: {
+      warn: vi.fn(),
+    },
+  }));
+
+  const fetchMock = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input).toBe('https://openrouter.ai/api/v1/chat/completions');
+      const body = JSON.parse(String(init?.body || '{}')) as Record<
+        string,
+        unknown
+      >;
+      expect(body.model).toBe('anthropic/claude-haiku-4-5');
+      return new Response(
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                role: 'assistant',
+                content: 'Recovered through OpenRouter fallback.',
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    },
+  );
+  vi.stubGlobal('fetch', fetchMock);
+
+  const { callAuxiliaryModel } = await import('../src/providers/auxiliary.js');
+  const result = await callAuxiliaryModel({
+    task: 'cv_narration',
+    agentId: 'main',
+    messages: [{ role: 'user', content: 'Write one CV entry.' }],
+  });
+
+  expect(result).toEqual({
+    provider: 'openrouter',
+    model: 'openrouter/anthropic/claude-haiku-4-5',
+    content: 'Recovered through OpenRouter fallback.',
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the auxiliary-provider recovery path that could pass HybridAI-routed model IDs to OpenRouter after the primary HybridAI resolution failed. A model like `hybridai/anthropic/claude-haiku-4-5` remains valid for HybridAI; the bug was that the OpenRouter recovery path reused that HybridAI wrapper when making an OpenRouter request, where the upstream model must be `anthropic/claude-haiku-4-5`.

## Changes

- Strip the outer HybridAI prefix only while building an OpenRouter fallback model hint.
- Preserve existing HybridAI routing behavior for `hybridai/anthropic/...` auxiliary fallback models.
- Preserve existing handling for OpenRouter-native hints, Anthropic vendor-scoped hints, and configured OpenRouter defaults.
- Add regression coverage for both the OpenRouter recovery failure shape and the valid HybridAI-routed vendor model path.

## Validation

- `npx vitest tests/providers.auxiliary.test.ts`
- `npm run typecheck`