### PR TITLE
docs: mark R1.14 webhook inbound shipped, note follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@
   JSON-RPC Agent Card peers or signed webhook peers with an outbox processor,
   retry/backoff, audit events, secret-backed bearer tokens, and operator
   escalation when delivery cannot continue safely.
+- **A2A webhook inbound endpoint**: Gateways accept signed envelopes from
+  trusted non-A2A peers at `POST /a2a/webhook/:peerId` with HMAC-SHA256
+  verification, replay-window enforcement, per-peer SecretRef-backed shared
+  secrets, sender/recipient validation against local agents, configurable
+  per-peer rate limiting (default 60/min → 429), and structured audit events
+  for every inbound POST.
 - **Monthly invoice harvester skill**: The bundled
   `download-platform-invoices` skill collects official SaaS invoice PDFs and
   normalized records across Stripe, Google Ads, AWS, Azure, GCP, browser-driven

--- a/docs/content/internal/roadmap.md
+++ b/docs/content/internal/roadmap.md
@@ -144,7 +144,7 @@ Use these as issue titles. Keep each issue small enough to ship independently.
 | R1.11 | Transport | A2A outbound adapter | ⬜ #766 |
 | R1.12 | Transport | A2A inbound adapter and Agent Card endpoint | ⬜ #767 |
 | R1.13 | Transport | Signed-HMAC webhook outbound adapter with retry and jitter | ✅ #768 via PR #782 |
-| R1.14 | Transport | Signed-HMAC webhook inbound adapter | ⬜ #769 |
+| R1.14 | Transport | Signed-HMAC webhook inbound adapter | ✅ #769 via PR #799 |
 | R1.15 | Transport | A2A streaming SSE for R9 RPC delegation responses | ⬜ #771 |
 
 ## R2 Workflow Work


### PR DESCRIPTION
## Summary

- Flips R1.14 in [docs/content/internal/roadmap.md](docs/content/internal/roadmap.md) to ✅ (closed by #769 via PR #799).
- Adds a CHANGELOG Unreleased entry for the signed A2A webhook inbound endpoint alongside the existing outbound bullet.
- Follow-ups filed: #806 (reconcile inbound-pipeline shim with R1.7 / R1.12), #807 (promote webhook trust store to shared F7 trust ledger), #808 (operator surface for registering webhook peers).

## Test plan

- [ ] Skim the rendered roadmap row and CHANGELOG entry for accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)