### PR TITLE
[codex] Keep slash autocomplete for argument values

### DIFF
--- a/src/tui-slash-menu.ts
+++ b/src/tui-slash-menu.ts
@@ -348,7 +348,10 @@ function normalizePatternLiteral(token: string): string {
 
 function isArgumentPlaceholder(token: string): boolean {
   const match = /^<([^>]+)>$/.exec(token) ?? /^\[([^\]]+)\]$/.exec(token);
-  return Boolean(match?.[1].trim() && !match[1].includes('|'));
+  const placeholder = match?.[1].trim() ?? '';
+  return Boolean(
+    placeholder && !placeholder.includes('|') && !placeholder.startsWith('-'),
+  );
 }
 
 function scoreCommandPrefixWithArguments(query: string, searchTerm: string) {

--- a/src/tui-slash-menu.ts
+++ b/src/tui-slash-menu.ts
@@ -342,6 +342,58 @@ function subsequenceScore(query: string, target: string): number | null {
   );
 }
 
+function normalizePatternLiteral(token: string): string {
+  return normalizeSearchText(token.replace(/^\/+/, ''));
+}
+
+function isArgumentPlaceholder(token: string): boolean {
+  const match = /^<([^>]+)>$/.exec(token) ?? /^\[([^\]]+)\]$/.exec(token);
+  return Boolean(match?.[1].trim() && !match[1].includes('|'));
+}
+
+function scoreCommandPrefixWithArguments(query: string, searchTerm: string) {
+  const queryTokens = normalizeSearchText(query).split(/\s+/).filter(Boolean);
+  if (queryTokens.length < 2) return null;
+
+  const patternTokens = searchTerm.trim().split(/\s+/).filter(Boolean);
+  const commandTokens: string[] = [];
+  let hasArgumentPlaceholder = false;
+
+  for (const patternToken of patternTokens) {
+    if (/^<[^>]+>$/.test(patternToken) || /^\[[^\]]+\]$/.test(patternToken)) {
+      hasArgumentPlaceholder = isArgumentPlaceholder(patternToken);
+      break;
+    }
+
+    const literal = normalizePatternLiteral(patternToken);
+    if (literal) commandTokens.push(literal);
+  }
+
+  if (
+    !hasArgumentPlaceholder ||
+    commandTokens.length === 0 ||
+    queryTokens.length <= commandTokens.length
+  ) {
+    return null;
+  }
+
+  let prefixPenalty = 0;
+  for (let i = 0; i < commandTokens.length; i += 1) {
+    const commandToken = commandTokens[i];
+    const queryToken = queryTokens[i];
+    if (commandToken === queryToken) continue;
+    if (!commandToken.startsWith(queryToken)) return null;
+    prefixPenalty += commandToken.length - queryToken.length;
+  }
+
+  return (
+    SCORE_WEIGHTS.substringNormalizedBase +
+    commandTokens.length * 20 -
+    (queryTokens.length - commandTokens.length) -
+    prefixPenalty
+  );
+}
+
 function scoreSearchTerm(query: string, searchTerm: string): number | null {
   if (!query) return 0;
 
@@ -370,6 +422,9 @@ function scoreSearchTerm(query: string, searchTerm: string): number | null {
       substringIndex * SCORE_WEIGHTS.substringIndexPenalty
     );
   }
+
+  const commandPrefixScore = scoreCommandPrefixWithArguments(query, searchTerm);
+  if (commandPrefixScore != null) return commandPrefixScore;
 
   const compactQuery = compactSearchText(normalizedQuery);
   const compactSearchTerm = compactSearchText(normalizedSearchTerm);

--- a/tests/tui-slash-menu.test.ts
+++ b/tests/tui-slash-menu.test.ts
@@ -221,6 +221,47 @@ test('fuzzy ranking can target nested command variants', () => {
   expect(ranked[0]?.label).toBe('/approve agent [approval_id]');
 });
 
