### PR TITLE
[codex] Add video.from-script skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,8 @@ Once the gateway is running, open HybridClaw locally:
   creation.
 - Native media tools generate images and videos through configured providers,
   persist the resulting artifacts, and expose the same capability through the
-  bundled `image-generation` and `video-generation` skills.
+  bundled `image-generation`, `video-generation`, and `video.from-script`
+  skills.
 - Browser automation can use local persistent Playwright profiles, Camofox
   profiles, or Browser Use Cloud sessions with encrypted `BROWSER_USE_API_KEY`
   storage, usage metering, shared navigation guards, and SecretRef-gated

--- a/docs/content/guides/bundled-skills.md
+++ b/docs/content/guides/bundled-skills.md
@@ -12,8 +12,7 @@ HybridClaw ships with 50+ bundled skills. A few notable categories:
   `office-workflows`
 - planning and engineering: `project-manager`, `feature-planning`,
   `code-review`, `code-simplification`, `gh-issues`, `warehouse-sql`
-- visual explainers, image, and video: `manim-video`, `excalidraw`,
-  `image-generation`, `video-generation`
+- visual explainers, image, and video: `manim-video`, `excalidraw`, `image-generation`, `video-generation`, `video.from-script`
 - platform integrations: `github-pr-workflow`, `notion`, `trello`, `stripe`,
   `download-platform-invoices`, `wordpress`, `gog`, `google-workspace`,
   `google-ads`, `airtable`, `fastbill`, `firecrawl`, `heygen`, `discord`

--- a/skills/heygen/client.cjs
+++ b/skills/heygen/client.cjs
@@ -102,6 +102,8 @@ function normalizeHeyGenPayload(wrapper) {
     json,
     videoId: firstString(record.video_id, record.id),
     videoTranslateId: firstString(record.video_translate_id, record.id),
+    videoUrl: firstString(record.video_url, record.videoUrl, record.url),
+    thumbnailUrl: firstString(record.thumbnail_url, record.thumbnailUrl),
     statusValue: firstString(record.status, record.state),
   };
 }

--- a/skills/heygen/heygen.cjs
+++ b/skills/heygen/heygen.cjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 'use strict';
 
-const net = require('node:net');
 const {
   DEFAULT_TIMEOUT_MS,
   INSUFFICIENT_CREDITS_RE,
+  isPrivateHostname,
   isRateLimitBody,
   parseRetryAfterMs,
 } = require('./lib/common.cjs');
@@ -46,11 +46,14 @@ function printJson(payload) {
   process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
 }
 
-function popFlag(args, name, fallback = undefined) {
+function popFlag(args, name, fallback = undefined, options = {}) {
   const index = args.indexOf(name);
   if (index === -1) return fallback;
   const value = args[index + 1];
-  if (value === undefined || value.startsWith('--')) {
+  if (
+    value === undefined ||
+    (!options.allowDashValue && value.startsWith('--'))
+  ) {
     die(`${name} requires a value.`);
   }
   args.splice(index, 2);
@@ -132,65 +135,7 @@ function isPrivateUrl(rawUrl) {
   } catch {
     return false;
   }
-  const hostname = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, '');
-  if (hostname === 'localhost' || hostname === '::1') return true;
-
-  if (net.isIP(hostname) === 6) {
-    if (
-      hostname.startsWith('fe80:') ||
-      hostname.startsWith('fc') ||
-      hostname.startsWith('fd')
-    ) {
-      return true;
-    }
-    const mapped = ipv4OctetsFromMappedIpv6(hostname);
-    return mapped ? isPrivateIpv4Octets(mapped) : false;
-  }
-
-  const octets = parseIpv4Octets(hostname);
-  if (!octets) {
-    return false;
-  }
-  return isPrivateIpv4Octets(octets);
-}
-
-function parseIpv4Octets(hostname) {
-  const parts = hostname.split('.');
-  if (parts.length !== 4 || parts.some((part) => !/^\d{1,3}$/.test(part))) {
-    return null;
-  }
-  const octets = parts.map((part) => Number.parseInt(part, 10));
-  if (octets.some((octet) => octet < 0 || octet > 255)) {
-    return null;
-  }
-  return octets;
-}
-
-function ipv4OctetsFromMappedIpv6(hostname) {
-  const dotted = hostname.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/);
-  if (dotted) {
-    return parseIpv4Octets(dotted[1]);
-  }
-  const packed = hostname.match(
-    /^::ffff:(?:0:)?([0-9a-f]{1,4}):([0-9a-f]{1,4})$/,
-  );
-  if (!packed) {
-    return null;
-  }
-  const high = Number.parseInt(packed[1], 16);
-  const low = Number.parseInt(packed[2], 16);
-  return [high >> 8, high & 255, low >> 8, low & 255];
-}
-
-function isPrivateIpv4Octets(octets) {
-  const [first, second] = octets;
-  return (
-    first === 10 ||
-    first === 127 ||
-    (first === 169 && second === 254) ||
-    (first === 172 && second >= 16 && second <= 31) ||
-    (first === 192 && second === 168)
-  );
+  return isPrivateHostname(parsed.hostname);
 }
 
 function validatePublicUrl(rawUrl, label) {
@@ -294,7 +239,9 @@ function buildGenerateVideo(args) {
       'Provide exactly one of --avatar-id, --image-url, or --image-asset-id.',
     );
   }
-  const script = popFlag(args, '--script');
+  const script = popFlag(args, '--script', undefined, {
+    allowDashValue: true,
+  });
   const voiceId = popFlag(args, '--voice-id');
   const audioUrl = popFlag(args, '--audio-url');
   const audioAssetId = popFlag(args, '--audio-asset-id');

--- a/skills/heygen/lib/common.cjs
+++ b/skills/heygen/lib/common.cjs
@@ -1,5 +1,7 @@
 'use strict';
 
+const net = require('node:net');
+
 const DEFAULT_TIMEOUT_MS = 60_000;
 const RATE_LIMIT_BODY_RE =
   /rate.?limit|too many requests|quota exceeded|exceed rate limit|daily rate limit/i;
@@ -20,10 +22,75 @@ function isRateLimitBody(body) {
   return RATE_LIMIT_BODY_RE.test(String(body || ''));
 }
 
