### PR TITLE
[codex] Use public URL for MCP OAuth callbacks

### DIFF
--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -2295,6 +2295,11 @@ function resolveRequestOrigin(
   const explicitBaseUrl = normalizePublicBaseUrl(bodyBaseUrl);
   if (explicitBaseUrl) return explicitBaseUrl;
 
+  const configuredPublicUrl = normalizePublicBaseUrl(
+    getRuntimeConfig().deployment.public_url,
+  );
+  if (configuredPublicUrl) return configuredPublicUrl;
+
   const forwardedHost = String(req.headers['x-forwarded-host'] || '')
     .split(',')[0]
     ?.trim();

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -86,6 +86,7 @@ import type {
 } from '../config/runtime-config.js';
 import {
   getRuntimeConfig,
+  onRuntimeConfigChange,
   parseSchedulerBoardStatus,
   reloadRuntimeConfig,
   resolveDefaultAgentId,
@@ -302,6 +303,7 @@ import type {
   GatewayChatResultMessageRole,
   GatewayCommandRequest,
 } from './gateway-types.js';
+import { normalizeHttpOrigin } from './gateway-url-utils.js';
 import {
   extensionToMimeType,
   resolveWorkspaceRelativePath,
@@ -1627,6 +1629,10 @@ type MobileLaunchTokenEntry = {
   expiresAt: number;
 };
 const mobileLaunchTokens = new Map<string, MobileLaunchTokenEntry>();
+let deploymentPublicUrl = getRuntimeConfig().deployment.public_url;
+onRuntimeConfigChange((next) => {
+  deploymentPublicUrl = next.deployment.public_url;
+});
 
 function parseApiAdminPolicyIndex(value: unknown): number {
   const parsed = parsePositiveInteger(value);
@@ -2273,31 +2279,14 @@ function resolveMobileLaunchToken(token: string):
   };
 }
 
-function normalizePublicBaseUrl(value: unknown): string | undefined {
-  if (typeof value !== 'string') return undefined;
-  const trimmed = value.trim();
-  if (!trimmed) return undefined;
-  try {
-    const url = new URL(trimmed);
-    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-      return undefined;
-    }
-    return url.origin;
-  } catch {
-    return undefined;
-  }
-}
-
 function resolveRequestOrigin(
   req: IncomingMessage,
   bodyBaseUrl?: unknown,
 ): string {
-  const explicitBaseUrl = normalizePublicBaseUrl(bodyBaseUrl);
+  const explicitBaseUrl = normalizeHttpOrigin(bodyBaseUrl);
   if (explicitBaseUrl) return explicitBaseUrl;
 
-  const configuredPublicUrl = normalizePublicBaseUrl(
-    getRuntimeConfig().deployment.public_url,
-  );
+  const configuredPublicUrl = normalizeHttpOrigin(deploymentPublicUrl);
   if (configuredPublicUrl) return configuredPublicUrl;
 
   const forwardedHost = String(req.headers['x-forwarded-host'] || '')
@@ -2309,9 +2298,9 @@ function resolveRequestOrigin(
 }
 
 function resolveA2AAgentCardOrigin(req: IncomingMessage): string | null {
-  const configuredPublicUrl = getRuntimeConfig().deployment.public_url.trim();
+  const configuredPublicUrl = deploymentPublicUrl.trim();
   if (configuredPublicUrl) {
-    const origin = normalizePublicBaseUrl(configuredPublicUrl);
+    const origin = normalizeHttpOrigin(configuredPublicUrl);
     if (origin) return origin;
     logger.warn(
       { publicUrl: configuredPublicUrl },

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -604,6 +604,10 @@ import {
   renderGatewayCommand,
 } from './gateway-types.js';
 import {
+  isPrivateHttpBaseUrl,
+  normalizeHttpBaseUrl,
+} from './gateway-url-utils.js';
+import {
   firstNumber,
   numberFromUnknown,
   parseAuditPayload,
@@ -6966,82 +6970,46 @@ function requireConfiguredMcpServer(name: string): {
 
 export function resolveMcpOAuthRedirectUri(requestBaseUrl?: string): string {
   const config = getRuntimeConfig();
-  const configuredPublicUrl = normalizeMcpOAuthCallbackBaseUrl(
+  const configuredPublicUrl = normalizeConfiguredMcpOAuthPublicUrl(
     config.deployment.public_url,
   );
-  const configuredGatewayUrl =
-    normalizeMcpOAuthCallbackBaseUrl(GATEWAY_BASE_URL);
-  const requestUrl = normalizeMcpOAuthCallbackBaseUrl(requestBaseUrl);
-  const publicConfiguredGatewayUrl =
-    configuredGatewayUrl &&
-    !isPrivateMcpOAuthCallbackBaseUrl(configuredGatewayUrl)
-      ? configuredGatewayUrl
-      : '';
-  const publicRequestUrl =
-    requestUrl && !isPrivateMcpOAuthCallbackBaseUrl(requestUrl)
-      ? requestUrl
-      : '';
-  const base =
-    configuredPublicUrl ||
-    publicConfiguredGatewayUrl ||
-    publicRequestUrl ||
-    requestUrl ||
-    configuredGatewayUrl ||
-    '';
+  if (configuredPublicUrl) return buildMcpOAuthRedirectUri(configuredPublicUrl);
+
+  // Prefer public callback bases; private fallbacks only keep local dev working
+  // when no public deployment URL or public request/gateway URL is available.
+  const configuredGatewayUrl = normalizeHttpBaseUrl(GATEWAY_BASE_URL);
+  if (configuredGatewayUrl && !isPrivateHttpBaseUrl(configuredGatewayUrl)) {
+    return buildMcpOAuthRedirectUri(configuredGatewayUrl);
+  }
+
+  const requestUrl = normalizeHttpBaseUrl(requestBaseUrl);
+  if (requestUrl && !isPrivateHttpBaseUrl(requestUrl)) {
+    return buildMcpOAuthRedirectUri(requestUrl);
+  }
+
+  const base = requestUrl || configuredGatewayUrl || '';
   if (!base) {
     throw new Error(
       'Cannot determine the gateway base URL for the OAuth redirect.',
     );
   }
-  return `${base}/api/mcp/oauth/callback`;
+  return buildMcpOAuthRedirectUri(base);
 }
 
-function normalizeMcpOAuthCallbackBaseUrl(value?: string): string {
-  const trimmed = String(value || '')
-    .trim()
-    .replace(/\/+$/, '');
-  if (!trimmed) return '';
-  try {
-    const url = new URL(trimmed);
-    if (url.protocol !== 'http:' && url.protocol !== 'https:') return '';
-  } catch {
-    return '';
-  }
-  return trimmed;
-}
-
-function isPrivateMcpOAuthCallbackBaseUrl(value: string): boolean {
-  let hostname = '';
-  try {
-    hostname = new URL(value).hostname.toLowerCase();
-  } catch {
-    return true;
-  }
-  if (hostname === 'localhost' || hostname === '::1' || hostname === '[::1]') {
-    return true;
-  }
-  const parts = hostname.split('.');
-  if (parts.length !== 4) return false;
-  const octets = parts.map((part) => Number.parseInt(part, 10));
-  if (
-    octets.some(
-      (octet, index) =>
-        !Number.isInteger(octet) ||
-        String(octet) !== parts[index] ||
-        octet < 0 ||
-        octet > 255,
-    )
-  ) {
-    return false;
-  }
-  const [first, second] = octets;
-  return (
-    first === 10 ||
-    first === 127 ||
-    (first === 172 && second >= 16 && second <= 31) ||
-    (first === 192 && second === 168) ||
-    (first === 169 && second === 254)
+function normalizeConfiguredMcpOAuthPublicUrl(value?: string): string {
+  const normalized = normalizeHttpBaseUrl(value);
+  if (normalized || !String(value || '').trim()) return normalized || '';
+  logger.warn(
+    { publicUrl: value },
+    'Invalid deployment.public_url for MCP OAuth callback',
   );
+  throw new Error(
+    'deployment.public_url must be an HTTP(S) URL for MCP OAuth callbacks.',
+  );
+}
+
+function buildMcpOAuthRedirectUri(baseUrl: string): string {
+  return `${baseUrl}/api/mcp/oauth/callback`;
 }
 
 export async function startGatewayAdminMcpOAuth(input: {

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -6965,15 +6965,83 @@ function requireConfiguredMcpServer(name: string): {
 }
 
 export function resolveMcpOAuthRedirectUri(requestBaseUrl?: string): string {
-  const base = String(requestBaseUrl || GATEWAY_BASE_URL || '')
-    .trim()
-    .replace(/\/+$/, '');
+  const config = getRuntimeConfig();
+  const configuredPublicUrl = normalizeMcpOAuthCallbackBaseUrl(
+    config.deployment.public_url,
+  );
+  const configuredGatewayUrl =
+    normalizeMcpOAuthCallbackBaseUrl(GATEWAY_BASE_URL);
+  const requestUrl = normalizeMcpOAuthCallbackBaseUrl(requestBaseUrl);
+  const publicConfiguredGatewayUrl =
+    configuredGatewayUrl &&
+    !isPrivateMcpOAuthCallbackBaseUrl(configuredGatewayUrl)
+      ? configuredGatewayUrl
+      : '';
+  const publicRequestUrl =
+    requestUrl && !isPrivateMcpOAuthCallbackBaseUrl(requestUrl)
+      ? requestUrl
+      : '';
+  const base =
+    configuredPublicUrl ||
+    publicConfiguredGatewayUrl ||
+    publicRequestUrl ||
+    requestUrl ||
+    configuredGatewayUrl ||
+    '';
   if (!base) {
     throw new Error(
       'Cannot determine the gateway base URL for the OAuth redirect.',
     );
   }
   return `${base}/api/mcp/oauth/callback`;
+}
+
+function normalizeMcpOAuthCallbackBaseUrl(value?: string): string {
+  const trimmed = String(value || '')
+    .trim()
+    .replace(/\/+$/, '');
+  if (!trimmed) return '';
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return '';
+  } catch {
+    return '';
+  }
+  return trimmed;
+}
+
+function isPrivateMcpOAuthCallbackBaseUrl(value: string): boolean {
+  let hostname = '';
+  try {
+    hostname = new URL(value).hostname.toLowerCase();
+  } catch {
+    return true;
+  }
+  if (hostname === 'localhost' || hostname === '::1' || hostname === '[::1]') {
+    return true;
+  }
+  const parts = hostname.split('.');
+  if (parts.length !== 4) return false;
+  const octets = parts.map((part) => Number.parseInt(part, 10));
+  if (
+    octets.some(
+      (octet, index) =>
+        !Number.isInteger(octet) ||
+        String(octet) !== parts[index] ||
+        octet < 0 ||
+        octet > 255,
+    )
+  ) {
+    return false;
+  }
+  const [first, second] = octets;
+  return (
+    first === 10 ||
+    first === 127 ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168) ||
+    (first === 169 && second === 254)
+  );
 }
 
 export async function startGatewayAdminMcpOAuth(input: {

--- a/src/gateway/gateway-url-utils.ts
+++ b/src/gateway/gateway-url-utils.ts
@@ -1,0 +1,79 @@
+export function normalizeHttpBaseUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim().replace(/\/+$/, '');
+  if (!trimmed) return undefined;
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return undefined;
+    }
+    return trimmed;
+  } catch {
+    return undefined;
+  }
+}
+
+export function normalizeHttpOrigin(value: unknown): string | undefined {
+  const baseUrl = normalizeHttpBaseUrl(value);
+  if (!baseUrl) return undefined;
+  return new URL(baseUrl).origin;
+}
+
+export function isPrivateHttpBaseUrl(value: string): boolean {
+  let hostname = '';
+  try {
+    hostname = normalizeHostname(new URL(value).hostname);
+  } catch {
+    return true;
+  }
+
+  if (hostname === 'localhost') return true;
+  if (hostname.includes(':')) return isPrivateIpv6Hostname(hostname);
+
+  const parts = hostname.split('.');
+  if (parts.length !== 4) return false;
+  const octets = parts.map((part) => Number.parseInt(part, 10));
+  if (
+    octets.some(
+      (octet, index) =>
+        !Number.isInteger(octet) ||
+        String(octet) !== parts[index] ||
+        octet < 0 ||
+        octet > 255,
+    )
+  ) {
+    return false;
+  }
+  return isPrivateIpv4Octets(octets);
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname.toLowerCase().replace(/^\[|\]$/g, '');
+}
+
+function isPrivateIpv6Hostname(hostname: string): boolean {
+  if (hostname === '::1') return true;
+
+  const mappedIpv4 = hostname.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mappedIpv4) {
+    return isPrivateHttpBaseUrl(`http://${mappedIpv4[1]}`);
+  }
+
+  const firstSegment = Number.parseInt(hostname.split(':')[0] || '0', 16);
+  if (!Number.isInteger(firstSegment)) return false;
+
+  return (
+    (firstSegment & 0xfe00) === 0xfc00 || (firstSegment & 0xffc0) === 0xfe80
+  );
+}
+
+function isPrivateIpv4Octets(octets: number[]): boolean {
+  const [first, second] = octets;
+  return (
+    first === 10 ||
+    first === 127 ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168) ||
+    (first === 169 && second === 254)
+  );
+}

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -2934,6 +2934,37 @@ describe('gateway HTTP server', () => {
     expect(state.reloadRuntimeConfig).toHaveBeenCalledWith('admin-api');
   });
 
+  test('allows signed session cookie API mutations with configured public URL and internal host', async () => {
+    const authSecret = 'api-session-cloud-public-origin-secret';
+    const state = await importFreshHealth({
+      authSecret,
+      deploymentPublicUrl: 'https://u-public.sbx.hybridai.one',
+      webApiToken: 'web-token',
+    });
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/admin/config/reload',
+      headers: {
+        cookie: makeSessionCookie(authSecret, {
+          sessionId: 'admin-session-1',
+          actor: 'admin-user',
+          role: 'admin.config_manager',
+        }),
+        host: '172.19.0.21:9090',
+        origin: 'https://u-public.sbx.hybridai.one',
+      },
+      noAuth: true,
+      remoteAddress: '203.0.113.10',
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(200);
+    expect(state.reloadRuntimeConfig).toHaveBeenCalledWith('admin-api');
+  });
+
   test('rejects signed session cookie mutations with mismatched forwarded origin', async () => {
     const authSecret = 'api-session-forwarded-origin-mismatch-secret';
     const state = await importFreshHealth({
@@ -5500,6 +5531,36 @@ describe('gateway HTTP server', () => {
 
     expect(replayRes.statusCode).toBe(401);
     expect(replayRes.body).toBe('Mobile launch QR code is invalid or expired.');
+  });
+
+  test('mobile chat QR uses configured public URL when request host is internal', async () => {
+    const state = await importFreshHealth({
+      authSecret: 'mobile-qr-public-url-secret',
+      deploymentPublicUrl: 'https://u-public.sbx.hybridai.one',
+      webApiToken: 'web-token',
+    });
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/chat/mobile-qr',
+      headers: {
+        authorization: 'Bearer web-token',
+        host: '172.19.0.21:9090',
+      },
+      body: {
+        userId: 'web-user-a',
+        sessionId: 'agent:main:channel:web:chat:dm:peer:1234567890abcdef',
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(200);
+    const payload = JSON.parse(res.body) as { launchUrl: string };
+    expect(payload.launchUrl).toMatch(
+      /^https:\/\/u-public\.sbx\.hybridai\.one\/chat\/continue\?token=/,
+    );
   });
 
   test('rejects protected mobile chat QR creation when auth secret is missing', async () => {

--- a/tests/gateway-service.mcp-oauth-redirect.test.ts
+++ b/tests/gateway-service.mcp-oauth-redirect.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from 'vitest';
+import { setupGatewayTest } from './helpers/gateway-test-setup.js';
+
+const { setupHome } = setupGatewayTest({
+  tempHomePrefix: 'hybridclaw-gateway-mcp-oauth-redirect-',
+});
+
+test('MCP OAuth redirect prefers deployment public URL over private admin request origin', async () => {
+  setupHome();
+  const { updateRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  updateRuntimeConfig((draft) => {
+    draft.deployment.mode = 'cloud';
+    draft.deployment.public_url = 'https://cloud.hybridclaw.example.com';
+    draft.ops.gatewayBaseUrl = 'http://127.0.0.1:9090';
+  });
+
+  const { resolveMcpOAuthRedirectUri } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  expect(resolveMcpOAuthRedirectUri('http://172.19.0.21:9090')).toBe(
+    'https://cloud.hybridclaw.example.com/api/mcp/oauth/callback',
+  );
+});
+
+test('MCP OAuth redirect prefers public gateway base URL over private admin request origin', async () => {
+  setupHome();
+  const { updateRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  updateRuntimeConfig((draft) => {
+    draft.deployment.public_url = '';
+    draft.ops.gatewayBaseUrl = 'https://gateway.hybridclaw.example.com';
+  });
+
+  const { resolveMcpOAuthRedirectUri } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  expect(resolveMcpOAuthRedirectUri('http://172.19.0.21:9090')).toBe(
+    'https://gateway.hybridclaw.example.com/api/mcp/oauth/callback',
+  );
+});
+
+test('MCP OAuth redirect keeps public request origin when configured gateway base is local', async () => {
+  setupHome();
+  const { resolveMcpOAuthRedirectUri } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  expect(resolveMcpOAuthRedirectUri('https://admin.hybridclaw.example.com')).toBe(
+    'https://admin.hybridclaw.example.com/api/mcp/oauth/callback',
+  );
+});
+
+test('MCP OAuth redirect falls back to configured local base URL without request origin', async () => {
+  setupHome();
+  const { updateRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  updateRuntimeConfig((draft) => {
+    draft.ops.gatewayBaseUrl = 'http://127.0.0.1:9090';
+  });
+
+  const { resolveMcpOAuthRedirectUri } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  expect(resolveMcpOAuthRedirectUri()).toBe(
+    'http://127.0.0.1:9090/api/mcp/oauth/callback',
+  );
+});

--- a/tests/gateway-service.mcp-oauth-redirect.test.ts
+++ b/tests/gateway-service.mcp-oauth-redirect.test.ts
@@ -44,6 +44,28 @@ test('MCP OAuth redirect prefers public gateway base URL over private admin requ
   );
 });
 
+test('MCP OAuth redirect prefers public gateway base URL over private IPv6 request origin', async () => {
+  setupHome();
+  const { updateRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  updateRuntimeConfig((draft) => {
+    draft.deployment.public_url = '';
+    draft.ops.gatewayBaseUrl = 'https://gateway.hybridclaw.example.com';
+  });
+
+  const { resolveMcpOAuthRedirectUri } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  expect(resolveMcpOAuthRedirectUri('http://[fd12::1]:9090')).toBe(
+    'https://gateway.hybridclaw.example.com/api/mcp/oauth/callback',
+  );
+  expect(resolveMcpOAuthRedirectUri('http://[fe80::1]:9090')).toBe(
+    'https://gateway.hybridclaw.example.com/api/mcp/oauth/callback',
+  );
+});
+
 test('MCP OAuth redirect keeps public request origin when configured gateway base is local', async () => {
   setupHome();
   const { resolveMcpOAuthRedirectUri } = await import(
@@ -71,4 +93,24 @@ test('MCP OAuth redirect falls back to configured local base URL without request
   expect(resolveMcpOAuthRedirectUri()).toBe(
     'http://127.0.0.1:9090/api/mcp/oauth/callback',
   );
+});
+
+test('MCP OAuth redirect rejects invalid configured deployment public URL', async () => {
+  setupHome();
+  const { updateRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  updateRuntimeConfig((draft) => {
+    draft.deployment.mode = 'cloud';
+    draft.deployment.public_url = 'ftp://cloud.hybridclaw.example.com';
+    draft.ops.gatewayBaseUrl = 'http://127.0.0.1:9090';
+  });
+
+  const { resolveMcpOAuthRedirectUri } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  expect(() =>
+    resolveMcpOAuthRedirectUri('http://172.19.0.21:9090'),
+  ).toThrow('deployment.public_url must be an HTTP(S) URL');
 });


### PR DESCRIPTION
## What changed

- Prefer `deployment.public_url` when building MCP OAuth callback URLs, so cloud admin flows do not hand providers an internal container address.
- Fall back through public gateway/request origins before private/local origins.
- Teach request-origin resolution to prefer the configured public deployment URL for other externally consumed admin URLs.
- Add targeted gateway and OAuth redirect tests for cloud/public URL behavior.

## Why

Cloud admin requests can arrive at the gateway with an internal `Host` such as `172.19.0.21:9090`. The MCP OAuth start flow used that request origin first, so providers like Zoho redirected back to an internal address that a browser cannot reach.

## Impact

Cloud deployments with `deployment.public_url` set now generate public callback and launch URLs for external OAuth/browser flows. Local development still falls back to the configured/request base URL when no public deployment URL is present.

## Validation

- `biome check` on the touched gateway and test files
- `vitest run tests/gateway-service.mcp-oauth-redirect.test.ts`
- `vitest run tests/gateway-http-server.test.ts -t "configured public URL|mobile chat QR uses configured public URL"`
- `tsc --noEmit`