### PR TITLE
feat: add curl|bash install script (Linux/macOS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,12 @@ jobs:
       - name: TypeScript lint (console)
         run: npm --prefix console run typecheck
 
+      - name: Shellcheck install scripts
+        run: shellcheck scripts/install.sh scripts/install.test.sh
+
+      - name: Installer unit tests
+        run: bash scripts/install.test.sh
+
   test:
     runs-on: ubuntu-latest
     permissions:

--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ HybridAI adds:
 
 ## Get running in 2 minutes
 
+One-line install on Linux/macOS (ensures Node 22, installs the CLI, runs
+onboarding):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/scripts/install.sh | bash
+```
+
+Or do it by hand with npm:
+
 ```bash
 npm install -g @hybridaione/hybridclaw
 hybridclaw onboarding

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -24,6 +24,18 @@ curl -fsSL https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/scripts
   | bash -s -- --version 0.21.0 --no-onboarding
 ```
 
+For automation, preview the plan with `--dry-run` (changes nothing), run
+headless with `--no-prompt`, and smoke-test the result with `--verify`
+(`hybridclaw --version` plus `hybridclaw doctor`). Each flag also has an
+environment-variable form (`HYBRIDCLAW_DRY_RUN=1`, `HYBRIDCLAW_NO_PROMPT=1`,
+`HYBRIDCLAW_VERIFY_INSTALL=1`) for CI runners that cannot pass arguments
+through the pipe:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/scripts/install.sh \
+  | bash -s -- --no-prompt --verify
+```
+
 The script never uses `sudo`: when no Node.js 22 is present it installs a
 user-local copy under `~/.hybridclaw/node`, and it falls back to a
 user-writable npm prefix if the global one is not writable. Windows users

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -37,10 +37,13 @@ curl -fsSL https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/scripts
 ```
 
 The script never uses `sudo`: when no Node.js 22 is present it installs a
-user-local copy under `~/.hybridclaw/node`, and it falls back to a
-user-writable npm prefix if the global one is not writable. Windows users
-should run it inside WSL2. Review `scripts/install.sh` before piping it to a
-shell if you prefer; the steps below cover each install method manually.
+user-local copy under `~/.hybridclaw/node` (verified against nodejs.org's
+published SHA-256 checksum), and it falls back to a user-writable npm prefix if
+the global one is not writable. Windows users should run it inside WSL2. On
+Alpine or other musl-based distros, install Node 22 with your package manager
+(`apk add nodejs npm`) and pass `--skip-node`, since nodejs.org ships glibc
+builds only. Review `scripts/install.sh` before piping it to a shell if you
+prefer; the steps below cover each install method manually.
 
 ## Install From npm
 

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -38,8 +38,9 @@ curl -fsSL https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/scripts
 
 The script never uses `sudo`: when no Node.js 22 is present it installs a
 user-local copy under `~/.hybridclaw/node` (verified against nodejs.org's
-published SHA-256 checksum), and it falls back to a user-writable npm prefix if
-the global one is not writable. Windows users should run it inside WSL2. On
+published SHA-256 checksum), and if the global npm prefix is not writable it
+prints the commands to switch to a user-writable one rather than escalating.
+Windows users should run it inside WSL2. On
 Alpine or other musl-based distros, install Node 22 with your package manager
 (`apk add nodejs npm`) and pass `--skip-node`, since nodejs.org ships glibc
 builds only. Review `scripts/install.sh` before piping it to a shell if you

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -6,6 +6,30 @@ sidebar_position: 2
 
 # Installation
 
+## Install With the One-Line Script
+
+The quickest path on Linux and macOS is the bootstrap installer. It ensures a
+compatible Node.js 22 and npm, installs the `hybridclaw` CLI from npm, checks
+for Docker, and offers to run onboarding:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/scripts/install.sh | bash
+```
+
+Pass options through the pipe with `-s --`, for example to pin a version and
+skip the interactive onboarding step:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/scripts/install.sh \
+  | bash -s -- --version 0.21.0 --no-onboarding
+```
+
+The script never uses `sudo`: when no Node.js 22 is present it installs a
+user-local copy under `~/.hybridclaw/node`, and it falls back to a
+user-writable npm prefix if the global one is not writable. Windows users
+should run it inside WSL2. Review `scripts/install.sh` before piping it to a
+shell if you prefer; the steps below cover each install method manually.
+
 ## Install From npm
 
 ```bash

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -39,7 +39,8 @@ curl -fsSL https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/scripts
 The script never uses `sudo`: when no Node.js 22 is present it installs a
 user-local copy under `~/.hybridclaw/node` (verified against nodejs.org's
 published SHA-256 checksum), and if the global npm prefix is not writable it
-prints the commands to switch to a user-writable one rather than escalating.
+automatically switches npm to a user-writable prefix
+(`~/.hybridclaw/npm-global`) rather than escalating.
 Windows users should run it inside WSL2. On
 Alpine or other musl-based distros, install Node 22 with your package manager
 (`apk add nodejs npm`) and pass `--skip-node`, since nodejs.org ships glibc

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -64,6 +64,7 @@ err()   { printf '%serror:%s %s\n' "$C_ERR" "$C_RESET" "$*" >&2; }
 die()   { err "$@"; exit 1; }
 
 is_dry() { [ "$DRY_RUN" -eq 1 ]; }
+have()   { command -v "$1" >/dev/null 2>&1; }
 
 usage() {
   cat <<'EOF'
@@ -140,8 +141,6 @@ version_ge() {
   [ "$lower" = "$2" ]
 }
 
-node_major() { "$1" --version 2>/dev/null | sed 's/^v//; s/\..*//'; }
-
 resolve_node_version() {
   local v
   v="$(curl -fsSL --max-time 15 https://nodejs.org/dist/index.json 2>/dev/null \
@@ -182,24 +181,23 @@ install_managed_node() {
 }
 
 ensure_node() {
-  local node_path major
-  node_path="$(command -v node || true)"
-
-  if [ -n "$node_path" ]; then
-    major="$(node_major "$node_path")"
+  local node_version major
+  if have node; then
+    node_version="$(node --version 2>/dev/null)"
+    major="${node_version#v}"; major="${major%%.*}"
     if [ "$major" = "$REQUIRED_NODE_MAJOR" ]; then
-      ok "Node.js $(node --version) detected"
+      ok "Node.js $node_version detected"
       return
     fi
     if [ "$MANAGE_NODE" -eq 0 ]; then
-      die "Node.js ${REQUIRED_NODE_MAJOR}.x is required, found $(node --version). Switch versions (nvm/fnm) and retry."
+      die "Node.js ${REQUIRED_NODE_MAJOR}.x is required, found $node_version. Switch versions (nvm/fnm) and retry."
     fi
-    warn "Node.js $(node --version) found, but HybridClaw needs ${REQUIRED_NODE_MAJOR}.x"
+    warn "Node.js $node_version found, but HybridClaw needs ${REQUIRED_NODE_MAJOR}.x"
   elif [ "$MANAGE_NODE" -eq 0 ]; then
     die "Node.js not found on PATH and --skip-node was set."
   fi
 
-  if command -v fnm >/dev/null 2>&1 || command -v nvm >/dev/null 2>&1; then
+  if have fnm || have nvm; then
     warn "A Node version manager (fnm/nvm) is installed. You may prefer:"
     warn "    fnm install 22 && fnm use 22    # or: nvm install 22 && nvm use 22"
     warn "Continuing with a HybridClaw-managed Node 22 in ${HYBRIDCLAW_HOME}/node."
@@ -213,7 +211,7 @@ ensure_npm() {
     info "[dry-run] would ensure npm >= ${REQUIRED_NPM} (upgrading via 'npm install -g npm@^11' if needed)"
     return 0
   fi
-  command -v npm >/dev/null 2>&1 || die "npm not found alongside Node.js; reinstall Node 22."
+  have npm || die "npm not found alongside Node.js; reinstall Node 22."
   npm_version="$(npm --version)"
   if version_ge "$npm_version" "$REQUIRED_NPM"; then
     ok "npm ${npm_version} detected"
@@ -246,23 +244,21 @@ persist_path() {
 npm_global_bin() {
   local prefix
   prefix="$(npm prefix -g 2>/dev/null)" || return 1
-  if [ "$PLATFORM_OS" = "darwin" ] || [ "$PLATFORM_OS" = "linux" ]; then
-    printf '%s/bin' "$prefix"
-  fi
+  printf '%s/bin' "$prefix"
 }
 
 # --- Docker ------------------------------------------------------------------
 
 check_docker() {
   [ "$CHECK_DOCKER" -eq 1 ] || return 0
-  if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
-    ok "Docker is available (default container sandbox supported)"
-  elif command -v docker >/dev/null 2>&1; then
-    warn "Docker is installed but its daemon is not reachable."
-    warn "Start Docker, or run the gateway with --sandbox=host."
-  else
+  if ! have docker; then
     warn "Docker not found. The default container sandbox will be unavailable."
     warn "Install Docker (https://docs.docker.com/get-docker/) or run with --sandbox=host."
+  elif docker info >/dev/null 2>&1; then
+    ok "Docker is available (default container sandbox supported)"
+  else
+    warn "Docker is installed but its daemon is not reachable."
+    warn "Start Docker, or run the gateway with --sandbox=host."
   fi
 }
 
@@ -287,7 +283,7 @@ install_cli() {
 
   local bin_dir
   bin_dir="$(npm_global_bin || true)"
-  if [ -n "$bin_dir" ] && ! command -v hybridclaw >/dev/null 2>&1; then
+  if [ -n "$bin_dir" ] && ! have hybridclaw; then
     export PATH="$bin_dir:$PATH"
     persist_path "$bin_dir"
     warn "Added npm global bin (${bin_dir}) to your PATH. Open a new shell if needed."
@@ -302,7 +298,7 @@ maybe_onboard() {
     return 0
   fi
 
-  command -v hybridclaw >/dev/null 2>&1 \
+  have hybridclaw \
     || die "hybridclaw was installed but is not on PATH yet. Open a new shell and run: hybridclaw onboarding"
 
   ok "Installed $(hybridclaw --version 2>/dev/null || echo "$PKG_NAME")"
@@ -314,14 +310,16 @@ maybe_onboard() {
 
   # When piped through `curl | bash`, stdin is the script, so read the wizard
   # from the controlling terminal if one is available.
-  if [ -t 0 ]; then
-    info "Starting onboarding (Ctrl-C to skip and run it later)"
-    hybridclaw onboarding || warn "onboarding did not complete; run 'hybridclaw onboarding' later"
-  elif [ -r /dev/tty ]; then
-    info "Starting onboarding (Ctrl-C to skip and run it later)"
-    hybridclaw onboarding </dev/tty || warn "onboarding did not complete; run 'hybridclaw onboarding' later"
-  else
+  if [ ! -t 0 ] && [ ! -r /dev/tty ]; then
     info "Non-interactive shell: run 'hybridclaw onboarding' when ready."
+    return
+  fi
+
+  info "Starting onboarding (Ctrl-C to skip and run it later)"
+  if [ -t 0 ]; then
+    hybridclaw onboarding || warn "onboarding did not complete; run 'hybridclaw onboarding' later"
+  else
+    hybridclaw onboarding </dev/tty || warn "onboarding did not complete; run 'hybridclaw onboarding' later"
   fi
 }
 
@@ -333,11 +331,11 @@ run_verify() {
   fi
 
   info "Verifying installation"
-  command -v hybridclaw >/dev/null 2>&1 \
-    || die "verification failed: 'hybridclaw' is not on PATH."
-  hybridclaw --version >/dev/null 2>&1 \
+  have hybridclaw || die "verification failed: 'hybridclaw' is not on PATH."
+  local version_output
+  version_output="$(hybridclaw --version 2>/dev/null)" \
     || die "verification failed: 'hybridclaw --version' did not run successfully."
-  ok "hybridclaw --version -> $(hybridclaw --version 2>/dev/null)"
+  ok "hybridclaw --version -> $version_output"
 
   # doctor reflects environment health (e.g. Docker availability), so a non-zero
   # exit here is a warning about the host, not a broken install.
@@ -372,8 +370,8 @@ EOF
 main() {
   printf '%sHybridClaw installer%s\n\n' "$C_BOLD" "$C_RESET"
   is_dry && warn "Dry run: no changes will be made."
-  command -v curl >/dev/null 2>&1 || die "curl is required but was not found."
-  command -v tar  >/dev/null 2>&1 || die "tar is required but was not found."
+  have curl || die "curl is required but was not found."
+  have tar  || die "tar is required but was not found."
 
   detect_platform
   ok "Platform: ${PLATFORM_OS}/${PLATFORM_ARCH}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -483,6 +483,11 @@ main() {
   print_next_steps
 }
 
-main "$@"
+# Run the installer — unless sourced with HYBRIDCLAW_INSTALL_LIB=1, which the
+# test suite (scripts/install.test.sh) uses to load these functions without
+# executing. Real invocations (executed or piped) never set it, so they run.
+if [ -z "${HYBRIDCLAW_INSTALL_LIB:-}" ]; then
+  main "$@"
+fi
 
 } # end download guard — keep this brace as the final line of the file

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,6 +16,9 @@
 #   4. Checks for Docker (recommended for the default container sandbox).
 #   5. Runs `hybridclaw onboarding` when attached to a terminal.
 #
+# For CI/headless use, pass --no-prompt; preview the plan with --dry-run; run a
+# post-install smoke test with --verify.
+#
 # The HybridClaw runtime itself never needs root. The installer only touches
 # your home directory and the npm global prefix; it never calls sudo.
 
@@ -31,11 +34,19 @@ REQUIRED_NPM="11.10.0"
 # Fallback used only when nodejs.org is unreachable for version discovery.
 NODE_VERSION_FALLBACK="${HYBRIDCLAW_NODE_VERSION:-22.20.0}"
 
-# --- Flags -------------------------------------------------------------------
+# --- Flags (env vars provide defaults; CLI flags override below) -------------
 
 RUN_ONBOARDING=1
 CHECK_DOCKER=1
 MANAGE_NODE=1
+DRY_RUN="${HYBRIDCLAW_DRY_RUN:-0}"
+VERIFY="${HYBRIDCLAW_VERIFY_INSTALL:-0}"
+# Honor both HYBRIDCLAW_NO_PROMPT and the conventional NO_PROMPT.
+if [ -n "${HYBRIDCLAW_NO_PROMPT:-}" ] || [ -n "${NO_PROMPT:-}" ]; then
+  NO_PROMPT=1
+else
+  NO_PROMPT=0
+fi
 
 # --- Output helpers ----------------------------------------------------------
 
@@ -52,6 +63,8 @@ warn()  { printf '%s warn:%s %s\n' "$C_WARN" "$C_RESET" "$*" >&2; }
 err()   { printf '%serror:%s %s\n' "$C_ERR" "$C_RESET" "$*" >&2; }
 die()   { err "$@"; exit 1; }
 
+is_dry() { [ "$DRY_RUN" -eq 1 ]; }
+
 usage() {
   cat <<'EOF'
 HybridClaw installer
@@ -59,15 +72,21 @@ HybridClaw installer
 Options:
   --version <ver>       Install a specific version (default: latest)
   --no-onboarding       Skip the interactive `hybridclaw onboarding` step
+  --no-prompt           Headless/CI mode: never prompt, skip onboarding
+  --dry-run             Print the steps without changing anything
+  --verify              Run a post-install smoke test (version + doctor)
   --skip-docker-check   Do not warn when Docker is missing
   --skip-node           Use the Node.js already on PATH; never download Node
   -h, --help            Show this help
 
 Environment:
-  HYBRIDCLAW_HOME           Install root for managed Node (default: ~/.hybridclaw)
+  HYBRIDCLAW_HOME             Install root for managed Node (default: ~/.hybridclaw)
   HYBRIDCLAW_INSTALL_VERSION  Version to install (default: latest)
-  HYBRIDCLAW_NODE_VERSION   Node version to fetch if one must be installed
-  NO_COLOR                  Disable colored output
+  HYBRIDCLAW_NODE_VERSION     Node version to fetch if one must be installed
+  HYBRIDCLAW_NO_PROMPT=1      Same as --no-prompt (also honors NO_PROMPT)
+  HYBRIDCLAW_DRY_RUN=1        Same as --dry-run
+  HYBRIDCLAW_VERIFY_INSTALL=1 Same as --verify
+  NO_COLOR                    Disable colored output
 EOF
 }
 
@@ -78,6 +97,9 @@ while [ "$#" -gt 0 ]; do
     --version)        INSTALL_VERSION="${2:?--version requires a value}"; shift 2 ;;
     --version=*)      INSTALL_VERSION="${1#*=}"; shift ;;
     --no-onboarding)  RUN_ONBOARDING=0; shift ;;
+    --no-prompt)      NO_PROMPT=1; shift ;;
+    --dry-run)        DRY_RUN=1; shift ;;
+    --verify)         VERIFY=1; shift ;;
     --skip-docker-check) CHECK_DOCKER=0; shift ;;
     --skip-node)      MANAGE_NODE=0; shift ;;
     -h|--help)        usage; exit 0 ;;
