### PR TITLE
feat: OAuth for remote MCP servers with guided setup in TUI and console

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,8 +328,9 @@ Skill resolution order (first match wins):
    ```
 2. Tools are auto-discovered at startup and merged into the tool namespace.
 3. Remote `http`/`sse` servers can set `"auth": "oauth"`; the gateway runs the
-   OAuth 2.1 flow (`src/mcp/mcp-oauth.ts`), stores tokens in
-   `~/.hybridclaw/mcp-oauth.json`, and injects a fresh `Authorization` header
+   OAuth 2.1 flow (`src/mcp/mcp-oauth.ts`), stores credentials in the
+   encrypted runtime secret store (`~/.hybridclaw/credentials.json`, one
+   `MCP_OAUTH_*` entry per server), and injects a fresh `Authorization` header
    per turn. Connect via `/mcp login <name>`, the TUI `/mcp add` wizard, or the
    console MCP page.
 4. Test with `hybridclaw` running in dev mode.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,7 +327,12 @@ Skill resolution order (first match wins):
    }
    ```
 2. Tools are auto-discovered at startup and merged into the tool namespace.
-3. Test with `hybridclaw` running in dev mode.
+3. Remote `http`/`sse` servers can set `"auth": "oauth"`; the gateway runs the
+   OAuth 2.1 flow (`src/mcp/mcp-oauth.ts`), stores tokens in
+   `~/.hybridclaw/mcp-oauth.json`, and injects a fresh `Authorization` header
+   per turn. Connect via `/mcp login <name>`, the TUI `/mcp add` wizard, or the
+   console MCP page.
+4. Test with `hybridclaw` running in dev mode.
 
 ### 7.4 Modifying Approval Policy
 

--- a/config.example.json
+++ b/config.example.json
@@ -513,6 +513,12 @@
       "command": "npx",
       "args": ["-y", "@playwright/mcp@latest"],
       "enabled": false
+    },
+    "linear": {
+      "transport": "http",
+      "url": "https://mcp.linear.app/mcp",
+      "auth": "oauth",
+      "enabled": false
     }
   },
   "web": {

--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -49,6 +49,8 @@ import type {
   AdminJobsContextResponse,
   AdminLanHttpAccessMode,
   AdminMcpConfig,
+  AdminMcpOAuthStartResponse,
+  AdminMcpOAuthStatusResponse,
   AdminMcpResponse,
   AdminModelsResponse,
   AdminOutputGuardPreviewResponse,
@@ -1212,6 +1214,39 @@ export function deleteMcpServer(
   return requestJson<AdminMcpResponse>(`/api/admin/mcp?${params.toString()}`, {
     token,
     method: 'DELETE',
+  });
+}
+
+export function startMcpOAuth(
+  token: string,
+  name: string,
+): Promise<AdminMcpOAuthStartResponse> {
+  return requestJson<AdminMcpOAuthStartResponse>('/api/admin/mcp/oauth/start', {
+    token,
+    method: 'POST',
+    body: { name },
+  });
+}
+
+export function fetchMcpOAuthStatus(
+  token: string,
+  name: string,
+): Promise<AdminMcpOAuthStatusResponse> {
+  const params = new URLSearchParams({ name });
+  return requestJson<AdminMcpOAuthStatusResponse>(
+    `/api/admin/mcp/oauth/status?${params.toString()}`,
+    { token },
+  );
+}
+
+export function logoutMcpOAuth(
+  token: string,
+  name: string,
+): Promise<AdminMcpResponse> {
+  return requestJson<AdminMcpResponse>('/api/admin/mcp/oauth/logout', {
+    token,
+    method: 'POST',
+    body: { name },
   });
 }
 

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -1276,7 +1276,17 @@ export interface AdminMcpConfig {
   cwd?: string;
   url?: string;
   headers?: Record<string, string>;
+  auth?: 'oauth';
   enabled?: boolean;
+}
+
+export type AdminMcpAuthState = 'connected' | 'expired' | 'unauthorized';
+
+export interface AdminMcpAuthStatus {
+  method: 'oauth' | 'none';
+  state?: AdminMcpAuthState;
+  expiresAt?: number | null;
+  scope?: string;
 }
 
 export interface AdminMcpServer {
@@ -1284,10 +1294,23 @@ export interface AdminMcpServer {
   enabled: boolean;
   summary: string;
   config: AdminMcpConfig;
+  auth: AdminMcpAuthStatus;
 }
 
 export interface AdminMcpResponse {
   servers: AdminMcpServer[];
+}
+
+export interface AdminMcpOAuthStartResponse {
+  serverName: string;
+  authorizationUrl: string;
+  state: string;
+  expiresAt: number;
+}
+
+export interface AdminMcpOAuthStatusResponse {
+  name: string;
+  auth: AdminMcpAuthStatus;
 }
 
 export interface AdminAuditEntry {

--- a/console/src/routes/mcp.test.tsx
+++ b/console/src/routes/mcp.test.tsx
@@ -7,6 +7,9 @@ import { McpPage } from './mcp';
 const fetchMcpMock = vi.fn<() => Promise<AdminMcpResponse>>();
 const saveMcpServerMock = vi.fn();
 const deleteMcpServerMock = vi.fn();
+const startMcpOAuthMock = vi.fn();
+const fetchMcpOAuthStatusMock = vi.fn();
+const logoutMcpOAuthMock = vi.fn();
 const useAuthMock = vi.fn();
 
 vi.mock('../api/client', () => ({
@@ -15,6 +18,12 @@ vi.mock('../api/client', () => ({
     saveMcpServerMock(token, payload),
   deleteMcpServer: (token: string, name: string) =>
     deleteMcpServerMock(token, name),
+  startMcpOAuth: (token: string, name: string) =>
+    startMcpOAuthMock(token, name),
+  fetchMcpOAuthStatus: (token: string, name: string) =>
+    fetchMcpOAuthStatusMock(token, name),
+  logoutMcpOAuth: (token: string, name: string) =>
+    logoutMcpOAuthMock(token, name),
 }));
 
 vi.mock('../auth', () => ({
@@ -33,6 +42,27 @@ function makeMcpResponse(): AdminMcpResponse {
           command: 'docker',
           args: ['run', 'ghcr.io/github/mcp'],
         },
+        auth: { method: 'none' },
+      },
+    ],
+  };
+}
+
+function makeOAuthMcpResponse(
+  state: 'connected' | 'unauthorized',
+): AdminMcpResponse {
+  return {
+    servers: [
+      {
+        name: 'linear',
+        enabled: true,
+        summary: 'http · https://mcp.linear.app/mcp',
+        config: {
+          transport: 'http',
+          url: 'https://mcp.linear.app/mcp',
+          auth: 'oauth',
+        },
+        auth: { method: 'oauth', state },
       },
     ],
   };
@@ -43,6 +73,9 @@ describe('McpPage', () => {
     fetchMcpMock.mockReset();
     saveMcpServerMock.mockReset();
     deleteMcpServerMock.mockReset();
+    startMcpOAuthMock.mockReset();
+    fetchMcpOAuthStatusMock.mockReset();
+    logoutMcpOAuthMock.mockReset();
     useAuthMock.mockReset();
     useAuthMock.mockReturnValue({ token: 'test-token' });
   });
@@ -65,6 +98,7 @@ describe('McpPage', () => {
           enabled: true,
           summary: 'stdio · uvx mcp-github',
           config: { transport: 'stdio', command: 'uvx', args: ['mcp-github'] },
+          auth: { method: 'none' },
         },
       ],
     });
@@ -98,20 +132,20 @@ describe('McpPage', () => {
     );
   });
 
-  it('switching transport to http reveals the URL field instead of command', async () => {
+  it('switching transport to stdio reveals the command field instead of URL', async () => {
     fetchMcpMock.mockResolvedValue({ servers: [] });
 
     renderWithProviders(<McpPage />);
 
     await screen.findByLabelText('Name');
-    expect(screen.getByLabelText('Command')).toBeTruthy();
-    expect(screen.queryByLabelText('URL')).toBeNull();
+    expect(screen.getByLabelText('URL')).toBeTruthy();
+    expect(screen.queryByLabelText('Command')).toBeNull();
 
     const transport = screen.getByLabelText('Transport') as HTMLSelectElement;
-    fireEvent.change(transport, { target: { value: 'http' } });
+    fireEvent.change(transport, { target: { value: 'stdio' } });
 
-    expect(screen.queryByLabelText('Command')).toBeNull();
-    expect(screen.getByLabelText('URL')).toBeTruthy();
+    expect(screen.queryByLabelText('URL')).toBeNull();
+    expect(screen.getByLabelText('Command')).toBeTruthy();
   });
 
   it('Switch toggles the enabled flag through to the save payload', async () => {
@@ -127,6 +161,7 @@ describe('McpPage', () => {
             args: ['run', 'ghcr.io/github/mcp'],
             enabled: false,
           },
+          auth: { method: 'none' },
         },
       ],
     });
@@ -147,5 +182,81 @@ describe('McpPage', () => {
     const [, payload] = saveMcpServerMock.mock.calls[0];
     expect(payload.config.enabled).toBeUndefined();
     expect(payload.config.transport).toBe('stdio');
+  });
+
+  it('saves auth: oauth for remote servers when OAuth is selected', async () => {
+    fetchMcpMock.mockResolvedValue({ servers: [] });
+    saveMcpServerMock.mockResolvedValue({ servers: [] });
+
+    renderWithProviders(<McpPage />);
+
+    const name = await screen.findByLabelText('Name');
+    fireEvent.change(name, { target: { value: 'linear' } });
+    fireEvent.change(screen.getByLabelText('URL'), {
+      target: { value: 'https://mcp.linear.app/mcp' },
+    });
+    // OAuth is the default auth mode for remote servers.
+    expect(
+      (screen.getByLabelText('Authentication') as HTMLSelectElement).value,
+    ).toBe('oauth');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save server' }));
+    await waitFor(() => expect(saveMcpServerMock).toHaveBeenCalledTimes(1));
+    const [, payload] = saveMcpServerMock.mock.calls[0];
+    expect(payload.config).toEqual({
+      transport: 'http',
+      url: 'https://mcp.linear.app/mcp',
+      auth: 'oauth',
+    });
+  });
+
+  it('Connect saves the server, opens the authorization URL, and polls until connected', async () => {
+    fetchMcpMock.mockResolvedValue(makeOAuthMcpResponse('unauthorized'));
+    saveMcpServerMock.mockResolvedValue(makeOAuthMcpResponse('unauthorized'));
+    startMcpOAuthMock.mockResolvedValue({
+      serverName: 'linear',
+      authorizationUrl: 'https://auth.linear.app/authorize?state=abc',
+      state: 'abc',
+      expiresAt: Date.now() + 600_000,
+    });
+    fetchMcpOAuthStatusMock.mockResolvedValue({
+      name: 'linear',
+      auth: { method: 'oauth', state: 'connected' },
+    });
+    const openSpy = vi
+      .spyOn(window, 'open')
+      .mockReturnValue(null as unknown as Window);
+
+    renderWithProviders(<McpPage />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /linear/i }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Connect' }));
+
+    await waitFor(() => expect(startMcpOAuthMock).toHaveBeenCalledTimes(1), {
+      timeout: 5_000,
+    });
+    expect(saveMcpServerMock).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://auth.linear.app/authorize?state=abc',
+      '_blank',
+      'noopener',
+    );
+    await waitFor(() => expect(fetchMcpOAuthStatusMock).toHaveBeenCalled(), {
+      timeout: 5_000,
+    });
+    openSpy.mockRestore();
+  });
+
+  it('Disconnect clears stored OAuth credentials', async () => {
+    fetchMcpMock.mockResolvedValue(makeOAuthMcpResponse('connected'));
+    logoutMcpOAuthMock.mockResolvedValue(makeOAuthMcpResponse('unauthorized'));
+
+    renderWithProviders(<McpPage />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /linear/i }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Disconnect' }));
+
+    await waitFor(() => expect(logoutMcpOAuthMock).toHaveBeenCalledTimes(1));
+    expect(logoutMcpOAuthMock).toHaveBeenCalledWith('test-token', 'linear');
   });
 });

--- a/console/src/routes/mcp.tsx
+++ b/console/src/routes/mcp.tsx
@@ -1,7 +1,18 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
-import { deleteMcpServer, fetchMcp, saveMcpServer } from '../api/client';
-import type { AdminMcpConfig, AdminMcpServer } from '../api/types';
+import { useEffect, useRef, useState } from 'react';
+import {
+  deleteMcpServer,
+  fetchMcp,
+  fetchMcpOAuthStatus,
+  logoutMcpOAuth,
+  saveMcpServer,
+  startMcpOAuth,
+} from '../api/client';
+import type {
+  AdminMcpAuthStatus,
+  AdminMcpConfig,
+  AdminMcpServer,
+} from '../api/types';
 import { useAuth } from '../auth';
 import { Button } from '../components/button';
 import {
@@ -11,7 +22,12 @@ import {
   CardHeader,
   CardTitle,
 } from '../components/card';
-import { Field, FieldContent, FieldLabel } from '../components/field';
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldLabel,
+} from '../components/field';
 import { Input } from '../components/input';
 import { NativeSelect, NativeSelectOption } from '../components/native-select';
 import { Switch } from '../components/switch';
@@ -19,6 +35,8 @@ import { Textarea } from '../components/textarea';
 import { useToast } from '../components/toast';
 import { BooleanPill, PageHeader } from '../components/ui';
 import { getErrorMessage } from '../lib/error-message';
+
+type McpAuthMode = 'none' | 'headers' | 'oauth';
 
 interface McpDraft {
   originalName: string | null;
@@ -30,25 +48,38 @@ interface McpDraft {
   cwd: string;
   url: string;
   envJson: string;
+  authMode: McpAuthMode;
   headersJson: string;
 }
+
+const OAUTH_POLL_INTERVAL_MS = 2_000;
+const OAUTH_POLL_TIMEOUT_MS = 3 * 60_000;
 
 function formatJson(value: Record<string, string> | undefined): string {
   if (!value || Object.keys(value).length === 0) return '';
   return JSON.stringify(value, null, 2);
 }
 
+function deriveAuthMode(config?: AdminMcpConfig): McpAuthMode {
+  if (config?.auth === 'oauth') return 'oauth';
+  if (config?.headers && Object.keys(config.headers).length > 0) {
+    return 'headers';
+  }
+  return 'none';
+}
+
 function createDraft(source?: AdminMcpServer): McpDraft {
   return {
     originalName: source?.name || null,
     name: source?.name || '',
-    transport: source?.config.transport || 'stdio',
+    transport: source?.config.transport || 'http',
     enabled: source?.enabled ?? true,
     command: source?.config.command || '',
     args: (source?.config.args || []).join('\n'),
     cwd: source?.config.cwd || '',
     url: source?.config.url || '',
     envJson: formatJson(source?.config.env),
+    authMode: source ? deriveAuthMode(source.config) : 'oauth',
     headersJson: formatJson(source?.config.headers),
   };
 }
@@ -100,12 +131,27 @@ function normalizeDraft(draft: McpDraft): {
           }
         : {
             url: draft.url.trim(),
-            ...(draft.headersJson.trim()
+            ...(draft.authMode === 'oauth' ? { auth: 'oauth' as const } : {}),
+            ...(draft.authMode === 'headers' && draft.headersJson.trim()
               ? { headers: parseJsonMap(draft.headersJson, 'Headers JSON') }
               : {}),
           }),
     },
   };
+}
+
+function describeAuthStatus(auth: AdminMcpAuthStatus): {
+  label: string;
+  connected: boolean;
+} {
+  if (auth.state === 'connected')
+    return { label: 'connected', connected: true };
+  if (auth.state === 'expired') return { label: 'expired', connected: false };
+  return { label: 'login required', connected: false };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export function McpPage() {
@@ -114,6 +160,8 @@ export function McpPage() {
   const toast = useToast();
   const [selectedName, setSelectedName] = useState<string | null>(null);
   const [draft, setDraft] = useState<McpDraft>(createDraft());
+  const [pendingAuthUrl, setPendingAuthUrl] = useState<string | null>(null);
+  const connectCancelled = useRef(false);
 
   const mcpQuery = useQuery({
     queryKey: ['mcp', auth.token],
@@ -149,6 +197,58 @@ export function McpPage() {
     },
   });
 
+  const connectMutation = useMutation({
+    mutationFn: async () => {
+      connectCancelled.current = false;
+      const payload = normalizeDraft(draft);
+      const saved = await saveMcpServer(auth.token, payload);
+      queryClient.setQueryData(['mcp', auth.token], saved);
+
+      const started = await startMcpOAuth(auth.token, payload.name);
+      setPendingAuthUrl(started.authorizationUrl);
+      window.open(started.authorizationUrl, '_blank', 'noopener');
+
+      const deadline =
+        Date.now() +
+        Math.max(
+          OAUTH_POLL_INTERVAL_MS,
+          Math.min(OAUTH_POLL_TIMEOUT_MS, started.expiresAt - Date.now()),
+        );
+      while (Date.now() < deadline) {
+        if (connectCancelled.current) {
+          throw new Error('Authorization cancelled.');
+        }
+        await sleep(OAUTH_POLL_INTERVAL_MS);
+        const status = await fetchMcpOAuthStatus(auth.token, payload.name);
+        if (status.auth.state === 'connected') return payload.name;
+      }
+      throw new Error(
+        'Timed out waiting for authorization. Complete the login in the opened tab and try again.',
+      );
+    },
+    onSuccess: async (name) => {
+      setPendingAuthUrl(null);
+      await queryClient.invalidateQueries({ queryKey: ['mcp', auth.token] });
+      setSelectedName(name);
+      toast.success(`Connected to ${name} via OAuth.`);
+    },
+    onError: (error) => {
+      setPendingAuthUrl(null);
+      toast.error('OAuth connection failed', getErrorMessage(error));
+    },
+  });
+
+  const disconnectMutation = useMutation({
+    mutationFn: () => logoutMcpOAuth(auth.token, draft.name.trim()),
+    onSuccess: (payload) => {
+      queryClient.setQueryData(['mcp', auth.token], payload);
+      toast.success('OAuth credentials cleared.');
+    },
+    onError: (error) => {
+      toast.error('Disconnect failed', getErrorMessage(error));
+    },
+  });
+
   const selectedServer =
     mcpQuery.data?.servers.find((entry) => entry.name === selectedName) || null;
 
@@ -161,6 +261,15 @@ export function McpPage() {
       setDraft(createDraft());
     }
   }, [selectedName, selectedServer]);
+
+  useEffect(() => {
+    return () => {
+      connectCancelled.current = true;
+    };
+  }, []);
+
+  const authStatus = selectedServer?.auth;
+  const oauthConnected = authStatus?.state === 'connected';
 
   return (
     <div className="page-stack">
@@ -192,32 +301,53 @@ export function McpPage() {
               <div className="empty-state">Loading MCP servers...</div>
             ) : mcpQuery.data?.servers.length ? (
               <div className="list-stack selectable-list">
-                {mcpQuery.data.servers.map((server) => (
-                  <button
-                    key={server.name}
-                    className={
-                      server.name === selectedName
-                        ? 'selectable-row active'
-                        : 'selectable-row'
-                    }
-                    type="button"
-                    onClick={() => setSelectedName(server.name)}
-                  >
-                    <div>
-                      <strong>{server.name}</strong>
-                      <small>{server.summary}</small>
-                    </div>
-                    <BooleanPill
-                      value={server.enabled}
-                      trueLabel="active"
-                      falseLabel="inactive"
-                    />
-                  </button>
-                ))}
+                {mcpQuery.data.servers.map((server) => {
+                  const serverAuth =
+                    server.auth.method === 'oauth'
+                      ? describeAuthStatus(server.auth)
+                      : null;
+                  return (
+                    <button
+                      key={server.name}
+                      className={
+                        server.name === selectedName
+                          ? 'selectable-row active'
+                          : 'selectable-row'
+                      }
+                      type="button"
+                      onClick={() => setSelectedName(server.name)}
+                    >
+                      <div>
+                        <strong>{server.name}</strong>
+                        <small>
+                          {server.summary.startsWith(`${server.name} — `)
+                            ? server.summary.slice(server.name.length + 3)
+                            : server.summary}
+                        </small>
+                      </div>
+                      <div className="button-row">
+                        {serverAuth ? (
+                          <BooleanPill
+                            value={serverAuth.connected}
+                            trueLabel="oauth"
+                            falseLabel={serverAuth.label}
+                            falseTone="danger"
+                          />
+                        ) : null}
+                        <BooleanPill
+                          value={server.enabled}
+                          trueLabel="active"
+                          falseLabel="inactive"
+                        />
+                      </div>
+                    </button>
+                  );
+                })}
               </div>
             ) : (
               <div className="empty-state">
-                No MCP servers are configured yet.
+                No MCP servers are configured yet. Add a remote server with its
+                URL and connect it with OAuth, or run a local stdio command.
               </div>
             )}
           </CardContent>
@@ -225,7 +355,12 @@ export function McpPage() {
 
         <Card variant="muted">
           <CardHeader>
-            <CardTitle>Server editor</CardTitle>
+            <CardTitle>
+              {selectedServer ? `Edit ${selectedServer.name}` : 'New server'}
+            </CardTitle>
+            <CardDescription>
+              Changes apply on the next agent turn.
+            </CardDescription>
           </CardHeader>
           <CardContent>
             <div className="stack-form">
@@ -242,6 +377,10 @@ export function McpPage() {
                     }
                     placeholder="github"
                   />
+                  <FieldDescription>
+                    Lowercase letters, numbers, - and _. Used as the tool
+                    prefix.
+                  </FieldDescription>
                 </Field>
                 <Field>
                   <FieldLabel>Transport</FieldLabel>
@@ -254,9 +393,15 @@ export function McpPage() {
                       }))
                     }
                   >
