### PR TITLE
refactor(console): drop PageHeader title prop, derive title from nav

### DIFF
--- a/console/src/components/ui.tsx
+++ b/console/src/components/ui.tsx
@@ -94,7 +94,6 @@ export function SortableHeader<Key extends string>(props: {
 }
 
 export function PageHeader(props: {
-  title?: string;
   description?: ReactNode;
   actions?: ReactNode;
 }) {

--- a/console/src/routes/a2a-inbox.tsx
+++ b/console/src/routes/a2a-inbox.tsx
@@ -75,7 +75,7 @@ export function A2AInboxPage() {
 
   return (
     <div className="page-stack">
-      <PageHeader title="A2A Inbox" />
+      <PageHeader />
       <div className="mailbox-shell a2a-inbox-shell">
         <section className="mailbox-main">
           <div className="mailbox-column-header">

--- a/console/src/routes/agent-scoreboard.tsx
+++ b/console/src/routes/agent-scoreboard.tsx
@@ -102,10 +102,7 @@ export function AgentsPage() {
 
   return (
     <div className="page-stack">
-      <PageHeader
-        title="Agents"
-        description="Review agent skill track records, top strengths, and generated CV paths."
-      />
+      <PageHeader description="Review agent skill track records, top strengths, and generated CV paths." />
 
       <div className="metric-grid">
         <MetricCard

--- a/console/src/routes/dashboard.test.tsx
+++ b/console/src/routes/dashboard.test.tsx
@@ -1,8 +1,7 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AdminOverview, AdminTunnelStatus } from '../api/types';
-import { ToastProvider } from '../components/toast';
+import { renderWithProviders } from '../test-utils';
 import { DashboardPage } from './dashboard';
 
 const fetchOverviewMock = vi.fn();
@@ -97,20 +96,7 @@ function makeOverview(
 }
 
 function renderDashboardPage(): void {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false },
-      mutations: { retry: false },
-    },
-  });
-
-  render(
-    <QueryClientProvider client={queryClient}>
-      <ToastProvider>
-        <DashboardPage />
-      </ToastProvider>
-    </QueryClientProvider>,
-  );
+  renderWithProviders(<DashboardPage />);
 }
 
 describe('DashboardPage', () => {

--- a/console/src/routes/dashboard.tsx
+++ b/console/src/routes/dashboard.tsx
@@ -246,7 +246,7 @@ export function DashboardPage() {
 
   return (
     <div className="page-stack">
-      <PageHeader title="Dashboard" />
+      <PageHeader />
 
       <div className="metric-grid">
         <MetricCard

--- a/console/src/routes/email.test.tsx
+++ b/console/src/routes/email.test.tsx
@@ -1,5 +1,4 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   AdminEmailDeleteResponse,
@@ -7,7 +6,7 @@ import type {
   AdminEmailMailboxResponse,
   AdminEmailMessageResponse,
 } from '../api/types';
-import { ToastProvider } from '../components/toast';
+import { renderWithProviders } from '../test-utils';
 import { EmailPage } from './email';
 
 const fetchAdminEmailMailboxMock =
@@ -90,23 +89,10 @@ function makeMailboxResponse(): AdminEmailMailboxResponse {
 }
 
 function renderEmailPage(options?: { emailEnabled?: boolean }): void {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false },
-      mutations: { retry: false },
-    },
-  });
   useAppShellConfigMock.mockReturnValue({
     emailEnabled: options?.emailEnabled ?? true,
   });
-
-  render(
-    <QueryClientProvider client={queryClient}>
-      <ToastProvider>
-        <EmailPage />
-      </ToastProvider>
-    </QueryClientProvider>,
-  );
+  renderWithProviders(<EmailPage />);
 }
 
 describe('EmailPage', () => {

--- a/console/src/routes/email.tsx
+++ b/console/src/routes/email.tsx
@@ -485,7 +485,6 @@ export function EmailPage() {
     return (
       <div className="page-stack">
         <PageHeader
-          title="Email"
           description="Enable the email channel to surface a mailbox view here."
           actions={
             <button
@@ -527,7 +526,6 @@ export function EmailPage() {
   return (
     <div className="page-stack">
       <PageHeader
-        title="Email"
         actions={
           <input
             className="compact-search"

--- a/console/src/routes/gateway.test.tsx
+++ b/console/src/routes/gateway.test.tsx
@@ -1,14 +1,6 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import {
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-  within,
-} from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ToastProvider } from '../components/toast';
-
+import { renderWithProviders } from '../test-utils';
 import { GatewayPage } from './gateway';
 
 const reloadGatewayMock = vi.fn();
@@ -85,20 +77,7 @@ function makeStatus(overrides: Record<string, unknown> = {}) {
 }
 
 function renderGatewayPage(): void {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false },
-      mutations: { retry: false },
-    },
-  });
-
-  render(
-    <QueryClientProvider client={queryClient}>
-      <ToastProvider>
-        <GatewayPage />
-      </ToastProvider>
-    </QueryClientProvider>,
-  );
+  renderWithProviders(<GatewayPage />);
 }
 
 describe('GatewayPage', () => {

--- a/console/src/routes/gateway.tsx
+++ b/console/src/routes/gateway.tsx
@@ -54,7 +54,6 @@ export function GatewayPage() {
   return (
     <div className="page-stack">
       <PageHeader
-        title="Gateway"
         actions={
           <button
             type="button"

--- a/console/src/routes/jobs.test.tsx
+++ b/console/src/routes/jobs.test.tsx
@@ -1,11 +1,4 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import {
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-  within,
-} from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   AdminJobCard,
@@ -13,7 +6,7 @@ import type {
   AdminSchedulerResponse,
   JobSession,
 } from '../api/types';
-import { ToastProvider } from '../components/toast';
+import { renderWithProviders } from '../test-utils';
 import { JobsPage } from './jobs';
 
 const fetchBoardBudgetSummariesMock = vi.fn();
@@ -133,19 +126,7 @@ function makeJobSession(overrides: Partial<JobSession> = {}): JobSession {
 }
 
 function renderJobsPage(): void {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false },
-      mutations: { retry: false },
-    },
-  });
-  render(
-    <QueryClientProvider client={queryClient}>
-      <ToastProvider>
-        <JobsPage />
-      </ToastProvider>
-    </QueryClientProvider>,
-  );
+  renderWithProviders(<JobsPage />);
 }
 
 describe('JobsPage', () => {

--- a/console/src/routes/jobs.tsx
+++ b/console/src/routes/jobs.tsx
@@ -1026,7 +1026,6 @@ export function JobsPage() {
   return (
     <div className="page-stack">
       <PageHeader
-        title={`Kanban Board (${visibleItems.length} task${visibleItems.length === 1 ? '' : 's'})`}
         actions={
           <div className="header-actions">
             <input

--- a/console/src/routes/jobs.tsx
+++ b/console/src/routes/jobs.tsx
@@ -1026,6 +1026,9 @@ export function JobsPage() {
   return (
     <div className="page-stack">
       <PageHeader
+        description={`${visibleItems.length} task${
+          visibleItems.length === 1 ? '' : 's'
+        }`}
         actions={
           <div className="header-actions">
             <input

--- a/console/src/routes/plugins.tsx
+++ b/console/src/routes/plugins.tsx
@@ -116,7 +116,6 @@ export function PluginsPage() {
   return (
     <div className="page-stack">
       <PageHeader
-        title="Plugins"
         description="Discovery and runtime load status for configured HybridClaw plugins."
         actions={
           <input

--- a/console/src/routes/sessions.tsx
+++ b/console/src/routes/sessions.tsx
@@ -112,7 +112,6 @@ export function SessionsPage() {
   return (
     <div className="page-stack">
       <PageHeader
-        title="Sessions"
         actions={
           <input
             className="compact-search"

--- a/console/src/routes/statistics.tsx
+++ b/console/src/routes/statistics.tsx
@@ -67,7 +67,7 @@ export function StatisticsPage() {
   if (statisticsQuery.isLoading && !statistics) {
     return (
       <div className="page-stack">
-        <PageHeader title="Statistics" actions={rangeSelect} />
+        <PageHeader actions={rangeSelect} />
         <div className="empty-state">Loading statistics…</div>
       </div>
     );
@@ -76,7 +76,7 @@ export function StatisticsPage() {
   if (statisticsQuery.isError && !statistics) {
     return (
       <div className="page-stack">
-        <PageHeader title="Statistics" actions={rangeSelect} />
+        <PageHeader actions={rangeSelect} />
         <div className="empty-state error">
           {getErrorMessage(statisticsQuery.error)}
         </div>
@@ -87,7 +87,7 @@ export function StatisticsPage() {
   if (!statistics || !totals) {
     return (
       <div className="page-stack">
-        <PageHeader title="Statistics" actions={rangeSelect} />
+        <PageHeader actions={rangeSelect} />
         <div className="empty-state">No statistics available.</div>
       </div>
     );
@@ -98,7 +98,6 @@ export function StatisticsPage() {
   return (
     <div className="page-stack">
       <PageHeader
-        title="Statistics"
         description={`Activity across the last ${pluralize(statistics.rangeDays, 'day')} (${rangeDescription}).`}
         actions={rangeSelect}
       />

--- a/console/src/routes/terminal.tsx
+++ b/console/src/routes/terminal.tsx
@@ -290,7 +290,6 @@ export function TerminalPage() {
   return (
     <div className="page-stack terminal-page">
       <PageHeader
-        title="Terminal"
         actions={
           <div className="button-row">
             <span className="status-pill">

--- a/console/src/routes/tools.tsx
+++ b/console/src/routes/tools.tsx
@@ -157,7 +157,6 @@ export function ToolsPage() {
   return (
     <div className="page-stack">
       <PageHeader
-        title="Tools"
         actions={
           <input
             className="compact-search"


### PR DESCRIPTION
**Stack 4 of 4** — base: `split/admin-audit-explorer` (#1093)

`PageHeader` never rendered its `title` (the title comes from route nav), so this removes the now-unused prop and stops every route passing it. This is the cleanup that closes out the optional-title transition introduced in #1091.

### What's here
- `PageHeader`: remove `title`; `description` accepts `ReactNode`
- Drop `title=` from `a2a-inbox`, `agent-scoreboard`, `dashboard`, `email`, `gateway`, `jobs`, `plugins`, `sessions`, `statistics`, `terminal`, `tools`
- Migrate the touched `dashboard`/`email`/`gateway`/`jobs` tests to `renderWithProviders`

### Validation
`tsc --noEmit` ✅ · `biome lint console/src` ✅ · 16 route tests ✅

> Final PR in the stack. Once all four merge, the tree is identical to the original combined branch (verified with `git diff`).