### PR TITLE
[codex] Audit A2A message events

### DIFF
--- a/src/a2a/a2a-outbox-delivery.ts
+++ b/src/a2a/a2a-outbox-delivery.ts
@@ -19,6 +19,7 @@ import {
   classifyA2AHttpStatus,
   shouldRetryA2AJsonRpcErrorCode,
 } from './a2a-retry-policy.js';
+import { recordA2AMessageAudit } from './audit.js';
 import { signA2ADelegationToken } from './delegation-token.js';
 import { summarizeA2AEnvelopeForAudit } from './envelope.js';
 import {
@@ -521,6 +522,17 @@ export async function deliverA2AItem(
     lastError: undefined,
   };
   persistA2AOutboxItem(delivered);
+  recordA2AMessageAudit({
+    type: 'a2a.deliver',
+    envelope: delivered.envelope,
+    sessionId: resolveItemSessionId(delivered),
+    runId: resolveItemRunId(delivered, 'a2a-outbound'),
+    route: 'a2a.outbound.delivery',
+    source: 'a2a-outbound',
+    transport: 'a2a',
+    statusCode: response.status,
+    attempts: attemptNumber,
+  });
   recordA2AAudit(delivered, {
     type: 'a2a.outbound.delivered',
     statusCode: response.status,

--- a/src/a2a/a2a-outbox-delivery.ts
+++ b/src/a2a/a2a-outbox-delivery.ts
@@ -19,7 +19,7 @@ import {
   classifyA2AHttpStatus,
   shouldRetryA2AJsonRpcErrorCode,
 } from './a2a-retry-policy.js';
-import { recordA2AMessageAudit } from './audit.js';
+import { getA2AAuditSessionId, recordA2AMessageAudit } from './audit.js';
 import { signA2ADelegationToken } from './delegation-token.js';
 import { summarizeA2AEnvelopeForAudit } from './envelope.js';
 import {
@@ -56,7 +56,7 @@ export interface A2AOutboxProcessOptions {
 }
 
 function resolveItemSessionId(item: A2AOutboxItem): string {
-  return item.sessionId || `a2a:outbound:${item.envelope.thread_id}`;
+  return item.sessionId ?? getA2AAuditSessionId(item.envelope);
 }
 
 function resolveItemRunId(item: A2AOutboxItem, prefix: string): string {

--- a/src/a2a/audit.ts
+++ b/src/a2a/audit.ts
@@ -1,0 +1,44 @@
+import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
+import type { A2AEnvelope } from './envelope.js';
+import { summarizeA2AEnvelopeForAudit } from './envelope.js';
+
+export type A2AMessageAuditEventType =
+  | 'a2a.send'
+  | 'a2a.deliver'
+  | 'a2a.handoff';
+
+export interface RecordA2AMessageAuditInput {
+  type: A2AMessageAuditEventType;
+  envelope: A2AEnvelope;
+  sessionId?: string;
+  runId?: string;
+  actor?: string;
+  route?: string;
+  source?: string;
+  transport?: string;
+  statusCode?: number;
+  attempts?: number;
+}
+
+function defaultA2ASessionId(envelope: A2AEnvelope): string {
+  return `a2a:thread:${envelope.thread_id}`;
+}
+
+export function recordA2AMessageAudit(input: RecordA2AMessageAuditInput): void {
+  recordAuditEvent({
+    sessionId: input.sessionId || defaultA2ASessionId(input.envelope),
+    runId: input.runId || makeAuditRunId('a2a-message'),
+    event: {
+      type: input.type,
+      actor: input.actor || null,
+      route: input.route || null,
+      source: input.source || null,
+      transport: input.transport || null,
+      envelope: summarizeA2AEnvelopeForAudit(input.envelope),
+      ...(input.statusCode !== undefined
+        ? { statusCode: input.statusCode }
+        : {}),
+      ...(input.attempts !== undefined ? { attempts: input.attempts } : {}),
+    },
+  });
+}

--- a/src/a2a/audit.ts
+++ b/src/a2a/audit.ts
@@ -7,8 +7,7 @@ export type A2AMessageAuditEventType =
   | 'a2a.deliver'
   | 'a2a.handoff';
 
-export interface RecordA2AMessageAuditInput {
-  type: A2AMessageAuditEventType;
+interface RecordA2AMessageAuditBaseInput {
   envelope: A2AEnvelope;
   sessionId?: string;
   runId?: string;
@@ -16,29 +15,46 @@ export interface RecordA2AMessageAuditInput {
   route?: string;
   source?: string;
   transport?: string;
-  statusCode?: number;
-  attempts?: number;
 }
 
-function defaultA2ASessionId(envelope: A2AEnvelope): string {
+export type RecordA2AMessageAuditInput = RecordA2AMessageAuditBaseInput &
+  (
+    | {
+        type: 'a2a.send' | 'a2a.handoff';
+      }
+    | {
+        type: 'a2a.deliver';
+        statusCode?: number;
+        attempts?: number;
+      }
+  );
+
+export function getA2AAuditSessionId(envelope: A2AEnvelope): string {
   return `a2a:thread:${envelope.thread_id}`;
+}
+
+function deliveryMetadata(
+  input: RecordA2AMessageAuditInput,
+): Record<string, unknown> {
+  if (input.type !== 'a2a.deliver') return {};
+  return {
+    ...(input.statusCode !== undefined ? { statusCode: input.statusCode } : {}),
+    ...(input.attempts !== undefined ? { attempts: input.attempts } : {}),
+  };
 }
 
 export function recordA2AMessageAudit(input: RecordA2AMessageAuditInput): void {
   recordAuditEvent({
-    sessionId: input.sessionId || defaultA2ASessionId(input.envelope),
-    runId: input.runId || makeAuditRunId('a2a-message'),
+    sessionId: input.sessionId ?? getA2AAuditSessionId(input.envelope),
+    runId: input.runId ?? makeAuditRunId('a2a-message'),
     event: {
       type: input.type,
-      actor: input.actor || null,
-      route: input.route || null,
-      source: input.source || null,
-      transport: input.transport || null,
+      actor: input.actor ?? null,
+      route: input.route ?? null,
+      source: input.source ?? null,
+      transport: input.transport ?? null,
       envelope: summarizeA2AEnvelopeForAudit(input.envelope),
-      ...(input.statusCode !== undefined
-        ? { statusCode: input.statusCode }
-        : {}),
-      ...(input.attempts !== undefined ? { attempts: input.attempts } : {}),
+      ...deliveryMetadata(input),
     },
   });
 }

--- a/src/a2a/inbound-pipeline.ts
+++ b/src/a2a/inbound-pipeline.ts
@@ -40,6 +40,7 @@ export function acceptA2AInboundEnvelope(
   }
   return sendMessage(envelope, {
     actor: `${meta.source}:${meta.actor}`,
+    auditRole: 'receiver',
     sessionId: meta.sessionId,
     auditRunId: meta.auditRunId,
   });

--- a/src/a2a/runtime.ts
+++ b/src/a2a/runtime.ts
@@ -1,4 +1,5 @@
 import type { EscalationTarget } from '../types/execution.js';
+import { recordA2AMessageAudit } from './audit.js';
 import {
   type A2AEnvelope,
   A2AEnvelopeValidationError,
@@ -53,6 +54,29 @@ export function sendMessage(
     route: 'a2a.sendMessage',
     source: 'a2a-runtime',
   });
+  const auditBase = {
+    envelope: deliveredEnvelope,
+    sessionId: meta?.sessionId,
+    runId: meta?.auditRunId,
+    actor: meta?.actor,
+    route: 'a2a.sendMessage',
+    source: 'a2a-runtime',
+    transport: meta?.peerDescriptor ? 'registered' : 'internal',
+  };
+  recordA2AMessageAudit({
+    type: 'a2a.send',
+    ...auditBase,
+  });
+  recordA2AMessageAudit({
+    type: 'a2a.deliver',
+    ...auditBase,
+  });
+  if (deliveredEnvelope.intent === 'handoff') {
+    recordA2AMessageAudit({
+      type: 'a2a.handoff',
+      ...auditBase,
+    });
+  }
   return {
     delivered: true,
     message_id: deliveredEnvelope.id,

--- a/src/a2a/runtime.ts
+++ b/src/a2a/runtime.ts
@@ -6,6 +6,7 @@ import {
   validateA2AEnvelope,
 } from './envelope.js';
 import { attachA2AHandoffContext } from './handoff-context.js';
+import { normalizePeerDescriptor } from './peer-descriptor.js';
 import { listA2AInboxEnvelopes, saveA2AEnvelope } from './store.js';
 import {
   encodeForRegisteredTransport,
@@ -41,9 +42,10 @@ export function sendMessage(
   envelope: unknown,
   meta?: A2ASendMessageMeta,
 ): A2ADeliveryConfirmation {
+  const peerDescriptor = normalizePeerDescriptor(meta?.peerDescriptor);
   const encodedEnvelope = encodeForRegisteredTransport({
     envelope: attachA2AHandoffContext(validateRuntimeEnvelope(envelope)),
-    peerDescriptor: meta?.peerDescriptor,
+    peerDescriptor,
     registry: meta?.transportRegistry,
     sessionId: meta?.sessionId,
     runId: meta?.auditRunId,
@@ -61,16 +63,18 @@ export function sendMessage(
     actor: meta?.actor,
     route: 'a2a.sendMessage',
     source: 'a2a-runtime',
-    transport: meta?.peerDescriptor ? 'registered' : 'internal',
+    transport: peerDescriptor.transport,
   };
   recordA2AMessageAudit({
     type: 'a2a.send',
     ...auditBase,
   });
-  recordA2AMessageAudit({
-    type: 'a2a.deliver',
-    ...auditBase,
-  });
+  if (peerDescriptor.transport === 'internal') {
+    recordA2AMessageAudit({
+      type: 'a2a.deliver',
+      ...auditBase,
+    });
+  }
   if (deliveredEnvelope.intent === 'handoff') {
     recordA2AMessageAudit({
       type: 'a2a.handoff',

--- a/src/a2a/runtime.ts
+++ b/src/a2a/runtime.ts
@@ -23,6 +23,7 @@ export interface A2ADeliveryConfirmation {
 
 export interface A2ASendMessageMeta {
   actor?: string;
+  auditRole?: 'sender' | 'receiver';
   peerDescriptor?: unknown;
   transportRegistry?: TransportRegistry;
   sessionId?: string;
@@ -65,10 +66,12 @@ export function sendMessage(
     source: 'a2a-runtime',
     transport: peerDescriptor.transport,
   };
-  recordA2AMessageAudit({
-    type: 'a2a.send',
-    ...auditBase,
-  });
+  if ((meta?.auditRole ?? 'sender') === 'sender') {
+    recordA2AMessageAudit({
+      type: 'a2a.send',
+      ...auditBase,
+    });
+  }
   if (peerDescriptor.transport === 'internal') {
     recordA2AMessageAudit({
       type: 'a2a.deliver',

--- a/src/a2a/webhook-outbound.ts
+++ b/src/a2a/webhook-outbound.ts
@@ -17,7 +17,7 @@ import {
   type SecretRef,
 } from '../security/secret-refs.js';
 import type { EscalationTarget } from '../types/execution.js';
-import { recordA2AMessageAudit } from './audit.js';
+import { getA2AAuditSessionId, recordA2AMessageAudit } from './audit.js';
 import {
   type A2AEnvelope,
   summarizeA2AEnvelopeForAudit,
@@ -338,12 +338,8 @@ export function enqueueWebhookEnvelope(
   return item;
 }
 
-function webhookSessionId(item: WebhookOutboxItem): string {
-  return `a2a:webhook:${item.envelope.thread_id}`;
-}
-
 function resolveItemSessionId(item: WebhookOutboxItem): string {
-  return item.sessionId || webhookSessionId(item);
+  return item.sessionId ?? getA2AAuditSessionId(item.envelope);
 }
 
 function resolveItemRunId(item: WebhookOutboxItem, prefix: string): string {

--- a/src/a2a/webhook-outbound.ts
+++ b/src/a2a/webhook-outbound.ts
@@ -17,6 +17,7 @@ import {
   type SecretRef,
 } from '../security/secret-refs.js';
 import type { EscalationTarget } from '../types/execution.js';
+import { recordA2AMessageAudit } from './audit.js';
 import {
   type A2AEnvelope,
   summarizeA2AEnvelopeForAudit,
@@ -537,6 +538,17 @@ async function deliverWebhookItem(
       lastError: undefined,
     };
     persistOutboxItem(delivered);
+    recordA2AMessageAudit({
+      type: 'a2a.deliver',
+      envelope: delivered.envelope,
+      sessionId: resolveItemSessionId(delivered),
+      runId: resolveItemRunId(delivered, 'a2a-webhook'),
+      route: 'a2a.webhook.delivery',
+      source: 'a2a-webhook',
+      transport: 'webhook',
+      statusCode: response.status,
+      attempts: attemptNumber,
+    });
     recordWebhookAudit(delivered, {
       type: 'a2a.webhook.delivered',
       statusCode: response.status,

--- a/tests/a2a-outbound.test.ts
+++ b/tests/a2a-outbound.test.ts
@@ -1,4 +1,5 @@
 import { generateKeyPairSync } from 'node:crypto';
+import fs from 'node:fs';
 import { describe, expect, test, vi } from 'vitest';
 
 import {
@@ -232,6 +233,73 @@ describe('A2A outbound adapter', () => {
     expect(
       requests.find((request) => request.ifNoneMatch === '"card-v1"'),
     ).toBeTruthy();
+  });
+
+  test('uses one default audit session for queued send and delivery events', async () => {
+    const { initDatabase } = await import('../src/memory/db.ts');
+    const audit = await import('../src/audit/audit-trail.ts');
+    const runtime = await import('../src/a2a/runtime.ts');
+    const transport = await import('../src/a2a/transport-registry.ts');
+    const a2a = await import('../src/a2a/a2a-outbound.ts');
+
+    initDatabase({ quiet: true });
+    const registry = new transport.TransportRegistry();
+    registry.register(new a2a.A2AOutboundAdapter());
+
+    runtime.sendMessage(sampleA2AEnvelope('msg-a2a-default-audit'), {
+      peerDescriptor: {
+        transport: 'a2a',
+        url: 'http://127.0.0.1:65535/a2a',
+      },
+      transportRegistry: registry,
+    });
+
+    const fetchImpl = vi.fn(
+      async (_url: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === 'GET') {
+          return Response.json({
+            name: 'Peer',
+            url: 'http://127.0.0.1:65535/a2a',
+            capabilities: [],
+          });
+        }
+        return Response.json({ jsonrpc: '2.0', result: { kind: 'message' } });
+      },
+    );
+
+    await expect(
+      a2a.processA2AOutbox({
+        fetchImpl,
+        now: () => new Date('2030-01-01T00:00:00.000Z'),
+      }),
+    ).resolves.toMatchObject({
+      processed: 1,
+      delivered: 1,
+    });
+
+    const sessionId = 'a2a:thread:thread-a2a';
+    const records = fs
+      .readFileSync(audit.getAuditWirePath(sessionId), 'utf-8')
+      .split('\n')
+      .filter(Boolean)
+      .slice(1)
+      .map((line) => JSON.parse(line));
+    const canonicalEvents = records.filter((record) =>
+      ['a2a.send', 'a2a.deliver'].includes(record.event.type),
+    );
+
+    expect(canonicalEvents.map((record) => record.event.type)).toEqual([
+      'a2a.send',
+      'a2a.deliver',
+    ]);
+    expect(canonicalEvents.map((record) => record.event.transport)).toEqual([
+      'a2a',
+      'a2a',
+    ]);
+    expect(audit.verifyAuditSessionChain(sessionId)).toMatchObject({
+      ok: true,
+      errors: [],
+    });
   });
 
   test('honors delegation token revocations and expiry', async () => {

--- a/tests/a2a-runtime.integration.test.ts
+++ b/tests/a2a-runtime.integration.test.ts
@@ -235,14 +235,14 @@ describe('A2A runtime API', () => {
 
     expect(records.map((record) => record.event.type)).toEqual(['a2a.send']);
     expect(records[0].event.transport).toBe('a2a');
-    expect(audit.verifyAuditSessionChain('session-a2a-queued-audit')).toMatchObject(
-      {
-        ok: true,
-        checkedRecords: 1,
-        errors: [],
-        lastSeq: 1,
-      },
-    );
+    expect(
+      audit.verifyAuditSessionChain('session-a2a-queued-audit'),
+    ).toMatchObject({
+      ok: true,
+      checkedRecords: 1,
+      errors: [],
+      lastSeq: 1,
+    });
   });
 
   test('audits and escalates when a peer transport has no adapter', async () => {

--- a/tests/a2a-runtime.integration.test.ts
+++ b/tests/a2a-runtime.integration.test.ts
@@ -198,6 +198,70 @@ describe('A2A runtime API', () => {
     });
   });
 
+  test('inbound handoffs audit receive without a local send event', async () => {
+    const { initDatabase } = await import('../src/memory/db.ts');
+    const audit = await import('../src/audit/audit-trail.ts');
+    const runtimeConfig = await import('../src/config/runtime-config.ts');
+    const inbound = await import('../src/a2a/inbound-pipeline.ts');
+
+    initDatabase({ quiet: true });
+    runtimeConfig.updateRuntimeConfig((draft) => {
+      draft.agents.list = [
+        { id: 'main', owner: 'team', role: 'lead' },
+        { id: 'stub-b', owner: 'team', role: 'recipient' },
+      ];
+    });
+
+    inbound.acceptA2AInboundEnvelope(
+      {
+        id: 'msg-inbound-audit',
+        sender_agent_id: 'remote@team@peer-instance',
+        recipient_agent_id: 'stub-b',
+        thread_id: 'thread-inbound-audit',
+        intent: 'handoff',
+        content: 'Remote peer is handing this off.',
+        created_at: '2026-05-01T10:00:00.000Z',
+      },
+      {
+        actor: 'trusted-peer',
+        source: 'a2a',
+        sessionId: 'session-a2a-inbound-audit',
+        auditRunId: 'run-a2a-inbound-audit',
+      },
+    );
+
+    const records = fs
+      .readFileSync(
+        audit.getAuditWirePath('session-a2a-inbound-audit'),
+        'utf-8',
+      )
+      .split('\n')
+      .filter(Boolean)
+      .slice(1)
+      .map((line) => JSON.parse(line));
+
+    expect(records.map((record) => record.event.type)).toEqual([
+      'a2a.deliver',
+      'a2a.handoff',
+    ]);
+    expect(records[0].event.actor).toBe('a2a:trusted-peer');
+    expect(records[0].event.envelope).toEqual(
+      expect.objectContaining({
+        messageId: 'msg-inbound-audit',
+        senderAgentId: 'remote@team@peer-instance',
+        recipientAgentId: 'stub-b@team@local-dev',
+      }),
+    );
+    expect(
+      audit.verifyAuditSessionChain('session-a2a-inbound-audit'),
+    ).toMatchObject({
+      ok: true,
+      checkedRecords: 2,
+      errors: [],
+      lastSeq: 2,
+    });
+  });
+
   test('does not audit outbound queued transport sends as delivered', async () => {
     const { initDatabase } = await import('../src/memory/db.ts');
     const audit = await import('../src/audit/audit-trail.ts');

--- a/tests/a2a-runtime.integration.test.ts
+++ b/tests/a2a-runtime.integration.test.ts
@@ -66,9 +66,11 @@ describe('A2A runtime API', () => {
   });
 
   test('delivers a message from stub agent A to stub agent B inbox', async () => {
+    const { initDatabase } = await import('../src/memory/db.ts');
     const runtimeConfig = await import('../src/config/runtime-config.ts');
     const runtime = await import('../src/a2a/runtime.ts');
 
+    initDatabase({ quiet: true });
     runtimeConfig.updateRuntimeConfig((draft) => {
       draft.agents.list = [
         { id: 'main', owner: 'team', role: 'lead' },
@@ -130,6 +132,70 @@ describe('A2A runtime API', () => {
     expect(handoff?.content).toContain(
       'recipient_escalation_chain: main (lead)',
     );
+  });
+
+  test('writes A2A message events to the hash-chain audit wire log', async () => {
+    const { initDatabase } = await import('../src/memory/db.ts');
+    const audit = await import('../src/audit/audit-trail.ts');
+    const runtimeConfig = await import('../src/config/runtime-config.ts');
+    const runtime = await import('../src/a2a/runtime.ts');
+
+    initDatabase({ quiet: true });
+    runtimeConfig.updateRuntimeConfig((draft) => {
+      draft.agents.list = [
+        { id: 'main', owner: 'team', role: 'lead' },
+        { id: 'stub-a', owner: 'team', role: 'sender' },
+        { id: 'stub-b', owner: 'team', role: 'recipient' },
+      ];
+    });
+
+    runtime.sendMessage(
+      {
+        id: 'msg-audit',
+        sender_agent_id: 'stub-a',
+        recipient_agent_id: 'stub-b',
+        thread_id: 'thread-audit',
+        intent: 'handoff',
+        content: 'Please pick this up.',
+        created_at: '2026-05-01T10:00:00.000Z',
+      },
+      {
+        actor: 'stub-a',
+        sessionId: 'session-a2a-audit',
+        auditRunId: 'run-a2a-audit',
+      },
+    );
+
+    const wirePath = audit.getAuditWirePath('session-a2a-audit');
+    const lines = fs
+      .readFileSync(wirePath, 'utf-8')
+      .split('\n')
+      .filter(Boolean);
+    const records = lines.slice(1).map((line) => JSON.parse(line));
+
+    expect(records.map((record) => record.event.type)).toEqual([
+      'a2a.send',
+      'a2a.deliver',
+      'a2a.handoff',
+    ]);
+    expect(records[0].event.envelope).toEqual(
+      expect.objectContaining({
+        messageId: 'msg-audit',
+        threadId: 'thread-audit',
+        senderAgentId: 'stub-a@team@local-dev',
+        recipientAgentId: 'stub-b@team@local-dev',
+      }),
+    );
+    expect(records[0].event.envelope).not.toHaveProperty('content');
+    expect(records[1]._prevHash).toBe(records[0]._hash);
+    expect(records[2]._prevHash).toBe(records[1]._hash);
+
+    expect(audit.verifyAuditSessionChain('session-a2a-audit')).toMatchObject({
+      ok: true,
+      checkedRecords: 3,
+      errors: [],
+      lastSeq: 3,
+    });
   });
 
   test('audits and escalates when a peer transport has no adapter', async () => {

--- a/tests/a2a-runtime.integration.test.ts
+++ b/tests/a2a-runtime.integration.test.ts
@@ -198,6 +198,53 @@ describe('A2A runtime API', () => {
     });
   });
 
+  test('does not audit outbound queued transport sends as delivered', async () => {
+    const { initDatabase } = await import('../src/memory/db.ts');
+    const audit = await import('../src/audit/audit-trail.ts');
+    const runtime = await import('../src/a2a/runtime.ts');
+
+    initDatabase({ quiet: true });
+
+    runtime.sendMessage(
+      {
+        id: 'msg-queued-audit',
+        sender_agent_id: 'main',
+        recipient_agent_id: 'remote@team@peer-instance',
+        thread_id: 'thread-queued-audit',
+        intent: 'chat',
+        content: 'Queue this for the remote peer.',
+        created_at: '2026-05-01T10:00:00.000Z',
+      },
+      {
+        sessionId: 'session-a2a-queued-audit',
+        auditRunId: 'run-a2a-queued-audit',
+        peerDescriptor: {
+          transport: 'a2a',
+          url: 'http://127.0.0.1:65535/a2a',
+        },
+      },
+    );
+
+    const wirePath = audit.getAuditWirePath('session-a2a-queued-audit');
+    const records = fs
+      .readFileSync(wirePath, 'utf-8')
+      .split('\n')
+      .filter(Boolean)
+      .slice(1)
+      .map((line) => JSON.parse(line));
+
+    expect(records.map((record) => record.event.type)).toEqual(['a2a.send']);
+    expect(records[0].event.transport).toBe('a2a');
+    expect(audit.verifyAuditSessionChain('session-a2a-queued-audit')).toMatchObject(
+      {
+        ok: true,
+        checkedRecords: 1,
+        errors: [],
+        lastSeq: 1,
+      },
+    );
+  });
+
   test('audits and escalates when a peer transport has no adapter', async () => {
     const { initDatabase, getRecentStructuredAuditForSession } = await import(
       '../src/memory/db.ts'

--- a/tests/a2a-webhook-outbound.test.ts
+++ b/tests/a2a-webhook-outbound.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import { describe, expect, test, vi } from 'vitest';
 
 import {
@@ -125,6 +126,66 @@ describe('A2A webhook outbound adapter', () => {
       lastStatusCode: 200,
     });
     expect(receivedHeaders).toHaveLength(1);
+  });
+
+  test('uses one default audit session for queued webhook send and delivery events', async () => {
+    const { initDatabase } = await import('../src/memory/db.ts');
+    const audit = await import('../src/audit/audit-trail.ts');
+    const runtime = await import('../src/a2a/runtime.ts');
+    const transport = await import('../src/a2a/transport-registry.ts');
+    const webhook = await import('../src/a2a/webhook-outbound.ts');
+    const secrets = await import('../src/security/runtime-secrets.ts');
+
+    initDatabase({ quiet: true });
+    secrets.saveNamedRuntimeSecrets({ A2A_WEBHOOK_SECRET: 'shared-secret' });
+    const registry = new transport.TransportRegistry();
+    registry.register(
+      new webhook.WebhookOutboundAdapter({ autoProcess: false }),
+    );
+
+    runtime.sendMessage(sampleA2AWebhookEnvelope('msg-webhook-default-audit'), {
+      peerDescriptor: {
+        transport: 'webhook',
+        url: 'https://hooks.example.com/a2a',
+        secretRef: { source: 'store', id: 'A2A_WEBHOOK_SECRET' },
+      },
+      transportRegistry: registry,
+    });
+
+    await expect(
+      webhook.processWebhookOutbox({
+        fetchImpl: vi.fn(async () => new Response('', { status: 200 })),
+        now: () => new Date('2030-01-01T00:00:00.000Z'),
+        jitterRatio: 0,
+      }),
+    ).resolves.toMatchObject({
+      processed: 1,
+      delivered: 1,
+    });
+
+    const sessionId = 'a2a:thread:thread-webhook';
+    const records = fs
+      .readFileSync(audit.getAuditWirePath(sessionId), 'utf-8')
+      .split('\n')
+      .filter(Boolean)
+      .slice(1)
+      .map((line) => JSON.parse(line));
+    const canonicalEvents = records.filter((record) =>
+      ['a2a.send', 'a2a.deliver'].includes(record.event.type),
+    );
+
+    expect(canonicalEvents.map((record) => record.event.type)).toEqual([
+      'a2a.send',
+      'a2a.deliver',
+    ]);
+    expect(canonicalEvents.map((record) => record.event.transport)).toEqual([
+      'webhook',
+      'webhook',
+    ]);
+    expect(audit.verifyAuditSessionChain(sessionId)).toMatchObject({
+      ok: true,
+      errors: [],
+    });
   });
 
   test('fails and escalates when the webhook secret cannot be resolved', async () => {


### PR DESCRIPTION
## Summary

Implements #429 by adding canonical A2A message audit events to the existing hash-chain audit trail.

- Adds metadata-only `a2a.send`, `a2a.deliver`, and `a2a.handoff` audit events.
- Records runtime send/local delivery events through the existing `recordAuditEvent` -> `appendAuditEvent` path.
- Records canonical `a2a.deliver` events for successful JSON-RPC and webhook outbound delivery.
- Adds an integration test that sends a handoff, reads `wire.jsonl`, verifies event ordering and `_prevHash` links, and runs `verifyAuditSessionChain`.

## Risk Notes

This touches the high-risk audit surface. The new payloads use the existing A2A envelope audit summary and intentionally omit message content and delegation tokens.

## Validation

- `npx vitest run tests/a2a-runtime.integration.test.ts`
- `npx vitest run tests/a2a-outbound.test.ts tests/a2a-outbound.integration.test.ts tests/a2a-webhook-outbound.test.ts tests/a2a-webhook-outbound.integration.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npx biome check src/a2a/audit.ts src/a2a/runtime.ts src/a2a/a2a-outbox-delivery.ts src/a2a/webhook-outbound.ts tests/a2a-runtime.integration.test.ts`

Closes #429.