### PR TITLE
[codex] enable Microsoft 365 connector

### DIFF
--- a/console/src/routes/connectors.test.tsx
+++ b/console/src/routes/connectors.test.tsx
@@ -95,23 +95,19 @@ function makeConnectorsResponse(): AdminConnectorsResponse {
         name: 'Microsoft 365',
         description:
           'Connect work mail, calendars, files, SharePoint, OneDrive, and Teams.',
-        state: 'connected',
+        state: 'not_connected',
         authKind: 'oauth',
-        account: 'user@example.com',
-        detail: 'OAuth refresh token configured.',
-        scopes: ['offline_access', 'User.Read'],
+        account: null,
+        detail: 'Managed by HybridAI connectors.',
+        scopes: [],
         routesConfigured: true,
         clientConfigured: true,
-        clientSecretConfigured: false,
-        tenantId: 'organizations',
-        loginUrl: null,
-        adminConsentUrl:
-          'https://login.microsoftonline.com/organizations/adminconsent?client_id=microsoft-client-id',
-        setupSecretNames: [
-          'MICROSOFT_365_ACCOUNT',
-          'MICROSOFT_365_TENANT_ID',
-          'MICROSOFT_365_CLIENT_ID',
-        ],
+        clientSecretConfigured: true,
+        tenantId: null,
+        loginUrl:
+          'https://hybridai.one/admin_workspace/connectors?connect=microsoft365',
+        adminConsentUrl: null,
+        setupSecretNames: [],
       },
     ],
   };
@@ -148,24 +144,6 @@ describe('ConnectorsPage', () => {
     expect(screen.queryByText('M365')).toBeNull();
   });
 
