### PR TITLE
[codex] Autostart launch agent chat sessions

### DIFF
--- a/console/src/api/chat.ts
+++ b/console/src/api/chat.ts
@@ -46,12 +46,14 @@ export function fetchChatHistory(
   sessionId: string,
   limit = 80,
   userId?: string,
+  agentId?: string,
 ): Promise<ChatHistoryResponse> {
   const params = new URLSearchParams({
     sessionId,
     limit: String(limit),
   });
   if (userId) params.set('userId', userId);
+  if (agentId?.trim()) params.set('agentId', agentId.trim());
   return requestJson<ChatHistoryResponse>(`/api/history?${params.toString()}`, {
     token,
   });

--- a/console/src/routes/chat/chat-history-query.ts
+++ b/console/src/routes/chat/chat-history-query.ts
@@ -111,7 +111,8 @@ export async function loadChatHistoryUi(
   token: string,
   sessionId: string,
   userId?: string,
+  agentId?: string,
 ): Promise<ChatHistoryUiData> {
-  const raw = await fetchChatHistory(token, sessionId, 80, userId);
+  const raw = await fetchChatHistory(token, sessionId, 80, userId, agentId);
   return buildChatHistoryUiData(raw, sessionId);
 }

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -49,7 +49,15 @@ const fetchChatRecentMock =
     ) => Promise<ChatRecentResponse>
   >();
 const fetchChatHistoryMock =
-  vi.fn<(token: string, sessionId: string) => Promise<ChatHistoryResponse>>();
+  vi.fn<
+    (
+      token: string,
+      sessionId: string,
+      limit?: number,
+      userId?: string,
+      agentId?: string,
+    ) => Promise<ChatHistoryResponse>
+  >();
 const fetchChatContextMock =
   vi.fn<(token: string, sessionId: string) => Promise<ChatContextResponse>>();
 const deleteChatSessionMock =
@@ -103,8 +111,13 @@ vi.mock('../../api/chat', () => ({
     query?: string,
     scope?: 'user' | 'all',
   ) => fetchChatRecentMock(token, userId, channelId, limit, query, scope),
-  fetchChatHistory: (token: string, sessionId: string) =>
-    fetchChatHistoryMock(token, sessionId),
+  fetchChatHistory: (
+    token: string,
+    sessionId: string,
+    limit?: number,
+    userId?: string,
+    agentId?: string,
+  ) => fetchChatHistoryMock(token, sessionId, limit, userId, agentId),
   fetchChatContext: (token: string, sessionId: string) =>
     fetchChatContextMock(token, sessionId),
   createChatMobileQr: (
@@ -426,6 +439,9 @@ describe('ChatPage', () => {
       expect(fetchChatHistoryMock).toHaveBeenCalledWith(
         'test-token',
         'session-b',
+        80,
+        'web-user-1',
+        undefined,
       ),
     );
   });
@@ -449,6 +465,37 @@ describe('ChatPage', () => {
     await waitFor(() =>
       expect(input.value).toBe(
         '/1password List all items in my "Development" vault',
+      ),
+    );
+  });
+
+  it('mints a session and loads history for a launch agent query param', async () => {
+    const routerModule = (await import(
+      '@tanstack/react-router'
+    )) as unknown as {
+      __testRouter: TestRouter;
+    };
+    routerModule.__testRouter.setSessionId(null);
+    window.history.replaceState(null, '', '/chat?agent=assistant');
+    fetchChatHistoryMock.mockImplementation(async (_token, sessionId) => ({
+      sessionId,
+      agentId: 'assistant',
+      history: [],
+    }));
+
+    renderChatPage();
+
+    await waitFor(() =>
+      expect(routerModule.__testRouter.lastTo).toBe('/chat/$sessionId'),
+    );
+    expect(routerModule.__testRouter.lastReplace).toBe(true);
+    await waitFor(() =>
+      expect(fetchChatHistoryMock).toHaveBeenCalledWith(
+        'test-token',
+        expect.stringMatching(/^sess_\d{8}_\d{6}_[0-9a-f]{8}$/),
+        80,
+        'web-user-1',
+        'assistant',
       ),
     );
   });
@@ -845,8 +892,8 @@ describe('ChatPage', () => {
 
     expect(fetchChatHistoryMock).toHaveBeenCalledTimes(2);
     expect(fetchChatHistoryMock.mock.calls).toEqual([
-      ['test-token', 'session-a'],
-      ['test-token', 'session-b'],
+      ['test-token', 'session-a', 80, 'web-user-1', undefined],
+      ['test-token', 'session-b', 80, 'web-user-1', undefined],
     ]);
   });
 
@@ -895,6 +942,9 @@ describe('ChatPage', () => {
       expect(fetchChatHistoryMock).toHaveBeenCalledWith(
         'test-token',
         'session-b',
+        80,
+        'web-user-1',
+        undefined,
       ),
     );
   });
@@ -950,6 +1000,9 @@ describe('ChatPage', () => {
       expect(fetchChatHistoryMock).toHaveBeenCalledWith(
         'test-token',
         'session-search',
+        80,
+        'web-user-1',
+        undefined,
       ),
     );
   });
