### PR TITLE
feat(skills): add Langfuse observability skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Added
+
+- **Langfuse skill**: LLM observability and evaluation based on the official
+  Langfuse skill (`github.com/langfuse/skills`, MIT). Reads traces, observations,
+  sessions, scores, prompts, datasets, models, and metrics, and creates scores,
+  comments, datasets, dataset items, and prompt versions through the
+  gateway-proxied `langfuse.cjs` helper. Auth uses a SecretRef-backed
+  `Authorization: Basic <secret:LANGFUSE_BASIC_AUTH>` header with a
+  `LANGFUSE_HOST` config variable; reads are green and writes are grant-gated.
+  Bundles the upstream reference docs (instrumentation, prompt migration, error
+  analysis, judge calibration, SDK upgrade, CI/CD) plus Langfuse documentation
+  lookup (llms.txt / markdown / search-docs).
+
 ## [0.25.2](https://github.com/HybridAIOne/hybridclaw/tree/v0.25.2) - 2026-06-20
 
 ### Fixed

--- a/docs/content/guides/bundled-skills.md
+++ b/docs/content/guides/bundled-skills.md
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 # Bundled Skills
 
-HybridClaw ships with 76 bundled skills. The production business skills are
+HybridClaw ships with 78 bundled skills. The production business skills are
 implemented as helper-backed workflows with targeted tests, eval scenarios,
 credential boundaries, and approval tiers. `Qwen/Qwen3.6-27B-FP8` is the
 small-model validation baseline for the business-skill path, so the catalog is
@@ -17,7 +17,7 @@ A few notable categories:
 - office workflows: `pdf`, `xlsx`, `docx`, `pptx`, `office-workflows`
 - planning, coworker creation, and engineering: `project-manager`, `feature-planning`, `human-distill`, `code-review`, `code-simplification`, `gh-issues`, `warehouse-sql`
 - visual explainers, image, video, and speech: `diagram`, `manim-video`, `excalidraw`, `image-generation`, `video-generation`, `video.from-script`, `speech.transcribe`, `speech.detect-language`
-- platform integrations: `github-pr-workflow`, `notion`, `trello`, `stripe`, `mailchimp`, `posthog`, `download-platform-invoices`, `wordpress`, `gog`, `google-workspace`, `google-ads`, `ga4`, `airtable`, `fastbill`, `hubspot`, `lexware-office`, `firecrawl`, `heygen`, `hermes3000-writing`, `discord`
+- platform integrations: `github-pr-workflow`, `notion`, `trello`, `stripe`, `mailchimp`, `posthog`, `langfuse`, `download-platform-invoices`, `wordpress`, `gog`, `google-workspace`, `google-ads`, `ga4`, `airtable`, `fastbill`, `hubspot`, `lexware-office`, `firecrawl`, `heygen`, `hermes3000-writing`, `discord`
 - infrastructure, production ops, home automation, and energy monitoring: `hetzner-cloud`, `hetzner-dns`, `hetzner-storage-box`, `mittwald`, `t-cloud-public`, `zabbix`, `shelly`, `homematic`, `fronius`, `byd-battery`, `alexa`, `blink`, `hue`, `warehouse-sql`
 - security and privacy: `distil-pii-redactor`
 - knowledge workflows: `llm-wiki`, `obsidian`, `zettelkasten`

