### PR TITLE
[codex] add SearXNG adapter and search skills

### DIFF
--- a/container/src/search-utils.ts
+++ b/container/src/search-utils.ts
@@ -1,0 +1,62 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function decodeEntities(value: string): string {
+  return value
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) =>
+      String.fromCharCode(Number.parseInt(hex, 16)),
+    )
+    .replace(/&#(\d+);/gi, (_, dec) =>
+      String.fromCharCode(Number.parseInt(dec, 10)),
+    );
+}
+
+export function stripTags(value: string): string {
+  return decodeEntities(value.replace(/<[^>]+>/g, ''));
+}
+
+export function normalizeWhitespace(value: string): string {
+  return String(value || '')
+    .replace(/\r/g, '')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/[ \t]{2,}/g, ' ')
+    .trim();
+}
+
+export function validateHttpUrl(value: string): string | null {
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return null;
+    }
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function normalizeResultUrl(value: unknown): string | null {
+  const normalized = String(value || '').trim();
+  if (!normalized) return null;
+  return validateHttpUrl(normalized);
+}
+
+export function dedupeResults<T extends { url: string }>(results: T[]): T[] {
+  const seen = new Set<string>();
+  const deduped: T[] = [];
+  for (const result of results) {
+    const urlKey = result.url.toLowerCase();
+    if (seen.has(urlKey)) continue;
+    seen.add(urlKey);
+    deduped.push(result);
+  }
+  return deduped;
+}

--- a/container/src/searxng-client.ts
+++ b/container/src/searxng-client.ts
@@ -1,5 +1,14 @@
+import {
+  dedupeResults,
+  isRecord,
+  normalizeResultUrl,
+  normalizeWhitespace,
+  stripTags,
+  validateHttpUrl,
+} from './search-utils.js';
+
 const DEFAULT_SEARXNG_PAGE = 1;
-const DEFAULT_SEARXNG_SAFE_SEARCH = 0;
+const DEFAULT_SEARXNG_SAFE_SEARCH = 1;
 
 export type SearxngTimeRange = 'day' | 'month' | 'year';
 export type SearxngSafeSearch = 0 | 1 | 2;
@@ -11,6 +20,7 @@ export interface SearxngSearchOptions {
   engines?: string[] | string;
   language?: string;
   page?: number;
+  count?: number;
   safeSearch?: SearxngSafeSearch;
   timeRange?: SearxngTimeRange;
 }
