### PR TITLE
[codex] Keep agent install file restore strict

### DIFF
--- a/docs/content/extensibility/agent-packages.md
+++ b/docs/content/extensibility/agent-packages.md
@@ -420,13 +420,13 @@ reuses one readline session for the whole export flow.
 5. picks the agent id from `--id`, then `manifest.id`, then sanitized
    `manifest.name`
 6. registers the agent in the normal agent registry
-7. copies `workspace/` into the agent workspace path
-8. restores bundled skills into `workspace/skills/`
+7. copies `workspace/` into the agent workspace path without adding missing
+   bootstrap templates
+8. restores manifest-declared bundled skills into `workspace/skills/`
 9. installs manifest-declared skill imports into `workspace/skills/`
-10. installs bundled plugins with the normal plugin installer
+10. installs manifest-declared bundled plugins with the normal plugin installer
 11. merges packaged skill config and validated bundled-plugin overrides into
    runtime config
-12. calls `ensureBootstrapFiles()` to fill any missing templates
 
 Use `--force` to replace an existing agent workspace or reinstall bundled
 plugins during import. Use `--skip-externals` to skip manifest-declared skill

--- a/src/agents/claw-archive.ts
+++ b/src/agents/claw-archive.ts
@@ -26,7 +26,6 @@ import {
 } from '../skills/skills-import.js';
 import { normalizeTrimmedString as normalizeString } from '../utils/normalized-strings.js';
 import { isRecord } from '../utils/type-guards.js';
-import { ensureBootstrapFiles } from '../workspace.js';
 import {
   deleteRegisteredAgent,
   getAgentById,
@@ -1305,8 +1304,6 @@ export async function unpackAgent(
       });
       runtimeConfigChanged = true;
     }
-
-    ensureBootstrapFiles(resolvedAgentId);
 
     if (workspaceBackupPath) {
       fs.rmSync(workspaceBackupPath, { recursive: true, force: true });

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -909,7 +909,7 @@ Notes:
   - Use \`--plugins active\` to bundle only enabled home plugins, \`--plugins all\` to bundle all installed home plugins, or \`--plugins some --plugin <id>\` to bundle a selected subset.
   - Interactive export defaults to \`--skills ask\` and \`--plugins ask\`; non-interactive export defaults to \`--skills all\` and \`--plugins active\`.
   - \`inspect\` validates the archive manifest and prints a summary without extracting files.
-  - \`install\` validates ZIP safety, confirms the manifest, registers the agent, restores bundled content, installs manifest-declared skill imports into the agent workspace, and fills missing bootstrap files.
+  - \`install\` validates ZIP safety, confirms the manifest, registers the agent, restores archived workspace content, and installs only manifest-declared bundled content or imports.
   - \`install official:<agent-dir>\` downloads a packaged agent from \`HybridAIOne/claws\` on GitHub before installing it.
   - \`install github:owner/repo/<agent-dir>\` resolves the packaged agent from a GitHub claws repo; use \`github:owner/repo/<ref>/<agent-dir>\` to pin a ref.
   - Direct \`https://.../*.claw\` URLs download the archive before installing it.

--- a/tests/unit/claw-archive.test.ts
+++ b/tests/unit/claw-archive.test.ts
@@ -381,6 +381,74 @@ describe('.claw archive support', () => {
     ).toBe(true);
   });
 
+  test('unpack does not synthesize missing bootstrap files', async () => {
+    const homeDir = makeTempDir('hybridclaw-claw-home-');
+    const cwd = makeTempDir('hybridclaw-claw-cwd-');
+    vi.stubEnv('HOME', homeDir);
+    vi.stubEnv('HYBRIDCLAW_DISABLE_CONFIG_WATCHER', '1');
+    process.chdir(cwd);
+
+    const { initDatabase } = await import('../../src/memory/db.js');
+    const { initAgentRegistry } = await import(
+      '../../src/agents/agent-registry.js'
+    );
+    const { unpackAgent } = await import('../../src/agents/claw-archive.js');
+
+    initDatabase({ quiet: true });
+    initAgentRegistry({
+      list: [{ id: 'main', name: 'Main Agent' }],
+    });
+
+    const archivePath = path.join(cwd, 'minimal-install.claw');
+    await writeZipArchive(archivePath, [
+      {
+        name: 'manifest.json',
+        content: JSON.stringify(
+          {
+            formatVersion: 1,
+            name: 'Minimal Install Agent',
+            id: 'minimal-install-agent',
+          },
+          null,
+          2,
+        ),
+      },
+      {
+        name: 'workspace/SOUL.md',
+        content: '# Soul\n',
+      },
+      {
+        name: 'workspace/notes/readme.md',
+        content: '# Read Me\n',
+      },
+    ]);
+
+    const unpacked = await unpackAgent(archivePath, {
+      yes: true,
+      homeDir,
+      cwd,
+    });
+
+    expect(
+      fs.readFileSync(path.join(unpacked.workspacePath, 'SOUL.md'), 'utf-8'),
+    ).toBe('# Soul\n');
+    expect(
+      fs.readFileSync(
+        path.join(unpacked.workspacePath, 'notes', 'readme.md'),
+        'utf-8',
+      ),
+    ).toBe('# Read Me\n');
+    expect(
+      fs.existsSync(path.join(unpacked.workspacePath, 'BOOTSTRAP.md')),
+    ).toBe(false);
+    expect(
+      fs.existsSync(path.join(unpacked.workspacePath, 'IDENTITY.md')),
+    ).toBe(false);
+    expect(fs.existsSync(path.join(unpacked.workspacePath, 'USER.md'))).toBe(
+      false,
+    );
+  });
+
   test('unpack installs manifest skill imports into the agent workspace', async () => {
     const homeDir = makeTempDir('hybridclaw-claw-home-');
     const cwd = makeTempDir('hybridclaw-claw-cwd-');


### PR DESCRIPTION
## Summary

This changes `.claw` agent install so it restores only the archived workspace content plus manifest-declared bundled/imported assets. It removes the install-time `ensureBootstrapFiles()` call that was adding default workspace templates such as `BOOTSTRAP.md`, `IDENTITY.md`, and `USER.md` when those files were not present in the package.

## Impact

- `agent create` remains responsible for seeding new agent bootstrap files, including `BOOTSTRAP.md`.
- `agent install` now preserves the package author's exact workspace file set, aside from manifest-declared bundled skills/plugins and skill imports.
- CLI help and agent package docs now describe the stricter install behavior.

## Validation

- `./node_modules/.bin/vitest run tests/unit/claw-archive.test.ts`
- `./node_modules/.bin/vitest run tests/gateway-service.agent-command.test.ts`