### PR TITLE
[codex] Advertise public A2A Agent Card URL

### DIFF
--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -2298,11 +2298,18 @@ function resolveRequestOrigin(
   return `${proto}://${host}`;
 }
 
-function resolveA2AAgentCardOrigin(req: IncomingMessage): string {
-  return (
-    normalizePublicBaseUrl(getRuntimeConfig().deployment.public_url) ||
-    resolveRequestOrigin(req)
-  );
+function resolveA2AAgentCardOrigin(req: IncomingMessage): string | null {
+  const configuredPublicUrl = getRuntimeConfig().deployment.public_url.trim();
+  if (configuredPublicUrl) {
+    const origin = normalizePublicBaseUrl(configuredPublicUrl);
+    if (origin) return origin;
+    logger.warn(
+      { publicUrl: configuredPublicUrl },
+      'Invalid deployment.public_url for A2A Agent Card',
+    );
+    return null;
+  }
+  return resolveRequestOrigin(req);
 }
 
 function buildMobileLaunchUrl(params: {
@@ -7074,6 +7081,12 @@ export function startGatewayHttpServer(): GatewayHttpServer {
     );
     if (pathname === '/.well-known/agent.json' && method === 'GET') {
       const origin = resolveA2AAgentCardOrigin(req);
+      if (!origin) {
+        sendJson(res, 500, {
+          error: 'deployment.public_url must be an HTTP(S) URL.',
+        });
+        return;
+      }
       const trust = resolveA2AAgentCardPeerTrust({
         authorization: req.headers.authorization || '',
         audience: new URL('/.well-known/agent.json', origin).toString(),

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -2298,6 +2298,13 @@ function resolveRequestOrigin(
   return `${proto}://${host}`;
 }
 
+function resolveA2AAgentCardOrigin(req: IncomingMessage): string {
+  return (
+    normalizePublicBaseUrl(getRuntimeConfig().deployment.public_url) ||
+    resolveRequestOrigin(req)
+  );
+}
+
 function buildMobileLaunchUrl(params: {
   origin: string;
   token: string;
@@ -7066,7 +7073,7 @@ export function startGatewayHttpServer(): GatewayHttpServer {
       getRuntimeConfig().voice.webhookPath,
     );
     if (pathname === '/.well-known/agent.json' && method === 'GET') {
-      const origin = resolveRequestOrigin(req);
+      const origin = resolveA2AAgentCardOrigin(req);
       const trust = resolveA2AAgentCardPeerTrust({
         authorization: req.headers.authorization || '',
         audience: new URL('/.well-known/agent.json', origin).toString(),

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -541,7 +541,7 @@ async function importFreshHealth(options?: {
   authSecret?: string;
   hybridAiBaseUrl?: string;
   runningInsideContainer?: boolean;
-  runtimeConfigPatch?: (config: RuntimeConfig) => void;
+  deploymentPublicUrl?: string;
   mediaUploadQuotaDecision?: {
     allowed: boolean;
     remainingBytes: number;
@@ -1995,7 +1995,7 @@ async function importFreshHealth(options?: {
     const actual = await vi.importActual<
       typeof import('../src/config/runtime-config.js')
     >('../src/config/runtime-config.js');
-    if (!options?.runtimeConfigPatch) {
+    if (options?.deploymentPublicUrl === undefined) {
       return {
         ...actual,
         reloadRuntimeConfig,
@@ -2004,7 +2004,9 @@ async function importFreshHealth(options?: {
     const runtimeConfig = JSON.parse(
       JSON.stringify(actual.getRuntimeConfig()),
     ) as RuntimeConfig;
-    options.runtimeConfigPatch(runtimeConfig);
+    runtimeConfig.deployment.mode = 'cloud';
+    runtimeConfig.deployment.public_url = options.deploymentPublicUrl;
+    runtimeConfig.deployment.tunnel.provider = 'manual';
     return {
       ...actual,
       getRuntimeConfig: vi.fn(() => runtimeConfig),
@@ -4326,11 +4328,7 @@ describe('gateway HTTP server', () => {
 
   test('serves the A2A Agent Card from the configured public deployment URL', async () => {
     const state = await importFreshHealth({
-      runtimeConfigPatch: (config) => {
-        config.deployment.mode = 'cloud';
-        config.deployment.public_url = 'https://u-public.sbx.hybridai.one';
-        config.deployment.tunnel.provider = 'manual';
-      },
+      deploymentPublicUrl: 'https://u-public.sbx.hybridai.one',
     });
     const req = makeRequest({
       url: '/.well-known/agent.json',
@@ -4348,6 +4346,54 @@ describe('gateway HTTP server', () => {
     expect(state.getGatewayA2AAgentCard).toHaveBeenCalledWith(
       'https://u-public.sbx.hybridai.one',
       expect.objectContaining({ peerTrustLevel: 'public' }),
+    );
+  });
+
+  test('serves the A2A Agent Card from request origin when public deployment URL is unset', async () => {
+    const state = await importFreshHealth({ deploymentPublicUrl: '' });
+    const req = makeRequest({
+      url: '/.well-known/agent.json',
+      headers: {
+        host: 'edge.example.test',
+        'x-forwarded-proto': 'https',
+      },
+      noAuth: true,
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toMatchObject({
+      url: 'https://edge.example.test/a2a',
+    });
+    expect(state.getGatewayA2AAgentCard).toHaveBeenCalledWith(
+      'https://edge.example.test',
+      expect.objectContaining({ peerTrustLevel: 'public' }),
+    );
+  });
+
+  test('rejects invalid configured public deployment URLs for the A2A Agent Card', async () => {
+    const state = await importFreshHealth({
+      deploymentPublicUrl: 'ftp://u-public.sbx.hybridai.one',
+    });
+    const req = makeRequest({
+      url: '/.well-known/agent.json',
+      headers: { host: '172.19.0.11:9090' },
+      noAuth: true,
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+
+    expect(res.statusCode).toBe(500);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'deployment.public_url must be an HTTP(S) URL.',
+    });
+    expect(state.getGatewayA2AAgentCard).not.toHaveBeenCalled();
+    expect(state.loggerWarn).toHaveBeenCalledWith(
+      { publicUrl: 'ftp://u-public.sbx.hybridai.one' },
+      'Invalid deployment.public_url for A2A Agent Card',
     );
   });
 

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { Readable } from 'node:stream';
 
 import { describe, expect, test, vi } from 'vitest';
+import type { RuntimeConfig } from '../src/config/runtime-config.ts';
 import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const DEFAULT_WEB_SESSION_ID = 'agent:main:channel:web:chat:dm:peer:default';
@@ -540,6 +541,7 @@ async function importFreshHealth(options?: {
   authSecret?: string;
   hybridAiBaseUrl?: string;
   runningInsideContainer?: boolean;
+  runtimeConfigPatch?: (config: RuntimeConfig) => void;
   mediaUploadQuotaDecision?: {
     allowed: boolean;
     remainingBytes: number;
@@ -1069,6 +1071,18 @@ async function importFreshHealth(options?: {
     },
     peers: [],
     pairingRequests: [],
+  }));
+  const getGatewayA2AAgentCard = vi.fn((origin: string) => ({
+    name: 'HybridClaw',
+    version: '0.0.0-test',
+    url: new URL('/a2a', origin).toString(),
+    capabilities: {
+      messageSend: true,
+      tasksSend: true,
+      streaming: false,
+    },
+    agents: [],
+    skills: [],
   }));
   const upsertGatewayAdminA2ATrustPeer = vi.fn(() =>
     getGatewayAdminA2ATrust(),
@@ -1981,8 +1995,19 @@ async function importFreshHealth(options?: {
     const actual = await vi.importActual<
       typeof import('../src/config/runtime-config.js')
     >('../src/config/runtime-config.js');
+    if (!options?.runtimeConfigPatch) {
+      return {
+        ...actual,
+        reloadRuntimeConfig,
+      };
+    }
+    const runtimeConfig = JSON.parse(
+      JSON.stringify(actual.getRuntimeConfig()),
+    ) as RuntimeConfig;
+    options.runtimeConfigPatch(runtimeConfig);
     return {
       ...actual,
+      getRuntimeConfig: vi.fn(() => runtimeConfig),
       reloadRuntimeConfig,
     };
   });
@@ -2056,6 +2081,7 @@ async function importFreshHealth(options?: {
     GatewayRequestError,
     getGatewayAgentList,
     getGatewayAgents,
+    getGatewayA2AAgentCard,
     getGatewayAdminAgents,
     getGatewayAdminHybridAIBots,
     getGatewayAdminAgentMarkdownFile,
@@ -2231,6 +2257,7 @@ async function importFreshHealth(options?: {
     getGatewayAdminApprovals,
     getGatewayAdminA2AInbox,
     getGatewayAdminA2ATrust,
+    getGatewayA2AAgentCard,
     previewGatewayAdminA2APairing,
     upsertGatewayAdminA2ATrustPeer,
     revokeGatewayAdminA2ATrustPeer,
@@ -4295,6 +4322,33 @@ describe('gateway HTTP server', () => {
       expect(aboutRes.headers['Content-Type']).toBe('text/html; charset=utf-8');
       expect(aboutRes.body).toContain('<h1>Docs</h1>');
     }
+  });
+
+  test('serves the A2A Agent Card from the configured public deployment URL', async () => {
+    const state = await importFreshHealth({
+      runtimeConfigPatch: (config) => {
+        config.deployment.mode = 'cloud';
+        config.deployment.public_url = 'https://u-public.sbx.hybridai.one';
+        config.deployment.tunnel.provider = 'manual';
+      },
+    });
+    const req = makeRequest({
+      url: '/.well-known/agent.json',
+      headers: { host: '172.19.0.11:9090' },
+      noAuth: true,
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toMatchObject({
+      url: 'https://u-public.sbx.hybridai.one/a2a',
+    });
+    expect(state.getGatewayA2AAgentCard).toHaveBeenCalledWith(
+      'https://u-public.sbx.hybridai.one',
+      expect.objectContaining({ peerTrustLevel: 'public' }),
+    );
   });
 
   test('serves /chat, /agents, and /admin without a session cookie outside Docker', async () => {


### PR DESCRIPTION
## Summary

- Use the configured `deployment.public_url` when rendering `/.well-known/agent.json`.
- Keep request/proxy-header origin reconstruction as the fallback for local/dev cases.
- Add a regression test for sandbox requests where the incoming `Host` is an internal container address but the configured public URL is HTTPS.

## Why

Sandbox instances were publishing Agent Cards with internal delivery URLs like `http://172.19.x.x:9090/a2a`. The A2A trust flow correctly rejects those cards because delivery URLs must use HTTPS unless targeting loopback, so pairing from `/admin/a2a-trust` failed even when the operator entered the public HTTPS sandbox URL.

## Validation

- `./node_modules/.bin/vitest tests/gateway-http-server.test.ts --run`