### PR TITLE
chore: release v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,27 +2,30 @@
 
 ## Unreleased
 
+## [0.24.0](https://github.com/HybridAIOne/hybridclaw/tree/v0.24.0) - 2026-06-11
+
 ### Added
 
 - **Human distillation (R72)**: New `hybridclaw coworker` command group and
-  bundled `human-distill` skill that distill a real person's source material
+  bundled `human-distill` skill that distills a real person's source material
   into a coworker agent. Collectors normalise Slack exports, mbox email,
   meeting transcripts, chat JSONL, documents, and gap-driven interview
   questionnaires into an agent-scoped corpus with quality weighting, stable
   provenance ids, and third-party PII masking at ingest. A resumable
   ingest → analyse → build → merge → correct pipeline writes the persona into
   the standard identity files (`IDENTITY.md`, `SOUL.md`, `USER.md`, `CV.md`)
-  and a generated work-module skill, with every claim citing corpus documents
-  (uncited claims are flagged, not written), every merge an F4-versioned
-  reversible edit, and conflicting evidence surfaced as operator review
-  items. Distilling a real, named human is hard-blocked until a consent
-  artefact is recorded; all lifecycle actions emit hash-chained `distill.*`
-  audit events; `coworker forget` erases corpus, persona, work module, runs,
-  and revision snapshots as one identifier set. Includes a leakage/fidelity
-  eval (`coworker eval`), conversational corrections (`coworker correct`),
-  and one-bundle multi-host export/install for Claude Code, Codex, OpenClaw,
-  and HybridClaw. Manifesto: Principle VII - A coworker you can trust with
-  real responsibility.
+  and a generated work-module skill, with `/admin/distill` managing subjects,
+  consent, source uploads, corpus documents, and runs from the browser. Every
+  claim cites corpus documents (uncited claims are flagged, not written),
+  every merge is an F4-versioned reversible edit, and conflicting evidence is
+  surfaced as operator review items. Distilling a real, named human is
+  hard-blocked until a consent artefact is recorded; all lifecycle actions
+  emit hash-chained `distill.*` audit events; `coworker forget` erases corpus,
+  persona, work module, runs, and revision snapshots as one identifier set.
+  Includes a leakage/fidelity eval (`coworker eval`), conversational
+  corrections (`coworker correct`), and one-bundle multi-host export/install
+  for Claude Code, Codex, OpenClaw, and HybridClaw. Manifesto: Principle VII -
+  A coworker you can trust with real responsibility.
 - **Cloud memory sync**: Agents now sync local memory files (`MEMORY.md`,
   `USER.md`, and recent daily memory notes) with the HybridAI cloud and receive
   shared installation- and company-scoped memory back for prompt context. Sync
@@ -37,14 +40,38 @@
   optional peer-side approval prompt. Incoming pairing requests arrive through
   a rate-limited `/a2a/pairing/requests` endpoint and can be approved or
   declined from the console with audit-trail decision reasons.
+- **Inbound A2A envelopes**: Added a JSON-RPC Agent Card envelope receiver for
+  cross-instance A2A delivery, including canonical sender/recipient metadata,
+  idempotent persistence, signed bearer-token validation, read-only admin
+  inbox visibility, and audit events for malformed or rejected envelopes.
+- **HybridAI proxy agents**: Agents can now proxy conversations to hosted
+  HybridAI chatbots via per-agent `proxy` config, SecretRef-backed API keys,
+  HTTPS-only upstreams, selectable channel- or user-scoped conversation ids,
+  streaming response forwarding, and `/status` visibility for proxy mode.
+- **Explicit agent addressing**: Chat channels and web chat can address
+  specific agents inline, with mention autocomplete, avatar-backed mention
+  pills, canonical recipient handling, and fanout hardening for local
+  proactive delivery.
 - **`byd-battery` skill**: Added read-only monitoring for BYD Battery-Box
   Premium HVS/HVM/LVS/LVL home-storage systems over local Modbus TCP or
   Fronius inverter delegation, covering state of charge, pack telemetry, cell
   extremes, tower/module inventory, decoded alarms, firmware info, and energy
   counters, with allowlisted register ranges and no write operations.
+- **`mailchimp` skill**: Added Mailchimp Marketing and Mailchimp
+  Transactional/Mandrill workflows for credential checks, audience/member
+  reads, guarded subscriber and tag mutations, campaign draft/content/report
+  operations, automations, journeys, and approval-gated campaign or
+  transactional sends through the gateway HTTP proxy.
 - **Amber approval cards**: Web chat approval prompts now render as structured
   confirmation cards with an approval-tier badge, parsed action/tool/reason
   detail rows, and separated confirm/deny and trust-scope button groups.
+- **Named local model endpoints**: Local provider config now supports
+  additional named Ollama, LM Studio, llama.cpp, and vLLM endpoints with
+  endpoint-prefixed model ids, CLI setup via `--name`, and per-endpoint model
+  behavior flags for Qwen thinking markup and Gemma tool-call formats.
+- **Auxiliary model testing**: Added `/aux test <task> <prompt>` so operators
+  can exercise configured auxiliary model routes directly and see the
+  provider/model used for the request.
 - **Response rating forwarding**: Thumbs up/down ratings on web chat responses
   are forwarded to the HybridAI feedback API when HybridAI authentication is
   active, alongside the existing local rating store and audit events.
@@ -52,11 +79,36 @@
 
 ### Changed
 
+- **README and skill docs positioning**: The public README and skills docs now
+  lead with HybridClaw's validated business-skill workflow: helper-backed
+  production skills, eval scenarios, approval tiers, credential boundaries, and
+  `Qwen/Qwen3.6-27B-FP8` as the small-model validation baseline.
+- **Multi-agent and credential-isolation positioning**: The README and docs
+  now call out multi-instance A2A workflows, hosted proxy agents, explicit
+  addressing, and SecretRef-backed execution that keeps raw credentials out of
+  model context.
+- **HybridAI Cloud launch path**: The README, docs landing page, and
+  installation guide now link to the managed HybridClaw cloud offering at
+  `hybridclaw.io`.
+- **Desktop release order docs**: The macOS desktop release guide now
+  recommends building and notarizing from the exact version tag, uploading
+  desktop assets to a draft GitHub Release, then publishing after assets are
+  verified.
 - **Provider request payloads**: Empty tool definitions are omitted from
   HybridAI, OpenAI-compatible, Codex, and Ollama provider requests instead of
   sending empty `tools` arrays.
+- **Local vLLM tool behavior**: OpenAI-compatible local providers infer and
+  remember native-tool fallback support, count prompt-side tool overhead in
+  context guards, refresh named-endpoint metadata, and parse Gemma text tool
+  calls emitted before or after Markdown wrappers.
+- **Structured actors in audit data**: Audit/event records now carry unified
+  actor identities across A2A envelopes, board cards, adaptive-skill
+  observations, scoreboards, and structured audit queries.
 - **Coworker liveness scan**: Skill scans during coworker liveness checks use
   set-based agent filtering, speeding up gateways with many agents.
+- **Release version sync tooling**: `npm run version:sync` now keeps root,
+  console, desktop, container, lockfile, and shrinkwrap package versions in
+  sync, with `release:check` validating the same invariant.
 - **Dependency updates**: Routine minor and patch dependency updates across the
   gateway, console, container, and desktop packages, plus overrides that lift
   transitive `shell-quote` and `tmp` to patched releases flagged by npm audit.
@@ -79,6 +131,10 @@
   no longer misreport container dependencies as missing when npm hoists a
   package whose `exports` map does not expose `package.json` (e.g.
   `dompurify`).
+- **Installer and setup hardening**: The one-line installer, postinstall
+  container setup, Node version guard, and Homebrew/source-checkout paths handle
+  no-sudo installs, user npm prefixes, and container dependency setup more
+  reliably.
 
 ## [0.23.0](https://github.com/HybridAIOne/hybridclaw/tree/v0.23.0) - 2026-06-09
 

