### PR TITLE
[codex] polish console loading title

### DIFF
--- a/console/src/app.tsx
+++ b/console/src/app.tsx
@@ -1,8 +1,10 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider } from '@tanstack/react-router';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useAuth } from './auth';
+import { HybridClaw } from './components/icons';
 import { LoginScreen } from './components/login-screen';
+import { resolveBrowserTitle } from './lib/browser-title';
 import { router } from './router';
 
 export function App() {
@@ -18,16 +20,28 @@ export function App() {
       }),
   );
 
+  useEffect(() => {
+    document.title = resolveBrowserTitle(window.location.pathname);
+  }, []);
+
   if (auth.status === 'checking') {
     return (
-      <div className="login-shell">
-        <div className="login-card">
-          <p className="eyebrow">HybridClaw Admin</p>
-          <h1>Connecting.</h1>
-          <p className="supporting-text">
-            Checking whether this instance is localhost-only or protected by
-            <code> WEB_API_TOKEN</code>.
-          </p>
+      <div className="loading-shell">
+        <div
+          aria-label="Loading HybridClaw"
+          aria-live="polite"
+          className="loading-panel"
+          role="status"
+        >
+          <div className="loading-mark-wrap">
+            <HybridClaw className="loading-mark" />
+          </div>
+          <div className="loading-copy">
+            <h1>Loading HybridClaw ...</h1>
+          </div>
+          <div className="loading-progress" aria-hidden="true">
+            <span />
+          </div>
         </div>
       </div>
     );

--- a/console/src/lib/browser-title.test.ts
+++ b/console/src/lib/browser-title.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { resolveBrowserTitle } from './browser-title';
+
+describe('resolveBrowserTitle', () => {
+  it('uses chat title for chat routes', () => {
+    expect(resolveBrowserTitle('/chat')).toBe('HybridClaw Chat');
+    expect(resolveBrowserTitle('/chat/session-1')).toBe('HybridClaw Chat');
+  });
+
+  it('uses admin title only for admin routes', () => {
+    expect(resolveBrowserTitle('/admin')).toBe('HybridClaw Admin');
+    expect(resolveBrowserTitle('/admin/config')).toBe('HybridClaw Admin');
+    expect(resolveBrowserTitle('/agents')).toBe('HybridClaw Agents');
+  });
+});

--- a/console/src/lib/browser-title.ts
+++ b/console/src/lib/browser-title.ts
@@ -1,0 +1,15 @@
+export function resolveBrowserTitle(pathname: string): string {
+  if (pathname === '/chat' || pathname.startsWith('/chat/')) {
+    return 'HybridClaw Chat';
+  }
+
+  if (pathname === '/agents' || pathname.startsWith('/agents/')) {
+    return 'HybridClaw Agents';
+  }
+
+  if (pathname === '/admin' || pathname.startsWith('/admin/')) {
+    return 'HybridClaw Admin';
+  }
+
+  return 'HybridClaw';
+}

--- a/console/src/router.tsx
+++ b/console/src/router.tsx
@@ -3,9 +3,11 @@ import {
   createRoute,
   createRouter,
   Outlet,
+  useRouterState,
 } from '@tanstack/react-router';
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, useEffect } from 'react';
 import { AppShell } from './components/app-shell';
+import { resolveBrowserTitle } from './lib/browser-title';
 import { A2AInboxPage } from './routes/a2a-inbox';
 import { A2ATrustPage } from './routes/a2a-trust';
 import { AgentsPage } from './routes/agent-scoreboard';
