### PR TITLE
[codex] Fix pnpm install blocked by Baileys libsignal Git dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@opentelemetry/resources": "2.6.1",
         "@opentelemetry/sdk-node": "0.214.0",
         "@slack/bolt": "4.7.0",
-        "@whiskeysockets/baileys": "7.0.0-rc.9",
+        "@whiskeysockets/baileys": "7.0.0-rc11",
         "ajv": "8.18.0",
         "better-sqlite3": "12.8.0",
         "botbuilder": "4.23.3",
@@ -4282,9 +4282,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -4310,9 +4310,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -4328,9 +4328,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@puppeteer/browsers": {
@@ -5637,12 +5637,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
-      "license": "MIT"
-    },
     "node_modules/@types/mailparser": {
       "version": "3.4.6",
       "resolved": "https://registry.npmjs.org/@types/mailparser/-/mailparser-3.4.6.tgz",
@@ -6155,21 +6149,22 @@
       }
     },
     "node_modules/@whiskeysockets/baileys": {
-      "version": "7.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@whiskeysockets/baileys/-/baileys-7.0.0-rc.9.tgz",
-      "integrity": "sha512-YFm5gKXfDP9byCXCW3OPHKXLzrAKzolzgVUlRosHHgwbnf2YOO3XknkMm6J7+F0ns8OA0uuSBhgkRHTDtqkacw==",
+      "version": "7.0.0-rc11",
+      "resolved": "https://registry.npmjs.org/@whiskeysockets/baileys/-/baileys-7.0.0-rc11.tgz",
+      "integrity": "sha512-4FKCVZR8mGz7oy6aRJgcBdM5t1CjzzDOedfccphwJao5BAy6RKCTTDbjyOaJejCkYDwjkEADpZBRmKDxvGmoUQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@cacheable/node-cache": "^1.4.0",
         "@hapi/boom": "^9.1.3",
         "async-mutex": "^0.5.0",
-        "libsignal": "git+https://github.com/whiskeysockets/libsignal-node.git",
+        "libsignal": "^6.0.0",
         "lru-cache": "^11.1.0",
-        "music-metadata": "^11.7.0",
+        "music-metadata": "^11.12.3",
         "p-queue": "^9.0.0",
         "pino": "^9.6",
-        "protobufjs": "^7.2.4",
+        "protobufjs": "^7.5.6",
+        "whatsapp-rust-bridge": "0.5.4",
         "ws": "^8.13.0"
       },
       "engines": {
@@ -6177,7 +6172,7 @@
       },
       "peerDependencies": {
         "audio-decode": "^2.1.3",
-        "jimp": "^1.6.0",
+        "jimp": "^1.6.1",
         "link-preview-js": "^3.0.0",
         "sharp": "*"
       },
@@ -11845,51 +11840,13 @@
       "license": "MIT"
     },
     "node_modules/libsignal": {
-      "name": "@whiskeysockets/libsignal-node",
-      "version": "2.0.1",
-      "resolved": "git+ssh://git@github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/libsignal/-/libsignal-6.0.0.tgz",
+      "integrity": "sha512-d/5V3YFtDljbFMufz4ncyUYGYhJl+vzAe+c2EFFBQ6bz1h8Q3IOMEGXYMzlibU60I+e8GagMMpji18iez3P1hA==",
       "license": "GPL-3.0",
       "dependencies": {
         "curve25519-js": "^0.0.4",
-        "protobufjs": "6.8.8"
-      }
-    },
-    "node_modules/libsignal/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-      "license": "MIT"
-    },
-    "node_modules/libsignal/node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/libsignal/node_modules/protobufjs": {
-      "version": "6.8.8",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
-      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
+        "protobufjs": "^7.5.5"
       }
     },
     "node_modules/lie": {
@@ -11944,7 +11901,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -11966,7 +11922,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -11988,7 +11943,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12010,7 +11964,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12032,7 +11985,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12054,7 +12006,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12076,7 +12027,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12098,7 +12048,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12120,7 +12069,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12142,7 +12090,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12164,7 +12111,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14057,22 +14003,22 @@
       "license": "ISC"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },
@@ -16908,6 +16854,12 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatsapp-rust-bridge": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.5.4.tgz",
+      "integrity": "sha512-yYO1qSs0Fe7tGtnxOFHomocUD6IZtoAgmA4oDFyGIRZ67D3QZk3w7swA6XXFXNQngiyrg2k7tul6IrM3eUFh7A==",
+      "license": "MIT"
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "test:integration": "vitest run --configLoader runner --project integration --passWithNoTests",
     "test:e2e": "vitest run --configLoader runner --project e2e --passWithNoTests",
     "test:console": "npm --workspace console run test",
