### PR TITLE
feat(gateway): proxy Vite dev server through gateway origin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,22 @@ npm --prefix container run lint
 npm --prefix container run release:check
 ```
 
+## Console Dev Server
+
+Iterating on the React console with HMR while the gateway handles real auth and
+APIs:
+
+```bash
+npm run dev:console
+```
+
+That starts the gateway daemon with `HYBRIDCLAW_DEV_VITE_URL=http://127.0.0.1:4173`
+then runs Vite in the foreground. Open http://127.0.0.1:9090/chat — the gateway
+proxies SPA HTML, Vite source modules, and the HMR WebSocket to Vite, so the
+page loads under the gateway origin and reuses the existing localhost session
+cookie. Plain `npm run dev` still serves the prebuilt `console/dist`. Stop the
+gateway daemon with `npx tsx src/cli.ts gateway stop`.
+
 ## Validation Expectations
 
 Choose the smallest set of checks that actually covers your change:

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "test:live": "vitest run --configLoader runner --config vitest.live.config.ts --passWithNoTests",
     "setup": "npm --prefix container install",
     "dev": "tsx src/cli.ts gateway",
+    "dev:console": "HYBRIDCLAW_DEV_VITE_URL=http://127.0.0.1:4173 tsx src/cli.ts gateway restart && npm --workspace console run dev",
     "gateway": "tsx src/cli.ts gateway",
     "tui": "tsx src/cli.ts tui",
     "start": "node dist/cli.js gateway",

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -4111,10 +4111,6 @@ const DEV_VITE_URL = (process.env.HYBRIDCLAW_DEV_VITE_URL || '')
   .trim()
   .replace(/\/+$/, '');
 
