### PR TITLE
[codex] Fix WhatsApp pairing after admin config changes

### DIFF
--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -297,6 +297,23 @@ function hasSignalConfigChanged(
   );
 }
 
+function hasWhatsAppConfigChanged(
+  next: ReturnType<typeof getConfigSnapshot>['whatsapp'],
+  prev: ReturnType<typeof getConfigSnapshot>['whatsapp'],
+): boolean {
+  return (
+    next.dmPolicy !== prev.dmPolicy ||
+    next.groupPolicy !== prev.groupPolicy ||
+    !equalStringSets(next.allowFrom, prev.allowFrom) ||
+    !equalStringSets(next.groupAllowFrom, prev.groupAllowFrom) ||
+    next.debounceMs !== prev.debounceMs ||
+    next.ackReaction !== prev.ackReaction ||
+    next.textChunkLimit !== prev.textChunkLimit ||
+    next.mediaMaxMb !== prev.mediaMaxMb ||
+    next.sendReadReceipts !== prev.sendReadReceipts
+  );
+}
+
 function hasThreemaConfigChanged(
   next: ReturnType<typeof getConfigSnapshot>['threema'],
   prev: ReturnType<typeof getConfigSnapshot>['threema'],
@@ -2665,6 +2682,30 @@ async function refreshSignalIntegrationForConfigChange(
   await startSignalIntegration();
 }
 
+async function refreshWhatsAppIntegrationForConfigChange(
+  next: ReturnType<typeof getConfigSnapshot>,
+  prev: ReturnType<typeof getConfigSnapshot>,
+): Promise<void> {
+  if (!hasWhatsAppConfigChanged(next.whatsapp, prev.whatsapp)) return;
+
+  logger.info(
+    {
+      dmPolicy: next.whatsapp.dmPolicy,
+      groupPolicy: next.whatsapp.groupPolicy,
+      allowFromCount: next.whatsapp.allowFrom.length,
+      groupAllowFromCount: next.whatsapp.groupAllowFrom.length,
+    },
+    'Config changed, restarting WhatsApp integration',
+  );
+  await shutdownWhatsApp().catch((error) => {
+    logger.debug(
+      { error },
+      'Failed to stop WhatsApp runtime during config-change restart',
+    );
+  });
+  await startWhatsAppIntegration();
+}
+
 async function refreshThreemaIntegrationForConfigChange(
   next: ReturnType<typeof getConfigSnapshot>,
   prev: ReturnType<typeof getConfigSnapshot>,
@@ -3516,6 +3557,14 @@ async function main(): Promise<void> {
         'Signal integration restart failed after config change',
       );
     });
+    void refreshWhatsAppIntegrationForConfigChange(next, prev).catch(
+      (error) => {
+        logger.warn(
+          { error },
+          'WhatsApp integration restart failed after config change',
+        );
+      },
+    );
     void refreshThreemaIntegrationForConfigChange(next, prev).catch((error) => {
       logger.warn(
         { error },

--- a/tests/gateway-main.test.ts
+++ b/tests/gateway-main.test.ts
@@ -166,6 +166,13 @@ function createGatewayMainTestState(options?: {
       whatsapp: {
         dmPolicy: options?.whatsappEnabled === false ? 'disabled' : 'pairing',
         groupPolicy: 'disabled',
+        allowFrom: [] as string[],
+        groupAllowFrom: [] as string[],
+        debounceMs: 1_000,
+        ackReaction: '👀',
+        textChunkLimit: 4_000,
+        mediaMaxMb: 20,
+        sendReadReceipts: false,
       },
       local: { enabled: false },
       container: {
@@ -1103,6 +1110,41 @@ describe('gateway bootstrap', () => {
       'Gateway channels',
       expect.objectContaining({
         whatsapp: false,
+      }),
+    );
+  });
+
+  test('starts WhatsApp pairing runtime when admin config enables the transport', async () => {
+    const state = await importFreshGatewayMain({
+      whatsappEnabled: false,
+      whatsappLinked: false,
+    });
+    const previousConfig = state.currentConfig;
+    const nextConfig = {
+      ...state.currentConfig,
+      whatsapp: {
+        ...state.currentConfig.whatsapp,
+        dmPolicy: 'pairing',
+      },
+    };
+
+    expect(state.initWhatsApp).not.toHaveBeenCalled();
+
+    state.currentConfig = nextConfig;
+    state.configChangeListener?.(nextConfig, previousConfig);
+    await settle();
+
+    expect(state.shutdownWhatsApp).toHaveBeenCalledTimes(1);
+    expect(state.initWhatsApp).toHaveBeenCalledTimes(1);
+    expect(state.whatsappMessageHandler).not.toBeNull();
+    expectInfoLog(
+      state,
+      'Config changed, restarting WhatsApp integration',
+      expect.objectContaining({
+        dmPolicy: 'pairing',
+        groupPolicy: 'disabled',
+        allowFromCount: 0,
+        groupAllowFromCount: 0,
       }),
     );
   });


### PR DESCRIPTION
## Summary
- Restart the WhatsApp runtime when admin channel settings change.
- Include WhatsApp policy, allowlist, debounce, media, and read-receipt fields in change detection.
- Add a gateway regression test that enables WhatsApp from a disabled state and verifies the pairing runtime starts.

## Root Cause
The admin console was already polling `/api/status` for `whatsapp.pairingQrText`, but changing WhatsApp settings through `/admin/channels` did not start or restart the gateway WhatsApp runtime. On cloud deployments this left the UI waiting for a QR that no runtime was producing until the gateway restarted.

## Validation
- `npx vitest run tests/gateway-main.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `npx biome check --write src/gateway/gateway.ts tests/gateway-main.test.ts`
- `git diff --check`