### PR TITLE
[codex] allow host bootstrap cleanup

### DIFF
--- a/container/src/approval-policy.ts
+++ b/container/src/approval-policy.ts
@@ -33,7 +33,11 @@ import {
   type BehaviorAnomalyTraceJudgeResult,
 } from './behavior-anomaly.js';
 import { classifyMcpTool } from './mcp/tool-classifier.js';
-import { WORKSPACE_ROOT, WORKSPACE_ROOT_DISPLAY } from './runtime-paths.js';
+import {
+  toWorkspaceRelativePath,
+  WORKSPACE_ROOT,
+  WORKSPACE_ROOT_DISPLAY,
+} from './runtime-paths.js';
 import {
   createStakesClassifier,
   type StakesClassifier,
@@ -683,6 +687,14 @@ function normalizePathValue(rawPath: string): string {
     ? value.slice('/workspace/'.length)
     : value;
   return withoutWorkspace.replace(/^\.\/+/, '').replace(/^\/+/, '');
+}
+
+function isRootBootstrapPath(rawPath: string): boolean {
+  const value = rawPath.trim();
+  if (!value) return false;
+
+  const relativePath = toWorkspaceRelativePath(value);
+  return relativePath === 'BOOTSTRAP.md';
 }
 
 function matchesPathPattern(candidatePath: string, pattern: string): boolean {
@@ -2946,7 +2958,7 @@ export class TrustedAgentApprovalRuntime {
 
     if (lowerTool === 'delete') {
       const rawPath = normalizeText(args.path);
-      if (normalizePathValue(rawPath) === 'BOOTSTRAP.md') {
+      if (isRootBootstrapPath(rawPath)) {
         return {
           tier: 'green',
           actionKey: 'delete:bootstrap',

--- a/tests/approval-policy.test.ts
+++ b/tests/approval-policy.test.ts
@@ -1032,6 +1032,51 @@ autonomy:
     expect(fs.existsSync(pendingStorePath)).toBe(false);
   });
 
+  test('actual workspace root BOOTSTRAP.md delete is allowed in host mode', async () => {
+    const workspaceRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'hybridclaw-bootstrap-workspace-'),
+    );
+    vi.stubEnv('HYBRIDCLAW_AGENT_WORKSPACE_ROOT', workspaceRoot);
+    vi.resetModules();
+
+    const { TrustedAgentApprovalRuntime: HostModeApprovalRuntime } =
+      await import('../container/src/approval-policy.js');
+    const pendingStorePath = tempTrustStorePath('bootstrap-host-pending');
+    const runtime = new HostModeApprovalRuntime(
+      '/tmp/hybridclaw-missing-policy.yaml',
+      tempTrustStorePath('bootstrap-host-agent-trust'),
+      tempTrustStorePath('bootstrap-host-all-trust'),
+      tempTrustStorePath('bootstrap-host-legacy-trust'),
+      undefined,
+      pendingStorePath,
+    );
+
+    const evaluation = runtime.evaluateToolCall({
+      toolName: 'delete',
+      argsJson: JSON.stringify({
+        path: path.join(workspaceRoot, 'BOOTSTRAP.md'),
+      }),
+      latestUserPrompt: 'Finish onboarding',
+    });
+
+    expect(evaluation.tier).toBe('green');
+    expect(evaluation.decision).toBe('auto');
+    expect(evaluation.actionKey).toBe('delete:bootstrap');
+    expect(evaluation.reason).toContain('one-time onboarding file');
+    expect(fs.existsSync(pendingStorePath)).toBe(false);
+
+    const nested = runtime.evaluateToolCall({
+      toolName: 'delete',
+      argsJson: JSON.stringify({
+        path: path.join(workspaceRoot, 'memory', 'BOOTSTRAP.md'),
+      }),
+      latestUserPrompt: 'Delete a workspace file',
+    });
+    expect(nested.tier).toBe('red');
+    expect(nested.decision).toBe('required');
+    expect(nested.reason).toBe('deletion is destructive');
+  });
+
   test('other delete calls still require approval', () => {
     const runtime = new TrustedAgentApprovalRuntime(
       '/tmp/hybridclaw-missing-policy.yaml',
@@ -1042,7 +1087,11 @@ autonomy:
       tempTrustStorePath('delete-pending'),
     );
 
-    for (const deletePath of ['notes.md', 'memory/BOOTSTRAP.md']) {
+    for (const deletePath of [
+      'notes.md',
+      'memory/BOOTSTRAP.md',
+      '/BOOTSTRAP.md',
+    ]) {
       const evaluation = runtime.evaluateToolCall({
         toolName: 'delete',
         argsJson: JSON.stringify({ path: deletePath }),


### PR DESCRIPTION
## Summary

- Resolve delete targets against the configured workspace root before classifying `BOOTSTRAP.md` cleanup.
- Allow only the root workspace `BOOTSTRAP.md` onboarding cleanup to auto-approve in host mode.
- Keep nested or unrelated `BOOTSTRAP.md` deletes on the destructive-delete approval path.

## Root Cause

The previous approval-policy exception matched string-normalized paths such as `BOOTSTRAP.md`, `./BOOTSTRAP.md`, and `/workspace/BOOTSTRAP.md`, but host-mode delete requests can arrive as the real mounted workspace path under `~/.hybridclaw/data/agents/.../workspace/BOOTSTRAP.md`. Those paths fell through to the generic destructive delete classifier.

## Validation

- `./node_modules/.bin/vitest tests/approval-policy.test.ts --run`
- `./node_modules/.bin/tsc --noEmit`
- `npx biome check container/src/approval-policy.ts tests/approval-policy.test.ts`
- `git diff --check`