### PR TITLE
fix: skip scheduler noop TUI delivery

### DIFF
--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -220,6 +220,7 @@ import {
   hasQueuedProactiveDeliveryPath,
   isDiscordChannelId,
   isEmailAddress,
+  isHeartbeatOkText,
   isSupportedProactiveChannelId,
   resolveHeartbeatDeliveryChannelId,
   shouldDropQueuedProactiveMessage,
@@ -3303,6 +3304,23 @@ async function runScheduledTask(
           'No delivery channel available for scheduled delivery.',
         );
       }
+      if (
+        resolvedDeliveryChannelId === 'tui' &&
+        (result.artifacts?.length || 0) === 0 &&
+        isSchedulerNoopTuiResult(result.text)
+      ) {
+        logger.info(
+          {
+            jobId: request.jobId,
+            taskId: request.taskId,
+            source: request.source,
+            channelId: resolvedDeliveryChannelId,
+            result: result.text,
+          },
+          'Scheduled task completed without TUI delivery',
+        );
+        return;
+      }
       await deliverProactiveMessage(
         resolvedDeliveryChannelId,
         result.text,
@@ -3335,6 +3353,26 @@ async function runScheduledTask(
     },
     runKey,
     request.agentId,
+  );
+}
+
+function isSchedulerNoopTuiResult(text: string): boolean {
+  if (isHeartbeatOkText(text)) return true;
+
+  const normalized = text.trim().replace(/\s+/g, ' ').toLowerCase();
+  if (!normalized) return true;
+
+  const reportsNoWork =
+    normalized.startsWith('nothing to report') ||
+    normalized.startsWith('no work to report') ||
+    normalized.startsWith('no pending work');
+  if (!reportsNoWork) return false;
+
+  return (
+    normalized.includes('no pending') ||
+    normalized.includes('no queued') ||
+    normalized.includes('no changes') ||
+    normalized.includes('idle')
   );
 }
 

