### PR TITLE
[codex] Make allowed senders editable in admin

### DIFF
--- a/console/src/routes/channels.test.tsx
+++ b/console/src/routes/channels.test.tsx
@@ -1098,7 +1098,7 @@ describe('ChannelsPage', () => {
           daemonUrl: 'http://127.0.0.1:8080',
           account: '+14155550123',
           dmPolicy: 'allowlist',
-          allowFrom: ['+14155551212'],
+          allowFrom: ['+14155551212', '+14155559876'],
         },
       },
     });
@@ -1126,8 +1126,13 @@ describe('ChannelsPage', () => {
       target: { value: 'allowlist' },
     });
     fireEvent.change(screen.getByLabelText('Allowed DM senders'), {
-      target: { value: '+14155551212' },
+      target: { value: '+14155551212, +14155559876' },
     });
+    const addButtons = within(panel as HTMLElement).getAllByRole('button', {
+      name: 'Add',
+    });
+    expect(addButtons[0]).toBeTruthy();
+    fireEvent.click(addButtons[0] as HTMLElement);
     fireEvent.click(
       within(panel as HTMLElement).getByRole('button', {
         name: 'Save channel settings',
@@ -1143,7 +1148,7 @@ describe('ChannelsPage', () => {
             daemonUrl: 'http://127.0.0.1:8080',
             account: '+14155550123',
             dmPolicy: 'allowlist',
-            allowFrom: ['+14155551212'],
+            allowFrom: ['+14155551212', '+14155559876'],
           }),
         }),
       );

