### PR TITLE
ci: stop blocking main pushes on missing trace-judge live secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,6 @@ jobs:
     env:
       HAS_HYBRIDAI_API_KEY: ${{ secrets.HYBRIDAI_API_KEY != '' }}
       HAS_HYBRIDAI_CHATBOT_ID: ${{ secrets.HYBRIDAI_CHATBOT_ID != '' }}
-      LIVE_TRACE_JUDGE_REQUIRED: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
       - name: Checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
@@ -151,12 +150,6 @@ jobs:
       - name: Trace judge eval gate
         run: npm run eval:trace-judge:gate
 
-      - name: Trace judge live accuracy credentials required
-        if: env.LIVE_TRACE_JUDGE_REQUIRED == 'true' && (env.HAS_HYBRIDAI_API_KEY != 'true' || env.HAS_HYBRIDAI_CHATBOT_ID != 'true')
-        run: |
-          echo "::error::Canonical CI requires HYBRIDAI_API_KEY and HYBRIDAI_CHATBOT_ID so live trace-judge accuracy regressions block promotion."
-          exit 1
-
       - name: Trace judge live accuracy gate
         if: env.HAS_HYBRIDAI_API_KEY == 'true' && env.HAS_HYBRIDAI_CHATBOT_ID == 'true'
         env:
@@ -166,8 +159,8 @@ jobs:
         run: npm run eval:trace-judge:gate:live
 
       - name: Trace judge live accuracy gate skipped
-        if: env.LIVE_TRACE_JUDGE_REQUIRED != 'true' && (env.HAS_HYBRIDAI_API_KEY != 'true' || env.HAS_HYBRIDAI_CHATBOT_ID != 'true')
-        run: echo "Skipping live trace-judge gate because HYBRIDAI_API_KEY and HYBRIDAI_CHATBOT_ID are not both available to this PR run; this run is harness-only. Pushes to main require the live gate."
+        if: env.HAS_HYBRIDAI_API_KEY != 'true' || env.HAS_HYBRIDAI_CHATBOT_ID != 'true'
+        run: echo "Skipping live trace-judge gate because HYBRIDAI_API_KEY and HYBRIDAI_CHATBOT_ID are not both available to this run."
 
       - name: Release bundle check (root)
         run: npm run release:check


### PR DESCRIPTION
## Summary

- The `Trace judge live accuracy credentials required` step in `ci.yml` hard-fails every push to `main` when `HYBRIDAI_CHATBOT_ID` is not set as a repo secret. That secret has never been configured (`HYBRIDAI_API_KEY` is the only trace-judge secret present), so CI on `main` has been red since the gate landed in #904 — including the v0.17.0 release push ([run 25751383343](https://github.com/HybridAIOne/hybridclaw/actions/runs/25751383343)).
- Drop the required-on-main branch and the `LIVE_TRACE_JUDGE_REQUIRED` flag. The remaining behavior: the live gate runs when both secrets are present, and the "skipped" message runs otherwise — same as the PR-run behavior we already accept.
- If we later want to re-require the live gate on `main`, we should add the `HYBRIDAI_CHATBOT_ID` secret first and then reintroduce the guard (option 1 from the triage).

## Test plan

- [ ] PR CI passes (the `test` job should hit the "skipped" message because `HYBRIDAI_CHATBOT_ID` is unset).
- [ ] After merge, confirm the next push to `main` no longer fails on the credentials-required step.