### PR TITLE
[codex] Add A2A inbound adapter

### DIFF
--- a/src/a2a/a2a-inbound.ts
+++ b/src/a2a/a2a-inbound.ts
@@ -5,6 +5,7 @@ import { getAgentById, listAgents } from '../agents/agent-registry.js';
 import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
 import { GatewayRequestError } from '../errors/gateway-request-error.js';
 import { readRequestBody, sendJson } from '../gateway/gateway-http-utils.js';
+import { logger } from '../logger.js';
 import { decodeA2AJsonRpcRequest, type JsonRpcId } from './a2a-json-rpc.js';
 import {
   A2A_AGENT_CARD_READ_SCOPE,
@@ -13,6 +14,7 @@ import {
 } from './a2a-outbox-delivery.js';
 import {
   A2ADelegationTokenError,
+  A2ARevokedDelegationTokenError,
   decodeA2ADelegationTokenClaims,
   verifyA2ADelegationToken,
 } from './delegation-token.js';
@@ -25,6 +27,7 @@ import {
 import { resolveA2AAgentId } from './identity.js';
 import { acceptA2AInboundEnvelope } from './inbound-pipeline.js';
 import {
+  type A2AAgentCardTrustLevel,
   type A2ATrustedA2APeer,
   getA2ATrustedA2APeerBySender,
   listA2ATrustedA2APeers,
@@ -47,7 +50,7 @@ export type A2AJsonRpcInboundDownstreamDisposition =
   | 'duplicate'
   | 'rejected'
   | 'error';
-export type A2AAgentCardPeerTrustLevel = 'public' | 'trusted';
+export type A2AAgentCardPeerTrustLevel = A2AAgentCardTrustLevel;
 type A2AInboundAuthMode = 'signed_bearer' | 'peer_public_key';
 
 export type { A2ATrustedA2APeer, UpsertA2ATrustedA2APeerInput };
@@ -230,7 +233,6 @@ function recordInboundAudit(params: {
       agentId: params.agentId,
       signatureOutcome: params.signatureOutcome,
       intent: params.intent,
-      outcome: params.downstreamDisposition,
       downstreamDisposition: params.downstreamDisposition,
       statusCode: params.statusCode,
       ...(params.reason ? { reason: params.reason } : {}),
@@ -307,6 +309,8 @@ function resolveTrustedPeerForMtls(params: {
 function resolveTrustedPeerForMtlsPublicKey(
   mtlsPublicKeyPem: string,
 ): A2ATrustedA2APeer | null {
+  // Agent Card reads may not include a sender agent id, so trust is resolved
+  // from the presented certificate key alone.
   return (
     listA2ATrustedA2APeers().find((peer) =>
       publicKeysMatch(mtlsPublicKeyPem, peer.publicKeyPem),
@@ -340,12 +344,7 @@ function signatureOutcomeForError(
   error: unknown,
 ): A2AJsonRpcInboundSignatureOutcome {
   if (error instanceof A2AMissingTrustedPeerError) return 'missing_peer';
-  if (
-    error instanceof A2ADelegationTokenError &&
-    error.message.includes('revoked')
-  ) {
-    return 'revoked';
-  }
+  if (error instanceof A2ARevokedDelegationTokenError) return 'revoked';
   return 'failed';
 }
 
@@ -370,11 +369,6 @@ export function acceptA2AJsonRpcInboundRequest(params: {
     method = meta.method;
     requestId = meta.id;
     envelope = decodeA2AJsonRpcRequest(parsed);
-    if (!localRecipientResolves(envelope.recipient_agent_id)) {
-      throw new A2AEnvelopeValidationError([
-        'recipient_agent_id does not resolve to a local agent',
-      ]);
-    }
     const authorization = String(params.authorization || '').trim();
     if (authorization) {
       authMode = 'signed_bearer';
@@ -404,6 +398,11 @@ export function acceptA2AJsonRpcInboundRequest(params: {
       throw new A2ADelegationTokenError(
         'Authorization bearer token or mTLS client certificate is required',
       );
+    }
+    if (!localRecipientResolves(envelope.recipient_agent_id)) {
+      throw new A2AEnvelopeValidationError([
+        'recipient_agent_id does not resolve to a local agent',
+      ]);
     }
   } catch (error) {
     const reason = extractErrorReason(error);
@@ -511,13 +510,25 @@ export function resolveA2AAgentCardPeerTrust(params: {
         now: params.now,
       });
       return { trustLevel: 'trusted', peerId: peer.peerId };
-    } catch {
+    } catch (error) {
+      logger.debug(
+        {
+          err: error,
+          authMode: 'signed_bearer',
+          trustLevel: 'public',
+        },
+        'A2A Agent Card trust degraded to public after bearer auth failure',
+      );
       return { trustLevel: 'public' };
     }
   }
   if (params.mtlsPublicKeyPem) {
     const peer = resolveTrustedPeerForMtlsPublicKey(params.mtlsPublicKeyPem);
     if (peer) return { trustLevel: 'trusted', peerId: peer.peerId };
+    logger.debug(
+      { authMode: 'peer_public_key', trustLevel: 'public' },
+      'A2A Agent Card trust degraded to public after unmatched mTLS key',
+    );
   }
   return { trustLevel: 'public' };
 }

--- a/src/a2a/a2a-inbound.ts
+++ b/src/a2a/a2a-inbound.ts
@@ -1,4 +1,4 @@
-import { createPublicKey, X509Certificate } from 'node:crypto';
+import { X509Certificate } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
 import { getAgentById, listAgents } from '../agents/agent-registry.js';
@@ -84,18 +84,12 @@ function readHeader(
   return raw || '';
 }
 
-function publicKeyPem(value: string): string {
-  return createPublicKey(value)
-    .export({ format: 'pem', type: 'spki' })
-    .toString();
+function normalizePemText(value: string): string {
+  return value.trim().replace(/\r\n/g, '\n');
 }
 
 function publicKeysMatch(leftPem: string, rightPem: string): boolean {
-  try {
-    return publicKeyPem(leftPem) === publicKeyPem(rightPem);
-  } catch {
-    return false;
-  }
+  return normalizePemText(leftPem) === normalizePemText(rightPem);
 }
 
 export function extractA2AMtlsPublicKeyPem(
@@ -168,12 +162,14 @@ function localRecipientResolves(recipientAgentId: string): boolean {
   return localCanonicalRecipientIds().has(recipientAgentId.toLowerCase());
 }
 
-function jsonRpcRequestMeta(payload: unknown): {
+function parseJsonRpcPayload(rawBody: string): unknown {
+  return JSON.parse(rawBody) as unknown;
+}
+
+function jsonRpcRequestMeta(parsed: unknown): {
   method: 'message/send' | 'tasks/send';
   id: JsonRpcId;
 } {
-  const parsed =
-    typeof payload === 'string' ? (JSON.parse(payload) as unknown) : payload;
   if (!isRecord(parsed) || parsed.jsonrpc !== '2.0') {
     throw new A2AEnvelopeValidationError([
       'A2A JSON-RPC payload must use jsonrpc "2.0"',
@@ -369,10 +365,11 @@ export function acceptA2AJsonRpcInboundRequest(params: {
   let authMode: A2AInboundAuthMode | null = null;
 
   try {
-    const meta = jsonRpcRequestMeta(params.rawBody);
+    const parsed = parseJsonRpcPayload(params.rawBody);
+    const meta = jsonRpcRequestMeta(parsed);
     method = meta.method;
     requestId = meta.id;
-    envelope = decodeA2AJsonRpcRequest(params.rawBody);
+    envelope = decodeA2AJsonRpcRequest(parsed);
     if (!localRecipientResolves(envelope.recipient_agent_id)) {
       throw new A2AEnvelopeValidationError([
         'recipient_agent_id does not resolve to a local agent',

--- a/src/a2a/a2a-inbound.ts
+++ b/src/a2a/a2a-inbound.ts
@@ -29,6 +29,7 @@ import { acceptA2AInboundEnvelope } from './inbound-pipeline.js';
 import {
   type A2AAgentCardTrustLevel,
   type A2ATrustedA2APeer,
+  getA2ATrustedA2APeerByPublicKeyPem,
   getA2ATrustedA2APeerBySender,
   listA2ATrustedA2APeers,
   type UpsertA2ATrustedA2APeerInput,
@@ -311,11 +312,7 @@ function resolveTrustedPeerForMtlsPublicKey(
 ): A2ATrustedA2APeer | null {
   // Agent Card reads may not include a sender agent id, so trust is resolved
   // from the presented certificate key alone.
-  return (
-    listA2ATrustedA2APeers().find((peer) =>
-      publicKeysMatch(mtlsPublicKeyPem, peer.publicKeyPem),
-    ) ?? null
-  );
+  return getA2ATrustedA2APeerByPublicKeyPem(mtlsPublicKeyPem);
 }
 
 function verifySignedRequest(params: {

--- a/src/a2a/a2a-inbound.ts
+++ b/src/a2a/a2a-inbound.ts
@@ -1,11 +1,13 @@
+import { createPublicKey, X509Certificate } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
 import { getAgentById, listAgents } from '../agents/agent-registry.js';
 import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
 import { GatewayRequestError } from '../errors/gateway-request-error.js';
 import { readRequestBody, sendJson } from '../gateway/gateway-http-utils.js';
-import { decodeA2AJsonRpcRequest } from './a2a-json-rpc.js';
+import { decodeA2AJsonRpcRequest, type JsonRpcId } from './a2a-json-rpc.js';
 import {
+  A2A_AGENT_CARD_READ_SCOPE,
   A2A_MESSAGE_SEND_SCOPE,
   A2A_TASK_SEND_SCOPE,
 } from './a2a-outbox-delivery.js';
@@ -45,6 +47,8 @@ export type A2AJsonRpcInboundDownstreamDisposition =
   | 'duplicate'
   | 'rejected'
   | 'error';
+export type A2AAgentCardPeerTrustLevel = 'public' | 'trusted';
+type A2AInboundAuthMode = 'signed_bearer' | 'peer_public_key';
 
 export type { A2ATrustedA2APeer, UpsertA2ATrustedA2APeerInput };
 export { listA2ATrustedA2APeers, upsertA2ATrustedA2APeer };
@@ -52,6 +56,11 @@ export { listA2ATrustedA2APeers, upsertA2ATrustedA2APeer };
 export interface A2AJsonRpcInboundResult {
   statusCode: number;
   body: Record<string, unknown>;
+}
+
+export interface A2AAgentCardPeerTrustResult {
+  trustLevel: A2AAgentCardPeerTrustLevel;
+  peerId?: string;
 }
 
 class A2AMissingTrustedPeerError extends A2ADelegationTokenError {
@@ -73,6 +82,46 @@ function readHeader(
   const raw = headers[headerName.toLowerCase()];
   if (Array.isArray(raw)) return raw[0] || '';
   return raw || '';
+}
+
+function publicKeyPem(value: string): string {
+  return createPublicKey(value)
+    .export({ format: 'pem', type: 'spki' })
+    .toString();
+}
+
+function publicKeysMatch(leftPem: string, rightPem: string): boolean {
+  try {
+    return publicKeyPem(leftPem) === publicKeyPem(rightPem);
+  } catch {
+    return false;
+  }
+}
+
+export function extractA2AMtlsPublicKeyPem(
+  req: IncomingMessage,
+): string | null {
+  const socket = req.socket as {
+    authorized?: boolean;
+    getPeerCertificate?: (detailed?: boolean) => { raw?: Buffer } | null;
+  };
+  if (
+    socket.authorized !== true ||
+    typeof socket.getPeerCertificate !== 'function'
+  ) {
+    return null;
+  }
+  const certificate = socket.getPeerCertificate(true);
+  if (!certificate?.raw || certificate.raw.length === 0) {
+    return null;
+  }
+  try {
+    return new X509Certificate(certificate.raw).publicKey
+      .export({ format: 'pem', type: 'spki' })
+      .toString();
+  } catch {
+    return null;
+  }
 }
 
 function extractBearerToken(authorization: string | null | undefined): string {
@@ -119,7 +168,10 @@ function localRecipientResolves(recipientAgentId: string): boolean {
   return localCanonicalRecipientIds().has(recipientAgentId.toLowerCase());
 }
 
-function jsonRpcMethod(payload: unknown): 'message/send' | 'tasks/send' {
+function jsonRpcRequestMeta(payload: unknown): {
+  method: 'message/send' | 'tasks/send';
+  id: JsonRpcId;
+} {
   const parsed =
     typeof payload === 'string' ? (JSON.parse(payload) as unknown) : payload;
   if (!isRecord(parsed) || parsed.jsonrpc !== '2.0') {
@@ -132,7 +184,13 @@ function jsonRpcMethod(payload: unknown): 'message/send' | 'tasks/send' {
       'A2A JSON-RPC method must be message/send or tasks/send',
     ]);
   }
-  return parsed.method;
+  const id =
+    typeof parsed.id === 'string' ||
+    typeof parsed.id === 'number' ||
+    parsed.id === null
+      ? parsed.id
+      : null;
+  return { method: parsed.method, id };
 }
 
 function extractErrorReason(error: unknown): string {
@@ -142,9 +200,20 @@ function extractErrorReason(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function peerInstanceIdFromEnvelope(
+  envelope: A2AEnvelope | null,
+): string | null {
+  const parts = envelope?.sender_agent_id.split('@') ?? [];
+  return parts.length === 3 && parts[2] ? parts[2] : null;
+}
+
 function recordInboundAudit(params: {
   runId: string;
   peerId: string | null;
+  peerInstanceId: string | null;
+  authMode: A2AInboundAuthMode | null;
+  method: 'message/send' | 'tasks/send' | null;
+  agentId: string | null;
   signatureOutcome: A2AJsonRpcInboundSignatureOutcome;
   intent: string | null;
   downstreamDisposition: A2AJsonRpcInboundDownstreamDisposition;
@@ -159,8 +228,13 @@ function recordInboundAudit(params: {
     event: {
       type: 'a2a.inbound_post',
       peerId,
+      peerInstanceId: params.peerInstanceId,
+      authMode: params.authMode,
+      method: params.method,
+      agentId: params.agentId,
       signatureOutcome: params.signatureOutcome,
       intent: params.intent,
+      outcome: params.downstreamDisposition,
       downstreamDisposition: params.downstreamDisposition,
       statusCode: params.statusCode,
       ...(params.reason ? { reason: params.reason } : {}),
@@ -169,6 +243,37 @@ function recordInboundAudit(params: {
         : {}),
     },
   });
+}
+
+function jsonRpcErrorBody(params: {
+  id: JsonRpcId;
+  code: number;
+  message: string;
+  reason?: string;
+}): Record<string, unknown> {
+  return {
+    jsonrpc: '2.0',
+    error: {
+      code: params.code,
+      message: params.message,
+      ...(params.reason ? { data: { reason: params.reason } } : {}),
+    },
+    id: params.id,
+  };
+}
+
+function jsonRpcErrorCode(error: unknown): number {
+  if (error instanceof A2ADelegationTokenError) return -32001;
+  if (error instanceof A2AEnvelopeDuplicateError) return -32009;
+  if (error instanceof A2AEnvelopeValidationError) return -32602;
+  return -32603;
+}
+
+function jsonRpcErrorMessage(error: unknown): string {
+  if (error instanceof A2ADelegationTokenError) return 'Unauthorized';
+  if (error instanceof A2AEnvelopeDuplicateError) return 'Duplicate envelope';
+  if (error instanceof A2AEnvelopeValidationError) return 'Invalid params';
+  return 'Internal error';
 }
 
 function resolveTrustedPeerForToken(params: {
@@ -183,6 +288,34 @@ function resolveTrustedPeerForToken(params: {
     throw new A2AMissingTrustedPeerError();
   }
   return peer;
+}
+
+function resolveTrustedPeerForMtls(params: {
+  senderAgentId: string;
+  mtlsPublicKeyPem: string;
+  peer?: A2ATrustedA2APeer;
+}): A2ATrustedA2APeer {
+  const peer =
+    params.peer ?? getA2ATrustedA2APeerBySender(params.senderAgentId);
+  if (!peer) {
+    throw new A2AMissingTrustedPeerError('No trusted A2A peer for mTLS sender');
+  }
+  if (!publicKeysMatch(params.mtlsPublicKeyPem, peer.publicKeyPem)) {
+    throw new A2ADelegationTokenError(
+      'mTLS certificate public key does not match trusted A2A peer',
+    );
+  }
+  return peer;
+}
+
+function resolveTrustedPeerForMtlsPublicKey(
+  mtlsPublicKeyPem: string,
+): A2ATrustedA2APeer | null {
+  return (
+    listA2ATrustedA2APeers().find((peer) =>
+      publicKeysMatch(mtlsPublicKeyPem, peer.publicKeyPem),
+    ) ?? null
+  );
 }
 
 function verifySignedRequest(params: {
@@ -224,40 +357,67 @@ export function acceptA2AJsonRpcInboundRequest(params: {
   rawBody: string;
   authorization: string | null | undefined;
   audience: string;
+  mtlsPublicKeyPem?: string | null;
   now?: Date;
   peer?: A2ATrustedA2APeer;
 }): A2AJsonRpcInboundResult {
   const runId = makeAuditRunId('a2a-inbound');
   let envelope: A2AEnvelope | null = null;
   let peer: A2ATrustedA2APeer | null = params.peer ?? null;
+  let method: 'message/send' | 'tasks/send' | null = null;
+  let requestId: JsonRpcId = null;
+  let authMode: A2AInboundAuthMode | null = null;
 
   try {
-    const method = jsonRpcMethod(params.rawBody);
+    const meta = jsonRpcRequestMeta(params.rawBody);
+    method = meta.method;
+    requestId = meta.id;
     envelope = decodeA2AJsonRpcRequest(params.rawBody);
     if (!localRecipientResolves(envelope.recipient_agent_id)) {
       throw new A2AEnvelopeValidationError([
         'recipient_agent_id does not resolve to a local agent',
       ]);
     }
-    const token = extractBearerToken(params.authorization);
-    peer = resolveTrustedPeerForToken({
-      token,
-      peer: params.peer,
-    });
-    verifySignedRequest({
-      token,
-      envelope,
-      method,
-      audience: params.audience,
-      now: params.now,
-      peer,
-    });
+    const authorization = String(params.authorization || '').trim();
+    if (authorization) {
+      authMode = 'signed_bearer';
+      const token = extractBearerToken(params.authorization);
+      peer = resolveTrustedPeerForToken({
+        token,
+        peer: params.peer,
+      });
+      verifySignedRequest({
+        token,
+        envelope,
+        method,
+        audience: params.audience,
+        now: params.now,
+        peer,
+      });
+    } else if (params.mtlsPublicKeyPem) {
+      authMode = 'peer_public_key';
+      peer =
+        params.peer ?? getA2ATrustedA2APeerBySender(envelope.sender_agent_id);
+      peer = resolveTrustedPeerForMtls({
+        senderAgentId: envelope.sender_agent_id,
+        mtlsPublicKeyPem: params.mtlsPublicKeyPem,
+        peer: peer ?? undefined,
+      });
+    } else {
+      throw new A2ADelegationTokenError(
+        'Authorization bearer token or mTLS client certificate is required',
+      );
+    }
   } catch (error) {
     const reason = extractErrorReason(error);
     const statusCode = error instanceof A2ADelegationTokenError ? 401 : 400;
     recordInboundAudit({
       runId,
       peerId: peer?.peerId || null,
+      peerInstanceId: peerInstanceIdFromEnvelope(envelope),
+      authMode,
+      method,
+      agentId: envelope?.recipient_agent_id || null,
       signatureOutcome: signatureOutcomeForError(error),
       intent: envelope?.intent || null,
       downstreamDisposition:
@@ -270,10 +430,12 @@ export function acceptA2AJsonRpcInboundRequest(params: {
     });
     return {
       statusCode,
-      body: {
-        error:
-          error instanceof A2ADelegationTokenError ? 'Unauthorized' : reason,
-      },
+      body: jsonRpcErrorBody({
+        id: requestId,
+        code: jsonRpcErrorCode(error),
+        message: jsonRpcErrorMessage(error),
+        reason,
+      }),
     };
   }
 
@@ -287,6 +449,10 @@ export function acceptA2AJsonRpcInboundRequest(params: {
     recordInboundAudit({
       runId,
       peerId: peer.peerId,
+      peerInstanceId: peerInstanceIdFromEnvelope(envelope),
+      authMode,
+      method,
+      agentId: envelope.recipient_agent_id,
       signatureOutcome: 'passed',
       intent: envelope.intent,
       downstreamDisposition: 'delivered',
@@ -295,7 +461,11 @@ export function acceptA2AJsonRpcInboundRequest(params: {
     });
     return {
       statusCode: 202,
-      body: { ...confirmation },
+      body: {
+        jsonrpc: '2.0',
+        result: { ...confirmation },
+        id: requestId,
+      },
     };
   } catch (error) {
     const isDuplicate = error instanceof A2AEnvelopeDuplicateError;
@@ -303,6 +473,10 @@ export function acceptA2AJsonRpcInboundRequest(params: {
     recordInboundAudit({
       runId,
       peerId: peer.peerId,
+      peerInstanceId: peerInstanceIdFromEnvelope(envelope),
+      authMode,
+      method,
+      agentId: envelope.recipient_agent_id,
       signatureOutcome: 'passed',
       intent: envelope.intent,
       downstreamDisposition: isDuplicate ? 'duplicate' : 'error',
@@ -312,9 +486,43 @@ export function acceptA2AJsonRpcInboundRequest(params: {
     });
     return {
       statusCode: isDuplicate ? 409 : 500,
-      body: { error: reason },
+      body: jsonRpcErrorBody({
+        id: requestId,
+        code: jsonRpcErrorCode(error),
+        message: jsonRpcErrorMessage(error),
+        reason,
+      }),
     };
   }
+}
+
+export function resolveA2AAgentCardPeerTrust(params: {
+  authorization: string | null | undefined;
+  audience: string;
+  mtlsPublicKeyPem?: string | null;
+  now?: Date;
+}): A2AAgentCardPeerTrustResult {
+  if (String(params.authorization || '').trim()) {
+    try {
+      const token = extractBearerToken(params.authorization);
+      const peer = resolveTrustedPeerForToken({ token });
+      verifyA2ADelegationToken({
+        token,
+        publicKeyPem: peer.publicKeyPem,
+        audience: params.audience,
+        requiredScope: A2A_AGENT_CARD_READ_SCOPE,
+        now: params.now,
+      });
+      return { trustLevel: 'trusted', peerId: peer.peerId };
+    } catch {
+      return { trustLevel: 'public' };
+    }
+  }
+  if (params.mtlsPublicKeyPem) {
+    const peer = resolveTrustedPeerForMtlsPublicKey(params.mtlsPublicKeyPem);
+    if (peer) return { trustLevel: 'trusted', peerId: peer.peerId };
+  }
+  return { trustLevel: 'public' };
 }
 
 export async function handleA2AJsonRpcInbound(
@@ -339,6 +547,7 @@ export async function handleA2AJsonRpcInbound(
       rawBody,
       authorization: readHeader(req.headers, 'authorization'),
       audience: normalizeAudience(url),
+      mtlsPublicKeyPem: extractA2AMtlsPublicKeyPem(req),
     });
     sendJson(res, result.statusCode, result.body);
   } catch (error) {

--- a/src/a2a/a2a-json-rpc.ts
+++ b/src/a2a/a2a-json-rpc.ts
@@ -7,6 +7,7 @@ export type JsonRpcId = string | number | null;
 export interface A2AAgentCard {
   url: string;
   capabilities?: unknown;
+  agents?: unknown;
   skills?: unknown;
   [key: string]: unknown;
 }
@@ -52,6 +53,7 @@ function hasTaskCapability(card: A2AAgentCard): boolean {
   // object-shaped capabilities, or skill entries; accept all three shapes.
   if (Array.isArray(card.capabilities)) values.push(...card.capabilities);
   if (isRecord(card.capabilities)) {
+    if (card.capabilities.tasksSend === true) return true;
     for (const [key, value] of Object.entries(card.capabilities)) {
       values.push(key, value);
     }

--- a/src/a2a/delegation-token.ts
+++ b/src/a2a/delegation-token.ts
@@ -94,6 +94,13 @@ export class A2ADelegationTokenError extends Error {
   }
 }
 
+export class A2ARevokedDelegationTokenError extends A2ADelegationTokenError {
+  constructor(message = 'JWT has been revoked') {
+    super(message);
+    this.name = 'A2ARevokedDelegationTokenError';
+  }
+}
+
 let cachedKeyPair: A2ADelegationTokenKeyPair | null = null;
 let cachedPrivateKey: { pem: string; key: KeyObject } | null = null;
 const cachedPublicKeys = new Map<string, KeyObject>();
@@ -618,7 +625,7 @@ export function verifyA2ADelegationToken(
       revocationRootDir: input.revocationRootDir,
     })
   ) {
-    throw new A2ADelegationTokenError('JWT has been revoked');
+    throw new A2ARevokedDelegationTokenError();
   }
   return claims;
 }

--- a/src/a2a/trust-ledger.ts
+++ b/src/a2a/trust-ledger.ts
@@ -9,6 +9,8 @@ import {
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { listAgents } from '../agents/agent-registry.js';
+import type { AgentA2AExposure, AgentConfig } from '../agents/agent-types.js';
 import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
 import {
   getRuntimeAssetRevisionState,
@@ -21,6 +23,7 @@ import { parseSecretInput, type SecretRef } from '../security/secret-refs.js';
 import { writeFileAtomicExclusive } from '../utils/atomic-file.js';
 import type { A2AAgentCard } from './a2a-json-rpc.js';
 import { A2AEnvelopeValidationError, classifyA2AAgentId } from './envelope.js';
+import { resolveA2AAgentId } from './identity.js';
 import { isRecord, normalizePositiveInteger } from './utils.js';
 import {
   WEBHOOK_BODY_VERSION,
@@ -101,6 +104,7 @@ export interface A2AInstanceKeypair {
 }
 
 export type A2APublicKeyTrustStatus = 'trusted' | 'revoked';
+export type A2AAgentCardTrustLevel = 'public' | 'trusted';
 
 // TOFU trust records persist until operator revocation; key changes fail closed
 // and emit mismatch audit events.
@@ -147,6 +151,11 @@ export interface UpsertA2ATrustedWebhookPeerInput {
   version?: string;
   replayWindowMs?: number;
   rateLimitPerMinute?: number;
+}
+
+export interface BuildLocalA2AAgentCardOptions {
+  peerTrustLevel?: A2AAgentCardTrustLevel;
+  peerId?: string;
 }
 
 export interface A2ATrustedA2APeer {
@@ -382,15 +391,104 @@ export function getA2AInstancePublicKey(): KeyObject {
   return cachedInstancePublicKey;
 }
 
-export function buildLocalA2AAgentCard(baseUrl: string): A2AAgentCard {
+function exposureVisibleTo(
+  exposure: AgentA2AExposure | undefined,
+  trustLevel: A2AAgentCardTrustLevel,
+): boolean {
+  const normalized = exposure || 'public';
+  if (normalized === 'private') return false;
+  if (normalized === 'trusted') return trustLevel === 'trusted';
+  return true;
+}
+
+function agentDisplayName(agent: AgentConfig): string {
+  return agent.displayName || agent.name || agent.id;
+}
+
+function agentDescription(agent: AgentConfig): string {
+  return agent.cv?.summary || agent.role || 'HybridClaw agent';
+}
+
+function visibleAgentSkills(
+  agent: AgentConfig,
+  trustLevel: A2AAgentCardTrustLevel,
+): string[] {
+  return (agent.skills ?? []).filter((skill) =>
+    exposureVisibleTo(agent.a2a?.skillExposure?.[skill], trustLevel),
+  );
+}
+
+function buildAgentCardAgentEntry(
+  agent: AgentConfig,
+  trustLevel: A2AAgentCardTrustLevel,
+): Record<string, unknown> {
+  const canonicalAgentId = resolveA2AAgentId(agent.id);
+  return {
+    id: canonicalAgentId,
+    name: agentDisplayName(agent),
+    description: agentDescription(agent),
+    skills: visibleAgentSkills(agent, trustLevel),
+    metadata: {
+      hybridclaw: {
+        localAgentId: agent.id,
+        owner: agent.owner || null,
+        exposure: agent.a2a?.exposure || 'public',
+      },
+    },
+  };
+}
+
+function buildAgentCardSkillEntries(
+  agent: AgentConfig,
+  trustLevel: A2AAgentCardTrustLevel,
+): Record<string, unknown>[] {
+  const canonicalAgentId = resolveA2AAgentId(agent.id);
+  return visibleAgentSkills(agent, trustLevel).map((skill) => ({
+    id: `${canonicalAgentId}:skill:${skill}`,
+    name: skill,
+    agentId: canonicalAgentId,
+    metadata: {
+      hybridclaw: {
+        localAgentId: agent.id,
+        skill,
+        exposure: agent.a2a?.skillExposure?.[skill] || 'public',
+      },
+    },
+  }));
+}
+
+function visibleA2AAgents(trustLevel: A2AAgentCardTrustLevel): AgentConfig[] {
+  return listAgents().filter((agent) =>
+    exposureVisibleTo(agent.a2a?.exposure, trustLevel),
+  );
+}
+
+export function buildLocalA2AAgentCard(
+  baseUrl: string,
+  options: BuildLocalA2AAgentCardOptions = {},
+): A2AAgentCard {
   const url = new URL(baseUrl);
   const identity = ensureA2AInstanceKeypair();
+  const peerTrustLevel = options.peerTrustLevel || 'public';
+  const agents = visibleA2AAgents(peerTrustLevel);
   return {
     name: 'HybridClaw',
     url: new URL('/a2a', url.origin).toString(),
-    capabilities: ['message/send', 'tasks/send'],
+    capabilities: {
+      messageSend: true,
+      tasksSend: true,
+      streaming: false,
+    },
+    agents: agents.map((agent) =>
+      buildAgentCardAgentEntry(agent, peerTrustLevel),
+    ),
+    skills: agents.flatMap((agent) =>
+      buildAgentCardSkillEntries(agent, peerTrustLevel),
+    ),
     hybridclaw: {
       instanceId: identity.instanceId,
+      peerTrustLevel,
+      peerId: options.peerId || null,
       // This TOFU identity key identifies Agent Cards; delegation JWT verification
       // uses delegation-token.ts until key distribution is unified.
       publicKeyJwk: identity.publicKeyJwk,

--- a/src/a2a/trust-ledger.ts
+++ b/src/a2a/trust-ledger.ts
@@ -420,14 +420,14 @@ function visibleAgentSkills(
 
 function buildAgentCardAgentEntry(
   agent: AgentConfig,
-  trustLevel: A2AAgentCardTrustLevel,
+  canonicalAgentId: string,
+  skills: string[],
 ): Record<string, unknown> {
-  const canonicalAgentId = resolveA2AAgentId(agent.id);
   return {
     id: canonicalAgentId,
     name: agentDisplayName(agent),
     description: agentDescription(agent),
-    skills: visibleAgentSkills(agent, trustLevel),
+    skills,
     metadata: {
       hybridclaw: {
         localAgentId: agent.id,
@@ -440,10 +440,10 @@ function buildAgentCardAgentEntry(
 
 function buildAgentCardSkillEntries(
   agent: AgentConfig,
-  trustLevel: A2AAgentCardTrustLevel,
+  canonicalAgentId: string,
+  skills: string[],
 ): Record<string, unknown>[] {
-  const canonicalAgentId = resolveA2AAgentId(agent.id);
-  return visibleAgentSkills(agent, trustLevel).map((skill) => ({
+  return skills.map((skill) => ({
     id: `${canonicalAgentId}:skill:${skill}`,
     name: skill,
     agentId: canonicalAgentId,
@@ -470,7 +470,11 @@ export function buildLocalA2AAgentCard(
   const url = new URL(baseUrl);
   const identity = ensureA2AInstanceKeypair();
   const peerTrustLevel = options.peerTrustLevel || 'public';
-  const agents = visibleA2AAgents(peerTrustLevel);
+  const agents = visibleA2AAgents(peerTrustLevel).map((agent) => ({
+    agent,
+    canonicalAgentId: resolveA2AAgentId(agent.id),
+    skills: visibleAgentSkills(agent, peerTrustLevel),
+  }));
   return {
     name: 'HybridClaw',
     url: new URL('/a2a', url.origin).toString(),
@@ -479,11 +483,11 @@ export function buildLocalA2AAgentCard(
       tasksSend: true,
       streaming: false,
     },
-    agents: agents.map((agent) =>
-      buildAgentCardAgentEntry(agent, peerTrustLevel),
+    agents: agents.map(({ agent, canonicalAgentId, skills }) =>
+      buildAgentCardAgentEntry(agent, canonicalAgentId, skills),
     ),
-    skills: agents.flatMap((agent) =>
-      buildAgentCardSkillEntries(agent, peerTrustLevel),
+    skills: agents.flatMap(({ agent, canonicalAgentId, skills }) =>
+      buildAgentCardSkillEntries(agent, canonicalAgentId, skills),
     ),
     hybridclaw: {
       instanceId: identity.instanceId,
@@ -647,13 +651,12 @@ function parseTrustedWebhookPeer(raw: string): A2ATrustedWebhookPeer | null {
       signatureHeader: parsed.signatureHeader,
       version: parsed.version,
     });
+    const policyAuthority = normalizePolicyAuthority(parsed.policyAuthority);
     return {
       schemaVersion: TRUSTED_WEBHOOK_PEER_SCHEMA_VERSION,
       peerId: normalizeA2APeerId(parsed.peerId),
       senderAgentId: normalizeSenderAgentId(parsed.senderAgentId),
-      ...(normalizePolicyAuthority(parsed.policyAuthority)
-        ? { policyAuthority: normalizePolicyAuthority(parsed.policyAuthority) }
-        : {}),
+      ...(policyAuthority ? { policyAuthority } : {}),
       capabilities: normalizeCapabilities(parsed.capabilities),
       secretRef: webhookConfig.secretRef,
       signatureHeader: webhookConfig.signatureHeader,
@@ -1099,13 +1102,12 @@ export function upsertA2ATrustedWebhookPeer(
   const webhookConfig = normalizeTrustedWebhookPeerConfig(input);
   const existing = getA2ATrustedWebhookPeer(peerId);
   const updatedAt = now.toISOString();
+  const policyAuthority = normalizePolicyAuthority(input.policyAuthority);
   const peer: A2ATrustedWebhookPeer = {
     schemaVersion: TRUSTED_WEBHOOK_PEER_SCHEMA_VERSION,
     peerId,
     senderAgentId: normalizeSenderAgentId(input.senderAgentId),
-    ...(normalizePolicyAuthority(input.policyAuthority)
-      ? { policyAuthority: normalizePolicyAuthority(input.policyAuthority) }
-      : {}),
+    ...(policyAuthority ? { policyAuthority } : {}),
     capabilities: normalizeCapabilities(input.capabilities),
     secretRef: webhookConfig.secretRef,
     signatureHeader: webhookConfig.signatureHeader,

--- a/src/a2a/trust-ledger.ts
+++ b/src/a2a/trust-ledger.ts
@@ -32,6 +32,7 @@ import {
 } from './webhook-outbound.js';
 
 export const A2A_TRUST_LEDGER_DEFAULT_WEBHOOK_RATE_LIMIT_PER_MINUTE = 60;
+export const A2A_AGENT_CARD_STREAMING_SUPPORTED = false;
 export const A2A_POLICY_AUTHORITY_KINDS = [
   'platform',
   'org_admin',
@@ -74,6 +75,8 @@ const EPOCH_ISO = new Date(0).toISOString();
 const TOFU_AUDIT_SESSION_ID = 'a2a:trust-ledger';
 
 let trustedA2APeersBySenderCache: Map<string, A2ATrustedA2APeer> | null = null;
+let trustedA2APeersByPublicKeyCache: Map<string, A2ATrustedA2APeer> | null =
+  null;
 let cachedInstanceKeypair: A2AInstanceKeypair | null = null;
 let cachedInstancePrivateKey: KeyObject | null = null;
 let cachedInstancePublicKey: KeyObject | null = null;
@@ -481,7 +484,7 @@ export function buildLocalA2AAgentCard(
     capabilities: {
       messageSend: true,
       tasksSend: true,
-      streaming: false,
+      streaming: A2A_AGENT_CARD_STREAMING_SUPPORTED,
     },
     agents: agents.map(({ agent, canonicalAgentId, skills }) =>
       buildAgentCardAgentEntry(agent, canonicalAgentId, skills),
@@ -535,6 +538,10 @@ function normalizePublicKeyPem(value: unknown): string {
       'publicKeyPem must be a valid public key',
     ]);
   }
+}
+
+function normalizePublicKeyPemText(value: string): string {
+  return value.trim().replace(/\r\n/g, '\n');
 }
 
 function normalizeSecretRef(value: unknown): SecretRef {
@@ -1166,6 +1173,7 @@ export function upsertA2ATrustedA2APeer(
     },
   );
   trustedA2APeersBySenderCache = null;
+  trustedA2APeersByPublicKeyCache = null;
   return peer;
 }
 
@@ -1213,10 +1221,31 @@ function trustedA2APeersBySender(): Map<string, A2ATrustedA2APeer> {
   return trustedA2APeersBySenderCache;
 }
 
+function trustedA2APeersByPublicKey(): Map<string, A2ATrustedA2APeer> {
+  if (trustedA2APeersByPublicKeyCache) return trustedA2APeersByPublicKeyCache;
+  trustedA2APeersByPublicKeyCache = new Map();
+  for (const peer of listA2ATrustedA2APeers()) {
+    const publicKey = normalizePublicKeyPemText(peer.publicKeyPem);
+    if (!trustedA2APeersByPublicKeyCache.has(publicKey)) {
+      trustedA2APeersByPublicKeyCache.set(publicKey, peer);
+    }
+  }
+  return trustedA2APeersByPublicKeyCache;
+}
+
 export function getA2ATrustedA2APeerBySender(
   senderAgentId: string,
 ): A2ATrustedA2APeer | null {
   const normalizedSenderAgentId =
     normalizeCanonicalSenderAgentId(senderAgentId);
   return trustedA2APeersBySender().get(normalizedSenderAgentId) ?? null;
+}
+
+export function getA2ATrustedA2APeerByPublicKeyPem(
+  publicKeyPem: string,
+): A2ATrustedA2APeer | null {
+  return (
+    trustedA2APeersByPublicKey().get(normalizePublicKeyPemText(publicKeyPem)) ??
+    null
+  );
 }

--- a/src/agents/agent-registry.ts
+++ b/src/agents/agent-registry.ts
@@ -29,8 +29,10 @@ import {
   type AgentModelConfig,
   type AgentsConfig,
   buildOptionalAgentPresentation,
+  cloneAgentA2AConfig,
   cloneAgentCv,
   DEFAULT_AGENT_ID,
+  normalizeAgentA2AConfig,
   normalizeAgentCv,
   normalizeAgentEscalationTarget,
   resolveSnakeCamelAlias,
@@ -189,6 +191,7 @@ function normalizeAgent(value: unknown): AgentConfig | null {
   const escalationTarget = normalizeAgentEscalationTarget(
     (value as { escalationTarget?: unknown }).escalationTarget,
   );
+  const a2a = normalizeAgentA2AConfig((value as { a2a?: unknown }).a2a);
   return {
     id,
     ...(name ? { name } : {}),
@@ -205,6 +208,7 @@ function normalizeAgent(value: unknown): AgentConfig | null {
     ...(peers !== undefined ? { peers } : {}),
     ...(cv ? { cv } : {}),
     ...(escalationTarget ? { escalationTarget } : {}),
+    ...(a2a ? { a2a } : {}),
   };
 }
 
@@ -257,6 +261,12 @@ function fingerprintAgent(agent: AgentConfig): string {
     fingerprintCv(agent.cv),
     fingerprintString(agent.escalationTarget?.channel),
     fingerprintString(agent.escalationTarget?.recipient),
+    fingerprintString(agent.a2a?.exposure),
+    fingerprintStringArray(
+      Object.entries(agent.a2a?.skillExposure ?? {})
+        .map(([skill, exposure]) => `${skill}:${exposure}`)
+        .sort(),
+    ),
   ].join('|');
 }
 
@@ -335,6 +345,7 @@ function applyDefaults(agent: AgentConfig): AgentConfig {
     ...(agent.escalationTarget
       ? { escalationTarget: { ...agent.escalationTarget } }
       : {}),
+    ...(agent.a2a ? { a2a: cloneAgentA2AConfig(agent.a2a) } : {}),
   };
 }
 
@@ -385,6 +396,7 @@ function configuredAgentForDatabase(agent: AgentConfig): AgentConfig {
     peers: agent.peers,
     cv: cloneAgentCv(agent.cv),
     escalationTarget: agent.escalationTarget,
+    a2a: cloneAgentA2AConfig(agent.a2a),
   };
 }
 

--- a/src/agents/agent-types.ts
+++ b/src/agents/agent-types.ts
@@ -26,6 +26,13 @@ export interface AgentCv {
   asset?: string;
 }
 
+export type AgentA2AExposure = 'public' | 'trusted' | 'private';
+
+export interface AgentA2AConfig {
+  exposure?: AgentA2AExposure;
+  skillExposure?: Record<string, AgentA2AExposure>;
+}
+
 export interface AgentConfig {
   id: string;
   name?: string;
@@ -43,6 +50,7 @@ export interface AgentConfig {
   peers?: string[];
   cv?: AgentCv;
   escalationTarget?: EscalationTarget;
+  a2a?: AgentA2AConfig;
 }
 
 export interface AgentDefaultsConfig {
@@ -101,6 +109,63 @@ export function cloneAgentCv(value: AgentCv | undefined): AgentCv | undefined {
   return {
     ...value,
     ...(value.capabilities ? { capabilities: [...value.capabilities] } : {}),
+  };
+}
+
+function normalizeAgentA2AExposureValue(
+  value: unknown,
+): AgentA2AExposure | undefined {
+  const normalized = normalizeTrimmedString(value).toLowerCase();
+  if (
+    normalized === 'public' ||
+    normalized === 'trusted' ||
+    normalized === 'private'
+  ) {
+    return normalized;
+  }
+  return undefined;
+}
+
+export function normalizeAgentA2AConfig(
+  value: unknown,
+): AgentA2AConfig | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const exposure = normalizeAgentA2AExposureValue(record.exposure);
+  const rawSkillExposure =
+    record.skillExposure ?? record.skill_exposure ?? record.skills;
+  const skillExposure: Record<string, AgentA2AExposure> = {};
+  if (
+    rawSkillExposure &&
+    typeof rawSkillExposure === 'object' &&
+    !Array.isArray(rawSkillExposure)
+  ) {
+    for (const [rawSkill, rawExposure] of Object.entries(rawSkillExposure)) {
+      const skill = normalizeTrimmedString(rawSkill);
+      const normalizedExposure = normalizeAgentA2AExposureValue(rawExposure);
+      if (skill && normalizedExposure) {
+        skillExposure[skill] = normalizedExposure;
+      }
+    }
+  }
+  const normalized: AgentA2AConfig = {
+    ...(exposure ? { exposure } : {}),
+    ...(Object.keys(skillExposure).length > 0 ? { skillExposure } : {}),
+  };
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+export function cloneAgentA2AConfig(
+  value: AgentA2AConfig | undefined,
+): AgentA2AConfig | undefined {
+  if (!value) return undefined;
+  return {
+    ...(value.exposure ? { exposure: value.exposure } : {}),
+    ...(value.skillExposure
+      ? { skillExposure: { ...value.skillExposure } }
+      : {}),
   };
 }
 

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -11,9 +11,11 @@ import {
   type AgentModelConfig,
   type AgentsConfig,
   buildOptionalAgentPresentation,
+  cloneAgentA2AConfig,
   cloneAgentCv,
   DEFAULT_AGENT_ID,
   hasSnakeCamelAlias,
+  normalizeAgentA2AConfig,
   normalizeAgentCv,
   normalizeAgentEscalationTarget,
   resolveSnakeCamelAlias,
@@ -2424,6 +2426,9 @@ function normalizeAgentConfig(
     : fallback?.escalationTarget
       ? { ...fallback.escalationTarget }
       : undefined;
+  const a2a = Object.hasOwn(value, 'a2a')
+    ? normalizeAgentA2AConfig(value.a2a)
+    : cloneAgentA2AConfig(fallback?.a2a);
   return {
     id,
     ...(name ? { name } : {}),
@@ -2440,6 +2445,7 @@ function normalizeAgentConfig(
     ...(peers !== undefined ? { peers } : {}),
     ...(cv ? { cv } : {}),
     ...(escalationTarget ? { escalationTarget } : {}),
+    ...(a2a ? { a2a } : {}),
   };
 }
 

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -2,7 +2,11 @@ import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import http, { type IncomingMessage, type ServerResponse } from 'node:http';
 import path from 'node:path';
-import { handleA2AJsonRpcInbound } from '../a2a/a2a-inbound.js';
+import {
+  extractA2AMtlsPublicKeyPem,
+  handleA2AJsonRpcInbound,
+  resolveA2AAgentCardPeerTrust,
+} from '../a2a/a2a-inbound.js';
 import {
   handleA2AWebhookInbound,
   parseA2AWebhookInboundPath,
@@ -4448,7 +4452,20 @@ export function startGatewayHttpServer(): GatewayHttpServer {
       getRuntimeConfig().voice.webhookPath,
     );
     if (pathname === '/.well-known/agent.json' && method === 'GET') {
-      sendJson(res, 200, getGatewayA2AAgentCard(resolveRequestOrigin(req)));
+      const origin = resolveRequestOrigin(req);
+      const trust = resolveA2AAgentCardPeerTrust({
+        authorization: req.headers.authorization || '',
+        audience: new URL('/.well-known/agent.json', origin).toString(),
+        mtlsPublicKeyPem: extractA2AMtlsPublicKeyPem(req),
+      });
+      sendJson(
+        res,
+        200,
+        getGatewayA2AAgentCard(origin, {
+          peerTrustLevel: trust.trustLevel,
+          peerId: trust.peerId,
+        }),
+      );
       return;
     }
     if (

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -11,6 +11,7 @@ import {
 } from '../../container/shared/workspace-time.js';
 import type { A2AAgentCard } from '../a2a/a2a-json-rpc.js';
 import {
+  type BuildLocalA2AAgentCardOptions,
   buildLocalA2AAgentCard,
   deleteA2ATrustedPublicKeyPeer,
   ensureA2AInstanceKeypair,
@@ -4978,8 +4979,11 @@ export function deleteGatewayAdminA2ATrustPeer(params: {
   return getGatewayAdminA2ATrust();
 }
 
-export function getGatewayA2AAgentCard(baseUrl: string): A2AAgentCard {
-  return buildLocalA2AAgentCard(baseUrl);
+export function getGatewayA2AAgentCard(
+  baseUrl: string,
+  options?: BuildLocalA2AAgentCardOptions,
+): A2AAgentCard {
+  return buildLocalA2AAgentCard(baseUrl, options);
 }
 
 function mapAdminAuditEntry(

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -9,6 +9,7 @@ import type {
 } from '../agents/agent-types.js';
 import {
   DEFAULT_AGENT_ID,
+  normalizeAgentA2AConfig,
   normalizeAgentCv,
   normalizeAgentEscalationTarget,
   validateAgentOrgChart,
@@ -135,7 +136,7 @@ let db: Database.Database;
 let databaseInitialized = false;
 let usageEventBatchInsertStatement: Database.Statement | null = null;
 
-export const DATABASE_SCHEMA_VERSION = 29;
+export const DATABASE_SCHEMA_VERSION = 30;
 const STRUCTURED_AUDIT_SESSION_LIMIT = 10_000;
 const RECENT_CHAT_MESSAGE_SEARCH_TABLE = 'recent_chat_message_search';
 const RECENT_CHAT_MESSAGE_SEARCH_INSERT_TRIGGER =
@@ -192,6 +193,7 @@ type AgentRow = {
   peers: string | null;
   cv: string | null;
   escalation_target: string | null;
+  a2a: string | null;
   created_at: string;
   updated_at: string;
 };
@@ -1269,6 +1271,7 @@ function migrateV6(
         chatbot_id TEXT,
         enable_rag INTEGER DEFAULT 1,
         workspace TEXT,
+        a2a TEXT,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
       );
@@ -2322,6 +2325,20 @@ function migrateV29(database: Database.Database): void {
   );
 }
 
+function migrateV30(
+  database: Database.Database,
+  opts?: InitDatabaseOptions,
+): void {
+  addColumnIfMissing({
+    database,
+    table: 'agents',
+    column: 'a2a',
+    ddl: 'a2a TEXT',
+    quiet: opts?.quiet === true,
+  });
+  recordMigration(database, 30, 'Persist per-agent A2A visibility metadata');
+}
+
 function runMigrations(
   database: Database.Database,
   opts?: InitDatabaseOptions,
@@ -2389,6 +2406,7 @@ function runMigrations(
   ) {
     migrateV29(database);
   }
+  if (currentVersion < 30) migrateV30(database, opts);
 
   setSchemaVersion(database, DATABASE_SCHEMA_VERSION);
   if (!quiet && currentVersion < DATABASE_SCHEMA_VERSION) {
@@ -2613,6 +2631,25 @@ function parseAgentEscalationTarget(
   }
 }
 
+function serializeAgentA2AConfig(a2a: AgentConfig['a2a']): string | null {
+  return a2a ? JSON.stringify(a2a) : null;
+}
+
+function parseAgentA2AConfig(rawConfig: string | null): AgentConfig['a2a'] {
+  const normalized = rawConfig?.trim() || '';
+  if (!normalized) return undefined;
+
+  try {
+    return normalizeAgentA2AConfig(JSON.parse(normalized));
+  } catch {
+    logger.warn(
+      { configLength: normalized.length },
+      'Failed to parse persisted agent A2A configuration',
+    );
+    return undefined;
+  }
+}
+
 function mapAgentRow(row: AgentRow): AgentConfig {
   const name = row.name?.trim() || '';
   const displayName = row.display_name?.trim() || '';
@@ -2628,6 +2665,7 @@ function mapAgentRow(row: AgentRow): AgentConfig {
   const peers = parseAgentStringArray(row.peers, 'peers');
   const cv = parseAgentCv(row.cv);
   const escalationTarget = parseAgentEscalationTarget(row.escalation_target);
+  const a2a = parseAgentA2AConfig(row.a2a);
   return {
     id: row.id,
     ...(name ? { name } : {}),
@@ -2647,11 +2685,12 @@ function mapAgentRow(row: AgentRow): AgentConfig {
     ...(peers !== undefined ? { peers } : {}),
     ...(cv ? { cv } : {}),
     ...(escalationTarget ? { escalationTarget } : {}),
+    ...(a2a ? { a2a } : {}),
   };
 }
 
 const AGENT_SELECT_COLUMNS =
-  'id, name, display_name, image_asset, model, skills, chatbot_id, enable_rag, workspace, owner, role, reports_to, delegates_to, peers, cv, escalation_target, created_at, updated_at';
+  'id, name, display_name, image_asset, model, skills, chatbot_id, enable_rag, workspace, owner, role, reports_to, delegates_to, peers, cv, escalation_target, a2a, created_at, updated_at';
 
 export function getAgentById(agentId: string): AgentConfig | null {
   const normalizedAgentId = agentId.trim();
@@ -2698,6 +2737,7 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
   const normalizedEscalationTarget = serializeAgentEscalationTarget(
     agent.escalationTarget,
   );
+  const normalizedA2A = serializeAgentA2AConfig(agent.a2a);
   const enableRag =
     typeof agent.enableRag === 'boolean' ? (agent.enableRag ? 1 : 0) : null;
   db.prepare(
@@ -2718,9 +2758,10 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
        peers,
        cv,
        escalation_target,
+       a2a,
        created_at,
        updated_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
      ON CONFLICT(id) DO UPDATE SET
        name = excluded.name,
        display_name = excluded.display_name,
@@ -2737,6 +2778,7 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
        peers = excluded.peers,
        cv = excluded.cv,
        escalation_target = excluded.escalation_target,
+       a2a = excluded.a2a,
        updated_at = datetime('now')`,
   ).run(
     normalizedId,
@@ -2755,6 +2797,7 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
     normalizedPeers,
     normalizedCv,
     normalizedEscalationTarget,
+    normalizedA2A,
   );
   const storedAgent = getAgentById(normalizedId);
   if (!storedAgent) {

--- a/tests/a2a-inbound.test.ts
+++ b/tests/a2a-inbound.test.ts
@@ -1,3 +1,4 @@
+import { generateKeyPairSync } from 'node:crypto';
 import { describe, expect, test } from 'vitest';
 
 import { encodeA2AJsonRpcRequest } from '../src/a2a/a2a-json-rpc.ts';
@@ -113,9 +114,12 @@ describe('A2A JSON-RPC inbound adapter', () => {
     expect(result).toMatchObject({
       statusCode: 202,
       body: {
-        delivered: true,
-        message_id: 'msg-inbound-a2a-1',
-        thread_id: 'thread-a2a-inbound',
+        jsonrpc: '2.0',
+        result: {
+          delivered: true,
+          message_id: 'msg-inbound-a2a-1',
+          thread_id: 'thread-a2a-inbound',
+        },
       },
     });
     expect(runtime.inbox('main')).toMatchObject([
@@ -134,6 +138,75 @@ describe('A2A JSON-RPC inbound adapter', () => {
         expect.objectContaining({
           type: 'a2a.inbound_post',
           peerId: 'peer-prod',
+          method: 'message/send',
+          agentId: 'main',
+          signatureOutcome: 'passed',
+          outcome: 'delivered',
+          downstreamDisposition: 'delivered',
+          statusCode: 202,
+        }),
+      ]),
+    );
+  });
+
+  test('accepts trusted mTLS client certificates and delivers to the local inbox', async () => {
+    process.env.HYBRIDCLAW_INSTANCE_ID = 'local-dev';
+    const { getRecentStructuredAuditForSession, runtime, inbound, outbound } =
+      await loadInboundTestModules();
+
+    const keyPair = outbound.getOrCreateA2ADelegationTokenKeyPair({
+      now: new Date('2030-01-01T00:00:00.000Z'),
+    });
+    inbound.upsertA2ATrustedA2APeer({
+      peerId: 'mtls-peer',
+      senderAgentId: 'remote@team@peer-instance',
+      publicKeyPem: keyPair.publicKeyPem,
+    });
+
+    const envelope = inboundEnvelope('msg-mtls-a2a');
+    const rawBody = JSON.stringify(
+      encodeA2AJsonRpcRequest(envelope, {
+        url: 'http://localhost/a2a',
+      }),
+    );
+
+    const result = inbound.acceptA2AJsonRpcInboundRequest({
+      rawBody,
+      authorization: null,
+      mtlsPublicKeyPem: keyPair.publicKeyPem,
+      audience: 'http://localhost/a2a',
+      now: new Date('2030-01-01T00:00:30.000Z'),
+    });
+
+    expect(result).toMatchObject({
+      statusCode: 202,
+      body: {
+        jsonrpc: '2.0',
+        result: {
+          delivered: true,
+          message_id: 'msg-mtls-a2a',
+          thread_id: 'thread-a2a-inbound',
+        },
+      },
+    });
+    expect(runtime.inbox('main')).toMatchObject([
+      {
+        id: 'msg-mtls-a2a',
+        sender_agent_id: 'remote@team@peer-instance',
+        recipient_agent_id: 'main@team@local-dev',
+      },
+    ]);
+    const audit = getRecentStructuredAuditForSession(
+      'a2a:inbound:mtls-peer',
+      10,
+    ).map((event) => JSON.parse(event.payload || '{}'));
+    expect(audit).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'a2a.inbound_post',
+          peerId: 'mtls-peer',
+          peerInstanceId: 'peer-instance',
+          method: 'message/send',
           signatureOutcome: 'passed',
           downstreamDisposition: 'delivered',
           statusCode: 202,
@@ -185,7 +258,15 @@ describe('A2A JSON-RPC inbound adapter', () => {
 
     expect(result).toEqual({
       statusCode: 401,
-      body: { error: 'Unauthorized' },
+      body: {
+        jsonrpc: '2.0',
+        error: {
+          code: -32001,
+          message: 'Unauthorized',
+          data: { reason: 'JWT has been revoked' },
+        },
+        id: null,
+      },
     });
     expect(runtime.inbox('main')).toEqual([]);
     const audit = getRecentStructuredAuditForSession(
@@ -239,7 +320,15 @@ describe('A2A JSON-RPC inbound adapter', () => {
       }),
     ).toEqual({
       statusCode: 401,
-      body: { error: 'Unauthorized' },
+      body: {
+        jsonrpc: '2.0',
+        error: {
+          code: -32001,
+          message: 'Unauthorized',
+          data: { reason: 'No trusted A2A peer for token sender' },
+        },
+        id: null,
+      },
     });
 
     const audit = getRecentStructuredAuditForSession(
@@ -257,5 +346,170 @@ describe('A2A JSON-RPC inbound adapter', () => {
         }),
       ]),
     );
+  });
+
+  test('rejects mTLS client certificates that are not trusted for the sender', async () => {
+    process.env.HYBRIDCLAW_INSTANCE_ID = 'local-dev';
+    const { getRecentStructuredAuditForSession, runtime, inbound, outbound } =
+      await loadInboundTestModules();
+
+    const trustedKeyPair = outbound.getOrCreateA2ADelegationTokenKeyPair({
+      now: new Date('2030-01-01T00:00:00.000Z'),
+    });
+    const untrustedKeyPair = generateKeyPairSync('ed25519');
+    const untrustedPublicKeyPem = untrustedKeyPair.publicKey
+      .export({ format: 'pem', type: 'spki' })
+      .toString();
+    inbound.upsertA2ATrustedA2APeer({
+      peerId: 'mtls-mismatch-peer',
+      senderAgentId: 'remote@team@peer-instance',
+      publicKeyPem: trustedKeyPair.publicKeyPem,
+    });
+
+    const envelope = inboundEnvelope('msg-mtls-mismatch-a2a');
+    const rawBody = JSON.stringify(
+      encodeA2AJsonRpcRequest(envelope, {
+        url: 'http://localhost/a2a',
+      }),
+    );
+
+    expect(
+      inbound.acceptA2AJsonRpcInboundRequest({
+        rawBody,
+        authorization: null,
+        mtlsPublicKeyPem: untrustedPublicKeyPem,
+        audience: 'http://localhost/a2a',
+        now: new Date('2030-01-01T00:00:30.000Z'),
+      }),
+    ).toEqual({
+      statusCode: 401,
+      body: {
+        jsonrpc: '2.0',
+        error: {
+          code: -32001,
+          message: 'Unauthorized',
+          data: {
+            reason:
+              'mTLS certificate public key does not match trusted A2A peer',
+          },
+        },
+        id: null,
+      },
+    });
+    expect(runtime.inbox('main')).toEqual([]);
+    const audit = getRecentStructuredAuditForSession(
+      'a2a:inbound:mtls-mismatch-peer',
+      10,
+    ).map((event) => JSON.parse(event.payload || '{}'));
+    expect(audit).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'a2a.inbound_post',
+          signatureOutcome: 'failed',
+          downstreamDisposition: 'rejected',
+          statusCode: 401,
+        }),
+      ]),
+    );
+  });
+
+  test('builds Agent Cards from the live registry with trust-scoped skills', async () => {
+    process.env.HYBRIDCLAW_INSTANCE_ID = 'local-dev';
+    const { initDatabase } = await import('../src/memory/db.ts');
+    const runtimeConfig = await import('../src/config/runtime-config.ts');
+    const trust = await import('../src/a2a/trust-ledger.ts');
+
+    initDatabase({ quiet: true });
+    runtimeConfig.updateRuntimeConfig((draft) => {
+      draft.agents.list = [
+        {
+          id: 'main',
+          name: 'Main Agent',
+          owner: 'team',
+          role: 'lead',
+          skills: ['public-search', 'incident-response'],
+          a2a: {
+            exposure: 'public',
+            skillExposure: {
+              'incident-response': 'trusted',
+            },
+          },
+        },
+        {
+          id: 'research',
+          owner: 'team',
+          skills: ['deep-research'],
+          a2a: { exposure: 'trusted' },
+        },
+        {
+          id: 'private',
+          owner: 'team',
+          skills: ['private-skill'],
+          a2a: { exposure: 'private' },
+        },
+      ];
+    });
+
+    const publicCard = trust.buildLocalA2AAgentCard('http://localhost');
+    expect(publicCard).toMatchObject({
+      url: 'http://localhost/a2a',
+      capabilities: {
+        messageSend: true,
+        tasksSend: true,
+        streaming: false,
+      },
+      hybridclaw: {
+        instanceId: 'local-dev',
+        peerTrustLevel: 'public',
+      },
+    });
+    expect(
+      (publicCard.agents as Array<{ id: string }>).map((agent) => agent.id),
+    ).toEqual(['main@team@local-dev']);
+    expect(
+      (publicCard.skills as Array<{ name: string }>).map((skill) => skill.name),
+    ).toEqual(['public-search']);
+
+    const trustedCard = trust.buildLocalA2AAgentCard('http://localhost', {
+      peerTrustLevel: 'trusted',
+      peerId: 'peer-prod',
+    });
+    expect(
+      (trustedCard.agents as Array<{ id: string }>).map((agent) => agent.id),
+    ).toEqual(['main@team@local-dev', 'research@team@local-dev']);
+    expect(
+      (trustedCard.skills as Array<{ name: string }>).map(
+        (skill) => skill.name,
+      ),
+    ).toEqual(['public-search', 'incident-response', 'deep-research']);
+    expect(trustedCard.hybridclaw).toMatchObject({
+      peerTrustLevel: 'trusted',
+      peerId: 'peer-prod',
+    });
+  });
+
+  test('treats trusted mTLS client certificates as trusted Agent Card readers', async () => {
+    process.env.HYBRIDCLAW_INSTANCE_ID = 'local-dev';
+    const { inbound, outbound } = await loadInboundTestModules();
+    const keyPair = outbound.getOrCreateA2ADelegationTokenKeyPair({
+      now: new Date('2030-01-01T00:00:00.000Z'),
+    });
+    inbound.upsertA2ATrustedA2APeer({
+      peerId: 'mtls-card-peer',
+      senderAgentId: 'remote@team@peer-instance',
+      publicKeyPem: keyPair.publicKeyPem,
+    });
+
+    expect(
+      inbound.resolveA2AAgentCardPeerTrust({
+        authorization: null,
+        mtlsPublicKeyPem: keyPair.publicKeyPem,
+        audience: 'http://localhost/.well-known/agent.json',
+        now: new Date('2030-01-01T00:00:30.000Z'),
+      }),
+    ).toEqual({
+      trustLevel: 'trusted',
+      peerId: 'mtls-card-peer',
+    });
   });
 });

--- a/tests/a2a-inbound.test.ts
+++ b/tests/a2a-inbound.test.ts
@@ -141,12 +141,53 @@ describe('A2A JSON-RPC inbound adapter', () => {
           method: 'message/send',
           agentId: 'main',
           signatureOutcome: 'passed',
-          outcome: 'delivered',
           downstreamDisposition: 'delivered',
           statusCode: 202,
         }),
       ]),
     );
+    const deliveredAudit = audit.find(
+      (event) => event.type === 'a2a.inbound_post' && event.statusCode === 202,
+    );
+    expect(deliveredAudit).not.toHaveProperty('outcome');
+  });
+
+  test('does not reveal local recipient existence before authentication', async () => {
+    process.env.HYBRIDCLAW_INSTANCE_ID = 'local-dev';
+    const { inbound } = await loadInboundTestModules();
+
+    const envelope = {
+      ...inboundEnvelope('msg-unknown-recipient-no-auth-a2a'),
+      recipient_agent_id: 'unknown-local-agent',
+    };
+    const rawBody = JSON.stringify(
+      encodeA2AJsonRpcRequest(envelope, {
+        url: 'http://localhost/a2a',
+      }),
+    );
+
+    expect(
+      inbound.acceptA2AJsonRpcInboundRequest({
+        rawBody,
+        authorization: null,
+        audience: 'http://localhost/a2a',
+        now: new Date('2030-01-01T00:00:30.000Z'),
+      }),
+    ).toEqual({
+      statusCode: 401,
+      body: {
+        jsonrpc: '2.0',
+        error: {
+          code: -32001,
+          message: 'Unauthorized',
+          data: {
+            reason:
+              'Authorization bearer token or mTLS client certificate is required',
+          },
+        },
+        id: null,
+      },
+    });
   });
 
   test('accepts trusted mTLS client certificates and delivers to the local inbox', async () => {


### PR DESCRIPTION
## Summary

Closes #767.

Implements the A2A inbound adapter by publishing a trust-scoped Agent Card at `/.well-known/agent.json`, accepting A2A JSON-RPC `message/send` and `tasks/send` calls on the sibling `/a2a` route, and handing decoded envelopes to the existing inbound pipeline.

## Details

- Agent Cards now include canonical instance identity, live registry-derived agents and skills, and `{ messageSend, tasksSend, streaming }` capabilities.
- Adds per-agent A2A exposure metadata (`public`, `trusted`, `private`) plus per-skill exposure overrides, persisted through runtime config and database schema v30.
- Supports signed bearer delegation tokens and mTLS client certificates for trusted A2A peers.
- Returns JSON-RPC result/error envelopes for A2A inbound calls, including unauthorized errors for unknown or mismatched peers.
- Records structured inbound audit entries with peer, peer instance, agent id, method, outcome, and envelope summary.

## Validation

- `npm run format`
- `npx vitest run tests/a2a-inbound.test.ts tests/a2a-outbound.test.ts tests/a2a-trust-ledger.test.ts`
- `npm run lint`
- `git diff --check`