### PR TITLE
[codex] add admin tunnel controls

### DIFF
--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -79,6 +79,8 @@ import type {
   AdminTerminalStartResponse,
   AdminTerminalStopResponse,
   AdminToolsResponse,
+  AdminTunnelConfigInput,
+  AdminTunnelConfigResponse,
   AdminTunnelStatus,
   AgentListItem,
   AgentListResponse,
@@ -320,6 +322,25 @@ export function fetchHealth(): Promise<GatewayStatus> {
 
 export function fetchOverview(token: string): Promise<AdminOverview> {
   return requestJson<AdminOverview>('/api/admin/overview', { token });
+}
+
+export function fetchTunnelConfig(
+  token: string,
+): Promise<AdminTunnelConfigResponse> {
+  return requestJson<AdminTunnelConfigResponse>('/api/admin/tunnel', {
+    token,
+  });
+}
+
+export function saveTunnelConfig(
+  token: string,
+  payload: AdminTunnelConfigInput,
+): Promise<AdminTunnelConfigResponse> {
+  return requestJson<AdminTunnelConfigResponse>('/api/admin/tunnel', {
+    token,
+    method: 'PUT',
+    body: payload,
+  });
 }
 
 export async function reconnectTunnel(

--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -356,6 +356,17 @@ export async function reconnectTunnel(
   return payload.tunnel;
 }
 
+export async function stopTunnel(token: string): Promise<AdminTunnelStatus> {
+  const payload = await requestJson<{ tunnel: AdminTunnelStatus }>(
+    '/api/admin/tunnel/stop',
+    {
+      token,
+      method: 'POST',
+    },
+  );
+  return payload.tunnel;
+}
+
 export function fetchStatistics(
   token: string,
   days?: number,

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -826,6 +826,20 @@ export interface AdminConfig {
       screenshotMode: 'som' | 'vision' | 'ax';
     };
   };
+  deployment: {
+    mode: 'cloud' | 'local';
+    public_url: string;
+    tunnel: {
+      provider?:
+        | 'cloudflare'
+        | 'manual'
+        | 'ngrok'
+        | 'ssh'
+        | 'tailscale'
+        | (string & {});
+      health_check_interval_ms: number;
+    };
+  };
   ops: {
     healthHost: string;
     healthPort: number;

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -329,6 +329,30 @@ export interface AdminModelUsageRow extends AdminUsageSummary {
 
 export type AdminTunnelHealth = 'healthy' | 'reconnecting' | 'down';
 
+export type AdminTunnelProvider =
+  | 'cloudflare'
+  | 'manual'
+  | 'ngrok'
+  | 'ssh'
+  | 'tailscale';
+
+export interface AdminTunnelConfig {
+  mode: 'cloud' | 'local';
+  provider: AdminTunnelProvider | (string & {}) | null;
+  publicUrl: string;
+  healthCheckIntervalMs: number;
+}
+
+export interface AdminTunnelConfigInput {
+  provider: AdminTunnelProvider;
+  publicUrl: string;
+}
+
+export interface AdminTunnelConfigResponse {
+  config: AdminTunnelConfig;
+  tunnel: AdminTunnelStatus;
+}
+
 export interface AdminTunnelStatus {
   provider: string | null;
   publicUrl: string | null;

--- a/console/src/routes/channels.test.tsx
+++ b/console/src/routes/channels.test.tsx
@@ -274,6 +274,14 @@ function makeConfig(overrides: Partial<AdminConfig> = {}): AdminConfig {
       maxConcurrent: 2,
       persistBashState: true,
     },
+    deployment: {
+      mode: 'local',
+      public_url: '',
+      tunnel: {
+        provider: 'manual',
+        health_check_interval_ms: 30000,
+      },
+    },
     ops: {
       healthHost: '127.0.0.1',
       healthPort: 3001,

--- a/console/src/routes/dashboard.test.tsx
+++ b/console/src/routes/dashboard.test.tsx
@@ -1,28 +1,28 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
-  AdminConfig,
   AdminOverview,
+  AdminTunnelConfigResponse,
   AdminTunnelStatus,
 } from '../api/types';
 import { renderWithProviders } from '../test-utils';
 import { DashboardPage } from './dashboard';
 
-const fetchConfigMock = vi.fn();
 const fetchOverviewMock = vi.fn();
 const fetchStatisticsMock = vi.fn();
+const fetchTunnelConfigMock = vi.fn();
 const reconnectTunnelMock = vi.fn();
-const saveConfigMock = vi.fn();
+const saveTunnelConfigMock = vi.fn();
 const navigateMock = vi.fn();
 const useAuthMock = vi.fn();
 const useLiveEventsMock = vi.fn();
 
 vi.mock('../api/client', () => ({
-  fetchConfig: (...args: unknown[]) => fetchConfigMock(...args),
   fetchOverview: (...args: unknown[]) => fetchOverviewMock(...args),
   fetchStatistics: (...args: unknown[]) => fetchStatisticsMock(...args),
+  fetchTunnelConfig: (...args: unknown[]) => fetchTunnelConfigMock(...args),
   reconnectTunnel: (...args: unknown[]) => reconnectTunnelMock(...args),
-  saveConfig: (...args: unknown[]) => saveConfigMock(...args),
+  saveTunnelConfig: (...args: unknown[]) => saveTunnelConfigMock(...args),
 }));
 
 vi.mock('../auth', () => ({
@@ -103,29 +103,26 @@ function makeOverview(
   };
 }
 
-function makeConfig(overrides: Partial<AdminConfig> = {}): AdminConfig {
+function makeTunnelConfigResponse(
+  overrides: Partial<AdminTunnelConfigResponse['config']> = {},
+): AdminTunnelConfigResponse {
   return {
-    version: 1,
-    deployment: {
+    config: {
       mode: 'local',
-      public_url: '',
-      tunnel: {
-        provider: 'manual',
-        health_check_interval_ms: 30000,
-      },
+      provider: 'manual',
+      publicUrl: '',
+      healthCheckIntervalMs: 30_000,
+      ...overrides,
     },
-    ops: {
-      healthHost: '127.0.0.1',
-      healthPort: 9090,
-      webApiToken: '',
-      gatewayBaseUrl: 'http://127.0.0.1:9090',
-      gatewayInternalBaseUrl: 'http://127.0.0.1:9090',
-      gatewayApiToken: '',
-      dbPath: '',
-      logLevel: 'info',
-    },
-    ...overrides,
-  } as AdminConfig;
+    tunnel: makeTunnelStatus({
+      provider: overrides.provider ?? 'manual',
+      publicUrl: overrides.publicUrl || null,
+      reconnectSupported:
+        overrides.provider === 'ngrok' ||
+        overrides.provider === 'tailscale' ||
+        overrides.provider === 'cloudflare',
+    }),
+  };
 }
 
 function renderDashboardPage(): void {
@@ -134,11 +131,6 @@ function renderDashboardPage(): void {
 
 describe('DashboardPage', () => {
   beforeEach(() => {
-    fetchConfigMock.mockReset();
-    fetchConfigMock.mockResolvedValue({
-      path: '/tmp/config.json',
-      config: makeConfig(),
-    });
     fetchOverviewMock.mockReset();
     fetchStatisticsMock.mockReset();
     fetchStatisticsMock.mockResolvedValue({
@@ -161,10 +153,13 @@ describe('DashboardPage', () => {
       trend: [],
       channels: [],
     });
+    fetchTunnelConfigMock.mockReset();
+    fetchTunnelConfigMock.mockResolvedValue(makeTunnelConfigResponse());
     reconnectTunnelMock.mockReset();
-    saveConfigMock.mockReset();
-    saveConfigMock.mockImplementation((_token: string, config: AdminConfig) =>
-      Promise.resolve({ path: '/tmp/config.json', config }),
+    saveTunnelConfigMock.mockReset();
+    saveTunnelConfigMock.mockImplementation(
+      (_token: string, payload: AdminTunnelConfigResponse['config']) =>
+        Promise.resolve(makeTunnelConfigResponse(payload)),
     );
     navigateMock.mockReset();
     useAuthMock.mockReset();
@@ -256,23 +251,61 @@ describe('DashboardPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
-      expect(saveConfigMock).toHaveBeenCalledWith(
-        'test-token',
-        expect.objectContaining({
-          deployment: expect.objectContaining({
-            mode: 'local',
-            public_url:
-              'https://unreinforced-ching-asthmatically.ngrok-free.dev',
-            tunnel: expect.objectContaining({ provider: 'manual' }),
-          }),
-          ops: expect.objectContaining({
-            gatewayBaseUrl:
-              'https://unreinforced-ching-asthmatically.ngrok-free.dev',
-          }),
-        }),
-      );
+      expect(saveTunnelConfigMock).toHaveBeenCalledWith('test-token', {
+        provider: 'manual',
+        publicUrl: 'https://unreinforced-ching-asthmatically.ngrok-free.dev',
+      });
     });
     expect(reconnectTunnelMock).not.toHaveBeenCalled();
+  });
+
+  it('disables saving invalid public tunnel URLs', async () => {
+    fetchOverviewMock.mockResolvedValue(
+      makeOverview(
+        makeTunnelStatus({
+          provider: 'manual',
+          publicUrl: null,
+          state: 'down',
+          health: 'down',
+          reconnectSupported: false,
+        }),
+      ),
+    );
+
+    renderDashboardPage();
+
+    fireEvent.change(await screen.findByLabelText('Public URL'), {
+      target: { value: 'not a url' },
+    });
+
+    expect(
+      await screen.findByText('Public URL must be a valid URL.'),
+    ).toBeTruthy();
+    expect(
+      (screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(saveTunnelConfigMock).not.toHaveBeenCalled();
+  });
+
+  it('warns when the configured public tunnel URL uses HTTP', async () => {
+    fetchOverviewMock.mockResolvedValue(makeOverview());
+
+    renderDashboardPage();
+
+    fireEvent.change(await screen.findByLabelText('Public URL'), {
+      target: { value: 'http://public.example.test' },
+    });
+
+    expect(
+      await screen.findByText(
+        'Public tunnel URL uses HTTP. HTTPS is recommended.',
+      ),
+    ).toBeTruthy();
+    expect(
+      (screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
   });
 
   it('saves managed ngrok config and starts the tunnel from the dashboard', async () => {
@@ -285,19 +318,12 @@ describe('DashboardPage', () => {
         }),
       ),
     );
-    fetchConfigMock.mockResolvedValue({
-      path: '/tmp/config.json',
-      config: makeConfig({
-        deployment: {
-          mode: 'local',
-          public_url: 'https://old.ngrok-free.dev',
-          tunnel: {
-            provider: 'manual',
-            health_check_interval_ms: 30000,
-          },
-        },
+    fetchTunnelConfigMock.mockResolvedValue(
+      makeTunnelConfigResponse({
+        provider: 'manual',
+        publicUrl: 'https://old.ngrok-free.dev',
       }),
-    });
+    );
     reconnectTunnelMock.mockResolvedValue(
       makeTunnelStatus({
         provider: 'ngrok',
@@ -313,16 +339,10 @@ describe('DashboardPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save & start' }));
 
     await waitFor(() => {
-      expect(saveConfigMock).toHaveBeenCalledWith(
-        'test-token',
-        expect.objectContaining({
-          deployment: expect.objectContaining({
-            mode: 'local',
-            public_url: '',
-            tunnel: expect.objectContaining({ provider: 'ngrok' }),
-          }),
-        }),
-      );
+      expect(saveTunnelConfigMock).toHaveBeenCalledWith('test-token', {
+        provider: 'ngrok',
+        publicUrl: '',
+      });
       expect(reconnectTunnelMock).toHaveBeenCalledWith('test-token');
     });
     expect(

--- a/console/src/routes/dashboard.test.tsx
+++ b/console/src/routes/dashboard.test.tsx
@@ -13,6 +13,7 @@ const fetchStatisticsMock = vi.fn();
 const fetchTunnelConfigMock = vi.fn();
 const reconnectTunnelMock = vi.fn();
 const saveTunnelConfigMock = vi.fn();
+const stopTunnelMock = vi.fn();
 const navigateMock = vi.fn();
 const useAuthMock = vi.fn();
 const useLiveEventsMock = vi.fn();
@@ -23,6 +24,7 @@ vi.mock('../api/client', () => ({
   fetchTunnelConfig: (...args: unknown[]) => fetchTunnelConfigMock(...args),
   reconnectTunnel: (...args: unknown[]) => reconnectTunnelMock(...args),
   saveTunnelConfig: (...args: unknown[]) => saveTunnelConfigMock(...args),
+  stopTunnel: (...args: unknown[]) => stopTunnelMock(...args),
 }));
 
 vi.mock('../auth', () => ({
@@ -161,6 +163,7 @@ describe('DashboardPage', () => {
       (_token: string, payload: AdminTunnelConfigResponse['config']) =>
         Promise.resolve(makeTunnelConfigResponse(payload)),
     );
+    stopTunnelMock.mockReset();
     navigateMock.mockReset();
     useAuthMock.mockReset();
     useLiveEventsMock.mockReset();
@@ -352,6 +355,71 @@ describe('DashboardPage', () => {
         })
       ).getAttribute('href'),
     ).toBe('https://next.ngrok-free.dev');
+  });
+
+  it('shows stop for a running managed tunnel and stops it from the dashboard', async () => {
+    fetchOverviewMock.mockResolvedValue(
+      makeOverview(
+        makeTunnelStatus({
+          provider: 'ngrok',
+          publicUrl: 'https://running.ngrok-free.dev',
+          state: 'up',
+          health: 'healthy',
+          reconnectSupported: true,
+        }),
+      ),
+    );
+    fetchTunnelConfigMock.mockResolvedValue(
+      makeTunnelConfigResponse({
+        provider: 'ngrok',
+        publicUrl: '',
+      }),
+    );
+    stopTunnelMock.mockResolvedValue(
+      makeTunnelStatus({
+        provider: 'ngrok',
+        publicUrl: null,
+        state: 'down',
+        health: 'down',
+        reconnectSupported: true,
+      }),
+    );
+
+    renderDashboardPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Stop' }));
+
+    await waitFor(() => {
+      expect(stopTunnelMock).toHaveBeenCalledWith('test-token');
+    });
+    expect(await screen.findByText('not configured')).toBeTruthy();
+  });
+
+  it('shows a spinner action while a managed tunnel is starting', async () => {
+    fetchOverviewMock.mockResolvedValue(
+      makeOverview(
+        makeTunnelStatus({
+          provider: 'ngrok',
+          publicUrl: null,
+          state: 'starting',
+          health: 'reconnecting',
+          reconnectSupported: true,
+        }),
+      ),
+    );
+    fetchTunnelConfigMock.mockResolvedValue(
+      makeTunnelConfigResponse({
+        provider: 'ngrok',
+        publicUrl: '',
+      }),
+    );
+
+    renderDashboardPage();
+
+    const button = await screen.findByRole('button', { name: 'Starting' });
+
+    expect(button.getAttribute('aria-busy')).toBe('true');
+    expect(button.querySelector('.button-spinner')).toBeTruthy();
   });
 
   it('does not repeat the same tunnel and reconnect error', async () => {

--- a/console/src/routes/dashboard.test.tsx
+++ b/console/src/routes/dashboard.test.tsx
@@ -1,20 +1,28 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { AdminOverview, AdminTunnelStatus } from '../api/types';
+import type {
+  AdminConfig,
+  AdminOverview,
+  AdminTunnelStatus,
+} from '../api/types';
 import { renderWithProviders } from '../test-utils';
 import { DashboardPage } from './dashboard';
 
+const fetchConfigMock = vi.fn();
 const fetchOverviewMock = vi.fn();
 const fetchStatisticsMock = vi.fn();
 const reconnectTunnelMock = vi.fn();
+const saveConfigMock = vi.fn();
 const navigateMock = vi.fn();
 const useAuthMock = vi.fn();
 const useLiveEventsMock = vi.fn();
 
 vi.mock('../api/client', () => ({
+  fetchConfig: (...args: unknown[]) => fetchConfigMock(...args),
   fetchOverview: (...args: unknown[]) => fetchOverviewMock(...args),
   fetchStatistics: (...args: unknown[]) => fetchStatisticsMock(...args),
   reconnectTunnel: (...args: unknown[]) => reconnectTunnelMock(...args),
+  saveConfig: (...args: unknown[]) => saveConfigMock(...args),
 }));
 
 vi.mock('../auth', () => ({
@@ -95,12 +103,42 @@ function makeOverview(
   };
 }
 
+function makeConfig(overrides: Partial<AdminConfig> = {}): AdminConfig {
+  return {
+    version: 1,
+    deployment: {
+      mode: 'local',
+      public_url: '',
+      tunnel: {
+        provider: 'manual',
+        health_check_interval_ms: 30000,
+      },
+    },
+    ops: {
+      healthHost: '127.0.0.1',
+      healthPort: 9090,
+      webApiToken: '',
+      gatewayBaseUrl: 'http://127.0.0.1:9090',
+      gatewayInternalBaseUrl: 'http://127.0.0.1:9090',
+      gatewayApiToken: '',
+      dbPath: '',
+      logLevel: 'info',
+    },
+    ...overrides,
+  } as AdminConfig;
+}
+
 function renderDashboardPage(): void {
   renderWithProviders(<DashboardPage />);
 }
 
 describe('DashboardPage', () => {
   beforeEach(() => {
+    fetchConfigMock.mockReset();
+    fetchConfigMock.mockResolvedValue({
+      path: '/tmp/config.json',
+      config: makeConfig(),
+    });
     fetchOverviewMock.mockReset();
     fetchStatisticsMock.mockReset();
     fetchStatisticsMock.mockResolvedValue({
@@ -124,6 +162,10 @@ describe('DashboardPage', () => {
       channels: [],
     });
     reconnectTunnelMock.mockReset();
+    saveConfigMock.mockReset();
+    saveConfigMock.mockImplementation((_token: string, config: AdminConfig) =>
+      Promise.resolve({ path: '/tmp/config.json', config }),
+    );
     navigateMock.mockReset();
     useAuthMock.mockReset();
     useLiveEventsMock.mockReset();
@@ -165,7 +207,7 @@ describe('DashboardPage', () => {
         .getByRole('link', { name: 'https://public.example.test' })
         .getAttribute('href'),
     ).toBe('https://public.example.test');
-    expect(screen.getByText('ngrok')).toBeTruthy();
+    expect(screen.getAllByText('ngrok').length).toBeGreaterThan(0);
     expect(screen.getByText('reconnecting')).toBeTruthy();
   });
 
@@ -189,6 +231,107 @@ describe('DashboardPage', () => {
         })
       ).getAttribute('href'),
     ).toBe('https://next.example.test');
+  });
+
+  it('saves a manually started public tunnel URL from the dashboard', async () => {
+    fetchOverviewMock.mockResolvedValue(
+      makeOverview(
+        makeTunnelStatus({
+          provider: 'manual',
+          publicUrl: null,
+          state: 'down',
+          health: 'down',
+          reconnectSupported: false,
+        }),
+      ),
+    );
+
+    renderDashboardPage();
+
+    fireEvent.change(await screen.findByLabelText('Public URL'), {
+      target: {
+        value: 'https://unreinforced-ching-asthmatically.ngrok-free.dev',
+      },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(saveConfigMock).toHaveBeenCalledWith(
+        'test-token',
+        expect.objectContaining({
+          deployment: expect.objectContaining({
+            mode: 'local',
+            public_url:
+              'https://unreinforced-ching-asthmatically.ngrok-free.dev',
+            tunnel: expect.objectContaining({ provider: 'manual' }),
+          }),
+          ops: expect.objectContaining({
+            gatewayBaseUrl:
+              'https://unreinforced-ching-asthmatically.ngrok-free.dev',
+          }),
+        }),
+      );
+    });
+    expect(reconnectTunnelMock).not.toHaveBeenCalled();
+  });
+
+  it('saves managed ngrok config and starts the tunnel from the dashboard', async () => {
+    fetchOverviewMock.mockResolvedValue(
+      makeOverview(
+        makeTunnelStatus({
+          provider: 'manual',
+          publicUrl: 'https://old.ngrok-free.dev',
+          reconnectSupported: false,
+        }),
+      ),
+    );
+    fetchConfigMock.mockResolvedValue({
+      path: '/tmp/config.json',
+      config: makeConfig({
+        deployment: {
+          mode: 'local',
+          public_url: 'https://old.ngrok-free.dev',
+          tunnel: {
+            provider: 'manual',
+            health_check_interval_ms: 30000,
+          },
+        },
+      }),
+    });
+    reconnectTunnelMock.mockResolvedValue(
+      makeTunnelStatus({
+        provider: 'ngrok',
+        publicUrl: 'https://next.ngrok-free.dev',
+      }),
+    );
+
+    renderDashboardPage();
+
+    fireEvent.change(await screen.findByLabelText('Provider'), {
+      target: { value: 'ngrok' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save & start' }));
+
+    await waitFor(() => {
+      expect(saveConfigMock).toHaveBeenCalledWith(
+        'test-token',
+        expect.objectContaining({
+          deployment: expect.objectContaining({
+            mode: 'local',
+            public_url: '',
+            tunnel: expect.objectContaining({ provider: 'ngrok' }),
+          }),
+        }),
+      );
+      expect(reconnectTunnelMock).toHaveBeenCalledWith('test-token');
+    });
+    expect(
+      (
+        await screen.findByRole('link', {
+          name: 'https://next.ngrok-free.dev',
+        })
+      ).getAttribute('href'),
+    ).toBe('https://next.ngrok-free.dev');
   });
 
   it('does not repeat the same tunnel and reconnect error', async () => {

--- a/console/src/routes/dashboard.tsx
+++ b/console/src/routes/dashboard.tsx
@@ -7,6 +7,7 @@ import {
   fetchTunnelConfig,
   reconnectTunnel,
   saveTunnelConfig,
+  stopTunnel,
 } from '../api/client';
 import type {
   AdminOverview,
@@ -238,23 +239,34 @@ function TunnelStatusPanel(props: {
   configDraft: TunnelConfigDraft;
   savedConfigDraft: TunnelConfigDraft | null;
   configSavePending: boolean;
+  configStartPending: boolean;
   configSaveError: string | null;
   reconnectPending: boolean;
   reconnectError: string | null;
+  stopPending: boolean;
+  stopError: string | null;
   onConfigDraftChange: (draft: TunnelConfigDraft) => void;
   onSaveConfig: () => void;
   onSaveConfigAndStart: () => void;
   onReconnect: () => void;
+  onStop: () => void;
 }) {
   const { tunnel } = props;
   const publicUrl = tunnel.publicUrl || 'not configured';
   const reconnectDisabled =
-    props.reconnectPending || !tunnel.reconnectSupported;
+    props.reconnectPending || props.stopPending || !tunnel.reconnectSupported;
   const normalizedTunnelError = tunnel.lastError?.trim() || null;
   const normalizedReconnectError = props.reconnectError?.trim() || null;
+  const normalizedStopError = props.stopError?.trim() || null;
   const distinctReconnectError =
     props.reconnectError && normalizedReconnectError !== normalizedTunnelError
       ? props.reconnectError
+      : null;
+  const distinctStopError =
+    props.stopError &&
+    normalizedStopError !== normalizedTunnelError &&
+    normalizedStopError !== normalizedReconnectError
+      ? props.stopError
       : null;
   const configDirty = props.savedConfigDraft
     ? !isSameTunnelDraft(props.configDraft, props.savedConfigDraft)
@@ -270,8 +282,40 @@ function TunnelStatusPanel(props: {
   const configBusy =
     !props.configLoaded || props.configPending || props.configSavePending;
   const saveDisabled = configBusy || !configDirty || Boolean(publicUrlError);
+  const currentProvider = normalizeTunnelProvider(tunnel.provider);
+  const tunnelMatchesDraftProvider =
+    currentProvider === props.configDraft.provider;
+  const tunnelRunning =
+    !configDirty && tunnelMatchesDraftProvider && tunnel.state === 'up';
+  const tunnelStarting =
+    !configDirty &&
+    tunnelMatchesDraftProvider &&
+    (tunnel.state === 'starting' || tunnel.state === 'reconnecting');
+  const startPending = props.configStartPending || props.reconnectPending;
+  const tunnelActionLoading =
+    startPending || props.stopPending || tunnelStarting;
+  const tunnelActionLabel = props.stopPending
+    ? 'Stopping'
+    : startPending || tunnelStarting
+      ? 'Starting'
+      : tunnelRunning
+        ? 'Stop'
+        : configDirty
+          ? 'Save & start'
+          : 'Start';
   const startDisabled =
-    configBusy || props.reconnectPending || Boolean(publicUrlError);
+    configBusy ||
+    props.reconnectPending ||
+    props.stopPending ||
+    Boolean(publicUrlError);
+  const stopDisabled =
+    configBusy || props.reconnectPending || props.stopPending;
+  const tunnelActionDisabled = tunnelRunning ? stopDisabled : startDisabled;
+  const tunnelActionVariant =
+    tunnelRunning || props.stopPending ? 'danger' : 'default';
+  const handleTunnelAction = tunnelRunning
+    ? props.onStop
+    : props.onSaveConfigAndStart;
 
   return (
     <Card>
@@ -345,7 +389,7 @@ function TunnelStatusPanel(props: {
               type="button"
               variant="outline"
               onClick={props.onSaveConfig}
-              loading={props.configSavePending && !props.reconnectPending}
+              loading={props.configSavePending && !props.configStartPending}
               disabled={saveDisabled}
             >
               Save
@@ -353,11 +397,15 @@ function TunnelStatusPanel(props: {
             {providerCanStart ? (
               <Button
                 type="button"
-                onClick={props.onSaveConfigAndStart}
-                loading={props.configSavePending || props.reconnectPending}
-                disabled={startDisabled}
+                variant={tunnelActionVariant}
+                onClick={handleTunnelAction}
+                loading={tunnelActionLoading}
+                disabled={tunnelActionDisabled}
               >
-                {configDirty ? 'Save & start' : 'Start'}
+                {tunnelActionLoading ? (
+                  <span className="button-spinner" aria-hidden="true" />
+                ) : null}
+                {tunnelActionLabel}
               </Button>
             ) : null}
           </div>
@@ -396,6 +444,9 @@ function TunnelStatusPanel(props: {
           <p className="supporting-text tunnel-error">
             {distinctReconnectError}
           </p>
+        ) : null}
+        {distinctStopError ? (
+          <p className="supporting-text tunnel-error">{distinctStopError}</p>
         ) : null}
         {props.configSaveError ? (
           <p className="supporting-text tunnel-error">
@@ -446,6 +497,15 @@ export function DashboardPage() {
       );
     },
   });
+  const stopMutation = useMutation({
+    mutationFn: () => stopTunnel(auth.token),
+    onSuccess: (tunnel) => {
+      queryClient.setQueryData<AdminOverview>(
+        ['overview', auth.token],
+        (current) => (current ? { ...current, tunnel } : current),
+      );
+    },
+  });
   const saveTunnelConfigMutation = useMutation({
     mutationFn: async (variables: {
       draft: TunnelConfigDraft;
@@ -481,6 +541,9 @@ export function DashboardPage() {
 
   const overview = live.overview || overviewQuery.data;
   const status = live.status || overview?.status || auth.gatewayStatus;
+  const tunnelStartPending =
+    saveTunnelConfigMutation.isPending &&
+    saveTunnelConfigMutation.variables?.start === true;
   const effectiveTunnelConfigDraft = tunnelConfigDraft ??
     savedTunnelDraft ?? {
       provider: normalizeTunnelProvider(overview?.tunnel.provider),
@@ -589,6 +652,7 @@ export function DashboardPage() {
         configDraft={effectiveTunnelConfigDraft}
         savedConfigDraft={savedTunnelDraft}
         configSavePending={saveTunnelConfigMutation.isPending}
+        configStartPending={tunnelStartPending}
         configSaveError={
           saveTunnelConfigMutation.isError
             ? getErrorMessage(saveTunnelConfigMutation.error)
@@ -599,6 +663,10 @@ export function DashboardPage() {
           reconnectMutation.isError
             ? getErrorMessage(reconnectMutation.error)
             : null
+        }
+        stopPending={stopMutation.isPending}
+        stopError={
+          stopMutation.isError ? getErrorMessage(stopMutation.error) : null
         }
         onConfigDraftChange={setTunnelConfigDraft}
         onSaveConfig={() =>
@@ -614,6 +682,7 @@ export function DashboardPage() {
           })
         }
         onReconnect={() => reconnectMutation.mutate()}
+        onStop={() => stopMutation.mutate()}
       />
 
       <Card>

--- a/console/src/routes/dashboard.tsx
+++ b/console/src/routes/dashboard.tsx
@@ -335,17 +335,18 @@ function TunnelStatusPanel(props: {
             )}
           </div>
           <div className="tunnel-action-stack">
-            <button
+            <Button
               type="button"
-              className="primary-button button-with-spinner"
+              className="tunnel-action-button"
               onClick={props.onReconnect}
+              loading={props.reconnectPending}
               disabled={reconnectDisabled}
             >
               {props.reconnectPending ? (
                 <span className="button-spinner" aria-hidden="true" />
               ) : null}
               {props.reconnectPending ? 'Reconnecting' : 'Reconnect'}
-            </button>
+            </Button>
           </div>
         </div>
         <div className="tunnel-config-grid">
@@ -397,6 +398,7 @@ function TunnelStatusPanel(props: {
             {providerCanStart ? (
               <Button
                 type="button"
+                className="tunnel-action-button"
                 variant={tunnelActionVariant}
                 onClick={handleTunnelAction}
                 loading={tunnelActionLoading}

--- a/console/src/routes/dashboard.tsx
+++ b/console/src/routes/dashboard.tsx
@@ -1,9 +1,23 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { fetchOverview, fetchStatistics, reconnectTunnel } from '../api/client';
-import type { AdminOverview, AdminTunnelStatus } from '../api/types';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  fetchConfig,
+  fetchOverview,
+  fetchStatistics,
+  reconnectTunnel,
+  saveConfig,
+} from '../api/client';
+import type {
+  AdminConfig,
+  AdminOverview,
+  AdminTunnelStatus,
+} from '../api/types';
 import { useAuth } from '../auth';
+import { Button } from '../components/button';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/card';
+import { Input } from '../components/input';
+import { NativeSelect, NativeSelectOption } from '../components/native-select';
 import { ProviderHealthPanel } from '../components/provider-health';
 import {
   MetricCard,
@@ -59,6 +73,21 @@ const RECENT_SESSION_DEFAULT_DIRECTIONS = {
   lastActive: 'desc',
 } as const;
 
+const TUNNEL_PROVIDER_OPTIONS = [
+  { value: 'manual', label: 'Manual URL' },
+  { value: 'ngrok', label: 'ngrok' },
+  { value: 'tailscale', label: 'Tailscale Funnel' },
+  { value: 'cloudflare', label: 'Cloudflare Tunnel' },
+  { value: 'ssh', label: 'SSH tunnel' },
+] as const;
+
+type TunnelProvider = (typeof TUNNEL_PROVIDER_OPTIONS)[number]['value'];
+
+interface TunnelConfigDraft {
+  provider: TunnelProvider;
+  publicUrl: string;
+}
+
 const TREND_DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
   month: 'short',
   day: 'numeric',
@@ -86,10 +115,113 @@ function tunnelStatusDotClass(health: AdminTunnelStatus['health']): string {
   return 'status-dot status-dot-danger';
 }
 
+function normalizeTunnelProvider(
+  value: string | null | undefined,
+): TunnelProvider {
+  if (value === 'ngrok') return 'ngrok';
+  if (value === 'tailscale') return 'tailscale';
+  if (value === 'cloudflare') return 'cloudflare';
+  if (value === 'ssh') return 'ssh';
+  return 'manual';
+}
+
+function normalizeTunnelUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  try {
+    return new URL(trimmed).toString().replace(/\/$/, '');
+  } catch {
+    return trimmed;
+  }
+}
+
+function tunnelDraftFromConfig(config: AdminConfig): TunnelConfigDraft {
+  return {
+    provider: normalizeTunnelProvider(config.deployment.tunnel.provider),
+    publicUrl: config.deployment.public_url || '',
+  };
+}
+
+function isManagedTunnelProvider(provider: TunnelProvider): boolean {
+  return (
+    provider === 'ngrok' ||
+    provider === 'tailscale' ||
+    provider === 'cloudflare'
+  );
+}
+
+function usesConfiguredPublicUrl(provider: TunnelProvider): boolean {
+  return (
+    provider === 'manual' || provider === 'ssh' || provider === 'cloudflare'
+  );
+}
+
+function isSameTunnelDraft(left: TunnelConfigDraft, right: TunnelConfigDraft) {
+  return (
+    left.provider === right.provider &&
+    normalizeTunnelUrl(left.publicUrl) === normalizeTunnelUrl(right.publicUrl)
+  );
+}
+
+function applyTunnelDraft(
+  config: AdminConfig,
+  draft: TunnelConfigDraft,
+): AdminConfig {
+  const publicUrl = usesConfiguredPublicUrl(draft.provider)
+    ? normalizeTunnelUrl(draft.publicUrl)
+    : '';
+  return {
+    ...config,
+    deployment: {
+      ...config.deployment,
+      mode: 'local',
+      public_url: publicUrl,
+      tunnel: {
+        ...config.deployment.tunnel,
+        provider: draft.provider,
+      },
+    },
+    ops: {
+      ...config.ops,
+      ...(publicUrl ? { gatewayBaseUrl: publicUrl } : {}),
+    },
+  };
+}
+
+function tunnelStatusFromDraft(
+  current: AdminTunnelStatus,
+  draft: TunnelConfigDraft,
+): AdminTunnelStatus {
+  const publicUrl = usesConfiguredPublicUrl(draft.provider)
+    ? normalizeTunnelUrl(draft.publicUrl) || null
+    : null;
+  const manualProvider = !isManagedTunnelProvider(draft.provider);
+  const state = manualProvider && publicUrl ? 'up' : 'down';
+  return {
+    ...current,
+    provider: draft.provider,
+    publicUrl,
+    state,
+    health: state === 'up' ? 'healthy' : 'down',
+    reconnectSupported: isManagedTunnelProvider(draft.provider),
+    lastError: null,
+    nextReconnectAt: null,
+  };
+}
+
 function TunnelStatusPanel(props: {
   tunnel: AdminTunnelStatus;
+  configLoaded: boolean;
+  configPending: boolean;
+  configDraft: TunnelConfigDraft;
+  savedConfigDraft: TunnelConfigDraft | null;
+  configSavePending: boolean;
+  configSaveError: string | null;
   reconnectPending: boolean;
   reconnectError: string | null;
+  onConfigDraftChange: (draft: TunnelConfigDraft) => void;
+  onSaveConfig: () => void;
+  onSaveConfigAndStart: () => void;
   onReconnect: () => void;
 }) {
   const { tunnel } = props;
@@ -102,6 +234,27 @@ function TunnelStatusPanel(props: {
     props.reconnectError && normalizedReconnectError !== normalizedTunnelError
       ? props.reconnectError
       : null;
+  const configDirty = props.savedConfigDraft
+    ? !isSameTunnelDraft(props.configDraft, props.savedConfigDraft)
+    : false;
+  const providerUsesPublicUrl = usesConfiguredPublicUrl(
+    props.configDraft.provider,
+  );
+  const providerCanStart = isManagedTunnelProvider(props.configDraft.provider);
+  const publicUrlMissing =
+    props.configDraft.provider === 'cloudflare' &&
+    !normalizeTunnelUrl(props.configDraft.publicUrl);
+  const saveDisabled =
+    !props.configLoaded ||
+    props.configPending ||
+    props.configSavePending ||
+    !configDirty;
+  const startDisabled =
+    !props.configLoaded ||
+    props.configPending ||
+    props.configSavePending ||
+    props.reconnectPending ||
+    publicUrlMissing;
 
   return (
     <Card>
@@ -134,6 +287,64 @@ function TunnelStatusPanel(props: {
             </button>
           </div>
         </div>
+        <div className="tunnel-config-grid">
+          <label className="tunnel-control">
+            <span>Provider</span>
+            <NativeSelect
+              value={props.configDraft.provider}
+              disabled={props.configPending || props.configSavePending}
+              onChange={(event) =>
+                props.onConfigDraftChange({
+                  ...props.configDraft,
+                  provider: normalizeTunnelProvider(event.target.value),
+                })
+              }
+            >
+              {TUNNEL_PROVIDER_OPTIONS.map((option) => (
+                <NativeSelectOption key={option.value} value={option.value}>
+                  {option.label}
+                </NativeSelectOption>
+              ))}
+            </NativeSelect>
+          </label>
+          {providerUsesPublicUrl ? (
+            <label className="tunnel-control">
+              <span>Public URL</span>
+              <Input
+                value={props.configDraft.publicUrl}
+                placeholder="https://example.ngrok-free.dev"
+                disabled={props.configPending || props.configSavePending}
+                onChange={(event) =>
+                  props.onConfigDraftChange({
+                    ...props.configDraft,
+                    publicUrl: event.target.value,
+                  })
+                }
+              />
+            </label>
+          ) : null}
+          <div className="tunnel-config-actions">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={props.onSaveConfig}
+              loading={props.configSavePending && !props.reconnectPending}
+              disabled={saveDisabled}
+            >
+              Save
+            </Button>
+            {providerCanStart ? (
+              <Button
+                type="button"
+                onClick={props.onSaveConfigAndStart}
+                loading={props.configSavePending || props.reconnectPending}
+                disabled={startDisabled}
+              >
+                {configDirty ? 'Save & start' : 'Start'}
+              </Button>
+            ) : null}
+          </div>
+        </div>
         <div className="tunnel-detail-grid">
           <div className="tunnel-detail">
             <span>Provider</span>
@@ -163,6 +374,11 @@ function TunnelStatusPanel(props: {
             {distinctReconnectError}
           </p>
         ) : null}
+        {props.configSaveError ? (
+          <p className="supporting-text tunnel-error">
+            {props.configSaveError}
+          </p>
+        ) : null}
       </CardContent>
     </Card>
   );
@@ -184,6 +400,22 @@ export function DashboardPage() {
     queryFn: () => fetchStatistics(auth.token, 30),
     staleTime: 60_000,
   });
+  const configQuery = useQuery({
+    queryKey: ['config', auth.token],
+    queryFn: () => fetchConfig(auth.token),
+    staleTime: 30_000,
+  });
+  const savedTunnelDraft = useMemo(
+    () =>
+      configQuery.data ? tunnelDraftFromConfig(configQuery.data.config) : null,
+    [configQuery.data],
+  );
+  const [tunnelConfigDraft, setTunnelConfigDraft] =
+    useState<TunnelConfigDraft | null>(null);
+  useEffect(() => {
+    if (!savedTunnelDraft) return;
+    setTunnelConfigDraft((current) => current ?? savedTunnelDraft);
+  }, [savedTunnelDraft]);
   const reconnectMutation = useMutation({
     mutationFn: () => reconnectTunnel(auth.token),
     onSuccess: (tunnel) => {
@@ -193,9 +425,46 @@ export function DashboardPage() {
       );
     },
   });
+  const saveTunnelConfigMutation = useMutation({
+    mutationFn: async (variables: {
+      draft: TunnelConfigDraft;
+      start: boolean;
+    }) => {
+      const currentConfig = configQuery.data?.config;
+      if (!currentConfig) {
+        throw new Error('Runtime config is not loaded.');
+      }
+      const nextConfig = applyTunnelDraft(currentConfig, variables.draft);
+      const payload = await saveConfig(auth.token, nextConfig);
+      const tunnel =
+        variables.start && isManagedTunnelProvider(variables.draft.provider)
+          ? await reconnectTunnel(auth.token)
+          : null;
+      return { payload, tunnel, draft: variables.draft };
+    },
+    onSuccess: ({ payload, tunnel, draft }) => {
+      queryClient.setQueryData(['config', auth.token], payload);
+      setTunnelConfigDraft(tunnelDraftFromConfig(payload.config));
+      queryClient.setQueryData<AdminOverview>(
+        ['overview', auth.token],
+        (current) =>
+          current
+            ? {
+                ...current,
+                tunnel: tunnel ?? tunnelStatusFromDraft(current.tunnel, draft),
+              }
+            : current,
+      );
+    },
+  });
 
   const overview = live.overview || overviewQuery.data;
   const status = live.status || overview?.status || auth.gatewayStatus;
+  const effectiveTunnelConfigDraft = tunnelConfigDraft ??
+    savedTunnelDraft ?? {
+      provider: normalizeTunnelProvider(overview?.tunnel.provider),
+      publicUrl: overview?.tunnel.publicUrl ?? '',
+    };
   const {
     sortedRows: recentSessions,
     sortState,
@@ -294,11 +563,34 @@ export function DashboardPage() {
 
       <TunnelStatusPanel
         tunnel={overview.tunnel}
+        configLoaded={Boolean(configQuery.data)}
+        configPending={configQuery.isLoading}
+        configDraft={effectiveTunnelConfigDraft}
+        savedConfigDraft={savedTunnelDraft}
+        configSavePending={saveTunnelConfigMutation.isPending}
+        configSaveError={
+          saveTunnelConfigMutation.isError
+            ? getErrorMessage(saveTunnelConfigMutation.error)
+            : null
+        }
         reconnectPending={reconnectMutation.isPending}
         reconnectError={
           reconnectMutation.isError
             ? getErrorMessage(reconnectMutation.error)
             : null
+        }
+        onConfigDraftChange={setTunnelConfigDraft}
+        onSaveConfig={() =>
+          saveTunnelConfigMutation.mutate({
+            draft: effectiveTunnelConfigDraft,
+            start: false,
+          })
+        }
+        onSaveConfigAndStart={() =>
+          saveTunnelConfigMutation.mutate({
+            draft: effectiveTunnelConfigDraft,
+            start: true,
+          })
         }
         onReconnect={() => reconnectMutation.mutate()}
       />

--- a/console/src/routes/dashboard.tsx
+++ b/console/src/routes/dashboard.tsx
@@ -1,16 +1,17 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
-  fetchConfig,
   fetchOverview,
   fetchStatistics,
+  fetchTunnelConfig,
   reconnectTunnel,
-  saveConfig,
+  saveTunnelConfig,
 } from '../api/client';
 import type {
-  AdminConfig,
   AdminOverview,
+  AdminTunnelConfig,
+  AdminTunnelProvider,
   AdminTunnelStatus,
 } from '../api/types';
 import { useAuth } from '../auth';
@@ -73,15 +74,55 @@ const RECENT_SESSION_DEFAULT_DIRECTIONS = {
   lastActive: 'desc',
 } as const;
 
-const TUNNEL_PROVIDER_OPTIONS = [
-  { value: 'manual', label: 'Manual URL' },
-  { value: 'ngrok', label: 'ngrok' },
-  { value: 'tailscale', label: 'Tailscale Funnel' },
-  { value: 'cloudflare', label: 'Cloudflare Tunnel' },
-  { value: 'ssh', label: 'SSH tunnel' },
-] as const;
+const TUNNEL_PROVIDER_META = {
+  manual: {
+    label: 'Manual URL',
+    managed: false,
+    usesConfiguredPublicUrl: true,
+    requiresPublicUrl: false,
+  },
+  ngrok: {
+    label: 'ngrok',
+    managed: true,
+    usesConfiguredPublicUrl: false,
+    requiresPublicUrl: false,
+  },
+  tailscale: {
+    label: 'Tailscale Funnel',
+    managed: true,
+    usesConfiguredPublicUrl: false,
+    requiresPublicUrl: false,
+  },
+  cloudflare: {
+    label: 'Cloudflare Tunnel',
+    managed: true,
+    usesConfiguredPublicUrl: true,
+    requiresPublicUrl: true,
+  },
+  ssh: {
+    label: 'SSH tunnel',
+    managed: false,
+    usesConfiguredPublicUrl: true,
+    requiresPublicUrl: false,
+  },
+} as const satisfies Record<
+  AdminTunnelProvider,
+  {
+    label: string;
+    managed: boolean;
+    usesConfiguredPublicUrl: boolean;
+    requiresPublicUrl: boolean;
+  }
+>;
 
-type TunnelProvider = (typeof TUNNEL_PROVIDER_OPTIONS)[number]['value'];
+const TUNNEL_PROVIDER_OPTIONS = Object.entries(TUNNEL_PROVIDER_META).map(
+  ([value, meta]) => ({
+    value: value as AdminTunnelProvider,
+    label: meta.label,
+  }),
+);
+
+type TunnelProvider = AdminTunnelProvider;
 
 interface TunnelConfigDraft {
   provider: TunnelProvider;
@@ -115,13 +156,14 @@ function tunnelStatusDotClass(health: AdminTunnelStatus['health']): string {
   return 'status-dot status-dot-danger';
 }
 
+function isTunnelProvider(value: string): value is TunnelProvider {
+  return Object.hasOwn(TUNNEL_PROVIDER_META, value);
+}
+
 function normalizeTunnelProvider(
   value: string | null | undefined,
 ): TunnelProvider {
-  if (value === 'ngrok') return 'ngrok';
-  if (value === 'tailscale') return 'tailscale';
-  if (value === 'cloudflare') return 'cloudflare';
-  if (value === 'ssh') return 'ssh';
+  if (value && isTunnelProvider(value)) return value;
   return 'manual';
 }
 
@@ -135,25 +177,19 @@ function normalizeTunnelUrl(value: string): string {
   }
 }
 
-function tunnelDraftFromConfig(config: AdminConfig): TunnelConfigDraft {
+function tunnelDraftFromConfig(config: AdminTunnelConfig): TunnelConfigDraft {
   return {
-    provider: normalizeTunnelProvider(config.deployment.tunnel.provider),
-    publicUrl: config.deployment.public_url || '',
+    provider: normalizeTunnelProvider(config.provider),
+    publicUrl: config.publicUrl || '',
   };
 }
 
 function isManagedTunnelProvider(provider: TunnelProvider): boolean {
-  return (
-    provider === 'ngrok' ||
-    provider === 'tailscale' ||
-    provider === 'cloudflare'
-  );
+  return TUNNEL_PROVIDER_META[provider].managed;
 }
 
 function usesConfiguredPublicUrl(provider: TunnelProvider): boolean {
-  return (
-    provider === 'manual' || provider === 'ssh' || provider === 'cloudflare'
-  );
+  return TUNNEL_PROVIDER_META[provider].usesConfiguredPublicUrl;
 }
 
 function isSameTunnelDraft(left: TunnelConfigDraft, right: TunnelConfigDraft) {
@@ -163,50 +199,36 @@ function isSameTunnelDraft(left: TunnelConfigDraft, right: TunnelConfigDraft) {
   );
 }
 
-function applyTunnelDraft(
-  config: AdminConfig,
-  draft: TunnelConfigDraft,
-): AdminConfig {
-  const publicUrl = usesConfiguredPublicUrl(draft.provider)
-    ? normalizeTunnelUrl(draft.publicUrl)
-    : '';
-  return {
-    ...config,
-    deployment: {
-      ...config.deployment,
-      mode: 'local',
-      public_url: publicUrl,
-      tunnel: {
-        ...config.deployment.tunnel,
-        provider: draft.provider,
-      },
-    },
-    ops: {
-      ...config.ops,
-      ...(publicUrl ? { gatewayBaseUrl: publicUrl } : {}),
-    },
-  };
+function getTunnelUrlValidation(draft: TunnelConfigDraft): string | null {
+  const meta = TUNNEL_PROVIDER_META[draft.provider];
+  if (!meta.usesConfiguredPublicUrl) return null;
+  const publicUrl = draft.publicUrl.trim();
+  if (!publicUrl) {
+    return meta.requiresPublicUrl
+      ? 'Public URL is required for Cloudflare Tunnel.'
+      : null;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(publicUrl);
+  } catch {
+    return 'Public URL must be a valid URL.';
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    return 'Public URL must use http:// or https://.';
+  }
+  return null;
 }
 
-function tunnelStatusFromDraft(
-  current: AdminTunnelStatus,
-  draft: TunnelConfigDraft,
-): AdminTunnelStatus {
-  const publicUrl = usesConfiguredPublicUrl(draft.provider)
-    ? normalizeTunnelUrl(draft.publicUrl) || null
-    : null;
-  const manualProvider = !isManagedTunnelProvider(draft.provider);
-  const state = manualProvider && publicUrl ? 'up' : 'down';
-  return {
-    ...current,
-    provider: draft.provider,
-    publicUrl,
-    state,
-    health: state === 'up' ? 'healthy' : 'down',
-    reconnectSupported: isManagedTunnelProvider(draft.provider),
-    lastError: null,
-    nextReconnectAt: null,
-  };
+function usesHttpTunnelUrl(draft: TunnelConfigDraft): boolean {
+  if (!usesConfiguredPublicUrl(draft.provider)) return false;
+  try {
+    return new URL(draft.publicUrl.trim()).protocol === 'http:';
+  } catch {
+    return false;
+  }
 }
 
 function TunnelStatusPanel(props: {
@@ -241,20 +263,15 @@ function TunnelStatusPanel(props: {
     props.configDraft.provider,
   );
   const providerCanStart = isManagedTunnelProvider(props.configDraft.provider);
-  const publicUrlMissing =
-    props.configDraft.provider === 'cloudflare' &&
-    !normalizeTunnelUrl(props.configDraft.publicUrl);
-  const saveDisabled =
-    !props.configLoaded ||
-    props.configPending ||
-    props.configSavePending ||
-    !configDirty;
+  const publicUrlError = getTunnelUrlValidation(props.configDraft);
+  const publicUrlWarning = usesHttpTunnelUrl(props.configDraft)
+    ? 'Public tunnel URL uses HTTP. HTTPS is recommended.'
+    : null;
+  const configBusy =
+    !props.configLoaded || props.configPending || props.configSavePending;
+  const saveDisabled = configBusy || !configDirty || Boolean(publicUrlError);
   const startDisabled =
-    !props.configLoaded ||
-    props.configPending ||
-    props.configSavePending ||
-    props.reconnectPending ||
-    publicUrlMissing;
+    configBusy || props.reconnectPending || Boolean(publicUrlError);
 
   return (
     <Card>
@@ -345,6 +362,12 @@ function TunnelStatusPanel(props: {
             ) : null}
           </div>
         </div>
+        {publicUrlError ? (
+          <p className="supporting-text tunnel-error">{publicUrlError}</p>
+        ) : null}
+        {publicUrlWarning ? (
+          <p className="supporting-text tunnel-warning">{publicUrlWarning}</p>
+        ) : null}
         <div className="tunnel-detail-grid">
           <div className="tunnel-detail">
             <span>Provider</span>
@@ -400,22 +423,20 @@ export function DashboardPage() {
     queryFn: () => fetchStatistics(auth.token, 30),
     staleTime: 60_000,
   });
-  const configQuery = useQuery({
-    queryKey: ['config', auth.token],
-    queryFn: () => fetchConfig(auth.token),
+  const tunnelConfigQuery = useQuery({
+    queryKey: ['tunnel-config', auth.token],
+    queryFn: () => fetchTunnelConfig(auth.token),
     staleTime: 30_000,
   });
   const savedTunnelDraft = useMemo(
     () =>
-      configQuery.data ? tunnelDraftFromConfig(configQuery.data.config) : null,
-    [configQuery.data],
+      tunnelConfigQuery.data
+        ? tunnelDraftFromConfig(tunnelConfigQuery.data.config)
+        : null,
+    [tunnelConfigQuery.data],
   );
   const [tunnelConfigDraft, setTunnelConfigDraft] =
     useState<TunnelConfigDraft | null>(null);
-  useEffect(() => {
-    if (!savedTunnelDraft) return;
-    setTunnelConfigDraft((current) => current ?? savedTunnelDraft);
-  }, [savedTunnelDraft]);
   const reconnectMutation = useMutation({
     mutationFn: () => reconnectTunnel(auth.token),
     onSuccess: (tunnel) => {
@@ -430,31 +451,31 @@ export function DashboardPage() {
       draft: TunnelConfigDraft;
       start: boolean;
     }) => {
-      const currentConfig = configQuery.data?.config;
-      if (!currentConfig) {
-        throw new Error('Runtime config is not loaded.');
-      }
-      const nextConfig = applyTunnelDraft(currentConfig, variables.draft);
-      const payload = await saveConfig(auth.token, nextConfig);
+      const payload = await saveTunnelConfig(auth.token, {
+        provider: variables.draft.provider,
+        publicUrl: usesConfiguredPublicUrl(variables.draft.provider)
+          ? normalizeTunnelUrl(variables.draft.publicUrl)
+          : '',
+      });
       const tunnel =
         variables.start && isManagedTunnelProvider(variables.draft.provider)
           ? await reconnectTunnel(auth.token)
           : null;
-      return { payload, tunnel, draft: variables.draft };
+      return { payload, tunnel };
     },
-    onSuccess: ({ payload, tunnel, draft }) => {
-      queryClient.setQueryData(['config', auth.token], payload);
-      setTunnelConfigDraft(tunnelDraftFromConfig(payload.config));
-      queryClient.setQueryData<AdminOverview>(
-        ['overview', auth.token],
-        (current) =>
-          current
-            ? {
-                ...current,
-                tunnel: tunnel ?? tunnelStatusFromDraft(current.tunnel, draft),
-              }
-            : current,
-      );
+    onSuccess: ({ payload, tunnel }) => {
+      queryClient.setQueryData(['tunnel-config', auth.token], payload);
+      setTunnelConfigDraft(null);
+      if (tunnel) {
+        queryClient.setQueryData<AdminOverview>(
+          ['overview', auth.token],
+          (current) => (current ? { ...current, tunnel } : current),
+        );
+        return;
+      }
+      void queryClient.invalidateQueries({
+        queryKey: ['overview', auth.token],
+      });
     },
   });
 
@@ -563,8 +584,8 @@ export function DashboardPage() {
 
       <TunnelStatusPanel
         tunnel={overview.tunnel}
-        configLoaded={Boolean(configQuery.data)}
-        configPending={configQuery.isLoading}
+        configLoaded={Boolean(tunnelConfigQuery.data)}
+        configPending={tunnelConfigQuery.isLoading}
         configDraft={effectiveTunnelConfigDraft}
         savedConfigDraft={savedTunnelDraft}
         configSavePending={saveTunnelConfigMutation.isPending}

--- a/console/src/styles.css
+++ b/console/src/styles.css
@@ -1876,6 +1876,7 @@ code {
 .tunnel-config-actions {
   display: flex;
   justify-content: end;
+  grid-column: 3;
   gap: 8px;
 }
 
@@ -1887,6 +1888,11 @@ code {
 .tunnel-error {
   margin-top: 14px;
   color: var(--danger);
+}
+
+.tunnel-warning {
+  margin-top: 14px;
+  color: var(--tone-review);
 }
 
 .selectable-row {
@@ -3995,6 +4001,7 @@ th {
   }
 
   .tunnel-config-actions {
+    grid-column: auto;
     justify-content: start;
   }
 

--- a/console/src/styles.css
+++ b/console/src/styles.css
@@ -1855,6 +1855,10 @@ code {
   justify-items: end;
 }
 
+.tunnel-action-button {
+  width: 128px;
+}
+
 .tunnel-config-grid {
   margin-top: 18px;
   grid-template-columns: minmax(180px, 0.35fr) minmax(280px, 1fr) auto;
@@ -4050,6 +4054,10 @@ th {
 
   .tunnel-config-actions {
     flex-direction: column;
+  }
+
+  .tunnel-action-button {
+    width: 100%;
   }
 
   .output-guard-model-source-control {

--- a/console/src/styles.css
+++ b/console/src/styles.css
@@ -1811,6 +1811,7 @@ code {
 }
 
 .tunnel-panel-grid,
+.tunnel-config-grid,
 .tunnel-detail-grid {
   display: grid;
   gap: 16px;
@@ -1852,6 +1853,30 @@ code {
 
 .tunnel-action-stack {
   justify-items: end;
+}
+
+.tunnel-config-grid {
+  margin-top: 18px;
+  grid-template-columns: minmax(180px, 0.35fr) minmax(280px, 1fr) auto;
+  align-items: end;
+}
+
+.tunnel-control {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.tunnel-control span {
+  color: var(--muted-foreground);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.tunnel-config-actions {
+  display: flex;
+  justify-content: end;
+  gap: 8px;
 }
 
 .tunnel-detail-grid {
@@ -3965,6 +3990,14 @@ th {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  .tunnel-config-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .tunnel-config-actions {
+    justify-content: start;
+  }
+
   .jobs-board-layout {
     grid-template-columns: 1fr;
   }
@@ -3998,12 +4031,18 @@ th {
   }
 
   .tunnel-panel-grid,
+  .tunnel-config-grid,
   .tunnel-detail-grid {
     grid-template-columns: 1fr;
   }
 
-  .tunnel-action-stack {
+  .tunnel-action-stack,
+  .tunnel-config-actions {
     justify-items: stretch;
+  }
+
+  .tunnel-config-actions {
+    flex-direction: column;
   }
 
   .output-guard-model-source-control {

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -279,6 +279,7 @@ import {
   setGatewayAdminSkillEnabled,
   startGatewayAdminA2APairing,
   startGatewayAdminMcpOAuth,
+  stopGatewayAdminTunnel,
   unblockGatewayAdminSkill,
   updateGatewayAdminAgent,
   uploadGatewayAdminSkillZip,
@@ -4158,6 +4159,10 @@ async function handleApiAdminTunnelReconnect(
   sendJson(res, 200, { tunnel: await reconnectGatewayAdminTunnel() });
 }
 
+async function handleApiAdminTunnelStop(res: ServerResponse): Promise<void> {
+  sendJson(res, 200, { tunnel: await stopGatewayAdminTunnel() });
+}
+
 async function handleApiAdminTunnelConfig(
   req: IncomingMessage,
   res: ServerResponse,
@@ -7287,6 +7292,18 @@ export function startGatewayHttpServer(): GatewayHttpServer {
           }
           if (pathname === '/api/admin/tunnel/reconnect' && method === 'POST') {
             await handleApiAdminTunnelReconnect(res);
+            return;
+          }
+          if (pathname === '/api/admin/tunnel/reconnect') {
+            sendMethodNotAllowed(res);
+            return;
+          }
+          if (pathname === '/api/admin/tunnel/stop' && method === 'POST') {
+            await handleApiAdminTunnelStop(res);
+            return;
+          }
+          if (pathname === '/api/admin/tunnel/stop') {
+            sendMethodNotAllowed(res);
             return;
           }
           if (pathname === '/api/admin/statistics' && method === 'GET') {

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -248,6 +248,7 @@ import {
   getGatewayAdminTeamStructure,
   getGatewayAdminTeamStructureRevision,
   getGatewayAdminTools,
+  getGatewayAdminTunnelConfig,
   getGatewayAgentList,
   getGatewayAgents,
   getGatewayBootstrapAutostartState,
@@ -274,6 +275,7 @@ import {
   saveGatewayAdminPolicyRule,
   saveGatewayAdminSkillPackageFile,
   saveGatewayAdminSlackWebhookTarget,
+  saveGatewayAdminTunnelConfig,
   setGatewayAdminSkillEnabled,
   startGatewayAdminA2APairing,
   startGatewayAdminMcpOAuth,
@@ -4156,6 +4158,19 @@ async function handleApiAdminTunnelReconnect(
   sendJson(res, 200, { tunnel: await reconnectGatewayAdminTunnel() });
 }
 
+async function handleApiAdminTunnelConfig(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  if ((req.method || 'GET') === 'GET') {
+    sendJson(res, 200, getGatewayAdminTunnelConfig());
+    return;
+  }
+
+  const body = await readJsonBody(req);
+  sendJson(res, 200, saveGatewayAdminTunnelConfig(body));
+}
+
 function handleApiAdminStatistics(res: ServerResponse, url: URL): void {
   const daysRaw = url.searchParams.get('days') ?? undefined;
   sendJson(res, 200, getGatewayAdminStatistics({ days: daysRaw }));
@@ -7256,6 +7271,17 @@ export function startGatewayHttpServer(): GatewayHttpServer {
             return;
           }
           if (pathname === '/api/admin/secrets') {
+            sendMethodNotAllowed(res);
+            return;
+          }
+          if (
+            pathname === '/api/admin/tunnel' &&
+            (method === 'GET' || method === 'PUT')
+          ) {
+            await handleApiAdminTunnelConfig(req, res);
+            return;
+          }
+          if (pathname === '/api/admin/tunnel') {
             sendMethodNotAllowed(res);
             return;
           }

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -514,8 +514,10 @@ import {
   parseTimestamp,
 } from './gateway-time.js';
 import {
+  getGatewayAdminTunnelConfig,
   getGatewayAdminTunnelStatus,
   reconnectGatewayAdminTunnel,
+  saveGatewayAdminTunnelConfig,
 } from './gateway-tunnel-service.js';
 import {
   type GatewayAdminA2AInboxResponse,
@@ -618,7 +620,11 @@ import {
 } from './show-mode.js';
 import { handleSkillCommand } from './skill-commands.js';
 
-export { reconnectGatewayAdminTunnel };
+export {
+  getGatewayAdminTunnelConfig,
+  reconnectGatewayAdminTunnel,
+  saveGatewayAdminTunnelConfig,
+};
 
 initializeGoalContinuationRunner();
 

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -518,6 +518,7 @@ import {
   getGatewayAdminTunnelStatus,
   reconnectGatewayAdminTunnel,
   saveGatewayAdminTunnelConfig,
+  stopGatewayAdminTunnel,
 } from './gateway-tunnel-service.js';
 import {
   type GatewayAdminA2AInboxResponse,
@@ -624,6 +625,7 @@ export {
   getGatewayAdminTunnelConfig,
   reconnectGatewayAdminTunnel,
   saveGatewayAdminTunnelConfig,
+  stopGatewayAdminTunnel,
 };
 
 initializeGoalContinuationRunner();

--- a/src/gateway/gateway-tunnel-service.ts
+++ b/src/gateway/gateway-tunnel-service.ts
@@ -1,7 +1,10 @@
 import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
 import {
   getRuntimeConfig,
+  RUNTIME_DEPLOYMENT_TUNNEL_PROVIDERS,
+  type RuntimeDeploymentKnownTunnelProvider,
   type RuntimeDeploymentTunnelProvider,
+  updateRuntimeConfig,
 } from '../config/runtime-config.js';
 import { GatewayRequestError } from '../errors/gateway-request-error.js';
 import { createCloudflareTunnelProvider } from '../tunnel/cloudflare-tunnel-provider.js';
@@ -17,6 +20,8 @@ import {
   errorMessage,
 } from '../tunnel/tunnel-provider-utils.js';
 import type {
+  GatewayAdminTunnelConfig,
+  GatewayAdminTunnelConfigResponse,
   GatewayAdminTunnelHealth,
   GatewayAdminTunnelStatus,
 } from './gateway-types.js';
@@ -25,8 +30,109 @@ let managedProvider: TunnelProvider | null = null;
 let managedProviderKey: string | null = null;
 let reconnectInFlight: Promise<GatewayAdminTunnelStatus> | null = null;
 
+const TUNNEL_PROVIDER_META = {
+  cloudflare: {
+    managed: true,
+    usesConfiguredPublicUrl: true,
+    requiresPublicUrl: true,
+  },
+  manual: {
+    managed: false,
+    usesConfiguredPublicUrl: true,
+    requiresPublicUrl: false,
+  },
+  ngrok: {
+    managed: true,
+    usesConfiguredPublicUrl: false,
+    requiresPublicUrl: false,
+  },
+  ssh: {
+    managed: false,
+    usesConfiguredPublicUrl: true,
+    requiresPublicUrl: false,
+  },
+  tailscale: {
+    managed: true,
+    usesConfiguredPublicUrl: false,
+    requiresPublicUrl: false,
+  },
+} as const satisfies Record<
+  RuntimeDeploymentKnownTunnelProvider,
+  {
+    managed: boolean;
+    usesConfiguredPublicUrl: boolean;
+    requiresPublicUrl: boolean;
+  }
+>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 function normalizePublicUrl(value: string | null | undefined): string | null {
   return value?.trim() || null;
+}
+
+function normalizeConfigPublicUrl(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value !== 'string') {
+    throw new GatewayRequestError(400, 'publicUrl must be a string.');
+  }
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new GatewayRequestError(400, 'publicUrl must be a valid URL.');
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new GatewayRequestError(
+      400,
+      'publicUrl must use http:// or https://.',
+    );
+  }
+  return url.toString().replace(/\/$/, '');
+}
+
+function normalizeKnownTunnelProvider(
+  value: unknown,
+): RuntimeDeploymentKnownTunnelProvider {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new GatewayRequestError(400, 'provider is required.');
+  }
+  const normalized = value.trim().toLowerCase();
+  if (
+    !(RUNTIME_DEPLOYMENT_TUNNEL_PROVIDERS as readonly string[]).includes(
+      normalized,
+    )
+  ) {
+    throw new GatewayRequestError(400, 'provider is not supported.');
+  }
+  return normalized as RuntimeDeploymentKnownTunnelProvider;
+}
+
+function getKnownTunnelProvider(
+  value: RuntimeDeploymentTunnelProvider | undefined,
+): RuntimeDeploymentKnownTunnelProvider | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().toLowerCase();
+  if (
+    (RUNTIME_DEPLOYMENT_TUNNEL_PROVIDERS as readonly string[]).includes(
+      normalized,
+    )
+  ) {
+    return normalized as RuntimeDeploymentKnownTunnelProvider;
+  }
+  return null;
+}
+
+function isManagedTunnelProvider(
+  provider: RuntimeDeploymentTunnelProvider | undefined,
+): boolean {
+  const knownProvider = getKnownTunnelProvider(provider);
+  return knownProvider ? TUNNEL_PROVIDER_META[knownProvider].managed : false;
 }
 
 function tunnelHealthForState(state: TunnelState): GatewayAdminTunnelHealth {
@@ -70,11 +176,7 @@ function stopStaleManagedProvider(provider: TunnelProvider): void {
 function getManagedTunnelProvider(): TunnelProvider | null {
   const config = getRuntimeConfig();
   const provider = config.deployment.tunnel.provider;
-  if (
-    provider !== 'ngrok' &&
-    provider !== 'tailscale' &&
-    provider !== 'cloudflare'
-  ) {
+  if (!isManagedTunnelProvider(provider)) {
     if (managedProvider) {
       stopStaleManagedProvider(managedProvider);
     }
@@ -137,13 +239,20 @@ function mapTunnelStatus(params: {
     publicUrl,
     state,
     health: tunnelHealthForState(state),
-    reconnectSupported:
-      params.provider === 'ngrok' ||
-      params.provider === 'tailscale' ||
-      params.provider === 'cloudflare',
+    reconnectSupported: isManagedTunnelProvider(params.provider),
     lastError: params.managedStatus?.last_error ?? null,
     lastCheckedAt: params.managedStatus?.last_checked_at ?? null,
     nextReconnectAt: params.managedStatus?.next_reconnect_at ?? null,
+  };
+}
+
+function mapTunnelConfig(): GatewayAdminTunnelConfig {
+  const config = getRuntimeConfig();
+  return {
+    mode: config.deployment.mode,
+    provider: config.deployment.tunnel.provider ?? null,
+    publicUrl: normalizePublicUrl(config.deployment.public_url) ?? '',
+    healthCheckIntervalMs: config.deployment.tunnel.health_check_interval_ms,
   };
 }
 
@@ -157,6 +266,49 @@ export function getGatewayAdminTunnelStatus(): GatewayAdminTunnelStatus {
     configuredPublicUrl: normalizePublicUrl(config.deployment.public_url),
     managedStatus,
   });
+}
+
+export function getGatewayAdminTunnelConfig(): GatewayAdminTunnelConfigResponse {
+  return {
+    config: mapTunnelConfig(),
+    tunnel: getGatewayAdminTunnelStatus(),
+  };
+}
+
+export function saveGatewayAdminTunnelConfig(
+  input: unknown,
+): GatewayAdminTunnelConfigResponse {
+  if (!isRecord(input)) {
+    throw new GatewayRequestError(
+      400,
+      'Expected tunnel config request object.',
+    );
+  }
+
+  const provider = normalizeKnownTunnelProvider(input.provider);
+  const meta = TUNNEL_PROVIDER_META[provider];
+  const publicUrl = meta.usesConfiguredPublicUrl
+    ? normalizeConfigPublicUrl(input.publicUrl)
+    : '';
+  if (meta.requiresPublicUrl && !publicUrl) {
+    throw new GatewayRequestError(
+      400,
+      'publicUrl is required for this tunnel provider.',
+    );
+  }
+
+  updateRuntimeConfig(
+    (draft) => {
+      draft.deployment.public_url = publicUrl;
+      draft.deployment.tunnel.provider = provider;
+    },
+    {
+      route: 'api.admin.tunnel',
+      source: 'admin-console',
+    },
+  );
+
+  return getGatewayAdminTunnelConfig();
 }
 
 export async function reconnectGatewayAdminTunnel(): Promise<GatewayAdminTunnelStatus> {

--- a/src/gateway/gateway-tunnel-service.ts
+++ b/src/gateway/gateway-tunnel-service.ts
@@ -29,6 +29,7 @@ import type {
 let managedProvider: TunnelProvider | null = null;
 let managedProviderKey: string | null = null;
 let reconnectInFlight: Promise<GatewayAdminTunnelStatus> | null = null;
+let stopInFlight: Promise<GatewayAdminTunnelStatus> | null = null;
 
 const TUNNEL_PROVIDER_META = {
   cloudflare: {
@@ -351,8 +352,48 @@ export async function reconnectGatewayAdminTunnel(): Promise<GatewayAdminTunnelS
   }
 }
 
+export async function stopGatewayAdminTunnel(): Promise<GatewayAdminTunnelStatus> {
+  const before = getGatewayAdminTunnelStatus();
+  recordAuditEvent({
+    sessionId: DEFAULT_TUNNEL_AUDIT_SESSION_ID,
+    runId: makeAuditRunId('tunnel-admin'),
+    event: {
+      type: 'tunnel.manual_stop',
+      provider: before.provider ?? 'none',
+      public_url: before.publicUrl,
+      state: before.state,
+    },
+  });
+
+  const provider = getManagedTunnelProvider();
+  if (!provider) {
+    throw new GatewayRequestError(
+      409,
+      'Manual stop is only supported for managed tunnel providers.',
+    );
+  }
+
+  if (stopInFlight) {
+    return stopInFlight;
+  }
+
+  const operation = (async () => {
+    await provider.stop();
+    return getGatewayAdminTunnelStatus();
+  })();
+  stopInFlight = operation;
+  try {
+    return await operation;
+  } finally {
+    if (stopInFlight === operation) {
+      stopInFlight = null;
+    }
+  }
+}
+
 export function resetGatewayAdminTunnelForTests(): void {
   managedProvider = null;
   managedProviderKey = null;
   reconnectInFlight = null;
+  stopInFlight = null;
 }

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -19,6 +19,7 @@ import type { SlackWebhookSendResult } from '../channels/slack-webhook/delivery.
 import type {
   MSTeamsReplyStyle,
   RuntimeConfig,
+  RuntimeDeploymentMode,
   RuntimeDeploymentTunnelProvider,
   RuntimeDiscordChannelConfig,
   RuntimeMSTeamsChannelConfig,
@@ -653,6 +654,18 @@ export interface GatewayAdminTunnelStatus {
   lastError: string | null;
   lastCheckedAt: string | null;
   nextReconnectAt: string | null;
+}
+
+export interface GatewayAdminTunnelConfig {
+  mode: RuntimeDeploymentMode;
+  provider: RuntimeDeploymentTunnelProvider | null;
+  publicUrl: string;
+  healthCheckIntervalMs: number;
+}
+
+export interface GatewayAdminTunnelConfigResponse {
+  config: GatewayAdminTunnelConfig;
+  tunnel: GatewayAdminTunnelStatus;
 }
 
 export interface GatewayAdminOverview {

--- a/src/security/admin-rbac.ts
+++ b/src/security/admin-rbac.ts
@@ -7,6 +7,8 @@ export const ADMIN_SECRET_RBAC_ACTIONS = [
 export const ADMIN_RBAC_ACTIONS = [
   ...ADMIN_SECRET_RBAC_ACTIONS,
   'admin.overview.read',
+  'admin.tunnel.read',
+  'admin.tunnel.write',
   'admin.tunnel.reconnect',
   'admin.statistics.read',
   'admin.logs.read',
@@ -78,6 +80,7 @@ export type AdminRbacAction = (typeof ADMIN_RBAC_ACTIONS)[number];
 
 const ADMIN_READ_ACTIONS = [
   'admin.overview.read',
+  'admin.tunnel.read',
   'admin.statistics.read',
   'admin.logs.read',
   'admin.team.read',
@@ -145,6 +148,7 @@ export const ADMIN_RBAC_ROLE_ACTIONS = {
   ],
   'admin.config_manager': [
     ...ADMIN_READ_ACTIONS,
+    'admin.tunnel.write',
     'admin.config.write',
     'admin.config.reload',
     'admin.models.write',
@@ -177,6 +181,7 @@ export const ADMIN_RBAC_ROLE_ACTIONS = {
   'admin:owner': ADMIN_RBAC_ACTIONS,
   'admin:operator': [
     ...ADMIN_AUDITOR_ACTIONS,
+    'admin.tunnel.write',
     'admin.tunnel.reconnect',
     'admin.team.write',
     'admin.agents.write',
@@ -346,6 +351,11 @@ export function resolveAdminRbacAction(
   if (pathname.startsWith('/api/admin/secrets/')) {
     if (method === 'PUT') return 'secret.overwrite';
     if (method === 'DELETE') return 'secret.unset';
+    return null;
+  }
+  if (pathname === '/api/admin/tunnel') {
+    if (method === 'GET') return 'admin.tunnel.read';
+    if (method === 'PUT') return 'admin.tunnel.write';
     return null;
   }
   if (pathname === '/api/admin/tunnel/reconnect' && method === 'POST') {

--- a/src/security/admin-rbac.ts
+++ b/src/security/admin-rbac.ts
@@ -10,6 +10,7 @@ export const ADMIN_RBAC_ACTIONS = [
   'admin.tunnel.read',
   'admin.tunnel.write',
   'admin.tunnel.reconnect',
+  'admin.tunnel.stop',
   'admin.statistics.read',
   'admin.logs.read',
   'admin.team.read',
@@ -120,6 +121,7 @@ export const ADMIN_RBAC_ROLE_ACTIONS = {
   'admin.operator': [
     ...ADMIN_READ_ACTIONS,
     'admin.tunnel.reconnect',
+    'admin.tunnel.stop',
     'admin.sessions.delete',
     'admin.scheduler.write',
     'admin.scheduler.delete',
@@ -183,6 +185,7 @@ export const ADMIN_RBAC_ROLE_ACTIONS = {
     ...ADMIN_AUDITOR_ACTIONS,
     'admin.tunnel.write',
     'admin.tunnel.reconnect',
+    'admin.tunnel.stop',
     'admin.team.write',
     'admin.agents.write',
     'admin.models.write',
@@ -360,6 +363,9 @@ export function resolveAdminRbacAction(
   }
   if (pathname === '/api/admin/tunnel/reconnect' && method === 'POST') {
     return 'admin.tunnel.reconnect';
+  }
+  if (pathname === '/api/admin/tunnel/stop' && method === 'POST') {
+    return 'admin.tunnel.stop';
   }
   if (pathname === '/api/admin/statistics' && method === 'GET') {
     return 'admin.statistics.read';

--- a/tests/admin-rbac.test.ts
+++ b/tests/admin-rbac.test.ts
@@ -124,5 +124,8 @@ describe('admin RBAC role bundles', () => {
     expect(resolveAdminRbacAction('/api/admin/tunnel/reconnect', 'POST')).toBe(
       'admin.tunnel.reconnect',
     );
+    expect(resolveAdminRbacAction('/api/admin/tunnel/stop', 'POST')).toBe(
+      'admin.tunnel.stop',
+    );
   });
 });

--- a/tests/admin-rbac.test.ts
+++ b/tests/admin-rbac.test.ts
@@ -6,6 +6,7 @@ import {
   collectAdminActionClaims,
   collectAdminRoleClaims,
   isAdminActionAllowed,
+  resolveAdminRbacAction,
 } from '../src/security/admin-rbac.js';
 
 describe('admin RBAC role bundles', () => {
@@ -38,6 +39,7 @@ describe('admin RBAC role bundles', () => {
     const payload = { role: 'admin.config_manager' };
     const claims = collectAdminActionClaims(payload);
 
+    expect(claims?.has('admin.tunnel.write')).toBe(true);
     expect(claims?.has('admin.config.reload')).toBe(true);
     expect(isAdminActionAllowed(payload, 'admin.config.reload')).toBe(true);
     expect(isAdminActionAllowed(payload, 'secret.overwrite')).toBe(false);
@@ -110,5 +112,17 @@ describe('admin RBAC role bundles', () => {
       'admin:owner',
       'admin:secret-manager',
     ]);
+  });
+
+  test('maps admin tunnel routes to scoped tunnel actions', () => {
+    expect(resolveAdminRbacAction('/api/admin/tunnel', 'GET')).toBe(
+      'admin.tunnel.read',
+    );
+    expect(resolveAdminRbacAction('/api/admin/tunnel', 'PUT')).toBe(
+      'admin.tunnel.write',
+    );
+    expect(resolveAdminRbacAction('/api/admin/tunnel/reconnect', 'POST')).toBe(
+      'admin.tunnel.reconnect',
+    );
   });
 });

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -865,6 +865,16 @@ async function importFreshHealth(options?: {
     lastCheckedAt: null,
     nextReconnectAt: null,
   };
+  const stopTunnelStatus = {
+    provider: 'ngrok',
+    publicUrl: null,
+    state: 'down' as const,
+    health: 'down' as const,
+    reconnectSupported: true,
+    lastError: null,
+    lastCheckedAt: null,
+    nextReconnectAt: null,
+  };
   const tunnelConfigResponse = {
     config: {
       mode: 'local' as const,
@@ -883,6 +893,7 @@ async function importFreshHealth(options?: {
     tunnel: reconnectTunnelStatus,
   }));
   const reconnectGatewayAdminTunnel = vi.fn(async () => reconnectTunnelStatus);
+  const stopGatewayAdminTunnel = vi.fn(async () => stopTunnelStatus);
   const getGatewayAdminStatistics = vi.fn(
     (params?: { days?: number | string }) => {
       const raw =
@@ -2159,6 +2170,7 @@ async function importFreshHealth(options?: {
     saveGatewayAdminModels,
     setGatewayAdminSkillEnabled,
     startGatewayAdminA2APairing,
+    stopGatewayAdminTunnel,
     updateGatewayAdminAgent,
     uploadGatewayAdminSkillZip,
     upsertGatewayAdminA2ATrustPeer,
@@ -2267,6 +2279,8 @@ async function importFreshHealth(options?: {
     saveGatewayAdminTunnelConfig,
     reconnectTunnelStatus,
     reconnectGatewayAdminTunnel,
+    stopTunnelStatus,
+    stopGatewayAdminTunnel,
     deleteGatewayAdminEmailMessage,
     getGatewayAdminEmailFolder,
     getGatewayAdminEmailMailbox,
@@ -6176,6 +6190,24 @@ describe('gateway HTTP server', () => {
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body)).toEqual({
       tunnel: state.reconnectTunnelStatus,
+    });
+  });
+
+  test('stops the admin tunnel for authorized API requests', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({
+      url: '/api/admin/tunnel/stop',
+      method: 'POST',
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.stopGatewayAdminTunnel).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({
+      tunnel: state.stopTunnelStatus,
     });
   });
 

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -865,6 +865,23 @@ async function importFreshHealth(options?: {
     lastCheckedAt: null,
     nextReconnectAt: null,
   };
+  const tunnelConfigResponse = {
+    config: {
+      mode: 'local' as const,
+      provider: 'manual',
+      publicUrl: 'https://public.example.test',
+      healthCheckIntervalMs: 30_000,
+    },
+    tunnel: reconnectTunnelStatus,
+  };
+  const getGatewayAdminTunnelConfig = vi.fn(() => tunnelConfigResponse);
+  const saveGatewayAdminTunnelConfig = vi.fn((value) => ({
+    config: {
+      ...tunnelConfigResponse.config,
+      ...value,
+    },
+    tunnel: reconnectTunnelStatus,
+  }));
   const reconnectGatewayAdminTunnel = vi.fn(async () => reconnectTunnelStatus);
   const getGatewayAdminStatistics = vi.fn(
     (params?: { days?: number | string }) => {
@@ -2113,6 +2130,7 @@ async function importFreshHealth(options?: {
     getGatewayAdminSkills,
     getGatewayAdminStatistics,
     getGatewayAdminTools,
+    getGatewayAdminTunnelConfig,
     getGatewayBootstrapAutostartState,
     getGatewayHistory,
     getGatewayRecentChatSessions,
@@ -2132,6 +2150,7 @@ async function importFreshHealth(options?: {
     revokeGatewayAdminA2ATrustPeer,
     saveGatewayAdminConfig,
     saveGatewayAdminSlackWebhookTarget,
+    saveGatewayAdminTunnelConfig,
     saveGatewayAdminAgentMarkdownFile,
     saveGatewayAdminPolicyDefault,
     saveGatewayAdminPolicyLanHttpAccess,
@@ -2243,6 +2262,9 @@ async function importFreshHealth(options?: {
     recordGatewayAdminSecretMutationFailure,
     unsetGatewayAdminSecret,
     getGatewayAdminStatistics,
+    tunnelConfigResponse,
+    getGatewayAdminTunnelConfig,
+    saveGatewayAdminTunnelConfig,
     reconnectTunnelStatus,
     reconnectGatewayAdminTunnel,
     deleteGatewayAdminEmailMessage,
@@ -6094,6 +6116,49 @@ describe('gateway HTTP server', () => {
     });
     expect(res.statusCode).toBe(400);
     expect(res.body).not.toContain('bad-json-secret');
+  });
+
+  test('returns admin tunnel config for authorized API requests', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({ url: '/api/admin/tunnel' });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.getGatewayAdminTunnelConfig).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual(state.tunnelConfigResponse);
+  });
+
+  test('saves admin tunnel config for authorized API requests', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({
+      url: '/api/admin/tunnel',
+      method: 'PUT',
+      body: JSON.stringify({
+        provider: 'ngrok',
+        publicUrl: '',
+      }),
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.saveGatewayAdminTunnelConfig).toHaveBeenCalledWith({
+      provider: 'ngrok',
+      publicUrl: '',
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({
+      config: {
+        ...state.tunnelConfigResponse.config,
+        provider: 'ngrok',
+        publicUrl: '',
+      },
+      tunnel: state.reconnectTunnelStatus,
+    });
   });
 
   test('reconnects the admin tunnel for authorized API requests', async () => {

--- a/tests/gateway-tunnel-service.test.ts
+++ b/tests/gateway-tunnel-service.test.ts
@@ -572,6 +572,52 @@ test('admin tunnel reconnect audits the action and restarts cloudflare', async (
   });
 });
 
+test('admin tunnel stop audits the action and stops ngrok', async () => {
+  let status: TunnelStatus = {
+    ...downStatus,
+    running: true,
+    public_url: 'https://running.example.test',
+    state: 'up',
+  };
+  const provider: TunnelProvider = {
+    status: vi.fn(() => status),
+    stop: vi.fn(async () => {
+      status = { ...downStatus };
+    }),
+    start: vi.fn(async () => ({ public_url: 'https://new.example.test' })),
+  };
+  const service = await importService({
+    config: makeRuntimeConfig({
+      mode: 'local',
+      public_url: '',
+      tunnel: {
+        provider: 'ngrok',
+        health_check_interval_ms: 45_000,
+      },
+    }),
+    provider,
+  });
+
+  await expect(service.stopGatewayAdminTunnel()).resolves.toMatchObject({
+    provider: 'ngrok',
+    publicUrl: null,
+    health: 'down',
+  });
+
+  expect(provider.stop).toHaveBeenCalledTimes(1);
+  expect(provider.start).not.toHaveBeenCalled();
+  expect(service.recordAuditEvent).toHaveBeenCalledWith({
+    sessionId: 'system:tunnel',
+    runId: 'tunnel-admin-run',
+    event: {
+      type: 'tunnel.manual_stop',
+      provider: 'ngrok',
+      public_url: 'https://running.example.test',
+      state: 'up',
+    },
+  });
+});
+
 test('admin tunnel reconnect serializes concurrent calls', async () => {
   let resolveStop!: () => void;
   const stopGate = new Promise<void>((resolve) => {
@@ -653,6 +699,33 @@ test('unsupported tunnel reconnect is still audited before returning conflict', 
     runId: 'tunnel-admin-run',
     event: {
       type: 'tunnel.manual_reconnect',
+      provider: 'manual',
+      public_url: null,
+      state: 'down',
+    },
+  });
+});
+
+test('unsupported tunnel stop is still audited before returning conflict', async () => {
+  const service = await importService({
+    config: makeRuntimeConfig({
+      mode: 'local',
+      public_url: '',
+      tunnel: {
+        provider: 'manual',
+        health_check_interval_ms: 30_000,
+      },
+    }),
+  });
+
+  await expect(service.stopGatewayAdminTunnel()).rejects.toMatchObject({
+    statusCode: 409,
+  });
+  expect(service.recordAuditEvent).toHaveBeenCalledWith({
+    sessionId: 'system:tunnel',
+    runId: 'tunnel-admin-run',
+    event: {
+      type: 'tunnel.manual_stop',
       provider: 'manual',
       public_url: null,
       state: 'down',

--- a/tests/gateway-tunnel-service.test.ts
+++ b/tests/gateway-tunnel-service.test.ts
@@ -63,9 +63,23 @@ async function importService(options: {
     }
     return provider;
   });
+  const updateRuntimeConfig = vi.fn(
+    (mutator: (draft: RuntimeConfig) => void) => {
+      mutator(options.config);
+      return options.config;
+    },
+  );
 
   vi.doMock('../src/config/runtime-config.js', () => ({
+    RUNTIME_DEPLOYMENT_TUNNEL_PROVIDERS: [
+      'cloudflare',
+      'manual',
+      'ngrok',
+      'ssh',
+      'tailscale',
+    ],
     getRuntimeConfig: () => options.config,
+    updateRuntimeConfig,
   }));
   vi.doMock('../src/audit/audit-events.js', () => ({
     makeAuditRunId,
@@ -90,6 +104,7 @@ async function importService(options: {
     createTailscaleTunnelProvider,
     makeAuditRunId,
     recordAuditEvent,
+    updateRuntimeConfig,
   };
 }
 
@@ -127,6 +142,138 @@ test('admin tunnel status reports configured manual public URL as healthy', asyn
   expect(service.createNgrokTunnelProvider).not.toHaveBeenCalled();
   expect(service.createTailscaleTunnelProvider).not.toHaveBeenCalled();
   expect(service.createCloudflareTunnelProvider).not.toHaveBeenCalled();
+});
+
+test('admin tunnel config returns lightweight config and current status', async () => {
+  const service = await importService({
+    config: makeRuntimeConfig({
+      mode: 'cloud',
+      public_url: 'https://bot.example.test',
+      tunnel: {
+        provider: 'manual',
+        health_check_interval_ms: 45_000,
+      },
+    }),
+  });
+
+  expect(service.getGatewayAdminTunnelConfig()).toEqual({
+    config: {
+      mode: 'cloud',
+      provider: 'manual',
+      publicUrl: 'https://bot.example.test',
+      healthCheckIntervalMs: 45_000,
+    },
+    tunnel: {
+      provider: 'manual',
+      publicUrl: 'https://bot.example.test',
+      state: 'up',
+      health: 'healthy',
+      reconnectSupported: false,
+      lastError: null,
+      lastCheckedAt: null,
+      nextReconnectAt: null,
+    },
+  });
+});
+
+test('admin tunnel config save preserves deployment mode and gateway base URL', async () => {
+  const config = makeRuntimeConfig({
+    mode: 'cloud',
+    public_url: '',
+    tunnel: {
+      provider: 'manual',
+      health_check_interval_ms: 30_000,
+    },
+  });
+  config.ops.gatewayBaseUrl = 'http://127.0.0.1:9090';
+  const service = await importService({ config });
+
+  const result = service.saveGatewayAdminTunnelConfig({
+    provider: 'manual',
+    publicUrl: 'https://public.example.test/',
+  });
+
+  expect(result.config).toEqual({
+    mode: 'cloud',
+    provider: 'manual',
+    publicUrl: 'https://public.example.test',
+    healthCheckIntervalMs: 30_000,
+  });
+  expect(config.deployment.mode).toBe('cloud');
+  expect(config.ops.gatewayBaseUrl).toBe('http://127.0.0.1:9090');
+  expect(config.deployment.public_url).toBe('https://public.example.test');
+  expect(config.deployment.tunnel.provider).toBe('manual');
+  expect(service.updateRuntimeConfig).toHaveBeenCalledWith(
+    expect.any(Function),
+    {
+      route: 'api.admin.tunnel',
+      source: 'admin-console',
+    },
+  );
+});
+
+test('admin tunnel config save clears configured public URL for ngrok', async () => {
+  const config = makeRuntimeConfig({
+    mode: 'local',
+    public_url: 'https://old.example.test',
+    tunnel: {
+      provider: 'manual',
+      health_check_interval_ms: 30_000,
+    },
+  });
+  const provider: TunnelProvider = {
+    status: vi.fn(() => downStatus),
+    stop: vi.fn(async () => {}),
+    start: vi.fn(async () => ({ public_url: 'https://next.example.test' })),
+  };
+  const service = await importService({ config, provider });
+
+  const result = service.saveGatewayAdminTunnelConfig({
+    provider: 'ngrok',
+    publicUrl: 'https://ignored.example.test',
+  });
+
+  expect(result.config).toMatchObject({
+    provider: 'ngrok',
+    publicUrl: '',
+  });
+  expect(config.deployment.public_url).toBe('');
+  expect(config.deployment.tunnel.provider).toBe('ngrok');
+});
+
+test('admin tunnel config save rejects unsupported providers and invalid URLs', async () => {
+  const service = await importService({
+    config: makeRuntimeConfig({
+      mode: 'local',
+      public_url: '',
+      tunnel: {
+        provider: 'manual',
+        health_check_interval_ms: 30_000,
+      },
+    }),
+  });
+
+  for (const input of [
+    {
+      provider: 'localtunnel',
+      publicUrl: 'https://public.example.test',
+    },
+    {
+      provider: 'manual',
+      publicUrl: 'not a url',
+    },
+    {
+      provider: 'cloudflare',
+      publicUrl: '',
+    },
+  ]) {
+    try {
+      service.saveGatewayAdminTunnelConfig(input);
+      throw new Error('expected tunnel config save to fail');
+    } catch (error) {
+      expect(error).toMatchObject({ statusCode: 400 });
+    }
+  }
 });
 
 test('admin tunnel status stops stale ngrok provider when config changes', async () => {


### PR DESCRIPTION
## Summary
- Add public tunnel configuration controls directly to the `/admin` dashboard card.
- Support saving manual/SSH/Cloudflare public URLs and launching managed ngrok/Tailscale/Cloudflare providers through the existing reconnect flow.
- Type the deployment config fields used by the console and cover manual URL plus managed ngrok flows in dashboard tests.

## Impact
Operators can switch local HybridClaw between a manually launched tunnel and managed providers from `/admin` instead of editing `/admin/config` JSON.

## Validation
- `npm --workspace console run test -- src/routes/dashboard.test.tsx`
- `npm --workspace console run typecheck`
- `npx biome check --write console/src/routes/dashboard.tsx console/src/routes/dashboard.test.tsx console/src/routes/channels.test.tsx console/src/api/types.ts console/src/styles.css`
- `git diff --check`