+function parseIpv4Octets(hostname) {
+  const parts = hostname.split('.');
+  if (parts.length !== 4 || parts.some((part) => !/^\d{1,3}$/.test(part))) {
+    return null;
+  }
+  const octets = parts.map((part) => Number.parseInt(part, 10));
+  if (octets.some((octet) => octet < 0 || octet > 255)) {
+    return null;
+  }
+  return octets;
+}
+
+function isPrivateIpv4Octets(octets) {
+  const [first, second] = octets;
+  return (
+    first === 10 ||
+    first === 127 ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168)
+  );
+}
+
+function ipv4OctetsFromMappedIpv6(hostname) {
+  const dotted = hostname.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/);
+  if (dotted) {
+    return parseIpv4Octets(dotted[1]);
+  }
+  const packed = hostname.match(
+    /^::ffff:(?:0:)?([0-9a-f]{1,4}):([0-9a-f]{1,4})$/,
+  );
+  if (!packed) {
+    return null;
+  }
+  const high = Number.parseInt(packed[1], 16);
+  const low = Number.parseInt(packed[2], 16);
+  return [high >> 8, high & 255, low >> 8, low & 255];
+}
+
+function isPrivateHostname(hostname) {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (normalized === 'localhost' || normalized.endsWith('.localhost')) {
+    return true;
+  }
+  if (net.isIP(normalized) === 4) {
+    const octets = parseIpv4Octets(normalized);
+    return octets ? isPrivateIpv4Octets(octets) : false;
+  }
+  if (net.isIP(normalized) === 6) {
+    const mapped = ipv4OctetsFromMappedIpv6(normalized);
+    if (mapped) return isPrivateIpv4Octets(mapped);
+    return (
+      normalized === '::1' ||
+      normalized.startsWith('fe80:') ||
+      normalized.startsWith('fc') ||
+      normalized.startsWith('fd')
+    );
+  }
+  return false;
+}
+
 module.exports = {
   DEFAULT_TIMEOUT_MS,
   INSUFFICIENT_CREDITS_RE,
   RATE_LIMIT_BODY_RE,
+  ipv4OctetsFromMappedIpv6,
+  isPrivateHostname,
+  isPrivateIpv4Octets,
   isRateLimitBody,
+  parseIpv4Octets,
   parseRetryAfterMs,
 };

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -209,7 +209,8 @@ Avoid:
 Before calling a skill complete, verify:
 
 1. Frontmatter `description` clearly states what it does and when to use it.
-2. Skill name is lowercase hyphen-case and <= 64 characters.
+2. Skill name uses lowercase skill-id characters (`a-z`, `0-9`, `-`, `.`) and
+   is <= 64 characters.
 3. `SKILL.md` contains concise workflow guidance and links to deep docs.
 4. Scripts execute successfully on representative inputs.
 5. `quick_validate.py` passes.

