### PR TITLE
[codex] Add board card store

### DIFF
--- a/src/board/card-store.ts
+++ b/src/board/card-store.ts
@@ -1,0 +1,639 @@
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+import type Database from 'better-sqlite3';
+
+import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
+import type { AuditEventPayload } from '../audit/audit-trail.js';
+import {
+  getRuntimeAssetRevision,
+  listRuntimeAssetRevisions,
+  type RuntimeConfigChangeMeta,
+  syncRuntimeAssetRevisionStateInOpenDatabase,
+} from '../config/runtime-config-revisions.js';
+import {
+  withMemoryDatabase,
+  withMemoryDatabaseRuntimeRevisionStore,
+} from '../memory/db.js';
+
+export const BOARD_CARD_COLUMNS = [
+  'triage',
+  'todo',
+  'in_progress',
+  'in_review',
+  'done',
+] as const;
+
+const BOARD_CARD_STATE_VERSION = 1;
+const BOARD_CARD_ASSET_PREFIX = 'board/cards';
+const SOURCE_PREFIXES = ['autopilot', 'a2a', 'workflow'] as const;
+
+export type BoardCardColumn = (typeof BOARD_CARD_COLUMNS)[number];
+
+export type BoardCardOwner =
+  | { userId: string; agentId?: never }
+  | { agentId: string; userId?: never };
+
+export type BoardCardActor = BoardCardOwner | { system: string };
+
+export type BoardCardSource =
+  | 'manual'
+  | `autopilot/${string}`
+  | `a2a/${string}`
+  | `workflow/${string}`;
+
+export interface Card {
+  id: string;
+  title: string;
+  body: string;
+  owner: BoardCardOwner;
+  column: BoardCardColumn;
+  status: string;
+  source: BoardCardSource;
+  parent: string | null;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+}
+
+export interface CreateCardInput {
+  id?: string;
+  title: string;
+  body?: string;
+  owner: BoardCardOwner;
+  column?: BoardCardColumn;
+  status?: string;
+  source?: BoardCardSource;
+  parent?: string | null;
+}
+
+export type UpdateCardPatch = Partial<
+  Pick<Card, 'title' | 'body' | 'owner' | 'status' | 'source'> & {
+    parent: string | null;
+  }
+>;
+
+export interface ListCardsFilter {
+  column?: BoardCardColumn;
+  owner?: BoardCardOwner;
+  sourcePrefix?: 'autopilot' | 'a2a' | 'workflow' | 'manual';
+  includeDeleted?: boolean;
+}
+
+export interface BoardCardMutationContext {
+  actor?: BoardCardActor | null;
+  sessionId?: string | null;
+  runId?: string | null;
+  meta?: RuntimeConfigChangeMeta;
+}
+
+export interface BoardCardFieldDiff {
+  before: unknown;
+  after: unknown;
+}
+
+export interface BoardCardMutationEvent extends AuditEventPayload {
+  type: 'board.card_created' | 'board.card_updated' | 'board.card_deleted';
+  actor: BoardCardActor;
+  cardId: string;
+  diff: Record<string, BoardCardFieldDiff>;
+  at: string;
+}
+
+interface BoardCardRow {
+  id: string;
+  title: string;
+  body: string;
+  owner: string;
+  owner_type: string;
+  owner_id: string;
+  column: string;
+  status: string;
+  source: string;
+  parent: string | null;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+}
+
+interface PersistedBoardCardState {
+  version: typeof BOARD_CARD_STATE_VERSION;
+  card: Card;
+}
+
+export type BoardCardSubscriber = (event: BoardCardMutationEvent) => unknown;
+
+const subscribers = new Set<BoardCardSubscriber>();
+
+export function subscribeBoardCardEvents(
+  subscriber: BoardCardSubscriber,
+): () => void {
+  subscribers.add(subscriber);
+  return () => {
+    subscribers.delete(subscriber);
+  };
+}
+
+export function boardCardAssetPath(id: string): string {
+  return path.join(BOARD_CARD_ASSET_PREFIX, `${encodeURIComponent(id)}.json`);
+}
+
+function normalizeNonEmptyString(value: unknown, field: string): string {
+  const normalized = typeof value === 'string' ? value.trim() : '';
+  if (!normalized) throw new Error(`${field} is required.`);
+  return normalized;
+}
+
+function normalizeOptionalString(value: unknown, field: string): string | null {
+  if (value == null) return null;
+  const normalized = normalizeNonEmptyString(value, field);
+  return normalized;
+}
+
+function normalizeColumn(value: unknown): BoardCardColumn {
+  const normalized = normalizeNonEmptyString(value, 'column');
+  if (BOARD_CARD_COLUMNS.includes(normalized as BoardCardColumn)) {
+    return normalized as BoardCardColumn;
+  }
+  throw new Error(`Unsupported board card column: ${normalized}`);
+}
+
+function normalizeOwner(owner: BoardCardOwner): {
+  owner: BoardCardOwner;
+  ownerType: 'user' | 'agent';
+  ownerId: string;
+  ownerJson: string;
+} {
+  const userId = typeof owner.userId === 'string' ? owner.userId.trim() : '';
+  const agentId = typeof owner.agentId === 'string' ? owner.agentId.trim() : '';
+  if (userId && agentId) {
+    throw new Error('Board card owner must reference one user or one agent.');
+  }
+  if (userId) {
+    const normalizedOwner = { userId };
+    return {
+      owner: normalizedOwner,
+      ownerType: 'user',
+      ownerId: userId,
+      ownerJson: JSON.stringify(normalizedOwner),
+    };
+  }
+  if (agentId) {
+    const normalizedOwner = { agentId };
+    return {
+      owner: normalizedOwner,
+      ownerType: 'agent',
+      ownerId: agentId,
+      ownerJson: JSON.stringify(normalizedOwner),
+    };
+  }
+  throw new Error('Board card owner is required.');
+}
+
+function normalizeActor(actor?: BoardCardActor | null): BoardCardActor {
+  if (!actor) return { system: 'board' };
+  if ('system' in actor) {
+    return { system: normalizeNonEmptyString(actor.system, 'actor.system') };
+  }
+  return normalizeOwner(actor).owner;
+}
+
+function normalizeSource(source: unknown): BoardCardSource {
+  const normalized = normalizeNonEmptyString(source, 'source');
+  if (normalized === 'manual') return normalized;
+  const [prefix, rest] = normalized.split('/', 2);
+  if (
+    SOURCE_PREFIXES.includes(prefix as (typeof SOURCE_PREFIXES)[number]) &&
+    rest?.trim()
+  ) {
+    return normalized as BoardCardSource;
+  }
+  throw new Error(`Unsupported board card source: ${normalized}`);
+}
+
+function parseOwner(
+  row: Pick<BoardCardRow, 'owner' | 'owner_type' | 'owner_id'>,
+): BoardCardOwner {
+  try {
+    return normalizeOwner(JSON.parse(row.owner) as BoardCardOwner).owner;
+  } catch {
+    return row.owner_type === 'user'
+      ? { userId: row.owner_id }
+      : { agentId: row.owner_id };
+  }
+}
+
+function mapCardRow(row: BoardCardRow): Card {
+  return {
+    id: row.id,
+    title: row.title,
+    body: row.body,
+    owner: parseOwner(row),
+    column: normalizeColumn(row.column),
+    status: row.status,
+    source: normalizeSource(row.source),
+    parent: row.parent,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    deletedAt: row.deleted_at,
+  };
+}
+
+function serializeCardState(card: Card): string {
+  return JSON.stringify({
+    version: BOARD_CARD_STATE_VERSION,
+    card,
+  } satisfies PersistedBoardCardState);
+}
+
+function parseCardState(raw: string): Card {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `Board card revision JSON is invalid: ${
+        error instanceof Error ? error.message : 'unknown parse error'
+      }`,
+    );
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Board card revision must be an object.');
+  }
+  const state = parsed as Partial<PersistedBoardCardState>;
+  if (state.version !== BOARD_CARD_STATE_VERSION) {
+    throw new Error(
+      `Board card revision version must be ${BOARD_CARD_STATE_VERSION}.`,
+    );
+  }
+  if (!state.card || typeof state.card !== 'object') {
+    throw new Error('Board card revision card is required.');
+  }
+  return normalizeCardForPersistence(state.card as Card);
+}
+
+function normalizeCardForPersistence(card: Card): Card {
+  return {
+    id: normalizeNonEmptyString(card.id, 'id'),
+    title: normalizeNonEmptyString(card.title, 'title'),
+    body: typeof card.body === 'string' ? card.body : '',
+    owner: normalizeOwner(card.owner).owner,
+    column: normalizeColumn(card.column),
+    status: normalizeNonEmptyString(card.status, 'status'),
+    source: normalizeSource(card.source),
+    parent: normalizeOptionalString(card.parent, 'parent'),
+    createdAt: normalizeNonEmptyString(card.createdAt, 'createdAt'),
+    updatedAt: normalizeNonEmptyString(card.updatedAt, 'updatedAt'),
+    deletedAt: card.deletedAt
+      ? normalizeNonEmptyString(card.deletedAt, 'deletedAt')
+      : null,
+  };
+}
+
+function diffCards(
+  before: Card | null,
+  after: Card | null,
+): Record<string, BoardCardFieldDiff> {
+  const fields = [
+    'id',
+    'title',
+    'body',
+    'owner',
+    'column',
+    'status',
+    'source',
+    'parent',
+    'createdAt',
+    'updatedAt',
+    'deletedAt',
+  ] as const;
+  const diff: Record<string, BoardCardFieldDiff> = {};
+  for (const field of fields) {
+    const beforeValue = before?.[field] ?? null;
+    const afterValue = after?.[field] ?? null;
+    if (JSON.stringify(beforeValue) === JSON.stringify(afterValue)) continue;
+    diff[field] = { before: beforeValue, after: afterValue };
+  }
+  return diff;
+}
+
+function emitBoardCardEvent(
+  event: BoardCardMutationEvent,
+  context?: BoardCardMutationContext,
+): void {
+  for (const subscriber of subscribers) {
+    try {
+      subscriber(event);
+    } catch {
+      // Subscribers are best-effort; structured audit is the durable stream.
+    }
+  }
+  recordAuditEvent({
+    sessionId: context?.sessionId?.trim() || 'board',
+    runId: context?.runId?.trim() || makeAuditRunId('board-card'),
+    event,
+  });
+}
+
+function syncCardRevisionState(
+  database: Database.Database,
+  revisionSchemaName: string,
+  card: Card,
+  context: BoardCardMutationContext | undefined,
+): void {
+  syncRuntimeAssetRevisionStateInOpenDatabase(
+    database,
+    'board_card',
+    boardCardAssetPath(card.id),
+    {
+      actor: formatActorForRevision(context?.actor),
+      route: context?.meta?.route || 'board.card-store',
+      source: context?.meta?.source || card.source,
+    },
+    {
+      exists: true,
+      content: serializeCardState(card),
+    },
+    card.updatedAt,
+    { schemaName: revisionSchemaName },
+  );
+}
+
+function formatActorForRevision(actor?: BoardCardActor | null): string {
+  const normalized = normalizeActor(actor);
+  if ('system' in normalized) return `system:${normalized.system}`;
+  if ('userId' in normalized) return `user:${normalized.userId}`;
+  return `agent:${normalized.agentId}`;
+}
+
+function insertOrReplaceCard(database: Database.Database, card: Card): Card {
+  const normalized = normalizeCardForPersistence(card);
+  const owner = normalizeOwner(normalized.owner);
+  database
+    .prepare(
+      `INSERT INTO board_cards (
+         id, title, body, owner, owner_type, owner_id, "column", status, source, parent, created_at, updated_at, deleted_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         title = excluded.title,
+         body = excluded.body,
+         owner = excluded.owner,
+         owner_type = excluded.owner_type,
+         owner_id = excluded.owner_id,
+         "column" = excluded."column",
+         status = excluded.status,
+         source = excluded.source,
+         parent = excluded.parent,
+         created_at = excluded.created_at,
+         updated_at = excluded.updated_at,
+         deleted_at = excluded.deleted_at`,
+    )
+    .run(
+      normalized.id,
+      normalized.title,
+      normalized.body,
+      owner.ownerJson,
+      owner.ownerType,
+      owner.ownerId,
+      normalized.column,
+      normalized.status,
+      normalized.source,
+      normalized.parent,
+      normalized.createdAt,
+      normalized.updatedAt,
+      normalized.deletedAt,
+    );
+  return normalized;
+}
+
+function selectCard(
+  database: Database.Database,
+  id: string,
+  opts?: { includeDeleted?: boolean },
+): Card | null {
+  const row = database
+    .prepare<[string], BoardCardRow>(
+      `SELECT id, title, body, owner, owner_type, owner_id, "column", status, source, parent, created_at, updated_at, deleted_at
+       FROM board_cards
+       WHERE id = ?`,
+    )
+    .get(id);
+  if (!row) return null;
+  const card = mapCardRow(row);
+  if (!opts?.includeDeleted && card.deletedAt) return null;
+  return card;
+}
+
+export function createCard(
+  input: CreateCardInput,
+  context?: BoardCardMutationContext,
+): Card {
+  const timestamp = new Date().toISOString();
+  const card: Card = normalizeCardForPersistence({
+    id: input.id?.trim() || randomUUID(),
+    title: input.title,
+    body: input.body ?? '',
+    owner: input.owner,
+    column: input.column ?? 'triage',
+    status: input.status ?? 'queued',
+    source: input.source ?? 'manual',
+    parent: input.parent ?? null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    deletedAt: null,
+  });
+
+  return withMemoryDatabaseRuntimeRevisionStore((database, revisionSchema) => {
+    const created = database.transaction(() => {
+      if (selectCard(database, card.id, { includeDeleted: true })) {
+        throw new Error(`Board card already exists: ${card.id}`);
+      }
+      const stored = insertOrReplaceCard(database, card);
+      syncCardRevisionState(database, revisionSchema, stored, context);
+      return stored;
+    })();
+    emitBoardCardEvent(
+      {
+        type: 'board.card_created',
+        actor: normalizeActor(context?.actor),
+        cardId: created.id,
+        diff: diffCards(null, created),
+        at: created.updatedAt,
+      },
+      context,
+    );
+    return created;
+  });
+}
+
+export function getCard(id: string): Card | null {
+  const normalizedId = normalizeNonEmptyString(id, 'id');
+  return withMemoryDatabase((database) => selectCard(database, normalizedId));
+}
+
+// This store is intentionally last-write-wins. R29.9 owns column/state-machine
+// conflict validation; this layer only persists the newest accepted mutation.
+export function listCards(filter: ListCardsFilter = {}): Card[] {
+  return withMemoryDatabase((database) => {
+    const clauses: string[] = [];
+    const values: unknown[] = [];
+    if (!filter.includeDeleted) {
+      clauses.push('deleted_at IS NULL');
+    }
+    if (filter.column) {
+      clauses.push('"column" = ?');
+      values.push(normalizeColumn(filter.column));
+    }
+    if (filter.owner) {
+      const owner = normalizeOwner(filter.owner);
+      clauses.push('owner_type = ? AND owner_id = ?');
+      values.push(owner.ownerType, owner.ownerId);
+    }
+    if (filter.sourcePrefix) {
+      if (filter.sourcePrefix === 'manual') {
+        clauses.push('source = ?');
+        values.push('manual');
+      } else {
+        clauses.push('source >= ? AND source < ?');
+        values.push(`${filter.sourcePrefix}/`, `${filter.sourcePrefix}0`);
+      }
+    }
+
+    const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
+    return database
+      .prepare<unknown[], BoardCardRow>(
+        `SELECT id, title, body, owner, owner_type, owner_id, "column", status, source, parent, created_at, updated_at, deleted_at
+         FROM board_cards
+         ${where}
+         ORDER BY created_at ASC, id ASC`,
+      )
+      .all(...values)
+      .map(mapCardRow);
+  });
+}
+
+export function updateCard(
+  id: string,
+  patch: UpdateCardPatch,
+  context?: BoardCardMutationContext,
+): Card {
+  const normalizedId = normalizeNonEmptyString(id, 'id');
+  return withMemoryDatabaseRuntimeRevisionStore((database, revisionSchema) => {
+    const { before, after } = database.transaction(() => {
+      const current = selectCard(database, normalizedId);
+      if (!current) throw new Error(`Board card not found: ${normalizedId}`);
+      const next = normalizeCardForPersistence({
+        ...current,
+        ...patch,
+        updatedAt: new Date().toISOString(),
+      });
+      const stored = insertOrReplaceCard(database, next);
+      syncCardRevisionState(database, revisionSchema, stored, context);
+      return { before: current, after: stored };
+    })();
+    emitBoardCardEvent(
+      {
+        type: 'board.card_updated',
+        actor: normalizeActor(context?.actor),
+        cardId: after.id,
+        diff: diffCards(before, after),
+        at: after.updatedAt,
+      },
+      context,
+    );
+    return after;
+  });
+}
+
+export function deleteCard(
+  id: string,
+  context?: BoardCardMutationContext,
+): Card {
+  const normalizedId = normalizeNonEmptyString(id, 'id');
+  return withMemoryDatabaseRuntimeRevisionStore((database, revisionSchema) => {
+    const { before, after } = database.transaction(() => {
+      const current = selectCard(database, normalizedId);
+      if (!current) throw new Error(`Board card not found: ${normalizedId}`);
+      const deleted = normalizeCardForPersistence({
+        ...current,
+        updatedAt: new Date().toISOString(),
+        deletedAt: new Date().toISOString(),
+      });
+      const stored = insertOrReplaceCard(database, deleted);
+      syncCardRevisionState(database, revisionSchema, stored, context);
+      return { before: current, after: stored };
+    })();
+    emitBoardCardEvent(
+      {
+        type: 'board.card_deleted',
+        actor: normalizeActor(context?.actor),
+        cardId: after.id,
+        diff: diffCards(before, after),
+        at: after.updatedAt,
+      },
+      context,
+    );
+    return after;
+  });
+}
+
+export function listCardRevisions(id: string) {
+  return listRuntimeAssetRevisions(
+    'board_card',
+    boardCardAssetPath(normalizeNonEmptyString(id, 'id')),
+  );
+}
+
+export function restoreCardRevision(
+  id: string,
+  revisionId: number,
+  context?: BoardCardMutationContext,
+): Card {
+  const normalizedId = normalizeNonEmptyString(id, 'id');
+  const revision = getRuntimeAssetRevision(
+    'board_card',
+    boardCardAssetPath(normalizedId),
+    revisionId,
+  );
+  if (!revision) {
+    throw new Error(
+      `Board card revision ${revisionId} was not found for ${normalizedId}.`,
+    );
+  }
+  const restored = parseCardState(revision.content);
+  if (restored.id !== normalizedId) {
+    throw new Error(`Board card revision belongs to ${restored.id}.`);
+  }
+
+  return withMemoryDatabaseRuntimeRevisionStore((database, revisionSchema) => {
+    const { before, after } = database.transaction(() => {
+      const current = selectCard(database, normalizedId, {
+        includeDeleted: true,
+      });
+      const next = normalizeCardForPersistence({
+        ...restored,
+        updatedAt: new Date().toISOString(),
+      });
+      const stored = insertOrReplaceCard(database, next);
+      syncCardRevisionState(database, revisionSchema, stored, {
+        ...context,
+        meta: {
+          actor: context?.meta?.actor,
+          route: context?.meta?.route || `board.card.rollback#${revisionId}`,
+          source: context?.meta?.source || 'rollback',
+        },
+      });
+      return { before: current, after: stored };
+    })();
+    emitBoardCardEvent(
+      {
+        type: 'board.card_updated',
+        actor: normalizeActor(context?.actor),
+        cardId: after.id,
+        diff: diffCards(before, after),
+        at: after.updatedAt,
+      },
+      context,
+    );
+    return after;
+  });
+}

