### PR TITLE
[codex] Honor auxiliary max token limits

### DIFF
--- a/container/src/providers/auxiliary.ts
+++ b/container/src/providers/auxiliary.ts
@@ -62,6 +62,13 @@ function resolveTaskOverride(
   return taskModels?.[task];
 }
 
+function normalizeMaxTokens(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return Math.floor(value);
+}
+
 function getAuxiliaryContextError(params: {
   context: AuxiliaryTaskContext;
   toolName: string;
@@ -155,10 +162,14 @@ export async function callAuxiliaryModel(
   if (contextError) throw new Error(contextError);
 
   if (params.task !== 'vision') {
-    const maxTokens = resolveProviderRequestMaxTokens({
+    const providerMaxTokens = resolveProviderRequestMaxTokens({
       model: context.model,
       discoveredMaxTokens: context.maxTokens,
     });
+    const maxTokens =
+      providerMaxTokens == null
+        ? undefined
+        : (normalizeMaxTokens(params.maxTokens) ?? providerMaxTokens);
     const response = await callRoutedModel({
       provider: context.provider,
       providerMethod: context.providerMethod,

--- a/src/providers/auxiliary.ts
+++ b/src/providers/auxiliary.ts
@@ -211,6 +211,10 @@ function buildResolvedContext(params: {
   discoveredMaxTokens?: number;
   isLocal?: boolean;
 }): AuxiliaryTextCallContext {
+  const providerMaxTokens = resolveProviderRequestMaxTokens({
+    model: params.model,
+    discoveredMaxTokens: params.discoveredMaxTokens,
+  });
   const context: Partial<AuxiliaryTextCallContext> = {
     provider: params.provider,
     providerMethod: params.providerMethod,
@@ -220,10 +224,10 @@ function buildResolvedContext(params: {
     chatbotId: params.chatbotId.trim(),
     enableRag: params.enableRag,
     requestHeaders: params.requestHeaders ? { ...params.requestHeaders } : {},
-    maxTokens: resolveProviderRequestMaxTokens({
-      model: params.model,
-      discoveredMaxTokens: params.discoveredMaxTokens,
-    }),
+    maxTokens:
+      providerMaxTokens == null
+        ? undefined
+        : (normalizeMaxTokens(params.maxTokens) ?? providerMaxTokens),
   };
   validateContext(params.task, context);
   return context;

--- a/tests/container.auxiliary-router.test.ts
+++ b/tests/container.auxiliary-router.test.ts
@@ -261,7 +261,7 @@ describe('container auxiliary router', () => {
     });
   });
 
-  test('falls back to 32000 max_tokens for Anthropic OpenRouter fallback text calls', async () => {
+  test('honors requested max_tokens for Anthropic OpenRouter fallback text calls', async () => {
     const fetchMock = vi.fn(
       async (input: RequestInfo | URL, init?: RequestInit) => {
         expect(input).toBe('https://openrouter.ai/api/v1/chat/completions');
@@ -269,7 +269,7 @@ describe('container auxiliary router', () => {
           string,
           unknown
         >;
-        expect(body.max_tokens).toBe(32_000);
+        expect(body.max_tokens).toBe(222);
         return new Response(
           JSON.stringify({
             id: 'resp_aux_text',

--- a/tests/providers.auxiliary.test.ts
+++ b/tests/providers.auxiliary.test.ts
@@ -432,7 +432,7 @@ test('host auxiliary caller supports explicit provider overrides and max_complet
       >;
       expect(body).toMatchObject({
         model: 'anthropic/claude-sonnet-4',
-        max_tokens: 64_000,
+        max_tokens: 77,
         temperature: 0.25,
         user: 'aux-test',
       });
@@ -447,7 +447,7 @@ test('host auxiliary caller supports explicit provider overrides and max_complet
         unknown
       >;
       expect(body.max_tokens).toBeUndefined();
-      expect(body.max_completion_tokens).toBe(64_000);
+      expect(body.max_completion_tokens).toBe(77);
       return new Response(
         JSON.stringify({
           choices: [
@@ -572,7 +572,70 @@ test('host auxiliary caller uses OpenAI-compatible routing for xAI models', asyn
   });
 });
 
-test('host auxiliary caller falls back to 32000 max tokens for OpenRouter Anthropic models without discovery metadata', async () => {
+test('host auxiliary caller honors requested max tokens for OpenRouter Anthropic models', async () => {
+  const resolveTaskModelPolicy = vi.fn(async () => undefined);
+  const resolveModelRuntimeCredentials = vi.fn(async () => ({
+    provider: 'openrouter' as const,
+    apiKey: 'openrouter-key',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    chatbotId: '',
+    enableRag: false,
+    requestHeaders: {},
+    agentId: 'main',
+    isLocal: false,
+    contextWindow: 200_000,
+    thinkingFormat: undefined,
+  }));
+  setupProviderMocks({
+    resolveTaskModelPolicy,
+    resolveModelRuntimeCredentials,
+  });
+
+  const fetchMock = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input).toBe('https://openrouter.ai/api/v1/chat/completions');
+      const body = JSON.parse(String(init?.body || '{}')) as Record<
+        string,
+        unknown
+      >;
+      expect(body.max_tokens).toBe(77);
+      return new Response(
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                role: 'assistant',
+                content: 'Fallback max tokens response.',
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    },
+  );
+  vi.stubGlobal('fetch', fetchMock);
+
+  const { callAuxiliaryModel } = await import('../src/providers/auxiliary.js');
+  const result = await callAuxiliaryModel({
+    task: 'compression',
+    provider: 'openrouter',
+    model: 'anthropic/claude-sonnet-4',
+    maxTokens: 77,
+    messages: [{ role: 'user', content: 'Summarize this transcript.' }],
+  });
+
+  expect(result).toEqual({
+    provider: 'openrouter',
+    model: 'openrouter/anthropic/claude-sonnet-4',
+    content: 'Fallback max tokens response.',
+  });
+});
+
+test('host auxiliary caller falls back to 32000 max tokens for OpenRouter Anthropic models without request or discovery metadata', async () => {
   const resolveTaskModelPolicy = vi.fn(async () => undefined);
   const resolveModelRuntimeCredentials = vi.fn(async () => ({
     provider: 'openrouter' as const,
@@ -624,7 +687,6 @@ test('host auxiliary caller falls back to 32000 max tokens for OpenRouter Anthro
     task: 'compression',
     provider: 'openrouter',
     model: 'anthropic/claude-sonnet-4',
-    maxTokens: 77,
     messages: [{ role: 'user', content: 'Summarize this transcript.' }],
   });
 
@@ -662,7 +724,7 @@ test('host auxiliary caller does not retry max_completion_tokens for unrelated u
         string,
         unknown
       >;
-      expect(body.max_tokens).toBe(48_000);
+      expect(body.max_tokens).toBe(77);
       expect(body.max_completion_tokens).toBeUndefined();
       return new Response('unsupported_parameter: tools', { status: 400 });
     },
@@ -815,6 +877,7 @@ test('host auxiliary caller strips HybridAI prefix from OpenRouter fallback hint
         unknown
       >;
       expect(body.model).toBe('anthropic/claude-haiku-4-5');
+      expect(body.max_tokens).toBe(1_200);
       return new Response(
         JSON.stringify({
           choices: [
@@ -839,6 +902,7 @@ test('host auxiliary caller strips HybridAI prefix from OpenRouter fallback hint
   const result = await callAuxiliaryModel({
     task: 'cv_narration',
     agentId: 'main',
+    maxTokens: 1_200,
     messages: [{ role: 'user', content: 'Write one CV entry.' }],
   });
 


### PR DESCRIPTION
## Summary

Fix auxiliary model routing so explicit task/request `maxTokens` values cap Anthropic-family provider defaults instead of being replaced by the provider fallback limit.

## Root Cause

Host and container auxiliary routing always used `resolveProviderRequestMaxTokens()` for Anthropic-family models. When CV narration fell back to OpenRouter Anthropic models, this replaced the task's 1,200-token request with the default 32,000-token ceiling, triggering OpenRouter credit errors.

## Changes

- Prefer explicit requested max token limits when an Anthropic-family provider max-token value would otherwise be sent.
- Preserve the existing behavior of omitting `max_tokens` for non-Anthropic OpenAI-compatible routes.
- Cover host and container auxiliary routing with focused tests, including the CV narration fallback case.

## Validation

- `./node_modules/.bin/vitest run tests/providers.auxiliary.test.ts tests/container.auxiliary-router.test.ts`
- `./node_modules/.bin/biome check --write src/providers/auxiliary.ts container/src/providers/auxiliary.ts tests/providers.auxiliary.test.ts tests/container.auxiliary-router.test.ts`
- `git diff --check`

Note: targeted Vitest passed, but emitted existing environment warnings because the borrowed `node_modules` native `better-sqlite3` binary was built for a different Node module ABI.