--- a/skills/langfuse/NOTICE.md
+++ b/skills/langfuse/NOTICE.md
@@ -1,0 +1,40 @@
+# Attribution
+
+This skill is adapted from the official **Langfuse Agent Skill**:
+<https://github.com/langfuse/skills>.
+
+The `SKILL.md` body and the `references/` documents
+(`instrumentation.md`, `prompt-migration.md`, `user-feedback.md`,
+`error-analysis.md`, `judge-calibration.md`, `sdk-upgrade.md`, `ci-cd.md`,
+`cli.md`, `skill-feedback.md`) are derived from that project.
+
+HybridClaw-specific additions: the `langfuse.cjs` gateway helper, SecretRef-based
+credential handling (`LANGFUSE_BASIC_AUTH` / `LANGFUSE_HOST`),
+`references/operator-setup.md`, `evals/scenarios.json`, and the manifest
+frontmatter.
+
+The upstream project is MIT-licensed:
+
+```
+MIT License
+
+Copyright (c) 2026 Langfuse GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: langfuse
+description: "Use Langfuse for LLM observability and evaluation and look up Langfuse documentation. In HybridClaw, data access (traces, observations, sessions, scores, prompts, datasets, metrics) goes through the gateway-proxied langfuse.cjs helper with SecretRef auth — reads are green, writes are grant-gated. Documentation retrieval uses langfuse.com llms.txt, markdown pages, and search-docs. Covers instrumentation, prompt migration, error analysis, and LLM-as-a-judge calibration."
+user-invocable: true
+requires:
+  bins:
+    - node
+credentials:
+  - id: langfuse-basic-auth
+    kind: header
+    required: true
+    secret_ref:
+      source: store
+      id: LANGFUSE_BASIC_AUTH
+    scope: "Langfuse public API Authorization Basic header secret for <LANGFUSE_HOST>/api/public"
+    how_to_obtain: |
+      In Langfuse, open Project Settings → API Keys and create a key pair
+      (public key `pk-lf-...` and secret key `sk-lf-...`). Locally base64-encode
+      `public-key:secret-key` and store only that encoded credential in chat with
+      `/secret set LANGFUSE_BASIC_AUTH "<base64-public-colon-secret>"`.
+      The same key reads observability data and writes scores, comments,
+      datasets, and prompt versions.
+config_variables:
+  - id: langfuse-host
+    env: LANGFUSE_HOST
+    required: true
+    scope: "Langfuse API base URL used in <LANGFUSE_HOST>/api/public"
+    how_to_obtain: |
+      Use your Langfuse deployment base URL: `https://cloud.langfuse.com` (EU),
+      `https://us.cloud.langfuse.com` (US), `https://jp.cloud.langfuse.com` (JP),
+      or your self-hosted origin. Store it in chat with
+      `/env set LANGFUSE_HOST https://cloud.langfuse.com`.
+metadata:
+  hybridclaw:
+    category: observability
+    short_description: "Langfuse LLM observability: traces, scores, prompts, datasets, metrics, docs lookup, and guarded evaluation writes."
+    tags:
+      - langfuse
+      - observability
+      - llm
+      - evaluation
+      - tracing
+      - prompts
+    stakes_tiers:
+      green:
+        - health
+        - get-project
+        - list-traces
+        - get-trace
+        - list-observations
+        - get-observation
+        - list-sessions
+        - get-session
+        - list-scores
+        - get-score
+        - list-score-configs
+        - get-score-config
+        - list-prompts
+        - get-prompt
+        - list-datasets
+        - get-dataset
+        - list-dataset-items
+        - get-dataset-item
+        - list-dataset-runs
+        - get-dataset-run
+        - list-models
+        - get-model
+        - list-comments
+        - get-comment
+        - metrics
+      amber:
+        - create-score
+        - create-comment
+        - create-dataset
+        - create-dataset-item
+        - create-prompt
+    escalation:
+      writes: confirm-each
+      route: f14
+    cost_measurement:
+      system: UsageTotals
+      sub_limit_key: langfuse
+---
+
+# Langfuse
+
+This skill helps you use Langfuse effectively across all common workflows:
+instrumenting applications, migrating prompts, debugging traces, accessing data,
+and evaluating outputs.
+
+> **HybridClaw integration.** This is the official Langfuse skill
+> ([github.com/langfuse/skills](https://github.com/langfuse/skills), MIT)
+> adapted for HybridClaw. Two things differ from the upstream skill:
+>
+> 1. **Credentials never leave the gateway.** Do not export
+>    `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY`, run `npx langfuse-cli`, or
+>    paste keys anywhere. Store them once in the runtime stores (below); the
+>    gateway injects them server-side.
+> 2. **Data access goes through `langfuse.cjs`**, not the Langfuse CLI. The
+>    helper builds each REST request and sends it through the HybridClaw gateway,
+>    which resolves `Authorization: Basic <secret:LANGFUSE_BASIC_AUTH>` and the
+>    `<env:LANGFUSE_HOST>` base URL. Wherever a reference says to run
+>    `langfuse-cli` or `curl -H "Authorization: Basic $AUTH"`, use the helper
+>    instead. Documentation retrieval (section 2) is unchanged.
+
+## HybridClaw setup
+
+The helper never sees credentials. Store two values once:
+
+1. `LANGFUSE_BASIC_AUTH` — base64 of `public-key:secret-key`:
+   `/secret set LANGFUSE_BASIC_AUTH "<base64-public-colon-secret>"`
+2. `LANGFUSE_HOST` — your Langfuse base URL:
+   `/env set LANGFUSE_HOST https://cloud.langfuse.com` (use
+   `https://us.cloud.langfuse.com` for US, `https://jp.cloud.langfuse.com` for
+   JP, or your self-hosted origin).
+
+Local-terminal alternative: `hybridclaw secret set LANGFUSE_BASIC_AUTH "<...>"`
+and `hybridclaw env set LANGFUSE_HOST https://cloud.langfuse.com`.
+
+See [references/operator-setup.md](references/operator-setup.md) for key scope,
+host selection, autonomy defaults, and network-policy notes.
+
+## Core Principles
+
+Follow these principles for ALL Langfuse work:
+
+1. **Documentation first**: never implement from memory. Langfuse updates
+   frequently — fetch current docs (section 2) before writing instrumentation or
+   SDK code.
+2. **Helper for data access**: use `langfuse.cjs` (gateway + SecretRef) when
+   querying or modifying Langfuse data. It owns endpoints, methods, bodies,
+   stakes tiers, host, and the Basic auth placeholder.
+3. **Best practices by use case**: check the relevant reference below before
+   implementing.
+4. **Use latest Langfuse versions**: unless the user says otherwise, target the
+   latest Langfuse SDKs/APIs.
+
+## Use-case references
+
+- instrumenting an existing function/application:
+  [references/instrumentation.md](references/instrumentation.md)
+- migrating prompts from a codebase into Langfuse:
+  [references/prompt-migration.md](references/prompt-migration.md)
+- capturing user feedback (thumbs, ratings, implicit signals) as scores:
+  [references/user-feedback.md](references/user-feedback.md)
+- systematic error analysis — reading traces, building a failure taxonomy,
+  deciding what to fix: [references/error-analysis.md](references/error-analysis.md)
+- judge calibration (LLM-as-a-Judge reliability, accuracy checks, confusion
+  matrices, metric ingestion):
+  [references/judge-calibration.md](references/judge-calibration.md)
+- upgrading or migrating Langfuse SDKs:
+  [references/sdk-upgrade.md](references/sdk-upgrade.md)
+- CI/CD experiment gates with `langfuse/experiment-action`:
+  [references/ci-cd.md](references/ci-cd.md)
+- raw Langfuse REST/CLI semantics (endpoints, pagination, v2 vs legacy):
+  [references/cli.md](references/cli.md)
+- HybridClaw credential, host, autonomy, and network-policy setup:
+  [references/operator-setup.md](references/operator-setup.md)
+- submitting feedback about this skill:
+  [references/skill-feedback.md](references/skill-feedback.md)
+
+## 1. Langfuse data access (HybridClaw gateway helper)
+
+`langfuse.cjs` is the API wrapper. Do not handcraft Langfuse API URLs, JSON
+bodies, tiers, host, or the Basic auth header from memory.
+
+```bash
+node skills/langfuse/langfuse.cjs --help
+```
+
+- **plan** classifies a natural-language request into an operation + tier:
+  `node skills/langfuse/langfuse.cjs --format json plan "average eval score this week"`
+- **run** executes a live request through the gateway (the gateway injects the
+  Basic auth header):
+  `node skills/langfuse/langfuse.cjs --format json run list-traces --user-id alice --limit 50`
+- **http-request** emits the gateway-ready payload without calling Langfuse —
+  use it for dry-run inspection or runtimes without helper gateway access.
+
+Read examples (green):
+
+```bash
+node skills/langfuse/langfuse.cjs --format json run get-trace --trace-id abc123
+node skills/langfuse/langfuse.cjs --format json run list-observations --type GENERATION --trace-id abc123
+node skills/langfuse/langfuse.cjs --format json run list-scores --name quality
+node skills/langfuse/langfuse.cjs --format json run get-prompt --prompt-name support-reply --label production
+node skills/langfuse/langfuse.cjs --format json run metrics --query '{"view":"traces","metrics":[{"measure":"count","aggregation":"count"}]}'
+```
+
+Guarded write examples (amber — only after an explicit operator grant):
+
+```bash
+node skills/langfuse/langfuse.cjs --format json run create-score \
+  --trace-id abc123 --name quality --value 0.8 --data-type NUMERIC --comment "reviewed" --operator-grant
+node skills/langfuse/langfuse.cjs --format json run create-prompt \
+  --name summarizer --type text --prompt "Summarize: {{input}}" --label production --operator-grant
+```
+
+Select region or self-hosted host explicitly (otherwise `<env:LANGFUSE_HOST>`):
+
+```bash
+node skills/langfuse/langfuse.cjs --format json run list-traces --host https://us.cloud.langfuse.com
+```
+
+### Working rules
+
+- Reads are green. Writes (`create-score`, `create-comment`, `create-dataset`,
+  `create-dataset-item`, `create-prompt`) require `--operator-grant`: produce a
+  plan, wait for the operator's grant, then run the exact approved command.
+- Deletions and project / API-key / organization / SCIM administration are out
+  of scope. Use the Langfuse UI for those.
+- Page size is capped at 100; use `--page` (legacy) or `--cursor` (modern
+  endpoints) to paginate. The helper rejects `--limit` above 100.
+- For broad trace queries that time out on Langfuse Cloud, prefer
+  `list-observations` (with `--trace-id` when traversing from a known trace).
+- In OpenTelemetry-instrumented apps, trace-level `input`/`output` can be null —
+  the content lives in a `GENERATION` observation, so read observations to see
+  prompts/outputs.
+- Before creating a score config, list existing ones (`list-score-configs`);
+  configs cannot be deleted.
+- Never print, inspect, or ask for `LANGFUSE_BASIC_AUTH`; the gateway injects it
+  as `Authorization: Basic <secret:LANGFUSE_BASIC_AUTH>`.
+- Cost per assistant run is recorded by HybridClaw `UsageTotals`; helper output
+  includes `costMeasurement.system = "UsageTotals"` for eval verification.
+
+## 2. Langfuse documentation
+
+Prefer your application's native web fetch/search tools (e.g. `web_fetch`,
+`web_search`) over `curl`. The URLs work with any fetching method.
+
+### 2a. Documentation index (llms.txt)
+
+Fetch the full index of doc pages, then fetch the right one:
+
+```bash
+curl -s https://langfuse.com/llms.txt
+```
+
+### 2b. Fetch individual pages as markdown
+
+Append `.md` to any doc path (or send `Accept: text/markdown`):
+
+```bash
+curl -s "https://langfuse.com/docs/observability/overview.md"
+```
+
+### 2c. Search documentation
+
+When you don't know the page (also indexes GitHub issues/discussions):
+
+```bash
+curl -s "https://langfuse.com/api/search-docs?query=How+do+I+trace+LangGraph+agents"
+```
+
+Workflow: start with **llms.txt** to orient → **fetch the specific page** → fall
+back to **search** when the topic is unclear.
+
+## Eval suite
+
+```bash
+node skills/langfuse/langfuse.cjs --format json eval-scenarios
+```
+
+The fixture at `evals/scenarios.json` contains 10 scenarios covering trace,
+observation, session, score, metric, prompt, and dataset reads plus guarded
+score, dataset, and prompt writes.
+
+## Skill feedback
+
+If the skill gives wrong or outdated guidance, is missing something, or could be
+improved, offer to submit feedback to the Langfuse skill maintainers following
+[references/skill-feedback.md](references/skill-feedback.md). Do **not** trigger
+this for issues with Langfuse the product — only this skill's instructions.
+
+## Attribution
+
+Adapted from the official Langfuse skill
+([github.com/langfuse/skills](https://github.com/langfuse/skills)), MIT-licensed,
+with HybridClaw gateway/SecretRef data access in place of the upstream
+`langfuse-cli` + plaintext-key path. See [NOTICE.md](NOTICE.md).
+
+## Validation
+
+```bash
+python3 skills/skill-creator/scripts/quick_validate.py skills/langfuse
+node skills/langfuse/langfuse.cjs --help
+node skills/langfuse/langfuse.cjs --format json eval-scenarios
+```

--- a/skills/langfuse/evals/scenarios.json
+++ b/skills/langfuse/evals/scenarios.json
@@ -1,0 +1,83 @@
+[
+  {
+    "id": "langfuse-01",
+    "category": "read-traces",
+    "prompt": "Pull the last 50 traces for user alice and flag any with errors.",
+    "expectedOperation": "list-traces",
+    "expectedTier": "green",
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "langfuse-02",
+    "category": "read-observations",
+    "prompt": "Show the slowest LLM generations from the last hour.",
+    "expectedOperation": "list-observations",
+    "expectedTier": "green",
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "langfuse-03",
+    "category": "read-sessions",
+    "prompt": "List recent conversation sessions so I can review one.",
+    "expectedOperation": "list-sessions",
+    "expectedTier": "green",
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "langfuse-04",
+    "category": "read-scores",
+    "prompt": "What evaluation scores were recorded this week and what is the average?",
+    "expectedOperation": "list-scores",
+    "expectedTier": "green",
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "langfuse-05",
+    "category": "read-metrics",
+    "prompt": "Give me daily trace volume and token cost as metrics for the last 7 days.",
+    "expectedOperation": "metrics",
+    "expectedTier": "green",
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "langfuse-06",
+    "category": "read-prompts",
+    "prompt": "Show me the production prompts we have in Langfuse.",
+    "expectedOperation": "list-prompts",
+    "expectedTier": "green",
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "langfuse-07",
+    "category": "read-datasets",
+    "prompt": "List the evaluation datasets and their items.",
+    "expectedOperation": "list-datasets",
+    "secondaryOperations": ["list-dataset-items"],
+    "expectedTier": "green",
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "langfuse-08",
+    "category": "write-score",
+    "prompt": "Record a quality score of 0.8 on this trace after reviewing it.",
+    "expectedOperation": "create-score",
+    "expectedTier": "amber",
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "langfuse-09",
+    "category": "write-dataset",
+    "prompt": "Add this failing example as a new dataset test case.",
+    "expectedOperation": "create-dataset-item",
+    "expectedTier": "amber",
+    "costMeasurement": { "system": "UsageTotals" }
+  },
+  {
+    "id": "langfuse-10",
+    "category": "write-prompt",
+    "prompt": "Publish a new version of the summarizer prompt with this updated text.",
+    "expectedOperation": "create-prompt",
+    "expectedTier": "amber",
+    "costMeasurement": { "system": "UsageTotals" }
+  }
+]

--- a/skills/langfuse/langfuse.cjs
+++ b/skills/langfuse/langfuse.cjs
@@ -1,0 +1,856 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('node:path');
+
+const DEFAULT_GATEWAY_URL = 'http://127.0.0.1:9090';
+const DEFAULT_TIMEOUT_MS = 30_000;
+const GATEWAY_TIMEOUT_BUFFER_MS = 5_000;
+const BASIC_AUTH_SECRET = 'LANGFUSE_BASIC_AUTH';
+const HOST_ENV = 'LANGFUSE_HOST';
+const HOST_PLACEHOLDER = `<env:${HOST_ENV}>`;
+const EVAL_SCENARIOS_PATH = path.join(__dirname, 'evals', 'scenarios.json');
+
+const COST_MEASUREMENT = {
+  system: 'UsageTotals',
+  source: 'HybridClaw usage_events',
+  scope: 'per assistant run/session',
+};
+
+const LIVE_EXECUTION = {
+  mode: 'live-langfuse-api',
+  requiresConfiguredSecrets: [BASIC_AUTH_SECRET],
+  requiresConfiguredEnv: [HOST_ENV],
+  dryRunSafe:
+    'For prompt/user testing, use http-request and stop after producing this payload; do not call run or http_request.',
+  approvalPolicy:
+    'Writes that create scores, comments, datasets, dataset items, or prompt versions require an explicit operator approval before --operator-grant may be used.',
+  callPolicy:
+    'Use this CJS helper as the API wrapper. For real user requests that need live Langfuse data, use the run command so the helper calls the gateway and the gateway injects the Basic auth header server-side.',
+  secretRefPolicy:
+    'Do not preflight, inspect, print, or ask the model for LANGFUSE_BASIC_AUTH. The Authorization header carries a <secret:LANGFUSE_BASIC_AUTH> placeholder that the gateway resolves.',
+  requestShape:
+    'Do not handcraft Langfuse API calls. The helper owns the endpoint, method, payload, tier, host, and Basic auth placeholder.',
+  unauthorizedPolicy:
+    'If a live call returns 401 or 403, stop after the first failure. Do not retry or call additional Langfuse endpoints; ask the operator to set or verify LANGFUSE_BASIC_AUTH and LANGFUSE_HOST.',
+};
+
+const OPERATION_TIERS = {
+  health: 'green',
+  'get-project': 'green',
+  'list-traces': 'green',
+  'get-trace': 'green',
+  'list-observations': 'green',
+  'get-observation': 'green',
+  'list-sessions': 'green',
+  'get-session': 'green',
+  'list-scores': 'green',
+  'get-score': 'green',
+  'list-score-configs': 'green',
+  'get-score-config': 'green',
+  'list-prompts': 'green',
+  'get-prompt': 'green',
+  'list-datasets': 'green',
+  'get-dataset': 'green',
+  'list-dataset-items': 'green',
+  'get-dataset-item': 'green',
+  'list-dataset-runs': 'green',
+  'get-dataset-run': 'green',
+  'list-models': 'green',
+  'get-model': 'green',
+  'list-comments': 'green',
+  'get-comment': 'green',
+  metrics: 'green',
+  'create-score': 'amber',
+  'create-comment': 'amber',
+  'create-dataset': 'amber',
+  'create-dataset-item': 'amber',
+  'create-prompt': 'amber',
+};
+const HTTP_OPERATIONS = new Set(Object.keys(OPERATION_TIERS));
+
+function die(message, code = 2) {
+  process.stderr.write(`${message}\n`);
+  process.exit(code);
+}
+
+function popFlag(args, name, fallback = undefined, options = {}) {
+  const index = args.indexOf(name);
+  if (index === -1) return fallback;
+  const value = args[index + 1];
+  if (value === undefined || (!options.allowDashValue && value.startsWith('--'))) {
+    die(`${name} requires a value.`);
+  }
+  args.splice(index, 2);
+  return value;
+}
+
+function popRepeatedFlag(args, name) {
+  const values = [];
+  let index = args.indexOf(name);
+  while (index !== -1) {
+    const value = args[index + 1];
+    if (value === undefined || value.startsWith('--')) {
+      die(`${name} requires a value.`);
+    }
+    values.push(value);
+    args.splice(index, 2);
+    index = args.indexOf(name);
+  }
+  return values;
+}
+
+function popBoolean(args, name) {
+  const index = args.indexOf(name);
+  if (index === -1) return false;
+  args.splice(index, 1);
+  return true;
+}
+
+function requireText(value, label) {
+  const normalized = String(value ?? '').trim();
+  if (!normalized) die(`${label} is required.`);
+  return normalized;
+}
+
+function parsePositiveInteger(raw, label) {
+  if (!/^\d+$/.test(String(raw ?? ''))) {
+    die(`${label} must be a positive integer.`);
+  }
+  return Number.parseInt(raw, 10);
+}
+
+function parseNumber(raw, label) {
+  const value = Number(raw);
+  if (!Number.isFinite(value)) die(`${label} must be a number.`);
+  return value;
+}
+
+function parseJsonFlag(raw, label) {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    die(`${label} must be valid JSON.`);
+  }
+}
+
+function encodeSegment(value, label) {
+  return encodeURIComponent(requireText(value, label));
+}
+
+function appendQuery(url, params) {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === '') continue;
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        if (entry === undefined || entry === null || entry === '') continue;
+        query.append(key, String(entry));
+      }
+      continue;
+    }
+    query.set(key, String(value));
+  }
+  const text = query.toString();
+  return text ? `${url}?${text}` : url;
+}
+
+function assertNoUnexpectedArgs(args) {
+  if (args.length > 0) {
+    die(`Unexpected arguments: ${args.join(' ')}`);
+  }
+}
+
+function requireSecretName(value, label) {
+  const secretName = requireText(value, label);
+  if (!/^[A-Z][A-Z0-9_]{0,127}$/u.test(secretName)) {
+    die(`${label} must be an uppercase runtime secret name.`);
+  }
+  return secretName;
+}
+
+function requireGrant(args, operation) {
+  if (OPERATION_TIERS[operation] === 'green') return false;
+  const granted = popBoolean(args, '--operator-grant');
+  if (!granted) {
+    die(
+      `Refusing Langfuse ${operation} without --operator-grant. ` +
+        'Run plan/read first and get an explicit operator grant.',
+    );
+  }
+  return true;
+}
+
+function resolveBaseUrl(args) {
+  const raw = popFlag(args, '--host');
+  if (raw === undefined) return HOST_PLACEHOLDER;
+  const host = requireText(raw, '--host');
+  let parsed;
+  try {
+    parsed = new URL(host);
+  } catch {
+    die('--host must be an absolute https URL, e.g. https://cloud.langfuse.com.');
+  }
+  if (parsed.protocol !== 'https:') {
+    die('--host must use https.');
+  }
+  return host.replace(/\/+$/u, '');
+}
+
+function resolveAuthSecret(args) {
+  return requireSecretName(
+    popFlag(args, '--basic-auth-secret', BASIC_AUTH_SECRET),
+    '--basic-auth-secret',
+  );
+}
+
+function buildHttpRequest(operation, { base, secretName, url, method = 'GET', json }) {
+  const payload = {
+    command: 'http-request',
+    operation,
+    stakesTier: OPERATION_TIERS[operation],
+    httpRequest: {
+      url: `${base}${url}`,
+      method,
+      headers: {
+        Authorization: `Basic <secret:${secretName}>`,
+      },
+      timeoutMs: DEFAULT_TIMEOUT_MS,
+      skillName: 'langfuse',
+      stakesTier: OPERATION_TIERS[operation],
+    },
+    costMeasurement: COST_MEASUREMENT,
+    liveExecution: LIVE_EXECUTION,
+  };
+  if (json !== undefined) payload.httpRequest.json = json;
+  return payload;
+}
+
+function parsePagination(args, query) {
+  const page = popFlag(args, '--page');
+  if (page !== undefined) query.page = parsePositiveInteger(page, '--page');
+  const limit = popFlag(args, '--limit');
+  if (limit !== undefined) {
+    const value = parsePositiveInteger(limit, '--limit');
+    if (value > 100) {
+      die('--limit cannot exceed 100 (Langfuse page-size cap); use --page to paginate.');
+    }
+    query.limit = value;
+  }
+  const cursor = popFlag(args, '--cursor');
+  if (cursor !== undefined) query.cursor = cursor;
+}
+
+function buildScoreBody(args) {
+  const targets = {
+    traceId: popFlag(args, '--trace-id'),
+    observationId: popFlag(args, '--observation-id'),
+    sessionId: popFlag(args, '--session-id'),
+    datasetRunId: popFlag(args, '--dataset-run-id'),
+  };
+  const selected = Object.entries(targets).filter(([, value]) => value !== undefined);
+  if (selected.length === 0) {
+    die(
+      'create-score requires one of --trace-id, --observation-id, --session-id, or --dataset-run-id.',
+    );
+  }
+  if (selected.length > 1) {
+    die('create-score accepts only one score target.');
+  }
+  const name = requireText(popFlag(args, '--name'), '--name');
+  const dataType = popFlag(args, '--data-type', 'NUMERIC');
+  if (!['NUMERIC', 'CATEGORICAL', 'BOOLEAN'].includes(dataType)) {
+    die('--data-type must be NUMERIC, CATEGORICAL, or BOOLEAN.');
+  }
+  const rawValue = requireText(popFlag(args, '--value'), '--value');
+  const body = {
+    name,
+    dataType,
+    value: dataType === 'CATEGORICAL' ? rawValue : parseNumber(rawValue, '--value'),
+    [selected[0][0]]: selected[0][1],
+  };
+  const comment = popFlag(args, '--comment', undefined, { allowDashValue: true });
+  if (comment !== undefined) body.comment = comment;
+  const configId = popFlag(args, '--config-id');
+  if (configId !== undefined) body.configId = configId;
+  const environment = popFlag(args, '--environment');
+  if (environment !== undefined) body.environment = environment;
+  const id = popFlag(args, '--id');
+  if (id !== undefined) body.id = id;
+  return body;
+}
+
+function commandHttpRequest(args) {
+  const operation = args.shift();
+  if (!operation) die('http-request requires an operation.');
+  if (!HTTP_OPERATIONS.has(operation)) {
+    die(`Unknown Langfuse operation: ${operation}`);
+  }
+  const base = resolveBaseUrl(args);
+  const secretName = resolveAuthSecret(args);
+  requireGrant(args, operation);
+  const build = (config) =>
+    buildHttpRequest(operation, { base, secretName, ...config });
+
+  let payload;
+  switch (operation) {
+    case 'health':
+      payload = build({ url: '/api/public/health' });
+      break;
+    case 'get-project':
+      payload = build({ url: '/api/public/projects' });
+      break;
+    case 'list-traces': {
+      const query = {};
+      parsePagination(args, query);
+      query.userId = popFlag(args, '--user-id');
+      query.name = popFlag(args, '--name');
+      query.sessionId = popFlag(args, '--session-id');
+      query.fromTimestamp = popFlag(args, '--from-timestamp');
+      query.toTimestamp = popFlag(args, '--to-timestamp');
+      query.environment = popRepeatedFlag(args, '--environment');
+      query.tags = popRepeatedFlag(args, '--tag');
+      query.version = popFlag(args, '--version');
+      query.release = popFlag(args, '--release');
+      query.orderBy = popFlag(args, '--order-by');
+      payload = build({ url: appendQuery('/api/public/traces', query) });
+      break;
+    }
+    case 'get-trace':
+      payload = build({
+        url: `/api/public/traces/${encodeSegment(popFlag(args, '--trace-id'), '--trace-id')}`,
+      });
+      break;
+    case 'list-observations': {
+      const query = {};
+      parsePagination(args, query);
+      query.name = popFlag(args, '--name');
+      query.userId = popFlag(args, '--user-id');
+      query.type = popFlag(args, '--type');
+      query.traceId = popFlag(args, '--trace-id');
+      query.parentObservationId = popFlag(args, '--parent-observation-id');
+      query.fromStartTime = popFlag(args, '--from-start-time');
+      query.toStartTime = popFlag(args, '--to-start-time');
+      query.environment = popRepeatedFlag(args, '--environment');
+      query.version = popFlag(args, '--version');
+      payload = build({ url: appendQuery('/api/public/observations', query) });
+      break;
+    }
+    case 'get-observation':
+      payload = build({
+        url: `/api/public/observations/${encodeSegment(popFlag(args, '--observation-id'), '--observation-id')}`,
+      });
+      break;
+    case 'list-sessions': {
+      const query = {};
+      parsePagination(args, query);
+      query.fromTimestamp = popFlag(args, '--from-timestamp');
+      query.toTimestamp = popFlag(args, '--to-timestamp');
+      query.environment = popRepeatedFlag(args, '--environment');
+      payload = build({ url: appendQuery('/api/public/sessions', query) });
+      break;
+    }
+    case 'get-session':
+      payload = build({
+        url: `/api/public/sessions/${encodeSegment(popFlag(args, '--session-id'), '--session-id')}`,
+      });
+      break;
+    case 'list-scores': {
+      const query = {};
+      parsePagination(args, query);
+      query.userId = popFlag(args, '--user-id');
+      query.name = popFlag(args, '--name');
+      query.fromTimestamp = popFlag(args, '--from-timestamp');
+      query.toTimestamp = popFlag(args, '--to-timestamp');
+      query.source = popFlag(args, '--source');
+      query.dataType = popFlag(args, '--data-type');
+      query.configId = popFlag(args, '--config-id');
+      query.environment = popRepeatedFlag(args, '--environment');
+      payload = build({ url: appendQuery('/api/public/v2/scores', query) });
+      break;
+    }
+    case 'get-score':
+      payload = build({
+        url: `/api/public/v2/scores/${encodeSegment(popFlag(args, '--score-id'), '--score-id')}`,
+      });
+      break;
+    case 'list-score-configs': {
+      const query = {};
+      parsePagination(args, query);
+      payload = build({ url: appendQuery('/api/public/score-configs', query) });
+      break;
+    }
+    case 'get-score-config':
+      payload = build({
+        url: `/api/public/score-configs/${encodeSegment(popFlag(args, '--config-id'), '--config-id')}`,
+      });
+      break;
+    case 'list-prompts': {
+      const query = {};
+      parsePagination(args, query);
+      query.name = popFlag(args, '--name');
+      query.label = popFlag(args, '--label');
+      query.tag = popFlag(args, '--tag');
+      query.fromUpdatedAt = popFlag(args, '--from-updated-at');
+      query.toUpdatedAt = popFlag(args, '--to-updated-at');
+      payload = build({ url: appendQuery('/api/public/v2/prompts', query) });
+      break;
+    }
+    case 'get-prompt': {
+      const query = {};
+      const version = popFlag(args, '--version');
+      if (version !== undefined) query.version = parsePositiveInteger(version, '--version');
+      query.label = popFlag(args, '--label');
+      payload = build({
+        url: appendQuery(
+          `/api/public/v2/prompts/${encodeSegment(popFlag(args, '--prompt-name'), '--prompt-name')}`,
+          query,
+        ),
+      });
+      break;
+    }
+    case 'list-datasets': {
+      const query = {};
+      parsePagination(args, query);
+      payload = build({ url: appendQuery('/api/public/v2/datasets', query) });
+      break;
+    }
+    case 'get-dataset':
+      payload = build({
+        url: `/api/public/v2/datasets/${encodeSegment(popFlag(args, '--dataset-name'), '--dataset-name')}`,
+      });
+      break;
+    case 'list-dataset-items': {
+      const query = {};
+      parsePagination(args, query);
+      query.datasetName = popFlag(args, '--dataset-name');
+      query.sourceTraceId = popFlag(args, '--source-trace-id');
+      query.sourceObservationId = popFlag(args, '--source-observation-id');
+      payload = build({ url: appendQuery('/api/public/dataset-items', query) });
+      break;
+    }
+    case 'get-dataset-item':
+      payload = build({
+        url: `/api/public/dataset-items/${encodeSegment(popFlag(args, '--item-id'), '--item-id')}`,
+      });
+      break;
+    case 'list-dataset-runs': {
+      const datasetName = encodeSegment(popFlag(args, '--dataset-name'), '--dataset-name');
+      const query = {};
+      parsePagination(args, query);
+      payload = build({
+        url: appendQuery(`/api/public/datasets/${datasetName}/runs`, query),
+      });
+      break;
+    }
+    case 'get-dataset-run': {
+      const datasetName = encodeSegment(popFlag(args, '--dataset-name'), '--dataset-name');
+      const runName = encodeSegment(popFlag(args, '--run-name'), '--run-name');
+      payload = build({
+        url: `/api/public/datasets/${datasetName}/runs/${runName}`,
+      });
+      break;
+    }
+    case 'list-models': {
+      const query = {};
+      parsePagination(args, query);
+      payload = build({ url: appendQuery('/api/public/models', query) });
+      break;
+    }
+    case 'get-model':
+      payload = build({
+        url: `/api/public/models/${encodeSegment(popFlag(args, '--model-id'), '--model-id')}`,
+      });
+      break;
+    case 'list-comments': {
+      const query = {};
+      parsePagination(args, query);
+      query.objectType = popFlag(args, '--object-type');
+      query.objectId = popFlag(args, '--object-id');
+      query.authorUserId = popFlag(args, '--author-user-id');
+      payload = build({ url: appendQuery('/api/public/comments', query) });
+      break;
+    }
+    case 'get-comment':
+      payload = build({
+        url: `/api/public/comments/${encodeSegment(popFlag(args, '--comment-id'), '--comment-id')}`,
+      });
+      break;
+    case 'metrics': {
+      const queryJson = requireText(popFlag(args, '--query'), '--query');
+      parseJsonFlag(queryJson, '--query');
+      payload = build({
+        url: appendQuery('/api/public/metrics', { query: queryJson }),
+      });
+      break;
+    }
+    case 'create-score':
+      payload = build({
+        url: '/api/public/scores',
+        method: 'POST',
+        json: buildScoreBody(args),
+      });
+      break;
+    case 'create-comment': {
+      const objectType = requireText(popFlag(args, '--object-type'), '--object-type');
+      if (!['TRACE', 'OBSERVATION', 'SESSION', 'PROMPT'].includes(objectType)) {
+        die('--object-type must be TRACE, OBSERVATION, SESSION, or PROMPT.');
+      }
+      const json = {
+        objectType,
+        objectId: requireText(popFlag(args, '--object-id'), '--object-id'),
+        content: requireText(
+          popFlag(args, '--content', undefined, { allowDashValue: true }),
+          '--content',
+        ),
+      };
+      const authorUserId = popFlag(args, '--author-user-id');
+      if (authorUserId !== undefined) json.authorUserId = authorUserId;
+      payload = build({ url: '/api/public/comments', method: 'POST', json });
+      break;
+    }
+    case 'create-dataset': {
+      const json = { name: requireText(popFlag(args, '--name'), '--name') };
+      const description = popFlag(args, '--description', undefined, {
+        allowDashValue: true,
+      });
+      if (description !== undefined) json.description = description;
+      const metadata = popFlag(args, '--metadata-json');
+      if (metadata !== undefined) json.metadata = parseJsonFlag(metadata, '--metadata-json');
+      payload = build({ url: '/api/public/v2/datasets', method: 'POST', json });
+      break;
+    }
+    case 'create-dataset-item': {
+      const json = {
+        datasetName: requireText(popFlag(args, '--dataset-name'), '--dataset-name'),
+      };
+      const input = popFlag(args, '--input-json');
+      if (input !== undefined) json.input = parseJsonFlag(input, '--input-json');
+      const expected = popFlag(args, '--expected-output-json');
+      if (expected !== undefined) {
+        json.expectedOutput = parseJsonFlag(expected, '--expected-output-json');
+      }
+      const metadata = popFlag(args, '--metadata-json');
+      if (metadata !== undefined) json.metadata = parseJsonFlag(metadata, '--metadata-json');
+      const sourceTraceId = popFlag(args, '--source-trace-id');
+      if (sourceTraceId !== undefined) json.sourceTraceId = sourceTraceId;
+      const sourceObservationId = popFlag(args, '--source-observation-id');
+      if (sourceObservationId !== undefined) {
+        json.sourceObservationId = sourceObservationId;
+      }
+      const id = popFlag(args, '--id');
+      if (id !== undefined) json.id = id;
+      const status = popFlag(args, '--status');
+      if (status !== undefined) {
+        if (!['ACTIVE', 'ARCHIVED'].includes(status)) {
+          die('--status must be ACTIVE or ARCHIVED.');
+        }
+        json.status = status;
+      }
+      payload = build({ url: '/api/public/dataset-items', method: 'POST', json });
+      break;
+    }
+    case 'create-prompt': {
+      const type = popFlag(args, '--type', 'text');
+      if (!['text', 'chat'].includes(type)) {
+        die('--type must be text or chat.');
+      }
+      const json = {
+        type,
+        name: requireText(popFlag(args, '--name'), '--name'),
+      };
+      if (type === 'chat') {
+        json.prompt = parseJsonFlag(
+          requireText(popFlag(args, '--prompt-json'), '--prompt-json'),
+          '--prompt-json',
+        );
+      } else {
+        json.prompt = requireText(
+          popFlag(args, '--prompt', undefined, { allowDashValue: true }),
+          '--prompt',
+        );
+      }
+      const labels = popRepeatedFlag(args, '--label');
+      if (labels.length > 0) json.labels = labels;
+      const tags = popRepeatedFlag(args, '--tag');
+      if (tags.length > 0) json.tags = tags;
+      const config = popFlag(args, '--config-json');
+      if (config !== undefined) json.config = parseJsonFlag(config, '--config-json');
+      const commitMessage = popFlag(args, '--commit-message', undefined, {
+        allowDashValue: true,
+      });
+      if (commitMessage !== undefined) json.commitMessage = commitMessage;
+      payload = build({ url: '/api/public/v2/prompts', method: 'POST', json });
+      break;
+    }
+    default:
+      die(`Unknown Langfuse operation: ${operation}`);
+  }
+  assertNoUnexpectedArgs(args);
+  return payload;
+}
+
+function buildPlan(text) {
+  const normalized = text.toLowerCase();
+  let operation = 'list-traces';
+  if (/\b(metric|analytics|aggregate|count|cost over time|daily)\b/.test(normalized)) {
+    operation = 'metrics';
+  } else if (/\b(score|eval|evaluat|rate|rating|grade)\b/.test(normalized) && /\b(add|create|write|record|submit|log)\b/.test(normalized)) {
+    operation = 'create-score';
+  } else if (/\b(comment|annotat|note)\b/.test(normalized) && /\b(add|create|write|leave)\b/.test(normalized)) {
+    operation = 'create-comment';
+  } else if (/\b(prompt)\b/.test(normalized) && /\b(create|new version|publish|push|update)\b/.test(normalized)) {
+    operation = 'create-prompt';
+  } else if (/\b(dataset item|test case|example)\b/.test(normalized) && /\b(add|create|new)\b/.test(normalized)) {
+    operation = 'create-dataset-item';
+  } else if (/\b(dataset)\b/.test(normalized) && /\b(create|new)\b/.test(normalized)) {
+    operation = 'create-dataset';
+  } else if (/\b(prompt)\b/.test(normalized)) {
+    operation = 'list-prompts';
+  } else if (/\b(dataset run|experiment run)\b/.test(normalized)) {
+    operation = 'list-dataset-runs';
+  } else if (/\b(dataset)\b/.test(normalized)) {
+    operation = 'list-datasets';
+  } else if (/\b(score|eval|rating)\b/.test(normalized)) {
+    operation = 'list-scores';
+  } else if (/\b(session|conversation)\b/.test(normalized)) {
+    operation = 'list-sessions';
+  } else if (/\b(observation|span|generation|llm call)\b/.test(normalized)) {
+    operation = 'list-observations';
+  } else if (/\b(model|pricing)\b/.test(normalized)) {
+    operation = 'list-models';
+  } else if (/\b(health|status|ping|connectivity)\b/.test(normalized)) {
+    operation = 'health';
+  }
+  const tier = OPERATION_TIERS[operation];
+  return {
+    command: 'plan',
+    operation,
+    stakesTier: tier,
+    requiresEscalation: tier !== 'green',
+    requiredGrant: tier === 'green' ? null : `approve-langfuse-${operation}`,
+    secretPolicy: {
+      basicAuthSecret: BASIC_AUTH_SECRET,
+      hostEnv: HOST_ENV,
+      modelSeesSecret: false,
+    },
+    costMeasurement: COST_MEASUREMENT,
+  };
+}
+
+function resolveGatewayUrl(raw) {
+  const value =
+    String(raw || '').trim() ||
+    String(process.env.HYBRIDCLAW_GATEWAY_URL || '').trim() ||
+    String(process.env.GATEWAY_BASE_URL || '').trim() ||
+    DEFAULT_GATEWAY_URL;
+  const normalized = value.replace(/\/+$/u, '');
+  let parsed;
+  try {
+    parsed = new URL(normalized);
+  } catch {
+    die('--gateway-url must be an absolute http or https URL.');
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    die('--gateway-url must use http or https.');
+  }
+  return normalized;
+}
+
+function resolveGatewayToken(raw) {
+  return (
+    String(raw || '').trim() ||
+    String(process.env.HYBRIDCLAW_GATEWAY_TOKEN || '').trim() ||
+    String(process.env.GATEWAY_API_TOKEN || '').trim() ||
+    String(process.env.WEB_API_TOKEN || '').trim()
+  );
+}
+
+async function gatewayRequest(httpRequest, { gatewayUrl, gatewayToken }) {
+  const url = `${gatewayUrl}/api/http/request`;
+  const headers = { 'Content-Type': 'application/json' };
+  if (gatewayToken) headers.Authorization = `Bearer ${gatewayToken}`;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    (httpRequest.timeoutMs || DEFAULT_TIMEOUT_MS) + GATEWAY_TIMEOUT_BUFFER_MS,
+  );
+  let response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(httpRequest),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    die(
+      `Cannot reach HybridClaw gateway at ${url}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      1,
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  const text = await response.text();
+  let envelope;
+  try {
+    envelope = text ? JSON.parse(text) : {};
+  } catch {
+    die(`Gateway returned non-JSON response: ${text.slice(0, 500)}`, 1);
+  }
+  if (!response.ok) {
+    die(
+      `Gateway request failed with HTTP ${response.status}: ${text.slice(0, 500)}`,
+      1,
+    );
+  }
+  return envelope;
+}
+
+async function commandRun(args) {
+  const gatewayUrl = resolveGatewayUrl(popFlag(args, '--gateway-url'));
+  const gatewayToken = resolveGatewayToken(popFlag(args, '--gateway-token'));
+  const requestPayload = commandHttpRequest(args);
+  const response = await gatewayRequest(requestPayload.httpRequest, {
+    gatewayUrl,
+    gatewayToken,
+  });
+  return {
+    command: 'run',
+    operation: requestPayload.operation,
+    stakesTier: requestPayload.stakesTier,
+    response,
+    costMeasurement: COST_MEASUREMENT,
+    liveExecution: requestPayload.liveExecution,
+  };
+}
+
+function commandEvalScenarios() {
+  const scenarios = JSON.parse(require('node:fs').readFileSync(EVAL_SCENARIOS_PATH, 'utf-8'));
+  const categories = {};
+  let failed = 0;
+  for (const scenario of scenarios) {
+    categories[scenario.category] = (categories[scenario.category] || 0) + 1;
+    if (
+      !scenario.expectedOperation ||
+      !scenario.expectedTier ||
+      scenario.costMeasurement?.system !== 'UsageTotals'
+    ) {
+      failed += 1;
+    }
+  }
+  return {
+    command: 'eval-scenarios',
+    scenarioCount: scenarios.length,
+    failed,
+    categories,
+    costMeasurement: COST_MEASUREMENT,
+  };
+}
+
+function printOutput(payload, format) {
+  if (format === 'json') {
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    return;
+  }
+  if (format === 'text') {
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+    return;
+  }
+  die('--format must be json or text.');
+}
+
+function showHelp() {
+  process.stdout.write(`Langfuse skill helper
+
+Usage:
+  node skills/langfuse/langfuse.cjs [--format json] plan <request>
+  node skills/langfuse/langfuse.cjs [--format json] run <operation> [flags]
+  node skills/langfuse/langfuse.cjs [--format json] http-request <operation> [flags]
+  node skills/langfuse/langfuse.cjs [--format json] eval-scenarios
+
+Live execution:
+  run sends the helper-built request through the HybridClaw gateway at /api/http/request.
+  It uses HYBRIDCLAW_GATEWAY_URL or GATEWAY_BASE_URL, default ${DEFAULT_GATEWAY_URL}.
+  It uses HYBRIDCLAW_GATEWAY_TOKEN, GATEWAY_API_TOKEN, or WEB_API_TOKEN if set.
+  Use http-request only for dry-run payload inspection or runtimes without helper gateway access.
+
+Auth and host (gateway-resolved, never seen by the model):
+  Authorization: Basic <secret:${BASIC_AUTH_SECRET}>   (base64 of public-key:secret-key)
+  Base URL defaults to ${HOST_PLACEHOLDER}; override with --host https://cloud.langfuse.com
+  --basic-auth-secret NAME   Runtime secret with base64 public:secret (default ${BASIC_AUTH_SECRET})
+
+Pagination (list operations):
+  --limit n   page size, max 100 (Langfuse cap)
+  --page n    page number (legacy endpoints) | --cursor c  cursor (modern endpoints)
+
+Read operations (green):
+  health
+  get-project
+  list-traces [--user-id u] [--name n] [--session-id s] [--from-timestamp iso] [--to-timestamp iso] [--tag t]... [--environment e]... [--page p] [--limit l]
+  get-trace --trace-id id
+  list-observations [--name n] [--type GENERATION|SPAN|EVENT] [--trace-id id] [--user-id u] [--from-start-time iso] [--page p] [--limit l]
+  get-observation --observation-id id
+  list-sessions [--from-timestamp iso] [--to-timestamp iso] [--environment e]... [--page p] [--limit l]
+  get-session --session-id id
+  list-scores [--name n] [--user-id u] [--source API|ANNOTATION|EVAL] [--data-type NUMERIC|CATEGORICAL|BOOLEAN] [--config-id id] [--page p] [--limit l]
+  get-score --score-id id
+  list-score-configs [--page p] [--limit l]
+  get-score-config --config-id id
+  list-prompts [--name n] [--label l] [--tag t] [--page p] [--limit l]
+  get-prompt --prompt-name name [--version n | --label l]
+  list-datasets [--page p] [--limit l]
+  get-dataset --dataset-name name
+  list-dataset-items [--dataset-name name] [--source-trace-id id] [--page p] [--limit l]
+  get-dataset-item --item-id id
+  list-dataset-runs --dataset-name name [--page p] [--limit l]
+  get-dataset-run --dataset-name name --run-name name
+  list-models [--page p] [--limit l]
+  get-model --model-id id
+  list-comments [--object-type TRACE|OBSERVATION|SESSION|PROMPT] [--object-id id] [--page p] [--limit l]
+  get-comment --comment-id id
+  metrics --query '<json metrics query>'
+
+Write operations require --operator-grant (amber):
+  create-score (--trace-id id | --observation-id id | --session-id id | --dataset-run-id id) --name n --value v [--data-type NUMERIC|CATEGORICAL|BOOLEAN] [--comment text] [--config-id id] [--environment e]
+  create-comment --object-type TRACE|OBSERVATION|SESSION|PROMPT --object-id id --content text [--author-user-id u]
+  create-dataset --name n [--description text] [--metadata-json '{...}']
+  create-dataset-item --dataset-name n [--input-json '{...}'] [--expected-output-json '{...}'] [--metadata-json '{...}'] [--source-trace-id id] [--status ACTIVE|ARCHIVED]
+  create-prompt --name n [--type text|chat] (--prompt text | --prompt-json '[...]') [--label l]... [--tag t]... [--config-json '{...}'] [--commit-message text]
+
+Out of scope (use the Langfuse UI or admin API directly):
+  deletions of any kind, and project / API-key / membership / organization / SCIM administration.
+`);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.length === 0) {
+    showHelp();
+    return;
+  }
+  const format = popFlag(args, '--format', 'text');
+  const command = args.shift();
+  let payload;
+  if (command === 'plan') {
+    payload = buildPlan(args.join(' '));
+  } else if (command === 'http-request') {
+    payload = commandHttpRequest(args);
+  } else if (command === 'run') {
+    payload = await commandRun(args);
+  } else if (command === 'eval-scenarios') {
+    payload = commandEvalScenarios();
+  } else {
+    die(`Unknown command: ${command}`);
+  }
+  printOutput(payload, format);
+}
+
+void main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/skills/langfuse/references/ci-cd.md
+++ b/skills/langfuse/references/ci-cd.md
@@ -1,0 +1,35 @@
+---
+name: langfuse-ci-cd
+description: Set up or extend agent regression checks / gating in GitHub Actions CI/CD using `langfuse/experiment-action`.
+---
+
+# Langfuse CI/CD
+
+## Checklist
+
+- [ ] Follow the [CI/CD docs page](https://langfuse.com/docs/evaluation/experiments/experiments-ci-cd) and the [langfuse/experiment-action README](https://github.com/langfuse/experiment-action)
+- [ ] Inspect whether the local repository is a GitHub repo. If not, `langfuse/experiment-action` is not applicable. Follow the guide for other [CI/CD systems](https://langfuse.com/docs/evaluation/experiments/experiments-ci-cd#other-cicd-systems) instead
+- [ ] Ask the user which [evaluators and run evaluators](https://langfuse.com/docs/evaluation/experiments/experiments-via-sdk#evaluators) they want to set up
+- [ ] Ask the user if and when yes which regression thresholds they want to set
+- [ ] Confirm dataset existence and shape of the dataset items before writing code with the Langfuse CLI (see `references/cli.md`)
+  - `langfuse-cli api datasets list`
+  - `langfuse-cli api dataset-items list --dataset-name <dataset name> --limit 5`
+- [ ] Propose the user to verify the check by actually running the new CI check (e.g. by creating a pull request)
+- [ ] If the evaluator task uses a third-party dependency, add the necessary CI steps to install them
+
+### GitHub specific checklist
+- [ ] Ask the user how they want the [workflow to be triggered](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows)
+- [ ] If available, use the `gh` CLI to check secret existence / set secrets for:
+      - Langfuse credentials
+      - Credentials required by the evaluator task (e.g. OpenAI or Anthropic API keys)
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| `gh` is missing or not authenticated | Install the GitHub CLI if needed, then run `gh auth status` and `gh auth login` before using `gh secret` or `gh workflow` commands. |
+| Local Langfuse environment variables are not set | Set `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_HOST` locally before using `langfuse-cli`; do not ask the user to paste secret values into chat. |
+| Workflow secrets or action inputs are wrong | Verify `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `langfuse_base_url`, and provider secrets exist in the target repo/environment and are passed to the action step. |
+| Forked PR cannot access secrets | GitHub restricts secret access for forked PRs. Document the limitation or choose a trusted trigger such as internal PR, trusted-branch `push`, or `workflow_dispatch`. |
+| No default/base branch exists | Create an initial empty commit on the intended default branch before trying to verify a PR-triggered workflow. |
+| Script fails reading dataset fields | Re-inspect the dataset items with the Langfuse CLI, check `input`, `expected_output`, and metadata, and extract fields from object-shaped outputs explicitly. |

--- a/skills/langfuse/references/cli.md
+++ b/skills/langfuse/references/cli.md
@@ -1,0 +1,59 @@
+# Langfuse CLI Reference
+
+Documentation: https://langfuse.com/docs/api-and-data-platform/features/cli
+
+> **HybridClaw note.** Use the `langfuse.cjs` gateway helper for data access
+> instead of `langfuse-cli`, and do not export `LANGFUSE_PUBLIC_KEY` /
+> `LANGFUSE_SECRET_KEY` — the gateway injects credentials from
+> `LANGFUSE_BASIC_AUTH`. The endpoint, pagination (`--page` / `--cursor`,
+> `--limit` ≤ 100), and v2-vs-legacy guidance below still describes the REST API
+> the helper calls. See SKILL.md section 1.
+
+## Install
+
+```bash
+# Run directly (recommended)
+npx langfuse-cli api <resource> <action>
+bunx langfuse-cli api <resource> <action>
+
+# Or install globally
+npm i -g langfuse-cli
+langfuse api <resource> <action>
+```
+
+## Discovery
+
+```bash
+# List all resources and auth info
+langfuse api __schema
+
+# List actions for a resource
+langfuse api <resource> --help
+
+# Show args/options for a specific action
+langfuse api <resource> <action> --help
+
+# Preview the curl command without executing
+langfuse api <resource> <action> --curl
+```
+
+## Credentials
+
+Set environment variables:
+
+```bash
+export LANGFUSE_PUBLIC_KEY=pk-lf-...
+export LANGFUSE_SECRET_KEY=sk-lf-...
+export LANGFUSE_BASE_URL=https://cloud.langfuse.com  
+```
+
+## Tips
+
+- Use `--json` for machine-readable JSON output
+- Use `--curl` to preview the HTTP request without executing
+- All list commands support filtering — check `<resource> <action> --help` for available options
+- Prefer `observations` over `legacy-observations-v1s` — `observations` is the modern high-performance endpoint (cursor pagination, selective field groups); `legacy-observations-v1s` is the deprecated v1
+- Prefer `metrics` over `legacy-metrics-v1s` for the same reason
+- Prefer `scores` over `legacy-score-v1s` for list/get operations
+- For broad trace queries, `traces list` can time out on Langfuse Cloud — use `observations list` (with `--trace-id` if you're traversing from a known trace) instead. See the [Observations API docs](https://langfuse.com/docs/api-and-data-platform/features/observations-api) for the v1 → v2 mapping.
+- Pagination: legacy v1 endpoints use `--limit` and `--page`; modern endpoints (`observations`, `metrics`, `scores`) use cursor-based pagination — pass `--limit`, then thread `meta.cursor` from the response into the next request's `--cursor`

--- a/skills/langfuse/references/error-analysis.md
+++ b/skills/langfuse/references/error-analysis.md
@@ -1,0 +1,107 @@
+---
+name: langfuse-error-analysis
+description: Deep-dive error analysis of an LLM pipeline or AI application using Langfuse traces.
+  Use this skill whenever the user wants to understand why their AI system is producing
+  bad outputs, where their pipeline is failing, how to categorise or label failures,
+  what to prioritise fixing, or how to set up evaluators. Also trigger for "review my
+  traces", "my outputs look wrong", "help me debug my LLM app", "I want to analyse
+  errors", "build a failure taxonomy", "what's going wrong with my pipeline", or any
+  request to systematically inspect, annotate, or score Langfuse traces. If the user
+  is trying to understand or improve the quality of an AI system's outputs, use this skill.
+---
+
+# Error Analysis
+
+> **HybridClaw note.** Run data access (trace/observation reads, score and
+> annotation-queue writes) through the `langfuse.cjs` gateway helper rather than
+> `langfuse-cli` or `curl` with exported keys. Where this guide shows
+> `LANGFUSE_PUBLIC_KEY` / `curl -H "Authorization: Basic $AUTH"`, the gateway
+> injects that header from `LANGFUSE_BASIC_AUTH` instead. The process and API
+> mechanics below are otherwise the same.
+
+## Primary Guide
+
+**1. Fetch the guide in this blogpost**
+
+https://langfuse.com/guides/cookbook/error-analysis-llm-applications.md
+
+If fetch is not available query for langfuse.com error analysis guide
+
+Read it in full. It defines the authoritative 5-step process (sample selection → open coding → clustering → labelling → deciding what to fix).
+
+**2. Guide the user through this step by step**
+
+You as a coding agent and the user go through this together to perform a full error analysis with their data in langfuse. Do everything you can achieve via CLI (look up traces, create annotation queues, ...) for the user. Provide them with direct links to UI wherever their action is required. Be proactive and narrate what is going on for the user. 
+
+## Rules CRITICAL
+Use Langfuse CLI wherever possible
+Use charts where possible to display data
+
+---
+
+## Langfuse Implementation Notes
+
+The guide describes the process. These notes cover the Langfuse-specific API and CLI mechanics required to execute it.
+
+### Credentials
+
+```bash
+echo $LANGFUSE_PUBLIC_KEY   # pk-lf-...
+echo $LANGFUSE_SECRET_KEY   # sk-lf-...
+echo $LANGFUSE_BASE_URL     # https://cloud.langfuse.com (EU), https://us.cloud.langfuse.com (US), https://jp.cloud.langfuse.com (JP) or self-hosted
+```
+
+If not set, check `.env` in the project root: `export $(grep -v '^#' .env | xargs)`. If `LANGFUSE_HOST` is used instead of `LANGFUSE_BASE_URL`, run `export LANGFUSE_BASE_URL="$LANGFUSE_HOST"`.
+
+```bash
+AUTH=$(echo -n "${LANGFUSE_PUBLIC_KEY}:${LANGFUSE_SECRET_KEY}" | base64)
+
+# Verify before proceeding
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Basic $AUTH" \
+  "${LANGFUSE_BASE_URL}/api/public/projects")
+echo "Auth check: $STATUS"
+```
+
+If status is not `200`, stop and ask the user to check their credentials and host before continuing.
+
+### Annotation target: OBSERVATION versus TRACE
+
+> **CRITICAL:** In OpenTelemetry-instrumented apps, trace-level `input`/`output` can be null — content often lives in a GENERATION observation. Always consider if the right objectType to add is `objectType: OBSERVATION` pointing to the GENERATION observation ID to annotation queues. 
+
+### Annotation queues
+
+> **CRITICAL:** Queues cannot be updated or deleted after creation. Create score configs first, then the queue with all config IDs. To add new configs later, create a new queue.
+
+
+**Always give the user a direct link immediately after creating a queue:**
+
+| Host | URL pattern |
+|------|-------------|
+| EU cloud | `https://cloud.langfuse.com/project/<projectId>/annotation-queues/<queueId>` |
+| US cloud | `https://us.cloud.langfuse.com/project/<projectId>/annotation-queues/<queueId>` |
+| Self-hosted | `<LANGFUSE_BASE_URL>/project/<projectId>/annotation-queues/<queueId>` |
+
+Instruction to give: *"Please open code the first ~50 examples. For each trace, write what you observe in the `open_coding` field (describe behaviour, don't diagnose root causes), then set `pass_fail_assessment` to Pass or Fail."*
+
+
+### Prompt fixes
+
+When a category warrants a prompt fix, always offer the user two options:
+1. Create it as a versioned prompt in Langfuse (tracked, usable via the prompt API)
+2. Draft the specific text change for them to review and apply
+
+### Setup evaluators
+
+When a category warrants an evaluator setup, propose the type of evaluator and offer to set it up for user via CLI
+
+
+### Common gotchas
+
+| Mistake | Fix |
+|---------|-----|
+| `objectType: TRACE` in queue | Use `objectType: OBSERVATION` with GENERATION obs ID |
+| Creating score config without checking existing | `GET /api/public/score-configs` first; can't delete |
+| Queue created before score configs | Create configs → collect IDs → create queue |
+| `--limit` > 100 on traces list | API hard cap; paginate with `--page` |
+| No rate limiting on queue item creation | `sleep 0.4` between calls to avoid 429 |

--- a/skills/langfuse/references/instrumentation.md
+++ b/skills/langfuse/references/instrumentation.md
@@ -1,0 +1,134 @@
+---
+name: langfuse-observability
+description: Instrument LLM applications with Langfuse tracing. Use when setting up Langfuse, adding observability to LLM calls, or auditing existing instrumentation.
+---
+
+# Langfuse Observability
+
+Instrument LLM applications with Langfuse tracing, following best practices and tailored to your use case.
+
+## Workflow
+
+### 1. Assess Current State
+
+Check the project:
+
+- Is Langfuse SDK installed?
+- What LLM frameworks are used? (OpenAI SDK, LangChain, LlamaIndex, Vercel AI SDK, etc.)
+- Is there existing instrumentation?
+
+**No integration yet:** Set up Langfuse using a framework integration if available. Integrations capture more context automatically and require less code than manual instrumentation.
+
+**Integration exists:** Audit against baseline requirements below.
+
+### 2. Verify Baseline Requirements
+
+Every trace should have these fundamentals:
+
+| Requirement               | Check                                                                                    | Why                                                    |
+| ------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| Model name                | Is the LLM model captured?                                                               | Enables model comparison and filtering                 |
+| Token usage               | Are input/output tokens tracked?                                                         | Enables automatic cost calculation                     |
+| Good trace names          | Are names descriptive? (`chat-response`, not `trace-1`)                                  | Makes traces findable and filterable                   |
+| Span hierarchy            | Are multi-step operations nested properly?                                               | Shows which step is slow or failing                    |
+| Correct observation types | Are generations marked as generations?                                                   | Enables model-specific analytics                       |
+| Sensitive data masked     | Is PII/confidential data excluded or masked?                                             | Prevents data leakage                                  |
+| Trace input/output        | Does the trace capture meaningful input/output? Is input explicitly set to show only relevant data (e.g., user message), not all function args? | Makes traces readable in the UI and avoids leaking sensitive args |
+
+Framework integrations (OpenAI, LangChain, etc.) handle model name, tokens, and observation types automatically. Prefer integrations over manual instrumentation.
+
+Docs: https://langfuse.com/docs/tracing
+
+### 3. Explore Traces First
+
+Once baseline instrumentation is working, encourage the user to explore their traces in the Langfuse UI before adding more context:
+
+"Your traces are now appearing in Langfuse. Take a look at a few of them—see what data is being captured, what's useful, and what's missing. This will help us decide what additional context to add."
+
+This helps the user:
+
+- Understand what they're already getting
+- Form opinions about what's missing
+- Ask better questions about what they need
+
+### 4. Discover Additional Context Needs
+
+Determine what additional instrumentation would be valuable. **Infer from code when possible, only ask when unclear.**
+
+**Infer from code:**
+
+| If you see in code...                                | Infer             | Suggest                   |
+| ---------------------------------------------------- | ----------------- | ------------------------- |
+| Conversation history, chat endpoints, message arrays | Multi-turn app    | `session_id`              |
+| User authentication, `user_id` variables             | User-aware app    | `user_id` on traces       |
+| Multiple distinct endpoints/features                 | Multi-feature app | `feature` tag             |
+| Customer/tenant identifiers                          | Multi-tenant app  | `customer_id` or tier tag |
+| Feedback collection, ratings                         | Has user feedback | Capture as scores         |
+
+**Only ask when not obvious from code:**
+
+- "How do you know when a response is good vs bad?" → Determines scoring approach
+- "What would you want to filter by in a dashboard?" → Surfaces non-obvious tags
+- "Are there different user segments you'd want to compare?" → Customer tiers, plans, etc.
+
+**Additions and their value:**
+
+| Addition            | Why                                         | Docs                                                |
+| ------------------- | ------------------------------------------- | --------------------------------------------------- |
+| `session_id`        | Groups conversations together               | https://langfuse.com/docs/tracing-features/sessions |
+| `user_id`           | Enables user filtering and cost attribution | https://langfuse.com/docs/tracing-features/users    |
+| User feedback score | Enables quality filtering and trends        | https://langfuse.com/docs/scores/overview           |
+| `feature` tag       | Per-feature analytics                       | https://langfuse.com/docs/tracing-features/tags     |
+| `customer_tier` tag | Cost/quality breakdown by segment           | https://langfuse.com/docs/tracing-features/tags     |
+
+These are NOT baseline requirements—only add what's relevant based on inference or user input.
+
+### 5. Guide to UI
+
+After adding context, point users to relevant UI features:
+
+- Traces view: See individual requests
+- Sessions view: See grouped conversations (if session_id added)
+- Dashboard: Build filtered views using tags
+- Scores: Filter by quality metrics
+
+## Framework Integrations
+
+Prefer these over manual instrumentation:
+
+| Framework     | Integration            | Docs                                                 |
+| ------------- | ---------------------- | ---------------------------------------------------- |
+| OpenAI SDK    | Drop-in replacement    | https://langfuse.com/docs/integrations/openai        |
+| LangChain     | Callback handler       | https://langfuse.com/docs/integrations/langchain     |
+| LlamaIndex    | Callback handler       | https://langfuse.com/docs/integrations/llama-index   |
+| Vercel AI SDK | OpenTelemetry exporter | https://langfuse.com/docs/integrations/vercel-ai-sdk |
+| LiteLLM       | Callback or proxy      | https://langfuse.com/docs/integrations/litellm       |
+
+Full list: https://langfuse.com/docs/integrations
+
+## Always Explain Why
+
+When suggesting additions, explain the user benefit:
+
+```
+"I recommend adding session_id to your traces.
+
+Why: This groups messages from the same conversation together.
+You'll be able to see full conversation flows in the Sessions view,
+making it much easier to debug multi-turn interactions.
+
+Learn more: https://langfuse.com/docs/tracing-features/sessions"
+```
+
+## Common Mistakes
+
+| Mistake                                        | Problem                                             | Fix                                                                               |
+| ---------------------------------------------- | --------------------------------------------------- | --------------------------------------------------------------------------------- |
+| No `flush()` in scripts                        | Traces never sent                                   | Call `langfuse.flush()` before exit                                               |
+| Flat traces                                    | Can't see which step failed                         | Use nested spans for distinct steps                                               |
+| Generic trace names                            | Hard to filter                                      | Use descriptive names: `chat-response`, `doc-summary`                             |
+| Logging sensitive data                         | Data leakage risk                                   | Mask PII before tracing                                                           |
+| Not explicitly setting input with `@observe`   | All function args become trace input (including API keys, configs) | Python: use `langfuse.update_current_span(input=...)`. JS/TS: use `updateActiveObservation({ input: ... })`. Set only the relevant input (e.g., user message) |
+| Manual instrumentation when integration exists | More code, less context                             | Use framework integration                                                         |
+| Langfuse import before env vars loaded         | Langfuse initializes with missing/wrong credentials | Import Langfuse AFTER loading environment variables (e.g., after `load_dotenv()`) |
+| Wrong import order with OpenAI                 | Langfuse can't patch the OpenAI client              | Import Langfuse and call its setup BEFORE importing OpenAI client                 |

--- a/skills/langfuse/references/judge-calibration.md
+++ b/skills/langfuse/references/judge-calibration.md
@@ -1,0 +1,288 @@
+---
+name: langfuse-judge-calibration
+description: Calibrate and validate LLM-as-a-Judge evaluators against dataset ground truth. Runs the judge prompt as a Langfuse dataset experiment, compares judge outputs with dataset item expected outputs, and reports simple accuracy or advanced confusion-matrix metrics. Use this guide whenever a user asks if their LLM judge is actually useful,
+aligned with human judgment, or safe to trust for monitoring decisions.
+---
+
+# Judge Calibration (LLM-as-a-Judge)
+
+## Goal
+
+Validate judge outputs against human labels using the smallest reliable workflow
+for the user's goal.
+
+Default to a **Langfuse dataset experiment** when the user has a Langfuse
+dataset or wants results in the Langfuse Experiments UI.
+
+Default to **simple calibration** unless the user asks for deeper metrics,
+split-based validation, thresholding, or production automation.
+
+## 1) Choose the calibration mode
+
+### Simple calibration
+
+Use this when the user wants a quick answer like "does this judge basically
+match human labels?" or explicitly asks for accuracy only.
+
+- No train/dev/test split is required.
+- Compute `exact_match` for each valid row.
+- Report valid sample size, invalid-label count, accuracy, and a short
+  recommendation.
+- Do not include Precision/Recall/F1, TPR/TNR, denominator notes, or top failure
+  direction unless the user asks for advanced metrics.
+
+### Advanced calibration
+
+Use this when the user asks for confusion matrix metrics, thresholds,
+production monitoring, high-stakes automation, or train/test-style validation.
+
+- If split labels exist, keep train/dev/test separate.
+- If no split exists, compute metrics on the provided rows and state that this is
+  not a held-out final quality claim.
+- Compute TP/FP/FN/TN and derived metrics.
+- Use `references/error-analysis.md` for qualitative diagnosis of disagreements.
+
+## 2) Primary workflow
+
+1. Confirm the dataset name, ground-truth label location in `expectedOutput`,
+   judge prompt name/version, judge model, and label vocabulary.
+2. Choose simple or advanced mode. If ambiguous, use simple mode.
+3. Run the judge prompt against each dataset item input as a Langfuse experiment.
+4. Compare the judge output to `item.expected_output` in evaluator functions.
+5. Return the matching report format from section 7.
+
+## 3) Langfuse experiment workflow
+
+Use the SDK experiment runner as the default implementation. A Langfuse-hosted
+dataset automatically creates a dataset run that can be inspected and compared
+in the Langfuse UI.
+
+Before implementing, you **must** retrieve the current experiment SDK
+documentation from the Langfuse docs — do not rely on memory, the SDK changes
+frequently. Fetch these pages (see SKILL.md section 2 for retrieval methods):
+
+- [Experiments via SDK](https://langfuse.com/docs/evaluation/experiments/experiments-via-sdk) — primary reference for `dataset.run_experiment`, task/evaluator signatures, and `Evaluation` return shape
+- [Datasets](https://langfuse.com/docs/evaluation/experiments/datasets) — dataset item structure (`input`, `expectedOutput`) and how to load a hosted dataset
+- [Experiments data model](https://langfuse.com/docs/evaluation/experiments/data-model) — how runs, items, and scores relate in the UI
+
+High-level shape of a simple-mode calibration experiment:
+
+```
+load dataset and judge prompt from Langfuse
+define POSITIVE / NEGATIVE label set
+
+task(item):
+    compile judge prompt with item.input
+    call judge model
+    return normalized label
+    # never read item.expected_output here — that would leak the answer
+
+item_evaluator(output, expected_output):
+    if either label is outside the allowed set:
+        return invalid (excluded from accuracy denominator)
+    return exact_match score (0 or 1)
+
+run_evaluator(item_results):
+    accuracy = matches / valid_rows
+    return aggregate score + invalid_label count
+
+dataset.run_experiment(task, [item_evaluator], [run_evaluator],
+                      metadata={calibration_mode, judge_prompt, labels})
+```
+
+For advanced calibration, the item evaluator emits one score per confusion-matrix
+cell (`judge-is-tp`, `judge-is-fp`, `judge-is-fn`, `judge-is-tn`), and the run
+evaluator aggregates them into Precision / Recall / F1 / TPR / TNR. See section
+6 for the metric definitions and zero-denominator guardrails.
+
+Rules:
+- Use a Langfuse-hosted dataset when the user wants a real Langfuse experiment.
+  Local SDK datasets create traces and scores, but not Langfuse dataset runs.
+- The dataset item `input` must contain everything needed to run the judge
+  prompt. The dataset item `expectedOutput` must contain the ground-truth label.
+- Never pass `expectedOutput` into the judge prompt or task. That would leak the
+  answer and invalidate calibration.
+- Return `Evaluation(...)` objects from item and run evaluators for stable SDK
+  formatting and score ingestion.
+- Store prompt name/version, judge model, label vocabulary, dataset version, and
+  calibration mode in run metadata.
+- Use a unique run name so the experiment appears as a separate dataset run.
+
+## 4) Label validation
+
+Never silently treat unknown labels as negative.
+
+- For binary judges, define the positive and negative labels before computing
+  confusion-matrix metrics.
+- Normalize only deterministic differences such as surrounding whitespace or
+  casing, and mention that normalization was applied.
+- Rows where `expected` or `actual` is outside the allowed label set are invalid.
+  Exclude them from metric denominators and report the invalid count.
+- For multi-class judges, use simple `exact_match` / accuracy unless the user
+  defines one positive class for binary metrics.
+
+Example binary labels:
+- Positive: `ESCALATE`
+- Negative: `RESOLVE`
+
+## 5) Simple metrics
+
+For each valid row:
+
+- `exact_match = 1 if actual == expected else 0`
+
+Aggregate:
+
+- `accuracy = sum(exact_match) / valid_rows`
+
+If `valid_rows == 0`, report that accuracy is undefined and ask for valid
+expected/actual labels.
+
+## 6) Advanced metrics
+
+### Dataset and split discipline
+
+Use split discipline only when the user asks for advanced validation or final
+quality claims.
+
+- **Train**: optional few-shot examples for the judge prompt
+- **Dev**: iterative prompt/model refinement
+- **Test**: single final calibration pass
+
+Do not tune on the same rows used to claim final quality. Use balanced classes
+in dev/test when possible so both error directions are measurable.
+
+### Per-row classification mapping
+
+For each row with `expected` and `actual` labels:
+
+- **TP**: expected = positive and actual = positive
+- **FP**: expected = negative and actual = positive
+- **FN**: expected = positive and actual = negative
+- **TN**: expected = negative and actual = negative
+
+Also compute:
+- `exact_match = 1 if actual == expected else 0`
+
+### Aggregate metrics
+
+From aggregate counts:
+- `accuracy = (TP + TN) / valid_rows`
+- `precision = TP / (TP + FP)`
+- `recall = TP / (TP + FN)`
+- `f1 = 2 * precision * recall / (precision + recall)`
+- `TPR = TP / (TP + FN)`
+- `TNR = TN / (TN + FP)`
+
+Guardrails:
+- if `TP + FP == 0`, precision is undefined (report null + note)
+- if `TP + FN == 0`, recall and TPR are undefined (report null + note)
+- if `TN + FP == 0`, TNR is undefined (report null + note)
+- if `precision + recall == 0`, set `f1 = 0`
+
+### Advanced quality gates
+
+Before trusting the judge on production traffic:
+
+1. **Split integrity**: no leakage from held-out rows into prompt examples.
+2. **Confusion matrix sanity**: `TP + FP + FN + TN == valid_rows`.
+3. **Metric recomputation check**: recompute aggregate stats from row-level
+   flags and compare.
+4. **TPR/TNR review**: inspect both directions for class-direction bias.
+5. **Threshold**: target `TPR > 0.90` and `TNR > 0.90` before high-stakes
+   automation.
+
+## 7) Report format
+
+### Simple report
+
+Return only:
+- dataset name and dataset run URL when available
+- valid rows / total rows
+- invalid-label count
+- accuracy
+- one-sentence recommendation
+
+### Advanced report
+
+Add:
+- confusion matrix: TP, FP, FN, TN
+- accuracy, precision, recall, F1, TPR, TNR
+- denominator notes for undefined metrics
+- top failure direction: false positives or false negatives
+- recommendation: ship, iterate, collect more labels, or do not automate
+
+## 8) Langfuse implementation notes
+
+Prefer SDK experiment evaluators for score creation. They attach item-level
+scores to the experiment traces and run-level scores to the dataset run.
+
+Use manual REST score creation only as a fallback when not using the SDK
+experiment runner, or for local smoke tests. See
+[Scores via SDK](https://langfuse.com/docs/evaluation/evaluation-methods/scores-via-sdk)
+and the [Scores API reference](https://langfuse.com/docs/api) (`POST /api/public/scores`)
+for the current payload shape. Do not use the current `langfuse-cli` score-create
+wrapper unless `--help` shows a usable `value` argument; `langfuse-cli@0.0.10`
+exposes `legacy-score-v1s create` but cannot pass the required score `value`.
+
+Score names to emit:
+
+Simple mode:
+- `judge-exact-match`
+- `judge-accuracy`
+
+Advanced mode:
+- `judge-exact-match`
+- `judge-is-tp`
+- `judge-is-fp`
+- `judge-is-fn`
+- `judge-is-tn`
+
+Recommended metadata:
+- `expected_label`, `actual_label`
+- calibration mode: `simple` or `advanced`
+- positive/negative labels when binary metrics are used
+- evaluator prompt name+version
+- dataset/split version when used
+- run identifier
+
+## 9) Classification logic (pseudo-code)
+
+The per-row classification each evaluator must perform:
+
+```
+normalize(label) = strip whitespace, uppercase
+ALLOWED = {POSITIVE, NEGATIVE}
+
+classify(expected, actual):
+    expected, actual = normalize(expected), normalize(actual)
+
+    if expected ∉ ALLOWED or actual ∉ ALLOWED:
+        mark row invalid → exclude from denominators
+
+    exact_match = (expected == actual)
+    is_tp = (expected == POSITIVE and actual == POSITIVE)
+    is_fp = (expected == NEGATIVE and actual == POSITIVE)
+    is_fn = (expected == POSITIVE and actual == NEGATIVE)
+    is_tn = (expected == NEGATIVE and actual == NEGATIVE)
+```
+
+## 10) Common failure modes
+
+- label vocabulary not constrained (judge outputs free text instead of strict
+  labels)
+- positive/negative label inversion between annotators and evaluator code
+- leaking `expectedOutput` into the judge task instead of only the evaluator
+- using local SDK data when the user expects a Langfuse dataset run in the UI
+- reporting only accuracy when classes are imbalanced and error direction matters
+- calculating F1 without explicit zero-denominator handling
+- using advanced validation claims without a held-out split
+
+## 11) What to do after calibration
+
+- If simple accuracy is enough: report it and stop.
+- If metrics are weak and advanced validation is needed: iterate prompt and
+  few-shots on dev data only.
+- If metrics pass: freeze the baseline and monitor drift over time.
+- For qualitative diagnosis of disagreements, switch to
+  `references/error-analysis.md`.

--- a/skills/langfuse/references/operator-setup.md
+++ b/skills/langfuse/references/operator-setup.md
@@ -1,0 +1,77 @@
+# Langfuse Operator Setup
+
+## API Keys
+
+In Langfuse, open **Project Settings → API Keys** and create a key pair for the
+project HybridClaw should observe:
+
+- public key, `pk-lf-...` (used as the Basic auth username)
+- secret key, `sk-lf-...` (used as the Basic auth password)
+
+Langfuse keys are project-scoped. The same key reads observability data and
+writes scores, comments, datasets, and prompt versions; there is no separate
+read-only tier, so treat the key as write-capable and rely on the skill's
+amber/grant gating for changes.
+
+## Store the Credential and Host
+
+The Langfuse public API uses HTTP Basic auth. Base64-encode `public:secret`
+locally and store only the encoded value, plus your deployment base URL:
+
+```text
+/secret set LANGFUSE_BASIC_AUTH "<base64-of-public-key:secret-key>"
+/env set LANGFUSE_HOST https://cloud.langfuse.com
+```
+
+Local-terminal alternative:
+
+```bash
+hybridclaw secret set LANGFUSE_BASIC_AUTH "<base64-of-public-key:secret-key>"
+hybridclaw env set LANGFUSE_HOST https://cloud.langfuse.com
+```
+
+To produce the encoded value locally:
+
+```bash
+printf '%s' 'pk-lf-xxxx:sk-lf-xxxx' | base64
+```
+
+The helper emits `Authorization: Basic <secret:LANGFUSE_BASIC_AUTH>` and a
+`<env:LANGFUSE_HOST>` base URL, so HybridClaw injects both server-side. Do not
+paste the keys into chat, logs, helper arguments, eval fixtures, or
+documentation examples.
+
+## Host Selection
+
+| Deployment        | `LANGFUSE_HOST`                  |
+| ----------------- | -------------------------------- |
+| Langfuse Cloud EU | `https://cloud.langfuse.com`     |
+| Langfuse Cloud US | `https://us.cloud.langfuse.com`  |
+| Langfuse Cloud JP | `https://jp.cloud.langfuse.com`  |
+| Self-hosted       | your origin, e.g. `https://langfuse.internal.example.com` |
+
+`LANGFUSE_HOST` is a plaintext config variable. A request can also override it
+for a single call with `--host https://...` (https only).
+
+## Network Policy
+
+The gateway HTTP proxy blocks private and loopback hosts. For self-hosted
+Langfuse on a private network, allow the host in workspace network policy with
+`/policy` (or `hybridclaw policy ...`) before live calls succeed. Langfuse Cloud
+hosts are public and need no extra allowlisting beyond the default policy.
+
+## Recommended Autonomy
+
+- Trace, observation, session, score, prompt, dataset, model, comment, and
+  metric reads: allow read-only autonomy for trusted operators.
+- Score, comment, dataset, dataset-item, and prompt-version creation:
+  `confirm-each`.
+- Deletions and project / API-key / organization administration: out of scope —
+  not exposed by this skill.
+
+## Cost Reporting
+
+Cost per assistant run is recorded by HybridClaw `UsageTotals`; helper output
+includes `costMeasurement.system = "UsageTotals"`. Langfuse's own usage and cost
+figures come from `metrics` and the trace/observation reads — the helper makes no
+hidden billing calls.

--- a/skills/langfuse/references/prompt-migration.md
+++ b/skills/langfuse/references/prompt-migration.md
@@ -1,0 +1,234 @@
+---
+name: langfuse-prompt-migration
+description: Migrate hardcoded prompts to Langfuse for version control and deployment-free iteration. Use when user wants to externalize prompts, move prompts to Langfuse, or set up prompt management.
+---
+
+# Langfuse Prompt Migration
+
+Migrate hardcoded prompts to Langfuse for version control, A/B testing, and deployment-free iteration.
+
+## Prerequisites
+
+Verify credentials are set before starting. Check existence only — never print the secret key, since the value would land in the agent's context and transcripts:
+
+```bash
+[ -n "$LANGFUSE_PUBLIC_KEY" ] && echo "LANGFUSE_PUBLIC_KEY: set" || echo "LANGFUSE_PUBLIC_KEY: missing"
+[ -n "$LANGFUSE_SECRET_KEY" ] && echo "LANGFUSE_SECRET_KEY: set" || echo "LANGFUSE_SECRET_KEY: missing"
+[ -n "$LANGFUSE_BASE_URL" ]   && echo "LANGFUSE_BASE_URL: $LANGFUSE_BASE_URL" || echo "LANGFUSE_BASE_URL: missing"
+```
+
+If not set, ask the user to configure them in their shell or a `.env` file. Do not ask them to paste keys into chat.
+
+## Migration Flow
+
+```
+1. Scan codebase for prompts
+2. Analyze templating compatibility
+3. Propose structure (names, subprompts, variables)
+4. User approves
+5. Create prompts in Langfuse
+6. Refactor code to use get_prompt()
+7. Link prompts to traces (if tracing enabled)
+8. Verify application works
+```
+
+## Step 1: Find Prompts and Build an Inventory
+
+Before writing ANY code, make a complete list of every prompt you found. For each one, note:
+
+- Name: descriptive, lowercase, hyphenated (e.g. chat-assistant, email-classifier)
+- Source file: where the prompt text lives
+- Code file to refactor: the Python/JS file that USES the prompt (for asset files like .txt/.yaml/.md, this is the file that reads/loads the asset — NOT the asset file itself)
+- Type: chat (used as a message in a chat API) or text (used as a plain string)
+- Variables: values interpolated into the prompt, converted to {{var}} syntax:
+f-string {var} → {{var}}
+.format(var=...) → {{var}}
+${var} → {{var}}
+String concatenation + var + → {{var}}
+YAML {var} → {{var}}
+- Prompt content: the actual text to upload, with variables converted to {{var}} syntax
+
+Search for these patterns:
+
+| Framework | Look for |
+|-----------|----------|
+| OpenAI | `messages=[{"role": "system", "content": "..."}]` |
+| Anthropic | `system="..."` |
+| LangChain | `ChatPromptTemplate`, `SystemMessage` |
+| Vercel AI | `system: "..."`, `prompt: "..."` |
+| Raw | Multi-line strings near LLM calls |
+
+## Step 2: Check Templating Compatibility
+
+**CRITICAL:** Langfuse only supports simple `{{variable}}` substitution. No conditionals, loops, or filters.
+
+| Template Feature | Langfuse Native | Action |
+|------------------|-----------------|--------|
+| `{{variable}}` | ✅ | Direct migration |
+| `{var}` / `${var}` | ⚠️ | Convert to `{{var}}` |
+| `{% if %}` / `{% for %}` | ❌ | Move logic to code |
+| `{{ var \| filter }}` | ❌ | Apply filter in code |
+
+**CRITICAL — Variable syntax:** Langfuse uses DOUBLE curly braces for variables: `{{var}}`. When uploading prompt content, you MUST convert every single-brace `{var}` from the original code to double-brace `{{var}}`. Never upload `{var}` — it must be `{{var}}`.
+
+### Decision Tree
+
+```
+Contains {% if %}, {% for %}, or filters?
+├─ No → Direct migration
+└─ Yes → Choose:
+    ├─ Option A (RECOMMENDED): Move logic to code, pass pre-computed values
+    └─ Option B: Store raw template, compile client-side with Jinja2
+        └─ ⚠️ Loses: Playground preview, UI experiments
+```
+
+### Simplifying Complex Templates
+
+**Conditionals** → Pre-compute in code:
+```python
+# Instead of {% if user.is_premium %}...{% endif %} in prompt
+# Use {{tier_message}} and compute value in code before compile()
+```
+
+**Loops** → Pre-format in code:
+```python
+# Instead of {% for tool in tools %}...{% endfor %} in prompt
+# Use {{tools_list}} and format the list in code before compile()
+```
+
+For external templating details, fetch: https://langfuse.com/faq/all/using-external-templating-libraries
+
+## Step 3: Propose Structure
+
+### Naming Conventions
+
+| Rule | Example | Bad |
+|------|---------|-----|
+| Lowercase, hyphenated | `chat-assistant` | `ChatAssistant_v2` |
+| Feature-based | `document-summarizer` | `prompt1` |
+| Hierarchical for related | `support/triage` | `supportTriage` |
+| Prefix subprompts with `_` | `_base-personality` | `shared-personality` |
+
+### Identify Subprompts
+
+Extract when:
+- Same text in 2+ prompts
+- Represents distinct component (personality, safety rules, format)
+- Would need to change together
+
+### Variable Extraction
+
+| Make Variable | Keep Hardcoded |
+|---------------|----------------|
+| User-specific (`{{user_name}}`) | Output format instructions |
+| Dynamic content (`{{context}}`) | Safety guardrails |
+| Per-request (`{{query}}`) | Persona/personality |
+| Environment-specific (`{{company_name}}`) | Static examples |
+
+## Step 4: Present Plan to User
+
+Format:
+```
+Found N prompts across M files:
+
+src/chat.py:
+  - System prompt (47 lines) → 'chat-assistant'
+
+src/support/triage.py:
+  - Triage prompt (34 lines) → 'support/triage'
+    ⚠️ Contains {% if %} - will simplify
+
+Subprompts to extract:
+  - '_base-personality' - used by: chat-assistant, support/triage
+
+Variables to add:
+  - {{user_name}} - hardcoded in 2 prompts
+
+Proceed?
+```
+
+## Step 5: Create Prompts in Langfuse
+
+Use `langfuse.create_prompt()` with:
+- `name`: Your chosen name
+- `prompt`: Template text (or message array for chat type)
+- `type`: `"text"` or `"chat"`
+- `labels`: `["production"]` (they're already live)
+- `config`: Optional model settings
+
+**Labeling strategy:**
+- `production` → All migrated prompts
+- `staging` → Add later for testing
+- `latest` → Auto-applied by Langfuse
+
+For full API: fetch https://langfuse.com/docs/prompts/get-started
+
+## Step 6: Refactor Code
+
+Replace hardcoded prompts with:
+
+```python
+prompt = langfuse.get_prompt("name", label="production")
+messages = prompt.compile(var1=value1, var2=value2)
+```
+
+**Key points:**
+- Always use `label="production"` (not `latest`) for stability
+- Call `.compile()` to substitute variables
+- For chat prompts, result is message array ready for API
+
+For SDK examples (Python/JS/TS): fetch https://langfuse.com/docs/prompts/get-started
+
+## Step 7: Link Prompts to Traces
+
+If codebase uses Langfuse tracing, link prompts so you can see which version produced each response.
+
+### Detect Existing Tracing
+
+Look for:
+- `@observe()` decorators
+- `langfuse.trace()` calls
+- `from langfuse.openai import openai` (instrumented client)
+
+### Link Methods
+
+| Setup | How to Link |
+|-------|-------------|
+| `@observe()` decorator | `langfuse_context.update_current_observation(prompt=prompt)` |
+| Manual tracing | `trace.generation(prompt=prompt, ...)` |
+| OpenAI integration | `openai.chat.completions.create(..., langfuse_prompt=prompt)` |
+
+### Verify in UI
+
+1. Go to **Traces** → select a trace
+2. Click on **Generation**
+3. Check **Prompt** field shows name and version
+
+For tracing details: fetch https://langfuse.com/docs/prompts/get-started#link-with-langfuse-tracing
+
+## Step 8: Verify Migration
+
+### Checklist
+
+- [ ] All prompts created with `production` label
+- [ ] Code fetches with `label="production"`
+- [ ] Variables compile without errors
+- [ ] Subprompts resolve correctly
+- [ ] Application behavior unchanged
+- [ ] Generations show linked prompt in UI (if tracing)
+
+### Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| `PromptNotFoundError` | Check name spelling |
+| Variables not replaced | Use `{{var}}` not `{var}`, call `.compile()` |
+| Subprompt not resolved | Must exist with same label |
+| Old prompt cached | Restart app |
+
+## Out of Scope
+
+- Prompt engineering (writing better prompts)
+- Evaluation setup
+- A/B testing workflow
+- Non-LLM string templates

--- a/skills/langfuse/references/sdk-upgrade.md
+++ b/skills/langfuse/references/sdk-upgrade.md
@@ -1,0 +1,175 @@
+---
+name: langfuse-sdk-upgrade
+description: Upgrade Langfuse SDKs from older versions to the latest. Use when migrating Python SDK v2/v3 to v4, or JS/TS SDK v3/v4 to v5.
+---
+
+# Langfuse SDK Upgrade Guide
+
+Assist users in upgrading their Langfuse SDK to the latest version. The Python and JS/TS SDKs share the same architectural changes but differ in syntax.
+
+## Migration Docs
+
+Always fetch the latest migration guide before starting — these pages are the source of truth:
+
+- **Python (v3 → v4):** https://langfuse.com/docs/observability/sdk/upgrade-path/python-v3-to-v4
+- **JS/TS (v4 → v5):** https://langfuse.com/docs/observability/sdk/upgrade-path/js-v4-to-v5
+
+Fetch the relevant page as markdown before implementing any changes:
+
+```bash
+curl -s "https://langfuse.com/docs/observability/sdk/upgrade-path/python-v3-to-v4.md"
+curl -s "https://langfuse.com/docs/observability/sdk/upgrade-path/js-v4-to-v5.md"
+```
+
+## Upgrade Checklist
+
+Work through each item in order. Skip items that don't apply to the user's codebase.
+
+### Both SDKs
+
+- [ ] **Update the SDK package** to the latest version
+- [ ] **Audit span filtering**: Non-LLM spans (HTTP, DB, queues) no longer export by default. If the user relied on these, configure a custom `should_export_span` / `shouldExportSpan` filter
+- [ ] **Replace `update_current_trace()` / `updateActiveTrace()`**: Split into three calls:
+  - `propagate_attributes()` / `propagateAttributes()` for correlating attributes (`user_id`, `session_id`, `tags`, `metadata`, `trace_name`)
+  - `set_current_trace_io()` / `setActiveTraceIO()` for input/output (deprecated — prefer setting I/O on root observation directly)
+  - `set_current_trace_as_public()` / `setActiveTraceAsPublic()` for public flag
+- [ ] **Replace `.update_trace()` / `.updateTrace()`** on observation objects (same decomposition as above)
+- [ ] **Update API namespace references**: `observations_v_2` / `observationsV2` → `observations`, `score_v_2` / `scoreV2` → `scores`, `metrics_v_2` / `metricsV2` → `metrics`. Legacy v1 APIs moved to `api.legacy.*`
+- [ ] **Validate metadata format**: Must be `dict[str, str]` / `Record<string, string>` with values ≤200 characters
+- [ ] **Move `release` and `environment`** from code parameters to environment variables (`LANGFUSE_RELEASE`, `LANGFUSE_TRACING_ENVIRONMENT`)
+- [ ] **Enable debug logging** during migration to catch issues (`debug=True` in Python, `LANGFUSE_DEBUG="true"` in JS/TS)
+- [ ] **Test trace hierarchies** to verify no spans are unexpectedly dropped
+
+### Python-specific
+
+- [ ] **Replace `start_span()` / `start_generation()`** with `start_observation()` (use `as_type="generation"` for generations)
+- [ ] **Replace `start_as_current_span()` / `start_as_current_generation()`** with `start_as_current_observation()`
+- [ ] **Replace dataset `item.run()`** with `dataset.run_experiment(name=..., task=...)`
+- [ ] **Remove `CallbackHandler(update_trace=...)`** parameter — use `propagate_attributes()` wrapper instead
+- [ ] **Upgrade to Pydantic v2** — the SDK now requires it. Use `pydantic.v1` compatibility shim if migrating gradually
+- [ ] **Update removed types**: `TraceMetadata`, `ObservationParams` removed from `langfuse.types`. Import `MapValue`, `ModelUsage`, `PromptClient` from `langfuse.model`
+
+### JS/TS-specific
+
+- [ ] **Update LangChain `CallbackHandler`** — `traceMetadata` now requires string values; internal behavior uses `propagateAttributes()` instead of direct trace updates
+- [ ] **Update OpenAI integration** — `traceMethod` wrapper now uses `propagateAttributes()` internally; wrap entire execution in `propagateAttributes()` if relying on parent attribute inheritance
+
+## Key API Changes Reference
+
+### Correlating attributes (both SDKs)
+
+**Before:**
+```python
+# Python
+langfuse.update_current_trace(name="trace-name", user_id="user-123", session_id="session-abc", tags=["tag1"])
+```
+```typescript
+// JS/TS
+updateActiveTrace({ name: "trace-name", userId: "user-123", sessionId: "session-456", tags: ["prod"] });
+```
+
+**After:**
+```python
+# Python
+from langfuse import propagate_attributes
+
+with propagate_attributes(trace_name="trace-name", user_id="user-123", session_id="session-abc", tags=["tag1"]):
+    result = call_llm("hello")
+```
+```typescript
+// JS/TS
+import { propagateAttributes } from "langfuse";
+
+await propagateAttributes(
+  { traceName: "trace-name", userId: "user-123", sessionId: "session-456", tags: ["prod"] },
+  async () => { /* traced code */ }
+);
+```
+
+### Span/Generation creation (Python)
+
+**Before:**
+```python
+langfuse.start_span(name="x")
+langfuse.start_generation(name="x", model="gpt-4")
+```
+
+**After:**
+```python
+langfuse.start_observation(name="x")
+langfuse.start_observation(name="x", as_type="generation", model="gpt-4")
+```
+
+### Dataset experiments (Python)
+
+**Before:**
+```python
+for item in dataset.items:
+    with item.run(run_name="my-run") as span:
+        result = my_llm(item.input)
+        span.update(output=result)
+```
+
+**After:**
+```python
+def my_task(*, item, **kwargs):
+    return my_llm(item.input)
+
+dataset.run_experiment(name="my-run", task=my_task)
+```
+
+### Span filtering (both SDKs)
+
+To restore pre-upgrade "export all" behavior:
+
+```python
+# Python
+langfuse = Langfuse(should_export_span=lambda span: True)
+```
+```typescript
+// JS/TS
+const spanProcessor = new LangfuseSpanProcessor({ shouldExportSpan: () => true });
+```
+
+To extend defaults with custom scopes:
+
+```python
+# Python
+from langfuse.span_filter import is_default_export_span
+
+langfuse = Langfuse(
+    should_export_span=lambda span: (
+        is_default_export_span(span)
+        or span.instrumentation_scope.name.startswith("my_framework")
+    )
+)
+```
+```typescript
+// JS/TS
+import { isDefaultExportSpan } from "@langfuse/otel";
+
+shouldExportSpan: ({ otelSpan }) =>
+  isDefaultExportSpan(otelSpan) || otelSpan.instrumentationScope.name.startsWith("my_framework")
+```
+
+## Common Pitfalls
+
+| Pitfall | Impact | Fix |
+| --- | --- | --- |
+| Dropping intermediate spans via filtering | Breaks trace trees — child spans become orphaned | Use `is_default_export_span` as base and only add/remove specific scopes |
+| Metadata with non-string values | Values silently coerced or dropped | Ensure all metadata values are strings ≤200 characters |
+| Setting attributes outside `propagate_attributes()` callback | Attributes don't attach to observations | Wrap all traced code inside the callback |
+| Using deprecated `set_current_trace_io()` for new code | Will be removed in future versions | Set input/output directly on the root observation |
+| Forgetting Pydantic v2 upgrade (Python) | Import errors or runtime failures | Upgrade Pydantic or use `pydantic.v1` shim |
+| `release`/`environment` still passed as parameters | Silently ignored | Use `LANGFUSE_RELEASE` and `LANGFUSE_TRACING_ENVIRONMENT` env vars |
+| LangChain/OpenAI attribute propagation direction changed | Attributes propagate downward only, not upward to parent traces | Wrap outer call in `propagate_attributes()` |
+
+## Best Practices
+
+1. **Always fetch the migration docs first** — they are the canonical source and may have been updated since this guide was written
+2. **Enable debug logging during migration** to surface dropped spans and trace hierarchy issues
+3. **Use `propagate_attributes()` as the primary mechanism** for setting trace-level correlating attributes
+4. **Set input/output on root observations directly** rather than using deprecated trace-level setters
+5. **Compose custom span filters** with `is_default_export_span` / `isDefaultExportSpan` to extend defaults rather than replacing them entirely
+6. **Test thoroughly** — run the application with debug logging, check the Langfuse UI for missing or orphaned spans, verify metadata appears correctly
+7. **Migrate incrementally** — upgrade the SDK first, fix breaking changes, then adopt new patterns

--- a/skills/langfuse/references/skill-feedback.md
+++ b/skills/langfuse/references/skill-feedback.md
@@ -1,0 +1,52 @@
+---
+name: langfuse-skill-feedback
+description: Submit feedback about the Langfuse skill to its maintainers via GitHub Discussions. Use when the user indicates the skill gave incorrect guidance, is missing information, or could be improved.
+---
+
+# Skill Feedback
+
+Follow these steps exactly:
+
+1. **Ask permission**: Ask the user if they'd like you to submit feedback to the skill maintainers. Make it clear this is about the skill (the agent instructions), not about Langfuse the product. If they decline, move on.
+2. **Draft feedback**: Write the feedback using the form structure below. Present the draft to the user and ask if they'd like to change anything before submitting.
+3. **Submit**: Once approved, submit via `gh` CLI as described below. Share the resulting discussion URL with the user.
+
+## Feedback Form Structure
+
+Draft the feedback using these two fields:
+
+**Describe your idea or feedback** (required)
+A clear description of what went wrong or what could be improved. Include:
+- What the user was trying to do
+- What the skill did vs what was expected
+- Any specific instructions that were incorrect or missing
+
+**What would the ideal outcome look like?** (optional)
+What the correct behavior or guidance should be.
+
+Format the body as markdown with the two field labels as headings.
+
+## Submitting
+
+Create a GitHub Discussion on the `langfuse/skills` repository using the GraphQL API:
+
+```bash
+gh api graphql -f query='
+mutation($repoId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
+  createDiscussion(input: {repositoryId: $repoId, categoryId: $categoryId, title: $title, body: $body}) {
+    discussion { url }
+  }
+}' \
+  -f repoId="$(gh api graphql -f query='{ repository(owner: "langfuse", name: "skills") { id } }' --jq '.data.repository.id')" \
+  -f categoryId="$(gh api graphql -f query='{ repository(owner: "langfuse", name: "skills") { discussionCategories(first: 10) { nodes { id name } } } }' --jq '.data.repository.discussionCategories.nodes[] | select(.name == "Ideas & Improvements") | .id')" \
+  -f title="<concise title>" \
+  -f body="<formatted feedback>"
+```
+
+If the `gh` CLI is not authenticated or the request fails, give the user this link to create the discussion manually:
+
+```
+https://github.com/langfuse/skills/discussions/new?category=ideas-improvements
+```
+
+After submission, share the discussion URL with the user.

--- a/skills/langfuse/references/user-feedback.md
+++ b/skills/langfuse/references/user-feedback.md
@@ -1,0 +1,88 @@
+---
+name: langfuse-user-feedback
+description: Wires up user feedback (thumbs up/down, ratings, comments) from an application's frontend to Langfuse scores. Use when user wants to capture end-user feedback, add ratings to traces, or connect user complaints to Langfuse.
+---
+
+# User Feedback
+
+Tracing must already be set up — feedback is stored as scores on traces.
+
+Docs: https://langfuse.com/docs/observability/features/user-feedback
+
+## Workflow
+
+### 1. Determine What Feedback to Capture
+
+If the user has asked for something specific, go with that. Otherwise, look at the application and **present a few UX options** for how feedback could work, then ask the user which they prefer before implementing.
+
+Common UX patterns to suggest:
+
+| UX Pattern | Best for | How it works |
+|------------|----------|--------------|
+| Thumbs up/down | Chat apps, Q&A | Simple binary buttons next to each response |
+| Star rating (1–5) | Content generation, summaries | Star row or dropdown after each output |
+| "Was this helpful?" banner | Search, documentation assistants | Single yes/no prompt at the bottom of a response |
+| Regenerate / copy tracking | Any app with these actions | Implicit — log when users retry (negative signal) or copy output (positive signal) |
+| Free-text comment | Complex outputs, internal tools | Optional text field alongside a rating |
+| Report button | Any user-facing app | Flag icon to report bad/harmful responses |
+
+This table is not exhaustive — if the application suggests a different feedback pattern that fits better, propose that instead. Present 2–3 options that match the application's use case and ask the user which approach they'd like. This decision shapes everything downstream (score names, data types, frontend components), so it's important to align early.
+
+Feedback can be **explicit** (user rates via thumbs, stars, etc.) or **implicit** (derived from behavior like copying output, retrying, or escalating to support). Both are stored as scores. Explicit feedback requires the trace ID to reach the frontend; implicit feedback is logged server-side where the event already happens.
+
+### 2. Choose Score Names
+
+Name reflects the signal source, not what you hope it measures (e.g., `user-thumbs` not `response-quality` — a thumbs down doesn't tell you *what* was wrong). Avoid generic names like `feedback` or `score`.
+
+Rules:
+- Lowercase with hyphens
+- One consistent name per feedback type across the entire app
+- If capturing multiple signals, each gets its own distinct name
+
+### 3. Implement Score Creation
+
+**For implicit feedback (server-side):** Use `langfuse.create_score()` / `langfuse.score.create()` wherever the event is already handled in application code. Fetch SDK docs for current API: https://langfuse.com/docs/evaluation/evaluation-methods/scores-via-sdk
+
+**For explicit feedback (frontend):** Use `LangfuseWeb` in the browser. It uses the public key only — no secret key exposed.
+
+```typescript
+import { LangfuseWeb } from "langfuse";
+
+const langfuse = new LangfuseWeb({
+  publicKey: process.env.NEXT_PUBLIC_LANGFUSE_PUBLIC_KEY!,
+  baseUrl: process.env.NEXT_PUBLIC_LANGFUSE_HOST,
+});
+
+langfuse.score({
+  traceId,
+  name: "user-thumbs",
+  value: 1, // 1 = positive, 0 = negative
+  dataType: "BOOLEAN",
+  comment: optionalUserComment,
+});
+```
+
+The trace ID must be available in the frontend for this to work. For Vercel AI SDK, the non-obvious pattern is using `generateMessageId`:
+
+```typescript
+import { getActiveTraceId } from "@langfuse/tracing";
+
+// Inside route handler wrapped with observe()
+return result.toUIMessageStreamResponse({
+  generateMessageId: () => getActiveTraceId() || crypto.randomUUID(),
+});
+```
+
+### 4. Verify
+
+Trigger a feedback action and check the trace's Scores tab in Langfuse. Confirm the score name, value, and data type are correct.
+
+Point users to what they can do with feedback data: filter traces by low scores, use score analytics for trends, build annotation queues for team review.
+
+## Common Mistakes
+
+| Mistake | Problem | Fix |
+|---------|---------|-----|
+| Secret key in frontend code | Security risk | Use `LangfuseWeb` with public key only |
+| Missing `dataType` on boolean scores | Value `1` inferred as `NUMERIC` | Always pass `dataType: "BOOLEAN"` explicitly |
+| Inconsistent score names across the app | Can't aggregate or filter reliably | Pick one name per feedback type, use it everywhere |

--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -29,6 +29,7 @@ ALLOWED_FRONTMATTER_KEYS = {
     "always",
     "requires",
     "credentials",
+    "config_variables",
     "metadata",
     "license",
     "allowed-tools",

--- a/tests/langfuse-skill.test.ts
+++ b/tests/langfuse-skill.test.ts
@@ -1,0 +1,392 @@
+import { spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import { parseSkillManifestFromMarkdown } from '../src/skills/skill-manifest.js';
+
+const skillDir = path.join(process.cwd(), 'skills', 'langfuse');
+const helperPath = path.join(skillDir, 'langfuse.cjs');
+const skillPath = path.join(skillDir, 'SKILL.md');
+
+function runHelper(args: string[]) {
+  return spawnSync('node', [helperPath, ...args], { encoding: 'utf-8' });
+}
+
+function build(args: string[]) {
+  const result = runHelper(['--format', 'json', 'http-request', ...args]);
+  return result;
+}
+
+function runHelperAsync(
+  args: string[],
+): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn('node', [helperPath, ...args], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf-8');
+    child.stderr.setEncoding('utf-8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('close', (status) => {
+      resolve({ status, stdout, stderr });
+    });
+  });
+}
+
+test('langfuse manifest declares Basic auth credential, host config, and tiers', () => {
+  const raw = fs.readFileSync(skillPath, 'utf-8');
+  const manifest = parseSkillManifestFromMarkdown(raw, { name: 'langfuse' });
+
+  expect(manifest.credentials).toEqual([
+    expect.objectContaining({
+      id: 'langfuse-basic-auth',
+      kind: 'header',
+      required: true,
+      secretRef: { source: 'store', id: 'LANGFUSE_BASIC_AUTH' },
+    }),
+  ]);
+  expect(manifest.configVariables).toEqual([
+    expect.objectContaining({
+      id: 'langfuse-host',
+      env: 'LANGFUSE_HOST',
+      required: true,
+    }),
+  ]);
+
+  expect(raw).toContain('name: langfuse');
+  expect(raw).toContain('category: observability');
+  expect(raw).toContain('stakes_tiers:');
+  expect(raw).toContain('confirm-each');
+  expect(raw).toContain('UsageTotals');
+  expect(raw).toContain('references/operator-setup.md');
+  expect(raw).toContain('Authorization: Basic');
+  expect(raw).toContain('/secret set LANGFUSE_BASIC_AUTH');
+  expect(raw).toContain('/env set LANGFUSE_HOST');
+  // Adapted from the official Langfuse skill (attribution) + docs lookup retained.
+  expect(raw).toContain('github.com/langfuse/skills');
+  expect(raw).toContain('llms.txt');
+
+  const operatorSetup = fs.readFileSync(
+    path.join(skillDir, 'references', 'operator-setup.md'),
+    'utf-8',
+  );
+  expect(operatorSetup).toContain('Recommended Autonomy');
+  expect(operatorSetup).toContain('confirm-each');
+  expect(operatorSetup).toContain('https://us.cloud.langfuse.com');
+});
+
+test('langfuse vendors official references with MIT attribution', () => {
+  for (const ref of [
+    'instrumentation.md',
+    'prompt-migration.md',
+    'user-feedback.md',
+    'error-analysis.md',
+    'judge-calibration.md',
+    'sdk-upgrade.md',
+    'ci-cd.md',
+    'cli.md',
+    'skill-feedback.md',
+    'operator-setup.md',
+  ]) {
+    expect(fs.existsSync(path.join(skillDir, 'references', ref))).toBe(true);
+  }
+  const notice = fs.readFileSync(path.join(skillDir, 'NOTICE.md'), 'utf-8');
+  expect(notice).toContain('github.com/langfuse/skills');
+  expect(notice).toContain('MIT License');
+  // HybridClaw banner redirects the CLI/credential path to the gateway helper.
+  const cli = fs.readFileSync(path.join(skillDir, 'references', 'cli.md'), 'utf-8');
+  expect(cli).toContain('HybridClaw note');
+  expect(cli).toContain('langfuse.cjs');
+});
+
+test('langfuse helper enforces the 100 page-size cap and forwards cursor', () => {
+  const overLimit = build(['list-traces', '--limit', '250']);
+  expect(overLimit.status).not.toBe(0);
+  expect(overLimit.stderr).toContain('cannot exceed 100');
+
+  const cursored = build(['list-observations', '--limit', '100', '--cursor', 'abc']);
+  expect(cursored.status).toBe(0);
+  expect(JSON.parse(cursored.stdout).httpRequest.url).toBe(
+    '<env:LANGFUSE_HOST>/api/public/observations?limit=100&cursor=abc',
+  );
+});
+
+test('langfuse helper --help lists read and write surfaces', () => {
+  const result = runHelper(['--help']);
+
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain('Langfuse skill helper');
+  for (const expected of [
+    'list-traces',
+    'get-prompt',
+    'metrics',
+    'create-score',
+    'create-prompt',
+    '--operator-grant',
+  ]) {
+    expect(result.stdout).toContain(expected);
+  }
+});
+
+test('langfuse helper runs when copied as a standalone skill package', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'langfuse-skill-'));
+  try {
+    const packaged = path.join(tempRoot, 'langfuse');
+    fs.cpSync(skillDir, packaged, { recursive: true });
+    const result = spawnSync(
+      'node',
+      [path.join(packaged, 'langfuse.cjs'), '--format', 'json', 'plan', 'show recent traces'],
+      { encoding: 'utf-8' },
+    );
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      command: 'plan',
+      operation: 'list-traces',
+      stakesTier: 'green',
+      costMeasurement: { system: 'UsageTotals' },
+    });
+  } finally {
+    fs.rmSync(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test('langfuse helper builds gateway-backed reads with placeholder auth and host', () => {
+  const traces = build(['list-traces', '--user-id', 'alice', '--limit', '50']);
+  const prompt = build([
+    'get-prompt',
+    '--host',
+    'https://us.cloud.langfuse.com',
+    '--prompt-name',
+    'team/support reply',
+    '--label',
+    'production',
+  ]);
+
+  expect(traces.status).toBe(0);
+  const tracesPayload = JSON.parse(traces.stdout);
+  expect(tracesPayload).toMatchObject({
+    operation: 'list-traces',
+    stakesTier: 'green',
+    httpRequest: {
+      url: '<env:LANGFUSE_HOST>/api/public/traces?limit=50&userId=alice',
+      method: 'GET',
+      headers: { Authorization: 'Basic <secret:LANGFUSE_BASIC_AUTH>' },
+      skillName: 'langfuse',
+      stakesTier: 'green',
+    },
+    liveExecution: {
+      requiresConfiguredSecrets: ['LANGFUSE_BASIC_AUTH'],
+      callPolicy: expect.stringContaining('CJS helper as the API wrapper'),
+      requestShape: expect.stringContaining('Do not handcraft'),
+      unauthorizedPolicy: expect.stringContaining('stop after the first failure'),
+    },
+  });
+  expect(tracesPayload.httpRequest).not.toHaveProperty('bearerSecretName');
+  expect(tracesPayload.httpRequest).not.toHaveProperty('secretHeaders');
+  expect(traces.stdout).not.toContain('Bearer');
+
+  expect(prompt.status).toBe(0);
+  expect(JSON.parse(prompt.stdout).httpRequest.url).toBe(
+    'https://us.cloud.langfuse.com/api/public/v2/prompts/team%2Fsupport%20reply?label=production',
+  );
+});
+
+test('langfuse helper forwards metrics query and rejects invalid JSON', () => {
+  const ok = build(['metrics', '--query', '{"view":"traces","metrics":[{"measure":"count","aggregation":"count"}]}']);
+  expect(ok.status).toBe(0);
+  expect(JSON.parse(ok.stdout).httpRequest.url).toBe(
+    '<env:LANGFUSE_HOST>/api/public/metrics?query=%7B%22view%22%3A%22traces%22%2C%22metrics%22%3A%5B%7B%22measure%22%3A%22count%22%2C%22aggregation%22%3A%22count%22%7D%5D%7D',
+  );
+
+  const bad = build(['metrics', '--query', 'not-json']);
+  expect(bad.status).not.toBe(0);
+  expect(bad.stderr).toContain('--query must be valid JSON');
+});
+
+test('langfuse helper guards writes behind an operator grant', () => {
+  const denied = build(['create-score', '--trace-id', 't1', '--name', 'quality', '--value', '0.8']);
+  expect(denied.status).not.toBe(0);
+  expect(denied.stderr).toContain('--operator-grant');
+
+  const granted = build([
+    'create-score',
+    '--trace-id',
+    't1',
+    '--name',
+    'quality',
+    '--value',
+    '0.8',
+    '--data-type',
+    'NUMERIC',
+    '--comment',
+    'reviewed',
+    '--operator-grant',
+  ]);
+  expect(granted.status).toBe(0);
+  expect(JSON.parse(granted.stdout)).toMatchObject({
+    operation: 'create-score',
+    stakesTier: 'amber',
+    httpRequest: {
+      method: 'POST',
+      url: '<env:LANGFUSE_HOST>/api/public/scores',
+      headers: { Authorization: 'Basic <secret:LANGFUSE_BASIC_AUTH>' },
+      json: {
+        name: 'quality',
+        dataType: 'NUMERIC',
+        value: 0.8,
+        traceId: 't1',
+        comment: 'reviewed',
+      },
+    },
+  });
+
+  const datasetItem = build([
+    'create-dataset-item',
+    '--dataset-name',
+    'regressions',
+    '--input-json',
+    '{"q":"hi"}',
+    '--expected-output-json',
+    '{"a":"hello"}',
+    '--source-trace-id',
+    't1',
+    '--operator-grant',
+  ]);
+  expect(datasetItem.status).toBe(0);
+  expect(JSON.parse(datasetItem.stdout).httpRequest.json).toEqual({
+    datasetName: 'regressions',
+    input: { q: 'hi' },
+    expectedOutput: { a: 'hello' },
+    sourceTraceId: 't1',
+  });
+
+  const chatPromptMissingJson = build([
+    'create-prompt',
+    '--type',
+    'chat',
+    '--name',
+    'router',
+    '--operator-grant',
+  ]);
+  expect(chatPromptMissingJson.status).not.toBe(0);
+  expect(chatPromptMissingJson.stderr).toContain('--prompt-json');
+});
+
+test('langfuse helper rejects unknown operations and stray flags', () => {
+  const unknownOp = build(['delete-everything']);
+  expect(unknownOp.status).not.toBe(0);
+  expect(unknownOp.stderr).toContain('Unknown Langfuse operation');
+  expect(unknownOp.stderr).not.toContain('--operator-grant');
+
+  const strayFlag = build(['list-traces', '--nope', 'x']);
+  expect(strayFlag.status).not.toBe(0);
+  expect(strayFlag.stderr).toContain('Unexpected arguments: --nope x');
+});
+
+test('langfuse plan classifier routes representative prompts', () => {
+  const cases = [
+    { prompt: 'Average eval score this week', operation: 'list-scores', tier: 'green' },
+    { prompt: 'Record a quality score on this trace', operation: 'create-score', tier: 'amber' },
+    { prompt: 'Publish a new version of the summarizer prompt', operation: 'create-prompt', tier: 'amber' },
+    { prompt: 'Show daily trace volume metrics', operation: 'metrics', tier: 'green' },
+    { prompt: 'List the conversation sessions', operation: 'list-sessions', tier: 'green' },
+  ];
+
+  for (const testCase of cases) {
+    const result = runHelper(['--format', 'json', 'plan', testCase.prompt]);
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      operation: testCase.operation,
+      stakesTier: testCase.tier,
+      costMeasurement: { system: 'UsageTotals' },
+    });
+  }
+});
+
+test('langfuse helper run executes requests through the gateway', async () => {
+  let receivedBody: Record<string, unknown> | null = null;
+  let receivedAuthorization = '';
+  const server = http.createServer((req, res) => {
+    receivedAuthorization = String(req.headers.authorization || '');
+    let raw = '';
+    req.setEncoding('utf-8');
+    req.on('data', (chunk) => {
+      raw += chunk;
+    });
+    req.on('end', () => {
+      receivedBody = raw ? JSON.parse(raw) : null;
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, status: 200, json: { data: [] } }));
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  try {
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Expected TCP test server address.');
+    }
+    const result = await runHelperAsync([
+      '--format',
+      'json',
+      'run',
+      'list-traces',
+      '--user-id',
+      'alice',
+      '--gateway-url',
+      `http://127.0.0.1:${address.port}`,
+      '--gateway-token',
+      'gateway-token',
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(receivedAuthorization).toBe('Bearer gateway-token');
+    expect(receivedBody).toMatchObject({
+      url: '<env:LANGFUSE_HOST>/api/public/traces?userId=alice',
+      method: 'GET',
+      headers: { Authorization: 'Basic <secret:LANGFUSE_BASIC_AUTH>' },
+      skillName: 'langfuse',
+    });
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      command: 'run',
+      operation: 'list-traces',
+      response: { ok: true, status: 200, json: { data: [] } },
+    });
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test('langfuse eval suite covers 10 UsageTotals scenarios', () => {
+  const scenarios = JSON.parse(
+    fs.readFileSync(path.join(skillDir, 'evals', 'scenarios.json'), 'utf-8'),
+  ) as Array<{ costMeasurement?: { system?: string } }>;
+
+  expect(scenarios).toHaveLength(10);
+  expect(scenarios.every((s) => s.costMeasurement?.system === 'UsageTotals')).toBe(true);
+
+  const result = runHelper(['--format', 'json', 'eval-scenarios']);
+  expect(result.status).toBe(0);
+  expect(JSON.parse(result.stdout)).toMatchObject({
+    scenarioCount: 10,
+    failed: 0,
+    costMeasurement: { system: 'UsageTotals' },
+  });
+});


### PR DESCRIPTION
## Summary

Adds a bundled `langfuse` skill for LLM observability and evaluation, **based on the official Langfuse skill** ([github.com/langfuse/skills](https://github.com/langfuse/skills), MIT) adapted to HybridClaw's gateway + SecretRef model.

### From upstream (vendored, attributed in `NOTICE.md`)
`SKILL.md` body (core principles + documentation lookup via `llms.txt` / `.md` / `search-docs`) and the reference docs: instrumentation, prompt-migration, user-feedback, error-analysis, judge-calibration, sdk-upgrade, ci-cd, cli, skill-feedback.

### HybridClaw-specific additions
- **Credentials via the SecretRef store** — no plaintext keys, no `langfuse-cli`. Store `LANGFUSE_BASIC_AUTH` (base64 `public:secret`) + `LANGFUSE_HOST` via `/secret set` / `/env set`.
- **`langfuse.cjs` gateway helper** is the data-access path: it builds each REST request and routes it through the gateway, which injects `Authorization: Basic <secret:LANGFUSE_BASIC_AUTH>` server-side, so the model never sees the keys. Reads are green; writes (`create-score`/`-comment`/`-dataset`/`-dataset-item`/`-prompt`) require `--operator-grant`. Deletions + project/API-key admin are out of scope.
- HybridClaw credential banners on `cli.md` / `error-analysis.md`; helper enforces the 100 page-size cap, supports `--page`/`--cursor`, documents EU/US/JP/self-hosted hosts.

### Other
- `quick_validate.py` now allows the documented `config_variables` key (also unblocks mailchimp/posthog/fronius/hue).
- `tests/langfuse-skill.test.ts` (12 tests), `evals/scenarios.json`, `docs/.../bundled-skills.md`, `CHANGELOG.md`.

## Validation
- `vitest run tests/langfuse-skill.test.ts` → **12 passed**
- `npm run typecheck` → clean
- `quick_validate.py skills/langfuse` → PASS; `eval-scenarios` → 10 scenarios, 0 failed

Companion PR: **HybridAIOne/claws** adds the `langfuse-agent` `.claw` bundling this skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
