### PR TITLE
[codex] Reuse shared isRecord guard

### DIFF
--- a/src/a2a/a2a-outbox-persistence.ts
+++ b/src/a2a/a2a-outbox-persistence.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
-
 import {
   listRuntimeAssetRevisionStates,
   syncRuntimeAssetRevisionState,
@@ -9,6 +8,7 @@ import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
 import { logger } from '../logger.js';
 import type { SecretRef } from '../security/secret-refs.js';
 import type { EscalationTarget } from '../types/execution.js';
+import { isRecord } from '../utils/type-guards.js';
 import { type A2AEnvelope, validateA2AEnvelope } from './envelope.js';
 import type { A2APeerDescriptor } from './peer-descriptor.js';
 import type { TransportAdapterContext } from './transport-registry.js';
@@ -76,10 +76,6 @@ export function nowIso(now: Date): string {
 
 function outboxAssetPath(id: string): string {
   return path.join(A2A_OUTBOX_ASSET_PREFIX, `${id}.json`);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function normalizeIdentityResolution(

--- a/src/a2a/utils.ts
+++ b/src/a2a/utils.ts
@@ -1,8 +1,6 @@
 import { isIP } from 'node:net';
 
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
+export { isRecord } from '../utils/type-guards.js';
 
 export const A2A_TRANSPORT_PATTERN = /^[a-z][a-z0-9._-]{0,63}$/;
 

--- a/src/agents/agent-config-command.ts
+++ b/src/agents/agent-config-command.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
 import { agentWorkspaceDir } from '../infra/ipc.js';
 import { normalizeOptionalTrimmedUniqueStringArray } from '../utils/normalized-strings.js';
+import { isRecord } from '../utils/type-guards.js';
 import { ensureBootstrapFiles } from '../workspace.js';
 import {
   getAgentById,
@@ -57,10 +57,6 @@ type AgentConfigJsonPayload = Record<string, unknown> & {
   files?: unknown;
   markdown?: unknown;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
-}
 
 function normalizeOptionalString(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;

--- a/src/agents/claw-archive.ts
+++ b/src/agents/claw-archive.ts
@@ -25,6 +25,7 @@ import {
   type SkillImportResult,
 } from '../skills/skills-import.js';
 import { normalizeTrimmedString as normalizeString } from '../utils/normalized-strings.js';
+import { isRecord } from '../utils/type-guards.js';
 import { ensureBootstrapFiles } from '../workspace.js';
 import {
   deleteRegisteredAgent,
@@ -178,10 +179,6 @@ export interface UninstallAgentResult {
 
 export interface UninstallAgentOptions {
   existingAgent?: AgentConfig | null;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value != null && typeof value === 'object' && !Array.isArray(value);
 }
 
 function sanitizeArchiveFileStem(value: string): string {

--- a/src/agents/claw-manifest.ts
+++ b/src/agents/claw-manifest.ts
@@ -1,10 +1,10 @@
 import path from 'node:path';
-
 import {
   normalizeOptionalTrimmedUniqueStringArray,
   normalizeTrimmedString as normalizeString,
   normalizeTrimmedUniqueStringArray,
 } from '../utils/normalized-strings.js';
+import { isRecord } from '../utils/type-guards.js';
 import type { AgentModelConfig } from './agent-types.js';
 
 export const CLAW_FORMAT_VERSION = 1 as const;
@@ -76,10 +76,6 @@ type ClawPluginConfigList = Array<{
   enabled: boolean;
   config?: Record<string, unknown>;
 }>;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value != null && typeof value === 'object' && !Array.isArray(value);
-}
 
 function normalizeStringArray(value: unknown): string[] {
   return Array.isArray(value) ? normalizeTrimmedUniqueStringArray(value) : [];

--- a/src/auth/anthropic-auth.ts
+++ b/src/auth/anthropic-auth.ts
@@ -11,6 +11,7 @@ import {
   runtimeSecretsPath,
 } from '../security/runtime-secrets.js';
 import type { AnthropicMethod } from '../types/models.js';
+import { isRecord } from '../utils/type-guards.js';
 
 const CLAUDE_CLI_CREDENTIALS_RELATIVE_PATH = '.claude/.credentials.json';
 const CLAUDE_CLI_KEYCHAIN_SERVICE = 'Claude Code-credentials';
@@ -66,10 +67,6 @@ export function claudeCliCredentialsPath(): string {
 
 export function claudeCliKeychainLabel(): string {
   return `macOS Keychain (${CLAUDE_CLI_KEYCHAIN_SERVICE})`;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function normalizeString(value: unknown): string {

--- a/src/auth/codex-auth.ts
+++ b/src/auth/codex-auth.ts
@@ -9,6 +9,7 @@ import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
 import { CODEX_DEFAULT_BASE_URL } from '../providers/codex-constants.js';
 import { normalizeTrimmedString as normalizeString } from '../utils/normalized-strings.js';
 import { sleep } from '../utils/sleep.js';
+import { isRecord } from '../utils/type-guards.js';
 
 export const CODEX_AUTH_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
 export const CODEX_AUTH_ISSUER = 'https://auth.openai.com';
@@ -134,10 +135,6 @@ export class CodexAuthError extends Error {
     this.retryable = options?.retryable === true;
     this.status = options?.status;
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function normalizeTimestamp(value: unknown): number {

--- a/src/browser/managed-browser-tenant-policy.ts
+++ b/src/browser/managed-browser-tenant-policy.ts
@@ -1,13 +1,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
-
 import YAML from 'yaml';
-
 import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import { DATA_DIR } from '../config/config.js';
 import { getRuntimeConfig } from '../config/runtime-config.js';
 import { agentWorkspaceDir } from '../infra/ipc.js';
 import { readPolicyState } from '../policy/policy-store.js';
+import { isRecord } from '../utils/type-guards.js';
 
 export interface ManagedBrowserTenantPolicySyncResult {
   tenantId: string;
@@ -59,10 +58,6 @@ export function ensureLocalManagedBrowserTenantPolicyFile(
     mode: 0o600,
   });
   return policyPath;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
 }
 
 function readPolicyDocument(policyPath: string): TenantPolicyDocument {

--- a/src/commands/second-opinion-web-search.ts
+++ b/src/commands/second-opinion-web-search.ts
@@ -5,6 +5,7 @@ import {
   WEB_SEARCH_PROVIDER,
   WEB_SEARCH_TAVILY_SEARCH_DEPTH,
 } from '../config/config.js';
+import { isRecord } from '../utils/type-guards.js';
 
 export type SecondOpinionWebSearchProvider = 'brave' | 'tavily' | 'duckduckgo';
 
@@ -30,10 +31,6 @@ const SECOND_OPINION_SEARCH_RESULT_LIMIT = 10;
 const SECOND_OPINION_FETCH_EXCERPT_LIMIT = 1200;
 const SECOND_OPINION_USER_AGENT =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36';
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
-}
 
 function decodeEntities(value: string): string {
   return value

--- a/src/config/app-version.ts
+++ b/src/config/app-version.ts
@@ -1,12 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
 import { logger } from '../logger.js';
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
+import { isRecord } from '../utils/type-guards.js';
 
 function readVersionFromPackageJson(packageJsonPath: string): string | null {
   try {

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -106,6 +106,7 @@ import {
   normalizeTrimmedStringSet,
 } from '../utils/normalized-strings.js';
 import { expandHomePath } from '../utils/path.js';
+import { isRecord } from '../utils/type-guards.js';
 import {
   clearRuntimeAssetRevisions as clearTrackedRuntimeAssetRevisions,
   clearRuntimeConfigRevisions as clearTrackedRuntimeConfigRevisions,
@@ -2048,10 +2049,6 @@ function isRuntimeConfigWatcherDisabled(): boolean {
 
 function cloneConfig<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function normalizeString(

--- a/src/evals/hybridai-skills-command.ts
+++ b/src/evals/hybridai-skills-command.ts
@@ -10,6 +10,7 @@ import { parseSessionKey } from '../session/session-key.js';
 import { DEFAULT_SKILL_SUPPORTED_CHANNELS } from '../skills/skill-manifest.js';
 import { resolveObservedSkillName, type Skill } from '../skills/skills.js';
 import type { ToolExecution } from '../types/execution.js';
+import { isRecord } from '../utils/type-guards.js';
 import {
   joinSections,
   renderKeyValueSection,
@@ -1929,10 +1930,6 @@ function infoResult(title: string, text: string): GatewayCommandResult {
 
 function errorResult(title: string, text: string): GatewayCommandResult {
   return { kind: 'error', title, text };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function resolveInstallRootSafe(): string {

--- a/src/evals/trace-preparation.ts
+++ b/src/evals/trace-preparation.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-
 import {
   type RuntimeConfigChangeMeta,
   syncRuntimeAssetRevisionState,
@@ -21,6 +20,7 @@ import {
 import { redactSecrets } from '../security/redact.js';
 import { estimateTokenCountFromText } from '../session/token-efficiency.js';
 import type { ChatMessage } from '../types/api.js';
+import { isRecord } from '../utils/type-guards.js';
 
 export const DEFAULT_TRACE_PREPARE_MAX_TOOL_CALLS = 40;
 export const DEFAULT_TRACE_PREPARE_MAX_TRACE_TOKENS = 16_000;
@@ -128,10 +128,6 @@ const DEFAULT_TRACE_JUDGE_TEMPLATE: TracePromptTemplate = {
     'Judge trace against criteria.',
   ].join('\n'),
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value != null && typeof value === 'object' && !Array.isArray(value);
-}
 
 export function serializeTracePreparationInput(value: unknown): string {
   if (typeof value === 'string') return value.trim();

--- a/src/gateway/gateway-plugin-service.ts
+++ b/src/gateway/gateway-plugin-service.ts
@@ -38,6 +38,7 @@ import {
   shutdownPluginManager,
 } from '../plugins/plugin-manager.js';
 import { isPluginInboundWebhookPath } from '../plugins/plugin-webhooks.js';
+import { isRecord } from '../utils/type-guards.js';
 import { consumeCommandApproval } from './command-approval-trust.js';
 import { handleGatewayMessage } from './gateway-chat-service.js';
 import { tryEnsurePluginManagerInitializedForGateway } from './gateway-plugin-runtime.js';
@@ -1022,10 +1023,6 @@ function normalizePluginCommandResult(value: unknown): GatewayCommandResult {
     }
   }
   return { kind: 'plain', text: JSON.stringify(value, null, 2) };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
 function isGatewayMessageComponents(

--- a/src/gateway/gateway-scheduled-task-service.ts
+++ b/src/gateway/gateway-scheduled-task-service.ts
@@ -32,6 +32,7 @@ import {
   resumeConfigJob,
 } from '../scheduler/scheduler.js';
 import type { SessionResetPolicy } from '../session/session-reset.js';
+import { isRecord } from '../utils/type-guards.js';
 import type { ProactiveMessagePayload } from './fullauto-runtime.js';
 import {
   prepareSessionAutoReset,
@@ -42,10 +43,6 @@ import type {
   GatewayAdminSchedulerJob,
   GatewayAdminSchedulerResponse,
 } from './gateway-types.js';
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
 
 function isRunOnceScheduleKind(
   kind: RuntimeSchedulerJob['schedule']['kind'],

--- a/src/gateway/openai-compatible-model.ts
+++ b/src/gateway/openai-compatible-model.ts
@@ -9,6 +9,7 @@ import {
 import type { ResolvedModelRuntimeCredentials } from '../providers/types.js';
 import type { ChatMessage, ToolCall } from '../types/api.js';
 import type { TokenUsageStats } from '../types/usage.js';
+import { isRecord } from '../utils/type-guards.js';
 
 export interface OpenAICompatibleToolDefinition {
   type: 'function';
@@ -149,10 +150,6 @@ function collapseSystemMessages(messages: ChatMessage[]): ChatMessage[] {
     },
     ...remaining,
   ];
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
 function parseErrorText(body: string): string {

--- a/src/gateway/output-guard-admin.ts
+++ b/src/gateway/output-guard-admin.ts
@@ -8,6 +8,7 @@ import {
 import { listRuntimeConfigRevisions } from '../config/runtime-config-revisions.js';
 import { logger } from '../logger.js';
 import { callAuxiliaryModel } from '../providers/auxiliary.js';
+import { isRecord } from '../utils/type-guards.js';
 import { reloadPluginRuntime } from './gateway-plugin-service.js';
 import type {
   GatewayAdminOutputGuardModelConfig,
@@ -94,10 +95,6 @@ interface ClassifierVerdict {
 // mirrors plugins/output-guard/src/{config,guard,llm,rules}. Keep provider
 // defaults, prompts, verdict parsing, and rule summaries aligned with the
 // plugin runtime when either side changes.
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value != null && typeof value === 'object' && !Array.isArray(value);
-}
 
 function normalizeString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';

--- a/src/identity/agent-id.ts
+++ b/src/identity/agent-id.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
-
 import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+import { isRecord } from '../utils/type-guards.js';
 import {
   formatUserId,
   parseUserId,
@@ -58,10 +58,6 @@ export class LocalInstanceIdAllocationError extends Error {
 const AGENT_IDENTITY_COMPONENT_PATTERN = /^[a-z0-9][a-z0-9._-]{0,127}$/;
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
 
 function normalizeAgentIdentityComponent(value: string): string {
   return value.trim().toLowerCase();

--- a/src/infra/container-setup.ts
+++ b/src/infra/container-setup.ts
@@ -2,9 +2,9 @@ import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
-
 import { APP_VERSION, CONTAINER_IMAGE } from '../config/config.js';
 import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+import { isRecord } from '../utils/type-guards.js';
 import { startProgressIndicator } from './progress-indicator.js';
 
 export type ContainerRebuildPolicy = 'if-stale' | 'always' | 'never';
@@ -166,10 +166,6 @@ export async function containerImageExists(
 ): Promise<boolean> {
   const result = await runCommand('docker', ['image', 'inspect', imageName]);
   return result.code === 0;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function normalizeContainerVersion(value: string | undefined): string | null {

--- a/src/migration/agent-home-migration.ts
+++ b/src/migration/agent-home-migration.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-
 import YAML from 'yaml';
 import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import {
@@ -23,6 +22,7 @@ import {
 } from '../security/runtime-secrets.js';
 import { bootstrapRuntimeSecrets } from '../security/runtime-secrets-bootstrap.js';
 import type { McpServerConfig } from '../types/models.js';
+import { isRecord } from '../utils/type-guards.js';
 
 export type AgentMigrationSource = 'openclaw' | 'hermes';
 
@@ -133,10 +133,6 @@ const RUNTIME_SECRET_KEYS: RuntimeSecretKey[] = [
   'WEB_API_TOKEN',
   'GATEWAY_API_TOKEN',
 ];
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value != null && typeof value === 'object' && !Array.isArray(value);
-}
 
 function parseJsonFile(filePath: string): Record<string, unknown> {
   if (!fs.existsSync(filePath)) return {};

--- a/src/plugins/plugin-manager.ts
+++ b/src/plugins/plugin-manager.ts
@@ -32,6 +32,7 @@ import type { ToolExecution } from '../types/execution.js';
 import type { McpServerConfig } from '../types/models.js';
 import type { StoredMessage } from '../types/session.js';
 import { hasExecutableCommand } from '../utils/executables.js';
+import { isRecord } from '../utils/type-guards.js';
 import { createPluginApi } from './plugin-api.js';
 import type {
   HybridClawPluginDefinition,
@@ -218,10 +219,6 @@ export interface PluginManagerOptions {
     pluginId: string,
     request: PluginDispatchInboundMessageRequest,
   ) => Promise<import('../gateway/gateway-types.js').GatewayChatResult>;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value != null && typeof value === 'object' && !Array.isArray(value);
 }
 
 function safeString(value: () => unknown, fallback: string): string {

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -1,3 +1,4 @@
+import { isRecord } from '../utils/type-guards.js';
 /**
  * Scheduler — timer-based, arms for exact next-fire time.
  *
@@ -160,10 +161,6 @@ function defaultConfigJobMeta(): ConfigJobMeta {
     disabled: false,
     oneShotCompleted: false,
   };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function normalizeConfigJobMeta(value: unknown): ConfigJobMeta {

--- a/src/security/runtime-secrets.ts
+++ b/src/security/runtime-secrets.ts
@@ -8,6 +8,7 @@ import {
 import fs from 'node:fs';
 import path from 'node:path';
 import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+import { isRecord } from '../utils/type-guards.js';
 import { migrateLegacySecretFile } from './runtime-secrets-migration.js';
 
 const RUNTIME_SECRETS_FILE = 'credentials.json';
@@ -161,10 +162,6 @@ interface EncryptedSecretEntry {
 interface EncryptedSecretStore {
   version: typeof SECRET_STORE_VERSION;
   entries: Record<string, EncryptedSecretEntry>;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value != null && typeof value === 'object' && !Array.isArray(value);
 }
 
 function isEncryptedSecretEntry(value: unknown): value is EncryptedSecretEntry {

--- a/src/security/secret-refs.ts
+++ b/src/security/secret-refs.ts
@@ -1,3 +1,4 @@
+import { isRecord } from '../utils/type-guards.js';
 import {
   isRuntimeSecretName,
   readStoredRuntimeSecret,
@@ -27,10 +28,6 @@ type ParsedSecretInput =
   | { kind: 'plain' }
   | { kind: 'ref'; ref: SecretRef }
   | { kind: 'invalid'; reason: string };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
 
 export function hardenSecretRef(ref: StoreSecretRef): SecretRef {
   const hardened = { source: 'store' as const, id: ref.id };

--- a/src/session/session-trace-export.ts
+++ b/src/session/session-trace-export.ts
@@ -21,6 +21,7 @@ import {
 import type { StructuredAuditEntry } from '../types/audit.js';
 import type { Session, StoredMessage } from '../types/session.js';
 import type { UsageTotals } from '../types/usage.js';
+import { isRecord } from '../utils/type-guards.js';
 import {
   type AuditTurnTraceSelector,
   buildAuditTurnTraceRecords,
@@ -135,10 +136,6 @@ interface TraceExportRedactionStats {
 function safeFilePart(raw: string): string {
   const normalized = raw.trim().replace(/[^a-zA-Z0-9_-]/g, '_');
   return normalized || 'session';
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function exportBaseDir(agentId: string, sessionId: string): string {

--- a/src/tunnel/tailscale-tunnel-provider.ts
+++ b/src/tunnel/tailscale-tunnel-provider.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'node:child_process';
 import { recordAuditEvent as defaultRecordAuditEvent } from '../audit/audit-events.js';
 import { readStoredRuntimeSecret } from '../security/runtime-secrets.js';
+import { isRecord } from '../utils/type-guards.js';
 import {
   DEFAULT_TUNNEL_HEALTH_CHECK_TIMEOUT_MS as DEFAULT_COMMAND_TIMEOUT_MS,
   DEFAULT_TUNNEL_HEALTH_CHECK_INTERVAL_MS as DEFAULT_HEALTH_INTERVAL_MS,
@@ -101,10 +102,6 @@ function parseJson(value: string): unknown {
   } catch {
     return null;
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function normalizePublicUrl(value: unknown): string | null {

--- a/src/usage/media-generation-usage.ts
+++ b/src/usage/media-generation-usage.ts
@@ -4,6 +4,7 @@ import {
   readString,
 } from '../../container/shared/primitive-values.js';
 import type { ToolExecution } from '../types/execution.js';
+import { isRecord } from '../utils/type-guards.js';
 import type { TokenUsageEvent } from './token-usage-buffer.js';
 
 interface MediaUsageEventInput {
@@ -11,10 +12,6 @@ interface MediaUsageEventInput {
   agentId: string;
   auditRunId: string;
   toolExecutions: ToolExecution[];
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
 function readNonNegativeNumber(value: unknown): number | null {


### PR DESCRIPTION
## Summary

- Replaced local `isRecord()` helper definitions across root `src/` modules with imports from `src/utils/type-guards.ts`.
- Changed `src/a2a/utils.ts` to re-export the canonical helper so existing A2A callers keep their current import surface.
- Left container-local helpers untouched because the container package has its own TypeScript root and utility exports.

## Why

The codebase had many equivalent local `isRecord()` implementations despite a canonical guard already existing. Centralizing the root app usage removes duplicated validation logic without changing behavior.

## Validation

- `npm run typecheck`
- `npm run lint`
- `rg "function isRecord" -n src` returns only `src/utils/type-guards.ts`
