### PR TITLE
[codex] Forward response ratings to HybridAI feedback

### DIFF
--- a/src/gateway/response-ratings.ts
+++ b/src/gateway/response-ratings.ts
@@ -1,9 +1,11 @@
 import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
 import {
   clearResponseRating,
+  getResponseRatingFeedbackContext,
   getResponseRatingTarget,
   upsertResponseRating,
 } from '../memory/db.js';
+import { normalizeBaseUrl } from '../providers/utils.js';
 import { recordSkillFeedbackForObservation } from '../skills/skills-observation.js';
 import type { ResponseRatingValue } from '../types/session.js';
 
@@ -24,6 +26,100 @@ export class ResponseRatingNotFoundError extends Error {
   constructor() {
     super('Response message was not found.');
     this.name = 'ResponseRatingNotFoundError';
+  }
+}
+
+const HYBRIDAI_CHAT_FEEDBACK_TIMEOUT_MS = 10_000;
+
+function resolveHybridAIChatFeedbackUrl(): string {
+  const baseUrl =
+    process.env.HYBRIDAI_BASE_URL?.trim() || 'https://hybridai.one';
+  return `${normalizeBaseUrl(baseUrl)}/api/chat_feedback`;
+}
+
+function isHybridAIResponseTarget(params: {
+  model: string | null;
+  provider: string | null;
+}): boolean {
+  if (params.provider === 'hybridai') return true;
+  if (params.provider) return false;
+
+  const normalizedModel = params.model?.trim();
+  if (!normalizedModel) return false;
+  return !normalizedModel.includes('/');
+}
+
+async function warnHybridAIChatFeedbackForwardingFailed(
+  context: Record<string, unknown>,
+): Promise<void> {
+  try {
+    const { logger } = await import('../logger.js');
+    logger.warn(context, 'HybridAI chat feedback forwarding failed');
+  } catch {
+    // Logging must not make rating submission fail.
+  }
+}
+
+export async function forwardHybridAIChatFeedbackForRating(input: {
+  sessionId: string;
+  messageId: number;
+  operatorUserId: string;
+  rating: ResponseRatingValue;
+  model: string | null;
+  provider: string | null;
+}): Promise<void> {
+  if (!isHybridAIResponseTarget(input)) return;
+
+  const context = getResponseRatingFeedbackContext({
+    sessionId: input.sessionId,
+    messageId: input.messageId,
+  });
+  const chatbotId = context?.chatbot_id?.trim();
+  if (!context || !chatbotId) return;
+
+  let apiKey = '';
+  try {
+    const { getHybridAIApiKey, getHybridAIAuthStatus } = await import(
+      '../auth/hybridai-auth.js'
+    );
+    if (!getHybridAIAuthStatus().authenticated) return;
+    apiKey = getHybridAIApiKey();
+  } catch {
+    return;
+  }
+
+  const payload = {
+    chatbot_id: chatbotId,
+    browser_id: input.sessionId,
+    rating: input.rating,
+    user_message: context.user_content ?? '',
+    bot_response: context.assistant_content,
+    external_user_id: input.operatorUserId,
+  };
+
+  try {
+    const response = await fetch(resolveHybridAIChatFeedbackUrl(), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(HYBRIDAI_CHAT_FEEDBACK_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      await warnHybridAIChatFeedbackForwardingFailed({
+        sessionId: input.sessionId,
+        messageId: input.messageId,
+        status: response.status,
+      });
+    }
+  } catch (err) {
+    await warnHybridAIChatFeedbackForwardingFailed({
+      sessionId: input.sessionId,
+      messageId: input.messageId,
+      err,
+    });
   }
 }
 
@@ -93,6 +189,17 @@ export function submitResponseRating(
       ratedAt: new Date().toISOString(),
     },
   });
