### PR TITLE
[codex] Harden npm supply-chain controls

### DIFF
--- a/.github/actions/setup-node-workspace/action.yml
+++ b/.github/actions/setup-node-workspace/action.yml
@@ -19,6 +19,10 @@ runs:
           container/package-lock.json
           console/package-lock.json
 
+    - name: Use npm 11
+      shell: bash
+      run: npm install --global npm@11.10.0 --no-audit --fund=false
+
     - name: Install root dependencies
       shell: bash
       env:
@@ -29,3 +33,7 @@ runs:
     - name: Install container dependencies
       shell: bash
       run: npm --prefix container ci --no-audit --fund=false
+
+    - name: Verify npm registry signatures
+      shell: bash
+      run: npm run audit:signatures

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -284,11 +284,13 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          # The package declares Node 22.x and .npmrc enforces engines during
-          # npm ci. The publish step invokes npm 11 through npx so trusted
-          # publishing does not require mutating the runner's bundled npm.
+          # The package declares Node 22.x and npm 11.x because .npmrc uses
+          # npm 11 supply-chain hardening such as min-release-age.
           node-version: 22
           cache: npm
+
+      - name: Use npm 11
+        run: npm install --global npm@11.10.0 --no-audit --fund=false
 
       - name: Install dependencies
         env:
@@ -306,4 +308,4 @@ jobs:
           else
             NPM_TAG="latest"
           fi
-          npx -y npm@11 publish --access public --tag "$NPM_TAG" --provenance
+          npm publish --access public --tag "$NPM_TAG" --provenance

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -297,6 +297,9 @@ jobs:
           ONNXRUNTIME_NODE_INSTALL_CUDA: skip
         run: npm ci
 
+      - name: Verify npm registry signatures
+        run: npm audit signatures
+
       - name: Build and verify pack contents
         run: npm run prepack
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 engine-strict=true
 save-exact=true
+min-release-age=7

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-COPY package*.json ./
+RUN npm install --global npm@11.10.0 --no-audit --fund=false
+
+COPY .npmrc package*.json ./
 COPY console/package*.json console/
 COPY scripts/postinstall-container.mjs scripts/
 RUN npm ci

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -160,6 +160,9 @@ controls:
 - CI upgrades to the pinned npm version before running `npm ci`, so pull
   requests and release publishes use the same install policy as local
   development.
+- Docker builds install the pinned npm version before npm install steps. The
+  gateway image copies the repository `.npmrc` before `npm ci`; the agent image
+  materializes the same safe npm config inside its isolated Docker context.
 - CI runs `npm audit signatures` after installs to verify npm registry
   signatures and available provenance attestations for installed packages.
 - Release publishing uses npm provenance through the trusted-publishing-capable
@@ -167,13 +170,15 @@ controls:
   publishing and to disallow token-based publishes after the OIDC workflow is
   verified.
 
