### PR TITLE
feat: add HybridAI proxy agents

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.7/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/console/src/api/client.test.ts
+++ b/console/src/api/client.test.ts
@@ -3,6 +3,7 @@ import {
   AUTH_REQUIRED_EVENT,
   buildWebCommandRequestBody,
   dispatchAuthRequired,
+  fetchAdminHybridAIBots,
   isLoopbackHostnameForTest,
   readStoredToken,
   setAuthReloadHandlerForTest,
@@ -377,6 +378,51 @@ describe('client command helpers', () => {
       },
     });
     expect(agent.proxy?.apiKey.id).toBe('HYBRIDAI_PROXY_KEY');
+  });
+
+  it('fetches HybridAI bot options from the admin endpoint', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          bots: [
+            {
+              id: 'bot-support',
+              name: 'Support Bot',
+              description: 'Handles support requests',
+              model: 'gpt-5',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      ),
+    );
+
+    const bots = await fetchAdminHybridAIBots(
+      'test-token',
+      'https://hybridai.one',
+    );
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/admin/hybridai/bots?baseUrl=https%3A%2F%2Fhybridai.one',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-token',
+        }),
+      }),
+    );
+    expect(bots).toEqual([
+      {
+        id: 'bot-support',
+        name: 'Support Bot',
+        description: 'Handles support requests',
+        model: 'gpt-5',
+      },
+    ]);
   });
 
   it('dispatches auth-required when skill zip upload returns 401', async () => {

--- a/console/src/api/client.test.ts
+++ b/console/src/api/client.test.ts
@@ -9,6 +9,7 @@ import {
   setRuntimeSecret,
   TOKEN_STORAGE_KEY,
   unblockSkill,
+  updateAdminAgent,
   uploadSkillZip,
 } from './client';
 
@@ -307,6 +308,75 @@ describe('client command helpers', () => {
     expect(JSON.parse(String(request?.body))).toEqual({
       name: 'rp26-schedule',
     });
+  });
+
+  it('updates admin agent proxy config through the agent endpoint', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          agent: {
+            id: 'support',
+            name: null,
+            model: null,
+            skills: null,
+            chatbotId: null,
+            enableRag: null,
+            proxy: {
+              kind: 'hybridai',
+              baseUrl: 'https://hybridai.example.com',
+              chatbotId: 'support-bot',
+              apiKey: { source: 'store', id: 'HYBRIDAI_PROXY_KEY' },
+              conversationScope: 'user',
+            },
+            role: null,
+            reportsTo: null,
+            delegatesTo: null,
+            peers: null,
+            workspace: null,
+            workspacePath: '/tmp/support/workspace',
+            markdownFiles: [],
+          },
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      ),
+    );
+
+    const agent = await updateAdminAgent('test-token', 'support', {
+      proxy: {
+        kind: 'hybridai',
+        baseUrl: 'https://hybridai.example.com',
+        chatbotId: 'support-bot',
+        apiKey: { source: 'store', id: 'HYBRIDAI_PROXY_KEY' },
+        conversationScope: 'user',
+      },
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/admin/agents/support',
+      expect.objectContaining({
+        method: 'PUT',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        }),
+      }),
+    );
+    const request = vi.mocked(fetch).mock.calls[0]?.[1];
+    expect(JSON.parse(String(request?.body))).toEqual({
+      proxy: {
+        kind: 'hybridai',
+        baseUrl: 'https://hybridai.example.com',
+        chatbotId: 'support-bot',
+        apiKey: { source: 'store', id: 'HYBRIDAI_PROXY_KEY' },
+        conversationScope: 'user',
+      },
+    });
+    expect(agent.proxy?.apiKey.id).toBe('HYBRIDAI_PROXY_KEY');
   });
 
   it('dispatches auth-required when skill zip upload returns 401', async () => {

--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -34,6 +34,8 @@ import type {
   AdminHarnessEvolutionManifestResponse,
   AdminHarnessEvolutionResponse,
   AdminHarnessEvolutionRunResponse,
+  AdminHybridAIBot,
+  AdminHybridAIBotsResponse,
   AdminInteractionResponse,
   AdminInteractionResumeResponse,
   AdminJobsContextResponse,
@@ -541,6 +543,20 @@ export async function fetchAdminAgents(token: string): Promise<AdminAgent[]> {
     token,
   });
   return payload.agents;
+}
+
+export async function fetchAdminHybridAIBots(
+  token: string,
+  baseUrl?: string,
+): Promise<AdminHybridAIBot[]> {
+  const params = new URLSearchParams();
+  if (baseUrl?.trim()) params.set('baseUrl', baseUrl.trim());
+  const query = params.toString();
+  const payload = await requestJson<AdminHybridAIBotsResponse>(
+    `/api/admin/hybridai/bots${query ? `?${query}` : ''}`,
+    { token },
+  );
+  return payload.bots;
 }
 
 export async function updateAdminAgent(

--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -10,6 +10,7 @@ import type {
   AdminAgent,
   AdminAgentMarkdownFileResponse,
   AdminAgentMarkdownRevisionResponse,
+  AdminAgentProxyConfig,
   AdminAgentScoreboardResponse,
   AdminAgentsResponse,
   AdminApprovalsResponse,
@@ -540,6 +541,24 @@ export async function fetchAdminAgents(token: string): Promise<AdminAgent[]> {
     token,
   });
   return payload.agents;
+}
+
+export async function updateAdminAgent(
+  token: string,
+  agentId: string,
+  payload: {
+    proxy?: AdminAgentProxyConfig | null;
+  },
+): Promise<AdminAgent> {
+  const response = await requestJson<{ agent: AdminAgent }>(
+    `/api/admin/agents/${encodeURIComponent(agentId)}`,
+    {
+      token,
+      method: 'PUT',
+      body: payload,
+    },
+  );
+  return response.agent;
 }
 
 export function fetchAdminTeamStructure(

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -1017,6 +1017,17 @@ export interface AdminAgentsResponse {
   agents: AdminAgent[];
 }
 
+export interface AdminHybridAIBot {
+  id: string;
+  name: string;
+  description?: string;
+  model?: string;
+}
+
+export interface AdminHybridAIBotsResponse {
+  bots: AdminHybridAIBot[];
+}
+
 export interface AdminTeamStructureEntry {
   id: string;
   role?: string;

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -983,6 +983,19 @@ export interface AdminAgentMarkdownRevision {
   source: 'save' | 'restore';
 }
 
+export type AdminAgentProxyConversationScope = 'channel' | 'user';
+
+export interface AdminAgentProxyConfig {
+  kind: 'hybridai';
+  baseUrl: string;
+  chatbotId: string;
+  apiKey: {
+    source: 'store';
+    id: string;
+  };
+  conversationScope?: AdminAgentProxyConversationScope;
+}
+
 export interface AdminAgent {
   id: string;
   name: string | null;
@@ -990,6 +1003,7 @@ export interface AdminAgent {
   skills: string[] | null;
   chatbotId: string | null;
   enableRag: boolean | null;
+  proxy?: AdminAgentProxyConfig | null;
   role: string | null;
   reportsTo: string | null;
   delegatesTo: string[] | null;

--- a/console/src/routes/gateway.test.tsx
+++ b/console/src/routes/gateway.test.tsx
@@ -189,4 +189,27 @@ describe('GatewayPage', () => {
       });
     });
   });
+
+  it('validates proxy base URL before saving', async () => {
+    fetchAdminAgentsMock.mockResolvedValue([makeAgent()]);
+
+    renderGatewayPage();
+
+    fireEvent.click(await screen.findByRole('switch', { name: 'Proxy mode' }));
+    fireEvent.change(screen.getByLabelText('HybridAI base URL'), {
+      target: { value: 'http://hybridai.example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Chatbot id'), {
+      target: { value: 'upstream-chatbot' },
+    });
+    fireEvent.change(screen.getByLabelText('API key SecretRef id'), {
+      target: { value: 'HYBRIDAI_PROXY_KEY' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save Proxy Mode' }));
+
+    expect(
+      await screen.findByText('HybridAI base URL must use HTTPS.'),
+    ).toBeTruthy();
+    expect(updateAdminAgentMock).not.toHaveBeenCalled();
+  });
 });

--- a/console/src/routes/gateway.test.tsx
+++ b/console/src/routes/gateway.test.tsx
@@ -1,15 +1,20 @@
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AdminAgent } from '../api/types';
 import { renderWithProviders } from '../test-utils';
 import { GatewayPage } from './gateway';
 
+const fetchAdminAgentsMock = vi.fn<() => Promise<AdminAgent[]>>();
 const reloadGatewayMock = vi.fn();
+const updateAdminAgentMock = vi.fn();
 const navigateMock = vi.fn();
 const useAuthMock = vi.fn();
 const useLiveEventsMock = vi.fn();
 
 vi.mock('../api/client', () => ({
+  fetchAdminAgents: () => fetchAdminAgentsMock(),
   reloadGateway: (...args: unknown[]) => reloadGatewayMock(...args),
+  updateAdminAgent: (...args: unknown[]) => updateAdminAgentMock(...args),
 }));
 
 vi.mock('../auth', () => ({
@@ -76,13 +81,34 @@ function makeStatus(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function makeAgent(overrides: Partial<AdminAgent> = {}): AdminAgent {
+  return {
+    id: 'main',
+    name: 'Main Agent',
+    model: 'gpt-5',
+    skills: null,
+    chatbotId: null,
+    enableRag: true,
+    role: null,
+    reportsTo: null,
+    delegatesTo: null,
+    peers: null,
+    workspace: null,
+    workspacePath: '/tmp/main/workspace',
+    markdownFiles: [],
+    ...overrides,
+  };
+}
+
 function renderGatewayPage(): void {
   renderWithProviders(<GatewayPage />);
 }
 
 describe('GatewayPage', () => {
   beforeEach(() => {
+    fetchAdminAgentsMock.mockReset();
     reloadGatewayMock.mockReset();
+    updateAdminAgentMock.mockReset();
     navigateMock.mockReset();
     useAuthMock.mockReset();
     useLiveEventsMock.mockReset();
@@ -97,6 +123,7 @@ describe('GatewayPage', () => {
       status: null,
       lastEventAt: Date.now(),
     });
+    fetchAdminAgentsMock.mockResolvedValue([makeAgent()]);
   });
 
   afterEach(() => {
@@ -116,6 +143,50 @@ describe('GatewayPage', () => {
 
     await waitFor(() => {
       expect(reloadGatewayMock).toHaveBeenCalledWith('test-token');
+    });
+  });
+
+  it('saves HybridAI proxy mode for the selected agent', async () => {
+    const mainAgent = makeAgent({ chatbotId: 'local-chatbot' });
+    const savedAgent = makeAgent({
+      proxy: {
+        kind: 'hybridai',
+        baseUrl: 'https://hybridai.example.com',
+        chatbotId: 'upstream-chatbot',
+        apiKey: { source: 'store', id: 'HYBRIDAI_PROXY_KEY' },
+        conversationScope: 'user',
+      },
+    });
+    fetchAdminAgentsMock.mockResolvedValue([mainAgent]);
+    updateAdminAgentMock.mockResolvedValue(savedAgent);
+
+    renderGatewayPage();
+
+    fireEvent.click(await screen.findByRole('switch', { name: 'Proxy mode' }));
+    fireEvent.change(screen.getByLabelText('HybridAI base URL'), {
+      target: { value: 'https://hybridai.example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Chatbot id'), {
+      target: { value: 'upstream-chatbot' },
+    });
+    fireEvent.change(screen.getByLabelText('API key SecretRef id'), {
+      target: { value: 'HYBRIDAI_PROXY_KEY' },
+    });
+    fireEvent.change(screen.getByLabelText('Conversation scope'), {
+      target: { value: 'user' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save Proxy Mode' }));
+
+    await waitFor(() => {
+      expect(updateAdminAgentMock).toHaveBeenCalledWith('test-token', 'main', {
+        proxy: {
+          kind: 'hybridai',
+          baseUrl: 'https://hybridai.example.com',
+          chatbotId: 'upstream-chatbot',
+          apiKey: { source: 'store', id: 'HYBRIDAI_PROXY_KEY' },
+          conversationScope: 'user',
+        },
+      });
     });
   });
 });

--- a/console/src/routes/gateway.test.tsx
+++ b/console/src/routes/gateway.test.tsx
@@ -1,10 +1,12 @@
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { AdminAgent } from '../api/types';
+import type { AdminAgent, AdminHybridAIBot } from '../api/types';
 import { renderWithProviders } from '../test-utils';
 import { GatewayPage } from './gateway';
 
 const fetchAdminAgentsMock = vi.fn<() => Promise<AdminAgent[]>>();
+const fetchAdminHybridAIBotsMock =
+  vi.fn<(token: string, baseUrl?: string) => Promise<AdminHybridAIBot[]>>();
 const reloadGatewayMock = vi.fn();
 const updateAdminAgentMock = vi.fn();
 const navigateMock = vi.fn();
@@ -13,6 +15,8 @@ const useLiveEventsMock = vi.fn();
 
 vi.mock('../api/client', () => ({
   fetchAdminAgents: () => fetchAdminAgentsMock(),
+  fetchAdminHybridAIBots: (...args: [string, string?]) =>
+    fetchAdminHybridAIBotsMock(...args),
   reloadGateway: (...args: unknown[]) => reloadGatewayMock(...args),
   updateAdminAgent: (...args: unknown[]) => updateAdminAgentMock(...args),
 }));
@@ -107,6 +111,7 @@ function renderGatewayPage(): void {
 describe('GatewayPage', () => {
   beforeEach(() => {
     fetchAdminAgentsMock.mockReset();
+    fetchAdminHybridAIBotsMock.mockReset();
     reloadGatewayMock.mockReset();
     updateAdminAgentMock.mockReset();
     navigateMock.mockReset();
@@ -124,6 +129,17 @@ describe('GatewayPage', () => {
       lastEventAt: Date.now(),
     });
     fetchAdminAgentsMock.mockResolvedValue([makeAgent()]);
+    fetchAdminHybridAIBotsMock.mockResolvedValue([
+      {
+        id: 'bot-support',
+        name: 'Support Bot',
+        model: 'gpt-5',
+      },
+      {
+        id: 'bot-research',
+        name: 'Research Bot',
+      },
+    ]);
   });
 
   afterEach(() => {
@@ -146,6 +162,60 @@ describe('GatewayPage', () => {
     });
   });
 
+  it('prefills the official HybridAI base URL and saves a selected known bot', async () => {
+    const savedAgent = makeAgent({
+      proxy: {
+        kind: 'hybridai',
+        baseUrl: 'https://hybridai.one',
+        chatbotId: 'bot-research',
+        apiKey: { source: 'store', id: 'HYBRIDAI_PROXY_KEY' },
+        conversationScope: 'channel',
+      },
+    });
+    updateAdminAgentMock.mockResolvedValue(savedAgent);
+
+    renderGatewayPage();
+
+    fireEvent.click(await screen.findByRole('switch', { name: 'Proxy mode' }));
+
+    const baseUrlInput = screen.getByLabelText(
+      'HybridAI base URL',
+    ) as HTMLInputElement;
+    expect(baseUrlInput.value).toBe('https://hybridai.one');
+
+    await waitFor(() => {
+      expect(fetchAdminHybridAIBotsMock).toHaveBeenCalledWith(
+        'test-token',
+        'https://hybridai.one',
+      );
+    });
+    expect(
+      await screen.findByRole('option', {
+        name: 'Support Bot (bot-support) - gpt-5',
+      }),
+    ).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('Chatbot id'), {
+      target: { value: 'bot-research' },
+    });
+    fireEvent.change(screen.getByLabelText('API key SecretRef id'), {
+      target: { value: 'HYBRIDAI_PROXY_KEY' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save Proxy Mode' }));
+
+    await waitFor(() => {
+      expect(updateAdminAgentMock).toHaveBeenCalledWith('test-token', 'main', {
+        proxy: {
+          kind: 'hybridai',
+          baseUrl: 'https://hybridai.one',
+          chatbotId: 'bot-research',
+          apiKey: { source: 'store', id: 'HYBRIDAI_PROXY_KEY' },
+          conversationScope: 'channel',
+        },
+      });
+    });
+  });
+
   it('saves HybridAI proxy mode for the selected agent', async () => {
     const mainAgent = makeAgent({ chatbotId: 'local-chatbot' });
     const savedAgent = makeAgent({
@@ -165,6 +235,9 @@ describe('GatewayPage', () => {
     fireEvent.click(await screen.findByRole('switch', { name: 'Proxy mode' }));
     fireEvent.change(screen.getByLabelText('HybridAI base URL'), {
       target: { value: 'https://hybridai.example.com' },
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText('Chatbot id').tagName).toBe('INPUT');
     });
     fireEvent.change(screen.getByLabelText('Chatbot id'), {
       target: { value: 'upstream-chatbot' },
@@ -198,6 +271,9 @@ describe('GatewayPage', () => {
     fireEvent.click(await screen.findByRole('switch', { name: 'Proxy mode' }));
     fireEvent.change(screen.getByLabelText('HybridAI base URL'), {
       target: { value: 'http://hybridai.example.com' },
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText('Chatbot id').tagName).toBe('INPUT');
     });
     fireEvent.change(screen.getByLabelText('Chatbot id'), {
       target: { value: 'upstream-chatbot' },

--- a/console/src/routes/gateway.tsx
+++ b/console/src/routes/gateway.tsx
@@ -3,12 +3,14 @@ import { useNavigate } from '@tanstack/react-router';
 import { useEffect, useRef, useState } from 'react';
 import {
   fetchAdminAgents,
+  fetchAdminHybridAIBots,
   reloadGateway,
   updateAdminAgent,
 } from '../api/client';
 import type {
   AdminAgent,
   AdminAgentProxyConversationScope,
+  AdminHybridAIBot,
 } from '../api/types';
 import { useAuth } from '../auth';
 import { Button } from '../components/button';
@@ -35,9 +37,14 @@ import { getErrorMessage } from '../lib/error-message';
 import { formatDateTime, formatUptime } from '../lib/format';
 
 const DEFAULT_PROXY_SECRET_ID = 'HYBRIDAI_API_KEY';
+const OFFICIAL_HYBRIDAI_BASE_URL = 'https://hybridai.one';
 
 function formatAgentLabel(agent: AdminAgent): string {
   return agent.name ? `${agent.name} (${agent.id})` : agent.id;
+}
+
+function formatHybridAIBotLabel(bot: AdminHybridAIBot): string {
+  return `${bot.name} (${bot.id})${bot.model ? ` - ${bot.model}` : ''}`;
 }
 
 function getProxyAgentFormSyncKey(agent: AdminAgent): string {
@@ -70,6 +77,14 @@ function normalizeProxyBaseUrlInput(value: string): string {
   return parsed.toString().replace(/\/+$/g, '');
 }
 
+function isOfficialHybridAIBaseUrl(value: string): boolean {
+  try {
+    return normalizeProxyBaseUrlInput(value) === OFFICIAL_HYBRIDAI_BASE_URL;
+  } catch {
+    return false;
+  }
+}
+
 export function GatewayPage() {
   const auth = useAuth();
   const toast = useToast();
@@ -79,7 +94,7 @@ export function GatewayPage() {
   const [reloadConfirmOpen, setReloadConfirmOpen] = useState(false);
   const [selectedProxyAgentId, setSelectedProxyAgentId] = useState('');
   const [proxyEnabled, setProxyEnabled] = useState(false);
-  const [proxyBaseUrl, setProxyBaseUrl] = useState('');
+  const [proxyBaseUrl, setProxyBaseUrl] = useState(OFFICIAL_HYBRIDAI_BASE_URL);
   const [proxyChatbotId, setProxyChatbotId] = useState('');
   const [proxyApiKeySecretId, setProxyApiKeySecretId] = useState(
     DEFAULT_PROXY_SECRET_ID,
@@ -95,6 +110,14 @@ export function GatewayPage() {
   const agentsQuery = useQuery({
     queryKey: ['admin-agents', auth.token],
     queryFn: () => fetchAdminAgents(auth.token),
+    refetchOnWindowFocus: false,
+  });
+  const proxyBaseUrlIsOfficial = isOfficialHybridAIBaseUrl(proxyBaseUrl);
+  const hybridAIBotsQuery = useQuery({
+    queryKey: ['admin-hybridai-bots', auth.token],
+    queryFn: () =>
+      fetchAdminHybridAIBots(auth.token, OFFICIAL_HYBRIDAI_BASE_URL),
+    enabled: proxyEnabled && proxyBaseUrlIsOfficial,
     refetchOnWindowFocus: false,
   });
   const reloadMutation = useMutation({
@@ -130,11 +153,29 @@ export function GatewayPage() {
     lastProxyAgentFormSyncKeyRef.current = syncKey;
     const proxy = nextAgent.proxy || null;
     setProxyEnabled(Boolean(proxy));
-    setProxyBaseUrl(proxy?.baseUrl || '');
+    setProxyBaseUrl(proxy?.baseUrl || OFFICIAL_HYBRIDAI_BASE_URL);
     setProxyChatbotId(proxy?.chatbotId || nextAgent.chatbotId || '');
     setProxyApiKeySecretId(proxy?.apiKey.id || DEFAULT_PROXY_SECRET_ID);
     setProxyConversationScope(proxy?.conversationScope || 'channel');
   }, [adminAgents, selectedProxyAgentId, status?.defaultAgentId]);
+
+  const hybridAIBots = hybridAIBotsQuery.data || [];
+  const hybridAIBotOptions =
+    proxyChatbotId && !hybridAIBots.some((bot) => bot.id === proxyChatbotId)
+      ? [
+          {
+            id: proxyChatbotId,
+            name: proxyChatbotId,
+          },
+          ...hybridAIBots,
+        ]
+      : hybridAIBots;
+
+  useEffect(() => {
+    if (!proxyEnabled || !proxyBaseUrlIsOfficial || proxyChatbotId) return;
+    const firstBotId = hybridAIBots[0]?.id;
+    if (firstBotId) setProxyChatbotId(firstBotId);
+  }, [hybridAIBots, proxyBaseUrlIsOfficial, proxyChatbotId, proxyEnabled]);
 
   const proxyMutation = useMutation({
     mutationFn: async () => {
@@ -357,7 +398,7 @@ export function GatewayPage() {
                         <Input
                           type="url"
                           value={proxyBaseUrl}
-                          placeholder="https://hybridai.example.com"
+                          placeholder={OFFICIAL_HYBRIDAI_BASE_URL}
                           onChange={(event) =>
                             setProxyBaseUrl(event.target.value)
                           }
@@ -365,12 +406,45 @@ export function GatewayPage() {
                       </Field>
                       <Field>
                         <FieldLabel>Chatbot id</FieldLabel>
-                        <Input
-                          value={proxyChatbotId}
-                          onChange={(event) =>
-                            setProxyChatbotId(event.target.value)
-                          }
-                        />
+                        {proxyBaseUrlIsOfficial ? (
+                          <>
+                            <NativeSelect
+                              value={proxyChatbotId}
+                              disabled={
+                                hybridAIBotsQuery.isLoading &&
+                                hybridAIBotOptions.length === 0
+                              }
+                              onChange={(event) =>
+                                setProxyChatbotId(event.target.value)
+                              }
+                            >
+                              {!proxyChatbotId ? (
+                                <NativeSelectOption value="" disabled>
+                                  {hybridAIBotsQuery.isLoading
+                                    ? 'Loading bots...'
+                                    : 'Select bot'}
+                                </NativeSelectOption>
+                              ) : null}
+                              {hybridAIBotOptions.map((bot) => (
+                                <NativeSelectOption key={bot.id} value={bot.id}>
+                                  {formatHybridAIBotLabel(bot)}
+                                </NativeSelectOption>
+                              ))}
+                            </NativeSelect>
+                            {hybridAIBotsQuery.isError ? (
+                              <p className="error-banner">
+                                {getErrorMessage(hybridAIBotsQuery.error)}
+                              </p>
+                            ) : null}
+                          </>
+                        ) : (
+                          <Input
+                            value={proxyChatbotId}
+                            onChange={(event) =>
+                              setProxyChatbotId(event.target.value)
+                            }
+                          />
+                        )}
                       </Field>
                       <Field>
                         <FieldLabel>API key SecretRef id</FieldLabel>

--- a/console/src/routes/gateway.tsx
+++ b/console/src/routes/gateway.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   fetchAdminAgents,
   reloadGateway,
@@ -40,6 +40,36 @@ function formatAgentLabel(agent: AdminAgent): string {
   return agent.name ? `${agent.name} (${agent.id})` : agent.id;
 }
 
+function getProxyAgentFormSyncKey(agent: AdminAgent): string {
+  return JSON.stringify({
+    id: agent.id,
+    chatbotId: agent.chatbotId,
+    proxy: agent.proxy || null,
+  });
+}
+
+function normalizeProxyBaseUrlInput(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error('HybridAI base URL is required.');
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error('HybridAI base URL must be a valid HTTPS URL.');
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new Error('HybridAI base URL must use HTTPS.');
+  }
+  parsed.pathname = parsed.pathname.replace(/\/+$/g, '');
+  parsed.username = '';
+  parsed.password = '';
+  parsed.search = '';
+  parsed.hash = '';
+  return parsed.toString().replace(/\/+$/g, '');
+}
+
 export function GatewayPage() {
   const auth = useAuth();
   const toast = useToast();
@@ -56,6 +86,7 @@ export function GatewayPage() {
   );
   const [proxyConversationScope, setProxyConversationScope] =
     useState<AdminAgentProxyConversationScope>('channel');
+  const lastProxyAgentFormSyncKeyRef = useRef('');
   const status = live.status || auth.gatewayStatus;
   const providerEntries = Object.entries(
     status?.providerHealth || status?.localBackends || {},
@@ -80,28 +111,30 @@ export function GatewayPage() {
   const adminAgents = agentsQuery.data || [];
   const selectedProxyAgent =
     adminAgents.find((agent) => agent.id === selectedProxyAgentId) ||
+    adminAgents.find((agent) => agent.id === status?.defaultAgentId) ||
     adminAgents[0] ||
     null;
 
   useEffect(() => {
     if (adminAgents.length === 0) return;
-    if (adminAgents.some((agent) => agent.id === selectedProxyAgentId)) return;
-    const nextAgentId =
-      adminAgents.find((agent) => agent.id === status?.defaultAgentId)?.id ||
-      adminAgents[0]?.id ||
-      '';
-    setSelectedProxyAgentId(nextAgentId);
-  }, [adminAgents, selectedProxyAgentId, status?.defaultAgentId]);
-
-  useEffect(() => {
-    if (!selectedProxyAgent) return;
-    const proxy = selectedProxyAgent.proxy || null;
+    const nextAgent =
+      adminAgents.find((agent) => agent.id === selectedProxyAgentId) ||
+      adminAgents.find((agent) => agent.id === status?.defaultAgentId) ||
+      adminAgents[0];
+    if (!nextAgent) return;
+    const syncKey = getProxyAgentFormSyncKey(nextAgent);
+    if (nextAgent.id !== selectedProxyAgentId) {
+      setSelectedProxyAgentId(nextAgent.id);
+    }
+    if (lastProxyAgentFormSyncKeyRef.current === syncKey) return;
+    lastProxyAgentFormSyncKeyRef.current = syncKey;
+    const proxy = nextAgent.proxy || null;
     setProxyEnabled(Boolean(proxy));
     setProxyBaseUrl(proxy?.baseUrl || '');
-    setProxyChatbotId(proxy?.chatbotId || selectedProxyAgent.chatbotId || '');
+    setProxyChatbotId(proxy?.chatbotId || nextAgent.chatbotId || '');
     setProxyApiKeySecretId(proxy?.apiKey.id || DEFAULT_PROXY_SECRET_ID);
     setProxyConversationScope(proxy?.conversationScope || 'channel');
-  }, [selectedProxyAgent]);
+  }, [adminAgents, selectedProxyAgentId, status?.defaultAgentId]);
 
   const proxyMutation = useMutation({
     mutationFn: async () => {
@@ -112,7 +145,7 @@ export function GatewayPage() {
       const proxy = proxyEnabled
         ? {
             kind: 'hybridai' as const,
-            baseUrl: proxyBaseUrl.trim(),
+            baseUrl: normalizeProxyBaseUrlInput(proxyBaseUrl),
             chatbotId: proxyChatbotId.trim(),
             apiKey: {
               source: 'store' as const,

--- a/console/src/routes/gateway.tsx
+++ b/console/src/routes/gateway.tsx
@@ -1,8 +1,13 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { useState } from 'react';
-import { reloadGateway } from '../api/client';
+import { useEffect, useState } from 'react';
+import { fetchAdminAgents, reloadGateway, updateAdminAgent } from '../api/client';
+import type {
+  AdminAgent,
+  AdminAgentProxyConversationScope,
+} from '../api/types';
 import { useAuth } from '../auth';
+import { Button } from '../components/button';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/card';
 import {
   Dialog,
@@ -13,7 +18,14 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../components/dialog';
+import { Field, FieldLabel } from '../components/field';
+import { Input } from '../components/input';
+import {
+  NativeSelect,
+  NativeSelectOption,
+} from '../components/native-select';
 import { ProviderHealthPanel } from '../components/provider-health';
+import { Switch } from '../components/switch';
 import { useToast } from '../components/toast';
 import { BooleanPill, MetricCard, PageHeader } from '../components/ui';
 import { useLiveConnectionToasts } from '../hooks/use-live-connection-toasts';
@@ -21,17 +33,38 @@ import { useLiveEvents } from '../hooks/use-live-events';
 import { getErrorMessage } from '../lib/error-message';
 import { formatDateTime, formatUptime } from '../lib/format';
 
+const DEFAULT_PROXY_SECRET_ID = 'HYBRIDAI_API_KEY';
+
+function formatAgentLabel(agent: AdminAgent): string {
+  return agent.name ? `${agent.name} (${agent.id})` : agent.id;
+}
+
 export function GatewayPage() {
   const auth = useAuth();
   const toast = useToast();
+  const queryClient = useQueryClient();
   const live = useLiveEvents(auth.token);
   useLiveConnectionToasts(live.connection);
   const [reloadConfirmOpen, setReloadConfirmOpen] = useState(false);
+  const [selectedProxyAgentId, setSelectedProxyAgentId] = useState('');
+  const [proxyEnabled, setProxyEnabled] = useState(false);
+  const [proxyBaseUrl, setProxyBaseUrl] = useState('');
+  const [proxyChatbotId, setProxyChatbotId] = useState('');
+  const [proxyApiKeySecretId, setProxyApiKeySecretId] = useState(
+    DEFAULT_PROXY_SECRET_ID,
+  );
+  const [proxyConversationScope, setProxyConversationScope] =
+    useState<AdminAgentProxyConversationScope>('channel');
   const status = live.status || auth.gatewayStatus;
   const providerEntries = Object.entries(
     status?.providerHealth || status?.localBackends || {},
   );
   const schedulerJobs = status?.scheduler?.jobs || [];
+  const agentsQuery = useQuery({
+    queryKey: ['admin-agents', auth.token],
+    queryFn: () => fetchAdminAgents(auth.token),
+    refetchOnWindowFocus: false,
+  });
   const reloadMutation = useMutation({
     mutationFn: () => reloadGateway(auth.token),
     onSuccess: () => {
@@ -43,6 +76,73 @@ export function GatewayPage() {
   });
 
   const navigate = useNavigate();
+  const adminAgents = agentsQuery.data || [];
+  const selectedProxyAgent =
+    adminAgents.find((agent) => agent.id === selectedProxyAgentId) ||
+    adminAgents[0] ||
+    null;
+
+  useEffect(() => {
+    if (adminAgents.length === 0) return;
+    if (adminAgents.some((agent) => agent.id === selectedProxyAgentId)) return;
+    const nextAgentId =
+      adminAgents.find((agent) => agent.id === status?.defaultAgentId)?.id ||
+      adminAgents[0]?.id ||
+      '';
+    setSelectedProxyAgentId(nextAgentId);
+  }, [adminAgents, selectedProxyAgentId, status?.defaultAgentId]);
+
+  useEffect(() => {
+    if (!selectedProxyAgent) return;
+    const proxy = selectedProxyAgent.proxy || null;
+    setProxyEnabled(Boolean(proxy));
+    setProxyBaseUrl(proxy?.baseUrl || '');
+    setProxyChatbotId(proxy?.chatbotId || selectedProxyAgent.chatbotId || '');
+    setProxyApiKeySecretId(proxy?.apiKey.id || DEFAULT_PROXY_SECRET_ID);
+    setProxyConversationScope(proxy?.conversationScope || 'channel');
+  }, [
+    selectedProxyAgent?.id,
+    selectedProxyAgent?.chatbotId,
+    selectedProxyAgent?.proxy?.baseUrl,
+    selectedProxyAgent?.proxy?.chatbotId,
+    selectedProxyAgent?.proxy?.apiKey.id,
+    selectedProxyAgent?.proxy?.conversationScope,
+  ]);
+
+  const proxyMutation = useMutation({
+    mutationFn: async () => {
+      if (!selectedProxyAgent) {
+        throw new Error('Select an agent first.');
+      }
+      const secretId = proxyApiKeySecretId.trim();
+      const proxy = proxyEnabled
+        ? {
+            kind: 'hybridai' as const,
+            baseUrl: proxyBaseUrl.trim(),
+            chatbotId: proxyChatbotId.trim(),
+            apiKey: {
+              source: 'store' as const,
+              id: secretId,
+            },
+            conversationScope: proxyConversationScope,
+          }
+        : null;
+      return updateAdminAgent(auth.token, selectedProxyAgent.id, { proxy });
+    },
+    onSuccess: (agent) => {
+      queryClient.setQueryData<AdminAgent[]>(
+        ['admin-agents', auth.token],
+        (current) =>
+          current?.map((entry) => (entry.id === agent.id ? agent : entry)) || [
+            agent,
+          ],
+      );
+      toast.success(`Saved proxy mode for ${agent.name || agent.id}.`);
+    },
+    onError: (error) => {
+      toast.error('Proxy mode update failed', getErrorMessage(error));
+    },
+  });
 
   if (!status) {
     return <div className="empty-state">Gateway status is unavailable.</div>;
@@ -179,6 +279,117 @@ export function GatewayPage() {
           entries={providerEntries}
           onLogin={() => void navigate({ to: '/admin/config' })}
         />
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Agent proxy mode</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {agentsQuery.isLoading ? (
+              <div className="empty-state">Loading agents...</div>
+            ) : adminAgents.length === 0 ? (
+              <div className="empty-state">No agents are registered.</div>
+            ) : (
+              <div className="list-stack">
+                <div className="field-grid">
+                  <Field>
+                    <FieldLabel>Agent</FieldLabel>
+                    <NativeSelect
+                      value={selectedProxyAgent?.id || ''}
+                      onChange={(event) =>
+                        setSelectedProxyAgentId(event.target.value)
+                      }
+                    >
+                      {adminAgents.map((agent) => (
+                        <NativeSelectOption key={agent.id} value={agent.id}>
+                          {formatAgentLabel(agent)}
+                        </NativeSelectOption>
+                      ))}
+                    </NativeSelect>
+                  </Field>
+
+                  <Field>
+                    <FieldLabel>Proxy mode</FieldLabel>
+                    <div className="button-row">
+                      <Switch
+                        checked={proxyEnabled}
+                        onCheckedChange={setProxyEnabled}
+                      />
+                      <BooleanPill
+                        value={proxyEnabled}
+                        trueLabel="on"
+                        falseLabel="off"
+                      />
+                    </div>
+                  </Field>
+
+                  {proxyEnabled ? (
+                    <>
+                      <Field>
+                        <FieldLabel>HybridAI base URL</FieldLabel>
+                        <Input
+                          type="url"
+                          value={proxyBaseUrl}
+                          placeholder="https://hybridai.example.com"
+                          onChange={(event) =>
+                            setProxyBaseUrl(event.target.value)
+                          }
+                        />
+                      </Field>
+                      <Field>
+                        <FieldLabel>Chatbot id</FieldLabel>
+                        <Input
+                          value={proxyChatbotId}
+                          onChange={(event) =>
+                            setProxyChatbotId(event.target.value)
+                          }
+                        />
+                      </Field>
+                      <Field>
+                        <FieldLabel>API key SecretRef id</FieldLabel>
+                        <Input
+                          value={proxyApiKeySecretId}
+                          placeholder={DEFAULT_PROXY_SECRET_ID}
+                          onChange={(event) =>
+                            setProxyApiKeySecretId(event.target.value)
+                          }
+                        />
+                      </Field>
+                      <Field>
+                        <FieldLabel>Conversation scope</FieldLabel>
+                        <NativeSelect
+                          value={proxyConversationScope}
+                          onChange={(event) =>
+                            setProxyConversationScope(
+                              event.target
+                                .value as AdminAgentProxyConversationScope,
+                            )
+                          }
+                        >
+                          <NativeSelectOption value="channel">
+                            channel
+                          </NativeSelectOption>
+                          <NativeSelectOption value="user">
+                            user
+                          </NativeSelectOption>
+                        </NativeSelect>
+                      </Field>
+                    </>
+                  ) : null}
+                </div>
+                <div className="button-row">
+                  <Button
+                    loading={proxyMutation.isPending}
+                    disabled={!selectedProxyAgent}
+                    onClick={() => proxyMutation.mutate()}
+                  >
+                    Save Proxy Mode
+                  </Button>
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
 
         <Card variant="muted">
           <CardHeader>

--- a/console/src/routes/gateway.tsx
+++ b/console/src/routes/gateway.tsx
@@ -1,7 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
-import { fetchAdminAgents, reloadGateway, updateAdminAgent } from '../api/client';
+import {
+  fetchAdminAgents,
+  reloadGateway,
+  updateAdminAgent,
+} from '../api/client';
 import type {
   AdminAgent,
   AdminAgentProxyConversationScope,
@@ -20,10 +24,7 @@ import {
 } from '../components/dialog';
 import { Field, FieldLabel } from '../components/field';
 import { Input } from '../components/input';
-import {
-  NativeSelect,
-  NativeSelectOption,
-} from '../components/native-select';
+import { NativeSelect, NativeSelectOption } from '../components/native-select';
 import { ProviderHealthPanel } from '../components/provider-health';
 import { Switch } from '../components/switch';
 import { useToast } from '../components/toast';
@@ -100,14 +101,7 @@ export function GatewayPage() {
     setProxyChatbotId(proxy?.chatbotId || selectedProxyAgent.chatbotId || '');
     setProxyApiKeySecretId(proxy?.apiKey.id || DEFAULT_PROXY_SECRET_ID);
     setProxyConversationScope(proxy?.conversationScope || 'channel');
-  }, [
-    selectedProxyAgent?.id,
-    selectedProxyAgent?.chatbotId,
-    selectedProxyAgent?.proxy?.baseUrl,
-    selectedProxyAgent?.proxy?.chatbotId,
-    selectedProxyAgent?.proxy?.apiKey.id,
-    selectedProxyAgent?.proxy?.conversationScope,
-  ]);
+  }, [selectedProxyAgent]);
 
   const proxyMutation = useMutation({
     mutationFn: async () => {

--- a/src/agents/agent-config-command.ts
+++ b/src/agents/agent-config-command.ts
@@ -17,6 +17,7 @@ import {
   hasSnakeCamelAlias,
   normalizeAgentCv,
   normalizeAgentEscalationTarget,
+  normalizeAgentProxyConfig,
   normalizeAgentWebSearchConfig,
   resolveSnakeCamelAlias,
 } from './agent-types.js';
@@ -286,6 +287,19 @@ function applyAgentConfigFieldUpdates(
         );
       }
       next.webSearch = webSearch;
+    }
+  }
+  if (Object.hasOwn(updates, 'proxy')) {
+    if (updates.proxy === null) {
+      delete next.proxy;
+    } else {
+      const proxy = normalizeAgentProxyConfig(updates.proxy, 'proxy');
+      if (!proxy) {
+        throw new Error(
+          '`proxy` must include kind, baseUrl, chatbotId, and apiKey fields, or null.',
+        );
+      }
+      next.proxy = proxy;
     }
   }
   return next;

--- a/src/agents/agent-registry.ts
+++ b/src/agents/agent-registry.ts
@@ -33,6 +33,7 @@ import {
   cloneAgentA2AConfig,
   cloneAgentBudgetConfig,
   cloneAgentCv,
+  cloneAgentProxyConfig,
   cloneAgentWebSearchConfig,
   DEFAULT_AGENT_ID,
   normalizeAgentA2AConfig,
@@ -40,6 +41,7 @@ import {
   normalizeAgentCv,
   normalizeAgentEscalationTarget,
   normalizeAgentIdentityFields,
+  normalizeAgentProxyConfig,
   normalizeAgentWebSearchConfig,
   resolveSnakeCamelAlias,
   validateAgentOrgChart,
@@ -210,6 +212,7 @@ function normalizeAgent(value: unknown): AgentConfig | null {
   const webSearch = normalizeAgentWebSearchConfig(
     (value as { webSearch?: unknown }).webSearch,
   );
+  const proxy = normalizeAgentProxyConfig((value as { proxy?: unknown }).proxy);
   const budget = normalizeAgentBudgetConfig(
     (value as { budget?: unknown }).budget,
   );
@@ -232,6 +235,7 @@ function normalizeAgent(value: unknown): AgentConfig | null {
     ...(escalationTarget ? { escalationTarget } : {}),
     ...(a2a ? { a2a } : {}),
     ...(webSearch ? { webSearch } : {}),
+    ...(proxy ? { proxy } : {}),
     ...(budget ? { budget } : {}),
   };
 }
@@ -275,6 +279,18 @@ function fingerprintWebSearch(webSearch: AgentConfig['webSearch']): string {
   ].join(':');
 }
 
+function fingerprintProxy(proxy: AgentConfig['proxy']): string {
+  if (!proxy) return '';
+  return [
+    fingerprintString(proxy.kind),
+    fingerprintString(proxy.baseUrl),
+    fingerprintString(proxy.chatbotId),
+    fingerprintString(proxy.apiKey.source),
+    fingerprintString(proxy.apiKey.id),
+    fingerprintString(proxy.conversationScope),
+  ].join(':');
+}
+
 function fingerprintBudget(budget: AgentConfig['budget']): string {
   if (!budget) return '';
   return budget.unit === 'tokens'
@@ -310,6 +326,7 @@ function fingerprintAgent(agent: AgentConfig): string {
         .sort(),
     ),
     fingerprintWebSearch(agent.webSearch),
+    fingerprintProxy(agent.proxy),
     fingerprintBudget(agent.budget),
   ].join('|');
 }
@@ -405,6 +422,7 @@ function applyDefaults(agent: AgentConfig): AgentConfig {
     ...(agent.webSearch
       ? { webSearch: cloneAgentWebSearchConfig(agent.webSearch) }
       : {}),
+    ...(agent.proxy ? { proxy: cloneAgentProxyConfig(agent.proxy) } : {}),
     ...(agent.budget ? { budget: cloneAgentBudgetConfig(agent.budget) } : {}),
   };
 }
@@ -459,6 +477,7 @@ function configuredAgentForDatabase(agent: AgentConfig): AgentConfig {
     cv: cloneAgentCv(agent.cv),
     escalationTarget: agent.escalationTarget,
     a2a: cloneAgentA2AConfig(agent.a2a),
+    proxy: cloneAgentProxyConfig(agent.proxy),
     budget: cloneAgentBudgetConfig(agent.budget),
     webSearch: cloneAgentWebSearchConfig(agent.webSearch),
   };

--- a/src/agents/agent-registry.ts
+++ b/src/agents/agent-registry.ts
@@ -280,15 +280,8 @@ function fingerprintWebSearch(webSearch: AgentConfig['webSearch']): string {
 }
 
 function fingerprintProxy(proxy: AgentConfig['proxy']): string {
-  if (!proxy) return '';
-  return [
-    fingerprintString(proxy.kind),
-    fingerprintString(proxy.baseUrl),
-    fingerprintString(proxy.chatbotId),
-    fingerprintString(proxy.apiKey.source),
-    fingerprintString(proxy.apiKey.id),
-    fingerprintString(proxy.conversationScope),
-  ].join(':');
+  const clone = cloneAgentProxyConfig(proxy);
+  return clone ? fingerprintString(JSON.stringify(clone)) : '';
 }
 
 function fingerprintBudget(budget: AgentConfig['budget']): string {

--- a/src/agents/agent-runtime-config.ts
+++ b/src/agents/agent-runtime-config.ts
@@ -22,6 +22,22 @@ function sameModelConfig(a?: AgentModelConfig, b?: AgentModelConfig): boolean {
   return a.primary === b.primary && sameStringArray(a.fallbacks, b.fallbacks);
 }
 
+function sameProxyConfig(
+  a?: AgentConfig['proxy'],
+  b?: AgentConfig['proxy'],
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.kind === b.kind &&
+    a.baseUrl === b.baseUrl &&
+    a.chatbotId === b.chatbotId &&
+    a.apiKey.source === b.apiKey.source &&
+    a.apiKey.id === b.apiKey.id &&
+    a.conversationScope === b.conversationScope
+  );
+}
+
 function sameAgentConfig(a: AgentConfig | undefined, b: AgentConfig): boolean {
   return (
     Boolean(a) &&
@@ -40,7 +56,8 @@ function sameAgentConfig(a: AgentConfig | undefined, b: AgentConfig): boolean {
     sameStringArray(a.delegatesTo, b.delegatesTo) &&
     sameStringArray(a.peers, b.peers) &&
     agentCvEquals(a.cv, b.cv) &&
-    agentEscalationTargetEquals(a.escalationTarget, b.escalationTarget)
+    agentEscalationTargetEquals(a.escalationTarget, b.escalationTarget) &&
+    sameProxyConfig(a.proxy, b.proxy)
   );
 }
 

--- a/src/agents/agent-runtime-config.ts
+++ b/src/agents/agent-runtime-config.ts
@@ -8,7 +8,11 @@ import type {
   AgentModelConfig,
   AgentsConfig,
 } from './agent-types.js';
-import { agentCvEquals, agentEscalationTargetEquals } from './agent-types.js';
+import {
+  agentCvEquals,
+  agentEscalationTargetEquals,
+  agentProxyConfigEquals,
+} from './agent-types.js';
 
 function sameStringArray(a?: string[], b?: string[]): boolean {
   if (a === b) return true;
@@ -20,22 +24,6 @@ function sameModelConfig(a?: AgentModelConfig, b?: AgentModelConfig): boolean {
   if (a === b) return true;
   if (typeof a === 'string' || typeof b === 'string' || !a || !b) return false;
   return a.primary === b.primary && sameStringArray(a.fallbacks, b.fallbacks);
-}
-
-function sameProxyConfig(
-  a?: AgentConfig['proxy'],
-  b?: AgentConfig['proxy'],
-): boolean {
-  if (a === b) return true;
-  if (!a || !b) return false;
-  return (
-    a.kind === b.kind &&
-    a.baseUrl === b.baseUrl &&
-    a.chatbotId === b.chatbotId &&
-    a.apiKey.source === b.apiKey.source &&
-    a.apiKey.id === b.apiKey.id &&
-    a.conversationScope === b.conversationScope
-  );
 }
 
 function sameAgentConfig(a: AgentConfig | undefined, b: AgentConfig): boolean {
@@ -57,7 +45,7 @@ function sameAgentConfig(a: AgentConfig | undefined, b: AgentConfig): boolean {
     sameStringArray(a.peers, b.peers) &&
     agentCvEquals(a.cv, b.cv) &&
     agentEscalationTargetEquals(a.escalationTarget, b.escalationTarget) &&
-    sameProxyConfig(a.proxy, b.proxy)
+    agentProxyConfigEquals(a.proxy, b.proxy)
   );
 }
 

--- a/src/agents/agent-types.ts
+++ b/src/agents/agent-types.ts
@@ -46,15 +46,13 @@ export interface AgentWebSearchConfig {
 
 export type AgentProxyConversationScope = 'channel' | 'user';
 
-export interface AgentHybridAIProxyConfig {
+export interface AgentProxyConfig {
   kind: 'hybridai';
   baseUrl: string;
   chatbotId: string;
   apiKey: SecretRef;
   conversationScope?: AgentProxyConversationScope;
 }
-
-export type AgentProxyConfig = AgentHybridAIProxyConfig;
 
 export type AgentBudgetCurrency = 'USD' | 'EUR';
 export type AgentBudgetUnit = AgentBudgetCurrency | 'tokens';
@@ -226,6 +224,22 @@ export function cloneAgentProxyConfig(
   };
 }
 
+export function agentProxyConfigEquals(
+  a: AgentProxyConfig | undefined,
+  b: AgentProxyConfig | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.kind === b.kind &&
+    a.baseUrl === b.baseUrl &&
+    a.chatbotId === b.chatbotId &&
+    a.apiKey.source === b.apiKey.source &&
+    a.apiKey.id === b.apiKey.id &&
+    a.conversationScope === b.conversationScope
+  );
+}
+
 export function cloneAgentBudgetConfig(
   value: AgentBudgetConfig | undefined,
 ): AgentBudgetConfig | undefined {
@@ -390,6 +404,8 @@ export function normalizeAgentProxyConfig(
     throw new Error(`${path}.baseUrl must use HTTPS.`);
   }
   parsedBaseUrl.pathname = parsedBaseUrl.pathname.replace(/\/+$/g, '');
+  parsedBaseUrl.username = '';
+  parsedBaseUrl.password = '';
   parsedBaseUrl.search = '';
   parsedBaseUrl.hash = '';
 

--- a/src/agents/agent-types.ts
+++ b/src/agents/agent-types.ts
@@ -44,6 +44,18 @@ export interface AgentWebSearchConfig {
   searxngBearerTokenRef?: SecretRef;
 }
 
+export type AgentProxyConversationScope = 'channel' | 'user';
+
+export interface AgentHybridAIProxyConfig {
+  kind: 'hybridai';
+  baseUrl: string;
+  chatbotId: string;
+  apiKey: SecretRef;
+  conversationScope?: AgentProxyConversationScope;
+}
+
+export type AgentProxyConfig = AgentHybridAIProxyConfig;
+
 export type AgentBudgetCurrency = 'USD' | 'EUR';
 export type AgentBudgetUnit = AgentBudgetCurrency | 'tokens';
 
@@ -74,6 +86,7 @@ export interface AgentConfig {
   escalationTarget?: EscalationTarget;
   a2a?: AgentA2AConfig;
   webSearch?: AgentWebSearchConfig;
+  proxy?: AgentProxyConfig;
   budget?: AgentBudgetConfig;
 }
 
@@ -198,6 +211,21 @@ export function cloneAgentWebSearchConfig(
   return Object.keys(clone).length > 0 ? clone : undefined;
 }
 
+export function cloneAgentProxyConfig(
+  value: AgentProxyConfig | undefined,
+): AgentProxyConfig | undefined {
+  if (!value) return undefined;
+  return {
+    kind: value.kind,
+    baseUrl: value.baseUrl,
+    chatbotId: value.chatbotId,
+    apiKey: { ...value.apiKey },
+    ...(value.conversationScope
+      ? { conversationScope: value.conversationScope }
+      : {}),
+  };
+}
+
 export function cloneAgentBudgetConfig(
   value: AgentBudgetConfig | undefined,
 ): AgentBudgetConfig | undefined {
@@ -299,6 +327,91 @@ export function normalizeAgentWebSearchConfig(
     ...(searxngBearerTokenRef ? { searxngBearerTokenRef } : {}),
   };
   return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function parseStoredSecretPlaceholder(
+  value: unknown,
+  path: string,
+): SecretRef | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim();
+  const match = normalized.match(/^<secret:([A-Z][A-Z0-9_]{0,127})>$/);
+  if (!match?.[1]) return undefined;
+  return parseSecretRefInput(
+    {
+      source: 'store',
+      id: match[1],
+    },
+    path,
+  );
+}
+
+function parseAgentProxySecretRef(value: unknown, path: string): SecretRef {
+  return (
+    parseStoredSecretPlaceholder(value, path) ??
+    parseSecretRefInput(value, path)
+  );
+}
+
+function normalizeProxyConversationScope(
+  value: unknown,
+): AgentProxyConversationScope | undefined {
+  const normalized = normalizeTrimmedString(value).toLowerCase();
+  if (normalized === 'channel' || normalized === 'user') return normalized;
+  return undefined;
+}
+
+export function normalizeAgentProxyConfig(
+  value: unknown,
+  path = 'agents.list[].proxy',
+): AgentProxyConfig | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${path} must be an object or null.`);
+  }
+
+  const raw = value as Record<string, unknown>;
+  const kind = normalizeTrimmedString(raw.kind).toLowerCase();
+  if (kind !== 'hybridai') {
+    throw new Error(`${path}.kind must be "hybridai".`);
+  }
+
+  const baseUrl = normalizeTrimmedString(raw.baseUrl ?? raw.base_url);
+  if (!baseUrl) {
+    throw new Error(`${path}.baseUrl is required for HybridAI proxy agents.`);
+  }
+  let parsedBaseUrl: URL;
+  try {
+    parsedBaseUrl = new URL(baseUrl);
+  } catch {
+    throw new Error(`${path}.baseUrl must be a valid HTTPS URL.`);
+  }
+  if (parsedBaseUrl.protocol !== 'https:') {
+    throw new Error(`${path}.baseUrl must use HTTPS.`);
+  }
+  parsedBaseUrl.pathname = parsedBaseUrl.pathname.replace(/\/+$/g, '');
+  parsedBaseUrl.search = '';
+  parsedBaseUrl.hash = '';
+
+  const chatbotId = normalizeTrimmedString(raw.chatbotId ?? raw.chatbot_id);
+  if (!chatbotId) {
+    throw new Error(`${path}.chatbotId is required for HybridAI proxy agents.`);
+  }
+
+  const apiKeyInput =
+    raw.apiKey ?? raw.api_key ?? raw.apiKeyRef ?? raw.api_key_ref;
+  const apiKey = parseAgentProxySecretRef(apiKeyInput, `${path}.apiKey`);
+  const conversationScope = normalizeProxyConversationScope(
+    raw.conversationScope ?? raw.conversation_scope,
+  );
+
+  return {
+    kind: 'hybridai',
+    baseUrl: parsedBaseUrl.toString().replace(/\/+$/g, ''),
+    chatbotId,
+    apiKey,
+    ...(conversationScope ? { conversationScope } : {}),
+  };
 }
 
 function normalizeAgentA2AExposureValue(

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -15,6 +15,7 @@ import {
   cloneAgentA2AConfig,
   cloneAgentBudgetConfig,
   cloneAgentCv,
+  cloneAgentProxyConfig,
   cloneAgentWebSearchConfig,
   DEFAULT_AGENT_ID,
   hasSnakeCamelAlias,
@@ -23,6 +24,7 @@ import {
   normalizeAgentCv,
   normalizeAgentEscalationTarget,
   normalizeAgentIdentityFields,
+  normalizeAgentProxyConfig,
   normalizeAgentWebSearchConfig,
   resolveSnakeCamelAlias,
   validateAgentOrgChart,
@@ -2823,6 +2825,9 @@ function normalizeAgentConfig(
         fallback?.webSearch,
       )
     : cloneAgentWebSearchConfig(fallback?.webSearch);
+  const proxy = Object.hasOwn(value, 'proxy')
+    ? normalizeAgentProxyConfig(value.proxy, 'agents.list[].proxy')
+    : cloneAgentProxyConfig(fallback?.proxy);
   const budget = Object.hasOwn(value, 'budget')
     ? normalizeAgentBudgetConfig(value.budget, fallback?.budget)
     : cloneAgentBudgetConfig(fallback?.budget);
@@ -2845,6 +2850,7 @@ function normalizeAgentConfig(
     ...(escalationTarget ? { escalationTarget } : {}),
     ...(a2a ? { a2a } : {}),
     ...(webSearch ? { webSearch } : {}),
+    ...(proxy ? { proxy } : {}),
     ...(budget ? { budget } : {}),
   };
 }

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -151,6 +151,7 @@ import {
   resolveWorkspaceRelativePath,
 } from './gateway-utils.js';
 import { isSupportedProactiveChannelId } from './proactive-delivery.js';
+import { forwardGatewayMessageToProxyAgent } from './proxy-agent.js';
 import {
   detectCliSecretSetCommand,
   renderCliSecretSetCommandWarning,
@@ -870,15 +871,6 @@ async function handleGatewayMessageInner(
   const resolvedAgent = resolveAgentConfig(agentId);
   let model = resolvedModel;
   let chatbotId = resolvedChatbotId;
-  let chatbotResolution = await resolveGatewayChatbotId({
-    model,
-    chatbotId,
-    sessionId: req.sessionId,
-    channelId: req.channelId,
-    agentId,
-    trigger: 'chat',
-  });
-  chatbotId = chatbotResolution.chatbotId;
   const channelType =
     resolveChannelType(req) || resolveSessionResetChannelKind(req.channelId);
   const channel =
@@ -961,6 +953,32 @@ async function handleGatewayMessageInner(
       req.sessionId = session.id;
     }
   }
+  if (resolvedAgent.proxy) {
+    try {
+      const result = await forwardGatewayMessageToProxyAgent({
+        req,
+        agent: resolvedAgent,
+        runId,
+        abortSignal: activeGatewayRequest.signal,
+      });
+      return attachSessionIdentity({
+        ...result,
+        assistantPresentation:
+          getGatewayAssistantPresentationForMessageAgent(agentId),
+      });
+    } finally {
+      activeGatewayRequest.release();
+    }
+  }
+  let chatbotResolution = await resolveGatewayChatbotId({
+    model,
+    chatbotId,
+    sessionId: req.sessionId,
+    channelId: req.channelId,
+    agentId,
+    trigger: 'chat',
+  });
+  chatbotId = chatbotResolution.chatbotId;
   const sessionContext = buildSessionContext({
     source: {
       channelKind: channelType || channel?.kind,

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -953,11 +953,12 @@ async function handleGatewayMessageInner(
       req.sessionId = session.id;
     }
   }
-  if (resolvedAgent.proxy) {
+  const proxy = resolvedAgent.proxy;
+  if (proxy) {
     try {
       const result = await forwardGatewayMessageToProxyAgent({
         req,
-        agent: resolvedAgent,
+        agent: { ...resolvedAgent, proxy },
         runId,
         abortSignal: activeGatewayRequest.signal,
       });

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -216,6 +216,7 @@ import {
   getGatewayAdminEmailFolder,
   getGatewayAdminEmailMailbox,
   getGatewayAdminEmailMessage,
+  getGatewayAdminHybridAIBots,
   getGatewayAdminJobsContext,
   getGatewayAdminMcp,
   getGatewayAdminModels,
@@ -4596,6 +4597,56 @@ async function handleApiAdminAgents(
   }
 }
 
+async function handleApiAdminHybridAIBots(
+  res: ServerResponse,
+  method: string,
+  url: URL,
+): Promise<void> {
+  if (method !== 'GET') {
+    sendMethodNotAllowed(res);
+    return;
+  }
+  try {
+    sendJson(
+      res,
+      200,
+      await getGatewayAdminHybridAIBots({
+        baseUrl: normalizeApiAdminHybridAIBaseUrl(url),
+      }),
+    );
+  } catch (error) {
+    if (error instanceof GatewayRequestError) {
+      sendJson(res, error.statusCode, { error: error.message });
+      return;
+    }
+    sendJson(res, 502, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function normalizeApiAdminHybridAIBaseUrl(url: URL): string | undefined {
+  const raw = url.searchParams.get('baseUrl');
+  if (raw === null) return undefined;
+  const normalized = raw.trim();
+  if (!normalized) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(normalized);
+  } catch {
+    throw new GatewayRequestError(400, 'baseUrl must be a valid HTTPS URL.');
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new GatewayRequestError(400, 'baseUrl must use HTTPS.');
+  }
+  parsed.pathname = parsed.pathname.replace(/\/+$/g, '');
+  parsed.username = '';
+  parsed.password = '';
+  parsed.search = '';
+  parsed.hash = '';
+  return parsed.toString().replace(/\/+$/g, '');
+}
+
 async function handleApiAdminTeamStructure(
   res: ServerResponse,
   method: string,
@@ -6746,6 +6797,10 @@ export function startGatewayHttpServer(): GatewayHttpServer {
             pathname.startsWith('/api/admin/agents/')
           ) {
             await handleApiAdminAgents(req, res, url);
+            return;
+          }
+          if (pathname === '/api/admin/hybridai/bots') {
+            await handleApiAdminHybridAIBots(res, method, url);
             return;
           }
           if (pathname === '/api/admin/agent-scoreboard' && method === 'GET') {

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -19,7 +19,9 @@ import {
 import { createSilentReplyStreamFilter } from '../agent/silent-reply-stream.js';
 import { getAgentById, resolveAgentConfig } from '../agents/agent-registry.js';
 import {
+  type AgentProxyConfig,
   DEFAULT_AGENT_ID,
+  normalizeAgentProxyConfig,
   resolveSnakeCamelAlias,
 } from '../agents/agent-types.js';
 import { getHybridAIApiKey } from '../auth/hybridai-auth.js';
@@ -4150,6 +4152,7 @@ type ApiAdminAgentPayloadBody = {
   skills?: unknown;
   chatbotId?: unknown;
   enableRag?: unknown;
+  proxy?: unknown;
   role?: unknown;
   reportsTo?: unknown;
   reports_to?: unknown;
@@ -4166,6 +4169,7 @@ type ApiAdminAgentPayload = {
   skills?: string[] | null;
   chatbotId?: string;
   enableRag?: boolean;
+  proxy?: AgentProxyConfig | null;
   role?: string;
   reportsTo?: string | null;
   delegatesTo?: string[] | null;
@@ -4320,6 +4324,14 @@ function normalizeApiAdminNullableStringAlias(
   return input === null ? null : undefined;
 }
 
+function normalizeApiAdminAgentProxy(
+  value: unknown,
+): AgentProxyConfig | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null || value === '') return null;
+  return normalizeAgentProxyConfig(value, 'proxy') ?? null;
+}
+
 async function readApiAdminAgentPayload(
   req: IncomingMessage,
   options?: { requireId?: boolean },
@@ -4337,6 +4349,7 @@ async function readApiAdminAgentPayload(
     skills: normalizeApiAdminAgentSkills(body.skills),
     chatbotId: typeof body.chatbotId === 'string' ? body.chatbotId : undefined,
     enableRag: typeof body.enableRag === 'boolean' ? body.enableRag : undefined,
+    proxy: normalizeApiAdminAgentProxy(body.proxy),
     role: typeof body.role === 'string' ? body.role : undefined,
     reportsTo: normalizeApiAdminNullableStringAlias(
       body,
@@ -4381,6 +4394,7 @@ async function handleApiAdminAgentCollectionResource(
           skills: payload.skills,
           chatbotId: payload.chatbotId,
           enableRag: payload.enableRag,
+          proxy: payload.proxy,
           role: payload.role,
           reportsTo: payload.reportsTo,
           delegatesTo: payload.delegatesTo,
@@ -4419,6 +4433,7 @@ async function handleApiAdminAgentResource(
           skills: payload.skills,
           chatbotId: payload.chatbotId,
           enableRag: payload.enableRag,
+          proxy: payload.proxy,
           role: payload.role,
           reportsTo: payload.reportsTo,
           delegatesTo: payload.delegatesTo,

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -1452,6 +1452,7 @@ function mapGatewayAdminAgentProxyConfig(
   proxy: AgentConfig['proxy'],
 ): GatewayAdminAgent['proxy'] {
   if (!proxy) return null;
+  if (proxy.apiKey.source !== 'store') return null;
   return {
     kind: 'hybridai',
     baseUrl: proxy.baseUrl,

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -11438,9 +11438,25 @@ export async function handleGatewayCommand(
 
       case 'status': {
         const status = await getGatewayStatus();
-        const delegationStatus = delegationQueueStatus();
         const commitShort = resolveGitCommitShort();
         const runtime = resolveSessionRuntimeTarget(session);
+        const activeAgent = resolveAgentConfig(runtime.agentId);
+        if (activeAgent.proxy) {
+          const proxyScope = activeAgent.proxy.conversationScope ?? 'channel';
+          const lines = [
+            `🦞 HybridClaw v${status.version}${commitShort ? ` (${commitShort})` : ''}`,
+            '🔁 Mode: HybridAI proxy',
+            `🤖 Agent: ${runtime.agentId}`,
+            `🌐 Upstream: ${activeAgent.proxy.baseUrl}`,
+            `💬 Chatbot: ${activeAgent.proxy.chatbotId}`,
+            `🧵 Conversation scope: ${proxyScope}`,
+            `🧵 Session: ${session.id} • updated ${formatRelativeTime(session.last_active)}`,
+            `📊 Gateway: uptime ${formatUptime(status.uptime)} · sessions ${status.sessions}`,
+          ];
+          return infoCommand('Status', lines.join('\n'));
+        }
+
+        const delegationStatus = delegationQueueStatus();
         const containerImageStatus =
           status.sandbox?.mode === 'container' && status.sandbox.image
             ? await resolveContainerImageStatus(status.sandbox.image)

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -1422,6 +1422,9 @@ function mapGatewayAdminAgent(
     chatbotId: resolved.chatbotId || null,
     enableRag:
       typeof resolved.enableRag === 'boolean' ? resolved.enableRag : null,
+    ...(resolved.proxy
+      ? { proxy: mapGatewayAdminAgentProxyConfig(resolved.proxy) }
+      : {}),
     role: resolved.role || null,
     reportsTo: resolved.reportsTo || null,
     delegatesTo: Array.isArray(resolved.delegatesTo)
@@ -1442,6 +1445,24 @@ function mapGatewayAdminAgent(
             : undefined,
         }),
     ),
+  };
+}
+
+function mapGatewayAdminAgentProxyConfig(
+  proxy: AgentConfig['proxy'],
+): GatewayAdminAgent['proxy'] {
+  if (!proxy) return null;
+  return {
+    kind: 'hybridai',
+    baseUrl: proxy.baseUrl,
+    chatbotId: proxy.chatbotId,
+    apiKey: {
+      source: 'store',
+      id: proxy.apiKey.id,
+    },
+    ...(proxy.conversationScope
+      ? { conversationScope: proxy.conversationScope }
+      : {}),
   };
 }
 
@@ -4831,6 +4852,7 @@ export function createGatewayAdminAgent(params: {
   skills?: string[] | null;
   chatbotId?: string | null;
   enableRag?: boolean | null;
+  proxy?: AgentConfig['proxy'] | null;
   role?: string | null;
   reportsTo?: string | null;
   delegatesTo?: string[] | null;
@@ -4848,6 +4870,9 @@ export function createGatewayAdminAgent(params: {
     ...(typeof params.enableRag === 'boolean'
       ? { enableRag: params.enableRag }
       : {}),
+    ...(params.proxy !== undefined
+      ? { proxy: params.proxy ?? undefined }
+      : {}),
     ...buildGatewayAdminAgentOrgChartPatch(params),
     ...(params.workspace?.trim() ? { workspace: params.workspace.trim() } : {}),
   });
@@ -4864,6 +4889,7 @@ export function updateGatewayAdminAgent(
     skills?: string[] | null;
     chatbotId?: string | null;
     enableRag?: boolean | null;
+    proxy?: AgentConfig['proxy'] | null;
     role?: string | null;
     reportsTo?: string | null;
     delegatesTo?: string[] | null;
@@ -4894,6 +4920,9 @@ export function updateGatewayAdminAgent(
       : {}),
     ...(typeof params.enableRag === 'boolean'
       ? { enableRag: params.enableRag }
+      : {}),
+    ...(params.proxy !== undefined
+      ? { proxy: params.proxy ?? undefined }
       : {}),
     ...buildGatewayAdminAgentOrgChartPatch(params),
   });

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -4870,9 +4870,7 @@ export function createGatewayAdminAgent(params: {
     ...(typeof params.enableRag === 'boolean'
       ? { enableRag: params.enableRag }
       : {}),
-    ...(params.proxy !== undefined
-      ? { proxy: params.proxy ?? undefined }
-      : {}),
+    ...(params.proxy !== undefined ? { proxy: params.proxy ?? undefined } : {}),
     ...buildGatewayAdminAgentOrgChartPatch(params),
     ...(params.workspace?.trim() ? { workspace: params.workspace.trim() } : {}),
   });
@@ -4921,9 +4919,7 @@ export function updateGatewayAdminAgent(
     ...(typeof params.enableRag === 'boolean'
       ? { enableRag: params.enableRag }
       : {}),
-    ...(params.proxy !== undefined
-      ? { proxy: params.proxy ?? undefined }
-      : {}),
+    ...(params.proxy !== undefined ? { proxy: params.proxy ?? undefined } : {}),
     ...buildGatewayAdminAgentOrgChartPatch(params),
   });
   return {

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -525,6 +525,7 @@ import {
   type GatewayAdminEmailFolderResponse,
   type GatewayAdminEmailMailboxResponse,
   type GatewayAdminEmailMessageResponse,
+  type GatewayAdminHybridAIBotsResponse,
   type GatewayAdminJobCard,
   type GatewayAdminJobCardEdge,
   type GatewayAdminJobsContextResponse,
@@ -4610,6 +4611,23 @@ export function getGatewayAdminAgents(): GatewayAdminAgentsResponse {
           getGatewayAdminAgentMarkdownFilePresenceStats(workspacePath),
       });
     }),
+  };
+}
+
+export async function getGatewayAdminHybridAIBots(options?: {
+  baseUrl?: string;
+}): Promise<GatewayAdminHybridAIBotsResponse> {
+  const bots = await fetchHybridAIBots({
+    baseUrl: options?.baseUrl,
+    cacheTtlMs: BOT_CACHE_TTL,
+  });
+  return {
+    bots: bots.map((bot) => ({
+      id: bot.id,
+      name: bot.name,
+      ...(bot.description ? { description: bot.description } : {}),
+      ...(bot.model ? { model: bot.model } : {}),
+    })),
   };
 }
 

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -7,6 +7,7 @@ import type { PromptMode, PromptPartName } from '../agent/prompt-hooks.js';
 import type {
   AgentBudgetCurrency,
   AgentBudgetUnit,
+  AgentProxyConversationScope,
 } from '../agents/agent-types.js';
 import type {
   AgentTeamStructureDiff,
@@ -1185,6 +1186,17 @@ export interface GatewayAdminAgentMarkdownRevision {
   source: 'save' | 'restore';
 }
 
+export interface GatewayAdminAgentProxyConfig {
+  kind: 'hybridai';
+  baseUrl: string;
+  chatbotId: string;
+  apiKey: {
+    source: 'store';
+    id: string;
+  };
+  conversationScope?: AgentProxyConversationScope;
+}
+
 export interface GatewayAdminAgent {
   id: string;
   name: string | null;
@@ -1192,6 +1204,7 @@ export interface GatewayAdminAgent {
   skills: string[] | null;
   chatbotId: string | null;
   enableRag: boolean | null;
+  proxy?: GatewayAdminAgentProxyConfig | null;
   role: string | null;
   reportsTo: string | null;
   delegatesTo: string[] | null;

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -1218,6 +1218,17 @@ export interface GatewayAdminAgentsResponse {
   agents: GatewayAdminAgent[];
 }
 
+export interface GatewayAdminHybridAIBot {
+  id: string;
+  name: string;
+  description?: string;
+  model?: string;
+}
+
+export interface GatewayAdminHybridAIBotsResponse {
+  bots: GatewayAdminHybridAIBot[];
+}
+
 export interface GatewayAdminTeamStructureRevision {
   id: number;
   createdAt: string;

--- a/src/gateway/proxy-agent.ts
+++ b/src/gateway/proxy-agent.ts
@@ -1,0 +1,495 @@
+import type { AgentConfig, AgentProxyConfig } from '../agents/agent-types.js';
+import { makeAuditRunId } from '../audit/audit-events.js';
+import { logger } from '../logger.js';
+import { resolveSecretInputUnsafe } from '../security/secret-refs.js';
+import { isRecord } from '../utils/type-guards.js';
+import { recordSecretUnsafeEscaped } from './gateway-secret-injection.js';
+import type { GatewayChatRequest, GatewayChatResult } from './gateway-types.js';
+
+const HYBRIDAI_PROXY_CHAT_PATH = '/api/v1/gateway/chat';
+const HYBRIDAI_PROXY_CONNECT_TIMEOUT_MS = 30_000;
+const HYBRIDAI_PROXY_STREAM_IDLE_TIMEOUT_MS = 90_000;
+const DEFAULT_PROXY_ERROR_REPLY =
+  'The bot is not reachable right now. Please try again later.';
+const PROXY_CONFIG_ERROR_REPLY =
+  'The bot is not reachable because its upstream configuration needs attention.';
+const PROXY_RATE_LIMIT_REPLY =
+  'The bot is receiving too many requests right now. Please try again shortly.';
+
+class ProxyAgentError extends Error {
+  status: number;
+  code: 'config' | 'rate_limit' | 'upstream' | 'network';
+
+  constructor(
+    message: string,
+    options: {
+      status?: number;
+      code?: ProxyAgentError['code'];
+      cause?: unknown;
+    } = {},
+  ) {
+    super(message, options.cause ? { cause: options.cause } : undefined);
+    this.name = 'ProxyAgentError';
+    this.status = options.status ?? 0;
+    this.code = options.code ?? 'upstream';
+  }
+}
+
+function normalizeBaseUrl(value: string): string {
+  return value.trim().replace(/\/+$/g, '');
+}
+
+function resolveProxyUrl(proxy: AgentProxyConfig): string {
+  return `${normalizeBaseUrl(proxy.baseUrl)}${HYBRIDAI_PROXY_CHAT_PATH}`;
+}
+
+function normalizeExternalUserNamespace(source: string | undefined): string {
+  const normalized = String(source || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return normalized || 'gateway';
+}
+
+function buildExternalUserId(req: GatewayChatRequest): string {
+  const namespace = normalizeExternalUserNamespace(req.source);
+  const userId = String(req.userId || '').trim() || 'unknown';
+  return `${namespace}:${userId}`;
+}
+
+function buildConversationId(params: {
+  proxy: AgentProxyConfig;
+  req: GatewayChatRequest;
+  externalUserId: string;
+}): string {
+  const sessionId = String(params.req.sessionId || '').trim();
+  if (params.proxy.conversationScope === 'user') {
+    return `${sessionId}:${params.externalUserId}`;
+  }
+  return sessionId;
+}
+
+function resolveProxyApiKey(params: {
+  proxy: AgentProxyConfig;
+  agentId: string;
+  sessionId: string;
+  runId: string;
+  url: string;
+}): string {
+  const secret = resolveSecretInputUnsafe(params.proxy.apiKey, {
+    path: `agents.${params.agentId}.proxy.apiKey`,
+    required: true,
+    reason: 'inject HybridAI proxy API key into Authorization header',
+    audit: (handle, reason) =>
+      recordSecretUnsafeEscaped({
+        sessionId: params.sessionId,
+        runId: params.runId,
+        skillName: 'gateway.proxy_agent',
+        secretSource: handle.ref.source,
+        secretId: handle.ref.id,
+        sinkKind: 'http',
+        host: new URL(params.url).host,
+        selector: 'Authorization',
+        reason,
+      }),
+  });
+  if (!secret) {
+    throw new ProxyAgentError('HybridAI proxy API key is not configured.', {
+      code: 'config',
+      status: 0,
+    });
+  }
+  return secret;
+}
+
+function createForwardedSignal(externalSignal: AbortSignal | undefined): {
+  signal: AbortSignal;
+  clearConnectTimeout: () => void;
+  dispose: () => void;
+} {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort(new Error('HybridAI proxy connection timed out.'));
+  }, HYBRIDAI_PROXY_CONNECT_TIMEOUT_MS);
+  const onAbort = () => controller.abort(externalSignal?.reason);
+  if (externalSignal) {
+    externalSignal.addEventListener('abort', onAbort, { once: true });
+    if (externalSignal.aborted) onAbort();
+  }
+  return {
+    signal: controller.signal,
+    clearConnectTimeout: () => clearTimeout(timeout),
+    dispose: () => {
+      clearTimeout(timeout);
+      externalSignal?.removeEventListener('abort', onAbort);
+    },
+  };
+}
+
+function readWithIdleTimeout(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  signal: AbortSignal,
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reader.cancel().catch(() => {});
+      reject(
+        new ProxyAgentError('HybridAI proxy stream timed out.', {
+          code: 'network',
+          status: 0,
+        }),
+      );
+    }, HYBRIDAI_PROXY_STREAM_IDLE_TIMEOUT_MS);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reader.cancel().catch(() => {});
+      reject(
+        new ProxyAgentError('HybridAI proxy request was aborted.', {
+          code: 'network',
+          status: 0,
+          cause: signal.reason,
+        }),
+      );
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+    reader.read().then(
+      (result) => {
+        clearTimeout(timer);
+        signal.removeEventListener('abort', onAbort);
+        resolve(result);
+      },
+      (error) => {
+        clearTimeout(timer);
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+function extractOpenAIChoiceText(payload: Record<string, unknown>): string {
+  const choice = Array.isArray(payload.choices) ? payload.choices[0] : null;
+  if (!isRecord(choice)) return '';
+  const delta = isRecord(choice.delta) ? choice.delta : null;
+  if (typeof delta?.content === 'string') return delta.content;
+  const message = isRecord(choice.message) ? choice.message : null;
+  if (typeof message?.content === 'string') return message.content;
+  return '';
+}
+
+function readStringField(
+  payload: Record<string, unknown>,
+  fields: string[],
+): string {
+  for (const field of fields) {
+    const value = payload[field];
+    if (typeof value === 'string') return value;
+  }
+  return '';
+}
+
+function extractResponseText(payload: unknown): string {
+  if (typeof payload === 'string') return payload;
+  if (!isRecord(payload)) return '';
+  const direct = readStringField(payload, [
+    'text',
+    'message',
+    'answer',
+    'response',
+    'result',
+    'content',
+  ]);
+  if (direct) return direct;
+  const data = payload.data;
+  if (isRecord(data)) return extractResponseText(data);
+  return extractOpenAIChoiceText(payload);
+}
+
+function extractStreamDelta(params: {
+  payload: unknown;
+  currentText: string;
+}): string {
+  if (typeof params.payload === 'string') return params.payload;
+  if (!isRecord(params.payload)) return '';
+
+  const explicitDelta = readStringField(params.payload, ['delta', 'chunk']);
+  if (explicitDelta) return explicitDelta;
+
+  const openAIText = extractOpenAIChoiceText(params.payload);
+  if (openAIText) return openAIText;
+
+  const fullText = readStringField(params.payload, [
+    'text',
+    'message',
+    'answer',
+    'response',
+    'result',
+    'content',
+  ]);
+  if (!fullText) {
+    const data = params.payload.data;
+    return isRecord(data)
+      ? extractStreamDelta({ payload: data, currentText: params.currentText })
+      : '';
+  }
+  return fullText.startsWith(params.currentText)
+    ? fullText.slice(params.currentText.length)
+    : fullText;
+}
+
+function parseStreamPayload(raw: string): unknown {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return trimmed;
+  }
+}
+
+function parseSseBlock(block: string): string[] {
+  const lines = block.split(/\r?\n/);
+  const dataLines = lines
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('data:'))
+    .map((line) => line.slice(5).trim());
+  return dataLines.length > 0 ? [dataLines.join('\n').trim()] : [];
+}
+
+function parseDelimitedStreamPayloads(buffer: string): {
+  payloads: string[];
+  remaining: string;
+} {
+  if (buffer.includes('\n\n') || buffer.includes('\r\n\r\n')) {
+    const blocks = buffer.split(/\r?\n\r?\n/);
+    return {
+      payloads: blocks.slice(0, -1).flatMap(parseSseBlock),
+      remaining: blocks.at(-1) || '',
+    };
+  }
+
+  const lines = buffer.split(/\r?\n/);
+  const remaining = lines.pop() || '';
+  return {
+    payloads: lines
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => (line.startsWith('data:') ? line.slice(5).trim() : line)),
+    remaining,
+  };
+}
+
+async function readStreamingResponse(params: {
+  response: Response;
+  signal: AbortSignal;
+  onTextDelta?: (delta: string) => void;
+}): Promise<string> {
+  if (!params.response.body) {
+    return extractResponseText(await params.response.json().catch(() => null));
+  }
+
+  const reader = params.response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let resultText = '';
+  try {
+    while (true) {
+      const next = await readWithIdleTimeout(reader, params.signal);
+      if (next.done) break;
+      buffer += decoder.decode(next.value, { stream: true });
+      const parsed = parseDelimitedStreamPayloads(buffer);
+      buffer = parsed.remaining;
+      for (const payloadText of parsed.payloads) {
+        if (!payloadText || payloadText === '[DONE]') continue;
+        const delta = extractStreamDelta({
+          payload: parseStreamPayload(payloadText),
+          currentText: resultText,
+        });
+        if (!delta) continue;
+        resultText += delta;
+        params.onTextDelta?.(delta);
+      }
+    }
+    if (buffer.trim() && buffer.trim() !== '[DONE]') {
+      const delta = extractStreamDelta({
+        payload: parseStreamPayload(buffer),
+        currentText: resultText,
+      });
+      if (delta) {
+        resultText += delta;
+        params.onTextDelta?.(delta);
+      }
+    }
+  } finally {
+    reader.releaseLock();
+    decoder.decode();
+  }
+  return resultText;
+}
+
+async function readHybridAIProxyResponse(params: {
+  response: Response;
+  signal: AbortSignal;
+  onTextDelta?: (delta: string) => void;
+}): Promise<string> {
+  const contentType = (
+    params.response.headers.get('content-type') || ''
+  ).toLowerCase();
+  if (
+    contentType.includes('application/json') &&
+    !contentType.includes('event-stream') &&
+    !contentType.includes('ndjson')
+  ) {
+    const text = extractResponseText(await params.response.json());
+    if (text) params.onTextDelta?.(text);
+    return text;
+  }
+  return readStreamingResponse(params);
+}
+
+function mapProxyErrorToReply(error: unknown): string {
+  if (error instanceof ProxyAgentError) {
+    if (
+      error.status === 401 ||
+      error.status === 403 ||
+      error.code === 'config'
+    ) {
+      return PROXY_CONFIG_ERROR_REPLY;
+    }
+    if (error.status === 429 || error.code === 'rate_limit') {
+      return PROXY_RATE_LIMIT_REPLY;
+    }
+  }
+  return DEFAULT_PROXY_ERROR_REPLY;
+}
+
+function logProxyFailure(params: {
+  agentId: string;
+  sessionId: string;
+  channelId: string;
+  url: string;
+  error: unknown;
+}): void {
+  const status =
+    params.error instanceof ProxyAgentError ? params.error.status : 0;
+  const code = params.error instanceof ProxyAgentError ? params.error.code : '';
+  logger.warn(
+    {
+      agentId: params.agentId,
+      sessionId: params.sessionId,
+      channelId: params.channelId,
+      upstreamHost: new URL(params.url).host,
+      status,
+      code,
+      error:
+        params.error instanceof Error
+          ? params.error.message
+          : String(params.error),
+    },
+    'HybridAI proxy agent request failed',
+  );
+}
+
+export async function forwardGatewayMessageToProxyAgent(params: {
+  req: GatewayChatRequest;
+  agent: AgentConfig;
+  runId?: string;
+  abortSignal?: AbortSignal;
+}): Promise<GatewayChatResult> {
+  const proxy = params.agent.proxy;
+  if (!proxy) {
+    throw new Error(
+      `Agent "${params.agent.id}" is not configured for proxying.`,
+    );
+  }
+  const runId = params.runId || makeAuditRunId('proxy-agent');
+  const url = resolveProxyUrl(proxy);
+
+  try {
+    const apiKey = resolveProxyApiKey({
+      proxy,
+      agentId: params.agent.id,
+      sessionId: params.req.sessionId,
+      runId,
+      url,
+    });
+    const externalUserId = buildExternalUserId(params.req);
+    const body = {
+      chatbot_id: proxy.chatbotId,
+      message: params.req.content,
+      external_user_id: externalUserId,
+      conversation_id: buildConversationId({
+        proxy,
+        req: params.req,
+        externalUserId,
+      }),
+      username: params.req.username || undefined,
+      stream: true,
+    };
+    const forwardedSignal = createForwardedSignal(params.abortSignal);
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          Accept: 'text/event-stream, application/x-ndjson, application/json',
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+        signal: forwardedSignal.signal,
+      });
+      forwardedSignal.clearConnectTimeout();
+      if (!response.ok) {
+        await response.body?.cancel();
+        throw new ProxyAgentError(
+          `HybridAI proxy returned HTTP ${response.status}.`,
+          {
+            status: response.status,
+            code: response.status === 429 ? 'rate_limit' : 'upstream',
+          },
+        );
+      }
+      const resultText =
+        (await readHybridAIProxyResponse({
+          response,
+          signal: forwardedSignal.signal,
+          onTextDelta: params.req.onTextDelta,
+        })) || DEFAULT_PROXY_ERROR_REPLY;
+      return {
+        status: 'success',
+        result: resultText,
+        messageRole: 'assistant',
+        toolsUsed: [],
+        agentId: params.agent.id,
+        provider: 'hybridai-proxy',
+      };
+    } catch (error) {
+      if (error instanceof ProxyAgentError) throw error;
+      throw new ProxyAgentError('HybridAI proxy request failed.', {
+        code: 'network',
+        status: 0,
+        cause: error,
+      });
+    } finally {
+      forwardedSignal.dispose();
+    }
+  } catch (error) {
+    logProxyFailure({
+      agentId: params.agent.id,
+      sessionId: params.req.sessionId,
+      channelId: params.req.channelId,
+      url,
+      error,
+    });
+    return {
+      status: 'success',
+      result: mapProxyErrorToReply(error),
+      messageRole: 'assistant',
+      toolsUsed: [],
+      agentId: params.agent.id,
+      provider: 'hybridai-proxy',
+    };
+  }
+}

--- a/src/gateway/proxy-agent.ts
+++ b/src/gateway/proxy-agent.ts
@@ -229,6 +229,8 @@ function extractHybridAIStreamDelta(payload: unknown): string {
 function isHybridAIStreamControlPayload(payloadText: string): boolean {
   return (
     payloadText === '[DONE]' ||
+    payloadText === '[END]' ||
+    payloadText === '[ADMIN][END]' ||
     payloadText.startsWith('[LANGFUSE_META]') ||
     payloadText.startsWith('[SESSION_TOKEN]')
   );

--- a/src/gateway/proxy-agent.ts
+++ b/src/gateway/proxy-agent.ts
@@ -201,10 +201,12 @@ function parseHybridAIStreamPayload(raw: string): unknown {
 function parseSseBlock(block: string): string[] {
   const lines = block.split(/\r?\n/);
   const dataLines = lines
-    .map((line) => line.trim())
     .filter((line) => line.startsWith('data:'))
-    .map((line) => line.slice(5).trim());
-  return dataLines.length > 0 ? [dataLines.join('\n').trim()] : [];
+    .map((line) => {
+      const value = line.slice(5);
+      return value.startsWith(' ') ? value.slice(1) : value;
+    });
+  return dataLines.length > 0 ? [dataLines.join('\n')] : [];
 }
 
 function parseHybridAISsePayloads(buffer: string): {
@@ -222,6 +224,22 @@ function extractHybridAIStreamDelta(payload: unknown): string {
   if (!isRecord(payload)) return '';
   const delta = payload.delta;
   return typeof delta === 'string' ? delta : '';
+}
+
+function isHybridAIStreamControlPayload(payloadText: string): boolean {
+  return (
+    payloadText === '[DONE]' ||
+    payloadText.startsWith('[LANGFUSE_META]') ||
+    payloadText.startsWith('[SESSION_TOKEN]')
+  );
+}
+
+function extractHybridAISseText(payloadText: string): string {
+  if (!payloadText || isHybridAIStreamControlPayload(payloadText)) return '';
+  const parsed = parseHybridAIStreamPayload(payloadText);
+  const delta = extractHybridAIStreamDelta(parsed);
+  if (delta) return delta;
+  return parsed === null ? payloadText : '';
 }
 
 function extractHybridAIJsonText(payload: unknown): string {
@@ -252,19 +270,14 @@ async function readHybridAISseResponse(params: {
       );
       buffer = parsed.remaining;
       for (const payloadText of parsed.payloads) {
-        if (!payloadText || payloadText === '[DONE]') continue;
-        const delta = extractHybridAIStreamDelta(
-          parseHybridAIStreamPayload(payloadText),
-        );
+        const delta = extractHybridAISseText(payloadText);
         if (!delta) continue;
         resultParts.push(delta);
         params.onTextDelta?.(delta);
       }
     }
-    if (buffer.trim() && buffer.trim() !== '[DONE]') {
-      const delta = extractHybridAIStreamDelta(
-        parseHybridAIStreamPayload(parseSseBlock(buffer)[0] || buffer),
-      );
+    if (buffer.trim()) {
+      const delta = extractHybridAISseText(parseSseBlock(buffer)[0] || buffer);
       if (delta) {
         resultParts.push(delta);
         params.onTextDelta?.(delta);

--- a/src/gateway/proxy-agent.ts
+++ b/src/gateway/proxy-agent.ts
@@ -1,5 +1,4 @@
 import type { AgentConfig, AgentProxyConfig } from '../agents/agent-types.js';
-import { makeAuditRunId } from '../audit/audit-events.js';
 import { logger } from '../logger.js';
 import { resolveSecretInputUnsafe } from '../security/secret-refs.js';
 import { isRecord } from '../utils/type-guards.js';
@@ -75,7 +74,7 @@ function resolveProxyApiKey(params: {
   agentId: string;
   sessionId: string;
   runId: string;
-  url: string;
+  upstreamHost: string;
 }): string {
   const secret = resolveSecretInputUnsafe(params.proxy.apiKey, {
     path: `agents.${params.agentId}.proxy.apiKey`,
@@ -89,7 +88,7 @@ function resolveProxyApiKey(params: {
         secretSource: handle.ref.source,
         secretId: handle.ref.id,
         sinkKind: 'http',
-        host: new URL(params.url).host,
+        host: params.upstreamHost,
         selector: 'Authorization',
         reason,
       }),
@@ -131,20 +130,41 @@ function readWithIdleTimeout(
   reader: ReadableStreamDefaultReader<Uint8Array>,
   signal: AbortSignal,
 ): Promise<ReadableStreamReadResult<Uint8Array>> {
+  if (signal.aborted) {
+    reader.cancel().catch(() => {});
+    return Promise.reject(
+      new ProxyAgentError('HybridAI proxy request was aborted.', {
+        code: 'network',
+        status: 0,
+        cause: signal.reason,
+      }),
+    );
+  }
+
   return new Promise((resolve, reject) => {
+    let settled = false;
     const timer = setTimeout(() => {
-      reader.cancel().catch(() => {});
-      reject(
+      fail(
         new ProxyAgentError('HybridAI proxy stream timed out.', {
           code: 'network',
           status: 0,
         }),
       );
     }, HYBRIDAI_PROXY_STREAM_IDLE_TIMEOUT_MS);
-    const onAbort = () => {
+
+    const cleanup = () => {
       clearTimeout(timer);
+      signal.removeEventListener('abort', onAbort);
+    };
+    const fail = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
       reader.cancel().catch(() => {});
-      reject(
+      reject(error);
+    };
+    const onAbort = () => {
+      fail(
         new ProxyAgentError('HybridAI proxy request was aborted.', {
           code: 'network',
           status: 0,
@@ -152,99 +172,29 @@ function readWithIdleTimeout(
         }),
       );
     };
+
     signal.addEventListener('abort', onAbort, { once: true });
     reader.read().then(
       (result) => {
-        clearTimeout(timer);
-        signal.removeEventListener('abort', onAbort);
+        if (settled) return;
+        settled = true;
+        cleanup();
         resolve(result);
       },
       (error) => {
-        clearTimeout(timer);
-        signal.removeEventListener('abort', onAbort);
-        reject(error);
+        fail(error);
       },
     );
   });
 }
 
-function extractOpenAIChoiceText(payload: Record<string, unknown>): string {
-  const choice = Array.isArray(payload.choices) ? payload.choices[0] : null;
-  if (!isRecord(choice)) return '';
-  const delta = isRecord(choice.delta) ? choice.delta : null;
-  if (typeof delta?.content === 'string') return delta.content;
-  const message = isRecord(choice.message) ? choice.message : null;
-  if (typeof message?.content === 'string') return message.content;
-  return '';
-}
-
-function readStringField(
-  payload: Record<string, unknown>,
-  fields: string[],
-): string {
-  for (const field of fields) {
-    const value = payload[field];
-    if (typeof value === 'string') return value;
-  }
-  return '';
-}
-
-function extractResponseText(payload: unknown): string {
-  if (typeof payload === 'string') return payload;
-  if (!isRecord(payload)) return '';
-  const direct = readStringField(payload, [
-    'text',
-    'message',
-    'answer',
-    'response',
-    'result',
-    'content',
-  ]);
-  if (direct) return direct;
-  const data = payload.data;
-  if (isRecord(data)) return extractResponseText(data);
-  return extractOpenAIChoiceText(payload);
-}
-
-function extractStreamDelta(params: {
-  payload: unknown;
-  currentText: string;
-}): string {
-  if (typeof params.payload === 'string') return params.payload;
-  if (!isRecord(params.payload)) return '';
-
-  const explicitDelta = readStringField(params.payload, ['delta', 'chunk']);
-  if (explicitDelta) return explicitDelta;
-
-  const openAIText = extractOpenAIChoiceText(params.payload);
-  if (openAIText) return openAIText;
-
-  const fullText = readStringField(params.payload, [
-    'text',
-    'message',
-    'answer',
-    'response',
-    'result',
-    'content',
-  ]);
-  if (!fullText) {
-    const data = params.payload.data;
-    return isRecord(data)
-      ? extractStreamDelta({ payload: data, currentText: params.currentText })
-      : '';
-  }
-  return fullText.startsWith(params.currentText)
-    ? fullText.slice(params.currentText.length)
-    : fullText;
-}
-
-function parseStreamPayload(raw: string): unknown {
+function parseHybridAIStreamPayload(raw: string): unknown {
   const trimmed = raw.trim();
   if (!trimmed) return null;
   try {
     return JSON.parse(trimmed) as unknown;
   } catch {
-    return trimmed;
+    return null;
   }
 }
 
@@ -257,67 +207,66 @@ function parseSseBlock(block: string): string[] {
   return dataLines.length > 0 ? [dataLines.join('\n').trim()] : [];
 }
 
-function parseDelimitedStreamPayloads(buffer: string): {
+function parseHybridAISsePayloads(buffer: string): {
   payloads: string[];
   remaining: string;
 } {
-  if (buffer.includes('\n\n') || buffer.includes('\r\n\r\n')) {
-    const blocks = buffer.split(/\r?\n\r?\n/);
-    return {
-      payloads: blocks.slice(0, -1).flatMap(parseSseBlock),
-      remaining: blocks.at(-1) || '',
-    };
-  }
-
-  const lines = buffer.split(/\r?\n/);
-  const remaining = lines.pop() || '';
+  const blocks = buffer.split(/\r?\n\r?\n/);
   return {
-    payloads: lines
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .map((line) => (line.startsWith('data:') ? line.slice(5).trim() : line)),
-    remaining,
+    payloads: blocks.slice(0, -1).flatMap(parseSseBlock),
+    remaining: blocks.at(-1) || '',
   };
 }
 
-async function readStreamingResponse(params: {
+function extractHybridAIStreamDelta(payload: unknown): string {
+  if (!isRecord(payload)) return '';
+  const delta = payload.delta;
+  return typeof delta === 'string' ? delta : '';
+}
+
+function extractHybridAIJsonText(payload: unknown): string {
+  if (!isRecord(payload)) return '';
+  const text = payload.text;
+  return typeof text === 'string' ? text : '';
+}
+
+async function readHybridAISseResponse(params: {
   response: Response;
   signal: AbortSignal;
   onTextDelta?: (delta: string) => void;
 }): Promise<string> {
   if (!params.response.body) {
-    return extractResponseText(await params.response.json().catch(() => null));
+    return '';
   }
 
   const reader = params.response.body.getReader();
   const decoder = new TextDecoder();
   let buffer = '';
-  let resultText = '';
+  const resultParts: string[] = [];
   try {
     while (true) {
       const next = await readWithIdleTimeout(reader, params.signal);
       if (next.done) break;
-      buffer += decoder.decode(next.value, { stream: true });
-      const parsed = parseDelimitedStreamPayloads(buffer);
+      const parsed = parseHybridAISsePayloads(
+        [buffer, decoder.decode(next.value, { stream: true })].join(''),
+      );
       buffer = parsed.remaining;
       for (const payloadText of parsed.payloads) {
         if (!payloadText || payloadText === '[DONE]') continue;
-        const delta = extractStreamDelta({
-          payload: parseStreamPayload(payloadText),
-          currentText: resultText,
-        });
+        const delta = extractHybridAIStreamDelta(
+          parseHybridAIStreamPayload(payloadText),
+        );
         if (!delta) continue;
-        resultText += delta;
+        resultParts.push(delta);
         params.onTextDelta?.(delta);
       }
     }
     if (buffer.trim() && buffer.trim() !== '[DONE]') {
-      const delta = extractStreamDelta({
-        payload: parseStreamPayload(buffer),
-        currentText: resultText,
-      });
+      const delta = extractHybridAIStreamDelta(
+        parseHybridAIStreamPayload(parseSseBlock(buffer)[0] || buffer),
+      );
       if (delta) {
-        resultText += delta;
+        resultParts.push(delta);
         params.onTextDelta?.(delta);
       }
     }
@@ -325,7 +274,7 @@ async function readStreamingResponse(params: {
     reader.releaseLock();
     decoder.decode();
   }
-  return resultText;
+  return resultParts.join('');
 }
 
 async function readHybridAIProxyResponse(params: {
@@ -338,14 +287,13 @@ async function readHybridAIProxyResponse(params: {
   ).toLowerCase();
   if (
     contentType.includes('application/json') &&
-    !contentType.includes('event-stream') &&
-    !contentType.includes('ndjson')
+    !contentType.includes('event-stream')
   ) {
-    const text = extractResponseText(await params.response.json());
+    const text = extractHybridAIJsonText(await params.response.json());
     if (text) params.onTextDelta?.(text);
     return text;
   }
-  return readStreamingResponse(params);
+  return readHybridAISseResponse(params);
 }
 
 function mapProxyErrorToReply(error: unknown): string {
@@ -368,7 +316,7 @@ function logProxyFailure(params: {
   agentId: string;
   sessionId: string;
   channelId: string;
-  url: string;
+  upstreamHost: string;
   error: unknown;
 }): void {
   const status =
@@ -379,7 +327,7 @@ function logProxyFailure(params: {
       agentId: params.agentId,
       sessionId: params.sessionId,
       channelId: params.channelId,
-      upstreamHost: new URL(params.url).host,
+      upstreamHost: params.upstreamHost,
       status,
       code,
       error:
@@ -393,26 +341,21 @@ function logProxyFailure(params: {
 
 export async function forwardGatewayMessageToProxyAgent(params: {
   req: GatewayChatRequest;
-  agent: AgentConfig;
-  runId?: string;
+  agent: AgentConfig & { proxy: AgentProxyConfig };
+  runId: string;
   abortSignal?: AbortSignal;
 }): Promise<GatewayChatResult> {
   const proxy = params.agent.proxy;
-  if (!proxy) {
-    throw new Error(
-      `Agent "${params.agent.id}" is not configured for proxying.`,
-    );
-  }
-  const runId = params.runId || makeAuditRunId('proxy-agent');
   const url = resolveProxyUrl(proxy);
+  const upstreamHost = new URL(url).host;
 
   try {
     const apiKey = resolveProxyApiKey({
       proxy,
       agentId: params.agent.id,
       sessionId: params.req.sessionId,
-      runId,
-      url,
+      runId: params.runId,
+      upstreamHost,
     });
     const externalUserId = buildExternalUserId(params.req);
     const body = {
@@ -433,7 +376,7 @@ export async function forwardGatewayMessageToProxyAgent(params: {
       response = await fetch(url, {
         method: 'POST',
         headers: {
-          Accept: 'text/event-stream, application/x-ndjson, application/json',
+          Accept: 'text/event-stream, application/json',
           Authorization: `Bearer ${apiKey}`,
           'Content-Type': 'application/json',
         },
@@ -480,7 +423,7 @@ export async function forwardGatewayMessageToProxyAgent(params: {
       agentId: params.agent.id,
       sessionId: params.req.sessionId,
       channelId: params.req.channelId,
-      url,
+      upstreamHost,
       error,
     });
     return {

--- a/src/gateway/proxy-agent.ts
+++ b/src/gateway/proxy-agent.ts
@@ -220,10 +220,14 @@ function parseHybridAISsePayloads(buffer: string): {
   };
 }
 
-function extractHybridAIStreamDelta(payload: unknown): string {
-  if (!isRecord(payload)) return '';
+function extractHybridAIStreamDelta(payload: unknown): string | null {
+  if (!isRecord(payload)) return null;
   const delta = payload.delta;
-  return typeof delta === 'string' ? delta : '';
+  return typeof delta === 'string' ? delta : null;
+}
+
+function unescapeHybridAISseText(text: string): string {
+  return text.replace(/\\n/g, '\n').replace(/\\r/g, '\r');
 }
 
 function isHybridAIStreamControlPayload(payloadText: string): boolean {
@@ -240,8 +244,8 @@ function extractHybridAISseText(payloadText: string): string {
   if (!payloadText || isHybridAIStreamControlPayload(payloadText)) return '';
   const parsed = parseHybridAIStreamPayload(payloadText);
   const delta = extractHybridAIStreamDelta(parsed);
-  if (delta) return delta;
-  return parsed === null ? payloadText : '';
+  if (delta !== null) return delta;
+  return unescapeHybridAISseText(payloadText);
 }
 
 function extractHybridAIJsonText(payload: unknown): string {

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -14,6 +14,7 @@ import {
   normalizeAgentCv,
   normalizeAgentEscalationTarget,
   normalizeAgentIdentityFields,
+  normalizeAgentProxyConfig,
   validateAgentOrgChart,
 } from '../agents/agent-types.js';
 import {
@@ -160,7 +161,7 @@ let databaseInitialized = false;
 let usageEventBatchInsertStatement: Database.Statement | null = null;
 const usageRecordSubscribers = new Set<UsageRecordSubscriber>();
 
-export const DATABASE_SCHEMA_VERSION = 43;
+export const DATABASE_SCHEMA_VERSION = 44;
 const AGENT_CANONICAL_ID_COLLISION_LIMIT = 20;
 const DEFAULT_LOCAL_OWNER_USER_ID = formatLocalOwnerUserId('');
 const STRUCTURED_AUDIT_SESSION_LIMIT = 10_000;
@@ -227,6 +228,7 @@ type AgentRow = {
   cv: string | null;
   escalation_target: string | null;
   a2a: string | null;
+  proxy: string | null;
   created_at: string;
   updated_at: string;
 };
@@ -555,6 +557,13 @@ function agentSkillScoresNeedMigration(database: Database.Database): boolean {
 function agentA2ANeedMigration(database: Database.Database): boolean {
   return (
     tableExists(database, 'agents') && !columnExists(database, 'agents', 'a2a')
+  );
+}
+
+function agentProxyNeedMigration(database: Database.Database): boolean {
+  return (
+    tableExists(database, 'agents') &&
+    !columnExists(database, 'agents', 'proxy')
   );
 }
 
@@ -3050,6 +3059,20 @@ function migrateV43(database: Database.Database): void {
   recordMigration(database, 43, 'Index structured audit events by Actor');
 }
 
+function migrateV44(
+  database: Database.Database,
+  opts?: InitDatabaseOptions,
+): void {
+  addColumnIfMissing({
+    database,
+    table: 'agents',
+    column: 'proxy',
+    ddl: 'proxy TEXT',
+    quiet: opts?.quiet === true,
+  });
+  recordMigration(database, 44, 'Persist per-agent proxy backend metadata');
+}
+
 function runMigrations(
   database: Database.Database,
   opts?: InitDatabaseOptions,
@@ -3158,6 +3181,9 @@ function runMigrations(
   }
   if (currentVersion < 43 || auditEventsNeedActorMigration(database)) {
     migrateV43(database);
+  }
+  if (currentVersion < 44 || agentProxyNeedMigration(database)) {
+    migrateV44(database, opts);
   }
 
   setSchemaVersion(database, DATABASE_SCHEMA_VERSION);
@@ -3423,6 +3449,25 @@ function parseAgentA2AConfig(rawConfig: string | null): AgentConfig['a2a'] {
   }
 }
 
+function serializeAgentProxyConfig(proxy: AgentConfig['proxy']): string | null {
+  return proxy ? JSON.stringify(proxy) : null;
+}
+
+function parseAgentProxyConfig(rawConfig: string | null): AgentConfig['proxy'] {
+  const normalized = rawConfig?.trim() || '';
+  if (!normalized) return undefined;
+
+  try {
+    return normalizeAgentProxyConfig(JSON.parse(normalized), 'agents.proxy');
+  } catch {
+    logger.warn(
+      { configLength: normalized.length },
+      'Failed to parse persisted agent proxy configuration',
+    );
+    return undefined;
+  }
+}
+
 function normalizeStoredIdentityField(
   value: string | null,
   parseIdentity: (normalized: string) => { id: string },
@@ -3591,6 +3636,7 @@ function mapAgentRow(row: AgentRow): AgentConfig {
   const cv = parseAgentCv(row.cv);
   const escalationTarget = parseAgentEscalationTarget(row.escalation_target);
   const a2a = parseAgentA2AConfig(row.a2a);
+  const proxy = parseAgentProxyConfig(row.proxy);
   return {
     id: row.id,
     ...(canonicalId ? { canonicalId } : {}),
@@ -3613,11 +3659,12 @@ function mapAgentRow(row: AgentRow): AgentConfig {
     ...(cv ? { cv } : {}),
     ...(escalationTarget ? { escalationTarget } : {}),
     ...(a2a ? { a2a } : {}),
+    ...(proxy ? { proxy } : {}),
   };
 }
 
 const AGENT_SELECT_COLUMNS =
-  'id, canonical_id, owner_user_id, name, display_name, image_asset, model, skills, chatbot_id, enable_rag, workspace, owner, role, reports_to, delegates_to, peers, cv, escalation_target, a2a, created_at, updated_at';
+  'id, canonical_id, owner_user_id, name, display_name, image_asset, model, skills, chatbot_id, enable_rag, workspace, owner, role, reports_to, delegates_to, peers, cv, escalation_target, a2a, proxy, created_at, updated_at';
 
 export function getAgentById(agentId: string): AgentConfig | null {
   const normalizedAgentId = agentId.trim();
@@ -3666,6 +3713,7 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
     agent.escalationTarget,
   );
   const normalizedA2A = serializeAgentA2AConfig(agent.a2a);
+  const normalizedProxy = serializeAgentProxyConfig(agent.proxy);
   const explicitIdentity = normalizeAgentIdentityFields({
     canonicalId: agent.canonicalId,
     ownerUserId: agent.ownerUserId,
@@ -3729,9 +3777,10 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
        cv,
        escalation_target,
        a2a,
+       proxy,
        created_at,
        updated_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
      ON CONFLICT(id) DO UPDATE SET
        canonical_id = excluded.canonical_id,
        owner_user_id = excluded.owner_user_id,
@@ -3751,6 +3800,7 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
        cv = excluded.cv,
        escalation_target = excluded.escalation_target,
        a2a = excluded.a2a,
+       proxy = excluded.proxy,
        updated_at = datetime('now')`,
   ).run(
     normalizedId,
@@ -3772,6 +3822,7 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
     normalizedCv,
     normalizedEscalationTarget,
     normalizedA2A,
+    normalizedProxy,
   );
   const storedAgent = getAgentById(normalizedId);
   if (!storedAgent) {

--- a/src/providers/hybridai-bots.ts
+++ b/src/providers/hybridai-bots.ts
@@ -4,6 +4,7 @@ import { logger } from '../logger.js';
 import type { HybridAIBot } from '../types/hybridai.js';
 
 interface BotCacheEntry {
+  baseUrl: string;
   bots: HybridAIBot[];
   fetchedAtMs: number;
 }
@@ -155,8 +156,13 @@ export function normalizeBots(payload: unknown): HybridAIBot[] {
 
 async function fetchHybridAIBotManagementPayload(
   route: string,
+  options?: { baseUrl?: string },
 ): Promise<unknown> {
-  const url = `${HYBRIDAI_BASE_URL}${route}`;
+  const baseUrl =
+    String(options?.baseUrl || HYBRIDAI_BASE_URL)
+      .trim()
+      .replace(/\/+$/g, '') || HYBRIDAI_BASE_URL;
+  const url = `${baseUrl}${route}`;
   let res: Response;
   try {
     res = await fetch(url, {
@@ -233,20 +239,30 @@ export function normalizeHybridAIAccountChatbotId(payload: unknown): string {
 }
 
 export async function fetchHybridAIBots(options?: {
+  baseUrl?: string;
   cacheTtlMs?: number;
 }): Promise<HybridAIBot[]> {
   const cacheTtlMs = Math.max(0, options?.cacheTtlMs ?? 0);
+  const baseUrl =
+    String(options?.baseUrl || HYBRIDAI_BASE_URL)
+      .trim()
+      .replace(/\/+$/g, '') || HYBRIDAI_BASE_URL;
   const now = Date.now();
 
-  if (cacheTtlMs > 0 && botCache && now - botCache.fetchedAtMs < cacheTtlMs) {
+  if (
+    cacheTtlMs > 0 &&
+    botCache &&
+    botCache.baseUrl === baseUrl &&
+    now - botCache.fetchedAtMs < cacheTtlMs
+  ) {
     return botCache.bots;
   }
 
   const bots = normalizeBots(
-    await fetchHybridAIBotManagementPayload(BOT_LIST_PATH),
+    await fetchHybridAIBotManagementPayload(BOT_LIST_PATH, { baseUrl }),
   );
   if (cacheTtlMs > 0) {
-    botCache = { bots, fetchedAtMs: now };
+    botCache = { baseUrl, bots, fetchedAtMs: now };
   } else {
     botCache = null;
   }

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -1256,6 +1256,20 @@ async function importFreshHealth(options?: {
       },
     ],
   }));
+  const getGatewayAdminHybridAIBots = vi.fn(async () => ({
+    bots: [
+      {
+        id: 'bot-support',
+        name: 'Support Bot',
+        description: 'Handles support requests',
+        model: 'gpt-5',
+      },
+      {
+        id: 'bot-research',
+        name: 'Research Bot',
+      },
+    ],
+  }));
   const getGatewayAdminAgentMarkdownFile = vi.fn(
     (agentId: string, fileName: string) => ({
       agent: makeTestAdminAgent(agentId),
@@ -1918,6 +1932,7 @@ async function importFreshHealth(options?: {
     getGatewayAgentList,
     getGatewayAgents,
     getGatewayAdminAgents,
+    getGatewayAdminHybridAIBots,
     getGatewayAdminAgentMarkdownFile,
     getGatewayAdminAgentMarkdownRevision,
     getGatewayAdminApprovals,
@@ -2080,6 +2095,7 @@ async function importFreshHealth(options?: {
     getGatewayAdminEmailMessage,
     getGatewayAgents,
     getGatewayAdminAgents,
+    getGatewayAdminHybridAIBots,
     getGatewayAdminAgentMarkdownFile,
     getGatewayAdminAgentMarkdownRevision,
     getGatewayAdminTeamStructure,
@@ -5854,6 +5870,53 @@ describe('gateway HTTP server', () => {
           ],
         },
       ],
+    });
+  });
+
+  test('returns HybridAI bots for authorized admin API requests', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({
+      url: '/api/admin/hybridai/bots?baseUrl=https%3A%2F%2Fuser%3Apass%40hybridai.one%2F%3Fdebug%3D1%23token',
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.getGatewayAdminHybridAIBots).toHaveBeenCalledWith({
+      baseUrl: 'https://hybridai.one',
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({
+      bots: [
+        {
+          id: 'bot-support',
+          name: 'Support Bot',
+          description: 'Handles support requests',
+          model: 'gpt-5',
+        },
+        {
+          id: 'bot-research',
+          name: 'Research Bot',
+        },
+      ],
+    });
+  });
+
+  test('rejects non-HTTPS HybridAI bot base URLs', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({
+      url: '/api/admin/hybridai/bots?baseUrl=http%3A%2F%2Fhybridai.one',
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.getGatewayAdminHybridAIBots).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'baseUrl must use HTTPS.',
     });
   });
 

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -6031,7 +6031,7 @@ describe('gateway HTTP server', () => {
       body: {
         proxy: {
           kind: 'hybridai',
-          baseUrl: 'https://hybridai.example.com///',
+          baseUrl: 'https://user:pass@hybridai.example.com///?debug=true#token',
           chatbotId: 'support-bot',
           apiKey: '<secret:HYBRIDAI_PROXY_KEY>',
           conversationScope: 'user',

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -1590,6 +1590,13 @@ async function importFreshHealth(options?: {
       skills?: string[] | null;
       chatbotId?: string | null;
       enableRag?: boolean | null;
+      proxy?: {
+        kind: 'hybridai';
+        baseUrl: string;
+        chatbotId: string;
+        apiKey: { source: 'store'; id: string };
+        conversationScope?: 'channel' | 'user';
+      } | null;
       workspace?: string | null;
     }) => ({
       agent: {
@@ -1600,6 +1607,7 @@ async function importFreshHealth(options?: {
         chatbotId: payload.chatbotId || null,
         enableRag:
           typeof payload.enableRag === 'boolean' ? payload.enableRag : null,
+        ...(payload.proxy ? { proxy: payload.proxy } : {}),
         workspace: payload.workspace || null,
         workspacePath: '/tmp/main/workspace',
         markdownFiles: mainAdminAgentMarkdownFiles,
@@ -1615,6 +1623,13 @@ async function importFreshHealth(options?: {
         skills?: string[] | null;
         chatbotId?: string | null;
         enableRag?: boolean | null;
+        proxy?: {
+          kind: 'hybridai';
+          baseUrl: string;
+          chatbotId: string;
+          apiKey: { source: 'store'; id: string };
+          conversationScope?: 'channel' | 'user';
+        } | null;
         workspace?: string | null;
       },
     ) => ({
@@ -1626,6 +1641,7 @@ async function importFreshHealth(options?: {
         chatbotId: payload.chatbotId || null,
         enableRag:
           typeof payload.enableRag === 'boolean' ? payload.enableRag : null,
+        ...(payload.proxy ? { proxy: payload.proxy } : {}),
         workspace: payload.workspace || null,
         workspacePath: `/tmp/${agentId}/workspace`,
         markdownFiles:
@@ -5880,6 +5896,7 @@ describe('gateway HTTP server', () => {
       skills: ['draft-outline', 'copy-edit'],
       chatbotId: undefined,
       enableRag: undefined,
+      proxy: undefined,
       role: undefined,
       reportsTo: undefined,
       delegatesTo: undefined,
@@ -5965,6 +5982,7 @@ describe('gateway HTTP server', () => {
       skills: null,
       chatbotId: undefined,
       enableRag: undefined,
+      proxy: undefined,
       role: undefined,
       reportsTo: undefined,
       delegatesTo: undefined,
@@ -5999,6 +6017,87 @@ describe('gateway HTTP server', () => {
           },
         ],
       },
+    });
+  });
+
+  test('passes HybridAI proxy config through admin agent update requests', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({
+      method: 'PUT',
+      url: '/api/admin/agents/writer',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: {
+        proxy: {
+          kind: 'hybridai',
+          baseUrl: 'https://hybridai.example.com///',
+          chatbotId: 'support-bot',
+          apiKey: '<secret:HYBRIDAI_PROXY_KEY>',
+          conversationScope: 'user',
+        },
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.updateGatewayAdminAgent).toHaveBeenCalledWith('writer', {
+      name: undefined,
+      model: undefined,
+      skills: undefined,
+      chatbotId: undefined,
+      enableRag: undefined,
+      proxy: {
+        kind: 'hybridai',
+        baseUrl: 'https://hybridai.example.com',
+        chatbotId: 'support-bot',
+        apiKey: { source: 'store', id: 'HYBRIDAI_PROXY_KEY' },
+        conversationScope: 'user',
+      },
+      role: undefined,
+      reportsTo: undefined,
+      delegatesTo: undefined,
+      peers: undefined,
+      workspace: undefined,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).agent.proxy).toEqual({
+      kind: 'hybridai',
+      baseUrl: 'https://hybridai.example.com',
+      chatbotId: 'support-bot',
+      apiKey: { source: 'store', id: 'HYBRIDAI_PROXY_KEY' },
+      conversationScope: 'user',
+    });
+  });
+
+  test('rejects non-HTTPS HybridAI proxy URLs in admin agent updates', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({
+      method: 'PUT',
+      url: '/api/admin/agents/writer',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: {
+        proxy: {
+          kind: 'hybridai',
+          baseUrl: 'http://hybridai.example.com',
+          chatbotId: 'support-bot',
+          apiKey: '<secret:HYBRIDAI_PROXY_KEY>',
+        },
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.updateGatewayAdminAgent).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'proxy.baseUrl must use HTTPS.',
     });
   });
 

--- a/tests/gateway-proxy-agent.test.ts
+++ b/tests/gateway-proxy-agent.test.ts
@@ -214,6 +214,76 @@ test('handleGatewayMessage forwards proxy agents to HybridAI without running loc
   );
 });
 
+test('handleGatewayMessage reads HybridAI plain text SSE proxy chunks', async () => {
+  setupHome();
+
+  const fetchMock = vi.fn(async () =>
+    streamResponse([
+      'data: [LANGFUSE_META]{"langfuseTraceId":"trace","messageId":"msg"}\n\n',
+      'data: [SESSION_TOKEN]session-token\n\n',
+      'data: Hello\n\n',
+      'data: !\n\n',
+      'data:  It works\n\n',
+      'data: [DONE]\n\n',
+    ]),
+  );
+  vi.stubGlobal('fetch', fetchMock);
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { updateRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  const { saveNamedRuntimeSecrets } = await import(
+    '../src/security/runtime-secrets.ts'
+  );
+  const { initAgentRegistry } = await import(
+    '../src/agents/agent-registry.ts'
+  );
+  const { handleGatewayMessage } = await import(
+    '../src/gateway/gateway-chat-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  saveNamedRuntimeSecrets({
+    HYBRIDAI_API_KEY: 'hai-proxy-test-key-1234567890',
+  });
+  updateRuntimeConfig((draft) => {
+    draft.agents.list = [
+      {
+        id: 'support',
+        proxy: proxyConfig(),
+      },
+    ];
+  });
+  initAgentRegistry({
+    list: [
+      {
+        id: 'support',
+        proxy: proxyConfig(),
+      },
+    ],
+  });
+
+  const deltas: string[] = [];
+  const result = await handleGatewayMessage({
+    sessionId: 'session-proxy-plain-sse',
+    guildId: 'guild-1',
+    channelId: 'channel-1',
+    userId: '248135798132',
+    username: 'ben#1234',
+    content: 'Help me',
+    agentId: 'support',
+    source: 'discord',
+    onTextDelta: (delta) => deltas.push(delta),
+  });
+
+  expect(result.status).toBe('success');
+  expect(result.result).toBe('Hello! It works');
+  expect(deltas).toEqual(['Hello', '!', ' It works']);
+  expect(runAgentMock).not.toHaveBeenCalled();
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
 test('handleGatewayMessage hides upstream proxy auth failure bodies from the channel', async () => {
   setupHome();
 

--- a/tests/gateway-proxy-agent.test.ts
+++ b/tests/gateway-proxy-agent.test.ts
@@ -70,7 +70,7 @@ test('agent registry normalizes and persists HybridAI proxy config', async () =>
         id: 'support',
         name: 'Support Proxy',
         proxy: proxyConfig({
-          baseUrl: 'https://app.hybridai.one///',
+          baseUrl: 'https://user:pass@app.hybridai.one///?debug=true#token',
           conversationScope: 'user',
         }),
       },
@@ -82,7 +82,7 @@ test('agent registry normalizes and persists HybridAI proxy config', async () =>
         id: 'support',
         name: 'Support Proxy',
         proxy: proxyConfig({
-          baseUrl: 'https://app.hybridai.one///',
+          baseUrl: 'https://user:pass@app.hybridai.one///?debug=true#token',
           conversationScope: 'user',
         }),
       },

--- a/tests/gateway-proxy-agent.test.ts
+++ b/tests/gateway-proxy-agent.test.ts
@@ -221,9 +221,11 @@ test('handleGatewayMessage reads HybridAI plain text SSE proxy chunks', async ()
     streamResponse([
       'data: [LANGFUSE_META]{"langfuseTraceId":"trace","messageId":"msg"}\n\n',
       'data: [SESSION_TOKEN]session-token\n\n',
-      'data: Hello\n\n',
-      'data: !\n\n',
-      'data:  It works\n\n',
+      'data: Am \n\n',
+      'data: 20\n\n',
+      'data: . Januar \n\n',
+      'data: 2025\n\n',
+      'data: \\n\\nIt works\n\n',
       'data: [END]\n\n',
     ]),
   );
@@ -278,8 +280,8 @@ test('handleGatewayMessage reads HybridAI plain text SSE proxy chunks', async ()
   });
 
   expect(result.status).toBe('success');
-  expect(result.result).toBe('Hello! It works');
-  expect(deltas).toEqual(['Hello', '!', ' It works']);
+  expect(result.result).toBe('Am 20. Januar 2025\n\nIt works');
+  expect(deltas).toEqual(['Am ', '20', '. Januar ', '2025', '\n\nIt works']);
   expect(runAgentMock).not.toHaveBeenCalled();
   expect(fetchMock).toHaveBeenCalledTimes(1);
 });

--- a/tests/gateway-proxy-agent.test.ts
+++ b/tests/gateway-proxy-agent.test.ts
@@ -1,0 +1,284 @@
+import { expect, test, vi } from 'vitest';
+import type { AgentProxyConfig } from '../src/agents/agent-types.ts';
+import { setupGatewayTest } from './helpers/gateway-test-setup.js';
+
+const { runAgentMock } = vi.hoisted(() => ({
+  runAgentMock: vi.fn(),
+}));
+
+vi.mock('../src/agent/agent.js', () => ({
+  runAgent: runAgentMock,
+}));
+
+const { setupHome } = setupGatewayTest({
+  tempHomePrefix: 'hybridclaw-gateway-proxy-agent-',
+  cleanup: () => {
+    runAgentMock.mockReset();
+  },
+});
+
+function streamResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(encoder.encode(chunk));
+        }
+        controller.close();
+      },
+    }),
+    {
+      headers: {
+        'content-type': 'text/event-stream',
+      },
+    },
+  );
+}
+
+function proxyConfig(params?: {
+  apiKey?: unknown;
+  baseUrl?: string;
+  conversationScope?: 'channel' | 'user';
+}): AgentProxyConfig {
+  return {
+    kind: 'hybridai',
+    baseUrl: params?.baseUrl ?? 'https://app.hybridai.one',
+    chatbotId: 'bot_abc123',
+    apiKey: params?.apiKey ?? '<secret:HYBRIDAI_API_KEY>',
+    ...(params?.conversationScope
+      ? { conversationScope: params.conversationScope }
+      : {}),
+  } as unknown as AgentProxyConfig;
+}
+
+test('agent registry normalizes and persists HybridAI proxy config', async () => {
+  setupHome();
+
+  const { initDatabase, getAgentById } = await import('../src/memory/db.ts');
+  const { updateRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  const { initAgentRegistry, resolveAgentConfig } = await import(
+    '../src/agents/agent-registry.ts'
+  );
+
+  initDatabase({ quiet: true });
+  updateRuntimeConfig((draft) => {
+    draft.agents.list = [
+      {
+        id: 'support',
+        name: 'Support Proxy',
+        proxy: proxyConfig({
+          baseUrl: 'https://app.hybridai.one///',
+          conversationScope: 'user',
+        }),
+      },
+    ];
+  });
+  initAgentRegistry({
+    list: [
+      {
+        id: 'support',
+        name: 'Support Proxy',
+        proxy: proxyConfig({
+          baseUrl: 'https://app.hybridai.one///',
+          conversationScope: 'user',
+        }),
+      },
+    ],
+  });
+
+  const expectedProxy = {
+    kind: 'hybridai',
+    baseUrl: 'https://app.hybridai.one',
+    chatbotId: 'bot_abc123',
+    apiKey: { source: 'store', id: 'HYBRIDAI_API_KEY' },
+    conversationScope: 'user',
+  };
+  expect(resolveAgentConfig('support').proxy).toEqual(expectedProxy);
+  expect(getAgentById('support')?.proxy).toEqual(expectedProxy);
+});
+
+test('agent registry rejects non-HTTPS HybridAI proxy base URLs', async () => {
+  setupHome();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { initAgentRegistry } = await import(
+    '../src/agents/agent-registry.ts'
+  );
+
+  initDatabase({ quiet: true });
+  expect(() =>
+    initAgentRegistry({
+      list: [
+        {
+          id: 'support',
+          proxy: proxyConfig({
+            baseUrl: 'http://app.hybridai.one',
+            apiKey: { source: 'store', id: 'HYBRIDAI_API_KEY' },
+          }),
+        },
+      ],
+    }),
+  ).toThrow('agents.list[].proxy.baseUrl must use HTTPS');
+});
+
+test('handleGatewayMessage forwards proxy agents to HybridAI without running local agent pipeline', async () => {
+  setupHome();
+
+  const fetchMock = vi.fn(async () =>
+    streamResponse([
+      'data: {"delta":"Hel"}\n\n',
+      'data: {"delta":"lo from HybridAI"}\n\n',
+      'data: [DONE]\n\n',
+    ]),
+  );
+  vi.stubGlobal('fetch', fetchMock);
+
+  const { initDatabase, getConversationHistory, getSessionById } =
+    await import('../src/memory/db.ts');
+  const { updateRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  const { saveNamedRuntimeSecrets } = await import(
+    '../src/security/runtime-secrets.ts'
+  );
+  const { initAgentRegistry } = await import(
+    '../src/agents/agent-registry.ts'
+  );
+  const { handleGatewayMessage } = await import(
+    '../src/gateway/gateway-chat-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  saveNamedRuntimeSecrets({
+    HYBRIDAI_API_KEY: 'hai-proxy-test-key-1234567890',
+  });
+  updateRuntimeConfig((draft) => {
+    draft.agents.list = [
+      {
+        id: 'support',
+        proxy: proxyConfig({ conversationScope: 'user' }),
+      },
+    ];
+  });
+  initAgentRegistry({
+    list: [
+      {
+        id: 'support',
+        proxy: proxyConfig({ conversationScope: 'user' }),
+      },
+    ],
+  });
+
+  const deltas: string[] = [];
+  const result = await handleGatewayMessage({
+    sessionId: 'session-proxy',
+    guildId: 'guild-1',
+    channelId: 'channel-1',
+    userId: '248135798132',
+    username: 'ben#1234',
+    content: 'Help me',
+    agentId: 'support',
+    source: 'discord',
+    onTextDelta: (delta) => deltas.push(delta),
+  });
+
+  expect(result.status).toBe('success');
+  expect(result.result).toBe('Hello from HybridAI');
+  expect(deltas).toEqual(['Hel', 'lo from HybridAI']);
+  expect(runAgentMock).not.toHaveBeenCalled();
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+    'https://app.hybridai.one/api/v1/gateway/chat',
+  );
+  const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+  expect(init.headers).toMatchObject({
+    Authorization: 'Bearer hai-proxy-test-key-1234567890',
+    'Content-Type': 'application/json',
+  });
+  expect(JSON.parse(String(init.body))).toEqual({
+    chatbot_id: 'bot_abc123',
+    message: 'Help me',
+    external_user_id: 'discord:248135798132',
+    conversation_id: 'session-proxy:discord:248135798132',
+    username: 'ben#1234',
+    stream: true,
+  });
+  expect(getSessionById(result.sessionId || 'session-proxy')?.message_count).toBe(
+    0,
+  );
+  expect(getConversationHistory(result.sessionId || 'session-proxy', 10)).toEqual(
+    [],
+  );
+});
+
+test('handleGatewayMessage hides upstream proxy auth failure bodies from the channel', async () => {
+  setupHome();
+
+  const fetchMock = vi.fn(
+    async () =>
+      new Response('tenant ownership check failed for bot_abc123', {
+        status: 403,
+      }),
+  );
+  vi.stubGlobal('fetch', fetchMock);
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { updateRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  const { saveNamedRuntimeSecrets } = await import(
+    '../src/security/runtime-secrets.ts'
+  );
+  const { initAgentRegistry } = await import(
+    '../src/agents/agent-registry.ts'
+  );
+  const { handleGatewayMessage } = await import(
+    '../src/gateway/gateway-chat-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  saveNamedRuntimeSecrets({
+    HYBRIDAI_API_KEY: 'hai-proxy-test-key-1234567890',
+  });
+  updateRuntimeConfig((draft) => {
+    draft.agents.list = [
+      {
+        id: 'support',
+        proxy: proxyConfig({
+          apiKey: { source: 'store', id: 'HYBRIDAI_API_KEY' },
+        }),
+      },
+    ];
+  });
+  initAgentRegistry({
+    list: [
+      {
+        id: 'support',
+        proxy: proxyConfig({
+          apiKey: { source: 'store', id: 'HYBRIDAI_API_KEY' },
+        }),
+      },
+    ],
+  });
+
+  const result = await handleGatewayMessage({
+    sessionId: 'session-proxy-auth',
+    guildId: null,
+    channelId: 'channel-1',
+    userId: 'user-1',
+    username: 'alice',
+    content: 'Hello',
+    agentId: 'support',
+    source: 'slack',
+  });
+
+  expect(result.status).toBe('success');
+  expect(result.result).toBe(
+    'The bot is not reachable because its upstream configuration needs attention.',
+  );
+  expect(result.result).not.toContain('tenant ownership');
+  expect(runAgentMock).not.toHaveBeenCalled();
+});

--- a/tests/gateway-proxy-agent.test.ts
+++ b/tests/gateway-proxy-agent.test.ts
@@ -224,7 +224,7 @@ test('handleGatewayMessage reads HybridAI plain text SSE proxy chunks', async ()
       'data: Hello\n\n',
       'data: !\n\n',
       'data:  It works\n\n',
-      'data: [DONE]\n\n',
+      'data: [END]\n\n',
     ]),
   );
   vi.stubGlobal('fetch', fetchMock);

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -1024,6 +1024,68 @@ test('status command includes the current session agent', async () => {
   );
 });
 
+test('status command reports proxy mode for HybridAI proxy agents', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { upsertRegisteredAgent } = await import(
+    '../src/agents/agent-registry.ts'
+  );
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  upsertRegisteredAgent({
+    id: 'proxy-support',
+    model: 'openai-codex/gpt-5.3-codex',
+    proxy: {
+      kind: 'hybridai',
+      baseUrl: 'https://hybridai.one',
+      chatbotId: '051df245-3f6e-459e-a890-c7e28e094a71',
+      apiKey: { source: 'store', id: 'HYBRIDAI_API_KEY' },
+      conversationScope: 'user',
+    },
+  });
+
+  await handleGatewayCommand({
+    sessionId: 'session-status-proxy-agent',
+    guildId: null,
+    channelId: 'channel-status-proxy-agent',
+    args: ['agent', 'switch', 'proxy-support'],
+  });
+  const result = await handleGatewayCommand({
+    sessionId: 'session-status-proxy-agent',
+    guildId: null,
+    channelId: 'channel-status-proxy-agent',
+    args: ['status'],
+  });
+
+  expect(result.kind).toBe('info');
+  if (result.kind !== 'info') {
+    throw new Error(`Unexpected result kind: ${result.kind}`);
+  }
+  expect(result.title).toBe('Status');
+  expect(result.text).toContain('Mode: HybridAI proxy');
+  expect(result.text).toContain('Agent: proxy-support');
+  expect(result.text).toContain('Upstream: https://hybridai.one');
+  expect(result.text).toContain(
+    'Chatbot: 051df245-3f6e-459e-a890-c7e28e094a71',
+  );
+  expect(result.text).toContain('Conversation scope: user');
+  expect(result.text).not.toContain('Model:');
+  expect(result.text).not.toContain('Tokens:');
+  expect(result.text).not.toContain('Cache:');
+  expect(result.text).not.toContain('Context:');
+  expect(result.text).not.toContain('CWD:');
+  expect(result.text).not.toContain('Runtime:');
+  expect(result.text).not.toContain('Sandbox:');
+  expect(result.text).not.toContain('RAG:');
+  expect(result.text).not.toContain('Ralph:');
+});
+
 test('status command labels Codex app-server turn runtime separately from sandbox', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;

--- a/tests/hybridai-bots.test.ts
+++ b/tests/hybridai-bots.test.ts
@@ -208,6 +208,57 @@ test('fetchHybridAIBots applies a request timeout', async () => {
   );
 });
 
+test('fetchHybridAIBots scopes cached bot lists by base URL', async () => {
+  process.env.HOME = os.homedir();
+  process.env.HYBRIDAI_API_KEY = 'hai-bot-test';
+
+  const fetchSpy = vi.fn(async (url: string) => {
+    const id = url.startsWith('https://hybridai.one')
+      ? 'official-bot'
+      : 'custom-bot';
+    return new Response(JSON.stringify({ data: [{ id, name: id }] }), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  });
+  vi.stubGlobal('fetch', fetchSpy);
+
+  const { fetchHybridAIBots } = await importFreshBots();
+
+  await expect(
+    fetchHybridAIBots({
+      baseUrl: 'https://hybridai.one/',
+      cacheTtlMs: 60_000,
+    }),
+  ).resolves.toMatchObject([{ id: 'official-bot' }]);
+  await expect(
+    fetchHybridAIBots({
+      baseUrl: 'https://hybridai.one',
+      cacheTtlMs: 60_000,
+    }),
+  ).resolves.toMatchObject([{ id: 'official-bot' }]);
+  await expect(
+    fetchHybridAIBots({
+      baseUrl: 'https://custom.hybridai.example.com',
+      cacheTtlMs: 60_000,
+    }),
+  ).resolves.toMatchObject([{ id: 'custom-bot' }]);
+  await expect(
+    fetchHybridAIBots({
+      baseUrl: 'https://custom.hybridai.example.com/',
+      cacheTtlMs: 60_000,
+    }),
+  ).resolves.toMatchObject([{ id: 'custom-bot' }]);
+
+  expect(fetchSpy).toHaveBeenCalledTimes(2);
+  expect(fetchSpy.mock.calls.map(([url]) => url)).toEqual([
+    'https://hybridai.one/api/v1/bot-management/bots',
+    'https://custom.hybridai.example.com/api/v1/bot-management/bots',
+  ]);
+});
+
 test('fetchHybridAIAccountChatbotId reads the current user id from /bot-management/me', async () => {
   process.env.HOME = os.homedir();
   process.env.HYBRIDAI_API_KEY = 'hai-bot-test';


### PR DESCRIPTION
## Summary
- add agent-level HybridAI proxy config with runtime normalization, DB persistence, and config command/runtime support
- route proxy agents through HybridAI `/api/v1/gateway/chat` before the local agent pipeline
- expose Proxy mode on `/admin/gateway` via the admin agent API, using SecretRef metadata only

## Validation
- `./node_modules/.bin/vitest tests/gateway-proxy-agent.test.ts tests/agent-registry.test.ts tests/database-session.integration.test.ts --run`
- `./node_modules/.bin/vitest tests/agent-config-command.test.ts tests/config-reload.integration.test.ts --run`
- `./node_modules/.bin/vitest tests/gateway-http-server.test.ts --run -t "admin agent"`
- `../node_modules/.bin/vitest run src/routes/gateway.test.tsx src/api/client.test.ts --config vitest.config.ts`
- `./node_modules/.bin/vitest tests/gateway-proxy-agent.test.ts --run`
- `./node_modules/.bin/tsc --noEmit`
- `../node_modules/.bin/tsc --noEmit`
- `npx biome check --write ...`
- `git diff --check`