@@ -137,6 +159,12 @@ install_managed_node() {
   dir="$HYBRIDCLAW_HOME/node"
   url="https://nodejs.org/dist/v${version}/node-v${version}-${PLATFORM_OS}-${PLATFORM_ARCH}.tar.xz"
 
+  if is_dry; then
+    info "[dry-run] would download ${url}"
+    info "[dry-run] would extract Node.js v${version} into ${dir} and add ${dir}/bin to PATH"
+    return 0
+  fi
+
   info "Installing Node.js v${version} into ${dir} (no system changes)"
   mkdir -p "$dir"
   tarball="$(mktemp "${TMPDIR:-/tmp}/hybridclaw-node.XXXXXX.tar.xz")"
@@ -181,6 +209,10 @@ ensure_node() {
 
 ensure_npm() {
   local npm_version
+  if is_dry; then
+    info "[dry-run] would ensure npm >= ${REQUIRED_NPM} (upgrading via 'npm install -g npm@^11' if needed)"
+    return 0
+  fi
   command -v npm >/dev/null 2>&1 || die "npm not found alongside Node.js; reinstall Node 22."
   npm_version="$(npm --version)"
   if version_ge "$npm_version" "$REQUIRED_NPM"; then
@@ -195,8 +227,13 @@ ensure_npm() {
 # --- PATH persistence --------------------------------------------------------
 
 persist_path() {
+  local dir="$1"
+  if is_dry; then
+    info "[dry-run] would add ${dir} to PATH in your shell rc files"
+    return 0
+  fi
   # Append an idempotent PATH export to the user's shell rc files.
-  local dir="$1" marker="# added by HybridClaw installer"
+  local marker="# added by HybridClaw installer"
   local line="export PATH=\"$dir:\$PATH\" $marker"
   local rc
   for rc in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.profile"; do
@@ -235,6 +272,10 @@ install_cli() {
   local spec="$PKG_NAME"
   [ "$INSTALL_VERSION" != "latest" ] && spec="${PKG_NAME}@${INSTALL_VERSION}"
   info "Installing ${spec} globally via npm"
+  if is_dry; then
+    info "[dry-run] would run: npm install -g ${spec}"
+    return 0
+  fi
   if ! npm install -g "$spec"; then
     err "Global npm install failed."
     err "If this was a permissions error, set a user-writable npm prefix:"
@@ -256,12 +297,18 @@ install_cli() {
 # --- Onboarding + next steps -------------------------------------------------
 
 maybe_onboard() {
+  if is_dry; then
+    info "[dry-run] would verify hybridclaw is on PATH and (unless --no-prompt) run onboarding"
+    return 0
+  fi
+
   command -v hybridclaw >/dev/null 2>&1 \
     || die "hybridclaw was installed but is not on PATH yet. Open a new shell and run: hybridclaw onboarding"
 
   ok "Installed $(hybridclaw --version 2>/dev/null || echo "$PKG_NAME")"
 
-  if [ "$RUN_ONBOARDING" -ne 1 ]; then
+  if [ "$RUN_ONBOARDING" -ne 1 ] || [ "$NO_PROMPT" -eq 1 ]; then
+    info "Skipping interactive onboarding: run 'hybridclaw onboarding' when ready."
     return
   fi
 
@@ -275,6 +322,30 @@ maybe_onboard() {
     hybridclaw onboarding </dev/tty || warn "onboarding did not complete; run 'hybridclaw onboarding' later"
   else
     info "Non-interactive shell: run 'hybridclaw onboarding' when ready."
+  fi
+}
+
+run_verify() {
+  [ "$VERIFY" -eq 1 ] || return 0
+  if is_dry; then
+    info "[dry-run] would run: hybridclaw --version && hybridclaw doctor --json"
+    return 0
+  fi
+
+  info "Verifying installation"
+  command -v hybridclaw >/dev/null 2>&1 \
+    || die "verification failed: 'hybridclaw' is not on PATH."
+  hybridclaw --version >/dev/null 2>&1 \
+    || die "verification failed: 'hybridclaw --version' did not run successfully."
+  ok "hybridclaw --version -> $(hybridclaw --version 2>/dev/null)"
+
+  # doctor reflects environment health (e.g. Docker availability), so a non-zero
+  # exit here is a warning about the host, not a broken install.
+  if hybridclaw doctor --json >/dev/null 2>&1; then
+    ok "hybridclaw doctor passed"
+  else
+    warn "hybridclaw doctor reported issues (often Docker/runtime env)."
+    warn "Run 'hybridclaw doctor' for the full report."
   fi
 }
 
@@ -300,6 +371,7 @@ EOF
 
 main() {
   printf '%sHybridClaw installer%s\n\n' "$C_BOLD" "$C_RESET"
+  is_dry && warn "Dry run: no changes will be made."
   command -v curl >/dev/null 2>&1 || die "curl is required but was not found."
   command -v tar  >/dev/null 2>&1 || die "tar is required but was not found."
 
@@ -311,6 +383,8 @@ main() {
   check_docker
   install_cli
   maybe_onboard
+  run_verify
+  is_dry && { info "Dry run complete; no changes were made."; return 0; }
   print_next_steps
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -146,10 +146,14 @@ detect_platform() {
   esac
 
   # nodejs.org publishes glibc builds only; detect musl (e.g. Alpine) so the
-  # managed-Node path can refuse to download an incompatible tarball.
+  # managed-Node path can refuse to download an incompatible tarball. Probe the
+  # musl loader directly first — `ldd --version` exits non-zero on musl, which
+  # `set -o pipefail` would otherwise turn into a false negative.
   PLATFORM_LIBC="glibc"
-  if [ "$PLATFORM_OS" = "linux" ] && ldd --version 2>&1 | grep -qi musl; then
-    PLATFORM_LIBC="musl"
+  if [ "$PLATFORM_OS" = "linux" ]; then
+    if ls /lib/ld-musl-* >/dev/null 2>&1 || { ldd --version 2>&1 || true; } | grep -qi musl; then
+      PLATFORM_LIBC="musl"
+    fi
   fi
 }
 
@@ -230,7 +234,8 @@ Install Node ${REQUIRED_NODE_MAJOR} with your package manager and re-run with --
 
   info "Installing Node.js v${version} into ${dir} (no system changes)"
   mkdir -p "$dir"
-  tarball="$(mktemp "${TMPDIR:-/tmp}/hybridclaw-node.XXXXXX.tar.xz")"
+  # No .tar.xz suffix: BusyBox mktemp requires the XXXXXX to be the final chars.
+  tarball="$(mktemp "${TMPDIR:-/tmp}/hybridclaw-node.XXXXXX")"
   trap 'rm -f "$tarball"' EXIT
   curl -fsSL --proto '=https' --tlsv1.2 --retry 3 --retry-delay 2 -o "$tarball" "$url" \
     || die "failed to download Node.js from $url"
@@ -329,6 +334,27 @@ check_docker() {
 
 # --- Install -----------------------------------------------------------------
 
+# The npm package builds native modules (better-sqlite3, node-pty) from source
+# whenever no prebuilt binary matches the platform, and node-gyp then needs a
+# toolchain. Warn early rather than failing deep inside an npm log.
+check_build_prereqs() {
+  local missing=""
+  have make || missing="make"
+  if ! have g++ && ! have clang++ && ! have c++; then
+    missing="${missing:+$missing, }a C/C++ compiler (g++)"
+  fi
+  if ! have python3 && ! have python; then
+    missing="${missing:+$missing, }python3"
+  fi
+  [ -z "$missing" ] && return 0
+  warn "Build tools may be missing: ${missing}."
+  warn "npm needs them to compile native modules when no prebuilt binary exists:"
+  warn "    Debian/Ubuntu: sudo apt-get install -y python3 make g++"
+  warn "    Fedora/RHEL:   sudo dnf install -y python3 make gcc-c++"
+  warn "    Alpine:        sudo apk add python3 make g++"
+  warn "    macOS:         xcode-select --install"
+}
+
 install_cli() {
   local spec="$PKG_NAME"
   [ "$INSTALL_VERSION" != "latest" ] && spec="${PKG_NAME}@${INSTALL_VERSION}"
@@ -338,10 +364,15 @@ install_cli() {
     return 0
   fi
   if ! npm install -g "$spec"; then
-    err "Global npm install failed."
-    err "If this was a permissions error, set a user-writable npm prefix:"
-    err "    npm config set prefix \"$HYBRIDCLAW_HOME/npm-global\""
-    err "    export PATH=\"$HYBRIDCLAW_HOME/npm-global/bin:\$PATH\""
+    err "Global npm install failed. Two common causes:"
+    err "  1) Missing build tools for native modules (node-gyp needs python3,"
+    err "     make, and a C/C++ compiler). Install them, e.g.:"
+    err "       Debian/Ubuntu: sudo apt-get install -y python3 make g++"
+    err "       Fedora/RHEL:   sudo dnf install -y python3 make gcc-c++"
+    err "       Alpine:        sudo apk add python3 make g++"
+    err "  2) A non-writable npm global prefix. Use a user-writable one:"
+    err "       npm config set prefix \"$HYBRIDCLAW_HOME/npm-global\""
+    err "       export PATH=\"$HYBRIDCLAW_HOME/npm-global/bin:\$PATH\""
     err "Then re-run this installer. (HybridClaw never needs sudo.)"
     exit 1
   fi
@@ -366,7 +397,7 @@ maybe_onboard() {
   have hybridclaw \
     || die "hybridclaw was installed but is not on PATH yet. Open a new shell and run: hybridclaw onboarding"
 
-  ok "Installed $(hybridclaw --version 2>/dev/null || echo "$PKG_NAME")"
+  ok "Installed $(hybridclaw --version 2>/dev/null | tail -1 || echo "$PKG_NAME")"
 
   if [ "$RUN_ONBOARDING" -ne 1 ] || [ "$NO_PROMPT" -eq 1 ]; then
     info "Skipping interactive onboarding: run 'hybridclaw onboarding' when ready."
@@ -398,7 +429,7 @@ run_verify() {
   info "Verifying installation"
   have hybridclaw || die "verification failed: 'hybridclaw' is not on PATH."
   local version_output
-  version_output="$(hybridclaw --version 2>/dev/null)" \
+  version_output="$(hybridclaw --version 2>/dev/null | tail -1)" \
     || die "verification failed: 'hybridclaw --version' did not run successfully."
   ok "hybridclaw --version -> $version_output"
 
@@ -444,6 +475,7 @@ main() {
   ensure_node
   ensure_npm
   check_docker
+  check_build_prereqs
   install_cli
   maybe_onboard
   run_verify

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,6 +12,9 @@
 #   1. Detects your OS/arch (Linux + macOS; Windows users are pointed at WSL2).
 #   2. Ensures Node.js 22 and npm >= 11.10.0 are available, installing a
 #      user-local Node 22 into ~/.hybridclaw/node when no compatible one exists.
+#      Downloaded Node tarballs are verified against nodejs.org's published
+#      SHA-256 checksum. Alpine/musl needs a system Node (apk add nodejs npm)
+#      plus --skip-node, since nodejs.org ships glibc builds only.
 #   3. Installs the `hybridclaw` CLI globally from npm.
 #   4. Checks for Docker (recommended for the default container sandbox).
 #   5. Runs `hybridclaw onboarding` when attached to a terminal.
@@ -21,6 +24,18 @@
 #
 # The HybridClaw runtime itself never needs root. The installer only touches
 # your home directory and the npm global prefix; it never calls sudo.
+
+# Require bash before any bash-only syntax below is parsed.
+if [ -z "${BASH_VERSION:-}" ]; then
+  echo "This installer needs bash. Re-run with:" >&2
+  echo "  curl -fsSL https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/scripts/install.sh | bash" >&2
+  exit 1
+fi
+
+# Download guard: bash parses to the matching closing brace at the end of the
+# file before executing anything, so a `curl | bash` that is truncated
+# mid-transfer fails to parse and runs nothing instead of executing a fragment.
+{
 
 set -euo pipefail
 
@@ -41,8 +56,8 @@ CHECK_DOCKER=1
 MANAGE_NODE=1
 DRY_RUN="${HYBRIDCLAW_DRY_RUN:-0}"
 VERIFY="${HYBRIDCLAW_VERIFY_INSTALL:-0}"
-# Honor both HYBRIDCLAW_NO_PROMPT and the conventional NO_PROMPT.
-if [ -n "${HYBRIDCLAW_NO_PROMPT:-}" ] || [ -n "${NO_PROMPT:-}" ]; then
+# Headless when HYBRIDCLAW_NO_PROMPT, the conventional NO_PROMPT, or CI is set.
+if [ -n "${HYBRIDCLAW_NO_PROMPT:-}" ] || [ -n "${NO_PROMPT:-}" ] || [ -n "${CI:-}" ]; then
   NO_PROMPT=1
 else
   NO_PROMPT=0
@@ -84,7 +99,7 @@ Environment:
   HYBRIDCLAW_HOME             Install root for managed Node (default: ~/.hybridclaw)
   HYBRIDCLAW_INSTALL_VERSION  Version to install (default: latest)
   HYBRIDCLAW_NODE_VERSION     Node version to fetch if one must be installed
-  HYBRIDCLAW_NO_PROMPT=1      Same as --no-prompt (also honors NO_PROMPT)
+  HYBRIDCLAW_NO_PROMPT=1      Same as --no-prompt (also honors NO_PROMPT / CI)
   HYBRIDCLAW_DRY_RUN=1        Same as --dry-run
   HYBRIDCLAW_VERIFY_INSTALL=1 Same as --verify
   NO_COLOR                    Disable colored output
@@ -129,6 +144,13 @@ detect_platform() {
     armv7l) PLATFORM_ARCH="armv7l" ;;
     *) die "unsupported architecture: $arch" ;;
   esac
+
+  # nodejs.org publishes glibc builds only; detect musl (e.g. Alpine) so the
+  # managed-Node path can refuse to download an incompatible tarball.
+  PLATFORM_LIBC="glibc"
+  if [ "$PLATFORM_OS" = "linux" ] && ldd --version 2>&1 | grep -qi musl; then
+    PLATFORM_LIBC="musl"
+  fi
 }
 
 # --- Node.js + npm -----------------------------------------------------------
@@ -143,7 +165,7 @@ version_ge() {
 
 resolve_node_version() {
   local v
-  v="$(curl -fsSL --max-time 15 https://nodejs.org/dist/index.json 2>/dev/null \
+  v="$(curl -fsSL --proto '=https' --tlsv1.2 --max-time 15 https://nodejs.org/dist/index.json 2>/dev/null \
         | grep -o '"version":"v22[^"]*"' | head -1 | sed 's/.*"v\(22[^"]*\)".*/\1/')" || true
   if [ -n "$v" ]; then
     printf '%s' "$v"
@@ -152,14 +174,56 @@ resolve_node_version() {
   fi
 }
 
+sha256_of() {
+  if have sha256sum; then
+    sha256sum "$1" | awk '{print $1}'
+  elif have shasum; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    return 1
+  fi
+}
+
+# Verify a downloaded Node tarball against nodejs.org's per-release SHASUMS256.
+verify_node_checksum() {
+  local file="$1" version="$2" filename="$3" expected actual
+  expected="$(curl -fsSL --proto '=https' --tlsv1.2 --max-time 30 \
+      "https://nodejs.org/dist/v${version}/SHASUMS256.txt" 2>/dev/null \
+      | awk -v f="$filename" '$2 == f {print $1}')"
+  if [ -z "$expected" ]; then
+    warn "Could not fetch published checksum for ${filename}; skipping verification."
+    return 0
+  fi
+  actual="$(sha256_of "$file")" || {
+    warn "No sha256 tool (sha256sum/shasum) found; skipping checksum verification."
+    return 0
+  }
+  if [ "$actual" != "$expected" ]; then
+    die "Checksum mismatch for ${filename}
+  expected ${expected}
+  got      ${actual}
+Refusing to install a corrupt or tampered Node.js download."
+  fi
+  ok "Verified Node.js download (sha256)"
+}
+
 install_managed_node() {
-  local version url tarball dir
+  local version dir filename url tarball
+  if [ "${PLATFORM_LIBC:-glibc}" = "musl" ]; then
+    die "Detected musl libc (e.g. Alpine). nodejs.org publishes glibc builds only.
+Install Node ${REQUIRED_NODE_MAJOR} with your package manager and re-run with --skip-node:
+    apk add --no-cache nodejs npm
+    curl -fsSL https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/scripts/install.sh | bash -s -- --skip-node"
+  fi
+
   version="$(resolve_node_version)"
   dir="$HYBRIDCLAW_HOME/node"
-  url="https://nodejs.org/dist/v${version}/node-v${version}-${PLATFORM_OS}-${PLATFORM_ARCH}.tar.xz"
+  filename="node-v${version}-${PLATFORM_OS}-${PLATFORM_ARCH}.tar.xz"
+  url="https://nodejs.org/dist/v${version}/${filename}"
 
   if is_dry; then
     info "[dry-run] would download ${url}"
+    info "[dry-run] would verify its sha256 against nodejs.org/dist/v${version}/SHASUMS256.txt"
     info "[dry-run] would extract Node.js v${version} into ${dir} and add ${dir}/bin to PATH"
     return 0
   fi
@@ -168,8 +232,9 @@ install_managed_node() {
   mkdir -p "$dir"
   tarball="$(mktemp "${TMPDIR:-/tmp}/hybridclaw-node.XXXXXX.tar.xz")"
   trap 'rm -f "$tarball"' EXIT
-  curl -fsSL --retry 3 --retry-delay 2 -o "$tarball" "$url" \
+  curl -fsSL --proto '=https' --tlsv1.2 --retry 3 --retry-delay 2 -o "$tarball" "$url" \
     || die "failed to download Node.js from $url"
+  verify_node_checksum "$tarball" "$version" "$filename"
   tar -xJf "$tarball" -C "$dir" --strip-components=1
   rm -f "$tarball"
   trap - EXIT
@@ -374,7 +439,7 @@ main() {
   have tar  || die "tar is required but was not found."
 
   detect_platform
-  ok "Platform: ${PLATFORM_OS}/${PLATFORM_ARCH}"
+  ok "Platform: ${PLATFORM_OS}/${PLATFORM_ARCH} (${PLATFORM_LIBC})"
 
   ensure_node
   ensure_npm
@@ -387,3 +452,5 @@ main() {
 }
 
 main "$@"
+
+} # end download guard — keep this brace as the final line of the file

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -218,7 +218,7 @@ verify_node_checksum() {
     die "Checksum mismatch for ${filename}
   expected ${expected}
   got      ${actual}
-Refusing to install a corrupt or tampered Node.js download."
+Refusing to install a corrupt or truncated Node.js download."
   fi
   ok "Verified Node.js download (sha256)"
 }
@@ -265,7 +265,9 @@ Install Node ${REQUIRED_NODE_MAJOR} with your package manager and re-run with --
 ensure_node() {
   local node_version major
   if have node; then
-    node_version="$(node --version 2>/dev/null)"
+    # `|| node_version=""`: a broken node that fails `--version` must not abort
+    # the installer under `set -e` — fall through to the managed-Node install.
+    node_version="$(node --version 2>/dev/null)" || node_version=""
     major="${node_version#v}"; major="${major%%.*}"
     if [ "$major" = "$REQUIRED_NODE_MAJOR" ]; then
       ok "Node.js $node_version detected"
@@ -324,7 +326,8 @@ ensure_npm() {
   # Make the prefix writable before any global install (the npm upgrade below
   # and the later CLI install both write there).
   ensure_writable_npm_prefix
-  npm_version="$(npm --version)"
+  npm_version="$(npm --version 2>/dev/null)" \
+    || die "'npm --version' failed; your npm install looks broken — reinstall Node ${REQUIRED_NODE_MAJOR}."
   if version_ge "$npm_version" "$REQUIRED_NPM"; then
     ok "npm ${npm_version} detected"
     return
@@ -416,6 +419,10 @@ build_tool_hint() {
 # whenever no prebuilt binary matches the platform, and node-gyp then needs a
 # toolchain. Warn early rather than failing deep inside an npm log.
 check_build_prereqs() {
+  if is_dry; then
+    info "[dry-run] would check for native-module build tools (make, C/C++ compiler, python3)"
+    return 0
+  fi
   local missing=""
   have make || missing="make"
   if ! have g++ && ! have clang++ && ! have c++; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+#
+# HybridClaw one-line installer.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/scripts/install.sh | bash
+#
+# Or with options (note the extra `-s --` to pass flags through the pipe):
+#   curl -fsSL https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/scripts/install.sh | bash -s -- --version 0.21.0 --no-onboarding
+#
+# What it does:
+#   1. Detects your OS/arch (Linux + macOS; Windows users are pointed at WSL2).
+#   2. Ensures Node.js 22 and npm >= 11.10.0 are available, installing a
+#      user-local Node 22 into ~/.hybridclaw/node when no compatible one exists.
+#   3. Installs the `hybridclaw` CLI globally from npm.
+#   4. Checks for Docker (recommended for the default container sandbox).
+#   5. Runs `hybridclaw onboarding` when attached to a terminal.
+#
+# The HybridClaw runtime itself never needs root. The installer only touches
+# your home directory and the npm global prefix; it never calls sudo.
+
+set -euo pipefail
+
+# --- Configuration (override via environment) --------------------------------
+
+HYBRIDCLAW_HOME="${HYBRIDCLAW_HOME:-$HOME/.hybridclaw}"
+PKG_NAME="@hybridaione/hybridclaw"
+INSTALL_VERSION="${HYBRIDCLAW_INSTALL_VERSION:-latest}"
+REQUIRED_NODE_MAJOR=22
+REQUIRED_NPM="11.10.0"
+# Fallback used only when nodejs.org is unreachable for version discovery.
+NODE_VERSION_FALLBACK="${HYBRIDCLAW_NODE_VERSION:-22.20.0}"
+
+# --- Flags -------------------------------------------------------------------
+
+RUN_ONBOARDING=1
+CHECK_DOCKER=1
+MANAGE_NODE=1
+
+# --- Output helpers ----------------------------------------------------------
+
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  C_RESET=$'\033[0m'; C_INFO=$'\033[36m'; C_OK=$'\033[32m'
+  C_WARN=$'\033[33m'; C_ERR=$'\033[31m'; C_BOLD=$'\033[1m'
+else
+  C_RESET=""; C_INFO=""; C_OK=""; C_WARN=""; C_ERR=""; C_BOLD=""
+fi
+
+info()  { printf '%s==>%s %s\n' "$C_INFO" "$C_RESET" "$*"; }
+ok()    { printf '%s ✓%s %s\n' "$C_OK" "$C_RESET" "$*"; }
+warn()  { printf '%s warn:%s %s\n' "$C_WARN" "$C_RESET" "$*" >&2; }
+err()   { printf '%serror:%s %s\n' "$C_ERR" "$C_RESET" "$*" >&2; }
+die()   { err "$@"; exit 1; }
+
+usage() {
+  cat <<'EOF'
+HybridClaw installer
+
+Options:
+  --version <ver>       Install a specific version (default: latest)
+  --no-onboarding       Skip the interactive `hybridclaw onboarding` step
+  --skip-docker-check   Do not warn when Docker is missing
+  --skip-node           Use the Node.js already on PATH; never download Node
+  -h, --help            Show this help
+
+Environment:
+  HYBRIDCLAW_HOME           Install root for managed Node (default: ~/.hybridclaw)
+  HYBRIDCLAW_INSTALL_VERSION  Version to install (default: latest)
+  HYBRIDCLAW_NODE_VERSION   Node version to fetch if one must be installed
+  NO_COLOR                  Disable colored output
+EOF
+}
+
+# --- Argument parsing --------------------------------------------------------
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version)        INSTALL_VERSION="${2:?--version requires a value}"; shift 2 ;;
+    --version=*)      INSTALL_VERSION="${1#*=}"; shift ;;
+    --no-onboarding)  RUN_ONBOARDING=0; shift ;;
+    --skip-docker-check) CHECK_DOCKER=0; shift ;;
+    --skip-node)      MANAGE_NODE=0; shift ;;
+    -h|--help)        usage; exit 0 ;;
+    *)                die "unknown option: $1 (try --help)" ;;
+  esac
+done
+
+# --- Platform detection ------------------------------------------------------
+
+detect_platform() {
+  local os arch
+  os="$(uname -s)"
+  arch="$(uname -m)"
+
+  case "$os" in
+    Linux)  PLATFORM_OS="linux" ;;
+    Darwin) PLATFORM_OS="darwin" ;;
+    MINGW*|MSYS*|CYGWIN*)
+      die "Windows is not supported directly. Install inside WSL2 (Ubuntu) and re-run this script there." ;;
+    *) die "unsupported operating system: $os" ;;
+  esac
+
+  case "$arch" in
+    x86_64|amd64) PLATFORM_ARCH="x64" ;;
+    arm64|aarch64) PLATFORM_ARCH="arm64" ;;
+    armv7l) PLATFORM_ARCH="armv7l" ;;
+    *) die "unsupported architecture: $arch" ;;
+  esac
+}
+
+# --- Node.js + npm -----------------------------------------------------------
+
+version_ge() {
+  # version_ge A B  -> true when A >= B (dotted numeric compare)
+  [ "$1" = "$2" ] && return 0
+  local lower
+  lower="$(printf '%s\n%s\n' "$1" "$2" | sort -t. -k1,1n -k2,2n -k3,3n | head -1)"
+  [ "$lower" = "$2" ]
+}
+
+node_major() { "$1" --version 2>/dev/null | sed 's/^v//; s/\..*//'; }
+
+resolve_node_version() {
+  local v
+  v="$(curl -fsSL --max-time 15 https://nodejs.org/dist/index.json 2>/dev/null \
+        | grep -o '"version":"v22[^"]*"' | head -1 | sed 's/.*"v\(22[^"]*\)".*/\1/')" || true
+  if [ -n "$v" ]; then
+    printf '%s' "$v"
+  else
+    printf '%s' "$NODE_VERSION_FALLBACK"
+  fi
+}
+
+install_managed_node() {
+  local version url tarball dir
+  version="$(resolve_node_version)"
+  dir="$HYBRIDCLAW_HOME/node"
+  url="https://nodejs.org/dist/v${version}/node-v${version}-${PLATFORM_OS}-${PLATFORM_ARCH}.tar.xz"
+
+  info "Installing Node.js v${version} into ${dir} (no system changes)"
+  mkdir -p "$dir"
+  tarball="$(mktemp "${TMPDIR:-/tmp}/hybridclaw-node.XXXXXX.tar.xz")"
+  trap 'rm -f "$tarball"' EXIT
+  curl -fsSL --retry 3 --retry-delay 2 -o "$tarball" "$url" \
+    || die "failed to download Node.js from $url"
+  tar -xJf "$tarball" -C "$dir" --strip-components=1
+  rm -f "$tarball"
+  trap - EXIT
+
+  NODE_BIN_DIR="$dir/bin"
+  export PATH="$NODE_BIN_DIR:$PATH"
+  persist_path "$NODE_BIN_DIR"
+  ok "Node.js $("$NODE_BIN_DIR/node" --version) ready"
+}
+
+ensure_node() {
+  local node_path major
+  node_path="$(command -v node || true)"
+
+  if [ -n "$node_path" ]; then
+    major="$(node_major "$node_path")"
+    if [ "$major" = "$REQUIRED_NODE_MAJOR" ]; then
+      ok "Node.js $(node --version) detected"
+      return
+    fi
+    if [ "$MANAGE_NODE" -eq 0 ]; then
+      die "Node.js ${REQUIRED_NODE_MAJOR}.x is required, found $(node --version). Switch versions (nvm/fnm) and retry."
+    fi
+    warn "Node.js $(node --version) found, but HybridClaw needs ${REQUIRED_NODE_MAJOR}.x"
+  elif [ "$MANAGE_NODE" -eq 0 ]; then
+    die "Node.js not found on PATH and --skip-node was set."
+  fi
+
+  if command -v fnm >/dev/null 2>&1 || command -v nvm >/dev/null 2>&1; then
+    warn "A Node version manager (fnm/nvm) is installed. You may prefer:"
+    warn "    fnm install 22 && fnm use 22    # or: nvm install 22 && nvm use 22"
+    warn "Continuing with a HybridClaw-managed Node 22 in ${HYBRIDCLAW_HOME}/node."
+  fi
+  install_managed_node
+}
+
+ensure_npm() {
+  local npm_version
+  command -v npm >/dev/null 2>&1 || die "npm not found alongside Node.js; reinstall Node 22."
+  npm_version="$(npm --version)"
+  if version_ge "$npm_version" "$REQUIRED_NPM"; then
+    ok "npm ${npm_version} detected"
+    return
+  fi
+  info "Upgrading npm ${npm_version} -> >=${REQUIRED_NPM}"
+  npm install -g "npm@^11" >/dev/null 2>&1 \
+    || warn "could not upgrade npm automatically; continuing with ${npm_version}"
+}
+
+# --- PATH persistence --------------------------------------------------------
+
+persist_path() {
+  # Append an idempotent PATH export to the user's shell rc files.
+  local dir="$1" marker="# added by HybridClaw installer"
+  local line="export PATH=\"$dir:\$PATH\" $marker"
+  local rc
+  for rc in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.profile"; do
+    [ -e "$rc" ] || continue
+    grep -qsF "$dir $marker" "$rc" 2>/dev/null && continue
+    printf '\n%s\n' "$line" >> "$rc"
+  done
+}
+
+npm_global_bin() {
+  local prefix
+  prefix="$(npm prefix -g 2>/dev/null)" || return 1
+  if [ "$PLATFORM_OS" = "darwin" ] || [ "$PLATFORM_OS" = "linux" ]; then
+    printf '%s/bin' "$prefix"
+  fi
+}
+
+# --- Docker ------------------------------------------------------------------
+
+check_docker() {
+  [ "$CHECK_DOCKER" -eq 1 ] || return 0
+  if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+    ok "Docker is available (default container sandbox supported)"
+  elif command -v docker >/dev/null 2>&1; then
+    warn "Docker is installed but its daemon is not reachable."
+    warn "Start Docker, or run the gateway with --sandbox=host."
+  else
+    warn "Docker not found. The default container sandbox will be unavailable."
+    warn "Install Docker (https://docs.docker.com/get-docker/) or run with --sandbox=host."
+  fi
+}
+
+# --- Install -----------------------------------------------------------------
+
+install_cli() {
+  local spec="$PKG_NAME"
+  [ "$INSTALL_VERSION" != "latest" ] && spec="${PKG_NAME}@${INSTALL_VERSION}"
+  info "Installing ${spec} globally via npm"
+  if ! npm install -g "$spec"; then
+    err "Global npm install failed."
+    err "If this was a permissions error, set a user-writable npm prefix:"
+    err "    npm config set prefix \"$HYBRIDCLAW_HOME/npm-global\""
+    err "    export PATH=\"$HYBRIDCLAW_HOME/npm-global/bin:\$PATH\""
+    err "Then re-run this installer. (HybridClaw never needs sudo.)"
+    exit 1
+  fi
+
+  local bin_dir
+  bin_dir="$(npm_global_bin || true)"
+  if [ -n "$bin_dir" ] && ! command -v hybridclaw >/dev/null 2>&1; then
+    export PATH="$bin_dir:$PATH"
+    persist_path "$bin_dir"
+    warn "Added npm global bin (${bin_dir}) to your PATH. Open a new shell if needed."
+  fi
+}
+
+# --- Onboarding + next steps -------------------------------------------------
+
+maybe_onboard() {
+  command -v hybridclaw >/dev/null 2>&1 \
+    || die "hybridclaw was installed but is not on PATH yet. Open a new shell and run: hybridclaw onboarding"
+
+  ok "Installed $(hybridclaw --version 2>/dev/null || echo "$PKG_NAME")"
+
+  if [ "$RUN_ONBOARDING" -ne 1 ]; then
+    return
+  fi
+
+  # When piped through `curl | bash`, stdin is the script, so read the wizard
+  # from the controlling terminal if one is available.
+  if [ -t 0 ]; then
+    info "Starting onboarding (Ctrl-C to skip and run it later)"
+    hybridclaw onboarding || warn "onboarding did not complete; run 'hybridclaw onboarding' later"
+  elif [ -r /dev/tty ]; then
+    info "Starting onboarding (Ctrl-C to skip and run it later)"
+    hybridclaw onboarding </dev/tty || warn "onboarding did not complete; run 'hybridclaw onboarding' later"
+  else
+    info "Non-interactive shell: run 'hybridclaw onboarding' when ready."
+  fi
+}
+
+print_next_steps() {
+  cat <<EOF
+
+${C_BOLD}HybridClaw is installed.${C_RESET}
+
+Next steps:
+  ${C_INFO}hybridclaw onboarding${C_RESET}   Connect a provider and save runtime secrets
+  ${C_INFO}hybridclaw gateway${C_RESET}      Start the local gateway
+  ${C_INFO}hybridclaw tui${C_RESET}          Open the terminal UI (in a second shell)
+
+Local surfaces once the gateway runs:
+  Chat   http://127.0.0.1:9090/chat
+  Admin  http://127.0.0.1:9090/admin
+
+Docs: https://hybridaione.github.io/hybridclaw/docs/getting-started/quickstart
+EOF
+}
+
+# --- Main --------------------------------------------------------------------
+
+main() {
+  printf '%sHybridClaw installer%s\n\n' "$C_BOLD" "$C_RESET"
+  command -v curl >/dev/null 2>&1 || die "curl is required but was not found."
+  command -v tar  >/dev/null 2>&1 || die "tar is required but was not found."
+
+  detect_platform
+  ok "Platform: ${PLATFORM_OS}/${PLATFORM_ARCH}"
+
+  ensure_node
+  ensure_npm
+  check_docker
+  install_cli
+  maybe_onboard
+  print_next_steps
+}
+
+main "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -285,13 +285,44 @@ ensure_node() {
   install_managed_node
 }
 
+# Writable if the directory exists and is writable, or its nearest existing
+# ancestor is (so npm can create it). Used to decide whether a global install
+# would hit EACCES before we attempt one.
+dir_writable() {
+  local d="$1"
+  while [ -n "$d" ] && [ "$d" != "/" ] && [ ! -e "$d" ]; do d="$(dirname "$d")"; done
+  [ -w "$d" ]
+}
+
+# A global `npm install -g` writes into <prefix>/lib/node_modules and
+# <prefix>/bin. A system Node using a root-owned prefix (e.g. /usr/local) is not
+# user-writable, so the advertised one-liner would fail with EACCES. Detect that
+# up front and point npm at a user-local prefix — no sudo, no manual rerun.
+ensure_writable_npm_prefix() {
+  local prefix
+  prefix="$(npm prefix -g 2>/dev/null)" || return 0
+  if dir_writable "$prefix/lib/node_modules" && dir_writable "$prefix/bin"; then
+    return 0
+  fi
+  local user_prefix="$HYBRIDCLAW_HOME/npm-global"
+  warn "npm global prefix ${prefix} is not writable; using ${user_prefix} instead (no sudo)."
+  mkdir -p "$user_prefix/bin"
+  npm config set prefix "$user_prefix" >/dev/null 2>&1 \
+    || die "could not point npm at a user-writable prefix (${user_prefix})."
+  export PATH="$user_prefix/bin:$PATH"
+  persist_path "$user_prefix/bin"
+}
+
 ensure_npm() {
   local npm_version
   if is_dry; then
-    info "[dry-run] would ensure npm >= ${REQUIRED_NPM} (upgrading via 'npm install -g npm@^11' if needed)"
+    info "[dry-run] would ensure a user-writable npm prefix, then npm >= ${REQUIRED_NPM} (upgrading via 'npm install -g npm@^11' if needed)"
     return 0
   fi
   have npm || die "npm not found alongside Node.js; reinstall Node 22."
+  # Make the prefix writable before any global install (the npm upgrade below
+  # and the later CLI install both write there).
+  ensure_writable_npm_prefix
   npm_version="$(npm --version)"
   if version_ge "$npm_version" "$REQUIRED_NPM"; then
     ok "npm ${npm_version} detected"
@@ -299,7 +330,11 @@ ensure_npm() {
   fi
   info "Upgrading npm ${npm_version} -> >=${REQUIRED_NPM}"
   npm install -g "npm@^11" >/dev/null 2>&1 \
-    || warn "could not upgrade npm automatically; continuing with ${npm_version}"
+    || die "could not upgrade npm to >= ${REQUIRED_NPM} (have ${npm_version}). Upgrade it manually ('npm install -g npm@^11') and re-run."
+  npm_version="$(npm --version)"
+  version_ge "$npm_version" "$REQUIRED_NPM" \
+    || die "npm is still ${npm_version} after the upgrade; HybridClaw requires >= ${REQUIRED_NPM}."
+  ok "npm ${npm_version} ready"
 }
 
 # --- PATH persistence --------------------------------------------------------
@@ -313,13 +348,26 @@ persist_path() {
   # Append an idempotent PATH export to the user's shell rc files.
   local marker="# added by HybridClaw installer"
   local line="export PATH=\"$dir:\$PATH\" $marker"
-  local rc
+  local rc wrote=0
   for rc in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.profile"; do
     [ -e "$rc" ] || continue
     # Match the exact line we write so re-runs don't append duplicates.
-    grep -qsF "$line" "$rc" 2>/dev/null && continue
-    printf '\n%s\n' "$line" >> "$rc"
+    if grep -qsF "$line" "$rc" 2>/dev/null; then wrote=1; continue; fi
+    printf '\n%s\n' "$line" >> "$rc" && wrote=1
   done
+
+  # Fresh system (common on macOS, where ~/.zshrc may not exist yet): none of
+  # the candidate rc files were present, so nothing above persisted the PATH.
+  # Create one matching the login shell, plus ~/.profile as a portable fallback.
+  if [ "$wrote" -eq 0 ]; then
+    case "${SHELL:-}" in
+      *zsh)  rc="$HOME/.zshrc" ;;
+      *bash) rc="$HOME/.bashrc" ;;
+      *)     rc="$HOME/.profile" ;;
+    esac
+    printf '\n%s\n' "$line" >> "$rc"
+    [ "$rc" = "$HOME/.profile" ] || printf '\n%s\n' "$line" >> "$HOME/.profile"
+  fi
 }
 
 npm_global_bin() {
@@ -353,10 +401,11 @@ check_docker() {
 # the given printer ($1 = warn or err) so the pre-flight warning and the
 # install-failure error stay in sync.
 build_tool_hint() {
-  "$1" "    Debian/Ubuntu: sudo apt-get install -y python3 make g++"
-  "$1" "    Fedora/RHEL:   sudo dnf install -y python3 make gcc-c++"
-  "$1" "    Alpine:        sudo apk add python3 make g++"
+  "$1" "    Debian/Ubuntu: apt-get install -y python3 make g++"
+  "$1" "    Fedora/RHEL:   dnf install -y python3 make gcc-c++"
+  "$1" "    Alpine:        apk add python3 make g++"
   "$1" "    macOS:         xcode-select --install"
+  "$1" "  (run the package-manager command as root, or via sudo, if needed)"
 }
 
 # The npm package builds native modules (better-sqlite3, node-pty) from source

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,6 +42,8 @@ set -euo pipefail
 # --- Configuration (override via environment) --------------------------------
 
 HYBRIDCLAW_HOME="${HYBRIDCLAW_HOME:-$HOME/.hybridclaw}"
+# User-writable npm prefix we fall back to when the global one needs root.
+NPM_USER_PREFIX="$HYBRIDCLAW_HOME/npm-global"
 PKG_NAME="@hybridaione/hybridclaw"
 INSTALL_VERSION="${HYBRIDCLAW_INSTALL_VERSION:-latest}"
 REQUIRED_NODE_MAJOR=22
@@ -304,13 +306,12 @@ ensure_writable_npm_prefix() {
   if dir_writable "$prefix/lib/node_modules" && dir_writable "$prefix/bin"; then
     return 0
   fi
-  local user_prefix="$HYBRIDCLAW_HOME/npm-global"
-  warn "npm global prefix ${prefix} is not writable; using ${user_prefix} instead (no sudo)."
-  mkdir -p "$user_prefix/bin"
-  npm config set prefix "$user_prefix" >/dev/null 2>&1 \
-    || die "could not point npm at a user-writable prefix (${user_prefix})."
-  export PATH="$user_prefix/bin:$PATH"
-  persist_path "$user_prefix/bin"
+  warn "npm global prefix ${prefix} is not writable; using ${NPM_USER_PREFIX} instead (no sudo)."
+  mkdir -p "$NPM_USER_PREFIX/bin"
+  npm config set prefix "$NPM_USER_PREFIX" >/dev/null 2>&1 \
+    || die "could not point npm at a user-writable prefix (${NPM_USER_PREFIX})."
+  export PATH="$NPM_USER_PREFIX/bin:$PATH"
+  persist_path "$NPM_USER_PREFIX/bin"
 }
 
 ensure_npm() {
@@ -348,26 +349,29 @@ persist_path() {
   # Append an idempotent PATH export to the user's shell rc files.
   local marker="# added by HybridClaw installer"
   local line="export PATH=\"$dir:\$PATH\" $marker"
-  local rc wrote=0
-  for rc in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.profile"; do
-    [ -e "$rc" ] || continue
-    # Match the exact line we write so re-runs don't append duplicates.
-    if grep -qsF "$line" "$rc" 2>/dev/null; then wrote=1; continue; fi
-    printf '\n%s\n' "$line" >> "$rc" && wrote=1
-  done
 
-  # Fresh system (common on macOS, where ~/.zshrc may not exist yet): none of
-  # the candidate rc files were present, so nothing above persisted the PATH.
-  # Create one matching the login shell, plus ~/.profile as a portable fallback.
-  if [ "$wrote" -eq 0 ]; then
-    case "${SHELL:-}" in
-      *zsh)  rc="$HOME/.zshrc" ;;
-      *bash) rc="$HOME/.bashrc" ;;
-      *)     rc="$HOME/.profile" ;;
-    esac
-    printf '\n%s\n' "$line" >> "$rc"
-    [ "$rc" = "$HOME/.profile" ] || printf '\n%s\n' "$line" >> "$HOME/.profile"
-  fi
+  # The rc file the login shell actually sources. We always (re)ensure this one,
+  # creating it if absent — otherwise a zsh user whose only existing rc is
+  # ~/.bashrc (which zsh never reads), or a fresh macOS box with no ~/.zshrc,
+  # would get no usable PATH persistence.
+  local login_rc
+  case "${SHELL:-}" in
+    *zsh)  login_rc="${ZDOTDIR:-$HOME}/.zshrc" ;;
+    *bash) login_rc="$HOME/.bashrc" ;;
+    *)     login_rc="$HOME/.profile" ;;
+  esac
+
+  local rc
+  for rc in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.profile" "$login_rc"; do
+    # Touch existing rc files; the login shell's rc is created even if absent.
+    [ -e "$rc" ] || [ "$rc" = "$login_rc" ] || continue
+    # Match the exact line so re-runs (and revisiting login_rc) don't duplicate.
+    grep -qsF "$line" "$rc" 2>/dev/null && continue
+    # A read-only rc (or a missing $ZDOTDIR) must not abort the install under
+    # `set -e`; PATH was already exported for this process, so warn and move on.
+    printf '\n%s\n' "$line" >> "$rc" \
+      || warn "could not update ${rc}; add '${dir}' to your PATH manually."
+  done
 }
 
 npm_global_bin() {
@@ -439,9 +443,9 @@ install_cli() {
     err "  1) Missing build tools for native modules (node-gyp needs python3,"
     err "     make, and a C/C++ compiler). Install them, e.g.:"
     build_tool_hint err
-    err "  2) A non-writable npm global prefix. Use a user-writable one:"
-    err "       npm config set prefix \"$HYBRIDCLAW_HOME/npm-global\""
-    err "       export PATH=\"$HYBRIDCLAW_HOME/npm-global/bin:\$PATH\""
+    err "  2) A non-writable npm global prefix that the automatic fallback to"
+    err "     ${NPM_USER_PREFIX} did not catch. Check 'npm config get prefix'"
+    err "     and ensure that directory is writable (no sudo needed)."
     err "Then re-run this installer. (HybridClaw never needs sudo.)"
     exit 1
   fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -78,7 +78,10 @@ warn()  { printf '%s warn:%s %s\n' "$C_WARN" "$C_RESET" "$*" >&2; }
 err()   { printf '%serror:%s %s\n' "$C_ERR" "$C_RESET" "$*" >&2; }
 die()   { err "$@"; exit 1; }
 
-is_dry() { [ "$DRY_RUN" -eq 1 ]; }
+# Truthy for env-derived flags: 1/true/yes/on (any case). Avoids the arithmetic
+# `-eq` test, which errors (and is then treated as false) on values like "true".
+is_truthy() { case "${1:-}" in [Tt][Rr][Uu][Ee]|[Yy][Ee][Ss]|[Oo][Nn]|1) return 0 ;; *) return 1 ;; esac; }
+is_dry() { is_truthy "$DRY_RUN"; }
 have()   { command -v "$1" >/dev/null 2>&1; }
 
 usage() {
@@ -159,6 +162,10 @@ detect_platform() {
 
 # --- Node.js + npm -----------------------------------------------------------
 
+# Hardened HTTPS fetch: the TLS/transfer flags every nodejs.org request shares,
+# in one place. Callers append --max-time/--retry/-o and the URL.
+fetch() { curl -fsSL --proto '=https' --tlsv1.2 "$@"; }
+
 version_ge() {
   # version_ge A B  -> true when A >= B (dotted numeric compare)
   [ "$1" = "$2" ] && return 0
@@ -168,9 +175,10 @@ version_ge() {
 }
 
 resolve_node_version() {
-  local v
-  v="$(curl -fsSL --proto '=https' --tlsv1.2 --max-time 15 https://nodejs.org/dist/index.json 2>/dev/null \
-        | grep -o '"version":"v22[^"]*"' | head -1 | sed 's/.*"v\(22[^"]*\)".*/\1/')" || true
+  local v major="$REQUIRED_NODE_MAJOR"
+  v="$(fetch --max-time 15 https://nodejs.org/dist/index.json 2>/dev/null \
+        | grep -o "\"version\":\"v${major}[^\"]*\"" | head -1 \
+        | sed "s/.*\"v\(${major}[^\"]*\)\".*/\1/")" || true
   if [ -n "$v" ]; then
     printf '%s' "$v"
   else
@@ -191,9 +199,11 @@ sha256_of() {
 # Verify a downloaded Node tarball against nodejs.org's per-release SHASUMS256.
 verify_node_checksum() {
   local file="$1" version="$2" filename="$3" expected actual
-  expected="$(curl -fsSL --proto '=https' --tlsv1.2 --max-time 30 \
+  # `|| true`: under `set -o pipefail` a failed fetch (offline/404/proxy) would
+  # otherwise abort the whole installer here instead of the graceful skip below.
+  expected="$(fetch --max-time 30 \
       "https://nodejs.org/dist/v${version}/SHASUMS256.txt" 2>/dev/null \
-      | awk -v f="$filename" '$2 == f {print $1}')"
+      | awk -v f="$filename" '$2 == f {print $1}')" || true
   if [ -z "$expected" ]; then
     warn "Could not fetch published checksum for ${filename}; skipping verification."
     return 0
@@ -237,7 +247,7 @@ Install Node ${REQUIRED_NODE_MAJOR} with your package manager and re-run with --
   # No .tar.xz suffix: BusyBox mktemp requires the XXXXXX to be the final chars.
   tarball="$(mktemp "${TMPDIR:-/tmp}/hybridclaw-node.XXXXXX")"
   trap 'rm -f "$tarball"' EXIT
-  curl -fsSL --proto '=https' --tlsv1.2 --retry 3 --retry-delay 2 -o "$tarball" "$url" \
+  fetch --retry 3 --retry-delay 2 -o "$tarball" "$url" \
     || die "failed to download Node.js from $url"
   verify_node_checksum "$tarball" "$version" "$filename"
   tar -xJf "$tarball" -C "$dir" --strip-components=1
@@ -306,7 +316,8 @@ persist_path() {
   local rc
   for rc in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.profile"; do
     [ -e "$rc" ] || continue
-    grep -qsF "$dir $marker" "$rc" 2>/dev/null && continue
+    # Match the exact line we write so re-runs don't append duplicates.
+    grep -qsF "$line" "$rc" 2>/dev/null && continue
     printf '\n%s\n' "$line" >> "$rc"
   done
 }
@@ -321,18 +332,32 @@ npm_global_bin() {
 
 check_docker() {
   [ "$CHECK_DOCKER" -eq 1 ] || return 0
+  if is_dry; then
+    info "[dry-run] would check for Docker (recommended for the default sandbox)"
+    return 0
+  fi
   if ! have docker; then
     warn "Docker not found. The default container sandbox will be unavailable."
-    warn "Install Docker (https://docs.docker.com/get-docker/) or run with --sandbox=host."
+    warn "Install Docker (https://docs.docker.com/get-docker/) or run 'hybridclaw gateway start --sandbox=host'."
   elif docker info >/dev/null 2>&1; then
     ok "Docker is available (default container sandbox supported)"
   else
     warn "Docker is installed but its daemon is not reachable."
-    warn "Start Docker, or run the gateway with --sandbox=host."
+    warn "Start Docker, or run 'hybridclaw gateway start --sandbox=host'."
   fi
 }
 
 # --- Install -----------------------------------------------------------------
+
+# Per-distro commands to install the native-module build toolchain, printed via
+# the given printer ($1 = warn or err) so the pre-flight warning and the
+# install-failure error stay in sync.
+build_tool_hint() {
+  "$1" "    Debian/Ubuntu: sudo apt-get install -y python3 make g++"
+  "$1" "    Fedora/RHEL:   sudo dnf install -y python3 make gcc-c++"
+  "$1" "    Alpine:        sudo apk add python3 make g++"
+  "$1" "    macOS:         xcode-select --install"
+}
 
 # The npm package builds native modules (better-sqlite3, node-pty) from source
 # whenever no prebuilt binary matches the platform, and node-gyp then needs a
@@ -349,10 +374,7 @@ check_build_prereqs() {
   [ -z "$missing" ] && return 0
   warn "Build tools may be missing: ${missing}."
   warn "npm needs them to compile native modules when no prebuilt binary exists:"
-  warn "    Debian/Ubuntu: sudo apt-get install -y python3 make g++"
-  warn "    Fedora/RHEL:   sudo dnf install -y python3 make gcc-c++"
-  warn "    Alpine:        sudo apk add python3 make g++"
-  warn "    macOS:         xcode-select --install"
+  build_tool_hint warn
 }
 
 install_cli() {
@@ -367,9 +389,7 @@ install_cli() {
     err "Global npm install failed. Two common causes:"
     err "  1) Missing build tools for native modules (node-gyp needs python3,"
     err "     make, and a C/C++ compiler). Install them, e.g.:"
-    err "       Debian/Ubuntu: sudo apt-get install -y python3 make g++"
-    err "       Fedora/RHEL:   sudo dnf install -y python3 make gcc-c++"
-    err "       Alpine:        sudo apk add python3 make g++"
+    build_tool_hint err
     err "  2) A non-writable npm global prefix. Use a user-writable one:"
     err "       npm config set prefix \"$HYBRIDCLAW_HOME/npm-global\""
     err "       export PATH=\"$HYBRIDCLAW_HOME/npm-global/bin:\$PATH\""
@@ -388,6 +408,9 @@ install_cli() {
 
 # --- Onboarding + next steps -------------------------------------------------
 
+# Last line of `hybridclaw --version` (the CLI may print a banner first).
+hc_version() { hybridclaw --version 2>/dev/null | tail -1; }
+
 maybe_onboard() {
   if is_dry; then
     info "[dry-run] would verify hybridclaw is on PATH and (unless --no-prompt) run onboarding"
@@ -397,7 +420,7 @@ maybe_onboard() {
   have hybridclaw \
     || die "hybridclaw was installed but is not on PATH yet. Open a new shell and run: hybridclaw onboarding"
 
-  ok "Installed $(hybridclaw --version 2>/dev/null | tail -1 || echo "$PKG_NAME")"
+  ok "Installed $(hc_version || echo "$PKG_NAME")"
 
   if [ "$RUN_ONBOARDING" -ne 1 ] || [ "$NO_PROMPT" -eq 1 ]; then
     info "Skipping interactive onboarding: run 'hybridclaw onboarding' when ready."
@@ -412,15 +435,14 @@ maybe_onboard() {
   fi
 
   info "Starting onboarding (Ctrl-C to skip and run it later)"
-  if [ -t 0 ]; then
-    hybridclaw onboarding || warn "onboarding did not complete; run 'hybridclaw onboarding' later"
-  else
-    hybridclaw onboarding </dev/tty || warn "onboarding did not complete; run 'hybridclaw onboarding' later"
-  fi
+  local onboard_in=/dev/stdin
+  [ -t 0 ] || onboard_in=/dev/tty
+  hybridclaw onboarding <"$onboard_in" \
+    || warn "onboarding did not complete; run 'hybridclaw onboarding' later"
 }
 
 run_verify() {
-  [ "$VERIFY" -eq 1 ] || return 0
+  is_truthy "$VERIFY" || return 0
   if is_dry; then
     info "[dry-run] would run: hybridclaw --version && hybridclaw doctor --json"
     return 0
@@ -429,7 +451,7 @@ run_verify() {
   info "Verifying installation"
   have hybridclaw || die "verification failed: 'hybridclaw' is not on PATH."
   local version_output
-  version_output="$(hybridclaw --version 2>/dev/null | tail -1)" \
+  version_output="$(hc_version)" \
     || die "verification failed: 'hybridclaw --version' did not run successfully."
   ok "hybridclaw --version -> $version_output"
 

--- a/scripts/install.test.sh
+++ b/scripts/install.test.sh
@@ -115,18 +115,22 @@ expect_contains "absent checksum warns" "skipping verification" "$out"
 rm -f "$tmp"
 
 echo "== dir_writable =="
-dir_writable "$HOME"
+writable_dir="$(mktemp -d)"
+dir_writable "$writable_dir"
 expect_rc "writable existing dir" 0 "$?"
 # A path under a writable parent that does not exist yet is still creatable.
-dir_writable "$HOME/.hybridclaw-test-$$/lib/node_modules"
+dir_writable "$writable_dir/lib/node_modules"
 expect_rc "creatable under writable parent" 0 "$?"
-# A root-owned prefix (e.g. /usr) is not user-writable, so npm would EACCES.
-if [ ! -w /usr/lib ]; then
-  dir_writable /usr/lib/node_modules
-  expect_rc "root-owned prefix not writable" 1 "$?"
+# A read-only directory's children are not creatable. Root bypasses permission
+# bits, so this case is only meaningful (and only run) for an unprivileged user.
+ro_dir="$writable_dir/ro"; mkdir -p "$ro_dir"; chmod a-w "$ro_dir"
+if [ "$(id -u)" != 0 ] && [ ! -w "$ro_dir" ]; then
+  dir_writable "$ro_dir/node_modules"
+  expect_rc "non-writable parent rejected" 1 "$?"
 else
-  ok "root-owned prefix not writable (skipped: /usr/lib is writable here)"
+  ok "non-writable parent rejected (skipped: running as root bypasses perms)"
 fi
+chmod u+w "$ro_dir" 2>/dev/null; rm -rf "$writable_dir"
 
 echo "== check_build_prereqs =="
 out="$( ( have() { return 0; } # all tools present

--- a/scripts/install.test.sh
+++ b/scripts/install.test.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# Offline unit tests for scripts/install.sh.
+#
+#   bash scripts/install.test.sh
+#
+# These are fast, deterministic, and need no network: install.sh is sourced as
+# a library (HYBRIDCLAW_INSTALL_LIB=1 skips main), and external commands such as
+# uname/curl/ls/have are stubbed to drive each code path. The full end-to-end
+# matrix (alpine/debian/node:22 in Docker) is documented in the PR.
+
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+# Load install.sh's functions without running it. Clear positional params so
+# its argument parser sees nothing.
+set --
+HYBRIDCLAW_INSTALL_LIB=1 NO_COLOR=1 source "$HERE/install.sh"
+set +eu +o pipefail # the tests below manage their own exit-status checks
+
+PASS=0
+FAIL=0
+ok()  { printf '  ok   %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL   %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+expect_eq() { # desc expected actual
+  if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 — expected [$2], got [$3]"; fi
+}
+expect_rc() { # desc expected_rc actual_rc
+  if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 — expected rc $2, got $3"; fi
+}
+expect_contains() { # desc needle haystack
+  case "$3" in
+    *"$2"*) ok "$1" ;;
+    *) bad "$1 — output missing [$2]" ;;
+  esac
+}
+
+echo "== version_ge =="
+for case in "11.10.0 11.10.0 0" "11.10.1 11.10.0 0" "12.0.0 11.10.0 0" \
+            "10.9.0 11.10.0 1" "11.9.9 11.10.0 1" "22.22.3 22.20.0 0"; do
+  # shellcheck disable=SC2086 # intentional split of the space-separated triple
+  set -- $case
+  version_ge "$1" "$2"
+  expect_rc "version_ge $1 >= $2" "$3" "$?"
+done
+
+echo "== sha256_of =="
+tmp="$(mktemp)"; printf 'hybridclaw' >"$tmp"
+expect_eq "sha256_of known string" \
+  "c1b0e433aa7b46071b1c5a5e6470a2e473a7dbc4d9909a38ca16cca9732beac0" \
+  "$(sha256_of "$tmp")"
+rm -f "$tmp"
+
+echo "== detect_platform =="
+# desc | uname -s | uname -m | expected "os arch libc"
+plat() { # stubs uname, runs detect_platform in a subshell, echoes result
+  local s="$1" m="$2"
+  ( uname() { case "$1" in -s) echo "$s" ;; -m) echo "$m" ;; esac; }
+    detect_platform
+    echo "$PLATFORM_OS $PLATFORM_ARCH $PLATFORM_LIBC" )
+}
+expect_eq "linux/x86_64 -> x64 glibc"  "linux x64 glibc"    "$(plat Linux x86_64)"
+expect_eq "linux/aarch64 -> arm64"     "linux arm64 glibc"  "$(plat Linux aarch64)"
+expect_eq "linux/armv7l"               "linux armv7l glibc" "$(plat Linux armv7l)"
+expect_eq "darwin/arm64"               "darwin arm64 glibc" "$(plat Darwin arm64)"
+
+# musl detection: stub `ls` so the ld-musl glob "matches".
+musl_libc="$(
+  ( uname() { case "$1" in -s) echo Linux ;; -m) echo x86_64 ;; esac; }
+    ls() { return 0; }
+    detect_platform
+    echo "$PLATFORM_LIBC" )
+)"
+expect_eq "musl loader present -> musl" "musl" "$musl_libc"
+
+# unsupported arch and Windows must die loudly.
+out="$( ( uname() { case "$1" in -s) echo Linux ;; -m) echo ppc64 ;; esac; }
+        detect_platform ) 2>&1 )"
+expect_rc "unsupported arch dies" 1 "$?"
+expect_contains "unsupported arch message" "unsupported architecture" "$out"
+
+out="$( ( uname() { case "$1" in -s) echo MINGW64_NT ;; -m) echo x86_64 ;; esac; }
+        detect_platform ) 2>&1 )"
+expect_rc "windows dies" 1 "$?"
+expect_contains "windows -> WSL2 hint" "WSL2" "$out"
+
+echo "== verify_node_checksum =="
+tmp="$(mktemp)"; printf 'pretend-node-tarball' >"$tmp"
+good="$(sha256_of "$tmp")"
+fn="node-vTEST-linux-x64.tar.xz"
+
+# Matching checksum -> succeeds quietly.
+( curl() { printf '%s  %s\n' "$good" "$fn"; }
+  verify_node_checksum "$tmp" TEST "$fn" ) >/dev/null 2>&1
+expect_rc "matching checksum passes" 0 "$?"
+
+# Mismatched checksum -> dies, refusing the download.
+out="$( ( curl() { printf '%s  %s\n' deadbeefdeadbeef "$fn"; }
+          verify_node_checksum "$tmp" TEST "$fn" ) 2>&1 )"
+expect_rc "mismatched checksum dies" 1 "$?"
+expect_contains "mismatch message" "Checksum mismatch" "$out"
+
+# No published checksum available -> warns and skips (non-fatal).
+out="$( ( curl() { printf ''; }
+          verify_node_checksum "$tmp" TEST "$fn" ) 2>&1 )"
+expect_rc "absent checksum is non-fatal" 0 "$?"
+expect_contains "absent checksum warns" "skipping verification" "$out"
+rm -f "$tmp"
+
+echo "== check_build_prereqs =="
+out="$( ( have() { return 0; } # all tools present
+          check_build_prereqs ) 2>&1 )"
+expect_eq "no warning when toolchain present" "" "$out"
+
+out="$( ( have() { return 1; } # nothing present
+          check_build_prereqs ) 2>&1 )"
+expect_contains "warns when toolchain missing" "Build tools may be missing" "$out"
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/install.test.sh
+++ b/scripts/install.test.sh
@@ -114,6 +114,20 @@ expect_rc "absent checksum is non-fatal" 0 "$?"
 expect_contains "absent checksum warns" "skipping verification" "$out"
 rm -f "$tmp"
 
