### PR TITLE
[codex] persist canonical agent identities

### DIFF
--- a/docs/content/developer-guide/identity.md
+++ b/docs/content/developer-guide/identity.md
@@ -96,8 +96,7 @@ display name, config value, or environment value.
 Agent registry records persist two canonical fields:
 
 - `canonicalId`: the stable `agent-slug@user@instance-id` identity for the agent
-- `ownerUserId`: the canonical `username@authority` owner user ID used when the
-  local identity is first derived
+- `ownerUserId`: the canonical `username@authority` owner user ID used when the local identity is first derived
 
 Existing local agents are backfilled on first database migration. Agents with no
 federated owner use the `local` user authority, so an owner like `benedikt`

--- a/docs/content/developer-guide/identity.md
+++ b/docs/content/developer-guide/identity.md
@@ -93,6 +93,17 @@ Use `parseAgentIdentity()` and `formatAgentIdentity()` from
 `slugifyAgentIdentityComponent()` when deriving a canonical component from a
 display name, config value, or environment value.
 
+Agent registry records persist two canonical fields:
+
+- `canonicalId`: the stable `agent-slug@user@instance-id` identity for the agent
+- `ownerUserId`: the canonical `username@authority` owner user ID used when the
+  local identity is first derived
+
+Existing local agents are backfilled on first database migration. Agents with no
+federated owner use the `local` user authority, so an owner like `benedikt`
+becomes `benedikt@local`. Bare local agent slugs remain accepted inside the same
+instance; A2A boundaries resolve them to the persisted `canonicalId`.
+
 ## A2A Envelope Federation Metadata
 
 A2A envelopes carry canonical `sender_agent_id` and `recipient_agent_id`

--- a/src/a2a/identity.ts
+++ b/src/a2a/identity.ts
@@ -5,6 +5,7 @@ import {
   parseAgentIdentity,
   resolveLocalInstanceId,
 } from '../identity/agent-id.js';
+import { logger } from '../logger.js';
 import {
   type A2AEnvelope,
   A2AEnvelopeValidationError,
@@ -31,6 +32,20 @@ function findLocalAgent(agentId: string): AgentConfig {
   ]);
 }
 
