### PR TITLE
[codex] Skip idle heartbeat agent runs

### DIFF
--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -285,7 +285,10 @@ import {
   previewGatewayAdminOutputGuardProfile,
   updateGatewayAdminOutputGuardProfile,
 } from './output-guard-admin.js';
-import { isSupportedProactiveChannelId } from './proactive-delivery.js';
+import {
+  isSupportedProactiveChannelId,
+  shouldSuppressProactiveMessage,
+} from './proactive-delivery.js';
 import { renderQrSvg } from './qr-svg.js';
 import {
   handleTextChannelApprovalCommand,
@@ -3676,7 +3679,9 @@ function handleApiProactivePull(res: ServerResponse, url: URL): void {
   }
   const parsedLimit = parseInt(url.searchParams.get('limit') || '20', 10);
   const limit = Number.isNaN(parsedLimit) ? 20 : parsedLimit;
-  const messages = claimQueuedProactiveMessages(channelId, limit);
+  const messages = claimQueuedProactiveMessages(channelId, limit).filter(
+    (message) => !shouldSuppressProactiveMessage(message),
+  );
   sendJson(res, 200, { channelId, messages });
 }
 

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -223,6 +223,7 @@ import {
   isSupportedProactiveChannelId,
   resolveHeartbeatDeliveryChannelId,
   shouldDropQueuedProactiveMessage,
+  shouldSuppressProactiveMessage,
 } from './proactive-delivery.js';
 import {
   normalizeSessionShowMode,
@@ -859,6 +860,11 @@ async function deliverProactiveMessage(
   source: string,
   artifacts?: ArtifactMetadata[],
 ): Promise<void> {
+  if (shouldSuppressProactiveMessage({ source, text })) {
+    logger.debug({ source, channelId }, 'Proactive message suppressed');
+    return;
+  }
+
   if (!isWithinActiveHours()) {
     if (PROACTIVE_QUEUE_OUTSIDE_HOURS) {
       const { queued, dropped } = enqueueProactiveMessage(
@@ -1309,11 +1315,12 @@ async function flushQueuedProactiveMessages(): Promise<void> {
   let droppedUndeliverable = 0;
   for (const item of pending) {
     if (!isWithinActiveHours()) break;
+    if (shouldDropQueuedProactiveMessage(item)) {
+      deleteQueuedProactiveMessage(item.id);
+      droppedUndeliverable += 1;
+      continue;
+    }
     if (!isSupportedProactiveChannelId(item.channel_id)) {
-      if (shouldDropQueuedProactiveMessage(item)) {
-        deleteQueuedProactiveMessage(item.id);
-        droppedUndeliverable += 1;
-      }
       continue;
     }
     await sendProactiveMessageNow(

--- a/src/gateway/proactive-delivery.ts
+++ b/src/gateway/proactive-delivery.ts
@@ -49,9 +49,29 @@ export function resolveHeartbeatDeliveryChannelId(params: {
   return params.lastUsedChannelId;
 }
 
+export function isHeartbeatOkText(text: string): boolean {
+  const normalized = text
+    .trim()
+    .replace(/[^a-z]/gi, '')
+    .toUpperCase();
+  return normalized === 'HEARTBEATOK' || normalized.startsWith('HEARTBEATOK');
+}
+
+export function shouldSuppressProactiveMessage(
+  item: Pick<QueuedProactiveMessage, 'source' | 'text'>,
+): boolean {
+  return item.source === 'heartbeat' && isHeartbeatOkText(item.text);
+}
+
 export function shouldDropQueuedProactiveMessage(
-  item: Pick<QueuedProactiveMessage, 'channel_id' | 'source'>,
+  item: Pick<QueuedProactiveMessage, 'channel_id' | 'source'> &
+    Partial<Pick<QueuedProactiveMessage, 'text'>>,
 ): boolean {
   if (!hasQueuedProactiveDeliveryPath(item)) return true;
+  if (
+    item.text != null &&
+    shouldSuppressProactiveMessage({ source: item.source, text: item.text })
+  )
+    return true;
   return item.source === 'heartbeat' && item.channel_id === 'heartbeat';
 }

--- a/src/scheduler/heartbeat.ts
+++ b/src/scheduler/heartbeat.ts
@@ -27,6 +27,7 @@ import {
   formatCoworkerLivenessPage,
   getCoworkerLivenessSummary,
 } from '../gateway/coworker-liveness.js';
+import { isHeartbeatOkText } from '../gateway/proactive-delivery.js';
 import { agentWorkspaceDir } from '../infra/ipc.js';
 import { logger } from '../logger.js';
 import { getAllJobs } from '../memory/jobs.js';
@@ -40,6 +41,7 @@ import { buildSessionKey } from '../session/session-key.js';
 import { maybeCompactSession } from '../session/session-maintenance.js';
 import { appendSessionTranscript } from '../session/session-transcripts.js';
 import { runPeriodicSkillInspection } from '../skills/skills-inspection.js';
+import { hasActionableHeartbeatFile } from '../workspace.js';
 import {
   buildModelUsageAuditStats,
   recordModelUsageAuditEvent,
@@ -90,14 +92,6 @@ let livenessPagingTimer: ReturnType<typeof setInterval> | null = null;
 let heartbeatRunning = false;
 let livenessPagingRunning = false;
 const lastPagedLivenessStateByAgent = new Map<string, string>();
-
-function isHeartbeatOk(text: string): boolean {
-  const normalized = text
-    .trim()
-    .replace(/[^a-z]/gi, '')
-    .toUpperCase();
-  return normalized === 'HEARTBEATOK' || normalized.startsWith('HEARTBEATOK');
-}
 
 async function pageRedCoworkerLivenessTransitions(
   onMessage: (text: string) => void,
@@ -184,6 +178,14 @@ export function startHeartbeat(
         logger.debug(
           { activeHours: proactiveWindowLabel() },
           'Heartbeat skipped — outside active hours window',
+        );
+        return;
+      }
+
+      if (!hasActionableHeartbeatFile(agentId)) {
+        logger.debug(
+          { agentId },
+          'Heartbeat skipped — no actionable HEARTBEAT.md',
         );
         return;
       }
@@ -359,7 +361,7 @@ export function startHeartbeat(
 
       const result = (output.result || '').trim();
 
-      if (isHeartbeatOk(result)) {
+      if (isHeartbeatOkText(result)) {
         logger.debug('Heartbeat: HEARTBEAT_OK — nothing to do');
         recordAuditEvent({
           sessionId,

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -40,6 +40,7 @@ import {
   saveGatewayAdminSkillEnabled,
 } from './gateway/gateway-client.js';
 import type { GatewayAdminSuspendedSession } from './gateway/gateway-types.js';
+import { shouldSuppressProactiveMessage } from './gateway/proactive-delivery.js';
 import {
   DEFAULT_SESSION_SHOW_MODE,
   isSessionShowMode,
@@ -3381,16 +3382,20 @@ async function pollProactiveMessages(
       TUI_PROACTIVE_PULL_LIMIT,
     );
     if (!Array.isArray(result.messages) || result.messages.length === 0) return;
+    const messages = result.messages.filter(
+      (message) => !shouldSuppressProactiveMessage(message),
+    );
+    if (messages.length === 0) return;
 
     clearTuiSlashMenu();
-    const regularMessages = result.messages.filter(
+    const regularMessages = messages.filter(
       (message) =>
         !isDelegateStatusMessage(message.text) ||
         isDelegateStreamSource(message.source),
     );
     let latestDelegateStatus: GatewayProactiveMessage | undefined;
-    for (let idx = result.messages.length - 1; idx >= 0; idx -= 1) {
-      const message = result.messages[idx];
+    for (let idx = messages.length - 1; idx >= 0; idx -= 1) {
+      const message = messages[idx];
       if (message && isDelegateStatusMessage(message.text)) {
         latestDelegateStatus = message;
         break;

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1,6 +1,6 @@
 /**
  * Workspace bootstrap files — loads SOUL.md, IDENTITY.md, USER.md,
- * TOOLS.md, MEMORY.md, HEARTBEAT.md from the agent workspace
+ * TOOLS.md, MEMORY.md, customized HEARTBEAT.md from the agent workspace
  * and injects them into the system prompt (like OpenClaw).
  */
 import fs from 'node:fs';
@@ -80,6 +80,10 @@ audit:
 
 const MAX_FILE_CHARS = 20_000;
 const TEMPLATES_DIR = resolveInstallPath('templates');
+const templateFileCache = new Map<
+  (typeof WORKSPACE_BOOTSTRAP_FILES)[number],
+  string
+>();
 
 /**
  * Directory (inside the agent container image) where runtime node_modules
@@ -180,8 +184,13 @@ function writeWorkspaceOnboardingState(
 function readTemplateFile(
   filename: (typeof WORKSPACE_BOOTSTRAP_FILES)[number],
 ): string {
+  const cached = templateFileCache.get(filename);
+  if (cached != null) return cached;
+
   const templatePath = path.join(TEMPLATES_DIR, filename);
-  return fs.readFileSync(templatePath, 'utf-8');
+  const content = fs.readFileSync(templatePath, 'utf-8');
+  templateFileCache.set(filename, content);
+  return content;
 }
 
 function stripMarkdownSection(content: string, heading: string): string {
@@ -220,6 +229,32 @@ function normalizeContextFileContent(params: {
   return content;
 }
 
+function normalizeBootstrapComparisonText(content: string): string {
+  return content.replace(/\r\n/g, '\n').trim();
+}
+
+function shouldLoadBootstrapContextFile(params: {
+  name: (typeof WORKSPACE_BOOTSTRAP_FILES)[number];
+  content: string;
+}): boolean {
+  const content = normalizeBootstrapComparisonText(params.content);
+  if (!content) return false;
+  if (params.name !== 'HEARTBEAT.md') return true;
+
+  try {
+    return (
+      content !==
+      normalizeBootstrapComparisonText(readTemplateFile(params.name))
+    );
+  } catch (error) {
+    logger.warn(
+      { file: params.name, error },
+      'Failed to compare heartbeat context against template',
+    );
+    return true;
+  }
+}
+
 function isWorkspaceFileCustomized(
   wsDir: string,
   filename: (typeof WORKSPACE_BOOTSTRAP_FILES)[number],
@@ -227,7 +262,10 @@ function isWorkspaceFileCustomized(
   const filePath = path.join(wsDir, filename);
   if (!fs.existsSync(filePath)) return false;
   try {
-    return fs.readFileSync(filePath, 'utf-8') !== readTemplateFile(filename);
+    return (
+      normalizeBootstrapComparisonText(fs.readFileSync(filePath, 'utf-8')) !==
+      normalizeBootstrapComparisonText(readTemplateFile(filename))
+    );
   } catch (error) {
     logger.warn(
       { wsDir, file: filename, error },
@@ -556,7 +594,9 @@ export function loadStaticBootstrapFiles(agentId: string): ContextFile[] {
 
     try {
       let content = fs.readFileSync(filePath, 'utf-8').trim();
-      if (!content) continue;
+      if (!shouldLoadBootstrapContextFile({ name: filename, content })) {
+        continue;
+      }
 
       content = normalizeContextFileContent({
         agentId,
@@ -579,6 +619,25 @@ export function loadStaticBootstrapFiles(agentId: string): ContextFile[] {
   }
 
   return files;
+}
+
+export function hasActionableHeartbeatFile(agentId: string): boolean {
+  const filePath = path.join(agentWorkspaceDir(agentId), 'HEARTBEAT.md');
+  if (!fs.existsSync(filePath)) return false;
+
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    return shouldLoadBootstrapContextFile({
+      name: 'HEARTBEAT.md',
+      content,
+    });
+  } catch (err) {
+    logger.warn(
+      { agentId, file: 'HEARTBEAT.md', err },
+      'Failed to read heartbeat file',
+    );
+    return false;
+  }
 }
 
 export function loadDailyMemoryFile(
@@ -776,7 +835,10 @@ export function resolveStartupBootstrapFile(
   try {
     const content = fs.readFileSync(openingPath, 'utf-8');
     if (!content.trim()) return null;
-    return content === readTemplateFile('OPENING.md') ? null : 'OPENING.md';
+    return normalizeBootstrapComparisonText(content) ===
+      normalizeBootstrapComparisonText(readTemplateFile('OPENING.md'))
+      ? null
+      : 'OPENING.md';
   } catch (error) {
     logger.warn(
       { agentId, path: openingPath, error },

--- a/tests/heartbeat.test.ts
+++ b/tests/heartbeat.test.ts
@@ -32,6 +32,7 @@ const mocks = vi.hoisted(() => ({
       `Agent liveness ${probe.state}: ${probe.agentId}`,
   ),
   getCoworkerLivenessSummary: vi.fn(() => ({ probes: [] })),
+  hasActionableHeartbeatFile: vi.fn(() => true),
   heartbeatEnabled: true,
   resolveAgentForRequest: vi.fn(() => ({
     agentId: 'vllm',
@@ -122,8 +123,13 @@ vi.mock('../src/session/token-efficiency.js', () => ({
   estimateTokenCountFromText: mocks.estimateTokenCountFromText,
 }));
 
+vi.mock('../src/workspace.js', () => ({
+  hasActionableHeartbeatFile: mocks.hasActionableHeartbeatFile,
+}));
+
 beforeEach(() => {
   mocks.heartbeatEnabled = true;
+  mocks.hasActionableHeartbeatFile.mockReturnValue(true);
 });
 
 afterEach(async () => {
@@ -173,6 +179,31 @@ test.each([
       );
     }),
   ).toBe(true);
+});
+
+test('skips the heartbeat agent when HEARTBEAT.md has no actionable tasks', async () => {
+  vi.useFakeTimers();
+  mocks.hasActionableHeartbeatFile.mockReturnValue(false);
+  mocks.runAgent.mockResolvedValue({
+    status: 'success',
+    result: 'Review the queued tasks today.',
+    toolExecutions: [],
+  });
+
+  const { startHeartbeat, stopHeartbeat } = await import(
+    '../src/scheduler/heartbeat.ts'
+  );
+  const onMessage = vi.fn();
+
+  startHeartbeat('vllm', 1_000, onMessage);
+  await vi.advanceTimersByTimeAsync(1_000);
+  stopHeartbeat();
+
+  expect(mocks.hasActionableHeartbeatFile).toHaveBeenCalledWith('vllm');
+  expect(mocks.memoryService.getOrCreateSession).not.toHaveBeenCalled();
+  expect(mocks.buildConversationContext).not.toHaveBeenCalled();
+  expect(mocks.runAgent).not.toHaveBeenCalled();
+  expect(onMessage).not.toHaveBeenCalled();
 });
 
 test('delivers substantive heartbeat messages', async () => {

--- a/tests/proactive-delivery.test.ts
+++ b/tests/proactive-delivery.test.ts
@@ -7,6 +7,7 @@ import {
   isSupportedProactiveChannelId,
   resolveHeartbeatDeliveryChannelId,
   shouldDropQueuedProactiveMessage,
+  shouldSuppressProactiveMessage,
 } from '../src/gateway/proactive-delivery.js';
 
 describe('proactive delivery helpers', () => {
@@ -119,6 +120,14 @@ describe('proactive delivery helpers', () => {
 
     expect(
       shouldDropQueuedProactiveMessage({
+        channel_id: 'tui',
+        source: 'heartbeat',
+        text: 'HEARTBEAT_OK',
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldDropQueuedProactiveMessage({
         channel_id: 'heartbeat',
         source: 'delegate',
       }),
@@ -130,5 +139,35 @@ describe('proactive delivery helpers', () => {
         source: 'fullauto',
       }),
     ).toBe(true);
+  });
+
+  test('suppresses heartbeat ok acknowledgements from proactive delivery', () => {
+    expect(
+      shouldSuppressProactiveMessage({
+        source: 'heartbeat',
+        text: 'HEARTBEAT_OK',
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldSuppressProactiveMessage({
+        source: 'heartbeat',
+        text: 'heartbeat ok.',
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldSuppressProactiveMessage({
+        source: 'heartbeat',
+        text: 'Review the queued tasks today.',
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldSuppressProactiveMessage({
+        source: 'delegate',
+        text: 'HEARTBEAT_OK',
+      }),
+    ).toBe(false);
   });
 });

--- a/tests/workspace-bootstrap.test.ts
+++ b/tests/workspace-bootstrap.test.ts
@@ -165,6 +165,72 @@ describe('workspace bootstrap lifecycle', () => {
     });
   });
 
+  test('omits the default HEARTBEAT.md from bootstrap context', async () => {
+    const homeDir = makeTempDir('hybridclaw-home-');
+    const unrelatedCwd = makeTempDir('hybridclaw-cwd-');
+    vi.stubEnv('HOME', homeDir);
+    process.chdir(unrelatedCwd);
+
+    const workspace = await import('../src/workspace.js');
+    const ipc = await import('../src/infra/ipc.js');
+
+    workspace.ensureBootstrapFiles('agent-test');
+
+    const workspaceDir = ipc.agentWorkspaceDir('agent-test');
+    expect(fs.existsSync(path.join(workspaceDir, 'HEARTBEAT.md'))).toBe(true);
+
+    const files = workspace.loadStaticBootstrapFiles('agent-test');
+    expect(files.some((file) => file.name === 'HEARTBEAT.md')).toBe(false);
+    expect(workspace.hasActionableHeartbeatFile('agent-test')).toBe(false);
+  });
+
+  test('does not treat missing or empty HEARTBEAT.md as actionable', async () => {
+    const homeDir = makeTempDir('hybridclaw-home-');
+    const unrelatedCwd = makeTempDir('hybridclaw-cwd-');
+    vi.stubEnv('HOME', homeDir);
+    process.chdir(unrelatedCwd);
+
+    const workspace = await import('../src/workspace.js');
+    const ipc = await import('../src/infra/ipc.js');
+
+    workspace.ensureBootstrapFiles('agent-test');
+
+    const workspaceDir = ipc.agentWorkspaceDir('agent-test');
+    const heartbeatPath = path.join(workspaceDir, 'HEARTBEAT.md');
+    fs.unlinkSync(heartbeatPath);
+    expect(workspace.hasActionableHeartbeatFile('agent-test')).toBe(false);
+
+    fs.writeFileSync(heartbeatPath, ' \n\t\n', 'utf-8');
+    expect(workspace.hasActionableHeartbeatFile('agent-test')).toBe(false);
+  });
+
+  test('loads customized HEARTBEAT.md into bootstrap context', async () => {
+    const homeDir = makeTempDir('hybridclaw-home-');
+    const unrelatedCwd = makeTempDir('hybridclaw-cwd-');
+    vi.stubEnv('HOME', homeDir);
+    process.chdir(unrelatedCwd);
+
+    const workspace = await import('../src/workspace.js');
+    const ipc = await import('../src/infra/ipc.js');
+
+    workspace.ensureBootstrapFiles('agent-test');
+
+    const workspaceDir = ipc.agentWorkspaceDir('agent-test');
+    fs.writeFileSync(
+      path.join(workspaceDir, 'HEARTBEAT.md'),
+      '# HEARTBEAT.md\n\n- Check whether the nightly import completed.\n',
+      'utf-8',
+    );
+
+    const files = workspace.loadStaticBootstrapFiles('agent-test');
+    expect(files).toContainEqual({
+      name: 'HEARTBEAT.md',
+      content:
+        '# HEARTBEAT.md\n\n- Check whether the nightly import completed.',
+    });
+    expect(workspace.hasActionableHeartbeatFile('agent-test')).toBe(true);
+  });
+
   test('removes stale BOOTSTRAP.md when the workspace already looks completed', async () => {
     const homeDir = makeTempDir('hybridclaw-home-');
     const unrelatedCwd = makeTempDir('hybridclaw-cwd-');


### PR DESCRIPTION
## Summary

- Skip the heartbeat agent run before session, memory, and prompt construction when `HEARTBEAT.md` is missing, empty, or still equal to the default template.
- Reuse the same heartbeat-file classification when loading workspace bootstrap context so the default heartbeat file is not injected into prompts.
- Add scheduler and workspace bootstrap tests for default, missing, empty, and customized heartbeat files.

## Why

The heartbeat loop previously still made an expensive model call with full context just to get `HEARTBEAT_OK` when the workspace had no actionable heartbeat tasks. This moves the no-op decision to the scheduler boundary.

## Validation

- `npx vitest run tests/workspace-bootstrap.test.ts tests/workspace-context.test.ts tests/heartbeat.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npx biome check src/workspace.ts src/scheduler/heartbeat.ts tests/workspace-bootstrap.test.ts tests/heartbeat.test.ts`

Note: Vitest emitted the existing `better-sqlite3` Node ABI warning from the shared dependency symlink, but all targeted tests passed.