### PR TITLE
[codex] add guarded session pruning

### DIFF
--- a/docs/content/reference/commands.md
+++ b/docs/content/reference/commands.md
@@ -14,7 +14,7 @@ hybridclaw gateway start [--foreground] [--debug] [--log-requests] [--debug-mode
 hybridclaw gateway restart [--foreground] [--debug] [--log-requests] [--debug-model-responses] [--system-prompt=<parts|none>] [--tools=full|none] [--no-tools] [--sandbox=container|host]
 hybridclaw gateway stop
 hybridclaw gateway status
-hybridclaw gateway sessions [active|clear-active]
+hybridclaw gateway sessions [active|clear-active|prune --older-than <duration> [--dry-run|--confirm]]
 hybridclaw gateway bot info
 hybridclaw gateway voice info
 hybridclaw gateway voice call <number>
@@ -671,7 +671,7 @@ plugins and explicit skill invocations can add dynamic slash commands; use
 | `/schedule add|list|remove|toggle ...` | local and chat channels | Manage scheduled tasks for the session |
 | `/secret [list|set|show|unset|route]` | local TUI/web | Manage encrypted secrets and HTTP auth routes |
 | `/second-opinion [compare|validate|fact-check]` | local and chat channels | Ask a stronger configured model to compare, validate, or fact-check |
-| `/sessions [active|clear-active]` | local and chat channels | Inspect or clear active session tracking |
+| `/sessions [active|clear-active|prune --older-than <duration> [--dry-run|--confirm]]` | local and chat channels | Inspect active session tracking or prune old persisted sessions |
 | `/show [all|thinking|tools|none]` | local and chat channels | Control thinking/tool activity visibility |
 | `/skill ...` or `/<skill>` | local TUI/web | Manage skills or explicitly invoke one skill |
 | `/status` | local and chat channels | Show runtime, session, and agent status |

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -64,7 +64,7 @@ Commands:
   hybridclaw gateway restart [--foreground] [--debug] [--log-requests] [--debug-model-responses] [--system-prompt=<parts|none>] [--tools=full|none] [--no-tools] [--sandbox=container|host]
   hybridclaw gateway stop
   hybridclaw gateway status
-  hybridclaw gateway sessions [active|clear-active]
+  hybridclaw gateway sessions [active|clear-active|prune --older-than <duration> [--dry-run|--confirm]]
   hybridclaw gateway bot info
   hybridclaw gateway voice [info|call <e164-number>]
   hybridclaw gateway show [all|thinking|tools|none]
@@ -178,7 +178,7 @@ Interactive slash commands inside TUI:
   /reset [yes|no]
   /schedule add "<cron>" <prompt> | at "<ISO time>" <prompt> | every <ms> <prompt>
   /secret list   /secret set <name> <value>   /secret show <name>   /secret unset <name>   /secret route ...
-  /sessions [active|clear-active]
+  /sessions [active|clear-active|prune --older-than <duration> [--dry-run|--confirm]]
   /show [all|thinking|tools|none]
   /skill config|list|inspect <name>|inspect --all|runs <name>|install <skill> <dependency>|learn <name> [--apply|--reject|--rollback]|history <name>|unblock <name>|sync [--skip-skill-scan] <source>|import [--force] [--skip-skill-scan] <source>
   /status

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -2316,7 +2316,8 @@ function buildSlashCommandCatalogDefinitions(
     },
     {
       name: 'sessions',
-      description: 'List chat sessions or inspect active sandbox sessions',
+      description:
+        'List chat sessions, inspect active sandbox sessions, or prune old persisted sessions',
     },
     {
       name: 'audit',

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -3826,6 +3826,229 @@ function plainCommand(text: string): GatewayCommandResult {
   return { kind: 'plain', text };
 }
 
+const SESSION_PRUNE_USAGE =
+  'Usage: `sessions prune --older-than <duration> [--dry-run|--confirm]`';
+const SESSION_PRUNE_MIN_AGE_MS = 24 * 60 * 60 * 1000;
+const SESSION_PRUNE_SAMPLE_LIMIT = 20;
+
+interface SessionPruneOptions {
+  olderThanMs: number;
+  olderThanLabel: string;
+  confirm: boolean;
+}
+
+interface SessionPrunePlan {
+  candidates: Array<{
+    session: Session;
+    lastActiveMs: number;
+  }>;
+  cutoffMs: number;
+  invalidTimestampSkipped: number;
+  protectedSkipped: number;
+}
+
+function normalizeSessionPruneDuration(
+  raw: string,
+): { label: string; ms: number } | null {
+  const normalized = String(raw || '')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '');
+  const match = /^(\d+)(h|hour|hours|d|day|days|w|week|weeks)$/.exec(
+    normalized,
+  );
+  if (!match) return null;
+
+  const count = Number.parseInt(match[1], 10);
+  if (!Number.isSafeInteger(count) || count <= 0) return null;
+
+  const unit = match[2];
+  if (unit === 'h' || unit === 'hour' || unit === 'hours') {
+    return { label: `${count}h`, ms: count * 60 * 60 * 1000 };
+  }
+  if (unit === 'd' || unit === 'day' || unit === 'days') {
+    return { label: `${count}d`, ms: count * 24 * 60 * 60 * 1000 };
+  }
+  return { label: `${count}w`, ms: count * 7 * 24 * 60 * 60 * 1000 };
+}
+
+function parseSessionPruneOptions(
+  args: string[],
+): { options: SessionPruneOptions } | { error: string } {
+  let olderThan: { label: string; ms: number } | null = null;
+  let confirm = false;
+  let dryRun = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = String(args[index] || '').trim();
+    if (!arg) continue;
+
+    if (arg === '--confirm') {
+      confirm = true;
+      continue;
+    }
+    if (arg === '--dry-run') {
+      dryRun = true;
+      continue;
+    }
+
+    let olderThanRaw: string | null = null;
+    if (arg.startsWith('--older-than=')) {
+      olderThanRaw = arg.slice('--older-than='.length);
+    } else if (arg === '--older-than') {
+      const next = String(args[index + 1] || '').trim();
+      const afterNext = String(args[index + 2] || '').trim();
+      if (next && /^\d+$/.test(next) && /^[a-zA-Z]+$/.test(afterNext)) {
+        olderThanRaw = `${next}${afterNext}`;
+        index += 2;
+      } else {
+        olderThanRaw = next;
+        index += 1;
+      }
+    }
+
+    if (olderThanRaw != null) {
+      const parsed = normalizeSessionPruneDuration(olderThanRaw);
+      if (!parsed) {
+        return {
+          error:
+            'Invalid `--older-than` value. Use a duration like `90d`, `12w`, or `48h`.',
+        };
+      }
+      olderThan = parsed;
+      continue;
+    }
+
+    return { error: `Unknown sessions prune option: ${arg}` };
+  }
+
+  if (!olderThan) {
+    return { error: 'Missing required `--older-than <duration>` option.' };
+  }
+  if (olderThan.ms < SESSION_PRUNE_MIN_AGE_MS) {
+    return { error: '`--older-than` must be at least 24h.' };
+  }
+  if (confirm && dryRun) {
+    return { error: 'Use either `--dry-run` or `--confirm`, not both.' };
+  }
+
+  return {
+    options: {
+      olderThanMs: olderThan.ms,
+      olderThanLabel: olderThan.label,
+      confirm,
+    },
+  };
+}
+
+function getSessionPruneProtectionReason(
+  session: Session,
+  params: {
+    activeSessionIds: Set<string>;
+    currentSessionId: string;
+  },
+): string | null {
+  if (session.id === params.currentSessionId) return 'current session';
+  if (params.activeSessionIds.has(session.id)) return 'active sandbox session';
+  if (session.full_auto_enabled) return 'full-auto session';
+  if (
+    session.id.startsWith('scheduler:') ||
+    session.channel_id === 'scheduler'
+  ) {
+    return 'scheduler session';
+  }
+  return null;
+}
+
+function buildSessionPrunePlan(params: {
+  activeSessionIds: Set<string>;
+  currentSessionId: string;
+  nowMs: number;
+  olderThanMs: number;
+  sessions: Session[];
+}): SessionPrunePlan {
+  const cutoffMs = params.nowMs - params.olderThanMs;
+  const candidates: SessionPrunePlan['candidates'] = [];
+  let invalidTimestampSkipped = 0;
+  let protectedSkipped = 0;
+
+  for (const session of params.sessions) {
+    const lastActiveMs = parseTimestamp(session.last_active)?.getTime();
+    if (!Number.isFinite(lastActiveMs)) {
+      invalidTimestampSkipped += 1;
+      continue;
+    }
+    if ((lastActiveMs as number) > cutoffMs) continue;
+
+    if (
+      getSessionPruneProtectionReason(session, {
+        activeSessionIds: params.activeSessionIds,
+        currentSessionId: params.currentSessionId,
+      })
+    ) {
+      protectedSkipped += 1;
+      continue;
+    }
+
+    candidates.push({
+      session,
+      lastActiveMs: lastActiveMs as number,
+    });
+  }
+
+  candidates.sort((left, right) => {
+    const byLastActive = left.lastActiveMs - right.lastActiveMs;
+    if (byLastActive !== 0) return byLastActive;
+    return left.session.id.localeCompare(right.session.id);
+  });
+
+  return {
+    candidates,
+    cutoffMs,
+    invalidTimestampSkipped,
+    protectedSkipped,
+  };
+}
+
+function formatSessionPruneSample(plan: SessionPrunePlan): string[] {
+  if (plan.candidates.length === 0) return [];
+  const shown = plan.candidates.slice(0, SESSION_PRUNE_SAMPLE_LIMIT);
+  return [
+    '',
+    'Oldest matched sessions:',
+    ...shown.map(
+      ({ session }) =>
+        `- ${session.id} — ${formatCompactNumber(session.message_count)} msgs, last: ${formatDisplayTimestamp(session.last_active)}`,
+    ),
+    ...(plan.candidates.length > shown.length
+      ? [
+          `...and ${formatCompactNumber(plan.candidates.length - shown.length)} more.`,
+        ]
+      : []),
+  ];
+}
+
+function formatSessionPrunePlanLines(
+  plan: SessionPrunePlan,
+  options: SessionPruneOptions,
+): string[] {
+  return [
+    `Older than: ${options.olderThanLabel}`,
+    `Cutoff: before ${formatDisplayTimestamp(new Date(plan.cutoffMs).toISOString())}`,
+    `Matched: ${formatCompactNumber(plan.candidates.length)} session${plan.candidates.length === 1 ? '' : 's'}`,
+    ...(plan.protectedSkipped > 0
+      ? [
+          `Protected skipped: ${formatCompactNumber(plan.protectedSkipped)} active/current/full-auto/scheduler session${plan.protectedSkipped === 1 ? '' : 's'}`,
+        ]
+      : []),
+    ...(plan.invalidTimestampSkipped > 0
+      ? [
+          `Invalid timestamps skipped: ${formatCompactNumber(plan.invalidTimestampSkipped)}`,
+        ]
+      : []),
+  ];
+}
+
 function normalizeSecretRouteHeader(raw: string | undefined): string {
   const header = String(raw || 'Authorization').trim();
   if (!/^[A-Za-z][A-Za-z0-9-]*$/.test(header)) {
@@ -11844,10 +12067,108 @@ export async function handleGatewayCommand(
             ].join('\n'),
           );
         }
