### PR TITLE
chat(web): keep latest message in view while streaming

### DIFF
--- a/console/src/lib/chat-helpers.ts
+++ b/console/src/lib/chat-helpers.ts
@@ -146,10 +146,3 @@ export function extractClipboardFiles(
   return files;
 }
 
-export function isScrolledNearBottom(
-  el: HTMLElement | null,
-  threshold = 64,
-): boolean {
-  if (!el) return true;
-  return el.scrollHeight - el.scrollTop - el.clientHeight <= threshold;
-}

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -349,6 +349,8 @@ aside[data-state="collapsed"] .chatSidebarContent {
   overflow-x: hidden;
   padding: 16px 24px 12px;
   scroll-behavior: smooth;
+  scroll-padding-top: 16px;
+  scroll-padding-bottom: 30vh;
 }
 
 .messageList {
@@ -358,6 +360,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
   width: 100%;
   min-width: 0;
   max-width: 100%;
+  padding-bottom: 30vh;
 }
 
 .sidebarCollapseButton {

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -24,7 +24,6 @@ import {
   buildApprovalCommand,
   copyToClipboard,
   DEFAULT_AGENT_ID,
-  isScrolledNearBottom,
   readStoredUserId,
 } from '../../lib/chat-helpers';
 import { CHAT_UI_CONFIG } from '../../lib/chat-ui-config';
@@ -350,16 +349,64 @@ export function ChatPage() {
   }, [stream.isStreaming, queryClient, auth.token, sessionId]);
 
   const scrollRafRef = useRef(0);
+  const prevMessageIdsRef = useRef<Set<string>>(new Set());
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally re-runs on message changes to auto-scroll
   useEffect(() => {
-    if (scrollRafRef.current) return;
+    const container = messageAreaRef.current;
+    if (!container) {
+      prevMessageIdsRef.current = new Set(messages.map((m) => m.id));
+      return;
+    }
+
+    const prev = prevMessageIdsRef.current;
+    let sharedCount = 0;
+    let newUserMsgId: string | null = null;
+    const next = new Set<string>();
+    for (const m of messages) {
+      next.add(m.id);
+      if (prev.has(m.id)) sharedCount++;
+      else if (m.role === 'user') newUserMsgId = m.id;
+    }
+    prevMessageIdsRef.current = next;
+
+    if (messages.length === 0) return;
+
+    // Wholesale replacement (history loaded, session switch) — jump to the bottom
+    // without animation so the user lands on the latest content. We treat
+    // "previously empty + not actively streaming" as a load too, otherwise the
+    // first paint of cached history would smooth-scroll mid-page.
+    const wasEmpty = prev.size === 0;
+    const isWholesaleReplace = !wasEmpty && sharedCount === 0;
+    const isInitialLoad = wasEmpty && !stream.isStreaming;
+    if (isWholesaleReplace || isInitialLoad) {
+      container.scrollTop = container.scrollHeight;
+      return;
+    }
+
+    if (scrollRafRef.current) cancelAnimationFrame(scrollRafRef.current);
     scrollRafRef.current = requestAnimationFrame(() => {
       scrollRafRef.current = 0;
-      if (isScrolledNearBottom(messageAreaRef.current)) {
+      const liveContainer = messageAreaRef.current;
+      if (!liveContainer) return;
+      const targetId = newUserMsgId ?? messages[messages.length - 1]?.id;
+      if (!targetId) return;
+      const target = liveContainer.querySelector(
+        `[data-message-id="${CSS.escape(targetId)}"]`,
+      );
+      if (target instanceof HTMLElement) {
+        target.scrollIntoView({
+          behavior: 'smooth',
+          block: newUserMsgId ? 'start' : 'end',
+        });
+      } else {
         messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
       }
     });
-  }, [messages]);
+  }, [messages, stream.isStreaming]);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset tracking when the active session changes
+  useEffect(() => {
+    prevMessageIdsRef.current = new Set();
+  }, [sessionId]);
   useEffect(() => {
     return () => {
       if (scrollRafRef.current) cancelAnimationFrame(scrollRafRef.current);
@@ -668,7 +715,11 @@ export function ChatPage() {
               <div className={css.messageList}>
                 {messages.map((msg) =>
                   editingId === msg.id && msg.role !== 'thinking' ? (
-                    <div key={msg.id} className={css.messageBlock}>
+                    <div
+                      key={msg.id}
+                      className={css.messageBlock}
+                      data-message-id={msg.id}
+                    >
                       <EditInline
                         initial={msg.rawContent ?? msg.content}
                         onSave={(newContent) =>

--- a/console/src/routes/chat/message-block.tsx
+++ b/console/src/routes/chat/message-block.tsx
@@ -274,7 +274,7 @@ export const MessageBlock = memo(function MessageBlock(props: {
 
   if (msg.role === 'thinking') {
     return (
-      <div className={css.thinking}>
+      <div className={css.thinking} data-message-id={msg.id}>
         <span className={css.thinkingDot} />
         <span className={css.thinkingDot} />
         <span className={css.thinkingDot} />
@@ -301,7 +301,7 @@ export const MessageBlock = memo(function MessageBlock(props: {
   );
 
   return (
-    <div className={blockClass}>
+    <div className={blockClass} data-message-id={msg.id}>
       {isAssistant ? (
         <div className={css.agentLabel}>
           {avatarUrl ? (


### PR DESCRIPTION
Switch the web chat auto-scroll from a "near bottom" gate to a per-event target: a freshly sent user message is pinned to the top of the viewport, streaming assistant updates follow the bottom of the latest bubble, and scroll-padding-bottom keeps that bottom roughly mid-screen instead of glued to the edge. Initial loads and session switches still jump to the end without animation.

## Summary

Describe the change in 2-5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did not change:

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Tests
- [ ] Refactor required for the fix
- [ ] Tooling or workflow
- [ ] Security hardening

## Linked Context

- Closes #
- Related #

## Manifesto Principle

Which manifesto principle does this serve?

- Principle:
- Changelog tag added or updated: `Manifesto: Principle <Roman numeral> - <principle title>.`

## Validation

List the checks you ran and the concrete scenarios you verified.

```bash
# Example
npm run typecheck
npm run lint
npm run test:unit
```

- Verified manually:
- Edge cases checked:
- Skipped checks and why:

## Docs And Config Impact

- [ ] README, docs, or examples updated
- [ ] Config or environment behavior changed
- [ ] Templates or workspace bootstrap files changed
- [ ] No docs or config impact

If `templates/` changed, confirm whether `src/workspace.ts` and the related
tests were updated.

## Risk Notes

- Security-sensitive paths touched? (`Yes/No`)
- Gateway, audit, approval, or container boundaries touched? (`Yes/No`)
- If yes, what is the failure mode and how did you test it?

## Evidence

Attach at least one when relevant:

- [ ] Failing output before and passing output after
- [ ] Screenshot or recording
- [ ] Log snippet
- [ ] New or updated test coverage
