### PR TITLE
[codex] Prepare v0.22.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,71 @@
 
 ## Unreleased
 
+## [0.22.0](https://github.com/HybridAIOne/hybridclaw/tree/v0.22.0) - 2026-06-05
+
 ### Added
 
+- **One-line installer**: Added `scripts/install.sh` for Linux/macOS bootstrap
+  installs that ensure Node.js 22, install the global CLI, check Docker, and
+  optionally run onboarding without requiring `sudo`. Installation docs now
+  cover dry-run, pinned-version, no-prompt, verification, WSL2, and Alpine
+  usage.
 - **Interactive startup update prompt**: Starting HybridClaw on a terminal
   (`hybridclaw tui`, `hybridclaw gateway`, or `hybridclaw gateway start`) now
   checks for a newer published release and offers a yes/no prompt to update
   before continuing. Skipped for non-interactive shells and source checkouts.
+- **`alexa` skill**: Added Alexa Skills Kit request verification, TTS-safe
+  response building, account-link session exchange, guarded Smart Home API
+  plans, and opt-in Alexa Remote workflows for devices, lists, announcements,
+  music playback, routines, and voice-command execution.
+- **Gateway Docker startup recovery**: Interactive gateway and TUI startup can
+  recover from missing Docker, unavailable Docker daemons, and Docker permission
+  failures by retrying after the operator starts Docker or by continuing in
+  host mode for the current run only.
+- **Agent runtime setup progress**: Container image pull/build operations now
+  show concise interactive progress for first-time setup, refreshes, and stale
+  runtime updates, with a `HYBRIDCLAW_NO_SPINNER=1` fallback for plain output.
+
+### Changed
+
+- **Full audit trace tool results**: Tool execution audit events now retain
+  redacted full result text for `/audit turn` and ATIF trace exports, with
+  `audit.toolResults.mode` and `audit.toolResults.maxChars` config available
+  when operators need truncation.
+- **Node.js runtime guard**: CLI startup now fails fast on unsupported Node.js
+  versions instead of allowing later dependency/runtime failures under an
+  incompatible engine.
+- **Test and CI wiring**: Docker-dependent e2e coverage is self-gating, while
+  container startup recovery, Node version guards, update prompts, audit
+  exports, and Alexa helpers gained targeted test coverage.
+
+### Fixed
+
+- **Provider onboarding secret exposure**: Provider API keys entered during
+  onboarding are masked instead of echoed in terminal prompts or summaries.
+- **WhatsApp config reloads**: Gateway config changes now restart the WhatsApp
+  integration so pairing and policy updates take effect without a full gateway
+  restart.
+- **OpenAI Codex auth compatibility**: Codex device-code auth now sends the
+  official `codex_cli_rs` originator and accepts responses that use `usercode`
+  instead of `user_code`.
+- **TypeScript plugin loading**: Runtime plugin loading handles `.ts` plugin
+  entrypoints through `amaro` for Node.js 22.x compatibility.
+- **Console theme initialization**: The admin console applies the configured
+  theme on every route instead of only initializing it from the admin shell.
+- **Scheduler noop TUI delivery**: Scheduled tasks that report heartbeat or
+  idle/no-work results no longer create unnecessary proactive TUI deliveries.
+- **Dependency audit advisories**: In-range and breaking dependency updates
+  clear high-severity transitive advisories while keeping release signature
+  audit baselines aligned.
+
+## [0.21.1](https://github.com/HybridAIOne/hybridclaw/tree/v0.21.1) - 2026-05-29
+
+### Fixed
+
+- **Codex device-code login**: Accepted OpenAI Codex device-code responses that
+  return `usercode` instead of `user_code`, and defaulted missing verification
+  URLs to the current Codex device login page.
 
 ## [0.21.0](https://github.com/HybridAIOne/hybridclaw/tree/v0.21.0) - 2026-05-29
 

--- a/container/npm-shrinkwrap.json
+++ b/container/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hybridclaw-agent",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
         "@mozilla/readability": "0.6.0",

--- a/container/package-lock.json
+++ b/container/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hybridclaw-agent",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
         "@mozilla/readability": "0.6.0",

--- a/container/package.json
+++ b/container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "type": "module",
   "main": "dist/index.js",
   "packageManager": "npm@11.10.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@hybridaione/hybridclaw-desktop",
   "productName": "HybridClaw",
   "private": true,
