### PR TITLE
feat(console): admin audit log explorer (cursor paging + range filters)

### DIFF
--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -914,6 +914,9 @@ export function fetchAudit(
     query?: string;
     sessionId?: string;
     eventType?: string;
+    since?: string;
+    until?: string;
+    cursor?: number;
     limit?: number;
   },
 ): Promise<AdminAuditResponse> {
@@ -921,6 +924,11 @@ export function fetchAudit(
   if (params.query) queryParams.set('query', params.query);
   if (params.sessionId) queryParams.set('sessionId', params.sessionId);
   if (params.eventType) queryParams.set('eventType', params.eventType);
+  if (params.since) queryParams.set('since', params.since);
+  if (params.until) queryParams.set('until', params.until);
+  if (typeof params.cursor === 'number' && params.cursor > 0) {
+    queryParams.set('cursor', String(params.cursor));
+  }
   if (typeof params.limit === 'number') {
     queryParams.set('limit', String(params.limit));
   }

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -1261,8 +1261,12 @@ export interface AdminAuditResponse {
   query: string;
   sessionId: string;
   eventType: string;
+  since: string | null;
+  until: string | null;
   limit: number;
   entries: AdminAuditEntry[];
+  /** Opaque cursor for the next page; pass back as `cursor=`. null on the last page. */
+  nextCursor: number | null;
 }
 
 export interface AdminA2AIdentity {

--- a/console/src/router.tsx
+++ b/console/src/router.tsx
@@ -194,6 +194,10 @@ const mcpRoute = createRoute({
 const auditRoute = createRoute({
   getParentRoute: () => adminLayoutRoute,
   path: '/admin/audit',
+  validateSearch: (search: Record<string, unknown>) => ({
+    q: optionalStringSearchValue(search.q),
+    range: optionalStringSearchValue(search.range),
+  }),
   component: AuditPage,
 });
 

--- a/console/src/routes/audit-filters.test.ts
+++ b/console/src/routes/audit-filters.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { categorize, rangeToSince, readRange } from './audit-filters';
+
+describe('categorize', () => {
+  it('returns the dot-prefix for a known category', () => {
+    expect(categorize('session.end')).toBe('session');
+    expect(categorize('tool.call')).toBe('tool');
+    expect(categorize('autonomy.decision')).toBe('autonomy');
+  });
+
+  it("returns 'default' for unknown prefixes", () => {
+    expect(categorize('unknown.event')).toBe('default');
+    expect(categorize('')).toBe('default');
+  });
+
+  it("treats events with no dot as 'default' unless the full string is a category", () => {
+    expect(categorize('session')).toBe('session');
+    expect(categorize('plain')).toBe('default');
+  });
+});
+
+describe('rangeToSince', () => {
+  const now = Date.parse('2026-05-23T12:00:00.000Z');
+
+  it("returns undefined when range is 'all'", () => {
+    expect(rangeToSince('all', now)).toBeUndefined();
+  });
+
+  it('subtracts one hour for `1h`', () => {
+    expect(rangeToSince('1h', now)).toBe('2026-05-23T11:00:00.000Z');
+  });
+
+  it('subtracts 24 hours for `24h`', () => {
+    expect(rangeToSince('24h', now)).toBe('2026-05-22T12:00:00.000Z');
+  });
+
+  it('subtracts 7 days for `7d`', () => {
+    expect(rangeToSince('7d', now)).toBe('2026-05-16T12:00:00.000Z');
+  });
+});
+
+describe('readRange', () => {
+  it('accepts the four known range values', () => {
+    expect(readRange('all')).toBe('all');
+    expect(readRange('1h')).toBe('1h');
+    expect(readRange('24h')).toBe('24h');
+    expect(readRange('7d')).toBe('7d');
+  });
+
+  it("falls back to 'all' for unknown or missing values", () => {
+    expect(readRange(undefined)).toBe('all');
+    expect(readRange('')).toBe('all');
+    expect(readRange('30d')).toBe('all');
+    expect(readRange('1H')).toBe('all');
+  });
+});

--- a/console/src/routes/audit-filters.ts
+++ b/console/src/routes/audit-filters.ts
@@ -1,0 +1,55 @@
+export const CATEGORIES = [
+  'session',
+  'turn',
+  'model',
+  'tool',
+  'autonomy',
+  'authorization',
+  'approval',
+  'a2a',
+] as const;
+export type Category = (typeof CATEGORIES)[number];
+
+export const KNOWN_CATEGORIES = new Set<string>(CATEGORIES);
+
+export const TIME_RANGES = [
+  { value: 'all', label: 'All' },
+  { value: '1h', label: '1h' },
+  { value: '24h', label: '24h' },
+  { value: '7d', label: '7d' },
+] as const;
+export type TimeRange = (typeof TIME_RANGES)[number]['value'];
+
+const TIME_RANGE_VALUES = new Set<string>(TIME_RANGES.map((r) => r.value));
+
+const RANGE_TO_MS: Record<Exclude<TimeRange, 'all'>, number> = {
+  '1h': 60 * 60 * 1000,
+  '24h': 24 * 60 * 60 * 1000,
+  '7d': 7 * 24 * 60 * 60 * 1000,
+};
+
+/**
+ * Map an event type like `session.end` or `tool.call` to its known category
+ * (the dot prefix) or 'default' when the prefix isn't one we colour.
+ */
+export function categorize(eventType: string): Category | 'default' {
+  const prefix = eventType.split('.', 1)[0] ?? '';
+  return KNOWN_CATEGORIES.has(prefix) ? (prefix as Category) : 'default';
+}
+
+/**
+ * Convert a time-range pill into a `since` cutoff (ISO string) suitable for
+ * the audit API's `since=` param. `'all'` returns undefined (no cutoff).
+ */
+export function rangeToSince(
+  range: TimeRange,
+  now: number = Date.now(),
+): string | undefined {
+  if (range === 'all') return undefined;
+  return new Date(now - RANGE_TO_MS[range]).toISOString();
+}
+
+/** Validate a raw URL `range` param; fall back to 'all'. */
+export function readRange(value: string | undefined): TimeRange {
+  return value && TIME_RANGE_VALUES.has(value) ? (value as TimeRange) : 'all';
+}

--- a/console/src/routes/audit-search.test.ts
+++ b/console/src/routes/audit-search.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseAuditSearch,
+  removeAuditField,
+  setAuditField,
+} from './audit-search';
+
+describe('parseAuditSearch', () => {
+  it('extracts session and type tokens', () => {
+    expect(parseAuditSearch('session:web type:tool error here')).toEqual({
+      sessionId: 'web',
+      eventType: 'tool',
+      query: 'error here',
+    });
+  });
+
+  it('treats unknown keys as free text', () => {
+    expect(parseAuditSearch('runId:foo:bar payload value')).toEqual({
+      sessionId: '',
+      eventType: '',
+      query: 'runId:foo:bar payload value',
+    });
+  });
+
+  it('accepts `event:` as an alias for `type:`', () => {
+    expect(parseAuditSearch('event:session.end')).toEqual({
+      sessionId: '',
+      eventType: 'session.end',
+      query: '',
+    });
+  });
+
+  it('respects quoted values that contain spaces', () => {
+    expect(parseAuditSearch('session:"web user" hello')).toEqual({
+      sessionId: 'web user',
+      eventType: '',
+      query: 'hello',
+    });
+  });
+
+  it('keeps quoted free text segments together', () => {
+    expect(parseAuditSearch('"some payload"')).toEqual({
+      sessionId: '',
+      eventType: '',
+      query: 'some payload',
+    });
+  });
+
+  it('lets later field tokens override earlier ones', () => {
+    expect(parseAuditSearch('type:tool type:session')).toEqual({
+      sessionId: '',
+      eventType: 'session',
+      query: '',
+    });
+  });
+
+  it('returns empty fields for empty input', () => {
+    expect(parseAuditSearch('   ')).toEqual({
+      sessionId: '',
+      eventType: '',
+      query: '',
+    });
+  });
+
+  it('treats an empty field value as "clear this filter"', () => {
+    // Pins UX: typing `type:` on its own erases any prior `type:` token
+    // rather than searching for the literal string "type:".
+    expect(parseAuditSearch('type:tool type:')).toEqual({
+      sessionId: '',
+      eventType: '',
+      query: '',
+    });
+  });
+
+  it('tolerates an unterminated leading quote on a field value', () => {
+    // Mid-type state: `session:"web` should still produce a usable
+    // sessionId rather than leaking the stray `"` to the API.
+    expect(parseAuditSearch('session:"web')).toEqual({
+      sessionId: 'web',
+      eventType: '',
+      query: '',
+    });
+  });
+
+  it('tolerates an unterminated leading quote on free text', () => {
+    expect(parseAuditSearch('"hello')).toEqual({
+      sessionId: '',
+      eventType: '',
+      query: 'hello',
+    });
+  });
+});
+
+describe('removeAuditField', () => {
+  it('removes the named field and keeps the rest', () => {
+    expect(removeAuditField('session:web type:tool error', 'session')).toBe(
+      'type:tool error',
+    );
+  });
+
+  it('is a no-op when the field is absent', () => {
+    expect(removeAuditField('hello world', 'type')).toBe('hello world');
+  });
+});
+
+describe('setAuditField', () => {
+  it('adds a field when none is present', () => {
+    expect(setAuditField('error', 'type', 'tool')).toBe('error type:tool');
+  });
+
+  it('replaces an existing field', () => {
+    expect(setAuditField('type:tool error', 'type', 'session')).toBe(
+      'error type:session',
+    );
+  });
+
+  it('clears the field when value is empty', () => {
+    expect(setAuditField('type:tool error', 'type', '')).toBe('error');
+  });
+
+  it('quotes values with whitespace', () => {
+    expect(setAuditField('', 'session', 'web user')).toBe('session:"web user"');
+  });
+});

--- a/console/src/routes/audit-search.ts
+++ b/console/src/routes/audit-search.ts
@@ -1,0 +1,124 @@
+export type ParsedAuditSearch = {
+  sessionId: string;
+  eventType: string;
+  query: string;
+};
+
+type Token =
+  | { kind: 'field'; key: 'session' | 'type'; value: string; raw: string }
+  | { kind: 'text'; value: string; raw: string };
+
+const FIELD_ALIASES: Record<string, 'session' | 'type'> = {
+  session: 'session',
+  type: 'type',
+  event: 'type',
+};
+
+/**
+ * Tokenize a search string while respecting double-quoted segments.
+ * `session:"web one" hello "two words" type:tool` →
+ *   ['session:"web one"', 'hello', '"two words"', 'type:tool']
+ */
+function tokenize(input: string): string[] {
+  const out: string[] = [];
+  let buffer = '';
+  let inQuotes = false;
+  for (const ch of input) {
+    if (ch === '"') {
+      inQuotes = !inQuotes;
+      buffer += ch;
+      continue;
+    }
+    if (!inQuotes && /\s/.test(ch)) {
+      if (buffer) {
+        out.push(buffer);
+        buffer = '';
+      }
+      continue;
+    }
+    buffer += ch;
+  }
+  if (buffer) out.push(buffer);
+  return out;
+}
+
+function stripQuotes(value: string): string {
+  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+    return value.slice(1, -1);
+  }
+  // Tolerate an unterminated leading quote (user mid-typing a quoted value).
+  if (value.startsWith('"')) {
+    return value.slice(1);
+  }
+  return value;
+}
+
+function classify(raw: string): Token {
+  const colonIdx = raw.indexOf(':');
+  if (colonIdx > 0) {
+    const key = raw.slice(0, colonIdx).toLowerCase();
+    const normalizedKey = FIELD_ALIASES[key];
+    if (normalizedKey) {
+      return {
+        kind: 'field',
+        key: normalizedKey,
+        value: stripQuotes(raw.slice(colonIdx + 1)),
+        raw,
+      };
+    }
+  }
+  return { kind: 'text', value: stripQuotes(raw), raw };
+}
+
+/**
+ * Parse a smart-search input into structured filter values.
+ * `session:web type:tool error` → { sessionId: 'web', eventType: 'tool', query: 'error' }
+ * Field tokens later in the string override earlier ones; free text joins with single spaces.
+ */
+export function parseAuditSearch(input: string): ParsedAuditSearch {
+  const tokens = tokenize(input).map(classify);
+  let sessionId = '';
+  let eventType = '';
+  const text: string[] = [];
+  for (const token of tokens) {
+    if (token.kind === 'field') {
+      if (token.key === 'session') sessionId = token.value;
+      else eventType = token.value;
+    } else if (token.value) {
+      text.push(token.value);
+    }
+  }
+  return { sessionId, eventType, query: text.join(' ') };
+}
+
+/**
+ * Remove a specific field token (`session:` or `type:`) from a raw search
+ * string, preserving free text. Used when the user dismisses a chip.
+ */
+export function removeAuditField(
+  input: string,
+  field: 'session' | 'type',
+): string {
+  return tokenize(input)
+    .map(classify)
+    .filter((token) => !(token.kind === 'field' && token.key === field))
+    .map((token) => token.raw)
+    .join(' ');
+}
+
+/**
+ * Replace or add a field token, preserving free text and other field tokens.
+ * Quotes the value if it contains whitespace.
+ */
+export function setAuditField(
+  input: string,
+  field: 'session' | 'type',
+  value: string,
+): string {
+  const trimmed = value.trim();
+  const stripped = removeAuditField(input, field);
+  if (!trimmed) return stripped;
+  const quoted = /\s/.test(trimmed) ? `"${trimmed}"` : trimmed;
+  const piece = `${field}:${quoted}`;
+  return stripped ? `${stripped} ${piece}` : piece;
+}

--- a/console/src/routes/audit.module.css
+++ b/console/src/routes/audit.module.css
@@ -158,26 +158,35 @@
   background: var(--muted-foreground);
 }
 
-.categoryChip[data-category="session"] {
+/* Category palette — shared by the filter chips and the per-row event pills. */
+.categoryChip[data-category="session"],
+.eventPill[data-category="session"] {
   --cat-color: #3b82f6;
 }
-.categoryChip[data-category="turn"] {
+.categoryChip[data-category="turn"],
+.eventPill[data-category="turn"] {
   --cat-color: #8b5cf6;
 }
-.categoryChip[data-category="model"] {
+.categoryChip[data-category="model"],
+.eventPill[data-category="model"] {
   --cat-color: #14b8a6;
 }
-.categoryChip[data-category="tool"] {
+.categoryChip[data-category="tool"],
+.eventPill[data-category="tool"] {
   --cat-color: #f97316;
 }
-.categoryChip[data-category="autonomy"] {
+.categoryChip[data-category="autonomy"],
+.eventPill[data-category="autonomy"] {
   --cat-color: #f59e0b;
 }
 .categoryChip[data-category="authorization"],
-.categoryChip[data-category="approval"] {
+.categoryChip[data-category="approval"],
+.eventPill[data-category="authorization"],
+.eventPill[data-category="approval"] {
   --cat-color: #ef4444;
 }
-.categoryChip[data-category="a2a"] {
+.categoryChip[data-category="a2a"],
+.eventPill[data-category="a2a"] {
   --cat-color: #ec4899;
 }
 
@@ -399,35 +408,6 @@
   flex: 0 0 auto;
 }
 
-.eventPill[data-category="session"] {
-  --cat-color: #3b82f6;
-}
-
-.eventPill[data-category="turn"] {
-  --cat-color: #8b5cf6;
-}
-
-.eventPill[data-category="model"] {
-  --cat-color: #14b8a6;
-}
-
-.eventPill[data-category="tool"] {
-  --cat-color: #f97316;
-}
-
-.eventPill[data-category="autonomy"] {
-  --cat-color: #f59e0b;
-}
-
-.eventPill[data-category="authorization"],
-.eventPill[data-category="approval"] {
-  --cat-color: #ef4444;
-}
-
-.eventPill[data-category="a2a"] {
-  --cat-color: #ec4899;
-}
-
 .eventPill[data-category="default"] {
   --cat-color: var(--muted-foreground);
 }
@@ -437,6 +417,32 @@
   text-align: center;
   color: var(--muted-foreground);
   font-size: 0.875rem;
+}
+
+.emptyError {
+  color: var(--danger);
+}
+
+.retry {
+  appearance: none;
+  border: 1px solid var(--danger-border);
+  background: var(--danger-soft);
+  color: var(--danger);
+  border-radius: 6px;
+  padding: 2px 10px;
+  font: inherit;
+  font-size: 0.8125rem;
+  cursor: pointer;
+}
+
+.retry:hover {
+  background: var(--danger);
+  color: var(--card);
+}
+
+.retry:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
 }
 
 .loadMoreRow {

--- a/console/src/routes/audit.module.css
+++ b/console/src/routes/audit.module.css
@@ -1,0 +1,607 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-width: 0;
+}
+
+.toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 8px 0 14px;
+  border-bottom: 1px solid var(--line);
+}
+
+.searchRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.searchWrap {
+  position: relative;
+  flex: 1 1 320px;
+  min-width: 240px;
+  display: flex;
+  align-items: center;
+}
+
+.searchIcon {
+  position: absolute;
+  left: 10px;
+  width: 14px;
+  height: 14px;
+  color: var(--muted-foreground);
+  pointer-events: none;
+  flex: 0 0 auto;
+}
+
+.searchWrap input.searchInput {
+  width: 100%;
+  padding-left: 32px;
+  font-size: 0.875rem;
+}
+
+.shortcutHint {
+  position: absolute;
+  right: 8px;
+  font-size: 0.7rem;
+  font-family: ui-monospace, SFMono-Regular, "Cascadia Mono", Menlo, monospace;
+  color: var(--muted-foreground);
+  background: var(--panel-muted);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 1px 5px;
+  pointer-events: none;
+}
+
+.shortcutHint[data-hidden="true"] {
+  display: none;
+}
+
+.timeRange {
+  display: inline-flex;
+  align-items: center;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--panel-bg);
+  min-width: 0;
+}
+
+.timeRange button {
+  background: transparent;
+  border: 0;
+  color: var(--muted-foreground);
+  padding: 6px 10px;
+  font-size: 0.8125rem;
+  cursor: pointer;
+  font-variant-numeric: tabular-nums;
+  border-right: 1px solid var(--line);
+}
+
+.timeRange button:last-child {
+  border-right: 0;
+}
+
+.timeRange button:hover {
+  color: var(--text);
+  background: var(--panel-muted);
+}
+
+.timeRange button[data-active="true"] {
+  background: var(--accent-soft);
+  color: var(--accent-foreground);
+}
+
+.timeRange button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
+  outline-offset: -2px;
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.8125rem;
+  color: var(--muted-foreground);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  margin-left: auto;
+}
+
+.chipRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  min-width: 0;
+}
+
+.categoryChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--panel-bg);
+  color: var(--muted-foreground);
+  font-size: 0.8125rem;
+  font-family: ui-monospace, SFMono-Regular, "Cascadia Mono", Menlo, monospace;
+  cursor: pointer;
+  transition:
+    background-color 80ms ease-out,
+    color 80ms ease-out,
+    border-color 80ms ease-out;
+}
+
+.categoryChip::before {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--cat-color, currentColor);
+  flex: 0 0 auto;
+  opacity: 0.85;
+}
+
+.categoryChip[data-category="all"]::before {
+  background: var(--muted-foreground);
+}
+
+.categoryChip[data-category="session"] {
+  --cat-color: #3b82f6;
+}
+.categoryChip[data-category="turn"] {
+  --cat-color: #8b5cf6;
+}
+.categoryChip[data-category="model"] {
+  --cat-color: #14b8a6;
+}
+.categoryChip[data-category="tool"] {
+  --cat-color: #f97316;
+}
+.categoryChip[data-category="autonomy"] {
+  --cat-color: #f59e0b;
+}
+.categoryChip[data-category="authorization"],
+.categoryChip[data-category="approval"] {
+  --cat-color: #ef4444;
+}
+.categoryChip[data-category="a2a"] {
+  --cat-color: #ec4899;
+}
+
+.categoryChip:hover {
+  color: var(--text);
+  border-color: var(--line-strong);
+}
+
+.categoryChip[data-active="true"] {
+  color: var(--text);
+  background: color-mix(
+    in srgb,
+    var(--cat-color, var(--accent)) 14%,
+    transparent
+  );
+  border-color: color-mix(
+    in srgb,
+    var(--cat-color, var(--accent)) 50%,
+    var(--line)
+  );
+}
+
+.categoryChip:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
+  outline-offset: 2px;
+}
+
+.activeRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  font-size: 0.8125rem;
+  color: var(--muted-foreground);
+}
+
+.activeRow[data-empty="true"] {
+  display: none;
+}
+
+.activeChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 4px 2px 8px;
+  border-radius: var(--radius-sm);
+  background: var(--panel-muted);
+  border: 1px solid var(--line);
+  color: var(--text);
+  font-size: 0.8125rem;
+  font-family: ui-monospace, SFMono-Regular, "Cascadia Mono", Menlo, monospace;
+}
+
+.activeChip strong {
+  color: var(--muted-foreground);
+  font-weight: 500;
+}
+
+.activeChipRemove {
+  background: transparent;
+  border: 0;
+  color: var(--muted-foreground);
+  font-size: 0.95rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 3px;
+}
+
+.activeChipRemove:hover {
+  color: var(--text);
+  background: var(--panel-bg);
+}
+
+.activeChipRemove:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
+  outline-offset: 1px;
+}
+
+.clearAll {
+  background: transparent;
+  border: 0;
+  color: var(--muted-foreground);
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  font-size: 0.8125rem;
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, currentColor 30%, transparent);
+}
+
+.clearAll:hover {
+  color: var(--text);
+}
+
+.clearAll:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
+  outline-offset: 2px;
+}
+
+.tableWrap {
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--panel-bg);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.table thead th {
+  position: sticky;
+  top: 0;
+  background: var(--panel-muted);
+  z-index: 1;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--line);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted-foreground);
+  font-weight: 600;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.table tbody tr {
+  cursor: pointer;
+  transition: background-color 80ms ease-out;
+}
+
+.table tbody tr:hover {
+  background: color-mix(in srgb, var(--panel-muted) 60%, transparent);
+}
+
+.table tbody tr:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
+  outline-offset: -2px;
+}
+
+.table tbody tr[data-selected="true"] {
+  background: var(--accent-soft);
+  box-shadow: inset 2px 0 0 var(--primary);
+}
+
+.table tbody td {
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--line);
+  vertical-align: middle;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.colTime {
+  width: 1%;
+  color: var(--muted-foreground);
+}
+
+.colEvent {
+  width: 1%;
+}
+
+.colSession {
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.colSeq,
+.colId {
+  width: 1%;
+  text-align: right;
+  color: var(--muted-foreground);
+  font-family: ui-monospace, SFMono-Regular, "Cascadia Mono", Menlo, monospace;
+  font-size: 0.8125rem;
+}
+
+.colRun {
+  width: 1%;
+  color: var(--muted-foreground);
+  font-family: ui-monospace, SFMono-Regular, "Cascadia Mono", Menlo, monospace;
+  font-size: 0.8125rem;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mono {
+  font-family: ui-monospace, SFMono-Regular, "Cascadia Mono", Menlo, monospace;
+}
+
+.eventPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  font-size: 0.8125rem;
+  font-family: ui-monospace, SFMono-Regular, "Cascadia Mono", Menlo, monospace;
+  background: color-mix(in srgb, currentColor 10%, transparent);
+  color: var(--cat-color, var(--muted-foreground));
+  white-space: nowrap;
+}
+
+.eventPill::before {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: currentColor;
+  flex: 0 0 auto;
+}
+
+.eventPill[data-category="session"] {
+  --cat-color: #3b82f6;
+}
+
+.eventPill[data-category="turn"] {
+  --cat-color: #8b5cf6;
+}
+
+.eventPill[data-category="model"] {
+  --cat-color: #14b8a6;
+}
+
+.eventPill[data-category="tool"] {
+  --cat-color: #f97316;
+}
+
+.eventPill[data-category="autonomy"] {
+  --cat-color: #f59e0b;
+}
+
+.eventPill[data-category="authorization"],
+.eventPill[data-category="approval"] {
+  --cat-color: #ef4444;
+}
+
+.eventPill[data-category="a2a"] {
+  --cat-color: #ec4899;
+}
+
+.eventPill[data-category="default"] {
+  --cat-color: var(--muted-foreground);
+}
+
+.empty {
+  padding: 48px 24px;
+  text-align: center;
+  color: var(--muted-foreground);
+  font-size: 0.875rem;
+}
+
+.loadMoreRow {
+  display: flex;
+  justify-content: center;
+  padding: 16px 24px 24px;
+}
+
+.loadMore {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: var(--card);
+  color: var(--foreground);
+  border-radius: 8px;
+  padding: 8px 18px;
+  font: inherit;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition:
+    background-color 80ms ease,
+    border-color 80ms ease;
+}
+
+.loadMore:hover:not(:disabled) {
+  background: var(--accent);
+}
+
+.loadMore:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.loadMore:disabled {
+  cursor: progress;
+  opacity: 0.6;
+}
+
+/* Sheet drawer */
+.sheet {
+  --sheet-width: min(560px, 100vw);
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+}
+
+.sheetHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.sheetHeaderMain {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.sheetHeaderId {
+  font-size: 0.8rem;
+  color: var(--muted-foreground);
+  font-variant-numeric: tabular-nums;
+}
+
+.sheetClose {
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+
+.sheetClose:hover {
+  color: var(--text);
+  background: var(--panel-muted);
+}
+
+.sheetClose:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
+  outline-offset: 2px;
+}
+
+.sheetBody {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 16px 24px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.sheetMeta {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 8px 16px;
+  font-size: 0.8125rem;
+  margin: 0;
+}
+
+.sheetMeta dt {
+  color: var(--muted-foreground);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.7rem;
+  align-self: center;
+}
+
+.sheetMeta dd {
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+  word-break: break-all;
+  font-family: ui-monospace, SFMono-Regular, "Cascadia Mono", Menlo, monospace;
+  color: var(--text);
+}
+
+.payloadSection {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.payloadHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted-foreground);
+  font-weight: 600;
+}
+
+.payloadBlock {
+  margin: 0;
+  padding: 14px 16px;
+  background: var(--editor, var(--terminal));
+  color: var(--editor-foreground, var(--terminal-foreground));
+  border: 1px solid var(--editor-border, var(--line));
+  border-radius: var(--radius-md);
+  font-family: ui-monospace, SFMono-Regular, "Cascadia Mono", Menlo, monospace;
+  font-size: 0.8125rem;
+  line-height: 1.55;
+  overflow-x: auto;
+  white-space: pre;
+  tab-size: 2;
+}
+
+@media (max-width: 720px) {
+  .colSession {
+    max-width: 160px;
+  }
+  .colRun {
+    display: none;
+  }
+  .table thead th[data-col="run"] {
+    display: none;
+  }
+}

--- a/console/src/routes/audit.test.tsx
+++ b/console/src/routes/audit.test.tsx
@@ -111,6 +111,18 @@ describe('AuditPage', () => {
     expect(await screen.findByText('Loading audit entries…')).toBeTruthy();
   });
 
+  it('surfaces an error state with a retry when the audit query fails', async () => {
+    fetchAuditMock.mockRejectedValue(new Error('gateway exploded'));
+    renderWithProviders(<AuditPage />);
+    const retry = await screen.findByRole('button', { name: 'Retry' });
+    expect(retry).toBeTruthy();
+    // A failed fetch must not masquerade as an empty result.
+    expect(screen.queryByText('No audit entries match these filters.')).toBe(
+      null,
+    );
+    expect(screen.getByRole('alert').textContent).toContain('gateway exploded');
+  });
+
   it('seeds filters from the URL on mount', async () => {
     window.history.replaceState(
       null,

--- a/console/src/routes/audit.test.tsx
+++ b/console/src/routes/audit.test.tsx
@@ -1,0 +1,430 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AdminAuditEntry, AdminAuditResponse } from '../api/types';
+import { renderWithProviders } from '../test-utils';
+import { AuditPage } from './audit';
+
+type FetchAuditParams = {
+  query?: string;
+  sessionId?: string;
+  eventType?: string;
+  since?: string;
+  cursor?: number;
+  limit?: number;
+};
+const fetchAuditMock =
+  vi.fn<
+    (token: string, params: FetchAuditParams) => Promise<AdminAuditResponse>
+  >();
+const navigateMock = vi.fn();
+const useAuthMock = vi.fn();
+
+vi.mock('../api/client', () => ({
+  fetchAudit: (token: string, params: FetchAuditParams) =>
+    fetchAuditMock(token, params),
+}));
+
+vi.mock('../auth', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => navigateMock,
+  useSearch: () => {
+    const params = new URLSearchParams(window.location.search);
+    return {
+      q: params.get('q') ?? undefined,
+      range: params.get('range') ?? undefined,
+    };
+  },
+}));
+
+function makeEntry(overrides: Partial<AdminAuditEntry> = {}): AdminAuditEntry {
+  return {
+    id: 1,
+    sessionId: 'web:default',
+    seq: 1,
+    eventType: 'session.start',
+    timestamp: new Date(Date.now() - 60_000).toISOString(),
+    runId: 'run_abc',
+    parentRunId: null,
+    payload: '{"foo":"bar"}',
+    createdAt: '2026-05-23T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeResponse(
+  entries: AdminAuditEntry[],
+  nextCursor: number | null = null,
+): AdminAuditResponse {
+  return {
+    query: '',
+    sessionId: '',
+    eventType: '',
+    since: null,
+    until: null,
+    limit: 200,
+    entries,
+    nextCursor,
+  };
+}
+
+describe('AuditPage', () => {
+  beforeEach(() => {
+    fetchAuditMock.mockReset();
+    navigateMock.mockReset();
+    navigateMock.mockResolvedValue(undefined);
+    useAuthMock.mockReset();
+    useAuthMock.mockReturnValue({ token: 'test-token' });
+    window.history.replaceState(null, '', '/admin/audit');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders entries returned by the API', async () => {
+    fetchAuditMock.mockResolvedValue(
+      makeResponse([
+        makeEntry({ id: 100, eventType: 'tool.call', sessionId: 'web:a' }),
+        makeEntry({ id: 101, eventType: 'tool.result', sessionId: 'web:a' }),
+      ]),
+    );
+    renderWithProviders(<AuditPage />);
+    expect(await screen.findByText('#100')).toBeTruthy();
+    expect(screen.getByText('#101')).toBeTruthy();
+    expect(screen.getByText('2 events')).toBeTruthy();
+  });
+
+  it('shows an empty state when no entries match', async () => {
+    fetchAuditMock.mockResolvedValue(makeResponse([]));
+    renderWithProviders(<AuditPage />);
+    expect(
+      await screen.findByText('No audit entries match these filters.'),
+    ).toBeTruthy();
+  });
+
+  it('shows a loading message while the query is in flight', async () => {
+    fetchAuditMock.mockReturnValue(new Promise(() => {}));
+    renderWithProviders(<AuditPage />);
+    expect(await screen.findByText('Loading audit entries…')).toBeTruthy();
+  });
+
+  it('seeds filters from the URL on mount', async () => {
+    window.history.replaceState(
+      null,
+      '',
+      '/admin/audit?q=type%3Atool&range=24h',
+    );
+    fetchAuditMock.mockResolvedValue(makeResponse([]));
+    renderWithProviders(<AuditPage />);
+    const input =
+      await screen.findByLabelText<HTMLInputElement>('Audit search');
+    expect(input.value).toBe('type:tool');
+    expect(
+      screen.getByRole('button', { name: '24h', pressed: true }),
+    ).toBeTruthy();
+  });
+
+  it('calls fetchAudit with parsed tokens from the search input', async () => {
+    fetchAuditMock.mockResolvedValue(makeResponse([]));
+    renderWithProviders(<AuditPage />);
+    const input = await screen.findByLabelText('Audit search');
+    fireEvent.change(input, {
+      target: { value: 'session:web type:tool error' },
+    });
+    await waitFor(() => {
+      expect(fetchAuditMock).toHaveBeenCalledWith(
+        'test-token',
+        expect.objectContaining({
+          query: 'error',
+          sessionId: 'web',
+          eventType: 'tool',
+          limit: 200,
+        }),
+      );
+    });
+  });
+
+  it('writes the search input to the URL via navigate', async () => {
+    fetchAuditMock.mockResolvedValue(makeResponse([]));
+    renderWithProviders(<AuditPage />);
+    const input = await screen.findByLabelText('Audit search');
+    fireEvent.change(input, { target: { value: 'type:tool' } });
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: '/admin/audit',
+          search: { q: 'type:tool', range: undefined },
+          replace: true,
+        }),
+      );
+    });
+  });
+
+  it('pushes the time range to the server as `since` and updates the URL', async () => {
+    fetchAuditMock.mockResolvedValue(makeResponse([]));
+    renderWithProviders(<AuditPage />);
+    await screen.findByText('0 events');
+    fetchAuditMock.mockClear();
+
+    fireEvent.click(screen.getByRole('button', { name: '1h' }));
+
+    await waitFor(() => {
+      const calls = fetchAuditMock.mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      const lastParams = calls[calls.length - 1]?.[1];
+      expect(lastParams?.since).toBeTruthy();
+      // since ≈ now − 1h; cheap sanity check that it's a sub-1h-old ISO ts.
+      expect(Date.now() - Date.parse(lastParams?.since ?? '')).toBeGreaterThan(
+        59 * 60_000,
+      );
+    });
+    expect(navigateMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        search: { q: undefined, range: '1h' },
+      }),
+    );
+  });
+
+  it('IntersectionObserver auto-fetches the next page when the sentinel enters view', async () => {
+    // Regression guard: an earlier iteration tore the observer down on every
+    // `isFetchingNextPage` flip, so the async initial IO callback never landed
+    // and auto-fetch silently never fired. This test stubs IO with a trigger
+    // we control to assert the fetch path is wired end-to-end.
+    const observerCallbacks: Array<
+      (entries: Array<{ isIntersecting: boolean }>) => void
+    > = [];
+    class StubIntersectionObserver {
+      constructor(
+        callback: (entries: Array<{ isIntersecting: boolean }>) => void,
+      ) {
+        observerCallbacks.push(callback);
+      }
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    }
+    vi.stubGlobal('IntersectionObserver', StubIntersectionObserver);
+
+    try {
+      fetchAuditMock.mockResolvedValueOnce(
+        makeResponse(
+          [makeEntry({ id: 300, eventType: 'tool.call' })],
+          /* nextCursor */ 299,
+        ),
+      );
+      renderWithProviders(<AuditPage />);
+      await screen.findByText('#300');
+
+      fetchAuditMock.mockResolvedValueOnce(
+        makeResponse([makeEntry({ id: 250, eventType: 'tool.result' })], null),
+      );
+
+      // Fire the most recent observer as if the sentinel scrolled into view.
+      expect(observerCallbacks.length).toBeGreaterThan(0);
+      observerCallbacks.at(-1)?.([{ isIntersecting: true }]);
+
+      await waitFor(() => {
+        expect(screen.getByText('#250')).toBeTruthy();
+      });
+      const calls = fetchAuditMock.mock.calls;
+      expect(calls.at(-1)?.[1]).toMatchObject({ cursor: 299 });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('Load more fetches the next page and appends rows', async () => {
+    fetchAuditMock.mockResolvedValueOnce(
+      makeResponse(
+        [
+          makeEntry({ id: 200, eventType: 'tool.call' }),
+          makeEntry({ id: 199, eventType: 'tool.result' }),
+        ],
+        /* nextCursor */ 199,
+      ),
+    );
+    renderWithProviders(<AuditPage />);
+    await screen.findByText('#200');
+    expect(screen.getByText('#199')).toBeTruthy();
+    expect(screen.queryByText('#150')).toBeNull();
+
+    fetchAuditMock.mockResolvedValueOnce(
+      makeResponse([makeEntry({ id: 150, eventType: 'session.start' })], null),
+    );
+    fireEvent.click(await screen.findByRole('button', { name: 'Load more' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('#150')).toBeTruthy();
+    });
+    // First two rows still rendered; pagination appends rather than replaces.
+    expect(screen.getByText('#200')).toBeTruthy();
+    // Cursor was passed back to the server on the second call.
+    const calls = fetchAuditMock.mock.calls;
+    expect(calls[calls.length - 1]?.[1]).toMatchObject({ cursor: 199 });
+    // No more pages → button disappears.
+    expect(screen.queryByRole('button', { name: 'Load more' })).toBeNull();
+  });
+
+  it('category chip click writes a type: token into the search', async () => {
+    fetchAuditMock.mockResolvedValue(makeResponse([]));
+    renderWithProviders(<AuditPage />);
+    fireEvent.click(await screen.findByRole('button', { name: 'tool' }));
+    const input = screen.getByLabelText<HTMLInputElement>('Audit search');
+    await waitFor(() => {
+      expect(input.value).toBe('type:tool');
+    });
+    expect(
+      screen.getByRole('button', { name: 'tool', pressed: true }),
+    ).toBeTruthy();
+  });
+
+  it('clicking the active category chip clears the type filter', async () => {
+    window.history.replaceState(null, '', '/admin/audit?q=type%3Atool');
+    fetchAuditMock.mockResolvedValue(makeResponse([]));
+    renderWithProviders(<AuditPage />);
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'tool', pressed: true }),
+    );
+    await waitFor(() => {
+      const input = screen.getByLabelText<HTMLInputElement>('Audit search');
+      expect(input.value).toBe('');
+    });
+  });
+
+  it('row click opens the inspector drawer', async () => {
+    fetchAuditMock.mockResolvedValue(
+      makeResponse([
+        makeEntry({ id: 42, eventType: 'tool.result', payload: '{"ok":true}' }),
+      ]),
+    );
+    renderWithProviders(<AuditPage />);
+    fireEvent.click(
+      await screen.findByRole('button', { name: /Inspect audit event 42/ }),
+    );
+    expect(await screen.findByText(/"ok": true/)).toBeTruthy();
+  });
+
+  it('drawer body survives a filter change that refetches different entries', async () => {
+    fetchAuditMock.mockResolvedValueOnce(
+      makeResponse([
+        makeEntry({ id: 42, eventType: 'tool.result', payload: '{"a":1}' }),
+      ]),
+    );
+    renderWithProviders(<AuditPage />);
+    fireEvent.click(
+      await screen.findByRole('button', { name: /Inspect audit event 42/ }),
+    );
+    expect(await screen.findByText(/"a": 1/)).toBeTruthy();
+
+    fetchAuditMock.mockResolvedValue(
+      makeResponse([
+        makeEntry({ id: 99, eventType: 'session.start', payload: '{"b":2}' }),
+      ]),
+    );
+    fireEvent.change(screen.getByLabelText('Audit search'), {
+      target: { value: 'type:session' },
+    });
+    await waitFor(() => {
+      expect(screen.getByText('#99')).toBeTruthy();
+    });
+    // Drawer still shows event 42's payload, not blank.
+    expect(screen.getByText(/"a": 1/)).toBeTruthy();
+  });
+
+  it('active-filter chip × strips that token from the search', async () => {
+    window.history.replaceState(
+      null,
+      '',
+      '/admin/audit?q=session%3Aweb+type%3Atool',
+    );
+    fetchAuditMock.mockResolvedValue(makeResponse([]));
+    renderWithProviders(<AuditPage />);
+    fireEvent.click(
+      await screen.findByRole('button', { name: /Remove session filter web/ }),
+    );
+    await waitFor(() => {
+      const input = screen.getByLabelText<HTMLInputElement>('Audit search');
+      expect(input.value).toBe('type:tool');
+    });
+  });
+
+  it('Clear all resets search and time range', async () => {
+    window.history.replaceState(
+      null,
+      '',
+      '/admin/audit?q=type%3Atool&range=24h',
+    );
+    fetchAuditMock.mockResolvedValue(makeResponse([]));
+    renderWithProviders(<AuditPage />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Clear all' }));
+    await waitFor(() => {
+      const input = screen.getByLabelText<HTMLInputElement>('Audit search');
+      expect(input.value).toBe('');
+    });
+    expect(
+      screen.getByRole('button', { name: 'All', pressed: true }),
+    ).toBeTruthy();
+  });
+
+  it('"/" focuses the search input from outside an input', async () => {
+    fetchAuditMock.mockResolvedValue(makeResponse([]));
+    renderWithProviders(<AuditPage />);
+    const input =
+      await screen.findByLabelText<HTMLInputElement>('Audit search');
+    expect(document.activeElement).not.toBe(input);
+    fireEvent.keyDown(window, { key: '/' });
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('"/" is ignored when typed inside an input', async () => {
+    fetchAuditMock.mockResolvedValue(makeResponse([]));
+    renderWithProviders(<AuditPage />);
+    const input =
+      await screen.findByLabelText<HTMLInputElement>('Audit search');
+    // Focus another input-like element so the shortcut would normally fire.
+    // Use a separate input we add ad-hoc.
+    const probe = document.createElement('input');
+    document.body.appendChild(probe);
+    probe.focus();
+    fireEvent.keyDown(probe, { key: '/' });
+    expect(document.activeElement).toBe(probe);
+    expect(document.activeElement).not.toBe(input);
+    probe.remove();
+  });
+
+  it('skips redundant navigate() when state already matches the URL on mount', async () => {
+    window.history.replaceState(null, '', '/admin/audit?q=type%3Atool');
+    fetchAuditMock.mockResolvedValue(makeResponse([]));
+    renderWithProviders(<AuditPage />);
+    await screen.findByDisplayValue('type:tool');
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('aria-pressed reflects the active category and time range', async () => {
+    window.history.replaceState(
+      null,
+      '',
+      '/admin/audit?q=type%3Atool&range=7d',
+    );
+    fetchAuditMock.mockResolvedValue(makeResponse([]));
+    renderWithProviders(<AuditPage />);
+    expect(
+      await screen.findByRole('button', { name: 'tool', pressed: true }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: 'session', pressed: false }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: 'all', pressed: false }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: '7d', pressed: true }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: 'All', pressed: false }),
+    ).toBeTruthy();
+  });
+});

