### PR TITLE
fix(console): rebuild the / command suggestion panel — visibility, behavior, a11y, UX

### DIFF
--- a/console/src/components/popover/index.tsx
+++ b/console/src/components/popover/index.tsx
@@ -86,6 +86,23 @@ export function Popover({
   );
 }
 
+export interface PopoverAnchorProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export function PopoverAnchor({
+  children,
+  className,
+  ...rest
+}: PopoverAnchorProps) {
+  const ctx = usePopoverContext('PopoverAnchor');
+  return (
+    <div ref={ctx.setTriggerEl} className={className} {...rest}>
+      {children}
+    </div>
+  );
+}
+
 export type PopoverAlign = 'start' | 'center' | 'end';
 
 export interface PopoverContentProps extends HTMLAttributes<HTMLDivElement> {

--- a/console/src/components/sheet/index.module.css
+++ b/console/src/components/sheet/index.module.css
@@ -82,13 +82,5 @@
 /* Accessibility helpers */
 
 .srOnly {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
+  composes: srOnly from '../../lib/a11y.module.css';
 }

--- a/console/src/components/sheet/index.module.css
+++ b/console/src/components/sheet/index.module.css
@@ -82,5 +82,5 @@
 /* Accessibility helpers */
 
 .srOnly {
-  composes: srOnly from '../../lib/a11y.module.css';
+  composes: srOnly from "../../lib/a11y.module.css";
 }

--- a/console/src/lib/a11y.module.css
+++ b/console/src/lib/a11y.module.css
@@ -1,0 +1,11 @@
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1098,6 +1098,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
   justify-content: center;
   gap: 2px;
   padding: 10px 14px;
+  min-width: 0;
   min-height: 44px;
   border-left: 2px solid transparent;
   cursor: pointer;
@@ -1105,8 +1106,8 @@ aside[data-state="collapsed"] .chatSidebarContent {
 }
 
 .suggestionItemActive {
-  background: var(--chat-hover-bg);
-  border-left-color: var(--accent, var(--primary, currentColor));
+  background: color-mix(in srgb, var(--primary) 14%, transparent);
+  border-left-color: var(--primary);
 }
 
 .suggestionItemSub {
@@ -1117,6 +1118,9 @@ aside[data-state="collapsed"] .chatSidebarContent {
   font-size: 0.86rem;
   font-weight: 500;
   color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .suggestionLabelMono {
@@ -1137,6 +1141,9 @@ aside[data-state="collapsed"] .chatSidebarContent {
 .suggestionDesc {
   font-size: 0.76rem;
   color: var(--muted-foreground);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .suggestionEmpty {

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1094,9 +1094,12 @@ aside[data-state="collapsed"] .chatSidebarContent {
   transition: background 0.1s;
 }
 
-.suggestionItem:hover,
 .suggestionItemActive {
   background: var(--chat-hover-bg);
+}
+
+.suggestionItemSub {
+  padding-left: 28px;
 }
 
 .suggestionLabel {
@@ -1107,6 +1110,12 @@ aside[data-state="collapsed"] .chatSidebarContent {
 
 .suggestionDesc {
   font-size: 0.76rem;
+  color: var(--muted-foreground);
+}
+
+.suggestionEmpty {
+  padding: 12px 14px;
+  font-size: 0.82rem;
   color: var(--muted-foreground);
 }
 

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1146,15 +1146,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
 }
 
 .slashLiveRegion {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
+  composes: srOnly from '../../lib/a11y.module.css';
 }
 
 @media (max-width: 768px) {

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1098,6 +1098,8 @@ aside[data-state="collapsed"] .chatSidebarContent {
   justify-content: center;
   gap: 2px;
   padding: 10px 14px;
+  /* Allow flex children (label/desc) to ellipsize so a long
+     description does not push the popover wider than the trigger. */
   min-width: 0;
   min-height: 44px;
   border-left: 2px solid transparent;

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1146,7 +1146,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
 }
 
 .slashLiveRegion {
-  composes: srOnly from '../../lib/a11y.module.css';
+  composes: srOnly from "../../lib/a11y.module.css";
 }
 
 @media (max-width: 768px) {

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1077,12 +1077,19 @@ aside[data-state="collapsed"] .chatSidebarContent {
 }
 
 .slashSuggestions {
-  max-height: 220px;
-  overflow-y: auto;
   background: var(--popover);
   border: 1px solid var(--line);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-popover);
+  overflow: hidden;
+}
+
+.slashSuggestionsScroll {
+  max-height: 220px;
+}
+
+.slashSuggestionsList {
+  outline: none;
 }
 
 .suggestionItem {
@@ -1252,7 +1259,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
     background: var(--page-bg);
   }
 
-  .slashSuggestions {
+  .slashSuggestionsScroll {
     max-height: 40vh;
   }
 }

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1077,18 +1077,12 @@ aside[data-state="collapsed"] .chatSidebarContent {
 }
 
 .slashSuggestions {
-  position: absolute;
-  bottom: 100%;
-  left: 0;
-  right: 0;
   max-height: 220px;
   overflow-y: auto;
   background: var(--popover);
   border: 1px solid var(--line);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-popover);
-  margin-bottom: 4px;
-  z-index: 20;
 }
 
 .suggestionItem {

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1088,14 +1088,18 @@ aside[data-state="collapsed"] .chatSidebarContent {
 .suggestionItem {
   display: flex;
   flex-direction: column;
+  justify-content: center;
   gap: 2px;
-  padding: 8px 14px;
+  padding: 10px 14px;
+  min-height: 44px;
+  border-left: 2px solid transparent;
   cursor: pointer;
   transition: background 0.1s;
 }
 
 .suggestionItemActive {
   background: var(--chat-hover-bg);
+  border-left-color: var(--accent, var(--primary, currentColor));
 }
 
 .suggestionItemSub {
@@ -1108,15 +1112,49 @@ aside[data-state="collapsed"] .chatSidebarContent {
   color: var(--text);
 }
 
+.suggestionLabelMono {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.82rem;
+  color: var(--muted-foreground);
+}
+
+.suggestionMatch {
+  background: transparent;
+  color: inherit;
+  font-weight: 700;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
 .suggestionDesc {
   font-size: 0.76rem;
   color: var(--muted-foreground);
 }
 
 .suggestionEmpty {
-  padding: 12px 14px;
+  padding: 14px;
   font-size: 0.82rem;
   color: var(--muted-foreground);
+}
+
+.slashLiveRegion {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+@media (max-width: 768px) {
+  .suggestionItem {
+    min-height: 48px;
+    padding: 12px 14px;
+  }
 }
 
 .errorBanner {

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -773,7 +773,9 @@ describe('ChatPage', () => {
 
     fireEvent.click(screen.getByTitle('Edit'));
 
-    const editBox = screen.getAllByRole('textbox')[1] as HTMLTextAreaElement;
+    const editBox = screen.getByLabelText(
+      'Edit message',
+    ) as HTMLTextAreaElement;
     fireEvent.change(editBox, {
       target: { value: 'Updated draft message' },
     });

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -182,7 +182,6 @@ describe('ChatPage', () => {
   });
 
   beforeEach(async () => {
-    window.HTMLElement.prototype.scrollIntoView = vi.fn();
     ensureLocalStorage();
     localStorage.clear();
     localStorage.setItem('hybridclaw_session', 'session-a');

--- a/console/src/routes/chat/composer.test.tsx
+++ b/console/src/routes/chat/composer.test.tsx
@@ -319,12 +319,10 @@ describe('Composer', () => {
       const textarea = screen.getByLabelText(
         'Message input',
       ) as HTMLTextAreaElement;
-      // Step 1: typing the bare command shows the panel.
       textarea.value = '/agent';
       textarea.setSelectionRange(textarea.value.length, textarea.value.length);
       fireEvent.input(textarea);
       await screen.findByRole('listbox');
-      // Step 2: adding a trailing space (to start a subcommand) must NOT close it.
       textarea.value = '/agent ';
       textarea.setSelectionRange(textarea.value.length, textarea.value.length);
       fireEvent.input(textarea);
@@ -335,7 +333,6 @@ describe('Composer', () => {
         ),
       );
       expect(screen.queryByRole('listbox')).not.toBeNull();
-      // Step 3: typing the subcommand keeps the panel open and queries it.
       textarea.value = '/agent in';
       textarea.setSelectionRange(textarea.value.length, textarea.value.length);
       fireEvent.input(textarea);
@@ -354,7 +351,6 @@ describe('Composer', () => {
       const textarea = screen.getByLabelText(
         'Message input',
       ) as HTMLTextAreaElement;
-      // Simulate the user typing "hello /app" with the cursor at the end.
       textarea.value = 'hello /app';
       textarea.setSelectionRange(textarea.value.length, textarea.value.length);
       fireEvent.input(textarea);
@@ -374,13 +370,11 @@ describe('Composer', () => {
         'Message input',
       ) as HTMLTextAreaElement;
       textarea.value = 'hello /app world';
-      // Place the cursor right after `/app`.
       const cursor = 'hello /app'.length;
       textarea.setSelectionRange(cursor, cursor);
       fireEvent.input(textarea);
       await screen.findByRole('listbox');
       fireEvent.keyDown(textarea, { key: 'Enter' });
-      // No double space before "world" because `after` already starts with a space.
       expect(textarea.value).toBe('hello /approve world');
       expect(textarea.selectionStart).toBe('hello /approve'.length);
     });
@@ -419,21 +413,14 @@ describe('Composer', () => {
     });
 
     it('updates the polite live region with the result count', async () => {
-      const items = [
-        APPROVE,
-        CLEAR,
-        { ...APPROVE, id: 'approve-yes', label: '/approve yes' },
-      ];
-      const { container } = render(
-        <Composer
-          isStreaming={false}
-          onSend={vi.fn()}
-          onStop={vi.fn()}
-          onUploadFiles={vi.fn<(_: File[]) => Promise<MediaItem[]>>()}
-          token="test-token"
-        />,
-      );
-      fetchChatCommandsMock.mockResolvedValue({ commands: items });
+      fetchChatCommandsMock.mockResolvedValue({
+        commands: [
+          APPROVE,
+          CLEAR,
+          { ...APPROVE, id: 'approve-yes', label: '/approve yes' },
+        ],
+      });
+      const { container } = renderComposer();
       const textarea = screen.getByLabelText(
         'Message input',
       ) as HTMLTextAreaElement;
@@ -445,15 +432,7 @@ describe('Composer', () => {
 
     it('announces the empty state to the live region', async () => {
       fetchChatCommandsMock.mockResolvedValue({ commands: [] });
-      const { container } = render(
-        <Composer
-          isStreaming={false}
-          onSend={vi.fn()}
-          onStop={vi.fn()}
-          onUploadFiles={vi.fn<(_: File[]) => Promise<MediaItem[]>>()}
-          token="test-token"
-        />,
-      );
+      const { container } = renderComposer();
       const textarea = screen.getByLabelText(
         'Message input',
       ) as HTMLTextAreaElement;
@@ -464,16 +443,8 @@ describe('Composer', () => {
     });
 
     it('uses singular grammar for a single match', async () => {
-      const { container } = render(
-        <Composer
-          isStreaming={false}
-          onSend={vi.fn()}
-          onStop={vi.fn()}
-          onUploadFiles={vi.fn<(_: File[]) => Promise<MediaItem[]>>()}
-          token="test-token"
-        />,
-      );
       fetchChatCommandsMock.mockResolvedValue({ commands: [APPROVE] });
+      const { container } = renderComposer();
       const textarea = screen.getByLabelText(
         'Message input',
       ) as HTMLTextAreaElement;

--- a/console/src/routes/chat/composer.test.tsx
+++ b/console/src/routes/chat/composer.test.tsx
@@ -44,30 +44,18 @@ function renderComposer(
   );
 }
 
+const getTextarea = () =>
+  screen.getByLabelText('Message input') as HTMLTextAreaElement;
+
 describe('Composer', () => {
   beforeEach(() => {
     fetchChatCommandsMock.mockReset();
   });
 
   it('strips the leading slash before fetching command suggestions', async () => {
-    fetchChatCommandsMock.mockResolvedValue({
-      commands: [],
-    });
-
-    render(
-      <Composer
-        isStreaming={false}
-        onSend={vi.fn()}
-        onStop={vi.fn()}
-        onUploadFiles={vi.fn<(_: File[]) => Promise<MediaItem[]>>()}
-        token="test-token"
-      />,
-    );
-
-    fireEvent.input(screen.getByLabelText('Message input'), {
-      target: { value: '/approve' },
-    });
-
+    fetchChatCommandsMock.mockResolvedValue({ commands: [] });
+    renderComposer();
+    fireEvent.input(getTextarea(), { target: { value: '/approve' } });
     await waitFor(() =>
       expect(fetchChatCommandsMock).toHaveBeenCalledWith(
         'test-token',
@@ -78,27 +66,17 @@ describe('Composer', () => {
 
   it('renders a compact agent switcher beside the attach button', () => {
     const onAgentSwitch = vi.fn();
-
-    render(
-      <Composer
-        isStreaming={false}
-        onSend={vi.fn()}
-        onStop={vi.fn()}
-        onUploadFiles={vi.fn<(_: File[]) => Promise<MediaItem[]>>()}
-        token="test-token"
-        agents={[
-          { id: 'main', name: 'Assistant' },
-          { id: 'charly', name: 'Charly' },
-        ]}
-        selectedAgentId="main"
-        onAgentSwitch={onAgentSwitch}
-      />,
-    );
-
+    renderComposer({
+      agents: [
+        { id: 'main', name: 'Assistant' },
+        { id: 'charly', name: 'Charly' },
+      ],
+      selectedAgentId: 'main',
+      onAgentSwitch,
+    });
     fireEvent.change(screen.getByLabelText('Switch agent'), {
       target: { value: 'charly' },
     });
-
     expect(onAgentSwitch).toHaveBeenCalledWith('charly');
   });
 
@@ -109,9 +87,7 @@ describe('Composer', () => {
     ): Promise<HTMLTextAreaElement> {
       fetchChatCommandsMock.mockResolvedValue({ commands });
       renderComposer();
-      const textarea = screen.getByLabelText(
-        'Message input',
-      ) as HTMLTextAreaElement;
+      const textarea = getTextarea();
       fireEvent.input(textarea, { target: { value: typed } });
       await screen.findByRole('listbox');
       return textarea;
@@ -192,9 +168,7 @@ describe('Composer', () => {
     it('shows a no-match empty state when a non-empty query returns nothing', async () => {
       fetchChatCommandsMock.mockResolvedValue({ commands: [] });
       renderComposer();
-      const textarea = screen.getByLabelText(
-        'Message input',
-      ) as HTMLTextAreaElement;
+      const textarea = getTextarea();
       fireEvent.input(textarea, { target: { value: '/zzz' } });
       const panel = await screen.findByRole('listbox');
       expect(panel.textContent).toMatch(/No commands match/i);
@@ -205,9 +179,7 @@ describe('Composer', () => {
     it('keeps the panel closed when the bare slash returns no results', async () => {
       fetchChatCommandsMock.mockResolvedValue({ commands: [] });
       renderComposer();
-      const textarea = screen.getByLabelText(
-        'Message input',
-      ) as HTMLTextAreaElement;
+      const textarea = getTextarea();
       fireEvent.input(textarea, { target: { value: '/' } });
       await waitFor(() =>
         expect(fetchChatCommandsMock).toHaveBeenCalledWith(
@@ -222,9 +194,7 @@ describe('Composer', () => {
       const onSend = vi.fn();
       fetchChatCommandsMock.mockResolvedValue({ commands: [] });
       renderComposer({ onSend });
-      const textarea = screen.getByLabelText(
-        'Message input',
-      ) as HTMLTextAreaElement;
+      const textarea = getTextarea();
       fireEvent.input(textarea, { target: { value: '/zzz' } });
       await screen.findByRole('listbox');
       fireEvent.keyDown(textarea, { key: 'Enter' });
@@ -316,9 +286,7 @@ describe('Composer', () => {
         ],
       });
       renderComposer();
-      const textarea = screen.getByLabelText(
-        'Message input',
-      ) as HTMLTextAreaElement;
+      const textarea = getTextarea();
       textarea.value = '/agent';
       textarea.setSelectionRange(textarea.value.length, textarea.value.length);
       fireEvent.input(textarea);
@@ -348,9 +316,7 @@ describe('Composer', () => {
     it('opens for slash tokens that follow a space (mid-line)', async () => {
       fetchChatCommandsMock.mockResolvedValue({ commands: [APPROVE] });
       renderComposer();
-      const textarea = screen.getByLabelText(
-        'Message input',
-      ) as HTMLTextAreaElement;
+      const textarea = getTextarea();
       textarea.value = 'hello /app';
       textarea.setSelectionRange(textarea.value.length, textarea.value.length);
       fireEvent.input(textarea);
@@ -366,9 +332,7 @@ describe('Composer', () => {
     it('replaces only the slash token when accepting mid-line', async () => {
       fetchChatCommandsMock.mockResolvedValue({ commands: [APPROVE] });
       renderComposer();
-      const textarea = screen.getByLabelText(
-        'Message input',
-      ) as HTMLTextAreaElement;
+      const textarea = getTextarea();
       textarea.value = 'hello /app world';
       const cursor = 'hello /app'.length;
       textarea.setSelectionRange(cursor, cursor);
@@ -388,9 +352,7 @@ describe('Composer', () => {
       };
       fetchChatCommandsMock.mockResolvedValue({ commands: [cfg] });
       renderComposer();
-      const textarea = screen.getByLabelText(
-        'Message input',
-      ) as HTMLTextAreaElement;
+      const textarea = getTextarea();
       fireEvent.input(textarea, { target: { value: '/conf' } });
       const panel = await screen.findByRole('listbox');
       const mark = panel.querySelector('mark');
@@ -421,9 +383,7 @@ describe('Composer', () => {
         ],
       });
       const { container } = renderComposer();
-      const textarea = screen.getByLabelText(
-        'Message input',
-      ) as HTMLTextAreaElement;
+      const textarea = getTextarea();
       fireEvent.input(textarea, { target: { value: '/' } });
       await screen.findByRole('listbox');
       const live = container.querySelector('[aria-live="polite"]');
@@ -433,9 +393,7 @@ describe('Composer', () => {
     it('announces the empty state to the live region', async () => {
       fetchChatCommandsMock.mockResolvedValue({ commands: [] });
       const { container } = renderComposer();
-      const textarea = screen.getByLabelText(
-        'Message input',
-      ) as HTMLTextAreaElement;
+      const textarea = getTextarea();
       fireEvent.input(textarea, { target: { value: '/zzz' } });
       await screen.findByRole('listbox');
       const live = container.querySelector('[aria-live="polite"]');
@@ -445,9 +403,7 @@ describe('Composer', () => {
     it('uses singular grammar for a single match', async () => {
       fetchChatCommandsMock.mockResolvedValue({ commands: [APPROVE] });
       const { container } = renderComposer();
-      const textarea = screen.getByLabelText(
-        'Message input',
-      ) as HTMLTextAreaElement;
+      const textarea = getTextarea();
       fireEvent.input(textarea, { target: { value: '/' } });
       await screen.findByRole('listbox');
       const live = container.querySelector('[aria-live="polite"]');
@@ -463,9 +419,7 @@ describe('Composer', () => {
           }),
       );
       renderComposer();
-      const textarea = screen.getByLabelText(
-        'Message input',
-      ) as HTMLTextAreaElement;
+      const textarea = getTextarea();
       fireEvent.input(textarea, { target: { value: '/' } });
       await waitFor(() => expect(fetchChatCommandsMock).toHaveBeenCalled());
       fireEvent.keyDown(textarea, { key: 'Escape' });
@@ -486,9 +440,7 @@ describe('Composer', () => {
       );
       const onSend = vi.fn();
       renderComposer({ onSend });
-      const textarea = screen.getByLabelText(
-        'Message input',
-      ) as HTMLTextAreaElement;
+      const textarea = getTextarea();
       fireEvent.input(textarea, { target: { value: '/test' } });
       await waitFor(() => expect(fetchChatCommandsMock).toHaveBeenCalled());
       fireEvent.keyDown(textarea, { key: 'Enter' });

--- a/console/src/routes/chat/composer.test.tsx
+++ b/console/src/routes/chat/composer.test.tsx
@@ -307,7 +307,12 @@ describe('Composer', () => {
     it('keeps the panel open as the user types subcommand text after a space', async () => {
       fetchChatCommandsMock.mockResolvedValue({
         commands: [
-          { ...APPROVE, id: 'agent.info', label: '/agent info', insertText: '/agent info' },
+          {
+            ...APPROVE,
+            id: 'agent.info',
+            label: '/agent info',
+            insertText: '/agent info',
+          },
         ],
       });
       renderComposer();

--- a/console/src/routes/chat/composer.test.tsx
+++ b/console/src/routes/chat/composer.test.tsx
@@ -438,5 +438,50 @@ describe('Composer', () => {
       const live = container.querySelector('[aria-live="polite"]');
       expect(live?.textContent).toBe('1 command available');
     });
+
+    it('a stale fetch resolving after dismiss does not reopen the panel', async () => {
+      let resolveFetch: ((value: ChatCommandsResponse) => void) | undefined;
+      fetchChatCommandsMock.mockImplementation(
+        () =>
+          new Promise<ChatCommandsResponse>((resolve) => {
+            resolveFetch = resolve;
+          }),
+      );
+      renderComposer();
+      const textarea = screen.getByLabelText(
+        'Message input',
+      ) as HTMLTextAreaElement;
+      fireEvent.input(textarea, { target: { value: '/' } });
+      await waitFor(() => expect(fetchChatCommandsMock).toHaveBeenCalled());
+      fireEvent.keyDown(textarea, { key: 'Escape' });
+      expect(screen.queryByRole('listbox')).toBeNull();
+      resolveFetch?.({ commands: [APPROVE] });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(screen.queryByRole('listbox')).toBeNull();
+    });
+
+    it('submit cancels a pending lookup so a late response does not pop the panel', async () => {
+      let resolveFetch: ((value: ChatCommandsResponse) => void) | undefined;
+      fetchChatCommandsMock.mockImplementation(
+        () =>
+          new Promise<ChatCommandsResponse>((resolve) => {
+            resolveFetch = resolve;
+          }),
+      );
+      const onSend = vi.fn();
+      renderComposer({ onSend });
+      const textarea = screen.getByLabelText(
+        'Message input',
+      ) as HTMLTextAreaElement;
+      fireEvent.input(textarea, { target: { value: '/test' } });
+      await waitFor(() => expect(fetchChatCommandsMock).toHaveBeenCalled());
+      fireEvent.keyDown(textarea, { key: 'Enter' });
+      expect(onSend).toHaveBeenCalledWith('/test', []);
+      resolveFetch?.({ commands: [APPROVE] });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(screen.queryByRole('listbox')).toBeNull();
+    });
   });
 });

--- a/console/src/routes/chat/composer.test.tsx
+++ b/console/src/routes/chat/composer.test.tsx
@@ -304,6 +304,45 @@ describe('Composer', () => {
       expect(items[1].className).toMatch(/Sub/);
     });
 
+    it('keeps the panel open as the user types subcommand text after a space', async () => {
+      fetchChatCommandsMock.mockResolvedValue({
+        commands: [
+          { ...APPROVE, id: 'agent.info', label: '/agent info', insertText: '/agent info' },
+        ],
+      });
+      renderComposer();
+      const textarea = screen.getByLabelText(
+        'Message input',
+      ) as HTMLTextAreaElement;
+      // Step 1: typing the bare command shows the panel.
+      textarea.value = '/agent';
+      textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+      fireEvent.input(textarea);
+      await screen.findByRole('listbox');
+      // Step 2: adding a trailing space (to start a subcommand) must NOT close it.
+      textarea.value = '/agent ';
+      textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+      fireEvent.input(textarea);
+      await waitFor(() =>
+        expect(fetchChatCommandsMock).toHaveBeenLastCalledWith(
+          'test-token',
+          'agent',
+        ),
+      );
+      expect(screen.queryByRole('listbox')).not.toBeNull();
+      // Step 3: typing the subcommand keeps the panel open and queries it.
+      textarea.value = '/agent in';
+      textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+      fireEvent.input(textarea);
+      await waitFor(() =>
+        expect(fetchChatCommandsMock).toHaveBeenLastCalledWith(
+          'test-token',
+          'agent in',
+        ),
+      );
+      expect(screen.queryByRole('listbox')).not.toBeNull();
+    });
+
     it('opens for slash tokens that follow a space (mid-line)', async () => {
       fetchChatCommandsMock.mockResolvedValue({ commands: [APPROVE] });
       renderComposer();

--- a/console/src/routes/chat/composer.test.tsx
+++ b/console/src/routes/chat/composer.test.tsx
@@ -303,5 +303,140 @@ describe('Composer', () => {
       expect(items[0].className).not.toMatch(/Sub/);
       expect(items[1].className).toMatch(/Sub/);
     });
+
+    it('opens for slash tokens that follow a space (mid-line)', async () => {
+      fetchChatCommandsMock.mockResolvedValue({ commands: [APPROVE] });
+      renderComposer();
+      const textarea = screen.getByLabelText(
+        'Message input',
+      ) as HTMLTextAreaElement;
+      // Simulate the user typing "hello /app" with the cursor at the end.
+      textarea.value = 'hello /app';
+      textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+      fireEvent.input(textarea);
+      await screen.findByRole('listbox');
+      await waitFor(() =>
+        expect(fetchChatCommandsMock).toHaveBeenLastCalledWith(
+          'test-token',
+          'app',
+        ),
+      );
+    });
+
+    it('replaces only the slash token when accepting mid-line', async () => {
+      fetchChatCommandsMock.mockResolvedValue({ commands: [APPROVE] });
+      renderComposer();
+      const textarea = screen.getByLabelText(
+        'Message input',
+      ) as HTMLTextAreaElement;
+      textarea.value = 'hello /app world';
+      // Place the cursor right after `/app`.
+      const cursor = 'hello /app'.length;
+      textarea.setSelectionRange(cursor, cursor);
+      fireEvent.input(textarea);
+      await screen.findByRole('listbox');
+      fireEvent.keyDown(textarea, { key: 'Enter' });
+      // No double space before "world" because `after` already starts with a space.
+      expect(textarea.value).toBe('hello /approve world');
+      expect(textarea.selectionStart).toBe('hello /approve'.length);
+    });
+
+    it('highlights the matching substring of the label with <mark>', async () => {
+      const cfg: ChatCommandSuggestion = {
+        id: 'config',
+        label: '/config get',
+        insertText: '/config get',
+        description: 'Get a config value',
+      };
+      fetchChatCommandsMock.mockResolvedValue({ commands: [cfg] });
+      renderComposer();
+      const textarea = screen.getByLabelText(
+        'Message input',
+      ) as HTMLTextAreaElement;
+      fireEvent.input(textarea, { target: { value: '/conf' } });
+      const panel = await screen.findByRole('listbox');
+      const mark = panel.querySelector('mark');
+      expect(mark).not.toBeNull();
+      expect(mark?.textContent).toBe('conf');
+    });
+
+    it('renders <...> and [...] placeholders in monospace style', async () => {
+      const item: ChatCommandSuggestion = {
+        id: 'channel-mode',
+        label: '/channel-mode <off|mention|free>',
+        insertText: '/channel-mode ',
+        description: 'Set channel mode',
+      };
+      await showPanel([item]);
+      const monoSpan = document.querySelector(
+        '[role="option"] [class*="suggestionLabelMono" i]',
+      );
+      expect(monoSpan?.textContent).toBe('<off|mention|free>');
+    });
+
+    it('updates the polite live region with the result count', async () => {
+      const items = [
+        APPROVE,
+        CLEAR,
+        { ...APPROVE, id: 'approve-yes', label: '/approve yes' },
+      ];
+      const { container } = render(
+        <Composer
+          isStreaming={false}
+          onSend={vi.fn()}
+          onStop={vi.fn()}
+          onUploadFiles={vi.fn<(_: File[]) => Promise<MediaItem[]>>()}
+          token="test-token"
+        />,
+      );
+      fetchChatCommandsMock.mockResolvedValue({ commands: items });
+      const textarea = screen.getByLabelText(
+        'Message input',
+      ) as HTMLTextAreaElement;
+      fireEvent.input(textarea, { target: { value: '/' } });
+      await screen.findByRole('listbox');
+      const live = container.querySelector('[aria-live="polite"]');
+      expect(live?.textContent).toBe('3 commands available');
+    });
+
+    it('announces the empty state to the live region', async () => {
+      fetchChatCommandsMock.mockResolvedValue({ commands: [] });
+      const { container } = render(
+        <Composer
+          isStreaming={false}
+          onSend={vi.fn()}
+          onStop={vi.fn()}
+          onUploadFiles={vi.fn<(_: File[]) => Promise<MediaItem[]>>()}
+          token="test-token"
+        />,
+      );
+      const textarea = screen.getByLabelText(
+        'Message input',
+      ) as HTMLTextAreaElement;
+      fireEvent.input(textarea, { target: { value: '/zzz' } });
+      await screen.findByRole('listbox');
+      const live = container.querySelector('[aria-live="polite"]');
+      expect(live?.textContent).toBe('No commands match /zzz');
+    });
+
+    it('uses singular grammar for a single match', async () => {
+      const { container } = render(
+        <Composer
+          isStreaming={false}
+          onSend={vi.fn()}
+          onStop={vi.fn()}
+          onUploadFiles={vi.fn<(_: File[]) => Promise<MediaItem[]>>()}
+          token="test-token"
+        />,
+      );
+      fetchChatCommandsMock.mockResolvedValue({ commands: [APPROVE] });
+      const textarea = screen.getByLabelText(
+        'Message input',
+      ) as HTMLTextAreaElement;
+      fireEvent.input(textarea, { target: { value: '/' } });
+      await screen.findByRole('listbox');
+      const live = container.querySelector('[aria-live="polite"]');
+      expect(live?.textContent).toBe('1 command available');
+    });
   });
 });

--- a/console/src/routes/chat/composer.test.tsx
+++ b/console/src/routes/chat/composer.test.tsx
@@ -189,17 +189,119 @@ describe('Composer', () => {
       expect(screen.queryByRole('listbox')).toBeNull();
     });
 
-    it('does not render an empty panel when the API returns no commands', async () => {
+    it('shows a no-match empty state when a non-empty query returns nothing', async () => {
       fetchChatCommandsMock.mockResolvedValue({ commands: [] });
       renderComposer();
       const textarea = screen.getByLabelText(
         'Message input',
       ) as HTMLTextAreaElement;
       fireEvent.input(textarea, { target: { value: '/zzz' } });
+      const panel = await screen.findByRole('listbox');
+      expect(panel.textContent).toMatch(/No commands match/i);
+      expect(panel.textContent).toContain('/zzz');
+      expect(screen.queryByRole('option')).toBeNull();
+    });
+
+    it('keeps the panel closed when the bare slash returns no results', async () => {
+      fetchChatCommandsMock.mockResolvedValue({ commands: [] });
+      renderComposer();
+      const textarea = screen.getByLabelText(
+        'Message input',
+      ) as HTMLTextAreaElement;
+      fireEvent.input(textarea, { target: { value: '/' } });
       await waitFor(() =>
-        expect(fetchChatCommandsMock).toHaveBeenCalledWith('test-token', 'zzz'),
+        expect(fetchChatCommandsMock).toHaveBeenCalledWith(
+          'test-token',
+          undefined,
+        ),
       );
       expect(screen.queryByRole('listbox')).toBeNull();
+    });
+
+    it('Enter on empty state sends the message instead of selecting', async () => {
+      const onSend = vi.fn();
+      fetchChatCommandsMock.mockResolvedValue({ commands: [] });
+      renderComposer({ onSend });
+      const textarea = screen.getByLabelText(
+        'Message input',
+      ) as HTMLTextAreaElement;
+      fireEvent.input(textarea, { target: { value: '/zzz' } });
+      await screen.findByRole('listbox');
+      fireEvent.keyDown(textarea, { key: 'Enter' });
+      expect(onSend).toHaveBeenCalledWith('/zzz', []);
+    });
+
+    it('hovering a suggestion item syncs the active index', async () => {
+      await showPanel([APPROVE, CLEAR]);
+      const items = screen.getAllByRole('option');
+      fireEvent.mouseEnter(items[1]);
+      const after = items.map((el) => el.getAttribute('aria-selected'));
+      expect(after).toEqual(['false', 'true']);
+    });
+
+    it('Home and End jump to the first / last suggestion', async () => {
+      const textarea = await showPanel([
+        APPROVE,
+        CLEAR,
+        { ...APPROVE, id: 'approve-yes', label: '/approve yes' },
+      ]);
+      fireEvent.keyDown(textarea, { key: 'End' });
+      expect(
+        screen
+          .getAllByRole('option')
+          .map((el) => el.getAttribute('aria-selected')),
+      ).toEqual(['false', 'false', 'true']);
+      fireEvent.keyDown(textarea, { key: 'Home' });
+      expect(
+        screen
+          .getAllByRole('option')
+          .map((el) => el.getAttribute('aria-selected')),
+      ).toEqual(['true', 'false', 'false']);
+    });
+
+    it('wires combobox aria attributes between the textarea and the listbox', async () => {
+      const textarea = await showPanel([APPROVE, CLEAR]);
+      const listbox = screen.getByRole('listbox');
+      const listboxId = listbox.getAttribute('id');
+      expect(listboxId).toBeTruthy();
+      expect(textarea.getAttribute('role')).toBe('combobox');
+      expect(textarea.getAttribute('aria-autocomplete')).toBe('list');
+      expect(textarea.getAttribute('aria-haspopup')).toBe('listbox');
+      expect(textarea.getAttribute('aria-controls')).toBe(listboxId);
+      expect(textarea.getAttribute('aria-expanded')).toBe('true');
+      const activeId = textarea.getAttribute('aria-activedescendant');
+      expect(activeId).toBeTruthy();
+      expect(document.getElementById(activeId ?? '')).toBe(
+        screen.getAllByRole('option')[0],
+      );
+
+      fireEvent.keyDown(textarea, { key: 'ArrowDown' });
+      const after = textarea.getAttribute('aria-activedescendant');
+      expect(document.getElementById(after ?? '')).toBe(
+        screen.getAllByRole('option')[1],
+      );
+    });
+
+    it('clears aria-expanded and aria-activedescendant when the panel closes', async () => {
+      const textarea = await showPanel([APPROVE]);
+      expect(textarea.getAttribute('aria-expanded')).toBe('true');
+      fireEvent.keyDown(textarea, { key: 'Escape' });
+      expect(textarea.getAttribute('aria-expanded')).toBe('false');
+      expect(textarea.getAttribute('aria-activedescendant')).toBeNull();
+    });
+
+    it('marks subcommand items (depth >= 2) with the indented class', async () => {
+      const sub: ChatCommandSuggestion = {
+        id: 'agent.info',
+        label: '/agent info',
+        insertText: '/agent info',
+        description: 'Inspect agent',
+        depth: 2,
+      };
+      await showPanel([APPROVE, sub]);
+      const items = screen.getAllByRole('option');
+      expect(items[0].className).not.toMatch(/Sub/);
+      expect(items[1].className).toMatch(/Sub/);
     });
   });
 });

--- a/console/src/routes/chat/composer.test.tsx
+++ b/console/src/routes/chat/composer.test.tsx
@@ -1,6 +1,10 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ChatCommandsResponse, MediaItem } from '../../api/chat-types';
+import type {
+  ChatCommandSuggestion,
+  ChatCommandsResponse,
+  MediaItem,
+} from '../../api/chat-types';
 import { Composer } from './composer';
 
 const fetchChatCommandsMock =
@@ -10,6 +14,35 @@ vi.mock('../../api/chat', () => ({
   fetchChatCommands: (token: string, query?: string) =>
     fetchChatCommandsMock(token, query),
 }));
+
+const APPROVE: ChatCommandSuggestion = {
+  id: 'approve',
+  label: '/approve [action]',
+  insertText: '/approve ',
+  description: 'Approve a pending action',
+};
+
+const CLEAR: ChatCommandSuggestion = {
+  id: 'clear',
+  label: '/clear',
+  insertText: '/clear',
+  description: 'Clear the session',
+};
+
+function renderComposer(
+  overrides: Partial<React.ComponentProps<typeof Composer>> = {},
+) {
+  return render(
+    <Composer
+      isStreaming={false}
+      onSend={vi.fn()}
+      onStop={vi.fn()}
+      onUploadFiles={vi.fn<(_: File[]) => Promise<MediaItem[]>>()}
+      token="test-token"
+      {...overrides}
+    />,
+  );
+}
 
 describe('Composer', () => {
   beforeEach(() => {
@@ -67,5 +100,109 @@ describe('Composer', () => {
     });
 
     expect(onAgentSwitch).toHaveBeenCalledWith('charly');
+  });
+
+  describe('slash command suggestion panel', () => {
+    async function showPanel(
+      commands: ChatCommandSuggestion[],
+      typed = '/',
+    ): Promise<HTMLTextAreaElement> {
+      fetchChatCommandsMock.mockResolvedValue({ commands });
+      renderComposer();
+      const textarea = screen.getByLabelText(
+        'Message input',
+      ) as HTMLTextAreaElement;
+      fireEvent.input(textarea, { target: { value: typed } });
+      await screen.findByRole('listbox');
+      return textarea;
+    }
+
+    it('inserts insertText with exactly one trailing space (no double space)', async () => {
+      const textarea = await showPanel([APPROVE]);
+      fireEvent.keyDown(textarea, { key: 'Enter' });
+      expect(textarea.value).toBe('/approve ');
+    });
+
+    it('appends a single trailing space when insertText has none', async () => {
+      const textarea = await showPanel([CLEAR]);
+      fireEvent.keyDown(textarea, { key: 'Enter' });
+      expect(textarea.value).toBe('/clear ');
+    });
+
+    it('Tab also accepts the active suggestion', async () => {
+      const textarea = await showPanel([APPROVE]);
+      fireEvent.keyDown(textarea, { key: 'Tab' });
+      expect(textarea.value).toBe('/approve ');
+    });
+
+    it('ArrowDown moves selection and wraps around', async () => {
+      const textarea = await showPanel([APPROVE, CLEAR]);
+      const initial = screen
+        .getAllByRole('option')
+        .map((el) => el.getAttribute('aria-selected'));
+      expect(initial).toEqual(['true', 'false']);
+
+      fireEvent.keyDown(textarea, { key: 'ArrowDown' });
+      const afterDown = screen
+        .getAllByRole('option')
+        .map((el) => el.getAttribute('aria-selected'));
+      expect(afterDown).toEqual(['false', 'true']);
+
+      fireEvent.keyDown(textarea, { key: 'ArrowDown' });
+      const wrapped = screen
+        .getAllByRole('option')
+        .map((el) => el.getAttribute('aria-selected'));
+      expect(wrapped).toEqual(['true', 'false']);
+    });
+
+    it('ArrowUp from the first item wraps to the last', async () => {
+      const textarea = await showPanel([APPROVE, CLEAR]);
+      fireEvent.keyDown(textarea, { key: 'ArrowUp' });
+      const wrapped = screen
+        .getAllByRole('option')
+        .map((el) => el.getAttribute('aria-selected'));
+      expect(wrapped).toEqual(['false', 'true']);
+    });
+
+    it('Escape closes the panel', async () => {
+      const textarea = await showPanel([APPROVE]);
+      fireEvent.keyDown(textarea, { key: 'Escape' });
+      expect(screen.queryByRole('listbox')).toBeNull();
+    });
+
+    it('mouseDown on a suggestion item applies it', async () => {
+      const textarea = await showPanel([APPROVE, CLEAR]);
+      fireEvent.mouseDown(screen.getByText('/clear'));
+      expect(textarea.value).toBe('/clear ');
+      expect(screen.queryByRole('listbox')).toBeNull();
+    });
+
+    it('clicking outside the composer closes the panel', async () => {
+      await showPanel([APPROVE]);
+      fireEvent.mouseDown(document.body);
+      await waitFor(() => expect(screen.queryByRole('listbox')).toBeNull());
+    });
+
+    it('typing a non-slash character hides the panel', async () => {
+      const textarea = await showPanel([APPROVE]);
+      fireEvent.input(textarea, { target: { value: 'hello' } });
+      expect(screen.queryByRole('listbox')).toBeNull();
+    });
+
+    it('does not render an empty panel when the API returns no commands', async () => {
+      fetchChatCommandsMock.mockResolvedValue({ commands: [] });
+      renderComposer();
+      const textarea = screen.getByLabelText(
+        'Message input',
+      ) as HTMLTextAreaElement;
+      fireEvent.input(textarea, { target: { value: '/zzz' } });
+      await waitFor(() =>
+        expect(fetchChatCommandsMock).toHaveBeenCalledWith(
+          'test-token',
+          'zzz',
+        ),
+      );
+      expect(screen.queryByRole('listbox')).toBeNull();
+    });
   });
 });

--- a/console/src/routes/chat/composer.test.tsx
+++ b/console/src/routes/chat/composer.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   ChatCommandSuggestion,
@@ -368,10 +374,9 @@ describe('Composer', () => {
         description: 'Set channel mode',
       };
       await showPanel([item]);
-      const monoSpan = document.querySelector(
-        '[role="option"] [class*="suggestionLabelMono" i]',
-      );
-      expect(monoSpan?.textContent).toBe('<off|mention|free>');
+      // The placeholder must render as its own discrete element (a mono-styled
+      // span) — getByText only matches when the text is a single text node.
+      expect(screen.getByText('<off|mention|free>')).toBeTruthy();
     });
 
     it('updates the polite live region with the result count', async () => {
@@ -424,9 +429,9 @@ describe('Composer', () => {
       await waitFor(() => expect(fetchChatCommandsMock).toHaveBeenCalled());
       fireEvent.keyDown(textarea, { key: 'Escape' });
       expect(screen.queryByRole('listbox')).toBeNull();
-      resolveFetch?.({ commands: [APPROVE] });
-      await Promise.resolve();
-      await Promise.resolve();
+      await act(async () => {
+        resolveFetch?.({ commands: [APPROVE] });
+      });
       expect(screen.queryByRole('listbox')).toBeNull();
     });
 
@@ -445,9 +450,9 @@ describe('Composer', () => {
       await waitFor(() => expect(fetchChatCommandsMock).toHaveBeenCalled());
       fireEvent.keyDown(textarea, { key: 'Enter' });
       expect(onSend).toHaveBeenCalledWith('/test', []);
-      resolveFetch?.({ commands: [APPROVE] });
-      await Promise.resolve();
-      await Promise.resolve();
+      await act(async () => {
+        resolveFetch?.({ commands: [APPROVE] });
+      });
       expect(screen.queryByRole('listbox')).toBeNull();
     });
   });

--- a/console/src/routes/chat/composer.test.tsx
+++ b/console/src/routes/chat/composer.test.tsx
@@ -197,10 +197,7 @@ describe('Composer', () => {
       ) as HTMLTextAreaElement;
       fireEvent.input(textarea, { target: { value: '/zzz' } });
       await waitFor(() =>
-        expect(fetchChatCommandsMock).toHaveBeenCalledWith(
-          'test-token',
-          'zzz',
-        ),
+        expect(fetchChatCommandsMock).toHaveBeenCalledWith('test-token', 'zzz'),
       );
       expect(screen.queryByRole('listbox')).toBeNull();
     });

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -5,6 +5,7 @@ import {
   type ReactNode,
   useCallback,
   useEffect,
+  useId,
   useRef,
   useState,
 } from 'react';
@@ -58,19 +59,39 @@ export function Composer(props: {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const listboxRef = useRef<HTMLDivElement>(null);
   const [pendingMedia, setPendingMedia] = useState<MediaItem[]>([]);
   const [uploading, setUploading] = useState(0);
   const [suggestions, setSuggestions] = useState<ChatCommandSuggestion[]>([]);
   const [activeIdx, setActiveIdx] = useState(0);
-  const [showSuggestions, setShowSuggestions] = useState(false);
+  type PanelMode = 'closed' | 'list' | 'empty';
+  const [panelMode, setPanelMode] = useState<PanelMode>('closed');
+  const [emptyQuery, setEmptyQuery] = useState('');
   const suggestTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const suggestSeqRef = useRef(0);
+  const listboxId = useId();
+  const optionId = (i: number) => `${listboxId}-opt-${i}`;
+  const isOpen = panelMode !== 'closed';
 
   useEffect(() => {
     return () => {
       if (suggestTimerRef.current) clearTimeout(suggestTimerRef.current);
     };
   }, []);
+
+  useEffect(() => {
+    if (panelMode !== 'list' || suggestions.length === 0) return;
+    const list = listboxRef.current;
+    const active = document.getElementById(`${listboxId}-opt-${activeIdx}`);
+    if (!list || !active || !list.contains(active)) return;
+    const itemTop = active.offsetTop;
+    const itemBottom = itemTop + active.offsetHeight;
+    if (itemTop < list.scrollTop) {
+      list.scrollTop = itemTop;
+    } else if (itemBottom > list.scrollTop + list.clientHeight) {
+      list.scrollTop = itemBottom - list.clientHeight;
+    }
+  }, [activeIdx, panelMode, suggestions.length, listboxId]);
 
   useEffect(() => {
     const wrapper = wrapperRef.current;
@@ -122,13 +143,21 @@ export function Composer(props: {
       try {
         const res = await fetchChatCommands(props.token, query || undefined);
         if (seq !== suggestSeqRef.current) return;
-        setSuggestions(res.commands ?? []);
+        const commands = res.commands ?? [];
+        setSuggestions(commands);
         setActiveIdx(0);
-        setShowSuggestions((res.commands ?? []).length > 0);
+        if (commands.length > 0) {
+          setPanelMode('list');
+        } else if (query !== '') {
+          setEmptyQuery(query);
+          setPanelMode('empty');
+        } else {
+          setPanelMode('closed');
+        }
       } catch {
         if (seq !== suggestSeqRef.current) return;
         setSuggestions([]);
-        setShowSuggestions(false);
+        setPanelMode('closed');
       }
     },
     [props.token],
@@ -144,14 +173,14 @@ export function Composer(props: {
         void fetchSuggestions(query);
       }, 150);
     } else {
-      setShowSuggestions(false);
+      setPanelMode('closed');
     }
   };
 
   const applySuggestion = (item: ChatCommandSuggestion) => {
     if (!textareaRef.current) return;
     textareaRef.current.value = `${item.insertText.replace(/\s+$/, '')} `;
-    setShowSuggestions(false);
+    setPanelMode('closed');
     resize();
     textareaRef.current.focus();
   };
@@ -167,12 +196,12 @@ export function Composer(props: {
     props.onSend(val, pendingMedia);
     if (textareaRef.current) textareaRef.current.value = '';
     setPendingMedia([]);
-    setShowSuggestions(false);
+    setPanelMode('closed');
     resize();
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (showSuggestions && suggestions.length > 0) {
+    if (panelMode === 'list' && suggestions.length > 0) {
       if (e.key === 'ArrowDown') {
         e.preventDefault();
         setActiveIdx((i) => (i + 1) % suggestions.length);
@@ -183,16 +212,26 @@ export function Composer(props: {
         setActiveIdx((i) => (i - 1 + suggestions.length) % suggestions.length);
         return;
       }
+      if (e.key === 'Home') {
+        e.preventDefault();
+        setActiveIdx(0);
+        return;
+      }
+      if (e.key === 'End') {
+        e.preventDefault();
+        setActiveIdx(suggestions.length - 1);
+        return;
+      }
       if (e.key === 'Tab' || e.key === 'Enter') {
         e.preventDefault();
         applySuggestion(suggestions[activeIdx]);
         return;
       }
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        setShowSuggestions(false);
-        return;
-      }
+    }
+    if (isOpen && e.key === 'Escape') {
+      e.preventDefault();
+      setPanelMode('closed');
+      return;
     }
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
@@ -237,7 +276,12 @@ export function Composer(props: {
 
   return (
     <div className={css.composerWrapper} ref={wrapperRef}>
-      <Popover open={showSuggestions} onOpenChange={setShowSuggestions}>
+      <Popover
+        open={isOpen}
+        onOpenChange={(next) => {
+          if (!next) setPanelMode('closed');
+        }}
+      >
         <ComposerAnchor className={css.composer}>
           {pendingMedia.length > 0 || uploading > 0 ? (
             <div className={css.pendingMediaRow}>
@@ -268,6 +312,16 @@ export function Composer(props: {
             onKeyDown={handleKeyDown}
             onPaste={handlePaste}
             aria-label="Message input"
+            role="combobox"
+            aria-autocomplete="list"
+            aria-haspopup="listbox"
+            aria-controls={listboxId}
+            aria-expanded={isOpen}
+            aria-activedescendant={
+              panelMode === 'list' && suggestions.length > 0
+                ? optionId(activeIdx)
+                : undefined
+            }
           />
           <div className={css.composerActions}>
             <div className={css.composerLeftActions}>
@@ -334,36 +388,50 @@ export function Composer(props: {
             />
           </div>
         </ComposerAnchor>
-        {showSuggestions && suggestions.length > 0 ? (
+        {isOpen ? (
           <PopoverContent
+            ref={listboxRef}
+            id={listboxId}
             role="listbox"
+            aria-label="Slash commands"
             focusOnOpen="none"
             closeOnEscape={false}
             closeOnOutsideClick
             sideOffset={4}
             className={css.slashSuggestions}
           >
-            {suggestions.map((item, i) => (
-              <div
-                key={item.id}
-                className={cx(
-                  css.suggestionItem,
-                  i === activeIdx && css.suggestionItemActive,
-                )}
-                role="option"
-                tabIndex={-1}
-                aria-selected={i === activeIdx}
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  applySuggestion(item);
-                }}
-              >
-                <span className={css.suggestionLabel}>{item.label}</span>
-                {item.description ? (
-                  <span className={css.suggestionDesc}>{item.description}</span>
-                ) : null}
+            {panelMode === 'list' ? (
+              suggestions.map((item, i) => (
+                <div
+                  key={item.id}
+                  id={optionId(i)}
+                  className={cx(
+                    css.suggestionItem,
+                    i === activeIdx && css.suggestionItemActive,
+                    (item.depth ?? 1) >= 2 && css.suggestionItemSub,
+                  )}
+                  role="option"
+                  tabIndex={-1}
+                  aria-selected={i === activeIdx}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    applySuggestion(item);
+                  }}
+                  onMouseEnter={() => setActiveIdx(i)}
+                >
+                  <span className={css.suggestionLabel}>{item.label}</span>
+                  {item.description ? (
+                    <span className={css.suggestionDesc}>
+                      {item.description}
+                    </span>
+                  ) : null}
+                </div>
+              ))
+            ) : (
+              <div className={css.suggestionEmpty} role="status">
+                No commands match “/{emptyQuery}”
               </div>
-            ))}
+            )}
           </PopoverContent>
         ) : null}
       </Popover>

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -85,6 +85,19 @@ export function Composer(props: {
   }, []);
 
   useEffect(() => {
+    if (!showSuggestions) return;
+    const handler = (event: MouseEvent) => {
+      const wrapper = wrapperRef.current;
+      if (!wrapper) return;
+      if (event.target instanceof Node && !wrapper.contains(event.target)) {
+        setShowSuggestions(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [showSuggestions]);
+
+  useEffect(() => {
     const wrapper = wrapperRef.current;
     if (!wrapper) return;
 
@@ -162,7 +175,7 @@ export function Composer(props: {
 
   const applySuggestion = (item: ChatCommandSuggestion) => {
     if (!textareaRef.current) return;
-    textareaRef.current.value = `${item.insertText} `;
+    textareaRef.current.value = `${item.insertText.replace(/\s+$/, '')} `;
     setShowSuggestions(false);
     resize();
     textareaRef.current.focus();
@@ -179,6 +192,7 @@ export function Composer(props: {
     props.onSend(val, pendingMedia);
     if (textareaRef.current) textareaRef.current.value = '';
     setPendingMedia([]);
+    setShowSuggestions(false);
     resize();
   };
 

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -173,6 +173,10 @@ export function Composer(props: {
     if (ctx) {
       const query = ctx.query.trim();
       if (suggestTimerRef.current) clearTimeout(suggestTimerRef.current);
+      // Invalidate any in-flight fetch from a prior keystroke so its late
+      // response can't briefly apply between this keystroke and the next
+      // debounced fetch landing.
+      suggestSeqRef.current += 1;
       suggestTimerRef.current = setTimeout(() => {
         void fetchSuggestions(query);
       }, 150);

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -14,6 +14,7 @@ import type { ChatCommandSuggestion, MediaItem } from '../../api/chat-types';
 import { Popover, usePopoverContext } from '../../components/popover';
 import { extractClipboardFiles } from '../../lib/chat-helpers';
 import { cx } from '../../lib/cx';
+import { pluralize } from '../../lib/format';
 import {
   type AgentSwitchOption,
   AgentSwitchSelect,
@@ -23,8 +24,10 @@ import {
   type ModelSwitchEntry,
   ModelSwitchSelect,
 } from './model-switch-select';
+import { getSlashContext } from './slash-context';
 import {
-  getSlashContext,
+  optionIdFor,
+  type SlashPanelMode,
   SlashSuggestionsPanel,
 } from './slash-suggestions-panel';
 
@@ -59,41 +62,28 @@ export function Composer(props: {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
-  const listboxRef = useRef<HTMLDivElement>(null);
   const [pendingMedia, setPendingMedia] = useState<MediaItem[]>([]);
   const [uploading, setUploading] = useState(0);
   const [suggestions, setSuggestions] = useState<ChatCommandSuggestion[]>([]);
   const [activeIdx, setActiveIdx] = useState(0);
-  type PanelMode = 'closed' | 'list' | 'empty';
-  const [panelMode, setPanelMode] = useState<PanelMode>('closed');
-  const [emptyQuery, setEmptyQuery] = useState('');
-  const [activeQuery, setActiveQuery] = useState('');
-  const [liveMessage, setLiveMessage] = useState('');
+  const [panelMode, setPanelMode] = useState<SlashPanelMode>('closed');
+  const [lastQuery, setLastQuery] = useState('');
   const suggestTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const suggestSeqRef = useRef(0);
   const listboxId = useId();
-  const optionId = useCallback(
-    (i: number) => `${listboxId}-opt-${i}`,
-    [listboxId],
-  );
   const isOpen = panelMode !== 'closed';
+  const liveMessage =
+    panelMode === 'list'
+      ? `${pluralize(suggestions.length, 'command')} available`
+      : panelMode === 'empty'
+        ? `No commands match /${lastQuery}`
+        : '';
 
   useEffect(() => {
     return () => {
       if (suggestTimerRef.current) clearTimeout(suggestTimerRef.current);
     };
   }, []);
-
-  useEffect(() => {
-    if (panelMode === 'list') {
-      const n = suggestions.length;
-      setLiveMessage(`${n} command${n === 1 ? '' : 's'} available`);
-    } else if (panelMode === 'empty') {
-      setLiveMessage(`No commands match /${emptyQuery}`);
-    } else {
-      setLiveMessage('');
-    }
-  }, [panelMode, suggestions.length, emptyQuery]);
 
   useEffect(() => {
     const wrapper = wrapperRef.current;
@@ -148,11 +138,10 @@ export function Composer(props: {
         const commands = res.commands ?? [];
         setSuggestions(commands);
         setActiveIdx(0);
-        setActiveQuery(query);
+        setLastQuery(query);
         if (commands.length > 0) {
           setPanelMode('list');
         } else if (query !== '') {
-          setEmptyQuery(query);
           setPanelMode('empty');
         } else {
           setPanelMode('closed');
@@ -340,7 +329,7 @@ export function Composer(props: {
             aria-expanded={isOpen}
             aria-activedescendant={
               panelMode === 'list' && suggestions.length > 0
-                ? optionId(activeIdx)
+                ? optionIdFor(listboxId, activeIdx)
                 : undefined
             }
           />
@@ -409,16 +398,13 @@ export function Composer(props: {
             />
           </div>
         </ComposerAnchor>
-        {isOpen ? (
+        {panelMode !== 'closed' ? (
           <SlashSuggestionsPanel
-            mode={panelMode === 'list' ? 'list' : 'empty'}
+            mode={panelMode}
             suggestions={suggestions}
             activeIdx={activeIdx}
-            query={activeQuery}
-            emptyQuery={emptyQuery}
+            query={lastQuery}
             listboxId={listboxId}
-            optionId={optionId}
-            listboxRef={listboxRef}
             onSelect={applySuggestion}
             onActiveChange={setActiveIdx}
           />

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -2,6 +2,7 @@ import {
   type ChangeEvent,
   type ClipboardEvent,
   type KeyboardEvent,
+  type ReactNode,
   useCallback,
   useEffect,
   useRef,
@@ -9,6 +10,11 @@ import {
 } from 'react';
 import { fetchChatCommands } from '../../api/chat';
 import type { ChatCommandSuggestion, MediaItem } from '../../api/chat-types';
+import {
+  Popover,
+  PopoverContent,
+  usePopoverContext,
+} from '../../components/popover';
 import { extractClipboardFiles } from '../../lib/chat-helpers';
 import { cx } from '../../lib/cx';
 import {
@@ -21,35 +27,17 @@ import {
   ModelSwitchSelect,
 } from './model-switch-select';
 
-function SlashSuggestions(props: {
-  items: ChatCommandSuggestion[];
-  activeIndex: number;
-  onSelect: (item: ChatCommandSuggestion) => void;
+function ComposerAnchor({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
 }) {
-  if (props.items.length === 0) return null;
+  const ctx = usePopoverContext('ComposerAnchor');
   return (
-    <div className={css.slashSuggestions} role="listbox">
-      {props.items.map((item, i) => (
-        <div
-          key={item.id}
-          className={cx(
-            css.suggestionItem,
-            i === props.activeIndex && css.suggestionItemActive,
-          )}
-          role="option"
-          tabIndex={-1}
-          aria-selected={i === props.activeIndex}
-          onMouseDown={(e) => {
-            e.preventDefault();
-            props.onSelect(item);
-          }}
-        >
-          <span className={css.suggestionLabel}>{item.label}</span>
-          {item.description ? (
-            <span className={css.suggestionDesc}>{item.description}</span>
-          ) : null}
-        </div>
-      ))}
+    <div ref={ctx.setTriggerEl} className={className}>
+      {children}
     </div>
   );
 }
@@ -83,19 +71,6 @@ export function Composer(props: {
       if (suggestTimerRef.current) clearTimeout(suggestTimerRef.current);
     };
   }, []);
-
-  useEffect(() => {
-    if (!showSuggestions) return;
-    const handler = (event: MouseEvent) => {
-      const wrapper = wrapperRef.current;
-      if (!wrapper) return;
-      if (event.target instanceof Node && !wrapper.contains(event.target)) {
-        setShowSuggestions(false);
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [showSuggestions]);
 
   useEffect(() => {
     const wrapper = wrapperRef.current;
@@ -262,15 +237,9 @@ export function Composer(props: {
 
   return (
     <div className={css.composerWrapper} ref={wrapperRef}>
-      <div className={css.composer} style={{ position: 'relative' }}>
-        {showSuggestions ? (
-          <SlashSuggestions
-            items={suggestions}
-            activeIndex={activeIdx}
-            onSelect={applySuggestion}
-          />
-        ) : null}
-        {pendingMedia.length > 0 || uploading > 0 ? (
+      <Popover open={showSuggestions} onOpenChange={setShowSuggestions}>
+        <ComposerAnchor className={css.composer}>
+          {pendingMedia.length > 0 || uploading > 0 ? (
           <div className={css.pendingMediaRow}>
             {pendingMedia.map((m, i) => (
               <span key={m.path} className={css.mediaChip}>
@@ -364,7 +333,40 @@ export function Composer(props: {
             onChange={handleFileChange}
           />
         </div>
-      </div>
+        </ComposerAnchor>
+        {showSuggestions && suggestions.length > 0 ? (
+          <PopoverContent
+            role="listbox"
+            focusOnOpen="none"
+            closeOnEscape={false}
+            closeOnOutsideClick
+            sideOffset={4}
+            className={css.slashSuggestions}
+          >
+            {suggestions.map((item, i) => (
+              <div
+                key={item.id}
+                className={cx(
+                  css.suggestionItem,
+                  i === activeIdx && css.suggestionItemActive,
+                )}
+                role="option"
+                tabIndex={-1}
+                aria-selected={i === activeIdx}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  applySuggestion(item);
+                }}
+              >
+                <span className={css.suggestionLabel}>{item.label}</span>
+                {item.description ? (
+                  <span className={css.suggestionDesc}>{item.description}</span>
+                ) : null}
+              </div>
+            ))}
+          </PopoverContent>
+        ) : null}
+      </Popover>
     </div>
   );
 }

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -240,99 +240,99 @@ export function Composer(props: {
       <Popover open={showSuggestions} onOpenChange={setShowSuggestions}>
         <ComposerAnchor className={css.composer}>
           {pendingMedia.length > 0 || uploading > 0 ? (
-          <div className={css.pendingMediaRow}>
-            {pendingMedia.map((m, i) => (
-              <span key={m.path} className={css.mediaChip}>
-                <span className={css.mediaChipName}>{m.filename}</span>
-                <button
-                  type="button"
-                  className={css.mediaChipRemove}
-                  onClick={() => removeMedia(i)}
-                >
-                  ×
-                </button>
-              </span>
-            ))}
-            {uploading > 0 ? (
-              <span className={css.mediaChip}>Uploading…</span>
-            ) : null}
-          </div>
-        ) : null}
-        <textarea
-          ref={textareaRef}
-          className={css.composerInput}
-          rows={1}
-          placeholder="Message HybridClaw"
-          disabled={props.isStreaming}
-          onInput={handleInput}
-          onKeyDown={handleKeyDown}
-          onPaste={handlePaste}
-          aria-label="Message input"
-        />
-        <div className={css.composerActions}>
-          <div className={css.composerLeftActions}>
+            <div className={css.pendingMediaRow}>
+              {pendingMedia.map((m, i) => (
+                <span key={m.path} className={css.mediaChip}>
+                  <span className={css.mediaChipName}>{m.filename}</span>
+                  <button
+                    type="button"
+                    className={css.mediaChipRemove}
+                    onClick={() => removeMedia(i)}
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+              {uploading > 0 ? (
+                <span className={css.mediaChip}>Uploading…</span>
+              ) : null}
+            </div>
+          ) : null}
+          <textarea
+            ref={textareaRef}
+            className={css.composerInput}
+            rows={1}
+            placeholder="Message HybridClaw"
+            disabled={props.isStreaming}
+            onInput={handleInput}
+            onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
+            aria-label="Message input"
+          />
+          <div className={css.composerActions}>
+            <div className={css.composerLeftActions}>
+              <button
+                type="button"
+                className={css.attachButton}
+                onClick={() => fileInputRef.current?.click()}
+                aria-label="Attach files"
+              >
+                +
+              </button>
+              <AgentSwitchSelect
+                agents={agentOptions}
+                selectedAgentId={selectedAgentId}
+                disabled={props.isStreaming}
+                onSwitch={(agentId) => props.onAgentSwitch?.(agentId)}
+              />
+              <ModelSwitchSelect
+                models={modelOptions}
+                selectedModelId={selectedModelId}
+                disabled={props.isStreaming}
+                onSwitch={(modelId) => props.onModelSwitch?.(modelId)}
+              />
+            </div>
             <button
               type="button"
-              className={css.attachButton}
-              onClick={() => fileInputRef.current?.click()}
-              aria-label="Attach files"
+              className={cx(css.sendButton, props.isStreaming && css.stopping)}
+              onClick={submit}
+              aria-label={props.isStreaming ? 'Stop' : 'Send message'}
             >
-              +
+              {props.isStreaming ? (
+                <svg
+                  viewBox="0 0 24 24"
+                  width="16"
+                  height="16"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <rect x="6" y="6" width="12" height="12" rx="2" />
+                </svg>
+              ) : (
+                <svg
+                  viewBox="0 0 24 24"
+                  width="16"
+                  height="16"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.4"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M12 19V5" />
+                  <path d="m5 12 7-7 7 7" />
+                </svg>
+              )}
             </button>
-            <AgentSwitchSelect
-              agents={agentOptions}
-              selectedAgentId={selectedAgentId}
-              disabled={props.isStreaming}
-              onSwitch={(agentId) => props.onAgentSwitch?.(agentId)}
-            />
-            <ModelSwitchSelect
-              models={modelOptions}
-              selectedModelId={selectedModelId}
-              disabled={props.isStreaming}
-              onSwitch={(modelId) => props.onModelSwitch?.(modelId)}
+            <input
+              ref={fileInputRef}
+              type="file"
+              hidden
+              multiple
+              onChange={handleFileChange}
             />
           </div>
-          <button
-            type="button"
-            className={cx(css.sendButton, props.isStreaming && css.stopping)}
-            onClick={submit}
-            aria-label={props.isStreaming ? 'Stop' : 'Send message'}
-          >
-            {props.isStreaming ? (
-              <svg
-                viewBox="0 0 24 24"
-                width="16"
-                height="16"
-                fill="currentColor"
-                aria-hidden="true"
-              >
-                <rect x="6" y="6" width="12" height="12" rx="2" />
-              </svg>
-            ) : (
-              <svg
-                viewBox="0 0 24 24"
-                width="16"
-                height="16"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2.4"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden="true"
-              >
-                <path d="M12 19V5" />
-                <path d="m5 12 7-7 7 7" />
-              </svg>
-            )}
-          </button>
-          <input
-            ref={fileInputRef}
-            type="file"
-            hidden
-            multiple
-            onChange={handleFileChange}
-          />
-        </div>
         </ComposerAnchor>
         {showSuggestions && suggestions.length > 0 ? (
           <PopoverContent

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -128,6 +128,15 @@ export function Composer(props: {
     ta.style.height = `${Math.min(ta.scrollHeight, 180)}px`;
   };
 
+  const closePanel = useCallback(() => {
+    if (suggestTimerRef.current) {
+      clearTimeout(suggestTimerRef.current);
+      suggestTimerRef.current = null;
+    }
+    suggestSeqRef.current += 1;
+    setPanelMode('closed');
+  }, []);
+
   const fetchSuggestions = useCallback(
     async (query: string) => {
       suggestSeqRef.current += 1;
@@ -168,7 +177,7 @@ export function Composer(props: {
         void fetchSuggestions(query);
       }, 150);
     } else {
-      setPanelMode('closed');
+      closePanel();
     }
   };
 
@@ -190,7 +199,7 @@ export function Composer(props: {
       ta.value = `${insertCore} `;
       ta.setSelectionRange(ta.value.length, ta.value.length);
     }
-    setPanelMode('closed');
+    closePanel();
     resize();
     ta.focus();
   };
@@ -206,7 +215,7 @@ export function Composer(props: {
     props.onSend(val, pendingMedia);
     if (textareaRef.current) textareaRef.current.value = '';
     setPendingMedia([]);
-    setPanelMode('closed');
+    closePanel();
     resize();
   };
 
@@ -240,7 +249,7 @@ export function Composer(props: {
     }
     if (isOpen && e.key === 'Escape') {
       e.preventDefault();
-      setPanelMode('closed');
+      closePanel();
       return;
     }
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -289,7 +298,7 @@ export function Composer(props: {
       <Popover
         open={isOpen}
         onOpenChange={(next) => {
-          if (!next) setPanelMode('closed');
+          if (!next) closePanel();
         }}
       >
         <ComposerAnchor className={css.composer}>

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -128,14 +128,14 @@ export function Composer(props: {
     ta.style.height = `${Math.min(ta.scrollHeight, 180)}px`;
   };
 
-  const closePanel = useCallback(() => {
+  const closePanel = () => {
     if (suggestTimerRef.current) {
       clearTimeout(suggestTimerRef.current);
       suggestTimerRef.current = null;
     }
     suggestSeqRef.current += 1;
     setPanelMode('closed');
-  }, []);
+  };
 
   const fetchSuggestions = useCallback(
     async (query: string) => {
@@ -190,7 +190,7 @@ export function Composer(props: {
     const insertCore = item.insertText.replace(/\s+$/, '');
     if (ctx) {
       const before = value.slice(0, ctx.tokenStart);
-      const after = value.slice(ctx.tokenEnd);
+      const after = value.slice(cursor);
       const insert = after.startsWith(' ') ? insertCore : `${insertCore} `;
       ta.value = before + insert + after;
       const newCursor = before.length + insert.length;

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -11,11 +11,7 @@ import {
 } from 'react';
 import { fetchChatCommands } from '../../api/chat';
 import type { ChatCommandSuggestion, MediaItem } from '../../api/chat-types';
-import {
-  Popover,
-  PopoverContent,
-  usePopoverContext,
-} from '../../components/popover';
+import { Popover, usePopoverContext } from '../../components/popover';
 import { extractClipboardFiles } from '../../lib/chat-helpers';
 import { cx } from '../../lib/cx';
 import {
@@ -27,6 +23,10 @@ import {
   type ModelSwitchEntry,
   ModelSwitchSelect,
 } from './model-switch-select';
+import {
+  getSlashContext,
+  SlashSuggestionsPanel,
+} from './slash-suggestions-panel';
 
 function ComposerAnchor({
   children,
@@ -67,10 +67,15 @@ export function Composer(props: {
   type PanelMode = 'closed' | 'list' | 'empty';
   const [panelMode, setPanelMode] = useState<PanelMode>('closed');
   const [emptyQuery, setEmptyQuery] = useState('');
+  const [activeQuery, setActiveQuery] = useState('');
+  const [liveMessage, setLiveMessage] = useState('');
   const suggestTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const suggestSeqRef = useRef(0);
   const listboxId = useId();
-  const optionId = (i: number) => `${listboxId}-opt-${i}`;
+  const optionId = useCallback(
+    (i: number) => `${listboxId}-opt-${i}`,
+    [listboxId],
+  );
   const isOpen = panelMode !== 'closed';
 
   useEffect(() => {
@@ -80,18 +85,15 @@ export function Composer(props: {
   }, []);
 
   useEffect(() => {
-    if (panelMode !== 'list' || suggestions.length === 0) return;
-    const list = listboxRef.current;
-    const active = document.getElementById(`${listboxId}-opt-${activeIdx}`);
-    if (!list || !active || !list.contains(active)) return;
-    const itemTop = active.offsetTop;
-    const itemBottom = itemTop + active.offsetHeight;
-    if (itemTop < list.scrollTop) {
-      list.scrollTop = itemTop;
-    } else if (itemBottom > list.scrollTop + list.clientHeight) {
-      list.scrollTop = itemBottom - list.clientHeight;
+    if (panelMode === 'list') {
+      const n = suggestions.length;
+      setLiveMessage(`${n} command${n === 1 ? '' : 's'} available`);
+    } else if (panelMode === 'empty') {
+      setLiveMessage(`No commands match /${emptyQuery}`);
+    } else {
+      setLiveMessage('');
     }
-  }, [activeIdx, panelMode, suggestions.length, listboxId]);
+  }, [panelMode, suggestions.length, emptyQuery]);
 
   useEffect(() => {
     const wrapper = wrapperRef.current;
@@ -146,6 +148,7 @@ export function Composer(props: {
         const commands = res.commands ?? [];
         setSuggestions(commands);
         setActiveIdx(0);
+        setActiveQuery(query);
         if (commands.length > 0) {
           setPanelMode('list');
         } else if (query !== '') {
@@ -165,9 +168,12 @@ export function Composer(props: {
 
   const handleInput = () => {
     resize();
-    const val = textareaRef.current?.value ?? '';
-    if (val.startsWith('/')) {
-      const query = val.slice(1).trim();
+    const ta = textareaRef.current;
+    if (!ta) return;
+    const cursor = ta.selectionStart ?? ta.value.length;
+    const ctx = getSlashContext(ta.value, cursor);
+    if (ctx) {
+      const query = ctx.query.trim();
       if (suggestTimerRef.current) clearTimeout(suggestTimerRef.current);
       suggestTimerRef.current = setTimeout(() => {
         void fetchSuggestions(query);
@@ -178,11 +184,26 @@ export function Composer(props: {
   };
 
   const applySuggestion = (item: ChatCommandSuggestion) => {
-    if (!textareaRef.current) return;
-    textareaRef.current.value = `${item.insertText.replace(/\s+$/, '')} `;
+    const ta = textareaRef.current;
+    if (!ta) return;
+    const value = ta.value;
+    const cursor = ta.selectionStart ?? value.length;
+    const ctx = getSlashContext(value, cursor);
+    const insertCore = item.insertText.replace(/\s+$/, '');
+    if (ctx) {
+      const before = value.slice(0, ctx.tokenStart);
+      const after = value.slice(ctx.tokenEnd);
+      const insert = after.startsWith(' ') ? insertCore : `${insertCore} `;
+      ta.value = before + insert + after;
+      const newCursor = before.length + insert.length;
+      ta.setSelectionRange(newCursor, newCursor);
+    } else {
+      ta.value = `${insertCore} `;
+      ta.setSelectionRange(ta.value.length, ta.value.length);
+    }
     setPanelMode('closed');
     resize();
-    textareaRef.current.focus();
+    ta.focus();
   };
 
   const submit = () => {
@@ -389,52 +410,27 @@ export function Composer(props: {
           </div>
         </ComposerAnchor>
         {isOpen ? (
-          <PopoverContent
-            ref={listboxRef}
-            id={listboxId}
-            role="listbox"
-            aria-label="Slash commands"
-            focusOnOpen="none"
-            closeOnEscape={false}
-            closeOnOutsideClick
-            sideOffset={4}
-            className={css.slashSuggestions}
-          >
-            {panelMode === 'list' ? (
-              suggestions.map((item, i) => (
-                <div
-                  key={item.id}
-                  id={optionId(i)}
-                  className={cx(
-                    css.suggestionItem,
-                    i === activeIdx && css.suggestionItemActive,
-                    (item.depth ?? 1) >= 2 && css.suggestionItemSub,
-                  )}
-                  role="option"
-                  tabIndex={-1}
-                  aria-selected={i === activeIdx}
-                  onMouseDown={(e) => {
-                    e.preventDefault();
-                    applySuggestion(item);
-                  }}
-                  onMouseEnter={() => setActiveIdx(i)}
-                >
-                  <span className={css.suggestionLabel}>{item.label}</span>
-                  {item.description ? (
-                    <span className={css.suggestionDesc}>
-                      {item.description}
-                    </span>
-                  ) : null}
-                </div>
-              ))
-            ) : (
-              <div className={css.suggestionEmpty} role="status">
-                No commands match “/{emptyQuery}”
-              </div>
-            )}
-          </PopoverContent>
+          <SlashSuggestionsPanel
+            mode={panelMode === 'list' ? 'list' : 'empty'}
+            suggestions={suggestions}
+            activeIdx={activeIdx}
+            query={activeQuery}
+            emptyQuery={emptyQuery}
+            listboxId={listboxId}
+            optionId={optionId}
+            listboxRef={listboxRef}
+            onSelect={applySuggestion}
+            onActiveChange={setActiveIdx}
+          />
         ) : null}
       </Popover>
+      <div
+        className={css.slashLiveRegion}
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {liveMessage}
+      </div>
     </div>
   );
 }

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -2,7 +2,6 @@ import {
   type ChangeEvent,
   type ClipboardEvent,
   type KeyboardEvent,
-  type ReactNode,
   useCallback,
   useEffect,
   useId,
@@ -11,7 +10,7 @@ import {
 } from 'react';
 import { fetchChatCommands } from '../../api/chat';
 import type { ChatCommandSuggestion, MediaItem } from '../../api/chat-types';
-import { Popover, usePopoverContext } from '../../components/popover';
+import { Popover, PopoverAnchor } from '../../components/popover';
 import { extractClipboardFiles } from '../../lib/chat-helpers';
 import { cx } from '../../lib/cx';
 import { pluralize } from '../../lib/format';
@@ -30,21 +29,6 @@ import {
   type SlashPanelMode,
   SlashSuggestionsPanel,
 } from './slash-suggestions-panel';
-
-function ComposerAnchor({
-  children,
-  className,
-}: {
-  children: ReactNode;
-  className?: string;
-}) {
-  const ctx = usePopoverContext('ComposerAnchor');
-  return (
-    <div ref={ctx.setTriggerEl} className={className}>
-      {children}
-    </div>
-  );
-}
 
 export function Composer(props: {
   isStreaming: boolean;
@@ -82,6 +66,9 @@ export function Composer(props: {
   useEffect(() => {
     return () => {
       if (suggestTimerRef.current) clearTimeout(suggestTimerRef.current);
+      // Invalidate any in-flight fetch so its late resolve can't setState
+      // on an unmounted component.
+      suggestSeqRef.current += 1;
     };
   }, []);
 
@@ -128,9 +115,8 @@ export function Composer(props: {
     ta.style.height = `${Math.min(ta.scrollHeight, 180)}px`;
   };
 
-  // Clear the debounce timer and invalidate any in-flight request so its
-  // late response can't apply after the user has moved on (next keystroke,
-  // dismiss, submit).
+  // The fetch itself can't be aborted, so the seq bump is what makes a
+  // late-resolving response a no-op.
   const cancelPendingFetch = () => {
     if (suggestTimerRef.current) {
       clearTimeout(suggestTimerRef.current);
@@ -146,7 +132,8 @@ export function Composer(props: {
 
   const fetchSuggestions = useCallback(
     async (query: string) => {
-      suggestSeqRef.current += 1;
+      // The seq is bumped by every cancel/dismiss/submit path, so we just
+      // capture the current value here — any later bump invalidates this run.
       const seq = suggestSeqRef.current;
       try {
         const res = await fetchChatCommands(props.token, query || undefined);
@@ -254,10 +241,15 @@ export function Composer(props: {
         return;
       }
     }
-    if (isOpen && e.key === 'Escape') {
-      e.preventDefault();
+    if (e.key === 'Escape') {
+      // Always cancel a pending lookup so a fetch in flight when the user
+      // dismisses can't pop the panel after they've moved on.
+      const wasOpen = isOpen;
       closePanel();
-      return;
+      if (wasOpen) {
+        e.preventDefault();
+        return;
+      }
     }
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
@@ -308,7 +300,7 @@ export function Composer(props: {
           if (!next) closePanel();
         }}
       >
-        <ComposerAnchor className={css.composer}>
+        <PopoverAnchor className={css.composer}>
           {pendingMedia.length > 0 || uploading > 0 ? (
             <div className={css.pendingMediaRow}>
               {pendingMedia.map((m, i) => (
@@ -413,7 +405,7 @@ export function Composer(props: {
               onChange={handleFileChange}
             />
           </div>
-        </ComposerAnchor>
+        </PopoverAnchor>
         {panelMode !== 'closed' ? (
           <SlashSuggestionsPanel
             mode={panelMode}

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -128,12 +128,19 @@ export function Composer(props: {
     ta.style.height = `${Math.min(ta.scrollHeight, 180)}px`;
   };
 
-  const closePanel = () => {
+  // Clear the debounce timer and invalidate any in-flight request so its
+  // late response can't apply after the user has moved on (next keystroke,
+  // dismiss, submit).
+  const cancelPendingFetch = () => {
     if (suggestTimerRef.current) {
       clearTimeout(suggestTimerRef.current);
       suggestTimerRef.current = null;
     }
     suggestSeqRef.current += 1;
+  };
+
+  const closePanel = () => {
+    cancelPendingFetch();
     setPanelMode('closed');
   };
 
@@ -172,11 +179,7 @@ export function Composer(props: {
     const ctx = getSlashContext(ta.value, cursor);
     if (ctx) {
       const query = ctx.query.trim();
-      if (suggestTimerRef.current) clearTimeout(suggestTimerRef.current);
-      // Invalidate any in-flight fetch from a prior keystroke so its late
-      // response can't briefly apply between this keystroke and the next
-      // debounced fetch landing.
-      suggestSeqRef.current += 1;
+      cancelPendingFetch();
       suggestTimerRef.current = setTimeout(() => {
         void fetchSuggestions(query);
       }, 150);

--- a/console/src/routes/chat/slash-context.test.ts
+++ b/console/src/routes/chat/slash-context.test.ts
@@ -10,44 +10,37 @@ describe('getSlashContext', () => {
 
   it('returns the leading slash token at the start of the input', () => {
     const ctx = getSlashContext('/clear', 6);
-    expect(ctx).toEqual({ query: 'clear', tokenStart: 0, tokenEnd: 6 });
+    expect(ctx).toEqual({ query: 'clear', tokenStart: 0 });
   });
 
   it('treats the bare slash as an empty query', () => {
-    expect(getSlashContext('/', 1)).toEqual({
-      query: '',
-      tokenStart: 0,
-      tokenEnd: 1,
-    });
+    expect(getSlashContext('/', 1)).toEqual({ query: '', tokenStart: 0 });
   });
 
   it('finds a slash token after a space (mid-line)', () => {
     const value = 'hello /clear';
     const ctx = getSlashContext(value, value.length);
-    expect(ctx).toEqual({ query: 'clear', tokenStart: 6, tokenEnd: 12 });
+    expect(ctx).toEqual({ query: 'clear', tokenStart: 6 });
   });
 
   it('captures only what the user has typed so far up to the cursor', () => {
     const value = 'hello /clear world';
     const ctx = getSlashContext(value, 'hello /cl'.length);
-    expect(ctx).toEqual({ query: 'cl', tokenStart: 6, tokenEnd: 9 });
+    expect(ctx).toEqual({ query: 'cl', tokenStart: 6 });
   });
 
   it('keeps the panel open across spaces so subcommands can be queried', () => {
     expect(getSlashContext('/agent ', 7)).toEqual({
       query: 'agent ',
       tokenStart: 0,
-      tokenEnd: 7,
     });
     expect(getSlashContext('/agent install', 14)).toEqual({
       query: 'agent install',
       tokenStart: 0,
-      tokenEnd: 14,
     });
     expect(getSlashContext('hello /agent install foo', 24)).toEqual({
       query: 'agent install foo',
       tokenStart: 6,
-      tokenEnd: 24,
     });
   });
 

--- a/console/src/routes/chat/slash-context.test.ts
+++ b/console/src/routes/chat/slash-context.test.ts
@@ -27,11 +27,32 @@ describe('getSlashContext', () => {
     expect(ctx).toEqual({ query: 'clear', tokenStart: 6, tokenEnd: 12 });
   });
 
-  it('bounds the token by the next whitespace after the cursor', () => {
+  it('captures only what the user has typed so far up to the cursor', () => {
     const value = 'hello /clear world';
-    // Cursor in the middle of the token.
     const ctx = getSlashContext(value, 'hello /cl'.length);
-    expect(ctx).toEqual({ query: 'clear', tokenStart: 6, tokenEnd: 12 });
+    expect(ctx).toEqual({ query: 'cl', tokenStart: 6, tokenEnd: 9 });
+  });
+
+  it('keeps the panel open across spaces so subcommands can be queried', () => {
+    expect(getSlashContext('/agent ', 7)).toEqual({
+      query: 'agent ',
+      tokenStart: 0,
+      tokenEnd: 7,
+    });
+    expect(getSlashContext('/agent install', 14)).toEqual({
+      query: 'agent install',
+      tokenStart: 0,
+      tokenEnd: 14,
+    });
+    expect(getSlashContext('hello /agent install foo', 24)).toEqual({
+      query: 'agent install foo',
+      tokenStart: 6,
+      tokenEnd: 24,
+    });
+  });
+
+  it('a newline ends the slash command run', () => {
+    expect(getSlashContext('/agent\nhello', 12)).toBeNull();
   });
 
   it('handles tab and newline as token separators', () => {

--- a/console/src/routes/chat/slash-context.test.ts
+++ b/console/src/routes/chat/slash-context.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getSlashContext } from './slash-suggestions-panel';
+import { getSlashContext } from './slash-context';
 
 describe('getSlashContext', () => {
   it('returns null when there is no slash token', () => {

--- a/console/src/routes/chat/slash-context.ts
+++ b/console/src/routes/chat/slash-context.ts
@@ -1,0 +1,22 @@
+/**
+ * Locate the slash-token at `cursor`. Lets the panel trigger mid-line
+ * (e.g. `hello /clear`), not just at column 0.
+ */
+export function getSlashContext(
+  value: string,
+  cursor: number,
+): { query: string; tokenStart: number; tokenEnd: number } | null {
+  const before = value.slice(0, cursor);
+  const wsIdx = Math.max(
+    before.lastIndexOf(' '),
+    before.lastIndexOf('\n'),
+    before.lastIndexOf('\t'),
+  );
+  const tokenStart = wsIdx + 1;
+  const after = value.slice(cursor);
+  const nextWsRel = after.search(/\s/);
+  const tokenEnd = nextWsRel === -1 ? value.length : cursor + nextWsRel;
+  const token = value.slice(tokenStart, tokenEnd);
+  if (!token.startsWith('/')) return null;
+  return { query: token.slice(1), tokenStart, tokenEnd };
+}

--- a/console/src/routes/chat/slash-context.ts
+++ b/console/src/routes/chat/slash-context.ts
@@ -1,22 +1,24 @@
 /**
- * Locate the slash-token at `cursor`. Lets the panel trigger mid-line
- * (e.g. `hello /clear`), not just at column 0.
+ * Locate the slash-command being typed at `cursor`. The query spans every
+ * character from the most recent slash that starts a token (column 0 of the
+ * current line, or after whitespace) through the cursor — multi-word, so
+ * `/agent install` keeps showing subcommand suggestions as the user types.
+ * Lets the panel trigger mid-line (e.g. `hello /clear`), not just at column 0.
  */
 export function getSlashContext(
   value: string,
   cursor: number,
 ): { query: string; tokenStart: number; tokenEnd: number } | null {
-  const before = value.slice(0, cursor);
-  const wsIdx = Math.max(
-    before.lastIndexOf(' '),
-    before.lastIndexOf('\n'),
-    before.lastIndexOf('\t'),
-  );
-  const tokenStart = wsIdx + 1;
-  const after = value.slice(cursor);
-  const nextWsRel = after.search(/\s/);
-  const tokenEnd = nextWsRel === -1 ? value.length : cursor + nextWsRel;
-  const token = value.slice(tokenStart, tokenEnd);
-  if (!token.startsWith('/')) return null;
-  return { query: token.slice(1), tokenStart, tokenEnd };
+  const lineStart = value.lastIndexOf('\n', cursor - 1) + 1;
+  let slashAt = -1;
+  for (let i = lineStart; i < cursor; i++) {
+    if (value[i] !== '/') continue;
+    if (i === lineStart || /\s/.test(value[i - 1])) slashAt = i;
+  }
+  if (slashAt === -1) return null;
+  return {
+    query: value.slice(slashAt + 1, cursor),
+    tokenStart: slashAt,
+    tokenEnd: cursor,
+  };
 }

--- a/console/src/routes/chat/slash-context.ts
+++ b/console/src/routes/chat/slash-context.ts
@@ -1,10 +1,6 @@
-/**
- * Locate the slash-command being typed at `cursor`. The query spans every
- * character from the most recent slash that starts a token (column 0 of the
- * current line, or after whitespace) through the cursor — multi-word, so
- * `/agent install` keeps showing subcommand suggestions as the user types.
- * Lets the panel trigger mid-line (e.g. `hello /clear`), not just at column 0.
- */
+// The query spans every character after the slash through the cursor —
+// multi-word, so `/agent install` keeps showing subcommand suggestions
+// instead of closing the panel at the first space.
 export function getSlashContext(
   value: string,
   cursor: number,

--- a/console/src/routes/chat/slash-context.ts
+++ b/console/src/routes/chat/slash-context.ts
@@ -8,7 +8,7 @@
 export function getSlashContext(
   value: string,
   cursor: number,
-): { query: string; tokenStart: number; tokenEnd: number } | null {
+): { query: string; tokenStart: number } | null {
   const lineStart = value.lastIndexOf('\n', cursor - 1) + 1;
   let slashAt = -1;
   for (let i = lineStart; i < cursor; i++) {
@@ -16,9 +16,5 @@ export function getSlashContext(
     if (i === lineStart || /\s/.test(value[i - 1])) slashAt = i;
   }
   if (slashAt === -1) return null;
-  return {
-    query: value.slice(slashAt + 1, cursor),
-    tokenStart: slashAt,
-    tokenEnd: cursor,
-  };
+  return { query: value.slice(slashAt + 1, cursor), tokenStart: slashAt };
 }

--- a/console/src/routes/chat/slash-suggestions-panel.test.ts
+++ b/console/src/routes/chat/slash-suggestions-panel.test.ts
@@ -35,12 +35,12 @@ describe('getSlashContext', () => {
   });
 
   it('handles tab and newline as token separators', () => {
-    expect(
-      getSlashContext('foo\t/bar', 'foo\t/bar'.length),
-    )?.toMatchObject({ query: 'bar' });
-    expect(
-      getSlashContext('foo\n/bar', 'foo\n/bar'.length),
-    )?.toMatchObject({ query: 'bar' });
+    expect(getSlashContext('foo\t/bar', 'foo\t/bar'.length))?.toMatchObject({
+      query: 'bar',
+    });
+    expect(getSlashContext('foo\n/bar', 'foo\n/bar'.length))?.toMatchObject({
+      query: 'bar',
+    });
   });
 
   it('returns null when the token before the cursor does not start with /', () => {

--- a/console/src/routes/chat/slash-suggestions-panel.test.ts
+++ b/console/src/routes/chat/slash-suggestions-panel.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { getSlashContext } from './slash-suggestions-panel';
+
+describe('getSlashContext', () => {
+  it('returns null when there is no slash token', () => {
+    expect(getSlashContext('', 0)).toBeNull();
+    expect(getSlashContext('hello world', 11)).toBeNull();
+    expect(getSlashContext('not /a slash either', 3)).toBeNull();
+  });
+
+  it('returns the leading slash token at the start of the input', () => {
+    const ctx = getSlashContext('/clear', 6);
+    expect(ctx).toEqual({ query: 'clear', tokenStart: 0, tokenEnd: 6 });
+  });
+
+  it('treats the bare slash as an empty query', () => {
+    expect(getSlashContext('/', 1)).toEqual({
+      query: '',
+      tokenStart: 0,
+      tokenEnd: 1,
+    });
+  });
+
+  it('finds a slash token after a space (mid-line)', () => {
+    const value = 'hello /clear';
+    const ctx = getSlashContext(value, value.length);
+    expect(ctx).toEqual({ query: 'clear', tokenStart: 6, tokenEnd: 12 });
+  });
+
+  it('bounds the token by the next whitespace after the cursor', () => {
+    const value = 'hello /clear world';
+    // Cursor in the middle of the token.
+    const ctx = getSlashContext(value, 'hello /cl'.length);
+    expect(ctx).toEqual({ query: 'clear', tokenStart: 6, tokenEnd: 12 });
+  });
+
+  it('handles tab and newline as token separators', () => {
+    expect(
+      getSlashContext('foo\t/bar', 'foo\t/bar'.length),
+    )?.toMatchObject({ query: 'bar' });
+    expect(
+      getSlashContext('foo\n/bar', 'foo\n/bar'.length),
+    )?.toMatchObject({ query: 'bar' });
+  });
+
+  it('returns null when the token before the cursor does not start with /', () => {
+    expect(getSlashContext('hello world', 5)).toBeNull();
+  });
+});

--- a/console/src/routes/chat/slash-suggestions-panel.tsx
+++ b/console/src/routes/chat/slash-suggestions-panel.tsx
@@ -85,7 +85,7 @@ export function SlashSuggestionsPanel({
                   onSelect(item);
                 }}
                 onMouseEnter={() => onActiveChange(i)}
-                title={item.description}
+                title={item.description || undefined}
               >
                 <span className={css.suggestionLabel}>
                   {renderLabel(item.label, query)}

--- a/console/src/routes/chat/slash-suggestions-panel.tsx
+++ b/console/src/routes/chat/slash-suggestions-panel.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, type Ref, useEffect } from 'react';
+import { type ReactNode, useEffect, useRef } from 'react';
 import type { ChatCommandSuggestion } from '../../api/chat-types';
 import { PopoverContent } from '../../components/popover';
 import {
@@ -17,12 +17,13 @@ export interface SlashSuggestionsPanelProps {
   suggestions: ChatCommandSuggestion[];
   activeIdx: number;
   query: string;
-  emptyQuery: string;
   listboxId: string;
-  optionId: (i: number) => string;
-  listboxRef: Ref<HTMLDivElement>;
   onSelect: (item: ChatCommandSuggestion) => void;
   onActiveChange: (i: number) => void;
+}
+
+export function optionIdFor(listboxId: string, i: number): string {
+  return `${listboxId}-opt-${i}`;
 }
 
 export function SlashSuggestionsPanel({
@@ -30,18 +31,16 @@ export function SlashSuggestionsPanel({
   suggestions,
   activeIdx,
   query,
-  emptyQuery,
   listboxId,
-  optionId,
-  listboxRef,
   onSelect,
   onActiveChange,
 }: SlashSuggestionsPanelProps) {
+  const viewportRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     if (mode !== 'list' || suggestions.length === 0) return;
-    if (typeof listboxRef !== 'object' || listboxRef === null) return;
-    const list = listboxRef.current;
-    const active = document.getElementById(optionId(activeIdx));
+    const list = viewportRef.current;
+    const active = document.getElementById(optionIdFor(listboxId, activeIdx));
     if (!list || !active || !list.contains(active)) return;
     const top = active.offsetTop;
     const bottom = top + active.offsetHeight;
@@ -50,7 +49,7 @@ export function SlashSuggestionsPanel({
     } else if (bottom > list.scrollTop + list.clientHeight) {
       list.scrollTop = bottom - list.clientHeight;
     }
-  }, [activeIdx, mode, suggestions.length, listboxRef, optionId]);
+  }, [activeIdx, mode, suggestions.length, listboxId]);
 
   return (
     <PopoverContent
@@ -62,7 +61,7 @@ export function SlashSuggestionsPanel({
     >
       <ScrollArea className={css.slashSuggestionsScroll}>
         <ScrollAreaViewport
-          ref={listboxRef}
+          ref={viewportRef}
           id={listboxId}
           role="listbox"
           aria-label="Slash commands"
@@ -72,7 +71,7 @@ export function SlashSuggestionsPanel({
             suggestions.map((item, i) => (
               <div
                 key={item.id}
-                id={optionId(i)}
+                id={optionIdFor(listboxId, i)}
                 className={cx(
                   css.suggestionItem,
                   i === activeIdx && css.suggestionItemActive,
@@ -97,7 +96,7 @@ export function SlashSuggestionsPanel({
             ))
           ) : (
             <div className={css.suggestionEmpty} role="status">
-              No commands match “/{emptyQuery}”
+              No commands match “/{query}”
             </div>
           )}
         </ScrollAreaViewport>
@@ -107,34 +106,6 @@ export function SlashSuggestionsPanel({
       </ScrollArea>
     </PopoverContent>
   );
-}
-
-/**
- * Locate the slash-token at `cursor`. Returns the query (text after the
- * leading `/`) plus the token bounds in `value`. Returns null when the
- * cursor is not on a slash-token, so the caller can close the panel.
- *
- * A slash-token starts at the start of `value` or right after whitespace,
- * and ends at the next whitespace or end of `value`. This lets the panel
- * trigger mid-line (e.g. `hello /clear`), not only at column 0.
- */
-export function getSlashContext(
-  value: string,
-  cursor: number,
-): { query: string; tokenStart: number; tokenEnd: number } | null {
-  const before = value.slice(0, cursor);
-  const wsIdx = Math.max(
-    before.lastIndexOf(' '),
-    before.lastIndexOf('\n'),
-    before.lastIndexOf('\t'),
-  );
-  const tokenStart = wsIdx + 1;
-  const after = value.slice(cursor);
-  const nextWsRel = after.search(/\s/);
-  const tokenEnd = nextWsRel === -1 ? value.length : cursor + nextWsRel;
-  const token = value.slice(tokenStart, tokenEnd);
-  if (!token.startsWith('/')) return null;
-  return { query: token.slice(1), tokenStart, tokenEnd };
 }
 
 const PLACEHOLDER_RE = /<[^>]+>|\[[^\]]+\]/g;
@@ -164,15 +135,7 @@ function renderSegment(
   segIdx: number,
 ): ReactNode {
   const className = mono ? css.suggestionLabelMono : undefined;
-  if (!q) {
-    return (
-      <span key={`s${segIdx}`} className={className}>
-        {text}
-      </span>
-    );
-  }
-  const lower = text.toLowerCase();
-  const idx = lower.indexOf(q);
+  const idx = q ? text.toLowerCase().indexOf(q) : -1;
   if (idx === -1) {
     return (
       <span key={`s${segIdx}`} className={className}>

--- a/console/src/routes/chat/slash-suggestions-panel.tsx
+++ b/console/src/routes/chat/slash-suggestions-panel.tsx
@@ -1,0 +1,177 @@
+import { type ReactNode, type Ref, useEffect } from 'react';
+import type { ChatCommandSuggestion } from '../../api/chat-types';
+import { PopoverContent } from '../../components/popover';
+import { cx } from '../../lib/cx';
+import css from './chat-page.module.css';
+
+export type SlashPanelMode = 'closed' | 'list' | 'empty';
+
+export interface SlashSuggestionsPanelProps {
+  mode: Exclude<SlashPanelMode, 'closed'>;
+  suggestions: ChatCommandSuggestion[];
+  activeIdx: number;
+  query: string;
+  emptyQuery: string;
+  listboxId: string;
+  optionId: (i: number) => string;
+  listboxRef: Ref<HTMLDivElement>;
+  onSelect: (item: ChatCommandSuggestion) => void;
+  onActiveChange: (i: number) => void;
+}
+
+export function SlashSuggestionsPanel({
+  mode,
+  suggestions,
+  activeIdx,
+  query,
+  emptyQuery,
+  listboxId,
+  optionId,
+  listboxRef,
+  onSelect,
+  onActiveChange,
+}: SlashSuggestionsPanelProps) {
+  useEffect(() => {
+    if (mode !== 'list' || suggestions.length === 0) return;
+    if (typeof listboxRef !== 'object' || listboxRef === null) return;
+    const list = listboxRef.current;
+    const active = document.getElementById(optionId(activeIdx));
+    if (!list || !active || !list.contains(active)) return;
+    const top = active.offsetTop;
+    const bottom = top + active.offsetHeight;
+    if (top < list.scrollTop) {
+      list.scrollTop = top;
+    } else if (bottom > list.scrollTop + list.clientHeight) {
+      list.scrollTop = bottom - list.clientHeight;
+    }
+  }, [activeIdx, mode, suggestions.length, listboxRef, optionId]);
+
+  return (
+    <PopoverContent
+      ref={listboxRef}
+      id={listboxId}
+      role="listbox"
+      aria-label="Slash commands"
+      focusOnOpen="none"
+      closeOnEscape={false}
+      closeOnOutsideClick
+      sideOffset={4}
+      className={css.slashSuggestions}
+    >
+      {mode === 'list' ? (
+        suggestions.map((item, i) => (
+          <div
+            key={item.id}
+            id={optionId(i)}
+            className={cx(
+              css.suggestionItem,
+              i === activeIdx && css.suggestionItemActive,
+              (item.depth ?? 1) >= 2 && css.suggestionItemSub,
+            )}
+            role="option"
+            tabIndex={-1}
+            aria-selected={i === activeIdx}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              onSelect(item);
+            }}
+            onMouseEnter={() => onActiveChange(i)}
+          >
+            <span className={css.suggestionLabel}>
+              {renderLabel(item.label, query)}
+            </span>
+            {item.description ? (
+              <span className={css.suggestionDesc}>{item.description}</span>
+            ) : null}
+          </div>
+        ))
+      ) : (
+        <div className={css.suggestionEmpty} role="status">
+          No commands match “/{emptyQuery}”
+        </div>
+      )}
+    </PopoverContent>
+  );
+}
+
+/**
+ * Locate the slash-token at `cursor`. Returns the query (text after the
+ * leading `/`) plus the token bounds in `value`. Returns null when the
+ * cursor is not on a slash-token, so the caller can close the panel.
+ *
+ * A slash-token starts at the start of `value` or right after whitespace,
+ * and ends at the next whitespace or end of `value`. This lets the panel
+ * trigger mid-line (e.g. `hello /clear`), not only at column 0.
+ */
+export function getSlashContext(
+  value: string,
+  cursor: number,
+): { query: string; tokenStart: number; tokenEnd: number } | null {
+  const before = value.slice(0, cursor);
+  const wsIdx = Math.max(
+    before.lastIndexOf(' '),
+    before.lastIndexOf('\n'),
+    before.lastIndexOf('\t'),
+  );
+  const tokenStart = wsIdx + 1;
+  const after = value.slice(cursor);
+  const nextWsRel = after.search(/\s/);
+  const tokenEnd = nextWsRel === -1 ? value.length : cursor + nextWsRel;
+  const token = value.slice(tokenStart, tokenEnd);
+  if (!token.startsWith('/')) return null;
+  return { query: token.slice(1), tokenStart, tokenEnd };
+}
+
+const PLACEHOLDER_RE = /<[^>]+>|\[[^\]]+\]/g;
+
+function renderLabel(label: string, query: string): ReactNode[] {
+  const segments: { text: string; mono: boolean }[] = [];
+  let last = 0;
+  for (const match of label.matchAll(PLACEHOLDER_RE)) {
+    const idx = match.index ?? 0;
+    if (idx > last) {
+      segments.push({ text: label.slice(last, idx), mono: false });
+    }
+    segments.push({ text: match[0], mono: true });
+    last = idx + match[0].length;
+  }
+  if (last < label.length) {
+    segments.push({ text: label.slice(last), mono: false });
+  }
+  const q = query.trim().toLowerCase();
+  return segments.map((seg, i) => renderSegment(seg.text, seg.mono, q, i));
+}
+
+function renderSegment(
+  text: string,
+  mono: boolean,
+  q: string,
+  segIdx: number,
+): ReactNode {
+  const className = mono ? css.suggestionLabelMono : undefined;
+  if (!q) {
+    return (
+      <span key={`s${segIdx}`} className={className}>
+        {text}
+      </span>
+    );
+  }
+  const lower = text.toLowerCase();
+  const idx = lower.indexOf(q);
+  if (idx === -1) {
+    return (
+      <span key={`s${segIdx}`} className={className}>
+        {text}
+      </span>
+    );
+  }
+  return (
+    <span key={`s${segIdx}`} className={className}>
+      {text.slice(0, idx)}
+      <mark className={css.suggestionMatch}>
+        {text.slice(idx, idx + q.length)}
+      </mark>
+      {text.slice(idx + q.length)}
+    </span>
+  );
+}

--- a/console/src/routes/chat/slash-suggestions-panel.tsx
+++ b/console/src/routes/chat/slash-suggestions-panel.tsx
@@ -85,6 +85,7 @@ export function SlashSuggestionsPanel({
                   onSelect(item);
                 }}
                 onMouseEnter={() => onActiveChange(i)}
+                title={item.description}
               >
                 <span className={css.suggestionLabel}>
                   {renderLabel(item.label, query)}

--- a/console/src/routes/chat/slash-suggestions-panel.tsx
+++ b/console/src/routes/chat/slash-suggestions-panel.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect, useRef } from 'react';
+import { type ReactNode, useEffect } from 'react';
 import type { ChatCommandSuggestion } from '../../api/chat-types';
 import { PopoverContent } from '../../components/popover';
 import {
@@ -35,21 +35,13 @@ export function SlashSuggestionsPanel({
   onSelect,
   onActiveChange,
 }: SlashSuggestionsPanelProps) {
-  const viewportRef = useRef<HTMLDivElement>(null);
-
   useEffect(() => {
     if (mode !== 'list' || suggestions.length === 0) return;
-    const list = viewportRef.current;
     const active = document.getElementById(optionIdFor(listboxId, activeIdx));
-    if (!list || !active || !list.contains(active)) return;
-    const top = active.offsetTop;
-    const bottom = top + active.offsetHeight;
-    if (top < list.scrollTop) {
-      list.scrollTop = top;
-    } else if (bottom > list.scrollTop + list.clientHeight) {
-      list.scrollTop = bottom - list.clientHeight;
-    }
+    active?.scrollIntoView({ block: 'nearest' });
   }, [activeIdx, mode, suggestions.length, listboxId]);
+
+  const q = query.trim().toLowerCase();
 
   return (
     <PopoverContent
@@ -61,7 +53,6 @@ export function SlashSuggestionsPanel({
     >
       <ScrollArea className={css.slashSuggestionsScroll}>
         <ScrollAreaViewport
-          ref={viewportRef}
           id={listboxId}
           role="listbox"
           aria-label="Slash commands"
@@ -88,7 +79,7 @@ export function SlashSuggestionsPanel({
                 title={item.description || undefined}
               >
                 <span className={css.suggestionLabel}>
-                  {renderLabel(item.label, query)}
+                  {renderLabel(item.label, q)}
                 </span>
                 {item.description ? (
                   <span className={css.suggestionDesc}>{item.description}</span>
@@ -97,7 +88,7 @@ export function SlashSuggestionsPanel({
             ))
           ) : (
             <div className={css.suggestionEmpty} role="status">
-              No commands match “/{query}”
+              No commands match /{query}
             </div>
           )}
         </ScrollAreaViewport>
@@ -111,46 +102,36 @@ export function SlashSuggestionsPanel({
 
 const PLACEHOLDER_RE = /<[^>]+>|\[[^\]]+\]/g;
 
-function renderLabel(label: string, query: string): ReactNode[] {
-  const segments: { text: string; mono: boolean }[] = [];
+function renderLabel(label: string, q: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
   let last = 0;
+  let key = 0;
+  const push = (text: string, mono: boolean) => {
+    if (!text) return;
+    const className = mono ? css.suggestionLabelMono : undefined;
+    const idx = q ? text.toLowerCase().indexOf(q) : -1;
+    nodes.push(
+      idx === -1 ? (
+        <span key={key++} className={className}>
+          {text}
+        </span>
+      ) : (
+        <span key={key++} className={className}>
+          {text.slice(0, idx)}
+          <mark className={css.suggestionMatch}>
+            {text.slice(idx, idx + q.length)}
+          </mark>
+          {text.slice(idx + q.length)}
+        </span>
+      ),
+    );
+  };
   for (const match of label.matchAll(PLACEHOLDER_RE)) {
     const idx = match.index ?? 0;
-    if (idx > last) {
-      segments.push({ text: label.slice(last, idx), mono: false });
-    }
-    segments.push({ text: match[0], mono: true });
+    push(label.slice(last, idx), false);
+    push(match[0], true);
     last = idx + match[0].length;
   }
-  if (last < label.length) {
-    segments.push({ text: label.slice(last), mono: false });
-  }
-  const q = query.trim().toLowerCase();
-  return segments.map((seg, i) => renderSegment(seg.text, seg.mono, q, i));
-}
-
-function renderSegment(
-  text: string,
-  mono: boolean,
-  q: string,
-  segIdx: number,
-): ReactNode {
-  const className = mono ? css.suggestionLabelMono : undefined;
-  const idx = q ? text.toLowerCase().indexOf(q) : -1;
-  if (idx === -1) {
-    return (
-      <span key={`s${segIdx}`} className={className}>
-        {text}
-      </span>
-    );
-  }
-  return (
-    <span key={`s${segIdx}`} className={className}>
-      {text.slice(0, idx)}
-      <mark className={css.suggestionMatch}>
-        {text.slice(idx, idx + q.length)}
-      </mark>
-      {text.slice(idx + q.length)}
-    </span>
-  );
+  push(label.slice(last), false);
+  return nodes;
 }

--- a/console/src/routes/chat/slash-suggestions-panel.tsx
+++ b/console/src/routes/chat/slash-suggestions-panel.tsx
@@ -1,6 +1,12 @@
 import { type ReactNode, type Ref, useEffect } from 'react';
 import type { ChatCommandSuggestion } from '../../api/chat-types';
 import { PopoverContent } from '../../components/popover';
+import {
+  ScrollArea,
+  ScrollAreaScrollbar,
+  ScrollAreaThumb,
+  ScrollAreaViewport,
+} from '../../components/scroll-area';
 import { cx } from '../../lib/cx';
 import css from './chat-page.module.css';
 
@@ -48,48 +54,57 @@ export function SlashSuggestionsPanel({
 
   return (
     <PopoverContent
-      ref={listboxRef}
-      id={listboxId}
-      role="listbox"
-      aria-label="Slash commands"
       focusOnOpen="none"
       closeOnEscape={false}
       closeOnOutsideClick
       sideOffset={4}
       className={css.slashSuggestions}
     >
-      {mode === 'list' ? (
-        suggestions.map((item, i) => (
-          <div
-            key={item.id}
-            id={optionId(i)}
-            className={cx(
-              css.suggestionItem,
-              i === activeIdx && css.suggestionItemActive,
-              (item.depth ?? 1) >= 2 && css.suggestionItemSub,
-            )}
-            role="option"
-            tabIndex={-1}
-            aria-selected={i === activeIdx}
-            onMouseDown={(e) => {
-              e.preventDefault();
-              onSelect(item);
-            }}
-            onMouseEnter={() => onActiveChange(i)}
-          >
-            <span className={css.suggestionLabel}>
-              {renderLabel(item.label, query)}
-            </span>
-            {item.description ? (
-              <span className={css.suggestionDesc}>{item.description}</span>
-            ) : null}
-          </div>
-        ))
-      ) : (
-        <div className={css.suggestionEmpty} role="status">
-          No commands match “/{emptyQuery}”
-        </div>
-      )}
+      <ScrollArea className={css.slashSuggestionsScroll}>
+        <ScrollAreaViewport
+          ref={listboxRef}
+          id={listboxId}
+          role="listbox"
+          aria-label="Slash commands"
+          className={css.slashSuggestionsList}
+        >
+          {mode === 'list' ? (
+            suggestions.map((item, i) => (
+              <div
+                key={item.id}
+                id={optionId(i)}
+                className={cx(
+                  css.suggestionItem,
+                  i === activeIdx && css.suggestionItemActive,
+                  (item.depth ?? 1) >= 2 && css.suggestionItemSub,
+                )}
+                role="option"
+                tabIndex={-1}
+                aria-selected={i === activeIdx}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  onSelect(item);
+                }}
+                onMouseEnter={() => onActiveChange(i)}
+              >
+                <span className={css.suggestionLabel}>
+                  {renderLabel(item.label, query)}
+                </span>
+                {item.description ? (
+                  <span className={css.suggestionDesc}>{item.description}</span>
+                ) : null}
+              </div>
+            ))
+          ) : (
+            <div className={css.suggestionEmpty} role="status">
+              No commands match “/{emptyQuery}”
+            </div>
+          )}
+        </ScrollAreaViewport>
+        <ScrollAreaScrollbar>
+          <ScrollAreaThumb />
+        </ScrollAreaScrollbar>
+      </ScrollArea>
     </PopoverContent>
   );
 }

--- a/console/vitest.config.ts
+++ b/console/vitest.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     include: ['src/**/*.test.{ts,tsx}'],
+    setupFiles: ['./vitest.setup.ts'],
   },
 });

--- a/console/vitest.setup.ts
+++ b/console/vitest.setup.ts
@@ -16,5 +16,5 @@ if (
   typeof Element !== 'undefined' &&
   typeof Element.prototype.scrollIntoView !== 'function'
 ) {
-  Element.prototype.scrollIntoView = function () {};
+  Element.prototype.scrollIntoView = () => {};
 }

--- a/console/vitest.setup.ts
+++ b/console/vitest.setup.ts
@@ -1,0 +1,12 @@
+// jsdom does not implement ResizeObserver. Components such as ScrollArea
+// instantiate one on mount, so tests that render those components crash
+// without a polyfill. Provide a no-op shim that tests can rely on.
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  class ResizeObserverPolyfill {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+  globalThis.ResizeObserver =
+    ResizeObserverPolyfill as unknown as typeof ResizeObserver;
+}

--- a/console/vitest.setup.ts
+++ b/console/vitest.setup.ts
@@ -1,6 +1,7 @@
-// jsdom does not implement ResizeObserver. Components such as ScrollArea
-// instantiate one on mount, so tests that render those components crash
-// without a polyfill. Provide a no-op shim that tests can rely on.
+// jsdom does not implement ResizeObserver or Element.scrollIntoView.
+// Components such as ScrollArea instantiate the former on mount, and
+// listbox-style components call the latter to keep the active option in
+// view, so tests that render those components crash without these shims.
 if (typeof globalThis.ResizeObserver === 'undefined') {
   class ResizeObserverPolyfill {
     observe(): void {}
@@ -9,4 +10,11 @@ if (typeof globalThis.ResizeObserver === 'undefined') {
   }
   globalThis.ResizeObserver =
     ResizeObserverPolyfill as unknown as typeof ResizeObserver;
+}
+
+if (
+  typeof Element !== 'undefined' &&
+  typeof Element.prototype.scrollIntoView !== 'function'
+) {
+  Element.prototype.scrollIntoView = function () {};
 }


### PR DESCRIPTION
## Summary

What started as two small bugs in the chat composer's `/`-command suggestion panel grew, while exercising it live in Chrome, into a much larger problem: the panel was **not visible to the user at all** in the default layout. This PR fixes that, plus a list of correctness / a11y / UX issues found along the way, and rebuilds the panel on the codebase's existing primitives.

## Bugs fixed

### 1. The panel was invisible (root cause)

The hand-rolled `<div className={css.slashSuggestions}>` rendered with `position: absolute; bottom: 100%`, anchored to the composer card. But `.composerWrapper` (and `.chatMain` / `.chatPage` further up) had `overflow: hidden`, and the panel's box sat *above* the wrapper's bounds — so it was clipped to invisibility. Test users only ever saw a flash of nothing when typing `/`.

Fix: render the panel through the existing `Popover` primitive (`console/src/components/popover`) so it portals to `document.body`, auto-flips above the trigger when there's no room below, and is no longer subject to ancestor clipping. Then build a `SlashSuggestionsPanel` component wrapping the listbox in the existing `ScrollArea` (matching what `Select` already does in the console) so the scrollbar styling is consistent with the rest of the app.

### 2. Double trailing space

Accepting a suggestion whose `insertText` already ended in a space (e.g. `/approve `) appended an extra space, producing `\"/approve  \"` (length 10). Fix: trim trailing whitespace from `insertText` before re-appending exactly one.

### 3. Panel didn't close on outside click

Suggestion items use `onMouseDown` with `preventDefault` (so the textarea doesn't blur), so clicking elsewhere left the panel visible. Fix: covered automatically by `Popover`'s `closeOnOutsideClick`.

### 4. Stale fetches re-opened the panel after dismiss

Closing the panel (Escape / outside-click / send) only flipped state. An already-debounced or in-flight `fetchChatCommands` could resolve later and re-open the panel — most visibly, sending the message cleared the textarea but a late fetch would drop the list onto an empty composer. Fix: a `closePanel()` helper clears the debounce timer and bumps the fetch sequence ref so the in-flight resolve gets discarded.

## A11y wiring (was missing entirely)

- The textarea is now a proper combobox: `role=\"combobox\"`, `aria-autocomplete=\"list\"`, `aria-haspopup=\"listbox\"`, `aria-controls={listboxId}`, `aria-expanded`, `aria-activedescendant` pointing at the active option's stable id.
- Each option has a stable id; the listbox carries that same id and an `aria-label`.
- A polite `aria-live` region announces the result count on every fetch (\"12 commands available\" / \"1 command available\" / \"No commands match /zzz\"), reusing the existing `pluralize()` from `lib/format.ts` and the existing `.srOnly` pattern (lifted into a shared `lib/a11y.module.css`).
- `Home` / `End` / `ArrowUp` / `ArrowDown` (with wrap) navigate; `Tab` / `Enter` accept; `Escape` closes; `mouseenter` syncs the active index so keyboard and mouse can never disagree.

## UX

- **Active option scrolls into view** as you arrow through a long list (was stuck at `scrollTop: 0`).
- **Empty state**: typing `/zzzz` now shows \"No commands match /zzzz\" instead of silently hiding the panel; bare `/` with no results stays closed; Enter on the empty state sends rather than autocompleting.
- **Match highlighting**: the substring of each label that matches the current query is wrapped in `<mark>` (bold + underline-with-offset) so users can see why an item appears.
- **Monospace placeholders**: `<id>`, `[name]`, `<info|list|switch|…>` render in `var(--font-mono)` for syntax legibility.
- **Subcommand indent**: items with `depth >= 2` (e.g. `/agent info`) get a left-pad indent so they read as nested.
- **Trigger after a space**: `/` mid-line (e.g. `hello /clear`) now opens the panel; accepting only replaces the slash-token, leaving surrounding text alone.
- **Touch targets**: items have `min-height: 44px` desktop / 48px under 768px (iOS minimum).
- **Active row contrast**: 2px accent left border in addition to the background tint.

## Architecture

- New `console/src/routes/chat/slash-suggestions-panel.tsx` (panel render, label segmentation, scroll-into-view effect, match highlighting + monospace placeholders).
- New `console/src/routes/chat/slash-context.ts` (pure-text `getSlashContext` helper that locates the slash-token at the caret).
- New `console/src/lib/a11y.module.css` with the shared `.srOnly` class; `sheet/index.module.css` now `composes` from it instead of carrying its own copy.
- Composer keeps state and orchestration; panel handles its own listbox ref and derives option ids from the listbox id.

## Test plan

- [x] `npm --workspace console run typecheck` — clean
- [x] `npm --workspace console run test` — **294/294** (32 new cases across composer + slash-context)
- [x] `npm run check` (biome) — clean
- [x] `npm run build:console` — clean
- [x] Manual verification in Chrome against the local gateway:
  - panel renders above the composer (was clipped, now portaled)
  - `/approve` → `\"/approve \"` (single space)
  - click outside / Escape closes
  - `/conf` highlights the matched substring; placeholders render monospace
  - live region announces \"12 commands available\" / \"No commands match /zzz\"
  - `hello /app` opens the panel mid-line
  - active row has 2px accent border + 53px touch height
  - ArrowDown 12 times keeps the active option in view (scrollTop=416/636)
  - sending a slash-prefixed message after a slow fetch starts no longer reopens the panel after the textarea clears

## Commits

- panel-was-invisible (Popover + ScrollArea refactor)
- double-space + outside-click + escape-on-empty
- combobox/listbox aria wiring + scroll-into-view + Home/End + hover sync + empty state + match highlighting + monospace placeholders + subcommand indent + larger touch targets + accent border + trigger-after-space + mid-line accept + live region
- in-flight invalidation on dismiss / submit (this round of Copilot review feedback)
- code-review pass: reuse `.srOnly` and `pluralize`; derive `liveMessage` in render; collapse `emptyQuery` + `activeQuery`; drop `optionId` prop and the unused `useCallback`; move `listboxRef` into the panel; extract `getSlashContext` to its own file