### PR TITLE
[codex] Add A2A federation sender instance metadata

### DIFF
--- a/docs/content/developer-guide/identity.md
+++ b/docs/content/developer-guide/identity.md
@@ -110,6 +110,11 @@ explicit field remain valid and hydrate with compatibility
 the derived instance from `sender_agent_id`. Neither migration path rewrites
 thread state just to add the derived field.
 
+Lookup APIs that address a single persisted envelope should use the same tuple.
+`getA2AEnvelope(threadId, envelopeId)` remains valid while the ID is unique
+within a thread, but callers must pass `sender_instance_id` when a federated
+thread can contain the same envelope ID from multiple sender instances.
+
 Delegation fields are a strict overlay on the federation base:
 `source_instance_id`, `target_instance_id`, and `delegation_token` are provided
 together for delegated handoffs. `source_instance_id` must match

--- a/docs/content/developer-guide/identity.md
+++ b/docs/content/developer-guide/identity.md
@@ -93,6 +93,28 @@ Use `parseAgentIdentity()` and `formatAgentIdentity()` from
 `slugifyAgentIdentityComponent()` when deriving a canonical component from a
 display name, config value, or environment value.
 
+## A2A Envelope Federation Metadata
+
+A2A envelopes carry canonical `sender_agent_id` and `recipient_agent_id`
+values when they cross instance boundaries. The sender instance is also exposed
+as `sender_instance_id` so transport headers, idempotency checks, and audit
+queries can index it without reparsing the agent identity string. If
+`sender_instance_id` is omitted and `sender_agent_id` is canonical, envelope
+validation derives it from the embedded `instance-id`. If both are present, they
+must match.
+
+The idempotency tuple for persisted A2A envelopes is
+`(envelope.id, sender_instance_id)`. Existing local envelopes without the
+explicit field remain valid and hydrate with compatibility
+`sender_instance_id: "local"` when read. Persisted canonical sender IDs receive
+the derived instance from `sender_agent_id`. Neither migration path rewrites
+thread state just to add the derived field.
+
+Delegation fields are a strict overlay on the federation base:
+`source_instance_id`, `target_instance_id`, and `delegation_token` are provided
+together for delegated handoffs. `source_instance_id` must match
+`sender_instance_id` and the instance portion of `sender_agent_id`.
+
 ## Identity Discovery
 
 Federated peers can resolve canonical user or agent IDs through DNS-style TXT

--- a/src/a2a/envelope.ts
+++ b/src/a2a/envelope.ts
@@ -14,6 +14,7 @@ export const A2A_ENVELOPE_INTENTS = [
   'ack',
   'policy.update',
 ] as const;
+export const A2A_LOCAL_INSTANCE_ID = 'local';
 
 export type A2AEnvelopeIntent = (typeof A2A_ENVELOPE_INTENTS)[number];
 export type A2AAgentIdKind = 'local' | 'canonical';
