### PR TITLE
Refactor approval policy into hook-fed rule pipeline

### DIFF
--- a/container/src/approval-policy.ts
+++ b/container/src/approval-policy.ts
@@ -376,6 +376,7 @@ const APPROVE_RE =
 const DENY_RE = /^(?:\/?(?:deny|reject|skip|no|n))(?:\s+([a-f0-9-]{6,64}))?$/i;
 const APPROVAL_RULE_NAME_SET = new Set<string>(DEFAULT_APPROVAL_RULE_ORDER);
 const NEXT_RULE: NextRule = { kind: 'next' };
+const invalidApprovalRuleOrderWarnings = new Set<string>();
 
 function isVoiceChannelId(value: string | undefined): boolean {
   return String(value || '')
@@ -471,7 +472,32 @@ function normalizeApprovalRuleOrder(raw: unknown): ApprovalRuleName[] {
   for (const ruleName of DEFAULT_APPROVAL_RULE_ORDER) {
     if (!ordered.includes(ruleName)) ordered.push(ruleName);
   }
+  if (!isApprovalRuleOrderDependencySafe(ordered)) {
+    warnInvalidApprovalRuleOrder(ordered);
+    return [...DEFAULT_APPROVAL_RULE_ORDER];
+  }
   return ordered;
+}
+
+function isApprovalRuleOrderDependencySafe(
+  ruleOrder: ApprovalRuleName[],
+): boolean {
+  let lastDefaultIndex = -1;
+  for (const ruleName of ruleOrder) {
+    const defaultIndex = DEFAULT_APPROVAL_RULE_ORDER.indexOf(ruleName);
+    if (defaultIndex < lastDefaultIndex) return false;
+    lastDefaultIndex = defaultIndex;
+  }
+  return true;
+}
+
+function warnInvalidApprovalRuleOrder(ruleOrder: ApprovalRuleName[]): void {
+  const key = ruleOrder.join(',');
+  if (invalidApprovalRuleOrderWarnings.has(key)) return;
+  invalidApprovalRuleOrderWarnings.add(key);
+  console.warn(
+    `[approval-policy] invalid approval.rule_order violates built-in rule dependencies; falling back to default order: ${key}`,
+  );
 }
 
 function normalizeAutonomyLevel(raw: unknown): AutonomyLevel | null {

--- a/container/src/approval-policy.ts
+++ b/container/src/approval-policy.ts
@@ -258,6 +258,7 @@ export interface ToolCallContextHelpers {
 
 export interface ApprovalRuleHookEvent {
   hook: 'pre_tool_use' | 'post_tool_use';
+  kind: 'approval_rule';
   ruleName: ApprovalRuleName;
   toolName: string;
   actionKey?: string;
@@ -376,7 +377,9 @@ const APPROVE_RE =
 const DENY_RE = /^(?:\/?(?:deny|reject|skip|no|n))(?:\s+([a-f0-9-]{6,64}))?$/i;
 const APPROVAL_RULE_NAME_SET = new Set<string>(DEFAULT_APPROVAL_RULE_ORDER);
 const NEXT_RULE: NextRule = { kind: 'next' };
+const unknownApprovalRuleNameWarnings = new Set<string>();
 const invalidApprovalRuleOrderWarnings = new Set<string>();
+const MAX_APPROVAL_RULE_WARNING_KEYS = 50;
 
 function isVoiceChannelId(value: string | undefined): boolean {
   return String(value || '')
@@ -463,9 +466,15 @@ function normalizeStringList(raw: unknown): string[] {
 }
 
 function normalizeApprovalRuleOrder(raw: unknown): ApprovalRuleName[] {
-  const requested = normalizeStringList(raw).filter(
-    (rule): rule is ApprovalRuleName => APPROVAL_RULE_NAME_SET.has(rule),
+  const rawRules = normalizeStringList(raw);
+  const requested = rawRules.filter((rule): rule is ApprovalRuleName =>
+    APPROVAL_RULE_NAME_SET.has(rule),
   );
+  for (const ruleName of rawRules) {
+    if (!APPROVAL_RULE_NAME_SET.has(ruleName)) {
+      warnUnknownApprovalRuleName(ruleName);
+    }
+  }
   if (requested.length === 0) return [...DEFAULT_APPROVAL_RULE_ORDER];
 
   const ordered = [...new Set(requested)];
@@ -482,6 +491,9 @@ function normalizeApprovalRuleOrder(raw: unknown): ApprovalRuleName[] {
 function isApprovalRuleOrderDependencySafe(
   ruleOrder: ApprovalRuleName[],
 ): boolean {
+  // Missing rules have already been appended in default order, so monotonicity
+  // against the default index sequence means built-in prerequisites stay ahead
+  // of their dependents.
   let lastDefaultIndex = -1;
   for (const ruleName of ruleOrder) {
     const defaultIndex = DEFAULT_APPROVAL_RULE_ORDER.indexOf(ruleName);
@@ -493,11 +505,30 @@ function isApprovalRuleOrderDependencySafe(
 
 function warnInvalidApprovalRuleOrder(ruleOrder: ApprovalRuleName[]): void {
   const key = ruleOrder.join(',');
-  if (invalidApprovalRuleOrderWarnings.has(key)) return;
-  invalidApprovalRuleOrderWarnings.add(key);
+  if (!rememberApprovalRuleWarning(invalidApprovalRuleOrderWarnings, key))
+    return;
   console.warn(
     `[approval-policy] invalid approval.rule_order violates built-in rule dependencies; falling back to default order: ${key}`,
   );
+}
+
+function warnUnknownApprovalRuleName(ruleName: string): void {
+  if (!rememberApprovalRuleWarning(unknownApprovalRuleNameWarnings, ruleName)) {
+    return;
+  }
+  console.warn(
+    `[approval-policy] unknown approval.rule_order entry ignored: ${ruleName}`,
+  );
+}
+
+function rememberApprovalRuleWarning(
+  warnings: Set<string>,
+  key: string,
+): boolean {
+  if (warnings.has(key)) return false;
+  if (warnings.size >= MAX_APPROVAL_RULE_WARNING_KEYS) warnings.clear();
+  warnings.add(key);
+  return true;
 }
 
 function normalizeAutonomyLevel(raw: unknown): AutonomyLevel | null {
@@ -657,7 +688,7 @@ export function loadPolicyFromDisk(policyPath: string): ApprovalPolicyConfig {
 
   return {
     approvalRuleOrder: Array.isArray(filePolicy.approvalRuleOrder)
-      ? normalizeApprovalRuleOrder(filePolicy.approvalRuleOrder)
+      ? [...filePolicy.approvalRuleOrder]
       : [...DEFAULT_POLICY.approvalRuleOrder],
     pinnedRed:
       Array.isArray(filePolicy.pinnedRed) && filePolicy.pinnedRed.length > 0
@@ -1311,6 +1342,85 @@ function buildEvaluation(
   };
 }
 
+function buildPipelineFailureEvaluation(
+  context: ToolCallContext,
+  ruleName: ApprovalRuleName | 'pipeline_fallback',
+  error?: unknown,
+): ToolApprovalEvaluation {
+  const classified = context.classified ||
+    safeClassifyAction(context) || {
+      tier: 'red',
+      actionKey: `approval-pipeline:${ruleName}`,
+      intent: `evaluate approval rule ${ruleName}`,
+      consequenceIfDenied:
+        'I will skip this tool call until the approval policy is fixed.',
+      reason: 'approval policy rule evaluation failed',
+      commandPreview: normalizePreview(context.params.argsJson),
+      pathHints: [],
+      hostHints: [],
+      writeIntent: false,
+      promotableRed: false,
+      stickyYellow: true,
+    };
+  const fingerprint =
+    context.fingerprint ||
+    stableHash(
+      [
+        context.params.toolName,
+        classified.actionKey,
+        normalizePreview(classified.commandPreview),
+        normalizeText(JSON.stringify(context.args)),
+      ].join('|'),
+    );
+  const message =
+    error instanceof Error ? error.message : String(error || 'unknown error');
+  const stakesScore: StakesScore = context.stakesScore || {
+    level: 'high',
+    score: 1,
+    confidence: 1,
+    classifier: 'approval-policy',
+    signals: [],
+    reasons: [`approval rule ${ruleName} failed: ${message}`],
+  };
+
+  return {
+    baseTier: 'red',
+    tier: 'red',
+    autonomyLevel: context.autonomyLevel || 'confirm-each',
+    stakes: context.stakes || stakesScore.level,
+    stakesScore,
+    stakesMiddlewareDecision: context.stakesMiddlewareDecision || {
+      action: 'block',
+      reason: `approval rule ${ruleName} failed: ${message}`,
+    },
+    escalationRoute: 'policy_denial',
+    ...(context.escalationTarget
+      ? { escalationTarget: context.escalationTarget }
+      : {}),
+    decision: 'denied',
+    actionKey: classified.actionKey,
+    fingerprint,
+    intent: classified.intent,
+    consequenceIfDenied:
+      'I will skip this tool call until the approval policy is fixed.',
+    reason: `Approval policy rule ${ruleName} failed: ${message}`,
+    commandPreview: classified.commandPreview,
+    pinned: context.pinnedByPolicy === true,
+    hostHints: classified.hostHints,
+  };
+}
+
+function safeClassifyAction(context: ToolCallContext): ClassifiedAction | null {
+  try {
+    return context.helpers.classifyAction(
+      context.params.toolName,
+      context.args,
+    );
+  } catch {
+    return null;
+  }
+}
+
 function isRedRuleActive(context: ToolCallContext): boolean {
   return requireBaseTier(context) === 'red' && context.decision === 'auto';
 }
@@ -1598,6 +1708,7 @@ export const approvalRules: Record<ApprovalRuleName, ApprovalRule> = {
 };
 
 export function runApprovalRulePipeline(context: ToolCallContext): Decision {
+  const emitHookEvent = context.helpers.emitHookEvent;
   for (
     let index = 0;
     index < context.policy.approvalRuleOrder.length;
@@ -1605,27 +1716,47 @@ export function runApprovalRulePipeline(context: ToolCallContext): Decision {
   ) {
     const ruleName = context.policy.approvalRuleOrder[index];
     const rule = approvalRules[ruleName];
-    context.helpers.emitHookEvent?.({
-      hook: 'pre_tool_use',
-      ruleName,
-      toolName: context.params.toolName,
-      actionKey: context.classified?.actionKey,
-      decision: context.decision,
-    });
-    const result = rule(context);
-    context.helpers.emitHookEvent?.({
-      hook: 'post_tool_use',
-      ruleName,
-      toolName: context.params.toolName,
-      actionKey: context.classified?.actionKey,
-      decision:
-        result.kind === 'decision'
-          ? result.evaluation.decision
-          : context.decision,
-    });
+    if (emitHookEvent) {
+      emitHookEvent({
+        hook: 'pre_tool_use',
+        kind: 'approval_rule',
+        ruleName,
+        toolName: context.params.toolName,
+        actionKey: context.classified?.actionKey,
+        decision: context.decision,
+      });
+    }
+    let result: ApprovalRuleResult;
+    try {
+      result = rule(context);
+    } catch (error) {
+      console.error(
+        `[approval-policy] approval rule ${ruleName} failed; denying tool call:`,
+        error,
+      );
+      result = decision(
+        buildPipelineFailureEvaluation(context, ruleName, error),
+      );
+    }
+    if (emitHookEvent) {
+      emitHookEvent({
+        hook: 'post_tool_use',
+        kind: 'approval_rule',
+        ruleName,
+        toolName: context.params.toolName,
+        actionKey: context.classified?.actionKey,
+        decision:
+          result.kind === 'decision'
+            ? result.evaluation.decision
+            : context.decision,
+      });
+    }
     if (result.kind === 'decision') return result;
   }
-  return decision(buildEvaluation(context));
+  console.error(
+    '[approval-policy] approval rule pipeline reached fallback without a terminal decision; denying tool call.',
+  );
+  return decision(buildPipelineFailureEvaluation(context, 'pipeline_fallback'));
 }
 
 export class TrustedAgentApprovalRuntime {
@@ -1766,11 +1897,32 @@ export class TrustedAgentApprovalRuntime {
         this.actionExecutionCounts.get(actionKey) || 0,
       shouldApplyImplicitDelay: (toolName, channelId) =>
         this.shouldApplyImplicitDelay(toolName, channelId),
-      emitHookEvent: (event) => {
-        if (!this.approvalRuleHookEmitter) return;
-        void this.approvalRuleHookEmitter(event);
-      },
+      ...(this.approvalRuleHookEmitter
+        ? {
+            emitHookEvent: (event) => this.emitApprovalRuleHookEvent(event),
+          }
+        : {}),
     };
+  }
+
+  private emitApprovalRuleHookEvent(event: ApprovalRuleHookEvent): void {
+    if (!this.approvalRuleHookEmitter) return;
+    try {
+      const result = this.approvalRuleHookEmitter(event);
+      if (result && typeof result === 'object' && 'catch' in result) {
+        void result.catch((error) => {
+          console.error(
+            '[approval-policy] approval rule hook emitter failed:',
+            error,
+          );
+        });
+      }
+    } catch (error) {
+      console.error(
+        '[approval-policy] approval rule hook emitter failed:',
+        error,
+      );
+    }
   }
 
   private getCurrentAgentId(): string {

--- a/container/src/approval-policy.ts
+++ b/container/src/approval-policy.ts
@@ -79,6 +79,31 @@ export type ApprovalDecision =
   | 'required'
   | 'denied';
 
+export const DEFAULT_APPROVAL_RULE_ORDER = [
+  'policy_reload',
+  'classify_action',
+  'fingerprint',
+  'pinned_red',
+  'autonomy',
+  'safety_tier',
+  'stakes',
+  'autonomy_override',
+  'red_hard_deny',
+  'red_one_shot',
+  'red_session_trust',
+  'red_agent_trust',
+  'red_workspace_trust',
+  'red_promotable',
+  'red_full_auto',
+  'red_queue',
+  'red_prompt',
+  'yellow_full_auto',
+  'yellow_execution_promotion',
+  'green_fallback',
+] as const;
+
+export type ApprovalRuleName = (typeof DEFAULT_APPROVAL_RULE_ORDER)[number];
+
 export interface ApprovalPolicyRule {
   pattern?: string;
   paths?: string[];
@@ -86,6 +111,7 @@ export interface ApprovalPolicyRule {
 }
 
 export interface ApprovalPolicyConfig {
+  approvalRuleOrder: ApprovalRuleName[];
   pinnedRed: ApprovalPolicyRule[];
   autonomy: {
     defaultLevel: AutonomyLevel;
@@ -104,7 +130,7 @@ export interface ApprovalPolicyConfig {
   };
 }
 
-interface ClassifiedAction {
+export interface ClassifiedAction {
   tier: ApprovalTier;
   actionKey: string;
   intent: string;
@@ -119,7 +145,7 @@ interface ClassifiedAction {
   hardDeny?: boolean;
 }
 
-interface PendingApproval {
+export interface PendingApproval {
   id: string;
   fingerprint: string;
   actionKey: string;
@@ -163,6 +189,97 @@ export interface ToolApprovalEvaluation {
   implicitDelayMs?: number;
   hostHints: string[];
 }
+
+export interface ToolCallContext {
+  params: {
+    toolName: string;
+    argsJson: string;
+    latestUserPrompt: string;
+    channelId?: string;
+    escalationTarget?: EscalationTarget;
+  };
+  args: Record<string, unknown>;
+  policy: ApprovalPolicyConfig;
+  classified?: ClassifiedAction;
+  fingerprint?: string;
+  pinnedByPolicy?: boolean;
+  autonomyLevel?: AutonomyLevel;
+  safetyTier?: ApprovalTier;
+  baseTier?: ApprovalTier;
+  tier?: ApprovalTier;
+  decision?: ApprovalDecision;
+  stakes?: StakesLevel;
+  stakesScore?: StakesScore;
+  stakesMiddlewareDecision?: StakesMiddlewareResult['decision'];
+  outOfBoundByAutonomy: boolean;
+  escalationTarget?: EscalationTarget;
+  helpers: ToolCallContextHelpers;
+}
+
+export interface ToolCallContextHelpers {
+  reloadPolicyIfNeeded(): ApprovalPolicyConfig;
+  cleanupExpiredPending(): void;
+  classifyAction(
+    toolName: string,
+    args: Record<string, unknown>,
+  ): ClassifiedAction;
+  isPinnedRed(input: {
+    toolName: string;
+    preview: string;
+    pathHints: string[];
+    args: Record<string, unknown>;
+  }): boolean;
+  resolveAutonomyLevel(input: {
+    toolName: string;
+    actionKey: string;
+  }): AutonomyLevel;
+  runStakesMiddleware(
+    context: Omit<StakesMiddlewareContext, 'recordStakesScore'>,
+  ): StakesMiddlewareResult;
+  hasOneShotFingerprint(fingerprint: string): boolean;
+  consumeOneShotFingerprint(fingerprint: string): void;
+  hasSessionTrust(actionKey: string, fingerprint: string): boolean;
+  hasAgentTrust(actionKey: string, fingerprint: string): boolean;
+  hasWorkspaceTrust(actionKey: string, fingerprint: string): boolean;
+  getExplicitApprovalCount(actionKey: string): number;
+  isFullAutoEnabled(): boolean;
+  shouldNeverAutoApprove(toolName: string, actionKey: string): boolean;
+  getPendingCount(): number;
+  getOrCreatePending(
+    input: Omit<PendingApproval, 'id' | 'createdAtMs' | 'expiresAtMs'>,
+  ): PendingApproval;
+  getActionExecutionCount(actionKey: string): number;
+  shouldApplyImplicitDelay(
+    toolName: string,
+    channelId: string | undefined,
+  ): boolean;
+  emitHookEvent?(event: ApprovalRuleHookEvent): void;
+}
+
+export interface ApprovalRuleHookEvent {
+  hook: 'pre_tool_use' | 'post_tool_use';
+  ruleName: ApprovalRuleName;
+  toolName: string;
+  actionKey?: string;
+  decision?: ApprovalDecision;
+}
+
+export interface NextRule {
+  kind: 'next';
+}
+
+export interface Decision {
+  kind: 'decision';
+  evaluation: ToolApprovalEvaluation;
+}
+
+export type ApprovalRuleResult = Decision | NextRule;
+
+export type ApprovalRule = (context: ToolCallContext) => ApprovalRuleResult;
+
+export type ApprovalRuleHookEmitter = (
+  event: ApprovalRuleHookEvent,
+) => void | Promise<void>;
 
 const WORKSPACE_ROOT_ACTUAL = WORKSPACE_ROOT;
 const POLICY_PATH = path.join(
@@ -210,6 +327,7 @@ const SCRATCH_ROOTS = Array.from(
 );
 
 export const DEFAULT_POLICY: ApprovalPolicyConfig = {
+  approvalRuleOrder: [...DEFAULT_APPROVAL_RULE_ORDER],
   pinnedRed: [
     { pattern: 'rm\\s+-rf\\s+/' },
     { paths: ['~/.ssh/**', '/etc/**', '.env*'] },
@@ -256,6 +374,8 @@ const HOST_RE =
 const APPROVE_RE =
   /^(?:\/?(?:approve|yes|y))(?:\s+([a-f0-9-]{6,64}))?(?:\s+(for\s+session|session|for\s+all|all|for\s+agent|agent))?$/i;
 const DENY_RE = /^(?:\/?(?:deny|reject|skip|no|n))(?:\s+([a-f0-9-]{6,64}))?$/i;
+const APPROVAL_RULE_NAME_SET = new Set<string>(DEFAULT_APPROVAL_RULE_ORDER);
+const NEXT_RULE: NextRule = { kind: 'next' };
 
 function isVoiceChannelId(value: string | undefined): boolean {
   return String(value || '')
@@ -339,6 +459,19 @@ function normalizeStringList(raw: unknown): string[] {
       .filter(Boolean);
   }
   return [];
+}
+
+function normalizeApprovalRuleOrder(raw: unknown): ApprovalRuleName[] {
+  const requested = normalizeStringList(raw).filter(
+    (rule): rule is ApprovalRuleName => APPROVAL_RULE_NAME_SET.has(rule),
+  );
+  if (requested.length === 0) return [...DEFAULT_APPROVAL_RULE_ORDER];
+
+  const ordered = [...new Set(requested)];
+  for (const ruleName of DEFAULT_APPROVAL_RULE_ORDER) {
+    if (!ordered.includes(ruleName)) ordered.push(ruleName);
+  }
+  return ordered;
 }
 
 function normalizeAutonomyLevel(raw: unknown): AutonomyLevel | null {
@@ -434,6 +567,7 @@ export function parsePolicyYaml(raw: string): Partial<ApprovalPolicyConfig> {
   const networkState = readNetworkPolicyState(document);
 
   return {
+    approvalRuleOrder: normalizeApprovalRuleOrder(approval.rule_order),
     ...(pinnedRed.length > 0 ? { pinnedRed } : {}),
     autonomy: {
       defaultLevel:
@@ -496,6 +630,9 @@ export function loadPolicyFromDisk(policyPath: string): ApprovalPolicyConfig {
   }
 
   return {
+    approvalRuleOrder: Array.isArray(filePolicy.approvalRuleOrder)
+      ? normalizeApprovalRuleOrder(filePolicy.approvalRuleOrder)
+      : [...DEFAULT_POLICY.approvalRuleOrder],
     pinnedRed:
       Array.isArray(filePolicy.pinnedRed) && filePolicy.pinnedRed.length > 0
         ? filePolicy.pinnedRed
@@ -1022,6 +1159,449 @@ function parsePersistedTrustStore(
   }
 }
 
+function nextRule(): NextRule {
+  return NEXT_RULE;
+}
+
+function decision(evaluation: ToolApprovalEvaluation): Decision {
+  return { kind: 'decision', evaluation };
+}
+
+function requireClassified(context: ToolCallContext): ClassifiedAction {
+  if (!context.classified) {
+    throw new Error('Approval rule requires action classification first.');
+  }
+  return context.classified;
+}
+
+function requireFingerprint(context: ToolCallContext): string {
+  if (!context.fingerprint) {
+    throw new Error('Approval rule requires a fingerprint first.');
+  }
+  return context.fingerprint;
+}
+
+function requirePinned(context: ToolCallContext): boolean {
+  if (typeof context.pinnedByPolicy !== 'boolean') {
+    throw new Error('Approval rule requires pinned-red classification first.');
+  }
+  return context.pinnedByPolicy;
+}
+
+function requireAutonomyLevel(context: ToolCallContext): AutonomyLevel {
+  if (!context.autonomyLevel) {
+    throw new Error('Approval rule requires autonomy resolution first.');
+  }
+  return context.autonomyLevel;
+}
+
+function requireBaseTier(context: ToolCallContext): ApprovalTier {
+  if (!context.baseTier) {
+    throw new Error('Approval rule requires safety-tier resolution first.');
+  }
+  return context.baseTier;
+}
+
+function requireStakes(context: ToolCallContext): {
+  stakes: StakesLevel;
+  stakesScore: StakesScore;
+  stakesMiddlewareDecision: StakesMiddlewareResult['decision'];
+} {
+  if (
+    !context.stakes ||
+    !context.stakesScore ||
+    !context.stakesMiddlewareDecision
+  ) {
+    throw new Error('Approval rule requires stakes classification first.');
+  }
+  return {
+    stakes: context.stakes,
+    stakesScore: context.stakesScore,
+    stakesMiddlewareDecision: context.stakesMiddlewareDecision,
+  };
+}
+
+function buildEvaluation(
+  context: ToolCallContext,
+  overrides: Partial<
+    Pick<
+      ToolApprovalEvaluation,
+      | 'baseTier'
+      | 'tier'
+      | 'decision'
+      | 'escalationRoute'
+      | 'requestId'
+      | 'expiresAtMs'
+      | 'consequenceIfDenied'
+      | 'reason'
+    >
+  > = {},
+): ToolApprovalEvaluation {
+  const classified = requireClassified(context);
+  const fingerprint = requireFingerprint(context);
+  const pinnedByPolicy = requirePinned(context);
+  const autonomyLevel = requireAutonomyLevel(context);
+  const stakes = requireStakes(context);
+  const baseTier = overrides.baseTier || requireBaseTier(context);
+  const tier = overrides.tier || context.tier || baseTier;
+  const nextDecision = overrides.decision || context.decision || 'auto';
+  const escalationRoute =
+    overrides.escalationRoute || escalationRouteForDecision(nextDecision, tier);
+
+  return {
+    baseTier,
+    tier,
+    autonomyLevel,
+    stakes: stakes.stakes,
+    stakesScore: stakes.stakesScore,
+    stakesMiddlewareDecision: stakes.stakesMiddlewareDecision,
+    escalationRoute,
+    ...(context.escalationTarget
+      ? { escalationTarget: context.escalationTarget }
+      : {}),
+    decision: nextDecision,
+    actionKey: classified.actionKey,
+    fingerprint,
+    ...(overrides.requestId ? { requestId: overrides.requestId } : {}),
+    ...(typeof overrides.expiresAtMs === 'number'
+      ? { expiresAtMs: overrides.expiresAtMs }
+      : {}),
+    intent: classified.intent,
+    consequenceIfDenied:
+      overrides.consequenceIfDenied || classified.consequenceIfDenied,
+    reason: overrides.reason || classified.reason,
+    commandPreview: classified.commandPreview,
+    pinned: pinnedByPolicy,
+    implicitDelayMs:
+      tier === 'yellow' &&
+      nextDecision === 'implicit' &&
+      context.helpers.shouldApplyImplicitDelay(
+        context.params.toolName,
+        context.params.channelId,
+      )
+        ? YELLOW_IMPLICIT_DELAY_MS
+        : undefined,
+    hostHints: classified.hostHints,
+  };
+}
+
+function isRedRuleActive(context: ToolCallContext): boolean {
+  return requireBaseTier(context) === 'red' && context.decision === 'auto';
+}
+
+export const approvalRules: Record<ApprovalRuleName, ApprovalRule> = {
+  policy_reload(context) {
+    context.policy = context.helpers.reloadPolicyIfNeeded();
+    context.helpers.cleanupExpiredPending();
+    return nextRule();
+  },
+
+  classify_action(context) {
+    context.classified = context.helpers.classifyAction(
+      context.params.toolName,
+      context.args,
+    );
+    context.decision = 'auto';
+    return nextRule();
+  },
+
+  fingerprint(context) {
+    const classified = requireClassified(context);
+    context.fingerprint = stableHash(
+      [
+        context.params.toolName,
+        classified.actionKey,
+        normalizePreview(classified.commandPreview),
+        normalizeText(JSON.stringify(context.args)),
+      ].join('|'),
+    );
+    return nextRule();
+  },
+
+  pinned_red(context) {
+    const classified = requireClassified(context);
+    context.pinnedByPolicy = context.helpers.isPinnedRed({
+      toolName: context.params.toolName,
+      preview: classified.commandPreview,
+      pathHints: classified.pathHints,
+      args: context.args,
+    });
+    return nextRule();
+  },
+
+  autonomy(context) {
+    const classified = requireClassified(context);
+    context.autonomyLevel = context.helpers.resolveAutonomyLevel({
+      toolName: context.params.toolName,
+      actionKey: classified.actionKey,
+    });
+    return nextRule();
+  },
+
+  safety_tier(context) {
+    const classified = requireClassified(context);
+    const pinnedByPolicy = requirePinned(context);
+    context.safetyTier =
+      pinnedByPolicy || classified.tier === 'red' ? 'red' : classified.tier;
+    context.baseTier = context.safetyTier;
+    context.tier = context.safetyTier;
+    return nextRule();
+  },
+
+  stakes(context) {
+    const classified = requireClassified(context);
+    const pinnedByPolicy = requirePinned(context);
+    const safetyTier = context.safetyTier || requireBaseTier(context);
+    const stakesMiddleware = context.helpers.runStakesMiddleware({
+      toolName: context.params.toolName,
+      args: context.args,
+      actionKey: classified.actionKey,
+      intent: classified.intent,
+      reason: classified.reason,
+      target: classified.commandPreview,
+      approvalTier: safetyTier,
+      pathHints: classified.pathHints,
+      hostHints: classified.hostHints,
+      writeIntent: classified.writeIntent,
+      pinned: pinnedByPolicy,
+    });
+    context.stakesScore = stakesMiddleware.stakesScore;
+    context.stakes = stakesMiddleware.stakesScore.level;
+    context.stakesMiddlewareDecision = stakesMiddleware.decision;
+    return nextRule();
+  },
+
+  autonomy_override(context) {
+    const autonomyLevel = requireAutonomyLevel(context);
+    const { stakes } = requireStakes(context);
+    context.outOfBoundByAutonomy = false;
+    if (autonomyLevel === 'confirm-each') {
+      context.outOfBoundByAutonomy = true;
+      context.baseTier = 'red';
+      context.tier = 'red';
+    } else if (autonomyLevel === 'low-stakes-autonomous' && stakes !== 'low') {
+      context.outOfBoundByAutonomy = true;
+      context.baseTier = 'red';
+      context.tier = 'red';
+    }
+    return nextRule();
+  },
+
+  red_hard_deny(context) {
+    const classified = requireClassified(context);
+    if (!isRedRuleActive(context) || !classified.hardDeny) return nextRule();
+    return decision(
+      buildEvaluation(context, {
+        tier: 'red',
+        decision: 'denied',
+        escalationRoute: 'policy_denial',
+      }),
+    );
+  },
+
+  red_one_shot(context) {
+    if (!isRedRuleActive(context)) return nextRule();
+    const fingerprint = requireFingerprint(context);
+    if (!context.helpers.hasOneShotFingerprint(fingerprint)) return nextRule();
+    context.helpers.consumeOneShotFingerprint(fingerprint);
+    context.tier = requirePinned(context) ? 'red' : 'yellow';
+    context.decision = 'approved_once';
+    return nextRule();
+  },
+
+  red_session_trust(context) {
+    if (!isRedRuleActive(context)) return nextRule();
+    const classified = requireClassified(context);
+    if (
+      requirePinned(context) ||
+      !context.helpers.hasSessionTrust(
+        classified.actionKey,
+        requireFingerprint(context),
+      )
+    ) {
+      return nextRule();
+    }
+    context.tier = 'yellow';
+    context.decision = 'approved_session';
+    return nextRule();
+  },
+
+  red_agent_trust(context) {
+    if (!isRedRuleActive(context)) return nextRule();
+    const classified = requireClassified(context);
+    if (
+      requirePinned(context) ||
+      !context.helpers.hasAgentTrust(
+        classified.actionKey,
+        requireFingerprint(context),
+      )
+    ) {
+      return nextRule();
+    }
+    context.tier = 'yellow';
+    context.decision = 'approved_agent';
+    return nextRule();
+  },
+
+  red_workspace_trust(context) {
+    if (!isRedRuleActive(context)) return nextRule();
+    const classified = requireClassified(context);
+    if (
+      requirePinned(context) ||
+      !context.helpers.hasWorkspaceTrust(
+        classified.actionKey,
+        requireFingerprint(context),
+      )
+    ) {
+      return nextRule();
+    }
+    context.tier = 'yellow';
+    context.decision = 'approved_all';
+    return nextRule();
+  },
+
+  red_promotable(context) {
+    if (!isRedRuleActive(context)) return nextRule();
+    const classified = requireClassified(context);
+    const promotable =
+      !requirePinned(context) &&
+      classified.promotableRed &&
+      context.helpers.getExplicitApprovalCount(classified.actionKey) > 0;
+    if (!promotable) return nextRule();
+    context.tier = 'yellow';
+    context.decision = 'promoted';
+    return nextRule();
+  },
+
+  red_full_auto(context) {
+    if (!isRedRuleActive(context)) return nextRule();
+    const classified = requireClassified(context);
+    if (
+      context.helpers.isFullAutoEnabled() &&
+      !context.outOfBoundByAutonomy &&
+      !context.helpers.shouldNeverAutoApprove(
+        context.params.toolName,
+        classified.actionKey,
+      )
+    ) {
+      context.tier = 'yellow';
+      context.decision = 'approved_fullauto';
+    }
+    return nextRule();
+  },
+
+  red_queue(context) {
+    if (!isRedRuleActive(context)) return nextRule();
+    if (
+      context.helpers.getPendingCount() < context.policy.maxPendingApprovals
+    ) {
+      return nextRule();
+    }
+    return decision(
+      buildEvaluation(context, {
+        tier: 'red',
+        decision: 'denied',
+        escalationRoute: 'policy_denial',
+        consequenceIfDenied:
+          'If this is denied, I will continue with non-destructive alternatives only.',
+        reason: `Approval queue is full (${context.policy.maxPendingApprovals} pending).`,
+      }),
+    );
+  },
+
+  red_prompt(context) {
+    if (!isRedRuleActive(context)) return nextRule();
+    const classified = requireClassified(context);
+    const request = context.helpers.getOrCreatePending({
+      fingerprint: requireFingerprint(context),
+      actionKey: classified.actionKey,
+      toolName: context.params.toolName,
+      intent: classified.intent,
+      consequenceIfDenied: classified.consequenceIfDenied,
+      reason: classified.reason,
+      commandPreview: classified.commandPreview,
+      originalPrompt: context.params.latestUserPrompt,
+      pinned: requirePinned(context),
+    });
+    return decision(
+      buildEvaluation(context, {
+        tier: 'red',
+        decision: 'required',
+        escalationRoute: 'approval_request',
+        requestId: request.id,
+        expiresAtMs: request.expiresAtMs,
+      }),
+    );
+  },
+
+  yellow_full_auto(context) {
+    const classified = requireClassified(context);
+    if (
+      context.tier === 'yellow' &&
+      context.decision === 'auto' &&
+      context.helpers.isFullAutoEnabled() &&
+      !context.outOfBoundByAutonomy &&
+      !context.helpers.shouldNeverAutoApprove(
+        context.params.toolName,
+        classified.actionKey,
+      )
+    ) {
+      context.decision = 'approved_fullauto';
+    }
+    return nextRule();
+  },
+
+  yellow_execution_promotion(context) {
+    const classified = requireClassified(context);
+    if (context.tier !== 'yellow') return nextRule();
+    const executions = context.helpers.getActionExecutionCount(
+      classified.actionKey,
+    );
+    if (!classified.stickyYellow && executions >= 1) {
+      context.tier = 'green';
+      if (context.decision === 'auto') context.decision = 'promoted';
+    } else if (context.decision === 'auto') {
+      context.decision = 'implicit';
+    }
+    return nextRule();
+  },
+
+  green_fallback(context) {
+    return decision(buildEvaluation(context));
+  },
+};
+
+export function runApprovalRulePipeline(context: ToolCallContext): Decision {
+  for (
+    let index = 0;
+    index < context.policy.approvalRuleOrder.length;
+    index += 1
+  ) {
+    const ruleName = context.policy.approvalRuleOrder[index];
+    const rule = approvalRules[ruleName];
+    context.helpers.emitHookEvent?.({
+      hook: 'pre_tool_use',
+      ruleName,
+      toolName: context.params.toolName,
+      actionKey: context.classified?.actionKey,
+      decision: context.decision,
+    });
+    const result = rule(context);
+    context.helpers.emitHookEvent?.({
+      hook: 'post_tool_use',
+      ruleName,
+      toolName: context.params.toolName,
+      actionKey: context.classified?.actionKey,
+      decision:
+        result.kind === 'decision'
+          ? result.evaluation.decision
+          : context.decision,
+    });
+    if (result.kind === 'decision') return result;
+  }
+  return decision(buildEvaluation(context));
+}
+
 export class TrustedAgentApprovalRuntime {
   private readonly policyPath: string;
   private readonly agentTrustStorePath: string;
@@ -1044,6 +1624,7 @@ export class TrustedAgentApprovalRuntime {
   private readonly stakesMiddleware: ClassifierMiddlewareSkill<StakesMiddlewareContext>;
   private fullAutoEnabled = false;
   private readonly fullAutoNeverApprove = new Set<string>();
+  private approvalRuleHookEmitter: ApprovalRuleHookEmitter | null = null;
 
   constructor(
     policyPath = POLICY_PATH,
@@ -1070,6 +1651,12 @@ export class TrustedAgentApprovalRuntime {
       actionSet: this.allowlistedActions,
       fingerprintSet: this.allowlistedFingerprints,
     });
+  }
+
+  setApprovalRuleHookEmitter(
+    emitter: ApprovalRuleHookEmitter | null | undefined,
+  ): void {
+    this.approvalRuleHookEmitter = emitter || null;
   }
 
   private runStakesMiddleware(
@@ -1118,6 +1705,46 @@ export class TrustedAgentApprovalRuntime {
       this.fullAutoNeverApprove.has(normalizedTool) ||
       this.fullAutoNeverApprove.has(normalizedAction)
     );
+  }
+
+  private createToolCallContextHelpers(): ToolCallContextHelpers {
+    return {
+      reloadPolicyIfNeeded: () => this.reloadPolicyIfNeeded(),
+      cleanupExpiredPending: () => this.cleanupExpiredPending(),
+      classifyAction: (toolName, args) => this.classifyAction(toolName, args),
+      isPinnedRed: (input) => this.isPinnedRed(input),
+      resolveAutonomyLevel: (input) => this.resolveAutonomyLevel(input),
+      runStakesMiddleware: (context) => this.runStakesMiddleware(context),
+      hasOneShotFingerprint: (fingerprint) =>
+        this.oneShotFingerprints.has(fingerprint),
+      consumeOneShotFingerprint: (fingerprint) => {
+        this.oneShotFingerprints.delete(fingerprint);
+      },
+      hasSessionTrust: (actionKey, fingerprint) =>
+        this.sessionTrustedActions.has(actionKey) ||
+        this.sessionTrustedActions.has(fingerprint),
+      hasAgentTrust: (actionKey, fingerprint) =>
+        this.agentTrustedActions.has(actionKey) ||
+        this.agentTrustedFingerprints.has(fingerprint),
+      hasWorkspaceTrust: (actionKey, fingerprint) =>
+        this.allowlistedActions.has(actionKey) ||
+        this.allowlistedFingerprints.has(fingerprint),
+      getExplicitApprovalCount: (actionKey) =>
+        this.explicitApprovalCounts.get(actionKey) || 0,
+      isFullAutoEnabled: () => this.fullAutoEnabled,
+      shouldNeverAutoApprove: (toolName, actionKey) =>
+        this.shouldNeverAutoApprove(toolName, actionKey),
+      getPendingCount: () => this.pending.size,
+      getOrCreatePending: (input) => this.getOrCreatePending(input),
+      getActionExecutionCount: (actionKey) =>
+        this.actionExecutionCounts.get(actionKey) || 0,
+      shouldApplyImplicitDelay: (toolName, channelId) =>
+        this.shouldApplyImplicitDelay(toolName, channelId),
+      emitHookEvent: (event) => {
+        if (!this.approvalRuleHookEmitter) return;
+        void this.approvalRuleHookEmitter(event);
+      },
+    };
   }
 
   private getCurrentAgentId(): string {
@@ -1323,239 +1950,15 @@ export class TrustedAgentApprovalRuntime {
     channelId?: string;
     escalationTarget?: EscalationTarget;
   }): ToolApprovalEvaluation {
-    this.reloadPolicyIfNeeded();
-    this.cleanupExpiredPending();
-    const args = parseJsonObject(params.argsJson);
-    const classified = this.classifyAction(params.toolName, args);
-
-    const fingerprint = stableHash(
-      [
-        params.toolName,
-        classified.actionKey,
-        normalizePreview(classified.commandPreview),
-        normalizeText(JSON.stringify(args)),
-      ].join('|'),
-    );
-
-    const pinnedByPolicy = this.isPinnedRed({
-      toolName: params.toolName,
-      preview: classified.commandPreview,
-      pathHints: classified.pathHints,
-      args,
-    });
-    const autonomyLevel = this.resolveAutonomyLevel({
-      toolName: params.toolName,
-      actionKey: classified.actionKey,
-    });
-    const safetyTier: ApprovalTier =
-      pinnedByPolicy || classified.tier === 'red' ? 'red' : classified.tier;
-    const stakesMiddleware = this.runStakesMiddleware({
-      toolName: params.toolName,
-      args,
-      actionKey: classified.actionKey,
-      intent: classified.intent,
-      reason: classified.reason,
-      target: classified.commandPreview,
-      approvalTier: safetyTier,
-      pathHints: classified.pathHints,
-      hostHints: classified.hostHints,
-      writeIntent: classified.writeIntent,
-      pinned: pinnedByPolicy,
-    });
-    const stakesScore = stakesMiddleware.stakesScore;
-    const stakes = stakesScore.level;
-    const escalationTarget = normalizeEscalationTarget(params.escalationTarget);
-
-    let baseTier: ApprovalTier = safetyTier;
-    let outOfBoundByAutonomy = false;
-    if (autonomyLevel === 'confirm-each') {
-      outOfBoundByAutonomy = true;
-      baseTier = 'red';
-    } else if (autonomyLevel === 'low-stakes-autonomous') {
-      // Low-stakes autonomy permits only low-stakes actions to proceed without
-      // escalation. Medium and high stakes are out-of-bound and require a
-      // paused explicit approval path, rather than a yellow implicit notice.
-      if (stakes !== 'low') {
-        outOfBoundByAutonomy = true;
-        baseTier = 'red';
-      }
-    }
-
-    let tier: ApprovalTier = baseTier;
-    let decision: ApprovalDecision = 'auto';
-
-    if (baseTier === 'red') {
-      if (classified.hardDeny) {
-        return {
-          baseTier,
-          tier: 'red',
-          autonomyLevel,
-          stakes,
-          stakesScore,
-          stakesMiddlewareDecision: stakesMiddleware.decision,
-          escalationRoute: 'policy_denial',
-          ...(escalationTarget ? { escalationTarget } : {}),
-          decision: 'denied',
-          actionKey: classified.actionKey,
-          fingerprint,
-          intent: classified.intent,
-          consequenceIfDenied: classified.consequenceIfDenied,
-          reason: classified.reason,
-          commandPreview: classified.commandPreview,
-          pinned: pinnedByPolicy,
-          hostHints: classified.hostHints,
-        };
-      }
-
-      const oneShotApproved = this.oneShotFingerprints.has(fingerprint);
-      const sessionApproved =
-        !pinnedByPolicy &&
-        (this.sessionTrustedActions.has(classified.actionKey) ||
-          this.sessionTrustedActions.has(fingerprint));
-      const agentApproved =
-        !pinnedByPolicy &&
-        (this.agentTrustedActions.has(classified.actionKey) ||
-          this.agentTrustedFingerprints.has(fingerprint));
-      const allowlisted =
-        !pinnedByPolicy &&
-        (this.allowlistedActions.has(classified.actionKey) ||
-          this.allowlistedFingerprints.has(fingerprint));
-      const promotable =
-        !pinnedByPolicy &&
-        classified.promotableRed &&
-        (this.explicitApprovalCounts.get(classified.actionKey) || 0) > 0;
-
-      if (oneShotApproved) {
-        this.oneShotFingerprints.delete(fingerprint);
-        tier = pinnedByPolicy ? 'red' : 'yellow';
-        decision = 'approved_once';
-      } else if (sessionApproved) {
-        tier = 'yellow';
-        decision = 'approved_session';
-      } else if (agentApproved) {
-        tier = 'yellow';
-        decision = 'approved_agent';
-      } else if (allowlisted) {
-        tier = 'yellow';
-        decision = 'approved_all';
-      } else if (promotable) {
-        tier = 'yellow';
-        decision = 'promoted';
-      } else if (
-        this.fullAutoEnabled &&
-        !outOfBoundByAutonomy &&
-        !this.shouldNeverAutoApprove(params.toolName, classified.actionKey)
-      ) {
-        tier = 'yellow';
-        decision = 'approved_fullauto';
-      } else {
-        if (this.pending.size >= this.loadedPolicy.maxPendingApprovals) {
-          return {
-            baseTier,
-            tier: 'red',
-            autonomyLevel,
-            stakes,
-            stakesScore,
-            stakesMiddlewareDecision: stakesMiddleware.decision,
-            escalationRoute: 'policy_denial',
-            ...(escalationTarget ? { escalationTarget } : {}),
-            decision: 'denied',
-            actionKey: classified.actionKey,
-            fingerprint,
-            intent: classified.intent,
-            consequenceIfDenied:
-              'If this is denied, I will continue with non-destructive alternatives only.',
-            reason: `Approval queue is full (${this.loadedPolicy.maxPendingApprovals} pending).`,
-            commandPreview: classified.commandPreview,
-            pinned: pinnedByPolicy,
-            hostHints: classified.hostHints,
-          };
-        }
-        const request = this.getOrCreatePending({
-          fingerprint,
-          actionKey: classified.actionKey,
-          toolName: params.toolName,
-          intent: classified.intent,
-          consequenceIfDenied: classified.consequenceIfDenied,
-          reason: classified.reason,
-          commandPreview: classified.commandPreview,
-          originalPrompt: params.latestUserPrompt,
-          pinned: pinnedByPolicy,
-        });
-        return {
-          baseTier,
-          tier: 'red',
-          autonomyLevel,
-          stakes,
-          stakesScore,
-          stakesMiddlewareDecision: stakesMiddleware.decision,
-          escalationRoute: 'approval_request',
-          ...(escalationTarget ? { escalationTarget } : {}),
-          decision: 'required',
-          actionKey: classified.actionKey,
-          fingerprint,
-          requestId: request.id,
-          expiresAtMs: request.expiresAtMs,
-          intent: classified.intent,
-          consequenceIfDenied: classified.consequenceIfDenied,
-          reason: classified.reason,
-          commandPreview: classified.commandPreview,
-          pinned: pinnedByPolicy,
-          hostHints: classified.hostHints,
-        };
-      }
-    }
-
-    if (
-      tier === 'yellow' &&
-      decision === 'auto' &&
-      this.fullAutoEnabled &&
-      !outOfBoundByAutonomy &&
-      !this.shouldNeverAutoApprove(params.toolName, classified.actionKey)
-    ) {
-      decision = 'approved_fullauto';
-    }
-
-    if (tier === 'yellow') {
-      const executions =
-        this.actionExecutionCounts.get(classified.actionKey) || 0;
-      if (!classified.stickyYellow && executions >= 1) {
-        tier = 'green';
-        if (decision === 'auto') decision = 'promoted';
-      } else if (decision === 'auto') {
-        decision = 'implicit';
-      }
-    }
-
-    if (tier === 'green' && decision === 'auto') {
-      decision = 'auto';
-    }
-
-    return {
-      baseTier,
-      tier,
-      autonomyLevel,
-      stakes,
-      stakesScore,
-      stakesMiddlewareDecision: stakesMiddleware.decision,
-      escalationRoute: escalationRouteForDecision(decision, tier),
-      ...(escalationTarget ? { escalationTarget } : {}),
-      decision,
-      actionKey: classified.actionKey,
-      fingerprint,
-      intent: classified.intent,
-      consequenceIfDenied: classified.consequenceIfDenied,
-      reason: classified.reason,
-      commandPreview: classified.commandPreview,
-      pinned: pinnedByPolicy,
-      implicitDelayMs:
-        tier === 'yellow' &&
-        decision === 'implicit' &&
-        this.shouldApplyImplicitDelay(params.toolName, params.channelId)
-          ? YELLOW_IMPLICIT_DELAY_MS
-          : undefined,
-      hostHints: classified.hostHints,
+    const context: ToolCallContext = {
+      params,
+      args: parseJsonObject(params.argsJson),
+      policy: this.loadedPolicy,
+      outOfBoundByAutonomy: false,
+      escalationTarget: normalizeEscalationTarget(params.escalationTarget),
+      helpers: this.createToolCallContextHelpers(),
     };
+    return runApprovalRulePipeline(context).evaluation;
   }
 
   afterToolExecution(

--- a/container/src/approval-policy.ts
+++ b/container/src/approval-policy.ts
@@ -102,7 +102,9 @@ export const DEFAULT_APPROVAL_RULE_ORDER = [
   'green_fallback',
 ] as const;
 
-export type ApprovalRuleName = (typeof DEFAULT_APPROVAL_RULE_ORDER)[number];
+export type BuiltinApprovalRuleName =
+  (typeof DEFAULT_APPROVAL_RULE_ORDER)[number];
+export type ApprovalRuleName = BuiltinApprovalRuleName | (string & {});
 
 export interface ApprovalPolicyRule {
   pattern?: string;
@@ -375,11 +377,14 @@ const HOST_RE =
 const APPROVE_RE =
   /^(?:\/?(?:approve|yes|y))(?:\s+([a-f0-9-]{6,64}))?(?:\s+(for\s+session|session|for\s+all|all|for\s+agent|agent))?$/i;
 const DENY_RE = /^(?:\/?(?:deny|reject|skip|no|n))(?:\s+([a-f0-9-]{6,64}))?$/i;
-const APPROVAL_RULE_NAME_SET = new Set<string>(DEFAULT_APPROVAL_RULE_ORDER);
+const registeredApprovalRuleNames = new Set<string>(
+  DEFAULT_APPROVAL_RULE_ORDER,
+);
 const NEXT_RULE: NextRule = { kind: 'next' };
 const unknownApprovalRuleNameWarnings = new Set<string>();
 const invalidApprovalRuleOrderWarnings = new Set<string>();
 const MAX_APPROVAL_RULE_WARNING_KEYS = 50;
+const APPROVAL_RULE_NAME_RE = /^[a-z][a-z0-9_:-]*$/;
 
 function isVoiceChannelId(value: string | undefined): boolean {
   return String(value || '')
@@ -467,40 +472,73 @@ function normalizeStringList(raw: unknown): string[] {
 
 function normalizeApprovalRuleOrder(raw: unknown): ApprovalRuleName[] {
   const rawRules = normalizeStringList(raw);
-  const requested = rawRules.filter((rule): rule is ApprovalRuleName =>
-    APPROVAL_RULE_NAME_SET.has(rule),
-  );
+  const requested: ApprovalRuleName[] = [];
   for (const ruleName of rawRules) {
-    if (!APPROVAL_RULE_NAME_SET.has(ruleName)) {
+    if (registeredApprovalRuleNames.has(ruleName)) {
+      requested.push(ruleName);
+    } else {
       warnUnknownApprovalRuleName(ruleName);
     }
   }
   if (requested.length === 0) return [...DEFAULT_APPROVAL_RULE_ORDER];
 
   const ordered = [...new Set(requested)];
-  for (const ruleName of DEFAULT_APPROVAL_RULE_ORDER) {
-    if (!ordered.includes(ruleName)) ordered.push(ruleName);
-  }
   if (!isApprovalRuleOrderDependencySafe(ordered)) {
     warnInvalidApprovalRuleOrder(ordered);
     return [...DEFAULT_APPROVAL_RULE_ORDER];
   }
-  return ordered;
+  return mergeApprovalRuleOrder(ordered);
 }
 
 function isApprovalRuleOrderDependencySafe(
   ruleOrder: ApprovalRuleName[],
 ): boolean {
-  // Missing rules have already been appended in default order, so monotonicity
-  // against the default index sequence means built-in prerequisites stay ahead
-  // of their dependents.
   let lastDefaultIndex = -1;
   for (const ruleName of ruleOrder) {
-    const defaultIndex = DEFAULT_APPROVAL_RULE_ORDER.indexOf(ruleName);
+    const defaultIndex = getBuiltinRuleIndex(ruleName);
+    if (defaultIndex === -1) continue;
     if (defaultIndex < lastDefaultIndex) return false;
     lastDefaultIndex = defaultIndex;
   }
   return true;
+}
+
+function mergeApprovalRuleOrder(
+  configuredOrder: ApprovalRuleName[],
+): ApprovalRuleName[] {
+  const merged: ApprovalRuleName[] = [];
+  let defaultIndex = 0;
+  let customRulesBeforeNextBuiltin: ApprovalRuleName[] = [];
+
+  for (const ruleName of configuredOrder) {
+    const builtinIndex = getBuiltinRuleIndex(ruleName);
+    if (builtinIndex === -1) {
+      customRulesBeforeNextBuiltin.push(ruleName);
+      continue;
+    }
+
+    while (defaultIndex < builtinIndex) {
+      merged.push(DEFAULT_APPROVAL_RULE_ORDER[defaultIndex]);
+      defaultIndex += 1;
+    }
+    merged.push(...customRulesBeforeNextBuiltin);
+    customRulesBeforeNextBuiltin = [];
+    merged.push(ruleName);
+    defaultIndex = builtinIndex + 1;
+  }
+
+  merged.push(...customRulesBeforeNextBuiltin);
+  while (defaultIndex < DEFAULT_APPROVAL_RULE_ORDER.length) {
+    merged.push(DEFAULT_APPROVAL_RULE_ORDER[defaultIndex]);
+    defaultIndex += 1;
+  }
+  return merged;
+}
+
+function getBuiltinRuleIndex(ruleName: ApprovalRuleName): number {
+  return DEFAULT_APPROVAL_RULE_ORDER.indexOf(
+    ruleName as BuiltinApprovalRuleName,
+  );
 }
 
 function warnInvalidApprovalRuleOrder(ruleOrder: ApprovalRuleName[]): void {
@@ -529,6 +567,24 @@ function rememberApprovalRuleWarning(
   if (warnings.size >= MAX_APPROVAL_RULE_WARNING_KEYS) warnings.clear();
   warnings.add(key);
   return true;
+}
+
+export function registerApprovalRule(
+  ruleName: string,
+  rule: ApprovalRule,
+): ApprovalRuleName {
+  const normalized = ruleName.trim();
+  if (!APPROVAL_RULE_NAME_RE.test(normalized)) {
+    throw new Error(
+      `Approval rule names must match ${APPROVAL_RULE_NAME_RE.source}: ${ruleName}`,
+    );
+  }
+  if (registeredApprovalRuleNames.has(normalized)) {
+    throw new Error(`Approval rule already registered: ${normalized}`);
+  }
+  registeredApprovalRuleNames.add(normalized);
+  approvalRules[normalized] = rule;
+  return normalized;
 }
 
 function normalizeAutonomyLevel(raw: unknown): AutonomyLevel | null {
@@ -1728,6 +1784,9 @@ export function runApprovalRulePipeline(context: ToolCallContext): Decision {
     }
     let result: ApprovalRuleResult;
     try {
+      if (!rule) {
+        throw new Error(`approval rule is not registered: ${ruleName}`);
+      }
       result = rule(context);
     } catch (error) {
       console.error(

--- a/container/src/extensions.ts
+++ b/container/src/extensions.ts
@@ -1,3 +1,5 @@
+import { parseToolArgsJsonOrThrow } from './tool-args.js';
+
 type RuntimeEventName =
   | 'before_agent_start'
   | 'before_model_call'
@@ -131,14 +133,7 @@ function logHookArgumentParseFailure(hook: string, error: unknown): void {
 }
 
 function parseArgs(argsJson: string): Record<string, unknown> {
-  try {
-    const parsed = JSON.parse(argsJson) as unknown;
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed))
-      return {};
-    return parsed as Record<string, unknown>;
-  } catch (error) {
-    throw new Error(INVALID_ARGS_MESSAGE, { cause: error });
-  }
+  return parseToolArgsJsonOrThrow(argsJson, INVALID_ARGS_MESSAGE);
 }
 
 export async function emitRuntimeEvent(

--- a/container/src/extensions.ts
+++ b/container/src/extensions.ts
@@ -4,6 +4,8 @@ type RuntimeEventName =
   | 'after_model_call'
   | 'model_retry'
   | 'model_error'
+  | 'pre_tool_use'
+  | 'post_tool_use'
   | 'before_tool_call'
   | 'after_tool_call'
   | 'mcp_server_connected'

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -148,6 +148,15 @@ function applyRuntimeEnv(runtimeEnv: ContainerInput['runtimeEnv']): void {
 }
 
 const approvalRuntime = new TrustedAgentApprovalRuntime();
+approvalRuntime.setApprovalRuleHookEmitter((event) =>
+  emitRuntimeEvent({
+    event: event.hook,
+    approvalRule: event.ruleName,
+    toolName: event.toolName,
+    ...(event.actionKey ? { actionKey: event.actionKey } : {}),
+    ...(event.decision ? { decision: event.decision } : {}),
+  }),
+);
 let cachedSelectedSkillPath: string | null = null;
 
 /** Auth material received once via stdin, held in memory for the agent lifetime. */

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -64,6 +64,7 @@ import {
   readChatCompletionUsageTokens,
   recordPerformanceSample,
 } from './token-usage.js';
+import { parseToolArgsJson } from './tool-args.js';
 import { validateStructuredToolCalls } from './tool-call-validation.js';
 import type { ToolCallHistoryEntry } from './tool-loop-detection.js';
 import {
@@ -151,6 +152,7 @@ const approvalRuntime = new TrustedAgentApprovalRuntime();
 approvalRuntime.setApprovalRuleHookEmitter((event) =>
   emitRuntimeEvent({
     event: event.hook,
+    kind: event.kind,
     approvalRule: event.ruleName,
     toolName: event.toolName,
     ...(event.actionKey ? { actionKey: event.actionKey } : {}),
@@ -290,21 +292,9 @@ function normalizePathSlashes(raw: string): string {
   return raw.replace(/\\/g, '/');
 }
 
-function parseToolArgs(argsJson: string): Record<string, unknown> | null {
-  try {
-    const parsed = JSON.parse(argsJson) as unknown;
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      return null;
-    }
-    return parsed as Record<string, unknown>;
-  } catch {
-    return null;
-  }
-}
-
 function captureSkillSelection(toolName: string, argsJson: string): void {
   if (toolName !== 'read') return;
-  const args = parseToolArgs(argsJson);
+  const args = parseToolArgsJson(argsJson);
   const rawPath = String(args?.path || '').trim();
   if (!rawPath) return;
   const normalized = rawPath.replace(/\\/g, '/');

--- a/container/src/tool-args.ts
+++ b/container/src/tool-args.ts
@@ -1,0 +1,28 @@
+export function parseToolArgsJson(
+  argsJson: string,
+): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(argsJson) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export function parseToolArgsJsonOrThrow(
+  argsJson: string,
+  message: string,
+): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(argsJson) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed as Record<string, unknown>;
+  } catch (error) {
+    throw new Error(message, { cause: error });
+  }
+}

--- a/docs/content/internal/approval-rule-pipeline.md
+++ b/docs/content/internal/approval-rule-pipeline.md
@@ -1,0 +1,61 @@
+# Approval Rule Pipeline
+
+The tool approval cascade is implemented as a policy-configured rule pipeline in
+`container/src/approval-policy.ts`. Each rule receives a typed `ToolCallContext`
+and either returns `NextRule` or a terminal `Decision`.
+
+The default order is also the compatibility order. Workspaces may override
+`approval.rule_order` in `.hybridclaw/policy.yaml`; unknown rule names are
+ignored and missing built-in rules are appended in their default order.
+
+## Default Order
+
+1. `policy_reload` reloads `.hybridclaw/policy.yaml` if it changed and clears
+   expired pending approvals.
+2. `classify_action` classifies the tool call into an action key, base safety
+   tier, intent, preview, path hints, host hints, write intent, and promotion
+   metadata.
+3. `fingerprint` builds the stable tool-call fingerprint from the tool name,
+   action key, normalized preview, and normalized arguments.
+4. `pinned_red` applies hard-coded pinned path safeguards plus
+   `approval.pinned_red` policy rules.
+5. `autonomy` resolves the autonomy level from action override, tool override,
+   then policy default.
+6. `safety_tier` raises pinned or red-classified actions to red and seeds the
+   working base tier.
+7. `stakes` runs the stakes classifier middleware and stores its score and
+   middleware decision on the context.
+8. `autonomy_override` raises `confirm-each` actions, or non-low-stakes actions
+   under `low-stakes-autonomous`, to red approval.
+9. `red_hard_deny` returns a policy denial for hard-denied red actions.
+10. `red_one_shot` consumes one-shot approval fingerprints.
+11. `red_session_trust` applies in-memory session trust for non-pinned actions.
+12. `red_agent_trust` applies durable agent trust for non-pinned actions.
+13. `red_workspace_trust` applies durable workspace allowlist trust for
+    non-pinned actions.
+14. `red_promotable` promotes repeat-approved promotable red actions to yellow.
+15. `red_full_auto` allows full-auto mode to promote eligible red actions to
+    yellow.
+16. `red_queue` denies new approval requests when the pending queue is full.
+17. `red_prompt` creates or reuses a pending approval request.
+18. `yellow_full_auto` allows full-auto mode to approve eligible yellow actions.
+19. `yellow_execution_promotion` promotes repeated non-sticky yellow actions to
+    green, or marks first yellow execution as implicit.
+20. `green_fallback` returns the final evaluation for all non-terminal paths.
+
+The trust-store layout is unchanged: one-shot fingerprints, session trusted
+actions/fingerprints, agent trusted actions/fingerprints, and workspace
+allowlisted actions/fingerprints retain their existing storage.
+
+## Hook Events
+
+The pipeline emits `pre_tool_use` and `post_tool_use` hook events around each
+rule through the rule context. The container runtime wires those events into
+the F2 runtime event bus via `emitRuntimeEvent`, including `approvalRule`,
+`toolName`, `actionKey`, and current `decision` when available. The plugin
+event bus also exposes `pre_tool_use` and `post_tool_use` as first-class hook
+names while preserving the older `before_tool_call` and `after_tool_call`
+hooks.
+
+Future approval extensions should add a named rule and place it through
+`approval.rule_order` instead of editing the surrounding cascade.

--- a/docs/content/internal/approval-rule-pipeline.md
+++ b/docs/content/internal/approval-rule-pipeline.md
@@ -4,9 +4,10 @@ The tool approval cascade is implemented as a policy-configured rule pipeline in
 `container/src/approval-policy.ts`. Each rule receives a typed `ToolCallContext`
 and either returns `NextRule` or a terminal `Decision`.
 
-The default order is also the compatibility order. Workspaces may override
-`approval.rule_order` in `.hybridclaw/policy.yaml`; unknown rule names are
-ignored and missing built-in rules are appended in their default order.
+The default order is also the compatibility order. Workspaces may list built-in
+rules in `approval.rule_order` in `.hybridclaw/policy.yaml`; unknown rule names
+warn and are ignored, missing built-in rules are appended in default order, and
+orders that violate built-in dependencies fall back to the full default order.
 
 ## Default Order
 
@@ -39,11 +40,11 @@ allowlisted actions/fingerprints retain their existing storage.
 
 The pipeline emits `pre_tool_use` and `post_tool_use` hook events around each
 rule through the rule context. The container runtime wires those events into
-the F2 runtime event bus via `emitRuntimeEvent`, including `approvalRule`,
-`toolName`, `actionKey`, and current `decision` when available. The plugin
-event bus also exposes `pre_tool_use` and `post_tool_use` as first-class hook
-names while preserving the older `before_tool_call` and `after_tool_call`
-hooks.
+the F2 runtime event bus via `emitRuntimeEvent`, including
+`kind: "approval_rule"`, `approvalRule`, `toolName`, `actionKey`, and current
+`decision` when available. The plugin event bus also exposes `pre_tool_use` and
+`post_tool_use` as first-class hook names with `kind: "tool_execution"` while
+preserving the older `before_tool_call` and `after_tool_call` hooks.
 
 Future approval extensions should add a named rule and place it through
 `approval.rule_order` instead of editing the surrounding cascade.

--- a/docs/content/internal/approval-rule-pipeline.md
+++ b/docs/content/internal/approval-rule-pipeline.md
@@ -10,37 +10,25 @@ ignored and missing built-in rules are appended in their default order.
 
 ## Default Order
 
-1. `policy_reload` reloads `.hybridclaw/policy.yaml` if it changed and clears
-   expired pending approvals.
-2. `classify_action` classifies the tool call into an action key, base safety
-   tier, intent, preview, path hints, host hints, write intent, and promotion
-   metadata.
-3. `fingerprint` builds the stable tool-call fingerprint from the tool name,
-   action key, normalized preview, and normalized arguments.
-4. `pinned_red` applies hard-coded pinned path safeguards plus
-   `approval.pinned_red` policy rules.
-5. `autonomy` resolves the autonomy level from action override, tool override,
-   then policy default.
-6. `safety_tier` raises pinned or red-classified actions to red and seeds the
-   working base tier.
-7. `stakes` runs the stakes classifier middleware and stores its score and
-   middleware decision on the context.
-8. `autonomy_override` raises `confirm-each` actions, or non-low-stakes actions
-   under `low-stakes-autonomous`, to red approval.
+1. `policy_reload` reloads `.hybridclaw/policy.yaml` if it changed and clears expired pending approvals.
+2. `classify_action` classifies the tool call into an action key, base safety tier, intent, preview, path hints, host hints, write intent, and promotion metadata.
+3. `fingerprint` builds the stable tool-call fingerprint from the tool name, action key, normalized preview, and normalized arguments.
+4. `pinned_red` applies hard-coded pinned path safeguards plus `approval.pinned_red` policy rules.
+5. `autonomy` resolves the autonomy level from action override, tool override, then policy default.
+6. `safety_tier` raises pinned or red-classified actions to red and seeds the working base tier.
+7. `stakes` runs the stakes classifier middleware and stores its score and middleware decision on the context.
+8. `autonomy_override` raises `confirm-each` actions, or non-low-stakes actions under `low-stakes-autonomous`, to red approval.
 9. `red_hard_deny` returns a policy denial for hard-denied red actions.
 10. `red_one_shot` consumes one-shot approval fingerprints.
 11. `red_session_trust` applies in-memory session trust for non-pinned actions.
 12. `red_agent_trust` applies durable agent trust for non-pinned actions.
-13. `red_workspace_trust` applies durable workspace allowlist trust for
-    non-pinned actions.
+13. `red_workspace_trust` applies durable workspace allowlist trust for non-pinned actions.
 14. `red_promotable` promotes repeat-approved promotable red actions to yellow.
-15. `red_full_auto` allows full-auto mode to promote eligible red actions to
-    yellow.
+15. `red_full_auto` allows full-auto mode to promote eligible red actions to yellow.
 16. `red_queue` denies new approval requests when the pending queue is full.
 17. `red_prompt` creates or reuses a pending approval request.
 18. `yellow_full_auto` allows full-auto mode to approve eligible yellow actions.
-19. `yellow_execution_promotion` promotes repeated non-sticky yellow actions to
-    green, or marks first yellow execution as implicit.
+19. `yellow_execution_promotion` promotes repeated non-sticky yellow actions to green, or marks first yellow execution as implicit.
 20. `green_fallback` returns the final evaluation for all non-terminal paths.
 
 The trust-store layout is unchanged: one-shot fingerprints, session trusted

--- a/docs/content/internal/approval-rule-pipeline.md
+++ b/docs/content/internal/approval-rule-pipeline.md
@@ -5,9 +5,12 @@ The tool approval cascade is implemented as a policy-configured rule pipeline in
 and either returns `NextRule` or a terminal `Decision`.
 
 The default order is also the compatibility order. Workspaces may list built-in
-rules in `approval.rule_order` in `.hybridclaw/policy.yaml`; unknown rule names
-warn and are ignored, missing built-in rules are appended in default order, and
-orders that violate built-in dependencies fall back to the full default order.
+or registered external rules in `approval.rule_order` in
+`.hybridclaw/policy.yaml`; unknown rule names warn and are ignored, missing
+built-in rules are merged back in default order, and orders that violate
+built-in dependencies fall back to the full default order. External rules can be
+slotted between built-in anchors, for example between `stakes` and
+`autonomy_override`.
 
 ## Default Order
 
@@ -42,9 +45,25 @@ The pipeline emits `pre_tool_use` and `post_tool_use` hook events around each
 rule through the rule context. The container runtime wires those events into
 the F2 runtime event bus via `emitRuntimeEvent`, including
 `kind: "approval_rule"`, `approvalRule`, `toolName`, `actionKey`, and current
-`decision` when available. The plugin event bus also exposes `pre_tool_use` and
-`post_tool_use` as first-class hook names with `kind: "tool_execution"` while
-preserving the older `before_tool_call` and `after_tool_call` hooks.
+`decision` when available.
 
-Future approval extensions should add a named rule and place it through
-`approval.rule_order` instead of editing the surrounding cascade.
+The plugin event bus also exposes `pre_tool_use` and `post_tool_use` as
+first-class hook names with `kind: "tool_execution"` while preserving the older
+`before_tool_call` and `after_tool_call` hooks. Subscribers that listen to both
+approval-rule and tool-execution events must filter on `kind`.
+
+## External Rules
+
+Approval extensions register named rules with `registerApprovalRule(ruleName,
+rule)`. Registered names are accepted in `approval.rule_order`; the policy
+loader keeps built-in prerequisites in their default relative order while
+admitting external names between built-in anchors. A custom anomaly reranker can
+therefore register a rule and configure:
+
+```yaml
+approval:
+  rule_order:
+    - stakes
+    - anomaly_reranker
+    - autonomy_override
+```

--- a/src/plugins/plugin-manager.ts
+++ b/src/plugins/plugin-manager.ts
@@ -2254,12 +2254,14 @@ export class PluginManager {
 
     const toolArgs = isRecord(params.args) ? params.args : {};
     await this.dispatchHook('pre_tool_use', {
+      kind: 'tool_execution',
       sessionId: params.sessionId,
       channelId: params.channelId,
       toolName: params.toolName,
       arguments: toolArgs,
     });
     await this.dispatchHook('before_tool_call', {
+      kind: 'tool_execution',
       sessionId: params.sessionId,
       channelId: params.channelId,
       toolName: params.toolName,
@@ -2277,6 +2279,7 @@ export class PluginManager {
         await entry.tool.handler(toolArgs, context),
       );
       await this.dispatchHook('after_tool_call', {
+        kind: 'tool_execution',
         sessionId: params.sessionId,
         channelId: params.channelId,
         toolName: params.toolName,
@@ -2285,6 +2288,7 @@ export class PluginManager {
         isError: false,
       });
       await this.dispatchHook('post_tool_use', {
+        kind: 'tool_execution',
         sessionId: params.sessionId,
         channelId: params.channelId,
         toolName: params.toolName,
@@ -2299,6 +2303,7 @@ export class PluginManager {
           ? error.message
           : String(error || 'Unknown error');
       await this.dispatchHook('after_tool_call', {
+        kind: 'tool_execution',
         sessionId: params.sessionId,
         channelId: params.channelId,
         toolName: params.toolName,
@@ -2307,6 +2312,7 @@ export class PluginManager {
         isError: true,
       });
       await this.dispatchHook('post_tool_use', {
+        kind: 'tool_execution',
         sessionId: params.sessionId,
         channelId: params.channelId,
         toolName: params.toolName,

--- a/src/plugins/plugin-manager.ts
+++ b/src/plugins/plugin-manager.ts
@@ -2253,6 +2253,12 @@ export class PluginManager {
     }
 
     const toolArgs = isRecord(params.args) ? params.args : {};
+    await this.dispatchHook('pre_tool_use', {
+      sessionId: params.sessionId,
+      channelId: params.channelId,
+      toolName: params.toolName,
+      arguments: toolArgs,
+    });
     await this.dispatchHook('before_tool_call', {
       sessionId: params.sessionId,
       channelId: params.channelId,
@@ -2278,6 +2284,14 @@ export class PluginManager {
         result,
         isError: false,
       });
+      await this.dispatchHook('post_tool_use', {
+        sessionId: params.sessionId,
+        channelId: params.channelId,
+        toolName: params.toolName,
+        arguments: toolArgs,
+        result,
+        isError: false,
+      });
       return result;
     } catch (error) {
       const message =
@@ -2285,6 +2299,14 @@ export class PluginManager {
           ? error.message
           : String(error || 'Unknown error');
       await this.dispatchHook('after_tool_call', {
+        sessionId: params.sessionId,
+        channelId: params.channelId,
+        toolName: params.toolName,
+        arguments: toolArgs,
+        result: message,
+        isError: true,
+      });
+      await this.dispatchHook('post_tool_use', {
         sessionId: params.sessionId,
         channelId: params.channelId,
         toolName: params.toolName,

--- a/src/plugins/plugin-types.ts
+++ b/src/plugins/plugin-types.ts
@@ -196,6 +196,7 @@ export interface PluginAgentEndContext {
 }
 
 export interface PluginToolHookContext {
+  kind: 'tool_execution';
   sessionId: string;
   channelId: string;
   toolName: string;

--- a/src/plugins/plugin-types.ts
+++ b/src/plugins/plugin-types.ts
@@ -257,6 +257,8 @@ export type PluginHookName =
   | 'before_prompt_build'
   | 'before_agent_start'
   | 'agent_end'
+  | 'pre_tool_use'
+  | 'post_tool_use'
   | 'before_tool_call'
   | 'after_tool_call'
   | 'before_compaction'
@@ -293,6 +295,8 @@ export interface PluginHookHandlerMap {
     model?: string;
   }) => Promise<void> | void;
   agent_end: (context: PluginAgentEndContext) => Promise<void> | void;
+  pre_tool_use: (context: PluginToolHookContext) => Promise<void> | void;
+  post_tool_use: (context: PluginAfterToolCallContext) => Promise<void> | void;
   before_tool_call: (context: PluginToolHookContext) => Promise<void> | void;
   after_tool_call: (
     context: PluginAfterToolCallContext,

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -32,6 +32,27 @@ const WORKSPACE_STATE_FILENAME = 'workspace-state.json';
 const WORKSPACE_STATE_VERSION = 1;
 const POLICY_RELATIVE_PATH = path.join('.hybridclaw', 'policy.yaml');
 const DEFAULT_POLICY_TEMPLATE = `approval:
+  rule_order:
+    - policy_reload
+    - classify_action
+    - fingerprint
+    - pinned_red
+    - autonomy
+    - safety_tier
+    - stakes
+    - autonomy_override
+    - red_hard_deny
+    - red_one_shot
+    - red_session_trust
+    - red_agent_trust
+    - red_workspace_trust
+    - red_promotable
+    - red_full_auto
+    - red_queue
+    - red_prompt
+    - yellow_full_auto
+    - yellow_execution_promotion
+    - green_fallback
   pinned_red:
     - pattern: "rm -rf /"
     - paths: ["~/.ssh/**", "/etc/**", ".env*"]

--- a/tests/approval-policy.test.ts
+++ b/tests/approval-policy.test.ts
@@ -158,6 +158,8 @@ afterEach(() => {
 
 describe('TrustedAgentApprovalRuntime', () => {
   test('parsePolicyYaml reads dependency-safe approval rule order and appends missing core rules', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
     const parsed = parsePolicyYaml(`
 approval:
   rule_order:
@@ -175,6 +177,9 @@ approval:
     );
     expect(new Set(parsed.approvalRuleOrder)).toEqual(
       new Set(DEFAULT_APPROVAL_RULE_ORDER),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[approval-policy] unknown approval.rule_order entry ignored: unknown_future_rule',
     );
   });
 
@@ -335,14 +340,37 @@ approval:
     expect(result.evaluation.decision).toBe('auto');
     expect(events[0]).toMatchObject({
       hook: 'pre_tool_use',
+      kind: 'approval_rule',
       ruleName: 'policy_reload',
       toolName: 'read',
     });
     expect(events.at(-1)).toMatchObject({
       hook: 'post_tool_use',
+      kind: 'approval_rule',
       ruleName: 'green_fallback',
       decision: 'auto',
     });
+  });
+
+  test('approval pipeline denies instead of throwing when a rule runs before prerequisites', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const context = makeRuleContext();
+    context.policy = {
+      ...DEFAULT_POLICY,
+      approvalRuleOrder: ['fingerprint'],
+    };
+
+    const result = runApprovalRulePipeline(context);
+
+    expect(result.evaluation.decision).toBe('denied');
+    expect(result.evaluation.escalationRoute).toBe('policy_denial');
+    expect(result.evaluation.reason).toContain(
+      'Approval policy rule fingerprint failed',
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('approval rule fingerprint failed'),
+      expect.any(Error),
+    );
   });
 
   test('TrustedAgentApprovalRuntime sends rule hook events through the configured emitter', () => {
@@ -363,14 +391,38 @@ approval:
     expect(evaluation.decision).toBe('auto');
     expect(events[0]).toMatchObject({
       hook: 'pre_tool_use',
+      kind: 'approval_rule',
       ruleName: 'policy_reload',
       toolName: 'read',
     });
     expect(events.at(-1)).toMatchObject({
       hook: 'post_tool_use',
+      kind: 'approval_rule',
       ruleName: 'green_fallback',
       decision: 'auto',
     });
+  });
+
+  test('approval rule hook emitter failures are logged', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const runtime = new TrustedAgentApprovalRuntime(
+      '/tmp/hybridclaw-missing-policy.yaml',
+    );
+    runtime.setApprovalRuleHookEmitter(async () => {
+      throw new Error('hook failed');
+    });
+
+    runtime.evaluateToolCall({
+      toolName: 'read',
+      argsJson: JSON.stringify({ path: 'README.md' }),
+      latestUserPrompt: 'Read the README',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[approval-policy] approval rule hook emitter failed:',
+      expect.any(Error),
+    );
   });
 
   test('loadPolicyFromDisk logs malformed policy files before falling back to defaults', () => {

--- a/tests/approval-policy.test.ts
+++ b/tests/approval-policy.test.ts
@@ -4,10 +4,19 @@ import path from 'node:path';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import {
+  type ApprovalRuleHookEvent,
+  approvalRules,
+  type ClassifiedAction,
+  DEFAULT_APPROVAL_RULE_ORDER,
+  DEFAULT_POLICY,
   loadPolicyFromDisk,
   parsePolicyYaml,
+  runApprovalRulePipeline,
+  type ToolCallContext,
+  type ToolCallContextHelpers,
   TrustedAgentApprovalRuntime,
 } from '../container/src/approval-policy.js';
+import type { StakesScore } from '../container/src/stakes-classifier.js';
 import type { ChatMessage } from '../container/src/types.js';
 
 function userMessage(text: string): ChatMessage {
@@ -26,12 +35,326 @@ function writeTempPolicy(raw: string): string {
   return policyPath;
 }
 
+const LOW_STAKES_SCORE: StakesScore = {
+  level: 'low',
+  score: 0,
+  confidence: 1,
+  reasons: ['test low stakes'],
+  classifier: 'test',
+};
+
+const GREEN_CLASSIFIED: ClassifiedAction = {
+  tier: 'green',
+  actionKey: 'read',
+  intent: 'run read',
+  consequenceIfDenied: 'I will continue without this lookup.',
+  reason: 'this is a read-only operation',
+  commandPreview: '{"path":"README.md"}',
+  pathHints: [],
+  hostHints: [],
+  writeIntent: false,
+  promotableRed: false,
+  stickyYellow: false,
+};
+
+function makeRuleContext(params?: {
+  classified?: ClassifiedAction;
+  helpers?: Partial<ToolCallContextHelpers>;
+  events?: ApprovalRuleHookEvent[];
+}): ToolCallContext {
+  const classified = params?.classified || GREEN_CLASSIFIED;
+  const helpers: ToolCallContextHelpers = {
+    reloadPolicyIfNeeded: () => DEFAULT_POLICY,
+    cleanupExpiredPending: () => {},
+    classifyAction: () => classified,
+    isPinnedRed: () => false,
+    resolveAutonomyLevel: () => 'full-autonomous',
+    runStakesMiddleware: () => ({
+      decision: { action: 'allow' },
+      stakesScore: LOW_STAKES_SCORE,
+    }),
+    hasOneShotFingerprint: () => false,
+    consumeOneShotFingerprint: () => {},
+    hasSessionTrust: () => false,
+    hasAgentTrust: () => false,
+    hasWorkspaceTrust: () => false,
+    getExplicitApprovalCount: () => 0,
+    isFullAutoEnabled: () => false,
+    shouldNeverAutoApprove: () => false,
+    getPendingCount: () => 0,
+    getOrCreatePending: () => ({
+      id: 'req123',
+      fingerprint: 'fp123',
+      actionKey: classified.actionKey,
+      toolName: 'read',
+      intent: classified.intent,
+      consequenceIfDenied: classified.consequenceIfDenied,
+      reason: classified.reason,
+      commandPreview: classified.commandPreview,
+      originalPrompt: 'Read the README',
+      createdAtMs: 1,
+      expiresAtMs: 2,
+      pinned: false,
+    }),
+    getActionExecutionCount: () => 0,
+    shouldApplyImplicitDelay: () => false,
+    emitHookEvent: params?.events
+      ? (event) => params.events?.push(event)
+      : undefined,
+    ...params?.helpers,
+  };
+
+  return {
+    params: {
+      toolName: 'read',
+      argsJson: JSON.stringify({ path: 'README.md' }),
+      latestUserPrompt: 'Read the README',
+    },
+    args: { path: 'README.md' },
+    policy: DEFAULT_POLICY,
+    outOfBoundByAutonomy: false,
+    helpers,
+  };
+}
+
+function prepareRedRuleContext(params?: {
+  classified?: Partial<ClassifiedAction>;
+  helpers?: Partial<ToolCallContextHelpers>;
+  pinned?: boolean;
+}): ToolCallContext {
+  const classified: ClassifiedAction = {
+    ...GREEN_CLASSIFIED,
+    tier: 'red',
+    actionKey: 'bash:delete',
+    intent: 'run destructive command',
+    reason: 'the command deletes files',
+    commandPreview: 'rm -rf dist',
+    writeIntent: true,
+    stickyYellow: true,
+    ...params?.classified,
+  };
+  const context = makeRuleContext({
+    classified,
+    helpers: params?.helpers,
+  });
+  context.classified = classified;
+  context.fingerprint = 'fp123';
+  context.pinnedByPolicy = params?.pinned === true;
+  context.autonomyLevel = 'full-autonomous';
+  context.safetyTier = 'red';
+  context.baseTier = 'red';
+  context.tier = 'red';
+  context.decision = 'auto';
+  context.stakes = 'low';
+  context.stakesScore = LOW_STAKES_SCORE;
+  context.stakesMiddlewareDecision = { action: 'allow' };
+  return context;
+}
+
 afterEach(() => {
   vi.unstubAllEnvs();
   vi.restoreAllMocks();
 });
 
 describe('TrustedAgentApprovalRuntime', () => {
+  test('parsePolicyYaml reads approval rule order and appends missing core rules', () => {
+    const parsed = parsePolicyYaml(`
+approval:
+  rule_order:
+    - classify_action
+    - policy_reload
+    - unknown_future_rule
+`);
+
+    expect(parsed.approvalRuleOrder?.slice(0, 2)).toEqual([
+      'classify_action',
+      'policy_reload',
+    ]);
+    expect(parsed.approvalRuleOrder).toHaveLength(
+      DEFAULT_APPROVAL_RULE_ORDER.length,
+    );
+    expect(new Set(parsed.approvalRuleOrder)).toEqual(
+      new Set(DEFAULT_APPROVAL_RULE_ORDER),
+    );
+  });
+
+  test('approval rules are standalone predicates over a typed tool-call context', () => {
+    const setup = makeRuleContext();
+    expect(approvalRules.policy_reload(setup).kind).toBe('next');
+    expect(approvalRules.classify_action(setup).kind).toBe('next');
+    expect(setup.classified?.actionKey).toBe('read');
+    expect(approvalRules.fingerprint(setup).kind).toBe('next');
+    expect(setup.fingerprint).toBeTruthy();
+    expect(approvalRules.pinned_red(setup).kind).toBe('next');
+    expect(setup.pinnedByPolicy).toBe(false);
+    expect(approvalRules.autonomy(setup).kind).toBe('next');
+    expect(setup.autonomyLevel).toBe('full-autonomous');
+    expect(approvalRules.safety_tier(setup).kind).toBe('next');
+    expect(setup.baseTier).toBe('green');
+    expect(approvalRules.stakes(setup).kind).toBe('next');
+    expect(setup.stakes).toBe('low');
+    expect(approvalRules.autonomy_override(setup).kind).toBe('next');
+
+    const hardDeny = prepareRedRuleContext({
+      classified: { hardDeny: true },
+    });
+    expect(approvalRules.red_hard_deny(hardDeny)).toMatchObject({
+      kind: 'decision',
+      evaluation: { decision: 'denied', escalationRoute: 'policy_denial' },
+    });
+
+    const oneShot = prepareRedRuleContext({
+      helpers: {
+        hasOneShotFingerprint: () => true,
+      },
+    });
+    expect(approvalRules.red_one_shot(oneShot).kind).toBe('next');
+    expect(oneShot.decision).toBe('approved_once');
+
+    const session = prepareRedRuleContext({
+      helpers: {
+        hasSessionTrust: () => true,
+      },
+    });
+    expect(approvalRules.red_session_trust(session).kind).toBe('next');
+    expect(session.decision).toBe('approved_session');
+
+    const agent = prepareRedRuleContext({
+      helpers: {
+        hasAgentTrust: () => true,
+      },
+    });
+    expect(approvalRules.red_agent_trust(agent).kind).toBe('next');
+    expect(agent.decision).toBe('approved_agent');
+
+    const workspace = prepareRedRuleContext({
+      helpers: {
+        hasWorkspaceTrust: () => true,
+      },
+    });
+    expect(approvalRules.red_workspace_trust(workspace).kind).toBe('next');
+    expect(workspace.decision).toBe('approved_all');
+
+    const promotable = prepareRedRuleContext({
+      classified: { promotableRed: true },
+      helpers: {
+        getExplicitApprovalCount: () => 1,
+      },
+    });
+    expect(approvalRules.red_promotable(promotable).kind).toBe('next');
+    expect(promotable.decision).toBe('promoted');
+
+    const fullAuto = prepareRedRuleContext({
+      helpers: {
+        isFullAutoEnabled: () => true,
+      },
+    });
+    expect(approvalRules.red_full_auto(fullAuto).kind).toBe('next');
+    expect(fullAuto.decision).toBe('approved_fullauto');
+
+    const fullQueue = prepareRedRuleContext({
+      helpers: {
+        getPendingCount: () => DEFAULT_POLICY.maxPendingApprovals,
+      },
+    });
+    expect(approvalRules.red_queue(fullQueue)).toMatchObject({
+      kind: 'decision',
+      evaluation: {
+        decision: 'denied',
+        reason: expect.stringContaining('full'),
+      },
+    });
+
+    const prompt = prepareRedRuleContext();
+    expect(approvalRules.red_prompt(prompt)).toMatchObject({
+      kind: 'decision',
+      evaluation: { decision: 'required', requestId: 'req123' },
+    });
+
+    const yellowFullAuto = prepareRedRuleContext({
+      helpers: {
+        isFullAutoEnabled: () => true,
+      },
+    });
+    yellowFullAuto.baseTier = 'yellow';
+    yellowFullAuto.tier = 'yellow';
+    expect(approvalRules.yellow_full_auto(yellowFullAuto).kind).toBe('next');
+    expect(yellowFullAuto.decision).toBe('approved_fullauto');
+
+    const repeatedYellow = prepareRedRuleContext({
+      classified: { stickyYellow: false },
+      helpers: {
+        getActionExecutionCount: () => 1,
+      },
+    });
+    repeatedYellow.baseTier = 'yellow';
+    repeatedYellow.tier = 'yellow';
+    expect(approvalRules.yellow_execution_promotion(repeatedYellow).kind).toBe(
+      'next',
+    );
+    expect(repeatedYellow.tier).toBe('green');
+    expect(repeatedYellow.decision).toBe('promoted');
+
+    const fallback = makeRuleContext();
+    approvalRules.classify_action(fallback);
+    approvalRules.fingerprint(fallback);
+    approvalRules.pinned_red(fallback);
+    approvalRules.autonomy(fallback);
+    approvalRules.safety_tier(fallback);
+    approvalRules.stakes(fallback);
+    expect(approvalRules.green_fallback(fallback)).toMatchObject({
+      kind: 'decision',
+      evaluation: { decision: 'auto', tier: 'green' },
+    });
+  });
+
+  test('approval pipeline emits pre_tool_use and post_tool_use hook events around rules', () => {
+    const events: ApprovalRuleHookEvent[] = [];
+    const context = makeRuleContext({ events });
+
+    const result = runApprovalRulePipeline(context);
+
+    expect(result.evaluation.decision).toBe('auto');
+    expect(events[0]).toMatchObject({
+      hook: 'pre_tool_use',
+      ruleName: 'policy_reload',
+      toolName: 'read',
+    });
+    expect(events.at(-1)).toMatchObject({
+      hook: 'post_tool_use',
+      ruleName: 'green_fallback',
+      decision: 'auto',
+    });
+  });
+
+  test('TrustedAgentApprovalRuntime sends rule hook events through the configured emitter', () => {
+    const events: ApprovalRuleHookEvent[] = [];
+    const runtime = new TrustedAgentApprovalRuntime(
+      '/tmp/hybridclaw-missing-policy.yaml',
+    );
+    runtime.setApprovalRuleHookEmitter((event) => {
+      events.push(event);
+    });
+
+    const evaluation = runtime.evaluateToolCall({
+      toolName: 'read',
+      argsJson: JSON.stringify({ path: 'README.md' }),
+      latestUserPrompt: 'Read the README',
+    });
+
+    expect(evaluation.decision).toBe('auto');
+    expect(events[0]).toMatchObject({
+      hook: 'pre_tool_use',
+      ruleName: 'policy_reload',
+      toolName: 'read',
+    });
+    expect(events.at(-1)).toMatchObject({
+      hook: 'post_tool_use',
+      ruleName: 'green_fallback',
+      decision: 'auto',
+    });
+  });
+
   test('loadPolicyFromDisk logs malformed policy files before falling back to defaults', () => {
     const policyPath = writeTempPolicy(`
 network:

--- a/tests/approval-policy.test.ts
+++ b/tests/approval-policy.test.ts
@@ -157,24 +157,42 @@ afterEach(() => {
 });
 
 describe('TrustedAgentApprovalRuntime', () => {
-  test('parsePolicyYaml reads approval rule order and appends missing core rules', () => {
+  test('parsePolicyYaml reads dependency-safe approval rule order and appends missing core rules', () => {
     const parsed = parsePolicyYaml(`
 approval:
   rule_order:
-    - classify_action
     - policy_reload
+    - classify_action
     - unknown_future_rule
 `);
 
     expect(parsed.approvalRuleOrder?.slice(0, 2)).toEqual([
-      'classify_action',
       'policy_reload',
+      'classify_action',
     ]);
     expect(parsed.approvalRuleOrder).toHaveLength(
       DEFAULT_APPROVAL_RULE_ORDER.length,
     );
     expect(new Set(parsed.approvalRuleOrder)).toEqual(
       new Set(DEFAULT_APPROVAL_RULE_ORDER),
+    );
+  });
+
+  test('parsePolicyYaml falls back to default rule order when dependencies are misordered', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const parsed = parsePolicyYaml(`
+approval:
+  rule_order:
+    - fingerprint
+    - classify_action
+`);
+
+    expect(parsed.approvalRuleOrder).toEqual(DEFAULT_APPROVAL_RULE_ORDER);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'invalid approval.rule_order violates built-in rule dependencies',
+      ),
     );
   });
 

--- a/tests/approval-policy.test.ts
+++ b/tests/approval-policy.test.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_POLICY,
   loadPolicyFromDisk,
   parsePolicyYaml,
+  registerApprovalRule,
   runApprovalRulePipeline,
   type ToolCallContext,
   type ToolCallContextHelpers,
@@ -201,6 +202,27 @@ approval:
     );
   });
 
+  test('parsePolicyYaml slots registered external rules between built-in anchors', () => {
+    registerApprovalRule('test_anomaly_reranker', () => ({ kind: 'next' }));
+
+    const parsed = parsePolicyYaml(`
+approval:
+  rule_order:
+    - stakes
+    - test_anomaly_reranker
+    - autonomy_override
+`);
+
+    const stakesIndex = parsed.approvalRuleOrder?.indexOf('stakes') ?? -1;
+    expect(stakesIndex).toBeGreaterThanOrEqual(0);
+    expect(
+      parsed.approvalRuleOrder?.slice(stakesIndex, stakesIndex + 3),
+    ).toEqual(['stakes', 'test_anomaly_reranker', 'autonomy_override']);
+    expect(parsed.approvalRuleOrder).toHaveLength(
+      DEFAULT_APPROVAL_RULE_ORDER.length + 1,
+    );
+  });
+
   test('approval rules are standalone predicates over a typed tool-call context', () => {
     const setup = makeRuleContext();
     expect(approvalRules.policy_reload(setup).kind).toBe('next');
@@ -350,6 +372,33 @@ approval:
       ruleName: 'green_fallback',
       decision: 'auto',
     });
+  });
+
+  test('approval pipeline runs registered external rules from configured order', () => {
+    const observed: string[] = [];
+    registerApprovalRule('test_external_stakes_rule', (context) => {
+      observed.push(context.stakes ? 'after_stakes' : 'before_stakes');
+      return { kind: 'next' };
+    });
+    const parsed = parsePolicyYaml(`
+approval:
+  rule_order:
+    - stakes
+    - test_external_stakes_rule
+    - autonomy_override
+`);
+    const context = makeRuleContext();
+    context.policy = {
+      ...DEFAULT_POLICY,
+      approvalRuleOrder:
+        parsed.approvalRuleOrder || DEFAULT_POLICY.approvalRuleOrder,
+    };
+    context.helpers.reloadPolicyIfNeeded = () => context.policy;
+
+    const result = runApprovalRulePipeline(context);
+
+    expect(result.evaluation.decision).toBe('auto');
+    expect(observed).toEqual(['after_stakes']);
   });
 
   test('approval pipeline denies instead of throwing when a rule runs before prerequisites', () => {


### PR DESCRIPTION
## Summary

Implements #731 by refactoring the container approval cascade into a typed rule pipeline while preserving existing approval decisions and trust-store layout.

## What changed

- Added named approval rules driven by `ToolCallContext` and `Decision | NextRule` results.
- Added policy-configured `approval.rule_order` with the current cascade as the default order.
- Wired approval rule `pre_tool_use` / `post_tool_use` events into the container runtime event bus and exposed those hook names in the plugin event bus.
- Preserved existing one-shot, session, agent, and workspace trust-store behavior.
- Added isolated rule tests, assembled runtime approval coverage, and an internal decision-flow doc.

## Validation

- `npx vitest run tests/approval-policy.test.ts tests/container.extensions.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm --prefix container run lint`
- `npm run build`

Note: `npm run check` still reports unrelated pre-existing Biome formatting/import issues in `src/cli/secret-command.ts` and `src/policy/secret-route-policy.ts`; those files are not part of this PR.

Closes #731