### PR TITLE
[codex] Update next minor release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,82 @@
 
 ## Unreleased
 
+### Added
+
+- **A2A cross-instance transport**: Outbound A2A delivery can resolve
+  canonical peer IDs through the local deployment URL or active tunnel URL, the
+  public-key trust ledger, and DNS-style discovery, then dispatch over the A2A
+  transport with route invalidation and coverage for remote handoff delivery.
+- **Harness evolution loop**: Added `hybridclaw harness-evolve` for
+  eval-driven coworker workspace evolution, including seed validation,
+  round/rollout summaries, F12 manifest reporting, allowed-surface write
+  enforcement, and admin inspection support.
+- **Second-opinion command**: Added `/second-opinion` for stronger-model
+  comparison, validation of the last answer, and optional fact-checking with
+  web-search evidence. The command refreshes the model catalog, estimates
+  context/cost, honors per-agent budgets, and redacts or blocks confidential
+  payloads before remote model calls.
+- **Web response ratings**: Added thumbs-up/thumbs-down controls for persisted
+  web chat assistant responses, backed by idempotent per-operator ratings,
+  `response.rating` observability events, and Adaptive Skills feedback when a
+  response maps to a skill observation.
+- **Turn-level audit traces**: Added focused `/audit turn` and `/audit run`
+  trace views plus session trace export support for inspecting the exact
+  request, response, tool, approval, and audit events around one turn.
+- **Token agent budgets**: Agent budget config now supports token caps in
+  addition to USD/EUR spend caps, and board/job budget chips report token
+  usage with neutral, warning, and over-budget states.
+- **Per-channel brand-voice profiles**: The `output-guard` plugin can apply
+  channel-specific brand-voice profiles, blocked terms, rewrite behavior, and
+  guard configuration.
+- **`homematic` skill**: Added Homematic IP Home Control Unit state reads,
+  Connect API auth setup payloads, WebSocket message planning, guarded switch,
+  thermostat, shutter, scene, and safety-alarm control plans, and offline HCU
+  state fixture summaries.
+- **`fronius` skill**: Added Fronius photovoltaic monitoring through local
+  Fronius Solar API V1 and Solar.web Query API reads, including local health,
+  live power flow, energy rollups, cloud system/device/status endpoints, and
+  SecretRef-backed Solar.web access-key headers.
+
+### Changed
+
+- **Security fallback deprecations**: Added migration warnings for legacy
+  BlueBubbles query-param webhook auth, unbound `bearerSecretName` and
+  `secretHeaders` injection, and legacy `container.additionalMounts` config.
+  Existing setups continue to work during the deprecation window while docs and
+  `hybridclaw doctor security` point operators to header auth, bound bearer
+  secrets, and `container.binds`.
+- **A2A handoff ownership**: Handoff envelopes now preserve recipient
+  ownership and org-chart context so inbox views, persisted threads, and audit
+  records can distinguish handoff recipient responsibility from ordinary chat
+  routing.
+- **Slash-command rendering**: Web chat treats slash-command output as a
+  distinct command-result block instead of rendering it as ordinary assistant
+  prose, with stream metadata carried through history reloads.
+- **Admin console dialog behavior**: Console sheets were consolidated into the
+  dialog component, exit animation handling moved to the Web Animations API,
+  and focus guards were tightened for modal navigation.
+- **Console linting**: Added a console lint script and moved Biome scoping into
+  the shared config so root and console checks use the same formatting source
+  of truth.
+- **Roadmap status**: Updated internal roadmap status for merged A2A,
+  brand-voice, budget-chip, second-opinion, response-rating, harness
+  evolution, Homematic, Fronius, and T Cloud Public work, and added follow-up
+  rows for AWS, Blink, BYD Battery, Alexa, Hue, skill identity assets/chat
+  rendering, and pluggable secret backends.
+
 ### Fixed
 
+- **Unknown provider prefixes**: Provider factory validation now rejects
+  unknown provider-prefixed model ids instead of falling through to an
+  unintended provider.
+- **Recovered skill tool failures**: Skill evaluations that recover from tool
+  failures are classified as partial instead of successful, and the admin
+  Skills page surfaces those partial states more clearly.
+- **Idle heartbeat runs**: Heartbeat scheduling skips idle agent runs instead
+  of creating empty proactive work.
+- **Web chat newlines**: Assistant message rendering preserves newlines in web
+  chat responses.
 - **npm signature audit attestation 404s**: Treat missing npm registry
   attestation endpoint artifacts as best-effort after retries while keeping
   registry signature validation failures fatal.
