### PR TITLE
[codex] Add optional Codex app-server runtime

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -310,7 +310,7 @@
   },
   "codex": {
     "baseUrl": "https://chatgpt.com/backend-api/codex",
-    "runtime": "hybridclaw"
+    "turnRuntime": "hybridclaw"
   },
   "anthropic": {
     "enabled": false,

--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,5 @@
 {
-  "version": 28,
+  "version": 29,
   "security": {
     "trustModelAccepted": false,
     "trustModelAcceptedAt": "",
@@ -309,7 +309,8 @@
     "models": ["gpt-4.1-mini", "gpt-5-nano", "gpt-5"]
   },
   "codex": {
-    "baseUrl": "https://chatgpt.com/backend-api/codex"
+    "baseUrl": "https://chatgpt.com/backend-api/codex",
+    "runtime": "hybridclaw"
   },
   "anthropic": {
     "enabled": false,

--- a/container/src/codex-app-server.ts
+++ b/container/src/codex-app-server.ts
@@ -1,0 +1,1094 @@
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import readline from 'node:readline';
+import { fileURLToPath } from 'node:url';
+import type {
+  ChatMessage,
+  ContainerInput,
+  ContainerOutput,
+  PendingApproval,
+  TokenUsageStats,
+  ToolExecution,
+} from './types.js';
+
+type JsonRpcId = string | number;
+
+interface JsonRpcMessage {
+  id?: JsonRpcId;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+  error?: unknown;
+}
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+interface CodexProjection {
+  threadId: string | null;
+  turnId: string | null;
+  textDeltas: string[];
+  agentMessages: string[];
+  toolExecutions: ToolExecution[];
+  toolsUsed: string[];
+  tokenUsage: TokenUsageStats;
+  approvalEvents: ToolExecution[];
+  pendingApproval: PendingApproval | null;
+  error: string | null;
+  completed: boolean;
+}
+
+interface RunCodexAppServerTurnParams {
+  sessionId: string;
+  messages: ChatMessage[];
+  model: string;
+  cwd?: string;
+  apiKey?: string;
+  baseUrl?: string;
+  provider?: ContainerInput['provider'];
+  providerMethod?: string;
+  chatbotId?: string;
+  requestHeaders?: Record<string, string>;
+  maxTokens?: number;
+  debugModelResponses?: boolean;
+  gatewayBaseUrl?: string;
+  gatewayApiToken?: string;
+  channelId?: string;
+  configuredDiscordChannels?: string[];
+  mcpServers?: ContainerInput['mcpServers'];
+  taskModels?: ContainerInput['taskModels'];
+  media?: ContainerInput['media'];
+  webSearch?: ContainerInput['webSearch'];
+  providerCredentials?: ContainerInput['providerCredentials'];
+  streamTextDeltas?: boolean;
+  onTextDelta?: (delta: string) => void;
+}
+
+const CODEX_REQUEST_TIMEOUT_MS = 30_000;
+const CODEX_APPROVAL_EXPIRES_MS = 10 * 60 * 1000;
+const MCP_SERVER_NAME_RE = /^[a-zA-Z0-9_-]{1,64}$/;
+const SENSITIVE_ENV_KEY_RE =
+  /(secret|token|password|passwd|credential|apikey|api_key|auth|bearer|private)/i;
+const MCP_SCRIPT_PATH = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'codex-hybridclaw-mcp.js',
+);
+
+interface PendingCodexApproval {
+  approvalId: string;
+  sessionId: string;
+  client: CodexAppServerClient;
+  projection: CodexProjection;
+  requestId: JsonRpcId;
+  method: string;
+  params: unknown;
+}
+
+let pendingCodexApproval: PendingCodexApproval | null = null;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeCodexModelName(model: string): string {
+  const trimmed = String(model || '').trim();
+  return trimmed.toLowerCase().startsWith('openai-codex/')
+    ? trimmed.slice('openai-codex/'.length)
+    : trimmed;
+}
+
+function stringifyContent(content: ChatMessage['content']): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .filter((part) => part.type === 'text')
+    .map((part) => part.text)
+    .join('\n');
+}
+
+function extractSystemInstructions(messages: ChatMessage[]): string | null {
+  const instructions = messages
+    .filter((message) => message.role === 'system')
+    .map((message) => stringifyContent(message.content).trim())
+    .filter(Boolean)
+    .join('\n\n');
+  return instructions || null;
+}
+
+function latestUserMessage(messages: ChatMessage[]): ChatMessage | null {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    if (messages[i]?.role === 'user') return messages[i];
+  }
+  return null;
+}
+
+export function buildCodexTurnText(messages: ChatMessage[]): string {
+  const latest = latestUserMessage(messages);
+  if (!latest) return '';
+  const latestText = stringifyContent(latest.content).trim();
+  const prior = messages
+    .filter((message) => message.role !== 'system' && message !== latest)
+    .map((message) => {
+      const content = stringifyContent(message.content).trim();
+      if (!content) return '';
+      return `${message.role}: ${content}`;
+    })
+    .filter(Boolean);
+
+  if (prior.length === 0) return latestText;
+  return [
+    'Prior conversation context:',
+    prior.join('\n\n'),
+    '',
+    'Current user request:',
+    latestText,
+  ].join('\n');
+}
+
+function buildCodexUserInput(
+  messages: ChatMessage[],
+): Array<Record<string, unknown>> {
+  const input: Array<Record<string, unknown>> = [];
+  const latest = latestUserMessage(messages);
+  const text = buildCodexTurnText(messages);
+  if (text) {
+    input.push({ type: 'text', text, text_elements: [] });
+  }
+  if (!latest || !Array.isArray(latest.content)) return input;
+  for (const part of latest.content) {
+    if (part.type === 'image_url' && part.image_url.url) {
+      input.push({ type: 'image', url: part.image_url.url });
+    }
+  }
+  return input;
+}
+
+function emptyTokenUsage(): TokenUsageStats {
+  return {
+    modelCalls: 1,
+    apiUsageAvailable: false,
+    apiPromptTokens: 0,
+    apiCompletionTokens: 0,
+    apiTotalTokens: 0,
+    apiCacheUsageAvailable: false,
+    apiCacheReadTokens: 0,
+    apiCacheWriteTokens: 0,
+    estimatedPromptTokens: 0,
+    estimatedCompletionTokens: 0,
+    estimatedTotalTokens: 0,
+  };
+}
+
+function readString(record: Record<string, unknown>, key: string): string {
+  return typeof record[key] === 'string' ? record[key] : '';
+}
+
+function readNumber(
+  record: Record<string, unknown>,
+  key: string,
+): number | null {
+  return typeof record[key] === 'number' && Number.isFinite(record[key])
+    ? record[key]
+    : null;
+}
+
+function appendToolExecution(
+  projection: CodexProjection,
+  execution: ToolExecution,
+): void {
+  projection.toolExecutions.push(execution);
+  if (!projection.toolsUsed.includes(execution.name)) {
+    projection.toolsUsed.push(execution.name);
+  }
+}
+
+function latestUserText(messages: ChatMessage[]): string {
+  const latest = latestUserMessage(messages);
+  return latest ? stringifyContent(latest.content).trim() : '';
+}
+
+function parseApprovalDirective(input: string): {
+  kind: 'approve' | 'deny';
+  mode?: 'session';
+  requestId: string;
+} | null {
+  const normalized = input.trim();
+  const approve = normalized.match(
+    /^(?:\/?(?:approve|yes|y))(?:\s+([a-f0-9-]{6,64}))?(?:\s+(?:for\s+)?(session))?$/i,
+  );
+  if (approve) {
+    return {
+      kind: 'approve',
+      requestId: String(approve[1] || '').trim(),
+      ...(approve[2] ? { mode: 'session' } : {}),
+    };
+  }
+  const deny = normalized.match(
+    /^(?:\/?(?:deny|reject|skip|no|n))(?:\s+([a-f0-9-]{6,64}))?$/i,
+  );
+  if (deny) {
+    return { kind: 'deny', requestId: String(deny[1] || '').trim() };
+  }
+  return null;
+}
+
+function isApprovalForPending(
+  sessionId: string,
+  messages: ChatMessage[],
+  pending: PendingCodexApproval | null,
+): boolean {
+  if (!pending) return false;
+  if (pending.sessionId !== sessionId) return false;
+  const directive = parseApprovalDirective(latestUserText(messages));
+  if (!directive) return false;
+  return !directive.requestId || directive.requestId === pending.approvalId;
+}
+
+function buildPendingApproval(
+  approvalId: string,
+  method: string,
+  params: unknown,
+): PendingApproval {
+  const prompt = [
+    'Codex app-server requested approval for a native runtime action.',
+    '',
+    `Approval ID: ${approvalId}`,
+    `Request: ${method}`,
+    '',
+    JSON.stringify(params, null, 2),
+  ].join('\n');
+  return {
+    approvalId,
+    prompt,
+    intent: method,
+    reason: 'Codex app-server requested permission before continuing the turn.',
+    allowSession: true,
+    allowAgent: false,
+    allowAll: false,
+    expiresAt: Date.now() + CODEX_APPROVAL_EXPIRES_MS,
+  };
+}
+
+function cryptoRandomApprovalId(): string {
+  return randomUUID();
+}
+
+function tomlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function tomlStringArray(values: string[]): string {
+  return `[${values.map(tomlString).join(', ')}]`;
+}
+
+function pushConfig(args: string[], key: string, value: string): void {
+  args.push('-c', `${key}=${value}`);
+}
+
+function sanitizeMcpServerName(name: string): string | null {
+  const trimmed = name.trim();
+  return MCP_SERVER_NAME_RE.test(trimmed) ? trimmed : null;
+}
+
+function pushHybridClawMcpConfig(args: string[], contextPath: string | null) {
+  pushConfig(
+    args,
+    'mcp_servers.hybridclaw.command',
+    tomlString(process.execPath),
+  );
+  pushConfig(
+    args,
+    'mcp_servers.hybridclaw.args',
+    tomlStringArray([MCP_SCRIPT_PATH]),
+  );
+  if (contextPath) {
+    pushConfig(
+      args,
+      'mcp_servers.hybridclaw.env.HYBRIDCLAW_CODEX_MCP_CONTEXT_PATH',
+      tomlString(contextPath),
+    );
+  }
+}
+
+function pushUserMcpServerConfig(
+  args: string[],
+  name: string,
+  config: NonNullable<ContainerInput['mcpServers']>[string],
+): void {
+  const safeName = sanitizeMcpServerName(name);
+  if (!safeName || config.enabled === false) return;
+  const prefix = `mcp_servers.${safeName}`;
+  if (config.transport === 'stdio') {
+    if (!config.command) return;
+    pushConfig(args, `${prefix}.command`, tomlString(config.command));
+    if (config.args?.length) {
+      pushConfig(args, `${prefix}.args`, tomlStringArray(config.args));
+    }
+    if (config.cwd) pushConfig(args, `${prefix}.cwd`, tomlString(config.cwd));
+    for (const [key, value] of Object.entries(config.env || {})) {
+      if (SENSITIVE_ENV_KEY_RE.test(key)) continue;
+      pushConfig(args, `${prefix}.env.${key}`, tomlString(value));
+    }
+    return;
+  }
+  if (config.url) {
+    pushConfig(args, `${prefix}.url`, tomlString(config.url));
+  }
+}
+
+export function buildCodexAppServerArgs(
+  mcpServers: ContainerInput['mcpServers'] | undefined,
+  contextPath: string | null,
+): string[] {
+  const args = ['app-server', '--listen', 'stdio://'];
+  pushHybridClawMcpConfig(args, contextPath);
+  for (const [name, config] of Object.entries(mcpServers || {})) {
+    pushUserMcpServerConfig(args, name, config);
+  }
+  return args;
+}
+
+function writeMcpContextFile(
+  params: RunCodexAppServerTurnParams,
+): string | null {
+  const context = {
+    provider: params.provider,
+    providerMethod: params.providerMethod,
+    baseUrl: params.baseUrl,
+    apiKey: params.apiKey,
+    model: params.model,
+    chatbotId: params.chatbotId,
+    requestHeaders: params.requestHeaders,
+    maxTokens: params.maxTokens,
+    debugModelResponses: params.debugModelResponses,
+    gatewayBaseUrl: params.gatewayBaseUrl,
+    gatewayApiToken: params.gatewayApiToken,
+    channelId: params.channelId,
+    configuredDiscordChannels: params.configuredDiscordChannels,
+    taskModels: params.taskModels,
+    media: params.media,
+    webSearch: params.webSearch,
+    providerCredentials: params.providerCredentials,
+  };
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-codex-mcp-'));
+  const contextPath = path.join(dir, 'context.json');
+  fs.writeFileSync(contextPath, JSON.stringify(context), {
+    encoding: 'utf-8',
+    mode: 0o600,
+  });
+  return contextPath;
+}
+
+export function projectCodexThreadItem(
+  projection: CodexProjection,
+  item: unknown,
+): void {
+  if (!isRecord(item)) return;
+  const type = readString(item, 'type');
+  if (type === 'agentMessage') {
+    const text = readString(item, 'text');
+    if (text) projection.agentMessages.push(text);
+    return;
+  }
+  if (type === 'commandExecution') {
+    appendToolExecution(projection, {
+      name: 'codex.command',
+      arguments: readString(item, 'command'),
+      result: readString(item, 'aggregatedOutput'),
+      durationMs: readNumber(item, 'durationMs') ?? 0,
+      isError: readString(item, 'status') !== 'completed',
+    });
+    return;
+  }
+  if (type === 'fileChange') {
+    appendToolExecution(projection, {
+      name: 'codex.patch',
+      arguments: JSON.stringify(item.changes ?? []),
+      result: readString(item, 'status') || 'file change completed',
+      durationMs: 0,
+      isError: readString(item, 'status') === 'failed',
+    });
+    return;
+  }
+  if (type === 'mcpToolCall' || type === 'dynamicToolCall') {
+    const tool =
+      type === 'mcpToolCall'
+        ? `${readString(item, 'server')}.${readString(item, 'tool')}`
+        : readString(item, 'tool');
+    appendToolExecution(projection, {
+      name: type === 'mcpToolCall' ? 'codex.mcp' : 'codex.tool',
+      arguments: JSON.stringify({ tool, arguments: item.arguments ?? null }),
+      result: JSON.stringify(
+        item.result ?? item.contentItems ?? item.error ?? null,
+      ),
+      durationMs: readNumber(item, 'durationMs') ?? 0,
+      isError:
+        item.success === false ||
+        readString(item, 'status') === 'failed' ||
+        Boolean(item.error),
+    });
+    return;
+  }
+  const normalizedType = type.toLowerCase();
+  if (normalizedType.includes('plan')) {
+    appendToolExecution(projection, {
+      name: 'codex.plan',
+      arguments: JSON.stringify(item.plan ?? item),
+      result: readString(item, 'status') || JSON.stringify(item),
+      durationMs: readNumber(item, 'durationMs') ?? 0,
+      isError: readString(item, 'status') === 'failed' || Boolean(item.error),
+    });
+    return;
+  }
+  if (normalizedType.includes('sandbox')) {
+    appendToolExecution(projection, {
+      name: 'codex.sandbox',
+      arguments: JSON.stringify(item),
+      result: readString(item, 'status') || JSON.stringify(item),
+      durationMs: readNumber(item, 'durationMs') ?? 0,
+      isError: readString(item, 'status') === 'failed' || Boolean(item.error),
+    });
+  }
+}
+
+function applyTokenUsage(
+  projection: CodexProjection,
+  tokenUsage: unknown,
+): void {
+  if (!isRecord(tokenUsage) || !isRecord(tokenUsage.total)) return;
+  const total = tokenUsage.total;
+  const inputTokens = readNumber(total, 'inputTokens') ?? 0;
+  const outputTokens = readNumber(total, 'outputTokens') ?? 0;
+  const totalTokens =
+    readNumber(total, 'totalTokens') ?? inputTokens + outputTokens;
+  const cachedInputTokens = readNumber(total, 'cachedInputTokens') ?? 0;
+  projection.tokenUsage.apiUsageAvailable = true;
+  projection.tokenUsage.apiPromptTokens = inputTokens;
+  projection.tokenUsage.apiCompletionTokens = outputTokens;
+  projection.tokenUsage.apiTotalTokens = totalTokens;
+  projection.tokenUsage.apiCacheUsageAvailable = cachedInputTokens > 0;
+  projection.tokenUsage.apiCacheReadTokens = cachedInputTokens;
+}
+
+function approvalExecution(method: string, params: unknown): ToolExecution {
+  return {
+    name: 'codex.approval',
+    arguments: JSON.stringify({ method, params }),
+    result:
+      'Codex app-server requested approval through the HybridClaw approval bridge.',
+    durationMs: 0,
+    isError: true,
+    blocked: true,
+    approvalTier: 'red',
+    approvalBaseTier: 'red',
+    approvalDecision: 'denied',
+  };
+}
+
+class CodexAppServerClient {
+  private nextId = 1;
+  private readonly pending = new Map<JsonRpcId, PendingRequest>();
+  private readonly projection: CodexProjection;
+  private completedResolver: ((projection: CodexProjection) => void) | null =
+    null;
+  private completedRejecter: ((error: Error) => void) | null = null;
+  private approvalResolver:
+    | ((approval: {
+        approvalId: string;
+        method: string;
+        params: unknown;
+        requestId: JsonRpcId;
+      }) => void)
+    | null = null;
+  private stderr = '';
+  private contextPath: string | null = null;
+
+  private readonly child;
+
+  constructor(
+    projection: CodexProjection,
+    params: RunCodexAppServerTurnParams,
+  ) {
+    this.projection = projection;
+    const spawnEnv = { ...process.env };
+    const contextPath = writeMcpContextFile(params);
+    if (contextPath) this.contextPath = contextPath;
+    const args = buildCodexAppServerArgs(params.mcpServers, contextPath);
+    this.child = spawn('codex', args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: spawnEnv,
+    });
+    const lines = readline.createInterface({ input: this.child.stdout });
+    lines.on('line', (line) => this.handleLine(line));
+    this.child.stderr.on('data', (chunk) => {
+      this.stderr += String(chunk);
+      if (this.stderr.length > 12_000) {
+        this.stderr = this.stderr.slice(-12_000);
+      }
+    });
+    this.child.on('error', (error) => this.rejectAll(error));
+    this.child.on('exit', (code, signal) => {
+      if (this.projection.completed) return;
+      this.rejectAll(
+        new Error(
+          `codex app-server exited before turn completion (code=${code ?? 'null'} signal=${signal ?? 'null'}).${this.stderr ? ` stderr: ${this.stderr.trim()}` : ''}`,
+        ),
+      );
+    });
+  }
+
+  request(method: string, params: unknown): Promise<unknown> {
+    const id = this.nextId++;
+    const payload = JSON.stringify({ id, method, params });
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`codex app-server request timed out: ${method}`));
+      }, CODEX_REQUEST_TIMEOUT_MS);
+      this.pending.set(id, { resolve, reject, timer });
+      this.child.stdin.write(`${payload}\n`);
+    });
+  }
+
+  waitForCompletion(): Promise<CodexProjection> {
+    if (this.projection.completed) return Promise.resolve(this.projection);
+    return new Promise((resolve, reject) => {
+      this.completedResolver = resolve;
+      this.completedRejecter = reject;
+    });
+  }
+
+  waitForCompletionOrApproval(): Promise<
+    | { kind: 'completed'; projection: CodexProjection }
+    | {
+        kind: 'approval';
+        approvalId: string;
+        method: string;
+        params: unknown;
+        requestId: JsonRpcId;
+      }
+  > {
+    if (this.projection.completed) {
+      return Promise.resolve({
+        kind: 'completed',
+        projection: this.projection,
+      });
+    }
+    return new Promise((resolve, reject) => {
+      this.completedResolver = (projection) => {
+        resolve({ kind: 'completed', projection });
+      };
+      this.completedRejecter = reject;
+      this.approvalResolver = (approval) => {
+        resolve({ kind: 'approval', ...approval });
+      };
+    });
+  }
+
+  resolveServerRequest(id: JsonRpcId, result: unknown): void {
+    this.sendResponse(id, result);
+  }
+
+  close(): void {
+    this.child.kill();
+    if (this.contextPath) {
+      fs.rmSync(path.dirname(this.contextPath), {
+        recursive: true,
+        force: true,
+      });
+      this.contextPath = null;
+    }
+  }
+
+  private resolveResponse(id: JsonRpcId, result: unknown): void {
+    const pending = this.pending.get(id);
+    if (!pending) return;
+    clearTimeout(pending.timer);
+    this.pending.delete(id);
+    pending.resolve(result);
+  }
+
+  private rejectResponse(id: JsonRpcId, error: unknown): void {
+    const pending = this.pending.get(id);
+    if (!pending) return;
+    clearTimeout(pending.timer);
+    this.pending.delete(id);
+    pending.reject(new Error(parseJsonRpcError(error)));
+  }
+
+  private rejectAll(error: Error): void {
+    for (const [id, pending] of this.pending) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+      this.pending.delete(id);
+    }
+    this.completedRejecter?.(error);
+  }
+
+  private handleLine(line: string): void {
+    if (!line.trim()) return;
+    let message: JsonRpcMessage;
+    try {
+      message = JSON.parse(line) as JsonRpcMessage;
+    } catch {
+      return;
+    }
+    if (message.id !== undefined && message.result !== undefined) {
+      this.resolveResponse(message.id, message.result);
+      return;
+    }
+    if (message.id !== undefined && message.error !== undefined) {
+      this.rejectResponse(message.id, message.error);
+      return;
+    }
+    if (message.id !== undefined && message.method) {
+      this.handleServerRequest(message.id, message.method, message.params);
+      return;
+    }
+    if (message.method) {
+      this.handleNotification(message.method, message.params);
+    }
+  }
+
+  private sendResponse(id: JsonRpcId, result: unknown): void {
+    this.child.stdin.write(`${JSON.stringify({ id, result })}\n`);
+  }
+
+  private sendError(id: JsonRpcId, message: string): void {
+    this.child.stdin.write(
+      `${JSON.stringify({ id, error: { code: -32000, message } })}\n`,
+    );
+  }
+
+  private handleServerRequest(
+    id: JsonRpcId,
+    method: string,
+    params: unknown,
+  ): void {
+    this.projection.approvalEvents.push(approvalExecution(method, params));
+    const approvalId = cryptoRandomApprovalId();
+    this.projection.pendingApproval = buildPendingApproval(
+      approvalId,
+      method,
+      params,
+    );
+    this.approvalResolver?.({ approvalId, method, params, requestId: id });
+    if (this.approvalResolver) {
+      this.approvalResolver = null;
+      return;
+    }
+    if (method === 'item/commandExecution/requestApproval') {
+      this.sendResponse(id, { decision: 'decline' });
+      return;
+    }
+    if (method === 'item/fileChange/requestApproval') {
+      this.sendResponse(id, { decision: 'decline' });
+      return;
+    }
+    if (method === 'item/permissions/requestApproval') {
+      this.sendResponse(id, {
+        permissions: {},
+        scope: 'turn',
+        strictAutoReview: true,
+      });
+      return;
+    }
+    if (method === 'execCommandApproval') {
+      this.sendResponse(id, { decision: 'denied' });
+      return;
+    }
+    if (method === 'applyPatchApproval') {
+      this.sendResponse(id, { decision: 'denied' });
+      return;
+    }
+    this.sendError(
+      id,
+      `HybridClaw Codex app-server bridge cannot service ${method}.`,
+    );
+  }
+
+  private handleNotification(method: string, params: unknown): void {
+    if (method === 'item/agentMessage/delta' && isRecord(params)) {
+      const delta = readString(params, 'delta');
+      if (delta) {
+        this.projection.textDeltas.push(delta);
+      }
+      return;
+    }
+    if (method === 'item/completed' && isRecord(params)) {
+      projectCodexThreadItem(this.projection, params.item);
+      return;
+    }
+    if (method === 'thread/tokenUsage/updated' && isRecord(params)) {
+      applyTokenUsage(this.projection, params.tokenUsage);
+      return;
+    }
+    if (method === 'turn/plan/updated' && isRecord(params)) {
+      appendToolExecution(this.projection, {
+        name: 'codex.plan',
+        arguments: JSON.stringify(params.plan ?? []),
+        result:
+          readString(params, 'explanation') ||
+          JSON.stringify(params.plan ?? []),
+        durationMs: 0,
+        isError: false,
+      });
+      return;
+    }
+    if (method === 'turn/completed' && isRecord(params)) {
+      this.projection.completed = true;
+      if (isRecord(params.turn) && isRecord(params.turn.error)) {
+        this.projection.error = parseTurnError(params.turn.error);
+      }
+      this.completedResolver?.(this.projection);
+      return;
+    }
+    if (method === 'error' && isRecord(params)) {
+      this.projection.error = parseTurnError(params);
+    }
+  }
+}
+
+function parseJsonRpcError(error: unknown): string {
+  if (isRecord(error) && typeof error.message === 'string') {
+    return error.message;
+  }
+  return typeof error === 'string' ? error : JSON.stringify(error);
+}
+
+function parseTurnError(error: Record<string, unknown>): string {
+  return (
+    readString(error, 'message') ||
+    readString(error, 'reason') ||
+    JSON.stringify(error)
+  );
+}
+
+function createProjection(): CodexProjection {
+  return {
+    threadId: null,
+    turnId: null,
+    textDeltas: [],
+    agentMessages: [],
+    toolExecutions: [],
+    toolsUsed: [],
+    tokenUsage: emptyTokenUsage(),
+    approvalEvents: [],
+    pendingApproval: null,
+    error: null,
+    completed: false,
+  };
+}
+
+export function buildCodexApprovalResponseForDirective(
+  method: string,
+  rawDirective: string,
+  params?: unknown,
+): unknown | null {
+  const directive = parseApprovalDirective(rawDirective);
+  if (!directive) return null;
+  if (
+    method === 'item/commandExecution/requestApproval' ||
+    method === 'item/fileChange/requestApproval'
+  ) {
+    return {
+      decision:
+        directive.kind === 'approve'
+          ? directive.mode === 'session'
+            ? 'acceptForSession'
+            : 'accept'
+          : 'decline',
+    };
+  }
+  if (method === 'execCommandApproval' || method === 'applyPatchApproval') {
+    return {
+      decision:
+        directive.kind === 'approve'
+          ? directive.mode === 'session'
+            ? 'approved_for_session'
+            : 'approved'
+          : 'denied',
+    };
+  }
+  if (method === 'item/permissions/requestApproval') {
+    const requestedPermissions =
+      isRecord(params) && isRecord(params.permissions)
+        ? params.permissions
+        : {};
+    return {
+      permissions: directive.kind === 'approve' ? requestedPermissions : {},
+      scope: directive.mode === 'session' ? 'session' : 'turn',
+      strictAutoReview: true,
+    };
+  }
+  return {
+    permissions: {},
+    scope: 'turn',
+    strictAutoReview: true,
+  };
+}
+
+function respondToCodexApproval(
+  pending: PendingCodexApproval,
+  directive: NonNullable<ReturnType<typeof parseApprovalDirective>>,
+): void {
+  const response = buildCodexApprovalResponseForDirective(
+    pending.method,
+    [
+      directive.kind,
+      directive.requestId,
+      directive.mode ? `for ${directive.mode}` : '',
+    ]
+      .filter(Boolean)
+      .join(' '),
+    pending.params,
+  );
+  pending.client.resolveServerRequest(pending.requestId, response);
+}
+
+function outputFromProjection(
+  completed: CodexProjection,
+  messages: ChatMessage[],
+): ContainerOutput {
+  const resultText =
+    completed.agentMessages.join('\n\n').trim() ||
+    completed.textDeltas.join('').trim();
+  const toolExecutions = [
+    ...completed.toolExecutions,
+    ...completed.approvalEvents,
+  ];
+  if (completed.pendingApproval && !completed.completed) {
+    return {
+      status: 'success',
+      result: completed.pendingApproval.prompt,
+      toolsUsed: completed.toolsUsed,
+      toolExecutions,
+      tokenUsage: completed.tokenUsage,
+      pendingApproval: completed.pendingApproval,
+      effectiveUserPrompt: buildCodexTurnText(messages),
+    };
+  }
+  if (completed.error) {
+    return {
+      status: 'error',
+      result: resultText || null,
+      toolsUsed: completed.toolsUsed,
+      toolExecutions,
+      tokenUsage: completed.tokenUsage,
+      error: completed.error,
+      effectiveUserPrompt: buildCodexTurnText(messages),
+    };
+  }
+  return {
+    status: 'success',
+    result: resultText || '',
+    toolsUsed: completed.toolsUsed,
+    toolExecutions,
+    tokenUsage: completed.tokenUsage,
+    effectiveUserPrompt: buildCodexTurnText(messages),
+  };
+}
+
+export async function resumePendingCodexAppServerApproval(
+  params: Pick<
+    RunCodexAppServerTurnParams,
+    'sessionId' | 'messages' | 'streamTextDeltas' | 'onTextDelta'
+  >,
+): Promise<ContainerOutput | null> {
+  const pending = pendingCodexApproval;
+  if (!isApprovalForPending(params.sessionId, params.messages, pending)) {
+    return null;
+  }
+  if (!pending) return null;
+  pendingCodexApproval = null;
+  const directive = parseApprovalDirective(latestUserText(params.messages));
+  if (!directive) return null;
+  try {
+    respondToCodexApproval(pending, directive);
+    const next = await pending.client.waitForCompletionOrApproval();
+    if (next.kind === 'approval') {
+      pending.projection.pendingApproval = buildPendingApproval(
+        next.approvalId,
+        next.method,
+        next.params,
+      );
+      pendingCodexApproval = {
+        approvalId: next.approvalId,
+        sessionId: pending.sessionId,
+        client: pending.client,
+        projection: pending.projection,
+        requestId: next.requestId,
+        method: next.method,
+        params: next.params,
+      };
+      return outputFromProjection(pending.projection, params.messages);
+    }
+    const output = outputFromProjection(next.projection, params.messages);
+    if (params.streamTextDeltas && output.result && params.onTextDelta) {
+      params.onTextDelta(output.result);
+    }
+    pending.client.close();
+    return output;
+  } catch (error) {
+    pending.client.close();
+    return {
+      status: 'error',
+      result: null,
+      toolsUsed: pending.projection.toolsUsed,
+      toolExecutions: [
+        ...pending.projection.toolExecutions,
+        ...pending.projection.approvalEvents,
+      ],
+      tokenUsage: pending.projection.tokenUsage,
+      error: error instanceof Error ? error.message : String(error),
+      effectiveUserPrompt: buildCodexTurnText(params.messages),
+    };
+  }
+}
+
+async function ensureCodexCliAvailable(): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn('codex', ['--version'], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+    let stderr = '';
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on('error', (error: NodeJS.ErrnoException) => {
+      if (error.code === 'ENOENT') {
+        reject(
+          new Error(
+            'Codex app-server runtime is selected, but `codex` is not installed or not on PATH. Install the OpenAI Codex CLI and restart the next HybridClaw session, or set `codex.runtime` back to `hybridclaw`.',
+          ),
+        );
+        return;
+      }
+      reject(error);
+    });
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(
+        new Error(
+          `Codex app-server runtime is selected, but \`codex --version\` failed with exit code ${code ?? 'null'}.${stderr ? ` ${stderr.trim()}` : ''}`,
+        ),
+      );
+    });
+  });
+}
+
+export async function runCodexAppServerTurn(
+  params: RunCodexAppServerTurnParams,
+): Promise<ContainerOutput> {
+  await ensureCodexCliAvailable();
+  if (pendingCodexApproval?.sessionId === params.sessionId) {
+    pendingCodexApproval.client.close();
+    pendingCodexApproval = null;
+  }
+  const projection = createProjection();
+  const client = new CodexAppServerClient(projection, params);
+  let keepClientOpen = false;
+  try {
+    await client.request('initialize', {
+      clientInfo: {
+        name: 'hybridclaw',
+        title: 'HybridClaw',
+        version: '0',
+      },
+      capabilities: { experimentalApi: true },
+    });
+
+    const thread = (await client.request('thread/start', {
+      model: normalizeCodexModelName(params.model),
+      cwd: params.cwd || process.cwd(),
+      approvalPolicy: 'on-request',
+      sandbox: 'workspace-write',
+      baseInstructions: extractSystemInstructions(params.messages),
+      developerInstructions:
+        'HybridClaw launched this turn through the optional Codex app-server runtime. If a HybridClaw-only tool is unavailable, say that the app-server bridge cannot service it in this mode.',
+      ephemeral: true,
+      experimentalRawEvents: true,
+      persistExtendedHistory: true,
+    })) as Record<string, unknown>;
+    const threadRecord = isRecord(thread.thread) ? thread.thread : {};
+    projection.threadId = readString(threadRecord, 'id');
+    if (!projection.threadId) {
+      throw new Error('codex app-server did not return a thread id');
+    }
+    if (thread.sandbox || thread.permissionProfile) {
+      appendToolExecution(projection, {
+        name: 'codex.sandbox',
+        arguments: JSON.stringify({
+          sandbox: thread.sandbox ?? null,
+          permissionProfile: thread.permissionProfile ?? null,
+        }),
+        result: 'sandbox policy active',
+        durationMs: 0,
+        isError: false,
+      });
+    }
+
+    const turn = (await client.request('turn/start', {
+      threadId: projection.threadId,
+      input: buildCodexUserInput(params.messages),
+      cwd: params.cwd || process.cwd(),
+      model: normalizeCodexModelName(params.model),
+    })) as Record<string, unknown>;
+    const turnRecord = isRecord(turn.turn) ? turn.turn : {};
+    projection.turnId = readString(turnRecord, 'id');
+    if (readString(turnRecord, 'status') === 'completed') {
+      projection.completed = true;
+    }
+
+    const next = projection.completed
+      ? { kind: 'completed' as const, projection }
+      : await client.waitForCompletionOrApproval();
+    if (next.kind === 'approval') {
+      projection.pendingApproval = buildPendingApproval(
+        next.approvalId,
+        next.method,
+        next.params,
+      );
+      pendingCodexApproval = {
+        approvalId: next.approvalId,
+        sessionId: params.sessionId,
+        client,
+        projection,
+        requestId: next.requestId,
+        method: next.method,
+        params: next.params,
+      };
+      keepClientOpen = true;
+      return outputFromProjection(projection, params.messages);
+    }
+    const output = outputFromProjection(next.projection, params.messages);
+    if (params.streamTextDeltas && output.result && params.onTextDelta) {
+      params.onTextDelta(output.result);
+    }
+    return output;
+  } catch (error) {
+    return {
+      status: 'error',
+      result: null,
+      toolsUsed: projection.toolsUsed,
+      toolExecutions: [
+        ...projection.toolExecutions,
+        ...projection.approvalEvents,
+      ],
+      tokenUsage: projection.tokenUsage,
+      error: error instanceof Error ? error.message : String(error),
+      effectiveUserPrompt: buildCodexTurnText(params.messages),
+    };
+  } finally {
+    if (!keepClientOpen) client.close();
+  }
+}

