### PR TITLE
ci: close test-wiring gaps and make e2e selection self-gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,42 +108,8 @@ jobs:
           BASE_SHA="${BASE_SHA:-${{ github.event.pull_request.base.sha }}}"
           node ./scripts/check-dependency-policy.mjs --base "${BASE_SHA}"
 
-      - name: Biome check (changed files)
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            PARENTS="$(git show -s --format=%P HEAD)"
-            BASE_SHA="${PARENTS%% *}"
-            BASE_SHA="${BASE_SHA:-${{ github.event.pull_request.base.sha }}}"
-          else
-            BASE_SHA="${{ github.event.before }}"
-          fi
-          HEAD_SHA="${{ github.sha }}"
-
-          FILES=()
-          if [[ -z "${BASE_SHA}" || "${BASE_SHA}" == "0000000000000000000000000000000000000000" ]]; then
-            while IFS= read -r file; do
-              [[ -n "${file}" ]] && FILES+=("${file}")
-            done < <(git ls-files src | grep -E '^src/.*\.(ts|tsx|js|jsx)$' || true)
-          else
-            while IFS= read -r file; do
-              [[ -n "${file}" ]] && FILES+=("${file}")
-            done < <(
-              git diff --name-only --diff-filter=ACMRT "${BASE_SHA}" "${HEAD_SHA}" \
-                | grep -E '^src/.*\.(ts|tsx|js|jsx)$' || true
-            )
-          fi
-
-          if [[ "${#FILES[@]}" -eq 0 ]]; then
-            echo "No changed source files for Biome check."
-            exit 0
-          fi
-
-          echo "Running Biome on changed files:"
-          printf ' - %s\n' "${FILES[@]}"
-          npx biome check "${FILES[@]}"
+      - name: Biome check (whole repo)
+        run: npm run check
 
       - name: TypeScript lint (root)
         run: npm run lint
@@ -200,6 +166,14 @@ jobs:
 
       - name: Frontend unit tests (console)
         run: npm run test:console
+
+      - name: Desktop unit tests
+        run: npm --workspace desktop run test
+
+      - name: CLI binary e2e
+        env:
+          HYBRIDCLAW_RUN_CLI_E2E: '1'
+        run: npx vitest run --project e2e
 
       - name: Generate coverage badge
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         env:
           HYBRIDCLAW_RUN_DOCKER_E2E: '1'
           HYBRIDCLAW_E2E_IMAGE: hybridclaw-gateway:preflight
-        run: npx vitest run --project e2e tests/gateway-docker.e2e.test.ts
+        run: npx vitest run --project e2e
 
       - name: Gateway e2e tests (external services)
         if: matrix.name == 'gateway' && env.HAS_HYBRIDAI_API_KEY == 'true'
@@ -68,14 +68,14 @@ jobs:
           HYBRIDCLAW_RUN_DOCKER_E2E: '1'
           HYBRIDCLAW_E2E_IMAGE: hybridclaw-gateway:preflight
           HYBRIDAI_API_KEY: ${{ secrets.HYBRIDAI_API_KEY }}
-        run: npx vitest run --project e2e tests/gateway-docker.e2e.test.ts -t "provider|chat API"
+        run: npx vitest run --project e2e -t "provider|chat API"
 
       - name: Agent container e2e tests
         if: matrix.name == 'agent'
         env:
           HYBRIDCLAW_RUN_DOCKER_E2E: '1'
           HYBRIDCLAW_E2E_AGENT_IMAGE: hybridclaw-agent:preflight
-        run: npx vitest run --project e2e tests/agent-container.e2e.test.ts
+        run: npx vitest run --project e2e
 
   lint:
     runs-on: ubuntu-latest
@@ -116,9 +116,6 @@ jobs:
 
       - name: TypeScript lint (container)
         run: npm --prefix container run lint
-
-      - name: TypeScript lint (console)
-        run: npm --prefix console run typecheck
 
   test:
     runs-on: ubuntu-latest
@@ -216,4 +213,4 @@ jobs:
       - name: npm install journey e2e
         env:
           HYBRIDCLAW_RUN_NPM_E2E: '1'
-        run: npx vitest run --project e2e tests/npm-install.e2e.test.ts
+        run: npx vitest run --project e2e

--- a/tests/agent-container.e2e.test.ts
+++ b/tests/agent-container.e2e.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import {
   cleanupStaleContainers,
+  dockerE2eGate,
   removeContainer,
   startContainer,
 } from './helpers/docker-test-setup.js';
