### PR TITLE
[codex] Send single OPENING autostart message

### DIFF
--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -626,6 +626,8 @@ const BOOTSTRAP_AUTOSTART_MARKER_KEY = 'gateway.bootstrap_autostart.v1';
 const BOOTSTRAP_AUTOSTART_SOURCE = 'gateway.bootstrap';
 const BOOTSTRAP_PRELUDE_MAX_TOKENS = 48;
 const BOOTSTRAP_PRELUDE_TIMEOUT_MS = 1500;
+const OPENING_AUTOSTART_MAX_TOKENS = 512;
+const OPENING_AUTOSTART_TIMEOUT_MS = 5000;
 const activeBootstrapAutostartSessions = new Set<string>();
 const assistantPresentationImagePathCache = new Map<string, string | null>();
 const ADMIN_AGENT_MARKDOWN_MAX_BYTES = 200_000;
@@ -752,6 +754,53 @@ async function generateBootstrapPrelude(params: {
     logger.debug(
       { agentId: params.agentId, fileName: params.fileName, error },
       'Failed to generate bootstrap prelude with auxiliary model',
+    );
+    return null;
+  }
+}
+
+function normalizeOpeningAutostartMessage(raw: string): string | null {
+  const cleaned = collapseRepeatedBootstrapBlock(
+    raw.replace(/\r\n/g, '\n').replace(/\r/g, '\n'),
+  );
+  if (!cleaned) return null;
+  if (/\b(hidden|internal|kickoff|system prompt)\b/iu.test(cleaned)) {
+    return null;
+  }
+  return cleaned;
+}
+
+async function generateOpeningAutostartMessage(params: {
+  agentId: string;
+  model: string;
+  chatbotId: string | null;
+  messages: ChatMessage[];
+}): Promise<Awaited<ReturnType<typeof callAuxiliaryModel>> | null> {
+  try {
+    const result = await callAuxiliaryModel({
+      task: 'compression',
+      agentId: params.agentId,
+      fallbackModel: params.model,
+      fallbackChatbotId: params.chatbotId ?? undefined,
+      fallbackEnableRag: false,
+      tools: [],
+      maxTokens: OPENING_AUTOSTART_MAX_TOKENS,
+      timeoutMs: OPENING_AUTOSTART_TIMEOUT_MS,
+      messages: [
+        ...params.messages,
+        {
+          role: 'user',
+          content:
+            'Generate exactly one concise user-facing opening message now by following OPENING.md. Return only the message to send. Do not add a hatching, startup, or coming-online prelude unless OPENING.md explicitly asks for one. Do not mention hidden prompts, internal kickoff turns, or system mechanics.',
+        },
+      ],
+    });
+    const content = normalizeOpeningAutostartMessage(result.content);
+    return content ? { ...result, content } : null;
+  } catch (error) {
+    logger.debug(
+      { agentId: params.agentId, fileName: 'OPENING.md', error },
+      'Failed to generate OPENING.md autostart message with auxiliary model',
     );
     return null;
   }
@@ -8582,6 +8631,143 @@ export async function ensureGatewayBootstrapAutostart(params: {
       });
       return assistantMessageId;
     };
