### PR TITLE
refactor(console): introduce Card primitive, migrate admin pages from Panel

### DIFF
--- a/console/src/components/card/card.module.css
+++ b/console/src/components/card/card.module.css
@@ -1,0 +1,90 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--line);
+  background: var(--panel-bg);
+  color: var(--text);
+  box-sizing: border-box;
+  min-width: 0;
+}
+
+.card[data-variant="muted"] {
+  background: var(--panel-muted);
+}
+
+.card[data-interactive] {
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
+}
+
+.card[data-interactive]:hover {
+  border-color: var(--line-strong);
+}
+
+.card[data-interactive]:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
+  outline-offset: 2px;
+}
+
+.header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 4px 12px;
+}
+
+.header:not(:has(.action)) {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.title {
+  grid-column: 1;
+  margin: 0;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--text);
+}
+
+.description {
+  grid-column: 1;
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  color: var(--muted-foreground);
+}
+
+.action {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+}
+
+@media (max-width: 780px) {
+  .card {
+    padding: 18px;
+  }
+}

--- a/console/src/components/card/index.tsx
+++ b/console/src/components/card/index.tsx
@@ -1,0 +1,111 @@
+import { forwardRef, type HTMLAttributes } from 'react';
+import { cx } from '../../lib/cx';
+import styles from './card.module.css';
+
+export type CardVariant = 'default' | 'muted';
+
+export type CardProps = HTMLAttributes<HTMLDivElement> & {
+  variant?: CardVariant;
+  interactive?: boolean;
+};
+
+export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
+  { variant = 'default', interactive, className, ...rest },
+  ref,
+) {
+  return (
+    <div
+      ref={ref}
+      data-slot="card"
+      data-variant={variant}
+      data-interactive={interactive ? '' : undefined}
+      tabIndex={interactive ? (rest.tabIndex ?? 0) : rest.tabIndex}
+      className={cx(styles.card, className)}
+      {...rest}
+    />
+  );
+});
+
+export const CardHeader = forwardRef<
+  HTMLDivElement,
+  HTMLAttributes<HTMLDivElement>
+>(function CardHeader({ className, ...rest }, ref) {
+  return (
+    <div
+      ref={ref}
+      data-slot="card-header"
+      className={cx(styles.header, className)}
+      {...rest}
+    />
+  );
+});
+
+export const CardTitle = forwardRef<
+  HTMLHeadingElement,
+  HTMLAttributes<HTMLHeadingElement>
+>(function CardTitle({ className, ...rest }, ref) {
+  return (
+    <h4
+      ref={ref}
+      data-slot="card-title"
+      className={cx(styles.title, className)}
+      {...rest}
+    />
+  );
+});
+
+export const CardDescription = forwardRef<
+  HTMLParagraphElement,
+  HTMLAttributes<HTMLParagraphElement>
+>(function CardDescription({ className, ...rest }, ref) {
+  return (
+    <p
+      ref={ref}
+      data-slot="card-description"
+      className={cx(styles.description, className)}
+      {...rest}
+    />
+  );
+});
+
+export const CardAction = forwardRef<
+  HTMLDivElement,
+  HTMLAttributes<HTMLDivElement>
+>(function CardAction({ className, ...rest }, ref) {
+  return (
+    <div
+      ref={ref}
+      data-slot="card-action"
+      className={cx(styles.action, className)}
+      {...rest}
+    />
+  );
+});
+
+export const CardContent = forwardRef<
+  HTMLDivElement,
+  HTMLAttributes<HTMLDivElement>
+>(function CardContent({ className, ...rest }, ref) {
+  return (
+    <div
+      ref={ref}
+      data-slot="card-content"
+      className={cx(styles.content, className)}
+      {...rest}
+    />
+  );
+});
+
+export const CardFooter = forwardRef<
+  HTMLDivElement,
+  HTMLAttributes<HTMLDivElement>
+>(function CardFooter({ className, ...rest }, ref) {
+  return (
+    <div
+      ref={ref}
+      data-slot="card-footer"
+      className={cx(styles.footer, className)}
+      {...rest}
+    />
+  );
+});

--- a/console/src/components/ui.tsx
+++ b/console/src/components/ui.tsx
@@ -118,31 +118,6 @@ export function PageHeader(props: {
   );
 }
 
