### PR TITLE
[codex] Clarify interrupted agent shutdown errors

### DIFF
--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -53,6 +53,7 @@ import {
   WORKSPACE_ROOT,
   WORKSPACE_ROOT_DISPLAY,
 } from './runtime-paths.js';
+import { buildInterruptedShutdownOutput } from './shutdown-output.js';
 import {
   advanceStalledTurnCount,
   MAX_STALLED_MODEL_TURNS,
@@ -178,6 +179,7 @@ let storedTaskModels: ContainerInput['taskModels'];
 let mcpClientManager: McpClientManager | null = null;
 let mcpConfigWatcher: McpConfigWatcher | null = null;
 let shutdownPromise: Promise<never> | null = null;
+let requestInFlight = false;
 
 function cloneTaskModels(
   taskModels: ContainerInput['taskModels'],
@@ -296,6 +298,16 @@ async function shutdownAgentProcess(
     process.exit(exitCode);
   })();
   return shutdownPromise;
+}
+
+function writeInterruptedShutdownOutput(reason: NodeJS.Signals): void {
+  if (!requestInFlight) return;
+  requestInFlight = false;
+  try {
+    writeOutput(buildInterruptedShutdownOutput(reason));
+  } catch (error) {
+    console.error('[hybridclaw-agent] shutdown output write failed:', error);
+  }
 }
 
 function normalizePathSlashes(raw: string): string {
@@ -1952,15 +1964,18 @@ async function main(): Promise<void> {
   // media, and model setup still runs after input and before agent start.
   console.error('[hybridclaw-agent] ready for input');
   process.once('SIGINT', () => {
+    writeInterruptedShutdownOutput('SIGINT');
     void shutdownAgentProcess(0, 'SIGINT');
   });
   process.once('SIGTERM', () => {
+    writeInterruptedShutdownOutput('SIGTERM');
     void shutdownAgentProcess(0, 'SIGTERM');
   });
 
   // First request arrives via stdin (contains apiKey — never written to disk)
   const stdinData = await readStdinLine();
   const firstInput: ContainerInput = JSON.parse(stdinData);
+  requestInFlight = true;
   applyRuntimeEnv(firstInput.runtimeEnv);
   storedApiKey = firstInput.apiKey;
   storedRequestHeaders = { ...(firstInput.requestHeaders || {}) };
@@ -2115,6 +2130,7 @@ async function main(): Promise<void> {
 
   firstOutput.sideEffects = getPendingSideEffects();
   writeOutput(firstOutput);
+  requestInFlight = false;
   console.error(
     `[hybridclaw-agent] first request complete: ${firstOutput.status}`,
   );
@@ -2138,6 +2154,7 @@ async function main(): Promise<void> {
       continue;
     }
 
+    requestInFlight = true;
     applyRuntimeEnv(input.runtimeEnv);
 
     // Use stored apiKey — IPC file no longer contains it
@@ -2222,6 +2239,7 @@ async function main(): Promise<void> {
       };
       immediate.sideEffects = getPendingSideEffects();
       writeOutput(immediate);
+      requestInFlight = false;
       console.error('[approval] resolved user response without model run');
       continue;
     }
@@ -2300,6 +2318,7 @@ async function main(): Promise<void> {
 
     output.sideEffects = getPendingSideEffects();
     writeOutput(output);
+    requestInFlight = false;
     console.error(`[hybridclaw-agent] request complete: ${output.status}`);
   }
 }

--- a/container/src/shutdown-output.ts
+++ b/container/src/shutdown-output.ts
@@ -1,0 +1,13 @@
+import type { ContainerOutput } from './types.js';
+
+export function buildInterruptedShutdownOutput(
+  reason: NodeJS.Signals,
+): ContainerOutput {
+  return {
+    status: 'error',
+    result: null,
+    toolsUsed: [],
+    toolExecutions: [],
+    error: `Request interrupted: the agent process received ${reason} before producing a final response.`,
+  };
+}

--- a/src/infra/warm-runner-utils.ts
+++ b/src/infra/warm-runner-utils.ts
@@ -82,6 +82,15 @@ export function summarizeExit(
   return 'unknown exit status';
 }
 
+function isInternalProgressLine(line: string): boolean {
+  return (
+    line === '[stream-activity]' ||
+    line.startsWith('[stream] ') ||
+    line.startsWith('[thinking] ') ||
+    line.startsWith('[approval] ')
+  );
+}
+
 export function formatWarmRunnerTerminalError(
   entry: Pick<WarmRunnerHealthEntry, 'process' | 'stderrHistory'>,
   runtimeLabel: string,
@@ -108,6 +117,7 @@ export function formatWarmRunnerTerminalError(
   }
 
   const detail = entry.stderrHistory
+    .filter((line) => !isInternalProgressLine(line))
     .slice(-4)
     .join(' ')
     .replace(/\s+/g, ' ')

--- a/tests/container-shutdown-output.test.ts
+++ b/tests/container-shutdown-output.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'vitest';
+import { buildInterruptedShutdownOutput } from '../container/src/shutdown-output.js';
+
+test('builds a structured interrupted output for signal shutdown', () => {
+  expect(buildInterruptedShutdownOutput('SIGINT')).toEqual({
+    status: 'error',
+    result: null,
+    toolsUsed: [],
+    toolExecutions: [],
+    error:
+      'Request interrupted: the agent process received SIGINT before producing a final response.',
+  });
+});

--- a/tests/warm-runner-utils.test.ts
+++ b/tests/warm-runner-utils.test.ts
@@ -4,6 +4,7 @@ import {
   claimWarmEntry,
   createWarmSessionId,
   enforceWarmPoolPressure,
+  formatWarmRunnerTerminalError,
   getCachedObservedMemoryBytes,
   maintainWarmPool,
   observeAgentLifecycleLine,
@@ -184,6 +185,29 @@ test('enforces process capacity without sampling memory', () => {
 
   expect(getObservedMemoryBytes).not.toHaveBeenCalled();
   expect(stopEntries).toHaveBeenCalledWith([warm]);
+});
+
+test('omits internal stream progress lines from terminal error details', () => {
+  const error = formatWarmRunnerTerminalError(
+    {
+      process: { exitCode: 1, killed: false },
+      stderrHistory: [
+        '[thinking] IHVzZXIgd2FudHM=',
+        '[stream-activity]',
+        '[stream] SGVsbG8=',
+        'runtime crashed',
+      ],
+    },
+    'Host agent process',
+    { code: 1, signal: null },
+  );
+
+  expect(error).toBe(
+    'Host agent process exited before producing output (exit code 1). runtime crashed',
+  );
+  expect(error).not.toContain('[thinking]');
+  expect(error).not.toContain('[stream-activity]');
+  expect(error).not.toContain('[stream]');
 });
 
 test('maintains target warm entries for recent agent traffic', () => {


### PR DESCRIPTION
## Summary

- Write a structured `ContainerOutput` error when an in-flight agent request receives `SIGINT` or `SIGTERM`.
- Track whether the container agent is actively handling a request so idle warm-agent shutdowns do not leave stale outputs.
- Filter internal stream/progress protocol markers out of runner fallback terminal-error details.

## Root Cause

The host/container runner previously had to summarize a child process that exited before writing output. When an agent handled `SIGINT` and exited with code `0`, the runner only had stderr history, so chat could show internal markers like `[thinking] ...` and `[stream-activity]` instead of the actual interruption story.

## Validation

- `./node_modules/.bin/vitest run --configLoader runner --project unit tests/warm-runner-utils.test.ts tests/container-shutdown-output.test.ts`
- `npm --prefix container run build`
- `git diff --check`