### PR TITLE
[codex] Add Lexware Office skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Once the gateway is running, open HybridClaw locally:
 - Bundled skills include API-backed Google Workspace workflows (`gog`, `gws`),
   Salesforce inspection, GitHub issue queue processing (`gh-issues`),
   monthly SaaS invoice harvesting (`download-platform-invoices`), Airtable,
-  FastBill, managed or self-hosted Firecrawl, Google Ads, GA4 reporting,
+  FastBill, Lexware Office, managed or self-hosted Firecrawl, Google Ads, GA4 reporting,
   HeyGen, Hermes3000 long-form writing, natural-language warehouse SQL
   (`warehouse-sql`), brand-voice drafting, speech transcription and language
   detection (`speech.transcribe`, `speech.detect-language`), validated

--- a/docs/content/guides/bundled-skills.md
+++ b/docs/content/guides/bundled-skills.md
@@ -11,7 +11,7 @@ HybridClaw ships with 50+ bundled skills. A few notable categories:
 - office workflows: `pdf`, `xlsx`, `docx`, `pptx`, `office-workflows`
 - planning and engineering: `project-manager`, `feature-planning`, `code-review`, `code-simplification`, `gh-issues`, `warehouse-sql`
 - visual explainers, image, video, and speech: `diagram`, `manim-video`, `excalidraw`, `image-generation`, `video-generation`, `video.from-script`, `speech.transcribe`, `speech.detect-language`
-- platform integrations: `github-pr-workflow`, `notion`, `trello`, `stripe`, `download-platform-invoices`, `wordpress`, `gog`, `google-workspace`, `google-ads`, `ga4`, `airtable`, `fastbill`, `firecrawl`, `heygen`, `hermes3000-writing`, `discord`
+- platform integrations: `github-pr-workflow`, `notion`, `trello`, `stripe`, `download-platform-invoices`, `wordpress`, `gog`, `google-workspace`, `google-ads`, `ga4`, `airtable`, `fastbill`, `lexware-office`, `firecrawl`, `heygen`, `hermes3000-writing`, `discord`
 - infrastructure and DevOps: `hetzner-cloud`, `hetzner-dns`, `hetzner-storage-box`, `warehouse-sql`
 - knowledge workflows: `llm-wiki`, `obsidian`, `zettelkasten`
 - search workflows: `search.web`, `search.news`, `search.images`

--- a/docs/content/guides/skills/README.md
+++ b/docs/content/guides/skills/README.md
@@ -35,7 +35,7 @@ For production package requirements see
 | Productivity | feature-planning, project-manager, trello | [Productivity Skills](./productivity.md) |
 | Memory & Knowledge | llm-wiki, notion, obsidian, personality, zettelkasten | [Memory & Knowledge Skills](./memory-knowledge.md) |
 | Publishing | diagram, excalidraw, hermes3000-writing, image-generation, manim-video, video-generation, video.from-script, wordpress, write-blog-post | [Publishing Skills](./publishing.md) |
-| Integrations & Utilities | 1password, stripe, download-platform-invoices, airtable, fastbill, firecrawl, ga4, google-ads, heygen, sokosumi, gog, google-workspace, current-time, hybridclaw-help, iss-position, search.web, search.news, search.images | [Integrations & Utilities](./integrations.md) |
+| Integrations & Utilities | 1password, stripe, download-platform-invoices, airtable, fastbill, lexware-office, firecrawl, ga4, google-ads, heygen, sokosumi, gog, google-workspace, current-time, hybridclaw-help, iss-position, search.web, search.news, search.images | [Integrations & Utilities](./integrations.md) |
 
 ## Evaluating Example Prompts
 

--- a/docs/content/guides/skills/integrations.md
+++ b/docs/content/guides/skills/integrations.md
@@ -135,6 +135,50 @@ providers need a reusable billing-portal login profile.
 
 ---
 
+## lexware-office
+
+Work with Lexware Office contacts, invoice articles, invoices, bookkeeping
+vouchers, receipt files, posting categories, payment status, and guarded
+invoice or expense writes through the Lexware Public API.
+
+**Prerequisites** — a Lexware Office plan with Public API access and an API key
+stored in the encrypted HybridClaw runtime secret store.
+
+```bash
+hybridclaw secret set LEXWARE_OFFICE_API_KEY "<api-key>"
+```
+
+> 💡 **Tips & Tricks**
+>
+> The helper emits `bearerSecretName: "LEXWARE_OFFICE_API_KEY"` so the gateway injects the API key server-side.
+>
+> Start with read-only calls such as `profile`, `list-contacts`, `list-invoices`, `list-expenses`, `get-payment`, and `posting-categories`.
+>
+> Invoice creation, contact creation, voucher updates, receipt uploads, and expense logging require explicit operator grant.
+>
+> Public API payment reads show payment items. The skill can score bank transactions against open invoices and write an operator-approved reconciliation note, while making clear that the public docs do not expose a direct banking-module assignment mutation.
+
+> 🎯 **Try it yourself**
+>
+> `Show the open invoices in Lexware Office`
+>
+> `Generate a draft invoice for Acme GmbH for last month's consulting hours`
+>
+> `Sync this receipt as a Reisekosten expense in Lexware Office`
+>
+> `Export a Q4 income statement plan from Lexware Office data`
+
+**Troubleshooting**
+
+- **401 or 403** — verify the key belongs to the active Lexware Office
+  organization and that Public API access is enabled.
+- **429** — reduce request rate; Lexware documents a 2-request-per-second
+  resource endpoint limit.
+- **voucher update conflict** — read the voucher again and include the current
+  `version` value before retrying with operator approval.
+
+---
+
 ## google-ads
 
 Use the Google Ads skill for GAQL performance reporting, MCC account

