### PR TITLE
chore: release v0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## [0.21.1](https://github.com/HybridAIOne/hybridclaw/tree/v0.21.1) - 2026-05-29
+
+### Fixed
+
+- **Codex device-code login**: Accepted OpenAI Codex device-code responses that
+  return `usercode` instead of `user_code`, and defaulted missing verification
+  URLs to the current Codex device login page.
+
 ## [0.21.0](https://github.com/HybridAIOne/hybridclaw/tree/v0.21.0) - 2026-05-29
 
 ### Added

--- a/container/npm-shrinkwrap.json
+++ b/container/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hybridclaw-agent",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
         "@mozilla/readability": "0.6.0",

--- a/container/package-lock.json
+++ b/container/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hybridclaw-agent",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
         "@mozilla/readability": "0.6.0",

--- a/container/package.json
+++ b/container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "type": "module",
   "main": "dist/index.js",
   "packageManager": "npm@11.10.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@hybridaione/hybridclaw-desktop",
   "productName": "HybridClaw",
   "private": true,
-  "version": "0.21.0",
+  "version": "0.21.1",
   "type": "module",
   "description": "macOS wrapper for the HybridClaw chat and admin web surfaces",
   "author": "HybridAI One",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hybridaione/hybridclaw",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "packageManager": "npm@11.10.0",
       "hasInstallScript": true,
       "workspaces": [
@@ -107,7 +107,7 @@
     },
     "container": {
       "name": "hybridclaw-agent",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
         "@mozilla/readability": "0.6.0",
@@ -412,7 +412,7 @@
     },
     "desktop": {
       "name": "@hybridaione/hybridclaw-desktop",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "dependencies": {
         "@hybridaione/hybridclaw-desktop-packaging-anchor": "file:./support/packaging-anchor"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hybridaione/hybridclaw",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "packageManager": "npm@11.10.0",
       "hasInstallScript": true,
       "workspaces": [
@@ -107,7 +107,7 @@
     },
     "container": {
       "name": "hybridclaw-agent",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
         "@mozilla/readability": "0.6.0",
@@ -412,7 +412,7 @@
     },
     "desktop": {
       "name": "@hybridaione/hybridclaw-desktop",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "dependencies": {
         "@hybridaione/hybridclaw-desktop-packaging-anchor": "file:./support/packaging-anchor"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "type": "module",
   "description": "Enterprise-ready self-hosted AI assistant runtime with sandboxed execution, secure credentials, approvals, and memory",
   "repository": {

--- a/scripts/dependency-policy-baseline.json
+++ b/scripts/dependency-policy-baseline.json
@@ -1,9 +1,9 @@
 {
   "lockfiles": {
-    "package-lock.json": "d228eeaa79c9b096bef585765026a0ed92c9c81704e3e9357450c039e9b13067",
-    "npm-shrinkwrap.json": "d228eeaa79c9b096bef585765026a0ed92c9c81704e3e9357450c039e9b13067",
-    "container/package-lock.json": "34bfb8fab82aca3763cd27bd2652da3287f72d82579a25b454d913164628254b",
-    "container/npm-shrinkwrap.json": "34bfb8fab82aca3763cd27bd2652da3287f72d82579a25b454d913164628254b",
+    "package-lock.json": "20ac8acbfb613d3d3fbaf571835f1c4a2084e1a91e9e70d600684c6a79a0edbe",
+    "npm-shrinkwrap.json": "20ac8acbfb613d3d3fbaf571835f1c4a2084e1a91e9e70d600684c6a79a0edbe",
+    "container/package-lock.json": "edcc6f7f3995a100b330401f4139d57a684b5b096736a9f041fef6574ebf0458",
+    "container/npm-shrinkwrap.json": "edcc6f7f3995a100b330401f4139d57a684b5b096736a9f041fef6574ebf0458",
     "plugins/brevo-email/package-lock.json": "3377225eb3bdbb252eaa28ad420b9a725ea1da533417388557aa1984730229b5"
   }
 }

--- a/src/auth/codex-auth.ts
+++ b/src/auth/codex-auth.ts
@@ -19,7 +19,7 @@ export const CODEX_DEFAULT_CALLBACK_HOST = '127.0.0.1';
 export const CODEX_DEFAULT_CALLBACK_PORT = 1455;
 export const CODEX_DEFAULT_CALLBACK_REDIRECT_HOST = 'localhost';
 export const CODEX_DEFAULT_DEVICE_CODE_VERIFICATION_URL =
-  'https://auth.openai.com/activate';
+  'https://auth.openai.com/codex/device';
 export const CODEX_REFRESH_SKEW_MS = 2 * 60_000;
 export const CODEX_LOCK_STALE_MS = 30_000;
 export const CODEX_LOCK_TIMEOUT_MS = 15_000;
@@ -785,7 +785,9 @@ function normalizeDeviceCodeResponse(payload: unknown): DeviceCodeResponse {
     normalizeString(payload.device_code) ||
     normalizeString(payload.deviceCode);
   const userCode =
-    normalizeString(payload.user_code) || normalizeString(payload.userCode);
+    normalizeString(payload.user_code) ||
+    normalizeString(payload.userCode) ||
+    normalizeString(payload.usercode);
   const verificationUrl =
     normalizeString(payload.verification_uri) ||
     normalizeString(payload.verification_url) ||

--- a/tests/codex-auth.test.ts
+++ b/tests/codex-auth.test.ts
@@ -482,7 +482,7 @@ describe('codex auth device code flow', () => {
     vi.useRealTimers();
   });
 
-  it('falls back to the default activation URL and tolerates nested pending errors', async () => {
+  it('falls back to the Codex device URL and tolerates usercode plus nested pending errors', async () => {
     vi.useFakeTimers();
     const homeDir = makeTempHome();
     const codexAuth = await importFreshCodexAuth(homeDir);
@@ -506,7 +506,7 @@ describe('codex auth device code flow', () => {
         return new Response(
           JSON.stringify({
             device_auth_id: 'device_auth_nested',
-            user_code: 'USER-NESTED',
+            usercode: 'USER-NESTED',
             interval: '1',
             expires_at: '2026-03-06T17:59:56.536528+00:00',
           }),
@@ -575,7 +575,7 @@ describe('codex auth device code flow', () => {
 
     expect(result.credentials.accountId).toBe('acct_device_nested');
     expect(consoleLog).toHaveBeenCalledWith(
-      'Verify: https://auth.openai.com/activate',
+      'Verify: https://auth.openai.com/codex/device',
     );
     expect(fetchMock).toHaveBeenCalledTimes(4);
     vi.useRealTimers();


### PR DESCRIPTION
## Summary

Create a patch release branch from `v0.21.0` containing only the Codex device-code login fix plus release metadata for `v0.21.1`.

## Changes

- Cherry-pick the Codex auth fix that accepts `usercode` responses and defaults to the current Codex device verification URL.
- Bump root, container, desktop, lockfile, and shrinkwrap versions to `0.21.1`.
- Add a focused `0.21.1` changelog entry.
- Update the dependency-policy baseline hashes for the patch-release lockfile version changes.

## Validation

- `node ./scripts/check-dependency-policy.mjs --base 3b631898c042e12d06dcd55eb1ad45bcfc204485`
- `npm run format`
- `./node_modules/.bin/vitest run --configLoader runner --project unit tests/codex-auth.test.ts`
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run release:check`
- `npm --prefix container run release:check`