### PR TITLE
[codex] Reduce IPC and redaction overhead

### DIFF
--- a/container/src/ipc.ts
+++ b/container/src/ipc.ts
@@ -8,6 +8,10 @@ const INPUT_PATH = path.join(IPC_DIR, 'input.json');
 const OUTPUT_PATH = path.join(IPC_DIR, 'output.json');
 const HEALTH_INPUT_PATH = path.join(IPC_DIR, 'health-input.json');
 const HEALTH_OUTPUT_PATH = path.join(IPC_DIR, 'health-output.json');
+const MIN_INPUT_POLL_INTERVAL_MS = 5;
+const MAX_INPUT_POLL_INTERVAL_MS = 200;
+// Keep the backoff formula aligned with src/infra/ipc.ts; max differs by side.
+const INPUT_POLL_BACKOFF_FACTOR = 1.5;
 
 function readInputFile(inputPath: string): ContainerInput | null {
   try {
@@ -28,8 +32,8 @@ function readInputFile(inputPath: string): ContainerInput | null {
 export async function waitForInput(
   idleTimeoutMs: number,
 ): Promise<ContainerInput | null> {
-  const pollInterval = 200;
   const deadline = Date.now() + idleTimeoutMs;
+  let pollInterval = MIN_INPUT_POLL_INTERVAL_MS;
 
   while (Date.now() < deadline) {
     if (fs.existsSync(HEALTH_INPUT_PATH)) {
@@ -40,7 +44,15 @@ export async function waitForInput(
       const input = readInputFile(INPUT_PATH);
       if (input) return input;
     }
-    await new Promise((resolve) => setTimeout(resolve, pollInterval));
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) break;
+    await new Promise((resolve) =>
+      setTimeout(resolve, Math.min(pollInterval, remainingMs)),
+    );
+    pollInterval = Math.min(
+      Math.ceil(pollInterval * INPUT_POLL_BACKOFF_FACTOR),
+      MAX_INPUT_POLL_INTERVAL_MS,
+    );
   }
 
   return null; // Idle timeout

--- a/src/infra/ipc.ts
+++ b/src/infra/ipc.ts
@@ -182,6 +182,10 @@ export function createActivityTracker(): ActivityTracker {
 }
 
 const ACTIVITY_HARD_TIMEOUT_MULTIPLIER = 4;
+const MIN_OUTPUT_POLL_INTERVAL_MS = 5;
+const MAX_OUTPUT_POLL_INTERVAL_MS = 250;
+// Keep the backoff formula aligned with container/src/ipc.ts; max differs by side.
+const OUTPUT_POLL_BACKOFF_FACTOR = 1.5;
 
 function normalizePositiveTimeoutMs(
   value: number | null | undefined,
@@ -237,7 +241,7 @@ async function readOutputFile(
         : Math.max(idleTimeoutMs, requestedWallClockMs);
   const hardDeadline =
     hardTimeoutMs === null ? Number.POSITIVE_INFINITY : start + hardTimeoutMs;
-  const pollInterval = 250;
+  let pollInterval = MIN_OUTPUT_POLL_INTERVAL_MS;
 
   if (signal?.aborted) return interruptedOutput();
 
@@ -303,6 +307,10 @@ async function readOutputFile(
     );
     const aborted = await sleepWithAbort(sleepMs, signal);
     if (aborted) return interruptedOutput();
+    pollInterval = Math.min(
+      Math.ceil(pollInterval * OUTPUT_POLL_BACKOFF_FACTOR),
+      MAX_OUTPUT_POLL_INTERVAL_MS,
+    );
   }
 
   return {

--- a/src/security/redact.ts
+++ b/src/security/redact.ts
@@ -7,6 +7,7 @@ type RedactionReplacer = (substring: string, ...args: string[]) => string;
 export interface SecretRedactionPattern {
   match: RegExp;
   replace: string | RedactionReplacer;
+  shouldRun?: (text: string) => boolean;
 }
 
 export interface HighEntropyRedactionOptions {
@@ -173,6 +174,14 @@ function redactConnectionString(value: string): string {
   return `${value.slice(0, schemeIdx + 3)}***`;
 }
 
+function containsDigit(text: string): boolean {
+  for (let index = 0; index < text.length; index += 1) {
+    const code = text.charCodeAt(index);
+    if (code >= 48 && code <= 57) return true;
+  }
+  return false;
+}
+
 const JSON_SECRET_KEY_RE =
   /((?:["'])(?:api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret|webhook[_-]?secret|auth(?:orization)?|token|secret|password|private[_-]?key)(?:["'])\s*:\s*)("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[^,\s}\]]+)/gi;
 const ENV_SECRET_ASSIGNMENT_RE =
@@ -186,78 +195,98 @@ export const CREDENTIAL_REDACTION_PATTERNS: readonly SecretRedactionPattern[] =
       match:
         /-----BEGIN(?: [A-Z0-9]+)* PRIVATE KEY-----[\s\S]*?-----END(?: [A-Z0-9]+)* PRIVATE KEY-----/g,
       replace: '***PRIVATE_KEY_REDACTED***',
+      shouldRun: (text) => text.includes('PRIVATE KEY'),
     },
     {
       match: JSON_SECRET_KEY_RE,
       replace: (_match: string, prefix: string, value: string) =>
         `${prefix}${redactStructuredSecretValue(value)}`,
+      shouldRun: (text) =>
+        text.includes(':') && (text.includes('"') || text.includes("'")),
     },
     {
       match: ENV_SECRET_ASSIGNMENT_RE,
       replace: (_match: string, key: string, value: string) =>
         `${key}=${redactStructuredSecretValue(value)}`,
+      shouldRun: (text) => text.includes('='),
     },
     {
       match: /\b(Bearer\s+)([^\s"',;]+)/gi,
       replace: (_match: string, prefix: string, token: string) =>
         `${prefix}${maskSecret(token)}`,
+      shouldRun: (text) => text.toLowerCase().includes('bearer'),
     },
     {
       match:
         /\b((?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis|rediss|mssql):\/\/[^\s"'`]+)/gi,
       replace: (_match: string, value: string) => redactConnectionString(value),
+      shouldRun: (text) => text.includes('://'),
     },
     {
       match: /\b(github_pat_[A-Za-z0-9_]{20,})\b/g,
       replace: (_match: string, token: string) => maskSecret(token),
+      shouldRun: (text) => text.includes('github_pat_'),
     },
     {
       match: /\b(gho_[A-Za-z0-9_]{20,})\b/g,
       replace: (_match: string, token: string) => maskSecret(token),
+      shouldRun: (text) => text.includes('gho_'),
     },
     {
       match: /\b(ghs_[A-Za-z0-9_]{20,})\b/g,
       replace: (_match: string, token: string) => maskSecret(token),
+      shouldRun: (text) => text.includes('ghs_'),
     },
     {
       match: /\b(ghu_[A-Za-z0-9_]{20,})\b/g,
       replace: (_match: string, token: string) => maskSecret(token),
+      shouldRun: (text) => text.includes('ghu_'),
     },
     {
       match: /\b(ghp_[A-Za-z0-9_]{20,})\b/g,
       replace: (_match: string, token: string) => maskSecret(token),
+      shouldRun: (text) => text.includes('ghp_'),
     },
     {
       match: /\b(npm_[A-Za-z0-9]{20,})\b/g,
       replace: (_match: string, token: string) => maskSecret(token),
+      shouldRun: (text) => text.includes('npm_'),
     },
     {
       match: /\b(sk_(?:live|test)_[A-Za-z0-9]{16,})\b/g,
       replace: (_match: string, token: string) => maskSecret(token),
+      shouldRun: (text) =>
+        text.includes('sk_live_') || text.includes('sk_test_'),
     },
     {
       match: /\b(sk-[A-Za-z0-9_-]{16,})\b/g,
       replace: (_match: string, token: string) => maskSecret(token),
+      shouldRun: (text) => text.includes('sk-'),
     },
     {
       match: /\b(AKIA[0-9A-Z]{16})\b/g,
       replace: (_match: string, token: string) => maskSecret(token),
+      shouldRun: (text) => text.includes('AKIA'),
     },
     {
       match: /\b(xox[baprs]-[A-Za-z0-9-]{10,})\b/g,
       replace: (_match: string, token: string) => maskSecret(token),
+      shouldRun: (text) => text.includes('xox'),
     },
     {
       match: /\b(AIza[0-9A-Za-z_-]{35})\b/g,
       replace: (_match: string, token: string) => maskSecret(token),
+      shouldRun: (text) => text.includes('AIza'),
     },
     {
       match: /\b(hf_[A-Za-z0-9]{20,})\b/g,
       replace: (_match: string, token: string) => maskSecret(token),
+      shouldRun: (text) => text.includes('hf_'),
     },
     {
       match: /\b(SG\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})\b/g,
       replace: (_match: string, token: string) => maskSecret(token),
+      shouldRun: (text) => text.includes('SG.'),
     },
   ]);
 
@@ -267,6 +296,7 @@ export const SECRET_REDACTION_PATTERNS: readonly SecretRedactionPattern[] =
     {
       match: /\b([A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,})\b/gi,
       replace: replaceEmail,
+      shouldRun: (text) => text.includes('@'),
     },
     {
       match:
@@ -281,15 +311,22 @@ export const SECRET_REDACTION_PATTERNS: readonly SecretRedactionPattern[] =
     {
       match: /\b(\d{3}-\d{2}-\d{4})\b/g,
       replace: replaceSsn,
+      shouldRun: (text) => text.includes('-'),
     },
     {
       match:
         /(?<!\w)((?:\+?1[\s.-]?)?(?:\(\d{3}\)|\d{3})[\s.-]\d{3}[\s.-]\d{4})(?!\w)/g,
       replace: replacePhone,
+      shouldRun: (text) =>
+        text.includes('(') ||
+        text.includes(' ') ||
+        text.includes('.') ||
+        text.includes('-'),
     },
     {
       match: /(?<!\w)(\+\d{1,3}(?:[\s./-]?\d){6,14})(?!\w)/g,
       replace: replacePhone,
+      shouldRun: (text) => text.includes('+'),
     },
     {
       match: /(?<!\w)(0\d{1,5}(?:[/\s.-]?\d){5,13})(?!\w)/g,
@@ -298,6 +335,7 @@ export const SECRET_REDACTION_PATTERNS: readonly SecretRedactionPattern[] =
     {
       match: /\b((?:\d[ -]?){13,19})\b/g,
       replace: replaceCreditCard,
+      shouldRun: containsDigit,
     },
   ]);
 
@@ -306,6 +344,9 @@ export function redactCredentialSecrets(text: string): string {
 
   let next = text;
   for (const pattern of CREDENTIAL_REDACTION_PATTERNS) {
+    // Guards run after earlier replacements, so each must remain a necessary
+    // match condition that prior patterns do not remove.
+    if (pattern.shouldRun && !pattern.shouldRun(next)) continue;
     next = next.replace(pattern.match, pattern.replace as never);
   }
   return next;
@@ -316,6 +357,9 @@ export function redactSecrets(text: string): string {
 
   let next = text;
   for (const pattern of SECRET_REDACTION_PATTERNS) {
+    // Guards run after earlier replacements, so each must remain a necessary
+    // match condition that prior patterns do not remove.
+    if (pattern.shouldRun && !pattern.shouldRun(next)) continue;
     next = next.replace(pattern.match, pattern.replace as never);
   }
   return next;

--- a/tests/ipc.test.ts
+++ b/tests/ipc.test.ts
@@ -193,7 +193,8 @@ test('readOutput does not time out when inactivity and wall-clock timeouts are d
     maxWallClockMs: null,
   });
 
-  await vi.advanceTimersByTimeAsync(500);
+  // Output appears at 500ms; adaptive polling may need one capped 250ms cycle.
+  await vi.advanceTimersByTimeAsync(750);
 
   await expect(outputPromise).resolves.toEqual(
     expect.objectContaining({

--- a/tests/redact.test.ts
+++ b/tests/redact.test.ts
@@ -92,6 +92,9 @@ test('masks bearer tokens and preserves short-token hard redaction', () => {
   expect(redactSecrets('Authorization: Bearer shorttoken')).toBe(
     'Authorization: Bearer ***',
   );
+  expect(redactSecrets('Authorization: bEaReR shorttoken')).toBe(
+    'Authorization: bEaReR ***',
+  );
   expect(
     redactSecrets('Authorization: Bearer 1234567890abcdefghijklmnopqrstuv'),
   ).toBe('Authorization: Bearer 123456...stuv');


### PR DESCRIPTION
## Summary

- replace fixed IPC polling delays with adaptive backoff for container input and gateway output waits
- add conservative pre-screen guards before redaction regex passes so clean text skips unnecessary scans
- update focused IPC and redaction tests for the changed timing and mixed-case bearer behavior


## Validation

- `./node_modules/.bin/vitest run tests/redact.test.ts tests/ipc.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `npm --prefix container run lint`