### PR TITLE
Publish Apple Desktop App release

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,15 @@ HybridClaw on HybridAI Cloud in a few minutes at
 
 Fastest managed launch: [HybridClaw on HybridAI Cloud](https://hybridclaw.io).
 
-Linux/macOS one-line installer:
+Apple Desktop App for macOS:
+
+- Download the signed and notarized Apple Silicon DMG:
+  [HybridClaw-0.25.2-arm64.dmg](https://github.com/HybridAIOne/hybridclaw/releases/download/v0.25.2/HybridClaw-0.25.2-arm64.dmg)
+- Open the DMG, drag `HybridClaw.app` into `/Applications`, and launch it.
+- The desktop app starts the local gateway and opens the chat, agents, and
+  admin surfaces in a native macOS window.
+
+Linux/macOS CLI one-line installer:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/scripts/install.sh | bash
@@ -98,7 +106,7 @@ After the gateway starts, open:
 | TUI | `hybridclaw tui` | Terminal chat, approvals, status, resume |
 | OpenAI-compatible API | `http://127.0.0.1:9090/v1/chat/completions` | Local evals and compatible clients |
 
-For signed macOS desktop builds, use the
+For signed macOS desktop builds and future architectures, use the
 [GitHub Releases](https://github.com/HybridAIOne/hybridclaw/releases/latest)
 page.
 

--- a/desktop/src/gateway-runtime.test.ts
+++ b/desktop/src/gateway-runtime.test.ts
@@ -1,0 +1,137 @@
+import { type ChildProcess, spawn } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { PassThrough } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { GatewayRuntime } from './gateway-runtime.js';
+
+vi.mock('node:child_process', async () => {
+  const actual =
+    await vi.importActual<typeof import('node:child_process')>(
+      'node:child_process',
+    );
+  return {
+    ...actual,
+    spawn: vi.fn(),
+  };
+});
+
+const spawnMock = vi.mocked(spawn);
+
+class MockChildProcess extends EventEmitter {
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  readonly kill = vi.fn((signal: NodeJS.Signals = 'SIGTERM') => {
+    if (this.exitCode !== null || this.signalCode !== null) return true;
+    this.signalCode = signal;
+    this.emit('exit', null, signal);
+    this.emit('close', null, signal);
+    return true;
+  });
+
+  exit(code: number | null, signal: NodeJS.Signals | null = null): void {
+    this.exitCode = code;
+    this.signalCode = signal;
+    this.emit('exit', code, signal);
+    this.emit('close', code, signal);
+  }
+}
+
+describe('GatewayRuntime', () => {
+  let runtimeRoot: string;
+
+  beforeEach(() => {
+    spawnMock.mockReset();
+    runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hc-gateway-runtime-'));
+    fs.mkdirSync(path.join(runtimeRoot, 'bin'), { recursive: true });
+    fs.mkdirSync(path.join(runtimeRoot, 'dist'), { recursive: true });
+    fs.mkdirSync(path.join(runtimeRoot, 'node_modules'), { recursive: true });
+    fs.writeFileSync(path.join(runtimeRoot, 'bin', 'node'), '');
+    fs.writeFileSync(path.join(runtimeRoot, 'dist', 'cli.js'), '');
+    fs.chmodSync(path.join(runtimeRoot, 'bin', 'node'), 0o755);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('not reachable');
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    fs.rmSync(runtimeRoot, { recursive: true, force: true });
+  });
+
+  test('reports startup child output and suppresses duplicate crash events', async () => {
+    const child = new MockChildProcess();
+    spawnMock.mockReturnValue(child as unknown as ChildProcess);
+    const logPath = path.join(runtimeRoot, 'logs', 'gateway.log');
+    const runtime = new GatewayRuntime({
+      baseUrl: 'http://127.0.0.1:9090',
+      logPath,
+      packaged: true,
+      processEnv: {},
+      processExecPath: '/Applications/HybridClaw.app/Contents/MacOS/HybridClaw',
+      runtimeRoot,
+    });
+    const unexpectedExit = vi.fn();
+    runtime.on('unexpected-exit', unexpectedExit);
+
+    const started = runtime.ensureRunning(1_000);
+    await waitFor(() => spawnMock.mock.calls.length > 0);
+
+    child.stderr.write('\u001b[31mstartup exploded\u001b[39m\n');
+    child.exit(1);
+
+    await expect(started).rejects.toThrow(
+      /gateway exited before becoming reachable/i,
+    );
+    await expect(started).rejects.toThrow(/startup exploded/);
+    await expect(started).rejects.toThrow(logPath);
+    expect(unexpectedExit).not.toHaveBeenCalled();
+    await waitFor(() => fs.existsSync(logPath));
+    expect(fs.readFileSync(logPath, 'utf8')).toContain('startup exploded');
+  });
+
+  test('emits unexpected-exit for crashes after startup succeeds', async () => {
+    const child = new MockChildProcess();
+    spawnMock.mockReturnValue(child as unknown as ChildProcess);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        if (spawnMock.mock.calls.length === 0) {
+          throw new Error('not reachable');
+        }
+        return { ok: true };
+      }),
+    );
+    const runtime = new GatewayRuntime({
+      baseUrl: 'http://127.0.0.1:9090',
+      packaged: true,
+      processEnv: {},
+      processExecPath: '/Applications/HybridClaw.app/Contents/MacOS/HybridClaw',
+      runtimeRoot,
+    });
+    const unexpectedExit = vi.fn();
+    runtime.on('unexpected-exit', unexpectedExit);
+
+    await runtime.ensureRunning(1_000);
+    child.exit(1);
+
+    expect(unexpectedExit).toHaveBeenCalledWith({ code: 1, signal: null });
+  });
+});
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('Timed out waiting for predicate.');
+}

