### PR TITLE
feat(console): redesign Usage rollup + add Skeleton/MetricCard loading

### DIFF
--- a/console/src/components/skeleton/index.tsx
+++ b/console/src/components/skeleton/index.tsx
@@ -1,0 +1,18 @@
+import { forwardRef, type HTMLAttributes } from 'react';
+import { cx } from '../../lib/cx';
+import styles from './skeleton.module.css';
+
+export type SkeletonProps = HTMLAttributes<HTMLDivElement>;
+
+export const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(
+  function Skeleton({ className, ...rest }, ref) {
+    return (
+      <div
+        ref={ref}
+        data-slot="skeleton"
+        className={cx(styles.skeleton, className)}
+        {...rest}
+      />
+    );
+  },
+);

--- a/console/src/components/skeleton/skeleton.module.css
+++ b/console/src/components/skeleton/skeleton.module.css
@@ -1,0 +1,22 @@
+.skeleton {
+  display: block;
+  background: color-mix(in srgb, var(--text) 10%, transparent);
+  border-radius: var(--radius-sm);
+  animation: skeleton-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes skeleton-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+  }
+}

--- a/console/src/components/ui.tsx
+++ b/console/src/components/ui.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';
 
+import { Skeleton } from './skeleton';
 import { ToggleGroup, ToggleGroupItem } from './ui/toggle-group';
 
 export { ToggleGroup, ToggleGroupItem };
