### PR TITLE
[codex] Use async realpath for gateway containment checks

### DIFF
--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -329,6 +329,8 @@ const HARNESS_EVOLUTION_ALLOWED_ROOTS = [
     .map((entry) => entry.trim())
     .filter(Boolean),
 ].map((entry) => path.resolve(entry));
+let resolvedHarnessEvolutionAllowedRootsPromise: Promise<string[]> | null =
+  null;
 const DISCORD_MEDIA_CACHE_ROOT_DISPLAY = '/discord-media-cache';
 const DISCORD_MEDIA_CACHE_DIR = path.resolve(
   path.join(DATA_DIR, 'discord-media-cache'),
@@ -2495,24 +2497,24 @@ async function resolveValidatedApiChatMediaHostPath(
 async function isAllowedApiChatMediaHostPath(
   hostPath: string,
 ): Promise<boolean> {
-  const normalizedHostPath = await resolvePathForContainmentCheck(hostPath);
-  if (
-    isWithinRoot(
-      normalizedHostPath,
-      await resolvePathForContainmentCheck(DISCORD_MEDIA_CACHE_DIR),
-    )
-  ) {
+  const uploadedMediaCacheDir = getUploadedMediaCacheDirOrNull();
+  const [normalizedHostPath, discordMediaCacheDir, uploadedMediaCacheRoot] =
+    await Promise.all([
+      resolvePathForContainmentCheck(hostPath),
+      resolvePathForContainmentCheck(DISCORD_MEDIA_CACHE_DIR),
+      uploadedMediaCacheDir
+        ? resolvePathForContainmentCheck(uploadedMediaCacheDir)
+        : Promise.resolve(null),
+    ]);
+
+  if (isWithinRoot(normalizedHostPath, discordMediaCacheDir)) {
     return true;
   }
 
-  const uploadedMediaCacheDir = getUploadedMediaCacheDirOrNull();
-  if (!uploadedMediaCacheDir) {
+  if (!uploadedMediaCacheRoot) {
     return false;
   }
-  return isWithinRoot(
-    normalizedHostPath,
-    await resolvePathForContainmentCheck(uploadedMediaCacheDir),
-  );
+  return isWithinRoot(normalizedHostPath, uploadedMediaCacheRoot);
 }
 
 async function normalizeApiChatMediaItems(
@@ -6123,16 +6125,22 @@ async function assertPathInsideRoot(
 async function isAllowedHarnessEvolutionRoot(
   targetRoot: string,
 ): Promise<boolean> {
-  const resolvedTargetRoot =
-    await resolveHarnessEvolutionAccessPathForRequest(targetRoot);
-  const allowedRoots = await Promise.all(
+  const [resolvedTargetRoot, allowedRoots] = await Promise.all([
+    resolveHarnessEvolutionAccessPathForRequest(targetRoot),
+    getResolvedHarnessEvolutionAllowedRoots(),
+  ]);
+  return allowedRoots.some((root) =>
+    isPathInsideRoot(root, resolvedTargetRoot),
+  );
+}
+
+function getResolvedHarnessEvolutionAllowedRoots(): Promise<string[]> {
+  resolvedHarnessEvolutionAllowedRootsPromise ??= Promise.all(
     HARNESS_EVOLUTION_ALLOWED_ROOTS.map((root) =>
       resolveHarnessEvolutionAccessPathForRequest(root),
     ),
   );
-  return allowedRoots.some((root) =>
-    isPathInsideRoot(root, resolvedTargetRoot),
-  );
+  return resolvedHarnessEvolutionAllowedRootsPromise;
 }
 
 async function resolveHarnessEvolutionAccessPathForRequest(

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -327,7 +327,7 @@ const HARNESS_EVOLUTION_ALLOWED_ROOTS = [
     .split(',')
     .map((entry) => entry.trim())
     .filter(Boolean),
-].map((entry) => resolveHarnessEvolutionAccessPath(entry));
+].map((entry) => path.resolve(entry));
 const DISCORD_MEDIA_CACHE_ROOT_DISPLAY = '/discord-media-cache';
 const DISCORD_MEDIA_CACHE_DIR = path.resolve(
   path.join(DATA_DIR, 'discord-media-cache'),
@@ -2371,9 +2371,11 @@ function isWithinRoot(candidate: string, root: string): boolean {
   );
 }
 
-function resolvePathForContainmentCheck(filePath: string): string {
+async function resolvePathForContainmentCheck(
+  filePath: string,
+): Promise<string> {
   try {
-    return fs.realpathSync(filePath);
+    return await fs.promises.realpath(filePath);
   } catch {
     return path.resolve(filePath);
   }
@@ -2451,7 +2453,9 @@ function resolveArtifactRequestPath(rawPath: string): string | null {
   );
 }
 
-function resolveValidatedApiChatMediaHostPath(rawPath: string): string | null {
+async function resolveValidatedApiChatMediaHostPath(
+  rawPath: string,
+): Promise<string | null> {
   const trimmed = rawPath.trim();
   if (!trimmed) return null;
 
@@ -2461,7 +2465,7 @@ function resolveValidatedApiChatMediaHostPath(rawPath: string): string | null {
       DISCORD_MEDIA_CACHE_ROOT_DISPLAY,
       DISCORD_MEDIA_CACHE_DIR,
     );
-    return resolved ? resolvePathForContainmentCheck(resolved) : null;
+    return resolved ? await resolvePathForContainmentCheck(resolved) : null;
   }
 
   const uploadedMediaCacheDir = getUploadedMediaCacheDirOrNull();
@@ -2474,7 +2478,7 @@ function resolveValidatedApiChatMediaHostPath(rawPath: string): string | null {
       UPLOADED_MEDIA_CACHE_ROOT_DISPLAY,
       uploadedMediaCacheDir,
     );
-    return resolved ? resolvePathForContainmentCheck(resolved) : null;
+    return resolved ? await resolvePathForContainmentCheck(resolved) : null;
   }
 
   if (!path.isAbsolute(trimmed)) {
@@ -2484,12 +2488,14 @@ function resolveValidatedApiChatMediaHostPath(rawPath: string): string | null {
   return resolvePathForContainmentCheck(trimmed);
 }
 
-function isAllowedApiChatMediaHostPath(hostPath: string): boolean {
-  const normalizedHostPath = resolvePathForContainmentCheck(hostPath);
+async function isAllowedApiChatMediaHostPath(
+  hostPath: string,
+): Promise<boolean> {
+  const normalizedHostPath = await resolvePathForContainmentCheck(hostPath);
   if (
     isWithinRoot(
       normalizedHostPath,
-      resolvePathForContainmentCheck(DISCORD_MEDIA_CACHE_DIR),
+      await resolvePathForContainmentCheck(DISCORD_MEDIA_CACHE_DIR),
     )
   ) {
     return true;
@@ -2501,11 +2507,13 @@ function isAllowedApiChatMediaHostPath(hostPath: string): boolean {
   }
   return isWithinRoot(
     normalizedHostPath,
-    resolvePathForContainmentCheck(uploadedMediaCacheDir),
+    await resolvePathForContainmentCheck(uploadedMediaCacheDir),
   );
 }
 
-function normalizeApiChatMediaItems(raw: unknown): MediaContextItem[] {
+async function normalizeApiChatMediaItems(
+  raw: unknown,
+): Promise<MediaContextItem[]> {
   if (raw == null) return [];
   if (!Array.isArray(raw)) {
     throw new GatewayRequestError(400, 'Invalid `media` in request body.');
@@ -2542,8 +2550,12 @@ function normalizeApiChatMediaItems(raw: unknown): MediaContextItem[] {
       );
     }
 
-    const resolvedHostPath = resolveValidatedApiChatMediaHostPath(pathValue);
-    if (!resolvedHostPath || !isAllowedApiChatMediaHostPath(resolvedHostPath)) {
+    const resolvedHostPath =
+      await resolveValidatedApiChatMediaHostPath(pathValue);
+    if (
+      !resolvedHostPath ||
+      !(await isAllowedApiChatMediaHostPath(resolvedHostPath))
+    ) {
       throw new GatewayRequestError(
         400,
         `Invalid \`media[${index}].path\`. Only uploaded or Discord media cache files are accepted.`,
@@ -2590,7 +2602,7 @@ function normalizeApiChatMediaItems(raw: unknown): MediaContextItem[] {
   return normalized;
 }
 
-function resolveArtifactFile(url: URL): string | null {
+async function resolveArtifactFile(url: URL): Promise<string | null> {
   const raw = (url.searchParams.get('path') || '').trim();
   if (!raw) return null;
   const resolved = resolveArtifactRequestPath(raw);
@@ -2598,31 +2610,31 @@ function resolveArtifactFile(url: URL): string | null {
   const uploadedMediaCacheDir = getUploadedMediaCacheDirOrNull();
   let realFilePath: string;
   try {
-    realFilePath = fs.realpathSync(resolved);
+    realFilePath = await fs.promises.realpath(resolved);
   } catch {
     return null;
   }
+  const allowedRoots = [
+    AGENT_ARTIFACT_ROOT,
+    DISCORD_MEDIA_CACHE_DIR,
+    ...(uploadedMediaCacheDir ? [uploadedMediaCacheDir] : []),
+  ];
+  const allowedRootPaths = await Promise.all(
+    allowedRoots.map((root) => resolvePathForContainmentCheck(root)),
+  );
   if (
-    !isWithinRoot(
-      realFilePath,
-      resolvePathForContainmentCheck(AGENT_ARTIFACT_ROOT),
-    ) &&
-    !isWithinRoot(
-      realFilePath,
-      resolvePathForContainmentCheck(DISCORD_MEDIA_CACHE_DIR),
-    ) &&
-    !(
-      uploadedMediaCacheDir &&
-      isWithinRoot(
-        realFilePath,
-        resolvePathForContainmentCheck(uploadedMediaCacheDir),
-      )
+    !allowedRootPaths.some((allowedRoot) =>
+      isWithinRoot(realFilePath, allowedRoot),
     )
   ) {
     return null;
   }
-  if (!fs.existsSync(realFilePath) || !fs.statSync(realFilePath).isFile())
+  try {
+    const stats = await fs.promises.stat(realFilePath);
+    if (!stats.isFile()) return null;
+  } catch {
     return null;
+  }
   return realFilePath;
 }
 
@@ -2816,7 +2828,7 @@ async function handleApiChat(
 ): Promise<void> {
   const body = (await readJsonBody(req)) as Partial<ApiChatRequestBody>;
   const wantsStream = body.stream === true;
-  const media = normalizeApiChatMediaItems(body.media);
+  const media = await normalizeApiChatMediaItems(body.media);
 
   const content = body.content?.trim() || buildMediaOnlyPromptContent(media);
   if (!content) {
@@ -6052,7 +6064,7 @@ async function handleApiAdminHarnessEvolution(
   }
 
   const root = path.resolve(targetRoot);
-  if (!isAllowedHarnessEvolutionRoot(root)) {
+  if (!(await isAllowedHarnessEvolutionRoot(root))) {
     sendJson(res, 403, {
       error:
         'targetRoot is not under an allowed harness evolution root. Set HYBRIDCLAW_HARNESS_EVOLUTION_ROOTS or use the runtime data harness-evolution directory.',
@@ -6062,14 +6074,14 @@ async function handleApiAdminHarnessEvolution(
   try {
     const evolution = await import('../evolution/harness-evolution.js');
     if (manifestPath) {
-      assertPathInsideRoot(root, manifestPath);
+      await assertPathInsideRoot(root, manifestPath);
       sendJson(res, 200, {
         manifest: evolution.readHarnessEvolutionManifest(manifestPath),
       });
       return;
     }
     if (summaryPath) {
-      assertPathInsideRoot(root, summaryPath);
+      await assertPathInsideRoot(root, summaryPath);
       sendJson(res, 200, {
         run: evolution.readHarnessEvolutionSummary(summaryPath),
       });
@@ -6087,28 +6099,47 @@ async function handleApiAdminHarnessEvolution(
   }
 }
 
-function assertPathInsideRoot(root: string, candidate: string): void {
-  const rootReal = fs.realpathSync(root);
+async function assertPathInsideRoot(
+  root: string,
+  candidate: string,
+): Promise<void> {
+  const rootReal = await fs.promises.realpath(root);
   const candidatePath = path.resolve(candidate);
-  if (!fs.existsSync(candidatePath)) {
+  try {
+    await fs.promises.access(candidatePath);
+  } catch {
     throw new GatewayRequestError(400, 'Requested path does not exist.');
   }
-  const candidateReal = fs.realpathSync(candidatePath);
+  const candidateReal = await fs.promises.realpath(candidatePath);
   if (!isPathInsideRoot(rootReal, candidateReal)) {
     throw new GatewayRequestError(400, 'Requested path is outside targetRoot.');
   }
 }
 
-function isAllowedHarnessEvolutionRoot(targetRoot: string): boolean {
-  const resolvedTargetRoot = resolveHarnessEvolutionAccessPath(targetRoot);
-  return HARNESS_EVOLUTION_ALLOWED_ROOTS.some((root) =>
+async function isAllowedHarnessEvolutionRoot(
+  targetRoot: string,
+): Promise<boolean> {
+  const resolvedTargetRoot =
+    await resolveHarnessEvolutionAccessPathForRequest(targetRoot);
+  const allowedRoots = await Promise.all(
+    HARNESS_EVOLUTION_ALLOWED_ROOTS.map((root) =>
+      resolveHarnessEvolutionAccessPathForRequest(root),
+    ),
+  );
+  return allowedRoots.some((root) =>
     isPathInsideRoot(root, resolvedTargetRoot),
   );
 }
 
-function resolveHarnessEvolutionAccessPath(candidate: string): string {
+async function resolveHarnessEvolutionAccessPathForRequest(
+  candidate: string,
+): Promise<string> {
   const resolved = path.resolve(candidate);
-  return fs.existsSync(resolved) ? fs.realpathSync(resolved) : resolved;
+  try {
+    return await fs.promises.realpath(resolved);
+  } catch {
+    return resolved;
+  }
 }
 
 function isPathInsideRoot(root: string, candidate: string): boolean {
@@ -6160,11 +6191,11 @@ function handleApiEvents(
   });
 }
 
-function handleApiArtifact(
+async function handleApiArtifact(
   req: IncomingMessage,
   res: ServerResponse,
   url: URL,
-): void {
+): Promise<void> {
   if (
     !hasApiAuth(req, url, {
       allowLocalWebSession: true,
@@ -6178,7 +6209,7 @@ function handleApiArtifact(
     return;
   }
 
-  const filePath = resolveArtifactFile(url);
+  const filePath = await resolveArtifactFile(url);
   if (!filePath) {
     sendJson(res, 404, { error: 'Artifact not found.' });
     return;
@@ -6550,9 +6581,8 @@ export function startGatewayHttpServer(): GatewayHttpServer {
         return;
       }
       if (pathname === '/api/artifact' && method === 'GET') {
-        try {
-          handleApiArtifact(req, res, url);
-        } catch (err) {
+        void handleApiArtifact(req, res, url).catch((err: unknown) => {
+          if (res.writableEnded) return;
           const errorText = err instanceof Error ? err.message : String(err);
           const statusCode =
             err instanceof GatewayRequestError ||
@@ -6560,7 +6590,7 @@ export function startGatewayHttpServer(): GatewayHttpServer {
               ? err.statusCode
               : 500;
           sendJson(res, statusCode, { error: errorText });
-        }
+        });
         return;
       }
       if (pathname === '/api/agent-avatar' && method === 'GET') {

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -8520,7 +8520,7 @@ describe('gateway HTTP server', () => {
     const res = makeResponse();
 
     state.handler(req as never, res as never);
-    await settle();
+    await waitForResponse(res, (response) => response.statusCode !== 0);
 
     expect(state.handleGatewayMessage).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -8564,7 +8564,7 @@ describe('gateway HTTP server', () => {
     const res = makeResponse();
 
     state.handler(req as never, res as never);
-    await settle();
+    await waitForResponse(res, (response) => response.statusCode !== 0);
 
     expect(state.handleGatewayMessage).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -8636,7 +8636,7 @@ describe('gateway HTTP server', () => {
     const res = makeResponse();
 
     state.handler(req as never, res as never);
-    await settle();
+    await waitForResponse(res, (response) => response.statusCode !== 0);
 
     expect(state.handleGatewayMessage).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(400);
@@ -12602,7 +12602,7 @@ describe('gateway HTTP server', () => {
     const res = makeResponse();
 
     state.handler(req as never, res as never);
-    await settle();
+    await waitForResponse(res, (response) => response.statusCode !== 0);
 
     expect(res.statusCode).toBe(404);
     expect(JSON.parse(res.body)).toEqual({


### PR DESCRIPTION
## Summary

- Convert gateway containment realpath checks from synchronous `fs.realpathSync` to `fs.promises.realpath` on artifact, chat media, and harness evolution request paths.
- Keep symlink-aware containment behavior intact while avoiding request-time blocking on realpath/stat syscalls.
- Wire `/api/artifact` through the async handler path and use async stat for the final file check.

## Validation

- `npx biome check --write src/gateway/gateway-http-server.ts`
- `./node_modules/.bin/tsc --noEmit`
- `npm run lint`
- `rg "realpathSync" src/gateway/gateway-http-server.ts`