### PR TITLE
[codex] Decouple console model provider types

### DIFF
--- a/console/src/routes/chat/model-switch-select.tsx
+++ b/console/src/routes/chat/model-switch-select.tsx
@@ -6,7 +6,7 @@ import {
   useMemo,
   useState,
 } from 'react';
-import type { GatewayModelProviderKey } from '../../../../src/gateway/gateway-types.js';
+import type { GatewayModelProviderKey } from '../../../../src/gateway/model-provider-keys.js';
 import type { ChatModel } from '../../api/types';
 import {
   Local as LocalIcon,

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -30,6 +30,7 @@ import type {
 import type { MemoryCitation } from '../types/memory.js';
 import type { McpServerConfig } from '../types/models.js';
 import type { TokenUsageStats } from '../types/usage.js';
+import type { GatewayModelProviderKey } from './model-provider-keys.js';
 
 export type GatewayMessageComponents = NonNullable<
   BaseMessageOptions['components']
@@ -449,28 +450,7 @@ export interface GatewayStatus {
     cliError: string | null;
   };
   providerHealth?: Partial<
-    Record<
-      | 'hybridai'
-      | 'codex'
-      | 'anthropic'
-      | 'openrouter'
-      | 'mistral'
-      | 'huggingface'
-      | 'gemini'
-      | 'deepseek'
-      | 'xai'
-      | 'zai'
-      | 'kimi'
-      | 'minimax'
-      | 'dashscope'
-      | 'xiaomi'
-      | 'kilo'
-      | 'ollama'
-      | 'lmstudio'
-      | 'llamacpp'
-      | 'vllm',
-      GatewayProviderHealthEntry
-    >
+    Record<GatewayModelProviderKey, GatewayProviderHealthEntry>
   >;
   localBackends?: Partial<
     Record<
@@ -1034,10 +1014,7 @@ export interface GatewayAdminAgentMarkdownRevisionResponse {
   };
 }
 
-/** Key into `GatewayAdminModelsResponse.providerStatus`. */
-export type GatewayModelProviderKey = keyof NonNullable<
-  GatewayAdminModelsResponse['providerStatus']
->;
+export type { GatewayModelProviderKey } from './model-provider-keys.js';
 
 export interface GatewayAdminModelCatalogEntry {
   id: string;

--- a/src/gateway/model-provider-keys.ts
+++ b/src/gateway/model-provider-keys.ts
@@ -1,0 +1,5 @@
+import type { RuntimeProviderId } from '../providers/provider-ids.js';
+
+export type GatewayModelProviderKey =
+  | Exclude<RuntimeProviderId, 'openai-codex'>
+  | 'codex';


### PR DESCRIPTION
## Summary

- Move `GatewayModelProviderKey` into a lightweight gateway type module backed by provider IDs.
- Keep the existing `gateway-types.ts` export compatible while avoiding a heavy type dependency chain.
- Update the console model switcher to import the lightweight type directly.

## Root Cause

The console imported `GatewayModelProviderKey` from `src/gateway/gateway-types.ts`. That broad type file imports `RuntimeConfig`, and `RuntimeConfig` imports Camofox launch option types from `camoufox-js`. When the console workspace typechecked without root dependencies installed, a small UI type dependency surfaced as a missing `camoufox-js` module error.

## Impact

The console no longer needs to resolve the full runtime config type graph just to type model provider labels. Backend callers can continue importing `GatewayModelProviderKey` from `gateway-types.ts`.

## Validation

- `npm --prefix console run build`
- `npm run typecheck`