### PR TITLE
[codex] Add Google OAuth recovery hint

### DIFF
--- a/src/auth/google-auth.ts
+++ b/src/auth/google-auth.ts
@@ -356,6 +356,21 @@ export function getGoogleAuthStatus(): {
   };
 }
 
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error || '');
+}
+
+export function getGoogleWorkspaceRuntimeEnvRecoveryHint(
+  error: unknown,
+): string {
+  const message = getErrorMessage(error);
+  if (message.includes('invalid_grant')) {
+    return 'Stored Google OAuth refresh token is expired or revoked. Run `hybridclaw auth login google --account <email>` to re-authorize Google, include `--client-id` and `--client-secret` if they are not already stored, complete the browser consent flow, then retry the request. Do not pass `--refresh-token`; unset `GOOGLE_OAUTH_REFRESH_TOKEN` first if it is exported.';
+  }
+  return 'Run `hybridclaw auth status google` to inspect stored Google OAuth credentials. If credentials are missing or stale, run `hybridclaw auth login google --account <email>` and complete the browser consent flow.';
+}
+
 export async function mintGoogleAccessToken(): Promise<{
   accessToken: string;
   expiresIn: number | null;

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -10,7 +10,10 @@ import type {
   ExecutorSessionHealthSnapshot,
 } from '../agent/executor-types.js';
 import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
-import { resolveGoogleWorkspaceRuntimeEnv } from '../auth/google-auth.js';
+import {
+  getGoogleWorkspaceRuntimeEnvRecoveryHint,
+  resolveGoogleWorkspaceRuntimeEnv,
+} from '../auth/google-auth.js';
 import { getBrowserProfileDir } from '../browser/browser-login.js';
 import { collectActiveMessageToolChannelKinds } from '../channels/message-tool-advertising.js';
 import {
@@ -1060,9 +1063,10 @@ async function runContainerInner(
     sessionModel: modelRuntime.model || model,
   });
   const runtimeEnv = await resolveGoogleWorkspaceRuntimeEnv().catch((error) => {
+    const recoveryHint = getGoogleWorkspaceRuntimeEnvRecoveryHint(error);
     logger.warn(
-      { error },
-      'Failed to resolve Google access token for Workspace CLI runtime environment',
+      { error, recoveryHint },
+      `Failed to resolve Google access token for Workspace CLI runtime environment. ${recoveryHint}`,
     );
     return {};
   });

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -8,7 +8,10 @@ import type {
   ExecutorSessionHealthSnapshot,
 } from '../agent/executor-types.js';
 import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
-import { resolveGoogleWorkspaceRuntimeEnv } from '../auth/google-auth.js';
+import {
+  getGoogleWorkspaceRuntimeEnvRecoveryHint,
+  resolveGoogleWorkspaceRuntimeEnv,
+} from '../auth/google-auth.js';
 import { collectActiveMessageToolChannelKinds } from '../channels/message-tool-advertising.js';
 import {
   ADDITIONAL_MOUNTS,
@@ -921,9 +924,10 @@ async function runHostProcessInner(
     sessionModel: modelRuntime.model || model,
   });
   const runtimeEnv = await resolveGoogleWorkspaceRuntimeEnv().catch((error) => {
+    const recoveryHint = getGoogleWorkspaceRuntimeEnvRecoveryHint(error);
     logger.warn(
-      { error },
-      'Failed to resolve Google access token for Workspace CLI runtime environment',
+      { error, recoveryHint },
+      `Failed to resolve Google access token for Workspace CLI runtime environment. ${recoveryHint}`,
     );
     return {};
   });

--- a/tests/google-auth.test.ts
+++ b/tests/google-auth.test.ts
@@ -103,3 +103,20 @@ test('Google Workspace runtime env exposes minted OAuth tokens for gog and gws',
   });
   expect(fetchMock).toHaveBeenCalledTimes(1);
 });
+
+test('Google Workspace runtime env recovery hint explains invalid_grant reauthorization', async () => {
+  const homeDir = makeTempHome();
+  const { getGoogleWorkspaceRuntimeEnvRecoveryHint } =
+    await importFreshGoogleAuth(homeDir);
+
+  const hint = getGoogleWorkspaceRuntimeEnvRecoveryHint(
+    new Error(
+      'Google OAuth token request failed: invalid_grant: Token has been expired or revoked.',
+    ),
+  );
+
+  expect(hint).toContain('refresh token is expired or revoked');
+  expect(hint).toContain('hybridclaw auth login google --account <email>');
+  expect(hint).toContain('complete the browser consent flow');
+  expect(hint).toContain('unset `GOOGLE_OAUTH_REFRESH_TOKEN`');
+});


### PR DESCRIPTION
## Summary

- Adds a shared recovery hint for Google Workspace runtime access-token resolution failures.
- Appends the hint to host and container runner warnings and includes it as structured `recoveryHint` log metadata.
- Covers the `invalid_grant` case so users are told to re-authorize Google OAuth instead of seeing only the low-level token error.

## Root Cause

When Google rejects the stored OAuth refresh token with `invalid_grant`, HybridClaw currently logs that token minting failed but does not explain that the stored refresh token is expired or revoked, or that the user needs to complete a new browser consent flow.

## Validation

- `npx vitest run tests/google-auth.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `npx biome check src/auth/google-auth.ts src/infra/host-runner.ts src/infra/container-runner.ts tests/google-auth.test.ts`