### PR TITLE
[codex] Add Firecrawl self-host adapter

### DIFF
--- a/docs/content/guides/skills/integrations.md
+++ b/docs/content/guides/skills/integrations.md
@@ -277,14 +277,24 @@ hybridclaw secret route add https://my.fastbill.com/api/1.0/ FASTBILL_BASIC_AUTH
 ## firecrawl
 
 Scrape pages, crawl public sites, map URLs, and run JSON-schema extraction
-through the managed Firecrawl API.
+through managed or self-hosted Firecrawl.
 
-**Prerequisites** — a managed Firecrawl API key stored in HybridClaw encrypted
-runtime secrets.
+**Prerequisites** — managed mode uses a Firecrawl API key stored in
+HybridClaw encrypted runtime secrets.
 
 ```bash
 hybridclaw secret set FIRECRAWL_API_KEY "<fc-api-key>"
 ```
+
+Self-host mode uses a gateway-reachable Firecrawl origin:
+
+```bash
+export FIRECRAWL_SELF_HOST_BASE_URL="http://firecrawl:3002"
+```
+
+If the self-hosted instance has API authentication enabled, store
+`FIRECRAWL_SELF_HOST_API_KEY` and pass `--self-host-auth` when building the
+request.
 
 > 💡 **Tips & Tricks**
 >

--- a/docs/content/internal/roadmap.md
+++ b/docs/content/internal/roadmap.md
@@ -116,7 +116,7 @@ Use these as issue titles. Keep each issue small enough to ship independently.
 | ID | Area | Todo | Status |
 |----|------|------|--------|
 | R53.1 | Managed adapter | Managed Firecrawl API adapter for `scrape`, `crawl`, `map`, and `extract`, using the F13 `FIRECRAWL_API_KEY` credential rail through gateway `http_request` secret injection | 🔄 #862 / #953 |
-| R53.2 | Self-host adapter | Open-source Firecrawl self-host adapter for Docker-managed deployments | ⬜ To be filed |
+| R53.2 | Self-host adapter | Open-source Firecrawl self-host adapter for Docker-managed deployments | 🔄 #863 |
 | R53.3 | Skill surface | User-invocable `scrape.url` and `crawl.site` surface with bounded defaults and clear output contracts | 🔄 #829 / #953 |
 | R53.4 | Extraction | Structured extraction via JSON Schema prompt and Firecrawl v2 extract lifecycle polling | 🔄 #829 / #953 |
 | R53.5 | Scoped knowledge | R47 ingestion bridge so crawled docs feed agent/skill collections without touching the global corpus | ⬜ To be filed |

--- a/skills/firecrawl/SKILL.md
+++ b/skills/firecrawl/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: firecrawl
-description: "Scrape pages, crawl public sites, map URLs, and run JSON-schema extraction through the managed Firecrawl API."
+description: "Scrape pages, crawl public sites, map URLs, and run JSON-schema extraction through managed or self-hosted Firecrawl."
 user-invocable: true
 requires:
   bins:
@@ -8,16 +8,24 @@ requires:
 credentials:
   - id: firecrawl-api-key
     kind: api_key
-    required: true
+    required: false
     secret_ref:
       source: store
       id: FIRECRAWL_API_KEY
     scope: "api.firecrawl.dev"
     how_to_obtain: "Create a managed Firecrawl API key in the Firecrawl dashboard."
+  - id: firecrawl-self-host-api-key
+    kind: api_key
+    required: false
+    secret_ref:
+      source: store
+      id: FIRECRAWL_SELF_HOST_API_KEY
+    scope: "self-hosted Firecrawl"
+    how_to_obtain: "Set this only when your self-hosted Firecrawl instance has API authentication enabled."
 metadata:
   hybridclaw:
     category: research
-    short_description: "Firecrawl managed scrape, crawl, map, and extraction."
+    short_description: "Firecrawl managed/self-host scrape, crawl, map, and extraction."
     tags:
       - firecrawl
       - scrape
@@ -27,8 +35,11 @@ metadata:
     related_roadmap:
       - R53
       - R53.1
+      - R53.2
     issue: 829
