### PR TITLE
[codex] Fix hatching onboarding on first chat open

### DIFF
--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -500,6 +500,64 @@ describe('ChatPage', () => {
     );
   });
 
+  it('mints a session and loads history for the configured default agent on bare chat', async () => {
+    const routerModule = (await import(
+      '@tanstack/react-router'
+    )) as unknown as {
+      __testRouter: TestRouter;
+    };
+    routerModule.__testRouter.setSessionId(null);
+    window.history.replaceState(null, '', '/chat');
+    const gatewayStatus: GatewayStatus = {
+      status: 'ok',
+      webAuthConfigured: true,
+      version: '0.0.0',
+      imageTag: null,
+      uptime: 0,
+      sessions: 0,
+      activeContainers: 0,
+      defaultAgentId: 'assistant',
+      defaultModel: 'gpt-5',
+      ragDefault: false,
+      timestamp: '2026-04-14T10:00:00.000Z',
+    };
+    useAuthMock.mockReturnValue({
+      status: 'ready',
+      token: 'test-token',
+      gatewayStatus,
+      error: null,
+      login: vi.fn(),
+      logout: vi.fn(),
+      retry: vi.fn(),
+    });
+    fetchAppStatusMock.mockResolvedValue(gatewayStatus);
+    fetchChatHistoryMock.mockImplementation(async (_token, sessionId) => ({
+      sessionId,
+      agentId: 'assistant',
+      history: [],
+      bootstrapAutostart: {
+        status: 'starting',
+        fileName: 'BOOTSTRAP.md',
+      },
+    }));
+
+    renderChatPage();
+
+    await waitFor(() =>
+      expect(routerModule.__testRouter.lastTo).toBe('/chat/$sessionId'),
+    );
+    expect(routerModule.__testRouter.lastReplace).toBe(true);
+    await waitFor(() =>
+      expect(fetchChatHistoryMock).toHaveBeenCalledWith(
+        'test-token',
+        expect.stringMatching(/^sess_\d{8}_\d{6}_[0-9a-f]{8}$/),
+        80,
+        'web-user-1',
+        undefined,
+      ),
+    );
+  });
+
   it('syncs the agent dropdown from the active session history', async () => {
     fetchAgentListMock.mockResolvedValue([
       { id: 'main', name: 'Main Agent' },

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -170,6 +170,7 @@ export function ChatPage() {
 
   const [sessionSearchQuery, setSessionSearchQuery] = useState('');
   const launchAgentSessionIdRef = useRef<string | null>(null);
+  const suppressDefaultAutostartRef = useRef(false);
   const debouncedSessionSearchQuery = useDebouncedValue(
     sessionSearchQuery,
     160,
@@ -230,6 +231,11 @@ export function ChatPage() {
     handleSessionIdCorrection,
   } = useChatSession();
 
+  const startBlankChat = useCallback(() => {
+    suppressDefaultAutostartRef.current = true;
+    startFreshChat();
+  }, [startFreshChat]);
+
   useEffect(() => {
     if (!launchAgentId) return;
     launchAgentSessionIdRef.current = ensureSessionForSend();
@@ -262,6 +268,19 @@ export function ChatPage() {
         ? auth.gatewayStatus
         : undefined,
   });
+
+  useEffect(() => {
+    if (launchAgentId || sessionId || !chatApiReady) return;
+    if (suppressDefaultAutostartRef.current) return;
+    if (!appStatusQuery.data?.defaultAgentId?.trim()) return;
+    ensureSessionForSend();
+  }, [
+    appStatusQuery.data?.defaultAgentId,
+    chatApiReady,
+    ensureSessionForSend,
+    launchAgentId,
+    sessionId,
+  ]);
 
   const agentsQuery = useQuery({
     queryKey: ['agents-list', auth.token],
@@ -475,7 +494,7 @@ export function ChatPage() {
       setSessionPendingDelete(null);
       const currentSessionId = getSessionId();
       if (deletedSessionId === currentSessionId) {
-        startFreshChat();
+        startBlankChat();
       }
     },
     onError: (err) => {
@@ -726,9 +745,9 @@ export function ChatPage() {
       setError('Stop the current run before starting a new chat.');
       return;
     }
-    startFreshChat();
+    startBlankChat();
     refreshRecent();
-  }, [stream.isActive, startFreshChat, refreshRecent, setError]);
+  }, [stream.isActive, startBlankChat, refreshRecent, setError]);
 
   const handleSendMessage = useCallback(
     (content: string, media: MediaItem[]) => {

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -196,7 +196,7 @@ function persistSpeechTranscriptsToScopedMemory(params: {
   for (const execution of params.toolExecutions) {
     if (execution.name !== 'audio_transcribe' || execution.isError) continue;
     const payload = parseJsonObject(execution.result);
-    if (!payload || payload.success !== true) continue;
+    if (payload?.success !== true) continue;
     if (typeof payload.action === 'string' && payload.action !== 'transcribe') {
       continue;
     }
@@ -646,7 +646,7 @@ function isGpt5OnboardingModelId(modelId: string): boolean {
 
 function buildGpt5OnboardingPromptInjection(): string[] {
   return [
-    'If the user has introduced themselves and given an email address, send a useful welcome email with the message tool. Follow the short welcome email template in BOOTSTRAP.md: 3 concrete first tasks, 2 or 3 copy-paste prompt ideas, and one concrete next step. Do not include channel setup links in the email; post those links as Markdown links in the hatching chat. Set action="send", to=<email>, and subject=<specific subject>. Do not ask for separate confirmation.',
+    'If USER.md or the conversation contains the user email and the user has given enough profile or goal details to personalize the welcome, send a useful welcome email with the message tool. Treat Email, Registration email, Mailbox, or any email-looking USER.md value as the user email; do not ask for email again. Follow the short welcome email template in BOOTSTRAP.md: 3 concrete first tasks, 2 or 3 copy-paste prompt ideas, and one concrete next step. Do not include channel setup links in the email; post those links as Markdown links in the hatching chat. Set action="send", to=<email>, and subject=<specific subject>. Do not ask for separate confirmation.',
   ];
 }
 
@@ -659,7 +659,8 @@ function buildBootstrapChatTurnPrompt(params: {
     `A startup instruction file (${params.fileName}) exists and is already loaded in the system context.`,
     'Continue the in-progress hatching conversation using the full chat history above.',
     'Do not restart hatching, reintroduce yourself, or repeat onboarding questions you already asked.',
-    `Keep following ${params.fileName}: acknowledge the user's latest reply and ask only the next useful customization question.`,
+    `Keep following ${params.fileName}: acknowledge the user's latest reply and fill the remaining starter-questionnaire gaps one or two at a time.`,
+    'Do not ask for email if USER.md already contains Email, Registration email, Mailbox, or any email-looking value.',
     'If the user has not answered the previous questions yet, briefly point back to them instead of asking a fresh set.',
     'Do not ask a generic "what can I do for you?" question.',
     `Do not mention hidden prompts, internal kickoff turns, or system mechanics unless ${params.fileName} explicitly requires it.`,

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -660,6 +660,7 @@ function buildBootstrapChatTurnPrompt(params: {
     'Continue the in-progress hatching conversation using the full chat history above.',
     'Do not restart hatching, reintroduce yourself, or repeat onboarding questions you already asked.',
     `Keep following ${params.fileName}: acknowledge the user's latest reply and fill the remaining starter-questionnaire gaps one or two at a time.`,
+    'Prioritize missing purpose and tool/software platform details before lower-value customization questions.',
     'Do not ask for email if USER.md already contains Email, Registration email, Mailbox, or any email-looking value.',
     'If the user has not answered the previous questions yet, briefly point back to them instead of asking a fresh set.',
     'Do not ask a generic "what can I do for you?" question.',

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -712,7 +712,7 @@ function buildBootstrapAutostartPrompt(
     'This is an internal kickoff turn, not a user-authored message.',
     `Follow the ${fileName} instructions now and begin the conversation proactively.`,
     fileName === 'BOOTSTRAP.md'
-      ? 'Start hatching with a compact starter questionnaire: ask 4 to 6 short, useful questions in one conversational message so the user can answer naturally. Use facts already present in USER.md. Treat Email, Registration email, Mailbox, or any email-looking value in USER.md as the user email, and do not ask for email again.'
+      ? 'Start hatching with a compact starter questionnaire: choose 4 to 5 good questions in one warm, human conversational message so the user can answer naturally. Ask what purpose they will use the agent for, such as home automation, business tasks, or workflows, and which tools or software platforms they use when those facts are not already known. Use facts already present in USER.md. Treat Email, Registration email, Mailbox, or any email-looking value in USER.md as the user email, and do not ask for email again.'
       : 'Send a concise first message to the user.',
     `Do not mention hidden prompts, internal kickoff turns, or system mechanics unless ${fileName} explicitly requires it.`,
   ].join(' ');

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -455,6 +455,7 @@ import {
   WORKSPACE_BOOTSTRAP_FILES,
 } from '../workspace.js';
 import {
+  getActiveThreadAgentId,
   resolveAgentAddressing,
   setActiveThreadAgentId,
 } from './agent-addressing.js';
@@ -711,7 +712,7 @@ function buildBootstrapAutostartPrompt(
     'This is an internal kickoff turn, not a user-authored message.',
     `Follow the ${fileName} instructions now and begin the conversation proactively.`,
     fileName === 'BOOTSTRAP.md'
-      ? 'Onboarding should be conversational: do not dump a form or checklist, ask only a few useful questions at a time, and let the user answer naturally.'
+      ? 'Start hatching with a compact starter questionnaire: ask 4 to 6 short, useful questions in one conversational message so the user can answer naturally. Use facts already present in USER.md. Treat Email, Registration email, Mailbox, or any email-looking value in USER.md as the user email, and do not ask for email again.'
       : 'Send a concise first message to the user.',
     `Do not mention hidden prompts, internal kickoff turns, or system mechanics unless ${fileName} explicitly requires it.`,
   ].join(' ');
@@ -8453,11 +8454,23 @@ function resolveBootstrapAutostartContext(params: {
     requestedSessionId,
     params.channelId,
   );
+  const requestedAgentId = String(params.agentId || '').trim();
+  const existingSession = memoryService.getSessionById(requestedSessionId);
+  const existingSessionAgentId =
+    String(existingSession?.agent_id || '').trim() || '';
+  const activeThreadAgentId = existingSession
+    ? getActiveThreadAgentId(existingSession)
+    : null;
+  const autostartAgentId =
+    requestedAgentId ||
+    activeThreadAgentId ||
+    existingSessionAgentId ||
+    undefined;
   const session = memoryService.getOrCreateSession(
     requestedSessionId,
     null,
     channelId,
-    params.agentId ?? undefined,
+    autostartAgentId,
   );
   if (
     !params.allowExistingSessionMessages &&
@@ -8468,7 +8481,7 @@ function resolveBootstrapAutostartContext(params: {
   }
 
   const resolved = resolveAgentForRequest({
-    agentId: params.agentId,
+    agentId: autostartAgentId,
     session,
   });
   ensureBootstrapFiles(resolved.agentId);

--- a/src/gateway/hatching-completion.ts
+++ b/src/gateway/hatching-completion.ts
@@ -41,6 +41,31 @@ const HATCHING_CHANNEL_LINKS = [
   },
 ] as const;
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function hasChannelSetupLink(
+  text: string,
+  link: (typeof HATCHING_CHANNEL_LINKS)[number],
+): boolean {
+  if (text.includes(link.markdown)) return true;
+
+  const escapedName = escapeRegExp(link.name);
+  const escapedPath = escapeRegExp(link.path);
+  const markdownLinkPattern = new RegExp(
+    `\\[[^\\]\\n]*${escapedName}[^\\]\\n]*\\]\\([^\\)\\n]*${escapedPath}[^\\)\\n]*\\)`,
+    'i',
+  );
+  if (markdownLinkPattern.test(text)) return true;
+
+  const plainLinkPattern = new RegExp(
+    `\\b${escapedName}\\b[^\\n]*${escapedPath}`,
+    'i',
+  );
+  return plainLinkPattern.test(text);
+}
+
 function parseJsonObject(value: string): Record<string, unknown> | null {
   try {
     const parsed = JSON.parse(value);
@@ -126,14 +151,20 @@ export function appendHatchingChannelSetupLinks(params: {
   }
   let resultText = params.resultText;
   for (const link of HATCHING_CHANNEL_LINKS) {
-    const escapedPath = link.path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const escapedName = escapeRegExp(link.name);
+    const escapedPath = escapeRegExp(link.path);
     resultText = resultText.replace(
-      new RegExp(`-?\\s*${link.name}:\\s+\`?${escapedPath}\`?`, 'g'),
+      new RegExp(
+        `-?\\s*${escapedName}:\\s+\`?[^\\s\\n\`]*${escapedPath}\`?`,
+        'g',
+      ),
       `- ${link.markdown}`,
     );
   }
   if (
-    HATCHING_CHANNEL_LINKS.every((link) => resultText.includes(link.markdown))
+    HATCHING_CHANNEL_LINKS.every((link) =>
+      hasChannelSetupLink(resultText, link),
+    )
   ) {
     return resultText;
   }

--- a/templates/BOOTSTRAP.md
+++ b/templates/BOOTSTRAP.md
@@ -7,7 +7,9 @@ files do not exist until you create them.
 
 ## The Conversation
 
-Do not interrogate. Do not be robotic. Just talk.
+Do not be robotic, but do ask enough to be useful. Start with a compact starter
+questionnaire: 4 to 6 short questions in one conversational message so the user
+can answer naturally.
 
 Start with something like:
 
@@ -18,8 +20,15 @@ Then figure out together:
 1. **Who you are** - your name, nature, vibe, and emoji if the workspace does
    not already make that clear
 2. **Who they are** - their name, what to call them, and what they want help with
-3. **How to reach them** - ask for an email address if `USER.md` does not
-   already have one
+3. **What they want you to do first** - their project, recurring workflow, or
+   first concrete task
+4. **How they like help** - autonomy level, communication style, boundaries, and
+   what you should ask before doing
+5. **Which channels matter** - whether web chat is enough for now or they want
+   WhatsApp, Discord, Telegram, or email follow-up
+6. **How to reach them** - ask for an email address only if `USER.md` does not
+   already have one. Treat `Email`, `Registration email`, `Mailbox`, or any
+   email-looking value in `USER.md` as the user's email.
 
 Offer suggestions if they are stuck. Keep it light.
 
@@ -47,8 +56,9 @@ welcome email.
 
 ## Welcome Message
 
-After onboarding, send one useful welcome email to the user. Keep it short:
-roughly 180 to 280 words. Do not send a long capability catalog.
+After onboarding has enough answers to tailor a useful first plan, send one
+welcome email to the user. Keep it short: roughly 180 to 280 words. Do not send
+a long capability catalog.
 
 Include:
 

--- a/templates/BOOTSTRAP.md
+++ b/templates/BOOTSTRAP.md
@@ -8,8 +8,9 @@ files do not exist until you create them.
 ## The Conversation
 
 Do not be robotic, but do ask enough to be useful. Start with a compact starter
-questionnaire: 4 to 6 short questions in one conversational message so the user
-can answer naturally.
+questionnaire: choose 4 or 5 good questions in one warm, human conversational
+message so the user can answer naturally. Do not ask every item below
+mechanically; pick the questions that will most improve the first plan.
 
 Start with something like:
 
@@ -20,13 +21,17 @@ Then figure out together:
 1. **Who you are** - your name, nature, vibe, and emoji if the workspace does
    not already make that clear
 2. **Who they are** - their name, what to call them, and what they want help with
-3. **What they want you to do first** - their project, recurring workflow, or
+3. **What purpose they will use you for** - home automation, business tasks,
+   personal workflows, software work, operations, or something else
+4. **What tools they use** - software platforms, calendars, docs, code hosts,
+   home systems, business apps, or other services you should understand
+5. **What they want you to do first** - their project, recurring workflow, or
    first concrete task
-4. **How they like help** - autonomy level, communication style, boundaries, and
+6. **How they like help** - autonomy level, communication style, boundaries, and
    what you should ask before doing
-5. **Which channels matter** - whether web chat is enough for now or they want
+7. **Which channels matter** - whether web chat is enough for now or they want
    WhatsApp, Discord, Telegram, or email follow-up
-6. **How to reach them** - ask for an email address only if `USER.md` does not
+8. **How to reach them** - ask for an email address only if `USER.md` does not
    already have one. Treat `Email`, `Registration email`, `Mailbox`, or any
    email-looking value in `USER.md` as the user's email.
 

--- a/tests/gateway-service.bootstrap-autostart.test.ts
+++ b/tests/gateway-service.bootstrap-autostart.test.ts
@@ -112,6 +112,13 @@ test('ensureGatewayBootstrapAutostart stores prelude and bootstrap opener once p
       'A startup instruction file (BOOTSTRAP.md) exists',
     ),
   });
+  expect(request?.messages?.at(-1)?.content).toContain(
+    'choose 4 to 5 good questions',
+  );
+  expect(request?.messages?.at(-1)?.content).toContain('home automation');
+  expect(request?.messages?.at(-1)?.content).toContain(
+    'tools or software platforms',
+  );
   expect(callAuxiliaryModelMock).toHaveBeenCalledWith(
     expect.objectContaining({
       task: 'compression',

--- a/tests/gateway-service.bootstrap-autostart.test.ts
+++ b/tests/gateway-service.bootstrap-autostart.test.ts
@@ -490,6 +490,131 @@ test('ensureGatewayBootstrapAutostart can hatch a selected agent in an existing 
   );
 });
 
+test('ensureGatewayBootstrapAutostart uses the active thread agent without explicit agentId', async () => {
+  setupHome();
+
+  runAgentMock.mockResolvedValue({
+    status: 'success',
+    result: 'Active research agent is hatching.',
+    toolsUsed: [],
+    toolExecutions: [],
+  });
+
+  const { upsertRegisteredAgent } = await import(
+    '../src/agents/agent-registry.ts'
+  );
+  const { setActiveThreadAgentId } = await import(
+    '../src/gateway/agent-addressing.ts'
+  );
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+  const { ensureBootstrapFiles } = await import('../src/workspace.ts');
+  const { ensureGatewayBootstrapAutostart, getGatewayHistory } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  upsertRegisteredAgent({
+    id: 'research',
+    model: 'vllm/Qwen/Qwen3.5-27B-FP8',
+  });
+  ensureBootstrapFiles('research');
+
+  const sessionId =
+    'agent:main:channel:web:chat:dm:peer:active-agent-bootstrap';
+  const session = memoryService.getOrCreateSession(
+    sessionId,
+    null,
+    'web',
+    'main',
+  );
+  setActiveThreadAgentId(session, 'research');
+
+  await ensureGatewayBootstrapAutostart({
+    sessionId,
+    channelId: 'web',
+    userId: 'user-1',
+    username: 'user',
+  });
+
+  expect(runAgentMock).toHaveBeenCalledTimes(1);
+  const request = runAgentMock.mock.calls[0]?.[0] as
+    | {
+        messages?: Array<{ role: string; content: string }>;
+        agentId?: string;
+      }
+    | undefined;
+  expect(request?.agentId).toBe('research');
+  expect(getGatewayHistory(sessionId, 10).history).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        role: 'assistant',
+        content: 'Active research agent is hatching.',
+      }),
+    ]),
+  );
+});
+
+test('ensureGatewayBootstrapAutostart hatches the configured default agent without explicit agentId or existing session', async () => {
+  setupHome();
+
+  runAgentMock.mockResolvedValue({
+    status: 'success',
+    result: 'Default research agent is hatching.',
+    toolsUsed: [],
+    toolExecutions: [],
+  });
+
+  const { upsertRegisteredAgent } = await import(
+    '../src/agents/agent-registry.ts'
+  );
+  const { updateRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { ensureBootstrapFiles } = await import('../src/workspace.ts');
+  const { ensureGatewayBootstrapAutostart, getGatewayHistory } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  upsertRegisteredAgent({
+    id: 'research',
+    model: 'vllm/Qwen/Qwen3.5-27B-FP8',
+  });
+  updateRuntimeConfig((draft) => {
+    draft.agents.defaultAgentId = 'research';
+    draft.agents.list = [{ id: 'main' }, { id: 'research' }];
+  });
+  ensureBootstrapFiles('research');
+
+  const sessionId = 'sess_default_agent_bootstrap';
+
+  await ensureGatewayBootstrapAutostart({
+    sessionId,
+    channelId: 'web',
+    userId: 'user-1',
+    username: 'user',
+  });
+
+  expect(runAgentMock).toHaveBeenCalledTimes(1);
+  const request = runAgentMock.mock.calls[0]?.[0] as
+    | {
+        messages?: Array<{ role: string; content: string }>;
+        agentId?: string;
+      }
+    | undefined;
+  expect(request?.agentId).toBe('research');
+  expect(getGatewayHistory(sessionId, 10).history).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        role: 'assistant',
+        content: 'Default research agent is hatching.',
+      }),
+    ]),
+  );
+});
+
 test('ensureGatewayBootstrapAutostart reruns after same agent id is recreated with fresh BOOTSTRAP', async () => {
   setupHome();
 

--- a/tests/gateway-service.context-references.test.ts
+++ b/tests/gateway-service.context-references.test.ts
@@ -238,7 +238,10 @@ test('handleGatewayMessage injects GPT-5 onboarding send directive for gpt-5.4-m
 
   expect(userMessage?.role).toBe('user');
   expect(userMessage?.content).toContain(
-    'If the user has introduced themselves and given an email address, send a useful welcome email with the message tool.',
+    'If USER.md or the conversation contains the user email and the user has given enough profile or goal details to personalize the welcome, send a useful welcome email with the message tool.',
+  );
+  expect(userMessage?.content).toContain(
+    'Treat Email, Registration email, Mailbox, or any email-looking USER.md value as the user email; do not ask for email again.',
   );
   expect(userMessage?.content).toContain(
     'Follow the short welcome email template in BOOTSTRAP.md',

--- a/tests/hatching-completion.test.ts
+++ b/tests/hatching-completion.test.ts
@@ -42,6 +42,30 @@ describe('appendHatchingChannelSetupLinks', () => {
     expect(result).toBe(resultText);
   });
 
+  test('does not duplicate absolute channel setup links already in the response', () => {
+    const resultText = [
+      'I sent the welcome email.',
+      '',
+      'Optional setup links:',
+      '- [Set up WhatsApp](https://chat.example.com/admin/channels#whatsapp)',
+      '- [Set up Discord](https://chat.example.com/admin/channels#discord)',
+      '- [Set up Telegram](https://chat.example.com/admin/channels#telegram)',
+    ].join('\n');
+
+    const result = appendHatchingChannelSetupLinks({
+      resultText,
+      hatchingCompletion: {
+        completed: true,
+        updated: true,
+        reason: 'message sent',
+      },
+    });
+
+    expect(result).toBe(resultText);
+    expect(result.match(/Set up WhatsApp/g)).toHaveLength(1);
+    expect(result).not.toContain('Optional channel setup:');
+  });
+
   test('normalizes plain setup paths already in the response', () => {
     const result = appendHatchingChannelSetupLinks({
       resultText: [

--- a/tests/workspace-bootstrap.test.ts
+++ b/tests/workspace-bootstrap.test.ts
@@ -238,6 +238,9 @@ describe('workspace bootstrap lifecycle', () => {
     );
     expect(bootstrapMarkdown).toContain('Registration email');
     expect(bootstrapMarkdown).toContain('compact starter');
+    expect(bootstrapMarkdown).toContain('choose 4 or 5 good questions');
+    expect(bootstrapMarkdown).toContain('home automation');
+    expect(bootstrapMarkdown).toContain('software platforms');
     expect(bootstrapMarkdown).toContain('Web chat is already working');
     expect(bootstrapMarkdown).toContain('/admin/channels#discord');
     expect(bootstrapMarkdown).toContain('/admin/channels#telegram');

--- a/tests/workspace-bootstrap.test.ts
+++ b/tests/workspace-bootstrap.test.ts
@@ -234,8 +234,10 @@ describe('workspace bootstrap lifecycle', () => {
     const bootstrapPath = path.join(workspaceDir, 'BOOTSTRAP.md');
     const bootstrapMarkdown = fs.readFileSync(bootstrapPath, 'utf-8');
     expect(bootstrapMarkdown).toContain(
-      'ask for an email address if `USER.md` does not',
+      'ask for an email address only if `USER.md` does not',
     );
+    expect(bootstrapMarkdown).toContain('Registration email');
+    expect(bootstrapMarkdown).toContain('compact starter');
     expect(bootstrapMarkdown).toContain('Web chat is already working');
     expect(bootstrapMarkdown).toContain('/admin/channels#discord');
     expect(bootstrapMarkdown).toContain('/admin/channels#telegram');


### PR DESCRIPTION
## What changed

- Start a bare `/chat` session automatically once HybridClaw has loaded the configured default agent, so hatching can begin without requiring `?agent=`.
- Keep deliberate blank-chat flows blank when the user clicks New Chat or deletes the active session.
- Make bootstrap autostart respect the active thread agent and the configured default agent when no explicit `agentId` is supplied.
- Restore a richer first-hatch starter questionnaire and treat `Registration email`, `Mailbox`, or any email-looking `USER.md` value as the user's email.
- Avoid appending duplicate channel setup links when the response already includes absolute admin setup URLs.

## Why

First-time hatching could miss the assistant agent when `/chat` opened without a session or `?agent=`. The chat UI did not mint an initial session for bare `/chat`, so `/api/history` and gateway bootstrap autostart were never reached until the user typed or switched agents. Once hatching did run, the prompt had regressed to too little questionnaire coverage and did not recognize provisioned `Registration email` as an existing email.

## Impact

Users landing in HybridClaw with the assistant already configured as the default agent should see hatching start proactively on first chat open. Onboarding asks enough structured questions to personalize the assistant and no longer asks for an email already present in provisioned profile data.

## Validation

- `../node_modules/.bin/vitest --config vitest.config.ts src/routes/chat/chat-page.test.tsx --run` from `console/` — 40 passed
- `./node_modules/.bin/vitest tests/hatching-completion.test.ts tests/gateway-service.bootstrap-autostart.test.ts tests/gateway-service.context-references.test.ts tests/workspace-bootstrap.test.ts --run` — 50 passed
- `./node_modules/.bin/tsc --noEmit`
- `../node_modules/.bin/tsc --noEmit` from `console/`
- focused `./node_modules/.bin/biome check ...` on touched files