### PR TITLE
[codex] audit confidential mask events

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
+import { makeAuditRunId } from '../audit/audit-events.js';
 import { HYBRIDAI_MODEL } from '../config/config.js';
 import { logger } from '../logger.js';
 import { injectPdfContextMessages } from '../media/pdf-context.js';
@@ -156,12 +157,18 @@ async function runAgentInner(
   const confidentialRuleSet = isConfidentialRedactionEnabled()
     ? withResolvedSecretLeakRules(sessionId, getConfidentialRuleSet())
     : null;
+  const confidentialAuditRunId = makeAuditRunId('secret-redaction');
   const confidential = confidentialRuleSet
-    ? createConfidentialRuntimeContext(confidentialRuleSet)
+    ? createConfidentialRuntimeContext(confidentialRuleSet, {
+        audit: { sessionId, runId: confidentialAuditRunId },
+      })
     : createConfidentialRuntimeContext({ rules: [], sourcePath: null });
   const confidentialLeakMiddleware =
     createConfidentialLeakMiddlewareSkill(confidentialRuleSet);
-  const dehydratedMessages = confidential.dehydrate(preparedMessages);
+  const dehydratedMessages = confidential.dehydrate(
+    preparedMessages,
+    'agent.messages',
+  );
   const output = await executor.exec({
     ...params,
     sessionId,
@@ -181,17 +188,19 @@ async function runAgentInner(
     blockedTools,
     onTextDelta: confidentialLeakMiddleware
       ? undefined
-      : confidential.wrapDelta(params.onTextDelta),
+      : confidential.wrapDelta(params.onTextDelta, 'agent.text_delta'),
     onThinkingDelta: confidentialLeakMiddleware
       ? undefined
-      : confidential.wrapDelta(params.onThinkingDelta),
+      : confidential.wrapDelta(params.onThinkingDelta, 'agent.thinking_delta'),
     onToolProgress: confidential.wrapEvent(
       params.onToolProgress,
       TOOL_PROGRESS_REHYDRATE_FIELDS,
+      'agent.tool_progress',
     ),
     onApprovalProgress: confidential.wrapEvent(
       params.onApprovalProgress,
       PENDING_APPROVAL_REHYDRATE_FIELDS,
+      'agent.approval_progress',
     ),
   });
   if (!confidential.enabled) return output;
@@ -200,20 +209,27 @@ async function runAgentInner(
       confidential.rehydrateFields(
         execution,
         TOOL_EXECUTION_REHYDRATE_FIELDS,
+        'agent.tool_executions',
       ) ?? execution,
   );
   const rehydratedPendingApproval = confidential.rehydrateFields(
     output.pendingApproval,
     PENDING_APPROVAL_REHYDRATE_FIELDS,
+    'agent.pending_approval',
   );
   const rehydratedOutput: ContainerOutput = {
     ...output,
     result: output.result
-      ? confidential.rehydrate(output.result)
+      ? confidential.rehydrate(output.result, 'agent.result')
       : output.result,
-    error: output.error ? confidential.rehydrate(output.error) : output.error,
+    error: output.error
+      ? confidential.rehydrate(output.error, 'agent.error')
+      : output.error,
     effectiveUserPrompt: output.effectiveUserPrompt
-      ? confidential.rehydrate(output.effectiveUserPrompt)
+      ? confidential.rehydrate(
+          output.effectiveUserPrompt,
+          'agent.effective_user_prompt',
+        )
       : output.effectiveUserPrompt,
     toolExecutions: rehydratedToolExecutions ?? output.toolExecutions,
     pendingApproval: rehydratedPendingApproval ?? output.pendingApproval,

--- a/src/security/confidential-redact.ts
+++ b/src/security/confidential-redact.ts
@@ -32,12 +32,26 @@ export interface ConfidentialPlaceholderMap {
   byPlaceholder: Map<string, string>;
   /** rule id → placeholder token */
   byRuleId: Map<string, string>;
+  /** placeholder token → confidential class for metadata-only audit counts */
+  byPlaceholderClass: Map<string, ConfidentialRule['kind']>;
+}
+
+export interface ConfidentialClassCount {
+  class: ConfidentialRule['kind'];
+  count: number;
 }
 
 export interface DehydrateResult {
   text: string;
   mappings: ConfidentialPlaceholderMap;
   hits: number;
+  classes: ConfidentialClassCount[];
+}
+
+export interface RehydrateResult {
+  text: string;
+  hits: number;
+  classes: ConfidentialClassCount[];
 }
 
 export interface ConfidentialFinding {
@@ -66,7 +80,26 @@ export interface ConfidentialScanResult {
 }
 
 export function createPlaceholderMap(): ConfidentialPlaceholderMap {
-  return { byPlaceholder: new Map(), byRuleId: new Map() };
+  return {
+    byPlaceholder: new Map(),
+    byRuleId: new Map(),
+    byPlaceholderClass: new Map(),
+  };
+}
+
+function incrementClassCount(
+  counts: Map<ConfidentialRule['kind'], number>,
+  kind: ConfidentialRule['kind'],
+): void {
+  counts.set(kind, (counts.get(kind) || 0) + 1);
+}
+
+function classCountsToArray(
+  counts: Map<ConfidentialRule['kind'], number>,
+): ConfidentialClassCount[] {
+  return [...counts.entries()]
+    .map(([className, count]) => ({ class: className, count }))
+    .sort((a, b) => a.class.localeCompare(b.class));
 }
 
 function escapeForRegex(value: string): string {
@@ -102,6 +135,7 @@ function placeholderForRule(
   if (existing) return existing;
   const token = `${PLACEHOLDER_PREFIX}${rule.id.toUpperCase()}${PLACEHOLDER_SUFFIX}`;
   mappings.byRuleId.set(rule.id, token);
+  mappings.byPlaceholderClass.set(token, rule.kind);
   return token;
 }
 
@@ -112,19 +146,22 @@ export function dehydrateConfidential(
 ): DehydrateResult {
   const mappings = initialMappings || createPlaceholderMap();
   if (!text || ruleSet.rules.length === 0) {
-    return { text: text || '', mappings, hits: 0 };
+    return { text: text || '', mappings, hits: 0, classes: [] };
   }
 
   let next = text;
   let hits = 0;
+  const classCounts = new Map<ConfidentialRule['kind'], number>();
 
   for (const rule of ruleSet.rules) {
     const regex = ruleRegex(rule);
     if (!regex) continue;
     const placeholder = placeholderForRule(rule, mappings);
+    mappings.byPlaceholderClass.set(placeholder, rule.kind);
 
     next = next.replace(regex, (match) => {
       hits += 1;
+      incrementClassCount(classCounts, rule.kind);
       if (!mappings.byPlaceholder.has(placeholder)) {
         mappings.byPlaceholder.set(placeholder, match);
       }
@@ -132,18 +169,39 @@ export function dehydrateConfidential(
     });
   }
 
-  return { text: next, mappings, hits };
+  return {
+    text: next,
+    mappings,
+    hits,
+    classes: classCountsToArray(classCounts),
+  };
+}
+
+export function rehydrateConfidentialWithStats(
+  text: string,
+  mappings: ConfidentialPlaceholderMap,
+): RehydrateResult {
+  if (!text || mappings.byPlaceholder.size === 0) {
+    return { text, hits: 0, classes: [] };
+  }
+  let hits = 0;
+  const classCounts = new Map<ConfidentialRule['kind'], number>();
+  const next = text.replace(PLACEHOLDER_RE, (match) => {
+    const original = mappings.byPlaceholder.get(match);
+    if (!original) return match;
+    hits += 1;
+    const kind = mappings.byPlaceholderClass.get(match);
+    if (kind) incrementClassCount(classCounts, kind);
+    return original;
+  });
+  return { text: next, hits, classes: classCountsToArray(classCounts) };
 }
 
 export function rehydrateConfidential(
   text: string,
   mappings: ConfidentialPlaceholderMap,
 ): string {
-  if (!text || mappings.byPlaceholder.size === 0) return text;
-  return text.replace(PLACEHOLDER_RE, (match) => {
-    const original = mappings.byPlaceholder.get(match);
-    return original ?? match;
-  });
+  return rehydrateConfidentialWithStats(text, mappings).text;
 }
 
 function buildExcerpt(
@@ -249,6 +307,11 @@ export function mergePlaceholderMaps(
   for (const [ruleId, token] of next.byRuleId) {
     if (!base.byRuleId.has(ruleId)) {
       base.byRuleId.set(ruleId, token);
+    }
+  }
+  for (const [token, className] of next.byPlaceholderClass) {
+    if (!base.byPlaceholderClass.has(token)) {
+      base.byPlaceholderClass.set(token, className);
     }
   }
   return base;

--- a/src/security/confidential-runtime.ts
+++ b/src/security/confidential-runtime.ts
@@ -1,9 +1,11 @@
+import { recordAuditEvent } from '../audit/audit-events.js';
 import { getRuntimeConfig } from '../config/runtime-config.js';
 import {
+  type ConfidentialClassCount,
   type ConfidentialPlaceholderMap,
   createPlaceholderMap,
   dehydrateConfidential,
-  rehydrateConfidential,
+  rehydrateConfidentialWithStats,
 } from './confidential-redact.js';
 import {
   type ConfidentialRuleSet,
@@ -49,23 +51,110 @@ export interface DehydrateMessageContent {
   tool_calls?: DehydrateMessageToolCall[];
 }
 
-function dehydrateText(
-  text: string,
-  mappings: ConfidentialPlaceholderMap,
-  ruleSet: ConfidentialRuleSet,
-): string {
-  if (!text) return text;
-  return dehydrateConfidential(text, ruleSet, mappings).text;
+export interface ConfidentialRuntimeAuditOptions {
+  sessionId: string;
+  runId: string;
+  parentRunId?: string;
+}
+
+export interface ConfidentialRuntimeOptions {
+  audit?: ConfidentialRuntimeAuditOptions;
+}
+
+interface ConfidentialRuntimeStats {
+  hits: number;
+  classes: Map<ConfidentialClassCount['class'], number>;
+}
+
+interface ConfidentialOperationStats {
+  hits: number;
+  classes: readonly ConfidentialClassCount[];
+}
+
+const DEFAULT_DEHYDRATE_SURFACE = 'runtime.messages';
+const DEFAULT_REHYDRATE_SURFACE = 'runtime.text';
+const DEFAULT_DELTA_SURFACE = 'runtime.delta';
+const DEFAULT_FIELDS_SURFACE = 'runtime.fields';
+const DEFAULT_EVENT_SURFACE = 'runtime.event';
+
+function createRuntimeStats(): ConfidentialRuntimeStats {
+  return { hits: 0, classes: new Map() };
+}
+
+function addClassCounts(
+  stats: ConfidentialRuntimeStats,
+  classes: readonly ConfidentialClassCount[],
+): void {
+  for (const entry of classes) {
+    stats.classes.set(
+      entry.class,
+      (stats.classes.get(entry.class) || 0) + entry.count,
+    );
+  }
+}
+
+function addRuntimeStats(
+  stats: ConfidentialRuntimeStats,
+  next: ConfidentialRuntimeStats,
+): void {
+  stats.hits += next.hits;
+  for (const [className, count] of next.classes) {
+    stats.classes.set(className, (stats.classes.get(className) || 0) + count);
+  }
+}
+
+function addConfidentialResult(
+  stats: ConfidentialRuntimeStats,
+  result: ConfidentialOperationStats,
+): void {
+  stats.hits += result.hits;
+  addClassCounts(stats, result.classes);
+}
+
+function sortedClassCounts(
+  stats: ConfidentialRuntimeStats,
+): ConfidentialClassCount[] {
+  return [...stats.classes.entries()]
+    .map(([className, count]) => ({ class: className, count }))
+    .sort((a, b) => a.class.localeCompare(b.class));
+}
+
+function emitConfidentialAuditEvent(params: {
+  audit: ConfidentialRuntimeAuditOptions | undefined;
+  type: 'secret.masked' | 'secret.rehydrated';
+  surface: string;
+  stats: ConfidentialRuntimeStats;
+  rulesSource: string | null;
+}): void {
+  if (!params.audit || params.stats.hits === 0) return;
+  recordAuditEvent({
+    sessionId: params.audit.sessionId,
+    runId: params.audit.runId,
+    parentRunId: params.audit.parentRunId,
+    event: {
+      type: params.type,
+      surface: params.surface,
+      count: params.stats.hits,
+      classes: sortedClassCounts(params.stats),
+      rulesSource: params.rulesSource,
+    },
+  });
 }
 
 function dehydrateContentField(
   content: unknown,
   mappings: ConfidentialPlaceholderMap,
   ruleSet: ConfidentialRuleSet,
-): { content: unknown; mutated: boolean } {
+): { content: unknown; mutated: boolean; stats: ConfidentialRuntimeStats } {
+  const stats = createRuntimeStats();
   if (typeof content === 'string') {
-    const dehydrated = dehydrateText(content, mappings, ruleSet);
-    return { content: dehydrated, mutated: dehydrated !== content };
+    const dehydrated = dehydrateConfidential(content, ruleSet, mappings);
+    addConfidentialResult(stats, dehydrated);
+    return {
+      content: dehydrated.text,
+      mutated: dehydrated.text !== content,
+      stats,
+    };
   }
   if (Array.isArray(content)) {
     let mutated = false;
@@ -77,17 +166,18 @@ function dehydrateContentField(
         typeof (part as { text?: unknown }).text === 'string'
       ) {
         const original = (part as { text: string }).text;
-        const dehydrated = dehydrateText(original, mappings, ruleSet);
-        if (dehydrated !== original) {
+        const dehydrated = dehydrateConfidential(original, ruleSet, mappings);
+        addConfidentialResult(stats, dehydrated);
+        if (dehydrated.text !== original) {
           mutated = true;
-          return { ...part, text: dehydrated };
+          return { ...part, text: dehydrated.text };
         }
       }
       return part;
     });
-    return { content: mutated ? next : content, mutated };
+    return { content: mutated ? next : content, mutated, stats };
   }
-  return { content, mutated: false };
+  return { content, mutated: false, stats };
 }
 
 /**
@@ -101,47 +191,60 @@ function dehydrateToolCalls(
   toolCalls: DehydrateMessageToolCall[],
   mappings: ConfidentialPlaceholderMap,
   ruleSet: ConfidentialRuleSet,
-): { toolCalls: DehydrateMessageToolCall[]; mutated: boolean } {
+): {
+  toolCalls: DehydrateMessageToolCall[];
+  mutated: boolean;
+  stats: ConfidentialRuntimeStats;
+} {
   let mutated = false;
+  const stats = createRuntimeStats();
   const next = toolCalls.map((call) => {
     const args = call.function?.arguments;
     if (typeof args !== 'string' || args.length === 0) return call;
-    const dehydrated = dehydrateText(args, mappings, ruleSet);
-    if (dehydrated === args) return call;
+    const dehydrated = dehydrateConfidential(args, ruleSet, mappings);
+    addConfidentialResult(stats, dehydrated);
+    if (dehydrated.text === args) return call;
     mutated = true;
     return {
       ...call,
       function: {
         ...(call.function ?? {}),
-        arguments: dehydrated,
+        arguments: dehydrated.text,
       },
     };
   });
-  return { toolCalls: mutated ? next : toolCalls, mutated };
+  return { toolCalls: mutated ? next : toolCalls, mutated, stats };
 }
 
 function dehydrateContent<T extends DehydrateMessageContent>(
   message: T,
   mappings: ConfidentialPlaceholderMap,
   ruleSet: ConfidentialRuleSet,
-): T {
+): { message: T; stats: ConfidentialRuntimeStats } {
+  const stats = createRuntimeStats();
   const contentResult = dehydrateContentField(
     message.content,
     mappings,
     ruleSet,
   );
+  addRuntimeStats(stats, contentResult.stats);
   let toolCallsResult: {
     toolCalls: DehydrateMessageToolCall[];
     mutated: boolean;
+    stats: ConfidentialRuntimeStats;
   } = {
     toolCalls: message.tool_calls ?? [],
     mutated: false,
+    stats: createRuntimeStats(),
   };
   if (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) {
     toolCallsResult = dehydrateToolCalls(message.tool_calls, mappings, ruleSet);
+    addRuntimeStats(stats, toolCallsResult.stats);
   }
 
-  if (!contentResult.mutated && !toolCallsResult.mutated) return message;
+  if (!contentResult.mutated && !toolCallsResult.mutated) {
+    return { message, stats };
+  }
   const next: T = { ...message };
   if (contentResult.mutated) {
     (next as { content: unknown }).content = contentResult.content;
@@ -150,27 +253,33 @@ function dehydrateContent<T extends DehydrateMessageContent>(
     (next as { tool_calls?: DehydrateMessageToolCall[] }).tool_calls =
       toolCallsResult.toolCalls;
   }
-  return next;
+  return { message: next, stats };
 }
 
 export interface ConfidentialRuntimeContext {
   enabled: boolean;
   ruleSet: ConfidentialRuleSet;
   mappings: ConfidentialPlaceholderMap;
-  dehydrate<T extends DehydrateMessageContent>(messages: T[]): T[];
-  rehydrate(text: string | null | undefined): string;
+  dehydrate<T extends DehydrateMessageContent>(
+    messages: T[],
+    surface?: string,
+  ): T[];
+  rehydrate(text: string | null | undefined, surface?: string): string;
   wrapDelta(
     callback: ((delta: string) => void) | undefined,
+    surface?: string,
   ): ((delta: string) => void) | undefined;
   /** Rehydrate every listed string field on an object (shallow). */
   rehydrateFields<T extends object>(
     value: T | null | undefined,
     fields: ReadonlyArray<keyof T>,
+    surface?: string,
   ): T | null | undefined;
   /** Map a callback that receives an object, rehydrating string fields by name. */
   wrapEvent<T extends object>(
     callback: ((event: T) => void) | undefined,
     fields: ReadonlyArray<keyof T>,
+    surface?: string,
   ): ((event: T) => void) | undefined;
 }
 
@@ -189,13 +298,16 @@ function rehydrateStringField<T extends object>(
   source: T,
   key: keyof T,
   mappings: ConfidentialPlaceholderMap,
-): { value: T[keyof T]; mutated: boolean } {
+): { value: T[keyof T]; mutated: boolean; stats: ConfidentialRuntimeStats } {
+  const stats = createRuntimeStats();
   const raw = source[key];
-  if (typeof raw !== 'string') return { value: raw, mutated: false };
-  const next = rehydrateConfidential(raw, mappings);
+  if (typeof raw !== 'string') return { value: raw, mutated: false, stats };
+  const result = rehydrateConfidentialWithStats(raw, mappings);
+  addConfidentialResult(stats, result);
   return {
-    value: next as T[keyof T],
-    mutated: next !== raw,
+    value: result.text as T[keyof T],
+    mutated: result.text !== raw,
+    stats,
   };
 }
 
@@ -214,6 +326,9 @@ const STREAM_PLACEHOLDER_LOOKAHEAD = 64;
 function makeStreamingDeltaWrapper(
   callback: (delta: string) => void,
   mappings: ConfidentialPlaceholderMap,
+  audit: ConfidentialRuntimeAuditOptions | undefined,
+  rulesSource: string | null,
+  surface: string,
 ): (delta: string) => void {
   // A placeholder may straddle two delta chunks — e.g. one delta ends
   // with `«CONF:CLIENT_` and the next begins with `001»`. If we
@@ -242,12 +357,23 @@ function makeStreamingDeltaWrapper(
     if (flushUpTo === 0) return;
     const ready = pending.slice(0, flushUpTo);
     pending = pending.slice(flushUpTo);
-    callback(rehydrateConfidential(ready, mappings));
+    const result = rehydrateConfidentialWithStats(ready, mappings);
+    const stats = createRuntimeStats();
+    addConfidentialResult(stats, result);
+    emitConfidentialAuditEvent({
+      audit,
+      type: 'secret.rehydrated',
+      surface,
+      stats,
+      rulesSource,
+    });
+    callback(result.text);
   };
 }
 
 export function createConfidentialRuntimeContext(
   ruleSetOverride?: ConfidentialRuleSet,
+  options: ConfidentialRuntimeOptions = {},
 ): ConfidentialRuntimeContext {
   if (process.env.HYBRIDCLAW_CONFIDENTIAL_DISABLE === '1') {
     return NOOP_CONTEXT;
@@ -263,21 +389,33 @@ export function createConfidentialRuntimeContext(
     return NOOP_CONTEXT;
   }
   const mappings = createPlaceholderMap();
+  const audit = options.audit;
+  const rulesSource = ruleSet.sourcePath;
 
   function rehydrateFields<T extends object>(
     value: T | null | undefined,
     fields: ReadonlyArray<keyof T>,
+    surface = DEFAULT_FIELDS_SURFACE,
   ): T | null | undefined {
     if (!value) return value;
     let mutated = false;
     const next = { ...value } as T;
+    const stats = createRuntimeStats();
     for (const field of fields) {
       const result = rehydrateStringField(value, field, mappings);
+      addRuntimeStats(stats, result.stats);
       if (result.mutated) {
         next[field] = result.value;
         mutated = true;
       }
     }
+    emitConfidentialAuditEvent({
+      audit,
+      type: 'secret.rehydrated',
+      surface,
+      stats,
+      rulesSource,
+    });
     return mutated ? next : value;
   }
 
@@ -285,24 +423,51 @@ export function createConfidentialRuntimeContext(
     enabled: true,
     ruleSet,
     mappings,
-    dehydrate(messages) {
-      return messages.map((message) =>
-        dehydrateContent(message, mappings, ruleSet),
+    dehydrate(messages, surface = DEFAULT_DEHYDRATE_SURFACE) {
+      const stats = createRuntimeStats();
+      const next = messages.map((message) => {
+        const result = dehydrateContent(message, mappings, ruleSet);
+        addRuntimeStats(stats, result.stats);
+        return result.message;
+      });
+      emitConfidentialAuditEvent({
+        audit,
+        type: 'secret.masked',
+        surface,
+        stats,
+        rulesSource,
+      });
+      return next;
+    },
+    rehydrate(text, surface = DEFAULT_REHYDRATE_SURFACE) {
+      if (!text) return text || '';
+      const result = rehydrateConfidentialWithStats(text, mappings);
+      const stats = createRuntimeStats();
+      addConfidentialResult(stats, result);
+      emitConfidentialAuditEvent({
+        audit,
+        type: 'secret.rehydrated',
+        surface,
+        stats,
+        rulesSource,
+      });
+      return result.text;
+    },
+    wrapDelta(callback, surface = DEFAULT_DELTA_SURFACE) {
+      if (!callback) return callback;
+      return makeStreamingDeltaWrapper(
+        callback,
+        mappings,
+        audit,
+        rulesSource,
+        surface,
       );
     },
-    rehydrate(text) {
-      if (!text) return text || '';
-      return rehydrateConfidential(text, mappings);
-    },
-    wrapDelta(callback) {
-      if (!callback) return callback;
-      return makeStreamingDeltaWrapper(callback, mappings);
-    },
     rehydrateFields,
-    wrapEvent(callback, fields) {
+    wrapEvent(callback, fields, surface = DEFAULT_EVENT_SURFACE) {
       if (!callback) return callback;
       return (event) => {
-        const next = rehydrateFields(event, fields);
+        const next = rehydrateFields(event, fields, surface);
         callback((next ?? event) as Parameters<typeof callback>[0]);
       };
     },

--- a/tests/audit-trail.integration.test.ts
+++ b/tests/audit-trail.integration.test.ts
@@ -17,6 +17,9 @@ let verifyAuditSessionChain: typeof import('../src/audit/audit-trail.js').verify
 let getAuditWirePath: typeof import('../src/audit/audit-trail.js').getAuditWirePath;
 let createAuditRunId: typeof import('../src/audit/audit-trail.js').createAuditRunId;
 let AUDIT_PROTOCOL_VERSION: typeof import('../src/audit/audit-trail.js').AUDIT_PROTOCOL_VERSION;
+let initDatabase: typeof import('../src/memory/db.js').initDatabase;
+let createConfidentialRuntimeContext: typeof import('../src/security/confidential-runtime.js').createConfidentialRuntimeContext;
+let parseConfidentialYaml: typeof import('../src/security/confidential-rules.js').parseConfidentialYaml;
 type WireRecord = import('../src/audit/audit-trail.js').WireRecord;
 
 beforeAll(async () => {
@@ -42,6 +45,20 @@ beforeAll(async () => {
   getAuditWirePath = auditMod.getAuditWirePath;
   createAuditRunId = auditMod.createAuditRunId;
   AUDIT_PROTOCOL_VERSION = auditMod.AUDIT_PROTOCOL_VERSION;
+
+  const dbMod = await import('../src/memory/db.js');
+  initDatabase = dbMod.initDatabase;
+  initDatabase({ quiet: true, dbPath: path.join(tmpDir, 'audit.db') });
+
+  const confidentialRuntimeMod = await import(
+    '../src/security/confidential-runtime.js'
+  );
+  createConfidentialRuntimeContext =
+    confidentialRuntimeMod.createConfidentialRuntimeContext;
+  const confidentialRulesMod = await import(
+    '../src/security/confidential-rules.js'
+  );
+  parseConfidentialYaml = confidentialRulesMod.parseConfidentialYaml;
 });
 
 afterAll(() => {
@@ -230,5 +247,84 @@ describe('audit trail integration', () => {
     for (let i = 1; i < records.length; i++) {
       expect(records[i].seq).toBe(records[i - 1].seq + 1);
     }
+  });
+
+  it('confidential runtime writes metadata-only mask and rehydrate audit events', () => {
+    const secretSessionId = 'audit-confidential-runtime';
+    const runId = createAuditRunId('secret-redaction');
+    const clientSecret = 'AsterWorks Labs';
+    const contractSecret = 'CONTRACT-ASTER-2026-001';
+    const ruleSet = parseConfidentialYaml(
+      `
+clients:
+  - name: ${clientSecret}
+    sensitivity: high
+keywords:
+  - term: ${contractSecret}
+    sensitivity: critical
+`,
+      'fixtures:trusted-agents',
+    );
+    const confidential = createConfidentialRuntimeContext(ruleSet, {
+      audit: { sessionId: secretSessionId, runId },
+    });
+
+    const [message] = confidential.dehydrate(
+      [
+        {
+          role: 'user',
+          content: `${clientSecret} signed ${contractSecret} for ${clientSecret}.`,
+        },
+      ],
+      'test.messages',
+    );
+    expect(String(message?.content)).not.toContain(clientSecret);
+    expect(String(message?.content)).not.toContain(contractSecret);
+
+    const rehydrated = confidential.rehydrate(
+      String(message?.content),
+      'test.result',
+    );
+    expect(rehydrated).toContain(clientSecret);
+    expect(rehydrated).toContain(contractSecret);
+
+    const wirePath = getAuditWirePath(secretSessionId);
+    const wireText = fs.readFileSync(wirePath, 'utf-8');
+    expect(wireText).not.toContain(clientSecret);
+    expect(wireText).not.toContain(contractSecret);
+
+    const records = wireText
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line))
+      .filter((entry): entry is WireRecord => entry.event != null);
+    expect(records.map((record) => record.event.type)).toEqual([
+      'secret.masked',
+      'secret.rehydrated',
+    ]);
+    expect(records[0]?.event).toMatchObject({
+      type: 'secret.masked',
+      surface: 'test.messages',
+      count: 3,
+      classes: [
+        { class: 'client', count: 2 },
+        { class: 'keyword', count: 1 },
+      ],
+      rulesSource: 'fixtures:trusted-agents',
+    });
+    expect(records[1]?.event).toMatchObject({
+      type: 'secret.rehydrated',
+      surface: 'test.result',
+      count: 3,
+      classes: [
+        { class: 'client', count: 2 },
+        { class: 'keyword', count: 1 },
+      ],
+      rulesSource: 'fixtures:trusted-agents',
+    });
+
+    const result = verifyAuditSessionChain(secretSessionId);
+    expect(result.ok).toBe(true);
+    expect(result.checkedRecords).toBe(2);
   });
 });

--- a/tests/confidential-redact.test.ts
+++ b/tests/confidential-redact.test.ts
@@ -4,6 +4,7 @@ import {
   createPlaceholderMap,
   dehydrateConfidential,
   rehydrateConfidential,
+  rehydrateConfidentialWithStats,
   scanForLeaks,
 } from '../src/security/confidential-redact.js';
 import { parseConfidentialYaml } from '../src/security/confidential-rules.js';
@@ -108,6 +109,22 @@ describe('dehydrate / rehydrate', () => {
   test('case-insensitive literal matching', () => {
     const { hits } = dehydrateConfidential('SERVICEPLAN told ACME', ruleSet);
     expect(hits).toBe(2);
+  });
+
+  test('reports metadata-only class counts for mask and rehydrate operations', () => {
+    const { text, mappings, classes } = dehydrateConfidential(
+      'Serviceplan discussed Project Falcon with Acme.',
+      ruleSet,
+    );
+
+    expect(classes).toEqual([
+      { class: 'client', count: 2 },
+      { class: 'project', count: 1 },
+    ]);
+    const rehydrated = rehydrateConfidentialWithStats(text, mappings);
+    expect(rehydrated.classes).toEqual(classes);
+    expect(rehydrated.text).toContain('Serviceplan');
+    expect(rehydrated.text).toContain('Project Falcon');
   });
 
   test('no-op when rule set is empty', () => {

--- a/tests/secret-injection.test.ts
+++ b/tests/secret-injection.test.ts
@@ -4,6 +4,19 @@ import path from 'node:path';
 
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
+function mockRuntimeSecrets(
+  readStoredRuntimeSecret: (name: string) => string | null,
+): void {
+  vi.doMock('../src/security/runtime-secrets.js', () => ({
+    isRuntimeSecretName: (value: string) =>
+      /^[A-Z][A-Z0-9_]{0,127}$/.test(value),
+    loadRuntimeSecrets: vi.fn(),
+    migrateLegacyRuntimeSecretsFile: vi.fn(() => false),
+    readStoredRuntimeSecret,
+    readStoredRuntimeSecrets: vi.fn(() => ({})),
+  }));
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
   vi.resetModules();
@@ -33,12 +46,9 @@ describe('SecretRef', () => {
 
 describe('SecretHandle', () => {
   test('blocks accidental coercion and JSON serialization', async () => {
-    vi.doMock('../src/security/runtime-secrets.js', () => ({
-      isRuntimeSecretName: (value: string) =>
-        /^[A-Z][A-Z0-9_]{0,127}$/.test(value),
-      readStoredRuntimeSecret: (name: string) =>
-        name === 'HYBRIDCLAW_TEST_SECRET' ? 'super-secret-value' : null,
-    }));
+    mockRuntimeSecrets((name) =>
+      name === 'HYBRIDCLAW_TEST_SECRET' ? 'super-secret-value' : null,
+    );
     const { resolveSecretHandleInput } = await import(
       '../src/security/secret-refs.js'
     );
@@ -72,12 +82,9 @@ describe('SecretHandle', () => {
   });
 
   test('resolved secret refs return handles and HTTP header injection audits', async () => {
-    vi.doMock('../src/security/runtime-secrets.js', () => ({
-      isRuntimeSecretName: (value: string) =>
-        /^[A-Z][A-Z0-9_]{0,127}$/.test(value),
-      readStoredRuntimeSecret: (name: string) =>
-        name === 'HYBRIDCLAW_TEST_SECRET' ? 'header-secret-value' : null,
-    }));
+    mockRuntimeSecrets((name) =>
+      name === 'HYBRIDCLAW_TEST_SECRET' ? 'header-secret-value' : null,
+    );
     const { resolveSecretInput } = await import(
       '../src/security/secret-refs.js'
     );
@@ -419,12 +426,9 @@ describe('gateway secret injection', () => {
       makeAuditRunId: () => 'run-secret',
       recordAuditEvent,
     }));
-    vi.doMock('../src/security/runtime-secrets.js', () => ({
-      isRuntimeSecretName: (value: string) =>
-        /^[A-Z][A-Z0-9_]{0,127}$/.test(value),
-      readStoredRuntimeSecret: (name: string) =>
-        name === 'AIRTABLE_PAT' ? 'pat-cleartext-secret' : null,
-    }));
+    mockRuntimeSecrets((name) =>
+      name === 'AIRTABLE_PAT' ? 'pat-cleartext-secret' : null,
+    );
 
     const { resolveStoredSecretForInjection } = await import(
       '../src/gateway/gateway-secret-injection.js'
@@ -456,11 +460,7 @@ describe('gateway secret injection', () => {
       makeAuditRunId: () => 'run-secret',
       recordAuditEvent: vi.fn(),
     }));
-    vi.doMock('../src/security/runtime-secrets.js', () => ({
-      isRuntimeSecretName: (value: string) =>
-        /^[A-Z][A-Z0-9_]{0,127}$/.test(value),
-      readStoredRuntimeSecret: () => null,
-    }));
+    mockRuntimeSecrets(() => null);
 
     const { resolveStoredSecretForInjection } = await import(
       '../src/gateway/gateway-secret-injection.js'
@@ -509,12 +509,9 @@ describe('gateway secret injection', () => {
       makeAuditRunId: () => 'run-secret',
       recordAuditEvent: vi.fn(),
     }));
-    vi.doMock('../src/security/runtime-secrets.js', () => ({
-      isRuntimeSecretName: (value: string) =>
-        /^[A-Z][A-Z0-9_]{0,127}$/.test(value),
-      readStoredRuntimeSecret: (name: string) =>
-        name === 'AIRTABLE_PAT' ? 'pat-cleartext-secret' : null,
-    }));
+    mockRuntimeSecrets((name) =>
+      name === 'AIRTABLE_PAT' ? 'pat-cleartext-secret' : null,
+    );
 
     const { resolveStoredSecretForInjection } = await import(
       '../src/gateway/gateway-secret-injection.js'
@@ -554,12 +551,9 @@ describe('gateway secret injection', () => {
       makeAuditRunId: () => 'run-secret',
       recordAuditEvent,
     }));
-    vi.doMock('../src/security/runtime-secrets.js', () => ({
-      isRuntimeSecretName: (value: string) =>
-        /^[A-Z][A-Z0-9_]{0,127}$/.test(value),
-      readStoredRuntimeSecret: (name: string) =>
-        name === 'DATEV_PASSWORD' ? 'datev-cleartext-secret' : null,
-    }));
+    mockRuntimeSecrets((name) =>
+      name === 'DATEV_PASSWORD' ? 'datev-cleartext-secret' : null,
+    );
 
     const { resolveStoredSecretForInjection } = await import(
       '../src/gateway/gateway-secret-injection.js'


### PR DESCRIPTION
## Summary

Implements GitHub issue, closes #446 by wiring confidential mask and rehydrate operations into the existing audit trail.

## What changed

- Tracks metadata-only class/count stats for confidential mask and rehydrate operations.
- Emits `secret.masked` and `secret.rehydrated` audit events from the confidential runtime when real replacements occur.
- Wires agent turns to pass an audit context and surface names for message masking, deltas, final results, tool executions, and pending approvals.
- Adds JSONL inspection coverage proving the events are written, raw secret values are absent, and the audit hash chain verifies.

## Impact

Operators can now inspect `wire.jsonl` for mask/demask activity without exposing raw confidential values. Existing pure redaction helpers remain behavior-compatible for current callers.

## Validation

Passed:

- `npm run format`
- `npx vitest run --configLoader runner --project unit tests/confidential-redact.test.ts tests/confidential-runtime.test.ts`
- `npx vitest run --configLoader runner tests/audit-trail.integration.test.ts`
- `git diff --check`

Known unrelated blockers:

- `npm run typecheck` currently stops on missing `@sentry/node` module/types in `src/observability/sentry.ts`.
- An accidental full `npm run test:unit` run failed on unrelated sandbox/environment issues including `listen EPERM`, read-only `/home/max/.hybridclaw`, and existing helper stdout failures; the focused tests above passed.