-                    <NativeSelectOption value="stdio">stdio</NativeSelectOption>
-                    <NativeSelectOption value="http">http</NativeSelectOption>
-                    <NativeSelectOption value="sse">sse</NativeSelectOption>
+                    <NativeSelectOption value="http">
+                      http — remote server
+                    </NativeSelectOption>
+                    <NativeSelectOption value="sse">
+                      sse — remote server (legacy)
+                    </NativeSelectOption>
+                    <NativeSelectOption value="stdio">
+                      stdio — local command
+                    </NativeSelectOption>
                   </NativeSelect>
                 </Field>
               </div>
@@ -344,23 +489,112 @@ export function McpPage() {
                           url: event.target.value,
                         }))
                       }
-                      placeholder="https://example.test/mcp"
+                      placeholder="https://mcp.example.com/mcp"
                     />
                   </Field>
                   <Field>
-                    <FieldLabel>Headers JSON</FieldLabel>
-                    <Textarea
-                      rows={5}
-                      value={draft.headersJson}
+                    <FieldLabel>Authentication</FieldLabel>
+                    <NativeSelect
+                      value={draft.authMode}
                       onChange={(event) =>
                         setDraft((current) => ({
                           ...current,
-                          headersJson: event.target.value,
+                          authMode: event.target.value as McpAuthMode,
                         }))
                       }
-                      placeholder='{"Authorization":"Bearer ..."}'
-                    />
+                    >
+                      <NativeSelectOption value="oauth">
+                        OAuth — log in via browser
+                      </NativeSelectOption>
+                      <NativeSelectOption value="headers">
+                        Custom headers (API key / bearer token)
+                      </NativeSelectOption>
+                      <NativeSelectOption value="none">None</NativeSelectOption>
+                    </NativeSelect>
+                    <FieldDescription>
+                      {draft.authMode === 'oauth'
+                        ? 'The gateway discovers the authorization server, registers a client, and refreshes tokens automatically.'
+                        : draft.authMode === 'headers'
+                          ? 'Headers are sent with every request to the server.'
+                          : 'Requests are sent without credentials.'}
+                    </FieldDescription>
                   </Field>
+
+                  {draft.authMode === 'headers' ? (
+                    <Field>
+                      <FieldLabel>Headers JSON</FieldLabel>
+                      <Textarea
+                        rows={5}
+                        value={draft.headersJson}
+                        onChange={(event) =>
+                          setDraft((current) => ({
+                            ...current,
+                            headersJson: event.target.value,
+                          }))
+                        }
+                        placeholder='{"Authorization":"Bearer ..."}'
+                      />
+                    </Field>
+                  ) : null}
+
+                  {draft.authMode === 'oauth' ? (
+                    <Field orientation="horizontal">
+                      <FieldContent>
+                        <FieldLabel>OAuth connection</FieldLabel>
+                        <FieldDescription>
+                          {connectMutation.isPending
+                            ? 'Waiting for you to approve access in the browser...'
+                            : oauthConnected
+                              ? 'Connected. Tokens refresh automatically.'
+                              : authStatus?.state === 'expired'
+                                ? 'The session expired. Reconnect to continue.'
+                                : 'Not connected yet. Saving happens automatically when you connect.'}
+                          {pendingAuthUrl && connectMutation.isPending ? (
+                            <>
+                              {' '}
+                              <a
+                                href={pendingAuthUrl}
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                Open the login page
+                              </a>{' '}
+                              if it did not open automatically.
+                            </>
+                          ) : null}
+                        </FieldDescription>
+                      </FieldContent>
+                      <div className="button-row">
+                        <Button
+                          type="button"
+                          loading={connectMutation.isPending}
+                          disabled={
+                            connectMutation.isPending ||
+                            !draft.name.trim() ||
+                            !draft.url.trim()
+                          }
+                          onClick={() => connectMutation.mutate()}
+                        >
+                          {connectMutation.isPending
+                            ? 'Waiting...'
+                            : oauthConnected
+                              ? 'Reconnect'
+                              : 'Connect'}
+                        </Button>
+                        {oauthConnected ? (
+                          <Button
+                            variant="ghost"
+                            type="button"
+                            loading={disconnectMutation.isPending}
+                            disabled={disconnectMutation.isPending}
+                            onClick={() => disconnectMutation.mutate()}
+                          >
+                            Disconnect
+                          </Button>
+                        ) : null}
+                      </div>
+                    </Field>
+                  ) : null}
                 </>
               )}
 

