### PR TITLE
[codex] Catch websocket handshake timeouts

### DIFF
--- a/src/channels/whatsapp/connection.ts
+++ b/src/channels/whatsapp/connection.ts
@@ -599,9 +599,8 @@ export function createWhatsAppConnectionManager(params?: {
     clearWhatsAppPairingState();
     connectionOpen = false;
     socket = null;
-    const statusCode = resolveDisconnectStatusCode(
-      update.lastDisconnect?.error,
-    );
+    const disconnectError = update.lastDisconnect?.error;
+    const statusCode = resolveDisconnectStatusCode(disconnectError);
     if (statusCode === DisconnectReason.loggedOut) {
       childLogger.warn(
         'WhatsApp session logged out; scan a new QR code to reconnect',
@@ -621,6 +620,7 @@ export function createWhatsAppConnectionManager(params?: {
     rejectWaiters(new Error('WhatsApp connection closed'));
     scheduleReconnect(
       statusCode != null ? `status:${statusCode}` : 'connection-close',
+      disconnectError,
     );
     await sleep(0);
   };

--- a/src/observability/sentry.ts
+++ b/src/observability/sentry.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import { readStoredRuntimeEnv } from '../config/runtime-env.js';
 import { redactSecretsDeep } from '../security/redact.js';
+import { isExpectedTransportError } from '../utils/transport-errors.js';
 
 type SentryModule = typeof import('@sentry/node');
 
@@ -74,6 +75,23 @@ function normalizeException(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
 }
 
+function sentryEventHasExpectedTransportError(event: {
+  exception?: {
+    values?: Array<{
+      type?: unknown;
+      value?: unknown;
+    }>;
+  };
+}): boolean {
+  return Boolean(
+    event.exception?.values?.some((value) =>
+      [value.type, value.value].some(
+        (part) => typeof part === 'string' && isExpectedTransportError(part),
+      ),
+    ),
+  );
+}
+
 export function isSentryConfigured(): boolean {
   return Boolean(readRuntimeSetting('SENTRY_DSN'));
 }
@@ -91,7 +109,13 @@ export async function initSentry(): Promise<void> {
         release: readRuntimeSetting('SENTRY_RELEASE') || defaultSentryRelease(),
         skipOpenTelemetrySetup: true,
         tracesSampleRate: readSampleRate(),
-        beforeSend(event) {
+        beforeSend(event, hint) {
+          if (
+            isExpectedTransportError(hint?.originalException) ||
+            sentryEventHasExpectedTransportError(event)
+          ) {
+            return null;
+          }
           return redactSecretsDeep(event);
         },
       });

--- a/src/utils/transport-errors.ts
+++ b/src/utils/transport-errors.ts
@@ -23,6 +23,8 @@ const EXPECTED_TRANSPORT_ERROR_MESSAGE_RE =
 interface ErrorLike {
   cause?: unknown;
   code?: unknown;
+  data?: unknown;
+  error?: unknown;
   hostname?: unknown;
   // Keep the standard AggregateError shape, but avoid speculative wrappers.
   errors?: unknown;
@@ -82,34 +84,15 @@ function findTransportErrorDetails(
 
   if (error && typeof error === 'object') {
     const candidate = error as ErrorLike;
-    if (Array.isArray(candidate.errors)) {
-      for (const nested of candidate.errors) {
-        const nestedDetails = findTransportErrorDetails(nested, depth + 1);
-        if (nestedDetails.code || nestedDetails.host || nestedDetails.message) {
-          return nestedDetails;
-        }
+    for (const nested of getNestedTransportErrors(candidate)) {
+      const nestedDetails = findTransportErrorDetails(nested, depth + 1);
+      if (nestedDetails.code || nestedDetails.host || nestedDetails.message) {
+        return nestedDetails;
       }
-    }
-
-    const causeDetails = findTransportErrorDetails(candidate.cause, depth + 1);
-    if (causeDetails.code || causeDetails.host || causeDetails.message) {
-      return causeDetails;
     }
   }
 
   return details;
-}
-
-function getTransportErrorCode(error: unknown): string {
-  return findTransportErrorDetails(error).code;
-}
-
-function getTransportErrorHost(
-  error: unknown,
-  fallbackHost?: string | null,
-): string {
-  const host = findTransportErrorDetails(error).host;
-  return host || String(fallbackHost || '').trim();
 }
 
 function hasMeaningfulHost(host: string): boolean {
@@ -128,8 +111,9 @@ export function describeExpectedTransportError(
   subject: string,
   fallbackHost?: string | null,
 ): string {
-  const code = getTransportErrorCode(error);
-  const host = getTransportErrorHost(error, fallbackHost);
+  const details = findTransportErrorDetails(error);
+  const code = details.code;
+  const host = details.host || String(fallbackHost || '').trim();
 
   switch (code) {
     case 'ENOTFOUND':
@@ -161,6 +145,9 @@ export function describeExpectedTransportError(
     case 'EPIPE':
       return `${subject} socket closed unexpectedly.`;
     default:
+      if (/\b(timed out|timeout)\b/i.test(details.message)) {
+        return `${formatTransportEndpoint(subject, host)} timed out.`;
+      }
       if (hasMeaningfulHost(host)) {
         return `${subject} is temporarily unavailable at ${host}.`;
       }
@@ -176,6 +163,23 @@ function hasExpectedTransportSignature(
   return (
     EXPECTED_TRANSPORT_ERROR_CODES.has(code) || messagePattern.test(message)
   );
+}
+
+function getNestedTransportErrors(candidate: ErrorLike): unknown[] {
+  const nested: unknown[] = [];
+  if (Array.isArray(candidate.errors)) {
+    nested.push(...candidate.errors);
+  }
+  if (candidate.cause != null) {
+    nested.push(candidate.cause);
+  }
+  if (candidate.data != null) {
+    nested.push(candidate.data);
+  }
+  if (candidate.error != null) {
+    nested.push(candidate.error);
+  }
+  return nested;
 }
 
 function matchesExpectedTransportError(
@@ -203,19 +207,8 @@ function matchesExpectedTransportError(
     return true;
   }
 
-  if (
-    Array.isArray(candidate.errors) &&
-    candidate.errors.some((nested) =>
-      matchesExpectedTransportError(nested, messagePattern, depth + 1),
-    )
-  ) {
-    return true;
-  }
-
-  return matchesExpectedTransportError(
-    candidate.cause,
-    messagePattern,
-    depth + 1,
+  return getNestedTransportErrors(candidate).some((nested) =>
+    matchesExpectedTransportError(nested, messagePattern, depth + 1),
   );
 }
 

--- a/tests/sentry.test.ts
+++ b/tests/sentry.test.ts
@@ -169,6 +169,38 @@ describe('Sentry observability', () => {
     });
   });
 
+  test('drops expected transport exceptions before sending events', async () => {
+    process.env.SENTRY_DSN = 'https://public@example.com/1';
+    const { initSentry } = await importFreshSentry();
+
+    await initSentry();
+    const options = sentryInit.mock.calls[0]?.[0] as {
+      beforeSend: (
+        event: Record<string, unknown>,
+        hint?: { originalException?: unknown },
+      ) => Record<string, unknown> | null;
+    };
+
+    expect(
+      options.beforeSend(
+        {},
+        { originalException: new Error('Opening handshake has timed out') },
+      ),
+    ).toBeNull();
+    expect(
+      options.beforeSend({
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value: 'Opening handshake has timed out',
+            },
+          ],
+        },
+      }),
+    ).toBeNull();
+  });
+
   test('keeps mechanism tag authoritative over caller tags', async () => {
     process.env.SENTRY_DSN = 'https://public@example.com/1';
     const { captureSentryException, initSentry } = await importFreshSentry();

--- a/tests/transport-errors.test.ts
+++ b/tests/transport-errors.test.ts
@@ -54,6 +54,21 @@ describe('isExpectedTransportError', () => {
     expect(isExpectedTransportError(error)).toBe(true);
   });
 
+  test('matches transport errors nested in wrapper data fields', () => {
+    const error = Object.assign(new Error('WebSocket Error'), {
+      data: new Error('Opening handshake has timed out'),
+    });
+
+    expect(isExpectedTransportError(error)).toBe(true);
+    expect(
+      describeExpectedTransportError(
+        error,
+        'WhatsApp WebSocket',
+        'web.whatsapp.com',
+      ),
+    ).toBe('WhatsApp WebSocket connection to web.whatsapp.com timed out.');
+  });
+
   test('ignores unrelated application errors', () => {
     expect(
       isExpectedTransportError(

--- a/tests/whatsapp.connection.test.ts
+++ b/tests/whatsapp.connection.test.ts
@@ -382,6 +382,34 @@ test('reconnect warnings use human-readable wording for lost connections', async
   await manager.stop();
 });
 
+test('reconnect warning catches wrapped WhatsApp websocket handshake timeouts', async () => {
+  const { createWhatsAppConnectionManager, sockets, whatsappLogger } =
+    await importFreshConnectionModule();
+
+  const manager = createWhatsAppConnectionManager();
+  await manager.start();
+
+  const updateHandlers = sockets[0]?.evHandlers.get('connection.update');
+  expect(updateHandlers).toHaveLength(1);
+
+  updateHandlers?.[0]?.({
+    connection: 'close',
+    lastDisconnect: {
+      error: Object.assign(new Error('WebSocket Error'), {
+        data: new Error('Opening handshake has timed out'),
+        output: { statusCode: 408 },
+      }),
+      date: new Date(),
+    },
+  });
+
+  expect(whatsappLogger.warn).toHaveBeenCalledWith(
+    'WhatsApp WebSocket connection to web.whatsapp.com timed out. Retrying connection in 1s.',
+  );
+
+  await manager.stop();
+});
+
 test('suppresses buffer flush noise while WhatsApp is offline', async () => {
   const { createWhatsAppConnectionManager, sockets, whatsappLogger } =
     await importFreshConnectionModule({


### PR DESCRIPTION
## Summary

- Treat Baileys-wrapped WebSocket handshake timeouts as expected transport failures.
- Pass WhatsApp disconnect errors into reconnect logging so retries show the concrete timeout reason.
- Drop expected transport exceptions in Sentry `beforeSend` to avoid noisy issues from global SDK handlers.

## Root Cause

`ws` can surface `Opening handshake has timed out` through Baileys as a wrapped error, with the original transport error stored under wrapper fields such as `data`. The existing transport classifier only followed `cause` and `errors`, so reconnect handling and Sentry filtering could miss the expected transport signature.

## Validation

- `vitest run tests/transport-errors.test.ts tests/whatsapp.connection.test.ts tests/sentry.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `npm run lint`
- `npx biome check src/utils/transport-errors.ts src/channels/whatsapp/connection.ts src/observability/sentry.ts tests/transport-errors.test.ts tests/whatsapp.connection.test.ts tests/sentry.test.ts`