--- a/skills/lexware-office/SKILL.md
+++ b/skills/lexware-office/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: lexware-office
+description: "Work with Lexware Office contacts, products, invoices, bookkeeping vouchers, receipts, payment status, and guarded invoice or expense writes through the Public API."
+user-invocable: true
+requires:
+  bins:
+    - node
+credentials:
+  - id: lexware-office-api-key
+    kind: bearer
+    required: true
+    secret_ref:
+      source: store
+      id: LEXWARE_OFFICE_API_KEY
+    scope: "https://api.lexware.io/"
+    how_to_obtain: "Create a Lexware Office Public API key at https://app.lexware.de/addons/public-api, then store it with `hybridclaw secret set LEXWARE_OFFICE_API_KEY \"<api-key>\"`."
+metadata:
+  hybridclaw:
+    category: accounting
+    short_description: "Lexware Office invoices, contacts, vouchers, receipts, and payment status."
+    tags:
+      - accounting
+      - invoices
+      - lexware
+      - lexoffice
+      - receipts
+      - dach
+    related_skills:
+      - fastbill
+      - download-platform-invoices
+      - pdf
+    stakes_tiers:
+      green:
+        - contact-read
+        - product-read
+        - invoice-read
+        - voucher-read
+        - payment-read
+        - reporting-plan
+      amber:
+        - contact-create
+        - invoice-create
+        - expense-log
+        - voucher-update
+        - receipt-upload
+        - transaction-match-plan
+    escalation:
+      writes: confirm-each
+      route: f14
+    cost_measurement:
+      system: UsageTotals
+      sub_limit_contract: R5.4
+      sub_limit_key: lexware-office
+---
+
+# Lexware Office
+
+Use this skill when the user wants to inspect or manage Lexware Office data for
+German SME accounting workflows: customers, products/articles, invoices,
+bookkeeping vouchers, receipt files, posting categories, payment status, and
+high-level revenue or income-statement summaries.
+
+Lexware Office was formerly branded lexoffice. This skill uses the current
+Public API gateway at `https://api.lexware.io`.
+
+## Scope
+
+- read contacts/customers
+- read articles/products/services used in invoice line items
+- list invoices through `voucherlist` and retrieve invoice details
+- download invoice files from the invoice file subresource
+- list and retrieve bookkeeping vouchers, including purchase invoices and
+  receipt records
+- read payment status and payment items for vouchers through `/v1/payments`
+- read bank-linked payment items by scanning voucher payments for
+  `partPaymentFinancialTransaction`
+- read posting categories for revenue and expense classification
+- prepare local revenue and income-statement aggregation plans from voucherlist
+  and posting-category reads
+- aggregate fetched voucher pages into revenue summaries and income statements
+- create contacts only after explicit operator grant
+- create draft or finalized invoices only after explicit operator grant
+- log expense vouchers and upload receipt files only after explicit operator
+  grant
+- match incoming bank transactions against open invoices locally, then prepare
+  a granted voucher reconciliation-note update through the documented voucher
+  `PUT` endpoint
+- update vouchers only after reading the current `version` and receiving
+  explicit operator grant
+
+## Credential Rules
+
+Lexware Office authenticates with a bearer API key. Store the API key in
+HybridClaw encrypted runtime secrets; never paste it into the prompt.
+
+Recommended setup:
+
+```bash
+hybridclaw secret set LEXWARE_OFFICE_API_KEY "<api-key>"
+```
+
+For live API calls inside HybridClaw, run the helper to build an `http_request`
+payload wrapper, then pass only the emitted `httpRequest` object to the built-in
+`http_request` tool. The helper sets
+`bearerSecretName: "LEXWARE_OFFICE_API_KEY"` so the gateway injects the bearer
+token server-side.
+
+Do not verify the key with bash/curl. The model cannot inspect the gateway
+secret store, and shell commands intentionally should not receive runtime API
+keys. Only say the secret is missing if the `http_request` tool returns a
+gateway error that explicitly says `LEXWARE_OFFICE_API_KEY` cannot be resolved.
+
+## Error Interpretation
+
+- Gateway errors saying `LEXWARE_OFFICE_API_KEY` is missing or unresolved: ask
+  the operator to store the key in the active HybridClaw runtime and restart any
+  already-running gateway if needed.
+- Gateway errors saying the secret is blocked by policy: report a
+  policy/runtime configuration problem, not a missing API key.
+- Lexware `401` or `403`: the gateway injected a token, but Lexware rejected it
+  or the account lacks Public API access. Ask the operator to regenerate the key
+  and verify the Lexware Office plan/API add-on.
+- Lexware `429`: back off; Lexware documents a 2-request-per-second resource
+  endpoint limit.
+- Lexware optimistic-locking errors on voucher updates: read the voucher again
+  and retry only after the user confirms the current version should be changed.
+
+## Default Workflow
+
+1. Start with read-only commands: `profile`, `list-contacts`,
+   `list-invoices`, `list-expenses`, `get-payment`, `list-bank-transactions`,
+   or `posting-categories`.
+2. Use `plan` for natural-language requests when the action tier is unclear.
+3. For writes, stop unless the operator has granted that exact mutation in the
+   current task.
+4. Pass `--operator-grant` only after explicit approval or an approved F14
+   escalation.
+5. Create invoices as drafts unless the user explicitly asks to finalize/send.
+6. Before voucher updates, fetch the current voucher and include its `version`
+   property in the write payload.
+7. For income-statement or revenue questions, use `income-statement-plan` or
+   `revenue-summary-plan`, execute the returned read requests, then run
+   `income-statement` or `revenue-summary` on the saved JSON responses.
+8. For bank-transaction matching, use `list-bank-transactions` and
+   `match-transaction` to score candidate invoices. Lexware Public API exposes
+   payment status and bank-linked payment items but no documented direct bank
+   assignment mutation, so the write path records an operator-approved
+   reconciliation note on the voucher via documented voucher update.
+
+## Command Contract
+
+Run the colocated helper with Node:
+
+```bash
+node skills/lexware-office/lexware_office.cjs --help
+```
+
+Plan a natural-language request without contacting Lexware:
+
+```bash
+node skills/lexware-office/lexware_office.cjs plan "Pull outstanding invoices and chase any over 30 days late"
+```
+
+Build read requests:
+
+```bash
+node skills/lexware-office/lexware_office.cjs http-request profile
+node skills/lexware-office/lexware_office.cjs http-request list-contacts --name Acme --size 10
+node skills/lexware-office/lexware_office.cjs http-request list-products --type SERVICE
+node skills/lexware-office/lexware_office.cjs http-request list-invoices --status open --size 25
+node skills/lexware-office/lexware_office.cjs http-request get-invoice --id 11111111-1111-4111-8111-111111111111
+node skills/lexware-office/lexware_office.cjs http-request list-expenses --status open --start-date 2026-01-01 --end-date 2026-03-31
+node skills/lexware-office/lexware_office.cjs http-request get-payment --voucher-id 11111111-1111-4111-8111-111111111111
+node skills/lexware-office/lexware_office.cjs http-request list-bank-transactions --status paid
+node skills/lexware-office/lexware_office.cjs http-request posting-categories
+node skills/lexware-office/lexware_office.cjs http-request income-statement-plan --start-date 2026-10-01 --end-date 2026-12-31
+node skills/lexware-office/lexware_office.cjs income-statement --revenue-file /tmp/lexware-revenue.json --expense-file /tmp/lexware-expenses.json --start-date 2026-10-01 --end-date 2026-12-31
+node skills/lexware-office/lexware_office.cjs revenue-summary --revenue-file /tmp/lexware-revenue.json
+node skills/lexware-office/lexware_office.cjs match-transaction --transaction-json '{"id":"tx-1","amount":119,"purpose":"Invoice 2026-042 Acme GmbH"}' --invoices-file /tmp/lexware-open-invoices.json
+```
+
+Build write requests only after explicit operator grant:
+
+```bash
+node skills/lexware-office/lexware_office.cjs http-request create-contact \
+  --json '{"roles":{"customer":{}},"company":{"name":"Acme GmbH"},"addresses":{"billing":[{"street":"Example Str. 1","zip":"10115","city":"Berlin","countryCode":"DE"}]}}' \
+  --operator-grant
+
+node skills/lexware-office/lexware_office.cjs http-request create-invoice \
+  --json '{"voucherDate":"2026-05-21T00:00:00.000+02:00","address":{"name":"Acme GmbH","street":"Example Str. 1","zip":"10115","city":"Berlin","countryCode":"DE"},"lineItems":[{"type":"custom","name":"Consulting","quantity":8,"unitName":"hours","unitPrice":{"currency":"EUR","netAmount":120,"taxRatePercentage":19}}],"totalPrice":{"currency":"EUR"},"taxConditions":{"taxType":"net"},"paymentConditions":{"paymentTermLabel":"Due in 14 days","paymentTermDuration":14}}' \
+  --operator-grant
+
+node skills/lexware-office/lexware_office.cjs http-request log-expense \
+  --json '{"type":"purchaseinvoice","voucherDate":"2026-05-21T00:00:00.000+02:00","totalGrossAmount":119,"taxType":"gross","voucherItems":[{"amount":119,"taxAmount":19,"taxRatePercent":19,"categoryId":"cf03a2b0-f838-474f-ac5e-67adb9b830c7"}]}' \
+  --operator-grant
+
+node skills/lexware-office/lexware_office.cjs http-request match-transaction \
+  --voucher-id 11111111-1111-4111-8111-111111111111 \
+  --voucher-json '{"type":"salesinvoice","voucherNumber":"2026-042","version":3,"remark":"Reviewed"}' \
+  --transaction-json '{"id":"tx-1","amount":119,"bookingDate":"2026-05-21","counterpartyName":"Acme GmbH"}' \
+  --operator-grant
+```
+
+Upload a receipt file:
+
+```bash
+node skills/lexware-office/lexware_office.cjs http-request upload-file --file /workspace/receipt.pdf --type voucher --operator-grant
+node skills/lexware-office/lexware_office.cjs http-request attach-file-to-voucher --voucher-id 11111111-1111-4111-8111-111111111111 --file /workspace/receipt.pdf --operator-grant
+```
+
+Run offline eval scenarios:
+
+```bash
+node skills/lexware-office/lexware_office.cjs eval-scenarios
+```
+
+## Conservative Mutations
+
+These helper operations require `--operator-grant`:
+
+- `create-contact`
+- `create-invoice`
+- `log-expense`
+- `upload-file`
+- `attach-file-to-voucher`
+- `update-voucher`
+- `match-transaction`
+
+`match-transaction` is intentionally conservative: it does not claim to assign
+the bank transaction inside Lexware's banking module, because the Public API
+does not document that mutation. It writes an auditable reconciliation note to
+the voucher after explicit operator grant.
+
+## Working Rules
+
+- Never print or ask for the Lexware Office API key.
+- Never build an Authorization header manually in a prompt. Use
+  `bearerSecretName: "LEXWARE_OFFICE_API_KEY"`.
+- Prefer helper-emitted `httpRequest` payloads over handcrafted API calls.
+- Read before write when IDs, versions, posting categories, contact IDs, or
+  invoice recipient details are ambiguous.
+- If multiple contacts or invoices match, stop and ask for the exact ID before
+  writing.
+- Default invoice creation to draft. Use `--finalize` only after explicit user
+  instruction.
+- Treat receipt uploads and voucher changes as account-data mutations.
+- Cost per assistant run is recorded by HybridClaw `UsageTotals`; helper output
+  includes `costMeasurement.system = "UsageTotals"` so evals can verify the
+  accounting contract.
+
+## References
+
+- Operator setup: [references/operator-setup.md](references/operator-setup.md)
+- Lexware Public API docs: https://developers.lexware.io/docs/
+
+## Validation
+
+Run:
+
+```bash
+python3 skills/skill-creator/scripts/quick_validate.py skills/lexware-office
+node skills/lexware-office/lexware_office.cjs --help
+node skills/lexware-office/lexware_office.cjs eval-scenarios
+node skills/lexware-office/lexware_office.cjs http-request list-invoices --status open
+node skills/lexware-office/lexware_office.cjs http-request list-bank-transactions --status paid
+node skills/lexware-office/lexware_office.cjs http-request create-invoice --json '{"voucherDate":"2026-05-21T00:00:00.000+02:00"}'
+```

