### PR TITLE
[codex] Show session timestamps in local time

### DIFF
--- a/src/gateway/gateway-time.ts
+++ b/src/gateway/gateway-time.ts
@@ -46,7 +46,6 @@ export function formatDisplayTimestamp(raw: string | null | undefined): string {
   if (!date) return 'unknown';
 
   const parts = new Intl.DateTimeFormat('en-US', {
-    timeZone: 'UTC',
     year: 'numeric',
     month: 'short',
     day: 'numeric',

--- a/tests/gateway-time.test.ts
+++ b/tests/gateway-time.test.ts
@@ -2,10 +2,34 @@ import { expect, test } from 'vitest';
 
 import { formatDisplayTimestamp } from '../src/gateway/gateway-time.ts';
 
+function withTimeZone<T>(timeZone: string, callback: () => T): T {
+  const previous = process.env.TZ;
+  try {
+    process.env.TZ = timeZone;
+    return callback();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.TZ;
+    } else {
+      process.env.TZ = previous;
+    }
+  }
+}
+
+test('formatDisplayTimestamp renders in the local timezone', () => {
+  withTimeZone('Europe/Berlin', () => {
+    expect(formatDisplayTimestamp('2026-03-30T09:27:30.580Z')).toBe(
+      'Mar 30, 2026, 11:27',
+    );
+  });
+});
+
 test('formatDisplayTimestamp omits seconds and timezone suffix', () => {
-  expect(formatDisplayTimestamp('2026-03-30T09:27:30.580Z')).toBe(
-    'Mar 30, 2026, 09:27',
-  );
+  withTimeZone('UTC', () => {
+    expect(formatDisplayTimestamp('2026-03-30T09:27:30.580Z')).toBe(
+      'Mar 30, 2026, 09:27',
+    );
+  });
 });
 
 test('formatDisplayTimestamp returns unknown for invalid values', () => {


### PR DESCRIPTION
## Summary

Fixes `/sessions` timestamp display so stored UTC timestamps render in the local runtime timezone instead of always displaying UTC.

## Root Cause

`formatDisplayTimestamp` hard-coded `timeZone: 'UTC'` when formatting session timestamps. SQLite stores `datetime('now')` values in UTC, but display commands should present those timestamps in the user's local environment.

## Impact

`/sessions` and other gateway surfaces that use the shared display formatter now show local time while preserving the existing compact format without seconds or timezone suffix.

## Validation

- `./node_modules/.bin/vitest tests/gateway-time.test.ts`
- `npm run typecheck`
- `./node_modules/.bin/biome check src/gateway/gateway-time.ts tests/gateway-time.test.ts`

The focused checks were run in the new `codex/session-local-times` worktree based on `origin/main`.