### PR TITLE
[codex] Update GitHub Pages docs URL

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation and quick start
-    url: https://www.hybridclaw.io/docs/
+    url: https://hybridaione.github.io/hybridclaw/docs/
     about: Start here for installation, setup, configuration, and command reference.
   - name: GitHub Discussions
     url: https://github.com/HybridAIOne/hybridclaw/discussions

--- a/.github/ISSUE_TEMPLATE/docs_issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs_issue.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: Affected page or file
       description: Link the docs page URL or file path if you know it.
-      placeholder: https://www.hybridclaw.io/docs/getting-started/quickstart or README.md
+      placeholder: https://hybridaione.github.io/hybridclaw/docs/getting-started/quickstart or README.md
     validations:
       required: true
   - type: textarea

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![npm](https://img.shields.io/npm/v/@hybridaione/hybridclaw)](https://www.npmjs.com/package/@hybridaione/hybridclaw)
 [![Node](https://img.shields.io/badge/node-22.x-5FA04E?logo=node.js&logoColor=white)](https://nodejs.org/en/download)
 [![License](https://img.shields.io/github/license/HybridAIOne/hybridclaw)](https://github.com/HybridAIOne/hybridclaw/blob/main/LICENSE)
-[![Docs](https://img.shields.io/badge/docs-hybridclaw.io-blue)](https://www.hybridclaw.io/docs/)
+[![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://hybridaione.github.io/hybridclaw/docs/)
 [![Powered by HybridAI](https://img.shields.io/badge/powered%20by-HybridAI-blueviolet)](https://hybridai.one)
 [![Discord](https://img.shields.io/badge/Discord-join%20chat-5865F2?logo=discord&logoColor=white)](https://discord.gg/jsVW4vJw27)
 
@@ -23,22 +23,22 @@ Connect it to Discord, Slack, Signal, WhatsApp, Telegram, Microsoft Teams,
 email, Twilio voice, or the web. Run it locally, deploy it for business
 workflows, and keep your agents, secrets, and data under your control.
 
-[Quick Start](https://www.hybridclaw.io/docs/getting-started/quickstart) ·
-[Installation](https://www.hybridclaw.io/docs/getting-started/installation) ·
-[Configuration](https://www.hybridclaw.io/docs/reference/configuration) ·
-[Migration](https://www.hybridclaw.io/docs/reference/commands#migration) ·
+[Quick Start](https://hybridaione.github.io/hybridclaw/docs/getting-started/quickstart) ·
+[Installation](https://hybridaione.github.io/hybridclaw/docs/getting-started/installation) ·
+[Configuration](https://hybridaione.github.io/hybridclaw/docs/reference/configuration) ·
+[Migration](https://hybridaione.github.io/hybridclaw/docs/reference/commands#migration) ·
 [Contributing](./CONTRIBUTING.md) ·
 [Support](./SUPPORT.md)
 
 ## Pick your path
 
 - Want the shortest path to a running assistant? Start with
-  [Quick Start](https://www.hybridclaw.io/docs/getting-started/quickstart).
+  [Quick Start](https://hybridaione.github.io/hybridclaw/docs/getting-started/quickstart).
 - Want the full setup flow with providers, channels, and admin surfaces? Start
-  with [Installation](https://www.hybridclaw.io/docs/getting-started/installation)
-  and [Authentication](https://www.hybridclaw.io/docs/getting-started/authentication).
+  with [Installation](https://hybridaione.github.io/hybridclaw/docs/getting-started/installation)
+  and [Authentication](https://hybridaione.github.io/hybridclaw/docs/getting-started/authentication).
 - Want to migrate from OpenClaw or Hermes? Start with the
-  [migration commands](https://www.hybridclaw.io/docs/reference/commands#migration).
+  [migration commands](https://hybridaione.github.io/hybridclaw/docs/reference/commands#migration).
 - Want to contribute from source? Start with [CONTRIBUTING.md](./CONTRIBUTING.md)
   and the maintainer docs under [docs/content/README.md](./docs/content/README.md).
 
@@ -98,7 +98,7 @@ listening on `http://127.0.0.1:9090`.
 
 Release notes live in [CHANGELOG.md](./CHANGELOG.md), and the browsable
 operator and maintainer manual lives at
-[hybridclaw.io/docs](https://www.hybridclaw.io/docs/).
+[hybridaione.github.io/hybridclaw/docs](https://hybridaione.github.io/hybridclaw/docs/).
 
 ## See it in Action
 
@@ -317,55 +317,55 @@ Once the gateway is running, open HybridClaw locally:
 ## Documentation
 
 Browse the full manual at
-[hybridclaw.io/docs](https://www.hybridclaw.io/docs/).
+[hybridaione.github.io/hybridclaw/docs](https://hybridaione.github.io/hybridclaw/docs/).
 
 - Getting started:
-  [Installation](https://www.hybridclaw.io/docs/getting-started/installation),
-  [Authentication](https://www.hybridclaw.io/docs/getting-started/authentication), and
-  [Quick Start](https://www.hybridclaw.io/docs/getting-started/quickstart)
+  [Installation](https://hybridaione.github.io/hybridclaw/docs/getting-started/installation),
+  [Authentication](https://hybridaione.github.io/hybridclaw/docs/getting-started/authentication), and
+  [Quick Start](https://hybridaione.github.io/hybridclaw/docs/getting-started/quickstart)
 - Enterprise deployment:
-  [Runtime Internals](https://www.hybridclaw.io/docs/developer-guide/runtime) and
-  [Architecture](https://www.hybridclaw.io/docs/developer-guide/architecture)
+  [Runtime Internals](https://hybridaione.github.io/hybridclaw/docs/developer-guide/runtime) and
+  [Architecture](https://hybridaione.github.io/hybridclaw/docs/developer-guide/architecture)
 - Operations:
-  [Remote Access](https://www.hybridclaw.io/docs/guides/remote-access)
+  [Remote Access](https://hybridaione.github.io/hybridclaw/docs/guides/remote-access)
 - Security:
   [SECURITY.md](./SECURITY.md) and [TRUST_MODEL.md](./TRUST_MODEL.md)
 - Migration:
-  [Commands: Migration](https://www.hybridclaw.io/docs/reference/commands#migration) and
-  [FAQ](https://www.hybridclaw.io/docs/reference/faq#can-i-migrate-an-existing-openclaw-or-hermes-agent-home)
+  [Commands: Migration](https://hybridaione.github.io/hybridclaw/docs/reference/commands#migration) and
+  [FAQ](https://hybridaione.github.io/hybridclaw/docs/reference/faq#can-i-migrate-an-existing-openclaw-or-hermes-agent-home)
 - Channels:
-  [Connect Your First Channel](https://www.hybridclaw.io/docs/getting-started/first-channel),
-  [Overview](https://www.hybridclaw.io/docs/channels/overview),
-  [Twilio Voice](https://www.hybridclaw.io/docs/guides/twilio-voice),
-  [Discord](https://www.hybridclaw.io/docs/channels/discord),
-  [Slack](https://www.hybridclaw.io/docs/channels/slack),
-  [Telegram](https://www.hybridclaw.io/docs/channels/telegram),
-  [Signal](https://www.hybridclaw.io/docs/channels/signal),
-  [Threema](https://www.hybridclaw.io/docs/channels/threema),
-  [Email](https://www.hybridclaw.io/docs/channels/email),
-  [WhatsApp](https://www.hybridclaw.io/docs/channels/whatsapp),
-  [iMessage](https://www.hybridclaw.io/docs/channels/imessage), and
-  [Microsoft Teams](https://www.hybridclaw.io/docs/channels/msteams)
+  [Connect Your First Channel](https://hybridaione.github.io/hybridclaw/docs/getting-started/first-channel),
+  [Overview](https://hybridaione.github.io/hybridclaw/docs/channels/overview),
+  [Twilio Voice](https://hybridaione.github.io/hybridclaw/docs/guides/twilio-voice),
+  [Discord](https://hybridaione.github.io/hybridclaw/docs/channels/discord),
+  [Slack](https://hybridaione.github.io/hybridclaw/docs/channels/slack),
+  [Telegram](https://hybridaione.github.io/hybridclaw/docs/channels/telegram),
+  [Signal](https://hybridaione.github.io/hybridclaw/docs/channels/signal),
+  [Threema](https://hybridaione.github.io/hybridclaw/docs/channels/threema),
+  [Email](https://hybridaione.github.io/hybridclaw/docs/channels/email),
+  [WhatsApp](https://hybridaione.github.io/hybridclaw/docs/channels/whatsapp),
+  [iMessage](https://hybridaione.github.io/hybridclaw/docs/channels/imessage), and
+  [Microsoft Teams](https://hybridaione.github.io/hybridclaw/docs/channels/msteams)
 - Tutorials:
-  [Practical Workflows](https://www.hybridclaw.io/docs/tutorials) for owner,
+  [Practical Workflows](https://hybridaione.github.io/hybridclaw/docs/tutorials) for owner,
   GTM, marketing, sales, DevRel, content, invoicing, webinar, and release
   launch workflows
 - Skills and plugins:
-  [Extensibility](https://www.hybridclaw.io/docs/extensibility),
-  [Bundled Skills](https://www.hybridclaw.io/docs/guides/bundled-skills),
-  [Plugin System](https://www.hybridclaw.io/docs/extensibility/plugins),
-  [Memory Plugins](https://www.hybridclaw.io/docs/extensibility/memory-plugins),
-  [ByteRover Memory Plugin](https://www.hybridclaw.io/docs/extensibility/byterover-memory-plugin),
-  [GBrain Plugin](https://www.hybridclaw.io/docs/extensibility/gbrain-plugin),
-  [Mem0 Memory Plugin](https://www.hybridclaw.io/docs/extensibility/mem0-memory-plugin),
-  [Honcho Memory Plugin](https://www.hybridclaw.io/docs/extensibility/honcho-memory-plugin), and
-  [MemPalace Memory Plugin](https://www.hybridclaw.io/docs/extensibility/mempalace-memory-plugin)
+  [Extensibility](https://hybridaione.github.io/hybridclaw/docs/extensibility),
+  [Bundled Skills](https://hybridaione.github.io/hybridclaw/docs/guides/bundled-skills),
+  [Plugin System](https://hybridaione.github.io/hybridclaw/docs/extensibility/plugins),
+  [Memory Plugins](https://hybridaione.github.io/hybridclaw/docs/extensibility/memory-plugins),
+  [ByteRover Memory Plugin](https://hybridaione.github.io/hybridclaw/docs/extensibility/byterover-memory-plugin),
+  [GBrain Plugin](https://hybridaione.github.io/hybridclaw/docs/extensibility/gbrain-plugin),
+  [Mem0 Memory Plugin](https://hybridaione.github.io/hybridclaw/docs/extensibility/mem0-memory-plugin),
+  [Honcho Memory Plugin](https://hybridaione.github.io/hybridclaw/docs/extensibility/honcho-memory-plugin), and
+  [MemPalace Memory Plugin](https://hybridaione.github.io/hybridclaw/docs/extensibility/mempalace-memory-plugin)
 - Configuration:
-  [Configuration Reference](https://www.hybridclaw.io/docs/reference/configuration)
+  [Configuration Reference](https://hybridaione.github.io/hybridclaw/docs/reference/configuration)
 - CLI reference:
-  [Commands](https://www.hybridclaw.io/docs/reference/commands),
-  [Diagnostics](https://www.hybridclaw.io/docs/reference/diagnostics), and
-  [FAQ](https://www.hybridclaw.io/docs/reference/faq)
+  [Commands](https://hybridaione.github.io/hybridclaw/docs/reference/commands),
+  [Diagnostics](https://hybridaione.github.io/hybridclaw/docs/reference/diagnostics), and
+  [FAQ](https://hybridaione.github.io/hybridclaw/docs/reference/faq)
 
 ## Contributing
 

--- a/container/shared/network-policy.js
+++ b/container/shared/network-policy.js
@@ -5,10 +5,10 @@ export const DEFAULT_NETWORK_DEFAULT = 'deny';
 export const DEFAULT_NETWORK_RULES = [
   {
     action: 'allow',
-    host: 'hybridclaw.io',
+    host: 'hybridaione.github.io',
     port: 443,
     methods: ['*'],
-    paths: ['/**'],
+    paths: ['/hybridclaw/**'],
     agent: '*',
   },
 ];

--- a/docs/404.html
+++ b/docs/404.html
@@ -5,26 +5,27 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Page Not Found</title>
   <meta name="description" content="HybridClaw docs fallback page.">
-  <link rel="icon" type="image/svg+xml" href="/static/hybridclaw-logo.svg?v=brand">
-  <link rel="icon" type="image/png" sizes="96x96" href="/static/favicon-96x96.png">
-  <link rel="icon" type="image/x-icon" href="/static/favicon.ico">
-  <link rel="apple-touch-icon" sizes="180x180" href="/static/apple-touch-icon.png">
-  <link rel="stylesheet" href="/static/docs.css">
+  <link rel="icon" type="image/svg+xml" href="/hybridclaw/static/hybridclaw-logo.svg?v=brand">
+  <link rel="icon" type="image/png" sizes="96x96" href="/hybridclaw/static/favicon-96x96.png">
+  <link rel="icon" type="image/x-icon" href="/hybridclaw/static/favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="/hybridclaw/static/apple-touch-icon.png">
+  <link rel="stylesheet" href="/hybridclaw/static/docs.css">
 </head>
 <body>
   <div data-docs-app hidden></div>
   <main data-docs-fallback hidden style="max-width: 860px; margin: 0 auto; padding: 56px 20px; font-family: system-ui, sans-serif; color: #e6edf8;">
     <h1 style="margin: 0 0 16px; font-size: 2.4rem; line-height: 1.05;">Page Not Found</h1>
-    <p style="margin: 0 0 16px; color: #aab8cf;">The requested page does not exist. If you were trying to open the docs, use <a href="/docs/" style="color: #7da2ff;">/docs/</a>. Raw markdown is published under <code>/content/*.md</code>, and legacy <code>/development/*</code> paths redirect to the canonical docs routes for now.</p>
-    <p style="margin: 0;"><a href="/about" style="color: #7da2ff;">Back to home</a></p>
+    <p style="margin: 0 0 16px; color: #aab8cf;">The requested page does not exist. If you were trying to open the docs, use <a href="/hybridclaw/docs/" style="color: #7da2ff;">/docs/</a>. Raw markdown is published under <code>/content/*.md</code>, and legacy <code>/development/*</code> paths redirect to the canonical docs routes for now.</p>
+    <p style="margin: 0;"><a href="/hybridclaw/about" style="color: #7da2ff;">Back to home</a></p>
   </main>
   <script type="module">
-    import { mountDocsApp } from '/static/docs.js';
+    import { mountDocsApp } from '/hybridclaw/static/docs.js';
 
     mountDocsApp({
       allowFallback: true,
-      basePath: '/docs',
-      contentBasePath: '/content',
+      basePath: '/hybridclaw/docs',
+      contentBasePath: '/hybridclaw/content',
+      siteBasePath: '/hybridclaw',
     }).catch((error) => {
       console.error('Failed to mount docs app', error);
       const fallback = document.querySelector('[data-docs-fallback]');

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="refresh" content="0; url=/">
-  <link rel="canonical" href="/">
+  <meta http-equiv="refresh" content="0; url=/hybridclaw/">
+  <link rel="canonical" href="/hybridclaw/">
   <title>HybridClaw — About</title>
 </head>
 <body>
-  <p><a href="/">Continue to HybridClaw.</a></p>
+  <p><a href="/hybridclaw/">Continue to HybridClaw.</a></p>
 </body>
 </html>

--- a/docs/agents.html
+++ b/docs/agents.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>HybridClaw Agents</title>
-  <link rel="icon" type="image/svg+xml" href="/static/hybridclaw-logo.svg?v=brand">
-  <link rel="icon" type="image/png" sizes="96x96" href="/static/favicon-96x96.png">
-  <link rel="icon" type="image/x-icon" href="/static/favicon.ico">
-  <link rel="apple-touch-icon" sizes="180x180" href="/static/apple-touch-icon.png">
+  <link rel="icon" type="image/svg+xml" href="/hybridclaw/static/hybridclaw-logo.svg?v=brand">
+  <link rel="icon" type="image/png" sizes="96x96" href="/hybridclaw/static/favicon-96x96.png">
+  <link rel="icon" type="image/x-icon" href="/hybridclaw/static/favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="/hybridclaw/static/apple-touch-icon.png">
   <style>
     :root {
       --page-bg: #ffffff;
@@ -1151,7 +1151,7 @@
         <div class="brand">
           <img
             class="brand-logo"
-            src="/static/hybridclaw-logo.svg"
+            src="/hybridclaw/static/hybridclaw-logo.svg"
             alt="HybridClaw"
           >
           <span class="brand-name">HybridClaw</span>
@@ -1171,7 +1171,7 @@
       </div>
 
       <nav class="sidebar-nav" aria-label="Primary navigation">
-        <a class="sidebar-link is-active" href="/agents" aria-current="page">
+        <a class="sidebar-link is-active" href="/hybridclaw/agents" aria-current="page">
           <span class="sidebar-link-icon">
             <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <rect x="3" y="3" width="7" height="7" rx="2"></rect>
@@ -1182,7 +1182,7 @@
           </span>
           <span class="sidebar-link-label">Agents</span>
         </a>
-        <a class="sidebar-link" href="/chat">
+        <a class="sidebar-link" href="/hybridclaw/chat">
           <span class="sidebar-link-icon">
             <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
@@ -1190,7 +1190,7 @@
           </span>
           <span class="sidebar-link-label">Chat</span>
         </a>
-        <a class="sidebar-link" href="/admin">
+        <a class="sidebar-link" href="/hybridclaw/admin">
           <span class="sidebar-link-icon">
             <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <path d="M12 3l7 4v10l-7 4-7-4V7l7-4z"></path>
@@ -1226,7 +1226,7 @@
 
           <div class="page-actions">
             <nav class="view-switch" aria-label="Switch view">
-              <a class="view-switch-link" href="/chat">
+              <a class="view-switch-link" href="/hybridclaw/chat">
                 <span class="sidebar-link-icon">
                   <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
@@ -1234,7 +1234,7 @@
                 </span>
                 <span>Chat</span>
               </a>
-              <a class="view-switch-link is-active" href="/agents" aria-current="page">
+              <a class="view-switch-link is-active" href="/hybridclaw/agents" aria-current="page">
                 <span class="sidebar-link-icon">
                   <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <rect x="3" y="3" width="7" height="7" rx="2"></rect>
@@ -1245,7 +1245,7 @@
                 </span>
                 <span>Agents</span>
               </a>
-              <a class="view-switch-link" href="/admin">
+              <a class="view-switch-link" href="/hybridclaw/admin">
                 <span class="sidebar-link-icon">
                   <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <path d="M12 3l7 4v10l-7 4-7-4V7l7-4z"></path>
@@ -1263,7 +1263,7 @@
                 </span>
                 <span>GitHub</span>
               </a>
-              <a class="view-switch-link" href="/docs">
+              <a class="view-switch-link" href="/hybridclaw/docs">
                 <span class="sidebar-link-icon">
                   <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path>

--- a/docs/content/developer-guide/approvals.md
+++ b/docs/content/developer-guide/approvals.md
@@ -18,7 +18,7 @@ user explicitly approves or denies it.
 | Pending red approvals | `3` | New blocked actions are denied once the queue is full |
 | Approval timeout | `120s` | Expired requests are removed from the pending queue |
 | Network default | `deny` | Unmatched HTTP/network access falls back to prompt unless changed to `allow` |
-| Seeded network rule | `allow hybridclaw.io:443 * /** agent=*` | New workspaces start with one explicit allow rule |
+| Seeded network rule | `allow hybridaione.github.io:443 * /hybridclaw/** agent=*` | New workspaces start with one explicit allow rule |
 | Workspace fence | `on` | Writes outside the workspace are blocked by default |
 | Agent trust file | `.hybridclaw/approval-agent-trust.json` | Durable `yes for agent` trust |
 | Workspace allowlist file | `approval-trust.json` | Durable `yes for all` trust |

--- a/docs/content/guides/skills/integrations.md
+++ b/docs/content/guides/skills/integrations.md
@@ -429,7 +429,7 @@ commands, runtime behavior, and release notes.
 
 > 💡 **Tips & Tricks**
 >
-> The skill consults public docs at `hybridclaw.io/docs` first, then falls back to GitHub source files.
+> The skill consults public docs at `hybridaione.github.io/hybridclaw/docs` first, then falls back to GitHub source files.
 >
 > It checks the CHANGELOG for recent changes when relevant.
 >

--- a/docs/development/index.html
+++ b/docs/development/index.html
@@ -4,16 +4,16 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Legacy Docs Redirect</title>
-  <meta http-equiv="refresh" content="0; url=/docs/">
-  <link rel="canonical" href="/docs/">
+  <meta http-equiv="refresh" content="0; url=/hybridclaw/docs/">
+  <link rel="canonical" href="/hybridclaw/docs/">
 </head>
 <body>
   <main style="max-width: 860px; margin: 0 auto; padding: 48px 20px; font-family: system-ui, sans-serif; color: #e6edf8; background: #08111f;">
     <h1>Legacy Docs Redirect</h1>
-    <p>The legacy <code>/development/</code> docs path now redirects to the canonical <a href="/docs/">/docs/</a> route.</p>
+    <p>The legacy <code>/development/</code> docs path now redirects to the canonical <a href="/hybridclaw/docs/">/docs/</a> route.</p>
   </main>
   <script>
-    window.location.replace('/docs/');
+    window.location.replace('/hybridclaw/docs/');
   </script>
 </body>
 </html>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -5,26 +5,27 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>HybridClaw Docs</title>
   <meta name="description" content="Browse the HybridClaw docs, open the underlying markdown, or copy any page as markdown.">
-  <link rel="icon" type="image/svg+xml" href="/static/hybridclaw-logo.svg?v=brand">
-  <link rel="icon" type="image/png" sizes="96x96" href="/static/favicon-96x96.png">
-  <link rel="icon" type="image/x-icon" href="/static/favicon.ico">
-  <link rel="apple-touch-icon" sizes="180x180" href="/static/apple-touch-icon.png">
-  <link rel="stylesheet" href="/static/docs.css">
+  <link rel="icon" type="image/svg+xml" href="/hybridclaw/static/hybridclaw-logo.svg?v=brand">
+  <link rel="icon" type="image/png" sizes="96x96" href="/hybridclaw/static/favicon-96x96.png">
+  <link rel="icon" type="image/x-icon" href="/hybridclaw/static/favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="/hybridclaw/static/apple-touch-icon.png">
+  <link rel="stylesheet" href="/hybridclaw/static/docs.css">
 </head>
 <body>
   <div data-docs-app hidden></div>
   <noscript>
     <main style="max-width: 860px; margin: 0 auto; padding: 48px 20px; font-family: system-ui, sans-serif; color: #e6edf8; background: #08111f;">
       <h1>HybridClaw Docs</h1>
-      <p>JavaScript is required for the browsable docs shell. You can still open the raw markdown directly, starting with <a href="/content/README.md">/content/README.md</a>.</p>
+      <p>JavaScript is required for the browsable docs shell. You can still open the raw markdown directly, starting with <a href="/hybridclaw/content/README.md">/content/README.md</a>.</p>
     </main>
   </noscript>
   <script type="module">
-    import { mountDocsApp } from '/static/docs.js';
+    import { mountDocsApp } from '/hybridclaw/static/docs.js';
 
     mountDocsApp({
-      basePath: '/docs',
-      contentBasePath: '/content',
+      basePath: '/hybridclaw/docs',
+      contentBasePath: '/hybridclaw/content',
+      siteBasePath: '/hybridclaw',
     }).catch((error) => {
       console.error('Failed to mount docs app', error);
     });

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,8 +9,8 @@
   <meta property="og:site_name" content="HybridClaw">
   <meta property="og:title" content="HybridClaw — Enterprise AI Digital Coworker">
   <meta property="og:description" content="One assistant brain across Discord, Slack, Telegram, Signal, Teams, iMessage, WhatsApp, email, web, and terminal with shared memory, bundled skills, and safe execution flow.">
-  <meta property="og:url" content="https://github.com/HybridAIOne/hybridclaw">
-  <meta property="og:image" content="https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/docs/hero.png">
+  <meta property="og:url" content="https://hybridaione.github.io/hybridclaw/">
+  <meta property="og:image" content="https://hybridaione.github.io/hybridclaw/hero.png">
   <meta property="og:image:type" content="image/png">
   <meta property="og:image:width" content="1536">
   <meta property="og:image:height" content="1024">
@@ -18,12 +18,12 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="HybridClaw — Enterprise AI Digital Coworker">
   <meta name="twitter:description" content="One assistant brain across Discord, Slack, Telegram, Signal, Teams, iMessage, WhatsApp, email, web, and terminal with shared memory, bundled skills, and safe execution flow.">
-  <meta name="twitter:image" content="https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/docs/hero.png">
-  <link rel="canonical" href="https://github.com/HybridAIOne/hybridclaw">
-  <link rel="icon" type="image/svg+xml" href="/static/hybridclaw-logo.svg?v=brand">
-  <link rel="icon" type="image/png" sizes="96x96" href="/static/favicon-96x96.png">
-  <link rel="icon" type="image/x-icon" href="/static/favicon.ico">
-  <link rel="apple-touch-icon" sizes="180x180" href="/static/apple-touch-icon.png">
+  <meta name="twitter:image" content="https://hybridaione.github.io/hybridclaw/hero.png">
+  <link rel="canonical" href="https://hybridaione.github.io/hybridclaw/">
+  <link rel="icon" type="image/svg+xml" href="/hybridclaw/static/hybridclaw-logo.svg?v=brand">
+  <link rel="icon" type="image/png" sizes="96x96" href="/hybridclaw/static/favicon-96x96.png">
+  <link rel="icon" type="image/x-icon" href="/hybridclaw/static/favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="/hybridclaw/static/apple-touch-icon.png">
   <style>
     :root {
       --bg: #0a1221;
@@ -735,7 +735,7 @@
         '@type': 'Organization',
         name: 'HybridAI GmbH',
         url: 'https://hybridai.one',
-        logo: 'https://www.hybridclaw.io/hero.png',
+        logo: 'https://hybridaione.github.io/hybridclaw/hero.png',
         foundingDate: '2024-01-01',
         sameAs: [
           'https://www.linkedin.com/company/hybridai-one/',
@@ -746,27 +746,27 @@
       {
         '@type': 'WebSite',
         name: 'HybridClaw',
-        url: 'https://www.hybridclaw.io',
+        url: 'https://hybridaione.github.io/hybridclaw/',
         publisher: {
           '@type': 'Organization',
           name: 'HybridAI GmbH',
           url: 'https://hybridai.one'
         },
         sameAs: [
-          'https://www.hybridclaw.io/docs/',
+          'https://hybridaione.github.io/hybridclaw/docs/',
           'https://github.com/HybridAIOne/hybridclaw'
         ],
         potentialAction: {
           '@type': 'SearchAction',
-          target: 'https://www.hybridclaw.io/search?q={search_term_string}',
+          target: 'https://hybridaione.github.io/hybridclaw/search?q={search_term_string}',
           'query-input': 'required name=search_term_string'
         }
       },
       {
         '@type': 'SoftwareApplication',
         name: 'HybridClaw AI Agent',
-        url: 'https://www.hybridclaw.io',
-        image: 'https://www.hybridclaw.io/hero.png',
+        url: 'https://hybridaione.github.io/hybridclaw/',
+        image: 'https://hybridaione.github.io/hybridclaw/hero.png',
         operatingSystem: 'All',
         applicationCategory: 'AI Agent',
         publisher: {
@@ -776,7 +776,7 @@
         },
         sameAs: [
           'https://github.com/HybridAIOne/hybridclaw',
-          'https://www.hybridclaw.io/docs/'
+          'https://hybridaione.github.io/hybridclaw/docs/'
         ],
         offers: {
           '@type': 'Offer',
@@ -798,7 +798,7 @@
 <nav>
   <div class="nav-inner">
     <a class="nav-logo" href="#" aria-label="HybridClaw Home">
-      <img src="/static/hybridclaw-logo.svg" alt="HybridClaw logo" class="nav-logo-img">
+      <img src="/hybridclaw/static/hybridclaw-logo.svg" alt="HybridClaw logo" class="nav-logo-img">
       <span class="nav-logo-text">HybridClaw</span>
     </a>
     <div class="nav-links">
@@ -818,7 +818,7 @@
         <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><title>GitHub</title><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
         GitHub
       </a>
-      <a href="/docs/" class="nav-gh">Docs</a>
+      <a href="/hybridclaw/docs/" class="nav-gh">Docs</a>
     </div>
   </div>
 </nav>
@@ -845,7 +845,7 @@
   </div>
   <div class="hero-cta">
     <a href="#quickstart" class="btn btn-primary">Get Started</a>
-    <a href="/docs/" class="btn btn-secondary">Read Docs</a>
+    <a href="/hybridclaw/docs/" class="btn btn-secondary">Read Docs</a>
     <a href="#comparison" class="btn btn-secondary">See Comparison</a>
     <a href="#features" class="btn btn-secondary">See Features</a>
   </div>
@@ -1828,7 +1828,7 @@ function switchQsTab(tab) {
   <div class="footer-inner">
     <div class="footer-links">
       <a href="https://github.com/HybridAIOne/hybridclaw">GitHub</a>
-      <a href="/docs/">Docs</a>
+      <a href="/hybridclaw/docs/">Docs</a>
       <a href="https://discord.gg/jsVW4vJw27">Discord</a>
       <a href="#features">Features</a>
       <a href="#architecture">Architecture</a>

--- a/docs/static/docs.js
+++ b/docs/static/docs.js
@@ -272,7 +272,7 @@ const DOCS_SEARCH_ENTRIES = DEVELOPMENT_DOCS_SECTIONS.flatMap((section) =>
   section.pages.map((page) => ({
     label: page.title,
     parentTitle: section.title,
-    routePath: buildDocHtmlHref(page.path),
+    path: page.path,
   })),
 );
 
@@ -287,6 +287,14 @@ export function normalizeDocPath(input) {
 function normalizeBasePath(basePath = DOCS_BASE_PATH) {
   const normalized = normalizeDocPath(basePath);
   return normalized ? `/${normalized.replace(/\/$/, '')}` : '';
+}
+
+function buildSiteHref(pathname, siteBasePath = '') {
+  const normalizedBasePath = normalizeBasePath(siteBasePath);
+  const normalizedPathname = String(pathname || '/').startsWith('/')
+    ? String(pathname || '/')
+    : `/${String(pathname || '/')}`;
+  return `${normalizedBasePath}${normalizedPathname}`;
 }
 
 function rewriteLegacyDocPath(docPath) {
@@ -1021,7 +1029,7 @@ function scrollToHash() {
   });
 }
 
-function renderNotFoundState(mount, docPath, basePath) {
+function renderNotFoundState(mount, docPath, basePath, siteBasePath) {
   document.title = 'Docs Not Found · HybridClaw';
   mount.innerHTML = `
     <div class="docs-app-shell">
@@ -1029,12 +1037,16 @@ function renderNotFoundState(mount, docPath, basePath) {
         <a class="docs-brand" href="${escapeHtml(
           buildDocHtmlHref('README.md', basePath),
         )}">
-          <img src="/static/hybridclaw-logo.svg" alt="HybridClaw">
+          <img src="${escapeHtml(
+            buildSiteHref('/static/hybridclaw-logo.svg', siteBasePath),
+          )}" alt="HybridClaw">
           <span>HybridClaw</span>
           <span class="docs-brand-accent">Docs</span>
         </a>
         <nav class="docs-topnav" aria-label="Top navigation">
-          <a href="/about">Home</a>
+          <a href="${escapeHtml(
+            buildSiteHref('/about', siteBasePath),
+          )}">Home</a>
           <a href="${GITHUB_REPO_URL}" target="_blank" rel="noreferrer">GitHub ${renderExternalLinkIcon()}</a>
           <a href="${DISCORD_URL}" target="_blank" rel="noreferrer">Discord ${renderExternalLinkIcon()}</a>
         </nav>
@@ -1095,6 +1107,7 @@ export async function mountDocsApp(options = {}) {
 
   const basePath = options.basePath || DOCS_BASE_PATH;
   const contentBasePath = options.contentBasePath || basePath;
+  const siteBasePath = options.siteBasePath || '';
   const mount = document.querySelector(
     options.mountSelector || '[data-docs-app]',
   );
@@ -1125,14 +1138,14 @@ export async function mountDocsApp(options = {}) {
 
   const docPath = resolveDocPathFromPathname(pathname, basePath);
   if (!KNOWN_DOC_PATHS.has(docPath)) {
-    renderNotFoundState(mount, docPath, basePath);
+    renderNotFoundState(mount, docPath, basePath, siteBasePath);
     return false;
   }
 
   const markdownHref = buildDocMarkdownHref(docPath, basePath, contentBasePath);
   const response = await fetch(markdownHref, { cache: 'no-store' });
   if (!response.ok) {
-    renderNotFoundState(mount, docPath, basePath);
+    renderNotFoundState(mount, docPath, basePath, siteBasePath);
     return false;
   }
 
@@ -1150,12 +1163,16 @@ export async function mountDocsApp(options = {}) {
         <a class="docs-brand" href="${escapeHtml(
           buildDocHtmlHref('README.md', basePath),
         )}">
-          <img src="/static/hybridclaw-logo.svg" alt="HybridClaw">
+          <img src="${escapeHtml(
+            buildSiteHref('/static/hybridclaw-logo.svg', siteBasePath),
+          )}" alt="HybridClaw">
           <span>HybridClaw</span>
           <span class="docs-brand-accent">Docs</span>
         </a>
         <nav class="docs-topnav" aria-label="Top navigation">
-          <a href="/about">Home</a>
+          <a href="${escapeHtml(
+            buildSiteHref('/about', siteBasePath),
+          )}">Home</a>
           <a href="${GITHUB_REPO_URL}" target="_blank" rel="noreferrer">GitHub ${renderExternalLinkIcon()}</a>
           <a href="${DISCORD_URL}" target="_blank" rel="noreferrer">Discord ${renderExternalLinkIcon()}</a>
         </nav>
@@ -1291,7 +1308,7 @@ export async function mountDocsApp(options = {}) {
     for (const entry of matches) {
       const link = document.createElement('a');
       link.className = 'docs-search-result';
-      link.href = entry.routePath;
+      link.href = buildDocHtmlHref(entry.path, basePath);
 
       const title = document.createElement('strong');
       title.textContent = entry.label;
@@ -1331,8 +1348,8 @@ export async function mountDocsApp(options = {}) {
       }
       if (event.key === 'Enter') {
         const matches = renderSearchResults(searchInput.value || '');
-        if (matches[0]?.routePath) {
-          window.location.href = matches[0].routePath;
+        if (matches[0]?.path) {
+          window.location.href = buildDocHtmlHref(matches[0].path, basePath);
         }
       }
     });

--- a/src/agent/prompt-hooks.ts
+++ b/src/agent/prompt-hooks.ts
@@ -433,7 +433,7 @@ function buildSafetyHook(context: PromptHookContext): string {
     'Decision rule: use `web_search` to discover relevant URLs when the target page is not already known, then use `web_fetch` for read-only content retrieval.',
     'Use `http_request` for direct API calls that need a specific method, headers, JSON body, or secret-backed auth injection. Prefer it over `bash` + `curl` for HTTP APIs.',
     'When a request needs a stored secret, use `http_request` with `bearerSecretName`, `secretHeaders`, configured URL auth routes, or strict `<secret:NAME>` placeholders. For browser credential fields, use `browser_secret_type` with a stored secret name. Never emit the real token in prose or tool arguments.',
-    'For HybridClaw product, setup, configuration, command, runtime behavior, or release-note questions: call `web_fetch` on the public docs at `https://www.hybridclaw.io/docs/` or the most specific `https://www.hybridclaw.io/docs/...` page before answering. Do not answer from memory if no fetch was attempted.',
+    'For HybridClaw product, setup, configuration, command, runtime behavior, or release-note questions: call `web_fetch` on the local docs route at `/docs/` or the most specific `/docs/...` page before answering. Do not answer from memory if no fetch was attempted.',
     'Use `web_extract` when you want the fetched page condensed into a model-processed markdown summary; it is higher cost than `web_fetch` because it runs an auxiliary model after extraction.',
     'Use browser tools only when at least one of these is true: (1) known app-like/auth-gated URL, (2) interaction is required (click/type/login/scroll), (3) `web_fetch` returned escalation hints, (4) user explicitly requested browser use.',
     'Prefer browser for: SPAs/client-rendered apps (React/Vue/Angular/Next client routes), dashboards/web apps, social feeds, login/OAuth/cookie-consent/CAPTCHA flows, or API-driven pages that populate after initial render.',
@@ -593,7 +593,7 @@ function buildRuntimeHook(context: PromptHookContext): string {
   const lines = [
     '## Runtime Metadata',
     `HybridClaw version: v${APP_VERSION}`,
-    'HybridClaw Documentation: [https://www.hybridclaw.io/docs/](https://www.hybridclaw.io/docs/)',
+    'HybridClaw Documentation: [/docs/](/docs/)',
     `Date (UTC): ${new Date().toISOString().slice(0, 10)}`,
     modelSentence,
     runtimeInfo.channelId?.trim()

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -65,10 +65,10 @@ network:
   default: deny
   rules:
     - action: allow
-      host: "hybridclaw.io"
+      host: "hybridaione.github.io"
       port: 443
       methods: ["*"]
-      paths: ["/**"]
+      paths: ["/hybridclaw/**"]
       agent: "*"
   presets: []
 

--- a/tests/approval-policy.test.ts
+++ b/tests/approval-policy.test.ts
@@ -745,7 +745,7 @@ network:
     expect(loaded.networkDefault).toBe('deny');
     expect(loaded.networkRules).toEqual([
       expect.objectContaining({
-        host: 'hybridclaw.io',
+        host: 'hybridaione.github.io',
         action: 'allow',
       }),
     ]);
@@ -2133,18 +2133,18 @@ network:
     expect(httpEvaluation.decision).toBe('auto');
   });
 
-  test('hybridclaw.io is allowlisted by default and does not require approval', () => {
+  test('GitHub Pages docs are allowlisted by default and do not require approval', () => {
     const runtime = new TrustedAgentApprovalRuntime(
       '/tmp/hybridclaw-missing-policy.yaml',
     );
 
     const evaluation = runtime.evaluateToolCall({
       toolName: 'web_fetch',
-      argsJson: JSON.stringify({ url: 'https://www.hybridclaw.io/docs/' }),
+      argsJson: JSON.stringify({ url: 'https://hybridaione.github.io/hybridclaw/docs/' }),
       latestUserPrompt: 'Open the HybridClaw docs',
     });
 
-    expect(evaluation.actionKey).toBe('network:hybridclaw.io');
+    expect(evaluation.actionKey).toBe('network:github.io');
     expect(evaluation.tier).toBe('green');
     expect(evaluation.decision).toBe('auto');
     expect(evaluation.reason).toBe(

--- a/tests/docs-viewer.test.ts
+++ b/tests/docs-viewer.test.ts
@@ -19,8 +19,8 @@ describe('docs viewer helpers', () => {
       'utf8',
     );
 
-    expect(aboutHtml).toContain('url=/');
-    expect(aboutHtml).toContain('href="/"');
+    expect(aboutHtml).toContain('url=/hybridclaw/');
+    expect(aboutHtml).toContain('href="/hybridclaw/"');
   });
 
   test('maps clean routes to markdown paths', () => {
@@ -60,6 +60,25 @@ describe('docs viewer helpers', () => {
     expect(
       buildDocMarkdownHref('extensibility/skills.md', '/docs', '/content'),
     ).toBe('/content/extensibility/skills.md');
+  });
+
+  test('builds routes for the GitHub Pages project base path', () => {
+    expect(
+      resolveDocPathFromPathname(
+        '/hybridclaw/docs/extensibility/skills',
+        '/hybridclaw/docs',
+      ),
+    ).toBe('extensibility/skills.md');
+    expect(buildDocHtmlHref('README.md', '/hybridclaw/docs')).toBe(
+      '/hybridclaw/docs/',
+    );
+    expect(
+      buildDocMarkdownHref(
+        'extensibility/skills.md',
+        '/hybridclaw/docs',
+        '/hybridclaw/content',
+      ),
+    ).toBe('/hybridclaw/content/extensibility/skills.md');
   });
 
   test('exposes remote access in the guides section metadata', () => {

--- a/tests/gateway-service.scheduler.test.ts
+++ b/tests/gateway-service.scheduler.test.ts
@@ -438,7 +438,7 @@ test('scheduled agent turns persist outputs for admin jobs detail', async () => 
 
   await runIsolatedScheduledTask({
     taskId: 249,
-    prompt: 'summarize the hybridclaw.io webpage',
+    prompt: 'summarize the HybridClaw docs page',
     channelId: 'tui',
     chatbotId: 'test-chatbot',
     model: 'gpt-4o-mini',
@@ -463,7 +463,7 @@ test('scheduled agent turns persist outputs for admin jobs detail', async () => 
   ).toEqual([
     {
       role: 'user',
-      content: 'summarize the hybridclaw.io webpage',
+      content: 'summarize the HybridClaw docs page',
     },
     {
       role: 'assistant',

--- a/tests/policy-cli.test.ts
+++ b/tests/policy-cli.test.ts
@@ -63,7 +63,7 @@ test('policy command supports status, allow, list, default, and delete flows', (
   expect(JSON.parse(listJson.text)).toMatchObject({
     default: 'deny',
     rules: expect.arrayContaining([
-      expect.objectContaining({ host: 'hybridclaw.io', agent: '*' }),
+      expect.objectContaining({ host: 'hybridaione.github.io', agent: '*' }),
       expect.objectContaining({ host: 'api.github.com', agent: 'main' }),
     ]),
   });
@@ -165,7 +165,7 @@ test('policy preset commands support list, dry-run, apply, and remove', () => {
   state = readPolicyState(workspacePath);
   expect(state.presets).toEqual([]);
   expect(state.rules).toEqual([
-    expect.objectContaining({ host: 'hybridclaw.io' }),
+    expect.objectContaining({ host: 'hybridaione.github.io' }),
   ]);
 });
 

--- a/tests/policy-remote-update.test.ts
+++ b/tests/policy-remote-update.test.ts
@@ -220,7 +220,7 @@ network:
         (readPolicy().network as { rules?: Array<{ host?: string }> }).rules ||
         []
       ).map((rule) => rule.host),
-    ).toEqual(['hybridclaw.io']);
+    ).toEqual(['hybridaione.github.io']);
   });
 
   test('rejects pipeline reorder operations outside the v1 update contract', async () => {
@@ -339,7 +339,7 @@ network:
       intent: 'policy.update',
       content: JSON.stringify({
         update_id: 'baseline-1',
-        operations: [{ kind: 'allowlist.add', host: 'docs.hybridclaw.io' }],
+        operations: [{ kind: 'allowlist.add', host: 'docs.example.com' }],
       }),
       created_at: '2026-05-01T10:00:00.000Z',
       version: '1',
@@ -369,7 +369,7 @@ network:
         (readPolicy().network as { rules?: Array<{ host?: string }> }).rules ||
         []
       ).map((rule) => rule.host),
-    ).toContain('docs.hybridclaw.io');
+    ).toContain('docs.example.com');
     expect(
       fs.existsSync(path.join(serverCwd, '.hybridclaw', 'policy.yaml')),
     ).toBe(false);
@@ -416,7 +416,7 @@ network:
           thread_id: 'policy-thread',
           intent: 'policy.update',
           content: JSON.stringify({
-            operations: [{ kind: 'allowlist.add', host: 'docs.hybridclaw.io' }],
+            operations: [{ kind: 'allowlist.add', host: 'docs.example.com' }],
           }),
           created_at: '2026-05-01T10:01:00.000Z',
           version: '1',

--- a/tests/policy-store.test.ts
+++ b/tests/policy-store.test.ts
@@ -44,10 +44,10 @@ test('reads the default network policy when policy.yaml is missing', () => {
     expect.objectContaining({
       index: 1,
       action: 'allow',
-      host: 'hybridclaw.io',
+      host: 'hybridaione.github.io',
       port: 443,
       methods: ['*'],
-      paths: ['/**'],
+      paths: ['/hybridclaw/**'],
       agent: '*',
     }),
   ]);
@@ -116,7 +116,7 @@ test('updates default action, deletes rules by host, and resets to the packaged 
   expect(deleted.deleted[0]?.host).toBe('api.openai.com');
   state = deleted.state;
   expect(state.rules).toEqual([
-    expect.objectContaining({ host: 'hybridclaw.io' }),
+    expect.objectContaining({ host: 'hybridaione.github.io' }),
   ]);
 
   state = resetPolicyNetwork(workspacePath);
@@ -124,10 +124,10 @@ test('updates default action, deletes rules by host, and resets to the packaged 
   expect(state.presets).toEqual([]);
   expect(state.rules).toEqual([
     expect.objectContaining({
-      host: 'hybridclaw.io',
+      host: 'hybridaione.github.io',
       action: 'allow',
       methods: ['*'],
-      paths: ['/**'],
+      paths: ['/hybridclaw/**'],
       agent: '*',
     }),
   ]);

--- a/tests/prompt-hooks.tool-summary.test.ts
+++ b/tests/prompt-hooks.tool-summary.test.ts
@@ -193,7 +193,7 @@ test('buildSystemPromptFromHooks adds mandatory routing instructions for availab
     'When a request needs a stored secret, use `http_request` with `bearerSecretName`, `secretHeaders`, configured URL auth routes, or strict `<secret:NAME>` placeholders. For browser credential fields, use `browser_secret_type` with a stored secret name. Never emit the real token in prose or tool arguments.',
   );
   expect(prompt).toContain(
-    'For HybridClaw product, setup, configuration, command, runtime behavior, or release-note questions: call `web_fetch` on the public docs at `https://www.hybridclaw.io/docs/` or the most specific `https://www.hybridclaw.io/docs/...` page before answering. Do not answer from memory if no fetch was attempted.',
+    'For HybridClaw product, setup, configuration, command, runtime behavior, or release-note questions: call `web_fetch` on the local docs route at `/docs/` or the most specific `/docs/...` page before answering. Do not answer from memory if no fetch was attempted.',
   );
   expect(prompt).toContain(
     'For structured documents, extracted fields, and comparisons, prefer complete field coverage over extreme brevity.',
@@ -250,7 +250,7 @@ test('buildSystemPromptFromHooks uses the provided workspace path in runtime met
 
   expect(prompt).toContain('Workspace: /tmp/hybridclaw-agent-workspace');
   expect(prompt).toContain(
-    'HybridClaw Documentation: [https://www.hybridclaw.io/docs/](https://www.hybridclaw.io/docs/)',
+    'HybridClaw Documentation: [/docs/](/docs/)',
   );
 });
 


### PR DESCRIPTION
## Summary

- Update public docs links from the old HybridClaw custom domain to `https://hybridaione.github.io/hybridclaw/`.
- Adjust static Pages assets/routes for the `/hybridclaw/` project base path.
- Keep runtime agent docs references local at `/docs/` for gateway/chat users.
- Update the default external network allowlist to `hybridaione.github.io:443 /hybridclaw/**` and align tests/docs.

## Validation

- `npm run format`
- `npm run lint`
- `npx vitest run --configLoader runner --config vitest.unit.config.ts tests/docs-viewer.test.ts tests/prompt-hooks.tool-summary.test.ts tests/policy-store.test.ts tests/policy-cli.test.ts tests/approval-policy.test.ts tests/policy-remote-update.test.ts tests/gateway-service.scheduler.test.ts`

## Notes

`mail.hybridclaw.io` and `mx.hybridclaw.io` references were intentionally left unchanged.