### PR TITLE
fix: load .ts plugins via amaro for Node 22.x compatibility

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -26,6 +26,7 @@
         "@slack/bolt": "4.7.0",
         "@whiskeysockets/baileys": "7.0.0-rc11",
         "ajv": "8.18.0",
+        "amaro": "1.1.9",
         "better-sqlite3": "12.8.0",
         "botbuilder": "4.23.3",
         "camoufox-js": "0.10.2",
@@ -6748,6 +6749,15 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/amaro": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/amaro/-/amaro-1.1.9.tgz",
+      "integrity": "sha512-Qx5+iHi3mKWz95XNx/WPFl8yRMZEGNoRZDaOkoej72kxAo20FbDVx7jALcvyOn/N3+h+GboKip49yba7xqLlKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/ansi-regex": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@slack/bolt": "4.7.0",
         "@whiskeysockets/baileys": "7.0.0-rc11",
         "ajv": "8.18.0",
+        "amaro": "1.1.9",
         "better-sqlite3": "12.8.0",
         "botbuilder": "4.23.3",
         "camoufox-js": "0.10.2",
@@ -6748,6 +6749,15 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/amaro": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/amaro/-/amaro-1.1.9.tgz",
+      "integrity": "sha512-Qx5+iHi3mKWz95XNx/WPFl8yRMZEGNoRZDaOkoej72kxAo20FbDVx7jALcvyOn/N3+h+GboKip49yba7xqLlKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "@slack/bolt": "4.7.0",
     "@whiskeysockets/baileys": "7.0.0-rc11",
     "ajv": "8.18.0",
+    "amaro": "1.1.9",
     "better-sqlite3": "12.8.0",
     "botbuilder": "4.23.3",
     "camoufox-js": "0.10.2",