--- a/skills/skill-creator/references/output-patterns.md
+++ b/skills/skill-creator/references/output-patterns.md
@@ -8,7 +8,7 @@ Use before implementation.
 
 ```markdown
 Skill design:
-- Name: <hyphen-case>
+- Name: <lowercase-skill-id>
 - Trigger description: <frontmatter description draft>
 - Scope: <in-scope tasks>
 - Exclusions: <out-of-scope tasks>

--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -142,12 +142,19 @@ def validate_frontmatter(frontmatter: Dict[str, Any]) -> Tuple[List[str], List[s
         errors.append("Missing or invalid frontmatter field: name")
     else:
         normalized = name.strip()
-        if not re.match(r"^[a-z0-9-]+$", normalized):
+        if not re.match(r"^[a-z0-9.-]+$", normalized):
             errors.append(
-                f"Skill name '{normalized}' must be lowercase hyphen-case (a-z, 0-9, -)"
+                f"Skill name '{normalized}' must use lowercase skill-id characters (a-z, 0-9, -, .)"
             )
-        if normalized.startswith("-") or normalized.endswith("-") or "--" in normalized:
-            errors.append(f"Skill name '{normalized}' cannot start/end with '-' or include '--'")
+        if (
+            normalized.startswith(("-", "."))
+            or normalized.endswith(("-", "."))
+            or "--" in normalized
+            or ".." in normalized
+        ):
+            errors.append(
+                f"Skill name '{normalized}' cannot start/end with '-' or '.', or include '--' or '..'"
+            )
         if len(normalized) > MAX_SKILL_NAME_LENGTH:
             errors.append(
                 f"Skill name '{normalized}' is too long ({len(normalized)} > {MAX_SKILL_NAME_LENGTH})"

--- a/skills/video.from-script/SKILL.md
+++ b/skills/video.from-script/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: video.from-script
+description: "Render approved avatar + voice + script briefs into HeyGen MP4 videos with async job polling."
+user-invocable: true
+requires:
+  bins:
+    - node
+credentials:
+  - id: heygen-api-key
+    kind: api_key
+    required: true
+    secret_ref:
+      source: store
+      id: HEYGEN_API_KEY
+    scope: HeyGen Direct API avatar video generation.
+    how_to_obtain: Create or regenerate the API token from HeyGen account settings, then store it with `hybridclaw secret set HEYGEN_API_KEY "<api-key>"`.
+metadata:
+  hybridclaw:
+    category: media
+    short_description: "Async HeyGen avatar videos from script text."
+    tags:
+      - video
+      - avatar-video
+      - heygen
+      - from-script
+      - mp4
+    related_roadmap:
+      - R55
+      - R55.2
+    issue: 875
+    depends_on:
+      - R55.1
+      - heygen
+    stakes_tiers:
+      green:
+        - plan
+        - status
+      amber:
+        - start
+        - render
+      red:
+        - public-auto-publish
+    escalation:
+      writes: confirm-each
+      route: f8
+    cost_measurement:
+      system: UsageTotals
+      sub_limit_contract: R5.4
+      sub_limit_key: heygen
+---
+
+# Video From Script
+
+Use this skill when the user wants an avatar video from three concrete inputs:
+an avatar or image source, a voice id, and approved script text. The backing
+provider is HeyGen Direct API via the bundled `heygen` adapter.
+
+## Scope
+
+- plan avatar video generation from script text
+- start a HeyGen video generation job and return the job id immediately
+- poll job status until it is `completed`, `failed`, or still rendering
+- download the completed MP4 into `.generated-videos`
+- keep HeyGen API keys behind gateway secret injection
+
+Template videos, free-form prompt-to-video, public publishing, social posting,
+and custom avatar training are outside this skill. Use `video-generation` for
+native Sora/Veo prompt videos and `heygen` for lower-level HeyGen API work.
+Polling is the completion transport implemented for R55.2; webhook callbacks
+belong in a provider/gateway adapter if that transport is added later.
+
+## Default Workflow
+
+1. Confirm the user has provided an avatar source, voice id, and final script.
+2. Run public-facing marketing, sales, training, or onboarding copy through
+   `/brand-voice` before starting a credit-consuming render.
+3. Use `plan` if the request is vague or needs an explicit risk summary.
+4. Use `start` after the operator grants the exact credit-consuming render.
+   Return the `jobId` to the user because HeyGen renders asynchronously.
+5. Use `status --job-id <id>` to poll conservatively. Add `--download` only
+   after the status is complete or when the user asks you to fetch the MP4.
+6. Use `render --wait` only when the user explicitly wants the agent to wait
+   for the final MP4 in the same run.
+
+Do not run parallel render bursts. HeyGen quotas are tight and account/plan
+dependent.
+
+## Command Contract
+
+Run the helper with Node:
+
+```bash
+node skills/video.from-script/video-from-script.cjs --help
+```
+
+Plan without contacting HeyGen:
+
+```bash
+node skills/video.from-script/video-from-script.cjs plan "Create a product update avatar video"
+```
+
+Start an async render after explicit operator grant:
+
+```bash
+node skills/video.from-script/video-from-script.cjs start \
+  --avatar-id avatar_123 \
+  --voice-id voice_123 \
+  --script "Approved script text" \
+  --title "Product update" \
+  --resolution 1080p \
+  --aspect-ratio 16:9 \
+  --operator-grant
+```
+
+Poll and download the completed MP4:
+
+```bash
+node skills/video.from-script/video-from-script.cjs status \
+  --job-id video_123 \
+  --download
+```
+
+Wait for completion in one command only when that behavior is requested:
+
+```bash
+node skills/video.from-script/video-from-script.cjs render --wait \
+  --avatar-id avatar_123 \
+  --voice-id voice_123 \
+  --script "Approved script text" \
+  --operator-grant
+```
+
+## Working Rules
+
+- Never print, request, or accept a raw HeyGen API key.
+- Keep script text at or below 5000 characters.
+- Provide exactly one avatar source: `--avatar-id`, `--image-url`, or
+  `--image-asset-id`.
+- Require `--operator-grant` for `start` and `render`.
+- Prefer `start` + `status` over a long blocking render.
+- Treat `pending`, `waiting`, and `processing` as normal async states.
+- Treat `failed` as terminal and include the provider error when available.
+- Download only completed provider URLs, and save MP4 artifacts under
+  `.generated-videos`.
+- Public auto-publish or share-link distribution is red tier and requires a
+  separate escalation.
+
+## Validation
+
+Run:
+
+```bash
+python3 skills/skill-creator/scripts/quick_validate.py skills/video.from-script
+node skills/video.from-script/video-from-script.cjs --help
+node skills/video.from-script/video-from-script.cjs eval-scenarios
+```

--- a/skills/video.from-script/video-from-script.cjs
+++ b/skills/video.from-script/video-from-script.cjs
@@ -1,0 +1,638 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const heygen = require('../heygen/heygen.cjs');
+const {
+  HeyGenApiError,
+  executeHeyGenGatewayRequest,
+} = require('../heygen/client.cjs');
+const { isPrivateHostname } = require('../heygen/lib/common.cjs');
+
+const DEFAULT_POLL_INTERVAL_MS = 10_000;
+const MIN_POLL_INTERVAL_MS = 1_000;
+const DEFAULT_MAX_WAIT_MS = 10 * 60_000;
+const DEFAULT_MAX_DOWNLOAD_BYTES = 250 * 1024 * 1024;
+const OUTPUT_DIR = '.generated-videos';
+const TERMINAL_SUCCESS = new Set(['completed', 'complete', 'done', 'success']);
+const TERMINAL_FAILURE = new Set(['failed', 'error', 'canceled', 'cancelled']);
+const IN_PROGRESS = new Set(['pending', 'waiting', 'processing', 'queued']);
+
+function die(message, code = 2) {
+  process.stderr.write(`${message}\n`);
+  process.exit(code);
+}
+
+function printJson(payload) {
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function popFlag(args, name, fallback = undefined, options = {}) {
+  const index = args.indexOf(name);
+  if (index === -1) return fallback;
+  const value = args[index + 1];
+  if (
+    value === undefined ||
+    (!options.allowDashValue && value.startsWith('--'))
+  ) {
+    die(`${name} requires a value.`);
+  }
+  args.splice(index, 2);
+  return value;
+}
+
+function popBoolean(args, name) {
+  const index = args.indexOf(name);
+  if (index === -1) return false;
+  args.splice(index, 1);
+  return true;
+}
+
+function required(value, label) {
+  const normalized = String(value || '').trim();
+  if (!normalized) die(`${label} is required.`);
+  return normalized;
+}
+
+function parseNonNegativeInteger(raw, label, fallback) {
+  if (raw === undefined || raw === '') return fallback;
+  if (!/^\d+$/.test(String(raw)))
+    die(`${label} must be a non-negative integer.`);
+  return Number.parseInt(raw, 10);
+}
+
+function parseIntegerWithMinimum(raw, label, fallback, minimum) {
+  const value = parseNonNegativeInteger(raw, label, fallback);
+  if (value < minimum) {
+    die(`${label} must be at least ${minimum}.`);
+  }
+  return value;
+}
+
+function assertNoUnsupportedFlags(args) {
+  const unsupported = args.find(
+    (arg) => arg === '--api-key' || arg === '--api-key-secret',
+  );
+  if (unsupported) {
+    die(
+      `${unsupported} is not supported by video.from-script. Store HEYGEN_API_KEY in HybridClaw secrets and use gateway injection.`,
+    );
+  }
+}
+
+function buildStartRequest(args) {
+  const operatorGrant = popBoolean(args, '--operator-grant');
+  const forwarded = ['generate-video'];
+  for (const flag of [
+    '--avatar-id',
+    '--image-url',
+    '--image-asset-id',
+    '--voice-id',
+    '--script',
+    '--title',
+    '--resolution',
+    '--aspect-ratio',
+    '--motion-prompt',
+    '--expressiveness',
+    '--background-json',
+    '--voice-settings-json',
+  ]) {
+    const value = popFlag(args, flag, undefined, {
+      allowDashValue: flag === '--script',
+    });
+    if (value !== undefined) forwarded.push(flag, value);
+  }
+  for (const flag of ['--remove-background']) {
+    if (popBoolean(args, flag)) forwarded.push(flag);
+  }
+  if (args.length > 0) die(`Unexpected arguments: ${args.join(' ')}`);
+  if (operatorGrant) forwarded.push('--operator-grant');
+  return heygen.buildRequest(forwarded);
+}
+
+function buildStatusRequest(args) {
+  const jobId = required(popFlag(args, '--job-id'), '--job-id');
+  return {
+    jobId,
+    request: heygen.buildRequest(['video-status', '--video-id', jobId]),
+  };
+}
+
+function statusKind(status) {
+  const normalized = String(status || '')
+    .trim()
+    .toLowerCase();
+  if (!normalized) return 'unknown';
+  if (TERMINAL_SUCCESS.has(normalized)) return 'completed';
+  if (TERMINAL_FAILURE.has(normalized)) return 'failed';
+  if (IN_PROGRESS.has(normalized)) return 'processing';
+  return normalized;
+}
+
+function responseRecord(result) {
+  const data = result.json?.data;
+  return data && typeof data === 'object' && !Array.isArray(data) ? data : {};
+}
+
+function responseErrorMessage(result) {
+  const record = responseRecord(result);
+  const error = record.error || record.error_message || record.message;
+  if (typeof error === 'string') return error;
+  if (error && typeof error === 'object') {
+    if (typeof error.message === 'string') return error.message;
+    return JSON.stringify(error);
+  }
+  return '';
+}
+
+function artifactPath(displayRoot, outputDir, filename) {
+  return path.posix
+    .join(displayRoot.replace(/\\/g, '/'), outputDir, filename)
+    .replace(/\/+/g, '/');
+}
+
+function sanitizeFilenamePart(value) {
+  return (
+    String(value || 'video')
+      .trim()
+      .replace(/[^a-zA-Z0-9._-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 80) || 'video'
+  );
+}
+
+function extensionFromMimeType(mimeType, fallbackUrl) {
+  const normalized = String(mimeType || '').toLowerCase();
+  if (normalized.includes('webm')) return '.webm';
+  if (normalized.includes('quicktime')) return '.mov';
+  if (normalized.includes('mp4') || normalized.startsWith('video/'))
+    return '.mp4';
+  try {
+    const ext = path.extname(new URL(fallbackUrl).pathname).toLowerCase();
+    if (['.mp4', '.webm', '.mov'].includes(ext)) return ext;
+  } catch {
+    return '.mp4';
+  }
+  return '.mp4';
+}
+
+function resolveOutputPath(options) {
+  const workspaceRoot =
+    options.workspaceRoot ||
+    process.env.HYBRIDCLAW_AGENT_WORKSPACE_ROOT ||
+    process.cwd();
+  const displayRoot =
+    options.displayRoot ||
+    process.env.HYBRIDCLAW_AGENT_WORKSPACE_DISPLAY_ROOT ||
+    workspaceRoot;
+  const outputDir = options.outputDir || OUTPUT_DIR;
+  if (path.isAbsolute(outputDir) || outputDir.split(/[\\/]/).includes('..')) {
+    throw new Error('--output-dir must be a workspace-relative path.');
+  }
+  const filename = options.filename;
+  if (!filename || path.basename(filename) !== filename) {
+    throw new Error('--filename must be a basename.');
+  }
+  const hostDir = path.resolve(workspaceRoot, outputDir);
+  const hostPath = path.resolve(hostDir, filename);
+  const rootWithSep = path.resolve(workspaceRoot) + path.sep;
+  if (
+    hostPath !== path.resolve(workspaceRoot) &&
+    !hostPath.startsWith(rootWithSep)
+  ) {
+    throw new Error('Resolved output path escapes the workspace.');
+  }
+  return {
+    hostDir,
+    hostPath,
+    displayPath: artifactPath(displayRoot, outputDir, filename),
+  };
+}
+
+function assertPublicDownloadUrl(rawUrl) {
+  const url = required(rawUrl, 'video URL');
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error('HeyGen completed without a valid video URL.');
+  }
+  if (isPrivateHostname(parsed.hostname)) {
+    throw new Error('HeyGen completed with a private or internal video URL.');
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new Error('HeyGen completed with a non-HTTPS video URL.');
+  }
+  return url;
+}
+
+async function writeResponseBodyToFile(response, hostPath, maxBytes) {
+  if (!response.body || typeof response.body.getReader !== 'function') {
+    throw new Error('Video download response did not include a readable body.');
+  }
+  const file = await fs.promises.open(hostPath, 'w');
+  const reader = response.body.getReader();
+  let bytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const chunk = Buffer.from(value);
+      bytes += chunk.length;
+      if (bytes > maxBytes) {
+        throw new Error(
+          `Video download exceeds max size (${bytes} bytes > ${maxBytes}).`,
+        );
+      }
+      await file.write(chunk);
+    }
+  } finally {
+    await file.close();
+    reader.releaseLock();
+  }
+  return bytes;
+}
+
+async function downloadVideo(videoUrl, options = {}) {
+  const url = assertPublicDownloadUrl(videoUrl);
+  const fetchImpl = options.fetch || globalThis.fetch;
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('fetch is not available for video download.');
+  }
+  const maxBytes = options.maxDownloadBytes ?? DEFAULT_MAX_DOWNLOAD_BYTES;
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    options.timeoutMs || 120_000,
+  );
+  let response;
+  let artifact;
+  let hostPath = '';
+  try {
+    response = await fetchImpl(url, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`Video download failed with HTTP ${response.status}.`);
+    }
+    const contentLength = Number.parseInt(
+      response.headers.get('content-length') || '',
+      10,
+    );
+    if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+      throw new Error(
+        `Video download exceeds max size (${contentLength} bytes > ${maxBytes}).`,
+      );
+    }
+    const mimeType = response.headers.get('content-type') || 'video/mp4';
+    const filename =
+      options.filename ||
+      `${sanitizeFilenamePart(options.jobId)}-${Date.now()}${extensionFromMimeType(
+        mimeType,
+        url,
+      )}`;
+    const resolved = resolveOutputPath({
+      ...options,
+      filename,
+    });
+    hostPath = resolved.hostPath;
+    fs.mkdirSync(resolved.hostDir, { recursive: true });
+    const bytes = await writeResponseBodyToFile(
+      response,
+      resolved.hostPath,
+      maxBytes,
+    );
+    artifact = {
+      path: resolved.displayPath,
+      hostPath: resolved.hostPath,
+      filename,
+      mimeType,
+      bytes,
+    };
+  } catch (error) {
+    if (hostPath) {
+      fs.rmSync(hostPath, { force: true });
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+  return artifact;
+}
+
+function normalizeStartResult(result) {
+  if (!result.videoId) {
+    throw new HeyGenApiError(
+      'HeyGen start response did not include a video id.',
+    );
+  }
+  return {
+    success: true,
+    jobId: result.videoId,
+    status: result.statusValue || 'submitted',
+    ready: false,
+    next: {
+      command: `node skills/video.from-script/video-from-script.cjs status --job-id ${result.videoId}`,
+    },
+  };
+}
+
+async function startFromScript(args, options = {}) {
+  const request = buildStartRequest([...args]);
+  const result = await executeHeyGenGatewayRequest(request.httpRequest, options);
+  return {
+    ...normalizeStartResult(result),
+    rateLimit: request.rateLimit,
+    costMeasurement: request.costMeasurement,
+  };
+}
+
+async function statusVideo(args, options = {}) {
+  const localArgs = [...args];
+  const download = popBoolean(localArgs, '--download');
+  const outputDir = popFlag(localArgs, '--output-dir', OUTPUT_DIR);
+  const filename = popFlag(localArgs, '--filename');
+  const maxDownloadBytes = parseNonNegativeInteger(
+    popFlag(localArgs, '--max-download-bytes'),
+    '--max-download-bytes',
+    DEFAULT_MAX_DOWNLOAD_BYTES,
+  );
+  const { jobId, request } = buildStatusRequest(localArgs);
+  if (localArgs.length > 0) die(`Unexpected arguments: ${localArgs.join(' ')}`);
+
+  const result = await executeHeyGenGatewayRequest(request.httpRequest, options);
+  const kind = statusKind(result.statusValue);
+  const payload = {
+    success: kind !== 'failed',
+    jobId,
+    status: result.statusValue || 'unknown',
+    state: kind,
+    ready: kind === 'completed',
+    videoUrl: result.videoUrl,
+    thumbnailUrl: result.thumbnailUrl,
+    error: responseErrorMessage(result) || undefined,
+  };
+  if (kind === 'failed') {
+    return payload;
+  }
+  if (download && kind === 'completed') {
+    if (!result.videoUrl) {
+      throw new Error('HeyGen completed without a downloadable video_url.');
+    }
+    const artifact = await downloadVideo(result.videoUrl, {
+      ...options,
+      jobId,
+      outputDir,
+      filename,
+      maxDownloadBytes,
+    });
+    return {
+      ...payload,
+      artifact: {
+        path: artifact.path,
+        filename: artifact.filename,
+        mimeType: artifact.mimeType,
+        bytes: artifact.bytes,
+      },
+    };
+  }
+  return payload;
+}
+
+async function sleep(ms) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function renderFromScript(args, options = {}) {
+  const localArgs = [...args];
+  const wait = popBoolean(localArgs, '--wait');
+  const pollIntervalMs = parseIntegerWithMinimum(
+    popFlag(localArgs, '--poll-interval-ms'),
+    '--poll-interval-ms',
+    DEFAULT_POLL_INTERVAL_MS,
+    MIN_POLL_INTERVAL_MS,
+  );
+  const maxWaitMs = parseNonNegativeInteger(
+    popFlag(localArgs, '--max-wait-ms'),
+    '--max-wait-ms',
+    DEFAULT_MAX_WAIT_MS,
+  );
+  const outputDir = popFlag(localArgs, '--output-dir', OUTPUT_DIR);
+  const filename = popFlag(localArgs, '--filename');
+  const maxDownloadBytes = parseNonNegativeInteger(
+    popFlag(localArgs, '--max-download-bytes'),
+    '--max-download-bytes',
+    DEFAULT_MAX_DOWNLOAD_BYTES,
+  );
+  const started = await startFromScript(localArgs, options);
+  if (!wait) {
+    return started;
+  }
+
+  const sleepImpl = options.sleep || sleep;
+  const startedAt = options.now ? options.now() : Date.now();
+  let attempts = 0;
+  while (true) {
+    const statusArgs = [
+      '--job-id',
+      started.jobId,
+      '--download',
+      '--output-dir',
+      outputDir,
+      ...(filename ? ['--filename', filename] : []),
+      '--max-download-bytes',
+      String(maxDownloadBytes),
+    ];
+    const status = await statusVideo(statusArgs, options);
+    attempts += 1;
+    if (status.state === 'completed') {
+      return {
+        ...status,
+        attempts,
+      };
+    }
+    if (status.state === 'failed') {
+      return {
+        ...status,
+        attempts,
+      };
+    }
+    const now = options.now ? options.now() : Date.now();
+    if (now - startedAt >= maxWaitMs) {
+      return {
+        ...status,
+        attempts,
+        success: false,
+        timedOut: true,
+        next: {
+          command: `node skills/video.from-script/video-from-script.cjs status --job-id ${started.jobId} --download`,
+        },
+      };
+    }
+    await sleepImpl(pollIntervalMs);
+  }
+}
+
+function classifyPlan(text) {
+  const base = heygen.classifyPlan(text);
+  return {
+    ...base,
+    skill: 'video.from-script',
+    operation: 'video-from-script',
+    async: true,
+    requiredInputs: ['avatar-id or image source', 'voice-id', 'script'],
+    output: 'mp4',
+    recommendedWorkflow: ['start', 'status --job-id <id>', 'status --download'],
+  };
+}
+
+function runEvalScenarios() {
+  const checks = [];
+  const start = buildStartRequest([
+    '--avatar-id',
+    'avatar_123',
+    '--voice-id',
+    'voice_123',
+    '--script',
+    'Approved script',
+    '--operator-grant',
+  ]);
+  checks.push({
+    name: 'start-request',
+    passed:
+      start.httpRequest.url === 'https://api.heygen.com/v2/videos' &&
+      start.httpRequest.method === 'POST' &&
+      start.httpRequest.secretHeaders?.some(
+        (header) => header.secretName === 'HEYGEN_API_KEY',
+      ),
+  });
+  const status = buildStatusRequest(['--job-id', 'video_123']);
+  checks.push({
+    name: 'status-request',
+    passed:
+      status.jobId === 'video_123' &&
+      status.request.httpRequest.url.endsWith('video_id=video_123'),
+  });
+  const plan = classifyPlan('Create an approved avatar video from this script');
+  checks.push({
+    name: 'plan',
+    passed:
+      plan.operation === 'video-from-script' &&
+      plan.requiredGrant === 'approve-heygen-video-generate' &&
+      plan.async === true,
+  });
+  return {
+    scenarioCount: checks.length,
+    failed: checks.filter((check) => !check.passed).length,
+    categories: {
+      planning: 1,
+      start: 1,
+      status: 1,
+    },
+    checks,
+  };
+}
+
+function helpText() {
+  return `video.from-script skill helper
+
+Usage:
+  node skills/video.from-script/video-from-script.cjs plan <request>
+  node skills/video.from-script/video-from-script.cjs start [flags]
+  node skills/video.from-script/video-from-script.cjs status --job-id <id> [--download]
+  node skills/video.from-script/video-from-script.cjs render [--wait] [flags]
+  node skills/video.from-script/video-from-script.cjs eval-scenarios
+
+Required start/render flags:
+  exactly one avatar source:
+    --avatar-id <id>
+    --image-url <public-url>
+    --image-asset-id <asset-id>
+  --voice-id <id>
+  --script <text>
+  --operator-grant
+
+Optional start/render flags:
+  --title <title>
+  --resolution 720p|1080p
+  --aspect-ratio 16:9|9:16
+  --motion-prompt <text>
+  --expressiveness low|medium|high
+  --remove-background
+  --background-json <json>
+  --voice-settings-json <json>
+
+Polling/download flags:
+  --wait
+  --poll-interval-ms <ms>
+  --max-wait-ms <ms>
+  --download
+  --output-dir <workspace-relative-dir>
+  --filename <basename>
+  --max-download-bytes <bytes>
+
+Authentication:
+  Store the Direct API key as HEYGEN_API_KEY. The helper sends HeyGen API requests through the HybridClaw gateway for secret injection.`;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.length === 0) {
+    process.stdout.write(`${helpText()}\n`);
+    return;
+  }
+  const format = popFlag(args, '--format', 'json');
+  if (format !== 'json') die('--format only supports json.');
+  assertNoUnsupportedFlags(args);
+  const command = args.shift();
+  let payload;
+  switch (command) {
+    case 'plan':
+      payload = classifyPlan(args.join(' '));
+      args.length = 0;
+      break;
+    case 'start':
+      payload = await startFromScript(args);
+      args.length = 0;
+      break;
+    case 'status':
+      payload = await statusVideo(args);
+      args.length = 0;
+      break;
+    case 'render':
+      payload = await renderFromScript(args);
+      args.length = 0;
+      break;
+    case 'eval-scenarios':
+      payload = runEvalScenarios();
+      args.length = 0;
+      break;
+    default:
+      die(`Unknown command: ${command || '(missing)'}.`);
+  }
+  if (args.length > 0) {
+    die(`Unexpected arguments: ${args.join(' ')}`);
+  }
+  printJson(payload);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  buildStartRequest,
+  buildStatusRequest,
+  classifyPlan,
+  downloadVideo,
+  renderFromScript,
+  runEvalScenarios,
+  startFromScript,
+  statusKind,
+  statusVideo,
+};

--- a/tests/video-from-script-skill.test.ts
+++ b/tests/video-from-script-skill.test.ts
@@ -1,0 +1,435 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+const helperPath = path.join(
+  process.cwd(),
+  'skills',
+  'video.from-script',
+  'video-from-script.cjs',
+);
+const skillPath = path.join(
+  process.cwd(),
+  'skills',
+  'video.from-script',
+  'SKILL.md',
+);
+const require = createRequire(import.meta.url);
+const videoFromScript = require('../skills/video.from-script/video-from-script.cjs');
+
+const ORIGINAL_WORKSPACE_ROOT = process.env.HYBRIDCLAW_AGENT_WORKSPACE_ROOT;
+const ORIGINAL_WORKSPACE_DISPLAY_ROOT =
+  process.env.HYBRIDCLAW_AGENT_WORKSPACE_DISPLAY_ROOT;
+
+let workspaceRoot = '';
+
+function runHelper(args: string[]) {
+  return spawnSync('node', [helperPath, ...args], {
+    encoding: 'utf-8',
+  });
+}
+
+beforeEach(() => {
+  workspaceRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-video-from-script-'),
+  );
+  process.env.HYBRIDCLAW_AGENT_WORKSPACE_ROOT = workspaceRoot;
+  process.env.HYBRIDCLAW_AGENT_WORKSPACE_DISPLAY_ROOT = '/workspace';
+});
+
+afterEach(() => {
+  if (ORIGINAL_WORKSPACE_ROOT == null) {
+    delete process.env.HYBRIDCLAW_AGENT_WORKSPACE_ROOT;
+  } else {
+    process.env.HYBRIDCLAW_AGENT_WORKSPACE_ROOT = ORIGINAL_WORKSPACE_ROOT;
+  }
+  if (ORIGINAL_WORKSPACE_DISPLAY_ROOT == null) {
+    delete process.env.HYBRIDCLAW_AGENT_WORKSPACE_DISPLAY_ROOT;
+  } else {
+    process.env.HYBRIDCLAW_AGENT_WORKSPACE_DISPLAY_ROOT =
+      ORIGINAL_WORKSPACE_DISPLAY_ROOT;
+  }
+  fs.rmSync(workspaceRoot, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+test('video.from-script skill manifest declares roadmap, dependency, and secret metadata', () => {
+  const skill = fs.readFileSync(skillPath, 'utf-8');
+
+  expect(skill).toContain('name: video.from-script');
+  expect(skill).toContain('R55.2');
+  expect(skill).toContain('issue: 875');
+  expect(skill).toContain('R55.1');
+  expect(skill).toContain('heygen');
+  expect(skill).toContain('HEYGEN_API_KEY');
+  expect(skill).toContain('UsageTotals');
+});
+
+test('video.from-script helper help and evals run without auth', () => {
+  const help = runHelper(['--help']);
+  const evals = runHelper(['--format', 'json', 'eval-scenarios']);
+
+  expect(help.status).toBe(0);
+  expect(help.stdout).toContain('video.from-script skill helper');
+  expect(help.stdout).toContain('start');
+  expect(help.stdout).toContain('status --job-id');
+  expect(help.stdout).toContain('render');
+  expect(help.stdout).not.toContain('--api-key ');
+  expect(evals.status).toBe(0);
+  expect(JSON.parse(evals.stdout)).toMatchObject({
+    scenarioCount: 3,
+    failed: 0,
+  });
+});
+
+test('video.from-script builds guarded HeyGen start requests', () => {
+  const payload = videoFromScript.buildStartRequest([
+    '--avatar-id',
+    'avatar_123',
+    '--voice-id',
+    'voice_123',
+    '--script',
+    'Approved script',
+    '--title',
+    'Launch update',
+    '--resolution',
+    '1080p',
+    '--aspect-ratio',
+    '16:9',
+    '--operator-grant',
+  ]);
+
+  expect(payload.httpRequest).toMatchObject({
+    method: 'POST',
+    url: 'https://api.heygen.com/v2/videos',
+    skillName: 'heygen',
+    json: {
+      avatar_id: 'avatar_123',
+      voice_id: 'voice_123',
+      script: 'Approved script',
+      title: 'Launch update',
+      resolution: '1080p',
+      aspect_ratio: '16:9',
+    },
+    secretHeaders: [
+      {
+        name: 'X-API-KEY',
+        secretName: 'HEYGEN_API_KEY',
+        prefix: '',
+      },
+    ],
+  });
+});
+
+test('video.from-script enforces avatar source exclusivity and accepts dash-prefixed scripts', () => {
+  const duplicateAvatarSource = runHelper([
+    '--format',
+    'json',
+    'start',
+      '--avatar-id',
+      'avatar_123',
+      '--image-asset-id',
+      'asset_123',
+      '--voice-id',
+      'voice_123',
+      '--script',
+      'Approved script',
+      '--operator-grant',
+  ]);
+
+  const payload = videoFromScript.buildStartRequest([
+    '--avatar-id',
+    'avatar_123',
+    '--voice-id',
+    'voice_123',
+    '--script',
+    '-- Approved script opening',
+    '--operator-grant',
+  ]);
+
+  expect(duplicateAvatarSource.status).not.toBe(0);
+  expect(duplicateAvatarSource.stderr).toContain(
+    'Provide exactly one of --avatar-id, --image-url, or --image-asset-id.',
+  );
+  expect(payload.httpRequest.json.script).toBe('-- Approved script opening');
+});
+
+test('video.from-script start returns async job id through gateway secret injection', async () => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Headers(),
+    text: async () =>
+      JSON.stringify({
+        ok: true,
+        status: 200,
+        headers: {},
+        body: JSON.stringify({
+          data: { video_id: 'video_123', status: 'pending' },
+        }),
+      }),
+  });
+
+  const result = await videoFromScript.startFromScript(
+    [
+      '--avatar-id',
+      'avatar_123',
+      '--voice-id',
+      'voice_123',
+      '--script',
+      'Approved script',
+      '--operator-grant',
+    ],
+    {
+      gatewayUrl: 'http://127.0.0.1:9090',
+      gatewayToken: 'gateway-token',
+      fetch: fetchMock,
+    },
+  );
+
+  expect(result).toMatchObject({
+    success: true,
+    jobId: 'video_123',
+    ready: false,
+  });
+  expect(result).not.toHaveProperty('videoId');
+  expect(fetchMock).toHaveBeenCalledWith(
+    'http://127.0.0.1:9090/api/http/request',
+    expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({
+        Authorization: 'Bearer gateway-token',
+      }),
+    }),
+  );
+  const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+  expect(body.secretHeaders).toEqual([
+    { name: 'X-API-KEY', secretName: 'HEYGEN_API_KEY', prefix: '' },
+  ]);
+});
+
+test('video.from-script status downloads completed MP4 artifacts', async () => {
+  const videoBytes = Buffer.from('fake-mp4');
+  const fetchMock = vi.fn(async (url: string) => {
+    if (url === 'https://cdn.heygen.example/video.mp4') {
+      return new Response(videoBytes, {
+        status: 200,
+        headers: {
+          'content-type': 'video/mp4',
+          'content-length': String(videoBytes.length),
+        },
+      });
+    }
+    return {
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      text: async () =>
+        JSON.stringify({
+          ok: true,
+          status: 200,
+          headers: {},
+          body: JSON.stringify({
+            data: {
+              video_id: 'video_123',
+              status: 'completed',
+              video_url: 'https://cdn.heygen.example/video.mp4',
+              thumbnail_url: 'https://cdn.heygen.example/thumb.jpg',
+            },
+          }),
+        }),
+    };
+  });
+
+  const result = await videoFromScript.statusVideo(
+    ['--job-id', 'video_123', '--download', '--filename', 'avatar-video.mp4'],
+    {
+      gatewayUrl: 'http://127.0.0.1:9090',
+      fetch: fetchMock,
+    },
+  );
+
+  expect(result).toMatchObject({
+    success: true,
+    jobId: 'video_123',
+    state: 'completed',
+    ready: true,
+    videoUrl: 'https://cdn.heygen.example/video.mp4',
+    artifact: {
+      path: '/workspace/.generated-videos/avatar-video.mp4',
+      filename: 'avatar-video.mp4',
+      mimeType: 'video/mp4',
+      bytes: videoBytes.length,
+    },
+  });
+  expect(
+    fs.readFileSync(
+      path.join(workspaceRoot, '.generated-videos', 'avatar-video.mp4'),
+    ),
+  ).toEqual(videoBytes);
+});
+
+test('video.from-script download rejects private completed video URLs', async () => {
+  const fetchMock = vi.fn();
+
+  await expect(
+    videoFromScript.downloadVideo('http://127.0.0.1/video.mp4', {
+      fetch: fetchMock,
+    }),
+  ).rejects.toThrow('private or internal video URL');
+  await expect(
+    videoFromScript.downloadVideo('http://[::ffff:127.0.0.1]/video.mp4', {
+      fetch: fetchMock,
+    }),
+  ).rejects.toThrow('private or internal video URL');
+  await expect(
+    videoFromScript.downloadVideo('http://[::ffff:7f00:1]/video.mp4', {
+      fetch: fetchMock,
+    }),
+  ).rejects.toThrow('private or internal video URL');
+  expect(fetchMock).not.toHaveBeenCalled();
+});
+
+test('video.from-script download requires HTTPS and enforces size while streaming', async () => {
+  const fetchMock = vi.fn(async () => {
+    return new Response(Buffer.from('too-big'), {
+      status: 200,
+      headers: { 'content-type': 'video/mp4' },
+    });
+  });
+
+  await expect(
+    videoFromScript.downloadVideo('http://cdn.heygen.example/video.mp4', {
+      fetch: fetchMock,
+    }),
+  ).rejects.toThrow('non-HTTPS video URL');
+  expect(fetchMock).not.toHaveBeenCalled();
+
+  await expect(
+    videoFromScript.downloadVideo('https://cdn.heygen.example/video.mp4', {
+      fetch: fetchMock,
+      filename: 'oversized.mp4',
+      maxDownloadBytes: 3,
+    }),
+  ).rejects.toThrow('exceeds max size');
+  expect(
+    fs.existsSync(path.join(workspaceRoot, '.generated-videos', 'oversized.mp4')),
+  ).toBe(false);
+});
+
+test('video.from-script helper fails fast on unknown flags and zero poll interval', () => {
+  const unknown = runHelper([
+    '--format',
+    'json',
+    'start',
+    '--avatar-id',
+    'avatar_123',
+    '--voice',
+    'voice_123',
+    '--script',
+    'Approved script',
+    '--operator-grant',
+  ]);
+  const zeroPoll = runHelper([
+    '--format',
+    'json',
+    'render',
+    '--wait',
+    '--poll-interval-ms',
+    '0',
+  ]);
+
+  expect(unknown.status).not.toBe(0);
+  expect(unknown.stderr).toContain('Unexpected arguments: --voice voice_123');
+  expect(zeroPoll.status).not.toBe(0);
+  expect(zeroPoll.stderr).toContain('--poll-interval-ms must be at least 1000');
+});
+
+test('video.from-script render waits with bounded polling and downloads on completion', async () => {
+  const videoBytes = Buffer.from('rendered-mp4');
+  let statusCalls = 0;
+  let now = 0;
+  const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+    if (url === 'https://cdn.heygen.example/rendered.mp4') {
+      return new Response(videoBytes, {
+        status: 200,
+        headers: { 'content-type': 'video/mp4' },
+      });
+    }
+    const body = JSON.parse(String(init?.body || '{}'));
+    if (String(body.url).includes('/v2/videos')) {
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({
+            ok: true,
+            status: 200,
+            headers: {},
+            body: JSON.stringify({ data: { video_id: 'video_wait' } }),
+          }),
+      };
+    }
+    statusCalls += 1;
+    return {
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      text: async () =>
+        JSON.stringify({
+          ok: true,
+          status: 200,
+          headers: {},
+          body: JSON.stringify({
+            data:
+              statusCalls === 1
+                ? { status: 'processing' }
+                : {
+                    status: 'completed',
+                    video_url: 'https://cdn.heygen.example/rendered.mp4',
+                  },
+          }),
+        }),
+    };
+  });
+
+  const result = await videoFromScript.renderFromScript(
+    [
+      '--wait',
+      '--avatar-id',
+      'avatar_123',
+      '--voice-id',
+      'voice_123',
+      '--script',
+      'Approved script',
+      '--operator-grant',
+      '--poll-interval-ms',
+      '1000',
+      '--filename',
+      'rendered.mp4',
+    ],
+    {
+      gatewayUrl: 'http://127.0.0.1:9090',
+      fetch: fetchMock,
+      now: () => now,
+      sleep: async (ms: number) => {
+        now += ms;
+      },
+    },
+  );
+
+  expect(result).toMatchObject({
+    success: true,
+    state: 'completed',
+    attempts: 2,
+    artifact: {
+      path: '/workspace/.generated-videos/rendered.mp4',
+    },
+  });
+  expect(statusCalls).toBe(2);
+});


### PR DESCRIPTION
## Summary

Implements the R55.2 `video.from-script` skill from #875.

- Adds a bundled `video.from-script` skill for avatar + voice + script to async HeyGen MP4 renders.
- Adds a helper with `plan`, `start`, `status --job-id`, `status --download`, and `render --wait` flows.
- Reuses the existing HeyGen adapter and gateway secret injection for `HEYGEN_API_KEY`.
- Normalizes HeyGen completed video and thumbnail URLs for status/download flows.
- Updates bundled skill docs and skill validator naming guidance for dotted skill ids already used by bundled skills.

Closes #875

## Validation

- `python3 skills/skill-creator/scripts/quick_validate.py skills/video.from-script`
- `node --check skills/video.from-script/video-from-script.cjs`
- `npx vitest run tests/video-from-script-skill.test.ts tests/heygen-skill.test.ts`
