### PR TITLE
[codex] Fix admin dropdown first selection

### DIFF
--- a/console/src/components/field/index.tsx
+++ b/console/src/components/field/index.tsx
@@ -146,6 +146,7 @@ export function Field({
   touched: touchedProp,
   validate: validateProp,
   onBlur,
+  onChange,
   ...props
 }: FieldProps) {
   // Auto-wire when nested under a `<FormField>` — match its generated id
@@ -293,34 +294,28 @@ export function Field({
     onBlur?.(event);
   };
 
-  // Native `input` and `change` events bubble out of form controls, so we
-  // can centralise "user has interacted with this field" detection on the
-  // wrapper. `input` fires on every keystroke; `change` fires for selects,
-  // radios, and native checkboxes that don't emit `input`.
-  const wrapperRef = useRef<HTMLDivElement | null>(null);
-  useEffect(() => {
-    const el = wrapperRef.current;
-    if (!el) return;
-    const touch = () => setInternalTouched(true);
-    el.addEventListener('input', touch);
-    el.addEventListener('change', touch);
-    return () => {
-      el.removeEventListener('input', touch);
-      el.removeEventListener('change', touch);
-    };
-  }, []);
+  // Keep touched-state updates on React change/blur only. Native select
+  // controls can emit an input event before change; touching the wrapper on
+  // input can re-render a controlled select with the old value before its own
+  // onChange sees the new selection.
+  const handleChange: NonNullable<ComponentProps<'div'>['onChange']> = (
+    event,
+  ) => {
+    setInternalTouched(true);
+    onChange?.(event);
+  };
 
   return (
     <FieldContext.Provider value={ctx}>
       {/* biome-ignore lint/a11y/noStaticElementInteractions: this div is a layout container; the onBlur listens for bubbled focusout from descendant controls to drive touched-detection, not direct interactivity. */}
       <div
-        ref={wrapperRef}
         data-slot="field"
         data-orientation={orientation}
         data-invalid={exposedInvalid || undefined}
         data-disabled={disabled || undefined}
         className={cx(styles.field, orientationClass[orientation], className)}
         onBlur={handleBlur}
+        onChange={handleChange}
         {...props}
       />
     </FieldContext.Provider>

--- a/console/src/components/native-select/native-select.test.tsx
+++ b/console/src/components/native-select/native-select.test.tsx
@@ -44,6 +44,31 @@ describe('NativeSelect', () => {
     expect(screen.getByDisplayValue('Bravo')).toBe(select);
   });
 
+  it('does not reset a select input event before the first change event', () => {
+    function ControlledInField() {
+      const [value, setValue] = useState('a');
+      return (
+        <Field controlId="choice">
+          <FieldLabel>Choice</FieldLabel>
+          <NativeSelect
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+          >
+            <NativeSelectOption value="a">Alpha</NativeSelectOption>
+            <NativeSelectOption value="b">Bravo</NativeSelectOption>
+          </NativeSelect>
+        </Field>
+      );
+    }
+
+    render(<ControlledInField />);
+    const select = screen.getByLabelText('Choice') as HTMLSelectElement;
+    fireEvent.input(select, { target: { value: 'b' } });
+    fireEvent.change(select);
+    expect(select.value).toBe('b');
+    expect(screen.getByDisplayValue('Bravo')).toBe(select);
+  });
+
   it('inherits id and disabled from the surrounding Field', () => {
     render(
       <Field controlId="region" disabled>


### PR DESCRIPTION
## Summary

Fix native admin-console dropdowns so the first selected option is applied immediately.

## Root Cause

`Field` marked fields as touched from ancestor-level native `input`/`change` listeners. For controlled native `<select>` elements, browsers can emit an `input` event before the final `change` event. Touching the wrapper on that early `input` event re-rendered the controlled select with its previous value before the select's own `onChange` handled the new selection, so the first selection appeared to do nothing. The second selection worked because the field was already touched and the extra wrapper update no longer changed state.

## Changes

- Remove the `Field` wrapper's native `input`/`change` listeners.
- Mark fields as touched through React `onChange` and `onBlur`, keeping the wrapper update after descendant controlled select `onChange` handlers.
- Add a focused NativeSelect regression test for the browser-like `input` then `change` sequence.

## Validation

- `npm --workspace console run test -- src/components/native-select/native-select.test.tsx`
- `npm --workspace console run typecheck`
- `npm --workspace console run lint`
- `npm --workspace console run build`
- `git diff --check`