@@ -74,16 +148,6 @@
 
 ### Changed
 
-- **Security fallback deprecations**: Added migration warnings for legacy
-  BlueBubbles query-param webhook auth, unbound `bearerSecretName` and
-  `secretHeaders` injection, and legacy `container.additionalMounts` config.
-  Existing setups continue to work during the deprecation window while docs and
-  `hybridclaw doctor security` point operators to header auth, bound bearer
-  secrets, and `container.binds`.
-- **A2A cross-instance transport**: Outbound A2A delivery can resolve
-  canonical peer IDs through identity discovery, pin the resolved public key
-  against the peer Agent Card, and round-trip messages between two HTTP
-  instances.
 - **Diagram validation and accounting**: Mermaid diagrams are validated with
   the bundled Mermaid parser before render, diagram render artifacts retain
   skill-scoped source/rendered metadata, and local diagram renders emit

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ Once the gateway is running, open HybridClaw locally:
 - Web Chat accepts `/btw <question>` side questions while a primary run is
   active, so you can ask an ephemeral follow-up without interrupting the
   current run
+- Web Chat renders slash-command output as command results and lets operators
+  rate persisted assistant responses with thumbs-up/down feedback that feeds
+  observability and skill-improvement signals
 - Admin Console: `http://127.0.0.1:9090/admin` for channels, versioned agent files,
   scheduler, audit, statistics, config, secrets, output guard, A2A inbox threads, and
   channel-specific instructions
@@ -147,6 +150,8 @@ Once the gateway is running, open HybridClaw locally:
   spend summaries without scanning every stored session on page load.
 - `/admin/agent-scoreboard` ranks agents by observed skill scores, reliability,
   timing, best skills, and CV links.
+- `/audit turn <n>` and `/audit run <runId>` show focused turn traces for
+  debugging one request without reading the full session audit stream.
 - `hybridclaw agent config` accepts generated JSON payloads to upsert agent
   metadata, write bootstrap markdown, import profile images into the agent
   workspace, and optionally activate the agent.
@@ -180,6 +185,9 @@ Once the gateway is running, open HybridClaw locally:
 - `/goal` stores a standing completion condition for the current thread and
   queues supervised continuations until the goal is judged complete, paused,
   cleared, interrupted, or blocked by approval policy.
+- `/second-opinion` asks a stronger configured model to compare a question,
+  validate the last answer, or fact-check with web-search evidence while
+  honoring configured model context, confidentiality, and agent-budget limits.
 - `proactive.delegation.model` can pin delegated work to a different model
   from the parent turn; `/status` shows delegate token totals and local-token
   share when that split is configured.
@@ -198,6 +206,9 @@ Once the gateway is running, open HybridClaw locally:
 - `container.persistBashState` controls whether bash tool calls share shell
   state (`cd`, exported env vars, aliases) across turns in the same active
   runtime session; `/admin/config` exposes the same setting as `Persistent bash state`.
+- Agent budget config supports monthly USD/EUR caps and token caps; job and
+  board budget chips show neutral, warning, and over-budget states for
+  configured agents.
 - `security.confidentialRedactionEnabled` controls whether optional
   `.confidential.yml` rules redact prompts and block matching outbound text;
   `/admin/config` exposes the same setting as `Confidential leak guard`.
@@ -226,8 +237,8 @@ Once the gateway is running, open HybridClaw locally:
   local operators review scanner-blocked skills and record a bypass marker for
   the installed copy when the finding has been accepted.
 - Bundled skills include CRM, finance, infrastructure, monitoring,
