### PR TITLE
[codex] stabilize chat agent switching

### DIFF
--- a/console/src/api/chat-types.ts
+++ b/console/src/api/chat-types.ts
@@ -1,5 +1,3 @@
-import type { AdminCommandResult } from './types';
-
 export interface ChatRecentSession {
   sessionId: string;
   title: string | null;
@@ -140,8 +138,6 @@ export interface MediaUploadResponse {
 export interface BranchResponse {
   sessionId: string;
 }
-
-export type CommandResponse = AdminCommandResult;
 
 export interface ChatMessage {
   id: string;

--- a/console/src/api/chat-types.ts
+++ b/console/src/api/chat-types.ts
@@ -140,8 +140,14 @@ export interface BranchResponse {
 }
 
 export interface CommandResponse {
+  kind?: 'plain' | 'info' | 'error';
   status?: string;
   error?: string;
+  title?: string;
+  text?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  mainSessionKey?: string;
 }
 
 export interface ChatMessage {

--- a/console/src/api/chat-types.ts
+++ b/console/src/api/chat-types.ts
@@ -1,3 +1,5 @@
+import type { AdminCommandResult } from './types';
+
 export interface ChatRecentSession {
   sessionId: string;
   title: string | null;
@@ -139,16 +141,7 @@ export interface BranchResponse {
   sessionId: string;
 }
 
-export interface CommandResponse {
-  kind?: 'plain' | 'info' | 'error';
-  status?: string;
-  error?: string;
-  title?: string;
-  text?: string;
-  sessionId?: string;
-  sessionKey?: string;
-  mainSessionKey?: string;
-}
+export type CommandResponse = AdminCommandResult;
 
 export interface ChatMessage {
   id: string;

--- a/console/src/api/chat.ts
+++ b/console/src/api/chat.ts
@@ -5,7 +5,6 @@ import type {
   ChatHistoryResponse,
   ChatMobileQrResponse,
   ChatRecentResponse,
-  CommandResponse,
   MediaUploadResponse,
 } from './chat-types';
 import {
@@ -15,6 +14,7 @@ import {
   requestJson,
   validateToken,
 } from './client';
+import type { AdminCommandResult } from './types';
 
 export { validateToken as fetchAppStatus };
 
@@ -100,8 +100,8 @@ export function executeCommand(
   sessionId: string,
   userId: string,
   args: string[],
-): Promise<CommandResponse> {
-  return requestJson<CommandResponse>('/api/command', {
+): Promise<AdminCommandResult> {
+  return requestJson<AdminCommandResult>('/api/command', {
     token,
     method: 'POST',
     body: buildWebCommandRequestBody({

--- a/console/src/auth.tsx
+++ b/console/src/auth.tsx
@@ -43,7 +43,7 @@ type AuthState =
       error: string;
     };
 
-type AuthContextValue = AuthState & {
+export type AuthContextValue = AuthState & {
   login: (token: string) => Promise<void>;
   logout: () => void;
   retry: () => Promise<void>;
@@ -243,6 +243,12 @@ export function AuthProvider(props: { children: ReactNode }) {
   return (
     <AuthContext.Provider value={value}>{props.children}</AuthContext.Provider>
   );
+}
+
+export function isAuthReadyForApi(auth: AuthContextValue): boolean {
+  if (auth.status !== 'ready') return false;
+  if (auth.gatewayStatus.webAuthConfigured !== true) return true;
+  return auth.token.trim().length > 0;
 }
 
 export function useAuth(): AuthContextValue {

--- a/console/src/lib/chat-helpers.ts
+++ b/console/src/lib/chat-helpers.ts
@@ -21,9 +21,23 @@ export function randomHex(bytes: number): string {
   return Array.from(arr, (v) => v.toString(16).padStart(2, '0')).join('');
 }
 
-export function generateWebSessionId(agentId = DEFAULT_AGENT_ID): string {
-  const normalized = agentId.trim().toLowerCase();
-  return `agent:${encodeURIComponent(normalized)}:channel:web:chat:dm:peer:${randomHex(8)}`;
+function padSessionTimestampPart(value: number): string {
+  return String(Math.max(0, Math.trunc(value))).padStart(2, '0');
+}
+
+export function generateWebSessionId(_agentId = DEFAULT_AGENT_ID): string {
+  const now = new Date();
+  const date = [
+    String(now.getUTCFullYear()).padStart(4, '0'),
+    padSessionTimestampPart(now.getUTCMonth() + 1),
+    padSessionTimestampPart(now.getUTCDate()),
+  ].join('');
+  const time = [
+    padSessionTimestampPart(now.getUTCHours()),
+    padSessionTimestampPart(now.getUTCMinutes()),
+    padSessionTimestampPart(now.getUTCSeconds()),
+  ].join('');
+  return `sess_${date}_${time}_${randomHex(4)}`;
 }
 
 export function readStoredUserId(): string {

--- a/console/src/lib/chat-helpers.ts
+++ b/console/src/lib/chat-helpers.ts
@@ -21,23 +21,13 @@ export function randomHex(bytes: number): string {
   return Array.from(arr, (v) => v.toString(16).padStart(2, '0')).join('');
 }
 
-function padSessionTimestampPart(value: number): string {
-  return String(Math.max(0, Math.trunc(value))).padStart(2, '0');
-}
-
-export function generateWebSessionId(_agentId = DEFAULT_AGENT_ID): string {
-  const now = new Date();
-  const date = [
-    String(now.getUTCFullYear()).padStart(4, '0'),
-    padSessionTimestampPart(now.getUTCMonth() + 1),
-    padSessionTimestampPart(now.getUTCDate()),
-  ].join('');
-  const time = [
-    padSessionTimestampPart(now.getUTCHours()),
-    padSessionTimestampPart(now.getUTCMinutes()),
-    padSessionTimestampPart(now.getUTCSeconds()),
-  ].join('');
-  return `sess_${date}_${time}_${randomHex(4)}`;
+export function generateWebSessionId(): string {
+  const timestamp = new Date()
+    .toISOString()
+    .slice(0, 19)
+    .replace(/[-:]/g, '')
+    .replace('T', '_');
+  return `sess_${timestamp}_${randomHex(4)}`;
 }
 
 export function readStoredUserId(): string {

--- a/console/src/router.tsx
+++ b/console/src/router.tsx
@@ -179,16 +179,15 @@ const toolsRoute = createRoute({
   component: ToolsPage,
 });
 
-const chatIndexRoute = createRoute({
+const chatRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/chat',
   component: ChatRouteComponent,
 });
 
 const chatSessionRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  path: '/chat/$sessionId',
-  component: ChatRouteComponent,
+  getParentRoute: () => chatRoute,
+  path: '$sessionId',
 });
 
 const routeTree = rootRoute.addChildren([
@@ -213,8 +212,7 @@ const routeTree = rootRoute.addChildren([
     pluginsRoute,
     toolsRoute,
   ]),
-  chatIndexRoute,
-  chatSessionRoute,
+  chatRoute.addChildren([chatSessionRoute]),
 ]);
 
 export const router = createRouter({

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -409,17 +409,15 @@ describe('ChatPage', () => {
       __testRouter: TestRouter;
     };
     routerModule.__testRouter.setSessionId(null);
-    fetchChatHistoryMock.mockResolvedValue({
-      sessionId: 'sess_20260504_154556_46df76d3',
+    fetchChatHistoryMock.mockImplementation(async (_token, sessionId) => ({
+      sessionId,
       history: [],
-    });
+    }));
     executeCommandMock.mockImplementation(
       async (_token, sessionId): Promise<CommandResponse> => ({
         kind: 'plain',
         text: 'Session agent set to `bk` (model: `openrouter/nvidia/nemotron-3-super-120b-a12b:free`).',
-        sessionId: sessionId.startsWith('agent:')
-          ? 'sess_20260504_154556_46df76d3'
-          : sessionId,
+        sessionId,
       }),
     );
 
@@ -434,6 +432,9 @@ describe('ChatPage', () => {
       expect(routerModule.__testRouter.lastTo).toBe('/chat/$sessionId'),
     );
     expect(routerModule.__testRouter.lastReplace).toBe(true);
+    expect(executeCommandMock.mock.calls[0]?.[1]).toMatch(
+      /^sess_\d{8}_\d{6}_[0-9a-f]{8}$/,
+    );
     await waitFor(() => {
       expect(document.body.textContent).toContain('Session agent set to bk');
       expect(document.body.textContent).toContain(

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -213,7 +213,7 @@ describe('ChatPage', () => {
     isActiveMock.mockReset();
     useChatStreamMock.mockReset();
 
-    useAuthMock.mockReturnValue({ token: 'test-token' });
+    useAuthMock.mockReturnValue({ status: 'ready', token: 'test-token' });
     fetchAppStatusMock.mockResolvedValue({
       status: 'ok',
       webAuthConfigured: true,
@@ -276,6 +276,28 @@ describe('ChatPage', () => {
       streamingMsgId: null,
       isActive: isActiveMock,
     });
+  });
+
+  it('does not issue chat API queries before auth is ready', async () => {
+    useAuthMock.mockReturnValue({
+      status: 'checking',
+      token: 'stale-token',
+      gatewayStatus: null,
+      error: null,
+    });
+
+    renderChatPage();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetchAppStatusMock).not.toHaveBeenCalled();
+    expect(fetchAgentListMock).not.toHaveBeenCalled();
+    expect(fetchModelsMock).not.toHaveBeenCalled();
+    expect(fetchChatRecentMock).not.toHaveBeenCalled();
+    expect(fetchChatHistoryMock).not.toHaveBeenCalled();
+    expect(fetchChatContextMock).not.toHaveBeenCalled();
   });
 
   it('loads history, sends from the composer, and switches recent sessions', async () => {

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -23,6 +23,7 @@ import type {
   ChatHistoryResponse,
   ChatMobileQrResponse,
   ChatRecentResponse,
+  CommandResponse,
   MediaUploadResponse,
 } from '../../api/chat-types';
 import type {
@@ -65,6 +66,15 @@ const createChatBranchMock =
   >();
 const uploadMediaMock =
   vi.fn<(token: string, file: File) => Promise<MediaUploadResponse>>();
+const executeCommandMock =
+  vi.fn<
+    (
+      token: string,
+      sessionId: string,
+      userId: string,
+      args: string[],
+    ) => Promise<CommandResponse>
+  >();
 const fetchAgentListMock = vi.fn<(token: string) => Promise<AgentListItem[]>>();
 const fetchModelsMock =
   vi.fn<(token: string) => Promise<AdminModelsResponse>>();
@@ -97,6 +107,12 @@ vi.mock('../../api/chat', () => ({
     beforeMessageId: number | string,
   ) => createChatBranchMock(token, sessionId, beforeMessageId),
   uploadMedia: (token: string, file: File) => uploadMediaMock(token, file),
+  executeCommand: (
+    token: string,
+    sessionId: string,
+    userId: string,
+    args: string[],
+  ) => executeCommandMock(token, sessionId, userId, args),
 }));
 
 vi.mock('../../api/client', () => ({
@@ -200,6 +216,7 @@ describe('ChatPage', () => {
     createChatMobileQrMock.mockReset();
     createChatBranchMock.mockReset();
     uploadMediaMock.mockReset();
+    executeCommandMock.mockReset();
     fetchAgentListMock.mockReset();
     fetchModelsMock.mockReset();
     fetchModelsMock.mockResolvedValue({
@@ -258,6 +275,11 @@ describe('ChatPage', () => {
     fetchChatContextMock.mockResolvedValue({
       sessionId: 'session-a',
       snapshot: null,
+    });
+    executeCommandMock.mockResolvedValue({
+      kind: 'plain',
+      text: 'Session agent set to `charly` (model: `gpt-5`).',
+      sessionId: 'session-a',
     });
     fetchAgentListMock.mockResolvedValue([
       { id: 'main', name: 'Assistant' },
@@ -348,12 +370,11 @@ describe('ChatPage', () => {
     );
   });
 
-  it('switches agents from the composer dropdown using the slash command path', async () => {
+  it('switches agents from the composer dropdown using the command path', async () => {
     fetchChatHistoryMock.mockResolvedValue({
       sessionId: 'session-a',
       history: [{ id: 101, role: 'assistant', content: 'Opened session A' }],
     });
-    sendMessageMock.mockResolvedValue(true);
 
     renderChatPage();
 
@@ -365,10 +386,60 @@ describe('ChatPage', () => {
     });
 
     await waitFor(() =>
-      expect(sendMessageMock).toHaveBeenCalledWith('/agent switch charly', [], {
-        hideUser: true,
+      expect(executeCommandMock).toHaveBeenCalledWith(
+        'test-token',
+        'session-a',
+        'web-user-1',
+        ['agent', 'switch', 'charly'],
+      ),
+    );
+    expect(sendMessageMock).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(document.body.textContent).toContain(
+        'Session agent set to charly',
+      );
+      expect(document.body.textContent).toContain('gpt-5');
+    });
+  });
+
+  it('keeps first agent switch result visible when bare /chat resolves to a server session id', async () => {
+    const routerModule = (await import(
+      '@tanstack/react-router'
+    )) as unknown as {
+      __testRouter: TestRouter;
+    };
+    routerModule.__testRouter.setSessionId(null);
+    fetchChatHistoryMock.mockResolvedValue({
+      sessionId: 'sess_20260504_154556_46df76d3',
+      history: [],
+    });
+    executeCommandMock.mockImplementation(
+      async (_token, sessionId): Promise<CommandResponse> => ({
+        kind: 'plain',
+        text: 'Session agent set to `bk` (model: `openrouter/nvidia/nemotron-3-super-120b-a12b:free`).',
+        sessionId: sessionId.startsWith('agent:')
+          ? 'sess_20260504_154556_46df76d3'
+          : sessionId,
       }),
     );
+
+    renderChatPage();
+
+    const agentSelect = await screen.findByLabelText('Switch agent');
+    fireEvent.change(agentSelect, {
+      target: { value: 'charly' },
+    });
+
+    await waitFor(() =>
+      expect(routerModule.__testRouter.lastTo).toBe('/chat/$sessionId'),
+    );
+    expect(routerModule.__testRouter.lastReplace).toBe(true);
+    await waitFor(() => {
+      expect(document.body.textContent).toContain('Session agent set to bk');
+      expect(document.body.textContent).toContain(
+        'openrouter/nvidia/nemotron-3-super-120b-a12b:free',
+      );
+    });
   });
 
   it('syncs the model dropdown from the session context snapshot', async () => {

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -23,10 +23,10 @@ import type {
   ChatHistoryResponse,
   ChatMobileQrResponse,
   ChatRecentResponse,
-  CommandResponse,
   MediaUploadResponse,
 } from '../../api/chat-types';
 import type {
+  AdminCommandResult,
   AdminModelsResponse,
   AgentListItem,
   GatewayStatus,
@@ -73,7 +73,7 @@ const executeCommandMock =
       sessionId: string,
       userId: string,
       args: string[],
-    ) => Promise<CommandResponse>
+    ) => Promise<AdminCommandResult>
   >();
 const fetchAgentListMock = vi.fn<(token: string) => Promise<AgentListItem[]>>();
 const fetchModelsMock =
@@ -431,7 +431,7 @@ describe('ChatPage', () => {
       history: [],
     }));
     executeCommandMock.mockImplementation(
-      async (_token, sessionId): Promise<CommandResponse> => ({
+      async (_token, sessionId): Promise<AdminCommandResult> => ({
         kind: 'plain',
         text: 'Session agent set to `bk` (model: `openrouter/nvidia/nemotron-3-super-120b-a12b:free`).',
         sessionId,

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -121,6 +121,14 @@ vi.mock('../../api/client', () => ({
 }));
 
 vi.mock('../../auth', () => ({
+  isAuthReadyForApi: (auth: {
+    status: string;
+    token: string;
+    gatewayStatus?: { webAuthConfigured?: boolean } | null;
+  }) =>
+    auth.status === 'ready' &&
+    (auth.gatewayStatus?.webAuthConfigured !== true ||
+      auth.token.trim().length > 0),
   useAuth: () => useAuthMock(),
 }));
 
@@ -230,8 +238,7 @@ describe('ChatPage', () => {
     isActiveMock.mockReset();
     useChatStreamMock.mockReset();
 
-    useAuthMock.mockReturnValue({ status: 'ready', token: 'test-token' });
-    fetchAppStatusMock.mockResolvedValue({
+    const gatewayStatus: GatewayStatus = {
       status: 'ok',
       webAuthConfigured: true,
       version: '0.0.0',
@@ -243,7 +250,17 @@ describe('ChatPage', () => {
       defaultModel: 'gpt-5',
       ragDefault: false,
       timestamp: '2026-04-14T10:00:00.000Z',
+    };
+    useAuthMock.mockReturnValue({
+      status: 'ready',
+      token: 'test-token',
+      gatewayStatus,
+      error: null,
+      login: vi.fn(),
+      logout: vi.fn(),
+      retry: vi.fn(),
     });
+    fetchAppStatusMock.mockResolvedValue(gatewayStatus);
     fetchChatRecentMock.mockImplementation(
       async (_token, _userId, _channelId, _limit, query) => ({
         sessions: query
@@ -842,9 +859,7 @@ describe('ChatPage', () => {
     expect(screen.getByDisplayValue('Updated draft message')).not.toBeNull();
   });
 
-  it('surfaces gateway status load failures instead of swallowing them', async () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    fetchAppStatusMock.mockRejectedValue(new Error('Gateway offline'));
+  it('seeds gateway status from auth without refetching it', async () => {
     fetchChatHistoryMock.mockResolvedValue({
       sessionId: 'session-a',
       history: [],
@@ -852,17 +867,8 @@ describe('ChatPage', () => {
 
     renderChatPage();
 
-    expect(
-      await screen.findByText(
-        'Failed to load the default agent. New chats will use main until gateway status loads.',
-      ),
-    ).not.toBeNull();
-    expect(errorSpy).toHaveBeenCalledWith(
-      'Failed to load gateway status for chat page',
-      expect.any(Error),
-    );
-
-    errorSpy.mockRestore();
+    expect(await screen.findByText('Ready to claw through your to-do list?'));
+    expect(fetchAppStatusMock).not.toHaveBeenCalled();
   });
 
   it('collapses to the icon rail and exposes an Expand trigger that re-opens it', async () => {

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   createChatBranch,
   createChatMobileQr,
+  executeCommand,
   fetchAppStatus,
   fetchChatContext,
   fetchChatRecent,
@@ -25,12 +26,14 @@ import {
   copyToClipboard,
   DEFAULT_AGENT_ID,
   isScrolledNearBottom,
+  nextMsgId,
   readStoredUserId,
 } from '../../lib/chat-helpers';
 import { CHAT_UI_CONFIG } from '../../lib/chat-ui-config';
 import { getErrorMessage } from '../../lib/error-message';
 import { useDebouncedValue } from '../../lib/use-debounced-value';
 import {
+  type ChatHistoryUiData,
   chatHistoryQueryKey,
   EMPTY_BRANCH_FAMILIES,
   loadChatHistoryUi,
@@ -476,35 +479,89 @@ export function ChatPage() {
     [ensureSessionForSend, stream.sendMessage],
   );
 
+  const appendLocalCommandResult = useCallback(
+    (targetSessionId: string, content: string) => {
+      const text = content.trim();
+      if (!text) return;
+      queryClient.setQueryData<ChatHistoryUiData>(
+        chatHistoryQueryKey(auth.token, targetSessionId),
+        (prev) => ({
+          messages: [
+            ...(prev?.messages ?? []),
+            {
+              id: nextMsgId(),
+              role: 'assistant',
+              content: text,
+              rawContent: text,
+              sessionId: targetSessionId,
+              artifacts: [],
+              replayRequest: null,
+            },
+          ],
+          branchFamilies: prev?.branchFamilies ?? new Map(),
+          resolvedSessionId: targetSessionId,
+        }),
+      );
+    },
+    [auth.token, queryClient],
+  );
+
   const sendSlashSwitch = useCallback(
     async (
-      command: string,
+      commandArgs: string[],
       value: string,
       onAccepted: (value: string) => void,
       busyMessage: string,
     ) => {
       if (!value || /\s/.test(value)) return;
+      if (stream.isActive()) {
+        setError(busyMessage);
+        return;
+      }
       ensureSessionForSend();
+      const requestedSessionId = getSessionId();
       try {
-        const accepted = await stream.sendMessage(`${command} ${value}`, [], {
-          hideUser: true,
-        });
-        if (accepted) {
-          onAccepted(value);
-        } else {
-          setError(busyMessage);
+        const result = await executeCommand(
+          auth.token,
+          requestedSessionId,
+          userId,
+          [...commandArgs, value],
+        );
+        if (result.kind === 'error') {
+          throw new Error(result.text || result.error || busyMessage);
         }
+        const resolvedSessionId =
+          result.sessionId?.trim() || requestedSessionId;
+        appendLocalCommandResult(resolvedSessionId, result.text ?? 'Done.');
+        if (resolvedSessionId !== requestedSessionId) {
+          await switchToSession(resolvedSessionId, { replace: true });
+        }
+        void queryClient.invalidateQueries({
+          queryKey: ['chat-context', auth.token, resolvedSessionId],
+        });
+        refreshRecent();
+        onAccepted(value);
       } catch (err) {
         setError(getErrorMessage(err));
       }
     },
-    [ensureSessionForSend, stream.sendMessage],
+    [
+      appendLocalCommandResult,
+      auth.token,
+      ensureSessionForSend,
+      getSessionId,
+      queryClient,
+      refreshRecent,
+      stream.isActive,
+      switchToSession,
+      userId,
+    ],
   );
 
   const handleAgentSwitch = useCallback(
     (agentId: string) =>
       sendSlashSwitch(
-        '/agent switch',
+        ['agent', 'switch'],
         agentId,
         setSelectedAgentId,
         'Could not switch agent — stop the current run and try again.',
@@ -515,7 +572,7 @@ export function ChatPage() {
   const handleModelSwitch = useCallback(
     (modelId: string) =>
       sendSlashSwitch(
-        '/model set',
+        ['model', 'set'],
         modelId,
         setSelectedModelId,
         'Could not switch model — stop the current run and try again.',

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -52,6 +52,12 @@ type BranchInfo = {
 const EMPTY_MESSAGES: ChatUiMessage[] = [];
 const EMPTY_MODELS: ChatModel[] = [];
 
+function isChatApiReady(auth: ReturnType<typeof useAuth>): boolean {
+  if (auth.status !== 'ready') return false;
+  if (auth.gatewayStatus?.webAuthConfigured !== true) return true;
+  return auth.token.trim().length > 0;
+}
+
 function buildBranchInfoMap(
   messages: ChatUiMessage[],
   branchFamilies: Map<string, BranchVariant[]>,
@@ -167,23 +173,31 @@ export function ChatPage() {
     onSessionIdCorrection: handleSessionIdCorrection,
     onModelResolved: setSelectedModelId,
   });
+  const chatApiReady = isChatApiReady(auth);
 
   const appStatusQuery = useQuery({
     queryKey: ['app-status', auth.token],
     queryFn: () => fetchAppStatus(auth.token),
     staleTime: Infinity,
+    enabled: chatApiReady,
+    initialData:
+      auth.status === 'ready' && auth.gatewayStatus
+        ? auth.gatewayStatus
+        : undefined,
   });
 
   const agentsQuery = useQuery({
     queryKey: ['agents-list', auth.token],
     queryFn: () => fetchAgentList(auth.token),
     staleTime: 30_000,
+    enabled: chatApiReady,
   });
 
   const modelsQuery = useQuery({
     queryKey: ['models', auth.token],
     queryFn: () => fetchModels(auth.token),
     staleTime: 30_000,
+    enabled: chatApiReady,
   });
 
   useEffect(() => {
@@ -240,6 +254,7 @@ export function ChatPage() {
         trimmedSessionSearchQuery || undefined,
       ),
     staleTime: 10_000,
+    enabled: chatApiReady,
   });
   const recentSessions = recentQuery.data?.sessions ?? [];
   const agentOptions = useMemo(
@@ -255,14 +270,14 @@ export function ChatPage() {
   const historyQuery = useQuery({
     queryKey: chatHistoryQueryKey(auth.token, sessionId),
     queryFn: () => loadChatHistoryUi(auth.token, sessionId),
-    enabled: Boolean(sessionId),
+    enabled: chatApiReady && Boolean(sessionId),
     staleTime: Infinity,
   });
 
   const contextQuery = useQuery({
     queryKey: ['chat-context', auth.token, sessionId],
     queryFn: () => fetchChatContext(auth.token, sessionId),
-    enabled: Boolean(sessionId),
+    enabled: chatApiReady && Boolean(sessionId),
     staleTime: 15_000,
     refetchOnWindowFocus: false,
   });

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -78,6 +78,14 @@ function buildBranchInfoMap(
   return map;
 }
 
+function chatRecentQueryKey(token: string, userId: string, query = '') {
+  return ['chat-recent', token, userId, query] as const;
+}
+
+function chatRecentQueryPrefix(token: string, userId: string) {
+  return ['chat-recent', token, userId] as const;
+}
+
 export function ChatPage() {
   const auth = useAuth();
   const queryClient = useQueryClient();
@@ -140,7 +148,6 @@ export function ChatPage() {
     };
   }, []);
 
-  const getDefaultAgentId = useCallback(() => defaultAgentIdRef.current, []);
   const {
     sessionId,
     getSessionId,
@@ -149,11 +156,11 @@ export function ChatPage() {
     startFreshChat,
     ensureSessionForSend,
     handleSessionIdCorrection,
-  } = useChatSession({ getDefaultAgentId });
+  } = useChatSession();
 
   const refreshRecent = useCallback(() => {
     void queryClient.invalidateQueries({
-      queryKey: ['chat-recent', auth.token, userId],
+      queryKey: chatRecentQueryPrefix(auth.token, userId),
     });
     void queryClient.invalidateQueries({
       queryKey: chatHistoryQueryKey(auth.token, getSessionId()),
@@ -239,7 +246,7 @@ export function ChatPage() {
   }, [modelsQuery.error]);
 
   const recentQuery = useQuery({
-    queryKey: ['chat-recent', auth.token, userId, trimmedSessionSearchQuery],
+    queryKey: chatRecentQueryKey(auth.token, userId, trimmedSessionSearchQuery),
     queryFn: () =>
       fetchChatRecent(
         auth.token,
@@ -500,6 +507,24 @@ export function ChatPage() {
     [auth.token, queryClient],
   );
 
+  const ensureSwitchHistory = useCallback(
+    async (resolvedSessionId: string) => {
+      await queryClient
+        .ensureQueryData({
+          queryKey: chatHistoryQueryKey(auth.token, resolvedSessionId),
+          queryFn: () => loadChatHistoryUi(auth.token, resolvedSessionId),
+        })
+        .catch((err: unknown) => {
+          console.warn(
+            'Failed to prefetch chat history before appending switch result',
+            err,
+          );
+          return null;
+        });
+    },
+    [auth.token, queryClient],
+  );
+
   const sendSlashSwitch = useCallback(
     async (
       commandArgs: string[],
@@ -523,12 +548,7 @@ export function ChatPage() {
         );
         const resolvedSessionId =
           result.sessionId?.trim() || requestedSessionId;
-        await queryClient
-          .ensureQueryData({
-            queryKey: chatHistoryQueryKey(auth.token, resolvedSessionId),
-            queryFn: () => loadChatHistoryUi(auth.token, resolvedSessionId),
-          })
-          .catch(() => null);
+        await ensureSwitchHistory(resolvedSessionId);
         appendLocalCommandResult(resolvedSessionId, result.text);
         if (resolvedSessionId !== requestedSessionId) {
           await switchToSession(resolvedSessionId, { replace: true });
@@ -546,6 +566,7 @@ export function ChatPage() {
       appendLocalCommandResult,
       auth.token,
       ensureSessionForSend,
+      ensureSwitchHistory,
       getSessionId,
       queryClient,
       refreshRecent,
@@ -602,7 +623,11 @@ export function ChatPage() {
 
   const handleRefreshRecent = useCallback(() => {
     void queryClient.invalidateQueries({
-      queryKey: ['chat-recent', auth.token, userId, trimmedSessionSearchQuery],
+      queryKey: chatRecentQueryKey(
+        auth.token,
+        userId,
+        trimmedSessionSearchQuery,
+      ),
     });
   }, [queryClient, auth.token, userId, trimmedSessionSearchQuery]);
 
@@ -675,7 +700,11 @@ export function ChatPage() {
         <div className={css.chatMain}>
           <div className={css.chatTopbar}>
             <MobileTopbarTrigger className={css.chatMobileTrigger} />
-            <ContextRing sessionId={sessionId} />
+            <ContextRing
+              sessionId={sessionId}
+              token={auth.token}
+              enabled={chatApiReady}
+            />
             <button
               type="button"
               className={css.mobileQrButton}

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -532,6 +532,12 @@ export function ChatPage() {
         }
         const resolvedSessionId =
           result.sessionId?.trim() || requestedSessionId;
+        await queryClient
+          .ensureQueryData({
+            queryKey: chatHistoryQueryKey(auth.token, resolvedSessionId),
+            queryFn: () => loadChatHistoryUi(auth.token, resolvedSessionId),
+          })
+          .catch(() => null);
         appendLocalCommandResult(resolvedSessionId, result.text ?? 'Done.');
         if (resolvedSessionId !== requestedSessionId) {
           await switchToSession(resolvedSessionId, { replace: true });

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -17,7 +17,7 @@ import type {
 } from '../../api/chat-types';
 import { fetchAgentList, fetchModels } from '../../api/client';
 import type { ChatModel } from '../../api/types';
-import { useAuth } from '../../auth';
+import { isAuthReadyForApi, useAuth } from '../../auth';
 import { MobileTopbarTrigger } from '../../components/sidebar/index';
 import { ViewSwitchNav } from '../../components/view-switch';
 import {
@@ -54,12 +54,6 @@ type BranchInfo = {
 
 const EMPTY_MESSAGES: ChatUiMessage[] = [];
 const EMPTY_MODELS: ChatModel[] = [];
-
-function isChatApiReady(auth: ReturnType<typeof useAuth>): boolean {
-  if (auth.status !== 'ready') return false;
-  if (auth.gatewayStatus?.webAuthConfigured !== true) return true;
-  return auth.token.trim().length > 0;
-}
 
 function buildBranchInfoMap(
   messages: ChatUiMessage[],
@@ -176,7 +170,7 @@ export function ChatPage() {
     onSessionIdCorrection: handleSessionIdCorrection,
     onModelResolved: setSelectedModelId,
   });
-  const chatApiReady = isChatApiReady(auth);
+  const chatApiReady = isAuthReadyForApi(auth);
 
   const appStatusQuery = useQuery({
     queryKey: ['app-status', auth.token],
@@ -527,9 +521,6 @@ export function ChatPage() {
           userId,
           [...commandArgs, value],
         );
-        if (result.kind === 'error') {
-          throw new Error(result.text || result.error || busyMessage);
-        }
         const resolvedSessionId =
           result.sessionId?.trim() || requestedSessionId;
         await queryClient
@@ -538,7 +529,7 @@ export function ChatPage() {
             queryFn: () => loadChatHistoryUi(auth.token, resolvedSessionId),
           })
           .catch(() => null);
-        appendLocalCommandResult(resolvedSessionId, result.text ?? 'Done.');
+        appendLocalCommandResult(resolvedSessionId, result.text);
         if (resolvedSessionId !== requestedSessionId) {
           await switchToSession(resolvedSessionId, { replace: true });
         }

--- a/console/src/routes/chat/context-ring.tsx
+++ b/console/src/routes/chat/context-ring.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchChatContext } from '../../api/chat';
-import { isAuthReadyForApi, useAuth } from '../../auth';
 import { cx } from '../../lib/cx';
 import css from './context-ring.module.css';
 
@@ -39,17 +38,18 @@ function severityFor(percent: number | null): 'nominal' | 'warn' | 'danger' {
 
 interface ContextRingProps {
   sessionId: string;
+  token: string;
+  enabled: boolean;
 }
 
 // ContextRing is only rendered on the chat route (via ChatPage). Callers
 // must not mount it elsewhere — there's no route-based opt-out here.
 export function ContextRing(props: ContextRingProps) {
-  const auth = useAuth();
   const sessionId = props.sessionId;
-  const enabled = isAuthReadyForApi(auth) && Boolean(sessionId);
+  const enabled = props.enabled && Boolean(sessionId);
   const query = useQuery({
-    queryKey: ['chat-context', auth.token, sessionId],
-    queryFn: () => fetchChatContext(auth.token, sessionId),
+    queryKey: ['chat-context', props.token, sessionId],
+    queryFn: () => fetchChatContext(props.token, sessionId),
     enabled,
     staleTime: 15_000,
     refetchOnWindowFocus: false,

--- a/console/src/routes/chat/context-ring.tsx
+++ b/console/src/routes/chat/context-ring.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchChatContext } from '../../api/chat';
-import { useAuth } from '../../auth';
+import { isAuthReadyForApi, useAuth } from '../../auth';
 import { cx } from '../../lib/cx';
 import css from './context-ring.module.css';
 
@@ -46,11 +46,7 @@ interface ContextRingProps {
 export function ContextRing(props: ContextRingProps) {
   const auth = useAuth();
   const sessionId = props.sessionId;
-  const authReady =
-    auth.status === 'ready' &&
-    (auth.gatewayStatus?.webAuthConfigured !== true ||
-      auth.token.trim().length > 0);
-  const enabled = authReady && Boolean(sessionId);
+  const enabled = isAuthReadyForApi(auth) && Boolean(sessionId);
   const query = useQuery({
     queryKey: ['chat-context', auth.token, sessionId],
     queryFn: () => fetchChatContext(auth.token, sessionId),

--- a/console/src/routes/chat/context-ring.tsx
+++ b/console/src/routes/chat/context-ring.tsx
@@ -46,7 +46,11 @@ interface ContextRingProps {
 export function ContextRing(props: ContextRingProps) {
   const auth = useAuth();
   const sessionId = props.sessionId;
-  const enabled = Boolean(sessionId);
+  const authReady =
+    auth.status === 'ready' &&
+    (auth.gatewayStatus?.webAuthConfigured !== true ||
+      auth.token.trim().length > 0);
+  const enabled = authReady && Boolean(sessionId);
   const query = useQuery({
     queryKey: ['chat-context', auth.token, sessionId],
     queryFn: () => fetchChatContext(auth.token, sessionId),

--- a/console/src/routes/chat/use-chat-session.test.ts
+++ b/console/src/routes/chat/use-chat-session.test.ts
@@ -16,6 +16,39 @@ async function getTestRouter(): Promise<TestRouter> {
   return mod.__testRouter;
 }
 
+function ensureLocalStorage() {
+  if (typeof globalThis.localStorage?.clear === 'function') return;
+  const store = new Map<string, string>();
+  const storage = {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, String(value));
+    },
+  } satisfies Storage;
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: storage,
+    configurable: true,
+  });
+  Object.defineProperty(window, 'localStorage', {
+    value: storage,
+    configurable: true,
+  });
+}
+
 function setup() {
   return renderHook(() =>
     useChatSession({
@@ -26,6 +59,7 @@ function setup() {
 
 describe('useChatSession', () => {
   beforeEach(async () => {
+    ensureLocalStorage();
     localStorage.clear();
     (await getTestRouter()).reset();
   });
@@ -50,9 +84,8 @@ describe('useChatSession', () => {
     const { result } = setup();
     expect(localStorage.getItem('hybridclaw_session')).toBeNull();
 
-    router.setSessionId('session-a');
-    // Flush effect
     await act(async () => {
+      router.setSessionId('session-a');
       await Promise.resolve();
     });
 
@@ -165,15 +198,17 @@ describe('useChatSession', () => {
     const minted = result.current.getSessionId();
 
     // URL catches up
-    router.setSessionId(minted);
-    rerender();
     await act(async () => {
+      router.setSessionId(minted);
+      rerender();
       await Promise.resolve();
     });
 
     // URL navigates to a different session — the old draft must not bleed in
-    router.setSessionId('session-other');
-    rerender();
+    act(() => {
+      router.setSessionId('session-other');
+      rerender();
+    });
 
     expect(result.current.sessionId).toBe('session-other');
   });

--- a/console/src/routes/chat/use-chat-session.test.ts
+++ b/console/src/routes/chat/use-chat-session.test.ts
@@ -103,9 +103,7 @@ describe('useChatSession', () => {
 
     const minted = result.current.getSessionId();
     expect(minted).not.toBe('');
-    expect(minted.startsWith('agent:main:channel:web:chat:dm:peer:')).toBe(
-      true,
-    );
+    expect(minted).toMatch(/^sess_\d{8}_\d{6}_[0-9a-f]{8}$/);
     expect(router.navigate).toHaveBeenCalledTimes(1);
     expect(router.lastTo).toBe('/chat/$sessionId');
     expect(router.lastReplace).toBe(true);

--- a/console/src/routes/chat/use-chat-session.test.ts
+++ b/console/src/routes/chat/use-chat-session.test.ts
@@ -50,11 +50,7 @@ function ensureLocalStorage() {
 }
 
 function setup() {
-  return renderHook(() =>
-    useChatSession({
-      getDefaultAgentId: () => 'main',
-    }),
-  );
+  return renderHook(() => useChatSession());
 }
 
 describe('useChatSession', () => {

--- a/console/src/routes/chat/use-chat-session.ts
+++ b/console/src/routes/chat/use-chat-session.ts
@@ -2,10 +2,6 @@ import { useNavigate, useParams } from '@tanstack/react-router';
 import { useCallback, useEffect, useRef } from 'react';
 import { generateWebSessionId, storeSessionId } from '../../lib/chat-helpers';
 
-interface UseChatSessionOptions {
-  getDefaultAgentId: () => string;
-}
-
 export interface UseChatSessionReturn {
   /** Empty string when the URL is `/chat` and no draft has been minted yet. */
   sessionId: string;
@@ -30,10 +26,7 @@ export interface UseChatSessionReturn {
  * Owns the chat session-id lifecycle: URL param, lazy draft for the bare
  * `/chat` route, localStorage persistence, and navigation between sessions.
  */
-export function useChatSession(
-  options: UseChatSessionOptions,
-): UseChatSessionReturn {
-  const { getDefaultAgentId } = options;
+export function useChatSession(): UseChatSessionReturn {
   const navigate = useNavigate();
   const params = useParams({ strict: false }) as { sessionId?: string };
   const urlSessionId = params.sessionId;
@@ -81,11 +74,11 @@ export function useChatSession(
 
   const ensureSessionForSend = useCallback(() => {
     if (sessionIdRef.current) return;
-    const newId = generateWebSessionId(getDefaultAgentId());
+    const newId = generateWebSessionId();
     draftSessionIdRef.current = newId;
     sessionIdRef.current = newId;
     void navigateToSession(newId, { replace: true });
-  }, [navigateToSession, getDefaultAgentId]);
+  }, [navigateToSession]);
 
   const handleSessionIdCorrection = useCallback(
     (serverSessionId: string) => {


### PR DESCRIPTION
## What changed

- Nested `/chat/$sessionId` under `/chat` so creating the first chat session updates route params without remounting the chat page.
- Gated chat page queries behind authenticated `ready` state and seeded the chat status query from the already-validated auth status.
- Gated the context ring query with the same auth readiness check.
- Added regression coverage for the auth bootstrap guard and cleaned up chat session hook test setup.

## Why

The first agent dropdown selection on bare `/chat` created a session and navigated to `/chat/<session>`. Because those routes were siblings, the navigation remounted `ChatPage` while the hidden `/agent switch` command was in flight, making the first selection look like a mini reload and requiring a second selection.

First load also showed 401s for chat-related endpoints when queries fired before the console auth state was ready. The new readiness guard prevents those doomed first requests.

## Validation

- `npm run format` (ran before commit; reverted unrelated formatter-only churn outside this PR scope)
- `npm --workspace console run typecheck`
- `npm --workspace console exec -- vitest run --config vitest.config.ts src/routes/chat/chat-page.test.tsx src/routes/chat/use-chat-session.test.ts src/routes/chat/use-chat-stream.test.ts`