### PR TITLE
fix(mcp): prefer GATEWAY_PUBLIC_BASE_URL for OAuth redirect URI

### DIFF
--- a/docs/content/developer-guide/runtime.md
+++ b/docs/content/developer-guide/runtime.md
@@ -111,6 +111,14 @@ Core details:
   already-running HybridClaw gateway.
 - `HEALTH_HOST` can override the health server bind address without rewriting
   runtime config, which is useful in containerized or proxied deployments.
+- `GATEWAY_PUBLIC_BASE_URL` is the public origin the gateway is reached at when
+  it runs behind an ingress proxy (e.g. `https://u-<id>.sbx.example.com`). When
+  set it is preferred over the request-derived origin for building
+  externally-reachable URLs — notably MCP OAuth redirect URIs, which otherwise
+  fall back to the incoming request's `Host`/`X-Forwarded-Host`. Set this when a
+  proxy can't be relied on to forward `X-Forwarded-Host`, so OAuth callbacks
+  don't end up pointing at the gateway's internal address. Leave it unset for
+  standalone/desktop runs.
 - `mcpServers.*.env` and `mcpServers.*.headers` are persisted in
   `~/.hybridclaw/config.json` exactly as configured today. Treat them as
   plaintext secrets and lock the runtime directory down with

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -540,6 +540,11 @@ export let HEALTH_PORT = 9090;
 export let WEB_API_TOKEN = '';
 export let GATEWAY_BASE_URL = 'http://127.0.0.1:9090';
 export let GATEWAY_CLIENT_BASE_URL = 'http://127.0.0.1:9090';
+// Public origin the gateway is reached at (e.g. behind an ingress proxy).
+// When set, it is preferred over the request-derived origin for building
+// externally-reachable URLs such as MCP OAuth redirect URIs. Empty = derive
+// from the incoming request (default standalone behavior).
+export let GATEWAY_PUBLIC_BASE_URL = '';
 const GATEWAY_API_TOKEN_LOCK_STALE_MS = 10_000;
 const GATEWAY_API_TOKEN_LOCK_TIMEOUT_MS = 5_000;
 const GATEWAY_API_TOKEN_LOCK_RETRY_MS = 25;