--- a/scripts/dependency-policy-baseline.json
+++ b/scripts/dependency-policy-baseline.json
@@ -1,7 +1,7 @@
 {
   "lockfiles": {
-    "package-lock.json": "d228eeaa79c9b096bef585765026a0ed92c9c81704e3e9357450c039e9b13067",
-    "npm-shrinkwrap.json": "d228eeaa79c9b096bef585765026a0ed92c9c81704e3e9357450c039e9b13067",
+    "package-lock.json": "af308997acf94575b54cd8a59e633239690d3bddaf9fdb11f7eff5a50e34aac5",
+    "npm-shrinkwrap.json": "af308997acf94575b54cd8a59e633239690d3bddaf9fdb11f7eff5a50e34aac5",
     "container/package-lock.json": "34bfb8fab82aca3763cd27bd2652da3287f72d82579a25b454d913164628254b",
     "container/npm-shrinkwrap.json": "34bfb8fab82aca3763cd27bd2652da3287f72d82579a25b454d913164628254b",
     "plugins/brevo-email/package-lock.json": "3377225eb3bdbb252eaa28ad420b9a725ea1da533417388557aa1984730229b5"

--- a/src/plugins/plugin-manager.ts
+++ b/src/plugins/plugin-manager.ts
@@ -1,5 +1,4 @@
 import fs from 'node:fs';
-import { stripTypeScriptTypes } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -715,6 +714,11 @@ function cleanupPluginImportSnapshot(rootDir: string): void {
   }
 }
 
+async function stripPluginTypeScript(source: string): Promise<string> {
+  const { transformSync } = await import('amaro');
+  return transformSync(source, { mode: 'strip-only' }).code;
+}
+
 async function importPluginModule(
   entrypoint: string,
   pluginDir: string,
@@ -728,7 +732,7 @@ async function importPluginModule(
   try {
     if (entrypoint.endsWith('.ts')) {
       const source = fs.readFileSync(snapshotEntrypoint, 'utf-8');
-      const stripped = stripTypeScriptTypes(source, { mode: 'strip' });
+      const stripped = await stripPluginTypeScript(source);
       const compiledPath = path.join(
         path.dirname(snapshotEntrypoint),
         `.${path.basename(snapshotEntrypoint, '.ts')}.hybridclaw.mjs`,


### PR DESCRIPTION
## Problem

Installing/running HybridClaw on **Node 22.0–22.12** crashes the gateway on boot:

```
hybridclaw error: The requested module 'node:module' does not provide an export named 'stripTypeScriptTypes'
```

(Reported during onboarding testing on Node 22.12.)

### Root cause

`src/plugins/plugin-manager.ts` stripped TypeScript types from `.ts` plugin entrypoints using a **named static import** of `stripTypeScriptTypes` from `node:module`. That API was only added in **Node v22.13.0** (verified against the Node docs: *"Added in: v23.2.0, v22.13.0"*). Because a named import is resolved at module-link time, the gateway crashed on boot on any 22.x below 22.13 — **even when no plugin used a `.ts` entrypoint**.

Meanwhile `engines` (`"22.x"`), the docs ("Node.js 22"), the doctor check, and CI (`node-version: 22` → latest 22.x) all advertise bare 22.x, so this never reproduced in the pipeline and only bit users on an older 22 minor. `.ts` is a documented, supported plugin entrypoint (`docs/content/extensibility/plugins.md`), so this was a real compatibility gap, not a niche.

## Fix

Strip types with [`amaro`](https://www.npmjs.com/package/amaro) instead — the same SWC/WASM engine Node bundles *behind* `module.stripTypeScriptTypes`:

```ts
async function stripPluginTypeScript(source: string): Promise<string> {
  const { transformSync } = await import('amaro');
  return transformSync(source, { mode: 'strip-only' }).code;
}
```

- **Uniform across all 22.x** — amaro (not a runtime-version-gated built-in) drives stripping on every supported Node, so `.ts` plugins behave identically everywhere.
- **Lazy-imported** — the WASM only loads when a plugin actually ships a `.ts` entrypoint; no boot-time cost.
- **Always amaro, no native fallback** — so the existing `.ts`-plugin tests exercise the shipped path on every Node version (the maintainer's Node included).
- Verified amaro's output is byte-identical to the native API (`const x         = 1;`, whitespace-preserving strip).

### Dependency notes
- Pinned `amaro@1.1.9` (exact). Not the latest `1.1.10` — `.npmrc` enforces `min-release-age=7` and 1.1.10 is too fresh; 1.1.9 is the newest eligible version (same minor, identical API).
- amaro has **zero runtime deps** (bundled WASM) and **no install scripts**.
- Lockfiles regenerated with the pinned npm 11.10.0 and kept byte-identical; dependency-policy baseline hashes updated.

No `engines` / version-check / doc changes needed — `"22.x"` is now genuinely accurate.


## Alternatives considered

**Raise the minimum to Node ≥ 22.13.0** (bump `engines`, `scripts/check-node-version.mjs`, the doctor runtime check, and the docs to make the real floor explicit). Simplest and adds no dependency, but it *narrows* the supported range rather than fixing compatibility — exactly the opposite of the goal here. `.ts` is a documented entrypoint, and dropping support for 22.0–22.12 would break installs that the docs/`engines` say are supported. Rejected in favor of actually supporting all of 22.x.

**Lazy feature-detect with a clear error on < 22.13** (keep the built-in, fall back to a "upgrade Node or ship compiled JS" error). Stops the boot crash and is dependency-free, but it leaves a *documented* feature (`.ts` entrypoints) silently non-functional on 22.0–22.12 — works on the maintainer's Node, breaks on a user's. That's the exact "works here, not there" failure mode being reported, just with a nicer message. Rejected as a half-measure.

**amaro (this PR)** is the only option that makes the documented `.ts` path genuinely work and behave identically across the whole supported 22.x range. Cost is one zero-dependency, no-install-script WASM package.

## Verification
- `node scripts/check-dependency-policy.mjs` and `--base origin/main` → **both pass**
- `tsc --noEmit` → **0 errors**; `biome check` → clean
- `vitest run` plugin-manager suites (`plugin-manager`, `plugin-manager.singleton`, `container.plugin-tool-dispatch`) → **all pass**, now running through amaro (including the broken-`.ts`-syntax error case)
