### PR TITLE
[codex] Add Zabbix monitoring skill

### DIFF
--- a/skills/zabbix/SKILL.md
+++ b/skills/zabbix/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: zabbix
+description: "Read Zabbix monitoring state, inspect monitored hosts, summarize current or recent problems, and prepare guarded incident-response context without exposing Zabbix credentials."
+user-invocable: true
+requires:
+  bins:
+    - node
+credentials:
+  - id: ZABBIX_API_TOKEN
+    kind: bearer
+    required: true
+    secret_ref:
+      source: store
+      id: ZABBIX_API_TOKEN
+    scope: "https://<zabbix-frontend>/api_jsonrpc.php Authorization bearer"
+    how_to_obtain: |
+      Create a Zabbix API token in the Zabbix frontend and store it with
+      `hybridclaw secret set ZABBIX_API_TOKEN "<token>"`.
+metadata:
+  hybridclaw:
+    category: production-ops
+    short_description: "Zabbix monitoring reads for incident triage."
+    tags:
+      - zabbix
+      - monitoring
+      - incident-response
+      - production
+      - r21
+    related_roadmap:
+      - R21
+      - R32
+      - R33
+    issue: 1045
+    stakes_tiers:
+      green:
+        - api-version
+        - host-inventory
+        - problem-read
+        - trigger-problem-read
+        - incident-summary
+      amber:
+        - event-acknowledge
+        - event-suppress
+      red:
+        - event-close
+    escalation:
+      writes: confirm-each
+      route: f14
+    cost_measurement:
+      system: UsageTotals
+      sub_limit_key: zabbix
+---
+
+# Zabbix
+
+Use this skill for Zabbix production monitoring reads: API health checks,
+monitored host inventory, current or recent problems, problem-state triggers by
+severity, and concise incident summaries that can feed R29 cards. Zabbix tells
+us what is broken; local or SSH maintenance skills investigate and remediate on
+the affected host.
+
+This v1 skill is read-only. Do not acknowledge, suppress, close, update, or
+delete Zabbix objects through this skill. If a later task adds write operations,
+each write must be amber/red, require an exact operator grant through F8/F14,
+and include the Zabbix event id and action in the approval text.
+
+## Credential Rules
+
+Store the API token in HybridClaw encrypted runtime secrets:
+
+```bash
+hybridclaw secret set ZABBIX_API_TOKEN "<zabbix-api-token>"
+```
+
+For live calls, run the helper to build a gateway `http_request` payload and
+pass only the emitted `httpRequest` object to the built-in `http_request` tool.
+The helper sets `bearerSecretName: "ZABBIX_API_TOKEN"` for authenticated
+Zabbix methods so the gateway injects the bearer token server-side. It never
+prints `Authorization` headers, token values, usernames, passwords, or Zabbix
+session tokens.
+
+When a terminal-side live smoke test is needed, use the helper's `run` mode.
+It posts the same `httpRequest` object to the HybridClaw gateway
+`/api/http/request` route and stops after the first Zabbix 401/403 response.
+Set `HYBRIDCLAW_GATEWAY_URL` and `HYBRIDCLAW_GATEWAY_TOKEN` only for gateway
+access; do not store those as Zabbix credentials.
+
+Do not call Zabbix with `curl` when the gateway `http_request` tool is
+available. Do not ask the user to paste a Zabbix API token, username/password,
+or session token into chat.
+
+If the operator has a tenant-specific frontend path, pass it with `--base-url`
+or set `ZABBIX_BASE_URL` in the runtime environment. The helper accepts both
+`https://zabbix.example.com/zabbix` and
+`https://zabbix.example.com/zabbix/api_jsonrpc.php` and normalizes both to the
+JSON-RPC endpoint.
+
+## Command Contract
+
+Show helper usage:
+
+```bash
+node skills/zabbix/zabbix.cjs --help
+```
+
+Build an unauthenticated API smoke-test request:
+
+```bash
+node skills/zabbix/zabbix.cjs --format json http-request api-version \
+  --base-url https://zabbix.example.com/zabbix
+```
+
+List monitored hosts and interfaces:
+
+```bash
+node skills/zabbix/zabbix.cjs --format json http-request hosts \
+  --base-url https://zabbix.example.com/zabbix \
+  --monitored-only
+```
+
+Read current or recent problems:
+
+```bash
+node skills/zabbix/zabbix.cjs --format json http-request problems \
+  --base-url https://zabbix.example.com/zabbix \
+  --recent \
+  --limit 50
+```
+
+Read triggers in problem state:
+
+```bash
+node skills/zabbix/zabbix.cjs --format json http-request triggers-problem \
+  --base-url https://zabbix.example.com/zabbix \
+  --limit 50
+```
+
+Run one live gateway-proxied request, with no retry loop:
+
+```bash
+node skills/zabbix/zabbix.cjs --format json run problems \
+  --base-url https://zabbix.example.com/zabbix \
+  --recent \
+  --limit 50
+```
+
+The helper prints a wrapper such as
+`{ "command": "http-request", "httpRequest": { ... } }`. Pass only the
+`httpRequest` value to the built-in `http_request` tool.
+
+Official API references:
+[Zabbix API overview](https://www.zabbix.com/documentation/current/en/manual/api),
+[`host.get`](https://www.zabbix.com/documentation/current/en/manual/api/reference/host/get),
+[`problem.get`](https://www.zabbix.com/documentation/current/en/manual/api/reference/problem/get),
+and
+[`trigger.get`](https://www.zabbix.com/documentation/current/en/manual/api/reference/trigger/get).
+
+## Filters
+
+Use IDs when filtering by host or host group because Zabbix JSON-RPC read
+methods filter most reliably on `hostids` and `groupids`:
+
+```bash
+node skills/zabbix/zabbix.cjs --format json http-request problems \
+  --base-url https://zabbix.example.com/zabbix \
+  --host-id 10084 \
+  --group-id 2 \
+  --severity high \
+  --unacknowledged \
+  --unsuppressed \
+  --tag service=postgres \
+  --time-from 1767225600 \
+  --limit 25
+```
+
+Supported read filters:
+
+- `--host-id <id>` / `--host <id>` and `--group-id <id>` /
+  `--host-group <id>` can be repeated.
+- `--tag <name>` or `--tag <name=value>` can be repeated.
+- `--severity <0-5|name>` can be repeated or comma-separated.
+- `--acknowledged` or `--unacknowledged` for problem reads.
+- `--suppressed` or `--unsuppressed` for problem reads.
+- `--time-from <unix-seconds>` and `--time-till <unix-seconds>` for problem reads.
+- `--recent` includes recently resolved problems; omit it for unresolved current problems.
+
+Severity names are `not-classified`, `information`, `warning`, `average`,
+`high`, and `disaster`.
+
+## Error Interpretation
+
+- Gateway errors saying `ZABBIX_API_TOKEN` is not set, unavailable, missing, or
+  unresolved mean the active HybridClaw runtime cannot resolve the stored
+  secret. Ask the operator to set it in the same runtime/session and retry once
+  after the runtime can see the secret.
+- Gateway errors saying `ZABBIX_API_TOKEN` is blocked by secret resolution
+  policy mean the stored secret exists but policy/runtime access blocked the
+  injection path. Report the policy problem instead of asking for the same
+  secret again.
+- Zabbix 401 or 403 responses mean the gateway injected a token but Zabbix
+  rejected it or the token lacks permission. Stop after that first failed live
+  call and report a credential/setup problem; do not retry in a loop.
+- Zabbix JSON-RPC `error` responses should be reported with the method, code,
+  message, and data. Do not transform them into local remediation steps unless
+  the user asks.
+- Network, timeout, 429, or 5xx responses are upstream or connectivity
+  failures. Report the response and retry only when the user asks.
+
+## Incident Summary Guidance
+
+When summarizing Zabbix state, preserve the event id, host, trigger/problem
+name, severity, acknowledged/suppressed state, age, tags, and any maintenance
+or acknowledgement context. Keep remediation separate from observation unless
+another approved maintenance skill has verified the host state.

--- a/skills/zabbix/SKILL.md
+++ b/skills/zabbix/SKILL.md
@@ -79,8 +79,8 @@ Zabbix methods so the gateway injects the bearer token server-side. It never
 prints `Authorization` headers, token values, usernames, passwords, or Zabbix
 session tokens.
 
-When a terminal-side live smoke test is needed, use the helper's `run` mode.
-It posts the same `httpRequest` object to the HybridClaw gateway
+When a terminal-side live smoke test is needed, pass `--live` to the same
+`http-request` command. It posts the same `httpRequest` object to the HybridClaw gateway
 `/api/http/request` route and stops after the first Zabbix 401/403 response.
 Set `HYBRIDCLAW_GATEWAY_URL` and `HYBRIDCLAW_GATEWAY_TOKEN` only for gateway
 access; do not store those as Zabbix credentials.
@@ -93,7 +93,9 @@ If the operator has a tenant-specific frontend path, pass it with `--base-url`
 or set `ZABBIX_BASE_URL` in the runtime environment. The helper accepts both
 `https://zabbix.example.com/zabbix` and
 `https://zabbix.example.com/zabbix/api_jsonrpc.php` and normalizes both to the
-JSON-RPC endpoint.
+JSON-RPC endpoint. HTTPS is required by default. Use `--allow-http` only for a
+trusted local or private Zabbix frontend where plaintext HTTP is an intentional
+operator choice.
 
 ## Command Contract
 
@@ -138,7 +140,7 @@ node skills/zabbix/zabbix.cjs --format json http-request triggers-problem \
 Run one live gateway-proxied request, with no retry loop:
 
 ```bash
-node skills/zabbix/zabbix.cjs --format json run problems \
+node skills/zabbix/zabbix.cjs --live --format json http-request problems \
   --base-url https://zabbix.example.com/zabbix \
   --recent \
   --limit 50

--- a/skills/zabbix/zabbix.cjs
+++ b/skills/zabbix/zabbix.cjs
@@ -1,13 +1,20 @@
 #!/usr/bin/env node
 'use strict';
 
-const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_GATEWAY_URL = 'http://127.0.0.1:9090';
-const GATEWAY_TIMEOUT_BUFFER_MS = 5_000;
+const GATEWAY_TIMEOUT_BUFFER_MS = 1_000;
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 100;
 const SKILL_NAME = 'zabbix';
 const SECRET_NAME = 'ZABBIX_API_TOKEN';
+
+const RPC_IDS = {
+  apiVersion: 1,
+  hosts: 2,
+  problems: 3,
+  triggersProblem: 4,
+};
 
 const SECRET_FLAGS = new Set([
   '--api-token',
@@ -42,13 +49,23 @@ const SEVERITIES = new Map([
   ['disaster', 5],
 ]);
 
+const PROBLEM_ONLY_FLAGS = new Set([
+  '--acknowledged',
+  '--unacknowledged',
+  '--suppressed',
+  '--unsuppressed',
+  '--time-from',
+  '--time-till',
+]);
+
 function fail(message, code = 2) {
   process.stderr.write(`${message}\n`);
   process.exit(code);
 }
 
-function printJson(payload) {
-  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+function printJson(payload, format = 'pretty') {
+  const indent = format === 'pretty' ? 2 : undefined;
+  process.stdout.write(`${JSON.stringify(payload, null, indent)}\n`);
 }
 
 function usage() {
@@ -59,12 +76,14 @@ Usage:
   node skills/zabbix/zabbix.cjs --format json http-request hosts --base-url https://zabbix.example.com/zabbix --monitored-only
   node skills/zabbix/zabbix.cjs --format json http-request problems --base-url https://zabbix.example.com/zabbix --recent --limit 50
   node skills/zabbix/zabbix.cjs --format json http-request triggers-problem --base-url https://zabbix.example.com/zabbix --limit 50
-  node skills/zabbix/zabbix.cjs --format json run problems --base-url https://zabbix.example.com/zabbix --recent --limit 50
+  node skills/zabbix/zabbix.cjs --live --format json http-request problems --base-url https://zabbix.example.com/zabbix --recent --limit 50
 
 Global options:
-  --format json|pretty        Output format. Defaults to pretty.
+  --format json|pretty        json emits compact output; pretty emits indented output. Defaults to pretty.
   --base-url URL              Zabbix frontend URL or api_jsonrpc.php endpoint.
                               Can also be set with ZABBIX_BASE_URL.
+  --live                      Send one live request through the HybridClaw gateway.
+  --allow-http                Allow an http:// Zabbix base URL. HTTPS is required by default.
   --help                      Show this help.
 
 Filters:
@@ -84,7 +103,7 @@ Filters:
 Secret values are not accepted on the command line. Store the token with:
   hybridclaw secret set ZABBIX_API_TOKEN "<token>"
 
-Live run mode uses HYBRIDCLAW_GATEWAY_URL and HYBRIDCLAW_GATEWAY_TOKEN when set.`;
+Live mode uses HYBRIDCLAW_GATEWAY_URL and HYBRIDCLAW_GATEWAY_TOKEN when set.`;
 }
 
 class ZabbixError extends Error {
@@ -102,17 +121,12 @@ class ZabbixCredentialError extends ZabbixError {
   }
 }
 
-class ZabbixConfigError extends ZabbixError {
-  constructor(message, details = {}) {
-    super(message, details);
-    this.name = 'ZabbixConfigError';
-  }
-}
-
 function parseArgs(argv) {
   const opts = {
+    allowHttp: false,
     format: 'pretty',
     help: false,
+    live: false,
   };
   const positional = [];
 
@@ -122,6 +136,14 @@ function parseArgs(argv) {
       opts.help = true;
       continue;
     }
+    if (arg === '--live') {
+      opts.live = true;
+      continue;
+    }
+    if (arg === '--allow-http') {
+      opts.allowHttp = true;
+      continue;
+    }
     if (SECRET_FLAGS.has(arg)) {
       fail(
         `${arg} is not supported. Store Zabbix credentials in ${SECRET_NAME}.`,
@@ -129,8 +151,11 @@ function parseArgs(argv) {
     }
     if (arg === '--format' || arg === '--base-url') {
       const value = argv[index + 1];
-      if (value === undefined || value.startsWith('--')) {
+      if (value === undefined || value.startsWith('--') || !value.trim()) {
         fail(`${arg} requires a value.`);
+      }
+      if (arg === '--format' && !['json', 'pretty'].includes(value)) {
+        fail('--format must be json or pretty.');
       }
       opts[arg.slice(2).replace(/-([a-z])/g, (_, c) => c.toUpperCase())] =
         value;
@@ -143,44 +168,7 @@ function parseArgs(argv) {
   return { opts, positional };
 }
 
-function popFlag(args, name, fallback = undefined) {
-  const index = args.indexOf(name);
-  if (index === -1) {
-    return fallback;
-  }
-  const value = args[index + 1];
-  if (value === undefined || value.startsWith('--')) {
-    fail(`${name} requires a value.`);
-  }
-  args.splice(index, 2);
-  return value;
-}
-
-function popRepeatedFlag(args, name) {
-  const values = [];
-  let index = args.indexOf(name);
-  while (index !== -1) {
-    const value = args[index + 1];
-    if (value === undefined || value.startsWith('--')) {
-      fail(`${name} requires a value.`);
-    }
-    values.push(value);
-    args.splice(index, 2);
-    index = args.indexOf(name);
-  }
-  return values;
-}
-
-function popBoolean(args, name) {
-  const index = args.indexOf(name);
-  if (index === -1) {
-    return false;
-  }
-  args.splice(index, 1);
-  return true;
-}
-
-function normalizeEndpoint(rawUrl) {
+function normalizeEndpoint(rawUrl, { allowHttp = false } = {}) {
   const text = String(rawUrl || '').trim();
   if (!text) {
     fail('--base-url is required or ZABBIX_BASE_URL must be set.');
@@ -193,8 +181,13 @@ function normalizeEndpoint(rawUrl) {
     fail('--base-url must be a valid URL.');
   }
 
-  if (!['http:', 'https:'].includes(url.protocol)) {
-    fail('--base-url must use http or https.');
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    fail('--base-url must use https.');
+  }
+  if (url.protocol === 'http:' && !allowHttp) {
+    fail(
+      '--base-url must use https. Pass --allow-http only for trusted local or private Zabbix frontends.',
+    );
   }
   if (url.username || url.password) {
     fail('--base-url must not include credentials.');
@@ -227,16 +220,20 @@ function parseInteger(raw, label, min, max) {
 
 function parseIdList(values) {
   return values.flatMap((value) =>
-    String(value)
+    normalizeText(value)
       .split(',')
       .map((part) => part.trim())
       .filter(Boolean),
   );
 }
 
+function normalizeText(value) {
+  return String(value).trim();
+}
+
 function parseTags(values) {
   return values.map((value) => {
-    const text = String(value).trim();
+    const text = normalizeText(value);
     if (!text) {
       fail('--tag cannot be empty.');
     }
@@ -256,7 +253,7 @@ function parseTags(values) {
 function parseSeverities(values) {
   const severities = [];
   for (const value of values) {
-    for (const part of String(value).split(',')) {
+    for (const part of normalizeText(value).split(',')) {
       const key = part.trim().toLowerCase();
       if (!key) {
         continue;
@@ -280,37 +277,68 @@ function parseUnixSeconds(raw, label) {
   return parseInteger(raw, label, 0, 4_102_444_800);
 }
 
-function ensureNoUnknownArgs(args) {
-  if (args.length > 0) {
-    fail(`Unknown option or argument: ${args[0]}`);
+function parseCommandOptions(args, spec = {}) {
+  const booleans = new Set(spec.booleans || []);
+  const values = new Set(spec.values || []);
+  const repeated = new Set(spec.repeated || []);
+  const result = {
+    booleans: {},
+    values: {},
+    repeated: {},
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!spec.allowProblemFilters && PROBLEM_ONLY_FLAGS.has(arg)) {
+      fail(`${arg} is only valid for the problems command.`);
+    }
+    if (booleans.has(arg)) {
+      result.booleans[arg] = true;
+      continue;
+    }
+    if (values.has(arg) || repeated.has(arg)) {
+      const value = args[index + 1];
+      if (value === undefined || value.startsWith('--') || !value.trim()) {
+        fail(`${arg} requires a value.`);
+      }
+      if (repeated.has(arg)) {
+        result.repeated[arg] ||= [];
+        result.repeated[arg].push(value);
+      } else {
+        result.values[arg] = value;
+      }
+      index += 1;
+      continue;
+    }
+    fail(`Unknown option or argument: ${arg}`);
   }
+
+  return result;
 }
 
-function addSharedFilters(params, args, { allowProblemFilters = false } = {}) {
+function addSharedFilters(params, options) {
   const hostIds = parseIdList([
-    ...popRepeatedFlag(args, '--host-id'),
-    ...popRepeatedFlag(args, '--host'),
+    ...(options.repeated['--host-id'] || []),
+    ...(options.repeated['--host'] || []),
   ]);
   const groupIds = parseIdList([
-    ...popRepeatedFlag(args, '--group-id'),
-    ...popRepeatedFlag(args, '--host-group'),
+    ...(options.repeated['--group-id'] || []),
+    ...(options.repeated['--host-group'] || []),
   ]);
-  const tags = parseTags(popRepeatedFlag(args, '--tag'));
-  const severities = parseSeverities(popRepeatedFlag(args, '--severity'));
+  const tags = parseTags(options.repeated['--tag'] || []);
+  const severities = parseSeverities(options.repeated['--severity'] || []);
 
   if (hostIds.length > 0) params.hostids = hostIds;
   if (groupIds.length > 0) params.groupids = groupIds;
   if (tags.length > 0) params.tags = tags;
   if (severities.length > 0) params.severities = severities;
+}
 
-  if (!allowProblemFilters) {
-    return;
-  }
-
-  const acknowledged = popBoolean(args, '--acknowledged');
-  const unacknowledged = popBoolean(args, '--unacknowledged');
-  const suppressed = popBoolean(args, '--suppressed');
-  const unsuppressed = popBoolean(args, '--unsuppressed');
+function addProblemFilters(params, options) {
+  const acknowledged = options.booleans['--acknowledged'] === true;
+  const unacknowledged = options.booleans['--unacknowledged'] === true;
+  const suppressed = options.booleans['--suppressed'] === true;
+  const unsuppressed = options.booleans['--unsuppressed'] === true;
   if (acknowledged && unacknowledged) {
     fail('Use only one of --acknowledged or --unacknowledged.');
   }
@@ -323,15 +351,38 @@ function addSharedFilters(params, args, { allowProblemFilters = false } = {}) {
   if (unsuppressed) params.suppressed = false;
 
   const timeFrom = parseUnixSeconds(
-    popFlag(args, '--time-from'),
+    options.values['--time-from'],
     '--time-from',
   );
   const timeTill = parseUnixSeconds(
-    popFlag(args, '--time-till'),
+    options.values['--time-till'],
     '--time-till',
   );
   if (timeFrom !== undefined) params.time_from = timeFrom;
   if (timeTill !== undefined) params.time_till = timeTill;
+}
+
+function parseReadOptions(args, extra = {}) {
+  return parseCommandOptions(args, {
+    allowProblemFilters: extra.allowProblemFilters === true,
+    booleans: [
+      ...(extra.booleans || []),
+      '--acknowledged',
+      '--unacknowledged',
+      '--suppressed',
+      '--unsuppressed',
+    ],
+    values: [...(extra.values || []), '--time-from', '--time-till'],
+    repeated: [
+      '--host-id',
+      '--host',
+      '--group-id',
+      '--host-group',
+      '--tag',
+      '--severity',
+      ...(extra.repeated || []),
+    ],
+  });
 }
 
 function buildRpc(method, params, id) {
@@ -367,7 +418,6 @@ function buildHttpRequest({
   }
   return {
     command: 'http-request',
-    operation: rpcMethod,
     httpRequest,
     costMeasurement: {
       system: 'UsageTotals',
@@ -381,37 +431,44 @@ function buildApiVersion(endpoint) {
     endpoint,
     rpcMethod: 'apiinfo.version',
     params: {},
-    id: 1,
+    id: RPC_IDS.apiVersion,
     auth: false,
     maxResponseBytes: 200_000,
   });
 }
 
 function buildHosts(endpoint, args) {
+  const options = parseReadOptions(args, {
+    booleans: ['--monitored-only'],
+  });
   const params = {
     output: ['hostid', 'host', 'name', 'status', 'maintenance_status'],
     selectInterfaces: ['interfaceid', 'ip', 'dns', 'type', 'main', 'useip'],
     selectTags: ['tag', 'value'],
     sortfield: 'name',
   };
-  if (popBoolean(args, '--monitored-only')) {
+  if (options.booleans['--monitored-only']) {
     params.monitored_hosts = true;
   }
-  addSharedFilters(params, args);
-  ensureNoUnknownArgs(args);
+  addSharedFilters(params, options);
   return buildHttpRequest({
     endpoint,
     rpcMethod: 'host.get',
     params,
-    id: 2,
+    id: RPC_IDS.hosts,
     auth: true,
     maxResponseBytes: 2_000_000,
   });
 }
 
 function buildProblems(endpoint, args) {
+  const options = parseReadOptions(args, {
+    allowProblemFilters: true,
+    booleans: ['--recent'],
+    values: ['--limit'],
+  });
   const limit = parseInteger(
-    popFlag(args, '--limit', String(DEFAULT_LIMIT)),
+    options.values['--limit'] || String(DEFAULT_LIMIT),
     '--limit',
     1,
     MAX_LIMIT,
@@ -425,24 +482,27 @@ function buildProblems(endpoint, args) {
     sortorder: 'DESC',
     limit,
   };
-  if (popBoolean(args, '--recent')) {
+  if (options.booleans['--recent']) {
     params.recent = true;
   }
-  addSharedFilters(params, args, { allowProblemFilters: true });
-  ensureNoUnknownArgs(args);
+  addSharedFilters(params, options);
+  addProblemFilters(params, options);
   return buildHttpRequest({
     endpoint,
     rpcMethod: 'problem.get',
     params,
-    id: 3,
+    id: RPC_IDS.problems,
     auth: true,
     maxResponseBytes: 4_000_000,
   });
 }
 
 function buildTriggersProblem(endpoint, args) {
+  const options = parseReadOptions(args, {
+    values: ['--limit'],
+  });
   const limit = parseInteger(
-    popFlag(args, '--limit', String(DEFAULT_LIMIT)),
+    options.values['--limit'] || String(DEFAULT_LIMIT),
     '--limit',
     1,
     MAX_LIMIT,
@@ -458,13 +518,12 @@ function buildTriggersProblem(endpoint, args) {
     sortorder: 'DESC',
     limit,
   };
-  addSharedFilters(params, args);
-  ensureNoUnknownArgs(args);
+  addSharedFilters(params, options);
   return buildHttpRequest({
     endpoint,
     rpcMethod: 'trigger.get',
     params,
-    id: 4,
+    id: RPC_IDS.triggersProblem,
     auth: true,
     maxResponseBytes: 4_000_000,
   });
@@ -475,21 +534,19 @@ function buildRequest(argv = process.argv.slice(2)) {
   if (opts.help) {
     return { help: true };
   }
-  if (!['json', 'pretty'].includes(opts.format)) {
-    fail('--format must be json or pretty.');
-  }
   const mode = positional.shift();
   const command = positional.shift();
-  if (!['http-request', 'run'].includes(mode)) {
-    fail('Expected command mode: http-request or run.');
+  if (mode !== 'http-request') {
+    fail('Expected command mode: http-request.');
   }
   const endpoint = normalizeEndpoint(
     opts.baseUrl || process.env.ZABBIX_BASE_URL,
+    { allowHttp: opts.allowHttp },
   );
 
   let request;
   if (command === 'api-version') {
-    ensureNoUnknownArgs(positional);
+    parseCommandOptions(positional);
     request = buildApiVersion(endpoint);
   } else if (command === 'hosts') {
     request = buildHosts(endpoint, positional);
@@ -501,9 +558,10 @@ function buildRequest(argv = process.argv.slice(2)) {
     fail(`Unsupported Zabbix operation: ${command || '(missing)'}`);
   }
 
-  if (mode === 'run') {
-    request.command = 'run';
+  if (opts.live) {
+    request.command = 'live';
   }
+  request.format = opts.format;
   return request;
 }
 
@@ -515,12 +573,7 @@ function resolveGatewayUrl() {
 }
 
 function resolveGatewayToken() {
-  return String(
-    process.env.HYBRIDCLAW_GATEWAY_TOKEN ||
-      process.env.GATEWAY_API_TOKEN ||
-      process.env.WEB_API_TOKEN ||
-      '',
-  ).trim();
+  return String(process.env.HYBRIDCLAW_GATEWAY_TOKEN || '').trim();
 }
 
 function parseJsonMaybe(text) {
@@ -529,17 +582,6 @@ function parseJsonMaybe(text) {
   } catch {
     return null;
   }
-}
-
-function responseHeadersToObject(headers) {
-  if (!headers || typeof headers.forEach !== 'function') {
-    return {};
-  }
-  const result = {};
-  headers.forEach((value, key) => {
-    result[key] = value;
-  });
-  return result;
 }
 
 function normalizeGatewayResult(wrapper, fallbackStatus) {
@@ -571,7 +613,7 @@ async function executeZabbixGatewayRequest(httpRequest, options = {}) {
   const gatewayToken = options.gatewayToken || resolveGatewayToken();
   const fetchImpl = options.fetch || globalThis.fetch;
   if (typeof fetchImpl !== 'function') {
-    throw new ZabbixConfigError('fetch is not available for Zabbix requests.');
+    throw new ZabbixError('fetch is not available for Zabbix requests.');
   }
 
   const headers = { 'Content-Type': 'application/json' };
@@ -609,7 +651,7 @@ async function executeZabbixGatewayRequest(httpRequest, options = {}) {
     return {
       ok: true,
       status: response.status,
-      headers: responseHeadersToObject(response.headers),
+      headers: {},
       body: text,
       bodyJson: null,
     };
@@ -654,9 +696,11 @@ async function main() {
     process.stdout.write(`${usage()}\n`);
     return;
   }
-  if (result.command === 'run') {
+  const format = result.format || 'pretty';
+  delete result.format;
+  if (result.command === 'live') {
     try {
-      printJson(await executeZabbixGatewayRequest(result.httpRequest));
+      printJson(await executeZabbixGatewayRequest(result.httpRequest), format);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       process.stderr.write(`${message}\n`);
@@ -664,7 +708,7 @@ async function main() {
     }
     return;
   }
-  printJson(result);
+  printJson(result, format);
 }
 
 if (require.main === module) {
@@ -677,7 +721,6 @@ if (require.main === module) {
 }
 
 module.exports = {
-  ZabbixConfigError,
   ZabbixCredentialError,
   ZabbixError,
   buildRequest,

--- a/skills/zabbix/zabbix.cjs
+++ b/skills/zabbix/zabbix.cjs
@@ -1,0 +1,686 @@
+#!/usr/bin/env node
+'use strict';
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_GATEWAY_URL = 'http://127.0.0.1:9090';
+const GATEWAY_TIMEOUT_BUFFER_MS = 5_000;
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+const SKILL_NAME = 'zabbix';
+const SECRET_NAME = 'ZABBIX_API_TOKEN';
+
+const SECRET_FLAGS = new Set([
+  '--api-token',
+  '--auth-token',
+  '--authorization',
+  '--authorization-header',
+  '--bearer',
+  '--password',
+  '--session',
+  '--session-token',
+  '--token',
+  '--user',
+  '--username',
+]);
+
+const SEVERITIES = new Map([
+  ['0', 0],
+  ['not-classified', 0],
+  ['not_classified', 0],
+  ['notclassified', 0],
+  ['1', 1],
+  ['information', 1],
+  ['info', 1],
+  ['2', 2],
+  ['warning', 2],
+  ['warn', 2],
+  ['3', 3],
+  ['average', 3],
+  ['4', 4],
+  ['high', 4],
+  ['5', 5],
+  ['disaster', 5],
+]);
+
+function fail(message, code = 2) {
+  process.stderr.write(`${message}\n`);
+  process.exit(code);
+}
+
+function printJson(payload) {
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function usage() {
+  return `Zabbix skill helper
+
+Usage:
+  node skills/zabbix/zabbix.cjs --format json http-request api-version --base-url https://zabbix.example.com/zabbix
+  node skills/zabbix/zabbix.cjs --format json http-request hosts --base-url https://zabbix.example.com/zabbix --monitored-only
+  node skills/zabbix/zabbix.cjs --format json http-request problems --base-url https://zabbix.example.com/zabbix --recent --limit 50
+  node skills/zabbix/zabbix.cjs --format json http-request triggers-problem --base-url https://zabbix.example.com/zabbix --limit 50
+  node skills/zabbix/zabbix.cjs --format json run problems --base-url https://zabbix.example.com/zabbix --recent --limit 50
+
+Global options:
+  --format json|pretty        Output format. Defaults to pretty.
+  --base-url URL              Zabbix frontend URL or api_jsonrpc.php endpoint.
+                              Can also be set with ZABBIX_BASE_URL.
+  --help                      Show this help.
+
+Filters:
+  --host-id ID                Filter by Zabbix host id. Repeatable.
+  --host ID                   Alias for --host-id.
+  --group-id ID               Filter by Zabbix host group id. Repeatable.
+  --host-group ID             Alias for --group-id.
+  --tag TAG[=VALUE]           Filter by Zabbix tag. Repeatable.
+  --severity 0-5|name         Filter by severity. Repeatable or comma-separated.
+  --acknowledged              Only acknowledged problems.
+  --unacknowledged            Only unacknowledged problems.
+  --suppressed                Only suppressed problems.
+  --unsuppressed              Only unsuppressed problems.
+  --time-from UNIX_SECONDS    Lower problem event timestamp.
+  --time-till UNIX_SECONDS    Upper problem event timestamp.
+
+Secret values are not accepted on the command line. Store the token with:
+  hybridclaw secret set ZABBIX_API_TOKEN "<token>"
+
+Live run mode uses HYBRIDCLAW_GATEWAY_URL and HYBRIDCLAW_GATEWAY_TOKEN when set.`;
+}
+
+class ZabbixError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = 'ZabbixError';
+    this.details = details;
+  }
+}
+
+class ZabbixCredentialError extends ZabbixError {
+  constructor(message, details = {}) {
+    super(message, details);
+    this.name = 'ZabbixCredentialError';
+  }
+}
+
+class ZabbixConfigError extends ZabbixError {
+  constructor(message, details = {}) {
+    super(message, details);
+    this.name = 'ZabbixConfigError';
+  }
+}
+
+function parseArgs(argv) {
+  const opts = {
+    format: 'pretty',
+    help: false,
+  };
+  const positional = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--help' || arg === '-h') {
+      opts.help = true;
+      continue;
+    }
+    if (SECRET_FLAGS.has(arg)) {
+      fail(
+        `${arg} is not supported. Store Zabbix credentials in ${SECRET_NAME}.`,
+      );
+    }
+    if (arg === '--format' || arg === '--base-url') {
+      const value = argv[index + 1];
+      if (value === undefined || value.startsWith('--')) {
+        fail(`${arg} requires a value.`);
+      }
+      opts[arg.slice(2).replace(/-([a-z])/g, (_, c) => c.toUpperCase())] =
+        value;
+      index += 1;
+      continue;
+    }
+    positional.push(arg);
+  }
+
+  return { opts, positional };
+}
+
+function popFlag(args, name, fallback = undefined) {
+  const index = args.indexOf(name);
+  if (index === -1) {
+    return fallback;
+  }
+  const value = args[index + 1];
+  if (value === undefined || value.startsWith('--')) {
+    fail(`${name} requires a value.`);
+  }
+  args.splice(index, 2);
+  return value;
+}
+
+function popRepeatedFlag(args, name) {
+  const values = [];
+  let index = args.indexOf(name);
+  while (index !== -1) {
+    const value = args[index + 1];
+    if (value === undefined || value.startsWith('--')) {
+      fail(`${name} requires a value.`);
+    }
+    values.push(value);
+    args.splice(index, 2);
+    index = args.indexOf(name);
+  }
+  return values;
+}
+
+function popBoolean(args, name) {
+  const index = args.indexOf(name);
+  if (index === -1) {
+    return false;
+  }
+  args.splice(index, 1);
+  return true;
+}
+
+function normalizeEndpoint(rawUrl) {
+  const text = String(rawUrl || '').trim();
+  if (!text) {
+    fail('--base-url is required or ZABBIX_BASE_URL must be set.');
+  }
+
+  let url;
+  try {
+    url = new URL(text);
+  } catch {
+    fail('--base-url must be a valid URL.');
+  }
+
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    fail('--base-url must use http or https.');
+  }
+  if (url.username || url.password) {
+    fail('--base-url must not include credentials.');
+  }
+  if (url.search || url.hash) {
+    fail('--base-url must not include a query string or fragment.');
+  }
+
+  let pathname = url.pathname.replace(/\/+$/, '');
+  if (!pathname.endsWith('/api_jsonrpc.php')) {
+    pathname = `${pathname}/api_jsonrpc.php`;
+  }
+  if (!pathname.startsWith('/')) {
+    pathname = `/${pathname}`;
+  }
+  url.pathname = pathname.replace(/\/{2,}/g, '/');
+  return url.toString();
+}
+
+function parseInteger(raw, label, min, max) {
+  if (!/^\d+$/.test(String(raw))) {
+    fail(`${label} must be an integer between ${min} and ${max}.`);
+  }
+  const value = Number.parseInt(raw, 10);
+  if (value < min || value > max) {
+    fail(`${label} must be between ${min} and ${max}.`);
+  }
+  return value;
+}
+
+function parseIdList(values) {
+  return values.flatMap((value) =>
+    String(value)
+      .split(',')
+      .map((part) => part.trim())
+      .filter(Boolean),
+  );
+}
+
+function parseTags(values) {
+  return values.map((value) => {
+    const text = String(value).trim();
+    if (!text) {
+      fail('--tag cannot be empty.');
+    }
+    const equalsIndex = text.indexOf('=');
+    if (equalsIndex === -1) {
+      return { tag: text };
+    }
+    const tag = text.slice(0, equalsIndex).trim();
+    const tagValue = text.slice(equalsIndex + 1).trim();
+    if (!tag) {
+      fail('--tag name cannot be empty.');
+    }
+    return { tag, value: tagValue };
+  });
+}
+
+function parseSeverities(values) {
+  const severities = [];
+  for (const value of values) {
+    for (const part of String(value).split(',')) {
+      const key = part.trim().toLowerCase();
+      if (!key) {
+        continue;
+      }
+      const severity = SEVERITIES.get(key);
+      if (severity === undefined) {
+        fail(
+          '--severity must be one of 0-5, not-classified, information, warning, average, high, or disaster.',
+        );
+      }
+      severities.push(severity);
+    }
+  }
+  return [...new Set(severities)];
+}
+
+function parseUnixSeconds(raw, label) {
+  if (raw === undefined) {
+    return undefined;
+  }
+  return parseInteger(raw, label, 0, 4_102_444_800);
+}
+
+function ensureNoUnknownArgs(args) {
+  if (args.length > 0) {
+    fail(`Unknown option or argument: ${args[0]}`);
+  }
+}
+
+function addSharedFilters(params, args, { allowProblemFilters = false } = {}) {
+  const hostIds = parseIdList([
+    ...popRepeatedFlag(args, '--host-id'),
+    ...popRepeatedFlag(args, '--host'),
+  ]);
+  const groupIds = parseIdList([
+    ...popRepeatedFlag(args, '--group-id'),
+    ...popRepeatedFlag(args, '--host-group'),
+  ]);
+  const tags = parseTags(popRepeatedFlag(args, '--tag'));
+  const severities = parseSeverities(popRepeatedFlag(args, '--severity'));
+
+  if (hostIds.length > 0) params.hostids = hostIds;
+  if (groupIds.length > 0) params.groupids = groupIds;
+  if (tags.length > 0) params.tags = tags;
+  if (severities.length > 0) params.severities = severities;
+
+  if (!allowProblemFilters) {
+    return;
+  }
+
+  const acknowledged = popBoolean(args, '--acknowledged');
+  const unacknowledged = popBoolean(args, '--unacknowledged');
+  const suppressed = popBoolean(args, '--suppressed');
+  const unsuppressed = popBoolean(args, '--unsuppressed');
+  if (acknowledged && unacknowledged) {
+    fail('Use only one of --acknowledged or --unacknowledged.');
+  }
+  if (suppressed && unsuppressed) {
+    fail('Use only one of --suppressed or --unsuppressed.');
+  }
+  if (acknowledged) params.acknowledged = true;
+  if (unacknowledged) params.acknowledged = false;
+  if (suppressed) params.suppressed = true;
+  if (unsuppressed) params.suppressed = false;
+
+  const timeFrom = parseUnixSeconds(
+    popFlag(args, '--time-from'),
+    '--time-from',
+  );
+  const timeTill = parseUnixSeconds(
+    popFlag(args, '--time-till'),
+    '--time-till',
+  );
+  if (timeFrom !== undefined) params.time_from = timeFrom;
+  if (timeTill !== undefined) params.time_till = timeTill;
+}
+
+function buildRpc(method, params, id) {
+  return {
+    jsonrpc: '2.0',
+    method,
+    params,
+    id,
+  };
+}
+
+function buildHttpRequest({
+  endpoint,
+  rpcMethod,
+  params,
+  id,
+  auth,
+  maxResponseBytes,
+}) {
+  const httpRequest = {
+    url: endpoint,
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json-rpc',
+    },
+    json: buildRpc(rpcMethod, params, id),
+    skillName: SKILL_NAME,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    maxResponseBytes,
+  };
+  if (auth) {
+    httpRequest.bearerSecretName = SECRET_NAME;
+  }
+  return {
+    command: 'http-request',
+    operation: rpcMethod,
+    httpRequest,
+    costMeasurement: {
+      system: 'UsageTotals',
+      subLimitKey: SKILL_NAME,
+    },
+  };
+}
+
+function buildApiVersion(endpoint) {
+  return buildHttpRequest({
+    endpoint,
+    rpcMethod: 'apiinfo.version',
+    params: {},
+    id: 1,
+    auth: false,
+    maxResponseBytes: 200_000,
+  });
+}
+
+function buildHosts(endpoint, args) {
+  const params = {
+    output: ['hostid', 'host', 'name', 'status', 'maintenance_status'],
+    selectInterfaces: ['interfaceid', 'ip', 'dns', 'type', 'main', 'useip'],
+    selectTags: ['tag', 'value'],
+    sortfield: 'name',
+  };
+  if (popBoolean(args, '--monitored-only')) {
+    params.monitored_hosts = true;
+  }
+  addSharedFilters(params, args);
+  ensureNoUnknownArgs(args);
+  return buildHttpRequest({
+    endpoint,
+    rpcMethod: 'host.get',
+    params,
+    id: 2,
+    auth: true,
+    maxResponseBytes: 2_000_000,
+  });
+}
+
+function buildProblems(endpoint, args) {
+  const limit = parseInteger(
+    popFlag(args, '--limit', String(DEFAULT_LIMIT)),
+    '--limit',
+    1,
+    MAX_LIMIT,
+  );
+  const params = {
+    output: 'extend',
+    selectAcknowledges: 'extend',
+    selectTags: 'extend',
+    selectSuppressionData: 'extend',
+    sortfield: ['eventid'],
+    sortorder: 'DESC',
+    limit,
+  };
+  if (popBoolean(args, '--recent')) {
+    params.recent = true;
+  }
+  addSharedFilters(params, args, { allowProblemFilters: true });
+  ensureNoUnknownArgs(args);
+  return buildHttpRequest({
+    endpoint,
+    rpcMethod: 'problem.get',
+    params,
+    id: 3,
+    auth: true,
+    maxResponseBytes: 4_000_000,
+  });
+}
+
+function buildTriggersProblem(endpoint, args) {
+  const limit = parseInteger(
+    popFlag(args, '--limit', String(DEFAULT_LIMIT)),
+    '--limit',
+    1,
+    MAX_LIMIT,
+  );
+  const params = {
+    output: ['triggerid', 'description', 'priority', 'lastchange'],
+    selectHosts: ['hostid', 'host', 'name'],
+    selectTags: 'extend',
+    filter: {
+      value: 1,
+    },
+    sortfield: 'priority',
+    sortorder: 'DESC',
+    limit,
+  };
+  addSharedFilters(params, args);
+  ensureNoUnknownArgs(args);
+  return buildHttpRequest({
+    endpoint,
+    rpcMethod: 'trigger.get',
+    params,
+    id: 4,
+    auth: true,
+    maxResponseBytes: 4_000_000,
+  });
+}
+
+function buildRequest(argv = process.argv.slice(2)) {
+  const { opts, positional } = parseArgs(argv);
+  if (opts.help) {
+    return { help: true };
+  }
+  if (!['json', 'pretty'].includes(opts.format)) {
+    fail('--format must be json or pretty.');
+  }
+  const mode = positional.shift();
+  const command = positional.shift();
+  if (!['http-request', 'run'].includes(mode)) {
+    fail('Expected command mode: http-request or run.');
+  }
+  const endpoint = normalizeEndpoint(
+    opts.baseUrl || process.env.ZABBIX_BASE_URL,
+  );
+
+  let request;
+  if (command === 'api-version') {
+    ensureNoUnknownArgs(positional);
+    request = buildApiVersion(endpoint);
+  } else if (command === 'hosts') {
+    request = buildHosts(endpoint, positional);
+  } else if (command === 'problems') {
+    request = buildProblems(endpoint, positional);
+  } else if (command === 'triggers-problem') {
+    request = buildTriggersProblem(endpoint, positional);
+  } else {
+    fail(`Unsupported Zabbix operation: ${command || '(missing)'}`);
+  }
+
+  if (mode === 'run') {
+    request.command = 'run';
+  }
+  return request;
+}
+
+function resolveGatewayUrl() {
+  return (
+    String(process.env.HYBRIDCLAW_GATEWAY_URL || '').trim() ||
+    DEFAULT_GATEWAY_URL
+  ).replace(/\/+$/u, '');
+}
+
+function resolveGatewayToken() {
+  return String(
+    process.env.HYBRIDCLAW_GATEWAY_TOKEN ||
+      process.env.GATEWAY_API_TOKEN ||
+      process.env.WEB_API_TOKEN ||
+      '',
+  ).trim();
+}
+
+function parseJsonMaybe(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function responseHeadersToObject(headers) {
+  if (!headers || typeof headers.forEach !== 'function') {
+    return {};
+  }
+  const result = {};
+  headers.forEach((value, key) => {
+    result[key] = value;
+  });
+  return result;
+}
+
+function normalizeGatewayResult(wrapper, fallbackStatus) {
+  const status = Number(wrapper.status || fallbackStatus || 0);
+  const body = typeof wrapper.body === 'string' ? wrapper.body : '';
+  const bodyJson = parseJsonMaybe(body);
+  return {
+    ok: wrapper.ok !== false,
+    status,
+    statusText: wrapper.statusText || '',
+    headers: wrapper.headers || {},
+    body,
+    bodyJson,
+    bodyTruncated: wrapper.bodyTruncated === true,
+    maxResponseBytes: wrapper.maxResponseBytes,
+  };
+}
+
+function zabbixCredentialMessage(status, body) {
+  const suffix = body ? ` Zabbix response: ${body}` : '';
+  return `Zabbix returned HTTP ${status} for the first live call. Check ZABBIX_API_TOKEN, token permissions, and the configured Zabbix frontend URL before retrying.${suffix}`;
+}
+
+async function executeZabbixGatewayRequest(httpRequest, options = {}) {
+  const gatewayUrl = String(options.gatewayUrl || resolveGatewayUrl()).replace(
+    /\/+$/u,
+    '',
+  );
+  const gatewayToken = options.gatewayToken || resolveGatewayToken();
+  const fetchImpl = options.fetch || globalThis.fetch;
+  if (typeof fetchImpl !== 'function') {
+    throw new ZabbixConfigError('fetch is not available for Zabbix requests.');
+  }
+
+  const headers = { 'Content-Type': 'application/json' };
+  if (gatewayToken) {
+    headers.Authorization = `Bearer ${gatewayToken}`;
+  }
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    (httpRequest.timeoutMs || DEFAULT_TIMEOUT_MS) + GATEWAY_TIMEOUT_BUFFER_MS,
+  );
+  let response;
+  let text = '';
+  try {
+    response = await fetchImpl(`${gatewayUrl}/api/http/request`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(httpRequest),
+      signal: controller.signal,
+    });
+    text = await response.text();
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (!response.ok) {
+    throw new ZabbixError(
+      `Gateway proxy returned HTTP ${response.status} for Zabbix request: ${text}`,
+      { status: response.status, body: text },
+    );
+  }
+
+  const parsed = parseJsonMaybe(text);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {
+      ok: true,
+      status: response.status,
+      headers: responseHeadersToObject(response.headers),
+      body: text,
+      bodyJson: null,
+    };
+  }
+
+  const normalized = normalizeGatewayResult(parsed, response.status);
+  if (normalized.bodyTruncated) {
+    throw new ZabbixError(
+      `Zabbix response was truncated by the gateway at ${normalized.maxResponseBytes || 'the configured'} bytes. Narrow the query or increase maxResponseBytes.`,
+      normalized,
+    );
+  }
+  if (parsed.ok === false) {
+    if (normalized.status === 401 || normalized.status === 403) {
+      throw new ZabbixCredentialError(
+        zabbixCredentialMessage(normalized.status, normalized.body),
+        normalized,
+      );
+    }
+    throw new ZabbixError(
+      `Zabbix returned HTTP ${normalized.status || 'error'}: ${
+        normalized.body || normalized.statusText
+      }`,
+      normalized,
+    );
+  }
+  if (normalized.bodyJson?.error) {
+    const error = normalized.bodyJson.error;
+    throw new ZabbixError(
+      `Zabbix JSON-RPC ${httpRequest.json?.method || 'request'} failed: ${error.code} ${error.message}${
+        error.data ? ` (${error.data})` : ''
+      }`,
+      { ...normalized, zabbixError: error },
+    );
+  }
+  return normalized;
+}
+
+async function main() {
+  const result = buildRequest();
+  if (result.help) {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+  if (result.command === 'run') {
+    try {
+      printJson(await executeZabbixGatewayRequest(result.httpRequest));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`${message}\n`);
+      process.exitCode = error instanceof ZabbixCredentialError ? 78 : 1;
+    }
+    return;
+  }
+  printJson(result);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  ZabbixConfigError,
+  ZabbixCredentialError,
+  ZabbixError,
+  buildRequest,
+  executeZabbixGatewayRequest,
+  normalizeEndpoint,
+};

--- a/tests/zabbix-skill.test.ts
+++ b/tests/zabbix-skill.test.ts
@@ -1,0 +1,421 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+import { expect, test, vi } from 'vitest';
+
+import { parseSkillManifestFromMarkdown } from '../src/skills/skill-manifest.js';
+
+const helperPath = path.join(process.cwd(), 'skills', 'zabbix', 'zabbix.cjs');
+const skillPath = path.join(process.cwd(), 'skills', 'zabbix', 'SKILL.md');
+const require = createRequire(import.meta.url);
+
+function runHelper(args: string[]) {
+  return spawnSync('node', [helperPath, ...args], {
+    encoding: 'utf-8',
+  });
+}
+
+test('Zabbix skill manifest declares SecretRef credential metadata', () => {
+  const skill = fs.readFileSync(skillPath, 'utf-8');
+  const manifest = parseSkillManifestFromMarkdown(skill, { name: 'zabbix' });
+
+  expect(manifest.credentials).toEqual([
+    {
+      id: 'zabbix-api-token',
+      kind: 'bearer',
+      required: true,
+      secretRef: {
+        source: 'store',
+        id: 'ZABBIX_API_TOKEN',
+      },
+      scope: 'https://<zabbix-frontend>/api_jsonrpc.php Authorization bearer',
+      howToObtain:
+        'Create a Zabbix API token in the Zabbix frontend and store it with\n' +
+        '`hybridclaw secret set ZABBIX_API_TOKEN "<token>"`.',
+    },
+  ]);
+  expect(skill).toContain('category: production-ops');
+  expect(skill).toContain('event-acknowledge');
+  expect(skill).toContain('event-close');
+  expect(skill).toContain('Stop after that first failed live');
+});
+
+test('Zabbix helper --help exits cleanly without secret flags', () => {
+  const result = runHelper(['--help']);
+
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain('Zabbix skill helper');
+  expect(result.stdout).toContain('api-version');
+  expect(result.stdout).toContain('hosts');
+  expect(result.stdout).toContain('problems');
+  expect(result.stdout).toContain('triggers-problem');
+  expect(result.stdout).not.toContain('--token');
+  expect(result.stdout).not.toContain('--password');
+});
+
+test('Zabbix run mode prepares the same gateway-proxied request', () => {
+  const zabbix = require('../skills/zabbix/zabbix.cjs');
+
+  const payload = zabbix.buildRequest([
+    'run',
+    'problems',
+    '--base-url',
+    'https://zabbix.example.com/zabbix',
+    '--recent',
+  ]);
+
+  expect(payload).toMatchObject({
+    command: 'run',
+    httpRequest: {
+      url: 'https://zabbix.example.com/zabbix/api_jsonrpc.php',
+      bearerSecretName: 'ZABBIX_API_TOKEN',
+      json: {
+        method: 'problem.get',
+      },
+    },
+  });
+});
+
+test('Zabbix helper normalizes frontend URLs to the JSON-RPC endpoint', () => {
+  const frontend = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'api-version',
+    '--base-url',
+    'https://zabbix.example.com/zabbix',
+  ]);
+  const endpoint = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'api-version',
+    '--base-url',
+    'https://zabbix.example.com/zabbix/api_jsonrpc.php',
+  ]);
+
+  expect(frontend.status).toBe(0);
+  expect(endpoint.status).toBe(0);
+  expect(JSON.parse(frontend.stdout).httpRequest.url).toBe(
+    'https://zabbix.example.com/zabbix/api_jsonrpc.php',
+  );
+  expect(JSON.parse(endpoint.stdout).httpRequest.url).toBe(
+    'https://zabbix.example.com/zabbix/api_jsonrpc.php',
+  );
+});
+
+test('Zabbix api-version request is unauthenticated and bounded', () => {
+  const result = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'api-version',
+    '--base-url',
+    'https://zabbix.example.com/zabbix',
+  ]);
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.httpRequest).toMatchObject({
+    url: 'https://zabbix.example.com/zabbix/api_jsonrpc.php',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json-rpc',
+    },
+    json: {
+      jsonrpc: '2.0',
+      method: 'apiinfo.version',
+      params: {},
+      id: 1,
+    },
+    skillName: 'zabbix',
+    timeoutMs: 30000,
+    maxResponseBytes: 200000,
+  });
+  expect(payload.httpRequest).not.toHaveProperty('bearerSecretName');
+  expect(payload.httpRequest.headers).not.toHaveProperty('Authorization');
+});
+
+test('Zabbix host request injects bearer SecretRef field and explicit outputs', () => {
+  const result = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'hosts',
+    '--base-url',
+    'https://zabbix.example.com/zabbix',
+    '--monitored-only',
+    '--host',
+    '10084',
+    '--host-group',
+    '2',
+    '--tag',
+    'role=db',
+  ]);
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.httpRequest).toMatchObject({
+    bearerSecretName: 'ZABBIX_API_TOKEN',
+    skillName: 'zabbix',
+  });
+  expect(payload.httpRequest.headers).not.toHaveProperty('Authorization');
+  expect(payload.httpRequest.json).toMatchObject({
+    method: 'host.get',
+    params: {
+      output: ['hostid', 'host', 'name', 'status', 'maintenance_status'],
+      selectInterfaces: ['interfaceid', 'ip', 'dns', 'type', 'main', 'useip'],
+      selectTags: ['tag', 'value'],
+      monitored_hosts: true,
+      hostids: ['10084'],
+      groupids: ['2'],
+      tags: [{ tag: 'role', value: 'db' }],
+      sortfield: 'name',
+    },
+    id: 2,
+  });
+  expect(result.stdout).not.toContain('Authorization');
+});
+
+test('Zabbix problem request supports recent, bounds, and incident filters', () => {
+  const result = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'problems',
+    '--base-url',
+    'https://zabbix.example.com/zabbix',
+    '--recent',
+    '--limit',
+    '25',
+    '--host-id',
+    '10084,10085',
+    '--group-id',
+    '2',
+    '--severity',
+    'high,disaster',
+    '--unacknowledged',
+    '--unsuppressed',
+    '--tag',
+    'service=postgres',
+    '--time-from',
+    '1767225600',
+    '--time-till',
+    '1767312000',
+  ]);
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.httpRequest).toMatchObject({
+    bearerSecretName: 'ZABBIX_API_TOKEN',
+    maxResponseBytes: 4000000,
+  });
+  expect(payload.httpRequest.json).toMatchObject({
+    method: 'problem.get',
+    params: {
+      output: 'extend',
+      selectAcknowledges: 'extend',
+      selectTags: 'extend',
+      selectSuppressionData: 'extend',
+      recent: true,
+      sortfield: ['eventid'],
+      sortorder: 'DESC',
+      limit: 25,
+      hostids: ['10084', '10085'],
+      groupids: ['2'],
+      severities: [4, 5],
+      acknowledged: false,
+      suppressed: false,
+      tags: [{ tag: 'service', value: 'postgres' }],
+      time_from: 1767225600,
+      time_till: 1767312000,
+    },
+    id: 3,
+  });
+});
+
+test('Zabbix trigger problem request follows documented problem-state pattern', () => {
+  const result = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'triggers-problem',
+    '--base-url',
+    'https://zabbix.example.com/zabbix/api_jsonrpc.php',
+    '--limit',
+    '10',
+    '--severity',
+    'warning',
+    '--tag',
+    'team=infra',
+  ]);
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.httpRequest.json).toMatchObject({
+    method: 'trigger.get',
+    params: {
+      output: ['triggerid', 'description', 'priority', 'lastchange'],
+      selectHosts: ['hostid', 'host', 'name'],
+      selectTags: 'extend',
+      filter: {
+        value: 1,
+      },
+      sortfield: 'priority',
+      sortorder: 'DESC',
+      limit: 10,
+      severities: [2],
+      tags: [{ tag: 'team', value: 'infra' }],
+    },
+    id: 4,
+  });
+});
+
+test('Zabbix helper validates limit bounds and mutually exclusive filters', () => {
+  const tooLarge = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'problems',
+    '--base-url',
+    'https://zabbix.example.com/zabbix',
+    '--limit',
+    '101',
+  ]);
+  const notInteger = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'triggers-problem',
+    '--base-url',
+    'https://zabbix.example.com/zabbix',
+    '--limit',
+    '25.5',
+  ]);
+  const conflictingAck = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'problems',
+    '--base-url',
+    'https://zabbix.example.com/zabbix',
+    '--acknowledged',
+    '--unacknowledged',
+  ]);
+
+  expect(tooLarge.status).not.toBe(0);
+  expect(tooLarge.stderr).toContain('--limit must be between 1 and 100.');
+  expect(notInteger.status).not.toBe(0);
+  expect(notInteger.stderr).toContain(
+    '--limit must be an integer between 1 and 100.',
+  );
+  expect(conflictingAck.status).not.toBe(0);
+  expect(conflictingAck.stderr).toContain(
+    'Use only one of --acknowledged or --unacknowledged.',
+  );
+});
+
+test('Zabbix helper rejects cleartext credential flags without echoing values', () => {
+  const result = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'hosts',
+    '--base-url',
+    'https://zabbix.example.com/zabbix',
+    '--token',
+    'super-secret-token',
+  ]);
+
+  expect(result.status).not.toBe(0);
+  expect(result.stderr).toContain(
+    '--token is not supported. Store Zabbix credentials in ZABBIX_API_TOKEN.',
+  );
+  expect(result.stderr).not.toContain('super-secret-token');
+  expect(result.stdout).not.toContain('super-secret-token');
+});
+
+test('Zabbix live executor uses the gateway http_request route without exposing secrets', async () => {
+  const zabbix = require('../skills/zabbix/zabbix.cjs');
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Headers(),
+    text: async () =>
+      JSON.stringify({
+        ok: true,
+        status: 200,
+        headers: {},
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          result: '7.4.0',
+          id: 1,
+        }),
+      }),
+  });
+  const payload = zabbix.buildRequest([
+    'http-request',
+    'api-version',
+    '--base-url',
+    'https://zabbix.example.com/zabbix',
+  ]);
+
+  const result = await zabbix.executeZabbixGatewayRequest(payload.httpRequest, {
+    gatewayUrl: 'http://127.0.0.1:9090',
+    gatewayToken: 'gateway-token',
+    fetch: fetchMock,
+  });
+
+  expect(result.bodyJson.result).toBe('7.4.0');
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  expect(fetchMock).toHaveBeenCalledWith(
+    'http://127.0.0.1:9090/api/http/request',
+    expect.objectContaining({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer gateway-token',
+      },
+    }),
+  );
+  const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+  expect(body).not.toHaveProperty('Authorization');
+  expect(JSON.stringify(body)).not.toContain('gateway-token');
+  expect(JSON.stringify(body)).not.toContain('zabbix-api-token');
+});
+
+test('Zabbix live executor stops after one Zabbix 401 response', async () => {
+  const zabbix = require('../skills/zabbix/zabbix.cjs');
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Headers(),
+    text: async () =>
+      JSON.stringify({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: {},
+        body: '{"error":"invalid bearer token"}',
+      }),
+  });
+  const payload = zabbix.buildRequest([
+    'http-request',
+    'problems',
+    '--base-url',
+    'https://zabbix.example.com/zabbix',
+  ]);
+
+  await expect(
+    zabbix.executeZabbixGatewayRequest(payload.httpRequest, {
+      gatewayUrl: 'http://127.0.0.1:9090',
+      gatewayToken: 'gateway-token',
+      fetch: fetchMock,
+    }),
+  ).rejects.toThrow(
+    'Zabbix returned HTTP 401 for the first live call. Check ZABBIX_API_TOKEN',
+  );
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});

--- a/tests/zabbix-skill.test.ts
+++ b/tests/zabbix-skill.test.ts
@@ -10,11 +10,19 @@ import { parseSkillManifestFromMarkdown } from '../src/skills/skill-manifest.js'
 const helperPath = path.join(process.cwd(), 'skills', 'zabbix', 'zabbix.cjs');
 const skillPath = path.join(process.cwd(), 'skills', 'zabbix', 'SKILL.md');
 const require = createRequire(import.meta.url);
+const zabbix = require('../skills/zabbix/zabbix.cjs');
+
+const BASE_URL = 'https://zabbix.example.com/zabbix';
+const ENDPOINT = 'https://zabbix.example.com/zabbix/api_jsonrpc.php';
 
 function runHelper(args: string[]) {
   return spawnSync('node', [helperPath, ...args], {
     encoding: 'utf-8',
   });
+}
+
+function request(args: string[]) {
+  return zabbix.buildRequest(['http-request', ...args]);
 }
 
 test('Zabbix skill manifest declares SecretRef credential metadata', () => {
@@ -55,21 +63,44 @@ test('Zabbix helper --help exits cleanly without secret flags', () => {
   expect(result.stdout).not.toContain('--password');
 });
 
-test('Zabbix run mode prepares the same gateway-proxied request', () => {
-  const zabbix = require('../skills/zabbix/zabbix.cjs');
+test('Zabbix helper formats json compactly and pretty output with indentation', () => {
+  const compact = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'api-version',
+    '--base-url',
+    BASE_URL,
+  ]);
+  const pretty = runHelper([
+    '--format',
+    'pretty',
+    'http-request',
+    'api-version',
+    '--base-url',
+    BASE_URL,
+  ]);
 
+  expect(compact.status).toBe(0);
+  expect(pretty.status).toBe(0);
+  expect(compact.stdout).not.toContain('\n  "');
+  expect(pretty.stdout).toContain('\n  "');
+});
+
+test('Zabbix live flag prepares the same gateway-proxied request', () => {
   const payload = zabbix.buildRequest([
-    'run',
+    '--live',
+    'http-request',
     'problems',
     '--base-url',
-    'https://zabbix.example.com/zabbix',
+    BASE_URL,
     '--recent',
   ]);
 
   expect(payload).toMatchObject({
-    command: 'run',
+    command: 'live',
     httpRequest: {
-      url: 'https://zabbix.example.com/zabbix/api_jsonrpc.php',
+      url: ENDPOINT,
       bearerSecretName: 'ZABBIX_API_TOKEN',
       json: {
         method: 'problem.get',
@@ -79,47 +110,18 @@ test('Zabbix run mode prepares the same gateway-proxied request', () => {
 });
 
 test('Zabbix helper normalizes frontend URLs to the JSON-RPC endpoint', () => {
-  const frontend = runHelper([
-    '--format',
-    'json',
-    'http-request',
-    'api-version',
-    '--base-url',
-    'https://zabbix.example.com/zabbix',
-  ]);
-  const endpoint = runHelper([
-    '--format',
-    'json',
-    'http-request',
-    'api-version',
-    '--base-url',
-    'https://zabbix.example.com/zabbix/api_jsonrpc.php',
-  ]);
+  const frontend = request(['api-version', '--base-url', BASE_URL]);
+  const endpoint = request(['api-version', '--base-url', ENDPOINT]);
 
-  expect(frontend.status).toBe(0);
-  expect(endpoint.status).toBe(0);
-  expect(JSON.parse(frontend.stdout).httpRequest.url).toBe(
-    'https://zabbix.example.com/zabbix/api_jsonrpc.php',
-  );
-  expect(JSON.parse(endpoint.stdout).httpRequest.url).toBe(
-    'https://zabbix.example.com/zabbix/api_jsonrpc.php',
-  );
+  expect(frontend.httpRequest.url).toBe(ENDPOINT);
+  expect(endpoint.httpRequest.url).toBe(ENDPOINT);
 });
 
 test('Zabbix api-version request is unauthenticated and bounded', () => {
-  const result = runHelper([
-    '--format',
-    'json',
-    'http-request',
-    'api-version',
-    '--base-url',
-    'https://zabbix.example.com/zabbix',
-  ]);
+  const payload = request(['api-version', '--base-url', BASE_URL]);
 
-  expect(result.status).toBe(0);
-  const payload = JSON.parse(result.stdout);
   expect(payload.httpRequest).toMatchObject({
-    url: 'https://zabbix.example.com/zabbix/api_jsonrpc.php',
+    url: ENDPOINT,
     method: 'POST',
     headers: {
       'Content-Type': 'application/json-rpc',
@@ -131,7 +133,7 @@ test('Zabbix api-version request is unauthenticated and bounded', () => {
       id: 1,
     },
     skillName: 'zabbix',
-    timeoutMs: 30000,
+    timeoutMs: 10000,
     maxResponseBytes: 200000,
   });
   expect(payload.httpRequest).not.toHaveProperty('bearerSecretName');
@@ -139,13 +141,10 @@ test('Zabbix api-version request is unauthenticated and bounded', () => {
 });
 
 test('Zabbix host request injects bearer SecretRef field and explicit outputs', () => {
-  const result = runHelper([
-    '--format',
-    'json',
-    'http-request',
+  const payload = request([
     'hosts',
     '--base-url',
-    'https://zabbix.example.com/zabbix',
+    BASE_URL,
     '--monitored-only',
     '--host',
     '10084',
@@ -155,8 +154,6 @@ test('Zabbix host request injects bearer SecretRef field and explicit outputs', 
     'role=db',
   ]);
 
-  expect(result.status).toBe(0);
-  const payload = JSON.parse(result.stdout);
   expect(payload.httpRequest).toMatchObject({
     bearerSecretName: 'ZABBIX_API_TOKEN',
     skillName: 'zabbix',
@@ -176,17 +173,14 @@ test('Zabbix host request injects bearer SecretRef field and explicit outputs', 
     },
     id: 2,
   });
-  expect(result.stdout).not.toContain('Authorization');
+  expect(JSON.stringify(payload)).not.toContain('Authorization');
 });
 
 test('Zabbix problem request supports recent, bounds, and incident filters', () => {
-  const result = runHelper([
-    '--format',
-    'json',
-    'http-request',
+  const payload = request([
     'problems',
     '--base-url',
-    'https://zabbix.example.com/zabbix',
+    BASE_URL,
     '--recent',
     '--limit',
     '25',
@@ -206,8 +200,6 @@ test('Zabbix problem request supports recent, bounds, and incident filters', () 
     '1767312000',
   ]);
 
-  expect(result.status).toBe(0);
-  const payload = JSON.parse(result.stdout);
   expect(payload.httpRequest).toMatchObject({
     bearerSecretName: 'ZABBIX_API_TOKEN',
     maxResponseBytes: 4000000,
@@ -237,13 +229,10 @@ test('Zabbix problem request supports recent, bounds, and incident filters', () 
 });
 
 test('Zabbix trigger problem request follows documented problem-state pattern', () => {
-  const result = runHelper([
-    '--format',
-    'json',
-    'http-request',
+  const payload = request([
     'triggers-problem',
     '--base-url',
-    'https://zabbix.example.com/zabbix/api_jsonrpc.php',
+    ENDPOINT,
     '--limit',
     '10',
     '--severity',
@@ -252,8 +241,6 @@ test('Zabbix trigger problem request follows documented problem-state pattern', 
     'team=infra',
   ]);
 
-  expect(result.status).toBe(0);
-  const payload = JSON.parse(result.stdout);
   expect(payload.httpRequest.json).toMatchObject({
     method: 'trigger.get',
     params: {
@@ -280,7 +267,7 @@ test('Zabbix helper validates limit bounds and mutually exclusive filters', () =
     'http-request',
     'problems',
     '--base-url',
-    'https://zabbix.example.com/zabbix',
+    BASE_URL,
     '--limit',
     '101',
   ]);
@@ -290,7 +277,7 @@ test('Zabbix helper validates limit bounds and mutually exclusive filters', () =
     'http-request',
     'triggers-problem',
     '--base-url',
-    'https://zabbix.example.com/zabbix',
+    BASE_URL,
     '--limit',
     '25.5',
   ]);
@@ -300,7 +287,7 @@ test('Zabbix helper validates limit bounds and mutually exclusive filters', () =
     'http-request',
     'problems',
     '--base-url',
-    'https://zabbix.example.com/zabbix',
+    BASE_URL,
     '--acknowledged',
     '--unacknowledged',
   ]);
@@ -317,6 +304,47 @@ test('Zabbix helper validates limit bounds and mutually exclusive filters', () =
   );
 });
 
+test('Zabbix helper rejects http base URLs unless explicitly allowed', () => {
+  const rejected = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'api-version',
+    '--base-url',
+    'http://zabbix.example.com/zabbix',
+  ]);
+  const allowed = zabbix.buildRequest([
+    '--allow-http',
+    'http-request',
+    'api-version',
+    '--base-url',
+    'http://127.0.0.1/zabbix',
+  ]);
+
+  expect(rejected.status).not.toBe(0);
+  expect(rejected.stderr).toContain('--base-url must use https.');
+  expect(allowed.httpRequest.url).toBe(
+    'http://127.0.0.1/zabbix/api_jsonrpc.php',
+  );
+});
+
+test('Zabbix helper reports problem-only filters on unsupported commands', () => {
+  const result = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'hosts',
+    '--base-url',
+    BASE_URL,
+    '--acknowledged',
+  ]);
+
+  expect(result.status).not.toBe(0);
+  expect(result.stderr).toContain(
+    '--acknowledged is only valid for the problems command.',
+  );
+});
+
 test('Zabbix helper rejects cleartext credential flags without echoing values', () => {
   const result = runHelper([
     '--format',
@@ -324,7 +352,28 @@ test('Zabbix helper rejects cleartext credential flags without echoing values', 
     'http-request',
     'hosts',
     '--base-url',
-    'https://zabbix.example.com/zabbix',
+    BASE_URL,
+    '--token',
+    'super-secret-token',
+  ]);
+
+  expect(result.status).not.toBe(0);
+  expect(result.stderr).toContain(
+    '--token is not supported. Store Zabbix credentials in ZABBIX_API_TOKEN.',
+  );
+  expect(result.stderr).not.toContain('super-secret-token');
+  expect(result.stdout).not.toContain('super-secret-token');
+});
+
+test('Zabbix helper rejects secret flags in value position without echoing values', () => {
+  const result = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'hosts',
+    '--base-url',
+    BASE_URL,
+    '--host-id',
     '--token',
     'super-secret-token',
   ]);
@@ -338,7 +387,6 @@ test('Zabbix helper rejects cleartext credential flags without echoing values', 
 });
 
 test('Zabbix live executor uses the gateway http_request route without exposing secrets', async () => {
-  const zabbix = require('../skills/zabbix/zabbix.cjs');
   const fetchMock = vi.fn().mockResolvedValue({
     ok: true,
     status: 200,
@@ -359,7 +407,7 @@ test('Zabbix live executor uses the gateway http_request route without exposing 
     'http-request',
     'api-version',
     '--base-url',
-    'https://zabbix.example.com/zabbix',
+    BASE_URL,
   ]);
 
   const result = await zabbix.executeZabbixGatewayRequest(payload.httpRequest, {
@@ -387,7 +435,6 @@ test('Zabbix live executor uses the gateway http_request route without exposing 
 });
 
 test('Zabbix live executor stops after one Zabbix 401 response', async () => {
-  const zabbix = require('../skills/zabbix/zabbix.cjs');
   const fetchMock = vi.fn().mockResolvedValue({
     ok: true,
     status: 200,
@@ -405,7 +452,7 @@ test('Zabbix live executor stops after one Zabbix 401 response', async () => {
     'http-request',
     'problems',
     '--base-url',
-    'https://zabbix.example.com/zabbix',
+    BASE_URL,
   ]);
 
   await expect(
@@ -418,4 +465,34 @@ test('Zabbix live executor stops after one Zabbix 401 response', async () => {
     'Zabbix returned HTTP 401 for the first live call. Check ZABBIX_API_TOKEN',
   );
   expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+test('Zabbix live executor reports truncated gateway responses', async () => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Headers(),
+    text: async () =>
+      JSON.stringify({
+        ok: true,
+        status: 200,
+        bodyTruncated: true,
+        maxResponseBytes: 200000,
+        body: '{"jsonrpc":"2.0","result":[],"id":3}',
+      }),
+  });
+  const payload = zabbix.buildRequest([
+    'http-request',
+    'problems',
+    '--base-url',
+    BASE_URL,
+  ]);
+
+  await expect(
+    zabbix.executeZabbixGatewayRequest(payload.httpRequest, {
+      gatewayUrl: 'http://127.0.0.1:9090',
+      gatewayToken: 'gateway-token',
+      fetch: fetchMock,
+    }),
+  ).rejects.toThrow('Zabbix response was truncated by the gateway');
 });


### PR DESCRIPTION
## Summary

Closes #1045.

Adds a bundled `zabbix` production ops skill for reading Zabbix monitoring state through HybridClaw's gateway `http_request` path. The skill documents SecretRef-backed setup with `ZABBIX_API_TOKEN`, Zabbix JSON-RPC command usage, incident-summary guidance, and credential/setup failure handling.

## What Changed

- Added `skills/zabbix/SKILL.md` with SecretRef credential metadata, trigger/scope guidance, read-only operating rules, setup instructions, filter docs, and guarded write-tier notes.
- Added `skills/zabbix/zabbix.cjs` to emit bounded JSON-RPC `httpRequest` payloads for `apiinfo.version`, `host.get`, `problem.get`, and `trigger.get`.
- Added `--live` mode that sends one gateway-proxied live request through `/api/http/request`, never emits cleartext Zabbix auth, and stops after the first Zabbix 401/403 with a credential/setup error.
- Addressed review feedback by requiring HTTPS by default, adding `--allow-http` opt-in, making `--format json` compact, reducing default monitoring timeouts, removing undocumented gateway-token fallbacks, simplifying emitted payloads, and moving most tests to direct module calls.
- Added unit coverage for URL normalization, JSON-RPC payload construction, SecretRef bearer injection, host/group/tag/severity filters, limit bounds, HTTP opt-in, problem-only filter errors, truncation handling, and no-secret-output behavior.

## Validation

- `npx biome check --write tests/zabbix-skill.test.ts skills/zabbix/zabbix.cjs`
- `./node_modules/.bin/vitest run --configLoader runner --project unit tests/zabbix-skill.test.ts`