### PR TITLE
[codex] Deprecate security compatibility fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,12 @@
 
 ### Changed
 
+- **Security fallback deprecations**: Added migration warnings for legacy
+  BlueBubbles query-param webhook auth, unbound `bearerSecretName` and
+  `secretHeaders` injection, and legacy `container.additionalMounts` config.
+  Existing setups continue to work during the deprecation window while docs and
+  `hybridclaw doctor security` point operators to header auth, bound bearer
+  secrets, and `container.binds`.
 - **Diagram validation and accounting**: Mermaid diagrams are validated with
   the bundled Mermaid parser before render, diagram render artifacts retain
   skill-scoped source/rendered metadata, and local diagram renders emit

--- a/docs/content/channels/imessage.md
+++ b/docs/content/channels/imessage.md
@@ -205,6 +205,9 @@ For headless or container deployments, provide the master key through
 `HYBRIDCLAW_MASTER_KEY` or `/run/secrets/hybridclaw_master_key`. Do not rely on
 plaintext `imessage.password` in config unless you have a very good reason.
 
+Inbound BlueBubbles webhooks must send the password in the
+`x-hybridclaw-imessage-password` header.
+
 ### Step 4: Add the iMessage Config
 
 Open `~/.hybridclaw/config.json` and add or update:

--- a/docs/content/channels/imessage.md
+++ b/docs/content/channels/imessage.md
@@ -205,8 +205,10 @@ For headless or container deployments, provide the master key through
 `HYBRIDCLAW_MASTER_KEY` or `/run/secrets/hybridclaw_master_key`. Do not rely on
 plaintext `imessage.password` in config unless you have a very good reason.
 
-Inbound BlueBubbles webhooks must send the password in the
-`x-hybridclaw-imessage-password` header.
+Inbound BlueBubbles webhooks should send the password in the
+`x-hybridclaw-imessage-password` header. Older relays that still send
+`password`, `guid`, or `token` as query parameters continue to work for now,
+but HybridClaw logs a deprecation warning for each query-auth webhook.
 
 ### Step 4: Add the iMessage Config
 
@@ -259,6 +261,17 @@ X-HybridClaw-iMessage-Password: YOUR_IMESSAGE_PASSWORD
 
 This is the primary and recommended setup. Use it unless your relay or proxy
 cannot send custom headers.
+
+Deprecated compatibility fallback:
+
+```text
+POST https://your-hybridclaw.example.com/api/imessage/webhook?password=YOUR_IMESSAGE_PASSWORD
+```
+
+HybridClaw still accepts `password`, `guid`, and `token` query parameters for
+older BlueBubbles webhook relays, but this path is scheduled for removal. Move
+to the `X-HybridClaw-iMessage-Password` header before upgrading to a version
+that removes query-param auth.
 
 The webhook must send `new-message` events to HybridClaw for inbound delivery.
 

--- a/docs/content/channels/imessage.md
+++ b/docs/content/channels/imessage.md
@@ -260,21 +260,6 @@ X-HybridClaw-iMessage-Password: YOUR_IMESSAGE_PASSWORD
 This is the primary and recommended setup. Use it unless your relay or proxy
 cannot send custom headers.
 
-Fallback only:
-
-```text
-https://your-hybridclaw.example.com/api/imessage/webhook?password=YOUR_IMESSAGE_PASSWORD
-```
-
-Warning: query-string secrets are more likely to end up in reverse-proxy access
-logs, browser history, and similar request traces. Only use the query-param
-form when header auth is genuinely unavailable.
-
-HybridClaw accepts:
-
-- header: `X-HybridClaw-iMessage-Password` (preferred)
-- query params: `password`, `guid`, or `token` (fallback only)
-
 The webhook must send `new-message` events to HybridClaw for inbound delivery.
 
 ### Step 7: Send a Test Message

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -413,6 +413,7 @@ hybridclaw secret route remove <url-prefix> [header]
 - `/secret route ...` is a convenience surface for editing
   `tools.httpRequest.authRules[]` without hand-editing `config.json`
 - `secret: { "source": "google-oauth" }` routes mint and inject the Google OAuth access token from `hybridclaw auth login google` for matching `*.googleapis.com` requests
+- bearer tokens injected with `bearerSecretName` require a companion `<NAME>_BOUND_DOMAIN` secret containing the exact hostname they may be sent to
 
 Codex OAuth sessions are stored separately in `~/.hybridclaw/codex-auth.json`.
 Trust-model acceptance is persisted in `config.json` under `security.*` and is
@@ -434,7 +435,7 @@ credential checks run.
   text in `config.json`
 - In `host` sandbox mode, the agent can access the user home directory, the
   gateway working directory, `/tmp`, and any host paths explicitly added
-  through `container.binds` or `container.additionalMounts`
+  through `container.binds`
 - prefer storing BlueBubbles credentials as `IMESSAGE_PASSWORD` in the
   encrypted secret store instead of plaintext `imessage.password`
 - prefer storing email passwords as `EMAIL_PASSWORD` or a SecretRef-backed

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -85,8 +85,7 @@ saved revision history directly.
 ## Important Config Areas
 
 - `container.*` for execution isolation, including `sandboxMode`, `memory`,
-  `memorySwap`, `cpus`, `network`, `binds`, additional mounts, and
-  `persistBashState`
+  `memorySwap`, `cpus`, `network`, `binds`, and `persistBashState`
 - `container.persistBashState` controls whether `bash` tool calls reuse shell
   state (`cd`, exported env vars, aliases) for the active runtime session
   (`true`, default) or start fresh on each call (`false`)
@@ -99,6 +98,9 @@ saved revision history directly.
 - `container.binds` for explicit host-to-container mounts in
   `host:container[:ro|rw]` format; mounted paths appear inside the sandbox
   under `/workspace/extra/<container>`
+- legacy `container.additionalMounts` JSON is migrated into `container.binds`
+  on startup; update config files to use `binds` before `additionalMounts` is
+  removed
 - `browser.provider` selects the browser automation backend. Supported values include `local`, `camofox`, `managed-cloud`, `browser-use-cloud`, and `mac-cua`. `browser.local.*` and `browser.camofox.*` configure persistent profile roots and headed mode; `browser.managedCloud.*` points at an operator-run HybridClaw browser pool with navigation-guard enforcement and optional `poolTokenRef` bearer authentication; `browser.browserUseCloud.*` configures the Browser Use Cloud passthrough and reads `BROWSER_USE_API_KEY` through the configured SecretRef; and `browser.macCua.*` selects the operator-owned macOS browser, driver command, driver args, and screenshot mode (`som`, `vision`, or `ax`). Camofox stealth mode is deny-by-default per host; allow it from the workspace policy with `browser.stealth.rules`. Run `hybridclaw doctor cua-mac` before enabling `mac-cua`; the provider requires the `cua-driver` binary plus macOS Accessibility and Screen Recording grants.
 - `ops.healthHost` and `ops.healthPort` for the gateway HTTP bind address and
   port; the default is loopback on `127.0.0.1:9090`
