### PR TITLE
[codex] Bind SearXNG bearer secrets per agent

### DIFF
--- a/container/shared/web-search-config.d.ts
+++ b/container/shared/web-search-config.d.ts
@@ -7,12 +7,17 @@ export type SearchProviderName =
 
 export type SearchProviderMode = SearchProviderName | 'auto';
 
+export type WebSearchSecretRef =
+  | { source: 'env'; id: string }
+  | { source: 'store'; id: string };
+
 export interface WebSearchConfig {
   provider: SearchProviderMode;
   fallbackProviders: SearchProviderName[];
   defaultCount: number;
   cacheTtlMinutes: number;
   searxngBaseUrl: string;
+  searxngBearerTokenRef?: WebSearchSecretRef;
   tavilySearchDepth: 'basic' | 'advanced';
   braveApiKey?: string;
   perplexityApiKey?: string;

--- a/container/src/tools.ts
+++ b/container/src/tools.ts
@@ -3399,6 +3399,13 @@ async function executeToolInternal(
           provider: args.provider,
         },
         currentWebSearchConfig,
+        {
+          gateway: {
+            baseUrl: gatewayBaseUrl,
+            apiToken: gatewayApiToken,
+            sessionId: currentSessionId,
+          },
+        },
       );
     }
 

--- a/container/src/web-search.ts
+++ b/container/src/web-search.ts
@@ -137,6 +137,16 @@ interface SearchExecutionContext {
   engines?: string;
 }
 
