### PR TITLE
[codex] enforce scoped admin RBAC actions

### DIFF
--- a/docs/content/developer-guide/README.md
+++ b/docs/content/developer-guide/README.md
@@ -21,6 +21,8 @@ These pages focus on how HybridClaw is built and operated under the hood.
   linked-identity boundaries
 - [Secret Threat Model](./threat-model.md) for credential-adjacent feature
   review, model-leakage paths, and PR checklist expectations
+- [ISO 27001 Control Matrix](./iso27001-control-matrix.md) for Annex A evidence
+  mapping, repo-visible gaps, and next evidence to collect
 - [Identity](./identity.md) for canonical user/agent IDs, authority boundaries,
   and discovery records
 - [Workflows](./workflows.md) for declarative YAML workflow schema and validation rules

--- a/docs/content/developer-guide/iso27001-control-matrix.md
+++ b/docs/content/developer-guide/iso27001-control-matrix.md
@@ -1,0 +1,114 @@
+---
+title: ISO 27001 Control Matrix
+description: Working ISO/IEC 27001:2022 Annex A evidence and gap matrix for HybridClaw.
+sidebar_position: 8
+---
+
+# ISO 27001 Control Matrix
+
+This is a working compliance support artifact, not a certification claim. It
+maps repo-visible HybridClaw evidence to ISO/IEC 27001:2022 Annex A control
+areas and highlights the biggest evidence gaps an auditor would ask about.
+
+Control intent is paraphrased. Use the purchased ISO standard for normative
+control wording.
+
+## Scope And Assumptions
+
+- Review date: 2026-06-16.
+- Scope: this repository, bundled docs, CI/CD workflows, and source-visible
+  security controls.
+- Out of scope: company ISMS records, HR records, contracts, cloud account
+  configuration, endpoint management, physical facilities, customer DPAs, and
+  edge proxy/WAF/SIEM settings unless represented in this repo.
+- Status values:
+  - `Evidence`: repo contains concrete implementation or documentation.
+  - `Partial`: repo contains useful evidence, but ISO-ready operating evidence
+    or technical coverage is incomplete.
+  - `Gap`: no sufficient repo-visible evidence.
+  - `Operator evidence`: primarily proven outside the product repo.
+- File and line references are from the checkout reviewed on the date above and
+  should be refreshed after substantive edits.
+
+## Immediate Gap Register
+
+| ID | Priority | Annex A refs | Gap | Repo evidence | Next evidence or control |
+| --- | --- | --- | --- | --- | --- |
+| G-001 | P0 | A.5.1, A.5.8, A.5.35, A.5.36 | No ISO evidence package: no visible Statement of Applicability, ISMS risk register, asset inventory, control owners, review cadence, or effectiveness evidence. | Runtime security docs exist in [`SECURITY.md`](../../../SECURITY.md) and [`TRUST_MODEL.md`](../../../TRUST_MODEL.md). Repo search only found generic "risk register" examples, not an ISMS register. | Create an ISMS evidence folder with SoA, risk register, asset/data inventory, control owner table, evidence calendar, and review sign-off trail. |
+| G-002 | P0 | A.5.15, A.5.16, A.5.18, A.8.2, A.8.3 | Admin RBAC now has route-level actions for scoped sessions, but the ISO gap remains until roles, owners, access reviews, and operator evidence exist. | Broad bearer credentials are still accepted for compatibility in [`src/gateway/gateway-http-server.ts:2046`](../../../src/gateway/gateway-http-server.ts). Scoped admin action names and route mapping live in [`src/security/admin-rbac.ts`](../../../src/security/admin-rbac.ts). | Define admin roles, assign action bundles to roles, document token/session issuance, and add periodic access-review evidence. |
+| G-003 | P0 | A.5.17, A.8.5, A.8.24, A.8.28 | Admin console token handling has high XSS blast radius: tokens are stored in `localStorage`, accepted from query params, and sent in an SSE query string. | Token bootstrap writes `hybridclaw_token` into local storage in [`src/gateway/gateway-http-server.ts:2211`](../../../src/gateway/gateway-http-server.ts). Console token handling is in [`console/src/api/client.ts:264`](../../../console/src/api/client.ts). | Prefer HttpOnly session cookies or short-lived scoped console sessions, remove query-token SSE auth where possible, add CSP and security headers, and document token lifetime/rotation. |
+| G-004 | P1 | A.5.28, A.5.33, A.8.15, A.8.16 | Audit is tamper-evident locally, but not ISO-ready retention/monitoring: no WORM or off-host sink, no SIEM alerting evidence, and admin mutation audit coverage is not mapped end to end. | Hash-chained wire logs are appended in [`src/audit/audit-trail.ts:232`](../../../src/audit/audit-trail.ts). Non-strict audit writes warn on failure in [`src/audit/audit-events.ts:29`](../../../src/audit/audit-events.ts). Runtime docs describe audit verification in [`docs/content/developer-guide/runtime.md`](./runtime.md). | Add an audit coverage matrix, privileged-action event catalog, export/off-host sink, retention policy, alert rules, and verification evidence. |
+| G-005 | P1 | A.5.12, A.5.31, A.5.34, A.8.10, A.8.11, A.8.12, A.8.13 | Data lifecycle is mostly operator-owned. There is no central retention schedule, deletion workflow, data classification register, backup/restore evidence, or PII processing inventory. | [`TRUST_MODEL.md`](../../../TRUST_MODEL.md) says operators are responsible for retention, backup, and deletion. Confidential redaction is configurable and disabled in [`config.example.json:3`](../../../config.example.json). | Add a data inventory, classification labels, retention/deletion policy, backup/restore runbook, privacy register, and testable deletion workflows. |
+| G-006 | P1 | A.5.21, A.8.8, A.8.25, A.8.28, A.8.29 | Supply-chain controls are good for npm but incomplete for container artifacts and application security testing. Docker SBOM and provenance are disabled, and repo-visible SAST/secret-scanning evidence is not present. | npm audit and signature verification are in [`.github/workflows/dependency-audit.yml`](../../../.github/workflows/dependency-audit.yml). Docker release builds set `provenance: false` and `sbom: false` in [`.github/workflows/publish-release.yml:165`](../../../.github/workflows/publish-release.yml). | Enable image SBOM/provenance, add SAST/secret scanning evidence, define vulnerability SLAs, and track remediation through issues/releases. |
+| G-007 | P1 | A.5.19, A.5.20, A.5.21, A.5.22, A.5.23 | Supplier and cloud-service governance is not represented in the repo. HybridClaw integrates with multiple model, channel, and infrastructure services, but no supplier inventory or DPA/security review evidence is visible. | Provider/channel dependencies are visible in [`package.json`](../../../package.json), but supplier risk artifacts are out of repo scope. | Maintain a supplier register with service owner, data categories, legal basis/DPA status, security review, subprocessor review, and exit plan. |
+| G-008 | P2 | A.5.24, A.5.25, A.5.26, A.5.27, A.5.29, A.5.30, A.8.14 | Incident response and business continuity are documented as emergency steps, but not as an exercised program. | Incident steps are in [`SECURITY.md`](../../../SECURITY.md) and [`TRUST_MODEL.md`](../../../TRUST_MODEL.md). | Add severity definitions, escalation contacts, tabletop records, backup/restore tests, RTO/RPO targets, and post-incident review templates. |
+| G-009 | P2 | A.5.17, A.8.24 | Runtime secret encryption is strong, but key custody and rotation policy are not ISO-ready. | Runtime secrets use a master key from env, mounted secret, or local fallback in [`src/security/runtime-secrets.ts:330`](../../../src/security/runtime-secrets.ts), with AES-256-GCM in [`src/security/runtime-secrets.ts:378`](../../../src/security/runtime-secrets.ts). | Define KMS/HSM or mounted-secret guidance, rotation cadence, recovery procedure, break-glass controls, and key-access audit evidence. |
+| G-010 | P2 | A.8.6, A.8.16, A.8.20, A.8.21 | Abuse controls and operational monitoring need runtime evidence. Code has request-size limits and container constraints, but no repo-visible global API throttling, alert thresholds, or capacity plan. | JSON body limits are enforced in [`src/gateway/gateway-http-utils.ts:12`](../../../src/gateway/gateway-http-utils.ts). Container isolation is documented in [`SECURITY.md`](../../../SECURITY.md). | Add production rate-limit policy, capacity metrics, alerting runbooks, and gateway abuse-event audit coverage. |
+
+## Annex A Coverage Matrix
+
+| Annex A area | Status | Repo-visible evidence | Main gap to close |
+| --- | --- | --- | --- |
+| A.5.1-A.5.3 Information security policies, roles, and segregation | Partial | [`SECURITY.md`](../../../SECURITY.md), [`TRUST_MODEL.md`](../../../TRUST_MODEL.md), and the PR template require risk notes and secret-handling review in [`.github/PULL_REQUEST_TEMPLATE.md`](../../../.github/PULL_REQUEST_TEMPLATE.md). | Convert product security docs into an ISMS policy set with named owners, approval dates, review cadence, and role/accountability matrix. |
+| A.5.4-A.5.8 Management responsibilities, external contacts, threat intelligence, and project security | Partial | PR template asks for security-sensitive path notes and failure modes. Secret-adjacent feature review is documented in [`docs/content/developer-guide/threat-model.md`](./threat-model.md). | Add threat-intelligence sources, project security gate criteria, management sign-off, and evidence of recurring review. |
+| A.5.9-A.5.11 Asset inventory, acceptable use, and return of assets | Gap | Product assets and data stores are described across docs, but no ISO asset register is visible. | Create an asset inventory for code, data stores, secrets, CI/CD systems, images, channels, providers, and runtime hosts. |
+| A.5.12-A.5.14 Information classification, labelling, and transfer | Partial | Secret classes and sensitive non-secret data are defined in [`docs/content/developer-guide/threat-model.md`](./threat-model.md). Optional confidential filtering is documented in [`SECURITY.md`](../../../SECURITY.md). | Add organization-wide classification labels, data transfer rules, approved destinations, and evidence that classification drives controls. |
+| A.5.15-A.5.18 Access control, identity, authentication information, and access rights | Partial | Bearer-token API auth is implemented in [`src/gateway/gateway-http-server.ts:2046`](../../../src/gateway/gateway-http-server.ts). Scoped admin route actions are mapped in [`src/security/admin-rbac.ts`](../../../src/security/admin-rbac.ts). | Add access-request/review/revocation evidence, role bundles, token/session issuance procedures, and MFA/IdP expectations for remote admin access. |
+| A.5.19-A.5.23 Supplier relationships and cloud services | Gap | Third-party service dependencies are visible in [`package.json`](../../../package.json) and channel/provider docs. | Maintain supplier and cloud-service registers, security review records, DPA/subprocessor evidence, monitoring, and exit plans. |
+| A.5.24-A.5.30 Incident management and ICT readiness | Partial | Incident steps exist in [`SECURITY.md`](../../../SECURITY.md) and [`TRUST_MODEL.md`](../../../TRUST_MODEL.md). Audit commands are documented in [`docs/content/developer-guide/runtime.md`](./runtime.md). | Add formal incident roles, escalation paths, evidence collection rules, lessons-learned records, continuity tests, and communication templates. |
+| A.5.31-A.5.34 Legal, IP, records, privacy, and PII | Gap | License metadata and product trust docs exist, but no privacy/legal obligation register is visible. | Add legal/register-of-processing evidence, PII inventory, retention schedule, deletion workflow, records ownership, and customer-facing privacy commitments. |
+| A.5.35-A.5.37 Independent review, policy compliance, and procedures | Partial | Automated CI and release checks exist in [`.github/workflows/ci.yml`](../../../.github/workflows/ci.yml). Runtime operating notes exist in docs. | Add independent security review schedule, compliance review evidence, operating procedures, and exception handling. |
+| A.6.1-A.6.8 People controls | Operator evidence | No HR or personnel controls should live in product source by default. | Keep screening, terms, awareness training, disciplinary process, termination/offboarding, confidentiality, remote work, and event reporting evidence in the organization ISMS. |
+| A.7.1-A.7.14 Physical controls | Operator evidence | No facility, office, datacenter, or endpoint physical controls are represented in this repo. | Link the SoA to office/cloud/hosting physical security evidence, visitor controls, secure disposal, and endpoint handling records. |
+| A.8.1-A.8.3 User endpoint devices, privileged rights, and access restriction | Partial | Runtime tool approval tiers are documented in [`SECURITY.md`](../../../SECURITY.md). Scoped admin route actions are enforced for session claims. | Define endpoint hardening expectations for operators and publish role/action bundles for privileged admin capabilities. |
+| A.8.4 Access to source code | Partial | CI requires lint, typecheck, tests, release checks, and Docker preflight in [`.github/workflows/ci.yml`](../../../.github/workflows/ci.yml). | Branch protection, CODEOWNERS, required reviews, and repository permission reviews are not visible in the repo. |
+| A.8.5 Secure authentication | Partial | Gateway auth supports bearer tokens and local web sessions in [`src/gateway/gateway-http-server.ts:2046`](../../../src/gateway/gateway-http-server.ts). | Harden browser token storage, define token rotation and session lifetime policies, and add MFA/SSO evidence for remote administration. |
+| A.8.6 Capacity management | Partial | Container resource constraints are documented in [`SECURITY.md`](../../../SECURITY.md), and request-size limits exist in [`src/gateway/gateway-http-utils.ts:12`](../../../src/gateway/gateway-http-utils.ts). | Add capacity baselines, runtime metrics, load thresholds, and alert response evidence. |
+| A.8.7 Protection against malware | Partial | npm lifecycle scripts are disabled in dependency-audit installs, and Docker isolation is documented. | Add endpoint/runner malware protection evidence and supply-chain scanning coverage beyond npm audit. |
+| A.8.8 Management of technical vulnerabilities | Partial | Scheduled npm audit and signature verification run in [`.github/workflows/dependency-audit.yml`](../../../.github/workflows/dependency-audit.yml). | Add SAST/secret scanning, vulnerability SLAs, triage ownership, remediation tracking, and exception records. |
+| A.8.9 Configuration management | Partial | Example config exists in [`config.example.json`](../../../config.example.json), policy is repo-controlled through `.hybridclaw/policy.yaml`, and CI checks dependency policy. | Add secure configuration baselines, drift checks, configuration owner reviews, and production config evidence. |
+| A.8.10-A.8.12 Information deletion, data masking, and data leakage prevention | Partial | Optional confidential filtering and audit leak scanning are documented in [`SECURITY.md`](../../../SECURITY.md). | Add deletion workflows, retention enforcement, DLP coverage, data masking rules, and privacy test evidence. |
+| A.8.13-A.8.14 Backup and redundancy | Gap | [`TRUST_MODEL.md`](../../../TRUST_MODEL.md) assigns backup and retention responsibility to operators. | Add backup schedule, restore tests, RTO/RPO, redundancy architecture, and owner sign-off. |
+| A.8.15-A.8.16 Logging and monitoring | Partial | Audit wire logs are hash-chained in [`src/audit/audit-trail.ts`](../../../src/audit/audit-trail.ts). Audit commands are documented in [`docs/content/developer-guide/runtime.md`](./runtime.md). | Add off-host retention, monitoring alerts, audit coverage mapping, and procedures for audit failure handling. |
+| A.8.17 Clock synchronization | Operator evidence | No NTP or host time configuration is visible in app code. | Record NTP/time-sync controls for production hosts, CI runners, and log aggregation systems. |
+| A.8.18 Use of privileged utility programs | Partial | Tool blocking and approval controls are documented in [`SECURITY.md`](../../../SECURITY.md). | Inventory privileged utilities, define allowed use cases, and audit high-risk tool execution consistently. |
+| A.8.19 Installation of software on operational systems | Partial | npm release-age, exact-save, shrinkwrap, and dependency verification are documented in [`SECURITY.md`](../../../SECURITY.md). | Add host and runner software-installation policies plus evidence of approved installation paths. |
+| A.8.20-A.8.23 Network controls, network services, segregation, and web filtering | Partial | Container isolation and mount allowlists are documented in [`SECURITY.md`](../../../SECURITY.md). Remote access docs describe token-auth requirements. | Add production network architecture, firewall/egress policy, segmentation, web filtering, and review evidence. |
+| A.8.24 Use of cryptography | Partial | Runtime secrets use AES-256-GCM and local permission controls in [`src/security/runtime-secrets.ts`](../../../src/security/runtime-secrets.ts). | Add cryptographic policy, key custody/rotation/recovery records, algorithm review, and external KMS guidance. |
+| A.8.25-A.8.29 Secure development lifecycle, app security requirements, architecture, coding, and testing | Partial | Threat-model review guidance exists in [`docs/content/developer-guide/threat-model.md`](./threat-model.md). CI runs build, lint, tests, release checks, coverage, and Docker preflight in [`.github/workflows/ci.yml`](../../../.github/workflows/ci.yml). | Add security requirements traceability, SAST/DAST or pen-test evidence, secure coding standard acceptance, and release security sign-off. |
+| A.8.30 Outsourced development | Operator evidence | No outsourced development process is visible in the repo. | Track third-party contributors, contractor access, contractual security terms, review requirements, and offboarding evidence. |
+| A.8.31-A.8.34 Environment separation, change management, test information, and audit testing | Partial | CI separates build/test workflows and the PR template requires validation evidence. | Add production/staging/dev separation evidence, formal change approvals, test-data handling rules, and audit-test procedures. |
+
+## Evidence Package To Build Next
+
+Create these artifacts before treating this matrix as audit-ready:
+
+1. `Statement of Applicability`: each Annex A control with applicable status,
+   justification, implementation summary, owner, evidence link, and residual
+   risk.
+2. `Risk register`: asset, threat, vulnerability, existing control, likelihood,
+   impact, treatment, owner, due date, and review status.
+3. `Asset and data inventory`: source systems, data categories, PII/secrets
+   status, retention period, backup class, owner, supplier, and location.
+4. `Access-control matrix`: roles, permissions, token/session lifetimes, MFA
+   expectations, approval workflow, and periodic review records.
+5. `Audit and monitoring matrix`: event catalog, source, retention, alerting,
+   off-host sink, integrity verification, and incident linkage.
+6. `Supplier register`: model providers, messaging providers, package
+   registries, GitHub/GHCR, CI runners, hosting/cloud services, and subprocessors.
+
+## Engineering Work Items
+
+These are the highest-value code or repo changes that would improve the matrix:
+
+1. Define admin role bundles and access-review evidence for the route-level RBAC
+   action catalog.
+2. Replace or constrain browser-stored admin bearer tokens and remove query-token
+   SSE authentication where feasible.
+3. Add a shared security-header helper for console and API responses, including
+   CSP for the admin console.
+4. Map all privileged mutations to structured audit events and add an off-host
+   audit export path.
+5. Enable Docker image SBOM and provenance for release images.
+6. Add repo-visible SAST and secret-scanning workflows, or document the
+   organization-level tooling that already covers them.

