### PR TITLE
[codex] fix gateway foreground log mirroring

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -861,6 +861,8 @@ async function runGatewayForeground(
     delete process.env[GATEWAY_LOG_FILE_ENV];
   } else {
     process.env[GATEWAY_LOG_FILE_ENV] = GATEWAY_LOG_PATH;
+    const { enableGatewayLogFileMirror } = await import('./logger.js');
+    enableGatewayLogFileMirror(GATEWAY_LOG_PATH);
   }
   if (logRequests) {
     process.env[GATEWAY_LOG_REQUESTS_ENV] = '1';

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -45,11 +45,13 @@ function resolveForcedLogLevel():
 
 let forcedLevel = resolveForcedLogLevel();
 const initialLevel = forcedLevel || getRuntimeConfig().ops.logLevel;
-const gatewayLogFile = String(
-  process.env.HYBRIDCLAW_GATEWAY_LOG_FILE || '',
-).trim();
 const stdoutMirrorsGatewayLog =
   String(process.env.HYBRIDCLAW_GATEWAY_STDIO_TO_LOG || '').trim() === '1';
+const gatewayLogFile = stdoutMirrorsGatewayLog
+  ? ''
+  : String(process.env.HYBRIDCLAW_GATEWAY_LOG_FILE || '').trim();
+let loggerOutput: ReturnType<typeof pino.multistream> | null = null;
+let gatewayLogFileMirrorPath: string | null = null;
 
 function createPrettyDestination(
   prettyOptions: typeof LOGGER_PRETTY_OPTIONS,
@@ -81,6 +83,20 @@ function createPrettyDestination(
   });
 }
 
