### PR TITLE
[codex] Speed up coworker liveness skill scan

### DIFF
--- a/src/gateway/coworker-liveness.ts
+++ b/src/gateway/coworker-liveness.ts
@@ -417,9 +417,10 @@ async function buildCoworkerLivenessSummary(
     auditEventsBySession.set(row.session_id, existing);
   }
   const skillRunsByAgent = new Map<string, SkillObservation[]>();
+  const agentIdSet = new Set(agentIds);
   for (const run of getSkillObservations({ limit: 1_000 })) {
     const agentId = (run.agent_id || DEFAULT_AGENT_ID).trim();
-    if (!agentIds.includes(agentId)) continue;
+    if (!agentIdSet.has(agentId)) continue;
     const existing = skillRunsByAgent.get(agentId) ?? [];
     if (existing.length >= 50) continue;
     existing.push(run);


### PR DESCRIPTION
## Summary

- Build a `Set` from probed coworker agent ids before processing skill observations.
- Replace per-row `agentIds.includes(...)` checks with constant-time `agentIdSet.has(...)` lookups.

## Impact

This keeps the coworker liveness cache rebuild scoped to O(n + m) membership work instead of doing repeated linear scans across agents for each observed skill run.

## Validation

- `npx biome check --write src/gateway/coworker-liveness.ts`
- `./node_modules/.bin/vitest run tests/coworker-liveness.test.ts`