### PR TITLE
feat: add delegation envelope schema fields

### DIFF
--- a/docs/content/internal/roadmap.md
+++ b/docs/content/internal/roadmap.md
@@ -236,7 +236,7 @@ Use these as issue titles. Keep each issue small enough to ship independently.
 | ID | Area | Todo | Status |
 |----|------|------|--------|
 | R9.1 | Auth | Inter-instance authentication with signed tokens | ⬜ #480 |
-| R9.2 | Delegation | Delegation envelope schema | ⬜ #481 |
+| R9.2 | Delegation | Delegation envelope schema | ✅ PR #889 |
 | R9.3 | Transport | Cross-instance HTTP transport | ⬜ #482 |
 | R9.4 | Audit | Cross-instance audit-log linking | ⬜ #483 |
 | R9.5 | Admin | Fleet topology admin UI | ⬜ #484 |

--- a/src/a2a/envelope.ts
+++ b/src/a2a/envelope.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import {
-  formatAgentIdentity,
+  isAgentIdentityComponent,
   isCanonicalAgentIdentity,
   parseAgentIdentity,
 } from '../identity/agent-id.js';
@@ -16,6 +16,12 @@ export const A2A_ENVELOPE_INTENTS = [
 
 export type A2AEnvelopeIntent = (typeof A2A_ENVELOPE_INTENTS)[number];
 export type A2AAgentIdKind = 'local' | 'canonical';
+
+interface NormalizedA2AAgentId {
+  value: string;
+  kind: A2AAgentIdKind | null;
+  instanceId?: string;
+}
 
 export interface A2AEnvelope {
   id: string;
@@ -41,9 +47,6 @@ export interface A2AEnvelopeAuditSummary {
   threadId: string | null;
   senderAgentId: string | null;
   recipientAgentId: string | null;
-  sourceInstanceId: string | null;
-  targetInstanceId: string | null;
-  hasDelegationToken: boolean;
 }
 
 export class A2AEnvelopeValidationError extends Error {
@@ -86,6 +89,7 @@ const A2A_ENVELOPE_FIELDS = new Set([
 
 const LOCAL_AGENT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 const OPAQUE_ID_DISALLOWED_PATTERN = /[\p{Cc}\s]/u;
+const DELEGATION_TOKEN_MAX_LENGTH = 8192;
 
 function readRequiredTrimmedString(
   record: Record<string, unknown>,
@@ -150,10 +154,20 @@ export function classifyA2AAgentId(value: string): A2AAgentIdKind | null {
   return null;
 }
 
-function normalizeAgentId(value: string): string {
-  return classifyA2AAgentId(value) === 'canonical'
-    ? value.trim().toLowerCase()
-    : value;
+function normalizeA2AAgentId(value: string): NormalizedA2AAgentId {
+  const normalized = value.trim();
+  if (normalized.includes('@') && isCanonicalAgentIdentity(normalized)) {
+    const parsed = parseAgentIdentity(normalized);
+    return {
+      value: parsed.id,
+      kind: 'canonical',
+      instanceId: parsed.instanceId,
+    };
+  }
+  if (!normalized.includes('@') && LOCAL_AGENT_ID_PATTERN.test(normalized)) {
+    return { value: normalized, kind: 'local' };
+  }
+  return { value: normalized, kind: null };
 }
 
 function normalizeInstanceId(value: string): string {
@@ -171,44 +185,40 @@ export function isA2AOpaqueId(value: string): boolean {
   );
 }
 
-export function isA2AInstanceId(value: string): boolean {
-  try {
-    formatAgentIdentity('agent', 'user', value);
-    return true;
-  } catch {
-    return false;
-  }
+function isA2AInstanceId(value: string): boolean {
+  return isAgentIdentityComponent(value);
 }
+
+type A2AOpaqueIdField =
+  | 'id'
+  | 'thread_id'
+  | 'parent_message_id'
+  | 'delegation_token';
 
 function validateOpaqueId(
-  field: 'id' | 'thread_id' | 'parent_message_id',
+  field: A2AOpaqueIdField,
   value: string | undefined,
   issues: string[],
+  opts: { noun?: 'id' | 'token'; maxLength?: number } = {},
 ): void {
   if (value === undefined) return;
+  const noun = opts.noun ?? 'id';
   if (!isA2AOpaqueId(value)) {
-    issues.push(`${field} must be a non-empty id without whitespace`);
+    issues.push(`${field} must be a non-empty ${noun} without whitespace`);
   }
-}
-
-function validateDelegationToken(
-  value: string | undefined,
-  issues: string[],
-): void {
-  if (value === undefined) return;
-  if (!isA2AOpaqueId(value)) {
-    issues.push(
-      'delegation_token must be a non-empty token without whitespace',
-    );
+  if (opts.maxLength !== undefined && value.length > opts.maxLength) {
+    issues.push(`${field} must be at most ${opts.maxLength} characters`);
   }
 }
 
 function validateAgentId(
   field: 'sender_agent_id' | 'recipient_agent_id',
   value: string,
+  kind: A2AAgentIdKind | null,
   issues: string[],
 ): void {
-  if (!isA2AAgentId(value)) {
+  if (!value) return;
+  if (kind === null) {
     issues.push(
       `${field} must be a local agent id or canonical agent id (agent-slug@user@instance-id)`,
     );
@@ -228,66 +238,60 @@ function validateInstanceId(
 
 function requireCanonicalAgentIdForDelegation(
   field: 'sender_agent_id' | 'recipient_agent_id',
-  value: string,
+  kind: A2AAgentIdKind | null,
   issues: string[],
 ): void {
-  if (classifyA2AAgentId(value) !== 'canonical') {
+  if (kind === 'local') {
     issues.push(
       `${field} must be canonical when delegation fields are provided`,
     );
   }
 }
 
-function agentInstanceId(value: string): string | undefined {
-  if (classifyA2AAgentId(value) !== 'canonical') return undefined;
-  return parseAgentIdentity(value).instanceId;
-}
-
 function validateDelegationInstanceMatch(
   instanceField: 'source_instance_id' | 'target_instance_id',
   instanceId: string | undefined,
   agentField: 'sender_agent_id' | 'recipient_agent_id',
-  agentId: string,
+  agentInstanceId: string | undefined,
   issues: string[],
 ): void {
   if (instanceId === undefined) return;
-  const embeddedInstanceId = agentInstanceId(agentId);
-  if (embeddedInstanceId && instanceId !== embeddedInstanceId) {
+  if (agentInstanceId && instanceId !== agentInstanceId) {
     issues.push(
       `${instanceField} must match the instance-id portion of ${agentField}`,
     );
   }
 }
 
-function validateDelegationFieldSet(params: {
-  sourceInstanceId: string | undefined;
-  targetInstanceId: string | undefined;
-  delegationToken: string | undefined;
-  senderAgentId: string;
-  recipientAgentId: string;
-  issues: string[];
-}): void {
+function validateDelegationFieldSet(
+  sourceInstanceId: string | undefined,
+  targetInstanceId: string | undefined,
+  delegationToken: string | undefined,
+  senderAgentKind: A2AAgentIdKind | null,
+  recipientAgentKind: A2AAgentIdKind | null,
+  issues: string[],
+): void {
   const presentCount = [
-    params.sourceInstanceId,
-    params.targetInstanceId,
-    params.delegationToken,
+    sourceInstanceId,
+    targetInstanceId,
+    delegationToken,
   ].filter((value) => value !== undefined).length;
   if (presentCount === 0) return;
 
   if (presentCount !== 3) {
-    params.issues.push(
+    issues.push(
       'source_instance_id, target_instance_id, and delegation_token must be provided together',
     );
   }
   requireCanonicalAgentIdForDelegation(
     'sender_agent_id',
-    params.senderAgentId,
-    params.issues,
+    senderAgentKind,
+    issues,
   );
   requireCanonicalAgentIdForDelegation(
     'recipient_agent_id',
-    params.recipientAgentId,
-    params.issues,
+    recipientAgentKind,
+    issues,
   );
 }
 
@@ -351,8 +355,8 @@ export function validateA2AEnvelope(value: unknown): A2AEnvelope {
     'delegation_token',
     issues,
   );
-  const normalizedSenderAgentId = normalizeAgentId(senderAgentId);
-  const normalizedRecipientAgentId = normalizeAgentId(recipientAgentId);
+  const senderAgent = normalizeA2AAgentId(senderAgentId);
+  const recipientAgent = normalizeA2AAgentId(recipientAgentId);
   const sourceInstanceId =
     rawSourceInstanceId === undefined
       ? undefined
@@ -365,31 +369,44 @@ export function validateA2AEnvelope(value: unknown): A2AEnvelope {
   validateOpaqueId('id', id, issues);
   validateOpaqueId('thread_id', threadId, issues);
   validateOpaqueId('parent_message_id', parentMessageId, issues);
-  validateAgentId('sender_agent_id', normalizedSenderAgentId, issues);
-  validateAgentId('recipient_agent_id', normalizedRecipientAgentId, issues);
+  validateAgentId(
+    'sender_agent_id',
+    senderAgent.value,
+    senderAgent.kind,
+    issues,
+  );
+  validateAgentId(
+    'recipient_agent_id',
+    recipientAgent.value,
+    recipientAgent.kind,
+    issues,
+  );
   validateInstanceId('source_instance_id', sourceInstanceId, issues);
   validateInstanceId('target_instance_id', targetInstanceId, issues);
-  validateDelegationToken(delegationToken, issues);
-  validateDelegationFieldSet({
+  validateOpaqueId('delegation_token', delegationToken, issues, {
+    noun: 'token',
+    maxLength: DELEGATION_TOKEN_MAX_LENGTH,
+  });
+  validateDelegationFieldSet(
     sourceInstanceId,
     targetInstanceId,
     delegationToken,
-    senderAgentId: normalizedSenderAgentId,
-    recipientAgentId: normalizedRecipientAgentId,
+    senderAgent.kind,
+    recipientAgent.kind,
     issues,
-  });
+  );
   validateDelegationInstanceMatch(
     'source_instance_id',
     sourceInstanceId,
     'sender_agent_id',
-    normalizedSenderAgentId,
+    senderAgent.instanceId,
     issues,
   );
   validateDelegationInstanceMatch(
     'target_instance_id',
     targetInstanceId,
     'recipient_agent_id',
-    normalizedRecipientAgentId,
+    recipientAgent.instanceId,
     issues,
   );
   if (!isA2AEnvelopeIntent(intent)) {
@@ -401,19 +418,20 @@ export function validateA2AEnvelope(value: unknown): A2AEnvelope {
     throw new A2AEnvelopeValidationError(issues);
   }
 
-  return {
+  const envelope: A2AEnvelope = {
     id,
-    sender_agent_id: normalizedSenderAgentId,
-    recipient_agent_id: normalizedRecipientAgentId,
-    ...(sourceInstanceId ? { source_instance_id: sourceInstanceId } : {}),
-    ...(targetInstanceId ? { target_instance_id: targetInstanceId } : {}),
+    sender_agent_id: senderAgent.value,
+    recipient_agent_id: recipientAgent.value,
     thread_id: threadId,
-    ...(parentMessageId ? { parent_message_id: parentMessageId } : {}),
     intent: intent as A2AEnvelopeIntent,
     content,
     created_at: createdAt,
-    ...(delegationToken ? { delegation_token: delegationToken } : {}),
   };
+  if (sourceInstanceId) envelope.source_instance_id = sourceInstanceId;
+  if (targetInstanceId) envelope.target_instance_id = targetInstanceId;
+  if (parentMessageId) envelope.parent_message_id = parentMessageId;
+  if (delegationToken) envelope.delegation_token = delegationToken;
+  return envelope;
 }
 
 export function createA2AEnvelope(input: CreateA2AEnvelopeInput): A2AEnvelope {
@@ -448,8 +466,5 @@ export function summarizeA2AEnvelopeForAudit(
     threadId: envelope.thread_id,
     senderAgentId: envelope.sender_agent_id,
     recipientAgentId: envelope.recipient_agent_id,
-    sourceInstanceId: envelope.source_instance_id ?? null,
-    targetInstanceId: envelope.target_instance_id ?? null,
-    hasDelegationToken: Boolean(envelope.delegation_token),
   };
 }

--- a/src/a2a/envelope.ts
+++ b/src/a2a/envelope.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from 'node:crypto';
 
-import { isCanonicalAgentIdentity } from '../identity/agent-id.js';
+import {
+  formatAgentIdentity,
+  isCanonicalAgentIdentity,
+  parseAgentIdentity,
+} from '../identity/agent-id.js';
 import { isRecord } from './utils.js';
 
 export const A2A_ENVELOPE_INTENTS = [
@@ -17,11 +21,14 @@ export interface A2AEnvelope {
   id: string;
   sender_agent_id: string;
   recipient_agent_id: string;
+  source_instance_id?: string;
+  target_instance_id?: string;
   thread_id: string;
   parent_message_id?: string;
   intent: A2AEnvelopeIntent;
   content: string;
   created_at: string;
+  delegation_token?: string;
 }
 
 export type CreateA2AEnvelopeInput = Omit<A2AEnvelope, 'id' | 'created_at'> & {
@@ -34,6 +41,9 @@ export interface A2AEnvelopeAuditSummary {
   threadId: string | null;
   senderAgentId: string | null;
   recipientAgentId: string | null;
+  sourceInstanceId: string | null;
+  targetInstanceId: string | null;
+  hasDelegationToken: boolean;
 }
 
 export class A2AEnvelopeValidationError extends Error {
@@ -64,11 +74,14 @@ const A2A_ENVELOPE_FIELDS = new Set([
   'id',
   'sender_agent_id',
   'recipient_agent_id',
+  'source_instance_id',
+  'target_instance_id',
   'thread_id',
   'parent_message_id',
   'intent',
   'content',
   'created_at',
+  'delegation_token',
 ]);
 
 const LOCAL_AGENT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
@@ -143,6 +156,10 @@ function normalizeAgentId(value: string): string {
     : value;
 }
 
+function normalizeInstanceId(value: string): string {
+  return value.trim().toLowerCase();
+}
+
 export function isA2AAgentId(value: string): boolean {
   return classifyA2AAgentId(value) !== null;
 }
@@ -152,6 +169,15 @@ export function isA2AOpaqueId(value: string): boolean {
   return (
     normalized.length > 0 && !OPAQUE_ID_DISALLOWED_PATTERN.test(normalized)
   );
+}
+
+export function isA2AInstanceId(value: string): boolean {
+  try {
+    formatAgentIdentity('agent', 'user', value);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function validateOpaqueId(
@@ -165,6 +191,18 @@ function validateOpaqueId(
   }
 }
 
+function validateDelegationToken(
+  value: string | undefined,
+  issues: string[],
+): void {
+  if (value === undefined) return;
+  if (!isA2AOpaqueId(value)) {
+    issues.push(
+      'delegation_token must be a non-empty token without whitespace',
+    );
+  }
+}
+
 function validateAgentId(
   field: 'sender_agent_id' | 'recipient_agent_id',
   value: string,
@@ -175,6 +213,82 @@ function validateAgentId(
       `${field} must be a local agent id or canonical agent id (agent-slug@user@instance-id)`,
     );
   }
+}
+
+function validateInstanceId(
+  field: 'source_instance_id' | 'target_instance_id',
+  value: string | undefined,
+  issues: string[],
+): void {
+  if (value === undefined) return;
+  if (!isA2AInstanceId(value)) {
+    issues.push(`${field} must be a canonical instance id`);
+  }
+}
+
+function requireCanonicalAgentIdForDelegation(
+  field: 'sender_agent_id' | 'recipient_agent_id',
+  value: string,
+  issues: string[],
+): void {
+  if (classifyA2AAgentId(value) !== 'canonical') {
+    issues.push(
+      `${field} must be canonical when delegation fields are provided`,
+    );
+  }
+}
+
+function agentInstanceId(value: string): string | undefined {
+  if (classifyA2AAgentId(value) !== 'canonical') return undefined;
+  return parseAgentIdentity(value).instanceId;
+}
+
+function validateDelegationInstanceMatch(
+  instanceField: 'source_instance_id' | 'target_instance_id',
+  instanceId: string | undefined,
+  agentField: 'sender_agent_id' | 'recipient_agent_id',
+  agentId: string,
+  issues: string[],
+): void {
+  if (instanceId === undefined) return;
+  const embeddedInstanceId = agentInstanceId(agentId);
+  if (embeddedInstanceId && instanceId !== embeddedInstanceId) {
+    issues.push(
+      `${instanceField} must match the instance-id portion of ${agentField}`,
+    );
+  }
+}
+
+function validateDelegationFieldSet(params: {
+  sourceInstanceId: string | undefined;
+  targetInstanceId: string | undefined;
+  delegationToken: string | undefined;
+  senderAgentId: string;
+  recipientAgentId: string;
+  issues: string[];
+}): void {
+  const presentCount = [
+    params.sourceInstanceId,
+    params.targetInstanceId,
+    params.delegationToken,
+  ].filter((value) => value !== undefined).length;
+  if (presentCount === 0) return;
+
+  if (presentCount !== 3) {
+    params.issues.push(
+      'source_instance_id, target_instance_id, and delegation_token must be provided together',
+    );
+  }
+  requireCanonicalAgentIdForDelegation(
+    'sender_agent_id',
+    params.senderAgentId,
+    params.issues,
+  );
+  requireCanonicalAgentIdForDelegation(
+    'recipient_agent_id',
+    params.recipientAgentId,
+    params.issues,
+  );
 }
 
 function validateCreatedAt(value: string, issues: string[]): void {
@@ -213,6 +327,16 @@ export function validateA2AEnvelope(value: unknown): A2AEnvelope {
     'recipient_agent_id',
     issues,
   );
+  const rawSourceInstanceId = readOptionalTrimmedString(
+    value,
+    'source_instance_id',
+    issues,
+  );
+  const rawTargetInstanceId = readOptionalTrimmedString(
+    value,
+    'target_instance_id',
+    issues,
+  );
   const threadId = readRequiredTrimmedString(value, 'thread_id', issues);
   const parentMessageId = readOptionalTrimmedString(
     value,
@@ -222,14 +346,52 @@ export function validateA2AEnvelope(value: unknown): A2AEnvelope {
   const intent = readRequiredTrimmedString(value, 'intent', issues);
   const content = readContent(value, issues);
   const createdAt = readRequiredTrimmedString(value, 'created_at', issues);
+  const delegationToken = readOptionalTrimmedString(
+    value,
+    'delegation_token',
+    issues,
+  );
   const normalizedSenderAgentId = normalizeAgentId(senderAgentId);
   const normalizedRecipientAgentId = normalizeAgentId(recipientAgentId);
+  const sourceInstanceId =
+    rawSourceInstanceId === undefined
+      ? undefined
+      : normalizeInstanceId(rawSourceInstanceId);
+  const targetInstanceId =
+    rawTargetInstanceId === undefined
+      ? undefined
+      : normalizeInstanceId(rawTargetInstanceId);
 
   validateOpaqueId('id', id, issues);
   validateOpaqueId('thread_id', threadId, issues);
   validateOpaqueId('parent_message_id', parentMessageId, issues);
   validateAgentId('sender_agent_id', normalizedSenderAgentId, issues);
   validateAgentId('recipient_agent_id', normalizedRecipientAgentId, issues);
+  validateInstanceId('source_instance_id', sourceInstanceId, issues);
+  validateInstanceId('target_instance_id', targetInstanceId, issues);
+  validateDelegationToken(delegationToken, issues);
+  validateDelegationFieldSet({
+    sourceInstanceId,
+    targetInstanceId,
+    delegationToken,
+    senderAgentId: normalizedSenderAgentId,
+    recipientAgentId: normalizedRecipientAgentId,
+    issues,
+  });
+  validateDelegationInstanceMatch(
+    'source_instance_id',
+    sourceInstanceId,
+    'sender_agent_id',
+    normalizedSenderAgentId,
+    issues,
+  );
+  validateDelegationInstanceMatch(
+    'target_instance_id',
+    targetInstanceId,
+    'recipient_agent_id',
+    normalizedRecipientAgentId,
+    issues,
+  );
   if (!isA2AEnvelopeIntent(intent)) {
     issues.push(`intent must be one of: ${A2A_ENVELOPE_INTENTS.join(', ')}`);
   }
@@ -243,11 +405,14 @@ export function validateA2AEnvelope(value: unknown): A2AEnvelope {
     id,
     sender_agent_id: normalizedSenderAgentId,
     recipient_agent_id: normalizedRecipientAgentId,
+    ...(sourceInstanceId ? { source_instance_id: sourceInstanceId } : {}),
+    ...(targetInstanceId ? { target_instance_id: targetInstanceId } : {}),
     thread_id: threadId,
     ...(parentMessageId ? { parent_message_id: parentMessageId } : {}),
     intent: intent as A2AEnvelopeIntent,
     content,
     created_at: createdAt,
+    ...(delegationToken ? { delegation_token: delegationToken } : {}),
   };
 }
 
@@ -283,5 +448,8 @@ export function summarizeA2AEnvelopeForAudit(
     threadId: envelope.thread_id,
     senderAgentId: envelope.sender_agent_id,
     recipientAgentId: envelope.recipient_agent_id,
+    sourceInstanceId: envelope.source_instance_id ?? null,
+    targetInstanceId: envelope.target_instance_id ?? null,
+    hasDelegationToken: Boolean(envelope.delegation_token),
   };
 }

--- a/src/a2a/envelope.ts
+++ b/src/a2a/envelope.ts
@@ -47,6 +47,9 @@ export interface A2AEnvelopeAuditSummary {
   threadId: string | null;
   senderAgentId: string | null;
   recipientAgentId: string | null;
+  sourceInstanceId: string | null;
+  targetInstanceId: string | null;
+  delegation: boolean;
 }
 
 export class A2AEnvelopeValidationError extends Error {
@@ -466,5 +469,8 @@ export function summarizeA2AEnvelopeForAudit(
     threadId: envelope.thread_id,
     senderAgentId: envelope.sender_agent_id,
     recipientAgentId: envelope.recipient_agent_id,
+    sourceInstanceId: envelope.source_instance_id ?? null,
+    targetInstanceId: envelope.target_instance_id ?? null,
+    delegation: Boolean(envelope.delegation_token),
   };
 }

--- a/src/identity/agent-id.ts
+++ b/src/identity/agent-id.ts
@@ -57,6 +57,12 @@ function normalizeAgentIdentityComponent(value: string): string {
   return value.trim().toLowerCase();
 }
 
+export function isAgentIdentityComponent(value: string): boolean {
+  return AGENT_IDENTITY_COMPONENT_PATTERN.test(
+    normalizeAgentIdentityComponent(value),
+  );
+}
+
 function validateAgentIdentityComponent(
   label: 'agent slug' | 'user slug' | 'instance id',
   value: string,
@@ -132,10 +138,7 @@ export function parseAgentIdentity(value: string): ParsedAgentIdentity {
 
 export function isCanonicalAgentIdentity(value: string): boolean {
   const parts = value.trim().toLowerCase().split('@');
-  return (
-    parts.length === 3 &&
-    parts.every((part) => AGENT_IDENTITY_COMPONENT_PATTERN.test(part))
-  );
+  return parts.length === 3 && parts.every(isAgentIdentityComponent);
 }
 
 export function slugifyAgentIdentityComponent(

--- a/tests/a2a-envelope.test.ts
+++ b/tests/a2a-envelope.test.ts
@@ -8,6 +8,7 @@ import {
   A2AEnvelopeValidationError,
   classifyA2AAgentId,
   createA2AEnvelope,
+  summarizeA2AEnvelopeForAudit,
   validateA2AEnvelope,
 } from '../src/a2a/envelope.ts';
 
@@ -106,6 +107,16 @@ describe('A2A envelope schema', () => {
       content: 'Please take this delegated task.',
       created_at: '2026-04-28T10:00:00.000Z',
       delegation_token: 'jwt.header.payload',
+    });
+
+    expect(summarizeA2AEnvelopeForAudit(envelope)).toEqual({
+      messageId: 'msg-delegate-1',
+      threadId: 'thread-delegate',
+      senderAgentId: 'researcher@team-a@inst-source',
+      recipientAgentId: 'writer@team-b@inst-target',
+      sourceInstanceId: 'inst-source',
+      targetInstanceId: 'inst-target',
+      delegation: true,
     });
   });
 

--- a/tests/a2a-envelope.test.ts
+++ b/tests/a2a-envelope.test.ts
@@ -17,6 +17,18 @@ const ORIGINAL_INSTANCE_ID = process.env.HYBRIDCLAW_INSTANCE_ID;
 
 let tmpDir: string;
 
+function expectEnvelopeValidationIssues(
+  value: unknown,
+): A2AEnvelopeValidationError {
+  try {
+    validateA2AEnvelope(value);
+  } catch (error) {
+    expect(error).toBeInstanceOf(A2AEnvelopeValidationError);
+    return error as A2AEnvelopeValidationError;
+  }
+  throw new Error('Expected validation to fail.');
+}
+
 function restoreEnvVar(name: string, value: string | undefined): void {
   if (value === undefined) {
     delete process.env[name];
@@ -69,48 +81,95 @@ describe('A2A envelope schema', () => {
     expect(classifyA2AAgentId('Charly@Benedikt@Local-Dev')).toBe('canonical');
   });
 
+  test('validates delegation metadata against canonical agent instances', () => {
+    const envelope = validateA2AEnvelope({
+      id: 'msg-delegate-1',
+      sender_agent_id: 'Researcher@Team-A@Inst-Source',
+      recipient_agent_id: 'Writer@Team-B@Inst-Target',
+      source_instance_id: ' Inst-Source ',
+      target_instance_id: ' Inst-Target ',
+      thread_id: 'thread-delegate',
+      intent: 'handoff',
+      content: 'Please take this delegated task.',
+      created_at: '2026-04-28T10:00:00.000Z',
+      delegation_token: 'jwt.header.payload',
+    });
+
+    expect(envelope).toEqual({
+      id: 'msg-delegate-1',
+      sender_agent_id: 'researcher@team-a@inst-source',
+      recipient_agent_id: 'writer@team-b@inst-target',
+      source_instance_id: 'inst-source',
+      target_instance_id: 'inst-target',
+      thread_id: 'thread-delegate',
+      intent: 'handoff',
+      content: 'Please take this delegated task.',
+      created_at: '2026-04-28T10:00:00.000Z',
+      delegation_token: 'jwt.header.payload',
+    });
+  });
+
   test('rejects malformed envelopes', () => {
-    expect(() =>
-      validateA2AEnvelope({
-        id: 'bad id',
-        sender_agent_id: 'agent@too@many@segments',
-        recipient_agent_id: 'writer one',
-        thread_id: 'thread-1',
-        intent: 'notify',
-        content: ['not', 'text'],
-        created_at: 'not-a-date',
-        extra: true,
-      }),
-    ).toThrow(A2AEnvelopeValidationError);
+    const error = expectEnvelopeValidationIssues({
+      id: 'bad id',
+      sender_agent_id: 'agent@too@many@segments',
+      recipient_agent_id: 'writer one',
+      thread_id: 'thread-1',
+      intent: 'notify',
+      content: ['not', 'text'],
+      created_at: 'not-a-date',
+      extra: true,
+    });
 
-    try {
-      validateA2AEnvelope({
-        id: 'bad id',
-        sender_agent_id: 'agent@too@many@segments',
-        recipient_agent_id: 'writer one',
-        thread_id: 'thread-1',
-        intent: 'notify',
-        content: ['not', 'text'],
-        created_at: 'not-a-date',
-        extra: true,
-      });
-    } catch (error) {
-      expect(error).toBeInstanceOf(A2AEnvelopeValidationError);
-      expect((error as A2AEnvelopeValidationError).issues).toEqual(
-        expect.arrayContaining([
-          'unexpected field: extra',
-          'id must be a non-empty id without whitespace',
-          'sender_agent_id must be a local agent id or canonical agent id (agent-slug@user@instance-id)',
-          'recipient_agent_id must be a local agent id or canonical agent id (agent-slug@user@instance-id)',
-          'intent must be one of: chat, handoff, escalate, ack',
-          'content must be a string',
-          'created_at must be an ISO timestamp',
-        ]),
-      );
-      return;
-    }
+    expect(error.issues).toEqual(
+      expect.arrayContaining([
+        'unexpected field: extra',
+        'id must be a non-empty id without whitespace',
+        'sender_agent_id must be a local agent id or canonical agent id (agent-slug@user@instance-id)',
+        'recipient_agent_id must be a local agent id or canonical agent id (agent-slug@user@instance-id)',
+        'intent must be one of: chat, handoff, escalate, ack',
+        'content must be a string',
+        'created_at must be an ISO timestamp',
+      ]),
+    );
+  });
 
-    throw new Error('Expected validation to fail.');
+  test('rejects incomplete or mismatched delegation metadata', () => {
+    const incomplete = expectEnvelopeValidationIssues({
+      id: 'msg-delegate-bad',
+      sender_agent_id: 'main',
+      recipient_agent_id: 'writer@team@inst-target',
+      source_instance_id: 'inst-source',
+      thread_id: 'thread-delegate',
+      intent: 'handoff',
+      content: 'Bad delegation metadata.',
+      created_at: '2026-04-28T10:00:00.000Z',
+    });
+    expect(incomplete.issues).toEqual(
+      expect.arrayContaining([
+        'source_instance_id, target_instance_id, and delegation_token must be provided together',
+        'sender_agent_id must be canonical when delegation fields are provided',
+      ]),
+    );
+
+    const mismatched = expectEnvelopeValidationIssues({
+      id: 'msg-delegate-mismatch',
+      sender_agent_id: 'researcher@team@inst-source',
+      recipient_agent_id: 'writer@team@inst-target',
+      source_instance_id: 'inst-other',
+      target_instance_id: 'inst-target',
+      thread_id: 'thread-delegate',
+      intent: 'handoff',
+      content: 'Bad delegation metadata.',
+      created_at: '2026-04-28T10:00:00.000Z',
+      delegation_token: 'bad token',
+    });
+    expect(mismatched.issues).toEqual(
+      expect.arrayContaining([
+        'source_instance_id must match the instance-id portion of sender_agent_id',
+        'delegation_token must be a non-empty token without whitespace',
+      ]),
+    );
   });
 
   test('creates envelopes with generated ids and timestamps', () => {

--- a/tests/a2a-envelope.test.ts
+++ b/tests/a2a-envelope.test.ts
@@ -152,6 +152,27 @@ describe('A2A envelope schema', () => {
       ]),
     );
 
+    const invalidSender = expectEnvelopeValidationIssues({
+      id: 'msg-delegate-invalid-sender',
+      sender_agent_id: 'bad sender',
+      recipient_agent_id: 'writer@team@inst-target',
+      source_instance_id: 'inst-source',
+      target_instance_id: 'inst-target',
+      thread_id: 'thread-delegate',
+      intent: 'handoff',
+      content: 'Bad delegation metadata.',
+      created_at: '2026-04-28T10:00:00.000Z',
+      delegation_token: 'jwt.header.payload',
+    });
+    expect(invalidSender.issues).toEqual(
+      expect.arrayContaining([
+        'sender_agent_id must be a local agent id or canonical agent id (agent-slug@user@instance-id)',
+      ]),
+    );
+    expect(invalidSender.issues).not.toContain(
+      'sender_agent_id must be canonical when delegation fields are provided',
+    );
+
     const mismatched = expectEnvelopeValidationIssues({
       id: 'msg-delegate-mismatch',
       sender_agent_id: 'researcher@team@inst-source',
@@ -168,6 +189,24 @@ describe('A2A envelope schema', () => {
       expect.arrayContaining([
         'source_instance_id must match the instance-id portion of sender_agent_id',
         'delegation_token must be a non-empty token without whitespace',
+      ]),
+    );
+
+    const oversizedToken = expectEnvelopeValidationIssues({
+      id: 'msg-delegate-oversized-token',
+      sender_agent_id: 'researcher@team@inst-source',
+      recipient_agent_id: 'writer@team@inst-target',
+      source_instance_id: 'inst-source',
+      target_instance_id: 'inst-target',
+      thread_id: 'thread-delegate',
+      intent: 'handoff',
+      content: 'Bad delegation metadata.',
+      created_at: '2026-04-28T10:00:00.000Z',
+      delegation_token: 'a'.repeat(8193),
+    });
+    expect(oversizedToken.issues).toEqual(
+      expect.arrayContaining([
+        'delegation_token must be at most 8192 characters',
       ]),
     );
   });

--- a/tests/agent-id.test.ts
+++ b/tests/agent-id.test.ts
@@ -8,6 +8,7 @@ import {
   AgentIdentityValidationError,
   formatAgentIdentity,
   formatLocalInstanceIdFromUuid,
+  isAgentIdentityComponent,
   isCanonicalAgentIdentity,
   parseAgentIdentity,
   resolveLocalInstanceId,
@@ -49,6 +50,12 @@ describe('canonical agent identities', () => {
       instanceId: 'inst-7f3a',
     });
     expect(isCanonicalAgentIdentity('support-lena@acme@inst-7f3a')).toBe(true);
+  });
+
+  test('validates individual identity components without formatting an identity', () => {
+    expect(isAgentIdentityComponent(' Inst-7F3A ')).toBe(true);
+    expect(isAgentIdentityComponent('support lena')).toBe(false);
+    expect(isAgentIdentityComponent('_inst-1')).toBe(false);
   });
 
   test('round-trips valid identities through parse and format', () => {


### PR DESCRIPTION
## Summary
- Add optional delegation envelope fields: `source_instance_id`, `target_instance_id`, and `delegation_token`.
- Keep legacy/intra-instance A2A envelopes valid when delegation metadata is absent.
- Validate delegation overlays as a complete set, require canonical sender/recipient agent IDs, and ensure explicit instance IDs match the canonical agent ID instance components.
- Add a direct identity-component predicate for instance ID validation, cap persisted delegation tokens at 8192 characters, and avoid duplicate canonical-agent errors when the underlying agent ID is malformed.
- Include source/target instance IDs and a non-secret `delegation` flag in A2A audit summaries, and mark R9.2 complete in the internal roadmap.

## Validation
- `npm run format`
- `./node_modules/.bin/vitest run tests/a2a-*.test.ts tests/agent-id.test.ts`
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.integration.config.ts tests/a2a-outbound.integration.test.ts tests/a2a-runtime.integration.test.ts tests/a2a-webhook-outbound.integration.test.ts`
- `npm run lint`
- `git diff --check`

Closes #481