### PR TITLE
feat(gateway): friendly progress indicator while preparing the agent image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,4 +242,9 @@ jobs:
       - name: npm install journey e2e
         env:
           HYBRIDCLAW_RUN_NPM_E2E: '1'
+          # The global install triggers onnxruntime-node's postinstall, which
+          # otherwise downloads the large CUDA EP build from GitHub releases —
+          # flaky (502s) and unused in CI. Skip it; the bundled CPU runtime is
+          # enough for the gateway and these tests.
+          ONNXRUNTIME_NODE_INSTALL_CUDA: skip
         run: npx vitest run --project e2e tests/npm-install.e2e.test.ts

--- a/docs/content/developer-guide/runtime.md
+++ b/docs/content/developer-guide/runtime.md
@@ -33,6 +33,8 @@ Maintainer overrides:
 - `HYBRIDCLAW_CONTAINER_REBUILD=if-stale|always|never` adjusts rebuild policy
 - `HYBRIDCLAW_CONTAINER_IMAGE=<name[:tag]> npm run build:container` builds and
   tags a custom image
+- `HYBRIDCLAW_NO_SPINNER=1` forces the plain (non-animated) image-setup output
+  even on an interactive terminal
 
 Build context hygiene is enforced by `container/.dockerignore` to avoid shipping
 local secrets or artifacts into published images.

--- a/src/infra/container-setup.ts
+++ b/src/infra/container-setup.ts
@@ -563,6 +563,18 @@ function ensureInteractiveAutoBuild(
   return false;
 }
 