-    "audit:signatures": "npm audit signatures && npm --prefix container audit signatures",
+    "audit:signatures": "npm --min-release-age=0 audit signatures && npm --prefix container audit signatures",
     "deps:update-lockfile": "npm update --package-lock-only && npm --prefix container update --package-lock-only",
     "deps:verify": "npm ci --no-audit --fund=false && npm --prefix container ci --no-audit --fund=false && npm run audit:signatures",
     "eval:trace-judge:gate": "HYBRIDCLAW_DATA_DIR=/tmp/hybridclaw-trace-judge-gate HYBRIDCLAW_DISABLE_CONFIG_WATCHER=1 node -e \"import('./dist/evals/trace-judge-native.js').then((m)=>m.runTraceJudgeNativeGate()).catch((err)=>{console.error(err);process.exitCode=1})\"",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "test:integration": "vitest run --configLoader runner --project integration --passWithNoTests",
     "test:e2e": "vitest run --configLoader runner --project e2e --passWithNoTests",
     "test:console": "npm --workspace console run test",
-    "audit:signatures": "npm --min-release-age=0 audit signatures && npm --prefix container audit signatures",
+    "audit:signatures": "node ./scripts/audit-signatures.mjs && npm --prefix container audit signatures",
     "deps:update-lockfile": "npm update --package-lock-only && npm --prefix container update --package-lock-only",
     "deps:verify": "npm ci --no-audit --fund=false && npm --prefix container ci --no-audit --fund=false && npm run audit:signatures",
     "eval:trace-judge:gate": "HYBRIDCLAW_DATA_DIR=/tmp/hybridclaw-trace-judge-gate HYBRIDCLAW_DISABLE_CONFIG_WATCHER=1 node -e \"import('./dist/evals/trace-judge-native.js').then((m)=>m.runTraceJudgeNativeGate()).catch((err)=>{console.error(err);process.exitCode=1})\"",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@slack/bolt": "4.7.0",
     "@huggingface/transformers": "3.8.1",
     "@ngrok/ngrok": "1.5.2",
-    "@whiskeysockets/baileys": "7.0.0-rc.9",
+    "@whiskeysockets/baileys": "7.0.0-rc11",
     "ajv": "8.18.0",
     "better-sqlite3": "12.8.0",
     "botbuilder": "4.23.3",

--- a/scripts/audit-signatures.mjs
+++ b/scripts/audit-signatures.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+
+const BAILEYS_RC11_MIN_RELEASE_AGE_EXPIRES_AT = Date.parse(
+  '2026-05-20T08:35:12.000Z',
+);
+
+const args = [];
+
+// Baileys 7.0.0-rc11 was published on 2026-05-13T08:35:11Z. Until npm's
+// seven-day age gate expires, signature audit needs the same resolver bypass
+// as install-time CI. After that date, use the repo-wide .npmrc policy again.
+if (Date.now() < BAILEYS_RC11_MIN_RELEASE_AGE_EXPIRES_AT) {
+  args.push('--min-release-age=0');
+}
+
+args.push('audit', 'signatures');
+
+const result = spawnSync('npm', args, {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    NPM_CONFIG_CACHE:
+      process.env.NPM_CONFIG_CACHE || '/tmp/hybridclaw-npm-cache',
+  },
+});
+
+process.exit(result.status ?? 1);