--- a/console/src/routes/audit.tsx
+++ b/console/src/routes/audit.tsx
@@ -20,7 +20,8 @@ import {
   SheetHeader,
   SheetTitle,
 } from '../components/sheet';
-import { formatDateTime, formatRelativeTime } from '../lib/format';
+import { getErrorMessage } from '../lib/error-message';
+import { formatDateTime, formatRelativeTime, pluralize } from '../lib/format';
 import { logNavigationError } from '../lib/navigation';
 import { isOneOf } from '../lib/oneof';
 import styles from './audit.module.css';
@@ -283,7 +284,9 @@ export function AuditPage() {
           <div className={styles.meta} aria-live="polite">
             {auditQuery.isLoading
               ? 'Loading…'
-              : `${entries.length} event${entries.length === 1 ? '' : 's'}`}
+              : auditQuery.isError
+                ? 'Failed to load'
+                : pluralize(entries.length, 'event')}
           </div>
         </div>
 
@@ -438,9 +441,25 @@ export function AuditPage() {
         </table>
         {entries.length === 0 ? (
           <div className={styles.empty}>
-            {auditQuery.isLoading
-              ? 'Loading audit entries…'
-              : 'No audit entries match these filters.'}
+            {auditQuery.isLoading ? (
+              'Loading audit entries…'
+            ) : auditQuery.isError ? (
+              <span className={styles.emptyError} role="alert">
+                Couldn't load audit events — {getErrorMessage(auditQuery.error)}
+                .{' '}
+                <button
+                  type="button"
+                  className={styles.retry}
+                  onClick={() => {
+                    void auditQuery.refetch();
+                  }}
+                >
+                  Retry
+                </button>
+              </span>
+            ) : (
+              'No audit entries match these filters.'
+            )}
           </div>
         ) : null}
         {auditQuery.hasNextPage ? (
@@ -453,7 +472,11 @@ export function AuditPage() {
               }}
               disabled={auditQuery.isFetchingNextPage}
             >
-              {auditQuery.isFetchingNextPage ? 'Loading…' : 'Load more'}
+              {auditQuery.isFetchingNextPage
+                ? 'Loading…'
+                : auditQuery.isFetchNextPageError
+                  ? 'Retry'
+                  : 'Load more'}
             </button>
           </div>
         ) : null}

