### PR TITLE
[codex] Preserve web chat newlines

### DIFF
--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -597,6 +597,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
   background: linear-gradient(135deg, var(--primary), var(--ring));
   color: var(--primary-foreground);
   border-bottom-right-radius: 4px;
+  white-space: pre-wrap;
 }
 
 .bubbleAssistant {

--- a/console/src/routes/chat/composer.test.tsx
+++ b/console/src/routes/chat/composer.test.tsx
@@ -86,6 +86,20 @@ describe('Composer', () => {
     expect(onAgentSwitch).toHaveBeenCalledWith('charly');
   });
 
+  it('preserves internal newlines when sending a multiline message', () => {
+    const onSend = vi.fn();
+    renderComposer({ onSend });
+    const textarea = getTextarea();
+    fireEvent.input(textarea, {
+      target: { value: 'first line\nsecond line\nthird line' },
+    });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(onSend).toHaveBeenCalledWith(
+      'first line\nsecond line\nthird line',
+      [],
+    );
+  });
+
   describe('slash command suggestion panel', () => {
     async function showPanel(
       commands: ChatCommandSuggestion[],

--- a/console/src/routes/chat/message-block.test.tsx
+++ b/console/src/routes/chat/message-block.test.tsx
@@ -7,6 +7,7 @@ import {
 } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ChatArtifact, ChatMessage } from '../../api/chat-types';
+import css from './chat-page.module.css';
 import type { ChatUiMessage } from './chat-ui-message';
 import { MessageBlock } from './message-block';
 
@@ -64,6 +65,30 @@ describe('MessageBlock artifacts', () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
+  });
+
+  it('renders multiline user message bubbles with newline-preserving styling', () => {
+    const content = 'first line\nsecond line\nthird line';
+    render(
+      <MessageBlock
+        message={makeMessage([], { role: 'user', content })}
+        token="test-token"
+        isStreaming={false}
+        onCopy={vi.fn()}
+        onEdit={vi.fn()}
+        onRegenerate={vi.fn()}
+        onApprovalAction={vi.fn()}
+        approvalBusy={false}
+        branchInfo={null}
+        onBranchNav={vi.fn()}
+      />,
+    );
+
+    const bubble = screen.getByText(
+      (_text, element) => element?.textContent === content,
+    );
+    expect(bubble.textContent).toBe(content);
+    expect(bubble.classList.contains(css.bubbleUser)).toBe(true);
   });
 
   it('renders image previews from blob URLs instead of tokenized artifact URLs', async () => {


### PR DESCRIPTION
## Summary

Fixes the web chat display path so pasted multiline user messages keep their line breaks after submission.

## Details

User messages were already submitted with internal newline characters intact, but the rendered user bubble used normal HTML whitespace behavior, which visually collapsed those newlines into spaces. This adds `white-space: pre-wrap` to user chat bubbles and covers both the composer submission path and rendered message content with focused tests.

## Validation

- `npx vitest run --config vitest.config.ts src/routes/chat/composer.test.tsx src/routes/chat/message-block.test.tsx`
- `npm run typecheck` in `console/`
- `npx biome check --write console/src/routes/chat/chat-page.module.css console/src/routes/chat/composer.test.tsx console/src/routes/chat/message-block.test.tsx`