### PR TITLE
[codex] Compare gateway tokens safely

### DIFF
--- a/src/gateway/auth-token.ts
+++ b/src/gateway/auth-token.ts
@@ -93,7 +93,7 @@ function normalizeExpirySeconds(
     : Math.floor(value);
 }
 
-function safeEqual(value: string, expected: string): boolean {
+export function safeEqualToken(value: string, expected: string): boolean {
   const valueBuffer = Buffer.from(value);
   const expectedBuffer = Buffer.from(expected);
   if (valueBuffer.length !== expectedBuffer.length) return false;
@@ -107,8 +107,8 @@ function hasValidSignature(
 ): boolean {
   const digest = createHmac('sha256', secret).update(signedPortion).digest();
   return (
-    safeEqual(signatureSegment, digest.toString('base64url')) ||
-    safeEqual(signatureSegment, digest.toString('hex'))
+    safeEqualToken(signatureSegment, digest.toString('base64url')) ||
+    safeEqualToken(signatureSegment, digest.toString('hex'))
   );
 }
 

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -137,6 +137,7 @@ import {
   getSessionAuthPayload,
   hasLocalWebSessionAuth,
   hasSessionAuth,
+  safeEqualToken,
   setLocalWebSessionCookie,
   setSessionCookie,
   verifyLaunchToken,
@@ -1921,8 +1922,12 @@ function isRuntimeMSTeamsChannelConfig(
 function hasQueryToken(url: URL): boolean {
   const token = (url.searchParams.get('token') || '').trim();
   if (!token) return false;
-  if (WEB_API_TOKEN && token === WEB_API_TOKEN) return true;
-  return token === GATEWAY_API_TOKEN;
+  if (WEB_API_TOKEN && safeEqualToken(token, WEB_API_TOKEN)) return true;
+  return Boolean(GATEWAY_API_TOKEN) && safeEqualToken(token, GATEWAY_API_TOKEN);
+}
+
+function hasBearerToken(authHeader: string, token: string): boolean {
+  return Boolean(token) && safeEqualToken(authHeader, `Bearer ${token}`);
 }
 
 function isLoopbackSocketAddress(address: string | undefined): boolean {
@@ -2027,11 +2032,10 @@ function hasApiAuth(
   },
 ): boolean {
   const authHeader = req.headers.authorization || '';
-  const gatewayTokenMatch =
-    Boolean(GATEWAY_API_TOKEN) && authHeader === `Bearer ${GATEWAY_API_TOKEN}`;
+  const gatewayTokenMatch = hasBearerToken(authHeader, GATEWAY_API_TOKEN);
   if (opts?.allowQueryToken && url && hasQueryToken(url)) return true;
 
-  if (WEB_API_TOKEN && authHeader === `Bearer ${WEB_API_TOKEN}`) return true;
+  if (hasBearerToken(authHeader, WEB_API_TOKEN)) return true;
   if (
     opts?.allowLocalWebSession &&
     isLocalWebSessionAllowed(req) &&
@@ -2045,16 +2049,16 @@ function hasApiAuth(
 
 function hasGatewayApiAuth(req: IncomingMessage): boolean {
   const authHeader = req.headers.authorization || '';
-  return (
-    Boolean(GATEWAY_API_TOKEN) && authHeader === `Bearer ${GATEWAY_API_TOKEN}`
-  );
+  return hasBearerToken(authHeader, GATEWAY_API_TOKEN);
 }
 
 function hasApiTokenValue(token: string): boolean {
   const trimmed = token.trim();
   if (!trimmed) return false;
-  if (WEB_API_TOKEN && trimmed === WEB_API_TOKEN) return true;
-  return Boolean(GATEWAY_API_TOKEN) && trimmed === GATEWAY_API_TOKEN;
+  if (WEB_API_TOKEN && safeEqualToken(trimmed, WEB_API_TOKEN)) return true;
+  return (
+    Boolean(GATEWAY_API_TOKEN) && safeEqualToken(trimmed, GATEWAY_API_TOKEN)
+  );
 }
 
 function readRecordProperty(
@@ -2115,10 +2119,10 @@ function resolveAdminSecretAuditContext(
 
 function resolveApiMediaUploadQuotaKey(req: IncomingMessage): string {
   const authHeader = req.headers.authorization || '';
-  if (WEB_API_TOKEN && authHeader === `Bearer ${WEB_API_TOKEN}`) {
+  if (hasBearerToken(authHeader, WEB_API_TOKEN)) {
     return 'web-token';
   }
-  if (GATEWAY_API_TOKEN && authHeader === `Bearer ${GATEWAY_API_TOKEN}`) {
+  if (hasBearerToken(authHeader, GATEWAY_API_TOKEN)) {
     return 'gateway-token';
   }
   return 'authenticated';

--- a/tests/gateway-auth-token.test.ts
+++ b/tests/gateway-auth-token.test.ts
@@ -42,6 +42,15 @@ afterEach(() => {
 });
 
 describe('gateway auth token helpers', () => {
+  test('compares tokens without throwing on length mismatches', async () => {
+    const { safeEqualToken } = await import('../src/gateway/auth-token.ts');
+
+    expect(safeEqualToken('test-token', 'test-token')).toBe(true);
+    expect(safeEqualToken('test-token', 'test-token-extra')).toBe(false);
+    expect(safeEqualToken('test-token-extra', 'test-token')).toBe(false);
+    expect(safeEqualToken('test-token', 'test-tokex')).toBe(false);
+  });
+
   test('verifies a valid launch token signed with the shared secret', async () => {
     process.env.HYBRIDCLAW_AUTH_SECRET = 'unit-secret';
     const { verifyLaunchToken } = await import('../src/gateway/auth-token.ts');


### PR DESCRIPTION
## Summary

- Export the gateway auth token constant-time comparison helper for shared use.
- Replace direct gateway/web API token equality checks in gateway HTTP auth paths with `safeEqualToken`.
- Add coverage for exact matches and length-mismatch failures without throwing.

## Root Cause

Gateway bearer and query token checks used direct string equality, which can leak match-prefix timing information for configured API tokens.

## Validation

- `npx biome check --write src/gateway/auth-token.ts src/gateway/gateway-http-server.ts tests/gateway-auth-token.test.ts`
- `npx vitest run tests/gateway-auth-token.test.ts`
- `./node_modules/.bin/tsc --noEmit`