@@ -65,8 +67,29 @@ function optionalStringSearchValue(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
 
+function BrowserTitle() {
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  });
+
+  useEffect(() => {
+    document.title = resolveBrowserTitle(pathname);
+  }, [pathname]);
+
+  return null;
+}
+
+function RootRouteComponent() {
+  return (
+    <>
+      <BrowserTitle />
+      <Outlet />
+    </>
+  );
+}
+
 const rootRoute = createRootRoute({
-  component: () => <Outlet />,
+  component: RootRouteComponent,
 });
 
 function AppShellRouteComponent() {

--- a/console/src/styles.css
+++ b/console/src/styles.css
@@ -3550,6 +3550,163 @@ th {
   font-size: 1.75rem;
 }
 
+.loading-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  overflow: hidden;
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--primary) 18%, transparent) 0%,
+      transparent 34%
+    ),
+    linear-gradient(
+      225deg,
+      color-mix(in srgb, var(--success) 16%, transparent) 0%,
+      transparent 38%
+    ),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--panel-muted) 74%, var(--panel-bg)) 0%,
+      var(--page-bg) 100%
+    );
+}
+
+.loading-panel {
+  position: relative;
+  display: grid;
+  justify-items: center;
+  gap: 20px;
+  width: min(420px, 100%);
+  padding: 36px 30px 32px;
+  border: 1px solid color-mix(in srgb, var(--line) 74%, transparent);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--panel-bg) 88%, transparent);
+  box-shadow:
+    0 24px 70px color-mix(in srgb, var(--text) 16%, transparent),
+    inset 0 1px 0 color-mix(in srgb, white 54%, transparent);
+  text-align: center;
+  backdrop-filter: blur(18px);
+}
+
+.loading-panel::before {
+  position: absolute;
+  inset: 10px;
+  border: 1px solid color-mix(in srgb, var(--line) 54%, transparent);
+  border-radius: calc(var(--radius-lg) - 3px);
+  pointer-events: none;
+  content: "";
+}
+
+.loading-mark-wrap {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 116px;
+  height: 116px;
+  border: 1px solid color-mix(in srgb, var(--primary) 22%, var(--line));
+  border-radius: 50%;
+  background:
+    linear-gradient(
+      145deg,
+      color-mix(in srgb, var(--primary) 16%, var(--panel-bg)),
+      color-mix(in srgb, var(--success) 10%, var(--panel-bg))
+    );
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 46%, transparent),
+    0 18px 36px color-mix(in srgb, var(--primary) 20%, transparent);
+}
+
+.loading-mark-wrap::after {
+  position: absolute;
+  inset: -7px;
+  border: 2px solid transparent;
+  border-top-color: color-mix(in srgb, var(--primary) 72%, transparent);
+  border-right-color: color-mix(in srgb, var(--success) 58%, transparent);
+  border-radius: 50%;
+  content: "";
+  animation: loading-ring-spin 1.8s linear infinite;
+}
+
+.loading-mark {
+  width: 68px;
+  height: 75px;
+  color: color-mix(in srgb, var(--primary) 76%, var(--text));
+  filter: drop-shadow(
+    0 8px 14px color-mix(in srgb, var(--primary) 24%, transparent)
+  );
+}
+
+.loading-copy {
+  display: grid;
+  gap: 8px;
+  justify-items: center;
+}
+
+.loading-copy h1 {
+  margin: 0;
+  color: var(--text);
+  font-size: clamp(1.55rem, 5vw, 2.05rem);
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1.08;
+}
+
+.loading-progress {
+  width: min(260px, 72vw);
+  height: 6px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--muted-foreground) 16%, transparent);
+}
+
+.loading-progress span {
+  display: block;
+  width: 42%;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(
+    90deg,
+    var(--primary),
+    var(--success),
+    color-mix(in srgb, var(--tone-review) 80%, var(--primary))
+  );
+  animation: loading-progress-slide 1.45s ease-in-out infinite;
+}
+
+@keyframes loading-ring-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes loading-progress-slide {
+  0% {
+    transform: translateX(-115%);
+  }
+
+  55% {
+    transform: translateX(85%);
+  }
+
+  100% {
+    transform: translateX(245%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loading-mark-wrap::after,
+  .loading-progress span {
+    animation: none;
+  }
+
+  .loading-progress span {
+    transform: translateX(68%);
+  }
+}
+
 .compact-search {
   min-width: 240px;
 }

--- a/console/src/styles.css
+++ b/console/src/styles.css
@@ -3608,12 +3608,11 @@ th {
   height: 116px;
   border: 1px solid color-mix(in srgb, var(--primary) 22%, var(--line));
   border-radius: 50%;
-  background:
-    linear-gradient(
-      145deg,
-      color-mix(in srgb, var(--primary) 16%, var(--panel-bg)),
-      color-mix(in srgb, var(--success) 10%, var(--panel-bg))
-    );
+  background: linear-gradient(
+    145deg,
+    color-mix(in srgb, var(--primary) 16%, var(--panel-bg)),
+    color-mix(in srgb, var(--success) 10%, var(--panel-bg))
+  );
   box-shadow:
     inset 0 1px 0 color-mix(in srgb, white 46%, transparent),
     0 18px 36px color-mix(in srgb, var(--primary) 20%, transparent);

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -2338,6 +2338,22 @@ function isConsoleSpaPath(pathname: string): boolean {
   );
 }
 
+function resolveConsolePageTitle(pathname: string): string {
+  if (pathname === '/chat' || pathname.startsWith('/chat/')) {
+    return 'HybridClaw Chat';
+  }
+
+  if (pathname === '/agents' || pathname.startsWith('/agents/')) {
+    return 'HybridClaw Agents';
+  }
+
+  if (pathname === '/admin' || pathname.startsWith('/admin/')) {
+    return 'HybridClaw Admin';
+  }
+
+  return 'HybridClaw';
+}
+
 function isLocalWebSurfacePath(pathname: string): boolean {
   return (
     isConsoleSpaPath(pathname) ||
@@ -2839,6 +2855,9 @@ function serveStatic(url: URL, res: ServerResponse): boolean {
 function serveConsoleFile(
   filePath: string | null,
   res: ServerResponse,
+  options?: {
+    title?: string;
+  },
 ): boolean {
   if (!filePath) return false;
   const ext = path.extname(filePath).toLowerCase();
@@ -2859,6 +2878,14 @@ function serveConsoleFile(
         }
       : {}),
   });
+  if (isIndex && options?.title) {
+    const html = fs
+      .readFileSync(filePath, 'utf-8')
+      .replace(/<title>.*?<\/title>/, `<title>${options.title}</title>`);
+    res.end(html);
+    return true;
+  }
+
   res.end(fs.readFileSync(filePath));
   return true;
 }
@@ -2867,10 +2894,13 @@ function serveConsoleAsset(pathname: string, res: ServerResponse): boolean {
   return serveConsoleFile(resolveStaticFile(CONSOLE_DIST_DIR, pathname), res);
 }
 
-function serveConsoleIndex(res: ServerResponse): boolean {
+function serveConsoleIndex(pathname: string, res: ServerResponse): boolean {
   return serveConsoleFile(
     resolveStaticFile(CONSOLE_DIST_DIR, '/index.html'),
     res,
+    {
+      title: resolveConsolePageTitle(pathname),
+    },
   );
 }
 
@@ -7769,7 +7799,7 @@ export function startGatewayHttpServer(): GatewayHttpServer {
         proxyToVite(req, res, '/');
         return;
       }
-      if (serveConsoleIndex(res)) return;
+      if (serveConsoleIndex(pathname, res)) return;
       sendText(
         res,
         503,

--- a/tests/npm-install.e2e.test.ts
+++ b/tests/npm-install.e2e.test.ts
@@ -246,7 +246,7 @@ describe.skipIf(!NPM_E2E)('npm install user journey', () => {
     });
     expect(res.status).toBe(200);
     const html = await res.text();
-    expect(html).toContain('<title>HybridClaw Admin</title>');
+    expect(html).toContain('<title>HybridClaw Chat</title>');
   });
 
   test('/admin serves the console (host mode, no container auth)', async () => {


### PR DESCRIPTION
## What changed

- Replaced the transient console connecting state with a branded `Loading HybridClaw ...` screen using the existing HybridClaw mark.
- Removed admin-specific copy from that loading screen so it works for both `/chat` and `/admin`.
- Added route-aware browser titles so `/chat` is `HybridClaw Chat`, `/admin` is `HybridClaw Admin`, and `/agents` is `HybridClaw Agents`.
- Updated the gateway SPA index response to serve the correct initial `<title>` for chat/admin/agents routes before the client finishes booting.

## Why

The shared console SPA is used by more than the admin surface. The intermediate loading screen and browser tab title should reflect the current surface instead of always saying admin.

## Validation

- `npm --workspace console run typecheck`
- `npm --workspace console run lint`
- `npm --workspace console run test -- browser-title`
- `npm run typecheck`
- `npm run lint`
- `npx vitest run --configLoader runner --project unit tests/gateway-http-server.test.ts -t "serves console index with defensive headers"`
- `npm --workspace console run build`
- Manual in-app browser preview at `/chat`: verified tab title `HybridClaw Chat`, loading screen visible, and no `HybridClaw Admin` label.