### PR TITLE
fix: guard the CLI against unsupported Node.js versions

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import './node-version-guard.js';
 import { spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';

--- a/src/node-version-guard.ts
+++ b/src/node-version-guard.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs';
+
+// The required Node.js major is sourced from this package's own `engines.node`
+// so there is a single source of truth. Imported first by the CLI entry, so
+// this read and check happen before the heavier module graph loads and an
+// unsupported runtime fails cleanly instead of crashing on a newer-Node API.
+
+export interface NodeVersionCheck {
+  ok: boolean;
+  requiredMajor: number;
+  actualMajor: number;
+  message?: string;
+}
+
+export function parseRequiredMajor(enginesNode: string): number {
+  const major = Number.parseInt(/\d+/.exec(enginesNode ?? '')?.[0] ?? '', 10);
+  if (!Number.isInteger(major)) {
+    throw new Error(
+      `Could not determine the required Node.js major from engines.node ("${enginesNode}").`,
+    );
+  }
+  return major;
+}
+
+function loadRequiredMajor(): number {
+  const pkg = JSON.parse(
+    readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+  ) as { engines?: { node?: string } };
+  return parseRequiredMajor(pkg.engines?.node ?? '');
+}
+
+export const REQUIRED_NODE_MAJOR = loadRequiredMajor();
+
+export function checkNodeVersion(
+  nodeVersion: string = process.versions.node,
+  requiredMajor: number = REQUIRED_NODE_MAJOR,
+): NodeVersionCheck {
+  const parsedMajor = Number.parseInt(
+    String(nodeVersion).replace(/^v/, '').split('.')[0] ?? '',
+    10,
+  );
+  const actualMajor = Number.isNaN(parsedMajor) ? 0 : parsedMajor;
+  if (actualMajor === requiredMajor) {
+    return { ok: true, requiredMajor, actualMajor };
+  }
+
+  const message = [
+    `hybridclaw requires Node.js ${requiredMajor}.x, but this process is running ${nodeVersion}.`,
+    `Install Node.js ${requiredMajor} (the current LTS) and run the command again.`,
+    `If you use a Node version manager (nvm, fnm, volta, asdf), switch to Node ${requiredMajor} first.`,
+  ].join('\n');
+
+  return { ok: false, requiredMajor, actualMajor, message };
+}
+
+export function enforceNodeVersion(
+  check: NodeVersionCheck = checkNodeVersion(),
+  reportError: (message: string) => void = (message) => console.error(message),
+  exit: (code: number) => void = (code) => process.exit(code),
+): void {
+  if (check.ok) return;
+  reportError(check.message ?? '');
+  exit(1);
+}
+
+enforceNodeVersion();

--- a/tests/node-version-guard.integration.test.ts
+++ b/tests/node-version-guard.integration.test.ts
@@ -1,0 +1,66 @@
+import { spawnSync } from 'node:child_process';
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, expect, test } from 'vitest';
+
+// End-to-end check of the real guard in a separate Node process. The layout
+// mirrors the published package (package.json at the root, the guard one level
+// down under dist/), and engines.node is pointed at a major other than the
+// runner's so the guard trips on the *current* Node. This exercises the real
+// process exit, the package.json read, and the import-ordering halt together —
+// the parts the in-process unit tests cannot reach on a supported runtime.
+
+const guardSource = fileURLToPath(
+  new URL('../src/node-version-guard.ts', import.meta.url),
+);
+
+let root = '';
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), 'hybridclaw-nodeguard-'));
+  mkdirSync(path.join(root, 'dist'));
+  copyFileSync(guardSource, path.join(root, 'dist', 'node-version-guard.ts'));
+  writeFileSync(
+    path.join(root, 'dist', 'probe.ts'),
+    "import './node-version-guard.ts';\nconsole.log('HEAVY GRAPH RAN');\n",
+  );
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+function runProbe(enginesNode: string) {
+  writeFileSync(
+    path.join(root, 'package.json'),
+    `${JSON.stringify({ type: 'module', engines: { node: enginesNode } })}\n`,
+  );
+  return spawnSync(
+    process.execPath,
+    ['--import', 'tsx/esm', path.join(root, 'dist', 'probe.ts')],
+    { encoding: 'utf8', env: { ...process.env, NODE_NO_WARNINGS: '1' } },
+  );
+}
+
+test('exits before the rest of the CLI loads on an unsupported Node major', () => {
+  // The test runner is not Node 18, so requiring 18.x trips the guard.
+  const result = runProbe('18.x');
+  expect(result.status).toBe(1);
+  expect(result.stderr).toContain('requires Node.js 18.x');
+  expect(result.stdout).not.toContain('HEAVY GRAPH RAN');
+});
+
+test('continues loading when the running Node matches engines.node', () => {
+  const runningMajor = process.versions.node.split('.')[0];
+  const result = runProbe(`${runningMajor}.x`);
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain('HEAVY GRAPH RAN');
+});

