### PR TITLE
[codex] Make audit event type search type ahead

### DIFF
--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -5816,6 +5816,7 @@ export function getGatewayAdminAudit(params?: {
       query,
       sessionId,
       eventType,
+      eventTypeMatch: 'prefix',
       limit,
     }).map(mapAdminAuditEntry),
   };

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -9112,9 +9112,14 @@ export function getWeeklyAgentAnomalyRollups(
   );
 }
 
+function escapeSqlLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, '\\$&');
+}
+
 function queryStructuredAuditEntries(params?: {
   sessionId?: string;
   eventType?: string;
+  eventTypeMatch?: 'exact' | 'prefix';
   query?: string;
   limit?: number;
   maxLimit?: number;
@@ -9136,8 +9141,13 @@ function queryStructuredAuditEntries(params?: {
     values.push(sessionId);
   }
   if (eventType) {
-    clauses.push('event_type = ?');
-    values.push(eventType);
+    if (params?.eventTypeMatch === 'prefix') {
+      clauses.push("event_type LIKE ? ESCAPE '\\'");
+      values.push(`${escapeSqlLikePattern(eventType)}%`);
+    } else {
+      clauses.push('event_type = ?');
+      values.push(eventType);
+    }
   }
   if (query) {
     const like = `%${query}%`;
@@ -9270,12 +9280,14 @@ export function getStructuredAuditForSession(
 export function listStructuredAuditEntries(params?: {
   sessionId?: string;
   eventType?: string;
+  eventTypeMatch?: 'exact' | 'prefix';
   query?: string;
   limit?: number;
 }): StructuredAuditEntry[] {
   return queryStructuredAuditEntries({
     sessionId: params?.sessionId,
     eventType: params?.eventType,
+    eventTypeMatch: params?.eventTypeMatch,
     query: params?.query,
     limit: params?.limit ?? 50,
     orderBy: 'id',

--- a/tests/gateway-service.audit.test.ts
+++ b/tests/gateway-service.audit.test.ts
@@ -105,6 +105,48 @@ test('admin tools exposes recent tool error summaries', async () => {
   });
 });
 
+test('admin audit event type filter supports partial type-ahead matches', async () => {
+  setupHome();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { makeAuditRunId, recordAuditEvent } = await import(
+    '../src/audit/audit-events.ts'
+  );
+
+  initDatabase({ quiet: true });
+  recordAuditEvent({
+    sessionId: 'session-usage',
+    runId: makeAuditRunId('test'),
+    event: {
+      type: 'usage.batch_flushed',
+      sessionCount: 1,
+      recordCount: 1,
+    },
+  });
+  recordAuditEvent({
+    sessionId: 'session-tool',
+    runId: makeAuditRunId('test'),
+    event: {
+      type: 'tool.result',
+      toolName: 'bash',
+      isError: false,
+    },
+  });
+
+  const { getGatewayAdminAudit } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+  const result = getGatewayAdminAudit({
+    eventType: 'usage',
+    limit: 10,
+  });
+
+  expect(result.eventType).toBe('usage');
+  expect(result.entries.map((entry) => entry.eventType)).toEqual([
+    'usage.batch_flushed',
+  ]);
+});
+
 test('bot set records a structured audit event for observability export', async () => {
   setupHome();
   const userId = 'u'.repeat(200);

--- a/tests/structured-audit-query.test.ts
+++ b/tests/structured-audit-query.test.ts
@@ -93,6 +93,25 @@ test('listStructuredAuditEntries can prefix-match event type for type-ahead filt
     ).toEqual(['usage.batch_flushed']);
   }
 
+  logStructuredAuditEvent({
+    version: '2.0',
+    seq: 3,
+    timestamp: new Date(3000).toISOString(),
+    runId: 'run-3',
+    sessionId: 'session-audit-typeahead',
+    event: { type: 'usage.batchXflushed' },
+    _prevHash: 'prev-3',
+    _hash: 'hash-3',
+  } satisfies WireRecord);
+
+  expect(
+    listStructuredAuditEntries({
+      eventType: 'usage.batch_',
+      eventTypeMatch: 'prefix',
+      limit: 10,
+    }).map((entry) => entry.event_type),
+  ).toEqual(['usage.batch_flushed']);
+
   expect(
     listStructuredAuditEntries({
       eventType: 'usage',

--- a/tests/structured-audit-query.test.ts
+++ b/tests/structured-audit-query.test.ts
@@ -59,3 +59,44 @@ test('getStructuredAuditForSession caps large sessions and warns once', async ()
   expect(logOutput).toContain('10000');
   expect(logOutput).toContain('10001');
 });
+
+test('listStructuredAuditEntries can prefix-match event type for type-ahead filters', async () => {
+  setupHome();
+
+  const { initDatabase, listStructuredAuditEntries, logStructuredAuditEvent } =
+    await import('../src/memory/db.ts');
+
+  initDatabase({ quiet: true });
+  for (const [index, type] of [
+    'usage.batch_flushed',
+    'tool.result',
+  ].entries()) {
+    logStructuredAuditEvent({
+      version: '2.0',
+      seq: index + 1,
+      timestamp: new Date((index + 1) * 1000).toISOString(),
+      runId: `run-${index + 1}`,
+      sessionId: 'session-audit-typeahead',
+      event: { type },
+      _prevHash: `prev-${index + 1}`,
+      _hash: `hash-${index + 1}`,
+    } satisfies WireRecord);
+  }
+
+  for (const eventType of ['u', 'usa', 'usage']) {
+    expect(
+      listStructuredAuditEntries({
+        eventType,
+        eventTypeMatch: 'prefix',
+        limit: 10,
+      }).map((entry) => entry.event_type),
+    ).toEqual(['usage.batch_flushed']);
+  }
+
+  expect(
+    listStructuredAuditEntries({
+      eventType: 'usage',
+      limit: 10,
+    }),
+  ).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- Add explicit prefix matching support for structured audit event type filters.
- Opt the admin audit endpoint into prefix matching so partial values like `u`, `usa`, or `usage` match `usage.batch_flushed`.
- Add regression coverage that preserves exact matching for existing structured audit callers unless prefix mode is requested.

## Root Cause
The admin audit Event type input sent partial text to a backend filter that required `event_type = ?`, so no entries appeared until the full event type was typed.

## Validation
- `npx vitest run tests/structured-audit-query.test.ts`
- `npx biome check src/memory/db.ts src/gateway/gateway-service.ts tests/structured-audit-query.test.ts`
- `npm run typecheck`
- `git diff --check`