### PR TITLE
[codex] fix HybridAI admin RBAC on cloud

### DIFF
--- a/docs/content/developer-guide/admin-access-control.md
+++ b/docs/content/developer-guide/admin-access-control.md
@@ -10,8 +10,10 @@ HybridClaw admin access has two compatibility modes:
 
 - Legacy bearer tokens (`WEB_API_TOKEN` and `GATEWAY_API_TOKEN`) are treated as
   broad admin credentials.
-- Scoped admin sessions are restricted by the `actions`, `scope`, `role`, and
-  `roles` claims in the signed session payload.
+- HybridAI-launched sessions without RBAC claims are treated as full admin
+  sessions for compatibility.
+- Scoped admin sessions are restricted only when the signed session payload
+  includes `actions`, `scope`, `role`, or `roles` claims.
 
 Browser admin surfaces prefer HttpOnly session cookies. If a bearer token must
 be entered manually, the console stores it in `sessionStorage` for the current

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -2028,17 +2028,10 @@ function requestUsesHttps(req: IncomingMessage): boolean {
   return (req.socket as { encrypted?: boolean }).encrypted === true;
 }
 
-function resolveRequestOriginForAuth(req: IncomingMessage): string | null {
-  const host = String(req.headers.host || '').trim();
-  if (!host) return null;
-  const protocol = requestUsesHttps(req) ? 'https' : 'http';
-  return `${protocol}://${host}`;
-}
-
 function hasSameGatewayOrigin(req: IncomingMessage): boolean {
   const origin = String(req.headers.origin || '').trim();
   if (!origin) return false;
-  return origin === resolveRequestOriginForAuth(req);
+  return origin === resolveRequestOrigin(req);
 }
 
 function hasApiAuth(

--- a/src/security/admin-rbac.ts
+++ b/src/security/admin-rbac.ts
@@ -270,6 +270,13 @@ export function collectAdminActionClaims(
   payload: Record<string, unknown> | null,
 ): Set<string> | null {
   if (!payload) return null;
+  const hasRbacClaims =
+    Object.hasOwn(payload, 'actions') ||
+    Object.hasOwn(payload, 'scope') ||
+    Object.hasOwn(payload, 'role') ||
+    Object.hasOwn(payload, 'roles');
+  if (!hasRbacClaims) return null;
+
   const claims = new Set<string>();
 
   addStringClaims(claims, readClaimValue(payload, 'actions'), /[,\s]+/);
@@ -305,10 +312,8 @@ export function isAdminActionAllowed(
 ): boolean {
   if (!payload) return true;
   const claims = collectAdminActionClaims(payload);
-  return (
-    claims?.has(action) === true ||
-    (claims ? hasWildcardClaim(claims, action) : false)
-  );
+  if (!claims) return true;
+  return claims.has(action) === true || hasWildcardClaim(claims, action);
 }
 
 function actionForReadWriteDelete(

--- a/tests/admin-rbac.test.ts
+++ b/tests/admin-rbac.test.ts
@@ -23,6 +23,17 @@ describe('admin RBAC role bundles', () => {
     expect(isAdminActionAllowed(null, 'admin.config.write')).toBe(true);
   });
 
+  test('keeps unscoped HybridAI session claims fully authorized', () => {
+    const payload = {
+      sub: 'user-1',
+      sessionId: 'admin-session-1',
+    };
+
+    expect(collectAdminActionClaims(payload)).toBeNull();
+    expect(isAdminActionAllowed(payload, 'admin.skills.read')).toBe(true);
+    expect(isAdminActionAllowed(payload, 'admin.gateway.shutdown')).toBe(true);
+  });
+
   test('expands config manager role claims into route actions', () => {
     const payload = { role: 'admin.config_manager' };
     const claims = collectAdminActionClaims(payload);

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -2829,6 +2829,70 @@ describe('gateway HTTP server', () => {
     expect(state.reloadRuntimeConfig).toHaveBeenCalledWith('admin-api');
   });
 
+  test('allows signed session cookie API mutations with forwarded public origin', async () => {
+    const authSecret = 'api-session-forwarded-origin-auth-secret';
+    const state = await importFreshHealth({
+      authSecret,
+      webApiToken: 'web-token',
+    });
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/admin/config/reload',
+      headers: {
+        cookie: makeSessionCookie(authSecret, {
+          sessionId: 'admin-session-1',
+          actor: 'admin-user',
+          role: 'admin.config_manager',
+        }),
+        host: '127.0.0.1:9090',
+        origin: 'https://u-example.sbx.hybridai.one',
+        'x-forwarded-host': 'u-example.sbx.hybridai.one',
+        'x-forwarded-proto': 'https',
+      },
+      noAuth: true,
+      remoteAddress: '203.0.113.10',
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(200);
+    expect(state.reloadRuntimeConfig).toHaveBeenCalledWith('admin-api');
+  });
+
+  test('rejects signed session cookie mutations with mismatched forwarded origin', async () => {
+    const authSecret = 'api-session-forwarded-origin-mismatch-secret';
+    const state = await importFreshHealth({
+      authSecret,
+      webApiToken: 'web-token',
+    });
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/admin/config/reload',
+      headers: {
+        cookie: makeSessionCookie(authSecret, {
+          sessionId: 'admin-session-1',
+          actor: 'admin-user',
+          role: 'admin.config_manager',
+        }),
+        host: '127.0.0.1:9090',
+        origin: 'https://evil.example.test',
+        'x-forwarded-host': 'u-example.sbx.hybridai.one',
+        'x-forwarded-proto': 'https',
+      },
+      noAuth: true,
+      remoteAddress: '203.0.113.10',
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(401);
+    expect(state.reloadRuntimeConfig).not.toHaveBeenCalled();
+  });
+
   test('rejects forwarded loopback headers from unauthenticated external sockets', async () => {
     const state = await importFreshHealth();
     const req = makeRequest({
@@ -5481,6 +5545,30 @@ describe('gateway HTTP server', () => {
     expect(JSON.parse(res.body)).toEqual({ error: 'Forbidden.' });
   });
 
+  test('allows unscoped HybridAI sessions as full admin sessions', async () => {
+    const authSecret = 'admin-rbac-unscoped-auth-secret';
+    const state = await importFreshHealth({ authSecret, webApiToken: 'web' });
+    const req = makeRequest({
+      url: '/api/admin/skills',
+      headers: {
+        cookie: makeSessionCookie(authSecret, {
+          sessionId: 'admin-session-1',
+          actor: 'admin-user',
+          sub: 'user-1',
+        }),
+      },
+      noAuth: true,
+      remoteAddress: '203.0.113.10',
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(res.statusCode).toBe(200);
+    expect(state.getGatewayAdminSkills).toHaveBeenCalledTimes(1);
+  });
+
   test('allows scoped admin sessions with a matching wildcard route action', async () => {
     const authSecret = 'admin-rbac-allow-auth-secret';
     const state = await importFreshHealth({ authSecret });
@@ -5632,7 +5720,7 @@ describe('gateway HTTP server', () => {
     expect(res.body).not.toContain('super-secret');
   });
 
-  test('denies admin secret metadata sessions without action claims', async () => {
+  test('denies scoped admin secret metadata sessions without secret action claims', async () => {
     const authSecret = 'secret-list-deny-auth-secret';
     const state = await importFreshHealth({ authSecret });
     const req = makeRequest({
@@ -5641,6 +5729,7 @@ describe('gateway HTTP server', () => {
         cookie: makeSessionCookie(authSecret, {
           sessionId: 'admin-session-1',
           actor: 'admin-user',
+          actions: ['admin.overview.read'],
         }),
       },
     });


### PR DESCRIPTION
## Summary
- Treat HybridAI-launched sessions without explicit RBAC claims as full admin sessions, while preserving restrictions for explicit `actions`, `scope`, `role`, or `roles` claims.
- Make session-cookie mutation origin checks respect the forwarded public origin used by the cloud proxy.
- Document the compatibility behavior for unscoped HybridAI sessions.

## Root Cause
Cloud HybridAI session cookies were authenticated but unscoped. The RBAC layer interpreted missing RBAC claims as an empty permission set, which produced `403` responses for admin APIs like `/api/admin/models` and `/api/admin/skills`. Cookie-authenticated mutations could also fail behind the cloud proxy because the same-origin check compared `Origin` to the internal `Host` header instead of the forwarded public host.

## Impact
HybridAI-launched sessions without explicit RBAC claims now behave as full admin sessions, matching the current cloud instance contract. Explicit scoped sessions remain restricted. HybridAI should still start issuing explicit `roles: ["admin.full"]` sessions next so this compatibility path is not the long-term authorization model.

## Validation
- `npx vitest tests/admin-rbac.test.ts --run`
- `npx vitest tests/gateway-http-server.test.ts --run -t "allows signed session cookie API mutations with forwarded public origin|rejects signed session cookie mutations with mismatched forwarded origin|allows unscoped HybridAI sessions as full admin sessions|denies scoped admin secret metadata sessions without secret action claims|denies scoped admin sessions without the required route action"`
- `./node_modules/.bin/tsc --noEmit`
- `npx biome check --write src/gateway/gateway-http-server.ts src/security/admin-rbac.ts tests/admin-rbac.test.ts tests/gateway-http-server.test.ts`
- `git diff --check`

## Notes
- A broader local gateway test invocation was not usable under the current local Node 26 setup because `better-sqlite3` was built for a different Node ABI. The repo and cloud runtime require Node 22, and the focused tests covering this patch passed.