### PR TITLE
[codex] Add signed A2A delegation tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Changed
+
+- **A2A delegation bearer auth**: Outbound A2A uses signed delegation JWTs as
+  the HTTP bearer credential. `bearerTokenRef` remains a required explicit
+  opt-in gate for non-loopback peer URLs, but its secret value is not sent on
+  the wire.
+
+### Fixed
+
+- **A2A delegation revocation cleanup**: Expired delegation-token revocation
+  records are pruned when new revocations are written, preventing stale
+  short-lived token revocations from accumulating indefinitely.
+
 ## [0.16.0](https://github.com/HybridAIOne/hybridclaw/tree/v0.16.0) - 2026-05-07
 
 ### Added

--- a/src/a2a/a2a-inbound.ts
+++ b/src/a2a/a2a-inbound.ts
@@ -254,6 +254,7 @@ export function acceptA2AJsonRpcInboundRequest(params: {
     });
   } catch (error) {
     const reason = extractErrorReason(error);
+    const statusCode = error instanceof A2ADelegationTokenError ? 401 : 400;
     recordInboundAudit({
       runId,
       peerId: peer?.peerId || null,
@@ -264,11 +265,11 @@ export function acceptA2AJsonRpcInboundRequest(params: {
           ? 'rejected'
           : 'validation_failed',
       envelope,
-      statusCode: error instanceof A2ADelegationTokenError ? 401 : 400,
+      statusCode,
       reason,
     });
     return {
-      statusCode: error instanceof A2ADelegationTokenError ? 401 : 400,
+      statusCode,
       body: {
         error:
           error instanceof A2ADelegationTokenError ? 'Unauthorized' : reason,

--- a/src/a2a/a2a-inbound.ts
+++ b/src/a2a/a2a-inbound.ts
@@ -1,0 +1,324 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+import { getAgentById, listAgents } from '../agents/agent-registry.js';
+import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
+import { GatewayRequestError } from '../errors/gateway-request-error.js';
+import { readRequestBody, sendJson } from '../gateway/gateway-http-utils.js';
+import { decodeA2AJsonRpcRequest } from './a2a-json-rpc.js';
+import {
+  A2A_MESSAGE_SEND_SCOPE,
+  A2A_TASK_SEND_SCOPE,
+} from './a2a-outbox-delivery.js';
+import {
+  A2ADelegationTokenError,
+  decodeA2ADelegationTokenClaims,
+  verifyA2ADelegationToken,
+} from './delegation-token.js';
+import {
+  type A2AEnvelope,
+  A2AEnvelopeDuplicateError,
+  A2AEnvelopeValidationError,
+  summarizeA2AEnvelopeForAudit,
+} from './envelope.js';
+import { resolveA2AAgentId } from './identity.js';
+import { acceptA2AInboundEnvelope } from './inbound-pipeline.js';
+import {
+  type A2ATrustedA2APeer,
+  getA2ATrustedA2APeerBySender,
+  listA2ATrustedA2APeers,
+  type UpsertA2ATrustedA2APeerInput,
+  upsertA2ATrustedA2APeer,
+} from './trust-ledger.js';
+import { isRecord } from './utils.js';
+
+export const A2A_JSON_RPC_INBOUND_PATH = '/a2a';
+export const A2A_JSON_RPC_INBOUND_MAX_BODY_BYTES = 1_000_000;
+
+export type A2AJsonRpcInboundSignatureOutcome =
+  | 'passed'
+  | 'failed'
+  | 'missing_peer'
+  | 'revoked';
+export type A2AJsonRpcInboundDownstreamDisposition =
+  | 'delivered'
+  | 'validation_failed'
+  | 'duplicate'
+  | 'rejected'
+  | 'error';
+
+export type { A2ATrustedA2APeer, UpsertA2ATrustedA2APeerInput };
+export { listA2ATrustedA2APeers, upsertA2ATrustedA2APeer };
+
+export interface A2AJsonRpcInboundResult {
+  statusCode: number;
+  body: Record<string, unknown>;
+}
+
+let localCanonicalRecipientCache: {
+  key: string;
+  canonicalAgentIds: Set<string>;
+} | null = null;
+
+function readHeader(
+  headers: IncomingMessage['headers'],
+  headerName: string,
+): string {
+  const raw = headers[headerName.toLowerCase()];
+  if (Array.isArray(raw)) return raw[0] || '';
+  return raw || '';
+}
+
+function extractBearerToken(authorization: string | null | undefined): string {
+  const normalized = String(authorization || '').trim();
+  const match = normalized.match(/^Bearer\s+(.+)$/i);
+  if (!match?.[1]?.trim()) {
+    throw new A2ADelegationTokenError('Authorization bearer token is required');
+  }
+  return match[1].trim();
+}
+
+function normalizeAudience(url: URL): string {
+  return new URL(url.pathname, url.origin).toString();
+}
+
+function localCanonicalRecipientCacheKey(): string {
+  return listAgents()
+    .map((agent) => `${agent.id}\0${agent.owner || ''}`)
+    .join('\n');
+}
+
+function localCanonicalRecipientIds(): Set<string> {
+  const key = localCanonicalRecipientCacheKey();
+  if (localCanonicalRecipientCache?.key === key) {
+    return localCanonicalRecipientCache.canonicalAgentIds;
+  }
+
+  const canonicalAgentIds = new Set<string>();
+  for (const agent of listAgents()) {
+    try {
+      canonicalAgentIds.add(resolveA2AAgentId(agent.id));
+    } catch {
+      // Agent registry validation owns surfacing malformed local records.
+    }
+  }
+  localCanonicalRecipientCache = { key, canonicalAgentIds };
+  return canonicalAgentIds;
+}
+
+function localRecipientResolves(recipientAgentId: string): boolean {
+  if (!recipientAgentId.includes('@')) {
+    return Boolean(getAgentById(recipientAgentId));
+  }
+  return localCanonicalRecipientIds().has(recipientAgentId.toLowerCase());
+}
+
+function jsonRpcMethod(payload: unknown): 'message/send' | 'tasks/send' {
+  const parsed =
+    typeof payload === 'string' ? (JSON.parse(payload) as unknown) : payload;
+  if (!isRecord(parsed) || parsed.jsonrpc !== '2.0') {
+    throw new A2AEnvelopeValidationError([
+      'A2A JSON-RPC payload must use jsonrpc "2.0"',
+    ]);
+  }
+  if (parsed.method !== 'message/send' && parsed.method !== 'tasks/send') {
+    throw new A2AEnvelopeValidationError([
+      'A2A JSON-RPC method must be message/send or tasks/send',
+    ]);
+  }
+  return parsed.method;
+}
+
+function extractErrorReason(error: unknown): string {
+  if (error instanceof A2AEnvelopeValidationError) {
+    return error.issues.join('; ');
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+function recordInboundAudit(params: {
+  runId: string;
+  peerId: string | null;
+  signatureOutcome: A2AJsonRpcInboundSignatureOutcome;
+  intent: string | null;
+  downstreamDisposition: A2AJsonRpcInboundDownstreamDisposition;
+  envelope: A2AEnvelope | null;
+  statusCode: number;
+  reason?: string;
+}): void {
+  const peerId = params.peerId || 'unknown';
+  recordAuditEvent({
+    sessionId: `a2a:inbound:${peerId}`,
+    runId: params.runId,
+    event: {
+      type: 'a2a.inbound_post',
+      peerId,
+      signatureOutcome: params.signatureOutcome,
+      intent: params.intent,
+      downstreamDisposition: params.downstreamDisposition,
+      statusCode: params.statusCode,
+      ...(params.reason ? { reason: params.reason } : {}),
+      ...(params.envelope
+        ? { envelope: summarizeA2AEnvelopeForAudit(params.envelope) }
+        : {}),
+    },
+  });
+}
+
+function validateSignedRequest(params: {
+  token: string;
+  envelope: A2AEnvelope;
+  method: 'message/send' | 'tasks/send';
+  audience: string;
+  now?: Date;
+  peer?: A2ATrustedA2APeer;
+}): A2ATrustedA2APeer {
+  const unverifiedClaims = decodeA2ADelegationTokenClaims(params.token);
+  const peer =
+    params.peer ??
+    getA2ATrustedA2APeerBySender(unverifiedClaims.sender_agent_id);
+  if (!peer) {
+    throw new A2ADelegationTokenError('No trusted A2A peer for token sender');
+  }
+  verifyA2ADelegationToken({
+    token: params.token,
+    publicKeyPem: peer.publicKeyPem,
+    audience: params.audience,
+    requiredScope:
+      params.method === 'tasks/send'
+        ? A2A_TASK_SEND_SCOPE
+        : A2A_MESSAGE_SEND_SCOPE,
+    senderAgentId: params.envelope.sender_agent_id,
+    targetAgentId: params.envelope.recipient_agent_id,
+    now: params.now,
+  });
+  return peer;
+}
+
+export function acceptA2AJsonRpcInboundRequest(params: {
+  rawBody: string;
+  authorization: string | null | undefined;
+  audience: string;
+  now?: Date;
+  peer?: A2ATrustedA2APeer;
+}): A2AJsonRpcInboundResult {
+  const runId = makeAuditRunId('a2a-inbound');
+  let envelope: A2AEnvelope | null = null;
+  let peer: A2ATrustedA2APeer | null = params.peer ?? null;
+
+  try {
+    const method = jsonRpcMethod(params.rawBody);
+    envelope = decodeA2AJsonRpcRequest(params.rawBody);
+    if (!localRecipientResolves(envelope.recipient_agent_id)) {
+      throw new A2AEnvelopeValidationError([
+        'recipient_agent_id does not resolve to a local agent',
+      ]);
+    }
+    const token = extractBearerToken(params.authorization);
+    peer = validateSignedRequest({
+      token,
+      envelope,
+      method,
+      audience: params.audience,
+      now: params.now,
+      peer: params.peer,
+    });
+  } catch (error) {
+    const reason = extractErrorReason(error);
+    recordInboundAudit({
+      runId,
+      peerId: peer?.peerId || null,
+      signatureOutcome: reason.includes('revoked')
+        ? 'revoked'
+        : error instanceof A2ADelegationTokenError
+          ? 'failed'
+          : 'failed',
+      intent: envelope?.intent || null,
+      downstreamDisposition:
+        error instanceof A2ADelegationTokenError
+          ? 'rejected'
+          : 'validation_failed',
+      envelope,
+      statusCode: error instanceof A2ADelegationTokenError ? 401 : 400,
+      reason,
+    });
+    return {
+      statusCode: error instanceof A2ADelegationTokenError ? 401 : 400,
+      body: {
+        error:
+          error instanceof A2ADelegationTokenError ? 'Unauthorized' : reason,
+      },
+    };
+  }
+
+  try {
+    const confirmation = acceptA2AInboundEnvelope(envelope, {
+      source: 'a2a',
+      actor: peer.peerId,
+      sessionId: `a2a:inbound:${peer.peerId}`,
+      auditRunId: runId,
+    });
+    recordInboundAudit({
+      runId,
+      peerId: peer.peerId,
+      signatureOutcome: 'passed',
+      intent: envelope.intent,
+      downstreamDisposition: 'delivered',
+      envelope,
+      statusCode: 202,
+    });
+    return {
+      statusCode: 202,
+      body: { ...confirmation },
+    };
+  } catch (error) {
+    const isDuplicate = error instanceof A2AEnvelopeDuplicateError;
+    const reason = extractErrorReason(error);
+    recordInboundAudit({
+      runId,
+      peerId: peer.peerId,
+      signatureOutcome: 'passed',
+      intent: envelope.intent,
+      downstreamDisposition: isDuplicate ? 'duplicate' : 'error',
+      envelope,
+      statusCode: isDuplicate ? 409 : 500,
+      reason,
+    });
+    return {
+      statusCode: isDuplicate ? 409 : 500,
+      body: { error: reason },
+    };
+  }
+}
+
+export async function handleA2AJsonRpcInbound(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL,
+): Promise<void> {
+  if (url.pathname !== A2A_JSON_RPC_INBOUND_PATH) {
+    sendJson(res, 404, { error: 'Not Found' });
+    return;
+  }
+  if (req.method !== 'POST') {
+    sendJson(res, 405, { error: 'Method Not Allowed' });
+    return;
+  }
+
+  try {
+    const rawBody = (
+      await readRequestBody(req, A2A_JSON_RPC_INBOUND_MAX_BODY_BYTES)
+    ).toString('utf-8');
+    const result = acceptA2AJsonRpcInboundRequest({
+      rawBody,
+      authorization: readHeader(req.headers, 'authorization'),
+      audience: normalizeAudience(url),
+    });
+    sendJson(res, result.statusCode, result.body);
+  } catch (error) {
+    if (error instanceof GatewayRequestError) {
+      sendJson(res, error.statusCode, { error: error.message });
+      return;
+    }
+    sendJson(res, 500, { error: 'Internal server error' });
+  }
+}

--- a/src/a2a/a2a-inbound.ts
+++ b/src/a2a/a2a-inbound.ts
@@ -54,6 +54,13 @@ export interface A2AJsonRpcInboundResult {
   body: Record<string, unknown>;
 }
 
+class A2AMissingTrustedPeerError extends A2ADelegationTokenError {
+  constructor(message = 'No trusted A2A peer for token sender') {
+    super(message);
+    this.name = 'A2AMissingTrustedPeerError';
+  }
+}
+
 let localCanonicalRecipientCache: {
   key: string;
   canonicalAgentIds: Set<string>;
@@ -164,12 +171,8 @@ function recordInboundAudit(params: {
   });
 }
 
-function validateSignedRequest(params: {
+function resolveTrustedPeerForToken(params: {
   token: string;
-  envelope: A2AEnvelope;
-  method: 'message/send' | 'tasks/send';
-  audience: string;
-  now?: Date;
   peer?: A2ATrustedA2APeer;
 }): A2ATrustedA2APeer {
   const unverifiedClaims = decodeA2ADelegationTokenClaims(params.token);
@@ -177,11 +180,22 @@ function validateSignedRequest(params: {
     params.peer ??
     getA2ATrustedA2APeerBySender(unverifiedClaims.sender_agent_id);
   if (!peer) {
-    throw new A2ADelegationTokenError('No trusted A2A peer for token sender');
+    throw new A2AMissingTrustedPeerError();
   }
+  return peer;
+}
+
+function verifySignedRequest(params: {
+  token: string;
+  envelope: A2AEnvelope;
+  method: 'message/send' | 'tasks/send';
+  audience: string;
+  now?: Date;
+  peer: A2ATrustedA2APeer;
+}): void {
   verifyA2ADelegationToken({
     token: params.token,
-    publicKeyPem: peer.publicKeyPem,
+    publicKeyPem: params.peer.publicKeyPem,
     audience: params.audience,
     requiredScope:
       params.method === 'tasks/send'
@@ -191,7 +205,19 @@ function validateSignedRequest(params: {
     targetAgentId: params.envelope.recipient_agent_id,
     now: params.now,
   });
-  return peer;
+}
+
+function signatureOutcomeForError(
+  error: unknown,
+): A2AJsonRpcInboundSignatureOutcome {
+  if (error instanceof A2AMissingTrustedPeerError) return 'missing_peer';
+  if (
+    error instanceof A2ADelegationTokenError &&
+    error.message.includes('revoked')
+  ) {
+    return 'revoked';
+  }
+  return 'failed';
 }
 
 export function acceptA2AJsonRpcInboundRequest(params: {
@@ -214,24 +240,24 @@ export function acceptA2AJsonRpcInboundRequest(params: {
       ]);
     }
     const token = extractBearerToken(params.authorization);
-    peer = validateSignedRequest({
+    peer = resolveTrustedPeerForToken({
+      token,
+      peer: params.peer,
+    });
+    verifySignedRequest({
       token,
       envelope,
       method,
       audience: params.audience,
       now: params.now,
-      peer: params.peer,
+      peer,
     });
   } catch (error) {
     const reason = extractErrorReason(error);
     recordInboundAudit({
       runId,
       peerId: peer?.peerId || null,
-      signatureOutcome: reason.includes('revoked')
-        ? 'revoked'
-        : error instanceof A2ADelegationTokenError
-          ? 'failed'
-          : 'failed',
+      signatureOutcome: signatureOutcomeForError(error),
       intent: envelope?.intent || null,
       downstreamDisposition:
         error instanceof A2ADelegationTokenError

--- a/src/a2a/a2a-outbound.ts
+++ b/src/a2a/a2a-outbound.ts
@@ -13,8 +13,11 @@ import type {
 
 export { A2A_AGENT_CARD_CACHE_TTL_MS } from './a2a-agent-card.js';
 export {
+  A2A_AGENT_CARD_READ_SCOPE,
+  A2A_MESSAGE_SEND_SCOPE,
   A2A_RETRY_BASE_DELAY_MS,
   A2A_RETRY_MAX_DELAY_MS,
+  A2A_TASK_SEND_SCOPE,
   type A2AOutboxProcessOptions,
 } from './a2a-outbox-delivery.js';
 export {
@@ -33,6 +36,18 @@ export {
   startA2AOutboxProcessor,
   stopA2AOutboxProcessor,
 } from './a2a-outbox-processor.js';
+export {
+  A2A_DELEGATION_TOKEN_TTL_SECONDS,
+  type A2ADelegationTokenClaims,
+  A2ADelegationTokenError,
+  type A2ADelegationTokenKeyPair,
+  decodeA2ADelegationTokenClaims,
+  getOrCreateA2ADelegationTokenKeyPair,
+  isA2ADelegationTokenRevoked,
+  revokeA2ADelegationTokenId,
+  signA2ADelegationToken,
+  verifyA2ADelegationToken,
+} from './delegation-token.js';
 
 export class A2AOutboundAdapter implements TransportAdapter<A2AOutboxItem> {
   readonly transport = 'a2a' as const;

--- a/src/a2a/a2a-outbox-delivery.ts
+++ b/src/a2a/a2a-outbox-delivery.ts
@@ -80,6 +80,29 @@ function assertBearerAuthConfigured(
   }
 }
 
+function recordDelegationAuthAudit(params: {
+  item: A2AOutboxItem;
+  audience: string;
+  scope: string;
+}): void {
+  recordA2AAudit(params.item, {
+    type: 'a2a.outbound.delegation_auth',
+    authMode: 'signed_delegation_jwt',
+    bearerTokenRefRole: params.item.bearerTokenRef
+      ? 'non_loopback_policy_gate'
+      : 'not_required_for_loopback',
+    bearerTokenRef: params.item.bearerTokenRef
+      ? {
+          source: params.item.bearerTokenRef.source,
+          id: params.item.bearerTokenRef.id,
+        }
+      : null,
+    audience: params.audience,
+    scope: params.scope,
+    envelope: summarizeA2AEnvelopeForAudit(params.item.envelope),
+  });
+}
+
 function resolveParentRunId(item: A2AOutboxItem): string {
   return item.runId || item.sessionId || item.envelope.thread_id;
 }
@@ -91,6 +114,7 @@ function authHeaders(params: {
   now: Date;
 }): Record<string, string> {
   assertBearerAuthConfigured(params.item, params.audience);
+  recordDelegationAuthAudit(params);
   return {
     authorization: `Bearer ${signA2ADelegationToken({
       senderAgentId: params.item.envelope.sender_agent_id,

--- a/src/a2a/a2a-outbox-delivery.ts
+++ b/src/a2a/a2a-outbox-delivery.ts
@@ -1,14 +1,9 @@
-import { createHmac } from 'node:crypto';
-
 import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
 import {
   createSuspendedSession,
   emitInteractionNeededEvent,
 } from '../gateway/interactive-escalation.js';
-import {
-  resolveSecretInputUnsafe,
-  type SecretRef,
-} from '../security/secret-refs.js';
+import { resolveSecretHandleInput } from '../security/secret-refs.js';
 import {
   A2AFailFastError,
   A2AHttpError,
@@ -20,6 +15,7 @@ import {
   nowIso,
   persistA2AOutboxItem,
 } from './a2a-outbox-persistence.js';
+import { signA2ADelegationToken } from './delegation-token.js';
 import { summarizeA2AEnvelopeForAudit } from './envelope.js';
 import {
   isA2AAllowedHttpUrl,
@@ -30,6 +26,9 @@ import {
 
 export const A2A_RETRY_BASE_DELAY_MS = 1_000;
 export const A2A_RETRY_MAX_DELAY_MS = 5 * 60_000;
+export const A2A_AGENT_CARD_READ_SCOPE = 'a2a:agent-card:read';
+export const A2A_MESSAGE_SEND_SCOPE = 'a2a:message:send';
+export const A2A_TASK_SEND_SCOPE = 'a2a:task:send';
 
 export interface A2AOutboxProcessOptions {
   /** Test hook for deterministic delivery without making live network calls. */
@@ -46,57 +45,6 @@ export interface A2AOutboxProcessOptions {
   agentCardCacheTtlMs?: number;
 }
 
-function base64UrlJson(value: unknown): string {
-  return Buffer.from(JSON.stringify(value)).toString('base64url');
-}
-
-function makeSignedBearer(input: {
-  item: A2AOutboxItem;
-  secret: string;
-  audience: string;
-  now: Date;
-}): string {
-  const issuedAt = Math.trunc(input.now.getTime() / 1000);
-  const header = base64UrlJson({ alg: 'HS256', typ: 'JWT' });
-  // pre-F7 (#574): descriptor-key bearer auth only until trust-ledger auth lands.
-  const payload = base64UrlJson({
-    iss: 'hybridclaw',
-    sub: input.item.envelope.sender_agent_id,
-    aud: input.audience,
-    jti: input.item.envelope.id,
-    thread_id: input.item.envelope.thread_id,
-    iat: issuedAt,
-    nbf: issuedAt,
-    exp: issuedAt + 300,
-  });
-  const signature = createHmac('sha256', input.secret)
-    .update(`${header}.${payload}`)
-    .digest('base64url');
-  return `${header}.${payload}.${signature}`;
-}
-
-function auditSecretEscape(params: {
-  sessionId: string;
-  runId: string;
-  ref: SecretRef;
-  url: string;
-  reason: string;
-}): void {
-  recordAuditEvent({
-    sessionId: params.sessionId,
-    runId: params.runId,
-    event: {
-      type: 'secret.unsafe_escape',
-      skill: 'a2a.outbound',
-      secretRef: params.ref,
-      sinkKind: 'http',
-      host: new URL(params.url).host,
-      selector: null,
-      reason: params.reason,
-    },
-  });
-}
-
 function resolveItemSessionId(item: A2AOutboxItem): string {
   return item.sessionId || `a2a:outbound:${item.envelope.thread_id}`;
 }
@@ -105,49 +53,55 @@ function resolveItemRunId(item: A2AOutboxItem, prefix: string): string {
   return item.runId || makeAuditRunId(prefix);
 }
 
-function resolveBearerSecret(
+function assertBearerAuthConfigured(
   item: A2AOutboxItem,
   authUrl: string,
-): string | undefined {
+): boolean {
   if (!item.bearerTokenRef) {
-    if (isA2ALoopbackHttpUrl(authUrl)) return undefined;
+    if (isA2ALoopbackHttpUrl(authUrl)) return false;
     throw new A2AFailFastError(
       'a2a.bearerTokenRef is required for non-loopback peers',
     );
   }
-  const secret = resolveSecretInputUnsafe(item.bearerTokenRef, {
-    path: 'a2a.bearerTokenRef',
-    required: true,
-    reason: 'sign outbound A2A bearer token',
-    audit: (handle, reason) =>
-      auditSecretEscape({
-        sessionId: resolveItemSessionId(item),
-        runId: resolveItemRunId(item, 'a2a-outbound-secret'),
-        ref: handle.ref,
-        url: authUrl,
-        reason,
-      }),
-  });
-  if (!secret) {
-    throw new Error(
-      `a2a.bearerTokenRef resolved to an empty secret for ${item.bearerTokenRef.source}:${item.bearerTokenRef.id}`,
+  try {
+    resolveSecretHandleInput(item.bearerTokenRef, {
+      path: 'a2a.bearerTokenRef',
+      required: true,
+      sinkKind: 'http',
+    });
+  } catch (error) {
+    throw new A2AFailFastError(
+      error instanceof Error ? error.message : String(error),
     );
   }
-  return secret;
+  return true;
+}
+
+function resolveParentRunId(item: A2AOutboxItem): string {
+  return item.runId || item.sessionId || item.envelope.thread_id;
 }
 
 function authHeaders(params: {
   item: A2AOutboxItem;
   audience: string;
+  scope: string;
   now: Date;
 }): Record<string, string> {
-  const secret = resolveBearerSecret(params.item, params.audience);
-  if (!secret) return {};
+  const requiresBearer = assertBearerAuthConfigured(
+    params.item,
+    params.audience,
+  );
+  if (!requiresBearer) return {};
   return {
-    authorization: `Bearer ${makeSignedBearer({
-      item: params.item,
-      secret,
+    authorization: `Bearer ${signA2ADelegationToken({
+      senderAgentId: params.item.envelope.sender_agent_id,
+      targetAgentId: params.item.envelope.recipient_agent_id,
       audience: params.audience,
+      scope: params.scope,
+      parentRunId: resolveParentRunId(params.item),
+      jwtId: params.item.envelope.id,
+      messageId: params.item.envelope.id,
+      threadId: params.item.envelope.thread_id,
       now: params.now,
     })}`,
   };
@@ -354,7 +308,12 @@ export async function deliverA2AItem(
       agentCardUrl: item.agentCardUrl,
       fetchImpl: opts.fetchImpl,
       now,
-      headers: authHeaders({ item, audience: item.agentCardUrl, now }),
+      headers: authHeaders({
+        item,
+        audience: item.agentCardUrl,
+        scope: A2A_AGENT_CARD_READ_SCOPE,
+        now,
+      }),
       authCacheKey: agentCardAuthCacheKey(item),
       agentCardCacheTtlMs: opts.agentCardCacheTtlMs,
     });
@@ -394,7 +353,15 @@ export async function deliverA2AItem(
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        ...authHeaders({ item, audience: card.url, now }),
+        ...authHeaders({
+          item,
+          audience: card.url,
+          scope:
+            request.method === 'tasks/send'
+              ? A2A_TASK_SEND_SCOPE
+              : A2A_MESSAGE_SEND_SCOPE,
+          now,
+        }),
       },
       body,
       redirect: 'error',

--- a/src/a2a/a2a-outbox-delivery.ts
+++ b/src/a2a/a2a-outbox-delivery.ts
@@ -60,9 +60,9 @@ function resolveItemRunId(item: A2AOutboxItem, prefix: string): string {
 function assertBearerAuthConfigured(
   item: A2AOutboxItem,
   authUrl: string,
-): boolean {
+): void {
   if (!item.bearerTokenRef) {
-    if (isA2ALoopbackHttpUrl(authUrl)) return false;
+    if (isA2ALoopbackHttpUrl(authUrl)) return;
     throw new A2AFailFastError(
       'a2a.bearerTokenRef is required for non-loopback peers',
     );
@@ -78,7 +78,6 @@ function assertBearerAuthConfigured(
       error instanceof Error ? error.message : String(error),
     );
   }
-  return true;
 }
 
 function resolveParentRunId(item: A2AOutboxItem): string {
@@ -91,11 +90,7 @@ function authHeaders(params: {
   scope: string;
   now: Date;
 }): Record<string, string> {
-  const requiresBearer = assertBearerAuthConfigured(
-    params.item,
-    params.audience,
-  );
-  if (!requiresBearer) return {};
+  assertBearerAuthConfigured(params.item, params.audience);
   return {
     authorization: `Bearer ${signA2ADelegationToken({
       senderAgentId: params.item.envelope.sender_agent_id,

--- a/src/a2a/delegation-token.ts
+++ b/src/a2a/delegation-token.ts
@@ -82,6 +82,11 @@ export interface A2ADelegationTokenRevocation {
   revokedAt: string;
 }
 
+export interface A2ADelegationTokenRevocationPruneResult {
+  scanned: number;
+  pruned: number;
+}
+
 export class A2ADelegationTokenError extends Error {
   constructor(message: string) {
     super(message);
@@ -432,6 +437,71 @@ function revocationAssetPath(jwtId: string, rootDir: string): string {
   );
 }
 
+function parseRevocation(raw: string): A2ADelegationTokenRevocation | null {
+  try {
+    const parsed = JSON.parse(raw) as Partial<A2ADelegationTokenRevocation>;
+    if (
+      parsed.schemaVersion !== A2A_DELEGATION_TOKEN_REVOCATION_SCHEMA_VERSION ||
+      typeof parsed.jwtId !== 'string' ||
+      !parsed.jwtId.trim() ||
+      typeof parsed.revokedAt !== 'string' ||
+      !parsed.revokedAt.trim()
+    ) {
+      return null;
+    }
+    return {
+      schemaVersion: A2A_DELEGATION_TOKEN_REVOCATION_SCHEMA_VERSION,
+      jwtId: parsed.jwtId,
+      revokedAt: parsed.revokedAt,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function pruneExpiredA2ADelegationTokenRevocations(
+  options: {
+    now?: Date;
+    maxAgeSeconds?: number;
+    revocationRootDir?: string;
+  } = {},
+): A2ADelegationTokenRevocationPruneResult {
+  const rootDir = options.revocationRootDir ?? delegationRevocationRootDir();
+  const maxAgeSeconds =
+    options.maxAgeSeconds && options.maxAgeSeconds > 0
+      ? Math.trunc(options.maxAgeSeconds)
+      : A2A_DELEGATION_TOKEN_TTL_SECONDS;
+  const expiresBeforeMs =
+    (options.now ?? new Date()).getTime() - maxAgeSeconds * 1000;
+  let scanned = 0;
+  let pruned = 0;
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(rootDir, { withFileTypes: true });
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err?.code === 'ENOENT') return { scanned, pruned };
+    throw error;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+    scanned += 1;
+    const assetPath = path.join(rootDir, entry.name);
+    const revocation = parseRevocation(fs.readFileSync(assetPath, 'utf-8'));
+    if (!revocation) continue;
+    const revokedAtMs = Date.parse(revocation.revokedAt);
+    if (!Number.isFinite(revokedAtMs) || revokedAtMs > expiresBeforeMs) {
+      continue;
+    }
+    fs.rmSync(assetPath, { force: true });
+    pruned += 1;
+  }
+
+  return { scanned, pruned };
+}
+
 export function revokeA2ADelegationTokenId(
   jwtId: string,
   options: {
@@ -447,6 +517,10 @@ export function revokeA2ADelegationTokenId(
   };
   const rootDir = options.revocationRootDir ?? delegationRevocationRootDir();
   fs.mkdirSync(rootDir, { recursive: true });
+  pruneExpiredA2ADelegationTokenRevocations({
+    now: options.revokedAt,
+    revocationRootDir: rootDir,
+  });
   fs.writeFileSync(
     revocationAssetPath(normalizedJwtId, rootDir),
     `${JSON.stringify(revocation, null, 2)}\n`,

--- a/src/a2a/delegation-token.ts
+++ b/src/a2a/delegation-token.ts
@@ -3,6 +3,7 @@ import {
   createPrivateKey,
   createPublicKey,
   generateKeyPairSync,
+  type KeyObject,
   randomUUID,
   sign,
   verify,
@@ -45,6 +46,7 @@ export interface A2ADelegationTokenClaims {
   target_agent_id: string;
   scope: string[];
   parent_run_id: string;
+  // Observability only; integrity is bound by jti, sender, target, audience, and scope.
   message_id?: string;
   thread_id?: string;
 }
@@ -87,6 +89,10 @@ export class A2ADelegationTokenError extends Error {
   }
 }
 
+let cachedKeyPair: A2ADelegationTokenKeyPair | null = null;
+let cachedPrivateKey: { pem: string; key: KeyObject } | null = null;
+const cachedPublicKeys = new Map<string, KeyObject>();
+
 function delegationKeyPairPath(): string {
   return path.join(
     DEFAULT_RUNTIME_HOME_DIR,
@@ -124,18 +130,6 @@ function normalizeTokenString(value: string, label: string): string {
   return normalized;
 }
 
-function normalizeAudience(value: string): string {
-  return normalizeTokenString(value, 'audience');
-}
-
-function normalizeParentRunId(value: string): string {
-  return normalizeTokenString(value, 'parentRunId');
-}
-
-function normalizeJwtId(value: string): string {
-  return normalizeTokenString(value, 'jwtId');
-}
-
 function normalizeScope(scope: string | string[]): string[] {
   const rawScopes = Array.isArray(scope) ? scope : [scope];
   const normalizedScopes = Array.from(
@@ -150,7 +144,23 @@ function normalizeScope(scope: string | string[]): string[] {
 function normalizeAgentIdForToken(agentId: string): string {
   const normalized = agentId.trim();
   if (isCanonicalAgentIdentity(normalized)) return normalized.toLowerCase();
+  // Local ids are resolved to canonical ids so tokens stay portable across instances.
   return resolveA2AAgentId(normalized);
+}
+
+function privateKeyObject(privateKeyPem: string): KeyObject {
+  if (cachedPrivateKey?.pem === privateKeyPem) return cachedPrivateKey.key;
+  const key = createPrivateKey(privateKeyPem);
+  cachedPrivateKey = { pem: privateKeyPem, key };
+  return key;
+}
+
+function publicKeyObject(publicKeyPem: string): KeyObject {
+  const cached = cachedPublicKeys.get(publicKeyPem);
+  if (cached) return cached;
+  const key = createPublicKey(publicKeyPem);
+  cachedPublicKeys.set(publicKeyPem, key);
+  return key;
 }
 
 function keyIdForPublicKey(publicKeyPem: string): string {
@@ -247,6 +257,7 @@ function writeNewKeyPair(
   fs.mkdirSync(keyPairDir, { recursive: true });
   const tempPath = path.join(keyPairDir, `.delegation-keypair-${randomUUID()}`);
   try {
+    // Atomic create: only one process wins if two instances bootstrap together.
     fs.writeFileSync(tempPath, `${JSON.stringify(keyPair, null, 2)}\n`, {
       encoding: 'utf-8',
       flag: 'wx',
@@ -265,13 +276,22 @@ function writeNewKeyPair(
 export function getOrCreateA2ADelegationTokenKeyPair(
   options: { keyPairPath?: string; now?: Date } = {},
 ): A2ADelegationTokenKeyPair {
-  const keyPairPath = options.keyPairPath ?? delegationKeyPairPath();
+  const defaultKeyPairPath = delegationKeyPairPath();
+  const keyPairPath = options.keyPairPath ?? defaultKeyPairPath;
+  const usesDefaultPath = keyPairPath === defaultKeyPairPath;
+  if (usesDefaultPath && cachedKeyPair) return cachedKeyPair;
+
   const existing = readKeyPair(keyPairPath);
-  if (existing) return existing;
+  if (existing) {
+    if (usesDefaultPath) cachedKeyPair = existing;
+    return existing;
+  }
 
   const generated = generateDelegationKeyPair(options.now ?? new Date());
   writeNewKeyPair(keyPairPath, generated);
-  return readKeyPair(keyPairPath) ?? generated;
+  const keyPair = readKeyPair(keyPairPath) ?? generated;
+  if (usesDefaultPath) cachedKeyPair = keyPair;
+  return keyPair;
 }
 
 function assertNumericDate(
@@ -364,15 +384,15 @@ export function signA2ADelegationToken(
   const claims: A2ADelegationTokenClaims = {
     iss: A2A_DELEGATION_TOKEN_ISSUER,
     sub: senderAgentId,
-    aud: normalizeAudience(input.audience),
-    jti: normalizeJwtId(input.jwtId),
+    aud: normalizeTokenString(input.audience, 'audience'),
+    jti: normalizeTokenString(input.jwtId, 'jwtId'),
     iat: issuedAt,
     nbf: issuedAt,
     exp: issuedAt + expiresInSeconds,
     sender_agent_id: senderAgentId,
     target_agent_id: targetAgentId,
     scope: normalizeScope(input.scope),
-    parent_run_id: normalizeParentRunId(input.parentRunId),
+    parent_run_id: normalizeTokenString(input.parentRunId, 'parentRunId'),
     ...(input.messageId
       ? { message_id: normalizeTokenString(input.messageId, 'messageId') }
       : {}),
@@ -390,7 +410,7 @@ export function signA2ADelegationToken(
   const signature = sign(
     null,
     Buffer.from(signingInput),
-    createPrivateKey(keyPair.privateKeyPem),
+    privateKeyObject(keyPair.privateKeyPem),
   ).toString('base64url');
   return `${signingInput}.${signature}`;
 }
@@ -408,7 +428,7 @@ export function decodeA2ADelegationTokenClaims(
 function revocationAssetPath(jwtId: string, rootDir: string): string {
   return path.join(
     rootDir,
-    `${encodeURIComponent(normalizeJwtId(jwtId))}.json`,
+    `${encodeURIComponent(normalizeTokenString(jwtId, 'jwtId'))}.json`,
   );
 }
 
@@ -419,7 +439,7 @@ export function revokeA2ADelegationTokenId(
     revocationRootDir?: string;
   } = {},
 ): A2ADelegationTokenRevocation {
-  const normalizedJwtId = normalizeJwtId(jwtId);
+  const normalizedJwtId = normalizeTokenString(jwtId, 'jwtId');
   const revocation: A2ADelegationTokenRevocation = {
     schemaVersion: A2A_DELEGATION_TOKEN_REVOCATION_SCHEMA_VERSION,
     jwtId: normalizedJwtId,
@@ -485,18 +505,18 @@ export function verifyA2ADelegationToken(
   const [headerSegment = '', payloadSegment = '', signatureSegment = ''] =
     parts;
   assertTokenHeader(decodeBase64UrlJson(headerSegment, 'JWT header'));
-  const claims = parseClaims(
-    decodeBase64UrlJson(payloadSegment, 'JWT payload'),
-  );
   const signatureOk = verify(
     null,
     Buffer.from(`${headerSegment}.${payloadSegment}`),
-    createPublicKey(input.publicKeyPem),
+    publicKeyObject(input.publicKeyPem),
     Buffer.from(signatureSegment, 'base64url'),
   );
   if (!signatureOk) {
     throw new A2ADelegationTokenError('JWT signature is invalid');
   }
+  const claims = parseClaims(
+    decodeBase64UrlJson(payloadSegment, 'JWT payload'),
+  );
 
   const nowSeconds = Math.trunc((input.now ?? new Date()).getTime() / 1000);
   if (claims.nbf > nowSeconds) {
@@ -505,7 +525,10 @@ export function verifyA2ADelegationToken(
   if (claims.exp <= nowSeconds) {
     throw new A2ADelegationTokenError('JWT has expired');
   }
-  if (input.audience && claims.aud !== normalizeAudience(input.audience)) {
+  if (
+    input.audience &&
+    claims.aud !== normalizeTokenString(input.audience, 'audience')
+  ) {
     throw new A2ADelegationTokenError('JWT audience does not match');
   }
   assertScope(claims, input.requiredScope);

--- a/src/a2a/delegation-token.ts
+++ b/src/a2a/delegation-token.ts
@@ -1,0 +1,532 @@
+import {
+  createHash,
+  createPrivateKey,
+  createPublicKey,
+  generateKeyPairSync,
+  randomUUID,
+  sign,
+  verify,
+} from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+import {
+  isCanonicalAgentIdentity,
+  resolveLocalInstanceId,
+} from '../identity/agent-id.js';
+import { resolveA2AAgentId } from './identity.js';
+import { isRecord } from './utils.js';
+
+export const A2A_DELEGATION_TOKEN_TTL_SECONDS = 300;
+export const A2A_DELEGATION_TOKEN_KEYPAIR_SCHEMA_VERSION = 1;
+export const A2A_DELEGATION_TOKEN_REVOCATION_SCHEMA_VERSION = 1;
+export const A2A_DELEGATION_TOKEN_ISSUER = 'hybridclaw';
+
+export interface A2ADelegationTokenKeyPair {
+  schemaVersion: typeof A2A_DELEGATION_TOKEN_KEYPAIR_SCHEMA_VERSION;
+  keyId: string;
+  algorithm: 'Ed25519';
+  publicKeyPem: string;
+  privateKeyPem: string;
+  instanceId: string;
+  createdAt: string;
+}
+
+export interface A2ADelegationTokenClaims {
+  iss: typeof A2A_DELEGATION_TOKEN_ISSUER;
+  sub: string;
+  aud: string;
+  jti: string;
+  iat: number;
+  nbf: number;
+  exp: number;
+  sender_agent_id: string;
+  target_agent_id: string;
+  scope: string[];
+  parent_run_id: string;
+  message_id?: string;
+  thread_id?: string;
+}
+
+export interface SignA2ADelegationTokenInput {
+  senderAgentId: string;
+  targetAgentId: string;
+  audience: string;
+  scope: string | string[];
+  parentRunId: string;
+  jwtId: string;
+  messageId?: string;
+  threadId?: string;
+  now?: Date;
+  expiresInSeconds?: number;
+  keyPair?: A2ADelegationTokenKeyPair;
+}
+
+export interface VerifyA2ADelegationTokenInput {
+  token: string;
+  publicKeyPem: string;
+  audience?: string;
+  requiredScope?: string | string[];
+  senderAgentId?: string;
+  targetAgentId?: string;
+  now?: Date;
+  revocationRootDir?: string;
+}
+
+export interface A2ADelegationTokenRevocation {
+  schemaVersion: typeof A2A_DELEGATION_TOKEN_REVOCATION_SCHEMA_VERSION;
+  jwtId: string;
+  revokedAt: string;
+}
+
+export class A2ADelegationTokenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'A2ADelegationTokenError';
+  }
+}
+
+function delegationKeyPairPath(): string {
+  return path.join(
+    DEFAULT_RUNTIME_HOME_DIR,
+    'identity',
+    'delegation-token-keypair.json',
+  );
+}
+
+function delegationRevocationRootDir(): string {
+  return path.join(DEFAULT_RUNTIME_HOME_DIR, 'a2a', 'delegation-revocations');
+}
+
+function base64UrlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString('base64url');
+}
+
+function decodeBase64UrlJson(segment: string, label: string): unknown {
+  try {
+    return JSON.parse(Buffer.from(segment, 'base64url').toString('utf-8'));
+  } catch {
+    throw new A2ADelegationTokenError(`${label} is not valid base64url JSON`);
+  }
+}
+
+function normalizeTokenString(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new A2ADelegationTokenError(`${label} is required`);
+  }
+  if (/[\p{Cc}\s]/u.test(normalized)) {
+    throw new A2ADelegationTokenError(
+      `${label} must not contain whitespace or control characters`,
+    );
+  }
+  return normalized;
+}
+
+function normalizeAudience(value: string): string {
+  return normalizeTokenString(value, 'audience');
+}
+
+function normalizeParentRunId(value: string): string {
+  return normalizeTokenString(value, 'parentRunId');
+}
+
+function normalizeJwtId(value: string): string {
+  return normalizeTokenString(value, 'jwtId');
+}
+
+function normalizeScope(scope: string | string[]): string[] {
+  const rawScopes = Array.isArray(scope) ? scope : [scope];
+  const normalizedScopes = Array.from(
+    new Set(rawScopes.map((entry) => normalizeTokenString(entry, 'scope'))),
+  );
+  if (normalizedScopes.length === 0) {
+    throw new A2ADelegationTokenError('scope is required');
+  }
+  return normalizedScopes;
+}
+
+function normalizeAgentIdForToken(agentId: string): string {
+  const normalized = agentId.trim();
+  if (isCanonicalAgentIdentity(normalized)) return normalized.toLowerCase();
+  return resolveA2AAgentId(normalized);
+}
+
+function keyIdForPublicKey(publicKeyPem: string): string {
+  return createHash('sha256')
+    .update(publicKeyPem)
+    .digest('base64url')
+    .slice(0, 32);
+}
+
+function validateKeyPair(value: unknown): A2ADelegationTokenKeyPair {
+  if (!isRecord(value)) {
+    throw new A2ADelegationTokenError('delegation keypair must be an object');
+  }
+  const keyPair = value as Partial<A2ADelegationTokenKeyPair>;
+  if (keyPair.schemaVersion !== A2A_DELEGATION_TOKEN_KEYPAIR_SCHEMA_VERSION) {
+    throw new A2ADelegationTokenError('unsupported delegation keypair schema');
+  }
+  if (keyPair.algorithm !== 'Ed25519') {
+    throw new A2ADelegationTokenError(
+      'delegation keypair algorithm must be Ed25519',
+    );
+  }
+  for (const field of [
+    'keyId',
+    'publicKeyPem',
+    'privateKeyPem',
+    'instanceId',
+    'createdAt',
+  ] as const) {
+    if (typeof keyPair[field] !== 'string' || !keyPair[field]?.trim()) {
+      throw new A2ADelegationTokenError(`${field} is required`);
+    }
+  }
+  const keyId = keyPair.keyId as string;
+  const publicKeyPem = keyPair.publicKeyPem as string;
+  const privateKeyPem = keyPair.privateKeyPem as string;
+  const instanceId = keyPair.instanceId as string;
+  const createdAt = keyPair.createdAt as string;
+  const publicKey = createPublicKey(publicKeyPem);
+  createPrivateKey(privateKeyPem);
+  const expectedKeyId = keyIdForPublicKey(
+    publicKey.export({ format: 'pem', type: 'spki' }).toString(),
+  );
+  if (keyId !== expectedKeyId) {
+    throw new A2ADelegationTokenError(
+      'delegation keypair keyId does not match public key',
+    );
+  }
+  return {
+    schemaVersion: A2A_DELEGATION_TOKEN_KEYPAIR_SCHEMA_VERSION,
+    keyId,
+    algorithm: 'Ed25519',
+    publicKeyPem,
+    privateKeyPem,
+    instanceId,
+    createdAt,
+  };
+}
+
+function readKeyPair(keyPairPath: string): A2ADelegationTokenKeyPair | null {
+  try {
+    return validateKeyPair(JSON.parse(fs.readFileSync(keyPairPath, 'utf-8')));
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err?.code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+function generateDelegationKeyPair(now: Date): A2ADelegationTokenKeyPair {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  const publicKeyPem = publicKey
+    .export({ format: 'pem', type: 'spki' })
+    .toString();
+  const privateKeyPem = privateKey
+    .export({ format: 'pem', type: 'pkcs8' })
+    .toString();
+  return {
+    schemaVersion: A2A_DELEGATION_TOKEN_KEYPAIR_SCHEMA_VERSION,
+    keyId: keyIdForPublicKey(publicKeyPem),
+    algorithm: 'Ed25519',
+    publicKeyPem,
+    privateKeyPem,
+    instanceId: resolveLocalInstanceId(),
+    createdAt: now.toISOString(),
+  };
+}
+
+function writeNewKeyPair(
+  keyPairPath: string,
+  keyPair: A2ADelegationTokenKeyPair,
+): void {
+  const keyPairDir = path.dirname(keyPairPath);
+  fs.mkdirSync(keyPairDir, { recursive: true });
+  const tempPath = path.join(keyPairDir, `.delegation-keypair-${randomUUID()}`);
+  try {
+    fs.writeFileSync(tempPath, `${JSON.stringify(keyPair, null, 2)}\n`, {
+      encoding: 'utf-8',
+      flag: 'wx',
+      mode: 0o600,
+    });
+    fs.linkSync(tempPath, keyPairPath);
+    fs.chmodSync(keyPairPath, 0o600);
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err?.code !== 'EEXIST') throw error;
+  } finally {
+    fs.rmSync(tempPath, { force: true });
+  }
+}
+
+export function getOrCreateA2ADelegationTokenKeyPair(
+  options: { keyPairPath?: string; now?: Date } = {},
+): A2ADelegationTokenKeyPair {
+  const keyPairPath = options.keyPairPath ?? delegationKeyPairPath();
+  const existing = readKeyPair(keyPairPath);
+  if (existing) return existing;
+
+  const generated = generateDelegationKeyPair(options.now ?? new Date());
+  writeNewKeyPair(keyPairPath, generated);
+  return readKeyPair(keyPairPath) ?? generated;
+}
+
+function assertNumericDate(
+  claims: Record<string, unknown>,
+  field: 'iat' | 'nbf' | 'exp',
+): number {
+  const value = claims[field];
+  if (!Number.isSafeInteger(value)) {
+    throw new A2ADelegationTokenError(`${field} must be an integer timestamp`);
+  }
+  return value as number;
+}
+
+function assertStringClaim(
+  claims: Record<string, unknown>,
+  field:
+    | 'iss'
+    | 'sub'
+    | 'aud'
+    | 'jti'
+    | 'sender_agent_id'
+    | 'target_agent_id'
+    | 'parent_run_id',
+): string {
+  const value = claims[field];
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new A2ADelegationTokenError(`${field} is required`);
+  }
+  return value.trim();
+}
+
+function parseClaims(payload: unknown): A2ADelegationTokenClaims {
+  if (!isRecord(payload)) {
+    throw new A2ADelegationTokenError('JWT payload must be an object');
+  }
+  const iss = assertStringClaim(payload, 'iss');
+  if (iss !== A2A_DELEGATION_TOKEN_ISSUER) {
+    throw new A2ADelegationTokenError('JWT issuer is not trusted');
+  }
+  const scope = payload.scope;
+  if (
+    !Array.isArray(scope) ||
+    scope.length === 0 ||
+    !scope.every((entry) => typeof entry === 'string' && !!entry.trim())
+  ) {
+    throw new A2ADelegationTokenError('scope must be a non-empty string array');
+  }
+  const claims: A2ADelegationTokenClaims = {
+    iss: A2A_DELEGATION_TOKEN_ISSUER,
+    sub: assertStringClaim(payload, 'sub'),
+    aud: assertStringClaim(payload, 'aud'),
+    jti: assertStringClaim(payload, 'jti'),
+    iat: assertNumericDate(payload, 'iat'),
+    nbf: assertNumericDate(payload, 'nbf'),
+    exp: assertNumericDate(payload, 'exp'),
+    sender_agent_id: assertStringClaim(payload, 'sender_agent_id'),
+    target_agent_id: assertStringClaim(payload, 'target_agent_id'),
+    scope: scope.map((entry) => entry.trim()),
+    parent_run_id: assertStringClaim(payload, 'parent_run_id'),
+    ...(typeof payload.message_id === 'string' && payload.message_id.trim()
+      ? { message_id: payload.message_id.trim() }
+      : {}),
+    ...(typeof payload.thread_id === 'string' && payload.thread_id.trim()
+      ? { thread_id: payload.thread_id.trim() }
+      : {}),
+  };
+  if (claims.sub !== claims.sender_agent_id) {
+    throw new A2ADelegationTokenError('JWT sub must match sender_agent_id');
+  }
+  if (!isCanonicalAgentIdentity(claims.sender_agent_id)) {
+    throw new A2ADelegationTokenError('sender_agent_id must be canonical');
+  }
+  if (!isCanonicalAgentIdentity(claims.target_agent_id)) {
+    throw new A2ADelegationTokenError('target_agent_id must be canonical');
+  }
+  return claims;
+}
+
+export function signA2ADelegationToken(
+  input: SignA2ADelegationTokenInput,
+): string {
+  const keyPair = input.keyPair ?? getOrCreateA2ADelegationTokenKeyPair();
+  const issuedAt = Math.trunc((input.now ?? new Date()).getTime() / 1000);
+  const expiresInSeconds =
+    input.expiresInSeconds && input.expiresInSeconds > 0
+      ? Math.trunc(input.expiresInSeconds)
+      : A2A_DELEGATION_TOKEN_TTL_SECONDS;
+  const senderAgentId = normalizeAgentIdForToken(input.senderAgentId);
+  const targetAgentId = normalizeAgentIdForToken(input.targetAgentId);
+  const claims: A2ADelegationTokenClaims = {
+    iss: A2A_DELEGATION_TOKEN_ISSUER,
+    sub: senderAgentId,
+    aud: normalizeAudience(input.audience),
+    jti: normalizeJwtId(input.jwtId),
+    iat: issuedAt,
+    nbf: issuedAt,
+    exp: issuedAt + expiresInSeconds,
+    sender_agent_id: senderAgentId,
+    target_agent_id: targetAgentId,
+    scope: normalizeScope(input.scope),
+    parent_run_id: normalizeParentRunId(input.parentRunId),
+    ...(input.messageId
+      ? { message_id: normalizeTokenString(input.messageId, 'messageId') }
+      : {}),
+    ...(input.threadId
+      ? { thread_id: normalizeTokenString(input.threadId, 'threadId') }
+      : {}),
+  };
+  const header = base64UrlJson({
+    alg: 'EdDSA',
+    typ: 'JWT',
+    kid: keyPair.keyId,
+  });
+  const payload = base64UrlJson(claims);
+  const signingInput = `${header}.${payload}`;
+  const signature = sign(
+    null,
+    Buffer.from(signingInput),
+    createPrivateKey(keyPair.privateKeyPem),
+  ).toString('base64url');
+  return `${signingInput}.${signature}`;
+}
+
+export function decodeA2ADelegationTokenClaims(
+  token: string,
+): A2ADelegationTokenClaims {
+  const parts = token.split('.');
+  if (parts.length !== 3 || parts.some((part) => !part)) {
+    throw new A2ADelegationTokenError('JWT must contain three segments');
+  }
+  return parseClaims(decodeBase64UrlJson(parts[1] || '', 'JWT payload'));
+}
+
+function revocationAssetPath(jwtId: string, rootDir: string): string {
+  return path.join(
+    rootDir,
+    `${encodeURIComponent(normalizeJwtId(jwtId))}.json`,
+  );
+}
+
+export function revokeA2ADelegationTokenId(
+  jwtId: string,
+  options: {
+    revokedAt?: Date;
+    revocationRootDir?: string;
+  } = {},
+): A2ADelegationTokenRevocation {
+  const normalizedJwtId = normalizeJwtId(jwtId);
+  const revocation: A2ADelegationTokenRevocation = {
+    schemaVersion: A2A_DELEGATION_TOKEN_REVOCATION_SCHEMA_VERSION,
+    jwtId: normalizedJwtId,
+    revokedAt: (options.revokedAt ?? new Date()).toISOString(),
+  };
+  const rootDir = options.revocationRootDir ?? delegationRevocationRootDir();
+  fs.mkdirSync(rootDir, { recursive: true });
+  fs.writeFileSync(
+    revocationAssetPath(normalizedJwtId, rootDir),
+    `${JSON.stringify(revocation, null, 2)}\n`,
+    {
+      encoding: 'utf-8',
+      mode: 0o600,
+    },
+  );
+  return revocation;
+}
+
+export function isA2ADelegationTokenRevoked(
+  jwtId: string,
+  options: { revocationRootDir?: string } = {},
+): boolean {
+  return fs.existsSync(
+    revocationAssetPath(
+      jwtId,
+      options.revocationRootDir ?? delegationRevocationRootDir(),
+    ),
+  );
+}
+
+function assertTokenHeader(header: unknown): void {
+  if (!isRecord(header)) {
+    throw new A2ADelegationTokenError('JWT header must be an object');
+  }
+  if (header.alg !== 'EdDSA') {
+    throw new A2ADelegationTokenError('JWT alg must be EdDSA');
+  }
+  if (header.typ !== undefined && header.typ !== 'JWT') {
+    throw new A2ADelegationTokenError('JWT typ must be JWT when provided');
+  }
+}
+
+function assertScope(
+  claims: A2ADelegationTokenClaims,
+  requiredScope: string | string[] | undefined,
+): void {
+  if (!requiredScope) return;
+  const requiredScopes = normalizeScope(requiredScope);
+  for (const scope of requiredScopes) {
+    if (!claims.scope.includes(scope)) {
+      throw new A2ADelegationTokenError(`JWT missing required scope: ${scope}`);
+    }
+  }
+}
+
+export function verifyA2ADelegationToken(
+  input: VerifyA2ADelegationTokenInput,
+): A2ADelegationTokenClaims {
+  const parts = input.token.split('.');
+  if (parts.length !== 3 || parts.some((part) => !part)) {
+    throw new A2ADelegationTokenError('JWT must contain three segments');
+  }
+  const [headerSegment = '', payloadSegment = '', signatureSegment = ''] =
+    parts;
+  assertTokenHeader(decodeBase64UrlJson(headerSegment, 'JWT header'));
+  const claims = parseClaims(
+    decodeBase64UrlJson(payloadSegment, 'JWT payload'),
+  );
+  const signatureOk = verify(
+    null,
+    Buffer.from(`${headerSegment}.${payloadSegment}`),
+    createPublicKey(input.publicKeyPem),
+    Buffer.from(signatureSegment, 'base64url'),
+  );
+  if (!signatureOk) {
+    throw new A2ADelegationTokenError('JWT signature is invalid');
+  }
+
+  const nowSeconds = Math.trunc((input.now ?? new Date()).getTime() / 1000);
+  if (claims.nbf > nowSeconds) {
+    throw new A2ADelegationTokenError('JWT is not active yet');
+  }
+  if (claims.exp <= nowSeconds) {
+    throw new A2ADelegationTokenError('JWT has expired');
+  }
+  if (input.audience && claims.aud !== normalizeAudience(input.audience)) {
+    throw new A2ADelegationTokenError('JWT audience does not match');
+  }
+  assertScope(claims, input.requiredScope);
+  if (
+    input.senderAgentId &&
+    claims.sender_agent_id !== normalizeAgentIdForToken(input.senderAgentId)
+  ) {
+    throw new A2ADelegationTokenError('JWT sender does not match');
+  }
+  if (
+    input.targetAgentId &&
+    claims.target_agent_id !== normalizeAgentIdForToken(input.targetAgentId)
+  ) {
+    throw new A2ADelegationTokenError('JWT target does not match');
+  }
+  if (
+    isA2ADelegationTokenRevoked(claims.jti, {
+      revocationRootDir: input.revocationRootDir,
+    })
+  ) {
+    throw new A2ADelegationTokenError('JWT has been revoked');
+  }
+  return claims;
+}

--- a/src/a2a/inbound-pipeline.ts
+++ b/src/a2a/inbound-pipeline.ts
@@ -3,7 +3,7 @@ import { type A2ADeliveryConfirmation, sendMessage } from './runtime.js';
 
 export interface A2AInboundPipelineMeta {
   actor: string;
-  source: 'webhook';
+  source: 'a2a' | 'webhook';
   sessionId?: string;
   auditRunId?: string;
 }

--- a/src/a2a/trust-ledger.ts
+++ b/src/a2a/trust-ledger.ts
@@ -1,3 +1,4 @@
+import { createPublicKey } from 'node:crypto';
 import path from 'node:path';
 
 import {
@@ -15,13 +16,21 @@ import {
 } from './webhook-outbound.js';
 
 export const A2A_TRUST_LEDGER_DEFAULT_WEBHOOK_RATE_LIMIT_PER_MINUTE = 60;
+export const A2A_TRUST_LEDGER_DEFAULT_A2A_RATE_LIMIT_PER_MINUTE = 60;
 
 const TRUSTED_WEBHOOK_PEER_SCHEMA_VERSION = 1;
+const TRUSTED_A2A_PEER_SCHEMA_VERSION = 1;
 const TRUSTED_WEBHOOK_PEER_ASSET_PREFIX = path.join(
   DEFAULT_RUNTIME_HOME_DIR,
   'a2a',
   'trust-ledger',
   'webhook',
+);
+const TRUSTED_A2A_PEER_ASSET_PREFIX = path.join(
+  DEFAULT_RUNTIME_HOME_DIR,
+  'a2a',
+  'trust-ledger',
+  'a2a',
 );
 const PEER_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 
@@ -48,6 +57,23 @@ export interface UpsertA2ATrustedWebhookPeerInput {
   rateLimitPerMinute?: number;
 }
 
+export interface A2ATrustedA2APeer {
+  schemaVersion: typeof TRUSTED_A2A_PEER_SCHEMA_VERSION;
+  peerId: string;
+  senderAgentId: string;
+  publicKeyPem: string;
+  rateLimitPerMinute: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpsertA2ATrustedA2APeerInput {
+  peerId: string;
+  senderAgentId: string;
+  publicKeyPem: string;
+  rateLimitPerMinute?: number;
+}
+
 export function normalizeA2APeerId(peerId: string): string {
   const normalized = peerId.trim();
   if (!PEER_ID_PATTERN.test(normalized)) {
@@ -71,6 +97,13 @@ function trustedWebhookPeerAssetPath(peerId: string): string {
   );
 }
 
+function trustedA2APeerAssetPath(peerId: string): string {
+  return path.join(
+    TRUSTED_A2A_PEER_ASSET_PREFIX,
+    `${encodeURIComponent(normalizeA2APeerId(peerId))}.json`,
+  );
+}
+
 function normalizeSenderAgentId(senderAgentId: string): string {
   const normalized = senderAgentId.trim();
   const kind = classifyA2AAgentId(normalized);
@@ -79,6 +112,31 @@ function normalizeSenderAgentId(senderAgentId: string): string {
   throw new A2AEnvelopeValidationError([
     'senderAgentId must be a local agent id or canonical agent id (agent-slug@user@instance-id)',
   ]);
+}
+
+function normalizeCanonicalSenderAgentId(senderAgentId: string): string {
+  const normalized = normalizeSenderAgentId(senderAgentId);
+  if (classifyA2AAgentId(normalized) !== 'canonical') {
+    throw new A2AEnvelopeValidationError([
+      'senderAgentId must be a canonical agent id (agent-slug@user@instance-id)',
+    ]);
+  }
+  return normalized.toLowerCase();
+}
+
+function normalizePublicKeyPem(value: unknown): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new A2AEnvelopeValidationError(['publicKeyPem is required']);
+  }
+  try {
+    return createPublicKey(value)
+      .export({ format: 'pem', type: 'spki' })
+      .toString();
+  } catch {
+    throw new A2AEnvelopeValidationError([
+      'publicKeyPem must be a valid public key',
+    ]);
+  }
 }
 
 function normalizeSecretRef(value: unknown): SecretRef {
@@ -190,6 +248,35 @@ function parseTrustedWebhookPeer(raw: string): A2ATrustedWebhookPeer | null {
   }
 }
 
+function parseTrustedA2APeer(raw: string): A2ATrustedA2APeer | null {
+  try {
+    const parsed = JSON.parse(raw) as A2ATrustedA2APeer;
+    if (parsed.schemaVersion !== TRUSTED_A2A_PEER_SCHEMA_VERSION) {
+      return null;
+    }
+    return {
+      schemaVersion: TRUSTED_A2A_PEER_SCHEMA_VERSION,
+      peerId: normalizeA2APeerId(parsed.peerId),
+      senderAgentId: normalizeCanonicalSenderAgentId(parsed.senderAgentId),
+      publicKeyPem: normalizePublicKeyPem(parsed.publicKeyPem),
+      rateLimitPerMinute: normalizePositiveInteger(
+        parsed.rateLimitPerMinute,
+        A2A_TRUST_LEDGER_DEFAULT_A2A_RATE_LIMIT_PER_MINUTE,
+      ),
+      createdAt:
+        typeof parsed.createdAt === 'string' && parsed.createdAt
+          ? parsed.createdAt
+          : new Date(0).toISOString(),
+      updatedAt:
+        typeof parsed.updatedAt === 'string' && parsed.updatedAt
+          ? parsed.updatedAt
+          : new Date(0).toISOString(),
+    };
+  } catch {
+    return null;
+  }
+}
+
 export function upsertA2ATrustedWebhookPeer(
   input: UpsertA2ATrustedWebhookPeerInput,
   now = new Date(),
@@ -231,6 +318,40 @@ export function upsertA2ATrustedWebhookPeer(
   return peer;
 }
 
+export function upsertA2ATrustedA2APeer(
+  input: UpsertA2ATrustedA2APeerInput,
+  now = new Date(),
+): A2ATrustedA2APeer {
+  const peerId = normalizeA2APeerId(input.peerId);
+  const existing = getA2ATrustedA2APeer(peerId);
+  const updatedAt = now.toISOString();
+  const peer: A2ATrustedA2APeer = {
+    schemaVersion: TRUSTED_A2A_PEER_SCHEMA_VERSION,
+    peerId,
+    senderAgentId: normalizeCanonicalSenderAgentId(input.senderAgentId),
+    publicKeyPem: normalizePublicKeyPem(input.publicKeyPem),
+    rateLimitPerMinute: normalizePositiveInteger(
+      input.rateLimitPerMinute,
+      A2A_TRUST_LEDGER_DEFAULT_A2A_RATE_LIMIT_PER_MINUTE,
+    ),
+    createdAt: existing?.createdAt || updatedAt,
+    updatedAt,
+  };
+  syncRuntimeAssetRevisionState(
+    'a2a',
+    trustedA2APeerAssetPath(peerId),
+    {
+      route: `a2a.trust-ledger.a2a#${peerId}`,
+      source: 'a2a-trust-ledger',
+    },
+    {
+      exists: true,
+      content: JSON.stringify(peer),
+    },
+  );
+  return peer;
+}
+
 export function getA2ATrustedWebhookPeer(
   peerId: string,
 ): A2ATrustedWebhookPeer | null {
@@ -241,6 +362,14 @@ export function getA2ATrustedWebhookPeer(
   return state ? parseTrustedWebhookPeer(state.content) : null;
 }
 
+export function getA2ATrustedA2APeer(peerId: string): A2ATrustedA2APeer | null {
+  const state = getRuntimeAssetRevisionState(
+    'a2a',
+    trustedA2APeerAssetPath(peerId),
+  );
+  return state ? parseTrustedA2APeer(state.content) : null;
+}
+
 export function listA2ATrustedWebhookPeers(): A2ATrustedWebhookPeer[] {
   return listRuntimeAssetRevisionStates('a2a', {
     assetPathPrefix: TRUSTED_WEBHOOK_PEER_ASSET_PREFIX,
@@ -248,4 +377,25 @@ export function listA2ATrustedWebhookPeers(): A2ATrustedWebhookPeer[] {
     .map((state) => parseTrustedWebhookPeer(state.content))
     .filter((peer): peer is A2ATrustedWebhookPeer => peer !== null)
     .sort((left, right) => left.peerId.localeCompare(right.peerId));
+}
+
+export function listA2ATrustedA2APeers(): A2ATrustedA2APeer[] {
+  return listRuntimeAssetRevisionStates('a2a', {
+    assetPathPrefix: TRUSTED_A2A_PEER_ASSET_PREFIX,
+  })
+    .map((state) => parseTrustedA2APeer(state.content))
+    .filter((peer): peer is A2ATrustedA2APeer => peer !== null)
+    .sort((left, right) => left.peerId.localeCompare(right.peerId));
+}
+
+export function getA2ATrustedA2APeerBySender(
+  senderAgentId: string,
+): A2ATrustedA2APeer | null {
+  const normalizedSenderAgentId =
+    normalizeCanonicalSenderAgentId(senderAgentId);
+  return (
+    listA2ATrustedA2APeers().find(
+      (peer) => peer.senderAgentId === normalizedSenderAgentId,
+    ) ?? null
+  );
 }

--- a/src/a2a/trust-ledger.ts
+++ b/src/a2a/trust-ledger.ts
@@ -9,6 +9,7 @@ import {
 import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
 import { parseSecretInput, type SecretRef } from '../security/secret-refs.js';
 import { A2AEnvelopeValidationError, classifyA2AAgentId } from './envelope.js';
+import { normalizePositiveInteger } from './utils.js';
 import {
   WEBHOOK_BODY_VERSION,
   WEBHOOK_REPLAY_WINDOW_MS,
@@ -16,7 +17,6 @@ import {
 } from './webhook-outbound.js';
 
 export const A2A_TRUST_LEDGER_DEFAULT_WEBHOOK_RATE_LIMIT_PER_MINUTE = 60;
-export const A2A_TRUST_LEDGER_DEFAULT_A2A_RATE_LIMIT_PER_MINUTE = 60;
 
 const TRUSTED_WEBHOOK_PEER_SCHEMA_VERSION = 1;
 const TRUSTED_A2A_PEER_SCHEMA_VERSION = 1;
@@ -33,6 +33,9 @@ const TRUSTED_A2A_PEER_ASSET_PREFIX = path.join(
   'a2a',
 );
 const PEER_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const EPOCH_ISO = new Date(0).toISOString();
+
+let trustedA2APeersBySenderCache: Map<string, A2ATrustedA2APeer> | null = null;
 
 export interface A2ATrustedWebhookPeer {
   schemaVersion: typeof TRUSTED_WEBHOOK_PEER_SCHEMA_VERSION;
@@ -62,7 +65,6 @@ export interface A2ATrustedA2APeer {
   peerId: string;
   senderAgentId: string;
   publicKeyPem: string;
-  rateLimitPerMinute: number;
   createdAt: string;
   updatedAt: string;
 }
@@ -71,7 +73,6 @@ export interface UpsertA2ATrustedA2APeerInput {
   peerId: string;
   senderAgentId: string;
   publicKeyPem: string;
-  rateLimitPerMinute?: number;
 }
 
 export function normalizeA2APeerId(peerId: string): string {
@@ -82,12 +83,6 @@ export function normalizeA2APeerId(peerId: string): string {
     ]);
   }
   return normalized;
-}
-
-function normalizePositiveInteger(value: unknown, fallback: number): number {
-  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0
-    ? value
-    : fallback;
 }
 
 function trustedWebhookPeerAssetPath(peerId: string): string {
@@ -173,6 +168,10 @@ function normalizeOptionalHttpHeaderName(value: unknown): string | undefined {
   return normalized;
 }
 
+function parseTimestampOr(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value ? value : fallback;
+}
+
 function normalizeWebhookVersion(value: unknown): string | undefined {
   if (value === undefined) return undefined;
   if (typeof value !== 'string') {
@@ -234,14 +233,8 @@ function parseTrustedWebhookPeer(raw: string): A2ATrustedWebhookPeer | null {
         parsed.rateLimitPerMinute,
         A2A_TRUST_LEDGER_DEFAULT_WEBHOOK_RATE_LIMIT_PER_MINUTE,
       ),
-      createdAt:
-        typeof parsed.createdAt === 'string' && parsed.createdAt
-          ? parsed.createdAt
-          : new Date(0).toISOString(),
-      updatedAt:
-        typeof parsed.updatedAt === 'string' && parsed.updatedAt
-          ? parsed.updatedAt
-          : new Date(0).toISOString(),
+      createdAt: parseTimestampOr(parsed.createdAt, EPOCH_ISO),
+      updatedAt: parseTimestampOr(parsed.updatedAt, EPOCH_ISO),
     };
   } catch {
     return null;
@@ -259,18 +252,8 @@ function parseTrustedA2APeer(raw: string): A2ATrustedA2APeer | null {
       peerId: normalizeA2APeerId(parsed.peerId),
       senderAgentId: normalizeCanonicalSenderAgentId(parsed.senderAgentId),
       publicKeyPem: normalizePublicKeyPem(parsed.publicKeyPem),
-      rateLimitPerMinute: normalizePositiveInteger(
-        parsed.rateLimitPerMinute,
-        A2A_TRUST_LEDGER_DEFAULT_A2A_RATE_LIMIT_PER_MINUTE,
-      ),
-      createdAt:
-        typeof parsed.createdAt === 'string' && parsed.createdAt
-          ? parsed.createdAt
-          : new Date(0).toISOString(),
-      updatedAt:
-        typeof parsed.updatedAt === 'string' && parsed.updatedAt
-          ? parsed.updatedAt
-          : new Date(0).toISOString(),
+      createdAt: parseTimestampOr(parsed.createdAt, EPOCH_ISO),
+      updatedAt: parseTimestampOr(parsed.updatedAt, EPOCH_ISO),
     };
   } catch {
     return null;
@@ -330,10 +313,6 @@ export function upsertA2ATrustedA2APeer(
     peerId,
     senderAgentId: normalizeCanonicalSenderAgentId(input.senderAgentId),
     publicKeyPem: normalizePublicKeyPem(input.publicKeyPem),
-    rateLimitPerMinute: normalizePositiveInteger(
-      input.rateLimitPerMinute,
-      A2A_TRUST_LEDGER_DEFAULT_A2A_RATE_LIMIT_PER_MINUTE,
-    ),
     createdAt: existing?.createdAt || updatedAt,
     updatedAt,
   };
@@ -349,6 +328,7 @@ export function upsertA2ATrustedA2APeer(
       content: JSON.stringify(peer),
     },
   );
+  trustedA2APeersBySenderCache = null;
   return peer;
 }
 
@@ -388,14 +368,18 @@ export function listA2ATrustedA2APeers(): A2ATrustedA2APeer[] {
     .sort((left, right) => left.peerId.localeCompare(right.peerId));
 }
 
+function trustedA2APeersBySender(): Map<string, A2ATrustedA2APeer> {
+  if (trustedA2APeersBySenderCache) return trustedA2APeersBySenderCache;
+  trustedA2APeersBySenderCache = new Map(
+    listA2ATrustedA2APeers().map((peer) => [peer.senderAgentId, peer]),
+  );
+  return trustedA2APeersBySenderCache;
+}
+
 export function getA2ATrustedA2APeerBySender(
   senderAgentId: string,
 ): A2ATrustedA2APeer | null {
   const normalizedSenderAgentId =
     normalizeCanonicalSenderAgentId(senderAgentId);
-  return (
-    listA2ATrustedA2APeers().find(
-      (peer) => peer.senderAgentId === normalizedSenderAgentId,
-    ) ?? null
-  );
+  return trustedA2APeersBySender().get(normalizedSenderAgentId) ?? null;
 }

--- a/src/a2a/utils.ts
+++ b/src/a2a/utils.ts
@@ -11,11 +11,12 @@ export function normalizeTransportString(transport: string): string {
 }
 
 export function normalizePositiveInteger(
-  value: number | undefined,
+  value: unknown,
   fallback: number,
 ): number {
-  if (!Number.isFinite(value)) return fallback;
-  return Math.max(1, Math.trunc(value as number));
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0
+    ? value
+    : fallback;
 }
 
 export function isLoopbackHostname(hostname: string): boolean {

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import http, { type IncomingMessage, type ServerResponse } from 'node:http';
 import path from 'node:path';
+import { handleA2AJsonRpcInbound } from '../a2a/a2a-inbound.js';
 import {
   handleA2AWebhookInbound,
   parseA2AWebhookInboundPath,
@@ -4241,6 +4242,10 @@ export function startGatewayHttpServer(): GatewayHttpServer {
 
     if (parseA2AWebhookInboundPath(pathname)) {
       dispatchWebhookRoute(res, () => handleA2AWebhookInbound(req, res, url));
+      return;
+    }
+    if (pathname === '/a2a') {
+      dispatchWebhookRoute(res, () => handleA2AJsonRpcInbound(req, res, url));
       return;
     }
 

--- a/tests/a2a-inbound.test.ts
+++ b/tests/a2a-inbound.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from 'vitest';
+
+import { encodeA2AJsonRpcRequest } from '../src/a2a/a2a-json-rpc.ts';
+import { setupA2AWebhookTestEnv } from './helpers/a2a-webhook-fixtures.ts';
+
+setupA2AWebhookTestEnv('hc-a2a-inbound-');
+
+function inboundEnvelope(id: string) {
+  return {
+    id,
+    sender_agent_id: 'remote@team@peer-instance',
+    recipient_agent_id: 'main',
+    thread_id: 'thread-a2a-inbound',
+    intent: 'chat' as const,
+    content: `Inbound A2A payload ${id}`,
+    created_at: '2026-05-01T10:00:00.000Z',
+  };
+}
+
+describe('A2A JSON-RPC inbound adapter', () => {
+  test('accepts a signed delegation token and delivers to the local inbox', async () => {
+    process.env.HYBRIDCLAW_INSTANCE_ID = 'local-dev';
+    const { initDatabase, getRecentStructuredAuditForSession } = await import(
+      '../src/memory/db.ts'
+    );
+    const runtimeConfig = await import('../src/config/runtime-config.ts');
+    const runtime = await import('../src/a2a/runtime.ts');
+    const inbound = await import('../src/a2a/a2a-inbound.ts');
+    const outbound = await import('../src/a2a/a2a-outbound.ts');
+
+    initDatabase({ quiet: true });
+    runtimeConfig.updateRuntimeConfig((draft) => {
+      draft.agents.list = [{ id: 'main', owner: 'team', role: 'lead' }];
+    });
+
+    const keyPair = outbound.getOrCreateA2ADelegationTokenKeyPair({
+      now: new Date('2030-01-01T00:00:00.000Z'),
+    });
+    inbound.upsertA2ATrustedA2APeer({
+      peerId: 'peer-prod',
+      senderAgentId: 'remote@team@peer-instance',
+      publicKeyPem: keyPair.publicKeyPem,
+    });
+
+    const envelope = inboundEnvelope('msg-inbound-a2a-1');
+    const rawBody = JSON.stringify(
+      encodeA2AJsonRpcRequest(envelope, {
+        url: 'http://localhost/a2a',
+      }),
+    );
+    const token = outbound.signA2ADelegationToken({
+      keyPair,
+      senderAgentId: 'remote@team@peer-instance',
+      targetAgentId: 'main@team@local-dev',
+      audience: 'http://localhost/a2a',
+      scope: outbound.A2A_MESSAGE_SEND_SCOPE,
+      parentRunId: 'run-remote-parent',
+      jwtId: 'msg-inbound-a2a-1',
+      messageId: 'msg-inbound-a2a-1',
+      threadId: 'thread-a2a-inbound',
+      now: new Date('2030-01-01T00:00:00.000Z'),
+    });
+
+    const result = inbound.acceptA2AJsonRpcInboundRequest({
+      rawBody,
+      authorization: `Bearer ${token}`,
+      audience: 'http://localhost/a2a',
+      now: new Date('2030-01-01T00:00:30.000Z'),
+    });
+
+    expect(result).toMatchObject({
+      statusCode: 202,
+      body: {
+        delivered: true,
+        message_id: 'msg-inbound-a2a-1',
+        thread_id: 'thread-a2a-inbound',
+      },
+    });
+    expect(runtime.inbox('main')).toMatchObject([
+      {
+        id: 'msg-inbound-a2a-1',
+        sender_agent_id: 'remote@team@peer-instance',
+        recipient_agent_id: 'main@team@local-dev',
+      },
+    ]);
+    const audit = getRecentStructuredAuditForSession(
+      'a2a:inbound:peer-prod',
+      10,
+    ).map((event) => JSON.parse(event.payload || '{}'));
+    expect(audit).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'a2a.inbound_post',
+          peerId: 'peer-prod',
+          signatureOutcome: 'passed',
+          downstreamDisposition: 'delivered',
+          statusCode: 202,
+        }),
+      ]),
+    );
+  });
+
+  test('honors delegation token revocation before delivery', async () => {
+    process.env.HYBRIDCLAW_INSTANCE_ID = 'local-dev';
+    const { initDatabase, getRecentStructuredAuditForSession } = await import(
+      '../src/memory/db.ts'
+    );
+    const runtimeConfig = await import('../src/config/runtime-config.ts');
+    const runtime = await import('../src/a2a/runtime.ts');
+    const inbound = await import('../src/a2a/a2a-inbound.ts');
+    const outbound = await import('../src/a2a/a2a-outbound.ts');
+
+    initDatabase({ quiet: true });
+    runtimeConfig.updateRuntimeConfig((draft) => {
+      draft.agents.list = [{ id: 'main', owner: 'team', role: 'lead' }];
+    });
+
+    const keyPair = outbound.getOrCreateA2ADelegationTokenKeyPair({
+      now: new Date('2030-01-01T00:00:00.000Z'),
+    });
+    inbound.upsertA2ATrustedA2APeer({
+      peerId: 'revoked-peer',
+      senderAgentId: 'remote@team@peer-instance',
+      publicKeyPem: keyPair.publicKeyPem,
+    });
+
+    const envelope = inboundEnvelope('msg-revoked-a2a');
+    const rawBody = JSON.stringify(
+      encodeA2AJsonRpcRequest(envelope, {
+        url: 'http://localhost/a2a',
+      }),
+    );
+    const token = outbound.signA2ADelegationToken({
+      keyPair,
+      senderAgentId: 'remote@team@peer-instance',
+      targetAgentId: 'main@team@local-dev',
+      audience: 'http://localhost/a2a',
+      scope: outbound.A2A_MESSAGE_SEND_SCOPE,
+      parentRunId: 'run-remote-parent',
+      jwtId: 'msg-revoked-a2a',
+      now: new Date('2030-01-01T00:00:00.000Z'),
+    });
+    outbound.revokeA2ADelegationTokenId('msg-revoked-a2a', {
+      revokedAt: new Date('2030-01-01T00:00:10.000Z'),
+    });
+
+    const result = inbound.acceptA2AJsonRpcInboundRequest({
+      rawBody,
+      authorization: `Bearer ${token}`,
+      audience: 'http://localhost/a2a',
+      now: new Date('2030-01-01T00:00:30.000Z'),
+    });
+
+    expect(result).toEqual({
+      statusCode: 401,
+      body: { error: 'Unauthorized' },
+    });
+    expect(runtime.inbox('main')).toEqual([]);
+    const audit = getRecentStructuredAuditForSession(
+      'a2a:inbound:unknown',
+      10,
+    ).map((event) => JSON.parse(event.payload || '{}'));
+    expect(audit).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'a2a.inbound_post',
+          signatureOutcome: 'revoked',
+          downstreamDisposition: 'rejected',
+          statusCode: 401,
+          reason: 'JWT has been revoked',
+        }),
+      ]),
+    );
+  });
+});

--- a/tests/a2a-inbound.test.ts
+++ b/tests/a2a-inbound.test.ts
@@ -17,21 +17,39 @@ function inboundEnvelope(id: string) {
   };
 }
 
+async function loadInboundTestModules() {
+  const [
+    { initDatabase, getRecentStructuredAuditForSession },
+    runtimeConfig,
+    runtime,
+    inbound,
+    outbound,
+  ] = await Promise.all([
+    import('../src/memory/db.ts'),
+    import('../src/config/runtime-config.ts'),
+    import('../src/a2a/runtime.ts'),
+    import('../src/a2a/a2a-inbound.ts'),
+    import('../src/a2a/a2a-outbound.ts'),
+  ]);
+
+  initDatabase({ quiet: true });
+  runtimeConfig.updateRuntimeConfig((draft) => {
+    draft.agents.list = [{ id: 'main', owner: 'team', role: 'lead' }];
+  });
+
+  return {
+    getRecentStructuredAuditForSession,
+    runtime,
+    inbound,
+    outbound,
+  };
+}
+
 describe('A2A JSON-RPC inbound adapter', () => {
   test('accepts a signed delegation token and delivers to the local inbox', async () => {
     process.env.HYBRIDCLAW_INSTANCE_ID = 'local-dev';
-    const { initDatabase, getRecentStructuredAuditForSession } = await import(
-      '../src/memory/db.ts'
-    );
-    const runtimeConfig = await import('../src/config/runtime-config.ts');
-    const runtime = await import('../src/a2a/runtime.ts');
-    const inbound = await import('../src/a2a/a2a-inbound.ts');
-    const outbound = await import('../src/a2a/a2a-outbound.ts');
-
-    initDatabase({ quiet: true });
-    runtimeConfig.updateRuntimeConfig((draft) => {
-      draft.agents.list = [{ id: 'main', owner: 'team', role: 'lead' }];
-    });
+    const { getRecentStructuredAuditForSession, runtime, inbound, outbound } =
+      await loadInboundTestModules();
 
     const keyPair = outbound.getOrCreateA2ADelegationTokenKeyPair({
       now: new Date('2030-01-01T00:00:00.000Z'),
@@ -102,18 +120,8 @@ describe('A2A JSON-RPC inbound adapter', () => {
 
   test('honors delegation token revocation before delivery', async () => {
     process.env.HYBRIDCLAW_INSTANCE_ID = 'local-dev';
-    const { initDatabase, getRecentStructuredAuditForSession } = await import(
-      '../src/memory/db.ts'
-    );
-    const runtimeConfig = await import('../src/config/runtime-config.ts');
-    const runtime = await import('../src/a2a/runtime.ts');
-    const inbound = await import('../src/a2a/a2a-inbound.ts');
-    const outbound = await import('../src/a2a/a2a-outbound.ts');
-
-    initDatabase({ quiet: true });
-    runtimeConfig.updateRuntimeConfig((draft) => {
-      draft.agents.list = [{ id: 'main', owner: 'team', role: 'lead' }];
-    });
+    const { getRecentStructuredAuditForSession, runtime, inbound, outbound } =
+      await loadInboundTestModules();
 
     const keyPair = outbound.getOrCreateA2ADelegationTokenKeyPair({
       now: new Date('2030-01-01T00:00:00.000Z'),
@@ -175,17 +183,8 @@ describe('A2A JSON-RPC inbound adapter', () => {
 
   test('audits unknown trusted senders separately from bad signatures', async () => {
     process.env.HYBRIDCLAW_INSTANCE_ID = 'local-dev';
-    const { initDatabase, getRecentStructuredAuditForSession } = await import(
-      '../src/memory/db.ts'
-    );
-    const runtimeConfig = await import('../src/config/runtime-config.ts');
-    const inbound = await import('../src/a2a/a2a-inbound.ts');
-    const outbound = await import('../src/a2a/a2a-outbound.ts');
-
-    initDatabase({ quiet: true });
-    runtimeConfig.updateRuntimeConfig((draft) => {
-      draft.agents.list = [{ id: 'main', owner: 'team', role: 'lead' }];
-    });
+    const { getRecentStructuredAuditForSession, inbound, outbound } =
+      await loadInboundTestModules();
 
     const keyPair = outbound.getOrCreateA2ADelegationTokenKeyPair({
       now: new Date('2030-01-01T00:00:00.000Z'),

--- a/tests/a2a-inbound.test.ts
+++ b/tests/a2a-inbound.test.ts
@@ -46,6 +46,30 @@ async function loadInboundTestModules() {
 }
 
 describe('A2A JSON-RPC inbound adapter', () => {
+  test('does not persist unenforced rate limits on trusted A2A peers', async () => {
+    process.env.HYBRIDCLAW_INSTANCE_ID = 'local-dev';
+    const { inbound, outbound } = await loadInboundTestModules();
+    const keyPair = outbound.getOrCreateA2ADelegationTokenKeyPair({
+      now: new Date('2030-01-01T00:00:00.000Z'),
+    });
+
+    const peer = inbound.upsertA2ATrustedA2APeer({
+      peerId: 'peer-no-rate-limit',
+      senderAgentId: 'remote@team@peer-instance',
+      publicKeyPem: keyPair.publicKeyPem,
+      rateLimitPerMinute: 1,
+    } as Parameters<typeof inbound.upsertA2ATrustedA2APeer>[0] & {
+      rateLimitPerMinute: number;
+    });
+
+    expect(peer).not.toHaveProperty('rateLimitPerMinute');
+    const persisted = inbound
+      .listA2ATrustedA2APeers()
+      .find((entry) => entry.peerId === 'peer-no-rate-limit');
+    expect(persisted).toBeDefined();
+    expect(persisted).not.toHaveProperty('rateLimitPerMinute');
+  });
+
   test('accepts a signed delegation token and delivers to the local inbox', async () => {
     process.env.HYBRIDCLAW_INSTANCE_ID = 'local-dev';
     const { getRecentStructuredAuditForSession, runtime, inbound, outbound } =

--- a/tests/a2a-inbound.test.ts
+++ b/tests/a2a-inbound.test.ts
@@ -157,7 +157,7 @@ describe('A2A JSON-RPC inbound adapter', () => {
     });
     expect(runtime.inbox('main')).toEqual([]);
     const audit = getRecentStructuredAuditForSession(
-      'a2a:inbound:unknown',
+      'a2a:inbound:revoked-peer',
       10,
     ).map((event) => JSON.parse(event.payload || '{}'));
     expect(audit).toEqual(
@@ -168,6 +168,69 @@ describe('A2A JSON-RPC inbound adapter', () => {
           downstreamDisposition: 'rejected',
           statusCode: 401,
           reason: 'JWT has been revoked',
+        }),
+      ]),
+    );
+  });
+
+  test('audits unknown trusted senders separately from bad signatures', async () => {
+    process.env.HYBRIDCLAW_INSTANCE_ID = 'local-dev';
+    const { initDatabase, getRecentStructuredAuditForSession } = await import(
+      '../src/memory/db.ts'
+    );
+    const runtimeConfig = await import('../src/config/runtime-config.ts');
+    const inbound = await import('../src/a2a/a2a-inbound.ts');
+    const outbound = await import('../src/a2a/a2a-outbound.ts');
+
+    initDatabase({ quiet: true });
+    runtimeConfig.updateRuntimeConfig((draft) => {
+      draft.agents.list = [{ id: 'main', owner: 'team', role: 'lead' }];
+    });
+
+    const keyPair = outbound.getOrCreateA2ADelegationTokenKeyPair({
+      now: new Date('2030-01-01T00:00:00.000Z'),
+    });
+    const envelope = inboundEnvelope('msg-missing-peer-a2a');
+    const rawBody = JSON.stringify(
+      encodeA2AJsonRpcRequest(envelope, {
+        url: 'http://localhost/a2a',
+      }),
+    );
+    const token = outbound.signA2ADelegationToken({
+      keyPair,
+      senderAgentId: 'remote@team@peer-instance',
+      targetAgentId: 'main@team@local-dev',
+      audience: 'http://localhost/a2a',
+      scope: outbound.A2A_MESSAGE_SEND_SCOPE,
+      parentRunId: 'run-remote-parent',
+      jwtId: 'msg-missing-peer-a2a',
+      now: new Date('2030-01-01T00:00:00.000Z'),
+    });
+
+    expect(
+      inbound.acceptA2AJsonRpcInboundRequest({
+        rawBody,
+        authorization: `Bearer ${token}`,
+        audience: 'http://localhost/a2a',
+        now: new Date('2030-01-01T00:00:30.000Z'),
+      }),
+    ).toEqual({
+      statusCode: 401,
+      body: { error: 'Unauthorized' },
+    });
+
+    const audit = getRecentStructuredAuditForSession(
+      'a2a:inbound:unknown',
+      10,
+    ).map((event) => JSON.parse(event.payload || '{}'));
+    expect(audit).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'a2a.inbound_post',
+          signatureOutcome: 'missing_peer',
+          downstreamDisposition: 'rejected',
+          statusCode: 401,
+          reason: 'No trusted A2A peer for token sender',
         }),
       ]),
     );

--- a/tests/a2a-outbound.test.ts
+++ b/tests/a2a-outbound.test.ts
@@ -268,6 +268,43 @@ describe('A2A outbound adapter', () => {
     ).toThrow('JWT has been revoked');
   });
 
+  test('rejects tampered delegation tokens before parsing claims', async () => {
+    const a2a = await import('../src/a2a/a2a-outbound.ts');
+    const keyPair = a2a.getOrCreateA2ADelegationTokenKeyPair({
+      now: new Date('2030-01-01T00:00:00.000Z'),
+    });
+    const token = a2a.signA2ADelegationToken({
+      keyPair,
+      senderAgentId: 'main@team@local-dev',
+      targetAgentId: 'remote@team@peer-instance',
+      audience: 'https://peer.example.com/a2a',
+      scope: a2a.A2A_MESSAGE_SEND_SCOPE,
+      parentRunId: 'run-parent',
+      jwtId: 'msg-tampered',
+      now: new Date('2030-01-01T00:00:00.000Z'),
+    });
+    const [headerSegment = '', payloadSegment = '', signatureSegment = ''] =
+      token.split('.');
+    const payload = JSON.parse(
+      Buffer.from(payloadSegment, 'base64url').toString('utf-8'),
+    );
+    const tamperedPayloadSegment = Buffer.from(
+      JSON.stringify({
+        ...payload,
+        sub: 'not-canonical',
+        sender_agent_id: 'not-canonical',
+      }),
+    ).toString('base64url');
+
+    expect(() =>
+      a2a.verifyA2ADelegationToken({
+        token: `${headerSegment}.${tamperedPayloadSegment}.${signatureSegment}`,
+        publicKeyPem: keyPair.publicKeyPem,
+        now: new Date('2030-01-01T00:00:01.000Z'),
+      }),
+    ).toThrow('JWT signature is invalid');
+  });
+
   test('uses tasks/send for handoff when the peer advertises task capability', async () => {
     const request = encodeA2AJsonRpcRequest(
       sampleA2AEnvelope('msg-task', 'handoff'),

--- a/tests/a2a-outbound.test.ts
+++ b/tests/a2a-outbound.test.ts
@@ -377,17 +377,23 @@ describe('A2A outbound adapter', () => {
       transportRegistry: registry,
     });
 
-    const fetchImpl = vi.fn().mockResolvedValueOnce(
-      Response.json({
-        url: 'https://peer.example.com/a2a',
-        capabilities: [],
-      }),
+    let agentCardAuthorization = '';
+    const fetchImpl = vi.fn(
+      async (_url: RequestInfo | URL, init?: RequestInit) => {
+        const headers = init?.headers as Record<string, string>;
+        agentCardAuthorization = headers?.authorization || '';
+        return Response.json({
+          url: 'https://peer.example.com/a2a',
+          capabilities: [],
+        });
+      },
     );
     await expect(a2a.processA2AOutbox({ fetchImpl })).resolves.toMatchObject({
       processed: 1,
       failed: 1,
     });
     expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(agentCardAuthorization).toMatch(/^Bearer [A-Za-z0-9_-]+\./);
     expect(a2a.listA2AOutboxItems()[0]).toMatchObject({
       status: 'failed',
       lastError: 'a2a.bearerTokenRef is required for non-loopback peers',

--- a/tests/a2a-outbound.test.ts
+++ b/tests/a2a-outbound.test.ts
@@ -22,7 +22,9 @@ function sampleA2AEnvelope(id: string, intent: 'chat' | 'handoff' = 'chat') {
 
 describe('A2A outbound adapter', () => {
   test('queues envelopes, fetches Agent Cards with ETag refresh, and sends message/send', async () => {
-    const { initDatabase } = await import('../src/memory/db.ts');
+    const { initDatabase, getRecentStructuredAuditForSession } = await import(
+      '../src/memory/db.ts'
+    );
     const runtime = await import('../src/a2a/runtime.ts');
     const transport = await import('../src/a2a/transport-registry.ts');
     const a2a = await import('../src/a2a/a2a-outbound.ts');
@@ -174,6 +176,22 @@ describe('A2A outbound adapter', () => {
       scope: [a2a.A2A_MESSAGE_SEND_SCOPE],
       parent_run_id: 'run-a2a-outbound',
     });
+    const audit = getRecentStructuredAuditForSession(
+      'session-a2a-outbound',
+      10,
+    ).map((event) => JSON.parse(event.payload || '{}'));
+    expect(audit).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'a2a.outbound.delegation_auth',
+          authMode: expect.stringMatching(/jwt$/),
+          bearerTokenRefRole: expect.stringMatching(/^non.*gate$/),
+          bearerTokenRef: { source: 'store', id: 'A2A_PEER_TOKEN' },
+          audience: 'https://peer.example.com/a2a',
+          scope: a2a.A2A_MESSAGE_SEND_SCOPE,
+        }),
+      ]),
+    );
 
     runtime.sendMessage(sampleA2AEnvelope('msg-a2a-2'), {
       peerDescriptor: descriptor,

--- a/tests/a2a-outbound.test.ts
+++ b/tests/a2a-outbound.test.ts
@@ -133,6 +133,47 @@ describe('A2A outbound adapter', () => {
     expect(decodeA2AJsonRpcRequest(rpc)).toEqual(
       sampleA2AEnvelope('msg-a2a-1'),
     );
+    const keyPair = a2a.getOrCreateA2ADelegationTokenKeyPair();
+    const agentCardToken = requests[0]?.authorization.replace(/^Bearer /, '');
+    const deliveryToken = requests[1]?.authorization.replace(/^Bearer /, '');
+    expect(agentCardToken).toBeTruthy();
+    expect(deliveryToken).toBeTruthy();
+    const agentCardClaims = a2a.verifyA2ADelegationToken({
+      token: agentCardToken || '',
+      publicKeyPem: keyPair.publicKeyPem,
+      audience: 'https://peer.example.com/.well-known/agent.json',
+      requiredScope: a2a.A2A_AGENT_CARD_READ_SCOPE,
+      targetAgentId: 'remote@team@peer-instance',
+      now: new Date('2030-01-01T00:00:30.000Z'),
+    });
+    expect(agentCardClaims).toMatchObject({
+      iss: 'hybridclaw',
+      aud: 'https://peer.example.com/.well-known/agent.json',
+      jti: 'msg-a2a-1',
+      parent_run_id: 'run-a2a-outbound',
+      message_id: 'msg-a2a-1',
+      thread_id: 'thread-a2a',
+      target_agent_id: 'remote@team@peer-instance',
+      scope: [a2a.A2A_AGENT_CARD_READ_SCOPE],
+    });
+    expect(agentCardClaims.sender_agent_id).toMatch(/^main@/);
+    expect(agentCardClaims.exp - agentCardClaims.iat).toBe(
+      a2a.A2A_DELEGATION_TOKEN_TTL_SECONDS,
+    );
+    expect(
+      a2a.verifyA2ADelegationToken({
+        token: deliveryToken || '',
+        publicKeyPem: keyPair.publicKeyPem,
+        audience: 'https://peer.example.com/a2a',
+        requiredScope: a2a.A2A_MESSAGE_SEND_SCOPE,
+        targetAgentId: 'remote@team@peer-instance',
+        now: new Date('2030-01-01T00:00:30.000Z'),
+      }),
+    ).toMatchObject({
+      aud: 'https://peer.example.com/a2a',
+      scope: [a2a.A2A_MESSAGE_SEND_SCOPE],
+      parent_run_id: 'run-a2a-outbound',
+    });
 
     runtime.sendMessage(sampleA2AEnvelope('msg-a2a-2'), {
       peerDescriptor: descriptor,
@@ -167,6 +208,64 @@ describe('A2A outbound adapter', () => {
     expect(
       requests.find((request) => request.ifNoneMatch === '"card-v1"'),
     ).toBeTruthy();
+  });
+
+  test('honors delegation token revocations and expiry', async () => {
+    const a2a = await import('../src/a2a/a2a-outbound.ts');
+    const keyPair = a2a.getOrCreateA2ADelegationTokenKeyPair({
+      now: new Date('2030-01-01T00:00:00.000Z'),
+    });
+    const token = a2a.signA2ADelegationToken({
+      keyPair,
+      senderAgentId: 'main@team@local-dev',
+      targetAgentId: 'remote@team@peer-instance',
+      audience: 'https://peer.example.com/a2a',
+      scope: a2a.A2A_MESSAGE_SEND_SCOPE,
+      parentRunId: 'run-parent',
+      jwtId: 'msg-revocable',
+      now: new Date('2030-01-01T00:00:00.000Z'),
+    });
+
+    expect(
+      a2a.verifyA2ADelegationToken({
+        token,
+        publicKeyPem: keyPair.publicKeyPem,
+        audience: 'https://peer.example.com/a2a',
+        requiredScope: a2a.A2A_MESSAGE_SEND_SCOPE,
+        senderAgentId: 'main@team@local-dev',
+        targetAgentId: 'remote@team@peer-instance',
+        now: new Date('2030-01-01T00:00:01.000Z'),
+      }),
+    ).toMatchObject({
+      jti: 'msg-revocable',
+      parent_run_id: 'run-parent',
+      sender_agent_id: 'main@team@local-dev',
+      target_agent_id: 'remote@team@peer-instance',
+    });
+
+    expect(() =>
+      a2a.verifyA2ADelegationToken({
+        token,
+        publicKeyPem: keyPair.publicKeyPem,
+        audience: 'https://peer.example.com/a2a',
+        requiredScope: a2a.A2A_MESSAGE_SEND_SCOPE,
+        now: new Date('2030-01-01T00:06:00.000Z'),
+      }),
+    ).toThrow('JWT has expired');
+
+    a2a.revokeA2ADelegationTokenId('msg-revocable', {
+      revokedAt: new Date('2030-01-01T00:01:00.000Z'),
+    });
+    expect(a2a.isA2ADelegationTokenRevoked('msg-revocable')).toBe(true);
+    expect(() =>
+      a2a.verifyA2ADelegationToken({
+        token,
+        publicKeyPem: keyPair.publicKeyPem,
+        audience: 'https://peer.example.com/a2a',
+        requiredScope: a2a.A2A_MESSAGE_SEND_SCOPE,
+        now: new Date('2030-01-01T00:01:01.000Z'),
+      }),
+    ).toThrow('JWT has been revoked');
   });
 
   test('uses tasks/send for handoff when the peer advertises task capability', async () => {

--- a/tests/a2a-outbound.test.ts
+++ b/tests/a2a-outbound.test.ts
@@ -268,6 +268,22 @@ describe('A2A outbound adapter', () => {
     ).toThrow('JWT has been revoked');
   });
 
+  test('prunes expired delegation token revocations', async () => {
+    const a2a = await import('../src/a2a/a2a-outbound.ts');
+
+    a2a.revokeA2ADelegationTokenId('msg-old-revocation', {
+      revokedAt: new Date('2030-01-01T00:00:00.000Z'),
+    });
+    expect(a2a.isA2ADelegationTokenRevoked('msg-old-revocation')).toBe(true);
+
+    a2a.revokeA2ADelegationTokenId('msg-new-revocation', {
+      revokedAt: new Date('2030-01-01T00:06:00.000Z'),
+    });
+
+    expect(a2a.isA2ADelegationTokenRevoked('msg-old-revocation')).toBe(false);
+    expect(a2a.isA2ADelegationTokenRevoked('msg-new-revocation')).toBe(true);
+  });
+
   test('rejects tampered delegation tokens before parsing claims', async () => {
     const a2a = await import('../src/a2a/a2a-outbound.ts');
     const keyPair = a2a.getOrCreateA2ADelegationTokenKeyPair({

--- a/tests/helpers/a2a-webhook-fixtures.ts
+++ b/tests/helpers/a2a-webhook-fixtures.ts
@@ -15,6 +15,7 @@ function restoreEnvVar(name: string, value: string | undefined): void {
 export function setupA2AWebhookTestEnv(tempHomePrefix: string): void {
   const originalDataDir = process.env.HYBRIDCLAW_DATA_DIR;
   const originalHome = process.env.HOME;
+  const originalInstanceId = process.env.HYBRIDCLAW_INSTANCE_ID;
   let tmpDir = '';
 
   beforeEach(() => {
@@ -27,6 +28,7 @@ export function setupA2AWebhookTestEnv(tempHomePrefix: string): void {
   afterEach(() => {
     restoreEnvVar('HYBRIDCLAW_DATA_DIR', originalDataDir);
     restoreEnvVar('HOME', originalHome);
+    restoreEnvVar('HYBRIDCLAW_INSTANCE_ID', originalInstanceId);
     vi.resetModules();
     if (tmpDir) {
       fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Implements #480 by adding signed inter-instance A2A delegation tokens and enforcing them on the JSON-RPC inbound path.

## What changed

- Added Ed25519 per-instance delegation JWT signing, verification, persisted keypair creation, and revocation-list checks with expired revocation cleanup.
- Updated outbound A2A delivery to mint scoped delegation JWTs for Agent Card fetches and `message/send` / `tasks/send` requests.
- Added trusted A2A peer records with public keys and wired `/a2a` inbound JSON-RPC requests through signature, audience, scope, expiry, canonical sender/target, and revocation verification before envelope delivery.
- Added outbound audit events that explicitly record A2A auth mode as signed delegation JWTs and `bearerTokenRef` as a non-loopback policy gate.
- Added focused inbound/outbound tests covering successful delivery, claim contents, expiry, revoked-token rejection before inbox persistence, expired revocation pruning, tampered-token rejection before claim parsing, A2A peer rate-limit omission, and delegation-auth audit semantics.

## Compatibility note

For A2A peers, `bearerTokenRef` is retained as a non-loopback policy gate so operators must explicitly opt in before sending to remote peer URLs. The configured secret value is not sent as the HTTP bearer value; outbound A2A now sends a short-lived signed delegation JWT on the wire and records this in `a2a.outbound.delegation_auth` audit events. Loopback peer URLs also receive a signed delegation JWT so local HybridClaw-to-HybridClaw deliveries satisfy the `/a2a` inbound requirement.

## Validation

- `npm run lint`
- `./node_modules/.bin/tsc --noEmit --noUnusedLocals --noUnusedParameters`
- `./node_modules/.bin/vitest run --configLoader runner --config vitest.unit.config.ts tests/a2a-outbound.test.ts tests/a2a-inbound.test.ts tests/a2a-webhook-inbound.test.ts tests/a2a-webhook-outbound.test.ts tests/a2a-retry-policy.test.ts`
- Biome formatting on touched files

Closes #480