### PR TITLE
[codex] Refresh local web token automatically

### DIFF
--- a/console/src/api/client.test.ts
+++ b/console/src/api/client.test.ts
@@ -2,13 +2,89 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   AUTH_REQUIRED_EVENT,
   buildWebCommandRequestBody,
+  dispatchAuthRequired,
+  isLoopbackHostnameForTest,
+  readStoredToken,
+  setAuthReloadHandlerForTest,
   setRuntimeSecret,
+  TOKEN_STORAGE_KEY,
   unblockSkill,
   uploadSkillZip,
 } from './client';
 
+function ensureLocalStorage() {
+  if (typeof globalThis.localStorage?.clear === 'function') return;
+  const store = new Map<string, string>();
+  const storage = {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, String(value));
+    },
+  } satisfies Storage;
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: storage,
+    configurable: true,
+  });
+  Object.defineProperty(window, 'localStorage', {
+    value: storage,
+    configurable: true,
+  });
+}
+
+function ensureSessionStorage() {
+  if (typeof globalThis.sessionStorage?.clear === 'function') return;
+  const store = new Map<string, string>();
+  const storage = {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, String(value));
+    },
+  } satisfies Storage;
+  Object.defineProperty(globalThis, 'sessionStorage', {
+    value: storage,
+    configurable: true,
+  });
+  Object.defineProperty(window, 'sessionStorage', {
+    value: storage,
+    configurable: true,
+  });
+}
+
 describe('client command helpers', () => {
   beforeEach(() => {
+    ensureLocalStorage();
+    ensureSessionStorage();
+    localStorage.clear();
+    sessionStorage.clear();
+    window.history.replaceState(null, '', '/');
     vi.stubGlobal('fetch', vi.fn());
   });
 
@@ -44,6 +120,75 @@ describe('client command helpers', () => {
       userId: 'web-user-1',
       username: 'web',
     });
+  });
+
+  it('removes the local token bootstrap marker after reading stored auth', () => {
+    window.localStorage.clear();
+    window.localStorage.setItem(TOKEN_STORAGE_KEY, 'stored-token');
+    window.history.pushState(
+      null,
+      '',
+      '/admin?__hybridclaw_token_bootstrapped=1&view=models#top',
+    );
+
+    expect(readStoredToken()).toBe('stored-token');
+    expect(window.location.pathname).toBe('/admin');
+    expect(window.location.search).toBe('?view=models');
+    expect(window.location.hash).toBe('#top');
+  });
+
+  it('reloads local chat surfaces instead of prompting when auth expires', () => {
+    const reload = vi.fn();
+    const restoreReload = setAuthReloadHandlerForTest(reload);
+    const events: CustomEvent[] = [];
+    const listener = (event: Event) => {
+      events.push(event as CustomEvent);
+    };
+    window.addEventListener(AUTH_REQUIRED_EVENT, listener);
+    window.localStorage.setItem(TOKEN_STORAGE_KEY, 'stale-token');
+    window.history.pushState(null, '', '/chat/sess_20260514_135843_6136cbbb');
+
+    dispatchAuthRequired('Unauthorized.');
+
+    expect(window.localStorage.getItem(TOKEN_STORAGE_KEY)).toBeNull();
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(events).toHaveLength(0);
+
+    window.removeEventListener(AUTH_REQUIRED_EVENT, listener);
+    restoreReload();
+  });
+
+  it('matches the server 127/8 loopback hostname range', () => {
+    expect(isLoopbackHostnameForTest('127.0.0.1')).toBe(true);
+    expect(isLoopbackHostnameForTest('127.12.34.56')).toBe(true);
+    expect(isLoopbackHostnameForTest('localhost')).toBe(true);
+    expect(isLoopbackHostnameForTest('example.com')).toBe(false);
+  });
+
+  it('prompts instead of repeatedly reloading local auth failures', () => {
+    const reload = vi.fn();
+    const restoreReload = setAuthReloadHandlerForTest(reload);
+    const events: CustomEvent[] = [];
+    const listener = (event: Event) => {
+      events.push(event as CustomEvent);
+    };
+    window.addEventListener(AUTH_REQUIRED_EVENT, listener);
+    window.history.pushState(null, '', '/admin');
+    window.sessionStorage.setItem(
+      'hybridclaw_local_auth_reload_at',
+      String(Date.now()),
+    );
+
+    dispatchAuthRequired('Unauthorized.');
+
+    expect(reload).not.toHaveBeenCalled();
+    expect(events).toHaveLength(1);
+    expect(events[0]?.detail).toMatchObject({
+      message: 'Unauthorized.',
+    });
+
+    window.removeEventListener(AUTH_REQUIRED_EVENT, listener);
+    restoreReload();
   });
 
   it('posts admin commands through the shared web command payload', async () => {

--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -55,6 +55,10 @@ import type {
 
 export const TOKEN_STORAGE_KEY = 'hybridclaw_token';
 export const AUTH_REQUIRED_EVENT = 'hybridclaw:auth-required';
+const LOCAL_TOKEN_BOOTSTRAP_PARAM = '__hybridclaw_token_bootstrapped';
+const LOCAL_AUTH_RELOAD_STORAGE_KEY = 'hybridclaw_local_auth_reload_at';
+const LOCAL_AUTH_RELOAD_COOLDOWN_MS = 15_000;
+let reloadForAuth = () => window.location.reload();
 
 export interface WebCommandRequestBody {
   sessionId: string;
@@ -95,11 +99,64 @@ export function buildWebCommandRequestBody(options: {
 
 export function dispatchAuthRequired(message: string): void {
   clearStoredToken();
+  if (reloadLocalWebSurfaceForAuth()) return;
   window.dispatchEvent(
     new CustomEvent(AUTH_REQUIRED_EVENT, {
       detail: { message },
     }),
   );
+}
+
+function reloadLocalWebSurfaceForAuth(): boolean {
+  if (!isLocalWebSurfaceLocation()) return false;
+
+  const now = Date.now();
+  const lastReloadAt = Number(
+    window.sessionStorage.getItem(LOCAL_AUTH_RELOAD_STORAGE_KEY) || '0',
+  );
+  if (Number.isFinite(lastReloadAt)) {
+    const elapsedMs = now - lastReloadAt;
+    if (elapsedMs >= 0 && elapsedMs < LOCAL_AUTH_RELOAD_COOLDOWN_MS) {
+      return false;
+    }
+  }
+
+  window.sessionStorage.setItem(LOCAL_AUTH_RELOAD_STORAGE_KEY, String(now));
+  reloadForAuth();
+  return true;
+}
+
+function isLocalWebSurfaceLocation(): boolean {
+  if (!isLoopbackHostname(window.location.hostname)) return false;
+  const pathname = window.location.pathname;
+  return (
+    pathname === '/admin' ||
+    pathname.startsWith('/admin/') ||
+    pathname === '/chat' ||
+    pathname.startsWith('/chat/')
+  );
+}
+
+function isLoopbackHostname(value: string): boolean {
+  const hostname = value.toLowerCase();
+  return (
+    hostname === 'localhost' ||
+    hostname === '::1' ||
+    hostname === '[::1]' ||
+    /^127(?:\.\d{1,3}){3}$/.test(hostname)
+  );
+}
+
+export function setAuthReloadHandlerForTest(reload: () => void): () => void {
+  const previous = reloadForAuth;
+  reloadForAuth = reload;
+  return () => {
+    reloadForAuth = previous;
+  };
+}
+
+export function isLoopbackHostnameForTest(value: string): boolean {
+  return isLoopbackHostname(value);
 }
 
 export async function readErrorResponseMessage(
@@ -171,9 +228,22 @@ export function readStoredToken(): string {
   const queryToken = (search.get('token') || '').trim();
   if (queryToken) {
     window.localStorage.setItem(TOKEN_STORAGE_KEY, queryToken);
+    removeSearchParam(LOCAL_TOKEN_BOOTSTRAP_PARAM);
     return queryToken;
   }
+  removeSearchParam(LOCAL_TOKEN_BOOTSTRAP_PARAM);
   return window.localStorage.getItem(TOKEN_STORAGE_KEY) || '';
+}
+
+function removeSearchParam(name: string): void {
+  const url = new URL(window.location.href);
+  if (!url.searchParams.has(name)) return;
+  url.searchParams.delete(name);
+  window.history.replaceState(
+    window.history.state,
+    '',
+    `${url.pathname}${url.search}${url.hash}`,
+  );
 }
 
 export function storeToken(token: string): void {

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -250,6 +250,7 @@ const DISCORD_MEDIA_CACHE_DIR = path.resolve(
 );
 const MAX_MEDIA_UPLOAD_BYTES = 20 * 1024 * 1024;
 const HYBRIDAI_LOGIN_PATH = '/login?context=hybridclaw&next=/admin_api_keys';
+const LOCAL_TOKEN_BOOTSTRAP_PARAM = '__hybridclaw_token_bootstrapped';
 
 const SITE_MIME_TYPES: Record<string, string> = {
   '.css': 'text/css; charset=utf-8',
@@ -751,13 +752,26 @@ function extractHostnameFromHostHeader(
 }
 
 function isLocalWebSessionAllowed(req: IncomingMessage): boolean {
+  return (
+    !WEB_API_TOKEN && isLoopbackHost(HEALTH_HOST) && isLoopbackWebRequest(req)
+  );
+}
+
+function isLoopbackWebRequest(req: IncomingMessage): boolean {
   const requestHost = extractHostnameFromHostHeader(req.headers.host);
   return (
-    !WEB_API_TOKEN &&
-    isLoopbackHost(HEALTH_HOST) &&
     isLoopbackSocketAddress(req.socket.remoteAddress) &&
     !hasForwardingHeaders(req) &&
     Boolean(requestHost && isLoopbackHost(requestHost))
+  );
+}
+
+function shouldBootstrapLocalWebToken(req: IncomingMessage, url: URL): boolean {
+  return (
+    Boolean(WEB_API_TOKEN) &&
+    isConsoleSpaPath(url.pathname) &&
+    !url.searchParams.has(LOCAL_TOKEN_BOOTSTRAP_PARAM) &&
+    isLoopbackWebRequest(req)
   );
 }
 
@@ -849,6 +863,39 @@ function dispatchWebhookRoute(
 function sendText(res: ServerResponse, statusCode: number, text: string): void {
   res.writeHead(statusCode, { 'Content-Type': 'text/plain; charset=utf-8' });
   res.end(text);
+}
+
+function sendWebTokenBootstrap(
+  res: ServerResponse,
+  params: {
+    redirectTo: string;
+    userId?: string;
+  },
+): void {
+  const escapedToken = escapeInlineScriptValue(WEB_API_TOKEN);
+  const escapedRedirect = escapeInlineScriptValue(params.redirectTo);
+  const escapedUserId = escapeInlineScriptValue(params.userId || '');
+  res.writeHead(200, {
+    'Content-Type': 'text/html; charset=utf-8',
+    'Cache-Control': 'no-store',
+    'Content-Security-Policy': "default-src 'none'; script-src 'unsafe-inline'",
+    'X-Content-Type-Options': 'nosniff',
+  });
+  res.end(
+    `<!DOCTYPE html><html><body><script>` +
+      `localStorage.setItem('hybridclaw_token',${escapedToken});` +
+      `if (${escapedUserId}) localStorage.setItem('hybridclaw_user_id',${escapedUserId});` +
+      `window.location.replace(${escapedRedirect});` +
+      `</script></body></html>`,
+  );
+}
+
+function sendLocalWebTokenBootstrap(res: ServerResponse, url: URL): void {
+  const redirectUrl = new URL(url);
+  redirectUrl.searchParams.set(LOCAL_TOKEN_BOOTSTRAP_PARAM, '1');
+  sendWebTokenBootstrap(res, {
+    redirectTo: `${redirectUrl.pathname}${redirectUrl.search}`,
+  });
 }
 
 function sendRedirect(
@@ -4465,35 +4512,10 @@ export function startGatewayHttpServer(): GatewayHttpServer {
         // token prompt.  The token never appears in the URL (avoiding
         // leaks via browser history, referrer headers, or server logs).
         if (WEB_API_TOKEN) {
-          // Escape for safe inline-script embedding: JSON.stringify handles
-          // JS-level escaping, then replace `<` to prevent the HTML parser
-          // from closing the <script> block early (e.g. a token containing
-          // "</script>").
-          const escaped = JSON.stringify(WEB_API_TOKEN).replace(
-            /</g,
-            '\\u003c',
-          );
-          const escapedRedirect = JSON.stringify(redirectTo).replace(
-            /</g,
-            '\\u003c',
-          );
-          const escapedUserId = JSON.stringify(
-            normalizeOptionalString(payload.sub) || '',
-          ).replace(/</g, '\\u003c');
-          res.writeHead(200, {
-            'Content-Type': 'text/html; charset=utf-8',
-            'Cache-Control': 'no-store',
-            'Content-Security-Policy':
-              "default-src 'none'; script-src 'unsafe-inline'",
-            'X-Content-Type-Options': 'nosniff',
+          sendWebTokenBootstrap(res, {
+            redirectTo,
+            userId: normalizeOptionalString(payload.sub) || undefined,
           });
-          res.end(
-            `<!DOCTYPE html><html><body><script>` +
-              `localStorage.setItem('hybridclaw_token',${escaped});` +
-              `if (${escapedUserId}) localStorage.setItem('hybridclaw_user_id',${escapedUserId});` +
-              `window.location.replace(${escapedRedirect});` +
-              `</script></body></html>`,
-          );
         } else {
           sendRedirect(res, 302, redirectTo);
         }
@@ -4990,6 +5012,11 @@ export function startGatewayHttpServer(): GatewayHttpServer {
     }
 
     if (requiresSessionAuth(pathname) && !ensureSessionAuth(req, res)) {
+      return;
+    }
+
+    if (shouldBootstrapLocalWebToken(req, url)) {
+      sendLocalWebTokenBootstrap(res, url);
       return;
     }
 

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -1995,6 +1995,96 @@ describe('gateway HTTP server', () => {
     expect(getSetCookieHeader(res)).toContain('SameSite=Strict');
   });
 
+  test('bootstraps WEB_API_TOKEN into localStorage for loopback console pages', async () => {
+    const state = await importFreshHealth({ webApiToken: 'web-token' });
+    const req = makeRequest({
+      url: '/admin',
+      headers: { host: 'localhost:9090' },
+      noAuth: true,
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['Content-Type']).toBe('text/html; charset=utf-8');
+    expect(res.headers['Cache-Control']).toBe('no-store');
+    expect(res.body).toContain(
+      'localStorage.setItem(\'hybridclaw_token\',"web-token")',
+    );
+    expect(res.body).toContain(
+      'window.location.replace("/admin?__hybridclaw_token_bootstrapped=1")',
+    );
+  });
+
+  test('serves console index after local WEB_API_TOKEN bootstrap marker', async () => {
+    const state = await importFreshHealth({ webApiToken: 'web-token' });
+    const req = makeRequest({
+      url: '/admin?__hybridclaw_token_bootstrapped=1',
+      headers: { host: 'localhost:9090' },
+      noAuth: true,
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('<h1>Admin</h1>');
+    expect(res.body).not.toContain('web-token');
+  });
+
+  test('does not bootstrap WEB_API_TOKEN for non-SPA local web pages', async () => {
+    const state = await importFreshHealth({ webApiToken: 'web-token' });
+    const req = makeRequest({
+      url: '/agents',
+      headers: { host: 'localhost:9090' },
+      noAuth: true,
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('<h1>Agents</h1>');
+    expect(res.body).not.toContain('web-token');
+    expect(res.body).not.toContain('__hybridclaw_token_bootstrapped');
+  });
+
+  test('does not bootstrap WEB_API_TOKEN for non-loopback request hosts', async () => {
+    const state = await importFreshHealth({ webApiToken: 'web-token' });
+    const req = makeRequest({
+      url: '/admin',
+      headers: { host: 'example.com' },
+      noAuth: true,
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('<h1>Admin</h1>');
+    expect(res.body).not.toContain('web-token');
+  });
+
+  test('does not bootstrap WEB_API_TOKEN with forwarding headers', async () => {
+    const state = await importFreshHealth({ webApiToken: 'web-token' });
+    const req = makeRequest({
+      url: '/admin',
+      headers: {
+        host: 'localhost:9090',
+        'x-forwarded-for': '203.0.113.10',
+      },
+      noAuth: true,
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('<h1>Admin</h1>');
+    expect(res.body).not.toContain('web-token');
+  });
+
   test('does not issue a local web-session cookie for non-loopback request hosts', async () => {
     const state = await importFreshHealth();
     const req = makeRequest({


### PR DESCRIPTION
## Summary

Fixes the local `/chat` and `/admin` auth flow when `WEB_API_TOKEN` is configured. Localhost requests now get a short bootstrap page that stores the current web token in `localStorage`, and already-loaded local console pages reload through that bootstrap once when a stale token causes a 401.

## Details

- Adds a loopback-only web token bootstrap for local console surfaces while rejecting forwarded and non-loopback requests.
- Reuses the existing auth callback token-storage HTML path so escaping, CSP, and cache behavior stay consistent.
- Cleans the temporary bootstrap marker from the browser URL after the React app reads stored auth.
- On local `/chat` and `/admin` runtime 401s, clears stale auth and reloads once with a cooldown instead of showing the manual token form immediately.

## Validation

- `npm run format`
- `git diff --check`
- `npm --prefix console test -- client.test.ts`
- `npx vitest run tests/gateway-http-server.test.ts --testNamePattern "local|WEB_API_TOKEN|auth/callback"`
- `npm run typecheck`