@@ -28,6 +29,7 @@ export interface A2AEnvelope {
   id: string;
   sender_agent_id: string;
   recipient_agent_id: string;
+  sender_instance_id?: string;
   source_instance_id?: string;
   target_instance_id?: string;
   thread_id: string;
@@ -48,6 +50,7 @@ export interface A2AEnvelopeAuditSummary {
   threadId: string | null;
   senderAgentId: string | null;
   recipientAgentId: string | null;
+  senderInstanceId: string | null;
   sourceInstanceId: string | null;
   targetInstanceId: string | null;
   delegation: boolean;
@@ -81,6 +84,7 @@ const A2A_ENVELOPE_FIELDS = new Set([
   'id',
   'sender_agent_id',
   'recipient_agent_id',
+  'sender_instance_id',
   'source_instance_id',
   'target_instance_id',
   'thread_id',
@@ -230,7 +234,7 @@ function validateAgentId(
 }
 
 function validateInstanceId(
-  field: 'source_instance_id' | 'target_instance_id',
+  field: 'sender_instance_id' | 'source_instance_id' | 'target_instance_id',
   value: string | undefined,
   issues: string[],
 ): void {
@@ -253,7 +257,10 @@ function requireCanonicalAgentIdForDelegation(
 }
 
 function validateDelegationInstanceMatch(
-  instanceField: 'source_instance_id' | 'target_instance_id',
+  instanceField:
+    | 'sender_instance_id'
+    | 'source_instance_id'
+    | 'target_instance_id',
   instanceId: string | undefined,
   agentField: 'sender_agent_id' | 'recipient_agent_id',
   agentInstanceId: string | undefined,
@@ -264,6 +271,19 @@ function validateDelegationInstanceMatch(
     issues.push(
       `${instanceField} must match the instance-id portion of ${agentField}`,
     );
+  }
+}
+
+function validateMatchingInstanceIds(
+  leftField: 'sender_instance_id' | 'source_instance_id',
+  leftValue: string | undefined,
+  rightField: 'sender_instance_id' | 'source_instance_id',
+  rightValue: string | undefined,
+  issues: string[],
+): void {
+  if (leftValue === undefined || rightValue === undefined) return;
+  if (leftValue !== rightValue) {
+    issues.push(`${leftField} must match ${rightField}`);
   }
 }
 
@@ -345,6 +365,11 @@ export function validateA2AEnvelope(value: unknown): A2AEnvelope {
     'target_instance_id',
     issues,
   );
+  const rawSenderInstanceId = readOptionalTrimmedString(
+    value,
+    'sender_instance_id',
+    issues,
+  );
   const threadId = readRequiredTrimmedString(value, 'thread_id', issues);
   const parentMessageId = readOptionalTrimmedString(
     value,
@@ -369,6 +394,14 @@ export function validateA2AEnvelope(value: unknown): A2AEnvelope {
     rawTargetInstanceId === undefined
       ? undefined
       : normalizeInstanceId(rawTargetInstanceId);
+  const explicitSenderInstanceId =
+    rawSenderInstanceId === undefined
+      ? undefined
+      : normalizeInstanceId(rawSenderInstanceId);
+  const senderInstanceId =
+    explicitSenderInstanceId ??
+    senderAgent.instanceId ??
+    (senderAgent.kind === 'local' ? A2A_LOCAL_INSTANCE_ID : undefined);
 
   validateOpaqueId('id', id, issues);
   validateOpaqueId('thread_id', threadId, issues);
@@ -387,6 +420,7 @@ export function validateA2AEnvelope(value: unknown): A2AEnvelope {
   );
   validateInstanceId('source_instance_id', sourceInstanceId, issues);
   validateInstanceId('target_instance_id', targetInstanceId, issues);
+  validateInstanceId('sender_instance_id', senderInstanceId, issues);
   validateOpaqueId('delegation_token', delegationToken, issues, {
     noun: 'token',
     maxLength: DELEGATION_TOKEN_MAX_LENGTH,
@@ -400,10 +434,24 @@ export function validateA2AEnvelope(value: unknown): A2AEnvelope {
     issues,
   );
   validateDelegationInstanceMatch(
+    'sender_instance_id',
+    senderInstanceId,
+    'sender_agent_id',
+    senderAgent.instanceId,
+    issues,
+  );
+  validateDelegationInstanceMatch(
     'source_instance_id',
     sourceInstanceId,
     'sender_agent_id',
     senderAgent.instanceId,
+    issues,
+  );
+  validateMatchingInstanceIds(
+    'source_instance_id',
+    sourceInstanceId,
+    'sender_instance_id',
+    senderInstanceId,
     issues,
   );
   validateDelegationInstanceMatch(
@@ -431,6 +479,7 @@ export function validateA2AEnvelope(value: unknown): A2AEnvelope {
     content,
     created_at: createdAt,
   };
+  if (senderInstanceId) envelope.sender_instance_id = senderInstanceId;
   if (sourceInstanceId) envelope.source_instance_id = sourceInstanceId;
   if (targetInstanceId) envelope.target_instance_id = targetInstanceId;
   if (parentMessageId) envelope.parent_message_id = parentMessageId;
@@ -470,6 +519,7 @@ export function summarizeA2AEnvelopeForAudit(
     threadId: envelope.thread_id,
     senderAgentId: envelope.sender_agent_id,
     recipientAgentId: envelope.recipient_agent_id,
+    senderInstanceId: envelope.sender_instance_id ?? null,
     sourceInstanceId: envelope.source_instance_id ?? null,
     targetInstanceId: envelope.target_instance_id ?? null,
     delegation: Boolean(envelope.delegation_token),

--- a/src/a2a/envelope.ts
+++ b/src/a2a/envelope.ts
@@ -274,19 +274,6 @@ function validateDelegationInstanceMatch(
   }
 }
 
-function validateMatchingInstanceIds(
-  leftField: 'sender_instance_id' | 'source_instance_id',
-  leftValue: string | undefined,
-  rightField: 'sender_instance_id' | 'source_instance_id',
-  rightValue: string | undefined,
-  issues: string[],
-): void {
-  if (leftValue === undefined || rightValue === undefined) return;
-  if (leftValue !== rightValue) {
-    issues.push(`${leftField} must match ${rightField}`);
-  }
-}
-
 function validateDelegationFieldSet(
   sourceInstanceId: string | undefined,
   targetInstanceId: string | undefined,
@@ -401,6 +388,7 @@ export function validateA2AEnvelope(value: unknown): A2AEnvelope {
   const senderInstanceId =
     explicitSenderInstanceId ??
     senderAgent.instanceId ??
+    // Legacy local-only envelopes predate explicit federation metadata.
     (senderAgent.kind === 'local' ? A2A_LOCAL_INSTANCE_ID : undefined);
 
   validateOpaqueId('id', id, issues);
@@ -447,13 +435,13 @@ export function validateA2AEnvelope(value: unknown): A2AEnvelope {
     senderAgent.instanceId,
     issues,
   );
-  validateMatchingInstanceIds(
-    'source_instance_id',
-    sourceInstanceId,
-    'sender_instance_id',
-    senderInstanceId,
-    issues,
-  );
+  if (
+    sourceInstanceId !== undefined &&
+    senderInstanceId !== undefined &&
+    sourceInstanceId !== senderInstanceId
+  ) {
+    issues.push('source_instance_id must match sender_instance_id');
+  }
   validateDelegationInstanceMatch(
     'target_instance_id',
     targetInstanceId,

--- a/src/a2a/identity.ts
+++ b/src/a2a/identity.ts
@@ -61,10 +61,10 @@ export function resolveA2AEnvelopeAgentIds(envelope: unknown): A2AEnvelope {
   const recipientAgentId = resolveA2AAgentId(
     normalizedEnvelope.recipient_agent_id,
   );
-  return validateA2AEnvelope({
+  return {
     ...normalizedEnvelope,
     sender_agent_id: senderAgentId,
     recipient_agent_id: recipientAgentId,
     sender_instance_id: parseAgentIdentity(senderAgentId).instanceId,
-  });
+  };
 }

--- a/src/a2a/identity.ts
+++ b/src/a2a/identity.ts
@@ -2,6 +2,7 @@ import { findAgentConfig, listAgents } from '../agents/agent-registry.js';
 import { type AgentConfig, DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import {
   formatAgentIdentity,
+  parseAgentIdentity,
   resolveLocalInstanceId,
   slugifyAgentIdentityComponent,
 } from '../identity/agent-id.js';
@@ -56,11 +57,14 @@ export function resolveA2AAgentId(agentId: string): string {
 
 export function resolveA2AEnvelopeAgentIds(envelope: unknown): A2AEnvelope {
   const normalizedEnvelope = validateA2AEnvelope(envelope);
-  return {
+  const senderAgentId = resolveA2AAgentId(normalizedEnvelope.sender_agent_id);
+  const recipientAgentId = resolveA2AAgentId(
+    normalizedEnvelope.recipient_agent_id,
+  );
+  return validateA2AEnvelope({
     ...normalizedEnvelope,
-    sender_agent_id: resolveA2AAgentId(normalizedEnvelope.sender_agent_id),
-    recipient_agent_id: resolveA2AAgentId(
-      normalizedEnvelope.recipient_agent_id,
-    ),
-  };
+    sender_agent_id: senderAgentId,
+    recipient_agent_id: recipientAgentId,
+    sender_instance_id: parseAgentIdentity(senderAgentId).instanceId,
+  });
 }

--- a/src/a2a/store.ts
+++ b/src/a2a/store.ts
@@ -272,12 +272,29 @@ export function listA2AInboxEnvelopes(agentId: string): A2AEnvelope[] {
 export function getA2AEnvelope(
   threadId: string,
   envelopeId: string,
+  senderInstanceId?: string,
 ): A2AEnvelope | null {
   const normalizedEnvelopeId = normalizeEnvelopeId(envelopeId);
-  const envelope = readThreadState(threadId).envelopes.find(
+  const normalizedSenderInstanceId =
+    senderInstanceId === undefined
+      ? undefined
+      : normalizeOpaqueId(senderInstanceId, 'sender_instance_id');
+  const matches = readThreadState(threadId).envelopes.filter(
     (entry) => entry.id === normalizedEnvelopeId,
   );
-  return envelope ?? null;
+  if (normalizedSenderInstanceId !== undefined) {
+    return (
+      matches.find(
+        (entry) => entry.sender_instance_id === normalizedSenderInstanceId,
+      ) ?? null
+    );
+  }
+  if (matches.length > 1) {
+    throw new A2AEnvelopeValidationError([
+      `envelope id ${normalizedEnvelopeId} is ambiguous; provide sender_instance_id`,
+    ]);
+  }
+  return matches[0] ?? null;
 }
 
 export function saveA2AEnvelope(

--- a/src/a2a/store.ts
+++ b/src/a2a/store.ts
@@ -55,6 +55,10 @@ function normalizeEnvelopeId(envelopeId: string): string {
   return normalizeOpaqueId(envelopeId, 'id');
 }
 
+function a2aEnvelopeIdempotencyKey(envelope: A2AEnvelope): string {
+  return `${envelope.id}\u0000${envelope.sender_instance_id ?? ''}`;
+}
+
 export function a2aThreadAssetPath(threadId: string): string {
   const normalizedThreadId = normalizeThreadId(threadId);
   return path.join(
@@ -111,18 +115,21 @@ function parsePersistedThreadState(
   }
 
   const envelopes: A2AEnvelope[] = [];
-  const seenEnvelopeIds = new Set<string>();
+  const seenEnvelopeKeys = new Set<string>();
   if (Array.isArray(rawEnvelopes)) {
     rawEnvelopes.forEach((entry, index) => {
       try {
         const envelope = validateA2AEnvelope(entry);
+        const idempotencyKey = a2aEnvelopeIdempotencyKey(envelope);
         if (envelope.thread_id !== expectedThreadId) {
           issues.push(`envelopes[${index}] belongs to ${envelope.thread_id}`);
         }
-        if (seenEnvelopeIds.has(envelope.id)) {
-          issues.push(`duplicate envelope id: ${envelope.id}`);
+        if (seenEnvelopeKeys.has(idempotencyKey)) {
+          issues.push(
+            `duplicate envelope id/sender_instance_id: ${envelope.id}`,
+          );
         }
-        seenEnvelopeIds.add(envelope.id);
+        seenEnvelopeKeys.add(idempotencyKey);
         envelopes.push(envelope);
       } catch (error) {
         if (error instanceof A2AEnvelopeValidationError) {
@@ -279,7 +286,13 @@ export function saveA2AEnvelope(
 ): A2AEnvelope {
   const normalizedEnvelope = resolveA2AEnvelopeAgentIds(envelope);
   const state = readThreadState(normalizedEnvelope.thread_id);
-  if (state.envelopes.some((entry) => entry.id === normalizedEnvelope.id)) {
+  if (
+    state.envelopes.some(
+      (entry) =>
+        a2aEnvelopeIdempotencyKey(entry) ===
+        a2aEnvelopeIdempotencyKey(normalizedEnvelope),
+    )
+  ) {
     throw new A2AEnvelopeDuplicateError(
       normalizedEnvelope.id,
       normalizedEnvelope.thread_id,

--- a/src/a2a/store.ts
+++ b/src/a2a/store.ts
@@ -6,6 +6,7 @@ import {
   syncRuntimeAssetRevisionState,
 } from '../config/runtime-config-revisions.js';
 import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+import { isAgentIdentityComponent } from '../identity/agent-id.js';
 import {
   type A2AEnvelope,
   A2AEnvelopeDuplicateError,
@@ -53,6 +54,16 @@ function normalizeThreadId(threadId: string): string {
 
 function normalizeEnvelopeId(envelopeId: string): string {
   return normalizeOpaqueId(envelopeId, 'id');
+}
+
+function normalizeSenderInstanceId(senderInstanceId: string): string {
+  const normalized = senderInstanceId.trim().toLowerCase();
+  if (!isAgentIdentityComponent(normalized)) {
+    throw new A2AEnvelopeValidationError([
+      'sender_instance_id must be a canonical instance id',
+    ]);
+  }
+  return normalized;
 }
 
 function a2aEnvelopeIdempotencyKey(envelope: A2AEnvelope): string {
@@ -278,7 +289,7 @@ export function getA2AEnvelope(
   const normalizedSenderInstanceId =
     senderInstanceId === undefined
       ? undefined
-      : normalizeOpaqueId(senderInstanceId, 'sender_instance_id');
+      : normalizeSenderInstanceId(senderInstanceId);
   const matches = readThreadState(threadId).envelopes.filter(
     (entry) => entry.id === normalizedEnvelopeId,
   );

--- a/src/a2a/store.ts
+++ b/src/a2a/store.ts
@@ -280,6 +280,11 @@ export function listA2AInboxEnvelopes(agentId: string): A2AEnvelope[] {
   });
 }
 
+/**
+ * Looks up a persisted envelope by the federation idempotency tuple.
+ * Callers may omit senderInstanceId only when the envelope id is unique
+ * within the thread; ambiguous federated ids fail fast.
+ */
 export function getA2AEnvelope(
   threadId: string,
   envelopeId: string,

--- a/tests/a2a-envelope.test.ts
+++ b/tests/a2a-envelope.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import {
+  A2A_LOCAL_INSTANCE_ID,
   type A2AEnvelopeDuplicateError,
   A2AEnvelopeValidationError,
   classifyA2AAgentId,
@@ -71,7 +72,7 @@ describe('A2A envelope schema', () => {
       id: 'msg-1',
       sender_agent_id: 'researcher',
       recipient_agent_id: 'charly@benedikt@local-dev',
-      sender_instance_id: 'local',
+      sender_instance_id: A2A_LOCAL_INSTANCE_ID,
       thread_id: 'thread-1',
       parent_message_id: 'msg-0',
       intent: 'handoff',
@@ -157,7 +158,7 @@ describe('A2A envelope schema', () => {
     expect(envelope).toMatchObject({
       id: 'msg-local-1',
       sender_agent_id: 'main',
-      sender_instance_id: 'local',
+      sender_instance_id: A2A_LOCAL_INSTANCE_ID,
       recipient_agent_id: 'writer',
     });
   });
@@ -479,7 +480,7 @@ describe('A2A envelope persistence', () => {
     expect(store.listA2AThreadEnvelopes('thread-local-legacy')).toEqual([
       {
         ...legacyState.envelopes[0],
-        sender_instance_id: 'local',
+        sender_instance_id: A2A_LOCAL_INSTANCE_ID,
       },
     ]);
     expect(
@@ -641,7 +642,7 @@ describe('A2A envelope persistence', () => {
       sender_instance_id: 'peer-b',
     });
     expect(store.listA2AThreadEnvelopes('thread-1')).toHaveLength(2);
-    expect(store.getA2AEnvelope('thread-1', 'msg-1', 'peer-a')).toMatchObject({
+    expect(store.getA2AEnvelope('thread-1', 'msg-1', 'PEER-A')).toMatchObject({
       id: 'msg-1',
       sender_instance_id: 'peer-a',
       content: 'Peer A copy.',
@@ -654,6 +655,9 @@ describe('A2A envelope persistence', () => {
     expect(
       store.getA2AEnvelope('thread-1', 'msg-1', 'missing-peer'),
     ).toBeNull();
+    expect(() =>
+      store.getA2AEnvelope('thread-1', 'msg-1', 'bad instance'),
+    ).toThrow('sender_instance_id must be a canonical instance id');
     expect(() => store.getA2AEnvelope('thread-1', 'msg-1')).toThrow(
       'envelope id msg-1 is ambiguous; provide sender_instance_id',
     );

--- a/tests/a2a-envelope.test.ts
+++ b/tests/a2a-envelope.test.ts
@@ -71,6 +71,7 @@ describe('A2A envelope schema', () => {
       id: 'msg-1',
       sender_agent_id: 'researcher',
       recipient_agent_id: 'charly@benedikt@local-dev',
+      sender_instance_id: 'local',
       thread_id: 'thread-1',
       parent_message_id: 'msg-0',
       intent: 'handoff',
@@ -87,6 +88,7 @@ describe('A2A envelope schema', () => {
       id: 'msg-delegate-1',
       sender_agent_id: 'Researcher@Team-A@Inst-Source',
       recipient_agent_id: 'Writer@Team-B@Inst-Target',
+      sender_instance_id: ' Inst-Source ',
       source_instance_id: ' Inst-Source ',
       target_instance_id: ' Inst-Target ',
       thread_id: 'thread-delegate',
@@ -100,6 +102,7 @@ describe('A2A envelope schema', () => {
       id: 'msg-delegate-1',
       sender_agent_id: 'researcher@team-a@inst-source',
       recipient_agent_id: 'writer@team-b@inst-target',
+      sender_instance_id: 'inst-source',
       source_instance_id: 'inst-source',
       target_instance_id: 'inst-target',
       thread_id: 'thread-delegate',
@@ -114,9 +117,48 @@ describe('A2A envelope schema', () => {
       threadId: 'thread-delegate',
       senderAgentId: 'researcher@team-a@inst-source',
       recipientAgentId: 'writer@team-b@inst-target',
+      senderInstanceId: 'inst-source',
       sourceInstanceId: 'inst-source',
       targetInstanceId: 'inst-target',
       delegation: true,
+    });
+  });
+
+  test('derives sender_instance_id from canonical sender ids', () => {
+    const envelope = validateA2AEnvelope({
+      id: 'msg-federated-1',
+      sender_agent_id: 'Remote@Team@Peer-Instance',
+      recipient_agent_id: 'main',
+      thread_id: 'thread-federated',
+      intent: 'chat',
+      content: 'Federated hello.',
+      created_at: '2026-04-28T10:00:00.000Z',
+    });
+
+    expect(envelope).toMatchObject({
+      id: 'msg-federated-1',
+      sender_agent_id: 'remote@team@peer-instance',
+      sender_instance_id: 'peer-instance',
+      recipient_agent_id: 'main',
+    });
+  });
+
+  test('derives sender_instance_id for local compatibility envelopes', () => {
+    const envelope = validateA2AEnvelope({
+      id: 'msg-local-1',
+      sender_agent_id: 'main',
+      recipient_agent_id: 'writer',
+      thread_id: 'thread-local',
+      intent: 'chat',
+      content: 'Local compatibility hello.',
+      created_at: '2026-04-28T10:00:00.000Z',
+    });
+
+    expect(envelope).toMatchObject({
+      id: 'msg-local-1',
+      sender_agent_id: 'main',
+      sender_instance_id: 'local',
+      recipient_agent_id: 'writer',
     });
   });
 
@@ -203,6 +245,22 @@ describe('A2A envelope schema', () => {
       ]),
     );
 
+    const mismatchedSenderInstance = expectEnvelopeValidationIssues({
+      id: 'msg-federation-mismatch',
+      sender_agent_id: 'researcher@team@inst-source',
+      recipient_agent_id: 'writer@team@inst-target',
+      sender_instance_id: 'inst-other',
+      thread_id: 'thread-delegate',
+      intent: 'chat',
+      content: 'Bad federation metadata.',
+      created_at: '2026-04-28T10:00:00.000Z',
+    });
+    expect(mismatchedSenderInstance.issues).toEqual(
+      expect.arrayContaining([
+        'sender_instance_id must match the instance-id portion of sender_agent_id',
+      ]),
+    );
+
     const oversizedToken = expectEnvelopeValidationIssues({
       id: 'msg-delegate-oversized-token',
       sender_agent_id: 'researcher@team@inst-source',
@@ -274,9 +332,11 @@ describe('A2A envelope persistence', () => {
     const resolvedFirst = {
       ...first,
       sender_agent_id: 'main@benedikt@local-dev',
+      sender_instance_id: 'local-dev',
     };
     const resolvedSecond = {
       ...second,
+      sender_instance_id: 'local-dev',
       recipient_agent_id: 'main@benedikt@local-dev',
     };
 
@@ -333,6 +393,98 @@ describe('A2A envelope persistence', () => {
       thread_id: 'thread-1',
       envelopes: [resolvedFirst],
     });
+  });
+
+  test('hydrates sender_instance_id from legacy canonical persisted envelopes without rewriting state', async () => {
+    const store = await import('../src/a2a/store.ts');
+    const revisions = await import('../src/config/runtime-config-revisions.ts');
+    const legacyState = {
+      version: 1,
+      thread_id: 'thread-legacy',
+      envelopes: [
+        {
+          id: 'msg-legacy',
+          sender_agent_id: 'remote@team@peer-instance',
+          recipient_agent_id: 'main',
+          thread_id: 'thread-legacy',
+          intent: 'chat',
+          content: 'Legacy persisted message.',
+          created_at: '2026-04-28T10:00:00.000Z',
+        },
+      ],
+    };
+    const assetPath = store.a2aThreadAssetPath('thread-legacy');
+    const legacyContent = JSON.stringify(legacyState);
+
+    revisions.syncRuntimeAssetRevisionState(
+      'a2a',
+      assetPath,
+      {
+        actor: 'test',
+        route: 'test.a2a.legacy',
+        source: 'internal',
+      },
+      {
+        exists: true,
+        content: legacyContent,
+      },
+    );
+
+    expect(store.listA2AThreadEnvelopes('thread-legacy')).toEqual([
+      {
+        ...legacyState.envelopes[0],
+        sender_instance_id: 'peer-instance',
+      },
+    ]);
+    expect(
+      revisions.getRuntimeAssetRevisionState('a2a', assetPath)?.content,
+    ).toBe(legacyContent);
+  });
+
+  test('hydrates sender_instance_id from legacy local persisted envelopes without rewriting state', async () => {
+    const store = await import('../src/a2a/store.ts');
+    const revisions = await import('../src/config/runtime-config-revisions.ts');
+    const legacyState = {
+      version: 1,
+      thread_id: 'thread-local-legacy',
+      envelopes: [
+        {
+          id: 'msg-local-legacy',
+          sender_agent_id: 'main',
+          recipient_agent_id: 'writer',
+          thread_id: 'thread-local-legacy',
+          intent: 'chat',
+          content: 'Legacy local persisted message.',
+          created_at: '2026-04-28T10:00:00.000Z',
+        },
+      ],
+    };
+    const assetPath = store.a2aThreadAssetPath('thread-local-legacy');
+    const legacyContent = JSON.stringify(legacyState);
+
+    revisions.syncRuntimeAssetRevisionState(
+      'a2a',
+      assetPath,
+      {
+        actor: 'test',
+        route: 'test.a2a.legacy-local',
+        source: 'internal',
+      },
+      {
+        exists: true,
+        content: legacyContent,
+      },
+    );
+
+    expect(store.listA2AThreadEnvelopes('thread-local-legacy')).toEqual([
+      {
+        ...legacyState.envelopes[0],
+        sender_instance_id: 'local',
+      },
+    ]);
+    expect(
+      revisions.getRuntimeAssetRevisionState('a2a', assetPath)?.content,
+    ).toBe(legacyContent);
   });
 
   test('rejects unknown local agent ids without default-agent fallback', async () => {
@@ -455,5 +607,39 @@ describe('A2A envelope persistence', () => {
       return;
     }
     throw new Error('Expected duplicate envelope save to fail.');
+  });
+
+  test('allows the same envelope id from different sender instances', async () => {
+    const store = await import('../src/a2a/store.ts');
+    const envelopeMod = await import('../src/a2a/envelope.ts');
+
+    const first = envelopeMod.validateA2AEnvelope({
+      id: 'msg-1',
+      sender_agent_id: 'agent@team@peer-a',
+      recipient_agent_id: 'main',
+      thread_id: 'thread-1',
+      intent: 'chat',
+      content: 'Peer A copy.',
+      created_at: '2026-04-28T10:00:00.000Z',
+    });
+    const second = envelopeMod.validateA2AEnvelope({
+      id: 'msg-1',
+      sender_agent_id: 'agent@team@peer-b',
+      recipient_agent_id: 'main',
+      thread_id: 'thread-1',
+      intent: 'chat',
+      content: 'Peer B copy.',
+      created_at: '2026-04-28T10:01:00.000Z',
+    });
+
+    expect(store.saveA2AEnvelope(first)).toMatchObject({
+      id: 'msg-1',
+      sender_instance_id: 'peer-a',
+    });
+    expect(store.saveA2AEnvelope(second)).toMatchObject({
+      id: 'msg-1',
+      sender_instance_id: 'peer-b',
+    });
+    expect(store.listA2AThreadEnvelopes('thread-1')).toHaveLength(2);
   });
 });

--- a/tests/a2a-envelope.test.ts
+++ b/tests/a2a-envelope.test.ts
@@ -641,5 +641,21 @@ describe('A2A envelope persistence', () => {
       sender_instance_id: 'peer-b',
     });
     expect(store.listA2AThreadEnvelopes('thread-1')).toHaveLength(2);
+    expect(store.getA2AEnvelope('thread-1', 'msg-1', 'peer-a')).toMatchObject({
+      id: 'msg-1',
+      sender_instance_id: 'peer-a',
+      content: 'Peer A copy.',
+    });
+    expect(store.getA2AEnvelope('thread-1', 'msg-1', 'peer-b')).toMatchObject({
+      id: 'msg-1',
+      sender_instance_id: 'peer-b',
+      content: 'Peer B copy.',
+    });
+    expect(
+      store.getA2AEnvelope('thread-1', 'msg-1', 'missing-peer'),
+    ).toBeNull();
+    expect(() => store.getA2AEnvelope('thread-1', 'msg-1')).toThrow(
+      'envelope id msg-1 is ambiguous; provide sender_instance_id',
+    );
   });
 });

--- a/tests/a2a-outbound.integration.test.ts
+++ b/tests/a2a-outbound.integration.test.ts
@@ -53,6 +53,7 @@ describe('A2A outbound integration', () => {
       id: 'msg-int-a2a',
       sender_agent_id: 'main',
       recipient_agent_id: 'remote@team@peer-instance',
+      sender_instance_id: 'local',
       thread_id: 'thread-int-a2a',
       intent: 'chat',
       content: 'Peer should decode this.',

--- a/tests/a2a-outbound.test.ts
+++ b/tests/a2a-outbound.test.ts
@@ -14,6 +14,7 @@ function sampleA2AEnvelope(id: string, intent: 'chat' | 'handoff' = 'chat') {
     id,
     sender_agent_id: 'main',
     recipient_agent_id: 'remote@team@peer-instance',
+    sender_instance_id: 'local',
     thread_id: 'thread-a2a',
     intent,
     content: `A2A payload ${id}`,

--- a/tests/a2a-runtime.integration.test.ts
+++ b/tests/a2a-runtime.integration.test.ts
@@ -110,6 +110,7 @@ describe('A2A runtime API', () => {
     const deliveredEnvelope = {
       id: 'msg-1',
       sender_agent_id: 'stub-a@team@local-dev',
+      sender_instance_id: 'local-dev',
       recipient_agent_id: 'stub-b@team@local-dev',
       thread_id: 'thread-1',
       intent: 'handoff',

--- a/tests/a2a-webhook-outbound.test.ts
+++ b/tests/a2a-webhook-outbound.test.ts
@@ -82,11 +82,12 @@ describe('A2A webhook outbound adapter', () => {
       intent: 'chat',
       recipient_agent_id: 'remote@team@peer-instance',
       sender_agent_id: 'main',
+      sender_instance_id: 'local',
       thread_id: 'thread-webhook',
       version: '1',
     });
     expect(receivedBodies[0]).toBe(
-      '{"content":"Webhook payload msg-webhook-1","created_at":"2026-05-01T10:00:00.000Z","id":"msg-webhook-1","intent":"chat","recipient_agent_id":"remote@team@peer-instance","sender_agent_id":"main","thread_id":"thread-webhook","version":"1"}',
+      '{"content":"Webhook payload msg-webhook-1","created_at":"2026-05-01T10:00:00.000Z","id":"msg-webhook-1","intent":"chat","recipient_agent_id":"remote@team@peer-instance","sender_agent_id":"main","sender_instance_id":"local","thread_id":"thread-webhook","version":"1"}',
     );
     expect(
       webhook.verifyWebhookSignature({


### PR DESCRIPTION
## Summary

Closes #719 by making `sender_instance_id` an explicit A2A federation metadata field. Envelope validation now derives the field from canonical sender agent IDs, hydrates legacy local envelopes with the compatibility `local` instance ID, and rejects mismatches between explicit instance metadata and the embedded sender agent instance.

## Details

- Adds `sender_instance_id` to the A2A envelope schema and audit summary.
- Keeps delegation as a strict overlay on the federation base by requiring `source_instance_id` to match `sender_instance_id` and the sender agent identity instance.
- Changes persisted duplicate detection to use `(envelope.id, sender_instance_id)`.
- Preserves compatibility for existing persisted envelopes by deriving the field on read without rewriting thread state.
- Documents the federation/idempotency/migration strategy in the identity developer guide.

## Validation

- `npx biome check --write src/a2a/envelope.ts src/a2a/identity.ts src/a2a/store.ts tests/a2a-envelope.test.ts tests/a2a-runtime.integration.test.ts tests/a2a-outbound.test.ts tests/a2a-webhook-outbound.test.ts tests/a2a-outbound.integration.test.ts docs/content/developer-guide/identity.md`
- `npx tsc --noEmit --noUnusedLocals --noUnusedParameters`
- `npx vitest run tests/a2a-*.test.ts tests/gateway-service.a2a-inbox.test.ts`