### PR TITLE
[codex] Clarify conversation preview role logging

### DIFF
--- a/src/gateway/gateway-agent-cards.ts
+++ b/src/gateway/gateway-agent-cards.ts
@@ -303,7 +303,7 @@ function getAgentWatcherLabel(
   return 'runtime detached';
 }
 
-function logUnsupportedConversationPreview(
+function logNonChatConversationPreview(
   sessionId: string,
   messages: StoredMessage[],
   conversation: {
@@ -314,7 +314,7 @@ function logUnsupportedConversationPreview(
   if (conversation.lastQuestion || conversation.lastAnswer) return;
   if (messages.length === 0) return;
 
-  const unsupportedRoles = Array.from(
+  const nonChatRoles = Array.from(
     new Set(
       messages
         .filter((message) => String(message.content || '').trim().length > 0)
@@ -322,15 +322,15 @@ function logUnsupportedConversationPreview(
         .filter((role) => role !== 'user' && role !== 'assistant'),
     ),
   );
-  if (unsupportedRoles.length === 0) return;
+  if (nonChatRoles.length === 0) return;
 
   logger.debug(
     {
       sessionId,
-      unsupportedRoles,
+      nonChatRoles,
       messageCount: messages.length,
     },
-    'Session conversation preview omitted unsupported message roles',
+    'Session conversation preview omitted non-chat message roles',
   );
 }
 
@@ -358,7 +358,7 @@ export function mapSessionCard(params: {
   const messages = getRecentMessages(session.id, 12);
   const preview = buildAgentPreview(session, messages);
   const conversation = buildSessionConversationPreview(messages);
-  logUnsupportedConversationPreview(session.id, messages, conversation);
+  logNonChatConversationPreview(session.id, messages, conversation);
 
   return {
     id: session.id,

--- a/tests/gateway-agent-cards.test.ts
+++ b/tests/gateway-agent-cards.test.ts
@@ -173,7 +173,7 @@ describe('mapLogicalAgentCard', () => {
     });
   });
 
-  test('logs debug details when conversation preview skips unsupported roles', async () => {
+  test('logs debug details when conversation preview skips non-chat roles', async () => {
     const { mapSessionCard } = await import(
       '../src/gateway/gateway-agent-cards.ts'
     );
@@ -235,10 +235,10 @@ describe('mapLogicalAgentCard', () => {
     expect(loggerDebugMock).toHaveBeenCalledWith(
       {
         sessionId: 'sess-1',
-        unsupportedRoles: ['system', 'tool'],
+        nonChatRoles: ['system', 'tool'],
         messageCount: 2,
       },
-      'Session conversation preview omitted unsupported message roles',
+      'Session conversation preview omitted non-chat message roles',
     );
   });
 });


### PR DESCRIPTION
## Summary

- Rename the conversation preview debug helper and payload from `unsupportedRoles` to `nonChatRoles`.
- Update the debug message so valid roles like `system` are not described as unsupported when they are only omitted from the last question/answer preview.
- Adjust the focused gateway agent card test expectation.

## Root Cause

The preview only renders user and assistant snippets because the fields are `lastQuestion` and `lastAnswer`. The existing debug log correctly identified omitted roles, but described them as unsupported, which made normal roles such as `system` look invalid.

## Validation

- `npx biome check --write src/gateway/gateway-agent-cards.ts tests/gateway-agent-cards.test.ts`
- `./node_modules/.bin/vitest run --configLoader runner --project unit tests/gateway-agent-cards.test.ts`