### PR TITLE
refactor(console): derive agent selection from query instead of mirroring

### DIFF
--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -96,16 +96,13 @@ export function ChatPage() {
   const auth = useAuth();
   const queryClient = useQueryClient();
   const userId = useRef(readStoredUserId()).current;
-  const defaultAgentIdRef = useRef(DEFAULT_AGENT_ID);
 
   const [error, setError] = useState('');
   const [editingId, setEditingId] = useState<string | null>(null);
   const [approvalBusy, setApprovalBusy] = useState(false);
   const [mobileQr, setMobileQr] = useState<ChatMobileQrResponse | null>(null);
   const [mobileQrBusy, setMobileQrBusy] = useState(false);
-  const [selectedAgentId, setSelectedAgentId] = useState(
-    defaultAgentIdRef.current,
-  );
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
   const [selectedModelId, setSelectedModelId] = useState('');
   const [recentChatScope, setRecentChatScope] =
     useState<RecentChatScope>('user');
@@ -212,16 +209,13 @@ export function ChatPage() {
     enabled: chatApiReady,
   });
 
-  useEffect(() => {
-    const id = appStatusQuery.data?.defaultAgentId;
-    if (id) {
-      const normalized = id.trim().toLowerCase();
-      defaultAgentIdRef.current = normalized;
-      setSelectedAgentId((current) =>
-        !current || current === DEFAULT_AGENT_ID ? normalized : current,
-      );
-    }
-  }, [appStatusQuery.data?.defaultAgentId]);
+  // Selection is local-once-set: until the user picks an agent the UI follows
+  // the gateway default; after they pick, their choice sticks even when the
+  // query refetches with a different default.
+  const effectiveAgentId =
+    selectedAgentId ??
+    appStatusQuery.data?.defaultAgentId?.trim().toLowerCase() ??
+    DEFAULT_AGENT_ID;
 
   // /model set is session-scoped on the gateway, so re-seed the local selection
   // to the gateway default whenever the session changes. We don't know what
@@ -828,7 +822,7 @@ export function ChatPage() {
             onUploadFiles={handleUploadFiles}
             token={auth.token}
             agents={agentOptions}
-            selectedAgentId={selectedAgentId}
+            selectedAgentId={effectiveAgentId}
             onAgentSwitch={(agentId) => void handleAgentSwitch(agentId)}
             models={modelOptions}
             selectedModelId={selectedModelId}


### PR DESCRIPTION
## Summary

`selectedAgentId` was seeded into local state via a `useEffect` watching `appStatusQuery.data.defaultAgentId` — the React 19 docs flag this exact pattern (mirror server state into state, then patch on every change) as an anti-pattern.

The effect also had a real corner-case bug: if the user explicitly picked the literal `DEFAULT_AGENT_ID` (\`'main'\`), their choice was treated as \"still default\" by the predicate and got re-overwritten by the next query refresh.

## Change

- Drop the effect and the unused \`defaultAgentIdRef\`.
- \`selectedAgentId\` becomes \`useState<string | null>(null)\` — null means \"no user choice yet\".
- Derive the displayed value inline:

  \`\`\`ts
  const effectiveAgentId =
    selectedAgentId
      ?? appStatusQuery.data?.defaultAgentId?.trim().toLowerCase()
      ?? DEFAULT_AGENT_ID;
  \`\`\`

Once the user picks, the value sticks regardless of later query refreshes.

## Test plan

- [x] All 303 console tests pass; \`chat-page.test.tsx\` (19 tests, including the agent/model dropdown sync coverage) is green.
- [x] \`npm --workspace console run typecheck\` clean.
- [x] Browser smoke test: page loads, default agent renders, picking a different agent persists across refetches.

## How surfaced

Found by an exploratory chat-implementation review. Companion to #893 (composer IME fix) — separate PRs because that one's a behavior bug fix and this one's a refactor.

## AI assistance

Drafted with Claude Code.