### PR TITLE
[codex] Add ISO 42001 AIMS readiness docs

### DIFF
--- a/docs/content/developer-guide/README.md
+++ b/docs/content/developer-guide/README.md
@@ -21,8 +21,13 @@ These pages focus on how HybridClaw is built and operated under the hood.
   linked-identity boundaries
 - [Secret Threat Model](./threat-model.md) for credential-adjacent feature
   review, model-leakage paths, and PR checklist expectations
-- [ISO 27001 Control Matrix](./iso27001-control-matrix.md) for Annex A evidence
-  mapping, repo-visible gaps, and next evidence to collect
+- [ISO/IEC 27001 Control Matrix](./iso27001-control-matrix.md) for Annex A
+  evidence mapping, repo-visible gaps, TISAX fit, and next evidence to collect
+- [ISO/IEC 42001 AIMS Readiness](./iso42001-aims-readiness.md) for AI
+  management-system scope, gap mapping, and implementation work items
+- [ISO/IEC 42001 Evidence Templates](./iso42001-aims-evidence-templates.md)
+  for AI system inventory, AI risk, impact assessment, provider review, eval,
+  incident, and management review records
 - [Admin Access Control](./admin-access-control.md) for scoped admin role
   bundles, session claims, and access-review evidence
 - [Identity](./identity.md) for canonical user/agent IDs, authority boundaries,

--- a/docs/content/developer-guide/admin-access-control.md
+++ b/docs/content/developer-guide/admin-access-control.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Access Control
-description: Admin RBAC role bundles, session claims, and ISO 27001 access-review evidence.
+description: Admin RBAC role bundles, session claims, and ISO/IEC 27001:2022 access-review evidence.
 sidebar_position: 9
 ---
 

--- a/docs/content/developer-guide/iso27001-control-matrix.md
+++ b/docs/content/developer-guide/iso27001-control-matrix.md
@@ -1,10 +1,10 @@
 ---
-title: ISO 27001 Control Matrix
-description: Working ISO/IEC 27001:2022 Annex A evidence and gap matrix for HybridClaw.
+title: ISO/IEC 27001 Control Matrix
+description: Working ISO/IEC 27001:2022 and ISO/IEC 27001:2022/Amd 1:2024 evidence and gap matrix for HybridClaw.
 sidebar_position: 8
 ---
 
-# ISO 27001 Control Matrix
+# ISO/IEC 27001 Control Matrix
 
 This is a working compliance support artifact, not a certification claim. It
 maps repo-visible HybridClaw evidence to ISO/IEC 27001:2022 Annex A control
@@ -12,6 +12,21 @@ areas and highlights the biggest evidence gaps an auditor would ask about.
 
 Control intent is paraphrased. Use the purchased ISO standard for normative
 control wording.