--- a/tests/node-version-guard.test.ts
+++ b/tests/node-version-guard.test.ts
@@ -1,0 +1,91 @@
+import { readFileSync } from 'node:fs';
+import { expect, test } from 'vitest';
+import {
+  REQUIRED_NODE_MAJOR,
+  checkNodeVersion,
+  enforceNodeVersion,
+  parseRequiredMajor,
+} from '../src/node-version-guard.ts';
+
+const pkg = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+) as { engines?: { node?: string } };
+
+test('parses the required major from an engines.node range', () => {
+  expect(parseRequiredMajor('22.x')).toBe(22);
+  expect(parseRequiredMajor('>=22 <23')).toBe(22);
+  expect(parseRequiredMajor('20.18.1')).toBe(20);
+  expect(() => parseRequiredMajor('')).toThrow();
+});
+
+test('sources REQUIRED_NODE_MAJOR from package.json engines.node', () => {
+  expect(REQUIRED_NODE_MAJOR).toBe(parseRequiredMajor(pkg.engines?.node ?? ''));
+});
+
+test('accepts a matching Node major', () => {
+  expect(checkNodeVersion('22.14.0', 22)).toMatchObject({
+    ok: true,
+    requiredMajor: 22,
+    actualMajor: 22,
+  });
+});
+
+test('rejects an older Node major with a clean message', () => {
+  const result = checkNodeVersion('20.18.1', 22);
+  expect(result.ok).toBe(false);
+  expect(result.actualMajor).toBe(20);
+  expect(result.message).toContain('requires Node.js 22.x');
+  expect(result.message).toContain('20.18.1');
+});
+
+test('rejects a newer Node major as well', () => {
+  expect(checkNodeVersion('24.0.0', 22)).toMatchObject({
+    ok: false,
+    actualMajor: 24,
+  });
+});
+
+test('accepts a v-prefixed version string', () => {
+  expect(checkNodeVersion('v22.1.0', 22)).toMatchObject({
+    ok: true,
+    actualMajor: 22,
+  });
+});
+
+test('treats an unparseable version as major 0', () => {
+  expect(checkNodeVersion('not-a-version', 22)).toMatchObject({
+    ok: false,
+    actualMajor: 0,
+  });
+});
+
+test('enforceNodeVersion reports the message and exits 1 on a bad runtime', () => {
+  const errors: string[] = [];
+  const exitCodes: number[] = [];
+  enforceNodeVersion(
+    checkNodeVersion('20.18.1', 22),
+    (message) => errors.push(message),
+    (code) => exitCodes.push(code),
+  );
+  expect(errors).toHaveLength(1);
+  expect(errors[0]).toContain('requires Node.js 22.x');
+  expect(exitCodes).toEqual([1]);
+});
+
+test('enforceNodeVersion is a no-op on a supported runtime', () => {
+  const errors: string[] = [];
+  const exitCodes: number[] = [];
+  enforceNodeVersion(
+    checkNodeVersion('22.0.0', 22),
+    (message) => errors.push(message),
+    (code) => exitCodes.push(code),
+  );
+  expect(errors).toEqual([]);
+  expect(exitCodes).toEqual([]);
+});
+
+test('cli.ts imports the version guard before any other module', () => {
+  const cli = readFileSync(new URL('../src/cli.ts', import.meta.url), 'utf8');
+  const firstImport = cli.match(/^import\b.*$/m)?.[0];
+  expect(firstImport).toBe("import './node-version-guard.js';");
+});