+export interface WebSearchGatewayContext {
+  baseUrl?: string;
+  apiToken?: string;
+  sessionId?: string;
+}
+
+interface SearchRuntimeContext {
+  gateway?: WebSearchGatewayContext;
+}
+
 export interface WebSearchExecutionResult {
   query: string;
   provider: SearchProviderName;
@@ -373,6 +383,9 @@ export function getWebSearchConfigFromEnv(
       ? {
           searxngBaseUrl: String(override.searxngBaseUrl || '').trim(),
         }
+      : {}),
+    ...(override?.searxngBearerTokenRef != null
+      ? { searxngBearerTokenRef: override.searxngBearerTokenRef }
       : {}),
     ...(override?.tavilySearchDepth != null
       ? {
@@ -910,9 +923,69 @@ function createDuckDuckGoProvider(): SearchProvider {
   };
 }
 
+async function fetchGatewayHttpJson(params: {
+  url: string;
+  provider: string;
+  signal: AbortSignal;
+  gateway?: WebSearchGatewayContext;
+  bearerSecretRef: NonNullable<WebSearchConfig['searxngBearerTokenRef']>;
+}): Promise<unknown> {
+  const base = String(params.gateway?.baseUrl || '')
+    .trim()
+    .replace(/\/+$/, '');
+  if (!base) {
+    throw new Error(
+      `${params.provider} bearer token requires gateway HTTP proxy`,
+    );
+  }
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  const apiToken = String(params.gateway?.apiToken || '').trim();
+  if (apiToken) headers.Authorization = `Bearer ${apiToken}`;
+
+  const response = await fetch(`${base}/api/http/request`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      url: params.url,
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': USER_AGENT,
+      },
+      bearerSecretRef: params.bearerSecretRef,
+      maxResponseBytes: MAX_RESPONSE_BYTES,
+      ...(params.gateway?.sessionId
+        ? { sessionId: params.gateway.sessionId }
+        : {}),
+    }),
+    signal: params.signal,
+  });
+  const proxyPayload = await readJsonResponse(response, params.provider);
+  if (!response.ok) throw buildHttpError(response);
+  if (!isRecord(proxyPayload)) {
+    throw new Error(`${params.provider} gateway proxy returned invalid JSON`);
+  }
+  if (proxyPayload.ok === false) {
+    throw new Error(`HTTP ${String(proxyPayload.status || '').trim()}`);
+  }
+  if (proxyPayload.json !== undefined) return proxyPayload.json;
+  if (typeof proxyPayload.body === 'string') {
+    try {
+      return JSON.parse(proxyPayload.body) as unknown;
+    } catch {
+      throw new Error(`${params.provider} returned invalid JSON`);
+    }
+  }
+  throw new Error(`${params.provider} gateway proxy returned no body`);
+}
+
 function createSearxngProvider(
   config: WebSearchConfig,
   context: SearchExecutionContext,
+  runtimeContext: SearchRuntimeContext = {},
 ): SearchProvider {
   const requestContext = buildProviderRequestContext(context);
   return {
@@ -922,24 +995,33 @@ function createSearxngProvider(
 
       const timeout = createTimeoutSignal(signal, DEFAULT_PROVIDER_TIMEOUT_MS);
       try {
-        const res = await fetch(
-          buildSearxngSearchUrl({
-            baseUrl: config.searxngBaseUrl,
-            query,
-            language: requestContext.language,
-            count,
-            categories: requestContext.categories,
-            engines: requestContext.engines,
-            timeRange: requestContext.searxngTimeRange,
-          }),
-          {
-            headers: {
-              Accept: 'application/json',
-              'User-Agent': USER_AGENT,
-            },
+        const url = buildSearxngSearchUrl({
+          baseUrl: config.searxngBaseUrl,
+          query,
+          language: requestContext.language,
+          count,
+          categories: requestContext.categories,
+          engines: requestContext.engines,
+          timeRange: requestContext.searxngTimeRange,
+        });
+        if (config.searxngBearerTokenRef) {
+          const payload = await fetchGatewayHttpJson({
+            url,
+            provider: 'SearXNG',
             signal: timeout.signal,
+            gateway: runtimeContext.gateway,
+            bearerSecretRef: config.searxngBearerTokenRef,
+          });
+          return parseSearxngSearchResponse(payload);
+        }
+
+        const res = await fetch(url, {
+          headers: {
+            Accept: 'application/json',
+            'User-Agent': USER_AGENT,
           },
-        );
+          signal: timeout.signal,
+        });
         if (!res.ok) throw buildHttpError(res);
         return parseSearxngSearchResponse(
           await readJsonResponse(res, 'SearXNG'),
@@ -961,6 +1043,7 @@ function createProvider(
   name: SearchProviderName,
   config: WebSearchConfig,
   context: SearchExecutionContext,
+  runtimeContext: SearchRuntimeContext = {},
 ): SearchProvider {
   switch (name) {
     case 'brave':
@@ -972,7 +1055,7 @@ function createProvider(
     case 'duckduckgo':
       return createDuckDuckGoProvider();
     case 'searxng':
-      return createSearxngProvider(config, context);
+      return createSearxngProvider(config, context, runtimeContext);
   }
 }
 
@@ -997,6 +1080,7 @@ function isProviderAvailable(
 export function buildProviderChain(
   config: WebSearchConfig,
   context: SearchExecutionContext = {},
+  runtimeContext: SearchRuntimeContext = {},
 ): SearchProvider[] {
   const mode = normalizeProviderMode(config.provider);
   const seen = new Set<SearchProviderName>();
@@ -1020,12 +1104,15 @@ export function buildProviderChain(
   }
 
   add('duckduckgo');
-  return ordered.map((provider) => createProvider(provider, config, context));
+  return ordered.map((provider) =>
+    createProvider(provider, config, context, runtimeContext),
+  );
 }
 
 export async function searchWeb(
   params: WebSearchParams,
   configOverride?: Partial<WebSearchRuntimeConfig>,
+  runtimeContext: SearchRuntimeContext = {},
 ): Promise<WebSearchExecutionResult> {
   const config = getWebSearchConfigFromEnv(configOverride);
   const normalized = normalizeSearchParams(params, config);
@@ -1040,7 +1127,11 @@ export async function searchWeb(
 
   const controller = new AbortController();
   const start = Date.now();
-  const providers = buildProviderChain(effectiveConfig, normalized);
+  const providers = buildProviderChain(
+    effectiveConfig,
+    normalized,
+    runtimeContext,
+  );
   const attemptedProviders: SearchProviderName[] = [];
   const errors: string[] = [];
 
@@ -1099,6 +1190,9 @@ function formatSearchResults(result: WebSearchExecutionResult): string {
 export async function webSearch(
   params: WebSearchParams,
   configOverride?: Partial<WebSearchRuntimeConfig>,
+  runtimeContext: SearchRuntimeContext = {},
 ): Promise<string> {
-  return formatSearchResults(await searchWeb(params, configOverride));
+  return formatSearchResults(
+    await searchWeb(params, configOverride, runtimeContext),
+  );
 }

--- a/container/src/web-search.ts
+++ b/container/src/web-search.ts
@@ -559,13 +559,39 @@ function sanitizeProviderError(error: unknown): string {
 function buildCacheKey(
   params: NormalizedSearchParams,
   requestedProvider: SearchProviderMode,
+  config: WebSearchConfig,
 ): string {
   const suffix = [params.country || '', params.language || '']
     .filter(Boolean)
     .join(':');
   const categories = params.categories || '';
   const engines = params.engines || '';
-  return `search:${params.query}:${params.count}:${requestedProvider}:${params.freshness || ''}:${categories}:${engines}${suffix ? `:${suffix}` : ''}`.toLowerCase();
+  const searxngPartition = buildSearxngCachePartition(config);
+  return `search:${params.query}:${params.count}:${requestedProvider}:${params.freshness || ''}:${categories}:${engines}:${searxngPartition}${suffix ? `:${suffix}` : ''}`.toLowerCase();
+}
+
+function buildSearxngCachePartition(config: WebSearchConfig): string {
+  const includesSearxng =
+    config.provider === 'auto' ||
+    config.provider === 'searxng' ||
+    config.fallbackProviders.includes('searxng');
+  if (!includesSearxng) return '';
+  return stableCacheHash(
+    [
+      config.searxngBaseUrl,
+      config.searxngBearerTokenRef?.source || '',
+      config.searxngBearerTokenRef?.id || '',
+    ].join('\0'),
+  );
+}
+
+function stableCacheHash(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
 }
 
 export function mapFreshnessForProvider(
@@ -923,7 +949,7 @@ function createDuckDuckGoProvider(): SearchProvider {
   };
 }
 
-async function fetchGatewayHttpJson(params: {
+async function fetchViaGatewayBearer(params: {
   url: string;
   provider: string;
   signal: AbortSignal;
@@ -963,8 +989,8 @@ async function fetchGatewayHttpJson(params: {
     }),
     signal: params.signal,
   });
-  const proxyPayload = await readJsonResponse(response, params.provider);
   if (!response.ok) throw buildHttpError(response);
+  const proxyPayload = await readJsonResponse(response, params.provider);
   if (!isRecord(proxyPayload)) {
     throw new Error(`${params.provider} gateway proxy returned invalid JSON`);
   }
@@ -1005,7 +1031,7 @@ function createSearxngProvider(
           timeRange: requestContext.searxngTimeRange,
         });
         if (config.searxngBearerTokenRef) {
-          const payload = await fetchGatewayHttpJson({
+          const payload = await fetchViaGatewayBearer({
             url,
             provider: 'SearXNG',
             signal: timeout.signal,
@@ -1121,7 +1147,11 @@ export async function searchWeb(
     ...config,
     provider: requestedProvider,
   };
-  const cacheKey = buildCacheKey(normalized, requestedProvider);
+  const cacheKey = buildCacheKey(
+    normalized,
+    requestedProvider,
+    effectiveConfig,
+  );
   const cached = readCache(cacheKey);
   if (cached) return { ...cached, cached: true };
 

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -152,6 +152,9 @@ saved revision history directly.
   an immediate local consolidation run
 - `agents.defaultAgentId` for the default agent used by new requests and fresh
   web sessions when no agent is pinned explicitly
+- `agents.list[].webSearch.searxngBaseUrl` and
+  `agents.list[].webSearch.searxngBearerTokenRef` override the global SearXNG
+  instance and bearer SecretRef for a specific agent
 - `channelInstructions.*` for transport-specific prompt guidance injected into
   the runtime prompt; `channelInstructions.voice` is the right place for
   spoken-style rules such as "no markdown" or "keep replies short"
@@ -218,9 +221,14 @@ saved revision history directly.
   fallback values when no encrypted secret is present
 - `web.search.provider`, `web.search.fallbackProviders`,
   `web.search.defaultCount`, `web.search.cacheTtlMinutes`,
-  `web.search.searxngBaseUrl`, and `web.search.tavilySearchDepth` control the
-  built-in web-search provider chain. Set `web.search.searxngBaseUrl` or
-  `SEARXNG_BASE_URL` when using the self-hosted SearXNG provider.
+  `web.search.searxngBaseUrl`, `web.search.searxngBearerTokenRef`, and
+  `web.search.tavilySearchDepth` control the built-in web-search provider
+  chain. Set `web.search.searxngBaseUrl` or `SEARXNG_BASE_URL` when using the
+  self-hosted SearXNG provider. Use `web.search.searxngBearerTokenRef` for
+  authenticated SearXNG instances; plaintext bearer tokens are rejected. Agent
+  entries can set `webSearch.searxngBaseUrl` and
+  `webSearch.searxngBearerTokenRef` to bind a tenant-specific SearXNG instance
+  without exposing the bearer token to the agent context.
 - `media.audio` for inbound audio transcription backend selection. Generated
   image and video artifacts are written through the native media-generation
   tools when the corresponding provider credentials and models are configured.

--- a/docs/content/reference/tools/web-search.md
+++ b/docs/content/reference/tools/web-search.md
@@ -92,6 +92,6 @@ If `provider` is set explicitly, the tool uses that provider first, then `fallba
 
 - Search responses are cached for 5 minutes by default.
 - API keys are read from environment variables only.
-- SearXNG bearer tokens must use env/store SecretRefs and are injected through the gateway HTTP proxy so they do not enter the LLM context.
+- SearXNG bearer tokens must use store SecretRefs and are injected through the gateway HTTP proxy so they do not enter the LLM context.
 - Result URLs are validated before they are returned.
 - Provider errors are aggregated without echoing secrets.

--- a/docs/content/reference/tools/web-search.md
+++ b/docs/content/reference/tools/web-search.md
@@ -65,7 +65,6 @@ Runtime settings are forwarded into the agent container with these derived env v
 - `HYBRIDCLAW_WEB_SEARCH_FALLBACK_PROVIDERS`
 - `HYBRIDCLAW_WEB_SEARCH_DEFAULT_COUNT`
 - `HYBRIDCLAW_WEB_SEARCH_CACHE_TTL_MINUTES`
-- `HYBRIDCLAW_WEB_SEARCH_SEARXNG_BASE_URL`
 - `HYBRIDCLAW_WEB_SEARCH_TAVILY_SEARCH_DEPTH`
 
 ## Auto Mode
@@ -93,7 +92,6 @@ If `provider` is set explicitly, the tool uses that provider first, then `fallba
 
 - Search responses are cached for 5 minutes by default.
 - API keys are read from environment variables only.
-- SearXNG bearer tokens must use env/store SecretRefs and are injected through
-  the gateway HTTP proxy so they do not enter the LLM context.
+- SearXNG bearer tokens must use env/store SecretRefs and are injected through the gateway HTTP proxy so they do not enter the LLM context.
 - Result URLs are validated before they are returned.
 - Provider errors are aggregated without echoing secrets.

--- a/docs/content/reference/tools/web-search.md
+++ b/docs/content/reference/tools/web-search.md
@@ -24,8 +24,30 @@ Add the runtime config section below to `~/.hybridclaw/config.json`:
       "defaultCount": 5,
       "cacheTtlMinutes": 5,
       "searxngBaseUrl": "",
+      "searxngBearerTokenRef": { "source": "store", "id": "SEARXNG_BEARER_TOKEN" },
       "tavilySearchDepth": "advanced"
     }
+  }
+}
+```
+
+Agent-specific SearXNG settings can override the global instance:
+
+```json
+{
+  "agents": {
+    "list": [
+      {
+        "id": "research",
+        "webSearch": {
+          "searxngBaseUrl": "https://search.research.example",
+          "searxngBearerTokenRef": {
+            "source": "store",
+            "id": "RESEARCH_SEARXNG_BEARER_TOKEN"
+          }
+        }
+      }
+    ]
   }
 }
 ```
@@ -71,5 +93,7 @@ If `provider` is set explicitly, the tool uses that provider first, then `fallba
 
 - Search responses are cached for 5 minutes by default.
 - API keys are read from environment variables only.
+- SearXNG bearer tokens must use env/store SecretRefs and are injected through
+  the gateway HTTP proxy so they do not enter the LLM context.
 - Result URLs are validated before they are returned.
 - Provider errors are aggregated without echoing secrets.

--- a/docs/tools/web-search.md
+++ b/docs/tools/web-search.md
@@ -92,6 +92,6 @@ If `provider` is set explicitly, the tool uses that provider first, then `fallba
 
 - Search responses are cached for 5 minutes by default.
 - API keys are read from environment variables only.
-- SearXNG bearer tokens must use env/store SecretRefs and are injected through the gateway HTTP proxy so they do not enter the LLM context.
+- SearXNG bearer tokens must use store SecretRefs and are injected through the gateway HTTP proxy so they do not enter the LLM context.
 - Result URLs are validated before they are returned.
 - Provider errors are aggregated without echoing secrets.

--- a/docs/tools/web-search.md
+++ b/docs/tools/web-search.md
@@ -65,7 +65,6 @@ Runtime settings are forwarded into the agent container with these derived env v
 - `HYBRIDCLAW_WEB_SEARCH_FALLBACK_PROVIDERS`
 - `HYBRIDCLAW_WEB_SEARCH_DEFAULT_COUNT`
 - `HYBRIDCLAW_WEB_SEARCH_CACHE_TTL_MINUTES`
-- `HYBRIDCLAW_WEB_SEARCH_SEARXNG_BASE_URL`
 - `HYBRIDCLAW_WEB_SEARCH_TAVILY_SEARCH_DEPTH`
 
 ## Auto Mode
@@ -93,7 +92,6 @@ If `provider` is set explicitly, the tool uses that provider first, then `fallba
 
 - Search responses are cached for 5 minutes by default.
 - API keys are read from environment variables only.
-- SearXNG bearer tokens must use env/store SecretRefs and are injected through
-  the gateway HTTP proxy so they do not enter the LLM context.
+- SearXNG bearer tokens must use env/store SecretRefs and are injected through the gateway HTTP proxy so they do not enter the LLM context.
 - Result URLs are validated before they are returned.
 - Provider errors are aggregated without echoing secrets.

--- a/docs/tools/web-search.md
+++ b/docs/tools/web-search.md
@@ -24,8 +24,30 @@ Add the runtime config section below to `~/.hybridclaw/config.json`:
       "defaultCount": 5,
       "cacheTtlMinutes": 5,
       "searxngBaseUrl": "",
+      "searxngBearerTokenRef": { "source": "store", "id": "SEARXNG_BEARER_TOKEN" },
       "tavilySearchDepth": "advanced"
     }
+  }
+}
+```
+
+Agent-specific SearXNG settings can override the global instance:
+
+```json
+{
+  "agents": {
+    "list": [
+      {
+        "id": "research",
+        "webSearch": {
+          "searxngBaseUrl": "https://search.research.example",
+          "searxngBearerTokenRef": {
+            "source": "store",
+            "id": "RESEARCH_SEARXNG_BEARER_TOKEN"
+          }
+        }
+      }
+    ]
   }
 }
 ```
@@ -43,6 +65,7 @@ Runtime settings are forwarded into the agent container with these derived env v
 - `HYBRIDCLAW_WEB_SEARCH_FALLBACK_PROVIDERS`
 - `HYBRIDCLAW_WEB_SEARCH_DEFAULT_COUNT`
 - `HYBRIDCLAW_WEB_SEARCH_CACHE_TTL_MINUTES`
+- `HYBRIDCLAW_WEB_SEARCH_SEARXNG_BASE_URL`
 - `HYBRIDCLAW_WEB_SEARCH_TAVILY_SEARCH_DEPTH`
 
 ## Auto Mode
@@ -70,5 +93,7 @@ If `provider` is set explicitly, the tool uses that provider first, then `fallba
 
 - Search responses are cached for 5 minutes by default.
 - API keys are read from environment variables only.
+- SearXNG bearer tokens must use env/store SecretRefs and are injected through
+  the gateway HTTP proxy so they do not enter the LLM context.
 - Result URLs are validated before they are returned.
 - Provider errors are aggregated without echoing secrets.

--- a/src/agents/agent-config-command.ts
+++ b/src/agents/agent-config-command.ts
@@ -17,6 +17,7 @@ import {
   hasSnakeCamelAlias,
   normalizeAgentCv,
   normalizeAgentEscalationTarget,
+  normalizeAgentWebSearchConfig,
   resolveSnakeCamelAlias,
 } from './agent-types.js';
 
@@ -273,6 +274,22 @@ function applyAgentConfigFieldUpdates(
         );
       }
       next.escalationTarget = escalationTarget;
+    }
+  }
+  if (Object.hasOwn(updates, 'webSearch')) {
+    if (updates.webSearch === null) {
+      delete next.webSearch;
+    } else {
+      const webSearch = normalizeAgentWebSearchConfig(
+        updates.webSearch,
+        'webSearch',
+      );
+      if (!webSearch) {
+        throw new Error(
+          '`webSearch` must include searxngBaseUrl or searxngBearerTokenRef fields, or null.',
+        );
+      }
+      next.webSearch = webSearch;
     }
   }
   return next;

--- a/src/agents/agent-registry.ts
+++ b/src/agents/agent-registry.ts
@@ -31,10 +31,12 @@ import {
   buildOptionalAgentPresentation,
   cloneAgentA2AConfig,
   cloneAgentCv,
+  cloneAgentWebSearchConfig,
   DEFAULT_AGENT_ID,
   normalizeAgentA2AConfig,
   normalizeAgentCv,
   normalizeAgentEscalationTarget,
+  normalizeAgentWebSearchConfig,
   resolveSnakeCamelAlias,
   validateAgentOrgChart,
 } from './agent-types.js';
@@ -192,6 +194,9 @@ function normalizeAgent(value: unknown): AgentConfig | null {
     (value as { escalationTarget?: unknown }).escalationTarget,
   );
   const a2a = normalizeAgentA2AConfig((value as { a2a?: unknown }).a2a);
+  const webSearch = normalizeAgentWebSearchConfig(
+    (value as { webSearch?: unknown }).webSearch,
+  );
   return {
     id,
     ...(name ? { name } : {}),
@@ -209,6 +214,7 @@ function normalizeAgent(value: unknown): AgentConfig | null {
     ...(cv ? { cv } : {}),
     ...(escalationTarget ? { escalationTarget } : {}),
     ...(a2a ? { a2a } : {}),
+    ...(webSearch ? { webSearch } : {}),
   };
 }
 
@@ -242,6 +248,15 @@ function fingerprintCv(cv: AgentConfig['cv']): string {
   ].join(':');
 }
 
+function fingerprintWebSearch(webSearch: AgentConfig['webSearch']): string {
+  if (!webSearch) return '';
+  return [
+    fingerprintString(webSearch.searxngBaseUrl),
+    fingerprintString(webSearch.searxngBearerTokenRef?.source),
+    fingerprintString(webSearch.searxngBearerTokenRef?.id),
+  ].join(':');
+}
+
 function fingerprintAgent(agent: AgentConfig): string {
   return [
     fingerprintString(agent.id),
@@ -267,6 +282,7 @@ function fingerprintAgent(agent: AgentConfig): string {
         .map(([skill, exposure]) => `${skill}:${exposure}`)
         .sort(),
     ),
+    fingerprintWebSearch(agent.webSearch),
   ].join('|');
 }
 
@@ -346,6 +362,9 @@ function applyDefaults(agent: AgentConfig): AgentConfig {
       ? { escalationTarget: { ...agent.escalationTarget } }
       : {}),
     ...(agent.a2a ? { a2a: cloneAgentA2AConfig(agent.a2a) } : {}),
+    ...(agent.webSearch
+      ? { webSearch: cloneAgentWebSearchConfig(agent.webSearch) }
+      : {}),
   };
 }
 
@@ -397,6 +416,7 @@ function configuredAgentForDatabase(agent: AgentConfig): AgentConfig {
     cv: cloneAgentCv(agent.cv),
     escalationTarget: agent.escalationTarget,
     a2a: cloneAgentA2AConfig(agent.a2a),
+    webSearch: cloneAgentWebSearchConfig(agent.webSearch),
   };
 }
 

--- a/src/agents/agent-types.ts
+++ b/src/agents/agent-types.ts
@@ -135,12 +135,17 @@ export function cloneAgentWebSearchConfig(
 export function normalizeAgentWebSearchConfig(
   value: unknown,
   path = 'agents.list[].webSearch',
+  fallback?: AgentWebSearchConfig,
 ): AgentWebSearchConfig | undefined {
+  if (value === undefined) return cloneAgentWebSearchConfig(fallback);
+  if (value === null || value === '') return undefined;
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return undefined;
+    return cloneAgentWebSearchConfig(fallback);
   }
   const raw = value as Record<string, unknown>;
-  const searxngBaseUrl = normalizeTrimmedString(raw.searxngBaseUrl);
+  const searxngBaseUrl = Object.hasOwn(raw, 'searxngBaseUrl')
+    ? normalizeTrimmedString(raw.searxngBaseUrl)
+    : fallback?.searxngBaseUrl;
   let searxngBearerTokenRef: SecretRef | undefined;
   if (
     raw.searxngBearerTokenRef !== undefined &&
@@ -153,6 +158,10 @@ export function normalizeAgentWebSearchConfig(
       );
     }
     searxngBearerTokenRef = parsed.ref;
+  } else if (!Object.hasOwn(raw, 'searxngBearerTokenRef')) {
+    searxngBearerTokenRef = fallback?.searxngBearerTokenRef
+      ? { ...fallback.searxngBearerTokenRef }
+      : undefined;
   }
   const normalized: AgentWebSearchConfig = {
     ...(searxngBaseUrl ? { searxngBaseUrl } : {}),

--- a/src/agents/agent-types.ts
+++ b/src/agents/agent-types.ts
@@ -1,4 +1,7 @@
-import { parseSecretInput, type SecretRef } from '../security/secret-refs.js';
+import {
+  parseSecretRefInput,
+  type SecretRef,
+} from '../security/secret-refs.js';
 import type { EscalationTarget } from '../types/execution.js';
 import {
   normalizeTrimmedString,
@@ -151,13 +154,10 @@ export function normalizeAgentWebSearchConfig(
     raw.searxngBearerTokenRef !== undefined &&
     raw.searxngBearerTokenRef !== ''
   ) {
-    const parsed = parseSecretInput(raw.searxngBearerTokenRef);
-    if (parsed.kind !== 'ref') {
-      throw new Error(
-        `${path}.searxngBearerTokenRef must use an env/store secret reference such as \`{ "source": "store", "id": "SECRET_NAME" }\` or \`\${ENV_VAR_NAME}\`.`,
-      );
-    }
-    searxngBearerTokenRef = parsed.ref;
+    searxngBearerTokenRef = parseSecretRefInput(
+      raw.searxngBearerTokenRef,
+      `${path}.searxngBearerTokenRef`,
+    );
   } else if (!Object.hasOwn(raw, 'searxngBearerTokenRef')) {
     searxngBearerTokenRef = fallback?.searxngBearerTokenRef
       ? { ...fallback.searxngBearerTokenRef }

--- a/src/agents/agent-types.ts
+++ b/src/agents/agent-types.ts
@@ -1,3 +1,4 @@
+import { parseSecretInput, type SecretRef } from '../security/secret-refs.js';
 import type { EscalationTarget } from '../types/execution.js';
 import {
   normalizeTrimmedString,
@@ -33,6 +34,11 @@ export interface AgentA2AConfig {
   skillExposure?: Record<string, AgentA2AExposure>;
 }
 
+export interface AgentWebSearchConfig {
+  searxngBaseUrl?: string;
+  searxngBearerTokenRef?: SecretRef;
+}
+
 export interface AgentConfig {
   id: string;
   name?: string;
@@ -51,6 +57,7 @@ export interface AgentConfig {
   cv?: AgentCv;
   escalationTarget?: EscalationTarget;
   a2a?: AgentA2AConfig;
+  webSearch?: AgentWebSearchConfig;
 }
 
 export interface AgentDefaultsConfig {
@@ -110,6 +117,48 @@ export function cloneAgentCv(value: AgentCv | undefined): AgentCv | undefined {
     ...value,
     ...(value.capabilities ? { capabilities: [...value.capabilities] } : {}),
   };
+}
+
+export function cloneAgentWebSearchConfig(
+  value: AgentWebSearchConfig | undefined,
+): AgentWebSearchConfig | undefined {
+  if (!value) return undefined;
+  const clone: AgentWebSearchConfig = {
+    ...(value.searxngBaseUrl ? { searxngBaseUrl: value.searxngBaseUrl } : {}),
+    ...(value.searxngBearerTokenRef
+      ? { searxngBearerTokenRef: { ...value.searxngBearerTokenRef } }
+      : {}),
+  };
+  return Object.keys(clone).length > 0 ? clone : undefined;
+}
+
+export function normalizeAgentWebSearchConfig(
+  value: unknown,
+  path = 'agents.list[].webSearch',
+): AgentWebSearchConfig | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  const raw = value as Record<string, unknown>;
+  const searxngBaseUrl = normalizeTrimmedString(raw.searxngBaseUrl);
+  let searxngBearerTokenRef: SecretRef | undefined;
+  if (
+    raw.searxngBearerTokenRef !== undefined &&
+    raw.searxngBearerTokenRef !== ''
+  ) {
+    const parsed = parseSecretInput(raw.searxngBearerTokenRef);
+    if (parsed.kind !== 'ref') {
+      throw new Error(
+        `${path}.searxngBearerTokenRef must use an env/store secret reference such as \`{ "source": "store", "id": "SECRET_NAME" }\` or \`\${ENV_VAR_NAME}\`.`,
+      );
+    }
+    searxngBearerTokenRef = parsed.ref;
+  }
+  const normalized: AgentWebSearchConfig = {
+    ...(searxngBaseUrl ? { searxngBaseUrl } : {}),
+    ...(searxngBearerTokenRef ? { searxngBearerTokenRef } : {}),
+  };
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
 }
 
 function normalizeAgentA2AExposureValue(

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -567,6 +567,7 @@ export let WEB_SEARCH_FALLBACK_PROVIDERS: RuntimeConfig['web']['search']['fallba
 export let WEB_SEARCH_DEFAULT_COUNT = 5;
 export let WEB_SEARCH_CACHE_TTL_MINUTES = 5;
 export let WEB_SEARCH_SEARXNG_BASE_URL = '';
+export let WEB_SEARCH_SEARXNG_BEARER_TOKEN_REF: RuntimeConfig['web']['search']['searxngBearerTokenRef'];
 export let WEB_SEARCH_TAVILY_SEARCH_DEPTH: RuntimeConfig['web']['search']['tavilySearchDepth'] =
   'advanced';
 
@@ -1117,6 +1118,7 @@ function applyRuntimeConfig(config: RuntimeConfig): void {
   );
   WEB_SEARCH_SEARXNG_BASE_URL =
     process.env.SEARXNG_BASE_URL || config.web.search.searxngBaseUrl;
+  WEB_SEARCH_SEARXNG_BEARER_TOKEN_REF = config.web.search.searxngBearerTokenRef;
   WEB_SEARCH_TAVILY_SEARCH_DEPTH = config.web.search.tavilySearchDepth;
 
   HEARTBEAT_ENABLED = config.heartbeat.enabled;

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -20,6 +20,7 @@ import {
   normalizeAgentA2AConfig,
   normalizeAgentCv,
   normalizeAgentEscalationTarget,
+  normalizeAgentWebSearchConfig,
   resolveSnakeCamelAlias,
   validateAgentOrgChart,
 } from '../agents/agent-types.js';
@@ -2515,31 +2516,6 @@ function normalizeAgentDefaultsConfig(
   };
 }
 
-function normalizeAgentWebSearchConfig(
-  value: unknown,
-  fallback?: AgentConfig['webSearch'],
-): AgentConfig['webSearch'] | undefined {
-  if (!isRecord(value)) return cloneAgentWebSearchConfig(fallback);
-  const searxngBaseUrl = normalizeString(
-    value.searxngBaseUrl,
-    fallback?.searxngBaseUrl ?? '',
-    { allowEmpty: true },
-  );
-  const searxngBearerTokenRef = Object.hasOwn(value, 'searxngBearerTokenRef')
-    ? normalizeOptionalSecretRef(
-        value.searxngBearerTokenRef,
-        'agents.list[].webSearch.searxngBearerTokenRef',
-      )
-    : fallback?.searxngBearerTokenRef
-      ? cloneConfig(fallback.searxngBearerTokenRef)
-      : undefined;
-  const normalized: AgentConfig['webSearch'] = {
-    ...(searxngBaseUrl ? { searxngBaseUrl } : {}),
-    ...(searxngBearerTokenRef ? { searxngBearerTokenRef } : {}),
-  };
-  return Object.keys(normalized).length > 0 ? normalized : undefined;
-}
-
 function normalizeAgentConfig(
   value: unknown,
   fallback?: AgentConfig,
@@ -2627,7 +2603,11 @@ function normalizeAgentConfig(
     ? normalizeAgentA2AConfig(value.a2a)
     : cloneAgentA2AConfig(fallback?.a2a);
   const webSearch = Object.hasOwn(value, 'webSearch')
-    ? normalizeAgentWebSearchConfig(value.webSearch, fallback?.webSearch)
+    ? normalizeAgentWebSearchConfig(
+        value.webSearch,
+        'agents.list[].webSearch',
+        fallback?.webSearch,
+      )
     : cloneAgentWebSearchConfig(fallback?.webSearch);
   return {
     id,

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -14,6 +14,7 @@ import {
   buildOptionalAgentPresentation,
   cloneAgentA2AConfig,
   cloneAgentCv,
+  cloneAgentWebSearchConfig,
   DEFAULT_AGENT_ID,
   hasSnakeCamelAlias,
   normalizeAgentA2AConfig,
@@ -1009,6 +1010,7 @@ export interface RuntimeConfig {
       defaultCount: number;
       cacheTtlMinutes: number;
       searxngBaseUrl: string;
+      searxngBearerTokenRef?: SecretRef;
       tavilySearchDepth: 'basic' | 'advanced';
     };
   };
@@ -2513,6 +2515,31 @@ function normalizeAgentDefaultsConfig(
   };
 }
 
+function normalizeAgentWebSearchConfig(
+  value: unknown,
+  fallback?: AgentConfig['webSearch'],
+): AgentConfig['webSearch'] | undefined {
+  if (!isRecord(value)) return cloneAgentWebSearchConfig(fallback);
+  const searxngBaseUrl = normalizeString(
+    value.searxngBaseUrl,
+    fallback?.searxngBaseUrl ?? '',
+    { allowEmpty: true },
+  );
+  const searxngBearerTokenRef = Object.hasOwn(value, 'searxngBearerTokenRef')
+    ? normalizeOptionalSecretRef(
+        value.searxngBearerTokenRef,
+        'agents.list[].webSearch.searxngBearerTokenRef',
+      )
+    : fallback?.searxngBearerTokenRef
+      ? cloneConfig(fallback.searxngBearerTokenRef)
+      : undefined;
+  const normalized: AgentConfig['webSearch'] = {
+    ...(searxngBaseUrl ? { searxngBaseUrl } : {}),
+    ...(searxngBearerTokenRef ? { searxngBearerTokenRef } : {}),
+  };
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
 function normalizeAgentConfig(
   value: unknown,
   fallback?: AgentConfig,
@@ -2599,6 +2626,9 @@ function normalizeAgentConfig(
   const a2a = Object.hasOwn(value, 'a2a')
     ? normalizeAgentA2AConfig(value.a2a)
     : cloneAgentA2AConfig(fallback?.a2a);
+  const webSearch = Object.hasOwn(value, 'webSearch')
+    ? normalizeAgentWebSearchConfig(value.webSearch, fallback?.webSearch)
+    : cloneAgentWebSearchConfig(fallback?.webSearch);
   return {
     id,
     ...(name ? { name } : {}),
@@ -2616,6 +2646,7 @@ function normalizeAgentConfig(
     ...(cv ? { cv } : {}),
     ...(escalationTarget ? { escalationTarget } : {}),
     ...(a2a ? { a2a } : {}),
+    ...(webSearch ? { webSearch } : {}),
   };
 }
 
@@ -4780,6 +4811,18 @@ function normalizeBrowserUseCloudApiKeyRef(
   );
 }
 
+function normalizeOptionalSecretRef(
+  value: unknown,
+  path: string,
+): SecretRef | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  const parsed = parseSecretInput(value);
+  if (parsed.kind === 'ref') return cloneConfig(parsed.ref);
+  throw new Error(
+    `${path} must use an env/store secret reference such as \`{ "source": "store", "id": "SECRET_NAME" }\` or \`\${ENV_VAR_NAME}\`.`,
+  );
+}
+
 const CAMOFOX_MANAGED_LAUNCH_OPTION_KEYS = new Set([
   'headless',
   'timeout',
@@ -5744,6 +5787,10 @@ function normalizeRuntimeConfig(
       required:
         isSecretRefInput(rawThreema.secret) && Boolean(rawThreema.enabled),
     },
+  );
+  const searxngBearerTokenRef = normalizeOptionalSecretRef(
+    rawWebSearch.searxngBearerTokenRef,
+    'web.search.searxngBearerTokenRef',
   );
   const healthPort = normalizeInteger(
     rawOps.healthPort,
@@ -6720,6 +6767,7 @@ function normalizeRuntimeConfig(
           DEFAULT_RUNTIME_CONFIG.web.search.searxngBaseUrl,
           { allowEmpty: true },
         ),
+        ...(searxngBearerTokenRef ? { searxngBearerTokenRef } : {}),
         tavilySearchDepth: normalizeTavilySearchDepth(
           rawWebSearch.tavilySearchDepth,
           DEFAULT_RUNTIME_CONFIG.web.search.tavilySearchDepth,

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -65,6 +65,7 @@ import type { SecretHandle } from '../security/secret-handles.js';
 import {
   isSecretRefInput,
   parseSecretInput,
+  parseSecretRefInput,
   resolveSecretInputUnsafe,
   type SecretInput,
   type SecretRef,
@@ -4796,11 +4797,7 @@ function normalizeOptionalSecretRef(
   path: string,
 ): SecretRef | undefined {
   if (value === undefined || value === null || value === '') return undefined;
-  const parsed = parseSecretInput(value);
-  if (parsed.kind === 'ref') return cloneConfig(parsed.ref);
-  throw new Error(
-    `${path} must use an env/store secret reference such as \`{ "source": "store", "id": "SECRET_NAME" }\` or \`\${ENV_VAR_NAME}\`.`,
-  );
+  return parseSecretRefInput(value, path);
 }
 
 const CAMOFOX_MANAGED_LAUNCH_OPTION_KEYS = new Set([

--- a/src/gateway/gateway-http-proxy.ts
+++ b/src/gateway/gateway-http-proxy.ts
@@ -38,8 +38,10 @@ import {
   normalizeSecretString,
 } from '../security/secret-normalization.js';
 import {
+  parseSecretRefInput,
   resolveSecretHandleInput,
   resolveSecretInputUnsafe,
+  type SecretRef,
 } from '../security/secret-refs.js';
 
 import {
@@ -73,6 +75,7 @@ type ApiHttpRequestBody = {
   body?: unknown;
   json?: unknown;
   bearerSecretName?: unknown;
+  bearerSecretRef?: unknown;
   secretHeaders?: unknown;
   googleServiceAccount?: unknown;
   replaceSecretPlaceholders?: unknown;
@@ -284,6 +287,26 @@ function setHeaderValue(
     delete headers[existing];
   }
   headers[existing || name] = value;
+}
+
+function hasHeaderValue(
+  headers: Record<string, string>,
+  name: string,
+): boolean {
+  return Object.keys(headers).some(
+    (key) => key.toLowerCase() === name.toLowerCase(),
+  );
+}
+
+function parseBearerSecretRef(value: unknown): SecretRef {
+  try {
+    return parseSecretRefInput(value, 'bearerSecretRef');
+  } catch {
+    throw new GatewayRequestError(
+      400,
+      '`bearerSecretRef` must be an env/store SecretRef.',
+    );
+  }
 }
 
 function normalizeHttpRequestSecretHeaders(
@@ -974,10 +997,15 @@ export async function handleApiHttpRequest(
   const googleServiceAccount = normalizeGoogleServiceAccountAuth(
     body.googleServiceAccount,
   );
-  if (bearerSecretName && googleServiceAccount) {
+  const authModes = [
+    bearerSecretName ? 'bearerSecretName' : '',
+    body.bearerSecretRef !== undefined ? 'bearerSecretRef' : '',
+    googleServiceAccount ? 'googleServiceAccount' : '',
+  ].filter(Boolean);
+  if (authModes.length > 1) {
     throw new GatewayRequestError(
       400,
-      'Use either bearerSecretName or googleServiceAccount, not both.',
+      'Use only one of bearerSecretName, bearerSecretRef, or googleServiceAccount.',
     );
   }
   if (bearerSecretName) {
@@ -993,6 +1021,31 @@ export async function handleApiHttpRequest(
         'Bearer',
       ),
     );
+  }
+  if (body.bearerSecretRef !== undefined) {
+    const bearerSecretRef = parseBearerSecretRef(body.bearerSecretRef);
+    // SecretRefs cross the F13 rail here: resolveHttpRuleSecret enforces the
+    // host/selector policy and injects the handle into the outbound header.
+    const assignment = await resolveHttpRuleSecret(
+      bearerSecretRef,
+      {
+        ...secretContext,
+        selector: 'Authorization',
+      },
+      'bearerSecretRef',
+      'Authorization',
+      'Bearer',
+    );
+    if (hasHeaderValue(headers, assignment.header)) {
+      logger.warn(
+        {
+          host: secretContext.host,
+          header: assignment.header,
+        },
+        'bearerSecretRef overriding existing outbound HTTP auth header',
+      );
+    }
+    setHeaderValue(headers, assignment.header, assignment.value);
   }
   if (googleServiceAccount) {
     setHeaderValue(

--- a/src/gateway/gateway-http-proxy.ts
+++ b/src/gateway/gateway-http-proxy.ts
@@ -304,7 +304,7 @@ function parseBearerSecretRef(value: unknown): SecretRef {
   } catch {
     throw new GatewayRequestError(
       400,
-      '`bearerSecretRef` must be an env/store SecretRef.',
+      '`bearerSecretRef` must be a store SecretRef.',
     );
   }
 }

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -15,7 +15,6 @@ import { getBrowserProfileDir } from '../browser/browser-login.js';
 import { collectActiveMessageToolChannelKinds } from '../channels/message-tool-advertising.js';
 import {
   ADDITIONAL_MOUNTS,
-  BRAVE_API_KEY,
   BROWSER_PROVIDER,
   CONTAINER_BINDS,
   CONTAINER_CPUS,
@@ -42,18 +41,15 @@ import {
   MAX_CONCURRENT_CONTAINERS,
   MCP_SERVERS,
   onConfigChange,
-  PERPLEXITY_API_KEY,
   PROACTIVE_AUTO_RETRY_BASE_DELAY_MS,
   PROACTIVE_AUTO_RETRY_ENABLED,
   PROACTIVE_AUTO_RETRY_MAX_ATTEMPTS,
   PROACTIVE_AUTO_RETRY_MAX_DELAY_MS,
   PROACTIVE_RALPH_MAX_ITERATIONS,
-  TAVILY_API_KEY,
   WEB_SEARCH_CACHE_TTL_MINUTES,
   WEB_SEARCH_DEFAULT_COUNT,
   WEB_SEARCH_FALLBACK_PROVIDERS,
   WEB_SEARCH_PROVIDER,
-  WEB_SEARCH_SEARXNG_BASE_URL,
   WEB_SEARCH_TAVILY_SEARCH_DEPTH,
 } from '../config/config.js';
 import { GATEWAY_DEBUG_MODEL_RESPONSES_ENV } from '../gateway/gateway-lifecycle.js';
@@ -121,6 +117,7 @@ import {
   stopWarmEntries as stopWarmPoolEntries,
   type WarmRunnerEntry,
 } from './warm-runner-utils.js';
+import { resolveWebSearchRuntimeConfig } from './web-search-runtime-config.js';
 import { computeWorkerSignature } from './worker-signature.js';
 
 function resolveExecutorMaxTokens(params: {
@@ -735,6 +732,7 @@ function getOrSpawnContainer(
     );
   }
   const containerName = `hybridclaw-${ipcSessionId.replace(/[^a-zA-Z0-9-]/g, '-')}-${Date.now()}`;
+  const webSearchRuntime = resolveWebSearchRuntimeConfig(agentId);
 
   const args = [
     'run',
@@ -810,7 +808,7 @@ function getOrSpawnContainer(
     '-e',
     `HYBRIDCLAW_WEB_SEARCH_TAVILY_SEARCH_DEPTH=${WEB_SEARCH_TAVILY_SEARCH_DEPTH}`,
     '-e',
-    `SEARXNG_BASE_URL=${WEB_SEARCH_SEARXNG_BASE_URL}`,
+    `SEARXNG_BASE_URL=${webSearchRuntime.searxngBaseUrl}`,
     '-e',
     'PLAYWRIGHT_BROWSERS_PATH=/ms-playwright',
     '-e',
@@ -1089,6 +1087,7 @@ async function runContainerInner(
   }
 
   const startTime = Date.now();
+  const webSearchRuntime = resolveWebSearchRuntimeConfig(agentId);
 
   const input: ContainerInput = {
     sessionId,
@@ -1147,17 +1146,7 @@ async function runContainerInner(
       overflowRatio: CONTEXT_GUARD_OVERFLOW_RATIO,
       maxRetries: CONTEXT_GUARD_MAX_RETRIES,
     },
-    webSearch: {
-      provider: WEB_SEARCH_PROVIDER,
-      fallbackProviders: [...WEB_SEARCH_FALLBACK_PROVIDERS],
-      defaultCount: WEB_SEARCH_DEFAULT_COUNT,
-      cacheTtlMinutes: WEB_SEARCH_CACHE_TTL_MINUTES,
-      searxngBaseUrl: WEB_SEARCH_SEARXNG_BASE_URL,
-      tavilySearchDepth: WEB_SEARCH_TAVILY_SEARCH_DEPTH,
-      braveApiKey: BRAVE_API_KEY,
-      perplexityApiKey: PERPLEXITY_API_KEY,
-      tavilyApiKey: TAVILY_API_KEY,
-    },
+    webSearch: webSearchRuntime,
     providerCredentials: resolveProviderCredentials(),
     persistBashState: CONTAINER_PERSIST_BASH_STATE,
     escalationTarget,

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -12,7 +12,6 @@ import { resolveGoogleWorkspaceRuntimeEnv } from '../auth/google-auth.js';
 import { collectActiveMessageToolChannelKinds } from '../channels/message-tool-advertising.js';
 import {
   ADDITIONAL_MOUNTS,
-  BRAVE_API_KEY,
   BROWSER_PROVIDER,
   CONTAINER_BINDS,
   CONTAINER_PERSIST_BASH_STATE,
@@ -30,18 +29,15 @@ import {
   MAX_CONCURRENT_CONTAINERS,
   MCP_SERVERS,
   onConfigChange,
-  PERPLEXITY_API_KEY,
   PROACTIVE_AUTO_RETRY_BASE_DELAY_MS,
   PROACTIVE_AUTO_RETRY_ENABLED,
   PROACTIVE_AUTO_RETRY_MAX_ATTEMPTS,
   PROACTIVE_AUTO_RETRY_MAX_DELAY_MS,
   PROACTIVE_RALPH_MAX_ITERATIONS,
-  TAVILY_API_KEY,
   WEB_SEARCH_CACHE_TTL_MINUTES,
   WEB_SEARCH_DEFAULT_COUNT,
   WEB_SEARCH_FALLBACK_PROVIDERS,
   WEB_SEARCH_PROVIDER,
-  WEB_SEARCH_SEARXNG_BASE_URL,
   WEB_SEARCH_TAVILY_SEARCH_DEPTH,
 } from '../config/config.js';
 import { GATEWAY_DEBUG_MODEL_RESPONSES_ENV } from '../gateway/gateway-lifecycle.js';
@@ -110,6 +106,7 @@ import {
   stopWarmEntries as stopWarmPoolEntries,
   type WarmRunnerEntry,
 } from './warm-runner-utils.js';
+import { resolveWebSearchRuntimeConfig } from './web-search-runtime-config.js';
 import { computeWorkerSignature } from './worker-signature.js';
 
 const HOST_CAPACITY_WAIT_MS = 15_000;
@@ -646,6 +643,7 @@ function getOrSpawnHostProcess(
     throw new Error('Host runtime unexpectedly unavailable.');
   }
   const agentBrowserBin = resolveHostAgentBrowserBinary();
+  const webSearchRuntime = resolveWebSearchRuntimeConfig(agentId);
   const env: NodeJS.ProcessEnv = {
     ...buildSanitizedEnv(process.env),
     ...buildHostGatewayRuntimeEnv(),
@@ -667,7 +665,7 @@ function getOrSpawnHostProcess(
       WEB_SEARCH_CACHE_TTL_MINUTES,
     ),
     HYBRIDCLAW_WEB_SEARCH_TAVILY_SEARCH_DEPTH: WEB_SEARCH_TAVILY_SEARCH_DEPTH,
-    SEARXNG_BASE_URL: WEB_SEARCH_SEARXNG_BASE_URL,
+    SEARXNG_BASE_URL: webSearchRuntime.searxngBaseUrl,
     HYBRIDCLAW_AGENT_ID: agentId,
     HYBRIDCLAW_BEHAVIOR_ANOMALY_TRAJECTORY_STORE_DIR:
       ensureBehaviorAnomalyTrajectoryStoreDir(),
@@ -946,6 +944,7 @@ async function runHostProcessInner(
   }
 
   const startTime = Date.now();
+  const webSearchRuntime = resolveWebSearchRuntimeConfig(agentId);
 
   const input: ContainerInput = {
     sessionId,
@@ -1004,17 +1003,7 @@ async function runHostProcessInner(
       overflowRatio: CONTEXT_GUARD_OVERFLOW_RATIO,
       maxRetries: CONTEXT_GUARD_MAX_RETRIES,
     },
-    webSearch: {
-      provider: WEB_SEARCH_PROVIDER,
-      fallbackProviders: [...WEB_SEARCH_FALLBACK_PROVIDERS],
-      defaultCount: WEB_SEARCH_DEFAULT_COUNT,
-      cacheTtlMinutes: WEB_SEARCH_CACHE_TTL_MINUTES,
-      searxngBaseUrl: WEB_SEARCH_SEARXNG_BASE_URL,
-      tavilySearchDepth: WEB_SEARCH_TAVILY_SEARCH_DEPTH,
-      braveApiKey: BRAVE_API_KEY,
-      perplexityApiKey: PERPLEXITY_API_KEY,
-      tavilyApiKey: TAVILY_API_KEY,
-    },
+    webSearch: webSearchRuntime,
     providerCredentials: resolveProviderCredentials(),
     persistBashState: CONTAINER_PERSIST_BASH_STATE,
     escalationTarget,

--- a/src/infra/web-search-runtime-config.ts
+++ b/src/infra/web-search-runtime-config.ts
@@ -1,0 +1,39 @@
+import {
+  BRAVE_API_KEY,
+  PERPLEXITY_API_KEY,
+  TAVILY_API_KEY,
+  WEB_SEARCH_CACHE_TTL_MINUTES,
+  WEB_SEARCH_DEFAULT_COUNT,
+  WEB_SEARCH_FALLBACK_PROVIDERS,
+  WEB_SEARCH_PROVIDER,
+  WEB_SEARCH_SEARXNG_BASE_URL,
+  WEB_SEARCH_SEARXNG_BEARER_TOKEN_REF,
+  WEB_SEARCH_TAVILY_SEARCH_DEPTH,
+} from '../config/config.js';
+import { getRuntimeConfig } from '../config/runtime-config.js';
+import type { WebSearchConfig } from '../types/container.js';
+
+export function resolveWebSearchRuntimeConfig(
+  agentId?: string,
+): WebSearchConfig {
+  const agentWebSearch = getRuntimeConfig().agents.list?.find(
+    (agent) => agent.id === agentId,
+  )?.webSearch;
+  const searxngBaseUrl =
+    agentWebSearch?.searxngBaseUrl || WEB_SEARCH_SEARXNG_BASE_URL;
+  const searxngBearerTokenRef =
+    agentWebSearch?.searxngBearerTokenRef ||
+    WEB_SEARCH_SEARXNG_BEARER_TOKEN_REF;
+  return {
+    provider: WEB_SEARCH_PROVIDER,
+    fallbackProviders: [...WEB_SEARCH_FALLBACK_PROVIDERS],
+    defaultCount: WEB_SEARCH_DEFAULT_COUNT,
+    cacheTtlMinutes: WEB_SEARCH_CACHE_TTL_MINUTES,
+    searxngBaseUrl,
+    ...(searxngBearerTokenRef ? { searxngBearerTokenRef } : {}),
+    tavilySearchDepth: WEB_SEARCH_TAVILY_SEARCH_DEPTH,
+    braveApiKey: BRAVE_API_KEY,
+    perplexityApiKey: PERPLEXITY_API_KEY,
+    tavilyApiKey: TAVILY_API_KEY,
+  };
+}

--- a/src/infra/web-search-runtime-config.ts
+++ b/src/infra/web-search-runtime-config.ts
@@ -1,3 +1,4 @@
+import { getAgentById } from '../agents/agent-registry.js';
 import {
   BRAVE_API_KEY,
   PERPLEXITY_API_KEY,
@@ -10,15 +11,12 @@ import {
   WEB_SEARCH_SEARXNG_BEARER_TOKEN_REF,
   WEB_SEARCH_TAVILY_SEARCH_DEPTH,
 } from '../config/config.js';
-import { getRuntimeConfig } from '../config/runtime-config.js';
 import type { WebSearchConfig } from '../types/container.js';
 
 export function resolveWebSearchRuntimeConfig(
   agentId?: string,
 ): WebSearchConfig {
-  const agentWebSearch = getRuntimeConfig().agents.list?.find(
-    (agent) => agent.id === agentId,
-  )?.webSearch;
+  const agentWebSearch = agentId ? getAgentById(agentId)?.webSearch : undefined;
   const searxngBaseUrl =
     agentWebSearch?.searxngBaseUrl || WEB_SEARCH_SEARXNG_BASE_URL;
   const searxngBearerTokenRef =

--- a/src/security/secret-refs.ts
+++ b/src/security/secret-refs.ts
@@ -95,6 +95,14 @@ export function parseSecretInput(value: unknown): ParsedSecretInput {
   };
 }
 
+export function parseSecretRefInput(value: unknown, path: string): SecretRef {
+  const parsed = parseSecretInput(value);
+  if (parsed.kind === 'ref') return { ...parsed.ref };
+  throw new Error(
+    `${path} must use an env/store secret reference such as \`{ "source": "store", "id": "SECRET_NAME" }\` or \`\${ENV_VAR_NAME}\`.`,
+  );
+}
+
 function describeSecretRef(ref: SecretRef): string {
   return `stored secret ${ref.id}`;
 }

--- a/src/security/secret-refs.ts
+++ b/src/security/secret-refs.ts
@@ -99,7 +99,7 @@ export function parseSecretRefInput(value: unknown, path: string): SecretRef {
   const parsed = parseSecretInput(value);
   if (parsed.kind === 'ref') return { ...parsed.ref };
   throw new Error(
-    `${path} must use an env/store secret reference such as \`{ "source": "store", "id": "SECRET_NAME" }\` or \`\${ENV_VAR_NAME}\`.`,
+    `${path} must use a store SecretRef such as \`{ "source": "store", "id": "SECRET_NAME" }\`.`,
   );
 }
 

--- a/tests/config-reload.integration.test.ts
+++ b/tests/config-reload.integration.test.ts
@@ -88,6 +88,92 @@ describe('config reload integration', () => {
     expect(cfg.ops.healthPort).toBe(7777);
   });
 
+  it('reloadRuntimeConfig accepts SearXNG bearer SecretRefs', () => {
+    writeConfig({
+      web: {
+        search: {
+          searxngBaseUrl: 'https://search.tenant.example',
+          searxngBearerTokenRef: {
+            source: 'store',
+            id: 'SEARXNG_BEARER_TOKEN',
+          },
+        },
+      },
+    });
+
+    const cfg = configMod.reloadRuntimeConfig('test');
+    expect(cfg.web.search.searxngBaseUrl).toBe('https://search.tenant.example');
+    expect(cfg.web.search.searxngBearerTokenRef).toEqual({
+      source: 'store',
+      id: 'SEARXNG_BEARER_TOKEN',
+    });
+  });
+
+  it('reloadRuntimeConfig accepts per-agent SearXNG bearer SecretRefs', () => {
+    writeConfig({
+      agents: {
+        list: [
+          {
+            id: 'research',
+            webSearch: {
+              searxngBaseUrl: 'https://search.research.example',
+              searxngBearerTokenRef: {
+                source: 'store',
+                id: 'RESEARCH_SEARXNG_BEARER_TOKEN',
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const cfg = configMod.reloadRuntimeConfig('test');
+    expect(
+      cfg.agents.list?.find((agent) => agent.id === 'research'),
+    ).toMatchObject({
+      webSearch: {
+        searxngBaseUrl: 'https://search.research.example',
+        searxngBearerTokenRef: {
+          source: 'store',
+          id: 'RESEARCH_SEARXNG_BEARER_TOKEN',
+        },
+      },
+    });
+  });
+
+  it('reloadRuntimeConfig rejects plaintext SearXNG bearer tokens', () => {
+    writeConfig({
+      web: {
+        search: {
+          searxngBearerTokenRef: 'plain-token',
+        },
+      },
+    });
+
+    expect(() => configMod.reloadRuntimeConfig('test')).toThrow(
+      'web.search.searxngBearerTokenRef must use an env/store secret reference',
+    );
+  });
+
+  it('reloadRuntimeConfig rejects plaintext per-agent SearXNG bearer tokens', () => {
+    writeConfig({
+      agents: {
+        list: [
+          {
+            id: 'research',
+            webSearch: {
+              searxngBearerTokenRef: 'plain-token',
+            },
+          },
+        ],
+      },
+    });
+
+    expect(() => configMod.reloadRuntimeConfig('test')).toThrow(
+      'agents.list[].webSearch.searxngBearerTokenRef must use an env/store secret reference',
+    );
+  });
+
   it('reloadRuntimeConfig normalizes supported Camofox launch options', () => {
     writeConfig({
       browser: {

--- a/tests/config-reload.integration.test.ts
+++ b/tests/config-reload.integration.test.ts
@@ -151,7 +151,7 @@ describe('config reload integration', () => {
     });
 
     expect(() => configMod.reloadRuntimeConfig('test')).toThrow(
-      'web.search.searxngBearerTokenRef must use an env/store secret reference',
+      'web.search.searxngBearerTokenRef must use a store SecretRef',
     );
   });
 
@@ -170,7 +170,7 @@ describe('config reload integration', () => {
     });
 
     expect(() => configMod.reloadRuntimeConfig('test')).toThrow(
-      'agents.list[].webSearch.searxngBearerTokenRef must use an env/store secret reference',
+      'agents.list[].webSearch.searxngBearerTokenRef must use a store SecretRef',
     );
   });
 

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -8792,6 +8792,74 @@ describe('gateway HTTP server', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  test('injects bearer SecretRefs for outbound http_request calls', async () => {
+    vi.doMock('node:dns/promises', () => ({
+      lookup: vi.fn(async () => [{ address: '104.21.30.182', family: 4 }]),
+    }));
+    const dataDir = makeTempDataDir();
+    writeRuntimeConfig(dataDir, (config) => {
+      const ops = config.ops as Record<string, unknown>;
+      ops.gatewayApiToken = 'gateway-token';
+    });
+    writeAllowAllSecretPolicy(dataDir);
+    const state = await importFreshHealth({
+      dataDir,
+      gatewayApiToken: 'gateway-token',
+    });
+    const { saveNamedRuntimeSecrets } = await import(
+      '../src/security/runtime-secrets.js'
+    );
+    saveNamedRuntimeSecrets({
+      SEARXNG_BEARER_TOKEN: 'searxng-secret-token',
+    });
+
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            results: [
+              {
+                title: 'Injected',
+                url: 'https://example.com/injected',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/http/request',
+      headers: { authorization: 'Bearer gateway-token' },
+      body: {
+        url: 'https://search.tenant.example/search?q=tenant&format=json',
+        bearerSecretRef: {
+          source: 'store',
+          id: 'SEARXNG_BEARER_TOKEN',
+        },
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(res.statusCode).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer searxng-secret-token',
+        }),
+      }),
+    );
+  });
+
   test('blocks outbound http_request redirects to avoid SSRF bypasses', async () => {
     vi.doMock('node:dns/promises', () => ({
       lookup: vi.fn(async () => [{ address: '104.21.30.182', family: 4 }]),

--- a/tests/host-runner.redaction.test.ts
+++ b/tests/host-runner.redaction.test.ts
@@ -440,6 +440,31 @@ test('HostExecutor exposes the uploaded media cache root to host agent processes
 test('HostExecutor strips ambient credentials from host agent process env', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;
+  fs.mkdirSync(path.join(homeDir, '.hybridclaw'), { recursive: true });
+  fs.writeFileSync(
+    path.join(homeDir, '.hybridclaw', 'config.json'),
+    `${JSON.stringify(
+      {
+        agents: {
+          list: [
+            {
+              id: 'default',
+              webSearch: {
+                searxngBaseUrl: 'https://search.default.example',
+                searxngBearerTokenRef: {
+                  source: 'store',
+                  id: 'DEFAULT_SEARXNG_BEARER_TOKEN',
+                },
+              },
+            },
+          ],
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    'utf-8',
+  );
   vi.stubEnv('OPENAI_API_KEY', 'openai-secret');
   vi.stubEnv('ANTHROPIC_API_KEY', 'anthropic-secret');
   vi.stubEnv('AWS_ACCESS_KEY_ID', 'aws-access-key');
@@ -553,6 +578,11 @@ test('HostExecutor strips ambient credentials from host agent process env', asyn
     String(proc.stdin.write.mock.calls[0]?.[0] || '').trim(),
   ) as { webSearch?: Record<string, unknown> };
   expect(firstInput.webSearch).toMatchObject({
+    searxngBaseUrl: 'https://search.default.example',
+    searxngBearerTokenRef: {
+      source: 'store',
+      id: 'DEFAULT_SEARXNG_BEARER_TOKEN',
+    },
     braveApiKey: 'brave-secret',
     perplexityApiKey: 'perplexity-secret',
     tavilyApiKey: 'tavily-secret',

--- a/tests/unit/web-search.test.ts
+++ b/tests/unit/web-search.test.ts
@@ -467,6 +467,51 @@ describe('SearXNG provider', () => {
     expect(second.cached).toBe(true);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it('partitions SearXNG cache entries by instance identity', async () => {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      const requestUrl = new URL(String(url));
+      return new Response(
+        JSON.stringify({
+          results: [
+            {
+              title: `Result from ${requestUrl.hostname}`,
+              url: `https://${requestUrl.hostname}/result`,
+              content: 'Partitioned snippet',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const first = await searchWeb(
+      { query: 'tenant cache', provider: 'searxng' },
+      makeConfig({
+        provider: 'searxng',
+        searxngBaseUrl: 'https://search-a.example.com',
+      }),
+    );
+    const second = await searchWeb(
+      { query: 'tenant cache', provider: 'searxng' },
+      makeConfig({
+        provider: 'searxng',
+        searxngBaseUrl: 'https://search-b.example.com',
+      }),
+    );
+
+    expect(first.cached).toBeUndefined();
+    expect(second.cached).toBeUndefined();
+    expect(first.results[0]?.title).toBe('Result from search-a.example.com');
+    expect(second.results[0]?.title).toBe('Result from search-b.example.com');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('cache behavior', () => {

--- a/tests/unit/web-search.test.ts
+++ b/tests/unit/web-search.test.ts
@@ -342,6 +342,89 @@ describe('SearXNG provider', () => {
     expect(requestUrl.searchParams.has('results')).toBe(false);
   });
 
+  it('routes SearXNG bearer SecretRefs through the gateway HTTP proxy', async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          status: 200,
+          json: {
+            results: [
+              {
+                title: 'Private SearXNG Result',
+                url: 'https://example.com/private',
+                content: 'Secret-backed snippet',
+              },
+            ],
+          },
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await searchWeb(
+      {
+        query: 'tenant search',
+        provider: 'searxng',
+      },
+      {
+        provider: 'searxng',
+        fallbackProviders: [],
+        defaultCount: 5,
+        cacheTtlMinutes: 5,
+        searxngBaseUrl: 'https://search.tenant.example',
+        searxngBearerTokenRef: {
+          source: 'store',
+          id: 'SEARXNG_BEARER_TOKEN',
+        },
+        tavilySearchDepth: 'advanced',
+      },
+      {
+        gateway: {
+          baseUrl: 'http://127.0.0.1:9090',
+          apiToken: 'gateway-token',
+          sessionId: 'agent:main:channel:web:chat:dm:peer:test',
+        },
+      },
+    );
+
+    expect(result.provider).toBe('searxng');
+    expect(result.results[0]).toMatchObject({
+      title: 'Private SearXNG Result',
+      url: 'https://example.com/private',
+      snippet: 'Secret-backed snippet',
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:9090/api/http/request',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer gateway-token',
+          'Content-Type': 'application/json',
+        }),
+      }),
+    );
+
+    const body = JSON.parse(
+      String((fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.body),
+    ) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      method: 'GET',
+      bearerSecretRef: {
+        source: 'store',
+        id: 'SEARXNG_BEARER_TOKEN',
+      },
+      sessionId: 'agent:main:channel:web:chat:dm:peer:test',
+    });
+    expect(String(body.url)).toContain('https://search.tenant.example/search?');
+  });
+
   it('uses canonical SearXNG category and engine lists for cache keys', async () => {
     process.env.HYBRIDCLAW_WEB_SEARCH_PROVIDER = 'searxng';
     process.env.SEARXNG_BASE_URL = 'https://search.example.com';


### PR DESCRIPTION
## Summary

- Adds global and per-agent SearXNG instance configuration with `searxngBearerTokenRef` SecretRefs.
- Routes authenticated SearXNG searches through the gateway HTTP proxy so bearer tokens are injected outside the LLM/container prompt context.
- Preserves agent-level web search config through runtime config, agent registry, and host/container execution paths.
- Documents global and agent-specific SearXNG bearer configuration.

Closes #858.

## Validation

- `npx vitest run tests/config-reload.integration.test.ts tests/host-runner.redaction.test.ts tests/unit/web-search.test.ts tests/gateway-http-server.test.ts -t "SearXNG bearer|strips ambient credentials|injects bearer SecretRefs"`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`

Note: the targeted Vitest run prints the existing `better-sqlite3` Node ABI warning during runtime-config revision sync under the local Node version, but the tests pass.