--- a/tests/gateway-main.test.ts
+++ b/tests/gateway-main.test.ts
@@ -664,15 +664,24 @@ async function importFreshGatewayMain(options?: {
     startGatewayHttpServer: state.startGatewayHttpServer,
   }));
   vi.doMock('../src/gateway/proactive-delivery.js', () => ({
-    deliverProactiveMessage: vi.fn(async () => {}),
     deliverWebhookMessage: vi.fn(async () => {}),
     hasQueuedProactiveDeliveryPath: vi.fn(() => true),
     isDiscordChannelId: vi.fn(() => true),
     isEmailAddress: vi.fn(() => false),
+    isHeartbeatOkText: vi.fn((text: string) => {
+      const normalized = text
+        .trim()
+        .replace(/[^a-z]/gi, '')
+        .toUpperCase();
+      return (
+        normalized === 'HEARTBEATOK' || normalized.startsWith('HEARTBEATOK')
+      );
+    }),
     isSupportedProactiveChannelId: vi.fn(() => true),
     resolveHeartbeatDeliveryChannelId: vi.fn(() => '123456789012345678'),
     resolveLastUsedDeliverableChannelId: vi.fn(() => '123456789012345678'),
     shouldDropQueuedProactiveMessage: vi.fn(() => false),
+    shouldSuppressProactiveMessage: vi.fn(() => false),
   }));
   vi.doMock('../src/gateway/managed-media-cleanup.js', () => ({
     runManagedMediaCleanup: state.runManagedMediaCleanup,
@@ -1134,6 +1143,151 @@ describe('gateway bootstrap', () => {
         delivery: 'last-channel',
       }),
       'Scheduled task failed',
+    );
+  });
+
+  test('does not deliver scheduler HEARTBEAT_OK results to the TUI inbox', async () => {
+    const state = await importFreshGatewayMain();
+    state.runGatewayScheduledTask.mockImplementation(
+      async (...args: unknown[]) => {
+        const onResult = args[4] as (result: {
+          text: string;
+        }) => Promise<void>;
+        await onResult({ text: 'HEARTBEAT_OK' });
+      },
+    );
+
+    await state.scheduledTaskRunner?.({
+      source: 'scheduler-job',
+      jobId: 'budget-tokens',
+      sessionId: 'scheduler:budget-tokens',
+      channelId: 'tui',
+      prompt: 'Hi',
+      actionKind: 'agent_turn',
+      delivery: {
+        kind: 'channel',
+        channelId: 'tui',
+      },
+    });
+
+    expect(state.runGatewayScheduledTask).toHaveBeenCalledTimes(1);
+    expect(state.loggerInfo).toHaveBeenCalledWith(
+      {
+        jobId: 'budget-tokens',
+        taskId: undefined,
+        source: 'scheduler-job',
+        channelId: 'tui',
+        result: 'HEARTBEAT_OK',
+      },
+      'Scheduled task completed without TUI delivery',
+    );
+    expect(state.loggerInfo).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: 'budget-tokens',
+        channelId: 'tui',
+        result: 'HEARTBEAT_OK',
+      }),
+      'Scheduled task completed',
+    );
+  });
+
+  test('does not deliver scheduler idle reports to the TUI inbox', async () => {
+    const state = await importFreshGatewayMain();
+    const idleText =
+      'Nothing to report. No pending tasks configured for this agent, no queued work, and no changes to act on. Idle — standing by.';
+    state.runGatewayScheduledTask.mockImplementation(
+      async (...args: unknown[]) => {
+        const onResult = args[4] as (result: {
+          text: string;
+        }) => Promise<void>;
+        await onResult({ text: idleText });
+      },
+    );
+
+    await state.scheduledTaskRunner?.({
+      source: 'scheduler-job',
+      jobId: 'budget-tokens',
+      sessionId: 'scheduler:budget-tokens',
+      channelId: 'tui',
+      prompt: 'Hi',
+      actionKind: 'agent_turn',
+      delivery: {
+        kind: 'channel',
+        channelId: 'tui',
+      },
+    });
+
+    expect(state.runGatewayScheduledTask).toHaveBeenCalledTimes(1);
+    expect(state.loggerInfo).toHaveBeenCalledWith(
+      {
+        jobId: 'budget-tokens',
+        taskId: undefined,
+        source: 'scheduler-job',
+        channelId: 'tui',
+        result: idleText,
+      },
+      'Scheduled task completed without TUI delivery',
+    );
+    expect(state.loggerInfo).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: 'budget-tokens',
+        channelId: 'tui',
+        result: idleText,
+      }),
+      'Scheduled task completed',
+    );
+  });
+
+  test('delivers scheduler no-op text to TUI when artifacts are present', async () => {
+    const state = await importFreshGatewayMain();
+    const artifacts = [
+      {
+        path: '/tmp/report.txt',
+        filename: 'report.txt',
+        mimeType: 'text/plain',
+      },
+    ];
+    state.runGatewayScheduledTask.mockImplementation(
+      async (...args: unknown[]) => {
+        const onResult = args[4] as (result: {
+          text: string;
+          artifacts?: typeof artifacts;
+        }) => Promise<void>;
+        await onResult({ text: 'HEARTBEAT_OK', artifacts });
+      },
+    );
+
+    await state.scheduledTaskRunner?.({
+      source: 'scheduler-job',
+      jobId: 'budget-tokens',
+      sessionId: 'scheduler:budget-tokens',
+      channelId: 'tui',
+      prompt: 'Hi',
+      actionKind: 'agent_turn',
+      delivery: {
+        kind: 'channel',
+        channelId: 'tui',
+      },
+    });
+
+    expect(state.loggerInfo).toHaveBeenCalledWith(
+      {
+        jobId: 'budget-tokens',
+        taskId: undefined,
+        source: 'scheduler-job',
+        channelId: 'tui',
+        result: 'HEARTBEAT_OK',
+        artifactCount: 1,
+      },
+      'Scheduled task completed',
+    );
+    expect(state.loggerInfo).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: 'budget-tokens',
+        channelId: 'tui',
+        result: 'HEARTBEAT_OK',
+      }),
+      'Scheduled task completed without TUI delivery',
     );
   });
 


### PR DESCRIPTION
## Summary
- keep scheduler no-op results available to the run, but skip delivering them to the local TUI inbox
- detect `HEARTBEAT_OK` and idle/no-work scheduler reports before proactive TUI delivery
- add gateway bootstrap coverage for both scheduler no-op cases

## Validation
- `npx vitest run tests/gateway-main.test.ts tests/proactive-delivery.test.ts`