+echo "== dir_writable =="
+dir_writable "$HOME"
+expect_rc "writable existing dir" 0 "$?"
+# A path under a writable parent that does not exist yet is still creatable.
+dir_writable "$HOME/.hybridclaw-test-$$/lib/node_modules"
+expect_rc "creatable under writable parent" 0 "$?"
+# A root-owned prefix (e.g. /usr) is not user-writable, so npm would EACCES.
+if [ ! -w /usr/lib ]; then
+  dir_writable /usr/lib/node_modules
+  expect_rc "root-owned prefix not writable" 1 "$?"
+else
+  ok "root-owned prefix not writable (skipped: /usr/lib is writable here)"
+fi
+
 echo "== check_build_prereqs =="
 out="$( ( have() { return 0; } # all tools present
           check_build_prereqs ) 2>&1 )"

--- a/scripts/install.test.sh
+++ b/scripts/install.test.sh
@@ -8,6 +8,12 @@
 # a library (HYBRIDCLAW_INSTALL_LIB=1 skips main), and external commands such as
 # uname/curl/ls/have are stubbed to drive each code path. The full end-to-end
 # matrix (alpine/debian/node:22 in Docker) is documented in the PR.
+#
+# The stub functions below override commands the sourced install.sh functions
+# call indirectly, which shellcheck's reachability pass can't see (SC2317); it
+# also can't follow the runtime source of install.sh (SC1091). Silence both
+# false positives file-wide so `shellcheck install.test.sh` stays clean.
+# shellcheck disable=SC2317,SC1091
 
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"


