### PR TITLE
[codex] Close ISO 27001 P0 evidence gaps

### DIFF
--- a/console/src/api/client.test.ts
+++ b/console/src/api/client.test.ts
@@ -129,49 +129,44 @@ describe('client command helpers', () => {
     });
   });
 
-  it('removes the local token bootstrap marker after reading stored auth', () => {
+  it('clears legacy browser-stored tokens and URL auth params', () => {
     window.localStorage.clear();
     window.sessionStorage.setItem(TOKEN_STORAGE_KEY, 'stored-token');
     window.history.pushState(
       null,
       '',
-      '/admin?__hybridclaw_token_bootstrapped=1&view=models#top',
+      '/admin?token=query-token&__hybridclaw_token_bootstrapped=1&view=models#top',
     );
 
-    expect(readStoredToken()).toBe('stored-token');
+    expect(readStoredToken()).toBe('');
+    expect(window.sessionStorage.getItem(TOKEN_STORAGE_KEY)).toBeNull();
     expect(window.localStorage.getItem(TOKEN_STORAGE_KEY)).toBeNull();
     expect(window.location.pathname).toBe('/admin');
     expect(window.location.search).toBe('?view=models');
     expect(window.location.hash).toBe('#top');
   });
 
-  it('moves query tokens into session storage and removes them from the URL', () => {
+  it('removes query tokens from the URL without persisting them', () => {
     window.history.pushState(null, '', '/admin?token=query-token&view=models');
 
-    expect(readStoredToken()).toBe('query-token');
-    expect(window.sessionStorage.getItem(TOKEN_STORAGE_KEY)).toBe(
-      'query-token',
-    );
+    expect(readStoredToken()).toBe('');
+    expect(window.sessionStorage.getItem(TOKEN_STORAGE_KEY)).toBeNull();
     expect(window.localStorage.getItem(TOKEN_STORAGE_KEY)).toBeNull();
     expect(window.location.search).toBe('?view=models');
   });
 
-  it('migrates legacy localStorage tokens into session storage', () => {
+  it('clears legacy localStorage tokens without migrating them', () => {
     window.localStorage.setItem(TOKEN_STORAGE_KEY, 'legacy-token');
 
-    expect(readStoredToken()).toBe('legacy-token');
-    expect(window.sessionStorage.getItem(TOKEN_STORAGE_KEY)).toBe(
-      'legacy-token',
-    );
+    expect(readStoredToken()).toBe('');
+    expect(window.sessionStorage.getItem(TOKEN_STORAGE_KEY)).toBeNull();
     expect(window.localStorage.getItem(TOKEN_STORAGE_KEY)).toBeNull();
   });
 
-  it('stores manual tokens in session storage only', () => {
+  it('does not persist manual tokens in browser storage', () => {
     storeToken(' manual-token ');
 
-    expect(window.sessionStorage.getItem(TOKEN_STORAGE_KEY)).toBe(
-      'manual-token',
-    );
+    expect(window.sessionStorage.getItem(TOKEN_STORAGE_KEY)).toBeNull();
     expect(window.localStorage.getItem(TOKEN_STORAGE_KEY)).toBeNull();
 
     clearStoredToken();
@@ -180,8 +175,8 @@ describe('client command helpers', () => {
     expect(window.localStorage.getItem(TOKEN_STORAGE_KEY)).toBeNull();
   });
 
-  it('does not put bearer tokens in the admin events URL', () => {
-    expect(adminEventsUrl('secret-token')).toBe('/api/events');
+  it('does not embed tokens into the admin events stream URL', () => {
+    expect(adminEventsUrl('test-token')).toBe('/api/events');
   });
 
   it('reloads local chat surfaces instead of prompting when auth expires', () => {

--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -263,25 +263,9 @@ export async function requestJson<T>(
 }
 
 export function readStoredToken(): string {
-  const search = new URLSearchParams(window.location.search);
-  const queryToken = (search.get('token') || '').trim();
-  if (queryToken) {
-    window.sessionStorage.setItem(TOKEN_STORAGE_KEY, queryToken);
-    window.localStorage.removeItem(TOKEN_STORAGE_KEY);
-    removeSearchParams(['token', LOCAL_TOKEN_BOOTSTRAP_PARAM]);
-    return queryToken;
-  }
-  removeSearchParams([LOCAL_TOKEN_BOOTSTRAP_PARAM]);
-
-  const sessionToken = window.sessionStorage.getItem(TOKEN_STORAGE_KEY);
-  if (sessionToken) return sessionToken;
-
-  const legacyToken = window.localStorage.getItem(TOKEN_STORAGE_KEY) || '';
-  if (legacyToken) {
-    window.sessionStorage.setItem(TOKEN_STORAGE_KEY, legacyToken);
-    window.localStorage.removeItem(TOKEN_STORAGE_KEY);
-  }
-  return legacyToken;
+  removeSearchParams(['token', LOCAL_TOKEN_BOOTSTRAP_PARAM]);
+  clearStoredToken();
+  return '';
 }
 
 function removeSearchParams(names: string[]): void {
@@ -301,8 +285,8 @@ function removeSearchParams(names: string[]): void {
 }
 
 export function storeToken(token: string): void {
-  window.sessionStorage.setItem(TOKEN_STORAGE_KEY, token.trim());
-  window.localStorage.removeItem(TOKEN_STORAGE_KEY);
+  void token;
+  clearStoredToken();
 }
 
 export function clearStoredToken(): void {
@@ -310,7 +294,8 @@ export function clearStoredToken(): void {
   window.localStorage.removeItem(TOKEN_STORAGE_KEY);
 }
 
-export function adminEventsUrl(_token: string): string {
+export function adminEventsUrl(token: string): string {
+  void token;
   return '/api/events';
 }
 

--- a/console/src/auth.tsx
+++ b/console/src/auth.tsx
@@ -78,15 +78,17 @@ export function AuthProvider(props: { children: ReactNode }) {
                 gatewayStatus,
                 error: null,
               });
-            } catch (error) {
+              return;
+            } catch {
               if (cancelled) return;
-              setState({
-                status: 'prompt',
-                token: '',
-                gatewayStatus: null,
-                error: error instanceof Error ? error.message : null,
-              });
             }
+
+            setState({
+              status: 'prompt',
+              token: '',
+              gatewayStatus: null,
+              error: null,
+            });
             return;
           }
 
@@ -258,9 +260,7 @@ export function AuthProvider(props: { children: ReactNode }) {
 }
 
 export function isAuthReadyForApi(auth: AuthContextValue): boolean {
-  if (auth.status !== 'ready') return false;
-  if (auth.gatewayStatus.webAuthConfigured !== true) return true;
-  return auth.token.trim().length > 0;
+  return auth.status === 'ready';
 }
 
 export function useAuth(): AuthContextValue {

--- a/docs/content/developer-guide/README.md
+++ b/docs/content/developer-guide/README.md
@@ -25,6 +25,8 @@ These pages focus on how HybridClaw is built and operated under the hood.
   mapping, repo-visible gaps, and next evidence to collect
 - [Admin Access Control](./admin-access-control.md) for scoped admin role
   bundles, session claims, and access-review evidence
+- [ISO 27001 Evidence Package](./iso27001/) for SoA, risk register, asset
+  inventory, access control, owners, review cadence, and sign-off trail
 - [Identity](./identity.md) for canonical user/agent IDs, authority boundaries,
   and discovery records
 - [Workflows](./workflows.md) for declarative YAML workflow schema and validation rules

--- a/docs/content/developer-guide/iso27001-control-matrix.md
+++ b/docs/content/developer-guide/iso27001-control-matrix.md
@@ -34,9 +34,9 @@ control wording.
 
 | ID | Priority | Annex A refs | Gap | Repo evidence | Next evidence or control |
 | --- | --- | --- | --- | --- | --- |
-| G-001 | P0 | A.5.1, A.5.8, A.5.35, A.5.36 | No ISO evidence package: no visible Statement of Applicability, ISMS risk register, asset inventory, control owners, review cadence, or effectiveness evidence. | Runtime security docs exist in [`SECURITY.md`](../../../SECURITY.md) and [`TRUST_MODEL.md`](../../../TRUST_MODEL.md). Repo search only found generic "risk register" examples, not an ISMS register. | Create an ISMS evidence folder with SoA, risk register, asset/data inventory, control owner table, evidence calendar, and review sign-off trail. |
-| G-002 | P0 | A.5.15, A.5.16, A.5.18, A.8.2, A.8.3 | Admin RBAC now has route-level actions and code-backed role bundles for scoped sessions, but the ISO gap remains until sessions and tokens are issued through a documented workflow and periodic access reviews exist. | Broad bearer credentials are still accepted for compatibility in [`src/gateway/gateway-http-server.ts:2046`](../../../src/gateway/gateway-http-server.ts). Scoped admin action names, route mapping, and role bundles live in [`src/security/admin-rbac.ts`](../../../src/security/admin-rbac.ts). Role intent and review evidence are documented in [`Admin Access Control`](./admin-access-control.md). | Issue scoped sessions with role claims, record approval/expiration evidence, run quarterly access reviews, and reduce broad bearer-token use to break-glass paths. |
-| G-003 | P0 | A.5.17, A.8.5, A.8.24, A.8.28 | Admin console token handling is partially hardened: signed session cookies can authorize same-origin API calls, manual bearer-token fallback is tab-scoped, and SSE no longer accepts query-token auth. The remaining ISO gap is browser-token lifetime/rotation evidence and full CSP/security-header coverage for the admin console. | Session-cookie API auth is enforced in [`src/gateway/gateway-http-server.ts`](../../../src/gateway/gateway-http-server.ts). Console token fallback uses `sessionStorage` and removes legacy `localStorage` copies in [`console/src/api/client.ts`](../../../console/src/api/client.ts). Admin EventSource URLs omit bearer tokens in [`console/src/hooks/use-live-events.ts`](../../../console/src/hooks/use-live-events.ts). | Add CSP and security headers for the built admin console, define token/session lifetime and rotation policy, and move remaining manual-token flows to short-lived scoped sessions where possible. |
+| G-001 | P1 | A.5.1, A.5.8, A.5.35, A.5.36 | ISO evidence package now exists, but operator review/sign-off and external operating records remain pending. | Working package lives in [`docs/content/developer-guide/iso27001/`](./iso27001/), including SoA, risk register, asset/data inventory, access control, audit/monitoring, owners, evidence calendar, supplier register, and sign-off trail. | Complete management/operator sign-off and attach external evidence references. |
+| G-002 | P1 | A.5.15, A.5.16, A.5.18, A.8.2, A.8.3 | Admin RBAC has route-level actions and role bundles; the remaining gap is real user assignment and periodic access-review evidence. | Scoped action names, route mapping, and role bundles live in [`src/security/admin-rbac.ts`](../../../src/security/admin-rbac.ts). The access-control record is [`docs/content/developer-guide/iso27001/access-control-matrix.md`](./iso27001/access-control-matrix.md). | Record actual admin subjects, role assignments, MFA/SSO evidence, and monthly/quarterly access reviews. |
+| G-003 | Closed | A.5.17, A.8.5, A.8.24, A.8.28 | Admin console token handling was hardened for the repo-visible surfaces in scope. | Local and HybridAI-launched consoles use HttpOnly cookies in [`src/gateway/gateway-http-server.ts`](../../../src/gateway/gateway-http-server.ts). Browser token localStorage/query bootstrap is removed in [`console/src/api/client.ts`](../../../console/src/api/client.ts), `/api/events` no longer accepts query-token auth, and console responses include CSP/security headers. | Prefer signed sessions over manual token entry and keep remote MFA/SSO evidence in the operator ISMS. |
 | G-004 | P1 | A.5.28, A.5.33, A.8.15, A.8.16 | Audit is tamper-evident locally, but not ISO-ready retention/monitoring: no WORM or off-host sink, no SIEM alerting evidence, and admin mutation audit coverage is not mapped end to end. | Hash-chained wire logs are appended in [`src/audit/audit-trail.ts:232`](../../../src/audit/audit-trail.ts). Non-strict audit writes warn on failure in [`src/audit/audit-events.ts:29`](../../../src/audit/audit-events.ts). Runtime docs describe audit verification in [`docs/content/developer-guide/runtime.md`](./runtime.md). | Add an audit coverage matrix, privileged-action event catalog, export/off-host sink, retention policy, alert rules, and verification evidence. |
 | G-005 | P1 | A.5.12, A.5.31, A.5.34, A.8.10, A.8.11, A.8.12, A.8.13 | Data lifecycle is mostly operator-owned. There is no central retention schedule, deletion workflow, data classification register, backup/restore evidence, or PII processing inventory. | [`TRUST_MODEL.md`](../../../TRUST_MODEL.md) says operators are responsible for retention, backup, and deletion. Confidential redaction is configurable and disabled in [`config.example.json:3`](../../../config.example.json). | Add a data inventory, classification labels, retention/deletion policy, backup/restore runbook, privacy register, and testable deletion workflows. |
 | G-006 | P1 | A.5.21, A.8.8, A.8.25, A.8.28, A.8.29 | Supply-chain controls are good for npm but incomplete for container artifacts and application security testing. Docker SBOM and provenance are disabled, and repo-visible SAST/secret-scanning evidence is not present. | npm audit and signature verification are in [`.github/workflows/dependency-audit.yml`](../../../.github/workflows/dependency-audit.yml). Docker release builds set `provenance: false` and `sbom: false` in [`.github/workflows/publish-release.yml:165`](../../../.github/workflows/publish-release.yml). | Enable image SBOM/provenance, add SAST/secret scanning evidence, define vulnerability SLAs, and track remediation through issues/releases. |
@@ -51,9 +51,9 @@ control wording.
 | --- | --- | --- | --- |
 | A.5.1-A.5.3 Information security policies, roles, and segregation | Partial | [`SECURITY.md`](../../../SECURITY.md), [`TRUST_MODEL.md`](../../../TRUST_MODEL.md), and the PR template require risk notes and secret-handling review in [`.github/PULL_REQUEST_TEMPLATE.md`](../../../.github/PULL_REQUEST_TEMPLATE.md). | Convert product security docs into an ISMS policy set with named owners, approval dates, review cadence, and role/accountability matrix. |
 | A.5.4-A.5.8 Management responsibilities, external contacts, threat intelligence, and project security | Partial | PR template asks for security-sensitive path notes and failure modes. Secret-adjacent feature review is documented in [`docs/content/developer-guide/threat-model.md`](./threat-model.md). | Add threat-intelligence sources, project security gate criteria, management sign-off, and evidence of recurring review. |
-| A.5.9-A.5.11 Asset inventory, acceptable use, and return of assets | Gap | Product assets and data stores are described across docs, but no ISO asset register is visible. | Create an asset inventory for code, data stores, secrets, CI/CD systems, images, channels, providers, and runtime hosts. |
+| A.5.9-A.5.11 Asset inventory, acceptable use, and return of assets | Partial | Product assets and data stores are tracked in [`docs/content/developer-guide/iso27001/asset-data-inventory.md`](./iso27001/asset-data-inventory.md). | Add operator endpoint, production host, and personnel asset records. |
 | A.5.12-A.5.14 Information classification, labelling, and transfer | Partial | Secret classes and sensitive non-secret data are defined in [`docs/content/developer-guide/threat-model.md`](./threat-model.md). Optional confidential filtering is documented in [`SECURITY.md`](../../../SECURITY.md). | Add organization-wide classification labels, data transfer rules, approved destinations, and evidence that classification drives controls. |
-| A.5.15-A.5.18 Access control, identity, authentication information, and access rights | Partial | Bearer-token API auth is implemented in [`src/gateway/gateway-http-server.ts:2046`](../../../src/gateway/gateway-http-server.ts). Scoped admin route actions and role bundles are mapped in [`src/security/admin-rbac.ts`](../../../src/security/admin-rbac.ts), with review guidance in [`Admin Access Control`](./admin-access-control.md). | Add access-request/review/revocation records, token/session issuance evidence, and MFA/IdP expectations for remote admin access. |
+| A.5.15-A.5.18 Access control, identity, authentication information, and access rights | Partial | Scoped admin route actions and role bundles are mapped in [`src/security/admin-rbac.ts`](../../../src/security/admin-rbac.ts). Token/session handling and review procedure are documented in [`docs/content/developer-guide/iso27001/access-control-matrix.md`](./iso27001/access-control-matrix.md). | Add access-request/review/revocation evidence and MFA/IdP records for actual admin subjects. |
 | A.5.19-A.5.23 Supplier relationships and cloud services | Gap | Third-party service dependencies are visible in [`package.json`](../../../package.json) and channel/provider docs. | Maintain supplier and cloud-service registers, security review records, DPA/subprocessor evidence, monitoring, and exit plans. |
 | A.5.24-A.5.30 Incident management and ICT readiness | Partial | Incident steps exist in [`SECURITY.md`](../../../SECURITY.md) and [`TRUST_MODEL.md`](../../../TRUST_MODEL.md). Audit commands are documented in [`docs/content/developer-guide/runtime.md`](./runtime.md). | Add formal incident roles, escalation paths, evidence collection rules, lessons-learned records, continuity tests, and communication templates. |
 | A.5.31-A.5.34 Legal, IP, records, privacy, and PII | Gap | License metadata and product trust docs exist, but no privacy/legal obligation register is visible. | Add legal/register-of-processing evidence, PII inventory, retention schedule, deletion workflow, records ownership, and customer-facing privacy commitments. |
@@ -62,7 +62,7 @@ control wording.
 | A.7.1-A.7.14 Physical controls | Operator evidence | No facility, office, datacenter, or endpoint physical controls are represented in this repo. | Link the SoA to office/cloud/hosting physical security evidence, visitor controls, secure disposal, and endpoint handling records. |
 | A.8.1-A.8.3 User endpoint devices, privileged rights, and access restriction | Partial | Runtime tool approval tiers are documented in [`SECURITY.md`](../../../SECURITY.md). Scoped admin route actions and role bundles are enforced for session claims. | Define endpoint hardening expectations for operators and collect privileged access-review evidence. |
 | A.8.4 Access to source code | Partial | CI requires lint, typecheck, tests, release checks, and Docker preflight in [`.github/workflows/ci.yml`](../../../.github/workflows/ci.yml). | Branch protection, CODEOWNERS, required reviews, and repository permission reviews are not visible in the repo. |
-| A.8.5 Secure authentication | Partial | Gateway auth supports bearer tokens, signed session cookies, and local web sessions in [`src/gateway/gateway-http-server.ts`](../../../src/gateway/gateway-http-server.ts). Console fallback tokens are tab-scoped in [`console/src/api/client.ts`](../../../console/src/api/client.ts). | Add CSP/security headers, define token rotation and session lifetime policies, and add MFA/SSO evidence for remote administration. |
+| A.8.5 Secure authentication | Partial | Gateway auth supports bearer tokens, signed session cookies, and local HttpOnly web sessions in [`src/gateway/gateway-http-server.ts`](../../../src/gateway/gateway-http-server.ts). Console token persistence and SSE query-token auth are removed. | Add MFA/SSO evidence for remote administration and operator token/session review records. |
 | A.8.6 Capacity management | Partial | Container resource constraints are documented in [`SECURITY.md`](../../../SECURITY.md), and request-size limits exist in [`src/gateway/gateway-http-utils.ts:12`](../../../src/gateway/gateway-http-utils.ts). | Add capacity baselines, runtime metrics, load thresholds, and alert response evidence. |
 | A.8.7 Protection against malware | Partial | npm lifecycle scripts are disabled in dependency-audit installs, and Docker isolation is documented. | Add endpoint/runner malware protection evidence and supply-chain scanning coverage beyond npm audit. |
 | A.8.8 Management of technical vulnerabilities | Partial | Scheduled npm audit and signature verification run in [`.github/workflows/dependency-audit.yml`](../../../.github/workflows/dependency-audit.yml). | Add SAST/secret scanning, vulnerability SLAs, triage ownership, remediation tracking, and exception records. |
@@ -79,36 +79,27 @@ control wording.
 | A.8.30 Outsourced development | Operator evidence | No outsourced development process is visible in the repo. | Track third-party contributors, contractor access, contractual security terms, review requirements, and offboarding evidence. |
 | A.8.31-A.8.34 Environment separation, change management, test information, and audit testing | Partial | CI separates build/test workflows and the PR template requires validation evidence. | Add production/staging/dev separation evidence, formal change approvals, test-data handling rules, and audit-test procedures. |
 
-## Evidence Package To Build Next
+## Evidence Package To Maintain Next
 
-Create these artifacts before treating this matrix as audit-ready:
+The initial evidence package lives in [`docs/content/developer-guide/iso27001/`](./iso27001/).
+Before treating it as audit-ready, complete these operator records:
 
-1. `Statement of Applicability`: each Annex A control with applicable status,
-   justification, implementation summary, owner, evidence link, and residual
-   risk.
-2. `Risk register`: asset, threat, vulnerability, existing control, likelihood,
-   impact, treatment, owner, due date, and review status.
-3. `Asset and data inventory`: source systems, data categories, PII/secrets
-   status, retention period, backup class, owner, supplier, and location.
-4. `Access-control matrix`: role bundles are documented in
-   [`Admin Access Control`](./admin-access-control.md); still needed are
-   token/session lifetime evidence, MFA expectations, approval workflow records,
-   and periodic review records.
-5. `Audit and monitoring matrix`: event catalog, source, retention, alerting,
+1. Management sign-off for the SoA, control owners, and residual risks.
+2. Actual admin subject inventory, role assignments, MFA/SSO evidence, and
+   access-review records.
+3. Production asset inventory for hosts, endpoints, backups, and network
+   controls outside this repository.
+4. Audit and monitoring matrix with event catalog, source, retention, alerting,
    off-host sink, integrity verification, and incident linkage.
-6. `Supplier register`: model providers, messaging providers, package
-   registries, GitHub/GHCR, CI runners, hosting/cloud services, and subprocessors.
+5. Supplier DPA/security review evidence for enabled providers and channels.
+6. Retention/deletion, backup/restore, and incident tabletop records.
 
 ## Engineering Work Items
 
 These are the highest-value code or repo changes that would improve the matrix:
 
-1. Start issuing scoped admin sessions with the documented role bundles and
-   collect approval, expiration, revocation, and quarterly review evidence.
-2. Add a shared security-header helper for console and API responses, including
-   CSP for the admin console.
-3. Map all privileged mutations to structured audit events and add an off-host
+1. Map all privileged mutations to structured audit events and add an off-host
    audit export path.
-4. Enable Docker image SBOM and provenance for release images.
-5. Add repo-visible SAST and secret-scanning workflows, or document the
+2. Enable Docker image SBOM and provenance for release images.
+3. Add repo-visible SAST and secret-scanning workflows, or document the
    organization-level tooling that already covers them.

--- a/docs/content/developer-guide/iso27001/README.md
+++ b/docs/content/developer-guide/iso27001/README.md
@@ -1,0 +1,45 @@
+---
+title: ISO 27001 Evidence Package
+description: Working ISMS evidence package for HybridClaw ISO/IEC 27001:2022 support.
+sidebar_position: 1
+---
+
+# ISO 27001 Evidence Package
+
+This folder is a working evidence package for ISO/IEC 27001:2022 support. It is
+not a certification claim. It separates repo-visible product controls from
+operator-owned ISMS records that must be completed with real organizational
+owners, dates, approvals, and operating evidence.
+
+## Package Index
+
+| Artifact | Purpose |
+| --- | --- |
+| [Statement of Applicability](./statement-of-applicability.md) | Annex A applicability, implementation status, owners, and evidence links. |
+| [Risk Register](./risk-register.md) | Initial information-security risks, treatment, owners, and due dates. |
+| [Asset And Data Inventory](./asset-data-inventory.md) | Systems, data categories, locations, owners, and retention classes. |
+| [Access-Control Matrix](./access-control-matrix.md) | Admin roles, permissions, session/token handling, and access-review procedure. |
+| [Control Owners](./control-owners.md) | Control ownership and RACI-style responsibilities. |
+| [Evidence Calendar](./evidence-calendar.md) | Required evidence cadence and recurring review schedule. |
+| [Audit And Monitoring Matrix](./audit-monitoring-matrix.md) | Event sources, retention, alerting, and audit-integrity evidence. |
+| [Supplier Register](./supplier-register.md) | Initial supplier/cloud-service inventory and review requirements. |
+| [Review Sign-Off](./review-signoff.md) | Evidence review log and pending operator sign-off trail. |
+
+## Current Evidence State
+
+| Area | State | Notes |
+| --- | --- | --- |
+| Repo evidence package | Created | Initial records are present in this folder and linked from the control matrix. |
+| Admin RBAC | Implemented | Role bundles and scoped action claims are implemented in source. |
+| Console token handling | Implemented | Console no longer persists `WEB_API_TOKEN` in browser storage or sends it in SSE URLs. |
+| Operator sign-off | Pending | Business owners must review and sign the package outside a code-only workflow. |
+
+## Maintenance Rules
+
+- Update these records when security-sensitive code, provider integrations,
+  admin access, audit logging, or data lifecycle behavior changes.
+- Do not store real credentials, customer data, HR records, contracts, or
+  confidential supplier documents in this repository.
+- Link external operator evidence by neutral record identifier, not by secret or
+  private URL.
+- Every quarterly review must update [Review Sign-Off](./review-signoff.md).

--- a/docs/content/developer-guide/iso27001/_category_.json
+++ b/docs/content/developer-guide/iso27001/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "ISO 27001 Evidence",
+  "position": 9,
+  "collapsed": false
+}

--- a/docs/content/developer-guide/iso27001/access-control-matrix.md
+++ b/docs/content/developer-guide/iso27001/access-control-matrix.md
@@ -1,0 +1,45 @@
+---
+title: Access-Control Matrix
+description: Admin RBAC, token/session handling, and access-review evidence for HybridClaw.
+sidebar_position: 5
+---
+
+# Access-Control Matrix
+
+Review date: 2026-06-16.
+
+## Admin Role Bundles
+
+Role bundles are implemented in `src/security/admin-rbac.ts`.
+
+| Role claim | Intended assignee | Permission summary | Review cadence |
+| --- | --- | --- | --- |
+| `admin:owner` | Primary system owner | Full admin action catalog, including secrets and gateway restart/shutdown. | Monthly |
+| `admin:operator` | Runtime operator | Read access plus operational writes, excluding secret overwrite/unset and gateway shutdown. | Quarterly |
+| `admin:auditor` | Auditor/compliance reviewer | Read-only admin, audit, logs, metadata, and secret metadata. | Quarterly |
+| `admin:secret-manager` | Credential custodian | Secret metadata, overwrite, and unset actions only. | Monthly |
+
+## Token And Session Handling
+
+| Surface | Authentication | Storage | Notes |
+| --- | --- | --- | --- |
+| Local loopback console | HttpOnly `hybridclaw_local_session` cookie | Browser cookie, `SameSite=Strict` | Issued only to loopback requests without forwarding headers. |
+| HybridAI-launched console | HttpOnly `hybridclaw_session` cookie | Browser cookie, `SameSite=Lax` | Signed session payload can carry action or role claims. |
+| Manual `WEB_API_TOKEN` entry | Bearer header from in-memory React state | Not persisted in browser storage | Reloading the page requires re-entry. |
+| `/api/events` SSE | Bearer header or cookie auth at request boundary | No query-token auth | Browser EventSource uses same-origin cookies. |
+| Artifact compatibility links | Bearer or query token | URL token for compatibility | Separate from admin SSE; review before external sharing. |
+
+## Access Review Procedure
+
+1. Export or list active admin subjects, role claims, and explicit action claims.
+2. Confirm each subject has a named owner and business need.
+3. Remove stale or overbroad roles, especially `admin:owner` and
+   `admin:secret-manager`.
+4. Record reviewer, date, sampled evidence, exceptions, and remediation due date
+   in [Review Sign-Off](./review-signoff.md).
+
+## Initial Access Review Record
+
+| Date | Reviewer | Scope | Result | Follow-up |
+| --- | --- | --- | --- | --- |
+| 2026-06-16 | Engineering | Repo-visible RBAC model | Role bundles and route-level actions exist in code. | Operator must attach real user/session inventory before audit. |

--- a/docs/content/developer-guide/iso27001/asset-data-inventory.md
+++ b/docs/content/developer-guide/iso27001/asset-data-inventory.md
@@ -1,0 +1,32 @@
+---
+title: Asset And Data Inventory
+description: Initial ISO asset and data inventory for HybridClaw.
+sidebar_position: 4
+---
+
+# Asset And Data Inventory
+
+Review date: 2026-06-16.
+
+| Asset | Type | Data categories | Location | Owner | Classification | Retention class | Backup class |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Source repository | Code | Source, docs, tests, policy | GitHub repository | Engineering Owner | Internal | Repository history | GitHub/operator |
+| Gateway runtime | Service | Messages, tool requests, admin operations | Operator host | Operations Owner | Confidential | Operator-defined | Operator-defined |
+| SQLite memory database | Data store | Sessions, memory, audit indexes, user IDs | `DATA_DIR` | Data Owner | Confidential / PII possible | Operator-defined | Required |
+| Audit wire logs | Log store | Prompts, tool events, approvals, hashes | `data/audit/*/wire.jsonl` | Audit Owner | Confidential | Retain per policy | Required, off-host recommended |
+| Runtime secret store | Secret store | Secret metadata and encrypted values | Operator host / mounted secret | Security Owner | Restricted | Until rotated/deleted | Required with key custody |
+| Container workspace | Execution environment | Workspace files, tool outputs | Docker container mounts | Engineering Owner | Matches source data | Session/workspace lifecycle | Optional |
+| Admin console | Web app | Admin API responses, no persisted web token | Browser + gateway | Access Owner | Confidential | Browser-memory token only | Not applicable |
+| CI workflows | Build system | Build logs, dependency metadata | GitHub Actions | Engineering Owner | Internal | GitHub retention | GitHub/operator |
+| Package registries | Supplier | Published packages, provenance metadata | npm, GHCR | Supplier Owner | Public/Internal | Registry retention | Registry |
+| Provider integrations | Supplier/service | Prompts, responses, provider metadata | Provider APIs | Supplier Owner | Confidential / PII possible | Supplier/operator | Supplier/operator |
+| Channel integrations | Supplier/service | Messages, attachments, identities | Discord, Slack, email, etc. | Supplier Owner | Confidential / PII possible | Supplier/operator | Supplier/operator |
+| Uploaded media cache | Data store | User-provided files/images/audio/video | `DATA_DIR/uploaded-media-cache` | Data Owner | Confidential / PII possible | Operator-defined | Optional/required by use |
+
+## Data Handling Notes
+
+- Secrets must use runtime secret storage or approved external vaults.
+- Browser admin tokens are not persisted by the console. Manual token entry is
+  memory-only; local and HybridAI-launched sessions use HttpOnly cookies.
+- Retention, backup, deletion, and subject-rights workflows need operator
+  records before audit.

--- a/docs/content/developer-guide/iso27001/audit-monitoring-matrix.md
+++ b/docs/content/developer-guide/iso27001/audit-monitoring-matrix.md
@@ -1,0 +1,29 @@
+---
+title: Audit And Monitoring Matrix
+description: Audit event, retention, alerting, and monitoring evidence map for HybridClaw.
+sidebar_position: 8
+---
+
+# Audit And Monitoring Matrix
+
+Review date: 2026-06-16.
+
+| Event/source | Source location | Integrity control | Retention | Alerting | Status |
+| --- | --- | --- | --- | --- | --- |
+| Session wire log | `data/audit/<session>/wire.jsonl` | SHA-256 hash chain | Operator-defined | Operator-defined | Implemented locally |
+| Approval decisions | SQLite `approvals`, audit events | Structured audit rows | Operator-defined | Recommended for denials/red approvals | Implemented locally |
+| Secret metadata list/overwrite/unset | Admin secret handlers | Structured mutation audit | Operator-defined | Recommended for failures and overwrites | Implemented locally |
+| Admin route access | Admin API + RBAC checks | HTTP status and selected audit records | Operator-defined | Needs privileged-action catalog | Partial |
+| Gateway/runtime logs | Structured logger output | Host log controls | Operator-defined | Operator-defined | Partial |
+| Dependency audit | GitHub Actions dependency workflow | CI logs | GitHub retention | GitHub notifications | Partial |
+| Container/image provenance | Release workflow | SBOM/provenance when enabled | Registry/GitHub retention | Registry/GitHub notifications | Open |
+| Off-host security sink | SIEM/WORM/object storage | External append-only control | Security retention policy | SIEM alerts | Open |
+
+## Required Operating Evidence
+
+- Quarterly sample of `hybridclaw audit verify <sessionId>` output.
+- Privileged-action event catalog that maps admin mutations to audit records.
+- Off-host retention configuration and restoration/export test.
+- Alert rules for secret mutation failures, denied approvals, gateway restart,
+  and audit verification failure.
+- Incident linkage showing how audit evidence is preserved during response.

--- a/docs/content/developer-guide/iso27001/control-owners.md
+++ b/docs/content/developer-guide/iso27001/control-owners.md
@@ -1,0 +1,23 @@
+---
+title: Control Owners
+description: Initial control owner map for ISO evidence maintenance.
+sidebar_position: 6
+---
+
+# Control Owners
+
+Review date: 2026-06-16.
+
+| Owner role | Accountable for | Repo-visible responsibility | Operator evidence required |
+| --- | --- | --- | --- |
+| ISMS Owner | ISMS scope, policy approval, SoA, risk acceptance | Maintain this package and control matrix links. | Management approval, review minutes, exceptions. |
+| Security Owner | Secret handling, cryptography, threat model | Maintain `SECURITY.md`, `TRUST_MODEL.md`, secret threat model. | Key custody, rotation, break-glass records. |
+| Engineering Owner | Secure development, CI, source-code controls | Maintain tests, CI, dependency policy, security headers, RBAC code. | Branch protection and repository access review. |
+| Access Owner | Admin access, authentication, privileged roles | Maintain RBAC role bundles and access matrix. | User assignments, MFA/SSO evidence, access reviews. |
+| Audit Owner | Audit integrity, logging, monitoring | Maintain audit code and verification docs. | Off-host sink, retention, alert rules, monitoring review. |
+| Data Owner | Data inventory, retention, deletion, privacy | Maintain data inventory and data-flow notes. | Retention schedule, deletion evidence, PII register. |
+| Supplier Owner | Supplier and cloud service governance | Maintain supplier register structure. | DPA/security review, subprocessors, exit plans. |
+| Operations Owner | Production config, backup, capacity, network controls | Maintain operational docs and examples. | Host config, backups, restore tests, network diagrams. |
+| Incident Owner | Incident response and continuity | Maintain incident steps in `SECURITY.md`. | Tabletop exercises, contacts, post-incident records. |
+| People Owner | HR/personnel controls | None by default. | Screening, training, offboarding, confidentiality. |
+| Facilities Owner | Physical and environmental controls | None by default. | Office/hosting physical security evidence. |

--- a/docs/content/developer-guide/iso27001/evidence-calendar.md
+++ b/docs/content/developer-guide/iso27001/evidence-calendar.md
@@ -1,0 +1,31 @@
+---
+title: Evidence Calendar
+description: Recurring ISO evidence collection and review schedule.
+sidebar_position: 7
+---
+
+# Evidence Calendar
+
+Review date: 2026-06-16.
+
+| Cadence | Evidence | Owner | Record location |
+| --- | --- | --- | --- |
+| Monthly | Admin owner and secret-manager access review | Access Owner | Review sign-off or external access-review record |
+| Monthly | Secret key custody and rotation exceptions | Security Owner | External key-management record |
+| Monthly | Critical/high vulnerability triage | Engineering Owner | Issue tracker or security review record |
+| Quarterly | Full admin RBAC and read-only access review | Access Owner | [Access-Control Matrix](./access-control-matrix.md) and external user inventory |
+| Quarterly | Risk register review | ISMS Owner | [Risk Register](./risk-register.md) |
+| Quarterly | Supplier register review | Supplier Owner | [Supplier Register](./supplier-register.md) |
+| Quarterly | Audit integrity verification sample | Audit Owner | Audit verify output or external evidence store |
+| Quarterly | Backup restore test | Operations Owner | External restore-test record |
+| Semiannual | Incident tabletop | Incident Owner | External tabletop record |
+| Annual | SoA and policy approval | ISMS Owner | [Statement of Applicability](./statement-of-applicability.md), sign-off record |
+| Annual | Independent security review | ISMS Owner | External review report or PR-linked report |
+
+## Next Scheduled Reviews
+
+| Due date | Review | Status |
+| --- | --- | --- |
+| 2026-06-30 | Initial operator sign-off of evidence package | Pending |
+| 2026-07-15 | Audit/off-host logging treatment review | Pending |
+| 2026-07-31 | Supplier and incident-response evidence review | Pending |

--- a/docs/content/developer-guide/iso27001/review-signoff.md
+++ b/docs/content/developer-guide/iso27001/review-signoff.md
@@ -1,0 +1,35 @@
+---
+title: Review Sign-Off
+description: ISO evidence package review and sign-off trail.
+sidebar_position: 10
+---
+
+# Review Sign-Off
+
+Review date: 2026-06-16.
+
+This page records evidence-package reviews. A code change can prepare the
+package, but business acceptance requires a real operator/management reviewer.
+
+| Date | Reviewer | Scope | Decision | Notes |
+| --- | --- | --- | --- | --- |
+| 2026-06-16 | Engineering automation | Initial repo evidence package | Prepared | SoA, risk register, asset inventory, access matrix, owner map, calendar, supplier register, and sign-off trail created. Operator sign-off pending. |
+
+## Pending Sign-Offs
+
+| Sign-off | Required reviewer | Due | Status |
+| --- | --- | --- | --- |
+| ISMS scope and SoA acceptance | ISMS Owner | 2026-06-30 | Pending |
+| Admin role assignment review | Access Owner | 2026-06-30 | Pending |
+| Data inventory and retention acceptance | Data Owner | 2026-07-15 | Pending |
+| Supplier register acceptance | Supplier Owner | 2026-07-31 | Pending |
+| Audit retention and monitoring acceptance | Audit Owner | 2026-07-15 | Pending |
+
+## Review Checklist
+
+- [ ] SoA statuses match current implementation and operator evidence.
+- [ ] Risk treatments have owners and due dates.
+- [ ] Asset inventory includes current production deployment components.
+- [ ] Admin role assignments match actual users and service accounts.
+- [ ] Supplier register reflects enabled providers and channels.
+- [ ] Exceptions have documented acceptance or remediation dates.

--- a/docs/content/developer-guide/iso27001/risk-register.md
+++ b/docs/content/developer-guide/iso27001/risk-register.md
@@ -1,0 +1,25 @@
+---
+title: Risk Register
+description: Initial ISMS risk register for HybridClaw.
+sidebar_position: 3
+---
+
+# Risk Register
+
+Review date: 2026-06-16.
+
+Scoring uses `Low`, `Medium`, and `High` until the operator adopts a formal
+likelihood/impact scale.
+
+| ID | Risk | Assets | Existing controls | Rating | Treatment | Owner | Due | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| R-001 | Missing ISMS operating records could block audit readiness. | ISMS records, product security docs | This evidence package and control matrix | High | Maintain SoA, risk register, owner table, evidence calendar, and sign-off records. | ISMS Owner | 2026-06-30 | In progress |
+| R-002 | Overbroad admin access could allow unauthorized privileged changes. | Admin API, runtime config, secrets metadata | Route-level RBAC, role bundles, session claims | High | Use named roles, review access quarterly, revoke stale sessions/tokens. | Access Owner | 2026-06-30 | In progress |
+| R-003 | Browser-readable admin tokens could be stolen through XSS. | Admin console, `WEB_API_TOKEN` | HttpOnly cookies for local/session auth, no token localStorage, no SSE query tokens, CSP | Medium | Keep manual token entry memory-only and prefer signed sessions. | Access Owner | 2026-06-16 | Treated in repo |
+| R-004 | Local audit logs could be deleted or altered by host compromise. | Audit wire logs, SQLite audit tables | Hash chaining, verify command | High | Add off-host/WORM export and alerting. | Audit Owner | 2026-07-15 | Open |
+| R-005 | Data retention/deletion obligations could be missed. | Session transcripts, memory DB, uploaded media | Trust model assigns operator responsibility | High | Define retention schedule and deletion workflow with tests. | Data Owner | 2026-07-15 | Open |
+| R-006 | Supplier or model-provider terms may not match data handling needs. | Provider APIs, channel providers, registries | Supplier register created | Medium | Complete DPA/security review and exit plan per supplier. | Supplier Owner | 2026-07-31 | Open |
+| R-007 | Container or package supply-chain compromise could affect runtime integrity. | npm packages, Docker image, GHCR | npm lockfiles, release-age policy, audit signatures | Medium | Enable image SBOM/provenance and SAST/secret scanning. | Engineering Owner | 2026-07-15 | Open |
+| R-008 | Incident response may be slow without exercised roles and contact paths. | Gateway runtime, data stores, credentials | SECURITY incident steps | Medium | Run tabletop, record severity matrix, contacts, and post-incident template. | Incident Owner | 2026-07-31 | Open |
+| R-009 | Secret-store master key loss or disclosure could affect credential access. | Runtime secret store | AES-256-GCM, local permission controls | High | Define key custody, rotation, recovery, and break-glass process. | Security Owner | 2026-07-15 | Open |
+| R-010 | Insufficient monitoring could delay abuse or capacity detection. | Gateway API, containers, channels | Request-size limits, resource constraints | Medium | Define rate limits, metrics, thresholds, and alert response. | Operations Owner | 2026-07-31 | Open |

--- a/docs/content/developer-guide/iso27001/statement-of-applicability.md
+++ b/docs/content/developer-guide/iso27001/statement-of-applicability.md
@@ -1,0 +1,45 @@
+---
+title: Statement of Applicability
+description: Working ISO/IEC 27001:2022 Annex A applicability statement for HybridClaw.
+sidebar_position: 2
+---
+
+# Statement of Applicability
+
+Review date: 2026-06-16.
+
+This SoA uses grouped Annex A control areas to match the public control matrix.
+The purchased ISO standard remains the normative source for individual control
+wording.
+
+| Annex A area | Applicable | Owner | Implementation status | Evidence | Residual risk |
+| --- | --- | --- | --- | --- | --- |
+| A.5.1-A.5.3 Policies, roles, segregation | Yes | ISMS Owner | Partial | `SECURITY.md`, `TRUST_MODEL.md`, [Control Owners](./control-owners.md) | Formal management approval remains operator-owned. |
+| A.5.4-A.5.8 Management, contacts, threat intelligence, project security | Yes | ISMS Owner | Partial | PR template, threat model, [Evidence Calendar](./evidence-calendar.md) | Threat-intel source review needs recurring records. |
+| A.5.9-A.5.11 Asset inventory, acceptable use, return of assets | Yes | Asset Owner | Partial | [Asset And Data Inventory](./asset-data-inventory.md) | Endpoint and personnel asset records are external. |
+| A.5.12-A.5.14 Classification, labelling, transfer | Yes | Data Owner | Partial | Threat model secret classes, [Asset And Data Inventory](./asset-data-inventory.md) | Organization-wide labels need operator adoption. |
+| A.5.15-A.5.18 Access control and authentication information | Yes | Access Owner | Partial | [Access-Control Matrix](./access-control-matrix.md), `src/security/admin-rbac.ts` | Periodic access review evidence must be collected. |
+| A.5.19-A.5.23 Supplier and cloud services | Yes | Supplier Owner | Partial | [Supplier Register](./supplier-register.md) | DPA and supplier security reviews are external. |
+| A.5.24-A.5.30 Incident management and ICT readiness | Yes | Incident Owner | Partial | `SECURITY.md`, `TRUST_MODEL.md`, [Evidence Calendar](./evidence-calendar.md) | Tabletop and continuity exercises need records. |
+| A.5.31-A.5.34 Legal, IP, records, privacy, PII | Yes | Privacy Owner | Partial | [Asset And Data Inventory](./asset-data-inventory.md) | Legal obligations and processing register are operator-owned. |
+| A.5.35-A.5.37 Independent review, compliance, procedures | Yes | ISMS Owner | Partial | CI workflows, [Review Sign-Off](./review-signoff.md) | Independent review evidence is pending. |
+| A.6.1-A.6.8 People controls | Yes | People Owner | Operator evidence | [Control Owners](./control-owners.md) | HR records stay outside this repo. |
+| A.7.1-A.7.14 Physical controls | Yes | Facilities Owner | Operator evidence | [Control Owners](./control-owners.md) | Facilities and hosting evidence stay outside this repo. |
+| A.8.1-A.8.3 Endpoint devices, privileged rights, access restriction | Yes | Access Owner | Partial | [Access-Control Matrix](./access-control-matrix.md), approval policy docs | Endpoint hardening evidence is external. |
+| A.8.4 Source-code access | Yes | Engineering Owner | Partial | CI workflows, PR template | Branch protection and repository permission review evidence is external. |
+| A.8.5 Secure authentication | Yes | Access Owner | Partial | HttpOnly session cookies, no browser token persistence, [Access-Control Matrix](./access-control-matrix.md) | Remote MFA/SSO evidence remains operator-owned. |
+| A.8.6 Capacity management | Yes | Operations Owner | Partial | Request-size limits, container resource docs | Production metrics and thresholds need operating records. |
+| A.8.7 Malware protection | Yes | Operations Owner | Partial | Docker isolation, npm install controls | Runner/endpoint malware evidence is external. |
+| A.8.8 Technical vulnerabilities | Yes | Engineering Owner | Partial | Dependency audit workflow | SAST/secret scanning evidence and SLAs need completion. |
+| A.8.9 Configuration management | Yes | Operations Owner | Partial | `config.example.json`, `.hybridclaw/policy.yaml` | Production drift review evidence is external. |
+| A.8.10-A.8.12 Deletion, masking, DLP | Yes | Data Owner | Partial | Confidential filter, audit leak scanner | Retention/deletion procedure needs operator execution records. |
+| A.8.13-A.8.14 Backup and redundancy | Yes | Operations Owner | Operator evidence | `TRUST_MODEL.md` responsibility assignment | Backup/restore tests are external. |
+| A.8.15-A.8.16 Logging and monitoring | Yes | Audit Owner | Partial | Hash-chained audit logs, runtime docs | Off-host sink and alert records remain open. |
+| A.8.17 Clock synchronization | Yes | Operations Owner | Operator evidence | [Evidence Calendar](./evidence-calendar.md) | Host NTP evidence is external. |
+| A.8.18 Privileged utility programs | Yes | Access Owner | Partial | Approval policy docs, tool blocking | Privileged utility inventory needs recurring review. |
+| A.8.19 Software installation | Yes | Engineering Owner | Partial | npm release-age and lockfile policy | Host install policy evidence is external. |
+| A.8.20-A.8.23 Network controls | Yes | Operations Owner | Partial | Container isolation, mount allowlists | Production network diagrams and firewall reviews are external. |
+| A.8.24 Cryptography | Yes | Security Owner | Partial | Runtime secrets AES-256-GCM docs/source | KMS/key custody records are external. |
+| A.8.25-A.8.29 Secure development | Yes | Engineering Owner | Partial | Threat-model guidance, CI tests | Security test traceability and release sign-off need records. |
+| A.8.30 Outsourced development | Conditional | People Owner | Operator evidence | [Control Owners](./control-owners.md) | Contractor evidence required only when used. |
+| A.8.31-A.8.34 Environment separation, change, test info, audit testing | Yes | Engineering Owner | Partial | CI separation, PR validation | Production environment and change-approval evidence is external. |

--- a/docs/content/developer-guide/iso27001/supplier-register.md
+++ b/docs/content/developer-guide/iso27001/supplier-register.md
@@ -1,0 +1,20 @@
+---
+title: Supplier Register
+description: Initial supplier and cloud-service register for HybridClaw.
+sidebar_position: 9
+---
+
+# Supplier Register
+
+Review date: 2026-06-16.
+
+| Supplier/service | Use | Data categories | Owner | Review evidence needed | Exit plan |
+| --- | --- | --- | --- | --- | --- |
+| GitHub | Source control, issues, CI, releases | Source, build logs, issue metadata | Supplier Owner | Org security settings, branch protection, app permissions | Mirror repository and export releases/issues. |
+| npm registry | Package publishing and dependency retrieval | Package metadata, provenance | Engineering Owner | Trusted publishing, tokenless publish evidence | Publish freeze and alternate registry/cache. |
+| GHCR/Docker registry | Container image distribution | Image metadata, SBOM/provenance when enabled | Engineering Owner | Image provenance/SBOM settings | Rebuild and publish to alternate registry. |
+| HybridAI | Model/API provider | Prompts, responses, account metadata | Supplier Owner | DPA/security review, data-processing settings | Switch provider config or self-hosted provider. |
+| OpenAI/Anthropic/other model providers | Optional model providers | Prompts, responses, account metadata | Supplier Owner | DPA/security review per provider | Disable provider and rotate credentials. |
+| Discord/Slack/Telegram/email/WhatsApp/MSTeams | Optional channels | Messages, files, user identifiers | Supplier Owner | DPA/security review per enabled channel | Disable channel and export relevant records. |
+| Cloud/hosting provider | Operator deployment | Runtime data, logs, backups | Operations Owner | Hosting security controls, location, backup evidence | Restore backup to alternate host. |
+| Package dependencies | Runtime and build dependencies | Code executed in build/runtime | Engineering Owner | Dependency review, vulnerability triage | Pin, patch, replace, or vendor reviewed code. |

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -356,7 +356,6 @@ const DISCORD_MEDIA_CACHE_DIR = path.resolve(
 );
 const MAX_MEDIA_UPLOAD_BYTES = 20 * 1024 * 1024;
 const HYBRIDAI_LOGIN_PATH = '/login?context=hybridclaw&next=/admin_api_keys';
-const LOCAL_TOKEN_BOOTSTRAP_PARAM = '__hybridclaw_token_bootstrapped';
 
 const SITE_MIME_TYPES: Record<string, string> = {
   '.css': 'text/css; charset=utf-8',
@@ -1998,9 +1997,7 @@ function extractHostnameFromHostHeader(
 }
 
 function isLocalWebSessionAllowed(req: IncomingMessage): boolean {
-  return (
-    !WEB_API_TOKEN && isLoopbackHost(HEALTH_HOST) && isLoopbackWebRequest(req)
-  );
+  return isLoopbackHost(HEALTH_HOST) && isLoopbackWebRequest(req);
 }
 
 function isLoopbackWebRequest(req: IncomingMessage): boolean {
@@ -2009,15 +2006,6 @@ function isLoopbackWebRequest(req: IncomingMessage): boolean {
     isLoopbackSocketAddress(req.socket.remoteAddress) &&
     !hasForwardingHeaders(req) &&
     Boolean(requestHost && isLoopbackHost(requestHost))
-  );
-}
-
-function shouldBootstrapLocalWebToken(req: IncomingMessage, url: URL): boolean {
-  return (
-    Boolean(WEB_API_TOKEN) &&
-    isConsoleSpaPath(url.pathname) &&
-    !url.searchParams.has(LOCAL_TOKEN_BOOTSTRAP_PARAM) &&
-    isLoopbackWebRequest(req)
   );
 }
 
@@ -2196,40 +2184,6 @@ function dispatchWebhookRoute(
 function sendText(res: ServerResponse, statusCode: number, text: string): void {
   res.writeHead(statusCode, { 'Content-Type': 'text/plain; charset=utf-8' });
   res.end(text);
-}
-
-function sendWebTokenBootstrap(
-  res: ServerResponse,
-  params: {
-    redirectTo: string;
-    userId?: string;
-  },
-): void {
-  const escapedToken = escapeInlineScriptValue(WEB_API_TOKEN);
-  const escapedRedirect = escapeInlineScriptValue(params.redirectTo);
-  const escapedUserId = escapeInlineScriptValue(params.userId || '');
-  res.writeHead(200, {
-    'Content-Type': 'text/html; charset=utf-8',
-    'Cache-Control': 'no-store',
-    'Content-Security-Policy': "default-src 'none'; script-src 'unsafe-inline'",
-    'X-Content-Type-Options': 'nosniff',
-  });
-  res.end(
-    `<!DOCTYPE html><html><body><script>` +
-      `sessionStorage.setItem('hybridclaw_token',${escapedToken});` +
-      `localStorage.removeItem('hybridclaw_token');` +
-      `if (${escapedUserId}) sessionStorage.setItem('hybridclaw_user_id',${escapedUserId});` +
-      `window.location.replace(${escapedRedirect});` +
-      `</script></body></html>`,
-  );
-}
-
-function sendLocalWebTokenBootstrap(res: ServerResponse, url: URL): void {
-  const redirectUrl = new URL(url);
-  redirectUrl.searchParams.set(LOCAL_TOKEN_BOOTSTRAP_PARAM, '1');
-  sendWebTokenBootstrap(res, {
-    redirectTo: `${redirectUrl.pathname}${redirectUrl.search}`,
-  });
 }
 
 function sendRedirect(
@@ -2859,11 +2813,21 @@ function serveConsoleFile(
   if (!filePath) return false;
   const ext = path.extname(filePath).toLowerCase();
   const mimeType = SITE_MIME_TYPES[ext] || 'application/octet-stream';
+  const isIndex = filePath.endsWith('index.html');
   res.writeHead(200, {
     'Content-Type': mimeType,
-    'Cache-Control': filePath.endsWith('index.html')
+    'Cache-Control': isIndex
       ? 'no-cache'
       : 'public, max-age=31536000, immutable',
+    'X-Content-Type-Options': 'nosniff',
+    'Referrer-Policy': 'no-referrer',
+    'Cross-Origin-Opener-Policy': 'same-origin',
+    ...(isIndex
+      ? {
+          'Content-Security-Policy':
+            "default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data: blob:; media-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ws: wss:",
+        }
+      : {}),
   });
   res.end(fs.readFileSync(filePath));
   return true;
@@ -7463,11 +7427,6 @@ export function startGatewayHttpServer(): GatewayHttpServer {
     }
 
     if (requiresSessionAuth(pathname) && !ensureSessionAuth(req, res)) {
-      return;
-    }
-
-    if (shouldBootstrapLocalWebToken(req, url)) {
-      sendLocalWebTokenBootstrap(res, url);
       return;
     }
 

--- a/src/security/admin-rbac.ts
+++ b/src/security/admin-rbac.ts
@@ -107,6 +107,11 @@ const ADMIN_READ_ACTIONS = [
   'admin.jobs.read',
 ] as const satisfies readonly AdminRbacAction[];
 
+const ADMIN_AUDITOR_ACTIONS = [
+  ...ADMIN_READ_ACTIONS,
+  'secret.list_metadata',
+] as const satisfies readonly AdminRbacAction[];
+
 export const ADMIN_RBAC_ROLE_ACTIONS = {
   'admin.viewer': ADMIN_READ_ACTIONS,
   'admin.operator': [
@@ -169,6 +174,54 @@ export const ADMIN_RBAC_ROLE_ACTIONS = {
     'admin.terminal.stream',
   ],
   'admin.full': ADMIN_RBAC_ACTIONS,
+  'admin:owner': ADMIN_RBAC_ACTIONS,
+  'admin:operator': [
+    ...ADMIN_AUDITOR_ACTIONS,
+    'admin.tunnel.reconnect',
+    'admin.team.write',
+    'admin.agents.write',
+    'admin.models.write',
+    'admin.sessions.delete',
+    'admin.email.delete',
+    'admin.scheduler.write',
+    'admin.scheduler.delete',
+    'admin.channels.write',
+    'admin.channels.delete',
+    'admin.mcp.write',
+    'admin.mcp.delete',
+    'admin.config.reload',
+    'admin.browser_pool.start',
+    'admin.webhook_targets.write',
+    'admin.a2a.write',
+    'admin.a2a.delete',
+    'admin.fleet.write',
+    'admin.fleet.delete',
+    'admin.signal.write',
+    'admin.policy.write',
+    'admin.policy.delete',
+    'admin.output_guard.write',
+    'admin.output_guard.preview',
+    'admin.distill.write',
+    'admin.distill.delete',
+    'admin.skills.write',
+    'admin.skills.unblock',
+    'admin.skills.upload',
+    'admin.jobs.write',
+    'admin.jobs.delete',
+    'admin.terminal.start',
+    'admin.terminal.stop',
+    'admin.terminal.stream',
+    'admin.gateway.restart',
+  ],
+  'admin:auditor': ADMIN_AUDITOR_ACTIONS,
+  'admin:secret-manager': ADMIN_SECRET_RBAC_ACTIONS,
+} as const satisfies Record<string, readonly AdminRbacAction[]>;
+
+export const ADMIN_RBAC_ROLE_BUNDLES = {
+  'admin:auditor': ADMIN_RBAC_ROLE_ACTIONS['admin:auditor'],
+  'admin:operator': ADMIN_RBAC_ROLE_ACTIONS['admin:operator'],
+  'admin:owner': ADMIN_RBAC_ROLE_ACTIONS['admin:owner'],
+  'admin:secret-manager': ADMIN_RBAC_ROLE_ACTIONS['admin:secret-manager'],
 } as const satisfies Record<string, readonly AdminRbacAction[]>;
 
 export type AdminRbacRole = keyof typeof ADMIN_RBAC_ROLE_ACTIONS;
@@ -205,9 +258,9 @@ function isAdminRbacRole(value: string): value is AdminRbacRole {
 
 export function collectAdminRoleClaims(
   payload: Record<string, unknown> | null,
-): Set<string> | null {
-  if (!payload) return null;
+): Set<string> {
   const roles = new Set<string>();
+  if (!payload) return roles;
   addStringClaims(roles, readClaimValue(payload, 'role'), /[,\s]+/);
   addStringClaims(roles, readClaimValue(payload, 'roles'), /[,\s]+/);
   return roles;
@@ -221,17 +274,14 @@ export function collectAdminActionClaims(
 
   addStringClaims(claims, readClaimValue(payload, 'actions'), /[,\s]+/);
 
-  for (const role of collectAdminRoleClaims(payload) || []) {
+  for (const role of collectAdminRoleClaims(payload)) {
     if (!isAdminRbacRole(role)) continue;
     for (const action of ADMIN_RBAC_ROLE_ACTIONS[role]) {
       claims.add(action);
     }
   }
 
-  const scope = readClaimValue(payload, 'scope');
-  if (typeof scope === 'string') {
-    addStringClaims(claims, scope, /\s+/);
-  }
+  addStringClaims(claims, readClaimValue(payload, 'scope'), /\s+/);
 
   return claims;
 }

--- a/tests/admin-rbac.test.ts
+++ b/tests/admin-rbac.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest';
 import {
   ADMIN_RBAC_ACTIONS,
   ADMIN_RBAC_ROLE_ACTIONS,
+  ADMIN_RBAC_ROLE_BUNDLES,
   collectAdminActionClaims,
   collectAdminRoleClaims,
   isAdminActionAllowed,
@@ -16,6 +17,10 @@ describe('admin RBAC role bundles', () => {
         expect(actionCatalog.has(action)).toBe(true);
       }
     }
+  });
+
+  test('keeps legacy bearer-token requests fully authorized without session claims', () => {
+    expect(isAdminActionAllowed(null, 'admin.config.write')).toBe(true);
   });
 
   test('expands config manager role claims into route actions', () => {
@@ -47,5 +52,52 @@ describe('admin RBAC role bundles', () => {
     );
     expect(isAdminActionAllowed(payload, 'admin.overview.read')).toBe(true);
     expect(isAdminActionAllowed(payload, 'admin.config.reload')).toBe(false);
+  });
+
+  test('expands auditor role claims into read-only actions', () => {
+    const payload = { roles: ['admin:auditor'] };
+
+    expect(collectAdminRoleClaims(payload)).toEqual(
+      new Set(['admin:auditor']),
+    );
+    expect(isAdminActionAllowed(payload, 'admin.audit.read')).toBe(true);
+    expect(isAdminActionAllowed(payload, 'admin.config.write')).toBe(false);
+  });
+
+  test('expands owner role claims into the full action catalog', () => {
+    const payload = { role: 'admin:owner' };
+
+    expect(isAdminActionAllowed(payload, 'secret.overwrite')).toBe(true);
+    expect(isAdminActionAllowed(payload, 'admin.gateway.restart')).toBe(true);
+  });
+
+  test('combines explicit actions, scope strings, and role bundles', () => {
+    const claims = collectAdminActionClaims({
+      actions: 'admin.overview.read',
+      scope: 'admin.config:*',
+      roles: 'admin:secret-manager',
+    });
+
+    expect(claims?.has('admin.overview.read')).toBe(true);
+    expect(claims?.has('admin.config:*')).toBe(true);
+    expect(claims?.has('secret.unset')).toBe(true);
+    expect(
+      isAdminActionAllowed({ roles: 'admin:secret-manager' }, 'secret.overwrite'),
+    ).toBe(true);
+    expect(
+      isAdminActionAllowed(
+        { roles: 'admin:secret-manager' },
+        'admin.config.write',
+      ),
+    ).toBe(false);
+  });
+
+  test('publishes stable ISO role bundle names for access reviews', () => {
+    expect(Object.keys(ADMIN_RBAC_ROLE_BUNDLES).sort()).toEqual([
+      'admin:auditor',
+      'admin:operator',
+      'admin:owner',
+      'admin:secret-manager',
+    ]);
   });
 });

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -2297,7 +2297,7 @@ describe('gateway HTTP server', () => {
     expect(getSetCookieHeader(res)).toContain('SameSite=Strict');
   });
 
-  test('bootstraps WEB_API_TOKEN into sessionStorage for loopback console pages', async () => {
+  test('issues a local web-session cookie for loopback console pages when WEB_API_TOKEN is configured', async () => {
     const state = await importFreshHealth({ webApiToken: 'web-token' });
     const req = makeRequest({
       url: '/admin',
@@ -2309,25 +2309,19 @@ describe('gateway HTTP server', () => {
     state.handler(req as never, res as never);
 
     expect(res.statusCode).toBe(200);
-    expect(res.headers['Content-Type']).toBe('text/html; charset=utf-8');
-    expect(res.headers['Cache-Control']).toBe('no-store');
-    expect(res.body).toContain(
-      'sessionStorage.setItem(\'hybridclaw_token\',"web-token")',
-    );
-    expect(res.body).toContain(
-      "localStorage.removeItem('hybridclaw_token')",
-    );
-    expect(res.body).toContain(
-      'window.location.replace("/admin?__hybridclaw_token_bootstrapped=1")',
-    );
+    expect(res.body).toBe('<h1>Admin</h1>');
+    expect(res.body).not.toContain('web-token');
+    expect(getSetCookieHeader(res)).toContain('hybridclaw_local_session=');
+    expect(getSetCookieHeader(res)).toContain('HttpOnly');
+    expect(getSetCookieHeader(res)).toContain('SameSite=Strict');
   });
 
-  test('serves console index after local WEB_API_TOKEN bootstrap marker', async () => {
+  test('serves console index with defensive headers', async () => {
     const state = await importFreshHealth({ webApiToken: 'web-token' });
 
     for (const pathname of ['/admin', '/agents']) {
       const req = makeRequest({
-        url: `${pathname}?__hybridclaw_token_bootstrapped=1`,
+        url: pathname,
         headers: { host: 'localhost:9090' },
         noAuth: true,
       });
@@ -2338,10 +2332,15 @@ describe('gateway HTTP server', () => {
       expect(res.statusCode).toBe(200);
       expect(res.body).toBe('<h1>Admin</h1>');
       expect(res.body).not.toContain('web-token');
+      expect(res.headers['X-Content-Type-Options']).toBe('nosniff');
+      expect(res.headers['Referrer-Policy']).toBe('no-referrer');
+      expect(res.headers['Content-Security-Policy']).toContain(
+        "default-src 'self'",
+      );
     }
   });
 
-  test('bootstraps WEB_API_TOKEN into sessionStorage for loopback agents SPA', async () => {
+  test('does not expose WEB_API_TOKEN in the loopback agents SPA', async () => {
     const state = await importFreshHealth({ webApiToken: 'web-token' });
     const req = makeRequest({
       url: '/agents',
@@ -2353,12 +2352,9 @@ describe('gateway HTTP server', () => {
     state.handler(req as never, res as never);
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toContain(
-      'sessionStorage.setItem(\'hybridclaw_token\',"web-token")',
-    );
-    expect(res.body).toContain(
-      'window.location.replace("/agents?__hybridclaw_token_bootstrapped=1")',
-    );
+    expect(res.body).toBe('<h1>Admin</h1>');
+    expect(res.body).not.toContain('web-token');
+    expect(getSetCookieHeader(res)).toContain('hybridclaw_local_session=');
   });
 
   test('does not bootstrap WEB_API_TOKEN for non-loopback request hosts', async () => {
@@ -2655,8 +2651,8 @@ describe('gateway HTTP server', () => {
     const req = makeRequest({
       url: '/api/status',
       headers: { 'x-forwarded-for': '127.0.0.1' },
-      remoteAddress: '203.0.113.10',
       noAuth: true,
+      remoteAddress: '203.0.113.10',
     });
     const res = makeResponse();
 
@@ -4189,9 +4185,12 @@ describe('gateway HTTP server', () => {
     expect(res.headers['Set-Cookie']).toEqual(
       expect.stringContaining('hybridclaw_session='),
     );
+    expect(res.headers['Set-Cookie']).toEqual(
+      expect.stringContaining('HttpOnly'),
+    );
   });
 
-  test('/auth/callback uses redirect cache controls when WEB_API_TOKEN is set', async () => {
+  test('/auth/callback does not render token-bearing HTML when WEB_API_TOKEN is set', async () => {
     const authSecret = 'health-secret';
     const launchToken = signAuthPayload(
       {
@@ -4214,9 +4213,11 @@ describe('gateway HTTP server', () => {
     expect(res.statusCode).toBe(302);
     expect(res.headers.Location).toBe('/admin');
     expect(res.headers['Cache-Control']).toBe('no-store');
+    expect(res.headers['Content-Security-Policy']).toBeUndefined();
+    expect(res.body).toBe('');
   });
 
-  test('/auth/callback does not render WEB_API_TOKEN script content', async () => {
+  test('/auth/callback never reflects WEB_API_TOKEN characters into the response body', async () => {
     const authSecret = 'health-secret';
     const launchToken = signAuthPayload(
       {
@@ -4240,6 +4241,7 @@ describe('gateway HTTP server', () => {
     expect(res.headers.Location).toBe('/admin');
     expect(res.body).not.toContain('token-with-');
     expect(res.body).not.toContain('<script>');
+    expect(res.body).toBe('');
   });
 
   test('/auth/callback returns 302 redirect when WEB_API_TOKEN is not set', async () => {
@@ -4306,7 +4308,7 @@ describe('gateway HTTP server', () => {
 
     expect(res.statusCode).toBe(302);
     expect(res.headers.Location).toBe('/dashboard');
-    expect(res.body).not.toContain('my-web-token');
+    expect(res.body).toBe('');
   });
 
   test('/auth/callback ignores protocol-relative next param to prevent open redirect', async () => {
@@ -5269,6 +5271,51 @@ describe('gateway HTTP server', () => {
     expect(state.refreshRuntimeSecretsFromEnv).toHaveBeenCalledTimes(1);
     expect(state.reloadRuntimeConfig).toHaveBeenCalledWith('admin-api');
     expect(res.statusCode).toBe(200);
+  });
+
+  test('allows scoped admin sessions through ISO role bundle aliases', async () => {
+    const authSecret = 'admin-rbac-iso-role-auth-secret';
+    const state = await importFreshHealth({ authSecret });
+    const req = makeRequest({
+      url: '/api/admin/audit',
+      headers: {
+        cookie: makeSessionCookie(authSecret, {
+          sessionId: 'admin-session-1',
+          actor: 'admin-user',
+          roles: ['admin:auditor'],
+        }),
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(res.statusCode).toBe(200);
+    expect(state.getGatewayAdminAudit).toHaveBeenCalledTimes(1);
+  });
+
+  test('denies scoped admin sessions when a role bundle lacks the route action', async () => {
+    const authSecret = 'admin-rbac-role-deny-auth-secret';
+    const state = await importFreshHealth({ authSecret });
+    const req = makeRequest({
+      method: 'PUT',
+      url: '/api/admin/config',
+      body: {},
+      headers: {
+        cookie: makeSessionCookie(authSecret, {
+          sessionId: 'admin-session-1',
+          actor: 'admin-user',
+          roles: ['admin:auditor'],
+        }),
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(res.statusCode).toBe(403);
   });
 
   test('returns admin secret metadata without cleartext values', async () => {
@@ -8303,6 +8350,24 @@ describe('gateway HTTP server', () => {
         }),
       },
       remoteAddress: '203.0.113.10',
+      noAuth: true,
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('event: overview');
+  });
+
+  test('allows cookie-authenticated SSE admin events', async () => {
+    const state = await importFreshHealth();
+    const cookie = issueLocalWebSessionCookie(state);
+    const req = makeRequest({
+      url: '/api/events',
+      headers: { cookie, host: 'localhost:9090' },
+      noAuth: true,
     });
     const res = makeResponse();
 


### PR DESCRIPTION
## Summary

- Add an ISO 27001 evidence package under `docs/content/developer-guide/iso27001/` covering SoA, risk, asset/data inventory, access control, owners, calendar, monitoring, suppliers, and signoff records.
- Downgrade the remaining evidence and privileged-access matrix gaps from P0 to P1 where implementation evidence now exists but operator signoff or external records are still required.
- Close the console token-handling P0 by removing URL/localStorage token bootstrap, issuing signed HttpOnly session cookies on auth callback, blocking `/api/events?token=...`, and adding defensive console headers/CSP.
- Add admin RBAC role bundles and regression coverage for role expansion, SSE auth, route permissions, and legacy cleanup.

## Validation

- `npx biome check --write ...`
- `./node_modules/.bin/vitest run --configLoader runner --project unit tests/admin-rbac.test.ts tests/gateway-http-server.test.ts`
- `../node_modules/.bin/vitest run --config vitest.config.ts src/api/client.test.ts src/hooks/use-live-events.test.tsx`
- `npm run lint`
- `git diff --check`
- static `rg` regression search for removed token-bootstrap/SSE query-token patterns

## Residual Follow-up

The remaining ISO work is external evidence collection: operator signoff, real user access-review exports, MFA/SSO records, supplier attestations, and dated review artifacts.