### PR TITLE
feat: add inbound A2A envelope endpoint

### DIFF
--- a/src/a2a/a2a-inbound.ts
+++ b/src/a2a/a2a-inbound.ts
@@ -5,6 +5,11 @@ import { getAgentById, listAgents } from '../agents/agent-registry.js';
 import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
 import { GatewayRequestError } from '../errors/gateway-request-error.js';
 import { readRequestBody, sendJson } from '../gateway/gateway-http-utils.js';
+import {
+  AgentIdentityValidationError,
+  parseAgentIdentity,
+  resolveLocalInstanceId,
+} from '../identity/agent-id.js';
 import { logger } from '../logger.js';
 import { decodeA2AJsonRpcRequest, type JsonRpcId } from './a2a-json-rpc.js';
 import {
@@ -23,9 +28,11 @@ import {
   A2AEnvelopeDuplicateError,
   A2AEnvelopeValidationError,
   summarizeA2AEnvelopeForAudit,
+  validateA2AEnvelope,
 } from './envelope.js';
 import { resolveA2AAgentId } from './identity.js';
 import { acceptA2AInboundEnvelope } from './inbound-pipeline.js';
+import { findA2AEnvelopeByIdempotencyKey } from './store.js';
 import {
   type A2AAgentCardTrustLevel,
   type A2ATrustedA2APeer,
@@ -38,7 +45,9 @@ import {
 import { isRecord } from './utils.js';
 
 export const A2A_JSON_RPC_INBOUND_PATH = '/a2a';
+export const A2A_HTTP_ENVELOPE_INBOUND_PATH = '/a2a/envelopes';
 export const A2A_JSON_RPC_INBOUND_MAX_BODY_BYTES = 1_000_000;
+export const A2A_HTTP_ENVELOPE_INBOUND_MAX_BODY_BYTES = 1_000_000;
 
 export type A2AJsonRpcInboundSignatureOutcome =
   | 'passed'
@@ -58,6 +67,11 @@ export type { A2ATrustedA2APeer, UpsertA2ATrustedA2APeerInput };
 export { listA2ATrustedA2APeers, upsertA2ATrustedA2APeer };
 
 export interface A2AJsonRpcInboundResult {
+  statusCode: number;
+  body: Record<string, unknown>;
+}
+
+export interface A2AHttpEnvelopeInboundResult {
   statusCode: number;
   body: Record<string, unknown>;
 }
@@ -170,6 +184,17 @@ function parseJsonRpcPayload(rawBody: string): unknown {
   return JSON.parse(rawBody) as unknown;
 }
 
+function parseHttpEnvelopePayload(rawBody: string): A2AEnvelope {
+  try {
+    return validateA2AEnvelope(JSON.parse(rawBody) as unknown);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new A2AEnvelopeValidationError([error.message]);
+    }
+    throw error;
+  }
+}
+
 function jsonRpcRequestMeta(parsed: unknown): {
   method: 'message/send' | 'tasks/send';
   id: JsonRpcId;
@@ -205,6 +230,69 @@ function peerInstanceIdFromEnvelope(
 ): string | null {
   const parts = envelope?.sender_agent_id.split('@') ?? [];
   return parts.length === 3 && parts[2] ? parts[2] : null;
+}
+
+function peerInstanceId(peer: A2ATrustedA2APeer): string {
+  return parseAgentIdentity(peer.senderAgentId).instanceId;
+}
+
+function parseCanonicalEnvelopeAgentId(
+  field: 'sender_agent_id' | 'recipient_agent_id',
+  value: string,
+) {
+  try {
+    return parseAgentIdentity(value);
+  } catch (error) {
+    if (error instanceof AgentIdentityValidationError) {
+      throw new A2AEnvelopeValidationError([
+        `${field} must be canonical (agent-slug@user@instance-id)`,
+      ]);
+    }
+    throw error;
+  }
+}
+
+function assertEnvelopeSenderMatchesPeer(
+  envelope: A2AEnvelope,
+  peer: A2ATrustedA2APeer,
+): void {
+  if (envelope.sender_agent_id !== peer.senderAgentId) {
+    throw new A2AEnvelopeValidationError([
+      'sender_agent_id does not match authenticated A2A peer',
+    ]);
+  }
+  const authenticatedPeerInstanceId = peerInstanceId(peer);
+  const envelopeSenderInstanceId = parseCanonicalEnvelopeAgentId(
+    'sender_agent_id',
+    envelope.sender_agent_id,
+  ).instanceId;
+  if (envelopeSenderInstanceId !== authenticatedPeerInstanceId) {
+    throw new A2AEnvelopeValidationError([
+      'sender_agent_id instance-id does not match authenticated A2A peer',
+    ]);
+  }
+  if (envelope.sender_instance_id !== authenticatedPeerInstanceId) {
+    throw new A2AEnvelopeValidationError([
+      'sender_instance_id does not match authenticated A2A peer',
+    ]);
+  }
+}
+
+function assertCanonicalLocalRecipient(envelope: A2AEnvelope): void {
+  const recipient = parseCanonicalEnvelopeAgentId(
+    'recipient_agent_id',
+    envelope.recipient_agent_id,
+  );
+  if (recipient.instanceId !== resolveLocalInstanceId()) {
+    throw new A2AEnvelopeValidationError([
+      'recipient_agent_id instance-id does not match this instance',
+    ]);
+  }
+  if (!localRecipientResolves(envelope.recipient_agent_id)) {
+    throw new A2AEnvelopeValidationError([
+      'recipient_agent_id does not resolve to a local agent',
+    ]);
+  }
 }
 
 function recordInboundAudit(params: {
@@ -343,6 +431,218 @@ function signatureOutcomeForError(
   if (error instanceof A2AMissingTrustedPeerError) return 'missing_peer';
   if (error instanceof A2ARevokedDelegationTokenError) return 'revoked';
   return 'failed';
+}
+
+function verifySignedHttpEnvelopeRequest(params: {
+  token: string;
+  envelope: A2AEnvelope;
+  audience: string;
+  now?: Date;
+  peer: A2ATrustedA2APeer;
+}): void {
+  verifyA2ADelegationToken({
+    token: params.token,
+    publicKeyPem: params.peer.publicKeyPem,
+    audience: params.audience,
+    requiredScope: A2A_MESSAGE_SEND_SCOPE,
+    senderAgentId: params.envelope.sender_agent_id,
+    targetAgentId: params.envelope.recipient_agent_id,
+    now: params.now,
+  });
+}
+
+function httpEnvelopeErrorStatusCode(error: unknown): number {
+  if (error instanceof A2ADelegationTokenError) return 401;
+  if (error instanceof A2AEnvelopeDuplicateError) return 200;
+  if (error instanceof A2AEnvelopeValidationError) return 400;
+  return 500;
+}
+
+function httpEnvelopeErrorResponse(error: unknown): Record<string, unknown> {
+  if (error instanceof A2ADelegationTokenError) {
+    return { error: 'Unauthorized', reason: extractErrorReason(error) };
+  }
+  if (error instanceof A2AEnvelopeValidationError) {
+    return { error: extractErrorReason(error) };
+  }
+  return { error: 'Internal server error' };
+}
+
+function alreadyDeliveredBody(envelope: A2AEnvelope): Record<string, unknown> {
+  return {
+    delivered: true,
+    already_delivered: true,
+    message_id: envelope.id,
+    thread_id: envelope.thread_id,
+    recipient_agent_id: envelope.recipient_agent_id,
+  };
+}
+
+export function acceptA2AHttpEnvelopeInboundRequest(params: {
+  rawBody: string;
+  authorization: string | null | undefined;
+  audience: string;
+  mtlsPublicKeyPem?: string | null;
+  now?: Date;
+  peer?: A2ATrustedA2APeer;
+}): A2AHttpEnvelopeInboundResult {
+  const runId = makeAuditRunId('a2a-http-inbound');
+  let envelope: A2AEnvelope | null = null;
+  let peer: A2ATrustedA2APeer | null = params.peer ?? null;
+  let authMode: A2AInboundAuthMode | null = null;
+
+  try {
+    envelope = parseHttpEnvelopePayload(params.rawBody);
+    const authorization = String(params.authorization || '').trim();
+    if (authorization) {
+      authMode = 'signed_bearer';
+      const token = extractBearerToken(params.authorization);
+      peer = resolveTrustedPeerForToken({
+        token,
+        peer: params.peer,
+      });
+      verifySignedHttpEnvelopeRequest({
+        token,
+        envelope,
+        audience: params.audience,
+        now: params.now,
+        peer,
+      });
+    } else if (params.mtlsPublicKeyPem) {
+      authMode = 'peer_public_key';
+      peer =
+        params.peer ?? getA2ATrustedA2APeerBySender(envelope.sender_agent_id);
+      peer = resolveTrustedPeerForMtls({
+        senderAgentId: envelope.sender_agent_id,
+        mtlsPublicKeyPem: params.mtlsPublicKeyPem,
+        peer: peer ?? undefined,
+      });
+    } else {
+      throw new A2ADelegationTokenError(
+        'Authorization bearer token or mTLS client certificate is required',
+      );
+    }
+    assertEnvelopeSenderMatchesPeer(envelope, peer);
+    assertCanonicalLocalRecipient(envelope);
+  } catch (error) {
+    const reason = extractErrorReason(error);
+    const statusCode = error instanceof A2ADelegationTokenError ? 401 : 400;
+    recordInboundAudit({
+      runId,
+      peerId: peer?.peerId || null,
+      peerInstanceId: peer
+        ? peerInstanceId(peer)
+        : peerInstanceIdFromEnvelope(envelope),
+      authMode,
+      method: null,
+      agentId: envelope?.recipient_agent_id || null,
+      signatureOutcome: signatureOutcomeForError(error),
+      intent: envelope?.intent || null,
+      downstreamDisposition:
+        error instanceof A2ADelegationTokenError
+          ? 'rejected'
+          : 'validation_failed',
+      envelope,
+      statusCode,
+      reason,
+    });
+    return {
+      statusCode,
+      body: httpEnvelopeErrorResponse(error),
+    };
+  }
+
+  if (!peer || !envelope) {
+    return {
+      statusCode: 500,
+      body: { error: 'Internal server error' },
+    };
+  }
+  const authenticatedPeer = peer;
+  const authenticatedPeerInstanceId = peerInstanceId(authenticatedPeer);
+  const existing = findA2AEnvelopeByIdempotencyKey(
+    envelope.id,
+    authenticatedPeerInstanceId,
+  );
+  if (existing) {
+    recordInboundAudit({
+      runId,
+      peerId: authenticatedPeer.peerId,
+      peerInstanceId: authenticatedPeerInstanceId,
+      authMode,
+      method: null,
+      agentId: envelope.recipient_agent_id,
+      signatureOutcome: 'passed',
+      intent: envelope.intent,
+      downstreamDisposition: 'duplicate',
+      envelope,
+      statusCode: 200,
+      reason: 'already delivered',
+    });
+    return {
+      statusCode: 200,
+      body: alreadyDeliveredBody(existing),
+    };
+  }
+
+  try {
+    const confirmation = acceptA2AInboundEnvelope(envelope, {
+      source: 'a2a',
+      actor: authenticatedPeerInstanceId,
+      sessionId: `a2a:inbound:${authenticatedPeer.peerId}`,
+      auditRunId: runId,
+    });
+    const statusCode =
+      'statusCode' in confirmation &&
+      typeof confirmation.statusCode === 'number'
+        ? confirmation.statusCode
+        : 202;
+    recordInboundAudit({
+      runId,
+      peerId: authenticatedPeer.peerId,
+      peerInstanceId: authenticatedPeerInstanceId,
+      authMode,
+      method: null,
+      agentId: envelope.recipient_agent_id,
+      signatureOutcome: 'passed',
+      intent: envelope.intent,
+      downstreamDisposition: statusCode === 202 ? 'delivered' : 'rejected',
+      envelope,
+      statusCode,
+    });
+    return {
+      statusCode,
+      body: { ...confirmation },
+    };
+  } catch (error) {
+    const isDuplicate = error instanceof A2AEnvelopeDuplicateError;
+    const statusCode = isDuplicate ? 200 : httpEnvelopeErrorStatusCode(error);
+    const reason = extractErrorReason(error);
+    recordInboundAudit({
+      runId,
+      peerId: authenticatedPeer.peerId,
+      peerInstanceId: authenticatedPeerInstanceId,
+      authMode,
+      method: null,
+      agentId: envelope.recipient_agent_id,
+      signatureOutcome: 'passed',
+      intent: envelope.intent,
+      downstreamDisposition: isDuplicate ? 'duplicate' : 'error',
+      envelope,
+      statusCode,
+      reason,
+    });
+    if (isDuplicate) {
+      return {
+        statusCode,
+        body: alreadyDeliveredBody(envelope),
+      };
+    }
+    return {
+      statusCode,
+      body: httpEnvelopeErrorResponse(error),
+    };
+  }
 }
 
 export function acceptA2AJsonRpcInboundRequest(params: {
@@ -549,6 +849,40 @@ export async function handleA2AJsonRpcInbound(
       await readRequestBody(req, A2A_JSON_RPC_INBOUND_MAX_BODY_BYTES)
     ).toString('utf-8');
     const result = acceptA2AJsonRpcInboundRequest({
+      rawBody,
+      authorization: readHeader(req.headers, 'authorization'),
+      audience: normalizeAudience(url),
+      mtlsPublicKeyPem: extractA2AMtlsPublicKeyPem(req),
+    });
+    sendJson(res, result.statusCode, result.body);
+  } catch (error) {
+    if (error instanceof GatewayRequestError) {
+      sendJson(res, error.statusCode, { error: error.message });
+      return;
+    }
+    sendJson(res, 500, { error: 'Internal server error' });
+  }
+}
+
+export async function handleA2AHttpEnvelopeInbound(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL,
+): Promise<void> {
+  if (url.pathname !== A2A_HTTP_ENVELOPE_INBOUND_PATH) {
+    sendJson(res, 404, { error: 'Not Found' });
+    return;
+  }
+  if (req.method !== 'POST') {
+    sendJson(res, 405, { error: 'Method Not Allowed' });
+    return;
+  }
+
+  try {
+    const rawBody = (
+      await readRequestBody(req, A2A_HTTP_ENVELOPE_INBOUND_MAX_BODY_BYTES)
+    ).toString('utf-8');
+    const result = acceptA2AHttpEnvelopeInboundRequest({
       rawBody,
       authorization: readHeader(req.headers, 'authorization'),
       audience: normalizeAudience(url),

--- a/src/a2a/a2a-inbound.ts
+++ b/src/a2a/a2a-inbound.ts
@@ -368,22 +368,6 @@ function resolveTrustedPeerForToken(params: {
   return peer;
 }
 
-function resolveTrustedPeerForMtls(params: {
-  senderAgentId: string;
-  mtlsPublicKeyPem: string;
-}): A2ATrustedA2APeer {
-  const peer = getA2ATrustedA2APeerBySender(params.senderAgentId);
-  if (!peer) {
-    throw new A2AMissingTrustedPeerError('No trusted A2A peer for mTLS sender');
-  }
-  if (!publicKeysMatch(params.mtlsPublicKeyPem, peer.publicKeyPem)) {
-    throw new A2ADelegationTokenError(
-      'mTLS certificate public key does not match trusted A2A peer',
-    );
-  }
-  return peer;
-}
-
 function resolveTrustedPeerForMtlsPublicKey(
   mtlsPublicKeyPem: string,
 ): A2ATrustedA2APeer | null {
@@ -430,11 +414,13 @@ function resolveAuthenticatedPeer(params: {
   method?: 'message/send' | 'tasks/send';
   // Test-only clock hook for direct unit tests; HTTP handlers always use wall time.
   now?: Date;
+  onPeerResolved?: (peer: A2ATrustedA2APeer) => void;
 }): A2AAuthenticatedPeer {
   const authorization = String(params.rawAuthorization || '').trim();
   if (authorization) {
     const token = extractBearerToken(params.rawAuthorization);
     const peer = resolveTrustedPeerForToken({ token });
+    params.onPeerResolved?.(peer);
     verifySignedRequest({
       token,
       envelope: params.envelope,
@@ -446,10 +432,18 @@ function resolveAuthenticatedPeer(params: {
     return { peer, authMode: 'signed_bearer' };
   }
   if (params.mtlsPublicKeyPem) {
-    const peer = resolveTrustedPeerForMtls({
-      senderAgentId: params.envelope.sender_agent_id,
-      mtlsPublicKeyPem: params.mtlsPublicKeyPem,
-    });
+    const peer = getA2ATrustedA2APeerBySender(params.envelope.sender_agent_id);
+    if (!peer) {
+      throw new A2AMissingTrustedPeerError(
+        'No trusted A2A peer for mTLS sender',
+      );
+    }
+    params.onPeerResolved?.(peer);
+    if (!publicKeysMatch(params.mtlsPublicKeyPem, peer.publicKeyPem)) {
+      throw new A2ADelegationTokenError(
+        'mTLS certificate public key does not match trusted A2A peer',
+      );
+    }
     return { peer, authMode: 'peer_public_key' };
   }
   throw new A2ADelegationTokenError(
@@ -512,6 +506,9 @@ export function acceptA2AHttpEnvelopeInboundRequest(params: {
       envelope,
       audience: params.audience,
       now: params.now,
+      onPeerResolved: (resolvedPeer) => {
+        peer = resolvedPeer;
+      },
     });
     peer = authenticated.peer;
     authMode = authenticated.authMode;
@@ -666,6 +663,9 @@ export function acceptA2AJsonRpcInboundRequest(params: {
       audience: params.audience,
       method,
       now: params.now,
+      onPeerResolved: (resolvedPeer) => {
+        peer = resolvedPeer;
+      },
     });
     peer = authenticated.peer;
     authMode = authenticated.authMode;

--- a/src/a2a/a2a-inbound.ts
+++ b/src/a2a/a2a-inbound.ts
@@ -458,6 +458,13 @@ function httpEnvelopeErrorStatusCode(error: unknown): number {
   return 500;
 }
 
+function isHttpEnvelopeAuthOrValidationError(error: unknown): boolean {
+  return (
+    error instanceof A2ADelegationTokenError ||
+    error instanceof A2AEnvelopeValidationError
+  );
+}
+
 function httpEnvelopeErrorResponse(error: unknown): Record<string, unknown> {
   if (error instanceof A2ADelegationTokenError) {
     return { error: 'Unauthorized', reason: extractErrorReason(error) };
@@ -526,7 +533,10 @@ export function acceptA2AHttpEnvelopeInboundRequest(params: {
     assertCanonicalLocalRecipient(envelope);
   } catch (error) {
     const reason = extractErrorReason(error);
-    const statusCode = error instanceof A2ADelegationTokenError ? 401 : 400;
+    const isExpectedError = isHttpEnvelopeAuthOrValidationError(error);
+    const statusCode = isExpectedError
+      ? httpEnvelopeErrorStatusCode(error)
+      : 500;
     recordInboundAudit({
       runId,
       peerId: peer?.peerId || null,
@@ -541,7 +551,9 @@ export function acceptA2AHttpEnvelopeInboundRequest(params: {
       downstreamDisposition:
         error instanceof A2ADelegationTokenError
           ? 'rejected'
-          : 'validation_failed',
+          : isExpectedError
+            ? 'validation_failed'
+            : 'error',
       envelope,
       statusCode,
       reason,

--- a/src/a2a/a2a-inbound.ts
+++ b/src/a2a/a2a-inbound.ts
@@ -32,7 +32,7 @@ import {
 } from './envelope.js';
 import { resolveA2AAgentId } from './identity.js';
 import { acceptA2AInboundEnvelope } from './inbound-pipeline.js';
-import { findA2AEnvelopeByIdempotencyKey } from './store.js';
+import { getA2AEnvelope } from './store.js';
 import {
   type A2AAgentCardTrustLevel,
   type A2ATrustedA2APeer,
@@ -46,8 +46,7 @@ import { isRecord } from './utils.js';
 
 export const A2A_JSON_RPC_INBOUND_PATH = '/a2a';
 export const A2A_HTTP_ENVELOPE_INBOUND_PATH = '/a2a/envelopes';
-export const A2A_JSON_RPC_INBOUND_MAX_BODY_BYTES = 1_000_000;
-export const A2A_HTTP_ENVELOPE_INBOUND_MAX_BODY_BYTES = 1_000_000;
+export const A2A_INBOUND_MAX_BODY_BYTES = 1_000_000;
 
 export type A2AJsonRpcInboundSignatureOutcome =
   | 'passed'
@@ -62,16 +61,21 @@ export type A2AJsonRpcInboundDownstreamDisposition =
   | 'error';
 export type A2AAgentCardPeerTrustLevel = A2AAgentCardTrustLevel;
 type A2AInboundAuthMode = 'signed_bearer' | 'peer_public_key';
+type A2AAuthenticatedPeer = {
+  peer: A2ATrustedA2APeer;
+  authMode: A2AInboundAuthMode;
+};
+type A2AInboundHandler = (params: {
+  rawBody: string;
+  authorization: string | null | undefined;
+  audience: string;
+  mtlsPublicKeyPem?: string | null;
+}) => A2AInboundResult;
 
 export type { A2ATrustedA2APeer, UpsertA2ATrustedA2APeerInput };
 export { listA2ATrustedA2APeers, upsertA2ATrustedA2APeer };
 
-export interface A2AJsonRpcInboundResult {
-  statusCode: number;
-  body: Record<string, unknown>;
-}
-
-export interface A2AHttpEnvelopeInboundResult {
+export interface A2AInboundResult {
   statusCode: number;
   body: Record<string, unknown>;
 }
@@ -149,20 +153,19 @@ function normalizeAudience(url: URL): string {
   return new URL(url.pathname, url.origin).toString();
 }
 
-function localCanonicalRecipientCacheKey(): string {
-  return listAgents()
-    .map((agent) => `${agent.id}\0${agent.owner || ''}`)
-    .join('\n');
+function localCanonicalRecipientCacheKey(agents = listAgents()): string {
+  return agents.map((agent) => `${agent.id}\0${agent.owner || ''}`).join('\n');
 }
 
 function localCanonicalRecipientIds(): Set<string> {
-  const key = localCanonicalRecipientCacheKey();
+  const agents = listAgents();
+  const key = localCanonicalRecipientCacheKey(agents);
   if (localCanonicalRecipientCache?.key === key) {
     return localCanonicalRecipientCache.canonicalAgentIds;
   }
 
   const canonicalAgentIds = new Set<string>();
-  for (const agent of listAgents()) {
+  for (const agent of agents) {
     try {
       canonicalAgentIds.add(resolveA2AAgentId(agent.id));
     } catch {
@@ -262,15 +265,6 @@ function assertEnvelopeSenderMatchesPeer(
     ]);
   }
   const authenticatedPeerInstanceId = peerInstanceId(peer);
-  const envelopeSenderInstanceId = parseCanonicalEnvelopeAgentId(
-    'sender_agent_id',
-    envelope.sender_agent_id,
-  ).instanceId;
-  if (envelopeSenderInstanceId !== authenticatedPeerInstanceId) {
-    throw new A2AEnvelopeValidationError([
-      'sender_agent_id instance-id does not match authenticated A2A peer',
-    ]);
-  }
   if (envelope.sender_instance_id !== authenticatedPeerInstanceId) {
     throw new A2AEnvelopeValidationError([
       'sender_instance_id does not match authenticated A2A peer',
@@ -365,12 +359,9 @@ function jsonRpcErrorMessage(error: unknown): string {
 
 function resolveTrustedPeerForToken(params: {
   token: string;
-  peer?: A2ATrustedA2APeer;
 }): A2ATrustedA2APeer {
   const unverifiedClaims = decodeA2ADelegationTokenClaims(params.token);
-  const peer =
-    params.peer ??
-    getA2ATrustedA2APeerBySender(unverifiedClaims.sender_agent_id);
+  const peer = getA2ATrustedA2APeerBySender(unverifiedClaims.sender_agent_id);
   if (!peer) {
     throw new A2AMissingTrustedPeerError();
   }
@@ -380,10 +371,8 @@ function resolveTrustedPeerForToken(params: {
 function resolveTrustedPeerForMtls(params: {
   senderAgentId: string;
   mtlsPublicKeyPem: string;
-  peer?: A2ATrustedA2APeer;
 }): A2ATrustedA2APeer {
-  const peer =
-    params.peer ?? getA2ATrustedA2APeerBySender(params.senderAgentId);
+  const peer = getA2ATrustedA2APeerBySender(params.senderAgentId);
   if (!peer) {
     throw new A2AMissingTrustedPeerError('No trusted A2A peer for mTLS sender');
   }
@@ -406,7 +395,7 @@ function resolveTrustedPeerForMtlsPublicKey(
 function verifySignedRequest(params: {
   token: string;
   envelope: A2AEnvelope;
-  method: 'message/send' | 'tasks/send';
+  method?: 'message/send' | 'tasks/send';
   audience: string;
   now?: Date;
   peer: A2ATrustedA2APeer;
@@ -433,22 +422,39 @@ function signatureOutcomeForError(
   return 'failed';
 }
 
-function verifySignedHttpEnvelopeRequest(params: {
-  token: string;
+function resolveAuthenticatedPeer(params: {
+  rawAuthorization: string | null | undefined;
+  mtlsPublicKeyPem?: string | null;
   envelope: A2AEnvelope;
   audience: string;
+  method?: 'message/send' | 'tasks/send';
+  // Test-only clock hook for direct unit tests; HTTP handlers always use wall time.
   now?: Date;
-  peer: A2ATrustedA2APeer;
-}): void {
-  verifyA2ADelegationToken({
-    token: params.token,
-    publicKeyPem: params.peer.publicKeyPem,
-    audience: params.audience,
-    requiredScope: A2A_MESSAGE_SEND_SCOPE,
-    senderAgentId: params.envelope.sender_agent_id,
-    targetAgentId: params.envelope.recipient_agent_id,
-    now: params.now,
-  });
+}): A2AAuthenticatedPeer {
+  const authorization = String(params.rawAuthorization || '').trim();
+  if (authorization) {
+    const token = extractBearerToken(params.rawAuthorization);
+    const peer = resolveTrustedPeerForToken({ token });
+    verifySignedRequest({
+      token,
+      envelope: params.envelope,
+      method: params.method,
+      audience: params.audience,
+      now: params.now,
+      peer,
+    });
+    return { peer, authMode: 'signed_bearer' };
+  }
+  if (params.mtlsPublicKeyPem) {
+    const peer = resolveTrustedPeerForMtls({
+      senderAgentId: params.envelope.sender_agent_id,
+      mtlsPublicKeyPem: params.mtlsPublicKeyPem,
+    });
+    return { peer, authMode: 'peer_public_key' };
+  }
+  throw new A2ADelegationTokenError(
+    'Authorization bearer token or mTLS client certificate is required',
+  );
 }
 
 function httpEnvelopeErrorStatusCode(error: unknown): number {
@@ -490,45 +496,25 @@ export function acceptA2AHttpEnvelopeInboundRequest(params: {
   authorization: string | null | undefined;
   audience: string;
   mtlsPublicKeyPem?: string | null;
+  // Test-only clock hook for direct unit tests; HTTP handlers always use wall time.
   now?: Date;
-  peer?: A2ATrustedA2APeer;
-}): A2AHttpEnvelopeInboundResult {
+}): A2AInboundResult {
   const runId = makeAuditRunId('a2a-http-inbound');
   let envelope: A2AEnvelope | null = null;
-  let peer: A2ATrustedA2APeer | null = params.peer ?? null;
+  let peer: A2ATrustedA2APeer | null = null;
   let authMode: A2AInboundAuthMode | null = null;
 
   try {
     envelope = parseHttpEnvelopePayload(params.rawBody);
-    const authorization = String(params.authorization || '').trim();
-    if (authorization) {
-      authMode = 'signed_bearer';
-      const token = extractBearerToken(params.authorization);
-      peer = resolveTrustedPeerForToken({
-        token,
-        peer: params.peer,
-      });
-      verifySignedHttpEnvelopeRequest({
-        token,
-        envelope,
-        audience: params.audience,
-        now: params.now,
-        peer,
-      });
-    } else if (params.mtlsPublicKeyPem) {
-      authMode = 'peer_public_key';
-      peer =
-        params.peer ?? getA2ATrustedA2APeerBySender(envelope.sender_agent_id);
-      peer = resolveTrustedPeerForMtls({
-        senderAgentId: envelope.sender_agent_id,
-        mtlsPublicKeyPem: params.mtlsPublicKeyPem,
-        peer: peer ?? undefined,
-      });
-    } else {
-      throw new A2ADelegationTokenError(
-        'Authorization bearer token or mTLS client certificate is required',
-      );
-    }
+    const authenticated = resolveAuthenticatedPeer({
+      rawAuthorization: params.authorization,
+      mtlsPublicKeyPem: params.mtlsPublicKeyPem,
+      envelope,
+      audience: params.audience,
+      now: params.now,
+    });
+    peer = authenticated.peer;
+    authMode = authenticated.authMode;
     assertEnvelopeSenderMatchesPeer(envelope, peer);
     assertCanonicalLocalRecipient(envelope);
   } catch (error) {
@@ -564,15 +550,10 @@ export function acceptA2AHttpEnvelopeInboundRequest(params: {
     };
   }
 
-  if (!peer || !envelope) {
-    return {
-      statusCode: 500,
-      body: { error: 'Internal server error' },
-    };
-  }
   const authenticatedPeer = peer;
   const authenticatedPeerInstanceId = peerInstanceId(authenticatedPeer);
-  const existing = findA2AEnvelopeByIdempotencyKey(
+  const existing = getA2AEnvelope(
+    envelope.thread_id,
     envelope.id,
     authenticatedPeerInstanceId,
   );
@@ -662,12 +643,12 @@ export function acceptA2AJsonRpcInboundRequest(params: {
   authorization: string | null | undefined;
   audience: string;
   mtlsPublicKeyPem?: string | null;
+  // Test-only clock hook for direct unit tests; HTTP handlers always use wall time.
   now?: Date;
-  peer?: A2ATrustedA2APeer;
-}): A2AJsonRpcInboundResult {
+}): A2AInboundResult {
   const runId = makeAuditRunId('a2a-inbound');
   let envelope: A2AEnvelope | null = null;
-  let peer: A2ATrustedA2APeer | null = params.peer ?? null;
+  let peer: A2ATrustedA2APeer | null = null;
   let method: 'message/send' | 'tasks/send' | null = null;
   let requestId: JsonRpcId = null;
   let authMode: A2AInboundAuthMode | null = null;
@@ -678,36 +659,16 @@ export function acceptA2AJsonRpcInboundRequest(params: {
     method = meta.method;
     requestId = meta.id;
     envelope = decodeA2AJsonRpcRequest(parsed);
-    const authorization = String(params.authorization || '').trim();
-    if (authorization) {
-      authMode = 'signed_bearer';
-      const token = extractBearerToken(params.authorization);
-      peer = resolveTrustedPeerForToken({
-        token,
-        peer: params.peer,
-      });
-      verifySignedRequest({
-        token,
-        envelope,
-        method,
-        audience: params.audience,
-        now: params.now,
-        peer,
-      });
-    } else if (params.mtlsPublicKeyPem) {
-      authMode = 'peer_public_key';
-      peer =
-        params.peer ?? getA2ATrustedA2APeerBySender(envelope.sender_agent_id);
-      peer = resolveTrustedPeerForMtls({
-        senderAgentId: envelope.sender_agent_id,
-        mtlsPublicKeyPem: params.mtlsPublicKeyPem,
-        peer: peer ?? undefined,
-      });
-    } else {
-      throw new A2ADelegationTokenError(
-        'Authorization bearer token or mTLS client certificate is required',
-      );
-    }
+    const authenticated = resolveAuthenticatedPeer({
+      rawAuthorization: params.authorization,
+      mtlsPublicKeyPem: params.mtlsPublicKeyPem,
+      envelope,
+      audience: params.audience,
+      method,
+      now: params.now,
+    });
+    peer = authenticated.peer;
+    authMode = authenticated.authMode;
     if (!localRecipientResolves(envelope.recipient_agent_id)) {
       throw new A2AEnvelopeValidationError([
         'recipient_agent_id does not resolve to a local agent',
@@ -805,6 +766,7 @@ export function resolveA2AAgentCardPeerTrust(params: {
   authorization: string | null | undefined;
   audience: string;
   mtlsPublicKeyPem?: string | null;
+  // Test-only clock hook for direct unit tests; HTTP handlers always use wall time.
   now?: Date;
 }): A2AAgentCardPeerTrustResult {
   if (String(params.authorization || '').trim()) {
@@ -842,15 +804,12 @@ export function resolveA2AAgentCardPeerTrust(params: {
   return { trustLevel: 'public' };
 }
 
-export async function handleA2AJsonRpcInbound(
+async function handleA2AInbound(
   req: IncomingMessage,
   res: ServerResponse,
   url: URL,
+  accept: A2AInboundHandler,
 ): Promise<void> {
-  if (url.pathname !== A2A_JSON_RPC_INBOUND_PATH) {
-    sendJson(res, 404, { error: 'Not Found' });
-    return;
-  }
   if (req.method !== 'POST') {
     sendJson(res, 405, { error: 'Method Not Allowed' });
     return;
@@ -858,9 +817,9 @@ export async function handleA2AJsonRpcInbound(
 
   try {
     const rawBody = (
-      await readRequestBody(req, A2A_JSON_RPC_INBOUND_MAX_BODY_BYTES)
+      await readRequestBody(req, A2A_INBOUND_MAX_BODY_BYTES)
     ).toString('utf-8');
-    const result = acceptA2AJsonRpcInboundRequest({
+    const result = accept({
       rawBody,
       authorization: readHeader(req.headers, 'authorization'),
       audience: normalizeAudience(url),
@@ -876,36 +835,18 @@ export async function handleA2AJsonRpcInbound(
   }
 }
 
+export async function handleA2AJsonRpcInbound(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL,
+): Promise<void> {
+  await handleA2AInbound(req, res, url, acceptA2AJsonRpcInboundRequest);
+}
+
 export async function handleA2AHttpEnvelopeInbound(
   req: IncomingMessage,
   res: ServerResponse,
   url: URL,
 ): Promise<void> {
-  if (url.pathname !== A2A_HTTP_ENVELOPE_INBOUND_PATH) {
-    sendJson(res, 404, { error: 'Not Found' });
-    return;
-  }
-  if (req.method !== 'POST') {
-    sendJson(res, 405, { error: 'Method Not Allowed' });
-    return;
-  }
-
-  try {
-    const rawBody = (
-      await readRequestBody(req, A2A_HTTP_ENVELOPE_INBOUND_MAX_BODY_BYTES)
-    ).toString('utf-8');
-    const result = acceptA2AHttpEnvelopeInboundRequest({
-      rawBody,
-      authorization: readHeader(req.headers, 'authorization'),
-      audience: normalizeAudience(url),
-      mtlsPublicKeyPem: extractA2AMtlsPublicKeyPem(req),
-    });
-    sendJson(res, result.statusCode, result.body);
-  } catch (error) {
-    if (error instanceof GatewayRequestError) {
-      sendJson(res, error.statusCode, { error: error.message });
-      return;
-    }
-    sendJson(res, 500, { error: 'Internal server error' });
-  }
+  await handleA2AInbound(req, res, url, acceptA2AHttpEnvelopeInboundRequest);
 }

--- a/src/a2a/store.ts
+++ b/src/a2a/store.ts
@@ -327,10 +327,6 @@ function threadIdFromAssetPath(assetPath: string): string | null {
   }
 }
 
-function a2aThreadAssetPathPrefix(): string {
-  return path.join(DEFAULT_RUNTIME_HOME_DIR, 'a2a', 'threads') + path.sep;
-}
-
 export function listA2AThreads(): A2AThreadSummary[] {
   const threads: A2AThreadSummary[] = [];
   for (const state of listRuntimeAssetRevisionStates('a2a')) {
@@ -418,31 +414,6 @@ export function getA2AEnvelope(
     ]);
   }
   return matches[0] ?? null;
-}
-
-export function findA2AEnvelopeByIdempotencyKey(
-  envelopeId: string,
-  senderInstanceId: string,
-): A2AEnvelope | null {
-  const normalizedEnvelopeId = normalizeEnvelopeId(envelopeId);
-  const normalizedSenderInstanceId =
-    normalizeSenderInstanceId(senderInstanceId);
-  for (const state of listRuntimeAssetRevisionStates('a2a', {
-    assetPathPrefix: a2aThreadAssetPathPrefix(),
-  })) {
-    const threadId = threadIdFromAssetPath(state.assetPath);
-    if (!threadId) continue;
-    const match = parsePersistedThreadState(
-      state.content,
-      threadId,
-    ).envelopes.find(
-      (entry) =>
-        entry.id === normalizedEnvelopeId &&
-        entry.sender_instance_id === normalizedSenderInstanceId,
-    );
-    if (match) return match;
-  }
-  return null;
 }
 
 export function saveA2AEnvelope(

--- a/src/a2a/store.ts
+++ b/src/a2a/store.ts
@@ -416,6 +416,29 @@ export function getA2AEnvelope(
   return matches[0] ?? null;
 }
 
+export function findA2AEnvelopeByIdempotencyKey(
+  envelopeId: string,
+  senderInstanceId: string,
+): A2AEnvelope | null {
+  const normalizedEnvelopeId = normalizeEnvelopeId(envelopeId);
+  const normalizedSenderInstanceId =
+    normalizeSenderInstanceId(senderInstanceId);
+  for (const state of listRuntimeAssetRevisionStates('a2a')) {
+    const threadId = threadIdFromAssetPath(state.assetPath);
+    if (!threadId) continue;
+    const match = parsePersistedThreadState(
+      state.content,
+      threadId,
+    ).envelopes.find(
+      (entry) =>
+        entry.id === normalizedEnvelopeId &&
+        entry.sender_instance_id === normalizedSenderInstanceId,
+    );
+    if (match) return match;
+  }
+  return null;
+}
+
 export function saveA2AEnvelope(
   envelope: unknown,
   meta?: RuntimeConfigChangeMeta,

--- a/src/a2a/store.ts
+++ b/src/a2a/store.ts
@@ -327,6 +327,10 @@ function threadIdFromAssetPath(assetPath: string): string | null {
   }
 }
 
+function a2aThreadAssetPathPrefix(): string {
+  return path.join(DEFAULT_RUNTIME_HOME_DIR, 'a2a', 'threads') + path.sep;
+}
+
 export function listA2AThreads(): A2AThreadSummary[] {
   const threads: A2AThreadSummary[] = [];
   for (const state of listRuntimeAssetRevisionStates('a2a')) {
@@ -423,7 +427,9 @@ export function findA2AEnvelopeByIdempotencyKey(
   const normalizedEnvelopeId = normalizeEnvelopeId(envelopeId);
   const normalizedSenderInstanceId =
     normalizeSenderInstanceId(senderInstanceId);
-  for (const state of listRuntimeAssetRevisionStates('a2a')) {
+  for (const state of listRuntimeAssetRevisionStates('a2a', {
+    assetPathPrefix: a2aThreadAssetPathPrefix(),
+  })) {
     const threadId = threadIdFromAssetPath(state.assetPath);
     if (!threadId) continue;
     const match = parsePersistedThreadState(

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -8,6 +8,7 @@ import {
 } from '../../container/shared/two-factor-detection.js';
 import {
   extractA2AMtlsPublicKeyPem,
+  handleA2AHttpEnvelopeInbound,
   handleA2AJsonRpcInbound,
   resolveA2AAgentCardPeerTrust,
 } from '../a2a/a2a-inbound.js';
@@ -6526,6 +6527,12 @@ export function startGatewayHttpServer(): GatewayHttpServer {
     }
     if (pathname === '/a2a') {
       dispatchWebhookRoute(res, () => handleA2AJsonRpcInbound(req, res, url));
+      return;
+    }
+    if (pathname === '/a2a/envelopes') {
+      dispatchWebhookRoute(res, () =>
+        handleA2AHttpEnvelopeInbound(req, res, url),
+      );
       return;
     }
 

--- a/tests/a2a-inbound.test.ts
+++ b/tests/a2a-inbound.test.ts
@@ -474,7 +474,7 @@ describe('A2A JSON-RPC inbound adapter', () => {
     ).toEqual({
       statusCode: 400,
       body: {
-        error: expect.stringContaining('recipient_agent_id must be a string'),
+        error: expect.stringContaining('recipient_agent_id'),
       },
     });
     expect(runtime.inbox('main')).toEqual([]);

--- a/tests/a2a-inbound.test.ts
+++ b/tests/a2a-inbound.test.ts
@@ -492,21 +492,21 @@ describe('A2A JSON-RPC inbound adapter', () => {
         },
       };
     });
-    const { getRecentStructuredAuditForSession, runtime, inbound } =
-      await loadInboundTestModules();
-    const keyPair = generateKeyPairSync('rsa', {
-      modulusLength: 2048,
-      publicKeyEncoding: { type: 'spki', format: 'pem' },
-      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
-    });
-
-    inbound.upsertA2ATrustedA2APeer({
-      peerId: 'instance-x',
-      senderAgentId: 'main@team@inst-x',
-      publicKeyPem: keyPair.publicKeyPem,
-    });
-
     try {
+      const { getRecentStructuredAuditForSession, runtime, inbound } =
+        await loadInboundTestModules();
+      const keyPair = generateKeyPairSync('rsa', {
+        modulusLength: 2048,
+        publicKeyEncoding: { type: 'spki', format: 'pem' },
+        privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+      });
+
+      inbound.upsertA2ATrustedA2APeer({
+        peerId: 'instance-x',
+        senderAgentId: 'main@team@inst-x',
+        publicKeyPem: keyPair.publicKey,
+      });
+
       expect(
         inbound.acceptA2AHttpEnvelopeInboundRequest({
           rawBody: JSON.stringify({
@@ -520,7 +520,7 @@ describe('A2A JSON-RPC inbound adapter', () => {
             created_at: '2026-05-01T10:00:00.000Z',
           }),
           authorization: null,
-          mtlsPublicKeyPem: keyPair.publicKeyPem,
+          mtlsPublicKeyPem: keyPair.publicKey,
           audience: 'http://localhost/a2a/envelopes',
           now: new Date('2030-01-01T00:00:30.000Z'),
         }),

--- a/tests/a2a-inbound.test.ts
+++ b/tests/a2a-inbound.test.ts
@@ -480,6 +480,77 @@ describe('A2A JSON-RPC inbound adapter', () => {
     expect(runtime.inbox('main')).toEqual([]);
   });
 
+  test('reports unexpected HTTP envelope auth failures as server errors', async () => {
+    process.env.HYBRIDCLAW_INSTANCE_ID = 'inst-y';
+    vi.doMock('../src/identity/agent-id.ts', async (importOriginal) => {
+      const actual =
+        await importOriginal<typeof import('../src/identity/agent-id.ts')>();
+      return {
+        ...actual,
+        resolveLocalInstanceId: () => {
+          throw new Error('local instance state unavailable');
+        },
+      };
+    });
+    const { getRecentStructuredAuditForSession, runtime, inbound } =
+      await loadInboundTestModules();
+    const keyPair = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    inbound.upsertA2ATrustedA2APeer({
+      peerId: 'instance-x',
+      senderAgentId: 'main@team@inst-x',
+      publicKeyPem: keyPair.publicKeyPem,
+    });
+
+    try {
+      expect(
+        inbound.acceptA2AHttpEnvelopeInboundRequest({
+          rawBody: JSON.stringify({
+            id: 'msg-http-unexpected-auth-a2a',
+            sender_agent_id: 'main@team@inst-x',
+            sender_instance_id: 'inst-x',
+            recipient_agent_id: 'remote@team@inst-y',
+            thread_id: 'thread-http-unexpected-auth-a2a',
+            intent: 'chat',
+            content: 'Unexpected auth-path failures are server errors.',
+            created_at: '2026-05-01T10:00:00.000Z',
+          }),
+          authorization: null,
+          mtlsPublicKeyPem: keyPair.publicKeyPem,
+          audience: 'http://localhost/a2a/envelopes',
+          now: new Date('2030-01-01T00:00:30.000Z'),
+        }),
+      ).toEqual({
+        statusCode: 500,
+        body: { error: 'Internal server error' },
+      });
+      expect(runtime.inbox('remote')).toEqual([]);
+      const audit = getRecentStructuredAuditForSession(
+        'a2a:inbound:instance-x',
+        10,
+      ).map((event) => JSON.parse(event.payload || '{}'));
+      expect(audit).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'a2a.inbound_post',
+            peerId: 'instance-x',
+            peerInstanceId: 'inst-x',
+            downstreamDisposition: 'error',
+            statusCode: 500,
+            reason: 'local instance state unavailable',
+          }),
+        ]),
+      );
+    } finally {
+      vi.doUnmock('../src/identity/agent-id.ts');
+      vi.resetModules();
+    }
+  });
+
   test('does not reveal local recipient existence before authentication', async () => {
     process.env.HYBRIDCLAW_INSTANCE_ID = 'local-dev';
     const { inbound } = await loadInboundTestModules();

--- a/tests/a2a-inbound.test.ts
+++ b/tests/a2a-inbound.test.ts
@@ -1,5 +1,9 @@
 import { generateKeyPairSync } from 'node:crypto';
-import { describe, expect, test } from 'vitest';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, test, vi } from 'vitest';
 
 import { encodeA2AJsonRpcRequest } from '../src/a2a/a2a-json-rpc.ts';
 import { setupA2AWebhookTestEnv } from './helpers/a2a-webhook-fixtures.ts';
@@ -16,6 +20,26 @@ function inboundEnvelope(id: string) {
     content: `Inbound A2A payload ${id}`,
     created_at: '2026-05-01T10:00:00.000Z',
   };
+}
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('A2A peer did not bind to a TCP port'));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+function closeServer(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
 }
 
 async function loadInboundTestModules() {
@@ -44,6 +68,82 @@ async function loadInboundTestModules() {
     inbound,
     outbound,
   };
+}
+
+async function loadHttpEnvelopeInstance(params: {
+  home: string;
+  instanceId: string;
+  agentId: string;
+}) {
+  process.env.HYBRIDCLAW_DATA_DIR = params.home;
+  process.env.HOME = params.home;
+  process.env.HYBRIDCLAW_INSTANCE_ID = params.instanceId;
+  vi.resetModules();
+  const [
+    { initDatabase, getRecentStructuredAuditForSession },
+    runtimeConfig,
+    runtime,
+    inbound,
+    outbound,
+  ] = await Promise.all([
+    import('../src/memory/db.ts'),
+    import('../src/config/runtime-config.ts'),
+    import('../src/a2a/runtime.ts'),
+    import('../src/a2a/a2a-inbound.ts'),
+    import('../src/a2a/a2a-outbound.ts'),
+  ]);
+
+  initDatabase({ quiet: true });
+  runtimeConfig.updateRuntimeConfig((draft) => {
+    draft.agents.list = [
+      {
+        id: params.agentId,
+        canonicalId: `${params.agentId}@team@${params.instanceId}`,
+        owner: 'team',
+        role: 'lead',
+      },
+    ];
+  });
+
+  return {
+    home: params.home,
+    instanceId: params.instanceId,
+    getRecentStructuredAuditForSession,
+    runtime,
+    inbound,
+    outbound,
+  };
+}
+
+function activateHttpEnvelopeInstance(
+  instance: Pick<
+    Awaited<ReturnType<typeof loadHttpEnvelopeInstance>>,
+    'home' | 'instanceId'
+  >,
+): void {
+  process.env.HYBRIDCLAW_DATA_DIR = instance.home;
+  process.env.HOME = instance.home;
+  process.env.HYBRIDCLAW_INSTANCE_ID = instance.instanceId;
+}
+
+function createHttpEnvelopeServer(
+  instance: Awaited<ReturnType<typeof loadHttpEnvelopeInstance>>,
+): http.Server {
+  return http.createServer(async (request, response) => {
+    activateHttpEnvelopeInstance(instance);
+    const origin = `http://${request.headers.host}`;
+    const url = new URL(request.url || '/', origin);
+    if (url.pathname === '/a2a/envelopes') {
+      await instance.inbound.handleA2AHttpEnvelopeInbound(
+        request,
+        response,
+        url,
+      );
+      return;
+    }
+    response.writeHead(404);
+    response.end();
+  });
 }
 
 describe('A2A JSON-RPC inbound adapter', () => {
@@ -150,6 +250,234 @@ describe('A2A JSON-RPC inbound adapter', () => {
       (event) => event.type === 'a2a.inbound_post' && event.statusCode === 202,
     );
     expect(deliveredAudit).not.toHaveProperty('outcome');
+  });
+
+  test('accepts an HTTP envelope from an authenticated peer and preserves idempotency', async () => {
+    const homeX = fs.mkdtempSync(path.join(os.tmpdir(), 'hc-a2a-http-x-'));
+    const homeY = fs.mkdtempSync(path.join(os.tmpdir(), 'hc-a2a-http-y-'));
+    let server: http.Server | null = null;
+
+    try {
+      const instanceX = await loadHttpEnvelopeInstance({
+        home: homeX,
+        instanceId: 'inst-x',
+        agentId: 'main',
+      });
+      const keyPair =
+        instanceX.outbound.getOrCreateA2ADelegationTokenKeyPair({
+          now: new Date('2030-01-01T00:00:00.000Z'),
+        });
+
+      const instanceY = await loadHttpEnvelopeInstance({
+        home: homeY,
+        instanceId: 'inst-y',
+        agentId: 'remote',
+      });
+      instanceY.inbound.upsertA2ATrustedA2APeer({
+        peerId: 'instance-x',
+        senderAgentId: 'main@team@inst-x',
+        publicKeyPem: keyPair.publicKeyPem,
+      });
+      server = createHttpEnvelopeServer(instanceY);
+      const port = await listen(server);
+      const audience = `http://127.0.0.1:${port}/a2a/envelopes`;
+      const envelope = {
+        id: 'msg-http-a2a',
+        sender_agent_id: 'main@team@inst-x',
+        sender_instance_id: 'inst-x',
+        recipient_agent_id: 'remote@team@inst-y',
+        thread_id: 'thread-http-a2a',
+        intent: 'chat' as const,
+        content: 'HTTP envelope delivery.',
+        created_at: '2026-05-01T10:00:00.000Z',
+      };
+      const token = instanceX.outbound.signA2ADelegationToken({
+        keyPair,
+        senderAgentId: envelope.sender_agent_id,
+        targetAgentId: envelope.recipient_agent_id,
+        audience,
+        scope: instanceX.outbound.A2A_MESSAGE_SEND_SCOPE,
+        parentRunId: 'run-http-envelope-parent',
+        jwtId: envelope.id,
+        messageId: envelope.id,
+        threadId: envelope.thread_id,
+      });
+
+      const first = await fetch(audience, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(envelope),
+      });
+      await expect(first.json()).resolves.toMatchObject({
+        delivered: true,
+        message_id: 'msg-http-a2a',
+        thread_id: 'thread-http-a2a',
+      });
+      expect(first.status).toBe(202);
+
+      const second = await fetch(audience, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(envelope),
+      });
+      await expect(second.json()).resolves.toMatchObject({
+        delivered: true,
+        already_delivered: true,
+        message_id: 'msg-http-a2a',
+        thread_id: 'thread-http-a2a',
+      });
+      expect(second.status).toBe(200);
+
+      activateHttpEnvelopeInstance(instanceY);
+      expect(instanceY.runtime.inbox('remote')).toEqual([
+        expect.objectContaining({
+          id: 'msg-http-a2a',
+          sender_agent_id: 'main@team@inst-x',
+          sender_instance_id: 'inst-x',
+          recipient_agent_id: 'remote@team@inst-y',
+        }),
+      ]);
+      const audit = instanceY
+        .getRecentStructuredAuditForSession('a2a:inbound:instance-x', 20)
+        .map((event) => JSON.parse(event.payload || '{}'));
+      expect(audit).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'a2a.inbound_post',
+            peerId: 'instance-x',
+            peerInstanceId: 'inst-x',
+            downstreamDisposition: 'duplicate',
+            statusCode: 200,
+          }),
+          expect.objectContaining({
+            type: 'a2a.deliver',
+            actor: 'a2a:inst-x',
+            source: 'a2a-runtime',
+          }),
+        ]),
+      );
+    } finally {
+      if (server) await closeServer(server);
+      fs.rmSync(homeX, { recursive: true, force: true });
+      fs.rmSync(homeY, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects HTTP envelopes addressed to a different instance', async () => {
+    process.env.HYBRIDCLAW_INSTANCE_ID = 'inst-y';
+    const { runtime, inbound, outbound } = await loadInboundTestModules();
+    const keyPair = outbound.getOrCreateA2ADelegationTokenKeyPair({
+      now: new Date('2030-01-01T00:00:00.000Z'),
+    });
+    inbound.upsertA2ATrustedA2APeer({
+      peerId: 'instance-x',
+      senderAgentId: 'main@team@inst-x',
+      publicKeyPem: keyPair.publicKeyPem,
+    });
+    const envelope = {
+      id: 'msg-http-misroute-a2a',
+      sender_agent_id: 'main@team@inst-x',
+      sender_instance_id: 'inst-x',
+      recipient_agent_id: 'main@team@other-instance',
+      thread_id: 'thread-http-misroute-a2a',
+      intent: 'chat' as const,
+      content: 'Wrong instance.',
+      created_at: '2026-05-01T10:00:00.000Z',
+    };
+    const token = outbound.signA2ADelegationToken({
+      keyPair,
+      senderAgentId: envelope.sender_agent_id,
+      targetAgentId: envelope.recipient_agent_id,
+      audience: 'http://localhost/a2a/envelopes',
+      scope: outbound.A2A_MESSAGE_SEND_SCOPE,
+      parentRunId: 'run-http-envelope-parent',
+      jwtId: envelope.id,
+      messageId: envelope.id,
+      threadId: envelope.thread_id,
+      now: new Date('2030-01-01T00:00:00.000Z'),
+    });
+
+    expect(
+      inbound.acceptA2AHttpEnvelopeInboundRequest({
+        rawBody: JSON.stringify(envelope),
+        authorization: `Bearer ${token}`,
+        audience: 'http://localhost/a2a/envelopes',
+        now: new Date('2030-01-01T00:00:30.000Z'),
+      }),
+    ).toEqual({
+      statusCode: 400,
+      body: {
+        error: 'recipient_agent_id instance-id does not match this instance',
+      },
+    });
+    expect(runtime.inbox('main')).toEqual([]);
+  });
+
+  test('rejects HTTP envelopes without a canonical recipient instance id', async () => {
+    process.env.HYBRIDCLAW_INSTANCE_ID = 'inst-y';
+    const { runtime, inbound, outbound } = await loadInboundTestModules();
+    const keyPair = outbound.getOrCreateA2ADelegationTokenKeyPair({
+      now: new Date('2030-01-01T00:00:00.000Z'),
+    });
+    inbound.upsertA2ATrustedA2APeer({
+      peerId: 'instance-x',
+      senderAgentId: 'main@team@inst-x',
+      publicKeyPem: keyPair.publicKeyPem,
+    });
+
+    expect(
+      inbound.acceptA2AHttpEnvelopeInboundRequest({
+        rawBody: JSON.stringify({
+          id: 'msg-http-local-recipient-a2a',
+          sender_agent_id: 'main@team@inst-x',
+          sender_instance_id: 'inst-x',
+          recipient_agent_id: 'main',
+          thread_id: 'thread-http-local-recipient-a2a',
+          intent: 'chat',
+          content: 'Local recipient ids are not accepted at the peer boundary.',
+          created_at: '2026-05-01T10:00:00.000Z',
+        }),
+        authorization: null,
+        mtlsPublicKeyPem: keyPair.publicKeyPem,
+        audience: 'http://localhost/a2a/envelopes',
+        now: new Date('2030-01-01T00:00:30.000Z'),
+      }),
+    ).toEqual({
+      statusCode: 400,
+      body: {
+        error:
+          'recipient_agent_id must be canonical (agent-slug@user@instance-id)',
+      },
+    });
+    expect(runtime.inbox('main')).toEqual([]);
+  });
+
+  test('rejects malformed HTTP envelopes before delivery', async () => {
+    process.env.HYBRIDCLAW_INSTANCE_ID = 'inst-y';
+    const { runtime, inbound } = await loadInboundTestModules();
+
+    expect(
+      inbound.acceptA2AHttpEnvelopeInboundRequest({
+        rawBody: JSON.stringify({
+          id: 'msg-http-malformed-a2a',
+          sender_agent_id: 'main@team@inst-x',
+        }),
+        authorization: null,
+        audience: 'http://localhost/a2a/envelopes',
+      }),
+    ).toEqual({
+      statusCode: 400,
+      body: {
+        error: expect.stringContaining('recipient_agent_id must be a string'),
+      },
+    });
+    expect(runtime.inbox('main')).toEqual([]);
   });
 
   test('does not reveal local recipient existence before authentication', async () => {

--- a/tests/a2a-inbound.test.ts
+++ b/tests/a2a-inbound.test.ts
@@ -528,7 +528,7 @@ describe('A2A JSON-RPC inbound adapter', () => {
         statusCode: 500,
         body: { error: 'Internal server error' },
       });
-      expect(runtime.inbox('remote')).toEqual([]);
+      expect(runtime.inbox('main')).toEqual([]);
       const audit = getRecentStructuredAuditForSession(
         'a2a:inbound:instance-x',
         10,


### PR DESCRIPTION
## Summary
- add `POST /a2a/envelopes` for inbound signed A2A envelope delivery
- enforce authenticated peer identity, canonical local recipient matching, sender-instance matching, and idempotent duplicate handling
- persist accepted envelopes through the A2A runtime store and audit inbound deliveries with `a2a:<peerInstanceId>` actors
- cover accepted delivery, duplicate delivery, misrouted recipients, local short-recipient rejection, and malformed envelopes

Closes #718.

## Validation
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run tests/a2a-inbound.test.ts tests/a2a-outbound.integration.test.ts` (passed before moving changes into the dedicated worktree)
- `git diff --check -- src/a2a/a2a-inbound.ts src/a2a/store.ts src/gateway/gateway-http-server.ts tests/a2a-inbound.test.ts`

Note: the targeted Vitest rerun in the worktree hit a local Node/native-module mismatch (`node` is v25.9.0 while the shared `better-sqlite3` install was built for Node 22), so I did not rebuild shared dependencies in place.