@@ -413,7 +415,7 @@ hybridclaw secret route remove <url-prefix> [header]
 - `/secret route ...` is a convenience surface for editing
   `tools.httpRequest.authRules[]` without hand-editing `config.json`
 - `secret: { "source": "google-oauth" }` routes mint and inject the Google OAuth access token from `hybridclaw auth login google` for matching `*.googleapis.com` requests
-- secrets injected with `bearerSecretName` or `secretHeaders` require a companion `<NAME>_BOUND_DOMAIN` secret containing the exact hostname they may be sent to
+- secrets injected with `bearerSecretName` or `secretHeaders` should have a companion `<NAME>_BOUND_DOMAIN` secret containing the exact hostname they may be sent to; unbound bearer secrets still work during the deprecation window, but runtime logs and `hybridclaw doctor security` warn before unbound injection is removed
 
 Codex OAuth sessions are stored separately in `~/.hybridclaw/codex-auth.json`.
 Trust-model acceptance is persisted in `config.json` under `security.*` and is

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -413,7 +413,7 @@ hybridclaw secret route remove <url-prefix> [header]
 - `/secret route ...` is a convenience surface for editing
   `tools.httpRequest.authRules[]` without hand-editing `config.json`
 - `secret: { "source": "google-oauth" }` routes mint and inject the Google OAuth access token from `hybridclaw auth login google` for matching `*.googleapis.com` requests
-- bearer tokens injected with `bearerSecretName` require a companion `<NAME>_BOUND_DOMAIN` secret containing the exact hostname they may be sent to
+- secrets injected with `bearerSecretName` or `secretHeaders` require a companion `<NAME>_BOUND_DOMAIN` secret containing the exact hostname they may be sent to
 
 Codex OAuth sessions are stored separately in `~/.hybridclaw/codex-auth.json`.
 Trust-model acceptance is persisted in `config.json` under `security.*` and is

--- a/docs/imessage.md
+++ b/docs/imessage.md
@@ -241,20 +241,23 @@ X-HybridClaw-iMessage-Password: YOUR_IMESSAGE_PASSWORD
 This is the primary and recommended setup. Use it unless your relay or proxy
 cannot send custom headers.
 
-Fallback only:
+Deprecated compatibility fallback:
 
 ```text
-https://your-hybridclaw.example.com/api/imessage/webhook?password=YOUR_IMESSAGE_PASSWORD
+POST https://your-hybridclaw.example.com/api/imessage/webhook?password=YOUR_IMESSAGE_PASSWORD
 ```
 
 Warning: query-string secrets are more likely to end up in reverse-proxy access
 logs, browser history, and similar request traces. Only use the query-param
-form when header auth is genuinely unavailable.
+form while migrating a relay that cannot send custom headers.
 
 HybridClaw accepts:
 
 - header: `X-HybridClaw-iMessage-Password` (preferred)
-- query params: `password`, `guid`, or `token` (fallback only)
+- query params: `password`, `guid`, or `token` (deprecated fallback)
+
+HybridClaw logs a deprecation warning for each query-auth webhook. Move to the
+header before upgrading to a version that removes query-param auth.
 
 The webhook must send `new-message` events to HybridClaw for inbound delivery.
 

