### PR TITLE
Fix provider prefix dispatch

### DIFF
--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -1,26 +1,9 @@
-import {
-  DASHSCOPE_ENABLED,
-  DEEPSEEK_ENABLED,
-  GEMINI_ENABLED,
-  HUGGINGFACE_ENABLED,
-  HYBRIDAI_ENABLE_RAG,
-  HYBRIDAI_MODEL,
-  KILO_ENABLED,
-  KIMI_ENABLED,
-  LOCAL_LLAMACPP_ENABLED,
-  LOCAL_LMSTUDIO_ENABLED,
-  LOCAL_OLLAMA_ENABLED,
-  LOCAL_VLLM_ENABLED,
-  MINIMAX_ENABLED,
-  MISTRAL_ENABLED,
-  OPENROUTER_ENABLED,
-  XAI_ENABLED,
-  XIAOMI_ENABLED,
-  ZAI_ENABLED,
-} from '../config/config.js';
+import { HYBRIDAI_ENABLE_RAG, HYBRIDAI_MODEL } from '../config/config.js';
+import { getRuntimeConfig } from '../config/runtime-config.js';
 import { anthropicProvider } from './anthropic.js';
 import { huggingfaceProvider } from './huggingface.js';
 import { hybridAIProvider } from './hybridai.js';