+        if (sub === 'prune') {
+          const parsed = parseSessionPruneOptions(req.args.slice(2));
+          if ('error' in parsed) {
+            return badCommand(
+              'Usage',
+              `${parsed.error}\n${SESSION_PRUNE_USAGE}`,
+            );
+          }
+
+          const activeSessionIds = new Set(getActiveExecutorSessionIds());
+          const plan = buildSessionPrunePlan({
+            activeSessionIds,
+            currentSessionId: session.id,
+            nowMs: Date.now(),
+            olderThanMs: parsed.options.olderThanMs,
+            sessions: getAllSessions(),
+          });
+          const lines = formatSessionPrunePlanLines(plan, parsed.options);
+
+          if (!parsed.options.confirm) {
+            return infoCommand(
+              'Sessions Prune Dry Run',
+              [
+                ...lines,
+                '',
+                'No sessions were deleted.',
+                `Run \`sessions prune --older-than ${parsed.options.olderThanLabel} --confirm\` to delete matched sessions.`,
+                ...formatSessionPruneSample(plan),
+              ].join('\n'),
+            );
+          }
+
+          let deleted = 0;
+          let deletedMessages = 0;
+          let deletedTasks = 0;
+          let deletedSemanticMemories = 0;
+          let deletedUsageEvents = 0;
+          let deletedAuditEntries = 0;
+          let deletedApprovalEntries = 0;
+
+          for (const { session: targetSession } of plan.candidates) {
+            const result = deleteGatewayAdminSession(targetSession.id);
+            if (!result.deleted) continue;
+            deleted += 1;
+            deletedMessages += result.deletedMessages;
+            deletedTasks += result.deletedTasks;
+            deletedSemanticMemories += result.deletedSemanticMemories;
+            deletedUsageEvents += result.deletedUsageEvents;
+            deletedAuditEntries +=
+              result.deletedAuditEntries + result.deletedStructuredAuditEntries;
+            deletedApprovalEntries += result.deletedApprovalEntries;
+          }
+
+          recordAuditEvent({
+            sessionId: session.id,
+            runId: makeAuditRunId('cmd'),
+            event: {
+              type: 'session.prune',
+              source: 'command',
+              olderThan: parsed.options.olderThanLabel,
+              cutoff: new Date(plan.cutoffMs).toISOString(),
+              matchedCount: plan.candidates.length,
+              deletedCount: deleted,
+              protectedSkipped: plan.protectedSkipped,
+              invalidTimestampSkipped: plan.invalidTimestampSkipped,
+              deletedRows: {
+                messages: deletedMessages,
+                tasks: deletedTasks,
+                semanticMemories: deletedSemanticMemories,
+                usageEvents: deletedUsageEvents,
+                auditEntries: deletedAuditEntries,
+                approvals: deletedApprovalEntries,
+              },
+              userId: boundAuditActorField(req.userId),
+              username: boundAuditActorField(req.username),
+            },
+          });
+
+          return infoCommand(
+            'Pruned Sessions',
+            [
+              ...lines,
+              '',
+              `Deleted: ${formatCompactNumber(deleted)} session${deleted === 1 ? '' : 's'}`,
+              `Deleted rows: ${[
+                `${formatCompactNumber(deletedMessages)} messages`,
+                `${formatCompactNumber(deletedTasks)} tasks`,
+                `${formatCompactNumber(deletedSemanticMemories)} semantic memories`,
+                `${formatCompactNumber(deletedUsageEvents)} usage events`,
+                `${formatCompactNumber(deletedAuditEntries)} audit entries`,
+                `${formatCompactNumber(deletedApprovalEntries)} approvals`,
+              ].join(', ')}`,
+            ].join('\n'),
+          );
+        }
         if (sub) {
           return badCommand(
             'Usage',
-            'Usage: `sessions`, `sessions active`, or `sessions clear-active`',
+            `Usage: \`sessions\`, \`sessions active\`, \`sessions clear-active\`, or ${SESSION_PRUNE_USAGE.replace(
+              'Usage: ',
+              '',
+            )}`,
           );
         }
         const sessions = getAllSessions();

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -1299,6 +1299,220 @@ test('sessions command includes abbreviated first and last message snippets', as
   expect(result.text).toContain('" ... "');
 });
 
