### PR TITLE
[codex] Reuse JSON object parser

### DIFF
--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -85,6 +85,7 @@ import type { CanonicalSessionContext } from '../types/session.js';
 import { buildMediaGenerationUsageEvents } from '../usage/media-generation-usage.js';
 import { resolveUsageCostUsdAfterMetadataRefresh } from '../usage/model-cost.js';
 import { enqueueTokenUsage } from '../usage/token-usage-buffer.js';
+import { parseJsonObject } from '../utils/json-object.js';
 import {
   ensureBootstrapFiles,
   resolveStartupBootstrapFile,
@@ -166,17 +167,6 @@ function resolveTurnRuntimeAuditLabel(
     : 'hybridclaw';
 }
 
-function parseToolResultObject(result: string): Record<string, unknown> | null {
-  try {
-    const parsed = JSON.parse(result) as unknown;
-    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : null;
-  } catch {
-    return null;
-  }
-}
-
 function persistSpeechTranscriptsToScopedMemory(params: {
   sessionId: string;
   skillName: string | null;
@@ -187,7 +177,7 @@ function persistSpeechTranscriptsToScopedMemory(params: {
     : 'skill:speech-to-text';
   for (const execution of params.toolExecutions) {
     if (execution.name !== 'audio_transcribe' || execution.isError) continue;
-    const payload = parseToolResultObject(execution.result);
+    const payload = parseJsonObject(execution.result);
     if (!payload || payload.success !== true) continue;
     if (typeof payload.action === 'string' && payload.action !== 'transcribe') {
       continue;

--- a/src/gateway/gateway-utils.ts
+++ b/src/gateway/gateway-utils.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import type { StructuredAuditEntry } from '../types/audit.js';
+import { parseJsonObject } from '../utils/json-object.js';
 import { finiteNumberOrNull } from '../utils/number-normalization.js';
 
 const COMMON_EXTENSION_MIME_TYPES: Record<string, string> = {
@@ -41,13 +42,7 @@ export function firstNumber(values: unknown[]): number | null {
 export function parseAuditPayload(
   entry: StructuredAuditEntry,
 ): Record<string, unknown> | null {
-  try {
-    const parsed = JSON.parse(entry.payload) as unknown;
-    if (!parsed || typeof parsed !== 'object') return null;
-    return parsed as Record<string, unknown>;
-  } catch {
-    return null;
-  }
+  return parseJsonObject(entry.payload);
 }
 
 export function resolveWorkspaceRelativePath(


### PR DESCRIPTION
## Summary

- Replace the local `parseToolResultObject` implementation with shared `parseJsonObject`.
- Keep `parseAuditPayload` as the gateway-facing wrapper, but delegate parsing to shared `parseJsonObject`.

## Why

`src/utils/json-object.ts` already provides the object-only JSON parsing behavior, so the gateway should not carry duplicate implementations for tool results or audit payloads.

## Validation

- `npx biome check src/gateway/gateway-chat-service.ts src/gateway/gateway-utils.ts src/utils/json-object.ts`
- `npm run typecheck`
- `npm run lint`
- `npx vitest run --configLoader runner --project unit tests/gateway-agent-cards.test.ts`
- `npx vitest run --configLoader runner --project unit tests/gateway-service.audio-transcription.test.ts`