### PR TITLE
[codex] skip empty heartbeat defaults

### DIFF
--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -209,6 +209,11 @@ const LEGACY_DEFAULT_BOOTSTRAP_MARKERS = [
   'Use the hatching task ideas guide in the docs website when available',
   'docs/content/guides/hatching-task-ideas.md',
 ] as const;
+const LEGACY_EMPTY_HEARTBEAT_TEXTS = [
+  '# HEARTBEAT.md\n\n# No recurring heartbeat tasks yet.',
+  '# HEARTBEAT.md\n\nNo recurring heartbeat tasks yet.',
+  '# No recurring heartbeat tasks yet.',
+] as const;
 
 function refreshLegacyDefaultBootstrapIfNeeded(params: {
   agentId: string;
@@ -283,6 +288,48 @@ function normalizeBootstrapComparisonText(content: string): string {
   return content.replace(/\r\n/g, '\n').trim();
 }
 
+function isEmptyHeartbeatContext(content: string): boolean {
+  const normalized = normalizeBootstrapComparisonText(content);
+  if (!normalized) return true;
+
+  try {
+    if (
+      normalized ===
+      normalizeBootstrapComparisonText(readTemplateFile('HEARTBEAT.md'))
+    ) {
+      return true;
+    }
+  } catch (error) {
+    logger.warn(
+      { file: 'HEARTBEAT.md', error },
+      'Failed to compare heartbeat context against template',
+    );
+  }
+
+  if (
+    LEGACY_EMPTY_HEARTBEAT_TEXTS.some(
+      (legacy) => normalized === normalizeBootstrapComparisonText(legacy),
+    )
+  ) {
+    return true;
+  }
+
+  const meaningfulLines = normalized
+    .split('\n')
+    .map((line) =>
+      line
+        .trim()
+        .replace(/^#+\s*/, '')
+        .trim(),
+    )
+    .filter(Boolean)
+    .filter((line) => line !== 'HEARTBEAT.md');
+  return (
+    meaningfulLines.length === 1 &&
+    /^no recurring heartbeat tasks yet\.?$/i.test(meaningfulLines[0] || '')
+  );
+}
+
 function shouldLoadBootstrapContextFile(params: {
   name: (typeof WORKSPACE_BOOTSTRAP_FILES)[number];
   content: string;
@@ -290,19 +337,7 @@ function shouldLoadBootstrapContextFile(params: {
   const content = normalizeBootstrapComparisonText(params.content);
   if (!content) return false;
   if (params.name !== 'HEARTBEAT.md') return true;
-
-  try {
-    return (
-      content !==
-      normalizeBootstrapComparisonText(readTemplateFile(params.name))
-    );
-  } catch (error) {
-    logger.warn(
-      { file: params.name, error },
-      'Failed to compare heartbeat context against template',
-    );
-    return true;
-  }
+  return !isEmptyHeartbeatContext(content);
 }
 
 function readUserMarkdown(wsDir: string): string | null {

--- a/tests/workspace-bootstrap.test.ts
+++ b/tests/workspace-bootstrap.test.ts
@@ -387,6 +387,30 @@ describe('workspace bootstrap lifecycle', () => {
     expect(workspace.hasActionableHeartbeatFile('agent-test')).toBe(false);
   });
 
+  test('does not treat legacy empty HEARTBEAT.md defaults as actionable', async () => {
+    const homeDir = makeTempDir('hybridclaw-home-');
+    const unrelatedCwd = makeTempDir('hybridclaw-cwd-');
+    vi.stubEnv('HOME', homeDir);
+    process.chdir(unrelatedCwd);
+
+    const workspace = await import('../src/workspace.js');
+    const ipc = await import('../src/infra/ipc.js');
+
+    workspace.ensureBootstrapFiles('agent-test');
+
+    const workspaceDir = ipc.agentWorkspaceDir('agent-test');
+    const heartbeatPath = path.join(workspaceDir, 'HEARTBEAT.md');
+    fs.writeFileSync(
+      heartbeatPath,
+      '# HEARTBEAT.md\n\n# No recurring heartbeat tasks yet.\n',
+      'utf-8',
+    );
+
+    const files = workspace.loadStaticBootstrapFiles('agent-test');
+    expect(files.some((file) => file.name === 'HEARTBEAT.md')).toBe(false);
+    expect(workspace.hasActionableHeartbeatFile('agent-test')).toBe(false);
+  });
+
   test('loads customized HEARTBEAT.md into bootstrap context', async () => {
     const homeDir = makeTempDir('hybridclaw-home-');
     const unrelatedCwd = makeTempDir('hybridclaw-cwd-');


### PR DESCRIPTION
## Summary

- Treat current and legacy default `HEARTBEAT.md` content as non-actionable in the gateway heartbeat predicate.
- Keep real custom heartbeat task files actionable so periodic checks still run when tasks are configured.
- Add a regression test for the legacy `# No recurring heartbeat tasks yet.` default that was reaching the model and producing `HEARTBEAT_OK` turns.

## Root Cause

Older runtime workspaces can contain a legacy empty heartbeat file that differs from the current template. The existing check only compared `HEARTBEAT.md` to the current template, so those legacy no-op files looked customized and got routed through the model.

## Validation

- `npx biome check --write src/workspace.ts tests/workspace-bootstrap.test.ts`
- `npx vitest run --configLoader runner --project unit tests/workspace-bootstrap.test.ts tests/heartbeat.test.ts tests/scheduler.backlog-retry.test.ts`
- `npm run typecheck`
- `npm run lint`