--- a/src/board/card-store.ts
+++ b/src/board/card-store.ts
@@ -383,7 +383,6 @@ function insertOrReplaceCard(database: Database.Database, card: Card): Card {
          status = excluded.status,
          source = excluded.source,
          parent = excluded.parent,
-         created_at = excluded.created_at,
          updated_at = excluded.updated_at,
          deleted_at = excluded.deleted_at`,
     )
@@ -402,7 +401,11 @@ function insertOrReplaceCard(database: Database.Database, card: Card): Card {
       normalized.updatedAt,
       normalized.deletedAt,
     );
-  return normalized;
+  const stored = selectCard(database, normalized.id, { includeDeleted: true });
+  if (!stored) {
+    throw new Error(`Failed to read persisted board card: ${normalized.id}`);
+  }
+  return stored;
 }
 
 function selectCard(
@@ -494,7 +497,7 @@ export function listCards(filter: ListCardsFilter = {}): Card[] {
         values.push('manual');
       } else {
         clauses.push('source >= ? AND source < ?');
-        values.push(`${filter.sourcePrefix}/`, `${filter.sourcePrefix}0`);
+        values.push(`${filter.sourcePrefix}/`, `${filter.sourcePrefix}/\uffff`);
       }
     }
 
@@ -521,9 +524,12 @@ export function updateCard(
     const { before, after } = database.transaction(() => {
       const current = selectCard(database, normalizedId);
       if (!current) throw new Error(`Board card not found: ${normalizedId}`);
+      const definedPatch = Object.fromEntries(
+        Object.entries(patch).filter(([, value]) => value !== undefined),
+      ) as UpdateCardPatch;
       const next = normalizeCardForPersistence({
         ...current,
-        ...patch,
+        ...definedPatch,
         updatedAt: new Date().toISOString(),
       });
       const stored = insertOrReplaceCard(database, next);

--- a/src/board/card-store.ts
+++ b/src/board/card-store.ts
@@ -14,6 +14,11 @@ import {
   withMemoryDatabase,
   withMemoryDatabaseRuntimeRevisionStore,
 } from '../memory/db.js';
+import {
+  emitRuntimeEvent,
+  subscribeRuntimeEvents,
+  type RuntimeEventPayload,
+} from '../skills/skill-run-events.js';
 
 export const BOARD_CARD_COLUMNS = [
   'triage',
@@ -128,15 +133,23 @@ interface PersistedBoardCardState {
 
 export type BoardCardSubscriber = (event: BoardCardMutationEvent) => unknown;
 
-const subscribers = new Set<BoardCardSubscriber>();
+function isBoardCardMutationEvent(
+  event: RuntimeEventPayload,
+): event is BoardCardMutationEvent {
+  return (
+    event.type === 'board.card_created' ||
+    event.type === 'board.card_updated' ||
+    event.type === 'board.card_deleted'
+  );
+}
 
 export function subscribeBoardCardEvents(
   subscriber: BoardCardSubscriber,
 ): () => void {
-  subscribers.add(subscriber);
-  return () => {
-    subscribers.delete(subscriber);
-  };
+  return subscribeRuntimeEvents((event) => {
+    if (!isBoardCardMutationEvent(event)) return;
+    subscriber(event);
+  });
 }
 
 function boardCardAssetPath(id: string): string {
@@ -349,13 +362,7 @@ function emitBoardCardEvent(
   event: BoardCardMutationEvent,
   context?: BoardCardMutationContext,
 ): void {
-  for (const subscriber of subscribers) {
-    try {
-      subscriber(event);
-    } catch {
-      // Subscribers are best-effort; structured audit is the durable stream.
-    }
-  }
+  emitRuntimeEvent(event);
   recordAuditEvent({
     sessionId: context?.sessionId?.trim() || 'board',
     runId: context?.runId?.trim() || makeAuditRunId('board-card'),

--- a/src/board/card-store.ts
+++ b/src/board/card-store.ts
@@ -26,6 +26,9 @@ export const BOARD_CARD_COLUMNS = [
 const BOARD_CARD_STATE_VERSION = 1;
 const BOARD_CARD_ASSET_PREFIX = 'board/cards';
 const SOURCE_PREFIXES = ['autopilot', 'a2a', 'workflow'] as const;
+const SOURCE_ID_RE = /^(?!.*\.\.)[a-zA-Z0-9_.-]+$/;
+const BOARD_CARD_SELECT_COLUMNS =
+  'id, title, body, owner_type, owner_id, "column", status, source, parent, created_at, updated_at, deleted_at';
 
 export type BoardCardColumn = (typeof BOARD_CARD_COLUMNS)[number];
 
@@ -40,6 +43,7 @@ export type BoardCardSource =
   | `autopilot/${string}`
   | `a2a/${string}`
   | `workflow/${string}`;
+export type BoardCardSourcePrefix = (typeof SOURCE_PREFIXES)[number];
 
 export interface Card {
   id: string;
@@ -75,8 +79,11 @@ export type UpdateCardPatch = Partial<
 export interface ListCardsFilter {
   column?: BoardCardColumn;
   owner?: BoardCardOwner;
-  sourcePrefix?: 'autopilot' | 'a2a' | 'workflow' | 'manual';
+  source?: BoardCardSource;
+  sourcePrefix?: BoardCardSourcePrefix;
   includeDeleted?: boolean;
+  limit?: number;
+  offset?: number;
 }
 
 export interface BoardCardMutationContext {
@@ -103,7 +110,6 @@ interface BoardCardRow {
   id: string;
   title: string;
   body: string;
-  owner: string;
   owner_type: string;
   owner_id: string;
   column: string;
@@ -133,7 +139,7 @@ export function subscribeBoardCardEvents(
   };
 }
 
-export function boardCardAssetPath(id: string): string {
+function boardCardAssetPath(id: string): string {
   return path.join(BOARD_CARD_ASSET_PREFIX, `${encodeURIComponent(id)}.json`);
 }
 
@@ -145,8 +151,21 @@ function normalizeNonEmptyString(value: unknown, field: string): string {
 
 function normalizeOptionalString(value: unknown, field: string): string | null {
   if (value == null) return null;
-  const normalized = normalizeNonEmptyString(value, field);
-  return normalized;
+  if (typeof value !== 'string') {
+    throw new Error(`${field} must be a string.`);
+  }
+  return value.trim() || null;
+}
+
+function normalizeOptionalNonNegativeInteger(
+  value: unknown,
+  field: string,
+): number | null {
+  if (value == null) return null;
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+    throw new Error(`${field} must be a non-negative integer.`);
+  }
+  return value;
 }
 
 function normalizeColumn(value: unknown): BoardCardColumn {
@@ -200,10 +219,14 @@ function normalizeActor(actor?: BoardCardActor | null): BoardCardActor {
 function normalizeSource(source: unknown): BoardCardSource {
   const normalized = normalizeNonEmptyString(source, 'source');
   if (normalized === 'manual') return normalized;
-  const [prefix, rest] = normalized.split('/', 2);
+  const separatorIndex = normalized.indexOf('/');
+  const prefix =
+    separatorIndex >= 0 ? normalized.slice(0, separatorIndex) : normalized;
+  const rest = separatorIndex >= 0 ? normalized.slice(separatorIndex + 1) : '';
   if (
     SOURCE_PREFIXES.includes(prefix as (typeof SOURCE_PREFIXES)[number]) &&
-    rest?.trim()
+    rest?.trim() &&
+    SOURCE_ID_RE.test(rest.trim())
   ) {
     return normalized as BoardCardSource;
   }
@@ -211,15 +234,17 @@ function normalizeSource(source: unknown): BoardCardSource {
 }
 
 function parseOwner(
-  row: Pick<BoardCardRow, 'owner' | 'owner_type' | 'owner_id'>,
+  row: Pick<BoardCardRow, 'owner_type' | 'owner_id'>,
 ): BoardCardOwner {
-  try {
-    return normalizeOwner(JSON.parse(row.owner) as BoardCardOwner).owner;
-  } catch {
-    return row.owner_type === 'user'
-      ? { userId: row.owner_id }
-      : { agentId: row.owner_id };
+  if (row.owner_type === 'user') {
+    return normalizeOwner({ userId: row.owner_id }).owner;
   }
+  if (row.owner_type === 'agent') {
+    return normalizeOwner({ agentId: row.owner_id }).owner;
+  }
+  throw new Error(
+    `Unsupported persisted board card owner type: ${row.owner_type}`,
+  );
 }
 
 function mapCardRow(row: BoardCardRow): Card {
@@ -310,7 +335,11 @@ function diffCards(
   for (const field of fields) {
     const beforeValue = before?.[field] ?? null;
     const afterValue = after?.[field] ?? null;
-    if (JSON.stringify(beforeValue) === JSON.stringify(afterValue)) continue;
+    const equal =
+      field === 'owner'
+        ? JSON.stringify(beforeValue) === JSON.stringify(afterValue)
+        : beforeValue === afterValue;
+    if (equal) continue;
     diff[field] = { before: beforeValue, after: afterValue };
   }
   return diff;
@@ -401,11 +430,7 @@ function insertOrReplaceCard(database: Database.Database, card: Card): Card {
       normalized.updatedAt,
       normalized.deletedAt,
     );
-  const stored = selectCard(database, normalized.id, { includeDeleted: true });
-  if (!stored) {
-    throw new Error(`Failed to read persisted board card: ${normalized.id}`);
-  }
-  return stored;
+  return normalized;
 }
 
 function selectCard(
@@ -415,15 +440,14 @@ function selectCard(
 ): Card | null {
   const row = database
     .prepare<[string], BoardCardRow>(
-      `SELECT id, title, body, owner, owner_type, owner_id, "column", status, source, parent, created_at, updated_at, deleted_at
+      `SELECT ${BOARD_CARD_SELECT_COLUMNS}
        FROM board_cards
-       WHERE id = ?`,
+       WHERE id = ?
+       ${opts?.includeDeleted ? '' : 'AND deleted_at IS NULL'}`,
     )
     .get(id);
   if (!row) return null;
-  const card = mapCardRow(row);
-  if (!opts?.includeDeleted && card.deletedAt) return null;
-  return card;
+  return mapCardRow(row);
 }
 
 export function createCard(
@@ -491,23 +515,29 @@ export function listCards(filter: ListCardsFilter = {}): Card[] {
       clauses.push('owner_type = ? AND owner_id = ?');
       values.push(owner.ownerType, owner.ownerId);
     }
+    if (filter.source) {
+      clauses.push('source = ?');
+      values.push(normalizeSource(filter.source));
+    }
     if (filter.sourcePrefix) {
-      if (filter.sourcePrefix === 'manual') {
-        clauses.push('source = ?');
-        values.push('manual');
-      } else {
-        clauses.push('source >= ? AND source < ?');
-        values.push(`${filter.sourcePrefix}/`, `${filter.sourcePrefix}/\uffff`);
-      }
+      clauses.push('source >= ? AND source < ?');
+      values.push(`${filter.sourcePrefix}/`, `${filter.sourcePrefix}/\uffff`);
+    }
+    const limit = normalizeOptionalNonNegativeInteger(filter.limit, 'limit');
+    const offset = normalizeOptionalNonNegativeInteger(filter.offset, 'offset');
+    if (limit !== null) {
+      values.push(limit);
+      if (offset !== null) values.push(offset);
     }
 
     const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
     return database
       .prepare<unknown[], BoardCardRow>(
-        `SELECT id, title, body, owner, owner_type, owner_id, "column", status, source, parent, created_at, updated_at, deleted_at
+        `SELECT ${BOARD_CARD_SELECT_COLUMNS}
          FROM board_cards
          ${where}
-         ORDER BY created_at ASC, id ASC`,
+         ORDER BY created_at ASC, id ASC
+         ${limit !== null ? `LIMIT ?${offset !== null ? ' OFFSET ?' : ''}` : ''}`,
       )
       .all(...values)
       .map(mapCardRow);
@@ -559,10 +589,11 @@ export function deleteCard(
     const { before, after } = database.transaction(() => {
       const current = selectCard(database, normalizedId);
       if (!current) throw new Error(`Board card not found: ${normalizedId}`);
+      const now = new Date().toISOString();
       const deleted = normalizeCardForPersistence({
         ...current,
-        updatedAt: new Date().toISOString(),
-        deletedAt: new Date().toISOString(),
+        updatedAt: now,
+        deletedAt: now,
       });
       const stored = insertOrReplaceCard(database, deleted);
       syncCardRevisionState(database, revisionSchema, stored, context);
@@ -608,6 +639,9 @@ export function restoreCardRevision(
   const restored = parseCardState(revision.content);
   if (restored.id !== normalizedId) {
     throw new Error(`Board card revision belongs to ${restored.id}.`);
+  }
+  if (restored.deletedAt) {
+    throw new Error(`Board card revision ${revisionId} is a deleted snapshot.`);
   }
 
   return withMemoryDatabaseRuntimeRevisionStore((database, revisionSchema) => {

--- a/src/config/runtime-config-revisions.ts
+++ b/src/config/runtime-config-revisions.ts
@@ -26,6 +26,7 @@ export const RUNTIME_REVISION_ASSET_TYPES = [
   'team',
   'pending_approval',
   'suspended_session',
+  'board_card',
 ] as const;
 
 export type RuntimeRevisionAssetType =

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -135,7 +135,7 @@ let db: Database.Database;
 let databaseInitialized = false;
 let usageEventBatchInsertStatement: Database.Statement | null = null;
 
-export const DATABASE_SCHEMA_VERSION = 29;
+export const DATABASE_SCHEMA_VERSION = 30;
 const STRUCTURED_AUDIT_SESSION_LIMIT = 10_000;
 const RECENT_CHAT_MESSAGE_SEARCH_TABLE = 'recent_chat_message_search';
 const RECENT_CHAT_MESSAGE_SEARCH_INSERT_TRIGGER =
@@ -2322,6 +2322,39 @@ function migrateV29(database: Database.Database): void {
   );
 }
 
+function migrateV30(database: Database.Database): void {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS board_cards (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      body TEXT NOT NULL,
+      owner TEXT NOT NULL,
+      owner_type TEXT NOT NULL CHECK (owner_type IN ('user', 'agent')),
+      owner_id TEXT NOT NULL,
+      "column" TEXT NOT NULL CHECK ("column" IN ('triage', 'todo', 'in_progress', 'in_review', 'done')),
+      status TEXT NOT NULL,
+      source TEXT NOT NULL,
+      parent TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      deleted_at TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_board_cards_column_deleted
+      ON board_cards("column", deleted_at);
+    CREATE INDEX IF NOT EXISTS idx_board_cards_owner_deleted
+      ON board_cards(owner_type, owner_id, deleted_at);
+    CREATE INDEX IF NOT EXISTS idx_board_cards_source_deleted
+      ON board_cards(source, deleted_at);
+    CREATE INDEX IF NOT EXISTS idx_board_cards_parent
+      ON board_cards(parent);
+  `);
+  recordMigration(
+    database,
+    30,
+    'Persist board card data model for admin work board',
+  );
+}
+
 function runMigrations(
   database: Database.Database,
   opts?: InitDatabaseOptions,
@@ -2389,6 +2422,7 @@ function runMigrations(
   ) {
     migrateV29(database);
   }
+  if (currentVersion < 30) migrateV30(database);
 
   setSchemaVersion(database, DATABASE_SCHEMA_VERSION);
   if (!quiet && currentVersion < DATABASE_SCHEMA_VERSION) {
@@ -2419,6 +2453,22 @@ export function isDatabaseInitialized(): boolean {
 function ensureDatabaseReady(): void {
   if (databaseInitialized) return;
   initDatabase({ quiet: true });
+}
+
+export function withMemoryDatabase<T>(
+  fn: (database: Database.Database) => T,
+): T {
+  ensureDatabaseReady();
+  return fn(db);
+}
+
+export function withMemoryDatabaseRuntimeRevisionStore<T>(
+  fn: (database: Database.Database, revisionSchemaName: string) => T,
+): T {
+  ensureDatabaseReady();
+  return withRuntimeRevisionDatabaseAttached(() =>
+    fn(db, RUNTIME_REVISION_ATTACHMENT),
+  );
 }
 
 function serializeAgentModelConfig(

--- a/src/skills/skill-run-events.ts
+++ b/src/skills/skill-run-events.ts
@@ -7,6 +7,11 @@ import type {
   SkillExecutionOutcome,
 } from './adaptive-skills-types.js';
 
+export interface RuntimeEventPayload {
+  type: string;
+  [key: string]: unknown;
+}
+
 export interface SkillRunTokenEnvelope {
   prompt: number;
   completion: number;
@@ -52,7 +57,7 @@ export interface SkillRunToolExecutionFull
   result: SkillRunFullPayload;
 }
 
-export interface SkillRunEvent {
+export interface SkillRunEvent extends RuntimeEventPayload {
   type: 'skill_run';
   skill_id: string;
   agent_id: string | null;
@@ -75,18 +80,28 @@ export interface SkillRunEvent {
   tool_executions_full: SkillRunToolExecutionFull[];
 }
 
+export type RuntimeEventSubscriber = (event: RuntimeEventPayload) => unknown;
 export type SkillRunSubscriber = (event: SkillRunEvent) => unknown;
 
-const subscribers = new Set<SkillRunSubscriber>();
+const runtimeSubscribers = new Set<RuntimeEventSubscriber>();
 const MAX_SKILL_RUN_PAYLOAD_CHARS = 4096;
+
+export function subscribeRuntimeEvents(
+  subscriber: RuntimeEventSubscriber,
+): () => void {
+  runtimeSubscribers.add(subscriber);
+  return () => {
+    runtimeSubscribers.delete(subscriber);
+  };
+}
 
 export function subscribeSkillRunEvents(
   subscriber: SkillRunSubscriber,
 ): () => void {
-  subscribers.add(subscriber);
-  return () => {
-    subscribers.delete(subscriber);
-  };
+  return subscribeRuntimeEvents((event) => {
+    if (event.type !== 'skill_run') return;
+    subscriber(event as SkillRunEvent);
+  });
 }
 
 function summarizeSkillRunToolExecution(
@@ -177,25 +192,27 @@ export function buildSkillRunFullPayload(
   return buildSkillRunPayloads(value).full;
 }
 
-export function emitSkillRunEvent(event: SkillRunEvent): void {
+export function emitRuntimeEvent(event: RuntimeEventPayload): void {
   let subscriberIndex = 0;
-  for (const subscriber of subscribers) {
+  for (const subscriber of runtimeSubscribers) {
     subscriberIndex += 1;
     try {
       subscriber(event);
     } catch (error) {
       logger.warn(
         {
-          sessionId: event.session_id,
-          runId: event.run_id,
-          skillId: event.skill_id,
+          eventType: event.type,
           subscriberIndex,
           error,
         },
-        'Skill run subscriber failed',
+        'Runtime event subscriber failed',
       );
     }
   }
+}
+
+export function emitSkillRunEvent(event: SkillRunEvent): void {
+  emitRuntimeEvent(event);
 }
 
 function normalizeSkillRunModelCalls(tokenUsage?: TokenUsageStats): number {

--- a/tests/board-card-store.test.ts
+++ b/tests/board-card-store.test.ts
@@ -111,6 +111,9 @@ describe.sequential('board card store', () => {
       }),
     ).toHaveLength(1);
     expect(boardModule.listCards({ sourcePrefix: 'manual' })).toHaveLength(1);
+    expect(boardModule.listCards({ sourcePrefix: 'autopilot' })).toHaveLength(
+      0,
+    );
 
     const deleted = boardModule.deleteCard('card-1', {
       actor: { userId: 'user_a' },
@@ -119,6 +122,45 @@ describe.sequential('board card store', () => {
     expect(deleted.deletedAt).toBeTruthy();
     expect(boardModule.getCard('card-1')).toBeNull();
     expect(boardModule.listCards({ includeDeleted: true })).toHaveLength(1);
+  });
+
+  test('update ignores undefined patch values and preserves createdAt', async () => {
+    const { boardModule } = await loadBoardStore();
+
+    const created = boardModule.createCard({
+      id: 'card-undefined-patch',
+      title: 'Patch target',
+      body: 'Body',
+      owner: { agentId: 'agent_builder' },
+      status: 'queued',
+      parent: 'parent-card',
+      source: 'autopilot/nightly',
+    });
+
+    const updated = boardModule.updateCard('card-undefined-patch', {
+      title: undefined,
+      status: undefined,
+      parent: undefined,
+      body: 'Updated body',
+    });
+
+    expect(updated).toMatchObject({
+      title: 'Patch target',
+      body: 'Updated body',
+      status: 'queued',
+      parent: 'parent-card',
+      source: 'autopilot/nightly',
+      createdAt: created.createdAt,
+    });
+    expect(boardModule.listCards({ sourcePrefix: 'autopilot' })).toHaveLength(
+      1,
+    );
+
+    const cleared = boardModule.updateCard('card-undefined-patch', {
+      parent: null,
+    });
+    expect(cleared.parent).toBeNull();
+    expect(cleared.createdAt).toBe(created.createdAt);
   });
 
   test('restores prior field state through F4 revisions', async () => {

--- a/tests/board-card-store.test.ts
+++ b/tests/board-card-store.test.ts
@@ -1,0 +1,247 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+let tmpDir: string;
+let originalDataDir: string | undefined;
+let originalHome: string | undefined;
+
+async function loadBoardStore() {
+  process.env.HYBRIDCLAW_DATA_DIR = tmpDir;
+  process.env.HOME = tmpDir;
+  vi.resetModules();
+  const dbModule = await import('../src/memory/db.js');
+  const boardModule = await import('../src/board/card-store.js');
+  dbModule.initDatabase({
+    quiet: true,
+    dbPath: path.join(tmpDir, 'data', 'hybridclaw.db'),
+  });
+  return { dbModule, boardModule };
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-board-'));
+  originalDataDir = process.env.HYBRIDCLAW_DATA_DIR;
+  originalHome = process.env.HOME;
+});
+
+afterEach(() => {
+  if (originalDataDir === undefined) delete process.env.HYBRIDCLAW_DATA_DIR;
+  else process.env.HYBRIDCLAW_DATA_DIR = originalDataDir;
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe.sequential('board card store', () => {
+  test('migrates the board card table', async () => {
+    const { dbModule } = await loadBoardStore();
+    const inspect = new Database(path.join(tmpDir, 'data', 'hybridclaw.db'), {
+      readonly: true,
+    });
+    const columns = inspect
+      .prepare(`PRAGMA table_info(board_cards)`)
+      .all() as Array<{ name: string }>;
+    inspect.close();
+
+    expect(dbModule.DATABASE_SCHEMA_VERSION).toBe(30);
+    expect(columns.map((column) => column.name)).toEqual(
+      expect.arrayContaining([
+        'id',
+        'title',
+        'body',
+        'owner',
+        'column',
+        'status',
+        'source',
+        'parent',
+        'created_at',
+        'updated_at',
+        'deleted_at',
+      ]),
+    );
+  });
+
+  test('round-trips create, get, update, list, and soft-delete', async () => {
+    const { boardModule } = await loadBoardStore();
+
+    const created = boardModule.createCard(
+      {
+        id: 'card-1',
+        title: 'Investigate importer failure',
+        body: 'The nightly import failed on row 42.',
+        owner: { agentId: 'agent_builder' },
+        column: 'triage',
+        status: 'queued',
+        source: 'manual',
+      },
+      { actor: { userId: 'user_a' }, sessionId: 'board-test' },
+    );
+
+    expect(boardModule.getCard('card-1')).toMatchObject({
+      id: 'card-1',
+      owner: { agentId: 'agent_builder' },
+      column: 'triage',
+      deletedAt: null,
+    });
+
+    const updated = boardModule.updateCard(
+      created.id,
+      {
+        title: 'Fix importer failure',
+        status: 'running',
+        parent: 'parent-card',
+      },
+      { actor: { agentId: 'agent_builder' }, sessionId: 'board-test' },
+    );
+
+    expect(updated).toMatchObject({
+      title: 'Fix importer failure',
+      column: 'triage',
+      status: 'running',
+      parent: 'parent-card',
+    });
+    expect(
+      boardModule.listCards({
+        column: 'triage',
+        owner: { agentId: 'agent_builder' },
+      }),
+    ).toHaveLength(1);
+    expect(boardModule.listCards({ sourcePrefix: 'manual' })).toHaveLength(1);
+
+    const deleted = boardModule.deleteCard('card-1', {
+      actor: { userId: 'user_a' },
+      sessionId: 'board-test',
+    });
+    expect(deleted.deletedAt).toBeTruthy();
+    expect(boardModule.getCard('card-1')).toBeNull();
+    expect(boardModule.listCards({ includeDeleted: true })).toHaveLength(1);
+  });
+
+  test('restores prior field state through F4 revisions', async () => {
+    const { boardModule } = await loadBoardStore();
+
+    boardModule.createCard({
+      id: 'card-rollback',
+      title: 'Original title',
+      body: 'Original body',
+      owner: { userId: 'user_a' },
+      column: 'todo',
+      status: 'queued',
+      source: 'workflow/step-1',
+    });
+    boardModule.updateCard('card-rollback', {
+      title: 'Changed title',
+      body: 'Changed body',
+      status: 'complete',
+    });
+
+    const revisions = boardModule.listCardRevisions('card-rollback');
+    const originalRevision = revisions[0];
+    expect(originalRevision).toBeTruthy();
+    if (!originalRevision) throw new Error('Expected card revision.');
+
+    const restored = boardModule.restoreCardRevision(
+      'card-rollback',
+      originalRevision.id,
+      { actor: { userId: 'user_a' }, sessionId: 'board-test' },
+    );
+
+    expect(restored).toMatchObject({
+      title: 'Original title',
+      body: 'Original body',
+      column: 'todo',
+      status: 'queued',
+      deletedAt: null,
+    });
+
+    boardModule.deleteCard('card-rollback', {
+      actor: { userId: 'user_a' },
+      sessionId: 'board-test',
+    });
+    expect(boardModule.getCard('card-rollback')).toBeNull();
+
+    const preDeleteRevision = boardModule.listCardRevisions('card-rollback')[0];
+    expect(preDeleteRevision).toBeTruthy();
+    if (!preDeleteRevision) throw new Error('Expected pre-delete revision.');
+
+    const undeleted = boardModule.restoreCardRevision(
+      'card-rollback',
+      preDeleteRevision.id,
+      { actor: { userId: 'user_a' }, sessionId: 'board-test' },
+    );
+    expect(undeleted).toMatchObject({
+      title: 'Original title',
+      deletedAt: null,
+    });
+  });
+
+  test('uses last-write-wins for sequential concurrent-style updates', async () => {
+    const { boardModule } = await loadBoardStore();
+
+    boardModule.createCard({
+      id: 'card-concurrent',
+      title: 'Start',
+      owner: { agentId: 'agent_builder' },
+    });
+
+    boardModule.updateCard('card-concurrent', { status: 'running' });
+    boardModule.updateCard('card-concurrent', { status: 'paused' });
+
+    expect(boardModule.getCard('card-concurrent')).toMatchObject({
+      status: 'paused',
+    });
+  });
+
+  test('emits F2-shaped board events to subscribers and structured audit', async () => {
+    const { boardModule, dbModule } = await loadBoardStore();
+    const received: unknown[] = [];
+    const unsubscribe = boardModule.subscribeBoardCardEvents((event) => {
+      received.push(event);
+    });
+
+    boardModule.createCard(
+      {
+        id: 'card-event',
+        title: 'Emit event',
+        owner: { userId: 'user_a' },
+        source: 'a2a/envelope-1',
+      },
+      {
+        actor: { userId: 'user_a' },
+        sessionId: 'board-event-session',
+        runId: 'board-event-run',
+      },
+    );
+    unsubscribe();
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({
+      type: 'board.card_created',
+      actor: { userId: 'user_a' },
+      cardId: 'card-event',
+      diff: {
+        id: { before: null, after: 'card-event' },
+        source: { before: null, after: 'a2a/envelope-1' },
+      },
+    });
+
+    const audit = dbModule.getRecentStructuredAuditForSession(
+      'board-event-session',
+      10,
+    );
+    expect(audit).toHaveLength(1);
+    expect(audit[0]).toMatchObject({
+      event_type: 'board.card_created',
+      run_id: 'board-event-run',
+    });
+    expect(JSON.parse(audit[0]?.payload || '{}')).toMatchObject({
+      actor: { userId: 'user_a' },
+      cardId: 'card-event',
+      diff: expect.any(Object),
+    });
+  });
+});

--- a/tests/board-card-store.test.ts
+++ b/tests/board-card-store.test.ts
@@ -47,7 +47,7 @@ describe.sequential('board card store', () => {
       .all() as Array<{ name: string }>;
     inspect.close();
 
-    expect(dbModule.DATABASE_SCHEMA_VERSION).toBe(30);
+    expect(dbModule.DATABASE_SCHEMA_VERSION).toBe(31);
     expect(columns.map((column) => column.name)).toEqual(
       expect.arrayContaining([
         'id',

--- a/tests/board-card-store.test.ts
+++ b/tests/board-card-store.test.ts
@@ -110,7 +110,7 @@ describe.sequential('board card store', () => {
         owner: { agentId: 'agent_builder' },
       }),
     ).toHaveLength(1);
-    expect(boardModule.listCards({ sourcePrefix: 'manual' })).toHaveLength(1);
+    expect(boardModule.listCards({ source: 'manual' })).toHaveLength(1);
     expect(boardModule.listCards({ sourcePrefix: 'autopilot' })).toHaveLength(
       0,
     );
@@ -157,10 +157,23 @@ describe.sequential('board card store', () => {
     );
 
     const cleared = boardModule.updateCard('card-undefined-patch', {
-      parent: null,
+      parent: '',
     });
     expect(cleared.parent).toBeNull();
     expect(cleared.createdAt).toBe(created.createdAt);
+  });
+
+  test('rejects unsafe source identifiers', async () => {
+    const { boardModule } = await loadBoardStore();
+
+    expect(() =>
+      boardModule.createCard({
+        id: 'card-unsafe-source',
+        title: 'Unsafe source',
+        owner: { agentId: 'agent_builder' },
+        source: 'autopilot/../../secret' as `autopilot/${string}`,
+      }),
+    ).toThrow(/Unsupported board card source/);
   });
 
   test('restores prior field state through F4 revisions', async () => {

--- a/tests/board-card-store.test.ts
+++ b/tests/board-card-store.test.ts
@@ -251,11 +251,22 @@ describe.sequential('board card store', () => {
     });
   });
 
-  test('emits F2-shaped board events to subscribers and structured audit', async () => {
+  test('emits board mutations through F2 runtime events and structured audit', async () => {
     const { boardModule, dbModule } = await loadBoardStore();
-    const received: unknown[] = [];
-    const unsubscribe = boardModule.subscribeBoardCardEvents((event) => {
-      received.push(event);
+    const { subscribeRuntimeEvents, subscribeSkillRunEvents } = await import(
+      '../src/skills/skill-run-events.js'
+    );
+    const runtimeEvents: unknown[] = [];
+    const boardEvents: unknown[] = [];
+    const skillRunEvents: unknown[] = [];
+    const unsubscribeRuntime = subscribeRuntimeEvents((event) => {
+      runtimeEvents.push(event);
+    });
+    const unsubscribeBoard = boardModule.subscribeBoardCardEvents((event) => {
+      boardEvents.push(event);
+    });
+    const unsubscribeSkillRun = subscribeSkillRunEvents((event) => {
+      skillRunEvents.push(event);
     });
 
     boardModule.createCard(
@@ -271,10 +282,12 @@ describe.sequential('board card store', () => {
         runId: 'board-event-run',
       },
     );
-    unsubscribe();
+    unsubscribeRuntime();
+    unsubscribeBoard();
+    unsubscribeSkillRun();
 
-    expect(received).toHaveLength(1);
-    expect(received[0]).toMatchObject({
+    expect(runtimeEvents).toHaveLength(1);
+    expect(runtimeEvents[0]).toMatchObject({
       type: 'board.card_created',
       actor: { userId: 'user_a' },
       cardId: 'card-event',
@@ -283,6 +296,8 @@ describe.sequential('board card store', () => {
         source: { before: null, after: 'a2a/envelope-1' },
       },
     });
+    expect(boardEvents).toEqual(runtimeEvents);
+    expect(skillRunEvents).toHaveLength(0);
 
     const audit = dbModule.getRecentStructuredAuditForSession(
       'board-event-session',


### PR DESCRIPTION
## Summary

Implements #913 / R29.8 by adding the internal board card data layer that later R29 board work can build on.

- Add a `board_cards` SQLite table in schema v30 with typed owner/source/column fields and soft-delete state.
- Add `src/board/card-store.ts` with typed create/get/list/update/delete APIs, F4-backed per-card revisions, rollback restore, and board card mutation events.
- Register `board_card` as a runtime revision asset type.
- Cover migration, CRUD, soft-delete rollback, last-write-wins update behavior, and F2-shaped structured audit event output.

Column moves are intentionally excluded from `updateCard`; R29.9 owns transition validation and state-machine moves.

Closes #913.

## Validation

- `./node_modules/.bin/biome check --write src/board/card-store.ts tests/board-card-store.test.ts src/config/runtime-config-revisions.ts src/memory/db.ts`
- `./node_modules/.bin/vitest run tests/board-card-store.test.ts`
- `./node_modules/.bin/tsc --noEmit`