### PR TITLE
fix: agent picker requires only one click after refresh

### DIFF
--- a/console/src/routes/chat/agent-switch-select.tsx
+++ b/console/src/routes/chat/agent-switch-select.tsx
@@ -5,6 +5,10 @@ export interface AgentSwitchOption {
   name?: string | null;
 }
 
+function agentLabel(agent: AgentSwitchOption): string {
+  return agent.name?.trim() || agent.id;
+}
+
 function ChevronGlyph() {
   return (
     <svg
@@ -32,11 +36,19 @@ export function AgentSwitchSelect(props: {
 }) {
   if (props.agents.length === 0) return null;
 
+  const selectedAgent =
+    props.agents.find((agent) => agent.id === props.selectedAgentId) ??
+    props.agents[0];
+
   return (
     <span
       className={css.composerPill}
       data-disabled={props.disabled ? '' : undefined}
     >
+      <span className={css.composerPillLabel}>{agentLabel(selectedAgent)}</span>
+      <span aria-hidden="true" className={css.composerPillChevron}>
+        <ChevronGlyph />
+      </span>
       <select
         className={css.agentSelect}
         value={props.selectedAgentId}
@@ -50,13 +62,10 @@ export function AgentSwitchSelect(props: {
       >
         {props.agents.map((agent) => (
           <option key={agent.id} value={agent.id}>
-            {agent.name?.trim() || agent.id}
+            {agentLabel(agent)}
           </option>
         ))}
       </select>
-      <span aria-hidden="true" className={css.composerPillChevron}>
-        <ChevronGlyph />
-      </span>
     </span>
   );
 }

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -932,29 +932,36 @@ aside[data-state="collapsed"] .chatSidebarContent {
   cursor: default;
 }
 
-/* The agent component is a native <select> wrapped in this pill. The select
-   itself stays transparent and inherits the pill's typography. */
+/* The agent component is a native <select> overlaid on top of the pill so any
+   click on the pill (including the padding and chevron) opens the dropdown.
+   The visible label is rendered separately by .composerPillLabel. */
 .agentSelect {
-  max-width: 180px;
-  height: 36px;
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
   border: none;
   appearance: none;
   background: transparent;
-  color: inherit;
   font: inherit;
-  font-size: inherit;
-  font-weight: inherit;
-  line-height: 36px;
   padding: 0;
+  margin: 0;
   outline: none;
   cursor: pointer;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  opacity: 0;
 }
 
 .agentSelect:disabled {
   cursor: default;
+}
+
+.composerPillLabel {
+  display: inline-block;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  pointer-events: none;
 }
 
 .composerPillChevron {


### PR DESCRIPTION
## Summary
- The native `<select>` in the chat composer's agent picker was content-sized (~29px wide for "main"), so the pill's 16px padding and the chevron span fell outside its hit area — clicking those did nothing, which read as "needing 2-3 clicks" to actually open the dropdown.
- Overlay the `<select>` across the full pill via `position: absolute; inset: 0; opacity: 0`, and render the visible agent name + chevron beneath it. Any click on the pill now opens the dropdown on first try.
- Extracted a small `agentLabel()` helper to dedupe the `name?.trim() || id` derivation used in both the visible label and the `<option>` list.

## Test plan
- [x] `npm --workspace console run test` (259/259 pass)
- [x] `npm run build:console`
- [x] Manual: load `/chat`, refresh, single click on any part of the agent pill (text, padding, or chevron) opens the dropdown.