+test('slash menu placeholder arguments match concrete values', () => {
+  const ranked = rankTuiSlashMenuEntries(
+    buildTuiSlashMenuEntries([], 'web'),
+    'agent create bob',
+  );
+
+  expect(ranked[0]?.label).toBe('/agent create <id> [model]');
+});
+
+test('slash menu argument matching works across command families', () => {
+  const entries = buildTuiSlashMenuEntries();
+
+  expect(rankTuiSlashMenuEntries(entries, 'mcp reconnect datalion')[0]?.label).toBe(
+    '/mcp reconnect <name>',
+  );
+  expect(
+    rankTuiSlashMenuEntries(entries, 'policy allow example.com')[0]?.label,
+  ).toBe('/policy allow <host>');
+  expect(rankTuiSlashMenuEntries(entries, 'model default gpt-5')[0]?.label).toBe(
+    '/model default [name]',
+  );
+});
+
+test('slash menu placeholder matching keeps choice groups literal', () => {
+  const ranked = rankTuiSlashMenuEntries(
+    buildTuiSlashMenuEntries([], 'web'),
+    'agent banana',
+  );
+
+  expect(ranked).toEqual([]);
+});
+
+test('slash menu argument matching still ignores unknown commands', () => {
+  const ranked = rankTuiSlashMenuEntries(
+    buildTuiSlashMenuEntries(),
+    'zzz datalion',
+  );
+
+  expect(ranked).toEqual([]);
+});
+
 test('includes plugin commands in slash menu results', () => {
   const entries = buildTuiSlashMenuEntries([
     {
@@ -365,7 +406,7 @@ test('second escape clears the current prompt line after dismissing the menu', (
 test('arrow up falls through to readline history when slash query has no matches', () => {
   const { rl, operations } = buildControllerHarness();
 
-  rl.line = '/mcp reconnect datalion';
+  rl.line = '/zzz datalion';
   rl.cursor = rl.line.length;
   operations.length = 0;
 
@@ -379,7 +420,7 @@ test('arrow up falls through to readline history when slash query has no matches
 test('arrow down falls through to readline history when slash query has no matches', () => {
   const { rl, operations } = buildControllerHarness();
 
-  rl.line = '/mcp reconnect datalion';
+  rl.line = '/zzz datalion';
   rl.cursor = rl.line.length;
   operations.length = 0;
 

--- a/tests/tui-slash-menu.test.ts
+++ b/tests/tui-slash-menu.test.ts
@@ -253,6 +253,25 @@ test('slash menu placeholder matching keeps choice groups literal', () => {
   expect(ranked).toEqual([]);
 });
 
+test('slash menu argument matching keeps flag placeholders literal', () => {
+  const entries = [
+    {
+      id: 'demo',
+      label: '/demo [--json]',
+      insertText: '/demo ',
+      description: 'Demo flag command',
+      searchTerms: ['/demo [--json]'],
+      depth: 1,
+      sortIndex: 0,
+    },
+  ];
+
+  expect(rankTuiSlashMenuEntries(entries, 'demo anything')).toEqual([]);
+  expect(rankTuiSlashMenuEntries(entries, 'demo --json')[0]?.label).toBe(
+    '/demo [--json]',
+  );
+});
+
 test('slash menu argument matching still ignores unknown commands', () => {
   const ranked = rankTuiSlashMenuEntries(
     buildTuiSlashMenuEntries(),


### PR DESCRIPTION
## Summary

Fix slash-menu ranking so commands with declared argument placeholders keep matching after the user types concrete argument values.

This keeps autocomplete active for entries like `/agent create bob`, `/mcp reconnect datalion`, `/policy allow example.com`, and `/model default gpt-5` instead of falling through to an empty "No commands match" state. The matcher stays simple: it scores the literal command prefix before a simple placeholder such as `<id>` or `[model]`, and it does not treat choice groups like `<info|list|...>` as arbitrary wildcards.

## Root Cause

The autocomplete scorer compared the full typed query against menu labels. Once the query included a real argument value, such as `bob`, it no longer matched labels containing placeholders like `<id>`.

## Validation

- `vitest run tests/tui-slash-menu.test.ts tests/tui-slash-menu-render.test.ts`
- `npx biome check src/tui-slash-menu.ts src/gateway/gateway-http-server.ts tests/tui-slash-menu.test.ts`
- `tsc --noEmit`