### PR TITLE
fix: let vision_analyze resolve /api/artifact?path=... URLs

### DIFF
--- a/container/src/tools.ts
+++ b/container/src/tools.ts
@@ -1662,9 +1662,22 @@ function normalizeDelegationTaskList(params: {
   return { tasks };
 }
 
+function extractArtifactUrlLocalPath(rawPath: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawPath, 'http://hybridclaw.invalid');
+  } catch {
+    return null;
+  }
+  if (parsed.pathname !== '/api/artifact') return null;
+  const pathParam = parsed.searchParams.get('path');
+  return pathParam ? pathParam.trim() : null;
+}
+
 function normalizeVisionLocalPath(rawPath: string): string | null {
-  const normalized = String(rawPath || '').trim();
-  if (!normalized) return null;
+  const trimmed = String(rawPath || '').trim();
+  if (!trimmed) return null;
+  const normalized = extractArtifactUrlLocalPath(trimmed) || trimmed;
 
   const workspacePath = resolveWorkspacePath(normalized);
   if (workspacePath) return workspacePath;
@@ -4652,7 +4665,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
         properties: {
           image_url: {
             type: 'string',
-            description: `Local image path (preferred) from ${WORKSPACE_ROOT_DISPLAY}, /discord-media-cache, or /uploaded-media-cache, or a Discord CDN HTTPS URL.`,
+            description: `Local image path (preferred) from ${WORKSPACE_ROOT_DISPLAY}, /discord-media-cache, or /uploaded-media-cache, an \`/api/artifact?path=...\` URL copied from chat history, or a Discord CDN HTTPS URL.`,
           },
           question: {
             type: 'string',

--- a/tests/container.tool-runtime-guards.test.ts
+++ b/tests/container.tool-runtime-guards.test.ts
@@ -146,6 +146,58 @@ describe.sequential('container tool runtime guards', () => {
     expect(result.output).toContain('Detected test image.');
   });
 
+  test('vision_analyze resolves /api/artifact?path=... URLs to their local image path', async () => {
+    tempImagePath = path.join(
+      os.tmpdir(),
+      `hybridclaw-vision-artifact-${Date.now()}.jpg`,
+    );
+    fs.writeFileSync(tempImagePath, Buffer.from([0xff, 0xd8, 0xff, 0xd9]));
+
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  content: 'Detected test image.',
+                },
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { executeToolWithMetadata, setModelContext } = await import(
+      '../container/src/tools.js'
+    );
+    setModelContext(
+      'vllm',
+      undefined,
+      'http://haigpu1:8000/v1',
+      '',
+      'vllm/Qwen/Qwen3.5-27B-FP8',
+      '',
+    );
+
+    const result = await executeToolWithMetadata(
+      'vision_analyze',
+      JSON.stringify({
+        image_url: `/api/artifact?path=${encodeURIComponent(tempImagePath)}`,
+        question: 'What is in this image?',
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.output).toContain('"success": true');
+    expect(result.output).toContain('Detected test image.');
+  });
+
   test('vision_analyze infers vllm provider from prefixed model context', async () => {
     tempImagePath = path.join(
       os.tmpdir(),


### PR DESCRIPTION
## Summary
- The `vision_analyze` tool only accepted raw local paths under `/workspace`, `/discord-media-cache`, `/uploaded-media-cache`, or an `https://` URL.
- Images referenced via the web chat's `/api/artifact?path=...` URL scheme (e.g. copied from earlier chat history, as happens when a user points the model at a screenshot rendered in a previous turn) were rejected outright: "the vision tool only accepts local paths under ... and these came through as artifact URLs instead."
- `normalizeVisionLocalPath` now unwraps `/api/artifact?path=...` URLs to their underlying `path` query param before running the existing workspace/media-cache/scratch-dir validation, so the model can pass these URLs directly.
- Updated the `vision_analyze` tool description to mention artifact URLs are accepted.

## Test plan
- [x] `npx vitest run tests/container.tool-runtime-guards.test.ts` — added a case asserting `vision_analyze` succeeds when given `image_url: /api/artifact?path=<encoded local path>`
- [x] `npx vitest run tests/container.tool-runtime-guards.test.ts tests/container.auxiliary-router.test.ts tests/container.tool-parallelism.test.ts` — 48 tests pass
- [x] `npx biome check container/src/tools.ts tests/container.tool-runtime-guards.test.ts` — clean