### PR TITLE
[codex] fix cloud chat cookie POST auth

### DIFF
--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -2031,7 +2031,16 @@ function requestUsesHttps(req: IncomingMessage): boolean {
 function hasSameGatewayOrigin(req: IncomingMessage): boolean {
   const origin = String(req.headers.origin || '').trim();
   if (!origin) return false;
-  return origin === resolveRequestOrigin(req);
+  if (origin === resolveRequestOrigin(req)) return true;
+
+  // Browsers set this header from the actual page/request relationship. It
+  // keeps cookie-backed writes working behind TLS-terminating proxies even
+  // when the backend cannot reconstruct the public origin exactly.
+  return (
+    String(req.headers['sec-fetch-site'] || '')
+      .trim()
+      .toLowerCase() === 'same-origin'
+  );
 }
 
 function hasApiAuth(

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -8967,15 +8967,6 @@ describe('gateway HTTP server', () => {
 
   test('uses the signed session subject for web chat requests', async () => {
     const authSecret = 'health-secret';
-    const sessionToken = signAuthPayload(
-      {
-        exp: Math.floor(Date.now() / 1000) + 60,
-        iat: Math.floor(Date.now() / 1000),
-        sub: 'user-1',
-        typ: 'session',
-      },
-      authSecret,
-    );
     const state = await importFreshHealth({ authSecret });
     state.handleGatewayCommand.mockResolvedValueOnce({
       kind: 'info',
@@ -8987,8 +8978,15 @@ describe('gateway HTTP server', () => {
       method: 'POST',
       url: '/api/chat',
       headers: {
-        cookie: `hybridclaw_session=${sessionToken}`,
+        cookie: makeSessionCookie(authSecret, {
+          sub: 'user-1',
+        }),
+        host: '127.0.0.1:9090',
+        origin: 'https://u-example.sbx.hybridai.one',
+        'sec-fetch-site': 'same-origin',
       },
+      noAuth: true,
+      remoteAddress: '203.0.113.10',
       body: {
         sessionId: 'session-web-slash',
         channelId: 'web',
@@ -9809,15 +9807,6 @@ describe('gateway HTTP server', () => {
 
   test('uses the signed session subject for /api/command web requests', async () => {
     const authSecret = 'health-secret';
-    const sessionToken = signAuthPayload(
-      {
-        exp: Math.floor(Date.now() / 1000) + 60,
-        iat: Math.floor(Date.now() / 1000),
-        sub: 'user-1',
-        typ: 'session',
-      },
-      authSecret,
-    );
     const state = await importFreshHealth({ authSecret });
     state.handleGatewayCommand.mockResolvedValueOnce({
       kind: 'plain',
@@ -9828,8 +9817,15 @@ describe('gateway HTTP server', () => {
       method: 'POST',
       url: '/api/command',
       headers: {
-        cookie: `hybridclaw_session=${sessionToken}`,
+        cookie: makeSessionCookie(authSecret, {
+          sub: 'user-1',
+        }),
+        host: '127.0.0.1:9090',
+        origin: 'https://u-example.sbx.hybridai.one',
+        'sec-fetch-site': 'same-origin',
       },
+      noAuth: true,
+      remoteAddress: '203.0.113.10',
       body: {
         sessionId: 'session-web-command',
         channelId: 'web',


### PR DESCRIPTION
## Summary
- Allow cookie-authenticated API writes when the browser marks the request as `Sec-Fetch-Site: same-origin`.
- Tighten chat and command regression tests so they use only the signed `hybridclaw_session` cookie, matching the cloud browser request path.

## Root Cause
The cloud browser request sends a valid `hybridclaw_session` cookie and `Origin: https://u-...sbx.hybridai.one`, but POST auth still returned `401`. The write guard required exact string equality between `Origin` and the gateway's reconstructed origin. Behind the TLS-terminating Caddy/proxy path, the backend can reconstruct the internal origin incorrectly, so cookie-backed browser writes like `/api/chat` and `/api/command` were rejected even though reads and admin pages worked.

`Sec-Fetch-Site: same-origin` is a browser-controlled Fetch Metadata header and directly describes the page/request relationship, so it is a better signal for this same-origin cookie write path when proxy origin reconstruction is lossy.

## Validation
- `npx vitest tests/gateway-http-server.test.ts --run -t "uses the signed session subject for web chat requests|uses the signed session subject for /api/command web requests|requires same-origin headers for signed session cookie API mutations|allows signed session cookie API mutations with forwarded public origin|rejects signed session cookie mutations with mismatched forwarded origin"`
- `./node_modules/.bin/tsc --noEmit`
- `npx biome check --write src/gateway/gateway-http-server.ts tests/gateway-http-server.test.ts`
- `git diff --check`