+
+## Standard Reference Check
+
+- Reviewed against the ISO-published current reference
+  [ISO/IEC 27001:2022](https://www.iso.org/standard/27001) on 2026-06-16.
+- ISO lists ISO/IEC 27001:2022 as published, Edition 3, publication date
+  2022-10. ISO also lists ISO/IEC 27001:2022/Amd 1:2024 for climate-action
+  changes.
+- This matrix maps the ISO/IEC 27001:2022 Annex A control areas. It is not a
+  complete management-system clause checklist; add clauses 4-10, including the
+  amendment-driven climate context check, before treating the package as
+  audit-ready.
+- Short form "ISO 27001" is used only in headings and navigation when brevity
+  helps. Evidence and certification claims should use the full reference
+  "ISO/IEC 27001:2022".
 
 ## Scope And Assumptions
 
@@ -30,9 +45,28 @@ control wording.
 - File and line references are from the checkout reviewed on the date above and
   should be refreshed after substantive edits.
 
+## TISAX Fit
+
+TISAX is worth preparing for only if automotive customers, suppliers, or
+partners ask for it. It is not an ISO certificate and should not replace the
+ISO/IEC 27001 path for general enterprise procurement.
+
+Use this ISO/IEC 27001 matrix as a foundation for TISAX evidence, then maintain
+a separate VDA ISA self-assessment because ENX runs TISAX as an assessment and
+exchange mechanism around the VDA ISA catalogue. ENX describes the ISA as an
+information-security requirements catalogue based on key aspects of
+ISO/IEC 27001, and its downloads page says ISA 6 is the basis for TISAX
+assessments ordered after 2024-04-01. TISAX readiness still needs:
+
+- ENX participant registration and assessment scope records.
+- Selected assessment objectives, protection needs, and assessment level.
+- VDA ISA 6.x self-assessment with maturity-level evidence.
+- Audit-provider selection, corrective action plan records, and exchange
+  release decisions.
+
 ## Immediate Gap Register
 
-| ID | Priority | Annex A refs | Gap | Repo evidence | Next evidence or control |
+| ID | Priority | ISO refs | Gap | Repo evidence | Next evidence or control |
 | --- | --- | --- | --- | --- | --- |
 | G-001 | P0 | A.5.1, A.5.8, A.5.35, A.5.36 | No ISO evidence package: no visible Statement of Applicability, ISMS risk register, asset inventory, control owners, review cadence, or effectiveness evidence. | Runtime security docs exist in [`SECURITY.md`](../../../SECURITY.md) and [`TRUST_MODEL.md`](../../../TRUST_MODEL.md). Repo search only found generic "risk register" examples, not an ISMS register. | Create an ISMS evidence folder with SoA, risk register, asset/data inventory, control owner table, evidence calendar, and review sign-off trail. |
 | G-002 | P0 | A.5.15, A.5.16, A.5.18, A.8.2, A.8.3 | Admin RBAC now has route-level actions and code-backed role bundles for scoped sessions, but the ISO gap remains until sessions and tokens are issued through a documented workflow and periodic access reviews exist. | Broad bearer credentials are still accepted for compatibility in [`src/gateway/gateway-http-server.ts:2046`](../../../src/gateway/gateway-http-server.ts). Scoped admin action names, route mapping, and role bundles live in [`src/security/admin-rbac.ts`](../../../src/security/admin-rbac.ts). Role intent and review evidence are documented in [`Admin Access Control`](./admin-access-control.md). | Issue scoped sessions with role claims, record approval/expiration evidence, run quarterly access reviews, and reduce broad bearer-token use to break-glass paths. |
@@ -44,6 +78,7 @@ control wording.
 | G-008 | P2 | A.5.24, A.5.25, A.5.26, A.5.27, A.5.29, A.5.30, A.8.14 | Incident response and business continuity are documented as emergency steps, but not as an exercised program. | Incident steps are in [`SECURITY.md`](../../../SECURITY.md) and [`TRUST_MODEL.md`](../../../TRUST_MODEL.md). | Add severity definitions, escalation contacts, tabletop records, backup/restore tests, RTO/RPO targets, and post-incident review templates. |
 | G-009 | P2 | A.5.17, A.8.24 | Runtime secret encryption is strong, but key custody and rotation policy are not ISO-ready. | Runtime secrets use a master key from env, mounted secret, or local fallback in [`src/security/runtime-secrets.ts:330`](../../../src/security/runtime-secrets.ts), with AES-256-GCM in [`src/security/runtime-secrets.ts:378`](../../../src/security/runtime-secrets.ts). | Define KMS/HSM or mounted-secret guidance, rotation cadence, recovery procedure, break-glass controls, and key-access audit evidence. |
 | G-010 | P2 | A.8.6, A.8.16, A.8.20, A.8.21 | Abuse controls and operational monitoring need runtime evidence. Code has request-size limits and container constraints, but no repo-visible global API throttling, alert thresholds, or capacity plan. | JSON body limits are enforced in [`src/gateway/gateway-http-utils.ts:12`](../../../src/gateway/gateway-http-utils.ts). Container isolation is documented in [`SECURITY.md`](../../../SECURITY.md). | Add production rate-limit policy, capacity metrics, alerting runbooks, and gateway abuse-event audit coverage. |
+| G-011 | P2 | Clauses 4-10, ISO/IEC 27001:2022/Amd 1:2024 | This matrix is Annex A focused and does not yet prove current management-system clause coverage, including the climate-context consideration introduced by the 2024 amendment. | The review date and standard reference are documented above, but no clause-by-clause checklist exists. | Add an ISMS clause checklist covering context, interested parties, scope, leadership, planning, support, operation, performance evaluation, improvement, and the amendment-driven climate question. |
 
 ## Annex A Coverage Matrix
 

--- a/docs/content/developer-guide/iso42001-aims-evidence-templates.md
+++ b/docs/content/developer-guide/iso42001-aims-evidence-templates.md
@@ -1,0 +1,184 @@
+---
+title: ISO/IEC 42001 Evidence Templates
+description: Starter evidence tables for ISO/IEC 42001:2023 AI management system preparation.
+sidebar_position: 11
+---
+
+# ISO/IEC 42001 Evidence Templates
+
+Use these starter templates to build HybridClaw's ISO/IEC 42001:2023 artificial
+intelligence management system evidence package.
+
+Do not commit customer data, personal data, secrets, production prompts,
+provider payloads, or live incident records to the public repo. Keep completed
+records in the organization evidence store and link back to repo files only
+when the evidence is already safe to publish.
+
+## Evidence Naming
+
+Recommended identifiers:
+
+| Prefix | Record type | Example |
+| --- | --- | --- |
+| `AIMS-SCOPE` | Scope and applicability records | `AIMS-SCOPE-2026-Q3` |
+| `AIMS-SYS` | AI system inventory entries | `AIMS-SYS-HYBRIDCLAW-ORCH` |
+| `AIMS-RISK` | AI risk register entries | `AIMS-RISK-PROMPT-INJECTION` |
+| `AIMS-IA` | AI impact assessments | `AIMS-IA-MODEL-ROUTING-2026-06` |
+| `AIMS-PROV` | AI provider/model reviews | `AIMS-PROV-HYBRIDAI-2026-Q3` |
+| `AIMS-EVAL` | Evaluation and release records | `AIMS-EVAL-AGENT-TOOLS-2026-06` |
+| `AIMS-INC` | AI incident or deviation records | `AIMS-INC-2026-0001` |
+| `AIMS-MR` | Management review records | `AIMS-MR-2026-Q3` |
+
+## AI System Inventory
+
+| Field | Guidance |
+| --- | --- |
+| System ID | Stable ID, for example `AIMS-SYS-HYBRIDCLAW-ORCH`. |
+| System name | Product subsystem or AI-enabled workflow. |
+| Owner | Human accountable for risk, lifecycle, and evidence. |
+| Purpose | Business and user purpose. |
+| Users and affected stakeholders | Operators, admins, end users, customers, maintainers, data subjects, suppliers. |
+| Deployment modes | Local, hosted gateway, Discord bot, channel integration, TUI, admin console, container mode, host mode. |
+| AI technique | LLM orchestration, model routing, embeddings, classifier, retrieval, tool-calling, output guard, speech or media model. |
+| Model/provider | Provider family, local model, hosted model, or user-configured provider. |
+| Data categories | Prompts, tool output, transcripts, memory, embeddings, uploaded files, secrets metadata, audit events, generated artifacts. |
+| Sensitive data | PII, confidential business data, secrets, credentials, customer data, regulated data. |
+| Autonomy level | Advisory only, user-confirmed action, policy-gated action, autonomous scheduled action, admin-only action. |
+| Human oversight | Approval tier, escalation path, stop/interrupt path, admin review, or manual validation. |
+| Risk tier | Low, medium, high, or prohibited until assessed. |
+| Current controls | Prompt rules, approval policy, sandbox, provider config, redaction, audit, evals, docs. |
+| Evidence links | Repo files, tickets, eval records, incident records, supplier reviews. |
+| Last review | Date, reviewer, decision, next review date. |
+
+### Starter Inventory Entries
+
+| System ID | System name | Purpose | Autonomy level | Risk tier | Current controls | Evidence to add |
+| --- | --- | --- | --- | --- | --- | --- |
+| `AIMS-SYS-HYBRIDCLAW-ORCH` | Agent conversation loop | Convert user requests, memory, files, and tool results into model calls and assistant actions. | User-directed, policy-gated tool use. | High | Prompt guardrails, tool approvals, audit logs, tests. | Owner, AI risk review, eval suite, release acceptance record. |
+| `AIMS-SYS-MODEL-ROUTER` | Model/provider routing | Select and call configured model providers. | User/operator configured. | High | Provider registry, model selection docs, config. | Provider approval register, data processing review, fallback risk review. |
+| `AIMS-SYS-TOOL-SANDBOX` | Tool and container execution | Execute shell, browser, MCP, and skill actions for agent sessions. | Policy-gated, sometimes autonomous inside approved task. | High | Docker sandbox, workspace fence, approval tiers, mount validation. | AI action-to-oversight matrix, adversarial tool tests, incident taxonomy. |
+| `AIMS-SYS-MEMORY` | Memory and session continuity | Store and recall session context and long-lived memory. | Context injection, not direct action. | High | Session routing, memory docs, confidential filter. | Data lifecycle record, retention/deletion test evidence, memory contamination evals. |
+| `AIMS-SYS-OUTPUT-GUARD` | Output guard and safety review | Detect and rewrite or block policy-sensitive output. | Classifier-assisted gate. | Medium | Admin output guard code and tests. | Classifier evaluation record, false positive/negative review, override policy. |
+
+## AI Risk Register
+
+| Field | Guidance |
+| --- | --- |
+| Risk ID | Stable ID, for example `AIMS-RISK-PROMPT-INJECTION`. |
+| Related system IDs | One or more AI system inventory IDs. |
+| Risk statement | Event, cause, and impact in one concise sentence. |
+| Affected stakeholders | Users, maintainers, customers, suppliers, data subjects, third parties. |
+| Threat or failure mode | Prompt injection, hallucination, provider drift, excessive agency, data leak, unsafe tool use, bias, cost runaway. |
+| Existing controls | Preventive, detective, and corrective controls. |
+| Likelihood | Low, medium, high, or numeric scale used by the organization. |
+| Impact | Low, medium, high, or numeric scale used by the organization. |
+| Inherent risk | Before treatment. |
+| Treatment | Avoid, mitigate, transfer, accept, or prohibit. |
+| Treatment owner | Human owner. |
+| Due date | Date or recurring review cycle. |
+| Residual risk | After controls. |
+| Acceptance decision | Approver, date, rationale, evidence link. |
+| Monitoring signal | Audit event, metric, eval result, support ticket, alert, incident record. |
+
+### Starter Risk Entries
+
+| Risk ID | Related system IDs | Risk statement | Existing controls | Treatment |
+| --- | --- | --- | --- | --- |
+| `AIMS-RISK-PROMPT-INJECTION` | `AIMS-SYS-HYBRIDCLAW-ORCH`, `AIMS-SYS-TOOL-SANDBOX` | Untrusted file, web, or tool content instructs the agent to disclose data or take unauthorized actions. | Prompt guardrails, approval tiers, secret threat model, sandbox, audit logs. | Add adversarial evals, high-risk prompt-injection test fixtures, and denied-action evidence. |
+| `AIMS-RISK-EXCESSIVE-AGENCY` | `AIMS-SYS-TOOL-SANDBOX` | The agent executes actions beyond the user's intended authority or operational scope. | Red-tier approval, workspace fence, policy hooks. | Maintain an AI action-to-oversight matrix and test unsafe command denial. |
+| `AIMS-RISK-MEMORY-LEAKAGE` | `AIMS-SYS-MEMORY` | Stored memory or transcripts expose one user's context to another user or future task. | Session routing, canonical session keys, confidential filter. | Add contamination tests, deletion evidence, and retention schedule. |
+| `AIMS-RISK-PROVIDER-DRIFT` | `AIMS-SYS-MODEL-ROUTER` | Provider or model behavior changes without updated risk review or eval sign-off. | Provider abstraction, model metadata tests. | Add provider review records and route-change release gates. |
+| `AIMS-RISK-HALLUCINATED-FACTS` | `AIMS-SYS-HYBRIDCLAW-ORCH` | Model output presents unsupported claims as facts in high-stakes contexts. | Stakes classifier, second-opinion commands, user review. | Add citation/evidence requirements and high-stakes response evals. |
+| `AIMS-RISK-COST-RUNAWAY` | `AIMS-SYS-HYBRIDCLAW-ORCH`, `AIMS-SYS-MODEL-ROUTER` | Long-running sessions, retries, or loops consume excessive model/tool budget. | Token usage tracking, loop detection, scheduler controls. | Add budget thresholds, alerting, and post-incident review records. |
+
+## AI Impact Assessment
+
+Use an impact assessment before major AI changes, including:
+
+- new model/provider route or fallback behavior
+- new autonomous or scheduled tool behavior
+- memory, retrieval, transcript, or embedding changes
+- output guard or policy classifier changes
+- hosted or customer-specific deployment
+- workflows affecting legal, financial, employment, safety, health, or other
+  high-impact decisions
+
+| Field | Guidance |
+| --- | --- |
+| Assessment ID | Stable ID, for example `AIMS-IA-MODEL-ROUTING-2026-06`. |
+| Change or system | Link to PR, issue, design doc, or inventory entry. |
+| Purpose and expected benefit | Why the AI capability is needed. |
+| Users and affected parties | Include indirect data subjects where relevant. |
+| Data categories | Inputs, generated outputs, logs, memory, embeddings, provider payloads. |
+| Sensitivity and legal constraints | PII, confidential data, minors, regulated domains, contractual restrictions. |
+| Autonomy and human oversight | What the AI can do and how humans can intervene or approve. |
+| Foreseeable misuse | Abuse, prompt injection, over-permissioned actions, social engineering, unsafe advice. |
+| Failure modes | Inaccuracy, bias, privacy leak, wrong account, unsafe action, denial of service, cost runaway. |
+| Controls | Preventive, detective, corrective controls and tests. |
+| Evaluation evidence | Evals, manual review, screenshots, logs, red-team cases, acceptance thresholds. |
+| Residual risk | Risk left after controls. |
+| Decision | Approve, approve with conditions, defer, reject. |
+| Approver and date | Human owner and evidence link. |
+
+## AI Provider And Model Review
+
+| Field | Guidance |
+| --- | --- |
+| Review ID | Stable ID, for example `AIMS-PROV-HYBRIDAI-2026-Q3`. |
+| Provider/model | Provider, API endpoint class, local model family, or user-configured source. |
+| Intended use | Supported workflows and prohibited workflows. |
+| Data sent | Prompt, tool output, memory, uploaded files, metadata, identifiers. |
+| Data retained by provider | Contractual or technical retention position. |
+| Hosting and jurisdiction | Region, cloud, local machine, or customer controlled. |
+| Security review | Authentication, encryption, access control, logging, abuse controls, incident contact. |
+| Privacy/legal review | DPA, subprocessors, data subject rights, restricted data categories. |
+| Safety features | Moderation, system prompts, tool limits, content filters, model cards, known limitations. |
+| Availability and fallback | SLA, outage behavior, fallback route, user notification. |
+| Change monitoring | Model deprecation, version pinning, release notes, regression eval cadence. |
+| Exit plan | Disable route, delete data, rotate keys, migrate provider, notify customers. |
+| Decision | Approved, conditional, not approved, deprecated. |
+
+## AI Evaluation And Release Record
+
+| Field | Guidance |
+| --- | --- |
+| Evaluation ID | Stable ID, for example `AIMS-EVAL-AGENT-TOOLS-2026-06`. |
+| Change under review | PR, issue, model route, prompt change, policy change, or release. |
+| Systems covered | Inventory IDs. |
+| Test scope | Unit tests, integration tests, adversarial prompts, manual review, trace replay. |
+| Acceptance criteria | Concrete pass/fail thresholds. |
+| Results | Command outputs, eval summary, failure list, residual risk. |
+| Regressions | Known behavior changes and owner decision. |
+| High-risk scenarios | Prompt injection, unsafe tool use, memory leakage, wrong provider, high-stakes claim. |
+| Sign-off | Reviewer, date, decision, conditions. |
+| Follow-up | Tickets, owners, due dates. |
+
+## AI Incident Or Deviation Record
+
+| Field | Guidance |
+| --- | --- |
+| Incident ID | Stable ID, for example `AIMS-INC-2026-0001`. |
+| Detected by | User report, audit alert, eval, monitoring, support, maintainer. |
+| System IDs | Inventory entries involved. |
+| Provider/model | Model or provider if relevant. |
+| Severity | Organization severity scale. |
+| Description | What happened, when, and how it was detected. |
+| Affected data or users | Data categories and affected stakeholder groups. |
+| Immediate containment | Disable route, revoke token, stop gateway, block tool, patch policy, notify user. |
+| Root cause | Technical and process cause. |
+| Corrective action | Code, policy, docs, tests, supplier action, communication. |
+| Preventive action | Eval, monitoring, training, review cadence, control change. |
+| Closure | Owner, date, evidence link, residual risk decision. |
+
+## Management Review Record
+
+| Field | Guidance |
+| --- | --- |
+| Review ID | Stable ID, for example `AIMS-MR-2026-Q3`. |
+| Period | Quarter or date range. |
+| Attendees | AIMS owner, security owner, product owner, operations, legal/privacy if relevant. |
+| Inputs reviewed | Risk register, incidents, eval results, provider changes, customer feedback, audits, regulatory changes. |
+| Metrics | Eval pass rate, policy denials, AI incidents, provider outages, leak-scan findings, cost anomalies. |
+| Decisions | Risk acceptances, priorities, provider decisions, policy changes, resources. |
+| Actions | Action, owner, due date, tracking link. |
+| Next review | Date and required inputs. |

--- a/docs/content/developer-guide/iso42001-aims-readiness.md
+++ b/docs/content/developer-guide/iso42001-aims-readiness.md
@@ -1,0 +1,131 @@
+---
+title: ISO/IEC 42001 AIMS Readiness
+description: Working ISO/IEC 42001:2023 AI management system readiness matrix for HybridClaw.
+sidebar_position: 10
+---
+
+# ISO/IEC 42001 AIMS Readiness
+
+This is a working compliance support artifact, not a certification claim. It
+maps repo-visible HybridClaw evidence to an ISO/IEC 42001:2023 artificial
+intelligence management system (AIMS) preparation plan.
+
+Control intent is paraphrased. Use the purchased ISO standard for normative
+requirements and control wording.
+
+## Standard Reference
+
+- Reviewed against the ISO-published
+  [ISO/IEC 42001:2023](https://www.iso.org/standard/42001) page on 2026-06-16.
+- ISO lists ISO/IEC 42001:2023 as published, Edition 1, publication date
+  2023-12.
+- ISO describes ISO/IEC 42001 as a management-system standard for establishing,
+  implementing, maintaining, and improving an AIMS for organizations that
+  provide or use AI-based products or services.
+
+## Scope And Assumptions
+
+- Review date: 2026-06-16.
+- Scope: this repository, bundled docs, provider routing, model selection,
+  agent orchestration, tool approvals, sandbox execution, memory, skills,
+  output guards, audit logs, and developer workflows.
+- Out of scope: company AIMS records, HR records, legal opinions, customer
+  contracts, customer-specific data protection impact assessments, production
+  telemetry, vendor contracts, and board-level management review records unless
+  represented in this repo.
+- Status values:
+  - `Evidence`: repo contains concrete implementation or documentation.
+  - `Partial`: repo contains useful evidence, but operating evidence or
+    management-system coverage is incomplete.
+  - `Gap`: no sufficient repo-visible evidence.
+  - `Operator evidence`: primarily proven outside the product repo.
+- This document should be used together with the
+  [ISO/IEC 27001 control matrix](./iso27001-control-matrix.md). The security
+  management system should carry shared controls such as access control,
+  supplier governance, logging, incident response, and secure development.
+
+## Product AI System Scope
+
+For AIMS scoping, treat HybridClaw as an AI assistant orchestration product with
+these AI-relevant subsystems:
+
+| Subsystem | AI role | Primary risks | Current repo evidence |
+| --- | --- | --- | --- |
+| Agent conversation loop | Turns user requests, context, memory, and tool results into model prompts and actions. | Prompt injection, misleading outputs, unsafe task decomposition, over-broad authority. | [`src/agent/`](../../../src/agent), [`docs/content/developer-guide/approvals.md`](./approvals.md), [`SECURITY.md`](../../../SECURITY.md) |
+| Model/provider routing | Selects model providers and routes requests across HybridAI, OpenAI-compatible APIs, local models, and other providers. | Wrong provider, data sent to unapproved model, untracked model behavior change. | [`src/providers/`](../../../src/providers), [`src/model-selection.ts`](../../../src/model-selection.ts), [`docs/content/reference/model-selection.md`](../reference/model-selection.md) |
+| Tool and skill execution | Lets AI-assisted sessions call tools, skills, MCP servers, shell commands, browsers, and external APIs. | Excessive agency, untrusted tool output, data exfiltration, destructive operations. | [`container/src/tools.ts`](../../../container/src/tools.ts), [`container/src/approval-policy.ts`](../../../container/src/approval-policy.ts), [`src/skills/`](../../../src/skills) |
+| Container sandbox | Executes agent tools in Docker or host mode with policy gates and mount controls. | Sandbox escape, over-broad mounts, network misuse, resource abuse. | [`src/infra/`](../../../src/infra), [`src/security/mount-security.ts`](../../../src/security/mount-security.ts), [`docs/content/developer-guide/runtime.md`](./runtime.md) |
+| Memory and transcripts | Persists conversation context, summaries, memory, and trace exports. | Privacy leakage, stale or wrong memory, cross-session contamination, retention gaps. | [`src/memory/`](../../../src/memory), [`docs/content/developer-guide/memory.md`](./memory.md), [`docs/content/developer-guide/session-routing.md`](./session-routing.md) |
+| Audit and output guard | Records approvals, audit events, leak scans, output-guard classifier decisions, and session traces. | Incomplete evidence, unmonitored incidents, unexplainable decisions, retained sensitive data. | [`src/audit/`](../../../src/audit), [`src/gateway/output-guard-admin.ts`](../../../src/gateway/output-guard-admin.ts), [`docs/content/developer-guide/runtime.md`](./runtime.md) |
+
+## Immediate AIMS Gap Register
+
+| ID | Priority | AIMS area | Gap | Repo evidence | Next evidence or control |
+| --- | --- | --- | --- | --- | --- |
+| AIMS-001 | P0 | AIMS scope, context, and interested parties | No visible AIMS scope statement, interested-party register, or AI-specific applicability rationale. | This readiness document defines a starter product scope. The ISO/IEC 27001 matrix already defines security-scope assumptions. | Create an AIMS scope record with product boundaries, deployment modes, affected stakeholders, regulatory/customer obligations, exclusions, and owner approval. |
+| AIMS-002 | P0 | AI policy and objectives | No approved AI policy, measurable AI objectives, or management review cadence is visible. | Security posture is documented in [`SECURITY.md`](../../../SECURITY.md) and [`TRUST_MODEL.md`](../../../TRUST_MODEL.md). | Add an AI policy covering responsible use, human oversight, data handling, transparency, safety/security, evaluation, incident handling, and continual improvement. |
+| AIMS-003 | P0 | AI system inventory | There is no central AI system inventory for HybridClaw subsystems, providers, model classes, tools, data stores, and user-impacting decisions. | Provider and subsystem code is visible across `src/`, `container/src/`, and docs. | Maintain the inventory template in [ISO/IEC 42001 Evidence Templates](./iso42001-aims-evidence-templates.md) with owner, purpose, data categories, model/provider, risk tier, and evidence links. |
+| AIMS-004 | P0 | AI risk management | AI-specific risks are spread across security docs and tests, but no AIMS risk register links risks to treatments, residual risk, owners, and review status. | Prompt and secret risks are documented in [`docs/content/developer-guide/threat-model.md`](./threat-model.md), [`SECURITY.md`](../../../SECURITY.md), and approval docs. | Create an AI risk register covering prompt injection, excessive agency, model/provider drift, memory leakage, unsafe tool use, hallucinated facts, privacy leakage, and unbounded consumption. |
+| AIMS-005 | P0 | AI impact assessment | No repeatable impact assessment exists for new AI features, providers, skills, or high-impact deployment contexts. | PR template requires risk notes and validation, but not AI impact fields. | Add an AI impact assessment template for new model routes, autonomous tools, memory changes, output guards, and customer-impacting workflows. |
+| AIMS-006 | P1 | Data governance for AI | Data categories are documented in security terms, but not as an AI data lifecycle covering source, purpose, retention, quality, provenance, consent, and deletion. | Memory and session docs describe storage boundaries. Confidential filtering is documented in [`SECURITY.md`](../../../SECURITY.md). | Add an AI data register for prompts, tool results, transcripts, memory, embeddings, provider payloads, eval fixtures, logs, and generated artifacts. |
+| AIMS-007 | P1 | Model and supplier governance | Provider integrations exist, but there is no model/provider approval register, review cadence, DPA/security review status, or model-change monitoring evidence. | Provider code and model selection docs exist. | Add a provider and model review record with data processing, hosting location, retention, safety features, rate limits, fallback behavior, and deprecation plan. |
+| AIMS-008 | P1 | Human oversight and authority boundaries | Runtime approvals exist, but there is no AIMS-level statement of which decisions require human approval, interruption, escalation, or denial. | Approval policy and traffic-light tiers are documented in [`docs/content/developer-guide/approvals.md`](./approvals.md). | Map AI action categories to required human oversight, escalation owner, approval evidence, and denied-action logging. |
+| AIMS-009 | P1 | AI evaluation and acceptance criteria | Tests exist, but there is no AI behavior acceptance framework for model/provider changes, prompt changes, tool autonomy, output guards, and memory behavior. | Vitest suites cover many runtime boundaries; trace and eval modules exist in [`src/distill/`](../../../src/distill) and [`src/session/session-trace-export.ts`](../../../src/session/session-trace-export.ts). | Define eval suites, adversarial prompts, regression thresholds, release gates, and sign-off records for AI behavior changes. |
+| AIMS-010 | P1 | AI monitoring and incident management | Audit logs exist, but AI-specific incident categories, monitoring thresholds, escalation paths, and post-incident reviews are not documented. | Hash-chained audit and leak scanning are documented in [`SECURITY.md`](../../../SECURITY.md). | Add AI incident categories for unsafe action, data leak, provider outage, model regression, policy bypass, memory contamination, and high-cost runaway behavior. |
+| AIMS-011 | P2 | Transparency and user communication | Product trust docs exist, but no standard disclosure template explains AI limitations, model/provider routing, data persistence, and human approval boundaries for customers. | [`TRUST_MODEL.md`](../../../TRUST_MODEL.md) provides operator acceptance language. | Add customer-facing AI transparency text and support-response language for hosted or enterprise deployments. |
+| AIMS-012 | P2 | Continual improvement | No recurring AIMS improvement cycle, metrics review, or corrective-action register is visible. | CI, tests, and docs provide engineering evidence but not management-system evidence. | Add quarterly AIMS review records with risk changes, incident trends, eval results, supplier changes, customer feedback, and improvement actions. |
+
+## Coverage Matrix
+
+| AIMS area | Status | Repo-visible evidence | Main gap to close |
+| --- | --- | --- | --- |
+| Context, scope, interested parties | Partial | Product architecture and runtime docs describe the system boundaries. | Formal AIMS scope, stakeholder map, obligations register, exclusions, and management approval. |
+| Leadership, policy, roles, objectives | Gap | Security ownership is implied by docs and PR review expectations. | Approved AI policy, named AIMS owner, role/accountability matrix, objectives, and management review. |
+| AI risk and impact assessment | Partial | Security threat model and approval policy cover several AI-agent risks. | AI-specific risk register, impact assessment workflow, residual-risk approvals, and review cadence. |
+| AI system inventory | Partial | Subsystems and providers are visible in code and docs. | Central register linking subsystem, purpose, data, model/provider, tools, owner, risk tier, and evidence. |
+| Data governance | Partial | Memory, session routing, redaction, and runtime secrets are documented. | AI data lifecycle records for prompt payloads, memory, transcripts, embeddings, eval fixtures, and provider data processing. |
+| Provider and supplier management | Partial | Provider integrations and model selection logic are implemented. | Supplier/model approval records, DPA/security review, data residency, retention, availability, fallback, and exit plan. |
+| Human oversight | Evidence | Green/yellow/red approval tiers, red-tier approvals, and admin approval surfaces exist. | AIMS-level mapping from AI action type to oversight requirement and evidence retention. |
+| Operational control | Partial | Container sandbox, mount allowlists, policy hooks, and audit trails exist. | AIMS operating procedure that ties controls to AI risks and production evidence. |
+| Evaluation and validation | Partial | Automated tests and trace/eval modules exist. | AI behavior acceptance criteria, eval suites, prompt/model-change gates, and signed release evidence. |
+| Monitoring and incident response | Partial | Audit logs, approvals, leak scan, and incident guidance exist. | AI incident taxonomy, monitoring thresholds, alert evidence, post-incident review, and corrective-action tracking. |
+| Transparency and communication | Partial | Trust model explains operator responsibilities and stored data. | Customer-facing AI disclosure, limitations, appeal/escalation path, and hosted-service data-use statement. |
+| Continual improvement | Gap | Development workflow and CI exist. | Recurring AIMS reviews, metrics, corrective actions, and improvement records. |
+
+## Evidence Package To Build Next
+
+Create these artifacts before treating HybridClaw as ISO/IEC 42001 audit-ready:
+
+1. `AIMS scope statement`: product boundaries, deployment modes, AI subsystems,
+   affected stakeholders, exclusions, and owner approval.
+2. `AI policy`: responsible development and use, human oversight, data
+   governance, provider governance, evaluation, incident handling, and
+   improvement commitments.
+3. `AI system inventory`: use the template in
+   [ISO/IEC 42001 Evidence Templates](./iso42001-aims-evidence-templates.md).
+4. `AI risk register`: risks, causes, affected stakeholders, controls,
+   treatment, owner, residual risk, review date, and decision.
+5. `AI impact assessment`: required for new provider routes, autonomy changes,
+   memory changes, output guard changes, and high-impact deployment contexts.
+6. `AI provider and model register`: data categories, retention, location,
+   security/privacy review, terms review, model behavior notes, fallback, and
+   exit plan.
+7. `AI evaluation records`: prompt and model regression suites, adversarial
+   tests, tool-boundary tests, acceptance thresholds, failures, and approvals.
+8. `AI incident and corrective-action log`: event type, severity, root cause,
+   containment, customer impact, model/provider involved, and follow-up owner.
+
+## Engineering Work Items
+
+These are the highest-value product changes that would improve the AIMS case:
+
+1. Add a repo-visible AI system inventory and risk register seeded from the
+   tables in this document.
+2. Add AI impact assessment fields to the PR template for provider routing,
+   model selection, tool autonomy, memory, output guard, and prompt changes.
+3. Define AI behavior eval suites for prompt injection, excessive agency,
+   memory leakage, model/provider fallback, and output-guard bypass.
+4. Add provider/model review records for each supported provider family and
+   make model-route changes link to a review entry.
+5. Add an AI incident taxonomy and event catalog that maps audit events to
+   incident review records.

--- a/docs/static/docs.js
+++ b/docs/static/docs.js
@@ -260,6 +260,22 @@ export const DEVELOPMENT_DOCS_SECTIONS = [
         path: 'developer-guide/session-routing.md',
       },
       { title: 'Secret Threat Model', path: 'developer-guide/threat-model.md' },
+      {
+        title: 'ISO/IEC 27001 Control Matrix',
+        path: 'developer-guide/iso27001-control-matrix.md',
+      },
+      {
+        title: 'ISO/IEC 42001 AIMS Readiness',
+        path: 'developer-guide/iso42001-aims-readiness.md',
+      },
+      {
+        title: 'ISO/IEC 42001 Evidence Templates',
+        path: 'developer-guide/iso42001-aims-evidence-templates.md',
+      },
+      {
+        title: 'Admin Access Control',
+        path: 'developer-guide/admin-access-control.md',
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- Confirmed the ISO/IEC 27001 matrix references ISO/IEC 27001:2022 and added the ISO/IEC 27001:2022/Amd 1:2024 caveat.
- Added a TISAX fit note that treats TISAX as automotive-customer-driven and adjacent to, not a replacement for, ISO/IEC 27001.
- Added ISO/IEC 42001:2023 AIMS readiness documentation and reusable evidence templates for HybridClaw.
- Wired the new compliance pages into the developer guide index and static docs navigation.

## Validation

- `npx biome check --write docs/static/docs.js docs/content/developer-guide/README.md docs/content/developer-guide/admin-access-control.md docs/content/developer-guide/iso27001-control-matrix.md docs/content/developer-guide/iso42001-aims-readiness.md docs/content/developer-guide/iso42001-aims-evidence-templates.md`
- `git diff --check`
- Direct `docs/static/docs.js` import/sidebar check
- Markdown relative-link check for the changed docs

## Notes

The full `vitest tests/docs-viewer.test.ts` suite could not start in this worktree because local `node_modules` is absent, and the shared Vitest binary still resolves `vitest/config` from the current checkout.