### PR TITLE
feat: suggest update on interactive startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+
+- **Interactive startup update prompt**: Starting HybridClaw on a terminal
+  (`hybridclaw tui`, `hybridclaw gateway`, or `hybridclaw gateway start`) now
+  checks for a newer published release and offers a yes/no prompt to update
+  before continuing. Skipped for non-interactive shells and source checkouts.
+
 ## [0.21.0](https://github.com/HybridAIOne/hybridclaw/tree/v0.21.0) - 2026-05-29
 
 ### Added

--- a/docs/content/reference/commands.md
+++ b/docs/content/reference/commands.md
@@ -517,6 +517,16 @@ running with a replayable launch command, HybridClaw restarts it automatically
 with the original parameters; otherwise it falls back to manual restart
 instructions. Source checkouts receive git-based update instructions instead.
 
+When you start HybridClaw interactively (`hybridclaw tui`, `hybridclaw gateway`,
+or `hybridclaw gateway start`) and a newer release is available, HybridClaw
+prints the available version and prompts you to update before continuing. Answer
+`y` to install and restart, or `n` to start on the current version. This prompt
+appears only on an interactive terminal and only for global package installs;
+non-interactive shells and source checkouts are never blocked. The registry
+check is cached under the runtime home (`version-check.json`, 20-hour TTL) and
+refreshed in a detached background process, so startup never waits on the
+network — a newly published version surfaces on the next launch.
+
 ## Network Policy
 
 ```bash

--- a/docs/content/reference/commands.md
+++ b/docs/content/reference/commands.md
@@ -520,9 +520,13 @@ instructions. Source checkouts receive git-based update instructions instead.
 When you start HybridClaw interactively (`hybridclaw tui`, `hybridclaw gateway`,
 or `hybridclaw gateway start`) and a newer release is available, HybridClaw
 prints the available version and prompts you to update before continuing. Answer
-`y` to install and restart, or `n` to start on the current version. This prompt
-appears only on an interactive terminal and only for global package installs;
-non-interactive shells and source checkouts are never blocked. The registry
+`y` to install the update, or `n` to start on the current version. Installing
+exits the current command once the update finishes (the running process still
+holds the old code), so relaunch HybridClaw to use the new version; an
+already-running gateway is restarted automatically with its original
+parameters. This prompt appears only on an interactive terminal and only for
+global package installs; non-interactive shells and source checkouts are never
+blocked. The registry
 check is cached under the runtime home (`version-check.json`, 20-hour TTL) and
 refreshed in a detached background process, so startup never waits on the
 network — a newly published version surfaces on the next launch.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -146,7 +146,10 @@ function resolveCliVersion(): string {
 
 async function promptStartupUpdate(): Promise<void> {
   const { maybePromptStartupUpdate } = await import('./update.js');
-  await maybePromptStartupUpdate(resolveCliVersion());
+  const updated = await maybePromptStartupUpdate(resolveCliVersion());
+  // After a successful self-update this process is still running the old code,
+  // so stop here rather than launch the TUI or gateway with stale modules.
+  if (updated) process.exit(0);
 }
 
 async function ensureConfigApi(): Promise<ConfigApi> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -144,6 +144,11 @@ function resolveCliVersion(): string {
   return cachedAppVersion;
 }
 
+async function promptStartupUpdate(): Promise<void> {
+  const { maybePromptStartupUpdate } = await import('./update.js');
+  await maybePromptStartupUpdate(resolveCliVersion());
+}
+
 async function ensureConfigApi(): Promise<ConfigApi> {
   return configApiState.ensure();
 }
@@ -648,6 +653,8 @@ async function launchTui(argv: string[]): Promise<void> {
     return;
   }
 
+  await promptStartupUpdate();
+
   const { ensureRuntimeCredentials } = await ensureOnboardingApi();
   const { resolveTuiRunOptions } = await import('./tui-session.js');
   const options = resolveTuiRunOptions({
@@ -1098,6 +1105,7 @@ async function runGatewayApiCommand(args: string[]): Promise<void> {
 async function handleGatewayCommand(args: string[]): Promise<void> {
   const normalized = normalizeArgs(args);
   if (normalized.length === 0) {
+    await promptStartupUpdate();
     await startGatewayBackend('hybridclaw gateway');
     return;
   }
@@ -1127,6 +1135,7 @@ async function handleGatewayCommand(args: string[]): Promise<void> {
       printGatewayUsage();
       return;
     }
+    await promptStartupUpdate();
     if (flags.foreground) {
       await runGatewayForeground(
         'hybridclaw gateway start --foreground',
@@ -1872,6 +1881,11 @@ export async function main(
         './gateway/gateway-restart.js'
       );
       await runGatewayRestartHelperFromArg(payload);
+      break;
+    }
+    case '__refresh-version-cache': {
+      const { refreshVersionCache } = await import('./update.js');
+      refreshVersionCache();
       break;
     }
     case 'eval':

--- a/src/update.ts
+++ b/src/update.ts
@@ -101,7 +101,16 @@ function findNearestPackageRoot(startPath: string | undefined): string | null {
 
   let current: string;
   try {
-    const resolved = path.resolve(startPath);
+    // Resolve symlinks first: a global install puts a bin shim at
+    // `process.argv[1]` (e.g. /usr/local/bin/hybridclaw) whose directory has no
+    // package.json above it. Following the link lands on the real
+    // node_modules/.../dist entry so the package root is actually found.
+    let resolved = path.resolve(startPath);
+    try {
+      resolved = fs.realpathSync(resolved);
+    } catch {
+      // The path may not exist yet (or in tests); fall back to the literal path.
+    }
     current =
       fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()
         ? resolved
@@ -372,6 +381,33 @@ function resolveUpdatedPackageRoot(
   return packagePathFromNodeModulesRoot(nodeModulesRoot, packageName);
 }
 
+function realpathOrSelf(target: string): string {
+  try {
+    return fs.realpathSync(target);
+  } catch {
+    return path.resolve(target);
+  }
+}
+
+// True only when the running entry point is the package manager's *global*
+// install of HybridClaw. A project-local dependency or npx cache resolves to
+// the same package name and a node_modules path, but it lives outside the
+// global root; updating it would run `npm install -g` and mutate the user's
+// global environment from a local invocation, so callers must not prompt for
+// or auto-update it.
+function isGlobalPackageInstall(
+  install: InstallContext,
+  packageName: string,
+): boolean {
+  if (install.kind !== 'package' || !install.root) return false;
+  const globalRoot = resolveUpdatedPackageRoot(
+    install.packageManager,
+    packageName,
+  );
+  if (!globalRoot) return false;
+  return realpathOrSelf(globalRoot) === realpathOrSelf(install.root);
+}
+
 function runExplicitPostinstall(installRoot: string | null): void {
   if (!installRoot) return;
   const scriptPath = path.join(
@@ -568,8 +604,9 @@ export async function maybePromptStartupUpdate(
 
   const packageName = resolvePackageName(process.argv[1]);
   const install = detectInstallContext(packageName, process.argv[1]);
-  // Only global package installs can be updated via the package manager.
-  // Source checkouts update via git; unknown installs are left untouched.
+  // A package-manager install is the only kind we can upgrade in place. Source
+  // checkouts update via git; unknown installs are left untouched. (Whether a
+  // `package` install is the *global* one is confirmed lazily below.)
   if (install.kind !== 'package') return false;
 
   // Cache-first, like Codex: decide using the previously cached latest version
@@ -581,6 +618,13 @@ export async function maybePromptStartupUpdate(
   }
   if (!cache) return false;
   if (compareSemver(currentVersion, cache.latestVersion) !== -1) return false;
+
+  // Confirm this is the global install before prompting. A project-local or npx
+  // copy matches the package name but auto-updating it would run a global
+  // install and mutate the user's environment. This `npm root -g` lookup is
+  // done here — after we know an update exists — so it stays off the common
+  // startup path where nothing is out of date.
+  if (!isGlobalPackageInstall(install, packageName)) return false;
 
   console.log(`Update available: ${currentVersion} -> ${cache.latestVersion}`);
   let confirmed = false;

--- a/src/update.ts
+++ b/src/update.ts
@@ -247,13 +247,10 @@ function compareSemver(a: string, b: string): number | null {
   return String(left.prerelease).localeCompare(String(right.prerelease));
 }
 
-function fetchLatestVersion(
-  packageName: string,
-  timeoutMs = 15_000,
-): LatestVersionResult {
+function fetchLatestVersion(packageName: string): LatestVersionResult {
   const result = spawnSync('npm', ['view', packageName, 'version'], {
     encoding: 'utf-8',
-    timeout: timeoutMs,
+    timeout: 15_000,
   });
 
   if (result.error) {
@@ -560,18 +557,20 @@ function spawnVersionCacheRefresh(): void {
   }
 }
 
+// Returns true when an update was installed and the caller should stop (this
+// process is still running the old code). Returns false to continue launching.
 export async function maybePromptStartupUpdate(
   currentVersion: string,
-): Promise<void> {
+): Promise<boolean> {
   // Only suggest updates in an interactive terminal. Non-TTY launches
   // (CI, the detached gateway daemon, scripts) must never block on a prompt.
-  if (!process.stdin.isTTY || !process.stdout.isTTY) return;
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return false;
 
   const packageName = resolvePackageName(process.argv[1]);
   const install = detectInstallContext(packageName, process.argv[1]);
   // Only global package installs can be updated via the package manager.
   // Source checkouts update via git; unknown installs are left untouched.
-  if (install.kind !== 'package') return;
+  if (install.kind !== 'package') return false;
 
   // Cache-first, like Codex: decide using the previously cached latest version
   // so startup never waits on the network. Refresh in a detached child when the
@@ -580,8 +579,8 @@ export async function maybePromptStartupUpdate(
   if (!cache || !isVersionCacheFresh(cache)) {
     spawnVersionCacheRefresh();
   }
-  if (!cache) return;
-  if (compareSemver(currentVersion, cache.latestVersion) !== -1) return;
+  if (!cache) return false;
+  if (compareSemver(currentVersion, cache.latestVersion) !== -1) return false;
 
   console.log(`Update available: ${currentVersion} -> ${cache.latestVersion}`);
   let confirmed = false;
@@ -593,15 +592,15 @@ export async function maybePromptStartupUpdate(
   }
   if (!confirmed) {
     console.log('Skipping update. Run `hybridclaw update` to update later.');
-    return;
+    return false;
   }
 
   // Delegate to the full update command so the install, native rebuild,
   // postinstall, and restart of any running gateway all match `hybridclaw