--- a/tests/npm-install.e2e.test.ts
+++ b/tests/npm-install.e2e.test.ts
@@ -65,11 +65,14 @@ describe.skipIf(!NPM_E2E)('npm install user journey', () => {
     }
     const tarball = path.join(tempDir, tarballName);
 
-    execSync(`npm install -g "${tarball}" --prefix "${npmPrefix()}"`, {
-      encoding: 'utf-8',
-      timeout: 120_000,
-      env: { ...process.env, HOME: tempDir },
-    });
+    execSync(
+      `npm --min-release-age=0 install -g "${tarball}" --prefix "${npmPrefix()}"`,
+      {
+        encoding: 'utf-8',
+        timeout: 120_000,
+        env: { ...process.env, HOME: tempDir },
+      },
+    );
 
     fs.writeFileSync(
       path.join(dataDir(), 'config.json'),

--- a/tests/npm-install.e2e.test.ts
+++ b/tests/npm-install.e2e.test.ts
@@ -18,6 +18,9 @@ import {
 const NPM_E2E = process.env.HYBRIDCLAW_RUN_NPM_E2E === '1';
 const STARTUP_TIMEOUT_MS = 30_000;
 const REQUEST_TIMEOUT_MS = 5_000;
+const BAILEYS_RC11_MIN_RELEASE_AGE_EXPIRES_AT = Date.parse(
+  '2026-05-20T08:35:12.000Z',
+);
 
 let tempDir: string;
 let gatewayProcess: ChildProcess | null = null;
@@ -44,6 +47,35 @@ function installedCliPath(): string {
   );
 }
 
+function npmMinReleaseAgeArg(): string {
+  // Baileys 7.0.0-rc11 was published on 2026-05-13T08:35:11Z. The bypass is
+  // only needed until npm's seven-day age gate can see that pinned version.
+  return Date.now() < BAILEYS_RC11_MIN_RELEASE_AGE_EXPIRES_AT
+    ? '--min-release-age=0 '
+    : '';
+}
+
+function verifyPnpmInstallBlocksExoticSubdeps(tarball: string): void {
+  const pnpmHome = path.join(tempDir, 'pnpm-home');
+  const pnpmGlobalDir = path.join(tempDir, 'pnpm-global');
+  fs.mkdirSync(pnpmHome, { recursive: true });
+  fs.mkdirSync(pnpmGlobalDir, { recursive: true });
+
+  execSync(
+    `npx --yes pnpm@10.23.0 add -g "${tarball}" --config.block-exotic-subdeps=true --global-dir "${pnpmGlobalDir}" --dir "${tempDir}"`,
+    {
+      encoding: 'utf-8',
+      timeout: 120_000,
+      env: {
+        ...process.env,
+        HOME: tempDir,
+        PATH: `${pnpmHome}${path.delimiter}${process.env.PATH ?? ''}`,
+        PNPM_HOME: pnpmHome,
+      },
+    },
+  );
+}
+
 describe.skipIf(!NPM_E2E)('npm install user journey', () => {
   beforeAll(async () => {
     HOST_PORT = await getAvailablePort(9198);
@@ -65,8 +97,10 @@ describe.skipIf(!NPM_E2E)('npm install user journey', () => {
     }
     const tarball = path.join(tempDir, tarballName);
 
+    verifyPnpmInstallBlocksExoticSubdeps(tarball);
+
     execSync(
-      `npm --min-release-age=0 install -g "${tarball}" --prefix "${npmPrefix()}"`,
+      `npm ${npmMinReleaseAgeArg()}install -g "${tarball}" --prefix "${npmPrefix()}"`,
       {
         encoding: 'utf-8',
         timeout: 120_000,


### PR DESCRIPTION
## Summary

- Bump `@whiskeysockets/baileys` from `7.0.0-rc.9` to `7.0.0-rc11`.
- Refresh `package-lock.json` so Baileys resolves `libsignal` from the npm registry as `libsignal@6.0.0` instead of `git+https://github.com/whiskeysockets/libsignal-node.git`.
- Keep normal npm dependency installs under the repo's `.npmrc` `min-release-age=7` policy.
- Use a self-expiring `--min-release-age=0` bypass only for the fresh Baileys RC signature audit / tarball e2e paths, ending after `2026-05-20T08:35:12Z`.
- Add automated pnpm coverage for `block-exotic-subdeps=true` against the packed HybridClaw tarball.
- Rebase onto current `main`, preserving the already-merged #1011 `impit@0.13.0` / pnpm postinstall fix in the base.

## Root Cause

`@whiskeysockets/baileys@7.0.0-rc.9` declared `libsignal` as a Git dependency. pnpm blocks exotic subdependencies by default, so `pnpm add -g @hybridaione/hybridclaw` failed with `ERR_PNPM_EXOTIC_SUBDEP` for consumers.

The CI failure after the dependency bump came from npm's `min-release-age=7` policy: the newly published but intentionally pinned `@whiskeysockets/baileys@7.0.0-rc11` was invisible to `npm audit signatures` and to the local tarball install e2e until it aged past the seven-day resolver gate.

## Impact

The next published HybridClaw package will resolve the WhatsApp/Baileys dependency tree from npm registry packages without requiring consumers to disable pnpm's exotic subdependency protection. CI still verifies registry signatures for the locked dependency graph, and ordinary npm installs keep the default seven-day release-age gate.

Fixes #984.

## Follow-up Notes

- `@whiskeysockets/baileys@7.0.0-rc11` is still an RC; #1016 tracks replacing it with a stable registry-`libsignal` release when one is available and compatible.
- Baileys rc11 introduces transitive `whatsapp-rust-bridge@0.5.4`; #1016 tracks consumer install reports for native/WASM bridge packaging issues.
- npm metadata for `whatsapp-rust-bridge@0.5.4` does not declare an install lifecycle script; Baileys itself remains the package with install-time scripts.

## Validation

- `npm_config_cache=/private/tmp/hybridclaw-npm-cache npm run audit:signatures`
- `npm run build`
- `npm run lint`
- `npx vitest run --configLoader runner --project unit tests/postinstall-container.test.ts`
- `npx vitest run --configLoader runner --project unit tests/whatsapp.runtime.test.ts tests/whatsapp.inbound.test.ts`
- `HYBRIDCLAW_RUN_NPM_E2E=1 npm_config_cache=/private/tmp/hybridclaw-npm-cache npx vitest run --project e2e tests/npm-install.e2e.test.ts`
- `npx biome check package.json scripts/audit-signatures.mjs tests/npm-install.e2e.test.ts`
- `git diff --check`
- Verified no Git-resolved `libsignal` remains in `package.json` or `package-lock.json`.
- Verified the npm e2e now includes `pnpm add -g <packed HybridClaw tarball> --config.block-exotic-subdeps=true`.