--- a/desktop/src/gateway-runtime.ts
+++ b/desktop/src/gateway-runtime.ts
@@ -15,9 +15,15 @@ import {
 
 const GATEWAY_READY_TIMEOUT_MS = 20_000;
 const GATEWAY_PING_TIMEOUT_MS = 1_500;
+const RECENT_OUTPUT_LIMIT = 12_000;
+const ANSI_ESCAPE_PATTERN = new RegExp(
+  `${String.fromCharCode(27)}\\[[0-9;]*m`,
+  'g',
+);
 
 export interface GatewayRuntimeOptions {
   baseUrl: string;
+  logPath?: string | null;
   packaged: boolean;
   processEnv: NodeJS.ProcessEnv;
   processExecPath: string;
@@ -31,17 +37,23 @@ export interface GatewayExitPayload {
 
 export class GatewayRuntime extends EventEmitter {
   readonly baseUrl: string;
+  readonly logPath: string | null;
   readonly packaged: boolean;
   readonly processEnv: NodeJS.ProcessEnv;
   readonly processExecPath: string;
   readonly runtimeRoot: string;
   #child: ChildProcess | null = null;
+  #lastExitPayload: GatewayExitPayload | null = null;
+  #lastSpawnError: Error | null = null;
+  #recentChildOutput = '';
   #startedChild = false;
+  #startupInProgress = false;
   #stopping = false;
 
   constructor(options: GatewayRuntimeOptions) {
     super();
     this.baseUrl = normalizeGatewayBaseUrl(options.baseUrl);
+    this.logPath = options.logPath ?? null;
     this.packaged = options.packaged;
     this.processEnv = options.processEnv;
     this.processExecPath = options.processExecPath;
@@ -55,37 +67,35 @@ export class GatewayRuntime extends EventEmitter {
   async ensureRunning(timeoutMs = GATEWAY_READY_TIMEOUT_MS): Promise<void> {
     if (await isGatewayReachable(this.baseUrl)) return;
 
-    if (!this.#child) {
-      this.startChild();
-    }
+    this.#startupInProgress = true;
+    let ready = false;
+    try {
+      const child = this.#child ?? this.startChild();
 
-    const ready = await waitForGatewayReachable(
-      this.baseUrl,
-      timeoutMs,
-      this.#child,
-    );
+      ready = await waitForGatewayReachable(this.baseUrl, timeoutMs, child);
+    } finally {
+      this.#startupInProgress = false;
+    }
     if (ready) return;
 
     await this.stop();
-    throw new Error(
-      `HybridClaw gateway did not become reachable at ${this.baseUrl} within ${timeoutMs}ms.`,
-    );
+    throw new Error(this.formatStartupFailure(timeoutMs));
   }
 
   async restart(timeoutMs = GATEWAY_READY_TIMEOUT_MS): Promise<void> {
     await this.stop();
-    this.startChild();
-    const ready = await waitForGatewayReachable(
-      this.baseUrl,
-      timeoutMs,
-      this.#child,
-    );
+    this.#startupInProgress = true;
+    let ready = false;
+    try {
+      const child = this.startChild();
+      ready = await waitForGatewayReachable(this.baseUrl, timeoutMs, child);
+    } finally {
+      this.#startupInProgress = false;
+    }
     if (ready) return;
 
     await this.stop();
-    throw new Error(
-      `HybridClaw gateway did not become reachable at ${this.baseUrl} within ${timeoutMs}ms.`,
-    );
+    throw new Error(this.formatStartupFailure(timeoutMs));
   }
 
   async stop(): Promise<void> {
@@ -111,7 +121,7 @@ export class GatewayRuntime extends EventEmitter {
     return routeUrl(this.baseUrl, route);
   }
 
-  private startChild(): void {
+  private startChild(): ChildProcess {
     const gatewayEntry = resolveGatewayEntry(this.runtimeRoot);
     const nodeExecutable = resolveGatewayNodeExecutable({
       env: this.processEnv,
@@ -140,6 +150,11 @@ export class GatewayRuntime extends EventEmitter {
       );
     }
 
+    this.#lastExitPayload = null;
+    this.#lastSpawnError = null;
+    this.#recentChildOutput = '';
+
+    const logStream = this.openLogStream();
     const child = spawn(
       nodeExecutable,
       [gatewayEntry, 'gateway', 'start', '--foreground'],
@@ -153,29 +168,125 @@ export class GatewayRuntime extends EventEmitter {
     child.stdout?.setEncoding('utf8');
     child.stderr?.setEncoding('utf8');
     child.stdout?.on('data', (chunk: string) => {
+      this.captureChildOutput('stdout', chunk, logStream);
       process.stdout.write(`[hybridclaw-desktop] ${chunk}`);
     });
     child.stderr?.on('data', (chunk: string) => {
+      this.captureChildOutput('stderr', chunk, logStream);
       process.stderr.write(`[hybridclaw-desktop] ${chunk}`);
     });
 
-    child.on('exit', (code, signal) => {
+    child.on('error', (error) => {
+      this.#lastSpawnError = error;
+      this.captureChildOutput(
+        'error',
+        `Failed to spawn gateway child: ${error.message}\n`,
+        logStream,
+      );
       if (this.#child === child) {
         this.#child = null;
         this.#startedChild = false;
       }
+      if (!this.#stopping && !this.#startupInProgress) {
+        this.emit('unexpected-exit', {
+          code: null,
+          signal: null,
+        } satisfies GatewayExitPayload);
+      }
+    });
+
+    child.on('exit', (code, signal) => {
+      this.#lastExitPayload = { code, signal };
+      if (this.#child === child) {
+        this.#child = null;
+        this.#startedChild = false;
+      }
+      this.writeLog(
+        'exit',
+        `Gateway child exited with code ${String(code)}, signal ${String(signal)}.\n`,
+        logStream,
+      );
       if (this.#stopping) {
         this.#stopping = false;
         return;
       }
+      if (this.#startupInProgress) return;
       this.emit('unexpected-exit', {
         code,
         signal,
       } satisfies GatewayExitPayload);
     });
+    child.once('close', () => {
+      logStream?.end();
+    });
 
     this.#child = child;
     this.#startedChild = true;
+    this.writeLog(
+      'start',
+      `Starting gateway child: ${nodeExecutable} ${gatewayEntry} gateway start --foreground\n`,
+      logStream,
+    );
+    return child;
+  }
+
+  private openLogStream(): fs.WriteStream | null {
+    if (!this.logPath) return null;
+
+    try {
+      fs.mkdirSync(path.dirname(this.logPath), { recursive: true });
+      return fs.createWriteStream(this.logPath, { flags: 'a' });
+    } catch (error) {
+      this.#recentChildOutput = trimRecentOutput(
+        `${this.#recentChildOutput}Failed to open desktop gateway log at ${this.logPath}: ${error instanceof Error ? error.message : String(error)}\n`,
+      );
+      return null;
+    }
+  }
+
+  private captureChildOutput(
+    source: string,
+    chunk: string,
+    logStream: fs.WriteStream | null,
+  ): void {
+    const text = String(chunk);
+    this.#recentChildOutput = trimRecentOutput(
+      `${this.#recentChildOutput}${stripAnsi(text)}`,
+    );
+    this.writeLog(source, text, logStream);
+  }
+
+  private writeLog(
+    source: string,
+    text: string,
+    logStream: fs.WriteStream | null,
+  ): void {
+    if (!logStream) return;
+    logStream.write(prefixLogLines(source, text));
+  }
+
+  private formatStartupFailure(timeoutMs: number): string {
+    const recentOutput = this.#recentChildOutput.trim();
+    const logHint = this.logPath ? `\n\nGateway log: ${this.logPath}` : '';
+    const outputHint = recentOutput
+      ? `\n\nRecent gateway output:\n${recentOutput}`
+      : '';
+
+    if (this.#lastSpawnError) {
+      return `HybridClaw gateway failed to launch: ${this.#lastSpawnError.message}.${logHint}${outputHint}`;
+    }
+    if (this.#lastExitPayload) {
+      return (
+        `HybridClaw gateway exited before becoming reachable at ${this.baseUrl} ` +
+        `(code ${String(this.#lastExitPayload.code)}, signal ${String(this.#lastExitPayload.signal)}).` +
+        `${logHint}${outputHint}`
+      );
+    }
+
+    return (
+      `HybridClaw gateway did not become reachable at ${this.baseUrl} within ${timeoutMs}ms.` +
+      `${logHint}${outputHint}`
+    );
   }
 }
 
@@ -202,6 +313,7 @@ async function waitForGatewayReachable(
     exited = true;
   };
   child?.once('exit', onExit);
+  child?.once('error', onExit);
 
   try {
     while (Date.now() < deadline && !exited) {
@@ -211,6 +323,7 @@ async function waitForGatewayReachable(
     return isGatewayReachable(baseUrl);
   } finally {
     child?.removeListener('exit', onExit);
+    child?.removeListener('error', onExit);
   }
 }
 
@@ -221,9 +334,15 @@ async function waitForExit(
   if (child.exitCode !== null || child.signalCode !== null) return;
 
   const exited = new Promise<void>((resolve) => {
-    child.once('exit', () => {
+    const done = () => {
+      child.removeListener('exit', done);
+      child.removeListener('close', done);
+      child.removeListener('error', done);
       resolve();
-    });
+    };
+    child.once('exit', done);
+    child.once('close', done);
+    child.once('error', done);
   });
 
   const killTimer = delay(timeoutMs).then(() => {
@@ -242,4 +361,21 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
+}
+
+function trimRecentOutput(text: string): string {
+  if (text.length <= RECENT_OUTPUT_LIMIT) return text;
+  return text.slice(text.length - RECENT_OUTPUT_LIMIT);
+}
+
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_ESCAPE_PATTERN, '');
+}
+
+function prefixLogLines(source: string, text: string): string {
+  const timestamp = new Date().toISOString();
+  return text
+    .split(/(?<=\n)/)
+    .map((line) => `[${timestamp}] ${source}: ${line}`)
+    .join('');
 }

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -57,6 +57,7 @@ const gateway = new GatewayRuntime({
       process.env.GATEWAY_BASE_URL ||
       undefined,
   ),
+  logPath: path.join(app.getPath('logs'), 'gateway.log'),
   packaged: app.isPackaged,
   processEnv: process.env,
   processExecPath: process.execPath,

--- a/docs/content/README.md
+++ b/docs/content/README.md
@@ -27,7 +27,9 @@ doc at once, start from [For Agents](./agents.md).
 
 ## Latest Highlights
 
-- HybridClaw v0.25.0 centers first-run hatching: onboarding can use a
+- HybridClaw v0.25.2 ships a signed and notarized Apple Desktop App for Apple
+  Silicon Macs.
+- First-run hatching can use a
   dedicated model, keeps setup links visible in chat, records first-job ideas,
   sends the welcome email when an email route is available, and avoids duplicate
   bootstrap starts.

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -32,7 +32,7 @@ skip the interactive onboarding step:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/scripts/install.sh \
-  | bash -s -- --version 0.25.0 --no-onboarding
+  | bash -s -- --version 0.25.2 --no-onboarding
 ```
 
 For automation, preview the plan with `--dry-run` (changes nothing), run
@@ -141,17 +141,21 @@ brew install hybridclaw
 
 Until then, most macOS users should stick to npm or the Nix flake.
 
-## Install The macOS Desktop App
+## Install The Apple Desktop App
 
-Signed macOS desktop builds are distributed as GitHub Release assets when a
-desktop artifact is published for a version:
+Signed and notarized macOS desktop builds are distributed as GitHub Release
+assets. For HybridClaw v0.25.2 on Apple Silicon, download:
+
+```text
+https://github.com/HybridAIOne/hybridclaw/releases/download/v0.25.2/HybridClaw-0.25.2-arm64.dmg
+```
+
+Open the DMG, drag `HybridClaw.app` into `/Applications`, and launch it. For
+future desktop builds and architectures, use the latest release page:
 
 ```text
 https://github.com/HybridAIOne/hybridclaw/releases/latest
 ```
-
-Download the `HybridClaw-<version>-<arch>.dmg` asset for your Mac, open it,
-and drag `HybridClaw.app` into `/Applications`.
 
 The desktop app is a native wrapper around the same local gateway, chat, agents,
 and admin surfaces. From a source checkout, use `npm run desktop` instead. For

--- a/docs/index.html
+++ b/docs/index.html
@@ -846,6 +846,7 @@
     <div class="hero-install-note">Prerequisites: Node.js 22+. The installer checks Node, installs the CLI, checks Docker, and can run onboarding. Docker provides full container isolation, while containerized deployments can switch to host sandbox mode. Manual npm install is still supported.</div>
   </div>
   <div class="hero-cta">
+    <a href="https://github.com/HybridAIOne/hybridclaw/releases/download/v0.25.2/HybridClaw-0.25.2-arm64.dmg" class="btn btn-primary">Download Apple Desktop App</a>
     <a href="#quickstart" class="btn btn-primary">Get Started</a>
     <a href="/hybridclaw/docs/" class="btn btn-secondary">Read Docs</a>
     <a href="#comparison" class="btn btn-secondary">See Comparison</a>
@@ -888,11 +889,16 @@
 <!-- RELEASE -->
 <section id="release">
   <div class="section-center">
-    <div class="section-label">Latest release: v0.25.0</div>
+    <div class="section-label">Latest release: v0.25.2</div>
     <h2 class="section-title">Current release highlights</h2>
-    <p class="section-desc">HybridClaw v0.25.0 focuses on a smoother first-run hatching experience, OAuth-backed MCP setup, richer skill administration, per-agent email routing, risk evals, and stronger governance evidence.</p>
+    <p class="section-desc">HybridClaw v0.25.2 ships a signed and notarized Apple Desktop App for Apple Silicon Macs, plus a smoother first-run hatching experience, OAuth-backed MCP setup, richer skill administration, per-agent email routing, risk evals, and stronger governance evidence.</p>
   </div>
   <div class="features-grid">
+    <div class="feature-card">
+      <div class="feature-icon">&#x1f5a5;</div>
+      <h3>Apple Desktop App</h3>
+      <p>Download the signed Apple Silicon DMG from GitHub Releases, drag <code>HybridClaw.app</code> into <code>/Applications</code>, and launch the local gateway, chat, agents, and admin surfaces from a native macOS window.</p>
+    </div>
     <div class="feature-card">
       <div class="feature-icon">&#x1f9ed;</div>
       <h3>Guided hatching</h3>
@@ -1658,6 +1664,10 @@
   <!-- LOCAL panel -->
   <div class="qs-panel active" id="qs-local">
     <div class="features-grid">
+      <div class="feature-card">
+        <h3 style="color: var(--accent-1);">Apple Desktop App</h3>
+        <p>On Apple Silicon Macs, download <a href="https://github.com/HybridAIOne/hybridclaw/releases/download/v0.25.2/HybridClaw-0.25.2-arm64.dmg">HybridClaw-0.25.2-arm64.dmg</a>, open it, and drag <code>HybridClaw.app</code> into <code>/Applications</code>.</p>
+      </div>
       <div class="feature-card">
         <h3 style="color: var(--accent-1);">1. Install CLI</h3>
         <p><code>curl -fsSL https://raw.githubusercontent.com/HybridAIOne/hybridclaw/main/scripts/install.sh | bash</code></p>


### PR DESCRIPTION
## Summary
- Add the signed/notarized Apple Silicon Desktop App download to the README, install docs, and hybridclaw.io landing page.
- Update desktop gateway startup handling to write gateway logs, surface child output on failures, and avoid duplicate startup crash dialogs.
- Add desktop runtime tests for startup failures and post-start gateway exits.

## Release asset
- Uploaded `HybridClaw-0.25.2-arm64.dmg` to the `v0.25.2` GitHub Release.
- Asset URL: https://github.com/HybridAIOne/hybridclaw/releases/download/v0.25.2/HybridClaw-0.25.2-arm64.dmg
- SHA-256: `af7ce4a8e485ac18602c07d7d5fd1c0ed92787b59b3029c20fc81eca6834ae09`

## Validation
- `npm --workspace desktop run build`
- `npm --workspace desktop run test`
- `npm --workspace desktop run typecheck`
- `npx biome check --write README.md docs/content/README.md docs/content/getting-started/installation.md docs/index.html desktop/src/gateway-runtime.ts desktop/src/main.ts desktop/src/gateway-runtime.test.ts`
- `xcrun stapler validate desktop/release/HybridClaw-0.25.2-arm64.dmg`
- `spctl --assess --type execute --verbose=4` on the packaged app from the mounted DMG
- `codesign --verify --deep --strict --verbose=2` on the packaged app from the mounted DMG