@@ -1567,6 +1620,9 @@ describe('ChatPage', () => {
       expect(fetchChatHistoryMock).toHaveBeenCalledWith(
         'test-token',
         'session-branch',
+        80,
+        'web-user-1',
+        undefined,
       ),
     );
     await waitFor(() =>

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -86,6 +86,16 @@ const BOOTSTRAP_AUTOSTART_REFETCH_MS = 1500;
 const DEFAULT_EMPTY_CHAT_HEADER = 'Ready to claw through your to-do list?';
 type RecentChatScope = 'user' | 'all';
 
+const AGENT_QUERY_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+function readLaunchAgentId(): string {
+  const value = new URLSearchParams(window.location.search)
+    .get('agent')
+    ?.trim();
+  if (!value) return '';
+  return AGENT_QUERY_ID_PATTERN.test(value) ? value : '';
+}
+
 function buildBranchInfoMap(
   messages: ChatUiMessage[],
   branchFamilies: Map<string, BranchVariant[]>,
@@ -134,6 +144,7 @@ export function ChatPage() {
     () => new URLSearchParams(window.location.search).get('prompt') || '',
     [],
   );
+  const launchAgentId = useMemo(readLaunchAgentId, []);
 
   const [errorState, setErrorState] = useState({ message: '', version: 0 });
   const error = errorState.message;
@@ -148,7 +159,9 @@ export function ChatPage() {
   const [approvalBusy, setApprovalBusy] = useState(false);
   const [mobileQr, setMobileQr] = useState<ChatMobileQrResponse | null>(null);
   const [mobileQrBusy, setMobileQrBusy] = useState(false);
-  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(
+    launchAgentId || null,
+  );
   const [selectedModelId, setSelectedModelId] = useState('');
   const [recentChatScope, setRecentChatScope] =
     useState<RecentChatScope>('user');
@@ -156,6 +169,7 @@ export function ChatPage() {
     useState<ChatRecentSession | null>(null);
 
   const [sessionSearchQuery, setSessionSearchQuery] = useState('');
+  const launchAgentSessionIdRef = useRef<string | null>(null);
   const debouncedSessionSearchQuery = useDebouncedValue(
     sessionSearchQuery,
     160,
@@ -216,6 +230,16 @@ export function ChatPage() {
     handleSessionIdCorrection,
   } = useChatSession();
 
+  useEffect(() => {
+    if (!launchAgentId) return;
+    launchAgentSessionIdRef.current = ensureSessionForSend();
+  }, [ensureSessionForSend, launchAgentId]);
+
+  const requestedHistoryAgentId =
+    sessionId && launchAgentSessionIdRef.current === sessionId
+      ? launchAgentId
+      : '';
+
   const refreshRecent = useCallback(() => {
     void queryClient.invalidateQueries({
       queryKey: chatRecentQueryPrefix(auth.token, userId),
@@ -264,7 +288,7 @@ export function ChatPage() {
   // to the gateway default whenever the session changes. We don't know what
   // model the new session was last set to, so the default is the best guess
   // until the user picks again.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: sessionId is intentionally a re-fire trigger, not read inside the body
+  // biome-ignore lint/correctness/useExhaustiveDependencies: sessionId intentionally resets the local model selection.
   useEffect(() => {
     const id = appStatusQuery.data?.defaultModel?.trim() ?? '';
     setSelectedModelId(id);
@@ -380,7 +404,13 @@ export function ChatPage() {
 
   const historyQuery = useQuery({
     queryKey: chatHistoryQueryKey(auth.token, sessionId),
-    queryFn: () => loadChatHistoryUi(auth.token, sessionId, userId),
+    queryFn: () =>
+      loadChatHistoryUi(
+        auth.token,
+        sessionId,
+        userId,
+        requestedHistoryAgentId || undefined,
+      ),
     enabled: chatApiReady && Boolean(sessionId),
     staleTime: Infinity,
   });
@@ -498,10 +528,13 @@ export function ChatPage() {
     if (id) setSelectedModelId(id);
   }, [contextQuery.data?.snapshot?.model]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: sessionId is intentionally a re-fire trigger, not read inside the body
   useEffect(() => {
+    if (launchAgentId && launchAgentSessionIdRef.current === sessionId) {
+      setSelectedAgentId(launchAgentId);
+      return;
+    }
     setSelectedAgentId(null);
-  }, [sessionId]);
+  }, [launchAgentId, sessionId]);
 
   useEffect(() => {
     if (!historyQuery.error) return;

--- a/console/src/routes/chat/use-chat-session.test.ts
+++ b/console/src/routes/chat/use-chat-session.test.ts
@@ -93,11 +93,13 @@ describe('useChatSession', () => {
     const router = await getTestRouter();
     const { result } = setup();
 
+    let returned = '';
     act(() => {
-      result.current.ensureSessionForSend();
+      returned = result.current.ensureSessionForSend();
     });
 
     const minted = result.current.getSessionId();
+    expect(returned).toBe(minted);
     expect(minted).not.toBe('');
     expect(minted).toMatch(/^sess_\d{8}_\d{6}_[0-9a-f]{8}$/);
     expect(router.navigate).toHaveBeenCalledTimes(1);
@@ -110,11 +112,13 @@ describe('useChatSession', () => {
     router.setSessionId('session-existing');
     const { result } = setup();
 
+    let returned = '';
     act(() => {
-      result.current.ensureSessionForSend();
+      returned = result.current.ensureSessionForSend();
     });
 
     expect(router.navigate).not.toHaveBeenCalled();
+    expect(returned).toBe('session-existing');
     expect(result.current.getSessionId()).toBe('session-existing');
   });
 

--- a/console/src/routes/chat/use-chat-session.ts
+++ b/console/src/routes/chat/use-chat-session.ts
@@ -18,7 +18,7 @@ export interface UseChatSessionReturn {
    */
   switchToSession: (id: string, opts?: { replace?: boolean }) => Promise<void>;
   startFreshChat: () => void;
-  ensureSessionForSend: () => void;
+  ensureSessionForSend: () => string;
   handleSessionIdCorrection: (serverSessionId: string) => void;
 }
 
@@ -72,12 +72,13 @@ export function useChatSession(): UseChatSessionReturn {
     void navigate({ to: '/chat' });
   }, [navigate]);
 
-  const ensureSessionForSend = useCallback(() => {
-    if (sessionIdRef.current) return;
+  const ensureSessionForSend = useCallback((): string => {
+    if (sessionIdRef.current) return sessionIdRef.current;
     const newId = generateWebSessionId();
     draftSessionIdRef.current = newId;
     sessionIdRef.current = newId;
     void navigateToSession(newId, { replace: true });
+    return newId;
   }, [navigateToSession]);
 
   const handleSessionIdCorrection = useCallback(

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -368,6 +368,7 @@ const DISCORD_MEDIA_CACHE_DIR = path.resolve(
 );
 const MAX_MEDIA_UPLOAD_BYTES = 20 * 1024 * 1024;
 const HYBRIDAI_LOGIN_PATH = '/login?context=hybridclaw&next=/admin_api_keys';
+const HISTORY_AGENT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 
 const SITE_MIME_TYPES: Record<string, string> = {
   '.css': 'text/css; charset=utf-8',
@@ -3496,19 +3497,33 @@ async function handleApiHistory(
     10,
   );
   const limit = Number.isNaN(parsedLimit) ? 40 : parsedLimit;
-  void ensureGatewayBootstrapAutostart({
-    sessionId,
-  }).catch((error) => {
-    logger.warn(
-      { sessionId, error },
-      'Failed to start gateway bootstrap autostart',
-    );
-  });
+  const rawAgentId = url.searchParams.get('agentId')?.trim() || '';
+  if (rawAgentId && !HISTORY_AGENT_ID_PATTERN.test(rawAgentId)) {
+    sendJson(res, 400, { error: 'Invalid `agentId` query parameter.' });
+    return;
+  }
+  const requestedAgentId = rawAgentId || undefined;
+  if (requestedAgentId && !getAgentById(requestedAgentId)) {
+    sendJson(res, 404, { error: 'Agent not found.' });
+    return;
+  }
   const operatorUserId = resolveGatewayRequestUserId({
     req,
     channelId: 'web',
     requestedUserId: url.searchParams.get('userId'),
     fallbackUserId: 'web',
+  });
+  void ensureGatewayBootstrapAutostart({
+    sessionId,
+    channelId: 'web',
+    userId: operatorUserId,
+    username: operatorUserId,
+    agentId: requestedAgentId,
+  }).catch((error) => {
+    logger.warn(
+      { sessionId, agentId: requestedAgentId ?? null, error },
+      'Failed to start gateway bootstrap autostart',
+    );
   });
   const historyPage = getGatewayHistory(sessionId, limit, {
     operatorUserId,
@@ -3518,6 +3533,8 @@ async function handleApiHistory(
   });
   const bootstrapAutostart = getGatewayBootstrapAutostartState({
     sessionId,
+    channelId: 'web',
+    agentId: requestedAgentId,
     allowExistingSessionMessages: true,
   });
   // These keys are returned only as chat-routing metadata for the web client.

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -4776,6 +4776,10 @@ describe('gateway HTTP server', () => {
 
     expect(state.ensureGatewayBootstrapAutostart).toHaveBeenCalledWith({
       sessionId: 's1',
+      channelId: 'web',
+      userId: 'web',
+      username: 'web',
+      agentId: undefined,
     });
     expect(state.getGatewayHistory).toHaveBeenCalledWith('s1', 2, {
       operatorUserId: 'web',


### PR DESCRIPTION
## What changed

- Read `/chat?agent=<id>` on initial chat load and preserve it as the launch agent hint.
- Mint or resolve a web chat session immediately for direct launch-agent chat startup.
- Pass `agentId` through console history loading to `/api/history`.
- Validate and honor `agentId` in the gateway history endpoint when triggering bootstrap autostart state.
- Add focused console regression coverage for `/chat?agent=assistant` with no existing session.

## Why

HybridAI can launch users directly into HybridClaw with an active assistant agent, but the old direct `/chat` path had no session id. Since `/api/history` is what triggers bootstrap autostart, onboarding stayed idle until the user sent a first message. The selected assistant agent also was not represented in the history/autostart call.

## Impact

Direct launch into `/chat?agent=assistant` now creates the initial session, calls history immediately with `agentId=assistant`, and lets the assistant proactive bootstrap start without waiting for user input.

Companion HybridAI PR: https://github.com/snoller/chat/pull/1800

## Validation

- `PATH='/Users/bkoehler/Library/Application Support/Herd/config/nvm/versions/node/v22.22.3/bin':$PATH npx biome check console/src/api/chat.ts console/src/routes/chat/chat-history-query.ts console/src/routes/chat/chat-page.tsx console/src/routes/chat/use-chat-session.ts console/src/routes/chat/chat-page.test.tsx console/src/routes/chat/use-chat-session.test.ts src/gateway/gateway-http-server.ts`
- `PATH='/Users/bkoehler/Library/Application Support/Herd/config/nvm/versions/node/v22.22.3/bin':$PATH npm --workspace console run test -- src/routes/chat/chat-page.test.tsx src/routes/chat/use-chat-session.test.ts`
- `PATH='/Users/bkoehler/Library/Application Support/Herd/config/nvm/versions/node/v22.22.3/bin':$PATH npm run typecheck`
- `git diff --check`