### PR TITLE
[codex] Allow bootstrap cleanup without approval

### DIFF
--- a/container/src/approval-policy.ts
+++ b/container/src/approval-policy.ts
@@ -2946,6 +2946,23 @@ export class TrustedAgentApprovalRuntime {
 
     if (lowerTool === 'delete') {
       const rawPath = normalizeText(args.path);
+      if (normalizePathValue(rawPath) === 'BOOTSTRAP.md') {
+        return {
+          tier: 'green',
+          actionKey: 'delete:bootstrap',
+          intent: 'delete `BOOTSTRAP.md`',
+          consequenceIfDenied:
+            'BOOTSTRAP.md will remain for future hatching checks.',
+          reason:
+            'BOOTSTRAP.md is a one-time onboarding file removed after bootstrapping',
+          commandPreview: normalizePreview(rawPath || 'BOOTSTRAP.md'),
+          pathHints: rawPath ? [rawPath] : ['BOOTSTRAP.md'],
+          hostHints: [],
+          writeIntent: false,
+          promotableRed: false,
+          stickyYellow: false,
+        };
+      }
       const key = rawPath
         ? `delete:${primaryPathKey(rawPath)}`
         : 'delete:unknown';

--- a/tests/approval-policy.test.ts
+++ b/tests/approval-policy.test.ts
@@ -1001,6 +1001,60 @@ autonomy:
     expect(evaluation.reason).toBe('this changes the local dependency state');
   });
 
+  test('root BOOTSTRAP.md delete is allowed as onboarding cleanup', () => {
+    const pendingStorePath = tempTrustStorePath('bootstrap-pending');
+    const runtime = new TrustedAgentApprovalRuntime(
+      '/tmp/hybridclaw-missing-policy.yaml',
+      tempTrustStorePath('bootstrap-agent-trust'),
+      tempTrustStorePath('bootstrap-all-trust'),
+      tempTrustStorePath('bootstrap-legacy-trust'),
+      undefined,
+      pendingStorePath,
+    );
+
+    for (const bootstrapPath of [
+      'BOOTSTRAP.md',
+      './BOOTSTRAP.md',
+      '/workspace/BOOTSTRAP.md',
+    ]) {
+      const evaluation = runtime.evaluateToolCall({
+        toolName: 'delete',
+        argsJson: JSON.stringify({ path: bootstrapPath }),
+        latestUserPrompt: 'Finish onboarding',
+      });
+
+      expect(evaluation.tier).toBe('green');
+      expect(evaluation.decision).toBe('auto');
+      expect(evaluation.actionKey).toBe('delete:bootstrap');
+      expect(evaluation.reason).toContain('one-time onboarding file');
+    }
+
+    expect(fs.existsSync(pendingStorePath)).toBe(false);
+  });
+
+  test('other delete calls still require approval', () => {
+    const runtime = new TrustedAgentApprovalRuntime(
+      '/tmp/hybridclaw-missing-policy.yaml',
+      tempTrustStorePath('delete-agent-trust'),
+      tempTrustStorePath('delete-all-trust'),
+      tempTrustStorePath('delete-legacy-trust'),
+      undefined,
+      tempTrustStorePath('delete-pending'),
+    );
+
+    for (const deletePath of ['notes.md', 'memory/BOOTSTRAP.md']) {
+      const evaluation = runtime.evaluateToolCall({
+        toolName: 'delete',
+        argsJson: JSON.stringify({ path: deletePath }),
+        latestUserPrompt: 'Delete a workspace file',
+      });
+
+      expect(evaluation.tier).toBe('red');
+      expect(evaluation.decision).toBe('required');
+      expect(evaluation.reason).toBe('deletion is destructive');
+    }
+  });
+
   test('message read-only actions are green', () => {
     const runtime = new TrustedAgentApprovalRuntime(
       '/tmp/hybridclaw-missing-policy.yaml',


### PR DESCRIPTION
## Summary

- Treat structured deletion of workspace-root `BOOTSTRAP.md` as green onboarding cleanup in the container approval policy.
- Keep all other delete calls on the existing red approval path, including nested `BOOTSTRAP.md` paths.
- Add regression coverage for the allowed bootstrap cleanup and nearby destructive-delete cases.

## Root Cause

`BOOTSTRAP.md` is a one-time onboarding file, but the generic file `delete` tool classified all deletions as destructive red actions. That made the agent ask for approval when following the bootstrap instructions to remove the file after onboarding.

## Validation

- `./node_modules/.bin/vitest run --configLoader runner --project unit tests/approval-policy.test.ts`