### PR TITLE
feat: add Lexware Office skill

### DIFF
--- a/docs/content/guides/bundled-skills.md
+++ b/docs/content/guides/bundled-skills.md
@@ -11,7 +11,7 @@ HybridClaw ships with 50+ bundled skills. A few notable categories:
 - office workflows: `pdf`, `xlsx`, `docx`, `pptx`, `office-workflows`
 - planning and engineering: `project-manager`, `feature-planning`, `code-review`, `code-simplification`, `gh-issues`, `warehouse-sql`
 - visual explainers, image, video, and speech: `diagram`, `manim-video`, `excalidraw`, `image-generation`, `video-generation`, `video.from-script`, `speech.transcribe`, `speech.detect-language`
-- platform integrations: `github-pr-workflow`, `notion`, `trello`, `stripe`, `download-platform-invoices`, `wordpress`, `gog`, `google-workspace`, `google-ads`, `ga4`, `airtable`, `fastbill`, `firecrawl`, `heygen`, `hermes3000-writing`, `discord`
+- platform integrations: `github-pr-workflow`, `notion`, `trello`, `stripe`, `download-platform-invoices`, `wordpress`, `gog`, `google-workspace`, `google-ads`, `ga4`, `airtable`, `fastbill`, `lexware-office`, `firecrawl`, `heygen`, `hermes3000-writing`, `discord`
 - infrastructure and DevOps: `hetzner-cloud`, `hetzner-dns`, `hetzner-storage-box`, `warehouse-sql`
 - knowledge workflows: `llm-wiki`, `obsidian`, `zettelkasten`
 - search workflows: `search.web`, `search.news`, `search.images`

--- a/skills/lexware-office/SKILL.md
+++ b/skills/lexware-office/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: lexware-office
+description: "Work with Lexware Office invoices, contacts, products, receipts, payments, and accounting reports through the Lexware Public API."
+user-invocable: true
+requires:
+  bins:
+    - node
+credentials:
+  - id: lexware-office-api-key
+    kind: bearer
+    required: true
+    secret_ref:
+      source: store
+      id: LEXWARE_OFFICE_API_KEY
+    scope: "https://api.lexware.io/v1"
+    how_to_obtain: "Generate a private API key at https://app.lexware.de/addons/public-api, then store it with `hybridclaw secret set LEXWARE_OFFICE_API_KEY \"<api-key>\"`."
+metadata:
+  hybridclaw:
+    category: accounting
+    short_description: "Lexware Office accounting for German SMEs."
+    tags:
+      - accounting
+      - invoices
+      - lexware
+      - lexoffice
+      - bookkeeping
+      - germany
+    related_skills:
+      - fastbill
+      - download-platform-invoices
+      - pdf
+---
+# Lexware Office
+
+Use this skill when the user wants to read or manage Lexware Office invoices,
+customers, products/services, expense receipts, payment status, posting
+categories, or derived revenue/expense reporting.
+
+Lexware Office was formerly known as lexoffice. Use the current Lexware Public
+API gateway at `https://api.lexware.io/v1`.
+
+## Scope
+
+- read organization profile
+- list and inspect customers/contacts
+- list and inspect products/services through articles
+- list invoice metadata through voucherlist
+- inspect invoices and download invoice files
+- list expense receipts/bookkeeping vouchers
+- download bookkeeping voucher files
+- inspect voucher payment status
+- upload receipt files to the Belege inbox
+- attach receipt files to an existing voucher
+- list posting categories for bookkeeping
+- derive income statement source data from voucherlist metadata and aggregate it
+- extract bank-linked payment items from voucher payment responses
+- create invoices
+- log expense receipts as bookkeeping vouchers
+- prepare a conservative transaction-match handoff
+
+## Credential Rules
+
+Lexware authenticates with a private API key sent as a bearer token. Store it in
+HybridClaw encrypted runtime secrets; never paste it into the prompt.
+
+Recommended setup:
+
+```bash
+hybridclaw secret set LEXWARE_OFFICE_API_KEY <lexware-office-api-key>
+```
+
+The helper builds `http_request` payloads with `bearerSecretName:
+"LEXWARE_OFFICE_API_KEY"` so the gateway injects `Authorization: Bearer ...`
+server-side. Secret values must not be printed, persisted, or returned to the
+model.
+
+For setup details, account-specific secret names, and API notes, read
+[references/operator-setup.md](references/operator-setup.md).
+
+## Default Workflow
+
+1. Start with read-only operations such as `list-invoices`, `list-customers`,
+   `list-products`, `list-expenses`, `payment-status`, or
+   `income-statement-plan`.
+2. For writes, build a dry run or exact payload first and stop unless the
+   operator has granted that mutation in the current task.
+3. Pass `--operator-grant` only after the user explicitly asks for the write.
+4. Prefer Lexware UUIDs over names for writes. If multiple contacts, invoices,
+   vouchers, or articles match, ask for the exact ID before writing.
+5. Use the helper to build an `http_request` payload, then call the built-in
+   `http_request` tool. Do not use shell `curl` for live calls.
+6. Keep responses summarized as JSON-shaped facts; do not expose bearer tokens,
+   headers, or raw secret-route diagnostics.
+
+## Command Contract
+
+Run the colocated helper with Node:
+
+```bash
+node skills/lexware-office/lexware_office.cjs --help
+```
+
+Plan a natural-language request without contacting Lexware:
+
+```bash
+node skills/lexware-office/lexware_office.cjs plan "Show outstanding invoices over 30 days late"
+```
+
+Build read requests:
+
+```bash
+node skills/lexware-office/lexware_office.cjs http-request list-invoices --query-json '{"voucherStatus":"open","voucherDateFrom":"2026-01-01"}'
+node skills/lexware-office/lexware_office.cjs http-request list-customers --query-json '{"name":"Acme GmbH"}'
+node skills/lexware-office/lexware_office.cjs http-request get-invoice --id e9066f04-8cc7-4616-93f8-ac9ecc8479c8
+node skills/lexware-office/lexware_office.cjs http-request payment-status --id e9066f04-8cc7-4616-93f8-ac9ecc8479c8
+node skills/lexware-office/lexware_office.cjs http-request download-file --id f9066f04-8cc7-4616-93f8-ac9ecc8479c8
+```
+
+Build a derived income statement read plan:
+
+```bash
+node skills/lexware-office/lexware_office.cjs income-statement-plan --from 2026-10-01 --to 2026-12-31
+node skills/lexware-office/lexware_office.cjs aggregate-income-statement --revenue-json '{"content":[{"voucherType":"invoice","totalAmount":1190}]}' --expenses-json '{"content":[{"voucherType":"purchaseinvoice","totalAmount":357}]}'
+node skills/lexware-office/lexware_office.cjs bank-transactions-from-payments --payments-json '{"id":"...","paymentItems":[{"paymentItemType":"partPaymentFinancialTransaction","amount":1190,"currency":"EUR"}]}'
+```
+
+Build write requests only after explicit operator grant:
+
+```bash
+node skills/lexware-office/lexware_office.cjs create-invoice --body-json '{"voucherDate":"2026-05-21T00:00:00.000+02:00","address":{"contactId":"..."},"lineItems":[],"totalPrice":{"currency":"EUR"},"taxConditions":{"taxType":"net"},"shippingConditions":{"shippingType":"service","shippingDate":"2026-05-21T00:00:00.000+02:00"}}' --operator-grant
+node skills/lexware-office/lexware_office.cjs log-expense --body-json '{"type":"purchaseinvoice","voucherStatus":"open","voucherNumber":"EXP-2026-001","voucherDate":"2026-05-21","totalGrossAmount":119,"totalTaxAmount":19,"taxType":"gross","useCollectiveContact":true,"contactName":"Deutsche Bahn","voucherItems":[{"amount":119,"taxAmount":19,"taxRatePercent":19,"categoryId":"..."}]}' --operator-grant
+node skills/lexware-office/lexware_office.cjs upload-file --file receipts/train.pdf --operator-grant
+node skills/lexware-office/lexware_office.cjs attach-voucher-file --id e9066f04-8cc7-4616-93f8-ac9ecc8479c8 --file receipts/train.pdf --operator-grant
+```
+
+Prepare a manual transaction-match handoff only after explicit operator grant:
+
+```bash
+node skills/lexware-office/lexware_office.cjs match-transaction --transaction-id txn-123 --voucher-id e9066f04-8cc7-4616-93f8-ac9ecc8479c8 --operator-grant
+```
+
+Run offline eval scenarios:
+
+```bash
+node skills/lexware-office/lexware_office.cjs eval-scenarios
+```
+
+## Conservative Mutations
+
+These actions require `--operator-grant`:
+
+- `create-invoice`
+- `log-expense`
+- `upload-file`
+- `attach-voucher-file`
+- `match-transaction`
+
+`match-transaction` produces a manual handoff. The Lexware Public API exposes
+payment status through `/payments/{id}` and labels bank-linked payments as
+`partPaymentFinancialTransaction`, but it does not expose a tenant-wide raw bank
+transaction feed or transaction matching writes. Do not invent an endpoint.
+
+## Reporting Notes
+
+Income statement requests are derived from voucherlist source requests for
+revenue and expense voucher types. Use `income-statement-plan` to produce the
+source `http_request` calls, then pass the collected voucherlist responses to
+`aggregate-income-statement`. Treat the result as an operational report unless
+the operator confirms the exact accounting basis needed for tax, Steuerberater,
+or statutory reporting.
+
+Bank transaction reads are derived from `/payments/{voucherId}` responses. Use
+`bank-transactions-from-payments` to extract `partPaymentFinancialTransaction`
+items after collecting payment statuses for candidate vouchers.
+
+Cost per assistant run is recorded by HybridClaw `UsageTotals`; helper and eval
+outputs include `costMeasurement.system = "UsageTotals"` so the accounting
+contract can be verified.
+
+## Validation
+
+Run:
+
+```bash
+python3 skills/skill-creator/scripts/quick_validate.py skills/lexware-office
+node skills/lexware-office/lexware_office.cjs --help
+node skills/lexware-office/lexware_office.cjs eval-scenarios
+node skills/lexware-office/lexware_office.cjs http-request list-invoices
+node skills/lexware-office/lexware_office.cjs income-statement-plan --from 2026-01-01 --to 2026-03-31
+node skills/lexware-office/lexware_office.cjs aggregate-income-statement --revenue-json '{"content":[{"voucherType":"invoice","totalAmount":100}]}' --expenses-json '{"content":[{"voucherType":"purchaseinvoice","totalAmount":40}]}'
+```

