### PR TITLE
fix: drop consumer npm engine pin and clear install warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,8 +171,11 @@ should verify no broken references.
 
 ### Prerequisites
 
-- Node.js 22 (matches CI and `engines` field)
-- npm
+- Node.js 22 (matches CI and the `engines` field)
+- npm 11.10+ — run `corepack enable` so repo commands use the `packageManager`
+  pin (`npm@11.10.0`). Contributors need this version because npm's
+  `min-release-age` supply-chain gate (see `SECURITY.md`) only takes effect on
+  npm 11.10+; it is deliberately not enforced on end users via `engines.npm`.
 - Docker when working on container-mode behavior or image builds
 
 ### Common Commands

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,9 @@ they are required to land a concrete fix.
 ## Prerequisites
 
 - Node.js 22
-- npm
+- npm 11.10+ — run `corepack enable` to pick up the repo's `packageManager`
+  pin (`npm@11.10.0`), which keeps npm's `min-release-age` supply-chain gate
+  active during dependency updates
 - Docker if you need to build or debug the container runtime
 - Optional credentials for live flows such as HybridAI auth or Discord
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -153,10 +153,16 @@ hybridclaw audit verify <sessionId>
 HybridClaw treats npm lockfiles and package-manager configuration as security
 controls:
 
-- `.npmrc` enforces exact saves, strict engines, and a seven-day minimum release
-  age.
-- `package.json` requires npm 11.10+ because older npm versions do not enforce
-  the release-age policy.
+- `.npmrc` enforces exact saves, a strict Node engine, and a seven-day minimum
+  release age.
+- The development and build toolchain pins npm 11.10+ through the
+  `packageManager` field (Corepack), CI, and Docker, because older npm versions
+  do not enforce the release-age policy. This requirement is intentionally
+  **not** expressed as a consumer-facing `engines.npm` constraint: the published
+  package ships a fully pinned `npm-shrinkwrap.json`, so install-time
+  release-age gating is moot for end users, and an `engines.npm` bound would
+  only emit spurious `EBADENGINE` warnings for anyone installing the CLI on the
+  npm that ships with Node 22.
 - CI upgrades to the pinned npm version before running `npm ci`, so pull
   requests and release publishes use the same install policy as local
   development.

--- a/console/package.json
+++ b/console/package.json
@@ -14,11 +14,11 @@
     "@tanstack/react-query": "5.90.21",
     "@tanstack/react-router": "1.167.4",
     "@xterm/addon-fit": "0.11.0",
+    "@xterm/xterm": "5.5.0",
     "marked": "17.0.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "sanitize-html": "2.17.1",
