### PR TITLE
[codex] Share docs navigation manifest

### DIFF
--- a/docs/content/navigation.json
+++ b/docs/content/navigation.json
@@ -1,0 +1,415 @@
+{
+  "sections": [
+    {
+      "title": "Overview",
+      "pages": [
+        {
+          "title": "HybridClaw Docs",
+          "path": "README.md"
+        },
+        {
+          "title": "Manifesto",
+          "path": "manifesto.md"
+        }
+      ]
+    },
+    {
+      "title": "Getting Started",
+      "pages": [
+        {
+          "title": "Getting Started",
+          "path": "getting-started/README.md"
+        },
+        {
+          "title": "Installation",
+          "path": "getting-started/installation.md"
+        },
+        {
+          "title": "Quick Start",
+          "path": "getting-started/quickstart.md"
+        },
+        {
+          "title": "Authentication",
+          "path": "getting-started/authentication.md"
+        },
+        {
+          "title": "Connect Your First Channel",
+          "path": "getting-started/first-channel.md"
+        }
+      ]
+    },
+    {
+      "title": "Channels",
+      "pages": [
+        {
+          "title": "Channels",
+          "path": "channels/README.md"
+        },
+        {
+          "title": "Overview",
+          "path": "channels/overview.md"
+        },
+        {
+          "title": "Discord",
+          "path": "channels/discord.md"
+        },
+        {
+          "title": "Slack",
+          "path": "channels/slack.md"
+        },
+        {
+          "title": "Slack Incoming Webhook",
+          "path": "channels/slack-webhook.md"
+        },
+        {
+          "title": "Discord Incoming Webhook",
+          "path": "channels/discord-webhook.md"
+        },
+        {
+          "title": "Telegram",
+          "path": "channels/telegram.md"
+        },
+        {
+          "title": "Threema",
+          "path": "channels/threema.md"
+        },
+        {
+          "title": "Email",
+          "path": "channels/email.md"
+        },
+        {
+          "title": "WhatsApp",
+          "path": "channels/whatsapp.md"
+        },
+        {
+          "title": "iMessage",
+          "path": "channels/imessage.md"
+        },
+        {
+          "title": "Microsoft Teams",
+          "path": "channels/msteams.md"
+        },
+        {
+          "title": "Admin Console",
+          "path": "channels/admin-console.md"
+        },
+        {
+          "title": "Local Config And Secrets",
+          "path": "channels/local-config-and-secrets.md"
+        },
+        {
+          "title": "Policies And Allowlists",
+          "path": "channels/policies-and-allowlists.md"
+        }
+      ]
+    },
+    {
+      "title": "Guides",
+      "pages": [
+        {
+          "title": "Guides",
+          "path": "guides/README.md"
+        },
+        {
+          "title": "Hatching Task Ideas",
+          "path": "guides/hatching-task-ideas.md"
+        },
+        {
+          "title": "Bundled Skills",
+          "path": "guides/bundled-skills.md"
+        },
+        {
+          "title": "Local Providers",
+          "path": "guides/local-providers.md"
+        },
+        {
+          "title": "Remote Access",
+          "path": "guides/remote-access.md"
+        },
+        {
+          "title": "Office Dependencies",
+          "path": "guides/office-dependencies.md"
+        },
+        {
+          "title": "TUI MCP",
+          "path": "guides/tui-mcp.md"
+        },
+        {
+          "title": "Twilio Voice",
+          "path": "guides/twilio-voice.md"
+        },
+        {
+          "title": "Voice TTS",
+          "path": "guides/voice-tts.md"
+        }
+      ]
+    },
+    {
+      "title": "Skills",
+      "pages": [
+        {
+          "title": "Overview",
+          "path": "guides/skills/README.md"
+        },
+        {
+          "title": "Office",
+          "path": "guides/skills/office.md"
+        },
+        {
+          "title": "Development",
+          "path": "guides/skills/development.md"
+        },
+        {
+          "title": "Communication",
+          "path": "guides/skills/communication.md"
+        },
+        {
+          "title": "Apple",
+          "path": "guides/skills/apple.md"
+        },
+        {
+          "title": "Productivity",
+          "path": "guides/skills/productivity.md"
+        },
+        {
+          "title": "Memory & Knowledge",
+          "path": "guides/skills/memory-knowledge.md"
+        },
+        {
+          "title": "Publishing",
+          "path": "guides/skills/publishing.md"
+        },
+        {
+          "title": "Integrations & Utilities",
+          "path": "guides/skills/integrations.md"
+        }
+      ]
+    },
+    {
+      "title": "Tutorials",
+      "pages": [
+        {
+          "title": "Overview",
+          "path": "tutorials/README.md"
+        },
+        {
+          "title": "Morning Competitor Briefing",
+          "path": "tutorials/morning-competitor-briefing.md"
+        },
+        {
+          "title": "Customer Feedback Digest",
+          "path": "tutorials/customer-feedback-digest.md"
+        },
+        {
+          "title": "Team Telegram Deal Desk",
+          "path": "tutorials/team-telegram-deal-desk.md"
+        },
+        {
+          "title": "Forwarded Lead Triage Inbox",
+          "path": "tutorials/forwarded-lead-triage.md"
+        },
+        {
+          "title": "WhatsApp Lead Follow-Up Copilot",
+          "path": "tutorials/whatsapp-lead-follow-up.md"
+        },
+        {
+          "title": "Daily Pipeline Standup In Slack",
+          "path": "tutorials/daily-pipeline-standup.md"
+        },
+        {
+          "title": "Post-Demo Follow-Up Pack",
+          "path": "tutorials/post-demo-follow-up-pack.md"
+        },
+        {
+          "title": "Proposal Generator From Discovery Notes",
+          "path": "tutorials/proposal-generator.md"
+        },
+        {
+          "title": "Campaign Pulse Digest From CSV Exports",
+          "path": "tutorials/campaign-pulse-digest.md"
+        },
+        {
+          "title": "Weekly Content Calendar With HybridClaw",
+          "path": "tutorials/weekly-content-calendar.md"
+        },
+        {
+          "title": "Release Launch Kit For X, LinkedIn, And Newsletter",
+          "path": "tutorials/release-launch-kit.md"
+        },
+        {
+          "title": "Newsletter Engine With Substack Sections And Notes",
+          "path": "tutorials/newsletter-engine.md"
+        },
+        {
+          "title": "Founder-Led Feature Explainer Videos",
+          "path": "tutorials/feature-explainer-videos.md"
+        },
+        {
+          "title": "Mini Feature Manual From A One-Line Brief",
+          "path": "tutorials/mini-feature-manual.md"
+        },
+        {
+          "title": "Developer Relations Engine For GitHub And X",
+          "path": "tutorials/devrel-engine.md"
+        },
+        {
+          "title": "Webinar Prep And Nachfassen Machine",
+          "path": "tutorials/webinar-machine.md"
+        },
+        {
+          "title": "Collect Invoices And Receipts From Email And Web Platforms",
+          "path": "tutorials/invoice-receipt-collector.md"
+        },
+        {
+          "title": "Check If A Document Adheres To Our Brand Guidelines",
+          "path": "tutorials/brand-guidelines-check.md"
+        }
+      ]
+    },
+    {
+      "title": "Extensibility",
+      "pages": [
+        {
+          "title": "Extensibility",
+          "path": "extensibility/README.md"
+        },
+        {
+          "title": "Adaptive Skills",
+          "path": "extensibility/adaptive-skills.md"
+        },
+        {
+          "title": "Agent Packages",
+          "path": "extensibility/agent-packages.md"
+        },
+        {
+          "title": "Memory Plugins",
+          "path": "extensibility/memory-plugins.md",
+          "children": [
+            {
+              "title": "ByteRover Memory Plugin",
+              "path": "extensibility/byterover-memory-plugin.md"
+            },
+            {
+              "title": "GBrain Plugin",
+              "path": "extensibility/gbrain-plugin.md"
+            },
+            {
+              "title": "Honcho Memory Plugin",
+              "path": "extensibility/honcho-memory-plugin.md"
+            },
+            {
+              "title": "Mem0 Memory Plugin",
+              "path": "extensibility/mem0-memory-plugin.md"
+            },
+            {
+              "title": "MemPalace Memory Plugin",
+              "path": "extensibility/mempalace-memory-plugin.md"
+            },
+            {
+              "title": "QMD Memory Plugin",
+              "path": "extensibility/qmd-memory-plugin.md"
+            }
+          ]
+        },
+        {
+          "title": "OTEL Plugin",
+          "path": "extensibility/otel-plugin.md"
+        },
+        {
+          "title": "Plugins",
+          "path": "extensibility/plugins.md"
+        },
+        {
+          "title": "Skills",
+          "path": "extensibility/skills.md"
+        }
+      ]
+    },
+    {
+      "title": "Developer Guide",
+      "pages": [
+        {
+          "title": "Developer Guide",
+          "path": "developer-guide/README.md"
+        },
+        {
+          "title": "Architecture",
+          "path": "developer-guide/architecture.md"
+        },
+        {
+          "title": "Runtime",
+          "path": "developer-guide/runtime.md"
+        },
+        {
+          "title": "Approvals",
+          "path": "developer-guide/approvals.md"
+        },
+        {
+          "title": "Memory",
+          "path": "developer-guide/memory.md"
+        },
+        {
+          "title": "Session Routing",
+          "path": "developer-guide/session-routing.md"
+        },
+        {
+          "title": "Secret Threat Model",
+          "path": "developer-guide/threat-model.md"
+        },
+        {
+          "title": "ISO/IEC 27001 Control Matrix",
+          "path": "developer-guide/iso27001-control-matrix.md"
+        },
+        {
+          "title": "ISO/IEC 42001 AIMS Readiness",
+          "path": "developer-guide/iso42001-aims-readiness.md"
+        },
+        {
+          "title": "ISO/IEC 42001 Evidence Templates",
+          "path": "developer-guide/iso42001-aims-evidence-templates.md"
+        },
+        {
+          "title": "Admin Access Control",
+          "path": "developer-guide/admin-access-control.md"
+        }
+      ]
+    },
+    {
+      "title": "Reference",
+      "pages": [
+        {
+          "title": "Reference",
+          "path": "reference/README.md"
+        },
+        {
+          "title": "Commands",
+          "path": "reference/commands.md"
+        },
+        {
+          "title": "Configuration",
+          "path": "reference/configuration.md"
+        },
+        {
+          "title": "Diagnostics",
+          "path": "reference/diagnostics.md"
+        },
+        {
+          "title": "FAQ",
+          "path": "reference/faq.md"
+        },
+        {
+          "title": "Model Selection",
+          "path": "reference/model-selection.md"
+        },
+        {
+          "title": "Tools",
+          "path": "reference/tools/README.md"
+        },
+        {
+          "title": "Web Search Tool",
+          "path": "reference/tools/web-search.md"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/static/docs.js
+++ b/docs/static/docs.js
@@ -1,3 +1,5 @@
+import docsNavigationManifest from '../content/navigation.json' with { type: 'json' };
+
 const DOCS_BASE_PATH = '/docs';
 const LEGACY_DOCS_BASE_PATH = '/development';
 const GITHUB_REPO_URL = 'https://github.com/HybridAIOne/hybridclaw';
@@ -41,266 +43,23 @@ const LEGACY_DOC_PREFIX_REWRITES = [
   { from: 'guides/tutorials/', to: 'tutorials/' },
 ];
 
-export const DEVELOPMENT_DOCS_SECTIONS = [
-  {
-    title: 'Overview',
-    pages: [
-      { title: 'HybridClaw Docs', path: 'README.md' },
-      {
-        title: 'Manifesto',
-        path: 'manifesto.md',
-      },
-    ],
-  },
-  {
-    title: 'Getting Started',
-    pages: [
-      { title: 'Getting Started', path: 'getting-started/README.md' },
-      { title: 'Installation', path: 'getting-started/installation.md' },
-      { title: 'Quick Start', path: 'getting-started/quickstart.md' },
-      { title: 'Authentication', path: 'getting-started/authentication.md' },
-      {
-        title: 'Connect Your First Channel',
-        path: 'getting-started/first-channel.md',
-      },
-    ],
-  },
-  {
-    title: 'Channels',
-    pages: [
-      { title: 'Channels', path: 'channels/README.md' },
-      { title: 'Overview', path: 'channels/overview.md' },
-      { title: 'Discord', path: 'channels/discord.md' },
-      { title: 'Slack', path: 'channels/slack.md' },
-      { title: 'Slack Incoming Webhook', path: 'channels/slack-webhook.md' },
-      {
-        title: 'Discord Incoming Webhook',
-        path: 'channels/discord-webhook.md',
-      },
-      { title: 'Telegram', path: 'channels/telegram.md' },
-      { title: 'Threema', path: 'channels/threema.md' },
-      { title: 'Email', path: 'channels/email.md' },
-      { title: 'WhatsApp', path: 'channels/whatsapp.md' },
-      { title: 'iMessage', path: 'channels/imessage.md' },
-      { title: 'Microsoft Teams', path: 'channels/msteams.md' },
-      { title: 'Admin Console', path: 'channels/admin-console.md' },
-      {
-        title: 'Local Config And Secrets',
-        path: 'channels/local-config-and-secrets.md',
-      },
-      {
-        title: 'Policies And Allowlists',
-        path: 'channels/policies-and-allowlists.md',
-      },
-    ],
-  },
-  {
-    title: 'Guides',
-    pages: [
-      { title: 'Guides', path: 'guides/README.md' },
-      { title: 'Hatching Task Ideas', path: 'guides/hatching-task-ideas.md' },
-      { title: 'Bundled Skills', path: 'guides/bundled-skills.md' },
-      { title: 'Local Providers', path: 'guides/local-providers.md' },
-      { title: 'Remote Access', path: 'guides/remote-access.md' },
-      { title: 'Office Dependencies', path: 'guides/office-dependencies.md' },
-      { title: 'TUI MCP', path: 'guides/tui-mcp.md' },
-      { title: 'Twilio Voice', path: 'guides/twilio-voice.md' },
-      { title: 'Voice TTS', path: 'guides/voice-tts.md' },
-    ],
-  },
-  {
-    title: 'Skills',
-    pages: [
-      { title: 'Overview', path: 'guides/skills/README.md' },
-      { title: 'Office', path: 'guides/skills/office.md' },
-      { title: 'Development', path: 'guides/skills/development.md' },
-      { title: 'Communication', path: 'guides/skills/communication.md' },
-      { title: 'Apple', path: 'guides/skills/apple.md' },
-      { title: 'Productivity', path: 'guides/skills/productivity.md' },
-      {
-        title: 'Memory & Knowledge',
-        path: 'guides/skills/memory-knowledge.md',
-      },
-      { title: 'Publishing', path: 'guides/skills/publishing.md' },
-      {
-        title: 'Integrations & Utilities',
-        path: 'guides/skills/integrations.md',
-      },
-    ],
-  },
-  {
-    title: 'Tutorials',
-    pages: [
-      { title: 'Overview', path: 'tutorials/README.md' },
-      {
-        title: 'Morning Competitor Briefing',
-        path: 'tutorials/morning-competitor-briefing.md',
-      },
-      {
-        title: 'Customer Feedback Digest',
-        path: 'tutorials/customer-feedback-digest.md',
-      },
-      {
-        title: 'Team Telegram Deal Desk',
-        path: 'tutorials/team-telegram-deal-desk.md',
-      },
-      {
-        title: 'Forwarded Lead Triage Inbox',
-        path: 'tutorials/forwarded-lead-triage.md',
-      },
-      {
-        title: 'WhatsApp Lead Follow-Up Copilot',
-        path: 'tutorials/whatsapp-lead-follow-up.md',
-      },
-      {
-        title: 'Daily Pipeline Standup In Slack',
-        path: 'tutorials/daily-pipeline-standup.md',
-      },
-      {
-        title: 'Post-Demo Follow-Up Pack',
-        path: 'tutorials/post-demo-follow-up-pack.md',
-      },
-      {
-        title: 'Proposal Generator From Discovery Notes',
-        path: 'tutorials/proposal-generator.md',
-      },
-      {
-        title: 'Campaign Pulse Digest From CSV Exports',
-        path: 'tutorials/campaign-pulse-digest.md',
-      },
-      {
-        title: 'Weekly Content Calendar With HybridClaw',
-        path: 'tutorials/weekly-content-calendar.md',
-      },
-      {
-        title: 'Release Launch Kit For X, LinkedIn, And Newsletter',
-        path: 'tutorials/release-launch-kit.md',
-      },
-      {
-        title: 'Newsletter Engine With Substack Sections And Notes',
-        path: 'tutorials/newsletter-engine.md',
-      },
-      {
-        title: 'Founder-Led Feature Explainer Videos',
-        path: 'tutorials/feature-explainer-videos.md',
-      },
-      {
-        title: 'Mini Feature Manual From A One-Line Brief',
-        path: 'tutorials/mini-feature-manual.md',
-      },
-      {
-        title: 'Developer Relations Engine For GitHub And X',
-        path: 'tutorials/devrel-engine.md',
-      },
-      {
-        title: 'Webinar Prep And Nachfassen Machine',
-        path: 'tutorials/webinar-machine.md',
-      },
-      {
-        title: 'Collect Invoices And Receipts From Email And Web Platforms',
-        path: 'tutorials/invoice-receipt-collector.md',
-      },
-      {
-        title: 'Check If A Document Adheres To Our Brand Guidelines',
-        path: 'tutorials/brand-guidelines-check.md',
-      },
-    ],
-  },
-  {
-    title: 'Extensibility',
-    pages: [
-      { title: 'Extensibility', path: 'extensibility/README.md' },
-      { title: 'Adaptive Skills', path: 'extensibility/adaptive-skills.md' },
-      { title: 'Agent Packages', path: 'extensibility/agent-packages.md' },
-      {
-        title: 'Memory Plugins',
-        path: 'extensibility/memory-plugins.md',
-        children: [
-          {
-            title: 'ByteRover Memory Plugin',
-            path: 'extensibility/byterover-memory-plugin.md',
-          },
-          {
-            title: 'GBrain Plugin',
-            path: 'extensibility/gbrain-plugin.md',
-          },
-          {
-            title: 'Honcho Memory Plugin',
-            path: 'extensibility/honcho-memory-plugin.md',
-          },
-          {
-            title: 'Mem0 Memory Plugin',
-            path: 'extensibility/mem0-memory-plugin.md',
-          },
-          {
-            title: 'MemPalace Memory Plugin',
-            path: 'extensibility/mempalace-memory-plugin.md',
-          },
-          {
-            title: 'QMD Memory Plugin',
-            path: 'extensibility/qmd-memory-plugin.md',
-          },
-        ],
-      },
-      { title: 'OTEL Plugin', path: 'extensibility/otel-plugin.md' },
-      { title: 'Plugins', path: 'extensibility/plugins.md' },
-      { title: 'Skills', path: 'extensibility/skills.md' },
-    ],
-  },
-  {
-    title: 'Developer Guide',
-    pages: [
-      { title: 'Developer Guide', path: 'developer-guide/README.md' },
-      { title: 'Architecture', path: 'developer-guide/architecture.md' },
-      { title: 'Runtime', path: 'developer-guide/runtime.md' },
-      { title: 'Approvals', path: 'developer-guide/approvals.md' },
-      { title: 'Memory', path: 'developer-guide/memory.md' },
-      {
-        title: 'Session Routing',
-        path: 'developer-guide/session-routing.md',
-      },
-      { title: 'Secret Threat Model', path: 'developer-guide/threat-model.md' },
-      {
-        title: 'ISO/IEC 27001 Control Matrix',
-        path: 'developer-guide/iso27001-control-matrix.md',
-      },
-      {
-        title: 'ISO/IEC 42001 AIMS Readiness',
-        path: 'developer-guide/iso42001-aims-readiness.md',
-      },
-      {
-        title: 'ISO/IEC 42001 Evidence Templates',
-        path: 'developer-guide/iso42001-aims-evidence-templates.md',
-      },
-      {
-        title: 'Admin Access Control',
-        path: 'developer-guide/admin-access-control.md',
-      },
-    ],
-  },
-  {
-    title: 'Reference',
-    pages: [
-      { title: 'Reference', path: 'reference/README.md' },
-      { title: 'Commands', path: 'reference/commands.md' },
-      { title: 'Configuration', path: 'reference/configuration.md' },
-      { title: 'Diagnostics', path: 'reference/diagnostics.md' },
-      { title: 'FAQ', path: 'reference/faq.md' },
-      { title: 'Model Selection', path: 'reference/model-selection.md' },
-      { title: 'Tools', path: 'reference/tools/README.md' },
-      { title: 'Web Search Tool', path: 'reference/tools/web-search.md' },
-    ],
-  },
-];
+export const DEVELOPMENT_DOCS_SECTIONS = docsNavigationManifest.sections;
+
+function flattenNavigationPages(pages) {
+  return pages.flatMap((page) => [
+    page,
+    ...flattenNavigationPages(page.children || []),
+  ]);
+}
 
 const DOCS_BY_PATH = new Map(
   DEVELOPMENT_DOCS_SECTIONS.flatMap((section) =>
-    section.pages.map((page) => [page.path, page]),
+    flattenNavigationPages(section.pages).map((page) => [page.path, page]),
   ),
 );
 const KNOWN_DOC_PATHS = new Set(DOCS_BY_PATH.keys());
 const DOCS_SEARCH_ENTRIES = DEVELOPMENT_DOCS_SECTIONS.flatMap((section) =>
-  section.pages.map((page) => ({
+  flattenNavigationPages(section.pages).map((page) => ({
     label: page.title,
     parentTitle: section.title,
     path: page.path,

--- a/src/gateway/docs.ts
+++ b/src/gateway/docs.ts
@@ -8,6 +8,11 @@ import { resolveInstallPath } from '../infra/install-root.js';
 
 const SITE_DIR = resolveInstallPath('docs');
 const DEVELOPMENT_DOCS_DIR = resolveInstallPath('docs', 'content');
+const DEVELOPMENT_DOCS_NAVIGATION_PATH = resolveInstallPath(
+  'docs',
+  'content',
+  'navigation.json',
+);
 const GITHUB_REPO_URL = 'https://github.com/HybridAIOne/hybridclaw';
 const DISCORD_URL = 'https://discord.gg/jsVW4vJw27';
 const SEARCH_RESULT_LIMIT = 10;
@@ -139,6 +144,21 @@ type DevelopmentDocSearchEntry = {
   markdownPath: string;
   parentTitle: string;
   routePath: string;
+};
+
+type DevelopmentDocsNavigationPage = {
+  children: DevelopmentDocsNavigationPage[];
+  path: string;
+  title: string;
+};
+
+type DevelopmentDocsNavigationSection = {
+  pages: DevelopmentDocsNavigationPage[];
+  title: string;
+};
+
+type DevelopmentDocsNavigationManifest = {
+  sections: DevelopmentDocsNavigationSection[];
 };
 
 type SidebarNode = {
@@ -554,6 +574,127 @@ function readDevelopmentDoc(relativePath: string): DevelopmentDocPage | null {
   };
 }
 
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseNavigationPage(
+  raw: unknown,
+  context: string,
+): DevelopmentDocsNavigationPage {
+  if (!isJsonObject(raw)) {
+    throw new Error(`Invalid docs navigation page at ${context}`);
+  }
+
+  const title = typeof raw.title === 'string' ? raw.title.trim() : '';
+  const requestedPath = typeof raw.path === 'string' ? raw.path.trim() : '';
+  if (!title || !requestedPath) {
+    throw new Error(`Invalid docs navigation page at ${context}`);
+  }
+
+  const normalizedPath =
+    normalizeRequestedDevelopmentDocRelativePath(requestedPath);
+  if (!normalizedPath) {
+    throw new Error(
+      `Invalid docs navigation path at ${context}: ${requestedPath}`,
+    );
+  }
+
+  const rawChildren = raw.children;
+  const children = Array.isArray(rawChildren)
+    ? rawChildren.map((child, index) =>
+        parseNavigationPage(child, `${context}.children[${index}]`),
+      )
+    : [];
+
+  return {
+    children,
+    path: normalizedPath,
+    title,
+  };
+}
+
+function readDevelopmentDocsNavigationManifest(): DevelopmentDocsNavigationManifest {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(
+      fs.readFileSync(DEVELOPMENT_DOCS_NAVIGATION_PATH, 'utf8'),
+    ) as unknown;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid docs navigation manifest: ${message}`);
+  }
+
+  if (!isJsonObject(parsed) || !Array.isArray(parsed.sections)) {
+    throw new Error(
+      'Invalid docs navigation manifest: sections must be an array',
+    );
+  }
+
+  return {
+    sections: parsed.sections.map((rawSection, sectionIndex) => {
+      if (!isJsonObject(rawSection)) {
+        throw new Error(
+          `Invalid docs navigation section at sections[${sectionIndex}]`,
+        );
+      }
+
+      const title =
+        typeof rawSection.title === 'string' ? rawSection.title.trim() : '';
+      if (!title || !Array.isArray(rawSection.pages)) {
+        throw new Error(
+          `Invalid docs navigation section at sections[${sectionIndex}]`,
+        );
+      }
+
+      return {
+        pages: rawSection.pages.map((rawPage, pageIndex) =>
+          parseNavigationPage(
+            rawPage,
+            `sections[${sectionIndex}].pages[${pageIndex}]`,
+          ),
+        ),
+        title,
+      };
+    }),
+  };
+}
+
+function flattenNavigationPages(
+  pages: DevelopmentDocsNavigationPage[],
+): DevelopmentDocsNavigationPage[] {
+  return pages.flatMap((page) => [
+    page,
+    ...flattenNavigationPages(page.children),
+  ]);
+}
+
+function resolveNavigationDocs(
+  manifest: DevelopmentDocsNavigationManifest,
+  docsByRelativePath: Map<string, DevelopmentDocPage>,
+): DevelopmentDocPage[] {
+  const seen = new Set<string>();
+  const navigationDocs: DevelopmentDocPage[] = [];
+
+  for (const navPage of manifest.sections.flatMap((section) =>
+    flattenNavigationPages(section.pages),
+  )) {
+    if (seen.has(navPage.path)) continue;
+    seen.add(navPage.path);
+
+    const page = docsByRelativePath.get(navPage.path);
+    if (!page) {
+      throw new Error(
+        `Docs navigation references missing page: ${navPage.path}`,
+      );
+    }
+
+    navigationDocs.push({ ...page, title: navPage.title });
+  }
+
+  return navigationDocs;
+}
+
 function collectDevelopmentDocPaths(
   rootDir: string,
   currentDir = rootDir,
@@ -612,14 +753,28 @@ function buildDevelopmentDocsSnapshot(
   const docsByRelativePath = new Map(
     docs.map((entry) => [entry.relativePath, entry] as const),
   );
+  const navigationManifest = readDevelopmentDocsNavigationManifest();
+  const navigationDocs = resolveNavigationDocs(
+    navigationManifest,
+    docsByRelativePath,
+  );
   const readCategoryMetadataCached = createCategoryMetadataReader();
+  const rootMeta = readCategoryMetadataCached('') || {};
+  const rootLabel =
+    typeof rootMeta.label === 'string' && rootMeta.label.trim()
+      ? rootMeta.label.trim()
+      : 'Development';
   const snapshot: DevelopmentDocsSnapshot = {
     cachedAt: Date.now(),
     docs,
     docsByRelativePath,
     readCategoryMetadataCached,
-    searchEntries: buildSearchIndex(docs),
-    sidebarTree: buildSidebarTree(docs, readCategoryMetadataCached),
+    searchEntries: buildSearchIndex(navigationDocs),
+    sidebarTree: buildSidebarTree(
+      navigationManifest,
+      docsByRelativePath,
+      rootLabel,
+    ),
   };
   developmentDocsSnapshotCache = snapshot;
   return snapshot;
@@ -713,106 +868,56 @@ function rewriteRelativeHref(
 }
 
 function buildSidebarTree(
-  docs: DevelopmentDocPage[],
-  readCategoryMetadataCached: CategoryMetadataReader,
+  manifest: DevelopmentDocsNavigationManifest,
+  docsByRelativePath: Map<string, DevelopmentDocPage>,
+  rootLabel: string,
 ): SidebarNode {
-  const rootMeta = readCategoryMetadataCached('') || {};
   const root: SidebarNode = {
     children: [],
     description: '',
     isPage: false,
-    label:
-      typeof rootMeta.label === 'string' && rootMeta.label.trim()
-        ? rootMeta.label.trim()
-        : 'Development',
+    label: rootLabel,
     pathKey: '',
-    position: typeof rootMeta.position === 'number' ? rootMeta.position : 1,
+    position: 1,
     routePath: null,
   };
 
-  const ensureSidebarGroup = (
-    parent: SidebarNode,
-    pathKey: string,
-    label: string,
-    position: number | null,
+  const buildPageNode = (
+    navPage: DevelopmentDocsNavigationPage,
+    index: number,
   ): SidebarNode => {
-    let group = parent.children.find(
-      (entry) => !entry.isPage && entry.pathKey === pathKey,
-    );
-    if (group) return group;
-    group = {
-      children: [],
-      description: '',
-      isPage: false,
-      label,
-      pathKey,
-      position,
-      routePath: null,
-    };
-    parent.children.push(group);
-    return group;
-  };
-
-  for (const page of docs) {
-    if (page.relativePath === 'README.md') continue;
-
-    const parts = page.relativePath.split('/');
-    const promotedGroup = getPromotedSidebarGroup(page.relativePath);
-    let cursor = root;
-    let currentPath = '';
-    let directorySegments = parts.slice(0, -1);
-
-    if (promotedGroup) {
-      cursor = ensureSidebarGroup(
-        root,
-        promotedGroup.pathKey,
-        promotedGroup.label,
-        promotedGroup.position,
-      );
-      currentPath = promotedGroup.pathKey;
-      const promotedDepth = promotedGroup.pathKey.split('/').length;
-      directorySegments = directorySegments.slice(promotedDepth);
-    }
-
-    for (const segment of directorySegments) {
-      currentPath = currentPath ? `${currentPath}/${segment}` : segment;
-      const categoryMeta = readCategoryMetadataCached(currentPath) || {};
-      const label =
-        typeof categoryMeta.label === 'string' && categoryMeta.label.trim()
-          ? categoryMeta.label.trim()
-          : humanizeSegment(segment);
-      cursor = ensureSidebarGroup(
-        cursor,
-        currentPath,
-        label,
-        typeof categoryMeta.position === 'number'
-          ? categoryMeta.position
-          : null,
+    const page = docsByRelativePath.get(navPage.path);
+    if (!page) {
+      throw new Error(
+        `Docs navigation references missing page: ${navPage.path}`,
       );
     }
 
-    cursor.children.push({
-      children: [],
+    return {
+      children: navPage.children.map((child, childIndex) =>
+        buildPageNode(child, childIndex),
+      ),
       description: page.description,
       isPage: true,
-      label: page.title,
-      pathKey: page.relativePath,
-      position: page.sidebarPosition,
+      label: navPage.title,
+      pathKey: navPage.path,
+      position: index,
       routePath: page.routePath,
-    });
-  }
-
-  const sortTree = (node: SidebarNode) => {
-    node.children.sort((left, right) => {
-      const leftPosition = left.position ?? Number.POSITIVE_INFINITY;
-      const rightPosition = right.position ?? Number.POSITIVE_INFINITY;
-      if (leftPosition !== rightPosition) return leftPosition - rightPosition;
-      if (left.isPage !== right.isPage) return left.isPage ? 1 : -1;
-      return left.label.localeCompare(right.label);
-    });
-    for (const child of node.children) sortTree(child);
+    };
   };
-  sortTree(root);
+
+  root.children = manifest.sections.map((section, sectionIndex) => ({
+    children: section.pages.map((page, pageIndex) =>
+      buildPageNode(page, pageIndex),
+    ),
+    description: '',
+    isPage: false,
+    label: section.title,
+    pathKey: `section:${sectionIndex}`,
+    position: sectionIndex,
+    routePath: null,
+  }));
+
   return root;
 }
 
@@ -820,9 +925,11 @@ function sidebarNodeContainsRoute(
   node: SidebarNode,
   currentRoutePath: string,
 ): boolean {
-  if (node.isPage) return node.routePath === currentRoutePath;
-  return node.children.some((child) =>
-    sidebarNodeContainsRoute(child, currentRoutePath),
+  return (
+    (node.isPage && node.routePath === currentRoutePath) ||
+    node.children.some((child) =>
+      sidebarNodeContainsRoute(child, currentRoutePath),
+    )
   );
 }
 
@@ -834,7 +941,13 @@ function renderSidebarNode(
   if (node.isPage) {
     const isActive = node.routePath === currentRoutePath;
     const topClass = isRootLevel ? ' docs-sidebar-link-top' : '';
-    return `<a class="docs-sidebar-link${topClass}${isActive ? ' is-active' : ''}" href="${escapeHtml(node.routePath || DOCS_ROUTE)}"${isActive ? ' aria-current="page"' : ''}><span>${escapeHtml(node.label)}</span></a>`;
+    const link = `<a class="docs-sidebar-link${topClass}${isActive ? ' is-active' : ''}" href="${escapeHtml(node.routePath || DOCS_ROUTE)}"${isActive ? ' aria-current="page"' : ''}><span>${escapeHtml(node.label)}</span></a>`;
+    if (node.children.length === 0) return link;
+
+    const childrenMarkup = node.children
+      .map((child) => renderSidebarNode(child, currentRoutePath, false))
+      .join('');
+    return `${link}<div class="docs-sidebar-group-items">${childrenMarkup}</div>`;
   }
 
   const hasActiveDescendant = sidebarNodeContainsRoute(node, currentRoutePath);

--- a/tests/gateway-http-docs.integration.test.ts
+++ b/tests/gateway-http-docs.integration.test.ts
@@ -190,6 +190,9 @@ describe('gateway docs HTTP integration', () => {
         `/docs/${section}`,
       );
     }
+    expect(html).not.toContain('/docs/internal');
+    expect(html).not.toContain('<summary>Internal</summary>');
+    expect(html).not.toContain('Agent, That Really Works');
     expect(html).toContain('<summary>Tutorials</summary>');
     expect(html).toContain('<summary>Skills</summary>');
     expect(html.indexOf('<summary>Skills</summary>')).toBeLessThan(

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -42,6 +42,7 @@ function makeTempDocsDir(options?: {
   const extensibilityDir = path.join(contentDocsDir, 'extensibility');
   const guidesDir = path.join(contentDocsDir, 'guides');
   const developerGuideDir = path.join(contentDocsDir, 'developer-guide');
+  const internalDir = path.join(contentDocsDir, 'internal');
   const referenceDir = path.join(contentDocsDir, 'reference');
   const consoleDistDir = path.join(root, 'console', 'dist');
   fs.mkdirSync(docsDir, { recursive: true });
@@ -51,6 +52,7 @@ function makeTempDocsDir(options?: {
   fs.mkdirSync(extensibilityDir, { recursive: true });
   fs.mkdirSync(guidesDir, { recursive: true });
   fs.mkdirSync(developerGuideDir, { recursive: true });
+  fs.mkdirSync(internalDir, { recursive: true });
   fs.mkdirSync(referenceDir, { recursive: true });
   fs.mkdirSync(consoleDistDir, { recursive: true });
   fs.writeFileSync(path.join(docsDir, 'index.html'), '<h1>Docs</h1>', 'utf8');
@@ -191,6 +193,31 @@ function makeTempDocsDir(options?: {
     'utf8',
   );
   fs.writeFileSync(
+    path.join(internalDir, 'roadmap.md'),
+    [
+      '---',
+      'title: Agent, That Really Works - Roadmap',
+      'description: Internal product roadmap. Not linked from public docs navigation.',
+      '---',
+      '',
+      '# Agent, That Really Works - Roadmap',
+      '',
+      'Private roadmap detail for issue links.',
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+  fs.writeFileSync(
+    path.join(internalDir, 'approval-rule-pipeline.md'),
+    [
+      '# Approval Rule Pipeline',
+      '',
+      'Internal approval pipeline implementation notes.',
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+  fs.writeFileSync(
     path.join(guidesDir, 'heading-order.md'),
     [
       '---',
@@ -269,6 +296,55 @@ function makeTempDocsDir(options?: {
       'Built-in tools and external tool surfaces live here.',
       '',
     ].join('\n'),
+    'utf8',
+  );
+  fs.writeFileSync(
+    path.join(contentDocsDir, 'navigation.json'),
+    `${JSON.stringify(
+      {
+        sections: [
+          {
+            title: 'Overview',
+            pages: [{ title: 'HybridClaw Docs', path: 'README.md' }],
+          },
+          {
+            title: 'Getting Started',
+            pages: [
+              { title: 'Getting Started', path: 'getting-started/README.md' },
+            ],
+          },
+          {
+            title: 'Channels',
+            pages: [{ title: 'Channels', path: 'channels/README.md' }],
+          },
+          {
+            title: 'Guides',
+            pages: [
+              { title: 'Guides', path: 'guides/README.md' },
+              { title: 'Heading Order', path: 'guides/heading-order.md' },
+            ],
+          },
+          {
+            title: 'Extensibility',
+            pages: [
+              { title: 'Extensibility', path: 'extensibility/README.md' },
+            ],
+          },
+          {
+            title: 'Developer Guide',
+            pages: [
+              { title: 'Developer Guide', path: 'developer-guide/README.md' },
+            ],
+          },
+          {
+            title: 'Reference',
+            pages: [{ title: 'Reference', path: 'reference/README.md' }],
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
     'utf8',
   );
   return root;
@@ -3714,10 +3790,40 @@ describe('gateway HTTP server', () => {
     expect(res.body).toContain('href="#getting-started"');
     expect(res.body).toContain('data-doc-copy-markdown');
     expect(res.body).toContain('href="/docs/README.md"');
-    expect(res.body).not.toContain(
+    expect(res.body).toContain(
       'class="docs-sidebar-link is-active" href="/docs"',
     );
-    expect(res.body).not.toContain('><span>HybridClaw Docs</span></a>');
+    expect(res.body).toContain('><span>HybridClaw Docs</span></a>');
+  });
+
+  test('hides internal docs from navigation and search while preserving direct links', async () => {
+    const state = await importFreshHealth();
+    const indexReq = makeRequest({ url: '/docs' });
+    const indexRes = makeResponse();
+
+    state.handler(indexReq as never, indexRes as never);
+
+    expect(indexRes.statusCode).toBe(200);
+    expect(indexRes.body).not.toContain('<summary>Internal</summary>');
+    expect(indexRes.body).not.toContain('href="/docs/internal/roadmap"');
+    expect(indexRes.body).not.toContain('Agent, That Really Works - Roadmap');
+
+    const searchReq = makeRequest({ url: '/docs?search=approval' });
+    const searchRes = makeResponse();
+    state.handler(searchReq as never, searchRes as never);
+
+    expect(searchRes.statusCode).toBe(200);
+    expect(searchRes.body).not.toContain(
+      'href="/docs/internal/approval-rule-pipeline"',
+    );
+
+    const directReq = makeRequest({ url: '/docs/internal/roadmap' });
+    const directRes = makeResponse();
+    state.handler(directReq as never, directRes as never);
+
+    expect(directRes.statusCode).toBe(200);
+    expect(directRes.body).toContain('Agent, That Really Works - Roadmap');
+    expect(directRes.body).not.toContain('<summary>Internal</summary>');
   });
 
   test('redirects legacy /development docs routes to /docs', async () => {


### PR DESCRIPTION
## Summary

- Move the explicit docs navigation list into `docs/content/navigation.json` as the single source of truth.
- Make the static docs app import that manifest instead of hardcoding its own nav list.
- Make the gateway docs renderer build sidebar and search metadata from the same manifest while still serving direct links to any markdown page under `docs/content`.
- Keep `docs/content/internal/**` direct-linkable but absent from docs navigation/search because it is not listed in the manifest.

## Root Cause

The static docs app had an explicit navigation list, but the gateway docs renderer built its sidebar by recursively scanning every markdown file under `docs/content`. That meant `docs/content/internal/*` appeared in gateway navigation even though it was not listed in the explicit docs nav.

## Validation

- `npm run format`
- `npm run typecheck`
- `./node_modules/.bin/vitest run --configLoader runner --project unit tests/docs-viewer.test.ts`
- `./node_modules/.bin/vitest run --configLoader runner --project unit tests/gateway-http-server.test.ts`
- `./node_modules/.bin/vitest run --configLoader runner --project integration tests/gateway-http-docs.integration.test.ts`
- `git diff --check`