### PR TITLE
[codex] Fix mobile chat QR session auth

### DIFF
--- a/src/gateway/auth-token.ts
+++ b/src/gateway/auth-token.ts
@@ -30,6 +30,10 @@ function readSharedSecret(): string {
   return (process.env.HYBRIDCLAW_AUTH_SECRET || '').trim();
 }
 
+export function hasSharedAuthSecret(): boolean {
+  return Boolean(readSharedSecret());
+}
+
 function parseSignedToken(token: string): ParsedToken | null {
   const trimmed = token.trim();
   if (!trimmed) return null;

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -144,6 +144,7 @@ import {
   getSessionAuthPayload,
   hasLocalWebSessionAuth,
   hasSessionAuth,
+  hasSharedAuthSecret,
   safeEqualToken,
   setLocalWebSessionCookie,
   setSessionCookie,
@@ -2257,15 +2258,6 @@ function resolveMobileLaunchToken(token: string):
   };
 }
 
-function resolveMobileLaunchAuthPayload(
-  req: IncomingMessage,
-  userId: string,
-): Record<string, unknown> {
-  const sessionPayload = getSessionAuthPayload(req);
-  if (sessionPayload) return sessionPayload;
-  return { sub: userId };
-}
-
 function normalizePublicBaseUrl(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
   const trimmed = value.trim();
@@ -3586,10 +3578,21 @@ async function handleApiChatMobileQr(
     return;
   }
 
+  const redirectPath = `/chat/${encodeURIComponent(sessionId)}`;
+  const mobileSessionCookieRequired =
+    requiresSessionAuth(redirectPath) || Boolean(WEB_API_TOKEN);
+  if (mobileSessionCookieRequired && !hasSharedAuthSecret()) {
+    sendJson(res, 500, {
+      error:
+        'Mobile launch QR code cannot establish a web session because HybridClaw auth secret is not configured.',
+    });
+    return;
+  }
+
   const token = createMobileLaunchToken({
     userId,
     sessionId,
-    authPayload: resolveMobileLaunchAuthPayload(req, userId),
+    authPayload: getSessionAuthPayload(req) ?? { sub: userId },
   });
   const launchUrl = buildMobileLaunchUrl({
     origin: resolveRequestOrigin(req, body.baseUrl),
@@ -3613,11 +3616,15 @@ function handleChatMobileContinue(res: ServerResponse, url: URL): void {
   const escapedUserId = escapeInlineScriptValue(launch.userId);
   const escapedSessionId = escapeInlineScriptValue(launch.sessionId);
   const redirectPath = `/chat/${encodeURIComponent(launch.sessionId)}`;
+  const mobileSessionCookieRequired =
+    requiresSessionAuth(redirectPath) || Boolean(WEB_API_TOKEN);
   try {
     setSessionCookie(res, launch.authPayload);
   } catch (err) {
     logger.warn({ err }, 'Failed to establish mobile launch web session');
-    if (requiresSessionAuth(redirectPath) || WEB_API_TOKEN) {
+    // WEB_API_TOKEN means mobile has no bearer-token path, so the session
+    // cookie is required.
+    if (mobileSessionCookieRequired) {
       sendText(
         res,
         500,

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -1609,6 +1609,7 @@ const MOBILE_LAUNCH_TOKEN_MAX_ENTRIES = 10_000;
 type MobileLaunchTokenEntry = {
   userId: string;
   sessionId: string;
+  authPayload: Record<string, unknown>;
   expiresAt: number;
 };
 const mobileLaunchTokens = new Map<string, MobileLaunchTokenEntry>();
@@ -2219,6 +2220,7 @@ function evictOldestMobileLaunchTokens(): void {
 function createMobileLaunchToken(params: {
   userId: string;
   sessionId: string;
+  authPayload: Record<string, unknown>;
 }): string {
   cleanupExpiredMobileLaunchTokens();
   evictOldestMobileLaunchTokens();
@@ -2226,6 +2228,7 @@ function createMobileLaunchToken(params: {
   mobileLaunchTokens.set(token, {
     userId: params.userId,
     sessionId: params.sessionId,
+    authPayload: params.authPayload,
     expiresAt: Date.now() + MOBILE_LAUNCH_TTL_MS,
   });
   return token;
@@ -2235,6 +2238,7 @@ function resolveMobileLaunchToken(token: string):
   | {
       userId: string;
       sessionId: string;
+      authPayload: Record<string, unknown>;
     }
   | undefined {
   cleanupExpiredMobileLaunchTokens();
@@ -2249,7 +2253,17 @@ function resolveMobileLaunchToken(token: string):
   return {
     userId: entry.userId,
     sessionId: entry.sessionId,
+    authPayload: entry.authPayload,
   };
+}
+
+function resolveMobileLaunchAuthPayload(
+  req: IncomingMessage,
+  userId: string,
+): Record<string, unknown> {
+  const sessionPayload = getSessionAuthPayload(req);
+  if (sessionPayload) return sessionPayload;
+  return { sub: userId };
 }
 
 function normalizePublicBaseUrl(value: unknown): string | undefined {
@@ -3572,7 +3586,11 @@ async function handleApiChatMobileQr(
     return;
   }
 
-  const token = createMobileLaunchToken({ userId, sessionId });
+  const token = createMobileLaunchToken({
+    userId,
+    sessionId,
+    authPayload: resolveMobileLaunchAuthPayload(req, userId),
+  });
   const launchUrl = buildMobileLaunchUrl({
     origin: resolveRequestOrigin(req, body.baseUrl),
     token,
@@ -3594,9 +3612,21 @@ function handleChatMobileContinue(res: ServerResponse, url: URL): void {
 
   const escapedUserId = escapeInlineScriptValue(launch.userId);
   const escapedSessionId = escapeInlineScriptValue(launch.sessionId);
-  const escapedRedirect = escapeInlineScriptValue(
-    `/chat/${encodeURIComponent(launch.sessionId)}`,
-  );
+  const redirectPath = `/chat/${encodeURIComponent(launch.sessionId)}`;
+  try {
+    setSessionCookie(res, launch.authPayload);
+  } catch (err) {
+    logger.warn({ err }, 'Failed to establish mobile launch web session');
+    if (requiresSessionAuth(redirectPath) || WEB_API_TOKEN) {
+      sendText(
+        res,
+        500,
+        'Mobile launch QR code could not establish a web session.',
+      );
+      return;
+    }
+  }
+  const escapedRedirect = escapeInlineScriptValue(redirectPath);
   res.writeHead(200, {
     'Content-Type': 'text/html; charset=utf-8',
     'Cache-Control': 'no-store',

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -2309,6 +2309,64 @@ useCleanMocks({
   suspendedSessions: [],
 });
 
+async function createAndRedeemMobileChatQr(params: {
+  state: Awaited<ReturnType<typeof importFreshHealth>>;
+  sessionId: string;
+  userId?: string;
+  baseUrl?: string;
+  continueNoAuth?: boolean;
+}): Promise<{
+  createRes: ReturnType<typeof makeResponse>;
+  payload: { launchUrl: string; expiresAt?: string; qrSvg?: string };
+  continueReq: ReturnType<typeof makeRequest>;
+  continueRes: ReturnType<typeof makeResponse>;
+  sessionCookie: string;
+}> {
+  const userId = params.userId || 'web-user-a';
+  const createReq = makeRequest({
+    method: 'POST',
+    url: '/api/chat/mobile-qr',
+    headers: {
+      authorization: 'Bearer web-token',
+    },
+    body: {
+      userId,
+      sessionId: params.sessionId,
+      baseUrl: params.baseUrl || 'https://example.test/chat',
+    },
+  });
+  const createRes = makeResponse();
+
+  params.state.handler(createReq as never, createRes as never);
+  await waitForResponse(createRes, (next) => next.writableEnded);
+
+  const payload = JSON.parse(createRes.body) as {
+    launchUrl: string;
+    expiresAt?: string;
+    qrSvg?: string;
+  };
+  const continueUrl = new URL(payload.launchUrl);
+  const continueReq = makeRequest({
+    url: `${continueUrl.pathname}${continueUrl.search}`,
+    ...(params.continueNoAuth ? { noAuth: true } : {}),
+  });
+  const continueRes = makeResponse();
+
+  params.state.handler(continueReq as never, continueRes as never);
+  await waitForResponse(continueRes, (next) => next.writableEnded);
+
+  return {
+    createRes,
+    payload,
+    continueReq,
+    continueRes,
+    sessionCookie: getCookiePair(
+      getSetCookieHeader(continueRes),
+      'hybridclaw_session',
+    ),
+  };
+}
+
 describe('gateway HTTP server', () => {
   test('starts the HTTP server and serves the health endpoint without auth', async () => {
     const state = await importFreshHealth();
@@ -5148,43 +5206,15 @@ describe('gateway HTTP server', () => {
       webApiToken: 'web-token',
     });
     const sessionId = 'agent:main:channel:web:chat:dm:peer:1234567890abcdef';
-    const createReq = makeRequest({
-      method: 'POST',
-      url: '/api/chat/mobile-qr',
-      headers: {
-        authorization: 'Bearer web-token',
-      },
-      body: {
-        userId: 'web-user-a',
-        sessionId,
-        baseUrl: 'https://example.test/chat',
-      },
-    });
-    const createRes = makeResponse();
-
-    state.handler(createReq as never, createRes as never);
-    await waitForResponse(createRes, (next) => next.writableEnded);
+    const { createRes, payload, continueReq, continueRes } =
+      await createAndRedeemMobileChatQr({ state, sessionId });
 
     expect(createRes.statusCode).toBe(200);
-    const payload = JSON.parse(createRes.body) as {
-      launchUrl: string;
-      expiresAt: string;
-      qrSvg: string;
-    };
     expect(payload.launchUrl).toMatch(
       /^https:\/\/example\.test\/chat\/continue\?token=/,
     );
     expect(payload.expiresAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     expect(payload.qrSvg).toContain('<svg');
-
-    const continueUrl = new URL(payload.launchUrl);
-    const continueReq = makeRequest({
-      url: `${continueUrl.pathname}${continueUrl.search}`,
-    });
-    const continueRes = makeResponse();
-
-    state.handler(continueReq as never, continueRes as never);
-    await waitForResponse(continueRes, (next) => next.writableEnded);
 
     expect(continueRes.statusCode).toBe(200);
     expect(continueRes.body).toContain(
@@ -5211,14 +5241,12 @@ describe('gateway HTTP server', () => {
     expect(replayRes.body).toBe('Mobile launch QR code is invalid or expired.');
   });
 
-  test('mobile chat QR handoff establishes session auth before redirecting to chat in Docker', async () => {
+  test('rejects protected mobile chat QR creation when auth secret is missing', async () => {
     const state = await importFreshHealth({
-      authSecret: 'mobile-qr-docker-auth-secret',
       runningInsideContainer: true,
       webApiToken: 'web-token',
     });
-    const sessionId = 'agent:main:channel:web:chat:dm:peer:1234567890abcdef';
-    const createReq = makeRequest({
+    const req = makeRequest({
       method: 'POST',
       url: '/api/chat/mobile-qr',
       headers: {
@@ -5226,30 +5254,35 @@ describe('gateway HTTP server', () => {
       },
       body: {
         userId: 'web-user-a',
-        sessionId,
+        sessionId: 'agent:main:channel:web:chat:dm:peer:1234567890abcdef',
         baseUrl: 'https://example.test/chat',
       },
     });
-    const createRes = makeResponse();
+    const res = makeResponse();
 
-    state.handler(createReq as never, createRes as never);
-    await waitForResponse(createRes, (next) => next.writableEnded);
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
 
-    const payload = JSON.parse(createRes.body) as { launchUrl: string };
-    const continueUrl = new URL(payload.launchUrl);
-    const continueReq = makeRequest({
-      url: `${continueUrl.pathname}${continueUrl.search}`,
-      noAuth: true,
+    expect(res.statusCode).toBe(500);
+    expect(JSON.parse(res.body)).toEqual({
+      error:
+        'Mobile launch QR code cannot establish a web session because HybridClaw auth secret is not configured.',
     });
-    const continueRes = makeResponse();
+  });
 
-    state.handler(continueReq as never, continueRes as never);
-    await waitForResponse(continueRes, (next) => next.writableEnded);
+  test('mobile chat QR handoff establishes session auth before redirecting to chat in Docker', async () => {
+    const state = await importFreshHealth({
+      authSecret: 'mobile-qr-docker-auth-secret',
+      runningInsideContainer: true,
+      webApiToken: 'web-token',
+    });
+    const sessionId = 'agent:main:channel:web:chat:dm:peer:1234567890abcdef';
+    const { continueRes, sessionCookie } = await createAndRedeemMobileChatQr({
+      state,
+      sessionId,
+      continueNoAuth: true,
+    });
 
-    const sessionCookie = getCookiePair(
-      getSetCookieHeader(continueRes),
-      'hybridclaw_session',
-    );
     expect(continueRes.statusCode).toBe(200);
     expect(sessionCookie).toMatch(/^hybridclaw_session=.+/);
     expect(continueRes.body).toContain(

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -5143,7 +5143,10 @@ describe('gateway HTTP server', () => {
   });
 
   test('creates and redeems mobile chat QR handoffs once', async () => {
-    const state = await importFreshHealth({ webApiToken: 'web-token' });
+    const state = await importFreshHealth({
+      authSecret: 'mobile-qr-auth-secret',
+      webApiToken: 'web-token',
+    });
     const sessionId = 'agent:main:channel:web:chat:dm:peer:1234567890abcdef';
     const createReq = makeRequest({
       method: 'POST',
@@ -5193,6 +5196,12 @@ describe('gateway HTTP server', () => {
     expect(continueRes.body).toContain(
       `window.location.replace("/chat/${encodeURIComponent(sessionId)}");`,
     );
+    expect(continueRes.headers['Set-Cookie']).toEqual(
+      expect.stringContaining('hybridclaw_session='),
+    );
+    expect(continueRes.headers['Set-Cookie']).toEqual(
+      expect.stringContaining('HttpOnly'),
+    );
 
     const replayRes = makeResponse();
     state.handler(continueReq as never, replayRes as never);
@@ -5200,6 +5209,65 @@ describe('gateway HTTP server', () => {
 
     expect(replayRes.statusCode).toBe(401);
     expect(replayRes.body).toBe('Mobile launch QR code is invalid or expired.');
+  });
+
+  test('mobile chat QR handoff establishes session auth before redirecting to chat in Docker', async () => {
+    const state = await importFreshHealth({
+      authSecret: 'mobile-qr-docker-auth-secret',
+      runningInsideContainer: true,
+      webApiToken: 'web-token',
+    });
+    const sessionId = 'agent:main:channel:web:chat:dm:peer:1234567890abcdef';
+    const createReq = makeRequest({
+      method: 'POST',
+      url: '/api/chat/mobile-qr',
+      headers: {
+        authorization: 'Bearer web-token',
+      },
+      body: {
+        userId: 'web-user-a',
+        sessionId,
+        baseUrl: 'https://example.test/chat',
+      },
+    });
+    const createRes = makeResponse();
+
+    state.handler(createReq as never, createRes as never);
+    await waitForResponse(createRes, (next) => next.writableEnded);
+
+    const payload = JSON.parse(createRes.body) as { launchUrl: string };
+    const continueUrl = new URL(payload.launchUrl);
+    const continueReq = makeRequest({
+      url: `${continueUrl.pathname}${continueUrl.search}`,
+      noAuth: true,
+    });
+    const continueRes = makeResponse();
+
+    state.handler(continueReq as never, continueRes as never);
+    await waitForResponse(continueRes, (next) => next.writableEnded);
+
+    const sessionCookie = getCookiePair(
+      getSetCookieHeader(continueRes),
+      'hybridclaw_session',
+    );
+    expect(continueRes.statusCode).toBe(200);
+    expect(sessionCookie).toMatch(/^hybridclaw_session=.+/);
+    expect(continueRes.body).toContain(
+      `window.location.replace("/chat/${encodeURIComponent(sessionId)}");`,
+    );
+
+    const chatReq = makeRequest({
+      url: `/chat/${encodeURIComponent(sessionId)}`,
+      headers: { cookie: sessionCookie },
+      noAuth: true,
+    });
+    const chatRes = makeResponse();
+
+    state.handler(chatReq as never, chatRes as never);
+
+    expect(chatRes.statusCode).toBe(200);
+    expect(chatRes.headers['Content-Type']).toBe('text/html; charset=utf-8');
+    expect(chatRes.body).toContain('<h1>Admin</h1>');
   });
 
   test('rejects expired mobile chat QR handoff tokens', async () => {


### PR DESCRIPTION
## Summary

Fix the mobile chat QR take-over flow so cloud/container deployments preserve Gateway web authentication after scanning the QR code.

## Root Cause

The `/chat/continue?token=...` endpoint only wrote the target chat user/session into `localStorage`. On cloud instances, `/chat/<session>` is protected by Gateway session auth, so the browser reached the right chat URL without a valid `hybridclaw_session` cookie and was redirected into the HybridAI login/API-key flow instead of opening the chat.

## Changes

- Store the current web-session auth payload with each one-time mobile launch token.
- Set a signed HttpOnly `hybridclaw_session` cookie when redeeming the QR token before redirecting to `/chat/<session>`.
- Preserve the existing one-time token and expiry behavior.
- Add a Docker/container-mode regression test that redeems the QR code and verifies `/chat/<session>` loads with the issued session cookie.

## Validation

- `npx vitest run tests/gateway-http-server.test.ts --testNamePattern mobile`
- `npx vitest run tests/gateway-http-server.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `npm run format`
- `git diff --check`