-  it('marks Microsoft 365 as coming soon and disables setup', async () => {
-    renderWithProviders(<ConnectorsPage />);
-
-    expect(await screen.findByText('Microsoft 365')).toBeTruthy();
-    expect(screen.getByText('coming soon')).toBeTruthy();
-    expect(screen.queryByRole('button', { name: 'Reconnect' })).toBeNull();
-
-    const comingSoonButton = screen.getByRole('button', {
-      name: 'Coming soon',
-    }) as HTMLButtonElement;
-    expect(comingSoonButton.disabled).toBe(true);
-    fireEvent.click(comingSoonButton);
-
-    expect(screen.queryByText('Sign in with your work account')).toBeNull();
-    expect(startConnectorOAuthMock).not.toHaveBeenCalled();
-    expect(logoutConnectorMock).not.toHaveBeenCalled();
-  });
-
   it('starts GitHub through HybridClaw and opens the returned authorization URL', async () => {
     startConnectorOAuthMock.mockResolvedValue({
       provider: 'github',
@@ -191,6 +169,37 @@ describe('ConnectorsPage', () => {
     );
     expect(openSpy).toHaveBeenCalledWith(
       'https://github.com/apps/hybridai-test/installations/new',
+      '_self',
+    );
+
+    openSpy.mockRestore();
+  });
+
+  it('starts Microsoft 365 through HybridClaw and opens the returned authorization URL', async () => {
+    startConnectorOAuthMock.mockResolvedValue({
+      provider: 'microsoft365',
+      authorizationUrl:
+        'https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize',
+      state: '',
+      expiresAt: Date.now() + 600_000,
+    });
+    const openSpy = vi
+      .spyOn(window, 'open')
+      .mockReturnValue(null as unknown as Window);
+
+    renderWithProviders(<ConnectorsPage />);
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Connect Microsoft 365' }),
+    );
+
+    await waitFor(() =>
+      expect(startConnectorOAuthMock).toHaveBeenCalledWith('admin-token', {
+        provider: 'microsoft365',
+      }),
+    );
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize',
       '_self',
     );
 

--- a/console/src/routes/connectors.tsx
+++ b/console/src/routes/connectors.tsx
@@ -21,7 +21,6 @@ import {
   DialogTitle,
 } from '../components/dialog';
 import { Field, FieldLabel } from '../components/field';
-import { HybridClaw } from '../components/icons';
 import {
   GitHubLogo,
   GoogleLogo,
@@ -36,16 +35,12 @@ import { cx } from '../lib/cx';
 import { getErrorMessage } from '../lib/error-message';
 import styles from './connectors.module.css';
 
-type LocalOAuthConnectorId = Extract<
-  AdminConnectorId,
-  'google' | 'microsoft365'
->;
+type LocalOAuthConnectorId = Extract<AdminConnectorId, 'google'>;
 type OAuthConnectorId = Exclude<AdminConnectorId, 'hybridai'>;
-type PlatformConnectorId = Extract<AdminConnectorId, 'github'>;
+type PlatformConnectorId = Extract<AdminConnectorId, 'github' | 'microsoft365'>;
 
 interface OAuthDraft {
   account: string;
-  tenantId: string;
   clientId: string;
   clientSecret: string;
   scopes: string;
@@ -54,7 +49,6 @@ interface OAuthDraft {
 interface OAuthStartPayload {
   provider: OAuthConnectorId;
   account?: string;
-  tenantId?: string;
   clientId?: string;
   clientSecret?: string;
   scopes?: string;
@@ -62,8 +56,10 @@ interface OAuthStartPayload {
 
 const OAUTH_POLL_INTERVAL_MS = 2_000;
 const OAUTH_POLL_TIMEOUT_MS = 5 * 60_000;
-const COMING_SOON_CONNECTORS = new Set<AdminConnectorId>(['microsoft365']);
-const PLATFORM_CONNECTORS = new Set<AdminConnectorId>(['github']);
+const PLATFORM_CONNECTORS = new Set<AdminConnectorId>([
+  'github',
+  'microsoft365',
+]);
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -83,10 +79,6 @@ function connectorIsPlatform(
   connector: AdminConnector,
 ): connector is AdminConnector & { id: PlatformConnectorId } {
   return PLATFORM_CONNECTORS.has(connector.id);
-}
-
-function connectorIsComingSoon(connector: AdminConnector): boolean {
-  return COMING_SOON_CONNECTORS.has(connector.id);
 }
 
 function connectorMarkClass(connector: AdminConnector): string {
@@ -115,7 +107,6 @@ function ConnectorLogo({ connector }: { connector: AdminConnector }) {
 function oauthDraftFromConnector(connector: AdminConnector): OAuthDraft {
   return {
     account: connector.account || '',
-    tenantId: connector.tenantId || '',
     clientId: '',
     clientSecret: '',
     scopes: connector.scopes.join(' '),
@@ -125,13 +116,17 @@ function oauthDraftFromConnector(connector: AdminConnector): OAuthDraft {
 function isOAuthConnectorId(
   value: AdminConnectorId,
 ): value is LocalOAuthConnectorId {
-  return value === 'google' || value === 'microsoft365';
+  return value === 'google';
 }
 
 function isPlatformConnectorId(
   value: string | null,
 ): value is PlatformConnectorId {
-  return value === 'github';
+  return value === 'github' || value === 'microsoft365';
+}
+
+function platformConnectorName(provider: PlatformConnectorId): string {
+  return provider === 'github' ? 'GitHub' : 'Microsoft 365';
 }
 
 function canUseStoredGoogleOAuth(connector: AdminConnector): boolean {
@@ -150,7 +145,6 @@ function oauthPayloadFromDraft(
   return {
     provider,
     account: draft.account,
-    tenantId: draft.tenantId,
     clientId: draft.clientId,
     clientSecret: draft.clientSecret,
     scopes: draft.scopes,
@@ -175,7 +169,6 @@ export function ConnectorsPage() {
   });
   const [oauthDraft, setOauthDraft] = useState<OAuthDraft>({
     account: '',
-    tenantId: '',
     clientId: '',
     clientSecret: '',
     scopes: '',
@@ -208,12 +201,12 @@ export function ConnectorsPage() {
   const oauthMutation = useMutation({
     mutationFn: async (payload: OAuthStartPayload) => {
       const started = await startConnectorOAuth(auth.token, payload);
-      setPendingAuthUrl(started.authorizationUrl);
-      if (started.provider === 'github') {
+      if (isPlatformConnectorId(started.provider)) {
         window.open(started.authorizationUrl, '_self');
-        return 'GitHub';
+        return platformConnectorName(started.provider);
       }
 
+      setPendingAuthUrl(started.authorizationUrl);
       window.open(started.authorizationUrl, '_blank', 'noopener');
 
       const deadline =
@@ -279,9 +272,6 @@ export function ConnectorsPage() {
   const connectors = connectorsQuery.data?.connectors || [];
   const oauthTarget =
     connectors.find((connector) => connector.id === oauthTargetId) || null;
-  const isMicrosoftOAuthTarget = oauthTargetId === 'microsoft365';
-  const microsoftNeedsClientSetup =
-    isMicrosoftOAuthTarget && oauthTarget?.clientConfigured === false;
   const googleNeedsAccount =
     oauthTargetId === 'google' && !oauthDraft.account.trim();
   const googleNeedsClientId =
@@ -295,7 +285,6 @@ export function ConnectorsPage() {
   const oauthSubmitDisabled =
     oauthMutation.isPending ||
     !oauthTargetId ||
-    (microsoftNeedsClientSetup && !oauthDraft.clientId.trim()) ||
     googleNeedsAccount ||
     googleNeedsClientId ||
     googleNeedsClientSecret;
@@ -312,7 +301,7 @@ export function ConnectorsPage() {
         next.add(connected);
         return next;
       });
-      toast.success('GitHub connected.');
+      toast.success(`${platformConnectorName(connected)} connected.`);
     } else {
       toast.error('Connector connection failed.');
     }
@@ -337,7 +326,6 @@ export function ConnectorsPage() {
 
   const openOAuthDialog = (connector: AdminConnector) => {
     if (!isOAuthConnectorId(connector.id)) return;
-    if (connectorIsComingSoon(connector)) return;
     if (canUseStoredGoogleOAuth(connector)) {
       oauthMutation.mutate({ provider: 'google' });
       return;
@@ -368,22 +356,13 @@ export function ConnectorsPage() {
     <div className="page-stack">
       <div className={styles.connectorGrid}>
         {connectors.map((connector) => {
-          const isComingSoon = connectorIsComingSoon(connector);
-          const isConnected =
-            (stateIsConnected(connector) ||
-              (connector.id === 'github' &&
-                platformConnectedIds.has(connector.id))) &&
-            !isComingSoon;
           const isPlatform = connectorIsPlatform(connector);
+          const isConnected =
+            stateIsConnected(connector) ||
+            (isPlatform && platformConnectedIds.has(connector.id));
 
           return (
-            <Card
-              key={connector.id}
-              className={cx(
-                styles.connectorCard,
-                isComingSoon && styles.connectorCardDisabled,
-              )}
-            >
+            <Card key={connector.id} className={styles.connectorCard}>
               <CardHeader>
                 <div className={styles.connectorHead}>
                   <span className={connectorMarkClass(connector)}>
@@ -397,11 +376,9 @@ export function ConnectorsPage() {
                       <BooleanPill
                         value={isConnected}
                         trueLabel="connected"
-                        falseLabel={
-                          isComingSoon ? 'coming soon' : stateLabel(connector)
-                        }
+                        falseLabel={stateLabel(connector)}
                         falseTone={
-                          connector.state === 'needs_setup' && !isComingSoon
+                          connector.state === 'needs_setup'
                             ? 'danger'
                             : 'default'
                         }
@@ -414,11 +391,7 @@ export function ConnectorsPage() {
                 </div>
               </CardHeader>
               <div className={styles.connectorActions}>
-                {isComingSoon ? (
-                  <Button type="button" size="sm" variant="outline" disabled>
-                    Coming soon
-                  </Button>
-                ) : connector.id === 'hybridai' ? (
+                {connector.id === 'hybridai' ? (
                   <>
                     <Button
                       type="button"
@@ -507,7 +480,7 @@ export function ConnectorsPage() {
                     testMutation.isPending &&
                     testMutation.variables === connector.id
                   }
-                  disabled={isComingSoon || testMutation.isPending}
+                  disabled={testMutation.isPending}
                   aria-label={`Test ${connector.name}`}
                   onClick={() => testMutation.mutate(connector.id)}
                 >
@@ -566,176 +539,94 @@ export function ConnectorsPage() {
         >
           <DialogHeader>
             <DialogTitle>
-              {isMicrosoftOAuthTarget
-                ? 'Sign in with your work account'
-                : oauthTarget
-                  ? `Connect ${oauthTarget.name}`
-                  : 'Connect'}
+              {oauthTarget ? `Connect ${oauthTarget.name}` : 'Connect'}
             </DialogTitle>
             <DialogDescription>
-              {isMicrosoftOAuthTarget
-                ? 'Sign in with your Microsoft 365 work or school account. Personal Microsoft accounts are not supported.'
-                : oauthMutation.isPending
-                  ? 'Waiting for authorization in the browser.'
-                  : 'Leave stored app credentials blank to reuse them.'}
+              {oauthMutation.isPending
+                ? 'Waiting for authorization in the browser.'
+                : 'Leave stored app credentials blank to reuse them.'}
             </DialogDescription>
           </DialogHeader>
 
-          {isMicrosoftOAuthTarget ? (
-            <div className={styles.microsoftDialog}>
-              <div className={styles.oauthBridge} aria-hidden="true">
-                <span
-                  className={cx(
-                    styles.oauthBridgeMark,
-                    styles.connectorMarkMicrosoft365,
-                  )}
-                >
-                  <MicrosoftLogo width={28} height={28} />
-                </span>
-                <span className={styles.oauthBridgeLine} />
-                <span
-                  className={cx(
-                    styles.oauthBridgeMark,
-                    styles.oauthBridgeMarkHybridClaw,
-                  )}
-                >
-                  <HybridClaw width={28} height={28} />
-                </span>
-              </div>
+          <div className={styles.dialogForm}>
+            <Field>
+              <FieldLabel>Google account</FieldLabel>
+              <Input
+                value={oauthDraft.account}
+                onChange={(event) =>
+                  setOauthDraft((current) => ({
+                    ...current,
+                    account: event.target.value,
+                  }))
+                }
+                placeholder="user@example.com"
+              />
+            </Field>
 
-              {oauthMutation.isPending ? (
-                <div className={styles.microsoftCopy}>
-                  <p>Complete the Microsoft sign-in in the new browser tab.</p>
-                  {pendingAuthUrl ? (
-                    <a
-                      className={styles.pendingLink}
-                      href={pendingAuthUrl}
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      Reopen Microsoft sign-in
-                    </a>
-                  ) : null}
-                </div>
-              ) : (
-                <div className={styles.microsoftCopy}>
-                  <p>
-                    Connect SharePoint, OneDrive, Outlook, Teams, calendar, and
-                    chat data to HybridClaw through Microsoft Graph.
-                  </p>
-                  <p>
-                    If you are the Microsoft Entra admin, approve access during
-                    sign-in. Otherwise your admin may need to approve it first.
-                  </p>
-                </div>
-              )}
-
-              {microsoftNeedsClientSetup ? (
-                <div className={styles.microsoftSetup}>
-                  <div>
-                    <strong>One-time Entra app setup</strong>
-                    <p>
-                      Add the HybridClaw Microsoft app client ID here once to
-                      enable the simple sign-in flow on this gateway.
-                    </p>
-                  </div>
-                  <Field>
-                    <FieldLabel>Microsoft app client ID</FieldLabel>
-                    <Input
-                      value={oauthDraft.clientId}
-                      onChange={(event) =>
-                        setOauthDraft((current) => ({
-                          ...current,
-                          clientId: event.target.value,
-                        }))
-                      }
-                      placeholder="00000000-0000-0000-0000-000000000000"
-                    />
-                  </Field>
-                </div>
-              ) : null}
-            </div>
-          ) : (
-            <div className={styles.dialogForm}>
+            <div className="field-grid">
               <Field>
-                <FieldLabel>Google account</FieldLabel>
+                <FieldLabel>Client ID</FieldLabel>
                 <Input
-                  value={oauthDraft.account}
+                  value={oauthDraft.clientId}
                   onChange={(event) =>
                     setOauthDraft((current) => ({
                       ...current,
-                      account: event.target.value,
+                      clientId: event.target.value,
                     }))
                   }
-                  placeholder="user@example.com"
+                  placeholder={
+                    oauthTarget?.clientConfigured
+                      ? 'stored client id'
+                      : 'client id'
+                  }
                 />
               </Field>
-
-              <div className="field-grid">
-                <Field>
-                  <FieldLabel>Client ID</FieldLabel>
-                  <Input
-                    value={oauthDraft.clientId}
-                    onChange={(event) =>
-                      setOauthDraft((current) => ({
-                        ...current,
-                        clientId: event.target.value,
-                      }))
-                    }
-                    placeholder={
-                      oauthTarget?.clientConfigured
-                        ? 'stored client id'
-                        : 'client id'
-                    }
-                  />
-                </Field>
-                <Field>
-                  <FieldLabel>Client secret</FieldLabel>
-                  <Input
-                    type="password"
-                    autoComplete="off"
-                    value={oauthDraft.clientSecret}
-                    onChange={(event) =>
-                      setOauthDraft((current) => ({
-                        ...current,
-                        clientSecret: event.target.value,
-                      }))
-                    }
-                    placeholder={
-                      oauthTarget?.clientSecretConfigured
-                        ? 'stored secret'
-                        : 'client secret'
-                    }
-                  />
-                </Field>
-              </div>
-
               <Field>
-                <FieldLabel>Scopes</FieldLabel>
-                <Textarea
-                  rows={4}
-                  value={oauthDraft.scopes}
+                <FieldLabel>Client secret</FieldLabel>
+                <Input
+                  type="password"
+                  autoComplete="off"
+                  value={oauthDraft.clientSecret}
                   onChange={(event) =>
                     setOauthDraft((current) => ({
                       ...current,
-                      scopes: event.target.value,
+                      clientSecret: event.target.value,
                     }))
+                  }
+                  placeholder={
+                    oauthTarget?.clientSecretConfigured
+                      ? 'stored secret'
+                      : 'client secret'
                   }
                 />
               </Field>
-
-              {pendingAuthUrl && oauthMutation.isPending ? (
-                <a
-                  className={styles.pendingLink}
-                  href={pendingAuthUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  Open authorization page
-                </a>
-              ) : null}
             </div>
-          )}
+
+            <Field>
+              <FieldLabel>Scopes</FieldLabel>
+              <Textarea
+                rows={4}
+                value={oauthDraft.scopes}
+                onChange={(event) =>
+                  setOauthDraft((current) => ({
+                    ...current,
+                    scopes: event.target.value,
+                  }))
+                }
+              />
+            </Field>
+
+            {pendingAuthUrl && oauthMutation.isPending ? (
+              <a
+                className={styles.pendingLink}
+                href={pendingAuthUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Open authorization page
+              </a>
+            ) : null}
+          </div>
 
           <DialogFooter>
             <DialogClose
@@ -755,11 +646,7 @@ export function ConnectorsPage() {
                 );
               }}
             >
-              {oauthMutation.isPending
-                ? 'Waiting...'
-                : isMicrosoftOAuthTarget
-                  ? 'Continue'
-                  : 'Connect'}
+              {oauthMutation.isPending ? 'Waiting...' : 'Connect'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/gateway/gateway-admin-connectors.ts
+++ b/src/gateway/gateway-admin-connectors.ts
@@ -20,22 +20,6 @@ import {
   getHybridAIAuthStatus,
 } from '../auth/hybridai-auth.js';
 import {
-  buildMicrosoft365AuthorizeUrl,
-  clearMicrosoft365Auth,
-  createMicrosoft365PkcePair,
-  DEFAULT_MICROSOFT_365_OAUTH_SCOPES,
-  exchangeMicrosoft365AuthorizationCode,
-  getMicrosoft365AuthStatus,
-  loginMicrosoft365,
-  MICROSOFT_365_ACCOUNT_SECRET,
-  MICROSOFT_365_OAUTH_CLIENT_ID_SECRET,
-  MICROSOFT_365_OAUTH_CLIENT_SECRET_SECRET,
-  MICROSOFT_365_OAUTH_SCOPES_SECRET,
-  MICROSOFT_365_TENANT_ID_SECRET,
-  mintMicrosoft365AccessToken,
-  parseMicrosoft365Scopes,
-} from '../auth/microsoft-auth.js';
-import {
   HYBRIDAI_BASE_URL,
   MissingRequiredEnvVarError,
   refreshRuntimeSecretsFromEnv,
@@ -43,9 +27,7 @@ import {
 import {
   getRuntimeConfig,
   isGoogleOAuthSecretRef,
-  isMicrosoftOAuthSecretRef,
   makeGoogleOAuthSecretRef,
-  makeMicrosoftOAuthSecretRef,
   normalizeHttpRequestAuthRuleUrlPrefix,
   type RuntimeHttpRequestAuthRule,
   updateRuntimeConfig,
@@ -66,9 +48,9 @@ export type GatewayAdminConnectorId =
   | 'github'
   | 'google'
   | 'microsoft365';
-export type GatewayAdminLocalOAuthConnectorId = Extract<
+type GatewayAdminPlatformConnectorId = Extract<
   GatewayAdminConnectorId,
-  'google' | 'microsoft365'
+  'github' | 'microsoft365'
 >;
 export type GatewayAdminOAuthConnectorId = Exclude<
   GatewayAdminConnectorId,
@@ -120,22 +102,17 @@ export interface GatewayAdminConnectorOAuthStartResult {
 interface ConnectorOAuthStartInput {
   provider?: unknown;
   account?: unknown;
-  tenantId?: unknown;
   clientId?: unknown;
   clientSecret?: unknown;
   scopes?: unknown;
 }
 
 interface PendingConnectorOAuthFlow {
-  provider: GatewayAdminLocalOAuthConnectorId;
   account: string;
-  tenantId: string;
   clientId: string;
   clientSecret: string;
   scopes: string[];
   redirectUri: string;
-  codeVerifier: string | null;
-  codeChallenge: string | null;
   createdAt: number;
 }
 
@@ -245,12 +222,6 @@ function hasGoogleOAuthRoute(): boolean {
   );
 }
 
-function hasMicrosoftOAuthRoute(): boolean {
-  return getRuntimeConfig().tools.httpRequest.authRules.some((rule) =>
-    isMicrosoftOAuthSecretRef(rule.secret),
-  );
-}
-
 function upsertHttpAuthRule(rule: RuntimeHttpRequestAuthRule): void {
   updateRuntimeConfig((draft) => {
     draft.tools.httpRequest.authRules =
@@ -278,27 +249,6 @@ function ensureGoogleWorkspaceRoutes(): void {
       secret: makeGoogleOAuthSecretRef(),
     });
   }
-}
-
-function ensureMicrosoftGraphRoute(): void {
-  upsertHttpAuthRule({
-    urlPrefix: normalizeHttpRequestAuthRuleUrlPrefix(
-      'https://graph.microsoft.com/',
-    ),
-    header: 'Authorization',
-    prefix: 'Bearer',
-    secret: makeMicrosoftOAuthSecretRef(),
-  });
-}
-
-function microsoftAdminConsentUrl(
-  clientId: string,
-  tenantId: string | null,
-): string | null {
-  if (!clientId) return null;
-  const tenant = tenantId || 'organizations';
-  const query = new URLSearchParams({ client_id: clientId });
-  return `https://login.microsoftonline.com/${encodeURIComponent(tenant)}/adminconsent?${query.toString()}`;
 }
 
 function buildHybridAIConnector(): GatewayAdminConnector {
@@ -392,44 +342,29 @@ function buildGitHubConnector(
   };
 }
 
-function buildMicrosoft365Connector(): GatewayAdminConnector {
-  const status = getMicrosoft365AuthStatus();
-  const clientId = readSecretOrEnv(MICROSOFT_365_OAUTH_CLIENT_ID_SECRET);
-  const clientSecret = readSecretOrEnv(
-    MICROSOFT_365_OAUTH_CLIENT_SECRET_SECRET,
-  );
-  const tenantId = status.tenantId || 'organizations';
+function buildMicrosoft365Connector(
+  status?: HybridAIPlatformConnectorStatus,
+): GatewayAdminConnector {
+  const connected = status?.connected === true;
   return {
     id: 'microsoft365',
     name: 'Microsoft 365',
     description:
       'Connect work mail, calendars, files, SharePoint, OneDrive, and Teams.',
-    state: status.authenticated
-      ? 'connected'
-      : clientId
-        ? 'not_connected'
-        : 'needs_setup',
+    state: connected ? 'connected' : 'not_connected',
     authKind: 'oauth',
-    account: status.account || null,
-    detail: status.authenticated
-      ? 'OAuth refresh token configured.'
-      : clientId
-        ? 'OAuth client configured. Connect to authorize Microsoft Graph.'
-        : 'A Microsoft Entra app client id is required until HybridClaw ships its hosted app id.',
-    scopes: status.scopes,
-    routesConfigured: hasMicrosoftOAuthRoute(),
-    clientConfigured: Boolean(clientId),
-    clientSecretConfigured: Boolean(clientSecret),
-    tenantId,
-    loginUrl: null,
-    adminConsentUrl: microsoftAdminConsentUrl(clientId, tenantId),
-    setupSecretNames: [
-      MICROSOFT_365_ACCOUNT_SECRET,
-      MICROSOFT_365_TENANT_ID_SECRET,
-      MICROSOFT_365_OAUTH_CLIENT_ID_SECRET,
-      MICROSOFT_365_OAUTH_CLIENT_SECRET_SECRET,
-      MICROSOFT_365_OAUTH_SCOPES_SECRET,
-    ],
+    account: status?.account || null,
+    detail: connected
+      ? 'Connected through HybridAI.'
+      : 'Managed by HybridAI connectors.',
+    scopes: [],
+    routesConfigured: true,
+    clientConfigured: true,
+    clientSecretConfigured: true,
+    tenantId: null,
+    loginUrl: resolveHybridAIConnectorUrl('microsoft365'),
+    adminConsentUrl: null,
+    setupSecretNames: [],
   };
 }
 
@@ -470,7 +405,7 @@ function parseHybridAIPlatformConnectorStatuses(
   for (const entry of connectors) {
     if (!entry || typeof entry !== 'object') continue;
     const record = entry as Record<string, unknown>;
-    const id = trimString(record.id).toLowerCase();
+    const id = normalizeHybridAIPlatformConnectorId(record.id);
     if (!id) continue;
     statuses.set(id, {
       connected:
@@ -483,6 +418,29 @@ function parseHybridAIPlatformConnectorStatuses(
     });
   }
   return statuses;
+}
+
+function normalizeHybridAIPlatformConnectorId(
+  value: unknown,
+): GatewayAdminPlatformConnectorId | null {
+  const id = trimString(value).toLowerCase();
+  if (id === 'github') return 'github';
+  if (
+    id === 'microsoft365' ||
+    id === 'microsoft-365' ||
+    id === 'm365' ||
+    id === 'windows365' ||
+    id === 'windows-365'
+  ) {
+    return 'microsoft365';
+  }
+  return null;
+}
+
+function platformConnectorName(
+  provider: GatewayAdminPlatformConnectorId,
+): string {
+  return provider === 'github' ? 'GitHub' : 'Microsoft 365';
 }
 
 async function readHybridAIPlatformConnectorStatuses(): Promise<
@@ -572,17 +530,20 @@ async function testHybridAIConnector(): Promise<GatewayAdminConnectorTestResult>
   }
 }
 
-async function testGitHubConnector(): Promise<GatewayAdminConnectorTestResult> {
+async function testHybridAIPlatformConnector(
+  provider: GatewayAdminPlatformConnectorId,
+): Promise<GatewayAdminConnectorTestResult> {
+  const name = platformConnectorName(provider);
   let apiKey: string;
   try {
     apiKey = getHybridAIApiKey();
   } catch (error) {
     if (error instanceof MissingRequiredEnvVarError) {
       return testResult({
-        provider: 'github',
-        name: 'GitHub',
+        provider,
+        name,
         ok: false,
-        message: 'Connect HybridAI first, then connect GitHub.',
+        message: `Connect HybridAI first, then connect ${name}.`,
       });
     }
     throw error;
@@ -598,8 +559,8 @@ async function testGitHubConnector(): Promise<GatewayAdminConnectorTestResult> {
     const payload = await readJsonObject(response);
     if (!response.ok) {
       return testResult({
-        provider: 'github',
-        name: 'GitHub',
+        provider,
+        name,
         ok: false,
         message: messageFromHybridAIResponse(
           payload,
@@ -608,34 +569,27 @@ async function testGitHubConnector(): Promise<GatewayAdminConnectorTestResult> {
       });
     }
 
-    const connectors = Array.isArray(payload.connectors)
-      ? payload.connectors
-      : [];
-    const github = connectors.find(
-      (entry) =>
-        entry &&
-        typeof entry === 'object' &&
-        (entry as Record<string, unknown>).id === 'github',
-    ) as Record<string, unknown> | undefined;
+    const connectors = parseHybridAIPlatformConnectorStatuses(payload);
+    const connector = connectors.get(provider);
 
-    if (github?.connected === true) {
+    if (connector?.connected === true) {
       return testResult({
-        provider: 'github',
-        name: 'GitHub',
+        provider,
+        name,
         ok: true,
-        message: 'GitHub is connected for this HybridAI account.',
+        message: `${name} is connected for this HybridAI account.`,
       });
     }
     return testResult({
-      provider: 'github',
-      name: 'GitHub',
+      provider,
+      name,
       ok: false,
-      message: 'GitHub is not connected for this HybridAI account.',
+      message: `${name} is not connected for this HybridAI account.`,
     });
   } catch (error) {
     return testResult({
-      provider: 'github',
-      name: 'GitHub',
+      provider,
+      name,
       ok: false,
       message: `Could not reach HybridAI connectors: ${errorMessage(error)}`,
     });
@@ -671,47 +625,22 @@ async function testGoogleConnector(): Promise<GatewayAdminConnectorTestResult> {
   }
 }
 
-async function testMicrosoft365Connector(): Promise<GatewayAdminConnectorTestResult> {
-  try {
-    const minted = await mintMicrosoft365AccessToken();
-    if (!minted) {
-      return testResult({
-        provider: 'microsoft365',
-        name: 'Microsoft 365',
-        ok: false,
-        message: 'Microsoft 365 is not connected.',
-      });
-    }
-    return testResult({
-      provider: 'microsoft365',
-      name: 'Microsoft 365',
-      ok: true,
-      message: 'Microsoft 365 is ready to use.',
-    });
-  } catch (error) {
-    return testResult({
-      provider: 'microsoft365',
-      name: 'Microsoft 365',
-      ok: false,
-      message: errorMessage(error),
-    });
-  }
-}
-
 export async function testGatewayAdminConnector(input: {
   provider?: unknown;
 }): Promise<GatewayAdminConnectorTestResult> {
   const provider = parseConnectorId(input.provider);
   if (provider === 'hybridai') return testHybridAIConnector();
-  if (provider === 'github') return testGitHubConnector();
-  if (provider === 'google') return testGoogleConnector();
-  return testMicrosoft365Connector();
+  if (provider === 'github' || provider === 'microsoft365') {
+    return testHybridAIPlatformConnector(provider);
+  }
+  return testGoogleConnector();
 }
 
 async function startHybridAIPlatformConnectorOAuth(input: {
-  provider: Extract<GatewayAdminConnectorId, 'github'>;
+  provider: GatewayAdminPlatformConnectorId;
   requestBaseUrl?: string;
 }): Promise<GatewayAdminConnectorOAuthStartResult> {
+  const name = platformConnectorName(input.provider);
   let apiKey: string;
   try {
     apiKey = getHybridAIApiKey();
@@ -719,7 +648,7 @@ async function startHybridAIPlatformConnectorOAuth(input: {
     if (error instanceof MissingRequiredEnvVarError) {
       throw new GatewayRequestError(
         400,
-        'Connect HybridAI first, then connect GitHub.',
+        `Connect HybridAI first, then connect ${name}.`,
       );
     }
     throw error;
@@ -785,7 +714,7 @@ export async function getGatewayAdminConnectorsWithPlatformState(): Promise<Gate
       buildHybridAIConnector(),
       buildGitHubConnector(platformStatuses.get('github')),
       buildGoogleConnector(),
-      buildMicrosoft365Connector(),
+      buildMicrosoft365Connector(platformStatuses.get('microsoft365')),
     ],
     secretsPath: runtimeSecretsPath(),
   };
@@ -832,60 +761,11 @@ function resolveGoogleOAuthFlow(input: {
   }
 
   return {
-    provider: 'google',
     account,
-    tenantId: '',
     clientId,
     clientSecret,
     scopes,
     redirectUri: input.redirectUri,
-    codeVerifier: null,
-    codeChallenge: null,
-    createdAt: Date.now(),
-  };
-}
-
-function resolveMicrosoft365OAuthFlow(input: {
-  body: ConnectorOAuthStartInput;
-  redirectUri: string;
-}): PendingConnectorOAuthFlow {
-  const current = getMicrosoft365AuthStatus();
-  const account = trimString(input.body.account) || current.account;
-  const tenantId =
-    trimString(input.body.tenantId) ||
-    readSecretOrEnv(MICROSOFT_365_TENANT_ID_SECRET) ||
-    current.tenantId ||
-    'organizations';
-  const clientId =
-    trimString(input.body.clientId) ||
-    readSecretOrEnv(MICROSOFT_365_OAUTH_CLIENT_ID_SECRET);
-  const clientSecret =
-    trimString(input.body.clientSecret) ||
-    readSecretOrEnv(MICROSOFT_365_OAUTH_CLIENT_SECRET_SECRET);
-  const scopes = parseMicrosoft365Scopes(
-    trimString(input.body.scopes) ||
-      readSecretOrEnv(MICROSOFT_365_OAUTH_SCOPES_SECRET) ||
-      DEFAULT_MICROSOFT_365_OAUTH_SCOPES.join(' '),
-  );
-  const pkce = createMicrosoft365PkcePair();
-
-  if (!clientId) {
-    throw new GatewayRequestError(
-      400,
-      'Microsoft 365 OAuth client id is required.',
-    );
-  }
-
-  return {
-    provider: 'microsoft365',
-    account,
-    tenantId,
-    clientId,
-    clientSecret,
-    scopes,
-    redirectUri: input.redirectUri,
-    codeVerifier: pkce.verifier,
-    codeChallenge: pkce.challenge,
     createdAt: Date.now(),
   };
 }
@@ -902,7 +782,7 @@ export async function startGatewayAdminConnectorOAuth(input: {
       'HybridAI uses an API key flow, not OAuth.',
     );
   }
-  if (provider === 'github') {
+  if (provider === 'github' || provider === 'microsoft365') {
     return startHybridAIPlatformConnectorOAuth({
       provider,
       requestBaseUrl: input.requestBaseUrl,
@@ -911,40 +791,20 @@ export async function startGatewayAdminConnectorOAuth(input: {
 
   const redirectUri = resolveOAuthRedirectUri(input.requestBaseUrl);
   const state = makeState();
-  const flow =
-    provider === 'google'
-      ? resolveGoogleOAuthFlow({ body: input.body, redirectUri })
-      : resolveMicrosoft365OAuthFlow({ body: input.body, redirectUri });
+  const flow = resolveGoogleOAuthFlow({ body: input.body, redirectUri });
 
   pendingConnectorOAuthFlows.set(state, flow);
-  if (provider === 'microsoft365' && !flow.codeChallenge) {
-    pendingConnectorOAuthFlows.delete(state);
-    throw new GatewayRequestError(
-      400,
-      'Microsoft 365 OAuth flow is missing PKCE challenge state.',
-    );
-  }
 
   return {
-    provider,
+    provider: 'google',
     state,
     expiresAt: flow.createdAt + PENDING_CONNECTOR_OAUTH_TTL_MS,
-    authorizationUrl:
-      provider === 'google'
-        ? buildGoogleAuthorizeUrl({
-            clientId: flow.clientId,
-            redirectUri,
-            state,
-            scopes: flow.scopes,
-          })
-        : buildMicrosoft365AuthorizeUrl({
-            tenantId: flow.tenantId,
-            clientId: flow.clientId,
-            redirectUri,
-            state,
-            scopes: flow.scopes,
-            codeChallenge: flow.codeChallenge || '',
-          }),
+    authorizationUrl: buildGoogleAuthorizeUrl({
+      clientId: flow.clientId,
+      redirectUri,
+      state,
+      scopes: flow.scopes,
+    }),
   };
 }
 
@@ -962,49 +822,21 @@ export async function completeGatewayAdminConnectorOAuthCallback(input: {
   }
   pendingConnectorOAuthFlows.delete(input.state);
 
-  if (flow.provider === 'google') {
-    const exchanged = await exchangeGoogleAuthorizationCode({
-      clientId: flow.clientId,
-      clientSecret: flow.clientSecret,
-      code: input.code,
-      redirectUri: flow.redirectUri,
-    });
-    await loginGoogle({
-      account: flow.account,
-      clientId: flow.clientId,
-      clientSecret: flow.clientSecret,
-      refreshToken: exchanged.refreshToken,
-      scopes: flow.scopes,
-    });
-    ensureGoogleWorkspaceRoutes();
-    return { provider: 'google', name: 'Google Workspace' };
-  }
-
-  if (!flow.codeVerifier) {
-    throw new GatewayRequestError(
-      400,
-      'Microsoft 365 OAuth flow is missing PKCE verifier state.',
-    );
-  }
-  const exchanged = await exchangeMicrosoft365AuthorizationCode({
-    tenantId: flow.tenantId,
+  const exchanged = await exchangeGoogleAuthorizationCode({
     clientId: flow.clientId,
     clientSecret: flow.clientSecret,
     code: input.code,
     redirectUri: flow.redirectUri,
-    codeVerifier: flow.codeVerifier,
-    scopes: flow.scopes,
   });
-  await loginMicrosoft365({
+  await loginGoogle({
     account: flow.account,
-    tenantId: flow.tenantId,
     clientId: flow.clientId,
     clientSecret: flow.clientSecret,
     refreshToken: exchanged.refreshToken,
     scopes: flow.scopes,
   });
-  ensureMicrosoftGraphRoute();
-  return { provider: 'microsoft365', name: 'Microsoft 365' };
+  ensureGoogleWorkspaceRoutes();
+  return { provider: 'google', name: 'Google Workspace' };
 }
 
 export function logoutGatewayAdminConnector(input: {
@@ -1013,15 +845,13 @@ export function logoutGatewayAdminConnector(input: {
   const provider = parseConnectorId(input.provider);
   if (provider === 'hybridai') {
     clearHybridAICredentials();
-  } else if (provider === 'github') {
+  } else if (provider === 'github' || provider === 'microsoft365') {
     throw new GatewayRequestError(
       400,
-      'GitHub is managed through HybridAI connectors.',
+      `${platformConnectorName(provider)} is managed through HybridAI connectors.`,
     );
   } else if (provider === 'google') {
     clearGoogleAuth();
-  } else {
-    clearMicrosoft365Auth();
   }
   return getGatewayAdminConnectors();
 }

--- a/tests/gateway-admin-connectors.test.ts
+++ b/tests/gateway-admin-connectors.test.ts
@@ -132,14 +132,15 @@ describe('gateway admin connectors', () => {
     expect(refreshRuntimeSecretsFromEnv).toHaveBeenCalledTimes(1);
   });
 
-  test('completes Microsoft OAuth and configures the Graph auth route', async () => {
-    const { connectors, runtimeConfig, runtimeSecrets } =
-      await importFreshConnectors();
+  test('starts Microsoft 365 OAuth through HybridAI as the API key owner', async () => {
+    const { connectors, runtimeSecrets } = await importFreshConnectors();
+    runtimeSecrets.saveNamedRuntimeSecrets({
+      HYBRIDAI_API_KEY: 'hai-test-secret-key',
+    });
     const fetchMock = vi.fn<typeof fetch>(async () => {
       return new Response(
         JSON.stringify({
-          refresh_token: 'microsoft-refresh-token',
-          token_type: 'Bearer',
+          authorization_url: 'https://microsoft.test/authorize',
         }),
         {
           status: 200,
@@ -152,47 +153,27 @@ describe('gateway admin connectors', () => {
     const started = await connectors.startGatewayAdminConnectorOAuth({
       requestBaseUrl: 'http://127.0.0.1:9090',
       body: {
-        provider: 'm365',
-        account: 'user@example.com',
-        tenantId: 'organizations',
-        clientId: 'microsoft-client-id',
-        scopes: 'offline_access User.Read Mail.Read',
+        provider: 'microsoft365',
       },
     });
 
-    const url = new URL(started.authorizationUrl);
-    expect(started.provider).toBe('microsoft365');
-    expect(url.origin + url.pathname).toBe(
-      'https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize',
-    );
-    expect(url.searchParams.get('redirect_uri')).toBe(
-      'http://127.0.0.1:9090/api/connectors/oauth/callback',
-    );
-    expect(url.searchParams.get('code_challenge')).toBeTruthy();
-
-    await expect(
-      connectors.completeGatewayAdminConnectorOAuthCallback({
-        state: started.state,
-        code: 'authorization-code',
-      }),
-    ).resolves.toEqual({
+    expect(started).toMatchObject({
       provider: 'microsoft365',
-      name: 'Microsoft 365',
-    });
-
-    expect(runtimeSecrets.readStoredRuntimeSecret('MICROSOFT_365_REFRESH_TOKEN')).toBe(
-      'microsoft-refresh-token',
-    );
-    expect(runtimeConfig.tools.httpRequest.authRules).toContainEqual({
-      urlPrefix: 'https://graph.microsoft.com/',
-      header: 'Authorization',
-      prefix: 'Bearer',
-      secret: { source: 'microsoft-oauth' },
+      authorizationUrl: 'https://microsoft.test/authorize',
+      state: '',
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(String(fetchMock.mock.calls[0]?.[1]?.body)).toContain(
-      'code_verifier=',
+    const [url, request] = fetchMock.mock.calls[0] || [];
+    expect(String(url)).toBe(
+      'https://hybridai.one/api/v1/connectors/oauth/authorize/microsoft365',
     );
+    const init = request as RequestInit;
+    expect(new Headers(init.headers).get('Authorization')).toBe(
+      'Bearer hai-test-secret-key',
+    );
+    expect(JSON.parse(String(init.body))).toEqual({
+      return_to: 'http://127.0.0.1:9090/admin/connectors',
+    });
   });
 
   test('starts GitHub OAuth through HybridAI as the API key owner', async () => {
@@ -304,6 +285,41 @@ describe('gateway admin connectors', () => {
     );
   });
 
+  test('tests Microsoft 365 through the HybridAI connector directory', async () => {
+    const { connectors, runtimeSecrets } = await importFreshConnectors();
+    runtimeSecrets.saveNamedRuntimeSecrets({
+      HYBRIDAI_API_KEY: 'hai-test-secret-key',
+    });
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      return new Response(
+        JSON.stringify({
+          connectors: [{ id: 'microsoft365', connected: true }],
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      connectors.testGatewayAdminConnector({ provider: 'microsoft365' }),
+    ).resolves.toEqual({
+      provider: 'microsoft365',
+      name: 'Microsoft 365',
+      ok: true,
+      message: 'Microsoft 365 is connected for this HybridAI account.',
+    });
+    const [url, request] = fetchMock.mock.calls[0] || [];
+    expect(String(url)).toBe(
+      'https://hybridai.one/api/v1/connectors/directory',
+    );
+    expect(new Headers((request as RequestInit).headers).get('Authorization')).toBe(
+      'Bearer hai-test-secret-key',
+    );
+  });
+
   test('marks GitHub connected from the HybridAI connector directory', async () => {
     const { connectors, runtimeSecrets } = await importFreshConnectors();
     runtimeSecrets.saveNamedRuntimeSecrets({
@@ -338,6 +354,49 @@ describe('gateway admin connectors', () => {
         detail: 'Connected through HybridAI.',
       },
     );
+    const [url, request] = fetchMock.mock.calls[0] || [];
+    expect(String(url)).toBe(
+      'https://hybridai.one/api/v1/connectors/directory',
+    );
+    expect(new Headers((request as RequestInit).headers).get('Authorization')).toBe(
+      'Bearer hai-test-secret-key',
+    );
+  });
+
+  test('marks Microsoft 365 connected from the HybridAI connector directory', async () => {
+    const { connectors, runtimeSecrets } = await importFreshConnectors();
+    runtimeSecrets.saveNamedRuntimeSecrets({
+      HYBRIDAI_API_KEY: 'hai-test-secret-key',
+    });
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      return new Response(
+        JSON.stringify({
+          connectors: [
+            {
+              id: 'windows365',
+              connected: true,
+              account: 'user@example.com',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response =
+      await connectors.getGatewayAdminConnectorsWithPlatformState();
+
+    expect(
+      response.connectors.find((entry) => entry.id === 'microsoft365'),
+    ).toMatchObject({
+      state: 'connected',
+      account: 'user@example.com',
+      detail: 'Connected through HybridAI.',
+    });
     const [url, request] = fetchMock.mock.calls[0] || [];
     expect(String(url)).toBe(
       'https://hybridai.one/api/v1/connectors/directory',


### PR DESCRIPTION
## Summary

Enables the Microsoft 365 admin connector card now that the HybridAI connector side is available.

## Changes

- Treat Microsoft 365 as a HybridAI-managed platform connector alongside GitHub.
- Route Microsoft 365 status, OAuth start, and connector testing through the HybridAI connector directory and authorization endpoint.
- Remove the console's Microsoft 365 "coming soon" gating and local Entra setup dialog from the connector card.
- Keep the direct `hybridclaw auth login microsoft365` Microsoft Graph OAuth path untouched.

## Validation

- `npm run format`
- `npm run lint`
- `./node_modules/.bin/vitest run --configLoader runner --project unit tests/gateway-admin-connectors.test.ts`
- `npm --workspace console run test -- connectors.test.tsx`
- `git diff --check`