### PR TITLE
[codex] Send HybridClaw user agent to HybridAI

### DIFF
--- a/container/src/providers/hybridai.ts
+++ b/container/src/providers/hybridai.ts
@@ -1,5 +1,6 @@
 import { stripHybridAIModelPrefix } from '../../shared/model-names.js';
 import type { ChatCompletionResponse, ToolCall } from '../types.js';
+import { HYBRIDCLAW_USER_AGENT } from '../user-agent.js';
 import {
   buildRequestHeaders,
   emitRawSseLineDebug,
@@ -63,6 +64,19 @@ function buildHybridAIRequestBody(
     request.max_tokens = Math.floor(args.maxTokens);
   }
   return request;
+}
+
+function buildHybridAIRequestHeaders(
+  args: NormalizedCallArgs,
+  extraHeaders?: Record<string, string>,
+): Record<string, string> {
+  return {
+    ...buildRequestHeaders(args.apiKey, {
+      'User-Agent': HYBRIDCLAW_USER_AGENT,
+      ...(args.requestHeaders || {}),
+    }),
+    ...(extraHeaders || {}),
+  };
 }
 
 function parseStreamPayloadLine(rawLine: string): string | null {
@@ -134,7 +148,7 @@ export async function callHybridAIProvider(
   }
   const response = await fetch(`${args.baseUrl}/v1/chat/completions`, {
     method: 'POST',
-    headers: buildRequestHeaders(args.apiKey, args.requestHeaders),
+    headers: buildHybridAIRequestHeaders(args),
     body: JSON.stringify(body),
   });
 
@@ -181,10 +195,9 @@ export async function callHybridAIProviderStream(
 
   const response = await fetch(`${args.baseUrl}/v1/chat/completions`, {
     method: 'POST',
-    headers: {
-      ...buildRequestHeaders(args.apiKey, args.requestHeaders),
+    headers: buildHybridAIRequestHeaders(args, {
       Accept: 'text/event-stream, application/x-ndjson, application/json',
-    },
+    }),
     body: JSON.stringify(body),
   });
 

--- a/container/src/user-agent.ts
+++ b/container/src/user-agent.ts
@@ -1,0 +1,40 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function readVersionFromPackageJson(packageJsonPath: string): string | null {
+  try {
+    const raw = fs.readFileSync(packageJsonPath, 'utf-8');
+    const parsed = JSON.parse(raw) as { version?: unknown };
+    if (typeof parsed.version === 'string' && parsed.version.trim()) {
+      return parsed.version.trim();
+    }
+  } catch {
+    // fall through
+  }
+  return null;
+}
+
+function resolveHybridClawVersion(): string {
+  const envVersion =
+    process.env.HYBRIDCLAW_VERSION?.trim() ||
+    process.env.npm_package_version?.trim();
+  if (envVersion) return envVersion;
+
+  const modulePath = fileURLToPath(import.meta.url);
+  const packageJsonPath = path.join(
+    path.dirname(modulePath),
+    '..',
+    'package.json',
+  );
+  return readVersionFromPackageJson(packageJsonPath) || '0.0.0';
+}
+
+export function buildHybridClawUserAgent(
+  version = resolveHybridClawVersion(),
+): string {
+  const normalized = String(version || '').trim() || '0.0.0';
+  return `hybridclaw/${normalized}`;
+}
+
+export const HYBRIDCLAW_USER_AGENT = buildHybridClawUserAgent();

--- a/src/evals/agent-risk-native.ts
+++ b/src/evals/agent-risk-native.ts
@@ -8,6 +8,7 @@ import {
   NIST_GAI_PROFILE_RISKS,
   OWASP_LLM_TOP_10_2025,
 } from '../evolution/harness-risk-taxonomy.js';
+import { HYBRIDCLAW_USER_AGENT } from '../providers/user-agent.js';
 import { normalizeOpenAIBaseUrl } from './openai-url.js';
 
 export type AgentRiskScenarioId =
@@ -1396,6 +1397,7 @@ async function callScenario(
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${options.apiKey}`,
+        'User-Agent': HYBRIDCLAW_USER_AGENT,
       },
       body: JSON.stringify(body),
       signal: controller.signal,

--- a/src/evals/hybridai-skills-command.ts
+++ b/src/evals/hybridai-skills-command.ts
@@ -6,6 +6,7 @@ import { resolveInstallPath } from '../infra/install-root.js';
 import { agentWorkspaceDir } from '../infra/ipc.js';
 import { logger } from '../logger.js';
 import { deleteSessionData, isDatabaseInitialized } from '../memory/db.js';
+import { HYBRIDCLAW_USER_AGENT } from '../providers/user-agent.js';
 import { parseSessionKey } from '../session/session-key.js';
 import { DEFAULT_SKILL_SUPPORTED_CHANNELS } from '../skills/skill-manifest.js';
 import { resolveObservedSkillName, type Skill } from '../skills/skills.js';
@@ -1088,6 +1089,7 @@ async function executeLiveTurn(
     headers: {
       'content-type': 'application/json',
       authorization: `Bearer ${env.apiKey}`,
+      'user-agent': HYBRIDCLAW_USER_AGENT,
     },
     body: JSON.stringify(body),
   });

--- a/src/evals/locomo-native.ts
+++ b/src/evals/locomo-native.ts
@@ -5,8 +5,8 @@ import { getRuntimeConfig } from '../config/runtime-config.js';
 import { initDatabase } from '../memory/db.js';
 import { normalizeMemoryEmbeddingProviderKind } from '../memory/embeddings.js';
 import { memoryService } from '../memory/memory-service.js';
-import { HYBRIDCLAW_USER_AGENT } from '../providers/user-agent.js';
 import { normalizeMemoryRecallBackend } from '../memory/semantic-recall.js';
+import { HYBRIDCLAW_USER_AGENT } from '../providers/user-agent.js';
 import { buildSessionKey } from '../session/session-key.js';
 import type { Session } from '../types/session.js';
 import {

--- a/src/evals/locomo-native.ts
+++ b/src/evals/locomo-native.ts
@@ -5,6 +5,7 @@ import { getRuntimeConfig } from '../config/runtime-config.js';
 import { initDatabase } from '../memory/db.js';
 import { normalizeMemoryEmbeddingProviderKind } from '../memory/embeddings.js';
 import { memoryService } from '../memory/memory-service.js';
+import { HYBRIDCLAW_USER_AGENT } from '../providers/user-agent.js';
 import { normalizeMemoryRecallBackend } from '../memory/semantic-recall.js';
 import { buildSessionKey } from '../session/session-key.js';
 import type { Session } from '../types/session.js';
@@ -2916,6 +2917,7 @@ async function requestModelAnswer(params: {
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${params.runtime.apiKey}`,
+        'User-Agent': HYBRIDCLAW_USER_AGENT,
       },
       body: JSON.stringify({
         model: params.model,

--- a/src/providers/hybridai.ts
+++ b/src/providers/hybridai.ts
@@ -11,6 +11,7 @@ import type {
   ResolvedModelRuntimeCredentials,
   ResolveProviderRuntimeParams,
 } from './types.js';
+import { HYBRIDCLAW_USER_AGENT } from './user-agent.js';
 
 function normalizeChatbotId(chatbotId: string | undefined): string {
   return String(chatbotId || '').trim();
@@ -30,7 +31,9 @@ async function resolveHybridAIRuntimeCredentials(
     baseUrl: HYBRIDAI_BASE_URL,
     chatbotId,
     enableRag,
-    requestHeaders: {},
+    requestHeaders: {
+      'User-Agent': HYBRIDCLAW_USER_AGENT,
+    },
     agentId,
     contextWindow:
       getDiscoveredHybridAIModelContextWindow(params.model) ?? undefined,

--- a/src/providers/user-agent.ts
+++ b/src/providers/user-agent.ts
@@ -1,0 +1,8 @@
+import { APP_VERSION } from '../config/app-version.js';
+
+export function buildHybridClawUserAgent(version = APP_VERSION): string {
+  const normalized = String(version || '').trim() || '0.0.0';
+  return `hybridclaw/${normalized}`;
+}
+
+export const HYBRIDCLAW_USER_AGENT = buildHybridClawUserAgent();

--- a/tests/provider-prompt-debug.test.ts
+++ b/tests/provider-prompt-debug.test.ts
@@ -91,4 +91,33 @@ describe('provider prompt debug logging', () => {
       expect.stringContaining('[last-prompt-file]'),
     );
   });
+  test('sends HybridClaw user agent on HybridAI requests', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const headers = init?.headers as Record<string, string>;
+
+        expect(headers['User-Agent']).toMatch(/^hybridclaw\/\d+\.\d+\.\d+/);
+
+        return new Response(
+          JSON.stringify({
+            id: 'chatcmpl_1',
+            model: 'gpt-4.1-mini',
+            choices: [
+              {
+                message: { role: 'assistant', content: 'ok' },
+                finish_reason: 'stop',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        );
+      }),
+    );
+
+    await callHybridAIProvider(makeArgs());
+  });
 });

--- a/tests/providers.factory.test.ts
+++ b/tests/providers.factory.test.ts
@@ -249,7 +249,9 @@ test('provider factory resolves HybridAI runtime credentials', async () => {
     apiKey: 'hai-provider-test',
     chatbotId: 'bot_123',
     enableRag: false,
-    requestHeaders: {},
+    requestHeaders: {
+      'User-Agent': expect.stringMatching(/^hybridclaw\/\d+\.\d+\.\d+/),
+    },
     agentId: 'main',
   });
 });


### PR DESCRIPTION
## Summary
- Add versioned `hybridclaw/<version>` user-agent helpers for gateway and container runtimes.
- Send that user agent on HybridAI `/v1/chat/completions` calls, including direct eval clients.
- Cover provider credential resolution and container request headers with targeted tests.

## Validation
- `npx biome check --write src/providers/user-agent.ts src/providers/hybridai.ts container/src/user-agent.ts container/src/providers/hybridai.ts src/evals/hybridai-skills-command.ts src/evals/locomo-native.ts src/evals/agent-risk-native.ts tests/providers.factory.test.ts tests/provider-prompt-debug.test.ts`
- `npx vitest run --configLoader runner tests/providers.factory.test.ts tests/provider-prompt-debug.test.ts`
- `./node_modules/.bin/tsc --noEmit --noUnusedLocals --noUnusedParameters`
- `npm --prefix container run lint`