--- a/skills/lexware-office/evals/scenarios.json
+++ b/skills/lexware-office/evals/scenarios.json
@@ -1,0 +1,287 @@
+[
+  {
+    "id": "invoice-read-open",
+    "category": "invoice_read",
+    "prompt": "Show the open invoices in Lexware Office.",
+    "expected": {
+      "operation": "list-invoices",
+      "requiresEscalation": false,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "invoice-read-overdue",
+    "category": "invoice_read",
+    "prompt": "Pull the outstanding invoices and find any over 30 days late.",
+    "expected": {
+      "operation": "get-payment",
+      "requiresEscalation": false,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "invoice-read-number",
+    "category": "invoice_read",
+    "prompt": "Look up invoice 2026-042 and summarize it.",
+    "expected": {
+      "operation": "list-invoices",
+      "requiresEscalation": false,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "invoice-create-consulting",
+    "category": "invoice_write",
+    "prompt": "Generate an invoice for Acme GmbH for last month's consulting hours.",
+    "expected": {
+      "operation": "create-invoice",
+      "requiresEscalation": true,
+      "requiredGrant": "approve-lexware-office-create-invoice",
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "invoice-create-send",
+    "category": "invoice_write",
+    "prompt": "Create and send the final Lexware invoice for customer 123.",
+    "expected": {
+      "operation": "create-invoice",
+      "requiresEscalation": true,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "invoice-draft",
+    "category": "invoice_write",
+    "prompt": "Draft a Lexware Office invoice with two line items.",
+    "expected": {
+      "operation": "create-invoice",
+      "requiresEscalation": true,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "customer-list",
+    "category": "customer_read",
+    "prompt": "Find the Lexware customer record for Acme.",
+    "expected": {
+      "operation": "list-contacts",
+      "requiresEscalation": false,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "customer-create",
+    "category": "customer_write",
+    "prompt": "Create a customer in Lexware Office for Acme GmbH.",
+    "expected": {
+      "operation": "create-contact",
+      "requiresEscalation": true,
+      "requiredGrant": "approve-lexware-office-create-contact",
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "customer-add-private",
+    "category": "customer_write",
+    "prompt": "Add a new private client contact for Jane Rivera.",
+    "expected": {
+      "operation": "create-contact",
+      "requiresEscalation": true,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "product-list",
+    "category": "product_read",
+    "prompt": "List Lexware Office products I can use as invoice articles.",
+    "expected": {
+      "operation": "list-products",
+      "requiresEscalation": false,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "service-list",
+    "category": "product_read",
+    "prompt": "Show the service articles configured in Lexware.",
+    "expected": {
+      "operation": "list-products",
+      "requiresEscalation": false,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "expense-list",
+    "category": "expense_read",
+    "prompt": "Show expense receipts in the Lexware Belege module.",
+    "expected": {
+      "operation": "list-expenses",
+      "requiresEscalation": false,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "expense-log-travel",
+    "category": "expense_write",
+    "prompt": "Sync this expense receipt with Lexware Office under category Reisekosten.",
+    "expected": {
+      "operation": "log-expense",
+      "requiresEscalation": true,
+      "requiredGrant": "approve-lexware-office-log-expense",
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "expense-upload",
+    "category": "expense_write",
+    "prompt": "Upload this receipt PDF and log it as a travel expense.",
+    "expected": {
+      "operation": "log-expense",
+      "requiresEscalation": true,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "payment-status",
+    "category": "payment_read",
+    "prompt": "What is the payment status for the invoice?",
+    "expected": {
+      "operation": "get-payment",
+      "requiresEscalation": false,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "bank-transaction-read",
+    "category": "payment_read",
+    "prompt": "Show the payment items linked to this bank transaction.",
+    "expected": {
+      "operation": "list-bank-transactions",
+      "requiresEscalation": false,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "bank-transaction-match",
+    "category": "payment_write",
+    "prompt": "Match the incoming bank transaction with the open invoice in Lexware Office.",
+    "expected": {
+      "operation": "match-transaction",
+      "requiresEscalation": true,
+      "requiredGrant": "approve-lexware-office-transaction-match",
+      "executable": true,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "payment-reminder",
+    "category": "invoice_read",
+    "prompt": "Find invoices that need a payment reminder.",
+    "expected": {
+      "operation": "get-payment",
+      "requiresEscalation": false,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "posting-categories",
+    "category": "accounting_read",
+    "prompt": "Which posting categories are available for travel expenses?",
+    "expected": {
+      "operation": "posting-categories",
+      "requiresEscalation": false,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "income-statement-q4",
+    "category": "report_read",
+    "prompt": "Export the Q4 income statement from Lexware Office.",
+    "expected": {
+      "operation": "income-statement-plan",
+      "requiresEscalation": false,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "revenue-quarter",
+    "category": "report_read",
+    "prompt": "What's our current revenue this quarter according to Lexware?",
+    "expected": {
+      "operation": "revenue-summary-plan",
+      "requiresEscalation": false,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "profile-read",
+    "category": "profile_read",
+    "prompt": "Show the connected Lexware Office profile.",
+    "expected": {
+      "operation": "profile",
+      "requiresEscalation": false,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "voucher-read",
+    "category": "expense_read",
+    "prompt": "Read the receipt voucher details.",
+    "expected": {
+      "operation": "list-expenses",
+      "requiresEscalation": false,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "invoice-file",
+    "category": "invoice_read",
+    "prompt": "Download the invoice file from Lexware Office.",
+    "expected": {
+      "operation": "download-invoice-file",
+      "requiresEscalation": false,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "expense-correct",
+    "category": "expense_write",
+    "prompt": "Correct the booked travel receipt category.",
+    "expected": {
+      "operation": "log-expense",
+      "requiresEscalation": true,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "customer-read-kunde",
+    "category": "customer_read",
+    "prompt": "Finde den Kunden Acme in Lexware Office.",
+    "expected": {
+      "operation": "list-contacts",
+      "requiresEscalation": false,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "invoice-create-german",
+    "category": "invoice_write",
+    "prompt": "Erstelle eine Rechnung fuer Beratungsstunden in Lexware.",
+    "expected": {
+      "operation": "create-invoice",
+      "requiresEscalation": true,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "expense-read-german",
+    "category": "expense_read",
+    "prompt": "Zeige offene Belege in Lexware Office.",
+    "expected": {
+      "operation": "list-expenses",
+      "requiresEscalation": false,
+      "costSystem": "UsageTotals"
+    }
+  }
+]

--- a/skills/lexware-office/index.cjs
+++ b/skills/lexware-office/index.cjs
@@ -1,0 +1,1 @@
+module.exports = require('./lexware_office.cjs');

--- a/skills/lexware-office/lexware_office.cjs
+++ b/skills/lexware-office/lexware_office.cjs
@@ -1,0 +1,973 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const API_BASE = 'https://api.lexware.io';
+const DEFAULT_TIMEOUT_MS = 30000;
+const TOKEN_SECRET = 'LEXWARE_OFFICE_API_KEY';
+const EVAL_SCENARIOS_PATH = path.join(__dirname, 'evals', 'scenarios.json');
+
+const COST_MEASUREMENT = {
+  system: 'UsageTotals',
+  source: 'HybridClaw usage_events',
+  scope: 'per assistant run/session',
+  fields: [
+    'total_input_tokens',
+    'total_output_tokens',
+    'total_tokens',
+    'total_cost_usd',
+    'call_count',
+    'total_tool_calls',
+  ],
+};
+
+const READ_OPERATIONS = new Set([
+  'profile',
+  'list-contacts',
+  'get-contact',
+  'list-products',
+  'get-product',
+  'list-invoices',
+  'get-invoice',
+  'download-invoice-file',
+  'list-expenses',
+  'get-voucher',
+  'get-payment',
+  'list-bank-transactions',
+  'posting-categories',
+  'income-statement-plan',
+  'revenue-summary-plan',
+]);
+
+const WRITE_OPERATIONS = new Set([
+  'create-contact',
+  'create-invoice',
+  'log-expense',
+  'upload-file',
+  'attach-file-to-voucher',
+  'update-voucher',
+  'match-transaction',
+]);
+
+const INVOICE_RE = /\b(invoices?|rechnung|rechnungen|receivables?)\b/i;
+const CUSTOMER_RE = /\b(customers?|clients?|contacts?|kunden?)\b/i;
+const PRODUCT_RE = /\b(products?|articles?|items?|services?|artikel)\b/i;
+const EXPENSE_RE =
+  /\b(expenses?|receipts?|belege?|purchase\s*invoices?|reisekosten)\b/i;
+const PAYMENT_RE =
+  /\b(payments?|paid|unpaid|open amount|outstanding|overdue|late|mahn)\b/i;
+const BANK_RE = /\b(bank|transaction|payment match|match incoming|konto)\b/i;
+const REPORT_RE =
+  /\b(income statement|p&l|profit and loss|einnahmen|revenue|quarter|q[1-4])\b/i;
+const CREATE_RE =
+  /\b(create|generate|draft|add|new|send|log|upload|attach|book|match|sync|erstell(?:e|en)?)\b/i;
+const UPDATE_RE = /\b(update|change|correct|edit|void|remove|replace)\b/i;
+const POSTING_RE =
+  /\b(posting categories?|booking categor(?:y|ies)|category ids?|kontierungs?kategorien?)\b/i;
+const FILE_RE = /\b(download|file|pdf|document)\b/i;
+const READ_ONLY_VOUCHER_FIELDS = new Set([
+  'id',
+  'organizationId',
+  'resourceUri',
+  'createdDate',
+  'updatedDate',
+]);
+
+function die(message, code = 2) {
+  process.stderr.write(`${message}\n`);
+  process.exit(code);
+}
+
+function printJson(payload) {
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function popFlag(args, name, fallback = undefined) {
+  const index = args.indexOf(name);
+  if (index === -1) return fallback;
+  const value = args[index + 1];
+  if (value === undefined || value.startsWith('--')) {
+    die(`${name} requires a value.`);
+  }
+  args.splice(index, 2);
+  return value;
+}
+
+function popBoolean(args, name) {
+  const index = args.indexOf(name);
+  if (index === -1) return false;
+  args.splice(index, 1);
+  return true;
+}
+
+function parseJsonValue(raw, label) {
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    die(`${label} must be valid JSON: ${error.message}`);
+  }
+}
+
+function loadJsonFile(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch (error) {
+    die(`Cannot read JSON file ${filePath}: ${error.message}`);
+  }
+}
+
+function unwrapJsonPayload(payload) {
+  if (payload?.bodyJson) return payload.bodyJson;
+  if (typeof payload?.body === 'string')
+    return parseJsonValue(payload.body, 'body');
+  return payload;
+}
+
+function loadJsonPayload(filePath) {
+  return unwrapJsonPayload(loadJsonFile(filePath));
+}
+
+function validateUuid(value, label) {
+  if (
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(
+      String(value || ''),
+    )
+  ) {
+    die(`${label} must be a UUID.`);
+  }
+}
+
+function appendQuery(url, params) {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === '') continue;
+    if (Array.isArray(value)) {
+      for (const item of value) query.append(key, String(item));
+    } else {
+      query.set(key, String(value));
+    }
+  }
+  const queryString = query.toString();
+  return queryString ? `${url}?${queryString}` : url;
+}
+
+function parsePageSize(raw) {
+  if (!/^\d+$/.test(String(raw))) die('--size must be an integer.');
+  const size = Number.parseInt(raw, 10);
+  if (size < 1 || size > 250) die('--size must be between 1 and 250.');
+  return size;
+}
+
+function buildHttpRequest({ url, method = 'GET', json, headers, bodyBase64 }) {
+  const httpRequest = {
+    url,
+    method,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    bearerSecretName: TOKEN_SECRET,
+    skillName: 'lexware-office',
+  };
+  if (json !== undefined) httpRequest.json = json;
+  if (headers !== undefined) httpRequest.headers = headers;
+  if (bodyBase64 !== undefined) httpRequest.bodyBase64 = bodyBase64;
+  return {
+    command: 'http-request',
+    httpRequest,
+    costMeasurement: COST_MEASUREMENT,
+  };
+}
+
+function requireGrant(args, operation) {
+  if (!popBoolean(args, '--operator-grant')) {
+    die(
+      `Refusing Lexware Office write without --operator-grant (${operation}). ` +
+        'Run plan first and get an explicit operator grant.',
+    );
+  }
+}
+
+function requireJsonPayload(args) {
+  const raw = popFlag(args, '--json');
+  if (!raw) die('--json is required.');
+  const payload = parseJsonValue(raw, '--json');
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    die('--json must be a JSON object.');
+  }
+  return payload;
+}
+
+function mimeTypeFor(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === '.pdf') return 'application/pdf';
+  if (ext === '.png') return 'image/png';
+  if (ext === '.jpg' || ext === '.jpeg') return 'image/jpeg';
+  if (ext === '.xml') return 'application/xml';
+  return 'application/octet-stream';
+}
+
+function normalizeUploadFile(filePath) {
+  const resolved = path.resolve(filePath);
+  const stat = fs.statSync(resolved);
+  if (!stat.isFile()) die(`--file must point to a file: ${filePath}`);
+  return {
+    path: resolved,
+    filename: path.basename(resolved).replace(/["\r\n]/g, '_'),
+    bytes: fs.readFileSync(resolved),
+    mimeType: mimeTypeFor(resolved),
+  };
+}
+
+function buildMultipartBody(parts) {
+  const boundary = `----hybridclaw-lexware-${Date.now().toString(36)}`;
+  const chunks = [];
+  for (const part of parts) {
+    chunks.push(Buffer.from(`--${boundary}\r\n`, 'utf-8'));
+    if (part.filename) {
+      chunks.push(
+        Buffer.from(
+          `Content-Disposition: form-data; name="${part.name}"; filename="${part.filename}"\r\n` +
+            `Content-Type: ${part.mimeType}\r\n\r\n`,
+          'utf-8',
+        ),
+      );
+      chunks.push(part.bytes);
+      chunks.push(Buffer.from('\r\n', 'utf-8'));
+    } else {
+      chunks.push(
+        Buffer.from(
+          `Content-Disposition: form-data; name="${part.name}"\r\n\r\n${part.value}\r\n`,
+          'utf-8',
+        ),
+      );
+    }
+  }
+  chunks.push(Buffer.from(`--${boundary}--\r\n`, 'utf-8'));
+  return {
+    boundary,
+    bodyBase64: Buffer.concat(chunks).toString('base64'),
+  };
+}
+
+function buildReadRequest(operation, args) {
+  if (operation === 'profile') {
+    return buildHttpRequest({ url: `${API_BASE}/v1/profile` });
+  }
+  if (operation === 'list-contacts') {
+    const url = appendQuery(`${API_BASE}/v1/contacts`, {
+      page: popFlag(args, '--page', '0'),
+      size: parsePageSize(popFlag(args, '--size', '25')),
+      email: popFlag(args, '--email'),
+      name: popFlag(args, '--name'),
+      number: popFlag(args, '--number'),
+    });
+    return buildHttpRequest({ url });
+  }
+  if (operation === 'get-contact') {
+    const id = popFlag(args, '--id');
+    validateUuid(id, '--id');
+    return buildHttpRequest({ url: `${API_BASE}/v1/contacts/${id}` });
+  }
+  if (operation === 'list-products') {
+    const url = appendQuery(`${API_BASE}/v1/articles`, {
+      page: popFlag(args, '--page', '0'),
+      size: parsePageSize(popFlag(args, '--size', '25')),
+      articleNumber: popFlag(args, '--article-number'),
+      type: popFlag(args, '--type'),
+    });
+    return buildHttpRequest({ url });
+  }
+  if (operation === 'get-product') {
+    const id = popFlag(args, '--id');
+    validateUuid(id, '--id');
+    return buildHttpRequest({ url: `${API_BASE}/v1/articles/${id}` });
+  }
+  if (operation === 'list-invoices') {
+    return buildVoucherListRequest(args, {
+      voucherType: 'invoice',
+      voucherStatus: popFlag(args, '--status'),
+    });
+  }
+  if (operation === 'get-invoice') {
+    const id = popFlag(args, '--id');
+    validateUuid(id, '--id');
+    return buildHttpRequest({ url: `${API_BASE}/v1/invoices/${id}` });
+  }
+  if (operation === 'download-invoice-file') {
+    const id = popFlag(args, '--id');
+    validateUuid(id, '--id');
+    return buildHttpRequest({
+      url: `${API_BASE}/v1/invoices/${id}/file`,
+      headers: { Accept: '*/*' },
+    });
+  }
+  if (operation === 'list-expenses') {
+    return buildVoucherListRequest(args, {
+      voucherType: 'purchaseinvoice,purchasecreditnote',
+      voucherStatus: popFlag(args, '--status'),
+    });
+  }
+  if (operation === 'get-voucher') {
+    const id = popFlag(args, '--id');
+    validateUuid(id, '--id');
+    return buildHttpRequest({ url: `${API_BASE}/v1/vouchers/${id}` });
+  }
+  if (operation === 'get-payment') {
+    const voucherId = popFlag(args, '--voucher-id');
+    validateUuid(voucherId, '--voucher-id');
+    return buildHttpRequest({ url: `${API_BASE}/v1/payments/${voucherId}` });
+  }
+  if (operation === 'list-bank-transactions') {
+    return buildBankTransactionPlan(args);
+  }
+  if (operation === 'posting-categories') {
+    return buildHttpRequest({ url: `${API_BASE}/v1/posting-categories` });
+  }
+  if (operation === 'income-statement-plan') return buildStatementPlan(args);
+  if (operation === 'revenue-summary-plan') return buildRevenuePlan(args);
+  die(`Unsupported read operation: ${operation}`);
+}
+
+function buildVoucherListRequest(args, defaults = {}) {
+  const url = appendQuery(`${API_BASE}/v1/voucherlist`, {
+    page: popFlag(args, '--page', '0'),
+    size: parsePageSize(popFlag(args, '--size', '25')),
+    voucherType: popFlag(args, '--voucher-type', defaults.voucherType),
+    voucherStatus: popFlag(args, '--status', defaults.voucherStatus),
+    voucherNumber: popFlag(args, '--voucher-number'),
+    contactId: popFlag(args, '--contact-id'),
+    voucherDateFrom: popFlag(args, '--start-date'),
+    voucherDateTo: popFlag(args, '--end-date'),
+  });
+  return buildHttpRequest({ url });
+}
+
+function statementWindow(args) {
+  return {
+    startDate: popFlag(args, '--start-date'),
+    endDate: popFlag(args, '--end-date'),
+  };
+}
+
+function buildStatementPlan(args) {
+  const originalArgs = [...args];
+  const window = statementWindow(args);
+  return {
+    command: 'income-statement-plan',
+    note: 'Lexware Office Public API does not expose a native income-statement endpoint. Use voucherlist plus posting categories and aggregate revenue and expenses locally.',
+    requestSequence: [
+      buildVoucherListRequest([...originalArgs], {
+        voucherType: 'invoice,creditnote,salesinvoice,salescreditnote',
+      }).httpRequest,
+      buildVoucherListRequest([...originalArgs], {
+        voucherType: 'purchaseinvoice,purchasecreditnote',
+      }).httpRequest,
+      buildHttpRequest({ url: `${API_BASE}/v1/posting-categories` })
+        .httpRequest,
+    ],
+    window,
+    costMeasurement: COST_MEASUREMENT,
+  };
+}
+
+function buildRevenuePlan(args) {
+  const originalArgs = [...args];
+  const window = statementWindow(args);
+  return {
+    command: 'revenue-summary-plan',
+    requestSequence: [
+      buildVoucherListRequest([...originalArgs], {
+        voucherType: 'invoice,creditnote,salesinvoice,salescreditnote',
+      }).httpRequest,
+    ],
+    window,
+    costMeasurement: COST_MEASUREMENT,
+  };
+}
+
+function buildBankTransactionPlan(args) {
+  const status = popFlag(args, '--status', 'any');
+  const originalArgs = [...args, '--status', status];
+  return {
+    command: 'bank-transaction-plan',
+    note: 'Lexware Office Public API exposes bank-linked payments as paymentItems with paymentItemType partPaymentFinancialTransaction on /v1/payments/{voucherId}. Fetch candidate vouchers first, then fetch payment details per voucher id.',
+    requestSequence: [
+      buildVoucherListRequest([...originalArgs], {
+        voucherType:
+          'invoice,creditnote,salesinvoice,salescreditnote,purchaseinvoice,purchasecreditnote',
+        voucherStatus: status,
+      }).httpRequest,
+    ],
+    followUpRequestTemplate: {
+      url: `${API_BASE}/v1/payments/{voucherId}`,
+      method: 'GET',
+      bearerSecretName: TOKEN_SECRET,
+      skillName: 'lexware-office',
+    },
+    filterPaymentItemType: 'partPaymentFinancialTransaction',
+    costMeasurement: COST_MEASUREMENT,
+  };
+}
+
+function buildWriteRequest(operation, args) {
+  requireGrant(args, operation);
+  if (operation === 'create-contact') {
+    return buildHttpRequest({
+      url: `${API_BASE}/v1/contacts`,
+      method: 'POST',
+      json: requireJsonPayload(args),
+    });
+  }
+  if (operation === 'create-invoice') {
+    const finalize = popBoolean(args, '--finalize');
+    return buildHttpRequest({
+      url: appendQuery(`${API_BASE}/v1/invoices`, { finalize }),
+      method: 'POST',
+      json: requireJsonPayload(args),
+    });
+  }
+  if (operation === 'log-expense') {
+    return buildHttpRequest({
+      url: `${API_BASE}/v1/vouchers`,
+      method: 'POST',
+      json: requireJsonPayload(args),
+    });
+  }
+  if (operation === 'update-voucher') {
+    const id = popFlag(args, '--id');
+    validateUuid(id, '--id');
+    return buildHttpRequest({
+      url: `${API_BASE}/v1/vouchers/${id}`,
+      method: 'PUT',
+      json: requireJsonPayload(args),
+    });
+  }
+  if (operation === 'upload-file') {
+    return buildUploadRequest(args, `${API_BASE}/v1/files`, [
+      { name: 'type', value: popFlag(args, '--type', 'voucher') },
+    ]);
+  }
+  if (operation === 'attach-file-to-voucher') {
+    const voucherId = popFlag(args, '--voucher-id');
+    validateUuid(voucherId, '--voucher-id');
+    return buildUploadRequest(
+      args,
+      `${API_BASE}/v1/vouchers/${voucherId}/files`,
+    );
+  }
+  if (operation === 'match-transaction') {
+    return buildMatchTransactionWriteRequest(args);
+  }
+  die(`Unsupported write operation: ${operation}`);
+}
+
+function buildMatchTransactionWriteRequest(args) {
+  const voucherId = popFlag(args, '--voucher-id');
+  validateUuid(voucherId, '--voucher-id');
+  const voucherRaw = popFlag(args, '--voucher-json');
+  const transactionRaw = popFlag(args, '--transaction-json');
+  if (!voucherRaw) die('--voucher-json is required.');
+  if (!transactionRaw) die('--transaction-json is required.');
+  const voucher = parseJsonValue(voucherRaw, '--voucher-json');
+  const transaction = parseJsonValue(transactionRaw, '--transaction-json');
+  const updatePayload = buildVoucherMatchAnnotation(voucher, transaction);
+  return buildHttpRequest({
+    url: `${API_BASE}/v1/vouchers/${voucherId}`,
+    method: 'PUT',
+    json: updatePayload,
+  });
+}
+
+function buildVoucherMatchAnnotation(voucher, transaction) {
+  if (!voucher || typeof voucher !== 'object' || Array.isArray(voucher)) {
+    die('--voucher-json must be a JSON object.');
+  }
+  if (voucher.version === undefined || voucher.version === null) {
+    die('--voucher-json must include the current Lexware voucher version.');
+  }
+  const output = {};
+  for (const [key, value] of Object.entries(voucher)) {
+    if (!READ_ONLY_VOUCHER_FIELDS.has(key)) output[key] = value;
+  }
+  const amount =
+    transaction.amount ?? transaction.value ?? transaction.totalAmount;
+  const bookingDate =
+    transaction.bookingDate ?? transaction.postingDate ?? transaction.date;
+  const transactionId =
+    transaction.id ??
+    transaction.transactionId ??
+    transaction.endToEndId ??
+    transaction.reference ??
+    'unreferenced';
+  const counterparty =
+    transaction.counterpartyName ??
+    transaction.name ??
+    transaction.debtorName ??
+    transaction.creditorName ??
+    'unknown counterparty';
+  const note =
+    `HybridClaw bank match: transaction ${transactionId}, ${counterparty}, ` +
+    `${amount ?? 'unknown amount'} EUR, ${bookingDate ?? 'unknown date'}.`;
+  output.remark = appendRemark(voucher.remark, note);
+  return output;
+}
+
+function appendRemark(currentRemark, note) {
+  const base = String(currentRemark || '').trim();
+  if (!base) return note;
+  if (base.includes(note)) return base;
+  return `${base}\n${note}`;
+}
+
+function buildUploadRequest(args, url, extraParts = []) {
+  const filePath = popFlag(args, '--file');
+  if (!filePath) die('--file is required.');
+  const file = normalizeUploadFile(filePath);
+  const multipart = buildMultipartBody([
+    ...extraParts,
+    {
+      name: 'file',
+      filename: file.filename,
+      mimeType: file.mimeType,
+      bytes: file.bytes,
+    },
+  ]);
+  return buildHttpRequest({
+    url,
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': `multipart/form-data; boundary=${multipart.boundary}`,
+    },
+    bodyBase64: multipart.bodyBase64,
+  });
+}
+
+function makePlan({
+  request,
+  operation,
+  resource,
+  stakesTier = 'green',
+  requiresEscalation = false,
+  requiredGrant = null,
+  executable = true,
+  findings = [],
+}) {
+  return {
+    command: 'plan',
+    request,
+    operation,
+    resource,
+    stakesTier,
+    requiresEscalation,
+    requiredGrant,
+    executable,
+    findings,
+    costMeasurement: COST_MEASUREMENT,
+  };
+}
+
+function planRequest(request) {
+  const text = request.toLowerCase();
+  const isWrite = CREATE_RE.test(text) || UPDATE_RE.test(text);
+
+  if (BANK_RE.test(text) && isWrite) {
+    return makePlan({
+      request,
+      operation: 'match-transaction',
+      resource: 'payments',
+      stakesTier: 'amber',
+      requiresEscalation: true,
+      requiredGrant: 'approve-lexware-office-transaction-match',
+      executable: true,
+      findings: [
+        'Lexware Office Public API exposes bank-linked payment reads but no direct bank-assignment mutation. This write path creates an operator-approved voucher reconciliation note through the documented voucher update endpoint.',
+      ],
+    });
+  }
+  if (EXPENSE_RE.test(text) && isWrite) {
+    return makePlan({
+      request,
+      operation: 'log-expense',
+      resource: 'vouchers',
+      stakesTier: 'amber',
+      requiresEscalation: true,
+      requiredGrant: 'approve-lexware-office-log-expense',
+    });
+  }
+  if (INVOICE_RE.test(text) && isWrite) {
+    return makePlan({
+      request,
+      operation: 'create-invoice',
+      resource: 'invoices',
+      stakesTier: 'amber',
+      requiresEscalation: true,
+      requiredGrant: 'approve-lexware-office-create-invoice',
+    });
+  }
+  if (CUSTOMER_RE.test(text) && isWrite) {
+    return makePlan({
+      request,
+      operation: 'create-contact',
+      resource: 'contacts',
+      stakesTier: 'amber',
+      requiresEscalation: true,
+      requiredGrant: 'approve-lexware-office-create-contact',
+    });
+  }
+  if (BANK_RE.test(text) || PAYMENT_RE.test(text)) {
+    return makePlan({
+      request,
+      operation: BANK_RE.test(text) ? 'list-bank-transactions' : 'get-payment',
+      resource: 'payments',
+    });
+  }
+  if (REPORT_RE.test(text)) {
+    return makePlan({
+      request,
+      operation: text.includes('revenue')
+        ? 'revenue-summary-plan'
+        : 'income-statement-plan',
+      resource: 'voucherlist',
+    });
+  }
+  if (POSTING_RE.test(text)) {
+    return makePlan({
+      request,
+      operation: 'posting-categories',
+      resource: 'posting-categories',
+    });
+  }
+  if (EXPENSE_RE.test(text)) {
+    return makePlan({
+      request,
+      operation: 'list-expenses',
+      resource: 'voucherlist',
+    });
+  }
+  if (PRODUCT_RE.test(text)) {
+    return makePlan({
+      request,
+      operation: 'list-products',
+      resource: 'articles',
+    });
+  }
+  if (INVOICE_RE.test(text) && FILE_RE.test(text)) {
+    return makePlan({
+      request,
+      operation: 'download-invoice-file',
+      resource: 'invoices',
+    });
+  }
+  if (CUSTOMER_RE.test(text)) {
+    return makePlan({
+      request,
+      operation: 'list-contacts',
+      resource: 'contacts',
+    });
+  }
+  return makePlan({
+    request,
+    operation: INVOICE_RE.test(text) ? 'list-invoices' : 'profile',
+    resource: INVOICE_RE.test(text) ? 'voucherlist' : 'profile',
+  });
+}
+
+function runEvalScenarios() {
+  const scenarios = loadJsonFile(EVAL_SCENARIOS_PATH);
+  const failures = [];
+  const categories = {};
+  for (const scenario of scenarios) {
+    categories[scenario.category] = (categories[scenario.category] ?? 0) + 1;
+    const plan = planRequest(scenario.prompt);
+    for (const [key, expectedValue] of Object.entries(
+      scenario.expected ?? {},
+    )) {
+      const actualValue =
+        key === 'costSystem' ? plan.costMeasurement.system : plan[key];
+      if (actualValue !== expectedValue) {
+        failures.push({
+          id: scenario.id,
+          key,
+          expected: expectedValue,
+          actual: actualValue,
+        });
+      }
+    }
+  }
+  return {
+    command: 'eval-scenarios',
+    scenarioCount: scenarios.length,
+    failed: failures.length,
+    failures,
+    categories,
+    costMeasurement: COST_MEASUREMENT,
+  };
+}
+
+function normalizeContentList(payload) {
+  const data = unwrapJsonPayload(payload);
+  if (Array.isArray(data)) return data;
+  if (Array.isArray(data?.content)) return data.content;
+  if (Array.isArray(data?.vouchers)) return data.vouchers;
+  if (Array.isArray(data?.items)) return data.items;
+  return [];
+}
+
+function amountValue(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function voucherAmount(voucher) {
+  return amountValue(
+    voucher.totalAmount ??
+      voucher.totalGrossAmount ??
+      voucher.totalPrice?.totalGrossAmount ??
+      voucher.totalPrice?.totalNetAmount,
+  );
+}
+
+function signedVoucherAmount(voucher, kind) {
+  const type = String(voucher.voucherType ?? voucher.type ?? '').toLowerCase();
+  const amount = voucherAmount(voucher);
+  const isCredit = type.includes('creditnote');
+  if (kind === 'revenue') return isCredit ? -amount : amount;
+  return isCredit ? -amount : amount;
+}
+
+function categoryBreakdown(vouchers) {
+  const categories = {};
+  for (const voucher of vouchers) {
+    for (const item of voucher.voucherItems ?? []) {
+      const categoryId = item.categoryId || 'uncategorized';
+      categories[categoryId] =
+        amountValue(categories[categoryId]) + amountValue(item.amount);
+    }
+  }
+  return categories;
+}
+
+function buildIncomeStatement(args) {
+  const revenueFile = popFlag(args, '--revenue-file');
+  const expenseFile = popFlag(args, '--expense-file');
+  const categoriesFile = popFlag(args, '--categories-file');
+  const startDate = popFlag(args, '--start-date');
+  const endDate = popFlag(args, '--end-date');
+  if (!revenueFile) die('--revenue-file is required.');
+  if (!expenseFile) die('--expense-file is required.');
+  const revenueVouchers = normalizeContentList(loadJsonPayload(revenueFile));
+  const expenseVouchers = normalizeContentList(loadJsonPayload(expenseFile));
+  const totalRevenue = revenueVouchers.reduce(
+    (sum, voucher) => sum + signedVoucherAmount(voucher, 'revenue'),
+    0,
+  );
+  const totalExpenses = expenseVouchers.reduce(
+    (sum, voucher) => sum + signedVoucherAmount(voucher, 'expense'),
+    0,
+  );
+  const categories = categoriesFile ? loadJsonPayload(categoriesFile) : null;
+  return {
+    command: 'income-statement',
+    currency: 'EUR',
+    period: { startDate, endDate },
+    totals: {
+      revenue: roundMoney(totalRevenue),
+      expenses: roundMoney(totalExpenses),
+      netIncome: roundMoney(totalRevenue - totalExpenses),
+    },
+    counts: {
+      revenueVouchers: revenueVouchers.length,
+      expenseVouchers: expenseVouchers.length,
+    },
+    categoryBreakdown: {
+      revenue: categoryBreakdown(revenueVouchers),
+      expenses: categoryBreakdown(expenseVouchers),
+    },
+    categories,
+    costMeasurement: COST_MEASUREMENT,
+  };
+}
+
+function buildRevenueSummary(args) {
+  const revenueFile = popFlag(args, '--revenue-file');
+  if (!revenueFile) die('--revenue-file is required.');
+  const revenueVouchers = normalizeContentList(loadJsonPayload(revenueFile));
+  const totalRevenue = revenueVouchers.reduce(
+    (sum, voucher) => sum + signedVoucherAmount(voucher, 'revenue'),
+    0,
+  );
+  return {
+    command: 'revenue-summary',
+    currency: 'EUR',
+    totalRevenue: roundMoney(totalRevenue),
+    voucherCount: revenueVouchers.length,
+    categoryBreakdown: categoryBreakdown(revenueVouchers),
+    costMeasurement: COST_MEASUREMENT,
+  };
+}
+
+function roundMoney(value) {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+function buildTransactionMatch(args) {
+  const transactionRaw = popFlag(args, '--transaction-json');
+  const invoicesFile = popFlag(args, '--invoices-file');
+  const threshold = Number(popFlag(args, '--threshold', '0.75'));
+  if (!transactionRaw) die('--transaction-json is required.');
+  if (!invoicesFile) die('--invoices-file is required.');
+  const transaction = parseJsonValue(transactionRaw, '--transaction-json');
+  const invoices = normalizeContentList(loadJsonPayload(invoicesFile));
+  const candidates = invoices
+    .map((invoice) => scoreInvoiceMatch(invoice, transaction))
+    .filter((candidate) => candidate.score > 0)
+    .sort((a, b) => b.score - a.score);
+  const best = candidates[0] ?? null;
+  return {
+    command: 'match-transaction',
+    transaction,
+    threshold,
+    bestMatch: best,
+    candidates,
+    matched: Boolean(best && best.score >= threshold),
+    writeOperation:
+      best && best.score >= threshold ? 'http-request match-transaction' : null,
+    costMeasurement: COST_MEASUREMENT,
+  };
+}
+
+function scoreInvoiceMatch(invoice, transaction) {
+  const reasons = [];
+  let score = 0;
+  const amount = Math.abs(amountValue(transaction.amount ?? transaction.value));
+  const openAmount = Math.abs(
+    amountValue(invoice.openAmount ?? voucherAmount(invoice)),
+  );
+  if (amount > 0 && openAmount > 0) {
+    const delta = Math.abs(amount - openAmount);
+    if (delta < 0.01) {
+      score += 0.55;
+      reasons.push('amount-exact');
+    } else if (delta <= 1) {
+      score += 0.35;
+      reasons.push('amount-near');
+    }
+  }
+  const memo = String(
+    transaction.purpose ??
+      transaction.remittanceInformation ??
+      transaction.description ??
+      '',
+  ).toLowerCase();
+  const voucherNumber = String(
+    invoice.voucherNumber ?? invoice.number ?? '',
+  ).toLowerCase();
+  if (voucherNumber && memo.includes(voucherNumber)) {
+    score += 0.3;
+    reasons.push('voucher-number');
+  }
+  const contactName = String(
+    invoice.contactName ?? invoice.address?.name ?? '',
+  ).toLowerCase();
+  if (contactName && memo.includes(contactName)) {
+    score += 0.15;
+    reasons.push('contact-name');
+  }
+  return {
+    voucherId: invoice.id,
+    voucherNumber: invoice.voucherNumber ?? invoice.number ?? null,
+    contactName: invoice.contactName ?? invoice.address?.name ?? null,
+    openAmount: invoice.openAmount ?? null,
+    totalAmount: voucherAmount(invoice),
+    score: roundMoney(Math.min(score, 1)),
+    reasons,
+  };
+}
+
+function handleHttpRequest(args) {
+  const operation = args.shift();
+  if (!operation) die('http-request requires an operation.');
+  if (READ_OPERATIONS.has(operation)) return buildReadRequest(operation, args);
+  if (WRITE_OPERATIONS.has(operation))
+    return buildWriteRequest(operation, args);
+  if (operation === 'match-transaction') {
+    return buildWriteRequest(operation, args);
+  }
+  die(`Unknown Lexware Office operation: ${operation}`);
+}
+
+function usage() {
+  return `Lexware Office skill helper
+
+Usage:
+  node skills/lexware-office/lexware_office.cjs --help
+  node skills/lexware-office/lexware_office.cjs plan "natural language request"
+  node skills/lexware-office/lexware_office.cjs http-request profile
+  node skills/lexware-office/lexware_office.cjs http-request list-contacts [--name NAME] [--email EMAIL] [--page N] [--size N]
+  node skills/lexware-office/lexware_office.cjs http-request get-contact --id UUID
+  node skills/lexware-office/lexware_office.cjs http-request list-products [--article-number VALUE] [--type PRODUCT|SERVICE]
+  node skills/lexware-office/lexware_office.cjs http-request list-invoices [--status open] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD]
+  node skills/lexware-office/lexware_office.cjs http-request get-invoice --id UUID
+  node skills/lexware-office/lexware_office.cjs http-request list-expenses [--status open] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD]
+  node skills/lexware-office/lexware_office.cjs http-request get-voucher --id UUID
+  node skills/lexware-office/lexware_office.cjs http-request get-payment --voucher-id UUID
+  node skills/lexware-office/lexware_office.cjs http-request list-bank-transactions [--status any]
+  node skills/lexware-office/lexware_office.cjs http-request posting-categories
+  node skills/lexware-office/lexware_office.cjs http-request income-statement-plan --start-date YYYY-MM-DD --end-date YYYY-MM-DD
+  node skills/lexware-office/lexware_office.cjs income-statement --revenue-file PATH --expense-file PATH [--categories-file PATH]
+  node skills/lexware-office/lexware_office.cjs revenue-summary --revenue-file PATH
+  node skills/lexware-office/lexware_office.cjs match-transaction --transaction-json JSON --invoices-file PATH
+  node skills/lexware-office/lexware_office.cjs http-request create-contact --json JSON --operator-grant
+  node skills/lexware-office/lexware_office.cjs http-request create-invoice --json JSON [--finalize] --operator-grant
+  node skills/lexware-office/lexware_office.cjs http-request log-expense --json JSON --operator-grant
+  node skills/lexware-office/lexware_office.cjs http-request upload-file --file PATH [--type voucher] --operator-grant
+  node skills/lexware-office/lexware_office.cjs http-request attach-file-to-voucher --voucher-id UUID --file PATH --operator-grant
+  node skills/lexware-office/lexware_office.cjs http-request match-transaction --voucher-id UUID --voucher-json JSON --transaction-json JSON --operator-grant
+  node skills/lexware-office/lexware_office.cjs eval-scenarios
+`;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const format = popFlag(args, '--format', 'json');
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    process.stdout.write(usage());
+    return;
+  }
+
+  const command = args.shift();
+  let payload;
+  if (command === 'plan') {
+    const request = args.join(' ').trim();
+    if (!request) die('plan requires a request.');
+    payload = planRequest(request);
+  } else if (command === 'http-request') {
+    payload = handleHttpRequest(args);
+  } else if (command === 'income-statement') {
+    payload = buildIncomeStatement(args);
+  } else if (command === 'revenue-summary') {
+    payload = buildRevenueSummary(args);
+  } else if (command === 'match-transaction') {
+    payload = buildTransactionMatch(args);
+  } else if (command === 'eval-scenarios') {
+    payload = runEvalScenarios();
+  } else {
+    die(`Unknown command: ${command}`);
+  }
+
+  if (format === 'json') {
+    printJson(payload);
+    return;
+  }
+  process.stdout.write(`${JSON.stringify(payload)}\n`);
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  planRequest,
+  runEvalScenarios,
+  buildIncomeStatement,
+  buildTransactionMatch,
+};

--- a/skills/lexware-office/lexware_office.cjs
+++ b/skills/lexware-office/lexware_office.cjs
@@ -386,8 +386,11 @@ function buildRevenuePlan(args) {
 }
 
 function buildBankTransactionPlan(args) {
-  const status = popFlag(args, '--status', 'any');
-  const originalArgs = [...args, '--status', status];
+  const status = popFlag(args, '--status');
+  const originalArgs = [...args];
+  if (status && status !== 'any') {
+    originalArgs.push('--status', status);
+  }
   return {
     command: 'bank-transaction-plan',
     note: 'Lexware Office Public API exposes bank-linked payments as paymentItems with paymentItemType partPaymentFinancialTransaction on /v1/payments/{voucherId}. Fetch candidate vouchers first, then fetch payment details per voucher id.',
@@ -395,7 +398,7 @@ function buildBankTransactionPlan(args) {
       buildVoucherListRequest([...originalArgs], {
         voucherType:
           'invoice,creditnote,salesinvoice,salescreditnote,purchaseinvoice,purchasecreditnote',
-        voucherStatus: status,
+        voucherStatus: status && status !== 'any' ? status : undefined,
       }).httpRequest,
     ],
     followUpRequestTemplate: {
@@ -728,21 +731,23 @@ function voucherAmount(voucher) {
   );
 }
 
-function signedVoucherAmount(voucher, kind) {
+function voucherSign(voucher) {
   const type = String(voucher.voucherType ?? voucher.type ?? '').toLowerCase();
-  const amount = voucherAmount(voucher);
-  const isCredit = type.includes('creditnote');
-  if (kind === 'revenue') return isCredit ? -amount : amount;
-  return isCredit ? -amount : amount;
+  return type.includes('creditnote') ? -1 : 1;
+}
+
+function signedVoucherAmount(voucher) {
+  return voucherSign(voucher) * voucherAmount(voucher);
 }
 
 function categoryBreakdown(vouchers) {
   const categories = {};
   for (const voucher of vouchers) {
+    const sign = voucherSign(voucher);
     for (const item of voucher.voucherItems ?? []) {
       const categoryId = item.categoryId || 'uncategorized';
       categories[categoryId] =
-        amountValue(categories[categoryId]) + amountValue(item.amount);
+        amountValue(categories[categoryId]) + sign * amountValue(item.amount);
     }
   }
   return categories;
@@ -759,11 +764,11 @@ function buildIncomeStatement(args) {
   const revenueVouchers = normalizeContentList(loadJsonPayload(revenueFile));
   const expenseVouchers = normalizeContentList(loadJsonPayload(expenseFile));
   const totalRevenue = revenueVouchers.reduce(
-    (sum, voucher) => sum + signedVoucherAmount(voucher, 'revenue'),
+    (sum, voucher) => sum + signedVoucherAmount(voucher),
     0,
   );
   const totalExpenses = expenseVouchers.reduce(
-    (sum, voucher) => sum + signedVoucherAmount(voucher, 'expense'),
+    (sum, voucher) => sum + signedVoucherAmount(voucher),
     0,
   );
   const categories = categoriesFile ? loadJsonPayload(categoriesFile) : null;
@@ -794,7 +799,7 @@ function buildRevenueSummary(args) {
   if (!revenueFile) die('--revenue-file is required.');
   const revenueVouchers = normalizeContentList(loadJsonPayload(revenueFile));
   const totalRevenue = revenueVouchers.reduce(
-    (sum, voucher) => sum + signedVoucherAmount(voucher, 'revenue'),
+    (sum, voucher) => sum + signedVoucherAmount(voucher),
     0,
   );
   return {
@@ -815,6 +820,9 @@ function buildTransactionMatch(args) {
   const transactionRaw = popFlag(args, '--transaction-json');
   const invoicesFile = popFlag(args, '--invoices-file');
   const threshold = Number(popFlag(args, '--threshold', '0.75'));
+  if (!Number.isFinite(threshold) || threshold < 0 || threshold > 1) {
+    die('--threshold must be a number between 0 and 1.');
+  }
   if (!transactionRaw) die('--transaction-json is required.');
   if (!invoicesFile) die('--invoices-file is required.');
   const transaction = parseJsonValue(transactionRaw, '--transaction-json');
@@ -906,10 +914,10 @@ Usage:
   node skills/lexware-office/lexware_office.cjs http-request profile
   node skills/lexware-office/lexware_office.cjs http-request list-contacts [--name NAME] [--email EMAIL] [--page N] [--size N]
   node skills/lexware-office/lexware_office.cjs http-request get-contact --id UUID
-  node skills/lexware-office/lexware_office.cjs http-request list-products [--article-number VALUE] [--type PRODUCT|SERVICE]
-  node skills/lexware-office/lexware_office.cjs http-request list-invoices [--status open] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD]
+  node skills/lexware-office/lexware_office.cjs http-request list-products [--article-number VALUE] [--type PRODUCT|SERVICE] [--page N] [--size N]
+  node skills/lexware-office/lexware_office.cjs http-request list-invoices [--status open] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--page N] [--size N]
   node skills/lexware-office/lexware_office.cjs http-request get-invoice --id UUID
-  node skills/lexware-office/lexware_office.cjs http-request list-expenses [--status open] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD]
+  node skills/lexware-office/lexware_office.cjs http-request list-expenses [--status open] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--page N] [--size N]
   node skills/lexware-office/lexware_office.cjs http-request get-voucher --id UUID
   node skills/lexware-office/lexware_office.cjs http-request get-payment --voucher-id UUID
   node skills/lexware-office/lexware_office.cjs http-request list-bank-transactions [--status any]

--- a/skills/lexware-office/lexware_office.cjs
+++ b/skills/lexware-office/lexware_office.cjs
@@ -899,9 +899,6 @@ function handleHttpRequest(args) {
   if (READ_OPERATIONS.has(operation)) return buildReadRequest(operation, args);
   if (WRITE_OPERATIONS.has(operation))
     return buildWriteRequest(operation, args);
-  if (operation === 'match-transaction') {
-    return buildWriteRequest(operation, args);
-  }
   die(`Unknown Lexware Office operation: ${operation}`);
 }
 

--- a/skills/lexware-office/references/operator-setup.md
+++ b/skills/lexware-office/references/operator-setup.md
@@ -1,0 +1,74 @@
+# Lexware Office Operator Setup
+
+## API Key
+
+Lexware Office uses a bearer API key for the Public API. Create the key in the
+Lexware Office account under the Public API add-on page:
+
+```text
+https://app.lexware.de/addons/public-api
+```
+
+Store the value in the encrypted HybridClaw runtime secret store:
+
+```bash
+hybridclaw secret set LEXWARE_OFFICE_API_KEY "<api-key>"
+```
+
+Do not paste the API key into chat, shell logs, tickets, or saved helper JSON.
+The skill helper emits `bearerSecretName: "LEXWARE_OFFICE_API_KEY"` so the
+gateway injects `Authorization: Bearer ...` server-side.
+
+## Public API Access
+
+Lexware Office requires a plan with Public API access. If the gateway injects
+the key but Lexware returns `401` or `403`, check that:
+
+- the key belongs to the active organization
+- Public API access is enabled for that account
+- the key has not been deleted or regenerated
+- the request targets `https://api.lexware.io`
+
+## Secret Route
+
+The helper can be used directly with the built-in `http_request` tool because
+it sets `bearerSecretName`. If the operator prefers a URL route, configure:
+
+```bash
+hybridclaw secret route add https://api.lexware.io/ LEXWARE_OFFICE_API_KEY Authorization Bearer
+```
+
+The helper path remains the same either way:
+
+```bash
+node skills/lexware-office/lexware_office.cjs http-request profile
+```
+
+## Operational Notes
+
+- Lexware documents a production resource URL of `https://api.lexware.io`.
+- Productive integrations should use that URL rather than the older
+  `api.lexoffice.io` gateway.
+- Lexware rate limits the Public API to 2 requests per second across resource
+  endpoints. Use small pages and back off on `429`.
+- Contacts, articles, vouchers, and voucherlist are paginated. Use `--page` and
+  `--size`; the helper caps `--size` at 250.
+- Voucher updates require the current `version` property for optimistic locking.
+  Read the voucher first, then update with the returned version.
+- The public payments endpoint is read-only. It can show payment items and
+  whether a financial transaction contributed to a payment. The skill can match
+  an incoming bank transaction against open invoices locally and, after
+  operator approval, write an auditable reconciliation note to the voucher.
+  Lexware's public docs do not expose a direct banking-module assignment
+  mutation.
+
+## Minimum Read Checks
+
+```bash
+node skills/lexware-office/lexware_office.cjs http-request profile
+node skills/lexware-office/lexware_office.cjs http-request list-contacts --size 5
+node skills/lexware-office/lexware_office.cjs http-request list-invoices --status open --size 5
+node skills/lexware-office/lexware_office.cjs http-request posting-categories
+```
+
+Pass each emitted `httpRequest` object to HybridClaw's `http_request` tool.

--- a/tests/lexware-office-skill.test.ts
+++ b/tests/lexware-office-skill.test.ts
@@ -71,6 +71,15 @@ test('Lexware Office helper --help exits cleanly', () => {
   expect(result.stdout).toContain('income-statement-plan');
   expect(result.stdout).toContain('income-statement');
   expect(result.stdout).toContain('match-transaction');
+  expect(result.stdout).toContain(
+    'list-products [--article-number VALUE] [--type PRODUCT|SERVICE] [--page N] [--size N]',
+  );
+  expect(result.stdout).toContain(
+    'list-invoices [--status open] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--page N] [--size N]',
+  );
+  expect(result.stdout).toContain(
+    'list-expenses [--status open] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--page N] [--size N]',
+  );
   expect(result.stdout).toContain('eval-scenarios');
 });
 
@@ -191,10 +200,27 @@ test('Lexware Office helper builds bank transaction read workflow', () => {
     bearerSecretName: 'LEXWARE_OFFICE_API_KEY',
   });
   expect(payload.requestSequence[0].url).toContain('/v1/voucherlist?');
+  expect(payload.requestSequence[0].url).toContain('voucherStatus=paid');
   expect(payload.followUpRequestTemplate.url).toBe(
     'https://api.lexware.io/v1/payments/{voucherId}',
   );
   expect(payload.filterPaymentItemType).toBe('partPaymentFinancialTransaction');
+});
+
+test('Lexware Office helper omits any status filter for bank transaction scans', () => {
+  const result = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'list-bank-transactions',
+    '--status',
+    'any',
+  ]);
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.requestSequence[0].url).not.toContain('voucherStatus=any');
+  expect(payload.requestSequence[0].url).not.toContain('voucherStatus=');
 });
 
 test('Lexware Office helper aggregates income statements from fetched voucher pages', () => {
@@ -215,6 +241,7 @@ test('Lexware Office helper aggregates income statements from fetched voucher pa
           id: '22222222-2222-4222-8222-222222222222',
           voucherType: 'creditnote',
           totalAmount: 100,
+          voucherItems: [{ amount: 100, categoryId: 'sales' }],
         },
       ],
     }),
@@ -262,6 +289,7 @@ test('Lexware Office helper aggregates income statements from fetched voucher pa
       expenseVouchers: 1,
     },
   });
+  expect(payload.categoryBreakdown.revenue.sales).toBe(900);
   expect(payload.categoryBreakdown.expenses.travel).toBe(250);
 });
 
@@ -367,6 +395,44 @@ test('Lexware Office helper matches bank transactions against open invoices', ()
     voucherId: '11111111-1111-4111-8111-111111111111',
     score: 1,
   });
+});
+
+test('Lexware Office helper validates transaction-match threshold', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lexware-office-'));
+  const invoicesPath = path.join(tempDir, 'invoices.json');
+  fs.writeFileSync(invoicesPath, JSON.stringify({ content: [] }));
+
+  const notNumber = runHelper([
+    '--format',
+    'json',
+    'match-transaction',
+    '--transaction-json',
+    '{"id":"tx-1","amount":119}',
+    '--invoices-file',
+    invoicesPath,
+    '--threshold',
+    'not-a-number',
+  ]);
+  const outOfRange = runHelper([
+    '--format',
+    'json',
+    'match-transaction',
+    '--transaction-json',
+    '{"id":"tx-1","amount":119}',
+    '--invoices-file',
+    invoicesPath,
+    '--threshold',
+    '1.5',
+  ]);
+
+  expect(notNumber.status).not.toBe(0);
+  expect(notNumber.stderr).toContain(
+    '--threshold must be a number between 0 and 1.',
+  );
+  expect(outOfRange.status).not.toBe(0);
+  expect(outOfRange.stderr).toContain(
+    '--threshold must be a number between 0 and 1.',
+  );
 });
 
 test('Lexware Office helper emits granted transaction-match voucher annotation request', () => {

--- a/tests/lexware-office-skill.test.ts
+++ b/tests/lexware-office-skill.test.ts
@@ -1,0 +1,469 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { expect, test } from 'vitest';
+
+const helperPath = path.join(
+  process.cwd(),
+  'skills',
+  'lexware-office',
+  'lexware_office.cjs',
+);
+const skillPath = path.join(
+  process.cwd(),
+  'skills',
+  'lexware-office',
+  'SKILL.md',
+);
+const scenariosPath = path.join(
+  process.cwd(),
+  'skills',
+  'lexware-office',
+  'evals',
+  'scenarios.json',
+);
+const docsPath = path.join(
+  process.cwd(),
+  'skills',
+  'lexware-office',
+  'references',
+  'operator-setup.md',
+);
+
+function runHelper(args: string[]) {
+  return spawnSync('node', [helperPath, ...args], {
+    encoding: 'utf-8',
+  });
+}
+
+test('Lexware Office skill manifest declares accounting category and safety metadata', () => {
+  const skill = fs.readFileSync(skillPath, 'utf-8');
+
+  expect(skill).toContain('name: lexware-office');
+  expect(skill).toContain('category: accounting');
+  expect(skill).toContain('LEXWARE_OFFICE_API_KEY');
+  expect(skill).toContain('https://api.lexware.io');
+  expect(skill).toContain('stakes_tiers:');
+  expect(skill).toContain('transaction-match-plan');
+  expect(skill).toContain('UsageTotals');
+});
+
+test('Lexware Office operator docs cover key creation and routing', () => {
+  const docs = fs.readFileSync(docsPath, 'utf-8');
+
+  expect(docs).toContain('https://app.lexware.de/addons/public-api');
+  expect(docs).toContain('hybridclaw secret set LEXWARE_OFFICE_API_KEY');
+  expect(docs).toContain('secret route add https://api.lexware.io/');
+  expect(docs).toContain('2 requests per second');
+  expect(docs).toContain('incoming bank transaction');
+});
+
+test('Lexware Office helper --help exits cleanly', () => {
+  const result = runHelper(['--help']);
+
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain('Lexware Office skill helper');
+  expect(result.stdout).toContain('list-contacts');
+  expect(result.stdout).toContain('list-invoices');
+  expect(result.stdout).toContain('log-expense');
+  expect(result.stdout).toContain('income-statement-plan');
+  expect(result.stdout).toContain('income-statement');
+  expect(result.stdout).toContain('match-transaction');
+  expect(result.stdout).toContain('eval-scenarios');
+});
+
+test('Lexware Office helper plans reads, writes, reports, and transaction matching', () => {
+  const invoiceRead = runHelper([
+    '--format',
+    'json',
+    'plan',
+    'Show open invoices in Lexware Office',
+  ]);
+  const invoiceWrite = runHelper([
+    '--format',
+    'json',
+    'plan',
+    'Generate an invoice for Acme GmbH',
+  ]);
+  const report = runHelper([
+    '--format',
+    'json',
+    'plan',
+    'Export the Q4 income statement',
+  ]);
+  const transactionMatch = runHelper([
+    '--format',
+    'json',
+    'plan',
+    'Match the incoming bank transaction with the open invoice',
+  ]);
+
+  expect(JSON.parse(invoiceRead.stdout)).toMatchObject({
+    operation: 'list-invoices',
+    requiresEscalation: false,
+  });
+  expect(JSON.parse(invoiceWrite.stdout)).toMatchObject({
+    operation: 'create-invoice',
+    stakesTier: 'amber',
+    requiredGrant: 'approve-lexware-office-create-invoice',
+  });
+  expect(JSON.parse(report.stdout)).toMatchObject({
+    operation: 'income-statement-plan',
+    requiresEscalation: false,
+  });
+  expect(JSON.parse(transactionMatch.stdout)).toMatchObject({
+    operation: 'match-transaction',
+    executable: true,
+    requiredGrant: 'approve-lexware-office-transaction-match',
+  });
+});
+
+test('Lexware Office helper emits gateway-proxied read requests without secrets', () => {
+  const result = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'list-invoices',
+    '--status',
+    'open',
+    '--size',
+    '50',
+  ]);
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.httpRequest).toMatchObject({
+    method: 'GET',
+    bearerSecretName: 'LEXWARE_OFFICE_API_KEY',
+    skillName: 'lexware-office',
+  });
+  expect(payload.httpRequest.url).toContain(
+    'https://api.lexware.io/v1/voucherlist?',
+  );
+  expect(payload.httpRequest.url).toContain('voucherType=invoice');
+  expect(payload.httpRequest.url).toContain('voucherStatus=open');
+  expect(payload.httpRequest.url).toContain('size=50');
+  expect(result.stdout).not.toContain('api-key');
+  expect(payload.costMeasurement.system).toBe('UsageTotals');
+});
+
+test('Lexware Office helper builds income statement read sequence', () => {
+  const result = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'income-statement-plan',
+    '--start-date',
+    '2026-10-01',
+    '--end-date',
+    '2026-12-31',
+  ]);
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.command).toBe('income-statement-plan');
+  expect(payload.requestSequence).toHaveLength(3);
+  expect(payload.requestSequence[0].url).toContain('/v1/voucherlist?');
+  expect(payload.requestSequence[1].url).toContain('/v1/voucherlist?');
+  expect(payload.requestSequence[2].url).toBe(
+    'https://api.lexware.io/v1/posting-categories',
+  );
+  expect(payload.costMeasurement.system).toBe('UsageTotals');
+});
+
+test('Lexware Office helper builds bank transaction read workflow', () => {
+  const result = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'list-bank-transactions',
+    '--status',
+    'paid',
+  ]);
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.command).toBe('bank-transaction-plan');
+  expect(payload.requestSequence[0]).toMatchObject({
+    method: 'GET',
+    bearerSecretName: 'LEXWARE_OFFICE_API_KEY',
+  });
+  expect(payload.requestSequence[0].url).toContain('/v1/voucherlist?');
+  expect(payload.followUpRequestTemplate.url).toBe(
+    'https://api.lexware.io/v1/payments/{voucherId}',
+  );
+  expect(payload.filterPaymentItemType).toBe('partPaymentFinancialTransaction');
+});
+
+test('Lexware Office helper aggregates income statements from fetched voucher pages', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lexware-office-'));
+  const revenuePath = path.join(tempDir, 'revenue.json');
+  const expensePath = path.join(tempDir, 'expenses.json');
+  fs.writeFileSync(
+    revenuePath,
+    JSON.stringify({
+      content: [
+        {
+          id: '11111111-1111-4111-8111-111111111111',
+          voucherType: 'invoice',
+          totalAmount: 1000,
+          voucherItems: [{ amount: 1000, categoryId: 'sales' }],
+        },
+        {
+          id: '22222222-2222-4222-8222-222222222222',
+          voucherType: 'creditnote',
+          totalAmount: 100,
+        },
+      ],
+    }),
+  );
+  fs.writeFileSync(
+    expensePath,
+    JSON.stringify({
+      content: [
+        {
+          id: '33333333-3333-4333-8333-333333333333',
+          voucherType: 'purchaseinvoice',
+          totalAmount: 250,
+          voucherItems: [{ amount: 250, categoryId: 'travel' }],
+        },
+      ],
+    }),
+  );
+
+  const result = runHelper([
+    '--format',
+    'json',
+    'income-statement',
+    '--revenue-file',
+    revenuePath,
+    '--expense-file',
+    expensePath,
+    '--start-date',
+    '2026-10-01',
+    '--end-date',
+    '2026-12-31',
+  ]);
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload).toMatchObject({
+    command: 'income-statement',
+    currency: 'EUR',
+    totals: {
+      revenue: 900,
+      expenses: 250,
+      netIncome: 650,
+    },
+    counts: {
+      revenueVouchers: 2,
+      expenseVouchers: 1,
+    },
+  });
+  expect(payload.categoryBreakdown.expenses.travel).toBe(250);
+});
+
+test('Lexware Office helper requires grants for writes', () => {
+  const result = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'create-invoice',
+    '--json',
+    '{"voucherDate":"2026-05-21T00:00:00.000+02:00"}',
+  ]);
+
+  expect(result.status).not.toBe(0);
+  expect(result.stderr).toContain(
+    'Refusing Lexware Office write without --operator-grant',
+  );
+});
+
+test('Lexware Office helper emits invoice write request after grant', () => {
+  const result = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'create-invoice',
+    '--json',
+    '{"voucherDate":"2026-05-21T00:00:00.000+02:00"}',
+    '--finalize',
+    '--operator-grant',
+  ]);
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.httpRequest).toMatchObject({
+    method: 'POST',
+    url: 'https://api.lexware.io/v1/invoices?finalize=true',
+    bearerSecretName: 'LEXWARE_OFFICE_API_KEY',
+  });
+  expect(payload.httpRequest.json).toEqual({
+    voucherDate: '2026-05-21T00:00:00.000+02:00',
+  });
+});
+
+test('Lexware Office helper validates UUIDs and page size bounds', () => {
+  const badUuid = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'get-invoice',
+    '--id',
+    'not-a-uuid',
+  ]);
+  const badSize = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'list-contacts',
+    '--size',
+    '251',
+  ]);
+
+  expect(badUuid.status).not.toBe(0);
+  expect(badUuid.stderr).toContain('--id must be a UUID.');
+  expect(badSize.status).not.toBe(0);
+  expect(badSize.stderr).toContain('--size must be between 1 and 250.');
+});
+
+test('Lexware Office helper matches bank transactions against open invoices', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lexware-office-'));
+  const invoicesPath = path.join(tempDir, 'invoices.json');
+  fs.writeFileSync(
+    invoicesPath,
+    JSON.stringify({
+      content: [
+        {
+          id: '11111111-1111-4111-8111-111111111111',
+          voucherNumber: '2026-042',
+          contactName: 'Acme GmbH',
+          openAmount: 119,
+        },
+      ],
+    }),
+  );
+
+  const result = runHelper([
+    '--format',
+    'json',
+    'match-transaction',
+    '--transaction-json',
+    '{"id":"tx-1","amount":119,"purpose":"Payment invoice 2026-042 Acme GmbH"}',
+    '--invoices-file',
+    invoicesPath,
+  ]);
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload).toMatchObject({
+    command: 'match-transaction',
+    matched: true,
+    writeOperation: 'http-request match-transaction',
+  });
+  expect(payload.bestMatch).toMatchObject({
+    voucherId: '11111111-1111-4111-8111-111111111111',
+    score: 1,
+  });
+});
+
+test('Lexware Office helper emits granted transaction-match voucher annotation request', () => {
+  const result = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'match-transaction',
+    '--voucher-id',
+    '11111111-1111-4111-8111-111111111111',
+    '--voucher-json',
+    '{"id":"11111111-1111-4111-8111-111111111111","type":"salesinvoice","voucherNumber":"2026-042","version":3,"remark":"Original"}',
+    '--transaction-json',
+    '{"id":"tx-1","amount":119,"bookingDate":"2026-05-21","counterpartyName":"Acme GmbH"}',
+    '--operator-grant',
+  ]);
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.httpRequest).toMatchObject({
+    method: 'PUT',
+    url: 'https://api.lexware.io/v1/vouchers/11111111-1111-4111-8111-111111111111',
+    bearerSecretName: 'LEXWARE_OFFICE_API_KEY',
+  });
+  expect(payload.httpRequest.json).not.toHaveProperty('id');
+  expect(payload.httpRequest.json).toMatchObject({
+    type: 'salesinvoice',
+    voucherNumber: '2026-042',
+    version: 3,
+  });
+  expect(payload.httpRequest.json.remark).toContain(
+    'HybridClaw bank match: transaction tx-1',
+  );
+});
+
+test('Lexware Office helper builds multipart receipt uploads', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lexware-office-'));
+  const receiptPath = path.join(tempDir, 'receipt.pdf');
+  fs.writeFileSync(receiptPath, 'pdf-bytes');
+
+  const result = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'upload-file',
+    '--file',
+    receiptPath,
+    '--operator-grant',
+  ]);
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.httpRequest).toMatchObject({
+    method: 'POST',
+    url: 'https://api.lexware.io/v1/files',
+    bearerSecretName: 'LEXWARE_OFFICE_API_KEY',
+  });
+  expect(payload.httpRequest.headers['Content-Type']).toContain(
+    'multipart/form-data',
+  );
+  expect(payload.httpRequest.bodyBase64).toBeTypeOf('string');
+});
+
+test('Lexware Office helper eval suite covers roadmap behaviors', () => {
+  const scenarios = JSON.parse(
+    fs.readFileSync(scenariosPath, 'utf-8'),
+  ) as Array<{ category?: string; expected?: { costSystem?: string } }>;
+  const categories = new Set(scenarios.map((scenario) => scenario.category));
+
+  expect(scenarios.length).toBeGreaterThanOrEqual(25);
+  expect(scenarios.length).toBeLessThanOrEqual(30);
+  expect(categories).toEqual(
+    new Set([
+      'invoice_read',
+      'invoice_write',
+      'customer_read',
+      'customer_write',
+      'product_read',
+      'expense_read',
+      'expense_write',
+      'payment_read',
+      'payment_write',
+      'accounting_read',
+      'report_read',
+      'profile_read',
+    ]),
+  );
+  expect(
+    scenarios.every(
+      (scenario) => scenario.expected?.costSystem === 'UsageTotals',
+    ),
+  ).toBe(true);
+
+  const result = runHelper(['--format', 'json', 'eval-scenarios']);
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.scenarioCount).toBe(scenarios.length);
+  expect(payload.failed).toBe(0);
+  expect(payload.costMeasurement.system).toBe('UsageTotals');
+});