-    sub_issue: 862
+    sub_issues:
+      - 862
+      - 863
     stakes_tiers:
       green:
         - scrape.url
@@ -51,17 +62,36 @@ bypass access controls.
 
 ## Credential Rules
 
-Store the managed Firecrawl API key in HybridClaw encrypted runtime secrets:
+For managed mode, store the Firecrawl API key in HybridClaw encrypted runtime secrets:
 
 ```bash
 hybridclaw secret set FIRECRAWL_API_KEY "<fc-api-key>"
 ```
 
+For a self-hosted Firecrawl instance, set the gateway-reachable base URL in the
+runtime environment or pass it explicitly to the helper:
+
+```bash
+export FIRECRAWL_SELF_HOST_BASE_URL="http://firecrawl:3002"
+```
+
+The helper accepts base URLs with or without `/v2` and normalizes them to the
+v2 API path. If your self-hosted Firecrawl deployment enables API
+authentication, store that token separately:
+
+```bash
+hybridclaw secret set FIRECRAWL_SELF_HOST_API_KEY "<self-host-api-key>"
+```
+
+Use HTTPS for any self-host endpoint outside a trusted private network, especially when `--self-host-auth` is enabled; plain HTTP can expose bearer tokens on untrusted networks.
+
 For live calls, run the colocated helper to build an `http_request` payload and
 pass only the emitted `httpRequest` object to the built-in `http_request` tool.
 The helper sets `bearerSecretName: "FIRECRAWL_API_KEY"` so the gateway injects
-the token server-side. Do not use bash/curl for live Firecrawl calls when
-`http_request` is available, and never ask the user to paste the API key into
+the managed token server-side. In self-host mode, pass `--self-host-auth` only
+when the deployment requires a bearer token; the helper then uses
+`FIRECRAWL_SELF_HOST_API_KEY`. Do not use bash/curl for live Firecrawl calls
+when `http_request` is available, and never ask the user to paste API keys into
 chat.
 
 ## Operations
@@ -75,10 +105,15 @@ chat.
 - `extract.structured`: start a structured extraction job through `POST /v2/extract`.
 - `extract.status`: fetch extraction status and results by job id.
 
-The current managed adapter targets Firecrawl API v2. For single-page JSON
-extraction during scraping, `scrape.url` can include `--schema-json`; for the
-R53.1 `extract` endpoint, use `extract.structured` and then poll
-`extract.status`.
+Both adapters target Firecrawl API v2. The managed adapter sends requests to
+`https://api.firecrawl.dev/v2`; the self-host adapter sends the same operations
+to the configured self-host base URL. Firecrawl self-host deployments may not
+enable every upstream managed feature; `/agent` and `/browser` are intentionally
+outside this skill surface.
+
+For single-page JSON extraction during scraping, `scrape.url` can include
+`--schema-json`; for the R53.1/R53.2 `extract` endpoint, use
+`extract.structured` and then poll `extract.status`.
 
 ## Command Contract
 
