### PR TITLE
[codex] Update homepage facts

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,11 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>HybridClaw — Enterprise AI Digital Coworker</title>
-  <meta name="description" content="HybridClaw is an enterprise-ready AI coworker that unifies Discord, Slack, Telegram, Signal, Teams, iMessage, WhatsApp, email, web, and terminal workflows with memory, guardrails, and tool execution.">
+  <meta name="description" content="HybridClaw is an enterprise-ready AI coworker that unifies chat, email, voice, webhook, web, and terminal workflows with memory, guardrails, tool execution, and multi-agent coordination.">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="HybridClaw">
   <meta property="og:title" content="HybridClaw — Enterprise AI Digital Coworker">
-  <meta property="og:description" content="One assistant brain across Discord, Slack, Telegram, Signal, Teams, iMessage, WhatsApp, email, web, and terminal with shared memory, bundled skills, and safe execution flow.">
+  <meta property="og:description" content="One assistant brain across chat, email, voice, webhook, web, and terminal workflows with shared memory, bundled skills, safe execution, and multi-agent coordination.">
   <meta property="og:url" content="https://hybridaione.github.io/hybridclaw/">
   <meta property="og:image" content="https://hybridaione.github.io/hybridclaw/hero.png">
   <meta property="og:image:type" content="image/png">
@@ -17,7 +17,7 @@
   <meta property="og:image:alt" content="HybridClaw hero image">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="HybridClaw — Enterprise AI Digital Coworker">
-  <meta name="twitter:description" content="One assistant brain across Discord, Slack, Telegram, Signal, Teams, iMessage, WhatsApp, email, web, and terminal with shared memory, bundled skills, and safe execution flow.">
+  <meta name="twitter:description" content="One assistant brain across chat, email, voice, webhook, web, and terminal workflows with shared memory, bundled skills, safe execution, and multi-agent coordination.">
   <meta name="twitter:image" content="https://hybridaione.github.io/hybridclaw/hero.png">
   <link rel="canonical" href="https://hybridaione.github.io/hybridclaw/">
   <link rel="icon" type="image/svg+xml" href="/hybridclaw/static/hybridclaw-logo.svg?v=brand">
