### PR TITLE
fix(console): apply theme on every route, not just the admin shell

### DIFF
--- a/console/src/main.tsx
+++ b/console/src/main.tsx
@@ -2,8 +2,11 @@ import ReactDOM from 'react-dom/client';
 import { App } from './app';
 import { AuthProvider } from './auth';
 import { ToastProvider } from './components/toast';
+import { initThemeStore } from './theme';
 import './theme.css';
 import './styles.css';
+
+initThemeStore();
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <AuthProvider>


### PR DESCRIPTION
## Problem

Reported during onboarding testing: *"Admin is in dark mode and agent view is in light mode (by default)."* The admin console renders in dark (system) theme, but the **Agents** view (and Chat) renders **light**, regardless of the user's theme preference.

## Root cause

Theme is applied to the document (`<html data-theme=…>`) by two things:

1. **`AppShell`** calls `useTheme()`, which initializes the theme store and applies the resolved theme. This is why every `/admin/*` route is themed correctly.
2. An **inline `<script>` in `console/index.html`** (`bootstrapTheme()`).

The standalone **`/agents`** and **`/chat`** views render **outside `AppShell`** and never call `useTheme()` themselves, so they depend entirely on (2). When that inline bootstrap doesn't run, those routes fall back to the light `:root` defaults (`--background: #ffffff`) while `/admin` is dark — producing the reported inconsistency.

This was reproduced live: a fresh load of `/agents` came up with `data-theme` **unset** and `body` background `rgb(255,255,255)`, while `/admin` in the same session was `data-theme=dark`, `rgb(11,18,32)`.

(The inline bootstrap is also fragile by construction — it's a separate Vite entry whose code gets folded into the main bundle at build time; whether it runs depends on bundler behavior, and it does **not** run through the Vite dev passthrough.)

## Fix

Initialize the theme store from **`main.tsx`** — the JS entry every route loads — so the resolved theme is applied for **all** routes, independent of the inline `index.html` bootstrap:

```ts
import { initThemeStore } from './theme';
…
initThemeStore();
```

- `initThemeStore()` is **idempotent** (guarded by an `initialized` flag), so the later `useTheme()` calls in `AppShell` are unaffected.
- The inline `index.html` bootstrap is kept as-is (good anti-FOUC); this is the belt-and-suspenders guarantee.

## Verification (drove the running console)

| Route | Before | After |
|---|---|---|
| `/admin` | dark (`data-theme=dark`, `#0b1220`) | dark (unchanged) |
| `/agents` (fresh load) | **light** (`data-theme` unset, `#ffffff`) | **dark** (`data-theme=dark`, `#0b1220`) |

- `npm --workspace console run typecheck` → clean
- `biome check` → clean
- `npm --workspace console run test` → **638/638 pass**