-    "xterm": "5.3.0"
+    "sanitize-html": "2.17.1"
   },
   "devDependencies": {
     "@testing-library/react": "16.3.2",

--- a/console/src/routes/terminal.tsx
+++ b/console/src/routes/terminal.tsx
@@ -1,6 +1,6 @@
 import { FitAddon } from '@xterm/addon-fit';
-import { Terminal } from 'xterm';
-import 'xterm/css/xterm.css';
+import { Terminal } from '@xterm/xterm';
+import '@xterm/xterm/css/xterm.css';
 import {
   type MutableRefObject,
   useCallback,

--- a/container/npm-shrinkwrap.json
+++ b/container/npm-shrinkwrap.json
@@ -25,8 +25,7 @@
         "typescript": "5.9.3"
       },
       "engines": {
-        "node": "22.x",
-        "npm": ">=11.10.0 <12"
+        "node": "22.x"
       },
       "optionalDependencies": {
         "@napi-rs/canvas": "0.1.96"

--- a/container/package-lock.json
+++ b/container/package-lock.json
@@ -25,8 +25,7 @@
         "typescript": "5.9.3"
       },
       "engines": {
-        "node": "22.x",
-        "npm": ">=11.10.0 <12"
+        "node": "22.x"
       },
       "optionalDependencies": {
         "@napi-rs/canvas": "0.1.96"

--- a/container/package.json
+++ b/container/package.json
@@ -5,8 +5,7 @@
   "main": "dist/index.js",
   "packageManager": "npm@11.10.0",
   "engines": {
-    "node": "22.x",
-    "npm": ">=11.10.0 <12"
+    "node": "22.x"
   },
   "files": [
     "dist/",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@hybridaione/hybridclaw",
       "version": "0.22.0",
-      "packageManager": "npm@11.10.0",
       "hasInstallScript": true,
       "workspaces": [
         "desktop",
@@ -75,8 +74,7 @@
         "vitest": "4.1.7"
       },
       "engines": {
-        "node": "22.x",
-        "npm": ">=11.10.0 <12"
+        "node": "22.x"
       },
       "optionalDependencies": {
         "appdmg": "0.6.6"
@@ -89,11 +87,11 @@
         "@tanstack/react-query": "5.90.21",
         "@tanstack/react-router": "1.167.4",
         "@xterm/addon-fit": "0.11.0",
+        "@xterm/xterm": "5.5.0",
         "marked": "17.0.4",
         "react": "19.2.4",
         "react-dom": "19.2.4",
-        "sanitize-html": "2.17.1",
-        "xterm": "5.3.0"
+        "sanitize-html": "2.17.1"
       },
       "devDependencies": {
         "@testing-library/react": "16.3.2",
@@ -127,8 +125,7 @@
         "typescript": "5.9.3"
       },
       "engines": {
-        "node": "22.x",
-        "npm": ">=11.10.0 <12"
+        "node": "22.x"
       },
       "optionalDependencies": {
         "@napi-rs/canvas": "0.1.96"
@@ -6755,6 +6752,12 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
       "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
       "license": "MIT"
     },
     "node_modules/@zip.js/zip.js": {
@@ -18345,13 +18348,6 @@
       "engines": {
         "node": ">=0.4"
       }
-    },
-    "node_modules/xterm": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
-      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
-      "deprecated": "This package is now deprecated. Move to @xterm/xterm instead.",
-      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@hybridaione/hybridclaw",
       "version": "0.22.0",
-      "packageManager": "npm@11.10.0",
       "hasInstallScript": true,
       "workspaces": [
         "desktop",
@@ -75,8 +74,7 @@
         "vitest": "4.1.7"
       },
       "engines": {
-        "node": "22.x",
-        "npm": ">=11.10.0 <12"
+        "node": "22.x"
       },
       "optionalDependencies": {
         "appdmg": "0.6.6"
@@ -89,11 +87,11 @@
         "@tanstack/react-query": "5.90.21",
         "@tanstack/react-router": "1.167.4",
         "@xterm/addon-fit": "0.11.0",
+        "@xterm/xterm": "5.5.0",
         "marked": "17.0.4",
         "react": "19.2.4",
         "react-dom": "19.2.4",
-        "sanitize-html": "2.17.1",
-        "xterm": "5.3.0"
+        "sanitize-html": "2.17.1"
       },
       "devDependencies": {
         "@testing-library/react": "16.3.2",
@@ -127,8 +125,7 @@
         "typescript": "5.9.3"
       },
       "engines": {
-        "node": "22.x",
-        "npm": ">=11.10.0 <12"
+        "node": "22.x"
       },
       "optionalDependencies": {
         "@napi-rs/canvas": "0.1.96"
@@ -6755,6 +6752,12 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
       "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
       "license": "MIT"
     },
     "node_modules/@zip.js/zip.js": {
@@ -18345,13 +18348,6 @@
       "engines": {
         "node": ">=0.4"
       }
-    },
-    "node_modules/xterm": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
-      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
-      "deprecated": "This package is now deprecated. Move to @xterm/xterm instead.",
-      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "container"
   ],
   "engines": {
-    "node": "22.x",
-    "npm": ">=11.10.0 <12"
+    "node": "22.x"
   },
   "publishConfig": {
     "access": "public"

--- a/scripts/dependency-policy-baseline.json
+++ b/scripts/dependency-policy-baseline.json
@@ -1,9 +1,9 @@
 {
   "lockfiles": {
-    "package-lock.json": "d83f24f9fcb65c7a9c59dc48e614ed90c8de04a0aea51dee61a662e6258dea91",
-    "npm-shrinkwrap.json": "d83f24f9fcb65c7a9c59dc48e614ed90c8de04a0aea51dee61a662e6258dea91",
-    "container/package-lock.json": "dc7c12b348c79903102cb50d1e6cc037dab14735476ef4a6beb7852737183239",
-    "container/npm-shrinkwrap.json": "dc7c12b348c79903102cb50d1e6cc037dab14735476ef4a6beb7852737183239",
+    "package-lock.json": "3990a47bab05bc52b4df3187fcca13178c5ff162db5f8e72ef8d10fc911deafa",
+    "npm-shrinkwrap.json": "3990a47bab05bc52b4df3187fcca13178c5ff162db5f8e72ef8d10fc911deafa",
+    "container/package-lock.json": "62ef7ea75396454f6febe9aae45eadb762b41637fb9479dcef6bd3891ffb32d3",
+    "container/npm-shrinkwrap.json": "62ef7ea75396454f6febe9aae45eadb762b41637fb9479dcef6bd3891ffb32d3",
     "plugins/brevo-email/package-lock.json": "3377225eb3bdbb252eaa28ad420b9a725ea1da533417388557aa1984730229b5"
   }
 }

--- a/src/update.ts
+++ b/src/update.ts
@@ -326,10 +326,17 @@ function buildUpdateCommand(
       return { bin: 'bun', args, display: `bun ${args.join(' ')}` };
     }
     default: {
+      // `--no-fund`/`--no-audit` are npm-specific and trim the funding/audit
+      // noise from the self-update output. They are intentionally not added to
+      // the pnpm/yarn/bun branches, which don't support these flags and don't
+      // emit that output. Deprecation warnings are left visible on purpose (see
+      // SECURITY.md and the npm supply-chain notes).
       const args = [
         'install',
         '-g',
         '--ignore-scripts',
+        '--no-fund',
+        '--no-audit',
         `${packageName}@latest`,
       ];
       return { bin: 'npm', args, display: `npm ${args.join(' ')}` };

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -160,7 +160,14 @@ describe('runUpdateCommand', () => {
     expect(requestExternalGatewayRestartMock).toHaveBeenCalledTimes(1);
     expect(spawnMock).toHaveBeenCalledWith(
       'npm',
-      ['install', '-g', '--ignore-scripts', '@hybridaione/hybridclaw@latest'],
+      [
+        'install',
+        '-g',
+        '--ignore-scripts',
+        '--no-fund',
+        '--no-audit',
+        '@hybridaione/hybridclaw@latest',
+      ],
       { stdio: 'inherit' },
     );
     const messages = logSpy.mock.calls.map((call) => call[0]);
@@ -623,7 +630,14 @@ describe('maybePromptStartupUpdate', () => {
     // Delegates to the full update command, which runs the global install.
     expect(spawnMock).toHaveBeenCalledWith(
       'npm',
-      ['install', '-g', '--ignore-scripts', '@hybridaione/hybridclaw@latest'],
+      [
+        'install',
+        '-g',
+        '--ignore-scripts',
+        '--no-fund',
+        '--no-audit',
+        '@hybridaione/hybridclaw@latest',
+      ],
       { stdio: 'inherit' },
     );
     expect(installRoot).toContain('@hybridaione');


### PR DESCRIPTION
## Why

Running `hybridclaw update` (or any `npm install -g @hybridaione/hybridclaw`) printed a wall of warnings, starting with `EBADENGINE`:

```
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: '@hybridaione/hybridclaw@0.22.0',
npm warn EBADENGINE   required: { node: '22.x', npm: '>=11.10.0 <12' },
npm warn EBADENGINE   current: { node: 'v22.22.2', npm: '10.9.7' }
```

The npm pin came from #948's supply-chain hardening, but as a **consumer-facing** `engines.npm` constraint it provides no value: the published package ships a fully pinned `npm-shrinkwrap.json`, and `.npmrc` (where `min-release-age` lives) is **not** published — so install-time release-age gating is moot for end users. The only effect was an `EBADENGINE` warning for everyone on the npm that ships with Node 22 (10.x).

## What

- **Remove `engines.npm`** from the root and container manifests (keep `node: 22.x`); sync the paired `package-lock.json`/`npm-shrinkwrap.json` files and refresh the dependency-policy baseline hashes. The npm 11.10+ requirement stays enforced for the **dev/build** environment via `packageManager` (Corepack), CI, and Docker — none of which touch consumers.
- **Docs**: `SECURITY.md` reframes the npm pin as a dev/build control and explains why it's deliberately not a consumer `engines` bound; `AGENTS.md`/`CONTRIBUTING.md` add the `corepack enable` step so contributors still get npm 11.10.
- **`xterm@5.3.0` → `@xterm/xterm@5.5.0`** in the console workspace — the one deprecation we own (renamed package; same major as the already-pinned `@xterm/addon-fit@0.11.0`).
- **Self-update tidy**: `--no-fund --no-audit` added to the generated npm update command (npm branch only — pnpm/yarn/bun don't support them). `--loglevel=error` intentionally omitted so real warnings stay visible.

## The other deprecation warnings (intentionally left as-is)

`lodash.isequal`, `prebuild-install`, `boolean`, `whatwg-encoding`, `glob@7/10`, `inflight`, `rimraf@2` are all **upstream-blocked transitives** — every direct dependency that pulls them in (`better-sqlite3`, `@huggingface/transformers`, `camoufox-js`/`header-generator`, `cheerio`, `webdriverio`, `electron-builder`, `temp`) is already at its latest version with the old pin intact. `npm audit` reports **0 vulnerabilities**. Forcing newer versions via `overrides` would cross majors the consumers pin against and risk breakage — the same call [ESLint made](https://github.com/eslint/eslint/issues/18573) for the identical `inflight` case. These clear when upstream updates (e.g. `boolean` once transformers.js adopts `onnxruntime-node ≥1.26`; `prebuild-install` tracked in [better-sqlite3#655](https://github.com/WiseLibs/better-sqlite3/issues/655)).

## Testing

- `npm ci` on npm 10.9.7 → **no `EBADENGINE`**
- Root `typecheck` (console + desktop) passes
- Console `vite build` bundles `@xterm/xterm` correctly
- `check-dependency-policy.mjs --base main` → exit 0 (baseline updated)
- Lockfile pairs verified byte-identical / in sync