### PR TITLE
fix: mask provider API keys during onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,6 @@
 
 ## Unreleased
 
-### Fixed
-
-- **Mask all provider keys during onboarding**: The Anthropic, OpenRouter,
-  Mistral, and Hugging Face credential prompts now read through the hidden
-  secret prompt like the HybridAI and speech-to-text prompts, so keys are no
-  longer echoed to the terminal during `hybridclaw onboarding`.
-
 ## [0.21.0](https://github.com/HybridAIOne/hybridclaw/tree/v0.21.0) - 2026-05-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Mask all provider keys during onboarding**: The Anthropic, OpenRouter,
+  Mistral, and Hugging Face credential prompts now read through the hidden
+  secret prompt like the HybridAI and speech-to-text prompts, so keys are no
+  longer echoed to the terminal during `hybridclaw onboarding`.
+
 ## [0.21.0](https://github.com/HybridAIOne/hybridclaw/tree/v0.21.0) - 2026-05-29
 
 ### Added

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -1295,6 +1295,7 @@ async function runAnthropicOnboarding(params: {
         ? 'Anthropic API key (Enter to keep current): '
         : 'Anthropic API key: ',
       ICON_KEY,
+      true,
     );
     const apiKey = (entered || existingApiKey).trim();
     if (!apiKey) {
@@ -1354,6 +1355,7 @@ async function runOpenRouterOnboarding(params: {
       ? 'OpenRouter API key (Enter to keep current): '
       : 'OpenRouter API key: ',
     ICON_KEY,
+    true,
   );
   const apiKey = (entered || existingKey).trim();
   if (!apiKey) {
@@ -1407,6 +1409,7 @@ async function runMistralOnboarding(params: {
       ? 'Mistral API key (Enter to keep current): '
       : 'Mistral API key: ',
     ICON_KEY,
+    true,
   );
   const apiKey = (entered || existingKey).trim();
   if (!apiKey) {
@@ -1460,6 +1463,7 @@ async function runHuggingFaceOnboarding(params: {
       ? 'Hugging Face token (Enter to keep current): '
       : 'Hugging Face token: ',
     ICON_KEY,
+    true,
   );
   const apiKey = (entered || existingKey).trim();
   if (!apiKey) {

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -9,9 +9,8 @@ import type { RuntimeConfig } from '../src/config/runtime-config.js';
 const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_DISABLE_CONFIG_WATCHER =
   process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
-// Provider credential variables that the onboarding tests delete (so onboarding
-// prompts for them) and must therefore restore in teardown — otherwise clearing
-// one here would leak into later tests in the same Vitest process.
+// Cleared by the tests (so onboarding prompts) and restored in afterEach so the
+// deletes don't leak into later tests in the same Vitest process.
 const PROVIDER_API_KEY_ENV_VARS = [
   'HYBRIDAI_API_KEY',
   'DEEPGRAM_API_KEY',
@@ -956,10 +955,8 @@ test.each(MASKED_PROVIDER_CASES)(
       configurable: true,
     });
 
-    // The plain readline interface only answers the non-secret prompts: keep the
-    // configured Anthropic auth method and decline the default-model switch. If a
-    // provider ever stopped masking its key prompt it would fall through to this
-    // mock instead of `promptForSecretInput`, and the assertions below would fail.
+    // Answers only the non-secret prompts; an unmasked key prompt would fall
+    // through to here instead of `promptForSecretInput` and fail the assertions.
     vi.doMock('node:readline/promises', () => ({
       default: {
         createInterface: () => ({

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -893,3 +893,113 @@ test('ensureRuntimeCredentials backfills the default HybridAI bot from account f
     'user-42',
   );
 });
+
+const MASKED_PROVIDER_CASES = [
+  {
+    name: 'Anthropic',
+    preferredAuth: 'anthropic' as const,
+    secretName: 'ANTHROPIC_API_KEY',
+    maskedValue: 'anthropic-masked-secret-key',
+  },
+  {
+    name: 'OpenRouter',
+    preferredAuth: 'openrouter' as const,
+    secretName: 'OPENROUTER_API_KEY',
+    maskedValue: 'or-masked-secret-key',
+  },
+  {
+    name: 'Mistral',
+    preferredAuth: 'mistral' as const,
+    secretName: 'MISTRAL_API_KEY',
+    maskedValue: 'mistral-masked-secret-key',
+  },
+  {
+    name: 'Hugging Face',
+    preferredAuth: 'huggingface' as const,
+    secretName: 'HF_TOKEN',
+    maskedValue: 'hf-masked-secret-token',
+  },
+];
+
+test.each(MASKED_PROVIDER_CASES)(
+  'interactive onboarding reads the $name credential through the hidden secret prompt',
+  async ({ preferredAuth, secretName, maskedValue }) => {
+    const homeDir = makeTempHome();
+    writeRuntimeConfig(homeDir);
+
+    process.env.HOME = homeDir;
+    process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
+    delete process.env.HYBRIDAI_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.MISTRAL_API_KEY;
+    delete process.env.HF_TOKEN;
+    delete process.env.HUGGINGFACE_API_KEY;
+    process.chdir(homeDir);
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+
+    // The plain readline interface only answers the non-secret prompts: keep the
+    // configured Anthropic auth method and decline the default-model switch. If a
+    // provider ever stopped masking its key prompt it would fall through to this
+    // mock instead of `promptForSecretInput`, and the assertions below would fail.
+    vi.doMock('node:readline/promises', () => ({
+      default: {
+        createInterface: () => ({
+          question: vi.fn(async (prompt: string) =>
+            /auth method/i.test(prompt) ? '' : 'n',
+          ),
+          close: vi.fn(),
+        }),
+      },
+    }));
+    vi.doMock('../src/utils/secret-prompt.js', () => ({
+      promptForSecretInput: vi.fn(async () => maskedValue),
+    }));
+    vi.doMock('../src/security/runtime-secrets.ts', async () => {
+      const actual = await vi.importActual<
+        typeof import('../src/security/runtime-secrets.ts')
+      >('../src/security/runtime-secrets.ts');
+      return {
+        ...actual,
+        loadRuntimeSecrets: (targetHomeDir?: string) =>
+          actual.loadRuntimeSecrets(targetHomeDir ?? homeDir, homeDir),
+      };
+    });
+    vi.doMock('../src/security/runtime-secrets-bootstrap.ts', async () => {
+      const actual = await vi.importActual<
+        typeof import('../src/security/runtime-secrets-bootstrap.ts')
+      >('../src/security/runtime-secrets-bootstrap.ts');
+      return {
+        ...actual,
+        bootstrapRuntimeSecrets: (targetHomeDir?: string) =>
+          actual.bootstrapRuntimeSecrets(targetHomeDir ?? homeDir),
+      };
+    });
+    vi.resetModules();
+
+    const runtimeConfig = await import('../src/config/runtime-config.ts');
+    runtimeConfig.acceptSecurityTrustModel({
+      acceptedAt: '2026-03-10T10:00:00.000Z',
+      acceptedBy: 'test',
+    });
+
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const onboarding = await import('../src/onboarding.ts');
+    await onboarding.ensureRuntimeCredentials({
+      commandName: 'hybridclaw onboarding',
+      preferredAuth,
+    });
+
+    const runtimeSecrets = await import('../src/security/runtime-secrets.ts');
+    const secretPrompt = await import('../src/utils/secret-prompt.js');
+    expect(secretPrompt.promptForSecretInput).toHaveBeenCalled();
+    expect(runtimeSecrets.readStoredRuntimeSecret(secretName)).toBe(maskedValue);
+  },
+);

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -9,8 +9,21 @@ import type { RuntimeConfig } from '../src/config/runtime-config.js';
 const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_DISABLE_CONFIG_WATCHER =
   process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
-const ORIGINAL_HYBRIDAI_API_KEY = process.env.HYBRIDAI_API_KEY;
-const ORIGINAL_DEEPGRAM_API_KEY = process.env.DEEPGRAM_API_KEY;
+// Provider credential variables that the onboarding tests delete (so onboarding
+// prompts for them) and must therefore restore in teardown — otherwise clearing
+// one here would leak into later tests in the same Vitest process.
+const PROVIDER_API_KEY_ENV_VARS = [
+  'HYBRIDAI_API_KEY',
+  'DEEPGRAM_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'OPENROUTER_API_KEY',
+  'MISTRAL_API_KEY',
+  'HF_TOKEN',
+  'HUGGINGFACE_API_KEY',
+] as const;
+const ORIGINAL_PROVIDER_API_KEY_ENV = new Map<string, string | undefined>(
+  PROVIDER_API_KEY_ENV_VARS.map((name) => [name, process.env[name]]),
+);
 const ORIGINAL_STDIN_IS_TTY = process.stdin.isTTY;
 const ORIGINAL_STDOUT_IS_TTY = process.stdout.isTTY;
 const ORIGINAL_CWD = process.cwd();
@@ -157,15 +170,13 @@ afterEach(() => {
     process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER =
       ORIGINAL_DISABLE_CONFIG_WATCHER;
   }
-  if (ORIGINAL_HYBRIDAI_API_KEY === undefined) {
-    delete process.env.HYBRIDAI_API_KEY;
-  } else {
-    process.env.HYBRIDAI_API_KEY = ORIGINAL_HYBRIDAI_API_KEY;
-  }
-  if (ORIGINAL_DEEPGRAM_API_KEY === undefined) {
-    delete process.env.DEEPGRAM_API_KEY;
-  } else {
-    process.env.DEEPGRAM_API_KEY = ORIGINAL_DEEPGRAM_API_KEY;
+  for (const name of PROVIDER_API_KEY_ENV_VARS) {
+    const original = ORIGINAL_PROVIDER_API_KEY_ENV.get(name);
+    if (original === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = original;
+    }
   }
   Object.defineProperty(process.stdin, 'isTTY', {
     value: ORIGINAL_STDIN_IS_TTY,


### PR DESCRIPTION
## Summary

While investigating whether the HybridAI API key entry in onboarding is protected, I found an inconsistency: HybridAI (and the speech-to-text providers) read their keys through the **hidden secret prompt** (raw TTY, no echo), but the **Anthropic, OpenRouter, Mistral, and Hugging Face** prompts passed the key through plain `readline`, so the key is echoed to the terminal as you type during `hybridclaw onboarding`.

This PR makes all provider credential prompts consistent by routing them through `promptForSecretInput`.

## What changed

- `src/onboarding.ts`: pass `secret = true` to the `promptOptional` calls for the Anthropic, OpenRouter, Mistral, and Hugging Face key/token prompts, so they read through `promptForSecretInput` (raw-TTY, no echo) — matching the existing HybridAI and speech-to-text behavior.
- `tests/onboarding.test.ts`: add a parametrized test (one case per provider) asserting that each provider's credential is read through the hidden secret prompt and never falls through to plain readline. The test would fail if a provider stopped masking its key prompt.
- `CHANGELOG.md`: note the fix under `Unreleased`.

## Notes

- **Shell history is not affected either way** — onboarding reads keys from an interactive stdin prompt inside the running process, never as a shell command argument, so keys never reach `~/.zsh_history`. This change is purely about terminal echo / shoulder-surfing during entry.
- `hybridclaw auth login <provider>` already masks (it calls `promptForSecretInput` directly); this only affects the interactive `onboarding` flow.

## Testing

- `npx vitest run tests/onboarding.test.ts` — 16 passed (incl. 4 new provider cases)
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run format` — no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)