### PR DESCRIPTION
## What

Adds `scripts/install.sh` — a one-line bootstrap installer for HybridClaw on Linux and macOS, plus docs that surface it.

```bash
curl -fsSL https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/scripts/install.sh | bash
```

## Why

The project ships several install paths (npm, Nix, Homebrew preview, source) but no `curl | bash` convenience installer like the reference scripts in [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent/blob/main/scripts/install.sh), OpenAI's Codex CLI, and [openclaw/openclaw](https://github.com/openclaw/openclaw). This closes that gap with a script tailored to HybridClaw's npm-distributed Node 22 CLI.

## What it does

1. **Platform detection** — Linux + macOS, x64/arm64/armv7l, glibc/musl; rejects Windows with a pointer to WSL2.
2. **Node.js 22 + npm ≥ 11.10.0** — uses an existing compatible Node if present; otherwise downloads a user-local Node 22 into `~/.hybridclaw/node` (version resolved live from `nodejs.org/dist`) and persists PATH idempotently. Node 22 ships npm 10.x, so npm is upgraded to satisfy the repo's `engines`.
3. **CLI install** — `npm install -g @hybridaione/hybridclaw` (version pinnable via `--version`).
4. **Docker check** — warns (non-fatal) when the daemon is missing, suggesting `--sandbox=host`.
5. **Onboarding** — runs `hybridclaw onboarding` when attached to a terminal (reads `/dev/tty` under `curl | bash`); prints next-steps otherwise.

