### PR TITLE
[codex] Start hatching from bare chat

### DIFF
--- a/console/src/api/chat-types.ts
+++ b/console/src/api/chat-types.ts
@@ -10,6 +10,12 @@ export interface ChatRecentResponse {
   sessions: ChatRecentSession[];
 }
 
+export interface ChatCleanupResponse {
+  deletedCount: number;
+  deletedSessionIds: string[];
+  keptSessionId?: string;
+}
+
 export interface ChatMobileQrResponse {
   launchUrl: string;
   expiresAt: string;

--- a/console/src/api/chat.ts
+++ b/console/src/api/chat.ts
@@ -1,5 +1,6 @@
 import type {
   BranchResponse,
+  ChatCleanupResponse,
   ChatCommandsResponse,
   ChatContextResponse,
   ChatHistoryResponse,
@@ -38,6 +39,25 @@ export function fetchChatRecent(
   return requestJson<ChatRecentResponse>(
     `/api/chat/recent?${params.toString()}`,
     { token },
+  );
+}
+
+export function cleanupNoUserChatSessions(
+  token: string,
+  params: {
+    channelId?: string;
+    keepSessionId?: string;
+  },
+): Promise<ChatCleanupResponse> {
+  const query = new URLSearchParams({
+    channelId: params.channelId || 'web',
+  });
+  if (params.keepSessionId) {
+    query.set('keepSessionId', params.keepSessionId);
+  }
+  return requestJson<ChatCleanupResponse>(
+    `/api/chat/cleanup?${query.toString()}`,
+    { token, method: 'POST' },
   );
 }
 

--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -972,8 +972,14 @@ export function deleteAdminEmailMessage(
 export function deleteSession(
   token: string,
   sessionId: string,
+  options?: {
+    onlyWithoutUserMessages?: boolean;
+  },
 ): Promise<DeleteSessionResult> {
   const params = new URLSearchParams({ sessionId });
+  if (options?.onlyWithoutUserMessages) {
+    params.set('ifNoUserMessages', '1');
+  }
   return requestJson<DeleteSessionResult>(
     `/api/admin/sessions?${params.toString()}`,
     {

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -2448,6 +2448,7 @@ export interface AdminSecretMutationResponse {
 export interface DeleteSessionResult {
   deleted: boolean;
   sessionId: string;
+  skippedReason?: 'has_user_messages';
   deletedMessages: number;
   deletedTasks: number;
   deletedSemanticMemories: number;

--- a/console/src/routes/chat/chat-history-query.ts
+++ b/console/src/routes/chat/chat-history-query.ts
@@ -10,6 +10,7 @@ import type { ChatUiMessage } from './chat-ui-message';
 export interface ChatHistoryUiData {
   messages: ChatUiMessage[];
   branchFamilies: Map<string, BranchVariant[]>;
+  requestedSessionId: string;
   resolvedSessionId: string;
   agentId: string | null;
   bootstrapAutostart: ChatHistoryResponse['bootstrapAutostart'];
@@ -94,6 +95,7 @@ export function buildChatHistoryUiData(
   return {
     messages,
     branchFamilies,
+    requestedSessionId,
     resolvedSessionId,
     agentId: raw.agentId?.trim() || null,
     bootstrapAutostart: raw.bootstrapAutostart ?? null,

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -19,6 +19,7 @@ vi.mock('@tanstack/react-router', async () => {
 
 import type {
   BranchResponse,
+  ChatCleanupResponse,
   ChatContextResponse,
   ChatHistoryResponse,
   ChatMobileQrResponse,
@@ -60,8 +61,21 @@ const fetchChatHistoryMock =
   >();
 const fetchChatContextMock =
   vi.fn<(token: string, sessionId: string) => Promise<ChatContextResponse>>();
+const cleanupNoUserChatSessionsMock =
+  vi.fn<
+    (
+      token: string,
+      params: { channelId?: string; keepSessionId?: string },
+    ) => Promise<ChatCleanupResponse>
+  >();
 const deleteChatSessionMock =
-  vi.fn<(token: string, sessionId: string) => Promise<DeleteSessionResult>>();
+  vi.fn<
+    (
+      token: string,
+      sessionId: string,
+      options?: { onlyWithoutUserMessages?: boolean },
+    ) => Promise<DeleteSessionResult>
+  >();
 const createChatMobileQrMock =
   vi.fn<
     (
@@ -102,6 +116,10 @@ const isActiveMock = vi.fn();
 const useChatStreamMock = vi.fn();
 
 vi.mock('../../api/chat', () => ({
+  cleanupNoUserChatSessions: (
+    token: string,
+    params: { channelId?: string; keepSessionId?: string },
+  ) => cleanupNoUserChatSessionsMock(token, params),
   fetchAppStatus: (token: string) => fetchAppStatusMock(token),
   fetchChatRecent: (
     token: string,
@@ -141,8 +159,11 @@ vi.mock('../../api/chat', () => ({
 }));
 
 vi.mock('../../api/client', () => ({
-  deleteSession: (token: string, sessionId: string) =>
-    deleteChatSessionMock(token, sessionId),
+  deleteSession: (
+    token: string,
+    sessionId: string,
+    options?: { onlyWithoutUserMessages?: boolean },
+  ) => deleteChatSessionMock(token, sessionId, options),
   fetchAgentList: (token: string) => fetchAgentListMock(token),
   fetchModels: (token: string) => fetchModelsMock(token),
   fetchSkills: (token: string) => fetchSkillsMock(token),
@@ -257,6 +278,7 @@ describe('ChatPage', () => {
     fetchChatRecentMock.mockReset();
     fetchChatHistoryMock.mockReset();
     fetchChatContextMock.mockReset();
+    cleanupNoUserChatSessionsMock.mockReset();
     deleteChatSessionMock.mockReset();
     createChatMobileQrMock.mockReset();
     createChatBranchMock.mockReset();
@@ -336,6 +358,10 @@ describe('ChatPage', () => {
     fetchChatContextMock.mockResolvedValue({
       sessionId: 'session-a',
       snapshot: null,
+    });
+    cleanupNoUserChatSessionsMock.mockResolvedValue({
+      deletedCount: 0,
+      deletedSessionIds: [],
     });
     deleteChatSessionMock.mockResolvedValue({
       deleted: true,
@@ -564,17 +590,6 @@ describe('ChatPage', () => {
     )) as unknown as {
       __testRouter: TestRouter;
     };
-    deleteChatSessionMock.mockImplementation(async (_token, sessionId) => ({
-      deleted: true,
-      sessionId,
-      deletedMessages: sessionId === 'session-a' ? 1 : 0,
-      deletedTasks: 0,
-      deletedSemanticMemories: 0,
-      deletedUsageEvents: 0,
-      deletedAuditEntries: 0,
-      deletedStructuredAuditEntries: 0,
-      deletedApprovalEntries: 0,
-    }));
     fetchChatHistoryMock.mockImplementation(async (_token, sessionId) => ({
       sessionId,
       history:
@@ -613,11 +628,12 @@ describe('ChatPage', () => {
       ),
     );
     await waitFor(() =>
-      expect(deleteChatSessionMock).toHaveBeenCalledWith(
-        'test-token',
-        'session-a',
-      ),
+      expect(cleanupNoUserChatSessionsMock).toHaveBeenCalledWith('test-token', {
+        channelId: 'web',
+        keepSessionId: expect.stringMatching(/^sess_\d{8}_\d{6}_[0-9a-f]{8}$/),
+      }),
     );
+    expect(deleteChatSessionMock).not.toHaveBeenCalled();
 
     const firstFreshSessionId = fetchChatHistoryMock.mock.calls
       .map((call) => call[1])
@@ -629,11 +645,12 @@ describe('ChatPage', () => {
     );
 
     await waitFor(() =>
-      expect(deleteChatSessionMock).toHaveBeenCalledWith(
-        'test-token',
-        firstFreshSessionId,
-      ),
+      expect(cleanupNoUserChatSessionsMock).toHaveBeenCalledWith('test-token', {
+        channelId: 'web',
+        keepSessionId: expect.stringMatching(/^sess_\d{8}_\d{6}_[0-9a-f]{8}$/),
+      }),
     );
+    expect(cleanupNoUserChatSessionsMock).toHaveBeenCalledTimes(2);
   });
 
   it('keeps sessions with user messages when starting a new conversation', async () => {
@@ -664,6 +681,12 @@ describe('ChatPage', () => {
 
     await waitFor(() =>
       expect(routerModule.__testRouter.lastTo).toBe('/chat/$sessionId'),
+    );
+    await waitFor(() =>
+      expect(cleanupNoUserChatSessionsMock).toHaveBeenCalledWith('test-token', {
+        channelId: 'web',
+        keepSessionId: expect.stringMatching(/^sess_\d{8}_\d{6}_[0-9a-f]{8}$/),
+      }),
     );
     expect(deleteChatSessionMock).not.toHaveBeenCalled();
   });

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -500,6 +500,64 @@ describe('ChatPage', () => {
     );
   });
 
+  it('mints a session and loads history for the configured default agent on bare chat', async () => {
+    const routerModule = (await import(
+      '@tanstack/react-router'
+    )) as unknown as {
+      __testRouter: TestRouter;
+    };
+    routerModule.__testRouter.setSessionId(null);
+    window.history.replaceState(null, '', '/chat');
+    const gatewayStatus: GatewayStatus = {
+      status: 'ok',
+      webAuthConfigured: true,
+      version: '0.0.0',
+      imageTag: null,
+      uptime: 0,
+      sessions: 0,
+      activeContainers: 0,
+      defaultAgentId: 'assistant',
+      defaultModel: 'gpt-5',
+      ragDefault: false,
+      timestamp: '2026-04-14T10:00:00.000Z',
+    };
+    useAuthMock.mockReturnValue({
+      status: 'ready',
+      token: 'test-token',
+      gatewayStatus,
+      error: null,
+      login: vi.fn(),
+      logout: vi.fn(),
+      retry: vi.fn(),
+    });
+    fetchAppStatusMock.mockResolvedValue(gatewayStatus);
+    fetchChatHistoryMock.mockImplementation(async (_token, sessionId) => ({
+      sessionId,
+      agentId: 'assistant',
+      history: [],
+      bootstrapAutostart: {
+        status: 'starting',
+        fileName: 'BOOTSTRAP.md',
+      },
+    }));
+
+    renderChatPage();
+
+    await waitFor(() =>
+      expect(routerModule.__testRouter.lastTo).toBe('/chat/$sessionId'),
+    );
+    expect(routerModule.__testRouter.lastReplace).toBe(true);
+    await waitFor(() =>
+      expect(fetchChatHistoryMock).toHaveBeenCalledWith(
+        'test-token',
+        expect.stringMatching(/^sess_\d{8}_\d{6}_[0-9a-f]{8}$/),
+        80,
+        'web-user-1',
+        undefined,
+      ),
+    );
+  });
+
   it('syncs the agent dropdown from the active session history', async () => {
     fetchAgentListMock.mockResolvedValue([
       { id: 'main', name: 'Main Agent' },

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -558,6 +558,116 @@ describe('ChatPage', () => {
     );
   });
 
+  it('mints a fresh session when starting a new conversation', async () => {
+    const routerModule = (await import(
+      '@tanstack/react-router'
+    )) as unknown as {
+      __testRouter: TestRouter;
+    };
+    deleteChatSessionMock.mockImplementation(async (_token, sessionId) => ({
+      deleted: true,
+      sessionId,
+      deletedMessages: sessionId === 'session-a' ? 1 : 0,
+      deletedTasks: 0,
+      deletedSemanticMemories: 0,
+      deletedUsageEvents: 0,
+      deletedAuditEntries: 0,
+      deletedStructuredAuditEntries: 0,
+      deletedApprovalEntries: 0,
+    }));
+    fetchChatHistoryMock.mockImplementation(async (_token, sessionId) => ({
+      sessionId,
+      history:
+        sessionId === 'session-a'
+          ? [{ id: 101, role: 'assistant', content: 'Opened session A' }]
+          : [],
+      bootstrapAutostart:
+        sessionId === 'session-a'
+          ? undefined
+          : {
+              status: 'starting',
+              fileName: 'OPENING.md',
+            },
+    }));
+
+    renderChatPage();
+
+    expect(await screen.findByText('Opened session A')).not.toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open sidebar' }));
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'New Conversation' }),
+    );
+
+    await waitFor(() =>
+      expect(routerModule.__testRouter.lastTo).toBe('/chat/$sessionId'),
+    );
+    expect(routerModule.__testRouter.lastReplace).toBe(false);
+    await waitFor(() =>
+      expect(fetchChatHistoryMock).toHaveBeenCalledWith(
+        'test-token',
+        expect.stringMatching(/^sess_\d{8}_\d{6}_[0-9a-f]{8}$/),
+        80,
+        'web-user-1',
+        undefined,
+      ),
+    );
+    await waitFor(() =>
+      expect(deleteChatSessionMock).toHaveBeenCalledWith(
+        'test-token',
+        'session-a',
+      ),
+    );
+
+    const firstFreshSessionId = fetchChatHistoryMock.mock.calls
+      .map((call) => call[1])
+      .find((sessionId) => /^sess_\d{8}_\d{6}_[0-9a-f]{8}$/.test(sessionId));
+    expect(firstFreshSessionId).toBeTruthy();
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'New Conversation' }),
+    );
+
+    await waitFor(() =>
+      expect(deleteChatSessionMock).toHaveBeenCalledWith(
+        'test-token',
+        firstFreshSessionId,
+      ),
+    );
+  });
+
+  it('keeps sessions with user messages when starting a new conversation', async () => {
+    const routerModule = (await import(
+      '@tanstack/react-router'
+    )) as unknown as {
+      __testRouter: TestRouter;
+    };
+    fetchChatHistoryMock.mockImplementation(async (_token, sessionId) => ({
+      sessionId,
+      history:
+        sessionId === 'session-a'
+          ? [
+              { id: 101, role: 'assistant', content: 'Opened session A' },
+              { id: 102, role: 'user', content: 'Hello' },
+            ]
+          : [],
+    }));
+
+    renderChatPage();
+
+    expect(await screen.findByText('Hello')).not.toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open sidebar' }));
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'New Conversation' }),
+    );
+
+    await waitFor(() =>
+      expect(routerModule.__testRouter.lastTo).toBe('/chat/$sessionId'),
+    );
+    expect(deleteChatSessionMock).not.toHaveBeenCalled();
+  });
+
   it('syncs the agent dropdown from the active session history', async () => {
     fetchAgentListMock.mockResolvedValue([
       { id: 'main', name: 'Main Agent' },
@@ -632,10 +742,13 @@ describe('ChatPage', () => {
   });
 
   it('switches agents from the composer dropdown using the command path', async () => {
-    fetchChatHistoryMock.mockResolvedValue({
-      sessionId: 'session-a',
-      history: [{ id: 101, role: 'assistant', content: 'Opened session A' }],
-    });
+    fetchChatHistoryMock.mockImplementation(async (_token, sessionId) => ({
+      sessionId,
+      history:
+        sessionId === 'session-a'
+          ? [{ id: 101, role: 'assistant', content: 'Opened session A' }]
+          : [],
+    }));
 
     renderChatPage();
 
@@ -1509,7 +1622,19 @@ describe('ChatPage', () => {
         'session-a',
       ),
     );
-    await waitFor(() => expect(routerModule.__testRouter.lastTo).toBe('/chat'));
+    await waitFor(() =>
+      expect(routerModule.__testRouter.lastTo).toBe('/chat/$sessionId'),
+    );
+    expect(routerModule.__testRouter.lastReplace).toBe(true);
+    await waitFor(() =>
+      expect(fetchChatHistoryMock).toHaveBeenCalledWith(
+        'test-token',
+        expect.stringMatching(/^sess_\d{8}_\d{6}_[0-9a-f]{8}$/),
+        80,
+        'web-user-1',
+        undefined,
+      ),
+    );
   });
 
   it('renders the jump-to-latest chip when scrolled away and clears it on click', async () => {

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -163,7 +163,10 @@ vi.mock('../../api/client', () => ({
     token: string,
     sessionId: string,
     options?: { onlyWithoutUserMessages?: boolean },
-  ) => deleteChatSessionMock(token, sessionId, options),
+  ) =>
+    options === undefined
+      ? deleteChatSessionMock(token, sessionId)
+      : deleteChatSessionMock(token, sessionId, options),
   fetchAgentList: (token: string) => fetchAgentListMock(token),
   fetchModels: (token: string) => fetchModelsMock(token),
   fetchSkills: (token: string) => fetchSkillsMock(token),
@@ -581,6 +584,62 @@ describe('ChatPage', () => {
         'web-user-1',
         undefined,
       ),
+    );
+  });
+
+  it('does not reuse a launch agent when starting a new conversation', async () => {
+    const routerModule = (await import(
+      '@tanstack/react-router'
+    )) as unknown as {
+      __testRouter: TestRouter;
+    };
+    routerModule.__testRouter.setSessionId(null);
+    window.history.replaceState(null, '', '/chat?agent=assistant');
+    fetchChatHistoryMock.mockImplementation(
+      async (_token, sessionId, _limit, _userId, agentId) => ({
+        sessionId,
+        agentId: agentId || undefined,
+        history:
+          agentId === 'assistant'
+            ? [
+                {
+                  id: 101,
+                  role: 'assistant',
+                  content: 'Launch agent session',
+                },
+              ]
+            : [],
+      }),
+    );
+
+    renderChatPage();
+
+    expect(await screen.findByText('Launch agent session')).not.toBeNull();
+    const launchCall = fetchChatHistoryMock.mock.calls.find(
+      (call) => call[4] === 'assistant',
+    );
+    const launchSessionId = launchCall?.[1];
+    expect(launchSessionId).toMatch(/^sess_\d{8}_\d{6}_[0-9a-f]{8}$/);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open sidebar' }));
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'New Conversation' }),
+    );
+
+    await waitFor(() => {
+      const freshCall = fetchChatHistoryMock.mock.calls.find(
+        (call) =>
+          call[4] === undefined &&
+          call[1] !== launchSessionId &&
+          /^sess_\d{8}_\d{6}_[0-9a-f]{8}$/.test(call[1]),
+      );
+      expect(freshCall).toBeTruthy();
+    });
+    await waitFor(() =>
+      expect(cleanupNoUserChatSessionsMock).toHaveBeenCalledWith('test-token', {
+        channelId: 'web',
+        keepSessionId: expect.stringMatching(/^sess_\d{8}_\d{6}_[0-9a-f]{8}$/),
+      }),
     );
   });
 
@@ -1611,6 +1670,7 @@ describe('ChatPage', () => {
     )) as unknown as {
       __testRouter: TestRouter;
     };
+    window.history.replaceState(null, '', '/chat/session-a?agent=assistant');
     fetchChatHistoryMock.mockResolvedValue({
       sessionId: 'session-a',
       history: [{ id: 101, role: 'assistant', content: 'Opened session A' }],
@@ -1630,6 +1690,15 @@ describe('ChatPage', () => {
     renderChatPage();
 
     expect(await screen.findByText('Opened session A')).not.toBeNull();
+    await waitFor(() =>
+      expect(fetchChatHistoryMock).toHaveBeenCalledWith(
+        'test-token',
+        'session-a',
+        80,
+        'web-user-1',
+        'assistant',
+      ),
+    );
 
     fireEvent.click(
       screen.getByRole('button', {
@@ -1649,15 +1718,15 @@ describe('ChatPage', () => {
       expect(routerModule.__testRouter.lastTo).toBe('/chat/$sessionId'),
     );
     expect(routerModule.__testRouter.lastReplace).toBe(true);
-    await waitFor(() =>
-      expect(fetchChatHistoryMock).toHaveBeenCalledWith(
-        'test-token',
-        expect.stringMatching(/^sess_\d{8}_\d{6}_[0-9a-f]{8}$/),
-        80,
-        'web-user-1',
-        undefined,
-      ),
-    );
+    await waitFor(() => {
+      const freshCall = fetchChatHistoryMock.mock.calls.find(
+        (call) =>
+          call[1] !== 'session-a' &&
+          call[4] === undefined &&
+          /^sess_\d{8}_\d{6}_[0-9a-f]{8}$/.test(call[1]),
+      );
+      expect(freshCall).toBeTruthy();
+    });
   });
 
   it('renders the jump-to-latest chip when scrolled away and clears it on click', async () => {

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from 'react';
 import {
+  cleanupNoUserChatSessions,
   createChatBranch,
   createChatMobileQr,
   executeCommand,
@@ -119,10 +120,6 @@ function buildBranchInfoMap(
   return map;
 }
 
-function hasUserMessage(messages: ChatUiMessage[]): boolean {
-  return messages.some((message) => message.role === 'user');
-}
-
 function chatRecentQueryKey(
   token: string,
   userId: string,
@@ -174,7 +171,6 @@ export function ChatPage() {
 
   const [sessionSearchQuery, setSessionSearchQuery] = useState('');
   const launchAgentSessionIdRef = useRef<string | null>(null);
-  const sessionsWithUserMessagesRef = useRef<Set<string>>(new Set());
   const debouncedSessionSearchQuery = useDebouncedValue(
     sessionSearchQuery,
     160,
@@ -232,7 +228,6 @@ export function ChatPage() {
     switchToSession,
     startFreshChat,
     ensureSessionForSend,
-    isLocallyCreatedSession,
     handleSessionIdCorrection,
   } = useChatSession();
 
@@ -429,15 +424,6 @@ export function ChatPage() {
   });
 
   const messages = historyQuery.data?.messages ?? EMPTY_MESSAGES;
-  useEffect(() => {
-    if (!sessionId || historyQuery.data?.requestedSessionId !== sessionId) {
-      return;
-    }
-    if (hasUserMessage(historyQuery.data.messages)) {
-      sessionsWithUserMessagesRef.current.add(sessionId);
-    }
-  }, [historyQuery.data, sessionId]);
-
   const isBootstrapAutostartStarting =
     historyQuery.data?.bootstrapAutostart?.status === 'starting';
   const visibleMessages = useMemo<ChatUiMessage[]>(() => {
@@ -744,49 +730,22 @@ export function ChatPage() {
     [auth.token, setError],
   );
 
-  const shouldCleanupNoUserSession = useCallback(
-    (targetSessionId: string) => {
-      if (!targetSessionId) return false;
-      if (sessionsWithUserMessagesRef.current.has(targetSessionId)) {
-        return false;
-      }
-
-      const matchingHistory =
-        historyQuery.data?.requestedSessionId === targetSessionId
-          ? historyQuery.data
-          : null;
-      if (matchingHistory && hasUserMessage(matchingHistory.messages)) {
-        return false;
-      }
-
-      if (isLocallyCreatedSession(targetSessionId)) return true;
-
-      return Boolean(
-        matchingHistory &&
-          !historyQuery.isPending &&
-          historyQuery.fetchStatus === 'idle',
-      );
-    },
-    [
-      historyQuery.data,
-      historyQuery.fetchStatus,
-      historyQuery.isPending,
-      isLocallyCreatedSession,
-    ],
-  );
-
-  const cleanupNoUserSession = useCallback(
-    (targetSessionId: string) => {
-      void deleteChatSession(auth.token, targetSessionId)
+  const cleanupNoUserSessions = useCallback(
+    (keepSessionId: string) => {
+      void cleanupNoUserChatSessions(auth.token, {
+        channelId: 'web',
+        keepSessionId,
+      })
         .then((data) => {
-          if (!data.deleted) return;
-          const deletedSessionId = data.sessionId;
-          queryClient.removeQueries({
-            queryKey: chatHistoryQueryKey(auth.token, deletedSessionId),
-          });
-          queryClient.removeQueries({
-            queryKey: chatContextQueryKey(auth.token, deletedSessionId),
-          });
+          if (data.deletedCount === 0) return;
+          for (const deletedSessionId of data.deletedSessionIds) {
+            queryClient.removeQueries({
+              queryKey: chatHistoryQueryKey(auth.token, deletedSessionId),
+            });
+            queryClient.removeQueries({
+              queryKey: chatContextQueryKey(auth.token, deletedSessionId),
+            });
+          }
           void queryClient.invalidateQueries({
             queryKey: chatRecentQueryPrefix(auth.token, userId),
           });
@@ -807,25 +766,20 @@ export function ChatPage() {
       setError('Stop the current run before starting a new chat.');
       return;
     }
-    const previousSessionId = getSessionId();
-    const shouldCleanupPrevious = shouldCleanupNoUserSession(previousSessionId);
-    startFreshChat();
-    if (shouldCleanupPrevious) cleanupNoUserSession(previousSessionId);
+    const nextSessionId = startFreshChat();
+    cleanupNoUserSessions(nextSessionId);
     refreshRecent();
   }, [
     stream.isActive,
-    getSessionId,
-    shouldCleanupNoUserSession,
     startFreshChat,
-    cleanupNoUserSession,
+    cleanupNoUserSessions,
     refreshRecent,
     setError,
   ]);
 
   const handleSendMessage = useCallback(
     (content: string, media: MediaItem[]) => {
-      const targetSessionId = ensureSessionForSend();
-      sessionsWithUserMessagesRef.current.add(targetSessionId);
+      ensureSessionForSend();
       // Sending re-engages the user with the live conversation — snap back so
       // their bubble and the incoming stream are visible without the "↓ Latest"
       // chip getting in the way.

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -170,6 +170,7 @@ export function ChatPage() {
 
   const [sessionSearchQuery, setSessionSearchQuery] = useState('');
   const launchAgentSessionIdRef = useRef<string | null>(null);
+  const suppressDefaultAutostartRef = useRef(false);
   const debouncedSessionSearchQuery = useDebouncedValue(
     sessionSearchQuery,
     160,
@@ -230,6 +231,11 @@ export function ChatPage() {
     handleSessionIdCorrection,
   } = useChatSession();
 
+  const startBlankChat = useCallback(() => {
+    suppressDefaultAutostartRef.current = true;
+    startFreshChat();
+  }, [startFreshChat]);
+
   useEffect(() => {
     if (!launchAgentId) return;
     launchAgentSessionIdRef.current = ensureSessionForSend();
@@ -262,6 +268,19 @@ export function ChatPage() {
         ? auth.gatewayStatus
         : undefined,
   });
+
+  useEffect(() => {
+    if (launchAgentId || sessionId || !chatApiReady) return;
+    if (suppressDefaultAutostartRef.current) return;
+    if (!appStatusQuery.data?.defaultAgentId?.trim()) return;
+    ensureSessionForSend();
+  }, [
+    appStatusQuery.data?.defaultAgentId,
+    chatApiReady,
+    ensureSessionForSend,
+    launchAgentId,
+    sessionId,
+  ]);
 
   const agentsQuery = useQuery({
     queryKey: ['agents-list', auth.token],
@@ -475,7 +494,7 @@ export function ChatPage() {
       setSessionPendingDelete(null);
       const currentSessionId = getSessionId();
       if (deletedSessionId === currentSessionId) {
-        startFreshChat();
+        startBlankChat();
       }
     },
     onError: (err) => {
@@ -726,9 +745,9 @@ export function ChatPage() {
       setError('Stop the current run before starting a new chat.');
       return;
     }
-    startFreshChat();
+    startBlankChat();
     refreshRecent();
-  }, [stream.isActive, startFreshChat, refreshRecent, setError]);
+  }, [stream.isActive, startBlankChat, refreshRecent, setError]);
 
   const handleSendMessage = useCallback(
     (content: string, media: MediaItem[]) => {

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -475,6 +475,8 @@ export function ChatPage() {
       setSessionPendingDelete(null);
       const currentSessionId = getSessionId();
       if (deletedSessionId === currentSessionId) {
+        // Keep the page bound to a concrete no-user session after deleting the
+        // active chat so history loading can mint the replacement immediately.
         startFreshChat({ replace: true });
       }
     },
@@ -766,6 +768,8 @@ export function ChatPage() {
       setError('Stop the current run before starting a new chat.');
       return;
     }
+    // New Conversation intentionally creates a concrete no-user session, then
+    // prunes older drafts so repeated clicks only keep the latest one.
     const nextSessionId = startFreshChat();
     cleanupNoUserSessions(nextSessionId);
     refreshRecent();

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -119,6 +119,10 @@ function buildBranchInfoMap(
   return map;
 }
 
+function hasUserMessage(messages: ChatUiMessage[]): boolean {
+  return messages.some((message) => message.role === 'user');
+}
+
 function chatRecentQueryKey(
   token: string,
   userId: string,
@@ -170,7 +174,7 @@ export function ChatPage() {
 
   const [sessionSearchQuery, setSessionSearchQuery] = useState('');
   const launchAgentSessionIdRef = useRef<string | null>(null);
-  const suppressDefaultAutostartRef = useRef(false);
+  const sessionsWithUserMessagesRef = useRef<Set<string>>(new Set());
   const debouncedSessionSearchQuery = useDebouncedValue(
     sessionSearchQuery,
     160,
@@ -228,18 +232,13 @@ export function ChatPage() {
     switchToSession,
     startFreshChat,
     ensureSessionForSend,
+    isLocallyCreatedSession,
     handleSessionIdCorrection,
   } = useChatSession();
 
-  const startBlankChat = useCallback(() => {
-    suppressDefaultAutostartRef.current = true;
-    startFreshChat();
-  }, [startFreshChat]);
-
-  useEffect(() => {
-    if (!launchAgentId) return;
-    launchAgentSessionIdRef.current = ensureSessionForSend();
-  }, [ensureSessionForSend, launchAgentId]);
+  if (launchAgentId && sessionId && !launchAgentSessionIdRef.current) {
+    launchAgentSessionIdRef.current = sessionId;
+  }
 
   const requestedHistoryAgentId =
     sessionId && launchAgentSessionIdRef.current === sessionId
@@ -268,19 +267,6 @@ export function ChatPage() {
         ? auth.gatewayStatus
         : undefined,
   });
-
-  useEffect(() => {
-    if (launchAgentId || sessionId || !chatApiReady) return;
-    if (suppressDefaultAutostartRef.current) return;
-    if (!appStatusQuery.data?.defaultAgentId?.trim()) return;
-    ensureSessionForSend();
-  }, [
-    appStatusQuery.data?.defaultAgentId,
-    chatApiReady,
-    ensureSessionForSend,
-    launchAgentId,
-    sessionId,
-  ]);
 
   const agentsQuery = useQuery({
     queryKey: ['agents-list', auth.token],
@@ -443,6 +429,15 @@ export function ChatPage() {
   });
 
   const messages = historyQuery.data?.messages ?? EMPTY_MESSAGES;
+  useEffect(() => {
+    if (!sessionId || historyQuery.data?.requestedSessionId !== sessionId) {
+      return;
+    }
+    if (hasUserMessage(historyQuery.data.messages)) {
+      sessionsWithUserMessagesRef.current.add(sessionId);
+    }
+  }, [historyQuery.data, sessionId]);
+
   const isBootstrapAutostartStarting =
     historyQuery.data?.bootstrapAutostart?.status === 'starting';
   const visibleMessages = useMemo<ChatUiMessage[]>(() => {
@@ -494,7 +489,7 @@ export function ChatPage() {
       setSessionPendingDelete(null);
       const currentSessionId = getSessionId();
       if (deletedSessionId === currentSessionId) {
-        startBlankChat();
+        startFreshChat({ replace: true });
       }
     },
     onError: (err) => {
@@ -618,10 +613,19 @@ export function ChatPage() {
 
   // Server may resolve to a canonical branch id; keep the URL in sync.
   useEffect(() => {
+    if (historyQuery.isPending || historyQuery.fetchStatus !== 'idle') return;
+    if (historyQuery.data?.requestedSessionId !== sessionId) return;
     const resolved = historyQuery.data?.resolvedSessionId;
     if (!resolved || resolved === sessionId) return;
     void navigateToSession(resolved, { replace: true });
-  }, [historyQuery.data?.resolvedSessionId, sessionId, navigateToSession]);
+  }, [
+    historyQuery.data?.requestedSessionId,
+    historyQuery.data?.resolvedSessionId,
+    historyQuery.fetchStatus,
+    historyQuery.isPending,
+    sessionId,
+    navigateToSession,
+  ]);
 
   const branchInfoMap = useMemo(
     () => buildBranchInfoMap(messages, branchFamilies),
@@ -740,18 +744,88 @@ export function ChatPage() {
     [auth.token, setError],
   );
 
+  const shouldCleanupNoUserSession = useCallback(
+    (targetSessionId: string) => {
+      if (!targetSessionId) return false;
+      if (sessionsWithUserMessagesRef.current.has(targetSessionId)) {
+        return false;
+      }
+
+      const matchingHistory =
+        historyQuery.data?.requestedSessionId === targetSessionId
+          ? historyQuery.data
+          : null;
+      if (matchingHistory && hasUserMessage(matchingHistory.messages)) {
+        return false;
+      }
+
+      if (isLocallyCreatedSession(targetSessionId)) return true;
+
+      return Boolean(
+        matchingHistory &&
+          !historyQuery.isPending &&
+          historyQuery.fetchStatus === 'idle',
+      );
+    },
+    [
+      historyQuery.data,
+      historyQuery.fetchStatus,
+      historyQuery.isPending,
+      isLocallyCreatedSession,
+    ],
+  );
+
+  const cleanupNoUserSession = useCallback(
+    (targetSessionId: string) => {
+      void deleteChatSession(auth.token, targetSessionId)
+        .then((data) => {
+          if (!data.deleted) return;
+          const deletedSessionId = data.sessionId;
+          queryClient.removeQueries({
+            queryKey: chatHistoryQueryKey(auth.token, deletedSessionId),
+          });
+          queryClient.removeQueries({
+            queryKey: chatContextQueryKey(auth.token, deletedSessionId),
+          });
+          void queryClient.invalidateQueries({
+            queryKey: chatRecentQueryPrefix(auth.token, userId),
+          });
+          void queryClient.invalidateQueries({
+            queryKey: ['overview'],
+            refetchType: 'none',
+          });
+        })
+        .catch((err: unknown) => {
+          console.warn('Failed to clean up no-user chat session', err);
+        });
+    },
+    [auth.token, queryClient, userId],
+  );
+
   const handleNewChat = useCallback(() => {
     if (stream.isActive()) {
       setError('Stop the current run before starting a new chat.');
       return;
     }
-    startBlankChat();
+    const previousSessionId = getSessionId();
+    const shouldCleanupPrevious = shouldCleanupNoUserSession(previousSessionId);
+    startFreshChat();
+    if (shouldCleanupPrevious) cleanupNoUserSession(previousSessionId);
     refreshRecent();
-  }, [stream.isActive, startBlankChat, refreshRecent, setError]);
+  }, [
+    stream.isActive,
+    getSessionId,
+    shouldCleanupNoUserSession,
+    startFreshChat,
+    cleanupNoUserSession,
+    refreshRecent,
+    setError,
+  ]);
 
   const handleSendMessage = useCallback(
     (content: string, media: MediaItem[]) => {
-      ensureSessionForSend();
+      const targetSessionId = ensureSessionForSend();
+      sessionsWithUserMessagesRef.current.add(targetSessionId);
       // Sending re-engages the user with the live conversation — snap back so
       // their bubble and the incoming stream are visible without the "↓ Latest"
       // chip getting in the way.
@@ -792,6 +866,7 @@ export function ChatPage() {
               },
             ],
             branchFamilies: prev?.branchFamilies ?? new Map(),
+            requestedSessionId: prev?.requestedSessionId ?? targetSessionId,
             resolvedSessionId: targetSessionId,
             agentId: prev?.agentId ?? null,
             bootstrapAutostart: prev?.bootstrapAutostart ?? null,

--- a/console/src/routes/chat/use-chat-session.test.ts
+++ b/console/src/routes/chat/use-chat-session.test.ts
@@ -60,10 +60,20 @@ describe('useChatSession', () => {
     (await getTestRouter()).reset();
   });
 
-  it('returns empty sessionId when the URL is bare and no draft has been minted', () => {
+  it('mints a session and replaces the URL when the route is bare', async () => {
+    const router = await getTestRouter();
     const { result } = setup();
-    expect(result.current.sessionId).toBe('');
-    expect(result.current.getSessionId()).toBe('');
+    const minted = result.current.sessionId;
+
+    expect(minted).toMatch(/^sess_\d{8}_\d{6}_[0-9a-f]{8}$/);
+    expect(result.current.getSessionId()).toBe(minted);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(router.lastTo).toBe('/chat/$sessionId');
+    expect(router.lastReplace).toBe(true);
   });
 
   it('returns the URL sessionId when the `/chat/$sessionId` route is active', async () => {
@@ -75,10 +85,16 @@ describe('useChatSession', () => {
     expect(result.current.getSessionId()).toBe('session-from-url');
   });
 
-  it('persists the sessionId to localStorage whenever it becomes truthy', async () => {
+  it('persists generated and URL session ids to localStorage', async () => {
     const router = await getTestRouter();
     const { result } = setup();
-    expect(localStorage.getItem('hybridclaw_session')).toBeNull();
+    const minted = result.current.sessionId;
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(localStorage.getItem('hybridclaw_session')).toBe(minted);
 
     await act(async () => {
       router.setSessionId('session-a');
@@ -89,20 +105,23 @@ describe('useChatSession', () => {
     expect(result.current.sessionId).toBe('session-a');
   });
 
-  it('ensureSessionForSend mints a draft, updates getSessionId immediately, and navigates replace', async () => {
+  it('ensureSessionForSend returns the generated session for a bare route', async () => {
     const router = await getTestRouter();
     const { result } = setup();
+    const minted = result.current.sessionId;
 
     let returned = '';
     act(() => {
       returned = result.current.ensureSessionForSend();
     });
 
-    const minted = result.current.getSessionId();
     expect(returned).toBe(minted);
-    expect(minted).not.toBe('');
     expect(minted).toMatch(/^sess_\d{8}_\d{6}_[0-9a-f]{8}$/);
-    expect(router.navigate).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
     expect(router.lastTo).toBe('/chat/$sessionId');
     expect(router.lastReplace).toBe(true);
   });
@@ -122,14 +141,12 @@ describe('useChatSession', () => {
     expect(result.current.getSessionId()).toBe('session-existing');
   });
 
-  it('startFreshChat clears the draft and navigates to `/chat`', async () => {
+  it('startFreshChat mints a fresh session and navigates to it', async () => {
     const router = await getTestRouter();
     const { result } = setup();
 
-    act(() => {
-      result.current.ensureSessionForSend();
-    });
-    expect(result.current.getSessionId()).not.toBe('');
+    const previous = result.current.getSessionId();
+    expect(previous).toMatch(/^sess_\d{8}_\d{6}_[0-9a-f]{8}$/);
     await act(async () => {
       await Promise.resolve();
     });
@@ -141,8 +158,10 @@ describe('useChatSession', () => {
       await Promise.resolve();
     });
 
-    expect(router.lastTo).toBe('/chat');
-    expect(result.current.sessionId).toBe('');
+    expect(router.lastTo).toBe('/chat/$sessionId');
+    expect(router.lastReplace).toBe(false);
+    expect(result.current.sessionId).toMatch(/^sess_\d{8}_\d{6}_[0-9a-f]{8}$/);
+    expect(result.current.sessionId).not.toBe(previous);
   });
 
   it('handleSessionIdCorrection navigates replace when the server id differs', async () => {
@@ -190,9 +209,6 @@ describe('useChatSession', () => {
     const router = await getTestRouter();
     const { result, rerender } = setup();
 
-    act(() => {
-      result.current.ensureSessionForSend();
-    });
     const minted = result.current.getSessionId();
 
     // URL catches up

--- a/console/src/routes/chat/use-chat-session.ts
+++ b/console/src/routes/chat/use-chat-session.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import { generateWebSessionId, storeSessionId } from '../../lib/chat-helpers';
 
 export interface UseChatSessionReturn {
-  /** Empty string when the URL is `/chat` and no draft has been minted yet. */
+  /** URL session id, or a generated session id while bare `/chat` catches up. */
   sessionId: string;
   getSessionId: () => string;
   navigateToSession: (
@@ -17,23 +17,31 @@ export interface UseChatSessionReturn {
    * where `sessionIdRef` would otherwise still point at the previous session.
    */
   switchToSession: (id: string, opts?: { replace?: boolean }) => Promise<void>;
-  startFreshChat: () => void;
+  startFreshChat: (opts?: { replace?: boolean }) => string;
   ensureSessionForSend: () => string;
+  isLocallyCreatedSession: (id: string) => boolean;
   handleSessionIdCorrection: (serverSessionId: string) => void;
 }
 
 /**
- * Owns the chat session-id lifecycle: URL param, lazy draft for the bare
- * `/chat` route, localStorage persistence, and navigation between sessions.
+ * Owns the chat session-id lifecycle: URL param, generated session for the
+ * bare `/chat` route, localStorage persistence, and navigation between
+ * sessions.
  */
 export function useChatSession(): UseChatSessionReturn {
-  const navigate = useNavigate();
   const params = useParams({ strict: false }) as { sessionId?: string };
+  const navigate = useNavigate();
   const urlSessionId = params.sessionId;
 
-  // Lazily-generated id for the bare `/chat` route — the first send targets
-  // this id before the URL catches up in the next render.
+  // Generated id for the bare `/chat` route. The URL is replaced with it as
+  // soon as the hook mounts, so `/chat` stays a transition state.
   const draftSessionIdRef = useRef<string | null>(null);
+  const locallyCreatedSessionIdsRef = useRef<Set<string>>(new Set());
+  if (!urlSessionId && !draftSessionIdRef.current) {
+    const newId = generateWebSessionId();
+    draftSessionIdRef.current = newId;
+    locallyCreatedSessionIdsRef.current.add(newId);
+  }
   const sessionId = urlSessionId ?? draftSessionIdRef.current ?? '';
   const sessionIdRef = useRef(sessionId);
   sessionIdRef.current = sessionId;
@@ -58,6 +66,11 @@ export function useChatSession(): UseChatSessionReturn {
     [navigate],
   );
 
+  useEffect(() => {
+    if (urlSessionId || !sessionId) return;
+    void navigateToSession(sessionId, { replace: true });
+  }, [navigateToSession, sessionId, urlSessionId]);
+
   const switchToSession = useCallback(
     (id: string, opts?: { replace?: boolean }) => {
       draftSessionIdRef.current = id;
@@ -67,19 +80,32 @@ export function useChatSession(): UseChatSessionReturn {
     [navigateToSession],
   );
 
-  const startFreshChat = useCallback(() => {
-    draftSessionIdRef.current = null;
-    void navigate({ to: '/chat' });
-  }, [navigate]);
+  const startFreshChat = useCallback(
+    (opts?: { replace?: boolean }): string => {
+      const newId = generateWebSessionId();
+      draftSessionIdRef.current = newId;
+      sessionIdRef.current = newId;
+      locallyCreatedSessionIdsRef.current.add(newId);
+      void navigateToSession(newId, opts);
+      return newId;
+    },
+    [navigateToSession],
+  );
 
   const ensureSessionForSend = useCallback((): string => {
     if (sessionIdRef.current) return sessionIdRef.current;
     const newId = generateWebSessionId();
     draftSessionIdRef.current = newId;
     sessionIdRef.current = newId;
+    locallyCreatedSessionIdsRef.current.add(newId);
     void navigateToSession(newId, { replace: true });
     return newId;
   }, [navigateToSession]);
+
+  const isLocallyCreatedSession = useCallback(
+    (id: string) => locallyCreatedSessionIdsRef.current.has(id),
+    [],
+  );
 
   const handleSessionIdCorrection = useCallback(
     (serverSessionId: string) => {
@@ -96,6 +122,7 @@ export function useChatSession(): UseChatSessionReturn {
     switchToSession,
     startFreshChat,
     ensureSessionForSend,
+    isLocallyCreatedSession,
     handleSessionIdCorrection,
   };
 }

--- a/console/src/routes/chat/use-chat-stream.test.ts
+++ b/console/src/routes/chat/use-chat-stream.test.ts
@@ -48,6 +48,7 @@ function makeHarness(initialMessages: ChatUiMessage[] = []) {
     {
       messages: [...initialMessages],
       branchFamilies: new Map(),
+      requestedSessionId: SESSION_ID,
       resolvedSessionId: SESSION_ID,
       agentId: null,
       bootstrapAutostart: null,

--- a/console/src/routes/chat/use-chat-stream.ts
+++ b/console/src/routes/chat/use-chat-stream.ts
@@ -121,6 +121,7 @@ export function useChatStream(
         return {
           messages: nextMessages,
           branchFamilies: prev?.branchFamilies ?? new Map(),
+          requestedSessionId: prev?.requestedSessionId ?? sessionId,
           resolvedSessionId: prev?.resolvedSessionId ?? sessionId,
           agentId: prev?.agentId ?? null,
           bootstrapAutostart: prev?.bootstrapAutostart ?? null,

--- a/docs/content/reference/diagnostics.md
+++ b/docs/content/reference/diagnostics.md
@@ -52,8 +52,8 @@ problems do not look like generic provider outages.
 gateway artifacts such as orphaned sessions, leaked worker pool slots, and
 abandoned workspace state. The check caches a DB snapshot and disk-state diff
 so repeated runs are efficient. When `--fix` is passed, safe cleanups are
-applied automatically (e.g. reclaiming leaked pool slots and removing empty
-sessions).
+applied automatically (e.g. reclaiming leaked pool slots and removing
+unstarted sessions that have no user messages).
 
 ## Request Logging
 

--- a/src/cli/channels-command.ts
+++ b/src/cli/channels-command.ts
@@ -12,7 +12,6 @@ import {
   normalizeEmailAllowEntry,
 } from '../channels/email/allowlist.js';
 import { normalizeIMessageHandle } from '../channels/imessage/handle.js';
-import { assertLocalIMessageBackendReady } from '../channels/imessage/local-prereqs.js';
 import { normalizeSignalDaemonUrl } from '../channels/signal/api.js';
 import { normalizeSignalRecipient } from '../channels/signal/target.js';
 import { allowSlackWebhookInWorkspacePolicy } from '../channels/slack-webhook/policy.js';
@@ -2405,10 +2404,6 @@ async function configureIMessageChannel(args: string[]): Promise<void> {
       'Remote iMessage setup requires `--server-url <url>` or an existing `imessage.serverUrl` value.',
     );
   }
-  if (backend === 'local') {
-    await assertLocalIMessageBackendReady(cliPath);
-  }
-
   const nextConfig = updateRuntimeConfig((draft) => {
     draft.imessage.enabled = true;
     draft.imessage.backend = backend;

--- a/src/doctor/checks/resource-hygiene.ts
+++ b/src/doctor/checks/resource-hygiene.ts
@@ -225,11 +225,16 @@ function loadSessionSnapshotFromDatabase(): SessionDatabaseSnapshot {
       .prepare('SELECT id FROM sessions')
       .all() as Array<{ id: string }>;
 
-    const emptySessionRows = db
+    const unstartedSessionRows = db
       .prepare(
         `SELECT id, last_active
-           FROM sessions
-          WHERE COALESCE(message_count, 0) = 0`,
+           FROM sessions s
+          WHERE NOT EXISTS (
+            SELECT 1
+              FROM messages m
+             WHERE m.session_id = s.id
+               AND m.role = 'user'
+          )`,
       )
       .all() as Array<{ id: string; last_active: string }>;
     // Candidate selection is intentionally broader than the token regex used
@@ -271,7 +276,7 @@ function loadSessionSnapshotFromDatabase(): SessionDatabaseSnapshot {
       allSessionKeys: new Set(
         allSessionRows.map((row) => safeFilePart(String(row.id || ''))),
       ),
-      emptySessions: emptySessionRows.map((row) => {
+      emptySessions: unstartedSessionRows.map((row) => {
         const lastActiveMs = Date.parse(row.last_active);
         return {
           id: row.id,
@@ -1013,7 +1018,7 @@ export async function checkEmptySessions(
     return [
       makeResult(
         'database',
-        'Empty sessions',
+        'Unstarted sessions',
         'error',
         `Cannot inspect sessions without ${shortenHomePath(DB_PATH)} (${toErrorMessage(error)})`,
       ),
@@ -1031,9 +1036,9 @@ export async function checkEmptySessions(
     return [
       makeResult(
         'database',
-        'Empty sessions',
+        'Unstarted sessions',
         'ok',
-        `No empty sessions older than ${formatAge(EMPTY_SESSION_MAX_AGE_MS)}`,
+        `No unstarted sessions older than ${formatAge(EMPTY_SESSION_MAX_AGE_MS)}`,
       ),
     ];
   }
@@ -1056,10 +1061,10 @@ export async function checkEmptySessions(
   return [
     makeResult(
       'database',
-      'Empty sessions',
+      'Unstarted sessions',
       'warn',
       [
-        `${stale.length} ${pluralize(stale.length, 'session has', 'sessions have')} zero messages and ${pluralize(stale.length, 'is', 'are')} older than ${formatAge(EMPTY_SESSION_MAX_AGE_MS)}`,
+        `${stale.length} ${pluralize(stale.length, 'session has', 'sessions have')} no user messages and ${pluralize(stale.length, 'is', 'are')} older than ${formatAge(EMPTY_SESSION_MAX_AGE_MS)}`,
         oldestSession?.lastActive
           ? `oldest activity ${oldestSession.lastActive}`
           : null,
@@ -1067,7 +1072,7 @@ export async function checkEmptySessions(
         .filter((part): part is string => Boolean(part))
         .join(', '),
       {
-        summary: `Delete ${stale.length} empty ${pluralize(stale.length, 'session', 'sessions')}`,
+        summary: `Delete ${stale.length} unstarted ${pluralize(stale.length, 'session', 'sessions')}`,
         requiresApproval: false,
         apply: async () => {
           for (const session of stale) {
@@ -1200,7 +1205,7 @@ export function resourceHygieneDoctorChecks(): DoctorCheck[] {
     },
     {
       category: 'database',
-      label: 'Empty sessions',
+      label: 'Unstarted sessions',
       run: () => checkEmptySessions(ctx),
     },
     {

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -209,6 +209,7 @@ import { handleApiSecretInject } from './gateway-secret-injection.js';
 import {
   applyGatewayAdminPolicyPreset,
   approveGatewayAdminA2APairingRequest,
+  cleanupGatewayNoUserChatSessions,
   completeGatewayMcpOAuthCallback,
   createGatewayAdminAgent,
   createGatewayAdminSkill,
@@ -3632,6 +3633,17 @@ function handleApiChatRecent(
   });
 }
 
+function handleApiChatCleanup(res: ServerResponse, url: URL): void {
+  sendJson(
+    res,
+    200,
+    cleanupGatewayNoUserChatSessions({
+      channelId: url.searchParams.get('channelId') || 'web',
+      keepSessionId: url.searchParams.get('keepSessionId'),
+    }),
+  );
+}
+
 async function handleApiChatMobileQr(
   req: IncomingMessage,
   res: ServerResponse,
@@ -4866,7 +4878,13 @@ function handleApiAdminSessionDelete(res: ServerResponse, url: URL): void {
     sendJson(res, 400, { error: 'Missing `sessionId` query parameter.' });
     return;
   }
-  sendJson(res, 200, deleteGatewayAdminSession(sessionId));
+  sendJson(
+    res,
+    200,
+    deleteGatewayAdminSession(sessionId, {
+      onlyWithoutUserMessages: url.searchParams.get('ifNoUserMessages') === '1',
+    }),
+  );
 }
 
 async function handleApiAdminChannels(
@@ -7671,6 +7689,10 @@ export function startGatewayHttpServer(): GatewayHttpServer {
           }
           if (pathname === '/api/chat/recent' && method === 'GET') {
             handleApiChatRecent(req, res, url);
+            return;
+          }
+          if (pathname === '/api/chat/cleanup' && method === 'POST') {
+            handleApiChatCleanup(res, url);
             return;
           }
           if (pathname === '/api/chat/mobile-qr' && method === 'POST') {

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -455,6 +455,7 @@ import {
   WORKSPACE_BOOTSTRAP_FILES,
 } from '../workspace.js';
 import {
+  getActiveThreadAgentId,
   resolveAgentAddressing,
   setActiveThreadAgentId,
 } from './agent-addressing.js';
@@ -8453,11 +8454,23 @@ function resolveBootstrapAutostartContext(params: {
     requestedSessionId,
     params.channelId,
   );
+  const requestedAgentId = String(params.agentId || '').trim();
+  const existingSession = memoryService.getSessionById(requestedSessionId);
+  const existingSessionAgentId =
+    String(existingSession?.agent_id || '').trim() || '';
+  const activeThreadAgentId = existingSession
+    ? getActiveThreadAgentId(existingSession)
+    : null;
+  const autostartAgentId =
+    requestedAgentId ||
+    activeThreadAgentId ||
+    existingSessionAgentId ||
+    undefined;
   const session = memoryService.getOrCreateSession(
     requestedSessionId,
     null,
     channelId,
-    params.agentId ?? undefined,
+    autostartAgentId,
   );
   if (
     !params.allowExistingSessionMessages &&
@@ -8468,7 +8481,7 @@ function resolveBootstrapAutostartContext(params: {
   }
 
   const resolved = resolveAgentForRequest({
-    agentId: params.agentId,
+    agentId: autostartAgentId,
     session,
   });
   ensureBootstrapFiles(resolved.agentId);

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -8484,8 +8484,7 @@ function resolveBootstrapAutostartContext(params: {
   ) {
     return null;
   }
-  const existingSessionAgentId =
-    String(existingSession?.agent_id || '').trim() || '';
+  const existingSessionAgentId = String(existingSession?.agent_id || '').trim();
   const activeThreadAgentId = existingSession
     ? getActiveThreadAgentId(existingSession)
     : null;

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -257,6 +257,7 @@ import {
   getSessionCount,
   getSessionFileChangeCounts,
   getSessionMessageCounts,
+  getSessionsByChannelId,
   getSessionToolCallBreakdown,
   getSessionUsageTotals,
   getSessionUsageTotalsSince,
@@ -274,6 +275,7 @@ import {
   listUsageBySession,
   listUsageDailyBreakdown,
   recordRequestLog,
+  sessionHasUserMessages,
   setMemoryValue,
   updateSessionAgent,
   updateSessionChatbot,
@@ -595,6 +597,7 @@ import {
   type GatewayCommandResult,
   type GatewayHistorySummary,
   type GatewayModelProviderKey,
+  type GatewayNoUserChatSessionCleanupResult,
   type GatewayRecentChatSession,
   type GatewayRemoteAgentListPeer,
   type GatewayStatus,
@@ -5820,7 +5823,24 @@ export async function deleteGatewayAdminEmailMessage(params: {
 
 export function deleteGatewayAdminSession(
   sessionId: string,
+  options?: {
+    onlyWithoutUserMessages?: boolean;
+  },
 ): GatewayAdminDeleteSessionResult {
+  if (options?.onlyWithoutUserMessages && sessionHasUserMessages(sessionId)) {
+    return {
+      deleted: false,
+      sessionId,
+      skippedReason: 'has_user_messages',
+      deletedMessages: 0,
+      deletedTasks: 0,
+      deletedSemanticMemories: 0,
+      deletedUsageEvents: 0,
+      deletedAuditEntries: 0,
+      deletedStructuredAuditEntries: 0,
+      deletedApprovalEntries: 0,
+    };
+  }
   interruptGatewaySessionExecution(sessionId);
   return deleteSessionData(sessionId);
 }
@@ -8456,6 +8476,14 @@ function resolveBootstrapAutostartContext(params: {
   );
   const requestedAgentId = String(params.agentId || '').trim();
   const existingSession = memoryService.getSessionById(requestedSessionId);
+  if (
+    existingSession &&
+    !params.allowExistingSessionMessages &&
+    (existingSession.message_count > 0 ||
+      String(existingSession.session_summary || '').trim().length > 0)
+  ) {
+    return null;
+  }
   const existingSessionAgentId =
     String(existingSession?.agent_id || '').trim() || '';
   const activeThreadAgentId = existingSession
@@ -8471,6 +8499,7 @@ function resolveBootstrapAutostartContext(params: {
     null,
     channelId,
     autostartAgentId,
+    { touch: false },
   );
   if (
     !params.allowExistingSessionMessages &&
@@ -9362,6 +9391,55 @@ export async function getGatewayAgentList(): Promise<GatewayAgentListResponse> {
   return {
     agents: getGatewayLocalAgentListItems(),
     ...(remotePeers.length > 0 ? { remotePeers } : {}),
+  };
+}
+
+function isProtectedNoUserChatCleanupSession(session: Session): boolean {
+  const sessionKey = String(session.session_key || '').trim();
+  return (
+    session.full_auto_enabled === 1 ||
+    session.channel_id === 'scheduler' ||
+    session.id.startsWith('scheduler:') ||
+    session.id.startsWith('cron:') ||
+    session.id.includes(':chat:cron:') ||
+    sessionKey.includes(':chat:cron:')
+  );
+}
+
+export function cleanupGatewayNoUserChatSessions(params: {
+  channelId?: string | null;
+  keepSessionId?: string | null;
+}): GatewayNoUserChatSessionCleanupResult {
+  const channelId = String(params.channelId || 'web').trim() || 'web';
+  const keepSessionId = String(params.keepSessionId || '').trim();
+  const keptSessionId = keepSessionId
+    ? memoryService.getSessionById(keepSessionId)?.id || keepSessionId
+    : '';
+  const keepSessionIds = new Set(
+    [keepSessionId, keptSessionId].filter((value) => value.length > 0),
+  );
+  const deletedSessionIds: string[] = [];
+
+  for (const session of getSessionsByChannelId(channelId)) {
+    if (
+      keepSessionIds.has(session.id) ||
+      keepSessionIds.has(session.session_key || '') ||
+      keepSessionIds.has(session.main_session_key || '')
+    ) {
+      continue;
+    }
+    if (isProtectedNoUserChatCleanupSession(session)) continue;
+    if (sessionHasUserMessages(session.id)) continue;
+    const result = deleteGatewayAdminSession(session.id, {
+      onlyWithoutUserMessages: true,
+    });
+    if (result.deleted) deletedSessionIds.push(result.sessionId);
+  }
+
+  return {
+    deletedCount: deletedSessionIds.length,
+    deletedSessionIds,
+    ...(keptSessionId ? { keptSessionId } : {}),
   };
 }
 

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -335,6 +335,12 @@ export interface GatewayRecentChatSessionsResponse {
   sessions: GatewayRecentChatSession[];
 }
 
+export interface GatewayNoUserChatSessionCleanupResult {
+  deletedCount: number;
+  deletedSessionIds: string[];
+  keptSessionId?: string;
+}
+
 export interface GatewaySchedulerJobStatus {
   id: string;
   name: string;
@@ -937,6 +943,7 @@ export interface GatewayAdminBoardBudgetResponse {
 export interface GatewayAdminDeleteSessionResult {
   deleted: boolean;
   sessionId: string;
+  skippedReason?: 'has_user_messages';
   deletedMessages: number;
   deletedTasks: number;
   deletedSemanticMemories: number;

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -6519,12 +6519,14 @@ export function getOrCreateSession(
   agentId?: string,
   options?: {
     forceNewCurrent?: boolean;
+    touch?: boolean;
   },
 ): Session {
   const requestedSessionId = String(sessionId || '').trim();
   const requestedAgentId = agentId?.trim() || '';
   const defaultAgentId = resolveDefaultAgentId(getRuntimeConfig());
   const forceNewCurrent = options?.forceNewCurrent === true;
+  const touch = options?.touch !== false;
   const canonicalSessionKey = resolveCanonicalSessionKey({
     requestedSessionId,
     guildId,
@@ -6541,12 +6543,12 @@ export function getOrCreateSession(
       requestedAgentId || exactSession.agent_id || defaultAgentId;
     db.prepare(
       `UPDATE sessions
-       SET last_active = datetime('now'),
-           agent_id = ?,
+       SET agent_id = ?,
            guild_id = ?,
            channel_id = ?,
            session_key = ?,
-           main_session_key = ?
+           main_session_key = ?,
+           last_active = CASE WHEN ? THEN datetime('now') ELSE last_active END
        WHERE id = ?`,
     ).run(
       nextAgentId,
@@ -6554,6 +6556,7 @@ export function getOrCreateSession(
       channelId,
       canonicalSessionKey || exactSession.id,
       mainSessionKey || canonicalSessionKey || exactSession.id,
+      touch ? 1 : 0,
       exactSession.id,
     );
     return requireSessionById(exactSession.id);
@@ -6573,12 +6576,12 @@ export function getOrCreateSession(
     const nextAgentId = requestedAgentId || existing.agent_id || defaultAgentId;
     db.prepare(
       `UPDATE sessions
-       SET last_active = datetime('now'),
-           agent_id = ?,
+       SET agent_id = ?,
            guild_id = ?,
            channel_id = ?,
            session_key = ?,
            main_session_key = ?,
+           last_active = CASE WHEN ? THEN datetime('now') ELSE last_active END,
            legacy_session_id = CASE
              WHEN ? THEN ?
              ELSE legacy_session_id
@@ -6590,6 +6593,7 @@ export function getOrCreateSession(
       channelId,
       canonicalSessionKey || existing.id,
       mainSessionKey || canonicalSessionKey || existing.id,
+      touch ? 1 : 0,
       requestedSessionId !== canonicalSessionKey &&
         isLegacySessionKey(requestedSessionId)
         ? 1
@@ -6638,6 +6642,21 @@ export function getSessionById(sessionId: string): Session | undefined {
     selectCurrentSessionByMainSessionKey(normalized) ||
     selectCurrentSessionByLegacySessionId(normalized)
   );
+}
+
+export function sessionHasUserMessages(sessionId: string): boolean {
+  ensureDatabaseReady();
+  const resolvedSessionId = resolveSessionIdCompat(sessionId);
+  if (!resolvedSessionId) return false;
+  const row = queryOne<{ count: number }, [string]>(
+    db,
+    `SELECT COUNT(*) AS count
+     FROM messages
+     WHERE session_id = ?
+       AND role = 'user'`,
+    resolvedSessionId,
+  );
+  return normalizeUsageNumber(row?.count) > 0;
 }
 
 export function getSessionsByChannelId(channelId: string): Session[] {

--- a/src/memory/memory-service.ts
+++ b/src/memory/memory-service.ts
@@ -101,6 +101,7 @@ export interface MemoryBackend {
     agentId?: string,
     options?: {
       forceNewCurrent?: boolean;
+      touch?: boolean;
     },
   ) => Session;
   getSessionById: (sessionId: string) => Session | undefined;
@@ -464,6 +465,7 @@ export class MemoryService {
     agentId?: string,
     options?: {
       forceNewCurrent?: boolean;
+      touch?: boolean;
     },
   ): Session {
     return this.backend.getOrCreateSession(

--- a/tests/doctor.resource-hygiene.test.ts
+++ b/tests/doctor.resource-hygiene.test.ts
@@ -205,6 +205,107 @@ test('session compaction backlog fix compacts oversized idle sessions and report
   );
 });
 
+test('unstarted session check prunes stale sessions with no user messages', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+
+  const { initDatabase, getOrCreateSession } = await import(
+    '../src/memory/db.ts'
+  );
+  const { DB_PATH } = await import('../src/config/config.ts');
+
+  initDatabase({ quiet: true });
+  const assistantOnlySession = getOrCreateSession(
+    'session-assistant-only-stale',
+    null,
+    'web',
+    'main',
+  );
+  const userSession = getOrCreateSession(
+    'session-with-user-stale',
+    null,
+    'web',
+    'main',
+  );
+  const recentAssistantOnlySession = getOrCreateSession(
+    'session-assistant-only-recent',
+    null,
+    'web',
+    'main',
+  );
+
+  const db = new Database(DB_PATH);
+  db.prepare(
+    'INSERT INTO messages (session_id, user_id, username, role, content, agent_id) VALUES (?, ?, ?, ?, ?, ?)',
+  ).run(
+    assistantOnlySession.id,
+    'web',
+    'Web',
+    'assistant',
+    'Opening message',
+    'main',
+  );
+  db.prepare(
+    'INSERT INTO messages (session_id, user_id, username, role, content, agent_id) VALUES (?, ?, ?, ?, ?, ?)',
+  ).run(userSession.id, 'web', 'Web', 'assistant', 'Opening message', 'main');
+  db.prepare(
+    'INSERT INTO messages (session_id, user_id, username, role, content, agent_id) VALUES (?, ?, ?, ?, ?, ?)',
+  ).run(userSession.id, 'web', 'Web', 'user', 'Hello', 'main');
+  db.prepare(
+    'INSERT INTO messages (session_id, user_id, username, role, content, agent_id) VALUES (?, ?, ?, ?, ?, ?)',
+  ).run(
+    recentAssistantOnlySession.id,
+    'web',
+    'Web',
+    'assistant',
+    'Recent opening',
+    'main',
+  );
+  db.prepare(
+    'UPDATE sessions SET message_count = ?, last_active = ? WHERE id = ?',
+  ).run(1, '2026-04-01T00:00:00.000Z', assistantOnlySession.id);
+  db.prepare(
+    'UPDATE sessions SET message_count = ?, last_active = ? WHERE id = ?',
+  ).run(2, '2026-04-01T00:00:00.000Z', userSession.id);
+  db.prepare(
+    'UPDATE sessions SET message_count = ?, last_active = ? WHERE id = ?',
+  ).run(1, new Date().toISOString(), recentAssistantOnlySession.id);
+  db.close();
+
+  const { checkEmptySessions } = await import(
+    '../src/doctor/checks/resource-hygiene.ts'
+  );
+
+  const [result] = await checkEmptySessions();
+
+  expect(result).toMatchObject({
+    label: 'Unstarted sessions',
+    severity: 'warn',
+  });
+  expect(result.message).toContain('no user messages');
+
+  await result.fix?.apply();
+
+  const verifyDb = new Database(DB_PATH);
+  const assistantOnlyRow = verifyDb
+    .prepare('SELECT id FROM sessions WHERE id = ?')
+    .get(assistantOnlySession.id);
+  const userRow = verifyDb
+    .prepare('SELECT id FROM sessions WHERE id = ?')
+    .get(userSession.id);
+  const recentAssistantOnlyRow = verifyDb
+    .prepare('SELECT id FROM sessions WHERE id = ?')
+    .get(recentAssistantOnlySession.id);
+  verifyDb.close();
+
+  expect(assistantOnlyRow).toBeUndefined();
+  expect(userRow).toEqual({ id: userSession.id });
+  expect(recentAssistantOnlyRow).toEqual({
+    id: recentAssistantOnlySession.id,
+  });
+});
+
 test('ephemeral eval artifact check removes stale eval sessions and directories', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -1436,6 +1436,11 @@ async function importFreshHealth(options?: {
     }),
   );
   const getGatewayAdminSessions = vi.fn(() => []);
+  const cleanupGatewayNoUserChatSessions = vi.fn(() => ({
+    deletedCount: 2,
+    deletedSessionIds: ['old-empty', 'old-opening'],
+    keptSessionId: 'new-session',
+  }));
   const getGatewayAdminScheduler = vi.fn(() => ({
     jobs: [],
   }));
@@ -2108,6 +2113,7 @@ async function importFreshHealth(options?: {
     deleteGatewayAdminAgent,
     deleteGatewayAdminSession,
     ensureGatewayBootstrapAutostart,
+    cleanupGatewayNoUserChatSessions,
     GatewayRequestError,
     getGatewayAgentList,
     getGatewayAgents,
@@ -2262,6 +2268,7 @@ async function importFreshHealth(options?: {
     listenArgs,
     getGatewayStatus,
     ensureGatewayBootstrapAutostart,
+    cleanupGatewayNoUserChatSessions,
     getGatewayAgentList,
     getGatewayBootstrapAutostartState,
     getGatewayHistory,
@@ -2282,6 +2289,7 @@ async function importFreshHealth(options?: {
     stopTunnelStatus,
     stopGatewayAdminTunnel,
     deleteGatewayAdminEmailMessage,
+    deleteGatewayAdminSession,
     getGatewayAdminEmailFolder,
     getGatewayAdminEmailMailbox,
     getGatewayAdminEmailMessage,
@@ -5707,6 +5715,50 @@ describe('gateway HTTP server', () => {
 
     expect(res.statusCode).toBe(200);
     expect(state.getGatewayAdminSkills).toHaveBeenCalledTimes(1);
+  });
+
+  test('passes no-user guard to admin session deletion', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({
+      method: 'DELETE',
+      url: '/api/admin/sessions?sessionId=session-a&ifNoUserMessages=1',
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.deleteGatewayAdminSession).toHaveBeenCalledWith('session-a', {
+      onlyWithoutUserMessages: true,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toMatchObject({
+      deleted: true,
+      sessionId: 's1',
+    });
+  });
+
+  test('cleans no-user web chat sessions through the chat cleanup endpoint', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/chat/cleanup?channelId=web&keepSessionId=new-session',
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.cleanupGatewayNoUserChatSessions).toHaveBeenCalledWith({
+      channelId: 'web',
+      keepSessionId: 'new-session',
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({
+      deletedCount: 2,
+      deletedSessionIds: ['old-empty', 'old-opening'],
+      keptSessionId: 'new-session',
+    });
   });
 
   test('allows scoped admin sessions with a matching wildcard route action', async () => {

--- a/tests/gateway-service.bootstrap-autostart.test.ts
+++ b/tests/gateway-service.bootstrap-autostart.test.ts
@@ -490,6 +490,131 @@ test('ensureGatewayBootstrapAutostart can hatch a selected agent in an existing 
   );
 });
 
+test('ensureGatewayBootstrapAutostart uses the active thread agent without explicit agentId', async () => {
+  setupHome();
+
+  runAgentMock.mockResolvedValue({
+    status: 'success',
+    result: 'Active research agent is hatching.',
+    toolsUsed: [],
+    toolExecutions: [],
+  });
+
+  const { upsertRegisteredAgent } = await import(
+    '../src/agents/agent-registry.ts'
+  );
+  const { setActiveThreadAgentId } = await import(
+    '../src/gateway/agent-addressing.ts'
+  );
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+  const { ensureBootstrapFiles } = await import('../src/workspace.ts');
+  const { ensureGatewayBootstrapAutostart, getGatewayHistory } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  upsertRegisteredAgent({
+    id: 'research',
+    model: 'vllm/Qwen/Qwen3.5-27B-FP8',
+  });
+  ensureBootstrapFiles('research');
+
+  const sessionId =
+    'agent:main:channel:web:chat:dm:peer:active-agent-bootstrap';
+  const session = memoryService.getOrCreateSession(
+    sessionId,
+    null,
+    'web',
+    'main',
+  );
+  setActiveThreadAgentId(session, 'research');
+
+  await ensureGatewayBootstrapAutostart({
+    sessionId,
+    channelId: 'web',
+    userId: 'user-1',
+    username: 'user',
+  });
+
+  expect(runAgentMock).toHaveBeenCalledTimes(1);
+  const request = runAgentMock.mock.calls[0]?.[0] as
+    | {
+        messages?: Array<{ role: string; content: string }>;
+        agentId?: string;
+      }
+    | undefined;
+  expect(request?.agentId).toBe('research');
+  expect(getGatewayHistory(sessionId, 10).history).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        role: 'assistant',
+        content: 'Active research agent is hatching.',
+      }),
+    ]),
+  );
+});
+
+test('ensureGatewayBootstrapAutostart hatches the configured default agent without explicit agentId or existing session', async () => {
+  setupHome();
+
+  runAgentMock.mockResolvedValue({
+    status: 'success',
+    result: 'Default research agent is hatching.',
+    toolsUsed: [],
+    toolExecutions: [],
+  });
+
+  const { upsertRegisteredAgent } = await import(
+    '../src/agents/agent-registry.ts'
+  );
+  const { updateRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { ensureBootstrapFiles } = await import('../src/workspace.ts');
+  const { ensureGatewayBootstrapAutostart, getGatewayHistory } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  upsertRegisteredAgent({
+    id: 'research',
+    model: 'vllm/Qwen/Qwen3.5-27B-FP8',
+  });
+  updateRuntimeConfig((draft) => {
+    draft.agents.defaultAgentId = 'research';
+    draft.agents.list = [{ id: 'main' }, { id: 'research' }];
+  });
+  ensureBootstrapFiles('research');
+
+  const sessionId = 'sess_default_agent_bootstrap';
+
+  await ensureGatewayBootstrapAutostart({
+    sessionId,
+    channelId: 'web',
+    userId: 'user-1',
+    username: 'user',
+  });
+
+  expect(runAgentMock).toHaveBeenCalledTimes(1);
+  const request = runAgentMock.mock.calls[0]?.[0] as
+    | {
+        messages?: Array<{ role: string; content: string }>;
+        agentId?: string;
+      }
+    | undefined;
+  expect(request?.agentId).toBe('research');
+  expect(getGatewayHistory(sessionId, 10).history).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        role: 'assistant',
+        content: 'Default research agent is hatching.',
+      }),
+    ]),
+  );
+});
+
 test('ensureGatewayBootstrapAutostart reruns after same agent id is recreated with fresh BOOTSTRAP', async () => {
   setupHome();
 

--- a/tests/gateway-service.bootstrap-autostart.test.ts
+++ b/tests/gateway-service.bootstrap-autostart.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import Database from 'better-sqlite3';
 import { expect, test, vi } from 'vitest';
 
 import {
@@ -151,6 +152,45 @@ test('ensureGatewayBootstrapAutostart stores prelude and bootstrap opener once p
   await ensureGatewayBootstrapAutostart({ sessionId });
   expect(runAgentMock).toHaveBeenCalledTimes(1);
   expect(getGatewayHistory(sessionId, 10).history).toHaveLength(2);
+});
+
+test('ensureGatewayBootstrapAutostart does not refresh started sessions on history probes', async () => {
+  setupHome();
+
+  const { initDatabase, getSessionById, storeMessage } = await import(
+    '../src/memory/db.ts'
+  );
+  const { DB_PATH } = await import('../src/config/config.ts');
+  const { ensureGatewayBootstrapAutostart } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+
+  initDatabase({ quiet: true });
+
+  const sessionId = 'agent:main:channel:web:chat:dm:peer:opened-session';
+  memoryService.getOrCreateSession(sessionId, null, 'web', 'main');
+  storeMessage(sessionId, 'user-1', 'user', 'user', 'previous turn', 'main');
+
+  const oldLastActive = '2026-04-01T00:00:00.000Z';
+  const storedSession = getSessionById(sessionId);
+  expect(storedSession).toBeTruthy();
+  const db = new Database(DB_PATH);
+  db.prepare('UPDATE sessions SET last_active = ? WHERE id = ?').run(
+    oldLastActive,
+    storedSession?.id,
+  );
+  db.close();
+
+  await ensureGatewayBootstrapAutostart({
+    sessionId,
+    channelId: 'web',
+    userId: 'user-1',
+    username: 'user',
+  });
+
+  expect(runAgentMock).not.toHaveBeenCalled();
+  expect(getSessionById(sessionId)?.last_active).toBe(oldLastActive);
 });
 
 test('ensureGatewayBootstrapAutostart uses regular model when onboarding model is empty', async () => {

--- a/tests/gateway-service.chat-cleanup.test.ts
+++ b/tests/gateway-service.chat-cleanup.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from 'vitest';
+
+import { setupGatewayTest } from './helpers/gateway-test-setup.js';
+
+const { setupHome } = setupGatewayTest({
+  tempHomePrefix: 'hybridclaw-gateway-chat-cleanup-',
+});
+
+test('cleanupGatewayNoUserChatSessions deletes web sessions with no user messages', async () => {
+  setupHome();
+
+  const { initDatabase, getOrCreateSession, getSessionById, storeMessage } =
+    await import('../src/memory/db.ts');
+  const { cleanupGatewayNoUserChatSessions } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+
+  const keepSession = getOrCreateSession('cleanup-keep', null, 'web', 'main');
+  const emptySession = getOrCreateSession('cleanup-empty', null, 'web', 'main');
+  const assistantOnlySession = getOrCreateSession(
+    'cleanup-assistant-only',
+    null,
+    'web',
+    'main',
+  );
+  const userSession = getOrCreateSession('cleanup-user', null, 'web', 'main');
+  const schedulerSession = getOrCreateSession(
+    'cron:cleanup-daily',
+    null,
+    'web',
+    'main',
+  );
+
+  storeMessage(
+    assistantOnlySession.id,
+    'assistant',
+    null,
+    'assistant',
+    'Opening message',
+    'main',
+  );
+  storeMessage(userSession.id, 'web-user', 'User', 'user', 'Hello', 'main');
+
+  const result = cleanupGatewayNoUserChatSessions({
+    channelId: 'web',
+    keepSessionId: keepSession.id,
+  });
+
+  expect(result.deletedCount).toBe(2);
+  expect([...result.deletedSessionIds].sort()).toEqual(
+    [assistantOnlySession.id, emptySession.id].sort(),
+  );
+  expect(result.keptSessionId).toBe(keepSession.id);
+  expect(getSessionById(assistantOnlySession.id)).toBeUndefined();
+  expect(getSessionById(emptySession.id)).toBeUndefined();
+  expect(getSessionById(keepSession.id)).toBeTruthy();
+  expect(getSessionById(userSession.id)).toBeTruthy();
+  expect(getSessionById(schedulerSession.id)).toBeTruthy();
+});

--- a/tests/local-cli.test.ts
+++ b/tests/local-cli.test.ts
@@ -20,32 +20,11 @@ function makeTempHome(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-local-cli-'));
 }
 
-async function importFreshCli(
-  homeDir: string,
-  options?: {
-    imessageLocalReadyError?: Error | null;
-  },
-) {
+async function importFreshCli(homeDir: string) {
   process.env.HOME = homeDir;
   process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
   process.env.HYBRIDCLAW_WHATSAPP_SETUP_SETTLE_MS = '0';
   vi.resetModules();
-  const imessageLocalPrereqsMock = () => ({
-    assertLocalIMessageBackendReady: vi.fn(() => {
-      if (options?.imessageLocalReadyError) {
-        throw options.imessageLocalReadyError;
-      }
-    }),
-    formatMissingIMessageCliMessage: vi.fn((cliPath: string) => cliPath),
-  });
-  vi.doMock(
-    '../src/channels/imessage/local-prereqs.js',
-    imessageLocalPrereqsMock,
-  );
-  vi.doMock(
-    '../src/channels/imessage/local-prereqs.ts',
-    imessageLocalPrereqsMock,
-  );
   vi.doMock('../src/channels/whatsapp/connection.ts', () => ({
     createWhatsAppConnectionManager: () => ({
       getSocket: () => null,
@@ -107,8 +86,6 @@ async function readRuntimeSecrets(
 
 afterEach(() => {
   vi.restoreAllMocks();
-  vi.doUnmock('../src/channels/imessage/local-prereqs.js');
-  vi.doUnmock('../src/channels/imessage/local-prereqs.ts');
   vi.doUnmock('../src/channels/whatsapp/connection.ts');
   vi.resetModules();
   if (ORIGINAL_HOME === undefined) {
@@ -998,17 +975,24 @@ test('local configure vllm with name stores a named endpoint secret ref', async 
   expect(secrets.LOCAL_ENDPOINT_HAIGPU2_API_KEY).toBe('gemma-secret-key');
 });
 
-test('channels imessage setup fails fast when the local imsg binary is missing', async () => {
+test('channels imessage setup writes local config without probing imsg', async () => {
   const homeDir = makeTempHome();
-  const cli = await importFreshCli(homeDir, {
-    imessageLocalReadyError: new Error(
-      'Missing iMessage CLI binary: imsg. Install it with `brew install steipete/tap/imsg` or rerun `hybridclaw channels imessage setup --cli-path /absolute/path/to/imsg ...`.',
-    ),
-  });
+  const cli = await importFreshCli(homeDir);
 
-  await expect(
-    cli.main(['channels', 'imessage', 'setup', '--allow-from', '+14155551212']),
-  ).rejects.toThrow(/Missing iMessage CLI binary: imsg/);
+  await cli.main([
+    'channels',
+    'imessage',
+    'setup',
+    '--allow-from',
+    '+14155551212',
+    '--cli-path',
+    '/missing/imsg',
+  ]);
+
+  const config = readRuntimeConfig(homeDir);
+  expect(config.imessage.enabled).toBe(true);
+  expect(config.imessage.backend).toBe('local');
+  expect(config.imessage.cliPath).toBe('/missing/imsg');
 });
 
 test('auth login msteams writes config and stores MSTEAMS_APP_PASSWORD', async () => {


### PR DESCRIPTION
## What changed

- Mint an initial chat session automatically when bare `/chat` opens after gateway status has loaded a default agent.
- Preserve deliberate blank chat flows by suppressing default autostart after New Chat or deleting the active session.
- Make gateway bootstrap autostart resolve the agent from an explicit `agentId`, active thread agent, or existing session agent before falling back to configured defaults.

## Why

Opening `/chat` with the assistant already configured did not start hatching because no session existed yet, so the web client never called `/api/history` and bootstrap autostart never ran. `?agent=` worked only because it forced session creation.

## Impact

Users landing on bare `/chat` with HybridClaw already set to the assistant/default agent get proactive hatching without a launch-agent query parameter. Existing New Chat behavior remains available when the user explicitly asks for a blank chat.

## Validation

- `./node_modules/.bin/vitest tests/gateway-service.bootstrap-autostart.test.ts --run` - 13 passed
- `../node_modules/.bin/vitest --config vitest.config.ts src/routes/chat/chat-page.test.tsx --run` from `console/` - 40 passed
- `./node_modules/.bin/tsc --noEmit`
- `../node_modules/.bin/tsc --noEmit` from `console/`
- `./node_modules/.bin/biome check console/src/routes/chat/chat-page.tsx console/src/routes/chat/chat-page.test.tsx src/gateway/gateway-service.ts tests/gateway-service.bootstrap-autostart.test.ts`
- `../node_modules/.bin/biome check src/routes/chat/chat-page.tsx src/routes/chat/chat-page.test.tsx` from `console/`