### PR TITLE
[codex] Keep gateway alive on transport timeouts

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -14,6 +14,7 @@ import {
   LOGGER_SERIALIZERS,
 } from './logger-format.js';
 import { getTraceContext } from './observability/otel.js';
+import { isExpectedTransportError } from './utils/transport-errors.js';
 
 const VALID_LOG_LEVELS = new Set([
   'fatal',
@@ -180,6 +181,14 @@ function getProcessHandlerRegistrationState(): ProcessHandlerRegistrationState {
 }
 
 function uncaughtExceptionHandler(err: Error) {
+  if (isExpectedTransportError(err)) {
+    logger.warn(
+      { err },
+      'Uncaught transport exception escaped local handler; keeping process alive',
+    );
+    return;
+  }
+
   logger.fatal({ err }, 'Uncaught exception');
   process.exit(1);
 }
@@ -190,6 +199,14 @@ function uncaughtExceptionHandler(err: Error) {
 )[UNCAUGHT_EXCEPTION_HANDLER_TAG] = true;
 
 function unhandledRejectionHandler(reason: unknown) {
+  if (isExpectedTransportError(reason)) {
+    logger.warn(
+      { err: reason },
+      'Unhandled transport rejection escaped local handler; keeping process alive',
+    );
+    return;
+  }
+
   logger.error({ err: reason }, 'Unhandled rejection');
 }
 (

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -4,6 +4,7 @@ import { Writable } from 'node:stream';
 import pino from 'pino';
 import pretty from 'pino-pretty';
 
+import { SlidingWindowRateLimiter } from './channels/discord/rate-limiter.js';
 import {
   getRuntimeConfig,
   onRuntimeConfigChange,
@@ -25,6 +26,11 @@ const VALID_LOG_LEVELS = new Set([
   'trace',
   'silent',
 ]);
+const EXPECTED_TRANSPORT_PROCESS_WARN_WINDOW_MS = 60_000;
+const EXPECTED_TRANSPORT_PROCESS_WARN_LIMIT = 2;
+const expectedTransportProcessWarnLimiter = new SlidingWindowRateLimiter(
+  EXPECTED_TRANSPORT_PROCESS_WARN_WINDOW_MS,
+);
 
 function resolveForcedLogLevel():
   | ReturnType<typeof getRuntimeConfig>['ops']['logLevel']
@@ -180,12 +186,45 @@ function getProcessHandlerRegistrationState(): ProcessHandlerRegistrationState {
   return state;
 }
 
+function getExpectedTransportProcessWarningKey(
+  kind: 'rejection' | 'exception',
+  error: unknown,
+): string {
+  if (!error || typeof error !== 'object') {
+    return `${kind}:${String(error)}`;
+  }
+
+  const candidate = error as {
+    code?: unknown;
+    message?: unknown;
+    name?: unknown;
+  };
+  const code =
+    typeof candidate.code === 'string' ? candidate.code.toUpperCase() : '';
+  const name = typeof candidate.name === 'string' ? candidate.name : '';
+  const message =
+    typeof candidate.message === 'string' ? candidate.message : '';
+  return [kind, code, name, message].filter(Boolean).join(':') || kind;
+}
+
+function shouldLogExpectedTransportProcessWarning(
+  kind: 'rejection' | 'exception',
+  error: unknown,
+): boolean {
+  return expectedTransportProcessWarnLimiter.check(
+    getExpectedTransportProcessWarningKey(kind, error),
+    EXPECTED_TRANSPORT_PROCESS_WARN_LIMIT,
+  ).allowed;
+}
+
 function uncaughtExceptionHandler(err: Error) {
   if (isExpectedTransportError(err)) {
-    logger.warn(
-      { err },
-      'Uncaught transport exception escaped local handler; keeping process alive',
-    );
+    if (shouldLogExpectedTransportProcessWarning('exception', err)) {
+      logger.warn(
+        { err },
+        'Uncaught transport exception escaped local handler; keeping process alive',
+      );
+    }
     return;
   }
 
@@ -200,10 +239,12 @@ function uncaughtExceptionHandler(err: Error) {
 
 function unhandledRejectionHandler(reason: unknown) {
   if (isExpectedTransportError(reason)) {
-    logger.warn(
-      { err: reason },
-      'Unhandled transport rejection escaped local handler; keeping process alive',
-    );
+    if (shouldLogExpectedTransportProcessWarning('rejection', reason)) {
+      logger.warn(
+        { err: reason },
+        'Unhandled transport rejection escaped local handler; keeping process alive',
+      );
+    }
     return;
   }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -187,39 +187,35 @@ function getProcessHandlerRegistrationState(): ProcessHandlerRegistrationState {
 }
 
 function getExpectedTransportProcessWarningKey(
-  kind: 'rejection' | 'exception',
   error: unknown,
 ): string {
   if (!error || typeof error !== 'object') {
-    return `${kind}:${String(error)}`;
+    return String(error);
   }
 
   const candidate = error as {
     code?: unknown;
     message?: unknown;
-    name?: unknown;
   };
   const code =
     typeof candidate.code === 'string' ? candidate.code.toUpperCase() : '';
-  const name = typeof candidate.name === 'string' ? candidate.name : '';
   const message =
-    typeof candidate.message === 'string' ? candidate.message : '';
-  return [kind, code, name, message].filter(Boolean).join(':') || kind;
+    typeof candidate.message === 'string'
+      ? candidate.message.slice(0, 200)
+      : '';
+  return [code, message].filter(Boolean).join(':') || 'transport-error';
 }
 
-function shouldLogExpectedTransportProcessWarning(
-  kind: 'rejection' | 'exception',
-  error: unknown,
-): boolean {
+function shouldLogExpectedTransportProcessWarning(error: unknown): boolean {
   return expectedTransportProcessWarnLimiter.check(
-    getExpectedTransportProcessWarningKey(kind, error),
+    getExpectedTransportProcessWarningKey(error),
     EXPECTED_TRANSPORT_PROCESS_WARN_LIMIT,
   ).allowed;
 }
 
 function uncaughtExceptionHandler(err: Error) {
   if (isExpectedTransportError(err)) {
-    if (shouldLogExpectedTransportProcessWarning('exception', err)) {
+    if (shouldLogExpectedTransportProcessWarning(err)) {
       logger.warn(
         { err },
         'Uncaught transport exception escaped local handler; keeping process alive',
@@ -239,7 +235,7 @@ function uncaughtExceptionHandler(err: Error) {
 
 function unhandledRejectionHandler(reason: unknown) {
   if (isExpectedTransportError(reason)) {
-    if (shouldLogExpectedTransportProcessWarning('rejection', reason)) {
+    if (shouldLogExpectedTransportProcessWarning(reason)) {
       logger.warn(
         { err: reason },
         'Unhandled transport rejection escaped local handler; keeping process alive',

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -175,7 +175,7 @@ describe('logger forced level override', () => {
     expect(logText).toContain('late forced debug mirror test');
   });
 
-  it('still exits on uncaught transport exceptions', async () => {
+  it('keeps running on uncaught transport exceptions', async () => {
     const { logger, uncaughtExceptionHandler } = await importFreshLogger();
     const exitSpy = vi
       .spyOn(process, 'exit')
@@ -189,12 +189,33 @@ describe('logger forced level override', () => {
 
     uncaughtExceptionHandler(new Error('Opening handshake has timed out'));
 
-    expect(warnSpy).not.toHaveBeenCalled();
-    expect(fatalSpy).toHaveBeenCalledWith(
+    expect(warnSpy).toHaveBeenCalledWith(
       { err: expect.any(Error) },
-      'Uncaught exception',
+      'Uncaught transport exception escaped local handler; keeping process alive',
     );
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(fatalSpy).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs transport rejections as recoverable warnings', async () => {
+    const { logger, handleUnhandledRejectionForTests } =
+      await importFreshLogger();
+    const errorSpy = vi
+      .spyOn(logger, 'error')
+      .mockImplementation(() => undefined);
+    const warnSpy = vi
+      .spyOn(logger, 'warn')
+      .mockImplementation(() => undefined);
+
+    handleUnhandledRejectionForTests(
+      new Error('Opening handshake has timed out'),
+    );
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      { err: expect.any(Error) },
+      'Unhandled transport rejection escaped local handler; keeping process alive',
+    );
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 
   it('still exits on unexpected uncaught exceptions', async () => {

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -218,6 +218,27 @@ describe('logger forced level override', () => {
     expect(errorSpy).not.toHaveBeenCalled();
   });
 
+  it('rate-limits repeated recoverable transport warnings', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-07T08:00:00Z'));
+
+    const { logger, uncaughtExceptionHandler } = await importFreshLogger();
+    const warnSpy = vi
+      .spyOn(logger, 'warn')
+      .mockImplementation(() => undefined);
+
+    for (let attempt = 0; attempt < 6; attempt += 1) {
+      uncaughtExceptionHandler(new Error('Opening handshake has timed out'));
+    }
+
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+
+    vi.setSystemTime(new Date('2026-05-07T08:01:01Z'));
+    uncaughtExceptionHandler(new Error('Opening handshake has timed out'));
+
+    expect(warnSpy).toHaveBeenCalledTimes(3);
+  });
+
   it('still exits on unexpected uncaught exceptions', async () => {
     const { logger, uncaughtExceptionHandler } = await importFreshLogger();
     const exitSpy = vi

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -42,16 +42,14 @@ async function importFreshLogger() {
     onRuntimeConfigChange: vi.fn(),
   }));
   const module = await importLoggerModule();
-  return {
-    ...module,
-    uncaughtExceptionHandler: module.handleUncaughtExceptionForTests,
-  };
+  return module;
 }
 
 describe('logger forced level override', () => {
   let tempDir: string | null = null;
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     vi.resetModules();
     vi.doUnmock('../src/config/runtime-config.ts');
@@ -176,7 +174,8 @@ describe('logger forced level override', () => {
   });
 
   it('keeps running on uncaught transport exceptions', async () => {
-    const { logger, uncaughtExceptionHandler } = await importFreshLogger();
+    const { logger, handleUncaughtExceptionForTests } =
+      await importFreshLogger();
     const exitSpy = vi
       .spyOn(process, 'exit')
       .mockImplementation((() => undefined) as never);
@@ -187,7 +186,9 @@ describe('logger forced level override', () => {
       .spyOn(logger, 'fatal')
       .mockImplementation(() => undefined);
 
-    uncaughtExceptionHandler(new Error('Opening handshake has timed out'));
+    handleUncaughtExceptionForTests(
+      new Error('Opening handshake has timed out'),
+    );
 
     expect(warnSpy).toHaveBeenCalledWith(
       { err: expect.any(Error) },
@@ -222,25 +223,38 @@ describe('logger forced level override', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-07T08:00:00Z'));
 
-    const { logger, uncaughtExceptionHandler } = await importFreshLogger();
+    const {
+      logger,
+      handleUncaughtExceptionForTests,
+      handleUnhandledRejectionForTests,
+    } = await importFreshLogger();
     const warnSpy = vi
       .spyOn(logger, 'warn')
       .mockImplementation(() => undefined);
 
-    for (let attempt = 0; attempt < 6; attempt += 1) {
-      uncaughtExceptionHandler(new Error('Opening handshake has timed out'));
-    }
+    handleUncaughtExceptionForTests(
+      new Error('Opening handshake has timed out'),
+    );
+    handleUnhandledRejectionForTests(
+      new Error('Opening handshake has timed out'),
+    );
+    handleUncaughtExceptionForTests(
+      new Error('Opening handshake has timed out'),
+    );
 
     expect(warnSpy).toHaveBeenCalledTimes(2);
 
     vi.setSystemTime(new Date('2026-05-07T08:01:01Z'));
-    uncaughtExceptionHandler(new Error('Opening handshake has timed out'));
+    handleUncaughtExceptionForTests(
+      new Error('Opening handshake has timed out'),
+    );
 
     expect(warnSpy).toHaveBeenCalledTimes(3);
   });
 
   it('still exits on unexpected uncaught exceptions', async () => {
-    const { logger, uncaughtExceptionHandler } = await importFreshLogger();
+    const { logger, handleUncaughtExceptionForTests } =
+      await importFreshLogger();
     const exitSpy = vi
       .spyOn(process, 'exit')
       .mockImplementation((() => undefined) as never);
@@ -251,7 +265,7 @@ describe('logger forced level override', () => {
       .spyOn(logger, 'fatal')
       .mockImplementation(() => undefined);
 
-    uncaughtExceptionHandler(new Error('Invariant violation'));
+    handleUncaughtExceptionForTests(new Error('Invariant violation'));
 
     expect(warnSpy).not.toHaveBeenCalled();
     expect(fatalSpy).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

- Treat expected transport failures that escape local handlers as recoverable process-level warnings.
- Keep fatal process exit behavior for unrelated uncaught exceptions.
- Update logger regression coverage for WebSocket handshake timeout exceptions and transport rejections.

## Root Cause

`Opening handshake has timed out` was already classified as expected network transport churn in channel-specific handlers, but the global uncaught exception fallback still logged it as fatal and called `process.exit(1)` if it escaped those local handlers.

## Impact

Intermittent WebSocket handshake timeouts from gateway transports no longer crash the gateway process. Unexpected application exceptions still fail fast.

## Validation

- `./node_modules/.bin/vitest run tests/logger.test.ts tests/transport-errors.test.ts tests/discord.error-handler.test.ts tests/whatsapp.connection.test.ts`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`