@@ -88,13 +123,26 @@ Run the helper with Node:
 node skills/firecrawl/firecrawl.cjs --help
 ```
 
-Build a single-page scrape request:
+Build a managed single-page scrape request:
 
 ```bash
 node skills/firecrawl/firecrawl.cjs --format json http-request scrape.url \
   --url https://example.com/docs \
   --format-name markdown
 ```
+
+Build the same request for self-hosted Firecrawl:
+
+```bash
+node skills/firecrawl/firecrawl.cjs --format json --adapter self-host \
+  --base-url http://firecrawl:3002 \
+  http-request scrape.url \
+  --url https://example.com/docs \
+  --format-name markdown
+```
+
+Add `--self-host-auth` only if the self-hosted deployment requires
+`FIRECRAWL_SELF_HOST_API_KEY`.
 
 Build a site crawl request:
 
@@ -147,11 +195,12 @@ The helper prints a wrapper such as
 ## Policy Defaults
 
 - Target URLs must be `http` or `https` and must not embed credentials.
+- Managed mode rejects custom API base URLs.
+- Self-host mode requires `--base-url` or `FIRECRAWL_SELF_HOST_BASE_URL`; API base URLs must be `http` or `https` and must not embed credentials.
 - `crawl.site` always emits `ignoreRobotsTxt: false`.
 - The helper rejects `--ignore-robots-txt`.
 - Crawl and map limits are explicit and bounded to reduce surprise cost.
-- Use `--zero-data-retention` only when the Firecrawl team has enabled it for
-  the configured account.
+- Use `--zero-data-retention` only when the Firecrawl team has enabled it for the configured account or self-hosted deployment.
 
 ## Error Interpretation
 
@@ -166,3 +215,5 @@ The helper prints a wrapper such as
 - Firecrawl 402, 408, 429, or 5xx responses are upstream billing, timeout, rate
   limit, or service failures. Report the upstream response and retry only when
   the user asks.
+- Self-host errors saying `FIRECRAWL_SELF_HOST_BASE_URL` is missing mean the
+  operator needs to configure the gateway-reachable Firecrawl API origin.

--- a/skills/firecrawl/firecrawl.cjs
+++ b/skills/firecrawl/firecrawl.cjs
@@ -5,6 +5,8 @@ const fs = require('node:fs');
 
 const DEFAULT_BASE_URL = 'https://api.firecrawl.dev/v2';
 const SECRET_NAME = 'FIRECRAWL_API_KEY';
+const SELF_HOST_BASE_URL_ENV = 'FIRECRAWL_SELF_HOST_BASE_URL';
+const SELF_HOST_SECRET_NAME = 'FIRECRAWL_SELF_HOST_API_KEY';
 const SKILL_NAME = 'firecrawl';
 const DEFAULT_CRAWL_LIMIT = 25;
 const DEFAULT_MAP_LIMIT = 500;
@@ -35,7 +37,7 @@ function usage() {
   return `
 Firecrawl skill helper
 
-Build gateway-proxied http_request payloads for the managed Firecrawl API.
+Build gateway-proxied http_request payloads for Firecrawl.
 
 Usage:
   node skills/firecrawl/firecrawl.cjs [--format json] http-request scrape.url --url https://example.com [--format-name markdown]
@@ -48,6 +50,11 @@ Usage:
 
 Global options:
   --format json|pretty       Output JSON or pretty-printed JSON. Default: pretty.
+  --adapter managed|self-host
+                              Firecrawl adapter. Default: managed.
+  --base-url <url>           Self-hosted Firecrawl API base URL. May include or omit /v2.
+                              Defaults to ${SELF_HOST_BASE_URL_ENV} in self-host mode.
+  --self-host-auth           Inject ${SELF_HOST_SECRET_NAME} as a bearer token for self-host mode.
   --timeout-ms <ms>          Gateway request timeout. Default: ${DEFAULT_TIMEOUT_MS}
   --max-response-bytes <n>   Gateway response cap. Default: ${DEFAULT_MAX_RESPONSE_BYTES}
 