-  home-automation, fax, local PII redaction, media, search, and office
-  workflows. Skill setup guides live in the
+  home-automation and solar monitoring, fax, local PII redaction, media,
+  search, and office workflows. Skill setup guides live in the
   [Skills Catalog](https://hybridaione.github.io/hybridclaw/docs/guides/skills/).
 - The bundled tutorials cover owner, GTM, marketing, sales, DevRel, content,
   invoicing, webinar, and release-launch workflows that can run from the TUI,
@@ -282,7 +293,8 @@ Once the gateway is running, open HybridClaw locally:
   Salesforce inspection, GitHub issue queue processing (`gh-issues`),
   monthly SaaS invoice harvesting (`download-platform-invoices`), Airtable,
   FastBill, Lexware Office, managed or self-hosted Firecrawl, Google Ads, GA4 reporting,
-  HeyGen, Hermes3000 long-form writing, natural-language warehouse SQL
+  HeyGen, Hermes3000 long-form writing, Fronius solar monitoring, Homematic
+  HCU state/control planning, natural-language warehouse SQL
   (`warehouse-sql`), brand-voice drafting, speech transcription and language
   detection (`speech.transcribe`, `speech.detect-language`), validated
   diagram-as-code creation through `diagram`, and editable Excalidraw diagram

--- a/docs/content/README.md
+++ b/docs/content/README.md
@@ -29,8 +29,8 @@ doc at once, start from [For Agents](./agents.md).
 
 - Native `image_generate` and `video_generate` tools produce managed media
   artifacts through configured image and video providers.
-- Bundled skills cover Airtable, FastBill, Firecrawl, HeyGen, Google Ads, and
-  SearXNG-backed web/news/image search workflows.
+- Bundled skills cover Airtable, FastBill, Firecrawl, Fronius, HeyGen,
+  Homematic, Google Ads, and SearXNG-backed web/news/image search workflows.
 - Threema Gateway Basic mode is available for outbound operator messaging in
   DACH-regulated or privacy-sensitive deployments.
 - A2A federation includes JSON-RPC Agent Card inbound delivery, signed
@@ -41,6 +41,10 @@ doc at once, start from [For Agents](./agents.md).
   skill-trace review a deterministic test path.
 - Harness evolution runs eval-driven coworker workspace improvement loops with
   F12 manifests, seed-delta reporting, and admin inspection.
+- `/second-opinion` compares or validates answers with a stronger configured
+  model while honoring confidentiality, context, and agent-budget limits.
+- Web chat renders slash-command results distinctly and records persisted
+  thumbs-up/down response ratings for observability and Adaptive Skills.
 - `npm run desktop` launches a native macOS wrapper around the local chat UI,
   with gateway reuse/startup and admin access from the app menu.
 - Canonical user and agent identity helpers now include DNS-style discovery for

--- a/docs/content/channels/admin-console.md
+++ b/docs/content/channels/admin-console.md
@@ -64,6 +64,8 @@ The A2A inbox at `/admin/a2a-inbox` shows instance-wide agent-to-agent message t
   without editing runtime config by hand
 - `/admin/audit` includes filter and search controls for audit event types,
   actors, resources, date ranges, and text queries
+- `/admin/audit` and local `/audit turn` or `/audit run` commands can inspect
+  focused turn traces when a single request needs debugging
 - `/admin/jobs` shows richer job rows with status, queue, owner, budget, and
   schedule context while keeping navigation inside the SPA
 - `/admin/scheduler` edits scheduled jobs through the shared form controls and
@@ -78,10 +80,13 @@ The A2A inbox at `/admin/a2a-inbox` shows instance-wide agent-to-agent message t
   native-select, number, radio, switch, textarea, validation, draft, and
   unsaved-change components so behavior is consistent across pages
 - pages that show owned work can render per-agent budget chips, including
-  neutral, warning, and over-budget states when agent budgets are configured
+  neutral, warning, and over-budget states when USD/EUR or token budgets are
+  configured
 - the web chat route shares the admin shell, supports improved session
   management, preserves scroll position while reading older messages, and
   renders assistant message blocks with better structured content handling
+- the web chat route renders slash-command results distinctly and lets
+  operators apply persisted thumbs-up/down ratings to assistant responses
 - destructive admin actions use explicit browser confirmation dialogs before
   HybridClaw applies the requested change
 

--- a/docs/content/guides/bundled-skills.md
+++ b/docs/content/guides/bundled-skills.md
@@ -6,13 +6,13 @@ sidebar_position: 4
 
 # Bundled Skills
 
-HybridClaw ships with 68 bundled skills. A few notable categories:
+HybridClaw ships with 70 bundled skills. A few notable categories:
 
 - office workflows: `pdf`, `xlsx`, `docx`, `pptx`, `office-workflows`
 - planning and engineering: `project-manager`, `feature-planning`, `code-review`, `code-simplification`, `gh-issues`, `warehouse-sql`
 - visual explainers, image, video, and speech: `diagram`, `manim-video`, `excalidraw`, `image-generation`, `video-generation`, `video.from-script`, `speech.transcribe`, `speech.detect-language`
 - platform integrations: `github-pr-workflow`, `notion`, `trello`, `stripe`, `download-platform-invoices`, `wordpress`, `gog`, `google-workspace`, `google-ads`, `ga4`, `airtable`, `fastbill`, `hubspot`, `lexware-office`, `firecrawl`, `heygen`, `hermes3000-writing`, `discord`
-- infrastructure, production ops, and home automation: `hetzner-cloud`, `hetzner-dns`, `hetzner-storage-box`, `mittwald`, `t-cloud-public`, `zabbix`, `shelly`, `warehouse-sql`
+- infrastructure, production ops, home automation, and energy monitoring: `hetzner-cloud`, `hetzner-dns`, `hetzner-storage-box`, `mittwald`, `t-cloud-public`, `zabbix`, `shelly`, `homematic`, `fronius`, `warehouse-sql`
 - security and privacy: `distil-pii-redactor`
 - knowledge workflows: `llm-wiki`, `obsidian`, `zettelkasten`
 - search workflows: `search.web`, `search.news`, `search.images`

--- a/docs/content/guides/skills/README.md
+++ b/docs/content/guides/skills/README.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 # Skills Catalog
 
-HybridClaw ships **68 bundled skills** across ten categories. Each page below
+HybridClaw ships **70 bundled skills** across ten categories. Each page below
 covers every skill in its category with prerequisites, install commands,
 tips & tricks, ready-to-try example prompts, and troubleshooting.
 
@@ -32,7 +32,7 @@ For production package requirements see
 |---|---|---|
 | Office | pdf, xlsx, docx, pptx, office-workflows | [Office Skills](./office.md) |
 | Development | code-review, gh-issues, github-pr-workflow, salesforce, skill-creator, warehouse-sql | [Development Skills](./development.md) |
-| Infrastructure & Production Ops | hetzner-cloud, hetzner-dns, hetzner-storage-box, mittwald, t-cloud-public, zabbix, shelly | [Development Skills](./development.md#hetzner-devops) |
+| Infrastructure, Production Ops & Energy | hetzner-cloud, hetzner-dns, hetzner-storage-box, mittwald, t-cloud-public, zabbix, shelly, homematic, fronius | [Development Skills](./development.md#hetzner-devops) |
 | Communication | brand-voice, discord, channel-catchup, fax-send | [Communication Skills](./communication.md) |
 | Apple | apple-calendar, apple-music, apple-passwords | [Apple Skills](./apple.md) |
 | Productivity | feature-planning, project-manager, trello | [Productivity Skills](./productivity.md) |

--- a/docs/content/guides/skills/development.md
+++ b/docs/content/guides/skills/development.md
@@ -1,6 +1,6 @@
 ---
 title: Development Skills
-description: Code review, GitHub issue automation, PR workflows, Salesforce inspection, Hetzner DevOps, and skill creation tools.
+description: Code review, GitHub issue automation, PR workflows, Salesforce inspection, Hetzner DevOps, smart-home monitoring, and skill creation tools.
 sidebar_position: 3
 ---
 
@@ -498,6 +498,100 @@ documented Shelly OAuth flow for the Real Time Events API access token.
   `SHELLY_CLOUD_ACCESS_TOKEN`.
 - **Control refused** — rerun the generated approval plan and include the
   exact operator grant from a later confirmation.
+
+---
+
+## homematic
+
+Inspect Homematic IP Home Control Unit state and prepare guarded smart-home
+control messages through the HCU Connect API.
+
+**Prerequisites** — an HCU with developer mode enabled, local network
+reachability to the HCU, and Connect API credentials stored in HybridClaw
+secrets.
+
+```bash
+hybridclaw secret set HOMEMATIC_HCU_ACTIVATION_KEY "<activation-key>"
+hybridclaw secret set HOMEMATIC_HCU_AUTH_TOKEN "<auth-token>"
+```
+
+Use the activation key only long enough to enroll a Connect API token, then
+prefer the stored `HOMEMATIC_HCU_AUTH_TOKEN` for normal read and control
+planning flows.
+
+> 💡 **Tips & Tricks**
+>
+> Start with `plugin-ready`, `get-state`, or `get-system-state` before planning controls.
+>
+> The helper emits WebSocket connection headers and message payloads with SecretRef placeholders; do not paste HCU tokens into chat or command arguments.
+>
+> Switch, thermostat, shutter, and scene controls are approval-gated. Safety alarm acknowledgement is red-tier.
+
+> 🎯 **Try it yourself**
+>
+> `Summarize the current Homematic HCU state from this fixture`
+>
+> `Prepare a read-only get-state message for my HCU at https://hcu1-1234.local`
+>
+> `Build an approval plan to set the hallway thermostat group to 20.5 degrees`
+>
+> `Plan a shutter move to 25 percent for this device without executing it`
+
+**Troubleshooting**
+
+- **HCU URL rejected** — use the local HCUweb hostname such as
+  `https://hcu1-1234.local` or the HCU IP address when mDNS is unavailable.
+- **Token missing** — store `HOMEMATIC_HCU_AUTH_TOKEN`; do not pass it as a
+  CLI argument.
+- **Local connection fails** — verify gateway network policy, macOS Local
+  Network permission, and HCU WebSocket exposure separately.
+
+---
+
+## fronius
+
+Read Fronius photovoltaic inverter and Solar.web monitoring data without
+exposing local host configuration or Solar.web access-key material.
+
+**Prerequisites** — a local inverter host for LAN reads, or Solar.web Query API
+access keys for cloud reads.
+
+```bash
+hybridclaw env set FRONIUS_LOCAL_HOST "http://<fronius-ip>"
+hybridclaw secret set FRONIUS_SOLARWEB_ACCESS_KEY_ID "<access-key-id>"
+hybridclaw secret set FRONIUS_SOLARWEB_ACCESS_KEY_VALUE "<access-key-value>"
+```
+
+`FRONIUS_LOCAL_HOST` is plaintext configuration because it is a local hostname
+or IP address. Solar.web access keys stay in encrypted secrets and are injected
+server-side as request headers.
+
+> 💡 **Tips & Tricks**
+>
+> Use `local-summary` or `local-power-flow` for live production, load, grid, and battery status.
+>
+> Use `cloud-pvsystems`, `cloud-flowdata`, `cloud-aggrdata`, and `cloud-histdata` for Solar.web inventory and energy rollups.
+>
+> State whether an answer came from local inverter data or Solar.web cloud data.
+
+> 🎯 **Try it yourself**
+>
+> `Show current Fronius local production, load, grid exchange, and battery state`
+>
+> `Check whether my Solar.web credentials can list PV systems`
+>
+> `Summarize produced energy for this PV system yesterday`
+>
+> `List recent Fronius cloud error messages and turn them into an incident summary`
+
+**Troubleshooting**
+
+- **Local host missing** — set `FRONIUS_LOCAL_HOST` or pass the inverter base
+  URL for the request.
+- **Solar.web 401 or 403** — verify both access-key secrets and the Solar.web
+  Query API package attached to the account.
+- **Gateway policy denial** — allow the selected local inverter host or
+  `api.solarweb.com` before running live requests.
 
 ---
 

--- a/docs/content/internal/roadmap.md
+++ b/docs/content/internal/roadmap.md
@@ -19,7 +19,7 @@ The roadmap is anchored in the [HybridClaw manifesto — *The AI Coworker Who's 
 
 | # | Feature | Description | Priority | Status |
 |---|---------|-------------|----------|--------|
-| 21 | **Business skills and connectors** | Production skills and connector work. See **R21 Production Skills** below for sub-issue rows. *Principle I — the skills are the product.* | P0 | 🟡 21/111 |
+| 21 | **Business skills and connectors** | Production skills and connector work. See **R21 Production Skills** below for sub-issue rows. *Principle I — the skills are the product.* | P0 | 🟡 23/116 |
 | 1 | **Agent-to-agent messaging** | First-class primitive for agents to message, hand off, escalate, federate across instances, and speak multiple transport formats. See **R1 Messaging Work** below for sub-issue rows. *Principle VI.* | P0 | 🟡 11/14 |
 | 2 | **Workflow engine — autonomous-by-default with high-stakes escalation** | Declarative YAML workflows. Sequential runner; escalation gates only on high-stakes steps. Return-for-revision rewinds. Built on top of #1. See **R2 Workflow Work** below for sub-issue rows. *Principles II + VI.* | P0 | 🔄 #461 |
 | 3 | **Agent scoreboard + auto-`CV.md`** | Per-skill score data model populated from the skill-run event bus. Auto-rendered CV per agent; admin scoreboard; "best at X" recommendation API. See **R3 Scoreboard Work** below for the follow-up row. *Principle IV.* | P0 | ✅ (5/5; follow-up R3.7 ✅ #618; #616, #619 still open) |

--- a/docs/content/reference/commands.md
+++ b/docs/content/reference/commands.md
@@ -299,6 +299,10 @@ hybridclaw secret unset <name>
 hybridclaw secret route list
 hybridclaw secret route add <url-prefix> <secret-name|google-oauth> [header] [prefix|none]
 hybridclaw secret route remove <url-prefix> [header]
+hybridclaw env list
+hybridclaw env set <name> <value>
+hybridclaw env show <name>
+hybridclaw env unset <name>
 ```
 
 ```text
@@ -309,6 +313,10 @@ hybridclaw secret route remove <url-prefix> [header]
 /secret route list
 /secret route add <url-prefix> <secret-name|google-oauth> [header] [prefix|none]
 /secret route remove <url-prefix> [header]
+/env list
+/env set <name> <value>
+/env show <name>
+/env unset <name>
 ```
 
 - local-only surface: `/secret ...` is available from local TUI and local web
@@ -325,6 +333,9 @@ hybridclaw secret route remove <url-prefix> [header]
 - use `google-oauth` as the secret name for direct Google API routes after
   `hybridclaw auth login google`; see
   [Google OAuth For Direct Google APIs](../getting-started/authentication.md#google-oauth-for-direct-google-apis)
+- `env` stores plaintext runtime values such as local device hostnames,
+  account ids, or usernames for agent helpers. Do not use it for passwords,
+  tokens, API keys, or signing material; use encrypted secrets for those.
 
 ## Channels
 
@@ -579,14 +590,19 @@ actions. Common examples:
 !claw schedule add every <ms> <prompt>
 ```
 
-`/agent`, `/model`, `/reset`, `/mcp`, `/btw`, and related slash commands route
-through the same gateway command surface used by TUI and web chat. `/context`
-is local-only because it exposes session context-window accounting.
+`/agent`, `/model`, `/reset`, `/mcp`, `/btw`, `/second-opinion`, and related
+slash commands route through the same gateway command surface used by TUI and
+web chat. `/context` is local-only because it exposes session context-window
+accounting.
 
 ## In Session
 
 - `/help` shows the same canonical slash-command list in TUI and embedded web
   chat, filtered per surface and kept in a consistent alphabetical order
+- `/audit turn <n>` and `/audit run <runId>` show focused turn traces for one
+  request, including nearby tool, approval, and audit events
+- `/second-opinion` compares a question or validates the last answer with a
+  stronger configured model; `fact-check` adds bounded web-search evidence
 
 ### Slash Command Inventory
 
@@ -599,7 +615,7 @@ plugins and explicit skill invocations can add dynamic slash commands; use
 |---|---|---|
 | `/agent [info|list|switch|create|install|model]` | local and chat channels | Inspect, create, switch, install, or set models for agents |
 | `/approve [view|yes|session|agent|all|no] [approval_id]` | local and chat channels | View or answer pending tool approval requests |
-| `/audit [sessionId]` | local and chat channels | Show recent structured audit events |
+| `/audit [sessionId]|last|turn <n>|run <runId>` | local and chat channels | Show recent audit events or focused turn traces |
 | `/auth status <provider>` | local TUI/web | Show local auth and provider config state |
 | `/bot [info|list|set <id|name>|clear]` | local and chat channels | Inspect or select the active chatbot |
 | `/btw <question>` | local and chat channels | Ask an ephemeral side question without tools or persistence |
@@ -611,6 +627,7 @@ plugins and explicit skill invocations can add dynamic slash commands; use
 | `/config [check|reload|get|set]` | local TUI/web | Inspect, reload, or edit runtime config |
 | `/context` | local TUI/web | Show context-window usage and compaction headroom |
 | `/dream [status|on|off|now]` | local TUI/web | Configure or run memory consolidation |
+| `/env [list|set|show|unset]` | local TUI/web | Manage plaintext runtime env values for agents and helpers |
 | `/eval [list|env|<suite>|<command...>]` | local TUI/web | Run local eval helpers or detached benchmark commands |
 | `/export session [sessionId]` | local and chat channels | Export a session snapshot |
 | `/export trace [sessionId|all]` | local and chat channels | Export trace JSONL |
@@ -630,6 +647,7 @@ plugins and explicit skill invocations can add dynamic slash commands; use
 | `/reset [yes|no]` | local and chat channels | Run the confirmed workspace reset flow |
 | `/schedule add|list|remove|toggle ...` | local and chat channels | Manage scheduled tasks for the session |
 | `/secret [list|set|show|unset|route]` | local TUI/web | Manage encrypted secrets and HTTP auth routes |
+| `/second-opinion [compare|validate|fact-check]` | local and chat channels | Ask a stronger configured model to compare, validate, or fact-check |
 | `/sessions [active|clear-active]` | local and chat channels | Inspect or clear active session tracking |
 | `/show [all|thinking|tools|none]` | local and chat channels | Control thinking/tool activity visibility |
 | `/skill ...` or `/<skill>` | local TUI/web | Manage skills or explicitly invoke one skill |

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -158,8 +158,10 @@ saved revision history directly.
 - `agents.list[].webSearch.searxngBaseUrl` and
   `agents.list[].webSearch.searxngBearerTokenRef` override the global SearXNG
   instance and bearer SecretRef for a specific agent
-- `agents.list[].budget.cap` and `agents.list[].budget.currency` configure the
-  read-only board budget chip for that agent; `currency` accepts `USD` or `EUR`
+- `agents.list[].budget.cap`, `agents.list[].budget.currency`, and optional
+  `agents.list[].budget.unit` configure the read-only board budget chip and
+  budget-aware commands for that agent. `unit` accepts `USD`, `EUR`, or
+  `tokens`; when omitted, the budget uses the configured currency.
 - `channelInstructions.*` for transport-specific prompt guidance injected into
   the runtime prompt; `channelInstructions.voice` is the right place for
   spoken-style rules such as "no markdown" or "keep replies short";
@@ -175,6 +177,9 @@ saved revision history directly.
   `auxiliaryModels.session_title.provider` to `"disabled"` to skip this
   forwarding and leave recent-session titles derived locally from conversation
   previews.
+- `auxiliaryModels.second_opinion` controls the default stronger model used by
+  `/second-opinion`. Set its `provider`, `model`, and `maxTokens` when the
+  automatic strongest-model selection is not the desired validator.
 - `adaptiveSkills.*` for skill observation, amendment staging, rollback, and opt-in trajectory capture via `adaptiveSkills.trajectoryCapture.enabledAgentIds`
 - Captured trajectories run through PII/secret redaction, and configured confidential-info rules preserve the documented `«CONF:<RULE_ID>»` placeholder format before trajectories are written
 - `adaptiveSkills.trajectoryCapture.storeDir` controls trajectory storage; empty stores beside the runtime database, absolute paths are used as-is, and relative paths resolve under the runtime home directory

--- a/docs/content/reference/diagnostics.md
+++ b/docs/content/reference/diagnostics.md
@@ -58,7 +58,16 @@ sessions).
 ## Request Logging
 
 When environment-level checks pass but a specific turn still needs debugging,
-start or restart the gateway with request logging enabled:
+start with the focused audit trace before enabling persistent request logging:
+
+```text
+/audit turn 3
+/audit run run_abc123
+```
+
+Those views show the request, response, tool, approval, and audit events around
+one turn. If the trace is not enough, start or restart the gateway with request
+logging enabled:
 
 ```bash
 hybridclaw gateway start --log-requests


### PR DESCRIPTION
## Summary

- Update `Unreleased` changelog entries for all changes on `main` since `v0.20.0`
- Refresh README and docs highlights for second-opinion, response ratings, turn traces, token budgets, A2A updates, and new skills
- Update bundled skill catalog counts and examples for Fronius and Homematic
- Align internal roadmap status with the current R21 table

## Validation

- `git diff --cached --check`
- `git diff --check`
- Relative Markdown link validation for changed docs
- Verified bundled skill count with `find skills -name SKILL.md | wc -l` => `70`

`npm run check` was attempted but could not run in this worktree because `node_modules` is absent and `biome` is not installed.