### PR TITLE
chore(console): remove the connected pill from admin headers

### DIFF
--- a/console/src/routes/dashboard.tsx
+++ b/console/src/routes/dashboard.tsx
@@ -220,19 +220,7 @@ export function DashboardPage() {
 
   return (
     <div className="page-stack">
-      <PageHeader
-        title="Dashboard"
-        actions={
-          <div className="status-pill">
-            <span
-              className={
-                live.connection === 'open' ? 'status-dot live' : 'status-dot'
-              }
-            />
-            {live.connection === 'open' ? 'connected' : 'polling fallback'}
-          </div>
-        }
-      />
+      <PageHeader title="Dashboard" />
 
       <div className="metric-grid">
         <MetricCard

--- a/console/src/routes/gateway.tsx
+++ b/console/src/routes/gateway.tsx
@@ -53,32 +53,22 @@ export function GatewayPage() {
       <PageHeader
         title="Gateway"
         actions={
-          <div className="button-row">
-            <div className="status-pill">
-              <span
-                className={
-                  live.connection === 'open' ? 'status-dot live' : 'status-dot'
-                }
-              />
-              {live.connection === 'open' ? 'connected' : 'status snapshot'}
-            </div>
-            <button
-              type="button"
-              className="primary-button"
-              disabled={reloadBusy}
-              onClick={() => setReloadConfirmOpen(true)}
-              aria-busy={reloadBusy}
-            >
-              {reloadBusy ? (
-                <span className="button-with-spinner">
-                  <span aria-hidden="true" className="button-spinner" />
-                  Reloading Gateway
-                </span>
-              ) : (
-                'Reload Gateway'
-              )}
-            </button>
-          </div>
+          <button
+            type="button"
+            className="primary-button"
+            disabled={reloadBusy}
+            onClick={() => setReloadConfirmOpen(true)}
+            aria-busy={reloadBusy}
+          >
+            {reloadBusy ? (
+              <span className="button-with-spinner">
+                <span aria-hidden="true" className="button-spinner" />
+                Reloading Gateway
+              </span>
+            ) : (
+              'Reload Gateway'
+            )}
+          </button>
         }
       />
       <div className="metric-grid">


### PR DESCRIPTION
## Summary

The \"● connected\" / \"● polling fallback\" pill on the Dashboard and Gateway admin pages conveyed SSE-vs-polling transport state that operators don't act on, and added visual noise to the page header. The underlying \`useLiveEvents\` hook still feeds \`live.overview\` / \`live.status\` into the page bodies — only the pill UI is removed.

## Changes

- \`console/src/routes/dashboard.tsx\` — drop the \`actions\` prop on the \`Dashboard\` PageHeader.
- \`console/src/routes/gateway.tsx\` — remove the pill from the actions slot; collapse the now-single-child \`button-row\` wrapper to just the Reload Gateway button.

## Test plan

- [x] \`npm --workspace console run typecheck\` clean.
- [x] All 300 console tests pass; no test was asserting on the pill.
- [x] Browser smoke test on \`/admin\` and \`/admin/gateway\`: pill is gone, layout intact, Reload Gateway button still works.

## AI assistance

Drafted with Claude Code.