@@ -10,12 +11,9 @@ import {
  * separate containers per test (~22s -> ~3s).
  */
 
-// Self-selecting gate: this suite runs only when its own image var is set, so
-// `vitest run --project e2e` is safe to invoke in any matrix leg without the
-// gateway leg accidentally running agent tests against an unbuilt image.
-const IMAGE = process.env.HYBRIDCLAW_E2E_AGENT_IMAGE ?? '';
-const DOCKER_E2E =
-  process.env.HYBRIDCLAW_RUN_DOCKER_E2E === '1' && IMAGE !== '';
+const { image: IMAGE, enabled: DOCKER_E2E } = dockerE2eGate(
+  'HYBRIDCLAW_E2E_AGENT_IMAGE',
+);
 
 const CONTAINER_NAME = `hc-e2e-agent-${process.pid}`;
 

--- a/tests/agent-container.e2e.test.ts
+++ b/tests/agent-container.e2e.test.ts
@@ -10,9 +10,12 @@ import {
  * separate containers per test (~22s -> ~3s).
  */
 
-const DOCKER_E2E = process.env.HYBRIDCLAW_RUN_DOCKER_E2E === '1';
-const IMAGE =
-  process.env.HYBRIDCLAW_E2E_AGENT_IMAGE || 'hybridclaw-agent:preflight';
+// Self-selecting gate: this suite runs only when its own image var is set, so
+// `vitest run --project e2e` is safe to invoke in any matrix leg without the
+// gateway leg accidentally running agent tests against an unbuilt image.
+const IMAGE = process.env.HYBRIDCLAW_E2E_AGENT_IMAGE ?? '';
+const DOCKER_E2E =
+  process.env.HYBRIDCLAW_RUN_DOCKER_E2E === '1' && IMAGE !== '';
 
 const CONTAINER_NAME = `hc-e2e-agent-${process.pid}`;
 

--- a/tests/gateway-docker.e2e.test.ts
+++ b/tests/gateway-docker.e2e.test.ts
@@ -14,8 +14,12 @@ import {
  * a dummy key lets the gateway start for static-content and endpoint tests.
  */
 
-const DOCKER_E2E = process.env.HYBRIDCLAW_RUN_DOCKER_E2E === '1';
-const IMAGE = process.env.HYBRIDCLAW_E2E_IMAGE || 'hybridclaw-gateway:e2e';
+// Self-selecting gate: this suite runs only when its own image var is set, so
+// `vitest run --project e2e` is safe to invoke in any matrix leg without the
+// agent leg accidentally running gateway tests against an unbuilt image.
+const IMAGE = process.env.HYBRIDCLAW_E2E_IMAGE ?? '';
+const DOCKER_E2E =
+  process.env.HYBRIDCLAW_RUN_DOCKER_E2E === '1' && IMAGE !== '';
 const CI_FALLBACK_KEY = 'hai-ci-placeholder-not-a-real-key';
 const API_KEY = process.env.HYBRIDAI_API_KEY || CI_FALLBACK_KEY;
 const HAS_REAL_KEY = !!process.env.HYBRIDAI_API_KEY;

--- a/tests/gateway-docker.e2e.test.ts
+++ b/tests/gateway-docker.e2e.test.ts
@@ -2,6 +2,7 @@ import { execSync } from 'node:child_process';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import {
   cleanupStaleContainers,
+  dockerE2eGate,
   getAvailablePort,
   removeContainer,
   startContainer,
@@ -14,12 +15,8 @@ import {
  * a dummy key lets the gateway start for static-content and endpoint tests.
  */
 
-// Self-selecting gate: this suite runs only when its own image var is set, so
-// `vitest run --project e2e` is safe to invoke in any matrix leg without the
-// agent leg accidentally running gateway tests against an unbuilt image.
-const IMAGE = process.env.HYBRIDCLAW_E2E_IMAGE ?? '';
-const DOCKER_E2E =
-  process.env.HYBRIDCLAW_RUN_DOCKER_E2E === '1' && IMAGE !== '';
+const { image: IMAGE, enabled: DOCKER_E2E } =
+  dockerE2eGate('HYBRIDCLAW_E2E_IMAGE');
 const CI_FALLBACK_KEY = 'hai-ci-placeholder-not-a-real-key';
 const API_KEY = process.env.HYBRIDAI_API_KEY || CI_FALLBACK_KEY;
 const HAS_REAL_KEY = !!process.env.HYBRIDAI_API_KEY;

--- a/tests/helpers/docker-test-setup.ts
+++ b/tests/helpers/docker-test-setup.ts
@@ -11,20 +11,39 @@ import net from 'node:net';
 export const CONTAINER_PREFIX = 'hc-e2e';
 
 /**
+ * Conservative Docker image-reference characters: lowercase/uppercase letters,
+ * digits, and the punctuation valid in a `name[:tag][@digest]` reference.
+ * Anything outside this set (notably whitespace and shell metacharacters)
+ * would be unsafe to splice into the `docker ...` commands built via execSync.
+ */
+const SAFE_IMAGE_REF = /^[A-Za-z0-9._/:@-]+$/;
+
+/**
  * Self-selecting gate for a Docker e2e suite. The suite is enabled only when
- * HYBRIDCLAW_RUN_DOCKER_E2E=1 *and* its own image var is set, so
- * `vitest run --project e2e` is safe to invoke in any CI matrix leg without one
- * suite running against an image another leg built.
+ * HYBRIDCLAW_RUN_DOCKER_E2E=1 *and* its own image var is set to a syntactically
+ * valid image reference, so `vitest run --project e2e` is safe to invoke in any
+ * CI matrix leg without one suite running against an image another leg built.
+ *
+ * The image value is trimmed and validated before the suite is enabled. An
+ * env var that is whitespace-only or contains characters illegal in a Docker
+ * reference disables the suite (with a warning) rather than letting an unsafe
+ * value reach the `docker ... ${image}` commands.
  */
 export function dockerE2eGate(imageEnvVar: string): {
   image: string;
   enabled: boolean;
 } {
-  const image = process.env[imageEnvVar] ?? '';
-  return {
-    image,
-    enabled: process.env.HYBRIDCLAW_RUN_DOCKER_E2E === '1' && image !== '',
-  };
+  const image = (process.env[imageEnvVar] ?? '').trim();
+  if (process.env.HYBRIDCLAW_RUN_DOCKER_E2E !== '1' || image === '') {
+    return { image, enabled: false };
+  }
+  if (!SAFE_IMAGE_REF.test(image)) {
+    console.warn(
+      `[gate] ${imageEnvVar} is set to an invalid image reference; suite disabled.`,
+    );
+    return { image, enabled: false };
+  }
+  return { image, enabled: true };
 }
 
 /**

--- a/tests/helpers/docker-test-setup.ts
+++ b/tests/helpers/docker-test-setup.ts
@@ -11,6 +11,23 @@ import net from 'node:net';
 export const CONTAINER_PREFIX = 'hc-e2e';
 
 /**
+ * Self-selecting gate for a Docker e2e suite. The suite is enabled only when
+ * HYBRIDCLAW_RUN_DOCKER_E2E=1 *and* its own image var is set, so
+ * `vitest run --project e2e` is safe to invoke in any CI matrix leg without one
+ * suite running against an image another leg built.
+ */
+export function dockerE2eGate(imageEnvVar: string): {
+  image: string;
+  enabled: boolean;
+} {
+  const image = process.env[imageEnvVar] ?? '';
+  return {
+    image,
+    enabled: process.env.HYBRIDCLAW_RUN_DOCKER_E2E === '1' && image !== '',
+  };
+}
+
+/**
  * Remove any stale containers from previous test runs that match the
  * given suite prefix (e.g. 'gw', 'agent').
  */


### PR DESCRIPTION
## Summary

A CI inventory found test/lint surfaces that exist but never ran in CI, plus a structural reason they could recur. Root cause: the workflow re-specified *what* to run (named test files, hand-listed steps) instead of letting the project's own gates decide. This PR closes the current gaps and removes the fragility that created them.

## Changes

### `.github/workflows/ci.yml`
- **Desktop tests now run** — the `test` job ran `--project unit` + `test:console` separately, silently dropping the desktop vitest suite (only `npm run test:unit` aggregates it). Added `npm --workspace desktop run test` (18 tests, verified locally).
- **CLI-recovery e2e now runs** — `tests/gateway-docker-recovery.e2e.test.ts` was orphaned; it gates on `HYBRIDCLAW_RUN_CLI_E2E` (a CLI-binary e2e needing `dist/cli.js`, no Docker), which no workflow set. Runs in the `test` job where `dist/` is already built.
- **Full-repo Biome** — replaced changed-`src/`-files-only logic with `npm run check` (`biome check .`, ~2s, clean on 1057 files). Also removed `${{ }}`-in-`run` interpolation from the old step.
- **Every e2e invocation is now `vitest run --project e2e`** (optionally `-t`-filtered), differentiated only by env vars — no named test files in any job. New e2e files are picked up automatically.
- **Dropped the redundant `TypeScript lint (console)` step** — `npm run lint` already runs console + desktop typecheck (container lint stays; it's not in root lint).

### `tests/agent-container.e2e.test.ts`, `tests/gateway-docker.e2e.test.ts`
- **Self-selecting gates.** Each Docker e2e suite now requires its *own* image var (`HYBRIDCLAW_E2E_IMAGE` / `HYBRIDCLAW_E2E_AGENT_IMAGE`) to be set, in addition to `HYBRIDCLAW_RUN_DOCKER_E2E`, and the default image-tag fallbacks are removed. Previously both suites shared one flag and defaulted their tags, so running the whole project fired both against fallback images — the reason the workflow had to name files per matrix leg. Now the gateway leg runs only gateway tests and the agent leg only agent tests.

## Why this is the durable fix
The orphaned-recovery-test bug is an instance of "a test exists but nothing selects it." Self-gating + whole-project invocation means selection is data-driven by env, not by a hand-maintained file list, so the bug class can't recur.

## Verification (local)
- [x] Desktop suite: 18 tests pass
- [x] `biome check .`: clean (1057 files)
- [x] `vitest run --project e2e` with no env → 65 skipped, exit 0
- [x] only `RUN_DOCKER_E2E=1` (no image var) → docker suites skip (no container attempt)
- [x] `RUN_DOCKER_E2E=1` + agent image var → only the agent suite activates; gateway stays skipped
- [ ] CI green on this PR

## Out of scope (tracked separately)
Nightly live-smoke job, dependabot, `ci-success` aggregator, coverage ratchet, composite-action dedup in `dependency-audit.yml`/`publish-release.yml`.