### PR TITLE
[codex] Slim hatching bootstrap prompt

### DIFF
--- a/src/agent/conversation.ts
+++ b/src/agent/conversation.ts
@@ -27,6 +27,7 @@ import {
   type PromptMode,
   type PromptPartName,
   type PromptRuntimeInfo,
+  type SkillPromptMode,
 } from './prompt-hooks.js';
 import { mergeBlockedToolNames } from './tool-policy.js';
 
@@ -127,6 +128,7 @@ export function buildConversationContext(params: {
   history: HistoryMessage[];
   expandLatestHistoryUser?: boolean;
   promptMode?: PromptMode;
+  skillPromptMode?: SkillPromptMode;
   includePromptParts?: PromptPartName[];
   omitPromptParts?: PromptPartName[];
   extraSafetyText?: string;
@@ -142,6 +144,7 @@ export function buildConversationContext(params: {
     history,
     expandLatestHistoryUser = false,
     promptMode = 'full',
+    skillPromptMode = 'full',
     includePromptParts,
     omitPromptParts,
     extraSafetyText,
@@ -173,6 +176,7 @@ export function buildConversationContext(params: {
     explicitSkillInvocation,
     purpose: 'conversation',
     promptMode,
+    skillPromptMode,
     includePromptParts,
     omitPromptParts,
     extraSafetyText,

--- a/src/agent/prompt-hooks.ts
+++ b/src/agent/prompt-hooks.ts
@@ -51,6 +51,7 @@ export type {
   WorkspacePromptPartName,
 } from './prompt-parts.js';
 export type PromptMode = 'full' | 'minimal' | 'none';
+export type SkillPromptMode = 'full' | 'compact';
 export const MESSAGE_SEND_SILENT_REPLY_TOKEN = SILENT_REPLY_TOKEN;
 export { PROMPT_PART_NAMES } from './prompt-parts.js';
 
@@ -74,6 +75,7 @@ export interface PromptHookContext {
   explicitSkillInvocation?: SkillInvocation | null;
   purpose?: 'conversation' | 'memory-flush';
   promptMode?: PromptMode;
+  skillPromptMode?: SkillPromptMode;
   includePromptParts?: PromptPartName[];
   omitPromptParts?: PromptPartName[];
   extraSafetyText?: string;
@@ -217,6 +219,43 @@ function buildSkillsSection(skillsPrompt: string): string {
   ].join('\n');
 }
 
+function escapeCompactSkillValue(value: string): string {
+  return String(value || '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
+function buildCompactSkillsPrompt(skills: Skill[]): string {
+  const promptCandidates = skills.filter(
+    (skill) => !skill.disableModelInvocation,
+  );
+  if (promptCandidates.length === 0) return '';
+
+  const lines = [
+    '## Skills',
+    'Available skills are listed only by top-level metadata. Do not read a skill during bootstrap unless the user explicitly asks for it or it directly helps onboarding.',
+    'For later work, if a skill clearly applies, read its SKILL.md at the listed location before using it.',
+    '',
+    '<available_skills>',
+  ];
+
+  for (const skill of promptCandidates) {
+    lines.push(
+      '  <skill>',
+      `    <name>${escapeCompactSkillValue(skill.name)}</name>`,
+      `    <category>${escapeCompactSkillValue(skill.category)}</category>`,
+      `    <description>${escapeCompactSkillValue(skill.description || skill.name)}</description>`,
+      `    <location>${escapeCompactSkillValue(skill.location)}</location>`,
+      '  </skill>',
+    );
+  }
+
+  lines.push('</available_skills>');
+  return lines.join('\n');
+}
+
 function buildBootstrapHook(context: PromptHookContext): string {
   const contextFiles = loadStaticBootstrapFiles(context.agentId).filter(
     (file) => {
@@ -231,7 +270,9 @@ function buildBootstrapHook(context: PromptHookContext): string {
   const skillsPrompt = context.explicitSkillInvocation
     ? ''
     : isBootstrapPartSelected('skills', context)
-      ? buildSkillsSection(buildSkillsPrompt(context.skills))
+      ? context.skillPromptMode === 'compact'
+        ? buildCompactSkillsPrompt(context.skills)
+        : buildSkillsSection(buildSkillsPrompt(context.skills))
       : '';
   return [contextPrompt, cloudMemoryPrompt, skillsPrompt]
     .filter(Boolean)

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -44,7 +44,7 @@ import {
   getSandboxDiagnostics,
   stopAllExecutions,
 } from '../agent/executor.js';
-import type { PromptMode } from '../agent/prompt-hooks.js';
+import type { PromptMode, PromptPartName } from '../agent/prompt-hooks.js';
 import { isSilentReply, stripSilentToken } from '../agent/silent-reply.js';
 import {
   buildToolsSummary,
@@ -647,6 +647,15 @@ const BOOTSTRAP_AUTOSTART_MARKER_KEY = 'gateway.bootstrap_autostart.v1';
 const BOOTSTRAP_AUTOSTART_SOURCE = 'gateway.bootstrap';
 const BOOTSTRAP_PRELUDE_MAX_TOKENS = 48;
 const BOOTSTRAP_PRELUDE_TIMEOUT_MS = 1500;
+const BOOTSTRAP_HATCHING_PROMPT_PARTS = [
+  'soul',
+  'identity',
+  'user',
+  'memory-file',
+  'bootstrap-file',
+  'skills',
+  'runtime',
+] satisfies PromptPartName[];
 const OPENING_AUTOSTART_MAX_TOKENS = 512;
 const OPENING_AUTOSTART_TIMEOUT_MS = 5000;
 const activeBootstrapAutostartSessions = new Set<string>();
@@ -8679,6 +8688,12 @@ export async function ensureGatewayBootstrapAutostart(params: {
       agentId: resolved.agentId,
       history: [],
       currentUserContent: buildBootstrapAutostartPrompt(bootstrapFile),
+      ...(bootstrapFile === 'BOOTSTRAP.md'
+        ? {
+            skillPromptMode: 'compact' as const,
+            includePromptParts: BOOTSTRAP_HATCHING_PROMPT_PARTS,
+          }
+        : {}),
       extraSafetyText:
         'Bootstrap kickoff turn. Start the conversation proactively with a concise user-facing opening message.',
       runtimeInfo: {

--- a/tests/gateway-service.bootstrap-autostart.test.ts
+++ b/tests/gateway-service.bootstrap-autostart.test.ts
@@ -95,6 +95,7 @@ test('ensureGatewayBootstrapAutostart stores prelude and bootstrap opener once p
     | {
         messages?: Array<{ role: string; content: string }>;
         channelId?: string;
+        chatbotId?: string;
       }
     | undefined;
   expect(request?.channelId).toBe('web');
@@ -102,16 +103,30 @@ test('ensureGatewayBootstrapAutostart stores prelude and bootstrap opener once p
   expect(request?.messages?.some((message) => message.role === 'system')).toBe(
     true,
   );
-  expect(
-    request?.messages?.some((message) =>
-      message.content.includes('## BOOTSTRAP.md'),
-    ),
-  ).toBe(true);
-  expect(
-    request?.messages?.some((message) =>
-      message.content.includes('Email is the only mandatory topic'),
-    ),
-  ).toBe(true);
+  const systemPrompt =
+    request?.messages?.find((message) => message.role === 'system')?.content ||
+    '';
+  expect(systemPrompt).toContain('## SOUL.md');
+  expect(systemPrompt).toContain('## IDENTITY.md');
+  expect(systemPrompt).toContain('## USER.md');
+  expect(systemPrompt).toContain('## MEMORY.md');
+  expect(systemPrompt).toContain('## BOOTSTRAP.md');
+  expect(systemPrompt).toContain('## Runtime Metadata');
+  expect(systemPrompt).toContain('Email is the only mandatory topic');
+  expect(systemPrompt).toContain('home automation');
+  expect(systemPrompt).toContain('software platforms');
+  expect(systemPrompt).not.toContain('## AGENTS.md');
+  expect(systemPrompt).not.toContain('## TOOLS.md');
+  expect(systemPrompt).not.toContain('## BOOT.md');
+  expect(systemPrompt).not.toContain('## OPENING.md');
+  expect(systemPrompt).not.toContain('## Skills (mandatory)');
+  expect(systemPrompt).not.toContain('<required_credentials>');
+  expect(systemPrompt).not.toContain('<supported_channels>');
+  expect(systemPrompt).not.toContain('## Runtime Safety Guardrails');
+  expect(systemPrompt).not.toContain('## Tool Execution Discipline');
+  expect(systemPrompt).not.toContain('## Web Retrieval Routing');
+  expect(systemPrompt).not.toContain('## Browser Auth Handling');
+  expect(systemPrompt).not.toContain('## Subagent Delegation Playbook');
   expect(request?.messages?.at(-1)).toEqual({
     role: 'user',
     content: expect.stringContaining(

--- a/tests/prompt-hooks.tool-summary.test.ts
+++ b/tests/prompt-hooks.tool-summary.test.ts
@@ -232,6 +232,38 @@ test('buildSystemPromptFromHooks adds mandatory routing instructions for availab
   );
 });
 
+test('buildSystemPromptFromHooks can render compact skill metadata only', () => {
+  const prompt = buildSystemPromptFromHooks({
+    agentId: 'test-agent',
+    skills: [
+      makeSkill({
+        always: true,
+        description: 'Create, inspect, and edit PDF files.',
+      }),
+    ],
+    skillPromptMode: 'compact',
+    includePromptParts: ['skills'],
+  });
+
+  expect(prompt).toContain('## Skills');
+  expect(prompt).not.toContain('## Skills (mandatory)');
+  expect(prompt).toContain('<available_skills>');
+  expect(prompt).toContain('<name>pdf</name>');
+  expect(prompt).toContain('<category>office</category>');
+  expect(prompt).toContain(
+    '<description>Create, inspect, and edit PDF files.</description>',
+  );
+  expect(prompt).toContain('<location>skills/pdf/SKILL.md</location>');
+  expect(prompt).not.toContain('<skill_always');
+  expect(prompt).not.toContain('<version>');
+  expect(prompt).not.toContain('<capabilities>');
+  expect(prompt).not.toContain('<required_credentials>');
+  expect(prompt).not.toContain('<supported_channels>');
+  expect(prompt).not.toContain(
+    'Run documented skill helper commands exactly as shown',
+  );
+});
+
 test('buildSystemPromptFromHooks omits mandatory routing instructions when no skills are available', () => {
   const prompt = buildSystemPromptFromHooks({
     agentId: 'test-agent',


### PR DESCRIPTION
## What changed

- Add a compact skill catalog that lists only skill name, category, description, and location for slim prompt profiles.
- Pass a hatching-specific prompt profile into `BOOTSTRAP.md` autostart turns so they include only `SOUL.md`, `IDENTITY.md`, `USER.md`, `MEMORY.md`, `BOOTSTRAP.md`, compact skills, and runtime metadata.
- Exclude full `AGENTS.md`, tool-discipline/browser/delegation prompt sections, full skill bodies, credential details, and channel details from the hatching autostart prompt.
- Keep regular chat prompts and `OPENING.md` autostart behavior on the existing full prompt path.

## Why

The hatching trace showed the first proactive turn receiving much more system context than the task needs. A smaller first-turn prompt keeps the model focused on the BOOTSTRAP onboarding instructions while preserving the top-level skill awareness it may need.

## Impact

First hatch prompts stay focused on identity, user, memory, BOOTSTRAP, high-level skill discovery, and runtime metadata. Normal turns are unchanged.

## Stacking

Base PR: #1268 (`codex/hatching-questionnaire-improvements`)

## Validation

- `./node_modules/.bin/vitest tests/workspace-bootstrap.test.ts tests/gateway-service.bootstrap-autostart.test.ts tests/gateway-service.context-references.test.ts tests/prompt-hooks.tool-summary.test.ts --run` — 65 passed
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/biome check --write templates/BOOTSTRAP.md src/gateway/gateway-service.ts src/gateway/gateway-chat-service.ts src/agent/prompt-hooks.ts src/agent/conversation.ts tests/workspace-bootstrap.test.ts tests/gateway-service.bootstrap-autostart.test.ts tests/gateway-service.context-references.test.ts tests/prompt-hooks.tool-summary.test.ts`