### PR TITLE
fix(install): work on clean Debian/Ubuntu + no-sudo system Node, add Docker e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,3 +225,11 @@ jobs:
           # enough for the gateway and these tests.
           ONNXRUNTIME_NODE_INSTALL_CUDA: skip
         run: npx vitest run --project e2e
+
+      # install.sh bootstrap matrix (clean Ubuntu/Alpine + no-sudo node:22).
+      # Its own opt-in flag keeps it out of the gateway/agent/CLI e2e jobs; this
+      # is the single job meant to pay its ~6-7 min Docker/network cost.
+      - name: Installer bootstrap e2e (Docker)
+        env:
+          HYBRIDCLAW_RUN_INSTALL_E2E: '1'
+        run: npx vitest run --project e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,10 +226,9 @@ jobs:
           ONNXRUNTIME_NODE_INSTALL_CUDA: skip
         run: npx vitest run --project e2e
 
-      # install.sh bootstrap matrix (clean Ubuntu/Alpine + no-sudo node:22).
-      # Its own opt-in flag keeps it out of the gateway/agent/CLI e2e jobs; this
-      # is the single job meant to pay its ~6-7 min Docker/network cost.
+      # install.sh bootstrap matrix (clean Ubuntu/Alpine + no-sudo node:22). It
+      # lives in its own `install-e2e` vitest project, so it stays out of the
+      # gateway/agent/CLI e2e jobs; this is the single job meant to pay its
+      # ~6-7 min Docker/network cost. Self-skips if Docker is unreachable.
       - name: Installer bootstrap e2e (Docker)
-        env:
-          HYBRIDCLAW_RUN_INSTALL_E2E: '1'
-        run: npx vitest run --project e2e
+        run: npm run test:install-e2e

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "test:watch": "vitest --configLoader runner --project unit",
     "test:integration": "vitest run --configLoader runner --project integration --passWithNoTests",
     "test:e2e": "vitest run --configLoader runner --project e2e --passWithNoTests",
+    "test:install-e2e": "vitest run --configLoader runner --project install-e2e --passWithNoTests",
     "test:console": "npm --workspace console run test",
     "audit:signatures": "node ./scripts/audit-signatures.mjs",
     "deps:policy": "node ./scripts/check-dependency-policy.mjs",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -234,7 +234,10 @@ Install Node ${REQUIRED_NODE_MAJOR} with your package manager and re-run with --
 
   version="$(resolve_node_version)"
   dir="$HYBRIDCLAW_HOME/node"
-  filename="node-v${version}-${PLATFORM_OS}-${PLATFORM_ARCH}.tar.xz"
+  # Use the gzip tarball, not .tar.xz: `tar -xz` only needs gzip (universally
+  # present), whereas `tar -xJ` shells out to an `xz` binary that minimal
+  # Debian/Ubuntu and many container/CI bases don't ship.
+  filename="node-v${version}-${PLATFORM_OS}-${PLATFORM_ARCH}.tar.gz"
   url="https://nodejs.org/dist/v${version}/${filename}"
 
   if is_dry; then
@@ -246,13 +249,17 @@ Install Node ${REQUIRED_NODE_MAJOR} with your package manager and re-run with --
 
   info "Installing Node.js v${version} into ${dir} (no system changes)"
   mkdir -p "$dir"
-  # No .tar.xz suffix: BusyBox mktemp requires the XXXXXX to be the final chars.
+  # No .tar.gz suffix: BusyBox mktemp requires the XXXXXX to be the final chars.
   tarball="$(mktemp "${TMPDIR:-/tmp}/hybridclaw-node.XXXXXX")"
-  trap 'rm -f "$tarball"' EXIT
+  # `${tarball:-}`: this EXIT trap also fires when a later step fails and the
+  # function unwinds, by which point the `local tarball` is out of scope; under
+  # `set -u` a bare "$tarball" would abort with "unbound variable" and mask the
+  # real error.
+  trap 'rm -f "${tarball:-}"' EXIT
   fetch --retry 3 --retry-delay 2 -o "$tarball" "$url" \
     || die "failed to download Node.js from $url"
   verify_node_checksum "$tarball" "$version" "$filename"
