### PR TITLE
[codex] add agent empty chat headers

### DIFF
--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -1071,6 +1071,7 @@ export interface AdminAgentProxyConfig {
 export interface AdminAgent {
   id: string;
   name: string | null;
+  emptyChatHeader?: string | null;
   model: string | null;
   skills: string[] | null;
   chatbotId: string | null;
@@ -1260,6 +1261,7 @@ export interface AgentListItem {
   id: string;
   name: string | null;
   imageUrl?: string | null;
+  emptyChatHeader?: string | null;
 }
 
 export interface AgentListResponse {

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -1596,6 +1596,25 @@ describe('ChatPage', () => {
     expect(fetchAppStatusMock).not.toHaveBeenCalled();
   });
 
+  it('uses the active agent empty chat header when configured', async () => {
+    fetchAgentListMock.mockResolvedValue([
+      {
+        id: 'main',
+        name: 'Assistant',
+        emptyChatHeader: 'Ready to tune the research engine?',
+      },
+      { id: 'charly', name: 'Charly' },
+    ]);
+    fetchChatHistoryMock.mockResolvedValue({
+      sessionId: 'session-a',
+      history: [],
+    });
+
+    renderChatPage();
+
+    expect(await screen.findByText('Ready to tune the research engine?'));
+  });
+
   it('collapses to the icon rail and exposes an Expand trigger that re-opens it', async () => {
     fetchChatHistoryMock.mockResolvedValue({
       sessionId: 'session-a',

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -82,6 +82,7 @@ const ERROR_BANNER_VISIBLE_MS = 5000;
 const ERROR_BANNER_FADE_MS = 200;
 const BOOTSTRAP_AUTOSTART_THINKING_ID = 'bootstrap-autostart-thinking';
 const BOOTSTRAP_AUTOSTART_REFETCH_MS = 1500;
+const DEFAULT_EMPTY_CHAT_HEADER = 'Ready to claw through your to-do list?';
 type RecentChatScope = 'user' | 'all';
 
 function buildBranchInfoMap(
@@ -305,6 +306,7 @@ export function ChatPage() {
         id: agent.id,
         name: agent.name,
         imageUrl: agent.imageUrl ?? null,
+        emptyChatHeader: agent.emptyChatHeader ?? null,
       })),
     [agentsQuery.data],
   );
@@ -389,10 +391,14 @@ export function ChatPage() {
   const branchFamilies =
     historyQuery.data?.branchFamilies ?? EMPTY_BRANCH_FAMILIES;
   const effectiveAgentId =
-    selectedAgentId ??
-    historyQuery.data?.agentId?.trim().toLowerCase() ??
-    appStatusQuery.data?.defaultAgentId?.trim().toLowerCase() ??
+    selectedAgentId?.trim().toLowerCase() ||
+    historyQuery.data?.agentId?.trim().toLowerCase() ||
+    appStatusQuery.data?.defaultAgentId?.trim().toLowerCase() ||
     DEFAULT_AGENT_ID;
+  const emptyChatHeader =
+    agentOptions
+      .find((agent) => agent.id.toLowerCase() === effectiveAgentId)
+      ?.emptyChatHeader?.trim() || DEFAULT_EMPTY_CHAT_HEADER;
 
   const deleteSessionMutation = useMutation({
     mutationFn: (targetSessionId: string) =>
@@ -1039,9 +1045,7 @@ export function ChatPage() {
           ) : null}
           {isEmpty ? (
             <div className={css.emptyState}>
-              <h1 className={css.greeting}>
-                Ready to claw through your to-do list?
-              </h1>
+              <h1 className={css.greeting}>{emptyChatHeader}</h1>
             </div>
           ) : (
             <div className={css.messageArea} ref={messageAreaRef}>

--- a/docs/content/extensibility/agent-packages.md
+++ b/docs/content/extensibility/agent-packages.md
@@ -109,10 +109,11 @@ payload can update only markdown without clearing the model, bot binding, skill
 allowlist, or RAG setting. Passing an empty value for a supported agent field
 clears that field.
 
-When `imageAsset` is an `http`/`https` URL or a local file path, `agent config`
-imports the image into the target workspace `assets/` directory and stores that
-workspace-relative path in the agent registry. Existing workspace-relative
-`imageAsset` paths are preserved as provided.
+`emptyChatHeader` sets the heading shown when the agent is selected in an empty
+chat. When `imageAsset` is an `http`/`https` URL or a local file path, `agent
+config` imports the image into the target workspace `assets/` directory and
+stores that workspace-relative path in the agent registry. Existing
+workspace-relative `imageAsset` paths are preserved as provided.
 
 Use `.claw` archives instead when you need portability, arbitrary workspace
 files, bundled workspace skills, bundled home plugins, or install-time external
@@ -246,6 +247,7 @@ interface ClawManifest {
   presentation?: {
     displayName?: string;
     imageAsset?: string;
+    emptyChatHeader?: string;
   };
 
   agent?: {

--- a/docs/content/reference/commands.md
+++ b/docs/content/reference/commands.md
@@ -397,11 +397,12 @@ for the same archive flows against a running gateway.
 pin an agent explicitly.
 
 `agent config` is the JSON provisioning path for generated agents. It upserts
-agent metadata directly, can overwrite top-level workspace markdown files, and
-imports `imageAsset` URLs or local file paths into the agent workspace:
+agent metadata directly, can overwrite top-level workspace markdown files, can
+set the empty-chat `emptyChatHeader`, and imports `imageAsset` URLs or local
+file paths into the agent workspace:
 
 ```bash
-hybridclaw agent config '{"id":"felix","model":"gpt-5.4-mini","imageAsset":"https://example.com/felix.jpg","markdown":{"IDENTITY.md":"# Felix\n"}}' --activate
+hybridclaw agent config '{"id":"felix","model":"gpt-5.4-mini","emptyChatHeader":"Ready to clear the support queue?","imageAsset":"https://example.com/felix.jpg","markdown":{"IDENTITY.md":"# Felix\n"}}' --activate
 ```
 
 Proxy agents use the same command with a per-agent `proxy` object:

--- a/src/agents/agent-config-command.ts
+++ b/src/agents/agent-config-command.ts
@@ -184,6 +184,14 @@ function applyAgentConfigFieldUpdates(
     if (imageAsset) next.imageAsset = imageAsset;
     else delete next.imageAsset;
   }
+  if (Object.hasOwn(updates, 'emptyChatHeader')) {
+    const emptyChatHeader = normalizeOptionalStringField(
+      'emptyChatHeader',
+      updates.emptyChatHeader,
+    );
+    if (emptyChatHeader) next.emptyChatHeader = emptyChatHeader;
+    else delete next.emptyChatHeader;
+  }
   if (Object.hasOwn(updates, 'model')) {
     const model = normalizeModelConfig(updates.model);
     if (model) next.model = model;

--- a/src/agents/agent-registry.ts
+++ b/src/agents/agent-registry.ts
@@ -181,6 +181,9 @@ function normalizeAgent(value: unknown): AgentConfig | null {
   const imageAsset = normalizeString(
     (value as { imageAsset?: unknown }).imageAsset,
   );
+  const emptyChatHeader = normalizeString(
+    (value as { emptyChatHeader?: unknown }).emptyChatHeader,
+  );
   const model = normalizeModelConfig((value as { model?: unknown }).model);
   const workspace = normalizeString(
     (value as { workspace?: unknown }).workspace,
@@ -222,7 +225,7 @@ function normalizeAgent(value: unknown): AgentConfig | null {
     id,
     ...identityFields,
     ...(name ? { name } : {}),
-    ...buildOptionalAgentPresentation(displayName, imageAsset),
+    ...buildOptionalAgentPresentation(displayName, imageAsset, emptyChatHeader),
     ...(model ? { model } : {}),
     ...(skills !== undefined ? { skills } : {}),
     ...(workspace ? { workspace } : {}),
@@ -301,6 +304,7 @@ function fingerprintAgent(agent: AgentConfig): string {
     fingerprintString(agent.name),
     fingerprintString(agent.displayName),
     fingerprintString(agent.imageAsset),
+    fingerprintString(agent.emptyChatHeader),
     fingerprintModel(agent.model),
     fingerprintStringArray(agent.skills),
     fingerprintString(agent.workspace),
@@ -407,7 +411,11 @@ function applyDefaults(agent: AgentConfig): AgentConfig {
     id: agent.id,
     ...identity,
     ...(agent.name ? { name: agent.name } : {}),
-    ...buildOptionalAgentPresentation(agent.displayName, agent.imageAsset),
+    ...buildOptionalAgentPresentation(
+      agent.displayName,
+      agent.imageAsset,
+      agent.emptyChatHeader,
+    ),
     ...(model ? { model } : {}),
     ...(skills !== undefined ? { skills } : {}),
     ...(agent.workspace ? { workspace: agent.workspace } : {}),
@@ -469,6 +477,7 @@ function configuredAgentForDatabase(agent: AgentConfig): AgentConfig {
     name: agent.name,
     displayName: agent.displayName,
     imageAsset: agent.imageAsset,
+    emptyChatHeader: agent.emptyChatHeader,
     model: cloneModelConfig(agent.model),
     skills: agent.skills,
     workspace: agent.workspace,

--- a/src/agents/agent-runtime-config.ts
+++ b/src/agents/agent-runtime-config.ts
@@ -33,6 +33,7 @@ function sameAgentConfig(a: AgentConfig | undefined, b: AgentConfig): boolean {
     a.name === b.name &&
     a.displayName === b.displayName &&
     a.imageAsset === b.imageAsset &&
+    a.emptyChatHeader === b.emptyChatHeader &&
     sameModelConfig(a.model, b.model) &&
     sameStringArray(a.skills, b.skills) &&
     a.workspace === b.workspace &&

--- a/src/agents/agent-types.ts
+++ b/src/agents/agent-types.ts
@@ -70,6 +70,7 @@ export interface AgentConfig {
   name?: string;
   displayName?: string;
   imageAsset?: string;
+  emptyChatHeader?: string;
   model?: AgentModelConfig;
   skills?: string[];
   workspace?: string;
@@ -152,10 +153,12 @@ export function normalizeAgentIdentityFields(params: {
 export function buildOptionalAgentPresentation(
   displayName?: string | null,
   imageAsset?: string | null,
-): Pick<AgentConfig, 'displayName' | 'imageAsset'> {
+  emptyChatHeader?: string | null,
+): Pick<AgentConfig, 'displayName' | 'imageAsset' | 'emptyChatHeader'> {
   return {
     ...(displayName ? { displayName } : {}),
     ...(imageAsset ? { imageAsset } : {}),
+    ...(emptyChatHeader ? { emptyChatHeader } : {}),
   };
 }
 

--- a/src/agents/claw-archive.ts
+++ b/src/agents/claw-archive.ts
@@ -998,7 +998,8 @@ export async function packAgent(
       : {}),
     createdAt: options.createdAt ?? new Date().toISOString(),
     ...(normalizeString(resolved.displayName) ||
-    normalizeString(resolved.imageAsset)
+    normalizeString(resolved.imageAsset) ||
+    normalizeString(resolved.emptyChatHeader)
       ? {
           presentation: {
             ...(normalizeString(resolved.displayName)
@@ -1006,6 +1007,9 @@ export async function packAgent(
               : {}),
             ...(normalizeString(resolved.imageAsset)
               ? { imageAsset: normalizeString(resolved.imageAsset) }
+              : {}),
+            ...(normalizeString(resolved.emptyChatHeader)
+              ? { emptyChatHeader: normalizeString(resolved.emptyChatHeader) }
               : {}),
           },
         }
@@ -1245,6 +1249,9 @@ export async function unpackAgent(
         : {}),
       ...(manifest.presentation?.imageAsset
         ? { imageAsset: manifest.presentation.imageAsset }
+        : {}),
+      ...(manifest.presentation?.emptyChatHeader
+        ? { emptyChatHeader: manifest.presentation.emptyChatHeader }
         : {}),
       ...(manifest.agent?.model ? { model: manifest.agent.model } : {}),
       ...(manifest.agent?.skills !== undefined

--- a/src/agents/claw-manifest.ts
+++ b/src/agents/claw-manifest.ts
@@ -28,6 +28,7 @@ export interface ClawPluginExternalRef {
 export interface ClawPresentation {
   displayName?: string;
   imageAsset?: string;
+  emptyChatHeader?: string;
 }
 
 export interface ClawManifest {
@@ -101,6 +102,7 @@ function normalizePresentation(value: unknown): ClawPresentation | undefined {
 
   const displayName = normalizeString(value.displayName);
   const imageAsset = normalizeString(value.imageAsset);
+  const emptyChatHeader = normalizeString(value.emptyChatHeader);
   if (
     imageAsset &&
     (path.isAbsolute(imageAsset) ||
@@ -112,10 +114,11 @@ function normalizePresentation(value: unknown): ClawPresentation | undefined {
     );
   }
 
-  if (!displayName && !imageAsset) return undefined;
+  if (!displayName && !imageAsset && !emptyChatHeader) return undefined;
   return {
     ...(displayName ? { displayName } : {}),
     ...(imageAsset ? { imageAsset } : {}),
+    ...(emptyChatHeader ? { emptyChatHeader } : {}),
   };
 }
 

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -2790,6 +2790,13 @@ function normalizeAgentConfig(
       allowEmpty: true,
     },
   );
+  const emptyChatHeader = normalizeString(
+    value.emptyChatHeader,
+    fallback?.emptyChatHeader ?? '',
+    {
+      allowEmpty: true,
+    },
+  );
   const model = normalizeAgentModelConfig(value.model, fallback?.model);
   const workspace = normalizeString(
     value.workspace,
@@ -2867,7 +2874,7 @@ function normalizeAgentConfig(
     id,
     ...identityFields,
     ...(name ? { name } : {}),
-    ...buildOptionalAgentPresentation(displayName, imageAsset),
+    ...buildOptionalAgentPresentation(displayName, imageAsset, emptyChatHeader),
     ...(model ? { model } : {}),
     ...(skills !== undefined ? { skills } : {}),
     ...(workspace ? { workspace } : {}),

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -1500,6 +1500,7 @@ function mapGatewayAdminAgent(
   return {
     id: resolved.id,
     name: resolved.name || null,
+    emptyChatHeader: resolved.emptyChatHeader || null,
     model: resolveAgentModel(resolved) || null,
     skills: Array.isArray(resolved.skills) ? [...resolved.skills] : null,
     chatbotId: resolved.chatbotId || null,
@@ -8370,6 +8371,9 @@ export function getGatewayAgentList(): GatewayAgentListResponse {
         id: agent.id,
         name: agent.name || null,
         ...(presentation.imageUrl ? { imageUrl: presentation.imageUrl } : {}),
+        ...(agent.emptyChatHeader
+          ? { emptyChatHeader: agent.emptyChatHeader }
+          : {}),
       };
     }),
   };

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -833,6 +833,7 @@ export interface GatewayAgentListItem {
   id: string;
   name: string | null;
   imageUrl?: string;
+  emptyChatHeader?: string;
 }
 
 export interface GatewayAgentListResponse {
@@ -1206,6 +1207,7 @@ export interface GatewayAdminAgentProxyConfig {
 export interface GatewayAdminAgent {
   id: string;
   name: string | null;
+  emptyChatHeader: string | null;
   model: string | null;
   skills: string[] | null;
   chatbotId: string | null;

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -162,7 +162,7 @@ let databaseInitialized = false;
 let usageEventBatchInsertStatement: Database.Statement | null = null;
 const usageRecordSubscribers = new Set<UsageRecordSubscriber>();
 
-export const DATABASE_SCHEMA_VERSION = 44;
+export const DATABASE_SCHEMA_VERSION = 45;
 const AGENT_CANONICAL_ID_COLLISION_LIMIT = 20;
 const DEFAULT_LOCAL_OWNER_USER_ID = formatLocalOwnerUserId('');
 const STRUCTURED_AUDIT_SESSION_LIMIT = 10_000;
@@ -216,6 +216,7 @@ type AgentRow = {
   name: string | null;
   display_name: string | null;
   image_asset: string | null;
+  empty_chat_header: string | null;
   model: string | null;
   skills: string | null;
   chatbot_id: string | null;
@@ -565,6 +566,15 @@ function agentProxyNeedMigration(database: Database.Database): boolean {
   return (
     tableExists(database, 'agents') &&
     !columnExists(database, 'agents', 'proxy')
+  );
+}
+
+function agentEmptyChatHeaderNeedMigration(
+  database: Database.Database,
+): boolean {
+  return (
+    tableExists(database, 'agents') &&
+    !columnExists(database, 'agents', 'empty_chat_header')
   );
 }
 
@@ -1406,6 +1416,7 @@ function migrateV6(
         name TEXT,
         display_name TEXT,
         image_asset TEXT,
+        empty_chat_header TEXT,
         model TEXT,
         skills TEXT,
         chatbot_id TEXT,
@@ -3074,6 +3085,20 @@ function migrateV44(
   recordMigration(database, 44, 'Persist per-agent proxy backend metadata');
 }
 
+function migrateV45(
+  database: Database.Database,
+  opts?: InitDatabaseOptions,
+): void {
+  addColumnIfMissing({
+    database,
+    table: 'agents',
+    column: 'empty_chat_header',
+    ddl: 'empty_chat_header TEXT',
+    quiet: opts?.quiet === true,
+  });
+  recordMigration(database, 45, 'Persist per-agent empty chat header');
+}
+
 function runMigrations(
   database: Database.Database,
   opts?: InitDatabaseOptions,
@@ -3185,6 +3210,9 @@ function runMigrations(
   }
   if (currentVersion < 44 || agentProxyNeedMigration(database)) {
     migrateV44(database, opts);
+  }
+  if (currentVersion < 45 || agentEmptyChatHeaderNeedMigration(database)) {
+    migrateV45(database, opts);
   }
 
   setSchemaVersion(database, DATABASE_SCHEMA_VERSION);
@@ -3625,6 +3653,7 @@ function mapAgentRow(row: AgentRow): AgentConfig {
   const name = row.name?.trim() || '';
   const displayName = row.display_name?.trim() || '';
   const imageAsset = row.image_asset?.trim() || '';
+  const emptyChatHeader = row.empty_chat_header?.trim() || '';
   const model = parseAgentModelConfig(row.model);
   const skills = parseAgentSkillsConfig(row.skills);
   const chatbotId = row.chatbot_id?.trim() || '';
@@ -3645,6 +3674,7 @@ function mapAgentRow(row: AgentRow): AgentConfig {
     ...(name ? { name } : {}),
     ...(displayName ? { displayName } : {}),
     ...(imageAsset ? { imageAsset } : {}),
+    ...(emptyChatHeader ? { emptyChatHeader } : {}),
     ...(model ? { model } : {}),
     ...(skills !== undefined ? { skills } : {}),
     ...(chatbotId ? { chatbotId } : {}),
@@ -3665,7 +3695,7 @@ function mapAgentRow(row: AgentRow): AgentConfig {
 }
 
 const AGENT_SELECT_COLUMNS =
-  'id, canonical_id, owner_user_id, name, display_name, image_asset, model, skills, chatbot_id, enable_rag, workspace, owner, role, reports_to, delegates_to, peers, cv, escalation_target, a2a, proxy, created_at, updated_at';
+  'id, canonical_id, owner_user_id, name, display_name, image_asset, empty_chat_header, model, skills, chatbot_id, enable_rag, workspace, owner, role, reports_to, delegates_to, peers, cv, escalation_target, a2a, proxy, created_at, updated_at';
 
 export function getAgentById(agentId: string): AgentConfig | null {
   const normalizedAgentId = agentId.trim();
@@ -3700,6 +3730,7 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
   const normalizedName = agent.name?.trim() || null;
   const normalizedDisplayName = agent.displayName?.trim() || null;
   const normalizedImageAsset = agent.imageAsset?.trim() || null;
+  const normalizedEmptyChatHeader = agent.emptyChatHeader?.trim() || null;
   const normalizedModel = serializeAgentModelConfig(agent.model);
   const normalizedSkills = serializeAgentSkillsConfig(agent.skills);
   const normalizedChatbotId = agent.chatbotId?.trim() || null;
@@ -3765,6 +3796,7 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
        name,
        display_name,
        image_asset,
+       empty_chat_header,
        model,
        skills,
        chatbot_id,
@@ -3781,13 +3813,14 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
        proxy,
        created_at,
        updated_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
      ON CONFLICT(id) DO UPDATE SET
        canonical_id = excluded.canonical_id,
        owner_user_id = excluded.owner_user_id,
        name = excluded.name,
        display_name = excluded.display_name,
        image_asset = excluded.image_asset,
+       empty_chat_header = excluded.empty_chat_header,
        model = excluded.model,
        skills = excluded.skills,
        chatbot_id = excluded.chatbot_id,
@@ -3810,6 +3843,7 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
     normalizedName,
     normalizedDisplayName,
     normalizedImageAsset,
+    normalizedEmptyChatHeader,
     normalizedModel,
     normalizedSkills,
     normalizedChatbotId,

--- a/tests/agent-config-command.test.ts
+++ b/tests/agent-config-command.test.ts
@@ -33,6 +33,8 @@ test('agent config command accepts direct JSON and overwrites markdown files', a
     JSON.stringify({
       id: 'felix',
       name: 'Felix',
+      displayName: 'Felix Support',
+      emptyChatHeader: 'Ready to clear the support queue?',
       model: 'gpt-5.4-mini',
       chatbotId: 'bot-felix',
       enableRag: true,
@@ -53,6 +55,8 @@ test('agent config command accepts direct JSON and overwrites markdown files', a
   expect(getAgentById('felix')).toMatchObject({
     id: 'felix',
     name: 'Felix',
+    displayName: 'Felix Support',
+    emptyChatHeader: 'Ready to clear the support queue?',
     model: 'gpt-5.4-mini',
     chatbotId: 'bot-felix',
     enableRag: true,

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -677,6 +677,9 @@ test('legacy agents without org-chart fields load cleanly after migration v26', 
   expect(columns.some((column) => column.name === 'reports_to')).toBe(true);
   expect(columns.some((column) => column.name === 'delegates_to')).toBe(true);
   expect(columns.some((column) => column.name === 'peers')).toBe(true);
+  expect(columns.some((column) => column.name === 'empty_chat_header')).toBe(
+    true,
+  );
 
   const userVersion = migratedDb.pragma('user_version', { simple: true });
   expect(userVersion).toBeGreaterThanOrEqual(26);

--- a/tests/agent-types.test.ts
+++ b/tests/agent-types.test.ts
@@ -15,10 +15,15 @@ import {
 
 test('buildOptionalAgentPresentation includes only populated presentation fields', () => {
   expect(
-    buildOptionalAgentPresentation('Charly', 'avatars/charly.png'),
+    buildOptionalAgentPresentation(
+      'Charly',
+      'avatars/charly.png',
+      'Ready for field notes?',
+    ),
   ).toEqual({
     displayName: 'Charly',
     imageAsset: 'avatars/charly.png',
+    emptyChatHeader: 'Ready for field notes?',
   });
   expect(buildOptionalAgentPresentation('', '')).toEqual({});
   expect(

--- a/tests/unit/claw-archive.test.ts
+++ b/tests/unit/claw-archive.test.ts
@@ -224,6 +224,7 @@ describe('.claw archive support', () => {
           name: 'Main Agent',
           displayName: 'Captain Claw',
           imageAsset: 'avatars/main.png',
+          emptyChatHeader: 'Ready to chart the course?',
           model: 'gpt-5-mini',
           skills: ['custom-skill'],
           enableRag: false,
@@ -266,6 +267,7 @@ describe('.claw archive support', () => {
           name: 'Main Agent',
           displayName: 'Captain Claw',
           imageAsset: 'avatars/main.png',
+          emptyChatHeader: 'Ready to chart the course?',
           model: 'gpt-5-mini',
           skills: ['custom-skill'],
           enableRag: false,
@@ -300,6 +302,7 @@ describe('.claw archive support', () => {
     expect(inspection.manifest.presentation).toEqual({
       displayName: 'Captain Claw',
       imageAsset: 'avatars/main.png',
+      emptyChatHeader: 'Ready to chart the course?',
     });
     expect(inspection.manifest.agent?.model).toBe('gpt-5-mini');
     expect(inspection.manifest.agent?.skills).toEqual(['custom-skill']);
@@ -337,6 +340,7 @@ describe('.claw archive support', () => {
       name: 'Main Agent',
       displayName: 'Captain Claw',
       imageAsset: 'avatars/main.png',
+      emptyChatHeader: 'Ready to chart the course?',
       skills: ['custom-skill'],
     });
     expect(


### PR DESCRIPTION
## Summary

- Add `emptyChatHeader` to agent metadata so `.claw` manifests and `agent config` can define the empty-chat greeting.
- Persist the new field through registry/runtime config, `.claw` pack/install, and a schema v45 database migration.
- Expose the header through the gateway agent list and render it in the console empty chat state, with docs and tests updated.

## Validation

- `npx vitest run tests/agent-config-command.test.ts tests/agent-types.test.ts tests/agent-registry.test.ts tests/unit/claw-archive.test.ts`
- `cd console && npx vitest run src/routes/chat/chat-page.test.tsx --config vitest.config.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run check` (passes with existing optional-chain warnings outside this change)
- `git diff --check`