### PR TITLE
[codex] Add model overlay metadata schema

### DIFF
--- a/src/providers/model-metadata.ts
+++ b/src/providers/model-metadata.ts
@@ -7,11 +7,19 @@ export interface ModelCapabilityFlags {
   reasoning: boolean;
 }
 
-interface StaticModelMetadataEntry {
+export interface ModelOverlay {
+  tool_discipline: string;
+  completion_contract: string;
+  execution_policy: string;
+  narrate_only_retry: boolean;
+}
+
+export interface StaticModelMetadataEntry {
   contextWindow: number | null;
   maxTokens?: number | null;
   capabilities: ModelCapabilityFlags;
   sources: string[];
+  model_overlay?: ModelOverlay;
 }
 
 const MODEL_METADATA_SOURCES = {
@@ -221,6 +229,26 @@ const EMPTY_CAPABILITIES: ModelCapabilityFlags = {
   reasoning: false,
 };
 
+const GPT5_MODEL_IDS = new Set([
+  'gpt-5',
+  'gpt-5-codex',
+  'gpt-5-mini',
+  'gpt-5-nano',
+  'gpt-5-pro',
+  'gpt-5.1',
+  'gpt-5.1-codex',
+  'gpt-5.1-codex-max',
+]);
+
+const MODEL_OVERLAY_MATCHERS: {
+  matches: (modelId: string) => boolean;
+  overlay: ModelOverlay | undefined;
+}[] = [
+  { matches: isGpt5ModelId, overlay: undefined },
+  { matches: isCodexFamilyModelId, overlay: undefined },
+  { matches: isLocalLlmModelId, overlay: undefined },
+];
+
 function uniqueStrings(values: string[]): string[] {
   return [...new Set(values.filter(Boolean))];
 }
@@ -244,6 +272,31 @@ function findStaticModelMetadataEntry(
   }
 
   return null;
+}
+
+export function isGpt5ModelId(modelId: string): boolean {
+  return collectModelLookupCandidates(modelId).some((candidate) =>
+    GPT5_MODEL_IDS.has(candidate),
+  );
+}
+
+export function isCodexFamilyModelId(_modelId: string): boolean {
+  return false;
+}
+
+export function isLocalLlmModelId(_modelId: string): boolean {
+  return false;
+}
+
+export function getModelOverlay(modelId: string): ModelOverlay | undefined {
+  const entry = findStaticModelMetadataEntry(modelId);
+  if (entry?.model_overlay) return entry.model_overlay;
+
+  for (const matcher of MODEL_OVERLAY_MATCHERS) {
+    if (matcher.matches(modelId)) return matcher.overlay;
+  }
+
+  return undefined;
 }
 
 export function resolveStaticModelCatalogMetadata(

--- a/src/providers/model-metadata.ts
+++ b/src/providers/model-metadata.ts
@@ -299,6 +299,10 @@ export function getModelOverlay(modelId: string): ModelOverlay | undefined {
   return undefined;
 }
 
+export function listStaticModelMetadataModelIds(): string[] {
+  return Object.keys(STATIC_MODEL_METADATA);
+}
+
 export function resolveStaticModelCatalogMetadata(
   modelName: string,
 ): StaticModelCatalogMetadata {

--- a/src/providers/model-metadata.ts
+++ b/src/providers/model-metadata.ts
@@ -7,6 +7,10 @@ export interface ModelCapabilityFlags {
   reasoning: boolean;
 }
 
+/**
+ * Prompt-destined, byte-stable model overlay text. String fields must be
+ * non-empty when an overlay is populated.
+ */
 export interface ModelOverlay {
   tool_discipline: string;
   completion_contract: string;
@@ -14,7 +18,7 @@ export interface ModelOverlay {
   narrate_only_retry: boolean;
 }
 
-export interface StaticModelMetadataEntry {
+interface StaticModelMetadataEntry {
   contextWindow: number | null;
   maxTokens?: number | null;
   capabilities: ModelCapabilityFlags;
@@ -214,6 +218,10 @@ const STATIC_MODEL_METADATA: Record<string, StaticModelMetadataEntry> = {
   },
 };
 
+const STATIC_MODEL_METADATA_MODEL_IDS = Object.freeze(
+  Object.keys(STATIC_MODEL_METADATA),
+);
+
 export interface StaticModelCatalogMetadata {
   known: boolean;
   contextWindow: number | null;
@@ -229,7 +237,9 @@ const EMPTY_CAPABILITIES: ModelCapabilityFlags = {
   reasoning: false,
 };
 
-const GPT5_MODEL_IDS = new Set([
+const GPT5_OVERLAY_MODEL_IDS = new Set([
+  // Canonical GPT-5 overlay family requested by #994. This is intentionally
+  // narrower than every gpt-5* static catalog entry.
   'gpt-5',
   'gpt-5-codex',
   'gpt-5-mini',
@@ -239,15 +249,6 @@ const GPT5_MODEL_IDS = new Set([
   'gpt-5.1-codex',
   'gpt-5.1-codex-max',
 ]);
-
-const MODEL_OVERLAY_MATCHERS: {
-  matches: (modelId: string) => boolean;
-  overlay: ModelOverlay | undefined;
-}[] = [
-  { matches: isGpt5ModelId, overlay: undefined },
-  { matches: isCodexFamilyModelId, overlay: undefined },
-  { matches: isLocalLlmModelId, overlay: undefined },
-];
 
 function uniqueStrings(values: string[]): string[] {
   return [...new Set(values.filter(Boolean))];
@@ -263,9 +264,14 @@ function resolveStaticMetadataEntryKey(candidate: string): string | null {
 function findStaticModelMetadataEntry(
   modelName: string,
 ): StaticModelMetadataEntry | null {
-  const candidates = collectModelLookupCandidates(modelName);
-  if (candidates.length === 0) return null;
+  return findStaticModelMetadataEntryFromCandidates(
+    collectModelLookupCandidates(modelName),
+  );
+}
 
+function findStaticModelMetadataEntryFromCandidates(
+  candidates: readonly string[],
+): StaticModelMetadataEntry | null {
   for (const candidate of candidates) {
     const directKey = resolveStaticMetadataEntryKey(candidate);
     if (directKey) return STATIC_MODEL_METADATA[directKey] ?? null;
@@ -274,33 +280,58 @@ function findStaticModelMetadataEntry(
   return null;
 }
 
+function candidatesIncludeGpt5ModelId(candidates: readonly string[]): boolean {
+  return candidates.some((candidate) => GPT5_OVERLAY_MODEL_IDS.has(candidate));
+}
+
 export function isGpt5ModelId(modelId: string): boolean {
-  return collectModelLookupCandidates(modelId).some((candidate) =>
-    GPT5_MODEL_IDS.has(candidate),
-  );
+  return candidatesIncludeGpt5ModelId(collectModelLookupCandidates(modelId));
 }
 
-export function isCodexFamilyModelId(_modelId: string): boolean {
-  return false;
+type ModelOverlayMatcher = (
+  candidates: readonly string[],
+) => ModelOverlay | undefined;
+
+function resolveGpt5ModelOverlay(
+  candidates: readonly string[],
+): ModelOverlay | undefined {
+  if (!candidatesIncludeGpt5ModelId(candidates)) return undefined;
+  return undefined;
 }
 
-export function isLocalLlmModelId(_modelId: string): boolean {
-  return false;
+function resolveCodexFamilyModelOverlay(
+  _candidates: readonly string[],
+): ModelOverlay | undefined {
+  return undefined;
 }
+
+function resolveLocalLlmModelOverlay(
+  _candidates: readonly string[],
+): ModelOverlay | undefined {
+  return undefined;
+}
+
+const MODEL_OVERLAY_MATCHERS: ModelOverlayMatcher[] = [
+  resolveGpt5ModelOverlay,
+  resolveCodexFamilyModelOverlay,
+  resolveLocalLlmModelOverlay,
+];
 
 export function getModelOverlay(modelId: string): ModelOverlay | undefined {
-  const entry = findStaticModelMetadataEntry(modelId);
+  const candidates = collectModelLookupCandidates(modelId);
+  const entry = findStaticModelMetadataEntryFromCandidates(candidates);
   if (entry?.model_overlay) return entry.model_overlay;
 
   for (const matcher of MODEL_OVERLAY_MATCHERS) {
-    if (matcher.matches(modelId)) return matcher.overlay;
+    const overlay = matcher(candidates);
+    if (overlay) return overlay;
   }
 
   return undefined;
 }
 
-export function listStaticModelMetadataModelIds(): string[] {
-  return Object.keys(STATIC_MODEL_METADATA);
+export function listStaticModelMetadataModelIds(): readonly string[] {
+  return STATIC_MODEL_METADATA_MODEL_IDS;
 }
 
 export function resolveStaticModelCatalogMetadata(

--- a/src/providers/model-metadata.ts
+++ b/src/providers/model-metadata.ts
@@ -218,10 +218,6 @@ const STATIC_MODEL_METADATA: Record<string, StaticModelMetadataEntry> = {
   },
 };
 
-const STATIC_MODEL_METADATA_MODEL_IDS = Object.freeze(
-  Object.keys(STATIC_MODEL_METADATA),
-);
-
 export interface StaticModelCatalogMetadata {
   known: boolean;
   contextWindow: number | null;
@@ -288,34 +284,29 @@ export function isGpt5ModelId(modelId: string): boolean {
   return candidatesIncludeGpt5ModelId(collectModelLookupCandidates(modelId));
 }
 
-type ModelOverlayMatcher = (
-  candidates: readonly string[],
-) => ModelOverlay | undefined;
-
-function resolveGpt5ModelOverlay(
-  candidates: readonly string[],
-): ModelOverlay | undefined {
-  if (!candidatesIncludeGpt5ModelId(candidates)) return undefined;
-  return undefined;
+export function isCodexFamilyModelId(_modelId: string): boolean {
+  return false;
 }
 
-function resolveCodexFamilyModelOverlay(
-  _candidates: readonly string[],
-): ModelOverlay | undefined {
-  return undefined;
+export function isLocalLlmModelId(_modelId: string): boolean {
+  return false;
 }
 
-function resolveLocalLlmModelOverlay(
-  _candidates: readonly string[],
-): ModelOverlay | undefined {
-  return undefined;
-}
-
-const MODEL_OVERLAY_MATCHERS: ModelOverlayMatcher[] = [
-  resolveGpt5ModelOverlay,
-  resolveCodexFamilyModelOverlay,
-  resolveLocalLlmModelOverlay,
+const MODEL_OVERLAY_MATCHERS: {
+  matches: (modelId: string) => boolean;
+  overlay: ModelOverlay | undefined;
+}[] = [
+  { matches: isGpt5ModelId, overlay: undefined },
+  { matches: isCodexFamilyModelId, overlay: undefined },
+  { matches: isLocalLlmModelId, overlay: undefined },
 ];
+
+function matchesModelOverlayCandidate(
+  matcher: (modelId: string) => boolean,
+  candidates: readonly string[],
+): boolean {
+  return candidates.some((candidate) => matcher(candidate));
+}
 
 export function getModelOverlay(modelId: string): ModelOverlay | undefined {
   const candidates = collectModelLookupCandidates(modelId);
@@ -323,15 +314,12 @@ export function getModelOverlay(modelId: string): ModelOverlay | undefined {
   if (entry?.model_overlay) return entry.model_overlay;
 
   for (const matcher of MODEL_OVERLAY_MATCHERS) {
-    const overlay = matcher(candidates);
-    if (overlay) return overlay;
+    if (matchesModelOverlayCandidate(matcher.matches, candidates)) {
+      return matcher.overlay;
+    }
   }
 
   return undefined;
-}
-
-export function listStaticModelMetadataModelIds(): readonly string[] {
-  return STATIC_MODEL_METADATA_MODEL_IDS;
 }
 
 export function resolveStaticModelCatalogMetadata(

--- a/tests/model-metadata.test.ts
+++ b/tests/model-metadata.test.ts
@@ -1,13 +1,8 @@
 import { expect, expectTypeOf, test } from 'vitest';
-import type {
-  ModelOverlay,
-  StaticModelMetadataEntry,
-} from '../src/providers/model-metadata.js';
+import type { ModelOverlay } from '../src/providers/model-metadata.js';
 import {
   getModelOverlay,
-  isCodexFamilyModelId,
   isGpt5ModelId,
-  isLocalLlmModelId,
   listStaticModelMetadataModelIds,
 } from '../src/providers/model-metadata.js';
 
@@ -19,6 +14,19 @@ const COMPLETE_OVERLAY = {
 } satisfies ModelOverlay;
 
 test('static model metadata entries accept an optional complete overlay', () => {
+  type EntryWithOptionalOverlay = {
+    contextWindow: number | null;
+    maxTokens?: number | null;
+    capabilities: {
+      vision: boolean;
+      tools: boolean;
+      jsonMode: boolean;
+      reasoning: boolean;
+    };
+    sources: string[];
+    model_overlay?: ModelOverlay;
+  };
+
   const entryWithoutOverlay = {
     contextWindow: 400_000,
     capabilities: {
@@ -28,16 +36,16 @@ test('static model metadata entries accept an optional complete overlay', () => 
       reasoning: true,
     },
     sources: ['test-source'],
-  } satisfies StaticModelMetadataEntry;
+  } satisfies EntryWithOptionalOverlay;
 
   const entryWithOverlay = {
     ...entryWithoutOverlay,
     model_overlay: COMPLETE_OVERLAY,
-  } satisfies StaticModelMetadataEntry;
+  } satisfies EntryWithOptionalOverlay;
 
   expect(entryWithoutOverlay).not.toHaveProperty('model_overlay');
   expect(entryWithOverlay.model_overlay).toEqual(COMPLETE_OVERLAY);
-  expectTypeOf<StaticModelMetadataEntry['model_overlay']>().toEqualTypeOf<
+  expectTypeOf<EntryWithOptionalOverlay['model_overlay']>().toEqualTypeOf<
     ModelOverlay | undefined
   >();
 });
@@ -78,9 +86,19 @@ test.each([
   expect(isGpt5ModelId(modelId)).toBe(true);
 });
 
-test('future family matcher skeletons are inert', () => {
-  expect(isCodexFamilyModelId('gpt-5-codex')).toBe(false);
-  expect(isLocalLlmModelId('ollama/qwen3')).toBe(false);
+test.each([
+  '',
+  '  ',
+  'gpt-5.2',
+  'gpt-5.3-codex',
+  'gpt-5.5-pro',
+])('isGpt5ModelId rejects non-overlay GPT-5 family input %s', (modelId) => {
+  expect(isGpt5ModelId(modelId)).toBe(false);
+});
+
+test('getModelOverlay returns undefined for blank model ids', () => {
+  expect(getModelOverlay('')).toBeUndefined();
+  expect(getModelOverlay('  ')).toBeUndefined();
 });
 
 test.each(

--- a/tests/model-metadata.test.ts
+++ b/tests/model-metadata.test.ts
@@ -1,9 +1,14 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import ts from 'typescript';
 import { expect, expectTypeOf, test } from 'vitest';
 import type { ModelOverlay } from '../src/providers/model-metadata.js';
 import {
   getModelOverlay,
+  isCodexFamilyModelId,
   isGpt5ModelId,
-  listStaticModelMetadataModelIds,
+  isLocalLlmModelId,
 } from '../src/providers/model-metadata.js';
 
 const COMPLETE_OVERLAY = {
@@ -12,6 +17,53 @@ const COMPLETE_OVERLAY = {
   execution_policy: 'execute only approved actions',
   narrate_only_retry: true,
 } satisfies ModelOverlay;
+
+function collectStaticModelMetadataIdsFromSource(): string[] {
+  const sourcePath = path.join(
+    process.cwd(),
+    'src/providers/model-metadata.ts',
+  );
+  const source = fs.readFileSync(sourcePath, 'utf-8');
+  const sourceFile = ts.createSourceFile(
+    sourcePath,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  let modelIds: string[] | null = null;
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isVariableStatement(node)) {
+      for (const declaration of node.declarationList.declarations) {
+        if (
+          ts.isIdentifier(declaration.name) &&
+          declaration.name.text === 'STATIC_MODEL_METADATA' &&
+          declaration.initializer &&
+          ts.isObjectLiteralExpression(declaration.initializer)
+        ) {
+          modelIds = declaration.initializer.properties
+            .filter(ts.isPropertyAssignment)
+            .map((property) => {
+              if (ts.isStringLiteralLike(property.name))
+                return property.name.text;
+              if (ts.isIdentifier(property.name)) return property.name.text;
+              throw new Error('Unsupported static model metadata key syntax');
+            });
+          return;
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  if (!modelIds) {
+    throw new Error('STATIC_MODEL_METADATA object not found');
+  }
+  return modelIds;
+}
 
 test('static model metadata entries accept an optional complete overlay', () => {
   type EntryWithOptionalOverlay = {
@@ -101,8 +153,13 @@ test('getModelOverlay returns undefined for blank model ids', () => {
   expect(getModelOverlay('  ')).toBeUndefined();
 });
 
+test('future family matcher predicates are inert skeletons', () => {
+  expect(isCodexFamilyModelId('gpt-5-codex')).toBe(false);
+  expect(isLocalLlmModelId('ollama/qwen3')).toBe(false);
+});
+
 test.each(
-  listStaticModelMetadataModelIds(),
+  collectStaticModelMetadataIdsFromSource(),
 )('getModelOverlay returns undefined for current catalog entry %s', (modelId) => {
   expect(getModelOverlay(modelId)).toBeUndefined();
 });

--- a/tests/model-metadata.test.ts
+++ b/tests/model-metadata.test.ts
@@ -8,6 +8,7 @@ import {
   isCodexFamilyModelId,
   isGpt5ModelId,
   isLocalLlmModelId,
+  listStaticModelMetadataModelIds,
 } from '../src/providers/model-metadata.js';
 
 const COMPLETE_OVERLAY = {
@@ -16,40 +17,6 @@ const COMPLETE_OVERLAY = {
   execution_policy: 'execute only approved actions',
   narrate_only_retry: true,
 } satisfies ModelOverlay;
-
-const CURRENT_STATIC_MODEL_IDS = [
-  'gpt-4.1',
-  'gpt-4.1-mini',
-  'gpt-4.1-nano',
-  'gpt-5',
-  'gpt-5-chat-latest',
-  'gpt-5-codex',
-  'gpt-5-mini',
-  'gpt-5-nano',
-  'gpt-5-pro',
-  'gpt-5.1',
-  'gpt-5.1-chat-latest',
-  'gpt-5.1-codex',
-  'gpt-5.1-codex-max',
-  'gpt-5.1-codex-mini',
-  'gpt-5.2',
-  'gpt-5.2-chat-latest',
-  'gpt-5.2-codex',
-  'gpt-5.2-pro',
-  'gpt-5.3-codex',
-  'gpt-5.3-codex-spark',
-  'gpt-5.4',
-  'gpt-5.4-mini',
-  'gpt-5.4-nano',
-  'gpt-5.5',
-  'gpt-5.5-pro',
-  'claude-haiku-4-5',
-  'claude-opus-4-1',
-  'claude-opus-4-6',
-  'claude-sonnet-4',
-  'claude-sonnet-4-5',
-  'claude-sonnet-4-6',
-];
 
 test('static model metadata entries accept an optional complete overlay', () => {
   const entryWithoutOverlay = {
@@ -117,7 +84,7 @@ test('future family matcher skeletons are inert', () => {
 });
 
 test.each(
-  CURRENT_STATIC_MODEL_IDS,
+  listStaticModelMetadataModelIds(),
 )('getModelOverlay returns undefined for current catalog entry %s', (modelId) => {
   expect(getModelOverlay(modelId)).toBeUndefined();
 });

--- a/tests/model-metadata.test.ts
+++ b/tests/model-metadata.test.ts
@@ -1,0 +1,129 @@
+import { expect, expectTypeOf, test } from 'vitest';
+import type {
+  ModelOverlay,
+  StaticModelMetadataEntry,
+} from '../src/providers/model-metadata.js';
+import {
+  getModelOverlay,
+  isCodexFamilyModelId,
+  isGpt5ModelId,
+  isLocalLlmModelId,
+} from '../src/providers/model-metadata.js';
+
+const COMPLETE_OVERLAY = {
+  tool_discipline: 'use tools deliberately',
+  completion_contract: 'return the final answer only after work is complete',
+  execution_policy: 'execute only approved actions',
+  narrate_only_retry: true,
+} satisfies ModelOverlay;
+
+const CURRENT_STATIC_MODEL_IDS = [
+  'gpt-4.1',
+  'gpt-4.1-mini',
+  'gpt-4.1-nano',
+  'gpt-5',
+  'gpt-5-chat-latest',
+  'gpt-5-codex',
+  'gpt-5-mini',
+  'gpt-5-nano',
+  'gpt-5-pro',
+  'gpt-5.1',
+  'gpt-5.1-chat-latest',
+  'gpt-5.1-codex',
+  'gpt-5.1-codex-max',
+  'gpt-5.1-codex-mini',
+  'gpt-5.2',
+  'gpt-5.2-chat-latest',
+  'gpt-5.2-codex',
+  'gpt-5.2-pro',
+  'gpt-5.3-codex',
+  'gpt-5.3-codex-spark',
+  'gpt-5.4',
+  'gpt-5.4-mini',
+  'gpt-5.4-nano',
+  'gpt-5.5',
+  'gpt-5.5-pro',
+  'claude-haiku-4-5',
+  'claude-opus-4-1',
+  'claude-opus-4-6',
+  'claude-sonnet-4',
+  'claude-sonnet-4-5',
+  'claude-sonnet-4-6',
+];
+
+test('static model metadata entries accept an optional complete overlay', () => {
+  const entryWithoutOverlay = {
+    contextWindow: 400_000,
+    capabilities: {
+      vision: true,
+      tools: true,
+      jsonMode: true,
+      reasoning: true,
+    },
+    sources: ['test-source'],
+  } satisfies StaticModelMetadataEntry;
+
+  const entryWithOverlay = {
+    ...entryWithoutOverlay,
+    model_overlay: COMPLETE_OVERLAY,
+  } satisfies StaticModelMetadataEntry;
+
+  expect(entryWithoutOverlay).not.toHaveProperty('model_overlay');
+  expect(entryWithOverlay.model_overlay).toEqual(COMPLETE_OVERLAY);
+  expectTypeOf<StaticModelMetadataEntry['model_overlay']>().toEqualTypeOf<
+    ModelOverlay | undefined
+  >();
+});
+
+test('model overlay type requires all four documented fields', () => {
+  expectTypeOf(COMPLETE_OVERLAY).toMatchTypeOf<ModelOverlay>();
+
+  // @ts-expect-error ModelOverlay requires narrate_only_retry when present.
+  const incompleteOverlay: ModelOverlay = {
+    tool_discipline: 'use tools deliberately',
+    completion_contract: 'finish cleanly',
+    execution_policy: 'execute only approved actions',
+  };
+
+  expect(incompleteOverlay).not.toHaveProperty('narrate_only_retry');
+});
+
+test.each([
+  'gpt-5',
+  'gpt-5-codex',
+  'gpt-5-mini',
+  'gpt-5-nano',
+  'gpt-5-pro',
+  'gpt-5.1',
+  'gpt-5.1-codex',
+  'gpt-5.1-codex-max',
+])('isGpt5ModelId accepts canonical GPT-5 model id %s', (modelId) => {
+  expect(isGpt5ModelId(modelId)).toBe(true);
+});
+
+test.each([
+  'openai-codex/gpt-5',
+  'hybridai/gpt-5-mini',
+  'gpt-5:latest',
+  'openai/gpt-5:latest',
+  'openai-codex/gpt-5.1-codex-max:latest',
+])('isGpt5ModelId accepts normalized GPT-5 variant %s', (modelId) => {
+  expect(isGpt5ModelId(modelId)).toBe(true);
+});
+
+test('future family matcher skeletons are inert', () => {
+  expect(isCodexFamilyModelId('gpt-5-codex')).toBe(false);
+  expect(isLocalLlmModelId('ollama/qwen3')).toBe(false);
+});
+
+test.each(
+  CURRENT_STATIC_MODEL_IDS,
+)('getModelOverlay returns undefined for current catalog entry %s', (modelId) => {
+  expect(getModelOverlay(modelId)).toBeUndefined();
+});
+
+test('getModelOverlay returns undefined for normalized model variants', () => {
+  expect(getModelOverlay('openai-codex/gpt-5')).toBeUndefined();
+  expect(getModelOverlay('gpt-5:latest')).toBeUndefined();
+  expect(getModelOverlay('openai/gpt-5:latest')).toBeUndefined();
+});


### PR DESCRIPTION
## Summary

Closes #994 by adding the model overlay schema to static model metadata without wiring any runtime consumers.

## Changes

- Export `ModelOverlay` and optional `model_overlay` support on static model metadata entries.
- Add GPT-5 model-family matching plus inert skeleton predicates for future Codex and local LLM families.
- Add `getModelOverlay(modelId)` lookup that checks direct metadata first, then declared family matchers, and currently returns `undefined` for all catalog entries.
- Add focused unit coverage for schema shape, matcher normalization, and the no-overlay current catalog behavior.

## Validation

- `vitest run --configLoader runner --project unit tests/model-metadata.test.ts`
- `tsc --noEmit`
- direct TypeScript check for `tests/model-metadata.test.ts`
- `tsc --noEmit --noUnusedLocals --noUnusedParameters`
- `biome check --write src/providers/model-metadata.ts tests/model-metadata.test.ts`
- `git diff --check`
- grep confirmed no `getModelOverlay` consumer outside tests and no `model_overlay` outside `model-metadata.ts` plus tests.