--- a/skills/lexware-office/evals/scenarios.json
+++ b/skills/lexware-office/evals/scenarios.json
@@ -1,0 +1,212 @@
+[
+  {
+    "id": "lexware-001",
+    "category": "invoice-read",
+    "prompt": "Show open invoices in Lexware Office.",
+    "expected": { "operation": "list-invoices", "operatorGrantRequired": false },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-002",
+    "category": "invoice-read",
+    "prompt": "Pull outstanding invoices older than 30 days.",
+    "expected": { "operation": "list-invoices", "operatorGrantRequired": false },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-003",
+    "category": "invoice-read",
+    "prompt": "Get invoice details by id for RE-2026-041.",
+    "expected": { "operation": "get-invoice", "operatorGrantRequired": false },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-004",
+    "category": "invoice-read",
+    "prompt": "Download the PDF file for this Lexware invoice.",
+    "expected": { "operation": "invoice-file", "operatorGrantRequired": false },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-005",
+    "category": "invoice-write",
+    "prompt": "Generate an invoice for Acme GmbH for last month's consulting hours.",
+    "expected": { "operation": "create-invoice", "operatorGrantRequired": true },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-006",
+    "category": "invoice-write",
+    "prompt": "Create and finalize a new Rechnung in Lexware Office.",
+    "expected": { "operation": "create-invoice", "operatorGrantRequired": true },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-007",
+    "category": "customers",
+    "prompt": "Find the customer record for Acme GmbH.",
+    "expected": { "operation": "list-customers", "operatorGrantRequired": false },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-008",
+    "category": "customers",
+    "prompt": "Look up the Kunde by email billing@example.com.",
+    "expected": { "operation": "list-customers", "operatorGrantRequired": false },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-009",
+    "category": "products",
+    "prompt": "List products and services I can use as Lexware invoice line items.",
+    "expected": { "operation": "list-products", "operatorGrantRequired": false },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-010",
+    "category": "products",
+    "prompt": "Find the Artikel for monthly retainer.",
+    "expected": { "operation": "list-products", "operatorGrantRequired": false },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-011",
+    "category": "expenses",
+    "prompt": "Show the Reisekosten Belege for Q4.",
+    "expected": { "operation": "list-expenses", "operatorGrantRequired": false },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-012",
+    "category": "expenses",
+    "prompt": "Sync this expense receipt with the Lexware Belege module.",
+    "expected": { "operation": "log-expense", "operatorGrantRequired": true },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-013",
+    "category": "expenses",
+    "prompt": "Record a purchase invoice for train travel.",
+    "expected": { "operation": "log-expense", "operatorGrantRequired": true },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-014",
+    "category": "payments",
+    "prompt": "Read payment status and open amount for this voucher id.",
+    "expected": { "operation": "payment-status", "operatorGrantRequired": false },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-015",
+    "category": "payments",
+    "prompt": "Show incoming bank transaction status for this invoice.",
+    "expected": { "operation": "list-bank-transactions", "operatorGrantRequired": false },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-016",
+    "category": "payments",
+    "prompt": "Match incoming bank transaction with the open invoice in Lexware Office.",
+    "expected": { "operation": "match-transaction", "operatorGrantRequired": true },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-017",
+    "category": "reporting",
+    "prompt": "Export the Q4 income statement from Lexware Office.",
+    "expected": { "operation": "income-statement", "operatorGrantRequired": false },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-018",
+    "category": "reporting",
+    "prompt": "What's our current revenue this quarter according to Lexware?",
+    "expected": { "operation": "income-statement", "operatorGrantRequired": false },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-019",
+    "category": "reporting",
+    "prompt": "Prepare a P&L from Lexware vouchers for March.",
+    "expected": { "operation": "income-statement", "operatorGrantRequired": false },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-020",
+    "category": "bookkeeping",
+    "prompt": "List posting categories for travel expenses.",
+    "expected": { "operation": "posting-categories", "operatorGrantRequired": false },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-021",
+    "category": "profile",
+    "prompt": "Show the Lexware organization profile and company name.",
+    "expected": { "operation": "profile", "operatorGrantRequired": false },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-022",
+    "category": "voucher-read",
+    "prompt": "Get the Beleg by id from Lexware.",
+    "expected": { "operation": "get-voucher", "operatorGrantRequired": false },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-023",
+    "category": "voucher-read",
+    "prompt": "Show all purchase invoices in Lexware.",
+    "expected": { "operation": "list-expenses", "operatorGrantRequired": false },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-024",
+    "category": "invoice-read",
+    "prompt": "Find overdue Lexware invoices due before last month.",
+    "expected": { "operation": "list-invoices", "operatorGrantRequired": false },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-025",
+    "category": "payments",
+    "prompt": "Check whether invoice voucher 123 is paid off.",
+    "expected": { "operation": "payment-status", "operatorGrantRequired": false },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-026",
+    "category": "expenses",
+    "prompt": "Upload and book a receipt under category Reisekosten.",
+    "expected": { "operation": "upload-file", "operatorGrantRequired": true },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-029",
+    "category": "expenses",
+    "prompt": "Attach this receipt file to the existing Beleg in Lexware.",
+    "expected": { "operation": "upload-file", "operatorGrantRequired": true },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-030",
+    "category": "expenses",
+    "prompt": "Download the receipt file for this Beleg id.",
+    "expected": { "operation": "download-file", "operatorGrantRequired": false },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-027",
+    "category": "customers",
+    "prompt": "Search contacts for customer number 10037.",
+    "expected": { "operation": "list-customers", "operatorGrantRequired": false },
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "lexware-028",
+    "category": "products",
+    "prompt": "Read service article details by id.",
+    "expected": { "operation": "list-products", "operatorGrantRequired": false },
+    "costMeasurement": { "system": "UsageTotals" }
+  }
+]

--- a/skills/lexware-office/index.cjs
+++ b/skills/lexware-office/index.cjs
@@ -1,0 +1,1 @@
+module.exports = require('./lexware_office.cjs');

