### PR TITLE
[codex] Lazy load Teams Bot Framework modules

### DIFF
--- a/src/channels/message/tool-actions.ts
+++ b/src/channels/message/tool-actions.ts
@@ -18,7 +18,6 @@ import {
 import type { DiscordToolActionRequest } from '../discord/tool-actions.js';
 import { isEmailAddress, normalizeEmailAddress } from '../email/allowlist.js';
 import { sendEmailAttachmentTo, sendToEmail } from '../email/runtime.js';
-import { maybeRunMSTeamsToolAction } from '../msteams/tool-actions.js';
 import { sendToSignalChat } from '../signal/runtime.js';
 import { normalizeSignalChannelId } from '../signal/target.js';
 import { maybeRunSlackToolAction } from '../slack/tool-actions.js';
@@ -53,6 +52,8 @@ const MESSAGE_TOOL_EMAIL_SESSION_PREFIX = 'email:';
 const MESSAGE_TOOL_EMAIL_PREFIX_RE = /^email:/i;
 const MESSAGE_TOOL_SIGNAL_PREFIX_RE = /^signal:/i;
 const MESSAGE_TOOL_SLACK_WEBHOOK_PREFIX_RE = /^slack[_-]?webhook(?::|$)/i;
+const MESSAGE_TOOL_TEAMS_CURRENT_PREFIX_RE = /^(?:msteams|teams):current$/i;
+const MESSAGE_TOOL_TEAMS_SESSION_PREFIX_RE = /^teams:/i;
 const MESSAGE_TOOL_TELEGRAM_PREFIX_RE = /^(telegram|tg):/i;
 const MESSAGE_TOOL_THREEMA_PREFIX_RE = /^threema:/i;
 const MESSAGE_TOOL_WHATSAPP_PREFIX_RE = /^whatsapp:/i;
@@ -163,6 +164,31 @@ function normalizeEmailMessageTarget(rawTarget: string): string | null {
     .replace(MESSAGE_TOOL_EMAIL_PREFIX_RE, '')
     .trim();
   return normalizeEmailAddress(withoutPrefix);
+}
+
+function normalizeMessageToolValue(rawValue: string | undefined): string {
+  return String(rawValue || '').trim();
+}
+
+function looksLikeMSTeamsConversationId(value: string): boolean {
+  return /^(?:a:|19:)/.test(normalizeMessageToolValue(value));
+}
+
+function isLikelyMSTeamsToolRequest(
+  request: DiscordToolActionRequest,
+): boolean {
+  const sessionId = normalizeMessageToolValue(request.sessionId);
+  if (MESSAGE_TOOL_TEAMS_SESSION_PREFIX_RE.test(sessionId)) {
+    return true;
+  }
+
+  const channelId = normalizeMessageToolValue(request.channelId);
+  if (!channelId) return false;
+  return (
+    MESSAGE_TOOL_TEAMS_CURRENT_PREFIX_RE.test(channelId) ||
+    MESSAGE_TOOL_TEAMS_SESSION_PREFIX_RE.test(channelId) ||
+    looksLikeMSTeamsConversationId(channelId)
+  );
 }
 
 function isDiscordSessionId(value: string | undefined): boolean {
@@ -655,11 +681,16 @@ async function runLocalMessageSendAction(
 export async function runMessageToolAction(
   request: DiscordToolActionRequest,
 ): Promise<Record<string, unknown>> {
-  const teamsResult = await maybeRunMSTeamsToolAction(request, {
-    resolveSendFilePath: resolveMessageToolSendFilePath,
-  });
-  if (teamsResult) {
-    return teamsResult;
+  if (isLikelyMSTeamsToolRequest(request)) {
+    const { maybeRunMSTeamsToolAction } = await import(
+      '../msteams/tool-actions.js'
+    );
+    const teamsResult = await maybeRunMSTeamsToolAction(request, {
+      resolveSendFilePath: resolveMessageToolSendFilePath,
+    });
+    if (teamsResult) {
+      return teamsResult;
+    }
   }
 
   const slackResult = await maybeRunSlackToolAction(request, {

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -25,7 +25,6 @@ import {
 import { normalizeEmailAddress } from '../channels/email/allowlist.js';
 import { handleIMessageWebhook } from '../channels/imessage/runtime.js';
 import { runMessageToolAction } from '../channels/message/tool-actions.js';
-import { handleMSTeamsWebhook } from '../channels/msteams/runtime.js';
 import {
   getSignalLinkState,
   startSignalLink,
@@ -4544,7 +4543,12 @@ export function startGatewayHttpServer(): GatewayHttpServer {
 
     if (pathname.startsWith('/api/')) {
       if (pathname === MSTEAMS_WEBHOOK_PATH && method === 'POST') {
-        dispatchWebhookRoute(res, () => handleMSTeamsWebhook(req, res));
+        dispatchWebhookRoute(res, async () => {
+          const { handleMSTeamsWebhook } = await import(
+            '../channels/msteams/runtime.js'
+          );
+          await handleMSTeamsWebhook(req, res);
+        });
         return;
       }
       if (pathname === IMESSAGE_WEBHOOK_PATH && method === 'POST') {

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -53,8 +53,6 @@ import {
   sendToIMessageChat,
   shutdownIMessage,
 } from '../channels/imessage/runtime.js';
-import { buildTeamsArtifactAttachments } from '../channels/msteams/attachments.js';
-import { initMSTeams } from '../channels/msteams/runtime.js';
 import {
   initSignal,
   type SignalReplyFn,
@@ -1483,6 +1481,7 @@ async function startMSTeamsIntegration(): Promise<boolean> {
     );
   }
 
+  const { initMSTeams } = await import('../channels/msteams/runtime.js');
   initMSTeams(
     async (
       sessionId,
@@ -1599,9 +1598,16 @@ async function startMSTeamsIntegration(): Promise<boolean> {
         }
 
         let attachments:
-          | Awaited<ReturnType<typeof buildTeamsArtifactAttachments>>
+          | Awaited<
+              ReturnType<
+                typeof import('../channels/msteams/attachments.js')['buildTeamsArtifactAttachments']
+              >
+            >
           | undefined;
         try {
+          const { buildTeamsArtifactAttachments } = await import(
+            '../channels/msteams/attachments.js'
+          );
           attachments = await buildTeamsArtifactAttachments({
             turnContext: context.turnContext,
             artifacts,

--- a/tests/gateway-main.test.ts
+++ b/tests/gateway-main.test.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
 import { describe, expect, test, vi } from 'vitest';
 import { useCleanMocks, useTempDir } from './test-utils.ts';
 
@@ -8,6 +9,7 @@ const makeTempDir = useTempDir();
 async function settle(): Promise<void> {
   await new Promise((resolve) => setImmediate(resolve));
   await new Promise((resolve) => setImmediate(resolve));
+  await delay(0);
 }
 
 function expectInfoLog(
@@ -665,7 +667,17 @@ async function importFreshGatewayMain(options?: {
   }));
 
   await import('../src/gateway/gateway.ts');
-  await settle();
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    await settle();
+    if (
+      options?.skipBootstrapHandlerCheck ||
+      (state.commandHandler &&
+        state.messageHandler &&
+        state.configChangeListener)
+    ) {
+      break;
+    }
+  }
 
   if (
     !options?.skipBootstrapHandlerCheck &&
@@ -673,7 +685,19 @@ async function importFreshGatewayMain(options?: {
       !state.messageHandler ||
       !state.configChangeListener)
   ) {
-    throw new Error('Gateway bootstrap did not capture handlers.');
+    throw new Error(
+      `Gateway bootstrap did not capture handlers: command=${Boolean(
+        state.commandHandler,
+      )}, message=${Boolean(state.messageHandler)}, config=${Boolean(
+        state.configChangeListener,
+      )}, teamsInit=${state.initMSTeams.mock.calls.length}, signalInit=${
+        state.initSignal.mock.calls.length
+      }, whatsappInit=${state.initWhatsApp.mock.calls.length}, errors=${state.loggerError.mock.calls
+        .map((call) => String(call[1] ?? call[0]))
+        .join('|')}, fatals=${state.loggerFatal.mock.calls
+        .map((call) => String(call[1] ?? call[0]))
+        .join('|')}.`,
+    );
   }
 
   return state;


### PR DESCRIPTION
## Summary

This fixes the startup-time DEP0040 `punycode` warning when Microsoft Teams is configured but not active.

Root cause: gateway startup eagerly imported Teams/Bot Framework modules through the Teams webhook route, Teams artifact handling, and generic message tool routing. Bot Framework brings in `node-fetch@2`, which loads `whatwg-url@5` and the deprecated Node `punycode` module during module initialization.

## Changes

- Lazy-load Teams runtime and attachment helpers only when Teams starts or handles a Teams webhook.
- Lazy-load Teams message tool actions only for Teams-shaped requests (`teams:` sessions, `teams:current`, or Bot Framework conversation IDs).
- Update the gateway bootstrap test helper so it waits correctly across dynamic import scheduling.

## Validation

- `npx biome check --write src/channels/message/tool-actions.ts src/gateway/gateway.ts src/gateway/gateway-http-server.ts tests/gateway-main.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `npm run build` with Node 22
- `./node_modules/.bin/vitest run tests/message.tool-actions-send.test.ts`
- `./node_modules/.bin/vitest run tests/gateway-main.test.ts`
- Isolated gateway startup with `NODE_OPTIONS="--require /tmp/hybridclaw-trace-punycode.cjs --trace-deprecation"` verified no `punycode`/Bot Framework trace and no `[DEP0040]` warning when Teams is configured but inactive.