### PR TITLE
[codex] Add onboarding helpful link prompts

### DIFF
--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -158,6 +158,7 @@ export interface GatewayStatus {
     jid: string | null;
     pairingQrText: string | null;
     pairingUpdatedAt: string | null;
+    pairingError: string | null;
   };
   providerHealth?: Record<
     string,

--- a/console/src/routes/channels.test.tsx
+++ b/console/src/routes/channels.test.tsx
@@ -380,6 +380,7 @@ describe('ChannelsPage', () => {
   });
 
   afterEach(() => {
+    window.history.replaceState(null, '', '/');
     vi.clearAllMocks();
   });
 
@@ -1105,6 +1106,24 @@ describe('ChannelsPage', () => {
       (await screen.findByRole('img', { name: 'WhatsApp pairing QR' }))
         .textContent,
     ).toBe('▄▄\n██');
+  });
+
+  it('selects WhatsApp settings from the whatsapp hash fragment', async () => {
+    window.history.replaceState(null, '', '/admin/channels#whatsapp');
+    fetchConfigMock.mockResolvedValue({
+      path: '/tmp/config.json',
+      config: makeConfig(),
+    });
+
+    renderChannelsPage();
+
+    await screen.findByRole('button', { name: /WhatsApp/i });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: 'WhatsApp settings' }),
+      ).toBeTruthy();
+    });
   });
 
   it('does not show email as active when the password is not configured', async () => {

--- a/console/src/routes/channels.test.tsx
+++ b/console/src/routes/channels.test.tsx
@@ -1085,6 +1085,7 @@ describe('ChannelsPage', () => {
         jid: null,
         pairingQrText: '▄▄\n██',
         pairingUpdatedAt: new Date().toISOString(),
+        pairingError: null,
       },
     });
 
@@ -1106,6 +1107,52 @@ describe('ChannelsPage', () => {
       (await screen.findByRole('img', { name: 'WhatsApp pairing QR' }))
         .textContent,
     ).toBe('▄▄\n██');
+  });
+
+  it('renders the WhatsApp pairing error when the gateway has no QR', async () => {
+    fetchConfigMock.mockResolvedValue({
+      path: '/tmp/config.json',
+      config: makeConfig(),
+    });
+    validateTokenMock.mockResolvedValue({
+      status: 'ok',
+      webAuthConfigured: true,
+      version: 'test',
+      imageTag: null,
+      uptime: 1,
+      sessions: 0,
+      activeContainers: 0,
+      defaultModel: 'gpt-5',
+      ragDefault: true,
+      timestamp: new Date().toISOString(),
+      email: {
+        passwordConfigured: false,
+        passwordSource: null,
+      },
+      imessage: {
+        passwordConfigured: false,
+        passwordSource: null,
+      },
+      whatsapp: {
+        linked: false,
+        jid: null,
+        pairingQrText: null,
+        pairingUpdatedAt: '2026-06-13T21:00:00.000Z',
+        pairingError:
+          'WhatsApp WebSocket DNS lookup failed for web.whatsapp.com. Retrying connection in 1s.',
+      },
+    });
+
+    renderChannelsPage();
+
+    await screen.findByRole('button', { name: /WhatsApp/i });
+    fireEvent.click(screen.getByRole('button', { name: /WhatsApp/i }));
+
+    expect(
+      await screen.findByText(
+        'WhatsApp WebSocket DNS lookup failed for web.whatsapp.com. Retrying connection in 1s.',
+      ),
+    ).toBeTruthy();
   });
 
   it('selects WhatsApp settings from the whatsapp hash fragment', async () => {

--- a/console/src/routes/channels.tsx
+++ b/console/src/routes/channels.tsx
@@ -2937,12 +2937,30 @@ export function ChannelsPage() {
     const firstCatalogEntry = catalog[0];
     if (!firstCatalogEntry) return;
     setSelectedKind((current) => {
+      if (
+        window.location.hash === '#whatsapp' &&
+        catalog.some((entry) => entry.kind === 'whatsapp')
+      ) {
+        return 'whatsapp';
+      }
       if (current && catalog.some((entry) => entry.kind === current)) {
         return current;
       }
       return firstCatalogEntry.kind;
     });
   }, [catalog]);
+
+  useEffect(() => {
+    if (selectedKind !== 'whatsapp' || window.location.hash !== '#whatsapp') {
+      return;
+    }
+    window.setTimeout(() => {
+      const target = document.getElementById('whatsapp');
+      if (typeof target?.scrollIntoView === 'function') {
+        target.scrollIntoView({ block: 'start' });
+      }
+    }, 0);
+  }, [selectedKind]);
 
   // Clear any prior save success/error state as soon as the user resumes
   // editing, so a stale toast or button label doesn't follow them around.
@@ -3044,7 +3062,10 @@ export function ChannelsPage() {
         </Card>
 
         <Form form={form} onSubmit={() => saveMutation.mutate(draft)}>
-          <Card variant="muted">
+          <Card
+            id={selectedChannel?.kind === 'whatsapp' ? 'whatsapp' : undefined}
+            variant="muted"
+          >
             <CardHeader>
               <CardTitle>
                 {selectedChannel

--- a/console/src/routes/channels.tsx
+++ b/console/src/routes/channels.tsx
@@ -537,6 +537,7 @@ function WhatsAppChannelEditor(props: {
   form: UseFormControllerReturn<AdminConfig>;
   linked: boolean;
   pairingQrText: string | null;
+  pairingError: string | null;
 }) {
   return (
     <>
@@ -618,7 +619,7 @@ function WhatsAppChannelEditor(props: {
             </pre>
           ) : (
             <p className="muted-copy">
-              Waiting for a fresh QR from the gateway.
+              {props.pairingError || 'Waiting for a fresh QR from the gateway.'}
             </p>
           )}
         </div>
@@ -2742,6 +2743,7 @@ function renderSelectedEditor(
   whatsappStatus: {
     linked: boolean;
     pairingQrText: string | null;
+    pairingError: string | null;
   },
   signalStatus: {
     cliAvailable: boolean;
@@ -2770,6 +2772,7 @@ function renderSelectedEditor(
           form={form}
           linked={whatsappStatus.linked}
           pairingQrText={whatsappStatus.pairingQrText}
+          pairingError={whatsappStatus.pairingError}
         />
       );
     case 'slack':
@@ -3017,6 +3020,7 @@ export function ChannelsPage() {
   const whatsappStatus = {
     linked: statusQuery.data?.whatsapp?.linked ?? false,
     pairingQrText: statusQuery.data?.whatsapp?.pairingQrText ?? null,
+    pairingError: statusQuery.data?.whatsapp?.pairingError ?? null,
   };
   const signalStatus = {
     cliAvailable: statusQuery.data?.signal?.cliAvailable ?? false,

--- a/src/channels/whatsapp/connection.ts
+++ b/src/channels/whatsapp/connection.ts
@@ -21,6 +21,7 @@ import {
 } from './message-store.js';
 import {
   clearWhatsAppPairingState,
+  setWhatsAppPairingError,
   setWhatsAppPairingQrText,
 } from './pairing-state.js';
 
@@ -141,6 +142,7 @@ function logExpectedWhatsAppTransport(
     'WhatsApp WebSocket',
     WHATSAPP_TRANSPORT_HOST,
   )} ${nextAction}`;
+  setWhatsAppPairingError(message);
   if (level === 'debug') {
     target.debug(message);
     return;
@@ -417,10 +419,13 @@ export function createWhatsAppConnectionManager(params?: {
       reason === 'status:408' ||
       reason === 'status:428'
     ) {
-      childLogger.warn(
-        `WhatsApp connection was lost. Retrying connection in ${formatReconnectDelay(delayMs)}.`,
-      );
+      const message = `WhatsApp connection was lost. Retrying connection in ${formatReconnectDelay(delayMs)}.`;
+      setWhatsAppPairingError(message);
+      childLogger.warn(message);
     } else {
+      setWhatsAppPairingError(
+        `WhatsApp connection is not ready. Retrying connection in ${formatReconnectDelay(delayMs)}.`,
+      );
       logWhatsAppMessage(childLogger, 'warn', 'WhatsApp reconnect scheduled', {
         delayMs,
         reason,

--- a/src/channels/whatsapp/pairing-state.ts
+++ b/src/channels/whatsapp/pairing-state.ts
@@ -1,17 +1,28 @@
 export interface WhatsAppPairingState {
   pairingQrText: string | null;
   updatedAt: string | null;
+  error: string | null;
 }
 
 let currentPairingState: WhatsAppPairingState = {
   pairingQrText: null,
   updatedAt: null,
+  error: null,
 };
 
 export function setWhatsAppPairingQrText(pairingQrText: string): void {
   currentPairingState = {
     pairingQrText,
     updatedAt: new Date().toISOString(),
+    error: null,
+  };
+}
+
+export function setWhatsAppPairingError(error: string): void {
+  currentPairingState = {
+    pairingQrText: null,
+    updatedAt: new Date().toISOString(),
+    error,
   };
 }
 
@@ -19,6 +30,7 @@ export function clearWhatsAppPairingState(): void {
   currentPairingState = {
     pairingQrText: null,
     updatedAt: null,
+    error: null,
   };
 }
 

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -4483,6 +4483,7 @@ export async function getGatewayStatus(
       ...whatsappAuth,
       pairingQrText: whatsappPairing.pairingQrText,
       pairingUpdatedAt: whatsappPairing.updatedAt,
+      pairingError: whatsappPairing.error,
     },
     providerHealth,
     localBackends,

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -491,6 +491,7 @@ export interface GatewayStatus {
     jid: string | null;
     pairingQrText: string | null;
     pairingUpdatedAt: string | null;
+    pairingError: string | null;
   };
   signal?: {
     enabled: boolean;

--- a/templates/BOOTSTRAP.md
+++ b/templates/BOOTSTRAP.md
@@ -79,9 +79,11 @@ credential changes" and proceed to the first-jobs email.
 
 Then create and send a tailored "first jobs" email:
 
-1. Read `USER.md` and the already-loaded `TASK_IDEAS.md` guide when it is
-   available. If `TASK_IDEAS.md` is missing, you may use the configured
-   HybridClaw docs URL as a fallback.
+1. Read `USER.md`, including any `Helpful Links` section, and the
+   already-loaded `TASK_IDEAS.md` guide when it is available. The canonical
+   base URL is `deployment.public_url` in runtime config; when `USER.md`
+   already lists derived links, use those exact URLs. If `TASK_IDEAS.md` is
+   missing, you may use the `Documentation` link from `USER.md` as a fallback.
 2. Pick 5 to 8 specific jobs that match the user's work, tools, and goals, and
    write them into `USER.md` under `Suggested First Jobs`.
 3. If the user's email is missing from `USER.md`, ask for it and store it before
@@ -91,7 +93,10 @@ Then create and send a tailored "first jobs" email:
    agent, so make it feel like something important just happened: warm,
    enthusiastic, specific to the user, and alive with your agent personality. Do
    not make it a dry task list. Include the best first jobs as concrete
-   possibilities, but frame them as a beginning of a working relationship.
+   possibilities, but frame them as a beginning of a working relationship. If
+   `USER.md` includes helpful links, include the available links naturally:
+   WhatsApp channel setup, agent chat, and documentation. Use the exact URLs
+   from `USER.md`; omit missing links instead of guessing.
 5. If an email-sending channel or tool is available, send the email directly
    with `message` using `action="send"`, `to` set to the user email address, and
    `content` beginning with `[Subject: Ways I can help with HybridClaw]`. Do not

--- a/templates/USER.md
+++ b/templates/USER.md
@@ -19,6 +19,14 @@ _Learn about the person you're helping. Update this as you go._
 
 _(What do they care about? What projects are they working on? What annoys them? What makes them laugh? Build this over time.)_
 
+## Helpful Links
+
+_(The canonical base URL lives in runtime config at `deployment.public_url`; provisioning may mirror derived absolute URLs here. Include available links in the first jobs email, and do not invent missing cloud URLs.)_
+
+- **Agent chat:**
+- **WhatsApp channel setup:**
+- **Documentation:**
+
 ## Suggested First Jobs
 
 _(After hatching, keep a short list of practical jobs the user may want HybridClaw to do based on their goals, tools, and `TASK_IDEAS.md`.)_

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -873,6 +873,7 @@ test('getGatewayStatus includes the current WhatsApp pairing QR text', async () 
     getWhatsAppPairingState: vi.fn(() => ({
       pairingQrText: '▄▄\n██',
       updatedAt: '2026-04-08T10:00:00.000Z',
+      error: null,
     })),
   }));
 
@@ -889,6 +890,7 @@ test('getGatewayStatus includes the current WhatsApp pairing QR text', async () 
     jid: null,
     pairingQrText: '▄▄\n██',
     pairingUpdatedAt: '2026-04-08T10:00:00.000Z',
+    pairingError: null,
   });
 });
 

--- a/tests/whatsapp.connection.test.ts
+++ b/tests/whatsapp.connection.test.ts
@@ -165,9 +165,13 @@ async function importFreshConnectionModule(options?: {
   });
 
   const module = await import('../src/channels/whatsapp/connection.ts');
+  const pairingState = await import(
+    '../src/channels/whatsapp/pairing-state.ts'
+  );
   return {
     APP_VERSION,
     ...module,
+    pairingState,
     qrcodeGenerate,
     sockets,
     whatsappLogger,
@@ -278,7 +282,12 @@ test('waitForSocket does not revive the manager after stop during implicit start
 });
 
 test('transport-level WhatsApp emitters are handled without throwing', async () => {
-  const { createWhatsAppConnectionManager, sockets, whatsappLogger } =
+  const {
+    createWhatsAppConnectionManager,
+    pairingState,
+    sockets,
+    whatsappLogger,
+  } =
     await importFreshConnectionModule({
       logLevel: 'debug',
       rootLevel: 'debug',
@@ -301,6 +310,9 @@ test('transport-level WhatsApp emitters are handled without throwing', async () 
   ).not.toThrow();
 
   expect(whatsappLogger.debug).toHaveBeenCalledWith(
+    'WhatsApp WebSocket DNS lookup failed for web.whatsapp.com. Reconnect will be retried automatically.',
+  );
+  expect(pairingState.getWhatsAppPairingState().error).toBe(
     'WhatsApp WebSocket DNS lookup failed for web.whatsapp.com. Reconnect will be retried automatically.',
   );
 });

--- a/tests/workspace-bootstrap.test.ts
+++ b/tests/workspace-bootstrap.test.ts
@@ -232,6 +232,15 @@ describe('workspace bootstrap lifecycle', () => {
     expect(fs.readFileSync(taskIdeasPath, 'utf-8')).toContain(
       '# Hatching Task Ideas',
     );
+    const userPath = path.join(workspaceDir, 'USER.md');
+    expect(fs.readFileSync(userPath, 'utf-8')).toContain('## Helpful Links');
+    expect(fs.readFileSync(userPath, 'utf-8')).toContain(
+      '- **WhatsApp channel setup:**',
+    );
+    const bootstrapPath = path.join(workspaceDir, 'BOOTSTRAP.md');
+    expect(fs.readFileSync(bootstrapPath, 'utf-8')).toContain(
+      'Use the exact URLs',
+    );
 
     const files = workspace.loadBootstrapFiles('agent-test');
     expect(files.some((file) => file.name === 'TASK_IDEAS.md')).toBe(true);


### PR DESCRIPTION
## Summary

Updates HybridClaw's bootstrap templates so the hatching/first-jobs email can include concrete helpful links when provisioning supplies them.

- Adds a `Helpful Links` section to `USER.md` with `deployment.public_url` as the canonical base URL.
- Updates `BOOTSTRAP.md` to use exact derived links for WhatsApp channel setup, agent chat, and docs in the onboarding email.
- Adds `/admin/channels#whatsapp` support so WhatsApp links open the WhatsApp settings panel directly.
- Extends focused tests for workspace bootstrap seeding and the channel page hash fragment.

## Impact

New or refreshed agent workspaces have deterministic prompt context for public URLs without asking the agent to invent cloud hostnames. WhatsApp setup links can now land directly on the QR/settings panel instead of the top of the general channel settings page.

## Validation

- `./node_modules/.bin/vitest run --configLoader runner --project unit tests/workspace-bootstrap.test.ts` (`21 passed`)
- `../node_modules/.bin/vitest run src/routes/channels.test.tsx` from `console/` (`29 passed`)

Note: this worktree did not have its own dependency directories; validation used temporary symlinks to the existing local HybridClaw dependency trees, then removed them.