-export function Panel(props: {
-  title?: string;
-  subtitle?: string;
-  children: ReactNode;
-  accent?: 'default' | 'warm';
-  id?: string;
-}) {
-  return (
-    <section
-      id={props.id}
-      className={props.accent === 'warm' ? 'panel warm' : 'panel'}
-    >
-      {props.title ? (
-        <header className="panel-header">
-          <h4 className="panel-title">{props.title}</h4>
-          {props.subtitle ? (
-            <p className="panel-subtitle">{props.subtitle}</p>
-          ) : null}
-        </header>
-      ) : null}
-      {props.children}
-    </section>
-  );
-}
-
 export function MetricCard(props: {
   label: string;
   value: string;

--- a/console/src/routes/a2a-trust.tsx
+++ b/console/src/routes/a2a-trust.tsx
@@ -8,7 +8,14 @@ import {
 } from '../api/client';
 import type { AdminA2ATrustPeer } from '../api/types';
 import { useAuth } from '../auth';
-import { BooleanPill, PageHeader, Panel } from '../components/ui';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../components/card';
+import { BooleanPill, PageHeader } from '../components/ui';
 import { formatDateTime, formatRelativeTime } from '../lib/format';
 
 function shortFingerprint(value: string): string {
@@ -100,218 +107,240 @@ export function A2ATrustPage() {
     <div className="page-stack">
       <PageHeader title="A2A Trust" />
 
-      <Panel title="Local identity">
-        {trustQuery.isLoading ? (
-          <div className="empty-state">Loading identity...</div>
-        ) : trustQuery.data ? (
-          <div className="key-value-grid">
-            <div>
-              <span>Instance</span>
-              <strong>{trustQuery.data.identity.instanceId}</strong>
-            </div>
-            <div>
-              <span>Public key</span>
-              <strong>
-                {shortFingerprint(
-                  trustQuery.data.identity.publicKeyFingerprint,
-                )}
-              </strong>
-            </div>
-          </div>
-        ) : (
-          <div className="empty-state">Identity unavailable.</div>
-        )}
-      </Panel>
-
-      <div className="two-column-grid">
-        <Panel
-          title="Trusted peers"
-          subtitle={`${peers.length} peer${peers.length === 1 ? '' : 's'}`}
-        >
+      <Card>
+        <CardHeader>
+          <CardTitle>Local identity</CardTitle>
+        </CardHeader>
+        <CardContent>
           {trustQuery.isLoading ? (
-            <div className="empty-state">Loading peers...</div>
-          ) : peers.length ? (
-            <div className="list-stack selectable-list">
-              {peers.map((peer) => (
-                <button
-                  key={peer.peerId}
-                  className={
-                    peer.peerId === selectedPeer?.peerId
-                      ? 'selectable-row active'
-                      : 'selectable-row'
-                  }
-                  type="button"
-                  onClick={() => setSelectedPeerId(peer.peerId)}
-                >
-                  <div>
-                    <strong>{peer.peerId}</strong>
-                    <small>{shortFingerprint(peer.publicKeyFingerprint)}</small>
-                  </div>
-                  {peerStatus(peer)}
-                </button>
-              ))}
+            <div className="empty-state">Loading identity...</div>
+          ) : trustQuery.data ? (
+            <div className="key-value-grid">
+              <div>
+                <span>Instance</span>
+                <strong>{trustQuery.data.identity.instanceId}</strong>
+              </div>
+              <div>
+                <span>Public key</span>
+                <strong>
+                  {shortFingerprint(
+                    trustQuery.data.identity.publicKeyFingerprint,
+                  )}
+                </strong>
+              </div>
             </div>
           ) : (
-            <div className="empty-state">No A2A peer keys cached.</div>
+            <div className="empty-state">Identity unavailable.</div>
           )}
-        </Panel>
+        </CardContent>
+      </Card>
+
+      <div className="two-column-grid">
+        <Card>
+          <CardHeader>
+            <CardTitle>Trusted peers</CardTitle>
+            <CardDescription>
+              {`${peers.length} peer${peers.length === 1 ? '' : 's'}`}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {trustQuery.isLoading ? (
+              <div className="empty-state">Loading peers...</div>
+            ) : peers.length ? (
+              <div className="list-stack selectable-list">
+                {peers.map((peer) => (
+                  <button
+                    key={peer.peerId}
+                    className={
+                      peer.peerId === selectedPeer?.peerId
+                        ? 'selectable-row active'
+                        : 'selectable-row'
+                    }
+                    type="button"
+                    onClick={() => setSelectedPeerId(peer.peerId)}
+                  >
+                    <div>
+                      <strong>{peer.peerId}</strong>
+                      <small>
+                        {shortFingerprint(peer.publicKeyFingerprint)}
+                      </small>
+                    </div>
+                    {peerStatus(peer)}
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <div className="empty-state">No A2A peer keys cached.</div>
+            )}
+          </CardContent>
+        </Card>
 
         <div className="sticky-detail">
-          <Panel title="Peer detail" accent="warm">
-            {!selectedPeer ? (
-              <div className="empty-state">Select a peer.</div>
-            ) : (
-              <div className="detail-stack">
-                <div className="key-value-grid">
-                  <div>
-                    <span>Peer</span>
-                    <strong>{selectedPeer.peerId}</strong>
+          <Card variant="muted">
+            <CardHeader>
+              <CardTitle>Peer detail</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {!selectedPeer ? (
+                <div className="empty-state">Select a peer.</div>
+              ) : (
+                <div className="detail-stack">
+                  <div className="key-value-grid">
+                    <div>
+                      <span>Peer</span>
+                      <strong>{selectedPeer.peerId}</strong>
+                    </div>
+                    <div>
+                      <span>Status</span>
+                      <strong>{selectedPeer.status}</strong>
+                    </div>
+                    <div>
+                      <span>Trusted</span>
+                      <strong>{formatDateTime(selectedPeer.trustedAt)}</strong>
+                    </div>
+                    <div>
+                      <span>Last seen</span>
+                      <strong>
+                        {formatRelativeTime(selectedPeer.lastSeenAt)}
+                      </strong>
+                    </div>
+                    <div>
+                      <span>Agent Card</span>
+                      <strong>{selectedPeer.agentCardUrl}</strong>
+                    </div>
+                    <div>
+                      <span>Delivery URL</span>
+                      <strong>{selectedPeer.deliveryUrl}</strong>
+                    </div>
+                    <div>
+                      <span>Fingerprint</span>
+                      <strong>{selectedPeer.publicKeyFingerprint}</strong>
+                    </div>
+                    <div>
+                      <span>Mismatch</span>
+                      <strong>{selectedPeer.lastMismatchAt || 'none'}</strong>
+                    </div>
                   </div>
-                  <div>
-                    <span>Status</span>
-                    <strong>{selectedPeer.status}</strong>
-                  </div>
-                  <div>
-                    <span>Trusted</span>
-                    <strong>{formatDateTime(selectedPeer.trustedAt)}</strong>
-                  </div>
-                  <div>
-                    <span>Last seen</span>
-                    <strong>
-                      {formatRelativeTime(selectedPeer.lastSeenAt)}
-                    </strong>
-                  </div>
-                  <div>
-                    <span>Agent Card</span>
-                    <strong>{selectedPeer.agentCardUrl}</strong>
-                  </div>
-                  <div>
-                    <span>Delivery URL</span>
-                    <strong>{selectedPeer.deliveryUrl}</strong>
-                  </div>
-                  <div>
-                    <span>Fingerprint</span>
-                    <strong>{selectedPeer.publicKeyFingerprint}</strong>
-                  </div>
-                  <div>
-                    <span>Mismatch</span>
-                    <strong>{selectedPeer.lastMismatchAt || 'none'}</strong>
-                  </div>
-                </div>
 
+                  <label className="field">
+                    <span>Revocation reason</span>
+                    <input
+                      value={revokeReason}
+                      onChange={(event) => setRevokeReason(event.target.value)}
+                    />
+                  </label>
+                  <button
+                    className="danger-button"
+                    type="button"
+                    disabled={
+                      selectedPeer.status === 'revoked' ||
+                      revokeMutation.isPending
+                    }
+                    onClick={() => revokeMutation.mutate(selectedPeer.peerId)}
+                  >
+                    Revoke
+                  </button>
+                  <button
+                    className="danger-button"
+                    type="button"
+                    disabled={deleteMutation.isPending}
+                    onClick={() => deleteMutation.mutate(selectedPeer.peerId)}
+                  >
+                    Delete
+                  </button>
+                  <button
+                    className="primary-button"
+                    type="button"
+                    onClick={() => fillSelectedPeer(selectedPeer)}
+                  >
+                    Use in override
+                  </button>
+                  {revokeMutation.error ? (
+                    <small className="row-status-note-danger">
+                      {revokeMutation.error instanceof Error
+                        ? revokeMutation.error.message
+                        : 'Revocation failed.'}
+                    </small>
+                  ) : null}
+                  {deleteMutation.error ? (
+                    <small className="row-status-note-danger">
+                      {deleteMutation.error instanceof Error
+                        ? deleteMutation.error.message
+                        : 'Delete failed.'}
+                    </small>
+                  ) : null}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Operator override</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="detail-stack">
                 <label className="field">
-                  <span>Revocation reason</span>
+                  <span>Peer</span>
                   <input
-                    value={revokeReason}
-                    onChange={(event) => setRevokeReason(event.target.value)}
+                    value={pinPeerId}
+                    onChange={(event) => setPinPeerId(event.target.value)}
+                  />
+                </label>
+                <label className="field">
+                  <span>Agent Card</span>
+                  <input
+                    value={pinAgentCardUrl}
+                    onChange={(event) => setPinAgentCardUrl(event.target.value)}
+                  />
+                </label>
+                <label className="field">
+                  <span>Delivery URL</span>
+                  <input
+                    value={pinDeliveryUrl}
+                    onChange={(event) => setPinDeliveryUrl(event.target.value)}
+                  />
+                </label>
+                <label className="field">
+                  <span>Fingerprint</span>
+                  <input
+                    value={pinFingerprint}
+                    onChange={(event) => setPinFingerprint(event.target.value)}
+                  />
+                </label>
+                <label className="field">
+                  <span>Public JWK</span>
+                  <textarea
+                    rows={5}
+                    value={pinPublicKeyJwk}
+                    onChange={(event) => setPinPublicKeyJwk(event.target.value)}
+                  />
+                </label>
+                <label className="field">
+                  <span>Reason</span>
+                  <input
+                    value={pinReason}
+                    onChange={(event) => setPinReason(event.target.value)}
                   />
                 </label>
                 <button
-                  className="danger-button"
-                  type="button"
-                  disabled={
-                    selectedPeer.status === 'revoked' ||
-                    revokeMutation.isPending
-                  }
-                  onClick={() => revokeMutation.mutate(selectedPeer.peerId)}
-                >
-                  Revoke
-                </button>
-                <button
-                  className="danger-button"
-                  type="button"
-                  disabled={deleteMutation.isPending}
-                  onClick={() => deleteMutation.mutate(selectedPeer.peerId)}
-                >
-                  Delete
-                </button>
-                <button
                   className="primary-button"
                   type="button"
-                  onClick={() => fillSelectedPeer(selectedPeer)}
+                  disabled={!pinPeerId.trim() || upsertMutation.isPending}
+                  onClick={() => upsertMutation.mutate()}
                 >
-                  Use in override
+                  Trust
                 </button>
-                {revokeMutation.error ? (
+                {upsertMutation.error ? (
                   <small className="row-status-note-danger">
-                    {revokeMutation.error instanceof Error
-                      ? revokeMutation.error.message
-                      : 'Revocation failed.'}
-                  </small>
-                ) : null}
-                {deleteMutation.error ? (
-                  <small className="row-status-note-danger">
-                    {deleteMutation.error instanceof Error
-                      ? deleteMutation.error.message
-                      : 'Delete failed.'}
+                    {upsertMutation.error instanceof Error
+                      ? upsertMutation.error.message
+                      : 'Trust update failed.'}
                   </small>
                 ) : null}
               </div>
-            )}
-          </Panel>
-
-          <Panel title="Operator override">
-            <div className="detail-stack">
-              <label className="field">
-                <span>Peer</span>
-                <input
-                  value={pinPeerId}
-                  onChange={(event) => setPinPeerId(event.target.value)}
-                />
-              </label>
-              <label className="field">
-                <span>Agent Card</span>
-                <input
-                  value={pinAgentCardUrl}
-                  onChange={(event) => setPinAgentCardUrl(event.target.value)}
-                />
-              </label>
-              <label className="field">
-                <span>Delivery URL</span>
-                <input
-                  value={pinDeliveryUrl}
-                  onChange={(event) => setPinDeliveryUrl(event.target.value)}
-                />
-              </label>
-              <label className="field">
-                <span>Fingerprint</span>
-                <input
-                  value={pinFingerprint}
-                  onChange={(event) => setPinFingerprint(event.target.value)}
-                />
-              </label>
-              <label className="field">
-                <span>Public JWK</span>
-                <textarea
-                  rows={5}
-                  value={pinPublicKeyJwk}
-                  onChange={(event) => setPinPublicKeyJwk(event.target.value)}
-                />
-              </label>
-              <label className="field">
-                <span>Reason</span>
-                <input
-                  value={pinReason}
-                  onChange={(event) => setPinReason(event.target.value)}
-                />
-              </label>
-              <button
-                className="primary-button"
-                type="button"
-                disabled={!pinPeerId.trim() || upsertMutation.isPending}
-                onClick={() => upsertMutation.mutate()}
-              >
-                Trust
-              </button>
-              {upsertMutation.error ? (
-                <small className="row-status-note-danger">
-                  {upsertMutation.error instanceof Error
-                    ? upsertMutation.error.message
-                    : 'Trust update failed.'}
-                </small>
-              ) : null}
-            </div>
-          </Panel>
+            </CardContent>
+          </Card>
         </div>
       </div>
     </div>

--- a/console/src/routes/agent-scoreboard.tsx
+++ b/console/src/routes/agent-scoreboard.tsx
@@ -3,9 +3,15 @@ import { fetchAgentScoreboard } from '../api/client';
 import type { AdminAgentScoreboardEntry } from '../api/types';
 import { useAuth } from '../auth';
 import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../components/card';
+import {
   MetricCard,
   PageHeader,
-  Panel,
   SortableHeader,
   useSortableRows,
 } from '../components/ui';
@@ -130,124 +136,129 @@ export function AgentsPage() {
         />
       </div>
 
-      <Panel
-        title="Agent scoreboard"
-        subtitle={`${sortedRows.length} agent${sortedRows.length === 1 ? '' : 's'} visible`}
-      >
-        {scoreboardQuery.isLoading ? (
-          <div className="empty-state">Loading agent scoreboard...</div>
-        ) : sortedRows.length === 0 ? (
-          <div className="empty-state">No agent skill runs recorded yet.</div>
-        ) : (
-          <div className="table-shell">
-            <table>
-              <thead>
-                <tr>
-                  <SortableHeader
-                    label="Agent"
-                    sortKey="agent"
-                    sortState={sortState}
-                    onToggle={toggleSort}
-                  />
-                  <SortableHeader
-                    label="Score"
-                    sortKey="score"
-                    sortState={sortState}
-                    onToggle={toggleSort}
-                  />
-                  <SortableHeader
-                    label="Runs"
-                    sortKey="runs"
-                    sortState={sortState}
-                    onToggle={toggleSort}
-                  />
-                  <SortableHeader
-                    label="Quality"
-                    sortKey="quality"
-                    sortState={sortState}
-                    onToggle={toggleSort}
-                  />
-                  <SortableHeader
-                    label="Reliability"
-                    sortKey="reliability"
-                    sortState={sortState}
-                    onToggle={toggleSort}
-                  />
-                  <SortableHeader
-                    label="Timing"
-                    sortKey="timing"
-                    sortState={sortState}
-                    onToggle={toggleSort}
-                  />
-                  <SortableHeader
-                    label="Best at"
-                    sortKey="skill"
-                    sortState={sortState}
-                    onToggle={toggleSort}
-                  />
-                  <SortableHeader
-                    label="Anomalies"
-                    sortKey="anomalies"
-                    sortState={sortState}
-                    onToggle={toggleSort}
-                  />
-                  <SortableHeader
-                    label="Recent"
-                    sortKey="recent"
-                    sortState={sortState}
-                    onToggle={toggleSort}
-                  />
-                  <th>CV</th>
-                </tr>
-              </thead>
-              <tbody>
-                {sortedRows.map((agent) => (
-                  <tr key={agent.agent_id}>
-                    <td>
-                      <strong>{agent.display_name}</strong>
-                      <div className="supporting-text">{agent.agent_id}</div>
-                    </td>
-                    <td>{agent.avg_score}/100</td>
-                    <td>{agent.total_executions}</td>
-                    <td>{agent.avg_quality_score}/100</td>
-                    <td>{agent.avg_reliability_score}/100</td>
-                    <td>{agent.avg_timing_score}/100</td>
-                    <td>
-                      <strong>{formatBestAt(agent)}</strong>
-                      {agent.best_skills[0] ? (
-                        <div className="supporting-text">
-                          Q {agent.best_skills[0].quality_score} · R{' '}
-                          {agent.best_skills[0].reliability_score} · T{' '}
-                          {agent.best_skills[0].timing_score}
-                        </div>
-                      ) : null}
-                    </td>
-                    <td>
-                      {agent.weekly_anomalies_flagged}
-                      <div className="supporting-text">
-                        {agent.weekly_anomalies_confirmed_normal} confirmed
-                        normal
-                      </div>
-                    </td>
-                    <td>
-                      {agent.last_observed_at
-                        ? formatRelativeTime(agent.last_observed_at)
-                        : 'No recent runs'}
-                    </td>
-                    <td>
-                      <a
-                        href={`/admin/agents?agent=${encodeURIComponent(agent.agent_id)}&file=CV.md`}
-                      >
-                        CV.md
-                      </a>
-                    </td>
+      <Card>
+        <CardHeader>
+          <CardTitle>Agent scoreboard</CardTitle>
+          <CardDescription>
+            {`${sortedRows.length} agent${sortedRows.length === 1 ? '' : 's'} visible`}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {scoreboardQuery.isLoading ? (
+            <div className="empty-state">Loading agent scoreboard...</div>
+          ) : sortedRows.length === 0 ? (
+            <div className="empty-state">No agent skill runs recorded yet.</div>
+          ) : (
+            <div className="table-shell">
+              <table>
+                <thead>
+                  <tr>
+                    <SortableHeader
+                      label="Agent"
+                      sortKey="agent"
+                      sortState={sortState}
+                      onToggle={toggleSort}
+                    />
+                    <SortableHeader
+                      label="Score"
+                      sortKey="score"
+                      sortState={sortState}
+                      onToggle={toggleSort}
+                    />
+                    <SortableHeader
+                      label="Runs"
+                      sortKey="runs"
+                      sortState={sortState}
+                      onToggle={toggleSort}
+                    />
+                    <SortableHeader
+                      label="Quality"
+                      sortKey="quality"
+                      sortState={sortState}
+                      onToggle={toggleSort}
+                    />
+                    <SortableHeader
+                      label="Reliability"
+                      sortKey="reliability"
+                      sortState={sortState}
+                      onToggle={toggleSort}
+                    />
+                    <SortableHeader
+                      label="Timing"
+                      sortKey="timing"
+                      sortState={sortState}
+                      onToggle={toggleSort}
+                    />
+                    <SortableHeader
+                      label="Best at"
+                      sortKey="skill"
+                      sortState={sortState}
+                      onToggle={toggleSort}
+                    />
+                    <SortableHeader
+                      label="Anomalies"
+                      sortKey="anomalies"
+                      sortState={sortState}
+                      onToggle={toggleSort}
+                    />
+                    <SortableHeader
+                      label="Recent"
+                      sortKey="recent"
+                      sortState={sortState}
+                      onToggle={toggleSort}
+                    />
+                    <th>CV</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </Panel>
+                </thead>
+                <tbody>
+                  {sortedRows.map((agent) => (
+                    <tr key={agent.agent_id}>
+                      <td>
+                        <strong>{agent.display_name}</strong>
+                        <div className="supporting-text">{agent.agent_id}</div>
+                      </td>
+                      <td>{agent.avg_score}/100</td>
+                      <td>{agent.total_executions}</td>
+                      <td>{agent.avg_quality_score}/100</td>
+                      <td>{agent.avg_reliability_score}/100</td>
+                      <td>{agent.avg_timing_score}/100</td>
+                      <td>
+                        <strong>{formatBestAt(agent)}</strong>
+                        {agent.best_skills[0] ? (
+                          <div className="supporting-text">
+                            Q {agent.best_skills[0].quality_score} · R{' '}
+                            {agent.best_skills[0].reliability_score} · T{' '}
+                            {agent.best_skills[0].timing_score}
+                          </div>
+                        ) : null}
+                      </td>
+                      <td>
+                        {agent.weekly_anomalies_flagged}
+                        <div className="supporting-text">
+                          {agent.weekly_anomalies_confirmed_normal} confirmed
+                          normal
+                        </div>
+                      </td>
+                      <td>
+                        {agent.last_observed_at
+                          ? formatRelativeTime(agent.last_observed_at)
+                          : 'No recent runs'}
+                      </td>
+                      <td>
+                        <a
+                          href={`/admin/agents?agent=${encodeURIComponent(agent.agent_id)}&file=CV.md`}
+                        >
+                          CV.md
+                        </a>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/console/src/routes/agents.tsx
+++ b/console/src/routes/agents.tsx
@@ -16,8 +16,14 @@ import type {
   AdminTeamStructureFieldDiff,
 } from '../api/types';
 import { useAuth } from '../auth';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../components/card';
 import { useToast } from '../components/toast';
-import { Panel } from '../components/ui';
 import { getErrorMessage } from '../lib/error-message';
 import { formatDateTime, formatRelativeTime } from '../lib/format';
 
@@ -313,7 +319,7 @@ export function AgentFilesPage() {
 
   return (
     <div className="page-stack">
-      <Panel accent="warm">
+      <Card variant="muted">
         {agentsQuery.isLoading ? (
           <div className="empty-state">Loading agents...</div>
         ) : !agentsQuery.data?.length ? (
@@ -428,205 +434,225 @@ export function AgentFilesPage() {
                 </div>
 
                 <div className="two-column-grid">
-                  <Panel
-                    title="Versions"
-                    subtitle={`${fileQuery.data?.file.revisions.length || 0} saved revision${fileQuery.data?.file.revisions.length === 1 ? '' : 's'}`}
-                  >
-                    {!fileQuery.data?.file.revisions.length ? (
-                      <div className="empty-state">
-                        Revisions appear here after the file changes.
-                      </div>
-                    ) : (
-                      <div className="list-stack selectable-list">
-                        {fileQuery.data.file.revisions.map((revision) => (
-                          <button
-                            key={revision.id}
-                            className={
-                              revision.id === selectedRevisionId
-                                ? 'selectable-row active'
-                                : 'selectable-row'
-                            }
-                            type="button"
-                            onClick={() => setSelectedRevisionId(revision.id)}
-                          >
-                            <div>
-                              <strong>
-                                {formatDateTime(revision.createdAt)}
-                              </strong>
-                              <small>
-                                {formatRelativeTime(revision.createdAt)} ·{' '}
-                                {revision.source} · {revision.sizeBytes} bytes
-                              </small>
-                            </div>
-                          </button>
-                        ))}
-                      </div>
-                    )}
-                  </Panel>
+                  <Card>
+                    <CardHeader>
+                      <CardTitle>Versions</CardTitle>
+                      <CardDescription>
+                        {`${fileQuery.data?.file.revisions.length || 0} saved revision${fileQuery.data?.file.revisions.length === 1 ? '' : 's'}`}
+                      </CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                      {!fileQuery.data?.file.revisions.length ? (
+                        <div className="empty-state">
+                          Revisions appear here after the file changes.
+                        </div>
+                      ) : (
+                        <div className="list-stack selectable-list">
+                          {fileQuery.data.file.revisions.map((revision) => (
+                            <button
+                              key={revision.id}
+                              className={
+                                revision.id === selectedRevisionId
+                                  ? 'selectable-row active'
+                                  : 'selectable-row'
+                              }
+                              type="button"
+                              onClick={() => setSelectedRevisionId(revision.id)}
+                            >
+                              <div>
+                                <strong>
+                                  {formatDateTime(revision.createdAt)}
+                                </strong>
+                                <small>
+                                  {formatRelativeTime(revision.createdAt)} ·{' '}
+                                  {revision.source} · {revision.sizeBytes} bytes
+                                </small>
+                              </div>
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </CardContent>
+                  </Card>
 
-                  <Panel title="Version Preview" accent="warm">
-                    {!selectedRevisionId ? (
-                      <div className="empty-state">
-                        Select a saved version to preview or restore it.
-                      </div>
-                    ) : revisionQuery.isLoading ? (
-                      <div className="empty-state">Loading version...</div>
-                    ) : !revisionQuery.data ? (
-                      <div className="empty-state">
-                        Version details are unavailable.
-                      </div>
-                    ) : (
-                      <div className="detail-stack">
-                        <div className="summary-block">
-                          <span>
-                            {formatDateTime(
-                              revisionQuery.data.revision.createdAt,
-                            )}
-                          </span>
-                          <p>
-                            {revisionQuery.data.revision.sha256.slice(0, 16)} ·{' '}
-                            {revisionQuery.data.revision.source}
-                          </p>
+                  <Card variant="muted">
+                    <CardHeader>
+                      <CardTitle>Version Preview</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      {!selectedRevisionId ? (
+                        <div className="empty-state">
+                          Select a saved version to preview or restore it.
                         </div>
-                        <label className="field textarea-field">
-                          <span>Saved content</span>
-                          <textarea
-                            className="code-editor"
-                            rows={14}
-                            readOnly
-                            value={revisionQuery.data.revision.content}
-                          />
-                        </label>
-                        <div className="button-row">
-                          <button
-                            className="primary-button"
-                            type="button"
-                            disabled={restoreMutation.isPending}
-                            onClick={() => restoreMutation.mutate()}
-                          >
-                            {restoreMutation.isPending
-                              ? 'Restoring...'
-                              : 'Restore Version'}
-                          </button>
-                          <button
-                            className="ghost-button"
-                            type="button"
-                            onClick={() =>
-                              setDraftContent(
-                                revisionQuery.data?.revision.content || '',
-                              )
-                            }
-                          >
-                            Copy to Editor
-                          </button>
+                      ) : revisionQuery.isLoading ? (
+                        <div className="empty-state">Loading version...</div>
+                      ) : !revisionQuery.data ? (
+                        <div className="empty-state">
+                          Version details are unavailable.
                         </div>
-                      </div>
-                    )}
-                  </Panel>
+                      ) : (
+                        <div className="detail-stack">
+                          <div className="summary-block">
+                            <span>
+                              {formatDateTime(
+                                revisionQuery.data.revision.createdAt,
+                              )}
+                            </span>
+                            <p>
+                              {revisionQuery.data.revision.sha256.slice(0, 16)}{' '}
+                              · {revisionQuery.data.revision.source}
+                            </p>
+                          </div>
+                          <label className="field textarea-field">
+                            <span>Saved content</span>
+                            <textarea
+                              className="code-editor"
+                              rows={14}
+                              readOnly
+                              value={revisionQuery.data.revision.content}
+                            />
+                          </label>
+                          <div className="button-row">
+                            <button
+                              className="primary-button"
+                              type="button"
+                              disabled={restoreMutation.isPending}
+                              onClick={() => restoreMutation.mutate()}
+                            >
+                              {restoreMutation.isPending
+                                ? 'Restoring...'
+                                : 'Restore Version'}
+                            </button>
+                            <button
+                              className="ghost-button"
+                              type="button"
+                              onClick={() =>
+                                setDraftContent(
+                                  revisionQuery.data?.revision.content || '',
+                                )
+                              }
+                            >
+                              Copy to Editor
+                            </button>
+                          </div>
+                        </div>
+                      )}
+                    </CardContent>
+                  </Card>
                 </div>
 
                 <div className="two-column-grid">
-                  <Panel
-                    title="Team Revisions"
-                    subtitle={`${teamQuery.data?.revisions.length || 0} saved revision${teamQuery.data?.revisions.length === 1 ? '' : 's'}`}
-                  >
-                    {teamQuery.isLoading ? (
-                      <div className="empty-state">
-                        Loading team revisions...
-                      </div>
-                    ) : !teamQuery.data?.revisions.length ? (
-                      <div className="empty-state">
-                        Team revisions appear here after org-chart changes.
-                      </div>
-                    ) : (
-                      <div className="list-stack selectable-list">
-                        {teamQuery.data.revisions.map((revision) => (
-                          <button
-                            key={revision.id}
-                            className={
-                              revision.id === selectedTeamRevisionId
-                                ? 'selectable-row active'
-                                : 'selectable-row'
-                            }
-                            type="button"
-                            onClick={() =>
-                              setSelectedTeamRevisionId(revision.id)
-                            }
-                          >
-                            <div>
-                              <strong>
-                                #{revision.id} ·{' '}
-                                {formatDateTime(revision.createdAt)}
-                              </strong>
-                              <small>
-                                {formatRelativeTime(revision.createdAt)} ·{' '}
-                                {revision.changeCount} change
-                                {revision.changeCount === 1 ? '' : 's'} ·{' '}
-                                {revision.route}
-                              </small>
-                            </div>
-                          </button>
-                        ))}
-                      </div>
-                    )}
-                  </Panel>
+                  <Card>
+                    <CardHeader>
+                      <CardTitle>Team Revisions</CardTitle>
+                      <CardDescription>
+                        {`${teamQuery.data?.revisions.length || 0} saved revision${teamQuery.data?.revisions.length === 1 ? '' : 's'}`}
+                      </CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                      {teamQuery.isLoading ? (
+                        <div className="empty-state">
+                          Loading team revisions...
+                        </div>
+                      ) : !teamQuery.data?.revisions.length ? (
+                        <div className="empty-state">
+                          Team revisions appear here after org-chart changes.
+                        </div>
+                      ) : (
+                        <div className="list-stack selectable-list">
+                          {teamQuery.data.revisions.map((revision) => (
+                            <button
+                              key={revision.id}
+                              className={
+                                revision.id === selectedTeamRevisionId
+                                  ? 'selectable-row active'
+                                  : 'selectable-row'
+                              }
+                              type="button"
+                              onClick={() =>
+                                setSelectedTeamRevisionId(revision.id)
+                              }
+                            >
+                              <div>
+                                <strong>
+                                  #{revision.id} ·{' '}
+                                  {formatDateTime(revision.createdAt)}
+                                </strong>
+                                <small>
+                                  {formatRelativeTime(revision.createdAt)} ·{' '}
+                                  {revision.changeCount} change
+                                  {revision.changeCount === 1 ? '' : 's'} ·{' '}
+                                  {revision.route}
+                                </small>
+                              </div>
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </CardContent>
+                  </Card>
 
-                  <Panel title="Team Diff" accent="warm">
-                    {!selectedTeamRevisionId ? (
-                      <div className="empty-state">
-                        Select a team revision to inspect its diff.
-                      </div>
-                    ) : teamRevisionQuery.isLoading ? (
-                      <div className="empty-state">
-                        Loading team revision...
-                      </div>
-                    ) : !teamRevisionQuery.data ? (
-                      <div className="empty-state">
-                        Team revision details are unavailable.
-                      </div>
-                    ) : (
-                      <div className="detail-stack">
-                        <div className="summary-block">
-                          <span>
-                            Revision #{teamRevisionQuery.data.revision.id}
-                          </span>
-                          <p>
-                            {teamRevisionQuery.data.revision.md5.slice(0, 16)} ·{' '}
-                            {teamRevisionQuery.data.revision.source}
-                          </p>
+                  <Card variant="muted">
+                    <CardHeader>
+                      <CardTitle>Team Diff</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      {!selectedTeamRevisionId ? (
+                        <div className="empty-state">
+                          Select a team revision to inspect its diff.
                         </div>
-                        <label className="field textarea-field">
-                          <span>Diff</span>
-                          <textarea
-                            className="code-editor"
-                            rows={10}
-                            readOnly
-                            value={formatTeamDiff(
-                              teamRevisionQuery.data.revision.diff,
-                            )}
-                          />
-                        </label>
-                        <div className="button-row">
-                          <button
-                            className="primary-button"
-                            type="button"
-                            disabled={restoreTeamMutation.isPending}
-                            onClick={() => restoreTeamMutation.mutate()}
-                          >
-                            {restoreTeamMutation.isPending
-                              ? 'Restoring...'
-                              : 'Restore Team'}
-                          </button>
+                      ) : teamRevisionQuery.isLoading ? (
+                        <div className="empty-state">
+                          Loading team revision...
                         </div>
-                      </div>
-                    )}
-                  </Panel>
+                      ) : !teamRevisionQuery.data ? (
+                        <div className="empty-state">
+                          Team revision details are unavailable.
+                        </div>
+                      ) : (
+                        <div className="detail-stack">
+                          <div className="summary-block">
+                            <span>
+                              Revision #{teamRevisionQuery.data.revision.id}
+                            </span>
+                            <p>
+                              {teamRevisionQuery.data.revision.md5.slice(0, 16)}{' '}
+                              · {teamRevisionQuery.data.revision.source}
+                            </p>
+                          </div>
+                          <label className="field textarea-field">
+                            <span>Diff</span>
+                            <textarea
+                              className="code-editor"
+                              rows={10}
+                              readOnly
+                              value={formatTeamDiff(
+                                teamRevisionQuery.data.revision.diff,
+                              )}
+                            />
+                          </label>
+                          <div className="button-row">
+                            <button
+                              className="primary-button"
+                              type="button"
+                              disabled={restoreTeamMutation.isPending}
+                              onClick={() => restoreTeamMutation.mutate()}
+                            >
+                              {restoreTeamMutation.isPending
+                                ? 'Restoring...'
+                                : 'Restore Team'}
+                            </button>
+                          </div>
+                        </div>
+                      )}
+                    </CardContent>
+                  </Card>
                 </div>
               </>
             )}
           </div>
         )}
-      </Panel>
+      </Card>
     </div>
   );
 }

--- a/console/src/routes/approvals.tsx
+++ b/console/src/routes/approvals.tsx
@@ -9,6 +9,7 @@ import {
 } from '../api/client';
 import type { AdminPolicyRule, AdminPolicyRuleInput } from '../api/types';
 import { useAuth } from '../auth';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/card';
 import {
   Dialog,
   DialogClose,
@@ -20,7 +21,7 @@ import {
 } from '../components/dialog';
 import { InteractionResumeControls } from '../components/interaction-resume-controls';
 import { useToast } from '../components/toast';
-import { MetricCard, PageHeader, Panel } from '../components/ui';
+import { MetricCard, PageHeader } from '../components/ui';
 import { getErrorMessage } from '../lib/error-message';
 import { formatDateTime, formatRelativeTime } from '../lib/format';
 
@@ -364,369 +365,389 @@ export function ApprovalsPage() {
       </div>
 
       <div className="page-stack">
-        <Panel title="Policy" accent="warm">
-          {approvalsQuery.isLoading ? (
-            <div className="empty-state">Loading policy...</div>
-          ) : approvalsQuery.data ? (
-            <div className="detail-stack">
-              {policyRules.length ? (
-                <div className="table-shell">
-                  <table className="policy-rules-table">
-                    <thead>
-                      <tr>
-                        <th>#</th>
-                        <th>Action</th>
-                        <th>Host</th>
-                        <th>Port</th>
-                        <th>Methods</th>
-                        <th>Paths</th>
-                        <th>Agent</th>
-                        <th>Comment</th>
-                        <th>Actions</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {policyRules.map((rule) => (
-                        <tr key={`${rule.index}:${rule.host}:${rule.agent}`}>
-                          <td>{rule.index}</td>
-                          <td>
-                            <strong>{rule.action.toUpperCase()}</strong>
-                          </td>
-                          <td>{rule.host}</td>
-                          <td>{String(rule.port)}</td>
-                          <td>{rule.methods.join(', ')}</td>
-                          <td>{rule.paths.join(', ')}</td>
-                          <td>{rule.agent}</td>
-                          <td>{formatRuleComment(rule)}</td>
-                          <td>
-                            <div className="policy-table-actions">
-                              <button
-                                className="ghost-button"
-                                type="button"
-                                disabled={policyMutationPending}
-                                onClick={() => beginEditRule(rule)}
-                              >
-                                Edit
-                              </button>
-                              <button
-                                className="danger-button"
-                                type="button"
-                                disabled={policyMutationPending}
-                                onClick={() => beginDeleteRule(rule)}
-                              >
-                                Delete
-                              </button>
-                            </div>
-                          </td>
+        <Card variant="muted">
+          <CardHeader>
+            <CardTitle>Policy</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {approvalsQuery.isLoading ? (
+              <div className="empty-state">Loading policy...</div>
+            ) : approvalsQuery.data ? (
+              <div className="detail-stack">
+                {policyRules.length ? (
+                  <div className="table-shell">
+                    <table className="policy-rules-table">
+                      <thead>
+                        <tr>
+                          <th>#</th>
+                          <th>Action</th>
+                          <th>Host</th>
+                          <th>Port</th>
+                          <th>Methods</th>
+                          <th>Paths</th>
+                          <th>Agent</th>
+                          <th>Comment</th>
+                          <th>Actions</th>
                         </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              ) : (
-                <div className="empty-state">No policy rules found.</div>
-              )}
+                      </thead>
+                      <tbody>
+                        {policyRules.map((rule) => (
+                          <tr key={`${rule.index}:${rule.host}:${rule.agent}`}>
+                            <td>{rule.index}</td>
+                            <td>
+                              <strong>{rule.action.toUpperCase()}</strong>
+                            </td>
+                            <td>{rule.host}</td>
+                            <td>{String(rule.port)}</td>
+                            <td>{rule.methods.join(', ')}</td>
+                            <td>{rule.paths.join(', ')}</td>
+                            <td>{rule.agent}</td>
+                            <td>{formatRuleComment(rule)}</td>
+                            <td>
+                              <div className="policy-table-actions">
+                                <button
+                                  className="ghost-button"
+                                  type="button"
+                                  disabled={policyMutationPending}
+                                  onClick={() => beginEditRule(rule)}
+                                >
+                                  Edit
+                                </button>
+                                <button
+                                  className="danger-button"
+                                  type="button"
+                                  disabled={policyMutationPending}
+                                  onClick={() => beginDeleteRule(rule)}
+                                >
+                                  Delete
+                                </button>
+                              </div>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                ) : (
+                  <div className="empty-state">No policy rules found.</div>
+                )}
 
-              <div className="policy-action-row">
-                <button
-                  className="primary-button"
-                  type="button"
-                  disabled={policyMutationPending}
-                  onClick={beginCreateRule}
-                >
-                  New rule
-                </button>
-                <div className="policy-template-actions">
-                  <label className="policy-template-inline">
-                    <span>Template:</span>
-                    <select
-                      value={selectedPresetName}
-                      disabled={
-                        policyMutationPending ||
-                        availablePresetOptions.length === 0
-                      }
-                      onChange={(event) =>
-                        setSelectedPresetName(event.target.value)
-                      }
-                    >
-                      {availablePresetOptions.length > 0 ? (
-                        availablePresetOptions.map((preset) => (
-                          <option key={preset.name} value={preset.name}>
-                            {preset.name}
-                          </option>
-                        ))
-                      ) : (
-                        <option value="">No templates available</option>
-                      )}
-                    </select>
-                  </label>
+                <div className="policy-action-row">
                   <button
-                    className="ghost-button"
+                    className="primary-button"
                     type="button"
-                    disabled={policyMutationPending || !selectedPresetName}
-                    onClick={() => presetMutation.mutate(selectedPresetName)}
+                    disabled={policyMutationPending}
+                    onClick={beginCreateRule}
                   >
-                    Add template
+                    New rule
                   </button>
-                </div>
-              </div>
-
-              {editorOpen ? (
-                <form
-                  className="config-section detail-stack"
-                  onSubmit={handleDraftSubmit}
-                >
-                  <strong>
-                    {editorMode === 'edit' && editingRuleIndex != null
-                      ? `Edit rule #${editingRuleIndex}`
-                      : 'Add rule'}
-                  </strong>
-
-                  <div className="field-grid policy-editor-grid">
-                    <label className="field">
-                      <span>Action</span>
+                  <div className="policy-template-actions">
+                    <label className="policy-template-inline">
+                      <span>Template:</span>
                       <select
-                        value={draft.action}
-                        disabled={policyMutationPending}
+                        value={selectedPresetName}
+                        disabled={
+                          policyMutationPending ||
+                          availablePresetOptions.length === 0
+                        }
                         onChange={(event) =>
-                          setDraft((current) => ({
-                            ...current,
-                            action:
-                              event.target.value === 'deny' ? 'deny' : 'allow',
-                          }))
+                          setSelectedPresetName(event.target.value)
                         }
                       >
-                        <option value="allow">allow</option>
-                        <option value="deny">deny</option>
+                        {availablePresetOptions.length > 0 ? (
+                          availablePresetOptions.map((preset) => (
+                            <option key={preset.name} value={preset.name}>
+                              {preset.name}
+                            </option>
+                          ))
+                        ) : (
+                          <option value="">No templates available</option>
+                        )}
                       </select>
                     </label>
-
-                    <label className="field">
-                      <span>Host</span>
-                      <input
-                        value={draft.host}
-                        disabled={policyMutationPending}
-                        placeholder="example.com"
-                        onChange={(event) =>
-                          setDraft((current) => ({
-                            ...current,
-                            host: event.target.value,
-                          }))
-                        }
-                      />
-                    </label>
-
-                    <label className="field">
-                      <span>Port</span>
-                      <input
-                        value={draft.port}
-                        disabled={policyMutationPending}
-                        placeholder="*"
-                        onChange={(event) =>
-                          setDraft((current) => ({
-                            ...current,
-                            port: event.target.value,
-                          }))
-                        }
-                      />
-                    </label>
-
-                    <label className="field">
-                      <span>Methods</span>
-                      <input
-                        value={draft.methods}
-                        disabled={policyMutationPending}
-                        placeholder="*"
-                        onChange={(event) =>
-                          setDraft((current) => ({
-                            ...current,
-                            methods: event.target.value,
-                          }))
-                        }
-                      />
-                    </label>
-
-                    <label className="field">
-                      <span>Paths</span>
-                      <input
-                        value={draft.paths}
-                        disabled={policyMutationPending}
-                        placeholder="/**"
-                        onChange={(event) =>
-                          setDraft((current) => ({
-                            ...current,
-                            paths: event.target.value,
-                          }))
-                        }
-                      />
-                    </label>
-
-                    <label className="field">
-                      <span>Agent</span>
-                      <input
-                        value={draft.agent}
-                        disabled={policyMutationPending}
-                        placeholder="*"
-                        onChange={(event) =>
-                          setDraft((current) => ({
-                            ...current,
-                            agent: event.target.value,
-                          }))
-                        }
-                      />
-                    </label>
-
-                    <label className="field policy-comment-field">
-                      <span>Comment</span>
-                      <textarea
-                        rows={2}
-                        value={draft.comment}
-                        disabled={policyMutationPending}
-                        placeholder="Optional note"
-                        onChange={(event) =>
-                          setDraft((current) => ({
-                            ...current,
-                            comment: event.target.value,
-                          }))
-                        }
-                      />
-                    </label>
-                  </div>
-
-                  <div className="button-row">
-                    <button
-                      className="primary-button"
-                      type="submit"
-                      disabled={policyMutationPending}
-                    >
-                      {saveMutation.isPending ? (
-                        <span className="button-with-spinner">
-                          <span aria-hidden="true" className="button-spinner" />
-                          {editorMode === 'edit' ? 'Saving...' : 'Adding...'}
-                        </span>
-                      ) : editorMode === 'edit' ? (
-                        'Save changes'
-                      ) : (
-                        'Save'
-                      )}
-                    </button>
                     <button
                       className="ghost-button"
                       type="button"
-                      disabled={policyMutationPending}
-                      onClick={resetDraft}
+                      disabled={policyMutationPending || !selectedPresetName}
+                      onClick={() => presetMutation.mutate(selectedPresetName)}
                     >
-                      Cancel
+                      Add template
                     </button>
                   </div>
-                </form>
-              ) : null}
-            </div>
-          ) : (
-            <div className="empty-state">Policy state is unavailable.</div>
-          )}
-        </Panel>
-
-        <Panel title="Blocked sessions">
-          {approvalsQuery.isLoading ? (
-            <div className="empty-state">Loading blocked sessions...</div>
-          ) : approvalsQuery.data?.suspendedSessions.length ? (
-            <div className="list-stack">
-              {approvalsQuery.data.suspendedSessions.map((session) => (
-                <div className="summary-block" key={session.sessionId}>
-                  <div className="key-value-grid">
-                    <div>
-                      <span>Status</span>
-                      <strong>{session.blockedLabel}</strong>
-                    </div>
-                    <div>
-                      <span>Modality</span>
-                      <strong>{session.modality}</strong>
-                    </div>
-                    <div>
-                      <span>Agent</span>
-                      <strong>{session.agentId || 'unknown'}</strong>
-                    </div>
-                    <div>
-                      <span>Host</span>
-                      <strong>{session.context.host || 'unknown'}</strong>
-                    </div>
-                    <div>
-                      <span>Created</span>
-                      <strong title={formatDateTime(session.createdAt)}>
-                        {formatRelativeTime(session.createdAt)}
-                      </strong>
-                    </div>
-                    <div>
-                      <span>Expires</span>
-                      <strong title={formatDateTime(session.expiresAt)}>
-                        {formatRelativeTime(session.expiresAt)}
-                      </strong>
-                    </div>
-                  </div>
-                  <p className="supporting-text">{session.prompt}</p>
-                  <InteractionResumeControls session={session} />
                 </div>
-              ))}
-            </div>
-          ) : (
-            <div className="empty-state">No blocked sessions right now.</div>
-          )}
-        </Panel>
 
-        <Panel title="Pending approvals">
-          {approvalsQuery.isLoading ? (
-            <div className="empty-state">Loading pending approvals...</div>
-          ) : approvalsQuery.data?.pending.length ? (
-            <div className="list-stack">
-              {approvalsQuery.data.pending.map((approval) => (
-                <div className="summary-block" key={approval.approvalId}>
-                  <div className="key-value-grid">
-                    <div>
-                      <span>Approval</span>
-                      <strong>
-                        {approval.actionKey || approval.approvalId}
-                      </strong>
+                {editorOpen ? (
+                  <form
+                    className="config-section detail-stack"
+                    onSubmit={handleDraftSubmit}
+                  >
+                    <strong>
+                      {editorMode === 'edit' && editingRuleIndex != null
+                        ? `Edit rule #${editingRuleIndex}`
+                        : 'Add rule'}
+                    </strong>
+
+                    <div className="field-grid policy-editor-grid">
+                      <label className="field">
+                        <span>Action</span>
+                        <select
+                          value={draft.action}
+                          disabled={policyMutationPending}
+                          onChange={(event) =>
+                            setDraft((current) => ({
+                              ...current,
+                              action:
+                                event.target.value === 'deny'
+                                  ? 'deny'
+                                  : 'allow',
+                            }))
+                          }
+                        >
+                          <option value="allow">allow</option>
+                          <option value="deny">deny</option>
+                        </select>
+                      </label>
+
+                      <label className="field">
+                        <span>Host</span>
+                        <input
+                          value={draft.host}
+                          disabled={policyMutationPending}
+                          placeholder="example.com"
+                          onChange={(event) =>
+                            setDraft((current) => ({
+                              ...current,
+                              host: event.target.value,
+                            }))
+                          }
+                        />
+                      </label>
+
+                      <label className="field">
+                        <span>Port</span>
+                        <input
+                          value={draft.port}
+                          disabled={policyMutationPending}
+                          placeholder="*"
+                          onChange={(event) =>
+                            setDraft((current) => ({
+                              ...current,
+                              port: event.target.value,
+                            }))
+                          }
+                        />
+                      </label>
+
+                      <label className="field">
+                        <span>Methods</span>
+                        <input
+                          value={draft.methods}
+                          disabled={policyMutationPending}
+                          placeholder="*"
+                          onChange={(event) =>
+                            setDraft((current) => ({
+                              ...current,
+                              methods: event.target.value,
+                            }))
+                          }
+                        />
+                      </label>
+
+                      <label className="field">
+                        <span>Paths</span>
+                        <input
+                          value={draft.paths}
+                          disabled={policyMutationPending}
+                          placeholder="/**"
+                          onChange={(event) =>
+                            setDraft((current) => ({
+                              ...current,
+                              paths: event.target.value,
+                            }))
+                          }
+                        />
+                      </label>
+
+                      <label className="field">
+                        <span>Agent</span>
+                        <input
+                          value={draft.agent}
+                          disabled={policyMutationPending}
+                          placeholder="*"
+                          onChange={(event) =>
+                            setDraft((current) => ({
+                              ...current,
+                              agent: event.target.value,
+                            }))
+                          }
+                        />
+                      </label>
+
+                      <label className="field policy-comment-field">
+                        <span>Comment</span>
+                        <textarea
+                          rows={2}
+                          value={draft.comment}
+                          disabled={policyMutationPending}
+                          placeholder="Optional note"
+                          onChange={(event) =>
+                            setDraft((current) => ({
+                              ...current,
+                              comment: event.target.value,
+                            }))
+                          }
+                        />
+                      </label>
                     </div>
-                    <div>
-                      <span>Agent</span>
-                      <strong>{approval.agentId || 'unknown'}</strong>
+
+                    <div className="button-row">
+                      <button
+                        className="primary-button"
+                        type="submit"
+                        disabled={policyMutationPending}
+                      >
+                        {saveMutation.isPending ? (
+                          <span className="button-with-spinner">
+                            <span
+                              aria-hidden="true"
+                              className="button-spinner"
+                            />
+                            {editorMode === 'edit' ? 'Saving...' : 'Adding...'}
+                          </span>
+                        ) : editorMode === 'edit' ? (
+                          'Save changes'
+                        ) : (
+                          'Save'
+                        )}
+                      </button>
+                      <button
+                        className="ghost-button"
+                        type="button"
+                        disabled={policyMutationPending}
+                        onClick={resetDraft}
+                      >
+                        Cancel
+                      </button>
                     </div>
-                    <div>
-                      <span>Session</span>
-                      <strong>{approval.sessionId}</strong>
+                  </form>
+                ) : null}
+              </div>
+            ) : (
+              <div className="empty-state">Policy state is unavailable.</div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Blocked sessions</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {approvalsQuery.isLoading ? (
+              <div className="empty-state">Loading blocked sessions...</div>
+            ) : approvalsQuery.data?.suspendedSessions.length ? (
+              <div className="list-stack">
+                {approvalsQuery.data.suspendedSessions.map((session) => (
+                  <div className="summary-block" key={session.sessionId}>
+                    <div className="key-value-grid">
+                      <div>
+                        <span>Status</span>
+                        <strong>{session.blockedLabel}</strong>
+                      </div>
+                      <div>
+                        <span>Modality</span>
+                        <strong>{session.modality}</strong>
+                      </div>
+                      <div>
+                        <span>Agent</span>
+                        <strong>{session.agentId || 'unknown'}</strong>
+                      </div>
+                      <div>
+                        <span>Host</span>
+                        <strong>{session.context.host || 'unknown'}</strong>
+                      </div>
+                      <div>
+                        <span>Created</span>
+                        <strong title={formatDateTime(session.createdAt)}>
+                          {formatRelativeTime(session.createdAt)}
+                        </strong>
+                      </div>
+                      <div>
+                        <span>Expires</span>
+                        <strong title={formatDateTime(session.expiresAt)}>
+                          {formatRelativeTime(session.expiresAt)}
+                        </strong>
+                      </div>
                     </div>
-                    <div>
-                      <span>Trust scopes</span>
-                      <strong>
-                        {formatPendingTrustScopes({
-                          allowSession: approval.allowSession,
-                          allowAgent: approval.allowAgent,
-                          allowAll: approval.allowAll,
-                        })}
-                      </strong>
-                    </div>
-                    <div>
-                      <span>Created</span>
-                      <strong title={formatDateTime(approval.createdAt)}>
-                        {formatRelativeTime(approval.createdAt)}
-                      </strong>
-                    </div>
-                    <div>
-                      <span>Expires</span>
-                      <strong title={formatDateTime(approval.expiresAt)}>
-                        {formatRelativeTime(approval.expiresAt)}
-                      </strong>
-                    </div>
+                    <p className="supporting-text">{session.prompt}</p>
+                    <InteractionResumeControls session={session} />
                   </div>
-                  <p className="supporting-text">{approval.prompt}</p>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div className="empty-state">No pending approvals right now.</div>
-          )}
-        </Panel>
+                ))}
+              </div>
+            ) : (
+              <div className="empty-state">No blocked sessions right now.</div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Pending approvals</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {approvalsQuery.isLoading ? (
+              <div className="empty-state">Loading pending approvals...</div>
+            ) : approvalsQuery.data?.pending.length ? (
+              <div className="list-stack">
+                {approvalsQuery.data.pending.map((approval) => (
+                  <div className="summary-block" key={approval.approvalId}>
+                    <div className="key-value-grid">
+                      <div>
+                        <span>Approval</span>
+                        <strong>
+                          {approval.actionKey || approval.approvalId}
+                        </strong>
+                      </div>
+                      <div>
+                        <span>Agent</span>
+                        <strong>{approval.agentId || 'unknown'}</strong>
+                      </div>
+                      <div>
+                        <span>Session</span>
+                        <strong>{approval.sessionId}</strong>
+                      </div>
+                      <div>
+                        <span>Trust scopes</span>
+                        <strong>
+                          {formatPendingTrustScopes({
+                            allowSession: approval.allowSession,
+                            allowAgent: approval.allowAgent,
+                            allowAll: approval.allowAll,
+                          })}
+                        </strong>
+                      </div>
+                      <div>
+                        <span>Created</span>
+                        <strong title={formatDateTime(approval.createdAt)}>
+                          {formatRelativeTime(approval.createdAt)}
+                        </strong>
+                      </div>
+                      <div>
+                        <span>Expires</span>
+                        <strong title={formatDateTime(approval.expiresAt)}>
+                          {formatRelativeTime(approval.expiresAt)}
+                        </strong>
+                      </div>
+                    </div>
+                    <p className="supporting-text">{approval.prompt}</p>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="empty-state">No pending approvals right now.</div>
+            )}
+          </CardContent>
+        </Card>
       </div>
       <Dialog
         open={deleteRuleTarget !== null}

--- a/console/src/routes/audit.tsx
+++ b/console/src/routes/audit.tsx
@@ -2,7 +2,14 @@ import { useQuery } from '@tanstack/react-query';
 import { useDeferredValue, useEffect, useState } from 'react';
 import { fetchAudit } from '../api/client';
 import { useAuth } from '../auth';
-import { PageHeader, Panel } from '../components/ui';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../components/card';
+import { PageHeader } from '../components/ui';
 import { formatDateTime, formatRelativeTime } from '../lib/format';
 
 function prettifyPayload(raw: string): string {
@@ -56,115 +63,131 @@ export function AuditPage() {
     <div className="page-stack">
       <PageHeader title="Audit Log" />
 
-      <Panel title="Filters">
-        <div className="field-grid">
+      <Card>
+        <CardHeader>
+          <CardTitle>Filters</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="field-grid">
+            <label className="field">
+              <span>Search</span>
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="approval, tool, error"
+              />
+            </label>
+            <label className="field">
+              <span>Session ID</span>
+              <input
+                value={sessionId}
+                onChange={(event) => setSessionId(event.target.value)}
+                placeholder="web:default"
+              />
+            </label>
+          </div>
           <label className="field">
-            <span>Search</span>
+            <span>Event type</span>
             <input
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="approval, tool, error"
+              value={eventType}
+              onChange={(event) => setEventType(event.target.value)}
+              placeholder="approval.response"
             />
           </label>
-          <label className="field">
-            <span>Session ID</span>
-            <input
-              value={sessionId}
-              onChange={(event) => setSessionId(event.target.value)}
-              placeholder="web:default"
-            />
-          </label>
-        </div>
-        <label className="field">
-          <span>Event type</span>
-          <input
-            value={eventType}
-            onChange={(event) => setEventType(event.target.value)}
-            placeholder="approval.response"
-          />
-        </label>
-      </Panel>
+        </CardContent>
+      </Card>
 
       <div className="two-column-grid">
-        <Panel
-          title="Entries"
-          subtitle={`${auditQuery.data?.entries.length || 0} matching event${auditQuery.data?.entries.length === 1 ? '' : 's'}`}
-        >
-          {auditQuery.isLoading ? (
-            <div className="empty-state">Loading audit entries...</div>
-          ) : auditQuery.data?.entries.length ? (
-            <div className="list-stack selectable-list">
-              {auditQuery.data.entries.map((entry) => (
-                <button
-                  key={entry.id}
-                  className={
-                    entry.id === selectedEntry?.id
-                      ? 'selectable-row active'
-                      : 'selectable-row'
-                  }
-                  type="button"
-                  onClick={() => setSelectedId(entry.id)}
-                >
-                  <div>
-                    <strong>{entry.eventType}</strong>
-                    <small>
-                      {entry.sessionId} · {formatRelativeTime(entry.timestamp)}
-                    </small>
-                  </div>
-                  <span>#{entry.id}</span>
-                </button>
-              ))}
-            </div>
-          ) : (
-            <div className="empty-state">
-              No audit entries match these filters.
-            </div>
-          )}
-        </Panel>
-
-        <div className="sticky-detail">
-          <Panel title="Inspection" accent="warm">
-            {!selectedEntry ? (
-              <div className="empty-state">
-                Select an audit event to inspect it.
+        <Card>
+          <CardHeader>
+            <CardTitle>Entries</CardTitle>
+            <CardDescription>
+              {`${auditQuery.data?.entries.length || 0} matching event${auditQuery.data?.entries.length === 1 ? '' : 's'}`}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {auditQuery.isLoading ? (
+              <div className="empty-state">Loading audit entries...</div>
+            ) : auditQuery.data?.entries.length ? (
+              <div className="list-stack selectable-list">
+                {auditQuery.data.entries.map((entry) => (
+                  <button
+                    key={entry.id}
+                    className={
+                      entry.id === selectedEntry?.id
+                        ? 'selectable-row active'
+                        : 'selectable-row'
+                    }
+                    type="button"
+                    onClick={() => setSelectedId(entry.id)}
+                  >
+                    <div>
+                      <strong>{entry.eventType}</strong>
+                      <small>
+                        {entry.sessionId} ·{' '}
+                        {formatRelativeTime(entry.timestamp)}
+                      </small>
+                    </div>
+                    <span>#{entry.id}</span>
+                  </button>
+                ))}
               </div>
             ) : (
-              <div className="detail-stack">
-                <div className="key-value-grid">
-                  <div>
-                    <span>Event type</span>
-                    <strong>{selectedEntry.eventType}</strong>
-                  </div>
-                  <div>
-                    <span>Session</span>
-                    <strong>{selectedEntry.sessionId}</strong>
-                  </div>
-                  <div>
-                    <span>Timestamp</span>
-                    <strong>{formatDateTime(selectedEntry.timestamp)}</strong>
-                  </div>
-                  <div>
-                    <span>Run ID</span>
-                    <strong>{selectedEntry.runId}</strong>
-                  </div>
-                  <div>
-                    <span>Seq</span>
-                    <strong>{selectedEntry.seq}</strong>
-                  </div>
-                  <div>
-                    <span>Parent run</span>
-                    <strong>{selectedEntry.parentRunId || 'none'}</strong>
-                  </div>
-                </div>
-                <div className="summary-block">
-                  <span>Payload</span>
-                  <pre className="payload-block">
-                    {prettifyPayload(selectedEntry.payload)}
-                  </pre>
-                </div>
+              <div className="empty-state">
+                No audit entries match these filters.
               </div>
             )}
-          </Panel>
+          </CardContent>
+        </Card>
+
+        <div className="sticky-detail">
+          <Card variant="muted">
+            <CardHeader>
+              <CardTitle>Inspection</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {!selectedEntry ? (
+                <div className="empty-state">
+                  Select an audit event to inspect it.
+                </div>
+              ) : (
+                <div className="detail-stack">
+                  <div className="key-value-grid">
+                    <div>
+                      <span>Event type</span>
+                      <strong>{selectedEntry.eventType}</strong>
+                    </div>
+                    <div>
+                      <span>Session</span>
+                      <strong>{selectedEntry.sessionId}</strong>
+                    </div>
+                    <div>
+                      <span>Timestamp</span>
+                      <strong>{formatDateTime(selectedEntry.timestamp)}</strong>
+                    </div>
+                    <div>
+                      <span>Run ID</span>
+                      <strong>{selectedEntry.runId}</strong>
+                    </div>
+                    <div>
+                      <span>Seq</span>
+                      <strong>{selectedEntry.seq}</strong>
+                    </div>
+                    <div>
+                      <span>Parent run</span>
+                      <strong>{selectedEntry.parentRunId || 'none'}</strong>
+                    </div>
+                  </div>
+                  <div className="summary-block">
+                    <span>Payload</span>
+                    <pre className="payload-block">
+                      {prettifyPayload(selectedEntry.payload)}
+                    </pre>
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
         </div>
       </div>
     </div>

--- a/console/src/routes/channels.test.tsx
+++ b/console/src/routes/channels.test.tsx
@@ -674,7 +674,7 @@ describe('ChannelsPage', () => {
 
     const panel = screen
       .getByRole('heading', { name: 'Signal settings' })
-      .closest('section');
+      .closest('[data-slot="card"]');
     expect(panel).not.toBeNull();
 
     fireEvent.click(
@@ -1067,7 +1067,7 @@ describe('ChannelsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: /Discord/i }));
     const panel = screen
       .getByRole('heading', { name: 'Discord settings' })
-      .closest('section');
+      .closest('[data-slot="card"]');
     expect(panel).not.toBeNull();
     const enabledToggle = within(panel as HTMLElement).getByRole('group', {
       name: 'Enabled',
@@ -1190,7 +1190,7 @@ describe('ChannelsPage', () => {
       await screen.findByRole('heading', {
         name: 'WhatsApp settings',
       })
-    ).closest('section');
+    ).closest('[data-slot="card"]');
     expect(panel).not.toBeNull();
     const enabledToggle = within(panel as HTMLElement).getByRole('group', {
       name: 'Enabled',

--- a/console/src/routes/channels.tsx
+++ b/console/src/routes/channels.tsx
@@ -11,9 +11,10 @@ import {
 } from '../api/client';
 import type { AdminConfig } from '../api/types';
 import { useAuth } from '../auth';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/card';
 import { ChannelLogo } from '../components/channel-logo';
 import { useToast } from '../components/toast';
-import { BooleanField, Panel } from '../components/ui';
+import { BooleanField } from '../components/ui';
 import { getErrorMessage } from '../lib/error-message';
 import { joinStringList, parseStringList } from '../lib/format';
 import {
@@ -3104,7 +3105,7 @@ export function ChannelsPage() {
   return (
     <div className="page-stack">
       <div className="two-column-grid channels-layout">
-        <Panel>
+        <Card>
           <div className="list-stack selectable-list channel-catalog">
             {catalog.map((entry) => (
               <button
@@ -3134,57 +3135,63 @@ export function ChannelsPage() {
               </button>
             ))}
           </div>
-        </Panel>
+        </Card>
 
-        <Panel
-          title={
-            selectedChannel ? `${selectedChannel.label} settings` : 'Channels'
-          }
-          accent="warm"
-        >
-          <div className="stack-form">
-            {selectedChannel
-              ? renderSelectedEditor(
-                  selectedChannel.kind,
-                  draft,
-                  updateDraft,
-                  auth.token,
-                  secretStatus,
-                  hybridaiApiKeyConfigured,
-                  whatsappStatus,
-                  signalStatus,
-                  () => {
-                    void queryClient.invalidateQueries({
-                      queryKey: ['status', auth.token],
-                    });
-                  },
-                )
-              : null}
+        <Card variant="muted">
+          <CardHeader>
+            <CardTitle>
+              {selectedChannel
+                ? `${selectedChannel.label} settings`
+                : 'Channels'}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="stack-form">
+              {selectedChannel
+                ? renderSelectedEditor(
+                    selectedChannel.kind,
+                    draft,
+                    updateDraft,
+                    auth.token,
+                    secretStatus,
+                    hybridaiApiKeyConfigured,
+                    whatsappStatus,
+                    signalStatus,
+                    () => {
+                      void queryClient.invalidateQueries({
+                        queryKey: ['status', auth.token],
+                      });
+                    },
+                  )
+                : null}
 
-            <div className="button-row">
-              <button
-                className="primary-button"
-                type="button"
-                disabled={!isDirty || saveMutation.isPending}
-                onClick={() => saveMutation.mutate(draft)}
-              >
-                {saveMutation.isPending ? 'Saving...' : 'Save channel settings'}
-              </button>
-              <button
-                className="ghost-button"
-                type="button"
-                disabled={!isDirty || !configQuery.data}
-                onClick={() => {
-                  if (!configQuery.data) return;
-                  saveMutation.reset();
-                  setDraft(cloneConfig(configQuery.data.config));
-                }}
-              >
-                Reset changes
-              </button>
+              <div className="button-row">
+                <button
+                  className="primary-button"
+                  type="button"
+                  disabled={!isDirty || saveMutation.isPending}
+                  onClick={() => saveMutation.mutate(draft)}
+                >
+                  {saveMutation.isPending
+                    ? 'Saving...'
+                    : 'Save channel settings'}
+                </button>
+                <button
+                  className="ghost-button"
+                  type="button"
+                  disabled={!isDirty || !configQuery.data}
+                  onClick={() => {
+                    if (!configQuery.data) return;
+                    saveMutation.reset();
+                    setDraft(cloneConfig(configQuery.data.config));
+                  }}
+                >
+                  Reset changes
+                </button>
+              </div>
             </div>
-          </div>
-        </Panel>
+          </CardContent>
+        </Card>
       </div>
     </div>
   );

--- a/console/src/routes/config.tsx
+++ b/console/src/routes/config.tsx
@@ -3,8 +3,15 @@ import { useEffect, useState } from 'react';
 import { fetchConfig, saveConfig } from '../api/client';
 import type { AdminConfig } from '../api/types';
 import { useAuth } from '../auth';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../components/card';
 import { useToast } from '../components/toast';
-import { BooleanField, PageHeader, Panel } from '../components/ui';
+import { BooleanField, PageHeader } from '../components/ui';
 import { getErrorMessage } from '../lib/error-message';
 
 function cloneConfig<T>(value: T): T {
@@ -72,249 +79,251 @@ export function ConfigPage() {
         }
       />
 
-      <Panel
-        title="Runtime config"
-        subtitle={configQuery.data.path}
-        accent="warm"
-      >
-        {rawMode ? (
-          <div className="stack-form">
-            <label className="field textarea-field">
-              <span>config.json</span>
-              <textarea
-                className="code-editor"
-                rows={24}
-                value={rawJson}
-                onChange={(event) => setRawJson(event.target.value)}
-              />
-            </label>
-            <div className="button-row">
-              <button
-                className="primary-button"
-                type="button"
-                onClick={() => {
-                  try {
-                    const parsed = JSON.parse(rawJson) as AdminConfig;
-                    setDraft(parsed);
-                    saveMutation.mutate(parsed);
-                  } catch (error) {
-                    toast.error('Invalid JSON', getErrorMessage(error));
-                  }
-                }}
-              >
-                Save JSON
-              </button>
+      <Card variant="muted">
+        <CardHeader>
+          <CardTitle>Runtime config</CardTitle>
+          <CardDescription>{configQuery.data.path}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {rawMode ? (
+            <div className="stack-form">
+              <label className="field textarea-field">
+                <span>config.json</span>
+                <textarea
+                  className="code-editor"
+                  rows={24}
+                  value={rawJson}
+                  onChange={(event) => setRawJson(event.target.value)}
+                />
+              </label>
+              <div className="button-row">
+                <button
+                  className="primary-button"
+                  type="button"
+                  onClick={() => {
+                    try {
+                      const parsed = JSON.parse(rawJson) as AdminConfig;
+                      setDraft(parsed);
+                      saveMutation.mutate(parsed);
+                    } catch (error) {
+                      toast.error('Invalid JSON', getErrorMessage(error));
+                    }
+                  }}
+                >
+                  Save JSON
+                </button>
+              </div>
             </div>
-          </div>
-        ) : (
-          <div className="config-grid">
-            <section className="config-section">
-              <h4>Operations</h4>
-              <label className="field">
-                <span>Health host</span>
-                <input
-                  value={draft.ops.healthHost}
-                  onChange={(event) =>
-                    setDraft((current) =>
-                      current
-                        ? {
-                            ...current,
-                            ops: {
-                              ...current.ops,
-                              healthHost: event.target.value,
-                            },
-                          }
-                        : current,
-                    )
-                  }
-                />
-              </label>
-              <label className="field">
-                <span>Health port</span>
-                <input
-                  value={String(draft.ops.healthPort)}
-                  onChange={(event) =>
-                    setDraft((current) =>
-                      current
-                        ? {
-                            ...current,
-                            ops: {
-                              ...current.ops,
-                              healthPort:
-                                Number.parseInt(event.target.value, 10) || 0,
-                            },
-                          }
-                        : current,
-                    )
-                  }
-                />
-              </label>
-              <label className="field">
-                <span>Log level</span>
-                <input
-                  value={draft.ops.logLevel}
-                  onChange={(event) =>
-                    setDraft((current) =>
-                      current
-                        ? {
-                            ...current,
-                            ops: {
-                              ...current.ops,
-                              logLevel: event.target.value,
-                            },
-                          }
-                        : current,
-                    )
-                  }
-                />
-              </label>
-            </section>
+          ) : (
+            <div className="config-grid">
+              <section className="config-section">
+                <h4>Operations</h4>
+                <label className="field">
+                  <span>Health host</span>
+                  <input
+                    value={draft.ops.healthHost}
+                    onChange={(event) =>
+                      setDraft((current) =>
+                        current
+                          ? {
+                              ...current,
+                              ops: {
+                                ...current.ops,
+                                healthHost: event.target.value,
+                              },
+                            }
+                          : current,
+                      )
+                    }
+                  />
+                </label>
+                <label className="field">
+                  <span>Health port</span>
+                  <input
+                    value={String(draft.ops.healthPort)}
+                    onChange={(event) =>
+                      setDraft((current) =>
+                        current
+                          ? {
+                              ...current,
+                              ops: {
+                                ...current.ops,
+                                healthPort:
+                                  Number.parseInt(event.target.value, 10) || 0,
+                              },
+                            }
+                          : current,
+                      )
+                    }
+                  />
+                </label>
+                <label className="field">
+                  <span>Log level</span>
+                  <input
+                    value={draft.ops.logLevel}
+                    onChange={(event) =>
+                      setDraft((current) =>
+                        current
+                          ? {
+                              ...current,
+                              ops: {
+                                ...current.ops,
+                                logLevel: event.target.value,
+                              },
+                            }
+                          : current,
+                      )
+                    }
+                  />
+                </label>
+              </section>
 
-            <section className="config-section">
-              <h4>Security</h4>
-              <BooleanField
-                label="Confidential leak guard"
-                value={draft.security?.confidentialRedactionEnabled ?? false}
-                trueLabel="on"
-                falseLabel="off"
-                onChange={(confidentialRedactionEnabled) =>
-                  setDraft((current) => {
-                    if (!current) return current;
-                    const security = current.security ?? {
-                      trustModelAccepted: false,
-                      trustModelAcceptedAt: '',
-                      trustModelVersion: '',
-                      trustModelAcceptedBy: '',
-                      confidentialRedactionEnabled: false,
-                    };
-                    return {
-                      ...current,
-                      security: {
-                        ...security,
-                        confidentialRedactionEnabled,
-                      },
-                    };
-                  })
-                }
-              />
-            </section>
+              <section className="config-section">
+                <h4>Security</h4>
+                <BooleanField
+                  label="Confidential leak guard"
+                  value={draft.security?.confidentialRedactionEnabled ?? false}
+                  trueLabel="on"
+                  falseLabel="off"
+                  onChange={(confidentialRedactionEnabled) =>
+                    setDraft((current) => {
+                      if (!current) return current;
+                      const security = current.security ?? {
+                        trustModelAccepted: false,
+                        trustModelAcceptedAt: '',
+                        trustModelVersion: '',
+                        trustModelAcceptedBy: '',
+                        confidentialRedactionEnabled: false,
+                      };
+                      return {
+                        ...current,
+                        security: {
+                          ...security,
+                          confidentialRedactionEnabled,
+                        },
+                      };
+                    })
+                  }
+                />
+              </section>
 
-            <section className="config-section">
-              <h4>HybridAI</h4>
-              <label className="field">
-                <span>Base URL</span>
-                <input
-                  value={draft.hybridai.baseUrl}
-                  onChange={(event) =>
+              <section className="config-section">
+                <h4>HybridAI</h4>
+                <label className="field">
+                  <span>Base URL</span>
+                  <input
+                    value={draft.hybridai.baseUrl}
+                    onChange={(event) =>
+                      setDraft((current) =>
+                        current
+                          ? {
+                              ...current,
+                              hybridai: {
+                                ...current.hybridai,
+                                baseUrl: event.target.value,
+                              },
+                            }
+                          : current,
+                      )
+                    }
+                  />
+                </label>
+                <label className="field">
+                  <span>Default model</span>
+                  <input
+                    value={draft.hybridai.defaultModel}
+                    onChange={(event) =>
+                      setDraft((current) =>
+                        current
+                          ? {
+                              ...current,
+                              hybridai: {
+                                ...current.hybridai,
+                                defaultModel: event.target.value,
+                              },
+                            }
+                          : current,
+                      )
+                    }
+                  />
+                </label>
+                <BooleanField
+                  label="RAG default"
+                  value={draft.hybridai.enableRag}
+                  trueLabel="on"
+                  falseLabel="off"
+                  onChange={(enableRag) =>
                     setDraft((current) =>
                       current
                         ? {
                             ...current,
                             hybridai: {
                               ...current.hybridai,
-                              baseUrl: event.target.value,
+                              enableRag,
                             },
                           }
                         : current,
                     )
                   }
                 />
-              </label>
-              <label className="field">
-                <span>Default model</span>
-                <input
-                  value={draft.hybridai.defaultModel}
-                  onChange={(event) =>
-                    setDraft((current) =>
-                      current
-                        ? {
-                            ...current,
-                            hybridai: {
-                              ...current.hybridai,
-                              defaultModel: event.target.value,
-                            },
-                          }
-                        : current,
-                    )
-                  }
-                />
-              </label>
-              <BooleanField
-                label="RAG default"
-                value={draft.hybridai.enableRag}
-                trueLabel="on"
-                falseLabel="off"
-                onChange={(enableRag) =>
-                  setDraft((current) =>
-                    current
-                      ? {
-                          ...current,
-                          hybridai: {
-                            ...current.hybridai,
-                            enableRag,
-                          },
-                        }
-                      : current,
-                  )
-                }
-              />
-            </section>
+              </section>
 
-            <section className="config-section">
-              <h4>Container</h4>
-              <label className="field">
-                <span>Memory</span>
-                <input
-                  value={draft.container.memory}
-                  onChange={(event) =>
+              <section className="config-section">
+                <h4>Container</h4>
+                <label className="field">
+                  <span>Memory</span>
+                  <input
+                    value={draft.container.memory}
+                    onChange={(event) =>
+                      setDraft((current) =>
+                        current
+                          ? {
+                              ...current,
+                              container: {
+                                ...current.container,
+                                memory: event.target.value,
+                              },
+                            }
+                          : current,
+                      )
+                    }
+                  />
+                </label>
+                <BooleanField
+                  label="Persistent bash state"
+                  value={draft.container.persistBashState}
+                  trueLabel="on"
+                  falseLabel="off"
+                  onChange={(persistBashState) =>
                     setDraft((current) =>
                       current
                         ? {
                             ...current,
                             container: {
                               ...current.container,
-                              memory: event.target.value,
+                              persistBashState,
                             },
                           }
                         : current,
                     )
                   }
                 />
-              </label>
-              <BooleanField
-                label="Persistent bash state"
-                value={draft.container.persistBashState}
-                trueLabel="on"
-                falseLabel="off"
-                onChange={(persistBashState) =>
-                  setDraft((current) =>
-                    current
-                      ? {
-                          ...current,
-                          container: {
-                            ...current.container,
-                            persistBashState,
-                          },
-                        }
-                      : current,
-                  )
-                }
-              />
-            </section>
-          </div>
-        )}
+              </section>
+            </div>
+          )}
 
-        <div className="button-row">
-          <button
-            className="primary-button"
-            type="button"
-            disabled={saveMutation.isPending}
-            onClick={() => saveMutation.mutate(draft)}
-          >
-            {saveMutation.isPending ? 'Saving...' : 'Save config'}
-          </button>
-        </div>
-      </Panel>
+          <div className="button-row">
+            <button
+              className="primary-button"
+              type="button"
+              disabled={saveMutation.isPending}
+              onClick={() => saveMutation.mutate(draft)}
+            >
+              {saveMutation.isPending ? 'Saving...' : 'Save config'}
+            </button>
+          </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/console/src/routes/dashboard.tsx
+++ b/console/src/routes/dashboard.tsx
@@ -3,11 +3,11 @@ import { useNavigate } from '@tanstack/react-router';
 import { fetchOverview, fetchStatistics, reconnectTunnel } from '../api/client';
 import type { AdminOverview, AdminTunnelStatus } from '../api/types';
 import { useAuth } from '../auth';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/card';
 import { ProviderHealthPanel } from '../components/provider-health';
 import {
   MetricCard,
   PageHeader,
-  Panel,
   SortableHeader,
   useSortableRows,
 } from '../components/ui';
@@ -104,60 +104,67 @@ function TunnelStatusPanel(props: {
       : null;
 
   return (
-    <Panel title="Public tunnel">
-      <div className="tunnel-panel-grid">
-        <div className="tunnel-url-stack">
-          <span>Public URL</span>
-          {tunnel.publicUrl ? (
-            <a href={tunnel.publicUrl} target="_blank" rel="noreferrer">
-              {publicUrl}
-            </a>
-          ) : (
-            <strong>{publicUrl}</strong>
-          )}
+    <Card>
+      <CardHeader>
+        <CardTitle>Public tunnel</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="tunnel-panel-grid">
+          <div className="tunnel-url-stack">
+            <span>Public URL</span>
+            {tunnel.publicUrl ? (
+              <a href={tunnel.publicUrl} target="_blank" rel="noreferrer">
+                {publicUrl}
+              </a>
+            ) : (
+              <strong>{publicUrl}</strong>
+            )}
+          </div>
+          <div className="tunnel-action-stack">
+            <button
+              type="button"
+              className="primary-button button-with-spinner"
+              onClick={props.onReconnect}
+              disabled={reconnectDisabled}
+            >
+              {props.reconnectPending ? (
+                <span className="button-spinner" aria-hidden="true" />
+              ) : null}
+              {props.reconnectPending ? 'Reconnecting' : 'Reconnect'}
+            </button>
+          </div>
         </div>
-        <div className="tunnel-action-stack">
-          <button
-            type="button"
-            className="primary-button button-with-spinner"
-            onClick={props.onReconnect}
-            disabled={reconnectDisabled}
-          >
-            {props.reconnectPending ? (
-              <span className="button-spinner" aria-hidden="true" />
-            ) : null}
-            {props.reconnectPending ? 'Reconnecting' : 'Reconnect'}
-          </button>
+        <div className="tunnel-detail-grid">
+          <div className="tunnel-detail">
+            <span>Provider</span>
+            <strong>{tunnel.provider || 'none'}</strong>
+          </div>
+          <div className="tunnel-detail">
+            <span>Status</span>
+            <strong className={tunnelStatusClass(tunnel.health)}>
+              <span className={tunnelStatusDotClass(tunnel.health)} />
+              {tunnel.health}
+            </strong>
+          </div>
+          <div className="tunnel-detail">
+            <span>Last checked</span>
+            <strong>{formatDateTime(tunnel.lastCheckedAt)}</strong>
+          </div>
+          <div className="tunnel-detail">
+            <span>Next reconnect</span>
+            <strong>{formatDateTime(tunnel.nextReconnectAt)}</strong>
+          </div>
         </div>
-      </div>
-      <div className="tunnel-detail-grid">
-        <div className="tunnel-detail">
-          <span>Provider</span>
-          <strong>{tunnel.provider || 'none'}</strong>
-        </div>
-        <div className="tunnel-detail">
-          <span>Status</span>
-          <strong className={tunnelStatusClass(tunnel.health)}>
-            <span className={tunnelStatusDotClass(tunnel.health)} />
-            {tunnel.health}
-          </strong>
-        </div>
-        <div className="tunnel-detail">
-          <span>Last checked</span>
-          <strong>{formatDateTime(tunnel.lastCheckedAt)}</strong>
-        </div>
-        <div className="tunnel-detail">
-          <span>Next reconnect</span>
-          <strong>{formatDateTime(tunnel.nextReconnectAt)}</strong>
-        </div>
-      </div>
-      {tunnel.lastError ? (
-        <p className="supporting-text tunnel-error">{tunnel.lastError}</p>
-      ) : null}
-      {distinctReconnectError ? (
-        <p className="supporting-text tunnel-error">{distinctReconnectError}</p>
-      ) : null}
-    </Panel>
+        {tunnel.lastError ? (
+          <p className="supporting-text tunnel-error">{tunnel.lastError}</p>
+        ) : null}
+        {distinctReconnectError ? (
+          <p className="supporting-text tunnel-error">
+            {distinctReconnectError}
+          </p>
+        ) : null}
+      </CardContent>
+    </Card>
   );
 }
 
@@ -265,13 +272,18 @@ export function DashboardPage() {
       </div>
 
       <div className="two-column-grid">
-        <Panel title="Usage">
-          <UsageRollup
-            usage={overview.usage}
-            trend={usageTrendQuery.data?.trend ?? null}
-            formatTrendDate={formatTrendDate}
-          />
-        </Panel>
+        <Card variant="muted">
+          <CardHeader>
+            <CardTitle>Usage rollup</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <UsageRollup
+              usage={overview.usage}
+              trend={usageTrendQuery.data?.trend ?? null}
+              formatTrendDate={formatTrendDate}
+            />
+          </CardContent>
+        </Card>
 
         <ProviderHealthPanel
           title="Backend health"
@@ -291,60 +303,65 @@ export function DashboardPage() {
         onReconnect={() => reconnectMutation.mutate()}
       />
 
-      <Panel title="Recent sessions">
-        <div className="table-shell">
-          <table>
-            <thead>
-              <tr>
-                <SortableHeader
-                  label="Session"
-                  sortKey="session"
-                  sortState={sortState}
-                  onToggle={toggleSort}
-                />
-                <SortableHeader
-                  label="Model"
-                  sortKey="model"
-                  sortState={sortState}
-                  onToggle={toggleSort}
-                />
-                <SortableHeader
-                  label="Messages"
-                  sortKey="messages"
-                  sortState={sortState}
-                  onToggle={toggleSort}
-                />
-                <SortableHeader
-                  label="Tasks"
-                  sortKey="tasks"
-                  sortState={sortState}
-                  onToggle={toggleSort}
-                />
-                <SortableHeader
-                  label="Last active"
-                  sortKey="lastActive"
-                  sortState={sortState}
-                  onToggle={toggleSort}
-                />
-              </tr>
-            </thead>
-            <tbody>
-              {recentSessions.map((session) => (
-                <tr key={session.id}>
-                  <td>
-                    <strong>{session.id}</strong>
-                    <small>{session.channelId}</small>
-                  </td>
-                  <td>{session.effectiveModel}</td>
-                  <td>{session.messageCount}</td>
-                  <td>{session.taskCount}</td>
-                  <td>{formatRelativeTime(session.lastActive)}</td>
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent sessions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="table-shell">
+            <table>
+              <thead>
+                <tr>
+                  <SortableHeader
+                    label="Session"
+                    sortKey="session"
+                    sortState={sortState}
+                    onToggle={toggleSort}
+                  />
+                  <SortableHeader
+                    label="Model"
+                    sortKey="model"
+                    sortState={sortState}
+                    onToggle={toggleSort}
+                  />
+                  <SortableHeader
+                    label="Messages"
+                    sortKey="messages"
+                    sortState={sortState}
+                    onToggle={toggleSort}
+                  />
+                  <SortableHeader
+                    label="Tasks"
+                    sortKey="tasks"
+                    sortState={sortState}
+                    onToggle={toggleSort}
+                  />
+                  <SortableHeader
+                    label="Last active"
+                    sortKey="lastActive"
+                    sortState={sortState}
+                    onToggle={toggleSort}
+                  />
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </Panel>
+              </thead>
+              <tbody>
+                {recentSessions.map((session) => (
+                  <tr key={session.id}>
+                    <td>
+                      <strong>{session.id}</strong>
+                      <small>{session.channelId}</small>
+                    </td>
+                    <td>{session.effectiveModel}</td>
+                    <td>{session.messageCount}</td>
+                    <td>{session.taskCount}</td>
+                    <td>{formatRelativeTime(session.lastActive)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/console/src/routes/gateway.tsx
+++ b/console/src/routes/gateway.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
 import { reloadGateway } from '../api/client';
 import { useAuth } from '../auth';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/card';
 import {
   Dialog,
   DialogClose,
@@ -14,7 +15,7 @@ import {
 } from '../components/dialog';
 import { ProviderHealthPanel } from '../components/provider-health';
 import { useToast } from '../components/toast';
-import { BooleanPill, MetricCard, PageHeader, Panel } from '../components/ui';
+import { BooleanPill, MetricCard, PageHeader } from '../components/ui';
 import { useLiveConnectionToasts } from '../hooks/use-live-connection-toasts';
 import { useLiveEvents } from '../hooks/use-live-events';
 import { getErrorMessage } from '../lib/error-message';
@@ -84,83 +85,93 @@ export function GatewayPage() {
       </div>
 
       <div className="two-column-grid">
-        <Panel title="Runtime">
-          <div className="key-value-grid">
-            <div>
-              <span>Version</span>
-              <strong>{status.version}</strong>
+        <Card>
+          <CardHeader>
+            <CardTitle>Runtime</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="key-value-grid">
+              <div>
+                <span>Version</span>
+                <strong>{status.version}</strong>
+              </div>
+              <div>
+                <span>PID</span>
+                <strong>{status.pid ?? 'n/a'}</strong>
+              </div>
+              <div>
+                <span>Timestamp</span>
+                <strong>{formatDateTime(status.timestamp)}</strong>
+              </div>
+              <div>
+                <span>Default model</span>
+                <strong>{status.defaultModel}</strong>
+              </div>
             </div>
-            <div>
-              <span>PID</span>
-              <strong>{status.pid ?? 'n/a'}</strong>
-            </div>
-            <div>
-              <span>Timestamp</span>
-              <strong>{formatDateTime(status.timestamp)}</strong>
-            </div>
-            <div>
-              <span>Default model</span>
-              <strong>{status.defaultModel}</strong>
-            </div>
-          </div>
-        </Panel>
+          </CardContent>
+        </Card>
 
-        <Panel title="Services" accent="warm">
-          <div className="key-value-grid">
-            <div>
-              <span>Sandbox mode</span>
-              <strong>{status.sandbox?.mode || 'unknown'}</strong>
+        <Card variant="muted">
+          <CardHeader>
+            <CardTitle>Services</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="key-value-grid">
+              <div>
+                <span>Sandbox mode</span>
+                <strong>{status.sandbox?.mode || 'unknown'}</strong>
+              </div>
+              <div>
+                <span>Sandbox sessions</span>
+                <strong>
+                  {status.sandbox?.activeSessions ?? status.activeContainers}
+                </strong>
+              </div>
+              <div>
+                <span>Web API auth</span>
+                <BooleanPill
+                  value={status.webAuthConfigured}
+                  trueLabel="on"
+                  falseLabel="off"
+                />
+              </div>
+              <div>
+                <span>RAG default</span>
+                <BooleanPill
+                  value={status.ragDefault}
+                  trueLabel="on"
+                  falseLabel="off"
+                />
+              </div>
+              <div>
+                <span>Observability</span>
+                <BooleanPill
+                  value={Boolean(
+                    status.observability?.enabled &&
+                      status.observability?.running,
+                  )}
+                  trueLabel="active"
+                  falseLabel="inactive"
+                />
+              </div>
+              <div>
+                <span>Last observability success</span>
+                <strong>
+                  {formatDateTime(status.observability?.lastSuccessAt || null)}
+                </strong>
+              </div>
             </div>
-            <div>
-              <span>Sandbox sessions</span>
-              <strong>
-                {status.sandbox?.activeSessions ?? status.activeContainers}
-              </strong>
-            </div>
-            <div>
-              <span>Web API auth</span>
-              <BooleanPill
-                value={status.webAuthConfigured}
-                trueLabel="on"
-                falseLabel="off"
-              />
-            </div>
-            <div>
-              <span>RAG default</span>
-              <BooleanPill
-                value={status.ragDefault}
-                trueLabel="on"
-                falseLabel="off"
-              />
-            </div>
-            <div>
-              <span>Observability</span>
-              <BooleanPill
-                value={Boolean(
-                  status.observability?.enabled &&
-                    status.observability?.running,
-                )}
-                trueLabel="active"
-                falseLabel="inactive"
-              />
-            </div>
-            <div>
-              <span>Last observability success</span>
-              <strong>
-                {formatDateTime(status.observability?.lastSuccessAt || null)}
-              </strong>
-            </div>
-          </div>
-          {sandboxWarning ? (
-            <p className="error-banner">{sandboxWarning}</p>
-          ) : null}
-          {status.codex?.reloginRequired ? (
-            <p className="error-banner">Codex login is required again.</p>
-          ) : null}
-          {status.observability?.lastError ? (
-            <p className="error-banner">{status.observability.lastError}</p>
-          ) : null}
-        </Panel>
+            {sandboxWarning ? (
+              <p className="error-banner">{sandboxWarning}</p>
+            ) : null}
+            {status.codex?.reloginRequired ? (
+              <p className="error-banner">Codex login is required again.</p>
+            ) : null}
+            {status.observability?.lastError ? (
+              <p className="error-banner">{status.observability.lastError}</p>
+            ) : null}
+          </CardContent>
+        </Card>
       </div>
 
       <div className="two-column-grid">
@@ -170,34 +181,41 @@ export function GatewayPage() {
           onLogin={() => void navigate({ to: '/admin/config' })}
         />
 
-        <Panel title="Scheduler snapshot" accent="warm">
-          {schedulerJobs.length === 0 ? (
-            <div className="empty-state">No scheduler jobs are registered.</div>
-          ) : (
-            <div className="list-stack">
-              {schedulerJobs.slice(0, 8).map((job) => (
-                <div className="list-row" key={job.id}>
-                  <div>
-                    <strong>{job.name}</strong>
-                    <small>
-                      {job.nextRunAt
-                        ? `next ${formatDateTime(job.nextRunAt)}`
-                        : 'no next run scheduled'}
-                    </small>
+        <Card variant="muted">
+          <CardHeader>
+            <CardTitle>Scheduler snapshot</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {schedulerJobs.length === 0 ? (
+              <div className="empty-state">
+                No scheduler jobs are registered.
+              </div>
+            ) : (
+              <div className="list-stack">
+                {schedulerJobs.slice(0, 8).map((job) => (
+                  <div className="list-row" key={job.id}>
+                    <div>
+                      <strong>{job.name}</strong>
+                      <small>
+                        {job.nextRunAt
+                          ? `next ${formatDateTime(job.nextRunAt)}`
+                          : 'no next run scheduled'}
+                      </small>
+                    </div>
+                    <div className="row-status-stack">
+                      <BooleanPill
+                        value={job.enabled && !job.disabled}
+                        trueLabel="active"
+                        falseLabel="inactive"
+                      />
+                      <small>{job.lastStatus || 'ready'}</small>
+                    </div>
                   </div>
-                  <div className="row-status-stack">
-                    <BooleanPill
-                      value={job.enabled && !job.disabled}
-                      trueLabel="active"
-                      falseLabel="inactive"
-                    />
-                    <small>{job.lastStatus || 'ready'}</small>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </Panel>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
       </div>
       <Dialog open={reloadConfirmOpen} onOpenChange={setReloadConfirmOpen}>
         <DialogContent size="sm" role="alertdialog">

--- a/console/src/routes/mcp.tsx
+++ b/console/src/routes/mcp.tsx
@@ -3,8 +3,15 @@ import { useEffect, useState } from 'react';
 import { deleteMcpServer, fetchMcp, saveMcpServer } from '../api/client';
 import type { AdminMcpConfig, AdminMcpServer } from '../api/types';
 import { useAuth } from '../auth';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../components/card';
 import { useToast } from '../components/toast';
-import { BooleanField, BooleanPill, PageHeader, Panel } from '../components/ui';
+import { BooleanField, BooleanPill, PageHeader } from '../components/ui';
 import { getErrorMessage } from '../lib/error-message';
 
 interface McpDraft {
@@ -168,211 +175,221 @@ export function McpPage() {
       />
 
       <div className="two-column-grid">
-        <Panel
-          title="Servers"
-          subtitle={`${mcpQuery.data?.servers.length || 0} configured server${mcpQuery.data?.servers.length === 1 ? '' : 's'}`}
-        >
-          {mcpQuery.isLoading ? (
-            <div className="empty-state">Loading MCP servers...</div>
-          ) : mcpQuery.data?.servers.length ? (
-            <div className="list-stack selectable-list">
-              {mcpQuery.data.servers.map((server) => (
-                <button
-                  key={server.name}
-                  className={
-                    server.name === selectedName
-                      ? 'selectable-row active'
-                      : 'selectable-row'
-                  }
-                  type="button"
-                  onClick={() => setSelectedName(server.name)}
-                >
-                  <div>
-                    <strong>{server.name}</strong>
-                    <small>{server.summary}</small>
-                  </div>
-                  <BooleanPill
-                    value={server.enabled}
-                    trueLabel="active"
-                    falseLabel="inactive"
-                  />
-                </button>
-              ))}
-            </div>
-          ) : (
-            <div className="empty-state">
-              No MCP servers are configured yet.
-            </div>
-          )}
-        </Panel>
-
-        <Panel title="Server editor" accent="warm">
-          <div className="stack-form">
-            <div className="field-grid">
-              <label className="field">
-                <span>Name</span>
-                <input
-                  value={draft.name}
-                  onChange={(event) =>
-                    setDraft((current) => ({
-                      ...current,
-                      name: event.target.value,
-                    }))
-                  }
-                  placeholder="github"
-                />
-              </label>
-              <label className="field">
-                <span>Transport</span>
-                <select
-                  value={draft.transport}
-                  onChange={(event) =>
-                    setDraft((current) => ({
-                      ...current,
-                      transport: event.target.value as McpDraft['transport'],
-                    }))
-                  }
-                >
-                  <option value="stdio">stdio</option>
-                  <option value="http">http</option>
-                  <option value="sse">sse</option>
-                </select>
-              </label>
-            </div>
-
-            <BooleanField
-              label="Server state"
-              value={draft.enabled}
-              trueLabel="on"
-              falseLabel="off"
-              onChange={(enabled) =>
-                setDraft((current) => ({
-                  ...current,
-                  enabled,
-                }))
-              }
-            />
-
-            {draft.transport === 'stdio' ? (
-              <>
-                <label className="field">
-                  <span>Command</span>
-                  <input
-                    value={draft.command}
-                    onChange={(event) =>
-                      setDraft((current) => ({
-                        ...current,
-                        command: event.target.value,
-                      }))
+        <Card>
+          <CardHeader>
+            <CardTitle>Servers</CardTitle>
+            <CardDescription>
+              {`${mcpQuery.data?.servers.length || 0} configured server${mcpQuery.data?.servers.length === 1 ? '' : 's'}`}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {mcpQuery.isLoading ? (
+              <div className="empty-state">Loading MCP servers...</div>
+            ) : mcpQuery.data?.servers.length ? (
+              <div className="list-stack selectable-list">
+                {mcpQuery.data.servers.map((server) => (
+                  <button
+                    key={server.name}
+                    className={
+                      server.name === selectedName
+                        ? 'selectable-row active'
+                        : 'selectable-row'
                     }
-                    placeholder="docker"
-                  />
-                </label>
-                <div className="field-grid">
-                  <label className="field">
-                    <span>Arguments</span>
-                    <textarea
-                      rows={4}
-                      value={draft.args}
-                      onChange={(event) =>
-                        setDraft((current) => ({
-                          ...current,
-                          args: event.target.value,
-                        }))
-                      }
-                      placeholder="One argument per line"
+                    type="button"
+                    onClick={() => setSelectedName(server.name)}
+                  >
+                    <div>
+                      <strong>{server.name}</strong>
+                      <small>{server.summary}</small>
+                    </div>
+                    <BooleanPill
+                      value={server.enabled}
+                      trueLabel="active"
+                      falseLabel="inactive"
                     />
-                  </label>
-                  <label className="field">
-                    <span>Working directory</span>
-                    <input
-                      value={draft.cwd}
-                      onChange={(event) =>
-                        setDraft((current) => ({
-                          ...current,
-                          cwd: event.target.value,
-                        }))
-                      }
-                      placeholder="/workspace"
-                    />
-                  </label>
-                </div>
-                <label className="field">
-                  <span>Environment JSON</span>
-                  <textarea
-                    rows={5}
-                    value={draft.envJson}
-                    onChange={(event) =>
-                      setDraft((current) => ({
-                        ...current,
-                        envJson: event.target.value,
-                      }))
-                    }
-                    placeholder='{"GITHUB_TOKEN":"..."}'
-                  />
-                </label>
-              </>
+                  </button>
+                ))}
+              </div>
             ) : (
-              <>
-                <label className="field">
-                  <span>URL</span>
-                  <input
-                    value={draft.url}
-                    onChange={(event) =>
-                      setDraft((current) => ({
-                        ...current,
-                        url: event.target.value,
-                      }))
-                    }
-                    placeholder="https://example.test/mcp"
-                  />
-                </label>
-                <label className="field">
-                  <span>Headers JSON</span>
-                  <textarea
-                    rows={5}
-                    value={draft.headersJson}
-                    onChange={(event) =>
-                      setDraft((current) => ({
-                        ...current,
-                        headersJson: event.target.value,
-                      }))
-                    }
-                    placeholder='{"Authorization":"Bearer ..."}'
-                  />
-                </label>
-              </>
+              <div className="empty-state">
+                No MCP servers are configured yet.
+              </div>
             )}
+          </CardContent>
+        </Card>
 
-            <div className="button-row">
-              <button
-                className="primary-button"
-                type="button"
-                disabled={saveMutation.isPending}
-                onClick={() => saveMutation.mutate()}
-              >
-                {saveMutation.isPending ? 'Saving...' : 'Save server'}
-              </button>
-              {selectedServer ? (
+        <Card variant="muted">
+          <CardHeader>
+            <CardTitle>Server editor</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="stack-form">
+              <div className="field-grid">
+                <label className="field">
+                  <span>Name</span>
+                  <input
+                    value={draft.name}
+                    onChange={(event) =>
+                      setDraft((current) => ({
+                        ...current,
+                        name: event.target.value,
+                      }))
+                    }
+                    placeholder="github"
+                  />
+                </label>
+                <label className="field">
+                  <span>Transport</span>
+                  <select
+                    value={draft.transport}
+                    onChange={(event) =>
+                      setDraft((current) => ({
+                        ...current,
+                        transport: event.target.value as McpDraft['transport'],
+                      }))
+                    }
+                  >
+                    <option value="stdio">stdio</option>
+                    <option value="http">http</option>
+                    <option value="sse">sse</option>
+                  </select>
+                </label>
+              </div>
+
+              <BooleanField
+                label="Server state"
+                value={draft.enabled}
+                trueLabel="on"
+                falseLabel="off"
+                onChange={(enabled) =>
+                  setDraft((current) => ({
+                    ...current,
+                    enabled,
+                  }))
+                }
+              />
+
+              {draft.transport === 'stdio' ? (
+                <>
+                  <label className="field">
+                    <span>Command</span>
+                    <input
+                      value={draft.command}
+                      onChange={(event) =>
+                        setDraft((current) => ({
+                          ...current,
+                          command: event.target.value,
+                        }))
+                      }
+                      placeholder="docker"
+                    />
+                  </label>
+                  <div className="field-grid">
+                    <label className="field">
+                      <span>Arguments</span>
+                      <textarea
+                        rows={4}
+                        value={draft.args}
+                        onChange={(event) =>
+                          setDraft((current) => ({
+                            ...current,
+                            args: event.target.value,
+                          }))
+                        }
+                        placeholder="One argument per line"
+                      />
+                    </label>
+                    <label className="field">
+                      <span>Working directory</span>
+                      <input
+                        value={draft.cwd}
+                        onChange={(event) =>
+                          setDraft((current) => ({
+                            ...current,
+                            cwd: event.target.value,
+                          }))
+                        }
+                        placeholder="/workspace"
+                      />
+                    </label>
+                  </div>
+                  <label className="field">
+                    <span>Environment JSON</span>
+                    <textarea
+                      rows={5}
+                      value={draft.envJson}
+                      onChange={(event) =>
+                        setDraft((current) => ({
+                          ...current,
+                          envJson: event.target.value,
+                        }))
+                      }
+                      placeholder='{"GITHUB_TOKEN":"..."}'
+                    />
+                  </label>
+                </>
+              ) : (
+                <>
+                  <label className="field">
+                    <span>URL</span>
+                    <input
+                      value={draft.url}
+                      onChange={(event) =>
+                        setDraft((current) => ({
+                          ...current,
+                          url: event.target.value,
+                        }))
+                      }
+                      placeholder="https://example.test/mcp"
+                    />
+                  </label>
+                  <label className="field">
+                    <span>Headers JSON</span>
+                    <textarea
+                      rows={5}
+                      value={draft.headersJson}
+                      onChange={(event) =>
+                        setDraft((current) => ({
+                          ...current,
+                          headersJson: event.target.value,
+                        }))
+                      }
+                      placeholder='{"Authorization":"Bearer ..."}'
+                    />
+                  </label>
+                </>
+              )}
+
+              <div className="button-row">
                 <button
-                  className="danger-button"
+                  className="primary-button"
                   type="button"
-                  disabled={deleteMutation.isPending}
-                  onClick={() => deleteMutation.mutate()}
+                  disabled={saveMutation.isPending}
+                  onClick={() => saveMutation.mutate()}
                 >
-                  {deleteMutation.isPending ? 'Deleting...' : 'Delete server'}
+                  {saveMutation.isPending ? 'Saving...' : 'Save server'}
                 </button>
+                {selectedServer ? (
+                  <button
+                    className="danger-button"
+                    type="button"
+                    disabled={deleteMutation.isPending}
+                    onClick={() => deleteMutation.mutate()}
+                  >
+                    {deleteMutation.isPending ? 'Deleting...' : 'Delete server'}
+                  </button>
+                ) : null}
+              </div>
+
+              {selectedServer ? (
+                <div className="summary-block">
+                  <span>Summary</span>
+                  <p>{selectedServer.summary}</p>
+                </div>
               ) : null}
             </div>
-
-            {selectedServer ? (
-              <div className="summary-block">
-                <span>Summary</span>
-                <p>{selectedServer.summary}</p>
-              </div>
-            ) : null}
-          </div>
-        </Panel>
+          </CardContent>
+        </Card>
       </div>
     </div>
   );

--- a/console/src/routes/models.tsx
+++ b/console/src/routes/models.tsx
@@ -2,13 +2,15 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { fetchModels, saveModels } from '../api/client';
 import { useAuth } from '../auth';
-import { useToast } from '../components/toast';
 import {
-  PageHeader,
-  Panel,
-  SortableHeader,
-  useSortableRows,
-} from '../components/ui';
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../components/card';
+import { useToast } from '../components/toast';
+import { PageHeader, SortableHeader, useSortableRows } from '../components/ui';
 import { getErrorMessage } from '../lib/error-message';
 import {
   formatCompactNumber,
@@ -223,213 +225,237 @@ export function ModelsPage() {
       />
 
       <div className="two-column-grid">
-        <Panel title="Provider status">
-          <div className="list-stack">
-            {providerEntries.map(({ name, status }) => (
-              <div className="list-row" key={name}>
-                <div>
-                  <strong>{name}</strong>
-                  <small>
-                    {status?.reachable
-                      ? `${status.detail || (typeof status.latencyMs === 'number' ? `${status.latencyMs}ms` : 'ready')} · ${status.modelCount ?? 0} models`
-                      : status
-                        ? status.error || 'unreachable'
-                        : 'Visible in catalog · no live health data'}
-                  </small>
-                </div>
-                <span
-                  className={
-                    status?.reachable
-                      ? 'list-status list-status-success'
-                      : status
-                        ? 'list-status list-status-danger'
-                        : 'list-status'
-                  }
-                >
+        <Card>
+          <CardHeader>
+            <CardTitle>Provider status</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="list-stack">
+              {providerEntries.map(({ name, status }) => (
+                <div className="list-row" key={name}>
+                  <div>
+                    <strong>{name}</strong>
+                    <small>
+                      {status?.reachable
+                        ? `${status.detail || (typeof status.latencyMs === 'number' ? `${status.latencyMs}ms` : 'ready')} · ${status.modelCount ?? 0} models`
+                        : status
+                          ? status.error || 'unreachable'
+                          : 'Visible in catalog · no live health data'}
+                    </small>
+                  </div>
                   <span
                     className={
                       status?.reachable
-                        ? 'status-dot status-dot-success'
+                        ? 'list-status list-status-success'
                         : status
-                          ? 'status-dot status-dot-danger'
-                          : 'status-dot'
+                          ? 'list-status list-status-danger'
+                          : 'list-status'
                     }
-                  />
-                  {status?.reachable ? 'healthy' : status ? 'down' : 'catalog'}
-                </span>
-              </div>
-            ))}
-            {providerEntries.length === 0 ? (
-              <div className="empty-state">
-                No provider health checks available.
-              </div>
-            ) : null}
-          </div>
-        </Panel>
+                  >
+                    <span
+                      className={
+                        status?.reachable
+                          ? 'status-dot status-dot-success'
+                          : status
+                            ? 'status-dot status-dot-danger'
+                            : 'status-dot'
+                      }
+                    />
+                    {status?.reachable
+                      ? 'healthy'
+                      : status
+                        ? 'down'
+                        : 'catalog'}
+                  </span>
+                </div>
+              ))}
+              {providerEntries.length === 0 ? (
+                <div className="empty-state">
+                  No provider health checks available.
+                </div>
+              ) : null}
+            </div>
+          </CardContent>
+        </Card>
 
-        <Panel title="Selection" accent="warm">
+        <Card variant="muted">
+          <CardHeader>
+            <CardTitle>Selection</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {modelsQuery.isLoading ? (
+              <div className="empty-state">Loading model catalog...</div>
+            ) : (
+              <div className="stack-form">
+                <label className="field">
+                  <span>Default model</span>
+                  <select
+                    value={draft.defaultModel}
+                    onChange={(event) =>
+                      setDraft((current) => ({
+                        ...current,
+                        defaultModel: event.target.value,
+                      }))
+                    }
+                  >
+                    <option value="">Select model</option>
+                    {(modelsQuery.data?.models || []).map((model) => (
+                      <option key={model.id} value={model.id}>
+                        {model.id}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <div className="button-row">
+                  <button
+                    className="primary-button"
+                    type="button"
+                    disabled={saveMutation.isPending}
+                    onClick={() => saveMutation.mutate()}
+                  >
+                    {saveMutation.isPending ? 'Saving...' : 'Save selection'}
+                  </button>
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Catalog</CardTitle>
+          <CardDescription>
+            {`${pluralize(models.length, 'model')} visible`}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
           {modelsQuery.isLoading ? (
             <div className="empty-state">Loading model catalog...</div>
           ) : (
-            <div className="stack-form">
-              <label className="field">
-                <span>Default model</span>
-                <select
-                  value={draft.defaultModel}
-                  onChange={(event) =>
-                    setDraft((current) => ({
-                      ...current,
-                      defaultModel: event.target.value,
-                    }))
-                  }
-                >
-                  <option value="">Select model</option>
-                  {(modelsQuery.data?.models || []).map((model) => (
-                    <option key={model.id} value={model.id}>
-                      {model.id}
-                    </option>
+            <div className="table-shell">
+              <table>
+                <thead>
+                  <tr>
+                    <SortableHeader
+                      label="Model"
+                      sortKey="model"
+                      sortState={sortState}
+                      onToggle={toggleSort}
+                    />
+                    <SortableHeader
+                      label="Backend"
+                      sortKey="backend"
+                      sortState={sortState}
+                      onToggle={toggleSort}
+                    />
+                    <SortableHeader
+                      label="Context"
+                      sortKey="context"
+                      sortState={sortState}
+                      onToggle={toggleSort}
+                    />
+                    <SortableHeader
+                      label="Monthly usage"
+                      sortKey="monthlyUsage"
+                      sortState={sortState}
+                      onToggle={toggleSort}
+                    />
+                  </tr>
+                </thead>
+                <tbody>
+                  {models.map((model) => (
+                    <tr key={model.id}>
+                      <td>
+                        <strong>{model.id}</strong>
+                        {formatModelMetadata(model) ? (
+                          <small>{formatModelMetadata(model)}</small>
+                        ) : null}
+                      </td>
+                      <td>{model.backend || 'remote'}</td>
+                      <td>
+                        {model.contextWindow
+                          ? formatCompactNumber(model.contextWindow)
+                          : 'unknown'}
+                      </td>
+                      <td>
+                        {model.usageMonthly ? (
+                          <>
+                            <strong>
+                              {formatCompactNumber(
+                                model.usageMonthly.totalTokens,
+                              )}
+                            </strong>
+                            <small>
+                              {formatTokenBreakdown({
+                                inputTokens:
+                                  model.usageMonthly.totalInputTokens ?? 0,
+                                outputTokens:
+                                  model.usageMonthly.totalOutputTokens ?? 0,
+                              })}
+                            </small>
+                            <small>
+                              {formatUsd(model.usageMonthly.totalCostUsd)} ·{' '}
+                              {pluralize(model.usageMonthly.callCount, 'call')}
+                            </small>
+                          </>
+                        ) : (
+                          <small>No usage recorded</small>
+                        )}
+                      </td>
+                    </tr>
                   ))}
-                </select>
-              </label>
-
-              <div className="button-row">
-                <button
-                  className="primary-button"
-                  type="button"
-                  disabled={saveMutation.isPending}
-                  onClick={() => saveMutation.mutate()}
-                >
-                  {saveMutation.isPending ? 'Saving...' : 'Save selection'}
-                </button>
-              </div>
+                  {models.length === 0 ? (
+                    <tr>
+                      <td colSpan={4}>
+                        <div className="empty-state">
+                          No models match this filter.
+                        </div>
+                      </td>
+                    </tr>
+                  ) : null}
+                </tbody>
+              </table>
             </div>
           )}
-        </Panel>
-      </div>
-
-      <Panel
-        title="Catalog"
-        subtitle={`${pluralize(models.length, 'model')} visible`}
-      >
-        {modelsQuery.isLoading ? (
-          <div className="empty-state">Loading model catalog...</div>
-        ) : (
-          <div className="table-shell">
-            <table>
-              <thead>
-                <tr>
-                  <SortableHeader
-                    label="Model"
-                    sortKey="model"
-                    sortState={sortState}
-                    onToggle={toggleSort}
-                  />
-                  <SortableHeader
-                    label="Backend"
-                    sortKey="backend"
-                    sortState={sortState}
-                    onToggle={toggleSort}
-                  />
-                  <SortableHeader
-                    label="Context"
-                    sortKey="context"
-                    sortState={sortState}
-                    onToggle={toggleSort}
-                  />
-                  <SortableHeader
-                    label="Monthly usage"
-                    sortKey="monthlyUsage"
-                    sortState={sortState}
-                    onToggle={toggleSort}
-                  />
-                </tr>
-              </thead>
-              <tbody>
-                {models.map((model) => (
-                  <tr key={model.id}>
-                    <td>
-                      <strong>{model.id}</strong>
-                      {formatModelMetadata(model) ? (
-                        <small>{formatModelMetadata(model)}</small>
-                      ) : null}
-                    </td>
-                    <td>{model.backend || 'remote'}</td>
-                    <td>
-                      {model.contextWindow
-                        ? formatCompactNumber(model.contextWindow)
-                        : 'unknown'}
-                    </td>
-                    <td>
-                      {model.usageMonthly ? (
-                        <>
-                          <strong>
-                            {formatCompactNumber(
-                              model.usageMonthly.totalTokens,
-                            )}
-                          </strong>
-                          <small>
-                            {formatTokenBreakdown({
-                              inputTokens:
-                                model.usageMonthly.totalInputTokens ?? 0,
-                              outputTokens:
-                                model.usageMonthly.totalOutputTokens ?? 0,
-                            })}
-                          </small>
-                          <small>
-                            {formatUsd(model.usageMonthly.totalCostUsd)} ·{' '}
-                            {pluralize(model.usageMonthly.callCount, 'call')}
-                          </small>
-                        </>
-                      ) : (
-                        <small>No usage recorded</small>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-                {models.length === 0 ? (
-                  <tr>
-                    <td colSpan={4}>
-                      <div className="empty-state">
-                        No models match this filter.
-                      </div>
-                    </td>
-                  </tr>
-                ) : null}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </Panel>
+        </CardContent>
+      </Card>
 
       {modelsWithDailyUsage.length > 0 ? (
-        <Panel
-          title="Recent daily activity"
-          subtitle={`Updated ${formatRelativeTime(new Date().toISOString())}`}
-        >
-          <div className="list-stack">
-            {modelsWithDailyUsage
-              .sort(
-                (left, right) =>
-                  right.usageDaily.totalTokens - left.usageDaily.totalTokens,
-              )
-              .slice(0, 6)
-              .map((model) => (
-                <div className="list-row" key={`${model.id}-daily`}>
-                  <div>
-                    <strong>{model.id}</strong>
-                    <small>
-                      {formatTokenBreakdown({
-                        inputTokens: model.usageDaily.totalInputTokens ?? 0,
-                        outputTokens: model.usageDaily.totalOutputTokens ?? 0,
-                      })}{' '}
-                      · {pluralize(model.usageDaily.callCount, 'call')} today
-                    </small>
+        <Card>
+          <CardHeader>
+            <CardTitle>Recent daily activity</CardTitle>
+            <CardDescription>
+              {`Updated ${formatRelativeTime(new Date().toISOString())}`}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="list-stack">
+              {modelsWithDailyUsage
+                .sort(
+                  (left, right) =>
+                    right.usageDaily.totalTokens - left.usageDaily.totalTokens,
+                )
+                .slice(0, 6)
+                .map((model) => (
+                  <div className="list-row" key={`${model.id}-daily`}>
+                    <div>
+                      <strong>{model.id}</strong>
+                      <small>
+                        {formatTokenBreakdown({
+                          inputTokens: model.usageDaily.totalInputTokens ?? 0,
+                          outputTokens: model.usageDaily.totalOutputTokens ?? 0,
+                        })}{' '}
+                        · {pluralize(model.usageDaily.callCount, 'call')} today
+                      </small>
+                    </div>
+                    <span>{formatUsd(model.usageDaily.totalCostUsd ?? 0)}</span>
                   </div>
-                  <span>{formatUsd(model.usageDaily.totalCostUsd ?? 0)}</span>
-                </div>
-              ))}
-          </div>
-        </Panel>
+                ))}
+            </div>
+          </CardContent>
+        </Card>
       ) : null}
     </div>
   );

--- a/console/src/routes/plugins.tsx
+++ b/console/src/routes/plugins.tsx
@@ -4,10 +4,16 @@ import { fetchPlugins } from '../api/client';
 import type { AdminPlugin } from '../api/types';
 import { useAuth } from '../auth';
 import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../components/card';
+import {
   BooleanPill,
   MetricCard,
   PageHeader,
-  Panel,
   SortableHeader,
   useSortableRows,
 } from '../components/ui';
@@ -150,142 +156,152 @@ export function PluginsPage() {
       </div>
 
       <div className="two-column-grid">
-        <Panel
-          title="Registry"
-          subtitle={`${plugins.length} plugin${plugins.length === 1 ? '' : 's'} visible`}
-        >
-          {pluginsQuery.isLoading ? (
-            <div className="empty-state">Loading plugins...</div>
-          ) : plugins.length === 0 ? (
-            <div className="empty-state">No plugins match this filter.</div>
-          ) : (
-            <div className="table-shell">
-              <table>
-                <thead>
-                  <tr>
-                    <SortableHeader
-                      label="Plugin"
-                      sortKey="plugin"
-                      sortState={sortState}
-                      onToggle={toggleSort}
-                    />
-                    <SortableHeader
-                      label="Source"
-                      sortKey="source"
-                      sortState={sortState}
-                      onToggle={toggleSort}
-                    />
-                    <SortableHeader
-                      label="Enabled"
-                      sortKey="enabled"
-                      sortState={sortState}
-                      onToggle={toggleSort}
-                    />
-                    <SortableHeader
-                      label="Status"
-                      sortKey="status"
-                      sortState={sortState}
-                      onToggle={toggleSort}
-                    />
-                    <SortableHeader
-                      label="Commands"
-                      sortKey="commands"
-                      sortState={sortState}
-                      onToggle={toggleSort}
-                    />
-                    <SortableHeader
-                      label="Tools"
-                      sortKey="tools"
-                      sortState={sortState}
-                      onToggle={toggleSort}
-                    />
-                    <SortableHeader
-                      label="Hooks"
-                      sortKey="hooks"
-                      sortState={sortState}
-                      onToggle={toggleSort}
-                    />
-                  </tr>
-                </thead>
-                <tbody>
-                  {plugins.map((plugin) => (
-                    <tr key={plugin.id}>
-                      <td>
-                        <strong>{plugin.name || plugin.id}</strong>
-                        <small>
-                          {plugin.id}
-                          {plugin.version ? ` · v${plugin.version}` : ''}
-                        </small>
-                        {plugin.description ? (
-                          <small>{plugin.description}</small>
-                        ) : null}
-                        {plugin.error ? <small>{plugin.error}</small> : null}
-                      </td>
-                      <td>{plugin.source}</td>
-                      <td>
-                        <BooleanPill
-                          value={plugin.enabled}
-                          trueLabel="enabled"
-                          falseLabel="disabled"
-                        />
-                      </td>
-                      <td>
-                        <BooleanPill
-                          value={plugin.status === 'loaded'}
-                          trueLabel="loaded"
-                          falseLabel="failed"
-                        />
-                      </td>
-                      <td>
-                        <strong>{plugin.commands.length}</strong>
-                        <small>{formatList(plugin.commands)}</small>
-                      </td>
-                      <td>
-                        <strong>{plugin.tools.length}</strong>
-                        <small>{formatList(plugin.tools)}</small>
-                      </td>
-                      <td>
-                        <strong>{plugin.hooks.length}</strong>
-                        <small>{formatList(plugin.hooks)}</small>
-                      </td>
+        <Card>
+          <CardHeader>
+            <CardTitle>Registry</CardTitle>
+            <CardDescription>
+              {`${plugins.length} plugin${plugins.length === 1 ? '' : 's'} visible`}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {pluginsQuery.isLoading ? (
+              <div className="empty-state">Loading plugins...</div>
+            ) : plugins.length === 0 ? (
+              <div className="empty-state">No plugins match this filter.</div>
+            ) : (
+              <div className="table-shell">
+                <table>
+                  <thead>
+                    <tr>
+                      <SortableHeader
+                        label="Plugin"
+                        sortKey="plugin"
+                        sortState={sortState}
+                        onToggle={toggleSort}
+                      />
+                      <SortableHeader
+                        label="Source"
+                        sortKey="source"
+                        sortState={sortState}
+                        onToggle={toggleSort}
+                      />
+                      <SortableHeader
+                        label="Enabled"
+                        sortKey="enabled"
+                        sortState={sortState}
+                        onToggle={toggleSort}
+                      />
+                      <SortableHeader
+                        label="Status"
+                        sortKey="status"
+                        sortState={sortState}
+                        onToggle={toggleSort}
+                      />
+                      <SortableHeader
+                        label="Commands"
+                        sortKey="commands"
+                        sortState={sortState}
+                        onToggle={toggleSort}
+                      />
+                      <SortableHeader
+                        label="Tools"
+                        sortKey="tools"
+                        sortState={sortState}
+                        onToggle={toggleSort}
+                      />
+                      <SortableHeader
+                        label="Hooks"
+                        sortKey="hooks"
+                        sortState={sortState}
+                        onToggle={toggleSort}
+                      />
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </Panel>
+                  </thead>
+                  <tbody>
+                    {plugins.map((plugin) => (
+                      <tr key={plugin.id}>
+                        <td>
+                          <strong>{plugin.name || plugin.id}</strong>
+                          <small>
+                            {plugin.id}
+                            {plugin.version ? ` · v${plugin.version}` : ''}
+                          </small>
+                          {plugin.description ? (
+                            <small>{plugin.description}</small>
+                          ) : null}
+                          {plugin.error ? <small>{plugin.error}</small> : null}
+                        </td>
+                        <td>{plugin.source}</td>
+                        <td>
+                          <BooleanPill
+                            value={plugin.enabled}
+                            trueLabel="enabled"
+                            falseLabel="disabled"
+                          />
+                        </td>
+                        <td>
+                          <BooleanPill
+                            value={plugin.status === 'loaded'}
+                            trueLabel="loaded"
+                            falseLabel="failed"
+                          />
+                        </td>
+                        <td>
+                          <strong>{plugin.commands.length}</strong>
+                          <small>{formatList(plugin.commands)}</small>
+                        </td>
+                        <td>
+                          <strong>{plugin.tools.length}</strong>
+                          <small>{formatList(plugin.tools)}</small>
+                        </td>
+                        <td>
+                          <strong>{plugin.hooks.length}</strong>
+                          <small>{formatList(plugin.hooks)}</small>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
 
-        <Panel title="Failures" accent="warm">
-          {pluginsQuery.isLoading ? (
-            <div className="empty-state">Loading plugin status...</div>
-          ) : failedPlugins.length > 0 ? (
-            <div className="list-stack selectable-list">
-              {failedPlugins.map((plugin) => (
-                <div className="list-row" key={plugin.id}>
-                  <div>
-                    <strong>{plugin.name || plugin.id}</strong>
-                    <small>
-                      {plugin.id}
-                      {plugin.version ? ` · v${plugin.version}` : ''}
-                    </small>
-                    <small>
-                      {plugin.error || 'Unknown plugin load error.'}
-                    </small>
+        <Card variant="muted">
+          <CardHeader>
+            <CardTitle>Failures</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {pluginsQuery.isLoading ? (
+              <div className="empty-state">Loading plugin status...</div>
+            ) : failedPlugins.length > 0 ? (
+              <div className="list-stack selectable-list">
+                {failedPlugins.map((plugin) => (
+                  <div className="list-row" key={plugin.id}>
+                    <div>
+                      <strong>{plugin.name || plugin.id}</strong>
+                      <small>
+                        {plugin.id}
+                        {plugin.version ? ` · v${plugin.version}` : ''}
+                      </small>
+                      <small>
+                        {plugin.error || 'Unknown plugin load error.'}
+                      </small>
+                    </div>
+                    <span className="list-status list-status-danger">
+                      <span className="status-dot status-dot-danger" />
+                      failed
+                    </span>
                   </div>
-                  <span className="list-status list-status-danger">
-                    <span className="status-dot status-dot-danger" />
-                    failed
-                  </span>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div className="empty-state">
-              No plugin load failures were reported.
-            </div>
-          )}
-        </Panel>
+                ))}
+              </div>
+            ) : (
+              <div className="empty-state">
+                No plugin load failures were reported.
+              </div>
+            )}
+          </CardContent>
+        </Card>
       </div>
     </div>
   );

--- a/console/src/routes/scheduler.tsx
+++ b/console/src/routes/scheduler.tsx
@@ -16,8 +16,15 @@ import type {
   GatewayStatus,
 } from '../api/types';
 import { useAuth } from '../auth';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../components/card';
 import { useToast } from '../components/toast';
-import { BooleanField, BooleanPill, PageHeader, Panel } from '../components/ui';
+import { BooleanField, BooleanPill, PageHeader } from '../components/ui';
 import { getErrorMessage } from '../lib/error-message';
 import { formatDateTime } from '../lib/format';
 import { buildChannelCatalog } from './channels-catalog';
@@ -538,76 +545,81 @@ function SchedulerTaskDetail(props: {
   onDelete: () => void;
 }) {
   return (
-    <Panel title="Task" accent="warm">
-      <div className="stack-form">
-        <div className="key-value-grid">
-          <div>
-            <span>Task</span>
-            <strong>#{props.job.taskId ?? 'n/a'}</strong>
+    <Card variant="muted">
+      <CardHeader>
+        <CardTitle>Task</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="stack-form">
+          <div className="key-value-grid">
+            <div>
+              <span>Task</span>
+              <strong>#{props.job.taskId ?? 'n/a'}</strong>
+            </div>
+            <div>
+              <span>State</span>
+              <BooleanPill
+                value={props.job.enabled && !props.job.disabled}
+                trueLabel="active"
+                falseLabel="inactive"
+              />
+            </div>
+            <div>
+              <span>Session</span>
+              <strong>{props.job.sessionId || 'n/a'}</strong>
+            </div>
+            <div>
+              <span>Channel</span>
+              <strong>{props.job.channelId || 'n/a'}</strong>
+            </div>
+            <div>
+              <span>Created</span>
+              <strong>{formatDateTime(props.job.createdAt)}</strong>
+            </div>
+            <div>
+              <span>Next run</span>
+              <strong>{formatDateTime(props.job.nextRunAt)}</strong>
+            </div>
+            <div>
+              <span>Last run</span>
+              <strong>{formatDateTime(props.job.lastRun)}</strong>
+            </div>
+            <div>
+              <span>Last status</span>
+              <strong>{props.job.lastStatus || 'n/a'}</strong>
+            </div>
           </div>
-          <div>
-            <span>State</span>
-            <BooleanPill
-              value={props.job.enabled && !props.job.disabled}
-              trueLabel="active"
-              falseLabel="inactive"
-            />
-          </div>
-          <div>
-            <span>Session</span>
-            <strong>{props.job.sessionId || 'n/a'}</strong>
-          </div>
-          <div>
-            <span>Channel</span>
-            <strong>{props.job.channelId || 'n/a'}</strong>
-          </div>
-          <div>
-            <span>Created</span>
-            <strong>{formatDateTime(props.job.createdAt)}</strong>
-          </div>
-          <div>
-            <span>Next run</span>
-            <strong>{formatDateTime(props.job.nextRunAt)}</strong>
-          </div>
-          <div>
-            <span>Last run</span>
-            <strong>{formatDateTime(props.job.lastRun)}</strong>
-          </div>
-          <div>
-            <span>Last status</span>
-            <strong>{props.job.lastStatus || 'n/a'}</strong>
+
+          <label className="field">
+            <span>Message</span>
+            <textarea readOnly rows={6} value={props.job.action.message} />
+          </label>
+
+          <div className="button-row">
+            <button
+              className="ghost-button"
+              type="button"
+              disabled={props.pausePending}
+              onClick={props.onPauseToggle}
+            >
+              {props.pausePending
+                ? 'Updating...'
+                : props.job.disabled
+                  ? 'Resume task'
+                  : 'Pause task'}
+            </button>
+            <button
+              className="danger-button"
+              type="button"
+              disabled={props.deletePending}
+              onClick={props.onDelete}
+            >
+              {props.deletePending ? 'Deleting...' : 'Delete task'}
+            </button>
           </div>
         </div>
-
-        <label className="field">
-          <span>Message</span>
-          <textarea readOnly rows={6} value={props.job.action.message} />
-        </label>
-
-        <div className="button-row">
-          <button
-            className="ghost-button"
-            type="button"
-            disabled={props.pausePending}
-            onClick={props.onPauseToggle}
-          >
-            {props.pausePending
-              ? 'Updating...'
-              : props.job.disabled
-                ? 'Resume task'
-                : 'Pause task'}
-          </button>
-          <button
-            className="danger-button"
-            type="button"
-            disabled={props.deletePending}
-            onClick={props.onDelete}
-          >
-            {props.deletePending ? 'Deleting...' : 'Delete task'}
-          </button>
-        </div>
-      </div>
-    </Panel>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -628,388 +640,393 @@ function SchedulerJobEditor(props: {
   const { draft, selectedJob } = props;
 
   return (
-    <Panel title="Job" accent="warm">
-      <div className="stack-form">
-        <div className="field-grid">
-          <label className="field">
-            <span>ID</span>
-            <input
-              value={draft.id}
-              onChange={(event) =>
-                props.onDraftChange((current) => ({
-                  ...current,
-                  id: event.target.value,
-                }))
-              }
-              placeholder="Auto-generated from name if blank"
-            />
-          </label>
-          <label className="field">
-            <span>Name</span>
-            <input
-              value={draft.name}
-              onChange={(event) =>
-                props.onDraftChange((current) => ({
-                  ...current,
-                  name: event.target.value,
-                }))
-              }
-              placeholder="Nightly research"
-            />
-          </label>
-        </div>
-
-        <label className="field">
-          <span>Description</span>
-          <input
-            value={draft.description}
-            onChange={(event) =>
-              props.onDraftChange((current) => ({
-                ...current,
-                description: event.target.value,
-              }))
-            }
-            placeholder="Optional"
-          />
-        </label>
-
-        <div className="field-grid">
-          <label className="field">
-            <span>Status</span>
-            <select
-              value={draft.boardStatus}
-              onChange={(event) =>
-                props.onDraftChange((current) => ({
-                  ...current,
-                  boardStatus: event.target
-                    .value as SchedulerDraft['boardStatus'],
-                }))
-              }
-            >
-              <option value="backlog">backlog</option>
-              <option value="in_progress">in progress</option>
-              <option value="review">review</option>
-              <option value="done">done</option>
-              <option value="cancelled">cancelled</option>
-            </select>
-          </label>
-          <BooleanField
-            label="State"
-            value={draft.enabled}
-            trueLabel="on"
-            falseLabel="off"
-            onChange={(enabled) =>
-              props.onDraftChange((current) => ({
-                ...current,
-                enabled,
-              }))
-            }
-          />
-        </div>
-
-        <div className="field-grid">
-          <label className="field">
-            <span>Schedule</span>
-            <select
-              value={draft.scheduleKind}
-              onChange={(event) =>
-                props.onDraftChange((current) => ({
-                  ...current,
-                  scheduleKind: event.target
-                    .value as SchedulerDraft['scheduleKind'],
-                  boardStatus:
-                    event.target.value === 'one_shot'
-                      ? 'backlog'
-                      : current.boardStatus,
-                  maxRetries:
-                    event.target.value === 'one_shot'
-                      ? current.maxRetries.trim() || '3'
-                      : current.maxRetries,
-                }))
-              }
-            >
-              <option value="cron">cron</option>
-              <option value="every">every</option>
-              <option value="at">at</option>
-              <option value="one_shot">one shot</option>
-            </select>
-          </label>
-          {draft.scheduleKind !== 'one_shot' ? (
-            <label className="field">
-              <span>Timezone</span>
-              <input
-                value={draft.scheduleTz}
-                onChange={(event) =>
-                  props.onDraftChange((current) => ({
-                    ...current,
-                    scheduleTz: event.target.value,
-                  }))
-                }
-                placeholder="Europe/Berlin"
-              />
-            </label>
-          ) : null}
-        </div>
-
-        {draft.scheduleKind === 'cron' ? (
-          <label className="field">
-            <span>Cron</span>
-            <input
-              value={draft.scheduleExpr}
-              onChange={(event) =>
-                props.onDraftChange((current) => ({
-                  ...current,
-                  scheduleExpr: event.target.value,
-                }))
-              }
-              placeholder="0 * * * *"
-            />
-          </label>
-        ) : null}
-
-        {draft.scheduleKind === 'every' ? (
-          <label className="field">
-            <span>Every ms</span>
-            <input
-              value={draft.scheduleEveryMs}
-              onChange={(event) =>
-                props.onDraftChange((current) => ({
-                  ...current,
-                  scheduleEveryMs: event.target.value,
-                }))
-              }
-              placeholder="60000"
-            />
-          </label>
-        ) : null}
-
-        {draft.scheduleKind === 'at' ? (
-          <label className="field">
-            <span>Run at</span>
-            <input
-              type="datetime-local"
-              value={draft.scheduleAt}
-              onChange={(event) =>
-                props.onDraftChange((current) => ({
-                  ...current,
-                  scheduleAt: event.target.value,
-                }))
-              }
-            />
-          </label>
-        ) : null}
-
-        {draft.scheduleKind === 'one_shot' ? (
-          <label className="field">
-            <span>Retries after failure</span>
-            <input
-              type="number"
-              min="0"
-              max="100"
-              step="1"
-              value={draft.maxRetries}
-              onChange={(event) =>
-                props.onDraftChange((current) => ({
-                  ...current,
-                  maxRetries: event.target.value,
-                }))
-              }
-              placeholder="3"
-            />
-          </label>
-        ) : null}
-
-        <div className="field-grid">
-          <label className="field">
-            <span>Action</span>
-            <select
-              value={draft.actionKind}
-              onChange={(event) =>
-                props.onDraftChange((current) => ({
-                  ...current,
-                  actionKind: event.target
-                    .value as SchedulerDraft['actionKind'],
-                }))
-              }
-            >
-              <option value="agent_turn">agent_turn</option>
-              <option value="system_event">system_event</option>
-            </select>
-          </label>
-          <label className="field">
-            <span>Delivery</span>
-            <select
-              value={draft.deliveryKind}
-              onChange={(event) =>
-                props.onDraftChange((current) => ({
-                  ...current,
-                  deliveryKind: event.target
-                    .value as SchedulerDraft['deliveryKind'],
-                }))
-              }
-            >
-              <option value="channel">channel</option>
-              <option value="last-channel">last-channel</option>
-              <option value="webhook">webhook</option>
-            </select>
-          </label>
-        </div>
-
-        <label className="field">
-          <span>Message</span>
-          <textarea
-            rows={4}
-            value={draft.actionMessage}
-            onChange={(event) =>
-              props.onDraftChange((current) => ({
-                ...current,
-                actionMessage: event.target.value,
-              }))
-            }
-            placeholder="Prompt or system-event message"
-          />
-        </label>
-
-        {draft.deliveryKind === 'channel' ? (
+    <Card variant="muted">
+      <CardHeader>
+        <CardTitle>Job</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="stack-form">
           <div className="field-grid">
             <label className="field">
-              <span>Channel type</span>
-              <select
-                value={draft.deliveryChannel}
+              <span>ID</span>
+              <input
+                value={draft.id}
                 onChange={(event) =>
                   props.onDraftChange((current) => ({
                     ...current,
-                    deliveryChannel: event.target.value,
-                    deliveryTo: '',
+                    id: event.target.value,
+                  }))
+                }
+                placeholder="Auto-generated from name if blank"
+              />
+            </label>
+            <label className="field">
+              <span>Name</span>
+              <input
+                value={draft.name}
+                onChange={(event) =>
+                  props.onDraftChange((current) => ({
+                    ...current,
+                    name: event.target.value,
+                  }))
+                }
+                placeholder="Nightly research"
+              />
+            </label>
+          </div>
+
+          <label className="field">
+            <span>Description</span>
+            <input
+              value={draft.description}
+              onChange={(event) =>
+                props.onDraftChange((current) => ({
+                  ...current,
+                  description: event.target.value,
+                }))
+              }
+              placeholder="Optional"
+            />
+          </label>
+
+          <div className="field-grid">
+            <label className="field">
+              <span>Status</span>
+              <select
+                value={draft.boardStatus}
+                onChange={(event) =>
+                  props.onDraftChange((current) => ({
+                    ...current,
+                    boardStatus: event.target
+                      .value as SchedulerDraft['boardStatus'],
                   }))
                 }
               >
-                {props.channelOptions.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
+                <option value="backlog">backlog</option>
+                <option value="in_progress">in progress</option>
+                <option value="review">review</option>
+                <option value="done">done</option>
+                <option value="cancelled">cancelled</option>
               </select>
             </label>
-            {props.targetControl.kind === 'select' ? (
+            <BooleanField
+              label="State"
+              value={draft.enabled}
+              trueLabel="on"
+              falseLabel="off"
+              onChange={(enabled) =>
+                props.onDraftChange((current) => ({
+                  ...current,
+                  enabled,
+                }))
+              }
+            />
+          </div>
+
+          <div className="field-grid">
+            <label className="field">
+              <span>Schedule</span>
+              <select
+                value={draft.scheduleKind}
+                onChange={(event) =>
+                  props.onDraftChange((current) => ({
+                    ...current,
+                    scheduleKind: event.target
+                      .value as SchedulerDraft['scheduleKind'],
+                    boardStatus:
+                      event.target.value === 'one_shot'
+                        ? 'backlog'
+                        : current.boardStatus,
+                    maxRetries:
+                      event.target.value === 'one_shot'
+                        ? current.maxRetries.trim() || '3'
+                        : current.maxRetries,
+                  }))
+                }
+              >
+                <option value="cron">cron</option>
+                <option value="every">every</option>
+                <option value="at">at</option>
+                <option value="one_shot">one shot</option>
+              </select>
+            </label>
+            {draft.scheduleKind !== 'one_shot' ? (
               <label className="field">
-                <span>{props.targetControl.label}</span>
-                <select
-                  value={props.targetControl.value}
+                <span>Timezone</span>
+                <input
+                  value={draft.scheduleTz}
                   onChange={(event) =>
                     props.onDraftChange((current) => ({
                       ...current,
-                      deliveryTo: event.target.value,
+                      scheduleTz: event.target.value,
+                    }))
+                  }
+                  placeholder="Europe/Berlin"
+                />
+              </label>
+            ) : null}
+          </div>
+
+          {draft.scheduleKind === 'cron' ? (
+            <label className="field">
+              <span>Cron</span>
+              <input
+                value={draft.scheduleExpr}
+                onChange={(event) =>
+                  props.onDraftChange((current) => ({
+                    ...current,
+                    scheduleExpr: event.target.value,
+                  }))
+                }
+                placeholder="0 * * * *"
+              />
+            </label>
+          ) : null}
+
+          {draft.scheduleKind === 'every' ? (
+            <label className="field">
+              <span>Every ms</span>
+              <input
+                value={draft.scheduleEveryMs}
+                onChange={(event) =>
+                  props.onDraftChange((current) => ({
+                    ...current,
+                    scheduleEveryMs: event.target.value,
+                  }))
+                }
+                placeholder="60000"
+              />
+            </label>
+          ) : null}
+
+          {draft.scheduleKind === 'at' ? (
+            <label className="field">
+              <span>Run at</span>
+              <input
+                type="datetime-local"
+                value={draft.scheduleAt}
+                onChange={(event) =>
+                  props.onDraftChange((current) => ({
+                    ...current,
+                    scheduleAt: event.target.value,
+                  }))
+                }
+              />
+            </label>
+          ) : null}
+
+          {draft.scheduleKind === 'one_shot' ? (
+            <label className="field">
+              <span>Retries after failure</span>
+              <input
+                type="number"
+                min="0"
+                max="100"
+                step="1"
+                value={draft.maxRetries}
+                onChange={(event) =>
+                  props.onDraftChange((current) => ({
+                    ...current,
+                    maxRetries: event.target.value,
+                  }))
+                }
+                placeholder="3"
+              />
+            </label>
+          ) : null}
+
+          <div className="field-grid">
+            <label className="field">
+              <span>Action</span>
+              <select
+                value={draft.actionKind}
+                onChange={(event) =>
+                  props.onDraftChange((current) => ({
+                    ...current,
+                    actionKind: event.target
+                      .value as SchedulerDraft['actionKind'],
+                  }))
+                }
+              >
+                <option value="agent_turn">agent_turn</option>
+                <option value="system_event">system_event</option>
+              </select>
+            </label>
+            <label className="field">
+              <span>Delivery</span>
+              <select
+                value={draft.deliveryKind}
+                onChange={(event) =>
+                  props.onDraftChange((current) => ({
+                    ...current,
+                    deliveryKind: event.target
+                      .value as SchedulerDraft['deliveryKind'],
+                  }))
+                }
+              >
+                <option value="channel">channel</option>
+                <option value="last-channel">last-channel</option>
+                <option value="webhook">webhook</option>
+              </select>
+            </label>
+          </div>
+
+          <label className="field">
+            <span>Message</span>
+            <textarea
+              rows={4}
+              value={draft.actionMessage}
+              onChange={(event) =>
+                props.onDraftChange((current) => ({
+                  ...current,
+                  actionMessage: event.target.value,
+                }))
+              }
+              placeholder="Prompt or system-event message"
+            />
+          </label>
+
+          {draft.deliveryKind === 'channel' ? (
+            <div className="field-grid">
+              <label className="field">
+                <span>Channel type</span>
+                <select
+                  value={draft.deliveryChannel}
+                  onChange={(event) =>
+                    props.onDraftChange((current) => ({
+                      ...current,
+                      deliveryChannel: event.target.value,
+                      deliveryTo: '',
                     }))
                   }
                 >
-                  {props.targetControl.options.map((option) => (
+                  {props.channelOptions.map((option) => (
                     <option key={option.value} value={option.value}>
                       {option.label}
                     </option>
                   ))}
                 </select>
               </label>
-            ) : null}
-            {props.targetControl.kind === 'input' ? (
-              <label className="field">
-                <span>{props.targetControl.label}</span>
-                <input
-                  value={props.targetControl.value}
-                  onChange={(event) =>
-                    props.onDraftChange((current) => ({
-                      ...current,
-                      deliveryTo: event.target.value,
-                    }))
-                  }
-                  placeholder={props.targetControl.placeholder}
-                />
-              </label>
-            ) : null}
-          </div>
-        ) : null}
+              {props.targetControl.kind === 'select' ? (
+                <label className="field">
+                  <span>{props.targetControl.label}</span>
+                  <select
+                    value={props.targetControl.value}
+                    onChange={(event) =>
+                      props.onDraftChange((current) => ({
+                        ...current,
+                        deliveryTo: event.target.value,
+                      }))
+                    }
+                  >
+                    {props.targetControl.options.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              ) : null}
+              {props.targetControl.kind === 'input' ? (
+                <label className="field">
+                  <span>{props.targetControl.label}</span>
+                  <input
+                    value={props.targetControl.value}
+                    onChange={(event) =>
+                      props.onDraftChange((current) => ({
+                        ...current,
+                        deliveryTo: event.target.value,
+                      }))
+                    }
+                    placeholder={props.targetControl.placeholder}
+                  />
+                </label>
+              ) : null}
+            </div>
+          ) : null}
 
-        {draft.deliveryKind === 'webhook' ? (
-          <label className="field">
-            <span>Webhook URL</span>
-            <input
-              value={draft.deliveryWebhookUrl}
-              onChange={(event) =>
-                props.onDraftChange((current) => ({
-                  ...current,
-                  deliveryWebhookUrl: event.target.value,
-                }))
-              }
-              placeholder="https://example.test/hook"
-            />
-          </label>
-        ) : null}
+          {draft.deliveryKind === 'webhook' ? (
+            <label className="field">
+              <span>Webhook URL</span>
+              <input
+                value={draft.deliveryWebhookUrl}
+                onChange={(event) =>
+                  props.onDraftChange((current) => ({
+                    ...current,
+                    deliveryWebhookUrl: event.target.value,
+                  }))
+                }
+                placeholder="https://example.test/hook"
+              />
+            </label>
+          ) : null}
 
-        {selectedJob ? (
-          <div className="key-value-grid">
-            <div>
-              <span>Next run</span>
-              <strong>{formatDateTime(selectedJob.nextRunAt)}</strong>
-            </div>
-            <div>
-              <span>Last run</span>
-              <strong>{formatDateTime(selectedJob.lastRun)}</strong>
-            </div>
-            <div>
-              <span>Last status</span>
-              <strong>{selectedJob.lastStatus || 'n/a'}</strong>
-            </div>
-            <div>
-              <span>Errors</span>
-              <strong>{selectedJob.consecutiveErrors}</strong>
-            </div>
-          </div>
-        ) : null}
-
-        <div className="button-row">
-          <button
-            className="primary-button"
-            type="button"
-            disabled={props.savePending}
-            onClick={props.onSave}
-          >
-            {props.savePending ? 'Saving...' : 'Save job'}
-          </button>
-          <button
-            className="ghost-button"
-            type="button"
-            disabled={props.savePending}
-            onClick={props.onCancel}
-          >
-            Cancel
-          </button>
           {selectedJob ? (
+            <div className="key-value-grid">
+              <div>
+                <span>Next run</span>
+                <strong>{formatDateTime(selectedJob.nextRunAt)}</strong>
+              </div>
+              <div>
+                <span>Last run</span>
+                <strong>{formatDateTime(selectedJob.lastRun)}</strong>
+              </div>
+              <div>
+                <span>Last status</span>
+                <strong>{selectedJob.lastStatus || 'n/a'}</strong>
+              </div>
+              <div>
+                <span>Errors</span>
+                <strong>{selectedJob.consecutiveErrors}</strong>
+              </div>
+            </div>
+          ) : null}
+
+          <div className="button-row">
+            <button
+              className="primary-button"
+              type="button"
+              disabled={props.savePending}
+              onClick={props.onSave}
+            >
+              {props.savePending ? 'Saving...' : 'Save job'}
+            </button>
             <button
               className="ghost-button"
               type="button"
-              disabled={props.pausePending}
-              onClick={props.onPauseToggle}
+              disabled={props.savePending}
+              onClick={props.onCancel}
             >
-              {props.pausePending
-                ? 'Updating...'
-                : selectedJob.disabled
-                  ? 'Resume job'
-                  : 'Pause job'}
+              Cancel
             </button>
-          ) : null}
-          {selectedJob ? (
-            <button
-              className="danger-button"
-              type="button"
-              disabled={props.deletePending}
-              onClick={props.onDelete}
-            >
-              {props.deletePending ? 'Deleting...' : 'Delete job'}
-            </button>
-          ) : null}
+            {selectedJob ? (
+              <button
+                className="ghost-button"
+                type="button"
+                disabled={props.pausePending}
+                onClick={props.onPauseToggle}
+              >
+                {props.pausePending
+                  ? 'Updating...'
+                  : selectedJob.disabled
+                    ? 'Resume job'
+                    : 'Pause job'}
+              </button>
+            ) : null}
+            {selectedJob ? (
+              <button
+                className="danger-button"
+                type="button"
+                disabled={props.deletePending}
+                onClick={props.onDelete}
+              >
+                {props.deletePending ? 'Deleting...' : 'Delete job'}
+              </button>
+            ) : null}
+          </div>
         </div>
-      </div>
-    </Panel>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -1168,44 +1185,49 @@ export function SchedulerPage() {
       />
 
       <div className="two-column-grid">
-        <Panel
-          title="Jobs"
-          subtitle={`${schedulerQuery.data?.jobs.length || 0} item${schedulerQuery.data?.jobs.length === 1 ? '' : 's'}`}
-        >
-          {schedulerQuery.isLoading ? (
-            <div className="empty-state">Loading scheduler items...</div>
-          ) : schedulerQuery.data?.jobs.length ? (
-            <div className="list-stack selectable-list">
-              {schedulerQuery.data.jobs.map((job) => (
-                <button
-                  key={job.id}
-                  className={
-                    job.id === selectedId
-                      ? 'selectable-row active'
-                      : 'selectable-row'
-                  }
-                  type="button"
-                  onClick={() => setSelectedId(job.id)}
-                >
-                  <div>
-                    <strong>{job.name}</strong>
-                    <small>{formatRowMeta(job)}</small>
-                  </div>
-                  <div className="row-status-stack">
-                    <BooleanPill
-                      value={job.enabled && !job.disabled}
-                      trueLabel="active"
-                      falseLabel="inactive"
-                    />
-                    <small>{formatRuntimeState(job)}</small>
-                  </div>
-                </button>
-              ))}
-            </div>
-          ) : (
-            <div className="empty-state">No scheduled work yet.</div>
-          )}
-        </Panel>
+        <Card>
+          <CardHeader>
+            <CardTitle>Jobs</CardTitle>
+            <CardDescription>
+              {`${schedulerQuery.data?.jobs.length || 0} item${schedulerQuery.data?.jobs.length === 1 ? '' : 's'}`}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {schedulerQuery.isLoading ? (
+              <div className="empty-state">Loading scheduler items...</div>
+            ) : schedulerQuery.data?.jobs.length ? (
+              <div className="list-stack selectable-list">
+                {schedulerQuery.data.jobs.map((job) => (
+                  <button
+                    key={job.id}
+                    className={
+                      job.id === selectedId
+                        ? 'selectable-row active'
+                        : 'selectable-row'
+                    }
+                    type="button"
+                    onClick={() => setSelectedId(job.id)}
+                  >
+                    <div>
+                      <strong>{job.name}</strong>
+                      <small>{formatRowMeta(job)}</small>
+                    </div>
+                    <div className="row-status-stack">
+                      <BooleanPill
+                        value={job.enabled && !job.disabled}
+                        trueLabel="active"
+                        falseLabel="inactive"
+                      />
+                      <small>{formatRuntimeState(job)}</small>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <div className="empty-state">No scheduled work yet.</div>
+            )}
+          </CardContent>
+        </Card>
 
         {isTaskJob(selectedJob) ? (
           <SchedulerTaskDetail

--- a/console/src/routes/sessions.tsx
+++ b/console/src/routes/sessions.tsx
@@ -3,6 +3,13 @@ import { useDeferredValue, useEffect, useState } from 'react';
 import { deleteSession, fetchSessions } from '../api/client';
 import { useAuth } from '../auth';
 import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../components/card';
+import {
   Dialog,
   DialogClose,
   DialogContent,
@@ -12,7 +19,7 @@ import {
   DialogTitle,
 } from '../components/dialog';
 import { useToast } from '../components/toast';
-import { BooleanPill, PageHeader, Panel } from '../components/ui';
+import { BooleanPill, PageHeader } from '../components/ui';
 import { getErrorMessage } from '../lib/error-message';
 import { formatRelativeTime } from '../lib/format';
 
@@ -87,105 +94,115 @@ export function SessionsPage() {
       />
 
       <div className="two-column-grid sessions-layout">
-        <Panel
-          title="Session list"
-          subtitle={`${filtered.length} result${filtered.length === 1 ? '' : 's'}`}
-        >
-          {sessionsQuery.isLoading ? (
-            <div className="empty-state">Loading sessions...</div>
-          ) : filtered.length === 0 ? (
-            <div className="empty-state">No sessions match this filter.</div>
-          ) : (
-            <div className="list-stack selectable-list">
-              {filtered.map((session) => (
-                <button
-                  key={session.id}
-                  className={
-                    session.id === selectedSession?.id
-                      ? 'selectable-row active'
-                      : 'selectable-row'
-                  }
-                  type="button"
-                  onClick={() => setSelectedId(session.id)}
-                >
-                  <div className="session-row-main">
-                    <strong>{session.id}</strong>
-                    <small className="session-row-meta">
-                      {session.channelId} · {session.effectiveModel}
-                    </small>
-                  </div>
-                  <span className="session-row-time">
-                    {formatRelativeTime(session.lastActive)}
-                  </span>
-                </button>
-              ))}
-            </div>
-          )}
-        </Panel>
+        <Card>
+          <CardHeader>
+            <CardTitle>Session list</CardTitle>
+            <CardDescription>
+              {`${filtered.length} result${filtered.length === 1 ? '' : 's'}`}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {sessionsQuery.isLoading ? (
+              <div className="empty-state">Loading sessions...</div>
+            ) : filtered.length === 0 ? (
+              <div className="empty-state">No sessions match this filter.</div>
+            ) : (
+              <div className="list-stack selectable-list">
+                {filtered.map((session) => (
+                  <button
+                    key={session.id}
+                    className={
+                      session.id === selectedSession?.id
+                        ? 'selectable-row active'
+                        : 'selectable-row'
+                    }
+                    type="button"
+                    onClick={() => setSelectedId(session.id)}
+                  >
+                    <div className="session-row-main">
+                      <strong>{session.id}</strong>
+                      <small className="session-row-meta">
+                        {session.channelId} · {session.effectiveModel}
+                      </small>
+                    </div>
+                    <span className="session-row-time">
+                      {formatRelativeTime(session.lastActive)}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
 
-        <Panel title="Inspection" accent="warm">
-          {!selectedSession ? (
-            <div className="empty-state">Select a session to inspect it.</div>
-          ) : (
-            <div className="detail-stack">
-              <div className="key-value-grid">
-                <div>
-                  <span>Session</span>
-                  <strong>{selectedSession.id}</strong>
+        <Card variant="muted">
+          <CardHeader>
+            <CardTitle>Inspection</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {!selectedSession ? (
+              <div className="empty-state">Select a session to inspect it.</div>
+            ) : (
+              <div className="detail-stack">
+                <div className="key-value-grid">
+                  <div>
+                    <span>Session</span>
+                    <strong>{selectedSession.id}</strong>
+                  </div>
+                  <div>
+                    <span>Channel</span>
+                    <strong>{selectedSession.channelId}</strong>
+                  </div>
+                  <div>
+                    <span>Guild</span>
+                    <strong>{selectedSession.guildId || 'direct/web'}</strong>
+                  </div>
+                  <div>
+                    <span>Model</span>
+                    <strong>{selectedSession.effectiveModel}</strong>
+                  </div>
+                  <div>
+                    <span>Messages</span>
+                    <strong>{selectedSession.messageCount}</strong>
+                  </div>
+                  <div>
+                    <span>Scheduled tasks</span>
+                    <strong>{selectedSession.taskCount}</strong>
+                  </div>
+                  <div>
+                    <span>RAG</span>
+                    <BooleanPill
+                      value={selectedSession.ragEnabled}
+                      trueLabel="on"
+                      falseLabel="off"
+                    />
+                  </div>
+                  <div>
+                    <span>Last active</span>
+                    <strong>
+                      {formatRelativeTime(selectedSession.lastActive)}
+                    </strong>
+                  </div>
                 </div>
-                <div>
-                  <span>Channel</span>
-                  <strong>{selectedSession.channelId}</strong>
+                <div className="summary-block">
+                  <span>Summary</span>
+                  <p>
+                    {selectedSession.summary ||
+                      'No summary stored for this session.'}
+                  </p>
                 </div>
-                <div>
-                  <span>Guild</span>
-                  <strong>{selectedSession.guildId || 'direct/web'}</strong>
-                </div>
-                <div>
-                  <span>Model</span>
-                  <strong>{selectedSession.effectiveModel}</strong>
-                </div>
-                <div>
-                  <span>Messages</span>
-                  <strong>{selectedSession.messageCount}</strong>
-                </div>
-                <div>
-                  <span>Scheduled tasks</span>
-                  <strong>{selectedSession.taskCount}</strong>
-                </div>
-                <div>
-                  <span>RAG</span>
-                  <BooleanPill
-                    value={selectedSession.ragEnabled}
-                    trueLabel="on"
-                    falseLabel="off"
-                  />
-                </div>
-                <div>
-                  <span>Last active</span>
-                  <strong>
-                    {formatRelativeTime(selectedSession.lastActive)}
-                  </strong>
-                </div>
+                <button
+                  className="danger-button"
+                  type="button"
+                  disabled={deleteMutation.isPending}
+                  onClick={() => setDeleteConfirmOpen(true)}
+                >
+                  {deleteMutation.isPending ? 'Deleting...' : 'Delete session'}
+                </button>
               </div>
-              <div className="summary-block">
-                <span>Summary</span>
-                <p>
-                  {selectedSession.summary ||
-                    'No summary stored for this session.'}
-                </p>
-              </div>
-              <button
-                className="danger-button"
-                type="button"
-                disabled={deleteMutation.isPending}
-                onClick={() => setDeleteConfirmOpen(true)}
-              >
-                {deleteMutation.isPending ? 'Deleting...' : 'Delete session'}
-              </button>
-            </div>
-          )}
-        </Panel>
+            )}
+          </CardContent>
+        </Card>
       </div>
       <Dialog open={deleteConfirmOpen} onOpenChange={setDeleteConfirmOpen}>
         <DialogContent size="sm" role="alertdialog">

--- a/console/src/routes/skills.tsx
+++ b/console/src/routes/skills.tsx
@@ -17,6 +17,13 @@ import type {
   AdminSkill,
 } from '../api/types';
 import { useAuth } from '../auth';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../components/card';
 import { useToast } from '../components/toast';
 import {
   BooleanField,
@@ -24,7 +31,6 @@ import {
   BooleanToggle,
   MetricCard,
   PageHeader,
-  Panel,
   SegmentedToggle,
   SortableHeader,
   useSortableRows,
@@ -489,295 +495,300 @@ export function SkillsPage() {
       />
 
       {showCreate ? (
-        <Panel title="Create skill" accent="warm">
-          <SegmentedToggle
-            ariaLabel="Create mode"
-            value={createMode}
-            options={[
-              { value: 'form', label: 'Form', activeTone: 'is-on' },
-              { value: 'zip', label: 'Upload ZIP', activeTone: 'is-on' },
-            ]}
-            onChange={(value) => {
-              if (value === 'form' || value === 'zip') {
-                setCreateMode(value);
-              }
-            }}
-          />
+        <Card variant="muted">
+          <CardHeader>
+            <CardTitle>Create skill</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <SegmentedToggle
+              ariaLabel="Create mode"
+              value={createMode}
+              options={[
+                { value: 'form', label: 'Form', activeTone: 'is-on' },
+                { value: 'zip', label: 'Upload ZIP', activeTone: 'is-on' },
+              ]}
+              onChange={(value) => {
+                if (value === 'form' || value === 'zip') {
+                  setCreateMode(value);
+                }
+              }}
+            />
 
-          {createMode === 'zip' ? (
-            <div className="stack-form" style={{ marginTop: '1rem' }}>
-              <label className="field">
-                <span>Skill archive (.zip)</span>
-                <input
-                  type="file"
-                  accept=".zip,.skill"
-                  onChange={(event) =>
-                    setZipFile(event.target.files?.[0] || null)
-                  }
-                />
-              </label>
-              <p className="supporting-text">
-                ZIP must contain a SKILL.md with a valid <code>name</code>{' '}
-                frontmatter field. May include scripts/, references/, and other
-                files.
-              </p>
-              <label
-                className="supporting-text"
-                style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: '0.4rem',
-                  cursor: 'pointer',
-                  width: 'fit-content',
-                }}
-              >
-                <input
-                  type="checkbox"
-                  checked={zipForce}
-                  onChange={(event) => setZipForce(event.target.checked)}
-                  style={{ margin: 0 }}
-                />
-                <span>Overwrite existing skill (--force)</span>
-              </label>
-              <div className="button-row">
-                <button
-                  className="primary-button"
-                  type="button"
-                  disabled={uploadMutation.isPending || !zipFile}
-                  onClick={() => uploadMutation.mutate()}
-                >
-                  {uploadMutation.isPending ? 'Uploading...' : 'Upload skill'}
-                </button>
-              </div>
-            </div>
-          ) : (
-            <div className="stack-form" style={{ marginTop: '1rem' }}>
-              <div className="field-grid">
+            {createMode === 'zip' ? (
+              <div className="stack-form" style={{ marginTop: '1rem' }}>
                 <label className="field">
-                  <span>Name</span>
+                  <span>Skill archive (.zip)</span>
                   <input
-                    value={draft.name}
+                    type="file"
+                    accept=".zip,.skill"
                     onChange={(event) =>
-                      setDraft((current) => ({
-                        ...current,
-                        name: event.target.value,
-                      }))
+                      setZipFile(event.target.files?.[0] || null)
                     }
-                    placeholder="my-skill"
                   />
                 </label>
+                <p className="supporting-text">
+                  ZIP must contain a SKILL.md with a valid <code>name</code>{' '}
+                  frontmatter field. May include scripts/, references/, and
+                  other files.
+                </p>
+                <label
+                  className="supporting-text"
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: '0.4rem',
+                    cursor: 'pointer',
+                    width: 'fit-content',
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={zipForce}
+                    onChange={(event) => setZipForce(event.target.checked)}
+                    style={{ margin: 0 }}
+                  />
+                  <span>Overwrite existing skill (--force)</span>
+                </label>
+                <div className="button-row">
+                  <button
+                    className="primary-button"
+                    type="button"
+                    disabled={uploadMutation.isPending || !zipFile}
+                    onClick={() => uploadMutation.mutate()}
+                  >
+                    {uploadMutation.isPending ? 'Uploading...' : 'Upload skill'}
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="stack-form" style={{ marginTop: '1rem' }}>
+                <div className="field-grid">
+                  <label className="field">
+                    <span>Name</span>
+                    <input
+                      value={draft.name}
+                      onChange={(event) =>
+                        setDraft((current) => ({
+                          ...current,
+                          name: event.target.value,
+                        }))
+                      }
+                      placeholder="my-skill"
+                    />
+                  </label>
+                  <label className="field">
+                    <span>Category</span>
+                    <select
+                      value={draft.category}
+                      onChange={(event) =>
+                        setDraft((current) => ({
+                          ...current,
+                          category: event.target.value,
+                        }))
+                      }
+                    >
+                      <option value="">Select category</option>
+                      {categoryOptions.map((category) => (
+                        <option key={category} value={category}>
+                          {category}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                </div>
+
+                <div className="field-grid">
+                  <label className="field">
+                    <span>Short description</span>
+                    <input
+                      value={draft.shortDescription}
+                      onChange={(event) =>
+                        setDraft((current) => ({
+                          ...current,
+                          shortDescription: event.target.value,
+                        }))
+                      }
+                      placeholder="One-line summary used in metadata"
+                    />
+                  </label>
+                  <label className="field">
+                    <span>Tags</span>
+                    <input
+                      value={draft.tags}
+                      onChange={(event) =>
+                        setDraft((current) => ({
+                          ...current,
+                          tags: event.target.value,
+                        }))
+                      }
+                      placeholder="tag1, tag2"
+                    />
+                  </label>
+                </div>
+
                 <label className="field">
-                  <span>Category</span>
-                  <select
-                    value={draft.category}
+                  <span>Description</span>
+                  <input
+                    value={draft.description}
                     onChange={(event) =>
                       setDraft((current) => ({
                         ...current,
-                        category: event.target.value,
+                        description: event.target.value,
+                      }))
+                    }
+                    placeholder="Short description of what this skill does"
+                  />
+                </label>
+
+                <div className="field-grid">
+                  <BooleanField
+                    label="User invocable"
+                    value={draft.userInvocable}
+                    trueLabel="yes"
+                    falseLabel="no"
+                    onChange={(userInvocable) =>
+                      setDraft((current) => ({ ...current, userInvocable }))
+                    }
+                  />
+                  <BooleanField
+                    label="Model invocable"
+                    value={!draft.disableModelInvocation}
+                    trueLabel="yes"
+                    falseLabel="no"
+                    onChange={(modelInvocable) =>
+                      setDraft((current) => ({
+                        ...current,
+                        disableModelInvocation: !modelInvocable,
+                      }))
+                    }
+                  />
+                </div>
+
+                <label className="field">
+                  <span>Skill body (Markdown)</span>
+                  <textarea
+                    rows={10}
+                    value={draft.body}
+                    onChange={(event) =>
+                      setDraft((current) => ({
+                        ...current,
+                        body: event.target.value,
+                      }))
+                    }
+                    placeholder={
+                      '# My Skill\n\nUse this skill when the user asks to ...\n\n## Workflow\n\n1. ...\n2. ...'
+                    }
+                  />
+                </label>
+
+                <div className="panel-header" style={{ marginTop: '0.5rem' }}>
+                  <div>
+                    <h4>Files</h4>
+                    <p className="supporting-text">
+                      Add scripts or references (e.g. scripts/run.mjs,
+                      references/guide.md)
+                    </p>
+                  </div>
+                  <button
+                    className="ghost-button"
+                    type="button"
+                    onClick={() =>
+                      setDraft((current) => ({
+                        ...current,
+                        files: [
+                          ...current.files,
+                          {
+                            id: nextFileId++,
+                            path: 'scripts/new-file.mjs',
+                            content: '',
+                          },
+                        ],
                       }))
                     }
                   >
-                    <option value="">Select category</option>
-                    {categoryOptions.map((category) => (
-                      <option key={category} value={category}>
-                        {category}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-              </div>
-
-              <div className="field-grid">
-                <label className="field">
-                  <span>Short description</span>
-                  <input
-                    value={draft.shortDescription}
-                    onChange={(event) =>
-                      setDraft((current) => ({
-                        ...current,
-                        shortDescription: event.target.value,
-                      }))
-                    }
-                    placeholder="One-line summary used in metadata"
-                  />
-                </label>
-                <label className="field">
-                  <span>Tags</span>
-                  <input
-                    value={draft.tags}
-                    onChange={(event) =>
-                      setDraft((current) => ({
-                        ...current,
-                        tags: event.target.value,
-                      }))
-                    }
-                    placeholder="tag1, tag2"
-                  />
-                </label>
-              </div>
-
-              <label className="field">
-                <span>Description</span>
-                <input
-                  value={draft.description}
-                  onChange={(event) =>
-                    setDraft((current) => ({
-                      ...current,
-                      description: event.target.value,
-                    }))
-                  }
-                  placeholder="Short description of what this skill does"
-                />
-              </label>
-
-              <div className="field-grid">
-                <BooleanField
-                  label="User invocable"
-                  value={draft.userInvocable}
-                  trueLabel="yes"
-                  falseLabel="no"
-                  onChange={(userInvocable) =>
-                    setDraft((current) => ({ ...current, userInvocable }))
-                  }
-                />
-                <BooleanField
-                  label="Model invocable"
-                  value={!draft.disableModelInvocation}
-                  trueLabel="yes"
-                  falseLabel="no"
-                  onChange={(modelInvocable) =>
-                    setDraft((current) => ({
-                      ...current,
-                      disableModelInvocation: !modelInvocable,
-                    }))
-                  }
-                />
-              </div>
-
-              <label className="field">
-                <span>Skill body (Markdown)</span>
-                <textarea
-                  rows={10}
-                  value={draft.body}
-                  onChange={(event) =>
-                    setDraft((current) => ({
-                      ...current,
-                      body: event.target.value,
-                    }))
-                  }
-                  placeholder={
-                    '# My Skill\n\nUse this skill when the user asks to ...\n\n## Workflow\n\n1. ...\n2. ...'
-                  }
-                />
-              </label>
-
-              <div className="panel-header" style={{ marginTop: '0.5rem' }}>
-                <div>
-                  <h4>Files</h4>
-                  <p className="supporting-text">
-                    Add scripts or references (e.g. scripts/run.mjs,
-                    references/guide.md)
-                  </p>
+                    Add file
+                  </button>
                 </div>
-                <button
-                  className="ghost-button"
-                  type="button"
-                  onClick={() =>
-                    setDraft((current) => ({
-                      ...current,
-                      files: [
-                        ...current.files,
-                        {
-                          id: nextFileId++,
-                          path: 'scripts/new-file.mjs',
-                          content: '',
-                        },
-                      ],
-                    }))
-                  }
-                >
-                  Add file
-                </button>
-              </div>
 
-              {draft.files.map((file, index) => (
-                <div
-                  key={file.id}
-                  className="stack-form"
-                  style={{ gap: '0.25rem' }}
-                >
-                  <div className="field-grid">
+                {draft.files.map((file, index) => (
+                  <div
+                    key={file.id}
+                    className="stack-form"
+                    style={{ gap: '0.25rem' }}
+                  >
+                    <div className="field-grid">
+                      <label className="field">
+                        <span>Path</span>
+                        <input
+                          value={file.path}
+                          onChange={(event) =>
+                            setDraft((current) => {
+                              const files = [...current.files];
+                              files[index] = {
+                                ...files[index],
+                                path: event.target.value,
+                              };
+                              return { ...current, files };
+                            })
+                          }
+                          placeholder="scripts/my-tool.mjs"
+                        />
+                      </label>
+                      <button
+                        className="danger-button"
+                        type="button"
+                        style={{ alignSelf: 'end' }}
+                        onClick={() =>
+                          setDraft((current) => ({
+                            ...current,
+                            files: current.files.filter((_, i) => i !== index),
+                          }))
+                        }
+                      >
+                        Remove
+                      </button>
+                    </div>
                     <label className="field">
-                      <span>Path</span>
-                      <input
-                        value={file.path}
+                      <span>Content</span>
+                      <textarea
+                        rows={8}
+                        value={file.content}
                         onChange={(event) =>
                           setDraft((current) => {
                             const files = [...current.files];
                             files[index] = {
                               ...files[index],
-                              path: event.target.value,
+                              content: event.target.value,
                             };
                             return { ...current, files };
                           })
                         }
-                        placeholder="scripts/my-tool.mjs"
+                        placeholder="// Script content..."
+                        style={{ fontFamily: 'monospace', fontSize: '0.85rem' }}
                       />
                     </label>
-                    <button
-                      className="danger-button"
-                      type="button"
-                      style={{ alignSelf: 'end' }}
-                      onClick={() =>
-                        setDraft((current) => ({
-                          ...current,
-                          files: current.files.filter((_, i) => i !== index),
-                        }))
-                      }
-                    >
-                      Remove
-                    </button>
                   </div>
-                  <label className="field">
-                    <span>Content</span>
-                    <textarea
-                      rows={8}
-                      value={file.content}
-                      onChange={(event) =>
-                        setDraft((current) => {
-                          const files = [...current.files];
-                          files[index] = {
-                            ...files[index],
-                            content: event.target.value,
-                          };
-                          return { ...current, files };
-                        })
-                      }
-                      placeholder="// Script content..."
-                      style={{ fontFamily: 'monospace', fontSize: '0.85rem' }}
-                    />
-                  </label>
-                </div>
-              ))}
+                ))}
 
-              <div className="button-row">
-                <button
-                  className="primary-button"
-                  type="button"
-                  disabled={
-                    createMutation.isPending ||
-                    !draft.name.trim() ||
-                    !draft.description.trim() ||
-                    !draft.category.trim()
-                  }
-                  onClick={() => createMutation.mutate()}
-                >
-                  {createMutation.isPending ? 'Creating...' : 'Create skill'}
-                </button>
+                <div className="button-row">
+                  <button
+                    className="primary-button"
+                    type="button"
+                    disabled={
+                      createMutation.isPending ||
+                      !draft.name.trim() ||
+                      !draft.description.trim() ||
+                      !draft.category.trim()
+                    }
+                    onClick={() => createMutation.mutate()}
+                  >
+                    {createMutation.isPending ? 'Creating...' : 'Create skill'}
+                  </button>
+                </div>
               </div>
-            </div>
-          )}
-        </Panel>
+            )}
+          </CardContent>
+        </Card>
       ) : null}
 
       <div className="metric-grid">
@@ -808,175 +819,16 @@ export function SkillsPage() {
         />
       </div>
 
-      <Panel
-        title="Installed skills"
-        subtitle={`${sortedInstalledSkills.length} skill${sortedInstalledSkills.length === 1 ? '' : 's'} visible`}
-      >
-        {skillsQuery.isLoading ? (
-          <div className="empty-state">Loading skill catalog...</div>
-        ) : (
-          <div className="table-shell">
-            <table>
-              <thead>
-                <tr>
-                  <SortableHeader
-                    label="Skill"
-                    sortKey="skill"
-                    sortState={installedSkillSortState}
-                    onToggle={toggleInstalledSkillSort}
-                  />
-                  <SortableHeader
-                    label="Category"
-                    sortKey="category"
-                    sortState={installedSkillSortState}
-                    onToggle={toggleInstalledSkillSort}
-                  />
-                  <SortableHeader
-                    label="Source"
-                    sortKey="source"
-                    sortState={installedSkillSortState}
-                    onToggle={toggleInstalledSkillSort}
-                  />
-                  <SortableHeader
-                    label="Health"
-                    sortKey="health"
-                    sortState={installedSkillSortState}
-                    onToggle={toggleInstalledSkillSort}
-                  />
-                  <SortableHeader
-                    label="Tags"
-                    sortKey="tags"
-                    sortState={installedSkillSortState}
-                    onToggle={toggleInstalledSkillSort}
-                  />
-                  <SortableHeader
-                    label="Action"
-                    sortKey="action"
-                    sortState={installedSkillSortState}
-                    onToggle={toggleInstalledSkillSort}
-                  />
-                </tr>
-              </thead>
-              <tbody>
-                {sortedInstalledSkills.map(({ skill, metrics }) => {
-                  const feedbackSummary = metrics
-                    ? formatFeedbackCounts(metrics)
-                    : null;
-                  const displayDescription =
-                    skill.shortDescription?.trim() ||
-                    abbreviateDescription(skill.description);
-                  const firstGuardFinding = skill.guardFindings?.[0];
-                  return (
-                    <tr key={skill.name}>
-                      <td>
-                        <button
-                          type="button"
-                          className="table-link-button"
-                          onClick={() => setSelectedSkillName(skill.name)}
-                        >
-                          {skill.name}
-                        </button>
-                        <small>{displayDescription}</small>
-                        {skill.blocked && firstGuardFinding ? (
-                          <small className="row-status-note-danger">
-                            {firstGuardFinding.severity}/
-                            {firstGuardFinding.category}:{' '}
-                            {firstGuardFinding.description}
-                          </small>
-                        ) : null}
-                      </td>
-                      <td>{skill.category}</td>
-                      <td>{skill.source}</td>
-                      <td>
-                        {metrics ? (
-                          <>
-                            <BooleanPill
-                              value={!metrics.degraded}
-                              trueLabel="healthy"
-                              falseLabel="degraded"
-                              falseTone="danger"
-                            />
-                            <small>
-                              {metrics.total_executions} runs
-                              {metrics.degraded || !feedbackSummary
-                                ? ''
-                                : ' · '}
-                              {metrics.degraded
-                                ? `${formatPercent(metrics.success_rate)} success`
-                                : feedbackSummary}
-                            </small>
-                          </>
-                        ) : null}
-                      </td>
-                      <td>{skill.tags.join(', ') || 'none'}</td>
-                      <td>
-                        <div className="row-status-stack">
-                          <BooleanToggle
-                            value={skill.enabled}
-                            ariaLabel={`${skill.name} status`}
-                            size="sm"
-                            disabled={
-                              skill.blocked ||
-                              toggleMutation.isPending ||
-                              (!skill.available && !skill.enabled)
-                            }
-                            trueLabel="active"
-                            falseLabel="inactive"
-                            onChange={(enabled) => {
-                              if (
-                                skill.blocked ||
-                                (enabled && !skill.available)
-                              ) {
-                                return;
-                              }
-                              toggleMutation.mutate({
-                                name: skill.name,
-                                enabled,
-                              });
-                            }}
-                          />
-                          {skill.blocked ? (
-                            <small className="row-status-note-danger">
-                              blocked: {skill.blockedReason || 'guarded'}
-                            </small>
-                          ) : !skill.available ? (
-                            <small className="row-status-note-danger">
-                              {skill.missing.join(', ') ||
-                                'missing requirements'}
-                            </small>
-                          ) : null}
-                        </div>
-                      </td>
-                    </tr>
-                  );
-                })}
-                {sortedInstalledSkills.length === 0 ? (
-                  <tr>
-                    <td colSpan={6}>
-                      <div className="empty-state">
-                        No skills match this filter.
-                      </div>
-                    </td>
-                  </tr>
-                ) : null}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </Panel>
-
-      <div className="two-column-grid">
-        <Panel
-          id="observed-skill-health"
-          title="Observed skill health"
-          subtitle={`${sortedHealthMetrics.length} observed skill${sortedHealthMetrics.length === 1 ? '' : 's'} visible`}
-        >
-          {healthQuery.isLoading ? (
-            <div className="empty-state">Loading AdaptiveSkills health...</div>
-          ) : sortedHealthMetrics.length === 0 ? (
-            <div className="empty-state">
-              No observed skills match this filter.
-            </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Installed skills</CardTitle>
+          <CardDescription>
+            {`${sortedInstalledSkills.length} skill${sortedInstalledSkills.length === 1 ? '' : 's'} visible`}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {skillsQuery.isLoading ? (
+            <div className="empty-state">Loading skill catalog...</div>
           ) : (
             <div className="table-shell">
               <table>
@@ -985,220 +837,404 @@ export function SkillsPage() {
                     <SortableHeader
                       label="Skill"
                       sortKey="skill"
-                      sortState={observedSkillSortState}
-                      onToggle={toggleObservedSkillSort}
+                      sortState={installedSkillSortState}
+                      onToggle={toggleInstalledSkillSort}
                     />
                     <SortableHeader
-                      label="Status"
-                      sortKey="status"
-                      sortState={observedSkillSortState}
-                      onToggle={toggleObservedSkillSort}
+                      label="Category"
+                      sortKey="category"
+                      sortState={installedSkillSortState}
+                      onToggle={toggleInstalledSkillSort}
                     />
                     <SortableHeader
-                      label="Executions"
-                      sortKey="executions"
-                      sortState={observedSkillSortState}
-                      onToggle={toggleObservedSkillSort}
+                      label="Source"
+                      sortKey="source"
+                      sortState={installedSkillSortState}
+                      onToggle={toggleInstalledSkillSort}
                     />
                     <SortableHeader
-                      label="Success"
-                      sortKey="success"
-                      sortState={observedSkillSortState}
-                      onToggle={toggleObservedSkillSort}
+                      label="Health"
+                      sortKey="health"
+                      sortState={installedSkillSortState}
+                      onToggle={toggleInstalledSkillSort}
                     />
                     <SortableHeader
-                      label="Tool breakage"
-                      sortKey="toolBreakage"
-                      sortState={observedSkillSortState}
-                      onToggle={toggleObservedSkillSort}
+                      label="Tags"
+                      sortKey="tags"
+                      sortState={installedSkillSortState}
+                      onToggle={toggleInstalledSkillSort}
                     />
                     <SortableHeader
-                      label="Feedback"
-                      sortKey="feedback"
-                      sortState={observedSkillSortState}
-                      onToggle={toggleObservedSkillSort}
-                    />
-                    <SortableHeader
-                      label="Reasons"
-                      sortKey="reasons"
-                      sortState={observedSkillSortState}
-                      onToggle={toggleObservedSkillSort}
+                      label="Action"
+                      sortKey="action"
+                      sortState={installedSkillSortState}
+                      onToggle={toggleInstalledSkillSort}
                     />
                   </tr>
                 </thead>
                 <tbody>
-                  {sortedHealthMetrics.map((metrics) => (
-                    <tr key={metrics.skill_name}>
-                      <td>
-                        <button
-                          type="button"
-                          className="table-link-button"
-                          onClick={() =>
-                            setSelectedSkillName(metrics.skill_name)
-                          }
-                        >
-                          {metrics.skill_name}
-                        </button>
-                        <small>
-                          Window ending{' '}
-                          {formatDateTime(metrics.window_ended_at)}
-                        </small>
-                      </td>
-                      <td>
-                        <BooleanPill
-                          value={!metrics.degraded}
-                          trueLabel="healthy"
-                          falseLabel="degraded"
-                          falseTone="danger"
-                        />
-                      </td>
-                      <td>{metrics.total_executions}</td>
-                      <td>{formatPercent(metrics.success_rate)}</td>
-                      <td>{formatPercent(metrics.tool_breakage_rate)}</td>
-                      <td>{formatFeedbackCounts(metrics) || null}</td>
-                      <td>
-                        <small>
-                          {metrics.degradation_reasons.join('; ') || 'healthy'}
-                        </small>
+                  {sortedInstalledSkills.map(({ skill, metrics }) => {
+                    const feedbackSummary = metrics
+                      ? formatFeedbackCounts(metrics)
+                      : null;
+                    const displayDescription =
+                      skill.shortDescription?.trim() ||
+                      abbreviateDescription(skill.description);
+                    const firstGuardFinding = skill.guardFindings?.[0];
+                    return (
+                      <tr key={skill.name}>
+                        <td>
+                          <button
+                            type="button"
+                            className="table-link-button"
+                            onClick={() => setSelectedSkillName(skill.name)}
+                          >
+                            {skill.name}
+                          </button>
+                          <small>{displayDescription}</small>
+                          {skill.blocked && firstGuardFinding ? (
+                            <small className="row-status-note-danger">
+                              {firstGuardFinding.severity}/
+                              {firstGuardFinding.category}:{' '}
+                              {firstGuardFinding.description}
+                            </small>
+                          ) : null}
+                        </td>
+                        <td>{skill.category}</td>
+                        <td>{skill.source}</td>
+                        <td>
+                          {metrics ? (
+                            <>
+                              <BooleanPill
+                                value={!metrics.degraded}
+                                trueLabel="healthy"
+                                falseLabel="degraded"
+                                falseTone="danger"
+                              />
+                              <small>
+                                {metrics.total_executions} runs
+                                {metrics.degraded || !feedbackSummary
+                                  ? ''
+                                  : ' · '}
+                                {metrics.degraded
+                                  ? `${formatPercent(metrics.success_rate)} success`
+                                  : feedbackSummary}
+                              </small>
+                            </>
+                          ) : null}
+                        </td>
+                        <td>{skill.tags.join(', ') || 'none'}</td>
+                        <td>
+                          <div className="row-status-stack">
+                            <BooleanToggle
+                              value={skill.enabled}
+                              ariaLabel={`${skill.name} status`}
+                              size="sm"
+                              disabled={
+                                skill.blocked ||
+                                toggleMutation.isPending ||
+                                (!skill.available && !skill.enabled)
+                              }
+                              trueLabel="active"
+                              falseLabel="inactive"
+                              onChange={(enabled) => {
+                                if (
+                                  skill.blocked ||
+                                  (enabled && !skill.available)
+                                ) {
+                                  return;
+                                }
+                                toggleMutation.mutate({
+                                  name: skill.name,
+                                  enabled,
+                                });
+                              }}
+                            />
+                            {skill.blocked ? (
+                              <small className="row-status-note-danger">
+                                blocked: {skill.blockedReason || 'guarded'}
+                              </small>
+                            ) : !skill.available ? (
+                              <small className="row-status-note-danger">
+                                {skill.missing.join(', ') ||
+                                  'missing requirements'}
+                              </small>
+                            ) : null}
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                  {sortedInstalledSkills.length === 0 ? (
+                    <tr>
+                      <td colSpan={6}>
+                        <div className="empty-state">
+                          No skills match this filter.
+                        </div>
                       </td>
                     </tr>
-                  ))}
+                  ) : null}
                 </tbody>
               </table>
             </div>
           )}
-        </Panel>
+        </CardContent>
+      </Card>
 
-        <Panel
-          id="staged-amendments"
-          title="Staged amendments"
-          subtitle={`${stagedAmendments.length} waiting for review`}
-          accent="warm"
-        >
-          {stagedAmendmentsQuery.isLoading ? (
-            <div className="empty-state">Loading staged amendments...</div>
-          ) : stagedAmendments.length === 0 ? (
+      <div className="two-column-grid">
+        <Card id="observed-skill-health">
+          <CardHeader>
+            <CardTitle>Observed skill health</CardTitle>
+            <CardDescription>
+              {`${sortedHealthMetrics.length} observed skill${sortedHealthMetrics.length === 1 ? '' : 's'} visible`}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {healthQuery.isLoading ? (
+              <div className="empty-state">
+                Loading AdaptiveSkills health...
+              </div>
+            ) : sortedHealthMetrics.length === 0 ? (
+              <div className="empty-state">
+                No observed skills match this filter.
+              </div>
+            ) : (
+              <div className="table-shell">
+                <table>
+                  <thead>
+                    <tr>
+                      <SortableHeader
+                        label="Skill"
+                        sortKey="skill"
+                        sortState={observedSkillSortState}
+                        onToggle={toggleObservedSkillSort}
+                      />
+                      <SortableHeader
+                        label="Status"
+                        sortKey="status"
+                        sortState={observedSkillSortState}
+                        onToggle={toggleObservedSkillSort}
+                      />
+                      <SortableHeader
+                        label="Executions"
+                        sortKey="executions"
+                        sortState={observedSkillSortState}
+                        onToggle={toggleObservedSkillSort}
+                      />
+                      <SortableHeader
+                        label="Success"
+                        sortKey="success"
+                        sortState={observedSkillSortState}
+                        onToggle={toggleObservedSkillSort}
+                      />
+                      <SortableHeader
+                        label="Tool breakage"
+                        sortKey="toolBreakage"
+                        sortState={observedSkillSortState}
+                        onToggle={toggleObservedSkillSort}
+                      />
+                      <SortableHeader
+                        label="Feedback"
+                        sortKey="feedback"
+                        sortState={observedSkillSortState}
+                        onToggle={toggleObservedSkillSort}
+                      />
+                      <SortableHeader
+                        label="Reasons"
+                        sortKey="reasons"
+                        sortState={observedSkillSortState}
+                        onToggle={toggleObservedSkillSort}
+                      />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {sortedHealthMetrics.map((metrics) => (
+                      <tr key={metrics.skill_name}>
+                        <td>
+                          <button
+                            type="button"
+                            className="table-link-button"
+                            onClick={() =>
+                              setSelectedSkillName(metrics.skill_name)
+                            }
+                          >
+                            {metrics.skill_name}
+                          </button>
+                          <small>
+                            Window ending{' '}
+                            {formatDateTime(metrics.window_ended_at)}
+                          </small>
+                        </td>
+                        <td>
+                          <BooleanPill
+                            value={!metrics.degraded}
+                            trueLabel="healthy"
+                            falseLabel="degraded"
+                            falseTone="danger"
+                          />
+                        </td>
+                        <td>{metrics.total_executions}</td>
+                        <td>{formatPercent(metrics.success_rate)}</td>
+                        <td>{formatPercent(metrics.tool_breakage_rate)}</td>
+                        <td>{formatFeedbackCounts(metrics) || null}</td>
+                        <td>
+                          <small>
+                            {metrics.degradation_reasons.join('; ') ||
+                              'healthy'}
+                          </small>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card id="staged-amendments" variant="muted">
+          <CardHeader>
+            <CardTitle>Staged amendments</CardTitle>
+            <CardDescription>
+              {`${stagedAmendments.length} waiting for review`}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {stagedAmendmentsQuery.isLoading ? (
+              <div className="empty-state">Loading staged amendments...</div>
+            ) : stagedAmendments.length === 0 ? (
+              <div className="empty-state">
+                No staged amendments are waiting for review.
+              </div>
+            ) : (
+              <div className="list-stack selectable-list">
+                {stagedAmendments.map((amendment) => (
+                  <div className="list-row" key={amendment.id}>
+                    <div>
+                      <button
+                        type="button"
+                        className="table-link-button"
+                        onClick={() =>
+                          setSelectedSkillName(amendment.skill_name)
+                        }
+                      >
+                        {amendment.skill_name}
+                      </button>
+                      <small>
+                        {formatAmendmentStatus(amendment)} ·{' '}
+                        {formatAmendmentTiming(amendment)} · guard{' '}
+                        {amendment.guard_verdict}/
+                        {amendment.guard_findings_count}
+                      </small>
+                      <small>
+                        {amendment.rationale || amendment.diff_summary}
+                      </small>
+                    </div>
+                    <div className="skill-review-actions">
+                      <button
+                        type="button"
+                        className="ghost-button"
+                        onClick={() =>
+                          setSelectedSkillName(amendment.skill_name)
+                        }
+                      >
+                        History
+                      </button>
+                      <button
+                        type="button"
+                        className="primary-button"
+                        disabled={reviewMutation.isPending}
+                        onClick={() =>
+                          reviewMutation.mutate({
+                            action: 'apply',
+                            skillName: amendment.skill_name,
+                          })
+                        }
+                      >
+                        Apply
+                      </button>
+                      <button
+                        type="button"
+                        className="danger-button"
+                        disabled={reviewMutation.isPending}
+                        onClick={() =>
+                          reviewMutation.mutate({
+                            action: 'reject',
+                            skillName: amendment.skill_name,
+                          })
+                        }
+                      >
+                        Reject
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            {effectiveSelectedSkillName
+              ? `Amendment history: ${effectiveSelectedSkillName}`
+              : 'Amendment history'}
+          </CardTitle>
+          <CardDescription>
+            Full review trail for the selected skill
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {!effectiveSelectedSkillName ? (
             <div className="empty-state">
-              No staged amendments are waiting for review.
+              Select a skill to inspect its amendment history.
+            </div>
+          ) : historyQuery.isLoading ? (
+            <div className="empty-state">Loading amendment history...</div>
+          ) : historyEntries.length === 0 ? (
+            <div className="empty-state">
+              No amendment history exists for this skill yet.
             </div>
           ) : (
             <div className="list-stack selectable-list">
-              {stagedAmendments.map((amendment) => (
+              {historyEntries.map((amendment) => (
                 <div className="list-row" key={amendment.id}>
                   <div>
-                    <button
-                      type="button"
-                      className="table-link-button"
-                      onClick={() => setSelectedSkillName(amendment.skill_name)}
-                    >
-                      {amendment.skill_name}
-                    </button>
-                    <small>
+                    <strong>
                       {formatAmendmentStatus(amendment)} ·{' '}
-                      {formatAmendmentTiming(amendment)} · guard{' '}
-                      {amendment.guard_verdict}/{amendment.guard_findings_count}
+                      {formatAmendmentTiming(amendment)}
+                    </strong>
+                    <small>
+                      Guard {amendment.guard_verdict}/
+                      {amendment.guard_findings_count} · runs since apply{' '}
+                      {amendment.runs_since_apply}
                     </small>
                     <small>
-                      {amendment.rationale || amendment.diff_summary}
+                      {amendment.rationale || 'No rationale recorded.'}
+                    </small>
+                    <small>
+                      {amendment.diff_summary || 'No diff summary recorded.'}
                     </small>
                   </div>
-                  <div className="skill-review-actions">
-                    <button
-                      type="button"
-                      className="ghost-button"
-                      onClick={() => setSelectedSkillName(amendment.skill_name)}
-                    >
-                      History
-                    </button>
-                    <button
-                      type="button"
-                      className="primary-button"
-                      disabled={reviewMutation.isPending}
-                      onClick={() =>
-                        reviewMutation.mutate({
-                          action: 'apply',
-                          skillName: amendment.skill_name,
-                        })
-                      }
-                    >
-                      Apply
-                    </button>
-                    <button
-                      type="button"
-                      className="danger-button"
-                      disabled={reviewMutation.isPending}
-                      onClick={() =>
-                        reviewMutation.mutate({
-                          action: 'reject',
-                          skillName: amendment.skill_name,
-                        })
-                      }
-                    >
-                      Reject
-                    </button>
-                  </div>
+                  <span
+                    className={
+                      amendment.status === 'applied'
+                        ? 'list-status list-status-success'
+                        : amendment.status === 'rejected'
+                          ? 'list-status list-status-danger'
+                          : 'list-status'
+                    }
+                  >
+                    {amendment.status}
+                  </span>
                 </div>
               ))}
             </div>
           )}
-        </Panel>
-      </div>
-
-      <Panel
-        title={
-          effectiveSelectedSkillName
-            ? `Amendment history: ${effectiveSelectedSkillName}`
-            : 'Amendment history'
-        }
-        subtitle="Full review trail for the selected skill"
-      >
-        {!effectiveSelectedSkillName ? (
-          <div className="empty-state">
-            Select a skill to inspect its amendment history.
-          </div>
-        ) : historyQuery.isLoading ? (
-          <div className="empty-state">Loading amendment history...</div>
-        ) : historyEntries.length === 0 ? (
-          <div className="empty-state">
-            No amendment history exists for this skill yet.
-          </div>
-        ) : (
-          <div className="list-stack selectable-list">
-            {historyEntries.map((amendment) => (
-              <div className="list-row" key={amendment.id}>
-                <div>
-                  <strong>
-                    {formatAmendmentStatus(amendment)} ·{' '}
-                    {formatAmendmentTiming(amendment)}
-                  </strong>
-                  <small>
-                    Guard {amendment.guard_verdict}/
-                    {amendment.guard_findings_count} · runs since apply{' '}
-                    {amendment.runs_since_apply}
-                  </small>
-                  <small>
-                    {amendment.rationale || 'No rationale recorded.'}
-                  </small>
-                  <small>
-                    {amendment.diff_summary || 'No diff summary recorded.'}
-                  </small>
-                </div>
-                <span
-                  className={
-                    amendment.status === 'applied'
-                      ? 'list-status list-status-success'
-                      : amendment.status === 'rejected'
-                        ? 'list-status list-status-danger'
-                        : 'list-status'
-                  }
-                >
-                  {amendment.status}
-                </span>
-              </div>
-            ))}
-          </div>
-        )}
-      </Panel>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/console/src/routes/statistics.tsx
+++ b/console/src/routes/statistics.tsx
@@ -6,7 +6,14 @@ import type {
   AdminStatisticsTrendDay,
 } from '../api/types';
 import { useAuth } from '../auth';
-import { MetricCard, PageHeader, Panel } from '../components/ui';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../components/card';
+import { MetricCard, PageHeader } from '../components/ui';
 import { getErrorMessage } from '../lib/error-message';
 import {
   formatCompactNumber,
@@ -123,52 +130,68 @@ export function StatisticsPage() {
       </div>
 
       <div className="two-column-grid">
-        <Panel
-          title="Message trend"
-          subtitle="User vs assistant messages per day"
-        >
-          <TrendChart
-            trend={trend}
-            series={[
-              {
-                key: 'userMessages',
-                label: 'User',
-                color: 'var(--primary)',
-              },
-              {
-                key: 'assistantMessages',
-                label: 'Assistant',
-                color: 'var(--success)',
-              },
-            ]}
-          />
-        </Panel>
-        <Panel title="Session trend" subtitle="New vs active sessions per day">
-          <TrendChart
-            trend={trend}
-            series={[
-              {
-                key: 'newSessions',
-                label: 'New',
-                color: 'var(--primary)',
-              },
-              {
-                key: 'activeSessions',
-                label: 'Active',
-                color: 'var(--accent-foreground)',
-              },
-            ]}
-            stacked={false}
-          />
-        </Panel>
+        <Card>
+          <CardHeader>
+            <CardTitle>Message trend</CardTitle>
+            <CardDescription>
+              User vs assistant messages per day
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <TrendChart
+              trend={trend}
+              series={[
+                {
+                  key: 'userMessages',
+                  label: 'User',
+                  color: 'var(--primary)',
+                },
+                {
+                  key: 'assistantMessages',
+                  label: 'Assistant',
+                  color: 'var(--success)',
+                },
+              ]}
+            />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Session trend</CardTitle>
+            <CardDescription>New vs active sessions per day</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <TrendChart
+              trend={trend}
+              series={[
+                {
+                  key: 'newSessions',
+                  label: 'New',
+                  color: 'var(--primary)',
+                },
+                {
+                  key: 'activeSessions',
+                  label: 'Active',
+                  color: 'var(--accent-foreground)',
+                },
+              ]}
+              stacked={false}
+            />
+          </CardContent>
+        </Card>
       </div>
 
-      <Panel
-        title="Channel breakdown"
-        subtitle="Distribution of sessions and messages by channel"
-      >
-        <ChannelBreakdown channels={channels} />
-      </Panel>
+      <Card>
+        <CardHeader>
+          <CardTitle>Channel breakdown</CardTitle>
+          <CardDescription>
+            Distribution of sessions and messages by channel
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ChannelBreakdown channels={channels} />
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/console/src/routes/tools.tsx
+++ b/console/src/routes/tools.tsx
@@ -3,10 +3,10 @@ import { useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
 import { fetchTools } from '../api/client';
 import type { AdminToolCatalogEntry } from '../api/types';
 import { useAuth } from '../auth';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/card';
 import {
   MetricCard,
   PageHeader,
-  Panel,
   SortableHeader,
   useSortableRows,
 } from '../components/ui';
@@ -196,115 +196,125 @@ export function ToolsPage() {
       </div>
 
       <div className="two-column-grid">
-        <Panel title="Catalog">
-          {toolsQuery.isLoading ? (
-            <div className="empty-state">Loading tool catalog...</div>
-          ) : sortedTools.length === 0 ? (
-            <div className="empty-state">No tools match this filter.</div>
-          ) : (
-            <div className="table-shell">
-              <table>
-                <thead>
-                  <tr>
-                    <SortableHeader
-                      label="Tool"
-                      sortKey="tool"
-                      sortState={sortState}
-                      onToggle={toggleSort}
-                    />
-                    <SortableHeader
-                      label="Group"
-                      sortKey="group"
-                      sortState={sortState}
-                      onToggle={toggleSort}
-                    />
-                    <SortableHeader
-                      label="Type"
-                      sortKey="type"
-                      sortState={sortState}
-                      onToggle={toggleSort}
-                    />
-                    <SortableHeader
-                      label="Invocations"
-                      sortKey="invocations"
-                      sortState={sortState}
-                      onToggle={toggleSort}
-                    />
-                    <SortableHeader
-                      label="Last used"
-                      sortKey="lastUsed"
-                      sortState={sortState}
-                      onToggle={toggleSort}
-                    />
-                  </tr>
-                </thead>
-                <tbody>
-                  {sortedTools.map((tool) => (
-                    <tr key={tool.name}>
-                      <td>
-                        <strong>{tool.name}</strong>
-                        <ToolErrorPreview
-                          recentErrors={tool.recentErrors}
-                          samples={tool.recentErrorSamples}
-                        />
-                      </td>
-                      <td>{tool.groupLabel}</td>
-                      <td>{tool.kind}</td>
-                      <td>{tool.recentCalls}</td>
-                      <td>{formatDateTime(tool.lastUsedAt)}</td>
+        <Card>
+          <CardHeader>
+            <CardTitle>Catalog</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {toolsQuery.isLoading ? (
+              <div className="empty-state">Loading tool catalog...</div>
+            ) : sortedTools.length === 0 ? (
+              <div className="empty-state">No tools match this filter.</div>
+            ) : (
+              <div className="table-shell">
+                <table>
+                  <thead>
+                    <tr>
+                      <SortableHeader
+                        label="Tool"
+                        sortKey="tool"
+                        sortState={sortState}
+                        onToggle={toggleSort}
+                      />
+                      <SortableHeader
+                        label="Group"
+                        sortKey="group"
+                        sortState={sortState}
+                        onToggle={toggleSort}
+                      />
+                      <SortableHeader
+                        label="Type"
+                        sortKey="type"
+                        sortState={sortState}
+                        onToggle={toggleSort}
+                      />
+                      <SortableHeader
+                        label="Invocations"
+                        sortKey="invocations"
+                        sortState={sortState}
+                        onToggle={toggleSort}
+                      />
+                      <SortableHeader
+                        label="Last used"
+                        sortKey="lastUsed"
+                        sortState={sortState}
+                        onToggle={toggleSort}
+                      />
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </Panel>
+                  </thead>
+                  <tbody>
+                    {sortedTools.map((tool) => (
+                      <tr key={tool.name}>
+                        <td>
+                          <strong>{tool.name}</strong>
+                          <ToolErrorPreview
+                            recentErrors={tool.recentErrors}
+                            samples={tool.recentErrorSamples}
+                          />
+                        </td>
+                        <td>{tool.groupLabel}</td>
+                        <td>{tool.kind}</td>
+                        <td>{tool.recentCalls}</td>
+                        <td>{formatDateTime(tool.lastUsedAt)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
 
-        <Panel title="Recent executions" accent="warm">
-          {toolsQuery.isLoading ? (
-            <div className="empty-state">Loading recent executions...</div>
-          ) : toolsQuery.data?.recentExecutions.length ? (
-            <div className="list-stack selectable-list">
-              {toolsQuery.data.recentExecutions.map((execution) => (
-                <div className="list-row" key={execution.id}>
-                  <div>
-                    <strong>{execution.toolName}</strong>
-                    <small>
-                      {execution.sessionId} ·{' '}
-                      {formatRelativeTime(execution.timestamp)}
-                      {execution.durationMs == null
-                        ? ''
-                        : ` · ${execution.durationMs}ms`}
-                    </small>
-                    {execution.isError && execution.summary ? (
-                      <small>{execution.summary}</small>
-                    ) : null}
-                  </div>
-                  <span
-                    className={
-                      execution.isError
-                        ? 'list-status list-status-danger'
-                        : 'list-status list-status-success'
-                    }
-                  >
+        <Card variant="muted">
+          <CardHeader>
+            <CardTitle>Recent executions</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {toolsQuery.isLoading ? (
+              <div className="empty-state">Loading recent executions...</div>
+            ) : toolsQuery.data?.recentExecutions.length ? (
+              <div className="list-stack selectable-list">
+                {toolsQuery.data.recentExecutions.map((execution) => (
+                  <div className="list-row" key={execution.id}>
+                    <div>
+                      <strong>{execution.toolName}</strong>
+                      <small>
+                        {execution.sessionId} ·{' '}
+                        {formatRelativeTime(execution.timestamp)}
+                        {execution.durationMs == null
+                          ? ''
+                          : ` · ${execution.durationMs}ms`}
+                      </small>
+                      {execution.isError && execution.summary ? (
+                        <small>{execution.summary}</small>
+                      ) : null}
+                    </div>
                     <span
                       className={
                         execution.isError
-                          ? 'status-dot status-dot-danger'
-                          : 'status-dot status-dot-success'
+                          ? 'list-status list-status-danger'
+                          : 'list-status list-status-success'
                       }
-                    />
-                    {execution.isError ? 'error' : 'ok'}
-                  </span>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div className="empty-state">
-              No recent tool executions were found in structured audit events.
-            </div>
-          )}
-        </Panel>
+                    >
+                      <span
+                        className={
+                          execution.isError
+                            ? 'status-dot status-dot-danger'
+                            : 'status-dot status-dot-success'
+                        }
+                      />
+                      {execution.isError ? 'error' : 'ok'}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="empty-state">
+                No recent tool executions were found in structured audit events.
+              </div>
+            )}
+          </CardContent>
+        </Card>
       </div>
     </div>
   );

--- a/console/src/styles.css
+++ b/console/src/styles.css
@@ -80,23 +80,6 @@ code {
   font-size: clamp(1.9rem, 2.4vw, 2.35rem);
 }
 
-.panel h4,
-.panel-title {
-  margin: 0;
-  font-size: 0.9375rem;
-  font-weight: 600;
-  line-height: 1.3;
-  letter-spacing: 0;
-  color: var(--text);
-}
-
-.panel-subtitle {
-  margin: 4px 0 0;
-  font-size: 0.8125rem;
-  line-height: 1.45;
-  color: color-mix(in srgb, var(--text) 60%, transparent);
-}
-
 .eyebrow {
   margin: 0;
   text-transform: uppercase;
@@ -343,13 +326,6 @@ code {
   max-width: 62ch;
 }
 
-.panel {
-  padding: 20px;
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--line);
-  background: var(--panel-bg);
-}
-
 .terminal-page {
   display: flex;
   flex: 1 1 auto;
@@ -460,17 +436,12 @@ code {
   }
 }
 
-.panel.warm,
 .metric-card,
 .config-section,
 .empty-state,
 .summary-block,
 .key-value-grid div {
   background: var(--panel-muted);
-}
-
-.panel-header {
-  margin-bottom: 18px;
 }
 
 .metric-grid,
@@ -1327,7 +1298,6 @@ th {
 
 .sessions-layout,
 .selectable-list,
-.sessions-layout .panel,
 .sessions-layout .detail-stack,
 .session-row-main,
 .key-value-grid div {
@@ -2323,7 +2293,6 @@ th {
     padding: 0;
   }
 
-  .panel,
   .login-card {
     padding: 18px;
   }


### PR DESCRIPTION
Part 3 of 3 splitting up #896. **Stacked on top of #934** (Usage rollup) which is stacked on #933 (toasts) — both should land first, or compare against #934's branch for the clean delta.

## What changed

### New Card primitive

Adds a shadcn-style Card primitive (`Card`, `CardHeader`, `CardTitle`, `CardDescription`, `CardAction`, `CardContent`, `CardFooter`) implemented with the local CSS-module + `cx` pattern and existing design tokens, so it sits alongside `Button`/`Skeleton` without pulling in Tailwind or Radix.

### Panel → Card migration across all 17 admin routes

`a2a-trust, agent-scoreboard, agents, approvals, audit, channels, config, dashboard, gateway, mcp, models, plugins, scheduler, sessions, skills, statistics, tools` — all switched from the legacy `<Panel>` wrapper to `<Card>`. Drops the now-unused `<Panel>` export from `ui.tsx` and the `.panel*` rules from `styles.css`. Maps the old `accent="warm"` variant to `variant="muted"` since both surface `--panel-muted`. Folds the sessions-layout `min-width: 0` and mobile padding rules into the Card module so the new component carries them universally.

### Cleanups

- Drops the unused `Card.interactive` prop + its CSS (no callers, ships unused API surface).
- Flattens a 3-deep ternary in `agent-scoreboard`.
- Restores a stray `panel-header` className in `skills` that referenced a since-deleted rule.
- Tightens the `MetricCard` loading API: explicit `loading?: boolean` prop instead of overloading `value=undefined`. The detail-skeleton now only renders when a `detail` prop is actually passed — fixes a hidden height-jump on the approvals page where loaded cards have no detail but the loading state was painting a phantom skeleton row.
- Updates `channels.test.tsx` to query the editor panel via `[data-slot="card"]` instead of `closest('section')` now that the underlying element is a `<div>`. (Was the CI fix on the original #896.)

## Files

- New: `console/src/components/card/{index.tsx,card.module.css}`
- Modified: `console/src/components/ui.tsx`, `console/src/styles.css`, and all 17 admin routes plus `channels.test.tsx`

## Test plan

- [x] `npm --workspace console run test` — 308 tests pass
- [x] `npm --workspace console run typecheck` clean
- [x] Visual smoke across every migrated admin page — layout intact, hairlines and spacing match the previous Panel rendering

## Related

Split out of #896. Stacks on #933 (toasts) and #934 (usage rollup).

## AI assistance

Drafted with Claude Code.