### PR TITLE
[codex] Fix legacy audit user actor indexing

### DIFF
--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -10480,14 +10480,28 @@ function readPayloadActor(
   }
 
   try {
-    return actorFromLegacyFields({
-      userId: readPayloadStringValue(payload, 'userId'),
-      agentId: readPayloadStringValue(payload, 'agentId'),
-    });
+    return readPayloadActorFromLegacyFields(payload);
   } catch (error) {
     warnInvalidAuditActor(error, options);
     return null;
   }
+}
+
+function readPayloadActorFromLegacyFields(
+  payload: Record<string, unknown>,
+): Actor | null {
+  const userId = readPayloadStringValue(payload, 'userId')?.trim() || '';
+  const agentId = readPayloadStringValue(payload, 'agentId')?.trim() || '';
+  if (userId && agentId) {
+    return actorFromLegacyFields({ userId, agentId });
+  }
+  if (userId) {
+    return { type: 'user', id: formatLocalOwnerUserId(userId) };
+  }
+  if (agentId) {
+    return actorFromLegacyFields({ agentId });
+  }
+  return null;
 }
 
 function readAuditActorFromPayloadText(payloadText: string): Actor | null {

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -38,6 +38,7 @@ import {
   type Actor,
   ActorValidationError,
   actorFromLegacyFields,
+  createUserActor,
   normalizeActor,
 } from '../identity/actor.js';
 import {
@@ -10496,7 +10497,7 @@ function readPayloadActorFromLegacyFields(
     return actorFromLegacyFields({ userId, agentId });
   }
   if (userId) {
-    return { type: 'user', id: formatLocalOwnerUserId(userId) };
+    return createUserActor(formatLocalOwnerUserId(userId));
   }
   if (agentId) {
     return actorFromLegacyFields({ agentId });

--- a/tests/structured-audit-query.test.ts
+++ b/tests/structured-audit-query.test.ts
@@ -158,6 +158,52 @@ test('structured audit writes and reads the unified actor surface', async () => 
   );
 });
 
+test('structured audit indexes legacy plain user IDs as local actors', async () => {
+  setupHome();
+
+  const { logger } = await import('../src/logger.ts');
+  const warnSpy = vi.spyOn(logger, 'warn');
+  const {
+    getRecentStructuredAuditForSession,
+    initDatabase,
+    logStructuredAuditEvent,
+  } = await import('../src/memory/db.ts');
+
+  initDatabase({ quiet: true });
+  logStructuredAuditEvent({
+    version: '2.0',
+    seq: 1,
+    timestamp: '2026-06-15T19:39:39.803Z',
+    runId: 'turn_1781552379747_23e4e59e',
+    sessionId: 'session-legacy-local-user',
+    event: {
+      type: 'session.start',
+      userId: 'web-user-b903d512',
+      channel: 'web',
+    },
+    _prevHash: 'prev-local-user',
+    _hash: 'hash-local-user',
+  } satisfies WireRecord);
+
+  const [entry] = getRecentStructuredAuditForSession(
+    'session-legacy-local-user',
+    10,
+  );
+  expect(entry?.actor_type).toBe('user');
+  expect(entry?.actor_id).toBe('web-user-b903d512@local');
+  expect(JSON.parse(entry?.payload || '{}')).toEqual(
+    expect.objectContaining({
+      userId: 'web-user-b903d512',
+    }),
+  );
+  expect(JSON.parse(entry?.payload || '{}')).not.toHaveProperty('actor');
+  expect(
+    warnSpy.mock.calls.some(
+      (call) => call[1] === 'Structured audit event has invalid actor fields',
+    ),
+  ).toBe(false);
+});
+
 test('migrateV43 backfills structured audit actors from legacy payload fields', async () => {
   const homeDir = setupHome();
   const dbPath = path.join(homeDir, 'hybridclaw.db');
@@ -215,6 +261,21 @@ test('migrateV43 backfills structured audit actors from legacy payload fields', 
         'prev-legacy-actor',
       );
 
+      insertLegacy.run(
+        'session-legacy-local-user',
+        1,
+        'session.start',
+        '2026-06-15T19:39:39.803Z',
+        'run-legacy-local-user',
+        null,
+        JSON.stringify({
+          type: 'session.start',
+          userId: 'web-user-b903d512',
+        }),
+        'hash-legacy-local-user',
+        'prev-legacy-local-user',
+      );
+
       insertWithActorColumns.run(
         'session-partial-actor',
         1,
@@ -258,6 +319,13 @@ test('migrateV43 backfills structured audit actors from legacy payload fields', 
     }),
   );
   expect(JSON.parse(entry?.payload || '{}')).not.toHaveProperty('actor');
+
+  const [localEntry] = getRecentStructuredAuditForSession(
+    'session-legacy-local-user',
+    10,
+  );
+  expect(localEntry?.actor_type).toBe('user');
+  expect(localEntry?.actor_id).toBe('web-user-b903d512@local');
 
   const [partialEntry] = getRecentStructuredAuditForSession(
     'session-partial-actor',


### PR DESCRIPTION
## Summary

- Canonicalize legacy structured-audit `userId` fields into local user actors for actor indexing.
- Preserve the signed audit payload shape instead of injecting a new `actor` field.
- Add regression coverage for live writes and v43 migration/backfill using the web user ID shape that triggered the warning.

## Root Cause

Structured audit ingestion treated legacy plain `userId` values like `web-user-b903d512` as canonical user IDs. Actor validation requires `username@authority`, so live `session.start` writes logged `Structured audit event has invalid actor fields` and skipped actor indexing.

## Validation

- `npm run format`
- `npx vitest run --configLoader runner tests/structured-audit-query.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`

Note: `npm run format` completed successfully and reported existing optional-chain warnings elsewhere in the repo; it did not modify files.