### PR TITLE
[codex] Fix remote agent selector caret

### DIFF
--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1391,14 +1391,17 @@ aside[data-state="collapsed"] .chatSidebarContent {
   padding: 6px 0;
 }
 
-.composerInputWrap:focus-within .composerInputOverlay::after {
-  content: "";
-  display: inline-block;
+.composerOverlayCaret {
+  display: none;
   width: 1px;
   height: 1.25em;
   margin-left: 1px;
   background: var(--text);
   vertical-align: -0.18em;
+}
+
+.composerInputWrap:focus-within .composerOverlayCaret {
+  display: inline-block;
 }
 
 .composerMentionPill {

--- a/console/src/routes/chat/composer.test.tsx
+++ b/console/src/routes/chat/composer.test.tsx
@@ -151,8 +151,10 @@ describe('Composer', () => {
       within(listbox).getByRole('option', { name: 'Remote Research' }),
     );
 
-    expect(getTextarea().value).toBe('@remote@team@inst-peer ');
-    expect(getTextarea().selectionStart).toBe('@remote@team@inst-peer '.length);
+    const textarea = getTextarea();
+    await waitFor(() => expect(document.activeElement).toBe(textarea));
+    expect(textarea.value).toBe('@remote@team@inst-peer ');
+    expect(textarea.selectionStart).toBe('@remote@team@inst-peer '.length);
     expect(onAgentSwitch).not.toHaveBeenCalled();
   });
 
@@ -183,7 +185,13 @@ describe('Composer', () => {
     );
 
     expect(textarea.value).toBe('@remote@team@inst-peer summarize this');
-    expect(textarea.selectionStart).toBe('@remote@team@inst-peer '.length);
+    await waitFor(() => {
+      expect(document.activeElement).toBe(textarea);
+      expect(textarea.selectionStart).toBe('@remote@team@inst-peer '.length);
+    });
+    expect(
+      document.querySelector(`.${css.composerOverlayCaret}`),
+    ).not.toBeNull();
   });
 
   it('does not render persistent agent mention chips', () => {

--- a/console/src/routes/chat/composer.test.tsx
+++ b/console/src/routes/chat/composer.test.tsx
@@ -152,7 +152,38 @@ describe('Composer', () => {
     );
 
     expect(getTextarea().value).toBe('@remote@team@inst-peer ');
+    expect(getTextarea().selectionStart).toBe('@remote@team@inst-peer '.length);
     expect(onAgentSwitch).not.toHaveBeenCalled();
+  });
+
+  it('places the caret after the inserted remote address before existing text', async () => {
+    renderComposer({
+      agents: [
+        { id: 'main', name: 'Assistant' },
+        {
+          id: 'remote@team@inst-peer',
+          name: 'Remote Research',
+          source: {
+            type: 'remote',
+            peerId: 'inst-peer',
+            instanceId: 'inst-peer',
+          },
+        },
+      ],
+      selectedAgentId: 'main',
+    });
+    const textarea = getTextarea();
+    fireEvent.input(textarea, { target: { value: 'summarize this' } });
+
+    fireEvent.click(screen.getByLabelText('Switch agent'));
+    fireEvent.click(
+      within(screen.getByRole('listbox')).getByRole('option', {
+        name: 'Remote Research',
+      }),
+    );
+
+    expect(textarea.value).toBe('@remote@team@inst-peer summarize this');
+    expect(textarea.selectionStart).toBe('@remote@team@inst-peer '.length);
   });
 
   it('does not render persistent agent mention chips', () => {

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -340,20 +340,23 @@ export function Composer(props: {
       const ta = textareaRef.current;
       if (!ta) return;
       const mention = `@${agentId}`;
+      const insertedPrefix = `${mention} `;
       const value = ta.value;
       const leadingMention = LEADING_AGENT_ADDRESS_RE.exec(value);
+      let nextValue: string;
       if (!value.trim()) {
-        ta.value = `${mention} `;
+        nextValue = insertedPrefix;
       } else if (leadingMention) {
-        ta.value = `${mention} ${value.slice(leadingMention[0].length).trimStart()}`;
+        nextValue = `${insertedPrefix}${value.slice(leadingMention[0].length).trimStart()}`;
       } else {
-        ta.value = `${mention} ${value.trimStart()}`;
+        nextValue = `${insertedPrefix}${value.trimStart()}`;
       }
-      ta.setSelectionRange(ta.value.length, ta.value.length);
+      ta.value = nextValue;
       setComposerValue(ta.value);
       closePanel();
       resize();
       ta.focus();
+      ta.setSelectionRange(insertedPrefix.length, insertedPrefix.length);
     },
     [closePanel, resize],
   );

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -94,8 +94,12 @@ export function Composer(props: {
   const [panelMode, setPanelMode] = useState<SlashPanelMode>('closed');
   const [lastQuery, setLastQuery] = useState('');
   const [composerValue, setComposerValue] = useState('');
+  const [composerCaretIndex, setComposerCaretIndex] = useState(0);
   const appliedInitialValueRef = useRef<string | null>(null);
   const suggestTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const selectionRestoreTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const suggestSeqRef = useRef(0);
   const overlayRef = useRef<HTMLDivElement>(null);
   const listboxId = useId();
@@ -114,6 +118,9 @@ export function Composer(props: {
   useEffect(() => {
     return () => {
       if (suggestTimerRef.current) clearTimeout(suggestTimerRef.current);
+      if (selectionRestoreTimerRef.current) {
+        clearTimeout(selectionRestoreTimerRef.current);
+      }
       // Invalidate any in-flight fetch so its late resolve can't setState
       // on an unmounted component.
       suggestSeqRef.current += 1;
@@ -163,6 +170,32 @@ export function Composer(props: {
     ta.style.height = `${Math.max(36, Math.min(ta.scrollHeight, 180))}px`;
   }, []);
 
+  const syncComposerSelection = useCallback(() => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    setComposerCaretIndex(ta.selectionStart ?? ta.value.length);
+  }, []);
+
+  const restoreComposerFocusAt = useCallback((cursor: number) => {
+    const applySelection = () => {
+      const ta = textareaRef.current;
+      if (!ta) return;
+      const nextCursor = Math.max(0, Math.min(cursor, ta.value.length));
+      ta.focus();
+      ta.setSelectionRange(nextCursor, nextCursor);
+      setComposerCaretIndex(nextCursor);
+    };
+
+    applySelection();
+    if (selectionRestoreTimerRef.current) {
+      clearTimeout(selectionRestoreTimerRef.current);
+    }
+    selectionRestoreTimerRef.current = setTimeout(() => {
+      selectionRestoreTimerRef.current = null;
+      applySelection();
+    }, 0);
+  }, []);
+
   useEffect(() => {
     const nextValue = props.initialValue?.trim() || '';
     if (appliedInitialValueRef.current === nextValue) return;
@@ -174,6 +207,7 @@ export function Composer(props: {
     ta.value = nextValue;
     ta.setSelectionRange(nextValue.length, nextValue.length);
     setComposerValue(nextValue);
+    setComposerCaretIndex(nextValue.length);
     setPanelMode('closed');
     suggestSeqRef.current += 1;
     resize();
@@ -260,6 +294,7 @@ export function Composer(props: {
     if (!ta) return;
     setComposerValue(ta.value);
     const cursor = ta.selectionStart ?? ta.value.length;
+    setComposerCaretIndex(cursor);
     const ctx = getSlashContext(ta.value, cursor);
     if (ctx) {
       const query = ctx.query.trim();
@@ -297,6 +332,7 @@ export function Composer(props: {
     const value = ta.value;
     const cursor = ta.selectionStart ?? value.length;
     const insertCore = item.insertText.replace(/\s+$/, '');
+    let nextCursor = ta.value.length;
     if (suggestionKind === 'agent') {
       const ctx = getAgentMentionContext(value, cursor);
       if (ctx) {
@@ -304,13 +340,15 @@ export function Composer(props: {
         const after = value.slice(cursor);
         const insert = after.startsWith(' ') ? insertCore : `${insertCore} `;
         ta.value = before + insert + after;
-        const newCursor = before.length + insert.length;
-        ta.setSelectionRange(newCursor, newCursor);
+        nextCursor = before.length + insert.length;
+        ta.setSelectionRange(nextCursor, nextCursor);
       } else {
         ta.value = `${insertCore} `;
-        ta.setSelectionRange(ta.value.length, ta.value.length);
+        nextCursor = ta.value.length;
+        ta.setSelectionRange(nextCursor, nextCursor);
       }
       setComposerValue(ta.value);
+      setComposerCaretIndex(nextCursor);
       closePanel();
       resize();
       ta.focus();
@@ -323,13 +361,15 @@ export function Composer(props: {
       const after = value.slice(cursor);
       const insert = after.startsWith(' ') ? insertCore : `${insertCore} `;
       ta.value = before + insert + after;
-      const newCursor = before.length + insert.length;
-      ta.setSelectionRange(newCursor, newCursor);
+      nextCursor = before.length + insert.length;
+      ta.setSelectionRange(nextCursor, nextCursor);
     } else {
       ta.value = `${insertCore} `;
-      ta.setSelectionRange(ta.value.length, ta.value.length);
+      nextCursor = ta.value.length;
+      ta.setSelectionRange(nextCursor, nextCursor);
     }
     setComposerValue(ta.value);
+    setComposerCaretIndex(nextCursor);
     closePanel();
     resize();
     ta.focus();
@@ -353,12 +393,12 @@ export function Composer(props: {
       }
       ta.value = nextValue;
       setComposerValue(ta.value);
+      setComposerCaretIndex(insertedPrefix.length);
       closePanel();
       resize();
-      ta.focus();
-      ta.setSelectionRange(insertedPrefix.length, insertedPrefix.length);
+      restoreComposerFocusAt(insertedPrefix.length);
     },
-    [closePanel, resize],
+    [closePanel, resize, restoreComposerFocusAt],
   );
 
   const submit = () => {
@@ -372,6 +412,7 @@ export function Composer(props: {
     props.onSend(val, pendingMedia);
     if (textareaRef.current) textareaRef.current.value = '';
     setComposerValue('');
+    setComposerCaretIndex(0);
     setPendingMedia([]);
     closePanel();
     resize();
@@ -510,6 +551,7 @@ export function Composer(props: {
               >
                 <ComposerInputPreview
                   value={composerValue}
+                  caretIndex={composerCaretIndex}
                   agents={agentById}
                   token={props.token}
                 />
@@ -525,6 +567,10 @@ export function Composer(props: {
               placeholder="Message HybridClaw"
               disabled={props.isStreaming}
               onInput={handleInput}
+              onSelect={syncComposerSelection}
+              onClick={syncComposerSelection}
+              onKeyUp={syncComposerSelection}
+              onFocus={syncComposerSelection}
               onKeyDown={handleKeyDown}
               onPaste={handlePaste}
               onScroll={handleScroll}
@@ -640,32 +686,71 @@ export function Composer(props: {
 
 function ComposerInputPreview(props: {
   value: string;
+  caretIndex: number;
   agents: ReadonlyMap<string, AgentSwitchOption>;
   token: string;
 }) {
   const parts: ReactNode[] = [];
   let last = 0;
   let key = 0;
+  let caretRendered = false;
+  const caretIndex = Math.max(
+    0,
+    Math.min(props.caretIndex, props.value.length),
+  );
+
+  const appendCaret = () => {
+    if (caretRendered) return;
+    parts.push(
+      <span
+        key={`caret-${key++}`}
+        className={css.composerOverlayCaret}
+        aria-hidden="true"
+      />,
+    );
+    caretRendered = true;
+  };
+
+  const appendText = (text: string, startIndex: number) => {
+    const endIndex = startIndex + text.length;
+    if (caretIndex < startIndex || caretIndex > endIndex) {
+      parts.push(text);
+      return;
+    }
+
+    const splitAt = caretIndex - startIndex;
+    if (splitAt > 0) parts.push(text.slice(0, splitAt));
+    appendCaret();
+    if (splitAt < text.length) parts.push(text.slice(splitAt));
+  };
 
   for (const match of props.value.matchAll(AGENT_MENTION_TOKEN_RE)) {
     const mention = match[0];
     const agentId = match[1] ?? '';
     const index = match.index ?? 0;
+    const mentionEnd = index + mention.length;
     const agent = props.agents.get(agentId);
     if (!agent) continue;
-    if (index > last) parts.push(props.value.slice(last, index));
-    parts.push(
-      <ComposerMentionPill
-        key={`mention-${key++}`}
-        mention={mention}
-        imageUrl={agent.imageUrl ?? null}
-        token={props.token}
-      />,
-    );
-    last = index + mention.length;
+    if (index > last) appendText(props.value.slice(last, index), last);
+    if (caretIndex > index && caretIndex < mentionEnd) {
+      appendText(mention, index);
+    } else {
+      if (caretIndex === index) appendCaret();
+      parts.push(
+        <ComposerMentionPill
+          key={`mention-${key++}`}
+          mention={mention}
+          imageUrl={agent.imageUrl ?? null}
+          token={props.token}
+        />,
+      );
+      if (caretIndex === mentionEnd) appendCaret();
+    }
+    last = mentionEnd;
   }
 
-  if (last < props.value.length) parts.push(props.value.slice(last));
+  if (last < props.value.length) appendText(props.value.slice(last), last);
+  if (!caretRendered && caretIndex === props.value.length) appendCaret();
   return parts.length > 0 ? parts : props.value;
 }
 


### PR DESCRIPTION
## Summary
- Place the composer caret immediately after an inserted remote A2A address.
- Preserve existing composer text after the inserted address.
- Add regression coverage for selector insertion with existing text.

## Root Cause
Remote-agent selector insertion always placed the caret at the end of the full composer value, so when it prepended an address before existing text the next typed characters landed in the wrong position.

## Validation
- `/Users/bkoehler/src/hybridclaw/node_modules/.bin/biome check --write console/src/routes/chat/composer.tsx console/src/routes/chat/composer.test.tsx`
- From `console/`: `/Users/bkoehler/Library/Application Support/Herd/config/nvm/versions/node/v22.22.3/bin/node /Users/bkoehler/src/hybridclaw/node_modules/vitest/vitest.mjs run --configLoader runner --config vitest.config.ts src/routes/chat/composer.test.tsx`