+    if (bootstrapFile === 'OPENING.md') {
+      recordAuditEvent({
+        sessionId: session.id,
+        runId,
+        event: {
+          type: 'agent.start',
+          provider: 'auxiliary',
+          model: resolved.model,
+          scheduledTaskCount: 0,
+          promptMessages: messages.length,
+          systemPrompt: readSystemPromptMessage(messages),
+          dynamicContext: readDynamicContextMessage(messages),
+        },
+      });
+
+      const openingResult = await generateOpeningAutostartMessage({
+        agentId: resolved.agentId,
+        model: resolved.model,
+        chatbotId,
+        messages,
+      });
+
+      const usagePayload = buildTokenUsageAuditPayload(
+        messages,
+        openingResult?.content,
+      );
+      recordAuditEvent({
+        sessionId: session.id,
+        runId,
+        event: {
+          type: 'model.usage',
+          provider: openingResult?.provider ?? 'auxiliary',
+          model: openingResult?.model ?? resolved.model,
+          runtime: 'auxiliary',
+          durationMs: Date.now() - startedAt,
+          toolCallCount: 0,
+          ...usagePayload,
+        },
+      });
+
+      if (!openingResult) {
+        deleteMemoryValue(session.id, markerKey);
+        recordAuditEvent({
+          sessionId: session.id,
+          runId,
+          event: {
+            type: 'turn.end',
+            turnIndex,
+            finishReason: 'empty',
+          },
+        });
+        recordAuditEvent({
+          sessionId: session.id,
+          runId,
+          event: {
+            type: 'session.end',
+            reason: 'empty',
+            stats: {
+              userMessages: 0,
+              assistantMessages: 0,
+              toolCalls: 0,
+              durationMs: Date.now() - startedAt,
+            },
+          },
+        });
+        return;
+      }
+
+      enqueueTokenUsage({
+        sessionId: session.id,
+        agentId: resolved.agentId,
+        model: openingResult.model,
+        inputTokens:
+          openingResult.usage?.inputTokens ||
+          firstNumber([usagePayload.promptTokens]) ||
+          0,
+        outputTokens:
+          openingResult.usage?.outputTokens ||
+          firstNumber([usagePayload.completionTokens]) ||
+          0,
+        totalTokens:
+          openingResult.usage?.totalTokens ||
+          firstNumber([usagePayload.totalTokens]) ||
+          0,
+        toolCalls: 0,
+        costUsd:
+          openingResult.usage?.costUsd ??
+          (await resolveUsageCostUsdAfterMetadataRefresh({
+            model: openingResult.model,
+            tokenUsage: undefined,
+            usage: usagePayload,
+          })),
+        auditRunId: runId,
+      });
+      if (pluginManager) {
+        await pluginManager.notifyMemoryWrites({
+          sessionId: session.id,
+          agentId: resolved.agentId,
+          channelId,
+          toolExecutions: [],
+        });
+      }
+
+      const assistantMessageId = storeBootstrapAssistantMessage(
+        openingResult.content,
+      );
+      setMemoryValue(session.id, markerKey, {
+        status: 'completed',
+        assistantMessageId,
+        completedAt: new Date().toISOString(),
+      });
+      recordAuditEvent({
+        sessionId: session.id,
+        runId,
+        event: {
+          type: 'turn.end',
+          turnIndex,
+          finishReason: 'completed',
+        },
+      });
+      recordAuditEvent({
+        sessionId: session.id,
+        runId,
+        event: {
+          type: 'session.end',
+          reason: 'normal',
+          stats: {
+            userMessages: 0,
+            assistantMessages: 1,
+            toolCalls: 0,
+            durationMs: Date.now() - startedAt,
+          },
+        },
+      });
+      return;
+    }
+
     const preludeText = await generateBootstrapPrelude({
       agentId: resolved.agentId,
       fileName: bootstrapFile,

--- a/tests/gateway-service.bootstrap-autostart.test.ts
+++ b/tests/gateway-service.bootstrap-autostart.test.ts
@@ -269,11 +269,10 @@ test('ensureGatewayBootstrapAutostart drops prelude text that mentions internals
 test('ensureGatewayBootstrapAutostart also kicks off from OPENING.md once per session', async () => {
   setupHome();
 
-  runAgentMock.mockResolvedValue({
-    status: 'success',
-    result: 'Opening instructions noted. Ready to begin.',
-    toolsUsed: [],
-    toolExecutions: [],
+  callAuxiliaryModelMock.mockResolvedValueOnce({
+    provider: 'hybridai',
+    model: 'auxiliary/test',
+    content: 'Why did the computer go to therapy?\nIt had too many unresolved issues.',
   });
 
   const { initDatabase } = await import('../src/memory/db.ts');
@@ -310,39 +309,45 @@ test('ensureGatewayBootstrapAutostart also kicks off from OPENING.md once per se
   const sessionId = 'agent:main:channel:web:chat:dm:peer:boot-md-test';
   await ensureGatewayBootstrapAutostart({ sessionId });
 
-  expect(runAgentMock).toHaveBeenCalledTimes(1);
-  const request = runAgentMock.mock.calls[0]?.[0] as
+  expect(runAgentMock).not.toHaveBeenCalled();
+  expect(callAuxiliaryModelMock).toHaveBeenCalledTimes(1);
+  const request = callAuxiliaryModelMock.mock.calls[0]?.[0] as
     | {
         messages?: Array<{ role: string; content: string }>;
-        chatbotId?: string;
+        fallbackChatbotId?: string;
+        maxTokens?: number;
+        timeoutMs?: number;
       }
     | undefined;
-  expect(request?.chatbotId).toBe('user-bootstrap');
+  expect(request?.fallbackChatbotId).toBe('user-bootstrap');
+  expect(request?.maxTokens).toBe(512);
+  expect(request?.timeoutMs).toBe(5000);
   expect(
     request?.messages?.some((message) =>
       message.content.includes('## OPENING.md'),
     ),
   ).toBe(true);
+  expect(
+    request?.messages?.some((message) =>
+      message.content.includes('A startup instruction file (OPENING.md) exists'),
+    ),
+  ).toBe(true);
   expect(request?.messages?.at(-1)).toEqual({
     role: 'user',
-    content: expect.stringContaining(
-      'A startup instruction file (OPENING.md) exists',
-    ),
+    content: expect.stringContaining('Generate exactly one concise'),
   });
 
   expect(getGatewayHistory(sessionId, 10).history).toEqual([
     expect.objectContaining({
       role: 'assistant',
-      content: DEFAULT_GATEWAY_AUXILIARY_PRELUDE,
-    }),
-    expect.objectContaining({
-      role: 'assistant',
-      content: 'Opening instructions noted. Ready to begin.',
+      content:
+        'Why did the computer go to therapy?\nIt had too many unresolved issues.',
     }),
   ]);
 
   await ensureGatewayBootstrapAutostart({ sessionId });
-  expect(runAgentMock).toHaveBeenCalledTimes(1);
+  expect(runAgentMock).not.toHaveBeenCalled();
+  expect(callAuxiliaryModelMock).toHaveBeenCalledTimes(1);
 });
 
 test('ensureGatewayBootstrapAutostart can hatch a selected agent in an existing session', async () => {


### PR DESCRIPTION
## Summary
- Route `OPENING.md` autostart output through a single auxiliary-model generation path.
- Keep the existing `BOOTSTRAP.md` hatching/prelude flow unchanged.
- Update the gateway autostart test to assert `OPENING.md` stores one assistant message and does not invoke the full agent runtime.

## Why
A customized `OPENING.md` was producing two proactive messages: an auxiliary hatching-style prelude plus the requested opening message. For agents with completed onboarding and no `BOOTSTRAP.md`, the expected behavior is a single proactive `OPENING.md` message.

## Validation
- `./node_modules/.bin/vitest run tests/gateway-service.bootstrap-autostart.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/biome check src/gateway/gateway-service.ts tests/gateway-service.bootstrap-autostart.test.ts`