### PR DESCRIPTION
## Summary

- **Problem:** `engines.node` is `22.x`, but that only emits a non-blocking `EBADENGINE` warning on install. The repo's `engine-strict` `.npmrc` is never published, and consumer npm defaults `engine-strict` to `false`. So a user on Node 18/20 installs "successfully" and then hits a confusing crash later when the CLI uses a Node 22-only API.
- **Why it matters:** First-run experience. The failure surfaces as an opaque stack trace far from the actual cause (wrong Node), not a clear "use Node 22" message.
- **What changed:** Added `src/node-version-guard.ts` and imported it **first** in `src/cli.ts`. ES module dependencies evaluate in import order, so the version check runs before the heavy module graph loads and exits with a clean message on an unsupported major.
- **What did not change:** `engines.node` (still `22.x`, still emits the install-time warning). No new lifecycle/`preinstall` scripts. No behavior change on supported Node 22.

## Change Type

- [x] Bug fix

## Why a runtime guard instead of `preinstall` / `engine-strict`

`engine-strict` can't be forced on consumers (the repo `.npmrc` isn't shipped). A `preinstall` hook would miss the most common real failure modes: `--ignore-scripts` installs and shells that switch to an older Node *after* a successful Node 22 install. A runtime guard fires at the actual point of failure — running the CLI — and covers all of those. This is what most popular CLIs do (npm/yarn/pnpm/Vite/Next).

It's wired as the first import rather than a separate `bin` shim because `cli.ts` gates `main()` on `isDirectExecution()` and has self-spawn logic keyed on `process.argv[1]`; a first-import side effect gives the same "runs before heavy imports" guarantee with a 2-line change and also covers direct dev entry points (`npm run dev` / `gateway` / `tui`).

## Validation

```bash
npx tsc --noEmit          # only pre-existing TS2307s for uninstalled optional deps (camoufox-js, @ngrok/ngrok)
npx @biomejs/biome check src/cli.ts src/node-version-guard.ts   # clean
npx vitest run --project unit tests/node-version-guard.test.ts tests/cli.test.ts tests/cli-verbosity.test.ts   # 165 passing
```

- **New unit test** (`tests/node-version-guard.test.ts`): accept-22 / reject-20 / reject-24.
- **ES module ordering** verified empirically: the first import fully evaluates (and can `process.exit`) before the second import runs.
- **Real Node via Docker** — compiled the actual guard and mirrored `cli.ts`'s import order (guard first, "heavy graph" second):

  | Node | Result | Exit |
  |------|--------|------|
  | 18.20.8 | clean message, heavy graph **never evaluated** | 1 |
  | 20.20.2 | clean message, heavy graph **never evaluated** | 1 |
  | 22 | `HEAVY MODULE GRAPH EVALUATED` → `CLI BODY RAN` | 0 |

  Message on old Node:
  ```
  hybridclaw requires Node.js 22.x, but this process is running 20.20.2.
  Install Node.js 22 (the current LTS) and run the command again.
  If you use a Node version manager (nvm, fnm, volta, asdf), switch to Node 22 first.
  ```

- **Edge cases checked:** existing `cli`-importing tests (153 in `cli.test.ts`) still pass through the new first import on Node 22 (guard is a no-op on the supported major).
- **Skipped checks:** did not run the full `npm run build` (container build); the guard was compiled and exercised in isolation on real Node 18/20/22 instead.

## Risk Notes

- Security-sensitive paths touched? **No.**
- Gateway, audit, approval, or container boundaries touched? **No.**
- Residual gap (called out for honesty): if a sibling module in the import graph did a *named* import of a Node 22-only builtin export, ESM linking would fail before the guard evaluates. The codebase's 22-specific usage is runtime API calls (covered), not missing named exports, so this is not currently hit.

## Docs And Config Impact

- [x] No docs or config impact

> Note: intentionally did **not** add a CHANGELOG entry per maintainer request on this PR.

🤖 AI-assisted: guard implementation, tests, and Docker validation were drafted with Claude Code; author reviewed the diff.