**No sudo, ever.** Only writes to `$HOME` and the npm prefix; falls back to a user-writable npm prefix on `EACCES`.

## Robustness (patterns from rustup / nvm / uv / Homebrew installers)

- **Partial-download guard** — the whole body is a brace group invoked on the last line, so a truncated `curl | bash` fails to parse and runs *nothing* rather than executing a fragment. Verified: piping a head-truncated copy to bash yields a parse error, no banner, no commands run.
- **Bash-required check** — friendly error (and exit) before any bash-only syntax if run under `sh`/`dash`.
- **Checksum verification** — managed Node downloads are verified against nodejs.org's per-release `SHASUMS256.txt` (`sha256sum`/`shasum`) before extraction; refuses a mismatched/corrupt tarball.
- **musl detection** — refuses to install glibc-only nodejs.org tarballs on Alpine/musl, pointing at `apk add nodejs npm` + `--skip-node`.
- **TLS hardening** — downloads use `curl --proto '=https' --tlsv1.2 --retry`.

## CI / automation flags

| Flag | Env | Effect |
|---|---|---|
| `--no-prompt` | `HYBRIDCLAW_NO_PROMPT` / `NO_PROMPT` / `CI` | Headless: never prompts, skips onboarding |
| `--dry-run` | `HYBRIDCLAW_DRY_RUN` | Prints every planned step (download, checksum, npm install, PATH edits, onboarding) without changing anything |
| `--verify` | `HYBRIDCLAW_VERIFY_INSTALL` | Post-install smoke test: `hybridclaw --version` (hard) + `hybridclaw doctor --json` (soft) |

