### PR TITLE
[codex] Implement cross-instance A2A HTTP transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@
   Existing setups continue to work during the deprecation window while docs and
   `hybridclaw doctor security` point operators to header auth, bound bearer
   secrets, and `container.binds`.
+- **A2A cross-instance transport**: Outbound A2A delivery can resolve
+  canonical peer IDs through identity discovery, pin the resolved public key
+  against the peer Agent Card, and round-trip messages between two HTTP
+  instances.
 - **Diagram validation and accounting**: Mermaid diagrams are validated with
   the bundled Mermaid parser before render, diagram render artifacts retain
   skill-scoped source/rendered metadata, and local diagram renders emit

--- a/README.md
+++ b/README.md
@@ -189,6 +189,10 @@ Once the gateway is running, open HybridClaw locally:
   Cloudflare Tunnel providers read `NGROK_AUTHTOKEN`, `TS_AUTHKEY`,
   `CLOUDFLARE_TUNNEL_TOKEN`, and Cloudflare certificate credentials from the
   encrypted runtime secret store.
+- A2A cross-instance delivery resolves canonical peer IDs in order from the
+  local deployment URL or active tunnel URL, the A2A public-key trust ledger,
+  then DNS-style discovery when `HYBRIDCLAW_IDENTITY_DISCOVERY_ZONE` is
+  configured.
 - `container.warmPool` keeps a bounded adaptive pool of idle host/container
   runtimes for recently active agents when low cold-start latency matters.
 - `container.persistBashState` controls whether bash tool calls share shell

--- a/docs/content/internal/roadmap.md
+++ b/docs/content/internal/roadmap.md
@@ -410,7 +410,7 @@ Use these as issue titles. Keep each issue small enough to ship independently.
 |----|------|------|--------|
 | R9.1 | Auth | Inter-instance authentication with signed tokens | ✅ #480 via PR #890 |
 | R9.2 | Delegation | Delegation envelope schema | ✅ #481 via PR #889 |
-| R9.3 | Transport | Cross-instance HTTP transport | ⬜ #482 |
+| R9.3 | Transport | Cross-instance HTTP transport | ✅ #482 |
 | R9.4 | Audit | Cross-instance audit-log linking | ⬜ #483 |
 | R9.5 | Admin | Fleet topology admin UI | ⬜ #484 |
 | R9.6 | Reliability | Failure handling for offline child instances | ⬜ #486 |

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -216,6 +216,8 @@ saved revision history directly.
   in the encrypted runtime secret store or use a SecretRef-backed
   `voice.twilio.authToken`
 - `deployment.mode`, `deployment.public_url`, `deployment.tunnel.provider`, and `deployment.tunnel.health_check_interval_ms` declare whether the gateway runs behind a cloud URL or a local tunnel; cloud mode requires `deployment.public_url`, while local mode requires a tunnel provider such as `manual`, `ssh`, `ngrok`, `cloudflare`, or `tailscale`
+- `HYBRIDCLAW_IDENTITY_DISCOVERY_ZONE` enables DNS-style canonical identity discovery for A2A cross-instance delivery; outbound A2A resolves canonical recipients in this order: local canonical agents from `deployment.public_url` or the active tunnel URL, trusted peer instances from the A2A public-key trust ledger, then DNS-style discovery.
+- DNS-style A2A identity discovery trusts the returned URL and public key as operator-provided discovery data; use DNSSEC or out-of-band verification for production peers before relying on first-seen DNS records.
 - The built-in ngrok tunnel provider reads `NGROK_AUTHTOKEN` from the encrypted runtime secret store and health-checks active tunnels every 30 seconds by default
 - The built-in Tailscale Funnel tunnel provider reads `TS_AUTHKEY` from the encrypted runtime secret store when the host is not already logged in to `tailscaled`
 - The built-in Cloudflare Tunnel provider reads `CLOUDFLARE_TUNNEL_TOKEN`, or `CLOUDFLARE_CERT_PEM` plus `CLOUDFLARE_TUNNEL_JSON`, from the encrypted runtime secret store and reports `deployment.public_url` as the stable public hostname