--- a/src/agent/executor.ts
+++ b/src/agent/executor.ts
@@ -1,5 +1,4 @@
 import {
-  ADDITIONAL_MOUNTS,
   CONTAINER_BINDS,
   CONTAINER_CPUS,
   CONTAINER_IMAGE,
@@ -12,10 +11,7 @@ import {
 } from '../config/config.js';
 import { ContainerExecutor } from '../infra/container-runner.js';
 import { HostExecutor } from '../infra/host-runner.js';
-import {
-  parseBindSpecs,
-  parseLegacyAdditionalMounts,
-} from '../security/mount-config.js';
+import { parseBindSpecs } from '../security/mount-config.js';
 import type {
   Executor,
   ExecutorSessionHealthSnapshot,
@@ -70,10 +66,7 @@ function initializedExecutors(): Executor[] {
 }
 
 function parseAdditionalMountsCount(): number {
-  const bindCount = parseBindSpecs(CONTAINER_BINDS).mounts.length;
-  const legacyCount =
-    parseLegacyAdditionalMounts(ADDITIONAL_MOUNTS).mounts.length;
-  return bindCount + legacyCount;
+  return parseBindSpecs(CONTAINER_BINDS).mounts.length;
 }
 
 export function getActiveExecutorCount(): number {

--- a/src/channels/imessage/backend-bluebubbles.ts
+++ b/src/channels/imessage/backend-bluebubbles.ts
@@ -12,6 +12,7 @@ import {
   IMESSAGE_SERVER_URL,
   IMESSAGE_TEXT_CHUNK_LIMIT,
 } from '../../config/config.js';
+import { logger } from '../../logger.js';
 import { SlidingWindowRateLimiter } from '../discord/rate-limiter.js';
 import {
   readWebhookJsonBody,
@@ -119,12 +120,31 @@ function safeEqual(value: string, expected: string): boolean {
   return timingSafeEqual(valueBuffer, expectedBuffer);
 }
 
-function readWebhookPassword(req: IncomingMessage): string | undefined {
+type WebhookPasswordReadResult = {
+  password?: string;
+  source: 'header' | 'query' | null;
+  parameterName?: string;
+};
+
+function readWebhookPassword(
+  req: IncomingMessage,
+  url: URL,
+): WebhookPasswordReadResult {
   const headerValue = req.headers['x-hybridclaw-imessage-password'];
   if (typeof headerValue === 'string' && headerValue.trim()) {
-    return headerValue.trim();
+    return { password: headerValue.trim(), source: 'header' };
   }
-  return undefined;
+  for (const key of ['password', 'guid', 'token']) {
+    const value = url.searchParams.get(key);
+    if (value?.trim()) {
+      return {
+        password: value.trim(),
+        source: 'query',
+        parameterName: key,
+      };
+    }
+  }
+  return { source: null };
 }
 
 async function sendBlueBubblesRequest(
@@ -282,6 +302,7 @@ export function createBlueBubblesIMessageBackend(
       req: IncomingMessage,
       res: ServerResponse,
     ): Promise<boolean> {
+      const url = new URL(req.url || '/', 'http://localhost');
       const decision = webhookRateLimiter.check(
         req.socket.remoteAddress || 'unknown',
         WEBHOOK_RATE_LIMIT,
@@ -294,7 +315,14 @@ export function createBlueBubblesIMessageBackend(
       }
 
       const expectedPassword = IMESSAGE_PASSWORD.trim();
-      const suppliedPassword = String(readWebhookPassword(req) || '').trim();
+      const suppliedAuth = readWebhookPassword(req, url);
+      if (suppliedAuth.source === 'query') {
+        logger.warn(
+          { parameterName: suppliedAuth.parameterName },
+          'BlueBubbles webhook used deprecated query-param auth; send x-hybridclaw-imessage-password instead before query-param auth is removed',
+        );
+      }
+      const suppliedPassword = String(suppliedAuth.password || '').trim();
       if (
         !expectedPassword ||
         !suppliedPassword ||

--- a/src/channels/imessage/backend-bluebubbles.ts
+++ b/src/channels/imessage/backend-bluebubbles.ts
@@ -119,19 +119,10 @@ function safeEqual(value: string, expected: string): boolean {
   return timingSafeEqual(valueBuffer, expectedBuffer);
 }
 
-function readWebhookPassword(
-  req: IncomingMessage,
-  url: URL,
-): string | undefined {
+function readWebhookPassword(req: IncomingMessage): string | undefined {
   const headerValue = req.headers['x-hybridclaw-imessage-password'];
   if (typeof headerValue === 'string' && headerValue.trim()) {
     return headerValue.trim();
-  }
-  // Header auth is preferred. Query-param secrets remain as a compatibility
-  // fallback because some relay/proxy setups cannot inject custom headers.
-  for (const key of ['password', 'guid', 'token']) {
-    const value = url.searchParams.get(key);
-    if (value?.trim()) return value.trim();
   }
   return undefined;
 }
@@ -291,7 +282,6 @@ export function createBlueBubblesIMessageBackend(
       req: IncomingMessage,
       res: ServerResponse,
     ): Promise<boolean> {
-      const url = new URL(req.url || '/', 'http://localhost');
       const decision = webhookRateLimiter.check(
         req.socket.remoteAddress || 'unknown',
         WEBHOOK_RATE_LIMIT,
@@ -304,9 +294,7 @@ export function createBlueBubblesIMessageBackend(
       }
 
       const expectedPassword = IMESSAGE_PASSWORD.trim();
-      const suppliedPassword = String(
-        readWebhookPassword(req, url) || '',
-      ).trim();
+      const suppliedPassword = String(readWebhookPassword(req) || '').trim();
       if (
         !expectedPassword ||
         !suppliedPassword ||

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -546,7 +546,6 @@ export const MOUNT_ALLOWLIST_PATH = path.join(
   'hybridclaw',
   'mount-allowlist.json',
 );
-export let ADDITIONAL_MOUNTS = '';
 
 export let CONTAINER_MAX_OUTPUT_SIZE = 10_485_760;
 export let MAX_CONCURRENT_CONTAINERS = 5;
@@ -1101,7 +1100,6 @@ function applyRuntimeConfig(config: RuntimeConfig): void {
   CONTAINER_NETWORK = config.container.network;
   CONTAINER_TIMEOUT = config.container.timeoutMs;
   CONTAINER_BINDS = config.container.binds;
-  ADDITIONAL_MOUNTS = config.container.additionalMounts;
   CONTAINER_MAX_OUTPUT_SIZE = config.container.maxOutputBytes;
   MAX_CONCURRENT_CONTAINERS = Math.max(1, config.container.maxConcurrent);
   CONTAINER_PERSIST_BASH_STATE = config.container.persistBashState;

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -73,6 +73,7 @@ import {
   isRuntimeProviderId,
   type RuntimeProviderId,
 } from '../providers/provider-ids.js';
+import { parseLegacyAdditionalMountBinds } from '../security/mount-config.js';
 import type { SecretHandle } from '../security/secret-handles.js';
 import {
   isSecretRefInput,
@@ -6443,6 +6444,19 @@ function normalizeRuntimeConfig(
     DEFAULT_RUNTIME_CONFIG.adaptiveSkills.trajectoryCapture.retentionDays,
     { min: 0 },
   );
+  const normalizedContainerBinds = normalizeStringArray(
+    rawContainer.binds,
+    DEFAULT_RUNTIME_CONFIG.container.binds,
+  );
+  const legacyAdditionalMountBinds = parseLegacyAdditionalMountBinds(
+    (rawContainer as Record<string, unknown>).additionalMounts,
+  );
+  const containerBinds = [
+    ...new Set([
+      ...normalizedContainerBinds,
+      ...legacyAdditionalMountBinds.binds,
+    ]),
+  ];
 
   return {
     version: CONFIG_VERSION,
@@ -7301,10 +7315,7 @@ function normalizeRuntimeConfig(
         DEFAULT_RUNTIME_CONFIG.container.timeoutMs,
         { min: 1_000 },
       ),
-      binds: normalizeStringArray(
-        rawContainer.binds,
-        DEFAULT_RUNTIME_CONFIG.container.binds,
-      ),
+      binds: containerBinds,
       maxOutputBytes: normalizeInteger(
         rawContainer.maxOutputBytes,
         DEFAULT_RUNTIME_CONFIG.container.maxOutputBytes,
@@ -8048,6 +8059,17 @@ function migrateConfigSchemaOnStartup(): void {
     const rawContainer = isRecord(parsedRecord.container)
       ? parsedRecord.container
       : {};
+    const legacyAdditionalMountBinds = parseLegacyAdditionalMountBinds(
+      rawContainer.additionalMounts,
+    );
+    if (legacyAdditionalMountBinds.binds.length > 0) {
+      console.warn(
+        '[runtime-config] migrated legacy container.additionalMounts into container.binds; update config.json to use container.binds before additionalMounts is removed',
+      );
+    }
+    for (const warning of legacyAdditionalMountBinds.warnings) {
+      console.warn(`[runtime-config] ${warning}`);
+    }
     const changed = writeConfigFile(
       migrated,
       {

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -1077,7 +1077,6 @@ export interface RuntimeConfig {
     network: string;
     timeoutMs: number;
     binds: string[];
-    additionalMounts: string;
     maxOutputBytes: number;
     maxConcurrent: number;
     persistBashState: boolean;
@@ -1810,7 +1809,6 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
     network: 'bridge',
     timeoutMs: 300_000,
     binds: [],
-    additionalMounts: '',
     maxOutputBytes: 10_485_760,
     maxConcurrent: 5,
     persistBashState: true,
@@ -7306,11 +7304,6 @@ function normalizeRuntimeConfig(
       binds: normalizeStringArray(
         rawContainer.binds,
         DEFAULT_RUNTIME_CONFIG.container.binds,
-      ),
-      additionalMounts: normalizeString(
-        rawContainer.additionalMounts,
-        DEFAULT_RUNTIME_CONFIG.container.additionalMounts,
-        { allowEmpty: true },
       ),
       maxOutputBytes: normalizeInteger(
         rawContainer.maxOutputBytes,

--- a/src/doctor/checks/security.ts
+++ b/src/doctor/checks/security.ts
@@ -15,6 +15,11 @@ import type { DiagResult } from '../types.js';
 import { findExistingPath, makeResult, severityFrom } from '../utils.js';
 
 const BOUND_DOMAIN_SUFFIX = '_BOUND_DOMAIN';
+const DOMAIN_BINDING_EXEMPT_SECRET_NAMES = new Set([
+  'GOG_ACCESS_TOKEN',
+  'GOOGLE_WORKSPACE_CLI_TOKEN',
+  'HUBSPOT_ACCESS_TOKEN',
+]);
 const NON_BEARER_SECRET_NAMES = new Set([
   'DISCORD_TOKEN',
   'GATEWAY_API_TOKEN',
@@ -37,6 +42,7 @@ function checkWritablePath(targetPath: string): boolean {
 
 function isLikelyBearerSecretName(name: string): boolean {
   if (
+    DOMAIN_BINDING_EXEMPT_SECRET_NAMES.has(name) ||
     NON_BEARER_SECRET_NAMES.has(name) ||
     name.endsWith(BOUND_DOMAIN_SUFFIX)
   ) {

--- a/src/doctor/checks/security.ts
+++ b/src/doctor/checks/security.ts
@@ -10,8 +10,21 @@ import {
   syncRuntimeInstructionCopies,
   verifyInstructionIntegrity,
 } from '../../security/instruction-integrity.js';
+import { listStoredRuntimeSecretNames } from '../../security/runtime-secrets.js';
 import type { DiagResult } from '../types.js';
 import { findExistingPath, makeResult, severityFrom } from '../utils.js';
+
+const BOUND_DOMAIN_SUFFIX = '_BOUND_DOMAIN';
+const NON_BEARER_SECRET_NAMES = new Set([
+  'DISCORD_TOKEN',
+  'GATEWAY_API_TOKEN',
+  'SLACK_APP_TOKEN',
+  'SLACK_BOT_TOKEN',
+  'TELEGRAM_BOT_TOKEN',
+  'THREEMA_GATEWAY_SECRET',
+  'TWILIO_AUTH_TOKEN',
+  'WEB_API_TOKEN',
+]);
 
 function checkWritablePath(targetPath: string): boolean {
   try {
@@ -22,12 +35,44 @@ function checkWritablePath(targetPath: string): boolean {
   }
 }
 
+function isLikelyBearerSecretName(name: string): boolean {
+  if (
+    NON_BEARER_SECRET_NAMES.has(name) ||
+    name.endsWith(BOUND_DOMAIN_SUFFIX)
+  ) {
+    return false;
+  }
+  return (
+    name.endsWith('_ACCESS_TOKEN') ||
+    name.endsWith('_API_TOKEN') ||
+    name.endsWith('_BEARER') ||
+    name.endsWith('_BEARER_TOKEN') ||
+    name.endsWith('_JWT')
+  );
+}
+
+function findUnboundBearerSecretNames(): string[] {
+  let secretNames: string[];
+  try {
+    secretNames = listStoredRuntimeSecretNames();
+  } catch {
+    return [];
+  }
+  const stored = new Set(secretNames);
+  return secretNames.filter(
+    (name) =>
+      isLikelyBearerSecretName(name) &&
+      !stored.has(`${name}${BOUND_DOMAIN_SUFFIX}`),
+  );
+}
+
 export async function checkSecurity(): Promise<DiagResult[]> {
   const config = getRuntimeConfig();
   const trustAccepted = isSecurityTrustAccepted(config);
   const instructionIntegrity = verifyInstructionIntegrity();
   const auditDir = path.join(DATA_DIR, 'audit');
   const auditWritable = checkWritablePath(auditDir);
+  const unboundBearerSecretNames = findUnboundBearerSecretNames();
 
   const integrityHasSourceGap = instructionIntegrity.files.some(
     (file) => file.status === 'source_missing',
@@ -49,6 +94,7 @@ export async function checkSecurity(): Promise<DiagResult[]> {
     ...(trustAccepted ? [] : ['error' as const]),
     ...(integritySeverity === 'ok' ? [] : [integritySeverity]),
     ...(auditWritable ? [] : ['error' as const]),
+    ...(unboundBearerSecretNames.length > 0 ? ['warn' as const] : []),
   ]);
 
   const messageParts = [];
@@ -63,6 +109,11 @@ export async function checkSecurity(): Promise<DiagResult[]> {
   messageParts.push(
     auditWritable ? 'audit trail writable' : 'audit trail not writable',
   );
+  if (unboundBearerSecretNames.length > 0) {
+    messageParts.push(
+      `bearer domain binding missing for ${unboundBearerSecretNames.join(', ')}; set ${unboundBearerSecretNames[0]}${BOUND_DOMAIN_SUFFIX}=<exact-host> before unbound bearer injection is removed`,
+    );
+  }
 
   const safeSyncFix =
     integrityHasMissing && !integrityHasModified && !integrityHasSourceGap

--- a/src/gateway/gateway-http-proxy.ts
+++ b/src/gateway/gateway-http-proxy.ts
@@ -1455,7 +1455,9 @@ export async function handleApiHttpRequest(
     );
   }
   if (bearerSecretName) {
-    assertBearerDomainBinding(bearerSecretName, url);
+    if (requiresBearerDomainBinding(bearerSecretName)) {
+      assertBearerDomainBinding(bearerSecretName, url);
+    }
     setHeaderValue(
       headers,
       'Authorization',

--- a/src/gateway/gateway-http-proxy.ts
+++ b/src/gateway/gateway-http-proxy.ts
@@ -829,7 +829,7 @@ function assertBearerDomainBinding(secretName: string, targetUrl: URL): void {
 
   throw new GatewayRequestError(
     403,
-    `Bearer secret ${secretName} is bound to *.${allowed} — ` +
+    `Secret ${secretName} is bound to *.${allowed} — ` +
       `request to ${targetHost} is blocked.`,
   );
 }

--- a/src/gateway/gateway-http-proxy.ts
+++ b/src/gateway/gateway-http-proxy.ts
@@ -498,6 +498,13 @@ function isHubSpotApiHost(host?: string): boolean {
   );
 }
 
+function requiresBearerDomainBinding(secretName: string): boolean {
+  return (
+    !isGoogleWorkspaceRuntimeTokenName(secretName) &&
+    secretName !== HUBSPOT_ACCESS_TOKEN_SECRET
+  );
+}
+
 function isGoogleOAuthHttpAuthRuleSecret(
   value: unknown,
 ): value is RuntimeHttpRequestGoogleOAuthSecretRef {
@@ -800,15 +807,21 @@ function extractBaseDomain(hostname: string): string {
  *
  * When a captured value is stored as a bearer secret, the gateway stores a
  * domain binding as `{SECRET_NAME}_BOUND_DOMAIN`. If a binding exists, the
- * target URL's hostname must match (exact or subdomain). If no binding exists,
- * any URL is allowed for backward compatibility.
+ * target URL's hostname must match (exact or subdomain).
  */
 function assertBearerDomainBinding(secretName: string, targetUrl: URL): void {
+  if (!requiresBearerDomainBinding(secretName)) return;
+
   const bindingKey = `${secretName}${BOUND_DOMAIN_SUFFIX}`;
   const boundDomain = readStoredRuntimeSecret(bindingKey);
-  if (!boundDomain) return; // no binding → unrestricted
-
   const targetHost = targetUrl.hostname.toLowerCase();
+  if (!boundDomain) {
+    throw new GatewayRequestError(
+      403,
+      `Secret ${secretName} is missing ${bindingKey}; request to ${targetHost} is blocked.`,
+    );
+  }
+
   const allowed = boundDomain.toLowerCase();
   if (targetHost === allowed || targetHost.endsWith(`.${allowed}`)) {
     return;

--- a/src/gateway/gateway-http-proxy.ts
+++ b/src/gateway/gateway-http-proxy.ts
@@ -816,10 +816,11 @@ function assertBearerDomainBinding(secretName: string, targetUrl: URL): void {
   const boundDomain = readStoredRuntimeSecret(bindingKey);
   const targetHost = targetUrl.hostname.toLowerCase();
   if (!boundDomain) {
-    throw new GatewayRequestError(
-      403,
-      `Secret ${secretName} is missing ${bindingKey}; request to ${targetHost} is blocked.`,
+    logger.warn(
+      { secretName, targetHost, bindingKey },
+      'Secret used without a domain binding; set the matching *_BOUND_DOMAIN runtime secret before unbound secret injection is removed',
     );
+    return;
   }
 
   const allowed = boundDomain.toLowerCase();

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -17,7 +17,6 @@ import {
 import { getBrowserProfileDir } from '../browser/browser-login.js';
 import { collectActiveMessageToolChannelKinds } from '../channels/message-tool-advertising.js';
 import {
-  ADDITIONAL_MOUNTS,
   BROWSER_ALLOW_PRIVATE_NETWORK,
   BROWSER_PROVIDER,
   CODEX_RUNTIME,
@@ -812,7 +811,6 @@ function getOrSpawnContainer(
   // Validate and append additional mounts
   const configuredMounts = resolveConfiguredAdditionalMounts({
     binds: CONTAINER_BINDS,
-    additionalMounts: ADDITIONAL_MOUNTS,
   });
   for (const warning of configuredMounts.warnings) {
     logger.warn({ warning }, 'Configured container bind ignored');

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -14,7 +14,6 @@ import {
 } from '../auth/google-auth.js';
 import { collectActiveMessageToolChannelKinds } from '../channels/message-tool-advertising.js';
 import {
-  ADDITIONAL_MOUNTS,
   BROWSER_ALLOW_PRIVATE_NETWORK,
   BROWSER_PROVIDER,
   CODEX_RUNTIME,
@@ -133,7 +132,6 @@ function resolveExecutorMaxTokens(params: {
 function buildHostAllowedRoots(extraRoots: string[] = []): string[] {
   const configured = resolveConfiguredAdditionalMounts({
     binds: CONTAINER_BINDS,
-    additionalMounts: ADDITIONAL_MOUNTS,
   });
   for (const warning of configured.warnings) {
     logger.warn({ warning }, 'Configured host-mode allowed root ignored');

--- a/src/media/audio-transcription.ts
+++ b/src/media/audio-transcription.ts
@@ -1,7 +1,6 @@
 import path from 'node:path';
 
 import {
-  ADDITIONAL_MOUNTS,
   CONTAINER_BINDS,
   CONTAINER_SANDBOX_MODE,
   DATA_DIR,
@@ -107,7 +106,6 @@ export async function prependAudioTranscriptionsToUserContent(params: {
 
   const mountAliases = buildValidatedMountAliases({
     binds: CONTAINER_BINDS,
-    additionalMounts: ADDITIONAL_MOUNTS,
   });
   const transcripts: AudioTranscriptItem[] = [];
   let remainingChars = audioConfig.maxTotalChars;

--- a/src/media/pdf-context.ts
+++ b/src/media/pdf-context.ts
@@ -3,7 +3,6 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
-  ADDITIONAL_MOUNTS,
   CONTAINER_BINDS,
   CONTAINER_SANDBOX_MODE,
   DATA_DIR,
@@ -204,7 +203,6 @@ function detectPdfReferences(prompt: string): string[] {
 function buildValidatedMountAliases(): ValidatedMountAlias[] {
   const configured = resolveConfiguredAdditionalMounts({
     binds: CONTAINER_BINDS,
-    additionalMounts: ADDITIONAL_MOUNTS,
   });
   if (configured.mounts.length === 0) return [];
 

--- a/src/security/media-paths.ts
+++ b/src/security/media-paths.ts
@@ -143,12 +143,10 @@ function resolveDisplayPathToHost(params: {
 
 export function buildValidatedMountAliases(params: {
   binds: string[];
-  additionalMounts: string;
 }): ValidatedMountAlias[] {
   try {
     const configured = resolveConfiguredAdditionalMounts({
       binds: params.binds,
-      additionalMounts: params.additionalMounts,
     });
     if (configured.mounts.length === 0) return [];
 

--- a/src/security/mount-config.ts
+++ b/src/security/mount-config.ts
@@ -9,6 +9,11 @@ export interface ConfiguredMountParseResult {
   warnings: string[];
 }
 
+export interface LegacyMountBindSpecResult {
+  binds: string[];
+  warnings: string[];
+}
+
 function expandUserPath(input: string): string {
   const expanded = expandHomePath(input);
   return expanded ? path.resolve(expanded) : '';
@@ -107,6 +112,74 @@ export function parseBindSpecs(specs: string[]): ConfiguredMountParseResult {
     mounts: dedupeMounts(mounts),
     warnings,
   };
+}
+
+function toBindSpec(mount: AdditionalMount): string {
+  const containerPath =
+    mount.containerPath?.trim() || path.basename(mount.hostPath.trim());
+  const mode = mount.readonly === false ? 'rw' : 'ro';
+  return `${mount.hostPath.trim()}:${containerPath.replace(/^\/+/, '')}:${mode}`;
+}
+
+export function parseLegacyAdditionalMountBinds(
+  raw: unknown,
+): LegacyMountBindSpecResult {
+  const trimmed = typeof raw === 'string' ? raw.trim() : '';
+  if (!trimmed) return { binds: [], warnings: [] };
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (!Array.isArray(parsed)) {
+      return {
+        binds: [],
+        warnings: ['container.additionalMounts must be a JSON array'],
+      };
+    }
+
+    const binds: string[] = [];
+    const warnings: string[] = [];
+    for (const item of parsed) {
+      if (!item || typeof item !== 'object') {
+        warnings.push('container.additionalMounts contains a non-object entry');
+        continue;
+      }
+      const mount = item as Partial<AdditionalMount>;
+      if (typeof mount.hostPath !== 'string' || !mount.hostPath.trim()) {
+        warnings.push(
+          'container.additionalMounts contains an entry without hostPath',
+        );
+        continue;
+      }
+      if (
+        mount.containerPath != null &&
+        (typeof mount.containerPath !== 'string' || !mount.containerPath.trim())
+      ) {
+        warnings.push(
+          `container.additionalMounts entry for "${mount.hostPath}" has an invalid containerPath`,
+        );
+        continue;
+      }
+      binds.push(
+        toBindSpec({
+          hostPath: mount.hostPath,
+          containerPath: mount.containerPath,
+          readonly: mount.readonly !== false,
+        }),
+      );
+    }
+
+    return {
+      binds: [...new Set(binds)],
+      warnings,
+    };
+  } catch (err) {
+    return {
+      binds: [],
+      warnings: [
+        `Failed to parse container.additionalMounts JSON: ${err instanceof Error ? err.message : String(err)}`,
+      ],
+    };
+  }
 }
 
 export function resolveConfiguredAdditionalMounts(

--- a/src/security/mount-config.ts
+++ b/src/security/mount-config.ts
@@ -109,65 +109,6 @@ export function parseBindSpecs(specs: string[]): ConfiguredMountParseResult {
   };
 }
 
-export function parseLegacyAdditionalMounts(
-  raw: string,
-): ConfiguredMountParseResult {
-  const trimmed = String(raw || '').trim();
-  if (!trimmed) return { mounts: [], warnings: [] };
-
-  try {
-    const parsed = JSON.parse(trimmed) as unknown;
-    if (!Array.isArray(parsed)) {
-      return {
-        mounts: [],
-        warnings: ['container.additionalMounts must be a JSON array'],
-      };
-    }
-
-    const mounts: AdditionalMount[] = [];
-    const warnings: string[] = [];
-    for (const item of parsed) {
-      if (!item || typeof item !== 'object') {
-        warnings.push('container.additionalMounts contains a non-object entry');
-        continue;
-      }
-      const mount = item as Partial<AdditionalMount>;
-      if (typeof mount.hostPath !== 'string' || !mount.hostPath.trim()) {
-        warnings.push(
-          'container.additionalMounts contains an entry without hostPath',
-        );
-        continue;
-      }
-      if (
-        mount.containerPath != null &&
-        (typeof mount.containerPath !== 'string' || !mount.containerPath.trim())
-      ) {
-        warnings.push(
-          `container.additionalMounts entry for "${mount.hostPath}" has an invalid containerPath`,
-        );
-        continue;
-      }
-      mounts.push({
-        hostPath: mount.hostPath.trim(),
-        containerPath: mount.containerPath?.trim(),
-        readonly: mount.readonly !== false,
-      });
-    }
-
-    return {
-      mounts: dedupeMounts(mounts),
-      warnings,
-    };
-  } catch (err) {
-    return {
-      mounts: [],
-      warnings: [
-        `Failed to parse container.additionalMounts JSON: ${err instanceof Error ? err.message : String(err)}`,
-      ],
-    };
-  }
-}
-
 export function resolveConfiguredAdditionalMounts(
   containerConfig: Pick<
     RuntimeConfig['container'],
@@ -175,11 +116,8 @@ export function resolveConfiguredAdditionalMounts(
   >,
 ): ConfiguredMountParseResult {
   const bindResult = parseBindSpecs(containerConfig.binds || []);
-  const legacyResult = parseLegacyAdditionalMounts(
-    containerConfig.additionalMounts || '',
-  );
   return {
-    mounts: dedupeMounts([...bindResult.mounts, ...legacyResult.mounts]),
-    warnings: [...bindResult.warnings, ...legacyResult.warnings],
+    mounts: bindResult.mounts,
+    warnings: bindResult.warnings,
   };
 }

--- a/src/security/mount-config.ts
+++ b/src/security/mount-config.ts
@@ -110,10 +110,7 @@ export function parseBindSpecs(specs: string[]): ConfiguredMountParseResult {
 }
 
 export function resolveConfiguredAdditionalMounts(
-  containerConfig: Pick<
-    RuntimeConfig['container'],
-    'binds' | 'additionalMounts'
-  >,
+  containerConfig: Pick<RuntimeConfig['container'], 'binds'>,
 ): ConfiguredMountParseResult {
   const bindResult = parseBindSpecs(containerConfig.binds || []);
   return {

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -106,6 +106,8 @@ test('checkSecurity warns on stored bearer secrets without domain bindings', asy
     );
     saveNamedRuntimeSecrets({
       EXTERNAL_ACCESS_TOKEN: 'external-token',
+      GOG_ACCESS_TOKEN: 'google-token',
+      HUBSPOT_ACCESS_TOKEN: 'hubspot-token',
       SF_ACCESS_TOKEN: 'salesforce-token',
       SF_ACCESS_TOKEN_BOUND_DOMAIN: 'api.example.com',
       WEB_API_TOKEN: 'gateway-token',
@@ -117,6 +119,8 @@ test('checkSecurity warns on stored bearer secrets without domain bindings', asy
     expect(result.severity).toBe('warn');
     expect(result.message).toContain('EXTERNAL_ACCESS_TOKEN');
     expect(result.message).toContain('EXTERNAL_ACCESS_TOKEN_BOUND_DOMAIN');
+    expect(result.message).not.toContain('GOG_ACCESS_TOKEN');
+    expect(result.message).not.toContain('HUBSPOT_ACCESS_TOKEN');
     expect(result.message).not.toContain('SF_ACCESS_TOKEN,');
     expect(result.message).not.toContain('WEB_API_TOKEN');
   } finally {

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -81,6 +81,51 @@ test('runDoctor fixes insecure credentials permissions and reruns the check', as
   expect(fs.statSync(credentialsPath).mode & 0o777).toBe(0o600);
 });
 
+test('checkSecurity warns on stored bearer secrets without domain bindings', async () => {
+  const homeDir = createTempDir('hybridclaw-doctor-security-');
+  const dataDir = path.join(homeDir, '.hybridclaw', 'data');
+  process.env.HOME = homeDir;
+  fs.mkdirSync(path.join(dataDir, 'audit'), { recursive: true });
+
+  vi.doMock('../src/config/config.js', () => ({
+    DATA_DIR: dataDir,
+  }));
+  vi.doMock('../src/config/runtime-config.js', () => ({
+    getRuntimeConfig: () => ({}),
+    isSecurityTrustAccepted: () => true,
+  }));
+  vi.doMock('../src/security/instruction-integrity.js', () => ({
+    summarizeInstructionIntegrity: () => 'instruction integrity OK',
+    syncRuntimeInstructionCopies: vi.fn(),
+    verifyInstructionIntegrity: () => ({ ok: true, files: [] }),
+  }));
+
+  try {
+    const { saveNamedRuntimeSecrets } = await import(
+      '../src/security/runtime-secrets.ts'
+    );
+    saveNamedRuntimeSecrets({
+      EXTERNAL_ACCESS_TOKEN: 'external-token',
+      SF_ACCESS_TOKEN: 'salesforce-token',
+      SF_ACCESS_TOKEN_BOUND_DOMAIN: 'api.example.com',
+      WEB_API_TOKEN: 'gateway-token',
+    });
+
+    const { checkSecurity } = await import('../src/doctor/checks/security.ts');
+    const [result] = await checkSecurity();
+
+    expect(result.severity).toBe('warn');
+    expect(result.message).toContain('EXTERNAL_ACCESS_TOKEN');
+    expect(result.message).toContain('EXTERNAL_ACCESS_TOKEN_BOUND_DOMAIN');
+    expect(result.message).not.toContain('SF_ACCESS_TOKEN,');
+    expect(result.message).not.toContain('WEB_API_TOKEN');
+  } finally {
+    vi.doUnmock('../src/config/config.js');
+    vi.doUnmock('../src/config/runtime-config.js');
+    vi.doUnmock('../src/security/instruction-integrity.js');
+  }
+});
+
 test('checkConfig fixes world-readable config permissions to owner-only', async () => {
   const dir = createTempDir('hybridclaw-doctor-config-');
   const configPath = path.join(dir, 'config.json');

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -9733,6 +9733,50 @@ describe('gateway HTTP server', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  test('blocks bearerSecretName when stored secret is unbound', async () => {
+    const homeDir = makeTempDocsRoot('hybridclaw-http-unbound-bearer-');
+    process.env.HOME = homeDir;
+    writeRuntimeConfig(homeDir);
+    writeAllowAllSecretPolicy(homeDir);
+
+    const { saveNamedRuntimeSecrets } = await import(
+      '../src/security/runtime-secrets.ts'
+    );
+    saveNamedRuntimeSecrets({
+      EXTERNAL_ACCESS_TOKEN: 'external-access-token',
+    });
+
+    vi.doMock('node:dns/promises', () => ({
+      lookup: vi.fn(async () => [{ address: '93.184.216.34', family: 4 }]),
+    }));
+    const state = await importFreshHealth({
+      dataDir: path.join(homeDir, '.hybridclaw', 'data'),
+      gatewayApiToken: 'gateway-token',
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/http/request',
+      headers: { authorization: 'Bearer gateway-token' },
+      body: {
+        url: 'https://api.example.com/v1/items',
+        bearerSecretName: 'EXTERNAL_ACCESS_TOKEN',
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toContain(
+      'EXTERNAL_ACCESS_TOKEN_BOUND_DOMAIN',
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   test('captures explicit bearer token fields without exposing the response body', async () => {
     const homeDir = makeTempDocsRoot('hybridclaw-http-token-capture-');
     process.env.HOME = homeDir;

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -9733,7 +9733,7 @@ describe('gateway HTTP server', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  test('blocks bearerSecretName when stored secret is unbound', async () => {
+  test('allows unbound bearerSecretName during deprecation window with a warning', async () => {
     const homeDir = makeTempDocsRoot('hybridclaw-http-unbound-bearer-');
     process.env.HOME = homeDir;
     writeRuntimeConfig(homeDir);
@@ -9753,7 +9753,12 @@ describe('gateway HTTP server', () => {
       dataDir: path.join(homeDir, '.hybridclaw', 'data'),
       gatewayApiToken: 'gateway-token',
     });
-    const fetchMock = vi.fn();
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
     vi.stubGlobal('fetch', fetchMock);
 
     const req = makeRequest({
@@ -9770,11 +9775,23 @@ describe('gateway HTTP server', () => {
     state.handler(req as never, res as never);
     await settle();
 
-    expect(res.statusCode).toBe(403);
-    expect(JSON.parse(res.body).error).toContain(
-      'EXTERNAL_ACCESS_TOKEN_BOUND_DOMAIN',
+    expect(res.statusCode).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer external-access-token',
+        }),
+      }),
     );
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(state.loggerWarn).toHaveBeenCalledWith(
+      {
+        secretName: 'EXTERNAL_ACCESS_TOKEN',
+        targetHost: 'api.example.com',
+        bindingKey: 'EXTERNAL_ACCESS_TOKEN_BOUND_DOMAIN',
+      },
+      expect.stringContaining('without a domain binding'),
+    );
   });
 
   test('captures explicit bearer token fields without exposing the response body', async () => {

--- a/tests/imessage.bluebubbles.test.ts
+++ b/tests/imessage.bluebubbles.test.ts
@@ -99,21 +99,34 @@ afterEach(() => {
 });
 
 describe('bluebubbles iMessage backend', () => {
-  test('rejects query-param webhook passwords', async () => {
+  test('accepts deprecated query-param webhook passwords with a warning', async () => {
     const { createBlueBubblesIMessageBackend } =
       await importFreshBlueBubblesBackend();
+    const { logger } = await import('../src/logger.js');
     const onInbound = vi.fn(async () => {});
     const backend = createBlueBubblesIMessageBackend({ onInbound });
     const req = makeRequest({
       url: '/api/imessage/webhook?password=test-password',
-      body: { type: 'new-message' },
+      body: {
+        type: 'new-message',
+        data: {
+          guid: 'msg-1',
+          text: 'hello',
+          handle: { address: '+14155551212' },
+          chats: [{ guid: 'any;-;+14155551212', participants: [] }],
+        },
+      },
     });
     const res = makeResponse();
 
     await backend.handleWebhook?.(req as never, res as never);
 
-    expect(res.statusCode).toBe(401);
-    expect(onInbound).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+    expect(onInbound).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      { parameterName: 'password' },
+      expect.stringContaining('deprecated query-param auth'),
+    );
   });
 
   test('accepts authenticated new-message webhooks and normalizes inbound data', async () => {

--- a/tests/imessage.bluebubbles.test.ts
+++ b/tests/imessage.bluebubbles.test.ts
@@ -99,13 +99,13 @@ afterEach(() => {
 });
 
 describe('bluebubbles iMessage backend', () => {
-  test('rejects unauthorized webhook requests', async () => {
+  test('rejects query-param webhook passwords', async () => {
     const { createBlueBubblesIMessageBackend } =
       await importFreshBlueBubblesBackend();
     const onInbound = vi.fn(async () => {});
     const backend = createBlueBubblesIMessageBackend({ onInbound });
     const req = makeRequest({
-      url: '/api/imessage/webhook?password=wrong',
+      url: '/api/imessage/webhook?password=test-password',
       body: { type: 'new-message' },
     });
     const res = makeResponse();
@@ -122,7 +122,7 @@ describe('bluebubbles iMessage backend', () => {
     const onInbound = vi.fn(async () => {});
     const backend = createBlueBubblesIMessageBackend({ onInbound });
     const req = makeRequest({
-      url: '/api/imessage/webhook?password=test-password',
+      url: '/api/imessage/webhook',
       body: {
         type: 'new-message',
         data: {
@@ -142,6 +142,7 @@ describe('bluebubbles iMessage backend', () => {
         },
       },
     });
+    req.headers['x-hybridclaw-imessage-password'] = 'test-password';
     const res = makeResponse();
 
     await backend.handleWebhook?.(req as never, res as never);
@@ -162,9 +163,10 @@ describe('bluebubbles iMessage backend', () => {
     const onInbound = vi.fn(async () => {});
     const backend = createBlueBubblesIMessageBackend({ onInbound });
     const req = makeRequest({
-      url: '/api/imessage/webhook?password=test-password',
+      url: '/api/imessage/webhook',
       body: '{not-valid-json',
     });
+    req.headers['x-hybridclaw-imessage-password'] = 'test-password';
     const res = makeResponse();
 
     await backend.handleWebhook?.(req as never, res as never);
@@ -180,9 +182,10 @@ describe('bluebubbles iMessage backend', () => {
     const onInbound = vi.fn(async () => {});
     const backend = createBlueBubblesIMessageBackend({ onInbound });
     const req = makeRequest({
-      url: '/api/imessage/webhook?password=test-password',
+      url: '/api/imessage/webhook',
       body: [{ type: 'new-message' }],
     });
+    req.headers['x-hybridclaw-imessage-password'] = 'test-password';
     const res = makeResponse();
 
     await backend.handleWebhook?.(req as never, res as never);

--- a/tests/local-cli.test.ts
+++ b/tests/local-cli.test.ts
@@ -1179,7 +1179,6 @@ test('channels whatsapp setup preserves an existing custom ack reaction', async 
           network: 'bridge',
           timeoutMs: 300000,
           binds: [],
-          additionalMounts: '',
           maxOutputBytes: 10485760,
           maxConcurrent: 5,
         },

--- a/tests/mount-config.test.ts
+++ b/tests/mount-config.test.ts
@@ -65,7 +65,7 @@ describe('mount config parsing', () => {
     });
   });
 
-  test('merges binds with legacy additionalMounts JSON', () => {
+  test('ignores legacy additionalMounts JSON', () => {
     const resolved = resolveConfiguredAdditionalMounts({
       binds: ['/host/data:/docs:ro'],
       additionalMounts:
@@ -78,11 +78,6 @@ describe('mount config parsing', () => {
         hostPath: '/host/data',
         containerPath: 'docs',
         readonly: true,
-      },
-      {
-        hostPath: '/legacy/path',
-        containerPath: 'legacy',
-        readonly: false,
       },
     ]);
   });

--- a/tests/mount-config.test.ts
+++ b/tests/mount-config.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import {
-  parseBindSpecs,
-  resolveConfiguredAdditionalMounts,
-} from '../src/security/mount-config.ts';
+import { parseBindSpecs } from '../src/security/mount-config.ts';
 
 describe('mount config parsing', () => {
   test('parses OpenClaw-style bind specs', () => {
@@ -63,22 +60,5 @@ describe('mount config parsing', () => {
       ],
       warnings: [],
     });
-  });
-
-  test('ignores legacy additionalMounts JSON', () => {
-    const resolved = resolveConfiguredAdditionalMounts({
-      binds: ['/host/data:/docs:ro'],
-      additionalMounts:
-        '[{"hostPath":"/legacy/path","containerPath":"legacy","readonly":false}]',
-    });
-
-    expect(resolved.warnings).toEqual([]);
-    expect(resolved.mounts).toEqual([
-      {
-        hostPath: '/host/data',
-        containerPath: 'docs',
-        readonly: true,
-      },
-    ]);
   });
 });

--- a/tests/mount-config.test.ts
+++ b/tests/mount-config.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'vitest';
 
-import { parseBindSpecs } from '../src/security/mount-config.ts';
+import {
+  parseBindSpecs,
+  parseLegacyAdditionalMountBinds,
+} from '../src/security/mount-config.ts';
 
 describe('mount config parsing', () => {
   test('parses OpenClaw-style bind specs', () => {
@@ -60,5 +63,34 @@ describe('mount config parsing', () => {
       ],
       warnings: [],
     });
+  });
+
+  test('converts legacy additionalMounts JSON into bind specs', () => {
+    expect(
+      parseLegacyAdditionalMountBinds(
+        JSON.stringify([
+          {
+            hostPath: '/host/legacy',
+            containerPath: 'legacy',
+            readonly: false,
+          },
+          {
+            hostPath: '/host/readonly',
+          },
+        ]),
+      ),
+    ).toEqual({
+      binds: ['/host/legacy:legacy:rw', '/host/readonly:readonly:ro'],
+      warnings: [],
+    });
+  });
+
+  test('surfaces warnings for invalid legacy additionalMounts JSON', () => {
+    expect(parseLegacyAdditionalMountBinds('{"hostPath":"/host/data"}')).toEqual(
+      {
+        binds: [],
+        warnings: ['container.additionalMounts must be a JSON array'],
+      },
+    );
   });
 });

--- a/tests/runtime-config.migration-logging.test.ts
+++ b/tests/runtime-config.migration-logging.test.ts
@@ -148,6 +148,45 @@ describe('runtime config migration logging', () => {
     );
   });
 
+  it('migrates legacy container additionalMounts into binds on startup', async () => {
+    const homeDir = makeTempHome();
+    writeRuntimeConfig(homeDir, (config) => {
+      config.container.binds = ['/host/current:/current:ro'];
+      (
+        config.container as RuntimeConfig['container'] & {
+          additionalMounts: string;
+        }
+      ).additionalMounts = JSON.stringify([
+        {
+          hostPath: '/host/legacy',
+          containerPath: 'legacy',
+          readonly: false,
+        },
+      ]);
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await importFreshRuntimeConfig(homeDir);
+
+    const stored = JSON.parse(
+      fs.readFileSync(
+        path.join(homeDir, '.hybridclaw', 'config.json'),
+        'utf-8',
+      ),
+    ) as RuntimeConfig & {
+      container: RuntimeConfig['container'] & { additionalMounts?: unknown };
+    };
+
+    expect(stored.container.binds).toEqual([
+      '/host/current:/current:ro',
+      '/host/legacy:legacy:rw',
+    ]);
+    expect(stored.container.additionalMounts).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[runtime-config] migrated legacy container.additionalMounts into container.binds; update config.json to use container.binds before additionalMounts is removed',
+    );
+  });
+
   it('normalizes MCP server transport aliases on startup', async () => {
     const homeDir = makeTempHome();
     writeRuntimeConfig(homeDir, (config) => {


### PR DESCRIPTION
## Summary

Closes #1074.

Adds the requested deprecation path for legacy security-sensitive fallbacks instead of removing them outright:

- Keeps BlueBubbles query-param webhook auth working for existing installations, but logs an actionable warning to move to `x-hybridclaw-imessage-password`.
- Keeps unbound generic bearer secret injection working during the deprecation window, but logs runtime warnings and adds `hybridclaw doctor security` coverage for likely bearer secrets without `<SECRET>_BOUND_DOMAIN` bindings.
- Migrates legacy `container.additionalMounts` JSON into `container.binds` during runtime config normalization and warns operators to update config before removal.
- Documents the migration path in iMessage/configuration docs and the changelog.

The implementation keeps the canonical runtime config schema on `container.binds` while preserving existing legacy mounts through startup migration.

## Validation

- `npx biome check --write CHANGELOG.md docs/content/channels/imessage.md docs/content/reference/configuration.md docs/imessage.md src/channels/imessage/backend-bluebubbles.ts src/config/runtime-config.ts src/doctor/checks/security.ts src/gateway/gateway-http-proxy.ts src/security/mount-config.ts tests/doctor.test.ts tests/gateway-http-server.test.ts tests/imessage.bluebubbles.test.ts tests/mount-config.test.ts tests/runtime-config.migration-logging.test.ts`
- `npx vitest run tests/imessage.bluebubbles.test.ts tests/mount-config.test.ts tests/runtime-config.migration-logging.test.ts tests/doctor.test.ts tests/gateway-http-server.test.ts`
- `npx tsc --noEmit --noUnusedLocals --noUnusedParameters`
- `git diff --check`