### PR TITLE
[codex] Fix global package manager installs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "docx": "9.6.1",
         "iconv-lite": "0.7.2",
         "imapflow": "1.2.18",
+        "impit": "0.13.0",
         "mailparser": "3.9.6",
         "marked": "17.0.4",
         "node-pty": "1.1.0",
@@ -10945,29 +10946,28 @@
       "license": "MIT"
     },
     "node_modules/impit": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/impit/-/impit-0.13.1.tgz",
-      "integrity": "sha512-nlqkHwotE4OCngPhkgLKPc+CiUSVbpFVfdDr/jWISalB9Mzf9Frw18pJ98rr73G94tEPnkL8Chx9skR11ogguw==",
-      "hasInstallScript": true,
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/impit/-/impit-0.13.0.tgz",
+      "integrity": "sha512-usW4/VjIPbs8js01DShcYmYnL/7p4k/Bm73Wrwh18qyiYJ6AKJaS6npN7YBxIzkBEgJYMg9aqUC1lKtFsnT2rw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "impit-darwin-arm64": "0.13.1",
-        "impit-darwin-x64": "0.13.1",
-        "impit-linux-arm64-gnu": "0.13.1",
-        "impit-linux-arm64-musl": "0.13.1",
-        "impit-linux-x64-gnu": "0.13.1",
-        "impit-linux-x64-musl": "0.13.1",
-        "impit-win32-arm64-msvc": "0.13.1",
-        "impit-win32-x64-msvc": "0.13.1"
+        "impit-darwin-arm64": "0.13.0",
+        "impit-darwin-x64": "0.13.0",
+        "impit-linux-arm64-gnu": "0.13.0",
+        "impit-linux-arm64-musl": "0.13.0",
+        "impit-linux-x64-gnu": "0.13.0",
+        "impit-linux-x64-musl": "0.13.0",
+        "impit-win32-arm64-msvc": "0.13.0",
+        "impit-win32-x64-msvc": "0.13.0"
       }
     },
     "node_modules/impit-darwin-arm64": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/impit-darwin-arm64/-/impit-darwin-arm64-0.13.1.tgz",
-      "integrity": "sha512-ZjIbzorKMe5uwEfryFE5GUNpFXlJPlTslLvO67f8rmt48nWu1JDJdSdnEhvselEgyD6Y1tXwYWFFATMWeOX6zQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/impit-darwin-arm64/-/impit-darwin-arm64-0.13.0.tgz",
+      "integrity": "sha512-th0HuWJzbfrUiU+BRi03aYXGWm+uo1o3OzWaXAr8mFPwmqOhs58IkqH0xRlP0RnsFq8wt/4g5WbE0sQH3i1zBg==",
       "cpu": [
         "arm64"
       ],
@@ -10981,9 +10981,9 @@
       }
     },
     "node_modules/impit-darwin-x64": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/impit-darwin-x64/-/impit-darwin-x64-0.13.1.tgz",
-      "integrity": "sha512-2NY+2nH+qcU4sSGbb4J9MS5CS3lDZYiVRrQXC+1uXAG6cGQuMSsfbf/VVxhMlW8F2bk7vdpKaaUJRQOJT8gyFQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/impit-darwin-x64/-/impit-darwin-x64-0.13.0.tgz",
+      "integrity": "sha512-EOZnUICnhwIlKuYrHU3M1ezhqK9+vLzYyPfAg0x+KAdfu0NRttHuqXij8UULuYQVFC+JQi0FFkmTovTHNxYHTg==",
       "cpu": [
         "x64"
       ],
@@ -10997,9 +10997,9 @@
       }
     },
     "node_modules/impit-linux-arm64-gnu": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/impit-linux-arm64-gnu/-/impit-linux-arm64-gnu-0.13.1.tgz",
-      "integrity": "sha512-druR0r2yu9pi26ErMdIE95pnJ+6GO0DKdHfifzr1acE+xKAHYMin4nW65bXLpIVLSLZSBMz+L7lP4vEZ1msC5Q==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/impit-linux-arm64-gnu/-/impit-linux-arm64-gnu-0.13.0.tgz",
+      "integrity": "sha512-CW7JRoBGSKhfN7wt+XtYD1mst1Z6P0w7IooUO31nIbGz9iOwjidULi1K8GusmUqNVQOA9h69IjRd0xQrLNz2Qw==",
       "cpu": [
         "arm64"
       ],
@@ -11013,9 +11013,9 @@
       }
     },
     "node_modules/impit-linux-arm64-musl": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/impit-linux-arm64-musl/-/impit-linux-arm64-musl-0.13.1.tgz",
