### PR TITLE
[codex] Add logs page logging mode controls

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -581,7 +581,9 @@
     "gatewayBaseUrl": "http://127.0.0.1:9090",
     "gatewayApiToken": "",
     "dbPath": "~/.hybridclaw/data/hybridclaw.db",
-    "logLevel": "info"
+    "logLevel": "info",
+    "logRequests": false,
+    "debugModelResponses": false
   },
   "observability": {
     "enabled": true,

--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -23,6 +23,7 @@ import type {
   AdminChannelTransport,
   AdminCommandResult,
   AdminConfig,
+  AdminConfigReloadResponse,
   AdminConfigResponse,
   AdminCreateSkillPayload,
   AdminDistillConsentPayload,
@@ -628,14 +629,11 @@ export function declineA2APairingRequest(
 
 export function reloadGateway(
   token: string,
-): Promise<{ status: 'ok'; message: string }> {
-  return requestJson<{ status: 'ok'; message: string }>(
-    '/api/admin/config/reload',
-    {
-      token,
-      method: 'POST',
-    },
-  );
+): Promise<AdminConfigReloadResponse> {
+  return requestJson<AdminConfigReloadResponse>('/api/admin/config/reload', {
+    token,
+    method: 'POST',
+  });
 }
 
 export function startAdminTerminal(

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -10,6 +10,11 @@ export const LOG_LEVELS = [
 
 export type LogLevel = (typeof LOG_LEVELS)[number];
 
+export interface AdminConfigReloadResponse {
+  status: string;
+  message?: string;
+}
+
 export interface GatewayStatus {
   status: 'ok';
   webAuthConfigured: boolean;

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -808,6 +808,8 @@ export interface AdminConfig {
     gatewayApiToken: string;
     dbPath: string;
     logLevel: LogLevel;
+    logRequests?: boolean;
+    debugModelResponses?: boolean;
   };
   [key: string]: unknown;
 }
@@ -836,9 +838,26 @@ export interface AdminLogTail {
   truncated: boolean;
 }
 
+export interface AdminLoggingState {
+  configuredLevel: LogLevel;
+  effectiveLevel: LogLevel;
+  forcedLevel: LogLevel | null;
+  logRequests: {
+    configured: boolean;
+    envEnabled: boolean;
+    effective: boolean;
+  };
+  debugModelResponses: {
+    configured: boolean;
+    envEnabled: boolean;
+    effective: boolean;
+  };
+}
+
 export interface AdminLogsResponse {
   files: AdminLogFile[];
   selected: AdminLogTail | null;
+  logging?: AdminLoggingState;
 }
 
 export interface AdminBrowserPoolHealthResponse {

--- a/console/src/components/ui.tsx
+++ b/console/src/components/ui.tsx
@@ -151,23 +151,23 @@ export function MetricCard(props: {
   return <div className="metric-card">{content}</div>;
 }
 
-export function SegmentedToggle(props: {
+export function SegmentedToggle<Value extends string>(props: {
   ariaLabel: string;
-  value: string;
+  value: Value;
   className?: string;
   options: Array<{
-    value: string;
+    value: Value;
     label: string;
     activeTone?: 'is-on' | 'is-off';
   }>;
-  onChange: (value: string) => void;
+  onChange: (value: Value) => void;
   disabled?: boolean;
   size?: 'sm' | 'default';
 }) {
   return (
     <ToggleGroup
       value={props.value}
-      onValueChange={props.onChange}
+      onValueChange={(value) => props.onChange(value as Value)}
       ariaLabel={props.ariaLabel}
       className={props.className}
       disabled={props.disabled}

--- a/console/src/routes/logs.test.tsx
+++ b/console/src/routes/logs.test.tsx
@@ -1,0 +1,336 @@
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  AdminConfig,
+  AdminConfigResponse,
+  AdminLogsResponse,
+} from '../api/types';
+import { renderWithProviders } from '../test-utils';
+import { LogsPage } from './logs';
+
+const fetchAdminLogsMock = vi.fn<() => Promise<AdminLogsResponse>>();
+const fetchConfigMock = vi.fn<() => Promise<AdminConfigResponse>>();
+const reloadGatewayMock = vi.fn();
+const saveConfigMock = vi.fn();
+const useAuthMock = vi.fn();
+
+vi.mock('../api/client', () => ({
+  fetchAdminLogs: () => fetchAdminLogsMock(),
+  fetchConfig: () => fetchConfigMock(),
+  reloadGateway: (...args: unknown[]) => reloadGatewayMock(...args),
+  saveConfig: (...args: unknown[]) => saveConfigMock(...args),
+}));
+
+vi.mock('../auth', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+function makeConfig(overrides: Partial<AdminConfig> = {}): AdminConfig {
+  const base = {
+    version: 1,
+    security: {
+      trustModelAccepted: false,
+      trustModelAcceptedAt: '',
+      trustModelVersion: '',
+      trustModelAcceptedBy: '',
+      confidentialRedactionEnabled: false,
+    },
+    hybridai: {
+      baseUrl: 'https://hybridai.one',
+      defaultModel: 'gpt-5',
+      defaultChatbotId: '',
+      maxTokens: 4096,
+      enableRag: true,
+      models: ['gpt-5'],
+    },
+    channelInstructions: {
+      discord: '',
+      discord_webhook: '',
+      msteams: '',
+      slack: '',
+      slack_webhook: '',
+      signal: '',
+      telegram: '',
+      threema: '',
+      voice: '',
+      whatsapp: '',
+      email: '',
+      imessage: '',
+    },
+    container: {
+      sandboxMode: 'container',
+      image: '',
+      memory: '2g',
+      memorySwap: '2g',
+      cpus: '2',
+      network: 'none',
+      timeoutMs: 300000,
+      binds: [],
+      additionalMounts: '',
+      maxOutputBytes: 100000,
+      maxConcurrent: 2,
+      persistBashState: false,
+    },
+    ops: {
+      healthHost: '127.0.0.1',
+      healthPort: 9090,
+      webApiToken: '',
+      gatewayBaseUrl: 'http://127.0.0.1:9090',
+      gatewayInternalBaseUrl: 'http://127.0.0.1:9090',
+      gatewayApiToken: '',
+      dbPath: '',
+      logLevel: 'info',
+      logRequests: false,
+      debugModelResponses: false,
+    },
+    browser: {
+      provider: 'local',
+      local: {
+        profileDir: '',
+        headed: false,
+      },
+      camofox: {
+        profileDir: '',
+        headed: false,
+      },
+      managedCloud: {
+        endpointUrl: 'http://127.0.0.1:8787',
+        poolTokenRef: undefined,
+        defaultTenantId: '',
+        pricing: {
+          actionUsd: 0,
+        },
+      },
+      browserUseCloud: {
+        apiKeyRef: undefined,
+        projectId: '',
+        profileId: '',
+        region: '',
+        keepAlive: false,
+        pricing: {
+          browserUsdPerMinute: 0,
+          actionUsd: 0,
+        },
+      },
+    },
+  } as unknown as AdminConfig;
+
+  return {
+    ...base,
+    ...overrides,
+    ops: {
+      ...base.ops,
+      ...(overrides.ops ?? {}),
+    },
+  };
+}
+
+function makeLogs(): AdminLogsResponse {
+  return {
+    files: [
+      {
+        id: 'gateway',
+        label: 'Gateway',
+        path: '/tmp/gateway.log',
+        exists: true,
+        readable: true,
+        sizeBytes: 12,
+        mtime: '2026-06-16T12:00:00.000Z',
+        description:
+          'Gateway process stdout/stderr and structured runtime logs.',
+        error: null,
+      },
+    ],
+    selected: {
+      fileId: 'gateway',
+      content: 'gateway log\n',
+      tailBytes: 12,
+      truncated: false,
+    },
+    logging: {
+      configuredLevel: 'info',
+      effectiveLevel: 'info',
+      forcedLevel: null,
+      logRequests: {
+        configured: false,
+        envEnabled: false,
+        effective: false,
+      },
+      debugModelResponses: {
+        configured: false,
+        envEnabled: false,
+        effective: false,
+      },
+    },
+  };
+}
+
+function renderLogsPage(): void {
+  renderWithProviders(<LogsPage />);
+}
+
+function restorePrototypeProperty(
+  prototype: object,
+  property: PropertyKey,
+  descriptor: PropertyDescriptor | undefined,
+): void {
+  if (descriptor) {
+    Object.defineProperty(prototype, property, descriptor);
+    return;
+  }
+  Reflect.deleteProperty(prototype, property);
+}
+
+describe('LogsPage', () => {
+  beforeEach(() => {
+    useAuthMock.mockReturnValue({ token: 'admin-token' });
+    fetchAdminLogsMock.mockResolvedValue(makeLogs());
+    const config = makeConfig();
+    fetchConfigMock.mockResolvedValue({
+      path: '/tmp/config.json',
+      config,
+    });
+    saveConfigMock.mockImplementation((_token: string, next: AdminConfig) =>
+      Promise.resolve({
+        path: '/tmp/config.json',
+        config: next,
+      }),
+    );
+    reloadGatewayMock.mockResolvedValue({
+      status: 'ok',
+      message: 'Gateway reloaded.',
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('saves debug logging mode to config and reloads the gateway', async () => {
+    renderLogsPage();
+
+    expect(await screen.findByText('Current mode: on')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Debug' }));
+
+    await waitFor(() => expect(saveConfigMock).toHaveBeenCalledTimes(1));
+    expect(saveConfigMock).toHaveBeenCalledWith(
+      'admin-token',
+      expect.objectContaining({
+        ops: expect.objectContaining({
+          logLevel: 'debug',
+          logRequests: true,
+          debugModelResponses: true,
+        }),
+      }),
+    );
+    expect(reloadGatewayMock).toHaveBeenCalledWith('admin-token');
+  });
+
+  it('shows debug when the runtime logger is forced to debug', async () => {
+    fetchAdminLogsMock.mockResolvedValue({
+      ...makeLogs(),
+      logging: {
+        configuredLevel: 'info',
+        effectiveLevel: 'debug',
+        forcedLevel: 'debug',
+        logRequests: {
+          configured: false,
+          envEnabled: false,
+          effective: false,
+        },
+        debugModelResponses: {
+          configured: false,
+          envEnabled: false,
+          effective: false,
+        },
+      },
+    });
+
+    renderLogsPage();
+
+    const description = await screen.findByText(
+      'Current mode: debug (forced by runtime)',
+    );
+    const loggingCard = description.closest('[data-slot="card"]');
+    expect(loggingCard).toBeTruthy();
+    await waitFor(() =>
+      expect(
+        within(loggingCard as HTMLElement)
+          .getByRole('button', { name: 'Debug' })
+          .getAttribute('aria-pressed'),
+      ).toBe('true'),
+    );
+  });
+
+  it('jumps to the end of the selected log after loading', async () => {
+    const scrollTopSetter = vi.fn();
+    const scrollTopDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLPreElement.prototype,
+      'scrollTop',
+    );
+    const scrollHeightDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLPreElement.prototype,
+      'scrollHeight',
+    );
+    Object.defineProperty(HTMLPreElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get: () => 4096,
+    });
+    Object.defineProperty(HTMLPreElement.prototype, 'scrollTop', {
+      configurable: true,
+      get: () => 0,
+      set: scrollTopSetter,
+    });
+
+    try {
+      renderLogsPage();
+
+      await screen.findByText('gateway log');
+      await waitFor(() => expect(scrollTopSetter).toHaveBeenCalledWith(4096));
+    } finally {
+      restorePrototypeProperty(
+        HTMLPreElement.prototype,
+        'scrollTop',
+        scrollTopDescriptor,
+      );
+      restorePrototypeProperty(
+        HTMLPreElement.prototype,
+        'scrollHeight',
+        scrollHeightDescriptor,
+      );
+    }
+  });
+
+  it('saves off logging mode to config and reloads the gateway', async () => {
+    const config = makeConfig({
+      ops: {
+        ...makeConfig().ops,
+        logLevel: 'debug',
+        logRequests: true,
+        debugModelResponses: true,
+      },
+    });
+    fetchConfigMock.mockResolvedValueOnce({
+      path: '/tmp/config.json',
+      config,
+    });
+
+    renderLogsPage();
+
+    expect(await screen.findByText('Current mode: debug')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Off' }));
+
+    await waitFor(() => expect(saveConfigMock).toHaveBeenCalledTimes(1));
+    expect(saveConfigMock).toHaveBeenCalledWith(
+      'admin-token',
+      expect.objectContaining({
+        ops: expect.objectContaining({
+          logLevel: 'silent',
+          logRequests: false,
+          debugModelResponses: false,
+        }),
+      }),
+    );
+    expect(reloadGatewayMock).toHaveBeenCalledWith('admin-token');
+  });
+});

--- a/console/src/routes/logs.test.tsx
+++ b/console/src/routes/logs.test.tsx
@@ -13,6 +13,9 @@ const fetchConfigMock = vi.fn<() => Promise<AdminConfigResponse>>();
 const reloadGatewayMock = vi.fn();
 const saveConfigMock = vi.fn();
 const useAuthMock = vi.fn();
+type AdminConfigOverrides = Partial<Omit<AdminConfig, 'ops'>> & {
+  ops?: Partial<AdminConfig['ops']>;
+};
 
 vi.mock('../api/client', () => ({
   fetchAdminLogs: () => fetchAdminLogsMock(),
@@ -25,52 +28,8 @@ vi.mock('../auth', () => ({
   useAuth: () => useAuthMock(),
 }));
 
-function makeConfig(overrides: Partial<AdminConfig> = {}): AdminConfig {
+function makeConfig(overrides: AdminConfigOverrides = {}): AdminConfig {
   const base = {
-    version: 1,
-    security: {
-      trustModelAccepted: false,
-      trustModelAcceptedAt: '',
-      trustModelVersion: '',
-      trustModelAcceptedBy: '',
-      confidentialRedactionEnabled: false,
-    },
-    hybridai: {
-      baseUrl: 'https://hybridai.one',
-      defaultModel: 'gpt-5',
-      defaultChatbotId: '',
-      maxTokens: 4096,
-      enableRag: true,
-      models: ['gpt-5'],
-    },
-    channelInstructions: {
-      discord: '',
-      discord_webhook: '',
-      msteams: '',
-      slack: '',
-      slack_webhook: '',
-      signal: '',
-      telegram: '',
-      threema: '',
-      voice: '',
-      whatsapp: '',
-      email: '',
-      imessage: '',
-    },
-    container: {
-      sandboxMode: 'container',
-      image: '',
-      memory: '2g',
-      memorySwap: '2g',
-      cpus: '2',
-      network: 'none',
-      timeoutMs: 300000,
-      binds: [],
-      additionalMounts: '',
-      maxOutputBytes: 100000,
-      maxConcurrent: 2,
-      persistBashState: false,
-    },
     ops: {
       healthHost: '127.0.0.1',
       healthPort: 9090,
@@ -82,36 +41,6 @@ function makeConfig(overrides: Partial<AdminConfig> = {}): AdminConfig {
       logLevel: 'info',
       logRequests: false,
       debugModelResponses: false,
-    },
-    browser: {
-      provider: 'local',
-      local: {
-        profileDir: '',
-        headed: false,
-      },
-      camofox: {
-        profileDir: '',
-        headed: false,
-      },
-      managedCloud: {
-        endpointUrl: 'http://127.0.0.1:8787',
-        poolTokenRef: undefined,
-        defaultTenantId: '',
-        pricing: {
-          actionUsd: 0,
-        },
-      },
-      browserUseCloud: {
-        apiKeyRef: undefined,
-        projectId: '',
-        profileId: '',
-        region: '',
-        keepAlive: false,
-        pricing: {
-          browserUsdPerMinute: 0,
-          actionUsd: 0,
-        },
-      },
     },
   } as unknown as AdminConfig;
 
@@ -279,6 +208,45 @@ describe('LogsPage', () => {
     );
   });
 
+  it('does not show manually configured trace logging as debug mode', async () => {
+    const config = makeConfig({ ops: { logLevel: 'trace' } });
+    fetchConfigMock.mockResolvedValueOnce({
+      path: '/tmp/config.json',
+      config,
+    });
+    fetchAdminLogsMock.mockResolvedValueOnce({
+      ...makeLogs(),
+      logging: {
+        configuredLevel: 'trace',
+        effectiveLevel: 'trace',
+        forcedLevel: null,
+        logRequests: {
+          configured: false,
+          envEnabled: false,
+          effective: false,
+        },
+        debugModelResponses: {
+          configured: false,
+          envEnabled: false,
+          effective: false,
+        },
+      },
+    });
+
+    renderLogsPage();
+
+    const description = await screen.findByText('Current mode: on');
+    const loggingCard = description.closest('[data-slot="card"]');
+    expect(loggingCard).toBeTruthy();
+    await waitFor(() =>
+      expect(
+        within(loggingCard as HTMLElement)
+          .getByRole('button', { name: 'On' })
+          .getAttribute('aria-pressed'),
+      ).toBe('true'),
+    );
+  });
+
   it('jumps to the end of the selected log after loading', async () => {
     const scrollTopSetter = vi.fn();
     const scrollTopDescriptor = Object.getOwnPropertyDescriptor(
@@ -321,7 +289,6 @@ describe('LogsPage', () => {
   it('saves off logging mode to config and reloads the gateway', async () => {
     const config = makeConfig({
       ops: {
-        ...makeConfig().ops,
         logLevel: 'debug',
         logRequests: true,
         debugModelResponses: true,

--- a/console/src/routes/logs.test.tsx
+++ b/console/src/routes/logs.test.tsx
@@ -226,6 +226,23 @@ describe('LogsPage', () => {
     expect(reloadGatewayMock).toHaveBeenCalledWith('admin-token');
   });
 
+  it('reports an error when the gateway reload response is not ok', async () => {
+    reloadGatewayMock.mockResolvedValueOnce({
+      status: 'error',
+      message: 'Reload refused.',
+    });
+
+    renderLogsPage();
+
+    expect(await screen.findByText('Current mode: on')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Debug' }));
+
+    await waitFor(() => expect(saveConfigMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(reloadGatewayMock).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('Logging mode update failed')).toBeTruthy();
+    expect(screen.getByText('Reload refused.')).toBeTruthy();
+  });
+
   it('shows debug when the runtime logger is forced to debug', async () => {
     fetchAdminLogsMock.mockResolvedValue({
       ...makeLogs(),

--- a/console/src/routes/logs.tsx
+++ b/console/src/routes/logs.tsx
@@ -138,7 +138,10 @@ export function LogsPage() {
         auth.token,
         applyLoggingMode(current, mode),
       );
-      await reloadGateway(auth.token);
+      const reload = await reloadGateway(auth.token);
+      if (reload.status !== 'ok') {
+        throw new Error(reload.message || 'Gateway reload failed.');
+      }
       return saved;
     },
     onSuccess: (payload) => {

--- a/console/src/routes/logs.tsx
+++ b/console/src/routes/logs.tsx
@@ -26,6 +26,7 @@ import { getErrorMessage } from '../lib/error-message';
 import { formatDateTime } from '../lib/format';
 
 const LOG_TAIL_BYTES = 128 * 1024;
+const CONFIG_STALE_TIME_MS = 30_000;
 type LoggingMode = 'off' | 'on' | 'debug';
 const LOGGING_MODE_OPTIONS: Array<{
   value: LoggingMode;
@@ -36,6 +37,18 @@ const LOGGING_MODE_OPTIONS: Array<{
   { value: 'on', label: 'On' },
   { value: 'debug', label: 'Debug' },
 ];
+const LOGGING_MODE_SETTINGS = {
+  off: { logLevel: 'silent', logRequests: false, debugModelResponses: false },
+  on: { logLevel: 'info', logRequests: false, debugModelResponses: false },
+  debug: { logLevel: 'debug', logRequests: true, debugModelResponses: true },
+} satisfies Record<
+  LoggingMode,
+  {
+    logLevel: AdminConfig['ops']['logLevel'];
+    logRequests: boolean;
+    debugModelResponses: boolean;
+  }
+>;
 
 function formatBytes(value: number | null): string {
   if (value == null) return 'missing';
@@ -62,10 +75,9 @@ function loggingModeFromState(
   state?: AdminLoggingState,
 ): LoggingMode {
   const effectiveLevel = state?.effectiveLevel ?? config?.ops.logLevel;
-  if (effectiveLevel === 'silent') return 'off';
+  if (effectiveLevel === LOGGING_MODE_SETTINGS.off.logLevel) return 'off';
   if (
-    effectiveLevel === 'debug' ||
-    effectiveLevel === 'trace' ||
+    effectiveLevel === LOGGING_MODE_SETTINGS.debug.logLevel ||
     state?.logRequests.effective === true ||
     state?.debugModelResponses.effective === true ||
     config?.ops.logRequests === true ||
@@ -91,14 +103,12 @@ function loggingModeDescription(
 }
 
 function applyLoggingMode(config: AdminConfig, mode: LoggingMode): AdminConfig {
-  const debug = mode === 'debug';
+  const settings = LOGGING_MODE_SETTINGS[mode];
   return {
     ...config,
     ops: {
       ...config.ops,
-      logLevel: mode === 'off' ? 'silent' : debug ? 'debug' : 'info',
-      logRequests: debug,
-      debugModelResponses: debug,
+      ...settings,
     },
   };
 }
@@ -124,6 +134,7 @@ export function LogsPage() {
     queryKey: ['config', auth.token],
     queryFn: () => fetchConfig(auth.token),
     refetchOnWindowFocus: false,
+    staleTime: CONFIG_STALE_TIME_MS,
   });
   const loggingState = logsQuery.data?.logging;
   const loggingMode = loggingModeFromState(
@@ -214,11 +225,7 @@ export function LogsPage() {
               configQuery.isFetching ||
               loggingMutation.isPending
             }
-            onChange={(mode) => {
-              if (mode === 'off' || mode === 'on' || mode === 'debug') {
-                loggingMutation.mutate(mode);
-              }
-            }}
+            onChange={(mode) => loggingMutation.mutate(mode)}
           />
         </CardContent>
       </Card>

--- a/console/src/routes/logs.tsx
+++ b/console/src/routes/logs.tsx
@@ -1,7 +1,16 @@
-import { useQuery } from '@tanstack/react-query';
-import { useEffect, useMemo, useState } from 'react';
-import { fetchAdminLogs } from '../api/client';
-import type { AdminLogFile } from '../api/types';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  fetchAdminLogs,
+  fetchConfig,
+  reloadGateway,
+  saveConfig,
+} from '../api/client';
+import type {
+  AdminConfig,
+  AdminLogFile,
+  AdminLoggingState,
+} from '../api/types';
 import { useAuth } from '../auth';
 import { Button } from '../components/button';
 import {
@@ -11,10 +20,22 @@ import {
   CardHeader,
   CardTitle,
 } from '../components/card';
-import { BooleanPill, PageHeader } from '../components/ui';
+import { useToast } from '../components/toast';
+import { BooleanPill, PageHeader, SegmentedToggle } from '../components/ui';
+import { getErrorMessage } from '../lib/error-message';
 import { formatDateTime } from '../lib/format';
 
 const LOG_TAIL_BYTES = 128 * 1024;
+type LoggingMode = 'off' | 'on' | 'debug';
+const LOGGING_MODE_OPTIONS: Array<{
+  value: LoggingMode;
+  label: string;
+  activeTone?: 'is-on' | 'is-off';
+}> = [
+  { value: 'off', label: 'Off', activeTone: 'is-off' },
+  { value: 'on', label: 'On' },
+  { value: 'debug', label: 'Debug' },
+];
 
 function formatBytes(value: number | null): string {
   if (value == null) return 'missing';
@@ -36,9 +57,58 @@ function fileStatusLabel(file: AdminLogFile): string {
   return 'readable';
 }
 
+function loggingModeFromState(
+  config: AdminConfig | null,
+  state?: AdminLoggingState,
+): LoggingMode {
+  const effectiveLevel = state?.effectiveLevel ?? config?.ops.logLevel;
+  if (effectiveLevel === 'silent') return 'off';
+  if (
+    effectiveLevel === 'debug' ||
+    effectiveLevel === 'trace' ||
+    state?.logRequests.effective === true ||
+    state?.debugModelResponses.effective === true ||
+    config?.ops.logRequests === true ||
+    config?.ops.debugModelResponses === true
+  ) {
+    return 'debug';
+  }
+  return 'on';
+}
+
+function loggingModeDescription(
+  mode: LoggingMode,
+  state?: AdminLoggingState,
+): string {
+  if (!state) return `Current mode: ${mode}`;
+  if (state.forcedLevel) {
+    return `Current mode: ${mode} (forced by runtime)`;
+  }
+  if (state.logRequests.envEnabled || state.debugModelResponses.envEnabled) {
+    return `Current mode: ${mode} (enabled by runtime flag)`;
+  }
+  return `Current mode: ${mode}`;
+}
+
+function applyLoggingMode(config: AdminConfig, mode: LoggingMode): AdminConfig {
+  const debug = mode === 'debug';
+  return {
+    ...config,
+    ops: {
+      ...config.ops,
+      logLevel: mode === 'off' ? 'silent' : debug ? 'debug' : 'info',
+      logRequests: debug,
+      debugModelResponses: debug,
+    },
+  };
+}
+
 export function LogsPage() {
   const auth = useAuth();
+  const queryClient = useQueryClient();
+  const toast = useToast();
   const [selectedFileId, setSelectedFileId] = useState<string | null>(null);
+  const logViewerRef = useRef<HTMLPreElement | null>(null);
 
   const logsQuery = useQuery({
     queryKey: ['admin-logs', auth.token, selectedFileId],
@@ -47,24 +117,62 @@ export function LogsPage() {
         fileId: selectedFileId,
         tailBytes: LOG_TAIL_BYTES,
       }),
+    placeholderData: (previousData) => previousData,
     refetchOnWindowFocus: false,
+  });
+  const configQuery = useQuery({
+    queryKey: ['config', auth.token],
+    queryFn: () => fetchConfig(auth.token),
+    refetchOnWindowFocus: false,
+  });
+  const loggingState = logsQuery.data?.logging;
+  const loggingMode = loggingModeFromState(
+    configQuery.data?.config ?? null,
+    loggingState,
+  );
+  const loggingMutation = useMutation({
+    mutationFn: async (mode: LoggingMode) => {
+      const current = configQuery.data?.config;
+      if (!current) throw new Error('Runtime config has not loaded yet.');
+      const saved = await saveConfig(
+        auth.token,
+        applyLoggingMode(current, mode),
+      );
+      await reloadGateway(auth.token);
+      return saved;
+    },
+    onSuccess: (payload) => {
+      queryClient.setQueryData(['config', auth.token], payload);
+      toast.success('Logging mode saved.');
+      void logsQuery.refetch();
+    },
+    onError: (error) => {
+      toast.error('Logging mode update failed', getErrorMessage(error));
+    },
   });
 
   const files = logsQuery.data?.files || [];
+  const selectedLog = logsQuery.data?.selected;
   const selectedFile = useMemo(() => {
-    const selectedId = logsQuery.data?.selected?.fileId || selectedFileId;
+    const selectedId = selectedLog?.fileId || selectedFileId;
     return (
       files.find((file) => file.id === selectedId) ||
       files.find((file) => file.readable) ||
       files[0] ||
       null
     );
-  }, [files, logsQuery.data?.selected?.fileId, selectedFileId]);
+  }, [files, selectedLog?.fileId, selectedFileId]);
 
   useEffect(() => {
     if (!selectedFile || selectedFile.id === selectedFileId) return;
     setSelectedFileId(selectedFile.id);
   }, [selectedFile, selectedFileId]);
+
+  useEffect(() => {
+    const logViewer = logViewerRef.current;
+    if (!logViewer || !selectedLog) return;
+    logViewer.scrollTop = logViewer.scrollHeight;
+  }, [selectedLog]);
 
   return (
     <div className="page-stack">
@@ -81,6 +189,36 @@ export function LogsPage() {
           </Button>
         }
       />
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Logging</CardTitle>
+          <CardDescription>
+            {configQuery.data
+              ? loggingModeDescription(loggingMode, loggingState)
+              : configQuery.isError
+                ? 'Runtime config unavailable.'
+                : 'Loading runtime config...'}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <SegmentedToggle
+            ariaLabel="Logging mode"
+            value={loggingMode}
+            options={LOGGING_MODE_OPTIONS}
+            disabled={
+              !configQuery.data ||
+              configQuery.isFetching ||
+              loggingMutation.isPending
+            }
+            onChange={(mode) => {
+              if (mode === 'off' || mode === 'on' || mode === 'debug') {
+                loggingMutation.mutate(mode);
+              }
+            }}
+          />
+        </CardContent>
+      </Card>
 
       <div className="two-column-grid logs-layout">
         <Card>
@@ -165,16 +303,15 @@ export function LogsPage() {
                 </div>
                 {selectedFile.error ? (
                   <div className="empty-state error">{selectedFile.error}</div>
-                ) : logsQuery.data?.selected ? (
+                ) : selectedLog ? (
                   <>
-                    {logsQuery.data.selected.truncated ? (
+                    {selectedLog.truncated ? (
                       <p className="muted-copy">
-                        Showing the last{' '}
-                        {formatBytes(logsQuery.data.selected.tailBytes)}.
+                        Showing the last {formatBytes(selectedLog.tailBytes)}.
                       </p>
                     ) : null}
-                    <pre className="log-viewer">
-                      {logsQuery.data.selected.content || '(empty log file)'}
+                    <pre className="log-viewer" ref={logViewerRef}>
+                      {selectedLog.content || '(empty log file)'}
                     </pre>
                   </>
                 ) : (

--- a/console/src/routes/output-guard.tsx
+++ b/console/src/routes/output-guard.tsx
@@ -215,13 +215,11 @@ function ModelSourceControl(props: {
             { value: 'model', label: 'other model' },
           ]}
           onChange={(provider) => {
-            const nextProvider =
-              provider as AdminOutputGuardModelConfig['provider'];
             const nextModel =
-              nextProvider === 'model'
+              provider === 'model'
                 ? props.value.model || props.defaultOtherModelId
                 : '';
-            props.onChange(modelConfigDefaults(nextProvider, nextModel));
+            props.onChange(modelConfigDefaults(provider, nextModel));
           }}
         />
         {props.value.provider === 'model' ? (
@@ -444,7 +442,7 @@ export function OutputGuardPage() {
                     onChange={(mode) =>
                       setProfile((current) => ({
                         ...current,
-                        mode: mode as AdminOutputGuardProfile['mode'],
+                        mode,
                       }))
                     }
                   />

--- a/console/src/routes/skills.tsx
+++ b/console/src/routes/skills.tsx
@@ -560,11 +560,7 @@ export function SkillsPage() {
                 { value: 'form', label: 'Form', activeTone: 'is-on' },
                 { value: 'zip', label: 'Upload ZIP', activeTone: 'is-on' },
               ]}
-              onChange={(value) => {
-                if (value === 'form' || value === 'zip') {
-                  setCreateMode(value);
-                }
-              }}
+              onChange={(value) => setCreateMode(value)}
             />
 
             {createMode === 'zip' ? (

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -881,10 +881,9 @@ async function runGatewayForeground(
     process.env[GATEWAY_TOOLS_MODE_ENV] = toolsMode;
   }
   if (debug || debugModelResponses) {
-    process.env.HYBRIDCLAW_FORCE_LOG_LEVEL = 'debug';
-    const { forceLoggerLevel } = await import('./logger.js');
-    forceLoggerLevel('debug');
-    console.log(`${commandName}: forcing gateway log level to debug.`);
+    const { setLoggerStartupLevel } = await import('./logger.js');
+    setLoggerStartupLevel('debug');
+    console.log(`${commandName}: setting startup log level to debug.`);
   }
   const foregroundGatewayPid = registerForegroundGatewayPid(commandName);
   await ensureRuntimeContainer(commandName, true, sandboxMode);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -73,7 +73,6 @@ import {
 } from './gateway/gateway-lifecycle.js';
 import type { GatewayStatus } from './gateway/gateway-types.js';
 import type { DockerAccessIssueKind } from './infra/container-setup.js';
-import { logger } from './logger.js';
 import { runtimeSecretsPath } from './security/runtime-secrets.js';
 import { sleep } from './utils/sleep.js';
 
@@ -540,6 +539,7 @@ async function resolveTuiPreflightSandboxMode(): Promise<SandboxModeOverride | n
       return health.sandbox.mode === 'host' ? 'host' : null;
     }
   } catch (err) {
+    const { logger } = await import('./logger.js');
     logger.debug(
       { err },
       'TUI preflight gateway health lookup failed; falling back to authenticated status.',

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -1165,6 +1165,8 @@ export interface RuntimeConfig {
     gatewayApiToken: string;
     dbPath: string;
     logLevel: LogLevel;
+    logRequests: boolean;
+    debugModelResponses: boolean;
   };
   observability: {
     enabled: boolean;
@@ -1927,6 +1929,8 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
     gatewayApiToken: '',
     dbPath: DEFAULT_DB_PATH,
     logLevel: 'info',
+    logRequests: false,
+    debugModelResponses: false,
   },
   observability: {
     enabled: true,
@@ -7769,6 +7773,11 @@ function normalizeRuntimeConfig(
       }),
       dbPath: normalizedDbPath,
       logLevel: normalizeLogLevel(rawOps.logLevel, defaultOps.logLevel),
+      logRequests: normalizeBoolean(rawOps.logRequests, defaultOps.logRequests),
+      debugModelResponses: normalizeBoolean(
+        rawOps.debugModelResponses,
+        defaultOps.debugModelResponses,
+      ),
     },
     observability: {
       enabled: normalizeBoolean(

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -93,7 +93,7 @@ import {
 import { GatewayRequestError } from '../errors/gateway-request-error.js';
 import { resolveInstallPath } from '../infra/install-root.js';
 import { agentWorkspaceDir } from '../infra/ipc.js';
-import { logger } from '../logger.js';
+import { logger, syncLoggerLevelFromRuntimeConfig } from '../logger.js';
 import { summarizeMediaFilenames } from '../media/media-summary.js';
 import { normalizeMimeType } from '../media/mime-utils.js';
 import {
@@ -3917,6 +3917,7 @@ function handleApiConfigReload(res: ServerResponse): void {
   try {
     refreshRuntimeSecretsFromEnv();
     reloadRuntimeConfig('admin-api');
+    syncLoggerLevelFromRuntimeConfig('admin-api');
   } catch (error) {
     sendJson(res, 500, {
       error:

--- a/src/gateway/gateway-log-service.ts
+++ b/src/gateway/gateway-log-service.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { getRuntimeConfig } from '../config/runtime-config.js';
 import { getLoggerRuntimeState } from '../logger.js';
+import { stripAnsi } from '../utils/ansi.js';
 import {
   GATEWAY_DEBUG_MODEL_RESPONSES_ENV,
   GATEWAY_LOG_PATH,
@@ -157,6 +158,7 @@ async function readLogTail(
       const firstLineBreak = content.indexOf('\n');
       if (firstLineBreak >= 0) content = content.slice(firstLineBreak + 1);
     }
+    content = stripAnsi(content);
     return {
       fileId: descriptor.id,
       content,

--- a/src/gateway/gateway-log-service.ts
+++ b/src/gateway/gateway-log-service.ts
@@ -152,9 +152,14 @@ async function readLogTail(
     const buffer = Buffer.alloc(bytesToRead);
     handle = await fs.open(descriptor.path, 'r');
     await handle.read(buffer, 0, bytesToRead, stat.size - bytesToRead);
+    let content = buffer.toString('utf-8');
+    if (stat.size > bytesToRead) {
+      const firstLineBreak = content.indexOf('\n');
+      if (firstLineBreak >= 0) content = content.slice(firstLineBreak + 1);
+    }
     return {
       fileId: descriptor.id,
-      content: buffer.toString('utf-8'),
+      content,
       tailBytes: bytesToRead,
       truncated: stat.size > bytesToRead,
     };

--- a/src/gateway/gateway-log-service.ts
+++ b/src/gateway/gateway-log-service.ts
@@ -1,13 +1,18 @@
 import type { FileHandle } from 'node:fs/promises';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { getRuntimeConfig } from '../config/runtime-config.js';
+import { getLoggerRuntimeState } from '../logger.js';
 import {
+  GATEWAY_DEBUG_MODEL_RESPONSES_ENV,
   GATEWAY_LOG_PATH,
+  GATEWAY_LOG_REQUESTS_ENV,
   GATEWAY_MODEL_RESPONSE_DEBUG_PATH,
 } from './gateway-lifecycle.js';
 
 const DEFAULT_TAIL_BYTES = 64 * 1024;
 const MAX_TAIL_BYTES = 256 * 1024;
+const ENABLED_ENV_VALUE = '1';
 
 export interface GatewayAdminLogFile {
   id: string;
@@ -28,9 +33,26 @@ export interface GatewayAdminLogTail {
   truncated: boolean;
 }
 
+export interface GatewayAdminLoggingState {
+  configuredLevel: ReturnType<typeof getRuntimeConfig>['ops']['logLevel'];
+  effectiveLevel: ReturnType<typeof getRuntimeConfig>['ops']['logLevel'];
+  forcedLevel: ReturnType<typeof getRuntimeConfig>['ops']['logLevel'] | null;
+  logRequests: {
+    configured: boolean;
+    envEnabled: boolean;
+    effective: boolean;
+  };
+  debugModelResponses: {
+    configured: boolean;
+    envEnabled: boolean;
+    effective: boolean;
+  };
+}
+
 export interface GatewayAdminLogsResponse {
   files: GatewayAdminLogFile[];
   selected: GatewayAdminLogTail | null;
+  logging: GatewayAdminLoggingState;
 }
 
 interface LogDescriptor {
@@ -143,6 +165,37 @@ async function readLogTail(
   }
 }
 
+function isEnvFlagEnabled(name: string): boolean {
+  return String(process.env[name] || '').trim() === ENABLED_ENV_VALUE;
+}
+
+function getGatewayAdminLoggingState(): GatewayAdminLoggingState {
+  const config = getRuntimeConfig();
+  const loggerState = getLoggerRuntimeState();
+  const logRequestsEnvEnabled = isEnvFlagEnabled(GATEWAY_LOG_REQUESTS_ENV);
+  const debugModelResponsesEnvEnabled = isEnvFlagEnabled(
+    GATEWAY_DEBUG_MODEL_RESPONSES_ENV,
+  );
+
+  return {
+    configuredLevel: loggerState.configuredLevel,
+    effectiveLevel: loggerState.effectiveLevel,
+    forcedLevel: loggerState.forcedLevel,
+    logRequests: {
+      configured: config.ops.logRequests === true,
+      envEnabled: logRequestsEnvEnabled,
+      effective: config.ops.logRequests === true || logRequestsEnvEnabled,
+    },
+    debugModelResponses: {
+      configured: config.ops.debugModelResponses === true,
+      envEnabled: debugModelResponsesEnvEnabled,
+      effective:
+        config.ops.debugModelResponses === true ||
+        debugModelResponsesEnvEnabled,
+    },
+  };
+}
+
 export async function getGatewayAdminLogs(options?: {
   fileId?: string | null;
   tailBytes?: string | null;
@@ -157,7 +210,11 @@ export async function getGatewayAdminLogs(options?: {
       ) ?? descriptors[0]);
 
   if (!selectedDescriptor) {
-    return { files, selected: null };
+    return {
+      files,
+      selected: null,
+      logging: getGatewayAdminLoggingState(),
+    };
   }
   if (requestedFileId && selectedDescriptor.id !== requestedFileId) {
     throw new Error(`Unknown log file "${requestedFileId}".`);
@@ -167,5 +224,9 @@ export async function getGatewayAdminLogs(options?: {
     selectedDescriptor,
     normalizeTailBytes(options?.tailBytes ?? null),
   );
-  return { files, selected };
+  return {
+    files,
+    selected,
+    logging: getGatewayAdminLoggingState(),
+  };
 }

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -760,7 +760,7 @@ let lastWarnedGatewayRequestLoggingValue: string | null = null;
 
 export function isGatewayRequestLoggingEnabled(): boolean {
   const raw = String(process.env[GATEWAY_LOG_REQUESTS_ENV] || '').trim();
-  if (!raw) return false;
+  if (!raw) return getRuntimeConfig().ops.logRequests === true;
   if (raw === GATEWAY_REQUEST_LOG_ENABLED_VALUE) {
     lastWarnedGatewayRequestLoggingValue = null;
     return true;

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -56,12 +56,8 @@ import {
   WEB_SEARCH_PROVIDER,
   WEB_SEARCH_TAVILY_SEARCH_DEPTH,
 } from '../config/config.js';
-import {
-  type CodexTurnRuntime,
-  getRuntimeConfig,
-} from '../config/runtime-config.js';
+import type { CodexTurnRuntime } from '../config/runtime-config.js';
 import { readStoredRuntimeEnv } from '../config/runtime-env.js';
-import { GATEWAY_DEBUG_MODEL_RESPONSES_ENV } from '../gateway/gateway-lifecycle.js';
 import { logger } from '../logger.js';
 import { resolveUploadedMediaCacheHostDir } from '../media/uploaded-media-cache.js';
 import { withSpan } from '../observability/otel.js';
@@ -96,7 +92,10 @@ import {
   readOutput,
   writeInput,
 } from './ipc.js';
-import { consumeModelResponseDebugFileLine } from './model-response-debug.js';
+import {
+  consumeModelResponseDebugFileLine,
+  isModelResponseDebugEnabled,
+} from './model-response-debug.js';
 import {
   consumeCollapsedStreamDebugLine,
   createStreamDebugState,
@@ -138,13 +137,6 @@ function resolveExecutorMaxTokens(params: {
     model: params.model,
     discoveredMaxTokens: params.discoveredMaxTokens,
   });
-}
-
-function isModelResponseDebugEnabled(): boolean {
-  return (
-    process.env[GATEWAY_DEBUG_MODEL_RESPONSES_ENV] === '1' ||
-    getRuntimeConfig().ops.debugModelResponses === true
-  );
 }
 
 interface PoolEntry extends WarmRunnerEntry {

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -56,7 +56,10 @@ import {
   WEB_SEARCH_PROVIDER,
   WEB_SEARCH_TAVILY_SEARCH_DEPTH,
 } from '../config/config.js';
-import type { CodexTurnRuntime } from '../config/runtime-config.js';
+import {
+  type CodexTurnRuntime,
+  getRuntimeConfig,
+} from '../config/runtime-config.js';
 import { readStoredRuntimeEnv } from '../config/runtime-env.js';
 import { GATEWAY_DEBUG_MODEL_RESPONSES_ENV } from '../gateway/gateway-lifecycle.js';
 import { logger } from '../logger.js';
@@ -135,6 +138,13 @@ function resolveExecutorMaxTokens(params: {
     model: params.model,
     discoveredMaxTokens: params.discoveredMaxTokens,
   });
+}
+
+function isModelResponseDebugEnabled(): boolean {
+  return (
+    process.env[GATEWAY_DEBUG_MODEL_RESPONSES_ENV] === '1' ||
+    getRuntimeConfig().ops.debugModelResponses === true
+  );
 }
 
 interface PoolEntry extends WarmRunnerEntry {
@@ -1123,7 +1133,7 @@ async function runContainerInner(
     scheduleSideEffectsEnabled,
     skipContainerSystemPrompt,
     streamTextDeltas: Boolean(onTextDelta),
-    debugModelResponses: process.env[GATEWAY_DEBUG_MODEL_RESPONSES_ENV] === '1',
+    debugModelResponses: isModelResponseDebugEnabled(),
     maxTokens: resolveExecutorMaxTokens({
       model: runtimeModel,
       discoveredMaxTokens: modelRuntime.maxTokens,

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -44,12 +44,8 @@ import {
   WEB_SEARCH_PROVIDER,
   WEB_SEARCH_TAVILY_SEARCH_DEPTH,
 } from '../config/config.js';
-import {
-  type CodexTurnRuntime,
-  getRuntimeConfig,
-} from '../config/runtime-config.js';
+import type { CodexTurnRuntime } from '../config/runtime-config.js';
 import { readStoredRuntimeEnv } from '../config/runtime-env.js';
-import { GATEWAY_DEBUG_MODEL_RESPONSES_ENV } from '../gateway/gateway-lifecycle.js';
 import { logger } from '../logger.js';
 import { resolveUploadedMediaCacheHostDir } from '../media/uploaded-media-cache.js';
 import { withSpan } from '../observability/otel.js';
@@ -85,7 +81,10 @@ import {
   readOutput,
   writeInput,
 } from './ipc.js';
-import { consumeModelResponseDebugFileLine } from './model-response-debug.js';
+import {
+  consumeModelResponseDebugFileLine,
+  isModelResponseDebugEnabled,
+} from './model-response-debug.js';
 import {
   consumeCollapsedStreamDebugLine,
   createStreamDebugState,
@@ -122,12 +121,6 @@ import { computeWorkerSignature } from './worker-signature.js';
 const HOST_CAPACITY_WAIT_MS = 15_000;
 const HOST_CAPACITY_POLL_MS = 100;
 
-function isModelResponseDebugEnabled(): boolean {
-  return (
-    process.env[GATEWAY_DEBUG_MODEL_RESPONSES_ENV] === '1' ||
-    getRuntimeConfig().ops.debugModelResponses === true
-  );
-}
 const APPROVAL_RE = /^\[approval\]\s+([A-Za-z0-9+/=]+)$/;
 
 function resolveExecutorMaxTokens(params: {

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -44,7 +44,10 @@ import {
   WEB_SEARCH_PROVIDER,
   WEB_SEARCH_TAVILY_SEARCH_DEPTH,
 } from '../config/config.js';
-import type { CodexTurnRuntime } from '../config/runtime-config.js';
+import {
+  type CodexTurnRuntime,
+  getRuntimeConfig,
+} from '../config/runtime-config.js';
 import { readStoredRuntimeEnv } from '../config/runtime-env.js';
 import { GATEWAY_DEBUG_MODEL_RESPONSES_ENV } from '../gateway/gateway-lifecycle.js';
 import { logger } from '../logger.js';
@@ -118,6 +121,13 @@ import { computeWorkerSignature } from './worker-signature.js';
 
 const HOST_CAPACITY_WAIT_MS = 15_000;
 const HOST_CAPACITY_POLL_MS = 100;
+
+function isModelResponseDebugEnabled(): boolean {
+  return (
+    process.env[GATEWAY_DEBUG_MODEL_RESPONSES_ENV] === '1' ||
+    getRuntimeConfig().ops.debugModelResponses === true
+  );
+}
 const APPROVAL_RE = /^\[approval\]\s+([A-Za-z0-9+/=]+)$/;
 
 function resolveExecutorMaxTokens(params: {
@@ -971,7 +981,7 @@ async function runHostProcessInner(
     scheduleSideEffectsEnabled,
     skipContainerSystemPrompt,
     streamTextDeltas: Boolean(onTextDelta),
-    debugModelResponses: process.env[GATEWAY_DEBUG_MODEL_RESPONSES_ENV] === '1',
+    debugModelResponses: isModelResponseDebugEnabled(),
     maxTokens: resolveExecutorMaxTokens({
       model: runtimeModel,
       discoveredMaxTokens: modelRuntime.maxTokens,

--- a/src/infra/model-response-debug.ts
+++ b/src/infra/model-response-debug.ts
@@ -6,12 +6,15 @@ import {
   GATEWAY_DEBUG_MODEL_RESPONSES_ENV,
   GATEWAY_MODEL_RESPONSE_DEBUG_PATH,
 } from '../gateway/gateway-lifecycle.js';
+import { logger } from '../logger.js';
 
 const MODEL_RESPONSE_DEBUG_FILE_RE =
   /^\[model-response-debug-file\]\s+([A-Za-z0-9+/=]+)$/;
 const LAST_PROMPT_FILE_RE = /^\[last-prompt-file\]\s+([A-Za-z0-9+/=]+)$/;
 const LAST_PROMPT_PATH = path.join(DATA_DIR, 'last_prompt.jsonl');
 const ensuredDebugDirs = new Set<string>();
+const MODEL_RESPONSE_DEBUG_ENABLED_VALUE = '1';
+let lastWarnedModelResponseDebugValue: string | null = null;
 
 function ensureDebugDir(filePath: string): void {
   const dir = path.dirname(filePath);
@@ -20,11 +23,27 @@ function ensureDebugDir(filePath: string): void {
   ensuredDebugDirs.add(dir);
 }
 
-function isModelResponseDebugEnabled(): boolean {
-  return (
-    process.env[GATEWAY_DEBUG_MODEL_RESPONSES_ENV] === '1' ||
-    getRuntimeConfig().ops.debugModelResponses === true
-  );
+export function isModelResponseDebugEnabled(): boolean {
+  const raw = String(
+    process.env[GATEWAY_DEBUG_MODEL_RESPONSES_ENV] || '',
+  ).trim();
+  if (!raw) return getRuntimeConfig().ops.debugModelResponses === true;
+  if (raw === MODEL_RESPONSE_DEBUG_ENABLED_VALUE) {
+    lastWarnedModelResponseDebugValue = null;
+    return true;
+  }
+  if (raw !== lastWarnedModelResponseDebugValue) {
+    logger.warn(
+      {
+        envVar: GATEWAY_DEBUG_MODEL_RESPONSES_ENV,
+        expectedValue: MODEL_RESPONSE_DEBUG_ENABLED_VALUE,
+        value: raw,
+      },
+      'Ignoring invalid gateway model response debug env value',
+    );
+    lastWarnedModelResponseDebugValue = raw;
+  }
+  return false;
 }
 
 export function consumeModelResponseDebugFileLine(line: string): boolean {

--- a/src/infra/model-response-debug.ts
+++ b/src/infra/model-response-debug.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { DATA_DIR } from '../config/config.js';
+import { getRuntimeConfig } from '../config/runtime-config.js';
 import {
   GATEWAY_DEBUG_MODEL_RESPONSES_ENV,
   GATEWAY_MODEL_RESPONSE_DEBUG_PATH,
@@ -20,7 +21,10 @@ function ensureDebugDir(filePath: string): void {
 }
 
 function isModelResponseDebugEnabled(): boolean {
-  return process.env[GATEWAY_DEBUG_MODEL_RESPONSES_ENV] === '1';
+  return (
+    process.env[GATEWAY_DEBUG_MODEL_RESPONSES_ENV] === '1' ||
+    getRuntimeConfig().ops.debugModelResponses === true
+  );
 }
 
 export function consumeModelResponseDebugFileLine(line: string): boolean {

--- a/src/logger-format.ts
+++ b/src/logger-format.ts
@@ -7,6 +7,7 @@ export const LOGGER_PRETTY_OPTIONS = {
   colorizeObjects: false,
   errorLikeObjectKeys: [] as string[],
   singleLine: true,
+  translateTime: 'SYS:yyyy-mm-dd HH:MM:ss.l',
 };
 
 function isDomException(value: Error): boolean {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -48,6 +48,8 @@ const initialLevel = forcedLevel || getRuntimeConfig().ops.logLevel;
 const gatewayLogFile = String(
   process.env.HYBRIDCLAW_GATEWAY_LOG_FILE || '',
 ).trim();
+const stdoutMirrorsGatewayLog =
+  String(process.env.HYBRIDCLAW_GATEWAY_STDIO_TO_LOG || '').trim() === '1';
 
 function createPrettyDestination(
   prettyOptions: typeof LOGGER_PRETTY_OPTIONS,
@@ -93,7 +95,15 @@ function createLogger() {
   const streams: Array<{ level: 'trace'; stream: NodeJS.WritableStream }> = [
     {
       level: 'trace',
-      stream: createPrettyDestination(LOGGER_PRETTY_OPTIONS, process.stdout),
+      stream: createPrettyDestination(
+        {
+          ...LOGGER_PRETTY_OPTIONS,
+          colorize: stdoutMirrorsGatewayLog
+            ? false
+            : LOGGER_PRETTY_OPTIONS.colorize,
+        },
+        process.stdout,
+      ),
     },
   ];
 
@@ -135,6 +145,36 @@ export function forceLoggerLevel(
   logger.debug({ forcedLevel: level }, 'Logger level forced programmatically');
 }
 
+export function setLoggerStartupLevel(
+  level: ReturnType<typeof getRuntimeConfig>['ops']['logLevel'],
+): void {
+  if (!VALID_LOG_LEVELS.has(level)) {
+    throw new Error(`Invalid log level: ${level}`);
+  }
+  if (forcedLevel) return;
+  logger.level = level;
+  logger.debug({ level }, 'Logger level set by startup flag');
+}
+
+export function syncLoggerLevelFromRuntimeConfig(reason: string): void {
+  if (forcedLevel) {
+    logger.debug(
+      {
+        configuredLevel: getRuntimeConfig().ops.logLevel,
+        forcedLevel,
+        reason,
+      },
+      'Ignoring runtime config log-level sync due to forced override',
+    );
+    return;
+  }
+
+  const level = getRuntimeConfig().ops.logLevel;
+  if (logger.level === level) return;
+  logger.level = level;
+  logger.info({ level, reason }, 'Logger level updated from runtime config');
+}
+
 export function getLoggerRuntimeState(): {
   configuredLevel: ReturnType<typeof getRuntimeConfig>['ops']['logLevel'];
   effectiveLevel: ReturnType<typeof getRuntimeConfig>['ops']['logLevel'];
@@ -163,11 +203,7 @@ onRuntimeConfigChange((next, prev) => {
     return;
   }
   if (next.ops.logLevel !== prev.ops.logLevel) {
-    logger.level = next.ops.logLevel;
-    logger.info(
-      { level: next.ops.logLevel },
-      'Logger level updated from runtime config',
-    );
+    syncLoggerLevelFromRuntimeConfig('runtime-config-change');
   }
 });
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -135,6 +135,20 @@ export function forceLoggerLevel(
   logger.debug({ forcedLevel: level }, 'Logger level forced programmatically');
 }
 
+export function getLoggerRuntimeState(): {
+  configuredLevel: ReturnType<typeof getRuntimeConfig>['ops']['logLevel'];
+  effectiveLevel: ReturnType<typeof getRuntimeConfig>['ops']['logLevel'];
+  forcedLevel: ReturnType<typeof getRuntimeConfig>['ops']['logLevel'] | null;
+} {
+  return {
+    configuredLevel: getRuntimeConfig().ops.logLevel,
+    effectiveLevel: logger.level as ReturnType<
+      typeof getRuntimeConfig
+    >['ops']['logLevel'],
+    forcedLevel,
+  };
+}
+
 onRuntimeConfigChange((next, prev) => {
   if (forcedLevel) {
     if (next.ops.logLevel !== prev.ops.logLevel) {

--- a/tests/config-reload.integration.test.ts
+++ b/tests/config-reload.integration.test.ts
@@ -369,6 +369,21 @@ describe('config reload integration', () => {
     expect(cfg.ops.healthPort).toBe(9090);
   });
 
+  it('normalizes persisted logging flags', () => {
+    writeConfig({
+      ops: {
+        logLevel: 'debug',
+        logRequests: true,
+        debugModelResponses: true,
+      },
+    });
+
+    const cfg = configMod.reloadRuntimeConfig('test');
+    expect(cfg.ops.logLevel).toBe('debug');
+    expect(cfg.ops.logRequests).toBe(true);
+    expect(cfg.ops.debugModelResponses).toBe(true);
+  });
+
   it('reloadRuntimeConfig accepts container.persistBashState=false', () => {
     writeConfig({
       container: { persistBashState: false },

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -1873,6 +1873,7 @@ async function importFreshHealth(options?: {
       effectiveLevel: 'info',
       forcedLevel: null,
     }),
+    syncLoggerLevelFromRuntimeConfig: vi.fn(),
     logger: {
       debug: loggerDebug,
       error: loggerError,
@@ -5840,10 +5841,14 @@ describe('gateway HTTP server', () => {
     const dataDir = makeTempDataDir();
     const logPath = path.join(dataDir, 'gateway', 'gateway.log');
     fs.mkdirSync(path.dirname(logPath), { recursive: true });
-    fs.writeFileSync(logPath, 'first line\nsecond line\nthird line\n', 'utf8');
+    fs.writeFileSync(
+      logPath,
+      'first line\nsecond line\nthird \x1b[32mline\x1b[39m\n',
+      'utf8',
+    );
     const state = await importFreshHealth({ dataDir });
     const req = makeRequest({
-      url: '/api/admin/logs?file=gateway&tailBytes=16',
+      url: '/api/admin/logs?file=gateway&tailBytes=28',
     });
     const res = makeResponse();
 

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -1868,6 +1868,11 @@ async function importFreshHealth(options?: {
     };
   });
   vi.doMock('../src/logger.js', () => ({
+    getLoggerRuntimeState: () => ({
+      configuredLevel: 'info',
+      effectiveLevel: 'info',
+      forcedLevel: null,
+    }),
     logger: {
       debug: loggerDebug,
       error: loggerError,
@@ -5838,14 +5843,14 @@ describe('gateway HTTP server', () => {
     fs.writeFileSync(logPath, 'first line\nsecond line\nthird line\n', 'utf8');
     const state = await importFreshHealth({ dataDir });
     const req = makeRequest({
-      url: '/api/admin/logs?file=gateway&tailBytes=11',
+      url: '/api/admin/logs?file=gateway&tailBytes=16',
     });
     const res = makeResponse();
 
     state.handler(req as never, res as never);
     await waitForResponse(res, (next) => next.writableEnded);
 
-    expect(res.statusCode).toBe(200);
+    expect(res.statusCode, res.body).toBe(200);
     const payload = JSON.parse(res.body) as {
       files: Array<{ id: string; exists: boolean; path: string }>;
       selected: { fileId: string; content: string; truncated: boolean };

--- a/tests/gateway-service.agent-command.test.ts
+++ b/tests/gateway-service.agent-command.test.ts
@@ -150,20 +150,22 @@ test('agent switch starts active BOOTSTRAP hatching in a reused session', async 
       'A startup instruction file (BOOTSTRAP.md) exists',
     ),
   });
-  expect(getGatewayHistory(sessionId, 10).history).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({
-        role: 'assistant',
-        agent_id: 'research',
-        content: DEFAULT_GATEWAY_AUXILIARY_PRELUDE,
-      }),
-      expect.objectContaining({
-        role: 'assistant',
-        agent_id: 'research',
-        content: 'Hi. I am hatching now.',
-      }),
-    ]),
-  );
+  await vi.waitFor(() => {
+    expect(getGatewayHistory(sessionId, 10).history).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: 'assistant',
+          agent_id: 'research',
+          content: DEFAULT_GATEWAY_AUXILIARY_PRELUDE,
+        }),
+        expect.objectContaining({
+          role: 'assistant',
+          agent_id: 'research',
+          content: 'Hi. I am hatching now.',
+        }),
+      ]),
+    );
+  });
 });
 
 test('agent switch omits hatching hint when BOOTSTRAP is not active', async () => {

--- a/tests/gateway-service.audit.test.ts
+++ b/tests/gateway-service.audit.test.ts
@@ -977,6 +977,55 @@ test('handleGatewayMessage stores redacted request logs when enabled', async () 
   );
 });
 
+test('handleGatewayMessage stores request logs when enabled in runtime config', async () => {
+  const homeDir = setupHome();
+  fs.mkdirSync(`${homeDir}/.hybridclaw`, { recursive: true });
+  fs.writeFileSync(
+    `${homeDir}/.hybridclaw/config.json`,
+    `${JSON.stringify({ ops: { logRequests: true } }, null, 2)}\n`,
+    'utf-8',
+  );
+
+  runAgentMock.mockResolvedValue({
+    status: 'success',
+    result: 'done',
+    toolsUsed: [],
+    toolExecutions: [],
+  });
+
+  const { DB_PATH } = await import('../src/config/config.ts');
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayMessage } = await import(
+    '../src/gateway/gateway-chat-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  const result = await handleGatewayMessage({
+    sessionId: 'session-request-log-config',
+    guildId: null,
+    channelId: 'web',
+    userId: 'user-1',
+    username: 'alice',
+    content: 'hello from config logging',
+    model: 'test-model',
+    chatbotId: 'bot-1',
+  });
+
+  expect(result.status).toBe('success');
+
+  const inspect = new Database(DB_PATH, { readonly: true });
+  const rowCount = inspect
+    .prepare(
+      `SELECT COUNT(*) AS count
+       FROM request_log
+       WHERE session_id = ?`,
+    )
+    .get('session-request-log-config') as { count: number };
+  inspect.close();
+
+  expect(rowCount.count).toBe(1);
+});
+
 test('handleGatewayMessage skips request logs when request logging is disabled', async () => {
   setupHome();
 

--- a/tests/logger-format.test.ts
+++ b/tests/logger-format.test.ts
@@ -35,6 +35,16 @@ function renderLogLines(writeEntries: (logger: pino.Logger) => void): string[] {
 }
 
 describe('logger formatting', () => {
+  it('renders full local dates in log timestamps', () => {
+    const [line] = renderLogLines((logger) => {
+      logger.info('Gateway started');
+    });
+
+    expect(line).toMatch(
+      /^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\]/,
+    );
+  });
+
   it('renders structured fields on one line as compact JSON', () => {
     const [line] = renderLogLines((logger) => {
       logger.info(

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -89,6 +89,24 @@ describe('logger forced level override', () => {
     expect(logger.level).toBe('debug');
   });
 
+  it('reports effective and forced logger levels', async () => {
+    process.env.HYBRIDCLAW_FORCE_LOG_LEVEL = 'debug';
+    vi.doMock('../src/config/runtime-config.ts', () => ({
+      getRuntimeConfig: () => ({
+        ops: { logLevel: 'info' },
+      }),
+      onRuntimeConfigChange: vi.fn(),
+    }));
+
+    const { getLoggerRuntimeState } = await importLoggerModule();
+
+    expect(getLoggerRuntimeState()).toEqual({
+      configuredLevel: 'info',
+      effectiveLevel: 'debug',
+      forcedLevel: 'debug',
+    });
+  });
+
   it('mirrors logs to the configured gateway log file', async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'hybridclaw-logger-'));
     const logPath = path.join(tempDir, 'gateway.log');

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -107,6 +107,37 @@ describe('logger forced level override', () => {
     });
   });
 
+  it('allows startup debug level to resync from runtime config', async () => {
+    vi.doMock('../src/config/runtime-config.ts', () => ({
+      getRuntimeConfig: () => ({
+        ops: { logLevel: 'info' },
+      }),
+      onRuntimeConfigChange: vi.fn(),
+    }));
+
+    const {
+      getLoggerRuntimeState,
+      logger,
+      setLoggerStartupLevel,
+      syncLoggerLevelFromRuntimeConfig,
+    } = await importLoggerModule();
+
+    expect(logger.level).toBe('info');
+    setLoggerStartupLevel('debug');
+    expect(getLoggerRuntimeState()).toEqual({
+      configuredLevel: 'info',
+      effectiveLevel: 'debug',
+      forcedLevel: null,
+    });
+
+    syncLoggerLevelFromRuntimeConfig('test');
+    expect(getLoggerRuntimeState()).toEqual({
+      configuredLevel: 'info',
+      effectiveLevel: 'info',
+      forcedLevel: null,
+    });
+  });
+
   it('mirrors logs to the configured gateway log file', async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'hybridclaw-logger-'));
     const logPath = path.join(tempDir, 'gateway.log');

--- a/tests/model-response-debug.test.ts
+++ b/tests/model-response-debug.test.ts
@@ -4,6 +4,10 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 import { GATEWAY_DEBUG_MODEL_RESPONSES_ENV } from '../src/gateway/gateway-lifecycle.js';
 import { consumeModelResponseDebugFileLine } from '../src/infra/model-response-debug.js';
 
+const runtimeConfigMock = vi.hoisted(() => ({
+  ops: { debugModelResponses: false },
+}));
+
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
   return {
@@ -17,6 +21,14 @@ vi.mock('node:fs', async (importOriginal) => {
   };
 });
 
+vi.mock('../src/config/config.js', () => ({
+  DATA_DIR: '/tmp/hybridclaw-model-debug-test',
+}));
+
+vi.mock('../src/config/runtime-config.js', () => ({
+  getRuntimeConfig: () => runtimeConfigMock,
+}));
+
 function encodeDebugLine(prefix: string, text: string): string {
   return `${prefix} ${Buffer.from(text, 'utf-8').toString('base64')}`;
 }
@@ -24,6 +36,7 @@ function encodeDebugLine(prefix: string, text: string): string {
 describe('model response debug file consumer', () => {
   afterEach(() => {
     delete process.env[GATEWAY_DEBUG_MODEL_RESPONSES_ENV];
+    runtimeConfigMock.ops.debugModelResponses = false;
     vi.clearAllMocks();
   });
 
@@ -66,5 +79,18 @@ describe('model response debug file consumer', () => {
     expect(fs.mkdirSync).toHaveBeenCalledTimes(2);
     expect(fs.appendFileSync).toHaveBeenCalledTimes(2);
     expect(fs.writeFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  test('writes debug output when enabled in runtime config', async () => {
+    runtimeConfigMock.ops.debugModelResponses = true;
+    vi.clearAllMocks();
+    const modelResponseLine = encodeDebugLine(
+      '[model-response-debug-file]',
+      'data: config\n\n',
+    );
+
+    expect(consumeModelResponseDebugFileLine(modelResponseLine)).toBe(true);
+
+    expect(fs.appendFileSync).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/model-response-debug.test.ts
+++ b/tests/model-response-debug.test.ts
@@ -7,6 +7,7 @@ import { consumeModelResponseDebugFileLine } from '../src/infra/model-response-d
 const runtimeConfigMock = vi.hoisted(() => ({
   ops: { debugModelResponses: false },
 }));
+const loggerWarnMock = vi.hoisted(() => vi.fn());
 
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
@@ -27,6 +28,12 @@ vi.mock('../src/config/config.js', () => ({
 
 vi.mock('../src/config/runtime-config.js', () => ({
   getRuntimeConfig: () => runtimeConfigMock,
+}));
+
+vi.mock('../src/logger.js', () => ({
+  logger: {
+    warn: loggerWarnMock,
+  },
 }));
 
 function encodeDebugLine(prefix: string, text: string): string {
@@ -92,5 +99,28 @@ describe('model response debug file consumer', () => {
     expect(consumeModelResponseDebugFileLine(modelResponseLine)).toBe(true);
 
     expect(fs.appendFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  test('warns once for invalid debug env values', () => {
+    process.env[GATEWAY_DEBUG_MODEL_RESPONSES_ENV] = 'true';
+    vi.clearAllMocks();
+    const modelResponseLine = encodeDebugLine(
+      '[model-response-debug-file]',
+      'data: invalid\n\n',
+    );
+
+    expect(consumeModelResponseDebugFileLine(modelResponseLine)).toBe(true);
+    expect(consumeModelResponseDebugFileLine(modelResponseLine)).toBe(true);
+
+    expect(fs.appendFileSync).not.toHaveBeenCalled();
+    expect(loggerWarnMock).toHaveBeenCalledTimes(1);
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      {
+        envVar: GATEWAY_DEBUG_MODEL_RESPONSES_ENV,
+        expectedValue: '1',
+        value: 'true',
+      },
+      'Ignoring invalid gateway model response debug env value',
+    );
   });
 });


### PR DESCRIPTION
## Summary

Adds a logging mode control to the admin Logs page so operators can switch logging Off, On, or Debug from the console. The control saves runtime config and reloads the gateway so the change takes effect without restarting from the CLI, and the log viewer stays pinned to the newest tail content when logs load or refresh.

## Details

- Adds persisted `ops.logRequests` and `ops.debugModelResponses` flags alongside `ops.logLevel`.
- Wires request logging and model-response debug capture to runtime config while preserving the existing environment/CLI overrides.
- Maps Logs page modes to config values: Off -> silent/no capture, On -> info/no capture, Debug -> debug plus request/model response capture.
- Keeps mode mapping in one typed table and does not treat a manually configured `trace` log level as the Debug mode.
- Treats CLI `--debug` as a startup log level instead of a permanent forced override, so `/admin/logs` can lower the level after a foreground debug start.
- Resyncs the logger from runtime config during admin reload, including the case where the persisted config value did not change.
- Derives the displayed mode from effective runtime logging state so true forced runtime settings are shown as Debug instead of On.
- Auto-scrolls the selected log tail to the end after load or refresh.
- Keeps tailed log content line-aligned when the tail starts mid-file, avoiding partial first lines like a clipped `DEBUG` token.
- Prints full local dates in formatted log timestamps instead of time-of-day only.
- Strips ANSI escape sequences from admin log tails and disables color output when stdout is redirected to `gateway.log`.
- Delays CLI logger construction so foreground gateway runs can attach the configured gateway log file before the logger stream is created.
- Centralizes model-response debug enablement and adds invalid-env-value warnings.
- Checks the gateway reload response before showing the logging update as saved.
- Narrows segmented toggle callbacks so route-level runtime guards and casts are not needed.
- Caches the admin config query briefly while still refreshing logs after save to read the effective post-reload runtime state.
- Updates `config.example.json` and adds backend and console coverage.

## Validation

- `npx vitest run tests/config-reload.integration.test.ts tests/gateway-service.audit.test.ts tests/model-response-debug.test.ts`
- `../node_modules/.bin/vitest run src/routes/logs.test.tsx`
- `./node_modules/.bin/vitest run tests/gateway-http-server.test.ts -t "returns admin log file metadata and selected tail"`
- `./node_modules/.bin/vitest run tests/logger-format.test.ts tests/logger.test.ts`
- `./node_modules/.bin/vitest run tests/logger.test.ts tests/model-response-debug.test.ts tests/gateway-http-server.test.ts -t "returns admin log file metadata and selected tail|reloads gateway config|logger|model response debug"`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/tsc --noEmit -p console/tsconfig.json`

## Notes

A Vite browser smoke test reached the admin auth/connect shell, but without a live gateway API behind the local frontend there was no meaningful Logs page render to inspect.