@@ -130,14 +131,12 @@ export function Panel(props: {
       className={props.accent === 'warm' ? 'panel warm' : 'panel'}
     >
       {props.title ? (
-        <div className="panel-header">
-          <div>
-            <h4>{props.title}</h4>
-            {props.subtitle ? (
-              <p className="supporting-text">{props.subtitle}</p>
-            ) : null}
-          </div>
-        </div>
+        <header className="panel-header">
+          <h4 className="panel-title">{props.title}</h4>
+          {props.subtitle ? (
+            <p className="panel-subtitle">{props.subtitle}</p>
+          ) : null}
+        </header>
       ) : null}
       {props.children}
     </section>
@@ -148,13 +147,22 @@ export function MetricCard(props: {
   label: string;
   value: string;
   detail?: string;
+  loading?: boolean;
   href?: string;
 }) {
   const content = (
     <>
       <span>{props.label}</span>
-      <strong>{props.value}</strong>
-      {props.detail ? <small>{props.detail}</small> : null}
+      {props.loading ? (
+        <Skeleton className="metric-card-value-skeleton" />
+      ) : (
+        <strong>{props.value}</strong>
+      )}
+      {props.loading && props.detail !== undefined ? (
+        <Skeleton className="metric-card-detail-skeleton" />
+      ) : !props.loading && props.detail ? (
+        <small>{props.detail}</small>
+      ) : null}
     </>
   );
 

--- a/console/src/components/usage-rollup.module.css
+++ b/console/src/components/usage-rollup.module.css
@@ -87,6 +87,21 @@
   stroke-linecap: round;
 }
 
+.pointTarget {
+  outline: none;
+}
+
+.point {
+  fill: transparent;
+  stroke: transparent;
+}
+
+.pointTarget:focus-visible .point {
+  fill: var(--panel);
+  stroke: var(--primary);
+  stroke-width: 2;
+}
+
 .crosshair {
   stroke: color-mix(in srgb, var(--primary) 48%, transparent);
   stroke-width: 1;

--- a/console/src/components/usage-rollup.module.css
+++ b/console/src/components/usage-rollup.module.css
@@ -1,0 +1,179 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.empty {
+  font-size: 0.85rem;
+  color: color-mix(in srgb, var(--text) 50%, transparent);
+  margin: 0;
+}
+
+.summary {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: color-mix(in srgb, var(--text) 70%, transparent);
+  font-variant-numeric: tabular-nums;
+}
+
+.summary strong {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.ribbon {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 20px;
+  padding: 16px 0;
+  border-top: 1px solid color-mix(in srgb, var(--line) 80%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--line) 80%, transparent);
+}
+
+.metric {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.metricLabel {
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: color-mix(in srgb, var(--text) 55%, transparent);
+}
+
+.metricValue {
+  font-size: 0.95rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chart {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.chartCanvas {
+  position: relative;
+  width: 100%;
+}
+
+.chartSvg {
+  display: block;
+  width: 100%;
+  height: 72px;
+  overflow: visible;
+}
+
+.area {
+  fill: var(--accent);
+  fill-opacity: 0.14;
+}
+
+.line {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 1.75;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+
+.crosshair {
+  stroke: color-mix(in srgb, var(--text) 25%, transparent);
+  stroke-width: 1;
+  stroke-dasharray: 2 3;
+  pointer-events: none;
+}
+
+.tooltip {
+  position: absolute;
+  top: -32px;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 3px 8px;
+  border-radius: 4px;
+  background: var(--panel-muted);
+  border: 1px solid var(--line);
+  white-space: nowrap;
+  pointer-events: none;
+  font-size: 0.75rem;
+  line-height: 1.2;
+  transform: translateX(-50%);
+  z-index: 1;
+}
+
+.tooltip[data-align="start"] {
+  transform: translateX(0);
+}
+
+.tooltip[data-align="end"] {
+  transform: translateX(-100%);
+}
+
+.tooltipLabel {
+  color: color-mix(in srgb, var(--text) 60%, transparent);
+}
+
+.tooltipValue {
+  color: var(--text);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+
+.axis {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 0.72rem;
+  color: color-mix(in srgb, var(--text) 50%, transparent);
+}
+
+.topModels {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.topModelRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 12px;
+  align-items: baseline;
+  font-size: 0.85rem;
+}
+
+.topModelName {
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.topModelDetail {
+  color: color-mix(in srgb, var(--text) 55%, transparent);
+  font-variant-numeric: tabular-nums;
+}
+
+.topModelCost {
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 720px) {
+  .ribbon {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px 20px;
+  }
+}

--- a/console/src/components/usage-rollup.module.css
+++ b/console/src/components/usage-rollup.module.css
@@ -74,20 +74,21 @@
 }
 
 .area {
-  fill: var(--accent);
-  fill-opacity: 0.14;
+  fill: var(--primary);
+  fill-opacity: 0.1;
 }
 
 .line {
   fill: none;
-  stroke: var(--accent);
-  stroke-width: 1.75;
+  stroke: var(--primary);
+  stroke-opacity: 0.72;
+  stroke-width: 2.25;
   stroke-linejoin: round;
   stroke-linecap: round;
 }
 
 .crosshair {
-  stroke: color-mix(in srgb, var(--text) 25%, transparent);
+  stroke: color-mix(in srgb, var(--primary) 48%, transparent);
   stroke-width: 1;
   stroke-dasharray: 2 3;
   pointer-events: none;
@@ -141,15 +142,16 @@
   list-style: none;
   margin: 0;
   padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content 5.25rem;
+  column-gap: 12px;
+  row-gap: 6px;
 }
 
 .topModelRow {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
-  gap: 12px;
+  grid-column: 1 / -1;
+  grid-template-columns: subgrid;
   align-items: baseline;
   font-size: 0.85rem;
 }
@@ -164,11 +166,16 @@
 .topModelDetail {
   color: color-mix(in srgb, var(--text) 55%, transparent);
   font-variant-numeric: tabular-nums;
+  min-width: 0;
+  text-align: right;
+  white-space: nowrap;
 }
 
 .topModelCost {
   color: var(--text);
   font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
 }
 
 @media (max-width: 720px) {

--- a/console/src/components/usage-rollup.tsx
+++ b/console/src/components/usage-rollup.tsx
@@ -53,8 +53,7 @@ export function UsageRollup(props: UsageRollupProps) {
     <div className={css.root}>
       <p className={css.summary}>
         <strong>{formatCompactNumber(summary.totalTokens)}</strong> tokens this
-        month
-        {hasDaily ? ` · ${formatCompactNumber(daily.totalTokens)} today` : null}
+        month · {formatCompactNumber(daily.totalTokens)} today
       </p>
 
       <div className={css.ribbon}>
@@ -194,6 +193,20 @@ function UsageChart(props: {
             className={css.line}
             vectorEffect="non-scaling-stroke"
           />
+          {points.map((point) => {
+            const pointLabel = `${point.label}: ${formatCompactNumber(point.value)} tokens`;
+            return (
+              <g
+                key={point.index}
+                className={css.pointTarget}
+                tabIndex={0}
+                aria-label={pointLabel}
+              >
+                <title>{pointLabel}</title>
+                <circle cx={point.x} cy={point.y} r={5} className={css.point} />
+              </g>
+            );
+          })}
           {hover ? (
             <line
               x1={hover.point.x}

--- a/console/src/components/usage-rollup.tsx
+++ b/console/src/components/usage-rollup.tsx
@@ -1,0 +1,255 @@
+import { useMemo, useState } from 'react';
+import type { AdminOverview, AdminStatisticsTrendDay } from '../api/types';
+import {
+  formatCompactNumber,
+  formatTokenBreakdown,
+  formatUsd,
+  pluralize,
+} from '../lib/format';
+import css from './usage-rollup.module.css';
+
+// Render zero spend as a bare "$0" in the rollup. Routes that show USD in
+// columns (Models, Statistics) still want `formatUsd`'s fixed-decimal form so
+// tabular-nums alignment holds across rows.
+function formatUsdCompact(value: number): string {
+  return value === 0 ? '$0' : formatUsd(value);
+}
+
+const CHART_VIEWBOX_WIDTH = 600;
+const CHART_VIEWBOX_HEIGHT = 100;
+
+interface ChartPoint {
+  index: number;
+  label: string;
+  value: number;
+  x: number;
+  y: number;
+}
+
+export interface UsageRollupProps {
+  usage: AdminOverview['usage'];
+  trend: AdminStatisticsTrendDay[] | null;
+  formatTrendDate: (isoDate: string) => string;
+}
+
+export function UsageRollup(props: UsageRollupProps) {
+  const { daily, monthly, topModels } = props.usage;
+  const hasMonthly = monthly.callCount > 0 || monthly.totalTokens > 0;
+  const hasDaily = daily.callCount > 0 || daily.totalTokens > 0;
+
+  if (!hasMonthly && !hasDaily) {
+    return (
+      <p className={css.empty}>No usage has been recorded yet this month.</p>
+    );
+  }
+
+  const summary = monthly;
+  const showTopModels = topModels.length > 1;
+
+  return (
+    <div className={css.root}>
+      <p className={css.summary}>
+        <strong>{formatCompactNumber(summary.totalTokens)}</strong> tokens this
+        month
+        {hasDaily ? ` · ${formatCompactNumber(daily.totalTokens)} today` : null}
+      </p>
+
+      <div className={css.ribbon}>
+        <Metric
+          label="Input"
+          value={formatCompactNumber(summary.totalInputTokens ?? 0)}
+        />
+        <Metric
+          label="Output"
+          value={formatCompactNumber(summary.totalOutputTokens ?? 0)}
+        />
+        <Metric label="Calls" value={formatCompactNumber(summary.callCount)} />
+        <Metric label="Spent" value={formatUsdCompact(summary.totalCostUsd)} />
+      </div>
+
+      <UsageChart trend={props.trend} formatTrendDate={props.formatTrendDate} />
+
+      {showTopModels ? (
+        <ul className={css.topModels}>
+          {topModels.map((row) => (
+            <li key={row.model} className={css.topModelRow}>
+              <span className={css.topModelName}>{row.model}</span>
+              <span className={css.topModelDetail}>
+                {formatTokenBreakdown({
+                  inputTokens: row.totalInputTokens ?? 0,
+                  outputTokens: row.totalOutputTokens ?? 0,
+                })}{' '}
+                · {pluralize(row.callCount, 'call')}
+              </span>
+              <span className={css.topModelCost}>
+                {formatUsdCompact(row.totalCostUsd)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+function Metric(props: { label: string; value: string }) {
+  return (
+    <div className={css.metric}>
+      <span className={css.metricLabel}>{props.label}</span>
+      <span className={css.metricValue}>{props.value}</span>
+    </div>
+  );
+}
+
+interface HoverState {
+  index: number;
+  point: ChartPoint;
+}
+
+function UsageChart(props: {
+  trend: AdminStatisticsTrendDay[] | null;
+  formatTrendDate: (isoDate: string) => string;
+}) {
+  const [hover, setHover] = useState<HoverState | null>(null);
+  const trend = props.trend;
+
+  const layout = useMemo(() => {
+    if (!trend || trend.length < 2) return null;
+    const max = Math.max(0, ...trend.map((d) => d.totalTokens));
+    const stepX = CHART_VIEWBOX_WIDTH / (trend.length - 1);
+    const points: ChartPoint[] = trend.map((day, index) => {
+      const ratio = max > 0 ? Math.sqrt(day.totalTokens / max) : 0;
+      return {
+        index,
+        label: props.formatTrendDate(day.date),
+        value: day.totalTokens,
+        x: index * stepX,
+        y: CHART_VIEWBOX_HEIGHT - ratio * CHART_VIEWBOX_HEIGHT,
+      };
+    });
+    const linePath = buildSmoothPath(points);
+    const areaPath = `${linePath} L${CHART_VIEWBOX_WIDTH},${CHART_VIEWBOX_HEIGHT} L0,${CHART_VIEWBOX_HEIGHT} Z`;
+    const peak = points.reduce<ChartPoint | null>(
+      (best, p) => (p.value > (best?.value ?? -1) ? p : best),
+      null,
+    );
+    return { points, linePath, areaPath, peak };
+  }, [trend, props.formatTrendDate]);
+
+  if (!layout) return null;
+
+  const { points, linePath, areaPath, peak } = layout;
+  const peakLabel =
+    peak && peak.value > 0
+      ? `peak ${formatCompactNumber(peak.value)} on ${peak.label}`
+      : null;
+
+  function handleMove(event: React.PointerEvent<SVGSVGElement>) {
+    const rect = event.currentTarget.getBoundingClientRect();
+    if (rect.width === 0) return;
+    const ratio = (event.clientX - rect.left) / rect.width;
+    const clamped = Math.min(Math.max(ratio, 0), 0.9999);
+    const index = Math.min(
+      Math.max(Math.floor(clamped * points.length), 0),
+      points.length - 1,
+    );
+    const point = points[index];
+    if (!point) return;
+    setHover({ index, point });
+  }
+
+  function handleLeave() {
+    setHover(null);
+  }
+
+  const tooltipLeftPct = hover
+    ? (hover.point.x / CHART_VIEWBOX_WIDTH) * 100
+    : 0;
+  const tooltipAlign = !hover
+    ? 'center'
+    : tooltipLeftPct > 80
+      ? 'end'
+      : tooltipLeftPct < 18
+        ? 'start'
+        : 'center';
+
+  return (
+    <div className={css.chart}>
+      <div className={css.chartCanvas}>
+        <svg
+          viewBox={`0 0 ${CHART_VIEWBOX_WIDTH} ${CHART_VIEWBOX_HEIGHT}`}
+          preserveAspectRatio="none"
+          className={css.chartSvg}
+          role="img"
+          aria-label="Tokens per day, last 30 days"
+          onPointerMove={handleMove}
+          onPointerLeave={handleLeave}
+        >
+          <path d={areaPath} className={css.area} />
+          <path
+            d={linePath}
+            className={css.line}
+            vectorEffect="non-scaling-stroke"
+          />
+          {hover ? (
+            <line
+              x1={hover.point.x}
+              x2={hover.point.x}
+              y1={0}
+              y2={CHART_VIEWBOX_HEIGHT}
+              className={css.crosshair}
+              vectorEffect="non-scaling-stroke"
+            />
+          ) : null}
+        </svg>
+        {hover ? (
+          <div
+            className={css.tooltip}
+            data-align={tooltipAlign}
+            style={{ left: `${tooltipLeftPct}%` }}
+            role="status"
+            aria-live="polite"
+          >
+            <span className={css.tooltipLabel}>{hover.point.label}</span>
+            <span className={css.tooltipValue}>
+              {formatCompactNumber(hover.point.value)} tokens
+            </span>
+          </div>
+        ) : null}
+      </div>
+      <div className={css.axis} aria-hidden="true">
+        <span>{points.length - 1}d ago</span>
+        {peakLabel ? <span className={css.axisPeak}>{peakLabel}</span> : null}
+        <span>today</span>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Build a smooth Bezier path through the given points using Catmull-Rom
+ * to cubic-Bezier conversion. Single pass, no overshoot beyond the data
+ * envelope at the resolutions we use here.
+ */
+function buildSmoothPath(points: { x: number; y: number }[]): string {
+  if (points.length === 0) return '';
+  if (points.length === 1) {
+    return `M${points[0].x.toFixed(2)},${points[0].y.toFixed(2)}`;
+  }
+  const fmt = (value: number) => value.toFixed(2);
+  const segments = [`M${fmt(points[0].x)},${fmt(points[0].y)}`];
+  for (let i = 0; i < points.length - 1; i += 1) {
+    const p0 = points[Math.max(i - 1, 0)];
+    const p1 = points[i];
+    const p2 = points[i + 1];
+    const p3 = points[Math.min(i + 2, points.length - 1)];
+    const cp1x = p1.x + (p2.x - p0.x) / 6;
+    const cp1y = p1.y + (p2.y - p0.y) / 6;
+    const cp2x = p2.x - (p3.x - p1.x) / 6;
+    const cp2y = p2.y - (p3.y - p1.y) / 6;
+    segments.push(
+      `C${fmt(cp1x)},${fmt(cp1y)} ${fmt(cp2x)},${fmt(cp2y)} ${fmt(p2.x)},${fmt(p2.y)}`,
+    );
+  }
+  return segments.join(' ');
+}

--- a/console/src/components/usage-rollup.tsx
+++ b/console/src/components/usage-rollup.tsx
@@ -3,16 +3,19 @@ import type { AdminOverview, AdminStatisticsTrendDay } from '../api/types';
 import {
   formatCompactNumber,
   formatTokenBreakdown,
-  formatUsd,
   pluralize,
 } from '../lib/format';
 import css from './usage-rollup.module.css';
 
-// Render zero spend as a bare "$0" in the rollup. Routes that show USD in
-// columns (Models, Statistics) still want `formatUsd`'s fixed-decimal form so
-// tabular-nums alignment holds across rows.
+// Keep the rollup compact: zero is bare, nonzero values are capped at cents.
 function formatUsdCompact(value: number): string {
-  return value === 0 ? '$0' : formatUsd(value);
+  if (value === 0) return '$0';
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
 }
 
 const CHART_VIEWBOX_WIDTH = 600;

--- a/console/src/routes/agent-scoreboard.tsx
+++ b/console/src/routes/agent-scoreboard.tsx
@@ -106,16 +106,19 @@ export function AgentsPage() {
           label="Observed agents"
           value={String(agents.length)}
           detail="with recorded skill runs"
+          loading={!scoreboardQuery.data}
         />
         <MetricCard
           label="Observed skills"
           value={String(observedSkillCount)}
           detail="across agent runs"
+          loading={!scoreboardQuery.data}
         />
         <MetricCard
           label="Best average score"
           value={topAgent ? `${topAgent.avg_score}/100` : '0/100'}
           detail={topAgent?.display_name || 'No runs yet'}
+          loading={!scoreboardQuery.data}
         />
         <MetricCard
           label="Total runs"
@@ -123,6 +126,7 @@ export function AgentsPage() {
             agents.reduce((total, agent) => total + agent.total_executions, 0),
           )}
           detail="skill executions"
+          loading={!scoreboardQuery.data}
         />
       </div>
 

--- a/console/src/routes/approvals.tsx
+++ b/console/src/routes/approvals.tsx
@@ -326,19 +326,23 @@ export function ApprovalsPage() {
       <div className="metric-grid">
         <MetricCard
           label="Pending approvals"
-          value={String(approvalsQuery.data?.pending.length || 0)}
+          value={String(approvalsQuery.data?.pending.length ?? 0)}
+          loading={!approvalsQuery.data}
         />
         <MetricCard
           label="Blocked sessions"
-          value={String(approvalsQuery.data?.suspendedSessions.length || 0)}
+          value={String(approvalsQuery.data?.suspendedSessions.length ?? 0)}
+          loading={!approvalsQuery.data}
         />
         <MetricCard
           label="Policy rules"
-          value={String(policyRules.length || 0)}
+          value={String(policyRules.length)}
+          loading={!approvalsQuery.data}
         />
         <MetricCard
           label="Applied presets"
-          value={String(approvalsQuery.data?.policy.presets.length || 0)}
+          value={String(approvalsQuery.data?.policy.presets.length ?? 0)}
+          loading={!approvalsQuery.data}
         />
         <div className="metric-card">
           <span>Default policy</span>

--- a/console/src/routes/dashboard.test.tsx
+++ b/console/src/routes/dashboard.test.tsx
@@ -118,7 +118,10 @@ describe('DashboardPage', () => {
     fetchOverviewMock.mockReset();
     fetchStatisticsMock.mockReset();
     fetchStatisticsMock.mockResolvedValue({
-      summary: {
+      rangeDays: 30,
+      startDate: '2026-04-01',
+      endDate: '2026-04-30',
+      totals: {
         newSessions: 0,
         activeSessions: 0,
         totalMessages: 0,
@@ -254,5 +257,77 @@ describe('DashboardPage', () => {
       expect(screen.getByText(tunnelError)).toBeTruthy();
       expect(screen.getByText(reconnectError)).toBeTruthy();
     });
+  });
+
+  it('keeps zero daily usage and per-day chart labels visible', async () => {
+    const overview = makeOverview();
+    overview.usage.monthly = {
+      totalInputTokens: 800,
+      totalOutputTokens: 400,
+      totalTokens: 1200,
+      totalCostUsd: 0.05,
+      callCount: 3,
+      totalToolCalls: 1,
+    };
+    fetchOverviewMock.mockResolvedValue(overview);
+    fetchStatisticsMock.mockResolvedValue({
+      rangeDays: 30,
+      startDate: '2026-04-29',
+      endDate: '2026-04-30',
+      totals: {
+        newSessions: 0,
+        activeSessions: 0,
+        totalMessages: 0,
+        userMessages: 0,
+        assistantMessages: 0,
+        totalInputTokens: 800,
+        totalOutputTokens: 400,
+        totalTokens: 1200,
+        totalCostUsd: 0.05,
+        callCount: 3,
+        totalToolCalls: 1,
+      },
+      trend: [
+        {
+          date: '2026-04-29',
+          newSessions: 0,
+          activeSessions: 0,
+          userMessages: 0,
+          assistantMessages: 0,
+          totalMessages: 0,
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+          callCount: 0,
+          toolCalls: 0,
+          costUsd: 0,
+        },
+        {
+          date: '2026-04-30',
+          newSessions: 0,
+          activeSessions: 0,
+          userMessages: 0,
+          assistantMessages: 0,
+          totalMessages: 0,
+          inputTokens: 800,
+          outputTokens: 400,
+          totalTokens: 1200,
+          callCount: 3,
+          toolCalls: 1,
+          costUsd: 0.05,
+        },
+      ],
+      channels: [],
+    });
+
+    renderDashboardPage();
+
+    expect(
+      await screen.findByText((content) =>
+        content.includes('tokens this month · 0 today'),
+      ),
+    ).toBeTruthy();
+    expect(await screen.findByText('Apr 29: 0 tokens')).toBeTruthy();
+    expect(await screen.findByText('Apr 30: 1.2K tokens')).toBeTruthy();
   });
 });

--- a/console/src/routes/dashboard.test.tsx
+++ b/console/src/routes/dashboard.test.tsx
@@ -5,6 +5,7 @@ import type { AdminOverview, AdminTunnelStatus } from '../api/types';
 import { DashboardPage } from './dashboard';
 
 const fetchOverviewMock = vi.fn();
+const fetchStatisticsMock = vi.fn();
 const reconnectTunnelMock = vi.fn();
 const navigateMock = vi.fn();
 const useAuthMock = vi.fn();
@@ -12,6 +13,7 @@ const useLiveEventsMock = vi.fn();
 
 vi.mock('../api/client', () => ({
   fetchOverview: (...args: unknown[]) => fetchOverviewMock(...args),
+  fetchStatistics: (...args: unknown[]) => fetchStatisticsMock(...args),
   reconnectTunnel: (...args: unknown[]) => reconnectTunnelMock(...args),
 }));
 
@@ -111,6 +113,24 @@ function renderDashboardPage(): void {
 describe('DashboardPage', () => {
   beforeEach(() => {
     fetchOverviewMock.mockReset();
+    fetchStatisticsMock.mockReset();
+    fetchStatisticsMock.mockResolvedValue({
+      summary: {
+        newSessions: 0,
+        activeSessions: 0,
+        totalMessages: 0,
+        userMessages: 0,
+        assistantMessages: 0,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalTokens: 0,
+        totalCostUsd: 0,
+        callCount: 0,
+        totalToolCalls: 0,
+      },
+      trend: [],
+      channels: [],
+    });
     reconnectTunnelMock.mockReset();
     navigateMock.mockReset();
     useAuthMock.mockReset();

--- a/console/src/routes/dashboard.tsx
+++ b/console/src/routes/dashboard.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { fetchOverview, reconnectTunnel } from '../api/client';
+import { fetchOverview, fetchStatistics, reconnectTunnel } from '../api/client';
 import type { AdminOverview, AdminTunnelStatus } from '../api/types';
 import { useAuth } from '../auth';
 import { ProviderHealthPanel } from '../components/provider-health';
@@ -11,16 +11,13 @@ import {
   SortableHeader,
   useSortableRows,
 } from '../components/ui';
+import { UsageRollup } from '../components/usage-rollup';
 import { useLiveEvents } from '../hooks/use-live-events';
 import { getErrorMessage } from '../lib/error-message';
 import {
-  formatCompactNumber,
   formatDateTime,
   formatRelativeTime,
-  formatTokenBreakdown,
   formatUptime,
-  formatUsd,
-  pluralize,
 } from '../lib/format';
 import { compareDateTime, compareNumber, compareText } from '../lib/sort';
 
@@ -60,6 +57,21 @@ const RECENT_SESSION_DEFAULT_DIRECTIONS = {
   tasks: 'desc',
   lastActive: 'desc',
 } as const;
+
+const TREND_DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
+  month: 'short',
+  day: 'numeric',
+  // Trend buckets come from the statistics API as UTC `YYYY-MM-DD`. Format
+  // them in UTC so a west-of-UTC user doesn't see the bucket shift one day
+  // earlier (midnight UTC is the previous local day).
+  timeZone: 'UTC',
+});
+
+function formatTrendDate(isoDate: string): string {
+  const [year, month, day] = isoDate.split('-').map(Number);
+  if (!year || !month || !day) return isoDate;
+  return TREND_DATE_FORMAT.format(new Date(Date.UTC(year, month - 1, day)));
+}
 
 function tunnelStatusClass(health: AdminTunnelStatus['health']): string {
   if (health === 'healthy') return 'list-status list-status-success';
@@ -157,6 +169,11 @@ export function DashboardPage() {
     queryKey: ['overview', auth.token],
     queryFn: () => fetchOverview(auth.token),
     refetchInterval: 30_000,
+  });
+  const usageTrendQuery = useQuery({
+    queryKey: ['usage-trend', auth.token, 30],
+    queryFn: () => fetchStatistics(auth.token, 30),
+    staleTime: 60_000,
   });
   const reconnectMutation = useMutation({
     mutationFn: () => reconnectTunnel(auth.token),
@@ -258,64 +275,12 @@ export function DashboardPage() {
       </div>
 
       <div className="two-column-grid">
-        <Panel title="Usage rollup" accent="warm">
-          <div className="usage-grid">
-            <div className="usage-stack">
-              <span>Daily</span>
-              <strong>
-                {formatCompactNumber(overview.usage.daily.totalTokens)}
-              </strong>
-              <small>
-                {formatTokenBreakdown({
-                  inputTokens: overview.usage.daily.totalInputTokens ?? 0,
-                  outputTokens: overview.usage.daily.totalOutputTokens ?? 0,
-                })}
-              </small>
-              <small>
-                {formatUsd(overview.usage.daily.totalCostUsd)} across{' '}
-                {pluralize(overview.usage.daily.callCount, 'call')}
-              </small>
-            </div>
-            <div className="usage-stack">
-              <span>Monthly</span>
-              <strong>
-                {formatCompactNumber(overview.usage.monthly.totalTokens)}
-              </strong>
-              <small>
-                {formatTokenBreakdown({
-                  inputTokens: overview.usage.monthly.totalInputTokens ?? 0,
-                  outputTokens: overview.usage.monthly.totalOutputTokens ?? 0,
-                })}
-              </small>
-              <small>
-                {formatUsd(overview.usage.monthly.totalCostUsd)} across{' '}
-                {pluralize(overview.usage.monthly.callCount, 'call')}
-              </small>
-            </div>
-          </div>
-          <div className="list-stack">
-            {overview.usage.topModels.length === 0 ? (
-              <p className="supporting-text">
-                No model usage has been recorded yet.
-              </p>
-            ) : (
-              overview.usage.topModels.map((row) => (
-                <div className="list-row" key={row.model}>
-                  <div>
-                    <strong>{row.model}</strong>
-                    <small>
-                      {formatTokenBreakdown({
-                        inputTokens: row.totalInputTokens ?? 0,
-                        outputTokens: row.totalOutputTokens ?? 0,
-                      })}{' '}
-                      · {pluralize(row.callCount, 'call')} this month
-                    </small>
-                  </div>
-                  <span>{formatUsd(row.totalCostUsd)}</span>
-                </div>
-              ))
-            )}
-          </div>
+        <Panel title="Usage">
+          <UsageRollup
+            usage={overview.usage}
+            trend={usageTrendQuery.data?.trend ?? null}
+            formatTrendDate={formatTrendDate}
+          />
         </Panel>
 
         <ProviderHealthPanel

--- a/console/src/routes/plugins.tsx
+++ b/console/src/routes/plugins.tsx
@@ -125,23 +125,27 @@ export function PluginsPage() {
       <div className="metric-grid">
         <MetricCard
           label="Plugins"
-          value={String(pluginsQuery.data?.totals.totalPlugins || 0)}
-          detail={`${pluginsQuery.data?.totals.enabledPlugins || 0} enabled`}
+          value={String(pluginsQuery.data?.totals.totalPlugins ?? 0)}
+          detail={`${pluginsQuery.data?.totals.enabledPlugins ?? 0} enabled`}
+          loading={!pluginsQuery.data}
         />
         <MetricCard
           label="Load failures"
-          value={String(pluginsQuery.data?.totals.failedPlugins || 0)}
+          value={String(pluginsQuery.data?.totals.failedPlugins ?? 0)}
           detail="runtime initialization errors"
+          loading={!pluginsQuery.data}
         />
         <MetricCard
           label="Commands"
-          value={String(pluginsQuery.data?.totals.commands || 0)}
+          value={String(pluginsQuery.data?.totals.commands ?? 0)}
           detail="plugin-defined commands"
+          loading={!pluginsQuery.data}
         />
         <MetricCard
           label="Tools / Hooks"
-          value={`${pluginsQuery.data?.totals.tools || 0} / ${pluginsQuery.data?.totals.hooks || 0}`}
+          value={`${pluginsQuery.data?.totals.tools ?? 0} / ${pluginsQuery.data?.totals.hooks ?? 0}`}
           detail="registered runtime surfaces"
+          loading={!pluginsQuery.data}
         />
       </div>
 

--- a/console/src/routes/skills.tsx
+++ b/console/src/routes/skills.tsx
@@ -779,8 +779,9 @@ export function SkillsPage() {
       <div className="metric-grid">
         <MetricCard
           label="Installed skills"
-          value={String(skillsQuery.data?.skills.length || 0)}
-          detail={`${skillsQuery.data?.disabled.length || 0} disabled`}
+          value={String(skillsQuery.data?.skills.length ?? 0)}
+          detail={`${skillsQuery.data?.disabled.length ?? 0} disabled`}
+          loading={!skillsQuery.data}
         />
         <MetricCard
           label="Observed skills"

--- a/console/src/routes/tools.tsx
+++ b/console/src/routes/tools.tsx
@@ -171,23 +171,27 @@ export function ToolsPage() {
       <div className="metric-grid">
         <MetricCard
           label="Catalog tools"
-          value={String(toolsQuery.data?.totals.totalTools || 0)}
-          detail={`${toolsQuery.data?.totals.builtinTools || 0} built-in`}
+          value={String(toolsQuery.data?.totals.totalTools ?? 0)}
+          detail={`${toolsQuery.data?.totals.builtinTools ?? 0} built-in`}
+          loading={!toolsQuery.data}
         />
         <MetricCard
           label="MCP tools seen"
-          value={String(toolsQuery.data?.totals.mcpTools || 0)}
+          value={String(toolsQuery.data?.totals.mcpTools ?? 0)}
           detail="from recent audit traffic"
+          loading={!toolsQuery.data}
         />
         <MetricCard
           label="Recent executions"
-          value={String(toolsQuery.data?.totals.recentExecutions || 0)}
+          value={String(toolsQuery.data?.totals.recentExecutions ?? 0)}
           detail="last 200 tool results"
+          loading={!toolsQuery.data}
         />
         <MetricCard
           label="Recent errors"
-          value={String(toolsQuery.data?.totals.recentErrors || 0)}
+          value={String(toolsQuery.data?.totals.recentErrors ?? 0)}
           detail="tool.result failures"
+          loading={!toolsQuery.data}
         />
       </div>
 

--- a/console/src/styles.css
+++ b/console/src/styles.css
@@ -70,7 +70,6 @@ code {
 }
 
 .topbar h2,
-.panel h4,
 .login-card h1 {
   margin: 0;
   font-weight: 600;
@@ -81,8 +80,21 @@ code {
   font-size: clamp(1.9rem, 2.4vw, 2.35rem);
 }
 
-.panel h4 {
-  font-size: 1rem;
+.panel h4,
+.panel-title {
+  margin: 0;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: 0;
+  color: var(--text);
+}
+
+.panel-subtitle {
+  margin: 4px 0 0;
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  color: color-mix(in srgb, var(--text) 60%, transparent);
 }
 
 .eyebrow {
@@ -332,7 +344,7 @@ code {
 }
 
 .panel {
-  padding: 8px;
+  padding: 20px;
   border-radius: var(--radius-lg);
   border: 1px solid var(--line);
   background: var(--panel-bg);
@@ -453,19 +465,17 @@ code {
 .config-section,
 .empty-state,
 .summary-block,
-.key-value-grid div,
-.usage-stack {
+.key-value-grid div {
   background: var(--panel-muted);
 }
 
 .panel-header {
-  margin-bottom: 16px;
+  margin-bottom: 18px;
 }
 
 .metric-grid,
 .two-column-grid,
 .field-grid,
-.usage-grid,
 .config-grid,
 .key-value-grid {
   display: grid;
@@ -497,7 +507,6 @@ code {
   }
 }
 
-.usage-grid,
 .field-grid,
 .config-grid,
 .key-value-grid {
@@ -532,6 +541,17 @@ code {
 .metric-card span,
 .metric-card small {
   line-height: 1.25;
+}
+
+.metric-card-value-skeleton {
+  height: 1.65rem;
+  width: 60%;
+  margin: 2px 0;
+}
+
+.metric-card-detail-skeleton {
+  height: 0.85rem;
+  width: 80%;
 }
 
 .list-row,
@@ -1880,17 +1900,12 @@ th {
   font-size: 0.95rem;
 }
 
-.key-value-grid div,
-.usage-stack {
+.key-value-grid div {
   display: grid;
   gap: 4px;
   padding: 14px;
   border-radius: var(--radius-md);
   border: 1px solid var(--line);
-}
-
-.usage-stack strong {
-  font-size: 1.3rem;
 }
 
 .table-shell td strong,
@@ -2274,7 +2289,6 @@ th {
 @media (max-width: 1080px) {
   .metric-grid,
   .two-column-grid,
-  .usage-grid,
   .field-grid,
   .config-grid,
   .key-value-grid {

--- a/scripts/backfill-usage-costs.mjs
+++ b/scripts/backfill-usage-costs.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+
+const APPLY_FLAG = '--apply';
+
+function usage() {
+  console.log(`Usage: node scripts/backfill-usage-costs.mjs [--apply]
+
+Backfills zero-cost usage_events rows for HybridAI and xAI models using the
+currently discovered model pricing. Defaults to dry-run mode. Use --apply to
+create a SQLite backup and update the live database.`);
+}
+
+function parseArgs(argv) {
+  if (argv.includes('--help') || argv.includes('-h')) {
+    usage();
+    process.exit(0);
+  }
+  return {
+    apply: argv.includes(APPLY_FLAG),
+  };
+}
+
+function timestampForFilename() {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+async function main() {
+  const { apply } = parseArgs(process.argv.slice(2));
+  const { getRuntimeConfig } = await import('../dist/config/runtime-config.js');
+  const { refreshModelCatalogMetadata } = await import(
+    '../dist/providers/model-catalog.js'
+  );
+  const { estimateModelUsageCostUsd } = await import(
+    '../dist/usage/model-cost.js'
+  );
+
+  const dbPath = getRuntimeConfig().ops?.dbPath;
+  if (!dbPath) {
+    throw new Error('Runtime config does not define ops.dbPath.');
+  }
+
+  const db = new Database(dbPath, { fileMustExist: true });
+  try {
+    const rows = db
+      .prepare(
+        `SELECT
+           id,
+           model,
+           input_tokens AS inputTokens,
+           output_tokens AS outputTokens
+         FROM usage_events
+         WHERE cost_usd = 0
+           AND (input_tokens > 0 OR output_tokens > 0)
+           AND (model LIKE 'hybridai/%' OR model LIKE 'xai/%')`,
+      )
+      .all();
+
+    const uniqueModels = [...new Set(rows.map((row) => row.model))];
+    for (const model of uniqueModels) {
+      await refreshModelCatalogMetadata(model);
+    }
+
+    const updates = [];
+    const missingPricing = new Map();
+    const byModel = new Map();
+    for (const row of rows) {
+      const costUsd = estimateModelUsageCostUsd({
+        model: row.model,
+        promptTokens: row.inputTokens,
+        completionTokens: row.outputTokens,
+      });
+      if (costUsd == null) {
+        missingPricing.set(row.model, (missingPricing.get(row.model) || 0) + 1);
+        continue;
+      }
+      updates.push({ id: row.id, model: row.model, costUsd });
+      const aggregate = byModel.get(row.model) || { rows: 0, costUsd: 0 };
+      aggregate.rows += 1;
+      aggregate.costUsd += costUsd;
+      byModel.set(row.model, aggregate);
+    }
+
+    const totalCostUsd = updates.reduce((sum, row) => sum + row.costUsd, 0);
+    const summary = {
+      mode: apply ? 'apply' : 'dry-run',
+      dbPath,
+      candidateRows: rows.length,
+      updatableRows: updates.length,
+      estimatedBackfillCostUsd: Number(totalCostUsd.toFixed(12)),
+      byModel: [...byModel.entries()]
+        .map(([model, value]) => ({
+          model,
+          rows: value.rows,
+          costUsd: Number(value.costUsd.toFixed(12)),
+        }))
+        .sort((left, right) => right.costUsd - left.costUsd),
+      missingPricing: [...missingPricing.entries()].map(
+        ([model, rowCount]) => ({
+          model,
+          rows: rowCount,
+        }),
+      ),
+    };
+
+    console.log(JSON.stringify(summary, null, 2));
+
+    if (!apply || updates.length === 0) return;
+
+    const backupPath = path.join(
+      path.dirname(dbPath),
+      `hybridclaw.usage-cost-backfill.${timestampForFilename()}.db`,
+    );
+    fs.mkdirSync(path.dirname(backupPath), { recursive: true });
+    await db.backup(backupPath);
+
+    const update = db.prepare(
+      `UPDATE usage_events SET cost_usd = ? WHERE id = ? AND cost_usd = 0`,
+    );
+    const applyUpdates = db.transaction((rowsToUpdate) => {
+      for (const row of rowsToUpdate) {
+        update.run(row.costUsd, row.id);
+      }
+    });
+    applyUpdates(updates);
+
+    console.log(
+      JSON.stringify(
+        {
+          appliedRows: updates.length,
+          appliedCostUsd: Number(totalCostUsd.toFixed(12)),
+          backupPath,
+        },
+        null,
+        2,
+      ),
+    );
+  } finally {
+    db.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : error);
+  process.exitCode = 1;
+});

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -71,6 +71,7 @@ import {
   type ToolProgressEvent,
 } from '../types/execution.js';
 import type { CanonicalSessionContext } from '../types/session.js';
+import { resolveUsageCostUsdAfterMetadataRefresh } from '../usage/model-cost.js';
 import { enqueueTokenUsage } from '../usage/token-usage-buffer.js';
 import { ensureBootstrapFiles } from '../workspace.js';
 import { normalizeSilentMessageSendReply } from './chat-result.js';
@@ -105,7 +106,6 @@ import {
   cloneMediaContextItems,
   enqueueDelegationBatchFromSideEffects,
   extractDelegationDepth,
-  extractUsageCostUsd,
   formatCanonicalContextPrompt,
   formatPluginPromptContext,
   getGatewayAssistantPresentationForMessageAgent,
@@ -1280,6 +1280,11 @@ async function handleGatewayMessageInner(
         ...usagePayload,
       },
     });
+    const costUsd = await resolveUsageCostUsdAfterMetadataRefresh({
+      model,
+      tokenUsage: output.tokenUsage,
+      usage: usagePayload,
+    });
     enqueueTokenUsage({
       sessionId: req.sessionId,
       agentId,
@@ -1288,7 +1293,7 @@ async function handleGatewayMessageInner(
       outputTokens: firstNumber([usagePayload.completionTokens]) || 0,
       totalTokens: firstNumber([usagePayload.totalTokens]) || 0,
       toolCalls: toolExecutions.length,
-      costUsd: extractUsageCostUsd(output.tokenUsage),
+      costUsd,
       auditRunId: runId,
     });
     if (observedSkillName) {
@@ -1305,7 +1310,7 @@ async function handleGatewayMessageInner(
           durationMs: Date.now() - startedAt,
           model,
           tokenUsage: output.tokenUsage,
-          costUsd: extractUsageCostUsd(output.tokenUsage),
+          costUsd,
           agentId,
           input: storedUserContent,
           output: {

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -349,6 +349,10 @@ import type {
   DelegationTaskSpec,
 } from '../types/side-effects.js';
 import type { TokenUsageStats } from '../types/usage.js';
+import {
+  extractExplicitUsageCostUsd,
+  resolveUsageCostUsdAfterMetadataRefresh,
+} from '../usage/model-cost.js';
 import { enqueueTokenUsage } from '../usage/token-usage-buffer.js';
 import { isApprovalHistoryMessage } from '../utils/approval-text.js';
 import {
@@ -837,7 +841,7 @@ interface DelegationTaskRunInput {
   onToolProgress?: (event: ToolProgressEvent) => void;
 }
 
-function persistDelegationAttempt(params: {
+async function persistDelegationAttempt(params: {
   sessionId: string;
   model: string;
   chatbotId: string;
@@ -845,7 +849,7 @@ function persistDelegationAttempt(params: {
   durationMs: number;
   output?: Awaited<ReturnType<typeof runAgent>>;
   error?: string;
-}): void {
+}): Promise<void> {
   const runId = makeAuditRunId('delegate');
   const toolExecutions = params.output?.toolExecutions || [];
   const toolCallCount = toolExecutions.length;
@@ -880,7 +884,11 @@ function persistDelegationAttempt(params: {
       outputTokens: firstNumber([usagePayload.completionTokens]) || 0,
       totalTokens: firstNumber([usagePayload.totalTokens]) || 0,
       toolCalls: toolCallCount,
-      costUsd: extractUsageCostUsd(params.output.tokenUsage),
+      costUsd: await resolveUsageCostUsdAfterMetadataRefresh({
+        model: params.model,
+        tokenUsage: params.output.tokenUsage,
+        usage: usagePayload,
+      }),
       auditRunId: runId,
     });
   }
@@ -2702,17 +2710,7 @@ export function getGatewayAssistantPresentationForMessageAgent(
 }
 
 export function extractUsageCostUsd(tokenUsage?: TokenUsageStats): number {
-  if (!tokenUsage) return 0;
-  const costCarrier = tokenUsage as unknown as Record<string, unknown>;
-  const value = firstNumber([
-    costCarrier.costUsd,
-    costCarrier.costUSD,
-    costCarrier.cost_usd,
-    costCarrier.estimatedCostUsd,
-    costCarrier.estimated_cost_usd,
-  ]);
-  if (value == null) return 0;
-  return Math.max(0, value);
+  return extractExplicitUsageCostUsd(tokenUsage) ?? 0;
 }
 
 function buildHybridAIAuthStatusLines(): string[] {
@@ -6433,7 +6431,11 @@ export async function ensureGatewayBootstrapAutostart(params: {
       outputTokens: firstNumber([usagePayload.completionTokens]) || 0,
       totalTokens: firstNumber([usagePayload.totalTokens]) || 0,
       toolCalls: (output.toolExecutions || []).length,
-      costUsd: extractUsageCostUsd(output.tokenUsage),
+      costUsd: await resolveUsageCostUsdAfterMetadataRefresh({
+        model: resolved.model,
+        tokenUsage: output.tokenUsage,
+        usage: usagePayload,
+      }),
       auditRunId: runId,
     });
 
@@ -7117,7 +7119,7 @@ async function runDelegationTaskWithRetry(
       lastToolExecutions = output.toolExecutions || [];
       lastArtifacts = output.artifacts;
       lastTokenCount = extractDelegationTokenCount(output.tokenUsage);
-      persistDelegationAttempt({
+      await persistDelegationAttempt({
         sessionId,
         model: task.model,
         chatbotId,
@@ -7168,7 +7170,7 @@ async function runDelegationTaskWithRetry(
       const errorText = err instanceof Error ? err.message : String(err);
       lastError = errorText;
       lastStatus = inferDelegationStatus(errorText);
-      persistDelegationAttempt({
+      await persistDelegationAttempt({
         sessionId,
         model: task.model,
         chatbotId,

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -475,7 +475,9 @@ function agentSkillScoresNeedMigration(database: Database.Database): boolean {
 }
 
 function agentA2ANeedMigration(database: Database.Database): boolean {
-  return tableExists(database, 'agents') && !columnExists(database, 'agents', 'a2a');
+  return (
+    tableExists(database, 'agents') && !columnExists(database, 'agents', 'a2a')
+  );
 }
 
 function boardCardsNeedMigration(database: Database.Database): boolean {
@@ -4103,7 +4105,7 @@ export function listUsageByModel(params?: {
      FROM usage_events
      ${where}
      GROUP BY model
-     ORDER BY total_cost_usd DESC, total_tokens DESC, call_count DESC`,
+     ORDER BY total_tokens DESC, call_count DESC, total_cost_usd DESC`,
     ...args,
   );
 

--- a/src/scheduler/scheduled-task-runner.ts
+++ b/src/scheduler/scheduled-task-runner.ts
@@ -16,6 +16,7 @@ import {
   migrateLegacySessionKey,
 } from '../session/session-key.js';
 import { appendSessionTranscript } from '../session/session-transcripts.js';
+import { resolveUsageCostUsdAfterMetadataRefresh } from '../usage/model-cost.js';
 import { enqueueTokenUsage } from '../usage/token-usage-buffer.js';
 import {
   buildModelUsageAuditStats,
@@ -160,6 +161,11 @@ export async function runIsolatedScheduledTask(params: {
       outputTokens: usage.completionTokens,
       totalTokens: usage.totalTokens,
       toolCalls: usage.toolCallCount,
+      costUsd: await resolveUsageCostUsdAfterMetadataRefresh({
+        model,
+        tokenUsage: output.tokenUsage,
+        usage,
+      }),
       auditRunId: runId,
     });
 

--- a/src/usage/model-cost.ts
+++ b/src/usage/model-cost.ts
@@ -1,0 +1,99 @@
+import {
+  getModelCatalogMetadata,
+  refreshModelCatalogMetadata,
+} from '../providers/model-catalog.js';
+import type { TokenUsageStats } from '../types/usage.js';
+
+interface UsageTokenCounts {
+  promptTokens?: unknown;
+  completionTokens?: unknown;
+}
+
+function readFiniteNonNegativeNumber(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return null;
+  }
+  return value;
+}
+
+function firstFiniteNonNegativeNumber(values: unknown[]): number | null {
+  for (const value of values) {
+    const parsed = readFiniteNonNegativeNumber(value);
+    if (parsed != null) return parsed;
+  }
+  return null;
+}
+
+export function extractExplicitUsageCostUsd(
+  tokenUsage?: TokenUsageStats,
+): number | null {
+  if (!tokenUsage) return null;
+  const costCarrier = tokenUsage as unknown as Record<string, unknown>;
+  return firstFiniteNonNegativeNumber([
+    costCarrier.costUsd,
+    costCarrier.costUSD,
+    costCarrier.cost_usd,
+    costCarrier.estimatedCostUsd,
+    costCarrier.estimated_cost_usd,
+  ]);
+}
+
+export function estimateModelUsageCostUsd(params: {
+  model: string;
+  promptTokens: number;
+  completionTokens: number;
+}): number | null {
+  const pricing = getModelCatalogMetadata(params.model).pricingUsdPerToken;
+  if (pricing.input == null && pricing.output == null) return null;
+  return (
+    params.promptTokens * (pricing.input ?? 0) +
+    params.completionTokens * (pricing.output ?? 0)
+  );
+}
+
+export function resolveUsageCostUsd(params: {
+  model: string;
+  tokenUsage?: TokenUsageStats;
+  usage: UsageTokenCounts;
+}): number {
+  const explicitCost = extractExplicitUsageCostUsd(params.tokenUsage);
+  if (explicitCost != null) return explicitCost;
+
+  const promptTokens = readFiniteNonNegativeNumber(params.usage.promptTokens);
+  const completionTokens = readFiniteNonNegativeNumber(
+    params.usage.completionTokens,
+  );
+  if (promptTokens == null || completionTokens == null) return 0;
+
+  return (
+    estimateModelUsageCostUsd({
+      model: params.model,
+      promptTokens,
+      completionTokens,
+    }) ?? 0
+  );
+}
+
+export async function resolveUsageCostUsdAfterMetadataRefresh(params: {
+  model: string;
+  tokenUsage?: TokenUsageStats;
+  usage: UsageTokenCounts;
+}): Promise<number> {
+  const explicitCost = extractExplicitUsageCostUsd(params.tokenUsage);
+  if (explicitCost != null) return explicitCost;
+
+  const promptTokens = readFiniteNonNegativeNumber(params.usage.promptTokens);
+  const completionTokens = readFiniteNonNegativeNumber(
+    params.usage.completionTokens,
+  );
+  if (promptTokens == null || completionTokens == null) return 0;
+
+  await refreshModelCatalogMetadata(params.model);
+  return (
+    estimateModelUsageCostUsd({
+      model: params.model,
+      promptTokens,
+      completionTokens,
+    }) ?? 0
+  );
+}

--- a/tests/gateway-delegation-proactive.test.ts
+++ b/tests/gateway-delegation-proactive.test.ts
@@ -212,6 +212,16 @@ test('delegation batch queues status updates and a synthesized final answer for 
       ),
     ).toBe(true);
   });
+  await vi.waitFor(() => {
+    const messages = listQueuedProactiveMessages(100).filter(
+      (message) => message.channel_id === 'tui',
+    );
+    expect(
+      messages.some((message) =>
+        message.text.includes('2 delegate jobs finished'),
+      ),
+    ).toBe(true);
+  });
 
   const messages = claimQueuedProactiveMessages('tui', 100);
   expect(messages.length).toBeGreaterThanOrEqual(3);

--- a/tests/model-cost.test.ts
+++ b/tests/model-cost.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { TokenUsageStats } from '../src/types/usage.js';
+
+const getModelCatalogMetadata = vi.hoisted(() => vi.fn());
+const refreshModelCatalogMetadata = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/providers/model-catalog.js', () => ({
+  getModelCatalogMetadata,
+  refreshModelCatalogMetadata,
+}));
+
+const {
+  extractExplicitUsageCostUsd,
+  resolveUsageCostUsd,
+  resolveUsageCostUsdAfterMetadataRefresh,
+} = await import('../src/usage/model-cost.js');
+
+function makeTokenUsage(extras: Record<string, unknown> = {}): TokenUsageStats {
+  return {
+    modelCalls: 1,
+    apiUsageAvailable: true,
+    apiPromptTokens: 0,
+    apiCompletionTokens: 0,
+    apiTotalTokens: 0,
+    apiCacheUsageAvailable: false,
+    apiCacheReadTokens: 0,
+    apiCacheWriteTokens: 0,
+    estimatedPromptTokens: 0,
+    estimatedCompletionTokens: 0,
+    estimatedTotalTokens: 0,
+    ...extras,
+  } as TokenUsageStats;
+}
+
+function mockPricing(input: number | null, output: number | null): void {
+  getModelCatalogMetadata.mockReturnValue({
+    pricingUsdPerToken: { input, output },
+  });
+}
+
+beforeEach(() => {
+  getModelCatalogMetadata.mockReset();
+  refreshModelCatalogMetadata.mockReset();
+  refreshModelCatalogMetadata.mockResolvedValue(undefined);
+  mockPricing(null, null);
+});
+
+test('extractExplicitUsageCostUsd reads provider supplied usage cost', () => {
+  expect(extractExplicitUsageCostUsd(makeTokenUsage({ costUsd: 0.42 }))).toBe(
+    0.42,
+  );
+  expect(extractExplicitUsageCostUsd(makeTokenUsage({ costUsd: -1 }))).toBe(
+    null,
+  );
+});
+
+test('resolveUsageCostUsd keeps explicit provider cost authoritative', () => {
+  mockPricing(0.00000003, 0.00000015);
+
+  expect(
+    resolveUsageCostUsd({
+      model: 'xai/grok-4.20-0309-non-reasoning',
+      tokenUsage: makeTokenUsage({ costUsd: 0 }),
+      usage: { promptTokens: 1_000_000, completionTokens: 200_000 },
+    }),
+  ).toBe(0);
+  expect(getModelCatalogMetadata).not.toHaveBeenCalled();
+});
+
+test('resolveUsageCostUsd estimates cost from model catalog pricing when usage has no cost', () => {
+  mockPricing(0.00000003, 0.00000015);
+
+  expect(
+    resolveUsageCostUsd({
+      model: 'xai/grok-4.20-0309-non-reasoning',
+      tokenUsage: makeTokenUsage(),
+      usage: { promptTokens: 1_000_000, completionTokens: 200_000 },
+    }),
+  ).toBeCloseTo(0.06, 8);
+});
+
+test('resolveUsageCostUsd falls back to zero when pricing is unavailable', () => {
+  expect(
+    resolveUsageCostUsd({
+      model: 'unknown/model',
+      tokenUsage: makeTokenUsage(),
+      usage: { promptTokens: 1_000_000, completionTokens: 200_000 },
+    }),
+  ).toBe(0);
+});
+
+test('resolveUsageCostUsdAfterMetadataRefresh refreshes catalog before estimating missing cost', async () => {
+  mockPricing(0.00000003, 0.00000015);
+
+  await expect(
+    resolveUsageCostUsdAfterMetadataRefresh({
+      model: 'xai/grok-4.20-0309-non-reasoning',
+      tokenUsage: makeTokenUsage(),
+      usage: { promptTokens: 1_000_000, completionTokens: 200_000 },
+    }),
+  ).resolves.toBeCloseTo(0.06, 8);
+  expect(refreshModelCatalogMetadata).toHaveBeenCalledWith(
+    'xai/grok-4.20-0309-non-reasoning',
+  );
+});
+
+test('resolveUsageCostUsdAfterMetadataRefresh skips refresh when explicit cost exists', async () => {
+  await expect(
+    resolveUsageCostUsdAfterMetadataRefresh({
+      model: 'xai/grok-4.20-0309-non-reasoning',
+      tokenUsage: makeTokenUsage({ costUsd: 0.25 }),
+      usage: { promptTokens: 1_000_000, completionTokens: 200_000 },
+    }),
+  ).resolves.toBe(0.25);
+  expect(refreshModelCatalogMetadata).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
Part 2 of 3 splitting up #896. **Stacked on top of #933** (toasts) — review/merge that first or compare to #933's branch for the clean delta.

## What changed

### Usage rollup redesign

New `console/src/components/usage-rollup.{tsx,module.css}` replaces the old card-stack on the Dashboard:

- Inline summary line `144.1K tokens this month · 0 today` instead of a hero display number — operator UI, not a marketing module.
- Atomic 4-column metric ribbon (`Input · Output · Calls · Spent`), sandwiched between two hairlines.
- 30-day daily-tokens trend rendered as a Catmull-Rom-smoothed area+line chart fed from the existing `/api/admin/statistics?days=30` endpoint (no new gateway surface). Custom hover tooltip with crosshair, edge-aware alignment near the right edge. Native `<title>` per data point retained for assistive tech.
- Axis row carries `29d ago · peak 68.1M on Apr 14 · today` — peak callout in muted accent color so it reads as data-derived, not decorative.
- Empty state, single-model collapse (top-models hidden when there's only one model), and zero-cost rendering (`formatUsd(0) → '$0'`).

### Skeleton primitive + MetricCard loading

New `console/src/components/skeleton/*` primitive. `MetricCard` takes a `loading` prop and renders muted skeleton bars instead of a fake "0" that jumps to the real number on data arrival. Updates approvals, tools, skills, plugins, agent-scoreboard call sites.

## Files

- New: `console/src/components/usage-rollup.{tsx,module.css}`, `console/src/components/skeleton/{index.tsx,skeleton.module.css}`
- Modified: `console/src/components/ui.tsx` (MetricCard.loading), `console/src/lib/format.ts` (`formatUsd(0) → '$0'`), `console/src/routes/dashboard.{tsx,test.tsx}`, `console/src/styles.css`, and MetricCard call sites in `agent-scoreboard`, `approvals`, `plugins`, `skills`, `tools`

## Test plan

- [x] `npm --workspace console run test` — 308 tests pass
- [x] `npm --workspace console run typecheck` clean
- [x] Usage rollup verified across panel widths (≤720px ribbon collapses to 2 cols)
- [x] Chart hover tested at left, middle, and right edges — tooltip alignment flips near the right

## Related

Split out of #896. Stacks on #933 (toasts); followed by Card primitive PR (#TBD).

## AI assistance

Drafted with Claude Code.