-      "integrity": "sha512-k1YA4szvgTvNnNPrqcqPCRzx7OxCal/jrAnUl06VBI3bsGvLklib1maIRp6lDSbge12k7h0DKVQmtyihPt2GDg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/impit-linux-arm64-musl/-/impit-linux-arm64-musl-0.13.0.tgz",
+      "integrity": "sha512-9xotzDECmGtRwsUChjApo/v8+oslQwdg65rk1ti5yOhCTenGq3zMzErjZkome7OiOGFamJdhyg6RUxvmFtgvFA==",
       "cpu": [
         "arm64"
       ],
@@ -11029,9 +11029,9 @@
       }
     },
     "node_modules/impit-linux-x64-gnu": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/impit-linux-x64-gnu/-/impit-linux-x64-gnu-0.13.1.tgz",
-      "integrity": "sha512-DUy/dZxDd5L9XQVL0pUrILQLtj4eMfExnpdZyQE2qSIe1pmqTndUyJW4UmjRfBkxBHY/sbQGcs0KYRbOWYsIrQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/impit-linux-x64-gnu/-/impit-linux-x64-gnu-0.13.0.tgz",
+      "integrity": "sha512-Melcw+hbzGPYxSHLwPRLF9LjKmvzgvnq86qNocwxrEsgtunccehn/Xf4b9I+TJg4KSFnMfZq9OsjrQg5bRK14A==",
       "cpu": [
         "x64"
       ],
@@ -11045,9 +11045,9 @@
       }
     },
     "node_modules/impit-linux-x64-musl": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/impit-linux-x64-musl/-/impit-linux-x64-musl-0.13.1.tgz",
-      "integrity": "sha512-qoCFYpH1HzPgt5LyPKGxdexwlhuf85/CWYZ35UNjE5TILT8qHW7szHt7CZ2EzDIRS0jkOxL4iZS7AxhFtv7c3g==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/impit-linux-x64-musl/-/impit-linux-x64-musl-0.13.0.tgz",
+      "integrity": "sha512-MSK+REPpWGjRbtEO94nL1uI9JSzq6E43VpfHerGXC5IO6E9xFBMKDeAOHjTEAQBbsaqpWDOBCfEjoaeUvRkmqQ==",
       "cpu": [
         "x64"
       ],
@@ -11061,9 +11061,9 @@
       }
     },
     "node_modules/impit-win32-arm64-msvc": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/impit-win32-arm64-msvc/-/impit-win32-arm64-msvc-0.13.1.tgz",
-      "integrity": "sha512-w0Y4Rssf9KOAyqtExtFD+He7aG1KPYRw4U0VktZyguDtZHCETbl/ODuddvh3GP4aToRZTpkBuMsDKSogggQbMA==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/impit-win32-arm64-msvc/-/impit-win32-arm64-msvc-0.13.0.tgz",
+      "integrity": "sha512-xTyhKcprmjfdp6nFF1Jn8gZ3Ig1CpwYpDzpGiTs0gPYz8NIt1qUwnKT7MFErOn47jSblPdYJeanbxFbelAlcyw==",
       "cpu": [
         "arm64"
       ],
@@ -11077,9 +11077,9 @@
       }
     },
     "node_modules/impit-win32-x64-msvc": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/impit-win32-x64-msvc/-/impit-win32-x64-msvc-0.13.1.tgz",
-      "integrity": "sha512-MAfYan7e+OK0JI70aHc2Qz92O4EaMXAsI1awQcwN0hGIFgbhf8z3q/XIbyy6h67aV1+L8DZYoITxvHoba1CEhg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/impit-win32-x64-msvc/-/impit-win32-x64-msvc-0.13.0.tgz",
+      "integrity": "sha512-q/WFS05LhLnYeQr9fV7skVlpHd2ei1QGOtCSIGiFtOWGXGNJ8/9j4k8ehUBV3GrwYEKyflygKQ7cZNeobZ5hUQ==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "docx": "9.6.1",
     "iconv-lite": "0.7.2",
     "imapflow": "1.2.18",
+    "impit": "0.13.0",
     "mailparser": "3.9.6",
     "marked": "17.0.4",
     "node-pty": "1.1.0",

