### PR TITLE
[codex] Fix context ring usage source

### DIFF
--- a/src/gateway/gateway-session-status.ts
+++ b/src/gateway/gateway-session-status.ts
@@ -48,6 +48,25 @@ function readPositiveNumber(value: unknown): number | null {
   return null;
 }
 
+function readNonNegativeNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+    return Math.floor(value);
+  }
+  return null;
+}
+
+function readLastPerformancePromptTokens(samples: unknown[]): number | null {
+  for (let index = samples.length - 1; index >= 0; index -= 1) {
+    const sample = samples[index];
+    if (!sample || typeof sample !== 'object') continue;
+    const promptTokens = readNonNegativeNumber(
+      (sample as Record<string, unknown>).promptTokens,
+    );
+    if (promptTokens != null) return promptTokens;
+  }
+  return null;
+}
+
 function addPerformanceSample(
   sample: Record<string, unknown>,
   samples: {
@@ -92,6 +111,7 @@ export function readSessionStatusSnapshot(
   const entries = getRecentStructuredAuditForSession(sessionId, 160);
   let usagePayload: Record<string, unknown> | null = null;
   let modelSelectionPayload: Record<string, unknown> | null = null;
+  let latestModelCallPromptTokens: number | null = null;
   const inputTokensPerSecondSamples: number[] = [];
   const outputTokensPerSecondSamples: number[] = [];
   const tokensPerSecondSamples: number[] = [];
@@ -108,6 +128,11 @@ export function readSessionStatusSnapshot(
       )
         ? payload.performanceSamples
         : [];
+      if (usagePayload === payload) {
+        latestModelCallPromptTokens = readLastPerformancePromptTokens(
+          payloadPerformanceSamples,
+        );
+      }
       let usedPerformanceSamples = false;
       for (const sample of payloadPerformanceSamples) {
         if (!sample || typeof sample !== 'object') continue;
@@ -220,6 +245,7 @@ export function readSessionStatusSnapshot(
     usagePayload?.context_tokens,
     usagePayload?.tokensInContext,
     usagePayload?.tokens_in_context,
+    latestModelCallPromptTokens,
     usagePayload?.promptTokens,
     usagePayload?.apiPromptTokens,
     usagePayload?.estimatedPromptTokens,

--- a/src/gateway/gateway-session-status.ts
+++ b/src/gateway/gateway-session-status.ts
@@ -2,6 +2,10 @@ import {
   getRecentStructuredAuditForSession,
   listStructuredAuditSessionIdsByPrefix,
 } from '../memory/db.js';
+import {
+  nonNegativeIntegerOrNull,
+  positiveNumberOrNull,
+} from '../utils/number-normalization.js';
 import { firstNumber, parseAuditPayload } from './gateway-utils.js';
 
 export interface SessionStatusSnapshot {
@@ -42,24 +46,14 @@ function sampleStddev(values: number[], mean: number): number {
 }
 
 function readPositiveNumber(value: unknown): number | null {
-  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
-    return value;
-  }
-  return null;
-}
-
-function readNonNegativeNumber(value: unknown): number | null {
-  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
-    return Math.floor(value);
-  }
-  return null;
+  return positiveNumberOrNull(value);
 }
 
 function readLastPerformancePromptTokens(samples: unknown[]): number | null {
   for (let index = samples.length - 1; index >= 0; index -= 1) {
     const sample = samples[index];
     if (!sample || typeof sample !== 'object') continue;
-    const promptTokens = readNonNegativeNumber(
+    const promptTokens = nonNegativeIntegerOrNull(
       (sample as Record<string, unknown>).promptTokens,
     );
     if (promptTokens != null) return promptTokens;

--- a/src/gateway/gateway-utils.ts
+++ b/src/gateway/gateway-utils.ts
@@ -1,16 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import type { StructuredAuditEntry } from '../types/audit.js';
+import { finiteNumberOrNull } from '../utils/number-normalization.js';
 
 export function numberFromUnknown(value: unknown): number | null {
-  if (
-    typeof value !== 'number' ||
-    Number.isNaN(value) ||
-    !Number.isFinite(value)
-  ) {
-    return null;
-  }
-  return value;
+  return finiteNumberOrNull(value);
 }
 
 export function firstNumber(values: unknown[]): number | null {

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -115,6 +115,10 @@ import type {
 import { isApprovalHistoryMessage } from '../utils/approval-text.js';
 import { normalizeTrimmedUniqueStringArray } from '../utils/normalized-strings.js';
 import {
+  normalizeNonNegativeInteger,
+  normalizeNonNegativeNumber,
+} from '../utils/number-normalization.js';
+import {
   buildMemoryFtsDocument,
   buildMemoryFtsMatchQuery,
   getMemoryFtsTokenizerSpec,
@@ -3339,17 +3343,11 @@ function usageWindowWhereClause(window: UsageWindow): string | null {
 }
 
 export function normalizeUsageNumber(value: unknown): number {
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return Math.max(0, Math.floor(value));
-  }
-  return 0;
+  return normalizeNonNegativeInteger(value);
 }
 
 export function normalizeUsageCost(value: unknown): number {
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return Math.max(0, value);
-  }
-  return 0;
+  return normalizeNonNegativeNumber(value);
 }
 
 function applyUsageFilters(params: {

--- a/src/providers/request-max-tokens.ts
+++ b/src/providers/request-max-tokens.ts
@@ -1,10 +1,9 @@
+import { positiveIntegerOrNull } from '../utils/number-normalization.js';
+
 export const DEFAULT_ANTHROPIC_PROVIDER_MAX_TOKENS = 32_000;
 
 function normalizePositiveInteger(value: unknown): number | undefined {
-  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
-    return undefined;
-  }
-  return Math.floor(value);
+  return positiveIntegerOrNull(value) ?? undefined;
 }
 
 export function isAnthropicProviderModel(model: string): boolean {

--- a/src/providers/task-routing.ts
+++ b/src/providers/task-routing.ts
@@ -10,6 +10,7 @@ import {
   type TaskModelPolicies,
   type TaskModelPolicy,
 } from '../types/models.js';
+import { positiveIntegerOrNull } from '../utils/number-normalization.js';
 import {
   resolveModelProvider,
   resolveModelRuntimeCredentials,
@@ -57,10 +58,7 @@ const RUNTIME_PROVIDER_PREFIXES: Record<RuntimeProvider, string> = {
 };
 
 export function normalizeMaxTokens(value: unknown): number | undefined {
-  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
-    return undefined;
-  }
-  return Math.floor(value);
+  return positiveIntegerOrNull(value) ?? undefined;
 }
 
 function normalizeTaskProviderSelection(

--- a/src/utils/number-normalization.ts
+++ b/src/utils/number-normalization.ts
@@ -1,0 +1,27 @@
+export function finiteNumberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+export function positiveNumberOrNull(value: unknown): number | null {
+  const number = finiteNumberOrNull(value);
+  return number != null && number > 0 ? number : null;
+}
+
+export function nonNegativeIntegerOrNull(value: unknown): number | null {
+  const number = finiteNumberOrNull(value);
+  return number != null && number >= 0 ? Math.floor(number) : null;
+}
+
+export function positiveIntegerOrNull(value: unknown): number | null {
+  const number = positiveNumberOrNull(value);
+  return number != null ? Math.floor(number) : null;
+}
+
+export function normalizeNonNegativeInteger(value: unknown): number {
+  return nonNegativeIntegerOrNull(value) ?? 0;
+}
+
+export function normalizeNonNegativeNumber(value: unknown): number {
+  const number = finiteNumberOrNull(value);
+  return number != null ? Math.max(0, number) : 0;
+}

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -44,10 +44,7 @@ function writeRuntimeConfig(
 
 function readMainAgentPolicy(homeDir: string): Record<string, unknown> {
   return YAML.parse(
-    fs.readFileSync(
-      mainAgentPolicyPath(homeDir),
-      'utf-8',
-    ),
+    fs.readFileSync(mainAgentPolicyPath(homeDir), 'utf-8'),
   ) as Record<string, unknown>;
 }
 
@@ -2001,6 +1998,95 @@ test('status uses OpenRouter context_length metadata for the context window', as
   }
   expect(result.text).toContain('🧠 Model: openrouter/hunter-alpha');
   expect(result.text).toContain('📚 Context: 12k/262k');
+});
+
+test('status reports context from the latest model call instead of aggregate prompt tokens', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  process.env.OPENROUTER_API_KEY = 'or-status-test';
+  writeRuntimeConfig(homeDir, (config) => {
+    config.openrouter.enabled = true;
+    config.hybridai.defaultModel = 'openrouter/hunter-alpha';
+    config.openrouter.models = ['openrouter/hunter-alpha'];
+    config.local.backends.ollama.enabled = false;
+    config.local.backends.lmstudio.enabled = false;
+    config.local.backends.vllm.enabled = false;
+  });
+  vi.resetModules();
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes('/models')) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: 'hunter-alpha',
+                context_length: 262144,
+                pricing: {
+                  prompt: '0',
+                  completion: '0',
+                },
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }),
+  );
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { makeAuditRunId, recordAuditEvent } = await import(
+    '../src/audit/audit-events.ts'
+  );
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  recordAuditEvent({
+    sessionId: 'session-status-context-latest-call',
+    runId: makeAuditRunId('test'),
+    event: {
+      type: 'model.usage',
+      provider: 'openrouter',
+      model: 'openrouter/hunter-alpha',
+      promptTokens: 860_000,
+      completionTokens: 1_000,
+      performanceSamples: [
+        {
+          promptTokens: 120_000,
+          completionTokens: 500,
+          totalTokens: 120_500,
+          durationMs: 2_000,
+        },
+        {
+          promptTokens: 54_000,
+          completionTokens: 500,
+          totalTokens: 54_500,
+          durationMs: 1_000,
+        },
+      ],
+    },
+  });
+
+  const result = await handleGatewayCommand({
+    sessionId: 'session-status-context-latest-call',
+    guildId: null,
+    channelId: 'channel-status-context-latest-call',
+    args: ['status'],
+  });
+
+  expect(result.kind).toBe('info');
+  if (result.kind !== 'info') {
+    throw new Error(`Unexpected result kind: ${result.kind}`);
+  }
+  expect(result.text).toContain('📚 Context: 54k/262k');
+  expect(result.text).toContain('🧮 Tokens: 860k in / 1k out');
 });
 
 test('status uses Hugging Face context_length metadata for the context window', async () => {

--- a/tests/number-normalization.test.ts
+++ b/tests/number-normalization.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from 'vitest';
+import {
+  finiteNumberOrNull,
+  nonNegativeIntegerOrNull,
+  normalizeNonNegativeInteger,
+  normalizeNonNegativeNumber,
+  positiveIntegerOrNull,
+  positiveNumberOrNull,
+} from '../src/utils/number-normalization.js';
+
+test('finiteNumberOrNull accepts only finite numeric values', () => {
+  expect(finiteNumberOrNull(1.5)).toBe(1.5);
+  expect(finiteNumberOrNull('1.5')).toBeNull();
+  expect(finiteNumberOrNull(Number.NaN)).toBeNull();
+  expect(finiteNumberOrNull(Number.POSITIVE_INFINITY)).toBeNull();
+  expect(finiteNumberOrNull(null)).toBeNull();
+});
+
+test('positiveNumberOrNull preserves positive finite numbers', () => {
+  expect(positiveNumberOrNull(1.5)).toBe(1.5);
+  expect(positiveNumberOrNull(0)).toBeNull();
+  expect(positiveNumberOrNull(-1)).toBeNull();
+});
+
+test('integer helpers floor finite numeric values after bounds checks', () => {
+  expect(nonNegativeIntegerOrNull(1.9)).toBe(1);
+  expect(nonNegativeIntegerOrNull(0)).toBe(0);
+  expect(nonNegativeIntegerOrNull(-1)).toBeNull();
+  expect(positiveIntegerOrNull(1.9)).toBe(1);
+  expect(positiveIntegerOrNull(0)).toBeNull();
+});
+
+test('normalizers fall back to zero and clamp negative values', () => {
+  expect(normalizeNonNegativeInteger(3.9)).toBe(3);
+  expect(normalizeNonNegativeInteger(-3.9)).toBe(0);
+  expect(normalizeNonNegativeInteger('3')).toBe(0);
+  expect(normalizeNonNegativeNumber(3.9)).toBe(3.9);
+  expect(normalizeNonNegativeNumber(-3.9)).toBe(0);
+  expect(normalizeNonNegativeNumber('3')).toBe(0);
+});


### PR DESCRIPTION
## Summary

Fixes the context usage snapshot used by `/status`, `/context`, and the console context ring so it reports the current prompt size from the latest model call instead of the aggregate prompt-token total for the whole turn.

Also extracts a small shared numeric-only normalization helper for repeated finite-number, positive-integer, and nonnegative-number cases found while reviewing `read*Number` / `normalize*Number` patterns.

## Root Cause

`readSessionStatusSnapshot` used aggregate `promptTokens` as the context fallback. Multi-call turns can legitimately accumulate more prompt tokens than the model context window, so the UI could show impossible values like `860k / 128k` even though each individual model call fit.

## Changes

- Prefer explicit context-token fields when providers report them.
- Otherwise use the latest model-call performance sample's prompt token count.
- Keep aggregate prompt/completion token totals unchanged for cost and token reporting.
- Add a regression test where aggregate prompt tokens are `860k` but the latest call context is `54k`.
- Add `src/utils/number-normalization.ts` for numeric-only finite/positive/nonnegative normalization.
- Reuse the shared helper in gateway context status, gateway number utilities, usage rollups, and provider max-token normalization.

## Validation

- `npm rebuild better-sqlite3` to fix the local Node ABI mismatch before DB-backed tests.
- `npx vitest run tests/gateway-status.test.ts tests/context-usage.test.ts`
- `npx vitest run tests/number-normalization.test.ts tests/gateway-status.test.ts tests/context-usage.test.ts tests/providers.task-routing.test.ts tests/request-max-tokens.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `npx biome check --write src/gateway/gateway-session-status.ts tests/gateway-status.test.ts`
- `npx biome check --write src/utils/number-normalization.ts src/gateway/gateway-utils.ts src/gateway/gateway-session-status.ts src/memory/db.ts src/providers/request-max-tokens.ts src/providers/task-routing.ts tests/number-normalization.test.ts`