+test('sessions prune defaults to dry-run and keeps matched sessions', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-06-16T12:00:00.000Z'));
+  vi.resetModules();
+
+  const {
+    getOrCreateSession,
+    getSessionById,
+    initDatabase,
+    storeMessage,
+    withMemoryDatabase,
+  } = await import('../src/memory/db.ts');
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  const oldSession = getOrCreateSession(
+    'session-prune-old-dry-run',
+    null,
+    'web',
+    'main',
+  );
+  storeMessage(
+    oldSession.id,
+    'user_a',
+    'user_a',
+    'user',
+    'Old message retained by dry run.',
+  );
+  withMemoryDatabase((db) => {
+    db.prepare('UPDATE sessions SET last_active = ? WHERE id = ?').run(
+      '2026-01-01T00:00:00.000Z',
+      oldSession.id,
+    );
+  });
+
+  const result = await handleGatewayCommand({
+    sessionId: 'session-prune-command-dry-run',
+    guildId: null,
+    channelId: 'web',
+    args: ['sessions', 'prune', '--older-than', '90d'],
+  });
+
+  expect(result.kind).toBe('info');
+  if (result.kind !== 'info') {
+    throw new Error(`Unexpected result kind: ${result.kind}`);
+  }
+  expect(result.title).toBe('Sessions Prune Dry Run');
+  expect(result.text).toContain('Matched: 1 session');
+  expect(result.text).toContain('No sessions were deleted.');
+  expect(result.text).toContain('session-prune-old-dry-run');
+  expect(getSessionById(oldSession.id)).toBeDefined();
+});
+
+test('sessions prune confirm deletes old sessions and skips protected sessions', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-06-16T12:00:00.000Z'));
+  vi.resetModules();
+  vi.doMock('../src/agent/executor.js', async (importOriginal) => {
+    const actual =
+      await importOriginal<typeof import('../src/agent/executor.js')>();
+    return {
+      ...actual,
+      getActiveExecutorSessionIds: vi.fn(() => ['session-prune-active']),
+    };
+  });
+
+  const {
+    getOrCreateSession,
+    getRecentStructuredAuditForSession,
+    getSessionById,
+    initDatabase,
+    storeMessage,
+    withMemoryDatabase,
+  } = await import('../src/memory/db.ts');
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  const deletedSession = getOrCreateSession(
+    'session-prune-delete',
+    null,
+    'web',
+    'main',
+  );
+  const recentSession = getOrCreateSession(
+    'session-prune-recent',
+    null,
+    'web',
+    'main',
+  );
+  const fullAutoSession = getOrCreateSession(
+    'session-prune-fullauto',
+    null,
+    'web',
+    'main',
+  );
+  const schedulerSession = getOrCreateSession(
+    'scheduler:session-prune',
+    null,
+    'scheduler',
+    'main',
+  );
+  const activeSession = getOrCreateSession(
+    'session-prune-active',
+    null,
+    'web',
+    'main',
+  );
+
+  for (const targetSession of [
+    deletedSession,
+    recentSession,
+    fullAutoSession,
+    schedulerSession,
+    activeSession,
+  ]) {
+    storeMessage(
+      targetSession.id,
+      'user_a',
+      'user_a',
+      'user',
+      `Message for ${targetSession.id}`,
+    );
+  }
+
+  withMemoryDatabase((db) => {
+    const updateLastActive = db.prepare(
+      'UPDATE sessions SET last_active = ? WHERE id = ?',
+    );
+    for (const targetSession of [
+      deletedSession,
+      fullAutoSession,
+      schedulerSession,
+      activeSession,
+    ]) {
+      updateLastActive.run('2026-01-01T00:00:00.000Z', targetSession.id);
+    }
+    updateLastActive.run('2026-06-01T00:00:00.000Z', recentSession.id);
+    db.prepare('UPDATE sessions SET full_auto_enabled = 1 WHERE id = ?').run(
+      fullAutoSession.id,
+    );
+  });
+
+  const result = await handleGatewayCommand({
+    sessionId: 'session-prune-command-confirm',
+    guildId: null,
+    channelId: 'web',
+    args: ['sessions', 'prune', '--older-than=90d', '--confirm'],
+  });
+
+  expect(result.kind).toBe('info');
+  if (result.kind !== 'info') {
+    throw new Error(`Unexpected result kind: ${result.kind}`);
+  }
+  expect(result.title).toBe('Pruned Sessions');
+  expect(result.text).toContain('Matched: 1 session');
+  expect(result.text).toContain('Protected skipped: 3');
+  expect(result.text).toContain('Deleted: 1 session');
+  const auditEvents = getRecentStructuredAuditForSession(
+    'session-prune-command-confirm',
+    10,
+  );
+  expect(auditEvents[0]?.event_type).toBe('session.prune');
+  expect(JSON.parse(auditEvents[0]?.payload || '{}')).toMatchObject({
+    type: 'session.prune',
+    source: 'command',
+    olderThan: '90d',
+    matchedCount: 1,
+    deletedCount: 1,
+    protectedSkipped: 3,
+    invalidTimestampSkipped: 0,
+    deletedRows: {
+      messages: 1,
+    },
+  });
+  expect(getSessionById(deletedSession.id)).toBeUndefined();
+  expect(getSessionById(recentSession.id)).toBeDefined();
+  expect(getSessionById(fullAutoSession.id)).toBeDefined();
+  expect(getSessionById(schedulerSession.id)).toBeDefined();
+  expect(getSessionById(activeSession.id)).toBeDefined();
+});
+
+test('sessions prune rejects retention windows shorter than 24h', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  const result = await handleGatewayCommand({
+    sessionId: 'session-prune-short-window',
+    guildId: null,
+    channelId: 'web',
+    args: ['sessions', 'prune', '--older-than', '1h', '--confirm'],
+  });
+
+  expect(result.kind).toBe('error');
+  if (result.kind !== 'error') {
+    throw new Error(`Unexpected result kind: ${result.kind}`);
+  }
+  expect(result.text).toContain('must be at least 24h');
+});
+
 test('sessions active lists active sandbox sessions and clear-active stops them', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;


### PR DESCRIPTION
## Summary

Adds a guarded `sessions prune` gateway command for cleaning old persisted session history without touching live/runtime-critical sessions.

## What Changed

- Added `sessions prune --older-than <duration>` with dry-run as the default.
- Requires `--confirm` before deleting any session data.
- Supports `h`, `d`, and `w` duration units with a minimum retention window of `24h`.
- Skips the current command session, active sandbox sessions, full-auto sessions, and scheduler sessions.
- Records a structured `session.prune` audit event for confirmed deletion runs.
- Updated CLI help, slash-command registry text, and command reference docs.
- Added gateway command tests for dry-run behavior, confirmed deletion, protected-session skips, audit event coverage, and short-window rejection.

## Why

`doctor database --fix` only cleans safe empty/eval artifacts. Operators also need a first-class, auditable way to prune intentionally retained non-empty sessions by age instead of deleting SQLite rows manually.

## Validation

- `npx vitest run tests/gateway-status.test.ts` passed (`71` tests).
- `./node_modules/.bin/tsc --noEmit --pretty false` passed.
- `git diff --check` passed.
- `npx biome check --write src/gateway/gateway-service.ts src/cli/help.ts src/command-registry.ts tests/gateway-status.test.ts` completed; it reports an existing optional-chain warning in `src/gateway/gateway-service.ts:862` unrelated to this change.