+import { getLocalModelInfo } from './local-discovery.js';
 import { ollamaProvider } from './local-ollama.js';
 import {
   llamacppProvider,
@@ -48,37 +31,97 @@ import type {
   ResolveProviderRuntimeParams,
 } from './types.js';
 
-function getActiveProviders(): AIProvider[] {
-  return [
-    openAIProvider,
-    anthropicProvider,
-    ...(OPENROUTER_ENABLED ? [openrouterProvider] : []),
-    ...(MISTRAL_ENABLED ? [mistralProvider] : []),
-    ...(HUGGINGFACE_ENABLED ? [huggingfaceProvider] : []),
-    ...(GEMINI_ENABLED ? [geminiProvider] : []),
-    ...(DEEPSEEK_ENABLED ? [deepseekProvider] : []),
-    ...(XAI_ENABLED ? [xaiProvider] : []),
-    ...(ZAI_ENABLED ? [zaiProvider] : []),
-    ...(KIMI_ENABLED ? [kimiProvider] : []),
-    ...(MINIMAX_ENABLED ? [minimaxProvider] : []),
-    ...(DASHSCOPE_ENABLED ? [dashscopeProvider] : []),
-    ...(XIAOMI_ENABLED ? [xiaomiProvider] : []),
-    ...(KILO_ENABLED ? [kiloProvider] : []),
-    ...(LOCAL_OLLAMA_ENABLED ? [ollamaProvider] : []),
-    ...(LOCAL_LMSTUDIO_ENABLED ? [lmstudioProvider] : []),
-    ...(LOCAL_LLAMACPP_ENABLED ? [llamacppProvider] : []),
-    ...(LOCAL_VLLM_ENABLED ? [vllmProvider] : []),
-    hybridAIProvider,
-  ];
+const KNOWN_PROVIDERS: AIProvider[] = [
+  openAIProvider,
+  anthropicProvider,
+  openrouterProvider,
+  mistralProvider,
+  huggingfaceProvider,
+  geminiProvider,
+  deepseekProvider,
+  xaiProvider,
+  zaiProvider,
+  kimiProvider,
+  minimaxProvider,
+  dashscopeProvider,
+  xiaomiProvider,
+  kiloProvider,
+  ollamaProvider,
+  lmstudioProvider,
+  llamacppProvider,
+  vllmProvider,
+  hybridAIProvider,
+];
+
+const KNOWN_PROVIDER_BY_ID = new Map<AIProviderId, AIProvider>(
+  KNOWN_PROVIDERS.map((provider) => [provider.id, provider]),
+);
+
+const runtimeConfig = getRuntimeConfig();
+const ACTIVE_PROVIDERS: AIProvider[] = [
+  openAIProvider,
+  anthropicProvider,
+  ...(runtimeConfig.openrouter.enabled ? [openrouterProvider] : []),
+  ...(runtimeConfig.mistral.enabled ? [mistralProvider] : []),
+  ...(runtimeConfig.huggingface.enabled ? [huggingfaceProvider] : []),
+  ...(runtimeConfig.gemini.enabled ? [geminiProvider] : []),
+  ...(runtimeConfig.deepseek.enabled ? [deepseekProvider] : []),
+  ...(runtimeConfig.xai.enabled ? [xaiProvider] : []),
+  ...(runtimeConfig.zai.enabled ? [zaiProvider] : []),
+  ...(runtimeConfig.kimi.enabled ? [kimiProvider] : []),
+  ...(runtimeConfig.minimax.enabled ? [minimaxProvider] : []),
+  ...(runtimeConfig.dashscope.enabled ? [dashscopeProvider] : []),
+  ...(runtimeConfig.xiaomi.enabled ? [xiaomiProvider] : []),
+  ...(runtimeConfig.kilo.enabled ? [kiloProvider] : []),
+  ...(runtimeConfig.local.backends.ollama.enabled ? [ollamaProvider] : []),
+  ...(runtimeConfig.local.backends.lmstudio.enabled ? [lmstudioProvider] : []),
+  ...(runtimeConfig.local.backends.llamacpp.enabled ? [llamacppProvider] : []),
+  ...(runtimeConfig.local.backends.vllm.enabled ? [vllmProvider] : []),
+  hybridAIProvider,
+];
+
+const PROVIDER_BY_MODEL_PREFIX = new Map<string, AIProvider>(
+  ACTIVE_PROVIDERS.map((provider) => [provider.id, provider]),
+);
+
+function normalizeModel(model: string): string {
+  return String(model || '').trim();
+}
+
+function getModelPrefix(model: string): string | null {
+  const slashIndex = model.indexOf('/');
+  if (slashIndex < 0) return null;
+  return model.slice(0, slashIndex).toLowerCase();
+}
+
+function resolvePrefixedProvider(model: string, prefix: string): AIProvider {
+  const provider = PROVIDER_BY_MODEL_PREFIX.get(prefix);
+  if (provider) return provider;
+
+  if (KNOWN_PROVIDER_BY_ID.has(prefix as AIProviderId)) return hybridAIProvider;
+
+  throw new Error(
+    `Unknown provider prefix \`${prefix}\` in model \`${model}\`.`,
+  );
+}
+
+function resolveBareModelProvider(model: string): AIProvider {
+  const localBackend = getLocalModelInfo(model)?.backend;
+  if (localBackend) {
+    const provider = KNOWN_PROVIDER_BY_ID.get(localBackend);
+    if (provider) return provider;
+    throw new Error(
+      `Unknown local model backend \`${localBackend}\` for model \`${model}\`.`,
+    );
+  }
+  return hybridAIProvider;
 }
 
 export function resolveProviderForModel(model: string): AIProvider {
-  const normalizedModel = String(model || '').trim();
-  return (
-    getActiveProviders().find((provider) =>
-      provider.matchesModel(normalizedModel),
-    ) || hybridAIProvider
-  );
+  const normalizedModel = normalizeModel(model);
+  const prefix = getModelPrefix(normalizedModel);
+  if (prefix) return resolvePrefixedProvider(normalizedModel, prefix);
+  return resolveBareModelProvider(normalizedModel);
 }
 
 export function resolveModelProvider(model: string): AIProviderId {

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -2760,7 +2760,7 @@ test('agent create warns when model validation is skipped because no models are 
     sessionId: 'session-create-agent',
     guildId: null,
     channelId: 'channel-create-agent',
-    args: ['agent', 'create', 'research', '--model', 'garbage/model'],
+    args: ['agent', 'create', 'research', '--model', 'garbage-model'],
   });
 
   expect(result.kind).toBe('info');
@@ -2769,12 +2769,12 @@ test('agent create warns when model validation is skipped because no models are 
   }
   expect(result.title).toBe('Agent Created');
   expect(result.text).toContain('Agent: research');
-  expect(result.text).toContain('Model: hybridai/garbage/model');
+  expect(result.text).toContain('Model: hybridai/garbage-model');
   expect(warnMock).toHaveBeenCalledWith(
     expect.objectContaining({
       sessionId: 'session-create-agent',
       agentId: 'research',
-      model: 'garbage/model',
+      model: 'garbage-model',
     }),
     'Skipping agent model validation because no available models are configured',
   );

--- a/tests/model-catalog.test.ts
+++ b/tests/model-catalog.test.ts
@@ -143,9 +143,7 @@ test('model catalog metadata falls back safely for missing models', async () => 
   writeRuntimeConfig(homeDir);
   const { catalog } = await importFreshCatalog(homeDir);
 
-  const metadata = catalog.getModelCatalogMetadata(
-    'unknown-provider/not-real-model',
-  );
+  const metadata = catalog.getModelCatalogMetadata('not-real-model');
 
   expect(metadata).toMatchObject({
     known: false,

--- a/tests/providers.factory.test.ts
+++ b/tests/providers.factory.test.ts
@@ -181,6 +181,57 @@ test('provider factory resolves adapters by model family', async () => {
   ).toBe(false);
 });
 
+test('provider factory rejects unknown provider prefixes', async () => {
+  const homeDir = makeTempHome();
+  writeRuntimeConfig(homeDir);
+  const factory = await importFreshFactory(homeDir);
+
+  expect(() => factory.resolveModelProvider('openrotuer/gpt-5-nano')).toThrow(
+    'Unknown provider prefix `openrotuer`',
+  );
+  expect(() => factory.modelRequiresChatbotId('openrotuer/gpt-5-nano')).toThrow(
+    'Unknown provider prefix `openrotuer`',
+  );
+  await expect(
+    factory.resolveModelRuntimeCredentials({
+      model: 'openrotuer/gpt-5-nano',
+    }),
+  ).rejects.toThrow('Unknown provider prefix `openrotuer`');
+});
+
+test('provider factory preserves HybridAI fallback for disabled known prefixes', async () => {
+  const homeDir = makeTempHome();
+  writeRuntimeConfig(homeDir, (config) => {
+    config.openrouter.enabled = false;
+  });
+  const factory = await importFreshFactory(homeDir);
+
+  expect(factory.resolveModelProvider('openrouter/openai/gpt-5')).toBe(
+    'hybridai',
+  );
+  expect(factory.modelRequiresChatbotId('openrouter/openai/gpt-5')).toBe(true);
+});
+
+test('provider factory routes discovered bare local models to their backend', async () => {
+  const homeDir = makeTempHome();
+  writeRuntimeConfig(homeDir);
+  vi.doMock('../src/providers/local-discovery.ts', async () => {
+    const actual = await vi.importActual<
+      typeof import('../src/providers/local-discovery.ts')
+    >('../src/providers/local-discovery.ts');
+    return {
+      ...actual,
+      getLocalModelInfo: vi.fn((model: string) =>
+        model === 'llama3.1:8b' ? { backend: 'ollama' } : null,
+      ),
+    };
+  });
+  const factory = await importFreshFactory(homeDir);
+
+  expect(factory.resolveModelProvider('llama3.1:8b')).toBe('ollama');
+  expect(factory.modelRequiresChatbotId('llama3.1:8b')).toBe(false);
+});
+
 test('provider factory resolves HybridAI runtime credentials', async () => {
   const homeDir = makeTempHome();
   process.env.HYBRIDAI_API_KEY = 'hai-provider-test';


### PR DESCRIPTION
## Summary

- Replaces linear provider matching in `src/providers/factory.ts` with module-level provider and prefix registries.
- Resolves active prefixed model ids through a direct prefix map while preserving bare HybridAI passthrough behavior.
- Rejects unknown slash-bearing provider prefixes consistently through `resolveProviderForModel`, `resolveModelProvider`, `modelRequiresChatbotId`, and runtime credential resolution.
- Preserves the previous compatibility behavior for known-but-disabled provider prefixes by falling back to HybridAI.
- Keeps discovered bare local models routable via `getLocalModelInfo`.

Fixes #1112.

## Validation

Local Node 22 checks run in `/Users/bkoehler/src/hybridclaw-issue-1112`:

- `npm run typecheck`
- `npm run lint`
- `npm run check`
- `./node_modules/.bin/vitest run tests/providers.factory.test.ts tests/local-provider.test.ts tests/model-catalog.test.ts tests/gateway-status.test.ts`

GitHub Actions on `bf997ce4`:

- `lint`
- `test`
- `docker-preflight (agent, ./container, ./container/Dockerfile, runtime, hybridclaw-agent)`
- `docker-preflight (gateway, ., ./Dockerfile, hybridclaw-gateway)`
- `npm-e2e`