### PR TITLE
fix(console): ignore composer key events during IME composition

### DIFF
--- a/console/src/routes/chat/composer.test.tsx
+++ b/console/src/routes/chat/composer.test.tsx
@@ -485,5 +485,19 @@ describe('Composer', () => {
       fireEvent.keyDown(textarea, { key: 'Enter', isComposing: true });
       expect(textarea.value).toBe('/');
     });
+
+    it('treats keyCode 229 as composing (Safari/WebKit fallback)', () => {
+      const onSend = vi.fn();
+      renderComposer({ onSend });
+      const textarea = getTextarea();
+      fireEvent.input(textarea, { target: { value: 'こん' } });
+      // Safari fires the confirm-Enter with isComposing: false but keyCode 229.
+      fireEvent.keyDown(textarea, {
+        key: 'Enter',
+        isComposing: false,
+        keyCode: 229,
+      });
+      expect(onSend).not.toHaveBeenCalled();
+    });
   });
 });

--- a/console/src/routes/chat/composer.test.tsx
+++ b/console/src/routes/chat/composer.test.tsx
@@ -456,4 +456,34 @@ describe('Composer', () => {
       expect(screen.queryByRole('listbox')).toBeNull();
     });
   });
+
+  describe('IME composition', () => {
+    it('does not send on Enter while an IME is composing', () => {
+      const onSend = vi.fn();
+      renderComposer({ onSend });
+      const textarea = getTextarea();
+      fireEvent.input(textarea, { target: { value: 'こん' } });
+      fireEvent.keyDown(textarea, { key: 'Enter', isComposing: true });
+      expect(onSend).not.toHaveBeenCalled();
+    });
+
+    it('sends on Enter once composition has ended', () => {
+      const onSend = vi.fn();
+      renderComposer({ onSend });
+      const textarea = getTextarea();
+      fireEvent.input(textarea, { target: { value: 'こんにちは' } });
+      fireEvent.keyDown(textarea, { key: 'Enter' });
+      expect(onSend).toHaveBeenCalledWith('こんにちは', []);
+    });
+
+    it('does not select a slash suggestion on Enter while composing', async () => {
+      fetchChatCommandsMock.mockResolvedValue({ commands: [APPROVE] });
+      renderComposer();
+      const textarea = getTextarea();
+      fireEvent.input(textarea, { target: { value: '/' } });
+      await screen.findByRole('listbox');
+      fireEvent.keyDown(textarea, { key: 'Enter', isComposing: true });
+      expect(textarea.value).toBe('/');
+    });
+  });
 });

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -214,9 +214,11 @@ export function Composer(props: {
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    // While an IME is composing, Enter/Tab/Arrow keys belong to the IME
-    // (confirming or navigating candidates), not to the composer UI.
-    if (e.nativeEvent.isComposing) return;
+    // While an IME is composing, all keystrokes belong to the IME (typing,
+    // navigating candidates, confirming) — never to the composer UI.
+    // keyCode 229 is the cross-browser fallback: Safari/WebKit fires the
+    // confirming Enter with `isComposing` already false but `keyCode === 229`.
+    if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
     if (panelMode === 'list' && suggestions.length > 0) {
       if (e.key === 'ArrowDown') {
         e.preventDefault();

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -214,6 +214,9 @@ export function Composer(props: {
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    // While an IME is composing, Enter/Tab/Arrow keys belong to the IME
+    // (confirming or navigating candidates), not to the composer UI.
+    if (e.nativeEvent.isComposing) return;
     if (panelMode === 'list' && suggestions.length > 0) {
       if (e.key === 'ArrowDown') {
         e.preventDefault();


### PR DESCRIPTION
## Summary

The composer's `handleKeyDown` acted on Enter/Tab/Arrow keys regardless of IME composition state. CJK / accented input would have a partial composition cut off and sent as a message (or used to confirm a slash suggestion) instead of being committed by the IME first.

## Fix

Early-return from `handleKeyDown` when `event.nativeEvent.isComposing` is true so the IME owns the keystroke (`composer.tsx:217–219`).

## Test plan

- [x] Three new regression tests in `composer.test.tsx` cover:
  - Enter mid-composition does not call `onSend`.
  - Enter after composition completes still sends.
  - Enter mid-composition while the slash-suggestion panel is open does not select an item.
- [x] All 303 console tests pass with the fix; 2 of the 3 new tests fail without it (verified by reverting locally).

## How surfaced

Found by an exploratory review pass over `console/src/routes/chat/`. Other findings from that pass turned out to be false positives (the optional `messageId` field, and the by-design captured-session-at-send-start streaming behavior — there's an explicit test for the latter at `use-chat-stream.test.ts:510`); only this one was a real bug.

## AI assistance

Drafted with Claude Code: review pass, fix, regression tests, and PR text.