--- a/skills/lexware-office/lexware_office.cjs
+++ b/skills/lexware-office/lexware_office.cjs
@@ -1,0 +1,1051 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const API_BASE = 'https://api.lexware.io/v1';
+const DEFAULT_TIMEOUT_MS = 30000;
+const DEFAULT_BEARER_SECRET_NAME = 'LEXWARE_OFFICE_API_KEY';
+const EVAL_SCENARIOS_PATH = path.join(__dirname, 'evals', 'scenarios.json');
+const MULTIPART_BOUNDARY_PREFIX = '----hybridclaw-lexware-office-';
+
+const COST_MEASUREMENT = {
+  system: 'UsageTotals',
+  source: 'HybridClaw usage_events',
+  scope: 'per assistant run/session',
+  fields: [
+    'total_input_tokens',
+    'total_output_tokens',
+    'total_tokens',
+    'total_cost_usd',
+    'call_count',
+    'total_tool_calls',
+  ],
+};
+
+const OPERATION_DEFINITIONS = {
+  profile: {
+    method: 'GET',
+    path: '/profile',
+    read: true,
+  },
+  'list-customers': {
+    method: 'GET',
+    path: '/contacts',
+    read: true,
+    paged: true,
+    queryKeys: ['email', 'name', 'number', 'customer', 'vendor'],
+    htmlEncodedQueryKeys: ['email', 'name'],
+  },
+  'get-customer': {
+    method: 'GET',
+    path: '/contacts/{id}',
+    read: true,
+    needsId: true,
+  },
+  'list-products': {
+    method: 'GET',
+    path: '/articles',
+    read: true,
+    paged: true,
+  },
+  'get-product': {
+    method: 'GET',
+    path: '/articles/{id}',
+    read: true,
+    needsId: true,
+  },
+  'list-invoices': {
+    method: 'GET',
+    path: '/voucherlist',
+    read: true,
+    paged: true,
+    defaults: {
+      voucherType: 'invoice,downpaymentinvoice',
+      voucherStatus: 'open,paid,paidoff,draft',
+    },
+    queryKeys: [
+      'voucherType',
+      'voucherStatus',
+      'voucherNumber',
+      'voucherDateFrom',
+      'voucherDateTo',
+      'updatedDateFrom',
+      'updatedDateTo',
+      'archived',
+    ],
+    htmlEncodedQueryKeys: ['voucherNumber'],
+  },
+  'get-invoice': {
+    method: 'GET',
+    path: '/invoices/{id}',
+    read: true,
+    needsId: true,
+  },
+  'invoice-file': {
+    method: 'GET',
+    path: '/invoices/{id}/file',
+    read: true,
+    needsId: true,
+    accept: '*/*',
+  },
+  'download-file': {
+    method: 'GET',
+    path: '/files/{id}',
+    read: true,
+    needsId: true,
+    accept: '*/*',
+  },
+  'list-expenses': {
+    method: 'GET',
+    path: '/voucherlist',
+    read: true,
+    paged: true,
+    defaults: {
+      voucherType: 'purchaseinvoice,purchasecreditnote',
+      voucherStatus: 'open,paid,paidoff,unchecked',
+    },
+    queryKeys: [
+      'voucherType',
+      'voucherStatus',
+      'voucherNumber',
+      'voucherDateFrom',
+      'voucherDateTo',
+      'updatedDateFrom',
+      'updatedDateTo',
+      'archived',
+    ],
+    htmlEncodedQueryKeys: ['voucherNumber'],
+  },
+  'get-voucher': {
+    method: 'GET',
+    path: '/vouchers/{id}',
+    read: true,
+    needsId: true,
+  },
+  'payment-status': {
+    method: 'GET',
+    path: '/payments/{id}',
+    read: true,
+    needsId: true,
+  },
+  'posting-categories': {
+    method: 'GET',
+    path: '/posting-categories',
+    read: true,
+  },
+  'create-invoice': {
+    method: 'POST',
+    path: '/invoices',
+    write: true,
+    bodyRequired: true,
+    grant: 'approve-lexware-office-invoice-create',
+  },
+  'log-expense': {
+    method: 'POST',
+    path: '/vouchers',
+    write: true,
+    bodyRequired: true,
+    grant: 'approve-lexware-office-expense-log',
+  },
+  'upload-file': {
+    method: 'POST',
+    path: '/files',
+    write: true,
+    fileRequired: true,
+    grant: 'approve-lexware-office-file-upload',
+  },
+  'attach-voucher-file': {
+    method: 'POST',
+    path: '/vouchers/{id}/files',
+    write: true,
+    fileRequired: true,
+    needsId: true,
+    grant: 'approve-lexware-office-voucher-file-attach',
+  },
+};
+
+const READ_OPERATIONS = new Set(
+  Object.entries(OPERATION_DEFINITIONS)
+    .filter(([, definition]) => definition.read)
+    .map(([operation]) => operation),
+);
+const WRITE_OPERATIONS = new Set(
+  Object.entries(OPERATION_DEFINITIONS)
+    .filter(([, definition]) => definition.write)
+    .map(([operation]) => operation),
+);
+const VIRTUAL_OPERATIONS = new Set([
+  'income-statement',
+  'list-bank-transactions',
+  'match-transaction',
+]);
+const SUPPORTED_OPERATIONS = new Set([
+  ...READ_OPERATIONS,
+  ...WRITE_OPERATIONS,
+  ...VIRTUAL_OPERATIONS,
+]);
+
+class LexwareOfficeConfigError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'LexwareOfficeConfigError';
+    this.code = 'LEXWARE_OFFICE_CONFIG_ERROR';
+  }
+}
+
+class LexwareOfficeOperatorGrantError extends Error {
+  constructor(operation, grant) {
+    super(
+      `Lexware Office operation ${operation} mutates accounting data and requires --operator-grant (${grant}).`,
+    );
+    this.name = 'LexwareOfficeOperatorGrantError';
+    this.code = 'LEXWARE_OFFICE_OPERATOR_GRANT_REQUIRED';
+    this.operation = operation;
+    this.requiredGrant = grant;
+  }
+}
+
+function usageTotalsMeasurement() {
+  return { ...COST_MEASUREMENT, fields: [...COST_MEASUREMENT.fields] };
+}
+
+function normalizeOperation(operation) {
+  const normalized = String(operation || '')
+    .trim()
+    .toLowerCase();
+  if (!SUPPORTED_OPERATIONS.has(normalized)) {
+    throw new LexwareOfficeConfigError(
+      `Unsupported Lexware Office operation: ${operation}`,
+    );
+  }
+  return normalized;
+}
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith('--')) {
+      args._.push(arg);
+      continue;
+    }
+    const key = arg.slice(2);
+    if (['dry-run', 'operator-grant', 'finalize', 'help'].includes(key)) {
+      args[key] = true;
+      continue;
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith('--')) {
+      throw new LexwareOfficeConfigError(`Missing value for --${key}`);
+    }
+    args[key] = value;
+    index += 1;
+  }
+  return args;
+}
+
+function printJson(value) {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function parseJsonValue(raw, label) {
+  if (!raw) return undefined;
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new LexwareOfficeConfigError(
+      `${label} is not valid JSON: ${error.message}`,
+    );
+  }
+}
+
+function parseJsonFile(filePath, label) {
+  if (!filePath) return undefined;
+  try {
+    return parseJsonValue(
+      fs.readFileSync(path.resolve(filePath), 'utf8'),
+      label,
+    );
+  } catch (error) {
+    if (error instanceof LexwareOfficeConfigError) throw error;
+    throw new LexwareOfficeConfigError(
+      `Cannot read ${label} JSON file ${filePath}: ${error.message}`,
+    );
+  }
+}
+
+function resolveJsonInput(args, label) {
+  const inline = parseJsonValue(args[`${label}-json`], label);
+  const file = parseJsonFile(args[`${label}-file`], label);
+  if (inline !== undefined && file !== undefined) {
+    throw new LexwareOfficeConfigError(
+      `Use either --${label}-json or --${label}-file, not both.`,
+    );
+  }
+  return inline ?? file;
+}
+
+function parsePositiveInt(value, flag, max = 250) {
+  if (value === undefined || value === null || value === '') return undefined;
+  if (!/^\d+$/u.test(String(value))) {
+    throw new LexwareOfficeConfigError(`${flag} must be a positive integer.`);
+  }
+  const parsed = Number(value);
+  if (parsed < 1 || parsed > max) {
+    throw new LexwareOfficeConfigError(`${flag} must be between 1 and ${max}.`);
+  }
+  return parsed;
+}
+
+function parsePage(value) {
+  if (value === undefined || value === null || value === '') return undefined;
+  if (!/^\d+$/u.test(String(value))) {
+    throw new LexwareOfficeConfigError(
+      '--page must be a non-negative integer.',
+    );
+  }
+  return Number(value);
+}
+
+function parseIsoDate(value, flag) {
+  if (!value) return undefined;
+  if (!/^\d{4}-\d{2}-\d{2}$/u.test(String(value))) {
+    throw new LexwareOfficeConfigError(`${flag} must use YYYY-MM-DD format.`);
+  }
+  return value;
+}
+
+function resolveFileUpload(input) {
+  if (!input.filePath) {
+    throw new LexwareOfficeConfigError(
+      '--file is required for this operation.',
+    );
+  }
+  const filePath = path.resolve(input.filePath);
+  let file;
+  try {
+    const stat = fs.statSync(filePath);
+    if (!stat.isFile()) {
+      throw new LexwareOfficeConfigError(
+        `--file is not a file: ${input.filePath}`,
+      );
+    }
+    file = fs.readFileSync(filePath);
+  } catch (error) {
+    if (error instanceof LexwareOfficeConfigError) throw error;
+    throw new LexwareOfficeConfigError(
+      `Cannot read upload file ${input.filePath}: ${error.message}`,
+    );
+  }
+  return {
+    file,
+    filename: input.filename || path.basename(filePath),
+    mimeType: input.mimeType || guessMimeType(filePath),
+  };
+}
+
+function guessMimeType(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === '.pdf') return 'application/pdf';
+  if (ext === '.png') return 'image/png';
+  if (ext === '.jpg' || ext === '.jpeg') return 'image/jpeg';
+  if (ext === '.xml') return 'application/xml';
+  return 'application/octet-stream';
+}
+
+function sanitizeMultipartToken(value, label) {
+  const text = String(value || '').trim();
+  if (!text) throw new LexwareOfficeConfigError(`${label} must not be empty.`);
+  if (/[\r\n"]/u.test(text)) {
+    throw new LexwareOfficeConfigError(
+      `${label} must not contain quotes or newlines.`,
+    );
+  }
+  return text;
+}
+
+function buildMultipartBody(parts) {
+  const boundary = `${MULTIPART_BOUNDARY_PREFIX}${Date.now().toString(36)}`;
+  const chunks = [];
+  for (const part of parts) {
+    chunks.push(Buffer.from(`--${boundary}\r\n`, 'utf8'));
+    const name = sanitizeMultipartToken(part.name, 'multipart part name');
+    if (part.file) {
+      const filename = sanitizeMultipartToken(part.filename, 'filename');
+      chunks.push(
+        Buffer.from(
+          `Content-Disposition: form-data; name="${name}"; filename="${filename}"\r\nContent-Type: ${part.mimeType}\r\n\r\n`,
+          'utf8',
+        ),
+      );
+      chunks.push(part.value);
+      chunks.push(Buffer.from('\r\n', 'utf8'));
+    } else {
+      chunks.push(
+        Buffer.from(
+          `Content-Disposition: form-data; name="${name}"\r\n\r\n`,
+          'utf8',
+        ),
+      );
+      chunks.push(Buffer.from(String(part.value), 'utf8'));
+      chunks.push(Buffer.from('\r\n', 'utf8'));
+    }
+  }
+  chunks.push(Buffer.from(`--${boundary}--\r\n`, 'utf8'));
+  return {
+    boundary,
+    bodyBase64: Buffer.concat(chunks).toString('base64'),
+  };
+}
+
+function htmlEncodeSearchValue(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function appendQuery(url, params = {}) {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === '') continue;
+    if (Array.isArray(value)) {
+      for (const entry of value) search.append(key, String(entry));
+    } else {
+      search.set(key, String(value));
+    }
+  }
+  const query = search.toString();
+  return query ? `${url}?${query}` : url;
+}
+
+function buildQuery(definition, inputQuery = {}, input = {}) {
+  const allowed = new Set([...(definition.queryKeys || []), 'page', 'size']);
+  const htmlEncoded = new Set(definition.htmlEncodedQueryKeys || []);
+  const query = { ...(definition.defaults || {}) };
+
+  for (const [key, value] of Object.entries(inputQuery || {})) {
+    if (allowed.size > 2 && !allowed.has(key)) {
+      throw new LexwareOfficeConfigError(
+        `Unsupported query parameter for this operation: ${key}`,
+      );
+    }
+    query[key] = htmlEncoded.has(key) ? htmlEncodeSearchValue(value) : value;
+  }
+  if (definition.paged) {
+    query.page = parsePage(input.page) ?? query.page ?? 0;
+    query.size = parsePositiveInt(input.size, '--size') ?? query.size ?? 100;
+  }
+  return query;
+}
+
+function buildUrl(definition, input) {
+  if (definition.needsId && !input.id) {
+    throw new LexwareOfficeConfigError('--id is required for this operation.');
+  }
+  const pathWithId = definition.path.replace(
+    '{id}',
+    encodeURIComponent(input.id || ''),
+  );
+  const query = buildQuery(definition, input.query, input);
+  if (input.finalize && definition.path === '/invoices') {
+    query.finalize = 'true';
+  }
+  return appendQuery(`${API_BASE}${pathWithId}`, query);
+}
+
+function assertOperatorGrant(operation, definition, hasGrant, dryRun) {
+  if (definition.write && !hasGrant && !dryRun) {
+    throw new LexwareOfficeOperatorGrantError(operation, definition.grant);
+  }
+}
+
+function buildHttpRequest(input) {
+  const operation = normalizeOperation(input.operation);
+  const definition = OPERATION_DEFINITIONS[operation];
+  if (!definition) {
+    if (operation === 'income-statement')
+      return buildIncomeStatementPlan(input);
+    if (operation === 'list-bank-transactions')
+      return buildBankTransactionLimitation();
+    if (operation === 'match-transaction')
+      return buildTransactionMatchHandoff(input);
+  }
+  assertOperatorGrant(
+    operation,
+    definition,
+    Boolean(input.operatorGrant),
+    Boolean(input.dryRun),
+  );
+  if (definition.bodyRequired && !input.body) {
+    throw new LexwareOfficeConfigError(
+      '--body-json or --body-file is required.',
+    );
+  }
+  if (definition.fileRequired && !input.filePath) {
+    throw new LexwareOfficeConfigError(
+      '--file is required for this operation.',
+    );
+  }
+  const request = {
+    url: buildUrl(definition, input),
+    method: definition.method,
+    headers: {
+      Accept: definition.accept || 'application/json',
+    },
+    timeoutMs: input.timeoutMs || DEFAULT_TIMEOUT_MS,
+    bearerSecretName: input.bearerSecretName || DEFAULT_BEARER_SECRET_NAME,
+    skillName: 'lexware-office',
+  };
+  if (definition.fileRequired) {
+    const upload = resolveFileUpload(input);
+    const parts =
+      operation === 'upload-file'
+        ? [
+            { name: 'type', value: input.uploadType || 'voucher' },
+            {
+              name: 'file',
+              value: upload.file,
+              file: true,
+              filename: upload.filename,
+              mimeType: upload.mimeType,
+            },
+          ]
+        : [
+            {
+              name: 'file',
+              value: upload.file,
+              file: true,
+              filename: upload.filename,
+              mimeType: upload.mimeType,
+            },
+          ];
+    const multipart = buildMultipartBody(parts);
+    request.headers['Content-Type'] =
+      `multipart/form-data; boundary=${multipart.boundary}`;
+    request.bodyBase64 = multipart.bodyBase64;
+  } else if (definition.method !== 'GET') {
+    request.headers['Content-Type'] = 'application/json';
+    request.json = input.body;
+  }
+  if (input.traceId) request.headers['x-trace-id'] = input.traceId;
+  return {
+    operation,
+    mutatesAccount: Boolean(definition.write),
+    requiredGrant: definition.grant || null,
+    dryRun: Boolean(input.dryRun),
+    httpRequest: request,
+    costMeasurement: usageTotalsMeasurement(),
+  };
+}
+
+function buildIncomeStatementPlan(input = {}) {
+  const from = parseIsoDate(input.from, '--from');
+  const to = parseIsoDate(input.to, '--to');
+  if (!from || !to) {
+    throw new LexwareOfficeConfigError(
+      'income-statement requires --from YYYY-MM-DD and --to YYYY-MM-DD.',
+    );
+  }
+  const common = {
+    voucherDateFrom: from,
+    voucherDateTo: to,
+  };
+  return {
+    operation: 'income-statement',
+    mutatesAccount: false,
+    basis:
+      'Derived from voucherlist revenue and expense voucher metadata; Lexware Public API does not expose a dedicated BWA/P&L endpoint.',
+    sourceRequests: [
+      buildHttpRequest({
+        operation: 'list-invoices',
+        query: {
+          ...common,
+          voucherType:
+            'invoice,downpaymentinvoice,salesinvoice,salescreditnote',
+          voucherStatus: 'open,paid,paidoff',
+        },
+        page: input.page,
+        size: input.size,
+        bearerSecretName: input.bearerSecretName,
+      }).httpRequest,
+      buildHttpRequest({
+        operation: 'list-expenses',
+        query: {
+          ...common,
+          voucherType: 'purchaseinvoice,purchasecreditnote',
+          voucherStatus: 'open,paid,paidoff',
+        },
+        page: input.page,
+        size: input.size,
+        bearerSecretName: input.bearerSecretName,
+      }).httpRequest,
+    ],
+    aggregation: {
+      revenueVoucherTypes: ['invoice', 'downpaymentinvoice', 'salesinvoice'],
+      contraRevenueVoucherTypes: ['salescreditnote'],
+      expenseVoucherTypes: ['purchaseinvoice', 'purchasecreditnote'],
+      amountFields: ['totalAmount', 'totalGrossAmount', 'openAmount'],
+      currency: 'EUR',
+    },
+    costMeasurement: usageTotalsMeasurement(),
+  };
+}
+
+function buildBankTransactionLimitation() {
+  return {
+    operation: 'list-bank-transactions',
+    mutatesAccount: false,
+    apiLimitation:
+      'The Lexware Public API exposes voucher payment status through /payments/{id}, but not a raw bank-transaction feed.',
+    supportedReadPath:
+      'Use bank-transactions-from-payments after collecting /payments/{voucherId} responses; it extracts paymentItems with type partPaymentFinancialTransaction.',
+    costMeasurement: usageTotalsMeasurement(),
+  };
+}
+
+function buildTransactionMatchHandoff(input = {}) {
+  if (!input.operatorGrant && !input.dryRun) {
+    throw new LexwareOfficeOperatorGrantError(
+      'match-transaction',
+      'approve-lexware-office-transaction-match',
+    );
+  }
+  return {
+    operation: 'match-transaction',
+    mutatesAccount: true,
+    requiredGrant: 'approve-lexware-office-transaction-match',
+    apiLimitation:
+      'The Lexware Public API does not expose a transaction-matching write endpoint. Use this as an operator-approved manual handoff in Lexware Office.',
+    manualHandoff: {
+      transactionId: input.transactionId || null,
+      voucherId: input.voucherId || input.invoiceId || null,
+      expectedAction:
+        'Open Lexware Office bank transactions, verify amount/date/counterparty, and match the transaction to the selected voucher.',
+    },
+    costMeasurement: usageTotalsMeasurement(),
+  };
+}
+
+function unwrapGatewayBody(value) {
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value;
+    }
+  }
+  if (value && typeof value === 'object') {
+    if (value.bodyJson !== undefined) return value.bodyJson;
+    if (value.json !== undefined) return value.json;
+    if (typeof value.body === 'string') {
+      try {
+        return JSON.parse(value.body);
+      } catch {
+        return value.body;
+      }
+    }
+  }
+  return value;
+}
+
+function collectObjects(value) {
+  const unwrapped = unwrapGatewayBody(value);
+  if (Array.isArray(unwrapped)) return unwrapped;
+  if (!unwrapped || typeof unwrapped !== 'object') return [];
+  if (Array.isArray(unwrapped.content)) return unwrapped.content;
+  if (Array.isArray(unwrapped.items)) return unwrapped.items;
+  if (Array.isArray(unwrapped.vouchers)) return unwrapped.vouchers;
+  return [unwrapped];
+}
+
+function amount(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function voucherAmount(voucher) {
+  return amount(
+    voucher.totalAmount ??
+      voucher.totalGrossAmount ??
+      voucher.amount ??
+      voucher.openAmount,
+  );
+}
+
+function aggregateIncomeStatement(input = {}) {
+  const revenueItems = collectObjects(input.revenue);
+  const expenseItems = collectObjects(input.expenses);
+  const revenue = revenueItems.reduce((sum, item) => {
+    const type = String(item.voucherType || item.type || '').toLowerCase();
+    const sign = type.includes('creditnote') ? -1 : 1;
+    return sum + sign * voucherAmount(item);
+  }, 0);
+  const expenses = expenseItems.reduce(
+    (sum, item) => sum + voucherAmount(item),
+    0,
+  );
+  return {
+    operation: 'income-statement',
+    mutatesAccount: false,
+    basis: 'Derived from Lexware voucherlist response payloads.',
+    period: {
+      from: input.from || null,
+      to: input.to || null,
+    },
+    totals: {
+      revenue: Number(revenue.toFixed(2)),
+      expenses: Number(expenses.toFixed(2)),
+      netIncome: Number((revenue - expenses).toFixed(2)),
+      currency: 'EUR',
+    },
+    sourceCounts: {
+      revenueVouchers: revenueItems.length,
+      expenseVouchers: expenseItems.length,
+    },
+    costMeasurement: usageTotalsMeasurement(),
+  };
+}
+
+function extractBankTransactionsFromPayments(input = {}) {
+  const payments = collectObjects(input.payments);
+  const transactions = [];
+  for (const payment of payments) {
+    const items = Array.isArray(payment.paymentItems)
+      ? payment.paymentItems
+      : [];
+    for (const item of items) {
+      if (item.paymentItemType !== 'partPaymentFinancialTransaction') continue;
+      transactions.push({
+        voucherId: payment.voucherId || payment.id || input.voucherId || null,
+        voucherType: payment.voucherType || null,
+        voucherStatus: payment.voucherStatus || null,
+        postingDate: item.postingDate || null,
+        amount: amount(item.amount),
+        currency: item.currency || payment.currency || 'EUR',
+        paymentItemType: item.paymentItemType,
+      });
+    }
+  }
+  return {
+    operation: 'list-bank-transactions',
+    mutatesAccount: false,
+    source: 'Extracted from Lexware /payments/{voucherId} paymentItems.',
+    transactions,
+    transactionCount: transactions.length,
+    costMeasurement: usageTotalsMeasurement(),
+  };
+}
+
+function planLexwareOfficeRequest(text) {
+  const raw = String(text || '').trim();
+  const normalized = raw.toLowerCase();
+  let operation = 'list-invoices';
+
+  if (
+    /(income statement|p&l|profit and loss|guv|bwa|revenue.*quarter|umsatz)/u.test(
+      normalized,
+    )
+  ) {
+    operation = 'income-statement';
+  } else if (
+    /(match|reconcile|zuordnen).*(transaction|bank|zahlung|invoice|rechnung)/u.test(
+      normalized,
+    )
+  ) {
+    operation = 'match-transaction';
+  } else if (
+    /(bank transaction|banking transaction|kontoumsatz|zahlungseingang)/u.test(
+      normalized,
+    )
+  ) {
+    operation = 'list-bank-transactions';
+  } else if (
+    /(payment status|paid status|open amount|outstanding payment|paid off|paidoff)/u.test(
+      normalized,
+    )
+  ) {
+    operation = 'payment-status';
+  } else if (
+    /(create|draft|generate|new).*(invoice|rechnung)/u.test(normalized)
+  ) {
+    operation = 'create-invoice';
+  } else if (
+    /(download|file|pdf|xrechnung|zugferd).*(invoice|rechnung)/u.test(
+      normalized,
+    )
+  ) {
+    operation = 'invoice-file';
+  } else if (
+    /(download).*(receipt|beleg|voucher file|file)|receipt file.*(download|get)/u.test(
+      normalized,
+    )
+  ) {
+    operation = 'download-file';
+  } else if (
+    /(receipt|beleg|expense|reisekosten|purchase invoice).*(sync|upload|attach|file|log|create|book|record)/u.test(
+      normalized,
+    ) ||
+    /(sync|upload|attach|file|log|create|book|record).*(receipt|beleg|expense|reisekosten|purchase invoice)/u.test(
+      normalized,
+    )
+  ) {
+    operation = /(upload|attach|file)/u.test(normalized)
+      ? 'upload-file'
+      : 'log-expense';
+  } else if (/(category|posting categor|konto|kontierung)/u.test(normalized)) {
+    operation = 'posting-categories';
+  } else if (
+    /(expense|belege|receipts|purchase invoices|reisekosten)/u.test(normalized)
+  ) {
+    operation = 'list-expenses';
+  } else if (/(customer|contact|kunde)/u.test(normalized)) {
+    operation = 'list-customers';
+  } else if (/(product|article|service|leistung|artikel)/u.test(normalized)) {
+    operation = 'list-products';
+  } else if (/(profile|organization|company)/u.test(normalized)) {
+    operation = 'profile';
+  } else if (/(voucher|beleg).*id/u.test(normalized)) {
+    operation = 'get-voucher';
+  } else if (/(invoice|rechnung).*id/u.test(normalized)) {
+    operation = 'get-invoice';
+  }
+
+  const mutatesAccount =
+    WRITE_OPERATIONS.has(operation) || operation === 'match-transaction';
+  return {
+    input: raw,
+    operation,
+    mutatesAccount,
+    operatorGrantRequired: mutatesAccount,
+    defaultAutonomy: mutatesAccount
+      ? 'operator_grant_required'
+      : 'read_allowed',
+    apiNotes:
+      operation === 'list-bank-transactions' ||
+      operation === 'match-transaction'
+        ? 'Lexware Public API does not expose raw bank-transaction listing or matching writes; use payment-status reads and operator handoff.'
+        : undefined,
+    costMeasurement: usageTotalsMeasurement(),
+  };
+}
+
+function loadEvalScenarios() {
+  return JSON.parse(fs.readFileSync(EVAL_SCENARIOS_PATH, 'utf8'));
+}
+
+function evaluateScenarios() {
+  const scenarios = loadEvalScenarios();
+  const results = scenarios.map((scenario) => {
+    const plan = planLexwareOfficeRequest(scenario.prompt);
+    const pass =
+      plan.operation === scenario.expected.operation &&
+      plan.operatorGrantRequired === scenario.expected.operatorGrantRequired &&
+      scenario.costMeasurement?.system === 'UsageTotals';
+    return {
+      id: scenario.id,
+      category: scenario.category,
+      pass,
+      expected: scenario.expected,
+      actual: {
+        operation: plan.operation,
+        operatorGrantRequired: plan.operatorGrantRequired,
+      },
+    };
+  });
+  const failed = results.filter((result) => !result.pass);
+  return {
+    command: 'eval-scenarios',
+    scenarioCount: scenarios.length,
+    passed: results.length - failed.length,
+    failed: failed.length,
+    results,
+    costMeasurement: usageTotalsMeasurement(),
+  };
+}
+
+function commonInput(args) {
+  return {
+    bearerSecretName:
+      args['bearer-secret-name'] ||
+      process.env.LEXWARE_OFFICE_BEARER_SECRET_NAME ||
+      DEFAULT_BEARER_SECRET_NAME,
+    dryRun: Boolean(args['dry-run']),
+    operatorGrant: Boolean(args['operator-grant']),
+    page: args.page,
+    size: args.size,
+    traceId: args['trace-id'],
+  };
+}
+
+function printHelp() {
+  process.stdout.write(`Lexware Office skill helper
+
+Usage:
+  node skills/lexware-office/lexware_office.cjs plan "natural language request"
+  node skills/lexware-office/lexware_office.cjs http-request <operation> [--id ID] [--query-json JSON] [--body-json JSON] [--operator-grant] [--finalize]
+  node skills/lexware-office/lexware_office.cjs income-statement-plan --from YYYY-MM-DD --to YYYY-MM-DD
+  node skills/lexware-office/lexware_office.cjs aggregate-income-statement --revenue-json JSON --expenses-json JSON [--from YYYY-MM-DD] [--to YYYY-MM-DD]
+  node skills/lexware-office/lexware_office.cjs bank-transactions-from-payments --payments-json JSON
+  node skills/lexware-office/lexware_office.cjs create-invoice --body-json JSON --operator-grant [--finalize]
+  node skills/lexware-office/lexware_office.cjs log-expense --body-json JSON --operator-grant
+  node skills/lexware-office/lexware_office.cjs upload-file --file PATH --operator-grant [--type voucher]
+  node skills/lexware-office/lexware_office.cjs attach-voucher-file --id VOUCHER_ID --file PATH --operator-grant
+  node skills/lexware-office/lexware_office.cjs match-transaction --transaction-id ID --voucher-id ID --operator-grant
+  node skills/lexware-office/lexware_office.cjs eval-scenarios
+
+Read operations:
+  profile, list-customers, get-customer, list-products, get-product,
+  list-invoices, get-invoice, invoice-file, list-expenses, get-voucher,
+  download-file, payment-status, posting-categories, income-statement,
+  list-bank-transactions
+
+Write operations requiring --operator-grant:
+  create-invoice, log-expense, upload-file, attach-voucher-file, match-transaction
+
+Environment:
+  LEXWARE_OFFICE_BEARER_SECRET_NAME  Stored secret name, default ${DEFAULT_BEARER_SECRET_NAME}
+`);
+}
+
+async function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const command = args._[0];
+  if (!command || command === 'help' || args.help) {
+    printHelp();
+    return;
+  }
+
+  if (command === 'plan') {
+    printJson(planLexwareOfficeRequest(args._.slice(1).join(' ')));
+    return;
+  }
+
+  if (command === 'eval-scenarios') {
+    const result = evaluateScenarios();
+    printJson(result);
+    if (result.failed > 0) process.exitCode = 1;
+    return;
+  }
+
+  if (command === 'income-statement-plan') {
+    printJson(
+      buildIncomeStatementPlan({
+        ...commonInput(args),
+        from: args.from,
+        to: args.to,
+      }),
+    );
+    return;
+  }
+
+  if (command === 'aggregate-income-statement') {
+    printJson(
+      aggregateIncomeStatement({
+        revenue: resolveJsonInput(args, 'revenue'),
+        expenses: resolveJsonInput(args, 'expenses'),
+        from: parseIsoDate(args.from, '--from'),
+        to: parseIsoDate(args.to, '--to'),
+      }),
+    );
+    return;
+  }
+
+  if (command === 'bank-transactions-from-payments') {
+    printJson(
+      extractBankTransactionsFromPayments({
+        payments: resolveJsonInput(args, 'payments'),
+        voucherId: args['voucher-id'],
+      }),
+    );
+    return;
+  }
+
+  if (command === 'match-transaction') {
+    printJson(
+      buildTransactionMatchHandoff({
+        ...commonInput(args),
+        transactionId: args['transaction-id'],
+        voucherId: args['voucher-id'],
+        invoiceId: args['invoice-id'],
+      }),
+    );
+    return;
+  }
+
+  if (command === 'http-request') {
+    printJson(
+      buildHttpRequest({
+        ...commonInput(args),
+        operation: args._[1],
+        id: args.id,
+        query: resolveJsonInput(args, 'query') || {},
+        body: resolveJsonInput(args, 'body'),
+        finalize: Boolean(args.finalize),
+      }),
+    );
+    return;
+  }
+
+  if (
+    command === 'create-invoice' ||
+    command === 'log-expense' ||
+    command === 'upload-file' ||
+    command === 'attach-voucher-file'
+  ) {
+    printJson(
+      buildHttpRequest({
+        ...commonInput(args),
+        operation: command,
+        id: args.id,
+        body: resolveJsonInput(args, 'body'),
+        filePath: args.file,
+        filename: args.filename,
+        mimeType: args['mime-type'],
+        uploadType: args.type,
+        finalize: Boolean(args.finalize),
+      }),
+    );
+    return;
+  }
+
+  throw new LexwareOfficeConfigError(`Unknown command: ${command}`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    printJson({
+      error: {
+        name: error.name || 'Error',
+        code: error.code || 'LEXWARE_OFFICE_ERROR',
+        message: error.message,
+        operation: error.operation,
+        requiredGrant: error.requiredGrant,
+      },
+      costMeasurement: usageTotalsMeasurement(),
+    });
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  API_BASE,
+  DEFAULT_BEARER_SECRET_NAME,
+  READ_OPERATIONS,
+  WRITE_OPERATIONS,
+  SUPPORTED_OPERATIONS,
+  LexwareOfficeConfigError,
+  LexwareOfficeOperatorGrantError,
+  buildBankTransactionLimitation,
+  aggregateIncomeStatement,
+  buildHttpRequest,
+  buildIncomeStatementPlan,
+  buildTransactionMatchHandoff,
+  evaluateScenarios,
+  extractBankTransactionsFromPayments,
+  htmlEncodeSearchValue,
+  planLexwareOfficeRequest,
+  usageTotalsMeasurement,
+};

--- a/skills/lexware-office/references/operator-setup.md
+++ b/skills/lexware-office/references/operator-setup.md
@@ -1,0 +1,109 @@
+# Lexware Office Operator Setup
+
+## API Surface
+
+Use the current Lexware Public API gateway:
+
+```text
+https://api.lexware.io/v1
+```
+
+Lexware rebranded from lexoffice to Lexware and changed the production API
+gateway on 2025-05-26. Use `https://api.lexware.io` for new integrations.
+
+## Secret Storage
+
+Generate the private API key in Lexware Office:
+
+```text
+https://app.lexware.de/addons/public-api
+```
+
+Store it in HybridClaw encrypted runtime secrets:
+
+```bash
+hybridclaw secret set LEXWARE_OFFICE_API_KEY <lexware-office-api-key>
+```
+
+Do not paste the API key into chat, shell history, eval fixtures, logs, or skill
+arguments. The helper emits `http_request` payloads with:
+
+```json
+{
+  "bearerSecretName": "LEXWARE_OFFICE_API_KEY",
+  "skillName": "lexware-office"
+}
+```
+
+That lets the gateway inject `Authorization: Bearer ...` without exposing the
+secret value to the model.
+
+For tenant-specific accounts, store a separate secret and pass it as:
+
+```bash
+node skills/lexware-office/lexware_office.cjs http-request list-invoices \
+  --bearer-secret-name LEXWARE_OFFICE_API_KEY_TENANT_A
+```
+
+## Operator Grants
+
+Read operations can run at default autonomy:
+
+- profile, contacts, articles/products, invoices, voucherlist, vouchers
+- payment status through `/payments/{id}`
+- posting categories
+- derived income statement source requests from voucherlist metadata
+
+Write operations require explicit operator grant in the current task:
+
+- `create-invoice`
+- `log-expense`
+- `upload-file`
+- `attach-voucher-file`
+- `match-transaction`
+
+Use `upload-file` for `POST /files` to place voucher files in the Lexware
+unchecked folder. Use `attach-voucher-file` for `POST /vouchers/{id}/files` when
+the operator already selected the target voucher.
+
+`match-transaction` is a manual handoff because the Lexware Public API exposes
+payment status and bank-linked payment items, but not raw bank transaction feeds
+or a transaction matching write endpoint. The assistant must not invent an API
+call for that action.
+
+## API Notes
+
+- Contacts and voucherlist search values containing `&`, `<`, or `>` need HTML
+  entity encoding before URL encoding. The helper handles this for supported
+  search keys.
+- Lexware API rate limits are documented as 2 requests per second. Paginated
+  reporting workflows should throttle requests.
+- Voucher updates use optimistic locking with a `version` property. This skill
+  does not perform voucher update writes; if a future write path is added, fetch
+  the latest resource version first.
+- Income statement output is derived from voucherlist revenue/expense metadata.
+  Lexware Public API does not provide a dedicated income-statement or BWA
+  endpoint.
+- Bank-transaction reads are derived from `/payments/{voucherId}` responses by
+  extracting `paymentItems` whose `paymentItemType` is
+  `partPaymentFinancialTransaction`.
+
+## Validation
+
+```bash
+python3 skills/skill-creator/scripts/quick_validate.py skills/lexware-office
+node skills/lexware-office/lexware_office.cjs --help
+node skills/lexware-office/lexware_office.cjs eval-scenarios
+node skills/lexware-office/lexware_office.cjs http-request list-invoices
+node skills/lexware-office/lexware_office.cjs income-statement-plan --from 2026-01-01 --to 2026-03-31
+node skills/lexware-office/lexware_office.cjs aggregate-income-statement --revenue-json '{"content":[{"voucherType":"invoice","totalAmount":100}]}' --expenses-json '{"content":[{"voucherType":"purchaseinvoice","totalAmount":40}]}'
+node skills/lexware-office/lexware_office.cjs bank-transactions-from-payments --payments-json '{"id":"voucher-1","paymentItems":[{"paymentItemType":"partPaymentFinancialTransaction","amount":100,"currency":"EUR"}]}'
+```
+
+## References
+
+- Lexware Public API documentation: https://developers.lexware.io/docs/
+- Invoice cookbook: https://developers.lexware.io/cookbooks/invoices/
+- Bookkeeping cookbook: https://developers.lexware.io/cookbooks/bookkeeping/
+- Public API key page: https://app.lexware.de/addons/public-api
+- Lexware status page: https://status.lexware.de

--- a/tests/lexware-office-skill.test.ts
+++ b/tests/lexware-office-skill.test.ts
@@ -1,0 +1,365 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { expect, test } from 'vitest';
+
+const helperPath = path.join(
+  process.cwd(),
+  'skills',
+  'lexware-office',
+  'lexware_office.cjs',
+);
+const skillPath = path.join(
+  process.cwd(),
+  'skills',
+  'lexware-office',
+  'SKILL.md',
+);
+const scenariosPath = path.join(
+  process.cwd(),
+  'skills',
+  'lexware-office',
+  'evals',
+  'scenarios.json',
+);
+
+function runHelper(args: string[]) {
+  return spawnSync('node', [helperPath, ...args], {
+    encoding: 'utf-8',
+  });
+}
+
+test('Lexware Office skill manifest declares accounting scope and secret handling', () => {
+  const skill = fs.readFileSync(skillPath, 'utf-8');
+
+  expect(skill).toContain('name: lexware-office');
+  expect(skill).toContain('category: accounting');
+  expect(skill).toContain('LEXWARE_OFFICE_API_KEY');
+  expect(skill).toContain('https://app.lexware.de/addons/public-api');
+  expect(skill).toContain('https://api.lexware.io/v1');
+  expect(skill).toContain('create-invoice');
+  expect(skill).toContain('log-expense');
+  expect(skill).toContain('match-transaction');
+  expect(skill).toContain('UsageTotals');
+});
+
+test('Lexware Office helper --help exits cleanly', () => {
+  const result = runHelper(['--help']);
+
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain('Lexware Office skill helper');
+  expect(result.stdout).toContain('http-request <operation>');
+  expect(result.stdout).toContain('income-statement-plan');
+  expect(result.stdout).toContain('eval-scenarios');
+});
+
+test('Lexware Office helper plans reads, guarded writes, and API limitations', () => {
+  const invoices = runHelper([
+    'plan',
+    'Pull outstanding invoices older than 30 days',
+  ]);
+  const createInvoice = runHelper([
+    'plan',
+    'Generate an invoice for Acme GmbH for consulting',
+  ]);
+  const receipt = runHelper([
+    'plan',
+    'Sync this expense receipt with category Reisekosten',
+  ]);
+  const bankTransactions = runHelper([
+    'plan',
+    'Show incoming bank transaction status for this invoice',
+  ]);
+  const match = runHelper([
+    'plan',
+    'Match incoming bank transaction with the open invoice',
+  ]);
+  const upload = runHelper(['plan', 'Upload this receipt file to Lexware']);
+
+  expect(invoices.status).toBe(0);
+  expect(createInvoice.status).toBe(0);
+  expect(receipt.status).toBe(0);
+  expect(bankTransactions.status).toBe(0);
+  expect(match.status).toBe(0);
+  expect(upload.status).toBe(0);
+  expect(JSON.parse(invoices.stdout)).toMatchObject({
+    operation: 'list-invoices',
+    operatorGrantRequired: false,
+  });
+  expect(JSON.parse(createInvoice.stdout)).toMatchObject({
+    operation: 'create-invoice',
+    operatorGrantRequired: true,
+  });
+  expect(JSON.parse(receipt.stdout)).toMatchObject({
+    operation: 'log-expense',
+    operatorGrantRequired: true,
+  });
+  expect(JSON.parse(bankTransactions.stdout)).toMatchObject({
+    operation: 'list-bank-transactions',
+    operatorGrantRequired: false,
+  });
+  expect(JSON.parse(match.stdout)).toMatchObject({
+    operation: 'match-transaction',
+    operatorGrantRequired: true,
+  });
+  expect(JSON.parse(upload.stdout)).toMatchObject({
+    operation: 'upload-file',
+    operatorGrantRequired: true,
+  });
+});
+
+test('Lexware Office helper builds bearer-secret http_request payloads', () => {
+  const result = runHelper([
+    'http-request',
+    'list-invoices',
+    '--query-json',
+    '{"voucherStatus":"open","voucherNumber":"ACME & Partner"}',
+    '--size',
+    '25',
+  ]);
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload).toMatchObject({
+    operation: 'list-invoices',
+    mutatesAccount: false,
+    httpRequest: {
+      method: 'GET',
+      bearerSecretName: 'LEXWARE_OFFICE_API_KEY',
+      skillName: 'lexware-office',
+    },
+    costMeasurement: { system: 'UsageTotals' },
+  });
+  expect(payload.httpRequest.url).toContain(
+    'https://api.lexware.io/v1/voucherlist?',
+  );
+  expect(payload.httpRequest.url).toContain('voucherStatus=open');
+  expect(payload.httpRequest.url).toContain(
+    'voucherNumber=ACME+%26amp%3B+Partner',
+  );
+  expect(payload.httpRequest.url).toContain('size=25');
+});
+
+test('Lexware Office helper builds bookkeeping file download requests', () => {
+  const result = runHelper([
+    'http-request',
+    'download-file',
+    '--id',
+    'file-123',
+  ]);
+
+  expect(result.status).toBe(0);
+  expect(JSON.parse(result.stdout)).toMatchObject({
+    operation: 'download-file',
+    mutatesAccount: false,
+    httpRequest: {
+      method: 'GET',
+      url: 'https://api.lexware.io/v1/files/file-123',
+      headers: {
+        Accept: '*/*',
+      },
+      bearerSecretName: 'LEXWARE_OFFICE_API_KEY',
+    },
+  });
+});
+
+test('Lexware Office helper refuses writes without operator grant', () => {
+  const denied = runHelper([
+    'create-invoice',
+    '--body-json',
+    '{"voucherDate":"2026-05-21T00:00:00.000+02:00"}',
+  ]);
+  const granted = runHelper([
+    'create-invoice',
+    '--body-json',
+    '{"voucherDate":"2026-05-21T00:00:00.000+02:00"}',
+    '--operator-grant',
+    '--finalize',
+  ]);
+
+  expect(denied.status).toBe(1);
+  expect(JSON.parse(denied.stdout).error).toMatchObject({
+    code: 'LEXWARE_OFFICE_OPERATOR_GRANT_REQUIRED',
+    requiredGrant: 'approve-lexware-office-invoice-create',
+  });
+  expect(granted.status).toBe(0);
+  const payload = JSON.parse(granted.stdout);
+  expect(payload).toMatchObject({
+    operation: 'create-invoice',
+    mutatesAccount: true,
+    requiredGrant: 'approve-lexware-office-invoice-create',
+    httpRequest: {
+      method: 'POST',
+      json: { voucherDate: '2026-05-21T00:00:00.000+02:00' },
+    },
+  });
+  expect(payload.httpRequest.url).toContain('/invoices?finalize=true');
+});
+
+test('Lexware Office helper builds multipart receipt upload requests', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lexware-office-'));
+  const filePath = path.join(tempDir, 'receipt.pdf');
+  fs.writeFileSync(filePath, Buffer.from('%PDF-1.7\n'));
+
+  const denied = runHelper(['upload-file', '--file', filePath]);
+  const upload = runHelper([
+    'upload-file',
+    '--file',
+    filePath,
+    '--operator-grant',
+  ]);
+  const attach = runHelper([
+    'attach-voucher-file',
+    '--id',
+    'voucher-123',
+    '--file',
+    filePath,
+    '--operator-grant',
+  ]);
+
+  expect(denied.status).toBe(1);
+  expect(JSON.parse(denied.stdout).error).toMatchObject({
+    code: 'LEXWARE_OFFICE_OPERATOR_GRANT_REQUIRED',
+    requiredGrant: 'approve-lexware-office-file-upload',
+  });
+  expect(upload.status).toBe(0);
+  const uploadPayload = JSON.parse(upload.stdout);
+  expect(uploadPayload).toMatchObject({
+    operation: 'upload-file',
+    mutatesAccount: true,
+    requiredGrant: 'approve-lexware-office-file-upload',
+    httpRequest: {
+      method: 'POST',
+      url: 'https://api.lexware.io/v1/files',
+      bearerSecretName: 'LEXWARE_OFFICE_API_KEY',
+    },
+  });
+  expect(uploadPayload.httpRequest.headers['Content-Type']).toContain(
+    'multipart/form-data; boundary=',
+  );
+  expect(uploadPayload.httpRequest.bodyBase64).toEqual(expect.any(String));
+
+  expect(attach.status).toBe(0);
+  expect(JSON.parse(attach.stdout)).toMatchObject({
+    operation: 'attach-voucher-file',
+    requiredGrant: 'approve-lexware-office-voucher-file-attach',
+    httpRequest: {
+      method: 'POST',
+      url: 'https://api.lexware.io/v1/vouchers/voucher-123/files',
+    },
+  });
+});
+
+test('Lexware Office helper returns income-statement source requests and transaction handoff', () => {
+  const report = runHelper([
+    'income-statement-plan',
+    '--from',
+    '2026-10-01',
+    '--to',
+    '2026-12-31',
+  ]);
+  const handoff = runHelper([
+    'match-transaction',
+    '--transaction-id',
+    'txn-123',
+    '--voucher-id',
+    'voucher-456',
+    '--operator-grant',
+  ]);
+
+  expect(report.status).toBe(0);
+  const reportPayload = JSON.parse(report.stdout);
+  expect(reportPayload).toMatchObject({
+    operation: 'income-statement',
+    mutatesAccount: false,
+    costMeasurement: { system: 'UsageTotals' },
+  });
+  expect(reportPayload.sourceRequests).toHaveLength(2);
+  expect(reportPayload.sourceRequests[0].url).toContain('/voucherlist?');
+  expect(reportPayload.sourceRequests[0].url).toContain(
+    'voucherDateFrom=2026-10-01',
+  );
+  expect(reportPayload.sourceRequests[1].url).toContain(
+    'purchaseinvoice%2Cpurchasecreditnote',
+  );
+
+  expect(handoff.status).toBe(0);
+  expect(JSON.parse(handoff.stdout)).toMatchObject({
+    operation: 'match-transaction',
+    mutatesAccount: true,
+    requiredGrant: 'approve-lexware-office-transaction-match',
+    manualHandoff: {
+      transactionId: 'txn-123',
+      voucherId: 'voucher-456',
+    },
+    costMeasurement: { system: 'UsageTotals' },
+  });
+});
+
+test('Lexware Office helper aggregates income statements and extracts bank transactions', () => {
+  const statement = runHelper([
+    'aggregate-income-statement',
+    '--revenue-json',
+    '{"content":[{"voucherType":"invoice","totalAmount":1190},{"voucherType":"salescreditnote","totalAmount":190}]}',
+    '--expenses-json',
+    '{"content":[{"voucherType":"purchaseinvoice","totalAmount":357}]}',
+    '--from',
+    '2026-01-01',
+    '--to',
+    '2026-03-31',
+  ]);
+  const bankTransactions = runHelper([
+    'bank-transactions-from-payments',
+    '--payments-json',
+    '{"id":"voucher-123","voucherType":"invoice","paymentItems":[{"paymentItemType":"partPaymentFinancialTransaction","postingDate":"2026-03-15T00:00:00.000+01:00","amount":1190,"currency":"EUR"},{"paymentItemType":"manualPayment","amount":10,"currency":"EUR"}]}',
+  ]);
+
+  expect(statement.status).toBe(0);
+  expect(JSON.parse(statement.stdout)).toMatchObject({
+    operation: 'income-statement',
+    totals: {
+      revenue: 1000,
+      expenses: 357,
+      netIncome: 643,
+      currency: 'EUR',
+    },
+    sourceCounts: {
+      revenueVouchers: 2,
+      expenseVouchers: 1,
+    },
+  });
+
+  expect(bankTransactions.status).toBe(0);
+  expect(JSON.parse(bankTransactions.stdout)).toMatchObject({
+    operation: 'list-bank-transactions',
+    transactionCount: 1,
+    transactions: [
+      {
+        voucherId: 'voucher-123',
+        paymentItemType: 'partPaymentFinancialTransaction',
+        amount: 1190,
+        currency: 'EUR',
+      },
+    ],
+  });
+});
+
+test('Lexware Office bundled eval suite covers representative accounting requests', () => {
+  const scenarios = JSON.parse(fs.readFileSync(scenariosPath, 'utf-8'));
+  const result = runHelper(['eval-scenarios']);
+
+  expect(scenarios).toHaveLength(30);
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload).toMatchObject({
+    command: 'eval-scenarios',
+    scenarioCount: 30,
+    failed: 0,
+    costMeasurement: { system: 'UsageTotals' },
+  });
+  expect(payload.results.every((entry: { pass: boolean }) => entry.pass)).toBe(
+    true,
+  );
+});


### PR DESCRIPTION
Closes #653.

## Summary

- Add a bundled `lexware-office` skill package for Lexware Office / lexoffice accounting workflows.
- Add a Node helper that builds gateway `http_request` payloads with `bearerSecretName: LEXWARE_OFFICE_API_KEY`, guarded write operations, multipart receipt upload/attach support, payment-derived bank transaction extraction, and income statement aggregation.
- Add 30 representative eval scenarios plus targeted Vitest coverage.
- Document operator API key setup, secret handling, API limitations, and validation commands.

## Notes

Lexware Public API supports payment status and bank-linked payment items, but does not expose a transaction-matching write endpoint. The skill implements `match-transaction` as an explicit operator-granted manual handoff instead of inventing an API call.

## Validation

- `python3 skills/skill-creator/scripts/quick_validate.py skills/lexware-office`
- `node skills/lexware-office/lexware_office.cjs eval-scenarios`
- `./node_modules/.bin/vitest run tests/lexware-office-skill.test.ts`
- `npx biome check tests/lexware-office-skill.test.ts skills/lexware-office/lexware_office.cjs skills/lexware-office/SKILL.md docs/content/guides/bundled-skills.md`