### PR TITLE
[codex] Enable deleting chat sessions

### DIFF
--- a/console/src/components/icons/Trash.tsx
+++ b/console/src/components/icons/Trash.tsx
@@ -1,0 +1,13 @@
+import { Icon, type IconProps } from './base';
+
+export function Trash(props: IconProps) {
+  return (
+    <Icon strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M3 6h18" />
+      <path d="M8 6V4h8v2" />
+      <path d="M19 6l-1 14H6L5 6" />
+      <path d="M10 11v5" />
+      <path d="M14 11v5" />
+    </Icon>
+  );
+}

--- a/console/src/components/icons/index.ts
+++ b/console/src/components/icons/index.ts
@@ -32,3 +32,4 @@ export { SquarePen } from './SquarePen';
 export { Statistics } from './Statistics';
 export { Terminal } from './Terminal';
 export { Tools } from './Tools';
+export { Trash } from './Trash';

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -149,6 +149,19 @@
   padding: 0;
 }
 
+.sessionItemRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 30px;
+  align-items: center;
+  border-radius: var(--radius-sm);
+  transition: background 0.12s;
+}
+
+.sessionItemRow:hover,
+.sessionItemRow:focus-within {
+  background: var(--chat-hover-bg);
+}
+
 .sessionItem {
   appearance: none;
   width: 100%;
@@ -160,15 +173,11 @@
   padding: 8px 10px;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: background 0.12s;
   overflow: hidden;
   text-align: left;
   font: inherit;
   color: inherit;
-}
-
-.sessionItem:hover {
-  background: var(--chat-hover-bg);
+  min-width: 0;
 }
 
 .sessionItemPending {
@@ -210,6 +219,55 @@
 .sessionItemActive .sessionTitle,
 .sessionItemActive .sessionSnippet {
   color: var(--primary);
+}
+
+.sessionDeleteButton {
+  appearance: none;
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--muted-foreground);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    background 120ms ease,
+    color 120ms ease,
+    opacity 120ms ease;
+}
+
+.sessionItemRow:hover .sessionDeleteButton,
+.sessionItemRow:focus-within .sessionDeleteButton {
+  opacity: 1;
+}
+
+.sessionDeleteButton:hover,
+.sessionDeleteButton:focus-visible {
+  background: var(--danger-soft);
+  color: var(--danger);
+  opacity: 1;
+}
+
+.sessionDeleteButton:disabled {
+  cursor: wait;
+  opacity: 0.5;
+}
+
+.sessionDeleteIcon {
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: currentColor;
+}
+
+@media (hover: none) {
+  .sessionDeleteButton {
+    opacity: 1;
+  }
 }
 
 .sidebarSearchWrap {

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -29,6 +29,7 @@ import type {
   AdminCommandResult,
   AdminModelsResponse,
   AgentListItem,
+  DeleteSessionResult,
   GatewayStatus,
 } from '../../api/types';
 import { SidebarProvider } from '../../components/sidebar/index';
@@ -50,6 +51,8 @@ const fetchChatHistoryMock =
   vi.fn<(token: string, sessionId: string) => Promise<ChatHistoryResponse>>();
 const fetchChatContextMock =
   vi.fn<(token: string, sessionId: string) => Promise<ChatContextResponse>>();
+const deleteChatSessionMock =
+  vi.fn<(token: string, sessionId: string) => Promise<DeleteSessionResult>>();
 const createChatMobileQrMock =
   vi.fn<
     (
@@ -118,6 +121,8 @@ vi.mock('../../api/chat', () => ({
 }));
 
 vi.mock('../../api/client', () => ({
+  deleteSession: (token: string, sessionId: string) =>
+    deleteChatSessionMock(token, sessionId),
   fetchAgentList: (token: string) => fetchAgentListMock(token),
   fetchModels: (token: string) => fetchModelsMock(token),
 }));
@@ -222,6 +227,7 @@ describe('ChatPage', () => {
     fetchChatRecentMock.mockReset();
     fetchChatHistoryMock.mockReset();
     fetchChatContextMock.mockReset();
+    deleteChatSessionMock.mockReset();
     createChatMobileQrMock.mockReset();
     createChatBranchMock.mockReset();
     uploadMediaMock.mockReset();
@@ -293,6 +299,17 @@ describe('ChatPage', () => {
     fetchChatContextMock.mockResolvedValue({
       sessionId: 'session-a',
       snapshot: null,
+    });
+    deleteChatSessionMock.mockResolvedValue({
+      deleted: true,
+      sessionId: 'session-b',
+      deletedMessages: 3,
+      deletedTasks: 0,
+      deletedSemanticMemories: 0,
+      deletedUsageEvents: 0,
+      deletedAuditEntries: 0,
+      deletedStructuredAuditEntries: 0,
+      deletedApprovalEntries: 0,
     });
     executeCommandMock.mockResolvedValue({
       kind: 'plain',
@@ -808,6 +825,142 @@ describe('ChatPage', () => {
 
     expect(screen.getByText('Opened session A')).not.toBeNull();
     expect(fetchChatHistoryMock.mock.calls.length).toBe(callsBefore);
+  });
+
+  it('deletes a recent session from the sidebar after confirmation', async () => {
+    fetchChatHistoryMock.mockResolvedValue({
+      sessionId: 'session-a',
+      history: [{ id: 101, role: 'assistant', content: 'Opened session A' }],
+    });
+
+    renderChatPage();
+
+    expect(await screen.findByText('Opened session A')).not.toBeNull();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Delete Session B session' }),
+    );
+    expect(await screen.findByText('Delete session?')).not.toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() =>
+      expect(deleteChatSessionMock).toHaveBeenCalledWith(
+        'test-token',
+        'session-b',
+      ),
+    );
+    await waitFor(() => expect(fetchChatRecentMock).toHaveBeenCalledTimes(2));
+    expect(screen.getByText('Opened session A')).not.toBeNull();
+  });
+
+  it('keeps the delete dialog open when the session was not deleted', async () => {
+    fetchChatHistoryMock.mockResolvedValue({
+      sessionId: 'session-a',
+      history: [{ id: 101, role: 'assistant', content: 'Opened session A' }],
+    });
+    deleteChatSessionMock.mockResolvedValue({
+      deleted: false,
+      sessionId: 'session-b',
+      deletedMessages: 0,
+      deletedTasks: 0,
+      deletedSemanticMemories: 0,
+      deletedUsageEvents: 0,
+      deletedAuditEntries: 0,
+      deletedStructuredAuditEntries: 0,
+      deletedApprovalEntries: 0,
+    });
+
+    renderChatPage();
+
+    expect(await screen.findByText('Opened session A')).not.toBeNull();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Delete Session B session' }),
+    );
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete' }));
+
+    expect(
+      await screen.findByText('Delete failed: session was not found.'),
+    ).not.toBeNull();
+    expect(screen.getByText('Delete session?')).not.toBeNull();
+    expect(fetchChatRecentMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables session delete buttons while deletion is pending', async () => {
+    fetchChatHistoryMock.mockResolvedValue({
+      sessionId: 'session-a',
+      history: [{ id: 101, role: 'assistant', content: 'Opened session A' }],
+    });
+    deleteChatSessionMock.mockImplementation(
+      () => new Promise<DeleteSessionResult>(() => {}),
+    );
+
+    renderChatPage();
+
+    expect(await screen.findByText('Opened session A')).not.toBeNull();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Delete Session B session' }),
+    );
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete' }));
+
+    await waitFor(() =>
+      expect(
+        (
+          screen.getByRole('button', {
+            name: 'Delete Session A session',
+          }) as HTMLButtonElement
+        ).disabled,
+      ).toBe(true),
+    );
+    expect(
+      (
+        screen.getByRole('button', {
+          name: 'Delete Session B session',
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+  });
+
+  it('starts a fresh chat after deleting the active recent session', async () => {
+    const routerModule = (await import(
+      '@tanstack/react-router'
+    )) as unknown as {
+      __testRouter: TestRouter;
+    };
+    fetchChatHistoryMock.mockResolvedValue({
+      sessionId: 'session-a',
+      history: [{ id: 101, role: 'assistant', content: 'Opened session A' }],
+    });
+    deleteChatSessionMock.mockResolvedValue({
+      deleted: true,
+      sessionId: 'session-a',
+      deletedMessages: 2,
+      deletedTasks: 0,
+      deletedSemanticMemories: 0,
+      deletedUsageEvents: 0,
+      deletedAuditEntries: 0,
+      deletedStructuredAuditEntries: 0,
+      deletedApprovalEntries: 0,
+    });
+
+    renderChatPage();
+
+    expect(await screen.findByText('Opened session A')).not.toBeNull();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Delete Session A session' }),
+    );
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete' }));
+
+    await waitFor(() =>
+      expect(deleteChatSessionMock).toHaveBeenCalledWith(
+        'test-token',
+        'session-a',
+      ),
+    );
+    await waitFor(() => expect(routerModule.__testRouter.lastTo).toBe('/chat'));
   });
 
   it('renders the jump-to-latest chip when scrolled away and clears it on click', async () => {

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   createChatBranch,
@@ -13,11 +13,25 @@ import type {
   BranchVariant,
   ChatMessage,
   ChatMobileQrResponse,
+  ChatRecentSession,
   MediaItem,
 } from '../../api/chat-types';
-import { fetchAgentList, fetchModels } from '../../api/client';
+import {
+  deleteSession as deleteChatSession,
+  fetchAgentList,
+  fetchModels,
+} from '../../api/client';
 import type { ChatModel } from '../../api/types';
 import { isAuthReadyForApi, useAuth } from '../../auth';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../../components/dialog';
 import { MobileTopbarTrigger } from '../../components/sidebar/index';
 import { ViewSwitchNav } from '../../components/view-switch';
 import {
@@ -92,6 +106,10 @@ function chatRecentQueryPrefix(token: string, userId: string) {
   return ['chat-recent', token, userId] as const;
 }
 
+function chatContextQueryKey(token: string, sessionId: string) {
+  return ['chat-context', token, sessionId] as const;
+}
+
 export function ChatPage() {
   const auth = useAuth();
   const queryClient = useQueryClient();
@@ -106,6 +124,8 @@ export function ChatPage() {
   const [selectedModelId, setSelectedModelId] = useState('');
   const [recentChatScope, setRecentChatScope] =
     useState<RecentChatScope>('user');
+  const [sessionPendingDelete, setSessionPendingDelete] =
+    useState<ChatRecentSession | null>(null);
 
   const [sessionSearchQuery, setSessionSearchQuery] = useState('');
   const debouncedSessionSearchQuery = useDebouncedValue(
@@ -292,7 +312,7 @@ export function ChatPage() {
   });
 
   const contextQuery = useQuery({
-    queryKey: ['chat-context', auth.token, sessionId],
+    queryKey: chatContextQueryKey(auth.token, sessionId),
     queryFn: () => fetchChatContext(auth.token, sessionId),
     enabled: chatApiReady && Boolean(sessionId),
     staleTime: 15_000,
@@ -302,6 +322,39 @@ export function ChatPage() {
   const messages = historyQuery.data?.messages ?? EMPTY_MESSAGES;
   const branchFamilies =
     historyQuery.data?.branchFamilies ?? EMPTY_BRANCH_FAMILIES;
+
+  const deleteSessionMutation = useMutation({
+    mutationFn: (targetSessionId: string) =>
+      deleteChatSession(auth.token, targetSessionId),
+    onSuccess: (data) => {
+      if (!data.deleted) {
+        setError('Delete failed: session was not found.');
+        return;
+      }
+      const deletedSessionId = data.sessionId;
+      queryClient.removeQueries({
+        queryKey: chatHistoryQueryKey(auth.token, deletedSessionId),
+      });
+      queryClient.removeQueries({
+        queryKey: chatContextQueryKey(auth.token, deletedSessionId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: chatRecentQueryPrefix(auth.token, userId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ['overview'],
+        refetchType: 'none',
+      });
+      setSessionPendingDelete(null);
+      const currentSessionId = getSessionId();
+      if (deletedSessionId === currentSessionId) {
+        startFreshChat();
+      }
+    },
+    onError: (err) => {
+      setError(`Delete failed: ${getErrorMessage(err)}`);
+    },
+  });
 
   // Forward fetch errors inline rather than throwing to the page-level error
   // boundary — a failed background refetch (invalidated after each stream)
@@ -375,7 +428,7 @@ export function ChatPage() {
   useEffect(() => {
     if (wasStreamingRef.current && !stream.isStreaming && sessionId) {
       void queryClient.invalidateQueries({
-        queryKey: ['chat-context', auth.token, sessionId],
+        queryKey: chatContextQueryKey(auth.token, sessionId),
       });
     }
     wasStreamingRef.current = stream.isStreaming;
@@ -563,7 +616,7 @@ export function ChatPage() {
           await switchToSession(resolvedSessionId, { replace: true });
         }
         void queryClient.invalidateQueries({
-          queryKey: ['chat-context', auth.token, resolvedSessionId],
+          queryKey: chatContextQueryKey(auth.token, resolvedSessionId),
         });
         refreshRecent();
         onAccepted(value);
@@ -617,6 +670,30 @@ export function ChatPage() {
     },
     [stream.isActive, navigateToSession],
   );
+
+  const canDeleteSession = useCallback(() => {
+    if (stream.isActive()) {
+      setError('Stop the current run before deleting a chat.');
+      return false;
+    }
+    return !deleteSessionMutation.isPending;
+  }, [deleteSessionMutation.isPending, stream.isActive]);
+
+  const handleRequestDeleteSession = useCallback(
+    (target: ChatRecentSession) => {
+      if (!canDeleteSession()) return;
+      setSessionPendingDelete(target);
+    },
+    [canDeleteSession],
+  );
+
+  const handleConfirmDeleteSession = useCallback(() => {
+    if (!sessionPendingDelete) {
+      throw new Error('Delete confirmation is missing a session.');
+    }
+    if (!canDeleteSession()) return;
+    deleteSessionMutation.mutate(sessionPendingDelete.sessionId);
+  }, [canDeleteSession, deleteSessionMutation, sessionPendingDelete]);
 
   const handleHoverSession = useCallback(
     (targetId: string) => {
@@ -701,6 +778,8 @@ export function ChatPage() {
     onNewChat: handleNewChat,
     onOpenSession: handleOpenSession,
     onHoverSession: handleHoverSession,
+    onRequestDeleteSession: handleRequestDeleteSession,
+    deleteDisabled: deleteSessionMutation.isPending,
     isPending: isSwitchingSession,
     searchQuery: sessionSearchQuery,
     onSearchQueryChange: setSessionSearchQuery,
@@ -840,6 +919,44 @@ export function ChatPage() {
             onModelSwitch={(modelId) => void handleModelSwitch(modelId)}
           />
         </div>
+        <Dialog
+          open={sessionPendingDelete !== null}
+          onOpenChange={(open) => {
+            if (!open && !deleteSessionMutation.isPending) {
+              setSessionPendingDelete(null);
+            }
+          }}
+        >
+          <DialogContent
+            size="sm"
+            role="alertdialog"
+            preventCloseOnOutsideClick={deleteSessionMutation.isPending}
+          >
+            <DialogHeader>
+              <DialogTitle>Delete session?</DialogTitle>
+              <DialogDescription>
+                This permanently removes the conversation and associated session
+                records.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <DialogClose
+                className="ghost-button"
+                disabled={deleteSessionMutation.isPending}
+              >
+                Cancel
+              </DialogClose>
+              <button
+                type="button"
+                className="danger-button"
+                disabled={deleteSessionMutation.isPending}
+                onClick={handleConfirmDeleteSession}
+              >
+                {deleteSessionMutation.isPending ? 'Deleting...' : 'Delete'}
+              </button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
     </ChatSidebarProvider>
   );

--- a/console/src/routes/chat/chat-sidebar.tsx
+++ b/console/src/routes/chat/chat-sidebar.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import type { ChatRecentSession } from '../../api/chat-types';
 import { useAuth } from '../../auth';
+import { Trash } from '../../components/icons';
 import {
   SidebarBrand,
   SidebarMeta,
@@ -27,6 +28,8 @@ export interface ChatSidebarProps {
   onNewChat: () => void;
   onOpenSession: (sessionId: string) => void;
   onHoverSession?: (sessionId: string) => void;
+  onRequestDeleteSession: (session: ChatRecentSession) => void;
+  deleteDisabled?: boolean;
   isPending?: boolean;
   searchQuery: string;
   onSearchQueryChange: (value: string) => void;
@@ -121,32 +124,46 @@ function ChatSessionList(props: ChatSidebarProps & { isSearching: boolean }) {
         <ul className={css.sessionList} aria-live="polite">
           {props.sessions.map((s) => (
             <li key={s.sessionId}>
-              <button
-                type="button"
-                className={cx(
-                  css.sessionItem,
-                  s.sessionId === props.activeSessionId &&
-                    css.sessionItemActive,
-                  s.sessionId === props.activeSessionId &&
-                    props.isPending &&
-                    css.sessionItemPending,
-                )}
-                aria-current={
-                  s.sessionId === props.activeSessionId ? 'page' : undefined
-                }
-                onMouseEnter={() => props.onHoverSession?.(s.sessionId)}
-                onClick={() => props.onOpenSession(s.sessionId)}
-              >
-                <span className={css.sessionTitle}>
-                  {s.title || 'Untitled'}
-                </span>
-                {s.searchSnippet ? (
-                  <span className={css.sessionSnippet}>{s.searchSnippet}</span>
-                ) : null}
-                <span className={css.sessionTime}>
-                  {formatRelativeTime(s.lastActive)}
-                </span>
-              </button>
+              <div className={css.sessionItemRow}>
+                <button
+                  type="button"
+                  className={cx(
+                    css.sessionItem,
+                    s.sessionId === props.activeSessionId &&
+                      css.sessionItemActive,
+                    s.sessionId === props.activeSessionId &&
+                      props.isPending &&
+                      css.sessionItemPending,
+                  )}
+                  aria-current={
+                    s.sessionId === props.activeSessionId ? 'page' : undefined
+                  }
+                  onMouseEnter={() => props.onHoverSession?.(s.sessionId)}
+                  onClick={() => props.onOpenSession(s.sessionId)}
+                >
+                  <span className={css.sessionTitle}>
+                    {s.title || 'Untitled'}
+                  </span>
+                  {s.searchSnippet ? (
+                    <span className={css.sessionSnippet}>
+                      {s.searchSnippet}
+                    </span>
+                  ) : null}
+                  <span className={css.sessionTime}>
+                    {formatRelativeTime(s.lastActive)}
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  className={css.sessionDeleteButton}
+                  aria-label={`Delete ${s.title || 'Untitled'} session`}
+                  title="Delete session"
+                  disabled={props.deleteDisabled}
+                  onClick={() => props.onRequestDeleteSession(s)}
+                >
+                  <Trash className={css.sessionDeleteIcon} />
+                </button>
+              </div>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary
- Adds a chat API wrapper for the existing session deletion endpoint.
- Adds a delete control to recent chat rows with a confirmation dialog.
- Clears cached session history/context and returns to a fresh chat when the active session is deleted.
- Covers inactive and active session deletion flows in chat page tests.

## Validation
- `npx biome check console/src/api/chat.ts console/src/routes/chat/chat-page.tsx console/src/routes/chat/chat-sidebar.tsx console/src/routes/chat/chat-page.module.css console/src/routes/chat/chat-page.test.tsx`
- `npm --workspace console run typecheck`
- `npx vitest run --config vitest.config.ts src/routes/chat/chat-page.test.tsx`