Other flags: `--version <ver>`, `--no-onboarding`, `--skip-docker-check`, `--skip-node`, `--help`. Env: `HYBRIDCLAW_HOME`, `HYBRIDCLAW_INSTALL_VERSION`, `HYBRIDCLAW_NODE_VERSION`, `NO_COLOR`.

## Testing

Validated **end-to-end in Docker** (mounting the branch script), plus local checks:

| Scenario | Result |
|---|---|
| `node:22` (Node 22 + build tools) | ✅ full real install of `@hybridaione/hybridclaw` (617 pkgs, native modules compiled), npm auto-upgraded 10→11, `hybridclaw --version` runs, `--verify` passes, **EXIT 0** |
| clean `debian:bookworm-slim` (no Node) | ✅ managed Node 22 download + **`✓ Verified Node.js download (sha256)`** + npm upgrade |
| `alpine:3.20` (musl) | ✅ musl correctly detected, glibc-tarball download refused with `apk` guidance |
| `node:22-slim` (no curl) | ✅ aborts at the `curl` preflight |
| `node:22-slim` + curl (no build tools) | ✅ build-tool pre-flight warning + corrected dual-cause failure message |
| local | ✅ `bash -n`, partial-download guard (truncated → parse error, nothing runs), bash-required check under dash, dry-run, SHASUMS256 extraction |

**Automated, repeatable now too:** `scripts/install.test.sh` — 23 offline unit tests (stub `uname`/`curl`/`ls`/`have`) covering `version_ge`, `sha256_of`, platform + musl detection, unsupported-arch/Windows aborts, the **checksum-mismatch rejection** path, and the build-prereq warning. The script is made sourceable via `HYBRIDCLAW_INSTALL_LIB` (verified it does not affect executed or piped runs). CI's lint job now runs `shellcheck` on the install scripts plus this suite; both are shellcheck-clean.

Container testing caught four issues that local checks couldn't: `pipefail` masking musl detection, a BusyBox-incompatible `mktemp` template, and a missing build-toolchain pre-flight with a misleading error message — all fixed.

## Follow-ups (out of scope)

- A hosted short URL (e.g. `get.hybridclaw...`) and a published checksum of the script itself.
- `wget` fallback when `curl` is absent; an `--uninstall` path; optional `git`/source install method.