--- a/console/src/routes/mcp.tsx
+++ b/console/src/routes/mcp.tsx
@@ -319,11 +319,7 @@ export function McpPage() {
                     >
                       <div>
                         <strong>{server.name}</strong>
-                        <small>
-                          {server.summary.startsWith(`${server.name} — `)
-                            ? server.summary.slice(server.name.length + 3)
-                            : server.summary}
-                        </small>
+                        <small>{server.summary}</small>
                       </div>
                       <div className="button-row">
                         {serverAuth ? (

--- a/container/src/mcp/types.ts
+++ b/container/src/mcp/types.ts
@@ -11,6 +11,8 @@ export interface McpServerConfig {
   cwd?: string;
   url?: string;
   headers?: Record<string, string>;
+  /** OAuth is handled by the gateway, which injects `headers.Authorization`. */
+  auth?: 'oauth';
   enabled?: boolean;
 }
 

--- a/docs/content/guides/tui-mcp.md
+++ b/docs/content/guides/tui-mcp.md
@@ -56,8 +56,9 @@ for remote servers — then log in:
 The gateway performs the full OAuth 2.1 flow on the host: it discovers the
 authorization server (RFC 9728/8414), registers a client dynamically
 (RFC 7591), runs the PKCE authorization-code exchange through
-`/api/mcp/oauth/callback`, and stores tokens in `~/.hybridclaw/mcp-oauth.json`
-(mode 0600). A fresh `Authorization` header is injected into the container's
+`/api/mcp/oauth/callback`, and stores tokens encrypted at rest in the runtime
+secret store (`~/.hybridclaw/credentials.json`, one `MCP_OAUTH_*` entry per
+server). A fresh `Authorization` header is injected into the container's
 MCP config on every turn, and tokens are refreshed automatically.
 
 The same flow is available in the web console on the MCP page via the

--- a/docs/content/guides/tui-mcp.md
+++ b/docs/content/guides/tui-mcp.md
@@ -22,14 +22,48 @@ Then use the TUI slash commands:
 
 ```text
 /mcp list
-/mcp add filesystem {"transport":"stdio","command":"npx","args":["-y","@modelcontextprotocol/server-filesystem","/Users/you/project"],"enabled":true}
+/mcp add                # guided wizard: name, transport, URL/command, auth
+/mcp edit <name>        # re-run the wizard prefilled with the saved config
 /mcp toggle filesystem
 /mcp reconnect filesystem
 /mcp remove filesystem
 ```
+
+`/mcp add` (without a JSON payload) starts an interactive wizard that asks for
+the transport, the URL or command, and the authentication method. The raw form
+`/mcp add <name> <json>` still works for scripted setups.
 
 Enabled MCP tools show up in prompts as namespaced tool names such as
 `filesystem__read_file` or `github__list_issues`.
 
 These `mcp list|add|remove|toggle|reconnect` commands update
 `~/.hybridclaw/config.json` and hot-reload future turns.
+
+## OAuth for remote MCP servers
+
+Remote `http`/`sse` servers that require OAuth (Linear, Notion, Sentry, and
+other hosted MCP servers) can be connected without handling tokens manually.
+Set `"auth": "oauth"` on the server — the wizard offers this as the default
+for remote servers — then log in:
+
+```text
+/mcp add                # choose http transport, then "OAuth"
+/mcp login <name>       # opens the provider's consent page in your browser
+/mcp status <name>      # shows connected / expired / login required
+/mcp logout <name>      # clears the stored credentials
+```
+
+The gateway performs the full OAuth 2.1 flow on the host: it discovers the
+authorization server (RFC 9728/8414), registers a client dynamically
+(RFC 7591), runs the PKCE authorization-code exchange through
+`/api/mcp/oauth/callback`, and stores tokens in `~/.hybridclaw/mcp-oauth.json`
+(mode 0600). A fresh `Authorization` header is injected into the container's
+MCP config on every turn, and tokens are refreshed automatically.
+
+The same flow is available in the web console on the MCP page via the
+**Connect** button, and from chat channels with `/mcp login <name>` (the
+authorization URL is printed for you to open).
+
+If the authorization server does not support dynamic client registration,
+configure the server with a static header instead:
+`{"transport":"http","url":"https://...","headers":{"Authorization":"Bearer <token>"}}`.

--- a/src/auth/codex-auth.ts
+++ b/src/auth/codex-auth.ts
@@ -1,4 +1,3 @@
-import { spawn } from 'node:child_process';
 import { createHash, randomBytes } from 'node:crypto';
 import fs from 'node:fs';
 import http from 'node:http';
@@ -8,6 +7,7 @@ import readline from 'node:readline/promises';
 import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
 import { CODEX_DEFAULT_BASE_URL } from '../providers/codex-constants.js';
 import { normalizeTrimmedString as normalizeString } from '../utils/normalized-strings.js';
+import { tryOpenUrlInBrowser } from '../utils/open-url.js';
 import { sleep } from '../utils/sleep.js';
 import { isRecord } from '../utils/type-guards.js';
 
@@ -176,31 +176,6 @@ function generatePkcePair(): PkcePair {
 
 function generateState(): string {
   return toBase64Url(randomBytes(32));
-}
-
-function getOpenCommand(url: string): { cmd: string; args: string[] } | null {
-  if (process.platform === 'darwin') return { cmd: 'open', args: [url] };
-  if (process.platform === 'win32')
-    return { cmd: 'cmd', args: ['/c', 'start', '', url] };
-  if (process.platform === 'linux') return { cmd: 'xdg-open', args: [url] };
-  return null;
-}
-
-async function openUrl(url: string): Promise<boolean> {
-  const openCommand = getOpenCommand(url);
-  if (!openCommand) return false;
-
-  return new Promise((resolve) => {
-    const child = spawn(openCommand.cmd, openCommand.args, {
-      stdio: 'ignore',
-      detached: true,
-    });
-    child.once('error', () => resolve(false));
-    child.once('spawn', () => {
-      child.unref();
-      resolve(true);
-    });
-  });
 }
 
 function maskToken(token: string): string {
@@ -1175,7 +1150,7 @@ export async function loginWithBrowserPkce(): Promise<{
     console.log(`Callback: ${redirectUri}`);
     console.log(`Auth URL: ${authUrl}`);
 
-    const opened = await openUrl(authUrl);
+    const opened = await tryOpenUrlInBrowser(authUrl);
     if (!opened) {
       console.log(
         'Could not open a browser automatically. Open the URL above.',

--- a/src/auth/hybridai-auth.ts
+++ b/src/auth/hybridai-auth.ts
@@ -1,4 +1,3 @@
-import { spawn } from 'node:child_process';
 import readline from 'node:readline/promises';
 
 import {
@@ -12,6 +11,7 @@ import {
   runtimeSecretsPath,
   saveRuntimeSecrets,
 } from '../security/runtime-secrets.js';
+import { tryOpenUrlInBrowser } from '../utils/open-url.js';
 import { promptForSecretInput } from '../utils/secret-prompt.js';
 
 export interface HybridAIAuthStatus {
@@ -168,32 +168,6 @@ async function validateApiKey(
   return { ok: true };
 }
 
-function getOpenCommand(url: string): { cmd: string; args: string[] } | null {
-  if (process.platform === 'darwin') return { cmd: 'open', args: [url] };
-  if (process.platform === 'win32') {
-    return { cmd: 'cmd', args: ['/c', 'start', '', url] };
-  }
-  if (process.platform === 'linux') return { cmd: 'xdg-open', args: [url] };
-  return null;
-}
-
-async function tryOpenUrl(url: string): Promise<boolean> {
-  const openCommand = getOpenCommand(url);
-  if (!openCommand) return false;
-
-  return new Promise((resolve) => {
-    const child = spawn(openCommand.cmd, openCommand.args, {
-      stdio: 'ignore',
-      detached: true,
-    });
-    child.once('error', () => resolve(false));
-    child.once('spawn', () => {
-      child.unref();
-      resolve(true);
-    });
-  });
-}
-
 async function promptYesNo(
   rl: readline.Interface,
   question: string,
@@ -244,7 +218,7 @@ async function loginWithApiKeyPrompt(options: {
       if (
         await promptYesNo(rl, 'Open the login page in your browser now?', true)
       ) {
-        const opened = await tryOpenUrl(loginUrl);
+        const opened = await tryOpenUrlInBrowser(loginUrl);
         if (!opened) {
           console.log('Could not auto-open browser. Open the link manually.');
         }

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -275,8 +275,10 @@ const LOCAL_SESSION_HELP_PRESENTATIONS: Record<
     description: 'Show current settings',
   },
   mcp: {
-    command: '/mcp [list|add|toggle|remove|reconnect] [name] [json]',
-    description: 'Manage MCP servers',
+    command:
+      '/mcp [list|add|edit|login|logout|status|toggle|remove|reconnect] [name] [json]',
+    description:
+      'Manage MCP servers (guided add/edit wizard and OAuth login in the TUI)',
   },
   model: {
     command:
@@ -2180,6 +2182,45 @@ function buildSlashCommandCatalogDefinitions(
             },
           ],
         },
+        {
+          kind: 'subcommand',
+          name: 'login',
+          description: 'Start the OAuth login flow for an MCP server',
+          options: [
+            {
+              kind: 'string',
+              name: 'name',
+              description: 'MCP server name',
+              required: true,
+            },
+          ],
+        },
+        {
+          kind: 'subcommand',
+          name: 'logout',
+          description: 'Clear stored OAuth credentials for an MCP server',
+          options: [
+            {
+              kind: 'string',
+              name: 'name',
+              description: 'MCP server name',
+              required: true,
+            },
+          ],
+        },
+        {
+          kind: 'subcommand',
+          name: 'status',
+          description: 'Show connection status for an MCP server',
+          options: [
+            {
+              kind: 'string',
+              name: 'name',
+              description: 'MCP server name',
+              required: true,
+            },
+          ],
+        },
       ],
     },
     {
@@ -3437,7 +3478,10 @@ export function parseCanonicalSlashCommandArgs(
       if (
         subcommand === 'remove' ||
         subcommand === 'toggle' ||
-        subcommand === 'reconnect'
+        subcommand === 'reconnect' ||
+        subcommand === 'login' ||
+        subcommand === 'logout' ||
+        subcommand === 'status'
       ) {
         const name = normalizeStringOption(interaction, 'name', true);
         return name ? ['mcp', subcommand, name] : null;

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -2988,6 +2988,12 @@ function normalizeMcpServerConfig(value: unknown): McpServerConfig | null {
   const cwd = normalizeString(value.cwd, '', { allowEmpty: true });
   const url = normalizeString(value.url, '', { allowEmpty: true });
   const headers = normalizeStringRecord(value.headers);
+  const auth =
+    String(value.auth || '')
+      .trim()
+      .toLowerCase() === 'oauth' && transport !== 'stdio'
+      ? ('oauth' as const)
+      : undefined;
   const enabled = normalizeBoolean(value.enabled, true);
 
   if (transport === 'stdio' && !command) return null;
@@ -3001,6 +3007,7 @@ function normalizeMcpServerConfig(value: unknown): McpServerConfig | null {
     ...(cwd ? { cwd } : {}),
     ...(url ? { url } : {}),
     ...(Object.keys(headers).length > 0 ? { headers } : {}),
+    ...(auth ? { auth } : {}),
     enabled,
   };
 }

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -47,6 +47,7 @@ import {
   normalizeSlackWebhookUrl,
   SLACK_WEBHOOK_DEFAULT_TARGET,
 } from '../channels/slack-webhook/target.js';
+import { supportsMcpOAuth } from '../mcp/server-config.js';
 import type {
   MemoryEmbeddingDtype,
   MemoryEmbeddingProviderKind,
@@ -2991,7 +2992,7 @@ function normalizeMcpServerConfig(value: unknown): McpServerConfig | null {
   const auth =
     String(value.auth || '')
       .trim()
-      .toLowerCase() === 'oauth' && transport !== 'stdio'
+      .toLowerCase() === 'oauth' && supportsMcpOAuth(transport)
       ? ('oauth' as const)
       : undefined;
   const enabled = normalizeBoolean(value.enabled, true);

--- a/src/gateway/docs.ts
+++ b/src/gateway/docs.ts
@@ -172,7 +172,7 @@ type PromotedSidebarGroup = {
 
 let developmentDocsSnapshotCache: DevelopmentDocsSnapshot | null = null;
 
-function escapeHtml(value: string): string {
+export function escapeHtml(value: string): string {
   return value
     .replaceAll('&', '&amp;')
     .replaceAll('<', '&lt;')

--- a/src/gateway/gateway-client.ts
+++ b/src/gateway/gateway-client.ts
@@ -1,6 +1,9 @@
 import type { SkillConfigChannelKind } from '../channels/channel.js';
 import { GATEWAY_API_TOKEN, GATEWAY_BASE_URL } from '../config/config.js';
 import {
+  type GatewayAdminMcpOAuthStartResponse,
+  type GatewayAdminMcpOAuthStatusResponse,
+  type GatewayAdminMcpResponse,
   type GatewayAdminSkillsResponse,
   type GatewayAdminSuspendedSession,
   type GatewayChatApprovalEvent,
@@ -333,6 +336,69 @@ export async function saveGatewayAdminSkillEnabled(params: {
       ...authHeaders(),
     },
     body: JSON.stringify(params),
+  });
+}
+
+export async function fetchGatewayAdminMcp(): Promise<GatewayAdminMcpResponse> {
+  return requestJson<GatewayAdminMcpResponse>('/api/admin/mcp', {
+    method: 'GET',
+    headers: authHeaders(),
+  });
+}
+
+export async function saveGatewayAdminMcpServer(params: {
+  name: string;
+  config: unknown;
+}): Promise<GatewayAdminMcpResponse> {
+  return requestJson<GatewayAdminMcpResponse>('/api/admin/mcp', {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeaders(),
+    },
+    body: JSON.stringify(params),
+  });
+}
+
+export async function startGatewayMcpOAuth(
+  name: string,
+): Promise<GatewayAdminMcpOAuthStartResponse> {
+  return requestJson<GatewayAdminMcpOAuthStartResponse>(
+    '/api/admin/mcp/oauth/start',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...authHeaders(),
+      },
+      body: JSON.stringify({ name }),
+    },
+  );
+}
+
+export async function fetchGatewayMcpOAuthStatus(
+  name: string,
+): Promise<GatewayAdminMcpOAuthStatusResponse> {
+  const params = new URLSearchParams({ name });
+  return requestJson<GatewayAdminMcpOAuthStatusResponse>(
+    `/api/admin/mcp/oauth/status?${params.toString()}`,
+    {
+      method: 'GET',
+      headers: authHeaders(),
+    },
+  );
+}
+
+export async function logoutGatewayMcpOAuth(
+  name: string,
+): Promise<GatewayAdminMcpResponse> {
+  return requestJson<GatewayAdminMcpResponse>('/api/admin/mcp/oauth/logout', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeaders(),
+    },
+    body: JSON.stringify({ name }),
   });
 }
 

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -156,7 +156,7 @@ import {
   normalizePlaceholderToolReply,
   normalizeSilentMessageSendReply,
 } from './chat-result.js';
-import { serveDocs } from './docs.js';
+import { escapeHtml, serveDocs } from './docs.js';
 import {
   getGatewayAdminSecrets,
   overwriteGatewayAdminSecret,
@@ -5336,18 +5336,6 @@ async function handleApiAdminMcp(
   );
 }
 
-function resolveRequestBaseUrl(req: IncomingMessage): string | undefined {
-  const host = String(req.headers['x-forwarded-host'] || req.headers.host || '')
-    .split(',')[0]
-    .trim();
-  if (!host) return undefined;
-  const proto =
-    String(req.headers['x-forwarded-proto'] || '')
-      .split(',')[0]
-      .trim() || 'http';
-  return `${proto}://${host}`;
-}
-
 async function handleApiAdminMcpOAuth(
   req: IncomingMessage,
   res: ServerResponse,
@@ -5367,7 +5355,7 @@ async function handleApiAdminMcpOAuth(
       200,
       await startGatewayAdminMcpOAuth({
         name,
-        requestBaseUrl: resolveRequestBaseUrl(req),
+        requestBaseUrl: resolveRequestOrigin(req),
       }),
     );
     return;
@@ -5382,12 +5370,6 @@ function sendMcpOAuthCallbackPage(
   detail: string,
   opts?: { autoClose?: boolean },
 ): void {
-  const escapeHtml = (value: string) =>
-    value
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;');
   // window.close() only works for script-opened tabs (the console's
   // window.open); for manually opened tabs it is a silent no-op.
   const autoClose = opts?.autoClose

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -203,6 +203,7 @@ import { handleApiSecretInject } from './gateway-secret-injection.js';
 import {
   applyGatewayAdminPolicyPreset,
   approveGatewayAdminA2APairingRequest,
+  completeGatewayMcpOAuthCallback,
   createGatewayAdminAgent,
   createGatewayAdminSkill,
   declineGatewayAdminA2APairingRequest,
@@ -229,6 +230,7 @@ import {
   getGatewayAdminHybridAIBots,
   getGatewayAdminJobsContext,
   getGatewayAdminMcp,
+  getGatewayAdminMcpOAuthStatus,
   getGatewayAdminModels,
   getGatewayAdminOverview,
   getGatewayAdminSessions,
@@ -246,6 +248,7 @@ import {
   getGatewaySessionContextUsage,
   getGatewayStatus,
   handleGatewayCommand,
+  logoutGatewayAdminMcpOAuth,
   previewGatewayAdminA2APairing,
   reconnectGatewayAdminTunnel,
   removeGatewayAdminChannel,
@@ -263,6 +266,7 @@ import {
   saveGatewayAdminSlackWebhookTarget,
   setGatewayAdminSkillEnabled,
   startGatewayAdminA2APairing,
+  startGatewayAdminMcpOAuth,
   unblockGatewayAdminSkill,
   updateGatewayAdminAgent,
   uploadGatewayAdminSkillZip,
@@ -5332,6 +5336,118 @@ async function handleApiAdminMcp(
   );
 }
 
+function resolveRequestBaseUrl(req: IncomingMessage): string | undefined {
+  const host = String(req.headers['x-forwarded-host'] || req.headers.host || '')
+    .split(',')[0]
+    .trim();
+  if (!host) return undefined;
+  const proto =
+    String(req.headers['x-forwarded-proto'] || '')
+      .split(',')[0]
+      .trim() || 'http';
+  return `${proto}://${host}`;
+}
+
+async function handleApiAdminMcpOAuth(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL,
+): Promise<void> {
+  const pathname = url.pathname;
+  if (pathname === '/api/admin/mcp/oauth/status') {
+    const name = (url.searchParams.get('name') || '').trim();
+    sendJson(res, 200, getGatewayAdminMcpOAuthStatus(name));
+    return;
+  }
+  const body = (await readJsonBody(req)) as { name?: unknown };
+  const name = String(body.name || '').trim();
+  if (pathname === '/api/admin/mcp/oauth/start') {
+    sendJson(
+      res,
+      200,
+      await startGatewayAdminMcpOAuth({
+        name,
+        requestBaseUrl: resolveRequestBaseUrl(req),
+      }),
+    );
+    return;
+  }
+  sendJson(res, 200, logoutGatewayAdminMcpOAuth(name));
+}
+
+function sendMcpOAuthCallbackPage(
+  res: ServerResponse,
+  status: number,
+  title: string,
+  detail: string,
+  opts?: { autoClose?: boolean },
+): void {
+  const escapeHtml = (value: string) =>
+    value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  // window.close() only works for script-opened tabs (the console's
+  // window.open); for manually opened tabs it is a silent no-op.
+  const autoClose = opts?.autoClose
+    ? '<script>setTimeout(function(){window.close()},1500)</script>'
+    : '';
+  res.writeHead(status, { 'Content-Type': 'text/html; charset=utf-8' });
+  res.end(
+    `<!doctype html><html><head><meta charset="utf-8"><title>${escapeHtml(title)}</title>` +
+      '<style>body{font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;background:#101418;color:#e8eaed}main{max-width:28rem;padding:2rem;text-align:center}h1{font-size:1.25rem}p{color:#9aa0a6}</style>' +
+      `</head><body><main><h1>${escapeHtml(title)}</h1><p>${escapeHtml(detail)}</p></main>${autoClose}</body></html>`,
+  );
+}
+
+async function handleApiMcpOAuthCallback(
+  res: ServerResponse,
+  url: URL,
+): Promise<void> {
+  const error = (url.searchParams.get('error') || '').trim();
+  if (error) {
+    const description = (
+      url.searchParams.get('error_description') || ''
+    ).trim();
+    sendMcpOAuthCallbackPage(
+      res,
+      400,
+      'MCP authorization failed',
+      description || error,
+    );
+    return;
+  }
+  const state = (url.searchParams.get('state') || '').trim();
+  const code = (url.searchParams.get('code') || '').trim();
+  if (!state || !code) {
+    sendMcpOAuthCallbackPage(
+      res,
+      400,
+      'MCP authorization failed',
+      'The callback is missing the authorization code or state parameter.',
+    );
+    return;
+  }
+  try {
+    const result = await completeGatewayMcpOAuthCallback({ state, code });
+    sendMcpOAuthCallbackPage(
+      res,
+      200,
+      `Connected to ${result.serverName}`,
+      'Authorization complete. You can close this tab and return to HybridClaw.',
+      { autoClose: true },
+    );
+  } catch (err) {
+    sendMcpOAuthCallbackPage(
+      res,
+      400,
+      'MCP authorization failed',
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
 function handleApiAdminAudit(res: ServerResponse, url: URL): void {
   const parsedLimit = parseInt(url.searchParams.get('limit') || '60', 10);
   const limit = Number.isNaN(parsedLimit) ? 60 : parsedLimit;
@@ -6854,6 +6970,18 @@ export function startGatewayHttpServer(): GatewayHttpServer {
         });
         return;
       }
+      if (pathname === '/api/mcp/oauth/callback' && method === 'GET') {
+        // Public by design: the OAuth provider redirects the user's browser
+        // here without gateway credentials. The flow is bound to a
+        // single-use `state` nonce validated by the pending-flow registry.
+        void handleApiMcpOAuthCallback(res, url).catch((err: unknown) => {
+          if (res.writableEnded) return;
+          sendJson(res, 500, {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
+        return;
+      }
       if (pathname === '/api/agent-avatar' && method === 'GET') {
         try {
           handleApiAgentAvatar(req, res, url);
@@ -7017,6 +7145,15 @@ export function startGatewayHttpServer(): GatewayHttpServer {
             (method === 'GET' || method === 'PUT' || method === 'DELETE')
           ) {
             await handleApiAdminMcp(req, res, url);
+            return;
+          }
+          if (
+            ((pathname === '/api/admin/mcp/oauth/start' ||
+              pathname === '/api/admin/mcp/oauth/logout') &&
+              method === 'POST') ||
+            (pathname === '/api/admin/mcp/oauth/status' && method === 'GET')
+          ) {
+            await handleApiAdminMcpOAuth(req, res, url);
             return;
           }
           if (

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -223,6 +223,7 @@ import {
   type McpOAuthStatus,
   startMcpOAuthFlow,
 } from '../mcp/mcp-oauth.js';
+import { MCP_SERVER_NAME_RE, supportsMcpOAuth } from '../mcp/server-config.js';
 import { isAudioMediaItem } from '../media/audio-transcription.js';
 import { summarizeMediaFilenames } from '../media/media-summary.js';
 import {
@@ -543,6 +544,7 @@ import {
   type GatewayAdminJobCardEdge,
   type GatewayAdminJobsContextResponse,
   type GatewayAdminLanHttpAccessMode,
+  type GatewayAdminMcpOAuthStatusResponse,
   type GatewayAdminMcpResponse,
   type GatewayAdminModelsResponse,
   type GatewayAdminModelUsageRow,
@@ -3964,8 +3966,6 @@ function enableFullAutoCommand(params: {
   );
 }
 
-const MCP_SERVER_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/;
-
 export function parseMcpServerName(rawName: string): {
   name?: string;
   error?: string;
@@ -4040,7 +4040,7 @@ export function parseMcpServerConfig(rawJson: string): {
   if (rawAuth && rawAuth !== 'none' && rawAuth !== 'oauth') {
     return { error: 'MCP server `auth` must be `oauth` when set.' };
   }
-  if (rawAuth === 'oauth' && transport === 'stdio') {
+  if (rawAuth === 'oauth' && !supportsMcpOAuth(transport)) {
     return {
       error: 'OAuth is only supported for `http` and `sse` MCP servers.',
     };
@@ -4056,28 +4056,24 @@ export function parseMcpServerConfig(rawJson: string): {
   return { config };
 }
 
-function describeMcpServerAuth(name: string, config: McpServerConfig): string {
-  if (config.auth !== 'oauth') return '';
-  const status = getMcpOAuthStatus(name, config);
+function describeMcpServerAuth(status: McpOAuthStatus): string {
+  if (status.method !== 'oauth') return '';
   if (status.state === 'connected') return ' · oauth: connected';
   if (status.state === 'expired') return ' · oauth: expired';
   return ' · oauth: login required';
 }
 
-function mcpOAuthNeedsLogin(name: string, config: McpServerConfig): boolean {
-  return (
-    config.auth === 'oauth' &&
-    getMcpOAuthStatus(name, config).state !== 'connected'
-  );
+function mcpOAuthNeedsLogin(status: McpOAuthStatus): boolean {
+  return status.method === 'oauth' && status.state !== 'connected';
 }
 
-function summarizeMcpServer(name: string, config: McpServerConfig): string {
+function summarizeMcpServer(config: McpServerConfig): string {
   const enabled = config.enabled === false ? 'disabled' : 'enabled';
   const target =
     config.transport === 'stdio'
       ? [config.command, ...(config.args || [])].filter(Boolean).join(' ')
       : config.url || '(missing url)';
-  return `${name} — ${enabled} · ${config.transport} · ${target || '(missing command)'}${describeMcpServerAuth(name, config)}`;
+  return `${enabled} · ${config.transport} · ${target || '(missing command)'}`;
 }
 
 function restartNoteForMcpChange(sessionId: string): string {
@@ -6494,7 +6490,7 @@ export function getGatewayAdminMcp(): GatewayAdminMcpResponse {
     .map(([name, config]) => ({
       name,
       enabled: config.enabled !== false,
-      summary: summarizeMcpServer(name, config),
+      summary: summarizeMcpServer(config),
       config,
       auth: getMcpOAuthStatus(name, config),
     }));
@@ -6533,7 +6529,7 @@ export async function startGatewayAdminMcpOAuth(input: {
   requestBaseUrl?: string;
 }): Promise<McpOAuthStartResult> {
   const { name, config } = requireConfiguredMcpServer(input.name);
-  if (config.transport !== 'http' && config.transport !== 'sse') {
+  if (!supportsMcpOAuth(config.transport)) {
     throw new Error('OAuth is only supported for http and sse MCP servers.');
   }
   if (!config.url?.trim()) {
@@ -6559,10 +6555,9 @@ export async function completeGatewayMcpOAuthCallback(input: {
   return await completeMcpOAuthFlow(input);
 }
 
-export function getGatewayAdminMcpOAuthStatus(name: string): {
-  name: string;
-  auth: McpOAuthStatus;
-} {
+export function getGatewayAdminMcpOAuthStatus(
+  name: string,
+): GatewayAdminMcpOAuthStatusResponse {
   const server = requireConfiguredMcpServer(name);
   return {
     name: server.name,
@@ -6591,14 +6586,19 @@ export function upsertGatewayAdminMcpServer(input: {
     throw new Error(parsedConfig.error || 'Invalid MCP server config.');
   }
   const serverName = parsedName.name;
-  if (!serverName) {
-    throw new Error(parsedName.error || 'Invalid MCP server name.');
-  }
 
   updateRuntimeConfig((draft) => {
     draft.mcpServers[serverName] = parsedConfig.config as McpServerConfig;
   });
   return getGatewayAdminMcp();
+}
+
+// Deleting a server must also drop its stored OAuth credentials.
+function deleteMcpServerConfig(name: string): void {
+  updateRuntimeConfig((draft) => {
+    delete draft.mcpServers[name];
+  });
+  clearMcpOAuth(name);
 }
 
 export function removeGatewayAdminMcpServer(
@@ -6608,15 +6608,8 @@ export function removeGatewayAdminMcpServer(
   if (!parsedName.name) {
     throw new Error(parsedName.error || 'Invalid MCP server name.');
   }
-  const serverName = parsedName.name;
-  if (!serverName) {
-    throw new Error(parsedName.error || 'Invalid MCP server name.');
-  }
 
-  updateRuntimeConfig((draft) => {
-    delete draft.mcpServers[serverName];
-  });
-  clearMcpOAuth(serverName);
+  deleteMcpServerConfig(parsedName.name);
   return getGatewayAdminMcp();
 }
 
@@ -11228,12 +11221,14 @@ export async function handleGatewayCommand(
             );
           }
           entries.sort(([left], [right]) => left.localeCompare(right));
-          const lines = entries.map(([name, config]) =>
-            summarizeMcpServer(name, config),
+          const statuses = entries.map(([name, config]) =>
+            getMcpOAuthStatus(name, config),
           );
-          if (
-            entries.some(([name, config]) => mcpOAuthNeedsLogin(name, config))
-          ) {
+          const lines = entries.map(
+            ([name, config], index) =>
+              `${name} — ${summarizeMcpServer(config)}${describeMcpServerAuth(statuses[index])}`,
+          );
+          if (statuses.some(mcpOAuthNeedsLogin)) {
             lines.push('', 'Connect OAuth servers with `mcp login <name>`.');
           }
           return infoCommand('MCP Servers', lines.join('\n'));
@@ -11276,10 +11271,7 @@ export async function handleGatewayCommand(
               `MCP server \`${name}\` was not found.`,
             );
           }
-          updateRuntimeConfig((draft) => {
-            delete draft.mcpServers[name];
-          });
-          clearMcpOAuth(name);
+          deleteMcpServerConfig(name);
           return plainCommand(
             `MCP server \`${name}\` removed.${restartNoteForMcpChange(req.sessionId)}`,
           );
@@ -11360,10 +11352,11 @@ export async function handleGatewayCommand(
               `MCP server \`${name}\` was not found.`,
             );
           }
+          const status = getMcpOAuthStatus(name, servers[name]);
           return infoCommand(
             'MCP Server Status',
-            summarizeMcpServer(name, servers[name]) +
-              (mcpOAuthNeedsLogin(name, servers[name])
+            `${name} — ${summarizeMcpServer(servers[name])}${describeMcpServerAuth(status)}` +
+              (mcpOAuthNeedsLogin(status)
                 ? `\nRun \`mcp login ${name}\` to connect.`
                 : ''),
           );

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -215,6 +215,14 @@ import { stopSessionHostProcess } from '../infra/host-runner.js';
 import { resolveInstallRoot } from '../infra/install-root.js';
 import { agentWorkspaceDir } from '../infra/ipc.js';
 import { logger } from '../logger.js';
+import {
+  clearMcpOAuth,
+  completeMcpOAuthFlow,
+  getMcpOAuthStatus,
+  type McpOAuthStartResult,
+  type McpOAuthStatus,
+  startMcpOAuthFlow,
+} from '../mcp/mcp-oauth.js';
 import { isAudioMediaItem } from '../media/audio-transcription.js';
 import { summarizeMediaFilenames } from '../media/media-summary.js';
 import {
@@ -3975,7 +3983,7 @@ export function parseMcpServerName(rawName: string): {
   return { name };
 }
 
-function parseMcpServerConfig(rawJson: string): {
+export function parseMcpServerConfig(rawJson: string): {
   config?: McpServerConfig;
   error?: string;
 } {
@@ -4026,7 +4034,41 @@ function parseMcpServerConfig(rawJson: string): {
     };
   }
 
-  return { config: parsed as McpServerConfig };
+  const rawAuth = String(record.auth ?? '')
+    .trim()
+    .toLowerCase();
+  if (rawAuth && rawAuth !== 'none' && rawAuth !== 'oauth') {
+    return { error: 'MCP server `auth` must be `oauth` when set.' };
+  }
+  if (rawAuth === 'oauth' && transport === 'stdio') {
+    return {
+      error: 'OAuth is only supported for `http` and `sse` MCP servers.',
+    };
+  }
+
+  const config = parsed as McpServerConfig;
+  config.transport = transport;
+  if (rawAuth === 'oauth') {
+    config.auth = 'oauth';
+  } else {
+    delete config.auth;
+  }
+  return { config };
+}
+
+function describeMcpServerAuth(name: string, config: McpServerConfig): string {
+  if (config.auth !== 'oauth') return '';
+  const status = getMcpOAuthStatus(name, config);
+  if (status.state === 'connected') return ' · oauth: connected';
+  if (status.state === 'expired') return ' · oauth: expired';
+  return ' · oauth: login required';
+}
+
+function mcpOAuthNeedsLogin(name: string, config: McpServerConfig): boolean {
+  return (
+    config.auth === 'oauth' &&
+    getMcpOAuthStatus(name, config).state !== 'connected'
+  );
 }
 
 function summarizeMcpServer(name: string, config: McpServerConfig): string {
@@ -4035,7 +4077,7 @@ function summarizeMcpServer(name: string, config: McpServerConfig): string {
     config.transport === 'stdio'
       ? [config.command, ...(config.args || [])].filter(Boolean).join(' ')
       : config.url || '(missing url)';
-  return `${name} — ${enabled} · ${config.transport} · ${target || '(missing command)'}`;
+  return `${name} — ${enabled} · ${config.transport} · ${target || '(missing command)'}${describeMcpServerAuth(name, config)}`;
 }
 
 function restartNoteForMcpChange(sessionId: string): string {
@@ -6454,8 +6496,86 @@ export function getGatewayAdminMcp(): GatewayAdminMcpResponse {
       enabled: config.enabled !== false,
       summary: summarizeMcpServer(name, config),
       config,
+      auth: getMcpOAuthStatus(name, config),
     }));
   return { servers };
+}
+
+function requireConfiguredMcpServer(name: string): {
+  name: string;
+  config: McpServerConfig;
+} {
+  const parsedName = parseMcpServerName(name);
+  if (!parsedName.name) {
+    throw new Error(parsedName.error || 'Invalid MCP server name.');
+  }
+  const config = getRuntimeConfig().mcpServers[parsedName.name];
+  if (!config) {
+    throw new Error(`MCP server \`${parsedName.name}\` was not found.`);
+  }
+  return { name: parsedName.name, config };
+}
+
+export function resolveMcpOAuthRedirectUri(requestBaseUrl?: string): string {
+  const base = String(requestBaseUrl || GATEWAY_BASE_URL || '')
+    .trim()
+    .replace(/\/+$/, '');
+  if (!base) {
+    throw new Error(
+      'Cannot determine the gateway base URL for the OAuth redirect.',
+    );
+  }
+  return `${base}/api/mcp/oauth/callback`;
+}
+
+export async function startGatewayAdminMcpOAuth(input: {
+  name: string;
+  requestBaseUrl?: string;
+}): Promise<McpOAuthStartResult> {
+  const { name, config } = requireConfiguredMcpServer(input.name);
+  if (config.transport !== 'http' && config.transport !== 'sse') {
+    throw new Error('OAuth is only supported for http and sse MCP servers.');
+  }
+  if (!config.url?.trim()) {
+    throw new Error(`MCP server \`${name}\` has no URL configured.`);
+  }
+  if (config.auth !== 'oauth') {
+    updateRuntimeConfig((draft) => {
+      const entry = draft.mcpServers[name];
+      if (entry) entry.auth = 'oauth';
+    });
+  }
+  return await startMcpOAuthFlow({
+    serverName: name,
+    serverUrl: config.url.trim(),
+    redirectUri: resolveMcpOAuthRedirectUri(input.requestBaseUrl),
+  });
+}
+
+export async function completeGatewayMcpOAuthCallback(input: {
+  state: string;
+  code: string;
+}): Promise<{ serverName: string }> {
+  return await completeMcpOAuthFlow(input);
+}
+
+export function getGatewayAdminMcpOAuthStatus(name: string): {
+  name: string;
+  auth: McpOAuthStatus;
+} {
+  const server = requireConfiguredMcpServer(name);
+  return {
+    name: server.name,
+    auth: getMcpOAuthStatus(server.name, server.config),
+  };
+}
+
+export function logoutGatewayAdminMcpOAuth(
+  name: string,
+): GatewayAdminMcpResponse {
+  const server = requireConfiguredMcpServer(name);
+  clearMcpOAuth(server.name);
+  return getGatewayAdminMcp();
 }
 
 export function upsertGatewayAdminMcpServer(input: {
@@ -6496,6 +6616,7 @@ export function removeGatewayAdminMcpServer(
   updateRuntimeConfig((draft) => {
     delete draft.mcpServers[serverName];
   });
+  clearMcpOAuth(serverName);
   return getGatewayAdminMcp();
 }
 
@@ -11107,12 +11228,15 @@ export async function handleGatewayCommand(
             );
           }
           entries.sort(([left], [right]) => left.localeCompare(right));
-          return infoCommand(
-            'MCP Servers',
-            entries
-              .map(([name, config]) => summarizeMcpServer(name, config))
-              .join('\n'),
+          const lines = entries.map(([name, config]) =>
+            summarizeMcpServer(name, config),
           );
+          if (
+            entries.some(([name, config]) => mcpOAuthNeedsLogin(name, config))
+          ) {
+            lines.push('', 'Connect OAuth servers with `mcp login <name>`.');
+          }
+          return infoCommand('MCP Servers', lines.join('\n'));
         }
 
         if (sub === 'add') {
@@ -11155,6 +11279,7 @@ export async function handleGatewayCommand(
           updateRuntimeConfig((draft) => {
             delete draft.mcpServers[name];
           });
+          clearMcpOAuth(name);
           return plainCommand(
             `MCP server \`${name}\` removed.${restartNoteForMcpChange(req.sessionId)}`,
           );
@@ -11198,9 +11323,74 @@ export async function handleGatewayCommand(
           );
         }
 
+        if (sub === 'login') {
+          const name = parseIdArg(req.args, 2);
+          if (!name) {
+            return badCommand('Usage', 'Usage: `mcp login <name>`');
+          }
+          try {
+            const started = await startGatewayAdminMcpOAuth({ name });
+            return infoCommand(
+              'MCP OAuth Login',
+              [
+                `Open this URL in your browser to authorize \`${name}\`:`,
+                started.authorizationUrl,
+                '',
+                'After approving access, run `mcp status ' +
+                  name +
+                  '` to confirm the connection.',
+              ].join('\n'),
+            );
+          } catch (error) {
+            return badCommand(
+              'MCP OAuth Login Failed',
+              error instanceof Error ? error.message : String(error),
+            );
+          }
+        }
+
+        if (sub === 'status') {
+          const name = parseIdArg(req.args, 2);
+          if (!name) {
+            return badCommand('Usage', 'Usage: `mcp status <name>`');
+          }
+          if (!servers[name]) {
+            return badCommand(
+              'Not Found',
+              `MCP server \`${name}\` was not found.`,
+            );
+          }
+          return infoCommand(
+            'MCP Server Status',
+            summarizeMcpServer(name, servers[name]) +
+              (mcpOAuthNeedsLogin(name, servers[name])
+                ? `\nRun \`mcp login ${name}\` to connect.`
+                : ''),
+          );
+        }
+
+        if (sub === 'logout') {
+          const name = parseIdArg(req.args, 2);
+          if (!name) {
+            return badCommand('Usage', 'Usage: `mcp logout <name>`');
+          }
+          if (!servers[name]) {
+            return badCommand(
+              'Not Found',
+              `MCP server \`${name}\` was not found.`,
+            );
+          }
+          const cleared = clearMcpOAuth(name);
+          return plainCommand(
+            cleared
+              ? `Cleared OAuth credentials for \`${name}\`. Run \`mcp login ${name}\` to reconnect.`
+              : `MCP server \`${name}\` has no stored OAuth credentials.`,
+          );
+        }
+
         return badCommand(
           'Usage',
-          'Usage: `mcp list|add <name> <json>|remove <name>|toggle <name>|reconnect <name>`',
+          'Usage: `mcp list|add <name> <json>|remove <name>|toggle <name>|reconnect <name>|login <name>|logout <name>|status <name>`',
         );
       }
 

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -1355,15 +1355,37 @@ export interface GatewayAdminSchedulerResponse {
   jobs: GatewayAdminSchedulerJob[];
 }
 
+export type GatewayAdminMcpAuthState = 'connected' | 'expired' | 'unauthorized';
+
+export interface GatewayAdminMcpAuthStatus {
+  method: 'oauth' | 'none';
+  state?: GatewayAdminMcpAuthState;
+  expiresAt?: number | null;
+  scope?: string;
+}
+
 export interface GatewayAdminMcpServer {
   name: string;
   enabled: boolean;
   summary: string;
   config: McpServerConfig;
+  auth: GatewayAdminMcpAuthStatus;
 }
 
 export interface GatewayAdminMcpResponse {
   servers: GatewayAdminMcpServer[];
+}
+
+export interface GatewayAdminMcpOAuthStartResponse {
+  serverName: string;
+  authorizationUrl: string;
+  state: string;
+  expiresAt: number;
+}
+
+export interface GatewayAdminMcpOAuthStatusResponse {
+  name: string;
+  auth: GatewayAdminMcpAuthStatus;
 }
 
 export interface GatewayAdminAuditEntry {

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -24,6 +24,11 @@ import type {
   RuntimeMSTeamsChannelConfig,
   RuntimeSchedulerJob,
 } from '../config/runtime-config.js';
+import type {
+  McpOAuthConnectionState,
+  McpOAuthStartResult,
+  McpOAuthStatus,
+} from '../mcp/mcp-oauth.js';
 import type { AgentScoreboardEntry } from '../skills/adaptive-skills-types.js';
 import type {
   SkillManifestConfigVariable,
@@ -1355,14 +1360,9 @@ export interface GatewayAdminSchedulerResponse {
   jobs: GatewayAdminSchedulerJob[];
 }
 
-export type GatewayAdminMcpAuthState = 'connected' | 'expired' | 'unauthorized';
+export type GatewayAdminMcpAuthState = McpOAuthConnectionState;
 
-export interface GatewayAdminMcpAuthStatus {
-  method: 'oauth' | 'none';
-  state?: GatewayAdminMcpAuthState;
-  expiresAt?: number | null;
-  scope?: string;
-}
+export type GatewayAdminMcpAuthStatus = McpOAuthStatus;
 
 export interface GatewayAdminMcpServer {
   name: string;
@@ -1376,12 +1376,7 @@ export interface GatewayAdminMcpResponse {
   servers: GatewayAdminMcpServer[];
 }
 
-export interface GatewayAdminMcpOAuthStartResponse {
-  serverName: string;
-  authorizationUrl: string;
-  state: string;
-  expiresAt: number;
-}
+export type GatewayAdminMcpOAuthStartResponse = McpOAuthStartResult;
 
 export interface GatewayAdminMcpOAuthStatusResponse {
   name: string;

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -60,6 +60,7 @@ import type { CodexTurnRuntime } from '../config/runtime-config.js';
 import { readStoredRuntimeEnv } from '../config/runtime-env.js';
 import { GATEWAY_DEBUG_MODEL_RESPONSES_ENV } from '../gateway/gateway-lifecycle.js';
 import { logger } from '../logger.js';
+import { resolveMcpServersForRuntime } from '../mcp/mcp-oauth.js';
 import { resolveUploadedMediaCacheHostDir } from '../media/uploaded-media-cache.js';
 import { withSpan } from '../observability/otel.js';
 import { resolveModelRuntimeCredentials } from '../providers/factory.js';
@@ -1090,6 +1091,7 @@ async function runContainerInner(
 
   const startTime = Date.now();
   const webSearchRuntime = resolveWebSearchRuntimeConfig(agentId);
+  const mcpServers = await resolveMcpServersForRuntime(MCP_SERVERS);
   const existingEntry = pool.get(sessionId);
   const selectedCodexRuntime =
     modelRuntime.provider === 'openai-codex' ? CODEX_RUNTIME : 'hybridclaw';
@@ -1149,7 +1151,7 @@ async function runContainerInner(
     media,
     audioTranscriptsPrepended,
     pluginTools,
-    mcpServers: MCP_SERVERS,
+    mcpServers,
     taskModels,
     runtimeEnv,
     contextGuard: {

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -48,6 +48,7 @@ import type { CodexTurnRuntime } from '../config/runtime-config.js';
 import { readStoredRuntimeEnv } from '../config/runtime-env.js';
 import { GATEWAY_DEBUG_MODEL_RESPONSES_ENV } from '../gateway/gateway-lifecycle.js';
 import { logger } from '../logger.js';
+import { resolveMcpServersForRuntime } from '../mcp/mcp-oauth.js';
 import { resolveUploadedMediaCacheHostDir } from '../media/uploaded-media-cache.js';
 import { withSpan } from '../observability/otel.js';
 import { resolveModelRuntimeCredentials } from '../providers/factory.js';
@@ -938,6 +939,7 @@ async function runHostProcessInner(
 
   const startTime = Date.now();
   const webSearchRuntime = resolveWebSearchRuntimeConfig(agentId);
+  const mcpServers = await resolveMcpServersForRuntime(MCP_SERVERS);
   const existingEntry = pool.get(sessionId);
   const selectedCodexRuntime =
     modelRuntime.provider === 'openai-codex' ? CODEX_RUNTIME : 'hybridclaw';
@@ -997,7 +999,7 @@ async function runHostProcessInner(
     media,
     audioTranscriptsPrepended,
     pluginTools,
-    mcpServers: MCP_SERVERS,
+    mcpServers,
     taskModels,
     runtimeEnv,
     contextGuard: {

--- a/src/mcp/mcp-oauth.ts
+++ b/src/mcp/mcp-oauth.ts
@@ -17,6 +17,7 @@ import path from 'node:path';
 import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
 import { logger } from '../logger.js';
 import type { McpServerConfig } from '../types/models.js';
+import { supportsMcpOAuth } from './server-config.js';
 
 const MCP_OAUTH_FILE = 'mcp-oauth.json';
 const DISCOVERY_TIMEOUT_MS = 10_000;
@@ -78,7 +79,7 @@ interface AuthorizationServerMetadata {
 
 const pendingFlows = new Map<string, PendingMcpOAuthFlow>();
 
-export function mcpOAuthStorePath(): string {
+function mcpOAuthStorePath(): string {
   return path.join(DEFAULT_RUNTIME_HOME_DIR, MCP_OAUTH_FILE);
 }
 
@@ -108,17 +109,9 @@ function writeStore(store: Record<string, McpOAuthRecord>): void {
   }
 }
 
-function toBase64Url(buffer: Buffer): string {
-  return buffer
-    .toString('base64')
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/g, '');
-}
-
 function generatePkcePair(): { verifier: string; challenge: string } {
-  const verifier = toBase64Url(randomBytes(32));
-  const challenge = toBase64Url(createHash('sha256').update(verifier).digest());
+  const verifier = randomBytes(32).toString('base64url');
+  const challenge = createHash('sha256').update(verifier).digest('base64url');
   return { verifier, challenge };
 }
 
@@ -155,6 +148,19 @@ function asTrimmedString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
 }
 
+function asStringArray(value: unknown): string[] | undefined {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === 'string')
+    : undefined;
+}
+
+function tokenExpiresSoon(tokens: McpOAuthTokenSet): boolean {
+  return (
+    typeof tokens.expiresAt === 'number' &&
+    tokens.expiresAt - Date.now() <= TOKEN_REFRESH_SKEW_MS
+  );
+}
+
 function wellKnownCandidates(baseUrl: string, suffix: string): string[] {
   const parsed = new URL(baseUrl);
   const candidates: string[] = [];
@@ -188,15 +194,10 @@ export async function discoverProtectedResource(serverUrl: string): Promise<{
             typeof entry === 'string' && Boolean(entry.trim()),
         )
       : [];
-    const scopes = Array.isArray(metadata.scopes_supported)
-      ? metadata.scopes_supported.filter(
-          (entry): entry is string => typeof entry === 'string',
-        )
-      : undefined;
     return {
       resource: asTrimmedString(metadata.resource) || serverUrl,
       authorizationServer: servers[0] || new URL(serverUrl).origin,
-      scopes,
+      scopes: asStringArray(metadata.scopes_supported),
     };
   }
   return {
@@ -229,11 +230,7 @@ export async function discoverAuthorizationServer(
       tokenEndpoint,
       registrationEndpoint:
         asTrimmedString(metadata.registration_endpoint) || undefined,
-      scopesSupported: Array.isArray(metadata.scopes_supported)
-        ? metadata.scopes_supported.filter(
-            (entry): entry is string => typeof entry === 'string',
-          )
-        : undefined,
+      scopesSupported: asStringArray(metadata.scopes_supported),
     };
   }
   const origin = new URL(issuer).origin;
@@ -390,7 +387,7 @@ export async function startMcpOAuthFlow(input: {
   }
 
   const pkce = generatePkcePair();
-  const state = toBase64Url(randomBytes(32));
+  const state = randomBytes(32).toString('base64url');
   const record: McpOAuthRecord = {
     serverUrl,
     resource: resource.resource,
@@ -493,10 +490,7 @@ export function getMcpOAuthStatus(
     return { method: 'oauth', state: 'unauthorized' };
   }
   const expiresAt = record.tokens.expiresAt ?? null;
-  const expired =
-    typeof expiresAt === 'number' &&
-    expiresAt - Date.now() <= TOKEN_REFRESH_SKEW_MS;
-  if (expired && !record.tokens.refreshToken) {
+  if (tokenExpiresSoon(record.tokens) && !record.tokens.refreshToken) {
     return { method: 'oauth', state: 'expired', expiresAt };
   }
   return {
@@ -514,15 +508,13 @@ export function getMcpOAuthStatus(
  */
 export async function ensureFreshMcpAccessToken(
   serverName: string,
+  records: Record<string, McpOAuthRecord> = readStore(),
 ): Promise<string | null> {
-  const record = readStore()[serverName];
+  const record = records[serverName];
   const tokens = record?.tokens;
   if (!record || !tokens?.accessToken) return null;
 
-  const expiresSoon =
-    typeof tokens.expiresAt === 'number' &&
-    tokens.expiresAt - Date.now() <= TOKEN_REFRESH_SKEW_MS;
-  if (!expiresSoon) return tokens.accessToken;
+  if (!tokenExpiresSoon(tokens)) return tokens.accessToken;
   if (!tokens.refreshToken) return null;
 
   const params = new URLSearchParams({
@@ -564,17 +556,18 @@ export async function ensureFreshMcpAccessToken(
 export async function resolveMcpServersForRuntime(
   servers: Record<string, McpServerConfig>,
 ): Promise<Record<string, McpServerConfig>> {
+  const records = readStore();
   const entries = await Promise.all(
     Object.entries(servers).map(
       async ([name, config]): Promise<[string, McpServerConfig]> => {
         if (
           config.auth !== 'oauth' ||
           config.enabled === false ||
-          (config.transport !== 'http' && config.transport !== 'sse')
+          !supportsMcpOAuth(config.transport)
         ) {
           return [name, config];
         }
-        const accessToken = await ensureFreshMcpAccessToken(name);
+        const accessToken = await ensureFreshMcpAccessToken(name, records);
         if (!accessToken) return [name, config];
         return [
           name,

--- a/src/mcp/mcp-oauth.ts
+++ b/src/mcp/mcp-oauth.ts
@@ -1,0 +1,593 @@
+/**
+ * OAuth 2.1 authorization for remote MCP servers (http/sse transports).
+ *
+ * Implements the MCP authorization spec on the gateway host:
+ * - RFC 9728 protected resource metadata discovery
+ * - RFC 8414 authorization server metadata discovery
+ * - RFC 7591 dynamic client registration
+ * - Authorization code flow with PKCE (S256) and RFC 8707 resource indicators
+ *
+ * Tokens are stored in `~/.hybridclaw/mcp-oauth.json` (0600) and injected as
+ * `Authorization` headers when MCP server configs are handed to the container.
+ */
+import { createHash, randomBytes } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+import { logger } from '../logger.js';
+import type { McpServerConfig } from '../types/models.js';
+
+const MCP_OAUTH_FILE = 'mcp-oauth.json';
+const DISCOVERY_TIMEOUT_MS = 10_000;
+const TOKEN_TIMEOUT_MS = 20_000;
+const PENDING_FLOW_TTL_MS = 10 * 60_000;
+const TOKEN_REFRESH_SKEW_MS = 60_000;
+const CLIENT_NAME = 'HybridClaw';
+
+export interface McpOAuthTokenSet {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt?: number;
+  scope?: string;
+}
+
+export interface McpOAuthRecord {
+  serverUrl: string;
+  resource: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  registrationEndpoint?: string;
+  clientId: string;
+  clientSecret?: string;
+  redirectUri: string;
+  scope?: string;
+  tokens?: McpOAuthTokenSet;
+  updatedAt: string;
+}
+
+export type McpOAuthConnectionState = 'connected' | 'expired' | 'unauthorized';
+
+export interface McpOAuthStatus {
+  method: 'oauth' | 'none';
+  state?: McpOAuthConnectionState;
+  expiresAt?: number | null;
+  scope?: string;
+}
+
+export interface McpOAuthStartResult {
+  serverName: string;
+  authorizationUrl: string;
+  state: string;
+  expiresAt: number;
+}
+
+interface PendingMcpOAuthFlow {
+  serverName: string;
+  verifier: string;
+  record: McpOAuthRecord;
+  createdAt: number;
+}
+
+interface AuthorizationServerMetadata {
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  registrationEndpoint?: string;
+  scopesSupported?: string[];
+}
+
+const pendingFlows = new Map<string, PendingMcpOAuthFlow>();
+
+export function mcpOAuthStorePath(): string {
+  return path.join(DEFAULT_RUNTIME_HOME_DIR, MCP_OAUTH_FILE);
+}
+
+function readStore(): Record<string, McpOAuthRecord> {
+  try {
+    const raw = fs.readFileSync(mcpOAuthStorePath(), 'utf-8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed as Record<string, McpOAuthRecord>;
+  } catch {
+    return {};
+  }
+}
+
+function writeStore(store: Record<string, McpOAuthRecord>): void {
+  const filePath = mcpOAuthStorePath();
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(store, null, 2)}\n`, {
+    mode: 0o600,
+  });
+  try {
+    fs.chmodSync(filePath, 0o600);
+  } catch {
+    // best effort on platforms without chmod support
+  }
+}
+
+function toBase64Url(buffer: Buffer): string {
+  return buffer
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}
+
+function generatePkcePair(): { verifier: string; challenge: string } {
+  const verifier = toBase64Url(randomBytes(32));
+  const challenge = toBase64Url(createHash('sha256').update(verifier).digest());
+  return { verifier, challenge };
+}
+
+function pruneExpiredFlows(): void {
+  const now = Date.now();
+  for (const [state, flow] of pendingFlows) {
+    if (now - flow.createdAt > PENDING_FLOW_TTL_MS) {
+      pendingFlows.delete(state);
+    }
+  }
+}
+
+async function fetchJson(
+  url: string,
+  init?: RequestInit & { timeoutMs?: number },
+): Promise<Record<string, unknown> | null> {
+  try {
+    const response = await fetch(url, {
+      ...init,
+      signal: AbortSignal.timeout(init?.timeoutMs ?? DISCOVERY_TIMEOUT_MS),
+    });
+    if (!response.ok) return null;
+    const payload = (await response.json()) as unknown;
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+      return null;
+    }
+    return payload as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function asTrimmedString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function wellKnownCandidates(baseUrl: string, suffix: string): string[] {
+  const parsed = new URL(baseUrl);
+  const candidates: string[] = [];
+  const pathname = parsed.pathname.replace(/\/+$/, '');
+  if (pathname && pathname !== '/') {
+    candidates.push(`${parsed.origin}/.well-known/${suffix}${pathname}`);
+  }
+  candidates.push(`${parsed.origin}/.well-known/${suffix}`);
+  return candidates;
+}
+
+/**
+ * RFC 9728: resolve the protected resource metadata for an MCP server URL.
+ * Returns the resource identifier, its authorization server issuer, and any
+ * advertised scopes. Falls back to treating the MCP origin as the issuer.
+ */
+export async function discoverProtectedResource(serverUrl: string): Promise<{
+  resource: string;
+  authorizationServer: string;
+  scopes?: string[];
+}> {
+  for (const candidate of wellKnownCandidates(
+    serverUrl,
+    'oauth-protected-resource',
+  )) {
+    const metadata = await fetchJson(candidate);
+    if (!metadata) continue;
+    const servers = Array.isArray(metadata.authorization_servers)
+      ? metadata.authorization_servers.filter(
+          (entry): entry is string =>
+            typeof entry === 'string' && Boolean(entry.trim()),
+        )
+      : [];
+    const scopes = Array.isArray(metadata.scopes_supported)
+      ? metadata.scopes_supported.filter(
+          (entry): entry is string => typeof entry === 'string',
+        )
+      : undefined;
+    return {
+      resource: asTrimmedString(metadata.resource) || serverUrl,
+      authorizationServer: servers[0] || new URL(serverUrl).origin,
+      scopes,
+    };
+  }
+  return {
+    resource: serverUrl,
+    authorizationServer: new URL(serverUrl).origin,
+  };
+}
+
+/**
+ * RFC 8414 / OIDC discovery for the authorization server, with a static
+ * fallback to conventional `/authorize`, `/token`, and `/register` paths.
+ */
+export async function discoverAuthorizationServer(
+  issuer: string,
+): Promise<AuthorizationServerMetadata> {
+  const candidates = [
+    ...wellKnownCandidates(issuer, 'oauth-authorization-server'),
+    ...wellKnownCandidates(issuer, 'openid-configuration'),
+  ];
+  for (const candidate of candidates) {
+    const metadata = await fetchJson(candidate);
+    if (!metadata) continue;
+    const authorizationEndpoint = asTrimmedString(
+      metadata.authorization_endpoint,
+    );
+    const tokenEndpoint = asTrimmedString(metadata.token_endpoint);
+    if (!authorizationEndpoint || !tokenEndpoint) continue;
+    return {
+      authorizationEndpoint,
+      tokenEndpoint,
+      registrationEndpoint:
+        asTrimmedString(metadata.registration_endpoint) || undefined,
+      scopesSupported: Array.isArray(metadata.scopes_supported)
+        ? metadata.scopes_supported.filter(
+            (entry): entry is string => typeof entry === 'string',
+          )
+        : undefined,
+    };
+  }
+  const origin = new URL(issuer).origin;
+  return {
+    authorizationEndpoint: `${origin}/authorize`,
+    tokenEndpoint: `${origin}/token`,
+    registrationEndpoint: `${origin}/register`,
+  };
+}
+
+/** RFC 7591 dynamic client registration. */
+async function registerClient(
+  registrationEndpoint: string,
+  redirectUri: string,
+): Promise<{ clientId: string; clientSecret?: string }> {
+  let response: Response;
+  try {
+    response = await fetch(registrationEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_name: CLIENT_NAME,
+        redirect_uris: [redirectUri],
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+        token_endpoint_auth_method: 'none',
+      }),
+      signal: AbortSignal.timeout(DISCOVERY_TIMEOUT_MS),
+    });
+  } catch (err) {
+    throw new Error(
+      `MCP OAuth client registration failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  const payload = (await response.json().catch(() => ({}))) as Record<
+    string,
+    unknown
+  >;
+  const clientId = asTrimmedString(payload.client_id);
+  if (!response.ok || !clientId) {
+    const detail =
+      asTrimmedString(payload.error_description) ||
+      asTrimmedString(payload.error) ||
+      `HTTP ${response.status}`;
+    throw new Error(
+      `MCP OAuth client registration failed (${detail}). The authorization server may require a manually configured client id.`,
+    );
+  }
+  return {
+    clientId,
+    clientSecret: asTrimmedString(payload.client_secret) || undefined,
+  };
+}
+
+interface TokenResponse {
+  access_token?: unknown;
+  refresh_token?: unknown;
+  expires_in?: unknown;
+  scope?: unknown;
+  error?: unknown;
+  error_description?: unknown;
+}
+
+async function requestToken(
+  tokenEndpoint: string,
+  params: URLSearchParams,
+): Promise<McpOAuthTokenSet> {
+  let response: Response;
+  try {
+    response = await fetch(tokenEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params,
+      signal: AbortSignal.timeout(TOKEN_TIMEOUT_MS),
+    });
+  } catch (err) {
+    throw new Error(
+      `MCP OAuth token request failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  const payload = (await response.json().catch(() => ({}))) as TokenResponse;
+  if (!response.ok) {
+    const error = asTrimmedString(payload.error) || `HTTP ${response.status}`;
+    const description = asTrimmedString(payload.error_description);
+    throw new Error(
+      `MCP OAuth token request failed: ${description ? `${error}: ${description}` : error}`,
+    );
+  }
+  const accessToken = asTrimmedString(payload.access_token);
+  if (!accessToken) {
+    throw new Error(
+      'MCP OAuth token response did not include an access token.',
+    );
+  }
+  const expiresIn =
+    typeof payload.expires_in === 'number' &&
+    Number.isFinite(payload.expires_in)
+      ? payload.expires_in
+      : null;
+  return {
+    accessToken,
+    refreshToken: asTrimmedString(payload.refresh_token) || undefined,
+    expiresAt: expiresIn === null ? undefined : Date.now() + expiresIn * 1000,
+    scope: asTrimmedString(payload.scope) || undefined,
+  };
+}
+
+/**
+ * Begin an authorization flow for a remote MCP server. Performs discovery and
+ * (when needed) dynamic client registration, then returns the authorization
+ * URL the user must open in a browser. The flow is completed by
+ * `completeMcpOAuthFlow` when the authorization server redirects back.
+ */
+export async function startMcpOAuthFlow(input: {
+  serverName: string;
+  serverUrl: string;
+  redirectUri: string;
+  scope?: string;
+}): Promise<McpOAuthStartResult> {
+  pruneExpiredFlows();
+  const serverUrl = input.serverUrl.trim();
+  if (!/^https?:\/\//i.test(serverUrl)) {
+    throw new Error('MCP OAuth requires an http(s) server URL.');
+  }
+
+  const resource = await discoverProtectedResource(serverUrl);
+  const authServer = await discoverAuthorizationServer(
+    resource.authorizationServer,
+  );
+
+  const requestedScope =
+    input.scope?.trim() ||
+    (resource.scopes?.length ? resource.scopes.join(' ') : '') ||
+    (authServer.scopesSupported?.length
+      ? authServer.scopesSupported.join(' ')
+      : '');
+
+  const existing = readStore()[input.serverName];
+  const canReuseClient =
+    existing &&
+    existing.serverUrl === serverUrl &&
+    existing.redirectUri === input.redirectUri &&
+    existing.authorizationEndpoint === authServer.authorizationEndpoint &&
+    Boolean(existing.clientId);
+  const client = canReuseClient
+    ? { clientId: existing.clientId, clientSecret: existing.clientSecret }
+    : authServer.registrationEndpoint
+      ? await registerClient(authServer.registrationEndpoint, input.redirectUri)
+      : null;
+  if (!client) {
+    throw new Error(
+      'The MCP authorization server does not support dynamic client registration. Configure the server with a static `Authorization` header instead.',
+    );
+  }
+
+  const pkce = generatePkcePair();
+  const state = toBase64Url(randomBytes(32));
+  const record: McpOAuthRecord = {
+    serverUrl,
+    resource: resource.resource,
+    authorizationEndpoint: authServer.authorizationEndpoint,
+    tokenEndpoint: authServer.tokenEndpoint,
+    registrationEndpoint: authServer.registrationEndpoint,
+    clientId: client.clientId,
+    clientSecret: client.clientSecret,
+    redirectUri: input.redirectUri,
+    scope: requestedScope || undefined,
+    tokens: undefined,
+    updatedAt: new Date().toISOString(),
+  };
+
+  pendingFlows.set(state, {
+    serverName: input.serverName,
+    verifier: pkce.verifier,
+    record,
+    createdAt: Date.now(),
+  });
+
+  const query = new URLSearchParams({
+    response_type: 'code',
+    client_id: client.clientId,
+    redirect_uri: input.redirectUri,
+    code_challenge: pkce.challenge,
+    code_challenge_method: 'S256',
+    state,
+    resource: resource.resource,
+  });
+  if (requestedScope) query.set('scope', requestedScope);
+  const separator = authServer.authorizationEndpoint.includes('?') ? '&' : '?';
+  return {
+    serverName: input.serverName,
+    authorizationUrl: `${authServer.authorizationEndpoint}${separator}${query.toString()}`,
+    state,
+    expiresAt: Date.now() + PENDING_FLOW_TTL_MS,
+  };
+}
+
+/** Exchange the authorization code delivered to the redirect URI for tokens. */
+export async function completeMcpOAuthFlow(input: {
+  state: string;
+  code: string;
+}): Promise<{ serverName: string }> {
+  pruneExpiredFlows();
+  const flow = pendingFlows.get(input.state);
+  if (!flow) {
+    throw new Error(
+      'Unknown or expired MCP OAuth state. Restart the login flow.',
+    );
+  }
+  pendingFlows.delete(input.state);
+
+  const params = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code: input.code,
+    redirect_uri: flow.record.redirectUri,
+    client_id: flow.record.clientId,
+    code_verifier: flow.verifier,
+    resource: flow.record.resource,
+  });
+  if (flow.record.clientSecret) {
+    params.set('client_secret', flow.record.clientSecret);
+  }
+  const tokens = await requestToken(flow.record.tokenEndpoint, params);
+
+  const store = readStore();
+  store[flow.serverName] = {
+    ...flow.record,
+    tokens,
+    updatedAt: new Date().toISOString(),
+  };
+  writeStore(store);
+  return { serverName: flow.serverName };
+}
+
+export function getMcpOAuthRecord(serverName: string): McpOAuthRecord | null {
+  return readStore()[serverName] || null;
+}
+
+export function clearMcpOAuth(serverName: string): boolean {
+  const store = readStore();
+  if (!store[serverName]) return false;
+  delete store[serverName];
+  writeStore(store);
+  return true;
+}
+
+export function getMcpOAuthStatus(
+  serverName: string,
+  config: Pick<McpServerConfig, 'auth' | 'url'>,
+): McpOAuthStatus {
+  if (config.auth !== 'oauth') return { method: 'none' };
+  const record = readStore()[serverName];
+  if (
+    !record?.tokens?.accessToken ||
+    (config.url && record.serverUrl !== config.url.trim())
+  ) {
+    return { method: 'oauth', state: 'unauthorized' };
+  }
+  const expiresAt = record.tokens.expiresAt ?? null;
+  const expired =
+    typeof expiresAt === 'number' &&
+    expiresAt - Date.now() <= TOKEN_REFRESH_SKEW_MS;
+  if (expired && !record.tokens.refreshToken) {
+    return { method: 'oauth', state: 'expired', expiresAt };
+  }
+  return {
+    method: 'oauth',
+    state: 'connected',
+    expiresAt,
+    scope: record.tokens.scope || record.scope,
+  };
+}
+
+/**
+ * Return a fresh access token for a server, refreshing via the stored refresh
+ * token when the current one is missing or about to expire. Returns null when
+ * the server has no usable credentials (the user must re-run the login flow).
+ */
+export async function ensureFreshMcpAccessToken(
+  serverName: string,
+): Promise<string | null> {
+  const record = readStore()[serverName];
+  const tokens = record?.tokens;
+  if (!record || !tokens?.accessToken) return null;
+
+  const expiresSoon =
+    typeof tokens.expiresAt === 'number' &&
+    tokens.expiresAt - Date.now() <= TOKEN_REFRESH_SKEW_MS;
+  if (!expiresSoon) return tokens.accessToken;
+  if (!tokens.refreshToken) return null;
+
+  const params = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: tokens.refreshToken,
+    client_id: record.clientId,
+    resource: record.resource,
+  });
+  if (record.clientSecret) params.set('client_secret', record.clientSecret);
+
+  try {
+    const refreshed = await requestToken(record.tokenEndpoint, params);
+    const store = readStore();
+    store[serverName] = {
+      ...record,
+      tokens: {
+        ...refreshed,
+        refreshToken: refreshed.refreshToken || tokens.refreshToken,
+      },
+      updatedAt: new Date().toISOString(),
+    };
+    writeStore(store);
+    return refreshed.accessToken;
+  } catch (err) {
+    logger.warn(
+      { serverName, err: err instanceof Error ? err.message : String(err) },
+      'MCP OAuth token refresh failed',
+    );
+    return null;
+  }
+}
+
+/**
+ * Resolve the MCP server map handed to the container: for servers configured
+ * with `auth: "oauth"`, inject a fresh `Authorization` header. Servers without
+ * usable credentials are passed through unchanged and will surface as
+ * unauthorized in `/mcp list` and the console.
+ */
+export async function resolveMcpServersForRuntime(
+  servers: Record<string, McpServerConfig>,
+): Promise<Record<string, McpServerConfig>> {
+  const entries = await Promise.all(
+    Object.entries(servers).map(
+      async ([name, config]): Promise<[string, McpServerConfig]> => {
+        if (
+          config.auth !== 'oauth' ||
+          config.enabled === false ||
+          (config.transport !== 'http' && config.transport !== 'sse')
+        ) {
+          return [name, config];
+        }
+        const accessToken = await ensureFreshMcpAccessToken(name);
+        if (!accessToken) return [name, config];
+        return [
+          name,
+          {
+            ...config,
+            headers: {
+              ...config.headers,
+              Authorization: `Bearer ${accessToken}`,
+            },
+          },
+        ];
+      },
+    ),
+  );
+  return Object.fromEntries(entries);
+}

--- a/src/mcp/mcp-oauth.ts
+++ b/src/mcp/mcp-oauth.ts
@@ -7,19 +7,24 @@
  * - RFC 7591 dynamic client registration
  * - Authorization code flow with PKCE (S256) and RFC 8707 resource indicators
  *
- * Tokens are stored in `~/.hybridclaw/mcp-oauth.json` (0600) and injected as
- * `Authorization` headers when MCP server configs are handed to the container.
+ * Credentials are stored in the encrypted runtime secret store
+ * (`~/.hybridclaw/credentials.json`) under one `MCP_OAUTH_*` entry per server
+ * and injected as `Authorization` headers when MCP server configs are handed
+ * to the container.
  */
 import { createHash, randomBytes } from 'node:crypto';
-import fs from 'node:fs';
-import path from 'node:path';
 
-import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
 import { logger } from '../logger.js';
+import {
+  readStoredRuntimeSecret,
+  saveNamedRuntimeSecrets,
+} from '../security/runtime-secrets.js';
 import type { McpServerConfig } from '../types/models.js';
+import { isRecord } from '../utils/type-guards.js';
 import { supportsMcpOAuth } from './server-config.js';
 
-const MCP_OAUTH_FILE = 'mcp-oauth.json';
+const MCP_OAUTH_SECRET_PREFIX = 'MCP_OAUTH_';
+const MAX_SECRET_NAME_LENGTH = 128;
 const DISCOVERY_TIMEOUT_MS = 10_000;
 const TOKEN_TIMEOUT_MS = 20_000;
 const PENDING_FLOW_TTL_MS = 10 * 60_000;
@@ -79,34 +84,43 @@ interface AuthorizationServerMetadata {
 
 const pendingFlows = new Map<string, PendingMcpOAuthFlow>();
 
-function mcpOAuthStorePath(): string {
-  return path.join(DEFAULT_RUNTIME_HOME_DIR, MCP_OAUTH_FILE);
+/**
+ * Map a server name to its runtime secret name. Hex encoding keeps the result
+ * within the secret name charset without collisions (`my-server` vs
+ * `my_server`); names beyond the 128-char secret name cap fall back to a
+ * digest, whose `H_` marker cannot clash with hex output.
+ */
+function mcpOAuthSecretName(serverName: string): string {
+  const hex = Buffer.from(serverName, 'utf-8').toString('hex').toUpperCase();
+  const name = `${MCP_OAUTH_SECRET_PREFIX}${hex}`;
+  if (name.length <= MAX_SECRET_NAME_LENGTH) return name;
+  const digest = createHash('sha256')
+    .update(serverName, 'utf-8')
+    .digest('hex')
+    .toUpperCase();
+  return `${MCP_OAUTH_SECRET_PREFIX}H_${digest}`;
 }
 
-function readStore(): Record<string, McpOAuthRecord> {
+function readMcpOAuthRecordFromStore(
+  serverName: string,
+): McpOAuthRecord | null {
+  const raw = readStoredRuntimeSecret(mcpOAuthSecretName(serverName));
+  if (!raw) return null;
   try {
-    const raw = fs.readFileSync(mcpOAuthStorePath(), 'utf-8');
-    const parsed = JSON.parse(raw) as unknown;
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      return {};
-    }
-    return parsed as Record<string, McpOAuthRecord>;
+    const parsed: unknown = JSON.parse(raw);
+    return isRecord(parsed) ? (parsed as unknown as McpOAuthRecord) : null;
   } catch {
-    return {};
+    return null;
   }
 }
 
-function writeStore(store: Record<string, McpOAuthRecord>): void {
-  const filePath = mcpOAuthStorePath();
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, `${JSON.stringify(store, null, 2)}\n`, {
-    mode: 0o600,
+function writeMcpOAuthRecordToStore(
+  serverName: string,
+  record: McpOAuthRecord,
+): void {
+  saveNamedRuntimeSecrets({
+    [mcpOAuthSecretName(serverName)]: JSON.stringify(record),
   });
-  try {
-    fs.chmodSync(filePath, 0o600);
-  } catch {
-    // best effort on platforms without chmod support
-  }
 }
 
 function generatePkcePair(): { verifier: string; challenge: string } {
@@ -368,7 +382,7 @@ export async function startMcpOAuthFlow(input: {
       ? authServer.scopesSupported.join(' ')
       : '');
 
-  const existing = readStore()[input.serverName];
+  const existing = readMcpOAuthRecordFromStore(input.serverName);
   const canReuseClient =
     existing &&
     existing.serverUrl === serverUrl &&
@@ -455,25 +469,22 @@ export async function completeMcpOAuthFlow(input: {
   }
   const tokens = await requestToken(flow.record.tokenEndpoint, params);
 
-  const store = readStore();
-  store[flow.serverName] = {
+  writeMcpOAuthRecordToStore(flow.serverName, {
     ...flow.record,
     tokens,
     updatedAt: new Date().toISOString(),
-  };
-  writeStore(store);
+  });
   return { serverName: flow.serverName };
 }
 
 export function getMcpOAuthRecord(serverName: string): McpOAuthRecord | null {
-  return readStore()[serverName] || null;
+  return readMcpOAuthRecordFromStore(serverName);
 }
 
 export function clearMcpOAuth(serverName: string): boolean {
-  const store = readStore();
-  if (!store[serverName]) return false;
-  delete store[serverName];
-  writeStore(store);
+  const secretName = mcpOAuthSecretName(serverName);
+  if (!readStoredRuntimeSecret(secretName)) return false;
+  saveNamedRuntimeSecrets({ [secretName]: null });
   return true;
 }
 
@@ -482,7 +493,7 @@ export function getMcpOAuthStatus(
   config: Pick<McpServerConfig, 'auth' | 'url'>,
 ): McpOAuthStatus {
   if (config.auth !== 'oauth') return { method: 'none' };
-  const record = readStore()[serverName];
+  const record = readMcpOAuthRecordFromStore(serverName);
   if (
     !record?.tokens?.accessToken ||
     (config.url && record.serverUrl !== config.url.trim())
@@ -508,9 +519,8 @@ export function getMcpOAuthStatus(
  */
 export async function ensureFreshMcpAccessToken(
   serverName: string,
-  records: Record<string, McpOAuthRecord> = readStore(),
 ): Promise<string | null> {
-  const record = records[serverName];
+  const record = readMcpOAuthRecordFromStore(serverName);
   const tokens = record?.tokens;
   if (!record || !tokens?.accessToken) return null;
 
@@ -527,16 +537,14 @@ export async function ensureFreshMcpAccessToken(
 
   try {
     const refreshed = await requestToken(record.tokenEndpoint, params);
-    const store = readStore();
-    store[serverName] = {
+    writeMcpOAuthRecordToStore(serverName, {
       ...record,
       tokens: {
         ...refreshed,
         refreshToken: refreshed.refreshToken || tokens.refreshToken,
       },
       updatedAt: new Date().toISOString(),
-    };
-    writeStore(store);
+    });
     return refreshed.accessToken;
   } catch (err) {
     logger.warn(
@@ -556,7 +564,6 @@ export async function ensureFreshMcpAccessToken(
 export async function resolveMcpServersForRuntime(
   servers: Record<string, McpServerConfig>,
 ): Promise<Record<string, McpServerConfig>> {
-  const records = readStore();
   const entries = await Promise.all(
     Object.entries(servers).map(
       async ([name, config]): Promise<[string, McpServerConfig]> => {
@@ -567,7 +574,7 @@ export async function resolveMcpServersForRuntime(
         ) {
           return [name, config];
         }
-        const accessToken = await ensureFreshMcpAccessToken(name, records);
+        const accessToken = await ensureFreshMcpAccessToken(name);
         if (!accessToken) return [name, config];
         return [
           name,

--- a/src/mcp/server-config.ts
+++ b/src/mcp/server-config.ts
@@ -1,0 +1,15 @@
+/** Shared MCP server config rules used by the gateway, TUI, and config loader. */
+import type { McpServerConfig } from '../types/models.js';
+
+export const MCP_SERVER_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/;
+
+export function isValidMcpServerName(name: string): boolean {
+  return MCP_SERVER_NAME_RE.test(name);
+}
+
+/** OAuth is only available for remote transports that carry HTTP headers. */
+export function supportsMcpOAuth(
+  transport: McpServerConfig['transport'],
+): boolean {
+  return transport === 'http' || transport === 'sse';
+}

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -1,4 +1,3 @@
-import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import readline from 'node:readline/promises';
@@ -50,6 +49,7 @@ import {
 } from './security/runtime-secrets.js';
 import { bootstrapRuntimeSecrets } from './security/runtime-secrets-bootstrap.js';
 import type { HybridAIBot } from './types/hybridai.js';
+import { tryOpenUrlInBrowser } from './utils/open-url.js';
 import { promptForSecretInput } from './utils/secret-prompt.js';
 
 interface ApiKeyValidationResult {
@@ -269,31 +269,6 @@ function extractApiKeyFromInput(raw: string): string | null {
 
   if (trimmed.startsWith('hai-')) return trimmed;
   return null;
-}
-
-function getOpenCommand(url: string): { cmd: string; args: string[] } | null {
-  if (process.platform === 'darwin') return { cmd: 'open', args: [url] };
-  if (process.platform === 'win32')
-    return { cmd: 'cmd', args: ['/c', 'start', '', url] };
-  if (process.platform === 'linux') return { cmd: 'xdg-open', args: [url] };
-  return null;
-}
-
-async function tryOpenUrl(url: string): Promise<boolean> {
-  const openCommand = getOpenCommand(url);
-  if (!openCommand) return false;
-
-  return new Promise((resolve) => {
-    const child = spawn(openCommand.cmd, openCommand.args, {
-      stdio: 'ignore',
-      detached: true,
-    });
-    child.once('error', () => resolve(false));
-    child.once('spawn', () => {
-      child.unref();
-      resolve(true);
-    });
-  });
 }
 
 async function validateApiKey(
@@ -1058,7 +1033,7 @@ async function runHybridAIApiKeyOnboarding(params: {
       ICON_PERSON,
     );
     if (openRegister) {
-      const opened = await tryOpenUrl(registerPageUrl);
+      const opened = await tryOpenUrlInBrowser(registerPageUrl);
       if (!opened) {
         printWarn('Could not auto-open browser. Open the link manually.');
       }
@@ -1090,7 +1065,7 @@ async function runHybridAIApiKeyOnboarding(params: {
     ICON_AUTH,
   );
   if (openLogin) {
-    const opened = await tryOpenUrl(loginUrl);
+    const opened = await tryOpenUrlInBrowser(loginUrl);
     if (!opened) {
       printWarn('Could not auto-open browser. Open the link manually.');
     }

--- a/src/tui-mcp-wizard.ts
+++ b/src/tui-mcp-wizard.ts
@@ -1,0 +1,467 @@
+/**
+ * Interactive TUI wizard for adding/editing MCP servers and running the
+ * gateway-managed OAuth login flow, so users never have to hand-write the
+ * JSON payload that `/mcp add <name> <json>` expects.
+ */
+import type readline from 'node:readline';
+
+import {
+  fetchGatewayMcpOAuthStatus,
+  logoutGatewayMcpOAuth,
+  saveGatewayAdminMcpServer,
+  startGatewayMcpOAuth,
+} from './gateway/gateway-client.js';
+import type {
+  GatewayAdminMcpOAuthStartResponse,
+  GatewayAdminMcpOAuthStatusResponse,
+  GatewayAdminMcpResponse,
+  GatewayAdminMcpServer,
+} from './gateway/gateway-types.js';
+import type { McpServerConfig } from './types/models.js';
+import { tryOpenUrlInBrowser } from './utils/open-url.js';
+
+const MCP_SERVER_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/;
+const OAUTH_POLL_INTERVAL_MS = 2_000;
+const OAUTH_POLL_TIMEOUT_MS = 3 * 60_000;
+
+export interface TuiMcpWizardPalette {
+  reset: string;
+  bold: string;
+  muted: string;
+  teal: string;
+  green: string;
+  red: string;
+}
+
+export const DEFAULT_TUI_MCP_WIZARD_PALETTE: Readonly<TuiMcpWizardPalette> =
+  Object.freeze({
+    reset: '\x1b[0m',
+    bold: '\x1b[1m',
+    muted: '\x1b[90m',
+    teal: '\x1b[36m',
+    green: '\x1b[32m',
+    red: '\x1b[31m',
+  });
+
+export type TuiMcpAuthChoice = 'oauth' | 'bearer' | 'headers' | 'none';
+
+export interface TuiMcpWizardAnswers {
+  name: string;
+  transport: 'stdio' | 'http' | 'sse';
+  command?: string;
+  argsLine?: string;
+  cwd?: string;
+  envPairs?: string;
+  url?: string;
+  authChoice?: TuiMcpAuthChoice;
+  bearerToken?: string;
+  headerPairs?: string;
+}
+
+export function isValidTuiMcpServerName(name: string): boolean {
+  return MCP_SERVER_NAME_RE.test(name);
+}
+
+/** Parse `KEY=VALUE` pairs separated by commas (values may contain `=`). */
+export function parseTuiMcpKeyValuePairs(
+  input: string,
+): Record<string, string> | undefined {
+  const trimmed = input.trim();
+  if (!trimmed) return undefined;
+  const result: Record<string, string> = {};
+  for (const pair of trimmed.split(',')) {
+    const entry = pair.trim();
+    if (!entry) continue;
+    const separator = entry.indexOf('=');
+    if (separator <= 0) {
+      throw new Error(
+        `Expected KEY=VALUE pairs separated by commas, got: ${entry}`,
+      );
+    }
+    result[entry.slice(0, separator).trim()] = entry
+      .slice(separator + 1)
+      .trim();
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+export function parseTuiMcpArgsLine(input: string): string[] {
+  const matches = input.match(/"[^"]*"|\S+/g) ?? [];
+  return matches.map((token) =>
+    token.startsWith('"') && token.endsWith('"') && token.length >= 2
+      ? token.slice(1, -1)
+      : token,
+  );
+}
+
+/** Build the gateway config payload from wizard answers. Throws on bad input. */
+export function buildTuiMcpServerConfig(
+  answers: TuiMcpWizardAnswers,
+): McpServerConfig {
+  if (answers.transport === 'stdio') {
+    const command = (answers.command || '').trim();
+    if (!command) throw new Error('stdio MCP servers require a command.');
+    const args = parseTuiMcpArgsLine(answers.argsLine || '');
+    const env = parseTuiMcpKeyValuePairs(answers.envPairs || '');
+    const cwd = (answers.cwd || '').trim();
+    return {
+      transport: 'stdio',
+      command,
+      ...(args.length > 0 ? { args } : {}),
+      ...(cwd ? { cwd } : {}),
+      ...(env ? { env } : {}),
+    };
+  }
+
+  const url = (answers.url || '').trim();
+  if (!/^https?:\/\//i.test(url)) {
+    throw new Error('Remote MCP servers require an http(s) URL.');
+  }
+  const config: McpServerConfig = { transport: answers.transport, url };
+  const choice = answers.authChoice || 'none';
+  if (choice === 'oauth') {
+    config.auth = 'oauth';
+  } else if (choice === 'bearer') {
+    const token = (answers.bearerToken || '').trim();
+    if (!token) throw new Error('A token is required for bearer auth.');
+    config.headers = { Authorization: `Bearer ${token}` };
+  } else if (choice === 'headers') {
+    const headers = parseTuiMcpKeyValuePairs(answers.headerPairs || '');
+    if (!headers) {
+      throw new Error('At least one header is required for custom headers.');
+    }
+    config.headers = headers;
+  }
+  return config;
+}
+
+export interface TuiMcpWizardDeps {
+  saveServer: typeof saveGatewayAdminMcpServer;
+  startOAuth: typeof startGatewayMcpOAuth;
+  fetchOAuthStatus: typeof fetchGatewayMcpOAuthStatus;
+  logoutOAuth: typeof logoutGatewayMcpOAuth;
+  openUrl: typeof tryOpenUrlInBrowser;
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+}
+
+const defaultDeps: TuiMcpWizardDeps = {
+  saveServer: saveGatewayAdminMcpServer,
+  startOAuth: startGatewayMcpOAuth,
+  fetchOAuthStatus: fetchGatewayMcpOAuthStatus,
+  logoutOAuth: logoutGatewayMcpOAuth,
+  openUrl: tryOpenUrlInBrowser,
+  sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  now: () => Date.now(),
+};
+
+function ask(rl: readline.Interface, query: string): Promise<string> {
+  return new Promise((resolve) => {
+    rl.question(query, resolve);
+  });
+}
+
+async function askWithDefault(
+  rl: readline.Interface,
+  palette: TuiMcpWizardPalette,
+  label: string,
+  options?: { defaultValue?: string; hint?: string },
+): Promise<string> {
+  const hint = options?.hint
+    ? ` ${palette.muted}(${options.hint})${palette.reset}`
+    : '';
+  const fallback = options?.defaultValue
+    ? ` ${palette.muted}[${options.defaultValue}]${palette.reset}`
+    : '';
+  const answer = (
+    await ask(
+      rl,
+      `  ${palette.teal}${label}${palette.reset}${hint}${fallback}: `,
+    )
+  ).trim();
+  return answer || options?.defaultValue || '';
+}
+
+async function askChoice(
+  rl: readline.Interface,
+  palette: TuiMcpWizardPalette,
+  label: string,
+  choices: Array<{ value: string; label: string; hint?: string }>,
+  defaultIndex: number,
+): Promise<string> {
+  console.log(`  ${palette.bold}${label}${palette.reset}`);
+  choices.forEach((choice, index) => {
+    const marker =
+      index === defaultIndex ? `${palette.green}*${palette.reset}` : ' ';
+    const hint = choice.hint
+      ? ` ${palette.muted}— ${choice.hint}${palette.reset}`
+      : '';
+    console.log(
+      `   ${marker} ${palette.teal}${index + 1}${palette.reset} ${choice.label}${hint}`,
+    );
+  });
+  const raw = (
+    await ask(
+      rl,
+      `  ${palette.muted}Select 1-${choices.length} (Enter for ${defaultIndex + 1}):${palette.reset} `,
+    )
+  ).trim();
+  if (!raw) return choices[defaultIndex].value;
+  const index = Number.parseInt(raw, 10);
+  if (Number.isFinite(index) && index >= 1 && index <= choices.length) {
+    return choices[index - 1].value;
+  }
+  const match = choices.find((choice) => choice.value === raw.toLowerCase());
+  return match ? match.value : choices[defaultIndex].value;
+}
+
+export interface TuiMcpWizardResult {
+  cancelled: boolean;
+  saved?: boolean;
+  name?: string;
+  oauthStarted?: boolean;
+  oauthConnected?: boolean;
+}
+
+/**
+ * Wait for the gateway to report the server as connected after the user
+ * approves access in the browser.
+ */
+export async function waitForTuiMcpOAuthConnection(input: {
+  name: string;
+  deps?: Partial<TuiMcpWizardDeps>;
+  timeoutMs?: number;
+}): Promise<GatewayAdminMcpOAuthStatusResponse | null> {
+  const deps = { ...defaultDeps, ...input.deps };
+  const deadline = deps.now() + (input.timeoutMs ?? OAUTH_POLL_TIMEOUT_MS);
+  while (deps.now() < deadline) {
+    await deps.sleep(OAUTH_POLL_INTERVAL_MS);
+    try {
+      const status = await deps.fetchOAuthStatus(input.name);
+      if (status.auth.state === 'connected') return status;
+    } catch {
+      // Gateway may be briefly unavailable mid-poll; keep waiting.
+    }
+  }
+  return null;
+}
+
+/**
+ * Run the OAuth login flow for a configured server: request the authorization
+ * URL from the gateway, open it in a browser, and poll until connected.
+ */
+export async function runTuiMcpOAuthLogin(input: {
+  name: string;
+  palette?: Partial<TuiMcpWizardPalette>;
+  deps?: Partial<TuiMcpWizardDeps>;
+}): Promise<boolean> {
+  const palette = { ...DEFAULT_TUI_MCP_WIZARD_PALETTE, ...input.palette };
+  const deps = { ...defaultDeps, ...input.deps };
+
+  let started: GatewayAdminMcpOAuthStartResponse;
+  try {
+    started = await deps.startOAuth(input.name);
+  } catch (error) {
+    console.log(
+      `  ${palette.red}OAuth login failed:${palette.reset} ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return false;
+  }
+
+  const opened = await deps.openUrl(started.authorizationUrl);
+  console.log('');
+  console.log(
+    opened
+      ? `  ${palette.green}Opened your browser to authorize ${palette.bold}${input.name}${palette.reset}${palette.green}.${palette.reset}`
+      : `  Open this URL in your browser to authorize ${palette.bold}${input.name}${palette.reset}:`,
+  );
+  console.log(`  ${palette.teal}${started.authorizationUrl}${palette.reset}`);
+  console.log(`  ${palette.muted}Waiting for authorization...${palette.reset}`);
+
+  const status = await waitForTuiMcpOAuthConnection({
+    name: input.name,
+    deps: input.deps,
+    timeoutMs: Math.max(
+      OAUTH_POLL_INTERVAL_MS,
+      Math.min(OAUTH_POLL_TIMEOUT_MS, started.expiresAt - deps.now()),
+    ),
+  });
+  if (status) {
+    console.log(
+      `  ${palette.green}Connected!${palette.reset} MCP server ${palette.bold}${input.name}${palette.reset} is authorized. Tools load on the next turn.`,
+    );
+    return true;
+  }
+  console.log(
+    `  ${palette.red}Timed out waiting for authorization.${palette.reset} Run ${palette.teal}/mcp login ${input.name}${palette.reset} to retry.`,
+  );
+  return false;
+}
+
+/**
+ * Guided add/edit flow. Pass `existing` to prefill answers when editing.
+ */
+export async function promptTuiMcpServerWizard(input: {
+  rl: readline.Interface;
+  existing?: GatewayAdminMcpServer | null;
+  presetName?: string;
+  palette?: Partial<TuiMcpWizardPalette>;
+  deps?: Partial<TuiMcpWizardDeps>;
+}): Promise<TuiMcpWizardResult> {
+  const { rl, existing } = input;
+  const palette = { ...DEFAULT_TUI_MCP_WIZARD_PALETTE, ...input.palette };
+  const deps = { ...defaultDeps, ...input.deps };
+
+  console.log('');
+  console.log(
+    `  ${palette.bold}${existing ? `Edit MCP server: ${existing.name}` : 'Add MCP server'}${palette.reset} ${palette.muted}(Enter to accept defaults, Ctrl+C to abort)${palette.reset}`,
+  );
+
+  const presetName = (input.presetName || '').trim();
+  let name =
+    existing?.name || (isValidTuiMcpServerName(presetName) ? presetName : '');
+  while (!name) {
+    const answer = await askWithDefault(rl, palette, 'Name', {
+      hint: 'lowercase letters, numbers, - and _',
+    });
+    if (!answer) return { cancelled: true };
+    if (!isValidTuiMcpServerName(answer)) {
+      console.log(
+        `  ${palette.red}Invalid name.${palette.reset} Use lowercase letters, numbers, \`-\` or \`_\`, starting with a letter or number.`,
+      );
+      continue;
+    }
+    name = answer;
+  }
+
+  const transport = (await askChoice(
+    rl,
+    palette,
+    'Transport',
+    [
+      {
+        value: 'http',
+        label: 'http',
+        hint: 'remote server (streamable HTTP)',
+      },
+      { value: 'sse', label: 'sse', hint: 'remote server (legacy SSE)' },
+      { value: 'stdio', label: 'stdio', hint: 'local command' },
+    ],
+    existing?.config.transport === 'sse'
+      ? 1
+      : existing?.config.transport === 'stdio'
+        ? 2
+        : 0,
+  )) as 'stdio' | 'http' | 'sse';
+
+  const answers: TuiMcpWizardAnswers = { name, transport };
+
+  if (transport === 'stdio') {
+    answers.command = await askWithDefault(rl, palette, 'Command', {
+      defaultValue: existing?.config.command || '',
+    });
+    answers.argsLine = await askWithDefault(rl, palette, 'Arguments', {
+      hint: 'space separated, quote as needed',
+      defaultValue: (existing?.config.args || []).join(' '),
+    });
+    answers.cwd = await askWithDefault(rl, palette, 'Working directory', {
+      hint: 'optional',
+      defaultValue: existing?.config.cwd || '',
+    });
+    answers.envPairs = await askWithDefault(rl, palette, 'Environment', {
+      hint: 'optional, KEY=VALUE pairs separated by commas',
+      defaultValue: Object.entries(existing?.config.env || {})
+        .map(([key, value]) => `${key}=${value}`)
+        .join(','),
+    });
+  } else {
+    answers.url = await askWithDefault(rl, palette, 'Server URL', {
+      hint: 'https://...',
+      defaultValue: existing?.config.url || '',
+    });
+    const existingChoice: TuiMcpAuthChoice =
+      existing?.config.auth === 'oauth'
+        ? 'oauth'
+        : existing?.config.headers &&
+            Object.keys(existing.config.headers).length > 0
+          ? 'headers'
+          : 'none';
+    answers.authChoice = (await askChoice(
+      rl,
+      palette,
+      'Authentication',
+      [
+        {
+          value: 'oauth',
+          label: 'OAuth',
+          hint: 'log in via browser; tokens managed automatically',
+        },
+        {
+          value: 'bearer',
+          label: 'API key / bearer token',
+          hint: 'sets an Authorization header',
+        },
+        {
+          value: 'headers',
+          label: 'Custom headers',
+          hint: 'KEY=VALUE pairs separated by commas',
+        },
+        { value: 'none', label: 'None', hint: 'no authentication' },
+      ],
+      existingChoice === 'headers' ? 2 : existingChoice === 'none' ? 3 : 0,
+    )) as TuiMcpAuthChoice;
+    if (answers.authChoice === 'bearer') {
+      answers.bearerToken = await askWithDefault(rl, palette, 'Token', {
+        hint: 'sent as `Authorization: Bearer <token>`',
+      });
+    } else if (answers.authChoice === 'headers') {
+      answers.headerPairs = await askWithDefault(rl, palette, 'Headers', {
+        hint: 'KEY=VALUE pairs separated by commas',
+        defaultValue: Object.entries(existing?.config.headers || {})
+          .map(([key, value]) => `${key}=${value}`)
+          .join(','),
+      });
+    }
+  }
+
+  let config: McpServerConfig;
+  try {
+    config = buildTuiMcpServerConfig(answers);
+  } catch (error) {
+    console.log(
+      `  ${palette.red}${error instanceof Error ? error.message : String(error)}${palette.reset}`,
+    );
+    return { cancelled: true };
+  }
+  if (existing?.config.enabled === false) config.enabled = false;
+
+  let response: GatewayAdminMcpResponse;
+  try {
+    response = await deps.saveServer({ name, config });
+  } catch (error) {
+    console.log(
+      `  ${palette.red}Save failed:${palette.reset} ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return { cancelled: false, saved: false, name };
+  }
+  const saved = response.servers.find((server) => server.name === name);
+  console.log(
+    `  ${palette.green}Saved.${palette.reset} ${saved?.summary || name}`,
+  );
+
+  if (config.auth !== 'oauth') {
+    return { cancelled: false, saved: true, name };
+  }
+  const connected = await runTuiMcpOAuthLogin({
+    name,
+    palette: input.palette,
+    deps: input.deps,
+  });
+  return {
+    cancelled: false,
+    saved: true,
+    name,
+    oauthStarted: true,
+    oauthConnected: connected,
+  };
+}

--- a/src/tui-mcp-wizard.ts
+++ b/src/tui-mcp-wizard.ts
@@ -7,7 +7,6 @@ import type readline from 'node:readline';
 
 import {
   fetchGatewayMcpOAuthStatus,
-  logoutGatewayMcpOAuth,
   saveGatewayAdminMcpServer,
   startGatewayMcpOAuth,
 } from './gateway/gateway-client.js';
@@ -17,31 +16,22 @@ import type {
   GatewayAdminMcpResponse,
   GatewayAdminMcpServer,
 } from './gateway/gateway-types.js';
+import { isValidMcpServerName } from './mcp/server-config.js';
 import type { McpServerConfig } from './types/models.js';
 import { tryOpenUrlInBrowser } from './utils/open-url.js';
+import { sleep } from './utils/sleep.js';
 
-const MCP_SERVER_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/;
 const OAUTH_POLL_INTERVAL_MS = 2_000;
 const OAUTH_POLL_TIMEOUT_MS = 3 * 60_000;
 
-export interface TuiMcpWizardPalette {
-  reset: string;
-  bold: string;
-  muted: string;
-  teal: string;
-  green: string;
-  red: string;
-}
-
-export const DEFAULT_TUI_MCP_WIZARD_PALETTE: Readonly<TuiMcpWizardPalette> =
-  Object.freeze({
-    reset: '\x1b[0m',
-    bold: '\x1b[1m',
-    muted: '\x1b[90m',
-    teal: '\x1b[36m',
-    green: '\x1b[32m',
-    red: '\x1b[31m',
-  });
+const palette = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  muted: '\x1b[90m',
+  teal: '\x1b[36m',
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+};
 
 export type TuiMcpAuthChoice = 'oauth' | 'bearer' | 'headers' | 'none';
 
@@ -56,10 +46,6 @@ export interface TuiMcpWizardAnswers {
   authChoice?: TuiMcpAuthChoice;
   bearerToken?: string;
   headerPairs?: string;
-}
-
-export function isValidTuiMcpServerName(name: string): boolean {
-  return MCP_SERVER_NAME_RE.test(name);
 }
 
 /** Parse `KEY=VALUE` pairs separated by commas (values may contain `=`). */
@@ -139,7 +125,6 @@ export interface TuiMcpWizardDeps {
   saveServer: typeof saveGatewayAdminMcpServer;
   startOAuth: typeof startGatewayMcpOAuth;
   fetchOAuthStatus: typeof fetchGatewayMcpOAuthStatus;
-  logoutOAuth: typeof logoutGatewayMcpOAuth;
   openUrl: typeof tryOpenUrlInBrowser;
   sleep: (ms: number) => Promise<void>;
   now: () => number;
@@ -149,9 +134,8 @@ const defaultDeps: TuiMcpWizardDeps = {
   saveServer: saveGatewayAdminMcpServer,
   startOAuth: startGatewayMcpOAuth,
   fetchOAuthStatus: fetchGatewayMcpOAuthStatus,
-  logoutOAuth: logoutGatewayMcpOAuth,
   openUrl: tryOpenUrlInBrowser,
-  sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  sleep,
   now: () => Date.now(),
 };
 
@@ -163,7 +147,6 @@ function ask(rl: readline.Interface, query: string): Promise<string> {
 
 async function askWithDefault(
   rl: readline.Interface,
-  palette: TuiMcpWizardPalette,
   label: string,
   options?: { defaultValue?: string; hint?: string },
 ): Promise<string> {
@@ -184,7 +167,6 @@ async function askWithDefault(
 
 async function askChoice(
   rl: readline.Interface,
-  palette: TuiMcpWizardPalette,
   label: string,
   choices: Array<{ value: string; label: string; hint?: string }>,
   defaultIndex: number,
@@ -213,14 +195,6 @@ async function askChoice(
   }
   const match = choices.find((choice) => choice.value === raw.toLowerCase());
   return match ? match.value : choices[defaultIndex].value;
-}
-
-export interface TuiMcpWizardResult {
-  cancelled: boolean;
-  saved?: boolean;
-  name?: string;
-  oauthStarted?: boolean;
-  oauthConnected?: boolean;
 }
 
 /**
@@ -252,10 +226,8 @@ export async function waitForTuiMcpOAuthConnection(input: {
  */
 export async function runTuiMcpOAuthLogin(input: {
   name: string;
-  palette?: Partial<TuiMcpWizardPalette>;
   deps?: Partial<TuiMcpWizardDeps>;
 }): Promise<boolean> {
-  const palette = { ...DEFAULT_TUI_MCP_WIZARD_PALETTE, ...input.palette };
   const deps = { ...defaultDeps, ...input.deps };
 
   let started: GatewayAdminMcpOAuthStartResponse;
@@ -305,11 +277,9 @@ export async function promptTuiMcpServerWizard(input: {
   rl: readline.Interface;
   existing?: GatewayAdminMcpServer | null;
   presetName?: string;
-  palette?: Partial<TuiMcpWizardPalette>;
   deps?: Partial<TuiMcpWizardDeps>;
-}): Promise<TuiMcpWizardResult> {
+}): Promise<void> {
   const { rl, existing } = input;
-  const palette = { ...DEFAULT_TUI_MCP_WIZARD_PALETTE, ...input.palette };
   const deps = { ...defaultDeps, ...input.deps };
 
   console.log('');
@@ -319,13 +289,13 @@ export async function promptTuiMcpServerWizard(input: {
 
   const presetName = (input.presetName || '').trim();
   let name =
-    existing?.name || (isValidTuiMcpServerName(presetName) ? presetName : '');
+    existing?.name || (isValidMcpServerName(presetName) ? presetName : '');
   while (!name) {
-    const answer = await askWithDefault(rl, palette, 'Name', {
+    const answer = await askWithDefault(rl, 'Name', {
       hint: 'lowercase letters, numbers, - and _',
     });
-    if (!answer) return { cancelled: true };
-    if (!isValidTuiMcpServerName(answer)) {
+    if (!answer) return;
+    if (!isValidMcpServerName(answer)) {
       console.log(
         `  ${palette.red}Invalid name.${palette.reset} Use lowercase letters, numbers, \`-\` or \`_\`, starting with a letter or number.`,
       );
@@ -336,7 +306,6 @@ export async function promptTuiMcpServerWizard(input: {
 
   const transport = (await askChoice(
     rl,
-    palette,
     'Transport',
     [
       {
@@ -357,25 +326,25 @@ export async function promptTuiMcpServerWizard(input: {
   const answers: TuiMcpWizardAnswers = { name, transport };
 
   if (transport === 'stdio') {
-    answers.command = await askWithDefault(rl, palette, 'Command', {
+    answers.command = await askWithDefault(rl, 'Command', {
       defaultValue: existing?.config.command || '',
     });
-    answers.argsLine = await askWithDefault(rl, palette, 'Arguments', {
+    answers.argsLine = await askWithDefault(rl, 'Arguments', {
       hint: 'space separated, quote as needed',
       defaultValue: (existing?.config.args || []).join(' '),
     });
-    answers.cwd = await askWithDefault(rl, palette, 'Working directory', {
+    answers.cwd = await askWithDefault(rl, 'Working directory', {
       hint: 'optional',
       defaultValue: existing?.config.cwd || '',
     });
-    answers.envPairs = await askWithDefault(rl, palette, 'Environment', {
+    answers.envPairs = await askWithDefault(rl, 'Environment', {
       hint: 'optional, KEY=VALUE pairs separated by commas',
       defaultValue: Object.entries(existing?.config.env || {})
         .map(([key, value]) => `${key}=${value}`)
         .join(','),
     });
   } else {
-    answers.url = await askWithDefault(rl, palette, 'Server URL', {
+    answers.url = await askWithDefault(rl, 'Server URL', {
       hint: 'https://...',
       defaultValue: existing?.config.url || '',
     });
@@ -388,7 +357,6 @@ export async function promptTuiMcpServerWizard(input: {
           : 'none';
     answers.authChoice = (await askChoice(
       rl,
-      palette,
       'Authentication',
       [
         {
@@ -411,11 +379,11 @@ export async function promptTuiMcpServerWizard(input: {
       existingChoice === 'headers' ? 2 : existingChoice === 'none' ? 3 : 0,
     )) as TuiMcpAuthChoice;
     if (answers.authChoice === 'bearer') {
-      answers.bearerToken = await askWithDefault(rl, palette, 'Token', {
+      answers.bearerToken = await askWithDefault(rl, 'Token', {
         hint: 'sent as `Authorization: Bearer <token>`',
       });
     } else if (answers.authChoice === 'headers') {
-      answers.headerPairs = await askWithDefault(rl, palette, 'Headers', {
+      answers.headerPairs = await askWithDefault(rl, 'Headers', {
         hint: 'KEY=VALUE pairs separated by commas',
         defaultValue: Object.entries(existing?.config.headers || {})
           .map(([key, value]) => `${key}=${value}`)
@@ -431,7 +399,7 @@ export async function promptTuiMcpServerWizard(input: {
     console.log(
       `  ${palette.red}${error instanceof Error ? error.message : String(error)}${palette.reset}`,
     );
-    return { cancelled: true };
+    return;
   }
   if (existing?.config.enabled === false) config.enabled = false;
 
@@ -442,26 +410,13 @@ export async function promptTuiMcpServerWizard(input: {
     console.log(
       `  ${palette.red}Save failed:${palette.reset} ${error instanceof Error ? error.message : String(error)}`,
     );
-    return { cancelled: false, saved: false, name };
+    return;
   }
   const saved = response.servers.find((server) => server.name === name);
   console.log(
-    `  ${palette.green}Saved.${palette.reset} ${saved?.summary || name}`,
+    `  ${palette.green}Saved.${palette.reset} ${name}${saved ? ` — ${saved.summary}` : ''}`,
   );
 
-  if (config.auth !== 'oauth') {
-    return { cancelled: false, saved: true, name };
-  }
-  const connected = await runTuiMcpOAuthLogin({
-    name,
-    palette: input.palette,
-    deps: input.deps,
-  });
-  return {
-    cancelled: false,
-    saved: true,
-    name,
-    oauthStarted: true,
-    oauthConnected: connected,
-  };
+  if (config.auth !== 'oauth') return;
+  await runTuiMcpOAuthLogin({ name, deps: input.deps });
 }

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -20,6 +20,7 @@ import {
 import { createApprovalPresentation } from './gateway/approval-presentation.js';
 import { extractGatewayChatApprovalEvent } from './gateway/chat-approval.js';
 import {
+  fetchGatewayAdminMcp,
   fetchGatewayAdminSkills,
   type GatewayChatApprovalEvent,
   type GatewayChatResult,
@@ -94,6 +95,10 @@ import {
   resolveTuiHistoryFetchLimit,
 } from './tui-history.js';
 import { TuiMultilineInputController } from './tui-input.js';
+import {
+  promptTuiMcpServerWizard,
+  runTuiMcpOAuthLogin,
+} from './tui-mcp-wizard.js';
 import {
   isGoalContinuationSource,
   normalizeGoalContinuationText,
@@ -2743,6 +2748,52 @@ async function handleSlashCommand(
       }
       await promptSkillConfigSelection(rl);
       return true;
+    }
+    case 'mcp': {
+      const sub = (parts[1] || '').trim().toLowerCase();
+      if (sub === 'add' && parts.length <= 3) {
+        await promptTuiMcpServerWizard({
+          rl,
+          presetName: (parts[2] || '').trim(),
+        });
+        return true;
+      }
+      if (sub === 'edit') {
+        const name = (parts[2] || '').trim();
+        if (!name) {
+          printInfo('Usage: /mcp edit <name>');
+          return true;
+        }
+        let existing = null;
+        try {
+          const response = await fetchGatewayAdminMcp();
+          existing =
+            response.servers.find((server) => server.name === name) || null;
+        } catch (error) {
+          printInfo(
+            `Failed to load MCP servers: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          return true;
+        }
+        if (!existing) {
+          printInfo(
+            `MCP server "${name}" was not found. Run /mcp add to create it.`,
+          );
+          return true;
+        }
+        await promptTuiMcpServerWizard({ rl, existing });
+        return true;
+      }
+      if (sub === 'login') {
+        const name = (parts[2] || '').trim();
+        if (!name) {
+          printInfo('Usage: /mcp login <name>');
+          return true;
+        }
+        await runTuiMcpOAuthLogin({ name });
+        return true;
+      }
+      break;
     }
     case 'info':
       await runGatewayCommand(['bot', 'info'], rl);

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -13,6 +13,11 @@ export interface McpServerConfig {
   cwd?: string;
   url?: string;
   headers?: Record<string, string>;
+  /**
+   * `oauth` enables the gateway-managed OAuth 2.1 flow for http/sse servers;
+   * the gateway injects a fresh `Authorization` header on each container turn.
+   */
+  auth?: 'oauth';
   enabled?: boolean;
 }
 

--- a/src/utils/open-url.ts
+++ b/src/utils/open-url.ts
@@ -1,0 +1,28 @@
+import { spawn } from 'node:child_process';
+
+function getOpenCommand(url: string): { cmd: string; args: string[] } | null {
+  if (process.platform === 'darwin') return { cmd: 'open', args: [url] };
+  if (process.platform === 'win32') {
+    return { cmd: 'cmd', args: ['/c', 'start', '', url] };
+  }
+  if (process.platform === 'linux') return { cmd: 'xdg-open', args: [url] };
+  return null;
+}
+
+/** Open a URL in the default browser. Returns false when no opener exists. */
+export async function tryOpenUrlInBrowser(url: string): Promise<boolean> {
+  const openCommand = getOpenCommand(url);
+  if (!openCommand) return false;
+
+  return new Promise((resolve) => {
+    const child = spawn(openCommand.cmd, openCommand.args, {
+      stdio: 'ignore',
+      detached: true,
+    });
+    child.once('error', () => resolve(false));
+    child.once('spawn', () => {
+      child.unref();
+      resolve(true);
+    });
+  });
+}

--- a/tests/gateway-service.mcp-auth.test.ts
+++ b/tests/gateway-service.mcp-auth.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from 'vitest';
+
+import { parseMcpServerConfig } from '../src/gateway/gateway-service.js';
+
+test('accepts oauth auth for remote transports and normalizes the transport', () => {
+  const parsed = parseMcpServerConfig(
+    JSON.stringify({
+      transport: 'streamable-http',
+      url: 'https://mcp.example.com/mcp',
+      auth: 'oauth',
+    }),
+  );
+  expect(parsed.error).toBeUndefined();
+  expect(parsed.config?.transport).toBe('http');
+  expect(parsed.config?.auth).toBe('oauth');
+});
+
+test('drops auth: none from the stored config', () => {
+  const parsed = parseMcpServerConfig(
+    JSON.stringify({
+      transport: 'sse',
+      url: 'https://mcp.example.com/sse',
+      auth: 'none',
+    }),
+  );
+  expect(parsed.config?.auth).toBeUndefined();
+});
+
+test('rejects oauth auth for stdio servers', () => {
+  const parsed = parseMcpServerConfig(
+    JSON.stringify({ transport: 'stdio', command: 'echo', auth: 'oauth' }),
+  );
+  expect(parsed.error).toContain('OAuth is only supported');
+});
+
+test('rejects unknown auth values', () => {
+  const parsed = parseMcpServerConfig(
+    JSON.stringify({
+      transport: 'http',
+      url: 'https://mcp.example.com/mcp',
+      auth: 'basic',
+    }),
+  );
+  expect(parsed.error).toContain('`auth` must be `oauth`');
+});

--- a/tests/mcp-oauth.test.ts
+++ b/tests/mcp-oauth.test.ts
@@ -1,0 +1,391 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, expect, test, vi } from 'vitest';
+
+const ORIGINAL_HYBRIDCLAW_DATA_DIR = process.env.HYBRIDCLAW_DATA_DIR;
+
+const tempDirs: string[] = [];
+
+function makeTempHome(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-mcp-oauth-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function importFreshMcpOAuth(homeDir: string) {
+  vi.resetModules();
+  process.env.HYBRIDCLAW_DATA_DIR = homeDir;
+  return await import('../src/mcp/mcp-oauth.ts');
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.resetModules();
+  if (ORIGINAL_HYBRIDCLAW_DATA_DIR === undefined) {
+    delete process.env.HYBRIDCLAW_DATA_DIR;
+  } else {
+    process.env.HYBRIDCLAW_DATA_DIR = ORIGINAL_HYBRIDCLAW_DATA_DIR;
+  }
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+interface RecordedRequest {
+  url: string;
+  method: string;
+  body: URLSearchParams | Record<string, unknown> | null;
+}
+
+function stubOAuthServerFetch(options?: {
+  withProtectedResourceMetadata?: boolean;
+  registrationFails?: boolean;
+  tokenResponse?: Record<string, unknown>;
+}): RecordedRequest[] {
+  const requests: RecordedRequest[] = [];
+  const tokenResponse = options?.tokenResponse ?? {
+    access_token: 'access-1',
+    refresh_token: 'refresh-1',
+    expires_in: 3600,
+    scope: 'mcp.read',
+  };
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = (init?.method || 'GET').toUpperCase();
+      let body: RecordedRequest['body'] = null;
+      if (init?.body instanceof URLSearchParams) {
+        body = init.body;
+      } else if (typeof init?.body === 'string') {
+        body = JSON.parse(init.body) as Record<string, unknown>;
+      }
+      requests.push({ url, method, body });
+
+      if (url.includes('/.well-known/oauth-protected-resource')) {
+        if (options?.withProtectedResourceMetadata === false) {
+          return jsonResponse({ error: 'not found' }, 404);
+        }
+        if (url !== 'https://mcp.example.com/.well-known/oauth-protected-resource/mcp') {
+          return jsonResponse({ error: 'not found' }, 404);
+        }
+        return jsonResponse({
+          resource: 'https://mcp.example.com/mcp',
+          authorization_servers: ['https://auth.example.com'],
+          scopes_supported: ['mcp.read', 'mcp.write'],
+        });
+      }
+      if (url.includes('/.well-known/oauth-authorization-server')) {
+        if (!url.startsWith('https://auth.example.com/')) {
+          return jsonResponse({ error: 'not found' }, 404);
+        }
+        return jsonResponse({
+          issuer: 'https://auth.example.com',
+          authorization_endpoint: 'https://auth.example.com/authorize',
+          token_endpoint: 'https://auth.example.com/token',
+          registration_endpoint: 'https://auth.example.com/register',
+        });
+      }
+      if (url.includes('/.well-known/openid-configuration')) {
+        return jsonResponse({ error: 'not found' }, 404);
+      }
+      if (url === 'https://auth.example.com/register') {
+        if (options?.registrationFails) {
+          return jsonResponse({ error: 'access_denied' }, 403);
+        }
+        return jsonResponse({ client_id: 'client-123' }, 201);
+      }
+      if (url === 'https://auth.example.com/token') {
+        return jsonResponse(tokenResponse);
+      }
+      return jsonResponse({ error: 'unexpected request' }, 500);
+    }),
+  );
+  return requests;
+}
+
+test('start + complete flow discovers metadata, registers a client, and stores tokens', async () => {
+  const homeDir = makeTempHome();
+  const mod = await importFreshMcpOAuth(homeDir);
+  const requests = stubOAuthServerFetch();
+
+  const started = await mod.startMcpOAuthFlow({
+    serverName: 'linear',
+    serverUrl: 'https://mcp.example.com/mcp',
+    redirectUri: 'http://127.0.0.1:8787/api/mcp/oauth/callback',
+  });
+
+  const authUrl = new URL(started.authorizationUrl);
+  expect(authUrl.origin + authUrl.pathname).toBe(
+    'https://auth.example.com/authorize',
+  );
+  expect(authUrl.searchParams.get('client_id')).toBe('client-123');
+  expect(authUrl.searchParams.get('response_type')).toBe('code');
+  expect(authUrl.searchParams.get('code_challenge_method')).toBe('S256');
+  expect(authUrl.searchParams.get('resource')).toBe(
+    'https://mcp.example.com/mcp',
+  );
+  expect(authUrl.searchParams.get('scope')).toBe('mcp.read mcp.write');
+  expect(authUrl.searchParams.get('state')).toBe(started.state);
+
+  const completed = await mod.completeMcpOAuthFlow({
+    state: started.state,
+    code: 'auth-code-1',
+  });
+  expect(completed.serverName).toBe('linear');
+
+  const tokenRequest = requests.find(
+    (request) => request.url === 'https://auth.example.com/token',
+  );
+  expect(tokenRequest).toBeTruthy();
+  const tokenBody = tokenRequest?.body as URLSearchParams;
+  expect(tokenBody.get('grant_type')).toBe('authorization_code');
+  expect(tokenBody.get('code')).toBe('auth-code-1');
+  expect(tokenBody.get('resource')).toBe('https://mcp.example.com/mcp');
+  const verifier = tokenBody.get('code_verifier') || '';
+  const expectedChallenge = createHash('sha256')
+    .update(verifier)
+    .digest('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+  expect(authUrl.searchParams.get('code_challenge')).toBe(expectedChallenge);
+
+  const record = mod.getMcpOAuthRecord('linear');
+  expect(record?.tokens?.accessToken).toBe('access-1');
+  expect(record?.tokens?.refreshToken).toBe('refresh-1');
+
+  const storePath = path.join(homeDir, 'mcp-oauth.json');
+  expect(fs.existsSync(storePath)).toBe(true);
+  expect(fs.statSync(storePath).mode & 0o777).toBe(0o600);
+});
+
+test('falls back to the server origin as issuer without protected resource metadata', async () => {
+  const homeDir = makeTempHome();
+  const mod = await importFreshMcpOAuth(homeDir);
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/.well-known/oauth-protected-resource')) {
+        return jsonResponse({ error: 'not found' }, 404);
+      }
+      if (
+        url ===
+        'https://mcp.example.com/.well-known/oauth-authorization-server'
+      ) {
+        return jsonResponse({
+          authorization_endpoint: 'https://mcp.example.com/authorize',
+          token_endpoint: 'https://mcp.example.com/token',
+          registration_endpoint: 'https://mcp.example.com/register',
+        });
+      }
+      if (url === 'https://mcp.example.com/register') {
+        return jsonResponse({ client_id: 'client-xyz' }, 201);
+      }
+      return jsonResponse({ error: 'not found' }, 404);
+    }),
+  );
+
+  const started = await mod.startMcpOAuthFlow({
+    serverName: 'local',
+    serverUrl: 'https://mcp.example.com/mcp',
+    redirectUri: 'http://127.0.0.1:8787/api/mcp/oauth/callback',
+  });
+  expect(started.authorizationUrl.startsWith('https://mcp.example.com/authorize?')).toBe(true);
+  expect(new URL(started.authorizationUrl).searchParams.get('resource')).toBe(
+    'https://mcp.example.com/mcp',
+  );
+});
+
+test('start fails with a clear error when registration is unsupported', async () => {
+  const homeDir = makeTempHome();
+  const mod = await importFreshMcpOAuth(homeDir);
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/.well-known/oauth-authorization-server')) {
+        return jsonResponse({
+          authorization_endpoint: 'https://auth.example.com/authorize',
+          token_endpoint: 'https://auth.example.com/token',
+        });
+      }
+      return jsonResponse({ error: 'not found' }, 404);
+    }),
+  );
+
+  await expect(
+    mod.startMcpOAuthFlow({
+      serverName: 'noreg',
+      serverUrl: 'https://mcp.example.com/mcp',
+      redirectUri: 'http://127.0.0.1:8787/api/mcp/oauth/callback',
+    }),
+  ).rejects.toThrow(/dynamic client registration/);
+});
+
+test('complete rejects unknown state', async () => {
+  const homeDir = makeTempHome();
+  const mod = await importFreshMcpOAuth(homeDir);
+  await expect(
+    mod.completeMcpOAuthFlow({ state: 'bogus', code: 'code' }),
+  ).rejects.toThrow(/Unknown or expired/);
+});
+
+async function seedConnectedServer(
+  mod: Awaited<ReturnType<typeof importFreshMcpOAuth>>,
+  tokenOverrides?: Record<string, unknown>,
+): Promise<void> {
+  stubOAuthServerFetch({
+    tokenResponse: {
+      access_token: 'access-1',
+      refresh_token: 'refresh-1',
+      expires_in: 3600,
+      ...tokenOverrides,
+    },
+  });
+  const started = await mod.startMcpOAuthFlow({
+    serverName: 'linear',
+    serverUrl: 'https://mcp.example.com/mcp',
+    redirectUri: 'http://127.0.0.1:8787/api/mcp/oauth/callback',
+  });
+  await mod.completeMcpOAuthFlow({ state: started.state, code: 'code-1' });
+}
+
+test('ensureFreshMcpAccessToken returns the stored token while valid', async () => {
+  const homeDir = makeTempHome();
+  const mod = await importFreshMcpOAuth(homeDir);
+  await seedConnectedServer(mod);
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => {
+      throw new Error('no network expected');
+    }),
+  );
+  await expect(mod.ensureFreshMcpAccessToken('linear')).resolves.toBe(
+    'access-1',
+  );
+});
+
+test('ensureFreshMcpAccessToken refreshes expired tokens and persists the result', async () => {
+  const homeDir = makeTempHome();
+  const mod = await importFreshMcpOAuth(homeDir);
+  await seedConnectedServer(mod, { expires_in: 1 });
+
+  const requests = stubOAuthServerFetch({
+    tokenResponse: { access_token: 'access-2', expires_in: 3600 },
+  });
+  await expect(mod.ensureFreshMcpAccessToken('linear')).resolves.toBe(
+    'access-2',
+  );
+  const refreshRequest = requests.find(
+    (request) => request.url === 'https://auth.example.com/token',
+  );
+  const body = refreshRequest?.body as URLSearchParams;
+  expect(body.get('grant_type')).toBe('refresh_token');
+  expect(body.get('refresh_token')).toBe('refresh-1');
+
+  // Rotated refresh tokens are kept; missing ones fall back to the old token.
+  const record = mod.getMcpOAuthRecord('linear');
+  expect(record?.tokens?.accessToken).toBe('access-2');
+  expect(record?.tokens?.refreshToken).toBe('refresh-1');
+});
+
+test('ensureFreshMcpAccessToken returns null when refresh fails', async () => {
+  const homeDir = makeTempHome();
+  const mod = await importFreshMcpOAuth(homeDir);
+  await seedConnectedServer(mod, { expires_in: 1 });
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => jsonResponse({ error: 'invalid_grant' }, 400)),
+  );
+  await expect(mod.ensureFreshMcpAccessToken('linear')).resolves.toBeNull();
+});
+
+test('resolveMcpServersForRuntime injects Authorization for oauth servers only', async () => {
+  const homeDir = makeTempHome();
+  const mod = await importFreshMcpOAuth(homeDir);
+  await seedConnectedServer(mod);
+
+  const resolved = await mod.resolveMcpServersForRuntime({
+    linear: {
+      transport: 'http',
+      url: 'https://mcp.example.com/mcp',
+      auth: 'oauth',
+      headers: { 'X-Extra': 'kept' },
+    },
+    plain: {
+      transport: 'http',
+      url: 'https://plain.example.com/mcp',
+      headers: { Authorization: 'Bearer static' },
+    },
+    disabled: {
+      transport: 'http',
+      url: 'https://mcp.example.com/mcp',
+      auth: 'oauth',
+      enabled: false,
+    },
+    local: { transport: 'stdio', command: 'echo' },
+  });
+
+  expect(resolved.linear.headers).toEqual({
+    'X-Extra': 'kept',
+    Authorization: 'Bearer access-1',
+  });
+  expect(resolved.plain.headers).toEqual({ Authorization: 'Bearer static' });
+  expect(resolved.disabled.headers).toBeUndefined();
+  expect(resolved.local.headers).toBeUndefined();
+});
+
+test('getMcpOAuthStatus reports unauthorized, connected, and url changes', async () => {
+  const homeDir = makeTempHome();
+  const mod = await importFreshMcpOAuth(homeDir);
+
+  expect(
+    mod.getMcpOAuthStatus('linear', {
+      auth: 'oauth',
+      url: 'https://mcp.example.com/mcp',
+    }),
+  ).toEqual({ method: 'oauth', state: 'unauthorized' });
+  expect(mod.getMcpOAuthStatus('linear', { url: 'x' })).toEqual({
+    method: 'none',
+  });
+
+  await seedConnectedServer(mod);
+  expect(
+    mod.getMcpOAuthStatus('linear', {
+      auth: 'oauth',
+      url: 'https://mcp.example.com/mcp',
+    }).state,
+  ).toBe('connected');
+
+  // Pointing the config at a different URL invalidates stored credentials.
+  expect(
+    mod.getMcpOAuthStatus('linear', {
+      auth: 'oauth',
+      url: 'https://other.example.com/mcp',
+    }).state,
+  ).toBe('unauthorized');
+
+  mod.clearMcpOAuth('linear');
+  expect(
+    mod.getMcpOAuthStatus('linear', {
+      auth: 'oauth',
+      url: 'https://mcp.example.com/mcp',
+    }).state,
+  ).toBe('unauthorized');
+});

--- a/tests/mcp-oauth.test.ts
+++ b/tests/mcp-oauth.test.ts
@@ -167,9 +167,41 @@ test('start + complete flow discovers metadata, registers a client, and stores t
   expect(record?.tokens?.accessToken).toBe('access-1');
   expect(record?.tokens?.refreshToken).toBe('refresh-1');
 
-  const storePath = path.join(homeDir, 'mcp-oauth.json');
+  // Credentials live in the encrypted runtime secret store: the entry name
+  // (hex of "linear") is visible, the token values are not.
+  const storePath = path.join(homeDir, 'credentials.json');
   expect(fs.existsSync(storePath)).toBe(true);
   expect(fs.statSync(storePath).mode & 0o777).toBe(0o600);
+  const rawStore = fs.readFileSync(storePath, 'utf-8');
+  expect(rawStore).toContain('MCP_OAUTH_6C696E656172');
+  expect(rawStore).not.toContain('access-1');
+  expect(rawStore).not.toContain('refresh-1');
+});
+
+test('server names too long for hex encoding fall back to a digest secret name', async () => {
+  const homeDir = makeTempHome();
+  const mod = await importFreshMcpOAuth(homeDir);
+  stubOAuthServerFetch();
+  const longName = `srv-${'a'.repeat(80)}`;
+
+  const started = await mod.startMcpOAuthFlow({
+    serverName: longName,
+    serverUrl: 'https://mcp.example.com/mcp',
+    redirectUri: 'http://127.0.0.1:8787/api/mcp/oauth/callback',
+  });
+  await mod.completeMcpOAuthFlow({ state: started.state, code: 'code-1' });
+
+  expect(mod.getMcpOAuthRecord(longName)?.tokens?.accessToken).toBe(
+    'access-1',
+  );
+  const rawStore = fs.readFileSync(
+    path.join(homeDir, 'credentials.json'),
+    'utf-8',
+  );
+  expect(rawStore).toContain('MCP_OAUTH_H_');
+
+  expect(mod.clearMcpOAuth(longName)).toBe(true);
+  expect(mod.getMcpOAuthRecord(longName)).toBeNull();
 });
 
 test('falls back to the server origin as issuer without protected resource metadata', async () => {

--- a/tests/runtime-config.migration-logging.test.ts
+++ b/tests/runtime-config.migration-logging.test.ts
@@ -217,6 +217,38 @@ describe('runtime config migration logging', () => {
     expect(stored.mcpServers.demo.url).toBe('https://example.com/mcp');
   });
 
+  it('preserves auth: oauth on remote MCP servers and drops it for stdio', async () => {
+    const homeDir = makeTempHome();
+    writeRuntimeConfig(homeDir, (config) => {
+      config.mcpServers = {
+        remote: {
+          transport: 'http',
+          url: 'https://example.com/mcp',
+          auth: 'oauth',
+          enabled: true,
+        },
+        local: {
+          transport: 'stdio',
+          command: 'node',
+          enabled: true,
+        },
+      };
+      (config.mcpServers.local as Record<string, unknown>).auth = 'oauth';
+    });
+
+    await importFreshRuntimeConfig(homeDir);
+
+    const stored = JSON.parse(
+      fs.readFileSync(
+        path.join(homeDir, '.hybridclaw', 'config.json'),
+        'utf-8',
+      ),
+    ) as RuntimeConfig;
+
+    expect(stored.mcpServers.remote.auth).toBe('oauth');
+    expect(stored.mcpServers.local.auth).toBeUndefined();
+  });
+
   it('normalizes plugin config entries and drops invalid rows on startup', async () => {
     const homeDir = makeTempHome();
     writeRuntimeConfig(homeDir, (config) => {

--- a/tests/tui-mcp-wizard.test.ts
+++ b/tests/tui-mcp-wizard.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from 'vitest';
+
+import {
+  buildTuiMcpServerConfig,
+  isValidTuiMcpServerName,
+  parseTuiMcpArgsLine,
+  parseTuiMcpKeyValuePairs,
+  waitForTuiMcpOAuthConnection,
+} from '../src/tui-mcp-wizard.js';
+
+test('validates MCP server names like the gateway', () => {
+  expect(isValidTuiMcpServerName('github')).toBe(true);
+  expect(isValidTuiMcpServerName('hf_server-1')).toBe(true);
+  expect(isValidTuiMcpServerName('Foo')).toBe(false);
+  expect(isValidTuiMcpServerName('foo bar')).toBe(false);
+  expect(isValidTuiMcpServerName('')).toBe(false);
+});
+
+test('parses comma separated KEY=VALUE pairs', () => {
+  expect(parseTuiMcpKeyValuePairs('')).toBeUndefined();
+  expect(parseTuiMcpKeyValuePairs('A=1, B=x=y')).toEqual({
+    A: '1',
+    B: 'x=y',
+  });
+  expect(() => parseTuiMcpKeyValuePairs('no-separator')).toThrow(
+    /KEY=VALUE/,
+  );
+});
+
+test('parses argument lines with quoted segments', () => {
+  expect(parseTuiMcpArgsLine('run --label "hello world" -v')).toEqual([
+    'run',
+    '--label',
+    'hello world',
+    '-v',
+  ]);
+  expect(parseTuiMcpArgsLine('')).toEqual([]);
+});
+
+test('builds stdio configs from wizard answers', () => {
+  expect(
+    buildTuiMcpServerConfig({
+      name: 'fs',
+      transport: 'stdio',
+      command: 'npx',
+      argsLine: '-y @modelcontextprotocol/server-filesystem /tmp',
+      envPairs: 'DEBUG=1',
+    }),
+  ).toEqual({
+    transport: 'stdio',
+    command: 'npx',
+    args: ['-y', '@modelcontextprotocol/server-filesystem', '/tmp'],
+    env: { DEBUG: '1' },
+  });
+  expect(() =>
+    buildTuiMcpServerConfig({ name: 'fs', transport: 'stdio' }),
+  ).toThrow(/command/);
+});
+
+test('builds remote configs for each auth choice', () => {
+  expect(
+    buildTuiMcpServerConfig({
+      name: 'linear',
+      transport: 'http',
+      url: 'https://mcp.linear.app/mcp',
+      authChoice: 'oauth',
+    }),
+  ).toEqual({
+    transport: 'http',
+    url: 'https://mcp.linear.app/mcp',
+    auth: 'oauth',
+  });
+  expect(
+    buildTuiMcpServerConfig({
+      name: 'tavily',
+      transport: 'http',
+      url: 'https://mcp.tavily.com/mcp',
+      authChoice: 'bearer',
+      bearerToken: 'tvly-123',
+    }).headers,
+  ).toEqual({ Authorization: 'Bearer tvly-123' });
+  expect(
+    buildTuiMcpServerConfig({
+      name: 'custom',
+      transport: 'sse',
+      url: 'https://example.com/sse',
+      authChoice: 'headers',
+      headerPairs: 'X-Api-Key=k1',
+    }).headers,
+  ).toEqual({ 'X-Api-Key': 'k1' });
+  expect(() =>
+    buildTuiMcpServerConfig({
+      name: 'bad',
+      transport: 'http',
+      url: 'not-a-url',
+    }),
+  ).toThrow(/http\(s\) URL/);
+});
+
+test('waitForTuiMcpOAuthConnection polls until connected', async () => {
+  let now = 0;
+  const states = ['unauthorized', 'unauthorized', 'connected'] as const;
+  let call = 0;
+  const status = await waitForTuiMcpOAuthConnection({
+    name: 'linear',
+    timeoutMs: 60_000,
+    deps: {
+      now: () => now,
+      sleep: async () => {
+        now += 2_000;
+      },
+      fetchOAuthStatus: async (name: string) => ({
+        name,
+        auth: { method: 'oauth', state: states[Math.min(call++, 2)] },
+      }),
+    },
+  });
+  expect(status?.auth.state).toBe('connected');
+  expect(call).toBe(3);
+});
+
+test('waitForTuiMcpOAuthConnection gives up at the deadline', async () => {
+  let now = 0;
+  const status = await waitForTuiMcpOAuthConnection({
+    name: 'linear',
+    timeoutMs: 10_000,
+    deps: {
+      now: () => now,
+      sleep: async () => {
+        now += 2_000;
+      },
+      fetchOAuthStatus: async (name: string) => ({
+        name,
+        auth: { method: 'oauth' as const, state: 'unauthorized' as const },
+      }),
+    },
+  });
+  expect(status).toBeNull();
+});

--- a/tests/tui-mcp-wizard.test.ts
+++ b/tests/tui-mcp-wizard.test.ts
@@ -1,19 +1,19 @@
 import { expect, test } from 'vitest';
 
+import { isValidMcpServerName } from '../src/mcp/server-config.js';
 import {
   buildTuiMcpServerConfig,
-  isValidTuiMcpServerName,
   parseTuiMcpArgsLine,
   parseTuiMcpKeyValuePairs,
   waitForTuiMcpOAuthConnection,
 } from '../src/tui-mcp-wizard.js';
 
-test('validates MCP server names like the gateway', () => {
-  expect(isValidTuiMcpServerName('github')).toBe(true);
-  expect(isValidTuiMcpServerName('hf_server-1')).toBe(true);
-  expect(isValidTuiMcpServerName('Foo')).toBe(false);
-  expect(isValidTuiMcpServerName('foo bar')).toBe(false);
-  expect(isValidTuiMcpServerName('')).toBe(false);
+test('validates MCP server names', () => {
+  expect(isValidMcpServerName('github')).toBe(true);
+  expect(isValidMcpServerName('hf_server-1')).toBe(true);
+  expect(isValidMcpServerName('Foo')).toBe(false);
+  expect(isValidMcpServerName('foo bar')).toBe(false);
+  expect(isValidMcpServerName('')).toBe(false);
 });
 
 test('parses comma separated KEY=VALUE pairs', () => {


### PR DESCRIPTION
## Summary

Adds gateway-managed **OAuth 2.1 for remote (`http`/`sse`) MCP servers** and overhauls the MCP setup UX in both the TUI and the web console. Servers opt in with `"auth": "oauth"`; no manual token handling needed.

### How it works
- The gateway runs the full spec flow on the host: RFC 9728 protected-resource discovery, RFC 8414 authorization-server metadata, RFC 7591 dynamic client registration, PKCE authorization-code exchange with RFC 8707 resource indicators (`src/mcp/mcp-oauth.ts`)
- Credentials are stored encrypted at rest in the runtime secret store (`~/.hybridclaw/credentials.json`, AES-256-GCM, one `MCP_OAUTH_*` entry per server) with automatic refresh; a fresh `Authorization` header is injected into the MCP config handed to the container on every turn — the container MCP client is unchanged
- `runtime-config` normalization preserves the new `auth` field (it strips unknown keys)
- Removing a server also clears its stored credentials

### Gateway API
- `POST /api/admin/mcp/oauth/start` (redirect URI derived from the request host), `GET /api/admin/mcp/oauth/status`, `POST /api/admin/mcp/oauth/logout`
- Public `GET /api/mcp/oauth/callback` — single-use state-nonce validated, renders a success/error page, auto-closes script-opened tabs
- `GET /api/admin/mcp` now includes per-server auth status

### TUI / chat channels
- `/mcp add` with no JSON launches a guided wizard (name, transport, URL/command, auth picker: OAuth / bearer / custom headers / none); `/mcp edit <name>` re-runs it prefilled; raw JSON form still works
- `/mcp login|logout|status <name>`; in the TUI, login opens the browser and polls until connected; from Discord etc. the authorization URL is printed
- `/mcp list` shows connection state and a login hint when needed

### Web console
- MCP page: auth mode selector (OAuth is the default for new remote servers), **Connect** button that auto-saves, opens the consent page, and polls until connected (with a fallback link if the popup is blocked), connected/expired/login-required pills, **Disconnect**
- Cleaned up list rows (no duplicated name, no CLI hints in the web UI); Connect gated on name+URL

### Docs
`docs/content/guides/tui-mcp.md`, AGENTS.md §7.3, and `config.example.json` updated.

## Testing
- New unit suites: OAuth module (discovery fallbacks, PKCE round-trip verified against the S256 challenge, refresh + rotation, header injection), config validation, runtime-config `auth` preservation, TUI wizard helpers and polling; console connect/disconnect flow tests
- Full unit project (514 files / 4,896 tests) and console suite (72 files / 710 tests) pass; root+console+container+desktop typecheck and strict lint clean
- **Verified live end to end** against Sentry (`https://mcp.sentry.dev/mcp`) and Linear (`https://mcp.linear.app/mcp`) hosted MCP servers: dynamic client registration, browser consent, callback exchange, token refresh path, and an authenticated MCP `initialize` using the injected token — exercised via slash commands and via the console UI (add-from-scratch, connect, disconnect, reconnect, delete)

Known limitation: authorization servers without dynamic client registration get a clear error pointing to static `Authorization` headers as the alternative (manual client-id entry is a possible follow-up).