@@ -1109,6 +1114,10 @@ function applyRuntimeConfig(config: RuntimeConfig): void {
     config.ops.webApiToken;
   GATEWAY_BASE_URL = config.ops.gatewayBaseUrl;
   GATEWAY_CLIENT_BASE_URL = config.ops.gatewayInternalBaseUrl;
+  GATEWAY_PUBLIC_BASE_URL = normalizeConfiguredBaseUrl(
+    process.env.GATEWAY_PUBLIC_BASE_URL,
+    '',
+  );
   gatewayApiTokenUsesGeneratedFallback = false;
   GATEWAY_API_TOKEN =
     readRuntimeSecretValue(

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -147,6 +147,7 @@ import {
   FULLAUTO_NEVER_APPROVE_TOOLS,
   GATEWAY_API_TOKEN,
   GATEWAY_BASE_URL,
+  GATEWAY_PUBLIC_BASE_URL,
   GATEWAY_CLIENT_BASE_URL,
   HUGGINGFACE_API_KEY,
   HYBRIDAI_BASE_URL,
@@ -6965,7 +6966,14 @@ function requireConfiguredMcpServer(name: string): {
 }
 
 export function resolveMcpOAuthRedirectUri(requestBaseUrl?: string): string {
-  const base = String(requestBaseUrl || GATEWAY_BASE_URL || '')
+  // Prefer an explicitly-configured public origin when set: behind an ingress
+  // proxy the request-derived origin can be the gateway's internal address
+  // (e.g. http://172.19.0.22:9090), which is not reachable by the user's browser
+  // and would make the OAuth redirect fail. Falls back to the request origin and
+  // then the internal base URL for standalone setups.
+  const base = String(
+    GATEWAY_PUBLIC_BASE_URL || requestBaseUrl || GATEWAY_BASE_URL || '',
+  )
     .trim()
     .replace(/\/+$/, '');
   if (!base) {

--- a/tests/mcp-oauth-redirect.test.ts
+++ b/tests/mcp-oauth-redirect.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit test for resolveMcpOAuthRedirectUri's base-URL precedence.
+ *
+ * In particular: an explicitly-configured public base URL
+ * (GATEWAY_PUBLIC_BASE_URL) must be preferred over a request-derived origin.
+ * This matters behind an ingress proxy, where the request origin can be the
+ * gateway's unreachable internal address (e.g. http://172.19.0.22:9090) and the
+ * OAuth redirect would otherwise be undeliverable to the user's browser.
+ *
+ * GATEWAY_PUBLIC_BASE_URL is applied from the environment when config.ts loads,
+ * so each case sets the env and re-imports the module under a fresh registry.
+ * Uses a temp HYBRIDCLAW_DATA_DIR and the file-watcher-disabled flag, matching
+ * config-reload.integration.test.ts.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+let tmpDir: string;
+let originalDataDir: string | undefined;
+let originalHome: string | undefined;
+let originalWatcher: string | undefined;
+let originalPublicBaseUrl: string | undefined;
+
+type GatewayServiceModule = typeof import('../src/gateway/gateway-service.js');
+
+// Sets GATEWAY_PUBLIC_BASE_URL (or clears it) and re-imports gateway-service so
+// config.ts re-applies it at module load.
+async function loadGateway(
+  publicBaseUrl: string | undefined,
+): Promise<GatewayServiceModule> {
+  if (publicBaseUrl === undefined) delete process.env.GATEWAY_PUBLIC_BASE_URL;
+  else process.env.GATEWAY_PUBLIC_BASE_URL = publicBaseUrl;
+  vi.resetModules();
+  return await import('../src/gateway/gateway-service.js');
+}
+
+beforeAll(() => {
+  originalDataDir = process.env.HYBRIDCLAW_DATA_DIR;
+  originalHome = process.env.HOME;
+  originalWatcher = process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
+  originalPublicBaseUrl = process.env.GATEWAY_PUBLIC_BASE_URL;
+});
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hc-oauth-redirect-'));
+  process.env.HYBRIDCLAW_DATA_DIR = tmpDir;
+  process.env.HOME = tmpDir;
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
+  delete process.env.GATEWAY_PUBLIC_BASE_URL;
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+afterAll(() => {
+  const restore = (key: string, value: string | undefined): void => {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  };
+  restore('HYBRIDCLAW_DATA_DIR', originalDataDir);
+  restore('HOME', originalHome);
+  restore('HYBRIDCLAW_DISABLE_CONFIG_WATCHER', originalWatcher);
+  restore('GATEWAY_PUBLIC_BASE_URL', originalPublicBaseUrl);
+});
+
+describe('resolveMcpOAuthRedirectUri', () => {
+  it('uses the request origin when no public base URL is configured', async () => {
+    const gw = await loadGateway(undefined);
+    expect(
+      gw.resolveMcpOAuthRedirectUri('https://u-abc.sbx.example.com'),
+    ).toBe('https://u-abc.sbx.example.com/api/mcp/oauth/callback');
+  });
+
+  it('prefers the configured public base URL over the request origin', async () => {
+    const gw = await loadGateway('https://u-abc.sbx.example.com');
+    // The request origin here is the unreachable internal gateway address.
+    expect(
+      gw.resolveMcpOAuthRedirectUri('http://172.19.0.22:9090'),
+    ).toBe('https://u-abc.sbx.example.com/api/mcp/oauth/callback');
+  });
+
+  it('strips a trailing slash from the configured public base URL', async () => {
+    const gw = await loadGateway('https://u-abc.sbx.example.com/');
+    expect(
+      gw.resolveMcpOAuthRedirectUri('http://172.19.0.22:9090'),
+    ).toBe('https://u-abc.sbx.example.com/api/mcp/oauth/callback');
+  });
+});


### PR DESCRIPTION
## Problem

When the gateway runs behind a reverse proxy, the MCP OAuth `redirect_uri` is derived from the incoming request's `Host` (via `resolveRequestOrigin` → `X-Forwarded-Host` → `Host`). If the proxy doesn't forward `X-Forwarded-Host`, the `Host` the gateway sees is its **internal** listen address, so it builds an unreachable redirect:

```
http://172.19.0.22:9090/api/mcp/oauth/callback
```

The user's browser (reaching the gateway via its public address) can't route there, so the `?code=` redirect after consent dies and OAuth-based MCP connects (Sentry's hosted MCP, Linear, Notion, …) can't complete.

`resolveMcpOAuthRedirectUri` already had a `GATEWAY_BASE_URL` fallback, but it never helped here: `requestBaseUrl` is always non-empty (it falls back to `127.0.0.1`), so the configured value was never reached.

## Fix

Add a `GATEWAY_PUBLIC_BASE_URL` env var, applied in `config.ts` alongside `HEALTH_HOST`. When set, `resolveMcpOAuthRedirectUri` **prefers** it over the request-derived origin:

```ts
String(GATEWAY_PUBLIC_BASE_URL || requestBaseUrl || GATEWAY_BASE_URL || '')
```

The redirect URI is computed once at authorize time and persisted on the flow record (`mcp-oauth.ts`), then reused verbatim at token exchange — so authorize and exchange stay consistent.

This is **defense-in-depth**: OAuth correctness doesn't depend solely on the upstream proxy forwarding `X-Forwarded-Host`. When `GATEWAY_PUBLIC_BASE_URL` is unset, behavior is unchanged (derive from the request), so standalone/desktop runs are unaffected.

## Tests

`tests/mcp-oauth-redirect.test.ts`:
- request origin used when no public base URL is configured (current behavior preserved),
- configured public base URL preferred over an internal request origin,
- trailing slash trimmed.

`tsc --noEmit` (incl. `--noUnusedLocals --noUnusedParameters`) clean; existing `tests/mcp-oauth.test.ts` still green.

## Docs

Documented the env var in `docs/content/developer-guide/runtime.md`.
