### PR TITLE
[codex] fix Codex device-code login response parsing

### DIFF
--- a/src/auth/codex-auth.ts
+++ b/src/auth/codex-auth.ts
@@ -19,7 +19,7 @@ export const CODEX_DEFAULT_CALLBACK_HOST = '127.0.0.1';
 export const CODEX_DEFAULT_CALLBACK_PORT = 1455;
 export const CODEX_DEFAULT_CALLBACK_REDIRECT_HOST = 'localhost';
 export const CODEX_DEFAULT_DEVICE_CODE_VERIFICATION_URL =
-  'https://auth.openai.com/activate';
+  'https://auth.openai.com/codex/device';
 export const CODEX_REFRESH_SKEW_MS = 2 * 60_000;
 export const CODEX_LOCK_STALE_MS = 30_000;
 export const CODEX_LOCK_TIMEOUT_MS = 15_000;
@@ -785,7 +785,9 @@ function normalizeDeviceCodeResponse(payload: unknown): DeviceCodeResponse {
     normalizeString(payload.device_code) ||
     normalizeString(payload.deviceCode);
   const userCode =
-    normalizeString(payload.user_code) || normalizeString(payload.userCode);
+    normalizeString(payload.user_code) ||
+    normalizeString(payload.userCode) ||
+    normalizeString(payload.usercode);
   const verificationUrl =
     normalizeString(payload.verification_uri) ||
     normalizeString(payload.verification_url) ||

--- a/tests/codex-auth.test.ts
+++ b/tests/codex-auth.test.ts
@@ -482,7 +482,7 @@ describe('codex auth device code flow', () => {
     vi.useRealTimers();
   });
 
-  it('falls back to the default activation URL and tolerates nested pending errors', async () => {
+  it('falls back to the Codex device URL and tolerates usercode plus nested pending errors', async () => {
     vi.useFakeTimers();
     const homeDir = makeTempHome();
     const codexAuth = await importFreshCodexAuth(homeDir);
@@ -506,7 +506,7 @@ describe('codex auth device code flow', () => {
         return new Response(
           JSON.stringify({
             device_auth_id: 'device_auth_nested',
-            user_code: 'USER-NESTED',
+            usercode: 'USER-NESTED',
             interval: '1',
             expires_at: '2026-03-06T17:59:56.536528+00:00',
           }),
@@ -575,7 +575,7 @@ describe('codex auth device code flow', () => {
 
     expect(result.credentials.accountId).toBe('acct_device_nested');
     expect(consoleLog).toHaveBeenCalledWith(
-      'Verify: https://auth.openai.com/activate',
+      'Verify: https://auth.openai.com/codex/device',
     );
     expect(fetchMock).toHaveBeenCalledTimes(4);
     vi.useRealTimers();


### PR DESCRIPTION
## Summary

Fix Codex device-code login for newer OpenAI auth responses that return `usercode` instead of `user_code`, which previously caused onboarding/login to fail with `Device code response was missing required fields` on VPS/headless installs.

## Changes

- Accept `usercode` as an alias for the device-code user code field.
- Use the current Codex device verification URL (`https://auth.openai.com/codex/device`) when the response omits a verification URL.
- Update the Codex auth regression test to cover the newer response shape.

## Validation

- `npx biome check --write src/auth/codex-auth.ts tests/codex-auth.test.ts`
- `./node_modules/.bin/vitest run --configLoader runner --project unit tests/codex-auth.test.ts`