--- a/src/gateway/gateway-admin-secrets.ts
+++ b/src/gateway/gateway-admin-secrets.ts
@@ -2,7 +2,7 @@ import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
 import { getRuntimeConfig } from '../config/runtime-config.js';
 import { GatewayRequestError } from '../errors/gateway-request-error.js';
 import {
-  ADMIN_RBAC_ACTIONS,
+  ADMIN_SECRET_RBAC_ACTIONS,
   type AdminRbacAction,
   isAdminActionAllowed,
 } from '../security/admin-rbac.js';
@@ -38,7 +38,7 @@ export interface AdminSecretAuditContext {
 function resolveAllowedAdminSecretActions(
   sessionPayload: Record<string, unknown> | null,
 ): AdminRbacAction[] {
-  return ADMIN_RBAC_ACTIONS.filter((action) =>
+  return ADMIN_SECRET_RBAC_ACTIONS.filter((action) =>
     isAdminActionAllowed(sessionPayload, action),
   );
 }

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -108,7 +108,11 @@ import {
 import { memoryService } from '../memory/memory-service.js';
 import { listLoadedPluginCommands } from '../plugins/plugin-manager.js';
 import { isPluginInboundWebhookPath } from '../plugins/plugin-webhooks.js';
-import { isAdminActionAllowed } from '../security/admin-rbac.js';
+import {
+  type AdminRbacAction,
+  isAdminActionAllowed,
+  resolveAdminRbacAction,
+} from '../security/admin-rbac.js';
 import { createSecretHandle } from '../security/secret-handles.js';
 import type { SecretInput } from '../security/secret-refs.js';
 import { hardenSecretRef } from '../security/secret-refs.js';
@@ -2132,6 +2136,30 @@ function resolveAdminSecretAuditContext(
     actor: resolveAdminSessionActor(sessionPayload),
     sourceIp: req.socket.remoteAddress || null,
   };
+}
+
+function shouldDeferAdminRbacToHandler(action: AdminRbacAction): boolean {
+  return action.startsWith('secret.');
+}
+
+function isAdminRouteActionAllowed(
+  req: IncomingMessage,
+  action: AdminRbacAction,
+): boolean {
+  return isAdminActionAllowed(getSessionAuthPayload(req), action);
+}
+
+function enforceAdminRouteRbac(
+  req: IncomingMessage,
+  res: ServerResponse,
+  pathname: string,
+  method: string,
+): boolean {
+  const action = resolveAdminRbacAction(pathname, method);
+  if (!action || shouldDeferAdminRbacToHandler(action)) return true;
+  if (isAdminRouteActionAllowed(req, action)) return true;
+  sendJson(res, 403, { error: 'Forbidden.' });
+  return false;
 }
 
 function resolveApiMediaUploadQuotaKey(req: IncomingMessage): string {
@@ -6901,6 +6929,10 @@ export function startGatewayHttpServer(): GatewayHttpServer {
         return;
       }
 
+      if (!enforceAdminRouteRbac(req, res, pathname, method)) {
+        return;
+      }
+
       void (async () => {
         try {
           if (pathname === '/api/events' && method === 'GET') {
@@ -7509,6 +7541,15 @@ export function startGatewayHttpServer(): GatewayHttpServer {
       !requestAuthenticated
     ) {
       writeUpgradeError(socket, 401, 'Unauthorized');
+      return;
+    }
+
+    const terminalStreamAction = resolveAdminRbacAction(url.pathname, 'GET');
+    if (
+      terminalStreamAction &&
+      !isAdminRouteActionAllowed(req, terminalStreamAction)
+    ) {
+      writeUpgradeError(socket, 403, 'Forbidden');
       return;
     }
 

--- a/src/security/admin-rbac.ts
+++ b/src/security/admin-rbac.ts
@@ -112,7 +112,10 @@ export function collectAdminActionClaims(
   return claims;
 }
 
-function hasWildcardClaim(claims: Set<string>, action: AdminRbacAction): boolean {
+function hasWildcardClaim(
+  claims: Set<string>,
+  action: AdminRbacAction,
+): boolean {
   if (claims.has('*')) return true;
   const segments = action.split('.');
   while (segments.length > 0) {

--- a/src/security/admin-rbac.ts
+++ b/src/security/admin-rbac.ts
@@ -1,7 +1,77 @@
-export const ADMIN_RBAC_ACTIONS = [
+export const ADMIN_SECRET_RBAC_ACTIONS = [
   'secret.list_metadata',
   'secret.overwrite',
   'secret.unset',
+] as const;
+
+export const ADMIN_RBAC_ACTIONS = [
+  ...ADMIN_SECRET_RBAC_ACTIONS,
+  'admin.overview.read',
+  'admin.tunnel.reconnect',
+  'admin.statistics.read',
+  'admin.logs.read',
+  'admin.team.read',
+  'admin.team.write',
+  'admin.agents.read',
+  'admin.agents.write',
+  'admin.agents.delete',
+  'admin.hybridai.bots.read',
+  'admin.agent_scoreboard.read',
+  'admin.harness_evolution.read',
+  'admin.models.read',
+  'admin.models.write',
+  'admin.sessions.read',
+  'admin.sessions.delete',
+  'admin.email.read',
+  'admin.email.delete',
+  'admin.scheduler.read',
+  'admin.scheduler.write',
+  'admin.scheduler.delete',
+  'admin.channels.read',
+  'admin.channels.write',
+  'admin.channels.delete',
+  'admin.mcp.read',
+  'admin.mcp.write',
+  'admin.mcp.delete',
+  'admin.config.read',
+  'admin.config.write',
+  'admin.config.reload',
+  'admin.browser_pool.read',
+  'admin.browser_pool.start',
+  'admin.webhook_targets.write',
+  'admin.a2a.read',
+  'admin.a2a.write',
+  'admin.a2a.delete',
+  'admin.fleet.read',
+  'admin.fleet.write',
+  'admin.fleet.delete',
+  'admin.signal.read',
+  'admin.signal.write',
+  'admin.email_config.fetch',
+  'admin.audit.read',
+  'admin.approvals.read',
+  'admin.policy.write',
+  'admin.policy.delete',
+  'admin.tools.read',
+  'admin.plugins.read',
+  'admin.output_guard.read',
+  'admin.output_guard.write',
+  'admin.output_guard.preview',
+  'admin.distill.read',
+  'admin.distill.write',
+  'admin.distill.delete',
+  'admin.skills.read',
+  'admin.skills.write',
+  'admin.skills.unblock',
+  'admin.skills.upload',
+  'admin.jobs.read',
+  'admin.jobs.write',
+  'admin.jobs.delete',
+  'admin.terminal.start',
+  'admin.terminal.stop',
+  'admin.terminal.stream',
+  'admin.gateway.shutdown',
+  'admin.gateway.restart',
 ] as const;
 
 export type AdminRbacAction = (typeof ADMIN_RBAC_ACTIONS)[number];
@@ -42,11 +112,264 @@ export function collectAdminActionClaims(
   return claims;
 }
 
+function hasWildcardClaim(claims: Set<string>, action: AdminRbacAction): boolean {
+  if (claims.has('*')) return true;
+  const segments = action.split('.');
+  while (segments.length > 0) {
+    if (claims.has(`${segments.join('.')}:*`)) return true;
+    segments.pop();
+  }
+  return false;
+}
+
 export function isAdminActionAllowed(
   payload: Record<string, unknown> | null,
   action: AdminRbacAction,
 ): boolean {
   if (!payload) return true;
   const claims = collectAdminActionClaims(payload);
-  return claims?.has(action) === true || claims?.has('secret:*') === true;
+  return (
+    claims?.has(action) === true ||
+    (claims ? hasWildcardClaim(claims, action) : false)
+  );
+}
+
+function actionForReadWriteDelete(
+  method: string,
+  readAction: AdminRbacAction,
+  writeAction: AdminRbacAction,
+  deleteAction?: AdminRbacAction,
+): AdminRbacAction | null {
+  if (method === 'GET') return readAction;
+  if (method === 'POST' || method === 'PUT') return writeAction;
+  if (method === 'DELETE') return deleteAction || writeAction;
+  return null;
+}
+
+function isPathOrChild(pathname: string, prefix: string): boolean {
+  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}
+
+export function resolveAdminRbacAction(
+  pathname: string,
+  rawMethod: string,
+): AdminRbacAction | null {
+  const method = rawMethod.toUpperCase();
+  if (pathname === '/api/admin/overview' && method === 'GET') {
+    return 'admin.overview.read';
+  }
+  if (pathname === '/api/admin/secrets' && method === 'GET') {
+    return 'secret.list_metadata';
+  }
+  if (pathname.startsWith('/api/admin/secrets/')) {
+    if (method === 'PUT') return 'secret.overwrite';
+    if (method === 'DELETE') return 'secret.unset';
+    return null;
+  }
+  if (pathname === '/api/admin/tunnel/reconnect' && method === 'POST') {
+    return 'admin.tunnel.reconnect';
+  }
+  if (pathname === '/api/admin/statistics' && method === 'GET') {
+    return 'admin.statistics.read';
+  }
+  if (pathname === '/api/admin/logs' && method === 'GET') {
+    return 'admin.logs.read';
+  }
+  if (isPathOrChild(pathname, '/api/admin/team-structure')) {
+    if (method === 'GET') return 'admin.team.read';
+    if (method === 'POST') return 'admin.team.write';
+    return null;
+  }
+  if (isPathOrChild(pathname, '/api/admin/agents')) {
+    if (method === 'GET') return 'admin.agents.read';
+    if (method === 'POST' || method === 'PUT') return 'admin.agents.write';
+    if (method === 'DELETE') return 'admin.agents.delete';
+    return null;
+  }
+  if (pathname === '/api/admin/hybridai/bots' && method === 'GET') {
+    return 'admin.hybridai.bots.read';
+  }
+  if (pathname === '/api/admin/agent-scoreboard' && method === 'GET') {
+    return 'admin.agent_scoreboard.read';
+  }
+  if (pathname === '/api/admin/harness-evolution' && method === 'GET') {
+    return 'admin.harness_evolution.read';
+  }
+  if (pathname === '/api/admin/models') {
+    if (method === 'GET') return 'admin.models.read';
+    if (method === 'PUT') return 'admin.models.write';
+    return null;
+  }
+  if (pathname === '/api/admin/sessions') {
+    if (method === 'GET') return 'admin.sessions.read';
+    if (method === 'DELETE') return 'admin.sessions.delete';
+    return null;
+  }
+  if (
+    pathname === '/api/admin/email' ||
+    pathname === '/api/admin/email/messages' ||
+    pathname === '/api/admin/email/message'
+  ) {
+    if (method === 'GET') return 'admin.email.read';
+    if (pathname === '/api/admin/email/message' && method === 'DELETE') {
+      return 'admin.email.delete';
+    }
+    return null;
+  }
+  if (pathname === '/api/admin/scheduler') {
+    if (method === 'GET') return 'admin.scheduler.read';
+    if (method === 'POST' || method === 'PUT') return 'admin.scheduler.write';
+    if (method === 'DELETE') return 'admin.scheduler.delete';
+    return null;
+  }
+  if (pathname === '/api/admin/channels') {
+    return actionForReadWriteDelete(
+      method,
+      'admin.channels.read',
+      'admin.channels.write',
+      'admin.channels.delete',
+    );
+  }
+  if (pathname === '/api/admin/mcp') {
+    return actionForReadWriteDelete(
+      method,
+      'admin.mcp.read',
+      'admin.mcp.write',
+      'admin.mcp.delete',
+    );
+  }
+  if (pathname === '/api/admin/config') {
+    if (method === 'GET') return 'admin.config.read';
+    if (method === 'PUT') return 'admin.config.write';
+    return null;
+  }
+  if (pathname === '/api/admin/config/reload' && method === 'POST') {
+    return 'admin.config.reload';
+  }
+  if (pathname === '/api/admin/browser-pool/health' && method === 'GET') {
+    return 'admin.browser_pool.read';
+  }
+  if (pathname === '/api/admin/browser-pool/start' && method === 'POST') {
+    return 'admin.browser_pool.start';
+  }
+  if (
+    (pathname === '/api/admin/slack-webhook-targets' ||
+      pathname === '/api/admin/discord-webhook-targets') &&
+    (method === 'POST' || method === 'PUT')
+  ) {
+    return 'admin.webhook_targets.write';
+  }
+  if (pathname === '/api/admin/a2a/inbox' && method === 'GET') {
+    return 'admin.a2a.read';
+  }
+  if (pathname === '/api/admin/a2a/trust') {
+    return actionForReadWriteDelete(
+      method,
+      'admin.a2a.read',
+      'admin.a2a.write',
+      'admin.a2a.delete',
+    );
+  }
+  if (pathname === '/api/admin/a2a/pairing/preview' && method === 'POST') {
+    return 'admin.a2a.read';
+  }
+  if (
+    (pathname === '/api/admin/a2a/pairing' ||
+      pathname === '/api/admin/a2a/pairing/approve' ||
+      pathname === '/api/admin/a2a/pairing/decline') &&
+    method === 'POST'
+  ) {
+    return 'admin.a2a.write';
+  }
+  if (pathname === '/api/admin/fleet-topology') {
+    return actionForReadWriteDelete(
+      method,
+      'admin.fleet.read',
+      'admin.fleet.write',
+      'admin.fleet.delete',
+    );
+  }
+  if (pathname === '/api/admin/signal/link') {
+    if (method === 'GET') return 'admin.signal.read';
+    if (method === 'POST') return 'admin.signal.write';
+    return null;
+  }
+  if (pathname === '/api/admin/email-config/fetch' && method === 'GET') {
+    return 'admin.email_config.fetch';
+  }
+  if (pathname === '/api/admin/audit' && method === 'GET') {
+    return 'admin.audit.read';
+  }
+  if (pathname === '/api/admin/approvals' && method === 'GET') {
+    return 'admin.approvals.read';
+  }
+  if (pathname === '/api/admin/policy') {
+    if (method === 'PUT') return 'admin.policy.write';
+    if (method === 'DELETE') return 'admin.policy.delete';
+    return null;
+  }
+  if (pathname === '/api/admin/tools' && method === 'GET') {
+    return 'admin.tools.read';
+  }
+  if (pathname === '/api/admin/plugins' && method === 'GET') {
+    return 'admin.plugins.read';
+  }
+  if (pathname === '/api/admin/output-guard') {
+    if (method === 'GET') return 'admin.output_guard.read';
+    if (method === 'PUT') return 'admin.output_guard.write';
+    return null;
+  }
+  if (pathname === '/api/admin/output-guard/preview' && method === 'POST') {
+    return 'admin.output_guard.preview';
+  }
+  if (isPathOrChild(pathname, '/api/admin/distill')) {
+    if (method === 'GET') return 'admin.distill.read';
+    if (method === 'POST') return 'admin.distill.write';
+    if (method === 'DELETE') return 'admin.distill.delete';
+    return null;
+  }
+  if (pathname === '/api/admin/skills') {
+    if (method === 'GET') return 'admin.skills.read';
+    if (method === 'POST' || method === 'PUT') return 'admin.skills.write';
+    return null;
+  }
+  if (pathname === '/api/admin/skills/unblock' && method === 'POST') {
+    return 'admin.skills.unblock';
+  }
+  if (pathname === '/api/admin/skills/upload' && method === 'POST') {
+    return 'admin.skills.upload';
+  }
+  if (
+    pathname === '/api/admin/jobs/context' ||
+    pathname === '/api/admin/jobs/budgets' ||
+    pathname === '/api/admin/jobs/blocked'
+  ) {
+    return method === 'GET' ? 'admin.jobs.read' : null;
+  }
+  if (pathname === '/api/admin/jobs/edges') {
+    if (method === 'GET') return 'admin.jobs.read';
+    if (method === 'POST') return 'admin.jobs.write';
+    if (method === 'DELETE') return 'admin.jobs.delete';
+    return null;
+  }
+  if (pathname === '/api/admin/jobs/edge-revisions') {
+    if (method === 'GET') return 'admin.jobs.read';
+    if (method === 'POST') return 'admin.jobs.write';
+    return null;
+  }
+  if (pathname === '/api/admin/terminal') {
+    if (method === 'POST') return 'admin.terminal.start';
+    if (method === 'DELETE') return 'admin.terminal.stop';
+    return null;
+  }
+  if (pathname === '/api/admin/terminal/stream' && method === 'GET') {
+    return 'admin.terminal.stream';
+  }
+  if (pathname === '/api/admin/shutdown' && method === 'POST') {
+    return 'admin.gateway.shutdown';
+  }
+  if (pathname === '/api/admin/restart' && method === 'POST') {
+    return 'admin.gateway.restart';
+  }
+  return null;
 }

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -5107,6 +5107,55 @@ describe('gateway HTTP server', () => {
     });
   });
 
+  test('denies scoped admin sessions without the required route action', async () => {
+    const authSecret = 'admin-rbac-deny-auth-secret';
+    const state = await importFreshHealth({ authSecret });
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/admin/config/reload',
+      headers: {
+        cookie: makeSessionCookie(authSecret, {
+          sessionId: 'admin-session-1',
+          actor: 'admin-user',
+          actions: ['admin.overview.read'],
+        }),
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.refreshRuntimeSecretsFromEnv).not.toHaveBeenCalled();
+    expect(state.reloadRuntimeConfig).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Forbidden.' });
+  });
+
+  test('allows scoped admin sessions with a matching wildcard route action', async () => {
+    const authSecret = 'admin-rbac-allow-auth-secret';
+    const state = await importFreshHealth({ authSecret });
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/admin/config/reload',
+      headers: {
+        cookie: makeSessionCookie(authSecret, {
+          sessionId: 'admin-session-1',
+          actor: 'admin-user',
+          scope: 'admin.config:*',
+        }),
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.refreshRuntimeSecretsFromEnv).toHaveBeenCalledTimes(1);
+    expect(state.reloadRuntimeConfig).toHaveBeenCalledWith('admin-api');
+    expect(res.statusCode).toBe(200);
+  });
+
   test('returns admin secret metadata without cleartext values', async () => {
     const authSecret = 'secret-list-auth-secret';
     const state = await importFreshHealth({ authSecret });
@@ -7066,6 +7115,76 @@ describe('gateway HTTP server', () => {
       expect.objectContaining({
         hasSessionAuth: false,
         hasRequestAuth: true,
+        validateToken: expect.any(Function),
+      }),
+    );
+    expect(socket.write).not.toHaveBeenCalled();
+  });
+
+  test('rejects terminal websocket upgrades for scoped sessions without stream access', async () => {
+    const authSecret = 'terminal-rbac-deny-auth-secret';
+    const state = await importFreshHealth({ authSecret });
+    const socket = {
+      write: vi.fn(),
+      destroy: vi.fn(),
+    };
+
+    state.upgradeHandler?.(
+      makeRequest({
+        method: 'GET',
+        url: '/api/admin/terminal/stream?sessionId=terminal-session-1',
+        headers: {
+          cookie: makeSessionCookie(authSecret, {
+            sessionId: 'admin-session-1',
+            actor: 'admin-user',
+            actions: ['admin.audit.read'],
+          }),
+        },
+        noAuth: true,
+      }) as never,
+      socket as never,
+      Buffer.alloc(0) as never,
+    );
+
+    expect(state.handleTerminalUpgrade).not.toHaveBeenCalled();
+    expect(String(socket.write.mock.calls[0]?.[0] || '')).toContain(
+      '403 Forbidden',
+    );
+  });
+
+  test('allows terminal websocket upgrades for scoped sessions with terminal wildcard access', async () => {
+    const authSecret = 'terminal-rbac-allow-auth-secret';
+    const state = await importFreshHealth({ authSecret });
+    const socket = {
+      write: vi.fn(),
+      destroy: vi.fn(),
+    };
+
+    state.upgradeHandler?.(
+      makeRequest({
+        method: 'GET',
+        url: '/api/admin/terminal/stream?sessionId=terminal-session-1',
+        headers: {
+          cookie: makeSessionCookie(authSecret, {
+            sessionId: 'admin-session-1',
+            actor: 'admin-user',
+            scope: 'admin.terminal:*',
+          }),
+        },
+        noAuth: true,
+      }) as never,
+      socket as never,
+      Buffer.alloc(0) as never,
+    );
+
+    expect(state.handleTerminalUpgrade).toHaveBeenCalledWith(
+      expect.anything(),
+      socket,
+      expect.any(Buffer),
+      expect.any(URL),
+      expect.objectContaining({
+        hasSessionAuth: true,
+        hasRequestAuth: false,
         validateToken: expect.any(Function),
       }),
     );


### PR DESCRIPTION
## Summary

- Add a route-level admin RBAC action catalog and resolver for scoped admin session claims.
- Enforce scoped admin actions at the gateway API boundary and terminal WebSocket upgrade path.
- Keep legacy bearer-token behavior as full-admin compatibility, and keep secret mutations on their existing handler-level checks so denied writes still produce specialized audit events.
- Add an ISO 27001 control matrix document and link it from the developer guide.

## User-visible changes

Yes. There are two user-visible effects:

- Documentation: the developer guide now includes an ISO 27001 control matrix with repo-visible evidence, gaps, and next evidence to collect.
- Admin sessions with scoped `actions` or `scope` claims are now restricted across `/api/admin/*` routes and terminal streams. Existing broad bearer tokens remain compatible.

## Validation

- `npx biome check --write src/security/admin-rbac.ts src/gateway/gateway-http-server.ts src/gateway/gateway-admin-secrets.ts tests/gateway-http-server.test.ts docs/content/developer-guide/iso27001-control-matrix.md docs/content/developer-guide/README.md`
- `./node_modules/.bin/vitest run --configLoader runner --project unit tests/gateway-http-server.test.ts` - 303 passed
- `./node_modules/.bin/vitest run --configLoader runner --project unit tests/gateway-admin-secrets.test.ts` - 10 passed
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`

## Risk notes

Security-sensitive paths touched: yes. This changes gateway/admin authorization behavior for scoped session cookies. Compatibility is preserved for existing `WEB_API_TOKEN` and `GATEWAY_API_TOKEN` bearer-token callers because legacy bearer-token auth remains full-admin when no scoped session payload is present.