### PR TITLE
[codex] Proactively refresh observability ingest tokens

### DIFF
--- a/src/audit/observability-ingest.ts
+++ b/src/audit/observability-ingest.ts
@@ -20,7 +20,7 @@ import { logger } from '../logger.js';
 import {
   deleteObservabilityIngestToken,
   getAnyChatbotId,
-  getObservabilityIngestToken,
+  getObservabilityIngestTokenRecord,
   getObservabilityOffset,
   getStructuredAuditAfterId,
   setObservabilityIngestToken,
@@ -38,6 +38,8 @@ const FETCH_LIMIT_FACTOR = 4;
 const TOKEN_ADMIN_PATH = '/api/v1/agent-observability/ingest-token:ensure';
 const OBSERVABILITY_TRANSIENT_WARN_WINDOW_MS = 60_000;
 const OBSERVABILITY_TRANSIENT_WARN_LIMIT = 1;
+const OBSERVABILITY_INGEST_TOKEN_MAX_CACHE_AGE_MS = 20 * 60 * 1000;
+const OBSERVABILITY_INGEST_TOKEN_FUTURE_SKEW_MS = 60 * 1000;
 
 interface ResolvedIngestConfig {
   enabled: boolean;
@@ -447,6 +449,22 @@ function formatGrantError(prefix: string, grant: TokenGrantResult): string {
   return `${prefix}: HTTP ${grant.statusCode}`;
 }
 
+function parseIngestTokenUpdatedMs(updatedAt: string): number {
+  const trimmed = updatedAt.trim();
+  if (!trimmed) return Number.NaN;
+  const sqliteUtcMatch = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(trimmed);
+  return Date.parse(sqliteUtcMatch ? `${trimmed.replace(' ', 'T')}Z` : trimmed);
+}
+
+function isFreshIngestToken(updatedAt: string, now = Date.now()): boolean {
+  const updatedMs = parseIngestTokenUpdatedMs(updatedAt);
+  if (!Number.isFinite(updatedMs)) return false;
+  if (updatedMs - now > OBSERVABILITY_INGEST_TOKEN_FUTURE_SKEW_MS) {
+    return false;
+  }
+  return now - updatedMs < OBSERVABILITY_INGEST_TOKEN_MAX_CACHE_AGE_MS;
+}
+
 async function requestIngestToken(
   config: ResolvedIngestConfig,
   rotate = false,
@@ -551,9 +569,26 @@ async function resolveIngestToken(
 
   const tokenKey = buildTokenCacheKey(config);
   if (!forceRefresh) {
-    const cached = getObservabilityIngestToken(tokenKey);
-    if (cached)
-      return { ok: true, token: cached, source: 'cache', reason: null };
+    const cached = getObservabilityIngestTokenRecord(tokenKey);
+    if (cached && isFreshIngestToken(cached.updatedAt)) {
+      return { ok: true, token: cached.token, source: 'cache', reason: null };
+    }
+    if (cached) {
+      const rotated = await requestIngestToken(config, true);
+      if (!rotated.ok) {
+        return { ok: true, token: cached.token, source: 'cache', reason: null };
+      }
+      if (!rotated.token) {
+        return { ok: true, token: cached.token, source: 'cache', reason: null };
+      }
+      setObservabilityIngestToken(tokenKey, rotated.token);
+      return {
+        ok: true,
+        token: rotated.token,
+        source: 'created',
+        reason: null,
+      };
+    }
   } else {
     deleteObservabilityIngestToken(tokenKey);
     const rotated = await requestIngestToken(config, true);

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -9377,17 +9377,32 @@ export function setObservabilityOffset(
   `).run(normalized, boundedLastEventId);
 }
 
-export function getObservabilityIngestToken(tokenKey: string): string | null {
+export interface ObservabilityIngestTokenRecord {
+  token: string;
+  updatedAt: string;
+}
+
+export function getObservabilityIngestTokenRecord(
+  tokenKey: string,
+): ObservabilityIngestTokenRecord | null {
   const normalized = tokenKey.trim();
   if (!normalized) return null;
-  const row = queryOne<{ token: string }, [string]>(
+  const row = queryOne<{ token: string; updated_at: string }, [string]>(
     db,
-    'SELECT token FROM observability_ingest_tokens WHERE token_key = ?',
+    'SELECT token, updated_at FROM observability_ingest_tokens WHERE token_key = ?',
     normalized,
   );
   if (!row || typeof row.token !== 'string') return null;
   const token = row.token.trim();
-  return token || null;
+  if (!token) return null;
+  return {
+    token,
+    updatedAt: typeof row.updated_at === 'string' ? row.updated_at : '',
+  };
+}
+
+export function getObservabilityIngestToken(tokenKey: string): string | null {
+  return getObservabilityIngestTokenRecord(tokenKey)?.token ?? null;
 }
 
 export function setObservabilityIngestToken(

--- a/tests/observability-ingest.test.ts
+++ b/tests/observability-ingest.test.ts
@@ -16,6 +16,73 @@ const { setupHome } = setupGatewayTest({
   },
 });
 
+const OBSERVABILITY_TOKEN_KEY =
+  'https://hybridai.one/api/v1/agent-observability/ingest-token:ensure|bot-observability';
+
+async function configureObservabilityFixture(): Promise<void> {
+  const { getRuntimeConfig, saveRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  const runtimeConfig = getRuntimeConfig();
+  saveRuntimeConfig({
+    ...runtimeConfig,
+    hybridai: {
+      ...runtimeConfig.hybridai,
+      defaultChatbotId: 'bot-default',
+    },
+    observability: {
+      ...runtimeConfig.observability,
+      enabled: true,
+      botId: 'bot-observability',
+      agentId: 'agent-observability',
+      flushIntervalMs: 60_000,
+      batchMaxEvents: 10,
+    },
+  });
+}
+
+async function seedCachedObservabilityToken(
+  token: string,
+  updatedAt: string,
+): Promise<void> {
+  const { setObservabilityIngestToken, withMemoryDatabase } = await import(
+    '../src/memory/db.ts'
+  );
+  setObservabilityIngestToken(OBSERVABILITY_TOKEN_KEY, token);
+  withMemoryDatabase((database) => {
+    database
+      .prepare(
+        `UPDATE observability_ingest_tokens
+         SET updated_at = ?
+         WHERE token_key = ?`,
+      )
+      .run(updatedAt, OBSERVABILITY_TOKEN_KEY);
+  });
+}
+
+async function recordObservabilityBotSetEvent(
+  sessionId: string,
+  runId: string,
+): Promise<void> {
+  const { recordAuditEvent } = await import('../src/audit/audit-events.ts');
+  recordAuditEvent({
+    sessionId,
+    runId,
+    event: {
+      type: 'bot.set',
+      source: 'command',
+      requestedBot: 'Research Bot',
+      previousBotId: null,
+      resolvedBotId: 'bot-research',
+      changed: true,
+      previousModel: 'gpt-5-nano',
+      syncedModel: 'gpt-4o-mini',
+      userId: 'user-1',
+      username: 'alice',
+    },
+  });
+}
+
 test('observability ingest forwards bot.set audit events to HybridAI', async () => {
   setupHome({ HYBRIDAI_API_KEY: 'test-key' });
 
@@ -140,6 +207,274 @@ test('observability ingest forwards bot.set audit events to HybridAI', async () 
       username: 'alice',
     },
   });
+});
+
+test('observability ingest proactively rotates stale cached tokens', async () => {
+  setupHome({ HYBRIDAI_API_KEY: 'test-key' });
+
+  const { getRuntimeConfig, saveRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  const runtimeConfig = getRuntimeConfig();
+  saveRuntimeConfig({
+    ...runtimeConfig,
+    hybridai: {
+      ...runtimeConfig.hybridai,
+      defaultChatbotId: 'bot-default',
+    },
+    observability: {
+      ...runtimeConfig.observability,
+      enabled: true,
+      botId: 'bot-observability',
+      agentId: 'agent-observability',
+      flushIntervalMs: 60_000,
+      batchMaxEvents: 10,
+    },
+  });
+
+  const fetchMock = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      if (url.endsWith('/api/v1/agent-observability/ingest-token:ensure')) {
+        const bodyText =
+          typeof init?.body === 'string' ? init.body : String(init?.body ?? '');
+        expect(JSON.parse(bodyText)).toMatchObject({
+          bot_id: 'bot-observability',
+          rotate: true,
+        });
+        return new Response(
+          JSON.stringify({
+            success: true,
+            rotated: true,
+            token: 'fresh-ingest-token',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      if (url.endsWith('/api/v1/agent-observability/events:batch')) {
+        expect(init?.headers).toMatchObject({
+          Authorization: 'Bearer fresh-ingest-token',
+        });
+        return new Response(
+          JSON.stringify({
+            status: 'ok',
+            inserted_events: 1,
+            duplicate_events: 0,
+            broken_chain_events: 0,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    },
+  );
+  vi.stubGlobal('fetch', fetchMock);
+
+  const { recordAuditEvent } = await import('../src/audit/audit-events.ts');
+  const { initDatabase, setObservabilityIngestToken, withMemoryDatabase } =
+    await import('../src/memory/db.ts');
+  const { startObservabilityIngest, stopObservabilityIngest } = await import(
+    '../src/audit/observability-ingest.ts'
+  );
+
+  initDatabase({ quiet: true });
+  setObservabilityIngestToken(
+    'https://hybridai.one/api/v1/agent-observability/ingest-token:ensure|bot-observability',
+    'stale-ingest-token',
+  );
+  withMemoryDatabase((database) => {
+    database
+      .prepare(
+        `UPDATE observability_ingest_tokens
+         SET updated_at = '2000-01-01 00:00:00'
+         WHERE token_key = ?`,
+      )
+      .run(
+        'https://hybridai.one/api/v1/agent-observability/ingest-token:ensure|bot-observability',
+      );
+  });
+  recordAuditEvent({
+    sessionId: 'session-observability-stale-token',
+    runId: 'run-observability-stale-token',
+    event: {
+      type: 'bot.set',
+      source: 'command',
+      requestedBot: 'Research Bot',
+      previousBotId: null,
+      resolvedBotId: 'bot-research',
+      changed: true,
+      previousModel: 'gpt-5-nano',
+      syncedModel: 'gpt-4o-mini',
+      userId: 'user-1',
+      username: 'alice',
+    },
+  });
+
+  startObservabilityIngest();
+
+  await vi.waitFor(() => {
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  stopObservabilityIngest();
+
+  expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+    '/api/v1/agent-observability/ingest-token:ensure',
+  );
+  expect(String(fetchMock.mock.calls[1]?.[0])).toContain(
+    '/api/v1/agent-observability/events:batch',
+  );
+});
+
+test('observability ingest treats future cached token timestamps as stale', async () => {
+  setupHome({ HYBRIDAI_API_KEY: 'test-key' });
+  await configureObservabilityFixture();
+
+  const fetchMock = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      if (url.endsWith('/api/v1/agent-observability/ingest-token:ensure')) {
+        const bodyText =
+          typeof init?.body === 'string' ? init.body : String(init?.body ?? '');
+        expect(JSON.parse(bodyText)).toMatchObject({
+          bot_id: 'bot-observability',
+          rotate: true,
+        });
+        return new Response(
+          JSON.stringify({
+            success: true,
+            rotated: true,
+            token: 'fresh-ingest-token',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      if (url.endsWith('/api/v1/agent-observability/events:batch')) {
+        expect(init?.headers).toMatchObject({
+          Authorization: 'Bearer fresh-ingest-token',
+        });
+        return new Response(
+          JSON.stringify({
+            status: 'ok',
+            inserted_events: 1,
+            duplicate_events: 0,
+            broken_chain_events: 0,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    },
+  );
+  vi.stubGlobal('fetch', fetchMock);
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { startObservabilityIngest, stopObservabilityIngest } = await import(
+    '../src/audit/observability-ingest.ts'
+  );
+
+  initDatabase({ quiet: true });
+  await seedCachedObservabilityToken(
+    'future-ingest-token',
+    '2999-01-01 00:00:00',
+  );
+  await recordObservabilityBotSetEvent(
+    'session-observability-future-token',
+    'run-observability-future-token',
+  );
+
+  startObservabilityIngest();
+
+  await vi.waitFor(() => {
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  stopObservabilityIngest();
+
+  expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+    '/api/v1/agent-observability/ingest-token:ensure',
+  );
+  expect(String(fetchMock.mock.calls[1]?.[0])).toContain(
+    '/api/v1/agent-observability/events:batch',
+  );
+});
+
+test('observability ingest falls back to cached token when proactive rotate fails', async () => {
+  setupHome({ HYBRIDAI_API_KEY: 'test-key' });
+  await configureObservabilityFixture();
+
+  const fetchMock = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      if (url.endsWith('/api/v1/agent-observability/ingest-token:ensure')) {
+        return new Response(JSON.stringify({ message: 'temporarily down' }), {
+          status: 503,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/api/v1/agent-observability/events:batch')) {
+        expect(init?.headers).toMatchObject({
+          Authorization: 'Bearer cached-ingest-token',
+        });
+        return new Response(
+          JSON.stringify({
+            status: 'ok',
+            inserted_events: 1,
+            duplicate_events: 0,
+            broken_chain_events: 0,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    },
+  );
+  vi.stubGlobal('fetch', fetchMock);
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { startObservabilityIngest, stopObservabilityIngest } = await import(
+    '../src/audit/observability-ingest.ts'
+  );
+
+  initDatabase({ quiet: true });
+  await seedCachedObservabilityToken(
+    'cached-ingest-token',
+    '2000-01-01 00:00:00',
+  );
+  await recordObservabilityBotSetEvent(
+    'session-observability-rotate-fallback',
+    'run-observability-rotate-fallback',
+  );
+
+  startObservabilityIngest();
+
+  await vi.waitFor(() => {
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  stopObservabilityIngest();
+
+  expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+    '/api/v1/agent-observability/ingest-token:ensure',
+  );
+  expect(String(fetchMock.mock.calls[1]?.[0])).toContain(
+    '/api/v1/agent-observability/events:batch',
+  );
 });
 
 test('observability ingest restart dispatches a new startup flush without waiting for an older push result', async () => {


### PR DESCRIPTION
## Summary

- Add cached observability ingest token metadata reads so the exporter can inspect token age.
- Proactively rotate cached ingest tokens after 20 minutes instead of waiting for the events endpoint to reject them with `403`.
- Parse SQLite `datetime('now')` token timestamps as UTC and add regression coverage for stale-token rotation.

## Root Cause

The observability exporter cached ingest tokens indefinitely. When audit traffic was sparse, such as heartbeat-generated batches every 30 minutes, the first upload reused an expired cached token, hit `403`, rotated, then retried successfully. That made the auth warning appear on every batch even though events eventually uploaded.

## Validation

- `npx vitest run tests/observability-ingest.test.ts`
- `npm run typecheck`
- `npx biome check --write src/audit/observability-ingest.ts src/memory/db.ts tests/observability-ingest.test.ts`