### PR TITLE
Fix cross-instance routing in sendMessage

### DIFF
--- a/docs/content/developer-guide/identity.md
+++ b/docs/content/developer-guide/identity.md
@@ -154,3 +154,11 @@ TXT record values are JSON objects:
 concurrent cold-cache lookups, caches successful records for five minutes by
 default, and supports explicit invalidation. Discovery URLs must use HTTPS
 unless they target loopback.
+
+The A2A outbound outbox uses this resolver automatically when
+`HYBRIDCLAW_IDENTITY_DISCOVERY_ZONE` is set. Remote `sendMessage` recipients are
+queued first, then the outbox resolves the recipient's canonical ID under that
+zone before dispatching through the A2A HTTP transport. The synchronous
+`sendMessage` confirmation reports `pending` for durable queued delivery and
+`false` only when dispatch is refused before an outbox item exists; later
+outbox failures are audited and routed through interactive escalation.

--- a/scripts/audit-signatures.mjs
+++ b/scripts/audit-signatures.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 import { spawnSync } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
 
 const BAILEYS_RC11_MIN_RELEASE_AGE_EXPIRES_AT = Date.parse(
   '2026-05-20T08:35:12.000Z',
@@ -15,24 +17,29 @@ const retryDelayMs = Number.parseInt(
   10,
 );
 
-const baseArgs = [];
+const auditPolicyArgs = [];
 
 // Baileys 7.0.0-rc11 was published on 2026-05-13T08:35:11Z. Until npm's
 // seven-day age gate expires, signature audit needs the same resolver bypass
 // as install-time CI. After that date, use the repo-wide .npmrc policy again.
 if (Date.now() < BAILEYS_RC11_MIN_RELEASE_AGE_EXPIRES_AT) {
-  baseArgs.push('--min-release-age=0');
+  auditPolicyArgs.push('--min-release-age=0');
 }
 
-const audits = [
-  { label: 'root', args: [...baseArgs, 'audit', 'signatures'] },
+const targets = [
+  {
+    label: 'root',
+    args: [...auditPolicyArgs, 'audit', 'signatures'],
+  },
   {
     label: 'container',
-    args: ['--prefix', 'container', ...baseArgs, 'audit', 'signatures'],
+    args: ['--prefix', 'container', ...auditPolicyArgs, 'audit', 'signatures'],
   },
 ];
 
 const transientPatterns = [
+  /E404[\s\S]*\/-\/npm\/v1\/attestations\//u,
+  /E5\d\d/u,
   'ECONNRESET',
   'ECONNREFUSED',
   'ETIMEDOUT',
@@ -42,28 +49,37 @@ const transientPatterns = [
   'aborted',
   'Invalid response body',
   'network connectivity',
+  'socket hang up',
 ];
+
+function auditCacheDir(label) {
+  return path.join(os.tmpdir(), `hybridclaw-npm-cache-${label}`);
+}
 
 function sleep(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
 function isTransientFailure(output) {
-  return transientPatterns.some((pattern) => output.includes(pattern));
+  return transientPatterns.some((pattern) =>
+    typeof pattern === 'string'
+      ? output.includes(pattern)
+      : pattern.test(output),
+  );
 }
 
-function runAudit(audit) {
+function runAudit(target) {
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     console.error(
-      `Running npm registry signature audit for ${audit.label} (${attempt}/${maxAttempts})`,
+      `Running npm registry signature audit for ${target.label} (${attempt}/${maxAttempts})`,
     );
 
-    const result = spawnSync('npm', audit.args, {
+    const result = spawnSync('npm', target.args, {
       encoding: 'utf8',
       env: {
         ...process.env,
         NPM_CONFIG_CACHE:
-          process.env.NPM_CONFIG_CACHE || '/tmp/hybridclaw-npm-cache',
+          process.env.NPM_CONFIG_CACHE || auditCacheDir(target.label),
       },
     });
 
@@ -85,7 +101,7 @@ function runAudit(audit) {
     }
 
     console.error(
-      `npm registry signature audit for ${audit.label} failed with a transient network error; retrying in ${retryDelayMs}ms.`,
+      `npm registry signature audit for ${target.label} failed with a transient network error; retrying in ${retryDelayMs}ms.`,
     );
     sleep(retryDelayMs);
   }
@@ -93,8 +109,8 @@ function runAudit(audit) {
   return 1;
 }
 
-for (const audit of audits) {
-  const status = runAudit(audit);
+for (const target of targets) {
+  const status = runAudit(target);
   if (status !== 0) {
     process.exit(status);
   }

--- a/src/a2a/a2a-outbound.ts
+++ b/src/a2a/a2a-outbound.ts
@@ -26,6 +26,7 @@ export {
   type A2AOutboundStatus,
   type A2AOutboxItem,
   enqueueA2AEnvelope,
+  enqueueUnresolvedA2AEnvelope,
   listA2AOutboxItems,
 } from './a2a-outbox-persistence.js';
 export {

--- a/src/a2a/a2a-outbox-delivery.ts
+++ b/src/a2a/a2a-outbox-delivery.ts
@@ -1,8 +1,14 @@
+import type { JsonWebKey } from 'node:crypto';
+
 import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
 import {
   createSuspendedSession,
   emitInteractionNeededEvent,
 } from '../gateway/interactive-escalation.js';
+import {
+  IdentityNotFoundError,
+  type IdentityResolution,
+} from '../identity/resolver.js';
 import { resolveSecretHandleInput } from '../security/secret-refs.js';
 import {
   A2AFailFastError,
@@ -22,10 +28,12 @@ import {
 import { getA2AAuditSessionId, recordA2AMessageAudit } from './audit.js';
 import { signA2ADelegationToken } from './delegation-token.js';
 import { summarizeA2AEnvelopeForAudit } from './envelope.js';
+import { normalizePeerDescriptor } from './peer-descriptor.js';
 import {
   type A2APeerPublicKeyMaterial,
   assertA2APeerPublicKeyTrust,
   extractA2APeerPublicKey,
+  fingerprintA2APublicKey,
 } from './trust-ledger.js';
 import {
   isA2AAllowedHttpUrl,
@@ -43,6 +51,10 @@ export const A2A_TASK_SEND_SCOPE = 'a2a:task:send';
 export interface A2AOutboxProcessOptions {
   /** Test hook for deterministic delivery without making live network calls. */
   fetchImpl?: typeof fetch;
+  /** Resolves canonical remote recipients that were queued without a peer descriptor. */
+  identityResolver?: {
+    resolve(canonicalId: string): Promise<IdentityResolution>;
+  };
   /** Test hook for deterministic retry/audit timestamps. */
   now?: () => Date;
   /** Test hook for deterministic retry jitter. */
@@ -175,7 +187,7 @@ function createA2AEscalation(item: A2AOutboxItem, reason: string): void {
     approvalId,
     prompt: [
       'A2A outbound delivery failed.',
-      `Agent Card: ${item.agentCardUrl}`,
+      `Agent Card: ${item.agentCardUrl || '<unresolved>'}`,
       `Message: ${item.envelope.id}`,
       `Reason: ${reason}`,
       'Reply `approved` after fixing the peer, or `declined` to cancel this delivery.',
@@ -221,7 +233,7 @@ function failA2AItem(
     statusCode: details.statusCode ?? null,
     jsonRpcCode: details.jsonRpcCode ?? null,
     envelope: summarizeA2AEnvelopeForAudit(failed.envelope),
-    agentCardUrl: failed.agentCardUrl,
+    agentCardUrl: failed.agentCardUrl ?? null,
   });
   recordA2AAudit(failed, {
     type: 'escalation.decision',
@@ -300,9 +312,124 @@ function retryA2AItem(
     statusCode: details.statusCode ?? null,
     jsonRpcCode: details.jsonRpcCode ?? null,
     envelope: summarizeA2AEnvelopeForAudit(retry.envelope),
-    agentCardUrl: retry.agentCardUrl,
+    agentCardUrl: retry.agentCardUrl ?? null,
   });
   return retry;
+}
+
+function retryOrFailA2AItem(
+  item: A2AOutboxItem,
+  now: Date,
+  attemptNumber: number,
+  maxAttempts: number,
+  reason: string,
+  options: Required<
+    Pick<
+      A2AOutboxProcessOptions,
+      'baseDelayMs' | 'maxDelayMs' | 'jitterRatio' | 'random'
+    >
+  >,
+  details: { statusCode?: number; jsonRpcCode?: number } = {},
+): 'retried' | 'failed' {
+  if (attemptNumber >= maxAttempts) {
+    failA2AItem(item, now, reason, details);
+    return 'failed';
+  }
+  retryA2AItem(item, now, reason, options, details);
+  return 'retried';
+}
+
+async function resolveA2AItemDeliveryTarget(
+  item: A2AOutboxItem,
+  opts: A2AOutboxProcessOptions,
+  now: Date,
+): Promise<A2AOutboxItem> {
+  if (item.agentCardUrl) return item;
+
+  const canonicalId = item.identityResolution?.canonicalId;
+  if (!canonicalId) {
+    throw new Error('A2A outbox item is missing an Agent Card URL');
+  }
+  if (!opts.identityResolver) {
+    throw new Error(
+      `A2A identity resolver is required for remote recipient ${canonicalId}`,
+    );
+  }
+
+  const resolution = await opts.identityResolver.resolve(canonicalId);
+  const descriptor = normalizePeerDescriptor({
+    transport: 'a2a',
+    url: resolution.url,
+    expectPublicKey: true,
+  });
+  if (descriptor.transport !== 'a2a' || !('agentCardUrl' in descriptor)) {
+    throw new Error('identity resolver did not produce an A2A peer descriptor');
+  }
+
+  const resolved: A2AOutboxItem = {
+    ...item,
+    agentCardUrl: descriptor.agentCardUrl,
+    identityResolution: {
+      status: 'resolved',
+      canonicalId,
+      url: resolution.url,
+      publicKey: resolution.publicKey,
+      resolvedAt: nowIso(now),
+    },
+    updatedAt: nowIso(now),
+  };
+  persistA2AOutboxItem(resolved);
+  recordA2AAudit(resolved, {
+    type: 'a2a.outbound.identity_resolved',
+    canonicalId,
+    url: resolution.url,
+    publicKey: resolution.publicKey,
+    envelope: summarizeA2AEnvelopeForAudit(resolved.envelope),
+    agentCardUrl: resolved.agentCardUrl,
+  });
+  return resolved;
+}
+
+function discoveryPublicKeyFingerprint(publicKey: string): string | null {
+  const normalized = publicKey.trim();
+  if (/^[A-Za-z0-9_-]{43}$/.test(normalized)) return normalized;
+  try {
+    const parsed = JSON.parse(normalized) as JsonWebKey;
+    if (
+      parsed.kty !== 'OKP' ||
+      parsed.crv !== 'Ed25519' ||
+      typeof parsed.x !== 'string'
+    ) {
+      return null;
+    }
+    return fingerprintA2APublicKey(parsed);
+  } catch {
+    return null;
+  }
+}
+
+function assertDiscoveryPublicKeyMatchesCard(
+  item: A2AOutboxItem,
+  peerKey: A2APeerPublicKeyMaterial | undefined,
+): void {
+  const identityResolution = item.identityResolution;
+  if (identityResolution?.status !== 'resolved') return;
+  const expected = discoveryPublicKeyFingerprint(identityResolution.publicKey);
+  if (!expected) {
+    throw new Error(
+      `identity discovery returned an unsupported public key format for ${identityResolution.canonicalId}`,
+    );
+  }
+  if (!peerKey) {
+    throw new Error(
+      'identity discovery returned a public key but the Agent Card did not advertise one',
+    );
+  }
+  if (peerKey.publicKeyFingerprint !== expected) {
+    throw new Error(
+      `A2A identity discovery public key mismatch for ${identityResolution.canonicalId}`,
+    );
+  }
 }
 
 async function readJsonRpcResponse(response: Response): Promise<unknown> {
@@ -341,75 +468,79 @@ export async function deliverA2AItem(
   );
   const retryOptions = normalizeRetryOptions(opts);
 
+  let deliveryItem = item;
   let card: A2AAgentCard;
   try {
+    deliveryItem = await resolveA2AItemDeliveryTarget(item, opts, now);
+    if (!deliveryItem.agentCardUrl) {
+      throw new Error('A2A outbox item is missing an Agent Card URL');
+    }
     card = await fetchA2AAgentCard({
-      agentCardUrl: item.agentCardUrl,
+      agentCardUrl: deliveryItem.agentCardUrl,
       fetchImpl: opts.fetchImpl,
       now,
       headers: authHeaders({
-        item,
-        audience: item.agentCardUrl,
+        item: deliveryItem,
+        audience: deliveryItem.agentCardUrl,
         scope: A2A_AGENT_CARD_READ_SCOPE,
         now,
         requireBearer: false,
       }),
-      authCacheKey: agentCardAuthCacheKey(item),
+      authCacheKey: agentCardAuthCacheKey(deliveryItem),
       agentCardCacheTtlMs: opts.agentCardCacheTtlMs,
     });
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     const statusCode =
       error instanceof A2AHttpError ? error.statusCode : undefined;
-    if (error instanceof A2AFailFastError) {
-      failA2AItem(item, now, reason);
+    if (
+      error instanceof A2AFailFastError ||
+      error instanceof IdentityNotFoundError
+    ) {
+      failA2AItem(deliveryItem, now, reason);
       return 'failed';
     }
     const httpDecision = statusCode
       ? classifyA2AHttpStatus(statusCode)
       : 'retry';
     if (httpDecision === 'fail-fast') {
-      failA2AItem(item, now, reason, { statusCode });
+      failA2AItem(deliveryItem, now, reason, { statusCode });
       return 'failed';
     }
-    if (httpDecision === 'retry') {
-      if (attemptNumber >= maxAttempts) {
-        failA2AItem(item, now, reason, { statusCode });
-        return 'failed';
-      }
-      retryA2AItem(item, now, reason, retryOptions, { statusCode });
-      return 'retried';
-    }
-    if (attemptNumber >= maxAttempts) {
-      failA2AItem(item, now, reason, { statusCode });
-      return 'failed';
-    }
-    retryA2AItem(item, now, reason, retryOptions, { statusCode });
-    return 'retried';
+    return retryOrFailA2AItem(
+      deliveryItem,
+      now,
+      attemptNumber,
+      maxAttempts,
+      reason,
+      retryOptions,
+      { statusCode },
+    );
   }
 
   let peerKey: A2APeerPublicKeyMaterial | undefined;
   try {
     peerKey = extractA2APeerPublicKey(card) ?? undefined;
+    assertDiscoveryPublicKeyMatchesCard(deliveryItem, peerKey);
     if (peerKey) {
       assertA2APeerPublicKeyTrust({
-        agentCardUrl: item.agentCardUrl,
+        agentCardUrl: deliveryItem.agentCardUrl,
         deliveryUrl: card.url,
         key: peerKey,
-        runId: resolveItemRunId(item, 'a2a-trust'),
+        runId: resolveItemRunId(deliveryItem, 'a2a-trust'),
         now,
       });
     }
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
-    failA2AItem(item, now, reason);
+    failA2AItem(deliveryItem, now, reason);
     return 'failed';
   }
 
-  const request = encodeA2AJsonRpcRequest(item.envelope, card);
+  const request = encodeA2AJsonRpcRequest(deliveryItem.envelope, card);
   if (!isA2AAllowedHttpUrl(card.url)) {
     failA2AItem(
-      item,
+      deliveryItem,
       now,
       'Agent Card url must use https unless targeting loopback',
     );
@@ -423,7 +554,7 @@ export async function deliverA2AItem(
       headers: {
         'content-type': 'application/json',
         ...authHeaders({
-          item,
+          item: deliveryItem,
           audience: card.url,
           scope:
             request.method === 'tasks/send'
@@ -440,35 +571,36 @@ export async function deliverA2AItem(
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     if (error instanceof A2AFailFastError) {
-      failA2AItem(item, now, reason);
+      failA2AItem(deliveryItem, now, reason);
       return 'failed';
     }
-    if (attemptNumber >= maxAttempts) {
-      failA2AItem(item, now, reason);
-      return 'failed';
-    }
-    retryA2AItem(item, now, reason, retryOptions);
-    return 'retried';
+    return retryOrFailA2AItem(
+      deliveryItem,
+      now,
+      attemptNumber,
+      maxAttempts,
+      reason,
+      retryOptions,
+    );
   }
 
   const httpDecision = classifyA2AHttpStatus(response.status);
   if (httpDecision === 'fail-fast') {
-    failA2AItem(item, now, `HTTP ${response.status}`, {
+    failA2AItem(deliveryItem, now, `HTTP ${response.status}`, {
       statusCode: response.status,
     });
     return 'failed';
   }
   if (httpDecision === 'retry') {
-    if (attemptNumber >= maxAttempts) {
-      failA2AItem(item, now, `HTTP ${response.status}`, {
-        statusCode: response.status,
-      });
-      return 'failed';
-    }
-    retryA2AItem(item, now, `HTTP ${response.status}`, retryOptions, {
-      statusCode: response.status,
-    });
-    return 'retried';
+    return retryOrFailA2AItem(
+      deliveryItem,
+      now,
+      attemptNumber,
+      maxAttempts,
+      `HTTP ${response.status}`,
+      retryOptions,
+      { statusCode: response.status },
+    );
   }
 
   let jsonRpcResponse: unknown;
@@ -479,7 +611,7 @@ export async function deliverA2AItem(
     }
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
-    failA2AItem(item, now, reason, { statusCode: response.status });
+    failA2AItem(deliveryItem, now, reason, { statusCode: response.status });
     return 'failed';
   }
 
@@ -491,20 +623,20 @@ export async function deliverA2AItem(
         : 'JSON-RPC error';
     const reason = `JSON-RPC ${Number.isFinite(code) ? code : 'error'}: ${message}`;
     if (Number.isFinite(code) && shouldRetryA2AJsonRpcErrorCode(code)) {
-      if (attemptNumber >= maxAttempts) {
-        failA2AItem(item, now, reason, {
+      return retryOrFailA2AItem(
+        deliveryItem,
+        now,
+        attemptNumber,
+        maxAttempts,
+        reason,
+        retryOptions,
+        {
           statusCode: response.status,
           jsonRpcCode: code,
-        });
-        return 'failed';
-      }
-      retryA2AItem(item, now, reason, retryOptions, {
-        statusCode: response.status,
-        jsonRpcCode: code,
-      });
-      return 'retried';
+        },
+      );
     }
-    failA2AItem(item, now, reason, {
+    failA2AItem(deliveryItem, now, reason, {
       statusCode: response.status,
       ...(Number.isFinite(code) ? { jsonRpcCode: code } : {}),
     });
@@ -512,7 +644,7 @@ export async function deliverA2AItem(
   }
 
   const delivered: A2AOutboxItem = {
-    ...item,
+    ...deliveryItem,
     status: 'delivered',
     attempts: attemptNumber,
     updatedAt: nowIso(now),
@@ -539,7 +671,7 @@ export async function deliverA2AItem(
     attempts: attemptNumber,
     method: request.method,
     envelope: summarizeA2AEnvelopeForAudit(delivered.envelope),
-    agentCardUrl: delivered.agentCardUrl,
+    agentCardUrl: delivered.agentCardUrl ?? null,
   });
   return 'delivered';
 }

--- a/src/a2a/a2a-outbox-persistence.ts
+++ b/src/a2a/a2a-outbox-persistence.ts
@@ -25,12 +25,26 @@ const A2A_OUTBOX_ASSET_PREFIX = path.join(
 
 export type A2AOutboundStatus = 'pending' | 'delivered' | 'failed';
 
+export type A2AOutboxIdentityResolution =
+  | {
+      status: 'unresolved';
+      canonicalId: string;
+    }
+  | {
+      status: 'resolved';
+      canonicalId: string;
+      url: string;
+      publicKey: string;
+      resolvedAt: string;
+    };
+
 export interface A2AOutboxItem {
   schemaVersion: typeof A2A_OUTBOX_SCHEMA_VERSION;
   id: string;
   status: A2AOutboundStatus;
   envelope: A2AEnvelope;
-  agentCardUrl: string;
+  agentCardUrl?: string;
+  identityResolution?: A2AOutboxIdentityResolution;
   bearerTokenRef?: SecretRef;
   attempts: number;
   maxAttempts: number;
@@ -48,6 +62,10 @@ export interface A2AOutboxItem {
   lastJsonRpcCode?: number;
 }
 
+export interface A2AOutboxListOptions {
+  status?: A2AOutboundStatus | readonly A2AOutboundStatus[];
+}
+
 export interface A2AOutboundAdapterOptions {
   maxAttempts?: number;
 }
@@ -58,6 +76,53 @@ export function nowIso(now: Date): string {
 
 function outboxAssetPath(id: string): string {
   return path.join(A2A_OUTBOX_ASSET_PREFIX, `${id}.json`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeIdentityResolution(
+  value: unknown,
+): A2AOutboxIdentityResolution | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value) || typeof value.canonicalId !== 'string') {
+    throw new Error('identityResolution must include canonicalId');
+  }
+  const canonicalId = value.canonicalId.trim();
+  if (!canonicalId) {
+    throw new Error('identityResolution canonicalId is required');
+  }
+  if (value.status === 'resolved') {
+    if (
+      typeof value.url !== 'string' ||
+      typeof value.publicKey !== 'string' ||
+      typeof value.resolvedAt !== 'string'
+    ) {
+      throw new Error(
+        'resolved identityResolution must include url, publicKey, and resolvedAt',
+      );
+    }
+    return {
+      status: 'resolved',
+      canonicalId,
+      url: value.url,
+      publicKey: value.publicKey,
+      resolvedAt: value.resolvedAt,
+    };
+  }
+  if (value.status === 'unresolved') {
+    return { status: 'unresolved', canonicalId };
+  }
+  if (
+    value.status === undefined &&
+    typeof value.url !== 'string' &&
+    typeof value.publicKey !== 'string' &&
+    typeof value.resolvedAt !== 'string'
+  ) {
+    return { status: 'unresolved', canonicalId };
+  }
+  throw new Error('identityResolution status must be unresolved or resolved');
 }
 
 function parseOutboxItem(raw: string, assetPath: string): A2AOutboxItem | null {
@@ -72,7 +137,13 @@ function parseOutboxItem(raw: string, assetPath: string): A2AOutboxItem | null {
     ) {
       return null;
     }
-    return parsed;
+    const identityResolution = normalizeIdentityResolution(
+      parsed.identityResolution,
+    );
+    return {
+      ...parsed,
+      ...(identityResolution ? { identityResolution } : {}),
+    };
   } catch (error) {
     logger.warn(
       { assetPath, err: error },
@@ -80,6 +151,15 @@ function parseOutboxItem(raw: string, assetPath: string): A2AOutboxItem | null {
     );
     return null;
   }
+}
+
+function matchesOutboxListStatus(
+  item: A2AOutboxItem,
+  status: A2AOutboxListOptions['status'],
+): boolean {
+  if (!status) return true;
+  if (Array.isArray(status)) return status.includes(item.status);
+  return item.status === status;
 }
 
 export function persistA2AOutboxItem(item: A2AOutboxItem): void {
@@ -97,12 +177,17 @@ export function persistA2AOutboxItem(item: A2AOutboxItem): void {
   );
 }
 
-export function listA2AOutboxItems(): A2AOutboxItem[] {
+export function listA2AOutboxItems(
+  options: A2AOutboxListOptions = {},
+): A2AOutboxItem[] {
   return listRuntimeAssetRevisionStates('a2a', {
     assetPathPrefix: A2A_OUTBOX_ASSET_PREFIX,
   })
     .map((state) => parseOutboxItem(state.content, state.assetPath))
-    .filter((item): item is A2AOutboxItem => item !== null)
+    .filter(
+      (item): item is A2AOutboxItem =>
+        item !== null && matchesOutboxListStatus(item, options.status),
+    )
     .sort((left, right) => {
       const nextAttemptOrder = left.nextAttemptAt.localeCompare(
         right.nextAttemptAt,
@@ -114,9 +199,12 @@ export function listA2AOutboxItems(): A2AOutboxItem[] {
 
 function makeOutboxItem(
   envelope: A2AEnvelope,
-  descriptor: A2APeerDescriptor,
+  descriptor: Partial<
+    Pick<A2APeerDescriptor, 'agentCardUrl' | 'bearerTokenRef'>
+  >,
   context?: TransportAdapterContext,
   opts?: A2AOutboundAdapterOptions,
+  identityResolution?: A2AOutboxItem['identityResolution'],
 ): A2AOutboxItem {
   const createdAt = new Date();
   const createdAtIso = nowIso(createdAt);
@@ -125,7 +213,10 @@ function makeOutboxItem(
     id: randomUUID(),
     status: 'pending',
     envelope: validateA2AEnvelope(envelope),
-    agentCardUrl: descriptor.agentCardUrl,
+    ...(descriptor.agentCardUrl
+      ? { agentCardUrl: descriptor.agentCardUrl }
+      : {}),
+    ...(identityResolution ? { identityResolution } : {}),
     bearerTokenRef: descriptor.bearerTokenRef,
     attempts: 0,
     maxAttempts: normalizePositiveInteger(
@@ -148,6 +239,20 @@ export function enqueueA2AEnvelope(
   opts?: A2AOutboundAdapterOptions,
 ): A2AOutboxItem {
   const item = makeOutboxItem(envelope, descriptor, context, opts);
+  persistA2AOutboxItem(item);
+  return item;
+}
+
+export function enqueueUnresolvedA2AEnvelope(
+  envelope: A2AEnvelope,
+  recipientAgentId: string,
+  context?: TransportAdapterContext,
+  opts?: A2AOutboundAdapterOptions,
+): A2AOutboxItem {
+  const item = makeOutboxItem(envelope, {}, context, opts, {
+    status: 'unresolved',
+    canonicalId: recipientAgentId,
+  });
   persistA2AOutboxItem(item);
   return item;
 }

--- a/src/a2a/a2a-outbox-processor.ts
+++ b/src/a2a/a2a-outbox-processor.ts
@@ -1,3 +1,4 @@
+import { getDefaultIdentityResolver } from '../identity/resolver.js';
 import { logger } from '../logger.js';
 import {
   type A2AOutboxProcessOptions,
@@ -23,14 +24,17 @@ export async function processA2AOutbox(
   opts: A2AOutboxProcessOptions = {},
 ): Promise<A2AOutboxProcessResult> {
   const now = opts.now?.() ?? new Date();
+  const deliveryOptions: A2AOutboxProcessOptions = {
+    ...opts,
+    identityResolver:
+      opts.identityResolver ?? getDefaultIdentityResolver() ?? undefined,
+  };
   const concurrency = normalizePositiveInteger(
     opts.concurrency,
     A2A_OUTBOX_CONCURRENCY,
   );
-  const due = listA2AOutboxItems().filter(
-    (item) =>
-      item.status === 'pending' &&
-      Date.parse(item.nextAttemptAt) <= now.getTime(),
+  const due = listA2AOutboxItems({ status: 'pending' }).filter(
+    (item) => Date.parse(item.nextAttemptAt) <= now.getTime(),
   );
   const result: A2AOutboxProcessResult = {
     processed: 0,
@@ -43,7 +47,7 @@ export async function processA2AOutbox(
     const batch = due.slice(index, index + concurrency);
     result.processed += batch.length;
     const outcomes = await Promise.allSettled(
-      batch.map((item) => deliverA2AItem(item, opts)),
+      batch.map((item) => deliverA2AItem(item, deliveryOptions)),
     );
     for (const outcome of outcomes) {
       if (outcome.status === 'fulfilled') {

--- a/src/a2a/runtime.ts
+++ b/src/a2a/runtime.ts
@@ -1,4 +1,11 @@
+import {
+  parseAgentIdentity,
+  resolveLocalInstanceId,
+} from '../identity/agent-id.js';
+import { IDENTITY_DISCOVERY_ZONE_ENV } from '../identity/resolver.js';
+import { logger } from '../logger.js';
 import type { EscalationTarget } from '../types/execution.js';
+import { enqueueUnresolvedA2AEnvelope } from './a2a-outbound.js';
 import { recordA2AMessageAudit } from './audit.js';
 import {
   type A2AEnvelope,
@@ -6,20 +13,38 @@ import {
   validateA2AEnvelope,
 } from './envelope.js';
 import { attachA2AHandoffContext } from './handoff-context.js';
+import { resolveA2AEnvelopeAgentIds } from './identity.js';
 import { normalizePeerDescriptor } from './peer-descriptor.js';
 import { listA2AInboxEnvelopes, saveA2AEnvelope } from './store.js';
 import {
   encodeForRegisteredTransport,
   type TransportRegistry,
+  TransportRegistryError,
 } from './transport-registry.js';
 
 // Public server-side A2A runtime API required by roadmap #425.
-export interface A2ADeliveryConfirmation {
-  delivered: true;
-  message_id: string;
-  thread_id: string;
-  recipient_agent_id: string;
-}
+// `false` is reserved for synchronous dispatch refusal before a durable outbox
+// item exists; later outbox failures are audited and escalated asynchronously.
+export type A2ADeliveryConfirmation =
+  | {
+      delivered: true;
+      message_id: string;
+      thread_id: string;
+      recipient_agent_id: string;
+    }
+  | {
+      delivered: 'pending';
+      message_id: string;
+      thread_id: string;
+      recipient_agent_id: string;
+    }
+  | {
+      delivered: false;
+      message_id: string;
+      thread_id: string;
+      recipient_agent_id: string;
+      failure_reason: string;
+    };
 
 export interface A2ASendMessageMeta {
   actor?: string;
@@ -31,8 +56,79 @@ export interface A2ASendMessageMeta {
   escalationTarget?: EscalationTarget;
 }
 
-function validateRuntimeEnvelope(envelope: unknown): A2AEnvelope {
-  return validateA2AEnvelope(envelope);
+let warnedMissingIdentityDiscoveryZone = false;
+
+function deliveryConfirmation(
+  delivered: true | 'pending',
+  envelope: A2AEnvelope,
+): A2ADeliveryConfirmation {
+  return {
+    delivered,
+    message_id: envelope.id,
+    thread_id: envelope.thread_id,
+    recipient_agent_id: envelope.recipient_agent_id,
+  };
+}
+
+function failedDeliveryConfirmation(
+  envelope: A2AEnvelope,
+  reason: string,
+): A2ADeliveryConfirmation {
+  return {
+    delivered: false,
+    message_id: envelope.id,
+    thread_id: envelope.thread_id,
+    recipient_agent_id: envelope.recipient_agent_id,
+    failure_reason: reason,
+  };
+}
+
+function warnIfIdentityDiscoveryDisabled(recipientAgentId: string): void {
+  if (process.env[IDENTITY_DISCOVERY_ZONE_ENV]?.trim()) return;
+  if (warnedMissingIdentityDiscoveryZone) return;
+  warnedMissingIdentityDiscoveryZone = true;
+  logger.warn(
+    {
+      recipientAgentId,
+      env: IDENTITY_DISCOVERY_ZONE_ENV,
+    },
+    'A2A remote send queued without identity discovery configured',
+  );
+}
+
+function recordSendAudits(params: {
+  envelope: A2AEnvelope;
+  meta?: A2ASendMessageMeta;
+  transport: string;
+  delivered?: boolean;
+}): void {
+  const auditBase = {
+    envelope: params.envelope,
+    sessionId: params.meta?.sessionId,
+    runId: params.meta?.auditRunId,
+    actor: params.meta?.actor,
+    route: 'a2a.sendMessage',
+    source: 'a2a-runtime',
+    transport: params.transport,
+  };
+  if ((params.meta?.auditRole ?? 'sender') === 'sender') {
+    recordA2AMessageAudit({
+      type: 'a2a.send',
+      ...auditBase,
+    });
+  }
+  if (params.delivered) {
+    recordA2AMessageAudit({
+      type: 'a2a.deliver',
+      ...auditBase,
+    });
+  }
+  if (params.envelope.intent === 'handoff') {
+    recordA2AMessageAudit({
+      type: 'a2a.handoff',
+      ...auditBase,
+    });
+  }
 }
 
 /**
@@ -44,52 +140,67 @@ export function sendMessage(
   meta?: A2ASendMessageMeta,
 ): A2ADeliveryConfirmation {
   const peerDescriptor = normalizePeerDescriptor(meta?.peerDescriptor);
-  const encodedEnvelope = encodeForRegisteredTransport({
-    envelope: attachA2AHandoffContext(validateRuntimeEnvelope(envelope)),
-    peerDescriptor,
-    registry: meta?.transportRegistry,
-    sessionId: meta?.sessionId,
-    runId: meta?.auditRunId,
-    escalationTarget: meta?.escalationTarget,
-  });
-  const deliveredEnvelope = saveA2AEnvelope(encodedEnvelope, {
+  const preparedEnvelope = attachA2AHandoffContext(
+    validateA2AEnvelope(envelope),
+  ) as A2AEnvelope;
+  const normalizedEnvelope = resolveA2AEnvelopeAgentIds(preparedEnvelope);
+
+  if (peerDescriptor.transport !== 'internal') {
+    try {
+      encodeForRegisteredTransport({
+        envelope: preparedEnvelope,
+        peerDescriptor,
+        registry: meta?.transportRegistry,
+        sessionId: meta?.sessionId,
+        runId: meta?.auditRunId,
+        escalationTarget: meta?.escalationTarget,
+      });
+    } catch (error) {
+      if (error instanceof TransportRegistryError) {
+        return failedDeliveryConfirmation(normalizedEnvelope, error.message);
+      }
+      throw error;
+    }
+    recordSendAudits({
+      envelope: preparedEnvelope,
+      meta,
+      transport: peerDescriptor.transport,
+    });
+    return deliveryConfirmation('pending', normalizedEnvelope);
+  }
+
+  const recipient = parseAgentIdentity(normalizedEnvelope.recipient_agent_id);
+  if (recipient.instanceId !== resolveLocalInstanceId()) {
+    warnIfIdentityDiscoveryDisabled(normalizedEnvelope.recipient_agent_id);
+    enqueueUnresolvedA2AEnvelope(
+      normalizedEnvelope,
+      normalizedEnvelope.recipient_agent_id,
+      {
+        sessionId: meta?.sessionId,
+        runId: meta?.auditRunId,
+        escalationTarget: meta?.escalationTarget,
+      },
+    );
+    recordSendAudits({
+      envelope: normalizedEnvelope,
+      meta,
+      transport: 'a2a',
+    });
+    return deliveryConfirmation('pending', normalizedEnvelope);
+  }
+
+  const deliveredEnvelope = saveA2AEnvelope(normalizedEnvelope, {
     actor: meta?.actor,
     route: 'a2a.sendMessage',
     source: 'a2a-runtime',
   });
-  const auditBase = {
+  recordSendAudits({
     envelope: deliveredEnvelope,
-    sessionId: meta?.sessionId,
-    runId: meta?.auditRunId,
-    actor: meta?.actor,
-    route: 'a2a.sendMessage',
-    source: 'a2a-runtime',
+    meta,
     transport: peerDescriptor.transport,
-  };
-  if ((meta?.auditRole ?? 'sender') === 'sender') {
-    recordA2AMessageAudit({
-      type: 'a2a.send',
-      ...auditBase,
-    });
-  }
-  if (peerDescriptor.transport === 'internal') {
-    recordA2AMessageAudit({
-      type: 'a2a.deliver',
-      ...auditBase,
-    });
-  }
-  if (deliveredEnvelope.intent === 'handoff') {
-    recordA2AMessageAudit({
-      type: 'a2a.handoff',
-      ...auditBase,
-    });
-  }
-  return {
     delivered: true,
-    message_id: deliveredEnvelope.id,
-    thread_id: deliveredEnvelope.thread_id,
-    recipient_agent_id: deliveredEnvelope.recipient_agent_id,
-  };
+  });
+  return deliveryConfirmation(true, deliveredEnvelope);
 }
 
 /**

--- a/src/identity/resolver.ts
+++ b/src/identity/resolver.ts
@@ -7,6 +7,7 @@ import { type ParsedUserId, parseUserId } from './user-id.js';
 
 export const IDENTITY_RESOLVER_CACHE_TTL_MS = 5 * 60_000;
 export const IDENTITY_RESOLVER_CACHE_MAX_ENTRIES = 1024;
+export const IDENTITY_DISCOVERY_ZONE_ENV = 'HYBRIDCLAW_IDENTITY_DISCOVERY_ZONE';
 
 export interface IdentityResolution {
   readonly url: string;
@@ -330,4 +331,26 @@ export class DnsIdentityResolverBackend implements IdentityResolverBackend {
     }
     return null;
   }
+}
+
+let cachedDefaultIdentityResolver: {
+  zone: string;
+  resolver: IdentityResolver;
+} | null = null;
+
+export function getDefaultIdentityResolver(): IdentityResolver | null {
+  const rawZone = (process.env[IDENTITY_DISCOVERY_ZONE_ENV] || '').trim();
+  if (!rawZone) {
+    cachedDefaultIdentityResolver = null;
+    return null;
+  }
+  const zone = normalizeDnsZone(rawZone);
+  if (cachedDefaultIdentityResolver?.zone === zone) {
+    return cachedDefaultIdentityResolver.resolver;
+  }
+  const resolver = new IdentityResolver({
+    backend: new DnsIdentityResolverBackend({ zone }),
+  });
+  cachedDefaultIdentityResolver = { zone, resolver };
+  return resolver;
 }

--- a/tests/a2a-outbound.integration.test.ts
+++ b/tests/a2a-outbound.integration.test.ts
@@ -1,6 +1,7 @@
+import { generateKeyPairSync } from 'node:crypto';
 import http from 'node:http';
 
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { decodeA2AJsonRpcRequest } from '../src/a2a/a2a-json-rpc.ts';
 import { setupA2AWebhookTestEnv } from './helpers/a2a-webhook-fixtures.ts';
@@ -118,6 +119,140 @@ describe('A2A outbound integration', () => {
         }),
         decoded: envelope,
       },
+    ]);
+  });
+
+  test('routes remote sendMessage recipients through identity resolution and HTTP delivery', async () => {
+    process.env.HYBRIDCLAW_INSTANCE_ID = 'instance-x';
+    process.env.HYBRIDCLAW_IDENTITY_DISCOVERY_ZONE = 'identity.test';
+
+    const peerPublicKeyJwk = generateKeyPairSync('ed25519').publicKey.export({
+      format: 'jwk',
+    });
+    const received: unknown[] = [];
+    let saveDeliveredEnvelope: (
+      decoded: ReturnType<typeof decodeA2AJsonRpcRequest>,
+    ) => void = () => {
+      throw new Error('store not initialized');
+    };
+    let listRecipientInbox: () => ReturnType<typeof decodeA2AJsonRpcRequest>[] =
+      () => {
+        throw new Error('store not initialized');
+      };
+    const server = http.createServer(async (request, response) => {
+      if (request.url === '/.well-known/agent.json') {
+        response.writeHead(200, {
+          'content-type': 'application/json',
+          etag: '"identity-card-v1"',
+        });
+        response.end(
+          JSON.stringify({
+            name: 'Stub Instance Y',
+            url: `http://${request.headers.host}/a2a`,
+            capabilities: {
+              messageSend: true,
+            },
+            hybridclaw: {
+              instanceId: 'instance-y',
+              publicKeyJwk: peerPublicKeyJwk,
+            },
+          }),
+        );
+        return;
+      }
+
+      if (request.url === '/a2a' && request.method === 'POST') {
+        const body = await readRequestBody(request);
+        const decoded = decodeA2AJsonRpcRequest(body);
+        received.push(decoded);
+        saveDeliveredEnvelope(decoded);
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end(JSON.stringify({ jsonrpc: '2.0', result: { ok: true } }));
+        return;
+      }
+
+      response.writeHead(404);
+      response.end();
+    });
+    const port = await listen(server);
+
+    try {
+      vi.doMock('node:dns/promises', () => ({
+        resolveTxt: vi.fn(async () => [
+          [
+            JSON.stringify({
+              canonicalId: 'stub-b@team@instance-y',
+              url: `http://127.0.0.1:${port}`,
+              publicKey: JSON.stringify(peerPublicKeyJwk),
+            }),
+          ],
+        ]),
+      }));
+
+      const { initDatabase } = await import('../src/memory/db.ts');
+      const runtimeConfig = await import('../src/config/runtime-config.ts');
+      const runtime = await import('../src/a2a/runtime.ts');
+      const a2a = await import('../src/a2a/a2a-outbound.ts');
+      const store = await import('../src/a2a/store.ts');
+
+      initDatabase({ quiet: true });
+      runtimeConfig.updateRuntimeConfig((draft) => {
+        draft.agents.list = [
+          { id: 'main', owner: 'team', role: 'lead' },
+          { id: 'stub-a', owner: 'team', role: 'sender' },
+        ];
+      });
+      saveDeliveredEnvelope = (decoded) => {
+        store.saveA2AEnvelope(decoded, {
+          actor: 'stub-instance-y',
+          route: 'test.a2a.remote',
+          source: 'stub-peer',
+        });
+      };
+      listRecipientInbox = () =>
+        store.listA2AInboxEnvelopes('stub-b@team@instance-y');
+
+      const confirmation = runtime.sendMessage({
+        id: 'msg-cross-instance',
+        sender_agent_id: 'stub-a',
+        recipient_agent_id: 'stub-b@team@instance-y',
+        thread_id: 'thread-cross-instance',
+        intent: 'chat',
+        content: 'Route this to instance Y.',
+        created_at: '2026-05-01T10:00:00.000Z',
+      });
+
+      expect(confirmation).toMatchObject({
+        delivered: 'pending',
+        message_id: 'msg-cross-instance',
+        thread_id: 'thread-cross-instance',
+        recipient_agent_id: 'stub-b@team@instance-y',
+      });
+      expect(listRecipientInbox()).toEqual([]);
+
+      await expect(a2a.processA2AOutbox()).resolves.toMatchObject({
+        processed: 1,
+        delivered: 1,
+      });
+    } finally {
+      await closeServer(server);
+    }
+
+    expect(received).toEqual([
+      expect.objectContaining({
+        id: 'msg-cross-instance',
+        sender_agent_id: 'stub-a@team@instance-x',
+        sender_instance_id: 'instance-x',
+        recipient_agent_id: 'stub-b@team@instance-y',
+        thread_id: 'thread-cross-instance',
+      }),
+    ]);
+    expect(listRecipientInbox()).toEqual([
+      expect.objectContaining({
+        id: 'msg-cross-instance',
+        sender_agent_id: 'stub-a@team@instance-x',
+        recipient_agent_id: 'stub-b@team@instance-y',
+      }),
     ]);
   });
 });

--- a/tests/a2a-outbound.test.ts
+++ b/tests/a2a-outbound.test.ts
@@ -701,6 +701,83 @@ describe('A2A outbound adapter', () => {
     });
   });
 
+  test('fails unresolved recipients without retrying missing identity records', async () => {
+    const { initDatabase } = await import('../src/memory/db.ts');
+    const a2a = await import('../src/a2a/a2a-outbound.ts');
+    const { IdentityNotFoundError } = await import(
+      '../src/identity/resolver.ts'
+    );
+
+    initDatabase({ quiet: true });
+    a2a.enqueueUnresolvedA2AEnvelope(
+      sampleA2AEnvelope('msg-missing-identity'),
+      'remote@team@peer-instance',
+    );
+    expect(a2a.listA2AOutboxItems()[0]).toMatchObject({
+      identityResolution: {
+        status: 'unresolved',
+        canonicalId: 'remote@team@peer-instance',
+      },
+    });
+
+    await expect(
+      a2a.processA2AOutbox({
+        identityResolver: {
+          async resolve(canonicalId: string) {
+            throw new IdentityNotFoundError(canonicalId);
+          },
+        },
+        now: () => new Date('2030-01-01T00:00:00.000Z'),
+        jitterRatio: 0,
+      }),
+    ).resolves.toMatchObject({ processed: 1, failed: 1 });
+    expect(a2a.listA2AOutboxItems()[0]).toMatchObject({
+      status: 'failed',
+      attempts: 1,
+      lastError:
+        'No identity discovery record found for remote@team@peer-instance.',
+    });
+  });
+
+  test('fails closed when identity discovery returns an unsupported public key', async () => {
+    const { initDatabase } = await import('../src/memory/db.ts');
+    const a2a = await import('../src/a2a/a2a-outbound.ts');
+
+    initDatabase({ quiet: true });
+    a2a.enqueueUnresolvedA2AEnvelope(
+      sampleA2AEnvelope('msg-invalid-discovery-key'),
+      'remote@team@peer-instance',
+    );
+
+    await expect(
+      a2a.processA2AOutbox({
+        identityResolver: {
+          async resolve() {
+            return {
+              url: 'http://127.0.0.1:8787',
+              publicKey: 'not-a-valid-key',
+            };
+          },
+        },
+        fetchImpl: vi.fn().mockResolvedValue(
+          Response.json({
+            url: 'http://127.0.0.1:8787/a2a',
+            capabilities: [],
+          }),
+        ),
+      }),
+    ).resolves.toMatchObject({ processed: 1, failed: 1 });
+    expect(a2a.listA2AOutboxItems()[0]).toMatchObject({
+      status: 'failed',
+      identityResolution: {
+        status: 'resolved',
+        canonicalId: 'remote@team@peer-instance',
+        publicKey: 'not-a-valid-key',
+      },
+      lastError: expect.stringContaining('unsupported public key format'),
+    });
+  });
+
   test('keys Agent Card cache by auth context', async () => {
     const { initDatabase } = await import('../src/memory/db.ts');
     const runtime = await import('../src/a2a/runtime.ts');

--- a/tests/a2a-runtime.integration.test.ts
+++ b/tests/a2a-runtime.integration.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 const ORIGINAL_DATA_DIR = process.env.HYBRIDCLAW_DATA_DIR;
 const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_INSTANCE_ID = process.env.HYBRIDCLAW_INSTANCE_ID;
+const ORIGINAL_DISCOVERY_ZONE = process.env.HYBRIDCLAW_IDENTITY_DISCOVERY_ZONE;
 
 let tmpDir: string;
 
@@ -24,6 +25,7 @@ beforeEach(() => {
   process.env.HYBRIDCLAW_DATA_DIR = tmpDir;
   process.env.HOME = tmpDir;
   process.env.HYBRIDCLAW_INSTANCE_ID = 'local-dev';
+  delete process.env.HYBRIDCLAW_IDENTITY_DISCOVERY_ZONE;
   vi.resetModules();
 });
 
@@ -31,6 +33,8 @@ afterEach(() => {
   restoreEnvVar('HYBRIDCLAW_DATA_DIR', ORIGINAL_DATA_DIR);
   restoreEnvVar('HOME', ORIGINAL_HOME);
   restoreEnvVar('HYBRIDCLAW_INSTANCE_ID', ORIGINAL_INSTANCE_ID);
+  restoreEnvVar('HYBRIDCLAW_IDENTITY_DISCOVERY_ZONE', ORIGINAL_DISCOVERY_ZONE);
+  vi.doUnmock('../src/logger.js');
   vi.resetModules();
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
@@ -269,7 +273,7 @@ describe('A2A runtime API', () => {
 
     initDatabase({ quiet: true });
 
-    runtime.sendMessage(
+    const confirmation = runtime.sendMessage(
       {
         id: 'msg-queued-audit',
         sender_agent_id: 'main',
@@ -288,6 +292,12 @@ describe('A2A runtime API', () => {
         },
       },
     );
+
+    expect(confirmation).toMatchObject({
+      delivered: 'pending',
+      message_id: 'msg-queued-audit',
+    });
+    expect(runtime.inbox('remote@team@peer-instance')).toEqual([]);
 
     const wirePath = audit.getAuditWirePath('session-a2a-queued-audit');
     const records = fs
@@ -309,40 +319,87 @@ describe('A2A runtime API', () => {
     });
   });
 
+  test('warns once when remote canonical sends are queued without identity discovery', async () => {
+    const loggerMock = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    };
+    vi.doMock('../src/logger.js', () => ({
+      logger: loggerMock,
+    }));
+    const { initDatabase } = await import('../src/memory/db.ts');
+    const runtime = await import('../src/a2a/runtime.ts');
+
+    initDatabase({ quiet: true });
+
+    for (const id of ['msg-no-discovery-a', 'msg-no-discovery-b']) {
+      expect(
+        runtime.sendMessage({
+          id,
+          sender_agent_id: 'main',
+          recipient_agent_id: 'remote@team@peer-instance',
+          thread_id: 'thread-no-discovery',
+          intent: 'chat',
+          content: 'Queue this for identity discovery.',
+          created_at: '2026-05-01T10:00:00.000Z',
+        }),
+      ).toMatchObject({
+        delivered: 'pending',
+        recipient_agent_id: 'remote@team@peer-instance',
+      });
+    }
+
+    expect(loggerMock.warn).toHaveBeenCalledTimes(1);
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      {
+        recipientAgentId: 'remote@team@peer-instance',
+        env: 'HYBRIDCLAW_IDENTITY_DISCOVERY_ZONE',
+      },
+      'A2A remote send queued without identity discovery configured',
+    );
+  });
+
   test('audits and escalates when a peer transport has no adapter', async () => {
     const { initDatabase, getRecentStructuredAuditForSession } = await import(
       '../src/memory/db.ts'
     );
     const escalation = await import('../src/gateway/interactive-escalation.ts');
     const runtime = await import('../src/a2a/runtime.ts');
-    const transport = await import('../src/a2a/transport-registry.ts');
 
     initDatabase({ quiet: true });
 
-    expect(() =>
-      runtime.sendMessage(
-        {
-          id: 'msg-remote',
-          sender_agent_id: 'main',
-          recipient_agent_id: 'remote@team@peer-instance',
-          thread_id: 'thread-remote',
-          intent: 'chat',
-          content: 'Can your peer agent receive this?',
-          created_at: '2026-05-01T10:00:00.000Z',
+    const confirmation = runtime.sendMessage(
+      {
+        id: 'msg-remote',
+        sender_agent_id: 'main',
+        recipient_agent_id: 'remote@team@peer-instance',
+        thread_id: 'thread-remote',
+        intent: 'chat',
+        content: 'Can your peer agent receive this?',
+        created_at: '2026-05-01T10:00:00.000Z',
+      },
+      {
+        sessionId: 'session-a2a-transport',
+        auditRunId: 'run-a2a-transport',
+        peerDescriptor: {
+          transport: 'smtp',
         },
-        {
-          sessionId: 'session-a2a-transport',
-          auditRunId: 'run-a2a-transport',
-          peerDescriptor: {
-            transport: 'smtp',
-          },
-          escalationTarget: {
-            channel: 'slack:COPS',
-            recipient: 'ops-lead',
-          },
+        escalationTarget: {
+          channel: 'slack:COPS',
+          recipient: 'ops-lead',
         },
-      ),
-    ).toThrow(transport.TransportRegistryError);
+      },
+    );
+
+    expect(confirmation).toMatchObject({
+      delivered: false,
+      message_id: 'msg-remote',
+      thread_id: 'thread-remote',
+      recipient_agent_id: 'remote@team@peer-instance',
+      failure_reason: 'No A2A transport adapter registered for "smtp".',
+    });
 
     const events = getRecentStructuredAuditForSession(
       'session-a2a-transport',
@@ -388,29 +445,28 @@ describe('A2A runtime API', () => {
     const { initDatabase } = await import('../src/memory/db.ts');
     const escalation = await import('../src/gateway/interactive-escalation.ts');
     const runtime = await import('../src/a2a/runtime.ts');
-    const transport = await import('../src/a2a/transport-registry.ts');
 
     initDatabase({ quiet: true });
 
-    expect(() =>
-      runtime.sendMessage(
-        {
-          id: 'msg:remote',
-          sender_agent_id: 'main',
-          recipient_agent_id: 'remote@team@peer-instance',
-          thread_id: 'thread:remote',
-          intent: 'chat',
-          content: 'Can your peer agent receive this?',
-          created_at: '2026-05-01T10:00:00.000Z',
+    const confirmation = runtime.sendMessage(
+      {
+        id: 'msg:remote',
+        sender_agent_id: 'main',
+        recipient_agent_id: 'remote@team@peer-instance',
+        thread_id: 'thread:remote',
+        intent: 'chat',
+        content: 'Can your peer agent receive this?',
+        created_at: '2026-05-01T10:00:00.000Z',
+      },
+      {
+        auditRunId: 'run-a2a-transport',
+        peerDescriptor: {
+          transport: 'smtp',
         },
-        {
-          auditRunId: 'run-a2a-transport',
-          peerDescriptor: {
-            transport: 'smtp',
-          },
-        },
-      ),
-    ).toThrow(transport.TransportRegistryError);
+      },
+    );
+
+    expect(confirmation.delivered).toBe(false);
 
     const threadKey = Buffer.from('thread:remote').toString('base64url');
     const messageKey = Buffer.from('msg:remote').toString('base64url');

--- a/tests/helpers/a2a-webhook-fixtures.ts
+++ b/tests/helpers/a2a-webhook-fixtures.ts
@@ -16,6 +16,8 @@ export function setupA2AWebhookTestEnv(tempHomePrefix: string): void {
   const originalDataDir = process.env.HYBRIDCLAW_DATA_DIR;
   const originalHome = process.env.HOME;
   const originalInstanceId = process.env.HYBRIDCLAW_INSTANCE_ID;
+  const originalIdentityDiscoveryZone =
+    process.env.HYBRIDCLAW_IDENTITY_DISCOVERY_ZONE;
   let tmpDir = '';
 
   beforeEach(() => {
@@ -29,6 +31,11 @@ export function setupA2AWebhookTestEnv(tempHomePrefix: string): void {
     restoreEnvVar('HYBRIDCLAW_DATA_DIR', originalDataDir);
     restoreEnvVar('HOME', originalHome);
     restoreEnvVar('HYBRIDCLAW_INSTANCE_ID', originalInstanceId);
+    restoreEnvVar(
+      'HYBRIDCLAW_IDENTITY_DISCOVERY_ZONE',
+      originalIdentityDiscoveryZone,
+    );
+    vi.doUnmock('node:dns/promises');
     vi.resetModules();
     if (tmpDir) {
       fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/tests/identity-resolver.integration.test.ts
+++ b/tests/identity-resolver.integration.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, test } from 'vitest';
 import {
   DnsIdentityResolverBackend,
   type DnsTxtLookup,
+  getDefaultIdentityResolver,
+  IDENTITY_DISCOVERY_ZONE_ENV,
   IdentityNotFoundError,
   IdentityResolver,
   IdentityResolverError,
@@ -286,5 +288,24 @@ describe('identity resolver discovery', () => {
     await expect(resolver.resolve('ada@hybridai')).rejects.toThrow(
       IdentityResolverError,
     );
+  });
+
+  test('caches default resolver by normalized discovery zone', () => {
+    const originalZone = process.env[IDENTITY_DISCOVERY_ZONE_ENV];
+    try {
+      process.env[IDENTITY_DISCOVERY_ZONE_ENV] = 'Identity.Test.';
+      const first = getDefaultIdentityResolver();
+      process.env[IDENTITY_DISCOVERY_ZONE_ENV] = 'identity.test';
+      const second = getDefaultIdentityResolver();
+
+      expect(first).toBeTruthy();
+      expect(second).toBe(first);
+    } finally {
+      if (originalZone === undefined) {
+        delete process.env[IDENTITY_DISCOVERY_ZONE_ENV];
+      } else {
+        process.env[IDENTITY_DISCOVERY_ZONE_ENV] = originalZone;
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary

Closes #717.

- Detect remote canonical A2A recipients in `sendMessage` and return a pending delivery confirmation instead of writing remote messages into the local inbox.
- Queue unresolved remote recipients in the durable A2A outbox, resolve them through the F7.3 identity resolver, and dispatch via the existing A2A JSON-RPC HTTP transport with public-key matching and retry handling.
- Wire the default outbox processor to use `HYBRIDCLAW_IDENTITY_DISCOVERY_ZONE` and document that resolver configuration.
- Add integration coverage for stub instance X delivering to stub instance Y through the default resolver/outbox path.

## Validation

- `npm run typecheck`
- `npx biome check src/identity/resolver.ts src/a2a/a2a-outbox-processor.ts src/a2a/a2a-outbox-delivery.ts src/a2a/a2a-outbox-persistence.ts src/a2a/runtime.ts src/a2a/a2a-outbound.ts tests/a2a-outbound.integration.test.ts tests/helpers/a2a-webhook-fixtures.ts docs/content/developer-guide/identity.md`
- `./node_modules/.bin/vitest run tests/a2a-runtime.integration.test.ts tests/a2a-outbound.integration.test.ts tests/a2a-outbound.test.ts tests/a2a-transport-registry.test.ts tests/identity-resolver.integration.test.ts`