@@ -211,6 +211,8 @@
       font-size: 0.98rem;
       color: var(--accent-1);
       margin-bottom: 0.6rem;
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
     .hero-install-note {
       font-size: 0.82rem;
@@ -834,14 +836,14 @@
     aria-label="Powered by HybridAI (opens hybridai.one)"
   >Powered by <span>HybridAI</span></a>
   <h1>One assistant brain<br><span class="gradient">across every team channel</span></h1>
-  <p>HybridClaw gives Discord, Slack, Telegram, Signal, Teams, iMessage, WhatsApp, email, web, and terminal users the same memory, the same guardrails, and the same reliable execution flow.</p>
+  <p>HybridClaw gives Discord, Slack, Teams, Telegram, Signal, WhatsApp, Threema, iMessage, email, fax, voice, webhook, web, and terminal users the same memory, guardrails, and execution flow.</p>
   <div class="hero-install">
     <div class="hero-install-head">
       <div class="hero-install-label">Install (Linux/macOS)</div>
-      <button class="hero-copy-btn" type="button" onclick="navigator.clipboard.writeText('npm install -g @hybridaione/hybridclaw'); this.textContent='Copied'; setTimeout(() => this.textContent='Copy', 1400);">Copy</button>
+      <button class="hero-copy-btn" type="button" onclick="navigator.clipboard.writeText('curl -fsSL https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/scripts/install.sh | bash'); this.textContent='Copied'; setTimeout(() => this.textContent='Copy', 1400);">Copy</button>
     </div>
-    <code>npm install -g @hybridaione/hybridclaw</code>
-    <div class="hero-install-note">Prerequisites: Node.js 22+. Docker provides full container isolation, while containerized deployments can switch the gateway to host sandbox mode to avoid nested Docker. Browser automation tooling ships with the agent runtime. HybridAI API key setup can be completed during onboarding.</div>
+    <code>curl -fsSL https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/scripts/install.sh | bash</code>
+    <div class="hero-install-note">Prerequisites: Node.js 22+. The installer checks Node, installs the CLI, checks Docker, and can run onboarding. Docker provides full container isolation, while containerized deployments can switch to host sandbox mode. Manual npm install is still supported.</div>
   </div>
   <div class="hero-cta">
     <a href="#quickstart" class="btn btn-primary">Get Started</a>
@@ -860,12 +862,12 @@
     <div class="stat-label">Onboarding</div>
   </div>
   <div class="stat">
-    <div class="stat-value">30</div>
+    <div class="stat-value">76+</div>
     <div class="stat-label">Bundled Skills</div>
   </div>
   <div class="stat">
-    <div class="stat-value">9</div>
-    <div class="stat-label">Channel Integrations</div>
+    <div class="stat-value">13</div>
+    <div class="stat-label">Channel Transports</div>
   </div>
   <div class="stat">
     <div class="stat-value">Memory-First</div>
@@ -888,38 +890,38 @@
   <div class="section-center">
     <div class="section-label">Latest release: v0.24.4</div>
     <h2 class="section-title">Current release highlights</h2>
-    <p class="section-desc">HybridClaw v0.24.4 is a patch release focused on admin logging controls, clearer Logs page output, GPT-5 onboarding email guidance, and reliable admin dropdown selection.</p>
+    <p class="section-desc">HybridClaw v0.24.4 caps the 0.24 release line with admin logging controls, human distillation, cloud memory sync, A2A trust, hosted proxy agents, explicit addressing, and guarded business skills.</p>
   </div>
   <div class="features-grid">
     <div class="feature-card">
       <div class="feature-icon">&#x1f39b;</div>
-      <h3>Log modes</h3>
-      <p>The admin Logs page can switch logging Off, On, or Debug, persist runtime config, reload the gateway, and refresh the effective logging state.</p>
+      <h3>Admin log modes</h3>
+      <p>The admin Logs page can switch logging Off, On, or Debug, persist runtime config, reload the gateway, tail files, and refresh the effective logging state.</p>
     </div>
     <div class="feature-card">
-      <div class="feature-icon">&#x1f50d;</div>
-      <h3>Log readability</h3>
-      <p>Log tails stay pinned to the newest content, align cleanly when the tail starts mid-file, strip ANSI color codes, and show full local dates.</p>
+      <div class="feature-icon">&#x1f9ec;</div>
+      <h3>Human distillation</h3>
+      <p>The <code>coworker</code> command and <code>human-distill</code> skill turn consented source material into cited coworker agents with reversible merges, review items, and audit events.</p>
     </div>
     <div class="feature-card">
-      <div class="feature-icon">&#x2709;</div>
-      <h3>Onboarding email</h3>
-      <p>GPT-5-family hatching prompts direct the agent to send the welcome message once the user profile includes basic info and a valid email address.</p>
+      <div class="feature-icon">&#x2601;&#xfe0f;</div>
+      <h3>Cloud memory sync</h3>
+      <p>Agents can sync local memory with HybridAI cloud memory and receive shared installation- and company-scoped context back as read-only prompt material.</p>
     </div>
     <div class="feature-card">
-      <div class="feature-icon">&#x2705;</div>
-      <h3>Admin dropdowns</h3>
-      <p>Controlled native selects in the admin console apply the first selected option immediately after browser-style input and change events.</p>
+      <div class="feature-icon">&#x1f91d;</div>
+      <h3>A2A trust</h3>
+      <p>Instances can pair through the admin console, inspect Agent Cards, trust peer fingerprints, and receive signed inbound A2A envelopes with audit-visible decisions.</p>
     </div>
     <div class="feature-card">
-      <div class="feature-icon">&#x1f5c2;</div>
-      <h3>Log layout</h3>
-      <p>The Logs page gives the detail viewer more room, avoids duplicate path display, and keeps the selected log path visible in metadata.</p>
+      <div class="feature-icon">&#x1f4e1;</div>
+      <h3>Proxy agents and addressing</h3>
+      <p>Agents can proxy hosted HybridAI chatbots, while chat channels and web chat can address specific local, hosted, or trusted peer agents inline.</p>
     </div>
     <div class="feature-card">
       <div class="feature-icon">&#x1f9ea;</div>
-      <h3>Regression coverage</h3>
-      <p>Backend and console tests cover logging mode config, gateway reload behavior, model-response debug capture, log formatting, and native select handling.</p>
+      <h3>Guarded business skills</h3>
+      <p>New and updated helper-backed skills cover Mailchimp, BYD Battery, Hue, Blink, Alexa, home automation, cloud operations, marketing, finance, and document work with approval tiers.</p>
     </div>
   </div>
 </section>
@@ -991,7 +993,7 @@
     <div class="feature-card">
       <div class="feature-icon">&#x1f4da;</div>
       <h3>Answer with context</h3>
-      <p>Blend workspace memory, semantic recall, and typed knowledge-graph relations with HybridAI grounding to produce actionable answers.</p>
+      <p>Blend workspace memory, semantic recall, typed knowledge-graph relations, and optional HybridAI cloud memory with grounding to produce actionable answers.</p>
     </div>
     <div class="feature-card">
       <div class="feature-icon">&#x1f512;</div>
@@ -1001,12 +1003,12 @@
     <div class="feature-card">
       <div class="feature-icon">&#x1f504;</div>
       <h3>Stay consistent across channels</h3>
-      <p>Share one assistant behavior across Discord, Slack, Telegram, Signal, Teams, iMessage, WhatsApp, email, web, and terminal without managing separate bot personalities.</p>
+      <p>Share one assistant behavior across Discord, Slack, Teams, Telegram, Signal, WhatsApp, Threema, iMessage, email, fax, voice, webhooks, web, and terminal without managing separate bot personalities.</p>
     </div>
     <div class="feature-card">
       <div class="feature-icon">&#x1f9e0;</div>
       <h3>Remember what matters</h3>
-      <p>Persist and compact long-running conversations with canonical session keys, per-channel DM isolation by default, optional linked-identity continuity, and configurable token-budget controls.</p>
+      <p>Persist and compact long-running conversations with canonical session keys, per-channel DM isolation by default, optional linked-identity continuity, cloud memory sync, and configurable token-budget controls.</p>
     </div>
     <div class="feature-card">
       <div class="feature-icon">&#x23f0;</div>
@@ -1016,7 +1018,7 @@
     <div class="feature-card">
       <div class="feature-icon">&#x1f4ca;</div>
       <h3>Operate with visibility</h3>
-      <p>Track status, sessions, usage/cost aggregates, tamper-evident audit history, approval decisions, and observability export health from one runtime surface.</p>
+      <p>Track status, sessions, usage/cost aggregates, logs, secrets metadata, peer trust, tamper-evident audit history, approval decisions, and observability export health from one runtime surface.</p>
     </div>
     <div class="feature-card">
       <div class="feature-icon">&#x2601;&#xfe0f;</div>
@@ -1094,7 +1096,7 @@
         <tr>
           <td>Runtime Control</td>
           <td>
-            <span class="compare-text">Live config updates + SecretRefs + URL auth routes</span>
+            <span class="compare-text">Live config updates + admin logs/secrets + SecretRefs + URL auth routes</span>
           </td>
           <td>
             <span class="compare-text">Setup-dependent tuning</span>
@@ -1109,7 +1111,7 @@
         <tr>
           <td>Digital Coworker Feel</td>
           <td>
-            <span class="compare-text">Memory + proactive follow-up</span>
+            <span class="compare-text">Human distillation + memory + proactive follow-up</span>
           </td>
           <td>
             <span class="compare-text">Strong continuity model</span>
@@ -1124,7 +1126,7 @@
         <tr>
           <td>Enterprise Readiness</td>
           <td>
-            <span class="compare-text">Hash-chained audit plus local instruction integrity controls</span>
+            <span class="compare-text">Hash-chained audit, A2A trust, and local instruction integrity controls</span>
           </td>
           <td>
             <span class="compare-text">Strong base, extended per team</span>
@@ -1239,7 +1241,7 @@
           <td>Cross-session user modeling</td>
           <td><span class="compare-text"><span class="status-check" aria-hidden="true">&#10003;</span>Honcho model</span></td>
           <td><span class="compare-text"><span class="status-cross" aria-hidden="true">&#10007;</span>File-based only</span></td>
-          <td><span class="compare-text"><span class="status-check" aria-hidden="true">&#10003;</span>Linked identities + memory backends</span></td>
+          <td><span class="compare-text"><span class="status-check" aria-hidden="true">&#10003;</span>Linked identities + cloud memory + memory backends</span></td>
         </tr>
         <tr>
           <td>Session key continuity</td>
@@ -1266,7 +1268,7 @@
           <td>Skill system</td>
           <td><span class="compare-text"><span class="status-check" aria-hidden="true">&#10003;</span>54 bundled + Skills Hub</span></td>
           <td><span class="compare-text"><span class="status-check" aria-hidden="true">&#10003;</span>53 bundled + ClawHub</span></td>
-          <td><span class="compare-text">33 bundled + 7 import sources</span></td>
+          <td><span class="compare-text">76+ bundled + community imports</span></td>
         </tr>
         <tr>
           <td>Skill standard</td>
@@ -1328,7 +1330,7 @@
   <div class="arch-flow" style="flex-wrap: nowrap; gap: 10px; overflow: hidden; justify-content: center;">
     <div class="arch-node" style="min-width: 180px; max-width: 180px; height: 190px; padding: 16px 14px; box-sizing: border-box; display: flex; flex-direction: column; justify-content: center;">
       <div class="arch-node-label" style="font-size: 12px; letter-spacing: 0.08em;">Where people work</div>
-      <div class="arch-node-title" style="font-size: 18px; line-height: 1.2;">Slack / Discord / Teams<br>Telegram / Signal / iMessage / WhatsApp / Email<br>Web / Terminal</div>
+      <div class="arch-node-title" style="font-size: 18px; line-height: 1.2;">Slack / Discord / Teams<br>Telegram / Signal / WhatsApp<br>Email / iMessage / Fax / Voice<br>Web / Terminal / Webhooks</div>
       <div class="arch-node-desc" style="font-size: 14px; line-height: 1.35;">One shared user experience</div>
     </div>
     <div class="arch-arrow" style="font-size: 34px; line-height: 1; flex: 0 0 auto;">&rarr;</div>
@@ -1358,7 +1360,7 @@
     </div>
     <div class="arch-detail-card">
       <h4>Reliable Operations</h4>
-      <p>Clear runtime surfaces make it easier to monitor, maintain, and trust in production.</p>
+      <p>Admin surfaces for logs, secrets, channels, agents, fleet topology, A2A trust, distillation, jobs, and audit make production operation visible.</p>
     </div>
     <div class="arch-detail-card">
       <h4>Safety by Default</h4>
@@ -1390,8 +1392,8 @@
       <p>Append-only wire logs are SHA-256 hash-chained for tamper-evident immutability, with searchable events, verification, and approval history.</p>
     </div>
     <div class="feature-card">
-      <h3 style="color: var(--accent-1);">Request Debugging</h3>
-      <p>Gateway start/restart accepts <code>--log-requests</code> to persist best-effort redacted prompts, responses, and tool payloads in SQLite <code>request_log</code> for operator debugging. Typed browser input is always redacted.</p>
+      <h3 style="color: var(--accent-1);">Request Debugging &amp; Logs</h3>
+      <p>Gateway start/restart accepts <code>--log-requests</code>, while <code>/admin/logs</code> can switch logging Off, On, or Debug, persist <code>ops.logRequests</code> and <code>ops.debugModelResponses</code>, reload the gateway, and show redacted log tails.</p>
     </div>
     <div class="feature-card">
       <h3 style="color: var(--accent-1);">Local Eval Workflows</h3>
@@ -1411,7 +1413,7 @@
     </div>
     <div class="feature-card">
       <h3 style="color: var(--accent-1);">Memory Continuity</h3>
-      <p>Persistent workspace memory, nightly dream consolidation with startup catch-up, semantic memory, typed entity/relation knowledge graph, canonical transport session keys, linked-identity continuity scopes, and long-session compaction keep context coherent across Discord, Slack, Telegram, Signal, Teams, iMessage, WhatsApp, email, web, and terminal channels.</p>
+      <p>Persistent workspace memory, nightly dream consolidation with startup catch-up, semantic memory, typed entity/relation knowledge graph, canonical transport session keys, linked-identity continuity scopes, optional HybridAI cloud memory sync, and long-session compaction keep context coherent across channels.</p>
     </div>
     <div class="feature-card">
       <h3 style="color: var(--accent-1);">SQLite Reliability</h3>
@@ -1431,11 +1433,23 @@
     </div>
     <div class="feature-card">
       <h3 style="color: var(--accent-1);">Skills Engine</h3>
-      <p>HybridClaw ships with 35 bundled skills, including the <code>gog</code> Google Workspace CLI workflow, the <code>manim-video</code> animation workflow, and the <code>excalidraw</code> diagramming workflow, category-aware catalog and admin authoring flows, and OpenClaw/CLAUDE-compatible <code>SKILL.md</code> discovery with prompt embedding modes (<code>always</code>/<code>summary</code>/<code>hidden</code>), eligibility checks, and trust-aware security scanning. Community imports support packaged <code>official/&lt;skill&gt;</code> skills, <code>skills-sh</code>, <code>clawhub</code>, <code>lobehub</code>, <code>claude-marketplace</code>, <code>well-known</code>, and explicit GitHub repo/path sources via <code>hybridclaw skill import</code> or <code>/skill import</code>.</p>
+      <p>HybridClaw ships with 76+ bundled skills across office, publishing, business apps, cloud ops, home automation, energy monitoring, privacy, search, and coworker distillation, with helper-backed workflows, eval fixtures, category-aware catalog and admin authoring flows, OpenClaw/CLAUDE-compatible <code>SKILL.md</code> discovery, prompt embedding modes, eligibility checks, and trust-aware scanning. Community imports support packaged <code>official/&lt;skill&gt;</code> skills, <code>skills-sh</code>, <code>clawhub</code>, <code>lobehub</code>, <code>claude-marketplace</code>, <code>well-known</code>, and explicit GitHub repo/path sources.</p>
+    </div>
+    <div class="feature-card">
+      <h3 style="color: var(--accent-1);">Human Distillation</h3>
+      <p><code>hybridclaw coworker</code> and the bundled <code>human-distill</code> skill collect consented source material, mask third-party PII, build a cited corpus, merge persona files and work-module skills through reversible edits, and expose runs in <code>/admin/distill</code>.</p>
     </div>
     <div class="feature-card">
       <h3 style="color: var(--accent-1);">Agent Packaging</h3>
       <p><code>hybridclaw agent export|inspect|install</code> manages portable <code>.claw</code> archives that can bundle an agent workspace plus selected workspace skills and home plugins for backup, transfer, or bootstrap workflows. Legacy <code>pack|unpack</code> aliases still work.</p>
+    </div>
+    <div class="feature-card">
+      <h3 style="color: var(--accent-1);">A2A Federation</h3>
+      <p>HybridClaw instances can pair through <code>/admin/a2a-trust</code>, store peer trust, inspect fleet topology, receive signed JSON-RPC Agent Card envelopes, preserve recipient ownership, and expose inbound coordination through read-only admin inboxes.</p>
+    </div>
+    <div class="feature-card">
+      <h3 style="color: var(--accent-1);">Proxy Agents &amp; Addressing</h3>
+      <p>Per-agent proxy config can forward conversations to hosted HybridAI chatbots with SecretRef-backed keys and scoped conversation ids, while web chat and chat channels support explicit agent mentions, autocomplete, avatar-backed pills, and stable addressed-agent routing.</p>
     </div>
     <div class="feature-card">
       <h3 style="color: var(--accent-1);">Authenticated Browser Sessions</h3>
@@ -1467,7 +1481,7 @@
     </div>
     <div class="feature-card">
       <h3 style="color: var(--accent-1);">Interfaces &amp; Integrations</h3>
-      <p>Shared assistant behavior across Discord, Slack, Telegram, Signal, Teams, iMessage, WhatsApp, email, web, and terminal, plus bundled skills for office docs, GitHub, Notion, Stripe, WordPress, Google Workspace, Discord, email, and Apple workflows.</p>
+      <p>Shared assistant behavior across Discord, Slack, Teams, Telegram, Signal, WhatsApp, Threema, email, iMessage, fax, Twilio voice, webhooks, web, and terminal, plus bundled skills for office docs, GitHub, Notion, Stripe, WordPress, Google Workspace, marketing, cloud, home automation, energy, email, and Apple workflows.</p>
     </div>
     <div class="feature-card">
       <h3 style="color: var(--accent-1);">Observability Export</h3>
@@ -1479,7 +1493,7 @@
     </div>
     <div class="feature-card">
       <h3 style="color: var(--accent-1);">Admin Console</h3>
-      <p>Embedded browser-based admin at <code>/admin</code> with Dashboard, Terminal, Gateway, Sessions, Jobs, Bindings, Models, Scheduler, MCP, Audit, Skills, Plugins, Tools, and Config pages. Use <code>/admin/terminal</code> for a live PTY session, pair <code>/chat</code> with web conversations, and keep <code>/agents</code> open for workspace dashboards. When <code>WEB_API_TOKEN</code> is set, the auth callback can store it in browser storage and redirect to a safe relative destination without leaving the token in the URL.</p>
+      <p>Embedded browser-based admin at <code>/admin</code> with Dashboard, Terminal, Gateway, Channels, Agents, Logs, Secrets, Distill, Fleet Topology, A2A Trust, Sessions, Jobs, Bindings, Models, Scheduler, MCP, Audit, Skills, Plugins, Tools, Statistics, Output Guard, and Config pages. Use <code>/admin/terminal</code> for a live PTY session, pair <code>/chat</code> with web conversations, and keep <code>/agents</code> open for workspace dashboards.</p>
     </div>
     <div class="feature-card">
       <h3 style="color: var(--accent-1);">Commands</h3>
@@ -1494,7 +1508,7 @@
 <section id="tools">
   <div class="section-center">
     <div class="section-label">Toolbox</div>
-    <h2 class="section-title">17 built-in capabilities</h2>
+    <h2 class="section-title">19 built-in capability groups</h2>
     <p class="section-desc">From reading content to taking action, HybridClaw can complete real workflows end-to-end.</p>
   </div>
   <div class="tools-grid">
@@ -1569,6 +1583,16 @@
       <div class="tool-pill-desc">Analyze images with vision and auto-route to a capable fallback model when needed</div>
     </div>
     <div class="tool-pill">
+      <div class="tool-pill-icon">&#x1f399;&#xfe0f;</div>
+      <div class="tool-pill-name">audio_transcribe</div>
+      <div class="tool-pill-desc">Transcribe speech with language detection, timestamps, diarization, artifacts, and usage accounting</div>
+    </div>
+    <div class="tool-pill">
+      <div class="tool-pill-icon">&#x1f4ca;</div>
+      <div class="tool-pill-name">diagram_*</div>
+      <div class="tool-pill-desc">Create, update, and validate Mermaid-first diagrams with rendered artifacts</div>
+    </div>
+    <div class="tool-pill">
       <div class="tool-pill-icon">&#x1f4e8;</div>
       <div class="tool-pill-name">message</div>
       <div class="tool-pill-desc">Send across Slack, Discord, Teams, Telegram, Signal, WhatsApp, email</div>
@@ -1636,7 +1660,7 @@
     <div class="features-grid">
       <div class="feature-card">
         <h3 style="color: var(--accent-1);">1. Install CLI</h3>
-        <p><code>npm install -g @hybridaione/hybridclaw</code></p>
+        <p><code>curl -fsSL https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/scripts/install.sh | bash</code></p>
       </div>
       <div class="feature-card">
         <h3 style="color: var(--accent-1);">2. Initialize workspace</h3>
@@ -1658,7 +1682,7 @@
     <div class="quickstart-box">
       <pre>
 <span class="comment"># 60-second flow</span>
-<span class="cmd">npm install -g @hybridaione/hybridclaw</span>
+<span class="cmd">curl -fsSL https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/scripts/install.sh | bash</span>
 <span class="cmd">hybridclaw</span> <span class="flag">onboarding</span>
 <span class="cmd">hybridclaw</span> <span class="flag">gateway</span>
 <span class="cmd">hybridclaw</span> <span class="flag">tui</span></pre>
@@ -1670,7 +1694,7 @@
     <div class="features-grid">
       <div class="feature-card">
         <h3 style="color: var(--accent-teal);">1. Register free account</h3>
-        <p>Sign up at <a href="https://hybridai.one" target="_blank">hybridai.one</a> to create your free HybridAI account.</p>
+        <p>Start at <a href="https://hybridclaw.io" target="_blank">hybridclaw.io</a> to launch the managed HybridClaw cloud offering through HybridAI.</p>
       </div>
       <div class="feature-card">
         <h3 style="color: var(--accent-teal);">2. Upgrade account</h3>
@@ -1678,7 +1702,7 @@
       </div>
       <div class="feature-card">
         <h3 style="color: var(--accent-teal);">3. Launch cloud instance</h3>
-        <p>Start your personal HybridClaw in the cloud — running in a secured Docker container, fully managed and always-on.</p>
+        <p>Start your personal HybridClaw at <a href="https://hybridclaw.io" target="_blank">hybridclaw.io</a> in a secured, fully managed, always-on container.</p>
       </div>
       <div class="feature-card">
         <h3 style="color: var(--accent-teal);">4. Start using it</h3>
@@ -1710,7 +1734,7 @@ window.switchQsTab = (tab) => {
   <div class="faq-list">
     <div class="faq-item">
       <div class="faq-q">How do I diagnose setup problems quickly?</div>
-      <div class="faq-a">Run <code>hybridclaw doctor</code>. It checks runtime, gateway, config, credentials, database, providers, Docker, channels, skills, security, and disk state in parallel. Use <code>hybridclaw doctor --fix</code> to apply safe remediations where supported, or <code>--json</code> for CI-friendly output. When the environment checks pass but a specific turn still needs inspection, start or restart the gateway with <code>--log-requests</code> to persist best-effort redacted prompts, responses, and tool payloads in SQLite <code>request_log</code>.</div>
+      <div class="faq-a">Run <code>hybridclaw doctor</code>. It checks runtime, gateway, config, credentials, database, providers, Docker, channels, skills, security, and disk state in parallel. Use <code>hybridclaw doctor --fix</code> to apply safe remediations where supported, or <code>--json</code> for CI-friendly output. When a specific turn still needs inspection, use <code>/admin/logs</code> to switch logging Off, On, or Debug, or start the gateway with <code>--log-requests</code> for best-effort redacted request logging.</div>
     </div>
     <div class="faq-item">
       <div class="faq-q">Why does onboarding ask me to accept TRUST_MODEL.md?</div>
@@ -1762,11 +1786,11 @@ window.switchQsTab = (tab) => {
     </div>
     <div class="faq-item">
       <div class="faq-q">What is HybridClaw Cloud?</div>
-      <div class="faq-a">HybridClaw Cloud lets you run your agent in a fully managed, secured Docker container — no local installation, no infrastructure to maintain. Sign up at <a href="https://hybridai.one">hybridai.one</a>, choose a paid plan or redeem a voucher code, and launch your cloud instance in seconds. It supports the same features, channels, and integrations as the local version.</div>
+      <div class="faq-a">HybridClaw Cloud lets you run your agent in a fully managed, secured Docker container — no local installation, no infrastructure to maintain. Start at <a href="https://hybridclaw.io">hybridclaw.io</a>, choose a paid plan or redeem a voucher code, and launch your cloud instance in seconds. It supports the same features, channels, and integrations as the local version.</div>
     </div>
     <div class="faq-item">
       <div class="faq-q">Can I use it without Discord?</div>
-      <div class="faq-a">Absolutely. Run <code>hybridclaw tui</code>, use the built-in web chat, or connect Slack, Telegram, Signal, Microsoft Teams, iMessage, WhatsApp, or email. The same assistant behavior and context model is shared across supported interfaces, and gateway startup stays available even if one transport is temporarily misconfigured.</div>
+      <div class="faq-a">Absolutely. Run <code>hybridclaw tui</code>, use the built-in web chat, or connect Slack, Telegram, Signal, Microsoft Teams, iMessage, WhatsApp, Threema, email, fax, Twilio voice, or incoming webhooks. The same assistant behavior and context model is shared across supported interfaces, and gateway startup stays available even if one transport is temporarily misconfigured.</div>
     </div>
     <div class="faq-item">
       <div class="faq-q">How are screenshots returned in Discord?</div>
@@ -1814,7 +1838,7 @@ window.switchQsTab = (tab) => {
     </div>
     <div class="faq-item">
       <div class="faq-q">Is there a web-based admin interface?</div>
-      <div class="faq-a">Yes. The gateway serves an embedded admin console at <code>/admin</code> with pages for Dashboard, Terminal, Gateway, Sessions, Jobs, Bindings, Models, Scheduler, MCP, Audit, Skills, Plugins, Tools, and Config. The Skills page can create local skills from a form or ZIP upload and review adaptive-skill amendments. There is also a live browser terminal at <code>/admin/terminal</code>, a web chat at <code>/chat</code>, and an agent/session dashboard at <code>/agents</code>. When <code>WEB_API_TOKEN</code> is unset, localhost access opens without a login prompt. When it is set, the auth callback can store the token in browser storage and redirect to a safe relative path after login.</div>
+      <div class="faq-a">Yes. The gateway serves an embedded admin console at <code>/admin</code> with pages for Dashboard, Terminal, Gateway, Channels, Agents, Logs, Secrets, Distill, Fleet Topology, A2A Trust, Sessions, Jobs, Bindings, Models, Scheduler, MCP, Audit, Skills, Plugins, Tools, Statistics, Output Guard, and Config. The Skills page can create local skills from a form or ZIP upload and review adaptive-skill amendments. There is also a live browser terminal at <code>/admin/terminal</code>, web chat at <code>/chat</code>, and an agent/session dashboard at <code>/agents</code>.</div>
     </div>
     <div class="faq-item">
       <div class="faq-q">Can I use skills from CLAUDE.md or OpenClaw?</div>


### PR DESCRIPTION
## Summary

- Refresh the homepage metadata, hero copy, stats, release highlights, comparison rows, technical cards, toolbox, quickstart, and FAQ to match the recent changelog/README facts.
- Add current 0.24-line positioning for admin logs, human distillation, cloud memory sync, A2A trust, proxy agents, explicit addressing, expanded channel transports, and guarded business skills.
- Point install guidance at the one-line installer and cloud guidance at `hybridclaw.io`.

## Validation

- `npx biome check docs/index.html`
- `git diff --check`
- stale-fact scan for old homepage/version/count strings