### PR TITLE
[codex] widen logs detail panel

### DIFF
--- a/console/src/routes/logs.tsx
+++ b/console/src/routes/logs.tsx
@@ -110,7 +110,6 @@ export function LogsPage() {
                   >
                     <div className="session-row-main">
                       <strong>{file.label}</strong>
-                      <small className="session-row-meta">{file.path}</small>
                     </div>
                     <span className="session-row-time">
                       {fileStatusLabel(file)}

--- a/console/src/styles.css
+++ b/console/src/styles.css
@@ -1512,6 +1512,11 @@ th {
 
 .logs-layout {
   align-items: start;
+  grid-template-columns: minmax(240px, 0.45fr) minmax(0, 1.55fr);
+}
+
+.logs-layout .selectable-row {
+  align-items: center;
 }
 
 .log-viewer {


### PR DESCRIPTION
## Summary
- remove the duplicated log file path from the left-side logs file list
- make the logs page layout allocate more width to the detail/log viewer panel
- keep the selected log path visible in the right-side metadata section

## Validation
- `npm --workspace console run typecheck`
- `npx @biomejs/biome@2.4.16 check console/src/routes/logs.tsx console/src/styles.css`
- `git diff --check`

## Notes
- Installed workspace dependencies with `npm ci` so the console typecheck could run locally.