### PR TITLE
[codex] retry empty HybridAI completions

### DIFF
--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -56,6 +56,7 @@ import {
   advanceStalledTurnCount,
   MAX_STALLED_MODEL_TURNS,
   shouldRetryEmptyFinalResponse,
+  shouldRetryEmptyVisibleCompletion,
 } from './stalled-turns.js';
 import {
   collapseSystemMessages,
@@ -157,6 +158,8 @@ const DEFAULT_RALPH_MAX_EXTRA_ITERATIONS = Number.isFinite(
     ? -1
     : Math.max(0, Math.min(64, RAW_DEFAULT_RALPH_MAX_EXTRA_ITERATIONS))
   : 0;
+const EMPTY_VISIBLE_COMPLETION_RETRY_PROMPT =
+  'Your last model response had no visible text and did not request a tool. Continue the task now. Reply with a visible answer, or request the next tool call if more work is needed.';
 
 function applyRuntimeEnv(runtimeEnv: ContainerInput['runtimeEnv']): void {
   for (const [name, value] of Object.entries(runtimeEnv || {})) {
@@ -1045,6 +1048,7 @@ async function processRequest(
   const maxStalledTurns = resolveMaxStalledTurns(ralphMaxExtraIterations);
   let ralphExtraIterations = 0;
   let stalledTurns = 0;
+  let emptyVisibleCompletionRetries = 0;
   let latestVisibleAssistantText: string | null = null;
   let compactionRetries = 0;
   const tokenEstimateCache = createTokenEstimateCache();
@@ -1439,28 +1443,36 @@ async function processRequest(
       }
     }
 
-    const assistantMessage: ChatMessage = {
-      role: 'assistant',
-      content: choice.message.content,
-    };
-
-    if (choice.message.tool_calls && choice.message.tool_calls.length > 0) {
-      assistantMessage.tool_calls = choice.message.tool_calls;
-    }
-
-    history.push(assistantMessage);
-    const visibleAssistantText = stripRalphChoiceTags(choice.message.content);
-    if (visibleAssistantText) {
-      latestVisibleAssistantText = visibleAssistantText;
-    }
+    const branchChoice = parseRalphChoice(choice.message.content);
     if (
       provider === 'hybridai' &&
-      parseRalphChoice(choice.message.content) === null &&
+      branchChoice === null &&
       isHybridAIEmptyVisibleCompletion(response)
     ) {
       console.error(
         `[model] empty completion provider=hybridai model=${model} debug=${summarizeHybridAICompletionForDebug(response)}`,
       );
+      if (
+        shouldRetryEmptyVisibleCompletion({
+          retryCount: emptyVisibleCompletionRetries,
+        })
+      ) {
+        emptyVisibleCompletionRetries += 1;
+        stalledTurns = advanceStalledTurnCount({
+          current: stalledTurns,
+          toolCalls: 0,
+          successfulToolCalls: 0,
+        });
+        history.push({
+          role: 'user',
+          content: EMPTY_VISIBLE_COMPLETION_RETRY_PROMPT,
+        });
+        console.error(
+          `[model] retrying empty HybridAI completion retry=${emptyVisibleCompletionRetries}`,
+        );
+        continue;
+      }
+
       const failed: ContainerOutput = {
         status: 'error',
         result: null,
@@ -1479,9 +1491,24 @@ async function processRequest(
       });
       return failed;
     }
+    emptyVisibleCompletionRetries = 0;
+
+    const assistantMessage: ChatMessage = {
+      role: 'assistant',
+      content: choice.message.content,
+    };
+
+    if (choice.message.tool_calls && choice.message.tool_calls.length > 0) {
+      assistantMessage.tool_calls = choice.message.tool_calls;
+    }
+
+    history.push(assistantMessage);
+    const visibleAssistantText = stripRalphChoiceTags(choice.message.content);
+    if (visibleAssistantText) {
+      latestVisibleAssistantText = visibleAssistantText;
+    }
     if (toolCalls.length === 0) {
       if (ralphEnabled) {
-        const branchChoice = parseRalphChoice(choice.message.content);
         if (branchChoice === 'STOP') {
           collectRequestedArtifacts({
             artifacts,

--- a/container/src/providers/shared.ts
+++ b/container/src/providers/shared.ts
@@ -145,7 +145,7 @@ export function isHybridAIEmptyVisibleCompletion(
   const choice = response.choices[0];
   if (!choice) return false;
   if ((choice.message.tool_calls || []).length > 0) return false;
-  return !normalizeMessageContentToText(choice.message.content);
+  return !normalizeMessageContentToText(choice.message.content).trim();
 }
 
 export function summarizeHybridAICompletionForDebug(

--- a/container/src/stalled-turns.ts
+++ b/container/src/stalled-turns.ts
@@ -1,4 +1,5 @@
 export const MAX_STALLED_MODEL_TURNS = 20;
+export const MAX_EMPTY_VISIBLE_COMPLETION_RETRIES = 1;
 
 export function advanceStalledTurnCount(params: {
   current: number;
@@ -21,4 +22,15 @@ export function shouldRetryEmptyFinalResponse(params: {
     params.toolExecutionCount > 0 &&
     params.artifactCount === 0
   );
+}
+
+export function shouldRetryEmptyVisibleCompletion(params: {
+  retryCount: number;
+  maxRetries?: number;
+}): boolean {
+  const maxRetries = Math.max(
+    0,
+    Math.floor(params.maxRetries ?? MAX_EMPTY_VISIBLE_COMPLETION_RETRIES),
+  );
+  return params.retryCount < maxRetries;
 }

--- a/tests/container.stalled-turns.test.ts
+++ b/tests/container.stalled-turns.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from 'vitest';
 
 import {
   advanceStalledTurnCount,
+  MAX_EMPTY_VISIBLE_COMPLETION_RETRIES,
   shouldRetryEmptyFinalResponse,
+  shouldRetryEmptyVisibleCompletion,
 } from '../container/src/stalled-turns.js';
 
 describe('container stalled turn budget', () => {
@@ -59,6 +61,40 @@ describe('container stalled turn budget', () => {
         visibleAssistantText: null,
         toolExecutionCount: 1,
         artifactCount: 1,
+      }),
+    ).toBe(false);
+  });
+
+  test('retries one consecutive empty visible completion', () => {
+    expect(
+      shouldRetryEmptyVisibleCompletion({
+        retryCount: 0,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRetryEmptyVisibleCompletion({
+        retryCount: MAX_EMPTY_VISIBLE_COMPLETION_RETRIES,
+      }),
+    ).toBe(false);
+  });
+
+  test('respects an overridden empty completion retry budget', () => {
+    expect(
+      shouldRetryEmptyVisibleCompletion({
+        retryCount: 1,
+        maxRetries: 2,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRetryEmptyVisibleCompletion({
+        retryCount: 2,
+        maxRetries: 2,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRetryEmptyVisibleCompletion({
+        retryCount: 0,
+        maxRetries: 0,
       }),
     ).toBe(false);
   });

--- a/tests/hybridai-request-error.test.ts
+++ b/tests/hybridai-request-error.test.ts
@@ -114,6 +114,24 @@ describe('HybridAI empty completion guard', () => {
     ).toBe(true);
   });
 
+  test('detects whitespace-only content as an empty visible completion', () => {
+    expect(
+      isHybridAIEmptyVisibleCompletion({
+        id: 'resp_blank',
+        model: 'gpt-5-nano',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: '   \n\t',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
   test('does not flag visible text or tool calls as empty completions', () => {
     expect(
       isHybridAIEmptyVisibleCompletion({


### PR DESCRIPTION
## Summary

Adds a bounded in-loop recovery for HybridAI responses that return HTTP 200 but contain no visible assistant text and no tool calls.

## Root Cause

The container agent treated a successful HybridAI response with empty content as a terminal container error. That propagated through the gateway as `HybridAI returned an empty completion without visible text or tool calls`, even though this can be a transient blank model output.

## Changes

- Retry one consecutive empty HybridAI visible completion with a direct continuation prompt before failing the turn.
- Keep the existing hard failure if the retry also returns empty output.
- Reset the empty-completion retry counter after any non-empty response or tool call.
- Treat whitespace-only assistant content as empty.
- Add unit coverage for the retry budget and whitespace-only empty-completion detection.

## Validation

- `npm run format`
- `./node_modules/.bin/vitest run --configLoader runner --project unit tests/container.stalled-turns.test.ts tests/hybridai-request-error.test.ts`
- `npm --prefix container run lint`
- `git diff --check`