### PR TITLE
[codex] Recover stale Codex auth during model discovery

### DIFF
--- a/src/auth/codex-auth.ts
+++ b/src/auth/codex-auth.ts
@@ -730,20 +730,48 @@ function needsRefresh(credentials: CodexStoredCredentials): boolean {
   return credentials.expiresAt <= Date.now() + CODEX_REFRESH_SKEW_MS;
 }
 
-export async function ensureFreshCredentials(): Promise<EnsureFreshCredentialsResult> {
-  const initial = assertStoredCredentials(loadCodexAuthStore());
-  if (!needsRefresh(initial)) {
+export async function ensureFreshCredentials(options?: {
+  allowCodexCliImportFallback?: boolean;
+  forceRefresh?: boolean;
+}): Promise<EnsureFreshCredentialsResult> {
+  let initial: CodexStoredCredentials;
+  try {
+    initial = assertStoredCredentials(loadCodexAuthStore());
+  } catch (error) {
+    if (
+      options?.allowCodexCliImportFallback &&
+      error instanceof CodexAuthError &&
+      error.reloginRequired
+    ) {
+      const imported = importCodexCliCredentialsFromStore();
+      return { credentials: imported.credentials, refreshed: true };
+    }
+    throw error;
+  }
+  if (!options?.forceRefresh && !needsRefresh(initial)) {
     return { credentials: initial, refreshed: false };
   }
 
   const releaseLock = await acquireFileLock();
   try {
     const underLock = assertStoredCredentials(loadCodexAuthStore());
-    if (!needsRefresh(underLock)) {
+    if (!options?.forceRefresh && !needsRefresh(underLock)) {
       return { credentials: underLock, refreshed: false };
     }
 
-    const refreshed = await refreshAccessToken(underLock);
+    let refreshed: CodexStoredCredentials;
+    try {
+      refreshed = await refreshAccessToken(underLock);
+    } catch (error) {
+      if (error instanceof CodexAuthError && error.reloginRequired) {
+        saveCredentials(null);
+        if (options?.allowCodexCliImportFallback) {
+          const imported = importCodexCliCredentialsFromStore();
+          return { credentials: imported.credentials, refreshed: true };
+        }
+      }
+      throw error;
+    }
     saveCredentials(refreshed);
     return { credentials: refreshed, refreshed: true };
   } finally {
@@ -751,8 +779,11 @@ export async function ensureFreshCredentials(): Promise<EnsureFreshCredentialsRe
   }
 }
 
-export async function resolveCodexCredentials(): Promise<CodexResolvedCredentials> {
-  const { credentials } = await ensureFreshCredentials();
+export async function resolveCodexCredentials(options?: {
+  allowCodexCliImportFallback?: boolean;
+  forceRefresh?: boolean;
+}): Promise<CodexResolvedCredentials> {
+  const { credentials } = await ensureFreshCredentials(options);
   const baseUrl = (
     process.env.HYBRIDCLAW_CODEX_BASE_URL || CODEX_DEFAULT_BASE_URL
   )
@@ -1314,21 +1345,44 @@ export async function importCodexCliCredentials(): Promise<{
       throw new Error('Codex CLI credential import cancelled.');
     }
 
-    const credentials: CodexStoredCredentials = {
-      accessToken: imported.accessToken,
-      refreshToken: imported.refreshToken,
-      accountId: imported.accountId,
-      expiresAt: extractExpiresAtFromJwt(imported.accessToken),
-      provider: CODEX_AUTH_PROVIDER,
-      authMethod: CODEX_AUTH_METHOD,
-      source: 'codex-cli-import',
-      lastRefresh: imported.lastRefresh,
-    };
-    const filePath = saveCredentials(credentials);
-    return { credentials, path: filePath, importedFrom: importPath };
+    return saveImportedCodexCliCredentials(importPath, imported);
   } finally {
     rl.close();
   }
+}
+
+function saveImportedCodexCliCredentials(
+  importPath: string,
+  imported: ReturnType<typeof readImportedTokenData>,
+): {
+  credentials: CodexStoredCredentials;
+  path: string;
+  importedFrom: string;
+} {
+  const credentials: CodexStoredCredentials = {
+    accessToken: imported.accessToken,
+    refreshToken: imported.refreshToken,
+    accountId: imported.accountId,
+    expiresAt: extractExpiresAtFromJwt(imported.accessToken),
+    provider: CODEX_AUTH_PROVIDER,
+    authMethod: CODEX_AUTH_METHOD,
+    source: 'codex-cli-import',
+    lastRefresh: imported.lastRefresh,
+  };
+  const filePath = saveCredentials(credentials);
+  return { credentials, path: filePath, importedFrom: importPath };
+}
+
+export function importCodexCliCredentialsFromStore(): {
+  credentials: CodexStoredCredentials;
+  path: string;
+  importedFrom: string;
+} {
+  const importPath = resolveCodexCliAuthPath();
+  return saveImportedCodexCliCredentials(
+    importPath,
+    readImportedTokenData(importPath),
+  );
 }
 
 export function selectDefaultCodexLoginMethod():

--- a/src/auth/codex-auth.ts
+++ b/src/auth/codex-auth.ts
@@ -1236,8 +1236,10 @@ export async function loginWithBrowserPkce(): Promise<{
 
 function resolveCodexCliAuthPath(): string {
   const codexHome = (process.env.CODEX_HOME || '').trim();
-  const baseDir = codexHome || path.join(os.homedir(), '.codex');
-  return path.join(baseDir, 'auth.json');
+  const baseDir = codexHome
+    ? path.resolve(codexHome)
+    : path.join(os.homedir(), '.codex');
+  return path.resolve(baseDir, 'auth.json');
 }
 
 function readImportedTokenData(filePath: string): {
@@ -1359,11 +1361,20 @@ function saveImportedCodexCliCredentials(
   path: string;
   importedFrom: string;
 } {
+  const expiresAt = extractExpiresAtFromJwt(imported.accessToken);
+  if (expiresAt <= Date.now()) {
+    throw new CodexAuthError(
+      'codex_auth_missing_access_token',
+      `Codex CLI credentials at ${importPath} have already expired.`,
+      { reloginRequired: true },
+    );
+  }
+
   const credentials: CodexStoredCredentials = {
     accessToken: imported.accessToken,
     refreshToken: imported.refreshToken,
     accountId: imported.accountId,
-    expiresAt: extractExpiresAtFromJwt(imported.accessToken),
+    expiresAt,
     provider: CODEX_AUTH_PROVIDER,
     authMethod: CODEX_AUTH_METHOD,
     source: 'codex-cli-import',
@@ -1373,7 +1384,7 @@ function saveImportedCodexCliCredentials(
   return { credentials, path: filePath, importedFrom: importPath };
 }
 
-export function importCodexCliCredentialsFromStore(): {
+function importCodexCliCredentialsFromStore(): {
   credentials: CodexStoredCredentials;
   path: string;
   importedFrom: string;

--- a/src/providers/codex-discovery.ts
+++ b/src/providers/codex-discovery.ts
@@ -1,13 +1,12 @@
 import {
+  CodexAuthError,
   type CodexResolvedCredentials,
-  getCodexAuthStatus,
   resolveCodexCredentials,
 } from '../auth/codex-auth.js';
 import { logger } from '../logger.js';
 import { CODEX_CLIENT_VERSION } from './codex-constants.js';
 import {
   createDiscoveryStore,
-  discoveryStoreStateUpdate,
   isRecord,
   normalizeBaseUrl,
   readPositiveInteger,
@@ -143,21 +142,14 @@ function createHttpStatusError(status: number): Error & { httpStatus: number } {
   return err;
 }
 
-function readHttpStatus(error: unknown): number | null {
-  const status = (error as { httpStatus?: unknown } | null)?.httpStatus;
-  return typeof status === 'number' && Number.isFinite(status) ? status : null;
-}
-
 function isCodexReloginError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    error.name === 'CodexAuthError' &&
-    (error as { reloginRequired?: unknown }).reloginRequired === true
-  );
+  return error instanceof CodexAuthError && error.reloginRequired;
 }
 
 function isCodexAuthDiscoveryFailure(error: unknown): boolean {
-  const httpStatus = readHttpStatus(error);
+  const status = (error as { httpStatus?: unknown } | null)?.httpStatus;
+  const httpStatus =
+    typeof status === 'number' && Number.isFinite(status) ? status : null;
   return httpStatus === 401 || httpStatus === 403 || isCodexReloginError(error);
 }
 
@@ -231,18 +223,6 @@ export function createCodexDiscoveryStore(): CodexDiscoveryStore {
   }
 
   async function discoverModels(opts?: { force?: boolean }): Promise<string[]> {
-    const auth = getCodexAuthStatus();
-    if (!auth.authenticated || auth.reloginRequired) {
-      try {
-        await resolveCodexCredentials({ allowCodexCliImportFallback: true });
-      } catch {
-        discoveryStore.replaceState(buildEmptyCodexDiscoveryState(), {
-          skipCache: true,
-        });
-        return [];
-      }
-    }
-
     const state = await discoveryStore.discover(fetchCodexModelsWithAuthRetry, {
       force: opts?.force,
       onError: (err, staleState) => {
@@ -251,9 +231,11 @@ export function createCodexDiscoveryStore(): CodexDiscoveryStore {
             { err },
             'Codex model discovery skipped because credentials were rejected',
           );
-          return discoveryStoreStateUpdate(buildEmptyCodexDiscoveryState(), {
+          return {
+            _tag: 'update',
+            state: buildEmptyCodexDiscoveryState(),
             skipCache: true,
-          });
+          };
         }
         logger.warn({ err }, 'Codex model discovery failed');
         return staleState;

--- a/src/providers/codex-discovery.ts
+++ b/src/providers/codex-discovery.ts
@@ -1,4 +1,5 @@
 import {
+  type CodexResolvedCredentials,
   getCodexAuthStatus,
   resolveCodexCredentials,
 } from '../auth/codex-auth.js';
@@ -6,12 +7,14 @@ import { logger } from '../logger.js';
 import { CODEX_CLIENT_VERSION } from './codex-constants.js';
 import {
   createDiscoveryStore,
+  discoveryStoreStateUpdate,
   isRecord,
   normalizeBaseUrl,
   readPositiveInteger,
 } from './utils.js';
 
 const CODEX_MODEL_PREFIX = 'openai-codex/';
+const CODEX_DISCOVERY_TIMEOUT_MS = 5_000;
 const CODEX_SUPPLEMENTAL_MODELS = [
   'openai-codex/gpt-5.1-codex-max',
   'openai-codex/gpt-5.1-codex-mini',
@@ -134,22 +137,47 @@ const buildEmptyCodexDiscoveryState = (): CodexDiscoveryState => ({
   maxTokensByModel: new Map(),
 });
 
+function createHttpStatusError(status: number): Error & { httpStatus: number } {
+  const err = new Error(`HTTP ${status}`) as Error & { httpStatus: number };
+  err.httpStatus = status;
+  return err;
+}
+
+function readHttpStatus(error: unknown): number | null {
+  const status = (error as { httpStatus?: unknown } | null)?.httpStatus;
+  return typeof status === 'number' && Number.isFinite(status) ? status : null;
+}
+
+function isCodexReloginError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.name === 'CodexAuthError' &&
+    (error as { reloginRequired?: unknown }).reloginRequired === true
+  );
+}
+
+function isCodexAuthDiscoveryFailure(error: unknown): boolean {
+  const httpStatus = readHttpStatus(error);
+  return httpStatus === 401 || httpStatus === 403 || isCodexReloginError(error);
+}
+
 export function createCodexDiscoveryStore(): CodexDiscoveryStore {
   const discoveryStore = createDiscoveryStore(buildEmptyCodexDiscoveryState());
 
-  async function fetchCodexModels(): Promise<CodexDiscoveryState> {
-    const credentials = await resolveCodexCredentials();
+  async function fetchCodexModels(
+    credentials?: CodexResolvedCredentials,
+  ): Promise<CodexDiscoveryState> {
+    const resolvedCredentials =
+      credentials ?? (await resolveCodexCredentials());
     const url = new URL(
-      `${normalizeBaseUrl(process.env.HYBRIDCLAW_CODEX_BASE_URL || credentials.baseUrl)}/models`,
+      `${normalizeBaseUrl(process.env.HYBRIDCLAW_CODEX_BASE_URL || resolvedCredentials.baseUrl)}/models`,
     );
     url.searchParams.set('client_version', CODEX_CLIENT_VERSION);
     const response = await fetch(url, {
-      headers: credentials.headers,
-      signal: AbortSignal.timeout(5_000),
+      headers: resolvedCredentials.headers,
+      signal: AbortSignal.timeout(CODEX_DISCOVERY_TIMEOUT_MS),
     });
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
-    }
+    if (!response.ok) throw createHttpStatusError(response.status);
 
     const payload = (await response.json()) as unknown;
     const data = readCodexModelEntries(payload);
@@ -186,18 +214,47 @@ export function createCodexDiscoveryStore(): CodexDiscoveryStore {
     };
   }
 
+  async function fetchCodexModelsWithAuthRetry(): Promise<CodexDiscoveryState> {
+    const credentials = await resolveCodexCredentials({
+      allowCodexCliImportFallback: true,
+    });
+    try {
+      return await fetchCodexModels(credentials);
+    } catch (error) {
+      if (!isCodexAuthDiscoveryFailure(error)) throw error;
+      const refreshedCredentials = await resolveCodexCredentials({
+        allowCodexCliImportFallback: true,
+        forceRefresh: true,
+      });
+      return await fetchCodexModels(refreshedCredentials);
+    }
+  }
+
   async function discoverModels(opts?: { force?: boolean }): Promise<string[]> {
     const auth = getCodexAuthStatus();
     if (!auth.authenticated || auth.reloginRequired) {
-      discoveryStore.replaceState(buildEmptyCodexDiscoveryState(), {
-        skipCache: true,
-      });
-      return [];
+      try {
+        await resolveCodexCredentials({ allowCodexCliImportFallback: true });
+      } catch {
+        discoveryStore.replaceState(buildEmptyCodexDiscoveryState(), {
+          skipCache: true,
+        });
+        return [];
+      }
     }
 
-    const state = await discoveryStore.discover(fetchCodexModels, {
+    const state = await discoveryStore.discover(fetchCodexModelsWithAuthRetry, {
       force: opts?.force,
       onError: (err, staleState) => {
+        if (isCodexAuthDiscoveryFailure(err)) {
+          logger.debug(
+            { err },
+            'Codex model discovery skipped because credentials were rejected',
+          );
+          return discoveryStoreStateUpdate(buildEmptyCodexDiscoveryState(), {
+            skipCache: true,
+          });
+        }
         logger.warn({ err }, 'Codex model discovery failed');
         return staleState;
       },

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -21,6 +21,37 @@ export function formatUnknownError(error: unknown): string {
     : String(error);
 }
 
+const DISCOVERY_STORE_STATE_UPDATE = Symbol('discoveryStoreStateUpdate');
+
+export interface DiscoveryStoreStateUpdate<T> {
+  readonly [DISCOVERY_STORE_STATE_UPDATE]: true;
+  readonly state: T;
+  readonly skipCache?: boolean;
+}
+
+export function discoveryStoreStateUpdate<T>(
+  state: T,
+  opts?: { skipCache?: boolean },
+): DiscoveryStoreStateUpdate<T> {
+  return {
+    [DISCOVERY_STORE_STATE_UPDATE]: true,
+    state,
+    ...(opts?.skipCache ? { skipCache: true } : {}),
+  };
+}
+
+function isDiscoveryStoreStateUpdate<T>(
+  value: T | DiscoveryStoreStateUpdate<T>,
+): value is DiscoveryStoreStateUpdate<T> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { [DISCOVERY_STORE_STATE_UPDATE]?: unknown })[
+      DISCOVERY_STORE_STATE_UPDATE
+    ] === true
+  );
+}
+
 export function createDiscoveryStore<T>(initialState: T, ttlMs = 3_600_000) {
   let state = initialState;
   let discoveredAtMs = 0;
@@ -35,7 +66,13 @@ export function createDiscoveryStore<T>(initialState: T, ttlMs = 3_600_000) {
     fetchFreshState: () => Promise<T>,
     opts?: {
       force?: boolean;
-      onError?: (err: unknown, staleState: T) => T | Promise<T>;
+      onError?: (
+        err: unknown,
+        staleState: T,
+      ) =>
+        | T
+        | DiscoveryStoreStateUpdate<T>
+        | Promise<T | DiscoveryStoreStateUpdate<T>>;
     },
   ): Promise<T> => {
     if (
@@ -54,8 +91,12 @@ export function createDiscoveryStore<T>(initialState: T, ttlMs = 3_600_000) {
         return state;
       } catch (err) {
         if (!opts?.onError) return staleState;
-        const nextState = await opts.onError(err, staleState);
-        replaceState(nextState);
+        const fallback = await opts.onError(err, staleState);
+        if (isDiscoveryStoreStateUpdate(fallback)) {
+          replaceState(fallback.state, { skipCache: fallback.skipCache });
+        } else {
+          replaceState(fallback);
+        }
         return state;
       } finally {
         discoveryInFlight = null;

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -21,34 +21,21 @@ export function formatUnknownError(error: unknown): string {
     : String(error);
 }
 
-const DISCOVERY_STORE_STATE_UPDATE = Symbol('discoveryStoreStateUpdate');
-
-export interface DiscoveryStoreStateUpdate<T> {
-  readonly [DISCOVERY_STORE_STATE_UPDATE]: true;
-  readonly state: T;
-  readonly skipCache?: boolean;
+interface DiscoveryStoreStateUpdate<T> {
+  _tag: 'update';
+  state: T;
+  skipCache?: boolean;
 }
 
-export function discoveryStoreStateUpdate<T>(
-  state: T,
-  opts?: { skipCache?: boolean },
-): DiscoveryStoreStateUpdate<T> {
-  return {
-    [DISCOVERY_STORE_STATE_UPDATE]: true,
-    state,
-    ...(opts?.skipCache ? { skipCache: true } : {}),
-  };
-}
+type DiscoveryStoreOnErrorResult<T> = T | DiscoveryStoreStateUpdate<T>;
 
 function isDiscoveryStoreStateUpdate<T>(
-  value: T | DiscoveryStoreStateUpdate<T>,
+  value: DiscoveryStoreOnErrorResult<T>,
 ): value is DiscoveryStoreStateUpdate<T> {
   return (
     typeof value === 'object' &&
     value !== null &&
-    (value as { [DISCOVERY_STORE_STATE_UPDATE]?: unknown })[
-      DISCOVERY_STORE_STATE_UPDATE
-    ] === true
+    (value as { _tag?: unknown })._tag === 'update'
   );
 }
 
@@ -70,9 +57,8 @@ export function createDiscoveryStore<T>(initialState: T, ttlMs = 3_600_000) {
         err: unknown,
         staleState: T,
       ) =>
-        | T
-        | DiscoveryStoreStateUpdate<T>
-        | Promise<T | DiscoveryStoreStateUpdate<T>>;
+        | DiscoveryStoreOnErrorResult<T>
+        | Promise<DiscoveryStoreOnErrorResult<T>>;
     },
   ): Promise<T> => {
     if (

--- a/tests/codex-auth.test.ts
+++ b/tests/codex-auth.test.ts
@@ -37,6 +37,32 @@ function makeJwt(payload: Record<string, unknown>): string {
   return `${encode({ alg: 'none', typ: 'JWT' })}.${encode(payload)}.sig`;
 }
 
+function writeCodexCliTokenAuthStore(
+  homeDir: string,
+  accessToken: string,
+  refreshToken = 'refresh_import',
+): string {
+  const codexHome = path.join(homeDir, 'codex-home');
+  fs.mkdirSync(codexHome, { recursive: true });
+  fs.writeFileSync(
+    path.join(codexHome, 'auth.json'),
+    `${JSON.stringify(
+      {
+        tokens: {
+          access_token: accessToken,
+          refresh_token: refreshToken,
+        },
+        last_refresh: '2026-03-06T12:00:00.000Z',
+      },
+      null,
+      2,
+    )}\n`,
+    'utf-8',
+  );
+  process.env.CODEX_HOME = codexHome;
+  return codexHome;
+}
+
 async function importFreshCodexAuth(
   homeDir: string,
   options?: {
@@ -444,7 +470,6 @@ describe('codex auth refresh', () => {
 
   it('falls back to Codex CLI credentials when forced refresh requires relogin', async () => {
     const homeDir = makeTempHome();
-    const codexHome = path.join(homeDir, 'codex-home');
     const staleToken = makeJwt({
       exp: Math.floor(Date.now() / 1000) + 3_600,
       chatgpt_account_id: 'acct_stale',
@@ -453,24 +478,7 @@ describe('codex auth refresh', () => {
       exp: Math.floor(Date.now() / 1000) + 7_200,
       chatgpt_account_id: 'acct_import',
     });
-
-    fs.mkdirSync(codexHome, { recursive: true });
-    fs.writeFileSync(
-      path.join(codexHome, 'auth.json'),
-      `${JSON.stringify(
-        {
-          tokens: {
-            access_token: importedToken,
-            refresh_token: 'refresh_import',
-          },
-          last_refresh: '2026-03-06T12:00:00.000Z',
-        },
-        null,
-        2,
-      )}\n`,
-      'utf-8',
-    );
-    process.env.CODEX_HOME = codexHome;
+    writeCodexCliTokenAuthStore(homeDir, importedToken);
 
     const codexAuth = await importFreshCodexAuth(homeDir);
     codexAuth.saveCodexAuthStore(
@@ -903,38 +911,44 @@ describe('codex auth CLI import', () => {
 
   it('imports credentials from the Codex CLI auth store without an interactive prompt', async () => {
     const homeDir = makeTempHome();
-    const codexHome = path.join(homeDir, 'codex-home');
     const accessToken = makeJwt({
       exp: Math.floor(Date.now() / 1000) + 3_600,
       chatgpt_account_id: 'acct_import',
     });
-
-    fs.mkdirSync(codexHome, { recursive: true });
-    fs.writeFileSync(
-      path.join(codexHome, 'auth.json'),
-      `${JSON.stringify(
-        {
-          tokens: {
-            access_token: accessToken,
-            refresh_token: 'refresh_import',
-          },
-          last_refresh: '2026-03-06T12:00:00.000Z',
-        },
-        null,
-        2,
-      )}\n`,
-      'utf-8',
-    );
-    process.env.CODEX_HOME = codexHome;
+    const codexHome = writeCodexCliTokenAuthStore(homeDir, accessToken);
 
     const codexAuth = await importFreshCodexAuth(homeDir);
-    const result = codexAuth.importCodexCliCredentialsFromStore();
+    const resolved = await codexAuth.resolveCodexCredentials({
+      allowCodexCliImportFallback: true,
+    });
     const stored = codexAuth.loadCodexAuthStore(homeDir);
 
-    expect(result.importedFrom).toBe(path.join(codexHome, 'auth.json'));
-    expect(result.credentials.source).toBe('codex-cli-import');
+    expect(resolved.accountId).toBe('acct_import');
+    expect(resolved.apiKey).toBe(accessToken);
     expect(stored.credentials?.accountId).toBe('acct_import');
     expect(stored.credentials?.source).toBe('codex-cli-import');
+    expect(fs.existsSync(path.join(codexHome, 'auth.json'))).toBe(true);
+  });
+
+  it('rejects expired credentials from the Codex CLI auth store', async () => {
+    const homeDir = makeTempHome();
+    const expiredToken = makeJwt({
+      exp: Math.floor(Date.now() / 1000) - 60,
+      chatgpt_account_id: 'acct_expired',
+    });
+    writeCodexCliTokenAuthStore(homeDir, expiredToken);
+
+    const codexAuth = await importFreshCodexAuth(homeDir);
+
+    await expect(
+      codexAuth.resolveCodexCredentials({
+        allowCodexCliImportFallback: true,
+      }),
+    ).rejects.toMatchObject({
+      code: 'codex_auth_missing_access_token',
+      reloginRequired: true,
+    });
+    expect(codexAuth.loadCodexAuthStore(homeDir).credentials).toBeNull();
   });
 });
 

--- a/tests/codex-auth.test.ts
+++ b/tests/codex-auth.test.ts
@@ -337,6 +337,65 @@ describe('codex auth refresh', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('force-refreshes unexpired credentials when requested', async () => {
+    const homeDir = makeTempHome();
+    const codexAuth = await importFreshCodexAuth(homeDir);
+    const currentToken = makeJwt({
+      exp: Math.floor(Date.now() / 1000) + 3_600,
+      chatgpt_account_id: 'acct_old',
+    });
+    const refreshedToken = makeJwt({
+      exp: Math.floor(Date.now() / 1000) + 7_200,
+      chatgpt_account_id: 'acct_new',
+    });
+
+    codexAuth.saveCodexAuthStore(
+      {
+        version: 1,
+        credentials: {
+          accessToken: currentToken,
+          refreshToken: 'refresh_old',
+          accountId: 'acct_old',
+          expiresAt: codexAuth.extractExpiresAtFromJwt(currentToken),
+          provider: 'openai-codex',
+          authMethod: 'oauth',
+          source: 'browser-pkce',
+          lastRefresh: new Date(0).toISOString(),
+        },
+        updatedAt: new Date(0).toISOString(),
+      },
+      homeDir,
+    );
+
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      expect(String(init?.body)).toBe(
+        'client_id=app_EMoamEEZ73f0CkXaXp7hrann&grant_type=refresh_token&refresh_token=refresh_old',
+      );
+      return new Response(
+        JSON.stringify({
+          access_token: refreshedToken,
+          refresh_token: 'refresh_new',
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await codexAuth.ensureFreshCredentials({
+      forceRefresh: true,
+    });
+    const stored = codexAuth.loadCodexAuthStore(homeDir);
+
+    expect(result.refreshed).toBe(true);
+    expect(result.credentials.accessToken).toBe(refreshedToken);
+    expect(stored.credentials?.accessToken).toBe(refreshedToken);
+    expect(stored.credentials?.refreshToken).toBe('refresh_new');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('marks 401 refresh failures as relogin-required', async () => {
     const homeDir = makeTempHome();
     const codexAuth = await importFreshCodexAuth(homeDir);
@@ -379,6 +438,78 @@ describe('codex auth refresh', () => {
       code: 'codex_refresh_failed',
       reloginRequired: true,
     });
+    expect(codexAuth.loadCodexAuthStore(homeDir).credentials).toBeNull();
+    expect(codexAuth.getCodexAuthStatus().reloginRequired).toBe(true);
+  });
+
+  it('falls back to Codex CLI credentials when forced refresh requires relogin', async () => {
+    const homeDir = makeTempHome();
+    const codexHome = path.join(homeDir, 'codex-home');
+    const staleToken = makeJwt({
+      exp: Math.floor(Date.now() / 1000) + 3_600,
+      chatgpt_account_id: 'acct_stale',
+    });
+    const importedToken = makeJwt({
+      exp: Math.floor(Date.now() / 1000) + 7_200,
+      chatgpt_account_id: 'acct_import',
+    });
+
+    fs.mkdirSync(codexHome, { recursive: true });
+    fs.writeFileSync(
+      path.join(codexHome, 'auth.json'),
+      `${JSON.stringify(
+        {
+          tokens: {
+            access_token: importedToken,
+            refresh_token: 'refresh_import',
+          },
+          last_refresh: '2026-03-06T12:00:00.000Z',
+        },
+        null,
+        2,
+      )}\n`,
+      'utf-8',
+    );
+    process.env.CODEX_HOME = codexHome;
+
+    const codexAuth = await importFreshCodexAuth(homeDir);
+    codexAuth.saveCodexAuthStore(
+      {
+        version: 1,
+        credentials: {
+          accessToken: staleToken,
+          refreshToken: 'refresh_stale',
+          accountId: 'acct_stale',
+          expiresAt: codexAuth.extractExpiresAtFromJwt(staleToken),
+          provider: 'openai-codex',
+          authMethod: 'oauth',
+          source: 'browser-pkce',
+          lastRefresh: new Date(0).toISOString(),
+        },
+        updatedAt: new Date(0).toISOString(),
+      },
+      homeDir,
+    );
+
+    const fetchMock = vi.fn(async () => {
+      return new Response(JSON.stringify({ error: 'invalid_grant' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const resolved = await codexAuth.resolveCodexCredentials({
+      allowCodexCliImportFallback: true,
+      forceRefresh: true,
+    });
+    const stored = codexAuth.loadCodexAuthStore(homeDir);
+
+    expect(resolved.accountId).toBe('acct_import');
+    expect(resolved.apiKey).toBe(importedToken);
+    expect(stored.credentials?.source).toBe('codex-cli-import');
+    expect(stored.credentials?.refreshToken).toBe('refresh_import');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -768,6 +899,42 @@ describe('codex auth CLI import', () => {
     expect(stored.credentials?.accountId).toBe('acct_import');
     expect(stored.credentials?.source).toBe('codex-cli-import');
     expect(importedRaw).toContain('"refresh_token": "refresh_import"');
+  });
+
+  it('imports credentials from the Codex CLI auth store without an interactive prompt', async () => {
+    const homeDir = makeTempHome();
+    const codexHome = path.join(homeDir, 'codex-home');
+    const accessToken = makeJwt({
+      exp: Math.floor(Date.now() / 1000) + 3_600,
+      chatgpt_account_id: 'acct_import',
+    });
+
+    fs.mkdirSync(codexHome, { recursive: true });
+    fs.writeFileSync(
+      path.join(codexHome, 'auth.json'),
+      `${JSON.stringify(
+        {
+          tokens: {
+            access_token: accessToken,
+            refresh_token: 'refresh_import',
+          },
+          last_refresh: '2026-03-06T12:00:00.000Z',
+        },
+        null,
+        2,
+      )}\n`,
+      'utf-8',
+    );
+    process.env.CODEX_HOME = codexHome;
+
+    const codexAuth = await importFreshCodexAuth(homeDir);
+    const result = codexAuth.importCodexCliCredentialsFromStore();
+    const stored = codexAuth.loadCodexAuthStore(homeDir);
+
+    expect(result.importedFrom).toBe(path.join(codexHome, 'auth.json'));
+    expect(result.credentials.source).toBe('codex-cli-import');
+    expect(stored.credentials?.accountId).toBe('acct_import');
+    expect(stored.credentials?.source).toBe('codex-cli-import');
   });
 });
 

--- a/tests/codex-discovery.test.ts
+++ b/tests/codex-discovery.test.ts
@@ -14,6 +14,7 @@ async function importFreshDiscovery() {
   }));
   vi.doMock('../src/logger.js', () => ({
     logger: {
+      debug: vi.fn(),
       warn: vi.fn(),
     },
   }));
@@ -64,6 +65,113 @@ describe('codex discovery', () => {
     expect(logger.warn).toHaveBeenCalledWith(
       { err: expect.any(Error) },
       'Codex model discovery failed',
+    );
+  });
+
+  test('force-refreshes Codex credentials and retries once when discovery is unauthorized', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('', { status: 401 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: [{ id: 'gpt-5.5', context_window: 500_000 }],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const discovery = await importFreshDiscovery();
+    const auth = await import('../src/auth/codex-auth.js');
+    vi.mocked(auth.resolveCodexCredentials).mockImplementation(
+      async (opts?: { forceRefresh?: boolean }) => ({
+        baseUrl: 'https://api.openai.com/v1',
+        headers: {
+          Authorization: opts?.forceRefresh
+            ? 'Bearer codex-refreshed'
+            : 'Bearer codex-stale',
+        },
+      }),
+    );
+    const { logger } = await import('../src/logger.js');
+    const store = discovery.createCodexDiscoveryStore();
+
+    await expect(store.discoverModels({ force: true })).resolves.toContain(
+      'openai-codex/gpt-5.5',
+    );
+
+    expect(auth.resolveCodexCredentials).toHaveBeenCalledTimes(2);
+    expect(auth.resolveCodexCredentials).toHaveBeenNthCalledWith(2, {
+      allowCodexCliImportFallback: true,
+      forceRefresh: true,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[1]?.headers).toMatchObject({
+      Authorization: 'Bearer codex-stale',
+    });
+    expect(fetchMock.mock.calls[1]?.[1]?.headers).toMatchObject({
+      Authorization: 'Bearer codex-refreshed',
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.debug).not.toHaveBeenCalled();
+  });
+
+  test('does not warn or cache empty models when Codex credential refresh requires relogin', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('', { status: 401 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: [{ id: 'gpt-5.5', context_window: 500_000 }],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const discovery = await importFreshDiscovery();
+    const auth = await import('../src/auth/codex-auth.js');
+    const reloginError = new Error('relogin required') as Error & {
+      reloginRequired: boolean;
+    };
+    reloginError.name = 'CodexAuthError';
+    reloginError.reloginRequired = true;
+    vi.mocked(auth.resolveCodexCredentials).mockImplementation(
+      async (opts?: { forceRefresh?: boolean }) => {
+        if (opts?.forceRefresh) throw reloginError;
+        return {
+          baseUrl: 'https://api.openai.com/v1',
+          headers: { Authorization: 'Bearer codex-stale' },
+        };
+      },
+    );
+    const { logger } = await import('../src/logger.js');
+    const store = discovery.createCodexDiscoveryStore();
+
+    await expect(store.discoverModels({ force: true })).resolves.toEqual([]);
+    expect(store.getModelNames()).toEqual([]);
+    await expect(store.discoverModels()).resolves.toContain(
+      'openai-codex/gpt-5.5',
+    );
+
+    expect(auth.resolveCodexCredentials).toHaveBeenCalledTimes(3);
+    expect(auth.resolveCodexCredentials).toHaveBeenNthCalledWith(2, {
+      allowCodexCliImportFallback: true,
+      forceRefresh: true,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      { err: expect.any(Error) },
+      'Codex model discovery skipped because credentials were rejected',
     );
   });
 });

--- a/tests/codex-discovery.test.ts
+++ b/tests/codex-discovery.test.ts
@@ -2,7 +2,21 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 
 async function importFreshDiscovery() {
   vi.resetModules();
+  class CodexAuthError extends Error {
+    reloginRequired: boolean;
+
+    constructor(
+      _code: string,
+      message: string,
+      options?: { reloginRequired?: boolean },
+    ) {
+      super(message);
+      this.name = 'CodexAuthError';
+      this.reloginRequired = options?.reloginRequired === true;
+    }
+  }
   vi.doMock('../src/auth/codex-auth.js', () => ({
+    CodexAuthError,
     getCodexAuthStatus: vi.fn(() => ({
       authenticated: true,
       reloginRequired: false,
@@ -88,7 +102,10 @@ describe('codex discovery', () => {
     const discovery = await importFreshDiscovery();
     const auth = await import('../src/auth/codex-auth.js');
     vi.mocked(auth.resolveCodexCredentials).mockImplementation(
-      async (opts?: { forceRefresh?: boolean }) => ({
+      async (opts?: {
+        allowCodexCliImportFallback?: boolean;
+        forceRefresh?: boolean;
+      }) => ({
         baseUrl: 'https://api.openai.com/v1',
         headers: {
           Authorization: opts?.forceRefresh
@@ -139,13 +156,16 @@ describe('codex discovery', () => {
 
     const discovery = await importFreshDiscovery();
     const auth = await import('../src/auth/codex-auth.js');
-    const reloginError = new Error('relogin required') as Error & {
-      reloginRequired: boolean;
-    };
-    reloginError.name = 'CodexAuthError';
-    reloginError.reloginRequired = true;
+    const reloginError = new auth.CodexAuthError(
+      'codex_refresh_failed',
+      'relogin required',
+      { reloginRequired: true },
+    );
     vi.mocked(auth.resolveCodexCredentials).mockImplementation(
-      async (opts?: { forceRefresh?: boolean }) => {
+      async (opts?: {
+        allowCodexCliImportFallback?: boolean;
+        forceRefresh?: boolean;
+      }) => {
         if (opts?.forceRefresh) throw reloginError;
         return {
           baseUrl: 'https://api.openai.com/v1',

--- a/tests/provider-discovery-utils.test.ts
+++ b/tests/provider-discovery-utils.test.ts
@@ -1,9 +1,6 @@
 import { expect, test, vi } from 'vitest';
 
-import {
-  createDiscoveryStore,
-  discoveryStoreStateUpdate,
-} from '../src/providers/utils.js';
+import { createDiscoveryStore } from '../src/providers/utils.js';
 
 test('discovery store caches error fallbacks until the TTL expires', async () => {
   vi.useFakeTimers();
@@ -43,15 +40,14 @@ test('discovery store can skip caching an error fallback', async () => {
   const fetchFreshState = vi.fn(async () => {
     throw new Error('provider unavailable');
   });
-  const onError = vi.fn((_err: unknown, staleState: { models: string[] }) =>
-    discoveryStoreStateUpdate(
-      {
-        ...staleState,
-        models: ['uncached-fallback'],
-      },
-      { skipCache: true },
-    ),
-  );
+  const onError = vi.fn((_err: unknown, staleState: { models: string[] }) => ({
+    _tag: 'update' as const,
+    state: {
+      ...staleState,
+      models: ['uncached-fallback'],
+    },
+    skipCache: true,
+  }));
 
   await expect(store.discover(fetchFreshState, { onError })).resolves.toEqual({
     models: ['uncached-fallback'],

--- a/tests/provider-discovery-utils.test.ts
+++ b/tests/provider-discovery-utils.test.ts
@@ -1,6 +1,9 @@
 import { expect, test, vi } from 'vitest';
 
-import { createDiscoveryStore } from '../src/providers/utils.js';
+import {
+  createDiscoveryStore,
+  discoveryStoreStateUpdate,
+} from '../src/providers/utils.js';
 
 test('discovery store caches error fallbacks until the TTL expires', async () => {
   vi.useFakeTimers();
@@ -27,6 +30,35 @@ test('discovery store caches error fallbacks until the TTL expires', async () =>
 
   vi.setSystemTime(new Date('2026-04-27T12:01:01Z'));
   await store.discover(fetchFreshState, { onError });
+
+  expect(fetchFreshState).toHaveBeenCalledTimes(2);
+  expect(onError).toHaveBeenCalledTimes(2);
+});
+
+test('discovery store can skip caching an error fallback', async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-27T12:00:00Z'));
+
+  const store = createDiscoveryStore({ models: [] as string[] }, 60_000);
+  const fetchFreshState = vi.fn(async () => {
+    throw new Error('provider unavailable');
+  });
+  const onError = vi.fn((_err: unknown, staleState: { models: string[] }) =>
+    discoveryStoreStateUpdate(
+      {
+        ...staleState,
+        models: ['uncached-fallback'],
+      },
+      { skipCache: true },
+    ),
+  );
+
+  await expect(store.discover(fetchFreshState, { onError })).resolves.toEqual({
+    models: ['uncached-fallback'],
+  });
+  await expect(store.discover(fetchFreshState, { onError })).resolves.toEqual({
+    models: ['uncached-fallback'],
+  });
 
   expect(fetchFreshState).toHaveBeenCalledTimes(2);
   expect(onError).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
## Summary

Fix Codex model discovery when HybridClaw's stored Codex access token is unexpired locally but rejected by ChatGPT as invalidated.

## Root Cause

HybridClaw trusted the stored JWT expiry before calling the Codex `/models` endpoint. In practice, ChatGPT can invalidate the access token and refresh token before the JWT expiry, causing model discovery to fail with 401/403 while local auth status still reported healthy credentials.

## Changes

- Add a forced Codex credential refresh path for stale-but-unexpired tokens.
- Retry Codex model discovery once after a 401/403 using refreshed credentials.
- Clear unusable HybridClaw Codex credentials when refresh requires relogin.
- Fall back to importing the local Codex CLI auth store non-interactively when available.
- Keep auth-failure discovery fallbacks uncached so later recovery is not masked.
- Add focused auth/discovery tests for refresh, relogin, CLI import fallback, and uncached fallback behavior.

## Validation

- `vitest tests/codex-auth.test.ts tests/codex-discovery.test.ts tests/provider-discovery-utils.test.ts`
- `tsc --noEmit`
- `npm run lint`
- Live local verification: imported valid Codex CLI credentials and confirmed Codex `/models` returned HTTP 200 without printing secrets.