### PR TITLE
[codex] Prevent duplicate bootstrap autostarts

### DIFF
--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -235,6 +235,7 @@ import {
 import { NoCompactableMessagesError } from '../memory/compaction.js';
 import { runMemoryConsolidation } from '../memory/consolidation-runner.js';
 import {
+  claimMemoryValue,
   countStructuredAuditEntries,
   createFreshSessionInstance,
   deleteMemoryValue,
@@ -7907,15 +7908,13 @@ export async function ensureGatewayBootstrapAutostart(params: {
   activeBootstrapAutostartSessions.add(lockKey);
 
   try {
-    if (getMemoryValue(session.id, markerKey)) {
-      return;
-    }
     const markerStartedAt = new Date().toISOString();
-    setMemoryValue(session.id, markerKey, {
+    const claimed = claimMemoryValue(session.id, markerKey, {
       status: 'started',
       fileName: bootstrapFile,
       at: markerStartedAt,
     });
+    if (!claimed) return;
 
     const startedAt = Date.now();
     const runId = makeAuditRunId('bootstrap');

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -4046,6 +4046,24 @@ export function setMemoryValue(
   ).run(sessionId, normalizedKey, valueBlob, now);
 }
 
+export function claimMemoryValue(
+  sessionId: string,
+  key: string,
+  value: unknown,
+): boolean {
+  const normalizedKey = normalizeMemoryKvKey(key);
+  if (!normalizedKey) return false;
+  const valueBlob = serializeMemoryKvValue(value);
+  const now = new Date().toISOString();
+  const result = db
+    .prepare(
+      `INSERT OR IGNORE INTO kv_store (agent_id, key, value, version, updated_at)
+       VALUES (?, ?, ?, 1, ?)`,
+    )
+    .run(sessionId, normalizedKey, valueBlob, now);
+  return result.changes > 0;
+}
+
 export function deleteMemoryValue(sessionId: string, key: string): boolean {
   const normalizedKey = normalizeMemoryKvKey(key);
   if (!normalizedKey) return false;

--- a/tests/memory-service.test.ts
+++ b/tests/memory-service.test.ts
@@ -8,6 +8,7 @@ import {
   addKnowledgeEntity,
   addKnowledgeRelation,
   appendCanonicalMessages,
+  claimMemoryValue,
   DATABASE_SCHEMA_VERSION,
   decaySemanticMemories,
   deleteMemoryValue,
@@ -560,6 +561,26 @@ describe.sequential('structured memory DB', () => {
     expect(deleteMemoryValue('s-kv', 'release.codename')).toBe(true);
     expect(deleteMemoryValue('s-kv', 'release.codename')).toBe(false);
     expect(getMemoryValue('s-kv', 'release.codename')).toBeNull();
+  });
+
+  test('claims key-value memory only when the key is absent', () => {
+    const dbPath = createTempDbPath();
+    initDatabase({ quiet: true, dbPath });
+    getOrCreateSession('s-kv-claim', null, 'channel-kv');
+
+    expect(
+      claimMemoryValue('s-kv-claim', 'bootstrap.autostart.main', {
+        status: 'started',
+      }),
+    ).toBe(true);
+    expect(
+      claimMemoryValue('s-kv-claim', 'bootstrap.autostart.main', {
+        status: 'second-start',
+      }),
+    ).toBe(false);
+    expect(getMemoryValue('s-kv-claim', 'bootstrap.autostart.main')).toEqual({
+      status: 'started',
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- Add an atomic `claimMemoryValue` helper backed by `INSERT OR IGNORE` for KV markers.
- Use that helper when claiming `bootstrap.autostart.*` so only one gateway process can start hatching for a session/agent.
- Cover the claim semantics with a focused structured-memory DB test.

## Root Cause

Bootstrap autostart used a read-then-upsert marker check. That worked for same-process duplicate calls with the in-memory lock, but it was not an atomic cross-process claim. Repeated history polling during hatching could therefore start multiple hidden `BOOTSTRAP.md` turns for the same session.

## Impact

This prevents duplicate first-run onboarding messages and reduces the risk of duplicated onboarding side effects, such as repeated memory writes or first-jobs emails.

## Validation

- `npm ci`
- `npx vitest run tests/memory-service.test.ts --testNamePattern "key-value memory|claims key-value memory"`
- `npx vitest run tests/gateway-service.bootstrap-autostart.test.ts`
- `npx biome check --write src/memory/db.ts src/gateway/gateway-service.ts tests/memory-service.test.ts`
- `./node_modules/.bin/tsc --noEmit`