### PR TITLE
[codex] Fix agents page navigation links

### DIFF
--- a/docs/agents.html
+++ b/docs/agents.html
@@ -1171,7 +1171,7 @@
       </div>
 
       <nav class="sidebar-nav" aria-label="Primary navigation">
-        <a class="sidebar-link is-active" href="/hybridclaw/agents" aria-current="page">
+        <a class="sidebar-link is-active" href="/agents" aria-current="page">
           <span class="sidebar-link-icon">
             <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <rect x="3" y="3" width="7" height="7" rx="2"></rect>
@@ -1182,7 +1182,7 @@
           </span>
           <span class="sidebar-link-label">Agents</span>
         </a>
-        <a class="sidebar-link" href="/hybridclaw/chat">
+        <a class="sidebar-link" href="/chat">
           <span class="sidebar-link-icon">
             <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
@@ -1190,7 +1190,7 @@
           </span>
           <span class="sidebar-link-label">Chat</span>
         </a>
-        <a class="sidebar-link" href="/hybridclaw/admin">
+        <a class="sidebar-link" href="/admin">
           <span class="sidebar-link-icon">
             <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <path d="M12 3l7 4v10l-7 4-7-4V7l7-4z"></path>
@@ -1226,7 +1226,7 @@
 
           <div class="page-actions">
             <nav class="view-switch" aria-label="Switch view">
-              <a class="view-switch-link" href="/hybridclaw/chat">
+              <a class="view-switch-link" href="/chat">
                 <span class="sidebar-link-icon">
                   <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
@@ -1234,7 +1234,7 @@
                 </span>
                 <span>Chat</span>
               </a>
-              <a class="view-switch-link is-active" href="/hybridclaw/agents" aria-current="page">
+              <a class="view-switch-link is-active" href="/agents" aria-current="page">
                 <span class="sidebar-link-icon">
                   <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <rect x="3" y="3" width="7" height="7" rx="2"></rect>
@@ -1245,7 +1245,7 @@
                 </span>
                 <span>Agents</span>
               </a>
-              <a class="view-switch-link" href="/hybridclaw/admin">
+              <a class="view-switch-link" href="/admin">
                 <span class="sidebar-link-icon">
                   <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <path d="M12 3l7 4v10l-7 4-7-4V7l7-4z"></path>


### PR DESCRIPTION
## Summary

Fixes the `/agents` page navigation links so the embedded gateway page routes to `/chat`, `/admin`, and `/agents` instead of GitHub Pages-style `/hybridclaw/...` paths.

## Root Cause

The static `docs/agents.html` file is served directly for `/agents`, but its sidebar and view-switch anchors still used the site base path intended for the published docs site.

## Impact

Users on the gateway `/agents` page can now navigate to Chat and Admin without being sent to non-gateway `/hybridclaw/...` URLs.

## Validation

- `rg -n "/hybridclaw/(chat|admin)" docs/agents.html` returns no matches