+function resolveLocalAgentOwnerFallback(agent: AgentConfig): string {
+  if (agent.owner) return agent.owner;
+  if (process.env.HYBRIDCLAW_USER_ID) return process.env.HYBRIDCLAW_USER_ID;
+
+  const osOwner = process.env.USER || process.env.LOGNAME || '';
+  if (osOwner) {
+    logger.warn(
+      { agentId: agent.id },
+      'Deriving transient local agent identity from OS user environment',
+    );
+  }
+  return osOwner;
+}
+
 export function resolveA2AAgentId(agentId: string): string {
   const normalized = agentId.trim();
   const kind = classifyA2AAgentId(normalized);
@@ -55,12 +70,7 @@ export function resolveA2AAgentId(agentId: string): string {
 
   return deriveLocalAgentIdentity({
     agentId: agent.id,
-    owner:
-      agent.owner ||
-      process.env.HYBRIDCLAW_USER_ID ||
-      process.env.USER ||
-      process.env.LOGNAME ||
-      '',
+    owner: resolveLocalAgentOwnerFallback(agent),
     ownerUserId: agent.ownerUserId,
     instanceId: resolveLocalInstanceId(),
   }).canonicalId;

--- a/src/a2a/identity.ts
+++ b/src/a2a/identity.ts
@@ -43,7 +43,14 @@ export function resolveA2AAgentId(agentId: string): string {
 
   const agent = findLocalAgent(normalized);
   if (agent.canonicalId) {
-    return parseAgentIdentity(agent.canonicalId).id;
+    try {
+      return parseAgentIdentity(agent.canonicalId).id;
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new A2AEnvelopeValidationError([
+        `canonical id for local agent ${agent.id} is invalid: ${detail}`,
+      ]);
+    }
   }
 
   return deriveLocalAgentIdentity({

--- a/src/a2a/identity.ts
+++ b/src/a2a/identity.ts
@@ -1,10 +1,9 @@
 import { findAgentConfig, listAgents } from '../agents/agent-registry.js';
-import { type AgentConfig, DEFAULT_AGENT_ID } from '../agents/agent-types.js';
+import type { AgentConfig } from '../agents/agent-types.js';
 import {
-  formatAgentIdentity,
+  deriveLocalAgentIdentity,
   parseAgentIdentity,
   resolveLocalInstanceId,
-  slugifyAgentIdentityComponent,
 } from '../identity/agent-id.js';
 import {
   type A2AEnvelope,
@@ -43,16 +42,21 @@ export function resolveA2AAgentId(agentId: string): string {
   }
 
   const agent = findLocalAgent(normalized);
-  const agentSlug = slugifyAgentIdentityComponent(agent.id, DEFAULT_AGENT_ID);
-  const userSlug = slugifyAgentIdentityComponent(
-    agent.owner ||
+  if (agent.canonicalId) {
+    return parseAgentIdentity(agent.canonicalId).id;
+  }
+
+  return deriveLocalAgentIdentity({
+    agentId: agent.id,
+    owner:
+      agent.owner ||
       process.env.HYBRIDCLAW_USER_ID ||
       process.env.USER ||
       process.env.LOGNAME ||
       '',
-    'local',
-  );
-  return formatAgentIdentity(agentSlug, userSlug, resolveLocalInstanceId());
+    ownerUserId: agent.ownerUserId,
+    instanceId: resolveLocalInstanceId(),
+  }).canonicalId;
 }
 
 export function resolveA2AEnvelopeAgentIds(envelope: unknown): A2AEnvelope {

--- a/src/agents/agent-registry.ts
+++ b/src/agents/agent-registry.ts
@@ -7,6 +7,7 @@ import {
   HYBRIDAI_MODEL,
 } from '../config/config.js';
 import { getRuntimeConfig } from '../config/runtime-config.js';
+import { deriveLocalAgentIdentity } from '../identity/agent-id.js';
 import { logger } from '../logger.js';
 import {
   deleteAgentWithTeamRevision as dbDeleteAgentWithTeamRevision,
@@ -159,6 +160,12 @@ function normalizeAgent(value: unknown): AgentConfig | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   const id = normalizeString((value as { id?: unknown }).id);
   if (!id) return null;
+  const canonicalId = normalizeString(
+    (value as { canonicalId?: unknown }).canonicalId,
+  );
+  const ownerUserId = normalizeString(
+    (value as { ownerUserId?: unknown }).ownerUserId,
+  );
   const name = normalizeString((value as { name?: unknown }).name);
   const displayName = normalizeString(
     (value as { displayName?: unknown }).displayName,
@@ -204,6 +211,8 @@ function normalizeAgent(value: unknown): AgentConfig | null {
   );
   return {
     id,
+    ...(canonicalId ? { canonicalId } : {}),
+    ...(ownerUserId ? { ownerUserId } : {}),
     ...(name ? { name } : {}),
     ...buildOptionalAgentPresentation(displayName, imageAsset),
     ...(model ? { model } : {}),
@@ -271,6 +280,8 @@ function fingerprintBudget(budget: AgentConfig['budget']): string {
 function fingerprintAgent(agent: AgentConfig): string {
   return [
     fingerprintString(agent.id),
+    fingerprintString(agent.canonicalId),
+    fingerprintString(agent.ownerUserId),
     fingerprintString(agent.name),
     fingerprintString(agent.displayName),
     fingerprintString(agent.imageAsset),
@@ -355,8 +366,15 @@ function applyDefaults(agent: AgentConfig): AgentConfig {
     agent.chatbotId ?? configuredDefaults.chatbotId,
   );
   const enableRag = agent.enableRag ?? configuredDefaults.enableRag;
+  const identity = deriveLocalAgentIdentity({
+    agentId: agent.id,
+    owner: agent.owner,
+    ownerUserId: agent.ownerUserId,
+  });
   return {
     id: agent.id,
+    canonicalId: agent.canonicalId ?? identity.canonicalId,
+    ownerUserId: agent.ownerUserId ?? identity.ownerUserId,
     ...(agent.name ? { name: agent.name } : {}),
     ...buildOptionalAgentPresentation(agent.displayName, agent.imageAsset),
     ...(model ? { model } : {}),
@@ -413,6 +431,8 @@ function rebuildRegistryFromDatabase(options?: { validate?: boolean }): void {
 function configuredAgentForDatabase(agent: AgentConfig): AgentConfig {
   return {
     id: agent.id,
+    canonicalId: agent.canonicalId,
+    ownerUserId: agent.ownerUserId,
     name: agent.name,
     displayName: agent.displayName,
     imageAsset: agent.imageAsset,

--- a/src/agents/agent-registry.ts
+++ b/src/agents/agent-registry.ts
@@ -39,6 +39,7 @@ import {
   normalizeAgentBudgetConfig,
   normalizeAgentCv,
   normalizeAgentEscalationTarget,
+  normalizeAgentIdentityFields,
   normalizeAgentWebSearchConfig,
   resolveSnakeCamelAlias,
   validateAgentOrgChart,
@@ -160,12 +161,15 @@ function normalizeAgent(value: unknown): AgentConfig | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   const id = normalizeString((value as { id?: unknown }).id);
   if (!id) return null;
-  const canonicalId = normalizeString(
-    (value as { canonicalId?: unknown }).canonicalId,
-  );
-  const ownerUserId = normalizeString(
-    (value as { ownerUserId?: unknown }).ownerUserId,
-  );
+  const identityFields = normalizeAgentIdentityFields({
+    canonicalId: normalizeString(
+      (value as { canonicalId?: unknown }).canonicalId,
+    ),
+    ownerUserId: normalizeString(
+      (value as { ownerUserId?: unknown }).ownerUserId,
+    ),
+    path: 'agents.list[]',
+  });
   const name = normalizeString((value as { name?: unknown }).name);
   const displayName = normalizeString(
     (value as { displayName?: unknown }).displayName,
@@ -211,8 +215,7 @@ function normalizeAgent(value: unknown): AgentConfig | null {
   );
   return {
     id,
-    ...(canonicalId ? { canonicalId } : {}),
-    ...(ownerUserId ? { ownerUserId } : {}),
+    ...identityFields,
     ...(name ? { name } : {}),
     ...buildOptionalAgentPresentation(displayName, imageAsset),
     ...(model ? { model } : {}),
@@ -366,15 +369,20 @@ function applyDefaults(agent: AgentConfig): AgentConfig {
     agent.chatbotId ?? configuredDefaults.chatbotId,
   );
   const enableRag = agent.enableRag ?? configuredDefaults.enableRag;
-  const identity = deriveLocalAgentIdentity({
-    agentId: agent.id,
-    owner: agent.owner,
-    ownerUserId: agent.ownerUserId,
-  });
+  const identity = agent.canonicalId
+    ? normalizeAgentIdentityFields({
+        canonicalId: agent.canonicalId,
+        ownerUserId: agent.ownerUserId,
+        path: 'agent',
+      })
+    : deriveLocalAgentIdentity({
+        agentId: agent.id,
+        owner: agent.owner,
+        ownerUserId: agent.ownerUserId,
+      });
   return {
     id: agent.id,
-    canonicalId: agent.canonicalId ?? identity.canonicalId,
-    ownerUserId: agent.ownerUserId ?? identity.ownerUserId,
+    ...identity,
     ...(agent.name ? { name: agent.name } : {}),
     ...buildOptionalAgentPresentation(agent.displayName, agent.imageAsset),
     ...(model ? { model } : {}),

--- a/src/agents/agent-types.ts
+++ b/src/agents/agent-types.ts
@@ -51,6 +51,8 @@ export interface AgentBudgetConfig {
 
 export interface AgentConfig {
   id: string;
+  canonicalId?: string;
+  ownerUserId?: string;
   name?: string;
   displayName?: string;
   imageAsset?: string;

--- a/src/agents/agent-types.ts
+++ b/src/agents/agent-types.ts
@@ -1,3 +1,5 @@
+import { parseAgentIdentity } from '../identity/agent-id.js';
+import { parseUserId } from '../identity/user-id.js';
 import {
   parseSecretRefInput,
   type SecretRef,
@@ -83,6 +85,55 @@ export interface AgentsConfig {
   defaultAgentId?: string;
   defaults?: AgentDefaultsConfig;
   list?: AgentConfig[];
+}
+
+export function normalizeAgentIdentityFields(params: {
+  canonicalId?: string;
+  ownerUserId?: string;
+  path: string;
+}): Pick<AgentConfig, 'canonicalId' | 'ownerUserId'> {
+  let canonicalId = '';
+  let canonicalUserSlug = '';
+  const rawCanonicalId = params.canonicalId?.trim() || '';
+  if (rawCanonicalId) {
+    try {
+      const parsed = parseAgentIdentity(rawCanonicalId);
+      canonicalId = parsed.id;
+      canonicalUserSlug = parsed.userSlug;
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(`${params.path}.canonicalId is invalid: ${detail}`);
+    }
+  }
+
+  let ownerUserId = '';
+  let ownerUsername = '';
+  const rawOwnerUserId = params.ownerUserId?.trim() || '';
+  if (rawOwnerUserId) {
+    try {
+      const parsed = parseUserId(rawOwnerUserId);
+      ownerUserId = parsed.id;
+      ownerUsername = parsed.username;
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(`${params.path}.ownerUserId is invalid: ${detail}`);
+    }
+  }
+
+  if (
+    canonicalUserSlug &&
+    ownerUsername &&
+    canonicalUserSlug !== ownerUsername
+  ) {
+    throw new Error(
+      `${params.path}.ownerUserId username must match ${params.path}.canonicalId user slug`,
+    );
+  }
+
+  return {
+    ...(canonicalId ? { canonicalId } : {}),
+    ...(ownerUserId ? { ownerUserId } : {}),
+  };
 }
 
 export function buildOptionalAgentPresentation(

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -22,6 +22,7 @@ import {
   normalizeAgentBudgetConfig,
   normalizeAgentCv,
   normalizeAgentEscalationTarget,
+  normalizeAgentIdentityFields,
   normalizeAgentWebSearchConfig,
   resolveSnakeCamelAlias,
   validateAgentOrgChart,
@@ -2673,20 +2674,23 @@ function normalizeAgentConfig(
     allowEmpty: false,
   });
   if (!id) return null;
-  const canonicalId = normalizeString(
-    value.canonicalId,
-    fallback?.canonicalId ?? '',
-    {
-      allowEmpty: true,
-    },
-  );
-  const ownerUserId = normalizeString(
-    value.ownerUserId,
-    fallback?.ownerUserId ?? '',
-    {
-      allowEmpty: true,
-    },
-  );
+  const identityFields = normalizeAgentIdentityFields({
+    canonicalId: normalizeString(
+      value.canonicalId,
+      fallback?.canonicalId ?? '',
+      {
+        allowEmpty: true,
+      },
+    ),
+    ownerUserId: normalizeString(
+      value.ownerUserId,
+      fallback?.ownerUserId ?? '',
+      {
+        allowEmpty: true,
+      },
+    ),
+    path: 'agents.list[]',
+  });
   const name = normalizeString(value.name, fallback?.name ?? '', {
     allowEmpty: true,
   });
@@ -2776,8 +2780,7 @@ function normalizeAgentConfig(
     : cloneAgentBudgetConfig(fallback?.budget);
   return {
     id,
-    ...(canonicalId ? { canonicalId } : {}),
-    ...(ownerUserId ? { ownerUserId } : {}),
+    ...identityFields,
     ...(name ? { name } : {}),
     ...buildOptionalAgentPresentation(displayName, imageAsset),
     ...(model ? { model } : {}),

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -2673,6 +2673,20 @@ function normalizeAgentConfig(
     allowEmpty: false,
   });
   if (!id) return null;
+  const canonicalId = normalizeString(
+    value.canonicalId,
+    fallback?.canonicalId ?? '',
+    {
+      allowEmpty: true,
+    },
+  );
+  const ownerUserId = normalizeString(
+    value.ownerUserId,
+    fallback?.ownerUserId ?? '',
+    {
+      allowEmpty: true,
+    },
+  );
   const name = normalizeString(value.name, fallback?.name ?? '', {
     allowEmpty: true,
   });
@@ -2762,6 +2776,8 @@ function normalizeAgentConfig(
     : cloneAgentBudgetConfig(fallback?.budget);
   return {
     id,
+    ...(canonicalId ? { canonicalId } : {}),
+    ...(ownerUserId ? { ownerUserId } : {}),
     ...(name ? { name } : {}),
     ...buildOptionalAgentPresentation(displayName, imageAsset),
     ...(model ? { model } : {}),

--- a/src/identity/agent-id.ts
+++ b/src/identity/agent-id.ts
@@ -3,6 +3,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+import {
+  formatUserId,
+  parseUserId,
+  USER_ID_LOCAL_AUTHORITY,
+} from './user-id.js';
 
 export const AGENT_IDENTITY_COMPONENT_MAX_LENGTH = 128;
 export const LOCAL_INSTANCE_ID_PREFIX = 'inst-';
@@ -20,6 +25,11 @@ export interface ParsedAgentIdentity {
 export interface LocalInstanceIdState {
   readonly currentInstanceId: string;
   readonly allocatedAt: string;
+}
+
+export interface LocalAgentIdentity {
+  readonly canonicalId: string;
+  readonly ownerUserId: string;
 }
 
 export interface ResolveLocalInstanceIdOptions {
@@ -154,6 +164,41 @@ export function slugifyAgentIdentityComponent(
     return normalized;
   }
   return fallback;
+}
+
+export function formatLocalOwnerUserId(owner: string | undefined): string {
+  const normalizedOwner = owner?.trim() || '';
+  if (normalizedOwner.includes('@')) {
+    try {
+      return parseUserId(normalizedOwner).id;
+    } catch {
+      // Fall through to local slug derivation for display names or emails.
+    }
+  }
+
+  return formatUserId(
+    slugifyAgentIdentityComponent(normalizedOwner, USER_ID_LOCAL_AUTHORITY),
+    USER_ID_LOCAL_AUTHORITY,
+  );
+}
+
+export function deriveLocalAgentIdentity(params: {
+  readonly agentId: string;
+  readonly owner?: string;
+  readonly ownerUserId?: string;
+  readonly instanceId?: string;
+}): LocalAgentIdentity {
+  const ownerUserId =
+    params.ownerUserId?.trim() || formatLocalOwnerUserId(params.owner);
+  const ownerUser = parseUserId(ownerUserId);
+  return {
+    ownerUserId: ownerUser.id,
+    canonicalId: formatAgentIdentity(
+      slugifyAgentIdentityComponent(params.agentId, 'agent'),
+      ownerUser.username,
+      params.instanceId ?? resolveLocalInstanceId(),
+    ),
+  };
 }
 
 export function localInstanceIdStatePath(): string {

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -36,6 +36,7 @@ import {
   AGENT_IDENTITY_COMPONENT_MAX_LENGTH,
   deriveLocalAgentIdentity,
   formatAgentIdentity,
+  formatLocalOwnerUserId,
   parseAgentIdentity,
 } from '../identity/agent-id.js';
 import { parseUserId } from '../identity/user-id.js';
@@ -148,6 +149,8 @@ let usageEventBatchInsertStatement: Database.Statement | null = null;
 const usageRecordSubscribers = new Set<UsageRecordSubscriber>();
 
 export const DATABASE_SCHEMA_VERSION = 36;
+const AGENT_CANONICAL_ID_COLLISION_LIMIT = 20;
+const DEFAULT_LOCAL_OWNER_USER_ID = formatLocalOwnerUserId('');
 const STRUCTURED_AUDIT_SESSION_LIMIT = 10_000;
 const RECENT_CHAT_MESSAGE_SEARCH_TABLE = 'recent_chat_message_search';
 const RECENT_CHAT_MESSAGE_SEARCH_INSERT_TRIGGER =
@@ -2547,8 +2550,12 @@ function backfillAgentCanonicalIdentities(database: Database.Database): void {
   for (const row of rows) {
     const existingCanonicalId = normalizeStoredCanonicalAgentId(
       row.canonical_id,
+      row.id,
     );
-    const existingOwnerUserId = normalizeStoredOwnerUserId(row.owner_user_id);
+    const existingOwnerUserId = normalizeStoredOwnerUserId(
+      row.owner_user_id,
+      row.id,
+    );
     if (existingCanonicalId && existingOwnerUserId) continue;
 
     const identity = allocateCanonicalAgentIdentity({
@@ -2958,49 +2965,69 @@ function parseAgentA2AConfig(rawConfig: string | null): AgentConfig['a2a'] {
   }
 }
 
-function normalizeStoredCanonicalAgentId(value: string | null): string {
+function normalizeStoredIdentityField(
+  value: string | null,
+  parseIdentity: (normalized: string) => { id: string },
+  params: {
+    agentId: string;
+    lengthKey: string;
+    warning: string;
+  },
+): string {
   const normalized = value?.trim() || '';
   if (!normalized) return '';
   try {
-    return parseAgentIdentity(normalized).id;
+    return parseIdentity(normalized).id;
   } catch {
     logger.warn(
-      { canonicalIdLength: normalized.length },
-      'Ignoring invalid persisted canonical agent identity',
+      { agentId: params.agentId, [params.lengthKey]: normalized.length },
+      params.warning,
     );
     return '';
   }
 }
 
-function normalizeStoredOwnerUserId(value: string | null): string {
-  const normalized = value?.trim() || '';
-  if (!normalized) return '';
-  try {
-    return parseUserId(normalized).id;
-  } catch {
-    logger.warn(
-      { ownerUserIdLength: normalized.length },
-      'Ignoring invalid persisted agent owner user id',
-    );
-    return '';
-  }
+function normalizeStoredCanonicalAgentId(
+  value: string | null,
+  agentId: string,
+): string {
+  return normalizeStoredIdentityField(value, parseAgentIdentity, {
+    agentId,
+    lengthKey: 'canonicalIdLength',
+    warning: 'Ignoring invalid persisted canonical agent identity',
+  });
+}
+
+function normalizeStoredOwnerUserId(
+  value: string | null,
+  agentId: string,
+): string {
+  return normalizeStoredIdentityField(value, parseUserId, {
+    agentId,
+    lengthKey: 'ownerUserIdLength',
+    warning: 'Ignoring invalid persisted agent owner user id',
+  });
+}
+
+function prepareCanonicalAgentIdentityConflictStatement(
+  database: Database.Database,
+): Database.Statement | null {
+  if (!tableExists(database, 'agents')) return null;
+  if (!columnExists(database, 'agents', 'canonical_id')) return null;
+  return database.prepare(
+    `SELECT id
+     FROM agents
+     WHERE canonical_id = ? AND id != ?
+     LIMIT 1`,
+  );
 }
 
 function canonicalAgentIdentityExists(
-  database: Database.Database,
+  statement: Database.Statement,
   canonicalId: string,
   agentId: string,
 ): boolean {
-  if (!tableExists(database, 'agents')) return false;
-  if (!columnExists(database, 'agents', 'canonical_id')) return false;
-  const row = database
-    .prepare(
-      `SELECT id
-       FROM agents
-       WHERE canonical_id = ? AND id != ?
-       LIMIT 1`,
-    )
-    .get(canonicalId, agentId) as { id: string } | undefined;
+  const row = statement.get(canonicalId, agentId) as { id: string } | undefined;
   return Boolean(row);
 }
 
@@ -3026,6 +3053,16 @@ function ownerUserIdMatchesCanonicalAgentId(
   }
 }
 
+function isDefaultPlaceholderIdentity(
+  agent: AgentConfig | null | undefined,
+): boolean {
+  return (
+    Boolean(agent) &&
+    !agent?.owner &&
+    agent?.ownerUserId === DEFAULT_LOCAL_OWNER_USER_ID
+  );
+}
+
 function allocateCanonicalAgentIdentity(params: {
   database: Database.Database;
   agentId: string;
@@ -3037,9 +3074,13 @@ function allocateCanonicalAgentIdentity(params: {
     owner: params.owner ?? undefined,
     ownerUserId: params.ownerUserId ?? undefined,
   });
+  const conflictStatement = prepareCanonicalAgentIdentityConflictStatement(
+    params.database,
+  );
+  if (!conflictStatement) return identity;
   if (
     !canonicalAgentIdentityExists(
-      params.database,
+      conflictStatement,
       identity.canonicalId,
       params.agentId,
     )
@@ -3048,7 +3089,7 @@ function allocateCanonicalAgentIdentity(params: {
   }
 
   const parsed = parseAgentIdentity(identity.canonicalId);
-  for (let index = 2; index <= 1000; index += 1) {
+  for (let index = 2; index <= AGENT_CANONICAL_ID_COLLISION_LIMIT; index += 1) {
     const canonicalId = formatAgentIdentity(
       addCollisionSuffixToAgentSlug(parsed.agentSlug, index),
       parsed.userSlug,
@@ -3056,7 +3097,7 @@ function allocateCanonicalAgentIdentity(params: {
     );
     if (
       !canonicalAgentIdentityExists(
-        params.database,
+        conflictStatement,
         canonicalId,
         params.agentId,
       )
@@ -3074,8 +3115,8 @@ function allocateCanonicalAgentIdentity(params: {
 }
 
 function mapAgentRow(row: AgentRow): AgentConfig {
-  const canonicalId = normalizeStoredCanonicalAgentId(row.canonical_id);
-  const ownerUserId = normalizeStoredOwnerUserId(row.owner_user_id);
+  const canonicalId = normalizeStoredCanonicalAgentId(row.canonical_id, row.id);
+  const ownerUserId = normalizeStoredOwnerUserId(row.owner_user_id, row.id);
   const name = row.name?.trim() || '';
   const displayName = row.display_name?.trim() || '';
   const imageAsset = row.image_asset?.trim() || '';
@@ -3174,12 +3215,10 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
   const explicitOwnerUserId = explicitIdentity.ownerUserId || '';
   const explicitCanonicalId = explicitIdentity.canonicalId || '';
   const shouldReplaceDefaultIdentity =
-    Boolean(existingAgent) &&
     !explicitOwnerUserId &&
     !explicitCanonicalId &&
-    !existingAgent?.owner &&
     Boolean(normalizedOwner) &&
-    existingAgent?.ownerUserId === 'local@local';
+    isDefaultPlaceholderIdentity(existingAgent);
   const existingOwnerUserId = shouldReplaceDefaultIdentity
     ? undefined
     : existingAgent?.ownerUserId;
@@ -3207,11 +3246,7 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
       });
   const canonicalId =
     explicitCanonicalId || existingCanonicalId || identity?.canonicalId || null;
-  const ownerUserId =
-    normalizedOwnerUserId ||
-    identity?.ownerUserId ||
-    compatibleExistingOwnerUserId ||
-    null;
+  const ownerUserId = normalizedOwnerUserId || identity?.ownerUserId || null;
   const enableRag =
     typeof agent.enableRag === 'boolean' ? (agent.enableRag ? 1 : 0) : null;
   db.prepare(

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -31,6 +31,13 @@ import {
   runtimeConfigRevisionStorePath,
   syncRuntimeAssetRevisionStateInOpenDatabase,
 } from '../config/runtime-config-revisions.js';
+import {
+  AGENT_IDENTITY_COMPONENT_MAX_LENGTH,
+  deriveLocalAgentIdentity,
+  formatAgentIdentity,
+  parseAgentIdentity,
+} from '../identity/agent-id.js';
+import { parseUserId } from '../identity/user-id.js';
 import { logger } from '../logger.js';
 import { MODEL_METADATA_USD_TO_EUR } from '../providers/model-metadata.js';
 import { DEFAULT_RESOURCE_HYGIENE_SCHEDULER_JOB } from '../scheduler/system-jobs.js';
@@ -139,7 +146,7 @@ let databaseInitialized = false;
 let usageEventBatchInsertStatement: Database.Statement | null = null;
 const usageRecordSubscribers = new Set<UsageRecordSubscriber>();
 
-export const DATABASE_SCHEMA_VERSION = 35;
+export const DATABASE_SCHEMA_VERSION = 36;
 const STRUCTURED_AUDIT_SESSION_LIMIT = 10_000;
 const RECENT_CHAT_MESSAGE_SEARCH_TABLE = 'recent_chat_message_search';
 const RECENT_CHAT_MESSAGE_SEARCH_INSERT_TRIGGER =
@@ -181,6 +188,8 @@ interface ColumnInfoRow {
 
 type AgentRow = {
   id: AgentConfig['id'];
+  canonical_id: string | null;
+  owner_user_id: string | null;
   name: string | null;
   display_name: string | null;
   image_asset: string | null;
@@ -2508,6 +2517,100 @@ function migrateV35(
   recordMigration(database, 35, 'Persist non-token billable usage units');
 }
 
+function backfillAgentCanonicalIdentities(database: Database.Database): void {
+  if (!tableExists(database, 'agents')) return;
+  if (!columnExists(database, 'agents', 'canonical_id')) return;
+  if (!columnExists(database, 'agents', 'owner_user_id')) return;
+
+  const ownerSelect = columnExists(database, 'agents', 'owner')
+    ? 'owner'
+    : 'NULL AS owner';
+  const rows = database
+    .prepare(
+      `SELECT id, ${ownerSelect}, canonical_id, owner_user_id
+       FROM agents
+       ORDER BY CASE WHEN id = ? THEN 0 ELSE 1 END, id ASC`,
+    )
+    .all(DEFAULT_AGENT_ID) as Array<{
+    id: string;
+    owner: string | null;
+    canonical_id: string | null;
+    owner_user_id: string | null;
+  }>;
+
+  const update = database.prepare(
+    `UPDATE agents
+     SET canonical_id = ?, owner_user_id = ?, updated_at = datetime('now')
+     WHERE id = ?`,
+  );
+  for (const row of rows) {
+    const existingCanonicalId = normalizeStoredCanonicalAgentId(
+      row.canonical_id,
+    );
+    const existingOwnerUserId = normalizeStoredOwnerUserId(row.owner_user_id);
+    if (existingCanonicalId && existingOwnerUserId) continue;
+
+    const identity = allocateCanonicalAgentIdentity({
+      database,
+      agentId: row.id,
+      owner: row.owner,
+      ownerUserId: existingOwnerUserId || undefined,
+    });
+    update.run(
+      existingCanonicalId || identity.canonicalId,
+      existingOwnerUserId || identity.ownerUserId,
+      row.id,
+    );
+  }
+}
+
+function agentCanonicalIdentityNeedMigration(
+  database: Database.Database,
+): boolean {
+  return (
+    tableExists(database, 'agents') &&
+    (!columnExists(database, 'agents', 'canonical_id') ||
+      !columnExists(database, 'agents', 'owner_user_id') ||
+      !indexExists(database, 'idx_agents_canonical_id'))
+  );
+}
+
+function migrateV36(
+  database: Database.Database,
+  opts?: InitDatabaseOptions,
+): void {
+  const quiet = opts?.quiet === true;
+  addColumnIfMissing({
+    database,
+    table: 'agents',
+    column: 'canonical_id',
+    ddl: 'canonical_id TEXT',
+    quiet,
+  });
+  addColumnIfMissing({
+    database,
+    table: 'agents',
+    column: 'owner_user_id',
+    ddl: 'owner_user_id TEXT',
+    quiet,
+  });
+  backfillAgentCanonicalIdentities(database);
+  if (tableExists(database, 'agents')) {
+    database.exec(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_agents_canonical_id
+        ON agents(canonical_id)
+        WHERE canonical_id IS NOT NULL AND TRIM(canonical_id) != '';
+      CREATE INDEX IF NOT EXISTS idx_agents_owner_user_id
+        ON agents(owner_user_id);
+    `);
+  }
+  recordMigration(
+    database,
+    36,
+    'Persist canonical local agent and owner user identities',
+  );
+}
+
 function runMigrations(
   database: Database.Database,
   opts?: InitDatabaseOptions,
@@ -2589,6 +2692,9 @@ function runMigrations(
   }
   if (currentVersion < 34) migrateV34(database);
   if (currentVersion < 35) migrateV35(database, opts);
+  if (currentVersion < 36 || agentCanonicalIdentityNeedMigration(database)) {
+    migrateV36(database, opts);
+  }
 
   setSchemaVersion(database, DATABASE_SCHEMA_VERSION);
   if (!quiet && currentVersion < DATABASE_SCHEMA_VERSION) {
@@ -2850,7 +2956,107 @@ function parseAgentA2AConfig(rawConfig: string | null): AgentConfig['a2a'] {
   }
 }
 
+function normalizeStoredCanonicalAgentId(value: string | null): string {
+  const normalized = value?.trim() || '';
+  if (!normalized) return '';
+  try {
+    return parseAgentIdentity(normalized).id;
+  } catch {
+    logger.warn(
+      { canonicalIdLength: normalized.length },
+      'Ignoring invalid persisted canonical agent identity',
+    );
+    return '';
+  }
+}
+
+function normalizeStoredOwnerUserId(value: string | null): string {
+  const normalized = value?.trim() || '';
+  if (!normalized) return '';
+  try {
+    return parseUserId(normalized).id;
+  } catch {
+    logger.warn(
+      { ownerUserIdLength: normalized.length },
+      'Ignoring invalid persisted agent owner user id',
+    );
+    return '';
+  }
+}
+
+function canonicalAgentIdentityExists(
+  database: Database.Database,
+  canonicalId: string,
+  agentId: string,
+): boolean {
+  if (!tableExists(database, 'agents')) return false;
+  if (!columnExists(database, 'agents', 'canonical_id')) return false;
+  const row = database
+    .prepare(
+      `SELECT id
+       FROM agents
+       WHERE canonical_id = ? AND id != ?
+       LIMIT 1`,
+    )
+    .get(canonicalId, agentId) as { id: string } | undefined;
+  return Boolean(row);
+}
+
+function addCollisionSuffixToAgentSlug(slug: string, index: number): string {
+  const suffix = `-${index}`;
+  return `${slug.slice(0, AGENT_IDENTITY_COMPONENT_MAX_LENGTH - suffix.length)}${suffix}`;
+}
+
+function allocateCanonicalAgentIdentity(params: {
+  database: Database.Database;
+  agentId: string;
+  owner?: string | null;
+  ownerUserId?: string | null;
+}): { canonicalId: string; ownerUserId: string } {
+  const identity = deriveLocalAgentIdentity({
+    agentId: params.agentId,
+    owner: params.owner ?? undefined,
+    ownerUserId: params.ownerUserId ?? undefined,
+  });
+  if (
+    !canonicalAgentIdentityExists(
+      params.database,
+      identity.canonicalId,
+      params.agentId,
+    )
+  ) {
+    return identity;
+  }
+
+  const parsed = parseAgentIdentity(identity.canonicalId);
+  for (let index = 2; index <= 1000; index += 1) {
+    const canonicalId = formatAgentIdentity(
+      addCollisionSuffixToAgentSlug(parsed.agentSlug, index),
+      parsed.userSlug,
+      parsed.instanceId,
+    );
+    if (
+      !canonicalAgentIdentityExists(
+        params.database,
+        canonicalId,
+        params.agentId,
+      )
+    ) {
+      return {
+        canonicalId,
+        ownerUserId: identity.ownerUserId,
+      };
+    }
+  }
+
+  throw new Error(
+    `Could not allocate a unique canonical agent identity for ${params.agentId}.`,
+  );
+}
+
 function mapAgentRow(row: AgentRow): AgentConfig {
+  const canonicalId = normalizeStoredCanonicalAgentId(row.canonical_id);
+  const ownerUserId = normalizeStoredOwnerUserId(row.owner_user_id);
   const name = row.name?.trim() || '';
   const displayName = row.display_name?.trim() || '';
   const imageAsset = row.image_asset?.trim() || '';
@@ -2868,6 +3074,8 @@ function mapAgentRow(row: AgentRow): AgentConfig {
   const a2a = parseAgentA2AConfig(row.a2a);
   return {
     id: row.id,
+    ...(canonicalId ? { canonicalId } : {}),
+    ...(ownerUserId ? { ownerUserId } : {}),
     ...(name ? { name } : {}),
     ...(displayName ? { displayName } : {}),
     ...(imageAsset ? { imageAsset } : {}),
@@ -2890,7 +3098,7 @@ function mapAgentRow(row: AgentRow): AgentConfig {
 }
 
 const AGENT_SELECT_COLUMNS =
-  'id, name, display_name, image_asset, model, skills, chatbot_id, enable_rag, workspace, owner, role, reports_to, delegates_to, peers, cv, escalation_target, a2a, created_at, updated_at';
+  'id, canonical_id, owner_user_id, name, display_name, image_asset, model, skills, chatbot_id, enable_rag, workspace, owner, role, reports_to, delegates_to, peers, cv, escalation_target, a2a, created_at, updated_at';
 
 export function getAgentById(agentId: string): AgentConfig | null {
   const normalizedAgentId = agentId.trim();
@@ -2921,6 +3129,7 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
   if (!normalizedId) {
     throw new Error('Agent id is required.');
   }
+  const existingAgent = getAgentById(normalizedId);
   const normalizedName = agent.name?.trim() || null;
   const normalizedDisplayName = agent.displayName?.trim() || null;
   const normalizedImageAsset = agent.imageAsset?.trim() || null;
@@ -2938,11 +3147,50 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
     agent.escalationTarget,
   );
   const normalizedA2A = serializeAgentA2AConfig(agent.a2a);
+  const explicitOwnerUserId = agent.ownerUserId?.trim()
+    ? parseUserId(agent.ownerUserId).id
+    : '';
+  const explicitCanonicalId = agent.canonicalId?.trim()
+    ? parseAgentIdentity(agent.canonicalId).id
+    : '';
+  const shouldReplaceDefaultIdentity =
+    Boolean(existingAgent) &&
+    !explicitOwnerUserId &&
+    !explicitCanonicalId &&
+    !existingAgent?.owner &&
+    Boolean(normalizedOwner) &&
+    existingAgent?.ownerUserId === 'local@local';
+  const existingOwnerUserId = shouldReplaceDefaultIdentity
+    ? undefined
+    : existingAgent?.ownerUserId;
+  const existingCanonicalId = shouldReplaceDefaultIdentity
+    ? undefined
+    : existingAgent?.canonicalId;
+  const normalizedOwnerUserId =
+    explicitOwnerUserId || existingOwnerUserId || null;
+  const identity =
+    explicitCanonicalId && normalizedOwnerUserId
+      ? null
+      : allocateCanonicalAgentIdentity({
+          database: db,
+          agentId: normalizedId,
+          owner: normalizedOwner,
+          ownerUserId: normalizedOwnerUserId,
+        });
+  const canonicalId =
+    explicitCanonicalId || existingCanonicalId || identity?.canonicalId || null;
+  const ownerUserId =
+    normalizedOwnerUserId ||
+    identity?.ownerUserId ||
+    existingOwnerUserId ||
+    null;
   const enableRag =
     typeof agent.enableRag === 'boolean' ? (agent.enableRag ? 1 : 0) : null;
   db.prepare(
     `INSERT INTO agents (
        id,
+       canonical_id,
+       owner_user_id,
        name,
        display_name,
        image_asset,
@@ -2961,8 +3209,10 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
        a2a,
        created_at,
        updated_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
      ON CONFLICT(id) DO UPDATE SET
+       canonical_id = excluded.canonical_id,
+       owner_user_id = excluded.owner_user_id,
        name = excluded.name,
        display_name = excluded.display_name,
        image_asset = excluded.image_asset,
@@ -2982,6 +3232,8 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
        updated_at = datetime('now')`,
   ).run(
     normalizedId,
+    canonicalId,
+    ownerUserId,
     normalizedName,
     normalizedDisplayName,
     normalizedImageAsset,

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -2547,6 +2547,8 @@ function backfillAgentCanonicalIdentities(database: Database.Database): void {
      SET canonical_id = ?, owner_user_id = ?, updated_at = datetime('now')
      WHERE id = ?`,
   );
+  const conflictStatement =
+    prepareCanonicalAgentIdentityConflictStatement(database);
   for (const row of rows) {
     const existingCanonicalId = normalizeStoredCanonicalAgentId(
       row.canonical_id,
@@ -2560,6 +2562,7 @@ function backfillAgentCanonicalIdentities(database: Database.Database): void {
 
     const identity = allocateCanonicalAgentIdentity({
       database,
+      conflictStatement,
       agentId: row.id,
       owner: row.owner,
       ownerUserId: existingOwnerUserId || undefined,
@@ -3065,6 +3068,7 @@ function isDefaultPlaceholderIdentity(
 
 function allocateCanonicalAgentIdentity(params: {
   database: Database.Database;
+  conflictStatement?: Database.Statement | null;
   agentId: string;
   owner?: string | null;
   ownerUserId?: string | null;
@@ -3074,9 +3078,9 @@ function allocateCanonicalAgentIdentity(params: {
     owner: params.owner ?? undefined,
     ownerUserId: params.ownerUserId ?? undefined,
   });
-  const conflictStatement = prepareCanonicalAgentIdentityConflictStatement(
-    params.database,
-  );
+  const conflictStatement =
+    params.conflictStatement ??
+    prepareCanonicalAgentIdentityConflictStatement(params.database);
   if (!conflictStatement) return identity;
   if (
     !canonicalAgentIdentityExists(

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -12,6 +12,7 @@ import {
   normalizeAgentA2AConfig,
   normalizeAgentCv,
   normalizeAgentEscalationTarget,
+  normalizeAgentIdentityFields,
   validateAgentOrgChart,
 } from '../agents/agent-types.js';
 import {
@@ -2571,7 +2572,8 @@ function agentCanonicalIdentityNeedMigration(
     tableExists(database, 'agents') &&
     (!columnExists(database, 'agents', 'canonical_id') ||
       !columnExists(database, 'agents', 'owner_user_id') ||
-      !indexExists(database, 'idx_agents_canonical_id'))
+      !indexExists(database, 'idx_agents_canonical_id') ||
+      !indexExists(database, 'idx_agents_owner_user_id'))
   );
 }
 
@@ -3007,6 +3009,23 @@ function addCollisionSuffixToAgentSlug(slug: string, index: number): string {
   return `${slug.slice(0, AGENT_IDENTITY_COMPONENT_MAX_LENGTH - suffix.length)}${suffix}`;
 }
 
+function ownerUserIdMatchesCanonicalAgentId(
+  canonicalId: string,
+  ownerUserId: string | undefined,
+): boolean {
+  if (!ownerUserId) return false;
+  try {
+    normalizeAgentIdentityFields({
+      canonicalId,
+      ownerUserId,
+      path: 'agents',
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function allocateCanonicalAgentIdentity(params: {
   database: Database.Database;
   agentId: string;
@@ -3147,12 +3166,13 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
     agent.escalationTarget,
   );
   const normalizedA2A = serializeAgentA2AConfig(agent.a2a);
-  const explicitOwnerUserId = agent.ownerUserId?.trim()
-    ? parseUserId(agent.ownerUserId).id
-    : '';
-  const explicitCanonicalId = agent.canonicalId?.trim()
-    ? parseAgentIdentity(agent.canonicalId).id
-    : '';
+  const explicitIdentity = normalizeAgentIdentityFields({
+    canonicalId: agent.canonicalId,
+    ownerUserId: agent.ownerUserId,
+    path: 'agents',
+  });
+  const explicitOwnerUserId = explicitIdentity.ownerUserId || '';
+  const explicitCanonicalId = explicitIdentity.canonicalId || '';
   const shouldReplaceDefaultIdentity =
     Boolean(existingAgent) &&
     !explicitOwnerUserId &&
@@ -3166,23 +3186,31 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
   const existingCanonicalId = shouldReplaceDefaultIdentity
     ? undefined
     : existingAgent?.canonicalId;
+  const compatibleExistingOwnerUserId =
+    explicitCanonicalId && !explicitOwnerUserId
+      ? ownerUserIdMatchesCanonicalAgentId(
+          explicitCanonicalId,
+          existingOwnerUserId,
+        )
+        ? existingOwnerUserId
+        : undefined
+      : existingOwnerUserId;
   const normalizedOwnerUserId =
-    explicitOwnerUserId || existingOwnerUserId || null;
-  const identity =
-    explicitCanonicalId && normalizedOwnerUserId
-      ? null
-      : allocateCanonicalAgentIdentity({
-          database: db,
-          agentId: normalizedId,
-          owner: normalizedOwner,
-          ownerUserId: normalizedOwnerUserId,
-        });
+    explicitOwnerUserId || compatibleExistingOwnerUserId || null;
+  const identity = explicitCanonicalId
+    ? null
+    : allocateCanonicalAgentIdentity({
+        database: db,
+        agentId: normalizedId,
+        owner: normalizedOwner,
+        ownerUserId: normalizedOwnerUserId,
+      });
   const canonicalId =
     explicitCanonicalId || existingCanonicalId || identity?.canonicalId || null;
   const ownerUserId =
     normalizedOwnerUserId ||
     identity?.ownerUserId ||
-    existingOwnerUserId ||
+    compatibleExistingOwnerUserId ||
     null;
   const enableRag =
     typeof agent.enableRag === 'boolean' ? (agent.enableRag ? 1 : 0) : null;

--- a/tests/agent-id.test.ts
+++ b/tests/agent-id.test.ts
@@ -6,8 +6,10 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import {
   AgentIdentityValidationError,
+  deriveLocalAgentIdentity,
   formatAgentIdentity,
   formatLocalInstanceIdFromUuid,
+  formatLocalOwnerUserId,
   isAgentIdentityComponent,
   isCanonicalAgentIdentity,
   parseAgentIdentity,
@@ -107,6 +109,25 @@ describe('canonical agent identities', () => {
       'user',
     );
     expect(slugifyAgentIdentityComponent(' !!! ', 'local')).toBe('local');
+  });
+
+  test('derives local owner user ids with the local authority by default', () => {
+    expect(formatLocalOwnerUserId(' Benedikt ')).toBe('benedikt@local');
+    expect(formatLocalOwnerUserId('Ada@HybridAI')).toBe('ada@hybridai');
+    expect(formatLocalOwnerUserId('')).toBe('local@local');
+  });
+
+  test('derives local agent identities from agent id, owner, and instance id', () => {
+    expect(
+      deriveLocalAgentIdentity({
+        agentId: 'Research Agent',
+        owner: 'Benedikt',
+        instanceId: 'inst-test',
+      }),
+    ).toEqual({
+      canonicalId: 'research-agent@benedikt@inst-test',
+      ownerUserId: 'benedikt@local',
+    });
   });
 });
 

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -412,6 +412,53 @@ test('agent registry persists canonical local identities and keeps bare slug A2A
   });
 });
 
+test('agent registry validates explicit canonical identity fields', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  process.env.HYBRIDCLAW_INSTANCE_ID = 'Inst Test';
+  vi.resetModules();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { updateRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  const { initAgentRegistry, resolveAgentConfig } = await import(
+    '../src/agents/agent-registry.ts'
+  );
+
+  initDatabase({ quiet: true });
+
+  expect(() =>
+    updateRuntimeConfig((draft) => {
+      draft.agents.list = [
+        {
+          id: 'writer',
+          canonicalId: 'writer@team@inst-test',
+          ownerUserId: 'ada@local',
+        },
+      ];
+    }),
+  ).toThrow(
+    'agents.list[].ownerUserId username must match agents.list[].canonicalId user slug',
+  );
+
+  initAgentRegistry({
+    list: [
+      {
+        id: 'writer',
+        canonicalId: 'writer@team@inst-test',
+      },
+    ],
+  });
+  expect(resolveAgentConfig('writer')).toEqual(
+    expect.objectContaining({
+      id: 'writer',
+      canonicalId: 'writer@team@inst-test',
+    }),
+  );
+  expect(resolveAgentConfig('writer').ownerUserId).toBeUndefined();
+});
+
 test('agent registry rejects cyclic reports_to relationships', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -6,6 +6,7 @@ import { expect, test, vi } from 'vitest';
 import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_INSTANCE_ID = process.env.HYBRIDCLAW_INSTANCE_ID;
 
 const makeTempHome = useTempDir('hybridclaw-agents-');
 
@@ -25,6 +26,7 @@ useCleanMocks({
     );
     resetAgentRegistryForTesting();
     restoreEnvVar('HOME', ORIGINAL_HOME);
+    restoreEnvVar('HYBRIDCLAW_INSTANCE_ID', ORIGINAL_INSTANCE_ID);
   },
   resetModules: true,
   unmock: ['../src/logger.js'],
@@ -346,6 +348,67 @@ test('agent owner, role, and CV persist through runtime config and registry', as
   expect(stored?.escalationTarget).toEqual({
     channel: 'slack:COPS',
     recipient: 'ops-lead',
+  });
+});
+
+test('agent registry persists canonical local identities and keeps bare slug A2A compatibility', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  process.env.HYBRIDCLAW_INSTANCE_ID = 'Inst Test';
+  vi.resetModules();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { updateRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  const { getAgentById, initAgentRegistry } = await import(
+    '../src/agents/agent-registry.ts'
+  );
+  const { resolveA2AAgentId } = await import('../src/a2a/identity.ts');
+
+  initDatabase({ quiet: true });
+  updateRuntimeConfig((draft) => {
+    draft.agents.list = [
+      {
+        id: 'main',
+        name: 'Main Agent',
+      },
+      {
+        id: 'writer',
+        owner: '  Benedikt  ',
+      },
+    ];
+  });
+  initAgentRegistry({
+    list: [
+      { id: 'main', name: 'Main Agent' },
+      { id: 'writer', owner: 'Benedikt' },
+    ],
+  });
+
+  expect(getAgentById('writer')).toMatchObject({
+    canonicalId: 'writer@benedikt@inst-test',
+    ownerUserId: 'benedikt@local',
+  });
+  expect(resolveA2AAgentId('writer')).toBe('writer@benedikt@inst-test');
+
+  updateRuntimeConfig((draft) => {
+    draft.agents.list = [
+      { id: 'main', name: 'Main Agent' },
+      { id: 'writer', owner: 'Ada' },
+    ];
+  });
+  initAgentRegistry({
+    list: [
+      { id: 'main', name: 'Main Agent' },
+      { id: 'writer', owner: 'Ada' },
+    ],
+  });
+
+  expect(getAgentById('writer')).toMatchObject({
+    owner: 'Ada',
+    canonicalId: 'writer@benedikt@inst-test',
+    ownerUserId: 'benedikt@local',
   });
 });
 

--- a/tests/board-card-store.test.ts
+++ b/tests/board-card-store.test.ts
@@ -45,9 +45,10 @@ describe.sequential('board card store', () => {
     const columns = inspect
       .prepare(`PRAGMA table_info(board_cards)`)
       .all() as Array<{ name: string }>;
+    const schemaVersion = inspect.pragma('user_version', { simple: true });
     inspect.close();
 
-    expect(dbModule.DATABASE_SCHEMA_VERSION).toBe(35);
+    expect(Number(schemaVersion)).toBe(dbModule.DATABASE_SCHEMA_VERSION);
     expect(columns.map((column) => column.name)).toEqual(
       expect.arrayContaining([
         'id',

--- a/tests/memory-service.test.ts
+++ b/tests/memory-service.test.ts
@@ -740,6 +740,62 @@ describe.sequential('schema migrations', () => {
     ]);
   });
 
+  test('self-heals v36 agents missing the owner user index', () => {
+    const dbPath = createTempDbPath();
+    const legacy = new Database(dbPath);
+    legacy.exec(`
+      CREATE TABLE agents (
+        id TEXT PRIMARY KEY,
+        canonical_id TEXT,
+        owner_user_id TEXT,
+        name TEXT,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+      );
+      INSERT INTO agents (id, canonical_id, owner_user_id, name)
+      VALUES ('main', 'main@local@inst-test', 'local@local', 'Main Agent');
+      CREATE UNIQUE INDEX idx_agents_canonical_id
+        ON agents(canonical_id)
+        WHERE canonical_id IS NOT NULL AND TRIM(canonical_id) != '';
+      CREATE TABLE jobs (
+        id TEXT PRIMARY KEY,
+        kind TEXT NOT NULL CHECK (kind IN ('scheduler_job', 'scheduled_task')),
+        legacy_task_id INTEGER UNIQUE,
+        session_id TEXT,
+        channel_id TEXT,
+        name TEXT,
+        description TEXT,
+        agent_id TEXT,
+        board_status TEXT CHECK (board_status IS NULL OR board_status IN ('backlog', 'in_progress', 'review', 'done', 'cancelled')),
+        max_retries INTEGER,
+        schedule TEXT NOT NULL,
+        action TEXT NOT NULL,
+        delivery TEXT NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        last_run TEXT,
+        last_status TEXT CHECK (last_status IS NULL OR last_status IN ('success', 'error')),
+        consecutive_errors INTEGER NOT NULL DEFAULT 0,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+      );
+      PRAGMA user_version = 36;
+    `);
+    legacy.close();
+
+    initDatabase({ quiet: true, dbPath });
+
+    const inspect = new Database(dbPath, { readonly: true });
+    const ownerIndex = inspect
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_agents_owner_user_id'",
+      )
+      .get() as { name: string } | undefined;
+    inspect.close();
+
+    expect(ownerIndex?.name).toBe('idx_agents_owner_user_id');
+  });
+
   test('fills admin statistics indexes for branch schema v23 databases', () => {
     const dbPath = createTempDbPath();
     const legacy = new Database(dbPath);

--- a/tests/memory-service.test.ts
+++ b/tests/memory-service.test.ts
@@ -740,6 +740,69 @@ describe.sequential('schema migrations', () => {
     ]);
   });
 
+  test('adds suffixes when migrated local agents derive duplicate canonical ids', () => {
+    const dbPath = createTempDbPath();
+    const originalInstanceId = process.env.HYBRIDCLAW_INSTANCE_ID;
+    process.env.HYBRIDCLAW_INSTANCE_ID = 'Inst Test';
+    const legacy = new Database(dbPath);
+    legacy.exec(`
+      CREATE TABLE agents (
+        id TEXT PRIMARY KEY,
+        name TEXT,
+        owner TEXT,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+      );
+      INSERT INTO agents (id, name, owner)
+      VALUES
+        ('writer', 'Writer', 'Benedikt'),
+        ('writer!', 'Writer Duplicate', 'Benedikt');
+      PRAGMA user_version = 33;
+    `);
+    legacy.close();
+
+    try {
+      initDatabase({ quiet: true, dbPath });
+    } finally {
+      if (originalInstanceId === undefined) {
+        delete process.env.HYBRIDCLAW_INSTANCE_ID;
+      } else {
+        process.env.HYBRIDCLAW_INSTANCE_ID = originalInstanceId;
+      }
+    }
+
+    const inspect = new Database(dbPath, { readonly: true });
+    const agents = inspect
+      .prepare(
+        'SELECT id, canonical_id, owner_user_id FROM agents ORDER BY id ASC',
+      )
+      .all() as Array<{
+      id: string;
+      canonical_id: string;
+      owner_user_id: string;
+    }>;
+    const uniqueCanonicalIndex = inspect
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_agents_canonical_id'",
+      )
+      .get() as { name: string } | undefined;
+    inspect.close();
+
+    expect(agents).toEqual([
+      {
+        id: 'writer',
+        canonical_id: 'writer@benedikt@inst-test',
+        owner_user_id: 'benedikt@local',
+      },
+      {
+        id: 'writer!',
+        canonical_id: 'writer-2@benedikt@inst-test',
+        owner_user_id: 'benedikt@local',
+      },
+    ]);
+    expect(uniqueCanonicalIndex?.name).toBe('idx_agents_canonical_id');
+  });
+
   test('self-heals v36 agents missing the owner user index', () => {
     const dbPath = createTempDbPath();
     const legacy = new Database(dbPath);

--- a/tests/memory-service.test.ts
+++ b/tests/memory-service.test.ts
@@ -676,6 +676,70 @@ describe.sequential('schema migrations', () => {
     expect(boardCardsTable?.name).toBe('board_cards');
   });
 
+  test('migrates legacy agents to canonical local identities', () => {
+    const dbPath = createTempDbPath();
+    const originalInstanceId = process.env.HYBRIDCLAW_INSTANCE_ID;
+    process.env.HYBRIDCLAW_INSTANCE_ID = 'Inst Test';
+    const legacy = new Database(dbPath);
+    legacy.exec(`
+      CREATE TABLE agents (
+        id TEXT PRIMARY KEY,
+        name TEXT,
+        owner TEXT,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+      );
+      INSERT INTO agents (id, name, owner)
+      VALUES ('main', 'Main Agent', NULL), ('writer', 'Writer', 'Benedikt');
+      PRAGMA user_version = 33;
+    `);
+    legacy.close();
+
+    try {
+      initDatabase({ quiet: true, dbPath });
+    } finally {
+      if (originalInstanceId === undefined) {
+        delete process.env.HYBRIDCLAW_INSTANCE_ID;
+      } else {
+        process.env.HYBRIDCLAW_INSTANCE_ID = originalInstanceId;
+      }
+    }
+
+    const inspect = new Database(dbPath, { readonly: true });
+    const schemaVersion = inspect.pragma('user_version', { simple: true });
+    const columns = inspect.pragma('table_info(agents)') as Array<{
+      name: string;
+    }>;
+    const agents = inspect
+      .prepare(
+        'SELECT id, canonical_id, owner_user_id FROM agents ORDER BY id ASC',
+      )
+      .all() as Array<{
+      id: string;
+      canonical_id: string;
+      owner_user_id: string;
+    }>;
+    inspect.close();
+
+    expect(Number(schemaVersion)).toBe(DATABASE_SCHEMA_VERSION);
+    expect(columns.some((column) => column.name === 'canonical_id')).toBe(true);
+    expect(columns.some((column) => column.name === 'owner_user_id')).toBe(
+      true,
+    );
+    expect(agents).toEqual([
+      {
+        id: 'main',
+        canonical_id: 'main@local@inst-test',
+        owner_user_id: 'local@local',
+      },
+      {
+        id: 'writer',
+        canonical_id: 'writer@benedikt@inst-test',
+        owner_user_id: 'benedikt@local',
+      },
+    ]);
+  });
+
   test('fills admin statistics indexes for branch schema v23 databases', () => {
     const dbPath = createTempDbPath();
     const legacy = new Database(dbPath);


### PR DESCRIPTION
## Summary

Implements the remaining global identity migration path for local agents.

- adds canonical agent and owner user identity fields to `AgentConfig`
- persists and backfills `canonical_id` / `owner_user_id` in SQLite schema v36
- keeps bare local agent slug resolution working by resolving A2A boundaries through the persisted canonical ID
- documents the canonical registry fields and migration behavior

## Validation

- `npx vitest run tests/agent-id.test.ts tests/agent-registry.test.ts tests/memory-service.test.ts`
- `npx vitest run tests/a2a-envelope.test.ts tests/a2a-inbound.test.ts tests/a2a-trust-ledger.test.ts tests/agent-registry.test.ts tests/memory-service.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run check`

Closes #575
Closes #577