--- a/scripts/postinstall-container.mjs
+++ b/scripts/postinstall-container.mjs
@@ -94,6 +94,10 @@ export function inspectContainerBootstrap(packageRoot) {
 
 export function resolveNpmCommand(containerDir, env = process.env) {
   const npmExecPath = String(env.npm_execpath || '').trim();
+  const npmUserAgent = String(env.npm_config_user_agent || '').toLowerCase();
+  const npmExecName = path.basename(npmExecPath).toLowerCase();
+  const invokedByPnpm =
+    npmUserAgent.startsWith('pnpm/') || npmExecName.includes('pnpm');
   const installArgs = [
     '--prefix',
     containerDir,
@@ -103,6 +107,7 @@ export function resolveNpmCommand(containerDir, env = process.env) {
   ];
 
   if (
+    !invokedByPnpm &&
     npmExecPath &&
     path.isAbsolute(npmExecPath) &&
     fs.existsSync(npmExecPath)
@@ -125,6 +130,7 @@ export function buildBootstrapEnv(env = process.env) {
   delete nextEnv.npm_config_global;
   delete nextEnv.npm_config_local_prefix;
   delete nextEnv.npm_config_prefix;
+  delete nextEnv.npm_config_user_agent;
   delete nextEnv.npm_execpath;
   delete nextEnv.npm_lifecycle_event;
   delete nextEnv.npm_lifecycle_script;

--- a/tests/postinstall-container.test.ts
+++ b/tests/postinstall-container.test.ts
@@ -84,12 +84,36 @@ test('prefers npm_execpath when npm exposes it during install', () => {
   expect(
     resolveNpmCommand('/tmp/hybridclaw-container', {
       ...process.env,
+      npm_config_user_agent: 'npm/11.10.0 node/v22.15.1 darwin arm64',
       npm_execpath: npmCliPath,
     }),
   ).toEqual({
     command: process.execPath,
     args: [
       npmCliPath,
+      '--prefix',
+      '/tmp/hybridclaw-container',
+      'install',
+      '--omit=dev',
+      '--workspaces=false',
+    ],
+  });
+});
+
+test('falls back to npm when installed through pnpm', () => {
+  const packageRoot = makeTempDir();
+  const pnpmCliPath = path.join(packageRoot, 'pnpm.cjs');
+  fs.writeFileSync(pnpmCliPath, '', 'utf-8');
+
+  expect(
+    resolveNpmCommand('/tmp/hybridclaw-container', {
+      ...process.env,
+      npm_config_user_agent: 'pnpm/11.1.1 npm/? node/v22.15.1 linux x64',
+      npm_execpath: pnpmCliPath,
+    }),
+  ).toEqual({
+    command: 'npm',
+    args: [
       '--prefix',
       '/tmp/hybridclaw-container',
       'install',
@@ -106,6 +130,7 @@ test('scrubs outer npm lifecycle variables before bootstrapping container deps',
       npm_config_cache: '/tmp/npm-cache',
       npm_config_global: 'true',
       npm_config_prefix: '/tmp/global-prefix',
+      npm_config_user_agent: 'pnpm/11.1.1 npm/? node/v22.15.1 linux x64',
       npm_execpath: '/tmp/npm-cli.js',
       npm_lifecycle_event: 'postinstall',
       npm_lifecycle_script: 'node ./scripts/postinstall-container.mjs',
@@ -169,6 +194,7 @@ process.exit(0);
       env: {
         ...process.env,
         npm_config_global: 'true',
+        npm_config_user_agent: 'npm/11.10.0 node/v22.15.1 darwin arm64',
         npm_lifecycle_event: 'postinstall',
         npm_lifecycle_script: 'node ./scripts/postinstall-container.mjs',
         npm_package_name: '@hybridaione/hybridclaw',


### PR DESCRIPTION
## Summary

Fixes global install failures for HybridClaw when users update through npm or install through pnpm.

## Root Cause

Two install paths were failing independently:

- npm installs resolved `camoufox-js -> impit@0.13.1`, whose published `preinstall` runs `npx only-allow pnpm` and fails before HybridClaw's own postinstall can run.
- pnpm installs reached `scripts/postinstall-container.mjs`, which reused the outer pnpm executable while passing npm-only install flags.

## Changes

- Add a direct `impit@0.13.0` production pin so `camoufox-js@0.10.2` dedupes to the preinstall-free version while keeping Camofox installed.
- Detect pnpm-launched postinstall runs and force the nested container dependency install through npm, preserving `container/package-lock.json` as the source of truth.
- Scrub the outer package-manager user agent before bootstrapping container dependencies.
- Add test coverage for pnpm command resolution in the postinstall container bootstrap.

## Validation

- `npx vitest run --configLoader runner --project unit tests/postinstall-container.test.ts`
- `npx biome check package.json scripts/postinstall-container.mjs tests/postinstall-container.test.ts`
- `git diff --check`
- Temporary npm resolution check confirmed `camoufox-js@0.10.2` dedupes to `impit@0.13.0`.