-  tar -xJf "$tarball" -C "$dir" --strip-components=1
+  tar -xzf "$tarball" -C "$dir" --strip-components=1
   rm -f "$tarball"
   trap - EXIT
 
@@ -335,6 +342,11 @@ ensure_npm() {
   info "Upgrading npm ${npm_version} -> >=${REQUIRED_NPM}"
   npm install -g "npm@^11" >/dev/null 2>&1 \
     || die "could not upgrade npm to >= ${REQUIRED_NPM} (have ${npm_version}). Upgrade it manually ('npm install -g npm@^11') and re-run."
+  # Forget the cached path to the old npm: when the prefix fallback installed
+  # the new npm into a different bin dir (e.g. ~/.hybridclaw/npm-global/bin), the
+  # shell's command hash still resolves `npm` to the old system binary, so the
+  # version check below would see the pre-upgrade version and wrongly fail.
+  hash -r
   npm_version="$(npm --version)"
   version_ge "$npm_version" "$REQUIRED_NPM" \
     || die "npm is still ${npm_version} after the upgrade; HybridClaw requires >= ${REQUIRED_NPM}."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -234,8 +234,8 @@ Install Node ${REQUIRED_NODE_MAJOR} with your package manager and re-run with --
 
   version="$(resolve_node_version)"
   dir="$HYBRIDCLAW_HOME/node"
-  # Use the gzip tarball, not .tar.xz: `tar -xz` only needs gzip (universally
-  # present), whereas `tar -xJ` shells out to an `xz` binary that minimal
+  # Use the gzip tarball, not .tar.xz: `tar -xzf` only needs gzip (universally
+  # present), whereas `tar -xJf` shells out to an `xz` binary that minimal
   # Debian/Ubuntu and many container/CI bases don't ship.
   filename="node-v${version}-${PLATFORM_OS}-${PLATFORM_ARCH}.tar.gz"
   url="https://nodejs.org/dist/v${version}/${filename}"

--- a/tests/install-script.e2e.test.ts
+++ b/tests/install-script.e2e.test.ts
@@ -1,0 +1,221 @@
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, test } from 'vitest';
+
+/**
+ * End-to-end coverage for the `curl | bash` bootstrap installer
+ * (scripts/install.sh), exercised inside throwaway Docker containers — the
+ * same matrix a maintainer would run by hand before publishing a release.
+ *
+ * Each case mounts the *working-tree* copy of install.sh (so it tests local
+ * edits, not the version on `main`) read-only at /tmp/install.sh and runs it
+ * against a deliberately bare base image. The scenarios pin three behaviours
+ * that have regressed before:
+ *
+ *   1. Managed-Node path needs no `xz`: nodejs.org's tarball is fetched as
+ *      .tar.gz and extracted with `tar -xz`, so a minimal Debian/Ubuntu box
+ *      (no xz-utils) installs cleanly instead of dying in `tar -xJ`.
+ *   2. System-Node + root-owned global prefix installs with no sudo: the
+ *      EACCES fallback repoints npm at ~/.hybridclaw/npm-global, and the npm
+ *      self-upgrade there actually takes effect (the shell's command-hash must
+ *      be cleared, or the version check sees the stale system npm and fails).
+ *   3. musl libc (Alpine) is refused up front with an actionable hint rather
+ *      than downloading an incompatible glibc Node.
+ *
+ * Heavy: each "real install" case downloads Node and runs a full global
+ * `npm install` of the published CLI. Self-selecting — the suite runs only when
+ * a Docker daemon is reachable and skips otherwise, so `vitest --project e2e`
+ * stays safe to invoke on a box without Docker (no opt-in env var to remember).
+ * Override the installed version (default: latest) with
+ * HYBRIDCLAW_E2E_INSTALL_VERSION.
+ */
+
+function dockerAvailable(): boolean {
+  const r = spawnSync('docker', ['info'], { stdio: 'ignore', timeout: 15_000 });
+  return r.status === 0;
+}
+
+const ENABLED = dockerAvailable();
+
+const REPO = fileURLToPath(new URL('..', import.meta.url));
+const SCRIPT = path.join(REPO, 'scripts', 'install.sh');
+const INSTALL_VERSION = process.env.HYBRIDCLAW_E2E_INSTALL_VERSION ?? 'latest';
+
+// Per single install attempt. The "real install" cases pull ~650 npm packages
+// over the network, so the vitest test timeout below leaves room for one retry.
+const INSTALL_ATTEMPT_MS = 300_000;
+const INSTALL_TEST_MS = 660_000;
+const QUICK_TIMEOUT_MS = 150_000;
+
+// npm registry reads flake intermittently (ETIMEDOUT/ECONNRESET) on a fat
+// install; that is infrastructure noise, not an installer bug. Retry the whole
+// container run a bounded number of times — but only on a network signature, so
+// a genuine logic failure still fails fast on the first attempt.
+const NETWORK_ERROR =
+  /ETIMEDOUT|ECONNRESET|ENOTFOUND|EAI_AGAIN|ECONNREFUSED|network (?:read|connectivity|request)/i;
+
+interface ContainerRun {
+  status: number;
+  output: string;
+}
+
+/**
+ * Run a shell snippet inside a fresh `--rm` container with install.sh mounted
+ * read-only at /tmp/install.sh. stdout and stderr are merged so assertions can
+ * match on either (the installer writes warnings/errors to stderr).
+ */
+function runInContainer(opts: {
+  image: string;
+  script: string;
+  user?: string;
+  shell?: 'bash' | 'sh';
+  timeoutMs?: number;
+}): ContainerRun {
+  const { image, script, user, shell = 'bash', timeoutMs } = opts;
+  const args = ['run', '--rm'];
+  if (user) args.push('--user', user);
+  args.push(
+    '--volume',
+    `${SCRIPT}:/tmp/install.sh:ro`,
+    image,
+    shell,
+    '-c',
+    script,
+  );
+  const r = spawnSync('docker', args, {
+    encoding: 'utf-8',
+    timeout: timeoutMs ?? INSTALL_ATTEMPT_MS,
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (r.error && (r.error as NodeJS.ErrnoException).code !== 'ETIMEDOUT') {
+    throw new Error(`docker run failed to start: ${r.error.message}`);
+  }
+  // status is null when the process is killed (e.g. by the timeout); surface
+  // that as a non-zero sentinel so the assertion fails loudly rather than
+  // throwing on a null comparison.
+  return { status: r.status ?? -1, output: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+}
+
+/**
+ * Like runInContainer, but retries on transient npm/network failures (up to
+ * `attempts` total). A non-network failure returns immediately so real bugs are
+ * not masked by retrying.
+ */
+function runInstall(
+  opts: Parameters<typeof runInContainer>[0],
+  attempts = 2,
+): ContainerRun {
+  let last: ContainerRun | undefined;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    last = runInContainer(opts);
+    if (last.status === 0 || !NETWORK_ERROR.test(last.output)) return last;
+    if (attempt < attempts) {
+      console.warn(
+        `[install-e2e] transient network failure on ${opts.image} (attempt ${attempt}/${attempts}); retrying`,
+      );
+    }
+  }
+  return last as ContainerRun;
+}
+
+describe.skipIf(!ENABLED)('install.sh bootstrap (Docker)', () => {
+  test(
+    'clean Debian/Ubuntu without xz: managed Node via gzip tarball, then CLI install',
+    () => {
+      const { status, output } = runInstall({
+        image: 'ubuntu:24.04',
+        script: [
+          'set -e',
+          'apt-get update -qq >/dev/null 2>&1',
+          // curl + ca-certificates is the floor a `curl | bash` user already
+          // meets; python3/make/g++ let native modules compile. We pointedly do
+          // NOT install xz-utils — the managed-Node path must not need it.
+          'apt-get install -y -qq curl ca-certificates python3 make g++ >/dev/null 2>&1',
+          'export npm_config_fetch_retries=5',
+          `bash /tmp/install.sh --no-prompt --verify --version ${INSTALL_VERSION}`,
+        ].join('\n'),
+      });
+
+      // Regression guards for the two bugs this path used to hit.
+      expect(output).not.toMatch(/xz: Cannot exec/);
+      expect(output).not.toMatch(/unbound variable/);
+      // Proof the download + checksum + extract stage actually ran.
+      expect(output).toContain('Verified Node.js download (sha256)');
+      expect(output).toMatch(/hybridclaw --version -> \d+\.\d+\.\d+/);
+      expect(status).toBe(0);
+    },
+    INSTALL_TEST_MS,
+  );
+
+  test(
+    'system Node 22, non-root, root-owned prefix: no-sudo fallback + effective npm upgrade',
+    () => {
+      const { status, output } = runInstall({
+        image: 'node:22',
+        user: 'node',
+        script: [
+          'export npm_config_fetch_retries=5',
+          'bash /tmp/install.sh --no-prompt --verify',
+          'echo "PREFIX=$(npm config get prefix)"',
+        ].join('\n'),
+      });
+
+      // EACCES on the root-owned /usr/local prefix → user-local prefix, no sudo.
+      expect(output).toMatch(
+        /not writable; using .*npm-global instead \(no sudo\)/,
+      );
+      expect(output).toContain('PREFIX=/home/node/.hybridclaw/npm-global');
+      // The npm self-upgrade must actually take effect: the old failure printed
+      // "npm is still <old> after the upgrade" because the shell's command-hash
+      // still resolved the stale system npm.
+      expect(output).not.toMatch(/is still .* after the upgrade/);
+      expect(output).toMatch(/npm \d+\.\d+\.\d+ ready/);
+      expect(output).toMatch(/hybridclaw --version -> \d+\.\d+\.\d+/);
+      expect(status).toBe(0);
+    },
+    INSTALL_TEST_MS,
+  );
+
+  test(
+    'musl libc (Alpine) is refused with a --skip-node hint, no partial install',
+    () => {
+      const { status, output } = runInContainer({
+        image: 'alpine:3.20',
+        shell: 'sh',
+        timeoutMs: QUICK_TIMEOUT_MS,
+        script: [
+          'apk add --no-cache bash curl >/dev/null 2>&1',
+          'bash /tmp/install.sh --no-prompt',
+        ].join('\n'),
+      });
+
+      expect(output).toMatch(/musl/i);
+      expect(output).toContain('--skip-node');
+      expect(status).not.toBe(0);
+    },
+    QUICK_TIMEOUT_MS,
+  );
+
+  test(
+    '--dry-run prints the plan and touches nothing',
+    () => {
+      const { status, output } = runInContainer({
+        image: 'ubuntu:24.04',
+        timeoutMs: QUICK_TIMEOUT_MS,
+        script: [
+          'apt-get update -qq >/dev/null 2>&1',
+          'apt-get install -y -qq curl ca-certificates >/dev/null 2>&1',
+          'bash /tmp/install.sh --dry-run --no-prompt',
+          'echo "HOME_EXISTS=$([ -e "$HOME/.hybridclaw" ] && echo yes || echo no)"',
+        ].join('\n'),
+      });
+
+      expect(output).toContain('[dry-run]');
+      expect(output).toContain('HOME_EXISTS=no');
+      expect(status).toBe(0);
+    },
+    QUICK_TIMEOUT_MS,
+  );
+});

--- a/tests/install-script.e2e.test.ts
+++ b/tests/install-script.e2e.test.ts
@@ -15,8 +15,8 @@ import { describe, expect, test } from 'vitest';
  * that have regressed before:
  *
  *   1. Managed-Node path needs no `xz`: nodejs.org's tarball is fetched as
- *      .tar.gz and extracted with `tar -xz`, so a minimal Debian/Ubuntu box
- *      (no xz-utils) installs cleanly instead of dying in `tar -xJ`.
+ *      .tar.gz and extracted with `tar -xzf`, so a minimal Debian/Ubuntu box
+ *      (no xz-utils) installs cleanly instead of dying in `tar -xJf`.
  *   2. System-Node + root-owned global prefix installs with no sudo: the
  *      EACCES fallback repoints npm at ~/.hybridclaw/npm-global, and the npm
  *      self-upgrade there actually takes effect (the shell's command-hash must
@@ -25,19 +25,24 @@ import { describe, expect, test } from 'vitest';
  *      than downloading an incompatible glibc Node.
  *
  * Heavy: each "real install" case downloads Node and runs a full global
- * `npm install` of the published CLI. Self-selecting — the suite runs only when
- * a Docker daemon is reachable and skips otherwise, so `vitest --project e2e`
- * stays safe to invoke on a box without Docker (no opt-in env var to remember).
- * Override the installed version (default: latest) with
- * HYBRIDCLAW_E2E_INSTALL_VERSION.
+ * `npm install` of the published CLI (~6-7 min total). Opt-in via
+ * HYBRIDCLAW_RUN_INSTALL_E2E=1 *and* a reachable Docker daemon. The explicit
+ * flag matters: CI invokes `vitest run --project e2e` from several jobs
+ * (gateway/agent/CLI/npm), all on Ubuntu runners that have Docker — without the
+ * flag this matrix would piggyback on every one of them. Override the installed
+ * version (default: latest) with HYBRIDCLAW_E2E_INSTALL_VERSION.
  */
+
+const RUN = process.env.HYBRIDCLAW_RUN_INSTALL_E2E === '1';
 
 function dockerAvailable(): boolean {
   const r = spawnSync('docker', ['info'], { stdio: 'ignore', timeout: 15_000 });
   return r.status === 0;
 }
 
-const ENABLED = dockerAvailable();
+// Flag gates *whether* the suite is meant to run here; the Docker probe lets an
+// opted-in box without a daemon skip gracefully instead of erroring.
+const ENABLED = RUN && dockerAvailable();
 
 const REPO = fileURLToPath(new URL('..', import.meta.url));
 const SCRIPT = path.join(REPO, 'scripts', 'install.sh');

--- a/tests/install-script.install-e2e.test.ts
+++ b/tests/install-script.install-e2e.test.ts
@@ -25,24 +25,20 @@ import { describe, expect, test } from 'vitest';
  *      than downloading an incompatible glibc Node.
  *
  * Heavy: each "real install" case downloads Node and runs a full global
- * `npm install` of the published CLI (~6-7 min total). Opt-in via
- * HYBRIDCLAW_RUN_INSTALL_E2E=1 *and* a reachable Docker daemon. The explicit
- * flag matters: CI invokes `vitest run --project e2e` from several jobs
- * (gateway/agent/CLI/npm), all on Ubuntu runners that have Docker — without the
- * flag this matrix would piggyback on every one of them. Override the installed
- * version (default: latest) with HYBRIDCLAW_E2E_INSTALL_VERSION.
+ * `npm install` of the published CLI (~6-7 min total). This file lives in its
+ * own `install-e2e` vitest project (see vitest.config.ts), so the several CI
+ * jobs that run `vitest run --project e2e` never pull it in — no opt-in env var
+ * needed. Run it with `npm run test:install-e2e` (or `--project install-e2e`).
+ * It self-selects on a reachable Docker daemon and skips otherwise. Override the
+ * installed version (default: latest) with HYBRIDCLAW_E2E_INSTALL_VERSION.
  */
-
-const RUN = process.env.HYBRIDCLAW_RUN_INSTALL_E2E === '1';
 
 function dockerAvailable(): boolean {
   const r = spawnSync('docker', ['info'], { stdio: 'ignore', timeout: 15_000 });
   return r.status === 0;
 }
 
-// Flag gates *whether* the suite is meant to run here; the Docker probe lets an
-// opted-in box without a daemon skip gracefully instead of erroring.
-const ENABLED = RUN && dockerAvailable();
+const ENABLED = dockerAvailable();
 
 const REPO = fileURLToPath(new URL('..', import.meta.url));
 const SCRIPT = path.join(REPO, 'scripts', 'install.sh');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,14 @@ const sharedTestConfig = {
 
 const sharedExclude = ['node_modules/**', 'dist/**', 'container/**'];
 
+// The installer Docker matrix (scripts/install.sh) lives in its own project so a
+// plain `vitest run --project e2e` — invoked by several CI jobs — never pulls it
+// in. It is gated only on a reachable Docker daemon (no opt-in env var); run it
+// explicitly with `--project install-e2e` (see the test:install-e2e script).
+// Note the `-e2e` suffix does NOT match the `.e2e.test.ts` glob, so it must be
+// excluded from the broad `unit` include explicitly.
+const installE2eGlob = 'tests/**/*.install-e2e.test.ts';
+
 export default defineConfig({
   test: {
     coverage: {
@@ -41,6 +49,7 @@ export default defineConfig({
           exclude: [
             'tests/**/*.integration.test.ts',
             'tests/**/*.e2e.test.ts',
+            installE2eGlob,
             'tests/**/*.live.test.ts',
             ...sharedExclude,
           ],
@@ -59,8 +68,16 @@ export default defineConfig({
           ...sharedTestConfig,
           name: 'e2e',
           include: ['tests/**/*.e2e.test.ts'],
-          exclude: sharedExclude,
+          exclude: [installE2eGlob, ...sharedExclude],
           globalSetup: ['tests/helpers/e2e-global-setup.ts'],
+        },
+      },
+      {
+        test: {
+          ...sharedTestConfig,
+          name: 'install-e2e',
+          include: [installE2eGlob],
+          exclude: sharedExclude,
         },
       },
       {


### PR DESCRIPTION
## Summary

Found by running the new `scripts/install.sh` (#1149) in clean Docker containers. Two of the most realistic "clean env" paths failed before this PR; only `root + xz present + build tools` worked.

### Bugs fixed

1. **`xz` was a required-but-unchecked dependency.** Node was downloaded as `.tar.xz` and extracted with `tar -xJf`, which shells out to the `xz` binary. Minimal Debian/Ubuntu and many container/CI bases don't ship it, so a clean box died with `tar (child): xz: Cannot exec`. Now downloads `.tar.gz` and extracts with `tar -xzf` (gzip is universal) — removes the dependency entirely. nodejs.org publishes `.tar.gz` with matching `SHASUMS256.txt` entries, so checksum verification is unchanged.

2. **`tarball: unbound variable` masked the real error.** The EXIT trap referenced a bare `"$tarball"`, but `tarball` is function-local and out of scope by the time the trap fires on a later failure; under `set -u` this aborted with a confusing message instead of the actual cause. Now uses `"${tarball:-}"`.

3. **The no-sudo / EACCES fallback npm upgrade failed.** On a system Node 22 with npm < 11.10.0 and a root-owned global prefix (the official `node:22` image, distro node packages, …), the EACCES detection correctly repointed npm at `~/.hybridclaw/npm-global` (no sudo ✓), but the self-upgrade then died with `npm is still 10.9.8 after the upgrade`: the new npm installed into a different bin dir, while bash's command hash still resolved the old system npm. Added `hash -r` before the version re-check.

### Test added

`tests/install-script.e2e.test.ts` runs the **working-tree** installer in throwaway Docker containers — the matrix used to find these bugs:

- clean `ubuntu:24.04` **without** `xz` → managed Node (gzip) + full CLI install (regression for #1/#2)
- `node:22` as non-root with a root-owned prefix → no-sudo fallback + effective npm upgrade (regression for #3)
- `alpine:3.20` → musl refused with the `--skip-node` hint
- `--dry-run` → prints the plan, touches nothing

Self-selecting on a reachable Docker daemon (skips otherwise, so `vitest --project e2e` stays safe to invoke anywhere — no opt-in env var). A bounded retry fires only on transient npm/network error signatures, so real bugs still fail fast.

## Test plan

- `bash scripts/install.test.sh` — 26/26 offline unit tests pass
- `bash -n scripts/install.sh` — clean
- e2e suite — **4/4 pass** (~6.5 min):
  - clean Debian/Ubuntu without xz ✓
  - system Node 22 non-root, root-owned prefix ✓
  - musl (Alpine) rejection ✓
  - --dry-run ✓