### PR TITLE
fix(mcp): don't let one failing MCP server crash the whole chat turn

### DIFF
--- a/container/src/mcp/config-watcher.ts
+++ b/container/src/mcp/config-watcher.ts
@@ -45,12 +45,25 @@ export class McpConfigWatcher {
 
     for (const name of Object.keys(previous)) {
       if (nextNames.has(name)) continue;
-      await this.manager.removeClient(name);
+      // Tearing down one server must not abort the whole apply.
+      try {
+        await this.manager.removeClient(name);
+      } catch (error) {
+        this.logServerFailure('disconnect', name, error);
+      }
     }
 
     for (const [name, config] of Object.entries(nextConfig)) {
-      if (!configsEqual(previous[name], config)) {
+      if (configsEqual(previous[name], config)) continue;
+      // A single MCP server failing to connect (e.g. an expired OAuth token
+      // answering the initial POST with 401/invalid_token) must NOT reject
+      // applyConfig — that rejection propagates up through syncMcpConfig into
+      // the chat turn and crashes it, taking down ALL chat for the agent.
+      // Log and skip the bad server so the turn proceeds with the rest.
+      try {
         await this.manager.replaceClient(name, config);
+      } catch (error) {
+        this.logServerFailure('connect', name, error);
       }
     }
 
@@ -62,5 +75,14 @@ export class McpConfigWatcher {
   stop(): void {
     this.lastConfig = {};
     this.lastHash = stableHash('{}');
+  }
+
+  private logServerFailure(
+    phase: 'connect' | 'disconnect',
+    name: string,
+    error: unknown,
+  ): void {
+    const detail = error instanceof Error ? error.message : String(error);
+    console.error(`[mcp:${name}] failed to ${phase}: ${detail}`);
   }
 }

--- a/tests/container.mcp-config-watcher.test.ts
+++ b/tests/container.mcp-config-watcher.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { McpConfigWatcher } from '../container/src/mcp/config-watcher.js';
+import type { McpClientManager } from '../container/src/mcp/client-manager.js';
+import type { McpServerConfig } from '../container/src/mcp/types.js';
+
+function httpServer(url: string): McpServerConfig {
+  return { transport: 'http', url };
+}
+
+/**
+ * The watcher must isolate per-server failures. A single MCP server whose
+ * connection rejects (e.g. an expired OAuth token answering with
+ * 401/invalid_token) previously rejected applyConfig, which propagated up
+ * through syncMcpConfig into the chat turn and crashed it — taking down ALL
+ * chat for the agent.
+ */
+describe('McpConfigWatcher.applyConfig graceful failure', () => {
+  test('a failing replaceClient does not reject applyConfig', async () => {
+    const replaceClient = vi.fn(async (name: string) => {
+      if (name === 'broken') {
+        throw new Error(
+          'Streamable HTTP error: invalid_token / Missing or invalid access token',
+        );
+      }
+    });
+    const manager = {
+      replaceClient,
+      removeClient: vi.fn(async () => undefined),
+    } as unknown as McpClientManager;
+
+    const watcher = new McpConfigWatcher(manager);
+
+    await expect(
+      watcher.applyConfig({
+        broken: httpServer('https://example.com/broken'),
+        healthy: httpServer('https://example.com/healthy'),
+      }),
+    ).resolves.toBe(true);
+
+    // Both servers were attempted; the broken one did not short-circuit the rest.
+    expect(replaceClient).toHaveBeenCalledTimes(2);
+    expect(replaceClient.mock.calls.map((c) => c[0]).sort()).toEqual([
+      'broken',
+      'healthy',
+    ]);
+  });
+
+  test('a failing removeClient does not reject applyConfig', async () => {
+    const manager = {
+      replaceClient: vi.fn(async () => undefined),
+      removeClient: vi.fn(async () => {
+        throw new Error('shutdown failed');
+      }),
+    } as unknown as McpClientManager;
+
+    const watcher = new McpConfigWatcher(manager);
+    // Seed lastConfig so the next apply triggers a removal.
+    await watcher.applyConfig({ gone: httpServer('https://example.com/gone') });
+
+    await expect(watcher.applyConfig({})).resolves.toBe(true);
+    expect(manager.removeClient).toHaveBeenCalledWith('gone');
+  });
+
+  test('healthy servers still connect when another server fails', async () => {
+    const connected: string[] = [];
+    const manager = {
+      replaceClient: vi.fn(async (name: string) => {
+        if (name === 'broken') throw new Error('401 invalid_token');
+        connected.push(name);
+      }),
+      removeClient: vi.fn(async () => undefined),
+    } as unknown as McpClientManager;
+
+    const watcher = new McpConfigWatcher(manager);
+    await watcher.applyConfig({
+      broken: httpServer('https://example.com/broken'),
+      a: httpServer('https://example.com/a'),
+      b: httpServer('https://example.com/b'),
+    });
+
+    expect(connected.sort()).toEqual(['a', 'b']);
+  });
+});


### PR DESCRIPTION
## Problem

A single misconfigured MCP server takes down **all** chat for an agent.

`McpConfigWatcher.applyConfig` awaited `manager.replaceClient(name, config)` per server with no error isolation (`container/src/mcp/config-watcher.ts`). When a server's initial Streamable-HTTP POST returns `401 / invalid_token`, the rejection propagates:

```
applyConfig → syncMcpConfig → handleGatewayMessage(Inner) → captureGatewayChatResultError → turn aborts
```

The chat turn dies during `processing-agent-output` (~1.5s, `toolCallCount: 0`) **before the model is ever called**, so the user gets no answer at all.

This commonly happens with an **OAuth MCP server** whose token can't be refreshed: `ensureFreshMcpAccessToken` returns `null`, so `resolveMcpServersForRuntime` passes the server through unauthenticated, and the connect then fails with `invalid_token`.

## Evidence

Reproduced live and captured as **Sentry [HYBRIDCLAW-5](https://hybridai.sentry.io/issues/HYBRIDCLAW-5)**:

> `Unhandled error: Streamable HTTP error: Error POSTing to endpoint: {"error":"invalid_token","error_description":"Missing or invalid access token"}`
> culprit: `captureGatewayChatResultError(gateway:gateway-chat-service)` · `provider: hybridai` · `model: gpt-5.4-mini` · `toolCallCount: 0` · 13 events

The same agent has had **zero** successful model calls since the failure started (frozen `last_llm_usage_at`), confirming the turn never reaches the model.

## Fix

Isolate per-server failures in `applyConfig`: wrap each `replaceClient` / `removeClient` in try/catch, log, and continue. One dead MCP server no longer aborts the turn — chat proceeds with the remaining servers, and the failed server still surfaces as unauthorized in `/mcp list`.

**Tradeoff:** a failed server is not re-attempted until its config changes (avoids a reconnect/connect-timeout storm on every turn). Re-auth via `/mcp login` (which changes config) triggers a fresh attempt.

## Scope / what this does *not* fix

- The expired OAuth token itself is a data/re-auth issue, not a code bug — the user must re-run the MCP login.
- The platform side already surfaces such gateway error results to the dashboard instead of a silent blank (separate change in the chat repo).

## Tests

`tests/container.mcp-config-watcher.test.ts` — a failing `replaceClient`/`removeClient` no longer rejects `applyConfig`, and healthy servers still connect when another fails.

```
✓ unit tests/container.mcp-config-watcher.test.ts (3 tests)
```