+
+  if (input.rating) {
+    void forwardHybridAIChatFeedbackForRating({
+      sessionId,
+      messageId: input.messageId,
+      operatorUserId,
+      rating: input.rating,
+      model: target.model,
+      provider: target.provider,
+    });
+  }
 
   return {
     sessionId,

--- a/src/gateway/response-ratings.ts
+++ b/src/gateway/response-ratings.ts
@@ -1,10 +1,18 @@
 import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
-import { HYBRIDAI_CHATBOT_ID, OBSERVABILITY_BOT_ID } from '../config/config.js';
+import {
+  getHybridAIApiKey,
+  getHybridAIAuthStatus,
+} from '../auth/hybridai-auth.js';
+import {
+  HYBRIDAI_BASE_URL,
+  HYBRIDAI_CHATBOT_ID,
+  OBSERVABILITY_BOT_ID,
+} from '../config/config.js';
+import { logger } from '../logger.js';
 import {
   clearResponseRating,
-  getAnyChatbotId,
-  getResponseRatingFeedbackContext,
   getResponseRatingTarget,
+  type ResponseRatingTarget,
   upsertResponseRating,
 } from '../memory/db.js';
 import { normalizeBaseUrl } from '../providers/utils.js';
@@ -32,12 +40,9 @@ export class ResponseRatingNotFoundError extends Error {
 }
 
 const HYBRIDAI_CHAT_FEEDBACK_TIMEOUT_MS = 10_000;
-
-function resolveHybridAIChatFeedbackUrl(): string {
-  const baseUrl =
-    process.env.HYBRIDAI_BASE_URL?.trim() || 'https://hybridai.one';
-  return `${normalizeBaseUrl(baseUrl)}/api/chat_feedback`;
-}
+const HYBRIDAI_CHAT_FEEDBACK_URL = `${normalizeBaseUrl(
+  HYBRIDAI_BASE_URL,
+)}/api/chat_feedback`;
 
 function resolveHybridAIChatFeedbackBotId(
   sessionChatbotId: string | null | undefined,
@@ -46,61 +51,55 @@ function resolveHybridAIChatFeedbackBotId(
     sessionChatbotId?.trim() ||
     OBSERVABILITY_BOT_ID.trim() ||
     HYBRIDAI_CHATBOT_ID.trim() ||
-    getAnyChatbotId() ||
     ''
   );
 }
 
-async function warnHybridAIChatFeedbackForwardingFailed(
+function warnHybridAIChatFeedbackForwardingFailed(
   context: Record<string, unknown>,
-): Promise<void> {
-  try {
-    const { logger } = await import('../logger.js');
-    logger.warn(context, 'HybridAI chat feedback forwarding failed');
-  } catch {
-    // Logging must not make rating submission fail.
-  }
+): void {
+  logger.warn(context, 'HybridAI chat feedback forwarding failed');
 }
 
-export async function forwardHybridAIChatFeedbackForRating(input: {
+function resolveHybridAIChatFeedbackBrowserId(sessionId: string): string {
+  // HybridAI's feedback API requires a stable opaque browser_id. Web ratings
+  // are session-scoped and do not expose a separate browser fingerprint here,
+  // so use the HybridClaw session id rather than adding user-identifying data.
+  return sessionId;
+}
+
+async function forwardHybridAIChatFeedbackForRating(input: {
   sessionId: string;
   messageId: number;
   operatorUserId: string;
   rating: ResponseRatingValue;
-  agentId: string | null;
+  target: ResponseRatingTarget;
 }): Promise<void> {
-  const context = getResponseRatingFeedbackContext({
-    sessionId: input.sessionId,
-    messageId: input.messageId,
-  });
-  if (!context) return;
-  const chatbotId = resolveHybridAIChatFeedbackBotId(context?.chatbot_id);
-  if (!chatbotId) return;
-
   let apiKey = '';
   try {
-    const { getHybridAIApiKey, getHybridAIAuthStatus } = await import(
-      '../auth/hybridai-auth.js'
-    );
     if (!getHybridAIAuthStatus().authenticated) return;
     apiKey = getHybridAIApiKey();
   } catch {
     return;
   }
 
+  const chatbotId = resolveHybridAIChatFeedbackBotId(input.target.chatbot_id);
+  if (!chatbotId) return;
+
+  const agentId = input.target.agent_id?.trim();
   const payload = {
     chatbot_id: chatbotId,
-    browser_id: input.sessionId,
+    browser_id: resolveHybridAIChatFeedbackBrowserId(input.sessionId),
     rating: input.rating,
-    user_message: context.user_content ?? '',
-    bot_response: input.agentId?.trim()
-      ? `[${input.agentId.trim()}] ${context.assistant_content}`
-      : context.assistant_content,
+    user_message: input.target.user_content ?? '',
+    bot_response: agentId
+      ? `[${agentId}] ${input.target.assistant_content}`
+      : input.target.assistant_content,
     external_user_id: input.operatorUserId,
   };
 
   try {
-    const response = await fetch(resolveHybridAIChatFeedbackUrl(), {
+    const response = await fetch(HYBRIDAI_CHAT_FEEDBACK_URL, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${apiKey}`,
@@ -110,14 +109,14 @@ export async function forwardHybridAIChatFeedbackForRating(input: {
       signal: AbortSignal.timeout(HYBRIDAI_CHAT_FEEDBACK_TIMEOUT_MS),
     });
     if (!response.ok) {
-      await warnHybridAIChatFeedbackForwardingFailed({
+      warnHybridAIChatFeedbackForwardingFailed({
         sessionId: input.sessionId,
         messageId: input.messageId,
         status: response.status,
       });
     }
   } catch (err) {
-    await warnHybridAIChatFeedbackForwardingFailed({
+    warnHybridAIChatFeedbackForwardingFailed({
       sessionId: input.sessionId,
       messageId: input.messageId,
       err,
@@ -198,7 +197,7 @@ export function submitResponseRating(
       messageId: input.messageId,
       operatorUserId,
       rating: input.rating,
-      agentId: target.agent_id,
+      target,
     });
   }
 

--- a/src/gateway/response-ratings.ts
+++ b/src/gateway/response-ratings.ts
@@ -67,6 +67,7 @@ export async function forwardHybridAIChatFeedbackForRating(input: {
   messageId: number;
   operatorUserId: string;
   rating: ResponseRatingValue;
+  agentId: string | null;
 }): Promise<void> {
   const context = getResponseRatingFeedbackContext({
     sessionId: input.sessionId,
@@ -92,7 +93,9 @@ export async function forwardHybridAIChatFeedbackForRating(input: {
     browser_id: input.sessionId,
     rating: input.rating,
     user_message: context.user_content ?? '',
-    bot_response: context.assistant_content,
+    bot_response: input.agentId?.trim()
+      ? `[${input.agentId.trim()}] ${context.assistant_content}`
+      : context.assistant_content,
     external_user_id: input.operatorUserId,
   };
 
@@ -195,6 +198,7 @@ export function submitResponseRating(
       messageId: input.messageId,
       operatorUserId,
       rating: input.rating,
+      agentId: target.agent_id,
     });
   }
 

--- a/src/gateway/response-ratings.ts
+++ b/src/gateway/response-ratings.ts
@@ -1,6 +1,8 @@
 import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
+import { HYBRIDAI_CHATBOT_ID, OBSERVABILITY_BOT_ID } from '../config/config.js';
 import {
   clearResponseRating,
+  getAnyChatbotId,
   getResponseRatingFeedbackContext,
   getResponseRatingTarget,
   upsertResponseRating,
@@ -37,16 +39,16 @@ function resolveHybridAIChatFeedbackUrl(): string {
   return `${normalizeBaseUrl(baseUrl)}/api/chat_feedback`;
 }
 
-function isHybridAIResponseTarget(params: {
-  model: string | null;
-  provider: string | null;
-}): boolean {
-  if (params.provider === 'hybridai') return true;
-  if (params.provider) return false;
-
-  const normalizedModel = params.model?.trim();
-  if (!normalizedModel) return false;
-  return !normalizedModel.includes('/');
+function resolveHybridAIChatFeedbackBotId(
+  sessionChatbotId: string | null | undefined,
+): string {
+  return (
+    sessionChatbotId?.trim() ||
+    OBSERVABILITY_BOT_ID.trim() ||
+    HYBRIDAI_CHATBOT_ID.trim() ||
+    getAnyChatbotId() ||
+    ''
+  );
 }
 
 async function warnHybridAIChatFeedbackForwardingFailed(
@@ -65,17 +67,14 @@ export async function forwardHybridAIChatFeedbackForRating(input: {
   messageId: number;
   operatorUserId: string;
   rating: ResponseRatingValue;
-  model: string | null;
-  provider: string | null;
 }): Promise<void> {
-  if (!isHybridAIResponseTarget(input)) return;
-
   const context = getResponseRatingFeedbackContext({
     sessionId: input.sessionId,
     messageId: input.messageId,
   });
-  const chatbotId = context?.chatbot_id?.trim();
-  if (!context || !chatbotId) return;
+  if (!context) return;
+  const chatbotId = resolveHybridAIChatFeedbackBotId(context?.chatbot_id);
+  if (!chatbotId) return;
 
   let apiKey = '';
   try {
@@ -196,8 +195,6 @@ export function submitResponseRating(
       messageId: input.messageId,
       operatorUserId,
       rating: input.rating,
-      model: target.model,
-      provider: target.provider,
     });
   }
 

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -260,6 +260,14 @@ export interface ResponseRatingTarget {
   skill_name: string | null;
 }
 
+export interface ResponseRatingFeedbackContext {
+  session_id: string;
+  message_id: number;
+  chatbot_id: string | null;
+  user_content: string | null;
+  assistant_content: string;
+}
+
 interface SessionBranchRow {
   session_id: string;
   parent_session_id: string;
@@ -7520,6 +7528,37 @@ export function getResponseRatingTarget(params: {
     ...row,
     provider: inferProviderFromModel(row.model),
   };
+}
+
+export function getResponseRatingFeedbackContext(params: {
+  sessionId: string;
+  messageId: number;
+}): ResponseRatingFeedbackContext | null {
+  const sessionId = resolveSessionIdCompat(params.sessionId);
+  const row = queryOne<ResponseRatingFeedbackContext, [string, number]>(
+    db,
+    `SELECT
+       m.session_id,
+       m.id AS message_id,
+       s.chatbot_id,
+       (
+         SELECT previous_user_message.content
+         FROM messages previous_user_message
+         WHERE previous_user_message.session_id = m.session_id
+           AND previous_user_message.id < m.id
+           AND previous_user_message.role = 'user'
+         ORDER BY previous_user_message.id DESC
+         LIMIT 1
+       ) AS user_content,
+       m.content AS assistant_content
+     FROM messages m
+     LEFT JOIN sessions s ON s.id = m.session_id
+     WHERE m.session_id = ? AND m.id = ?
+     LIMIT 1`,
+    sessionId,
+    params.messageId,
+  );
+  return row ?? null;
 }
 
 export function upsertResponseRating(input: {

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -255,17 +255,12 @@ export interface ResponseRatingTarget {
   role: string;
   model: string | null;
   provider: string | null;
-  skill_observation_id: number | null;
-  skill_run_id: string | null;
-  skill_name: string | null;
-}
-
-export interface ResponseRatingFeedbackContext {
-  session_id: string;
-  message_id: number;
   chatbot_id: string | null;
   user_content: string | null;
   assistant_content: string;
+  skill_observation_id: number | null;
+  skill_run_id: string | null;
+  skill_name: string | null;
 }
 
 interface SessionBranchRow {
@@ -7465,6 +7460,9 @@ export function getResponseRatingTarget(params: {
       agent_id: string | null;
       role: string;
       model: string | null;
+      chatbot_id: string | null;
+      user_content: string | null;
+      assistant_content: string;
       skill_observation_id: number | null;
       skill_run_id: string | null;
       skill_name: string | null;
@@ -7478,8 +7476,19 @@ export function getResponseRatingTarget(params: {
          m.id AS message_id,
          m.agent_id,
          m.role,
+         COALESCE(m.content, '') AS assistant_content,
          m.created_at,
+         s.chatbot_id,
          s.model,
+         (
+           SELECT previous_user_message.content
+           FROM messages previous_user_message
+           WHERE previous_user_message.session_id = m.session_id
+             AND previous_user_message.id < m.id
+             AND previous_user_message.role = 'user'
+           ORDER BY previous_user_message.id DESC
+           LIMIT 1
+         ) AS user_content,
          (
            SELECT julianday(MAX(previous_user_message.created_at))
            FROM messages previous_user_message
@@ -7515,6 +7524,9 @@ export function getResponseRatingTarget(params: {
        target_message.agent_id,
        target_message.role,
        target_message.model,
+       target_message.chatbot_id,
+       target_message.user_content,
+       target_message.assistant_content,
        attributed_skill.id AS skill_observation_id,
        attributed_skill.run_id AS skill_run_id,
        attributed_skill.skill_name
@@ -7528,37 +7540,6 @@ export function getResponseRatingTarget(params: {
     ...row,
     provider: inferProviderFromModel(row.model),
   };
-}
-
-export function getResponseRatingFeedbackContext(params: {
-  sessionId: string;
-  messageId: number;
-}): ResponseRatingFeedbackContext | null {
-  const sessionId = resolveSessionIdCompat(params.sessionId);
-  const row = queryOne<ResponseRatingFeedbackContext, [string, number]>(
-    db,
-    `SELECT
-       m.session_id,
-       m.id AS message_id,
-       s.chatbot_id,
-       (
-         SELECT previous_user_message.content
-         FROM messages previous_user_message
-         WHERE previous_user_message.session_id = m.session_id
-           AND previous_user_message.id < m.id
-           AND previous_user_message.role = 'user'
-         ORDER BY previous_user_message.id DESC
-         LIMIT 1
-       ) AS user_content,
-       m.content AS assistant_content
-     FROM messages m
-     LEFT JOIN sessions s ON s.id = m.session_id
-     WHERE m.session_id = ? AND m.id = ?
-     LIMIT 1`,
-    sessionId,
-    params.messageId,
-  );
-  return row ?? null;
 }
 
 export function upsertResponseRating(input: {

--- a/tests/response-ratings.test.ts
+++ b/tests/response-ratings.test.ts
@@ -350,7 +350,6 @@ describe('response ratings', () => {
       rating: 'up',
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -369,7 +368,6 @@ describe('response ratings', () => {
       rating: 'up',
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -392,7 +390,6 @@ describe('response ratings', () => {
       rating: 'up',
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -464,7 +461,6 @@ describe('response ratings', () => {
       rating: null,
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/response-ratings.test.ts
+++ b/tests/response-ratings.test.ts
@@ -268,7 +268,7 @@ describe('response ratings', () => {
       browser_id: service.sessionId,
       rating: 'up',
       user_message: 'Hello',
-      bot_response: 'Hi there',
+      bot_response: '[main] Hi there',
       external_user_id: 'operator-a',
     });
   });
@@ -301,7 +301,7 @@ describe('response ratings', () => {
       chatbot_id: 'bot-feedback',
       rating: 'up',
       user_message: 'Hello',
-      bot_response: 'Hi there',
+      bot_response: '[main] Hi there',
     });
   });
 

--- a/tests/response-ratings.test.ts
+++ b/tests/response-ratings.test.ts
@@ -7,18 +7,37 @@ const makeTempDir = useTempDir('hybridclaw-response-ratings-');
 
 useCleanMocks({
   resetModules: true,
+  unstubAllEnvs: true,
+  unstubAllGlobals: true,
   unmock: [
     '../src/audit/audit-events.js',
+    '../src/auth/hybridai-auth.js',
     '../src/skills/skills-observation.js',
   ],
 });
 
-async function setup() {
+async function setup(options?: {
+  apiKey?: string;
+  authenticated?: boolean;
+  chatbotId?: string | null;
+}) {
   const recordAuditEvent = vi.fn();
   const recordSkillFeedbackForObservation = vi.fn();
   vi.doMock('../src/audit/audit-events.js', () => ({
     makeAuditRunId: () => 'rating_run',
     recordAuditEvent,
+  }));
+  vi.doMock('../src/auth/hybridai-auth.js', () => ({
+    getHybridAIAuthStatus: () => ({
+      authenticated: options?.authenticated ?? Boolean(options?.apiKey),
+      path: 'test',
+      maskedApiKey: options?.apiKey ? 'hai-…test' : null,
+      source: options?.apiKey ? 'env' : null,
+    }),
+    getHybridAIApiKey: () => {
+      if (options?.apiKey) return options.apiKey;
+      throw new Error('HYBRIDAI_API_KEY is not configured.');
+    },
   }));
   vi.doMock('../src/skills/skills-observation.js', () => ({
     recordSkillFeedbackForObservation,
@@ -34,6 +53,9 @@ async function setup() {
     'main',
   );
   dbModule.updateSessionModel(session.id, 'hybridai/gpt-5');
+  if (options?.chatbotId !== undefined) {
+    dbModule.updateSessionChatbot(session.id, options.chatbotId);
+  }
   const userMessageId = dbModule.storeMessage(
     session.id,
     'user_a',
@@ -199,6 +221,107 @@ describe('response ratings', () => {
     });
   });
 
+  test('forwards accepted HybridAI ratings to chat feedback endpoint with stored prompt and response', async () => {
+    vi.stubEnv('HYBRIDAI_BASE_URL', 'https://hybridai.example/');
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const service = await setup({
+      apiKey: 'hai-feedback-test-key',
+      chatbotId: 'bot-feedback',
+    });
+
+    service.submitResponseRating({
+      sessionId: service.sessionId,
+      messageId: service.assistantMessageId,
+      operatorUserId: 'operator-a',
+      rating: 'up',
+    });
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    const [url, request] = fetchMock.mock.calls[0] as [
+      string,
+      RequestInit & { body: string },
+    ];
+    expect(url).toBe('https://hybridai.example/api/chat_feedback');
+    expect(request.method).toBe('POST');
+    expect(request.headers).toMatchObject({
+      Authorization: 'Bearer hai-feedback-test-key',
+      'Content-Type': 'application/json',
+    });
+    expect(JSON.parse(request.body)).toEqual({
+      chatbot_id: 'bot-feedback',
+      browser_id: service.sessionId,
+      rating: 'up',
+      user_message: 'Hello',
+      bot_response: 'Hi there',
+      external_user_id: 'operator-a',
+    });
+  });
+
+  test('does not forward without a HybridAI key', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const service = await setup({ chatbotId: 'bot-feedback' });
+    service.submitResponseRating({
+      sessionId: service.sessionId,
+      messageId: service.assistantMessageId,
+      operatorUserId: 'operator-a',
+      rating: 'up',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('does not forward without a bot id', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const service = await setup({ apiKey: 'hai-feedback-test-key' });
+    service.submitResponseRating({
+      sessionId: service.sessionId,
+      messageId: service.assistantMessageId,
+      operatorUserId: 'operator-a',
+      rating: 'up',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('does not forward when HybridAI auth is inactive', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const service = await setup({
+      apiKey: 'hai-feedback-test-key',
+      authenticated: false,
+      chatbotId: 'bot-feedback',
+    });
+    service.submitResponseRating({
+      sessionId: service.sessionId,
+      messageId: service.assistantMessageId,
+      operatorUserId: 'operator-a',
+      rating: 'up',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   test('rejects missing and non-assistant response identifiers', async () => {
     const service = await setup();
 
@@ -247,5 +370,27 @@ describe('response ratings', () => {
       }),
     ).toEqual(new Map());
     expect(service.recordSkillFeedbackForObservation).not.toHaveBeenCalled();
+  });
+
+  test('does not forward cleared ratings', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const service = await setup({
+      apiKey: 'hai-feedback-test-key',
+      chatbotId: 'bot-feedback',
+    });
+
+    service.submitResponseRating({
+      sessionId: service.sessionId,
+      messageId: service.assistantMessageId,
+      operatorUserId: 'operator-a',
+      rating: null,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/response-ratings.test.ts
+++ b/tests/response-ratings.test.ts
@@ -1,9 +1,14 @@
 import path from 'node:path';
 
 import { describe, expect, test, vi } from 'vitest';
+import { setupGatewayTest } from './helpers/gateway-test-setup.ts';
 import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const makeTempDir = useTempDir('hybridclaw-response-ratings-');
+const { setupHome } = setupGatewayTest({
+  tempHomePrefix: 'hybridclaw-response-ratings-home-',
+  envVars: ['HYBRIDAI_BASE_URL', 'HYBRIDAI_CHATBOT_ID'],
+});
 
 useCleanMocks({
   resetModules: true,
@@ -19,8 +24,15 @@ useCleanMocks({
 async function setup(options?: {
   apiKey?: string;
   authenticated?: boolean;
+  hybridAIBaseUrl?: string;
+  hybridAIChatbotId?: string;
   chatbotId?: string | null;
+  model?: string;
 }) {
+  setupHome({
+    HYBRIDAI_BASE_URL: options?.hybridAIBaseUrl ?? '',
+    HYBRIDAI_CHATBOT_ID: options?.hybridAIChatbotId ?? '',
+  });
   const recordAuditEvent = vi.fn();
   const recordSkillFeedbackForObservation = vi.fn();
   vi.doMock('../src/audit/audit-events.js', () => ({
@@ -52,7 +64,7 @@ async function setup(options?: {
     'web',
     'main',
   );
-  dbModule.updateSessionModel(session.id, 'hybridai/gpt-5');
+  dbModule.updateSessionModel(session.id, options?.model ?? 'hybridai/gpt-5');
   if (options?.chatbotId !== undefined) {
     dbModule.updateSessionChatbot(session.id, options.chatbotId);
   }
@@ -221,8 +233,7 @@ describe('response ratings', () => {
     });
   });
 
-  test('forwards accepted HybridAI ratings to chat feedback endpoint with stored prompt and response', async () => {
-    vi.stubEnv('HYBRIDAI_BASE_URL', 'https://hybridai.example/');
+  test('forwards accepted ratings to chat feedback endpoint with stored prompt and response', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       status: 201,
@@ -230,6 +241,7 @@ describe('response ratings', () => {
     vi.stubGlobal('fetch', fetchMock);
     const service = await setup({
       apiKey: 'hai-feedback-test-key',
+      hybridAIBaseUrl: 'https://hybridai.example/',
       chatbotId: 'bot-feedback',
     });
 
@@ -258,6 +270,68 @@ describe('response ratings', () => {
       user_message: 'Hello',
       bot_response: 'Hi there',
       external_user_id: 'operator-a',
+    });
+  });
+
+  test('forwards non-HybridAI model ratings when a HybridAI bot is active', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const service = await setup({
+      apiKey: 'hai-feedback-test-key',
+      chatbotId: 'bot-feedback',
+      model: 'vllm/Qwen/Qwen3.6-27B-FP8',
+    });
+
+    service.submitResponseRating({
+      sessionId: service.sessionId,
+      messageId: service.assistantMessageId,
+      operatorUserId: 'operator-a',
+      rating: 'up',
+    });
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    const [, request] = fetchMock.mock.calls[0] as [
+      string,
+      RequestInit & { body: string },
+    ];
+    expect(JSON.parse(request.body)).toMatchObject({
+      chatbot_id: 'bot-feedback',
+      rating: 'up',
+      user_message: 'Hello',
+      bot_response: 'Hi there',
+    });
+  });
+
+  test('uses configured HybridAI bot id when the rated session has no bot id', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const service = await setup({
+      apiKey: 'hai-feedback-test-key',
+      hybridAIChatbotId: 'bot-configured',
+      model: 'vllm/Qwen/Qwen3.6-27B-FP8',
+    });
+
+    service.submitResponseRating({
+      sessionId: service.sessionId,
+      messageId: service.assistantMessageId,
+      operatorUserId: 'operator-a',
+      rating: 'down',
+    });
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    const [, request] = fetchMock.mock.calls[0] as [
+      string,
+      RequestInit & { body: string },
+    ];
+    expect(JSON.parse(request.body)).toMatchObject({
+      chatbot_id: 'bot-configured',
+      rating: 'down',
     });
   });
 


### PR DESCRIPTION
## Summary

- Forward accepted response ratings to the HybridAI `/api/chat_feedback` endpoint when HybridAI auth and a bot id are active, regardless of which model produced the response.
- Include the stored previous user message and rated assistant response so HybridAI receives the same prompt/response pair used by the existing feedback API.
- Prefix forwarded `bot_response` values with the rated response agent, for example `[main] ...`, when an agent id is available.
- Resolve the feedback bot id from the rated session first, then the configured observability/HybridAI bot id fallbacks; clears and missing prerequisites stay local only.

## Validation

- `mise exec node@22 -- npx vitest run tests/response-ratings.test.ts`
- `mise exec node@22 -- npm run typecheck`
- `mise exec node@22 -- npm run lint`
- `mise exec node@22 -- npx biome check src/gateway/response-ratings.ts tests/response-ratings.test.ts`