### PR TITLE
fix(security/media-paths): don't remap host paths sharing a display prefix

### DIFF
--- a/src/security/media-paths.ts
+++ b/src/security/media-paths.ts
@@ -86,6 +86,31 @@ function resolveDisplayPathToHost(params: {
   } = params;
   const normalized = normalizePathSlashes(rawPath);
 
+  // If the input is already an absolute path that lives inside one of the
+  // known *host* roots, leave the display-to-host remap to the caller's
+  // host-absolute branch. Otherwise a host path that happens to share a
+  // leading segment with a display prefix (e.g. host path
+  // /workspace/.data/data/uploaded-media-cache/foo.ogg vs.
+  // workspaceRootDisplay='/workspace') would be falsely re-rooted under the
+  // workspace and stat would fail.
+  if (path.isAbsolute(normalized)) {
+    const hostRoots = [
+      workspaceRoot,
+      mediaCacheRoot,
+      uploadedMediaRoot,
+      ...mountAliases.map((alias) => alias.hostPath),
+    ];
+    for (const root of hostRoots) {
+      const normalizedRoot = normalizePathSlashes(path.resolve(root));
+      if (
+        normalized === normalizedRoot ||
+        normalized.startsWith(`${normalizedRoot}/`)
+      ) {
+        return null;
+      }
+    }
+  }
+
   for (const alias of mountAliases) {
     const resolved = resolveUnderPrefix(
       normalized,

--- a/tests/security.media-paths.test.ts
+++ b/tests/security.media-paths.test.ts
@@ -25,6 +25,7 @@ function buildParams(
   overrides: Partial<{
     rawPath: string;
     workspaceRoot: string;
+    workspaceRootDisplay: string;
     mediaCacheRoot: string;
     uploadedMediaRoot: string;
     mountAliases: ValidatedMountAlias[];
@@ -39,7 +40,7 @@ function buildParams(
   return {
     rawPath: overrides.rawPath || '',
     workspaceRoot,
-    workspaceRootDisplay: '/workspace',
+    workspaceRootDisplay: overrides.workspaceRootDisplay || '/workspace',
     mediaCacheRoot,
     mediaCacheRootDisplay: '/discord-media-cache',
     uploadedMediaRoot,
@@ -140,6 +141,40 @@ test('allows explicit host absolute paths when host mode is enabled', async () =
     buildParams({
       rawPath: filePath,
       workspaceRoot,
+      allowHostAbsolutePaths: true,
+    }),
+  );
+
+  expect(resolved).toBe(canonicalPath(filePath));
+});
+
+test('allows host absolute paths inside uploaded-media root that share workspace display prefix', async () => {
+  // Repro for host-sandbox-mode: runtime path is the real host path
+  // (e.g. /workspace/.data/data/uploaded-media-cache/foo.ogg) and happens to
+  // share a leading segment with workspaceRootDisplay ('/workspace'). The
+  // display-to-host resolver must not greedily reinterpret a real host path
+  // as a workspace display URI.
+  const sharedPrefix = makeTempDir('hc-shared-prefix-');
+  const workspaceRoot = path.join(sharedPrefix, 'workspace');
+  const uploadedMediaRoot = path.join(
+    sharedPrefix,
+    '.data',
+    'data',
+    'uploaded-media-cache',
+  );
+  fs.mkdirSync(workspaceRoot, { recursive: true });
+  fs.mkdirSync(uploadedMediaRoot, { recursive: true });
+  const filePath = writeFile(uploadedMediaRoot, '2026-05-07/voice-note.ogg');
+
+  const resolved = await resolveAllowedHostMediaPath(
+    buildParams({
+      rawPath: filePath,
+      workspaceRoot,
+      // Display prefix shares an ancestor with uploadedMediaRoot — same pattern
+      // as the real container where workspaceRootDisplay is '/workspace' and
+      // uploadedMediaRoot is '/workspace/.data/data/uploaded-media-cache'.
+      workspaceRootDisplay: sharedPrefix,
+      uploadedMediaRoot,
       allowHostAbsolutePaths: true,
     }),
   );


### PR DESCRIPTION
## Summary

In host sandbox mode (`container.sandbox.mode = "host"`), runtime paths from the uploaded-media cache come back as real host paths because [`normalizeUploadedMediaPathForRuntime`](https://github.com/HybridAIOne/hybridclaw/blob/main/src/media/uploaded-media-cache.ts) returns the `hostPath` unchanged. When the host path happens to share a leading segment with `workspaceRootDisplay` (`/workspace`) — which it does in any default deployment where `DATA_DIR` lives under `/workspace/.data` — `resolveDisplayPathToHost` greedily reinterprets the host path as a workspace display URI and re-roots it under the agent `workspaceRoot`, where the file does not exist. `stat()` fails, `resolveAllowedHostMediaPath` returns `null`, and audio transcription is silently skipped (`Skipping audio transcription for media outside allowed roots` at debug level).

Reproducible end-to-end: send a Telegram voice message to a bot running the Telegram channel in host sandbox mode → the OGG attachment hits the uploaded-media cache at `/workspace/.data/data/uploaded-media-cache/<date>/<id>.ogg` → the audio backend never sees the file → the agent receives a raw `<media:voice>` marker with no transcript.

## Fix

Short-circuit in `resolveDisplayPathToHost`: if the input is already an absolute path inside one of the known *host* roots (`workspaceRoot`, `mediaCacheRoot`, `uploadedMediaRoot`, or any configured mount alias `hostPath`), return `null` so the caller's host-absolute branch takes over rather than re-rooting under a display prefix that shares a leading segment.

The change is conservative — it only kicks in when the input is unambiguously a host path under a known root. Existing display URIs (`/workspace/...`, `/uploaded-media-cache/...`) are unaffected because the temp-dir test paths in the unit tests don't share leading segments with the display prefixes.

## Test plan

- [x] New regression test `allows host absolute paths inside uploaded-media root that share workspace display prefix` reproduces the failing real-world setup: `workspaceRoot` and `uploadedMediaRoot` share a common parent, and `workspaceRootDisplay` equals that parent — without depending on platform-absolute layout. Test fails on `main`, passes with the fix.
- [x] All other media-path tests (workspace/upload/managed-temp/host-absolute) still pass — the short-circuit is gated on the input already being inside a host root, so display-URI inputs flow through unchanged.
- [x] Verified end-to-end on a 0.15.0 deployment with the patched `dist/security/media-paths.js`: Telegram voice messages now go through `media.audio.models[].cli` to a local Whisper-compatible endpoint and the agent receives the transcript before its turn.