### PR TITLE
[codex] Add canonical agent identity allocation

### DIFF
--- a/docs/content/developer-guide/identity.md
+++ b/docs/content/developer-guide/identity.md
@@ -51,3 +51,44 @@ Use `parseUserId()` and `formatUserId()` from `src/identity/user-id.ts` at
 boundaries instead of hand-parsing strings. Use `userIdsEqual()` or
 `compareUserIds()` when comparing IDs so case and whitespace are normalized
 before comparison.
+
+## Agent Identities
+
+HybridClaw canonical agent identities use this format:
+
+```text
+agent-slug@user@instance-id
+```
+
+Examples:
+
+```text
+support-lena@acme@inst-7f3a
+main@local@inst-550e8400-e29b-41d4-a716-446655440000
+research.agent@team_1@local-dev
+```
+
+The canonical form is lowercase ASCII. `agent-slug`, `user`, and
+`instance-id` must:
+
+- start with a lowercase letter or digit
+- contain only lowercase letters, digits, dots, underscores, or hyphens
+- be 1-128 characters long
+
+The `@` separator is required and must appear exactly twice. The `user`
+component is a routing slug derived from the agent owner or local operator, not
+an embedded `username@authority` user ID.
+
+Local HybridClaw instances allocate `instance-id` on first use and persist it
+under the runtime home at `identity/instance-id.json`. Auto-allocated IDs are
+UUID-backed and use the `inst-<uuid>` form. Once allocated, the same instance ID
+is reused for every local agent identity so remote peers can distinguish one
+stable runtime instance from another. Operators may set `HYBRIDCLAW_INSTANCE_ID`
+for explicit deployments; in that case the configured component is used as-is
+after normalization and no local state file is written.
+
+Use `parseAgentIdentity()` and `formatAgentIdentity()` from
+`src/identity/agent-id.ts` at boundaries instead of hand-parsing strings. Use
+`resolveLocalInstanceId()` for local allocation and
+`slugifyAgentIdentityComponent()` when deriving a canonical component from a
+display name, config value, or environment value.

