### PR TITLE
[codex] Sync product package versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,11 +350,16 @@ Skill resolution order (first match wins):
 When the user says "bump release":
 
 1. Bump the requested semantic version (if unspecified, default to patch).
-2. Update version strings in:
+2. Update `package.json` to the new version, then run `npm run version:sync`
+   to propagate it through product package metadata:
    - `package.json`
-   - `package-lock.json` (root `version` and `packages[""]`)
+   - `package-lock.json` and `npm-shrinkwrap.json` (root `version`,
+     `packages[""]`, and product workspace entries)
+   - `console/package.json`
+   - `desktop/package.json`
    - `container/package.json`
-   - `container/package-lock.json` (root `version` and `packages[""]`)
+   - `container/package-lock.json` and `container/npm-shrinkwrap.json` (root
+     `version` and `packages[""]`)
    - any user-facing version text (for example `src/tui.ts` banner)
 3. Move `CHANGELOG.md` release notes from `Unreleased` to the new version
    heading (or create one).

--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hybridaione/hybridclaw-console",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.23.0",
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && vite build",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -83,7 +83,7 @@
     },
     "console": {
       "name": "@hybridaione/hybridclaw-console",
-      "version": "0.0.0",
+      "version": "0.23.0",
       "dependencies": {
         "@tanstack/react-query": "5.101.0",
         "@tanstack/react-router": "1.170.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
     },
     "console": {
       "name": "@hybridaione/hybridclaw-console",
-      "version": "0.0.0",
+      "version": "0.23.0",
       "dependencies": {
         "@tanstack/react-query": "5.101.0",
         "@tanstack/react-router": "1.170.11",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
     "build:console": "npm --workspace console run build",
     "build:desktop": "npm run build && npm --workspace desktop run build",
     "build": "npm --prefix container run build && tsc && node -e \"require('node:fs').chmodSync('dist/cli.js', 0o755)\"",
+    "version:sync": "node ./scripts/sync-package-versions.mjs",
+    "version:check": "node ./scripts/sync-package-versions.mjs --check",
     "typecheck": "tsc --noEmit && npm --workspace console run typecheck && npm --workspace desktop run typecheck",
     "lint": "tsc --noEmit --noUnusedLocals --noUnusedParameters && npm --workspace console run typecheck && npm --workspace desktop run typecheck",
     "check": "biome check .",
@@ -96,7 +98,7 @@
     "prebuild": "npm run check:node && npm run build:console",
     "pretest:unit": "npm run check:node",
     "prepack": "npm run clean && npm run build && npm run release:check",
-    "release:check": "node ./scripts/check-dependency-policy.mjs && node ./scripts/release-check.mjs",
+    "release:check": "npm run version:check && node ./scripts/check-dependency-policy.mjs && node ./scripts/release-check.mjs",
     "publish:dry": "npm publish --access public --dry-run",
     "prepare": "command -v git >/dev/null 2>&1 && test -w .git/config && husky || true"
   },

--- a/scripts/dependency-policy-baseline.json
+++ b/scripts/dependency-policy-baseline.json
@@ -1,7 +1,7 @@
 {
   "lockfiles": {
-    "package-lock.json": "a13561a5c4a3c8e2f5937545e062bae28a593e5ecdc9e73852e2e55647c9e70c",
-    "npm-shrinkwrap.json": "a13561a5c4a3c8e2f5937545e062bae28a593e5ecdc9e73852e2e55647c9e70c",
+    "package-lock.json": "81af06f1fb148696d9f25e85855830ff8308758ad4e366b283bd7b413544b9cd",
+    "npm-shrinkwrap.json": "81af06f1fb148696d9f25e85855830ff8308758ad4e366b283bd7b413544b9cd",
     "container/package-lock.json": "4f69cef8803e53c29fb25480f964db1da21741cc9eb4707424c4bc9920226e71",
     "container/npm-shrinkwrap.json": "4f69cef8803e53c29fb25480f964db1da21741cc9eb4707424c4bc9920226e71",
     "plugins/brevo-email/package-lock.json": "3377225eb3bdbb252eaa28ad420b9a725ea1da533417388557aa1984730229b5"

--- a/scripts/sync-package-versions.mjs
+++ b/scripts/sync-package-versions.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+
+const checkOnly = process.argv.includes('--check');
+
+const productPackageFiles = [
+  'package.json',
+  'console/package.json',
+  'container/package.json',
+  'desktop/package.json',
+];
+
+const rootLockPackageEntries = ['', 'console', 'container', 'desktop'];
+const lockfiles = [
+  {
+    path: 'package-lock.json',
+    packageEntries: rootLockPackageEntries,
+    topLevel: true,
+  },
+  {
+    path: 'npm-shrinkwrap.json',
+    packageEntries: rootLockPackageEntries,
+    topLevel: true,
+  },
+  {
+    path: 'container/package-lock.json',
+    packageEntries: [''],
+    topLevel: true,
+  },
+  {
+    path: 'container/npm-shrinkwrap.json',
+    packageEntries: [''],
+    topLevel: true,
+  },
+];
+
+function fail(message) {
+  console.error(`version-sync: ${message}`);
+  process.exit(1);
+}
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    fail(`${filePath} is not valid JSON: ${message}`);
+  }
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function setVersion(targets, object, filePath, fieldPath, version) {
+  if (!object || typeof object !== 'object') {
+    fail(`${filePath} ${fieldPath} is missing.`);
+  }
+  if (object.version === version) return;
+  targets.push(
+    `${filePath} ${fieldPath}: ${object.version ?? '<missing>'} -> ${version}`,
+  );
+  object.version = version;
+}
+
+const rootPackage = readJson('package.json');
+const rootVersion = rootPackage.version;
+if (typeof rootVersion !== 'string' || !rootVersion.trim()) {
+  fail('package.json version must be a non-empty string.');
+}
+
+const changedFiles = new Set();
+const changes = [];
+
+for (const filePath of productPackageFiles) {
+  const parsed = readJson(filePath);
+  const before = JSON.stringify(parsed);
+  setVersion(changes, parsed, filePath, 'version', rootVersion);
+  if (JSON.stringify(parsed) !== before) {
+    changedFiles.add(filePath);
+    if (!checkOnly) writeJson(filePath, parsed);
+  }
+}
+
+for (const lockfile of lockfiles) {
+  const parsed = readJson(lockfile.path);
+  const before = JSON.stringify(parsed);
+  if (lockfile.topLevel) {
+    setVersion(changes, parsed, lockfile.path, 'version', rootVersion);
+  }
+  for (const packageEntry of lockfile.packageEntries) {
+    const entry = parsed.packages?.[packageEntry];
+    const displayPath = packageEntry || '<root>';
+    setVersion(
+      changes,
+      entry,
+      lockfile.path,
+      `packages[${JSON.stringify(displayPath)}].version`,
+      rootVersion,
+    );
+  }
+  if (JSON.stringify(parsed) !== before) {
+    changedFiles.add(lockfile.path);
+    if (!checkOnly) writeJson(lockfile.path, parsed);
+  }
+}
+
+if (changes.length === 0) {
+  console.log(
+    `version-sync: product package versions are aligned at ${rootVersion}.`,
+  );
+} else if (checkOnly) {
+  console.error('version-sync: product package versions are out of sync:');
+  for (const change of changes) console.error(`  - ${change}`);
+  process.exit(1);
+} else {
+  console.log(
+    `version-sync: aligned ${changedFiles.size} file(s) to ${rootVersion}.`,
+  );
+}


### PR DESCRIPTION
## Summary

- Align the private console workspace package version with the root HybridClaw release version.
- Add `npm run version:sync` and `npm run version:check` so product package metadata is synchronized from the root package version.
- Gate `release:check` on version alignment and update the release playbook to use the sync command.

## Why

The console workspace stayed at `0.0.0`, so npm lifecycle output showed `@hybridaione/hybridclaw-console@0.0.0` during builds even though the product release was `0.23.0`. The new sync/check command makes root, console, desktop, container, and lockfile product-version metadata deterministic.

## Validation

- `npm run version:check`
- `node scripts/check-dependency-policy.mjs`
- `npm --workspace console run typecheck`
- `npx biome check scripts/sync-package-versions.mjs package.json console/package.json AGENTS.md scripts/dependency-policy-baseline.json`
