### PR TITLE
[codex] Centralize TUI ANSI handling

### DIFF
--- a/src/tui-approval-prompt.ts
+++ b/src/tui-approval-prompt.ts
@@ -3,6 +3,7 @@ import type readline from 'node:readline';
 import type { ApprovalScopeMode } from './approval-commands.js';
 import type { TuiApprovalDetails } from './tui-approval.js';
 import { wrapTuiBlock } from './tui-thinking.js';
+import { truncateAnsi, visibleAnsiWidth } from './utils/ansi.js';
 
 export type TuiApprovalSelectionOption = ApprovalScopeMode | 'skip';
 
@@ -36,66 +37,16 @@ type InternalReadline = readline.Interface & {
   _ttyWrite?: (chunk: string, key: readline.Key) => void;
 };
 
-function getAnsiSequenceLength(value: string, index: number): number {
-  if (value.charCodeAt(index) !== 27 || value[index + 1] !== '[') {
-    return 0;
-  }
-
-  let cursor = index + 2;
-  while (cursor < value.length) {
-    const code = value.charCodeAt(cursor);
-    if (code >= 64 && code <= 126) {
-      return cursor - index + 1;
-    }
-    cursor += 1;
-  }
-
-  return 0;
-}
-
 function truncateLine(value: string, width: number, reset = ''): string {
-  if (width <= 0) return '';
-  const targetVisibleLength = width === 1 ? 1 : width - 3;
-  let output = '';
-  let visibleLength = 0;
-  let truncated = false;
-  const hasAnsi = value.includes('\x1b[');
-
-  for (let index = 0; index < value.length; ) {
-    const ansiSequenceLength = getAnsiSequenceLength(value, index);
-    if (ansiSequenceLength > 0) {
-      output += value.slice(index, index + ansiSequenceLength);
-      index += ansiSequenceLength;
-      continue;
-    }
-
-    if (visibleLength >= targetVisibleLength) {
-      truncated = true;
-      break;
-    }
-
-    output += value[index] || '';
-    visibleLength += 1;
-    index += 1;
-  }
-
-  if (!truncated) return output;
-
-  return hasAnsi ? `${output}...${reset}` : `${output}...`;
+  return truncateAnsi(value, width, {
+    ellipsis: '...',
+    reset,
+    resetMode: 'ansi',
+  });
 }
 
 function visibleTerminalLength(value: string): number {
-  let visible = 0;
-  for (let index = 0; index < value.length; ) {
-    const ansiSequenceLength = getAnsiSequenceLength(value, index);
-    if (ansiSequenceLength > 0) {
-      index += ansiSequenceLength;
-      continue;
-    }
-    visible += 1;
-    index += (value.codePointAt(index) || 0) > 0xffff ? 2 : 1;
-  }
-  return visible;
+  return visibleAnsiWidth(value);
 }
 
 function sentenceCase(value: string): string {

--- a/src/tui-banner.ts
+++ b/src/tui-banner.ts
@@ -1,4 +1,5 @@
 import { detectRuntimeProviderPrefix } from './providers/task-routing.js';
+import { visibleAnsiWidth } from './utils/ansi.js';
 
 export interface TuiBannerPalette {
   reset: string;
@@ -106,47 +107,12 @@ const SLASH_COMMANDS = [
   '/usage',
 ] as const;
 
-function getAnsiSequenceLength(value: string, index: number): number {
-  if (value.charCodeAt(index) !== 27 || value[index + 1] !== '[') {
-    return 0;
-  }
-
-  let cursor = index + 2;
-  while (cursor < value.length) {
-    const code = value.charCodeAt(cursor);
-    if (code >= 64 && code <= 126) {
-      return cursor - index + 1;
-    }
-    cursor += 1;
-  }
-
-  return 0;
-}
-
-function stripAnsi(value: string): string {
-  let output = '';
-  for (let index = 0; index < value.length; ) {
-    const ansiSequenceLength = getAnsiSequenceLength(value, index);
-    if (ansiSequenceLength > 0) {
-      index += ansiSequenceLength;
-      continue;
-    }
-    output += value[index] || '';
-    index += 1;
-  }
-  return output;
-}
-
-function visibleLength(value: string): number {
-  return [...stripAnsi(value)].length;
-}
-
 function maxVisibleLength(lines: readonly string[]): number {
-  return lines.reduce((max, line) => Math.max(max, visibleLength(line)), 0);
+  return lines.reduce((max, line) => Math.max(max, visibleAnsiWidth(line)), 0);
 }
 
 function padVisibleEnd(value: string, width: number): string {
-  return `${value}${' '.repeat(Math.max(0, width - visibleLength(value)))}`;
+  return `${value}${' '.repeat(Math.max(0, width - visibleAnsiWidth(value)))}`;
 }
 
 function wrapValue(label: string, rawValue: string, width: number): string[] {

--- a/src/tui-skill-config.ts
+++ b/src/tui-skill-config.ts
@@ -7,6 +7,7 @@ import type {
   GatewayAdminSkill,
   GatewayAdminSkillsResponse,
 } from './gateway/gateway-types.js';
+import { truncateAnsi } from './utils/ansi.js';
 import { normalizeTrimmedStringSet } from './utils/normalized-strings.js';
 
 export type TuiSkillConfigScope = 'global' | SkillConfigChannelKind;
@@ -79,23 +80,6 @@ function resolveTuiSkillConfigPalette(
     ...DEFAULT_TUI_SKILL_CONFIG_PALETTE,
     ...palette,
   };
-}
-
-function getAnsiSequenceLength(value: string, index: number): number {
-  if (value.charCodeAt(index) !== 27 || value[index + 1] !== '[') {
-    return 0;
-  }
-
-  let cursor = index + 2;
-  while (cursor < value.length) {
-    const code = value.charCodeAt(cursor);
-    if (code >= 64 && code <= 126) {
-      return cursor - index + 1;
-    }
-    cursor += 1;
-  }
-
-  return 0;
 }
 
 export function getTuiSkillConfigChannel(
@@ -192,43 +176,12 @@ function countChangedScopes(mutations: TuiSkillConfigMutation[]): number {
 }
 
 function truncateLine(value: string, width: number): string {
-  if (width <= 0) return '';
-  let visibleLength = 0;
-  for (let index = 0; index < value.length; ) {
-    const ansiSequenceLength = getAnsiSequenceLength(value, index);
-    if (ansiSequenceLength > 0) {
-      index += ansiSequenceLength;
-      continue;
-    }
-    visibleLength += 1;
-    index += 1;
-  }
-  if (visibleLength <= width) return value;
-
-  const targetVisibleLength = width === 1 ? 1 : width - 1;
-  let output = '';
-  let writtenVisibleLength = 0;
-  const hasAnsi = value.includes('\x1b[');
-
-  for (
-    let index = 0;
-    index < value.length && writtenVisibleLength < targetVisibleLength;
-  ) {
-    const ansiSequenceLength = getAnsiSequenceLength(value, index);
-    if (ansiSequenceLength > 0) {
-      output += value.slice(index, index + ansiSequenceLength);
-      index += ansiSequenceLength;
-      continue;
-    }
-    output += value[index] || '';
-    writtenVisibleLength += 1;
-    index += 1;
-  }
-
-  if (width === 1) {
-    return hasAnsi ? `${output}\x1b[0m` : output;
-  }
-  return hasAnsi ? `${output}…\x1b[0m` : `${output}…`;
+  return truncateAnsi(value, width, {
+    ellipsis: '…',
+    includeEllipsis: width > 1,
+    reset: DEFAULT_TUI_SKILL_CONFIG_PALETTE.reset,
+    resetMode: 'ansi',
+  });
 }
 
 function scopeTab(

--- a/src/tui-thinking.ts
+++ b/src/tui-thinking.ts
@@ -1,9 +1,11 @@
+import {
+  stripAnsi,
+  terminalCellWidth,
+  terminalCharCellWidth,
+} from './utils/ansi.js';
+
 const DEFAULT_TUI_INDENT = '  ';
 const STREAM_TOKEN_PATTERN = /(\n|[^\S\n]+|\S+)/g;
-const ANSI_ESCAPE_PATTERN = new RegExp(
-  `${String.fromCharCode(27)}(?:[@-Z\\\\-_]|\\[[0-?]*[ -/]*[@-~])`,
-  'g',
-);
 
 export interface TuiStreamFormatState {
   lineNeedsIndent: boolean;
@@ -592,7 +594,7 @@ function sliceTerminalCells(text: string, maxCells: number): string {
   let cells = 0;
   let result = '';
   for (const char of text) {
-    const width = terminalCellWidth(char);
+    const width = terminalCharCellWidth(char);
     if (cells > 0 && cells + width > maxCells) break;
     if (cells === 0 && width > maxCells) {
       result += char;
@@ -603,52 +605,4 @@ function sliceTerminalCells(text: string, maxCells: number): string {
     if (cells >= maxCells) break;
   }
   return result;
-}
-
-function stripAnsi(text: string): string {
-  return text.replace(ANSI_ESCAPE_PATTERN, '');
-}
-
-function terminalCellWidth(text: string): number {
-  let width = 0;
-  for (const char of text) {
-    width += terminalCharCellWidth(char);
-  }
-  return width;
-}
-
-function terminalCharCellWidth(char: string): number {
-  const codePoint = char.codePointAt(0) ?? 0;
-  if (codePoint === 0) return 0;
-  if (codePoint < 32 || (codePoint >= 0x7f && codePoint < 0xa0)) return 0;
-  if (isCombiningCodePoint(codePoint)) return 0;
-  return isWideCodePoint(codePoint) ? 2 : 1;
-}
-
-function isCombiningCodePoint(codePoint: number): boolean {
-  return (
-    (codePoint >= 0x0300 && codePoint <= 0x036f) ||
-    (codePoint >= 0x1ab0 && codePoint <= 0x1aff) ||
-    (codePoint >= 0x1dc0 && codePoint <= 0x1dff) ||
-    (codePoint >= 0x20d0 && codePoint <= 0x20ff) ||
-    (codePoint >= 0xfe20 && codePoint <= 0xfe2f)
-  );
-}
-
-function isWideCodePoint(codePoint: number): boolean {
-  return (
-    codePoint >= 0x1100 &&
-    (codePoint <= 0x115f ||
-      codePoint === 0x2329 ||
-      codePoint === 0x232a ||
-      (codePoint >= 0x2e80 && codePoint <= 0xa4cf) ||
-      (codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
-      (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
-      (codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
-      (codePoint >= 0xfe30 && codePoint <= 0xfe6f) ||
-      (codePoint >= 0xff00 && codePoint <= 0xff60) ||
-      (codePoint >= 0xffe0 && codePoint <= 0xffe6) ||
-      (codePoint >= 0x1f300 && codePoint <= 0x1faff) ||
-      (codePoint >= 0x20000 && codePoint <= 0x3fffd))
-  );
 }

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -129,6 +129,13 @@ import {
   wrapTuiBlock,
 } from './tui-thinking.js';
 import type { SessionShowMode } from './types/session.js';
+import {
+  getAnsiSequenceLength,
+  stripAnsi,
+  terminalCharCellWidth,
+  truncateAnsi,
+  visibleAnsiWidth,
+} from './utils/ansi.js';
 
 const RESET = '\x1b[0m';
 const BOLD = '\x1b[1m';
@@ -856,59 +863,6 @@ interface TuiMarkdownTable {
   endLine: number;
 }
 
-function stripAnsiTui(value: string): string {
-  let output = '';
-  for (let index = 0; index < value.length; ) {
-    if (value.charCodeAt(index) === 27 && value[index + 1] === '[') {
-      index += 2;
-      while (index < value.length) {
-        const code = value.charCodeAt(index);
-        index += 1;
-        if (code >= 64 && code <= 126) break;
-      }
-      continue;
-    }
-    output += value[index] || '';
-    index += 1;
-  }
-  return output;
-}
-
-function tuiCharacterWidth(symbol: string): number {
-  const code = symbol.codePointAt(0);
-  if (code == null) return 0;
-  if (code === 0) return 0;
-  if (code < 32 || (code >= 0x7f && code < 0xa0)) return 0;
-  if (
-    (code >= 0x300 && code <= 0x36f) ||
-    (code >= 0x200b && code <= 0x200f) ||
-    code === 0x200d ||
-    (code >= 0xfe00 && code <= 0xfe0f) ||
-    (code >= 0xe0100 && code <= 0xe01ef)
-  ) {
-    return 0;
-  }
-  if (
-    code >= 0x1100 &&
-    (code <= 0x115f ||
-      code === 0x2329 ||
-      code === 0x232a ||
-      (code >= 0x2e80 && code <= 0xa4cf && code !== 0x303f) ||
-      (code >= 0xac00 && code <= 0xd7a3) ||
-      (code >= 0xf900 && code <= 0xfaff) ||
-      (code >= 0xfe10 && code <= 0xfe19) ||
-      (code >= 0xfe30 && code <= 0xfe6f) ||
-      (code >= 0xff00 && code <= 0xff60) ||
-      (code >= 0xffe0 && code <= 0xffe6) ||
-      (code >= 0x2600 && code <= 0x27bf) ||
-      (code >= 0x1f300 && code <= 0x1faff) ||
-      (code >= 0x20000 && code <= 0x3fffd))
-  ) {
-    return 2;
-  }
-  return 1;
-}
-
 function nextTuiSymbol(
   source: string,
   index: number,
@@ -923,24 +877,7 @@ function nextTuiSymbol(
 }
 
 export function visibleTuiLength(value: string): number {
-  const source = String(value || '');
-  let width = 0;
-  for (let index = 0; index < source.length; ) {
-    if (source.charCodeAt(index) === 27 && source[index + 1] === '[') {
-      index += 2;
-      while (index < source.length) {
-        const code = source.charCodeAt(index);
-        index += 1;
-        if (code >= 64 && code <= 126) break;
-      }
-      continue;
-    }
-
-    const next = nextTuiSymbol(source, index);
-    width += tuiCharacterWidth(next.symbol);
-    index = next.nextIndex;
-  }
-  return width;
+  return visibleAnsiWidth(value);
 }
 
 function padAnsiTuiEnd(value: string, width: number): string {
@@ -955,15 +892,13 @@ function tokenizeAnsiTui(value: string): TuiAnsiToken[] {
   const source = String(value || '');
   const tokens: TuiAnsiToken[] = [];
   for (let index = 0; index < source.length; ) {
-    if (source.charCodeAt(index) === 27 && source[index + 1] === '[') {
-      const start = index;
-      index += 2;
-      while (index < source.length) {
-        const code = source.charCodeAt(index);
-        index += 1;
-        if (code >= 64 && code <= 126) break;
-      }
-      tokens.push({ kind: 'ansi', value: source.slice(start, index) });
+    const ansiSequenceLength = getAnsiSequenceLength(source, index);
+    if (ansiSequenceLength > 0) {
+      tokens.push({
+        kind: 'ansi',
+        value: source.slice(index, index + ansiSequenceLength),
+      });
+      index += ansiSequenceLength;
       continue;
     }
     const next = nextTuiSymbol(source, index);
@@ -1044,7 +979,7 @@ function sliceAnsiTuiVisible(
       continue;
     }
 
-    const symbolWidth = tuiCharacterWidth(token.value);
+    const symbolWidth = terminalCharCellWidth(token.value);
     const nextVisibleIndex = visibleIndex + symbolWidth;
     const includeToken =
       symbolWidth === 0
@@ -1075,36 +1010,11 @@ function sliceAnsiTuiVisible(
 }
 
 function truncateAnsiTuiEnd(value: string, width: number): string {
-  if (width <= 0) return '';
-  const source = String(value || '');
-  if (visibleTuiLength(source) <= width) return source;
-  if (width === 1) return '…';
-
-  let output = '';
-  let visibleCount = 0;
-  for (let index = 0; index < source.length; ) {
-    if (source.charCodeAt(index) === 27 && source[index + 1] === '[') {
-      const start = index;
-      index += 2;
-      while (index < source.length) {
-        const code = source.charCodeAt(index);
-        index += 1;
-        if (code >= 64 && code <= 126) break;
-      }
-      output += source.slice(start, index);
-      continue;
-    }
-    const next = nextTuiSymbol(source, index);
-    const symbolWidth = tuiCharacterWidth(next.symbol);
-    if (symbolWidth > 0 && visibleCount + symbolWidth + 1 > width) {
-      output += '…';
-      return output.endsWith(RESET) ? output : `${output}${RESET}`;
-    }
-    output += next.symbol;
-    visibleCount += symbolWidth;
-    index = next.nextIndex;
-  }
-  return output;
+  return truncateAnsi(value, width, {
+    ellipsis: '…',
+    reset: RESET,
+    resetMode: 'always',
+  });
 }
 
 function stripInlineMarkdownForTui(value: string): string {
@@ -1229,7 +1139,7 @@ function wrapAnsiTuiVisibleLine(value: string, width: number): string[] {
 
   while (visibleTuiLength(remaining) > safeWidth) {
     let takeWidth = safeWidth;
-    const visiblePrefix = stripAnsiTui(
+    const visiblePrefix = stripAnsi(
       sliceAnsiTuiVisible(remaining, 0, safeWidth),
     );
     const lastSpace = visiblePrefix.search(/\s+\S*$/u);
@@ -1374,7 +1284,7 @@ function looksLikeTuiTableSection(rows: readonly string[]): boolean {
   if (rows.length < 2) return false;
   const headerCells = rows[0]?.split(/ {2,}/).filter(Boolean) || [];
   if (headerCells.length < 3) return false;
-  return /^[- ]+$/u.test(stripAnsiTui(rows[1] || ''));
+  return /^[- ]+$/u.test(stripAnsi(rows[1] || ''));
 }
 
 function reflowTuiTableSection(
@@ -3270,7 +3180,7 @@ function clearDelegateStatusBlock(): void {
 }
 
 function currentPromptRows(): number {
-  return countTerminalRows(stripAnsiTui(buildPromptText()), terminalColumns());
+  return countTerminalRows(stripAnsi(buildPromptText()), terminalColumns());
 }
 
 function clearTerminalRows(rows: number, moveUpRows: number): void {

--- a/src/utils/ansi.ts
+++ b/src/utils/ansi.ts
@@ -82,7 +82,9 @@ export function truncateAnsi(
 
   const ellipsis = options.ellipsis ?? '…';
   const includeEllipsis = options.includeEllipsis ?? true;
-  const marker = includeEllipsis ? ellipsis : '';
+  const requestedMarker = includeEllipsis ? ellipsis : '';
+  const marker =
+    visibleAnsiWidth(requestedMarker) <= width ? requestedMarker : '';
   const markerWidth = visibleAnsiWidth(marker);
   const targetWidth = Math.max(0, width - markerWidth);
   let output = '';
@@ -157,7 +159,7 @@ function getControlSequenceLength(
     cursor += 1;
   }
 
-  return 0;
+  return value.length - index;
 }
 
 function isZeroWidthCodePoint(codePoint: number): boolean {

--- a/src/utils/ansi.ts
+++ b/src/utils/ansi.ts
@@ -1,0 +1,194 @@
+export type AnsiResetMode = 'never' | 'ansi' | 'always';
+
+export interface TruncateAnsiOptions {
+  ellipsis?: string;
+  reset?: string;
+  resetMode?: AnsiResetMode;
+  includeEllipsis?: boolean;
+}
+
+export function getAnsiSequenceLength(value: string, index: number): number {
+  const code = value.charCodeAt(index);
+  if (code !== 27 && code !== 0x9b) {
+    return 0;
+  }
+
+  if (code === 0x9b) {
+    return getControlSequenceLength(value, index, index + 1);
+  }
+
+  const next = value.charCodeAt(index + 1);
+  if (next === 0x5b) {
+    return getControlSequenceLength(value, index, index + 2);
+  }
+
+  if (
+    (next >= 0x40 && next <= 0x5a) ||
+    next === 0x5c ||
+    next === 0x5d ||
+    next === 0x5e ||
+    next === 0x5f
+  ) {
+    return 2;
+  }
+
+  return 0;
+}
+
+export function stripAnsi(value: string): string {
+  const source = String(value || '');
+  let output = '';
+  for (let index = 0; index < source.length; ) {
+    const ansiSequenceLength = getAnsiSequenceLength(source, index);
+    if (ansiSequenceLength > 0) {
+      index += ansiSequenceLength;
+      continue;
+    }
+
+    output += source[index] || '';
+    index += 1;
+  }
+  return output;
+}
+
+export function visibleAnsiWidth(value: string): number {
+  const source = String(value || '');
+  let width = 0;
+  for (let index = 0; index < source.length; ) {
+    const ansiSequenceLength = getAnsiSequenceLength(source, index);
+    if (ansiSequenceLength > 0) {
+      index += ansiSequenceLength;
+      continue;
+    }
+
+    const codePoint = source.codePointAt(index);
+    const symbol =
+      codePoint == null ? source[index] || '' : String.fromCodePoint(codePoint);
+    width += terminalCharCellWidth(symbol);
+    index += symbol.length || 1;
+  }
+  return width;
+}
+
+export function truncateAnsi(
+  value: string,
+  width: number,
+  options: TruncateAnsiOptions = {},
+): string {
+  if (width <= 0) return '';
+
+  const source = String(value || '');
+  if (visibleAnsiWidth(source) <= width) return source;
+
+  const ellipsis = options.ellipsis ?? '…';
+  const includeEllipsis = options.includeEllipsis ?? true;
+  const marker = includeEllipsis ? ellipsis : '';
+  const markerWidth = visibleAnsiWidth(marker);
+  const targetWidth = Math.max(0, width - markerWidth);
+  let output = '';
+  let visibleWidth = 0;
+  let hasAnsi = false;
+
+  for (let index = 0; index < source.length; ) {
+    const ansiSequenceLength = getAnsiSequenceLength(source, index);
+    if (ansiSequenceLength > 0) {
+      hasAnsi = true;
+      output += source.slice(index, index + ansiSequenceLength);
+      index += ansiSequenceLength;
+      continue;
+    }
+
+    const codePoint = source.codePointAt(index);
+    const symbol =
+      codePoint == null ? source[index] || '' : String.fromCodePoint(codePoint);
+    const symbolWidth = terminalCharCellWidth(symbol);
+    if (symbolWidth > 0 && visibleWidth + symbolWidth > targetWidth) {
+      break;
+    }
+
+    output += symbol;
+    visibleWidth += symbolWidth;
+    index += symbol.length || 1;
+  }
+
+  if (marker) {
+    output += marker;
+  }
+
+  const reset = options.reset ?? '';
+  const resetMode = options.resetMode ?? 'never';
+  if (
+    reset &&
+    !output.endsWith(reset) &&
+    (resetMode === 'always' || (resetMode === 'ansi' && hasAnsi))
+  ) {
+    output += reset;
+  }
+
+  return output;
+}
+
+export function terminalCellWidth(text: string): number {
+  let width = 0;
+  for (const char of String(text || '')) {
+    width += terminalCharCellWidth(char);
+  }
+  return width;
+}
+
+export function terminalCharCellWidth(char: string): number {
+  const codePoint = char.codePointAt(0) ?? 0;
+  if (codePoint === 0) return 0;
+  if (codePoint < 32 || (codePoint >= 0x7f && codePoint < 0xa0)) return 0;
+  if (isZeroWidthCodePoint(codePoint)) return 0;
+  return isWideCodePoint(codePoint) ? 2 : 1;
+}
+
+function getControlSequenceLength(
+  value: string,
+  index: number,
+  cursor: number,
+): number {
+  while (cursor < value.length) {
+    const code = value.charCodeAt(cursor);
+    if (code >= 0x40 && code <= 0x7e) {
+      return cursor - index + 1;
+    }
+    cursor += 1;
+  }
+
+  return 0;
+}
+
+function isZeroWidthCodePoint(codePoint: number): boolean {
+  return (
+    (codePoint >= 0x0300 && codePoint <= 0x036f) ||
+    (codePoint >= 0x1ab0 && codePoint <= 0x1aff) ||
+    (codePoint >= 0x1dc0 && codePoint <= 0x1dff) ||
+    (codePoint >= 0x200b && codePoint <= 0x200f) ||
+    (codePoint >= 0x20d0 && codePoint <= 0x20ff) ||
+    codePoint === 0x200d ||
+    (codePoint >= 0xfe00 && codePoint <= 0xfe0f) ||
+    (codePoint >= 0xfe20 && codePoint <= 0xfe2f) ||
+    (codePoint >= 0xe0100 && codePoint <= 0xe01ef)
+  );
+}
+
+function isWideCodePoint(codePoint: number): boolean {
+  return (
+    codePoint >= 0x1100 &&
+    (codePoint <= 0x115f ||
+      codePoint === 0x2329 ||
+      codePoint === 0x232a ||
+      (codePoint >= 0x2e80 && codePoint <= 0xa4cf && codePoint !== 0x303f) ||
+      (codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
+      (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+      (codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
+      (codePoint >= 0xfe30 && codePoint <= 0xfe6f) ||
+      (codePoint >= 0xff00 && codePoint <= 0xff60) ||
+      (codePoint >= 0xffe0 && codePoint <= 0xffe6) ||
+      (codePoint >= 0x2600 && codePoint <= 0x27bf) ||
+      (codePoint >= 0x1f300 && codePoint <= 0x1faff) ||
+      (codePoint >= 0x20000 && codePoint <= 0x3fffd))
+  );
+}

--- a/tests/ansi-utils.test.ts
+++ b/tests/ansi-utils.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from 'vitest';
+
+import {
+  getAnsiSequenceLength,
+  stripAnsi,
+  truncateAnsi,
+  visibleAnsiWidth,
+} from '../src/utils/ansi.js';
+
+test('strips ANSI escape sequences without removing visible text', () => {
+  expect(stripAnsi('\x1b[31mred\x1b[0m plain')).toBe('red plain');
+  expect(getAnsiSequenceLength('\x1b[1;33mtext', 0)).toBe(7);
+});
+
+test('counts terminal cell width for ANSI-styled and wide glyph text', () => {
+  expect(visibleAnsiWidth('\x1b[32m界e\u0301✅\x1b[0m')).toBe(5);
+});
+
+test('truncates ANSI-styled text without splitting escape sequences', () => {
+  expect(
+    truncateAnsi('\x1b[36malpha beta\x1b[0m', 8, {
+      ellipsis: '...',
+      reset: '\x1b[0m',
+      resetMode: 'ansi',
+    }),
+  ).toBe('\x1b[36malpha...\x1b[0m');
+});

--- a/tests/ansi-utils.test.ts
+++ b/tests/ansi-utils.test.ts
@@ -12,6 +12,12 @@ test('strips ANSI escape sequences without removing visible text', () => {
   expect(getAnsiSequenceLength('\x1b[1;33mtext', 0)).toBe(7);
 });
 
+test('treats incomplete trailing CSI sequences as non-visible control text', () => {
+  expect(stripAnsi('ready\x1b[')).toBe('ready');
+  expect(visibleAnsiWidth('ready\x1b[')).toBe(5);
+  expect(getAnsiSequenceLength('ready\x1b[', 5)).toBe(2);
+});
+
 test('counts terminal cell width for ANSI-styled and wide glyph text', () => {
   expect(visibleAnsiWidth('\x1b[32m界e\u0301✅\x1b[0m')).toBe(5);
 });
@@ -24,4 +30,8 @@ test('truncates ANSI-styled text without splitting escape sequences', () => {
       resetMode: 'ansi',
     }),
   ).toBe('\x1b[36malpha...\x1b[0m');
+});
+
+test('omits truncation markers that cannot fit in the target width', () => {
+  expect(truncateAnsi('abc', 1, { ellipsis: '...' })).toBe('a');
 });

--- a/tests/local-cli.test.ts
+++ b/tests/local-cli.test.ts
@@ -30,14 +30,22 @@ async function importFreshCli(
   process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
   process.env.HYBRIDCLAW_WHATSAPP_SETUP_SETTLE_MS = '0';
   vi.resetModules();
-  vi.doMock('../src/channels/imessage/local-prereqs.js', () => ({
+  const imessageLocalPrereqsMock = () => ({
     assertLocalIMessageBackendReady: vi.fn(() => {
       if (options?.imessageLocalReadyError) {
         throw options.imessageLocalReadyError;
       }
     }),
     formatMissingIMessageCliMessage: vi.fn((cliPath: string) => cliPath),
-  }));
+  });
+  vi.doMock(
+    '../src/channels/imessage/local-prereqs.js',
+    imessageLocalPrereqsMock,
+  );
+  vi.doMock(
+    '../src/channels/imessage/local-prereqs.ts',
+    imessageLocalPrereqsMock,
+  );
   vi.doMock('../src/channels/whatsapp/connection.ts', () => ({
     createWhatsAppConnectionManager: () => ({
       getSocket: () => null,
@@ -97,6 +105,7 @@ async function readRuntimeSecrets(
 afterEach(() => {
   vi.restoreAllMocks();
   vi.doUnmock('../src/channels/imessage/local-prereqs.js');
+  vi.doUnmock('../src/channels/imessage/local-prereqs.ts');
   vi.doUnmock('../src/channels/whatsapp/connection.ts');
   vi.resetModules();
   if (ORIGINAL_HOME === undefined) {


### PR DESCRIPTION
## Summary
- Add a shared ANSI utility for escape parsing, stripping, visible terminal width, and ANSI-aware truncation.
- Replace duplicated ANSI helpers across the TUI banner, approval prompt, skill config, thinking renderer, and main TUI formatter.
- Add focused utility coverage for stripping, wide glyph width, and styled truncation behavior.

## Impact
This keeps ANSI handling consistent across TUI surfaces and preserves terminal-cell width behavior for wide and zero-width glyphs.

## Validation
- `npx biome check --write src/utils/ansi.ts src/tui.ts src/tui-thinking.ts src/tui-banner.ts src/tui-approval-prompt.ts src/tui-skill-config.ts tests/ansi-utils.test.ts`
- `./node_modules/.bin/tsc --noEmit --noUnusedLocals --noUnusedParameters`
- `npx vitest run --configLoader runner --project unit tests/ansi-utils.test.ts tests/tui-format.test.ts tests/tui-thinking.test.ts tests/tui-banner.test.ts`
- `npx vitest run --configLoader runner --project unit tests/tui-approval-prompt.test.ts tests/tui-skill-config.test.ts`