--- a/container/src/codex-app-server.ts
+++ b/container/src/codex-app-server.ts
@@ -90,6 +90,11 @@ interface PendingCodexApproval {
   params: unknown;
 }
 
+interface CodexMcpContextPayloads {
+  fileContext: Record<string, unknown>;
+  secretContext: Record<string, unknown>;
+}
+
 let pendingCodexApproval: PendingCodexApproval | null = null;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -354,28 +359,80 @@ export function buildCodexAppServerArgs(
   return args;
 }
 
+export function buildCodexMcpContextPayloads(
+  params: Pick<
+    RunCodexAppServerTurnParams,
+    | 'provider'
+    | 'providerMethod'
+    | 'baseUrl'
+    | 'apiKey'
+    | 'model'
+    | 'chatbotId'
+    | 'requestHeaders'
+    | 'maxTokens'
+    | 'debugModelResponses'
+    | 'gatewayBaseUrl'
+    | 'gatewayApiToken'
+    | 'channelId'
+    | 'configuredDiscordChannels'
+    | 'taskModels'
+    | 'media'
+    | 'webSearch'
+    | 'providerCredentials'
+  >,
+): CodexMcpContextPayloads {
+  return {
+    fileContext: {
+      provider: params.provider,
+      providerMethod: params.providerMethod,
+      baseUrl: params.baseUrl,
+      model: params.model,
+      chatbotId: params.chatbotId,
+      maxTokens: params.maxTokens,
+      debugModelResponses: params.debugModelResponses,
+      channelId: params.channelId,
+      configuredDiscordChannels: params.configuredDiscordChannels,
+      taskModels: params.taskModels,
+      media: params.media,
+    },
+    secretContext: {
+      apiKey: params.apiKey,
+      requestHeaders: params.requestHeaders,
+      gatewayBaseUrl: params.gatewayBaseUrl,
+      gatewayApiToken: params.gatewayApiToken,
+      webSearch: params.webSearch,
+      providerCredentials: params.providerCredentials,
+    },
+  };
+}
+
+function compactRecord(
+  record: Record<string, unknown>,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(record).filter(([, value]) => value !== undefined),
+  );
+}
+
+function buildMcpSecretEnv(
+  params: RunCodexAppServerTurnParams,
+): Record<string, string> {
+  const { secretContext } = buildCodexMcpContextPayloads(params);
+  const compact = compactRecord(secretContext);
+  if (Object.keys(compact).length === 0) return {};
+  return {
+    HYBRIDCLAW_CODEX_MCP_SECRET_CONTEXT_B64: Buffer.from(
+      JSON.stringify(compact),
+      'utf-8',
+    ).toString('base64'),
+  };
+}
+
 function writeMcpContextFile(
   params: RunCodexAppServerTurnParams,
 ): string | null {
-  const context = {
-    provider: params.provider,
-    providerMethod: params.providerMethod,
-    baseUrl: params.baseUrl,
-    apiKey: params.apiKey,
-    model: params.model,
-    chatbotId: params.chatbotId,
-    requestHeaders: params.requestHeaders,
-    maxTokens: params.maxTokens,
-    debugModelResponses: params.debugModelResponses,
-    gatewayBaseUrl: params.gatewayBaseUrl,
-    gatewayApiToken: params.gatewayApiToken,
-    channelId: params.channelId,
-    configuredDiscordChannels: params.configuredDiscordChannels,
-    taskModels: params.taskModels,
-    media: params.media,
-    webSearch: params.webSearch,
-    providerCredentials: params.providerCredentials,
-  };
+  const { fileContext } = buildCodexMcpContextPayloads(params);
+  const context = compactRecord(fileContext);
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-codex-mcp-'));
   const contextPath = path.join(dir, 'context.json');
   fs.writeFileSync(contextPath, JSON.stringify(context), {
@@ -483,11 +540,36 @@ function approvalExecution(method: string, params: unknown): ToolExecution {
     result:
       'Codex app-server requested approval through the HybridClaw approval bridge.',
     durationMs: 0,
-    isError: true,
+    isError: false,
     blocked: true,
     approvalTier: 'red',
     approvalBaseTier: 'red',
-    approvalDecision: 'denied',
+    approvalDecision: 'required',
+  };
+}
+
+function approvalResolutionExecution(
+  method: string,
+  params: unknown,
+  directive: NonNullable<ReturnType<typeof parseApprovalDirective>>,
+): ToolExecution {
+  const approved = directive.kind === 'approve';
+  return {
+    name: 'codex.approval',
+    arguments: JSON.stringify({ method, params }),
+    result: approved
+      ? 'Codex app-server approval granted by user response.'
+      : 'Codex app-server approval denied by user response.',
+    durationMs: 0,
+    isError: !approved,
+    blocked: !approved,
+    approvalTier: 'red',
+    approvalBaseTier: 'red',
+    approvalDecision: approved
+      ? directive.mode === 'session'
+        ? 'approved_session'
+        : 'approved_once'
+      : 'denied',
   };
 }
 
@@ -516,7 +598,7 @@ class CodexAppServerClient {
     params: RunCodexAppServerTurnParams,
   ) {
     this.projection = projection;
-    const spawnEnv = { ...process.env };
+    const spawnEnv = { ...process.env, ...buildMcpSecretEnv(params) };
     const contextPath = writeMcpContextFile(params);
     if (contextPath) this.contextPath = contextPath;
     const args = buildCodexAppServerArgs(params.mcpServers, contextPath);
@@ -848,6 +930,9 @@ function respondToCodexApproval(
       .filter(Boolean)
       .join(' '),
     pending.params,
+  );
+  pending.projection.approvalEvents.push(
+    approvalResolutionExecution(pending.method, pending.params, directive),
   );
   pending.client.resolveServerRequest(pending.requestId, response);
 }

--- a/container/src/codex-app-server.ts
+++ b/container/src/codex-app-server.ts
@@ -5,6 +5,11 @@ import os from 'node:os';
 import path from 'node:path';
 import readline from 'node:readline';
 import { fileURLToPath } from 'node:url';
+import type { CodexMcpContext } from './codex-app-types.js';
+import {
+  isRecord,
+  readString as readUnknownString,
+} from './codex-app-utils.js';
 import type {
   ChatMessage,
   ContainerInput,
@@ -32,11 +37,10 @@ interface PendingRequest {
 
 interface CodexProjection {
   threadId: string | null;
-  turnId: string | null;
   textDeltas: string[];
   agentMessages: string[];
   toolExecutions: ToolExecution[];
-  toolsUsed: string[];
+  toolsUsed: Set<string>;
   tokenUsage: TokenUsageStats;
   approvalEvents: ToolExecution[];
   pendingApproval: PendingApproval | null;
@@ -74,7 +78,7 @@ const CODEX_REQUEST_TIMEOUT_MS = 30_000;
 const CODEX_APPROVAL_EXPIRES_MS = 10 * 60 * 1000;
 const MCP_SERVER_NAME_RE = /^[a-zA-Z0-9_-]{1,64}$/;
 const SENSITIVE_ENV_KEY_RE =
-  /(secret|token|password|passwd|credential|apikey|api_key|auth|bearer|private)/i;
+  /(^|[_-])(secret|token|password|passwd|pass|credential|credentials|apikey|api[-_]?key|auth|bearer|private|key)([_-]|$)|apikey|api_key/i;
 const MCP_SCRIPT_PATH = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
   'codex-hybridclaw-mcp.js',
@@ -95,11 +99,8 @@ interface CodexMcpContextPayloads {
   secretContext: Record<string, unknown>;
 }
 
-let pendingCodexApproval: PendingCodexApproval | null = null;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
+const pendingCodexApprovals = new Map<string, PendingCodexApproval>();
+let codexCliAvailablePromise: Promise<void> | null = null;
 
 function normalizeCodexModelName(model: string): string {
   const trimmed = String(model || '').trim();
@@ -158,10 +159,10 @@ export function buildCodexTurnText(messages: ChatMessage[]): string {
 
 function buildCodexUserInput(
   messages: ChatMessage[],
+  text = buildCodexTurnText(messages),
 ): Array<Record<string, unknown>> {
   const input: Array<Record<string, unknown>> = [];
   const latest = latestUserMessage(messages);
-  const text = buildCodexTurnText(messages);
   if (text) {
     input.push({ type: 'text', text, text_elements: [] });
   }
@@ -191,7 +192,7 @@ function emptyTokenUsage(): TokenUsageStats {
 }
 
 function readString(record: Record<string, unknown>, key: string): string {
-  return typeof record[key] === 'string' ? record[key] : '';
+  return readUnknownString(record[key]);
 }
 
 function readNumber(
@@ -208,9 +209,11 @@ function appendToolExecution(
   execution: ToolExecution,
 ): void {
   projection.toolExecutions.push(execution);
-  if (!projection.toolsUsed.includes(execution.name)) {
-    projection.toolsUsed.push(execution.name);
-  }
+  projection.toolsUsed.add(execution.name);
+}
+
+function projectionToolsUsed(projection: CodexProjection): string[] {
+  return [...projection.toolsUsed];
 }
 
 function latestUserText(messages: ChatMessage[]): string {
@@ -243,11 +246,13 @@ function parseApprovalDirective(input: string): {
   return null;
 }
 
+type ApprovalDirective = NonNullable<ReturnType<typeof parseApprovalDirective>>;
+
 function isApprovalForPending(
   sessionId: string,
   messages: ChatMessage[],
   pending: PendingCodexApproval | null,
-): boolean {
+): pending is PendingCodexApproval {
   if (!pending) return false;
   if (pending.sessionId !== sessionId) return false;
   const directive = parseApprovalDirective(latestUserText(messages));
@@ -278,10 +283,6 @@ function buildPendingApproval(
     allowAll: false,
     expiresAt: Date.now() + CODEX_APPROVAL_EXPIRES_MS,
   };
-}
-
-function cryptoRandomApprovalId(): string {
-  return randomUUID();
 }
 
 function tomlString(value: string): string {
@@ -359,6 +360,38 @@ export function buildCodexAppServerArgs(
   return args;
 }
 
+function compactRecord(
+  record: Record<string, unknown>,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(record).filter(([, value]) => value !== undefined),
+  );
+}
+
+function splitWebSearchConfig(webSearch: ContainerInput['webSearch']): {
+  fileWebSearch?: ContainerInput['webSearch'];
+  secretWebSearch?: Partial<NonNullable<ContainerInput['webSearch']>>;
+} {
+  if (!webSearch) return {};
+  const {
+    braveApiKey,
+    perplexityApiKey,
+    tavilyApiKey,
+    searxngBearerTokenRef,
+    ...fileWebSearch
+  } = webSearch;
+  const secretWebSearch = compactRecord({
+    braveApiKey,
+    perplexityApiKey,
+    tavilyApiKey,
+    searxngBearerTokenRef,
+  }) as Partial<NonNullable<ContainerInput['webSearch']>>;
+  return {
+    fileWebSearch,
+    ...(Object.keys(secretWebSearch).length > 0 ? { secretWebSearch } : {}),
+  };
+}
+
 export function buildCodexMcpContextPayloads(
   params: Pick<
     RunCodexAppServerTurnParams,
@@ -381,8 +414,11 @@ export function buildCodexMcpContextPayloads(
     | 'providerCredentials'
   >,
 ): CodexMcpContextPayloads {
+  const { fileWebSearch, secretWebSearch } = splitWebSearchConfig(
+    params.webSearch,
+  );
   return {
-    fileContext: {
+    fileContext: compactRecord({
       provider: params.provider,
       providerMethod: params.providerMethod,
       baseUrl: params.baseUrl,
@@ -394,24 +430,17 @@ export function buildCodexMcpContextPayloads(
       configuredDiscordChannels: params.configuredDiscordChannels,
       taskModels: params.taskModels,
       media: params.media,
-    },
-    secretContext: {
+      webSearch: fileWebSearch,
+    }) satisfies CodexMcpContext,
+    secretContext: compactRecord({
       apiKey: params.apiKey,
       requestHeaders: params.requestHeaders,
       gatewayBaseUrl: params.gatewayBaseUrl,
       gatewayApiToken: params.gatewayApiToken,
-      webSearch: params.webSearch,
+      webSearch: secretWebSearch,
       providerCredentials: params.providerCredentials,
-    },
+    }) satisfies CodexMcpContext,
   };
-}
-
-function compactRecord(
-  record: Record<string, unknown>,
-): Record<string, unknown> {
-  return Object.fromEntries(
-    Object.entries(record).filter(([, value]) => value !== undefined),
-  );
 }
 
 function buildMcpSecretEnv(
@@ -588,7 +617,8 @@ class CodexAppServerClient {
         requestId: JsonRpcId;
       }) => void)
     | null = null;
-  private stderr = '';
+  private readonly stderrChunks: string[] = [];
+  private stderrLength = 0;
   private contextPath: string | null = null;
 
   private readonly child;
@@ -609,20 +639,32 @@ class CodexAppServerClient {
     const lines = readline.createInterface({ input: this.child.stdout });
     lines.on('line', (line) => this.handleLine(line));
     this.child.stderr.on('data', (chunk) => {
-      this.stderr += String(chunk);
-      if (this.stderr.length > 12_000) {
-        this.stderr = this.stderr.slice(-12_000);
-      }
+      this.appendStderr(String(chunk));
     });
     this.child.on('error', (error) => this.rejectAll(error));
     this.child.on('exit', (code, signal) => {
       if (this.projection.completed) return;
+      const stderr = this.stderrText().trim();
       this.rejectAll(
         new Error(
-          `codex app-server exited before turn completion (code=${code ?? 'null'} signal=${signal ?? 'null'}).${this.stderr ? ` stderr: ${this.stderr.trim()}` : ''}`,
+          `codex app-server exited before turn completion (code=${code ?? 'null'} signal=${signal ?? 'null'}).${stderr ? ` stderr: ${stderr}` : ''}`,
         ),
       );
     });
+  }
+
+  private appendStderr(chunk: string): void {
+    if (!chunk) return;
+    this.stderrChunks.push(chunk);
+    this.stderrLength += chunk.length;
+    while (this.stderrLength > 24_000 && this.stderrChunks.length > 1) {
+      this.stderrLength -= this.stderrChunks.shift()?.length ?? 0;
+    }
+  }
+
+  private stderrText(): string {
+    const text = this.stderrChunks.join('');
+    return text.length > 12_000 ? text.slice(-12_000) : text;
   }
 
   request(method: string, params: unknown): Promise<unknown> {
@@ -754,7 +796,7 @@ class CodexAppServerClient {
     params: unknown,
   ): void {
     this.projection.approvalEvents.push(approvalExecution(method, params));
-    const approvalId = cryptoRandomApprovalId();
+    const approvalId = randomUUID();
     this.projection.pendingApproval = buildPendingApproval(
       approvalId,
       method,
@@ -855,11 +897,10 @@ function parseTurnError(error: Record<string, unknown>): string {
 function createProjection(): CodexProjection {
   return {
     threadId: null,
-    turnId: null,
     textDeltas: [],
     agentMessages: [],
     toolExecutions: [],
-    toolsUsed: [],
+    toolsUsed: new Set<string>(),
     tokenUsage: emptyTokenUsage(),
     approvalEvents: [],
     pendingApproval: null,
@@ -868,13 +909,11 @@ function createProjection(): CodexProjection {
   };
 }
 
-export function buildCodexApprovalResponseForDirective(
+function buildCodexApprovalResponse(
   method: string,
-  rawDirective: string,
+  directive: ApprovalDirective,
   params?: unknown,
 ): unknown | null {
-  const directive = parseApprovalDirective(rawDirective);
-  if (!directive) return null;
   if (
     method === 'item/commandExecution/requestApproval' ||
     method === 'item/fileChange/requestApproval'
@@ -916,19 +955,24 @@ export function buildCodexApprovalResponseForDirective(
   };
 }
 
+export function buildCodexApprovalResponseForDirective(
+  method: string,
+  rawDirective: string,
+  params?: unknown,
+): unknown | null {
+  const directive = parseApprovalDirective(rawDirective);
+  return directive
+    ? buildCodexApprovalResponse(method, directive, params)
+    : null;
+}
+
 function respondToCodexApproval(
   pending: PendingCodexApproval,
-  directive: NonNullable<ReturnType<typeof parseApprovalDirective>>,
+  directive: ApprovalDirective,
 ): void {
-  const response = buildCodexApprovalResponseForDirective(
+  const response = buildCodexApprovalResponse(
     pending.method,
-    [
-      directive.kind,
-      directive.requestId,
-      directive.mode ? `for ${directive.mode}` : '',
-    ]
-      .filter(Boolean)
-      .join(' '),
+    directive,
     pending.params,
   );
   pending.projection.approvalEvents.push(
@@ -939,7 +983,7 @@ function respondToCodexApproval(
 
 function outputFromProjection(
   completed: CodexProjection,
-  messages: ChatMessage[],
+  effectiveUserPrompt: string,
 ): ContainerOutput {
   const resultText =
     completed.agentMessages.join('\n\n').trim() ||
@@ -952,31 +996,50 @@ function outputFromProjection(
     return {
       status: 'success',
       result: completed.pendingApproval.prompt,
-      toolsUsed: completed.toolsUsed,
+      toolsUsed: projectionToolsUsed(completed),
       toolExecutions,
       tokenUsage: completed.tokenUsage,
       pendingApproval: completed.pendingApproval,
-      effectiveUserPrompt: buildCodexTurnText(messages),
+      effectiveUserPrompt,
     };
   }
   if (completed.error) {
     return {
       status: 'error',
       result: resultText || null,
-      toolsUsed: completed.toolsUsed,
+      toolsUsed: projectionToolsUsed(completed),
       toolExecutions,
       tokenUsage: completed.tokenUsage,
       error: completed.error,
-      effectiveUserPrompt: buildCodexTurnText(messages),
+      effectiveUserPrompt,
     };
   }
   return {
     status: 'success',
     result: resultText || '',
-    toolsUsed: completed.toolsUsed,
+    toolsUsed: projectionToolsUsed(completed),
     toolExecutions,
     tokenUsage: completed.tokenUsage,
-    effectiveUserPrompt: buildCodexTurnText(messages),
+    effectiveUserPrompt,
+  };
+}
+
+function errorOutputFromProjection(
+  projection: CodexProjection,
+  effectiveUserPrompt: string,
+  error: unknown,
+): ContainerOutput {
+  return {
+    status: 'error',
+    result: null,
+    toolsUsed: projectionToolsUsed(projection),
+    toolExecutions: [
+      ...projection.toolExecutions,
+      ...projection.approvalEvents,
+    ],
+    tokenUsage: projection.tokenUsage,
+    error: error instanceof Error ? error.message : String(error),
+    effectiveUserPrompt,
   };
 }
 
@@ -986,12 +1049,12 @@ export async function resumePendingCodexAppServerApproval(
     'sessionId' | 'messages' | 'streamTextDeltas' | 'onTextDelta'
   >,
 ): Promise<ContainerOutput | null> {
-  const pending = pendingCodexApproval;
+  const effectiveUserPrompt = buildCodexTurnText(params.messages);
+  const pending = pendingCodexApprovals.get(params.sessionId) ?? null;
   if (!isApprovalForPending(params.sessionId, params.messages, pending)) {
     return null;
   }
-  if (!pending) return null;
-  pendingCodexApproval = null;
+  pendingCodexApprovals.delete(params.sessionId);
   const directive = parseApprovalDirective(latestUserText(params.messages));
   if (!directive) return null;
   try {
@@ -1003,7 +1066,7 @@ export async function resumePendingCodexAppServerApproval(
         next.method,
         next.params,
       );
-      pendingCodexApproval = {
+      pendingCodexApprovals.set(pending.sessionId, {
         approvalId: next.approvalId,
         sessionId: pending.sessionId,
         client: pending.client,
@@ -1011,10 +1074,10 @@ export async function resumePendingCodexAppServerApproval(
         requestId: next.requestId,
         method: next.method,
         params: next.params,
-      };
-      return outputFromProjection(pending.projection, params.messages);
+      });
+      return outputFromProjection(pending.projection, effectiveUserPrompt);
     }
-    const output = outputFromProjection(next.projection, params.messages);
+    const output = outputFromProjection(next.projection, effectiveUserPrompt);
     if (params.streamTextDeltas && output.result && params.onTextDelta) {
       params.onTextDelta(output.result);
     }
@@ -1022,22 +1085,15 @@ export async function resumePendingCodexAppServerApproval(
     return output;
   } catch (error) {
     pending.client.close();
-    return {
-      status: 'error',
-      result: null,
-      toolsUsed: pending.projection.toolsUsed,
-      toolExecutions: [
-        ...pending.projection.toolExecutions,
-        ...pending.projection.approvalEvents,
-      ],
-      tokenUsage: pending.projection.tokenUsage,
-      error: error instanceof Error ? error.message : String(error),
-      effectiveUserPrompt: buildCodexTurnText(params.messages),
-    };
+    return errorOutputFromProjection(
+      pending.projection,
+      effectiveUserPrompt,
+      error,
+    );
   }
 }
 
-async function ensureCodexCliAvailable(): Promise<void> {
+async function checkCodexCliAvailable(): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     const child = spawn('codex', ['--version'], {
       stdio: ['ignore', 'ignore', 'pipe'],
@@ -1071,14 +1127,21 @@ async function ensureCodexCliAvailable(): Promise<void> {
   });
 }
 
+async function ensureCodexCliAvailable(): Promise<void> {
+  codexCliAvailablePromise ??= checkCodexCliAvailable();
+  await codexCliAvailablePromise;
+}
+
 export async function runCodexAppServerTurn(
   params: RunCodexAppServerTurnParams,
 ): Promise<ContainerOutput> {
   await ensureCodexCliAvailable();
-  if (pendingCodexApproval?.sessionId === params.sessionId) {
-    pendingCodexApproval.client.close();
-    pendingCodexApproval = null;
+  const stalePending = pendingCodexApprovals.get(params.sessionId);
+  if (stalePending) {
+    stalePending.client.close();
+    pendingCodexApprovals.delete(params.sessionId);
   }
+  const effectiveUserPrompt = buildCodexTurnText(params.messages);
   const projection = createProjection();
   const client = new CodexAppServerClient(projection, params);
   let keepClientOpen = false;
@@ -1101,6 +1164,7 @@ export async function runCodexAppServerTurn(
       developerInstructions:
         'HybridClaw launched this turn through the optional Codex app-server runtime. If a HybridClaw-only tool is unavailable, say that the app-server bridge cannot service it in this mode.',
       ephemeral: true,
+      // These event streams are load-bearing for projecting Codex state back into HybridClaw transcripts.
       experimentalRawEvents: true,
       persistExtendedHistory: true,
     })) as Record<string, unknown>;
@@ -1124,12 +1188,11 @@ export async function runCodexAppServerTurn(
 
     const turn = (await client.request('turn/start', {
       threadId: projection.threadId,
-      input: buildCodexUserInput(params.messages),
+      input: buildCodexUserInput(params.messages, effectiveUserPrompt),
       cwd: params.cwd || process.cwd(),
       model: normalizeCodexModelName(params.model),
     })) as Record<string, unknown>;
     const turnRecord = isRecord(turn.turn) ? turn.turn : {};
-    projection.turnId = readString(turnRecord, 'id');
     if (readString(turnRecord, 'status') === 'completed') {
       projection.completed = true;
     }
@@ -1143,7 +1206,7 @@ export async function runCodexAppServerTurn(
         next.method,
         next.params,
       );
-      pendingCodexApproval = {
+      pendingCodexApprovals.set(params.sessionId, {
         approvalId: next.approvalId,
         sessionId: params.sessionId,
         client,
@@ -1151,28 +1214,17 @@ export async function runCodexAppServerTurn(
         requestId: next.requestId,
         method: next.method,
         params: next.params,
-      };
+      });
       keepClientOpen = true;
-      return outputFromProjection(projection, params.messages);
+      return outputFromProjection(projection, effectiveUserPrompt);
     }
-    const output = outputFromProjection(next.projection, params.messages);
+    const output = outputFromProjection(next.projection, effectiveUserPrompt);
     if (params.streamTextDeltas && output.result && params.onTextDelta) {
       params.onTextDelta(output.result);
     }
     return output;
   } catch (error) {
-    return {
-      status: 'error',
-      result: null,
-      toolsUsed: projection.toolsUsed,
-      toolExecutions: [
-        ...projection.toolExecutions,
-        ...projection.approvalEvents,
-      ],
-      tokenUsage: projection.tokenUsage,
-      error: error instanceof Error ? error.message : String(error),
-      effectiveUserPrompt: buildCodexTurnText(params.messages),
-    };
+    return errorOutputFromProjection(projection, effectiveUserPrompt, error);
   } finally {
     if (!keepClientOpen) client.close();
   }

--- a/container/src/codex-app-types.ts
+++ b/container/src/codex-app-types.ts
@@ -1,0 +1,21 @@
+import type { ContainerInput } from './types.js';
+
+export interface CodexMcpContext {
+  provider?: ContainerInput['provider'];
+  providerMethod?: string;
+  baseUrl?: string;
+  apiKey?: string;
+  model?: string;
+  chatbotId?: string;
+  requestHeaders?: Record<string, string>;
+  maxTokens?: number;
+  debugModelResponses?: boolean;
+  gatewayBaseUrl?: string;
+  gatewayApiToken?: string;
+  channelId?: string;
+  configuredDiscordChannels?: string[];
+  taskModels?: ContainerInput['taskModels'];
+  media?: ContainerInput['media'];
+  webSearch?: ContainerInput['webSearch'];
+  providerCredentials?: ContainerInput['providerCredentials'];
+}

--- a/container/src/codex-app-utils.ts
+++ b/container/src/codex-app-utils.ts
@@ -1,0 +1,11 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function readRecord(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+export function readString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}

--- a/container/src/codex-hybridclaw-mcp.ts
+++ b/container/src/codex-hybridclaw-mcp.ts
@@ -67,6 +67,16 @@ const CUSTOM_CALLBACK_TOOLS: McpToolDefinition[] = [
       },
     },
   },
+  {
+    name: 'voice_status',
+    description:
+      'Inspect read-only HybridClaw voice and TTS gateway configuration status. This does not place calls or synthesize speech.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {},
+    },
+  },
 ];
 
 function isCallbackTool(tool: ToolDefinition): boolean {
@@ -238,6 +248,67 @@ function handleSkillLookup(args: Record<string, unknown>): string {
   return JSON.stringify({ skills }, null, 2);
 }
 
+function gatewayStatusUrl(context: CodexMcpContext | null): string | null {
+  const baseUrl = String(context?.gatewayBaseUrl || '').trim();
+  if (!baseUrl) return null;
+  try {
+    const url = new URL(baseUrl);
+    url.pathname = `${url.pathname.replace(/\/+$/, '')}/api/status`;
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+async function handleVoiceStatus(
+  context: CodexMcpContext | null,
+): Promise<string> {
+  const url = gatewayStatusUrl(context);
+  if (!url) {
+    return JSON.stringify(
+      {
+        ok: false,
+        error:
+          'HybridClaw voice status is unavailable because gatewayBaseUrl is not configured.',
+      },
+      null,
+      2,
+    );
+  }
+
+  const headers: Record<string, string> = {};
+  if (context?.gatewayApiToken) {
+    headers.Authorization = `Bearer ${context.gatewayApiToken}`;
+  }
+  const response = await fetch(url, { method: 'GET', headers });
+  const rawText = await response.text();
+  let parsed: Record<string, unknown> | null = null;
+  try {
+    const maybe = JSON.parse(rawText) as unknown;
+    if (maybe && typeof maybe === 'object' && !Array.isArray(maybe)) {
+      parsed = maybe as Record<string, unknown>;
+    }
+  } catch {
+    parsed = null;
+  }
+
+  if (!response.ok) {
+    return JSON.stringify(
+      {
+        ok: false,
+        status: response.status,
+        error: parsed?.error || rawText || `HTTP ${response.status}`,
+      },
+      null,
+      2,
+    );
+  }
+
+  return JSON.stringify({ ok: true, voice: parsed?.voice ?? null }, null, 2);
+}
+
 export function buildUnavailableCallbackToolResult(toolName: string): {
   content: Array<{ type: 'text'; text: string }>;
   isError: true;
@@ -263,7 +334,8 @@ export function getHybridClawCallbackMcpToolNames(): string[] {
 }
 
 async function main(): Promise<void> {
-  applyContext(readContext());
+  const context = readContext();
+  applyContext(context);
   const tools = [
     ...TOOL_DEFINITIONS.filter(isCallbackTool).map(buildMcpTool),
     ...CUSTOM_CALLBACK_TOOLS,
@@ -288,6 +360,12 @@ async function main(): Promise<void> {
             text: handleSkillLookup(readRecord(request.params.arguments)),
           },
         ],
+        isError: false,
+      };
+    }
+    if (toolName === 'voice_status') {
+      return {
+        content: [{ type: 'text', text: await handleVoiceStatus(context) }],
         isError: false,
       };
     }

--- a/container/src/codex-hybridclaw-mcp.ts
+++ b/container/src/codex-hybridclaw-mcp.ts
@@ -110,12 +110,33 @@ function readContext(): McpContext | null {
   const contextPath = String(
     process.env.HYBRIDCLAW_CODEX_MCP_CONTEXT_PATH || '',
   ).trim();
-  if (!contextPath) return null;
+  const secretContext = readSecretContext();
+  if (!contextPath) return secretContext;
   try {
-    return JSON.parse(fs.readFileSync(contextPath, 'utf-8')) as McpContext;
+    const fileContext = JSON.parse(
+      fs.readFileSync(contextPath, 'utf-8'),
+    ) as McpContext;
+    return { ...fileContext, ...secretContext };
   } catch (error) {
     console.error(
       `[hybridclaw-mcp] failed to read context: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return secretContext;
+  }
+}
+
+function readSecretContext(): McpContext | null {
+  const encoded = String(
+    process.env.HYBRIDCLAW_CODEX_MCP_SECRET_CONTEXT_B64 || '',
+  ).trim();
+  if (!encoded) return null;
+  try {
+    return JSON.parse(
+      Buffer.from(encoded, 'base64').toString('utf-8'),
+    ) as McpContext;
+  } catch (error) {
+    console.error(
+      `[hybridclaw-mcp] failed to read secret context: ${error instanceof Error ? error.message : String(error)}`,
     );
     return null;
   }

--- a/container/src/codex-hybridclaw-mcp.ts
+++ b/container/src/codex-hybridclaw-mcp.ts
@@ -9,6 +9,8 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
+import type { CodexMcpContext } from './codex-app-types.js';
+import { readRecord, readString } from './codex-app-utils.js';
 import {
   executeToolWithMetadata,
   setGatewayContext,
@@ -19,27 +21,7 @@ import {
   setWebSearchConfig,
   TOOL_DEFINITIONS,
 } from './tools.js';
-import type { ContainerInput, ToolDefinition } from './types.js';
-
-interface McpContext {
-  provider?: ContainerInput['provider'];
-  providerMethod?: string;
-  baseUrl?: string;
-  apiKey?: string;
-  model?: string;
-  chatbotId?: string;
-  requestHeaders?: Record<string, string>;
-  maxTokens?: number;
-  debugModelResponses?: boolean;
-  gatewayBaseUrl?: string;
-  gatewayApiToken?: string;
-  channelId?: string;
-  configuredDiscordChannels?: string[];
-  taskModels?: ContainerInput['taskModels'];
-  media?: ContainerInput['media'];
-  webSearch?: ContainerInput['webSearch'];
-  providerCredentials?: ContainerInput['providerCredentials'];
-}
+import type { ToolDefinition } from './types.js';
 
 const CALLBACK_TOOL_NAMES = new Set([
   'web_fetch',
@@ -55,6 +37,10 @@ interface McpToolDefinition {
   description: string;
   inputSchema: unknown;
 }
+
+type SkillEntry = NonNullable<ReturnType<typeof readSkillEntry>>;
+
+let skillEntriesCache: SkillEntry[] | null = null;
 
 const CUSTOM_CALLBACK_TOOLS: McpToolDefinition[] = [
   {
@@ -81,16 +67,6 @@ const CUSTOM_CALLBACK_TOOLS: McpToolDefinition[] = [
       },
     },
   },
-  {
-    name: 'tts_status',
-    description:
-      'Explain whether HybridClaw text-to-speech is available through the safe Codex app-server MCP callback surface.',
-    inputSchema: {
-      type: 'object',
-      additionalProperties: false,
-      properties: {},
-    },
-  },
 ];
 
 function isCallbackTool(tool: ToolDefinition): boolean {
@@ -106,7 +82,7 @@ export function isHybridClawCallbackToolName(toolName: string): boolean {
   );
 }
 
-function readContext(): McpContext | null {
+function readContext(): CodexMcpContext | null {
   const contextPath = String(
     process.env.HYBRIDCLAW_CODEX_MCP_CONTEXT_PATH || '',
   ).trim();
@@ -115,7 +91,7 @@ function readContext(): McpContext | null {
   try {
     const fileContext = JSON.parse(
       fs.readFileSync(contextPath, 'utf-8'),
-    ) as McpContext;
+    ) as CodexMcpContext;
     return { ...fileContext, ...secretContext };
   } catch (error) {
     console.error(
@@ -125,7 +101,7 @@ function readContext(): McpContext | null {
   }
 }
 
-function readSecretContext(): McpContext | null {
+function readSecretContext(): CodexMcpContext | null {
   const encoded = String(
     process.env.HYBRIDCLAW_CODEX_MCP_SECRET_CONTEXT_B64 || '',
   ).trim();
@@ -133,7 +109,7 @@ function readSecretContext(): McpContext | null {
   try {
     return JSON.parse(
       Buffer.from(encoded, 'base64').toString('utf-8'),
-    ) as McpContext;
+    ) as CodexMcpContext;
   } catch (error) {
     console.error(
       `[hybridclaw-mcp] failed to read secret context: ${error instanceof Error ? error.message : String(error)}`,
@@ -142,7 +118,7 @@ function readSecretContext(): McpContext | null {
   }
 }
 
-function applyContext(context: McpContext | null): void {
+function applyContext(context: CodexMcpContext | null): void {
   if (!context) return;
   setGatewayContext(
     context.gatewayBaseUrl,
@@ -173,16 +149,6 @@ function buildMcpTool(tool: ToolDefinition): McpToolDefinition {
     description: tool.function.description,
     inputSchema: tool.function.parameters,
   };
-}
-
-function readString(value: unknown): string {
-  return typeof value === 'string' ? value : '';
-}
-
-function readRecord(value: unknown): Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : {};
 }
 
 function readBoolean(value: unknown): boolean {
@@ -232,12 +198,8 @@ function candidateSkillRoots(): string[] {
   ];
 }
 
-function loadSkillEntries(): Array<{
-  name: string;
-  description: string;
-  location: string;
-  body: string;
-}> {
+function loadSkillEntries(): SkillEntry[] {
+  if (skillEntriesCache) return skillEntriesCache;
   const entries = new Map<
     string,
     NonNullable<ReturnType<typeof readSkillEntry>>
@@ -250,7 +212,8 @@ function loadSkillEntries(): Array<{
       if (entry) entries.set(entry.location, entry);
     }
   }
-  return [...entries.values()];
+  skillEntriesCache = [...entries.values()];
+  return skillEntriesCache;
 }
 
 function handleSkillLookup(args: Record<string, unknown>): string {
@@ -273,13 +236,6 @@ function handleSkillLookup(args: Record<string, unknown>): string {
       ...(includeBody ? { body: skill.body.slice(0, 12_000) } : {}),
     }));
   return JSON.stringify({ skills }, null, 2);
-}
-
-function handleTtsStatus(): string {
-  return [
-    'HybridClaw text-to-speech is not exposed as a Codex app-server MCP callback.',
-    'Voice relay TTS is managed by the gateway and may place or affect live calls, so it is intentionally unavailable from this safe callback surface.',
-  ].join(' ');
 }
 
 export function buildUnavailableCallbackToolResult(toolName: string): {
@@ -335,13 +291,6 @@ async function main(): Promise<void> {
         isError: false,
       };
     }
-    if (toolName === 'tts_status') {
-      return {
-        content: [{ type: 'text', text: handleTtsStatus() }],
-        isError: false,
-      };
-    }
-
     const known = TOOL_DEFINITIONS.some(
       (tool) => tool.function.name === toolName,
     );

--- a/container/src/codex-hybridclaw-mcp.ts
+++ b/container/src/codex-hybridclaw-mcp.ts
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import {
+  executeToolWithMetadata,
+  setGatewayContext,
+  setMediaContext,
+  setModelContext,
+  setProviderCredentials,
+  setTaskModelPolicies,
+  setWebSearchConfig,
+  TOOL_DEFINITIONS,
+} from './tools.js';
+import type { ContainerInput, ToolDefinition } from './types.js';
+
+interface McpContext {
+  provider?: ContainerInput['provider'];
+  providerMethod?: string;
+  baseUrl?: string;
+  apiKey?: string;
+  model?: string;
+  chatbotId?: string;
+  requestHeaders?: Record<string, string>;
+  maxTokens?: number;
+  debugModelResponses?: boolean;
+  gatewayBaseUrl?: string;
+  gatewayApiToken?: string;
+  channelId?: string;
+  configuredDiscordChannels?: string[];
+  taskModels?: ContainerInput['taskModels'];
+  media?: ContainerInput['media'];
+  webSearch?: ContainerInput['webSearch'];
+  providerCredentials?: ContainerInput['providerCredentials'];
+}
+
+const CALLBACK_TOOL_NAMES = new Set([
+  'web_fetch',
+  'web_extract',
+  'web_search',
+  'vision_analyze',
+  'image_generate',
+  'audio_transcribe',
+]);
+
+interface McpToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: unknown;
+}
+
+const CUSTOM_CALLBACK_TOOLS: McpToolDefinition[] = [
+  {
+    name: 'skill_lookup',
+    description:
+      'List or inspect HybridClaw skills available in the current workspace. This is read-only and returns skill names, descriptions, locations, and optionally SKILL.md body excerpts.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        query: {
+          type: 'string',
+          description:
+            'Optional case-insensitive search across skill name and description.',
+        },
+        includeBody: {
+          type: 'boolean',
+          description: 'Include a truncated SKILL.md excerpt for matches.',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum number of skills to return. Defaults to 20.',
+        },
+      },
+    },
+  },
+  {
+    name: 'tts_status',
+    description:
+      'Explain whether HybridClaw text-to-speech is available through the safe Codex app-server MCP callback surface.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {},
+    },
+  },
+];
+
+function isCallbackTool(tool: ToolDefinition): boolean {
+  const name = tool.function.name;
+  return CALLBACK_TOOL_NAMES.has(name) || name.startsWith('browser_');
+}
+
+export function isHybridClawCallbackToolName(toolName: string): boolean {
+  return (
+    CALLBACK_TOOL_NAMES.has(toolName) ||
+    toolName.startsWith('browser_') ||
+    CUSTOM_CALLBACK_TOOLS.some((tool) => tool.name === toolName)
+  );
+}
+
+function readContext(): McpContext | null {
+  const contextPath = String(
+    process.env.HYBRIDCLAW_CODEX_MCP_CONTEXT_PATH || '',
+  ).trim();
+  if (!contextPath) return null;
+  try {
+    return JSON.parse(fs.readFileSync(contextPath, 'utf-8')) as McpContext;
+  } catch (error) {
+    console.error(
+      `[hybridclaw-mcp] failed to read context: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return null;
+  }
+}
+
+function applyContext(context: McpContext | null): void {
+  if (!context) return;
+  setGatewayContext(
+    context.gatewayBaseUrl,
+    context.gatewayApiToken,
+    context.channelId || 'codex-app-server',
+    context.configuredDiscordChannels,
+  );
+  setModelContext(
+    context.provider,
+    context.providerMethod,
+    context.baseUrl || '',
+    context.apiKey || '',
+    context.model || '',
+    context.chatbotId || '',
+    context.requestHeaders,
+    context.maxTokens,
+    context.debugModelResponses === true,
+  );
+  setTaskModelPolicies(context.taskModels);
+  setMediaContext(context.media);
+  setWebSearchConfig(context.webSearch);
+  setProviderCredentials(context.providerCredentials);
+}
+
+function buildMcpTool(tool: ToolDefinition): McpToolDefinition {
+  return {
+    name: tool.function.name,
+    description: tool.function.description,
+    inputSchema: tool.function.parameters,
+  };
+}
+
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function readRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function readBoolean(value: unknown): boolean {
+  return value === true;
+}
+
+function readLimit(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.max(1, Math.min(100, Math.floor(value)))
+    : 20;
+}
+
+function firstFrontmatterValue(body: string, key: string): string {
+  const pattern = new RegExp(`^${key}:\\s*['"]?([^'"\\n]+)['"]?\\s*$`, 'im');
+  return body.match(pattern)?.[1]?.trim() || '';
+}
+
+function readSkillEntry(skillFile: string): {
+  name: string;
+  description: string;
+  location: string;
+  body: string;
+} | null {
+  try {
+    const body = fs.readFileSync(skillFile, 'utf-8');
+    const name =
+      firstFrontmatterValue(body, 'name') ||
+      path.basename(path.dirname(skillFile));
+    const description = firstFrontmatterValue(body, 'description');
+    return {
+      name,
+      description,
+      location: skillFile,
+      body,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function candidateSkillRoots(): string[] {
+  return [
+    path.join(process.cwd(), 'skills'),
+    path.join(process.cwd(), '.synced-skills'),
+    '/workspace/skills',
+    '/workspace/.synced-skills',
+  ];
+}
+
+function loadSkillEntries(): Array<{
+  name: string;
+  description: string;
+  location: string;
+  body: string;
+}> {
+  const entries = new Map<
+    string,
+    NonNullable<ReturnType<typeof readSkillEntry>>
+  >();
+  for (const root of candidateSkillRoots()) {
+    if (!fs.existsSync(root)) continue;
+    for (const dirent of fs.readdirSync(root, { withFileTypes: true })) {
+      if (!dirent.isDirectory()) continue;
+      const entry = readSkillEntry(path.join(root, dirent.name, 'SKILL.md'));
+      if (entry) entries.set(entry.location, entry);
+    }
+  }
+  return [...entries.values()];
+}
+
+function handleSkillLookup(args: Record<string, unknown>): string {
+  const query = readString(args.query).trim().toLowerCase();
+  const includeBody = readBoolean(args.includeBody);
+  const limit = readLimit(args.limit);
+  const skills = loadSkillEntries()
+    .filter((skill) => {
+      if (!query) return true;
+      return (
+        skill.name.toLowerCase().includes(query) ||
+        skill.description.toLowerCase().includes(query)
+      );
+    })
+    .slice(0, limit)
+    .map((skill) => ({
+      name: skill.name,
+      description: skill.description,
+      location: skill.location,
+      ...(includeBody ? { body: skill.body.slice(0, 12_000) } : {}),
+    }));
+  return JSON.stringify({ skills }, null, 2);
+}
+
+function handleTtsStatus(): string {
+  return [
+    'HybridClaw text-to-speech is not exposed as a Codex app-server MCP callback.',
+    'Voice relay TTS is managed by the gateway and may place or affect live calls, so it is intentionally unavailable from this safe callback surface.',
+  ].join(' ');
+}
+
+export function buildUnavailableCallbackToolResult(toolName: string): {
+  content: Array<{ type: 'text'; text: string }>;
+  isError: true;
+} {
+  return {
+    content: [
+      {
+        type: 'text',
+        text: `HybridClaw callback tool is unavailable in Codex app-server mode: ${toolName}`,
+      },
+    ],
+    isError: true,
+  };
+}
+
+export function getHybridClawCallbackMcpToolNames(): string[] {
+  return [
+    ...TOOL_DEFINITIONS.filter(isCallbackTool).map(
+      (tool) => tool.function.name,
+    ),
+    ...CUSTOM_CALLBACK_TOOLS.map((tool) => tool.name),
+  ];
+}
+
+async function main(): Promise<void> {
+  applyContext(readContext());
+  const tools = [
+    ...TOOL_DEFINITIONS.filter(isCallbackTool).map(buildMcpTool),
+    ...CUSTOM_CALLBACK_TOOLS,
+  ];
+  const server = new Server(
+    { name: 'hybridclaw-callback', version: '1.0.0' },
+    {
+      capabilities: { tools: {} },
+      instructions:
+        'HybridClaw callback tools exposed to Codex app-server. Use these for web extraction, browser automation, image/vision, and audio surfaces when available.',
+    },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, () => ({ tools }));
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const toolName = request.params.name;
+    if (toolName === 'skill_lookup') {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: handleSkillLookup(readRecord(request.params.arguments)),
+          },
+        ],
+        isError: false,
+      };
+    }
+    if (toolName === 'tts_status') {
+      return {
+        content: [{ type: 'text', text: handleTtsStatus() }],
+        isError: false,
+      };
+    }
+
+    const known = TOOL_DEFINITIONS.some(
+      (tool) => tool.function.name === toolName,
+    );
+    if (!known || !tools.some((tool) => tool.name === toolName)) {
+      return buildUnavailableCallbackToolResult(toolName);
+    }
+
+    const result = await executeToolWithMetadata(
+      toolName,
+      JSON.stringify(request.params.arguments || {}),
+    );
+    return {
+      content: [{ type: 'text', text: result.output }],
+      isError: result.isError,
+    };
+  });
+
+  await server.connect(new StdioServerTransport());
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main().catch((error) => {
+    console.error(
+      `[hybridclaw-mcp] fatal: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -1050,6 +1050,7 @@ async function processRequest(
       onTextDelta: emitStreamDelta,
     });
     if (resumed) {
+      resumed.codexRuntime = 'app-server';
       await emitRuntimeEvent({
         event: 'turn_end',
         status: resumed.status,
@@ -1082,6 +1083,7 @@ async function processRequest(
       streamTextDeltas,
       onTextDelta: emitStreamDelta,
     });
+    output.codexRuntime = 'app-server';
     await emitRuntimeEvent({
       event: 'turn_end',
       status: output.status,
@@ -1893,6 +1895,7 @@ async function processRequest(
     toolsUsed: [...new Set(toolsUsed)],
     ...(artifacts.length > 0 ? { artifacts } : {}),
     toolExecutions,
+    codexRuntime,
     tokenUsage: finalizeTokenUsage(tokenUsage),
     effectiveUserPrompt,
   };

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -949,6 +949,29 @@ interface ProcessRequestParams {
   approvedToolCall?: ApprovalPrelude['approvedToolCall'];
 }
 
+function inputRuntimeContext(
+  input: ContainerInput,
+): Pick<
+  ProcessRequestParams,
+  | 'gatewayBaseUrl'
+  | 'gatewayApiToken'
+  | 'configuredDiscordChannels'
+  | 'mcpServers'
+  | 'media'
+  | 'webSearch'
+  | 'providerCredentials'
+> {
+  return {
+    gatewayBaseUrl: input.gatewayBaseUrl,
+    gatewayApiToken: input.gatewayApiToken,
+    configuredDiscordChannels: input.configuredDiscordChannels,
+    mcpServers: input.mcpServers,
+    media: input.media,
+    webSearch: input.webSearch,
+    providerCredentials: input.providerCredentials,
+  };
+}
+
 async function processRequest(
   params: ProcessRequestParams,
 ): Promise<ContainerOutput> {
@@ -2026,13 +2049,7 @@ async function main(): Promise<void> {
       chatbotId: firstInput.chatbotId,
       enableRag: firstInput.enableRag,
       requestHeaders: storedRequestHeaders,
-      gatewayBaseUrl: firstInput.gatewayBaseUrl,
-      gatewayApiToken: firstInput.gatewayApiToken,
-      configuredDiscordChannels: firstInput.configuredDiscordChannels,
-      mcpServers: firstInput.mcpServers,
-      media: firstInput.media,
-      webSearch: firstInput.webSearch,
-      providerCredentials: firstInput.providerCredentials,
+      ...inputRuntimeContext(firstInput),
       tools: resolveTools(firstInput),
       taskModels: firstTaskModels,
       contextGuard: firstInput.contextGuard,
@@ -2074,13 +2091,7 @@ async function main(): Promise<void> {
         chatbotId: firstInput.chatbotId,
         enableRag: firstInput.enableRag,
         requestHeaders: firstInput.requestHeaders,
-        gatewayBaseUrl: firstInput.gatewayBaseUrl,
-        gatewayApiToken: firstInput.gatewayApiToken,
-        configuredDiscordChannels: firstInput.configuredDiscordChannels,
-        mcpServers: firstInput.mcpServers,
-        media: firstInput.media,
-        webSearch: firstInput.webSearch,
-        providerCredentials: firstInput.providerCredentials,
+        ...inputRuntimeContext(firstInput),
         tools: resolveTools(firstInput),
         taskModels: firstTaskModels,
         contextGuard: firstInput.contextGuard,
@@ -2225,13 +2236,7 @@ async function main(): Promise<void> {
       chatbotId: input.chatbotId,
       enableRag: input.enableRag,
       requestHeaders,
-      gatewayBaseUrl: input.gatewayBaseUrl,
-      gatewayApiToken: input.gatewayApiToken,
-      configuredDiscordChannels: input.configuredDiscordChannels,
-      mcpServers: input.mcpServers,
-      media: input.media,
-      webSearch: input.webSearch,
-      providerCredentials: input.providerCredentials,
+      ...inputRuntimeContext(input),
       tools: resolveTools(input),
       taskModels,
       contextGuard: input.contextGuard,
@@ -2272,13 +2277,7 @@ async function main(): Promise<void> {
         chatbotId: input.chatbotId,
         enableRag: input.enableRag,
         requestHeaders,
-        gatewayBaseUrl: input.gatewayBaseUrl,
-        gatewayApiToken: input.gatewayApiToken,
-        configuredDiscordChannels: input.configuredDiscordChannels,
-        mcpServers: input.mcpServers,
-        media: input.media,
-        webSearch: input.webSearch,
-        providerCredentials: input.providerCredentials,
+        ...inputRuntimeContext(input),
         tools: resolveTools(input),
         taskModels,
         contextGuard: input.contextGuard,

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -10,6 +10,10 @@ import {
   cleanupAllBrowserSessions,
   getBrowserProviderLogLabel,
 } from './browser-tools.js';
+import {
+  resumePendingCodexAppServerApproval,
+  runCodexAppServerTurn,
+} from './codex-app-server.js';
 import { applyContextGuard } from './context-guard.js';
 import {
   emitRuntimeEvent,
@@ -916,6 +920,7 @@ interface ProcessRequestParams {
   baseUrl: string;
   provider: ContainerInput['provider'];
   providerMethod?: string;
+  codexRuntime?: ContainerInput['codexRuntime'];
   isLocal?: boolean;
   contextWindow?: number;
   thinkingFormat?: 'qwen';
@@ -923,6 +928,13 @@ interface ProcessRequestParams {
   chatbotId: string;
   enableRag: boolean;
   requestHeaders?: Record<string, string>;
+  gatewayBaseUrl?: string;
+  gatewayApiToken?: string;
+  configuredDiscordChannels?: string[];
+  mcpServers?: ContainerInput['mcpServers'];
+  media?: ContainerInput['media'];
+  webSearch?: ContainerInput['webSearch'];
+  providerCredentials?: ContainerInput['providerCredentials'];
   tools: ToolDefinition[];
   taskModels?: ContainerInput['taskModels'];
   contextGuard?: ContainerInput['contextGuard'];
@@ -947,6 +959,7 @@ async function processRequest(
     baseUrl,
     provider,
     providerMethod,
+    codexRuntime,
     isLocal,
     contextWindow,
     thinkingFormat,
@@ -954,6 +967,13 @@ async function processRequest(
     chatbotId,
     enableRag,
     requestHeaders,
+    gatewayBaseUrl,
+    gatewayApiToken,
+    configuredDiscordChannels,
+    mcpServers,
+    media,
+    webSearch,
+    providerCredentials,
     tools,
     taskModels,
     contextGuard,
@@ -998,6 +1018,55 @@ async function processRequest(
   let compactionRetries = 0;
   const tokenEstimateCache = createTokenEstimateCache();
   const maxContextGuardRetries = Math.max(0, contextGuard?.maxRetries ?? 3);
+
+  if (provider === 'openai-codex' && codexRuntime === 'app-server') {
+    const resumed = await resumePendingCodexAppServerApproval({
+      sessionId,
+      messages: history,
+      streamTextDeltas,
+      onTextDelta: emitStreamDelta,
+    });
+    if (resumed) {
+      await emitRuntimeEvent({
+        event: 'turn_end',
+        status: resumed.status,
+        toolsUsed: resumed.toolsUsed,
+      });
+      return resumed;
+    }
+    const output = await runCodexAppServerTurn({
+      sessionId,
+      messages: history,
+      model,
+      cwd: WORKSPACE_ROOT,
+      apiKey,
+      baseUrl,
+      provider,
+      providerMethod,
+      chatbotId,
+      requestHeaders,
+      maxTokens,
+      debugModelResponses,
+      gatewayBaseUrl,
+      gatewayApiToken,
+      channelId,
+      configuredDiscordChannels,
+      mcpServers,
+      taskModels,
+      media,
+      webSearch,
+      providerCredentials,
+      streamTextDeltas,
+      onTextDelta: emitStreamDelta,
+    });
+    await emitRuntimeEvent({
+      event: 'turn_end',
+      status: output.status,
+      toolsUsed: output.toolsUsed,
+    });
+    return output;
+  }
+
   const resolveToolApproval = async (input: {
     toolName: string;
     argsJson: string;
@@ -1949,6 +2018,7 @@ async function main(): Promise<void> {
       baseUrl: firstInput.baseUrl,
       provider: firstInput.provider,
       providerMethod: firstInput.providerMethod,
+      codexRuntime: firstInput.codexRuntime,
       isLocal: firstInput.isLocal,
       contextWindow: firstInput.contextWindow,
       thinkingFormat: firstInput.thinkingFormat,
@@ -1956,6 +2026,13 @@ async function main(): Promise<void> {
       chatbotId: firstInput.chatbotId,
       enableRag: firstInput.enableRag,
       requestHeaders: storedRequestHeaders,
+      gatewayBaseUrl: firstInput.gatewayBaseUrl,
+      gatewayApiToken: firstInput.gatewayApiToken,
+      configuredDiscordChannels: firstInput.configuredDiscordChannels,
+      mcpServers: firstInput.mcpServers,
+      media: firstInput.media,
+      webSearch: firstInput.webSearch,
+      providerCredentials: firstInput.providerCredentials,
       tools: resolveTools(firstInput),
       taskModels: firstTaskModels,
       contextGuard: firstInput.contextGuard,
@@ -1989,6 +2066,7 @@ async function main(): Promise<void> {
         baseUrl: firstInput.baseUrl,
         provider: firstInput.provider,
         providerMethod: firstInput.providerMethod,
+        codexRuntime: firstInput.codexRuntime,
         isLocal: firstInput.isLocal,
         contextWindow: firstInput.contextWindow,
         thinkingFormat: firstInput.thinkingFormat,
@@ -1996,6 +2074,13 @@ async function main(): Promise<void> {
         chatbotId: firstInput.chatbotId,
         enableRag: firstInput.enableRag,
         requestHeaders: firstInput.requestHeaders,
+        gatewayBaseUrl: firstInput.gatewayBaseUrl,
+        gatewayApiToken: firstInput.gatewayApiToken,
+        configuredDiscordChannels: firstInput.configuredDiscordChannels,
+        mcpServers: firstInput.mcpServers,
+        media: firstInput.media,
+        webSearch: firstInput.webSearch,
+        providerCredentials: firstInput.providerCredentials,
         tools: resolveTools(firstInput),
         taskModels: firstTaskModels,
         contextGuard: firstInput.contextGuard,
@@ -2132,6 +2217,7 @@ async function main(): Promise<void> {
       baseUrl: input.baseUrl,
       provider: input.provider,
       providerMethod: input.providerMethod,
+      codexRuntime: input.codexRuntime,
       isLocal: input.isLocal,
       contextWindow: input.contextWindow,
       thinkingFormat: input.thinkingFormat,
@@ -2139,6 +2225,13 @@ async function main(): Promise<void> {
       chatbotId: input.chatbotId,
       enableRag: input.enableRag,
       requestHeaders,
+      gatewayBaseUrl: input.gatewayBaseUrl,
+      gatewayApiToken: input.gatewayApiToken,
+      configuredDiscordChannels: input.configuredDiscordChannels,
+      mcpServers: input.mcpServers,
+      media: input.media,
+      webSearch: input.webSearch,
+      providerCredentials: input.providerCredentials,
       tools: resolveTools(input),
       taskModels,
       contextGuard: input.contextGuard,
@@ -2171,6 +2264,7 @@ async function main(): Promise<void> {
         baseUrl: input.baseUrl,
         provider: input.provider,
         providerMethod: input.providerMethod,
+        codexRuntime: input.codexRuntime,
         isLocal: input.isLocal,
         contextWindow: input.contextWindow,
         thinkingFormat: input.thinkingFormat,
@@ -2178,6 +2272,13 @@ async function main(): Promise<void> {
         chatbotId: input.chatbotId,
         enableRag: input.enableRag,
         requestHeaders,
+        gatewayBaseUrl: input.gatewayBaseUrl,
+        gatewayApiToken: input.gatewayApiToken,
+        configuredDiscordChannels: input.configuredDiscordChannels,
+        mcpServers: input.mcpServers,
+        media: input.media,
+        webSearch: input.webSearch,
+        providerCredentials: input.providerCredentials,
         tools: resolveTools(input),
         taskModels,
         contextGuard: input.contextGuard,

--- a/container/src/types.ts
+++ b/container/src/types.ts
@@ -232,6 +232,7 @@ export interface ContainerInput {
   gatewayApiToken?: string;
   browserProvider?: string;
   model: string;
+  codexRuntime?: 'hybridclaw' | 'app-server';
   ralphMaxIterations?: number | null;
   fullAutoEnabled?: boolean;
   fullAutoNeverApproveTools?: string[];

--- a/container/src/types.ts
+++ b/container/src/types.ts
@@ -396,6 +396,7 @@ export interface ContainerOutput {
   status: 'success' | 'error';
   result: string | null;
   toolsUsed: string[];
+  codexRuntime?: CodexTurnRuntime;
   artifacts?: ArtifactMetadata[];
   toolExecutions?: ToolExecution[];
   pendingApproval?: PendingApproval;

--- a/container/src/types.ts
+++ b/container/src/types.ts
@@ -201,6 +201,8 @@ export interface ProviderCredentials {
   assemblyai?: ProviderCredential;
 }
 
+export type CodexTurnRuntime = 'hybridclaw' | 'app-server';
+
 export interface ContainerInput {
   healthCheck?: {
     nonce: string;
@@ -232,7 +234,7 @@ export interface ContainerInput {
   gatewayApiToken?: string;
   browserProvider?: string;
   model: string;
-  codexRuntime?: 'hybridclaw' | 'app-server';
+  codexRuntime?: CodexTurnRuntime;
   ralphMaxIterations?: number | null;
   fullAutoEnabled?: boolean;
   fullAutoNeverApproveTools?: string[];

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -123,6 +123,11 @@ saved revision history directly.
 - `hybridai.maxTokens` for the default completion output budget; the shipped
   default is `4096`; you can change it live with
   `hybridclaw config set hybridai.maxTokens <n>`
+- `codex.baseUrl`, `codex.turnRuntime`, and `codex.models` for first-class
+  Codex provider behavior. `codex.turnRuntime` accepts `hybridclaw` for the
+  standard HybridClaw tool loop or `app-server` for the native Codex app-server
+  turn loop on `openai-codex/*` models. `codex.runtime` is accepted as a
+  compatibility alias; new config should use `codex.turnRuntime`.
 - `HYBRIDAI_FALLBACK_CHAIN` accepts a JSON array of fallback entries with
   `model`, optional `baseUrl`, `keyEnv`, `chatbotId`, and `agentId`. Gateway
   model calls use the chain for auth and rate-limit failures, then cool down

--- a/docs/content/reference/model-selection.md
+++ b/docs/content/reference/model-selection.md
@@ -117,10 +117,7 @@ spend across active models.
 
 ## Provider Routing
 
-- when the selected model starts with `openai-codex/`, HybridClaw resolves
-  OAuth credentials through the Codex provider instead of `HYBRIDAI_API_KEY`
-  and uses the default HybridClaw tool loop unless `codex.runtime` is set to
-  `app-server` for new sessions
+- when the selected model starts with `openai-codex/`, HybridClaw resolves OAuth credentials through the Codex provider instead of `HYBRIDAI_API_KEY` and uses the default HybridClaw tool loop unless `codex.runtime` is set to `app-server` for new sessions
 - when the selected model starts with `anthropic/`, HybridClaw resolves
   credentials through `ANTHROPIC_API_KEY` or the configured Claude CLI method
 - when the selected model starts with `openrouter/`, HybridClaw resolves

--- a/docs/content/reference/model-selection.md
+++ b/docs/content/reference/model-selection.md
@@ -119,6 +119,8 @@ spend across active models.
 
 - when the selected model starts with `openai-codex/`, HybridClaw resolves
   OAuth credentials through the Codex provider instead of `HYBRIDAI_API_KEY`
+  and uses the default HybridClaw tool loop unless `codex.runtime` is set to
+  `app-server` for new sessions
 - when the selected model starts with `anthropic/`, HybridClaw resolves
   credentials through `ANTHROPIC_API_KEY` or the configured Claude CLI method
 - when the selected model starts with `openrouter/`, HybridClaw resolves

--- a/docs/content/reference/model-selection.md
+++ b/docs/content/reference/model-selection.md
@@ -85,6 +85,58 @@ The admin Models page combines the same metadata with daily and monthly usage
 rollups, so operators can sort by context window or monthly usage and compare
 spend across active models.
 
+## Codex Turn Runtime
+
+`codex.turnRuntime` controls how turns run when the selected model starts with
+`openai-codex/`.
+
+- `hybridclaw` is the default. HybridClaw calls the Codex model through its
+  existing provider path and keeps the standard HybridClaw tool loop.
+- `app-server` starts the native `codex app-server` runtime for Codex turns and
+  projects Codex shell, patch, plan, sandbox, approval, and callback-MCP events
+  back into HybridClaw transcripts and audit records.
+
+HybridClaw still owns gateway routing, sessions, memory, approvals, audit,
+channels, and the outer worker sandbox. `/status` reports those concerns
+separately: `Runtime: codex` alongside `Sandbox: host` means the turn loop is
+the Codex app-server runtime while the outer HybridClaw worker is running in
+host sandbox mode.
+
+Enable the Codex turn runtime from inside HybridClaw:
+
+```text
+/config set codex.turnRuntime app-server
+/config reload
+/status
+```
+
+Or set it from a shell before starting the gateway:
+
+```bash
+hybridclaw auth status codex
+codex app-server --help
+hybridclaw config set codex.turnRuntime app-server
+hybridclaw gateway restart --foreground --sandbox=host
+```
+
+The selected model must use the `openai-codex/` prefix, the `codex` CLI must be
+installed and expose `codex app-server`, and Codex auth must be configured with
+`hybridclaw auth login codex` or an existing valid Codex OAuth file.
+
+Runtime selection is baked into active worker sessions. After changing
+`codex.turnRuntime`, start a fresh session or restart idle workers before using
+`/status` to verify the switch.
+
+Audit records expose the runtime used by each turn. Codex app-server turns
+write `model.usage` rows with `"runtime":"codex"` and
+`"codexRuntime":"app-server"`, and projected Codex tools use names such as
+`codex.command`, `codex.patch`, `codex.plan`, and `codex.sandbox`. Standard
+HybridClaw-loop turns write `"runtime":"hybridclaw"` and normal tool names such
+as `bash`, `write`, or `delete`.
+
+`codex.runtime` remains accepted as a backward-compatible alias. New config and
+docs should use `codex.turnRuntime`.
+
 ## Allowed Model Lists
 
 - `codex.models` controls the allowed Codex model list shown in selectors and
@@ -117,7 +169,10 @@ spend across active models.
 
 ## Provider Routing
 
-- when the selected model starts with `openai-codex/`, HybridClaw resolves OAuth credentials through the Codex provider instead of `HYBRIDAI_API_KEY` and uses the default HybridClaw tool loop unless `codex.runtime` is set to `app-server` for new sessions
+- when the selected model starts with `openai-codex/`, HybridClaw resolves
+  OAuth credentials through the Codex provider instead of `HYBRIDAI_API_KEY`;
+  Codex turns use the HybridClaw loop by default, or the native Codex app-server
+  loop when `codex.turnRuntime` is set to `app-server`
 - when the selected model starts with `anthropic/`, HybridClaw resolves
   credentials through `ANTHROPIC_API_KEY` or the configured Claude CLI method
 - when the selected model starts with `openrouter/`, HybridClaw resolves

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1043,7 +1043,7 @@ function applyRuntimeConfig(config: RuntimeConfig): void {
   );
   HYBRIDAI_ENABLE_RAG = config.hybridai.enableRag;
   CODEX_BASE_URL = config.codex.baseUrl;
-  CODEX_RUNTIME = config.codex.runtime;
+  CODEX_RUNTIME = config.codex.turnRuntime;
   ANTHROPIC_ENABLED = config.anthropic.enabled;
   ANTHROPIC_BASE_URL = config.anthropic.baseUrl;
   ANTHROPIC_METHOD = config.anthropic.method;

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -481,6 +481,7 @@ export let HYBRIDAI_CHATBOT_ID = '';
 export let HYBRIDAI_MAX_TOKENS = 4_096;
 export let HYBRIDAI_ENABLE_RAG = true;
 export let CODEX_BASE_URL = CODEX_DEFAULT_BASE_URL;
+export let CODEX_RUNTIME: RuntimeConfig['codex']['runtime'] = 'hybridclaw';
 export let ANTHROPIC_ENABLED = false;
 export let ANTHROPIC_BASE_URL = 'https://api.anthropic.com/v1';
 export let ANTHROPIC_METHOD: RuntimeConfig['anthropic']['method'] = 'api-key';
@@ -1042,6 +1043,7 @@ function applyRuntimeConfig(config: RuntimeConfig): void {
   );
   HYBRIDAI_ENABLE_RAG = config.hybridai.enableRag;
   CODEX_BASE_URL = config.codex.baseUrl;
+  CODEX_RUNTIME = config.codex.runtime;
   ANTHROPIC_ENABLED = config.anthropic.enabled;
   ANTHROPIC_BASE_URL = config.anthropic.baseUrl;
   ANTHROPIC_METHOD = config.anthropic.method;

--- a/src/config/runtime-config-edit.ts
+++ b/src/config/runtime-config-edit.ts
@@ -49,7 +49,7 @@ export function setRuntimeConfigValueAtPath(
   if (
     segments.length === 2 &&
     segments[0] === 'codex' &&
-    segments[1] === 'runtime' &&
+    (segments[1] === 'runtime' || segments[1] === 'turnRuntime') &&
     normalizeCodexTurnRuntime(value) === 'app-server'
   ) {
     assertCodexAppServerRuntimeAvailable();
@@ -72,6 +72,15 @@ export function setRuntimeConfigValueAtPath(
     throw new Error(`Config key \`${keyPath}\` was not found.`);
   }
   current[leaf] = value;
+  if (
+    segments.length === 2 &&
+    segments[0] === 'codex' &&
+    (segments[1] === 'runtime' || segments[1] === 'turnRuntime')
+  ) {
+    const normalized = normalizeCodexTurnRuntime(value);
+    current.runtime = normalized;
+    current.turnRuntime = normalized;
+  }
 }
 
 export function assertCodexAppServerRuntimeAvailable(): void {

--- a/src/config/runtime-config-edit.ts
+++ b/src/config/runtime-config-edit.ts
@@ -1,5 +1,8 @@
 import { spawnSync } from 'node:child_process';
-import type { RuntimeConfig } from './runtime-config.js';
+import {
+  normalizeCodexTurnRuntime,
+  type RuntimeConfig,
+} from './runtime-config.js';
 
 const FORBIDDEN_CONFIG_PATH_SEGMENTS = new Set([
   '__proto__',
@@ -47,7 +50,7 @@ export function setRuntimeConfigValueAtPath(
     segments.length === 2 &&
     segments[0] === 'codex' &&
     segments[1] === 'runtime' &&
-    String(value || '').trim() === 'app-server'
+    normalizeCodexTurnRuntime(value) === 'app-server'
   ) {
     assertCodexAppServerRuntimeAvailable();
   }

--- a/src/config/runtime-config-edit.ts
+++ b/src/config/runtime-config-edit.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process';
 import type { RuntimeConfig } from './runtime-config.js';
 
 const FORBIDDEN_CONFIG_PATH_SEGMENTS = new Set([
@@ -42,6 +43,14 @@ export function setRuntimeConfigValueAtPath(
   value: unknown,
 ): void {
   const segments = splitRuntimeConfigPath(keyPath);
+  if (
+    segments.length === 2 &&
+    segments[0] === 'codex' &&
+    segments[1] === 'runtime' &&
+    String(value || '').trim() === 'app-server'
+  ) {
+    assertCodexAppServerRuntimeAvailable();
+  }
   let current = config as unknown as Record<string, unknown>;
 
   for (const segment of segments.slice(0, -1)) {
@@ -60,6 +69,37 @@ export function setRuntimeConfigValueAtPath(
     throw new Error(`Config key \`${keyPath}\` was not found.`);
   }
   current[leaf] = value;
+}
+
+export function assertCodexAppServerRuntimeAvailable(): void {
+  const version = spawnSync('codex', ['--version'], {
+    encoding: 'utf-8',
+  });
+  if (version.error) {
+    const code = (version.error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      throw new Error(
+        'Cannot enable `codex.runtime=app-server`: `codex` is not installed or is not on PATH. Install the OpenAI Codex CLI, then run `hybridclaw config set codex.runtime app-server` again.',
+      );
+    }
+    throw new Error(
+      `Cannot enable \`codex.runtime=app-server\`: failed to run \`codex --version\`: ${version.error.message}`,
+    );
+  }
+  if (version.status !== 0) {
+    throw new Error(
+      `Cannot enable \`codex.runtime=app-server\`: \`codex --version\` exited with ${version.status ?? 'null'}.${version.stderr ? ` ${version.stderr.trim()}` : ''}`,
+    );
+  }
+
+  const help = spawnSync('codex', ['app-server', '--help'], {
+    encoding: 'utf-8',
+  });
+  if (help.error || help.status !== 0) {
+    throw new Error(
+      'Cannot enable `codex.runtime=app-server`: the installed Codex CLI does not expose `codex app-server`. Upgrade the OpenAI Codex CLI, then try again.',
+    );
+  }
 }
 
 export function getRuntimeConfigValueAtPath(

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -131,7 +131,7 @@ import {
 import { DEFAULT_RUNTIME_HOME_DIR } from './runtime-paths.js';
 
 export const CONFIG_FILE_NAME = 'config.json';
-export const CONFIG_VERSION = 28;
+export const CONFIG_VERSION = 29;
 export const SECURITY_POLICY_VERSION = '2026-02-28';
 export const DEFAULT_HYBRIDAI_MODEL = 'gpt-5.4-mini';
 const LEGACY_DEFAULT_DB_PATH = 'data/hybridclaw.db';
@@ -243,6 +243,7 @@ export const SCHEDULER_BOARD_STATUSES = [
 export type SchedulerBoardStatus = (typeof SCHEDULER_BOARD_STATUSES)[number];
 const SCHEDULER_BOARD_STATUS_SET = new Set<string>(SCHEDULER_BOARD_STATUSES);
 export type ContainerSandboxMode = 'container' | 'host';
+export type CodexTurnRuntime = 'hybridclaw' | 'app-server';
 export type RuntimeWebSearchProvider =
   | 'auto'
   | 'brave'
@@ -964,6 +965,7 @@ export interface RuntimeConfig {
   };
   codex: {
     baseUrl: string;
+    runtime: CodexTurnRuntime;
     models: string[];
   };
   anthropic: {
@@ -1597,6 +1599,7 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
   },
   codex: {
     baseUrl: CODEX_DEFAULT_BASE_URL,
+    runtime: 'hybridclaw',
     models: [...DEFAULT_CODEX_MODEL_LIST],
   },
   anthropic: {
@@ -2919,6 +2922,13 @@ function normalizeCodexModelArray(
     return [...DEFAULT_CODEX_MODEL_LIST];
   }
   return normalized;
+}
+
+export function normalizeCodexTurnRuntime(value: unknown): CodexTurnRuntime {
+  const normalized = String(value || '')
+    .trim()
+    .toLowerCase();
+  return normalized === 'app-server' ? 'app-server' : 'hybridclaw';
 }
 
 function normalizePathForCompare(value: string): string {
@@ -6683,6 +6693,7 @@ function normalizeRuntimeConfig(
         rawCodex.baseUrl,
         DEFAULT_RUNTIME_CONFIG.codex.baseUrl,
       ),
+      runtime: normalizeCodexTurnRuntime(rawCodex.runtime),
       models: codexModelList,
     },
     anthropic: {

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -966,6 +966,7 @@ export interface RuntimeConfig {
   codex: {
     baseUrl: string;
     runtime: CodexTurnRuntime;
+    turnRuntime: CodexTurnRuntime;
     models: string[];
   };
   anthropic: {
@@ -1600,6 +1601,7 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
   codex: {
     baseUrl: CODEX_DEFAULT_BASE_URL,
     runtime: 'hybridclaw',
+    turnRuntime: 'hybridclaw',
     models: [...DEFAULT_CODEX_MODEL_LIST],
   },
   anthropic: {
@@ -2929,6 +2931,13 @@ export function normalizeCodexTurnRuntime(value: unknown): CodexTurnRuntime {
     .trim()
     .toLowerCase();
   return normalized === 'app-server' ? 'app-server' : 'hybridclaw';
+}
+
+function normalizeCodexTurnRuntimeConfig(rawCodex: Record<string, unknown>) {
+  if (Object.hasOwn(rawCodex, 'turnRuntime')) {
+    return normalizeCodexTurnRuntime(rawCodex.turnRuntime);
+  }
+  return normalizeCodexTurnRuntime(rawCodex.runtime);
 }
 
 function normalizePathForCompare(value: string): string {
@@ -6693,7 +6702,8 @@ function normalizeRuntimeConfig(
         rawCodex.baseUrl,
         DEFAULT_RUNTIME_CONFIG.codex.baseUrl,
       ),
-      runtime: normalizeCodexTurnRuntime(rawCodex.runtime),
+      runtime: normalizeCodexTurnRuntimeConfig(rawCodex),
+      turnRuntime: normalizeCodexTurnRuntimeConfig(rawCodex),
       models: codexModelList,
     },
     anthropic: {
@@ -7619,6 +7629,7 @@ function buildSerializableConfig(
     : null;
   if (serializableCodex) {
     delete (serializableCodex as { models?: string[] }).models;
+    delete (serializableCodex as { runtime?: string }).runtime;
   }
   const serializableContainer = isRecord(serializable.container)
     ? serializable.container

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -73,7 +73,7 @@ import {
   deriveSkillExecutionOutcome,
   recordSkillExecution,
 } from '../skills/skills-observation.js';
-import type { MediaContextItem } from '../types/container.js';
+import type { ContainerOutput, MediaContextItem } from '../types/container.js';
 import {
   type ArtifactMetadata,
   normalizeEscalationTarget,
@@ -147,6 +147,16 @@ import {
 } from './show-mode.js';
 
 const MAX_HISTORY_MESSAGES = 40;
+
+function resolveTurnRuntimeAuditLabel(
+  model: string,
+  output: Pick<ContainerOutput, 'codexRuntime'> | undefined,
+): 'codex' | 'hybridclaw' {
+  return resolveModelProvider(model) === 'openai-codex' &&
+    output?.codexRuntime === 'app-server'
+    ? 'codex'
+    : 'hybridclaw';
+}
 
 function parseToolResultObject(result: string): Record<string, unknown> | null {
   try {
@@ -1629,6 +1639,8 @@ async function handleGatewayMessageInner(
         type: 'model.usage',
         provider,
         model,
+        runtime: resolveTurnRuntimeAuditLabel(model, output),
+        codexRuntime: output.codexRuntime || null,
         durationMs: Date.now() - startedAt,
         toolCallCount: toolExecutions.length,
         ...usagePayload,

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -351,7 +351,7 @@ import {
 } from '../skills/skills-guard.js';
 import type { ChatMessage } from '../types/api.js';
 import type { StructuredAuditEntry } from '../types/audit.js';
-import type { MediaContextItem } from '../types/container.js';
+import type { ContainerOutput, MediaContextItem } from '../types/container.js';
 import type {
   ArtifactMetadata,
   ToolExecution,
@@ -889,6 +889,16 @@ interface DelegationTaskRunInput {
   onToolProgress?: (event: ToolProgressEvent) => void;
 }
 
+function resolveTurnRuntimeAuditLabel(
+  model: string,
+  output: Pick<ContainerOutput, 'codexRuntime'> | undefined,
+): 'codex' | 'hybridclaw' {
+  return resolveModelProvider(model) === 'openai-codex' &&
+    output?.codexRuntime === 'app-server'
+    ? 'codex'
+    : 'hybridclaw';
+}
+
 async function persistDelegationAttempt(params: {
   sessionId: string;
   model: string;
@@ -919,6 +929,8 @@ async function persistDelegationAttempt(params: {
         type: 'model.usage',
         provider: resolveModelProvider(params.model),
         model: params.model,
+        runtime: resolveTurnRuntimeAuditLabel(params.model, params.output),
+        codexRuntime: params.output.codexRuntime || null,
         durationMs: params.durationMs,
         toolCallCount,
         ...usagePayload,
@@ -6758,6 +6770,8 @@ export async function ensureGatewayBootstrapAutostart(params: {
         type: 'model.usage',
         provider,
         model: resolved.model,
+        runtime: resolveTurnRuntimeAuditLabel(resolved.model, output),
+        codexRuntime: output.codexRuntime || null,
         durationMs: Date.now() - startedAt,
         toolCallCount: (output.toolExecutions || []).length,
         ...usagePayload,
@@ -10534,7 +10548,13 @@ export async function handleGatewayCommand(
             : contextSnapshot.contextUsedTokens != null
               ? `${formatCompactNumber(contextSnapshot.contextUsedTokens)}/? (window unknown)`
               : 'n/a';
-        const sandboxLabel = `${status.sandbox?.mode || 'container'} (${status.sandbox?.activeSessions ?? status.activeContainers} active)`;
+        const sandboxMode = status.sandbox?.mode || 'container';
+        const sandboxLabel = `${sandboxMode} (${status.sandbox?.activeSessions ?? status.activeContainers} active)`;
+        const turnRuntimeLabel =
+          resolveModelProvider(sessionModel) === 'openai-codex' &&
+          getRuntimeConfig().codex.turnRuntime === 'app-server'
+            ? 'codex'
+            : 'hybridclaw';
         const activeSandboxSessionIds = status.sandbox?.activeSessionIds || [];
         const fullAutoState = getFullAutoRuntimeState(session.id);
         const fullAutoLabel = isFullAutoEnabled(session)
@@ -10585,7 +10605,7 @@ export async function handleGatewayCommand(
                   .join(' · ')}`,
               ]
             : []),
-          `⚙️ Runtime: ${status.sandbox?.mode || 'container'} · RAG: ${session.enable_rag ? 'on' : 'off'} · Ralph: ${formatRalphIterations(resolveSessionRalphIterations(session))} · Show: ${showMode}`,
+          `⚙️ Runtime: ${turnRuntimeLabel} · Sandbox: ${sandboxMode} · RAG: ${session.enable_rag ? 'on' : 'off'} · Ralph: ${formatRalphIterations(resolveSessionRalphIterations(session))} · Show: ${showMode}`,
           `🤖 Full-auto: ${fullAutoLabel}`,
           `👥 Activation: ${resolveActivationModeLabel()} · 🪢 Queue: ${queueLabel} · 📬 Proactive queued: ${proactiveQueued}`,
           `🩺 Agents: ${coworkerHealthLabel}`,

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -53,6 +53,7 @@ import {
   WEB_SEARCH_PROVIDER,
   WEB_SEARCH_TAVILY_SEARCH_DEPTH,
 } from '../config/config.js';
+import type { CodexTurnRuntime } from '../config/runtime-config.js';
 import { GATEWAY_DEBUG_MODEL_RESPONSES_ENV } from '../gateway/gateway-lifecycle.js';
 import { logger } from '../logger.js';
 import { resolveUploadedMediaCacheHostDir } from '../media/uploaded-media-cache.js';
@@ -146,7 +147,7 @@ interface PoolEntry extends WarmRunnerEntry {
   stderrHistory: string[];
   streamDebug: StreamDebugState;
   workerSignature: string;
-  codexRuntime?: 'hybridclaw' | 'app-server';
+  codexRuntime?: CodexTurnRuntime;
   terminalError: string | null;
   onTextDelta?: (delta: string) => void;
   onThinkingDelta?: (delta: string) => void;

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -16,6 +16,7 @@ import { collectActiveMessageToolChannelKinds } from '../channels/message-tool-a
 import {
   ADDITIONAL_MOUNTS,
   BROWSER_PROVIDER,
+  CODEX_RUNTIME,
   CONTAINER_BINDS,
   CONTAINER_CPUS,
   CONTAINER_IMAGE,
@@ -145,6 +146,7 @@ interface PoolEntry extends WarmRunnerEntry {
   stderrHistory: string[];
   streamDebug: StreamDebugState;
   workerSignature: string;
+  codexRuntime?: 'hybridclaw' | 'app-server';
   terminalError: string | null;
   onTextDelta?: (delta: string) => void;
   onThinkingDelta?: (delta: string) => void;
@@ -1089,6 +1091,10 @@ async function runContainerInner(
 
   const startTime = Date.now();
   const webSearchRuntime = resolveWebSearchRuntimeConfig(agentId);
+  const existingEntry = pool.get(sessionId);
+  const selectedCodexRuntime =
+    modelRuntime.provider === 'openai-codex' ? CODEX_RUNTIME : 'hybridclaw';
+  const codexRuntime = existingEntry?.codexRuntime || selectedCodexRuntime;
 
   const input: ContainerInput = {
     sessionId,
@@ -1108,6 +1114,7 @@ async function runContainerInner(
     gatewayApiToken: GATEWAY_API_TOKEN || undefined,
     browserProvider: BROWSER_PROVIDER,
     model,
+    codexRuntime,
     ralphMaxIterations,
     fullAutoEnabled,
     fullAutoNeverApproveTools,
@@ -1159,6 +1166,7 @@ async function runContainerInner(
     agentId,
     provider: input.provider,
     providerMethod: input.providerMethod,
+    codexRuntime: input.codexRuntime,
     baseUrl: input.baseUrl,
     apiKey: input.apiKey,
     requestHeaders: input.requestHeaders,
@@ -1170,7 +1178,6 @@ async function runContainerInner(
     bashProxy: params.bashProxy,
   });
 
-  const existingEntry = pool.get(sessionId);
   if (existingEntry && existingEntry.workerSignature !== workerSignature) {
     logger.info(
       {
@@ -1221,6 +1228,7 @@ async function runContainerInner(
   ensureSessionDirs(entry.ipcSessionId);
   const activity = createActivityTracker();
   entry.workerSignature = workerSignature;
+  entry.codexRuntime = input.codexRuntime;
   entry.onTextDelta = onTextDelta;
   entry.onThinkingDelta = onThinkingDelta;
   entry.onToolProgress = onToolProgress;

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -41,6 +41,7 @@ import {
   WEB_SEARCH_PROVIDER,
   WEB_SEARCH_TAVILY_SEARCH_DEPTH,
 } from '../config/config.js';
+import type { CodexTurnRuntime } from '../config/runtime-config.js';
 import { GATEWAY_DEBUG_MODEL_RESPONSES_ENV } from '../gateway/gateway-lifecycle.js';
 import { logger } from '../logger.js';
 import { resolveUploadedMediaCacheHostDir } from '../media/uploaded-media-cache.js';
@@ -195,7 +196,7 @@ interface PoolEntry extends WarmRunnerEntry {
   stderrHistory: string[];
   streamDebug: StreamDebugState;
   workerSignature: string;
-  codexRuntime?: 'hybridclaw' | 'app-server';
+  codexRuntime?: CodexTurnRuntime;
   terminalError: string | null;
   onTextDelta?: (delta: string) => void;
   onThinkingDelta?: (delta: string) => void;

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -13,6 +13,7 @@ import { collectActiveMessageToolChannelKinds } from '../channels/message-tool-a
 import {
   ADDITIONAL_MOUNTS,
   BROWSER_PROVIDER,
+  CODEX_RUNTIME,
   CONTAINER_BINDS,
   CONTAINER_PERSIST_BASH_STATE,
   CONTAINER_TIMEOUT,
@@ -194,6 +195,7 @@ interface PoolEntry extends WarmRunnerEntry {
   stderrHistory: string[];
   streamDebug: StreamDebugState;
   workerSignature: string;
+  codexRuntime?: 'hybridclaw' | 'app-server';
   terminalError: string | null;
   onTextDelta?: (delta: string) => void;
   onThinkingDelta?: (delta: string) => void;
@@ -946,6 +948,10 @@ async function runHostProcessInner(
 
   const startTime = Date.now();
   const webSearchRuntime = resolveWebSearchRuntimeConfig(agentId);
+  const existingEntry = pool.get(sessionId);
+  const selectedCodexRuntime =
+    modelRuntime.provider === 'openai-codex' ? CODEX_RUNTIME : 'hybridclaw';
+  const codexRuntime = existingEntry?.codexRuntime || selectedCodexRuntime;
 
   const input: ContainerInput = {
     sessionId,
@@ -965,6 +971,7 @@ async function runHostProcessInner(
     gatewayApiToken: GATEWAY_API_TOKEN || undefined,
     browserProvider: BROWSER_PROVIDER,
     model,
+    codexRuntime,
     ralphMaxIterations,
     fullAutoEnabled,
     fullAutoNeverApproveTools,
@@ -1016,6 +1023,7 @@ async function runHostProcessInner(
     agentId,
     provider: input.provider,
     providerMethod: input.providerMethod,
+    codexRuntime: input.codexRuntime,
     baseUrl: input.baseUrl,
     apiKey: input.apiKey,
     requestHeaders: input.requestHeaders,
@@ -1026,7 +1034,6 @@ async function runHostProcessInner(
     workspaceDisplayRootOverride: params.workspaceDisplayRootOverride,
     bashProxy: params.bashProxy,
   });
-  const existingEntry = pool.get(sessionId);
   if (existingEntry && existingEntry.workerSignature !== workerSignature) {
     logger.info(
       { sessionId, agentId, provider: input.provider },
@@ -1071,6 +1078,7 @@ async function runHostProcessInner(
   cleanupIpc(entry.ipcSessionId);
   ensureSessionDirs(entry.ipcSessionId);
   entry.workerSignature = workerSignature;
+  entry.codexRuntime = input.codexRuntime;
 
   const activity = createActivityTracker();
   entry.onTextDelta = onTextDelta;

--- a/src/infra/worker-signature.ts
+++ b/src/infra/worker-signature.ts
@@ -1,3 +1,4 @@
+import type { CodexTurnRuntime } from '../config/runtime-config.js';
 import type { ProviderCredentials } from '../types/container.js';
 import { TASK_MODEL_KEYS, type TaskModelKey } from '../types/models.js';
 
@@ -20,7 +21,7 @@ export interface WorkerSignatureInput {
   agentId: string;
   provider: string | undefined;
   providerMethod?: string;
-  codexRuntime?: 'hybridclaw' | 'app-server';
+  codexRuntime?: CodexTurnRuntime;
   baseUrl: string;
   apiKey: string;
   requestHeaders: Record<string, string> | undefined;

--- a/src/infra/worker-signature.ts
+++ b/src/infra/worker-signature.ts
@@ -20,6 +20,7 @@ export interface WorkerSignatureInput {
   agentId: string;
   provider: string | undefined;
   providerMethod?: string;
+  codexRuntime?: 'hybridclaw' | 'app-server';
   baseUrl: string;
   apiKey: string;
   requestHeaders: Record<string, string> | undefined;
@@ -119,6 +120,7 @@ export function computeWorkerSignature(input: WorkerSignatureInput): string {
     agentId: String(input.agentId || '').trim(),
     provider: String(input.provider || '').trim(),
     providerMethod: String(input.providerMethod || '').trim(),
+    codexRuntime: String(input.codexRuntime || '').trim(),
     baseUrl: String(input.baseUrl || '')
       .trim()
       .replace(/\/+$/g, ''),

--- a/src/types/container.ts
+++ b/src/types/container.ts
@@ -106,6 +106,7 @@ export interface ContainerOutput {
   status: 'success' | 'error';
   result: string | null;
   toolsUsed: string[];
+  codexRuntime?: CodexTurnRuntime;
   artifacts?: ArtifactMetadata[];
   memoryCitations?: MemoryCitation[];
   toolExecutions?: ToolExecution[];

--- a/src/types/container.ts
+++ b/src/types/container.ts
@@ -1,4 +1,5 @@
 import type { WebSearchConfig } from '../../container/shared/web-search-config.js';
+import type { CodexTurnRuntime } from '../config/runtime-config.js';
 import type { ChatMessage } from './api.js';
 import type {
   ArtifactMetadata,
@@ -73,7 +74,7 @@ export interface ContainerInput {
   gatewayApiToken?: string;
   browserProvider?: string;
   model: string;
-  codexRuntime?: 'hybridclaw' | 'app-server';
+  codexRuntime?: CodexTurnRuntime;
   ralphMaxIterations?: number | null;
   fullAutoEnabled?: boolean;
   fullAutoNeverApproveTools?: string[];

--- a/src/types/container.ts
+++ b/src/types/container.ts
@@ -73,6 +73,7 @@ export interface ContainerInput {
   gatewayApiToken?: string;
   browserProvider?: string;
   model: string;
+  codexRuntime?: 'hybridclaw' | 'app-server';
   ralphMaxIterations?: number | null;
   fullAutoEnabled?: boolean;
   fullAutoNeverApproveTools?: string[];

--- a/tests/codex-app-runtime.test.ts
+++ b/tests/codex-app-runtime.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 import {
   buildCodexApprovalResponseForDirective,
   buildCodexAppServerArgs,
+  buildCodexMcpContextPayloads,
   buildCodexTurnText,
   projectCodexThreadItem,
 } from '../container/src/codex-app-server.js';
@@ -112,6 +113,28 @@ describe('Codex app-server runtime helpers', () => {
     );
   });
 
+  test('validates app-server runtime case-insensitively when editing config', async () => {
+    vi.resetModules();
+    const spawnSync = vi.fn().mockReturnValue({ status: 0, stderr: '' });
+    vi.doMock('node:child_process', () => ({ spawnSync }));
+    const { setRuntimeConfigValueAtPath } = await import(
+      '../src/config/runtime-config-edit.js'
+    );
+    const { DEFAULT_RUNTIME_CONFIG } = await import(
+      '../src/config/runtime-config.js'
+    );
+    const config = structuredClone(DEFAULT_RUNTIME_CONFIG);
+
+    setRuntimeConfigValueAtPath(config, 'codex.runtime', 'APP-SERVER');
+
+    expect(spawnSync).toHaveBeenCalledWith('codex', ['--version'], {
+      encoding: 'utf-8',
+    });
+    expect(spawnSync).toHaveBeenCalledWith('codex', ['app-server', '--help'], {
+      encoding: 'utf-8',
+    });
+  });
+
   test('translates Codex approval requests into Codex app-server responses', () => {
     expect(
       buildCodexApprovalResponseForDirective(
@@ -186,6 +209,41 @@ describe('Codex app-server runtime helpers', () => {
     expect(joined).not.toContain('secret-password');
     expect(joined).not.toContain('Authorization');
     expect(joined).not.toContain('bad name');
+  });
+
+  test('keeps callback MCP secrets out of the persisted context payload', () => {
+    const payloads = buildCodexMcpContextPayloads({
+      provider: 'openai-codex',
+      providerMethod: 'oauth',
+      baseUrl: 'https://api.example.com',
+      apiKey: 'secret-api-key',
+      model: 'openai-codex/gpt-5.4',
+      chatbotId: 'chatbot-a',
+      requestHeaders: { Authorization: 'Bearer secret-header' },
+      gatewayBaseUrl: 'https://gateway.example.com',
+      gatewayApiToken: 'secret-gateway-token',
+      webSearch: {
+        provider: 'brave',
+        fallbackProviders: [],
+        defaultCount: 5,
+        cacheTtlMinutes: 0,
+        searxngBaseUrl: '',
+        tavilySearchDepth: 'basic',
+        braveApiKey: 'secret-web-key',
+      },
+      providerCredentials: { openai: { apiKey: 'secret-provider-key' } },
+    });
+    const fileContext = JSON.stringify(payloads.fileContext);
+    const secretContext = JSON.stringify(payloads.secretContext);
+
+    expect(fileContext).toContain('openai-codex');
+    expect(fileContext).not.toContain('secret-api-key');
+    expect(fileContext).not.toContain('secret-gateway-token');
+    expect(fileContext).not.toContain('Authorization');
+    expect(fileContext).not.toContain('secret-web-key');
+    expect(fileContext).not.toContain('secret-provider-key');
+    expect(secretContext).toContain('secret-api-key');
+    expect(secretContext).toContain('secret-gateway-token');
   });
 
   test('projects Codex command and patch items into HybridClaw tool executions', () => {

--- a/tests/codex-app-runtime.test.ts
+++ b/tests/codex-app-runtime.test.ts
@@ -1,0 +1,342 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import {
+  buildCodexApprovalResponseForDirective,
+  buildCodexAppServerArgs,
+  buildCodexTurnText,
+  projectCodexThreadItem,
+} from '../container/src/codex-app-server.js';
+import {
+  buildUnavailableCallbackToolResult,
+  getHybridClawCallbackMcpToolNames,
+  isHybridClawCallbackToolName,
+} from '../container/src/codex-hybridclaw-mcp.js';
+import {
+  DEFAULT_RUNTIME_CONFIG,
+  normalizeCodexTurnRuntime,
+} from '../src/config/runtime-config.js';
+
+describe('Codex app-server runtime helpers', () => {
+  afterEach(() => {
+    vi.doUnmock('node:child_process');
+    vi.resetModules();
+  });
+
+  test('defaults to the existing HybridClaw runtime', () => {
+    expect(DEFAULT_RUNTIME_CONFIG.codex.runtime).toBe('hybridclaw');
+    expect(normalizeCodexTurnRuntime('app-server')).toBe('app-server');
+    expect(normalizeCodexTurnRuntime('unknown')).toBe('hybridclaw');
+  });
+
+  test('builds a turn prompt without mutating system instructions', () => {
+    expect(
+      buildCodexTurnText([
+        { role: 'system', content: 'system stays separate' },
+        { role: 'user', content: 'first' },
+        { role: 'assistant', content: 'second' },
+        { role: 'user', content: 'third' },
+      ]),
+    ).toContain('Current user request:\nthird');
+  });
+
+  test('registers the HybridClaw callback MCP server with transient context', () => {
+    const args = buildCodexAppServerArgs(
+      undefined,
+      '/tmp/hybridclaw-context.json',
+    );
+    const joined = args.join('\n');
+
+    expect(args.slice(0, 3)).toEqual(['app-server', '--listen', 'stdio://']);
+    expect(joined).toContain('mcp_servers.hybridclaw.command');
+    expect(joined).toContain('mcp_servers.hybridclaw.args');
+    expect(joined).toContain(
+      'mcp_servers.hybridclaw.env.HYBRIDCLAW_CODEX_MCP_CONTEXT_PATH',
+    );
+    expect(joined).toContain('/tmp/hybridclaw-context.json');
+  });
+
+  test('callback MCP exposes safe HybridClaw surfaces and clear fallback messaging', () => {
+    const names = getHybridClawCallbackMcpToolNames();
+
+    expect(names).toContain('web_fetch');
+    expect(names).toContain('web_extract');
+    expect(names).toContain('web_search');
+    expect(names).toContain('vision_analyze');
+    expect(names).toContain('image_generate');
+    expect(names).toContain('audio_transcribe');
+    expect(names).toContain('skill_lookup');
+    expect(names).toContain('tts_status');
+    expect(names).toContain('browser_navigate');
+    expect(isHybridClawCallbackToolName('bash')).toBe(false);
+
+    expect(buildUnavailableCallbackToolResult('bash')).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: 'HybridClaw callback tool is unavailable in Codex app-server mode: bash',
+        },
+      ],
+      isError: true,
+    });
+  });
+
+  test('validates missing Codex CLI with an actionable error', async () => {
+    vi.resetModules();
+    const spawnSync = vi.fn().mockReturnValue({
+      error: Object.assign(new Error('spawn codex ENOENT'), {
+        code: 'ENOENT',
+      }),
+    });
+    vi.doMock('node:child_process', () => ({ spawnSync }));
+    const { assertCodexAppServerRuntimeAvailable } = await import(
+      '../src/config/runtime-config-edit.js'
+    );
+
+    expect(() => assertCodexAppServerRuntimeAvailable()).toThrow(
+      'Install the OpenAI Codex CLI',
+    );
+  });
+
+  test('validates missing app-server support with an actionable upgrade error', async () => {
+    vi.resetModules();
+    const spawnSync = vi
+      .fn()
+      .mockReturnValueOnce({ status: 0, stderr: '' })
+      .mockReturnValueOnce({ status: 1, stderr: 'unknown command' });
+    vi.doMock('node:child_process', () => ({ spawnSync }));
+    const { assertCodexAppServerRuntimeAvailable } = await import(
+      '../src/config/runtime-config-edit.js'
+    );
+
+    expect(() => assertCodexAppServerRuntimeAvailable()).toThrow(
+      'Upgrade the OpenAI Codex CLI',
+    );
+  });
+
+  test('translates Codex approval requests into Codex app-server responses', () => {
+    expect(
+      buildCodexApprovalResponseForDirective(
+        'item/commandExecution/requestApproval',
+        'approve abc123',
+      ),
+    ).toEqual({ decision: 'accept' });
+    expect(
+      buildCodexApprovalResponseForDirective(
+        'item/fileChange/requestApproval',
+        'approve abc123 for session',
+      ),
+    ).toEqual({ decision: 'acceptForSession' });
+    expect(
+      buildCodexApprovalResponseForDirective('execCommandApproval', 'deny'),
+    ).toEqual({ decision: 'denied' });
+    expect(
+      buildCodexApprovalResponseForDirective(
+        'item/permissions/requestApproval',
+        'approve for session',
+        {
+          permissions: {
+            fileSystem: { writableRoots: ['/workspace'] },
+          },
+        },
+      ),
+    ).toEqual({
+      permissions: {
+        fileSystem: { writableRoots: ['/workspace'] },
+      },
+      scope: 'session',
+      strictAutoReview: true,
+    });
+  });
+
+  test('migrates user MCP servers without embedding sensitive environment values', () => {
+    const args = buildCodexAppServerArgs(
+      {
+        docs: {
+          transport: 'stdio',
+          command: 'node',
+          args: ['server.js'],
+          cwd: '/workspace',
+          env: {
+            SAFE_MODE: '1',
+            API_TOKEN: 'secret-token',
+            password: 'secret-password',
+          },
+        },
+        remote: {
+          transport: 'http',
+          url: 'https://mcp.example.com',
+          headers: { Authorization: 'Bearer secret' },
+        },
+        'bad name': {
+          transport: 'stdio',
+          command: 'node',
+        },
+      },
+      '/tmp/hybridclaw-context.json',
+    );
+    const joined = args.join('\n');
+
+    expect(joined).toContain('mcp_servers.docs.command');
+    expect(joined).toContain('mcp_servers.docs.args');
+    expect(joined).toContain('mcp_servers.docs.cwd');
+    expect(joined).toContain('mcp_servers.docs.env.SAFE_MODE');
+    expect(joined).toContain('mcp_servers.remote.url');
+    expect(joined).not.toContain('API_TOKEN');
+    expect(joined).not.toContain('secret-token');
+    expect(joined).not.toContain('password');
+    expect(joined).not.toContain('secret-password');
+    expect(joined).not.toContain('Authorization');
+    expect(joined).not.toContain('bad name');
+  });
+
+  test('projects Codex command and patch items into HybridClaw tool executions', () => {
+    const projection: Parameters<typeof projectCodexThreadItem>[0] = {
+      threadId: null,
+      turnId: null,
+      textDeltas: [],
+      agentMessages: [],
+      toolExecutions: [],
+      toolsUsed: [],
+      tokenUsage: {
+        modelCalls: 1,
+        apiUsageAvailable: false,
+        apiPromptTokens: 0,
+        apiCompletionTokens: 0,
+        apiTotalTokens: 0,
+        apiCacheUsageAvailable: false,
+        apiCacheReadTokens: 0,
+        apiCacheWriteTokens: 0,
+        estimatedPromptTokens: 0,
+        estimatedCompletionTokens: 0,
+        estimatedTotalTokens: 0,
+      },
+      approvalEvents: [],
+      pendingApproval: null,
+      error: null,
+      completed: false,
+    };
+
+    projectCodexThreadItem(projection, {
+      type: 'commandExecution',
+      command: 'npm test',
+      aggregatedOutput: 'ok',
+      status: 'completed',
+      durationMs: 12,
+    });
+    projectCodexThreadItem(projection, {
+      type: 'fileChange',
+      changes: [{ path: 'src/index.ts' }],
+      status: 'applied',
+    });
+
+    expect(projection.toolsUsed).toEqual(['codex.command', 'codex.patch']);
+    expect(projection.toolExecutions[0]).toMatchObject({
+      name: 'codex.command',
+      arguments: 'npm test',
+      result: 'ok',
+      isError: false,
+    });
+    expect(projection.toolExecutions[1]?.arguments).toContain('src/index.ts');
+  });
+
+  test('projects Codex MCP and dynamic tool items into HybridClaw tool executions', () => {
+    const projection: Parameters<typeof projectCodexThreadItem>[0] = {
+      threadId: null,
+      turnId: null,
+      textDeltas: [],
+      agentMessages: [],
+      toolExecutions: [],
+      toolsUsed: [],
+      tokenUsage: {
+        modelCalls: 1,
+        apiUsageAvailable: false,
+        apiPromptTokens: 0,
+        apiCompletionTokens: 0,
+        apiTotalTokens: 0,
+        apiCacheUsageAvailable: false,
+        apiCacheReadTokens: 0,
+        apiCacheWriteTokens: 0,
+        estimatedPromptTokens: 0,
+        estimatedCompletionTokens: 0,
+        estimatedTotalTokens: 0,
+      },
+      approvalEvents: [],
+      pendingApproval: null,
+      error: null,
+      completed: false,
+    };
+
+    projectCodexThreadItem(projection, {
+      type: 'mcpToolCall',
+      server: 'hybridclaw',
+      tool: 'web_fetch',
+      arguments: { url: 'https://example.com' },
+      result: [{ type: 'text', text: 'ok' }],
+      durationMs: 5,
+    });
+    projectCodexThreadItem(projection, {
+      type: 'dynamicToolCall',
+      tool: 'apply_patch',
+      arguments: { path: 'src/index.ts' },
+      status: 'completed',
+    });
+
+    expect(projection.toolsUsed).toEqual(['codex.mcp', 'codex.tool']);
+    expect(projection.toolExecutions[0]).toMatchObject({
+      name: 'codex.mcp',
+      isError: false,
+    });
+    expect(projection.toolExecutions[0]?.arguments).toContain(
+      'hybridclaw.web_fetch',
+    );
+    expect(projection.toolExecutions[1]).toMatchObject({
+      name: 'codex.tool',
+      isError: false,
+    });
+    expect(projection.toolExecutions[1]?.arguments).toContain('apply_patch');
+  });
+
+  test('projects Codex plan and sandbox items into normalized tool executions', () => {
+    const projection: Parameters<typeof projectCodexThreadItem>[0] = {
+      threadId: null,
+      turnId: null,
+      textDeltas: [],
+      agentMessages: [],
+      toolExecutions: [],
+      toolsUsed: [],
+      tokenUsage: {
+        modelCalls: 1,
+        apiUsageAvailable: false,
+        apiPromptTokens: 0,
+        apiCompletionTokens: 0,
+        apiTotalTokens: 0,
+        apiCacheUsageAvailable: false,
+        apiCacheReadTokens: 0,
+        apiCacheWriteTokens: 0,
+        estimatedPromptTokens: 0,
+        estimatedCompletionTokens: 0,
+        estimatedTotalTokens: 0,
+      },
+      approvalEvents: [],
+      pendingApproval: null,
+      error: null,
+      completed: false,
+    };
+
+    projectCodexThreadItem(projection, {
+      type: 'planUpdate',
+      plan: [{ step: 'inspect', status: 'completed' }],
+      status: 'completed',
+    });
+    projectCodexThreadItem(projection, {
+      type: 'sandboxPolicy',
+      profile: 'workspace-write',
+      status: 'active',
+    });
+
+    expect(projection.toolsUsed).toEqual(['codex.plan', 'codex.sandbox']);
+    expect(projection.toolExecutions[0]?.arguments).toContain('inspect');
+    expect(projection.toolExecutions[1]?.arguments).toContain(
+      'workspace-write',
+    );
+  });
+});

--- a/tests/codex-app-runtime.test.ts
+++ b/tests/codex-app-runtime.test.ts
@@ -139,6 +139,7 @@ describe('Codex app-server runtime helpers', () => {
 
   test('defaults to the existing HybridClaw runtime', () => {
     expect(DEFAULT_RUNTIME_CONFIG.codex.runtime).toBe('hybridclaw');
+    expect(DEFAULT_RUNTIME_CONFIG.codex.turnRuntime).toBe('hybridclaw');
     expect(normalizeCodexTurnRuntime('app-server')).toBe('app-server');
     expect(normalizeCodexTurnRuntime('unknown')).toBe('hybridclaw');
   });
@@ -243,6 +244,32 @@ describe('Codex app-server runtime helpers', () => {
 
     setRuntimeConfigValueAtPath(config, 'codex.runtime', 'APP-SERVER');
 
+    expect(config.codex.runtime).toBe('app-server');
+    expect(config.codex.turnRuntime).toBe('app-server');
+    expect(spawnSync).toHaveBeenCalledWith('codex', ['--version'], {
+      encoding: 'utf-8',
+    });
+    expect(spawnSync).toHaveBeenCalledWith('codex', ['app-server', '--help'], {
+      encoding: 'utf-8',
+    });
+  });
+
+  test('validates app-server turnRuntime alias when editing config', async () => {
+    vi.resetModules();
+    const spawnSync = vi.fn().mockReturnValue({ status: 0, stderr: '' });
+    vi.doMock('node:child_process', () => ({ spawnSync }));
+    const { setRuntimeConfigValueAtPath } = await import(
+      '../src/config/runtime-config-edit.js'
+    );
+    const { DEFAULT_RUNTIME_CONFIG } = await import(
+      '../src/config/runtime-config.js'
+    );
+    const config = structuredClone(DEFAULT_RUNTIME_CONFIG);
+
+    setRuntimeConfigValueAtPath(config, 'codex.turnRuntime', 'APP-SERVER');
+
+    expect(config.codex.runtime).toBe('app-server');
+    expect(config.codex.turnRuntime).toBe('app-server');
     expect(spawnSync).toHaveBeenCalledWith('codex', ['--version'], {
       encoding: 'utf-8',
     });

--- a/tests/codex-app-runtime.test.ts
+++ b/tests/codex-app-runtime.test.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import {
   buildCodexApprovalResponseForDirective,
@@ -21,6 +23,119 @@ describe('Codex app-server runtime helpers', () => {
     vi.doUnmock('node:child_process');
     vi.resetModules();
   });
+
+  function makeProjection(): Parameters<typeof projectCodexThreadItem>[0] {
+    return {
+      threadId: null,
+      textDeltas: [],
+      agentMessages: [],
+      toolExecutions: [],
+      toolsUsed: new Set<string>(),
+      tokenUsage: {
+        modelCalls: 1,
+        apiUsageAvailable: false,
+        apiPromptTokens: 0,
+        apiCompletionTokens: 0,
+        apiTotalTokens: 0,
+        apiCacheUsageAvailable: false,
+        apiCacheReadTokens: 0,
+        apiCacheWriteTokens: 0,
+        estimatedPromptTokens: 0,
+        estimatedCompletionTokens: 0,
+        estimatedTotalTokens: 0,
+      },
+      approvalEvents: [],
+      pendingApproval: null,
+      error: null,
+      completed: false,
+    };
+  }
+
+  function createMockChild() {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: PassThrough;
+      stderr: PassThrough;
+      stdin: { write: ReturnType<typeof vi.fn> };
+      kill: ReturnType<typeof vi.fn>;
+    };
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    child.stdin = { write: vi.fn() };
+    child.kill = vi.fn(() => {
+      child.emit('exit', null, 'SIGTERM');
+      return true;
+    });
+    return child;
+  }
+
+  function writeJsonLine(
+    child: ReturnType<typeof createMockChild>,
+    value: unknown,
+  ) {
+    child.stdout.write(`${JSON.stringify(value)}\n`);
+  }
+
+  function createCodexSpawnMock() {
+    let appServerIndex = 0;
+    return vi.fn((_command: string, args: string[]) => {
+      const child = createMockChild();
+      if (args[0] === '--version') {
+        queueMicrotask(() => child.emit('exit', 0));
+        return child;
+      }
+
+      const index = appServerIndex;
+      appServerIndex += 1;
+      const approvalRequestId = 900 + index;
+      child.stdin.write = vi.fn((line: string) => {
+        const message = JSON.parse(line) as {
+          id?: number;
+          method?: string;
+          result?: unknown;
+        };
+        if (message.method === 'initialize') {
+          writeJsonLine(child, { id: message.id, result: {} });
+          return true;
+        }
+        if (message.method === 'thread/start') {
+          writeJsonLine(child, {
+            id: message.id,
+            result: { thread: { id: `thread-${index}` } },
+          });
+          return true;
+        }
+        if (message.method === 'turn/start') {
+          writeJsonLine(child, {
+            id: message.id,
+            result: { turn: { id: `turn-${index}`, status: 'in_progress' } },
+          });
+          setTimeout(() => {
+            writeJsonLine(child, {
+              id: approvalRequestId,
+              method: 'item/commandExecution/requestApproval',
+              params: { command: `echo ${index}` },
+            });
+          }, 0);
+          return true;
+        }
+        if (message.id === approvalRequestId && message.result) {
+          writeJsonLine(child, {
+            method: 'item/completed',
+            params: {
+              item: { type: 'agentMessage', text: `approved-${index}` },
+            },
+          });
+          writeJsonLine(child, {
+            method: 'turn/completed',
+            params: { turn: { status: 'completed' } },
+          });
+          return true;
+        }
+        return true;
+      });
+      return child;
+    });
+  }
 
   test('defaults to the existing HybridClaw runtime', () => {
     expect(DEFAULT_RUNTIME_CONFIG.codex.runtime).toBe('hybridclaw');
@@ -65,7 +180,7 @@ describe('Codex app-server runtime helpers', () => {
     expect(names).toContain('image_generate');
     expect(names).toContain('audio_transcribe');
     expect(names).toContain('skill_lookup');
-    expect(names).toContain('tts_status');
+    expect(names).not.toContain('tts_status');
     expect(names).toContain('browser_navigate');
     expect(isHybridClawCallbackToolName('bash')).toBe(false);
 
@@ -170,6 +285,63 @@ describe('Codex app-server runtime helpers', () => {
     });
   });
 
+  test('keeps pending app-server approvals isolated by session', async () => {
+    vi.resetModules();
+    const spawn = createCodexSpawnMock();
+    vi.doMock('node:child_process', () => ({ spawn }));
+    const { resumePendingCodexAppServerApproval, runCodexAppServerTurn } =
+      await import('../container/src/codex-app-server.js');
+    const baseParams = {
+      messages: [{ role: 'user' as const, content: 'run a command' }],
+      model: 'openai-codex/gpt-5.4',
+      cwd: '/workspace',
+      provider: 'openai-codex' as const,
+    };
+
+    const first = await runCodexAppServerTurn({
+      ...baseParams,
+      sessionId: 'session-a',
+    });
+    const second = await runCodexAppServerTurn({
+      ...baseParams,
+      sessionId: 'session-b',
+    });
+
+    expect(first.pendingApproval?.approvalId).toBeTruthy();
+    expect(second.pendingApproval?.approvalId).toBeTruthy();
+    expect(
+      await resumePendingCodexAppServerApproval({
+        sessionId: 'session-c',
+        messages: [{ role: 'user', content: 'approve' }],
+      }),
+    ).toBeNull();
+
+    const resumedFirst = await resumePendingCodexAppServerApproval({
+      sessionId: 'session-a',
+      messages: [
+        {
+          role: 'user',
+          content: `approve ${first.pendingApproval?.approvalId}`,
+        },
+      ],
+    });
+    const resumedSecond = await resumePendingCodexAppServerApproval({
+      sessionId: 'session-b',
+      messages: [
+        {
+          role: 'user',
+          content: `approve ${second.pendingApproval?.approvalId}`,
+        },
+      ],
+    });
+
+    expect(resumedFirst?.result).toBe('approved-0');
+    expect(resumedSecond?.result).toBe('approved-1');
+    expect(
+      spawn.mock.calls.filter(([, args]) => args[0] === '--version'),
+    ).toHaveLength(1);
+  });
+
   test('migrates user MCP servers without embedding sensitive environment values', () => {
     const args = buildCodexAppServerArgs(
       {
@@ -181,6 +353,10 @@ describe('Codex app-server runtime helpers', () => {
           env: {
             SAFE_MODE: '1',
             API_TOKEN: 'secret-token',
+            OPENAI_KEY: 'secret-openai-key',
+            DB_PASS: 'secret-db-pass',
+            SVC_CREDENTIAL: 'secret-service-credential',
+            X_API_SECRET: 'secret-api-secret',
             password: 'secret-password',
           },
         },
@@ -205,6 +381,14 @@ describe('Codex app-server runtime helpers', () => {
     expect(joined).toContain('mcp_servers.remote.url');
     expect(joined).not.toContain('API_TOKEN');
     expect(joined).not.toContain('secret-token');
+    expect(joined).not.toContain('OPENAI_KEY');
+    expect(joined).not.toContain('secret-openai-key');
+    expect(joined).not.toContain('DB_PASS');
+    expect(joined).not.toContain('secret-db-pass');
+    expect(joined).not.toContain('SVC_CREDENTIAL');
+    expect(joined).not.toContain('secret-service-credential');
+    expect(joined).not.toContain('X_API_SECRET');
+    expect(joined).not.toContain('secret-api-secret');
     expect(joined).not.toContain('password');
     expect(joined).not.toContain('secret-password');
     expect(joined).not.toContain('Authorization');
@@ -237,6 +421,8 @@ describe('Codex app-server runtime helpers', () => {
     const secretContext = JSON.stringify(payloads.secretContext);
 
     expect(fileContext).toContain('openai-codex');
+    expect(fileContext).toContain('"provider":"brave"');
+    expect(fileContext).toContain('"defaultCount":5');
     expect(fileContext).not.toContain('secret-api-key');
     expect(fileContext).not.toContain('secret-gateway-token');
     expect(fileContext).not.toContain('Authorization');
@@ -244,34 +430,12 @@ describe('Codex app-server runtime helpers', () => {
     expect(fileContext).not.toContain('secret-provider-key');
     expect(secretContext).toContain('secret-api-key');
     expect(secretContext).toContain('secret-gateway-token');
+    expect(secretContext).toContain('secret-web-key');
+    expect(secretContext).not.toContain('"defaultCount":5');
   });
 
   test('projects Codex command and patch items into HybridClaw tool executions', () => {
-    const projection: Parameters<typeof projectCodexThreadItem>[0] = {
-      threadId: null,
-      turnId: null,
-      textDeltas: [],
-      agentMessages: [],
-      toolExecutions: [],
-      toolsUsed: [],
-      tokenUsage: {
-        modelCalls: 1,
-        apiUsageAvailable: false,
-        apiPromptTokens: 0,
-        apiCompletionTokens: 0,
-        apiTotalTokens: 0,
-        apiCacheUsageAvailable: false,
-        apiCacheReadTokens: 0,
-        apiCacheWriteTokens: 0,
-        estimatedPromptTokens: 0,
-        estimatedCompletionTokens: 0,
-        estimatedTotalTokens: 0,
-      },
-      approvalEvents: [],
-      pendingApproval: null,
-      error: null,
-      completed: false,
-    };
+    const projection = makeProjection();
 
     projectCodexThreadItem(projection, {
       type: 'commandExecution',
@@ -286,7 +450,7 @@ describe('Codex app-server runtime helpers', () => {
       status: 'applied',
     });
 
-    expect(projection.toolsUsed).toEqual(['codex.command', 'codex.patch']);
+    expect([...projection.toolsUsed]).toEqual(['codex.command', 'codex.patch']);
     expect(projection.toolExecutions[0]).toMatchObject({
       name: 'codex.command',
       arguments: 'npm test',
@@ -297,31 +461,7 @@ describe('Codex app-server runtime helpers', () => {
   });
 
   test('projects Codex MCP and dynamic tool items into HybridClaw tool executions', () => {
-    const projection: Parameters<typeof projectCodexThreadItem>[0] = {
-      threadId: null,
-      turnId: null,
-      textDeltas: [],
-      agentMessages: [],
-      toolExecutions: [],
-      toolsUsed: [],
-      tokenUsage: {
-        modelCalls: 1,
-        apiUsageAvailable: false,
-        apiPromptTokens: 0,
-        apiCompletionTokens: 0,
-        apiTotalTokens: 0,
-        apiCacheUsageAvailable: false,
-        apiCacheReadTokens: 0,
-        apiCacheWriteTokens: 0,
-        estimatedPromptTokens: 0,
-        estimatedCompletionTokens: 0,
-        estimatedTotalTokens: 0,
-      },
-      approvalEvents: [],
-      pendingApproval: null,
-      error: null,
-      completed: false,
-    };
+    const projection = makeProjection();
 
     projectCodexThreadItem(projection, {
       type: 'mcpToolCall',
@@ -338,7 +478,7 @@ describe('Codex app-server runtime helpers', () => {
       status: 'completed',
     });
 
-    expect(projection.toolsUsed).toEqual(['codex.mcp', 'codex.tool']);
+    expect([...projection.toolsUsed]).toEqual(['codex.mcp', 'codex.tool']);
     expect(projection.toolExecutions[0]).toMatchObject({
       name: 'codex.mcp',
       isError: false,
@@ -354,31 +494,7 @@ describe('Codex app-server runtime helpers', () => {
   });
 
   test('projects Codex plan and sandbox items into normalized tool executions', () => {
-    const projection: Parameters<typeof projectCodexThreadItem>[0] = {
-      threadId: null,
-      turnId: null,
-      textDeltas: [],
-      agentMessages: [],
-      toolExecutions: [],
-      toolsUsed: [],
-      tokenUsage: {
-        modelCalls: 1,
-        apiUsageAvailable: false,
-        apiPromptTokens: 0,
-        apiCompletionTokens: 0,
-        apiTotalTokens: 0,
-        apiCacheUsageAvailable: false,
-        apiCacheReadTokens: 0,
-        apiCacheWriteTokens: 0,
-        estimatedPromptTokens: 0,
-        estimatedCompletionTokens: 0,
-        estimatedTotalTokens: 0,
-      },
-      approvalEvents: [],
-      pendingApproval: null,
-      error: null,
-      completed: false,
-    };
+    const projection = makeProjection();
 
     projectCodexThreadItem(projection, {
       type: 'planUpdate',
@@ -391,7 +507,7 @@ describe('Codex app-server runtime helpers', () => {
       status: 'active',
     });
 
-    expect(projection.toolsUsed).toEqual(['codex.plan', 'codex.sandbox']);
+    expect([...projection.toolsUsed]).toEqual(['codex.plan', 'codex.sandbox']);
     expect(projection.toolExecutions[0]?.arguments).toContain('inspect');
     expect(projection.toolExecutions[1]?.arguments).toContain(
       'workspace-write',

--- a/tests/codex-app-runtime.test.ts
+++ b/tests/codex-app-runtime.test.ts
@@ -180,6 +180,7 @@ describe('Codex app-server runtime helpers', () => {
     expect(names).toContain('image_generate');
     expect(names).toContain('audio_transcribe');
     expect(names).toContain('skill_lookup');
+    expect(names).toContain('voice_status');
     expect(names).not.toContain('tts_status');
     expect(names).toContain('browser_navigate');
     expect(isHybridClawCallbackToolName('bash')).toBe(false);

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -977,6 +977,36 @@ test('status command includes the current session agent', async () => {
   );
 });
 
+test('status command labels Codex app-server turn runtime separately from sandbox', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  writeRuntimeConfig(homeDir, (config) => {
+    config.hybridai.defaultModel = 'openai-codex/gpt-5.5';
+    config.codex.turnRuntime = 'app-server';
+  });
+  vi.resetModules();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  const result = await handleGatewayCommand({
+    sessionId: 'session-status-codex-runtime',
+    guildId: null,
+    channelId: 'channel-status-codex-runtime',
+    args: ['status'],
+  });
+
+  expect(result.kind).toBe('info');
+  if (result.kind !== 'info') {
+    throw new Error(`Unexpected result kind: ${result.kind}`);
+  }
+  expect(result.text).toContain('Model: openai-codex/gpt-5.5');
+  expect(result.text).toContain('Runtime: codex · Sandbox:');
+});
+
 test('status command includes active sandbox session ids when present', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;


### PR DESCRIPTION
## Summary

Closes #1022.

Adds an opt-in `codex.runtime` selector for OpenAI/Codex turns, defaulting to the existing HybridClaw runtime. When `app-server` is selected for a new OpenAI/Codex session, HybridClaw launches `codex app-server`, projects Codex command/file/tool/plan/sandbox events back into the normal container output shape, and routes Codex approvals through HybridClaw pending approval handling.

## Details

- Adds `codex.runtime` config normalization, config example/docs, and CLI validation that `codex app-server` is available before enabling it.
- Freezes the selected runtime per existing worker/session by including it in worker signatures and container input.
- Adds the app-server JSON-RPC bridge, approval resume handling, transient MCP context, and secret-filtered user MCP migration via `-c` overrides.
- Adds a HybridClaw callback MCP server for safe web/browser/skill/image/vision/audio surfaces, with explicit fallback messaging for unavailable in-process tools.
- Adds focused coverage for runtime selection, missing CLI, approval translation, MCP callback registration, event projection, and fallback messaging.

## Validation

- `npx vitest run tests/codex-app-runtime.test.ts`
- `npm run lint`
- `npm --prefix container run lint`
- `npm run build`
- `git diff --check`