--- a/src/a2a/a2a-outbox-delivery.ts
+++ b/src/a2a/a2a-outbox-delivery.ts
@@ -7,7 +7,7 @@ import {
 } from '../gateway/interactive-escalation.js';
 import {
   IdentityNotFoundError,
-  type IdentityResolution,
+  type IdentityResolver,
 } from '../identity/resolver.js';
 import { resolveSecretHandleInput } from '../security/secret-refs.js';
 import {
@@ -28,12 +28,14 @@ import {
 import { getA2AAuditSessionId, recordA2AMessageAudit } from './audit.js';
 import { signA2ADelegationToken } from './delegation-token.js';
 import { summarizeA2AEnvelopeForAudit } from './envelope.js';
+import { resolveA2AIdentity } from './identity-resolver.js';
 import { normalizePeerDescriptor } from './peer-descriptor.js';
 import {
   type A2APeerPublicKeyMaterial,
   assertA2APeerPublicKeyTrust,
   extractA2APeerPublicKey,
   fingerprintA2APublicKey,
+  normalizePublicKeyFingerprint,
 } from './trust-ledger.js';
 import {
   isA2AAllowedHttpUrl,
@@ -52,9 +54,7 @@ export interface A2AOutboxProcessOptions {
   /** Test hook for deterministic delivery without making live network calls. */
   fetchImpl?: typeof fetch;
   /** Resolves canonical remote recipients that were queued without a peer descriptor. */
-  identityResolver?: {
-    resolve(canonicalId: string): Promise<IdentityResolution>;
-  };
+  identityResolver?: Pick<IdentityResolver, 'resolve'>;
   /** Test hook for deterministic retry/audit timestamps. */
   now?: () => Date;
   /** Test hook for deterministic retry jitter. */
@@ -178,7 +178,29 @@ function recordA2AAudit(
   });
 }
 
-function createA2AEscalation(item: A2AOutboxItem, reason: string): void {
+function describeA2AItemDestination(
+  item: A2AOutboxItem,
+  agentCardUrl?: string,
+): string {
+  return (
+    agentCardUrl ||
+    item.agentCardUrl ||
+    item.identityResolution?.canonicalId ||
+    'unresolved peer'
+  );
+}
+
+interface A2AAttemptDetails {
+  statusCode?: number;
+  jsonRpcCode?: number;
+  agentCardUrl?: string;
+}
+
+function createA2AEscalation(
+  item: A2AOutboxItem,
+  reason: string,
+  agentCardUrl?: string,
+): void {
   const sessionId = resolveItemSessionId(item);
   const runId = resolveItemRunId(item, 'a2a-outbound');
   const approvalId = `a2a-outbound-${item.envelope.id}`;
@@ -187,7 +209,7 @@ function createA2AEscalation(item: A2AOutboxItem, reason: string): void {
     approvalId,
     prompt: [
       'A2A outbound delivery failed.',
-      `Agent Card: ${item.agentCardUrl || '<unresolved>'}`,
+      `Destination: ${describeA2AItemDestination(item, agentCardUrl)}`,
       `Message: ${item.envelope.id}`,
       `Reason: ${reason}`,
       'Reply `approved` after fixing the peer, or `declined` to cancel this delivery.',
@@ -213,7 +235,7 @@ function failA2AItem(
   item: A2AOutboxItem,
   now: Date,
   reason: string,
-  details: { statusCode?: number; jsonRpcCode?: number } = {},
+  details: A2AAttemptDetails = {},
 ): A2AOutboxItem {
   const failed: A2AOutboxItem = {
     ...item,
@@ -233,7 +255,8 @@ function failA2AItem(
     statusCode: details.statusCode ?? null,
     jsonRpcCode: details.jsonRpcCode ?? null,
     envelope: summarizeA2AEnvelopeForAudit(failed.envelope),
-    agentCardUrl: failed.agentCardUrl ?? null,
+    agentCardUrl: details.agentCardUrl ?? failed.agentCardUrl ?? null,
+    canonicalId: failed.identityResolution?.canonicalId ?? null,
   });
   recordA2AAudit(failed, {
     type: 'escalation.decision',
@@ -246,9 +269,11 @@ function failA2AItem(
     classifierReasoning: [reason],
     approvalDecision: 'required',
     reason,
+    agentCardUrl: details.agentCardUrl ?? failed.agentCardUrl ?? null,
+    canonicalId: failed.identityResolution?.canonicalId ?? null,
     envelope: summarizeA2AEnvelopeForAudit(failed.envelope),
   });
-  createA2AEscalation(failed, reason);
+  createA2AEscalation(failed, reason, details.agentCardUrl);
   return failed;
 }
 
@@ -284,7 +309,7 @@ function retryA2AItem(
       'baseDelayMs' | 'maxDelayMs' | 'jitterRatio' | 'random'
     >
   >,
-  details: { statusCode?: number; jsonRpcCode?: number } = {},
+  details: A2AAttemptDetails = {},
 ): A2AOutboxItem {
   const attempts = item.attempts + 1;
   const exponentialDelay = Math.min(
@@ -312,9 +337,19 @@ function retryA2AItem(
     statusCode: details.statusCode ?? null,
     jsonRpcCode: details.jsonRpcCode ?? null,
     envelope: summarizeA2AEnvelopeForAudit(retry.envelope),
-    agentCardUrl: retry.agentCardUrl ?? null,
+    agentCardUrl: details.agentCardUrl ?? retry.agentCardUrl ?? null,
+    canonicalId: retry.identityResolution?.canonicalId ?? null,
   });
   return retry;
+}
+
+function attemptDetails(
+  item: A2AOutboxItem,
+  details: Omit<A2AAttemptDetails, 'agentCardUrl'> = {},
+): A2AAttemptDetails {
+  return item.agentCardUrl
+    ? { ...details, agentCardUrl: item.agentCardUrl }
+    : details;
 }
 
 function retryOrFailA2AItem(
@@ -329,7 +364,7 @@ function retryOrFailA2AItem(
       'baseDelayMs' | 'maxDelayMs' | 'jitterRatio' | 'random'
     >
   >,
-  details: { statusCode?: number; jsonRpcCode?: number } = {},
+  details: A2AAttemptDetails = {},
 ): 'retried' | 'failed' {
   if (attemptNumber >= maxAttempts) {
     failA2AItem(item, now, reason, details);
@@ -350,13 +385,8 @@ async function resolveA2AItemDeliveryTarget(
   if (!canonicalId) {
     throw new Error('A2A outbox item is missing an Agent Card URL');
   }
-  if (!opts.identityResolver) {
-    throw new Error(
-      `A2A identity resolver is required for remote recipient ${canonicalId}`,
-    );
-  }
-
-  const resolution = await opts.identityResolver.resolve(canonicalId);
+  const resolution = await (opts.identityResolver?.resolve(canonicalId) ??
+    resolveA2AIdentity(canonicalId));
   const descriptor = normalizePeerDescriptor({
     transport: 'a2a',
     url: resolution.url,
@@ -392,7 +422,13 @@ async function resolveA2AItemDeliveryTarget(
 
 function discoveryPublicKeyFingerprint(publicKey: string): string | null {
   const normalized = publicKey.trim();
-  if (/^[A-Za-z0-9_-]{43}$/.test(normalized)) return normalized;
+  if (/^[A-Za-z0-9_-]+$/u.test(normalized)) {
+    try {
+      return normalizePublicKeyFingerprint(normalized);
+    } catch {
+      return null;
+    }
+  }
   try {
     const parsed = JSON.parse(normalized) as JsonWebKey;
     if (
@@ -497,14 +533,19 @@ export async function deliverA2AItem(
       error instanceof A2AFailFastError ||
       error instanceof IdentityNotFoundError
     ) {
-      failA2AItem(deliveryItem, now, reason);
+      failA2AItem(deliveryItem, now, reason, attemptDetails(deliveryItem));
       return 'failed';
     }
     const httpDecision = statusCode
       ? classifyA2AHttpStatus(statusCode)
       : 'retry';
     if (httpDecision === 'fail-fast') {
-      failA2AItem(deliveryItem, now, reason, { statusCode });
+      failA2AItem(
+        deliveryItem,
+        now,
+        reason,
+        attemptDetails(deliveryItem, { statusCode }),
+      );
       return 'failed';
     }
     return retryOrFailA2AItem(
@@ -514,7 +555,7 @@ export async function deliverA2AItem(
       maxAttempts,
       reason,
       retryOptions,
-      { statusCode },
+      attemptDetails(deliveryItem, { statusCode }),
     );
   }
 
@@ -533,7 +574,7 @@ export async function deliverA2AItem(
     }
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
-    failA2AItem(deliveryItem, now, reason);
+    failA2AItem(deliveryItem, now, reason, attemptDetails(deliveryItem));
     return 'failed';
   }
 
@@ -543,6 +584,7 @@ export async function deliverA2AItem(
       deliveryItem,
       now,
       'Agent Card url must use https unless targeting loopback',
+      attemptDetails(deliveryItem),
     );
     return 'failed';
   }
@@ -571,7 +613,7 @@ export async function deliverA2AItem(
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     if (error instanceof A2AFailFastError) {
-      failA2AItem(deliveryItem, now, reason);
+      failA2AItem(deliveryItem, now, reason, attemptDetails(deliveryItem));
       return 'failed';
     }
     return retryOrFailA2AItem(
@@ -581,14 +623,18 @@ export async function deliverA2AItem(
       maxAttempts,
       reason,
       retryOptions,
+      attemptDetails(deliveryItem),
     );
   }
 
   const httpDecision = classifyA2AHttpStatus(response.status);
   if (httpDecision === 'fail-fast') {
-    failA2AItem(deliveryItem, now, `HTTP ${response.status}`, {
-      statusCode: response.status,
-    });
+    failA2AItem(
+      deliveryItem,
+      now,
+      `HTTP ${response.status}`,
+      attemptDetails(deliveryItem, { statusCode: response.status }),
+    );
     return 'failed';
   }
   if (httpDecision === 'retry') {
@@ -599,7 +645,7 @@ export async function deliverA2AItem(
       maxAttempts,
       `HTTP ${response.status}`,
       retryOptions,
-      { statusCode: response.status },
+      attemptDetails(deliveryItem, { statusCode: response.status }),
     );
   }
 
@@ -611,7 +657,12 @@ export async function deliverA2AItem(
     }
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
-    failA2AItem(deliveryItem, now, reason, { statusCode: response.status });
+    failA2AItem(
+      deliveryItem,
+      now,
+      reason,
+      attemptDetails(deliveryItem, { statusCode: response.status }),
+    );
     return 'failed';
   }
 
@@ -630,16 +681,21 @@ export async function deliverA2AItem(
         maxAttempts,
         reason,
         retryOptions,
-        {
+        attemptDetails(deliveryItem, {
           statusCode: response.status,
           jsonRpcCode: code,
-        },
+        }),
       );
     }
-    failA2AItem(deliveryItem, now, reason, {
-      statusCode: response.status,
-      ...(Number.isFinite(code) ? { jsonRpcCode: code } : {}),
-    });
+    failA2AItem(
+      deliveryItem,
+      now,
+      reason,
+      attemptDetails(deliveryItem, {
+        statusCode: response.status,
+        ...(Number.isFinite(code) ? { jsonRpcCode: code } : {}),
+      }),
+    );
     return 'failed';
   }
 
@@ -672,6 +728,7 @@ export async function deliverA2AItem(
     method: request.method,
     envelope: summarizeA2AEnvelopeForAudit(delivered.envelope),
     agentCardUrl: delivered.agentCardUrl ?? null,
+    canonicalId: delivered.identityResolution?.canonicalId ?? null,
   });
   return 'delivered';
 }

--- a/src/a2a/a2a-outbox-persistence.ts
+++ b/src/a2a/a2a-outbox-persistence.ts
@@ -200,7 +200,7 @@ export function listA2AOutboxItems(
 function makeOutboxItem(
   envelope: A2AEnvelope,
   descriptor: Partial<
-    Pick<A2APeerDescriptor, 'agentCardUrl' | 'bearerTokenRef'>
+    Pick<A2APeerDescriptor, 'agentCardUrl' | 'bearerTokenRef' | 'canonicalId'>
   >,
   context?: TransportAdapterContext,
   opts?: A2AOutboundAdapterOptions,
@@ -216,7 +216,16 @@ function makeOutboxItem(
     ...(descriptor.agentCardUrl
       ? { agentCardUrl: descriptor.agentCardUrl }
       : {}),
-    ...(identityResolution ? { identityResolution } : {}),
+    ...(identityResolution
+      ? { identityResolution }
+      : descriptor.canonicalId
+        ? {
+            identityResolution: {
+              status: 'unresolved',
+              canonicalId: descriptor.canonicalId,
+            } satisfies A2AOutboxIdentityResolution,
+          }
+        : {}),
     bearerTokenRef: descriptor.bearerTokenRef,
     attempts: 0,
     maxAttempts: normalizePositiveInteger(

--- a/src/a2a/identity-resolver-invalidation.ts
+++ b/src/a2a/identity-resolver-invalidation.ts
@@ -1,0 +1,18 @@
+type A2AIdentityResolverInvalidator = (canonicalId?: string) => void;
+
+const invalidators = new Set<A2AIdentityResolverInvalidator>();
+
+export function registerA2AIdentityResolverInvalidator(
+  invalidator: A2AIdentityResolverInvalidator,
+): () => void {
+  invalidators.add(invalidator);
+  return () => {
+    invalidators.delete(invalidator);
+  };
+}
+
+export function invalidateA2AIdentityResolvers(canonicalId?: string): void {
+  for (const invalidator of invalidators) {
+    invalidator(canonicalId);
+  }
+}

--- a/src/a2a/identity-resolver.ts
+++ b/src/a2a/identity-resolver.ts
@@ -1,0 +1,166 @@
+import { listAgents } from '../agents/agent-registry.js';
+import { getRuntimeConfig } from '../config/runtime-config.js';
+import { getGatewayAdminTunnelStatus } from '../gateway/gateway-tunnel-service.js';
+import { resolveLocalInstanceId } from '../identity/agent-id.js';
+import {
+  DnsIdentityResolverBackend,
+  IdentityNotFoundError,
+  type IdentityResolution,
+  IdentityResolver,
+  type IdentityResolverBackend,
+  IdentityResolverError,
+  normalizeIdentityUrl,
+  parseCanonicalIdentity,
+} from '../identity/resolver.js';
+import { resolveA2AAgentId } from './identity.js';
+import { registerA2AIdentityResolverInvalidator } from './identity-resolver-invalidation.js';
+import {
+  ensureA2AInstanceKeypair,
+  getA2ATrustedPublicKeyPeer,
+} from './trust-ledger.js';
+
+export const A2A_IDENTITY_DISCOVERY_ZONE_ENV =
+  'HYBRIDCLAW_IDENTITY_DISCOVERY_ZONE';
+
+function configuredIdentityDiscoveryZone(): string | null {
+  return process.env[A2A_IDENTITY_DISCOVERY_ZONE_ENV]?.trim() || null;
+}
+
+function agentCardBaseUrl(agentCardUrl: string): string {
+  const url = new URL(agentCardUrl);
+  return normalizeIdentityUrl(url.origin);
+}
+
+function publicKeyAsResolverValue(value: unknown): string {
+  if (typeof value === 'string') return value;
+  return JSON.stringify(value);
+}
+
+function localDeploymentPublicUrl(): string {
+  const tunnelStatus = getGatewayAdminTunnelStatus();
+  const publicUrl =
+    tunnelStatus.publicUrl || getRuntimeConfig().deployment.public_url;
+  if (!publicUrl) {
+    throw new IdentityResolverError(
+      'Local identity resolution requires deployment.public_url or an active tunnel public URL',
+    );
+  }
+  return normalizeIdentityUrl(publicUrl);
+}
+
+class LocalDeploymentA2AIdentityResolverBackend
+  implements IdentityResolverBackend
+{
+  private cachedAgentKey = '';
+  private cachedCanonicalAgentIds = new Set<string>();
+
+  private localCanonicalAgentIds(): Set<string> {
+    const agents = listAgents();
+    const key = [
+      resolveLocalInstanceId(),
+      ...agents.map(
+        (agent) =>
+          `${agent.id}\0${agent.canonicalId || ''}\0${agent.owner || ''}\0${agent.ownerUserId || ''}`,
+      ),
+    ].join('\n');
+    if (key === this.cachedAgentKey) return this.cachedCanonicalAgentIds;
+
+    const canonicalAgentIds = new Set<string>();
+    for (const agent of agents) {
+      try {
+        canonicalAgentIds.add(resolveA2AAgentId(agent.id));
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        throw new IdentityResolverError(
+          `Local A2A identity resolution failed for agent ${agent.id}: ${reason}`,
+        );
+      }
+    }
+    this.cachedAgentKey = key;
+    this.cachedCanonicalAgentIds = canonicalAgentIds;
+    return canonicalAgentIds;
+  }
+
+  async lookup(canonicalId: string): Promise<IdentityResolution | null> {
+    const parsed = parseCanonicalIdentity(canonicalId);
+    if (parsed.kind !== 'agent') return null;
+    if (parsed.parsed.instanceId !== resolveLocalInstanceId()) return null;
+    if (!this.localCanonicalAgentIds().has(parsed.id)) return null;
+
+    return {
+      url: localDeploymentPublicUrl(),
+      publicKey: JSON.stringify(ensureA2AInstanceKeypair().publicKeyJwk),
+    };
+  }
+}
+
+class TrustedPeerA2AIdentityResolverBackend implements IdentityResolverBackend {
+  async lookup(canonicalId: string): Promise<IdentityResolution | null> {
+    const parsed = parseCanonicalIdentity(canonicalId);
+    if (parsed.kind !== 'agent') return null;
+
+    const peer = getA2ATrustedPublicKeyPeer(parsed.parsed.instanceId);
+    if (!peer || peer.status !== 'trusted') return null;
+    const reachableUrl = peer.deliveryUrl || peer.agentCardUrl;
+    if (!reachableUrl) return null;
+    return {
+      url: agentCardBaseUrl(reachableUrl),
+      publicKey: publicKeyAsResolverValue(
+        peer.publicKeyJwk ?? peer.publicKeyFingerprint,
+      ),
+    };
+  }
+}
+
+class DefaultA2AIdentityResolverBackend implements IdentityResolverBackend {
+  private readonly localBackend =
+    new LocalDeploymentA2AIdentityResolverBackend();
+  private readonly trustedPeerBackend =
+    new TrustedPeerA2AIdentityResolverBackend();
+  private dnsZone: string | null = null;
+  private dnsBackend: DnsIdentityResolverBackend | null = null;
+
+  async lookup(canonicalId: string): Promise<IdentityResolution | null> {
+    const local = await this.localBackend.lookup(canonicalId);
+    if (local) return local;
+
+    const trustedPeer = await this.trustedPeerBackend.lookup(canonicalId);
+    if (trustedPeer) return trustedPeer;
+
+    const zone = configuredIdentityDiscoveryZone();
+    if (!zone) return null;
+    if (zone !== this.dnsZone) {
+      this.dnsZone = zone;
+      this.dnsBackend = new DnsIdentityResolverBackend({ zone });
+    }
+    return this.dnsBackend?.lookup(canonicalId) ?? null;
+  }
+}
+
+let cachedDefaultA2AIdentityResolver: IdentityResolver | null = null;
+
+registerA2AIdentityResolverInvalidator((canonicalId) => {
+  cachedDefaultA2AIdentityResolver?.invalidate(canonicalId);
+});
+
+export function getDefaultA2AIdentityResolver(): IdentityResolver {
+  cachedDefaultA2AIdentityResolver ??= new IdentityResolver({
+    backend: new DefaultA2AIdentityResolverBackend(),
+  });
+  return cachedDefaultA2AIdentityResolver;
+}
+
+export async function resolveA2AIdentity(
+  canonicalId: string,
+): Promise<IdentityResolution> {
+  try {
+    return await getDefaultA2AIdentityResolver().resolve(canonicalId);
+  } catch (error) {
+    if (error instanceof IdentityNotFoundError) {
+      throw new IdentityResolverError(
+        `No A2A identity resolution found for ${error.canonicalId}; configure ${A2A_IDENTITY_DISCOVERY_ZONE_ENV} or trust the peer public key first.`,
+      );
+    }
+    throw error;
+  }
+}

--- a/src/a2a/peer-descriptor.ts
+++ b/src/a2a/peer-descriptor.ts
@@ -1,3 +1,4 @@
+import { parseAgentIdentity } from '../identity/agent-id.js';
 import type { SecretRef } from '../security/secret-refs.js';
 import { parseSecretInput } from '../security/secret-refs.js';
 import {
@@ -22,6 +23,8 @@ const A2A_ALLOWED_FIELDS = new Set([
   'base_url',
   'agentCardUrl',
   'agent_card_url',
+  'canonicalId',
+  'canonical_id',
   'bearerTokenRef',
   'bearer_token_ref',
   'expectPublicKey',
@@ -44,7 +47,8 @@ export interface InternalPeerDescriptor {
 
 export interface A2APeerDescriptor {
   transport: 'a2a';
-  agentCardUrl: string;
+  agentCardUrl?: string;
+  canonicalId?: string;
   bearerTokenRef?: SecretRef;
   expectPublicKey?: boolean;
 }
@@ -229,7 +233,7 @@ function deriveAgentCardUrl(peerUrl: string): string {
 function readA2AAgentCardUrl(
   record: Record<string, unknown>,
   issues: string[],
-): string {
+): string | undefined {
   const explicitAgentCardUrl = readAlias(
     record,
     'agentCardUrl',
@@ -243,23 +247,36 @@ function readA2AAgentCardUrl(
     );
   }
 
-  const hasPeerUrl =
-    Object.hasOwn(record, 'peerUrl') ||
-    Object.hasOwn(record, 'peer_url') ||
-    Object.hasOwn(record, 'baseUrl') ||
-    Object.hasOwn(record, 'base_url') ||
-    Object.hasOwn(record, 'url');
   const peerUrl =
     readOptionalUrlAlias(record, 'peerUrl', 'peer_url', 'peerUrl', issues) ||
     readOptionalUrlAlias(record, 'baseUrl', 'base_url', 'baseUrl', issues) ||
     readOptionalUrlAlias(record, 'url', 'url', 'url', issues);
   if (!peerUrl) {
-    if (!hasPeerUrl) {
-      issues.push('agentCardUrl or url is required');
-    }
-    return '';
+    return undefined;
   }
   return deriveAgentCardUrl(peerUrl);
+}
+
+function readA2ACanonicalId(
+  record: Record<string, unknown>,
+  issues: string[],
+): string | undefined {
+  const canonicalId = readOptionalStringAlias(
+    record,
+    'canonicalId',
+    'canonical_id',
+    'canonicalId',
+    issues,
+  );
+  if (!canonicalId) return undefined;
+  try {
+    return parseAgentIdentity(canonicalId).id;
+  } catch {
+    issues.push(
+      'canonicalId must be a canonical agent id (agent-slug@user@instance-id)',
+    );
+    return undefined;
+  }
 }
 
 function readHttpHeaderName(
@@ -359,6 +376,10 @@ export function normalizePeerDescriptor(value: unknown): PeerDescriptor {
   if (transport === 'a2a') {
     validateAllowedFields(value, A2A_ALLOWED_FIELDS, issues);
     const agentCardUrl = readA2AAgentCardUrl(value, issues);
+    const canonicalId = readA2ACanonicalId(value, issues);
+    if (!agentCardUrl && !canonicalId) {
+      issues.push('agentCardUrl, url, or canonicalId is required');
+    }
     const bearerTokenRef = normalizeSecretRef(
       readAlias(value, 'bearerTokenRef', 'bearer_token_ref'),
       'bearerTokenRef',
@@ -372,10 +393,11 @@ export function normalizePeerDescriptor(value: unknown): PeerDescriptor {
       'expectPublicKey',
       issues,
     );
+    const effectiveExpectPublicKey = Boolean(expectPublicKey || canonicalId);
     if (
       agentCardUrl &&
       !bearerTokenRef &&
-      !expectPublicKey &&
+      !effectiveExpectPublicKey &&
       !isA2ALoopbackHttpUrl(agentCardUrl)
     ) {
       issues.push(
@@ -387,9 +409,10 @@ export function normalizePeerDescriptor(value: unknown): PeerDescriptor {
     }
     return {
       transport: 'a2a',
-      agentCardUrl,
+      ...(agentCardUrl ? { agentCardUrl } : {}),
+      ...(canonicalId ? { canonicalId } : {}),
       ...(bearerTokenRef ? { bearerTokenRef } : {}),
-      ...(expectPublicKey ? { expectPublicKey } : {}),
+      ...(effectiveExpectPublicKey ? { expectPublicKey: true } : {}),
     };
   }
 

--- a/src/a2a/trust-ledger.ts
+++ b/src/a2a/trust-ledger.ts
@@ -24,6 +24,7 @@ import { writeFileAtomicExclusive } from '../utils/atomic-file.js';
 import type { A2AAgentCard } from './a2a-json-rpc.js';
 import { A2AEnvelopeValidationError, classifyA2AAgentId } from './envelope.js';
 import { resolveA2AAgentId } from './identity.js';
+import { invalidateA2AIdentityResolvers } from './identity-resolver-invalidation.js';
 import { isRecord, normalizePositiveInteger } from './utils.js';
 import {
   WEBHOOK_BODY_VERSION,
@@ -219,7 +220,7 @@ export function fingerprintA2APublicKey(publicKeyJwk: JsonWebKey): string {
     .digest('base64url');
 }
 
-function normalizePublicKeyFingerprint(value: unknown): string {
+export function normalizePublicKeyFingerprint(value: unknown): string {
   if (typeof value !== 'string' || !value.trim()) {
     throw new A2AEnvelopeValidationError(['publicKeyFingerprint is required']);
   }
@@ -1015,6 +1016,7 @@ export function revokeA2ATrustedPublicKeyPeer(
       params.reason?.trim() || A2A_TRUST_LEDGER_DEFAULT_REVOKE_REASON,
   };
   persistTrustedPublicKeyPeer(revoked);
+  invalidateA2AIdentityResolvers();
   recordTrustAudit({
     runId: params.runId,
     event: {
@@ -1061,6 +1063,7 @@ export function upsertA2ATrustedPublicKeyPeer(
     lastSeenAt: timestamp,
   };
   persistTrustedPublicKeyPeer(peer);
+  invalidateA2AIdentityResolvers();
   recordTrustAudit({
     event: {
       type: 'a2a.trust.operator_override',
@@ -1089,6 +1092,7 @@ export function deleteA2ATrustedPublicKeyPeer(peerId: string): void {
     },
     { exists: false, content: null },
   );
+  invalidateA2AIdentityResolvers();
   if (existing) {
     recordTrustAudit({
       event: {

--- a/src/identity/resolver.ts
+++ b/src/identity/resolver.ts
@@ -119,7 +119,7 @@ function normalizeIdentityResolution(value: unknown): IdentityResolution {
   };
 }
 
-function normalizeIdentityUrl(value: string): string {
+export function normalizeIdentityUrl(value: string): string {
   const trimmed = value.trim();
   if (!isA2AAllowedHttpUrl(trimmed)) {
     throw new IdentityResolverError(

--- a/tests/a2a-identity-resolver.test.ts
+++ b/tests/a2a-identity-resolver.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'vitest';
+
+import { setupA2AWebhookTestEnv } from './helpers/a2a-webhook-fixtures.ts';
+
+setupA2AWebhookTestEnv('hc-a2a-identity-resolver-');
+
+describe('A2A identity resolver', () => {
+  test('resolves local canonical agents through deployment public URL and local public key', async () => {
+    process.env.HYBRIDCLAW_INSTANCE_ID = 'inst-local';
+    const { initDatabase } = await import('../src/memory/db.ts');
+    const runtimeConfig = await import('../src/config/runtime-config.ts');
+    const resolver = await import('../src/a2a/identity-resolver.ts');
+
+    initDatabase({ quiet: true });
+    runtimeConfig.updateRuntimeConfig((draft) => {
+      draft.deployment.mode = 'local';
+      draft.deployment.public_url = 'https://local-tunnel.example.com';
+      draft.deployment.tunnel.provider = 'manual';
+      draft.agents.list = [
+        {
+          id: 'main',
+          canonicalId: 'main@team@inst-local',
+          owner: 'team',
+          role: 'lead',
+        },
+      ];
+    });
+
+    const resolved = await resolver.resolveA2AIdentity('main@team@inst-local');
+
+    expect(resolved.url).toBe('https://local-tunnel.example.com');
+    expect(JSON.parse(resolved.publicKey)).toMatchObject({
+      kty: 'OKP',
+      crv: 'Ed25519',
+    });
+  });
+
+  test('invalidates cached trusted peer resolutions when trust records change', async () => {
+    const { initDatabase } = await import('../src/memory/db.ts');
+    const resolver = await import('../src/a2a/identity-resolver.ts');
+    const trust = await import('../src/a2a/trust-ledger.ts');
+
+    initDatabase({ quiet: true });
+    trust.upsertA2ATrustedPublicKeyPeer({
+      peerId: 'peer-instance',
+      agentCardUrl: 'https://peer-a.example.com/.well-known/agent.json',
+      deliveryUrl: 'https://peer-a.example.com/a2a',
+      publicKeyFingerprint: 'A'.repeat(43),
+    });
+
+    await expect(
+      resolver.resolveA2AIdentity('remote@team@peer-instance'),
+    ).resolves.toMatchObject({
+      url: 'https://peer-a.example.com',
+      publicKey: 'A'.repeat(43),
+    });
+
+    trust.upsertA2ATrustedPublicKeyPeer({
+      peerId: 'peer-instance',
+      agentCardUrl: 'https://peer-b.example.com/.well-known/agent.json',
+      deliveryUrl: 'https://peer-b.example.com/a2a',
+      publicKeyFingerprint: 'B'.repeat(43),
+    });
+
+    await expect(
+      resolver.resolveA2AIdentity('remote@team@peer-instance'),
+    ).resolves.toMatchObject({
+      url: 'https://peer-b.example.com',
+      publicKey: 'B'.repeat(43),
+    });
+  });
+});

--- a/tests/a2a-outbound.integration.test.ts
+++ b/tests/a2a-outbound.integration.test.ts
@@ -1,5 +1,8 @@
 import { generateKeyPairSync } from 'node:crypto';
+import fs from 'node:fs';
 import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
 
 import { describe, expect, test, vi } from 'vitest';
 
@@ -36,6 +39,91 @@ function listen(server: http.Server): Promise<number> {
 function closeServer(server: http.Server): Promise<void> {
   return new Promise((resolve, reject) => {
     server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function loadA2AInstance(params: {
+  home: string;
+  instanceId: string;
+  agentId: string;
+}) {
+  process.env.HYBRIDCLAW_DATA_DIR = params.home;
+  process.env.HOME = params.home;
+  process.env.HYBRIDCLAW_INSTANCE_ID = params.instanceId;
+  vi.resetModules();
+
+  const [{ initDatabase }, runtimeConfig, runtime, inbound, outbound, trust] =
+    await Promise.all([
+      import('../src/memory/db.ts'),
+      import('../src/config/runtime-config.ts'),
+      import('../src/a2a/runtime.ts'),
+      import('../src/a2a/a2a-inbound.ts'),
+      import('../src/a2a/a2a-outbound.ts'),
+      import('../src/a2a/trust-ledger.ts'),
+    ]);
+
+  initDatabase({ quiet: true });
+  runtimeConfig.updateRuntimeConfig((draft) => {
+    draft.agents.list = [
+      {
+        id: params.agentId,
+        canonicalId: `${params.agentId}@team@${params.instanceId}`,
+        owner: 'team',
+        role: 'lead',
+        a2a: { exposure: 'trusted' },
+      },
+    ];
+  });
+
+  return {
+    home: params.home,
+    instanceId: params.instanceId,
+    runtimeConfig,
+    runtime,
+    inbound,
+    outbound,
+    trust,
+  };
+}
+
+function activateA2AInstance(
+  instance: Pick<
+    Awaited<ReturnType<typeof loadA2AInstance>>,
+    'home' | 'instanceId'
+  >,
+): void {
+  process.env.HYBRIDCLAW_DATA_DIR = instance.home;
+  process.env.HOME = instance.home;
+  process.env.HYBRIDCLAW_INSTANCE_ID = instance.instanceId;
+}
+
+function createA2AInstanceServer(
+  instance: Awaited<ReturnType<typeof loadA2AInstance>>,
+): http.Server {
+  return http.createServer(async (request, response) => {
+    activateA2AInstance(instance);
+    const origin = `http://${request.headers.host}`;
+    const url = new URL(request.url || '/', origin);
+    if (
+      url.pathname === '/.well-known/agent.json' &&
+      request.method === 'GET'
+    ) {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(
+        JSON.stringify(
+          instance.trust.buildLocalA2AAgentCard(origin, {
+            peerTrustLevel: 'trusted',
+          }),
+        ),
+      );
+      return;
+    }
+    if (url.pathname === '/a2a') {
+      await instance.inbound.handleA2AJsonRpcInbound(request, response, url);
+      return;
+    }
+    response.writeHead(404);
+    response.end();
   });
 }
 
@@ -122,7 +210,7 @@ describe('A2A outbound integration', () => {
     ]);
   });
 
-  test('routes remote sendMessage recipients through identity resolution and HTTP delivery', async () => {
+  test('routes remote sendMessage recipients through DNS discovery and HTTP delivery', async () => {
     process.env.HYBRIDCLAW_INSTANCE_ID = 'instance-x';
     process.env.HYBRIDCLAW_IDENTITY_DISCOVERY_ZONE = 'identity.test';
 
@@ -254,5 +342,227 @@ describe('A2A outbound integration', () => {
         recipient_agent_id: 'stub-b@team@instance-y',
       }),
     ]);
+  });
+
+  test('routes local canonical recipients through deployment public URL and HTTP delivery', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'hc-a2a-inst-local-'));
+    let server: http.Server | null = null;
+
+    try {
+      const instance = await loadA2AInstance({
+        home,
+        instanceId: 'inst-local',
+        agentId: 'main',
+      });
+      const delegationKey =
+        instance.outbound.getOrCreateA2ADelegationTokenKeyPair({
+          now: new Date('2030-01-01T00:00:00.000Z'),
+        });
+      instance.inbound.upsertA2ATrustedA2APeer({
+        peerId: 'self',
+        senderAgentId: 'main@team@inst-local',
+        publicKeyPem: delegationKey.publicKeyPem,
+      });
+
+      server = createA2AInstanceServer(instance);
+      const port = await listen(server);
+      const url = `http://127.0.0.1:${port}`;
+
+      activateA2AInstance(instance);
+      instance.runtimeConfig.updateRuntimeConfig((draft) => {
+        draft.deployment.mode = 'local';
+        draft.deployment.public_url = url;
+        draft.deployment.tunnel.provider = 'manual';
+      });
+
+      instance.runtime.sendMessage(
+        {
+          id: 'msg-local-via-public-url',
+          sender_agent_id: 'main@team@inst-local',
+          recipient_agent_id: 'main@team@inst-local',
+          sender_instance_id: 'inst-local',
+          thread_id: 'thread-local-public-url',
+          intent: 'chat',
+          content: 'Loop through the public deployment URL.',
+          created_at: '2026-05-01T10:00:00.000Z',
+        },
+        {
+          peerDescriptor: {
+            transport: 'a2a',
+            canonicalId: 'main@team@inst-local',
+          },
+        },
+      );
+
+      await expect(instance.outbound.processA2AOutbox()).resolves.toMatchObject(
+        { processed: 1, delivered: 1 },
+      );
+
+      expect(instance.runtime.inbox('main')).toMatchObject([
+        {
+          id: 'msg-local-via-public-url',
+          sender_agent_id: 'main@team@inst-local',
+          recipient_agent_id: 'main@team@inst-local',
+        },
+      ]);
+      expect(
+        instance.outbound.listA2AOutboxItems({ status: 'delivered' }),
+      ).toEqual([
+        expect.objectContaining({
+          status: 'delivered',
+          agentCardUrl: `${url}/.well-known/agent.json`,
+          identityResolution: expect.objectContaining({
+            status: 'resolved',
+            canonicalId: 'main@team@inst-local',
+            url,
+          }),
+        }),
+      ]);
+    } finally {
+      if (server) await closeServer(server);
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test('instance A sends to instance B through identity resolution and B replies', async () => {
+    const homeA = fs.mkdtempSync(path.join(os.tmpdir(), 'hc-a2a-inst-a-'));
+    const homeB = fs.mkdtempSync(path.join(os.tmpdir(), 'hc-a2a-inst-b-'));
+    let serverA: http.Server | null = null;
+    let serverB: http.Server | null = null;
+
+    try {
+      const instanceA = await loadA2AInstance({
+        home: homeA,
+        instanceId: 'inst-a',
+        agentId: 'main',
+      });
+      const delegationKeyA =
+        instanceA.outbound.getOrCreateA2ADelegationTokenKeyPair({
+          now: new Date('2030-01-01T00:00:00.000Z'),
+        });
+      const instanceKeyA = instanceA.trust.ensureA2AInstanceKeypair(
+        new Date('2030-01-01T00:00:00.000Z'),
+      );
+
+      const instanceB = await loadA2AInstance({
+        home: homeB,
+        instanceId: 'inst-b',
+        agentId: 'remote',
+      });
+      const delegationKeyB =
+        instanceB.outbound.getOrCreateA2ADelegationTokenKeyPair({
+          now: new Date('2030-01-01T00:00:00.000Z'),
+        });
+      const instanceKeyB = instanceB.trust.ensureA2AInstanceKeypair(
+        new Date('2030-01-01T00:00:00.000Z'),
+      );
+
+      instanceA.inbound.upsertA2ATrustedA2APeer({
+        peerId: 'instance-b',
+        senderAgentId: 'remote@team@inst-b',
+        publicKeyPem: delegationKeyB.publicKeyPem,
+      });
+      instanceB.inbound.upsertA2ATrustedA2APeer({
+        peerId: 'instance-a',
+        senderAgentId: 'main@team@inst-a',
+        publicKeyPem: delegationKeyA.publicKeyPem,
+      });
+
+      serverA = createA2AInstanceServer(instanceA);
+      serverB = createA2AInstanceServer(instanceB);
+      const [portA, portB] = await Promise.all([
+        listen(serverA),
+        listen(serverB),
+      ]);
+      const urlA = `http://127.0.0.1:${portA}`;
+      const urlB = `http://127.0.0.1:${portB}`;
+
+      activateA2AInstance(instanceA);
+      instanceA.trust.upsertA2ATrustedPublicKeyPeer({
+        peerId: 'inst-b',
+        agentCardUrl: `${urlB}/.well-known/agent.json`,
+        deliveryUrl: `${urlB}/a2a`,
+        publicKeyJwk: instanceKeyB.publicKeyJwk,
+      });
+      activateA2AInstance(instanceB);
+      instanceB.trust.upsertA2ATrustedPublicKeyPeer({
+        peerId: 'inst-a',
+        agentCardUrl: `${urlA}/.well-known/agent.json`,
+        deliveryUrl: `${urlA}/a2a`,
+        publicKeyJwk: instanceKeyA.publicKeyJwk,
+      });
+
+      activateA2AInstance(instanceA);
+      instanceA.runtime.sendMessage(
+        {
+          id: 'msg-a-to-b',
+          sender_agent_id: 'main@team@inst-a',
+          recipient_agent_id: 'remote@team@inst-b',
+          sender_instance_id: 'inst-a',
+          thread_id: 'thread-cross-instance-reply',
+          intent: 'chat',
+          content: 'Hello from A.',
+          created_at: '2026-05-01T10:00:00.000Z',
+        },
+        {
+          peerDescriptor: {
+            transport: 'a2a',
+            canonicalId: 'remote@team@inst-b',
+          },
+        },
+      );
+
+      activateA2AInstance(instanceA);
+      await expect(
+        instanceA.outbound.processA2AOutbox(),
+      ).resolves.toMatchObject({ processed: 1, delivered: 1 });
+      activateA2AInstance(instanceB);
+      expect(instanceB.runtime.inbox('remote')).toMatchObject([
+        {
+          id: 'msg-a-to-b',
+          sender_agent_id: 'main@team@inst-a',
+          recipient_agent_id: 'remote@team@inst-b',
+        },
+      ]);
+
+      activateA2AInstance(instanceB);
+      instanceB.runtime.sendMessage(
+        {
+          id: 'msg-b-to-a',
+          sender_agent_id: 'remote@team@inst-b',
+          recipient_agent_id: 'main@team@inst-a',
+          sender_instance_id: 'inst-b',
+          thread_id: 'thread-cross-instance-reply',
+          parent_message_id: 'msg-a-to-b',
+          intent: 'chat',
+          content: 'Reply from B.',
+          created_at: '2026-05-01T10:01:00.000Z',
+        },
+        {
+          peerDescriptor: {
+            transport: 'a2a',
+            canonicalId: 'main@team@inst-a',
+          },
+        },
+      );
+
+      await expect(
+        instanceB.outbound.processA2AOutbox(),
+      ).resolves.toMatchObject({ processed: 1, delivered: 1 });
+      activateA2AInstance(instanceA);
+      expect(instanceA.runtime.inbox('main')).toMatchObject([
+        {
+          id: 'msg-b-to-a',
+          sender_agent_id: 'remote@team@inst-b',
+          recipient_agent_id: 'main@team@inst-a',
+          parent_message_id: 'msg-a-to-b',
+        },
+      ]);
+    } finally {
+      if (serverA) await closeServer(serverA);
+      if (serverB) await closeServer(serverB);
+      fs.rmSync(homeA, { recursive: true, force: true });
+      fs.rmSync(homeB, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/a2a-outbound.test.ts
+++ b/tests/a2a-outbound.test.ts
@@ -577,6 +577,329 @@ describe('A2A outbound adapter', () => {
     ).toContain('a2a.trust.granted');
   });
 
+  test('resolves canonical A2A peer destinations through identity discovery', async () => {
+    const { initDatabase } = await import('../src/memory/db.ts');
+    const runtime = await import('../src/a2a/runtime.ts');
+    const transport = await import('../src/a2a/transport-registry.ts');
+    const a2a = await import('../src/a2a/a2a-outbound.ts');
+    const trust = await import('../src/a2a/trust-ledger.ts');
+
+    initDatabase({ quiet: true });
+    const registry = new transport.TransportRegistry();
+    registry.register(new a2a.A2AOutboundAdapter());
+    const peerKey = publicKeyJwk();
+    const resolver = {
+      resolve: vi.fn(async (canonicalId: string) => {
+        expect(canonicalId).toBe('remote@team@peer-instance');
+        return {
+          url: 'https://peer.example.com',
+          publicKey: JSON.stringify(peerKey),
+        };
+      }),
+    };
+    const requests: Array<{
+      url: string;
+      method: string;
+      authorization: string;
+      body: string;
+    }> = [];
+    const fetchImpl = vi.fn(
+      async (url: RequestInfo | URL, init?: RequestInit) => {
+        const headers = init?.headers as Record<string, string>;
+        requests.push({
+          url: String(url),
+          method: init?.method || 'GET',
+          authorization: headers?.authorization || '',
+          body: String(init?.body || ''),
+        });
+        if (init?.method === 'GET') {
+          return Response.json({
+            url: 'https://peer.example.com/a2a',
+            capabilities: [],
+            hybridclaw: {
+              instanceId: 'peer-prod',
+              publicKeyJwk: peerKey,
+            },
+          });
+        }
+        return Response.json({ jsonrpc: '2.0', result: { ok: true } });
+      },
+    );
+
+    runtime.sendMessage(sampleA2AEnvelope('msg-resolved-peer'), {
+      peerDescriptor: {
+        transport: 'a2a',
+        canonicalId: 'remote@team@peer-instance',
+      },
+      transportRegistry: registry,
+    });
+
+    await expect(
+      a2a.processA2AOutbox({ fetchImpl, identityResolver: resolver }),
+    ).resolves.toMatchObject({
+      processed: 1,
+      delivered: 1,
+    });
+
+    expect(requests[0]).toMatchObject({
+      url: 'https://peer.example.com/.well-known/agent.json',
+      method: 'GET',
+      authorization: expect.stringMatching(/^Bearer [A-Za-z0-9_-]+\./),
+    });
+    expect(requests[1]).toMatchObject({
+      url: 'https://peer.example.com/a2a',
+      method: 'POST',
+      authorization: expect.stringMatching(/^Bearer [A-Za-z0-9_-]+\./),
+    });
+    expect(trust.getA2ATrustedPublicKeyPeer('peer-prod')).toMatchObject({
+      publicKeyFingerprint: trust.fingerprintA2APublicKey(peerKey),
+      status: 'trusted',
+    });
+  });
+
+  test('uses the default A2A resolver for trusted canonical peers', async () => {
+    const { initDatabase } = await import('../src/memory/db.ts');
+    const runtime = await import('../src/a2a/runtime.ts');
+    const transport = await import('../src/a2a/transport-registry.ts');
+    const a2a = await import('../src/a2a/a2a-outbound.ts');
+    const trust = await import('../src/a2a/trust-ledger.ts');
+
+    initDatabase({ quiet: true });
+    const registry = new transport.TransportRegistry();
+    registry.register(new a2a.A2AOutboundAdapter());
+    const peerKey = publicKeyJwk();
+    trust.upsertA2ATrustedPublicKeyPeer({
+      peerId: 'peer-instance',
+      agentCardUrl: 'https://peer.example.com/.well-known/agent.json',
+      deliveryUrl: 'https://peer.example.com/a2a',
+      publicKeyJwk: peerKey,
+    });
+    const requests: Array<{ url: string; method: string }> = [];
+    const fetchImpl = vi.fn(
+      async (url: RequestInfo | URL, init?: RequestInit) => {
+        requests.push({
+          url: String(url),
+          method: init?.method || 'GET',
+        });
+        if (init?.method === 'GET') {
+          return Response.json({
+            url: 'https://peer.example.com/a2a',
+            capabilities: [],
+            hybridclaw: {
+              instanceId: 'peer-instance',
+              publicKeyJwk: peerKey,
+            },
+          });
+        }
+        return Response.json({ jsonrpc: '2.0', result: { ok: true } });
+      },
+    );
+
+    runtime.sendMessage(sampleA2AEnvelope('msg-default-resolver'), {
+      peerDescriptor: {
+        transport: 'a2a',
+        canonicalId: 'remote@team@peer-instance',
+      },
+      transportRegistry: registry,
+    });
+
+    await expect(a2a.processA2AOutbox({ fetchImpl })).resolves.toMatchObject({
+      processed: 1,
+      delivered: 1,
+    });
+    expect(requests).toEqual([
+      {
+        url: 'https://peer.example.com/.well-known/agent.json',
+        method: 'GET',
+      },
+      {
+        url: 'https://peer.example.com/a2a',
+        method: 'POST',
+      },
+    ]);
+  });
+
+  test('records resolved canonical peer destinations on retry audits', async () => {
+    const { getRecentStructuredAuditForSession, initDatabase } = await import(
+      '../src/memory/db.ts'
+    );
+    const runtime = await import('../src/a2a/runtime.ts');
+    const transport = await import('../src/a2a/transport-registry.ts');
+    const a2a = await import('../src/a2a/a2a-outbound.ts');
+
+    initDatabase({ quiet: true });
+    const registry = new transport.TransportRegistry();
+    registry.register(new a2a.A2AOutboundAdapter());
+    const peerKey = publicKeyJwk();
+
+    runtime.sendMessage(sampleA2AEnvelope('msg-resolved-peer-retry'), {
+      peerDescriptor: {
+        transport: 'a2a',
+        canonicalId: 'remote@team@peer-instance',
+      },
+      transportRegistry: registry,
+      sessionId: 'session-resolved-peer-retry',
+    });
+
+    await expect(
+      a2a.processA2AOutbox({
+        identityResolver: {
+          async resolve() {
+            return {
+              url: 'https://peer.example.com',
+              publicKey: JSON.stringify(peerKey),
+            };
+          },
+        },
+        fetchImpl: vi
+          .fn()
+          .mockResolvedValueOnce(
+            Response.json({
+              url: 'https://peer.example.com/a2a',
+              capabilities: [],
+              hybridclaw: {
+                instanceId: 'peer-prod',
+                publicKeyJwk: peerKey,
+              },
+            }),
+          )
+          .mockResolvedValueOnce(new Response('', { status: 503 })),
+        now: () => new Date('2030-01-01T00:00:00.000Z'),
+        jitterRatio: 0,
+      }),
+    ).resolves.toMatchObject({
+      processed: 1,
+      retried: 1,
+    });
+
+    const retryAudit = getRecentStructuredAuditForSession(
+      'session-resolved-peer-retry',
+      5,
+    )
+      .map((event) => JSON.parse(event.payload || '{}'))
+      .find((event) => event.type === 'a2a.outbound.delivery_retry');
+    expect(retryAudit).toMatchObject({
+      agentCardUrl: 'https://peer.example.com/.well-known/agent.json',
+      canonicalId: 'remote@team@peer-instance',
+      statusCode: 503,
+    });
+  });
+
+  test('rejects resolved peers whose Agent Card key does not match discovery', async () => {
+    const { getRecentStructuredAuditForSession, initDatabase } = await import(
+      '../src/memory/db.ts'
+    );
+    const runtime = await import('../src/a2a/runtime.ts');
+    const transport = await import('../src/a2a/transport-registry.ts');
+    const a2a = await import('../src/a2a/a2a-outbound.ts');
+
+    initDatabase({ quiet: true });
+    const registry = new transport.TransportRegistry();
+    registry.register(new a2a.A2AOutboundAdapter());
+    const resolverKey = publicKeyJwk();
+    const cardKey = publicKeyJwk();
+
+    runtime.sendMessage(sampleA2AEnvelope('msg-resolved-peer-mismatch'), {
+      peerDescriptor: {
+        transport: 'a2a',
+        canonicalId: 'remote@team@peer-instance',
+      },
+      transportRegistry: registry,
+      sessionId: 'session-resolved-peer-mismatch',
+    });
+
+    await expect(
+      a2a.processA2AOutbox({
+        identityResolver: {
+          async resolve() {
+            return {
+              url: 'https://peer.example.com',
+              publicKey: JSON.stringify(resolverKey),
+            };
+          },
+        },
+        fetchImpl: vi.fn().mockResolvedValue(
+          Response.json({
+            url: 'https://peer.example.com/a2a',
+            capabilities: [],
+            hybridclaw: {
+              instanceId: 'peer-prod',
+              publicKeyJwk: cardKey,
+            },
+          }),
+        ),
+      }),
+    ).resolves.toMatchObject({
+      processed: 1,
+      failed: 1,
+    });
+    expect(a2a.listA2AOutboxItems()[0]).toMatchObject({
+      status: 'failed',
+      lastError:
+        'A2A identity discovery public key mismatch for remote@team@peer-instance',
+    });
+    const failureAudit = getRecentStructuredAuditForSession(
+      'session-resolved-peer-mismatch',
+      5,
+    )
+      .map((event) => JSON.parse(event.payload || '{}'))
+      .find((event) => event.type === 'a2a.outbound.delivery_failed');
+    expect(failureAudit).toMatchObject({
+      agentCardUrl: 'https://peer.example.com/.well-known/agent.json',
+      canonicalId: 'remote@team@peer-instance',
+    });
+  });
+
+  test('rejects malformed resolved public key fingerprints before mismatch checks', async () => {
+    const { initDatabase } = await import('../src/memory/db.ts');
+    const runtime = await import('../src/a2a/runtime.ts');
+    const transport = await import('../src/a2a/transport-registry.ts');
+    const a2a = await import('../src/a2a/a2a-outbound.ts');
+
+    initDatabase({ quiet: true });
+    const registry = new transport.TransportRegistry();
+    registry.register(new a2a.A2AOutboundAdapter());
+    const cardKey = publicKeyJwk();
+
+    runtime.sendMessage(sampleA2AEnvelope('msg-resolved-peer-bad-key'), {
+      peerDescriptor: {
+        transport: 'a2a',
+        canonicalId: 'remote@team@peer-instance',
+      },
+      transportRegistry: registry,
+    });
+
+    await expect(
+      a2a.processA2AOutbox({
+        identityResolver: {
+          async resolve() {
+            return {
+              url: 'https://peer.example.com',
+              publicKey: 'not-a-valid-fingerprint',
+            };
+          },
+        },
+        fetchImpl: vi.fn().mockResolvedValue(
+          Response.json({
+            url: 'https://peer.example.com/a2a',
+            capabilities: [],
+            hybridclaw: {
+              instanceId: 'peer-prod',
+              publicKeyJwk: cardKey,
+            },
+          }),
+        ),
+      }),
+    ).resolves.toMatchObject({
+      processed: 1,
+      failed: 1,
+    });
+    expect(a2a.listA2AOutboxItems()[0]).toMatchObject({
+      status: 'failed',
+      lastError: expect.stringContaining('unsupported public key format'),
+    });
+  });
+
   test('fails and audits when a TOFU peer key changes', async () => {
     const { initDatabase, getRecentStructuredAuditForSession } = await import(
       '../src/memory/db.ts'

--- a/tests/a2a-transport-registry.test.ts
+++ b/tests/a2a-transport-registry.test.ts
@@ -158,6 +158,16 @@ describe('A2A transport adapter registry', () => {
     expect(
       normalizePeerDescriptor({
         transport: 'a2a',
+        canonical_id: 'Remote@Team@Peer-Instance',
+      }),
+    ).toEqual({
+      transport: 'a2a',
+      canonicalId: 'remote@team@peer-instance',
+      expectPublicKey: true,
+    });
+    expect(
+      normalizePeerDescriptor({
+        transport: 'a2a',
         url: 'https://peer.example.com/a2a',
         bearerTokenRef: { source: 'store', id: 'A2A_PEER_TOKEN' },
       }),


### PR DESCRIPTION
Closes #482.

## Summary
- Add canonical A2A peer descriptors and persisted outbox canonical IDs.
- Resolve canonical A2A destinations through local deployment/tunnel URLs, trusted peer records, or DNS identity discovery.
- Pin resolved peer public keys against the fetched Agent Card before outbound delivery.
- Add end-to-end HTTP coverage for instance A sending to instance B and B replying.

## Validation
- `npx vitest run tests/a2a-webhook-outbound.test.ts tests/a2a-webhook-outbound.integration.test.ts tests/a2a-envelope.test.ts tests/gateway-service.a2a-inbox.test.ts tests/a2a-retry-policy.test.ts tests/a2a-outbound.test.ts tests/a2a-identity-resolver.test.ts tests/a2a-transport-registry.test.ts tests/a2a-runtime.integration.test.ts tests/a2a-webhook-inbound.test.ts tests/a2a-trust-ledger.test.ts tests/a2a-inbound.test.ts tests/a2a-outbound.integration.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run check`
- `git diff --check`