@@ -25,59 +35,8 @@ export interface SearxngSearchResult {
   thumbnail?: string;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function decodeEntities(value: string): string {
-  return value
-    .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/gi, '&')
-    .replace(/&quot;/gi, '"')
-    .replace(/&#39;/gi, "'")
-    .replace(/&lt;/gi, '<')
-    .replace(/&gt;/gi, '>')
-    .replace(/&#x([0-9a-f]+);/gi, (_, hex) =>
-      String.fromCharCode(Number.parseInt(hex, 16)),
-    )
-    .replace(/&#(\d+);/gi, (_, dec) =>
-      String.fromCharCode(Number.parseInt(dec, 10)),
-    );
-}
-
-function stripTags(value: string): string {
-  return decodeEntities(value.replace(/<[^>]+>/g, ''));
-}
-
-function normalizeWhitespace(value: string): string {
-  return String(value || '')
-    .replace(/\r/g, '')
-    .replace(/[ \t]+\n/g, '\n')
-    .replace(/\n{3,}/g, '\n\n')
-    .replace(/[ \t]{2,}/g, ' ')
-    .trim();
-}
-
 function normalizeText(value: unknown): string {
   return normalizeWhitespace(stripTags(String(value || '')));
-}
-
-function validateHttpUrl(value: string): string | null {
-  try {
-    const parsed = new URL(value);
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-      return null;
-    }
-    return parsed.toString();
-  } catch {
-    return null;
-  }
-}
-
-function normalizeResultUrl(value: unknown): string | null {
-  const normalized = String(value || '').trim();
-  if (!normalized) return null;
-  return validateHttpUrl(normalized);
 }
 
 function normalizeSearxngPath(pathname: string): string {
@@ -98,7 +57,9 @@ function normalizePositiveInteger(value: unknown, fallback: number): number {
 }
 
 function normalizeSafeSearch(value: unknown): SearxngSafeSearch {
-  return value === 1 || value === 2 ? value : DEFAULT_SEARXNG_SAFE_SEARCH;
+  return value === 0 || value === 1 || value === 2
+    ? value
+    : DEFAULT_SEARXNG_SAFE_SEARCH;
 }
 
 export function normalizeSearxngListParam(
@@ -120,23 +81,6 @@ export function normalizeSearxngListParam(
   return normalized.join(',');
 }
 
-function readOptionalText(value: unknown): string | undefined {
-  const normalized = normalizeText(value);
-  return normalized || undefined;
-}
-
-function dedupeResults(results: SearxngSearchResult[]): SearxngSearchResult[] {
-  const seen = new Set<string>();
-  const deduped: SearxngSearchResult[] = [];
-  for (const result of results) {
-    const urlKey = result.url.toLowerCase();
-    if (seen.has(urlKey)) continue;
-    seen.add(urlKey);
-    deduped.push(result);
-  }
-  return deduped;
-}
-
 export function buildSearxngSearchUrl(options: SearxngSearchOptions): string {
   const normalizedBase = validateHttpUrl(options.baseUrl);
   if (!normalizedBase) throw new Error('SearXNG base URL is invalid');
@@ -151,6 +95,10 @@ export function buildSearxngSearchUrl(options: SearxngSearchOptions): string {
     'pageno',
     String(normalizePositiveInteger(options.page, DEFAULT_SEARXNG_PAGE)),
   );
+  if (options.count != null) {
+    const count = normalizePositiveInteger(options.count, 0);
+    if (count > 0) url.searchParams.set('num_results', String(count));
+  }
   url.searchParams.set('language', options.language || 'all');
   url.searchParams.set(
     'safesearch',
@@ -187,11 +135,11 @@ export function parseSearxngSearchResponse(
     const snippet = normalizeText(
       entry.content ?? entry.snippet ?? entry.description,
     );
-    const age = readOptionalText(
-      entry.publishedDate ?? entry.published_date ?? entry.age,
-    );
-    const category = readOptionalText(entry.category);
-    const engine = readOptionalText(entry.engine);
+    const age =
+      normalizeText(entry.publishedDate ?? entry.published_date ?? entry.age) ||
+      undefined;
+    const category = normalizeText(entry.category) || undefined;
+    const engine = normalizeText(entry.engine) || undefined;
     const thumbnail = normalizeResultUrl(entry.thumbnail ?? entry.img_src);
 
     results.push({

--- a/container/src/searxng-client.ts
+++ b/container/src/searxng-client.ts
@@ -101,7 +101,9 @@ function normalizeSafeSearch(value: unknown): SearxngSafeSearch {
   return value === 1 || value === 2 ? value : DEFAULT_SEARXNG_SAFE_SEARCH;
 }
 
-function normalizeListParam(value: string[] | string | undefined): string {
+export function normalizeSearxngListParam(
+  value: string[] | string | undefined,
+): string {
   const rawValues = Array.isArray(value)
     ? value
     : typeof value === 'string'
@@ -155,10 +157,10 @@ export function buildSearxngSearchUrl(options: SearxngSearchOptions): string {
     String(normalizeSafeSearch(options.safeSearch)),
   );
 
-  const categories = normalizeListParam(options.categories);
+  const categories = normalizeSearxngListParam(options.categories);
   if (categories) url.searchParams.set('categories', categories);
 
-  const engines = normalizeListParam(options.engines);
+  const engines = normalizeSearxngListParam(options.engines);
   if (engines) url.searchParams.set('engines', engines);
 
   if (options.timeRange) {

--- a/container/src/searxng-client.ts
+++ b/container/src/searxng-client.ts
@@ -1,0 +1,207 @@
+const DEFAULT_SEARXNG_PAGE = 1;
+const DEFAULT_SEARXNG_SAFE_SEARCH = 0;
+
+export type SearxngTimeRange = 'day' | 'month' | 'year';
+export type SearxngSafeSearch = 0 | 1 | 2;
+
+export interface SearxngSearchOptions {
+  baseUrl: string;
+  query: string;
+  categories?: string[] | string;
+  engines?: string[] | string;
+  language?: string;
+  page?: number;
+  safeSearch?: SearxngSafeSearch;
+  timeRange?: SearxngTimeRange;
+}
+
+export interface SearxngSearchResult {
+  title: string;
+  url: string;
+  snippet: string;
+  age?: string;
+  category?: string;
+  engine?: string;
+  thumbnail?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function decodeEntities(value: string): string {
+  return value
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) =>
+      String.fromCharCode(Number.parseInt(hex, 16)),
+    )
+    .replace(/&#(\d+);/gi, (_, dec) =>
+      String.fromCharCode(Number.parseInt(dec, 10)),
+    );
+}
+
+function stripTags(value: string): string {
+  return decodeEntities(value.replace(/<[^>]+>/g, ''));
+}
+
+function normalizeWhitespace(value: string): string {
+  return String(value || '')
+    .replace(/\r/g, '')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/[ \t]{2,}/g, ' ')
+    .trim();
+}
+
+function normalizeText(value: unknown): string {
+  return normalizeWhitespace(stripTags(String(value || '')));
+}
+
+function validateHttpUrl(value: string): string | null {
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return null;
+    }
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+function normalizeResultUrl(value: unknown): string | null {
+  const normalized = String(value || '').trim();
+  if (!normalized) return null;
+  return validateHttpUrl(normalized);
+}
+
+function normalizeSearxngPath(pathname: string): string {
+  const trimmed = pathname.replace(/\/+$/, '');
+  if (trimmed.endsWith('/search')) return trimmed || '/search';
+  return `${trimmed || ''}/search`;
+}
+
+function normalizePositiveInteger(value: unknown, fallback: number): number {
+  const parsed =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string' && value.trim()
+        ? Number.parseInt(value, 10)
+        : fallback;
+  if (!Number.isFinite(parsed) || parsed < 1) return fallback;
+  return Math.trunc(parsed);
+}
+
+function normalizeSafeSearch(value: unknown): SearxngSafeSearch {
+  return value === 1 || value === 2 ? value : DEFAULT_SEARXNG_SAFE_SEARCH;
+}
+
+function normalizeListParam(value: string[] | string | undefined): string {
+  const rawValues = Array.isArray(value)
+    ? value
+    : typeof value === 'string'
+      ? value.split(',')
+      : [];
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const raw of rawValues) {
+    const item = String(raw || '').trim();
+    if (!item || seen.has(item)) continue;
+    seen.add(item);
+    normalized.push(item);
+  }
+  return normalized.join(',');
+}
+
+function readOptionalText(value: unknown): string | undefined {
+  const normalized = normalizeText(value);
+  return normalized || undefined;
+}
+
+function dedupeResults(results: SearxngSearchResult[]): SearxngSearchResult[] {
+  const seen = new Set<string>();
+  const deduped: SearxngSearchResult[] = [];
+  for (const result of results) {
+    const urlKey = result.url.toLowerCase();
+    if (seen.has(urlKey)) continue;
+    seen.add(urlKey);
+    deduped.push(result);
+  }
+  return deduped;
+}
+
+export function buildSearxngSearchUrl(options: SearxngSearchOptions): string {
+  const normalizedBase = validateHttpUrl(options.baseUrl);
+  if (!normalizedBase) throw new Error('SearXNG base URL is invalid');
+  const query = normalizeWhitespace(options.query);
+  if (!query) throw new Error('SearXNG query is required');
+
+  const url = new URL(normalizedBase);
+  url.pathname = normalizeSearxngPath(url.pathname);
+  url.searchParams.set('format', 'json');
+  url.searchParams.set('q', query);
+  url.searchParams.set(
+    'pageno',
+    String(normalizePositiveInteger(options.page, DEFAULT_SEARXNG_PAGE)),
+  );
+  url.searchParams.set('language', options.language || 'all');
+  url.searchParams.set(
+    'safesearch',
+    String(normalizeSafeSearch(options.safeSearch)),
+  );
+
+  const categories = normalizeListParam(options.categories);
+  if (categories) url.searchParams.set('categories', categories);
+
+  const engines = normalizeListParam(options.engines);
+  if (engines) url.searchParams.set('engines', engines);
+
+  if (options.timeRange) {
+    url.searchParams.set('time_range', options.timeRange);
+  }
+
+  return url.toString();
+}
+
+export function parseSearxngSearchResponse(
+  payload: unknown,
+): SearxngSearchResult[] {
+  if (!isRecord(payload)) throw new Error('Invalid SearXNG search response');
+  if (!Array.isArray(payload.results)) return [];
+
+  const results: SearxngSearchResult[] = [];
+  for (const entry of payload.results) {
+    if (!isRecord(entry)) continue;
+
+    const title = normalizeText(entry.title);
+    const url = normalizeResultUrl(entry.url);
+    if (!title || !url) continue;
+
+    const snippet = normalizeText(
+      entry.content ?? entry.snippet ?? entry.description,
+    );
+    const age = readOptionalText(
+      entry.publishedDate ?? entry.published_date ?? entry.age,
+    );
+    const category = readOptionalText(entry.category);
+    const engine = readOptionalText(entry.engine);
+    const thumbnail = normalizeResultUrl(entry.thumbnail ?? entry.img_src);
+
+    results.push({
+      title,
+      url,
+      snippet,
+      ...(age ? { age } : {}),
+      ...(category ? { category } : {}),
+      ...(engine ? { engine } : {}),
+      ...(thumbnail ? { thumbnail } : {}),
+    });
+  }
+
+  return dedupeResults(results);
+}

--- a/container/src/tools.ts
+++ b/container/src/tools.ts
@@ -3295,6 +3295,8 @@ async function executeToolInternal(
           freshness: args.freshness,
           country: args.country,
           language: args.language,
+          categories: args.categories,
+          engines: args.engines,
           provider: args.provider,
         },
         currentWebSearchConfig,
@@ -4165,6 +4167,22 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
           language: {
             type: 'string',
             description: 'ISO 639-1 language code (e.g. "en", "de").',
+          },
+          categories: {
+            type: ['string', 'array'],
+            items: {
+              type: 'string',
+            },
+            description:
+              'Optional SearXNG categories such as "general", "images", or "news". Only used by the searxng provider.',
+          },
+          engines: {
+            type: ['string', 'array'],
+            items: {
+              type: 'string',
+            },
+            description:
+              'Optional SearXNG engine names or comma-separated engine list. Only used by the searxng provider.',
           },
           provider: {
             type: 'string',

--- a/container/src/web-search.ts
+++ b/container/src/web-search.ts
@@ -4,6 +4,14 @@ import type {
   WebSearchConfig,
 } from '../shared/web-search-config.js';
 import {
+  decodeEntities,
+  dedupeResults,
+  isRecord,
+  normalizeResultUrl,
+  normalizeWhitespace,
+  stripTags,
+} from './search-utils.js';
+import {
   buildSearxngSearchUrl,
   normalizeSearxngListParam,
   parseSearxngSearchResponse,
@@ -174,39 +182,6 @@ function writeCache(
 
 export function clearWebSearchCache(): void {
   cache.clear();
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function decodeEntities(value: string): string {
-  return value
-    .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/gi, '&')
-    .replace(/&quot;/gi, '"')
-    .replace(/&#39;/gi, "'")
-    .replace(/&lt;/gi, '<')
-    .replace(/&gt;/gi, '>')
-    .replace(/&#x([0-9a-f]+);/gi, (_, hex) =>
-      String.fromCharCode(Number.parseInt(hex, 16)),
-    )
-    .replace(/&#(\d+);/gi, (_, dec) =>
-      String.fromCharCode(Number.parseInt(dec, 10)),
-    );
-}
-
-function stripTags(value: string): string {
-  return decodeEntities(value.replace(/<[^>]+>/g, ''));
-}
-
-function normalizeWhitespace(value: string): string {
-  return String(value || '')
-    .replace(/\r/g, '')
-    .replace(/[ \t]+\n/g, '\n')
-    .replace(/\n{3,}/g, '\n\n')
-    .replace(/[ \t]{2,}/g, ' ')
-    .trim();
 }
 
 function readEnv(name: string): string {
@@ -419,36 +394,6 @@ export function getWebSearchConfigFromEnv(
   };
 }
 
-function validateHttpUrl(value: string): string | null {
-  try {
-    const parsed = new URL(value);
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-      return null;
-    }
-    return parsed.toString();
-  } catch {
-    return null;
-  }
-}
-
-function normalizeResultUrl(value: unknown): string | null {
-  const normalized = String(value || '').trim();
-  if (!normalized) return null;
-  return validateHttpUrl(normalized);
-}
-
-function dedupeResults(results: SearchResult[]): SearchResult[] {
-  const seen = new Set<string>();
-  const deduped: SearchResult[] = [];
-  for (const result of results) {
-    const urlKey = result.url.toLowerCase();
-    if (seen.has(urlKey)) continue;
-    seen.add(urlKey);
-    deduped.push(result);
-  }
-  return deduped;
-}
-
 function normalizeSearchResults(
   results: Array<{
     title?: unknown;
@@ -643,28 +588,28 @@ function buildProviderRequestContext(
   tavilyDays?: number;
   searxngTimeRange?: SearxngTimeRange;
 } {
+  const braveFreshness = mapFreshnessForProvider('brave', context.freshness);
+  const perplexityFreshness = mapFreshnessForProvider(
+    'perplexity',
+    context.freshness,
+  );
+  const tavilyDays = mapFreshnessForProvider('tavily', context.freshness);
+  const searxngTimeRange = mapFreshnessForProvider(
+    'searxng',
+    context.freshness,
+  );
+
   return {
     ...context,
     braveFreshness:
-      typeof mapFreshnessForProvider('brave', context.freshness) === 'string'
-        ? (mapFreshnessForProvider('brave', context.freshness) as string)
-        : undefined,
+      typeof braveFreshness === 'string' ? braveFreshness : undefined,
     braveLanguage: mapLanguageForBrave(context.language),
     perplexityFreshness:
-      typeof mapFreshnessForProvider('perplexity', context.freshness) ===
-      'string'
-        ? (mapFreshnessForProvider('perplexity', context.freshness) as string)
-        : undefined,
-    tavilyDays:
-      typeof mapFreshnessForProvider('tavily', context.freshness) === 'number'
-        ? (mapFreshnessForProvider('tavily', context.freshness) as number)
-        : undefined,
+      typeof perplexityFreshness === 'string' ? perplexityFreshness : undefined,
+    tavilyDays: typeof tavilyDays === 'number' ? tavilyDays : undefined,
     searxngTimeRange:
-      typeof mapFreshnessForProvider('searxng', context.freshness) === 'string'
-        ? (mapFreshnessForProvider(
-            'searxng',
-            context.freshness,
-          ) as SearxngTimeRange)
+      typeof searxngTimeRange === 'string'
+        ? (searxngTimeRange as SearxngTimeRange)
         : undefined,
   };
 }
@@ -972,7 +917,7 @@ function createSearxngProvider(
   const requestContext = buildProviderRequestContext(context);
   return {
     name: 'searxng',
-    async search(query: string, _count: number, signal: AbortSignal) {
+    async search(query: string, count: number, signal: AbortSignal) {
       if (!config.searxngBaseUrl) throw new Error('SearXNG is not configured');
 
       const timeout = createTimeoutSignal(signal, DEFAULT_PROVIDER_TIMEOUT_MS);
@@ -982,6 +927,7 @@ function createSearxngProvider(
             baseUrl: config.searxngBaseUrl,
             query,
             language: requestContext.language,
+            count,
             categories: requestContext.categories,
             engines: requestContext.engines,
             timeRange: requestContext.searxngTimeRange,

--- a/container/src/web-search.ts
+++ b/container/src/web-search.ts
@@ -5,6 +5,7 @@ import type {
 } from '../shared/web-search-config.js';
 import {
   buildSearxngSearchUrl,
+  normalizeSearxngListParam,
   parseSearxngSearchResponse,
   type SearxngTimeRange,
 } from './searxng-client.js';
@@ -115,8 +116,8 @@ interface NormalizedSearchParams {
   freshness?: SearchFreshness;
   country?: string;
   language?: string;
-  categories?: string[] | string;
-  engines?: string[] | string;
+  categories?: string;
+  engines?: string;
   provider?: SearchProviderMode;
 }
 
@@ -124,8 +125,8 @@ interface SearchExecutionContext {
   freshness?: SearchFreshness;
   country?: string;
   language?: string;
-  categories?: string[] | string;
-  engines?: string[] | string;
+  categories?: string;
+  engines?: string;
 }
 
 export interface WebSearchExecutionResult {
@@ -331,8 +332,8 @@ export function normalizeSearchParams(
     freshness: normalizeFreshness(params.freshness),
     country: normalizeCountry(params.country),
     language: normalizeLanguage(params.language),
-    categories: params.categories,
-    engines: params.engines,
+    categories: normalizeSearxngListParam(params.categories) || undefined,
+    engines: normalizeSearxngListParam(params.engines) || undefined,
     provider: params.provider
       ? normalizeProviderMode(params.provider)
       : undefined,
@@ -604,12 +605,8 @@ function buildCacheKey(
   const suffix = [params.country || '', params.language || '']
     .filter(Boolean)
     .join(':');
-  const categories = Array.isArray(params.categories)
-    ? params.categories.join(',')
-    : params.categories || '';
-  const engines = Array.isArray(params.engines)
-    ? params.engines.join(',')
-    : params.engines || '';
+  const categories = params.categories || '';
+  const engines = params.engines || '';
   return `search:${params.query}:${params.count}:${requestedProvider}:${params.freshness || ''}:${categories}:${engines}${suffix ? `:${suffix}` : ''}`.toLowerCase();
 }
 

--- a/container/src/web-search.ts
+++ b/container/src/web-search.ts
@@ -3,6 +3,11 @@ import type {
   SearchProviderName,
   WebSearchConfig,
 } from '../shared/web-search-config.js';
+import {
+  buildSearxngSearchUrl,
+  parseSearxngSearchResponse,
+  type SearxngTimeRange,
+} from './searxng-client.js';
 
 const DEFAULT_COUNT = 5;
 const MIN_COUNT = 1;
@@ -86,6 +91,9 @@ export interface SearchResult {
   url: string;
   snippet: string;
   age?: string;
+  category?: string;
+  engine?: string;
+  thumbnail?: string;
 }
 
 export type WebSearchRuntimeConfig = WebSearchConfig;
@@ -96,6 +104,8 @@ export interface WebSearchParams {
   freshness?: SearchFreshness;
   country?: string;
   language?: string;
+  categories?: string[] | string;
+  engines?: string[] | string;
   provider?: SearchProviderMode;
 }
 
@@ -105,6 +115,8 @@ interface NormalizedSearchParams {
   freshness?: SearchFreshness;
   country?: string;
   language?: string;
+  categories?: string[] | string;
+  engines?: string[] | string;
   provider?: SearchProviderMode;
 }
 
@@ -112,6 +124,8 @@ interface SearchExecutionContext {
   freshness?: SearchFreshness;
   country?: string;
   language?: string;
+  categories?: string[] | string;
+  engines?: string[] | string;
 }
 
 export interface WebSearchExecutionResult {
@@ -317,6 +331,8 @@ export function normalizeSearchParams(
     freshness: normalizeFreshness(params.freshness),
     country: normalizeCountry(params.country),
     language: normalizeLanguage(params.language),
+    categories: params.categories,
+    engines: params.engines,
     provider: params.provider
       ? normalizeProviderMode(params.provider)
       : undefined,
@@ -588,7 +604,13 @@ function buildCacheKey(
   const suffix = [params.country || '', params.language || '']
     .filter(Boolean)
     .join(':');
-  return `search:${params.query}:${params.count}:${requestedProvider}:${params.freshness || ''}${suffix ? `:${suffix}` : ''}`.toLowerCase();
+  const categories = Array.isArray(params.categories)
+    ? params.categories.join(',')
+    : params.categories || '';
+  const engines = Array.isArray(params.engines)
+    ? params.engines.join(',')
+    : params.engines || '';
+  return `search:${params.query}:${params.count}:${requestedProvider}:${params.freshness || ''}:${categories}:${engines}${suffix ? `:${suffix}` : ''}`.toLowerCase();
 }
 
 export function mapFreshnessForProvider(
@@ -622,7 +644,7 @@ function buildProviderRequestContext(
   braveLanguage?: string;
   perplexityFreshness?: string;
   tavilyDays?: number;
-  searxngTimeRange?: string;
+  searxngTimeRange?: SearxngTimeRange;
 } {
   return {
     ...context,
@@ -642,7 +664,10 @@ function buildProviderRequestContext(
         : undefined,
     searxngTimeRange:
       typeof mapFreshnessForProvider('searxng', context.freshness) === 'string'
-        ? (mapFreshnessForProvider('searxng', context.freshness) as string)
+        ? (mapFreshnessForProvider(
+            'searxng',
+            context.freshness,
+          ) as SearxngTimeRange)
         : undefined,
   };
 }
@@ -702,21 +727,6 @@ function parseTavilySearchResponse(payload: unknown): SearchResult[] {
         url: entry.url,
         snippet: entry.content ?? entry.snippet ?? entry.description,
         age: entry.published_date,
-      })),
-  );
-}
-
-function parseSearxngSearchResponse(payload: unknown): SearchResult[] {
-  if (!isRecord(payload)) throw new Error('Invalid SearXNG search response');
-  const rawResults = extractArray(payload.results);
-  return normalizeSearchResults(
-    rawResults
-      .filter((entry): entry is Record<string, unknown> => isRecord(entry))
-      .map((entry) => ({
-        title: entry.title,
-        url: entry.url,
-        snippet: entry.content ?? entry.snippet ?? entry.description,
-        age: entry.publishedDate ?? entry.published_date ?? entry.age,
       })),
   );
 }
@@ -958,30 +968,6 @@ function createDuckDuckGoProvider(): SearchProvider {
   };
 }
 
-function buildSearxngSearchUrl(
-  baseUrl: string,
-  query: string,
-  count: number,
-  context: ReturnType<typeof buildProviderRequestContext>,
-): string {
-  const normalizedBase = validateHttpUrl(baseUrl);
-  if (!normalizedBase) throw new Error('SearXNG base URL is invalid');
-  const url = new URL(normalizedBase);
-  if (!url.pathname.endsWith('/search')) {
-    url.pathname = `${url.pathname.replace(/\/+$/, '')}/search`;
-  }
-  url.searchParams.set('format', 'json');
-  url.searchParams.set('q', query);
-  url.searchParams.set('pageno', '1');
-  url.searchParams.set('language', context.language || 'all');
-  url.searchParams.set('safesearch', '0');
-  url.searchParams.set('results', String(count));
-  if (context.searxngTimeRange) {
-    url.searchParams.set('time_range', context.searxngTimeRange);
-  }
-  return url.toString();
-}
-
 function createSearxngProvider(
   config: WebSearchConfig,
   context: SearchExecutionContext,
@@ -989,18 +975,20 @@ function createSearxngProvider(
   const requestContext = buildProviderRequestContext(context);
   return {
     name: 'searxng',
-    async search(query: string, count: number, signal: AbortSignal) {
+    async search(query: string, _count: number, signal: AbortSignal) {
       if (!config.searxngBaseUrl) throw new Error('SearXNG is not configured');
 
       const timeout = createTimeoutSignal(signal, DEFAULT_PROVIDER_TIMEOUT_MS);
       try {
         const res = await fetch(
-          buildSearxngSearchUrl(
-            config.searxngBaseUrl,
+          buildSearxngSearchUrl({
+            baseUrl: config.searxngBaseUrl,
             query,
-            count,
-            requestContext,
-          ),
+            language: requestContext.language,
+            categories: requestContext.categories,
+            engines: requestContext.engines,
+            timeRange: requestContext.searxngTimeRange,
+          }),
           {
             headers: {
               Accept: 'application/json',
@@ -1157,6 +1145,9 @@ function formatSearchResults(result: WebSearchExecutionResult): string {
     lines.push(`${index + 1}. ${entry.title}`);
     lines.push(entry.url);
     if (entry.age) lines.push(`Age: ${entry.age}`);
+    if (entry.category) lines.push(`Category: ${entry.category}`);
+    if (entry.engine) lines.push(`Engine: ${entry.engine}`);
+    if (entry.thumbnail) lines.push(`Thumbnail: ${entry.thumbnail}`);
     if (entry.snippet) lines.push(entry.snippet);
   }
   return lines.join('\n');

--- a/skills/search.images/SKILL.md
+++ b/skills/search.images/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: search.images
+description: Search image results through the configured self-hosted SearXNG instance for visual references, source images, thumbnails, or image result URLs.
+user-invocable: true
+disable-model-invocation: false
+metadata:
+  hybridclaw:
+    category: research
+    short_description: "SearXNG image search."
+    tags:
+      - search
+      - images
+      - searxng
+      - research
+---
+# Search Images
+
+Use this skill when the user asks to search for images, visual references, pictures, thumbnails, screenshots, product photos, logos, diagrams, or image-source URLs.
+
+## Workflow
+
+1. Call `web_search` with:
+   - `provider: "searxng"`
+   - `categories: "images"`
+   - the user's visual search query
+   - `count`, `freshness`, `country`, or `language` only when the user asks for them or they are clearly implied.
+2. Return the most relevant image results with title, URL, and thumbnail URL when available.
+3. Use `web_fetch` only for a result page when the user asks to inspect the source page.
+
+## Constraints
+
+- Do not use hosted image search providers for this skill unless the user explicitly asks to leave the sovereign SearXNG path.
+- Do not present thumbnails or result URLs as licensed assets unless licensing is verified from the source page.
+- If SearXNG is not configured, say that the self-hosted image search provider is unavailable and include the tool error.

--- a/skills/search.news/SKILL.md
+++ b/skills/search.news/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: search.news
+description: Search news results through the configured self-hosted SearXNG instance for recent events, current reporting, headlines, and time-sensitive source discovery.
+user-invocable: true
+disable-model-invocation: false
+metadata:
+  hybridclaw:
+    category: research
+    short_description: "SearXNG news search."
+    tags:
+      - search
+      - news
+      - searxng
+      - research
+---
+# Search News
+
+Use this skill when the user asks for news, latest reporting, headlines, recent events, current developments, or time-sensitive source discovery.
+
+## Workflow
+
+1. Call `web_search` with:
+   - `provider: "searxng"`
+   - `categories: "news"`
+   - the user's news query
+   - `freshness: "day"` or `freshness: "week"` when the user asks for recent/latest news and no tighter window is specified.
+   - `count`, `country`, or `language` only when the user asks for them or they are clearly implied.
+2. Return the most relevant news results with title, URL, age/date when available, and a short snippet.
+3. Use `web_fetch` after `web_search` before making factual claims beyond the snippets.
+
+## Constraints
+
+- Do not use hosted news search providers for this skill unless the user explicitly asks to leave the sovereign SearXNG path.
+- Make recency explicit when reporting news.
+- If SearXNG is not configured, say that the self-hosted news search provider is unavailable and include the tool error.

--- a/skills/search.web/SKILL.md
+++ b/skills/search.web/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: search.web
+description: Search the public web through the configured self-hosted SearXNG instance for current information, source discovery, or sovereignty-sensitive research.
+user-invocable: true
+disable-model-invocation: false
+metadata:
+  hybridclaw:
+    category: research
+    short_description: "SearXNG web search."
+    tags:
+      - search
+      - web
+      - searxng
+      - research
+---
+# Search Web
+
+Use this skill when the user asks to search the web, find current sources, look something up, discover URLs, or perform sovereignty-sensitive web research.
+
+## Workflow
+
+1. Call `web_search` with:
+   - `provider: "searxng"`
+   - `categories: "general"`
+   - the user's query
+   - `count`, `freshness`, `country`, or `language` only when the user asks for them or they are clearly implied.
+2. Return the most relevant results with title, URL, and a short snippet.
+3. Use `web_fetch` after `web_search` only when the user asks for content from a result or when an answer needs page-level evidence.
+
+## Constraints
+
+- Do not use hosted search providers for this skill unless the user explicitly asks to leave the sovereign SearXNG path.
+- Do not invent citations or claim fetched-page facts from search snippets alone.
+- If SearXNG is not configured, say that the self-hosted search provider is unavailable and include the tool error.

--- a/tests/skills.invocation.test.ts
+++ b/tests/skills.invocation.test.ts
@@ -97,6 +97,18 @@ test('expands $skill mentions into explicit skill instructions', () => {
   expect(expanded).toContain('Skill input: next track');
 });
 
+test('resolves dotted slash skill names through command sanitization', () => {
+  const searchImages = makeTempSkill('search.images');
+
+  const expanded = expandSkillInvocation('/search.images query cats', [
+    searchImages,
+  ]);
+
+  expect(expanded).toContain('[Explicit skill invocation]');
+  expect(expanded).toContain('Use the "search.images" skill for this request.');
+  expect(expanded).toContain('Skill input: query cats');
+});
+
 test('inherits the previous explicit skill for a short follow-up turn', () => {
   const appleMusic = makeTempSkill('apple-music');
 

--- a/tests/unit/web-search.test.ts
+++ b/tests/unit/web-search.test.ts
@@ -319,6 +319,49 @@ describe('SearXNG provider', () => {
     expect(requestUrl.searchParams.get('time_range')).toBe('year');
     expect(requestUrl.searchParams.has('results')).toBe(false);
   });
+
+  it('uses canonical SearXNG category and engine lists for cache keys', async () => {
+    process.env.HYBRIDCLAW_WEB_SEARCH_PROVIDER = 'searxng';
+    process.env.SEARXNG_BASE_URL = 'https://search.example.com';
+
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          results: [
+            {
+              title: 'Cached Result',
+              url: 'https://example.com/cached',
+              content: 'Cached snippet',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const first = await searchWeb({
+      query: 'searxng cache',
+      categories: ['general', 'news', 'general'],
+      engines: 'brave, duckduckgo',
+      provider: 'searxng',
+    });
+    const second = await searchWeb({
+      query: 'searxng cache',
+      categories: 'general,news',
+      engines: ['brave', 'duckduckgo'],
+      provider: 'searxng',
+    });
+
+    expect(first.cached).toBeUndefined();
+    expect(second.cached).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('cache behavior', () => {

--- a/tests/unit/web-search.test.ts
+++ b/tests/unit/web-search.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-
+import {
+  buildSearxngSearchUrl,
+  parseSearxngSearchResponse,
+} from '../../container/src/searxng-client.js';
 import {
   buildProviderChain,
   clearWebSearchCache,
@@ -180,6 +183,141 @@ describe('provider parsers', () => {
     expect(parseDuckDuckGoHtml('<html><body>No hits</body></html>')).toEqual(
       [],
     );
+  });
+
+  it('builds SearXNG JSON search URLs with query options', () => {
+    const url = new URL(
+      buildSearxngSearchUrl({
+        baseUrl: 'https://search.example.com/searxng/',
+        query: 'sovereign search',
+        categories: ['general', 'news', 'general'],
+        engines: 'brave, duckduckgo, brave',
+        language: 'de',
+        page: 2,
+        safeSearch: 1,
+        timeRange: 'month',
+      }),
+    );
+
+    expect(url.origin).toBe('https://search.example.com');
+    expect(url.pathname).toBe('/searxng/search');
+    expect(url.searchParams.get('format')).toBe('json');
+    expect(url.searchParams.get('q')).toBe('sovereign search');
+    expect(url.searchParams.get('categories')).toBe('general,news');
+    expect(url.searchParams.get('engines')).toBe('brave,duckduckgo');
+    expect(url.searchParams.get('language')).toBe('de');
+    expect(url.searchParams.get('pageno')).toBe('2');
+    expect(url.searchParams.get('safesearch')).toBe('1');
+    expect(url.searchParams.get('time_range')).toBe('month');
+  });
+
+  it('rejects SearXNG URLs without a query', () => {
+    expect(() =>
+      buildSearxngSearchUrl({
+        baseUrl: 'https://search.example.com',
+        query: '   ',
+      }),
+    ).toThrow('SearXNG query is required');
+  });
+
+  it('parses and normalizes SearXNG JSON results', () => {
+    const results = parseSearxngSearchResponse({
+      results: [
+        {
+          title: '<b>SearXNG Result</b>',
+          url: 'https://example.com/search',
+          content: 'Sovereign &amp; private',
+          publishedDate: '2026-05-01',
+          category: 'general',
+          engine: 'brave',
+          thumbnail: 'https://example.com/thumb.jpg',
+        },
+        {
+          title: 'Duplicate Result',
+          url: 'https://example.com/search',
+          content: 'Duplicate URL should be dropped',
+        },
+        {
+          title: 'Missing URL',
+          content: 'ignored',
+        },
+      ],
+    });
+
+    expect(results).toEqual([
+      {
+        title: 'SearXNG Result',
+        url: 'https://example.com/search',
+        snippet: 'Sovereign & private',
+        age: '2026-05-01',
+        category: 'general',
+        engine: 'brave',
+        thumbnail: 'https://example.com/thumb.jpg',
+      },
+    ]);
+  });
+
+  it('rejects malformed SearXNG responses', () => {
+    expect(() => parseSearxngSearchResponse('bad-payload')).toThrow(
+      'Invalid SearXNG search response',
+    );
+  });
+});
+
+describe('SearXNG provider', () => {
+  it('queries SearXNG JSON output with normalized options', async () => {
+    process.env.HYBRIDCLAW_WEB_SEARCH_PROVIDER = 'searxng';
+    process.env.SEARXNG_BASE_URL = 'https://search.example.com';
+
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          results: [
+            {
+              title: 'SearXNG Result',
+              url: 'https://example.com/searxng',
+              content: 'SearXNG snippet',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await searchWeb({
+      query: 'searxng adapter',
+      count: 3,
+      categories: 'images',
+      engines: ['brave', 'duckduckgo'],
+      freshness: 'year',
+      language: 'en',
+      provider: 'searxng',
+    });
+
+    expect(result.provider).toBe('searxng');
+    expect(result.results).toEqual([
+      {
+        title: 'SearXNG Result',
+        url: 'https://example.com/searxng',
+        snippet: 'SearXNG snippet',
+      },
+    ]);
+
+    const requestUrl = new URL(String(fetchMock.mock.calls[0]?.[0]));
+    expect(requestUrl.pathname).toBe('/search');
+    expect(requestUrl.searchParams.get('format')).toBe('json');
+    expect(requestUrl.searchParams.get('q')).toBe('searxng adapter');
+    expect(requestUrl.searchParams.get('categories')).toBe('images');
+    expect(requestUrl.searchParams.get('engines')).toBe('brave,duckduckgo');
+    expect(requestUrl.searchParams.get('language')).toBe('en');
+    expect(requestUrl.searchParams.get('time_range')).toBe('year');
+    expect(requestUrl.searchParams.has('results')).toBe(false);
   });
 });
 

--- a/tests/unit/web-search.test.ts
+++ b/tests/unit/web-search.test.ts
@@ -194,6 +194,7 @@ describe('provider parsers', () => {
         engines: 'brave, duckduckgo, brave',
         language: 'de',
         page: 2,
+        count: 4,
         safeSearch: 1,
         timeRange: 'month',
       }),
@@ -207,8 +208,28 @@ describe('provider parsers', () => {
     expect(url.searchParams.get('engines')).toBe('brave,duckduckgo');
     expect(url.searchParams.get('language')).toBe('de');
     expect(url.searchParams.get('pageno')).toBe('2');
+    expect(url.searchParams.get('num_results')).toBe('4');
     expect(url.searchParams.get('safesearch')).toBe('1');
     expect(url.searchParams.get('time_range')).toBe('month');
+  });
+
+  it('defaults SearXNG safe search to moderate while allowing explicit opt-out', () => {
+    const defaultUrl = new URL(
+      buildSearxngSearchUrl({
+        baseUrl: 'https://search.example.com',
+        query: 'safe default',
+      }),
+    );
+    const optOutUrl = new URL(
+      buildSearxngSearchUrl({
+        baseUrl: 'https://search.example.com',
+        query: 'explicit opt out',
+        safeSearch: 0,
+      }),
+    );
+
+    expect(defaultUrl.searchParams.get('safesearch')).toBe('1');
+    expect(optOutUrl.searchParams.get('safesearch')).toBe('0');
   });
 
   it('rejects SearXNG URLs without a query', () => {
@@ -313,6 +334,7 @@ describe('SearXNG provider', () => {
     expect(requestUrl.pathname).toBe('/search');
     expect(requestUrl.searchParams.get('format')).toBe('json');
     expect(requestUrl.searchParams.get('q')).toBe('searxng adapter');
+    expect(requestUrl.searchParams.get('num_results')).toBe('3');
     expect(requestUrl.searchParams.get('categories')).toBe('images');
     expect(requestUrl.searchParams.get('engines')).toBe('brave,duckduckgo');
     expect(requestUrl.searchParams.get('language')).toBe('en');


### PR DESCRIPTION
## Summary

Implements the first two R52 slices:

- Closes #856 by adding a dedicated SearXNG `format=json` adapter with query option construction, engine/category support, response normalization, dedupe, and focused tests.
- Closes #857 by adding bundled `search.web`, `search.images`, and `search.news` skill entry points that route through the configured self-hosted SearXNG provider.

## Details

- Extends `web_search` with SearXNG-only `categories` and `engines` options.
- Preserves existing provider behavior for Brave, Perplexity, Tavily, and DuckDuckGo.
- Surfaces SearXNG metadata such as category, engine, and thumbnail when present.
- Adds dotted skill invocation coverage so `/search.images ...` resolves through the skill command path.
- Canonicalizes SearXNG category/engine lists before cache-key construction so equivalent requests reuse cached results.
- Addresses Claude review feedback by extracting shared search utilities, defaulting SearXNG safe search to moderate, passing `count` as opportunistic `num_results`, simplifying freshness mapping, and removing the one-line optional text wrapper.

## Validation

- `npx biome check --write container/src/search-utils.ts container/src/searxng-client.ts container/src/web-search.ts tests/unit/web-search.test.ts`
- `npx vitest run --configLoader runner --project unit tests/unit/web-search.test.ts tests/skills.invocation.test.ts`
- `npm --prefix container run lint`
- `npm --prefix container run build`
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`

## Remaining R52 Work

The parent #828 still has follow-up slices for F13 bearer binding, citation passthrough, R47 corpus promotion, and the hosted-search eval suite.