@@ -89,6 +96,7 @@ function fail(message) {
 
 function parseArgs(argv) {
   const opts = {
+    adapter: 'managed',
     format: 'pretty',
     timeoutMs: DEFAULT_TIMEOUT_MS,
     maxResponseBytes: DEFAULT_MAX_RESPONSE_BYTES,
@@ -121,6 +129,15 @@ function parseArgs(argv) {
     switch (arg) {
       case '--format':
         opts.format = readValue();
+        break;
+      case '--adapter':
+        opts.adapter = readValue();
+        break;
+      case '--base-url':
+        opts.baseUrl = readValue();
+        break;
+      case '--self-host-auth':
+        opts.selfHostAuth = true;
         break;
       case '--timeout-ms':
         opts.timeoutMs = parseInteger(readValue(), '--timeout-ms', 1, 600_000);
@@ -227,6 +244,19 @@ function parseArgs(argv) {
   return { opts, positional };
 }
 
+function normalizeAdapter(value) {
+  const raw =
+    value === undefined || value === null ? 'managed' : String(value).trim();
+  if (!raw) {
+    fail('--adapter requires a value.');
+  }
+  const normalized = raw.toLowerCase();
+  if (normalized === 'managed' || normalized === 'self-host') {
+    return normalized;
+  }
+  fail('--adapter must be managed or self-host.');
+}
+
 function parseBoolean(value, label) {
   const normalized = String(value).trim().toLowerCase();
   if (normalized === 'true') return true;
@@ -278,6 +308,34 @@ function normalizeJobId(value, label = '--id') {
     fail(`${label} must contain only letters, numbers, "_" or "-".`);
   }
   return encodeURIComponent(normalized);
+}
+
+function normalizeSelfHostBaseUrl(value) {
+  const normalized = String(value || '').trim();
+  if (!normalized) {
+    fail(`Self-host mode requires --base-url or ${SELF_HOST_BASE_URL_ENV}.`);
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(normalized);
+  } catch {
+    fail('--base-url must be a valid http(s) URL.');
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    fail('--base-url must use http or https.');
+  }
+  if (parsed.username || parsed.password) {
+    fail('--base-url must not contain embedded credentials.');
+  }
+  if (parsed.search || parsed.hash) {
+    fail('--base-url must not include query strings or fragments.');
+  }
+
+  const withoutTrailingSlash = parsed.toString().replace(/\/+$/u, '');
+  return withoutTrailingSlash.endsWith('/v2')
+    ? withoutTrailingSlash
+    : `${withoutTrailingSlash}/v2`;
 }
 
 function parseJsonObject(value, label) {
@@ -337,7 +395,21 @@ function scrapeOptions(opts, schema, defaults = ['markdown']) {
 }
 
 function buildRequest(command, opts) {
-  const baseUrl = DEFAULT_BASE_URL;
+  const adapter = normalizeAdapter(opts.adapter);
+  if (adapter === 'managed') {
+    if (opts.baseUrl) {
+      fail('--base-url is only supported with --adapter self-host.');
+    }
+    if (opts.selfHostAuth) {
+      fail('--self-host-auth is only supported with --adapter self-host.');
+    }
+  }
+  const baseUrl =
+    adapter === 'self-host'
+      ? normalizeSelfHostBaseUrl(
+          opts.baseUrl || process.env[SELF_HOST_BASE_URL_ENV],
+        )
+      : DEFAULT_BASE_URL;
   const schema = readSchema(opts);
   const operation = normalizeCommand(command);
   let path;
@@ -436,23 +508,34 @@ function buildRequest(command, opts) {
 
   const result = {
     command: 'http-request',
-    adapter: 'firecrawl-managed',
+    adapter:
+      adapter === 'self-host' ? 'firecrawl-self-host' : 'firecrawl-managed',
     operation,
     httpRequest: {
       url: `${baseUrl}${path}`,
       method,
-      bearerSecretName: SECRET_NAME,
       skillName: SKILL_NAME,
       timeoutMs: opts.timeoutMs,
       maxResponseBytes: opts.maxResponseBytes,
     },
   };
+  if (adapter === 'managed') {
+    result.httpRequest.bearerSecretName = SECRET_NAME;
+  } else if (opts.selfHostAuth) {
+    result.httpRequest.bearerSecretName = SELF_HOST_SECRET_NAME;
+  } else if (String(process.env[SELF_HOST_SECRET_NAME] || '').trim()) {
+    process.stderr.write(
+      `Warning: ${SELF_HOST_SECRET_NAME} is set but --self-host-auth was not passed; the secret will not be injected.\n`,
+    );
+  }
   if (json !== undefined) {
     result.httpRequest.json = json;
-    result.costMeasurement = {
-      system: 'UsageTotals',
-      subLimitKey: 'firecrawl',
-    };
+    if (adapter === 'managed') {
+      result.costMeasurement = {
+        system: 'UsageTotals',
+        subLimitKey: 'firecrawl',
+      };
+    }
   }
   return result;
 }

--- a/tests/firecrawl-skill.test.ts
+++ b/tests/firecrawl-skill.test.ts
@@ -14,9 +14,13 @@ const helperPath = path.join(
 );
 const skillPath = path.join(process.cwd(), 'skills', 'firecrawl', 'SKILL.md');
 
-function runHelper(args: string[]) {
+function runHelper(args: string[], env: NodeJS.ProcessEnv = {}) {
   return spawnSync('node', [helperPath, ...args], {
     encoding: 'utf-8',
+    env: {
+      ...process.env,
+      ...env,
+    },
   });
 }
 
@@ -26,23 +30,38 @@ test('Firecrawl skill manifest declares managed credential and roadmap metadata'
     name: 'firecrawl',
   });
 
-  expect(manifest.credentials).toEqual([
-    expect.objectContaining({
-      id: 'firecrawl-api-key',
-      kind: 'api_key',
-      required: true,
-      secretRef: {
-        source: 'store',
-        id: 'FIRECRAWL_API_KEY',
-      },
-      scope: 'api.firecrawl.dev',
-    }),
-  ]);
+  expect(manifest.credentials).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        id: 'firecrawl-api-key',
+        kind: 'api_key',
+        required: false,
+        secretRef: {
+          source: 'store',
+          id: 'FIRECRAWL_API_KEY',
+        },
+        scope: 'api.firecrawl.dev',
+      }),
+      expect.objectContaining({
+        id: 'firecrawl-self-host-api-key',
+        kind: 'api_key',
+        required: false,
+        secretRef: {
+          source: 'store',
+          id: 'FIRECRAWL_SELF_HOST_API_KEY',
+        },
+        scope: 'self-hosted Firecrawl',
+      }),
+    ]),
+  );
   expect(skill).toContain('related_roadmap:');
   expect(skill).toContain('- R53');
   expect(skill).toContain('- R53.1');
+  expect(skill).toContain('- R53.2');
   expect(skill).toContain('issue: 829');
-  expect(skill).toContain('sub_issue: 862');
+  expect(skill).toContain('sub_issues:');
+  expect(skill).toContain('- 862');
+  expect(skill).toContain('- 863');
   expect(skill).toContain('scrape.url');
   expect(skill).toContain('crawl.site');
   expect(skill).toContain('crawl.status');
@@ -55,6 +74,7 @@ test('Firecrawl helper --help exits cleanly', () => {
 
   expect(result.status).toBe(0);
   expect(result.stdout).toContain('Firecrawl skill helper');
+  expect(result.stdout).toContain('--adapter managed|self-host');
   expect(result.stdout).toContain('scrape.url');
   expect(result.stdout).toContain('crawl.site');
   expect(result.stdout).toContain('crawl.status');
@@ -99,6 +119,221 @@ test('Firecrawl helper emits gateway-proxied scrape requests without secrets', (
     subLimitKey: 'firecrawl',
   });
   expect(result.stdout).not.toContain('fc-');
+});
+
+test('Firecrawl helper emits self-host requests with the same operation surface', () => {
+  const result = runHelper([
+    '--format',
+    'json',
+    '--adapter',
+    'self-host',
+    '--base-url',
+    'http://firecrawl:3002',
+    '--self-host-auth',
+    'http-request',
+    'scrape.url',
+    '--url',
+    'https://example.com/docs',
+    '--format-name',
+    'markdown',
+  ]);
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload).toMatchObject({
+    command: 'http-request',
+    adapter: 'firecrawl-self-host',
+    operation: 'scrape.url',
+    httpRequest: {
+      url: 'http://firecrawl:3002/v2/scrape',
+      method: 'POST',
+      bearerSecretName: 'FIRECRAWL_SELF_HOST_API_KEY',
+      skillName: 'firecrawl',
+      json: {
+        url: 'https://example.com/docs',
+        formats: ['markdown'],
+        onlyMainContent: true,
+      },
+    },
+  });
+  expect(payload).not.toHaveProperty('costMeasurement');
+  expect(result.stdout).not.toContain('fc-');
+});
+
+test('Firecrawl helper reads the self-host base URL from the environment', () => {
+  const result = runHelper(
+    [
+      '--format',
+      'json',
+      '--adapter',
+      'self-host',
+      'http-request',
+      'map.site',
+      '--url',
+      'https://example.com',
+    ],
+    {
+      FIRECRAWL_SELF_HOST_BASE_URL: 'https://firecrawl.example/internal',
+    },
+  );
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.httpRequest).toMatchObject({
+    url: 'https://firecrawl.example/internal/v2/map',
+    method: 'POST',
+  });
+  expect(payload.httpRequest).not.toHaveProperty('bearerSecretName');
+  expect(payload).not.toHaveProperty('costMeasurement');
+});
+
+test('Firecrawl helper warns when self-host auth secret is set but not enabled', () => {
+  const result = runHelper(
+    [
+      '--format',
+      'json',
+      '--adapter',
+      'self-host',
+      '--base-url',
+      'http://firecrawl:3002',
+      'http-request',
+      'scrape.url',
+      '--url',
+      'https://example.com/docs',
+    ],
+    {
+      FIRECRAWL_SELF_HOST_API_KEY: 'test-key',
+    },
+  );
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.httpRequest).not.toHaveProperty('bearerSecretName');
+  expect(result.stderr).toContain(
+    'Warning: FIRECRAWL_SELF_HOST_API_KEY is set but --self-host-auth was not passed; the secret will not be injected.',
+  );
+  expect(result.stdout).not.toContain('test-key');
+});
+
+test('Firecrawl helper keeps crawl and extract interfaces available in self-host mode', () => {
+  const crawl = runHelper([
+    '--format',
+    'json',
+    '--adapter',
+    'self-host',
+    '--base-url',
+    'http://firecrawl:3002/v2',
+    'http-request',
+    'crawl.site',
+    '--url',
+    'https://example.com/docs',
+    '--limit',
+    '10',
+  ]);
+  const extract = runHelper([
+    '--format',
+    'json',
+    '--adapter',
+    'self-host',
+    '--base-url',
+    'http://firecrawl:3002',
+    'http-request',
+    'extract.structured',
+    '--url',
+    'https://example.com/pricing/*',
+    '--schema-json',
+    '{"type":"object","properties":{"plans":{"type":"array"}}}',
+  ]);
+  const crawlStatus = runHelper([
+    '--format',
+    'json',
+    '--adapter',
+    'self-host',
+    '--base-url',
+    'http://firecrawl:3002',
+    'http-request',
+    'crawl.status',
+    '--id',
+    'crawl_123',
+  ]);
+  const crawlCancel = runHelper([
+    '--format',
+    'json',
+    '--adapter',
+    'self-host',
+    '--base-url',
+    'http://firecrawl:3002',
+    'http-request',
+    'crawl.cancel',
+    '--id',
+    'crawl_123',
+  ]);
+  const activeCrawls = runHelper([
+    '--format',
+    'json',
+    '--adapter',
+    'self-host',
+    '--base-url',
+    'http://firecrawl:3002',
+    'http-request',
+    'crawl.active',
+  ]);
+  const extractStatus = runHelper([
+    '--format',
+    'json',
+    '--adapter',
+    'self-host',
+    '--base-url',
+    'http://firecrawl:3002',
+    'http-request',
+    'extract.status',
+    '--id',
+    'extract_123',
+  ]);
+
+  expect(crawl.status).toBe(0);
+  expect(JSON.parse(crawl.stdout).httpRequest).toMatchObject({
+    url: 'http://firecrawl:3002/v2/crawl',
+    method: 'POST',
+    json: {
+      url: 'https://example.com/docs',
+      limit: 10,
+      ignoreRobotsTxt: false,
+      scrapeOptions: {
+        formats: ['markdown'],
+        onlyMainContent: true,
+      },
+    },
+  });
+  expect(extract.status).toBe(0);
+  expect(JSON.parse(extract.stdout).httpRequest).toMatchObject({
+    url: 'http://firecrawl:3002/v2/extract',
+    method: 'POST',
+    json: {
+      urls: ['https://example.com/pricing/*'],
+      ignoreInvalidURLs: true,
+    },
+  });
+  expect(crawlStatus.status).toBe(0);
+  expect(JSON.parse(crawlStatus.stdout).httpRequest).toMatchObject({
+    url: 'http://firecrawl:3002/v2/crawl/crawl_123',
+    method: 'GET',
+  });
+  expect(crawlCancel.status).toBe(0);
+  expect(JSON.parse(crawlCancel.stdout).httpRequest).toMatchObject({
+    url: 'http://firecrawl:3002/v2/crawl/crawl_123',
+    method: 'DELETE',
+  });
+  expect(activeCrawls.status).toBe(0);
+  expect(JSON.parse(activeCrawls.stdout).httpRequest).toMatchObject({
+    url: 'http://firecrawl:3002/v2/crawl/active',
+    method: 'GET',
+  });
+  expect(extractStatus.status).toBe(0);
+  expect(JSON.parse(extractStatus.stdout).httpRequest).toMatchObject({
+    url: 'http://firecrawl:3002/v2/extract/extract_123',
+    method: 'GET',
+  });
 });
 
 test('Firecrawl helper normalizes short operation aliases', () => {
@@ -319,6 +554,35 @@ test('Firecrawl helper rejects unsafe or oversized crawl requests', () => {
     '--url',
     'https://example.com',
   ]);
+  const selfHostMissingBaseUrl = runHelper(
+    [
+      '--adapter',
+      'self-host',
+      'http-request',
+      'scrape.url',
+      '--url',
+      'https://example.com',
+    ],
+    { FIRECRAWL_SELF_HOST_BASE_URL: '' },
+  );
+  const credentialBaseUrl = runHelper([
+    '--adapter',
+    'self-host',
+    '--base-url',
+    'https://user:pass@firecrawl.example',
+    'http-request',
+    'scrape.url',
+    '--url',
+    'https://example.com',
+  ]);
+  const emptyAdapter = runHelper([
+    '--adapter',
+    '',
+    'http-request',
+    'scrape.url',
+    '--url',
+    'https://example.com',
+  ]);
 
   expect(ignoreRobots.status).not.toBe(0);
   expect(ignoreRobots.stderr).toContain('--ignore-robots-txt');
@@ -333,5 +597,17 @@ test('Firecrawl helper rejects unsafe or oversized crawl requests', () => {
     '--url must not contain embedded credentials.',
   );
   expect(customBaseUrl.status).not.toBe(0);
-  expect(customBaseUrl.stderr).toContain('Unknown option: --base-url');
+  expect(customBaseUrl.stderr).toContain(
+    '--base-url is only supported with --adapter self-host.',
+  );
+  expect(selfHostMissingBaseUrl.status).not.toBe(0);
+  expect(selfHostMissingBaseUrl.stderr).toContain(
+    'Self-host mode requires --base-url or FIRECRAWL_SELF_HOST_BASE_URL.',
+  );
+  expect(credentialBaseUrl.status).not.toBe(0);
+  expect(credentialBaseUrl.stderr).toContain(
+    '--base-url must not contain embedded credentials.',
+  );
+  expect(emptyAdapter.status).not.toBe(0);
+  expect(emptyAdapter.stderr).toContain('--adapter requires a value.');
 });


### PR DESCRIPTION
## Summary

Implements the R53.2 self-host Firecrawl adapter for sovereign-deployment tenants.

- Add `--adapter self-host` support to the bundled Firecrawl helper while keeping managed mode as the default.
- Route self-host requests to `--base-url` or `FIRECRAWL_SELF_HOST_BASE_URL`, normalizing base URLs with or without `/v2`.
- Support optional self-host bearer auth through `--self-host-auth` and `FIRECRAWL_SELF_HOST_API_KEY`.
- Preserve the same operation surface as R53.1: scrape, crawl, crawl lifecycle, map, extract, and extract status.
- Document managed vs self-host setup and mark R53.2 against #863 in the roadmap.

Closes #863.
Refs #829.

## Validation

- `/Users/bkoehler/src/hybridclaw/node_modules/.bin/vitest run tests/firecrawl-skill.test.ts`
- `npx biome check skills/firecrawl tests/firecrawl-skill.test.ts docs/content/guides/skills/integrations.md docs/content/internal/roadmap.md`
- `git diff --check`

## Notes

No live Docker/self-host Firecrawl smoke test was run in this session.