### PR TITLE
fix: stream container text deltas live instead of buffering the turn

### DIFF
--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -1316,7 +1316,6 @@ async function processRequest(
     tokenUsage.estimatedPromptTokens += estimatedPromptTokensForCall;
 
     let response: Awaited<ReturnType<typeof callHybridAIWithRetry>>;
-    const modelCallTextDeltas: string[] = [];
     try {
       response = await callHybridAIWithRetry({
         sessionId,
@@ -1331,9 +1330,7 @@ async function processRequest(
         history,
         tools,
         onTextDelta: streamTextDeltas
-          ? (delta) => {
-              if (delta) modelCallTextDeltas.push(delta);
-            }
+          ? (delta) => emitStreamDelta(delta)
           : undefined,
         onThinkingDelta: streamTextDeltas
           ? (delta) => emitStreamThinkingDelta(delta)
@@ -1437,12 +1434,6 @@ async function processRequest(
       });
       return failed;
     }
-    if (toolCalls.length === 0) {
-      for (const delta of modelCallTextDeltas) {
-        emitStreamDelta(delta);
-      }
-    }
-
     const branchChoice = parseRalphChoice(choice.message.content);
     if (
       provider === 'hybridai' &&


### PR DESCRIPTION
## Problem

When a client consumes the gateway's streaming chat endpoint (`/api/chat` with `stream: true`, NDJSON), the assistant's visible answer does **not** stream — it arrives all at once at the end of the turn instead of token-by-token.

The gateway and its NDJSON transport stream correctly; the response was being collapsed earlier, inside the container agent itself.

## Root cause

In `container/src/index.ts`, the model-call `onTextDelta` callback pushed each delta into a `modelCallTextDeltas` array, and the buffer was only flushed via `emitStreamDelta` **after** the model call resolved — and only on turns with no tool calls:

```ts
onTextDelta: streamTextDeltas
  ? (delta) => { if (delta) modelCallTextDeltas.push(delta); }  // buffered
  : undefined,
...
if (toolCalls.length === 0) {
  for (const delta of modelCallTextDeltas) emitStreamDelta(delta);  // replayed at end
}
```

Thinking deltas already streamed live (`onThinkingDelta: (delta) => emitStreamThinkingDelta(delta)`); only the visible answer text was buffered. Since the streamed `[stream]` text deltas are what downstream consumers render incrementally, buffering them defeated streaming for the whole turn.

## Fix

Emit text deltas immediately as they arrive, mirroring the existing thinking-delta path, and remove the deferred replay buffer:

```ts
onTextDelta: streamTextDeltas
  ? (delta) => emitStreamDelta(delta)
  : undefined,
```

This emits the same bytes the replay loop already produced — just live instead of at end-of-turn — so there is no duplication and no change to ralph `<choice>` tag handling. One intentional behavior change: text the model produces alongside a tool call now streams too (previously suppressed), which matches standard streaming-chat UX.

## Testing

- `npm --prefix container run lint` (tsc `--noUnusedLocals --noUnusedParameters`) ✅
- `npm --prefix container run build` ✅
- `npx biome check` on changed files ✅
- `vitest` — `container.ralph`, `container-runner.redaction`, `container.anthropic-provider` ✅ (20 passed)