### PR TITLE
[codex] Autosave email allowlist additions

### DIFF
--- a/console/src/routes/channels.test.tsx
+++ b/console/src/routes/channels.test.tsx
@@ -509,6 +509,98 @@ describe('ChannelsPage', () => {
     );
   });
 
+  it('collapses email advanced settings above additional mailboxes by default', async () => {
+    const config = makeConfig({
+      channelInstructions: {
+        ...makeConfig().channelInstructions,
+        email: 'Use concise email replies.',
+      },
+    });
+    fetchConfigMock.mockResolvedValue({
+      path: '/tmp/config.json',
+      config,
+    });
+
+    renderChannelsPage();
+
+    const [emailChannelButton] = await screen.findAllByRole('button', {
+      name: /Email/i,
+    });
+
+    fireEvent.click(emailChannelButton);
+
+    const summary = screen.getByText('Advanced settings');
+    const details = summary.closest('details') as HTMLDetailsElement | null;
+    if (!details) throw new Error('Expected advanced settings details.');
+    expect(details.open).toBe(false);
+
+    const additionalMailboxes = screen.getByText('Additional agent mailboxes');
+    expect(
+      Boolean(
+        details.compareDocumentPosition(additionalMailboxes) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ),
+    ).toBe(true);
+
+    fireEvent.click(summary);
+
+    expect(details.open).toBe(true);
+    expect(within(details).getByLabelText('Poll interval ms')).toBeTruthy();
+    expect(within(details).getByLabelText('Text chunk limit')).toBeTruthy();
+    expect(within(details).getByLabelText('Media max MB')).toBeTruthy();
+    expect(
+      (
+        within(details).getByLabelText(
+          'Channel instructions',
+        ) as HTMLTextAreaElement
+      ).value,
+    ).toBe('Use concise email replies.');
+  });
+
+  it('saves email channel settings immediately when adding an allowed sender', async () => {
+    const config = makeConfig();
+    const savedConfig = {
+      ...config,
+      email: {
+        ...config.email,
+        allowFrom: ['ops@example.com', 'new@example.com'],
+      },
+    };
+    fetchConfigMock.mockResolvedValue({
+      path: '/tmp/config.json',
+      config,
+    });
+    saveConfigMock.mockResolvedValue({
+      path: '/tmp/config.json',
+      config: savedConfig,
+    });
+
+    renderChannelsPage();
+
+    const [emailChannelButton] = await screen.findAllByRole('button', {
+      name: /Email/i,
+    });
+
+    fireEvent.click(emailChannelButton);
+    fireEvent.change(screen.getByLabelText('Allowed senders'), {
+      target: { value: 'new@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    await waitFor(() => {
+      expect(saveConfigMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(saveConfigMock).toHaveBeenCalledWith(
+      'test-token',
+      expect.objectContaining({
+        email: expect.objectContaining({
+          allowFrom: ['ops@example.com', 'new@example.com'],
+        }),
+      }),
+    );
+  });
+
   it('saves agent mailbox mappings through the email channel editor', async () => {
     const config = makeConfig();
     fetchConfigMock.mockResolvedValue({

--- a/console/src/routes/channels.tsx
+++ b/console/src/routes/channels.tsx
@@ -113,6 +113,7 @@ function AllowListField(props: {
   value: string[];
   placeholder?: string;
   onChange: (value: string[]) => void;
+  onAdd?: (value: string[]) => void;
 }) {
   const [nextValue, setNextValue] = useState('');
   const entries = dedupeAllowListEntries(props.value);
@@ -133,7 +134,9 @@ function AllowListField(props: {
 
     // Channel runtimes own format-specific normalization. The admin UI only
     // trims and dedupes raw entries so channel-specific identities stay valid.
-    props.onChange(dedupeAllowListEntries([...entries, nextEntry]));
+    const nextEntries = dedupeAllowListEntries([...entries, nextEntry]);
+    props.onChange(nextEntries);
+    props.onAdd?.(nextEntries);
     setNextValue('');
   };
 
@@ -1547,6 +1550,7 @@ function EmailChannelEditor(props: {
   hybridaiApiKeyConfigured: boolean;
   agents: AdminAgent[];
   token: string;
+  onAutoSave: (config: AdminConfig) => void;
   onSecretSaved: () => void;
 }) {
   const [fetchingEmailConfig, setFetchingEmailConfig] = useState(false);
@@ -1602,6 +1606,18 @@ function EmailChannelEditor(props: {
     setEmailAccounts(
       emailAccounts.filter((_, currentIndex) => currentIndex !== index),
     );
+  }
+
+  function saveDefaultAllowFrom(allowFrom: string[]) {
+    const nextConfig = {
+      ...props.draft,
+      email: {
+        ...props.draft.email,
+        allowFrom,
+      },
+    };
+    props.form.setDraft(nextConfig);
+    props.onAutoSave(nextConfig);
   }
 
   async function handleFetchEmailConfig() {
@@ -1899,55 +1915,62 @@ function EmailChannelEditor(props: {
             value={field.value as string[]}
             placeholder="name@example.com, *@example.com"
             onChange={field.onChange}
+            onAdd={saveDefaultAllowFrom}
           />
         )}
       />
 
-      <div className="field-grid">
-        <FormField
-          name="email.pollIntervalMs"
-          render={({ field }) => (
-            <Field>
-              <FieldLabel>Poll interval ms</FieldLabel>
-              <NumberField
-                integer
-                min={0}
-                value={field.value as number}
-                onValueChange={field.onChange}
-              />
-            </Field>
-          )}
-        />
-        <FormField
-          name="email.textChunkLimit"
-          render={({ field }) => (
-            <Field>
-              <FieldLabel>Text chunk limit</FieldLabel>
-              <NumberField
-                integer
-                min={0}
-                value={field.value as number}
-                onValueChange={field.onChange}
-              />
-            </Field>
-          )}
-        />
-      </div>
-
-      <FormField
-        name="email.mediaMaxMb"
-        render={({ field }) => (
-          <Field>
-            <FieldLabel>Media max MB</FieldLabel>
-            <NumberField
-              integer
-              min={0}
-              value={field.value as number}
-              onValueChange={field.onChange}
+      <details className="channel-advanced-settings">
+        <summary>Advanced settings</summary>
+        <div className="channel-advanced-settings-body">
+          <div className="field-grid">
+            <FormField
+              name="email.pollIntervalMs"
+              render={({ field }) => (
+                <Field>
+                  <FieldLabel>Poll interval ms</FieldLabel>
+                  <NumberField
+                    integer
+                    min={0}
+                    value={field.value as number}
+                    onValueChange={field.onChange}
+                  />
+                </Field>
+              )}
             />
-          </Field>
-        )}
-      />
+            <FormField
+              name="email.textChunkLimit"
+              render={({ field }) => (
+                <Field>
+                  <FieldLabel>Text chunk limit</FieldLabel>
+                  <NumberField
+                    integer
+                    min={0}
+                    value={field.value as number}
+                    onValueChange={field.onChange}
+                  />
+                </Field>
+              )}
+            />
+          </div>
+
+          <FormField
+            name="email.mediaMaxMb"
+            render={({ field }) => (
+              <Field>
+                <FieldLabel>Media max MB</FieldLabel>
+                <NumberField
+                  integer
+                  min={0}
+                  value={field.value as number}
+                  onValueChange={field.onChange}
+                />
+              </Field>
+            )}
+          />
+          <ChannelInstructionsField kind="email" />
+        </div>
+      </details>
       <div className="email-account-section">
         <div className="email-account-section-header">
           <h4>Additional agent mailboxes</h4>
@@ -2234,7 +2257,6 @@ function EmailChannelEditor(props: {
           </div>
         )}
       </div>
-      <ChannelInstructionsField kind="email" />
     </>
   );
 }
@@ -3379,6 +3401,7 @@ function renderSelectedEditor(
   },
   agents: AdminAgent[],
   onConfigSaved: (config: AdminConfig) => void,
+  onConfigAutoSave: (config: AdminConfig) => void,
   onSecretSaved: () => void,
 ) {
   switch (kind) {
@@ -3488,6 +3511,7 @@ function renderSelectedEditor(
           hybridaiApiKeyConfigured={hybridaiApiKeyConfigured}
           agents={agents}
           token={token}
+          onAutoSave={onConfigAutoSave}
           onSecretSaved={onSecretSaved}
         />
       );
@@ -3731,6 +3755,7 @@ export function ChannelsPage() {
                           queryKey: ['status', auth.token],
                         });
                       },
+                      (config) => saveMutation.mutate(config),
                       () => {
                         void queryClient.invalidateQueries({
                           queryKey: ['status', auth.token],

--- a/console/src/styles.css
+++ b/console/src/styles.css
@@ -2243,6 +2243,31 @@ th {
   font-weight: 500;
 }
 
+.channel-advanced-settings {
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-bg);
+}
+
+.channel-advanced-settings summary {
+  padding: 12px 14px;
+  cursor: pointer;
+  color: var(--text);
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.channel-advanced-settings summary::marker {
+  color: var(--muted-foreground);
+}
+
+.channel-advanced-settings-body {
+  display: grid;
+  gap: 12px;
+  padding: 0 14px 14px;
+}
+
 .email-default-agent-target {
   margin-left: 8px;
   color: var(--muted-foreground);


### PR DESCRIPTION
## Summary

- Move email poll interval, text chunk limit, media max, and email channel instructions into a collapsed Advanced settings block above additional mailboxes.
- Autosave the default email Allowed senders list immediately when a sender is added.
- Add console regression coverage for the collapsed section placement and the add-sender autosave flow.

## Impact

Operators no longer lose a newly added email sender by reloading before pressing the page-level save button. Advanced email tuning remains available but is tucked away by default.

## Validation

- `npm --workspace console run test -- channels.test.tsx`
- `npm --workspace console run typecheck`