--- a/docs/content/internal/roadmap.md
+++ b/docs/content/internal/roadmap.md
@@ -271,7 +271,7 @@ Cross-cutting work that several roadmap items depend on. Decomposed under the `f
 - ✅ **F4** — Versioning + rollback for skills, knowledge, CVs, and classifier weights. Extends `runtime-config-revisions`. Required by Principle VII.
 - ✅ **F5** — Model pricing & capability matrix on top of `model-catalog`. Required by #5 cost compute and future routing.
 - 🟡 **F6** — Deployment-mode + public-URL abstraction. See **Foundation Sub-Issues** below for F6 rows.
-- 🟡 **F7** — Global identity primitives. Agent-ID format and canonical user IDs are in production ([`src/a2a/identity.ts`](../../../src/a2a/identity.ts) + F7.1 ✅ via PR #776); instance-ID allocation, cross-instance resolver, and TOFU trust remain. See **Foundation Sub-Issues** below for F7 rows.
+- 🟡 **F7** — Global identity primitives. Agent-ID format, canonical user IDs, and local instance-ID allocation are in production ([`src/identity/agent-id.ts`](../../../src/identity/agent-id.ts), [`src/identity/user-id.ts`](../../../src/identity/user-id.ts), and F7.1 ✅ via PR #776); cross-instance resolver and TOFU trust remain. See **Foundation Sub-Issues** below for F7 rows.
 - 🟡 **F8** — Autonomy + escalation policy framework. Stakes classification and escalation routing are substantially shipped; policy-pipeline work remains. See **Foundation Sub-Issues** below for F8 rows.
 - 🟡 **F9** — Always-on runtime guarantees. Warm process pool and liveness probes are done; restart and fleet visibility remain. See **Foundation Sub-Issues** below for F9 rows.
 - 🟡 **F10** — Agent org-chart / team primitive. Schema, persistence, and resolution helpers are done; admin editing remains. See **Foundation Sub-Issues** below for F10 rows.
@@ -298,7 +298,7 @@ Use these as issue titles. Keep each issue small enough to ship independently.
 | F6.7 | Public URL | Cloudflare Tunnel provider | ⬜ #645 |
 | F6.8 | Public URL | Admin UI for tunnel provider configuration | ⬜ #681 |
 | F7.1 | Identity | Canonical user IDs | ✅ #571 via PR #776 |
-| F7.2 | Identity | Instance-ID allocation | ⬜ #572 |
+| F7.2 | Identity | Instance-ID allocation | ✅ #572 |
 | F7.3 | Identity | Cross-instance identity resolver | ⬜ #573 |
 | F7.4 | Identity | TOFU trust ledger for peer instances | ⬜ #574 |
 | F8.1 | Policy | Autonomy levels | ✅ Done |

--- a/src/a2a/envelope.ts
+++ b/src/a2a/envelope.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from 'node:crypto';
+
+import { isCanonicalAgentIdentity } from '../identity/agent-id.js';
 import { isRecord } from './utils.js';
 
 export const A2A_ENVELOPE_INTENTS = [
@@ -70,8 +72,6 @@ const A2A_ENVELOPE_FIELDS = new Set([
 ]);
 
 const LOCAL_AGENT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
-const CANONICAL_AGENT_ID_PATTERN =
-  /^[a-z0-9][a-z0-9._-]{0,127}@[a-z0-9][a-z0-9._-]{0,127}@[a-z0-9][a-z0-9._-]{0,127}$/;
 const OPAQUE_ID_DISALLOWED_PATTERN = /[\p{Cc}\s]/u;
 
 function readRequiredTrimmedString(
@@ -128,10 +128,7 @@ export function isA2AEnvelopeIntent(value: string): value is A2AEnvelopeIntent {
 
 export function classifyA2AAgentId(value: string): A2AAgentIdKind | null {
   const normalized = value.trim();
-  if (
-    normalized.includes('@') &&
-    CANONICAL_AGENT_ID_PATTERN.test(normalized.toLowerCase())
-  ) {
+  if (normalized.includes('@') && isCanonicalAgentIdentity(normalized)) {
     return 'canonical';
   }
   if (!normalized.includes('@') && LOCAL_AGENT_ID_PATTERN.test(normalized)) {

--- a/src/a2a/identity.ts
+++ b/src/a2a/identity.ts
@@ -1,36 +1,16 @@
-import { createHash } from 'node:crypto';
-import os from 'node:os';
-
 import { findAgentConfig, listAgents } from '../agents/agent-registry.js';
 import { type AgentConfig, DEFAULT_AGENT_ID } from '../agents/agent-types.js';
-import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+import {
+  formatAgentIdentity,
+  resolveLocalInstanceId,
+  slugifyAgentIdentityComponent,
+} from '../identity/agent-id.js';
 import {
   type A2AEnvelope,
   A2AEnvelopeValidationError,
   classifyA2AAgentId,
   validateA2AEnvelope,
 } from './envelope.js';
-
-const CANONICAL_COMPONENT_PATTERN = /^[a-z0-9][a-z0-9._-]{0,127}$/;
-let cachedInstanceId: string | undefined;
-
-function canonicalComponent(value: string, fallback: string): string {
-  const normalized = value
-    .trim()
-    .toLowerCase()
-    .replace(/@.*$/u, '')
-    .replace(/[^a-z0-9._-]+/gu, '-')
-    .replace(/^[._-]+|[._-]+$/gu, '')
-    .slice(0, 128);
-  if (normalized && CANONICAL_COMPONENT_PATTERN.test(normalized)) {
-    return normalized;
-  }
-  return fallback;
-}
-
-function readEnvInstanceId(): string {
-  return canonicalComponent(process.env.HYBRIDCLAW_INSTANCE_ID || '', '');
-}
 
 function findLocalAgent(agentId: string): AgentConfig {
   const exact = findAgentConfig(agentId);
@@ -52,22 +32,7 @@ function findLocalAgent(agentId: string): AgentConfig {
 }
 
 export function resolveLocalA2AInstanceId(): string {
-  if (cachedInstanceId) return cachedInstanceId;
-
-  const envInstanceId = readEnvInstanceId();
-  if (envInstanceId) {
-    cachedInstanceId = envInstanceId;
-    return envInstanceId;
-  }
-
-  const digest = createHash('sha256')
-    .update(os.hostname(), 'utf-8')
-    .update('\0')
-    .update(DEFAULT_RUNTIME_HOME_DIR, 'utf-8')
-    .digest('hex')
-    .slice(0, 12);
-  cachedInstanceId = `local-${digest}`;
-  return cachedInstanceId;
+  return resolveLocalInstanceId();
 }
 
 export function resolveA2AAgentId(agentId: string): string {
@@ -81,8 +46,8 @@ export function resolveA2AAgentId(agentId: string): string {
   }
 
   const agent = findLocalAgent(normalized);
-  const agentSlug = canonicalComponent(agent.id, DEFAULT_AGENT_ID);
-  const userSlug = canonicalComponent(
+  const agentSlug = slugifyAgentIdentityComponent(agent.id, DEFAULT_AGENT_ID);
+  const userSlug = slugifyAgentIdentityComponent(
     agent.owner ||
       process.env.HYBRIDCLAW_USER_ID ||
       process.env.USER ||
@@ -90,7 +55,7 @@ export function resolveA2AAgentId(agentId: string): string {
       '',
     'local',
   );
-  return `${agentSlug}@${userSlug}@${resolveLocalA2AInstanceId()}`;
+  return formatAgentIdentity(agentSlug, userSlug, resolveLocalA2AInstanceId());
 }
 
 export function resolveA2AEnvelopeAgentIds(envelope: unknown): A2AEnvelope {

--- a/src/a2a/identity.ts
+++ b/src/a2a/identity.ts
@@ -31,10 +31,6 @@ function findLocalAgent(agentId: string): AgentConfig {
   ]);
 }
 
-export function resolveLocalA2AInstanceId(): string {
-  return resolveLocalInstanceId();
-}
-
 export function resolveA2AAgentId(agentId: string): string {
   const normalized = agentId.trim();
   const kind = classifyA2AAgentId(normalized);
@@ -55,7 +51,7 @@ export function resolveA2AAgentId(agentId: string): string {
       '',
     'local',
   );
-  return formatAgentIdentity(agentSlug, userSlug, resolveLocalA2AInstanceId());
+  return formatAgentIdentity(agentSlug, userSlug, resolveLocalInstanceId());
 }
 
 export function resolveA2AEnvelopeAgentIds(envelope: unknown): A2AEnvelope {

--- a/src/cli/secret-command.ts
+++ b/src/cli/secret-command.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import {
   getRuntimeConfig,
   isGoogleApisUrlPrefix,
@@ -9,7 +10,6 @@ import {
   runtimeConfigPath,
   updateRuntimeConfig,
 } from '../config/runtime-config.js';
-import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import { agentWorkspaceDir } from '../infra/ipc.js';
 import {
   allowHttpSecretRouteInWorkspacePolicy,
@@ -268,7 +268,9 @@ export async function handleSecretCommand(args: string[]): Promise<void> {
       );
       console.log(`Updated runtime config at ${runtimeConfigPath()}.`);
       if (policyRuleId) {
-        console.log(`Allowed this route in secret policy rule \`${policyRuleId}\`.`);
+        console.log(
+          `Allowed this route in secret policy rule \`${policyRuleId}\`.`,
+        );
       }
       return;
     }
@@ -284,15 +286,14 @@ export async function handleSecretCommand(args: string[]): Promise<void> {
       }
       const urlPrefix = normalizeUrlPrefix(rawPrefix);
       const header = rawHeader ? normalizeSecretRouteHeader(rawHeader) : '';
-      const currentRules = getRuntimeConfig().tools.httpRequest.authRules.filter(
-        (rule) => {
+      const currentRules =
+        getRuntimeConfig().tools.httpRequest.authRules.filter((rule) => {
           if (rule.urlPrefix !== urlPrefix) return false;
           if (header && rule.header.toLowerCase() !== header.toLowerCase()) {
             return false;
           }
           return true;
-        },
-      );
+        });
       const policyWorkspacePath = agentWorkspaceDir(DEFAULT_AGENT_ID);
       const policySnapshot =
         captureHttpSecretRoutePolicySnapshot(policyWorkspacePath);

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -105,6 +105,7 @@ import {
   TWILIO_AUTH_TOKEN,
 } from '../config/config.js';
 import type { RuntimeConfig } from '../config/runtime-config.js';