--- a/console/src/routes/channels.test.tsx
+++ b/console/src/routes/channels.test.tsx
@@ -1125,14 +1125,24 @@ describe('ChannelsPage', () => {
     fireEvent.change(screen.getByLabelText('DM policy'), {
       target: { value: 'allowlist' },
     });
+    const addDmSenderButton = within(panel as HTMLElement).getAllByRole(
+      'button',
+      {
+        name: 'Add',
+      },
+    )[0] as HTMLElement;
     fireEvent.change(screen.getByLabelText('Allowed DM senders'), {
-      target: { value: '+14155551212, +14155559876' },
+      target: { value: '+14155551212' },
     });
-    const addButtons = within(panel as HTMLElement).getAllByRole('button', {
-      name: 'Add',
+    fireEvent.click(addDmSenderButton);
+    fireEvent.change(screen.getByLabelText('Allowed DM senders'), {
+      target: { value: '+14155551212' },
     });
-    expect(addButtons[0]).toBeTruthy();
-    fireEvent.click(addButtons[0] as HTMLElement);
+    fireEvent.click(addDmSenderButton);
+    fireEvent.change(screen.getByLabelText('Allowed DM senders'), {
+      target: { value: '+14155559876' },
+    });
+    fireEvent.click(addDmSenderButton);
     fireEvent.click(
       within(panel as HTMLElement).getByRole('button', {
         name: 'Save channel settings',
@@ -1153,6 +1163,50 @@ describe('ChannelsPage', () => {
         }),
       );
     });
+  });
+
+  it('confirms and labels wildcard Signal allowlist entries', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    fetchConfigMock.mockResolvedValue({
+      path: '/tmp/config.json',
+      config: makeConfig({
+        signal: {
+          ...makeConfig().signal,
+          enabled: true,
+          account: '+14155550123',
+          dmPolicy: 'allowlist',
+        },
+      }),
+    });
+
+    renderChannelsPage();
+
+    await screen.findByRole('button', { name: /Signal/i });
+    fireEvent.click(screen.getByRole('button', { name: /Signal/i }));
+
+    const panel = screen
+      .getByRole('heading', { name: 'Signal settings' })
+      .closest('[data-slot="card"]');
+    expect(panel).not.toBeNull();
+
+    const addDmSenderButton = within(panel as HTMLElement).getAllByRole(
+      'button',
+      {
+        name: 'Add',
+      },
+    )[0] as HTMLElement;
+    fireEvent.change(screen.getByLabelText('Allowed DM senders'), {
+      target: { value: '*' },
+    });
+    fireEvent.click(addDmSenderButton);
+
+    expect(confirmSpy).toHaveBeenCalledWith(
+      'Adding * allows every sender for this allowlist. Continue?',
+    );
+    expect(within(panel as HTMLElement).getByText('*')).toBeTruthy();
+    expect(within(panel as HTMLElement).getByText('all senders')).toBeTruthy();
+
+    confirmSpy.mockRestore();
   });
 
   it('starts Signal linked-device setup and renders the QR', async () => {

--- a/console/src/routes/channels.tsx
+++ b/console/src/routes/channels.tsx
@@ -92,6 +92,22 @@ function ListField(props: {
   );
 }
 
+const WILDCARD_ALLOW_ENTRY = '*';
+
+function normalizeAllowListEntry(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function dedupeAllowListEntries(values: string[]): string[] {
+  const entries: string[] = [];
+  for (const value of values) {
+    if (!value || entries.includes(value)) continue;
+    entries.push(value);
+  }
+  return entries;
+}
+
 function AllowListField(props: {
   label: string;
   value: string[];
@@ -99,15 +115,25 @@ function AllowListField(props: {
   onChange: (value: string[]) => void;
 }) {
   const [nextValue, setNextValue] = useState('');
-  const entries = [
-    ...new Set(props.value.map((entry) => entry.trim()).filter(Boolean)),
-  ];
-  const canAdd = parseStringList(nextValue).length > 0;
+  const entries = dedupeAllowListEntries(props.value);
+  const nextEntry = normalizeAllowListEntry(nextValue);
+  const canAdd = nextEntry !== null;
 
-  const addEntries = () => {
-    const nextEntries = parseStringList(nextValue);
-    if (nextEntries.length === 0) return;
-    props.onChange([...new Set([...entries, ...nextEntries])]);
+  const addEntry = () => {
+    if (!nextEntry) return;
+    if (
+      nextEntry === WILDCARD_ALLOW_ENTRY &&
+      !entries.includes(WILDCARD_ALLOW_ENTRY) &&
+      !window.confirm(
+        'Adding * allows every sender for this allowlist. Continue?',
+      )
+    ) {
+      return;
+    }
+
+    // Channel runtimes own format-specific normalization. The admin UI only
+    // trims and dedupes raw entries so channel-specific identities stay valid.
+    props.onChange(dedupeAllowListEntries([...entries, nextEntry]));
     setNextValue('');
   };
 
@@ -118,7 +144,7 @@ function AllowListField(props: {
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key !== 'Enter') return;
     event.preventDefault();
-    addEntries();
+    addEntry();
   };
 
   return (
@@ -135,7 +161,7 @@ function AllowListField(props: {
           type="button"
           variant="ghost"
           disabled={!canAdd}
-          onClick={addEntries}
+          onClick={addEntry}
         >
           Add
         </Button>
@@ -143,8 +169,20 @@ function AllowListField(props: {
       {entries.length > 0 ? (
         <ul className="allow-list-items">
           {entries.map((entry) => (
-            <li className="allow-list-item" key={entry}>
-              <span>{entry}</span>
+            <li
+              className={
+                entry === WILDCARD_ALLOW_ENTRY
+                  ? 'allow-list-item allow-list-item-wildcard'
+                  : 'allow-list-item'
+              }
+              key={entry}
+            >
+              <div className="allow-list-entry-main">
+                <span className="allow-list-entry-value">{entry}</span>
+                {entry === WILDCARD_ALLOW_ENTRY ? (
+                  <span className="allow-list-warning-label">all senders</span>
+                ) : null}
+              </div>
               <Button
                 type="button"
                 variant="ghost"

--- a/console/src/routes/channels.tsx
+++ b/console/src/routes/channels.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
+import { type KeyboardEvent, useEffect, useState } from 'react';
 import {
   fetchAdminAgents,
   fetchConfig,
@@ -89,6 +89,76 @@ function ListField(props: {
         placeholder={props.placeholder}
       />
     </label>
+  );
+}
+
+function AllowListField(props: {
+  label: string;
+  value: string[];
+  placeholder?: string;
+  onChange: (value: string[]) => void;
+}) {
+  const [nextValue, setNextValue] = useState('');
+  const entries = props.value.map((entry) => entry.trim()).filter(Boolean);
+  const canAdd = parseStringList(nextValue).length > 0;
+
+  const addEntries = () => {
+    const nextEntries = parseStringList(nextValue);
+    if (nextEntries.length === 0) return;
+    props.onChange([...entries, ...nextEntries]);
+    setNextValue('');
+  };
+
+  const removeEntry = (index: number) => {
+    props.onChange(entries.filter((_, entryIndex) => entryIndex !== index));
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== 'Enter') return;
+    event.preventDefault();
+    addEntries();
+  };
+
+  return (
+    <Field className="allow-list-field">
+      <FieldLabel>{props.label}</FieldLabel>
+      <div className="allow-list-add-row">
+        <Input
+          value={nextValue}
+          onChange={(event) => setNextValue(event.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={props.placeholder}
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          disabled={!canAdd}
+          onClick={addEntries}
+        >
+          Add
+        </Button>
+      </div>
+      {entries.length > 0 ? (
+        <div className="allow-list-items" role="list">
+          {entries.map((entry, index) => (
+            <div className="allow-list-item" role="listitem" key={`${index}-${entry}`}>
+              <span>{entry}</span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label={`Remove ${entry}`}
+                onClick={() => removeEntry(index)}
+              >
+                <Trash width={15} height={15} />
+              </Button>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="muted-copy">No allowed senders configured.</p>
+      )}
+    </Field>
   );
 }
 
@@ -751,11 +821,10 @@ function WhatsAppChannelEditor(props: {
       <FormField
         name="whatsapp.allowFrom"
         render={({ field }) => (
-          <ListField
+          <AllowListField
             label="Allowed DM senders"
             value={field.value as string[]}
-            rows={3}
-            placeholder="comma or newline separated"
+            placeholder="+14155551212 or *"
             onChange={field.onChange}
           />
         )}
@@ -764,11 +833,10 @@ function WhatsAppChannelEditor(props: {
       <FormField
         name="whatsapp.groupAllowFrom"
         render={({ field }) => (
-          <ListField
+          <AllowListField
             label="Allowed group senders"
             value={field.value as string[]}
-            rows={3}
-            placeholder="comma or newline separated"
+            placeholder="+14155551212 or *"
             onChange={field.onChange}
           />
         )}
@@ -963,10 +1031,9 @@ function TelegramChannelEditor(props: {
       <FormField
         name="telegram.allowFrom"
         render={({ field }) => (
-          <ListField
+          <AllowListField
             label="Allowed DM senders"
             value={field.value as string[]}
-            rows={3}
             placeholder="numeric user id, @username, or *"
             onChange={field.onChange}
           />
@@ -976,10 +1043,9 @@ function TelegramChannelEditor(props: {
       <FormField
         name="telegram.groupAllowFrom"
         render={({ field }) => (
-          <ListField
+          <AllowListField
             label="Allowed group senders"
             value={field.value as string[]}
-            rows={3}
             placeholder="numeric user id, @username, or *"
             onChange={field.onChange}
           />
@@ -1114,10 +1180,9 @@ function ThreemaChannelEditor(props: {
       <FormField
         name="threema.allowFrom"
         render={({ field }) => (
-          <ListField
+          <AllowListField
             label="Allowed senders"
             value={field.value as string[]}
-            rows={3}
             placeholder="threema:ABCDEFGH, threema:phone:41791234567, or *"
             onChange={field.onChange}
           />
@@ -1358,10 +1423,9 @@ function SignalChannelEditor(props: {
       <FormField
         name="signal.allowFrom"
         render={({ field }) => (
-          <ListField
+          <AllowListField
             label="Allowed DM senders"
             value={field.value as string[]}
-            rows={3}
             placeholder="+14155551212, Signal UUID, or *"
             onChange={field.onChange}
           />
@@ -1371,10 +1435,9 @@ function SignalChannelEditor(props: {
       <FormField
         name="signal.groupAllowFrom"
         render={({ field }) => (
-          <ListField
+          <AllowListField
             label="Allowed group senders"
             value={field.value as string[]}
-            rows={3}
             placeholder="+14155551212, Signal UUID, or *"
             onChange={field.onChange}
           />
@@ -1791,10 +1854,9 @@ function EmailChannelEditor(props: {
       <FormField
         name="email.allowFrom"
         render={({ field }) => (
-          <ListField
+          <AllowListField
             label="Allowed senders"
             value={field.value as string[]}
-            rows={3}
             placeholder="name@example.com, *@example.com"
             onChange={field.onChange}
           />
@@ -2084,10 +2146,9 @@ function EmailChannelEditor(props: {
                     }
                   />
 
-                  <ListField
+                  <AllowListField
                     label="Mailbox allowed senders"
                     value={account.allowFrom}
-                    rows={2}
                     placeholder="name@example.com, *@example.com"
                     onChange={(allowFrom) =>
                       updateEmailAccount(index, (current) => ({
@@ -2479,11 +2540,10 @@ function TeamsChannelEditor(props: {
       <FormField
         name="msteams.allowFrom"
         render={({ field }) => (
-          <ListField
+          <AllowListField
             label="Allowed AAD object IDs"
             value={field.value as string[]}
-            rows={4}
-            placeholder="comma or newline separated"
+            placeholder="AAD object ID or *"
             onChange={field.onChange}
           />
         )}
@@ -2651,11 +2711,10 @@ function SlackChannelEditor(props: {
       <FormField
         name="slack.allowFrom"
         render={({ field }) => (
-          <ListField
+          <AllowListField
             label="Allowed DM Slack user IDs"
             value={field.value as string[]}
-            rows={4}
-            placeholder="comma or newline separated"
+            placeholder="Slack user ID or *"
             onChange={field.onChange}
           />
         )}
@@ -2664,11 +2723,10 @@ function SlackChannelEditor(props: {
       <FormField
         name="slack.groupAllowFrom"
         render={({ field }) => (
-          <ListField
+          <AllowListField
             label="Allowed channel Slack user IDs"
             value={field.value as string[]}
-            rows={4}
-            placeholder="comma or newline separated"
+            placeholder="Slack user ID or *"
             onChange={field.onChange}
           />
         )}
@@ -3142,10 +3200,9 @@ function IMessageChannelEditor(props: {
       <FormField
         name="imessage.allowFrom"
         render={({ field }) => (
-          <ListField
+          <AllowListField
             label="Allowed DM senders"
             value={field.value as string[]}
-            rows={3}
             placeholder="phone, email, or chat:id"
             onChange={field.onChange}
           />
@@ -3155,10 +3212,9 @@ function IMessageChannelEditor(props: {
       <FormField
         name="imessage.groupAllowFrom"
         render={({ field }) => (
-          <ListField
+          <AllowListField
             label="Allowed group senders"
             value={field.value as string[]}
-            rows={3}
             placeholder="phone, email, or chat:id"
             onChange={field.onChange}
           />

--- a/console/src/routes/channels.tsx
+++ b/console/src/routes/channels.tsx
@@ -99,18 +99,20 @@ function AllowListField(props: {
   onChange: (value: string[]) => void;
 }) {
   const [nextValue, setNextValue] = useState('');
-  const entries = props.value.map((entry) => entry.trim()).filter(Boolean);
+  const entries = [
+    ...new Set(props.value.map((entry) => entry.trim()).filter(Boolean)),
+  ];
   const canAdd = parseStringList(nextValue).length > 0;
 
   const addEntries = () => {
     const nextEntries = parseStringList(nextValue);
     if (nextEntries.length === 0) return;
-    props.onChange([...entries, ...nextEntries]);
+    props.onChange([...new Set([...entries, ...nextEntries])]);
     setNextValue('');
   };
 
-  const removeEntry = (index: number) => {
-    props.onChange(entries.filter((_, entryIndex) => entryIndex !== index));
+  const removeEntry = (entryToRemove: string) => {
+    props.onChange(entries.filter((entry) => entry !== entryToRemove));
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
@@ -139,22 +141,22 @@ function AllowListField(props: {
         </Button>
       </div>
       {entries.length > 0 ? (
-        <div className="allow-list-items" role="list">
-          {entries.map((entry, index) => (
-            <div className="allow-list-item" role="listitem" key={`${index}-${entry}`}>
+        <ul className="allow-list-items">
+          {entries.map((entry) => (
+            <li className="allow-list-item" key={entry}>
               <span>{entry}</span>
               <Button
                 type="button"
                 variant="ghost"
                 size="icon"
                 aria-label={`Remove ${entry}`}
-                onClick={() => removeEntry(index)}
+                onClick={() => removeEntry(entry)}
               >
                 <Trash width={15} height={15} />
               </Button>
-            </div>
+            </li>
           ))}
-        </div>
+        </ul>
       ) : (
         <p className="muted-copy">No allowed senders configured.</p>
       )}

--- a/console/src/styles.css
+++ b/console/src/styles.css
@@ -2155,6 +2155,9 @@ th {
 .allow-list-items {
   display: grid;
   gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
 .allow-list-item {

--- a/console/src/styles.css
+++ b/console/src/styles.css
@@ -2171,7 +2171,20 @@ th {
   background: var(--chip-surface);
 }
 
-.allow-list-item span {
+.allow-list-item-wildcard {
+  border-color: var(--danger-border);
+  background: var(--danger-soft);
+}
+
+.allow-list-entry-main {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.allow-list-entry-value {
   min-width: 0;
   overflow-wrap: anywhere;
   color: var(--text);
@@ -2180,6 +2193,20 @@ th {
     "Liberation Mono", "Courier New", monospace;
   font-size: 0.84rem;
   line-height: 1.35;
+}
+
+.allow-list-warning-label {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 2px 7px;
+  border: 1px solid var(--danger-border);
+  border-radius: 999px;
+  background: var(--panel-bg);
+  color: var(--danger);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
 }
 
 .email-account-section,

--- a/console/src/styles.css
+++ b/console/src/styles.css
@@ -2141,6 +2141,44 @@ th {
   background: var(--panel-muted);
 }
 
+.allow-list-field {
+  align-content: start;
+}
+
+.allow-list-add-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.allow-list-items {
+  display: grid;
+  gap: 8px;
+}
+
+.allow-list-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 6px 6px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--chip-surface);
+}
+
+.allow-list-item span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--text);
+  font-family:
+    ui-monospace, SFMono-Regular, SFMono, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+  font-size: 0.84rem;
+  line-height: 1.35;
+}
+
 .email-account-section,
 .email-account-list,
 .email-account-row {


### PR DESCRIPTION
## Summary

- Replaces raw sender allowlist textareas in the admin channel settings with an explicit add/remove list editor.
- Applies the editor to DM/group sender allowlists across chat, email, Slack, Teams, and iMessage channel settings while leaving non-sender list fields as textareas.
- Updates the channel settings test to cover adding multiple Signal allowed senders through the UI.

## Why

The underlying config already stores allowed senders as arrays, but the admin UI made adding more senders implicit by requiring comma/newline editing in a textarea. This makes the affordance explicit without changing the saved config shape or runtime authorization behavior.

## Impact

Admins can add and remove multiple allowed senders directly in `/admin/channels`. Existing configs remain compatible because the API payload still uses the same `string[]` fields.

## Validation

- `npx biome check --write console/src/routes/channels.tsx console/src/routes/channels.test.tsx console/src/styles.css`
- `npm --workspace console run test -- src/routes/channels.test.tsx`
- `npm --workspace console run typecheck`