--- a/README.md
+++ b/README.md
@@ -7,75 +7,70 @@
 [![License](https://img.shields.io/github/license/HybridAIOne/hybridclaw)](https://github.com/HybridAIOne/hybridclaw/blob/main/LICENSE)
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://hybridaione.github.io/hybridclaw/docs/)
 [![Powered by HybridAI](https://img.shields.io/badge/powered%20by-HybridAI-blueviolet)](https://hybridai.one)
+[![Cloud](https://img.shields.io/badge/cloud-launch%20HybridClaw-2ea44f)](https://hybridclaw.io)
 [![Discord](https://img.shields.io/badge/Discord-join%20chat-5865F2?logo=discord&logoColor=white)](https://discord.gg/jsVW4vJw27)
 
 <img width="420" height="397" alt="HybridClaw - Enterprise-ready self-hosted AI assistant runtime" src="docs/hero.png" />
 
-## All of the Claw, None of the Chaos
-### Enterprise-ready self-hosted AI assistant runtime
+## Business Skills That Work On Smaller Models
 
-HybridClaw is a self-hosted AI assistant runtime for teams that need control,
-security, and operational visibility. It combines sandboxed execution, secure
-credentials, approvals, persistent memory, and admin surfaces behind a single
-gateway.
+HybridClaw's main promise is practical business work. The bundled CRM,
+marketing, analytics, finance, cloud, office, and operations skills are
+implemented as tested helpers with eval scenarios, credential boundaries, and
+approval tiers, and are validated against `Qwen/Qwen3.6-27B-FP8` as the
+small-model baseline.
 
-Connect it to Discord, Discord Incoming Webhooks, Slack, Slack Incoming
-Webhooks, Signal, WhatsApp, Telegram, Microsoft Teams, email, fax, Twilio
-voice, or the web. Run it locally, deploy it for business workflows, and keep your
-agents, secrets, and data under your control.
+That is the useful difference: a compact model can operate Salesforce,
+HubSpot, GA4, Google Ads, Lexware, Airtable, warehouse SQL, invoices, cloud
+ops, and office documents through structured rails instead of fragile
+free-form prompting.
+
+HybridClaw also treats agents as networked coworkers. Local agents, hosted
+HybridAI proxy agents, and trusted peer HybridClaw instances can address one
+another, exchange A2A envelopes, and route work through approval-aware
+channels.
+
+Credentials stay outside the model context. Secrets live in the encrypted
+runtime store and SecretRef-backed tools resolve them at execution time, so
+LLMs see the requested action and approval context, not raw API keys,
+passwords, or bearer tokens.
+
+Run one local assistant, operate a fleet of role-specific coworkers, or launch
+HybridClaw on HybridAI Cloud in a few minutes at
+[hybridclaw.io](https://hybridclaw.io).
 
 [Quick Start](https://hybridaione.github.io/hybridclaw/docs/getting-started/quickstart) ·
+[Launch Cloud](https://hybridclaw.io) ·
 [Installation](https://hybridaione.github.io/hybridclaw/docs/getting-started/installation) ·
+[Docs](https://hybridaione.github.io/hybridclaw/docs/) ·
 [Configuration](https://hybridaione.github.io/hybridclaw/docs/reference/configuration) ·
-[Migration](https://hybridaione.github.io/hybridclaw/docs/reference/commands#migration) ·
-[Contributing](./CONTRIBUTING.md) ·
-[Support](./SUPPORT.md)
+[Commands](https://hybridaione.github.io/hybridclaw/docs/reference/commands) ·
+[Contributing](./CONTRIBUTING.md)
 
-## Pick your path
+## Why HybridClaw
 
-- Want the shortest path to a running assistant? Start with
-  [Quick Start](https://hybridaione.github.io/hybridclaw/docs/getting-started/quickstart).
-- Want the full setup flow with providers, channels, and admin surfaces? Start
-  with [Installation](https://hybridaione.github.io/hybridclaw/docs/getting-started/installation)
-  and [Authentication](https://hybridaione.github.io/hybridclaw/docs/getting-started/authentication).
-- Want to migrate from OpenClaw or Hermes? Start with the
-  [migration commands](https://hybridaione.github.io/hybridclaw/docs/reference/commands#migration).
-- Want to contribute from source? Start with [CONTRIBUTING.md](./CONTRIBUTING.md)
-  and the maintainer docs under [docs/content/README.md](./docs/content/README.md).
+| You need | HybridClaw gives you |
+| --- | --- |
+| Business workflows that survive real use | Production skill helpers with fixtures, eval scenarios, targeted tests, approval tiers, and a `Qwen/Qwen3.6-27B-FP8` validation baseline |
+| Multi-agent workflows across installations | Local agents, hosted proxy agents, A2A trust, explicit addressing, inbound envelopes, and admin-visible peer pairing |
+| Credentials the model cannot read | Encrypted runtime secrets and SecretRef-backed execution paths that keep raw keys and passwords out of prompts and tool results |
+| Assistants that can act, not just chat | A gateway, web chat, TUI, admin console, scheduler, tools, and OpenAI-compatible API behind one local service |
+| Control over sensitive work | Approval policy, sandbox boundaries, output guardrails, and hash-chained audit trails |
+| Agents that fit existing teams | Discord, Slack, Teams, Telegram, WhatsApp, email, voice, web, and more through the same runtime |
+| Operational memory | Local files, SQLite state, semantic recall, session compaction, and optional HybridAI cloud memory |
+| Repeatable expert workflows | Per-agent workspaces, budgets, model routing, A2A trust, proxy agents, `.claw` archives, and human-distillation workflows |
 
-## Coming from OpenClaw or Hermes?
+## Install
 
-```bash
-hybridclaw migrate openclaw --dry-run
-hybridclaw migrate hermes --dry-run
-```
+Fastest managed launch: [HybridClaw on HybridAI Cloud](https://hybridclaw.io).
 
-Preview and import compatible state from OpenClaw or Hermes in minutes.
-Imports compatible skills, memory, config, and optional secrets.
-
-## HybridAI Platform Advantage
-
-HybridClaw is the runtime. HybridAI is the (optional) platform layer around it.
-
-HybridAI adds:
-
-- one-click cloud deployment
-- enterprise shared RAG / knowledge
-- access to current models from Anthropic, OpenAI, Google, xAI, and others
-- observability across multiple agents
-- built-in email addresses for your agents
-- ready-to-run virtual coworkers
-
-## Get running in 2 minutes
-
-One-line install on Linux/macOS (ensures Node 22, installs the CLI, runs
-onboarding):
+Linux/macOS one-line installer:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/scripts/install.sh | bash
 ```
 
-Or do it by hand with npm:
+Manual npm install:
 
 ```bash
 npm install -g @hybridaione/hybridclaw
@@ -84,16 +79,23 @@ hybridclaw gateway
 hybridclaw tui
 ```
 
-Open locally:
+Requirements: Node.js 22. Docker is recommended for the default sandbox.
 
-- Chat UI: `http://127.0.0.1:9090/chat`
-- Admin UI: `http://127.0.0.1:9090/admin` for channels, versioned agent files,
-  scheduler, audit, statistics, config, secrets, output guard, and
-  channel-specific instructions
-- Agents UI: `http://127.0.0.1:9090/agents`
-- OpenAI-compatible API: `http://127.0.0.1:9090/v1/models` and `http://127.0.0.1:9090/v1/chat/completions`
+## First Run
 
-Requirement: Node.js 22 (Docker recommended for sandbox)
+After the gateway starts, open:
+
+| Surface | URL / command | Use it for |
+| --- | --- | --- |
+| Web Chat | `http://127.0.0.1:9090/chat` | Chat, slash commands, model and agent switching |
+| Admin Console | `http://127.0.0.1:9090/admin` | Channels, agents, approvals, audit, config, secrets, skills, distillation |
+| Agents UI | `http://127.0.0.1:9090/agents` | Agent fleet overview and prompt-file editing |
+| TUI | `hybridclaw tui` | Terminal chat, approvals, status, resume |
+| OpenAI-compatible API | `http://127.0.0.1:9090/v1/chat/completions` | Local evals and compatible clients |
+
+For signed macOS desktop builds, use the
+[GitHub Releases](https://github.com/HybridAIOne/hybridclaw/releases/latest)
+page.
 
 Desktop wrapper from source:
 
@@ -102,364 +104,116 @@ npm install
 npm run desktop
 ```
 
-The Electron workspace opens the existing `/chat` surface in a native macOS
-window, exposes `/admin` from the app menu, reuses a running local gateway when
-available, and starts the bundled gateway automatically when it is not already
-listening on `http://127.0.0.1:9090`.
+## What You Get
 
-Release notes live in [CHANGELOG.md](./CHANGELOG.md), and the browsable
-operator and maintainer manual lives at
-[hybridaione.github.io/hybridclaw/docs](https://hybridaione.github.io/hybridclaw/docs/).
+| Area | Built in |
+| --- | --- |
+| Skills | 76 bundled skills, production business helpers, eval fixtures, packaged skill lifecycle, and human-distillation workflows |
+| Channels | Discord, Slack, Signal, WhatsApp, Telegram, Microsoft Teams, email, iMessage, fax, Twilio voice, web, and incoming webhooks |
+| Runtime | Gateway service, TUI client, web chat, admin console, loopback OpenAI-compatible API, Docker or host execution |
+| Governance | Encrypted runtime secrets, SecretRef credential isolation, approval policies, sandbox controls, audit trails with hash-chain integrity |
+| Memory | Local memory files, SQLite persistence, semantic recall, session compaction, optional HybridAI cloud memory sync |
+| Agents | Per-agent workspaces, models, budgets, prompt files, explicit addressing, proxy agents, A2A trust, peer-instance communication |
+| Extensibility | Packaged business skills, plugins, MCP servers, SecretRef-backed HTTP tools |
 
-## See it in Action
+## Product Strengths
 
-Once the gateway is running, open HybridClaw locally:
+- **Validated business skills**: production skills use deterministic helpers,
+  fixtures, eval scenarios, and targeted tests so small models can perform
+  useful work through structured actions.
+- **Multi-agent operations**: agents can coordinate across local workspaces,
+  hosted HybridAI proxies, and trusted peer HybridClaw instances with A2A
+  pairing, explicit addressing, inbound envelopes, and admin-visible trust.
+- **Prompt-level credential isolation**: encrypted secrets and SecretRefs keep
+  credential values out of model context while tools receive only the scoped
+  credential material needed at execution time.
+- **One runtime for many surfaces**: web, terminal, Discord, Slack, Teams,
+  email, voice, webhooks, and local API clients all use the same gateway,
+  memory, policy, and audit model.
+- **Secure by default**: LLM output is treated as untrusted, risky actions
+  route through approval policy, and every sensitive boundary is visible in
+  audit.
+- **Model freedom**: use HybridAI, major hosted providers, local engines, or
+  named OpenAI-compatible endpoints from the same model picker and config
+  surface.
+- **Operator visibility**: `/admin` covers channels, approvals, audit,
+  statistics, output guard, secrets, fleet topology, A2A inbox/trust, and
+  distillation without requiring shell access.
+- **Business-ready extension model**: packaged skills, plugins, MCP servers,
+  and SecretRef-backed HTTP tools share the same approval and credential
+  boundaries.
+- **Practical migration path**: preview compatible imports from OpenClaw or
+  Hermes, then package agents as portable `.claw` archives.
 
-- Web Chat: `http://127.0.0.1:9090/chat`
-- Web Chat keeps a recent-session sidebar and can search conversation titles
-  with contextual snippets before you reopen or delete an older browser session
-- Web Chat shows live context-window usage, accepts `/context`, and lets you
-  switch the active agent and model from the composer; active agent switching is
-  preserved across session reloads and UI route changes
-- Web Chat keeps scrolling pinned when you read older messages and shows a
-  jump-to-latest affordance when new output arrives below the current viewport
-- Web Chat accepts `/btw <question>` side questions while a primary run is
-  active, so you can ask an ephemeral follow-up without interrupting the
-  current run
-- Web Chat renders slash-command output as command results and lets operators
-  rate persisted assistant responses with thumbs-up/down feedback that feeds
-  observability and skill-improvement signals
-- Web Chat syntax-highlights completed code blocks, shows language labels, and
-  exposes copy controls that work on hover and touch devices
-- Admin Console: `http://127.0.0.1:9090/admin` for channels, versioned agent files,
-  scheduler, audit, statistics, config, secrets, output guard, A2A inbox
-  threads, fleet topology, and channel-specific instructions
-- Agent Dashboard: `http://127.0.0.1:9090/agents`
-- or connect Discord, Discord Incoming Webhooks, Slack, Slack Incoming
-  Webhooks, Signal, WhatsApp, Telegram, Microsoft Teams, Email, Fax
+## Common Commands
 
-## Operator workflows
+```bash
+hybridclaw gateway status
+hybridclaw tui --resume <sessionId>
+hybridclaw config get <key>
+hybridclaw skill list
+hybridclaw agent list
+hybridclaw doctor
+hybridclaw update --yes
+```
 
-- Install from npm, source, or the multi-arch Nix flake; a preview Homebrew
-  formula is available for `--HEAD` builds while stable tap publication is
-  prepared.
-- `hybridclaw gateway status` reports sandbox/runtime details, and in
-  container mode it includes the configured image name plus the resolved
-  version and short image id.
-- `hybridclaw backup` creates a WAL-safe archive of the runtime home, and
-  `hybridclaw backup restore <archive.zip>` validates the archive before
-  replacing local runtime state.
-- `hybridclaw update --yes` upgrades a global npm install and auto-restarts a
-  running local gateway with its original launch parameters when possible,
-  falling back to `hybridclaw gateway restart` if not.
-- `/admin/agents` edits allowlisted bootstrap markdown files such as
-  `AGENTS.md`, keeps saved revisions, and restores earlier versions from the
-  browser.
-- `/admin/statistics` reports message, session, token, cost, and channel trends
-  across a selected date range.
-- The Usage rollup surfaces loading skeletons, cost metrics, and per-model
-  spend summaries without scanning every stored session on page load.
-- `/admin/agent-scoreboard` ranks agents by observed skill scores, reliability,
-  timing, best skills, and CV links.
-- `/audit turn <n>` and `/audit run <runId>` show focused turn traces for
-  debugging one request without reading the full session audit stream.
-- `hybridclaw agent config` accepts generated JSON payloads to upsert agent
-  metadata, write bootstrap markdown, import profile images into the agent
-  workspace, and optionally activate the agent.
-- `/admin/channels` edits transport config, encrypted channel credentials,
-  Signal QR linking, Twilio voice settings, and per-channel instructions that
-  are injected into prompts at runtime.
-- `/admin/secrets` lists stored and declared-but-empty secrets by metadata
-  only, supports overwrite and unset actions, and never returns cleartext
-  secret values to the browser.
-- `/admin/output-guard` configures response guardrails and plugin-backed
-  output classification without editing runtime config by hand.
-- `slack_webhook` targets provide outbound-only Slack Incoming Webhook delivery
-  with encrypted webhook URLs, named destinations, Block Kit text chunking,
-  reachability status, and POST-only network policy grants.
-- `discord_webhook` targets provide outbound-only Discord Incoming Webhook
-  delivery with encrypted webhook URLs, named destinations, message chunking,
-  reachability status, and POST-only network policy grants.
-- `/admin/approvals` manages approval policies from the browser.
-- Approval policy evaluation runs through a hook-fed rule pipeline, so
-  workspace policy ordering and plugin tool-use hooks share one approval path.
-- `/admin/a2a-inbox` shows read-only A2A message threads across the instance,
-  with sender, recipient, timestamp, intent, and content for each message.
-- `/admin/a2a-trust` shows the local A2A public-key trust ledger for paired
-  peer instances.
-- `/admin/fleet-topology` shows the local A2A instance identity, checks trusted
-  child instances through Agent Card URLs, and edits trust-ledger peers from the
-  browser.
-- `/admin/gateway` reloads runtime config and refreshes secrets from the
-  browser, and shows public URL plus tunnel status, without tearing down the
-  enclosing workspace container; keep `hybridclaw gateway restart` for
-  local/manual full restarts.
-- `/context` and the web chat context ring show current context-window usage,
-  remaining headroom, and compaction counts for the active session.
-- `/goal` stores a standing completion condition for the current thread and
-  queues supervised continuations until the goal is judged complete, paused,
-  cleared, interrupted, or blocked by approval policy.
-- `/second-opinion` asks a stronger configured model to compare a question,
-  validate the last answer, or fact-check with web-search evidence while
-  honoring configured model context, confidentiality, and agent-budget limits.
-- `proactive.delegation.model` can pin delegated work to a different model
-  from the parent turn; `/status` shows delegate token totals and local-token
-  share when that split is configured.
-- `deployment.mode`, `deployment.public_url`, `deployment.tunnel.provider`, and
-  `deployment.tunnel.health_check_interval_ms` describe local/cloud exposure
-  and tunnel health cadence. The built-in ngrok, Tailscale Funnel, and
-  Cloudflare Tunnel providers read `NGROK_AUTHTOKEN`, `TS_AUTHKEY`,
-  `CLOUDFLARE_TUNNEL_TOKEN`, and Cloudflare certificate credentials from the
-  encrypted runtime secret store.
-- A2A cross-instance delivery resolves canonical peer IDs in order from the
-  local deployment URL or active tunnel URL, the A2A public-key trust ledger,
-  then DNS-style discovery when `HYBRIDCLAW_IDENTITY_DISCOVERY_ZONE` is
-  configured.
-- `container.warmPool` keeps a bounded adaptive pool of idle host/container
-  runtimes for recently active agents when low cold-start latency matters.
-- `container.persistBashState` controls whether bash tool calls share shell
-  state (`cd`, exported env vars, aliases) across turns in the same active
-  runtime session; `/admin/config` exposes the same setting as `Persistent bash state`.
-- Agent budget config supports monthly USD/EUR caps and token caps; job and
-  board budget chips show neutral, warning, and over-budget states for
-  configured agents.
-- `security.confidentialRedactionEnabled` controls whether optional
-  `.confidential.yml` rules redact prompts and block matching outbound text;
-  `/admin/config` exposes the same setting as `Confidential leak guard`.
-- `hybridclaw audit scan-leaks` scans historical audit logs against optional
-  `.confidential.yml` rules for NDA-class client, project, person, keyword,
-  and regex matches.
-- Generated artifacts remain downloadable and attachable even when the sandbox
-  exposes a custom workspace display root such as `/app`.
-- `hybridclaw tui` includes live delegate progress, pulsing tool rows,
-  completion checkmarks, rendered Markdown tables, a keyboard-driven approval
-  picker, and a ready-to-run `hybridclaw tui --resume <sessionId>` command on
-  exit. Pressing `Esc` stops the active run and returns control to the prompt.
-- `hybridclaw doctor` checks runtime health including resource hygiene
-  maintenance for stale gateway artifacts. `hybridclaw doctor browser-use`
-  checks the local Playwright browser automation substrate and can install
-  missing Chromium support with `--fix`.
-- `hybridclaw onboarding` and related local setup flows can restore the last
-  known-good saved config snapshot or roll back to a tracked revision when
-  `config.json` becomes invalid.
-- `hybridclaw skill import` supports community sources, local directories,
-  and `.zip` archives.
-- `hybridclaw skill install <source>`, `skill upgrade`, `skill revisions`, and
-  `skill rollback` manage packaged business skills with manifests, audit
-  events, and snapshots.
-- `hybridclaw skill list blocked` and `hybridclaw skill unblock <name>` let
-  local operators review scanner-blocked skills and record a bypass marker for
-  the installed copy when the finding has been accepted.
-- Bundled skills include CRM, finance, infrastructure, monitoring,
-  home-automation, home-security, lighting, solar monitoring, fax, local PII
-  redaction, media, search, and office workflows. Skill setup guides live in the
-  [Skills Catalog](https://hybridaione.github.io/hybridclaw/docs/guides/skills/).
-- The bundled tutorials cover owner, GTM, marketing, sales, DevRel, content,
-  invoicing, webinar, and release-launch workflows that can run from the TUI,
-  web chat, or connected channels.
-- `hybridclaw eval hybridai-skills` turns the bundled skills pages' "Try it
-  yourself" prompts into a local eval suite, and live summaries surface the
-  observed skill, artifact presence, and counted tool-call totals.
-- Channel delivery stays predictable: email seeds its first mailbox cursor from
-  the current head instead of replaying old inbox mail, retry-aware transports
-  honor server `Retry-After` backoff, expected transient Discord/Email/WhatsApp
-  transport outages stay local with rate-limited logging, and WhatsApp startup
-  avoids intermittent init-query bad-request failures.
+Migration preview:
 
-## Models, Skills, and Memory
+```bash
+hybridclaw migrate openclaw --dry-run
+hybridclaw migrate hermes --dry-run
+```
 
-- `hybridclaw auth login` and `/model list` cover HybridAI, Codex,
-  Anthropic, OpenRouter, Mistral, Hugging Face, Gemini, DeepSeek, xAI, Z.AI,
-  Kimi, MiniMax, DashScope, Xiaomi, Kilo Code, and local backends such as
-  Ollama, LM Studio, llama.cpp, and vLLM. Remote OpenAI-compatible providers
-  can merge runtime-discovered model catalogs with operator-pinned lists.
-- `/model info`, `/usage monthly`, `/usage model monthly`, and the admin
-  Models page surface discovered context windows, output limits, model
-  capabilities, pricing, and per-model monthly spend where provider metadata is
-  available.
-- Anthropic can run through the direct Messages API with `ANTHROPIC_API_KEY`
-  or through the official Claude CLI transport in host sandbox mode.
-- Brave, Perplexity, and Tavily web-search credentials can live in the
-  encrypted runtime secret store and are passed into host or container agent
-  runtimes from the active config.
-- Web search can also target a self-hosted SearXNG instance through
-  `web.search.searxngBaseUrl` or `SEARXNG_BASE_URL`; authenticated instances
-  use store-backed SearXNG bearer SecretRefs, and agents can override the
-  global SearXNG base URL and bearer SecretRef for tenant-specific search.
-  Bundled `search.web`, `search.news`, and `search.images` skills prefer that
-  sovereign search path.
-- Google OAuth credentials for Workspace skills live in the encrypted runtime
-  secret store; agent runtimes receive short-lived access tokens for `gog` and
-  `gws` instead of long-lived refresh tokens.
-- Canonical user and agent identities use stable lowercase IDs and DNS-style
-  discovery records so A2A peers can resolve remote URLs and public keys.
-- `hybridclaw secret route ...` and `/secret route ...` can attach stored
-  secrets or Google OAuth access tokens to matching `http_request` URL
-  prefixes, including Google Ads API calls.
-- `HYBRIDAI_FALLBACK_CHAIN` can route auth and rate-limit provider failures to
-  alternate models/providers with cooldowns before retrying the primary.
-- Skills can be enabled or disabled globally or per channel from
-  `hybridclaw skill enable|disable`, TUI `/skill config`, or the admin
-  `Skills` page.
-- Packaged skills can declare versioned manifests, capabilities, required
-  credentials, supported channels, and per-agent autonomy policy.
-- Bundled skills include API-backed Google Workspace workflows (`gog`, `gws`),
-  Salesforce inspection, GitHub issue queue processing (`gh-issues`),
-  monthly SaaS invoice harvesting (`download-platform-invoices`), Airtable,
-  FastBill, Lexware Office, managed or self-hosted Firecrawl, Google Ads, GA4
-  reporting, HeyGen, Hermes3000 long-form writing, Alexa custom-skill and
-  smart-home planning, Blink home-security reads and guarded controls, Philips
-  Hue lighting reads and guarded controls, Fronius solar monitoring, Homematic
-  HCU state/control planning, natural-language warehouse SQL (`warehouse-sql`),
-  brand-voice drafting, speech transcription and language detection
-  (`speech.transcribe`, `speech.detect-language`), validated diagram-as-code
-  creation through `diagram`, and editable Excalidraw diagram creation.
-- Native media tools generate images and videos through configured providers,
-  persist the resulting artifacts, and expose the same capability through the
-  bundled `image-generation`, `video-generation`, and `video.from-script`
-  skills.
-- Native audio transcription can route through configured local or provider
-  backends, produce private transcript artifacts, and attach language,
-  timestamp, speaker, duration, and cost metadata when available.
-- Dynamic per-turn context such as current date, host, today's daily memory,
-  session summary, and retrieved context is appended after the static system
-  prompt so provider prefix caches can reuse the stable prompt prefix.
-- Browser automation can use local persistent Playwright profiles, Camofox
-  profiles, or Browser Use Cloud sessions with encrypted `BROWSER_USE_API_KEY`
-  storage, usage metering, shared navigation guards, SecretRef-gated credential
-  fills, and deny-by-default host allowlisting for Camofox stealth mode.
-- The repo-shipped `brand-voice` plugin can flag, rewrite, or block final
-  responses that violate configured voice rules before they reach users.
-- Built-in office skills handle longer PDF creation flows cleanly: the bundled
-  PDF creator wraps long lines, honors explicit `\n`, and adds pages
-  automatically when reports or invoices spill past the first page.
-- Built-in memory can stay standalone or layer with ByteRover, Mem0, Honcho,
-  MemPalace, QMD, and GBrain plugins depending on whether you want
-  local-first recall, hosted memory, or domain-specific retrieval.
-- Optional OpenTelemetry tracing exports gateway and agent spans to OTLP
-  backends and annotates structured logs with trace ids for cross-system
-  correlation.
-- Optional Sentry reporting sends gateway startup failures, uncaught
-  exceptions, unhandled rejections, and shared span errors when `SENTRY_DSN` is
-  stored with `hybridclaw env set`.
+## HybridAI Platform
 
-## How HybridClaw compares
+HybridClaw runs self-hosted. HybridAI is the optional platform layer around it:
 
-| Capability | HybridClaw | OpenClaw | Hermes Agent |
-| --- | --- | --- | --- |
-| Self-hosted runtime | ✅ Gateway + sandboxed container runtime | ✅ Self-hosted gateway/runtime | ✅ Self-hosted gateway/runtime |
-| Migration support | ✅ Imports from OpenClaw and Hermes | ❌ No comparable import path surfaced | ⚠️ Imports from OpenClaw only |
-| Encrypted secrets | ✅ Encrypted store + SecretRefs | ⚠️ SecretRefs, not a built-in encrypted store | ⚠️ File-permission-based secret storage |
-| Approvals / governance | ✅ Approvals, audit trails, sandbox, config history | ⚠️ Strong approvals/audit, less enterprise-governance framing | ⚠️ Strong approvals/isolation, less audit/admin surface |
-| Memory / knowledge | ✅ Shared memory + HybridAI knowledge path | ⚠️ Strong memory/session features | ⚠️ Strong persistent/self-improving memory |
-| Multi-agent observability | ✅ Built-in audit surfaces + platform path | ⚠️ Multi-agent/task inspection exists | ⚠️ Subagents + logs/session search, not central observability |
-| Local + cloud deployment model | ✅ Local-first runtime with HybridAI cloud path plus SSH/Tailscale remote access | ⚠️ Self-hosted + remote access | ✅ Local, VPS, Docker, Modal, Daytona |
-| Multiple UIs | ✅ TUI + Chat UI + Admin UI + Agents UI | ✅ TUI + WebChat + Control UI | ⚠️ TUI + messaging + API server, no comparable built-in admin/chat web UI |
-
-## Adjacent tools
-
-| Comparison point | HybridClaw | LangChain | n8n |
-| --- | --- | --- | --- |
-| Framework vs runtime | Runtime | Framework | Workflow builder |
-| Coding required | Low to medium | High | Low |
-| Workflow builder vs agent runtime | Agent runtime | Framework for building agent systems | Visual workflow builder |
-| Enterprise controls | ✅ Approvals, audit, sandbox, encrypted secrets | ⚠️ You build them | ⚠️ Workflow-level controls |
-
-## Security and governance built in
-
-- secure credential storage
-- optional confidential-info redaction before model calls
-- retroactive audit leak scanning
-- sandboxed execution
-- approvals
-- audit trails with hash chain
-- config versioning and backup/rollback
-- observability
-
-## Built for real workflows
-
-- channels
-- versioned agent workspace prompt files with saved revisions and restore
-- browser sessions
-- office docs
-- skills / plugins / MCP
-- persistent workspaces
-
-## Built for rollout and migration
-
-- import from OpenClaw / Hermes
-- portable `.claw` packages with bundled knowledge and skills
-- local-first to cloud-ready path
+- managed HybridClaw launch at [hybridclaw.io](https://hybridclaw.io)
+- enterprise shared RAG and cloud memory
+- managed access to current models
+- observability across multiple agents
+- hosted email addresses for agents
+- ready-to-run virtual coworkers
 
 ## Architecture
 
-- **Gateway service** (Node.js) — shared message/command handlers, SQLite persistence (KV + semantic + knowledge graph + canonical sessions + usage events), scheduler, heartbeat, web/API, loopback OpenAI-compatible API, A2A peer trust, board-card storage, and channel integrations for Discord, Discord Incoming Webhooks, Slack, Slack Incoming Webhooks, Signal, Threema, Microsoft Teams, Telegram, iMessage, WhatsApp, Twilio voice, and email
-- **TUI client** — thin client over HTTP (`/api/chat`, `/api/command`) with
-  a structured startup banner that surfaces model, sandbox, gateway, and
-  chatbot context before the first prompt, live delegate status/progress,
-  an interactive approval picker for pending approvals, and an exit summary
-  with a ready-to-run resume command
-- **Container** (Docker, ephemeral) — HybridAI API client, sandboxed tool executor, native media-generation tools, web/search adapters, and preinstalled browser automation runtime with cursor-aware snapshots for JS-heavy custom UI
-- Communication via file-based IPC (input.json / output.json)
+```text
+User message
+  -> Gateway (HTTP, web chat, TUI, Discord, Slack, email, etc.)
+  -> ContainerInput JSON
+  -> Host or Docker runtime
+  -> Agent loop, tools, approvals, memory, MCP
+  -> ContainerOutput JSON
+  -> Gateway response, session store, audit trail
+```
 
-## Documentation
+Core pieces:
 
-Browse the full manual at
-[hybridaione.github.io/hybridclaw/docs](https://hybridaione.github.io/hybridclaw/docs/).
+- **Gateway service**: command handling, channel transports, REST APIs,
+  scheduler, SQLite persistence, audit, A2A, admin surfaces.
+- **Container runtime**: sandboxed tool execution, provider adapters, browser
+  automation, media/search tooling, file-based IPC.
+- **TUI client**: thin HTTP client for terminal-first operation.
+- **Console**: web chat and admin UI served by the gateway.
 
-- Getting started:
-  [Installation](https://hybridaione.github.io/hybridclaw/docs/getting-started/installation),
-  [Authentication](https://hybridaione.github.io/hybridclaw/docs/getting-started/authentication), and
-  [Quick Start](https://hybridaione.github.io/hybridclaw/docs/getting-started/quickstart)
-- Enterprise deployment:
-  [Runtime Internals](https://hybridaione.github.io/hybridclaw/docs/developer-guide/runtime) and
-  [Architecture](https://hybridaione.github.io/hybridclaw/docs/developer-guide/architecture)
-- Operations:
-  [Remote Access](https://hybridaione.github.io/hybridclaw/docs/guides/remote-access)
-- Security:
-  [SECURITY.md](./SECURITY.md) and [TRUST_MODEL.md](./TRUST_MODEL.md)
-- Migration:
-  [Commands: Migration](https://hybridaione.github.io/hybridclaw/docs/reference/commands#migration) and
-  [FAQ](https://hybridaione.github.io/hybridclaw/docs/reference/faq#can-i-migrate-an-existing-openclaw-or-hermes-agent-home)
-- Channels:
-  [Connect Your First Channel](https://hybridaione.github.io/hybridclaw/docs/getting-started/first-channel),
-  [Overview](https://hybridaione.github.io/hybridclaw/docs/channels/overview),
-  [Twilio Voice](https://hybridaione.github.io/hybridclaw/docs/guides/twilio-voice),
-  [Discord](https://hybridaione.github.io/hybridclaw/docs/channels/discord),
-  [Discord Incoming Webhook](https://hybridaione.github.io/hybridclaw/docs/channels/discord-webhook),
-  [Slack](https://hybridaione.github.io/hybridclaw/docs/channels/slack),
-  [Slack Incoming Webhook](https://hybridaione.github.io/hybridclaw/docs/channels/slack-webhook),
-  [Telegram](https://hybridaione.github.io/hybridclaw/docs/channels/telegram),
-  [Signal](https://hybridaione.github.io/hybridclaw/docs/channels/signal),
-  [Threema](https://hybridaione.github.io/hybridclaw/docs/channels/threema),
-  [Email](https://hybridaione.github.io/hybridclaw/docs/channels/email),
-  [WhatsApp](https://hybridaione.github.io/hybridclaw/docs/channels/whatsapp),
-  [iMessage](https://hybridaione.github.io/hybridclaw/docs/channels/imessage), and
-  [Microsoft Teams](https://hybridaione.github.io/hybridclaw/docs/channels/msteams)
-- Tutorials:
-  [Practical Workflows](https://hybridaione.github.io/hybridclaw/docs/tutorials) for owner,
-  GTM, marketing, sales, DevRel, content, invoicing, webinar, and release
-  launch workflows
-- Skills and plugins:
-  [Extensibility](https://hybridaione.github.io/hybridclaw/docs/extensibility),
-  [Bundled Skills](https://hybridaione.github.io/hybridclaw/docs/guides/bundled-skills),
-  [Plugin System](https://hybridaione.github.io/hybridclaw/docs/extensibility/plugins),
-  [Memory Plugins](https://hybridaione.github.io/hybridclaw/docs/extensibility/memory-plugins),
-  [ByteRover Memory Plugin](https://hybridaione.github.io/hybridclaw/docs/extensibility/byterover-memory-plugin),
-  [GBrain Plugin](https://hybridaione.github.io/hybridclaw/docs/extensibility/gbrain-plugin),
-  [Mem0 Memory Plugin](https://hybridaione.github.io/hybridclaw/docs/extensibility/mem0-memory-plugin),
-  [Honcho Memory Plugin](https://hybridaione.github.io/hybridclaw/docs/extensibility/honcho-memory-plugin), and
-  [MemPalace Memory Plugin](https://hybridaione.github.io/hybridclaw/docs/extensibility/mempalace-memory-plugin)
-- Configuration:
-  [Configuration Reference](https://hybridaione.github.io/hybridclaw/docs/reference/configuration)
-- CLI reference:
-  [Commands](https://hybridaione.github.io/hybridclaw/docs/reference/commands),
-  [Diagnostics](https://hybridaione.github.io/hybridclaw/docs/reference/diagnostics), and
-  [FAQ](https://hybridaione.github.io/hybridclaw/docs/reference/faq)
+## Docs By Goal
 
-## Contributing
+| Goal | Start here |
+| --- | --- |
+| Install and launch | [Quick Start](https://hybridaione.github.io/hybridclaw/docs/getting-started/quickstart), [Installation](https://hybridaione.github.io/hybridclaw/docs/getting-started/installation) |
+| Configure providers and models | [Authentication](https://hybridaione.github.io/hybridclaw/docs/getting-started/authentication), [Model Selection](https://hybridaione.github.io/hybridclaw/docs/reference/model-selection) |
+| Connect channels | [Connect Your First Channel](https://hybridaione.github.io/hybridclaw/docs/getting-started/first-channel), [Channels](https://hybridaione.github.io/hybridclaw/docs/channels/overview) |
+| Use bundled skills | [Bundled Skills](https://hybridaione.github.io/hybridclaw/docs/guides/bundled-skills), [Skills Catalog](https://hybridaione.github.io/hybridclaw/docs/guides/skills/) |
+| Distill a coworker | [Human Distillation](https://hybridaione.github.io/hybridclaw/docs/guides/human-distillation) |
+| Operate securely | [Security](./SECURITY.md), [Trust Model](./TRUST_MODEL.md), [Approvals](https://hybridaione.github.io/hybridclaw/docs/developer-guide/approvals) |
+| Inspect commands | [Commands](https://hybridaione.github.io/hybridclaw/docs/reference/commands), [Diagnostics](https://hybridaione.github.io/hybridclaw/docs/reference/diagnostics) |
+| Extend HybridClaw | [Extensibility](https://hybridaione.github.io/hybridclaw/docs/extensibility), [Plugins](https://hybridaione.github.io/hybridclaw/docs/extensibility/plugins), [MCP](https://hybridaione.github.io/hybridclaw/docs/guides/tui-mcp) |
+| Build desktop releases | [Desktop Release Builds](https://hybridaione.github.io/hybridclaw/docs/developer-guide/desktop-release) |
+| Contribute | [CONTRIBUTING.md](./CONTRIBUTING.md), [docs/content/README.md](./docs/content/README.md) |
 
-Contributor quick start:
+Release notes: [CHANGELOG.md](./CHANGELOG.md)
+
+## Development
 
 ```bash
 npm install
@@ -469,12 +223,18 @@ npm run typecheck
 npm run test:unit
 ```
 
-Use `npm run typecheck`, `npm run lint`, and targeted tests for code changes.
-For docs-only changes, verify links, commands, and examples. GitHub issue forms
-cover bug reports, setup help, feature requests, and docs fixes, and the PR
-template asks for validation and scope boundaries up front. See
-[CONTRIBUTING.md](./CONTRIBUTING.md) for the full workflow, check matrix, and
-community guidance.
+Useful dev commands:
+
+```bash
+npm run dev          # gateway in hot-reload mode
+npm run tui          # terminal client
+npm run check        # Biome check
+npm run format       # Biome write
+```
+
+For docs-only changes, verify links, commands, and examples. For code changes,
+run `npm run typecheck`, `npm run lint`, and targeted tests for the touched
+area.
 
 ## Community
 

--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hybridaione/hybridclaw-console",
   "private": true,
-  "version": "0.23.0",
+  "version": "0.24.0",
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && vite build",

--- a/container/npm-shrinkwrap.json
+++ b/container/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hybridclaw-agent",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
         "@mozilla/readability": "0.6.0",

--- a/container/package-lock.json
+++ b/container/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hybridclaw-agent",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
         "@mozilla/readability": "0.6.0",

--- a/container/package.json
+++ b/container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "type": "module",
   "main": "dist/index.js",
   "packageManager": "npm@11.10.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@hybridaione/hybridclaw-desktop",
   "productName": "HybridClaw",
   "private": true,
-  "version": "0.23.0",
+  "version": "0.24.0",
   "type": "module",
   "description": "macOS wrapper for the HybridClaw chat and admin web surfaces",
   "author": "HybridAI One",

--- a/docs/content/README.md
+++ b/docs/content/README.md
@@ -27,6 +27,15 @@ doc at once, start from [For Agents](./agents.md).
 
 ## Latest Highlights
 
+- HybridAI Cloud launches hosted HybridClaw environments from
+  [hybridclaw.io](https://hybridclaw.io) when teams want the fastest managed
+  path instead of preparing local infrastructure first.
+- Multi-agent workflows span local agents, hosted HybridAI proxy agents, and
+  trusted peer HybridClaw instances through explicit addressing, A2A pairing,
+  inbound envelopes, and admin-visible trust.
+- Encrypted runtime secrets and SecretRefs keep raw credentials out of model
+  context; tools receive scoped credential material at execution time instead
+  of asking the LLM to handle API keys or passwords.
 - Native `image_generate` and `video_generate` tools produce managed media
   artifacts through configured image and video providers.
 - Bundled skills cover Airtable, FastBill, Firecrawl, Fronius, HeyGen,
@@ -34,7 +43,15 @@ doc at once, start from [For Agents](./agents.md).
 - Threema Gateway Basic mode is available for outbound operator messaging in
   DACH-regulated or privacy-sensitive deployments.
 - A2A federation includes JSON-RPC Agent Card inbound delivery, signed
-  delegation bearer tokens, and a public-key trust ledger.
+  delegation bearer tokens, operator pairing, and a public-key trust ledger.
+- Human distillation turns consented source material into cited coworker-agent
+  personas with reversible merges, leakage/fidelity evals, and multi-host
+  export bundles.
+- Named local endpoints let operators run multiple Ollama, LM Studio,
+  llama.cpp, or vLLM servers side by side, including Qwen and Gemma behavior
+  hints for local models.
+- HybridAI proxy agents forward selected agents to hosted HybridAI chatbots
+  while keeping gateway channel routing and SecretRef-backed upstream auth.
 - Browser automation supports local Playwright profiles, Camofox profiles, and
   Browser Use Cloud sessions with SecretRef-gated credential fills.
 - Trace-judge eval gates and behavioral anomaly reranking give tool-call and
@@ -59,6 +76,9 @@ doc at once, start from [For Agents](./agents.md).
   portals, Google Ads, cloud providers, and DATEV handoff flows.
 - The `warehouse-sql` skill reviews and runs read-only natural-language SQL
   against cached warehouse schemas.
+- The `mailchimp` skill covers Mailchimp Marketing audiences, campaigns,
+  reports, automations, journeys, and Transactional/Mandrill sends with
+  approval-gated writes.
 - Signal joins the channel catalog with a full `signal-cli` daemon setup guide,
   private-by-default DM policy, group controls, and admin QR linking.
 - `.confidential.yml` rules can redact NDA-class business data before model
@@ -102,6 +122,8 @@ doc at once, start from [For Agents](./agents.md).
 
 ## Fast Paths
 
+- Want the fastest managed launch? Start at
+  [hybridclaw.io](https://hybridclaw.io).
 - Need to install HybridClaw quickly? Go to
   [Installation](./getting-started/installation.md).
 - Need the shortest path to a running gateway and chat UI? Go to

--- a/docs/content/channels/admin-console.md
+++ b/docs/content/channels/admin-console.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Console
-description: Manage channels, agents, approvals, config, secrets, output guard, audit, jobs, and browser-based operator workflows from /admin.
+description: Manage channels, agents, human distillation, approvals, config, secrets, output guard, audit, jobs, and browser-based operator workflows from /admin.
 sidebar_position: 10
 ---
 
@@ -12,6 +12,8 @@ instead of the CLI. The channel setup page lives at `/admin/channels`, and the
 agent prompt-file editor lives at `/admin/agents`. The approvals page at
 `/admin/approvals` shows live pending approvals and lets operators add, edit,
 and delete the current workspace network policy rules for a selected agent.
+The human distillation page at `/admin/distill` manages subjects, consent,
+corpus documents, source uploads, and distillation runs.
 The A2A inbox at `/admin/a2a-inbox` shows instance-wide agent-to-agent message threads and uses the same web-console authentication as the rest of `/admin`: `WEB_API_TOKEN` when configured, or loopback-only local web access.
 The fleet page at `/admin/fleet-topology` shows the local A2A instance identity
 and trusted child instances from the A2A trust ledger. The A2A trust page at
@@ -44,6 +46,9 @@ pairing requests.
   restore an earlier version without opening the workspace directory manually
 - `/admin/agents` lists synced installation- and company-scoped cloud memory under a separate "Shared memory" group as read-only cache views without save or revision actions
 - `/admin/agents` also shows org-chart/team-structure revisions, per-revision diffs, and a restore action for rolling back role, reporting, delegation, and peer relationships
+- `/admin/distill` creates distillation subjects, records consent artefacts,
+  registers or uploads source material, manages corpus documents, starts runs,
+  and opens generated run reports
 - `/admin/approvals` shows unresolved approval prompts across sessions and the
   selected agent workspace's current `policy.yaml` network rules in one place
 - `/admin/approvals` can add, edit, and delete network rules without switching
@@ -98,6 +103,8 @@ pairing requests.
 - the web chat route shares the admin shell, supports improved session
   management, preserves scroll position while reading older messages, and
   renders assistant message blocks with better structured content handling
+- the web chat route supports explicit agent addressing with autocomplete,
+  avatar-backed mention pills, and stable addressed-agent routing
 - the web chat route renders slash-command results distinctly and lets
   operators apply persisted thumbs-up/down ratings to assistant responses
 - the web chat route syntax-highlights completed code blocks, shows language
@@ -126,6 +133,8 @@ scoped to the built-in allowlist and is not a general workspace file browser.
 - you want to inspect or roll back agent org-chart changes from the browser
 - you want to compare all agents, models, budgets, and prompt metadata from a
   single overview page
+- you want to distill a consented coworker agent from source material without
+  stitching CLI commands together by hand
 - you want to inspect pending approvals and compare them with the declarative
   network policy without switching to `/chat` or opening the workspace files
 - you want to add, edit, or remove network policy rules from the browser

--- a/docs/content/developer-guide/README.md
+++ b/docs/content/developer-guide/README.md
@@ -26,3 +26,5 @@ These pages focus on how HybridClaw is built and operated under the hood.
 - [Workflows](./workflows.md) for declarative YAML workflow schema and validation rules
 - [Harness Evolution](./harness-evolution.md) for eval-driven coworker
   workspace evolution loops, example suites, and admin inspection
+- [Desktop Release Builds](./desktop-release.md) for signed macOS Electron
+  packaging, notarization, and GitHub Release uploads

--- a/docs/content/developer-guide/desktop-release.md
+++ b/docs/content/developer-guide/desktop-release.md
@@ -1,0 +1,199 @@
+---
+title: Desktop Release Builds
+description: Build, sign, notarize, and upload the macOS Electron desktop wrapper.
+sidebar_position: 9
+---
+
+# Desktop Release Builds
+
+HybridClaw's desktop app is an Electron wrapper around the existing `/chat`,
+`/agents`, and `/admin` gateway surfaces. The release build bundles the
+compiled gateway, console, container runtime files, production dependencies,
+and a Node.js runtime into the app package.
+
+The current desktop packaging flow builds signed macOS app artifacts when
+`electron-builder` can find a valid signing identity. Notarization is not wired
+as an automatic build hook yet, so maintainers should notarize and staple the
+DMG explicitly before uploading it to GitHub Releases.
+
+## Prerequisites
+
+- macOS build host for DMG creation and Apple notarization.
+- Node.js 22 and npm 11.10+.
+- Xcode Command Line Tools: `xcode-select --install`.
+- A clean release checkout at the tag or release commit.
+- Installed root and container dependencies.
+- Apple Developer Program access with a `Developer ID Application` certificate.
+- GitHub CLI authenticated with permission to edit releases.
+
+For local keychain signing, install the certificate in the login keychain.
+For CI or an isolated build host, provide the certificate through
+`electron-builder` code-signing environment variables:
+
+```bash
+export CSC_LINK="/absolute/path/to/developer-id-application.p12"
+export CSC_KEY_PASSWORD="<p12 password>"
+```
+
+If the build host has multiple signing identities, set `CSC_NAME` to the exact
+`Developer ID Application: ...` identity. Do not publish artifacts built with
+`CSC_IDENTITY_AUTO_DISCOVERY=false` or ad-hoc signing.
+
+For notarization with `notarytool`, provide:
+
+```bash
+export APPLE_ID="apple-id@example.com"
+export APPLE_TEAM_ID="TEAMID12345"
+export APPLE_APP_SPECIFIC_PASSWORD="<app-specific password>"
+```
+
+Use an app-specific password or an equivalent keychain profile. Do not commit
+these values or store them in release notes.
+
+## Release Order
+
+Do not publish the public GitHub Release first and then start building the
+desktop app. The safer order is:
+
+1. Finalize the release commit with version, changelog, README, and docs.
+2. Create the annotated version tag and make sure the desktop build host is
+   building from that exact tag or commit.
+3. Build, sign, notarize, staple, and verify the macOS artifacts.
+4. Create the GitHub Release as a draft if the release entry is needed before
+   asset upload.
+5. Upload the DMG, ZIP, and blockmap to the same version tag.
+6. Publish the GitHub Release only after the npm/package release notes and
+   desktop assets are all present and verified.
+
+This keeps the public release page from advertising a version before the
+signed desktop artifact is attached. If a release has already been published,
+upload the desktop assets to that same tag rather than creating a second
+desktop-only release.
+
+## Build
+
+From the repository root:
+
+```bash
+npm ci
+npm --prefix container ci
+npm run version:check
+npm run typecheck
+npm run test:unit
+npm run desktop:mac
+```
+
+`npm run desktop:mac` runs the root build first, then the desktop workspace
+build. The desktop build stages runtime dependencies, packages the app with
+`electron-builder --mac dir zip`, and creates a custom DMG with
+`desktop/scripts/build-dmg.mjs`.
+
+Expected outputs are under `desktop/release/`:
+
+```text
+desktop/release/mac-arm64/HybridClaw.app
+desktop/release/HybridClaw-<version>-arm64.dmg
+desktop/release/HybridClaw-<version>-arm64-mac.zip
+desktop/release/HybridClaw-<version>-arm64-mac.zip.blockmap
+```
+
+The architecture follows the build host unless you explicitly run a different
+`electron-builder` architecture target. Build Apple Silicon artifacts on an
+arm64 Mac. If an Intel artifact is needed, build it on an x64 Mac or add an
+explicit x64 packaging step and verify the resulting `mac-x64` output before
+release.
+
+## Verify Signing
+
+Check the packaged app before notarization:
+
+```bash
+codesign --verify --deep --strict --verbose=2 \
+  desktop/release/mac-arm64/HybridClaw.app
+
+spctl --assess --type execute --verbose=4 \
+  desktop/release/mac-arm64/HybridClaw.app
+```
+
+`codesign` must report a valid signature. `spctl` can still reject the app
+before notarization; that is expected. If `codesign` shows ad-hoc signing or no
+Developer ID identity, stop and rebuild with the correct certificate.
+
+## Notarize And Staple
+
+Set the release version once to avoid uploading the wrong file:
+
+```bash
+VERSION="$(node -p "require('./desktop/package.json').version")"
+DMG="desktop/release/HybridClaw-${VERSION}-arm64.dmg"
+```
+
+Submit the DMG to Apple and wait for the result:
+
+```bash
+xcrun notarytool submit "$DMG" \
+  --apple-id "$APPLE_ID" \
+  --team-id "$APPLE_TEAM_ID" \
+  --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+  --wait
+```
+
+Staple the notarization ticket:
+
+```bash
+xcrun stapler staple "$DMG"
+xcrun stapler validate "$DMG"
+spctl --assess --type open --verbose=4 "$DMG"
+```
+
+For a final user-flow check, copy the DMG to a clean macOS account or VM,
+mount it, drag `HybridClaw.app` to `/Applications`, launch it, and verify that
+the bundled gateway opens the chat surface.
+
+## Upload To GitHub Releases
+
+Desktop artifacts belong on the GitHub Release for the same version tag as the
+npm package. Prefer a draft release while assets are still being prepared:
+
+```bash
+TAG="v${VERSION}"
+
+gh release create "$TAG" \
+  --draft \
+  --verify-tag \
+  --title "HybridClaw ${TAG}" \
+  --notes-file /path/to/curated-release-notes.md
+
+gh release upload "$TAG" \
+  "$DMG" \
+  "desktop/release/HybridClaw-${VERSION}-arm64-mac.zip" \
+  "desktop/release/HybridClaw-${VERSION}-arm64-mac.zip.blockmap"
+
+gh release view "$TAG"
+gh release edit "$TAG" --draft=false --latest
+```
+
+Use `--clobber` only when intentionally replacing an asset after a failed or
+incorrect upload:
+
+```bash
+gh release upload "$TAG" "$DMG" --clobber
+```
+
+After upload, confirm the public asset list:
+
+```bash
+gh release view "$TAG" --web
+```
+
+## README And Docs Links
+
+User-facing install links should point at the latest release page rather than a
+hardcoded asset name:
+
+```text
+https://github.com/HybridAIOne/hybridclaw/releases/latest
+```
+
+Use hardcoded asset links only in a specific release note after the artifact is
+uploaded, because asset filenames include the version and architecture.

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -6,6 +6,17 @@ sidebar_position: 2
 
 # Installation
 
+## Launch On HybridAI Cloud
+
+The fastest managed path is the HybridAI Cloud offering for HybridClaw:
+
+```text
+https://hybridclaw.io
+```
+
+Use it when you want a hosted HybridClaw environment running in a few minutes
+without preparing a local Node.js, npm, or Docker setup first.
+
 ## Install With the One-Line Script
 
 The quickest path on Linux and macOS is the bootstrap installer. It ensures a
@@ -129,6 +140,23 @@ brew install hybridclaw
 ```
 
 Until then, most macOS users should stick to npm or the Nix flake.
+
+## Install The macOS Desktop App
+
+Signed macOS desktop builds are distributed as GitHub Release assets when a
+desktop artifact is published for a version:
+
+```text
+https://github.com/HybridAIOne/hybridclaw/releases/latest
+```
+
+Download the `HybridClaw-<version>-<arch>.dmg` asset for your Mac, open it,
+and drag `HybridClaw.app` into `/Applications`.
+
+The desktop app is a native wrapper around the same local gateway, chat, agents,
+and admin surfaces. From a source checkout, use `npm run desktop` instead. For
+maintainer packaging, signing, notarization, and upload steps, see
+[Desktop Release Builds](../developer-guide/desktop-release.md).
 
 ## Install From a Source Checkout
 

--- a/docs/content/guides/README.md
+++ b/docs/content/guides/README.md
@@ -18,6 +18,8 @@ These pages focus on common operator workflows after the base install works.
 - [TUI MCP Quickstart](./tui-mcp.md) for host-mode MCP server setup
 - [Bundled Skills](./bundled-skills.md) for notable built-in skills and
   install helpers
+- [Human Distillation](./human-distillation.md) for consent-gated coworker
+  synthesis from source material
 - [Hatching Task Ideas](./hatching-task-ideas.md) for first-run questions and starter jobs tailored to the user's tools and goals
 - [Twilio Voice](./twilio-voice.md) for phone-channel setup, public webhook
   exposure, testing, and troubleshooting

--- a/docs/content/guides/bundled-skills.md
+++ b/docs/content/guides/bundled-skills.md
@@ -6,12 +6,18 @@ sidebar_position: 4
 
 # Bundled Skills
 
-HybridClaw ships with 74 bundled skills. A few notable categories:
+HybridClaw ships with 76 bundled skills. The production business skills are
+implemented as helper-backed workflows with targeted tests, eval scenarios,
+credential boundaries, and approval tiers. `Qwen/Qwen3.6-27B-FP8` is the
+small-model validation baseline for the business-skill path, so the catalog is
+optimized for practical work on compact models instead of prompt-only demos.
+
+A few notable categories:
 
 - office workflows: `pdf`, `xlsx`, `docx`, `pptx`, `office-workflows`
-- planning and engineering: `project-manager`, `feature-planning`, `code-review`, `code-simplification`, `gh-issues`, `warehouse-sql`
+- planning, coworker creation, and engineering: `project-manager`, `feature-planning`, `human-distill`, `code-review`, `code-simplification`, `gh-issues`, `warehouse-sql`
 - visual explainers, image, video, and speech: `diagram`, `manim-video`, `excalidraw`, `image-generation`, `video-generation`, `video.from-script`, `speech.transcribe`, `speech.detect-language`
-- platform integrations: `github-pr-workflow`, `notion`, `trello`, `stripe`, `download-platform-invoices`, `wordpress`, `gog`, `google-workspace`, `google-ads`, `ga4`, `airtable`, `fastbill`, `hubspot`, `lexware-office`, `firecrawl`, `heygen`, `hermes3000-writing`, `discord`
+- platform integrations: `github-pr-workflow`, `notion`, `trello`, `stripe`, `mailchimp`, `download-platform-invoices`, `wordpress`, `gog`, `google-workspace`, `google-ads`, `ga4`, `airtable`, `fastbill`, `hubspot`, `lexware-office`, `firecrawl`, `heygen`, `hermes3000-writing`, `discord`
 - infrastructure, production ops, home automation, and energy monitoring: `hetzner-cloud`, `hetzner-dns`, `hetzner-storage-box`, `mittwald`, `t-cloud-public`, `zabbix`, `shelly`, `homematic`, `fronius`, `byd-battery`, `alexa`, `blink`, `hue`, `warehouse-sql`
 - security and privacy: `distil-pii-redactor`
 - knowledge workflows: `llm-wiki`, `obsidian`, `zettelkasten`

--- a/docs/content/guides/human-distillation.md
+++ b/docs/content/guides/human-distillation.md
@@ -109,5 +109,7 @@ bundle into a fresh agent workspace without re-distillation.
 
 ## See also
 
-- The bundled [`human-distill` skill](../extensibility/skills.md) drives the agent half of the pipeline: intake, interviews, mirroring sessions, and writing the extraction contract.
+- The bundled [`human-distill` skill](./skills/productivity.md#human-distill)
+  drives the agent half of the pipeline: intake, interviews, mirroring
+  sessions, and writing the extraction contract.
 - Roadmap: R72 in `docs/content/internal/roadmap.md`.

--- a/docs/content/guides/local-providers.md
+++ b/docs/content/guides/local-providers.md
@@ -69,6 +69,6 @@ the runtime can reach those local endpoints directly.
 - Interactive onboarding can skip remote-provider auth completely when you plan
   to use a local backend only.
 - For longer agent sessions, `16k` context is a minimum and `32k` is safer.
-- The TUI and Discord model pickers come from the live gateway model list, so
-  restart the gateway after enabling a new backend or loading a different
-  local model.
+- The TUI, web chat, and Discord model pickers come from the live gateway model
+  list, so restart the gateway after enabling a new backend or loading a
+  different local model.

--- a/docs/content/guides/skills/README.md
+++ b/docs/content/guides/skills/README.md
@@ -6,9 +6,15 @@ sidebar_position: 1
 
 # Skills Catalog
 
-HybridClaw ships **73 bundled skills** across ten categories. Each page below
-covers every skill in its category with prerequisites, install commands,
-tips & tricks, ready-to-try example prompts, and troubleshooting.
+HybridClaw ships **76 bundled skills**. The pages below cover the main
+user-facing catalog groups with prerequisites, install commands, tips &
+tricks, ready-to-try example prompts, and troubleshooting.
+
+The strongest part of the catalog is the production business skill set: CRM,
+marketing, analytics, finance, cloud, office, and operations workflows use
+helper scripts, fixtures, eval scenarios, targeted tests, credential
+boundaries, and approval tiers. `Qwen/Qwen3.6-27B-FP8` is the small-model
+validation baseline for that path.
 
 For CLI management commands see [Bundled Skills](../bundled-skills.md); for
 resolution rules and runtime internals see
@@ -35,10 +41,10 @@ For production package requirements see
 | Infrastructure, Production Ops, Smart Home & Energy | hetzner-cloud, hetzner-dns, hetzner-storage-box, mittwald, t-cloud-public, zabbix, shelly, homematic, fronius, byd-battery, alexa, blink, hue | [Development Skills](./development.md#hetzner-devops) |
 | Communication | brand-voice, discord, channel-catchup, fax-send | [Communication Skills](./communication.md) |
 | Apple | apple-calendar, apple-music, apple-passwords | [Apple Skills](./apple.md) |
-| Productivity | feature-planning, project-manager, trello | [Productivity Skills](./productivity.md) |
+| Productivity | feature-planning, human-distill, project-manager, trello | [Productivity Skills](./productivity.md) |
 | Memory & Knowledge | llm-wiki, notion, obsidian, personality, zettelkasten | [Memory & Knowledge Skills](./memory-knowledge.md) |
 | Publishing | diagram, excalidraw, hermes3000-writing, image-generation, manim-video, video-generation, video.from-script, wordpress, write-blog-post | [Publishing Skills](./publishing.md) |
-| Integrations & Utilities | 1password, stripe, download-platform-invoices, airtable, fastbill, hubspot, lexware-office, firecrawl, ga4, google-ads, heygen, sokosumi, gog, google-workspace, current-time, hybridclaw-help, iss-position, search.web, search.news, search.images | [Integrations & Utilities](./integrations.md) |
+| Integrations & Utilities | 1password, stripe, mailchimp, download-platform-invoices, airtable, fastbill, hubspot, lexware-office, firecrawl, ga4, google-ads, heygen, sokosumi, gog, google-workspace, current-time, hybridclaw-help, iss-position, search.web, search.news, search.images | [Integrations & Utilities](./integrations.md) |
 | Security & Privacy | distil-pii-redactor | [Integrations & Utilities](./integrations.md#distil-pii-redactor) |
 
 ## Evaluating Example Prompts

--- a/docs/content/guides/skills/business-skills.md
+++ b/docs/content/guides/skills/business-skills.md
@@ -10,6 +10,13 @@ A business skill is a versioned `SKILL.md` package that declares what work it
 can perform, which credentials it needs, which channels it supports, and how
 operators manage its lifecycle.
 
+Business skills are product workflows, not prompt-only descriptions. A
+production business skill should have deterministic helper commands, fixtures
+or eval scenarios, targeted tests, explicit credential requirements, and
+approval tiers for mutations. `Qwen/Qwen3.6-27B-FP8` is the small-model
+validation baseline: if a workflow only succeeds with frontier-model
+guesswork, tighten the helper surface before shipping it.
+
 ## Package Layout
 
 Use one directory per skill:
@@ -71,6 +78,22 @@ Required fields for business packages:
 
 `web` is normalized to `tui` for local browser sessions. Unknown channels are
 ignored.
+
+## Validation Standard
+
+Production business skills should include:
+
+- a helper command that exposes deterministic plans or actions
+- offline fixtures for representative read and mutation workflows
+- an `eval-scenarios` surface or equivalent scenario file
+- targeted tests for helper parsing, safety tiers, credential declarations,
+  and scenario coverage
+- approval-grant requirements for amber or red mutations
+- small-model validation against `Qwen/Qwen3.6-27B-FP8`
+
+The goal is to keep the model responsible for intent and judgment while helper
+code owns API shape, request validation, redaction, cost accounting, and
+guarded side effects.
 
 ## Lifecycle Commands
 

--- a/docs/content/guides/skills/integrations.md
+++ b/docs/content/guides/skills/integrations.md
@@ -1,6 +1,6 @@
 ---
 title: Integrations & Utilities
-description: 1Password, Stripe, Google Ads, GA4, Firecrawl, Sokosumi, Google Workspace, and utility skills.
+description: 1Password, Stripe, Mailchimp, Google Ads, GA4, Firecrawl, Sokosumi, Google Workspace, and utility skills.
 sidebar_position: 9
 ---
 
@@ -93,6 +93,52 @@ keys as environment variables.
 - **CLI not authenticated** — run `stripe login` to connect your account.
 - **"No such customer"** — you may be looking in test mode while the customer
   is in live mode (or vice versa). Confirm with `stripe config --list`.
+
+---
+
+## mailchimp
+
+Operate Mailchimp Marketing audiences, campaigns, reports, automations,
+journeys, and Mailchimp Transactional/Mandrill email through SecretRef-backed
+gateway requests.
+
+**Prerequisites** — Mailchimp Marketing API credentials and data-center prefix
+for Marketing API work; a Transactional/Mandrill API key for transactional
+email workflows.
+
+```bash
+hybridclaw secret set MAILCHIMP_MARKETING_BASIC_AUTH "<base64-user-colon-api-key>"
+hybridclaw env set MAILCHIMP_SERVER_PREFIX us21
+hybridclaw secret set MANDRILL_API_KEY "<mandrill-api-key>"
+```
+
+> 💡 **Tips & Tricks**
+>
+> Start with credential checks and read-only audience, campaign, report, automation, or journey queries before planning writes.
+>
+> Use OAuth metadata when setup uses `MAILCHIMP_MARKETING_OAUTH_TOKEN`; it returns the account-specific API endpoint and data-center prefix.
+>
+> Audience mutations, bulk plans, campaign schedule/send, and Mandrill sends require an approval plan and explicit operator approval.
+>
+> Keep subscriber PII out of summaries where possible; use subscriber hashes for lookup and archive/tag operations when practical.
+
+> 🎯 **Try it yourself**
+>
+> `Check whether Mailchimp Marketing credentials are configured and list my audiences`
+>
+> `Summarize the last campaign report and call out opens, clicks, unsubscribes, and bounces`
+>
+> `Prepare an approval plan to tag these subscribers as newsletter:active without executing it`
+>
+> `Review the journey configuration for our onboarding automation`
+
+**Troubleshooting**
+
+- **401 or 403** — verify the API token, user role, Transactional
+  provisioning, and `MAILCHIMP_SERVER_PREFIX`.
+- **429** — report the upstream rate-limit guidance and avoid retry loops.
+- **Credential uncertainty** — use the helper's `credential-check` path rather
+  than inspecting local files or environment variables from the agent sandbox.
 
 ---
 

--- a/docs/content/guides/skills/productivity.md
+++ b/docs/content/guides/skills/productivity.md
@@ -1,6 +1,6 @@
 ---
 title: Productivity Skills
-description: Feature planning, project management, and Trello board integration.
+description: Feature planning, human distillation, project management, and Trello board integration.
 sidebar_position: 6
 ---
 
@@ -36,6 +36,53 @@ tasks.
 > `1. Plan the implementation of a webhook delivery system with retry logic and dead-letter queue`
 > `2. The retry backoff strategy — break that subtask down further with exact acceptance criteria and edge cases`
 > `3. What's the riskiest part of this plan and what should we prototype first?`
+
+---
+
+## human-distill
+
+Distill a real person's source material into a coworker agent with consent
+gating, cited claims, reversible merges, leakage/fidelity evals, and
+multi-host export.
+
+**Prerequisites** — source material owned or approved for this use, plus a
+recorded consent artefact before distilling a real, named human.
+
+```bash
+hybridclaw coworker consent record --alias maya \
+  --granted-by "Maya Lindqvist" --method written \
+  --statement "I consent to HybridClaw distilling my work communications into a coworker agent."
+
+hybridclaw coworker distill --alias maya --name "Maya Lindqvist" \
+  --source ./slack-export --source ./maya-mail.mbox
+```
+
+> 💡 **Tips & Tricks**
+>
+> The deterministic engine is `hybridclaw coworker`; the `human-distill` skill drives intake, extraction, interviews, and mirroring.
+>
+> Every persona claim must cite corpus document ids. Unsupported claims are flagged into the run report instead of written into identity files.
+>
+> Use `hybridclaw coworker eval --alias <alias>` before assigning real work to a distilled coworker.
+
+> 🎯 **Try it yourself**
+>
+> `Help me prepare a consent-gated distillation run for Maya from this Slack export and mbox file`
+>
+> `Review this distillation analysis packet and write extraction.json with cited claims only`
+>
+> `Run the coworker leakage/fidelity eval and summarize any blockers`
+
+**Troubleshooting**
+
+- **Consent missing** — record consent first; the pipeline blocks real-person
+  distillation without it.
+- **Uncited claims** — remove the claim or cite a real corpus document id from
+  the analysis packet.
+- **PII leakage** — stop and run the eval; fix generated files before using
+  the coworker.
+
+See [Human Distillation](../human-distillation.md) for the full workflow.
 
 ---
 

--- a/docs/content/reference/commands.md
+++ b/docs/content/reference/commands.md
@@ -404,6 +404,12 @@ imports `imageAsset` URLs or local file paths into the agent workspace:
 hybridclaw agent config '{"id":"felix","model":"gpt-5.4-mini","imageAsset":"https://example.com/felix.jpg","markdown":{"IDENTITY.md":"# Felix\n"}}' --activate
 ```
 
+Proxy agents use the same command with a per-agent `proxy` object:
+
+```bash
+hybridclaw agent config '{"id":"support-proxy","name":"Support Proxy","proxy":{"kind":"hybridai","baseUrl":"https://app.hybridai.one","chatbotId":"bot_abc123","apiKey":"<secret:HYBRIDAI_API_KEY>","conversationScope":"user"}}'
+```
+
 Use `agent config` for metadata plus bootstrap markdown. Use `agent install`
 when you need a portable `.claw` archive with arbitrary workspace files,
 bundled skills, bundled plugins, or install-time imports.

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -162,6 +162,10 @@ saved revision history directly.
   an immediate local consolidation run
 - `agents.defaultAgentId` for the default agent used by new requests and fresh
   web sessions when no agent is pinned explicitly
+- `agents.list[].proxy` for agents that forward their turns to a hosted
+  HybridAI chatbot instead of running the local agent loop. Proxy agents
+  require `kind: "hybridai"`, an HTTPS `baseUrl`, `chatbotId`, and a
+  SecretRef-backed `apiKey`; `conversationScope` can be `channel` or `user`.
 - `agents.list[].webSearch.searxngBaseUrl` and
   `agents.list[].webSearch.searxngBearerTokenRef` override the global SearXNG
   instance and bearer SecretRef for a specific agent
@@ -387,6 +391,10 @@ For the local speech and fallback workflow, see
 ## Secrets And Trust
 
 Keep runtime secrets in the encrypted `~/.hybridclaw/credentials.json` store.
+When a tool or channel uses a SecretRef, the model sees the requested action,
+secret name, and approval context, not the raw credential value. The gateway
+resolves the secret at the execution boundary and injects it only into the
+scoped request or channel adapter that needs it.
 Common built-in entries include `HYBRIDAI_API_KEY`, `OPENROUTER_API_KEY`,
 `ANTHROPIC_API_KEY`, `MISTRAL_API_KEY`, `HF_TOKEN`, `OPENAI_API_KEY`,
 `GROQ_API_KEY`, `DEEPGRAM_API_KEY`, `GEMINI_API_KEY`, `GOOGLE_API_KEY`,

--- a/docs/content/reference/model-selection.md
+++ b/docs/content/reference/model-selection.md
@@ -22,7 +22,9 @@ Model prefixes:
 - DashScope / Qwen models use `dashscope/`
 - Xiaomi MiMo models use `xiaomi/`
 - Kilo Code models use `kilo/`
-- local backends use prefixes such as `ollama/`, `lmstudio/`, and `vllm/`
+- local backends use prefixes such as `ollama/`, `lmstudio/`, and `vllm/`;
+  named local endpoints use their configured endpoint name as the prefix, for
+  example `haigpu2/google/gemma-4-e4b-it`
 
 The shipped default Codex model is `openai-codex/gpt-5-codex`.
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hybridaione/hybridclaw",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "hasInstallScript": true,
       "workspaces": [
         "desktop",
@@ -83,7 +83,7 @@
     },
     "console": {
       "name": "@hybridaione/hybridclaw-console",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "dependencies": {
         "@tanstack/react-query": "5.101.0",
         "@tanstack/react-router": "1.170.11",
@@ -108,7 +108,7 @@
     },
     "container": {
       "name": "hybridclaw-agent",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
         "@mozilla/readability": "0.6.0",
@@ -412,7 +412,7 @@
     },
     "desktop": {
       "name": "@hybridaione/hybridclaw-desktop",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "dependencies": {
         "@hybridaione/hybridclaw-desktop-packaging-anchor": "file:./support/packaging-anchor"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hybridaione/hybridclaw",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "hasInstallScript": true,
       "workspaces": [
         "desktop",
@@ -83,7 +83,7 @@
     },
     "console": {
       "name": "@hybridaione/hybridclaw-console",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "dependencies": {
         "@tanstack/react-query": "5.101.0",
         "@tanstack/react-router": "1.170.11",
@@ -108,7 +108,7 @@
     },
     "container": {
       "name": "hybridclaw-agent",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
         "@mozilla/readability": "0.6.0",
@@ -412,7 +412,7 @@
     },
     "desktop": {
       "name": "@hybridaione/hybridclaw-desktop",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "dependencies": {
         "@hybridaione/hybridclaw-desktop-packaging-anchor": "file:./support/packaging-anchor"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "type": "module",
   "description": "Enterprise-ready self-hosted AI assistant runtime with sandboxed execution, secure credentials, approvals, and memory",
   "repository": {

--- a/scripts/dependency-policy-baseline.json
+++ b/scripts/dependency-policy-baseline.json
@@ -1,9 +1,9 @@
 {
   "lockfiles": {
-    "package-lock.json": "81af06f1fb148696d9f25e85855830ff8308758ad4e366b283bd7b413544b9cd",
-    "npm-shrinkwrap.json": "81af06f1fb148696d9f25e85855830ff8308758ad4e366b283bd7b413544b9cd",
-    "container/package-lock.json": "4f69cef8803e53c29fb25480f964db1da21741cc9eb4707424c4bc9920226e71",
-    "container/npm-shrinkwrap.json": "4f69cef8803e53c29fb25480f964db1da21741cc9eb4707424c4bc9920226e71",
+    "package-lock.json": "d6d26e088dbb26c81c6c29796df899678951312dca402ef4a52318aeda49ad34",
+    "npm-shrinkwrap.json": "d6d26e088dbb26c81c6c29796df899678951312dca402ef4a52318aeda49ad34",
+    "container/package-lock.json": "b1965a0851d9fbf80efb095fbf546dc7e4f046f7013d18867a64eca40cbf3654",
+    "container/npm-shrinkwrap.json": "b1965a0851d9fbf80efb095fbf546dc7e4f046f7013d18867a64eca40cbf3654",
     "plugins/brevo-email/package-lock.json": "3377225eb3bdbb252eaa28ad420b9a725ea1da533417388557aa1984730229b5"
   }
 }


### PR DESCRIPTION
## What changed

- Bumped HybridClaw package metadata to 0.24.0 across root, console, desktop, container, lockfiles, and shrinkwraps.
- Curated CHANGELOG.md for the 0.24.0 minor release based on changes since v0.23.0.
- Reworked README.md into a cleaner GitHub start page focused on the main USPs: validated business skills on Qwen/Qwen3.6-27B-FP8, multi-agent/A2A workflows, encrypted SecretRef credential handling, and the HybridAI Cloud launch path.
- Updated docs for HybridAI Cloud, skills positioning, business-skill validation, proxy agents, explicit agent addressing, named local endpoints, Mailchimp, human distillation, and desktop release packaging.
- Added a macOS Electron desktop release guide covering signed builds, notarization, GitHub Release asset upload, and release order.

## Why

This prepares the next minor release while moving exhaustive README detail back behind docs links, making the repository front page easier to scan and more strongly differentiated against Hermes/OpenClaw-style agent runtimes.

## Validation

- npm run format
- npm run check
- git diff --check
- npm run typecheck
- npm run release:check
- npm --prefix container run release:check

I also ran npm run test:unit locally. It reached 510 passing test files and failed one unrelated local test in tests/gateway-service.audit.test.ts with ReferenceError: Cannot access 'CONFIG_PATH' before initialization. Remote CI is expected to be authoritative for that suite.