### PR TITLE
[codex] Add A2A public-key trust ledger

### DIFF
--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -1,4 +1,6 @@
 import type {
+  AdminA2ATrustResponse,
+  AdminA2ATrustUpsertRequest,
   AdminAdaptiveSkillAmendmentsResponse,
   AdminAdaptiveSkillHealthResponse,
   AdminAgent,
@@ -230,6 +232,52 @@ export function fetchStatistics(
   return requestJson<AdminStatisticsResponse>(
     `/api/admin/statistics${search}`,
     { token },
+  );
+}
+
+export function fetchA2ATrust(token: string): Promise<AdminA2ATrustResponse> {
+  return requestJson<AdminA2ATrustResponse>('/api/admin/a2a/trust', { token });
+}
+
+export function revokeA2ATrustPeer(
+  token: string,
+  params: { peerId: string; reason?: string },
+): Promise<AdminA2ATrustResponse> {
+  const search = new URLSearchParams({ peerId: params.peerId });
+  if (params.reason?.trim()) {
+    search.set('reason', params.reason.trim());
+  }
+  return requestJson<AdminA2ATrustResponse>(
+    `/api/admin/a2a/trust?${search.toString()}`,
+    {
+      token,
+      method: 'DELETE',
+    },
+  );
+}
+
+export function upsertA2ATrustPeer(
+  token: string,
+  body: AdminA2ATrustUpsertRequest,
+): Promise<AdminA2ATrustResponse> {
+  return requestJson<AdminA2ATrustResponse>('/api/admin/a2a/trust', {
+    token,
+    method: 'POST',
+    body,
+  });
+}
+
+export function deleteA2ATrustPeer(
+  token: string,
+  peerId: string,
+): Promise<AdminA2ATrustResponse> {
+  const search = new URLSearchParams({ peerId, action: 'delete' });
+  return requestJson<AdminA2ATrustResponse>(
+    `/api/admin/a2a/trust?${search.toString()}`,
+    {
+      token,
+      method: 'DELETE',
+    },
   );
 }
 

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -1029,6 +1029,43 @@ export interface AdminAuditResponse {
   entries: AdminAuditEntry[];
 }
 
+export interface AdminA2AIdentity {
+  instanceId: string;
+  publicKeyFingerprint: string;
+  publicKeyJwk: JsonWebKey;
+}
+
+export interface AdminA2ATrustPeer {
+  peerId: string;
+  agentCardUrl: string;
+  deliveryUrl: string;
+  publicKeyFingerprint: string;
+  publicKeyJwk: JsonWebKey | null;
+  status: 'trusted' | 'revoked';
+  trustedAt: string;
+  createdAt: string;
+  updatedAt: string;
+  lastSeenAt: string;
+  revokedAt: string | null;
+  revokedReason: string | null;
+  lastMismatchAt: string | null;
+  lastMismatchFingerprint: string | null;
+}
+
+export interface AdminA2ATrustResponse {
+  identity: AdminA2AIdentity;
+  peers: AdminA2ATrustPeer[];
+}
+
+export interface AdminA2ATrustUpsertRequest {
+  peerId: string;
+  agentCardUrl?: string;
+  deliveryUrl?: string;
+  publicKeyFingerprint?: string;
+  publicKeyJwk?: JsonWebKey;
+  reason?: string;
+}
+
 export interface AdminApprovalAgent {
   id: string;
   name: string | null;

--- a/console/src/components/sidebar/navigation.ts
+++ b/console/src/components/sidebar/navigation.ts
@@ -40,6 +40,7 @@ export const SIDEBAR_NAV_GROUPS: ReadonlyArray<SidebarNavGroup> = [
       { to: '/admin', label: 'Dashboard', icon: Dashboard },
       { to: '/admin/statistics', label: 'Statistics', icon: Statistics },
       { to: '/admin/approvals', label: 'Approvals', icon: Policy },
+      { to: '/admin/a2a-trust', label: 'A2A Trust', icon: Policy },
       { to: '/admin/audit', label: 'Audit', icon: Audit },
       { to: '/admin/jobs', label: 'Jobs', icon: Jobs },
     ],

--- a/console/src/router.tsx
+++ b/console/src/router.tsx
@@ -6,6 +6,7 @@ import {
 } from '@tanstack/react-router';
 import { lazy, Suspense } from 'react';
 import { AppShell } from './components/app-shell';
+import { A2ATrustPage } from './routes/a2a-trust';
 import { AgentsPage } from './routes/agent-scoreboard';
 import { AgentFilesPage } from './routes/agents';
 import { ApprovalsPage } from './routes/approvals';
@@ -81,6 +82,12 @@ const approvalsRoute = createRoute({
   getParentRoute: () => adminLayoutRoute,
   path: '/admin/approvals',
   component: ApprovalsPage,
+});
+
+const a2aTrustRoute = createRoute({
+  getParentRoute: () => adminLayoutRoute,
+  path: '/admin/a2a-trust',
+  component: A2ATrustPage,
 });
 
 const agentFilesRoute = createRoute({
@@ -195,6 +202,7 @@ const routeTree = rootRoute.addChildren([
     dashboardRoute,
     statisticsRoute,
     approvalsRoute,
+    a2aTrustRoute,
     agentFilesRoute,
     agentScoreboardRoute,
     terminalRoute,

--- a/console/src/routes/a2a-trust.tsx
+++ b/console/src/routes/a2a-trust.tsx
@@ -1,0 +1,319 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import {
+  deleteA2ATrustPeer,
+  fetchA2ATrust,
+  revokeA2ATrustPeer,
+  upsertA2ATrustPeer,
+} from '../api/client';
+import type { AdminA2ATrustPeer } from '../api/types';
+import { useAuth } from '../auth';
+import { BooleanPill, PageHeader, Panel } from '../components/ui';
+import { formatDateTime, formatRelativeTime } from '../lib/format';
+
+function shortFingerprint(value: string): string {
+  return value.length > 18
+    ? `${value.slice(0, 12)}...${value.slice(-6)}`
+    : value;
+}
+
+function peerStatus(peer: AdminA2ATrustPeer) {
+  if (peer.status === 'revoked') {
+    return (
+      <BooleanPill value={false} falseLabel="revoked" falseTone="danger" />
+    );
+  }
+  return <BooleanPill value={true} trueLabel="trusted" />;
+}
+
+export function A2ATrustPage() {
+  const auth = useAuth();
+  const queryClient = useQueryClient();
+  const [selectedPeerId, setSelectedPeerId] = useState<string | null>(null);
+  const [revokeReason, setRevokeReason] = useState('');
+  const [pinPeerId, setPinPeerId] = useState('');
+  const [pinAgentCardUrl, setPinAgentCardUrl] = useState('');
+  const [pinDeliveryUrl, setPinDeliveryUrl] = useState('');
+  const [pinFingerprint, setPinFingerprint] = useState('');
+  const [pinPublicKeyJwk, setPinPublicKeyJwk] = useState('');
+  const [pinReason, setPinReason] = useState('');
+
+  const trustQuery = useQuery({
+    queryKey: ['a2a-trust', auth.token],
+    queryFn: () => fetchA2ATrust(auth.token),
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: (peerId: string) =>
+      revokeA2ATrustPeer(auth.token, {
+        peerId,
+        reason: revokeReason,
+      }),
+    onSuccess: (data) => {
+      queryClient.setQueryData(['a2a-trust', auth.token], data);
+    },
+  });
+
+  const upsertMutation = useMutation({
+    mutationFn: () => {
+      const publicKeyJwk = pinPublicKeyJwk.trim()
+        ? JSON.parse(pinPublicKeyJwk)
+        : undefined;
+      return upsertA2ATrustPeer(auth.token, {
+        peerId: pinPeerId,
+        agentCardUrl: pinAgentCardUrl || undefined,
+        deliveryUrl: pinDeliveryUrl || undefined,
+        publicKeyFingerprint: pinFingerprint || undefined,
+        publicKeyJwk,
+        reason: pinReason || undefined,
+      });
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(['a2a-trust', auth.token], data);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (peerId: string) => deleteA2ATrustPeer(auth.token, peerId),
+    onSuccess: (data) => {
+      queryClient.setQueryData(['a2a-trust', auth.token], data);
+      setSelectedPeerId(data.peers[0]?.peerId || null);
+    },
+  });
+
+  const peers = trustQuery.data?.peers || [];
+  const selectedPeer =
+    peers.find((peer) => peer.peerId === selectedPeerId) || peers[0] || null;
+
+  function fillSelectedPeer(peer: AdminA2ATrustPeer): void {
+    setPinPeerId(peer.peerId);
+    setPinAgentCardUrl(peer.agentCardUrl);
+    setPinDeliveryUrl(peer.deliveryUrl);
+    setPinFingerprint(peer.publicKeyFingerprint);
+    setPinPublicKeyJwk(
+      peer.publicKeyJwk ? JSON.stringify(peer.publicKeyJwk, null, 2) : '',
+    );
+    setPinReason('');
+  }
+
+  return (
+    <div className="page-stack">
+      <PageHeader title="A2A Trust" />
+
+      <Panel title="Local identity">
+        {trustQuery.isLoading ? (
+          <div className="empty-state">Loading identity...</div>
+        ) : trustQuery.data ? (
+          <div className="key-value-grid">
+            <div>
+              <span>Instance</span>
+              <strong>{trustQuery.data.identity.instanceId}</strong>
+            </div>
+            <div>
+              <span>Public key</span>
+              <strong>
+                {shortFingerprint(
+                  trustQuery.data.identity.publicKeyFingerprint,
+                )}
+              </strong>
+            </div>
+          </div>
+        ) : (
+          <div className="empty-state">Identity unavailable.</div>
+        )}
+      </Panel>
+
+      <div className="two-column-grid">
+        <Panel
+          title="Trusted peers"
+          subtitle={`${peers.length} peer${peers.length === 1 ? '' : 's'}`}
+        >
+          {trustQuery.isLoading ? (
+            <div className="empty-state">Loading peers...</div>
+          ) : peers.length ? (
+            <div className="list-stack selectable-list">
+              {peers.map((peer) => (
+                <button
+                  key={peer.peerId}
+                  className={
+                    peer.peerId === selectedPeer?.peerId
+                      ? 'selectable-row active'
+                      : 'selectable-row'
+                  }
+                  type="button"
+                  onClick={() => setSelectedPeerId(peer.peerId)}
+                >
+                  <div>
+                    <strong>{peer.peerId}</strong>
+                    <small>{shortFingerprint(peer.publicKeyFingerprint)}</small>
+                  </div>
+                  {peerStatus(peer)}
+                </button>
+              ))}
+            </div>
+          ) : (
+            <div className="empty-state">No A2A peer keys cached.</div>
+          )}
+        </Panel>
+
+        <div className="sticky-detail">
+          <Panel title="Peer detail" accent="warm">
+            {!selectedPeer ? (
+              <div className="empty-state">Select a peer.</div>
+            ) : (
+              <div className="detail-stack">
+                <div className="key-value-grid">
+                  <div>
+                    <span>Peer</span>
+                    <strong>{selectedPeer.peerId}</strong>
+                  </div>
+                  <div>
+                    <span>Status</span>
+                    <strong>{selectedPeer.status}</strong>
+                  </div>
+                  <div>
+                    <span>Trusted</span>
+                    <strong>{formatDateTime(selectedPeer.trustedAt)}</strong>
+                  </div>
+                  <div>
+                    <span>Last seen</span>
+                    <strong>
+                      {formatRelativeTime(selectedPeer.lastSeenAt)}
+                    </strong>
+                  </div>
+                  <div>
+                    <span>Agent Card</span>
+                    <strong>{selectedPeer.agentCardUrl}</strong>
+                  </div>
+                  <div>
+                    <span>Delivery URL</span>
+                    <strong>{selectedPeer.deliveryUrl}</strong>
+                  </div>
+                  <div>
+                    <span>Fingerprint</span>
+                    <strong>{selectedPeer.publicKeyFingerprint}</strong>
+                  </div>
+                  <div>
+                    <span>Mismatch</span>
+                    <strong>{selectedPeer.lastMismatchAt || 'none'}</strong>
+                  </div>
+                </div>
+
+                <label className="field">
+                  <span>Revocation reason</span>
+                  <input
+                    value={revokeReason}
+                    onChange={(event) => setRevokeReason(event.target.value)}
+                  />
+                </label>
+                <button
+                  className="danger-button"
+                  type="button"
+                  disabled={
+                    selectedPeer.status === 'revoked' ||
+                    revokeMutation.isPending
+                  }
+                  onClick={() => revokeMutation.mutate(selectedPeer.peerId)}
+                >
+                  Revoke
+                </button>
+                <button
+                  className="danger-button"
+                  type="button"
+                  disabled={deleteMutation.isPending}
+                  onClick={() => deleteMutation.mutate(selectedPeer.peerId)}
+                >
+                  Delete
+                </button>
+                <button
+                  className="primary-button"
+                  type="button"
+                  onClick={() => fillSelectedPeer(selectedPeer)}
+                >
+                  Use in override
+                </button>
+                {revokeMutation.error ? (
+                  <small className="row-status-note-danger">
+                    {revokeMutation.error instanceof Error
+                      ? revokeMutation.error.message
+                      : 'Revocation failed.'}
+                  </small>
+                ) : null}
+                {deleteMutation.error ? (
+                  <small className="row-status-note-danger">
+                    {deleteMutation.error instanceof Error
+                      ? deleteMutation.error.message
+                      : 'Delete failed.'}
+                  </small>
+                ) : null}
+              </div>
+            )}
+          </Panel>
+
+          <Panel title="Operator override">
+            <div className="detail-stack">
+              <label className="field">
+                <span>Peer</span>
+                <input
+                  value={pinPeerId}
+                  onChange={(event) => setPinPeerId(event.target.value)}
+                />
+              </label>
+              <label className="field">
+                <span>Agent Card</span>
+                <input
+                  value={pinAgentCardUrl}
+                  onChange={(event) => setPinAgentCardUrl(event.target.value)}
+                />
+              </label>
+              <label className="field">
+                <span>Delivery URL</span>
+                <input
+                  value={pinDeliveryUrl}
+                  onChange={(event) => setPinDeliveryUrl(event.target.value)}
+                />
+              </label>
+              <label className="field">
+                <span>Fingerprint</span>
+                <input
+                  value={pinFingerprint}
+                  onChange={(event) => setPinFingerprint(event.target.value)}
+                />
+              </label>
+              <label className="field">
+                <span>Public JWK</span>
+                <textarea
+                  rows={5}
+                  value={pinPublicKeyJwk}
+                  onChange={(event) => setPinPublicKeyJwk(event.target.value)}
+                />
+              </label>
+              <label className="field">
+                <span>Reason</span>
+                <input
+                  value={pinReason}
+                  onChange={(event) => setPinReason(event.target.value)}
+                />
+              </label>
+              <button
+                className="primary-button"
+                type="button"
+                disabled={!pinPeerId.trim() || upsertMutation.isPending}
+                onClick={() => upsertMutation.mutate()}
+              >
+                Trust
+              </button>
+              {upsertMutation.error ? (
+                <small className="row-status-note-danger">
+                  {upsertMutation.error instanceof Error
+                    ? upsertMutation.error.message
+                    : 'Trust update failed.'}
+                </small>
+              ) : null}
+            </div>
+          </Panel>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/a2a/a2a-outbox-delivery.ts
+++ b/src/a2a/a2a-outbox-delivery.ts
@@ -22,6 +22,11 @@ import {
 import { signA2ADelegationToken } from './delegation-token.js';
 import { summarizeA2AEnvelopeForAudit } from './envelope.js';
 import {
+  type A2APeerPublicKeyMaterial,
+  assertA2APeerPublicKeyTrust,
+  extractA2APeerPublicKey,
+} from './trust-ledger.js';
+import {
   isA2AAllowedHttpUrl,
   isA2ALoopbackHttpUrl,
   isRecord,
@@ -60,9 +65,10 @@ function resolveItemRunId(item: A2AOutboxItem, prefix: string): string {
 function assertBearerAuthConfigured(
   item: A2AOutboxItem,
   authUrl: string,
+  opts: { required?: boolean } = {},
 ): void {
   if (!item.bearerTokenRef) {
-    if (isA2ALoopbackHttpUrl(authUrl)) return;
+    if (!opts.required || isA2ALoopbackHttpUrl(authUrl)) return;
     throw new A2AFailFastError(
       'a2a.bearerTokenRef is required for non-loopback peers',
     );
@@ -84,17 +90,26 @@ function recordDelegationAuthAudit(params: {
   item: A2AOutboxItem;
   audience: string;
   scope: string;
+  peerKey?: A2APeerPublicKeyMaterial;
 }): void {
   recordA2AAudit(params.item, {
     type: 'a2a.outbound.delegation_auth',
     authMode: 'signed_delegation_jwt',
     bearerTokenRefRole: params.item.bearerTokenRef
       ? 'non_loopback_policy_gate'
-      : 'not_required_for_loopback',
+      : params.peerKey
+        ? 'not_required_public_key_trust'
+        : 'not_required_for_loopback_or_agent_card',
     bearerTokenRef: params.item.bearerTokenRef
       ? {
           source: params.item.bearerTokenRef.source,
           id: params.item.bearerTokenRef.id,
+        }
+      : null,
+    peerPublicKey: params.peerKey
+      ? {
+          peerId: params.peerKey.peerId,
+          fingerprint: params.peerKey.publicKeyFingerprint,
         }
       : null,
     audience: params.audience,
@@ -112,8 +127,12 @@ function authHeaders(params: {
   audience: string;
   scope: string;
   now: Date;
+  peerKey?: A2APeerPublicKeyMaterial;
+  requireBearer?: boolean;
 }): Record<string, string> {
-  assertBearerAuthConfigured(params.item, params.audience);
+  assertBearerAuthConfigured(params.item, params.audience, {
+    required: params.requireBearer !== false,
+  });
   recordDelegationAuthAudit(params);
   return {
     authorization: `Bearer ${signA2ADelegationToken({
@@ -332,6 +351,7 @@ export async function deliverA2AItem(
         audience: item.agentCardUrl,
         scope: A2A_AGENT_CARD_READ_SCOPE,
         now,
+        requireBearer: false,
       }),
       authCacheKey: agentCardAuthCacheKey(item),
       agentCardCacheTtlMs: opts.agentCardCacheTtlMs,
@@ -367,6 +387,24 @@ export async function deliverA2AItem(
     return 'retried';
   }
 
+  let peerKey: A2APeerPublicKeyMaterial | undefined;
+  try {
+    peerKey = extractA2APeerPublicKey(card) ?? undefined;
+    if (peerKey) {
+      assertA2APeerPublicKeyTrust({
+        agentCardUrl: item.agentCardUrl,
+        deliveryUrl: card.url,
+        key: peerKey,
+        runId: resolveItemRunId(item, 'a2a-trust'),
+        now,
+      });
+    }
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    failA2AItem(item, now, reason);
+    return 'failed';
+  }
+
   const request = encodeA2AJsonRpcRequest(item.envelope, card);
   if (!isA2AAllowedHttpUrl(card.url)) {
     failA2AItem(
@@ -391,6 +429,8 @@ export async function deliverA2AItem(
               ? A2A_TASK_SEND_SCOPE
               : A2A_MESSAGE_SEND_SCOPE,
           now,
+          peerKey,
+          requireBearer: !peerKey,
         }),
       },
       body,

--- a/src/a2a/delegation-token.ts
+++ b/src/a2a/delegation-token.ts
@@ -4,7 +4,6 @@ import {
   createPublicKey,
   generateKeyPairSync,
   type KeyObject,
-  randomUUID,
   sign,
   verify,
 } from 'node:crypto';
@@ -16,6 +15,7 @@ import {
   isCanonicalAgentIdentity,
   resolveLocalInstanceId,
 } from '../identity/agent-id.js';
+import { writeFileAtomicExclusive } from '../utils/atomic-file.js';
 import { resolveA2AAgentId } from './identity.js';
 import { isRecord } from './utils.js';
 
@@ -258,23 +258,18 @@ function writeNewKeyPair(
   keyPairPath: string,
   keyPair: A2ADelegationTokenKeyPair,
 ): void {
-  const keyPairDir = path.dirname(keyPairPath);
-  fs.mkdirSync(keyPairDir, { recursive: true });
-  const tempPath = path.join(keyPairDir, `.delegation-keypair-${randomUUID()}`);
   try {
-    // Atomic create: only one process wins if two instances bootstrap together.
-    fs.writeFileSync(tempPath, `${JSON.stringify(keyPair, null, 2)}\n`, {
-      encoding: 'utf-8',
-      flag: 'wx',
-      mode: 0o600,
-    });
-    fs.linkSync(tempPath, keyPairPath);
-    fs.chmodSync(keyPairPath, 0o600);
+    writeFileAtomicExclusive(
+      keyPairPath,
+      `${JSON.stringify(keyPair, null, 2)}\n`,
+      {
+        tempPrefix: 'delegation-keypair',
+        fileMode: 0o600,
+      },
+    );
   } catch (error) {
     const err = error as NodeJS.ErrnoException;
     if (err?.code !== 'EEXIST') throw error;
-  } finally {
-    fs.rmSync(tempPath, { force: true });
   }
 }
 

--- a/src/a2a/peer-descriptor.ts
+++ b/src/a2a/peer-descriptor.ts
@@ -24,6 +24,8 @@ const A2A_ALLOWED_FIELDS = new Set([
   'agent_card_url',
   'bearerTokenRef',
   'bearer_token_ref',
+  'expectPublicKey',
+  'expect_public_key',
 ]);
 const WEBHOOK_ALLOWED_FIELDS = new Set([
   'transport',
@@ -44,6 +46,7 @@ export interface A2APeerDescriptor {
   transport: 'a2a';
   agentCardUrl: string;
   bearerTokenRef?: SecretRef;
+  expectPublicKey?: boolean;
 }
 
 export interface WebhookPeerDescriptor {
@@ -140,6 +143,24 @@ function readOptionalString(
     return undefined;
   }
   return normalized;
+}
+
+function readOptionalBooleanAlias(
+  record: Record<string, unknown>,
+  camelKey: string,
+  snakeKey: string,
+  field: string,
+  issues: string[],
+): boolean | undefined {
+  if (!Object.hasOwn(record, camelKey) && !Object.hasOwn(record, snakeKey)) {
+    return undefined;
+  }
+  const value = readAlias(record, camelKey, snakeKey);
+  if (typeof value !== 'boolean') {
+    issues.push(`${field} must be a boolean when provided`);
+    return undefined;
+  }
+  return value;
 }
 
 function validateAllowedFields(
@@ -344,12 +365,22 @@ export function normalizePeerDescriptor(value: unknown): PeerDescriptor {
       issues,
       false,
     );
+    const expectPublicKey = readOptionalBooleanAlias(
+      value,
+      'expectPublicKey',
+      'expect_public_key',
+      'expectPublicKey',
+      issues,
+    );
     if (
       agentCardUrl &&
-      !isA2ALoopbackHttpUrl(agentCardUrl) &&
-      !bearerTokenRef
+      !bearerTokenRef &&
+      !expectPublicKey &&
+      !isA2ALoopbackHttpUrl(agentCardUrl)
     ) {
-      issues.push('bearerTokenRef is required for non-loopback a2a peers');
+      issues.push(
+        'bearerTokenRef is required for non-loopback A2A peers unless expectPublicKey is true',
+      );
     }
     if (issues.length > 0) {
       throw new PeerDescriptorValidationError(issues);
@@ -358,6 +389,7 @@ export function normalizePeerDescriptor(value: unknown): PeerDescriptor {
       transport: 'a2a',
       agentCardUrl,
       ...(bearerTokenRef ? { bearerTokenRef } : {}),
+      ...(expectPublicKey ? { expectPublicKey } : {}),
     };
   }
 

--- a/src/a2a/trust-ledger.ts
+++ b/src/a2a/trust-ledger.ts
@@ -1,15 +1,27 @@
-import { createPublicKey } from 'node:crypto';
+import {
+  createHash,
+  createPrivateKey,
+  createPublicKey,
+  generateKeyPairSync,
+  type JsonWebKey,
+  type KeyObject,
+} from 'node:crypto';
+import fs from 'node:fs';
 import path from 'node:path';
 
+import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
 import {
   getRuntimeAssetRevisionState,
   listRuntimeAssetRevisionStates,
   syncRuntimeAssetRevisionState,
 } from '../config/runtime-config-revisions.js';
 import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+import { resolveLocalInstanceId } from '../identity/agent-id.js';
 import { parseSecretInput, type SecretRef } from '../security/secret-refs.js';
+import { writeFileAtomicExclusive } from '../utils/atomic-file.js';
+import type { A2AAgentCard } from './a2a-json-rpc.js';
 import { A2AEnvelopeValidationError, classifyA2AAgentId } from './envelope.js';
-import { normalizePositiveInteger } from './utils.js';
+import { isRecord, normalizePositiveInteger } from './utils.js';
 import {
   WEBHOOK_BODY_VERSION,
   WEBHOOK_REPLAY_WINDOW_MS,
@@ -39,10 +51,29 @@ const TRUSTED_A2A_PEER_ASSET_PREFIX = path.join(
   'trust-ledger',
   'a2a',
 );
+const TRUSTED_PUBLIC_KEY_PEER_SCHEMA_VERSION = 1;
+const INSTANCE_KEYPAIR_SCHEMA_VERSION = 1;
+const INSTANCE_KEYPAIR_PATH = path.join(
+  DEFAULT_RUNTIME_HOME_DIR,
+  'a2a',
+  'identity-keypair.json',
+);
+const TRUSTED_PUBLIC_KEY_PEER_ASSET_PREFIX = path.join(
+  DEFAULT_RUNTIME_HOME_DIR,
+  'a2a',
+  'trust-ledger',
+  'public-key',
+);
+const A2A_TRUST_LEDGER_LAST_SEEN_REFRESH_MS = 60_000;
+export const A2A_TRUST_LEDGER_DEFAULT_REVOKE_REASON = 'operator revocation';
 const PEER_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 const EPOCH_ISO = new Date(0).toISOString();
+const TOFU_AUDIT_SESSION_ID = 'a2a:trust-ledger';
 
 let trustedA2APeersBySenderCache: Map<string, A2ATrustedA2APeer> | null = null;
+let cachedInstanceKeypair: A2AInstanceKeypair | null = null;
+let cachedInstancePrivateKey: KeyObject | null = null;
+let cachedInstancePublicKey: KeyObject | null = null;
 
 export interface A2ATrustedWebhookPeer {
   schemaVersion: typeof TRUSTED_WEBHOOK_PEER_SCHEMA_VERSION;
@@ -57,6 +88,53 @@ export interface A2ATrustedWebhookPeer {
   rateLimitPerMinute: number;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface A2AInstanceKeypair {
+  schemaVersion: typeof INSTANCE_KEYPAIR_SCHEMA_VERSION;
+  instanceId: string;
+  algorithm: 'Ed25519';
+  publicKeyJwk: JsonWebKey;
+  privateKeyJwk: JsonWebKey;
+  publicKeyFingerprint: string;
+  createdAt: string;
+}
+
+export type A2APublicKeyTrustStatus = 'trusted' | 'revoked';
+
+// TOFU trust records persist until operator revocation; key changes fail closed
+// and emit mismatch audit events.
+export interface A2ATrustedPublicKeyPeer {
+  schemaVersion: typeof TRUSTED_PUBLIC_KEY_PEER_SCHEMA_VERSION;
+  peerId: string;
+  agentCardUrl: string;
+  deliveryUrl: string;
+  publicKeyJwk: JsonWebKey | null;
+  publicKeyFingerprint: string;
+  status: A2APublicKeyTrustStatus;
+  trustedAt: string;
+  createdAt: string;
+  updatedAt: string;
+  lastSeenAt: string;
+  revokedAt?: string;
+  revokedReason?: string;
+  lastMismatchAt?: string;
+  lastMismatchFingerprint?: string;
+}
+
+export interface A2APeerPublicKeyMaterial {
+  peerId: string;
+  publicKeyJwk: JsonWebKey;
+  publicKeyFingerprint: string;
+}
+
+export interface UpsertA2ATrustedPublicKeyPeerInput {
+  peerId: string;
+  agentCardUrl?: string;
+  deliveryUrl?: string;
+  publicKeyJwk?: unknown;
+  publicKeyFingerprint?: string;
+  reason?: string;
 }
 
 export interface UpsertA2ATrustedWebhookPeerInput {
@@ -108,6 +186,218 @@ function trustedA2APeerAssetPath(peerId: string): string {
     TRUSTED_A2A_PEER_ASSET_PREFIX,
     `${encodeURIComponent(normalizeA2APeerId(peerId))}.json`,
   );
+}
+
+function trustedPublicKeyPeerAssetPath(peerId: string): string {
+  return path.join(
+    TRUSTED_PUBLIC_KEY_PEER_ASSET_PREFIX,
+    `${encodeURIComponent(normalizeA2APeerId(peerId))}.json`,
+  );
+}
+
+export function fingerprintA2APublicKey(publicKeyJwk: JsonWebKey): string {
+  return createHash('sha256')
+    .update(
+      JSON.stringify({
+        kty: publicKeyJwk.kty,
+        crv: publicKeyJwk.crv,
+        x: publicKeyJwk.x,
+      }),
+    )
+    .digest('base64url');
+}
+
+function normalizePublicKeyFingerprint(value: unknown): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new A2AEnvelopeValidationError(['publicKeyFingerprint is required']);
+  }
+  const normalized = value.trim();
+  if (!/^[A-Za-z0-9_-]{43}$/.test(normalized)) {
+    throw new A2AEnvelopeValidationError([
+      'publicKeyFingerprint must be a sha256 base64url fingerprint',
+    ]);
+  }
+  return normalized;
+}
+
+function normalizePublicKeyJwk(value: unknown): JsonWebKey {
+  if (!isRecord(value)) {
+    throw new A2AEnvelopeValidationError(['publicKeyJwk must be an object']);
+  }
+  const jwk = { ...value } as JsonWebKey;
+  if (jwk.kty !== 'OKP' || jwk.crv !== 'Ed25519' || typeof jwk.x !== 'string') {
+    throw new A2AEnvelopeValidationError([
+      'publicKeyJwk must be an Ed25519 public JWK',
+    ]);
+  }
+  if ('d' in jwk) {
+    throw new A2AEnvelopeValidationError([
+      'publicKeyJwk must not include private key material',
+    ]);
+  }
+  return {
+    kty: 'OKP',
+    crv: 'Ed25519',
+    x: jwk.x,
+    ...(typeof jwk.kid === 'string' && jwk.kid.trim()
+      ? { kid: jwk.kid.trim() }
+      : {}),
+  };
+}
+
+function normalizePrivateKeyJwk(value: unknown): JsonWebKey {
+  if (!isRecord(value)) {
+    throw new A2AEnvelopeValidationError(['privateKeyJwk must be an object']);
+  }
+  const jwk = { ...value } as JsonWebKey;
+  if (
+    jwk.kty !== 'OKP' ||
+    jwk.crv !== 'Ed25519' ||
+    typeof jwk.x !== 'string' ||
+    typeof jwk.d !== 'string'
+  ) {
+    throw new A2AEnvelopeValidationError([
+      'privateKeyJwk must be an Ed25519 private JWK',
+    ]);
+  }
+  return jwk;
+}
+
+function normalizeOptionalUrl(value: unknown, field: string): string {
+  if (value === undefined) return '';
+  if (typeof value !== 'string') {
+    throw new A2AEnvelopeValidationError([`${field} must be a string`]);
+  }
+  const normalized = value.trim();
+  if (!normalized) return '';
+  try {
+    new URL(normalized);
+  } catch {
+    throw new A2AEnvelopeValidationError([`${field} must be a valid URL`]);
+  }
+  return normalized;
+}
+
+function readKeypairState(): A2AInstanceKeypair | null {
+  try {
+    const parsed = JSON.parse(
+      fs.readFileSync(INSTANCE_KEYPAIR_PATH, 'utf-8'),
+    ) as A2AInstanceKeypair;
+    if (parsed.schemaVersion !== INSTANCE_KEYPAIR_SCHEMA_VERSION) return null;
+    const publicKeyJwk = normalizePublicKeyJwk(parsed.publicKeyJwk);
+    const privateKeyJwk = normalizePrivateKeyJwk(parsed.privateKeyJwk);
+    const fingerprint = fingerprintA2APublicKey(publicKeyJwk);
+    return {
+      schemaVersion: INSTANCE_KEYPAIR_SCHEMA_VERSION,
+      instanceId: normalizeA2APeerId(parsed.instanceId),
+      algorithm: 'Ed25519',
+      publicKeyJwk,
+      privateKeyJwk,
+      publicKeyFingerprint: fingerprint,
+      createdAt:
+        typeof parsed.createdAt === 'string' && parsed.createdAt
+          ? parsed.createdAt
+          : new Date(0).toISOString(),
+    };
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err?.code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+function writeNewKeypairState(state: A2AInstanceKeypair): void {
+  writeFileAtomicExclusive(
+    INSTANCE_KEYPAIR_PATH,
+    `${JSON.stringify(state, null, 2)}\n`,
+    {
+      tempPrefix: 'identity-keypair',
+      dirMode: 0o700,
+      fileMode: 0o600,
+    },
+  );
+}
+
+function cacheInstanceKeypair(state: A2AInstanceKeypair): A2AInstanceKeypair {
+  cachedInstanceKeypair = state;
+  cachedInstancePrivateKey = null;
+  cachedInstancePublicKey = null;
+  return state;
+}
+
+export function ensureA2AInstanceKeypair(now = new Date()): A2AInstanceKeypair {
+  if (cachedInstanceKeypair) return cachedInstanceKeypair;
+
+  const existing = readKeypairState();
+  if (existing) return cacheInstanceKeypair(existing);
+
+  const generated = generateKeyPairSync('ed25519');
+  const publicKeyJwk = normalizePublicKeyJwk(
+    generated.publicKey.export({ format: 'jwk' }),
+  );
+  const privateKeyJwk = normalizePrivateKeyJwk(
+    generated.privateKey.export({ format: 'jwk' }),
+  );
+  const publicKeyFingerprint = fingerprintA2APublicKey(publicKeyJwk);
+  const state: A2AInstanceKeypair = {
+    schemaVersion: INSTANCE_KEYPAIR_SCHEMA_VERSION,
+    instanceId: resolveLocalInstanceId(),
+    algorithm: 'Ed25519',
+    publicKeyJwk: {
+      ...publicKeyJwk,
+      kid: publicKeyJwk.kid || publicKeyFingerprint,
+    },
+    privateKeyJwk,
+    publicKeyFingerprint,
+    createdAt: now.toISOString(),
+  };
+
+  try {
+    writeNewKeypairState(state);
+    return cacheInstanceKeypair(state);
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err?.code !== 'EEXIST') throw error;
+    const racedState = readKeypairState();
+    if (racedState) return cacheInstanceKeypair(racedState);
+    throw error;
+  }
+}
+
+export function getA2AInstancePrivateKey(): KeyObject {
+  if (cachedInstancePrivateKey) return cachedInstancePrivateKey;
+  cachedInstancePrivateKey = createPrivateKey({
+    key: ensureA2AInstanceKeypair().privateKeyJwk,
+    format: 'jwk',
+  });
+  return cachedInstancePrivateKey;
+}
+
+export function getA2AInstancePublicKey(): KeyObject {
+  if (cachedInstancePublicKey) return cachedInstancePublicKey;
+  cachedInstancePublicKey = createPublicKey({
+    key: ensureA2AInstanceKeypair().publicKeyJwk,
+    format: 'jwk',
+  });
+  return cachedInstancePublicKey;
+}
+
+export function buildLocalA2AAgentCard(baseUrl: string): A2AAgentCard {
+  const url = new URL(baseUrl);
+  const identity = ensureA2AInstanceKeypair();
+  return {
+    name: 'HybridClaw',
+    url: new URL('/a2a', url.origin).toString(),
+    capabilities: ['message/send', 'tasks/send'],
+    hybridclaw: {
+      instanceId: identity.instanceId,
+      // This TOFU identity key identifies Agent Cards; delegation JWT verification
+      // uses delegation-token.ts until key distribution is unified.
+      publicKeyJwk: identity.publicKeyJwk,
+      publicKeyFingerprint: identity.publicKeyFingerprint,
+      trustModel: 'tofu-ed25519-v1',
+    },
+  };
 }
 
 function normalizeSenderAgentId(senderAgentId: string): string {
@@ -302,6 +592,404 @@ function parseTrustedA2APeer(raw: string): A2ATrustedA2APeer | null {
     };
   } catch {
     return null;
+  }
+}
+
+function normalizeTrustStatus(value: unknown): A2APublicKeyTrustStatus {
+  return value === 'revoked' ? 'revoked' : 'trusted';
+}
+
+function parseTrustedPublicKeyPeer(
+  raw: string,
+): A2ATrustedPublicKeyPeer | null {
+  try {
+    const parsed = JSON.parse(raw) as A2ATrustedPublicKeyPeer;
+    if (parsed.schemaVersion !== TRUSTED_PUBLIC_KEY_PEER_SCHEMA_VERSION) {
+      return null;
+    }
+    const publicKeyJwk =
+      parsed.publicKeyJwk === null || parsed.publicKeyJwk === undefined
+        ? null
+        : normalizePublicKeyJwk(parsed.publicKeyJwk);
+    const fingerprint = publicKeyJwk
+      ? fingerprintA2APublicKey(publicKeyJwk)
+      : normalizePublicKeyFingerprint(parsed.publicKeyFingerprint);
+    return {
+      schemaVersion: TRUSTED_PUBLIC_KEY_PEER_SCHEMA_VERSION,
+      peerId: normalizeA2APeerId(parsed.peerId),
+      agentCardUrl:
+        typeof parsed.agentCardUrl === 'string' ? parsed.agentCardUrl : '',
+      deliveryUrl:
+        typeof parsed.deliveryUrl === 'string' ? parsed.deliveryUrl : '',
+      publicKeyJwk,
+      publicKeyFingerprint: fingerprint,
+      status: normalizeTrustStatus(parsed.status),
+      trustedAt: parseTimestampOr(parsed.trustedAt, EPOCH_ISO),
+      createdAt: parseTimestampOr(parsed.createdAt, EPOCH_ISO),
+      updatedAt: parseTimestampOr(parsed.updatedAt, EPOCH_ISO),
+      lastSeenAt: parseTimestampOr(parsed.lastSeenAt, EPOCH_ISO),
+      ...(typeof parsed.revokedAt === 'string' && parsed.revokedAt
+        ? { revokedAt: parsed.revokedAt }
+        : {}),
+      ...(typeof parsed.revokedReason === 'string' && parsed.revokedReason
+        ? { revokedReason: parsed.revokedReason }
+        : {}),
+      ...(typeof parsed.lastMismatchAt === 'string' && parsed.lastMismatchAt
+        ? { lastMismatchAt: parsed.lastMismatchAt }
+        : {}),
+      ...(typeof parsed.lastMismatchFingerprint === 'string' &&
+      parsed.lastMismatchFingerprint
+        ? { lastMismatchFingerprint: parsed.lastMismatchFingerprint }
+        : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function shouldRefreshTrustedPublicKeyPeer(
+  peer: A2ATrustedPublicKeyPeer,
+  params: { agentCardUrl: string; deliveryUrl: string; now: Date },
+): boolean {
+  if (
+    peer.agentCardUrl !== params.agentCardUrl ||
+    peer.deliveryUrl !== params.deliveryUrl
+  ) {
+    return true;
+  }
+  const lastSeenMs = Date.parse(peer.lastSeenAt);
+  if (!Number.isFinite(lastSeenMs)) return true;
+  return (
+    params.now.getTime() - lastSeenMs >= A2A_TRUST_LEDGER_LAST_SEEN_REFRESH_MS
+  );
+}
+
+function persistTrustedPublicKeyPeer(peer: A2ATrustedPublicKeyPeer): void {
+  syncRuntimeAssetRevisionState(
+    'a2a',
+    trustedPublicKeyPeerAssetPath(peer.peerId),
+    {
+      route: `a2a.trust-ledger.public-key#${peer.peerId}`,
+      source: 'a2a-trust-ledger',
+    },
+    {
+      exists: true,
+      content: JSON.stringify(peer),
+    },
+  );
+}
+
+function resolveOperatorPublicKeyInput(
+  input: UpsertA2ATrustedPublicKeyPeerInput,
+): { publicKeyJwk: JsonWebKey | null; publicKeyFingerprint: string } {
+  const publicKeyJwk =
+    input.publicKeyJwk === undefined || input.publicKeyJwk === null
+      ? null
+      : normalizePublicKeyJwk(input.publicKeyJwk);
+  const derivedFingerprint = publicKeyJwk
+    ? fingerprintA2APublicKey(publicKeyJwk)
+    : null;
+  const providedFingerprint =
+    input.publicKeyFingerprint === undefined ||
+    input.publicKeyFingerprint === null
+      ? null
+      : normalizePublicKeyFingerprint(input.publicKeyFingerprint);
+  if (!derivedFingerprint && !providedFingerprint) {
+    throw new A2AEnvelopeValidationError([
+      'publicKeyJwk or publicKeyFingerprint is required',
+    ]);
+  }
+  if (
+    derivedFingerprint &&
+    providedFingerprint &&
+    derivedFingerprint !== providedFingerprint
+  ) {
+    throw new A2AEnvelopeValidationError([
+      'publicKeyFingerprint does not match publicKeyJwk',
+    ]);
+  }
+  return {
+    publicKeyJwk,
+    publicKeyFingerprint: providedFingerprint || derivedFingerprint || '',
+  };
+}
+
+function recordTrustAudit(params: {
+  runId?: string;
+  event: Record<string, unknown> & { type: string };
+}): void {
+  recordAuditEvent({
+    sessionId: TOFU_AUDIT_SESSION_ID,
+    runId: params.runId || makeAuditRunId('a2a-trust'),
+    event: params.event,
+  });
+}
+
+function readHybridClawCardMetadata(
+  card: A2AAgentCard,
+): Record<string, unknown> {
+  return isRecord(card.hybridclaw) ? card.hybridclaw : {};
+}
+
+function normalizePeerIdFromAgentCard(card: A2AAgentCard): string {
+  const metadata = readHybridClawCardMetadata(card);
+  const candidate =
+    typeof metadata.instanceId === 'string' && metadata.instanceId
+      ? metadata.instanceId
+      : new URL(card.url).host;
+  return normalizeA2APeerId(candidate);
+}
+
+export function extractA2APeerPublicKey(
+  card: A2AAgentCard,
+): A2APeerPublicKeyMaterial | null {
+  const metadata = readHybridClawCardMetadata(card);
+  if (!metadata.publicKeyJwk) return null;
+  const publicKeyJwk = normalizePublicKeyJwk(metadata.publicKeyJwk);
+  return {
+    peerId: normalizePeerIdFromAgentCard(card),
+    publicKeyJwk,
+    publicKeyFingerprint: fingerprintA2APublicKey(publicKeyJwk),
+  };
+}
+
+export function getA2ATrustedPublicKeyPeer(
+  peerId: string,
+): A2ATrustedPublicKeyPeer | null {
+  const state = getRuntimeAssetRevisionState(
+    'a2a',
+    trustedPublicKeyPeerAssetPath(peerId),
+  );
+  return state ? parseTrustedPublicKeyPeer(state.content) : null;
+}
+
+export function listA2ATrustedPublicKeyPeers(): A2ATrustedPublicKeyPeer[] {
+  return listRuntimeAssetRevisionStates('a2a', {
+    assetPathPrefix: TRUSTED_PUBLIC_KEY_PEER_ASSET_PREFIX,
+  })
+    .map((state) => parseTrustedPublicKeyPeer(state.content))
+    .filter((peer): peer is A2ATrustedPublicKeyPeer => peer !== null)
+    .sort((left, right) => left.peerId.localeCompare(right.peerId));
+}
+
+export function assertA2APeerPublicKeyTrust(params: {
+  agentCardUrl: string;
+  deliveryUrl: string;
+  key: A2APeerPublicKeyMaterial;
+  runId?: string;
+  now?: Date;
+}): A2ATrustedPublicKeyPeer {
+  const now = params.now ?? new Date();
+  const timestamp = now.toISOString();
+  const existing = getA2ATrustedPublicKeyPeer(params.key.peerId);
+  if (!existing) {
+    const trusted: A2ATrustedPublicKeyPeer = {
+      schemaVersion: TRUSTED_PUBLIC_KEY_PEER_SCHEMA_VERSION,
+      peerId: params.key.peerId,
+      agentCardUrl: params.agentCardUrl,
+      deliveryUrl: params.deliveryUrl,
+      publicKeyJwk: params.key.publicKeyJwk,
+      publicKeyFingerprint: params.key.publicKeyFingerprint,
+      status: 'trusted',
+      trustedAt: timestamp,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      lastSeenAt: timestamp,
+    };
+    persistTrustedPublicKeyPeer(trusted);
+    recordTrustAudit({
+      runId: params.runId,
+      event: {
+        type: 'a2a.trust.granted',
+        peerId: trusted.peerId,
+        agentCardUrl: trusted.agentCardUrl,
+        deliveryUrl: trusted.deliveryUrl,
+        publicKeyFingerprint: trusted.publicKeyFingerprint,
+        grant: 'tofu',
+      },
+    });
+    return trusted;
+  }
+
+  if (existing.publicKeyFingerprint !== params.key.publicKeyFingerprint) {
+    const mismatch: A2ATrustedPublicKeyPeer = {
+      ...existing,
+      agentCardUrl: params.agentCardUrl,
+      deliveryUrl: params.deliveryUrl,
+      updatedAt: timestamp,
+      lastMismatchAt: timestamp,
+      lastMismatchFingerprint: params.key.publicKeyFingerprint,
+    };
+    persistTrustedPublicKeyPeer(mismatch);
+    recordTrustAudit({
+      runId: params.runId,
+      event: {
+        type: 'a2a.trust.mismatch',
+        peerId: existing.peerId,
+        agentCardUrl: params.agentCardUrl,
+        deliveryUrl: params.deliveryUrl,
+        expectedPublicKeyFingerprint: existing.publicKeyFingerprint,
+        observedPublicKeyFingerprint: params.key.publicKeyFingerprint,
+        severity: 'high',
+      },
+    });
+    throw new Error(
+      `A2A peer public key mismatch for ${existing.peerId}; refusing delivery`,
+    );
+  }
+
+  if (existing.status === 'revoked') {
+    throw new Error(`A2A peer trust has been revoked for ${existing.peerId}`);
+  }
+
+  if (!existing.publicKeyJwk) {
+    const hydrated: A2ATrustedPublicKeyPeer = {
+      ...existing,
+      agentCardUrl: params.agentCardUrl,
+      deliveryUrl: params.deliveryUrl,
+      publicKeyJwk: params.key.publicKeyJwk,
+      updatedAt: timestamp,
+      lastSeenAt: timestamp,
+    };
+    persistTrustedPublicKeyPeer(hydrated);
+    recordTrustAudit({
+      runId: params.runId,
+      event: {
+        type: 'a2a.trust.pin_matched',
+        peerId: hydrated.peerId,
+        agentCardUrl: hydrated.agentCardUrl,
+        deliveryUrl: hydrated.deliveryUrl,
+        publicKeyFingerprint: hydrated.publicKeyFingerprint,
+      },
+    });
+    return hydrated;
+  }
+
+  if (
+    !shouldRefreshTrustedPublicKeyPeer(existing, {
+      agentCardUrl: params.agentCardUrl,
+      deliveryUrl: params.deliveryUrl,
+      now,
+    })
+  ) {
+    return existing;
+  }
+
+  const refreshed: A2ATrustedPublicKeyPeer = {
+    ...existing,
+    agentCardUrl: params.agentCardUrl,
+    deliveryUrl: params.deliveryUrl,
+    updatedAt: timestamp,
+    lastSeenAt: timestamp,
+  };
+  persistTrustedPublicKeyPeer(refreshed);
+  return refreshed;
+}
+
+export function revokeA2ATrustedPublicKeyPeer(
+  peerId: string,
+  params: { reason?: string; runId?: string; now?: Date } = {},
+): A2ATrustedPublicKeyPeer {
+  const normalizedPeerId = normalizeA2APeerId(peerId);
+  const existing = getA2ATrustedPublicKeyPeer(normalizedPeerId);
+  if (!existing) {
+    throw new A2AEnvelopeValidationError([
+      `trusted public-key peer not found: ${normalizedPeerId}`,
+    ]);
+  }
+  const timestamp = (params.now ?? new Date()).toISOString();
+  const revoked: A2ATrustedPublicKeyPeer = {
+    ...existing,
+    status: 'revoked',
+    updatedAt: timestamp,
+    revokedAt: timestamp,
+    revokedReason:
+      params.reason?.trim() || A2A_TRUST_LEDGER_DEFAULT_REVOKE_REASON,
+  };
+  persistTrustedPublicKeyPeer(revoked);
+  recordTrustAudit({
+    runId: params.runId,
+    event: {
+      type: 'a2a.trust.revoked',
+      peerId: revoked.peerId,
+      agentCardUrl: revoked.agentCardUrl,
+      deliveryUrl: revoked.deliveryUrl,
+      publicKeyFingerprint: revoked.publicKeyFingerprint,
+      reason: revoked.revokedReason,
+    },
+  });
+  return revoked;
+}
+
+export function upsertA2ATrustedPublicKeyPeer(
+  input: UpsertA2ATrustedPublicKeyPeerInput,
+  now = new Date(),
+): A2ATrustedPublicKeyPeer {
+  const peerId = normalizeA2APeerId(input.peerId);
+  const existing = getA2ATrustedPublicKeyPeer(peerId);
+  const key = resolveOperatorPublicKeyInput(input);
+  const timestamp = now.toISOString();
+  const peer: A2ATrustedPublicKeyPeer = {
+    schemaVersion: TRUSTED_PUBLIC_KEY_PEER_SCHEMA_VERSION,
+    peerId,
+    agentCardUrl:
+      normalizeOptionalUrl(input.agentCardUrl, 'agentCardUrl') ||
+      existing?.agentCardUrl ||
+      '',
+    deliveryUrl:
+      normalizeOptionalUrl(input.deliveryUrl, 'deliveryUrl') ||
+      existing?.deliveryUrl ||
+      '',
+    publicKeyJwk:
+      key.publicKeyJwk ||
+      (existing?.publicKeyFingerprint === key.publicKeyFingerprint
+        ? existing.publicKeyJwk
+        : null),
+    publicKeyFingerprint: key.publicKeyFingerprint,
+    status: 'trusted',
+    trustedAt: timestamp,
+    createdAt: existing?.createdAt || timestamp,
+    updatedAt: timestamp,
+    lastSeenAt: timestamp,
+  };
+  persistTrustedPublicKeyPeer(peer);
+  recordTrustAudit({
+    event: {
+      type: 'a2a.trust.operator_override',
+      peerId: peer.peerId,
+      agentCardUrl: peer.agentCardUrl,
+      deliveryUrl: peer.deliveryUrl,
+      publicKeyFingerprint: peer.publicKeyFingerprint,
+      previousStatus: existing?.status || null,
+      previousPublicKeyFingerprint: existing?.publicKeyFingerprint || null,
+      reason: input.reason?.trim() || null,
+      publicKeyMaterial: peer.publicKeyJwk ? 'jwk' : 'fingerprint',
+    },
+  });
+  return peer;
+}
+
+export function deleteA2ATrustedPublicKeyPeer(peerId: string): void {
+  const normalizedPeerId = normalizeA2APeerId(peerId);
+  const existing = getA2ATrustedPublicKeyPeer(normalizedPeerId);
+  syncRuntimeAssetRevisionState(
+    'a2a',
+    trustedPublicKeyPeerAssetPath(normalizedPeerId),
+    {
+      route: `a2a.trust-ledger.public-key#${normalizedPeerId}`,
+      source: 'a2a-trust-ledger',
+    },
+    { exists: false, content: null },
+  );
+  if (existing) {
+    recordTrustAudit({
+      event: {
+        type: 'a2a.trust.deleted',
+        peerId: existing.peerId,
+        publicKeyFingerprint: existing.publicKeyFingerprint,
+        previousStatus: existing.status,
+      },
+    });
   }
 }
 

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -143,11 +143,14 @@ import {
   applyGatewayAdminPolicyPreset,
   createGatewayAdminAgent,
   createGatewayAdminSkill,
+  deleteGatewayAdminA2ATrustPeer,
   deleteGatewayAdminAgent,
   deleteGatewayAdminEmailMessage,
   deleteGatewayAdminPolicyRule,
   deleteGatewayAdminSession,
   ensureGatewayBootstrapAutostart,
+  getGatewayA2AAgentCard,
+  getGatewayAdminA2ATrust,
   getGatewayAdminAgentMarkdownFile,
   getGatewayAdminAgentMarkdownRevision,
   getGatewayAdminAgentScoreboard,
@@ -183,6 +186,7 @@ import {
   removeGatewayAdminMcpServer,
   restoreGatewayAdminAgentMarkdownRevision,
   restoreGatewayAdminTeamStructureRevision,
+  revokeGatewayAdminA2ATrustPeer,
   saveGatewayAdminAgentMarkdownFile,
   saveGatewayAdminConfig,
   saveGatewayAdminModels,
@@ -191,10 +195,12 @@ import {
   setGatewayAdminSkillEnabled,
   updateGatewayAdminAgent,
   uploadGatewayAdminSkillZip,
+  upsertGatewayAdminA2ATrustPeer,
   upsertGatewayAdminChannel,
   upsertGatewayAdminMcpServer,
 } from './gateway-service.js';
 import type {
+  GatewayAdminA2ATrustUpsertRequest,
   GatewayChatBranchRequestBody,
   GatewayChatRequest,
   GatewayChatRequestBody,
@@ -363,6 +369,7 @@ function parseThreadReferenceListInput(value: unknown): string[] | undefined {
   if (normalized.length === 0) return undefined;
   return [...new Set(normalized)];
 }
+
 type ApiPluginToolRequestBody = {
   toolName?: unknown;
   args?: unknown;
@@ -2979,6 +2986,66 @@ async function handleApiAdminConfig(
   sendJson(res, 200, saveGatewayAdminConfig(body.config as RuntimeConfig));
 }
 
+async function handleApiAdminA2ATrust(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL,
+): Promise<void> {
+  const method = req.method || 'GET';
+  if (method === 'GET') {
+    sendJson(res, 200, getGatewayAdminA2ATrust());
+    return;
+  }
+
+  if (method === 'POST' || method === 'PUT') {
+    const body = (await readJsonBody(req).catch(() => ({}))) as
+      | GatewayAdminA2ATrustUpsertRequest
+      | undefined;
+    try {
+      sendJson(res, 200, upsertGatewayAdminA2ATrustPeer(body || {}));
+    } catch (error) {
+      sendJson(
+        res,
+        error instanceof GatewayRequestError ? error.statusCode : 400,
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+    return;
+  }
+
+  if (method !== 'DELETE') {
+    sendJson(res, 405, { error: 'Method Not Allowed' });
+    return;
+  }
+
+  const peerId = (url.searchParams.get('peerId') || '').trim();
+  if (!peerId) {
+    sendJson(res, 400, { error: 'Missing `peerId` query parameter.' });
+    return;
+  }
+  const reason = (url.searchParams.get('reason') || '').trim() || undefined;
+  const action = (url.searchParams.get('action') || '').trim();
+  try {
+    sendJson(
+      res,
+      200,
+      action === 'delete'
+        ? deleteGatewayAdminA2ATrustPeer({ peerId })
+        : revokeGatewayAdminA2ATrustPeer({ peerId, reason }),
+    );
+  } catch (error) {
+    sendJson(
+      res,
+      error instanceof GatewayRequestError ? error.statusCode : 400,
+      {
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+  }
+}
+
 async function handleApiAdminSignalLink(
   req: IncomingMessage,
   res: ServerResponse,
@@ -4380,6 +4447,10 @@ export function startGatewayHttpServer(): GatewayHttpServer {
     const voicePaths = resolveVoiceWebhookPaths(
       getRuntimeConfig().voice.webhookPath,
     );
+    if (pathname === '/.well-known/agent.json' && method === 'GET') {
+      sendJson(res, 200, getGatewayA2AAgentCard(resolveRequestOrigin(req)));
+      return;
+    }
     if (
       method === 'POST' &&
       (pathname === voicePaths.webhookPath ||
@@ -4561,6 +4632,13 @@ export function startGatewayHttpServer(): GatewayHttpServer {
             (method === 'GET' || method === 'PUT')
           ) {
             await handleApiAdminConfig(req, res);
+            return;
+          }
+          if (
+            pathname === '/api/admin/a2a/trust' &&
+            (method === 'GET' || method === 'DELETE')
+          ) {
+            await handleApiAdminA2ATrust(req, res, url);
             return;
           }
           if (

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -9,6 +9,15 @@ import {
   currentDateStampInTimezone,
   extractUserTimezone,
 } from '../../container/shared/workspace-time.js';
+import type { A2AAgentCard } from '../a2a/a2a-json-rpc.js';
+import {
+  buildLocalA2AAgentCard,
+  deleteA2ATrustedPublicKeyPeer,
+  ensureA2AInstanceKeypair,
+  listA2ATrustedPublicKeyPeers,
+  revokeA2ATrustedPublicKeyPeer,
+  upsertA2ATrustedPublicKeyPeer,
+} from '../a2a/trust-ledger.js';
 import { runAgent } from '../agent/agent.js';
 import { buildConversationContext } from '../agent/conversation.js';
 import {
@@ -416,6 +425,9 @@ import {
   reconnectGatewayAdminTunnel,
 } from './gateway-tunnel-service.js';
 import {
+  type GatewayAdminA2ATrustPeer,
+  type GatewayAdminA2ATrustResponse,
+  type GatewayAdminA2ATrustUpsertRequest,
   type GatewayAdminAgent,
   type GatewayAdminAgentMarkdownFile,
   type GatewayAdminAgentMarkdownFileResponse,
@@ -4859,6 +4871,102 @@ export function saveGatewayAdminConfig(
     path: runtimeConfigPath(),
     config: saveRuntimeConfig(next),
   };
+}
+
+function mapA2ATrustPeer(
+  peer: ReturnType<typeof listA2ATrustedPublicKeyPeers>[number],
+): GatewayAdminA2ATrustPeer {
+  return {
+    peerId: peer.peerId,
+    agentCardUrl: peer.agentCardUrl,
+    deliveryUrl: peer.deliveryUrl,
+    publicKeyFingerprint: peer.publicKeyFingerprint,
+    publicKeyJwk: peer.publicKeyJwk,
+    status: peer.status,
+    trustedAt: peer.trustedAt,
+    createdAt: peer.createdAt,
+    updatedAt: peer.updatedAt,
+    lastSeenAt: peer.lastSeenAt,
+    revokedAt: peer.revokedAt || null,
+    revokedReason: peer.revokedReason || null,
+    lastMismatchAt: peer.lastMismatchAt || null,
+    lastMismatchFingerprint: peer.lastMismatchFingerprint || null,
+  };
+}
+
+export function getGatewayAdminA2ATrust(): GatewayAdminA2ATrustResponse {
+  const identity = ensureA2AInstanceKeypair();
+  return {
+    identity: {
+      instanceId: identity.instanceId,
+      publicKeyFingerprint: identity.publicKeyFingerprint,
+      publicKeyJwk: identity.publicKeyJwk,
+    },
+    peers: listA2ATrustedPublicKeyPeers().map(mapA2ATrustPeer),
+  };
+}
+
+export function revokeGatewayAdminA2ATrustPeer(params: {
+  peerId: string;
+  reason?: string;
+}): GatewayAdminA2ATrustResponse {
+  revokeA2ATrustedPublicKeyPeer(params.peerId, {
+    reason: params.reason,
+  });
+  return getGatewayAdminA2ATrust();
+}
+
+function normalizeA2AStringInput(value: unknown, label: string): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new GatewayRequestError(400, `Expected string \`${label}\`.`);
+  }
+  return value.trim();
+}
+
+function normalizeOptionalA2AStringInput(
+  value: unknown,
+  label: string,
+): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== 'string') {
+    throw new GatewayRequestError(400, `Expected string \`${label}\`.`);
+  }
+  const normalized = value.trim();
+  return normalized || undefined;
+}
+
+export function upsertGatewayAdminA2ATrustPeer(
+  input: GatewayAdminA2ATrustUpsertRequest,
+): GatewayAdminA2ATrustResponse {
+  upsertA2ATrustedPublicKeyPeer({
+    peerId: normalizeA2AStringInput(input.peerId, 'peerId'),
+    agentCardUrl: normalizeOptionalA2AStringInput(
+      input.agentCardUrl,
+      'agentCardUrl',
+    ),
+    deliveryUrl: normalizeOptionalA2AStringInput(
+      input.deliveryUrl,
+      'deliveryUrl',
+    ),
+    publicKeyFingerprint: normalizeOptionalA2AStringInput(
+      input.publicKeyFingerprint,
+      'publicKeyFingerprint',
+    ),
+    publicKeyJwk: input.publicKeyJwk,
+    reason: normalizeOptionalA2AStringInput(input.reason, 'reason'),
+  });
+  return getGatewayAdminA2ATrust();
+}
+
+export function deleteGatewayAdminA2ATrustPeer(params: {
+  peerId: string;
+}): GatewayAdminA2ATrustResponse {
+  deleteA2ATrustedPublicKeyPeer(params.peerId);
+  return getGatewayAdminA2ATrust();
+}
+
+export function getGatewayA2AAgentCard(baseUrl: string): A2AAgentCard {
+  return buildLocalA2AAgentCard(baseUrl);
 }
 
 function mapAdminAuditEntry(

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -1,4 +1,6 @@
+import type { JsonWebKey } from 'node:crypto';
 import type { BaseMessageOptions } from 'discord.js';
+import type { A2ATrustedPublicKeyPeer } from '../a2a/trust-ledger.js';
 import type { PromptMode, PromptPartName } from '../agent/prompt-hooks.js';
 import type {
   AgentTeamStructureDiff,
@@ -883,6 +885,47 @@ export type GatewayAdminChannelUpsertRequest =
 export interface GatewayAdminConfigResponse {
   path: string;
   config: RuntimeConfig;
+}
+
+export interface GatewayAdminA2AIdentity {
+  instanceId: string;
+  publicKeyFingerprint: string;
+  publicKeyJwk: JsonWebKey;
+}
+
+type GatewayAdminA2ATrustPeerBase = Pick<
+  A2ATrustedPublicKeyPeer,
+  | 'peerId'
+  | 'agentCardUrl'
+  | 'deliveryUrl'
+  | 'publicKeyFingerprint'
+  | 'publicKeyJwk'
+  | 'status'
+  | 'trustedAt'
+  | 'createdAt'
+  | 'updatedAt'
+  | 'lastSeenAt'
+>;
+
+export interface GatewayAdminA2ATrustPeer extends GatewayAdminA2ATrustPeerBase {
+  revokedAt: string | null;
+  revokedReason: string | null;
+  lastMismatchAt: string | null;
+  lastMismatchFingerprint: string | null;
+}
+
+export interface GatewayAdminA2ATrustResponse {
+  identity: GatewayAdminA2AIdentity;
+  peers: GatewayAdminA2ATrustPeer[];
+}
+
+export interface GatewayAdminA2ATrustUpsertRequest {
+  peerId?: unknown;
+  agentCardUrl?: unknown;
+  deliveryUrl?: unknown;
+  publicKeyFingerprint?: unknown;
+  publicKeyJwk?: unknown;
+  reason?: unknown;
 }
 
 export interface GatewayAdminAgentMarkdownFile {

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -5,6 +5,7 @@ import {
   startA2AOutboxProcessor,
   stopA2AOutboxProcessor,
 } from '../a2a/a2a-outbound.js';
+import { ensureA2AInstanceKeypair } from '../a2a/trust-ledger.js';
 import {
   startWebhookOutboxProcessor,
   stopWebhookOutboxProcessor,
@@ -3038,6 +3039,7 @@ function logWarmProcessPoolStartup(config: RuntimeConfig['container']): void {
 async function main(): Promise<void> {
   await initOtel();
   logger.info('Starting HybridClaw gateway');
+  ensureA2AInstanceKeypair();
   logger.info(
     { instanceId: resolveLocalInstanceId() },
     'Local instance identity ready',

--- a/src/utils/atomic-file.ts
+++ b/src/utils/atomic-file.ts
@@ -1,0 +1,34 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export function writeFileAtomicExclusive(
+  targetPath: string,
+  content: string,
+  options: {
+    tempPrefix: string;
+    dirMode?: number;
+    fileMode?: number;
+  },
+): void {
+  const targetDir = path.dirname(targetPath);
+  fs.mkdirSync(targetDir, {
+    recursive: true,
+    ...(options.dirMode === undefined ? {} : { mode: options.dirMode }),
+  });
+  const tempPath = path.join(
+    targetDir,
+    `.${options.tempPrefix}-${randomUUID()}.tmp`,
+  );
+  try {
+    fs.writeFileSync(tempPath, content, {
+      encoding: 'utf-8',
+      flag: 'wx',
+      mode: options.fileMode ?? 0o600,
+    });
+    fs.linkSync(tempPath, targetPath);
+    fs.chmodSync(targetPath, options.fileMode ?? 0o600);
+  } finally {
+    fs.rmSync(tempPath, { force: true });
+  }
+}

--- a/tests/a2a-outbound.test.ts
+++ b/tests/a2a-outbound.test.ts
@@ -1,3 +1,4 @@
+import { generateKeyPairSync } from 'node:crypto';
 import { describe, expect, test, vi } from 'vitest';
 
 import {
@@ -18,6 +19,10 @@ function sampleA2AEnvelope(id: string, intent: 'chat' | 'handoff' = 'chat') {
     content: `A2A payload ${id}`,
     created_at: '2026-05-01T10:00:00.000Z',
   };
+}
+
+function publicKeyJwk() {
+  return generateKeyPairSync('ed25519').publicKey.export({ format: 'jwk' });
 }
 
 describe('A2A outbound adapter', () => {
@@ -428,6 +433,162 @@ describe('A2A outbound adapter', () => {
       status: 'failed',
       lastError: 'Agent Card url must use https unless targeting loopback',
     });
+  });
+
+  test('uses TOFU public-key auth when the Agent Card publishes a peer key', async () => {
+    const { initDatabase, getRecentStructuredAuditForSession } = await import(
+      '../src/memory/db.ts'
+    );
+    const runtime = await import('../src/a2a/runtime.ts');
+    const transport = await import('../src/a2a/transport-registry.ts');
+    const a2a = await import('../src/a2a/a2a-outbound.ts');
+    const trust = await import('../src/a2a/trust-ledger.ts');
+
+    initDatabase({ quiet: true });
+    const registry = new transport.TransportRegistry();
+    registry.register(new a2a.A2AOutboundAdapter());
+    const peerKey = publicKeyJwk();
+    const requests: Array<{
+      method: string;
+      authorization: string;
+      body: string;
+    }> = [];
+    const fetchImpl = vi.fn(
+      async (_url: RequestInfo | URL, init?: RequestInit) => {
+        const headers = init?.headers as Record<string, string>;
+        requests.push({
+          method: init?.method || 'GET',
+          authorization: headers?.authorization || '',
+          body: String(init?.body || ''),
+        });
+        if (init?.method === 'GET') {
+          return Response.json({
+            url: 'https://peer.example.com/a2a',
+            capabilities: [],
+            hybridclaw: {
+              instanceId: 'peer-prod',
+              publicKeyJwk: peerKey,
+            },
+          });
+        }
+        return Response.json({ jsonrpc: '2.0', result: { kind: 'message' } });
+      },
+    );
+
+    runtime.sendMessage(sampleA2AEnvelope('msg-tofu'), {
+      peerDescriptor: {
+        transport: 'a2a',
+        agentCardUrl: 'https://peer.example.com/.well-known/agent.json',
+        expectPublicKey: true,
+      },
+      transportRegistry: registry,
+      auditRunId: 'run-a2a-tofu',
+    });
+
+    await expect(a2a.processA2AOutbox({ fetchImpl })).resolves.toMatchObject({
+      processed: 1,
+      delivered: 1,
+    });
+
+    expect(requests[0]?.authorization).toMatch(/^Bearer [A-Za-z0-9_-]+\./);
+    expect(requests[1]?.authorization).toMatch(/^Bearer [A-Za-z0-9_-]+\./);
+    const token = requests[1]?.authorization.replace(/^Bearer /, '') || '';
+    const [header] = token.split('.');
+    expect(
+      JSON.parse(Buffer.from(header || '', 'base64url').toString()),
+    ).toEqual(expect.objectContaining({ alg: 'EdDSA' }));
+    expect(trust.getA2ATrustedPublicKeyPeer('peer-prod')).toMatchObject({
+      peerId: 'peer-prod',
+      status: 'trusted',
+    });
+    expect(
+      getRecentStructuredAuditForSession('a2a:trust-ledger', 10).map(
+        (event) => event.event_type,
+      ),
+    ).toContain('a2a.trust.granted');
+  });
+
+  test('fails and audits when a TOFU peer key changes', async () => {
+    const { initDatabase, getRecentStructuredAuditForSession } = await import(
+      '../src/memory/db.ts'
+    );
+    const runtime = await import('../src/a2a/runtime.ts');
+    const transport = await import('../src/a2a/transport-registry.ts');
+    const a2a = await import('../src/a2a/a2a-outbound.ts');
+
+    initDatabase({ quiet: true });
+    const registry = new transport.TransportRegistry();
+    registry.register(new a2a.A2AOutboundAdapter());
+    const firstPeerKey = publicKeyJwk();
+    const secondPeerKey = publicKeyJwk();
+    let currentPeerKey = firstPeerKey;
+    const fetchImpl = vi.fn(
+      async (_url: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === 'GET') {
+          return Response.json({
+            url: 'https://peer.example.com/a2a',
+            capabilities: [],
+            hybridclaw: {
+              instanceId: 'peer-prod',
+              publicKeyJwk: currentPeerKey,
+            },
+          });
+        }
+        return Response.json({ jsonrpc: '2.0', result: { kind: 'message' } });
+      },
+    );
+
+    runtime.sendMessage(sampleA2AEnvelope('msg-tofu-first'), {
+      peerDescriptor: {
+        transport: 'a2a',
+        agentCardUrl: 'https://peer.example.com/.well-known/agent.json',
+        expectPublicKey: true,
+      },
+      transportRegistry: registry,
+    });
+    await expect(
+      a2a.processA2AOutbox({
+        fetchImpl,
+        now: () => new Date('2030-01-01T00:00:00.000Z'),
+        agentCardCacheTtlMs: 1,
+      }),
+    ).resolves.toMatchObject({
+      delivered: 1,
+    });
+
+    currentPeerKey = secondPeerKey;
+    runtime.sendMessage(sampleA2AEnvelope('msg-tofu-mismatch'), {
+      peerDescriptor: {
+        transport: 'a2a',
+        agentCardUrl: 'https://peer.example.com/.well-known/agent.json',
+        expectPublicKey: true,
+      },
+      transportRegistry: registry,
+      sessionId: 'session-a2a-mismatch',
+    });
+    await expect(
+      a2a.processA2AOutbox({
+        fetchImpl,
+        now: () => new Date('2030-01-01T00:00:00.010Z'),
+        agentCardCacheTtlMs: 1,
+      }),
+    ).resolves.toMatchObject({
+      failed: 1,
+    });
+
+    expect(
+      a2a
+        .listA2AOutboxItems()
+        .find((item) => item.envelope.id === 'msg-tofu-mismatch'),
+    ).toMatchObject({
+      status: 'failed',
+      lastError: expect.stringContaining('public key mismatch'),
+    });
+    expect(
+      getRecentStructuredAuditForSession('a2a:trust-ledger', 10).map(
+        (event) => event.event_type,
+      ),
+    ).toContain('a2a.trust.mismatch');
   });
 
   test('requires bearer auth based on the resolved delivery URL', async () => {

--- a/tests/a2a-transport-registry.test.ts
+++ b/tests/a2a-transport-registry.test.ts
@@ -105,7 +105,7 @@ describe('A2A transport adapter registry', () => {
         transport: 'a2a',
         agentCardUrl: 'https://peer.example.com/.well-known/agent.json',
       }),
-    ).toThrow('bearerTokenRef is required for non-loopback a2a peers');
+    ).toThrow('bearerTokenRef is required');
     expect(() =>
       normalizePeerDescriptor({
         transport: 'webhook',
@@ -148,12 +148,12 @@ describe('A2A transport adapter registry', () => {
       normalizePeerDescriptor({
         transport: 'a2a',
         agent_card_url: 'https://peer.example.com/.well-known/agent.json',
-        bearer_token_ref: { source: 'env', id: 'A2A_PEER_TOKEN' },
+        expect_public_key: true,
       }),
     ).toEqual({
       transport: 'a2a',
       agentCardUrl: 'https://peer.example.com/.well-known/agent.json',
-      bearerTokenRef: { source: 'env', id: 'A2A_PEER_TOKEN' },
+      expectPublicKey: true,
     });
     expect(
       normalizePeerDescriptor({

--- a/tests/a2a-trust-ledger.test.ts
+++ b/tests/a2a-trust-ledger.test.ts
@@ -1,0 +1,264 @@
+import { generateKeyPairSync } from 'node:crypto';
+import { describe, expect, test } from 'vitest';
+
+import { setupA2AWebhookTestEnv } from './helpers/a2a-webhook-fixtures.ts';
+
+setupA2AWebhookTestEnv('hc-a2a-trust-ledger-');
+
+function peerPublicKeyJwk() {
+  const pair = generateKeyPairSync('ed25519');
+  return pair.publicKey.export({ format: 'jwk' });
+}
+
+describe('A2A public-key trust ledger', () => {
+  test('generates and persists one local instance keypair', async () => {
+    const originalInstanceId = process.env.HYBRIDCLAW_INSTANCE_ID;
+    process.env.HYBRIDCLAW_INSTANCE_ID = 'local-dev';
+    try {
+      const trust = await import('../src/a2a/trust-ledger.ts');
+
+      const first = trust.ensureA2AInstanceKeypair(
+        new Date('2030-01-01T00:00:00.000Z'),
+      );
+      const second = trust.ensureA2AInstanceKeypair(
+        new Date('2030-01-02T00:00:00.000Z'),
+      );
+
+      expect(first.instanceId).toBe('local-dev');
+      expect(second.publicKeyFingerprint).toBe(first.publicKeyFingerprint);
+      expect(second.createdAt).toBe('2030-01-01T00:00:00.000Z');
+      expect(first.publicKeyJwk).toMatchObject({
+        kty: 'OKP',
+        crv: 'Ed25519',
+      });
+    } finally {
+      if (originalInstanceId === undefined) {
+        delete process.env.HYBRIDCLAW_INSTANCE_ID;
+      } else {
+        process.env.HYBRIDCLAW_INSTANCE_ID = originalInstanceId;
+      }
+    }
+  });
+
+  test('records TOFU grants and operator revocations in audit', async () => {
+    const { initDatabase, getRecentStructuredAuditForSession } = await import(
+      '../src/memory/db.ts'
+    );
+    const trust = await import('../src/a2a/trust-ledger.ts');
+
+    initDatabase({ quiet: true });
+    const key = trust.extractA2APeerPublicKey({
+      url: 'https://peer.example.com/a2a',
+      hybridclaw: {
+        instanceId: 'peer-prod',
+        publicKeyJwk: peerPublicKeyJwk(),
+      },
+    });
+    expect(key).not.toBeNull();
+    if (!key) throw new Error('expected peer key material');
+
+    const granted = trust.assertA2APeerPublicKeyTrust({
+      agentCardUrl: 'https://peer.example.com/.well-known/agent.json',
+      deliveryUrl: 'https://peer.example.com/a2a',
+      key,
+      runId: 'run-trust-grant',
+      now: new Date('2030-01-01T00:00:00.000Z'),
+    });
+    expect(granted).toMatchObject({
+      peerId: 'peer-prod',
+      status: 'trusted',
+      trustedAt: '2030-01-01T00:00:00.000Z',
+    });
+
+    const revoked = trust.revokeA2ATrustedPublicKeyPeer('peer-prod', {
+      reason: 'rotating peer',
+      runId: 'run-trust-revoke',
+      now: new Date('2030-01-02T00:00:00.000Z'),
+    });
+    expect(revoked).toMatchObject({
+      peerId: 'peer-prod',
+      status: 'revoked',
+      revokedReason: 'rotating peer',
+    });
+
+    const auditTypes = getRecentStructuredAuditForSession(
+      'a2a:trust-ledger',
+      10,
+    ).map((entry) => entry.event_type);
+    expect(auditTypes).toContain('a2a.trust.granted');
+    expect(auditTypes).toContain('a2a.trust.revoked');
+  });
+
+  test('coalesces trusted peer last-seen refreshes', async () => {
+    const { initDatabase } = await import('../src/memory/db.ts');
+    const trust = await import('../src/a2a/trust-ledger.ts');
+
+    initDatabase({ quiet: true });
+    const key = trust.extractA2APeerPublicKey({
+      url: 'https://fresh-peer.example.com/a2a',
+      hybridclaw: {
+        instanceId: 'fresh-peer',
+        publicKeyJwk: peerPublicKeyJwk(),
+      },
+    });
+    expect(key).not.toBeNull();
+    if (!key) throw new Error('expected peer key material');
+
+    trust.assertA2APeerPublicKeyTrust({
+      agentCardUrl: 'https://fresh-peer.example.com/.well-known/agent.json',
+      deliveryUrl: 'https://fresh-peer.example.com/a2a',
+      key,
+      now: new Date('2030-01-01T00:00:00.000Z'),
+    });
+    trust.assertA2APeerPublicKeyTrust({
+      agentCardUrl: 'https://fresh-peer.example.com/.well-known/agent.json',
+      deliveryUrl: 'https://fresh-peer.example.com/a2a',
+      key,
+      now: new Date('2030-01-01T00:00:30.000Z'),
+    });
+
+    expect(trust.getA2ATrustedPublicKeyPeer('fresh-peer')).toMatchObject({
+      lastSeenAt: '2030-01-01T00:00:00.000Z',
+    });
+
+    trust.assertA2APeerPublicKeyTrust({
+      agentCardUrl: 'https://fresh-peer.example.com/.well-known/agent.json',
+      deliveryUrl: 'https://fresh-peer.example.com/a2a',
+      key,
+      now: new Date('2030-01-01T00:01:01.000Z'),
+    });
+
+    expect(trust.getA2ATrustedPublicKeyPeer('fresh-peer')).toMatchObject({
+      lastSeenAt: '2030-01-01T00:01:01.000Z',
+    });
+  });
+
+  test('allows operator pre-pinning by fingerprint before first contact', async () => {
+    const { initDatabase, getRecentStructuredAuditForSession } = await import(
+      '../src/memory/db.ts'
+    );
+    const trust = await import('../src/a2a/trust-ledger.ts');
+
+    initDatabase({ quiet: true });
+    const publicKeyJwk = peerPublicKeyJwk();
+    const publicKeyFingerprint = trust.fingerprintA2APublicKey(publicKeyJwk);
+
+    const pinned = trust.upsertA2ATrustedPublicKeyPeer(
+      {
+        peerId: 'pinned-peer',
+        agentCardUrl: 'https://pinned.example.com/.well-known/agent.json',
+        deliveryUrl: 'https://pinned.example.com/a2a',
+        publicKeyFingerprint,
+        reason: 'out-of-band fingerprint',
+      },
+      new Date('2030-01-01T00:00:00.000Z'),
+    );
+    expect(pinned).toMatchObject({
+      peerId: 'pinned-peer',
+      publicKeyJwk: null,
+      publicKeyFingerprint,
+      status: 'trusted',
+    });
+
+    const key = trust.extractA2APeerPublicKey({
+      url: 'https://pinned.example.com/a2a',
+      hybridclaw: {
+        instanceId: 'pinned-peer',
+        publicKeyJwk,
+      },
+    });
+    expect(key).not.toBeNull();
+    if (!key) throw new Error('expected peer key material');
+
+    const hydrated = trust.assertA2APeerPublicKeyTrust({
+      agentCardUrl: 'https://pinned.example.com/.well-known/agent.json',
+      deliveryUrl: 'https://pinned.example.com/a2a',
+      key,
+      now: new Date('2030-01-01T00:00:05.000Z'),
+    });
+    expect(hydrated.publicKeyJwk).toMatchObject({ kty: 'OKP', crv: 'Ed25519' });
+    expect(hydrated.lastSeenAt).toBe('2030-01-01T00:00:05.000Z');
+
+    const auditTypes = getRecentStructuredAuditForSession(
+      'a2a:trust-ledger',
+      10,
+    ).map((entry) => entry.event_type);
+    expect(auditTypes).toContain('a2a.trust.operator_override');
+    expect(auditTypes).toContain('a2a.trust.pin_matched');
+  });
+
+  test('allows operator re-trust after revocation or rotation', async () => {
+    const { initDatabase } = await import('../src/memory/db.ts');
+    const trust = await import('../src/a2a/trust-ledger.ts');
+
+    initDatabase({ quiet: true });
+    const firstKey = trust.extractA2APeerPublicKey({
+      url: 'https://rotate.example.com/a2a',
+      hybridclaw: {
+        instanceId: 'rotating-peer',
+        publicKeyJwk: peerPublicKeyJwk(),
+      },
+    });
+    const secondKey = trust.extractA2APeerPublicKey({
+      url: 'https://rotate.example.com/a2a',
+      hybridclaw: {
+        instanceId: 'rotating-peer',
+        publicKeyJwk: peerPublicKeyJwk(),
+      },
+    });
+    expect(firstKey).not.toBeNull();
+    expect(secondKey).not.toBeNull();
+    if (!firstKey || !secondKey) throw new Error('expected peer key material');
+
+    trust.assertA2APeerPublicKeyTrust({
+      agentCardUrl: 'https://rotate.example.com/.well-known/agent.json',
+      deliveryUrl: 'https://rotate.example.com/a2a',
+      key: firstKey,
+      now: new Date('2030-01-01T00:00:00.000Z'),
+    });
+    trust.revokeA2ATrustedPublicKeyPeer('rotating-peer', {
+      reason: 'rotation',
+      now: new Date('2030-01-01T00:01:00.000Z'),
+    });
+    expect(() =>
+      trust.assertA2APeerPublicKeyTrust({
+        agentCardUrl: 'https://rotate.example.com/.well-known/agent.json',
+        deliveryUrl: 'https://rotate.example.com/a2a',
+        key: secondKey,
+        now: new Date('2030-01-01T00:02:00.000Z'),
+      }),
+    ).toThrow('public key mismatch');
+
+    const trusted = trust.upsertA2ATrustedPublicKeyPeer(
+      {
+        peerId: 'rotating-peer',
+        agentCardUrl: 'https://rotate.example.com/.well-known/agent.json',
+        deliveryUrl: 'https://rotate.example.com/a2a',
+        publicKeyJwk: secondKey.publicKeyJwk,
+        reason: 'accepted rotation',
+      },
+      new Date('2030-01-01T00:03:00.000Z'),
+    );
+    expect(trusted).toMatchObject({
+      status: 'trusted',
+      publicKeyFingerprint: secondKey.publicKeyFingerprint,
+    });
+    expect(trusted.revokedAt).toBeUndefined();
+    expect(trusted.lastMismatchAt).toBeUndefined();
+
+    expect(
+      trust.assertA2APeerPublicKeyTrust({
+        agentCardUrl: 'https://rotate.example.com/.well-known/agent.json',
+        deliveryUrl: 'https://rotate.example.com/a2a',
+        key: secondKey,
+        now: new Date('2030-01-01T00:03:05.000Z'),
+      }),
+    ).toMatchObject({
+      status: 'trusted',
+      publicKeyFingerprint: secondKey.publicKeyFingerprint,
+    });
+
+    trust.deleteA2ATrustedPublicKeyPeer('rotating-peer');
+    expect(trust.getA2ATrustedPublicKeyPeer('rotating-peer')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Implements #574 by adding the public-key trust model for A2A cross-instance auth.

- Generate and persist a per-instance Ed25519 identity keypair on gateway startup.
- Publish local A2A public-key metadata via `/.well-known/agent.json`.
- Add TOFU peer-key trust records with grant, mismatch, and revocation audit events.
- Use trust-ledger EdDSA bearer tokens for A2A outbound delivery when a peer Agent Card publishes key material, while keeping descriptor bearer auth as fallback.
- Add admin API and console UI to view and revoke A2A peer trust.

## Validation

- `./node_modules/.bin/vitest run tests/a2a-trust-ledger.test.ts tests/a2a-outbound.test.ts tests/a2a-transport-registry.test.ts`
- `npm run lint`
- `git diff --check`

Fixes #574