-Dependency updates should use `npm ci` for verification, avoid blind `npm
-update`, and keep `package-lock.json` changes reviewable. Do not add git,
-tarball, or non-registry dependencies without a specific security review. The
-current WhatsApp channel dependency chain includes a pinned GitHub dependency
-from `@whiskeysockets/baileys` to `libsignal`; replacing that dependency with a
-registry-only package should be prioritized before enabling npm's `allow-git`
-restriction.
+Dependency updates should use `npm ci` for verification and keep
+`package-lock.json` changes reviewable. Avoid unconstrained interactive or
+ad-hoc `npm update` runs; use the lockfile-only update script below so npm's
+configured release-age gate applies and the resulting diff can be reviewed. Do
+not add git, tarball, or non-registry dependencies without a specific security
+review. The current WhatsApp channel dependency chain includes a pinned GitHub
+dependency from `@whiskeysockets/baileys` to `libsignal`; replacing that
+dependency with a registry-only package should be prioritized before enabling
+npm's `allow-git` restriction.
 
 Recommended dependency update workflow:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -148,6 +148,51 @@ Verification command:
 hybridclaw audit verify <sessionId>
 ```
 
+### 6) npm Supply-Chain Controls
+
+HybridClaw treats npm lockfiles and package-manager configuration as security
+controls:
+
+- `.npmrc` enforces exact saves, strict engines, and a seven-day minimum release
+  age.
+- `package.json` requires npm 11.10+ because older npm versions do not enforce
+  the release-age policy.
+- CI upgrades to the pinned npm version before running `npm ci`, so pull
+  requests and release publishes use the same install policy as local
+  development.
+- CI runs `npm audit signatures` after installs to verify npm registry
+  signatures and available provenance attestations for installed packages.
+- Release publishing uses npm provenance through the trusted-publishing-capable
+  npm CLI. The npm package should be configured on npmjs.com to use trusted
+  publishing and to disallow token-based publishes after the OIDC workflow is
+  verified.
+
+Dependency updates should use `npm ci` for verification, avoid blind `npm
+update`, and keep `package-lock.json` changes reviewable. Do not add git,
+tarball, or non-registry dependencies without a specific security review. The
+current WhatsApp channel dependency chain includes a pinned GitHub dependency
+from `@whiskeysockets/baileys` to `libsignal`; replacing that dependency with a
+registry-only package should be prioritized before enabling npm's `allow-git`
+restriction.
+
+Recommended dependency update workflow:
+
+```bash
+npm install --global npm@11.10.0 --no-audit --fund=false
+npm run deps:update-lockfile
+git diff -- package.json package-lock.json container/package.json container/package-lock.json
+npm run deps:verify
+npm run typecheck
+npm run test:unit
+```
+
+`deps:update-lockfile` regenerates the root/workspace lockfile and the standalone
+container lockfile through npm's configured seven-day release-age filter.
+`deps:verify` then performs clean installs from those lockfiles and verifies npm
+registry signatures. Review lockfile diffs before merging; unexpected new
+maintainers, new install scripts, git/tarball URLs, or large transitive churn
+should be treated as security review triggers.
+
 ## Incident Response
 
 If compromise is suspected:
@@ -157,6 +202,8 @@ If compromise is suspected:
 3. Review mount allowlist, workspace files, and `sessionRouting.identityLinks`.
 4. Inspect denied/authorization events with `hybridclaw audit approvals --denied`.
 5. Validate audit integrity with `hybridclaw audit verify`.
+6. If compromise may involve npm install-time malware, rotate npm, GitHub, SSH,
+   cloud, and registry credentials reachable from the affected host or runner.
 
 ## Reporting A Vulnerability
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,6 +1,14 @@
 # --- Build stage ---
 FROM node:22-slim@sha256:80fdb3f57c815e1b638d221f30a826823467c4a56c8f6a8d7aa091cd9b1675ea AS builder
 WORKDIR /app
+
+RUN --mount=type=cache,target=/root/.npm \
+    npm install --global npm@11.10.0 --no-audit --fund=false
+RUN printf '%s\n' \
+    'engine-strict=true' \
+    'save-exact=true' \
+    'min-release-age=7' \
+    > .npmrc
 COPY package.json package-lock.json ./
 RUN --mount=type=cache,target=/root/.npm \
     npm ci
@@ -16,6 +24,9 @@ ARG HYBRIDCLAW_VERSION=0.0.0
 LABEL org.opencontainers.image.source="https://github.com/HybridAIOne/hybridclaw"
 LABEL org.opencontainers.image.description="HybridClaw sandboxed agent runtime"
 LABEL org.opencontainers.image.version="${HYBRIDCLAW_VERSION}"
+
+RUN --mount=type=cache,target=/root/.npm \
+    npm install --global npm@11.10.0 --no-audit --fund=false
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
@@ -43,7 +54,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 WORKDIR /app
 
-COPY --link --from=builder /app/package.json /app/package-lock.json ./
+COPY --link --from=builder /app/.npmrc /app/package.json /app/package-lock.json ./
 RUN --mount=type=cache,target=/root/.npm \
     npm ci --omit=dev
 

--- a/container/package-lock.json
+++ b/container/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "hybridclaw-agent",
       "version": "0.16.0",
+      "packageManager": "npm@11.10.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
         "@mozilla/readability": "0.6.0",
@@ -24,6 +25,10 @@
       },
       "optionalDependencies": {
         "@napi-rs/canvas": "0.1.96"
+      },
+      "engines": {
+        "node": "22.x",
+        "npm": ">=11.10.0 <12"
       }
     },
     "node_modules/@appium/logger": {

--- a/container/package.json
+++ b/container/package.json
@@ -3,6 +3,11 @@
   "version": "0.16.0",
   "type": "module",
   "main": "dist/index.js",
+  "packageManager": "npm@11.10.0",
+  "engines": {
+    "node": "22.x",
+    "npm": ">=11.10.0 <12"
+  },
   "files": [
     "dist/",
     "shared/",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@hybridaione/hybridclaw",
       "version": "0.16.0",
+      "packageManager": "npm@11.10.0",
       "hasInstallScript": true,
       "workspaces": [
         "desktop",
@@ -21,7 +22,6 @@
         "@opentelemetry/exporter-trace-otlp-http": "0.214.0",
         "@opentelemetry/resources": "2.6.1",
         "@opentelemetry/sdk-node": "0.214.0",
-        "@opentelemetry/semantic-conventions": "1.40.0",
         "@slack/bolt": "4.7.0",
         "@whiskeysockets/baileys": "7.0.0-rc.9",
         "ajv": "8.18.0",
@@ -65,14 +65,14 @@
         "@types/yauzl": "2.10.3",
         "@types/yazl": "3.3.0",
         "@vitest/coverage-v8": "4.0.18",
-        "html-to-text": "9.0.5",
         "husky": "9.1.7",
         "tsx": "4.21.0",
         "typescript": "5.9.3",
         "vitest": "4.0.18"
       },
       "engines": {
-        "node": "22.x"
+        "node": "22.x",
+        "npm": ">=11.10.0 <12"
       },
       "optionalDependencies": {
         "appdmg": "0.6.6"
@@ -119,6 +119,10 @@
       "devDependencies": {
         "@types/node": "22.19.11",
         "typescript": "5.9.3"
+      },
+      "engines": {
+        "node": "22.x",
+        "npm": ">=11.10.0 <12"
       },
       "optionalDependencies": {
         "@napi-rs/canvas": "0.1.96"

--- a/package.json
+++ b/package.json
@@ -11,13 +11,15 @@
   "bugs": {
     "url": "https://github.com/HybridAIOne/hybridclaw/issues"
   },
+  "packageManager": "npm@11.10.0",
   "workspaces": [
     "desktop",
     "console",
     "container"
   ],
   "engines": {
-    "node": "22.x"
+    "node": "22.x",
+    "npm": ">=11.10.0 <12"
   },
   "publishConfig": {
     "access": "public"
@@ -68,6 +70,9 @@
     "test:integration": "vitest run --configLoader runner --config vitest.integration.config.ts --passWithNoTests",
     "test:e2e": "vitest run --configLoader runner --config vitest.e2e.config.ts --passWithNoTests",
     "test:console": "npm --workspace console run test",
+    "audit:signatures": "npm audit signatures && npm --prefix container audit signatures",
+    "deps:update-lockfile": "npm update --package-lock-only && npm --prefix container update --package-lock-only",
+    "deps:verify": "npm ci --no-audit --fund=false && npm --prefix container ci --no-audit --fund=false && npm run audit:signatures",
     "eval:trace-judge:gate": "HYBRIDCLAW_DATA_DIR=/tmp/hybridclaw-trace-judge-gate HYBRIDCLAW_DISABLE_CONFIG_WATCHER=1 node -e \"import('./dist/evals/trace-judge-native.js').then((m)=>m.runTraceJudgeNativeGate()).catch((err)=>{console.error(err);process.exitCode=1})\"",
     "eval:trace-judge:gate:live": "HYBRIDCLAW_DATA_DIR=/tmp/hybridclaw-trace-judge-live-gate HYBRIDCLAW_DISABLE_CONFIG_WATCHER=1 node -e \"import('./dist/evals/trace-judge-native.js').then((m)=>m.runTraceJudgeNativeGate({live:true})).catch((err)=>{console.error(err);process.exitCode=1})\"",
     "desktop": "npm run build:desktop && npm --workspace desktop run start",
@@ -94,7 +99,6 @@
     "@opentelemetry/exporter-trace-otlp-http": "0.214.0",
     "@opentelemetry/resources": "2.6.1",
     "@opentelemetry/sdk-node": "0.214.0",
-    "@opentelemetry/semantic-conventions": "1.40.0",
     "@slack/bolt": "4.7.0",
     "@huggingface/transformers": "3.8.1",
     "@ngrok/ngrok": "1.5.2",
@@ -137,7 +141,6 @@
     "@types/yauzl": "2.10.3",
     "@types/yazl": "3.3.0",
     "@vitest/coverage-v8": "4.0.18",
-    "html-to-text": "9.0.5",
     "husky": "9.1.7",
     "tsx": "4.21.0",
     "typescript": "5.9.3",


### PR DESCRIPTION
## Summary

- Require npm 11.10.x for root and container installs so npm's release-age policy is enforced consistently.
- Add a 7-day npm `min-release-age` gate, CI npm signature verification, and documented dependency update workflow.
- Remove unused direct root dependencies on `@opentelemetry/semantic-conventions` and `html-to-text` while leaving transitive copies resolved by their actual dependents.
- Keep release publishing on the pinned npm CLI while preserving provenance publishing.

## Security Notes

The repo still has a pinned GitHub dependency through `@whiskeysockets/baileys` -> `libsignal`, so this PR documents that as the blocker before enabling npm's `allow-git` restriction.

## Validation

- `git diff --check`
- JSON parse check for root and container package manifests/lockfiles
- `npm ci --dry-run --no-audit --fund=false` with npm 11.10.0
- Earlier local `npm audit signatures` checks passed before the unused direct dependency removal: root verified 1478 registry signatures / 191 attestations, container verified 361 registry signatures / 29 attestations.