### PR TITLE
fix: disambiguate local model routes

### DIFF
--- a/console/src/routes/chat/model-switch-select.test.ts
+++ b/console/src/routes/chat/model-switch-select.test.ts
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { createElement } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import type { ChatModel } from '../../api/types';
@@ -66,7 +66,19 @@ describe('parseModel', () => {
     );
     expect(parsed.provider).toBe('vLLM');
     expect(parsed.groupLabel).toBe('vLLM · Google');
+    expect(parsed.routeLabel).toBe('haigpu2');
     expect(parsed.displayName).toBe('Gemma 4 E4b It');
+  });
+
+  it('keeps the default vLLM backend route visible', () => {
+    const parsed = parseModel(
+      model({
+        id: 'vllm/Qwen/Qwen3.6-27B-FP8',
+        provider: 'vllm',
+        backend: 'vllm',
+      }),
+    );
+    expect(parsed.routeLabel).toBe('vLLM');
   });
 
   it('strips Anthropic date-stamp suffixes from displayName', () => {
@@ -96,5 +108,41 @@ describe('parseModel', () => {
     const trigger = screen.getByRole('combobox', { name: 'Switch model' });
     expect(trigger.textContent).toContain('Grok 4.20 0309 Non Reasoning');
     expect(trigger.textContent).not.toContain('Qwen3.6 27b Fp8');
+  });
+
+  it('disambiguates duplicate local model names by route in the dropdown', () => {
+    render(
+      createElement(ModelSwitchSelect, {
+        models: [
+          model({
+            id: 'vllm/Qwen/Qwen3.6-27B-FP8',
+            provider: 'vllm',
+            backend: 'vllm',
+            contextWindow: 131_072,
+          }),
+          model({
+            id: 'haigpu1/Qwen/Qwen3.6-27B-FP8',
+            provider: 'vllm',
+            backend: 'vllm',
+            contextWindow: 131_072,
+          }),
+        ],
+        selectedModelId: 'vllm/Qwen/Qwen3.6-27B-FP8',
+        onSwitch: vi.fn(),
+      }),
+    );
+
+    fireEvent.click(screen.getByRole('combobox', { name: 'Switch model' }));
+
+    const defaultRoute = document.querySelector<HTMLElement>(
+      '[data-value="vllm/Qwen/Qwen3.6-27B-FP8"]',
+    );
+    const namedRoute = document.querySelector<HTMLElement>(
+      '[data-value="haigpu1/Qwen/Qwen3.6-27B-FP8"]',
+    );
+    expect(defaultRoute?.textContent).toContain('vLLM');
+    expect(defaultRoute?.getAttribute('aria-label')).toContain('vLLM');
+    expect(namedRoute?.textContent).toContain('haigpu1');
+    expect(namedRoute?.getAttribute('aria-label')).toContain('haigpu1');
   });
 });

--- a/console/src/routes/chat/model-switch-select.tsx
+++ b/console/src/routes/chat/model-switch-select.tsx
@@ -67,6 +67,7 @@ export interface ParsedModel {
   groupLabel: string;
   providerRank: number;
   vendorRank: number;
+  routeLabel: string | null;
   shortName: string;
   displayName: string;
   vendor: string | null;
@@ -414,6 +415,18 @@ function inferVendor(name: string): string | null {
   return VENDOR_BY_PREFIX.find(([prefix]) => n.startsWith(prefix))?.[1] ?? null;
 }
 
+function routeLabelForLocalModel(
+  parts: string[],
+  entry: ModelSwitchEntry,
+): string | null {
+  if (!entry.backend || parts.length < 2) return null;
+  const route = parts[0]?.trim();
+  if (!route) return null;
+  return route.toLowerCase() === entry.backend
+    ? pretty(entry.backend, PROVIDER_LABELS)
+    : route;
+}
+
 export function parseModel(entry: ModelSwitchEntry): ParsedModel {
   const id = entry.id;
   const parts = id.split('/');
@@ -438,12 +451,14 @@ export function parseModel(entry: ModelSwitchEntry): ParsedModel {
   const groupLabel = vendor ? `${provider} · ${vendor}` : provider;
   const providerRank = PROVIDER_RANK[provider as KnownProvider] ?? 50;
   const vendorRank = vendor ? (VENDOR_ORDER[vendor] ?? 50) : 0;
+  const routeLabel = routeLabelForLocalModel(parts, entry);
 
   return {
     id,
     groupLabel,
     providerRank,
     vendorRank,
+    routeLabel,
     shortName,
     displayName: prettifyModelName(shortName),
     vendor,
@@ -471,6 +486,7 @@ function formatSubtitle(model: ParsedModel): string | null {
   const familyLabel =
     family && family !== model.shortName ? prettifyModelName(family) : null;
   const parts = [
+    model.routeLabel,
     model.meta.parameterSize?.trim() || null,
     familyLabel && familyLabel !== model.displayName ? familyLabel : null,
     model.vendor,
@@ -486,6 +502,7 @@ function modelMatchesQuery(model: ParsedModel, query: string): boolean {
     model.shortName,
     model.displayName,
     model.provider,
+    model.routeLabel ?? '',
     model.vendor ?? '',
     model.groupLabel,
   ]
@@ -539,7 +556,12 @@ export function ModelSwitchSelect(props: {
       compareGroupRank(a.head, b.head),
     );
     for (const group of ordered) {
-      group.items.sort((a, b) => a.shortName.localeCompare(b.shortName));
+      group.items.sort(
+        (a, b) =>
+          a.shortName.localeCompare(b.shortName) ||
+          (a.routeLabel ?? '').localeCompare(b.routeLabel ?? '') ||
+          a.id.localeCompare(b.id),
+      );
     }
     return ordered;
   }, [parsed, query, railFilter]);
@@ -625,7 +647,9 @@ export function ModelSwitchSelect(props: {
                   <SelectItem
                     key={model.id}
                     value={model.id}
-                    textValue={`${model.displayName} ${model.groupLabel}`}
+                    textValue={`${model.displayName} ${model.groupLabel} ${
+                      model.routeLabel ?? ''
+                    }`}
                   >
                     <span aria-hidden="true" className={chrome.itemLogo}>
                       <VendorIcon


### PR DESCRIPTION
## Summary
- Show the local route label in model switcher rows and accessible search text.
- Keep default backend routes readable, e.g. `vLLM`, while preserving named routes like `haigpu1`.
- Add regression coverage for duplicate-looking local Qwen model entries.

## Root Cause
Local model IDs such as `vllm/Qwen/Qwen3.6-27B-FP8` and `haigpu1/Qwen/Qwen3.6-27B-FP8` were parsed into the same provider, vendor, and display name. The selector dropped the route prefix in the row subtitle, so two distinct endpoints rendered as identical entries.

## Validation
- `npm --workspace console run test -- src/routes/chat/model-switch-select.test.ts`
- `npm --workspace console run lint`