### PR TITLE
[codex] Use UUIDs for delegation identifiers

### DIFF
--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -7843,7 +7843,7 @@ function nextDelegationSessionId(
   const safeParent = parentSessionId
     .replace(/[^a-zA-Z0-9:_-]/g, '-')
     .slice(0, 48);
-  const nonce = Math.random().toString(36).slice(2, 8);
+  const nonce = randomUUID();
   return `delegate:d${nextDepth}:${safeParent}:${Date.now()}:${nonce}`;
 }
 
@@ -8829,7 +8829,7 @@ export function enqueueDelegationBatchFromSideEffects(params: {
           .filter(Boolean)
           .join(', ') || undefined;
 
-  const jobId = `${parentSessionId}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`;
+  const jobId = `${parentSessionId}:${Date.now()}:${randomUUID()}`;
   enqueueDelegation({
     id: jobId,
     run: async () => {

--- a/tests/gateway-delegation-proactive.test.ts
+++ b/tests/gateway-delegation-proactive.test.ts
@@ -360,6 +360,11 @@ test('delegation batch queues status updates and a synthesized final answer for 
   inspect.close();
 
   expect(childRows).toHaveLength(2);
+  for (const row of childRows) {
+    expect(row.session_id).toMatch(
+      /^delegate:d1:parent-session:\d+:[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  }
   const parsedChildRows = childRows.map((row) => ({
     session_id: row.session_id,
     messages: JSON.parse(row.messages_json || '[]') as Array<{


### PR DESCRIPTION
## Summary
- Replace short `Math.random()` delegation session nonces with `randomUUID()`.
- Replace delegation batch job ID random suffixes with `randomUUID()`.
- Add a focused delegation proactive test assertion for UUID-shaped child session IDs.

## Why
Delegation session IDs and job IDs previously used roughly 31 bits of non-cryptographic entropy from `Math.random()`. If these identifiers are ever used to gate access to session or job state, that makes them easier to enumerate or predict. UUID v4 identifiers use cryptographic randomness through Node's `crypto` module.

## Validation
- `rg "Math\\.random" src/gateway/gateway-service.ts`
- `npx vitest run --configLoader runner --project unit tests/gateway-delegation-proactive.test.ts`
- `npm run typecheck`