+function createGatewayLogFileDestination(
+  logFile: string,
+): NodeJS.WritableStream {
+  fs.mkdirSync(path.dirname(logFile), { recursive: true });
+  const fileStream = fs.createWriteStream(logFile, { flags: 'a' });
+  return createPrettyDestination(
+    {
+      ...LOGGER_PRETTY_OPTIONS,
+      colorize: false,
+    },
+    fileStream,
+  );
+}
+
 function createLogger() {
   const options = {
     errorKey: LOGGER_ERROR_KEY,
@@ -108,24 +124,41 @@ function createLogger() {
   ];
 
   if (gatewayLogFile) {
-    fs.mkdirSync(path.dirname(gatewayLogFile), { recursive: true });
-    const fileStream = fs.createWriteStream(gatewayLogFile, { flags: 'a' });
+    gatewayLogFileMirrorPath = path.resolve(gatewayLogFile);
     streams.push({
       level: 'trace',
-      stream: createPrettyDestination(
-        {
-          ...LOGGER_PRETTY_OPTIONS,
-          colorize: false,
-        },
-        fileStream,
-      ),
+      stream: createGatewayLogFileDestination(gatewayLogFile),
     });
   }
 
-  return pino(options, pino.multistream(streams));
+  loggerOutput = pino.multistream(streams);
+  return pino(options, loggerOutput);
 }
 
 export const logger = createLogger();
+
+export function enableGatewayLogFileMirror(logFile: string): void {
+  const trimmed = logFile.trim();
+  if (!trimmed) return;
+  const normalized = path.resolve(trimmed);
+  if (gatewayLogFileMirrorPath === normalized) return;
+  if (gatewayLogFileMirrorPath) {
+    logger.warn(
+      { configuredPath: gatewayLogFileMirrorPath, requestedPath: normalized },
+      'Gateway log file mirror already configured; ignoring new path',
+    );
+    return;
+  }
+  if (!loggerOutput) {
+    throw new Error('Logger output stream is not initialized.');
+  }
+
+  loggerOutput.add({
+    level: 'trace',
+    stream: createGatewayLogFileDestination(normalized),
+  });
+  gatewayLogFileMirrorPath = normalized;
+}
 
 if (forcedLevel) {
   logger.debug(

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1187,6 +1187,14 @@ async function importFreshCli(options?: {
   const removeGatewayPidFile = vi.fn();
   const writeGatewayPid = vi.fn();
   const isPidRunning = vi.fn(() => true);
+  const enableGatewayLogFileMirror = vi.fn();
+  const setLoggerStartupLevel = vi.fn();
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
   const gatewayModuleLoaded = vi.fn();
   const tuiModuleLoaded = vi.fn();
   const runTui = vi.fn(async () => {
@@ -1296,6 +1304,11 @@ async function importFreshCli(options?: {
     readGatewayPid,
     removeGatewayPidFile,
     writeGatewayPid,
+  }));
+  vi.doMock('../src/logger.js', () => ({
+    enableGatewayLogFileMirror,
+    logger,
+    setLoggerStartupLevel,
   }));
   vi.doMock('../src/gateway/gateway.ts', () => {
     if (options?.gatewayModuleError) throw options.gatewayModuleError;
@@ -1496,6 +1509,9 @@ async function importFreshCli(options?: {
     removeGatewayPidFile,
     writeGatewayPid,
     isPidRunning,
+    enableGatewayLogFileMirror,
+    setLoggerStartupLevel,
+    logger,
     gatewayModuleLoaded,
     loadSkillCatalog,
     initDatabase,
@@ -4803,6 +4819,7 @@ describe('CLI hybridai commands', () => {
   it('writes and cleans up a managed PID file for gateway start --foreground', async () => {
     const {
       cli,
+      enableGatewayLogFileMirror,
       ensureGatewayRunDir,
       ensureRuntimeCredentials,
       gatewayModuleLoaded,
@@ -4834,6 +4851,12 @@ describe('CLI hybridai commands', () => {
       requireCredentials: false,
     });
     expect(ensureGatewayRunDir).toHaveBeenCalled();
+    expect(process.env.HYBRIDCLAW_GATEWAY_LOG_FILE).toBe(
+      '/tmp/hybridclaw-data/gateway/gateway.log',
+    );
+    expect(enableGatewayLogFileMirror).toHaveBeenCalledWith(
+      '/tmp/hybridclaw-data/gateway/gateway.log',
+    );
     expect(writeGatewayPid).toHaveBeenCalledWith(
       expect.objectContaining({
         pid: process.pid,

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -58,6 +58,7 @@ describe('logger forced level override', () => {
     loadedLoggerModule = null;
     delete process.env.HYBRIDCLAW_FORCE_LOG_LEVEL;
     delete process.env.HYBRIDCLAW_GATEWAY_LOG_FILE;
+    delete process.env.HYBRIDCLAW_GATEWAY_STDIO_TO_LOG;
     if (tempDir) {
       void fs.rm(tempDir, { recursive: true, force: true });
       tempDir = null;
@@ -159,6 +160,50 @@ describe('logger forced level override', () => {
     );
 
     expect(logText).toContain('foreground log mirror test');
+  });
+
+  it('does not open the gateway log file when stdout already mirrors it', async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'hybridclaw-logger-'));
+    const logPath = path.join(tempDir, 'gateway.log');
+    process.env.HYBRIDCLAW_GATEWAY_LOG_FILE = logPath;
+    process.env.HYBRIDCLAW_GATEWAY_STDIO_TO_LOG = '1';
+
+    vi.doMock('../src/config/runtime-config.ts', () => ({
+      getRuntimeConfig: () => ({
+        ops: { logLevel: 'info' },
+      }),
+      onRuntimeConfigChange: vi.fn(),
+    }));
+
+    const { logger } = await importLoggerModule();
+
+    logger.info('stdio gateway log mirror test');
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    await expect(fs.stat(logPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('can enable the gateway log file mirror after logger initialization', async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'hybridclaw-logger-'));
+    const logPath = path.join(tempDir, 'gateway.log');
+
+    vi.doMock('../src/config/runtime-config.ts', () => ({
+      getRuntimeConfig: () => ({
+        ops: { logLevel: 'info' },
+      }),
+      onRuntimeConfigChange: vi.fn(),
+    }));
+
+    const { enableGatewayLogFileMirror, logger } = await importLoggerModule();
+    enableGatewayLogFileMirror(logPath);
+
+    logger.info('late gateway log mirror test');
+
+    const logText = await waitForFileText(logPath, (text) =>
+      text.includes('late gateway log mirror test'),
+    );
+
+    expect(logText).toContain('late gateway log mirror test');
   });
 
   it('writes debug logs when the forced level is debug', async () => {


### PR DESCRIPTION
## Summary

Fixes foreground gateway runs so they reliably write to the configured gateway log file even when the shared logger module has already been imported during CLI/config initialization.

## Root Cause

`src/config/config.ts` imports the logger during CLI startup. Foreground gateway startup set `HYBRIDCLAW_GATEWAY_LOG_FILE` later in `runGatewayForeground()`, so the logger had already snapshotted an empty log-file setting and never opened `~/.hybridclaw/data/gateway/gateway.log`.

## Changes

- Added `enableGatewayLogFileMirror()` to attach the gateway log file stream after logger initialization.
- Foreground gateway startup now explicitly enables that mirror after setting `HYBRIDCLAW_GATEWAY_LOG_FILE`.
- Kept background child behavior from double-opening the log file when stdout/stderr already point at the gateway log.
- Added logger and CLI regression tests for both paths.

## Validation

- `npx vitest run --configLoader runner --project unit tests/logger.test.ts tests/cli.test.ts tests/gateway-status.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npx biome check src/logger.ts src/cli.ts tests/logger.test.ts tests/cli.test.ts`
- `git diff --check`
- `npm run format`