-function isDevConsoleEnabled(): boolean {
-  return DEV_VITE_URL.length > 0;
-}
-
 function isViteSourcePath(pathname: string): boolean {
   return (
     pathname.startsWith('/@vite/') ||
@@ -4126,22 +4122,28 @@ function isViteSourcePath(pathname: string): boolean {
   );
 }
 
+function buildViteRequestOptions(
+  req: IncomingMessage,
+  targetPath: string,
+): http.RequestOptions {
+  const upstream = new URL(targetPath, DEV_VITE_URL);
+  return {
+    protocol: upstream.protocol,
+    hostname: upstream.hostname,
+    port: upstream.port,
+    method: req.method,
+    path: upstream.pathname + upstream.search,
+    headers: { ...req.headers, host: upstream.host },
+  };
+}
+
 function proxyToVite(
   req: IncomingMessage,
   res: ServerResponse,
   targetPath: string,
 ): void {
-  const upstream = new URL(targetPath, DEV_VITE_URL);
-  const headers = { ...req.headers, host: upstream.host };
   const upstreamReq = http.request(
-    {
-      protocol: upstream.protocol,
-      hostname: upstream.hostname,
-      port: upstream.port,
-      method: req.method,
-      path: upstream.pathname + upstream.search,
-      headers,
-    },
+    buildViteRequestOptions(req, targetPath),
     (upstreamRes) => {
       res.writeHead(upstreamRes.statusCode || 502, upstreamRes.headers);
       upstreamRes.pipe(res);
@@ -4158,6 +4160,13 @@ function proxyToVite(
       res.destroy(error);
     }
   });
+  // Abort the upstream request if the client disconnects before we finish
+  // streaming the response back. ServerResponse 'close' fires only on
+  // premature closure, not on normal end-of-response, so this won't fight
+  // the happy path.
+  res.on('close', () => {
+    if (!res.writableEnded) upstreamReq.destroy();
+  });
   req.pipe(upstreamReq);
 }
 
@@ -4166,16 +4175,9 @@ function proxyViteUpgrade(
   socket: import('node:stream').Duplex,
   head: Buffer,
 ): void {
-  const upstream = new URL(req.url || '/', DEV_VITE_URL);
-  const headers = { ...req.headers, host: upstream.host };
-  const upstreamReq = http.request({
-    protocol: upstream.protocol,
-    hostname: upstream.hostname,
-    port: upstream.port,
-    method: req.method,
-    path: upstream.pathname + upstream.search,
-    headers,
-  });
+  const upstreamReq = http.request(
+    buildViteRequestOptions(req, req.url || '/'),
+  );
   upstreamReq.on('upgrade', (upstreamRes, upstreamSocket, upstreamHead) => {
     const lines = [
       `HTTP/1.1 ${upstreamRes.statusCode ?? 101} ${upstreamRes.statusMessage || 'Switching Protocols'}`,
@@ -4192,8 +4194,14 @@ function proxyViteUpgrade(
     if (head.length > 0) upstreamSocket.write(head);
     upstreamSocket.pipe(socket);
     socket.pipe(upstreamSocket);
-    upstreamSocket.on('error', () => socket.destroy());
-    socket.on('error', () => upstreamSocket.destroy());
+    const closeBoth = (): void => {
+      socket.destroy();
+      upstreamSocket.destroy();
+    };
+    upstreamSocket.on('error', closeBoth);
+    upstreamSocket.on('close', closeBoth);
+    socket.on('error', closeBoth);
+    socket.on('close', closeBoth);
   });
   upstreamReq.on('error', () => {
     writeUpgradeError(socket, 502, 'Vite dev server unreachable');
@@ -4761,7 +4769,7 @@ export function startGatewayHttpServer(): GatewayHttpServer {
       return;
     }
 
-    if (isDevConsoleEnabled() && isViteSourcePath(pathname)) {
+    if (DEV_VITE_URL && isViteSourcePath(pathname)) {
       proxyToVite(req, res, req.url || pathname);
       return;
     }
@@ -4785,7 +4793,7 @@ export function startGatewayHttpServer(): GatewayHttpServer {
     }
 
     if (isConsoleSpaPath(pathname)) {
-      if (isDevConsoleEnabled()) {
+      if (DEV_VITE_URL) {
         proxyToVite(req, res, '/');
         return;
       }
@@ -4811,7 +4819,7 @@ export function startGatewayHttpServer(): GatewayHttpServer {
     }
 
     if (url.pathname !== '/api/admin/terminal/stream') {
-      if (isDevConsoleEnabled()) {
+      if (DEV_VITE_URL) {
         proxyViteUpgrade(req, socket, head);
         return;
       }

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -4107,9 +4107,30 @@ function writeUpgradeError(
 // gateway forwards SPA HTML, Vite source/asset paths, and the HMR WebSocket
 // to the configured Vite dev server so the console can be developed under
 // the gateway's origin (and pick up the hybridclaw_local_session cookie).
-const DEV_VITE_URL = (process.env.HYBRIDCLAW_DEV_VITE_URL || '')
-  .trim()
-  .replace(/\/+$/, '');
+// Refused unless the upstream is http:// AND the gateway is bound to
+// loopback, since the proxy intentionally bypasses the console-surface auth
+// gate (Vite serves source straight from disk).
+const DEV_VITE_URL = (() => {
+  const raw = (process.env.HYBRIDCLAW_DEV_VITE_URL || '')
+    .trim()
+    .replace(/\/+$/, '');
+  if (!raw) return '';
+  if (!raw.startsWith('http://')) {
+    logger.warn(
+      { value: raw },
+      'HYBRIDCLAW_DEV_VITE_URL must be an http:// URL — Vite passthrough disabled',
+    );
+    return '';
+  }
+  if (!isLoopbackHost(HEALTH_HOST)) {
+    logger.warn(
+      { healthHost: HEALTH_HOST },
+      'HYBRIDCLAW_DEV_VITE_URL ignored: gateway is not bound to a loopback host',
+    );
+    return '';
+  }
+  return raw;
+})();
 
 function isViteSourcePath(pathname: string): boolean {
   return (
@@ -4119,6 +4140,14 @@ function isViteSourcePath(pathname: string): boolean {
     pathname.startsWith('/@fs/') ||
     pathname.startsWith('/src/') ||
     pathname.startsWith('/node_modules/')
+  );
+}
+
+function canUseDevViteProxy(req: IncomingMessage): boolean {
+  return (
+    DEV_VITE_URL.length > 0 &&
+    isLoopbackSocketAddress(req.socket.remoteAddress) &&
+    !hasForwardingHeaders(req)
   );
 }
 
@@ -4202,6 +4231,17 @@ function proxyViteUpgrade(
     upstreamSocket.on('close', closeBoth);
     socket.on('error', closeBoth);
     socket.on('close', closeBoth);
+  });
+  // Vite may answer with a regular HTTP response (e.g. 426/4xx) instead of
+  // upgrading. Surface that as an upgrade error so the client socket doesn't
+  // hang.
+  upstreamReq.on('response', (upstreamRes) => {
+    writeUpgradeError(
+      socket,
+      502,
+      `Vite did not upgrade (status ${upstreamRes.statusCode ?? 'unknown'})`,
+    );
+    upstreamRes.resume();
   });
   upstreamReq.on('error', () => {
     writeUpgradeError(socket, 502, 'Vite dev server unreachable');
@@ -4769,8 +4809,8 @@ export function startGatewayHttpServer(): GatewayHttpServer {
       return;
     }
 
-    if (DEV_VITE_URL && isViteSourcePath(pathname)) {
-      proxyToVite(req, res, req.url || pathname);
+    if (canUseDevViteProxy(req) && isViteSourcePath(pathname)) {
+      proxyToVite(req, res, pathname + url.search);
       return;
     }
 
@@ -4793,7 +4833,7 @@ export function startGatewayHttpServer(): GatewayHttpServer {
     }
 
     if (isConsoleSpaPath(pathname)) {
-      if (DEV_VITE_URL) {
+      if (canUseDevViteProxy(req)) {
         proxyToVite(req, res, '/');
         return;
       }
@@ -4819,7 +4859,7 @@ export function startGatewayHttpServer(): GatewayHttpServer {
     }
 
     if (url.pathname !== '/api/admin/terminal/stream') {
-      if (DEV_VITE_URL) {
+      if (canUseDevViteProxy(req)) {
         proxyViteUpgrade(req, socket, head);
         return;
       }

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -4103,6 +4103,104 @@ function writeUpgradeError(
   socket.destroy();
 }
 
+// Optional Vite dev passthrough: when HYBRIDCLAW_DEV_VITE_URL is set the
+// gateway forwards SPA HTML, Vite source/asset paths, and the HMR WebSocket
+// to the configured Vite dev server so the console can be developed under
+// the gateway's origin (and pick up the hybridclaw_local_session cookie).
+const DEV_VITE_URL = (process.env.HYBRIDCLAW_DEV_VITE_URL || '')
+  .trim()
+  .replace(/\/+$/, '');
+
+function isDevConsoleEnabled(): boolean {
+  return DEV_VITE_URL.length > 0;
+}
+
+function isViteSourcePath(pathname: string): boolean {
+  return (
+    pathname.startsWith('/@vite/') ||
+    pathname === '/@react-refresh' ||
+    pathname.startsWith('/@id/') ||
+    pathname.startsWith('/@fs/') ||
+    pathname.startsWith('/src/') ||
+    pathname.startsWith('/node_modules/')
+  );
+}
+
+function proxyToVite(
+  req: IncomingMessage,
+  res: ServerResponse,
+  targetPath: string,
+): void {
+  const upstream = new URL(targetPath, DEV_VITE_URL);
+  const headers = { ...req.headers, host: upstream.host };
+  const upstreamReq = http.request(
+    {
+      protocol: upstream.protocol,
+      hostname: upstream.hostname,
+      port: upstream.port,
+      method: req.method,
+      path: upstream.pathname + upstream.search,
+      headers,
+    },
+    (upstreamRes) => {
+      res.writeHead(upstreamRes.statusCode || 502, upstreamRes.headers);
+      upstreamRes.pipe(res);
+    },
+  );
+  upstreamReq.on('error', (error) => {
+    if (!res.headersSent) {
+      sendText(
+        res,
+        502,
+        `Vite dev server unreachable at ${DEV_VITE_URL}: ${error.message}`,
+      );
+    } else {
+      res.destroy(error);
+    }
+  });
+  req.pipe(upstreamReq);
+}
+
+function proxyViteUpgrade(
+  req: IncomingMessage,
+  socket: import('node:stream').Duplex,
+  head: Buffer,
+): void {
+  const upstream = new URL(req.url || '/', DEV_VITE_URL);
+  const headers = { ...req.headers, host: upstream.host };
+  const upstreamReq = http.request({
+    protocol: upstream.protocol,
+    hostname: upstream.hostname,
+    port: upstream.port,
+    method: req.method,
+    path: upstream.pathname + upstream.search,
+    headers,
+  });
+  upstreamReq.on('upgrade', (upstreamRes, upstreamSocket, upstreamHead) => {
+    const lines = [
+      `HTTP/1.1 ${upstreamRes.statusCode ?? 101} ${upstreamRes.statusMessage || 'Switching Protocols'}`,
+    ];
+    for (const [key, value] of Object.entries(upstreamRes.headers)) {
+      if (Array.isArray(value)) {
+        for (const item of value) lines.push(`${key}: ${item}`);
+      } else if (value != null) {
+        lines.push(`${key}: ${value}`);
+      }
+    }
+    socket.write(`${lines.join('\r\n')}\r\n\r\n`);
+    if (upstreamHead.length > 0) socket.write(upstreamHead);
+    if (head.length > 0) upstreamSocket.write(head);
+    upstreamSocket.pipe(socket);
+    socket.pipe(upstreamSocket);
+    upstreamSocket.on('error', () => socket.destroy());
+    socket.on('error', () => upstreamSocket.destroy());
+  });
+  upstreamReq.on('error', () => {
+    writeUpgradeError(socket, 502, 'Vite dev server unreachable');
+  });
+  upstreamReq.end();
+}
+
 export interface GatewayHttpServer {
   broadcastShutdown: () => void;
   setReady: () => void;
@@ -4663,6 +4761,11 @@ export function startGatewayHttpServer(): GatewayHttpServer {
       return;
     }
 
+    if (isDevConsoleEnabled() && isViteSourcePath(pathname)) {
+      proxyToVite(req, res, req.url || pathname);
+      return;
+    }
+
     if (requiresSessionAuth(pathname) && !ensureSessionAuth(req, res)) {
       return;
     }
@@ -4682,6 +4785,10 @@ export function startGatewayHttpServer(): GatewayHttpServer {
     }
 
     if (isConsoleSpaPath(pathname)) {
+      if (isDevConsoleEnabled()) {
+        proxyToVite(req, res, '/');
+        return;
+      }
       if (serveConsoleIndex(res)) return;
       sendText(
         res,
@@ -4704,6 +4811,10 @@ export function startGatewayHttpServer(): GatewayHttpServer {
     }
 
     if (url.pathname !== '/api/admin/terminal/stream') {
+      if (isDevConsoleEnabled()) {
+        proxyViteUpgrade(req, socket, head);
+        return;
+      }
       writeUpgradeError(socket, 404, 'Not Found');
       return;
     }


### PR DESCRIPTION
## Summary

- Adds opt-in `HYBRIDCLAW_DEV_VITE_URL` env var; when set, the gateway proxies SPA HTML, Vite source modules, and the HMR WebSocket to the configured Vite dev server. Page loads under the gateway origin and reuses the existing localhost session cookie, so the dev console hits the same auth path real users do (no `WEB_API_TOKEN` workaround).
- Adds `npm run dev:console` — restarts the gateway with the env var set, then runs Vite in the foreground. One command for HMR-driven console development.
- Documents the workflow in `CONTRIBUTING.md`. Without the env var, gateway behavior is unchanged (still serves prebuilt `console/dist`).

## Why

Currently `npm --workspace console run dev` (Vite on `:4173`) can't authenticate against the gateway: the gateway's `hybridclaw_local_session` cookie is only set for requests it serves itself, and cookies don't cross origins to `:4173`. Devs end up using the prebuilt console at `:9090` (no HMR) or rebuilding `console/dist` repeatedly. Same-origin proxy fixes both.

## Test plan

- [x] `npm run dev:console` → open http://127.0.0.1:9090/chat, page loads under the gateway origin, session works, sent a message and got a reply.
- [x] Verified Vite source modules (`/src/main.tsx`) and `/@vite/client` are 200 via `:9090`.
- [x] `npx tsc --noEmit` passes (pre-existing `@ngrok/ngrok` and `policy-command.ts` biome issues are unrelated, present on `main`).
- [ ] HMR edit-reload cycle (no automated coverage; manual smoke).

## AI assistance

Drafted with Claude Code: design discussion, implementation, and PR text.