### PR TITLE
[codex] Serialize scheduled cloud memory sync

### DIFF
--- a/src/memory/cloud-memory.ts
+++ b/src/memory/cloud-memory.ts
@@ -432,5 +432,4 @@ export function stopPeriodicCloudMemorySync(): void {
     clearInterval(periodicSyncTimer);
     periodicSyncTimer = null;
   }
-  periodicSyncInFlight = null;
 }

--- a/src/memory/cloud-memory.ts
+++ b/src/memory/cloud-memory.ts
@@ -48,6 +48,30 @@ const DAILY_MEMORY_FILE_RE = /^\d{4}-\d{2}-\d{2}\.md$/;
 const inFlightSyncs = new Map<string, Promise<void>>();
 const lastSyncStartedAt = new Map<string, number>();
 let periodicSyncTimer: ReturnType<typeof setInterval> | null = null;
+let periodicSyncInFlight: Promise<void> | null = null;
+
+interface StartedCloudMemorySync {
+  normalizedAgentId: string;
+  inFlightKey: string;
+}
+
+function cloudMemoryInFlightKey(agentId: string): string {
+  return agentId.trim().toLowerCase();
+}
+
+function beginCloudMemorySync(agentId: string): StartedCloudMemorySync | null {
+  const normalizedAgentId = agentId.trim();
+  if (!normalizedAgentId) return null;
+  const inFlightKey = cloudMemoryInFlightKey(normalizedAgentId);
+  if (!isCloudMemoryConfigured()) return null;
+  if (inFlightSyncs.has(inFlightKey)) return null;
+
+  const now = Date.now();
+  const lastStarted = lastSyncStartedAt.get(normalizedAgentId) || 0;
+  if (now - lastStarted < CLOUD_MEMORY_SYNC_MIN_INTERVAL_MS) return null;
+  lastSyncStartedAt.set(normalizedAgentId, now);
+  return { normalizedAgentId, inFlightKey };
+}
 
 function getCloudMemoryConfig(): {
   apiKey: string;
@@ -330,35 +354,45 @@ export async function syncCloudMemoryNow(agentId: string): Promise<void> {
 }
 
 export function scheduleCloudMemorySync(agentId: string): void {
-  const normalizedAgentId = agentId.trim();
-  if (!normalizedAgentId) return;
-  if (!isCloudMemoryConfigured()) return;
-  if (inFlightSyncs.has(normalizedAgentId)) return;
+  const started = beginCloudMemorySync(agentId);
+  if (!started) return;
 
-  const now = Date.now();
-  const lastStarted = lastSyncStartedAt.get(normalizedAgentId) || 0;
-  if (now - lastStarted < CLOUD_MEMORY_SYNC_MIN_INTERVAL_MS) return;
-  lastSyncStartedAt.set(normalizedAgentId, now);
-
-  const promise = syncCloudMemoryNow(normalizedAgentId)
+  const promise = syncCloudMemoryNow(started.normalizedAgentId)
     .catch((err) => {
       logger.warn(
-        { agentId: normalizedAgentId, err },
+        { agentId: started.normalizedAgentId, err },
         'Cloud memory sync failed',
       );
     })
     .finally(() => {
-      inFlightSyncs.delete(normalizedAgentId);
+      inFlightSyncs.delete(started.inFlightKey);
     });
-  inFlightSyncs.set(normalizedAgentId, promise);
+  inFlightSyncs.set(started.inFlightKey, promise);
 }
 
-function syncAgentIds(agentIds: string[]): void {
-  const uniqueAgentIds = Array.from(
+function uniqueSyncAgentIds(agentIds: string[]): string[] {
+  return Array.from(
     new Set(agentIds.map((agentId) => agentId.trim()).filter(Boolean)),
   );
-  for (const agentId of uniqueAgentIds) {
-    scheduleCloudMemorySync(agentId);
+}
+
+async function syncAgentIds(agentIds: string[]): Promise<void> {
+  for (const agentId of uniqueSyncAgentIds(agentIds)) {
+    const started = beginCloudMemorySync(agentId);
+    if (!started) continue;
+
+    const promise = syncCloudMemoryNow(started.normalizedAgentId);
+    inFlightSyncs.set(started.inFlightKey, promise);
+    try {
+      await promise;
+    } catch (err) {
+      logger.warn(
+        { agentId: started.normalizedAgentId, err },
+        'Cloud memory sync failed',
+      );
+    } finally {
+      inFlightSyncs.delete(started.inFlightKey);
+    }
   }
 }
 
@@ -376,9 +410,13 @@ export function startPeriodicCloudMemorySync(options?: {
   );
   const resolveAgentIds = options?.resolveAgentIds ?? (() => ['main']);
   const runSync = () => {
+    if (periodicSyncInFlight) return;
     try {
-      syncAgentIds(resolveAgentIds());
+      periodicSyncInFlight = syncAgentIds(resolveAgentIds()).finally(() => {
+        periodicSyncInFlight = null;
+      });
     } catch (err) {
+      periodicSyncInFlight = null;
       logger.warn({ err }, 'Cloud memory periodic sync failed to list agents');
     }
   };
@@ -390,7 +428,9 @@ export function startPeriodicCloudMemorySync(options?: {
 }
 
 export function stopPeriodicCloudMemorySync(): void {
-  if (!periodicSyncTimer) return;
-  clearInterval(periodicSyncTimer);
-  periodicSyncTimer = null;
+  if (periodicSyncTimer) {
+    clearInterval(periodicSyncTimer);
+    periodicSyncTimer = null;
+  }
+  periodicSyncInFlight = null;
 }

--- a/tests/cloud-memory.test.ts
+++ b/tests/cloud-memory.test.ts
@@ -298,13 +298,11 @@ test('startPeriodicCloudMemorySync refreshes registered agents on an interval', 
       resolveAgentIds: () => [agentId, 'cloud-periodic-peer', agentId],
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
 
-    await Promise.resolve();
-    await Promise.resolve();
     await vi.advanceTimersByTimeAsync(5 * 60_000);
 
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4));
 
     stopPeriodicCloudMemorySync();
     await Promise.resolve();
@@ -312,6 +310,97 @@ test('startPeriodicCloudMemorySync refreshes registered agents on an interval', 
     await vi.advanceTimersByTimeAsync(5 * 60_000);
 
     expect(fetchMock).toHaveBeenCalledTimes(4);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test('startPeriodicCloudMemorySync runs scheduled agent syncs sequentially', async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-06-09T12:00:00.000Z'));
+
+  try {
+    await createAgentWorkspace('scheduled-a');
+    await createAgentWorkspace('scheduled-b');
+    let releaseFirst: (() => void) | undefined;
+    const fetchMock = vi.fn(async () => {
+      if (fetchMock.mock.calls.length === 1) {
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ enabled: false, files: [] }),
+      };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { startPeriodicCloudMemorySync, stopPeriodicCloudMemorySync } =
+      await import('../src/memory/cloud-memory.js');
+
+    startPeriodicCloudMemorySync({
+      intervalMs: 5 * 60_000,
+      resolveAgentIds: () => ['scheduled-a', 'scheduled-b'],
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    releaseFirst?.();
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    stopPeriodicCloudMemorySync();
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test('startPeriodicCloudMemorySync serializes case-variant agent ids', async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-06-09T12:00:00.000Z'));
+
+  try {
+    await createAgentWorkspace('bob');
+    await createAgentWorkspace('Bob');
+
+    let releaseFirst: (() => void) | undefined;
+    const fetchMock = vi.fn(async () => {
+      if (fetchMock.mock.calls.length === 1) {
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ enabled: false, files: [] }),
+      };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { startPeriodicCloudMemorySync, stopPeriodicCloudMemorySync } =
+      await import('../src/memory/cloud-memory.js');
+
+    startPeriodicCloudMemorySync({
+      intervalMs: 5 * 60_000,
+      resolveAgentIds: () => ['bob', 'Bob'],
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    releaseFirst?.();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const bodies = fetchMock.mock.calls.map((call) =>
+      JSON.parse(String((call[1] as RequestInit).body)),
+    ) as Array<{ agent_id: string }>;
+    expect(bodies.map((body) => body.agent_id)).toEqual(['bob', 'Bob']);
+
+    stopPeriodicCloudMemorySync();
   } finally {
     vi.useRealTimers();
   }

--- a/tests/cloud-memory.test.ts
+++ b/tests/cloud-memory.test.ts
@@ -360,6 +360,54 @@ test('startPeriodicCloudMemorySync runs scheduled agent syncs sequentially', asy
   }
 });
 
+test('startPeriodicCloudMemorySync does not overlap after restart while a batch is running', async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-06-09T12:00:00.000Z'));
+
+  try {
+    await createAgentWorkspace('restart-a');
+    await createAgentWorkspace('restart-b');
+    let releaseFirst: (() => void) | undefined;
+    const fetchMock = vi.fn(async () => {
+      if (fetchMock.mock.calls.length === 1) {
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ enabled: false, files: [] }),
+      };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { startPeriodicCloudMemorySync, stopPeriodicCloudMemorySync } =
+      await import('../src/memory/cloud-memory.js');
+
+    const options = {
+      intervalMs: 5 * 60_000,
+      resolveAgentIds: () => ['restart-a', 'restart-b'],
+    };
+    startPeriodicCloudMemorySync(options);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    startPeriodicCloudMemorySync(options);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    releaseFirst?.();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    stopPeriodicCloudMemorySync();
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
 test('startPeriodicCloudMemorySync serializes case-variant agent ids', async () => {
   vi.useFakeTimers();
   vi.setSystemTime(new Date('2026-06-09T12:00:00.000Z'));


### PR DESCRIPTION
## Summary

- Run periodic cloud memory sync batches sequentially instead of firing every agent request concurrently.
- Keep the direct `scheduleCloudMemorySync` path non-blocking while sharing the in-flight guard.
- Add regression coverage that scheduled syncs do not overlap and that `bob`/`Bob` case variants are processed one after the other rather than concurrently.

## Root Cause

The manual sync path sends one HybridAI memory sync request at a time. The scheduled path fanned out all registered agents concurrently, so case-variant agents like `bob` and `Bob` could race against the same case-insensitive server-side memory scope and trigger intermittent HybridAI 500s during embedding refresh.

## Validation

- `npx vitest run tests/cloud-memory.test.ts` passed in the isolated Codex worktree: 13 tests.
- `npx biome check --write src/memory/cloud-memory.ts tests/cloud-memory.test.ts` passed.
- `./node_modules/.bin/tsc --noEmit` passed.
- In `/Users/bkoehler/src/hybridclaw`, the targeted test file was rerun but one pre-existing environment-sensitive assertion picked up the checkout's local `.env` HybridAI key instead of the stubbed key; the new scheduled-sync tests passed before that file-level failure was reported.