--- a/console/src/routes/audit.tsx
+++ b/console/src/routes/audit.tsx
@@ -1,16 +1,45 @@
-import { useQuery } from '@tanstack/react-query';
-import { useDeferredValue, useEffect, useState } from 'react';
-import { fetchAudit } from '../api/client';
-import { useAuth } from '../auth';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useNavigate, useSearch } from '@tanstack/react-router';
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '../components/card';
-import { PageHeader } from '../components/ui';
+  type KeyboardEvent as ReactKeyboardEvent,
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { fetchAudit } from '../api/client';
+import type { AdminAuditEntry } from '../api/types';
+import { useAuth } from '../auth';
+import { Search as SearchIcon } from '../components/icons';
+import { Input } from '../components/input';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '../components/sheet';
 import { formatDateTime, formatRelativeTime } from '../lib/format';
+import { logNavigationError } from '../lib/navigation';
+import { isOneOf } from '../lib/oneof';
+import styles from './audit.module.css';
+import {
+  CATEGORIES,
+  type Category,
+  categorize,
+  rangeToSince,
+  readRange,
+  TIME_RANGES,
+  type TimeRange,
+} from './audit-filters';
+import {
+  parseAuditSearch,
+  removeAuditField,
+  setAuditField,
+} from './audit-search';
+
+const PAGE_SIZE = 200;
 
 function prettifyPayload(raw: string): string {
   try {
@@ -20,176 +49,495 @@ function prettifyPayload(raw: string): string {
   }
 }
 
+type AuditSearchParams = { q: string | undefined; range: string | undefined };
+
 export function AuditPage() {
   const auth = useAuth();
-  const [query, setQuery] = useState('');
-  const [sessionId, setSessionId] = useState('');
-  const [eventType, setEventType] = useState('');
-  const [selectedId, setSelectedId] = useState<number | null>(null);
-  const deferredQuery = useDeferredValue(query);
-  const deferredSessionId = useDeferredValue(sessionId);
-  const deferredEventType = useDeferredValue(eventType);
+  const navigate = useNavigate();
+  const search = useSearch({ strict: false }) as AuditSearchParams;
+  const initialQ = search.q ?? '';
+  const initialRange = readRange(search.range);
 
-  const auditQuery = useQuery({
+  const [searchInput, setSearchInput] = useState(initialQ);
+  const [range, setRange] = useState<TimeRange>(initialRange);
+  const [selectedEntry, setSelectedEntry] = useState<AdminAuditEntry | null>(
+    null,
+  );
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const loadMoreRef = useRef<HTMLDivElement>(null);
+  const lastSyncedQ = useRef<string | undefined>(search.q);
+  const lastSyncedRange = useRef<string | undefined>(search.range);
+
+  // Parse eagerly for UI (chips, active-filter row). The queryKey gets
+  // the deferred values below so typing doesn't refetch on every keystroke.
+  const parsed = useMemo(() => parseAuditSearch(searchInput), [searchInput]);
+  const deferredQuery = useDeferredValue(parsed.query);
+  const deferredSessionId = useDeferredValue(parsed.sessionId);
+  const deferredEventType = useDeferredValue(parsed.eventType);
+
+  // state → URL. Gates off `lastSynced*` refs instead of `search.*` so an
+  // external URL change (back/forward) handled by the URL→state effect
+  // below doesn't trip this one into navigating back to the stale value.
+  useEffect(() => {
+    const nextQ = searchInput.trim() || undefined;
+    const nextRange = range === 'all' ? undefined : range;
+    if (
+      nextQ === lastSyncedQ.current &&
+      nextRange === lastSyncedRange.current
+    ) {
+      return;
+    }
+    lastSyncedQ.current = nextQ;
+    lastSyncedRange.current = nextRange;
+    void navigate({
+      to: '/admin/audit',
+      search: { q: nextQ, range: nextRange },
+      replace: true,
+    }).catch(logNavigationError);
+  }, [navigate, searchInput, range]);
+
+  // URL → state: re-seed when the URL changes for any reason other than
+  // our own write (back/forward navigation, deep link). Updates the refs
+  // so the state→URL effect treats the new value as already-synced.
+  useEffect(() => {
+    if (search.q !== lastSyncedQ.current) {
+      lastSyncedQ.current = search.q;
+      setSearchInput(search.q ?? '');
+    }
+    if (search.range !== lastSyncedRange.current) {
+      lastSyncedRange.current = search.range;
+      setRange(readRange(search.range));
+    }
+  }, [search.q, search.range]);
+
+  // Global `/` shortcut to focus the search input.
+  useEffect(() => {
+    function handler(event: KeyboardEvent): void {
+      if (event.key !== '/' || event.metaKey || event.ctrlKey || event.altKey) {
+        return;
+      }
+      const target = event.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) {
+        return;
+      }
+      event.preventDefault();
+      searchRef.current?.focus();
+      searchRef.current?.select();
+    }
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  // Cutoff is computed at render time and baked into the queryKey below.
+  // For an idle admin page this is fine; any user interaction (filter
+  // change, scroll-triggered fetchNextPage) re-renders and refreshes it.
+  const since = useMemo(() => rangeToSince(range), [range]);
+
+  const auditQuery = useInfiniteQuery({
     queryKey: [
       'audit',
       auth.token,
       deferredQuery,
       deferredSessionId,
       deferredEventType,
+      since,
     ],
-    queryFn: () =>
+    initialPageParam: undefined as number | undefined,
+    queryFn: ({ pageParam }) =>
       fetchAudit(auth.token, {
         query: deferredQuery,
         sessionId: deferredSessionId,
         eventType: deferredEventType,
-        limit: 100,
+        since,
+        cursor: pageParam,
+        limit: PAGE_SIZE,
       }),
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
   });
 
-  const selectedEntry =
-    auditQuery.data?.entries.find((entry) => entry.id === selectedId) ||
-    auditQuery.data?.entries[0] ||
-    null;
-
+  // Auto-fetch the next page when the sentinel near the bottom enters view.
+  // The Load more button remains as the keyboard/screen-reader fallback and
+  // as the visible loading indicator while a fetch is in flight.
+  //
+  // Only `hasNextPage` is in the deps: re-attaching the observer on every
+  // `isFetchingNextPage` flip would tear it down before the async initial
+  // callback ever landed, silently breaking auto-fetch. The callback reads
+  // the latest state via a ref instead.
+  const auditQueryRef = useRef(auditQuery);
+  auditQueryRef.current = auditQuery;
   useEffect(() => {
-    if (!selectedEntry) return;
-    if (selectedEntry.id !== selectedId) {
-      setSelectedId(selectedEntry.id);
+    const sentinel = loadMoreRef.current;
+    if (!sentinel || !auditQuery.hasNextPage) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        const q = auditQueryRef.current;
+        if (entry?.isIntersecting && q.hasNextPage && !q.isFetchingNextPage) {
+          void q.fetchNextPage();
+        }
+      },
+      { rootMargin: '400px' },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [auditQuery.hasNextPage]);
+
+  const entries = useMemo<AdminAuditEntry[]>(
+    () => auditQuery.data?.pages.flatMap((page) => page.entries) ?? [],
+    [auditQuery.data],
+  );
+
+  const activeCategory: Category | null = useMemo(() => {
+    const v = parsed.eventType;
+    return v && isOneOf(CATEGORIES, v) ? v : null;
+  }, [parsed.eventType]);
+
+  const hasAnyFilter = Boolean(
+    parsed.query || parsed.sessionId || parsed.eventType || range !== 'all',
+  );
+
+  function openEntry(entry: AdminAuditEntry): void {
+    setSelectedEntry(entry);
+    setDrawerOpen(true);
+  }
+
+  function handleRowKeyDown(
+    event: ReactKeyboardEvent<HTMLTableRowElement>,
+    entry: AdminAuditEntry,
+  ): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      openEntry(entry);
     }
-  }, [selectedEntry, selectedId]);
+  }
+
+  const toggleCategory = useCallback((category: Category | null) => {
+    setSearchInput((current) => {
+      if (category === null) return removeAuditField(current, 'type');
+      const next = parseAuditSearch(current).eventType;
+      if (next === category) return removeAuditField(current, 'type');
+      return setAuditField(current, 'type', category);
+    });
+  }, []);
+
+  function removeSessionFilter(): void {
+    setSearchInput((current) => removeAuditField(current, 'session'));
+  }
+
+  function removeTypeFilter(): void {
+    setSearchInput((current) => removeAuditField(current, 'type'));
+  }
+
+  function clearAll(): void {
+    setSearchInput('');
+    setRange('all');
+  }
 
   return (
-    <div className="page-stack">
-      <PageHeader title="Audit Log" />
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Filters</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="field-grid">
-            <label className="field">
-              <span>Search</span>
-              <input
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                placeholder="approval, tool, error"
-              />
-            </label>
-            <label className="field">
-              <span>Session ID</span>
-              <input
-                value={sessionId}
-                onChange={(event) => setSessionId(event.target.value)}
-                placeholder="web:default"
-              />
-            </label>
-          </div>
-          <label className="field">
-            <span>Event type</span>
-            <input
-              value={eventType}
-              onChange={(event) => setEventType(event.target.value)}
-              placeholder="approval.response"
+    <div className={styles.page}>
+      <div className={styles.toolbar}>
+        <div className={styles.searchRow}>
+          <div className={styles.searchWrap}>
+            <SearchIcon className={styles.searchIcon} aria-hidden="true" />
+            <Input
+              ref={searchRef}
+              className={styles.searchInput}
+              value={searchInput}
+              onChange={(event) => setSearchInput(event.target.value)}
+              placeholder="Search payloads… try session:web type:tool"
+              aria-label="Audit search"
+              spellCheck={false}
+              autoComplete="off"
             />
-          </label>
-        </CardContent>
-      </Card>
+            <span
+              className={styles.shortcutHint}
+              data-hidden={searchInput ? 'true' : undefined}
+              aria-hidden="true"
+            >
+              /
+            </span>
+          </div>
 
-      <div className="two-column-grid">
-        <Card>
-          <CardHeader>
-            <CardTitle>Entries</CardTitle>
-            <CardDescription>
-              {`${auditQuery.data?.entries.length || 0} matching event${auditQuery.data?.entries.length === 1 ? '' : 's'}`}
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            {auditQuery.isLoading ? (
-              <div className="empty-state">Loading audit entries...</div>
-            ) : auditQuery.data?.entries.length ? (
-              <div className="list-stack selectable-list">
-                {auditQuery.data.entries.map((entry) => (
-                  <button
-                    key={entry.id}
-                    className={
-                      entry.id === selectedEntry?.id
-                        ? 'selectable-row active'
-                        : 'selectable-row'
-                    }
-                    type="button"
-                    onClick={() => setSelectedId(entry.id)}
-                  >
-                    <div>
-                      <strong>{entry.eventType}</strong>
-                      <small>
-                        {entry.sessionId} ·{' '}
-                        {formatRelativeTime(entry.timestamp)}
-                      </small>
-                    </div>
-                    <span>#{entry.id}</span>
-                  </button>
-                ))}
-              </div>
-            ) : (
-              <div className="empty-state">
-                No audit entries match these filters.
-              </div>
-            )}
-          </CardContent>
-        </Card>
+          <div
+            className={styles.timeRange}
+            role="toolbar"
+            aria-label="Time range"
+          >
+            {TIME_RANGES.map((option) => {
+              const active = range === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  aria-pressed={active}
+                  data-active={active || undefined}
+                  onClick={() => setRange(option.value)}
+                >
+                  {option.label}
+                </button>
+              );
+            })}
+          </div>
 
-        <div className="sticky-detail">
-          <Card variant="muted">
-            <CardHeader>
-              <CardTitle>Inspection</CardTitle>
-            </CardHeader>
-            <CardContent>
-              {!selectedEntry ? (
-                <div className="empty-state">
-                  Select an audit event to inspect it.
-                </div>
-              ) : (
-                <div className="detail-stack">
-                  <div className="key-value-grid">
-                    <div>
-                      <span>Event type</span>
-                      <strong>{selectedEntry.eventType}</strong>
-                    </div>
-                    <div>
-                      <span>Session</span>
-                      <strong>{selectedEntry.sessionId}</strong>
-                    </div>
-                    <div>
-                      <span>Timestamp</span>
-                      <strong>{formatDateTime(selectedEntry.timestamp)}</strong>
-                    </div>
-                    <div>
-                      <span>Run ID</span>
-                      <strong>{selectedEntry.runId}</strong>
-                    </div>
-                    <div>
-                      <span>Seq</span>
-                      <strong>{selectedEntry.seq}</strong>
-                    </div>
-                    <div>
-                      <span>Parent run</span>
-                      <strong>{selectedEntry.parentRunId || 'none'}</strong>
-                    </div>
-                  </div>
-                  <div className="summary-block">
-                    <span>Payload</span>
-                    <pre className="payload-block">
-                      {prettifyPayload(selectedEntry.payload)}
-                    </pre>
-                  </div>
-                </div>
-              )}
-            </CardContent>
-          </Card>
+          <div className={styles.meta} aria-live="polite">
+            {auditQuery.isLoading
+              ? 'Loading…'
+              : `${entries.length} event${entries.length === 1 ? '' : 's'}`}
+          </div>
+        </div>
+
+        <div
+          className={styles.chipRow}
+          role="toolbar"
+          aria-label="Event category"
+        >
+          <button
+            type="button"
+            className={styles.categoryChip}
+            data-category="all"
+            aria-pressed={activeCategory === null}
+            data-active={activeCategory === null || undefined}
+            onClick={() => toggleCategory(null)}
+          >
+            all
+          </button>
+          {CATEGORIES.map((category) => {
+            const active = activeCategory === category;
+            return (
+              <button
+                key={category}
+                type="button"
+                className={styles.categoryChip}
+                data-category={category}
+                aria-pressed={active}
+                data-active={active || undefined}
+                onClick={() => toggleCategory(category)}
+              >
+                {category}
+              </button>
+            );
+          })}
+        </div>
+
+        <div
+          className={styles.activeRow}
+          data-empty={hasAnyFilter ? undefined : 'true'}
+          aria-live="polite"
+        >
+          {parsed.sessionId ? (
+            <span className={styles.activeChip}>
+              <strong>session:</strong>
+              {parsed.sessionId}
+              <button
+                type="button"
+                className={styles.activeChipRemove}
+                aria-label={`Remove session filter ${parsed.sessionId}`}
+                onClick={removeSessionFilter}
+              >
+                ×
+              </button>
+            </span>
+          ) : null}
+          {parsed.eventType ? (
+            <span className={styles.activeChip}>
+              <strong>type:</strong>
+              {parsed.eventType}
+              <button
+                type="button"
+                className={styles.activeChipRemove}
+                aria-label={`Remove event type filter ${parsed.eventType}`}
+                onClick={removeTypeFilter}
+              >
+                ×
+              </button>
+            </span>
+          ) : null}
+          {range !== 'all' ? (
+            <span className={styles.activeChip}>
+              <strong>last:</strong>
+              {range}
+              <button
+                type="button"
+                className={styles.activeChipRemove}
+                aria-label="Reset time range"
+                onClick={() => setRange('all')}
+              >
+                ×
+              </button>
+            </span>
+          ) : null}
+          {hasAnyFilter ? (
+            <button
+              type="button"
+              className={styles.clearAll}
+              onClick={clearAll}
+            >
+              Clear all
+            </button>
+          ) : null}
         </div>
       </div>
+
+      <div className={styles.tableWrap}>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th scope="col">Time</th>
+              <th scope="col">Event</th>
+              <th scope="col">Session</th>
+              <th scope="col" data-col="run">
+                Run
+              </th>
+              <th scope="col" className={styles.colSeq}>
+                Seq
+              </th>
+              <th scope="col" className={styles.colId}>
+                ID
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map((entry) => {
+              const category = categorize(entry.eventType);
+              const isSelected = entry.id === selectedEntry?.id;
+              return (
+                // biome-ignore lint/a11y/useSemanticElements: a <tr> must remain a <tr> to stay inside <tbody>; role=button + keyboard handlers preserve the click-to-inspect affordance.
+                <tr
+                  key={entry.id}
+                  role="button"
+                  tabIndex={0}
+                  data-selected={isSelected || undefined}
+                  aria-label={`Inspect audit event ${entry.id} (${entry.eventType})`}
+                  onClick={() => openEntry(entry)}
+                  onKeyDown={(event) => handleRowKeyDown(event, entry)}
+                >
+                  <td
+                    className={styles.colTime}
+                    title={formatDateTime(entry.timestamp)}
+                  >
+                    {formatRelativeTime(entry.timestamp)}
+                  </td>
+                  <td className={styles.colEvent}>
+                    <span className={styles.eventPill} data-category={category}>
+                      {entry.eventType}
+                    </span>
+                  </td>
+                  <td className={styles.colSession} title={entry.sessionId}>
+                    <span className={styles.mono}>{entry.sessionId}</span>
+                  </td>
+                  <td className={styles.colRun} title={entry.runId}>
+                    {entry.runId}
+                  </td>
+                  <td className={styles.colSeq}>{entry.seq}</td>
+                  <td className={styles.colId}>#{entry.id}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+        {entries.length === 0 ? (
+          <div className={styles.empty}>
+            {auditQuery.isLoading
+              ? 'Loading audit entries…'
+              : 'No audit entries match these filters.'}
+          </div>
+        ) : null}
+        {auditQuery.hasNextPage ? (
+          <div ref={loadMoreRef} className={styles.loadMoreRow}>
+            <button
+              type="button"
+              className={styles.loadMore}
+              onClick={() => {
+                void auditQuery.fetchNextPage();
+              }}
+              disabled={auditQuery.isFetchingNextPage}
+            >
+              {auditQuery.isFetchingNextPage ? 'Loading…' : 'Load more'}
+            </button>
+          </div>
+        ) : null}
+      </div>
+
+      <Sheet open={drawerOpen} onOpenChange={setDrawerOpen}>
+        <SheetContent side="right" className={styles.sheet}>
+          <SheetHeader>
+            <SheetTitle>
+              {selectedEntry
+                ? `Audit event #${selectedEntry.id} (${selectedEntry.eventType})`
+                : 'Audit event'}
+            </SheetTitle>
+          </SheetHeader>
+          {/*
+            `selectedEntry` is deliberately retained while the sheet animates
+            closed, and across filter changes that refetch a different result
+            set — see the "drawer body survives a filter change" regression
+            test. Clearing it on close would blank the body mid-exit-animation.
+          */}
+          {selectedEntry ? (
+            <AuditInspector
+              entry={selectedEntry}
+              onClose={() => setDrawerOpen(false)}
+            />
+          ) : null}
+        </SheetContent>
+      </Sheet>
     </div>
+  );
+}
+
+function AuditInspector({
+  entry,
+  onClose,
+}: {
+  entry: AdminAuditEntry;
+  onClose: () => void;
+}) {
+  return (
+    <>
+      <div className={styles.sheetHeader}>
+        <div className={styles.sheetHeaderMain}>
+          <span
+            className={styles.eventPill}
+            data-category={categorize(entry.eventType)}
+          >
+            {entry.eventType}
+          </span>
+          <span className={styles.sheetHeaderId}>
+            #{entry.id} · {formatDateTime(entry.timestamp)}
+          </span>
+        </div>
+        <button
+          type="button"
+          className={styles.sheetClose}
+          aria-label="Close inspector"
+          onClick={onClose}
+        >
+          ×
+        </button>
+      </div>
+      <div className={styles.sheetBody}>
+        <dl className={styles.sheetMeta}>
+          <dt>Session</dt>
+          <dd>{entry.sessionId}</dd>
+          <dt>Run ID</dt>
+          <dd>{entry.runId}</dd>
+          <dt>Parent run</dt>
+          <dd>{entry.parentRunId || '—'}</dd>
+          <dt>Seq</dt>
+          <dd>{entry.seq}</dd>
+          <dt>Timestamp</dt>
+          <dd>{formatDateTime(entry.timestamp)}</dd>
+        </dl>
+        <section className={styles.payloadSection}>
+          <div className={styles.payloadHeader}>
+            <span>Payload</span>
+          </div>
+          <pre className={styles.payloadBlock}>
+            {prettifyPayload(entry.payload)}
+          </pre>
+        </section>
+      </div>
+    </>
   );
 }

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -4704,6 +4704,10 @@ async function handleApiAdminMcp(
 function handleApiAdminAudit(res: ServerResponse, url: URL): void {
   const parsedLimit = parseInt(url.searchParams.get('limit') || '60', 10);
   const limit = Number.isNaN(parsedLimit) ? 60 : parsedLimit;
+  const rawCursor = url.searchParams.get('cursor');
+  const parsedCursor = rawCursor ? parseInt(rawCursor, 10) : Number.NaN;
+  const cursor =
+    Number.isFinite(parsedCursor) && parsedCursor > 0 ? parsedCursor : 0;
   sendJson(
     res,
     200,
@@ -4711,6 +4715,9 @@ function handleApiAdminAudit(res: ServerResponse, url: URL): void {
       query: url.searchParams.get('query') || '',
       sessionId: url.searchParams.get('sessionId') || '',
       eventType: url.searchParams.get('eventType') || '',
+      since: url.searchParams.get('since') || '',
+      until: url.searchParams.get('until') || '',
+      cursor,
       limit,
     }),
   );

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -4708,6 +4708,22 @@ function handleApiAdminAudit(res: ServerResponse, url: URL): void {
   const parsedCursor = rawCursor ? parseInt(rawCursor, 10) : Number.NaN;
   const cursor =
     Number.isFinite(parsedCursor) && parsedCursor > 0 ? parsedCursor : 0;
+  const since = url.searchParams.get('since') || '';
+  const until = url.searchParams.get('until') || '';
+  // since/until feed a lexicographic timestamp comparison in SQL. Reject
+  // unparseable input rather than silently returning the wrong slice of the
+  // audit log — there's no sensible default to coerce a bad timestamp to.
+  for (const [name, value] of [
+    ['since', since],
+    ['until', until],
+  ] as const) {
+    if (value && Number.isNaN(Date.parse(value))) {
+      sendJson(res, 400, {
+        error: `\`${name}\` must be an ISO-8601 timestamp.`,
+      });
+      return;
+    }
+  }
   sendJson(
     res,
     200,
@@ -4715,8 +4731,8 @@ function handleApiAdminAudit(res: ServerResponse, url: URL): void {
       query: url.searchParams.get('query') || '',
       sessionId: url.searchParams.get('sessionId') || '',
       eventType: url.searchParams.get('eventType') || '',
-      since: url.searchParams.get('since') || '',
-      until: url.searchParams.get('until') || '',
+      since,
+      until,
       cursor,
       limit,
     }),

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -5748,25 +5748,49 @@ export function getGatewayAdminAudit(params?: {
   query?: string;
   sessionId?: string;
   eventType?: string;
+  since?: string;
+  until?: string;
+  cursor?: number;
   limit?: number;
 }): GatewayAdminAuditResponse {
   const query = String(params?.query || '').trim();
   const sessionId = String(params?.sessionId || '').trim();
   const eventType = String(params?.eventType || '').trim();
+  const since = String(params?.since || '').trim();
+  const until = String(params?.until || '').trim();
+  const cursor =
+    typeof params?.cursor === 'number' && Number.isFinite(params.cursor)
+      ? Math.max(0, Math.floor(params.cursor))
+      : 0;
   const limit = Math.max(1, Math.min(params?.limit ?? 60, 200));
+
+  // Fetch one extra row so we can detect a next page without a separate count.
+  // `maxLimit` must also be lifted past the default 200 cap, or the +1 row gets
+  // silently clamped away and `hasMore` is wrong at the page boundary.
+  const rows = listStructuredAuditEntries({
+    query,
+    sessionId,
+    eventType,
+    eventTypeMatch: 'prefix',
+    since: since || undefined,
+    until: until || undefined,
+    beforeId: cursor > 0 ? cursor : undefined,
+    limit: limit + 1,
+    maxLimit: limit + 1,
+  });
+  const hasMore = rows.length > limit;
+  const page = hasMore ? rows.slice(0, limit) : rows;
+  const nextCursor = hasMore ? (page[page.length - 1]?.id ?? null) : null;
 
   return {
     query,
     sessionId,
     eventType,
+    since: since || null,
+    until: until || null,
     limit,
-    entries: listStructuredAuditEntries({
-      query,
-      sessionId,
-      eventType,
-      eventTypeMatch: 'prefix',
-      limit,
-    }).map(mapAdminAuditEntry),
+    entries: page.map(mapAdminAuditEntry),
+    nextCursor,
   };
 }
 

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -1220,8 +1220,12 @@ export interface GatewayAdminAuditResponse {
   query: string;
   sessionId: string;
   eventType: string;
+  since: string | null;
+  until: string | null;
   limit: number;
   entries: GatewayAdminAuditEntry[];
+  /** Opaque cursor for the next page; pass back as `cursor=`. null when this is the last page. */
+  nextCursor: number | null;
 }
 
 export interface GatewayAdminApprovalAgent {

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -148,7 +148,7 @@ let databaseInitialized = false;
 let usageEventBatchInsertStatement: Database.Statement | null = null;
 const usageRecordSubscribers = new Set<UsageRecordSubscriber>();
 
-export const DATABASE_SCHEMA_VERSION = 37;
+export const DATABASE_SCHEMA_VERSION = 38;
 const AGENT_CANONICAL_ID_COLLISION_LIMIT = 20;
 const DEFAULT_LOCAL_OWNER_USER_ID = formatLocalOwnerUserId('');
 const STRUCTURED_AUDIT_SESSION_LIMIT = 10_000;
@@ -2662,6 +2662,33 @@ function migrateV37(database: Database.Database): void {
   recordMigration(database, 37, 'Persist typed board card dependency edges');
 }
 
+function auditTimestampIndexNeedMigration(
+  database: Database.Database,
+): boolean {
+  return (
+    tableExists(database, 'audit_events') &&
+    !indexExists(database, 'idx_audit_events_timestamp')
+  );
+}
+
+function migrateV38(database: Database.Database): void {
+  // Lets the admin audit list seek by timestamp (range pills) and id
+  // (cursor paging) when there's no event_type/session predicate to lean
+  // on; without it the query table-scans audit_events. Added as its own
+  // migration (not folded into migrateV1) so existing databases — which
+  // never re-run migrateV1 — actually pick the index up.
+  if (tableExists(database, 'audit_events')) {
+    database.exec(
+      'CREATE INDEX IF NOT EXISTS idx_audit_events_timestamp ON audit_events(timestamp)',
+    );
+  }
+  recordMigration(
+    database,
+    38,
+    'Index audit_events(timestamp) for admin audit range + cursor paging',
+  );
+}
+
 function runMigrations(
   database: Database.Database,
   opts?: InitDatabaseOptions,
@@ -2748,6 +2775,9 @@ function runMigrations(
   }
   if (currentVersion < 37 || boardCardEdgesNeedMigration(database)) {
     migrateV37(database);
+  }
+  if (currentVersion < 38 || auditTimestampIndexNeedMigration(database)) {
+    migrateV38(database);
   }
 
   setSchemaVersion(database, DATABASE_SCHEMA_VERSION);
@@ -9576,6 +9606,9 @@ function queryStructuredAuditEntries(params?: {
   eventType?: string;
   eventTypeMatch?: 'exact' | 'prefix';
   query?: string;
+  since?: string;
+  until?: string;
+  beforeId?: number;
   limit?: number;
   maxLimit?: number;
   orderBy?: 'id' | 'seq';
@@ -9584,6 +9617,12 @@ function queryStructuredAuditEntries(params?: {
   const sessionId = String(params?.sessionId || '').trim();
   const eventType = String(params?.eventType || '').trim();
   const query = String(params?.query || '').trim();
+  const since = String(params?.since || '').trim();
+  const until = String(params?.until || '').trim();
+  const beforeId =
+    typeof params?.beforeId === 'number' && Number.isFinite(params.beforeId)
+      ? Math.max(0, Math.floor(params.beforeId))
+      : 0;
   const orderBy = params?.orderBy === 'seq' ? 'seq' : 'id';
   const sortDirection = params?.sortDirection === 'ASC' ? 'ASC' : 'DESC';
   ensureDatabaseReady();
@@ -9610,6 +9649,18 @@ function queryStructuredAuditEntries(params?: {
       '(event_type LIKE ? OR payload LIKE ? OR session_id LIKE ? OR run_id LIKE ?)',
     );
     values.push(like, like, like, like);
+  }
+  if (since) {
+    clauses.push('timestamp >= ?');
+    values.push(since);
+  }
+  if (until) {
+    clauses.push('timestamp <= ?');
+    values.push(until);
+  }
+  if (beforeId > 0) {
+    clauses.push('id < ?');
+    values.push(beforeId);
   }
 
   const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
@@ -9737,14 +9788,22 @@ export function listStructuredAuditEntries(params?: {
   eventType?: string;
   eventTypeMatch?: 'exact' | 'prefix';
   query?: string;
+  since?: string;
+  until?: string;
+  beforeId?: number;
   limit?: number;
+  maxLimit?: number;
 }): StructuredAuditEntry[] {
   return queryStructuredAuditEntries({
     sessionId: params?.sessionId,
     eventType: params?.eventType,
     eventTypeMatch: params?.eventTypeMatch,
     query: params?.query,
+    since: params?.since,
+    until: params?.until,
+    beforeId: params?.beforeId,
     limit: params?.limit ?? 50,
+    maxLimit: params?.maxLimit,
     orderBy: 'id',
     sortDirection: 'DESC',
   });

--- a/tests/audit-timestamp-index-migration.test.ts
+++ b/tests/audit-timestamp-index-migration.test.ts
@@ -1,0 +1,70 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterEach, expect, test, vi } from 'vitest';
+
+let tempDir: string | null = null;
+const ORIGINAL_HOME = process.env.HOME;
+
+afterEach(() => {
+  vi.resetModules();
+  if (ORIGINAL_HOME === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = ORIGINAL_HOME;
+  }
+  if (tempDir) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  }
+});
+
+function auditTimestampIndex(dbPath: string): { name: string } | undefined {
+  const database = new Database(dbPath, { readonly: true });
+  try {
+    return database
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?",
+      )
+      .get('idx_audit_events_timestamp') as { name: string } | undefined;
+  } finally {
+    database.close();
+  }
+}
+
+// Regression guard: the timestamp index lives in migrateV38, NOT migrateV1.
+// migrateV1 only runs on a brand-new (v0) database, so an index added there
+// would never reach the existing deployments that need it. This test proves
+// a database that predates V38 picks the index up on the next boot.
+test('migrateV38 adds idx_audit_events_timestamp to a pre-V38 database', async () => {
+  tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-audit-index-migration-'),
+  );
+  process.env.HOME = tempDir;
+  const dbPath = path.join(tempDir, 'hybridclaw.db');
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+
+  // 1. Build a complete, current-schema database.
+  initDatabase({ quiet: true, dbPath });
+  expect(auditTimestampIndex(dbPath)).toEqual({
+    name: 'idx_audit_events_timestamp',
+  });
+
+  // 2. Simulate a database created before migrateV38: drop the index and
+  //    roll user_version back one step so the next boot re-runs migrations.
+  const downgrade = new Database(dbPath);
+  downgrade.prepare('DROP INDEX IF EXISTS idx_audit_events_timestamp').run();
+  downgrade.pragma('user_version = 37');
+  downgrade.close();
+  expect(auditTimestampIndex(dbPath)).toBeUndefined();
+
+  // 3. Re-initialise, as a fresh process boot would.
+  initDatabase({ quiet: true, dbPath });
+
+  // 4. The index is back even though migrateV1 never re-runs.
+  expect(auditTimestampIndex(dbPath)).toEqual({
+    name: 'idx_audit_events_timestamp',
+  });
+});

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -1282,8 +1282,11 @@ async function importFreshHealth(options?: {
     query: '',
     sessionId: '',
     eventType: '',
+    since: null,
+    until: null,
     limit: 60,
     entries: [],
+    nextCursor: null,
   }));
   const getGatewayAdminApprovals = vi.fn(() => ({
     selectedAgentId: 'main',
@@ -6586,8 +6589,46 @@ describe('gateway HTTP server', () => {
       limit: 25,
       query: 'approval',
       sessionId: 's1',
+      since: '',
+      until: '',
+      cursor: 0,
     });
     expect(res.statusCode).toBe(200);
+  });
+
+  test('forwards since/until/cursor pagination params on admin audit requests', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({
+      url: '/api/admin/audit?since=2026-05-01T00:00:00.000Z&until=2026-05-23T00:00:00.000Z&cursor=512&limit=50',
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.getGatewayAdminAudit).toHaveBeenCalledWith({
+      eventType: '',
+      limit: 50,
+      query: '',
+      sessionId: '',
+      since: '2026-05-01T00:00:00.000Z',
+      until: '2026-05-23T00:00:00.000Z',
+      cursor: 512,
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  test('admin audit `cursor` defaults to 0 when missing or non-positive', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({ url: '/api/admin/audit?cursor=-1' });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.getGatewayAdminAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ cursor: 0 }),
+    );
   });
 
   test('returns pending approvals and policy state for authorized API requests', async () => {

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -6631,6 +6631,19 @@ describe('gateway HTTP server', () => {
     );
   });
 
+  test('admin audit rejects an unparseable since/until with 400', async () => {
+    const state = await importFreshHealth();
+    const res = makeResponse();
+    state.handler(
+      makeRequest({ url: '/api/admin/audit?since=not-a-date' }) as never,
+      res as never,
+    );
+    await settle();
+    expect(res.statusCode).toBe(400);
+    // A bad timestamp must not silently return the wrong slice of the log.
+    expect(state.getGatewayAdminAudit).not.toHaveBeenCalled();
+  });
+
   test('returns pending approvals and policy state for authorized API requests', async () => {
     const state = await importFreshHealth();
     const req = makeRequest({ url: '/api/admin/approvals?agentId=writer' });

--- a/tests/gateway-service.audit.test.ts
+++ b/tests/gateway-service.audit.test.ts
@@ -147,6 +147,123 @@ test('admin audit event type filter supports partial type-ahead matches', async 
   ]);
 });
 
+test('admin audit returns nextCursor and paginates back via the cursor', async () => {
+  setupHome();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { makeAuditRunId, recordAuditEvent } = await import(
+    '../src/audit/audit-events.ts'
+  );
+
+  initDatabase({ quiet: true });
+  for (let i = 0; i < 5; i += 1) {
+    recordAuditEvent({
+      sessionId: 'session-pagination',
+      runId: makeAuditRunId('test'),
+      event: { type: 'tool.result', toolName: `t${i}`, isError: false },
+    });
+  }
+
+  const { getGatewayAdminAudit } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  const firstPage = getGatewayAdminAudit({
+    sessionId: 'session-pagination',
+    limit: 2,
+  });
+  expect(firstPage.entries).toHaveLength(2);
+  expect(firstPage.nextCursor).toBe(firstPage.entries[1]?.id);
+
+  const secondPage = getGatewayAdminAudit({
+    sessionId: 'session-pagination',
+    limit: 2,
+    cursor: firstPage.nextCursor ?? undefined,
+  });
+  expect(secondPage.entries).toHaveLength(2);
+  // Cursor advances: second page's newest id < first page's oldest id.
+  expect(secondPage.entries[0]?.id).toBeLessThan(firstPage.nextCursor ?? 0);
+  expect(secondPage.nextCursor).toBe(secondPage.entries[1]?.id);
+
+  const lastPage = getGatewayAdminAudit({
+    sessionId: 'session-pagination',
+    limit: 2,
+    cursor: secondPage.nextCursor ?? undefined,
+  });
+  expect(lastPage.entries).toHaveLength(1);
+  expect(lastPage.nextCursor).toBeNull();
+});
+
+test('admin audit returns nextCursor when limit equals the DB maxLimit cap', async () => {
+  // Regression: queryStructuredAuditEntries has its own maxLimit (default 200)
+  // that silently clamped the +1 hasMore probe back to 200, leaving nextCursor
+  // permanently null at the page boundary. getGatewayAdminAudit must lift the
+  // cap when paginating.
+  setupHome();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { makeAuditRunId, recordAuditEvent } = await import(
+    '../src/audit/audit-events.ts'
+  );
+
+  initDatabase({ quiet: true });
+  for (let i = 0; i < 201; i += 1) {
+    recordAuditEvent({
+      sessionId: 'session-boundary',
+      runId: makeAuditRunId('test'),
+      event: { type: 'tool.result', toolName: `t${i}`, isError: false },
+    });
+  }
+
+  const { getGatewayAdminAudit } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+  const page = getGatewayAdminAudit({
+    sessionId: 'session-boundary',
+    limit: 200,
+  });
+  expect(page.entries).toHaveLength(200);
+  expect(page.nextCursor).not.toBeNull();
+  expect(page.nextCursor).toBe(page.entries[199]?.id);
+});
+
+test('admin audit since filter excludes entries before the cutoff', async () => {
+  setupHome();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { makeAuditRunId, recordAuditEvent } = await import(
+    '../src/audit/audit-events.ts'
+  );
+
+  initDatabase({ quiet: true });
+  recordAuditEvent({
+    sessionId: 'session-since',
+    runId: makeAuditRunId('test'),
+    event: { type: 'tool.result', toolName: 'bash', isError: false },
+  });
+
+  const { getGatewayAdminAudit } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  // A cutoff in the far future excludes every just-inserted row.
+  const future = getGatewayAdminAudit({
+    sessionId: 'session-since',
+    since: '2099-01-01T00:00:00.000Z',
+    limit: 10,
+  });
+  expect(future.entries).toHaveLength(0);
+  expect(future.since).toBe('2099-01-01T00:00:00.000Z');
+
+  // A cutoff in the distant past includes them.
+  const past = getGatewayAdminAudit({
+    sessionId: 'session-since',
+    since: '1970-01-01T00:00:00.000Z',
+    limit: 10,
+  });
+  expect(past.entries).toHaveLength(1);
+});
+
 test('bot set records a structured audit event for observability export', async () => {
   setupHome();
   const userId = 'u'.repeat(200);


### PR DESCRIPTION
**Stack 3 of 4** — base: `split/console-form-migration` (#1092)

Reworks the admin audit view into a dense log explorer backed by a new keyset-paginated gateway API. Backend + frontend kept together since the frontend is unusable without the API.

### Gateway / DB
- `getGatewayAdminAudit` gains `since`/`until`/`cursor` params and returns `nextCursor` (fetches `limit+1` to detect the next page without a separate count)
- `listStructuredAuditEntries` supports `since`/`until`/`beforeId` predicates
- **schema v38**: index `audit_events(timestamp)` for range + cursor seeks (its own migration so existing DBs pick it up)

### Console
- audit route: smart-search filter parsing, range pills, URL sync, infinite scroll via `useInfiniteQuery` + the new `nextCursor`
- `audit-filters` / `audit-search` helpers (+ tests), `audit.module.css`
- `fetchAudit` sends `since`/`until`/`cursor`; `AdminAuditResponse` carries `since`/`until`/`nextCursor`; router validates `?q` / `?range`

### Validation
console `tsc --noEmit` ✅ · 44 audit frontend tests ✅ · 273 gateway/migration backend tests ✅

> Depends on the form primitives (#1091) for `Input`/`oneof`. Stacked on #1092 only for a clean diff — no functional dependency on the route migration. Review after #1091/#1092.