-  // update`. Exit afterward: this process is still running the old code and
-  // must not continue into the TUI or gateway.
+  // update`. The caller exits afterward so we never continue into the TUI or
+  // gateway on the old code.
   await runUpdateCommand(['--yes'], currentVersion);
-  process.exit(0);
+  return true;
 }
 
 export function printUpdateUsage(): void {

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,4 +1,5 @@
 import { spawn, spawnSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import readline from 'node:readline/promises';
@@ -466,7 +467,6 @@ function runUpdateInstall(command: UpdateCommand): Promise<number> {
 
 const VERSION_CACHE_FILE = 'version-check.json';
 const VERSION_CACHE_TTL_MS = 20 * 60 * 60 * 1000;
-const VERSION_CACHE_FETCH_TIMEOUT_MS = 15_000;
 const REFRESH_VERSION_CACHE_COMMAND = '__refresh-version-cache';
 
 interface VersionCache {
@@ -511,13 +511,22 @@ function writeVersionCache(latestVersion: string): void {
     latestVersion,
     lastCheckedAt: new Date().toISOString(),
   };
+  // Overwriting temp+rename (writeFileAtomicExclusive can't be reused here: it
+  // hard-links with flag 'wx' and throws once the cache file already exists).
   const filePath = versionCachePath();
-  const tempPath = `${filePath}.tmp-${process.pid}`;
+  const tempPath = `${filePath}.tmp-${process.pid}-${randomBytes(6).toString('hex')}`;
   try {
-    fs.mkdirSync(path.dirname(filePath), { recursive: true });
-    fs.writeFileSync(tempPath, `${JSON.stringify(cache)}\n`, 'utf-8');
+    // The cache shares the runtime home with secrets, so create the directory
+    // and file with the restrictive modes the rest of the runtime uses rather
+    // than leaving them at the umask default.
+    fs.mkdirSync(DEFAULT_RUNTIME_HOME_DIR, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(tempPath, `${JSON.stringify(cache)}\n`, {
+      encoding: 'utf-8',
+      mode: 0o600,
+    });
     fs.renameSync(tempPath, filePath);
   } catch {
+    // A failed cache write must never affect startup; the next launch retries.
     fs.rmSync(tempPath, { force: true });
   }
 }
@@ -527,10 +536,7 @@ function writeVersionCache(latestVersion: string): void {
 // cache for the next interactive launch to read.
 export function refreshVersionCache(): void {
   const packageName = resolvePackageName(process.argv[1]);
-  const latest = fetchLatestVersion(
-    packageName,
-    VERSION_CACHE_FETCH_TIMEOUT_MS,
-  );
+  const latest = fetchLatestVersion(packageName);
   if (latest.version) {
     writeVersionCache(latest.version);
   }
@@ -540,9 +546,12 @@ function spawnVersionCacheRefresh(): void {
   const cliEntry = process.argv[1];
   if (!cliEntry) return;
   try {
+    // Do not forward process.execArgv: an inherited exclusive flag such as
+    // --inspect would make the child fail to bind its debug port and exit
+    // before it can refresh the cache.
     const child = spawn(
       process.execPath,
-      [...process.execArgv, cliEntry, REFRESH_VERSION_CACHE_COMMAND],
+      [cliEntry, REFRESH_VERSION_CACHE_COMMAND],
       { detached: true, stdio: 'ignore' },
     );
     child.unref();
@@ -574,32 +583,24 @@ export async function maybePromptStartupUpdate(
   if (!cache) return;
   if (compareSemver(currentVersion, cache.latestVersion) !== -1) return;
 
-  const manager = resolveAvailablePackageManager(install.packageManager);
-  if (!manager) return;
-  const updateCommand = buildUpdateCommand(manager, packageName);
-
   console.log(`Update available: ${currentVersion} -> ${cache.latestVersion}`);
-  const confirmed = await askForConfirmation('Update HybridClaw now?');
+  let confirmed = false;
+  try {
+    confirmed = await askForConfirmation('Update HybridClaw now?');
+  } catch {
+    // An aborted prompt (e.g. Ctrl-C) is a decline, not a crash.
+    confirmed = false;
+  }
   if (!confirmed) {
     console.log('Skipping update. Run `hybridclaw update` to update later.');
     return;
   }
 
-  console.log(`Update command: ${updateCommand.display}`);
-  const exitCode = await runUpdateInstall(updateCommand);
-  if (exitCode !== 0) {
-    console.log(
-      `Update failed with exit code ${exitCode}. Continuing with the current version.`,
-    );
-    return;
-  }
-
-  const updatedRoot =
-    resolveUpdatedPackageRoot(manager, packageName) || install.root;
-  rebuildReviewedNativeDependencies(updatedRoot);
-  runExplicitPostinstall(updatedRoot);
-
-  console.log('Update complete. Restart HybridClaw to use the new version.');
+  // Delegate to the full update command so the install, native rebuild,
+  // postinstall, and restart of any running gateway all match `hybridclaw
+  // update`. Exit afterward: this process is still running the old code and
+  // must not continue into the TUI or gateway.
+  await runUpdateCommand(['--yes'], currentVersion);
   process.exit(0);
 }
 

--- a/src/update.ts
+++ b/src/update.ts
@@ -2,6 +2,7 @@ import { spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import readline from 'node:readline/promises';
+import { DEFAULT_RUNTIME_HOME_DIR } from './config/runtime-paths.js';
 
 const DEFAULT_PACKAGE_NAME = '@hybridaione/hybridclaw';
 
@@ -245,10 +246,13 @@ function compareSemver(a: string, b: string): number | null {
   return String(left.prerelease).localeCompare(String(right.prerelease));
 }
 
-function fetchLatestVersion(packageName: string): LatestVersionResult {
+function fetchLatestVersion(
+  packageName: string,
+  timeoutMs = 15_000,
+): LatestVersionResult {
   const result = spawnSync('npm', ['view', packageName, 'version'], {
     encoding: 'utf-8',
-    timeout: 15_000,
+    timeout: timeoutMs,
   });
 
   if (result.error) {
@@ -458,6 +462,145 @@ function runUpdateInstall(command: UpdateCommand): Promise<number> {
     child.on('error', (err) => reject(err));
     child.on('close', (code) => resolve(code ?? 1));
   });
+}
+
+const VERSION_CACHE_FILE = 'version-check.json';
+const VERSION_CACHE_TTL_MS = 20 * 60 * 60 * 1000;
+const VERSION_CACHE_FETCH_TIMEOUT_MS = 15_000;
+const REFRESH_VERSION_CACHE_COMMAND = '__refresh-version-cache';
+
+interface VersionCache {
+  latestVersion: string;
+  // ISO-8601 timestamp of the last successful registry check.
+  lastCheckedAt: string;
+}
+
+function versionCachePath(): string {
+  return path.join(DEFAULT_RUNTIME_HOME_DIR, VERSION_CACHE_FILE);
+}
+
+function readVersionCache(): VersionCache | null {
+  try {
+    const parsed = JSON.parse(
+      fs.readFileSync(versionCachePath(), 'utf-8'),
+    ) as Partial<VersionCache>;
+    if (
+      typeof parsed.latestVersion === 'string' &&
+      parsed.latestVersion.trim() &&
+      typeof parsed.lastCheckedAt === 'string' &&
+      !Number.isNaN(Date.parse(parsed.lastCheckedAt))
+    ) {
+      return {
+        latestVersion: parsed.latestVersion.trim(),
+        lastCheckedAt: parsed.lastCheckedAt,
+      };
+    }
+  } catch {
+    // A missing or unreadable cache is expected on the first run.
+  }
+  return null;
+}
+
+function isVersionCacheFresh(cache: VersionCache): boolean {
+  const age = Date.now() - Date.parse(cache.lastCheckedAt);
+  return age >= 0 && age < VERSION_CACHE_TTL_MS;
+}
+
+function writeVersionCache(latestVersion: string): void {
+  const cache: VersionCache = {
+    latestVersion,
+    lastCheckedAt: new Date().toISOString(),
+  };
+  const filePath = versionCachePath();
+  const tempPath = `${filePath}.tmp-${process.pid}`;
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(tempPath, `${JSON.stringify(cache)}\n`, 'utf-8');
+    fs.renameSync(tempPath, filePath);
+  } catch {
+    fs.rmSync(tempPath, { force: true });
+  }
+}
+
+// Runs inside the detached `__refresh-version-cache` child process. It owns its
+// own process, so it may block on the registry call; the result lands in the
+// cache for the next interactive launch to read.
+export function refreshVersionCache(): void {
+  const packageName = resolvePackageName(process.argv[1]);
+  const latest = fetchLatestVersion(
+    packageName,
+    VERSION_CACHE_FETCH_TIMEOUT_MS,
+  );
+  if (latest.version) {
+    writeVersionCache(latest.version);
+  }
+}
+
+function spawnVersionCacheRefresh(): void {
+  const cliEntry = process.argv[1];
+  if (!cliEntry) return;
+  try {
+    const child = spawn(
+      process.execPath,
+      [...process.execArgv, cliEntry, REFRESH_VERSION_CACHE_COMMAND],
+      { detached: true, stdio: 'ignore' },
+    );
+    child.unref();
+  } catch {
+    // A failed background refresh must never affect startup.
+  }
+}
+
+export async function maybePromptStartupUpdate(
+  currentVersion: string,
+): Promise<void> {
+  // Only suggest updates in an interactive terminal. Non-TTY launches
+  // (CI, the detached gateway daemon, scripts) must never block on a prompt.
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return;
+
+  const packageName = resolvePackageName(process.argv[1]);
+  const install = detectInstallContext(packageName, process.argv[1]);
+  // Only global package installs can be updated via the package manager.
+  // Source checkouts update via git; unknown installs are left untouched.
+  if (install.kind !== 'package') return;
+
+  // Cache-first, like Codex: decide using the previously cached latest version
+  // so startup never waits on the network. Refresh in a detached child when the
+  // cache is missing or stale; a newly learned version surfaces next launch.
+  const cache = readVersionCache();
+  if (!cache || !isVersionCacheFresh(cache)) {
+    spawnVersionCacheRefresh();
+  }
+  if (!cache) return;
+  if (compareSemver(currentVersion, cache.latestVersion) !== -1) return;
+
+  const manager = resolveAvailablePackageManager(install.packageManager);
+  if (!manager) return;
+  const updateCommand = buildUpdateCommand(manager, packageName);
+
+  console.log(`Update available: ${currentVersion} -> ${cache.latestVersion}`);
+  const confirmed = await askForConfirmation('Update HybridClaw now?');
+  if (!confirmed) {
+    console.log('Skipping update. Run `hybridclaw update` to update later.');
+    return;
+  }
+
+  console.log(`Update command: ${updateCommand.display}`);
+  const exitCode = await runUpdateInstall(updateCommand);
+  if (exitCode !== 0) {
+    console.log(
+      `Update failed with exit code ${exitCode}. Continuing with the current version.`,
+    );
+    return;
+  }
+
+  const updatedRoot =
+    resolveUpdatedPackageRoot(manager, packageName) || install.root;
+  rebuildReviewedNativeDependencies(updatedRoot);
+  runExplicitPostinstall(updatedRoot);
+
+  console.log('Update complete. Restart HybridClaw to use the new version.');
+  process.exit(0);
 }
 
 export function printUpdateUsage(): void {

--- a/src/update.ts
+++ b/src/update.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import readline from 'node:readline/promises';
 import { DEFAULT_RUNTIME_HOME_DIR } from './config/runtime-paths.js';
+import { logger } from './logger.js';
 
 const DEFAULT_PACKAGE_NAME = '@hybridaione/hybridclaw';
 
@@ -101,16 +102,7 @@ function findNearestPackageRoot(startPath: string | undefined): string | null {
 
   let current: string;
   try {
-    // Resolve symlinks first: a global install puts a bin shim at
-    // `process.argv[1]` (e.g. /usr/local/bin/hybridclaw) whose directory has no
-    // package.json above it. Following the link lands on the real
-    // node_modules/.../dist entry so the package root is actually found.
-    let resolved = path.resolve(startPath);
-    try {
-      resolved = fs.realpathSync(resolved);
-    } catch {
-      // The path may not exist yet (or in tests); fall back to the literal path.
-    }
+    const resolved = resolveEntryPathThroughBinSymlink(path.resolve(startPath));
     current =
       fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()
         ? resolved
@@ -126,6 +118,18 @@ function findNearestPackageRoot(startPath: string | undefined): string | null {
     const parent = path.dirname(current);
     if (parent === current) return null;
     current = parent;
+  }
+}
+
+function resolveEntryPathThroughBinSymlink(entryPath: string): string {
+  try {
+    return fs.realpathSync(entryPath);
+  } catch (error) {
+    logger.debug(
+      { entryPath, err: error },
+      'Startup update check could not resolve the CLI entry symlink; using the literal path',
+    );
+    return entryPath;
   }
 }
 
@@ -558,8 +562,11 @@ function writeVersionCache(latestVersion: string): void {
       mode: 0o600,
     });
     fs.renameSync(tempPath, filePath);
-  } catch {
-    // A failed cache write must never affect startup; the next launch retries.
+  } catch (error) {
+    logger.debug(
+      { err: error, filePath },
+      'Failed to write the version cache; the next launch retries',
+    );
     fs.rmSync(tempPath, { force: true });
   }
 }
@@ -588,8 +595,11 @@ function spawnVersionCacheRefresh(): void {
       { detached: true, stdio: 'ignore' },
     );
     child.unref();
-  } catch {
-    // A failed background refresh must never affect startup.
+  } catch (error) {
+    logger.debug(
+      { err: error },
+      'Failed to spawn the background version-cache refresh; the next launch retries',
+    );
   }
 }
 

--- a/src/update.ts
+++ b/src/update.ts
@@ -70,7 +70,11 @@ function readPackageInfo(packageJsonPath: string): PackageInfo {
         ? parsed.version.trim()
         : null;
     return { name, version };
-  } catch {
+  } catch (error) {
+    logger.debug(
+      { packageJsonPath, err: error },
+      'Could not read package manifest',
+    );
     return { name: null, version: null };
   }
 }
@@ -102,12 +106,16 @@ function findNearestPackageRoot(startPath: string | undefined): string | null {
 
   let current: string;
   try {
-    const resolved = resolveEntryPathThroughBinSymlink(path.resolve(startPath));
+    const resolved = realpathOrSelf(startPath);
     current =
       fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()
         ? resolved
         : path.dirname(resolved);
-  } catch {
+  } catch (error) {
+    logger.debug(
+      { startPath, err: error },
+      'Could not determine the package root for the CLI entry path',
+    );
     return null;
   }
 
@@ -118,18 +126,6 @@ function findNearestPackageRoot(startPath: string | undefined): string | null {
     const parent = path.dirname(current);
     if (parent === current) return null;
     current = parent;
-  }
-}
-
-function resolveEntryPathThroughBinSymlink(entryPath: string): string {
-  try {
-    return fs.realpathSync(entryPath);
-  } catch (error) {
-    logger.debug(
-      { entryPath, err: error },
-      'Startup update check could not resolve the CLI entry symlink; using the literal path',
-    );
-    return entryPath;
   }
 }
 
@@ -388,7 +384,11 @@ function resolveUpdatedPackageRoot(
 function realpathOrSelf(target: string): string {
   try {
     return fs.realpathSync(target);
-  } catch {
+  } catch (error) {
+    logger.debug(
+      { target, err: error },
+      'Could not resolve the real path; using the literal path',
+    );
     return path.resolve(target);
   }
 }
@@ -532,8 +532,11 @@ function readVersionCache(): VersionCache | null {
         lastCheckedAt: parsed.lastCheckedAt,
       };
     }
-  } catch {
-    // A missing or unreadable cache is expected on the first run.
+  } catch (error) {
+    logger.debug(
+      { err: error },
+      'Could not read the version cache; treating it as absent',
+    );
   }
   return null;
 }
@@ -640,8 +643,11 @@ export async function maybePromptStartupUpdate(
   let confirmed = false;
   try {
     confirmed = await askForConfirmation('Update HybridClaw now?');
-  } catch {
-    // An aborted prompt (e.g. Ctrl-C) is a decline, not a crash.
+  } catch (error) {
+    logger.debug(
+      { err: error },
+      'Update confirmation prompt aborted (e.g. Ctrl-C); treating as a decline',
+    );
     confirmed = false;
   }
   if (!confirmed) {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1390,6 +1390,8 @@ async function importFreshCli(options?: {
   vi.doMock('../src/update.ts', () => ({
     printUpdateUsage,
     runUpdateCommand,
+    maybePromptStartupUpdate: vi.fn(),
+    refreshVersionCache: vi.fn(),
   }));
   vi.doMock('../src/doctor.ts', () => ({
     runDoctorCli,

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -564,13 +564,56 @@ describe('maybePromptStartupUpdate', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     const { maybePromptStartupUpdate } = await import('../src/update.js');
-    await maybePromptStartupUpdate('0.9.8');
+    const updated = await maybePromptStartupUpdate('0.9.8');
 
+    expect(updated).toBe(false);
     const messages = logSpy.mock.calls.map((call) => String(call[0]));
     expect(messages).toContain('Update available: 0.9.8 -> 0.42.0');
     expect(messages.some((m) => m.startsWith('Skipping update'))).toBe(true);
     // Fresh cache means no refresh; declining means no install spawn.
     expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('installs and reports updated=true when the user accepts', async () => {
+    setTty(true);
+    const { installRoot } = setupGlobalPackageInstall();
+    writeCache('0.42.0', 60 * 1000);
+    readlineState.answer = 'y';
+    requestExternalGatewayRestartMock.mockReturnValue({
+      status: 'not-running',
+      pid: null,
+      reason: null,
+    });
+    spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+      if (command === 'npm' && args[0] === 'view') {
+        return { status: 0, stdout: '0.42.0\n', stderr: '' };
+      }
+      if (command === 'npm' && args[0] === '--version') {
+        return { status: 0, stdout: '10.0.0\n', stderr: '' };
+      }
+      if (command === 'npm' && args[0] === 'rebuild') {
+        return { status: 0, stdout: '', stderr: '' };
+      }
+      return { status: 1, stdout: '', stderr: '' };
+    });
+    spawnMock.mockImplementation(() => ({
+      on(event: string, handler: (value?: number) => void) {
+        if (event === 'close') handler(0);
+      },
+    }));
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { maybePromptStartupUpdate } = await import('../src/update.js');
+    const updated = await maybePromptStartupUpdate('0.9.8');
+
+    expect(updated).toBe(true);
+    // Delegates to the full update command, which runs the global install.
+    expect(spawnMock).toHaveBeenCalledWith(
+      'npm',
+      ['install', '-g', '--ignore-scripts', '@hybridaione/hybridclaw@latest'],
+      { stdio: 'inherit' },
+    );
+    expect(installRoot).toContain('@hybridaione');
   });
 });
 

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -16,6 +16,22 @@ vi.mock('../src/gateway/gateway-restart.js', () => ({
   requestExternalGatewayRestart: requestExternalGatewayRestartMock,
 }));
 
+const readlineState = vi.hoisted(() => ({ answer: 'n' }));
+vi.mock('node:readline/promises', () => {
+  const createInterface = () => ({
+    question: async () => readlineState.answer,
+    close: () => {},
+  });
+  return { default: { createInterface }, createInterface };
+});
+
+// The version cache lives under the runtime home dir, which is resolved from
+// HYBRIDCLAW_DATA_DIR at module load. Point it at a throwaway dir before any
+// dynamic import of update.js so cache reads/writes stay isolated.
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-data-'));
+process.env.HYBRIDCLAW_DATA_DIR = TEST_DATA_DIR;
+const CACHE_FILE = path.join(TEST_DATA_DIR, 'version-check.json');
+
 describe('runUpdateCommand', () => {
   const originalArgv = [...process.argv];
   const originalCwd = process.cwd();
@@ -373,5 +389,251 @@ describe('runUpdateCommand', () => {
       [path.join(updatedRoot, 'scripts', 'postinstall-container.mjs')],
       { stdio: 'inherit' },
     );
+  });
+});
+
+describe('maybePromptStartupUpdate', () => {
+  const originalArgv = [...process.argv];
+  const originalCwd = process.cwd();
+  const originalStdinIsTTY = process.stdin.isTTY;
+  const originalStdoutIsTTY = process.stdout.isTTY;
+  let tempDir = '';
+
+  beforeEach(() => {
+    spawnMock.mockReset();
+    spawnSyncMock.mockReset();
+    readlineState.answer = 'n';
+    fs.rmSync(CACHE_FILE, { force: true });
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-startup-'));
+  });
+
+  afterEach(() => {
+    process.argv = [...originalArgv];
+    process.chdir(originalCwd);
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: originalStdinIsTTY,
+      configurable: true,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: originalStdoutIsTTY,
+      configurable: true,
+    });
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    fs.rmSync(CACHE_FILE, { force: true });
+    vi.restoreAllMocks();
+  });
+
+  function setTty(value: boolean) {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value,
+      configurable: true,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value,
+      configurable: true,
+    });
+  }
+
+  function setupGlobalPackageInstall() {
+    const installRoot = path.join(
+      tempDir,
+      'node_modules',
+      '@hybridaione',
+      'hybridclaw',
+    );
+    fs.mkdirSync(path.join(installRoot, 'dist'), { recursive: true });
+    fs.writeFileSync(
+      path.join(installRoot, 'package.json'),
+      JSON.stringify({ name: '@hybridaione/hybridclaw', version: '0.9.8' }),
+    );
+    // chdir into tempDir (no package.json, no .git) so detectInstallContext
+    // classifies the entry as a global `package`, not the repo source checkout.
+    process.chdir(tempDir);
+    process.argv = [
+      originalArgv[0] || 'node',
+      path.join(installRoot, 'dist', 'cli.js'),
+    ];
+    return { installRoot };
+  }
+
+  function writeCache(latestVersion: string, ageMs = 0) {
+    fs.writeFileSync(
+      CACHE_FILE,
+      JSON.stringify({
+        latestVersion,
+        lastCheckedAt: new Date(Date.now() - ageMs).toISOString(),
+      }),
+    );
+  }
+
+  it('does nothing in a non-interactive terminal', async () => {
+    setTty(false);
+    setupGlobalPackageInstall();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { maybePromptStartupUpdate } = await import('../src/update.js');
+    await maybePromptStartupUpdate('0.9.8');
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not prompt or refresh from a source checkout', async () => {
+    setTty(true);
+    fs.mkdirSync(path.join(tempDir, '.git'), { recursive: true });
+    fs.mkdirSync(path.join(tempDir, 'dist'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({ name: '@hybridaione/hybridclaw', version: '0.9.8' }),
+    );
+    process.chdir(tempDir);
+    process.argv = [
+      originalArgv[0] || 'node',
+      path.join(tempDir, 'dist', 'cli.js'),
+    ];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { maybePromptStartupUpdate } = await import('../src/update.js');
+    await maybePromptStartupUpdate('0.9.8');
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('spawns a detached background refresh when no cache exists, without prompting', async () => {
+    setTty(true);
+    setupGlobalPackageInstall();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { maybePromptStartupUpdate } = await import('../src/update.js');
+    await maybePromptStartupUpdate('0.9.8');
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [, args, opts] = spawnMock.mock.calls[0];
+    expect(args).toContain('__refresh-version-cache');
+    expect(opts).toMatchObject({ detached: true, stdio: 'ignore' });
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('spawns a refresh when the cache is stale', async () => {
+    setTty(true);
+    setupGlobalPackageInstall();
+    writeCache('0.9.8', 21 * 60 * 60 * 1000); // older than the 20h TTL
+
+    const { maybePromptStartupUpdate } = await import('../src/update.js');
+    await maybePromptStartupUpdate('0.9.8');
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(spawnMock.mock.calls[0][1]).toContain('__refresh-version-cache');
+  });
+
+  it('does not refresh when the cache is fresh', async () => {
+    setTty(true);
+    setupGlobalPackageInstall();
+    writeCache('0.9.8', 60 * 1000); // 1 minute old
+
+    const { maybePromptStartupUpdate } = await import('../src/update.js');
+    await maybePromptStartupUpdate('0.9.8');
+
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('stays silent when the cached latest matches the current version', async () => {
+    setTty(true);
+    setupGlobalPackageInstall();
+    writeCache('0.9.8', 60 * 1000);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { maybePromptStartupUpdate } = await import('../src/update.js');
+    await maybePromptStartupUpdate('0.9.8');
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('prompts from a fresh cache with a newer version and skips when declined', async () => {
+    setTty(true);
+    setupGlobalPackageInstall();
+    writeCache('0.42.0', 60 * 1000);
+    readlineState.answer = 'n';
+    spawnSyncMock.mockImplementation((_command: string, args: string[]) => {
+      if (args[0] === '--version') {
+        return { status: 0, stdout: '10.0.0\n', stderr: '' };
+      }
+      return { status: 1, stdout: '', stderr: '' };
+    });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { maybePromptStartupUpdate } = await import('../src/update.js');
+    await maybePromptStartupUpdate('0.9.8');
+
+    const messages = logSpy.mock.calls.map((call) => String(call[0]));
+    expect(messages).toContain('Update available: 0.9.8 -> 0.42.0');
+    expect(messages.some((m) => m.startsWith('Skipping update'))).toBe(true);
+    // Fresh cache means no refresh; declining means no install spawn.
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('refreshVersionCache', () => {
+  const originalArgv = [...process.argv];
+
+  beforeEach(() => {
+    spawnSyncMock.mockReset();
+    fs.rmSync(CACHE_FILE, { force: true });
+  });
+
+  afterEach(() => {
+    process.argv = [...originalArgv];
+    fs.rmSync(CACHE_FILE, { force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('writes the latest version to the cache file', async () => {
+    spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+      if (command === 'npm' && args[0] === 'view') {
+        return { status: 0, stdout: '0.42.0\n', stderr: '' };
+      }
+      return { status: 1, stdout: '', stderr: '' };
+    });
+
+    const { refreshVersionCache } = await import('../src/update.js');
+    refreshVersionCache();
+
+    expect(fs.existsSync(CACHE_FILE)).toBe(true);
+    const parsed = JSON.parse(fs.readFileSync(CACHE_FILE, 'utf-8')) as {
+      latestVersion: string;
+      lastCheckedAt: string;
+    };
+    expect(parsed.latestVersion).toBe('0.42.0');
+    expect(Number.isNaN(Date.parse(parsed.lastCheckedAt))).toBe(false);
+  });
+
+  it('does not write a cache when the registry check fails', async () => {
+    spawnSyncMock.mockImplementation(() => ({
+      status: 1,
+      stdout: '',
+      stderr: 'network error',
+    }));
+
+    const { refreshVersionCache } = await import('../src/update.js');
+    refreshVersionCache();
+
+    expect(fs.existsSync(CACHE_FILE)).toBe(false);
+  });
+});
+
+describe('printUpdateUsage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('prints usage with the documented options', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { printUpdateUsage } = await import('../src/update.js');
+    printUpdateUsage();
+    const output = logSpy.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(output).toContain('Usage: hybridclaw update');
+    expect(output).toContain('--check');
+    expect(output).toContain('--yes');
   });
 });

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -435,9 +435,9 @@ describe('maybePromptStartupUpdate', () => {
   }
 
   function setupGlobalPackageInstall() {
+    const globalNodeModules = path.join(tempDir, 'node_modules');
     const installRoot = path.join(
-      tempDir,
-      'node_modules',
+      globalNodeModules,
       '@hybridaione',
       'hybridclaw',
     );
@@ -453,7 +453,22 @@ describe('maybePromptStartupUpdate', () => {
       originalArgv[0] || 'node',
       path.join(installRoot, 'dist', 'cli.js'),
     ];
-    return { installRoot };
+    return { installRoot, globalNodeModules };
+  }
+
+  // The prompt confirms the entry point is the *global* install via `npm root
+  // -g` before prompting. Point that lookup at the global node_modules holding
+  // the install (matches) unless a test overrides it (project-local install).
+  function mockNpmGlobalRoot(globalNodeModules: string) {
+    spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+      if (command === 'npm' && args[0] === 'root' && args[1] === '-g') {
+        return { status: 0, stdout: `${globalNodeModules}\n`, stderr: '' };
+      }
+      if (args[0] === '--version') {
+        return { status: 0, stdout: '10.0.0\n', stderr: '' };
+      }
+      return { status: 1, stdout: '', stderr: '' };
+    });
   }
 
   function writeCache(latestVersion: string, ageMs = 0) {
@@ -552,15 +567,10 @@ describe('maybePromptStartupUpdate', () => {
 
   it('prompts from a fresh cache with a newer version and skips when declined', async () => {
     setTty(true);
-    setupGlobalPackageInstall();
+    const { globalNodeModules } = setupGlobalPackageInstall();
     writeCache('0.42.0', 60 * 1000);
     readlineState.answer = 'n';
-    spawnSyncMock.mockImplementation((_command: string, args: string[]) => {
-      if (args[0] === '--version') {
-        return { status: 0, stdout: '10.0.0\n', stderr: '' };
-      }
-      return { status: 1, stdout: '', stderr: '' };
-    });
+    mockNpmGlobalRoot(globalNodeModules);
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     const { maybePromptStartupUpdate } = await import('../src/update.js');
@@ -576,7 +586,7 @@ describe('maybePromptStartupUpdate', () => {
 
   it('installs and reports updated=true when the user accepts', async () => {
     setTty(true);
-    const { installRoot } = setupGlobalPackageInstall();
+    const { installRoot, globalNodeModules } = setupGlobalPackageInstall();
     writeCache('0.42.0', 60 * 1000);
     readlineState.answer = 'y';
     requestExternalGatewayRestartMock.mockReturnValue({
@@ -590,6 +600,9 @@ describe('maybePromptStartupUpdate', () => {
       }
       if (command === 'npm' && args[0] === '--version') {
         return { status: 0, stdout: '10.0.0\n', stderr: '' };
+      }
+      if (command === 'npm' && args[0] === 'root' && args[1] === '-g') {
+        return { status: 0, stdout: `${globalNodeModules}\n`, stderr: '' };
       }
       if (command === 'npm' && args[0] === 'rebuild') {
         return { status: 0, stdout: '', stderr: '' };
@@ -614,6 +627,73 @@ describe('maybePromptStartupUpdate', () => {
       { stdio: 'inherit' },
     );
     expect(installRoot).toContain('@hybridaione');
+  });
+
+  it('resolves a global bin symlink to the real package before prompting', async () => {
+    setTty(true);
+    const { installRoot, globalNodeModules } = setupGlobalPackageInstall();
+    // A global npm install exposes the CLI as a bin shim on PATH that symlinks
+    // to the real dist entry. process.argv[1] is that shim, not the package
+    // path, so detection must follow the link to find the package root.
+    const realEntry = path.join(installRoot, 'dist', 'cli.js');
+    fs.writeFileSync(realEntry, '');
+    const binDir = path.join(tempDir, 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    const binShim = path.join(binDir, 'hybridclaw');
+    fs.symlinkSync(realEntry, binShim);
+    process.argv = [originalArgv[0] || 'node', binShim];
+    writeCache('0.42.0', 60 * 1000);
+    readlineState.answer = 'n';
+    mockNpmGlobalRoot(globalNodeModules);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { maybePromptStartupUpdate } = await import('../src/update.js');
+    const updated = await maybePromptStartupUpdate('0.9.8');
+
+    expect(updated).toBe(false);
+    const messages = logSpy.mock.calls.map((call) => String(call[0]));
+    expect(messages).toContain('Update available: 0.9.8 -> 0.42.0');
+  });
+
+  it('does not prompt for a project-local install whose global root differs', async () => {
+    setTty(true);
+    const { installRoot } = setupGlobalPackageInstall();
+    writeCache('0.42.0', 60 * 1000);
+    // The package manager's global root holds a *different* copy, so the
+    // running entry point is a project-local dependency we must not upgrade
+    // with a global install.
+    const otherGlobalPkg = path.join(
+      tempDir,
+      'global',
+      'node_modules',
+      '@hybridaione',
+      'hybridclaw',
+    );
+    fs.mkdirSync(otherGlobalPkg, { recursive: true });
+    fs.writeFileSync(
+      path.join(otherGlobalPkg, 'package.json'),
+      JSON.stringify({ name: '@hybridaione/hybridclaw', version: '0.42.0' }),
+    );
+    expect(installRoot).not.toBe(otherGlobalPkg);
+    spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+      if (command === 'npm' && args[0] === 'root' && args[1] === '-g') {
+        return {
+          status: 0,
+          stdout: `${path.dirname(path.dirname(otherGlobalPkg))}\n`,
+          stderr: '',
+        };
+      }
+      return { status: 1, stdout: '', stderr: '' };
+    });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { maybePromptStartupUpdate } = await import('../src/update.js');
+    const updated = await maybePromptStartupUpdate('0.9.8');
+
+    expect(updated).toBe(false);
+    // No prompt, no install: a local copy never triggers a global update.
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## What

Prompt the user to update HybridClaw when a newer release is available and they start it **interactively** — `hybridclaw tui`, `hybridclaw gateway`, or `hybridclaw gateway start`. Answer `y` to install, rebuild native deps, run the postinstall, and exit (relaunch on the new version); `n` to continue on the current version.

## How it works (cache-first, mirroring Codex)

Modeled on `codex-rs/tui/src/updates.rs`:

- The prompt is decided from a **cached** latest version at `<runtime-home>/version-check.json` (`{ latestVersion, lastCheckedAt }`, **20h TTL**).
- When the cache is missing or stale, a **detached** `__refresh-version-cache` child process (`detached: true`, `stdio: 'ignore'`, unref'd) refreshes it via `npm view` for the *next* launch.
- **Startup never blocks on the network.** First run with no cache stays silent and warms the cache; the banner appears next launch.
- The actual install reuses the existing `hybridclaw update` machinery (package-manager detection, native rebuild, postinstall, gateway restart).

## Gating

- Only on an interactive terminal (both stdin and stdout TTY).
- Only for **global package installs** — source checkouts and unknown installs are skipped (no prompt, no refresh).
- Non-interactive shells / the detached gateway daemon never prompt.

## Differences from Codex (intentional, not implemented here)

- Binary `[y/N]` prompt rather than the 3-option modal with "skip this version".
- No config opt-out flag yet.
- npm registry as the only version source (Codex tailors per install method).
- Also covers the gateway entry points, not just the TUI.

## Tests

- `tests/update.test.ts`: 15 tests — non-TTY, source checkout (no prompt **and** no refresh), missing-cache→spawn refresh, stale→refresh, fresh→no refresh, up-to-date→silent, newer→prompt→decline, and `refreshVersionCache` write / no-write-on-failure. Original 5 `runUpdateCommand` tests intact.
- `tests/cli.test.ts`: mock updated for the new exports.

## Validation

- `tsc --noEmit`: clean
- `tsc --noEmit --noUnusedLocals --noUnusedParameters`: clean
- `biome check` (changed files): clean
- `vitest tests/cli.test.ts tests/update.test.ts`: **168/168 pass**

Not run: full `npm run test:unit` suite, `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)