### PR TITLE
Remove HybridClaw chat request signing

### DIFF
--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -750,7 +750,6 @@ async function executePreparedToolCall(
 
 async function callHybridAIWithRetry(params: {
   sessionId?: string;
-  agentId?: string;
   provider?: ContainerInput['provider'];
   providerMethod?: string;
   baseUrl: string;
@@ -773,7 +772,6 @@ async function callHybridAIWithRetry(params: {
 }): Promise<ChatCompletionResponse> {
   const {
     sessionId,
-    agentId,
     provider,
     providerMethod,
     baseUrl,
@@ -821,7 +819,6 @@ async function callHybridAIWithRetry(params: {
             provider,
             providerMethod,
             sessionId,
-            agentId,
             baseUrl,
             apiKey,
             model,
@@ -850,7 +847,6 @@ async function callHybridAIWithRetry(params: {
             provider,
             providerMethod,
             sessionId,
-            agentId,
             baseUrl,
             apiKey,
             model,
@@ -872,7 +868,6 @@ async function callHybridAIWithRetry(params: {
           provider,
           providerMethod,
           sessionId,
-          agentId,
           baseUrl,
           apiKey,
           model,
@@ -929,7 +924,6 @@ async function callHybridAIWithRetry(params: {
  */
 interface ProcessRequestParams {
   sessionId: string;
-  agentId?: string;
   messages: ChatMessage[];
   apiKey: string;
   baseUrl: string;
@@ -993,7 +987,6 @@ async function processRequest(
 ): Promise<ContainerOutput> {
   const {
     sessionId,
-    agentId,
     messages,
     apiKey,
     baseUrl,
@@ -1327,7 +1320,6 @@ async function processRequest(
     try {
       response = await callHybridAIWithRetry({
         sessionId,
-        agentId,
         provider,
         providerMethod,
         baseUrl,
@@ -1992,7 +1984,6 @@ async function main(): Promise<void> {
   } else {
     firstOutput = await processRequest({
       sessionId: firstInput.sessionId,
-      agentId: firstInput.agentId,
       messages: firstMessagesForRequest,
       apiKey: storedApiKey,
       baseUrl: firstInput.baseUrl,
@@ -2036,7 +2027,6 @@ async function main(): Promise<void> {
         injectSkillCacheHint(firstRetryMessages);
       firstOutput = await processRequest({
         sessionId: firstInput.sessionId,
-        agentId: firstInput.agentId,
         messages: firstRetryMessagesWithSkillCache,
         apiKey: storedApiKey,
         baseUrl: firstInput.baseUrl,
@@ -2188,7 +2178,6 @@ async function main(): Promise<void> {
 
     let output = await processRequest({
       sessionId: input.sessionId,
-      agentId: input.agentId,
       messages: messagesForRequestWithSkillCache,
       apiKey,
       baseUrl: input.baseUrl,
@@ -2231,7 +2220,6 @@ async function main(): Promise<void> {
       const retryMessagesWithSkillCache = injectSkillCacheHint(retryMessages);
       output = await processRequest({
         sessionId: input.sessionId,
-        agentId: input.agentId,
         messages: retryMessagesWithSkillCache,
         apiKey,
         baseUrl: input.baseUrl,

--- a/container/src/providers/hybridai.ts
+++ b/container/src/providers/hybridai.ts
@@ -1,4 +1,3 @@
-import { createHash, createHmac, randomUUID } from 'node:crypto';
 import { stripHybridAIModelPrefix } from '../../shared/model-names.js';
 import type { ChatCompletionResponse, ToolCall } from '../types.js';
 import {
@@ -41,40 +40,6 @@ interface StreamChunkPayload {
   model?: string;
   usage?: ChatCompletionResponse['usage'];
   choices?: StreamChoiceChunk[];
-}
-
-const HYBRIDCLAW_SIGNATURE_PATH = '/v1/chat/completions';
-
-function hybridclawAuthSecret(): string {
-  return String(process.env.HYBRIDCLAW_AUTH_SECRET || '').trim();
-}
-
-function buildHybridClawSignatureHeaders(
-  args: NormalizedCallArgs,
-  bodyText: string,
-): Record<string, string> {
-  const secret = hybridclawAuthSecret();
-  if (!secret) return {};
-  const timestamp = String(Math.floor(Date.now() / 1000));
-  const nonce = randomUUID();
-  const bodyHash = createHash('sha256').update(bodyText, 'utf8').digest('hex');
-  const signaturePayload = [
-    'POST',
-    HYBRIDCLAW_SIGNATURE_PATH,
-    bodyHash,
-    timestamp,
-    nonce,
-  ].join('\n');
-  const signature = createHmac('sha256', secret)
-    .update(signaturePayload, 'utf8')
-    .digest('hex');
-  return {
-    'X-HybridClaw-Session-Id': String(args.sessionId || ''),
-    'X-HybridClaw-Agent-Id': String(args.agentId || ''),
-    'X-HybridClaw-Timestamp': timestamp,
-    'X-HybridClaw-Nonce': nonce,
-    'X-HybridClaw-Signature': signature,
-  };
 }
 
 function buildHybridAIRequestBody(
@@ -154,7 +119,6 @@ export async function callHybridAIProvider(
   args: NormalizedCallArgs,
 ): Promise<ChatCompletionResponse> {
   const body = buildHybridAIRequestBody(args);
-  const bodyText = JSON.stringify(body);
   if (args.debugModelResponses) {
     logLastPrompt({
       sessionId: args.sessionId,
@@ -170,11 +134,8 @@ export async function callHybridAIProvider(
   }
   const response = await fetch(`${args.baseUrl}/v1/chat/completions`, {
     method: 'POST',
-    headers: {
-      ...buildRequestHeaders(args.apiKey, args.requestHeaders),
-      ...buildHybridClawSignatureHeaders(args, bodyText),
-    },
-    body: bodyText,
+    headers: buildRequestHeaders(args.apiKey, args.requestHeaders),
+    body: JSON.stringify(body),
   });
 
   if (!response.ok) {
@@ -204,7 +165,6 @@ export async function callHybridAIProviderStream(
       include_usage: true,
     },
   };
-  const bodyText = JSON.stringify(body);
   if (args.debugModelResponses) {
     logLastPrompt({
       sessionId: args.sessionId,
@@ -224,9 +184,8 @@ export async function callHybridAIProviderStream(
     headers: {
       ...buildRequestHeaders(args.apiKey, args.requestHeaders),
       Accept: 'text/event-stream, application/x-ndjson, application/json',
-      ...buildHybridClawSignatureHeaders(args, bodyText),
     },
-    body: bodyText,
+    body: JSON.stringify(body),
   });
 
   if (!response.ok) {

--- a/container/src/providers/router.ts
+++ b/container/src/providers/router.ts
@@ -43,7 +43,6 @@ const DEFAULT_VISION_INSTRUCTIONS =
 
 export interface RoutedModelContext {
   sessionId?: string;
-  agentId?: string;
   provider: RuntimeProvider | undefined;
   providerMethod?: string;
   baseUrl: string;
@@ -86,7 +85,6 @@ export interface RoutedVisionCallParams extends RoutedModelContext {
 function buildCallArgs(params: RoutedModelCallParams): NormalizedCallArgs {
   return {
     sessionId: params.sessionId,
-    agentId: params.agentId,
     provider: params.provider,
     providerMethod: params.providerMethod,
     baseUrl: params.baseUrl.trim(),

--- a/container/src/providers/shared.ts
+++ b/container/src/providers/shared.ts
@@ -15,7 +15,6 @@ export type { RuntimeProvider } from './provider-ids.js';
 
 export interface NormalizedCallArgs {
   sessionId?: string;
-  agentId?: string;
   provider: RuntimeProvider | undefined;
   providerMethod?: string;
   baseUrl: string;

--- a/tests/provider-prompt-debug.test.ts
+++ b/tests/provider-prompt-debug.test.ts
@@ -1,4 +1,3 @@
-import { createHash, createHmac } from 'node:crypto';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import { callHybridAIProvider } from '../container/src/providers/hybridai.js';
@@ -90,63 +89,6 @@ describe('provider prompt debug logging', () => {
 
     expect(stderr).toHaveBeenCalledWith(
       expect.stringContaining('[last-prompt-file]'),
-    );
-  });
-
-  test('signs HybridClaw instance requests when auth secret is available', async () => {
-    vi.stubEnv('HYBRIDCLAW_AUTH_SECRET', 'hybridclaw-secret');
-
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-        const headers = init?.headers as Record<string, string>;
-        const bodyText = String(init?.body || '');
-        const timestamp = headers['X-HybridClaw-Timestamp'];
-        const nonce = headers['X-HybridClaw-Nonce'];
-        const bodyHash = createHash('sha256')
-          .update(bodyText, 'utf8')
-          .digest('hex');
-        const expectedSignature = createHmac('sha256', 'hybridclaw-secret')
-          .update(
-            ['POST', '/v1/chat/completions', bodyHash, timestamp, nonce].join(
-              '\n',
-            ),
-            'utf8',
-          )
-          .digest('hex');
-
-        expect(headers['X-HybridClaw-Session-Id']).toBe('sess_test');
-        expect(headers['X-HybridClaw-Agent-Id']).toBe('bob5');
-        expect(Number(timestamp)).toBeGreaterThan(0);
-        expect(nonce).toMatch(
-          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
-        );
-        expect(headers['X-HybridClaw-Signature']).toBe(expectedSignature);
-
-        return new Response(
-          JSON.stringify({
-            id: 'chatcmpl_1',
-            model: 'gpt-4.1-mini',
-            choices: [
-              {
-                message: { role: 'assistant', content: 'ok' },
-                finish_reason: 'stop',
-              },
-            ],
-          }),
-          {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          },
-        );
-      }),
-    );
-
-    await callHybridAIProvider(
-      makeArgs({
-        sessionId: 'sess_test',
-        agentId: 'bob5',
-      }),
     );
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to the onboarding/bot-clear work after simplifying the chat-side rule:

- remove `X-HybridClaw-Signature` request signing from container HybridAI chat calls
- remove the provider/router plumbing that only existed for that signature gate
- remove the signature-focused provider prompt debug test

The matching chat PR now always combines API-provided system messages with HybridAI bot instructions, so HybridClaw no longer needs a request-signing path for this behavior.

## Validation

- `npm run security:secret-scan`
- `./node_modules/.bin/vitest run --configLoader runner --project unit tests/gateway-service.bot-auth.test.ts tests/gateway-service.bootstrap-autostart.test.ts`
- `npm --workspace console run test -- use-chat-stream.test.ts`
- `npm run lint`