+import { resolveLocalInstanceId } from '../identity/agent-id.js';
 import { logger } from '../logger.js';
 import {
   getDreamTimezone,
@@ -3037,6 +3038,10 @@ function logWarmProcessPoolStartup(config: RuntimeConfig['container']): void {
 async function main(): Promise<void> {
   await initOtel();
   logger.info('Starting HybridClaw gateway');
+  logger.info(
+    { instanceId: resolveLocalInstanceId() },
+    'Local instance identity ready',
+  );
   logWarmProcessPoolStartup(getConfigSnapshot().container);
   validateGatewayPromptEnvDefaults();
   initDatabase();

--- a/src/identity/agent-id.ts
+++ b/src/identity/agent-id.ts
@@ -1,0 +1,320 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+
+export const AGENT_IDENTITY_STATE_VERSION = 1;
+export const AGENT_IDENTITY_COMPONENT_MAX_LENGTH = 128;
+export const LOCAL_INSTANCE_ID_PREFIX = 'inst-';
+export const LOCAL_INSTANCE_ID_MAX_ATTEMPTS = 16;
+
+export interface ParsedAgentIdentity {
+  readonly id: string;
+  readonly agentSlug: string;
+  readonly userSlug: string;
+  readonly instanceId: string;
+}
+
+export interface LocalInstanceIdState {
+  readonly version: typeof AGENT_IDENTITY_STATE_VERSION;
+  readonly currentInstanceId: string;
+  readonly allocatedInstanceIds: readonly string[];
+  readonly allocatedAt: string;
+}
+
+export interface ResolveLocalInstanceIdOptions {
+  readonly statePath?: string;
+  readonly randomUuid?: () => string;
+  readonly now?: () => Date;
+}
+
+export class AgentIdentityValidationError extends Error {
+  readonly issues: readonly string[];
+
+  constructor(issues: string[]) {
+    super(`Invalid agent identity: ${issues.join('; ')}`);
+    this.name = 'AgentIdentityValidationError';
+    this.issues = [...issues];
+  }
+}
+
+export class LocalInstanceIdAllocationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'LocalInstanceIdAllocationError';
+  }
+}
+
+const AGENT_IDENTITY_COMPONENT_PATTERN = /^[a-z0-9][a-z0-9._-]{0,127}$/;
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeAgentIdentityComponent(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function validateAgentIdentityComponent(
+  label: 'agent slug' | 'user slug' | 'instance id',
+  value: string,
+  issues: string[],
+): void {
+  if (!value) {
+    issues.push(`${label} is required`);
+    return;
+  }
+  if (!AGENT_IDENTITY_COMPONENT_PATTERN.test(value)) {
+    issues.push(
+      `${label} must start with a letter or digit and contain only lowercase letters, digits, dots, underscores, or hyphens`,
+    );
+  }
+}
+
+function normalizeAndValidateAgentIdentityParts(
+  agentSlug: string,
+  userSlug: string,
+  instanceId: string,
+): ParsedAgentIdentity {
+  const normalizedAgentSlug = normalizeAgentIdentityComponent(agentSlug);
+  const normalizedUserSlug = normalizeAgentIdentityComponent(userSlug);
+  const normalizedInstanceId = normalizeAgentIdentityComponent(instanceId);
+  const issues: string[] = [];
+
+  validateAgentIdentityComponent('agent slug', normalizedAgentSlug, issues);
+  validateAgentIdentityComponent('user slug', normalizedUserSlug, issues);
+  validateAgentIdentityComponent('instance id', normalizedInstanceId, issues);
+
+  if (issues.length > 0) {
+    throw new AgentIdentityValidationError(issues);
+  }
+
+  return {
+    id: `${normalizedAgentSlug}@${normalizedUserSlug}@${normalizedInstanceId}`,
+    agentSlug: normalizedAgentSlug,
+    userSlug: normalizedUserSlug,
+    instanceId: normalizedInstanceId,
+  };
+}
+
+export function formatAgentIdentity(
+  agentSlug: string,
+  userSlug: string,
+  instanceId: string,
+): string {
+  return normalizeAndValidateAgentIdentityParts(agentSlug, userSlug, instanceId)
+    .id;
+}
+
+export function parseAgentIdentity(value: string): ParsedAgentIdentity {
+  const normalized = value.trim();
+
+  if (!normalized) {
+    throw new AgentIdentityValidationError(['agent identity is required']);
+  }
+
+  const parts = normalized.split('@');
+  if (parts.length !== 3) {
+    throw new AgentIdentityValidationError([
+      'agent identity must use the agent-slug@user@instance-id format',
+    ]);
+  }
+
+  const [agentSlug = '', userSlug = '', instanceId = ''] = parts;
+  return normalizeAndValidateAgentIdentityParts(
+    agentSlug,
+    userSlug,
+    instanceId,
+  );
+}
+
+export function isCanonicalAgentIdentity(value: string): boolean {
+  try {
+    parseAgentIdentity(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function slugifyAgentIdentityComponent(
+  value: string,
+  fallback: string,
+): string {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/@.*$/u, '')
+    .replace(/[^a-z0-9._-]+/gu, '-')
+    .replace(/^[._-]+|[._-]+$/gu, '')
+    .slice(0, AGENT_IDENTITY_COMPONENT_MAX_LENGTH);
+  if (normalized && AGENT_IDENTITY_COMPONENT_PATTERN.test(normalized)) {
+    return normalized;
+  }
+  return fallback;
+}
+
+export function localInstanceIdStatePath(): string {
+  return path.join(DEFAULT_RUNTIME_HOME_DIR, 'identity', 'instance-id.json');
+}
+
+export function formatLocalInstanceIdFromUuid(uuid: string): string {
+  const normalized = uuid.trim().toLowerCase();
+  if (!UUID_PATTERN.test(normalized)) {
+    throw new AgentIdentityValidationError([
+      'instance id UUID must be a valid RFC 4122 UUID',
+    ]);
+  }
+  return `${LOCAL_INSTANCE_ID_PREFIX}${normalized}`;
+}
+
+export function allocateUniqueLocalInstanceId(
+  allocatedInstanceIds: Iterable<string>,
+  randomUuid: () => string = randomUUID,
+): string {
+  const allocated = new Set(
+    Array.from(allocatedInstanceIds, (entry) =>
+      normalizeAgentIdentityComponent(entry),
+    ),
+  );
+
+  for (
+    let attempt = 0;
+    attempt < LOCAL_INSTANCE_ID_MAX_ATTEMPTS;
+    attempt += 1
+  ) {
+    const candidate = formatLocalInstanceIdFromUuid(randomUuid());
+    if (!allocated.has(candidate)) return candidate;
+  }
+
+  throw new LocalInstanceIdAllocationError(
+    `Failed to allocate a unique local instance id after ${LOCAL_INSTANCE_ID_MAX_ATTEMPTS} attempts.`,
+  );
+}
+
+function validateLocalInstanceIdState(value: unknown): LocalInstanceIdState {
+  if (!isRecord(value)) {
+    throw new AgentIdentityValidationError([
+      'local instance identity state must be an object',
+    ]);
+  }
+
+  const issues: string[] = [];
+  if (value.version !== AGENT_IDENTITY_STATE_VERSION) {
+    issues.push(
+      `local instance identity state version must be ${AGENT_IDENTITY_STATE_VERSION}`,
+    );
+  }
+  const currentInstanceId =
+    typeof value.currentInstanceId === 'string'
+      ? normalizeAgentIdentityComponent(value.currentInstanceId)
+      : '';
+  validateAgentIdentityComponent('instance id', currentInstanceId, issues);
+
+  const allocatedInstanceIds = Array.isArray(value.allocatedInstanceIds)
+    ? value.allocatedInstanceIds
+        .filter((entry): entry is string => typeof entry === 'string')
+        .map((entry) => normalizeAgentIdentityComponent(entry))
+    : [];
+  if (!Array.isArray(value.allocatedInstanceIds)) {
+    issues.push('allocated instance ids must be an array');
+  }
+  for (const allocatedId of allocatedInstanceIds) {
+    validateAgentIdentityComponent('instance id', allocatedId, issues);
+  }
+  if (
+    currentInstanceId &&
+    !new Set(allocatedInstanceIds).has(currentInstanceId)
+  ) {
+    issues.push('allocated instance ids must include current instance id');
+  }
+
+  const allocatedAt =
+    typeof value.allocatedAt === 'string' ? value.allocatedAt.trim() : '';
+  if (!allocatedAt || Number.isNaN(Date.parse(allocatedAt))) {
+    issues.push('allocated at must be an ISO timestamp');
+  }
+
+  if (issues.length > 0) {
+    throw new AgentIdentityValidationError(issues);
+  }
+
+  return {
+    version: AGENT_IDENTITY_STATE_VERSION,
+    currentInstanceId,
+    allocatedInstanceIds: Array.from(new Set(allocatedInstanceIds)),
+    allocatedAt,
+  };
+}
+
+function readLocalInstanceIdState(
+  statePath: string,
+): LocalInstanceIdState | null {
+  try {
+    return validateLocalInstanceIdState(
+      JSON.parse(fs.readFileSync(statePath, 'utf-8')),
+    );
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err?.code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+function writeNewLocalInstanceIdState(
+  statePath: string,
+  state: LocalInstanceIdState,
+): void {
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  const fd = fs.openSync(statePath, 'wx');
+  try {
+    fs.writeFileSync(fd, `${JSON.stringify(state, null, 2)}\n`, 'utf-8');
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function readEnvInstanceId(): string {
+  return slugifyAgentIdentityComponent(
+    process.env.HYBRIDCLAW_INSTANCE_ID || '',
+    '',
+  );
+}
+
+export function resolveLocalInstanceId(
+  options: ResolveLocalInstanceIdOptions = {},
+): string {
+  const envInstanceId = readEnvInstanceId();
+  if (envInstanceId) return envInstanceId;
+
+  const statePath = options.statePath ?? localInstanceIdStatePath();
+  const existingState = readLocalInstanceIdState(statePath);
+  if (existingState) return existingState.currentInstanceId;
+
+  const currentInstanceId = allocateUniqueLocalInstanceId(
+    [],
+    options.randomUuid,
+  );
+  const allocatedAt = (options.now ?? (() => new Date()))().toISOString();
+  const state: LocalInstanceIdState = {
+    version: AGENT_IDENTITY_STATE_VERSION,
+    currentInstanceId,
+    allocatedInstanceIds: [currentInstanceId],
+    allocatedAt,
+  };
+
+  try {
+    writeNewLocalInstanceIdState(statePath, state);
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err?.code !== 'EEXIST') throw error;
+    const racedState = readLocalInstanceIdState(statePath);
+    if (racedState) return racedState.currentInstanceId;
+    throw error;
+  }
+
+  return currentInstanceId;
+}

--- a/src/identity/agent-id.ts
+++ b/src/identity/agent-id.ts
@@ -4,10 +4,8 @@ import path from 'node:path';
 
 import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
 
-export const AGENT_IDENTITY_STATE_VERSION = 1;
 export const AGENT_IDENTITY_COMPONENT_MAX_LENGTH = 128;
 export const LOCAL_INSTANCE_ID_PREFIX = 'inst-';
-export const LOCAL_INSTANCE_ID_MAX_ATTEMPTS = 16;
 
 let cachedDefaultInstanceId: string | undefined;
 let cachedDefaultInstanceEnvValue: string | undefined;
@@ -20,9 +18,7 @@ export interface ParsedAgentIdentity {
 }
 
 export interface LocalInstanceIdState {
-  readonly version: typeof AGENT_IDENTITY_STATE_VERSION;
   readonly currentInstanceId: string;
-  readonly allocatedInstanceIds: readonly string[];
   readonly allocatedAt: string;
 }
 
@@ -135,21 +131,18 @@ export function parseAgentIdentity(value: string): ParsedAgentIdentity {
 }
 
 export function isCanonicalAgentIdentity(value: string): boolean {
-  try {
-    parseAgentIdentity(value);
-    return true;
-  } catch {
-    return false;
-  }
+  const parts = value.trim().toLowerCase().split('@');
+  return (
+    parts.length === 3 &&
+    parts.every((part) => AGENT_IDENTITY_COMPONENT_PATTERN.test(part))
+  );
 }
 
 export function slugifyAgentIdentityComponent(
   value: string,
   fallback: string,
 ): string {
-  const normalized = value
-    .trim()
-    .toLowerCase()
+  const normalized = normalizeAgentIdentityComponent(value)
     .replace(/@.*$/u, '')
     .replace(/[^a-z0-9._-]+/gu, '-')
     .replace(/^[._-]+|[._-]+$/gu, '')
@@ -174,28 +167,10 @@ export function formatLocalInstanceIdFromUuid(uuid: string): string {
   return `${LOCAL_INSTANCE_ID_PREFIX}${normalized}`;
 }
 
-export function allocateUniqueLocalInstanceId(
-  allocatedInstanceIds: Iterable<string>,
+function allocateLocalInstanceId(
   randomUuid: () => string = randomUUID,
 ): string {
-  const allocated = new Set(
-    Array.from(allocatedInstanceIds, (entry) =>
-      normalizeAgentIdentityComponent(entry),
-    ),
-  );
-
-  for (
-    let attempt = 0;
-    attempt < LOCAL_INSTANCE_ID_MAX_ATTEMPTS;
-    attempt += 1
-  ) {
-    const candidate = formatLocalInstanceIdFromUuid(randomUuid());
-    if (!allocated.has(candidate)) return candidate;
-  }
-
-  throw new LocalInstanceIdAllocationError(
-    `Failed to allocate a unique local instance id after ${LOCAL_INSTANCE_ID_MAX_ATTEMPTS} attempts.`,
-  );
+  return formatLocalInstanceIdFromUuid(randomUuid());
 }
 
 function validateLocalInstanceIdState(value: unknown): LocalInstanceIdState {
@@ -206,34 +181,11 @@ function validateLocalInstanceIdState(value: unknown): LocalInstanceIdState {
   }
 
   const issues: string[] = [];
-  if (value.version !== AGENT_IDENTITY_STATE_VERSION) {
-    issues.push(
-      `local instance identity state version must be ${AGENT_IDENTITY_STATE_VERSION}`,
-    );
-  }
   const currentInstanceId =
     typeof value.currentInstanceId === 'string'
       ? normalizeAgentIdentityComponent(value.currentInstanceId)
       : '';
   validateAgentIdentityComponent('instance id', currentInstanceId, issues);
-
-  const allocatedInstanceIds = Array.isArray(value.allocatedInstanceIds)
-    ? value.allocatedInstanceIds
-        .filter((entry): entry is string => typeof entry === 'string')
-        .map((entry) => normalizeAgentIdentityComponent(entry))
-    : [];
-  if (!Array.isArray(value.allocatedInstanceIds)) {
-    issues.push('allocated instance ids must be an array');
-  }
-  for (const allocatedId of allocatedInstanceIds) {
-    validateAgentIdentityComponent('instance id', allocatedId, issues);
-  }
-  if (
-    currentInstanceId &&
-    !new Set(allocatedInstanceIds).has(currentInstanceId)
-  ) {
-    issues.push('allocated instance ids must include current instance id');
-  }
 
   const allocatedAt =
     typeof value.allocatedAt === 'string' ? value.allocatedAt.trim() : '';
@@ -246,9 +198,7 @@ function validateLocalInstanceIdState(value: unknown): LocalInstanceIdState {
   }
 
   return {
-    version: AGENT_IDENTITY_STATE_VERSION,
     currentInstanceId,
-    allocatedInstanceIds: Array.from(new Set(allocatedInstanceIds)),
     allocatedAt,
   };
 }
@@ -273,10 +223,7 @@ function writeNewLocalInstanceIdState(
 ): void {
   const stateDir = path.dirname(statePath);
   fs.mkdirSync(stateDir, { recursive: true });
-  const tempPath = path.join(
-    stateDir,
-    `.instance-id-${process.pid}-${Date.now().toString(36)}-${randomUUID()}.tmp`,
-  );
+  const tempPath = path.join(stateDir, `.instance-id-${randomUUID()}.tmp`);
   try {
     fs.writeFileSync(tempPath, `${JSON.stringify(state, null, 2)}\n`, {
       encoding: 'utf-8',
@@ -290,13 +237,6 @@ function writeNewLocalInstanceIdState(
   }
 }
 
-function readEnvInstanceId(): string {
-  return slugifyAgentIdentityComponent(
-    process.env.HYBRIDCLAW_INSTANCE_ID || '',
-    '',
-  );
-}
-
 export function resolveLocalInstanceId(
   options: ResolveLocalInstanceIdOptions = {},
 ): string {
@@ -305,6 +245,7 @@ export function resolveLocalInstanceId(
     options.randomUuid === undefined &&
     options.now === undefined;
   const envValue = process.env.HYBRIDCLAW_INSTANCE_ID || '';
+  const envInstanceId = slugifyAgentIdentityComponent(envValue, '');
   if (
     cacheable &&
     cachedDefaultInstanceId &&
@@ -313,7 +254,6 @@ export function resolveLocalInstanceId(
     return cachedDefaultInstanceId;
   }
 
-  const envInstanceId = readEnvInstanceId();
   if (envInstanceId) {
     if (cacheable) {
       cachedDefaultInstanceId = envInstanceId;
@@ -332,15 +272,10 @@ export function resolveLocalInstanceId(
     return existingState.currentInstanceId;
   }
 
-  const currentInstanceId = allocateUniqueLocalInstanceId(
-    [],
-    options.randomUuid,
-  );
+  const currentInstanceId = allocateLocalInstanceId(options.randomUuid);
   const allocatedAt = (options.now ?? (() => new Date()))().toISOString();
   const state: LocalInstanceIdState = {
-    version: AGENT_IDENTITY_STATE_VERSION,
     currentInstanceId,
-    allocatedInstanceIds: [currentInstanceId],
     allocatedAt,
   };
 
@@ -357,7 +292,9 @@ export function resolveLocalInstanceId(
       }
       return racedState.currentInstanceId;
     }
-    throw error;
+    throw new LocalInstanceIdAllocationError(
+      'Local instance id state file was created by another process but was missing on read; state directory may be unstable.',
+    );
   }
 
   if (cacheable) {

--- a/src/identity/agent-id.ts
+++ b/src/identity/agent-id.ts
@@ -9,6 +9,9 @@ export const AGENT_IDENTITY_COMPONENT_MAX_LENGTH = 128;
 export const LOCAL_INSTANCE_ID_PREFIX = 'inst-';
 export const LOCAL_INSTANCE_ID_MAX_ATTEMPTS = 16;
 
+let cachedDefaultInstanceId: string | undefined;
+let cachedDefaultInstanceEnvValue: string | undefined;
+
 export interface ParsedAgentIdentity {
   readonly id: string;
   readonly agentSlug: string;
@@ -268,12 +271,22 @@ function writeNewLocalInstanceIdState(
   statePath: string,
   state: LocalInstanceIdState,
 ): void {
-  fs.mkdirSync(path.dirname(statePath), { recursive: true });
-  const fd = fs.openSync(statePath, 'wx');
+  const stateDir = path.dirname(statePath);
+  fs.mkdirSync(stateDir, { recursive: true });
+  const tempPath = path.join(
+    stateDir,
+    `.instance-id-${process.pid}-${Date.now().toString(36)}-${randomUUID()}.tmp`,
+  );
   try {
-    fs.writeFileSync(fd, `${JSON.stringify(state, null, 2)}\n`, 'utf-8');
+    fs.writeFileSync(tempPath, `${JSON.stringify(state, null, 2)}\n`, {
+      encoding: 'utf-8',
+      flag: 'wx',
+    });
+    // Hard-linking creates the target only after the complete temp file exists
+    // and fails with EEXIST instead of overwriting a concurrently-created id.
+    fs.linkSync(tempPath, statePath);
   } finally {
-    fs.closeSync(fd);
+    fs.rmSync(tempPath, { force: true });
   }
 }
 
@@ -287,12 +300,37 @@ function readEnvInstanceId(): string {
 export function resolveLocalInstanceId(
   options: ResolveLocalInstanceIdOptions = {},
 ): string {
+  const cacheable =
+    options.statePath === undefined &&
+    options.randomUuid === undefined &&
+    options.now === undefined;
+  const envValue = process.env.HYBRIDCLAW_INSTANCE_ID || '';
+  if (
+    cacheable &&
+    cachedDefaultInstanceId &&
+    cachedDefaultInstanceEnvValue === envValue
+  ) {
+    return cachedDefaultInstanceId;
+  }
+
   const envInstanceId = readEnvInstanceId();
-  if (envInstanceId) return envInstanceId;
+  if (envInstanceId) {
+    if (cacheable) {
+      cachedDefaultInstanceId = envInstanceId;
+      cachedDefaultInstanceEnvValue = envValue;
+    }
+    return envInstanceId;
+  }
 
   const statePath = options.statePath ?? localInstanceIdStatePath();
   const existingState = readLocalInstanceIdState(statePath);
-  if (existingState) return existingState.currentInstanceId;
+  if (existingState) {
+    if (cacheable) {
+      cachedDefaultInstanceId = existingState.currentInstanceId;
+      cachedDefaultInstanceEnvValue = envValue;
+    }
+    return existingState.currentInstanceId;
+  }
 
   const currentInstanceId = allocateUniqueLocalInstanceId(
     [],
@@ -312,9 +350,19 @@ export function resolveLocalInstanceId(
     const err = error as NodeJS.ErrnoException;
     if (err?.code !== 'EEXIST') throw error;
     const racedState = readLocalInstanceIdState(statePath);
-    if (racedState) return racedState.currentInstanceId;
+    if (racedState) {
+      if (cacheable) {
+        cachedDefaultInstanceId = racedState.currentInstanceId;
+        cachedDefaultInstanceEnvValue = envValue;
+      }
+      return racedState.currentInstanceId;
+    }
     throw error;
   }
 
+  if (cacheable) {
+    cachedDefaultInstanceId = currentInstanceId;
+    cachedDefaultInstanceEnvValue = envValue;
+  }
   return currentInstanceId;
 }

--- a/src/policy/secret-route-policy.ts
+++ b/src/policy/secret-route-policy.ts
@@ -3,11 +3,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import YAML from 'yaml';
+import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import {
   isGoogleOAuthSecretRef,
   type RuntimeHttpRequestAuthRuleSecret,
 } from '../config/runtime-config.js';
-import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import type { SecretRef } from '../security/secret-refs.js';
 import { resolveWorkspacePolicyPath } from './policy-store.js';
 
@@ -50,7 +50,9 @@ function writeRawPolicyObject(
   fs.writeFileSync(policyPath, YAML.stringify(document), 'utf-8');
 }
 
-export function captureHttpSecretRoutePolicySnapshot(workspacePath: string): SecretRoutePolicySnapshot {
+export function captureHttpSecretRoutePolicySnapshot(
+  workspacePath: string,
+): SecretRoutePolicySnapshot {
   const policyPath = resolveWorkspacePolicyPath(workspacePath);
   if (!fs.existsSync(policyPath)) {
     return {
@@ -66,7 +68,9 @@ export function captureHttpSecretRoutePolicySnapshot(workspacePath: string): Sec
   };
 }
 
-export function restoreHttpSecretRoutePolicySnapshot(snapshot: SecretRoutePolicySnapshot): void {
+export function restoreHttpSecretRoutePolicySnapshot(
+  snapshot: SecretRoutePolicySnapshot,
+): void {
   if (!snapshot.exists) {
     if (fs.existsSync(snapshot.policyPath)) {
       fs.unlinkSync(snapshot.policyPath);

--- a/tests/agent-id.test.ts
+++ b/tests/agent-id.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import {
   AgentIdentityValidationError,
@@ -17,6 +17,7 @@ import {
 } from '../src/identity/agent-id.js';
 
 const ORIGINAL_INSTANCE_ID = process.env.HYBRIDCLAW_INSTANCE_ID;
+const ORIGINAL_DATA_DIR = process.env.HYBRIDCLAW_DATA_DIR;
 
 let tmpDir: string;
 
@@ -35,6 +36,8 @@ beforeEach(() => {
 
 afterEach(() => {
   restoreEnvVar('HYBRIDCLAW_INSTANCE_ID', ORIGINAL_INSTANCE_ID);
+  restoreEnvVar('HYBRIDCLAW_DATA_DIR', ORIGINAL_DATA_DIR);
+  vi.resetModules();
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
@@ -131,6 +134,44 @@ describe('local instance id allocation', () => {
       allocatedInstanceIds: [first],
       allocatedAt: '2026-05-03T10:00:00.000Z',
     });
+  });
+
+  test('caches the default resolved instance id after first allocation', async () => {
+    process.env.HYBRIDCLAW_DATA_DIR = tmpDir;
+    vi.resetModules();
+    const identity = await import('../src/identity/agent-id.js');
+
+    const first = identity.resolveLocalInstanceId();
+    fs.rmSync(identity.localInstanceIdStatePath(), { force: true });
+    const second = identity.resolveLocalInstanceId();
+
+    expect(second).toBe(first);
+    expect(fs.existsSync(identity.localInstanceIdStatePath())).toBe(false);
+  });
+
+  test('keeps explicit state-path resolution uncached for tests', () => {
+    const statePath = path.join(tmpDir, 'identity', 'instance-id.json');
+    const randomUuid = () => '550e8400-e29b-41d4-a716-446655440000';
+    const now = () => new Date('2026-05-03T10:00:00.000Z');
+
+    const first = resolveLocalInstanceId({ statePath, randomUuid, now });
+    const replacement = 'inst-660e8400-e29b-41d4-a716-446655440000';
+    fs.writeFileSync(
+      statePath,
+      `${JSON.stringify(
+        {
+          version: 1,
+          currentInstanceId: replacement,
+          allocatedInstanceIds: [first, replacement],
+          allocatedAt: '2026-05-03T10:01:00.000Z',
+        },
+        null,
+        2,
+      )}\n`,
+      'utf-8',
+    );
+
+    expect(resolveLocalInstanceId({ statePath })).toBe(replacement);
   });
 
   test('honors explicit instance id overrides without mutating persisted state', () => {

--- a/tests/agent-id.test.ts
+++ b/tests/agent-id.test.ts
@@ -1,0 +1,167 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import {
+  AgentIdentityValidationError,
+  allocateUniqueLocalInstanceId,
+  formatAgentIdentity,
+  formatLocalInstanceIdFromUuid,
+  isCanonicalAgentIdentity,
+  LocalInstanceIdAllocationError,
+  parseAgentIdentity,
+  resolveLocalInstanceId,
+  slugifyAgentIdentityComponent,
+} from '../src/identity/agent-id.js';
+
+const ORIGINAL_INSTANCE_ID = process.env.HYBRIDCLAW_INSTANCE_ID;
+
+let tmpDir: string;
+
+function restoreEnvVar(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hc-agent-id-'));
+  delete process.env.HYBRIDCLAW_INSTANCE_ID;
+});
+
+afterEach(() => {
+  restoreEnvVar('HYBRIDCLAW_INSTANCE_ID', ORIGINAL_INSTANCE_ID);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('canonical agent identities', () => {
+  test('parses and normalizes agent-slug@user@instance-id identities', () => {
+    expect(parseAgentIdentity(' Support-Lena@Acme@Inst-7F3A ')).toEqual({
+      id: 'support-lena@acme@inst-7f3a',
+      agentSlug: 'support-lena',
+      userSlug: 'acme',
+      instanceId: 'inst-7f3a',
+    });
+    expect(isCanonicalAgentIdentity('support-lena@acme@inst-7f3a')).toBe(true);
+  });
+
+  test('round-trips valid identities through parse and format', () => {
+    const values = [
+      'support-lena@acme@inst-7f3a',
+      'main@local@inst-550e8400-e29b-41d4-a716-446655440000',
+      'research.agent@team_1@local-dev',
+    ];
+
+    for (const value of values) {
+      const parsed = parseAgentIdentity(value);
+      expect(
+        formatAgentIdentity(
+          parsed.agentSlug,
+          parsed.userSlug,
+          parsed.instanceId,
+        ),
+      ).toBe(value);
+    }
+  });
+
+  test('rejects malformed identities', () => {
+    const invalidValues = [
+      '',
+      'support-lena',
+      'support-lena@acme',
+      'support-lena@acme@inst@extra',
+      '@acme@inst-1',
+      'support lena@acme@inst-1',
+      'support-lena@acme ltd@inst-1',
+      'support-lena@acme@',
+      '.support@acme@inst-1',
+      'support@-acme@inst-1',
+      'support@acme@_inst-1',
+    ];
+
+    for (const value of invalidValues) {
+      expect(() => parseAgentIdentity(value), value).toThrow(
+        AgentIdentityValidationError,
+      );
+    }
+  });
+
+  test('slugifies local agent identity components with a fallback', () => {
+    expect(slugifyAgentIdentityComponent(' Support Lena! ', 'main')).toBe(
+      'support-lena',
+    );
+    expect(slugifyAgentIdentityComponent(' user@example.com ', 'local')).toBe(
+      'user',
+    );
+    expect(slugifyAgentIdentityComponent(' !!! ', 'local')).toBe('local');
+  });
+});
+
+describe('local instance id allocation', () => {
+  test('formats UUID-based instance ids', () => {
+    expect(
+      formatLocalInstanceIdFromUuid('550E8400-E29B-41D4-A716-446655440000'),
+    ).toBe('inst-550e8400-e29b-41d4-a716-446655440000');
+    expect(() => formatLocalInstanceIdFromUuid('not-a-uuid')).toThrow(
+      AgentIdentityValidationError,
+    );
+  });
+
+  test('allocates once and persists the UUID-backed instance id', () => {
+    const statePath = path.join(tmpDir, 'identity', 'instance-id.json');
+    const randomUuid = () => '550e8400-e29b-41d4-a716-446655440000';
+    const now = () => new Date('2026-05-03T10:00:00.000Z');
+
+    const first = resolveLocalInstanceId({ statePath, randomUuid, now });
+    const second = resolveLocalInstanceId({
+      statePath,
+      randomUuid: () => '660e8400-e29b-41d4-a716-446655440000',
+      now,
+    });
+
+    expect(first).toBe('inst-550e8400-e29b-41d4-a716-446655440000');
+    expect(second).toBe(first);
+    expect(JSON.parse(fs.readFileSync(statePath, 'utf-8'))).toEqual({
+      version: 1,
+      currentInstanceId: first,
+      allocatedInstanceIds: [first],
+      allocatedAt: '2026-05-03T10:00:00.000Z',
+    });
+  });
+
+  test('honors explicit instance id overrides without mutating persisted state', () => {
+    const statePath = path.join(tmpDir, 'identity', 'instance-id.json');
+    process.env.HYBRIDCLAW_INSTANCE_ID = 'Local Dev!';
+
+    expect(resolveLocalInstanceId({ statePath })).toBe('local-dev');
+    expect(fs.existsSync(statePath)).toBe(false);
+  });
+
+  test('retries when generated UUID instance ids collide with allocated ids', () => {
+    const duplicateUuid = '550e8400-e29b-41d4-a716-446655440000';
+    const nextUuid = '660e8400-e29b-41d4-a716-446655440000';
+    const uuids = [duplicateUuid, duplicateUuid, nextUuid];
+
+    const allocated = ['inst-550e8400-e29b-41d4-a716-446655440000'];
+    const allocatedId = allocateUniqueLocalInstanceId(allocated, () => {
+      const next = uuids.shift();
+      if (!next) throw new Error('unexpected UUID request');
+      return next;
+    });
+
+    expect(allocatedId).toBe('inst-660e8400-e29b-41d4-a716-446655440000');
+  });
+
+  test('fails fast when UUID allocation keeps colliding', () => {
+    expect(() =>
+      allocateUniqueLocalInstanceId(
+        ['inst-550e8400-e29b-41d4-a716-446655440000'],
+        () => '550e8400-e29b-41d4-a716-446655440000',
+      ),
+    ).toThrow(LocalInstanceIdAllocationError);
+  });
+});

--- a/tests/agent-id.test.ts
+++ b/tests/agent-id.test.ts
@@ -6,11 +6,9 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import {
   AgentIdentityValidationError,
-  allocateUniqueLocalInstanceId,
   formatAgentIdentity,
   formatLocalInstanceIdFromUuid,
   isCanonicalAgentIdentity,
-  LocalInstanceIdAllocationError,
   parseAgentIdentity,
   resolveLocalInstanceId,
   slugifyAgentIdentityComponent,
@@ -129,9 +127,7 @@ describe('local instance id allocation', () => {
     expect(first).toBe('inst-550e8400-e29b-41d4-a716-446655440000');
     expect(second).toBe(first);
     expect(JSON.parse(fs.readFileSync(statePath, 'utf-8'))).toEqual({
-      version: 1,
       currentInstanceId: first,
-      allocatedInstanceIds: [first],
       allocatedAt: '2026-05-03T10:00:00.000Z',
     });
   });
@@ -154,15 +150,13 @@ describe('local instance id allocation', () => {
     const randomUuid = () => '550e8400-e29b-41d4-a716-446655440000';
     const now = () => new Date('2026-05-03T10:00:00.000Z');
 
-    const first = resolveLocalInstanceId({ statePath, randomUuid, now });
+    resolveLocalInstanceId({ statePath, randomUuid, now });
     const replacement = 'inst-660e8400-e29b-41d4-a716-446655440000';
     fs.writeFileSync(
       statePath,
       `${JSON.stringify(
         {
-          version: 1,
           currentInstanceId: replacement,
-          allocatedInstanceIds: [first, replacement],
           allocatedAt: '2026-05-03T10:01:00.000Z',
         },
         null,
@@ -182,27 +176,19 @@ describe('local instance id allocation', () => {
     expect(fs.existsSync(statePath)).toBe(false);
   });
 
-  test('retries when generated UUID instance ids collide with allocated ids', () => {
-    const duplicateUuid = '550e8400-e29b-41d4-a716-446655440000';
-    const nextUuid = '660e8400-e29b-41d4-a716-446655440000';
-    const uuids = [duplicateUuid, duplicateUuid, nextUuid];
-
-    const allocated = ['inst-550e8400-e29b-41d4-a716-446655440000'];
-    const allocatedId = allocateUniqueLocalInstanceId(allocated, () => {
-      const next = uuids.shift();
-      if (!next) throw new Error('unexpected UUID request');
-      return next;
+  test('preserves an existing state file instead of reallocating', () => {
+    const statePath = path.join(tmpDir, 'identity', 'instance-id.json');
+    const first = resolveLocalInstanceId({
+      statePath,
+      randomUuid: () => '550e8400-e29b-41d4-a716-446655440000',
+      now: () => new Date('2026-05-03T10:00:00.000Z'),
+    });
+    const second = resolveLocalInstanceId({
+      statePath,
+      randomUuid: () => '660e8400-e29b-41d4-a716-446655440000',
+      now: () => new Date('2026-05-03T10:01:00.000Z'),
     });
 
-    expect(allocatedId).toBe('inst-660e8400-e29b-41d4-a716-446655440000');
-  });
-
-  test('fails fast when UUID allocation keeps colliding', () => {
-    expect(() =>
-      allocateUniqueLocalInstanceId(
-        ['inst-550e8400-e29b-41d4-a716-446655440000'],
-        () => '550e8400-e29b-41d4-a716-446655440000',
-      ),
-    ).toThrow(LocalInstanceIdAllocationError);
+    expect(second).toBe(first);
   });
 });

--- a/tests/agent-id.test.ts
+++ b/tests/agent-id.test.ts
@@ -35,6 +35,7 @@ beforeEach(() => {
 afterEach(() => {
   restoreEnvVar('HYBRIDCLAW_INSTANCE_ID', ORIGINAL_INSTANCE_ID);
   restoreEnvVar('HYBRIDCLAW_DATA_DIR', ORIGINAL_DATA_DIR);
+  vi.restoreAllMocks();
   vi.resetModules();
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
@@ -190,5 +191,40 @@ describe('local instance id allocation', () => {
     });
 
     expect(second).toBe(first);
+  });
+
+  test('uses the winning state file when concurrent allocation hits EEXIST', () => {
+    const statePath = path.join(tmpDir, 'identity', 'instance-id.json');
+    const winnerId = 'inst-660e8400-e29b-41d4-a716-446655440000';
+    const winnerState = {
+      currentInstanceId: winnerId,
+      allocatedAt: '2026-05-03T10:01:00.000Z',
+    };
+    const linkSpy = vi
+      .spyOn(fs, 'linkSync')
+      .mockImplementation(
+        (_existingPath: fs.PathLike, newPath: fs.PathLike) => {
+          fs.writeFileSync(
+            newPath,
+            `${JSON.stringify(winnerState, null, 2)}\n`,
+            'utf-8',
+          );
+          const error = new Error('file exists') as NodeJS.ErrnoException;
+          error.code = 'EEXIST';
+          throw error;
+        },
+      );
+
+    const resolved = resolveLocalInstanceId({
+      statePath,
+      randomUuid: () => '550e8400-e29b-41d4-a716-446655440000',
+      now: () => new Date('2026-05-03T10:00:00.000Z'),
+    });
+
+    expect(resolved).toBe(winnerId);
+    expect(linkSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fs.readFileSync(statePath, 'utf-8'))).toEqual(
+      winnerState,
+    );
   });
 });


### PR DESCRIPTION
## Summary

Implements #572, the Foundation F7.2 canonical agent-identity format and local instance-id allocation work.

## Acceptance Criteria

- Documents the canonical `agent-slug@user@instance-id` format, including examples and component rules.
- Adds parse/format helpers for canonical agent identities.
- Allocates a UUID-backed local `instance-id` on first gateway start and persists it under the runtime home.
- Reuses explicit `HYBRIDCLAW_INSTANCE_ID` overrides for deployments that provide their own stable instance id.
- Adds unit tests for parse/format round trips, existing-state reuse, default resolver caching, explicit state-path testability, and concurrent allocation collision recovery.

## Notes

- `src/cli/secret-command.ts` and `src/policy/secret-route-policy.ts` contain Biome-only formatting/import-order fixes. Reverting them makes `npm run check` fail, so they are kept as validation-required formatting cleanup with no behavioral change.
- The old deterministic `local-<hash>` A2A instance id is replaced by the new persisted UUID-backed id. No release-note migration is added here because the cross-instance resolver and TOFU trust ledger are still unshipped, and there is no in-tree persisted A2A trust state that references the old id.

## Validation

- `npm run check`
- `npm run lint`
- `./node_modules/.bin/vitest run tests/agent-id.test.ts tests/a2a-envelope.test.ts`
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.integration.config.ts tests/a2a-runtime.integration.test.ts`
- `git diff --check`

Closes #572.