### PR TITLE
[codex] Omit empty tools from provider requests

### DIFF
--- a/container/src/providers/hybridai.ts
+++ b/container/src/providers/hybridai.ts
@@ -49,10 +49,12 @@ function buildHybridAIRequestBody(
     model: stripHybridAIModelPrefix(args.model),
     chatbot_id: args.chatbotId,
     messages: args.messages,
-    tools: args.tools,
-    tool_choice: 'auto',
     enable_rag: args.enableRag,
   };
+  if (args.tools.length > 0) {
+    request.tools = args.tools;
+    request.tool_choice = 'auto';
+  }
   if (
     typeof args.maxTokens === 'number' &&
     Number.isFinite(args.maxTokens) &&

--- a/container/src/providers/local-ollama.ts
+++ b/container/src/providers/local-ollama.ts
@@ -128,9 +128,11 @@ function buildRequestBody(
   const request: Record<string, unknown> = {
     model: normalizeOllamaModelName(args.model),
     messages: args.messages.map(convertMessage),
-    tools: convertTools(args.tools),
     stream,
   };
+  if (args.tools.length > 0) {
+    request.tools = convertTools(args.tools);
+  }
   if (
     typeof args.maxTokens === 'number' &&
     Number.isFinite(args.maxTokens) &&

--- a/container/src/providers/local-openai-compat.ts
+++ b/container/src/providers/local-openai-compat.ts
@@ -317,9 +317,11 @@ function buildRequestBody(args: NormalizedCallArgs): Record<string, unknown> {
   const request: Record<string, unknown> = {
     model: normalizeLocalModelName(args.provider, args.model),
     messages: buildRequestMessages(args),
-    tools: args.tools,
-    tool_choice: 'auto',
   };
+  if (args.tools.length > 0) {
+    request.tools = args.tools;
+    request.tool_choice = 'auto';
+  }
   if (
     typeof args.maxTokens === 'number' &&
     Number.isFinite(args.maxTokens) &&

--- a/container/src/providers/openai-codex.ts
+++ b/container/src/providers/openai-codex.ts
@@ -157,15 +157,18 @@ function buildCodexRequestBody(
   messages: ChatMessage[],
   tools: ToolDefinition[],
 ): Record<string, unknown> {
-  return {
+  const body: Record<string, unknown> = {
     model: normalizeCodexModelName(model),
     store: false,
     instructions: extractCodexInstructions(messages),
     input: messages.flatMap(convertMessageToResponsesInput),
-    tools: convertToolsToResponsesTools(tools),
-    tool_choice: 'auto',
-    parallel_tool_calls: true,
   };
+  if (tools.length > 0) {
+    body.tools = convertToolsToResponsesTools(tools);
+    body.tool_choice = 'auto';
+    body.parallel_tool_calls = true;
+  }
+  return body;
 }
 
 function buildCodexSyntheticMessageOutput(

--- a/src/gateway/openai-compatible-model.ts
+++ b/src/gateway/openai-compatible-model.ts
@@ -182,28 +182,34 @@ function createProviderError(status: number, body: string): Error {
 function buildHybridAIRequestBody(
   params: OpenAICompatibleModelCallParams,
 ): Record<string, unknown> {
-  return {
+  const body: Record<string, unknown> = {
     model: stripHybridAIModelPrefix(params.model),
     chatbot_id: params.runtime.chatbotId,
     messages: params.messages,
-    tools: params.tools,
-    tool_choice: params.toolChoice || 'auto',
     enable_rag: params.runtime.enableRag,
   };
+  if (params.tools.length > 0) {
+    body.tools = params.tools;
+    body.tool_choice = params.toolChoice || 'auto';
+  }
+  return body;
 }
 
 function buildOpenAICompatRequestBody(
   params: OpenAICompatibleModelCallParams,
 ): Record<string, unknown> {
-  return {
+  const body: Record<string, unknown> = {
     model: normalizeOpenAICompatModelName(
       params.runtime.provider,
       params.model,
     ),
     messages: collapseSystemMessages(params.messages),
-    tools: params.tools,
-    tool_choice: params.toolChoice || 'auto',
   };
+  if (params.tools.length > 0) {
+    body.tools = params.tools;
+    body.tool_choice = params.toolChoice || 'auto';
+  }
+  return body;
 }
 
 function convertMessageToResponsesInput(
@@ -261,20 +267,23 @@ function buildCodexRequestBody(
     .map((message) => contentToText(message.content).trim())
     .filter(Boolean)
     .join('\n\n');
-  return {
+  const body: Record<string, unknown> = {
     model: normalizeCodexModelName(params.model),
     store: false,
     instructions: instructions || 'You are Codex, a coding assistant.',
     input: params.messages.flatMap(convertMessageToResponsesInput),
-    tools: params.tools.map((tool) => ({
+  };
+  if (params.tools.length > 0) {
+    body.tools = params.tools.map((tool) => ({
       type: 'function',
       name: tool.function.name,
       description: tool.function.description,
       parameters: tool.function.parameters,
-    })),
-    tool_choice: params.toolChoice || 'auto',
-    parallel_tool_calls: true,
-  };
+    }));
+    body.tool_choice = params.toolChoice || 'auto';
+    body.parallel_tool_calls = true;
+  }
+  return body;
 }
 
 function adaptCodexResponse(

--- a/src/providers/auxiliary.ts
+++ b/src/providers/auxiliary.ts
@@ -1034,9 +1034,10 @@ async function callHybridAITextModel(
       model: stripHybridAIModelPrefix(context.model),
       chatbot_id: context.chatbotId,
       messages,
-      tools: options.tools,
-      tool_choice: 'auto',
       enable_rag: context.enableRag,
+      ...(options.tools.length > 0
+        ? { tools: options.tools, tool_choice: 'auto' }
+        : {}),
       ...(context.maxTokens ? { max_tokens: context.maxTokens } : {}),
     },
     options,
@@ -1301,10 +1302,12 @@ async function callCodexTextModel(
     stream: true,
     instructions: instructions || 'You are Codex, a coding assistant.',
     input: messages.flatMap(convertMessageToCodexInput),
-    tools: convertToolsToCodexTools(options.tools),
-    tool_choice: 'auto',
-    parallel_tool_calls: true,
   };
+  if (options.tools.length > 0) {
+    body.tools = convertToolsToCodexTools(options.tools);
+    body.tool_choice = 'auto';
+    body.parallel_tool_calls = true;
+  }
 
   const response = await fetch(`${context.baseUrl}/responses`, {
     method: 'POST',
@@ -1454,9 +1457,11 @@ async function callOllamaTextModel(
       role: message.role,
       content: contentToText(message.content),
     })),
-    tools: options.tools,
     stream: false,
   };
+  if (options.tools.length > 0) {
+    body.tools = options.tools;
+  }
   const ollamaOptions: Record<string, unknown> = {
     ...(rawOptions || {}),
   };

--- a/tests/hybridai-client.test.ts
+++ b/tests/hybridai-client.test.ts
@@ -46,6 +46,8 @@ test('callRoutedModel forwards max_tokens when provided', async () => {
       unknown
     >;
     expect(body.max_tokens).toBe(4096);
+    expect(body.tools).toBeUndefined();
+    expect(body.tool_choice).toBeUndefined();
     return new Response(JSON.stringify(okResponse), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
@@ -296,8 +298,9 @@ test('callRoutedModelStream parses Codex SSE text deltas and tool calls', async 
     expect(body.store).toBe(false);
     expect(body.instructions).toBe('You are a focused coding assistant.');
     expect(body.input).toEqual([{ role: 'user', content: 'hello' }]);
-    expect(body.tool_choice).toBe('auto');
-    expect(body.parallel_tool_calls).toBe(true);
+    expect(body.tools).toBeUndefined();
+    expect(body.tool_choice).toBeUndefined();
+    expect(body.parallel_tool_calls).toBeUndefined();
     expect(body.max_output_tokens).toBeUndefined();
     expect(String((init?.headers as Record<string, string>).Accept)).toContain(
       'text/event-stream',
@@ -421,8 +424,9 @@ test('callRoutedModel sends Codex instructions and omits system messages from in
     expect(body.stream).toBe(true);
     expect(body.instructions).toBe('Follow repository conventions exactly.');
     expect(body.input).toEqual([{ role: 'user', content: 'hello' }]);
-    expect(body.tool_choice).toBe('auto');
-    expect(body.parallel_tool_calls).toBe(true);
+    expect(body.tools).toBeUndefined();
+    expect(body.tool_choice).toBeUndefined();
+    expect(body.parallel_tool_calls).toBeUndefined();
     expect(body.max_output_tokens).toBeUndefined();
     expect(String((init?.headers as Record<string, string>).Accept)).toContain(
       'text/event-stream',

--- a/tests/local-container-providers.test.ts
+++ b/tests/local-container-providers.test.ts
@@ -75,6 +75,7 @@ describe('local container providers', () => {
       const messages = body.messages as Array<Record<string, unknown>>;
       expect(body.model).toBe('llava:7b');
       expect(body.stream).toBe(false);
+      expect(body.tools).toEqual(tools);
       expect(body.options).toEqual({ num_predict: 64 });
       expect(messages[0]?.images).toEqual(['ZmFrZQ==']);
       return new Response(
@@ -131,14 +132,19 @@ describe('local container providers', () => {
     const deltas: string[] = [];
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () =>
-        makeNdjsonResponse([
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body || '{}')) as Record<
+          string,
+          unknown
+        >;
+        expect(body.tools).toBeUndefined();
+        return makeNdjsonResponse([
           '{"model":"deepseek-r1","message":{"role":"assistant","content":"<think>plan"},"done":false}\n',
           '{"model":"deepseek-r1","message":{"role":"assistant","content":"</think>Hello"},"done":false}\n',
           '{"model":"deepseek-r1","message":{"role":"assistant","content":" world"},"done":false}\n',
           '{"model":"deepseek-r1","done":true,"done_reason":"stop","prompt_eval_count":10,"eval_count":4}\n',
-        ]),
-      ),
+        ]);
+      }),
     );
 
     const result = await callOllamaProviderStream({
@@ -458,6 +464,8 @@ describe('local container providers', () => {
         string,
         unknown
       >;
+      expect(body.tools).toEqual(tools);
+      expect(body.tool_choice).toBe('auto');
       const messages = body.messages as Array<Record<string, unknown>>;
       expect(messages).toEqual([
         { role: 'user', content: 'hello' },
@@ -546,6 +554,8 @@ describe('local container providers', () => {
         string,
         unknown
       >;
+      expect(body.tools).toEqual(tools);
+      expect(body.tool_choice).toBe('auto');
       const messages = body.messages as Array<Record<string, unknown>>;
       expect(messages).toEqual([
         { role: 'user', content: 'hello' },
@@ -633,6 +643,8 @@ describe('local container providers', () => {
         string,
         unknown
       >;
+      expect(body.tools).toBeUndefined();
+      expect(body.tool_choice).toBeUndefined();
       const messages = body.messages as Array<Record<string, unknown>>;
       expect(messages).toEqual([
         {

--- a/tests/openai-codex-provider.test.ts
+++ b/tests/openai-codex-provider.test.ts
@@ -49,21 +49,27 @@ describe('OpenAI Codex provider', () => {
   test('uses top-level output_text when output is empty', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn(
-        async () =>
-          new Response(
-            JSON.stringify({
-              id: 'resp_1',
-              model: 'gpt-5.4',
-              output: [],
-              output_text: 'Created llm-wiki',
-            }),
-            {
-              status: 200,
-              headers: { 'Content-Type': 'application/json' },
-            },
-          ),
-      ),
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body || '{}')) as Record<
+          string,
+          unknown
+        >;
+        expect(body.tools).toBeUndefined();
+        expect(body.tool_choice).toBeUndefined();
+        expect(body.parallel_tool_calls).toBeUndefined();
+        return new Response(
+          JSON.stringify({
+            id: 'resp_1',
+            model: 'gpt-5.4',
+            output: [],
+            output_text: 'Created llm-wiki',
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        );
+      }),
     );
 
     const result = await callOpenAICodexProvider(baseArgs);

--- a/tests/openai-compatible-model.test.ts
+++ b/tests/openai-compatible-model.test.ts
@@ -17,6 +17,9 @@ test('openai-compatible Codex calls strip the provider prefix from request model
         unknown
       >;
       expect(body.model).toBe('gpt-5.4');
+      expect(body.tools).toBeUndefined();
+      expect(body.tool_choice).toBeUndefined();
+      expect(body.parallel_tool_calls).toBeUndefined();
       return new Response(
         JSON.stringify({
           id: 'resp_1',
@@ -50,6 +53,110 @@ test('openai-compatible Codex calls strip the provider prefix from request model
       thinkingFormat: undefined,
     },
     model: 'openai-codex/gpt-5.4',
+    messages: [{ role: 'user', content: 'hello' }],
+    tools: [],
+  });
+
+  expect(result.choices[0]?.message.content).toBe('ok');
+});
+
+test('openai-compatible HybridAI calls omit empty tools', async () => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input).toBe('https://hybridai.one/v1/chat/completions');
+      const body = JSON.parse(String(init?.body || '{}')) as Record<
+        string,
+        unknown
+      >;
+      expect(body.model).toBe('Qwen/Qwen3.6-27B-FP8');
+      expect(body.tools).toBeUndefined();
+      expect(body.tool_choice).toBeUndefined();
+      return new Response(
+        JSON.stringify({
+          id: 'resp_1',
+          model: 'Qwen/Qwen3.6-27B-FP8',
+          choices: [
+            {
+              message: { role: 'assistant', content: 'ok' },
+              finish_reason: 'stop',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    }),
+  );
+
+  const result = await callOpenAICompatibleModel({
+    runtime: {
+      provider: 'hybridai',
+      apiKey: 'hybridai-key',
+      baseUrl: 'https://hybridai.one',
+      chatbotId: 'bot_123',
+      enableRag: false,
+      requestHeaders: {},
+      agentId: 'main',
+      isLocal: false,
+      contextWindow: 200_000,
+      thinkingFormat: undefined,
+    },
+    model: 'hybridai/Qwen/Qwen3.6-27B-FP8',
+    messages: [{ role: 'user', content: 'hello' }],
+    tools: [],
+  });
+
+  expect(result.choices[0]?.message.content).toBe('ok');
+});
+
+test('openai-compatible remote calls omit empty tools', async () => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input).toBe('https://openrouter.ai/api/v1/chat/completions');
+      const body = JSON.parse(String(init?.body || '{}')) as Record<
+        string,
+        unknown
+      >;
+      expect(body.model).toBe('google/gemini-2.5-flash-lite');
+      expect(body.tools).toBeUndefined();
+      expect(body.tool_choice).toBeUndefined();
+      return new Response(
+        JSON.stringify({
+          id: 'resp_1',
+          model: 'google/gemini-2.5-flash-lite',
+          choices: [
+            {
+              message: { role: 'assistant', content: 'ok' },
+              finish_reason: 'stop',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    }),
+  );
+
+  const result = await callOpenAICompatibleModel({
+    runtime: {
+      provider: 'openrouter',
+      apiKey: 'openrouter-key',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      chatbotId: '',
+      enableRag: false,
+      requestHeaders: {},
+      agentId: 'main',
+      isLocal: false,
+      contextWindow: 200_000,
+      thinkingFormat: undefined,
+    },
+    model: 'openrouter/google/gemini-2.5-flash-lite',
     messages: [{ role: 'user', content: 'hello' }],
     tools: [],
   });

--- a/tests/providers.auxiliary.test.ts
+++ b/tests/providers.auxiliary.test.ts
@@ -409,6 +409,69 @@ test('host auxiliary caller strips the HybridAI display prefix from request mode
   });
 });
 
+test('host auxiliary caller avoids empty tools for HybridAI providers', async () => {
+  const resolveTaskModelPolicy = vi.fn(async () => undefined);
+  const resolveModelRuntimeCredentials = vi.fn(async () => ({
+    provider: 'hybridai' as const,
+    apiKey: 'hybridai-key',
+    baseUrl: 'https://hybridai.one',
+    chatbotId: 'bot_123',
+    enableRag: false,
+    requestHeaders: {},
+    agentId: 'main',
+    isLocal: false,
+    contextWindow: 200_000,
+    thinkingFormat: undefined,
+  }));
+  setupProviderMocks({
+    resolveTaskModelPolicy,
+    resolveModelRuntimeCredentials,
+  });
+
+  const fetchMock = vi.fn(
+    async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body || '{}')) as Record<
+        string,
+        unknown
+      >;
+      expect(body.tools).toBeUndefined();
+      expect(body.tool_choice).toBeUndefined();
+      return new Response(
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                role: 'assistant',
+                content: 'HybridAI response without empty tools.',
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    },
+  );
+  vi.stubGlobal('fetch', fetchMock);
+
+  const { callAuxiliaryModel } = await import('../src/providers/auxiliary.js');
+  const result = await callAuxiliaryModel({
+    task: 'session_title',
+    provider: 'hybridai',
+    model: 'Qwen/Qwen3.6-27B-FP8',
+    fallbackChatbotId: 'bot_123',
+    messages: [{ role: 'user', content: 'Name this session.' }],
+  });
+
+  expect(result).toEqual({
+    provider: 'hybridai',
+    model: 'Qwen/Qwen3.6-27B-FP8',
+    content: 'HybridAI response without empty tools.',
+  });
+});
+
 test('host auxiliary caller supports HybridAI-routed vendor model hints', async () => {
   const resolveTaskModelPolicy = vi.fn(async () => undefined);
   const resolveModelRuntimeCredentials = vi.fn(async () => ({
@@ -520,6 +583,9 @@ test('host auxiliary caller streams Codex responses for auxiliary tasks', async 
         unknown
       >;
       expect(body.stream).toBe(true);
+      expect(body.tools).toBeUndefined();
+      expect(body.tool_choice).toBeUndefined();
+      expect(body.parallel_tool_calls).toBeUndefined();
       expect(body.temperature).toBeUndefined();
       expect(body.max_output_tokens).toBeUndefined();
       return new Response(streamBody, {
@@ -1705,6 +1771,9 @@ test('host auxiliary caller falls through to Codex when OpenRouter and Anthropic
         unknown
       >;
       expect(body.model).toBe('gpt-5.4-mini');
+      expect(body.tools).toBeUndefined();
+      expect(body.tool_choice).toBeUndefined();
+      expect(body.parallel_tool_calls).toBeUndefined();
       return new Response(
         JSON.stringify({
           output: [


### PR DESCRIPTION
## Summary

- Omit `tools` from provider payloads whenever the tool list is empty.
- Omit dependent tool-control fields (`tool_choice`, `parallel_tool_calls`) when no tools are present.
- Cover host auxiliary calls, gateway OpenAI-compatible routing, and container providers.

## Root Cause

Some request builders serialized `tools: []` for tool-free calls. HybridAI rejects that shape with `ValueError('`tools` must not be an empty array...')`, which surfaced as a 500 on session-title auxiliary calls.

## Validation

- `npx biome check --write ...` on touched files
- `./node_modules/.bin/vitest run tests/providers.auxiliary.test.ts tests/session-title.test.ts tests/hybridai-client.test.ts tests/local-container-providers.test.ts tests/openai-compatible-model.test.ts tests/openai-codex-provider.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`