+function buildErrorWithEarlierPullFailure(
+  buildError: unknown,
+  lastPullError: string | null,
+): unknown {
+  if (!lastPullError) return buildError;
+  const detail =
+    buildError instanceof Error ? buildError.message : String(buildError);
+  return new Error(
+    `${detail} (after a published image pull also failed: ${lastPullError})`,
+  );
+}
+
 async function buildAndValidateImage(params: {
   commandName: string;
   required: boolean;
@@ -631,8 +643,6 @@ async function buildAndValidateImage(params: {
             indicator.succeed('Agent runtime ready.');
             return;
           } catch (err) {
-            // Try the next candidate (e.g. version-specific tag, then latest)
-            // before surfacing anything; only the final failure matters.
             lastPullError = err instanceof Error ? err.message : String(err);
           }
         }
@@ -654,17 +664,7 @@ async function buildAndValidateImage(params: {
       recordImageState(cwd, imageName, fingerprint);
       indicator.succeed('Agent runtime ready.');
     } catch (buildError) {
-      // If we only reached the local build because every published-image pull
-      // failed, surface that pull failure too — otherwise it is discarded and
-      // the user can't tell the pull was even attempted or why it failed.
-      if (lastPullError) {
-        const detail =
-          buildError instanceof Error ? buildError.message : String(buildError);
-        throw new Error(
-          `${detail} (after a published image pull also failed: ${lastPullError})`,
-        );
-      }
-      throw buildError;
+      throw buildErrorWithEarlierPullFailure(buildError, lastPullError);
     } finally {
       indicator.clear();
     }

--- a/src/infra/container-setup.ts
+++ b/src/infra/container-setup.ts
@@ -604,6 +604,7 @@ async function buildAndValidateImage(params: {
   }
 
   try {
+    let lastPullError: string | null = null;
     if (
       acquisitionMode === 'pull-or-build' ||
       acquisitionMode === 'pull-only'
@@ -621,7 +622,6 @@ async function buildAndValidateImage(params: {
       const indicator = startProgressIndicator(
         `${progressLabel} — downloading image…`,
       );
-      let lastPullError: string | null = null;
       try {
         for (const pullImage of pullImages) {
           try {
@@ -653,6 +653,18 @@ async function buildAndValidateImage(params: {
       await buildContainerImage(cwd, imageName);
       recordImageState(cwd, imageName, fingerprint);
       indicator.succeed('Agent runtime ready.');
+    } catch (buildError) {
+      // If we only reached the local build because every published-image pull
+      // failed, surface that pull failure too — otherwise it is discarded and
+      // the user can't tell the pull was even attempted or why it failed.
+      if (lastPullError) {
+        const detail =
+          buildError instanceof Error ? buildError.message : String(buildError);
+        throw new Error(
+          `${detail} (after a published image pull also failed: ${lastPullError})`,
+        );
+      }
+      throw buildError;
     } finally {
       indicator.clear();
     }

--- a/src/infra/container-setup.ts
+++ b/src/infra/container-setup.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 
 import { APP_VERSION, CONTAINER_IMAGE } from '../config/config.js';
 import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+import { startProgressIndicator } from './progress-indicator.js';
 
 export type ContainerRebuildPolicy = 'if-stale' | 'always' | 'never';
 export type ContainerImageAcquisitionMode =
@@ -570,6 +571,7 @@ async function buildAndValidateImage(params: {
   acquisitionMode: ContainerImageAcquisitionMode;
   reason: string;
   hint: string;
+  progressLabel: string;
   fingerprint: string | null;
   fallbackToExistingImage?: boolean;
 }): Promise<void> {
@@ -581,6 +583,7 @@ async function buildAndValidateImage(params: {
     acquisitionMode,
     reason,
     hint,
+    progressLabel,
     fingerprint,
     fallbackToExistingImage = false,
   } = params;
@@ -601,7 +604,6 @@ async function buildAndValidateImage(params: {
   }
 
   try {
-    let reasonLoggedBeforeBuild = false;
     if (
       acquisitionMode === 'pull-or-build' ||
       acquisitionMode === 'pull-only'
@@ -616,44 +618,44 @@ async function buildAndValidateImage(params: {
           ].join(' '),
         );
       }
-      console.log(`${commandName}: ${reason}`);
-      reasonLoggedBeforeBuild = true;
-      for (const pullImage of pullImages) {
-        console.log(
-          `${commandName}: Pulling container image '${pullImage}'...`,
-        );
-        try {
-          await pullContainerImage(pullImage);
-          await tagContainerImage(pullImage, imageName);
-          recordImageState(cwd, imageName, fingerprint);
-          if (pullImage === imageName) {
-            console.log(
-              `${commandName}: Pulled container image '${imageName}'.`,
-            );
-          } else {
-            console.log(
-              `${commandName}: Pulled container image '${pullImage}' and tagged it as '${imageName}'.`,
-            );
+      const indicator = startProgressIndicator(
+        `${progressLabel} — downloading image…`,
+      );
+      let lastPullError: string | null = null;
+      try {
+        for (const pullImage of pullImages) {
+          try {
+            await pullContainerImage(pullImage);
+            await tagContainerImage(pullImage, imageName);
+            recordImageState(cwd, imageName, fingerprint);
+            indicator.succeed('Agent runtime ready.');
+            return;
+          } catch (err) {
+            // Try the next candidate (e.g. version-specific tag, then latest)
+            // before surfacing anything; only the final failure matters.
+            lastPullError = err instanceof Error ? err.message : String(err);
           }
-          return;
-        } catch (err) {
-          const pullMessage = err instanceof Error ? err.message : String(err);
-          console.warn(`${commandName}: Unable to pull image '${pullImage}'.`);
-          console.warn(`Details: ${pullMessage}`);
         }
+      } finally {
+        indicator.clear();
       }
       if (acquisitionMode === 'pull-only') {
-        throw new Error('Published container image pull attempts failed.');
+        throw new Error(
+          lastPullError || 'Published container image pull attempts failed.',
+        );
       }
     }
 
-    const buildLogMessage = reasonLoggedBeforeBuild
-      ? `${commandName}: Building container image '${imageName}'...`
-      : `${commandName}: ${reason} Building container image '${imageName}'...`;
-    console.log(buildLogMessage);
-    await buildContainerImage(cwd, imageName);
-    recordImageState(cwd, imageName, fingerprint);
-    console.log(`${commandName}: Built container image '${imageName}'.`);
+    const indicator = startProgressIndicator(
+      `${progressLabel} — building image…`,
+    );
+    try {
+      await buildContainerImage(cwd, imageName);
+      recordImageState(cwd, imageName, fingerprint);
+      indicator.succeed('Agent runtime ready.');
+    } finally {
+      indicator.clear();
+    }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     if (fallbackToExistingImage) {
@@ -743,6 +745,7 @@ export async function ensureContainerImageReady(
       acquisitionMode,
       reason: 'Container image not found.',
       hint: missingImageHint,
+      progressLabel: 'Setting up the agent runtime',
       fingerprint,
     });
     return;
@@ -764,6 +767,7 @@ export async function ensureContainerImageReady(
       acquisitionMode,
       reason: "Container refresh policy is 'always'.",
       hint: rebuildImageHint,
+      progressLabel: 'Refreshing the agent runtime',
       fingerprint,
     });
     return;
@@ -789,6 +793,7 @@ export async function ensureContainerImageReady(
     acquisitionMode,
     reason: staleImageReason,
     hint: refreshImageHint,
+    progressLabel: 'Updating the agent runtime',
     fingerprint,
     fallbackToExistingImage: true,
   });

--- a/src/infra/progress-indicator.ts
+++ b/src/infra/progress-indicator.ts
@@ -1,0 +1,95 @@
+const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+const FRAME_INTERVAL_MS = 90;
+
+const CYAN = '\x1b[36m';
+const GREEN = '\x1b[32m';
+const RED = '\x1b[31m';
+const DIM = '\x1b[2m';
+const RESET = '\x1b[0m';
+const CLEAR_LINE = '\r\x1b[2K';
+
+export interface ProgressIndicator {
+  /** Stop the animation and print a success line with a check mark. */
+  succeed(message: string): void;
+  /** Stop the animation and print a failure line with a cross mark. */
+  fail(message: string): void;
+  /** Stop the animation and leave no result line behind. */
+  clear(): void;
+}
+
+/**
+ * Decide whether to draw the animated spinner. We only animate on a real TTY so
+ * piped output, log files (e.g. the detached gateway backend), and the test
+ * runner get plain, readable lines instead of ANSI escape noise.
+ */
+function isAnimated(stream: NodeJS.WriteStream): boolean {
+  if (process.env.HYBRIDCLAW_NO_SPINNER === '1') return false;
+  if (process.env.VITEST) return false;
+  return stream.isTTY === true;
+}
+
+function formatElapsed(elapsedMs: number): string {
+  const totalSeconds = Math.floor(elapsedMs / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}m${String(seconds).padStart(2, '0')}s`;
+}
+
+/**
+ * Start a single-line progress indicator for a long-running step. On an
+ * interactive terminal it animates a spinner with an elapsed-time counter; on
+ * non-interactive streams it stays silent until a result line is printed, so
+ * logs and test output stay clean.
+ */
+export function startProgressIndicator(
+  message: string,
+  stream: NodeJS.WriteStream = process.stdout,
+): ProgressIndicator {
+  const animated = isAnimated(stream);
+  const startedAt = Date.now();
+  let frame = 0;
+  let timer: NodeJS.Timeout | null = null;
+  let finished = false;
+
+  const render = () => {
+    const glyph = SPINNER_FRAMES[frame % SPINNER_FRAMES.length];
+    frame += 1;
+    const elapsed = formatElapsed(Date.now() - startedAt);
+    stream.write(
+      `${CLEAR_LINE}${CYAN}${glyph}${RESET} ${message} ${DIM}(${elapsed})${RESET}`,
+    );
+  };
+
+  if (animated) {
+    render();
+    timer = setInterval(render, FRAME_INTERVAL_MS);
+    // Never let the spinner keep the process alive on its own.
+    timer.unref?.();
+  }
+
+  const stop = () => {
+    if (finished) return false;
+    finished = true;
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+    if (animated) stream.write(CLEAR_LINE);
+    return true;
+  };
+
+  return {
+    succeed(result) {
+      if (!stop()) return;
+      console.log(animated ? `${GREEN}✔${RESET} ${result}` : result);
+    },
+    fail(result) {
+      if (!stop()) return;
+      console.warn(animated ? `${RED}✖${RESET} ${result}` : result);
+    },
+    clear() {
+      stop();
+    },
+  };
+}

--- a/src/infra/progress-indicator.ts
+++ b/src/infra/progress-indicator.ts
@@ -9,27 +9,11 @@ const RESET = '\x1b[0m';
 const CLEAR_LINE = '\r\x1b[2K';
 
 export interface ProgressIndicator {
-  /**
-   * Stop the animation and print a success result line. On an animated stream
-   * the line is prefixed with a green check mark; on plain output the raw
-   * message is printed with no marker.
-   */
   succeed(message: string): void;
-  /**
-   * Stop the animation and print a failure result line. On an animated stream
-   * the line is prefixed with a red cross mark; on plain output the raw
-   * message is printed with no marker.
-   */
   fail(message: string): void;
-  /** Stop the animation and leave no result line behind. */
   clear(): void;
 }
 
-/**
- * Decide whether to draw the animated spinner. We only animate on a real TTY so
- * piped output, log files (e.g. the detached gateway backend), and the test
- * runner get plain, readable lines instead of ANSI escape noise.
- */
 function isAnimated(stream: NodeJS.WriteStream): boolean {
   if (process.env.HYBRIDCLAW_NO_SPINNER === '1') return false;
   if (process.env.VITEST) return false;
@@ -44,13 +28,6 @@ function formatElapsed(elapsedMs: number): string {
   return `${minutes}m${String(seconds).padStart(2, '0')}s`;
 }
 
-/**
- * Start a single-line progress indicator for a long-running step. On an
- * interactive terminal it animates a spinner with an elapsed-time counter; on
- * non-interactive streams it emits a single plain breadcrumb line up front (and
- * a plain result line at the end) instead of animating, so logs and test output
- * stay free of ANSI escape noise.
- */
 export function startProgressIndicator(
   message: string,
   stream: NodeJS.WriteStream = process.stdout,
@@ -73,12 +50,8 @@ export function startProgressIndicator(
   if (animated) {
     render();
     timer = setInterval(render, FRAME_INTERVAL_MS);
-    // Never let the spinner keep the process alive on its own.
     timer.unref?.();
   } else {
-    // No animation (NO_SPINNER, non-TTY, or test runner): emit a single plain
-    // line so a long pull/build still leaves a breadcrumb instead of going
-    // completely silent until the result.
     console.log(message);
   }
 

--- a/src/infra/progress-indicator.ts
+++ b/src/infra/progress-indicator.ts
@@ -66,6 +66,11 @@ export function startProgressIndicator(
     timer = setInterval(render, FRAME_INTERVAL_MS);
     // Never let the spinner keep the process alive on its own.
     timer.unref?.();
+  } else {
+    // No animation (NO_SPINNER, non-TTY, or test runner): emit a single plain
+    // line so a long pull/build still leaves a breadcrumb instead of going
+    // completely silent until the result.
+    console.log(message);
   }
 
   const stop = () => {

--- a/src/infra/progress-indicator.ts
+++ b/src/infra/progress-indicator.ts
@@ -9,9 +9,17 @@ const RESET = '\x1b[0m';
 const CLEAR_LINE = '\r\x1b[2K';
 
 export interface ProgressIndicator {
-  /** Stop the animation and print a success line with a check mark. */
+  /**
+   * Stop the animation and print a success result line. On an animated stream
+   * the line is prefixed with a green check mark; on plain output the raw
+   * message is printed with no marker.
+   */
   succeed(message: string): void;
-  /** Stop the animation and print a failure line with a cross mark. */
+  /**
+   * Stop the animation and print a failure result line. On an animated stream
+   * the line is prefixed with a red cross mark; on plain output the raw
+   * message is printed with no marker.
+   */
   fail(message: string): void;
   /** Stop the animation and leave no result line behind. */
   clear(): void;
@@ -39,8 +47,9 @@ function formatElapsed(elapsedMs: number): string {
 /**
  * Start a single-line progress indicator for a long-running step. On an
  * interactive terminal it animates a spinner with an elapsed-time counter; on
- * non-interactive streams it stays silent until a result line is printed, so
- * logs and test output stay clean.
+ * non-interactive streams it emits a single plain breadcrumb line up front (and
+ * a plain result line at the end) instead of animating, so logs and test output
+ * stay free of ANSI escape noise.
  */
 export function startProgressIndicator(
   message: string,

--- a/tests/container-setup.test.ts
+++ b/tests/container-setup.test.ts
@@ -642,6 +642,62 @@ describe('ensureContainerImageReady', () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
+  test('surfaces the pull failure when the fallback local build also fails', async () => {
+    const cwd = createTempDir();
+    writeTrackedFiles(cwd);
+    vi.stubEnv(
+      'HYBRIDCLAW_CONTAINER_PULL_IMAGE',
+      'ghcr.io/hybridaione/hybridclaw-agent:latest',
+    );
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+
+    const spawnMock = vi.fn((command: string, args: string[]) => {
+      const dockerAvailable = mockDockerAvailable(command, args);
+      if (dockerAvailable) return dockerAvailable;
+      if (
+        command === 'docker' &&
+        args[0] === 'image' &&
+        args[1] === 'inspect'
+      ) {
+        return makeSpawnResult({ code: 1, err: 'missing image' });
+      }
+      if (command === 'docker' && args[0] === 'pull') {
+        return makeSpawnResult({ code: 1, err: 'pull failed' });
+      }
+      if (
+        command === 'npm' &&
+        args[0] === 'run' &&
+        args[1] === 'build:container'
+      ) {
+        return makeSpawnResult({ code: 1, err: 'build failed' });
+      }
+      throw new Error(`Unexpected spawn: ${command} ${args.join(' ')}`);
+    });
+
+    const containerSetup = await importFreshContainerSetup({
+      homeDir: createTempDir(),
+      spawnMock,
+    });
+
+    // When both the published-image pull and the local build fail, the thrown
+    // error keeps both reasons instead of discarding the pull failure.
+    await expect(
+      containerSetup.ensureContainerImageReady({
+        commandName: 'hybridclaw gateway restart',
+        cwd,
+      }),
+    ).rejects.toThrow(
+      'build failed (after a published image pull also failed: pull failed)',
+    );
+  });
+
   test('refreshes stale packaged installs by pulling from Docker Hub before building locally', async () => {
     const cwd = createTempDir();
     const homeDir = createTempDir();

--- a/tests/container-setup.test.ts
+++ b/tests/container-setup.test.ts
@@ -445,9 +445,8 @@ describe('ensureContainerImageReady', () => {
       "hybridclaw gateway restart: Unable to refresh image automatically. Continuing with existing container image 'hybridclaw-agent'.",
     );
     expect(warnSpy).toHaveBeenCalledWith('Details: build failed');
-    expect(logSpy).toHaveBeenCalledWith(
-      "hybridclaw gateway restart: Container sources changed since the last recorded build. Building container image 'hybridclaw-agent'...",
-    );
+    // The build failed, so no success line should be printed.
+    expect(logSpy).not.toHaveBeenCalledWith('Agent runtime ready.');
   });
 
   test('throws when the required image is missing and build fails', async () => {
@@ -556,7 +555,7 @@ describe('ensureContainerImageReady', () => {
     ).toBe(false);
   });
 
-  test('does not repeat the refresh reason when pull-or-build falls back to a local build', async () => {
+  test('falls back to a local build when the configured pull image is unavailable', async () => {
     const cwd = createTempDir();
     const homeDir = createTempDir();
     writeTrackedFiles(cwd);
@@ -615,22 +614,32 @@ describe('ensureContainerImageReady', () => {
       }),
     ).resolves.toBeUndefined();
 
-    expect(logSpy).toHaveBeenCalledWith(
-      'hybridclaw gateway restart: Container sources changed since the last recorded build.',
-    );
-    expect(logSpy).toHaveBeenCalledWith(
-      "hybridclaw gateway restart: Pulling container image 'ghcr.io/hybridaione/hybridclaw-agent:latest'...",
-    );
-    expect(logSpy).toHaveBeenCalledWith(
-      "hybridclaw gateway restart: Building container image 'hybridclaw-agent'...",
-    );
-    expect(logSpy).not.toHaveBeenCalledWith(
-      "hybridclaw gateway restart: Container sources changed since the last recorded build. Building container image 'hybridclaw-agent'...",
-    );
-    expect(warnSpy).toHaveBeenCalledWith(
-      "hybridclaw gateway restart: Unable to pull image 'ghcr.io/hybridaione/hybridclaw-agent:latest'.",
-    );
-    expect(warnSpy).toHaveBeenCalledWith('Details: pull failed');
+    // The configured pull image is tried first, then we quietly fall back to a
+    // local build.
+    expect(
+      spawnMock.mock.calls.some(
+        ([command, args]) =>
+          command === 'docker' &&
+          Array.isArray(args) &&
+          args[0] === 'pull' &&
+          args[1] === 'ghcr.io/hybridaione/hybridclaw-agent:latest',
+      ),
+    ).toBe(true);
+    expect(
+      spawnMock.mock.calls.some(
+        ([command, args]) =>
+          command === 'npm' &&
+          Array.isArray(args) &&
+          args[0] === 'run' &&
+          args[1] === 'build:container',
+      ),
+    ).toBe(true);
+    // Exactly one success line, and no scary per-candidate pull warnings.
+    expect(
+      logSpy.mock.calls.filter(([message]) => message === 'Agent runtime ready.')
+        .length,
+    ).toBe(1);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   test('refreshes stale packaged installs by pulling from Docker Hub before building locally', async () => {
@@ -712,11 +721,81 @@ describe('ensureContainerImageReady', () => {
           args[1] === 'build:container',
       ),
     ).toBe(false);
+    expect(logSpy).toHaveBeenCalledWith('Agent runtime ready.');
+  });
+
+  test('animates a download progress indicator while pulling on an interactive terminal', async () => {
+    const cwd = createTempDir();
+    const homeDir = createTempDir();
+    writePackagedTrackedFiles(cwd);
+    writeState(homeDir, cwd, 'hybridclaw-agent', 'stale-fingerprint');
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+    // The test runner disables spinner animation via VITEST; clear it so the
+    // real interactive code path runs end to end.
+    vi.stubEnv('VITEST', '');
+
+    const spawnMock = vi.fn((command: string, args: string[]) => {
+      const dockerAvailable = mockDockerAvailable(command, args);
+      if (dockerAvailable) return dockerAvailable;
+      if (
+        command === 'docker' &&
+        args[0] === 'image' &&
+        args[1] === 'inspect'
+      ) {
+        return makeSpawnResult({ code: 0 });
+      }
+      if (
+        command === 'docker' &&
+        args[0] === 'pull' &&
+        args[1] === 'hybridaione/hybridclaw-agent:v0.4.1'
+      ) {
+        return makeSpawnResult({ code: 0 });
+      }
+      if (
+        command === 'docker' &&
+        args[0] === 'tag' &&
+        args[1] === 'hybridaione/hybridclaw-agent:v0.4.1' &&
+        args[2] === 'hybridclaw-agent'
+      ) {
+        return makeSpawnResult({ code: 0 });
+      }
+      throw new Error(`Unexpected spawn: ${command} ${args.join(' ')}`);
+    });
+
+    const containerSetup = await importFreshContainerSetup({
+      homeDir,
+      spawnMock,
+    });
+    const writeSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await expect(
+      containerSetup.ensureContainerImageReady({
+        commandName: 'hybridclaw gateway start',
+        cwd,
+      }),
+    ).resolves.toBeUndefined();
+
+    const rendered = writeSpy.mock.calls
+      .map(([chunk]) => String(chunk))
+      .join('');
+    // A live spinner frame announcing the download phase was drawn...
+    expect(rendered).toContain('Updating the agent runtime — downloading image');
+    expect(rendered).toMatch(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/);
+    // ...then cleared before the final result line is printed (with a check
+    // mark, since this is the interactive/animated path).
+    expect(rendered).toContain('\x1b[2K');
     expect(logSpy).toHaveBeenCalledWith(
-      'hybridclaw gateway restart: A newer published container image may be available for this install.',
-    );
-    expect(logSpy).toHaveBeenCalledWith(
-      "hybridclaw gateway restart: Pulling container image 'hybridaione/hybridclaw-agent:v0.4.1'...",
+      expect.stringContaining('Agent runtime ready.'),
     );
   });
 

--- a/tests/progress-indicator.test.ts
+++ b/tests/progress-indicator.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { startProgressIndicator } from '../src/infra/progress-indicator.ts';
+
+function fakeStream(isTTY: boolean): {
+  stream: NodeJS.WriteStream;
+  writes: string[];
+} {
+  const writes: string[] = [];
+  const stream = {
+    isTTY,
+    write: (chunk: string) => {
+      writes.push(chunk);
+      return true;
+    },
+  } as unknown as NodeJS.WriteStream;
+  return { stream, writes };
+}
+
+describe('startProgressIndicator', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  test('stays silent on a non-interactive stream and prints a plain result line', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { stream, writes } = fakeStream(false);
+
+    const indicator = startProgressIndicator('Setting up the agent runtime…', stream);
+    indicator.succeed('Agent runtime ready.');
+
+    expect(writes).toEqual([]);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith('Agent runtime ready.');
+  });
+
+  test('animates a spinner and clears the line on an interactive stream', () => {
+    // The test runner disables animation via VITEST; clear it for this case.
+    vi.stubEnv('VITEST', '');
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { stream, writes } = fakeStream(true);
+
+    const indicator = startProgressIndicator('Updating the agent runtime…', stream);
+    // The first frame renders synchronously on start.
+    expect(writes.length).toBeGreaterThan(0);
+    expect(writes[0]).toContain('Updating the agent runtime…');
+
+    indicator.succeed('Agent runtime ready.');
+    // The spinner line is cleared before the result line is printed.
+    expect(writes[writes.length - 1]).toContain('\x1b[2K');
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Agent runtime ready.'),
+    );
+  });
+
+  test('routes failures to console.warn', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { stream } = fakeStream(false);
+
+    startProgressIndicator('Setting up the agent runtime…', stream).fail(
+      'Could not set up the agent runtime.',
+    );
+
+    expect(warnSpy).toHaveBeenCalledWith('Could not set up the agent runtime.');
+  });
+
+  test('is idempotent once finished', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { stream } = fakeStream(false);
+
+    const indicator = startProgressIndicator('Setting up the agent runtime…', stream);
+    indicator.succeed('Agent runtime ready.');
+    indicator.succeed('ignored');
+    indicator.fail('ignored');
+    indicator.clear();
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/progress-indicator.test.ts
+++ b/tests/progress-indicator.test.ts
@@ -23,16 +23,19 @@ describe('startProgressIndicator', () => {
     vi.restoreAllMocks();
   });
 
-  test('stays silent on a non-interactive stream and prints a plain result line', () => {
+  test('prints plain start and result lines on a non-interactive stream (no ANSI)', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const { stream, writes } = fakeStream(false);
 
     const indicator = startProgressIndicator('Setting up the agent runtime…', stream);
     indicator.succeed('Agent runtime ready.');
 
+    // No ANSI/animation is written to the stream...
     expect(writes).toEqual([]);
-    expect(logSpy).toHaveBeenCalledTimes(1);
-    expect(logSpy).toHaveBeenCalledWith('Agent runtime ready.');
+    // ...but a plain start breadcrumb and the result line are logged.
+    expect(logSpy).toHaveBeenNthCalledWith(1, 'Setting up the agent runtime…');
+    expect(logSpy).toHaveBeenNthCalledWith(2, 'Agent runtime ready.');
+    expect(logSpy).toHaveBeenCalledTimes(2);
   });
 
   test('animates a spinner and clears the line on an interactive stream', () => {
@@ -76,7 +79,9 @@ describe('startProgressIndicator', () => {
     indicator.fail('ignored');
     indicator.clear();
 
-    expect(logSpy).toHaveBeenCalledTimes(1);
+    // One start line + exactly one result line; later finish calls are no-ops.
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy).toHaveBeenLastCalledWith('Agent runtime ready.');
     expect(warnSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- **Problem:** Starting the gateway printed developer-facing lines while preparing the agent container image (`hybridclaw gateway start: Pulling container image 'hybridaione/hybridclaw-agent:v0.4.1'...`, raw image refs, command-name prefixes) and then went silent for the whole pull/build.
- **Why it matters:** First-run setup and refreshes are among the first things a user sees; the old output reads like internal logs and gives zero feedback during an otherwise-silent, possibly multi-minute download or build.
- **What changed:** A small, dependency-free, TTY-aware progress indicator (`src/infra/progress-indicator.ts`) now drives image setup. It shows an animated spinner with the current phase and a live elapsed timer — `⠋ Setting up the agent runtime — downloading image… (12s)` / `… — building image…` — resolving to `✔ Agent runtime ready.`. The headline adapts to context (Setting up / Updating / Refreshing).
- **What did not change:** Acquisition logic (pull-only / pull-or-build / build-only), fingerprint and state tracking, Docker availability checks, and the detailed failure/troubleshooting messages (kept verbose for diagnosis). On non-interactive streams (the detached gateway backend log, CI, pipes) the indicator falls back to plain lines, so logs stay clean.

## Change Type

- [x] Feature
- [x] Tests

## Linked Context

- Closes # N/A
- Related # N/A

## Manifesto Principle

Which manifesto principle does this serve?

- Principle: **IV. A coworker is a colleague, not a chatbot** — startup should feel polished and human, not like raw developer logs.
- Changelog tag added or updated: `Manifesto: Principle IV - A coworker is a colleague, not a chatbot.`
  (Flagging: the release-notes/changelog entry itself is **not yet added** — left for confirmation since this is a draft.)

## Validation

```bash
npx tsc --noEmit --noUnusedLocals --noUnusedParameters                              # clean
npx biome check src/infra/progress-indicator.ts src/infra/container-setup.ts        # clean
npx vitest run --project unit tests/container-setup.test.ts tests/progress-indicator.test.ts   # 26 passed
```

- **Verified manually:** rendered the real escape sequences — `⠋ Setting up the agent runtime — downloading image… (0s)` animating in color, clearing the line, then `✔ Agent runtime ready.`.
- **End-to-end test:** `tests/container-setup.test.ts` now includes a test that drives the *real* `ensureContainerImageReady` pull path with a faked TTY and asserts the spinner frames, phase text, and line-clear are actually emitted (not just that a string was logged).
- **Edge cases checked:** non-TTY fallback (plain lines, no ANSI); failed pull candidate falls through silently to the next tag / local build; `fallbackToExistingImage` path still warns and reuses the existing image; idempotent `succeed`/`fail`/`clear`; the spinner interval is `.unref()`'d and always cleared in a `finally`.
- **Full unit suite:** 4559 pass. The only 5 failures (`host-runner.worker-restart`, `session-trace-export`) were confirmed to pre-exist on the pristine tree (timing- and host/time-dependent) and are unrelated to this change.
- **Skipped checks and why:** did not run a live `gateway start` with a real multi-GB Docker pull — covered by the integration test plus the manual render; the pull/build path only executes on an interactive TTY (gated by `ensureInteractiveAutoBuild`), which is exactly when the spinner animates.

## Docs And Config Impact

- [x] Config or environment behavior changed
- [x] No docs impact

New opt-out only: `HYBRIDCLAW_NO_SPINNER=1` forces the plain (non-animated) output. Default behavior is unchanged on non-TTY streams. Currently undocumented — can add a docs note if desired.

## Risk Notes

- Security-sensitive paths touched? **No**
- Gateway, audit, approval, or container boundaries touched? **No** — only the console presentation of the existing image pull/build steps changes; the container acquisition/approval/audit boundaries are untouched.
- Failure mode: on any error the spinner clears and the pre-existing detailed troubleshooting/throw path runs exactly as before.

## Evidence

- [x] New or updated test coverage (`tests/progress-indicator.test.ts` + an end-to-end animation test in `tests/container-setup.test.ts`)

Before:
```
hybridclaw gateway start: Pulling container image 'hybridaione/hybridclaw-agent:v0.4.1'...
   (silent for the duration of the pull)
```
After:
```
⠋ Setting up the agent runtime — downloading image… (12s)
✔ Agent runtime ready.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