### PR DESCRIPTION
## Summary

Closes #653.

Adds a bundled `lexware-office` accounting skill for Lexware Office / lexoffice workflows, including:

- R21.1-style `SKILL.md` package with `metadata.hybridclaw.category: accounting`
- gateway-injected bearer auth via `LEXWARE_OFFICE_API_KEY`
- read helpers for contacts, products/articles, invoices, vouchers/Belege, payments, posting categories, bank-linked payment scans, and report planning
- guarded write helpers for contact creation, invoice creation, voucher/expense logging, receipt upload/attach, voucher update, and transaction reconciliation notes
- local income statement and revenue summary aggregation over fetched Lexware voucher JSON
- local bank transaction matching against open invoices plus a conservative operator-approved voucher annotation write path
- 28 offline eval scenarios and focused Vitest coverage
- operator setup docs and bundled skill catalog references

## Notes

Lexware Public API docs expose payment reads and bank-linked payment items, but do not document a direct banking-module assignment mutation. The skill therefore makes transaction matching executable as a conservative reconciliation workflow: score the transaction locally, then write an auditable operator-approved note to the voucher through the documented voucher update endpoint.

## Validation

- `python3 skills/skill-creator/scripts/quick_validate.py skills/lexware-office`
- `node skills/lexware-office/lexware_office.cjs --format json eval-scenarios`
- `npx vitest run tests/lexware-office-skill.test.ts`
- `npx biome check skills/lexware-office tests/lexware-office-skill.test.ts docs/content/guides/skills/integrations.md README.md docs/content/guides/bundled-skills.md`
- `./node_modules/.bin/tsc --noEmit --noUnusedLocals --noUnusedParameters`
- `git diff --check`