### PR TITLE
feat(connectors): auto-wire HybridAI connectors MCP server

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -312,6 +312,7 @@
     "defaultChatbotId": "",
     "maxTokens": 4096,
     "enableRag": true,
+    "enableConnectors": true,
     "models": ["gpt-4.1-mini", "gpt-5-nano", "gpt-5"]
   },
   "codex": {

--- a/container/src/mcp/client-manager.ts
+++ b/container/src/mcp/client-manager.ts
@@ -27,6 +27,18 @@ import type {
 
 const MCP_CONNECT_TIMEOUT_MS = 60_000;
 const MCP_TOOL_CALL_TIMEOUT_MS = 120_000;
+/* Remote (http/sse) servers can grow or lose tools while we stay connected —
+   e.g. the HybridAI connector gateway's tool list changes when the user
+   connects a service on the platform. Re-discover on a TTL so long-lived
+   agents pick that up, and retry once shortly after a connect that returned
+   zero tools (a transient upstream hiccup would otherwise mute the server
+   for the agent's whole lifetime). */
+const MCP_REMOTE_TOOLS_REFRESH_INTERVAL_MS = 5 * 60_000;
+const MCP_EMPTY_TOOLS_RETRY_DELAY_MS = 30_000;
+
+function isRemoteTransport(config: McpServerConfig): boolean {
+  return config.transport === 'http' || config.transport === 'sse';
+}
 const MCP_CLIENT_INFO = {
   name: 'hybridclaw-agent',
   version: process.env.npm_package_version || '0.0.0',
@@ -160,6 +172,11 @@ export class McpClientManager {
   private readonly toolIndex = new Map<string, ToolIndexEntry>();
   private readonly closingServers = new Set<string>();
   private readonly replaceLocks = new Map<string, Promise<void>>();
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+  private readonly emptyToolsRetryTimers = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
 
   async initFromConfig(
     servers: Record<string, McpServerConfig>,
@@ -201,6 +218,10 @@ export class McpClientManager {
         toolCount: nextHandle.tools.length,
       });
       if (existing) await this.closeHandle(existing);
+      if (isRemoteTransport(config)) {
+        this.ensurePeriodicRefresh();
+        if (nextHandle.tools.length === 0) this.scheduleEmptyToolsRetry(name);
+      }
     });
   }
 
@@ -251,10 +272,66 @@ export class McpClientManager {
   }
 
   async shutdown(): Promise<void> {
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+    for (const timer of this.emptyToolsRetryTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.emptyToolsRetryTimers.clear();
     for (const name of [...this.clients.keys()]) {
       await this.disconnectClient(name);
     }
     this.configs.clear();
+  }
+
+  /** Re-list tools on a connected handle without tearing the session down. */
+  private async refreshServerTools(name: string): Promise<void> {
+    await this.runWithLock(name, async () => {
+      const handle = this.clients.get(name);
+      if (!handle || !handle.healthy) return;
+      try {
+        handle.tools = await this.discoverTools(handle);
+        this.rebuildToolIndex();
+      } catch (error) {
+        this.markServerUnhealthy(name, error);
+      }
+    });
+  }
+
+  private async refreshRemoteServers(): Promise<void> {
+    for (const [name, config] of this.configs) {
+      if (config.enabled === false || !isRemoteTransport(config)) continue;
+      const handle = this.clients.get(name);
+      if (!handle || !handle.healthy) {
+        // Connection died (or never came up) — a reconnect also re-lists.
+        await this.reconnectClient(name).catch(() => {
+          /* still down; the next tick tries again */
+        });
+      } else {
+        await this.refreshServerTools(name);
+      }
+    }
+  }
+
+  private ensurePeriodicRefresh(): void {
+    if (this.refreshTimer) return;
+    this.refreshTimer = setInterval(() => {
+      void this.refreshRemoteServers();
+    }, MCP_REMOTE_TOOLS_REFRESH_INTERVAL_MS);
+    // Never keep the worker process alive just for refreshes.
+    this.refreshTimer.unref?.();
+  }
+
+  private scheduleEmptyToolsRetry(name: string): void {
+    if (this.emptyToolsRetryTimers.has(name)) return;
+    const timer = setTimeout(() => {
+      this.emptyToolsRetryTimers.delete(name);
+      void this.refreshServerTools(name);
+    }, MCP_EMPTY_TOOLS_RETRY_DELAY_MS);
+    timer.unref?.();
+    this.emptyToolsRetryTimers.set(name, timer);
   }
 
   private async buildClient(
@@ -480,6 +557,11 @@ export class McpClientManager {
   }
 
   private async disconnectClient(name: string): Promise<void> {
+    const retryTimer = this.emptyToolsRetryTimers.get(name);
+    if (retryTimer) {
+      clearTimeout(retryTimer);
+      this.emptyToolsRetryTimers.delete(name);
+    }
     const handle = this.clients.get(name);
     if (!handle) return;
     this.clients.delete(name);

--- a/container/src/mcp/client-manager.ts
+++ b/container/src/mcp/client-manager.ts
@@ -29,7 +29,7 @@ const MCP_CONNECT_TIMEOUT_MS = 60_000;
 const MCP_TOOL_CALL_TIMEOUT_MS = 120_000;
 /* Remote (http/sse) servers can grow or lose tools while we stay connected —
    e.g. the HybridAI connector gateway's tool list changes when the user
-   connects a service on the platform. Re-discover on a TTL so long-lived
+   connects a new service. Re-discover on a TTL so long-lived
    agents pick that up, and retry once shortly after a connect that returned
    zero tools (a transient upstream hiccup would otherwise mute the server
    for the agent's whole lifetime). */

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1113,7 +1113,8 @@ function applyRuntimeConfig(config: RuntimeConfig): void {
   CONTAINER_WARM_POOL = structuredClone(config.container.warmPool);
   // Auto-wire the HybridAI connector gateway when the HybridAI provider is
   // configured, so self-hosted installs need no manual mcpServers entry. Kept
-  // in-memory only (the API key is never written back to config.json).
+  // in-memory only, and the entry carries no credential — the bearer is
+  // attached per agent run via withConnectorGatewayAuth in the runners.
   MCP_SERVERS = injectHybridAIConnectorGateway(
     structuredClone(config.mcpServers || {}),
     HYBRIDAI_BASE_URL,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -331,6 +331,11 @@ syncRuntimeSecretExports();
 export function refreshRuntimeSecretsFromEnv(): void {
   loadRuntimeSecrets();
   syncRuntimeSecretExports();
+  // Re-derive config that mixes in a runtime secret. The connector gateway
+  // injects HYBRIDAI_API_KEY into MCP_SERVERS, so a key supplied AFTER startup
+  // (`claw login`, onboarding, `/secret set HYBRIDAI_API_KEY`, config reload)
+  // wires the gateway without a restart instead of leaving MCP_SERVERS stale.
+  applyRuntimeConfig(getRuntimeConfig());
 }
 
 export let DISCORD_PREFIX = '!claw';

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -17,6 +17,7 @@ import {
   saveRuntimeSecrets,
 } from '../security/runtime-secrets.js';
 import { bootstrapRuntimeSecrets } from '../security/runtime-secrets-bootstrap.js';
+import { injectHybridAIConnectorGateway } from './connector-gateway.js';
 import {
   ensureRuntimeConfigFile,
   getRuntimeConfig,
@@ -1105,7 +1106,14 @@ function applyRuntimeConfig(config: RuntimeConfig): void {
   CONTAINER_PERSIST_BASH_STATE = config.container.persistBashState;
   warnIfWarmPoolMinIdleIsClamped(config.container.warmPool);
   CONTAINER_WARM_POOL = structuredClone(config.container.warmPool);
-  MCP_SERVERS = structuredClone(config.mcpServers || {});
+  // Auto-wire the HybridAI connector gateway when the HybridAI provider is
+  // configured, so self-hosted installs need no manual mcpServers entry. Kept
+  // in-memory only (the API key is never written back to config.json).
+  MCP_SERVERS = injectHybridAIConnectorGateway(
+    structuredClone(config.mcpServers || {}),
+    HYBRIDAI_BASE_URL,
+    HYBRIDAI_API_KEY,
+  );
   BROWSER_PROVIDER = config.browser.provider;
   BROWSER_ALLOW_PRIVATE_NETWORK = config.browser.allowPrivateNetwork;
   WEB_SEARCH_PROVIDER = config.web.search.provider;

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -486,6 +486,7 @@ export let HYBRIDAI_MODEL = 'gpt-4.1-mini';
 export let HYBRIDAI_CHATBOT_ID = '';
 export let HYBRIDAI_MAX_TOKENS = 4_096;
 export let HYBRIDAI_ENABLE_RAG = true;
+export let HYBRIDAI_ENABLE_CONNECTORS = true;
 export let CODEX_BASE_URL = CODEX_DEFAULT_BASE_URL;
 export let CODEX_RUNTIME: RuntimeConfig['codex']['runtime'] = 'hybridclaw';
 export let ANTHROPIC_ENABLED = false;
@@ -1048,6 +1049,7 @@ function applyRuntimeConfig(config: RuntimeConfig): void {
     Math.min(32_768, config.hybridai.maxTokens),
   );
   HYBRIDAI_ENABLE_RAG = config.hybridai.enableRag;
+  HYBRIDAI_ENABLE_CONNECTORS = config.hybridai.enableConnectors;
   CODEX_BASE_URL = config.codex.baseUrl;
   CODEX_RUNTIME = config.codex.turnRuntime;
   ANTHROPIC_ENABLED = config.anthropic.enabled;
@@ -1112,13 +1114,15 @@ function applyRuntimeConfig(config: RuntimeConfig): void {
   warnIfWarmPoolMinIdleIsClamped(config.container.warmPool);
   CONTAINER_WARM_POOL = structuredClone(config.container.warmPool);
   // Auto-wire the HybridAI connector gateway when the HybridAI provider is
-  // configured, so self-hosted installs need no manual mcpServers entry. Kept
-  // in-memory only, and the entry carries no credential — the bearer is
-  // attached per agent run via withConnectorGatewayAuth in the runners.
+  // configured and connectors are enabled, so self-hosted installs need no
+  // manual mcpServers entry. Kept in-memory only, and the entry carries no
+  // credential — the bearer is attached per agent run via
+  // withConnectorGatewayAuth in the runners.
   MCP_SERVERS = injectHybridAIConnectorGateway(
     structuredClone(config.mcpServers || {}),
     HYBRIDAI_BASE_URL,
     HYBRIDAI_API_KEY,
+    HYBRIDAI_ENABLE_CONNECTORS,
   );
   BROWSER_PROVIDER = config.browser.provider;
   BROWSER_ALLOW_PRIVATE_NETWORK = config.browser.allowPrivateNetwork;

--- a/src/config/connector-gateway.ts
+++ b/src/config/connector-gateway.ts
@@ -6,6 +6,11 @@ import type { RuntimeConfig } from './runtime-config.js';
  */
 export const CONNECTOR_GATEWAY_SERVER_NAME = 'hybridai-connectors';
 
+function connectorGatewayUrl(baseUrl: string): string {
+  const trimmedBase = baseUrl.trim().replace(/\/+$/, '');
+  return trimmedBase ? `${trimmedBase}/connectors/mcp` : '';
+}
+
 /**
  * Auto-wire the HybridAI connector gateway as an MCP server when the HybridAI
  * provider is configured.
@@ -13,27 +18,62 @@ export const CONNECTOR_GATEWAY_SERVER_NAME = 'hybridai-connectors';
  * On self-hosted installs this means simply configuring the HybridAI provider
  * (base URL + API key) is enough to give agents the platform's connectors and
  * first-party tools — no manual `mcpServers` entry needed. The entry is injected
- * into the in-memory server map only (never persisted to config.json), so the
- * API key is not written to disk. A user-defined server of the same name always
- * wins, and the entry is omitted when the provider isn't configured.
+ * into the in-memory server map only (never persisted to config.json). A
+ * user-defined server of the same name always wins, and the entry is omitted
+ * when the provider isn't configured.
+ *
+ * The entry deliberately carries NO Authorization header: the API key is
+ * resolved per agent run by {@link withConnectorGatewayAuth}, so the long-lived
+ * server map can be listed/logged without exposing the credential.
  */
 export function injectHybridAIConnectorGateway(
   servers: RuntimeConfig['mcpServers'],
   baseUrl: string,
   apiKey: string,
 ): RuntimeConfig['mcpServers'] {
-  const trimmedKey = apiKey.trim();
-  const trimmedBase = baseUrl.trim().replace(/\/+$/, '');
-  if (!trimmedKey || !trimmedBase) return servers;
+  const url = connectorGatewayUrl(baseUrl);
+  if (!apiKey.trim() || !url) return servers;
   if (servers[CONNECTOR_GATEWAY_SERVER_NAME]) return servers;
 
   return {
     ...servers,
     [CONNECTOR_GATEWAY_SERVER_NAME]: {
       transport: 'http',
-      url: `${trimmedBase}/connectors/mcp`,
-      headers: { Authorization: `Bearer ${trimmedKey}` },
+      url,
       enabled: true,
+    },
+  };
+}
+
+/**
+ * Attach the HybridAI API key to the connector gateway entry, returning a new
+ * map (the input is never mutated). Called by the host/container runners right
+ * before the server map is handed to an agent run, so the credential lives
+ * only in the per-run payload — never in the long-lived `MCP_SERVERS` map.
+ *
+ * The header is attached only when the entry's URL is exactly the gateway URL
+ * derived from the configured base URL — a user-defined entry pointing
+ * anywhere else never receives the key — and an existing Authorization header
+ * is always left untouched.
+ */
+export function withConnectorGatewayAuth(
+  servers: RuntimeConfig['mcpServers'],
+  baseUrl: string,
+  apiKey: string,
+): RuntimeConfig['mcpServers'] {
+  const trimmedKey = apiKey.trim();
+  const url = connectorGatewayUrl(baseUrl);
+  if (!trimmedKey || !url) return servers;
+
+  const entry = servers[CONNECTOR_GATEWAY_SERVER_NAME];
+  if (!entry || entry.url !== url) return servers;
+  if (entry.headers?.Authorization) return servers;
+
+  return {
+    ...servers,
+    [CONNECTOR_GATEWAY_SERVER_NAME]: {
+      ...entry,
+      headers: { ...entry.headers, Authorization: `Bearer ${trimmedKey}` },
     },
   };
 }

--- a/src/config/connector-gateway.ts
+++ b/src/config/connector-gateway.ts
@@ -20,7 +20,8 @@ function connectorGatewayUrl(baseUrl: string): string {
  * first-party tools — no manual `mcpServers` entry needed. The entry is injected
  * into the in-memory server map only (never persisted to config.json). A
  * user-defined server of the same name always wins, and the entry is omitted
- * when the provider isn't configured.
+ * when the provider isn't configured or when `enabled` is false (the
+ * `hybridai.enableConnectors` config flag).
  *
  * The entry deliberately carries NO Authorization header: the API key is
  * resolved per agent run by {@link withConnectorGatewayAuth}, so the long-lived
@@ -30,7 +31,9 @@ export function injectHybridAIConnectorGateway(
   servers: RuntimeConfig['mcpServers'],
   baseUrl: string,
   apiKey: string,
+  enabled = true,
 ): RuntimeConfig['mcpServers'] {
+  if (!enabled) return servers;
   const url = connectorGatewayUrl(baseUrl);
   if (!apiKey.trim() || !url) return servers;
   if (servers[CONNECTOR_GATEWAY_SERVER_NAME]) return servers;

--- a/src/config/connector-gateway.ts
+++ b/src/config/connector-gateway.ts
@@ -1,8 +1,8 @@
 import type { RuntimeConfig } from './runtime-config.js';
 
 /**
- * Name of the auto-wired MCP server entry pointing at the HybridAI chat
- * platform's connector gateway.
+ * Name of the auto-wired MCP server entry pointing at the HybridAI connectors
+ * MCP endpoint.
  */
 export const CONNECTOR_GATEWAY_SERVER_NAME = 'hybridai-connectors';
 
@@ -16,7 +16,7 @@ function connectorGatewayUrl(baseUrl: string): string {
  * provider is configured.
  *
  * On self-hosted installs this means simply configuring the HybridAI provider
- * (base URL + API key) is enough to give agents the platform's connectors and
+ * (base URL + API key) is enough to give agents HybridAI connectors and
  * first-party tools — no manual `mcpServers` entry needed. The entry is injected
  * into the in-memory server map only (never persisted to config.json). A
  * user-defined server of the same name always wins, and the entry is omitted

--- a/src/config/connector-gateway.ts
+++ b/src/config/connector-gateway.ts
@@ -1,0 +1,39 @@
+import type { RuntimeConfig } from './runtime-config.js';
+
+/**
+ * Name of the auto-wired MCP server entry pointing at the HybridAI chat
+ * platform's connector gateway.
+ */
+export const CONNECTOR_GATEWAY_SERVER_NAME = 'hybridai-connectors';
+
+/**
+ * Auto-wire the HybridAI connector gateway as an MCP server when the HybridAI
+ * provider is configured.
+ *
+ * On self-hosted installs this means simply configuring the HybridAI provider
+ * (base URL + API key) is enough to give agents the platform's connectors and
+ * first-party tools — no manual `mcpServers` entry needed. The entry is injected
+ * into the in-memory server map only (never persisted to config.json), so the
+ * API key is not written to disk. A user-defined server of the same name always
+ * wins, and the entry is omitted when the provider isn't configured.
+ */
+export function injectHybridAIConnectorGateway(
+  servers: RuntimeConfig['mcpServers'],
+  baseUrl: string,
+  apiKey: string,
+): RuntimeConfig['mcpServers'] {
+  const trimmedKey = apiKey.trim();
+  const trimmedBase = baseUrl.trim().replace(/\/+$/, '');
+  if (!trimmedKey || !trimmedBase) return servers;
+  if (servers[CONNECTOR_GATEWAY_SERVER_NAME]) return servers;
+
+  return {
+    ...servers,
+    [CONNECTOR_GATEWAY_SERVER_NAME]: {
+      transport: 'http',
+      url: `${trimmedBase}/connectors/mcp`,
+      headers: { Authorization: `Bearer ${trimmedKey}` },
+      enabled: true,
+    },
+  };
+}

--- a/src/config/connector-gateway.ts
+++ b/src/config/connector-gateway.ts
@@ -8,7 +8,7 @@ export const CONNECTOR_GATEWAY_SERVER_NAME = 'hybridai-connectors';
 
 function connectorGatewayUrl(baseUrl: string): string {
   const trimmedBase = baseUrl.trim().replace(/\/+$/, '');
-  return trimmedBase ? `${trimmedBase}/connectors/mcp` : '';
+  return trimmedBase ? `${trimmedBase}/api/v1/connectors/mcp` : '';
 }
 
 /**

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -994,6 +994,7 @@ export interface RuntimeConfig {
     defaultChatbotId: string;
     maxTokens: number;
     enableRag: boolean;
+    enableConnectors: boolean;
     models: string[];
   };
   codex: {
@@ -1652,6 +1653,7 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
     defaultChatbotId: '',
     maxTokens: 4_096,
     enableRag: true,
+    enableConnectors: true,
     models: ['gpt-4.1-mini', 'gpt-5-nano', 'gpt-5-mini', 'gpt-5'],
   },
   codex: {
@@ -6931,6 +6933,10 @@ function normalizeRuntimeConfig(
       enableRag: normalizeBoolean(
         rawHybridAi.enableRag,
         DEFAULT_RUNTIME_CONFIG.hybridai.enableRag,
+      ),
+      enableConnectors: normalizeBoolean(
+        rawHybridAi.enableConnectors,
+        DEFAULT_RUNTIME_CONFIG.hybridai.enableConnectors,
       ),
       models: modelList,
     },

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -40,6 +40,7 @@ import {
   DISCORD_SEND_ALLOWED_CHANNEL_IDS,
   GATEWAY_API_TOKEN,
   GATEWAY_BASE_URL,
+  HYBRIDAI_API_KEY,
   HYBRIDAI_BASE_URL,
   HYBRIDAI_MODEL,
   MAX_CONCURRENT_CONTAINERS,
@@ -56,6 +57,7 @@ import {
   WEB_SEARCH_PROVIDER,
   WEB_SEARCH_TAVILY_SEARCH_DEPTH,
 } from '../config/config.js';
+import { withConnectorGatewayAuth } from '../config/connector-gateway.js';
 import type { CodexTurnRuntime } from '../config/runtime-config.js';
 import { readStoredRuntimeEnv } from '../config/runtime-env.js';
 import { GATEWAY_DEBUG_MODEL_RESPONSES_ENV } from '../gateway/gateway-lifecycle.js';
@@ -1138,7 +1140,13 @@ async function runContainerInner(
     media,
     audioTranscriptsPrepended,
     pluginTools,
-    mcpServers: MCP_SERVERS,
+    // The gateway bearer is attached per run, so the long-lived MCP_SERVERS
+    // map never holds the API key (it would leak via listings/logs).
+    mcpServers: withConnectorGatewayAuth(
+      MCP_SERVERS,
+      HYBRIDAI_BASE_URL,
+      HYBRIDAI_API_KEY,
+    ),
     taskModels,
     runtimeEnv,
     contextGuard: {

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -28,6 +28,7 @@ import {
   CONTEXT_GUARD_PER_RESULT_SHARE,
   GATEWAY_API_TOKEN,
   GATEWAY_BASE_URL,
+  HYBRIDAI_API_KEY,
   HYBRIDAI_BASE_URL,
   HYBRIDAI_MODEL,
   MAX_CONCURRENT_CONTAINERS,
@@ -44,6 +45,7 @@ import {
   WEB_SEARCH_PROVIDER,
   WEB_SEARCH_TAVILY_SEARCH_DEPTH,
 } from '../config/config.js';
+import { withConnectorGatewayAuth } from '../config/connector-gateway.js';
 import type { CodexTurnRuntime } from '../config/runtime-config.js';
 import { readStoredRuntimeEnv } from '../config/runtime-env.js';
 import { GATEWAY_DEBUG_MODEL_RESPONSES_ENV } from '../gateway/gateway-lifecycle.js';
@@ -993,7 +995,13 @@ async function runHostProcessInner(
     media,
     audioTranscriptsPrepended,
     pluginTools,
-    mcpServers: MCP_SERVERS,
+    // The gateway bearer is attached per run, so the long-lived MCP_SERVERS
+    // map never holds the API key (it would leak via listings/logs).
+    mcpServers: withConnectorGatewayAuth(
+      MCP_SERVERS,
+      HYBRIDAI_BASE_URL,
+      HYBRIDAI_API_KEY,
+    ),
     taskModels,
     runtimeEnv,
     contextGuard: {

--- a/tests/connector-gateway.test.ts
+++ b/tests/connector-gateway.test.ts
@@ -41,6 +41,15 @@ describe('injectHybridAIConnectorGateway', () => {
     expect(injectHybridAIConnectorGateway({}, '   ', KEY)).toEqual({});
   });
 
+  test('does not inject when connectors are disabled', () => {
+    expect(injectHybridAIConnectorGateway({}, BASE, KEY, false)).toEqual({});
+  });
+
+  test('injects when connectors are explicitly enabled', () => {
+    const result = injectHybridAIConnectorGateway({}, BASE, KEY, true);
+    expect(result[CONNECTOR_GATEWAY_SERVER_NAME]?.url).toBe(GATEWAY_URL);
+  });
+
   test('a user-defined server of the same name always wins', () => {
     const existing: Record<string, McpServerConfig> = {
       [CONNECTOR_GATEWAY_SERVER_NAME]: {

--- a/tests/connector-gateway.test.ts
+++ b/tests/connector-gateway.test.ts
@@ -9,7 +9,7 @@ import type { McpServerConfig } from '../src/types/models.ts';
 
 const BASE = 'https://hybridai.one';
 const KEY = 'hai-secret-key';
-const GATEWAY_URL = 'https://hybridai.one/connectors/mcp';
+const GATEWAY_URL = 'https://hybridai.one/api/v1/connectors/mcp';
 
 describe('injectHybridAIConnectorGateway', () => {
   test('injects the connector gateway without embedding the API key', () => {

--- a/tests/connector-gateway.test.ts
+++ b/tests/connector-gateway.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  CONNECTOR_GATEWAY_SERVER_NAME,
+  injectHybridAIConnectorGateway,
+} from '../src/config/connector-gateway.ts';
+import type { McpServerConfig } from '../src/types/models.ts';
+
+const BASE = 'https://hybridai.one';
+const KEY = 'hai-secret-key';
+
+describe('injectHybridAIConnectorGateway', () => {
+  test('injects the connector gateway when base URL and key are present', () => {
+    const result = injectHybridAIConnectorGateway({}, BASE, KEY);
+    expect(result[CONNECTOR_GATEWAY_SERVER_NAME]).toEqual({
+      transport: 'http',
+      url: 'https://hybridai.one/connectors/mcp',
+      headers: { Authorization: `Bearer ${KEY}` },
+      enabled: true,
+    });
+  });
+
+  test('strips trailing slashes from the base URL and trims the key', () => {
+    const result = injectHybridAIConnectorGateway(
+      {},
+      'https://hybridai.one///',
+      '  hai-spaced  ',
+    );
+    const entry = result[CONNECTOR_GATEWAY_SERVER_NAME];
+    expect(entry?.url).toBe('https://hybridai.one/connectors/mcp');
+    expect(entry?.headers).toEqual({ Authorization: 'Bearer hai-spaced' });
+  });
+
+  test('does not inject when the API key is missing or blank', () => {
+    expect(injectHybridAIConnectorGateway({}, BASE, '')).toEqual({});
+    expect(injectHybridAIConnectorGateway({}, BASE, '   ')).toEqual({});
+  });
+
+  test('does not inject when the base URL is missing or blank', () => {
+    expect(injectHybridAIConnectorGateway({}, '', KEY)).toEqual({});
+    expect(injectHybridAIConnectorGateway({}, '   ', KEY)).toEqual({});
+  });
+
+  test('a user-defined server of the same name always wins', () => {
+    const existing: Record<string, McpServerConfig> = {
+      [CONNECTOR_GATEWAY_SERVER_NAME]: {
+        transport: 'http',
+        url: 'https://example.test/custom',
+        enabled: true,
+      },
+    };
+    const result = injectHybridAIConnectorGateway(existing, BASE, KEY);
+    expect(result[CONNECTOR_GATEWAY_SERVER_NAME]?.url).toBe(
+      'https://example.test/custom',
+    );
+  });
+
+  test('preserves other configured servers', () => {
+    const existing: Record<string, McpServerConfig> = {
+      other: { transport: 'stdio', command: 'node', enabled: true },
+    };
+    const result = injectHybridAIConnectorGateway(existing, BASE, KEY);
+    expect(result.other).toEqual(existing.other);
+    expect(result[CONNECTOR_GATEWAY_SERVER_NAME]).toBeDefined();
+  });
+});

--- a/tests/connector-gateway.test.ts
+++ b/tests/connector-gateway.test.ts
@@ -3,32 +3,32 @@ import { describe, expect, test } from 'vitest';
 import {
   CONNECTOR_GATEWAY_SERVER_NAME,
   injectHybridAIConnectorGateway,
+  withConnectorGatewayAuth,
 } from '../src/config/connector-gateway.ts';
 import type { McpServerConfig } from '../src/types/models.ts';
 
 const BASE = 'https://hybridai.one';
 const KEY = 'hai-secret-key';
+const GATEWAY_URL = 'https://hybridai.one/connectors/mcp';
 
 describe('injectHybridAIConnectorGateway', () => {
-  test('injects the connector gateway when base URL and key are present', () => {
+  test('injects the connector gateway without embedding the API key', () => {
     const result = injectHybridAIConnectorGateway({}, BASE, KEY);
     expect(result[CONNECTOR_GATEWAY_SERVER_NAME]).toEqual({
       transport: 'http',
-      url: 'https://hybridai.one/connectors/mcp',
-      headers: { Authorization: `Bearer ${KEY}` },
+      url: GATEWAY_URL,
       enabled: true,
     });
+    expect(JSON.stringify(result)).not.toContain(KEY);
   });
 
-  test('strips trailing slashes from the base URL and trims the key', () => {
+  test('strips trailing slashes from the base URL', () => {
     const result = injectHybridAIConnectorGateway(
       {},
       'https://hybridai.one///',
-      '  hai-spaced  ',
+      KEY,
     );
-    const entry = result[CONNECTOR_GATEWAY_SERVER_NAME];
-    expect(entry?.url).toBe('https://hybridai.one/connectors/mcp');
-    expect(entry?.headers).toEqual({ Authorization: 'Bearer hai-spaced' });
+    expect(result[CONNECTOR_GATEWAY_SERVER_NAME]?.url).toBe(GATEWAY_URL);
   });
 
   test('does not inject when the API key is missing or blank', () => {
@@ -62,5 +62,66 @@ describe('injectHybridAIConnectorGateway', () => {
     const result = injectHybridAIConnectorGateway(existing, BASE, KEY);
     expect(result.other).toEqual(existing.other);
     expect(result[CONNECTOR_GATEWAY_SERVER_NAME]).toBeDefined();
+  });
+});
+
+describe('withConnectorGatewayAuth', () => {
+  function injected(): Record<string, McpServerConfig> {
+    return injectHybridAIConnectorGateway({}, BASE, KEY);
+  }
+
+  test('attaches the bearer to the injected entry without mutating the input', () => {
+    const servers = injected();
+    const result = withConnectorGatewayAuth(servers, BASE, KEY);
+    expect(result[CONNECTOR_GATEWAY_SERVER_NAME]?.headers).toEqual({
+      Authorization: `Bearer ${KEY}`,
+    });
+    // The long-lived map stays credential-free.
+    expect(servers[CONNECTOR_GATEWAY_SERVER_NAME]?.headers).toBeUndefined();
+  });
+
+  test('trims the key and tolerates trailing slashes on the base URL', () => {
+    const result = withConnectorGatewayAuth(
+      injected(),
+      'https://hybridai.one///',
+      '  hai-spaced  ',
+    );
+    expect(result[CONNECTOR_GATEWAY_SERVER_NAME]?.headers).toEqual({
+      Authorization: 'Bearer hai-spaced',
+    });
+  });
+
+  test('never attaches the key to an entry pointing at a foreign URL', () => {
+    const servers: Record<string, McpServerConfig> = {
+      [CONNECTOR_GATEWAY_SERVER_NAME]: {
+        transport: 'http',
+        url: 'https://evil.test/connectors/mcp',
+        enabled: true,
+      },
+    };
+    const result = withConnectorGatewayAuth(servers, BASE, KEY);
+    expect(result[CONNECTOR_GATEWAY_SERVER_NAME]?.headers).toBeUndefined();
+  });
+
+  test('leaves a user-supplied Authorization header untouched', () => {
+    const servers: Record<string, McpServerConfig> = {
+      [CONNECTOR_GATEWAY_SERVER_NAME]: {
+        transport: 'http',
+        url: GATEWAY_URL,
+        headers: { Authorization: 'Bearer user-token' },
+        enabled: true,
+      },
+    };
+    const result = withConnectorGatewayAuth(servers, BASE, KEY);
+    expect(result[CONNECTOR_GATEWAY_SERVER_NAME]?.headers).toEqual({
+      Authorization: 'Bearer user-token',
+    });
+  });
+
+  test('is a no-op when the key or base URL is blank or the entry is absent', () => {
+    expect(withConnectorGatewayAuth({}, BASE, KEY)).toEqual({});
+    const servers = injected();
+    expect(withConnectorGatewayAuth(servers, BASE, '')).toBe(servers);
+    expect(withConnectorGatewayAuth(servers, '', KEY)).toBe(servers);
   });
 });


### PR DESCRIPTION
## What

Auto-wire the **HybridAI connectors MCP server** whenever the HybridAI provider is configured.

When `HYBRIDAI_BASE_URL` and `HYBRIDAI_API_KEY` are present, `applyRuntimeConfig` now injects an in-memory `mcpServers` entry:

```json
{
  "hybridai-connectors": {
    "transport": "http",
    "url": "{HYBRIDAI_BASE_URL}/api/v1/connectors/mcp",
    "enabled": true
  }
}
```

The injected entry is credential-free. The bearer token is attached per agent run by `withConnectorGatewayAuth` in the host/container runners, and only when the configured server URL exactly matches the connector endpoint derived from the active HybridAI base URL. User-defined MCP entries that point elsewhere never receive the HybridAI API key.

## Why

HybridClaw users who configure the HybridAI provider should get access to HybridAI-provided connectors without duplicating setup in `mcpServers` or managing a second credential.

This keeps the open-source configuration model straightforward:

- provider credentials stay in the existing HybridAI provider settings
- the generated MCP server entry is runtime-only and never written to `config.json`
- users can still override or disable `hybridai-connectors` with an explicit config entry
- long-running agents can discover connector changes without restarting

## How

- Injects `hybridai-connectors` into the in-memory `MCP_SERVERS` map only.
- Leaves the persisted runtime config credential-free and unchanged.
- Preserves user-defined servers with the same name instead of overwriting them.
- Omits the auto-wired server when either the base URL or API key is missing.
- Normalizes trailing slashes on the base URL and trims the API key.
- Re-runs `applyRuntimeConfig` when runtime secrets are refreshed so post-startup key paths wire the server without a gateway restart.
- Refreshes remote MCP tool discovery in `container/src/mcp/client-manager.ts` every 5 minutes, reconnects unhealthy remote servers on the same tick, and retries once after 30 seconds when a remote connection returns zero tools.

## Security notes

- `MCP_SERVERS` remains safe to list or log because the generated entry never stores the bearer token.
- Authorization is added only to the expected HybridAI connector endpoint.
- Existing user-supplied `Authorization` headers are preserved.
- API key rotation is picked up on the next run because the credential is resolved at run time, not stored in the generated MCP entry.

## Tests

`tests/connector-gateway.test.ts` covers:

- credential-free server injection
- trailing-slash and API-key trimming behavior
- omission when base URL or key is blank
- user override precedence
- preservation of unrelated MCP servers
- `withConnectorGatewayAuth` attaching auth without mutating the long-lived map
- no auth attachment for foreign URLs, blank config, missing entries, or user-supplied `Authorization`

Validation reported for this PR:

- `npx vitest run tests/connector-gateway.test.ts` -> 11 passed
- root `tsc --noEmit` clean for the changed files, with only pre-existing unrelated `@sentry/node` errors in this checkout
- `npm --prefix container run lint` clean for the changed files

## Known follow-up

The auto-wired server is not yet visible or manageable through `/mcp`, the admin MCP API, or the `doctor` MCP check because it lives in the in-memory server map rather than persisted runtime config. Users can still disable it by adding:

```json
{
  "mcpServers": {
    "hybridai-connectors": {
      "enabled": false
    }
  }
}
```

Surfacing runtime-injected MCP servers in those read paths is a separate product decision and a follow-up change.

---

Opened as a draft while integration validation and release coordination finish.