-  "version": "0.21.0",
+  "version": "0.22.0",
   "type": "module",
   "description": "macOS wrapper for the HybridClaw chat and admin web surfaces",
   "author": "HybridAI One",

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -21,7 +21,7 @@ skip the interactive onboarding step:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/scripts/install.sh \
-  | bash -s -- --version 0.21.0 --no-onboarding
+  | bash -s -- --version x.y.z --no-onboarding
 ```
 
 For automation, preview the plan with `--dry-run` (changes nothing), run

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -21,7 +21,7 @@ skip the interactive onboarding step:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/scripts/install.sh \
-  | bash -s -- --version x.y.z --no-onboarding
+  | bash -s -- --version 0.22.0 --no-onboarding
 ```
 
 For automation, preview the plan with `--dry-run` (changes nothing), run

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hybridaione/hybridclaw",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "packageManager": "npm@11.10.0",
       "hasInstallScript": true,
       "workspaces": [
@@ -108,7 +108,7 @@
     },
     "container": {
       "name": "hybridclaw-agent",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
         "@mozilla/readability": "0.6.0",
@@ -413,7 +413,7 @@
     },
     "desktop": {
       "name": "@hybridaione/hybridclaw-desktop",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "dependencies": {
         "@hybridaione/hybridclaw-desktop-packaging-anchor": "file:./support/packaging-anchor"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hybridaione/hybridclaw",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "packageManager": "npm@11.10.0",
       "hasInstallScript": true,
       "workspaces": [
@@ -108,7 +108,7 @@
     },
     "container": {
       "name": "hybridclaw-agent",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
         "@mozilla/readability": "0.6.0",
@@ -413,7 +413,7 @@
     },
     "desktop": {
       "name": "@hybridaione/hybridclaw-desktop",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "dependencies": {
         "@hybridaione/hybridclaw-desktop-packaging-anchor": "file:./support/packaging-anchor"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "type": "module",
   "description": "Enterprise-ready self-hosted AI assistant runtime with sandboxed execution, secure credentials, approvals, and memory",
   "repository": {

--- a/scripts/dependency-policy-baseline.json
+++ b/scripts/dependency-policy-baseline.json
@@ -1,9 +1,9 @@
 {
   "lockfiles": {
-    "package-lock.json": "7b456566f03cd01be640dc0a9f811e9b972e7580a929c45074b8d45af3da1182",
-    "npm-shrinkwrap.json": "7b456566f03cd01be640dc0a9f811e9b972e7580a929c45074b8d45af3da1182",
-    "container/package-lock.json": "bcd8b096a12a92d393d71c7d5efca45ea87cee30bc053a6ae47e3609169916b3",
-    "container/npm-shrinkwrap.json": "bcd8b096a12a92d393d71c7d5efca45ea87cee30bc053a6ae47e3609169916b3",
+    "package-lock.json": "d83f24f9fcb65c7a9c59dc48e614ed90c8de04a0aea51dee61a662e6258dea91",
+    "npm-shrinkwrap.json": "d83f24f9fcb65c7a9c59dc48e614ed90c8de04a0aea51dee61a662e6258dea91",
+    "container/package-lock.json": "dc7c12b348c79903102cb50d1e6cc037dab14735476ef4a6beb7852737183239",
+    "container/npm-shrinkwrap.json": "dc7c12b348c79903102cb50d1e6cc037dab14735476ef4a6beb7852737183239",
     "plugins/brevo-email/package-lock.json": "3377225eb3bdbb252eaa28ad420b9a725ea1da533417388557aa1984730229b5"
   }
 }


### PR DESCRIPTION
## Summary

- Bump root, container, and desktop package metadata to `0.22.0`.
- Add curated `0.22.0` changelog notes based on changes since `v0.21.1` and restore the missing `0.21.1` changelog section.
- Keep install docs from going stale by replacing the pinned script example version with a placeholder.
- Sync root and container lockfile/shrinkwrap release metadata.

## Impact

This prepares the next minor release without tagging, publishing, or creating the GitHub Release entry. The release notes call out the new installer, startup update prompt, Alexa skill, Docker startup recovery, audit trace retention, Node runtime guard, and relevant fixes.

## Validation

- `npm run build`
- `npm run release:check`
- `npm --prefix container run release:check`
- `git diff --check`
- Verified root and container shrinkwraps match their lockfiles.