### PR TITLE
Update bundled skill secret setup guidance

### DIFF
--- a/docs/content/extensibility/skills.md
+++ b/docs/content/extensibility/skills.md
@@ -201,9 +201,16 @@ signing material belong in `credentials:` with `secret_ref`, not in
 
 Every skill setup section that mentions `hybridclaw env set`, `hybridclaw env
 list`, `hybridclaw secret set`, or `hybridclaw secret list` must also include
-the slash-command equivalent (`/env ...` or `/secret ...`) for operators using
-chat surfaces without CLI access. For user-invocable chat skills, put slash
-commands in frontmatter `how_to_obtain` text and the first setup example; keep
+the browser or slash-command equivalent (`/env ...` or `/secret ...`) for
+operators using chat surfaces without CLI access. When a skill depends on
+credentials, advise operators to set or update runtime secrets in this order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets`.
+2. Browser `/chat` or TUI: run `/secret set NAME value`.
+3. Local console fallback: run `hybridclaw secret set NAME value`.
+
+For user-invocable chat skills, put browser-admin and slash-command guidance in
+frontmatter `how_to_obtain` text and the first setup example; keep
 `hybridclaw ...` commands only in a clearly labeled local-terminal alternative.
 Do not tell chat users to run local CLI diagnostics when a gateway error or
 operator-provided slash-command output already identifies the missing value.

--- a/skills/airtable/SKILL.md
+++ b/skills/airtable/SKILL.md
@@ -13,7 +13,7 @@ credentials:
       source: store
       id: AIRTABLE_PAT
     scope: "api.airtable.com/v0"
-    how_to_obtain: "Create an Airtable Personal Access Token or OAuth bearer token with the needed scopes, then store it with `hybridclaw secret set AIRTABLE_PAT \"<token>\"`."
+    how_to_obtain: "Create an Airtable Personal Access Token or OAuth bearer token with the needed scopes. Set `AIRTABLE_PAT` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set AIRTABLE_PAT \"<token>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set AIRTABLE_PAT \"<token>\"`."
 metadata:
   hybridclaw:
     category: productivity
@@ -73,7 +73,13 @@ field payloads, formula/lookup/rollup reads, and carefully gated deletes.
 Airtable uses Personal Access Tokens or OAuth bearer tokens. Store the token in
 HybridClaw encrypted runtime secrets; never paste it into the prompt.
 
-Recommended setup:
+Recommended setup order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets` and set
+   `AIRTABLE_PAT`.
+2. Browser `/chat` or TUI fallback:
+   `/secret set AIRTABLE_PAT "<pat-or-oauth-access-token>"`.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set AIRTABLE_PAT "<pat-or-oauth-access-token>"
@@ -108,8 +114,10 @@ Required Airtable PAT scopes depend on the task:
 
 - Gateway errors saying `AIRTABLE_PAT` is not set, unavailable, missing, or
   unresolved: the active gateway runtime cannot resolve that stored secret. Ask
-  the operator to set it in the same HybridClaw runtime/session using
-  `/secret set AIRTABLE_PAT <pat>` or
+  the operator to set it in the same HybridClaw runtime/session in this order:
+  browser admin at the active `/admin/secrets` route,
+  `/secret set AIRTABLE_PAT <pat>` in browser `/chat` or TUI, then local
+  console fallback
   `hybridclaw secret set AIRTABLE_PAT <pat>`, then start a fresh agent runtime
   if the gateway was already running.
 - Gateway errors saying `AIRTABLE_PAT` is blocked by secret resolution policy:

--- a/skills/alexa/SKILL.md
+++ b/skills/alexa/SKILL.md
@@ -14,8 +14,12 @@ credentials:
       id: ALEXA_ASK_SKILL_ID
     scope: "Alexa Skills Kit applicationId verification for inbound custom skill requests"
     how_to_obtain: |
-      Create a custom Alexa skill in the Alexa developer console and store the
-      skill id with `hybridclaw secret set ALEXA_ASK_SKILL_ID "amzn1.ask.skill.<uuid>"`.
+      Create a custom Alexa skill in the Alexa developer console. Set the skill
+      id as `ALEXA_ASK_SKILL_ID` through browser admin at
+      `/admin/secrets`; if browser admin is unavailable,
+      use `/secret set ALEXA_ASK_SKILL_ID "amzn1.ask.skill.<uuid>"` in browser
+      `/chat` or TUI; local console fallback:
+      `hybridclaw secret set ALEXA_ASK_SKILL_ID "amzn1.ask.skill.<uuid>"`.
   - id: alexa-lwa-client-id
     kind: oauth
     required: true
@@ -24,8 +28,12 @@ credentials:
       id: ALEXA_LWA_CLIENT_ID
     scope: "Login with Amazon account linking client id"
     how_to_obtain: |
-      Configure Login with Amazon account linking for the Alexa skill and store
-      the OAuth client id with `hybridclaw secret set ALEXA_LWA_CLIENT_ID "amzn1.application-oa2-client.<id>"`.
+      Configure Login with Amazon account linking for the Alexa skill. Set the
+      OAuth client id as `ALEXA_LWA_CLIENT_ID` through browser admin at
+      `/admin/secrets`; if browser admin is unavailable,
+      use `/secret set ALEXA_LWA_CLIENT_ID "amzn1.application-oa2-client.<id>"`
+      in browser `/chat` or TUI; local console fallback:
+      `hybridclaw secret set ALEXA_LWA_CLIENT_ID "amzn1.application-oa2-client.<id>"`.
   - id: alexa-lwa-client-secret
     kind: oauth
     required: true
@@ -34,7 +42,10 @@ credentials:
       id: ALEXA_LWA_CLIENT_SECRET
     scope: "Login with Amazon account linking client secret"
     how_to_obtain: |
-      Store the LWA client secret with
+      Set the LWA client secret as `ALEXA_LWA_CLIENT_SECRET` through browser
+      admin at the active `/admin/secrets` route; if browser admin is
+      unavailable, use `/secret set ALEXA_LWA_CLIENT_SECRET "<client secret>"`
+      in browser `/chat` or TUI; local console fallback:
       `hybridclaw secret set ALEXA_LWA_CLIENT_SECRET "<client secret>"`.
   - id: alexa-smarthome-refresh-token
     kind: oauth
@@ -44,7 +55,11 @@ credentials:
       id: ALEXA_SMARTHOME_REFRESH_TOKEN
     scope: "Alexa Smart Home Skill API token refresh"
     how_to_obtain: |
-      Complete the Smart Home Skill OAuth flow and store the refresh token with
+      Complete the Smart Home Skill OAuth flow. Set the refresh token as
+      `ALEXA_SMARTHOME_REFRESH_TOKEN` through browser admin at
+      `/admin/secrets`; if browser admin is unavailable,
+      use `/secret set ALEXA_SMARTHOME_REFRESH_TOKEN "<refresh token>"` in
+      browser `/chat` or TUI; local console fallback:
       `hybridclaw secret set ALEXA_SMARTHOME_REFRESH_TOKEN "<refresh token>"`.
   - id: alexa-smarthome-access-token
     kind: bearer
@@ -368,7 +383,13 @@ successful verification or a separate read confirms the selected track.
 
 ## Required Setup
 
-Path A custom ASK skill:
+Set or update required secrets in this order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets`.
+2. Browser `/chat` or TUI fallback with `/secret set NAME value`.
+3. Local console fallback with `hybridclaw secret set NAME value`.
+
+Path A custom ASK skill local-console examples:
 
 ```bash
 hybridclaw secret set ALEXA_ASK_SKILL_ID "amzn1.ask.skill.<uuid>"
@@ -376,7 +397,7 @@ hybridclaw secret set ALEXA_LWA_CLIENT_ID "amzn1.application-oa2-client.<id>"
 hybridclaw secret set ALEXA_LWA_CLIENT_SECRET "<lwa client secret>"
 ```
 
-Path B Smart Home Skill API:
+Path B Smart Home Skill API local-console examples:
 
 ```bash
 hybridclaw secret set ALEXA_SMARTHOME_CLIENT_ID "<smart-home oauth client id>"
@@ -384,7 +405,7 @@ hybridclaw secret set ALEXA_SMARTHOME_CLIENT_SECRET "<smart-home oauth client se
 hybridclaw secret set ALEXA_SMARTHOME_REFRESH_TOKEN "<refresh token>"
 ```
 
-Path B community Alexa Remote / `alexapy` surface:
+Path B community Alexa Remote / `alexapy` surface local-console example:
 
 ```bash
 hybridclaw secret set ALEXA_AMAZON_DOMAIN "amazon.de"

--- a/skills/blink/SKILL.md
+++ b/skills/blink/SKILL.md
@@ -13,7 +13,7 @@ credentials:
       source: store
       id: BLINK_EMAIL
     scope: "Blink account email for OAuth v2 login"
-    how_to_obtain: "In the TUI, use `/secret set BLINK_EMAIL \"<account email>\"`. From a shell, use `hybridclaw secret set BLINK_EMAIL \"<account email>\"`."
+    how_to_obtain: "Set `BLINK_EMAIL` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set BLINK_EMAIL \"<account email>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set BLINK_EMAIL \"<account email>\"`."
   - id: blink-password
     kind: api_key
     required: true
@@ -21,7 +21,7 @@ credentials:
       source: store
       id: BLINK_PASSWORD
     scope: "Blink account password for OAuth v2 login"
-    how_to_obtain: "In the TUI, use `/secret set BLINK_PASSWORD \"<account password>\"`. From a shell, use `hybridclaw secret set BLINK_PASSWORD \"<account password>\"`."
+    how_to_obtain: "Set `BLINK_PASSWORD` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set BLINK_PASSWORD \"<account password>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set BLINK_PASSWORD \"<account password>\"`."
   - id: blink-auth-token
     kind: bearer
     required: false
@@ -111,14 +111,18 @@ best-effort and stop on the first authentication or verification failure.
 
 ## Setup
 
-Store the initial secrets in the TUI:
+Set the initial secrets in this order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets` and set
+   `BLINK_EMAIL` and `BLINK_PASSWORD`.
+2. Browser `/chat` or TUI fallback:
 
 ```text
 /secret set BLINK_EMAIL "<account email>"
 /secret set BLINK_PASSWORD "<account password>"
 ```
 
-Equivalent shell commands:
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set BLINK_EMAIL "<account email>"

--- a/skills/byd-battery/SKILL.md
+++ b/skills/byd-battery/SKILL.md
@@ -13,7 +13,7 @@ credentials:
       source: store
       id: BYD_BMU_HOST
     scope: "LAN hostname or IP address of the BYD BMU Modbus endpoint"
-    how_to_obtain: "Find the BMU LAN address from the router, inverter installer page, or Be Connect Plus commissioning notes, then store it with `hybridclaw secret set BYD_BMU_HOST \"192.168.1.50\"`."
+    how_to_obtain: "Find the BMU LAN address from the router, inverter page, or Be Connect Plus notes. Set `BYD_BMU_HOST` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set BYD_BMU_HOST \"192.168.1.50\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set BYD_BMU_HOST \"192.168.1.50\"`."
   - id: byd-bmu-modbus-port
     kind: header
     required: false
@@ -21,7 +21,7 @@ credentials:
       source: store
       id: BYD_BMU_MODBUS_PORT
     scope: "BYD BMU Modbus TCP port, usually 8080 or 502 depending on firmware and wiring"
-    how_to_obtain: "Confirm the port in the installer documentation or LAN scan and store it with `hybridclaw secret set BYD_BMU_MODBUS_PORT \"8080\"`."
+    how_to_obtain: "Confirm the port in the installer documentation or LAN scan. Set `BYD_BMU_MODBUS_PORT` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set BYD_BMU_MODBUS_PORT \"8080\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set BYD_BMU_MODBUS_PORT \"8080\"`."
   - id: byd-bmu-unit-id
     kind: header
     required: false
@@ -29,7 +29,7 @@ credentials:
       source: store
       id: BYD_BMU_UNIT_ID
     scope: "Pinned Modbus unit id for the BMU, usually 1"
-    how_to_obtain: "Confirm the unit id from the installer handoff or Modbus adapter configuration and store it with `hybridclaw secret set BYD_BMU_UNIT_ID \"1\"`."
+    how_to_obtain: "Confirm the unit id from the installer handoff or Modbus adapter configuration. Set `BYD_BMU_UNIT_ID` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set BYD_BMU_UNIT_ID \"1\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set BYD_BMU_UNIT_ID \"1\"`."
   - id: byd-bmu-model
     kind: header
     required: false
@@ -37,7 +37,7 @@ credentials:
       source: store
       id: BYD_BMU_MODEL
     scope: "Operator-declared Battery-Box model family such as Premium HVS, HVM, LVS, LVL, HV, or LV"
-    how_to_obtain: "Read the battery nameplate or installer handoff and store it with `hybridclaw secret set BYD_BMU_MODEL \"Premium HVS\"`."
+    how_to_obtain: "Read the battery nameplate or installer handoff. Set `BYD_BMU_MODEL` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set BYD_BMU_MODEL \"Premium HVS\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set BYD_BMU_MODEL \"Premium HVS\"`."
 metadata:
   hybridclaw:
     category: home-automation
@@ -109,7 +109,14 @@ are well known.
 
 ## Setup
 
-Store local BMU connection values in HybridClaw runtime secrets:
+Set local BMU connection values in this order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets` and set the
+   `BYD_BMU_*` values.
+2. Browser `/chat` or TUI fallback:
+   `/secret set BYD_BMU_HOST "192.168.1.50"` plus the matching port, unit id,
+   and model values.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set BYD_BMU_HOST "192.168.1.50"

--- a/skills/download-platform-invoices/SKILL.md
+++ b/skills/download-platform-invoices/SKILL.md
@@ -82,6 +82,9 @@ The runtime implementation is colocated with this skill:
 - Store secrets in HybridClaw encrypted runtime secrets with provider-specific
   uppercase names such as `STRIPE_INVOICE_API_KEY`,
   `OPENAI_INVOICE_PASSWORD`, or `GITHUB_INVOICE_TOTP_SECRET`.
+- When advising an operator to set or update those secrets, use this order:
+  browser admin at the active `/admin/secrets` route, `/secret set ...` in
+  browser `/chat` or TUI, then `hybridclaw secret set ...` in a local console.
 - Resolve credentials through `resolveInvoiceCredentials`; do not inline or log
   cleartext secrets.
 - Keep provider credential references in invoice harvester config as

--- a/skills/fastbill/SKILL.md
+++ b/skills/fastbill/SKILL.md
@@ -13,7 +13,7 @@ credentials:
       source: store
       id: FASTBILL_BASIC_AUTH
     scope: "https://my.fastbill.com/api/1.0/"
-    how_to_obtain: "Base64-encode the FastBill login email and API key as email:api-key, then store it with `hybridclaw secret set FASTBILL_BASIC_AUTH \"<base64>\"`."
+    how_to_obtain: "Base64-encode the FastBill login email and API key as email:api-key. Set `FASTBILL_BASIC_AUTH` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set FASTBILL_BASIC_AUTH \"<base64>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set FASTBILL_BASIC_AUTH \"<base64>\"`."
 metadata:
   hybridclaw:
     category: accounting

--- a/skills/fastbill/references/operator-setup.md
+++ b/skills/fastbill/references/operator-setup.md
@@ -20,7 +20,12 @@ FastBill classic API authentication uses HTTP Basic auth with the account email
 address as the username and the account API key as the password. API access is
 stateless, so the credentials are submitted for every request.
 
-Store the Basic credential as a HybridClaw runtime secret:
+Set the Basic credential as a HybridClaw runtime secret in this order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets`.
+2. Browser `/chat` or TUI fallback:
+   `/secret set FASTBILL_BASIC_AUTH <base64-output>`.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set FASTBILL_EMAIL you@example.com
@@ -36,7 +41,9 @@ auth requires `base64(email:api-key)` as one header value. Keeping
 credential pair without exposing either value to the model.
 
 Do not paste the API key into the model context. If a user provides it in chat,
-ask them to rotate the key and store the replacement through `/secret set`.
+ask them to rotate the key and store the replacement through browser admin at
+`/admin/secrets`, falling back to `/secret set` in browser
+`/chat` or TUI only if the admin page is unavailable.
 
 ## Gateway Proxy Authentication
 

--- a/skills/fax-send/SKILL.md
+++ b/skills/fax-send/SKILL.md
@@ -13,7 +13,7 @@ credentials:
       source: store
       id: SINCH_FAX_BASIC_AUTH
     scope: "fax.api.sinch.com"
-    how_to_obtain: "Create Sinch Fax API credentials for the target EU project/service, base64-encode username:password, and store the value with `hybridclaw secret set SINCH_FAX_BASIC_AUTH \"<base64>\"`."
+    how_to_obtain: "Create Sinch Fax API credentials for the target EU project/service and base64-encode username:password. Set `SINCH_FAX_BASIC_AUTH` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set SINCH_FAX_BASIC_AUTH \"<base64>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set SINCH_FAX_BASIC_AUTH \"<base64>\"`."
   - id: sinch-fax-oauth-token
     kind: bearer
     required: false
@@ -21,7 +21,7 @@ credentials:
       source: store
       id: SINCH_FAX_OAUTH_TOKEN
     scope: "fax.api.sinch.com"
-    how_to_obtain: "Use only when the operator has an OAuth token minting path for Sinch Fax; store the current bearer token as `SINCH_FAX_OAUTH_TOKEN`."
+    how_to_obtain: "Use only when the operator has an OAuth token minting path for Sinch Fax. Set `SINCH_FAX_OAUTH_TOKEN` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set SINCH_FAX_OAUTH_TOKEN \"<access-token>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set SINCH_FAX_OAUTH_TOKEN \"<access-token>\"`."
 metadata:
   hybridclaw:
     category: communication
@@ -103,14 +103,27 @@ cover-page templating are outside this skill slice.
 Store credentials in HybridClaw encrypted runtime secrets. Never paste them into
 chat or helper arguments.
 
-For Sinch Basic auth, store the base64 value of `username:password`:
+For Sinch Basic auth, set the base64 value of `username:password` in this
+order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets` and set
+   `SINCH_FAX_BASIC_AUTH`.
+2. Browser `/chat` or TUI fallback:
+   `/secret set SINCH_FAX_BASIC_AUTH "<base64-username-password>"`.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set SINCH_FAX_BASIC_AUTH "<base64-username-password>"
 ```
 
-For Sinch OAuth, store a bearer token only if the operator has a token minting
-process:
+For Sinch OAuth, set a bearer token only if the operator has a token minting
+process, using the same setup order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets` and set
+   `SINCH_FAX_OAUTH_TOKEN`.
+2. Browser `/chat` or TUI fallback:
+   `/secret set SINCH_FAX_OAUTH_TOKEN "<access-token>"`.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set SINCH_FAX_OAUTH_TOKEN "<access-token>"
@@ -120,8 +133,14 @@ The helper emits either `secretHeaders: [{ name: "Authorization", secretName:
 "SINCH_FAX_BASIC_AUTH", prefix: "Basic" }]` or `bearerSecretName:
 "SINCH_FAX_OAUTH_TOKEN"` so the gateway injects the secret server-side.
 
-Store the Sinch project default once so normal sends do not need provider
-account arguments:
+Set the Sinch project default once so normal sends do not need provider account
+arguments:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets` and set
+   `SINCH_FAX_PROJECT_ID`.
+2. Browser `/chat` or TUI fallback:
+   `/secret set SINCH_FAX_PROJECT_ID "<sinch-project-id>"`.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set SINCH_FAX_PROJECT_ID "<sinch-project-id>"

--- a/skills/firecrawl/SKILL.md
+++ b/skills/firecrawl/SKILL.md
@@ -13,7 +13,7 @@ credentials:
       source: store
       id: FIRECRAWL_API_KEY
     scope: "api.firecrawl.dev"
-    how_to_obtain: "Create a managed Firecrawl API key in the Firecrawl dashboard."
+    how_to_obtain: "Create a managed Firecrawl API key in the Firecrawl dashboard. Set `FIRECRAWL_API_KEY` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set FIRECRAWL_API_KEY \"<fc-api-key>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set FIRECRAWL_API_KEY \"<fc-api-key>\"`."
   - id: firecrawl-self-host-api-key
     kind: api_key
     required: false
@@ -21,7 +21,7 @@ credentials:
       source: store
       id: FIRECRAWL_SELF_HOST_API_KEY
     scope: "self-hosted Firecrawl"
-    how_to_obtain: "Set this only when your self-hosted Firecrawl instance has API authentication enabled."
+    how_to_obtain: "Set this only when your self-hosted Firecrawl instance has API authentication enabled. Set `FIRECRAWL_SELF_HOST_API_KEY` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set FIRECRAWL_SELF_HOST_API_KEY \"<self-host-api-key>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set FIRECRAWL_SELF_HOST_API_KEY \"<self-host-api-key>\"`."
 metadata:
   hybridclaw:
     category: research
@@ -62,7 +62,13 @@ bypass access controls.
 
 ## Credential Rules
 
-For managed mode, store the Firecrawl API key in HybridClaw encrypted runtime secrets:
+For managed mode, set or update the Firecrawl API key in this order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets` and set
+   `FIRECRAWL_API_KEY`.
+2. Browser `/chat` or TUI fallback:
+   `/secret set FIRECRAWL_API_KEY "<fc-api-key>"`.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set FIRECRAWL_API_KEY "<fc-api-key>"
@@ -77,7 +83,13 @@ export FIRECRAWL_SELF_HOST_BASE_URL="http://firecrawl:3002"
 
 The helper accepts base URLs with or without `/v2` and normalizes them to the
 v2 API path. If your self-hosted Firecrawl deployment enables API
-authentication, store that token separately:
+authentication, set that token separately in the same order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets` and set
+   `FIRECRAWL_SELF_HOST_API_KEY`.
+2. Browser `/chat` or TUI fallback:
+   `/secret set FIRECRAWL_SELF_HOST_API_KEY "<self-host-api-key>"`.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set FIRECRAWL_SELF_HOST_API_KEY "<self-host-api-key>"

--- a/skills/fronius/SKILL.md
+++ b/skills/fronius/SKILL.md
@@ -19,7 +19,7 @@ credentials:
       source: store
       id: FRONIUS_SOLARWEB_ACCESS_KEY_ID
     scope: "Solar.web Query API AccessKeyId header"
-    how_to_obtain: "Apply for Solar.web Query API access in Solar.web, create an API key, and store the key id with `hybridclaw secret set FRONIUS_SOLARWEB_ACCESS_KEY_ID \"<access-key-id>\"`."
+    how_to_obtain: "Apply for Solar.web Query API access in Solar.web and create an API key. Set `FRONIUS_SOLARWEB_ACCESS_KEY_ID` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set FRONIUS_SOLARWEB_ACCESS_KEY_ID \"<access-key-id>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set FRONIUS_SOLARWEB_ACCESS_KEY_ID \"<access-key-id>\"`."
   - id: fronius-solarweb-access-key-value
     kind: api_key
     required: false
@@ -27,7 +27,7 @@ credentials:
       source: store
       id: FRONIUS_SOLARWEB_ACCESS_KEY_VALUE
     scope: "Solar.web Query API AccessKeyValue header"
-    how_to_obtain: "Save the API key value when Solar.web shows it and store it with `hybridclaw secret set FRONIUS_SOLARWEB_ACCESS_KEY_VALUE \"<access-key-value>\"`."
+    how_to_obtain: "Save the API key value when Solar.web shows it. Set `FRONIUS_SOLARWEB_ACCESS_KEY_VALUE` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set FRONIUS_SOLARWEB_ACCESS_KEY_VALUE \"<access-key-value>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set FRONIUS_SOLARWEB_ACCESS_KEY_VALUE \"<access-key-value>\"`."
 metadata:
   hybridclaw:
     category: home-automation
@@ -121,7 +121,15 @@ The inverter LAN URL is configuration, not credential material. It can also be
 passed per request with `--local-host http://<fronius-ip>` or exported as
 `FRONIUS_LOCAL_HOST`.
 
-Solar.web cloud path:
+Solar.web cloud path setup order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets` and set
+   `FRONIUS_SOLARWEB_ACCESS_KEY_ID` and
+   `FRONIUS_SOLARWEB_ACCESS_KEY_VALUE`.
+2. Browser `/chat` or TUI fallback:
+   `/secret set FRONIUS_SOLARWEB_ACCESS_KEY_ID "<access-key-id>"` and
+   `/secret set FRONIUS_SOLARWEB_ACCESS_KEY_VALUE "<access-key-value>"`.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set FRONIUS_SOLARWEB_ACCESS_KEY_ID "<access-key-id>"

--- a/skills/ga4/SKILL.md
+++ b/skills/ga4/SKILL.md
@@ -102,6 +102,14 @@ PEM `private_key` as encrypted runtime secrets. The gateway reads those named
 secrets, signs the JWT assertion server-side, exchanges it for a short-lived
 Google access token, and injects that token into the GA4 request.
 
+Set or update those secrets in this order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets`.
+2. Browser `/chat` or TUI fallback:
+   `/secret set GA4_SERVICE_ACCOUNT_EMAIL "<client-email>"` and
+   `/secret set GA4_SERVICE_ACCOUNT_PRIVATE_KEY "<pem-private-key>"`.
+3. Local console fallback:
+
 ```bash
 hybridclaw secret set GA4_SERVICE_ACCOUNT_EMAIL "<client-email>"
 hybridclaw secret set GA4_SERVICE_ACCOUNT_PRIVATE_KEY '<pem-private-key>'
@@ -111,7 +119,9 @@ Do not paste OAuth access tokens, refresh tokens, service-account private keys,
 or downloaded JSON key files into the prompt. Real credentials stay in the
 HybridClaw secret runtime and are used server-side by the gateway.
 
-Optional stored defaults:
+Optional stored defaults use the same setup order: browser admin at
+`/admin/secrets`, then `/secret set` in browser `/chat` or
+TUI, then local console fallback.
 
 ```bash
 hybridclaw secret set GA4_PROPERTY_ID "<numeric-property-id>"

--- a/skills/gh-issues/SKILL.md
+++ b/skills/gh-issues/SKILL.md
@@ -113,7 +113,10 @@ the `http_request` tool with `bearerSecretName: "GH_TOKEN"`. The gateway resolve
 `GH_TOKEN` from the encrypted secret store; do not ask the shell for `GH_TOKEN`,
 do not echo tokens, and do not use `curl` for authenticated GitHub API calls. If
 neither `gh` auth nor stored secret `GH_TOKEN` works, ask the user to run
-`gh auth login` or store a GitHub token with `/secret set GH_TOKEN <token>`.
+`gh auth login` or store a GitHub token in this order: browser admin at
+`/admin/secrets`, `/secret set GH_TOKEN <token>` in
+browser `/chat` or TUI, then local console fallback
+`hybridclaw secret set GH_TOKEN <token>`.
 
 When not in `--reviews-only`, fetch issues with a current-turn GitHub data call.
 Primary `gh` path:

--- a/skills/google-ads/SKILL.md
+++ b/skills/google-ads/SKILL.md
@@ -112,15 +112,24 @@ hybridclaw auth login google \
   --scopes "https://www.googleapis.com/auth/adwords"
 
 hybridclaw auth status google
-hybridclaw secret set GOOGLEADS_DEVELOPER_TOKEN "<developer-token>"
 ```
+
+Set `GOOGLEADS_DEVELOPER_TOKEN` in this order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets`.
+2. Browser `/chat` or TUI fallback:
+   `/secret set GOOGLEADS_DEVELOPER_TOKEN "<developer-token>"`.
+3. Local console fallback:
+   `hybridclaw secret set GOOGLEADS_DEVELOPER_TOKEN "<developer-token>"`.
 
 Do not ask the user to add `secret route` entries for normal Google Ads skill
 use. The skill should pass `bearerSecretName: "GOOGLE_WORKSPACE_CLI_TOKEN"` and
 `secretHeaders: [{ "name": "developer-token", "secretName":
 "GOOGLEADS_DEVELOPER_TOKEN", "prefix": "" }]` in each `http_request` call.
 
-Optional stored defaults:
+Optional stored defaults use the same setup order: browser admin at
+`/admin/secrets`, then `/secret set` in browser `/chat` or
+TUI, then local console fallback.
 
 ```bash
 hybridclaw secret set GOOGLEADS_CUSTOMER_ID "<customer-id-without-hyphens>"

--- a/skills/google-ads/references/setup-and-operations.md
+++ b/skills/google-ads/references/setup-and-operations.md
@@ -4,7 +4,12 @@
 
 Google Ads API calls require a Google Ads developer token in addition to OAuth.
 Create or reuse a Google Ads manager account, open API Center, request a
-developer token, and store it in HybridClaw:
+developer token, and set it in HybridClaw in this order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets`.
+2. Browser `/chat` or TUI fallback:
+   `/secret set GOOGLEADS_DEVELOPER_TOKEN "<developer-token>"`.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set GOOGLEADS_DEVELOPER_TOKEN "<developer-token>"
@@ -45,7 +50,11 @@ python3 skills/google-ads/scripts/google_ads.py gaql 1234567890 \
   "SELECT campaign.id, campaign.name FROM campaign LIMIT 20"
 ```
 
-Store defaults when useful:
+Store defaults when useful in the same setup order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets`.
+2. Browser `/chat` or TUI fallback with `/secret set GOOGLEADS_* ...`.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set GOOGLEADS_CUSTOMER_ID "1234567890"

--- a/skills/hermes3000-writing/SKILL.md
+++ b/skills/hermes3000-writing/SKILL.md
@@ -12,7 +12,7 @@ credentials:
       source: store
       id: HERMES3000_JWT
     scope: "hermes3000.ai"
-    how_to_obtain: "Store HERMES3000_EMAIL and HERMES3000_PASSWORD in HybridClaw runtime secrets, then run the bundled auth.login helper so the gateway captures the login JWT into HERMES3000_JWT without exposing it to the agent."
+    how_to_obtain: "Set `HERMES3000_EMAIL` and `HERMES3000_PASSWORD` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set HERMES3000_EMAIL ...` and `/secret set HERMES3000_PASSWORD ...` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set ...`. Then run the bundled auth.login helper so the gateway captures the login JWT into `HERMES3000_JWT` without exposing it to the agent."
 metadata:
   hybridclaw:
     category: productivity
@@ -60,14 +60,18 @@ secrets with chat/TUI secret commands; do not ask them to run `node`, `curl`, or
 or password; it resolves `HERMES3000_EMAIL` and `HERMES3000_PASSWORD` from the
 gateway secret store.
 
-Ask the user to set the login inputs once from chat or TUI:
+Ask the user to set the login inputs once through browser admin first:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets` and set
+   `HERMES3000_EMAIL` and `HERMES3000_PASSWORD`.
+2. Browser `/chat` or TUI fallback:
 
 ```text
 /secret set HERMES3000_EMAIL you@example.com
 /secret set HERMES3000_PASSWORD <password>
 ```
 
-For local operator setup only, the shell-side equivalent is:
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set HERMES3000_EMAIL you@example.com

--- a/skills/hermes3000-writing/references/api-workflow.md
+++ b/skills/hermes3000-writing/references/api-workflow.md
@@ -44,8 +44,10 @@ Subsequent helper requests use `bearerSecretName: "HERMES3000_JWT"`.
 
 Do not ask chat/TUI users to run this command. If `HERMES3000_JWT` is missing or
 blocked, the agent should run `auth.login`; the user should only be asked to set
-`HERMES3000_EMAIL` and `HERMES3000_PASSWORD` with `/secret set ...` if those
-stored login inputs are missing. The helper does not prompt for credentials.
+`HERMES3000_EMAIL` and `HERMES3000_PASSWORD` if those stored login inputs are
+missing. Prefer browser admin at the active `/admin/secrets` route; fall
+back to `/secret set ...` in browser `/chat` or TUI only if the admin page is
+unavailable. The helper does not prompt for credentials.
 
 Do not use `curl` with a raw Hermes3000 `Authorization` header. If a runtime
 does not allow direct helper execution but does expose the built-in

--- a/skills/hetzner-cloud/SKILL.md
+++ b/skills/hetzner-cloud/SKILL.md
@@ -13,7 +13,7 @@ credentials:
       source: store
       id: HETZNER_API_TOKEN
     scope: "api.hetzner.cloud/v1"
-    how_to_obtain: "Create a Hetzner Console API token for the target project with read-only scope for inventory work or read-write scope only when provisioning, snapshotting, restoring, or deleting resources."
+    how_to_obtain: "Create a Hetzner Console API token for the target project with read-only scope for inventory work or read-write scope only when provisioning, snapshotting, restoring, or deleting resources. Set `HETZNER_API_TOKEN` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set HETZNER_API_TOKEN \"<hetzner-console-api-token>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set HETZNER_API_TOKEN \"<hetzner-console-api-token>\"`."
 metadata:
   hybridclaw:
     category: infrastructure

--- a/skills/hetzner-cloud/references/operator-setup.md
+++ b/skills/hetzner-cloud/references/operator-setup.md
@@ -11,7 +11,12 @@ volume, and image reads. Use read-write scope only for a bounded mutation
 window when the operator has approved provisioning, snapshot, restore, network,
 volume, or delete actions.
 
-Store the token in the encrypted runtime secret store:
+Set the token in the encrypted runtime secret store in this order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets`.
+2. Browser `/chat` or TUI fallback:
+   `/secret set HETZNER_API_TOKEN "<hetzner-console-api-token>"`.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set HETZNER_API_TOKEN "<hetzner-console-api-token>"

--- a/skills/hetzner-dns/SKILL.md
+++ b/skills/hetzner-dns/SKILL.md
@@ -13,7 +13,7 @@ credentials:
       source: store
       id: HETZNER_DNS_API_TOKEN
     scope: "dns.hetzner.com/api/v1"
-    how_to_obtain: "Create a DNS API access token in the Hetzner DNS Console and store it as HETZNER_DNS_API_TOKEN. The helper injects it into the Auth-API-Token header server-side."
+    how_to_obtain: "Create a DNS API access token in the Hetzner DNS Console. Set `HETZNER_DNS_API_TOKEN` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set HETZNER_DNS_API_TOKEN \"<hetzner-dns-api-token>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set HETZNER_DNS_API_TOKEN \"<hetzner-dns-api-token>\"`. The helper injects it into the Auth-API-Token header server-side."
 metadata:
   hybridclaw:
     category: infrastructure

--- a/skills/hetzner-dns/references/operator-setup.md
+++ b/skills/hetzner-dns/references/operator-setup.md
@@ -6,7 +6,12 @@ Hetzner DNS uses the DNS Console and DNS API, not the Hetzner Cloud bearer-token
 API. Create a DNS API token in the Hetzner DNS Console for the account that owns
 the target zones.
 
-Store the token in the encrypted runtime secret store:
+Set the token in the encrypted runtime secret store in this order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets`.
+2. Browser `/chat` or TUI fallback:
+   `/secret set HETZNER_DNS_API_TOKEN "<hetzner-dns-api-token>"`.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set HETZNER_DNS_API_TOKEN "<hetzner-dns-api-token>"

--- a/skills/hetzner-storage-box/SKILL.md
+++ b/skills/hetzner-storage-box/SKILL.md
@@ -13,7 +13,7 @@ credentials:
       source: store
       id: HETZNER_API_TOKEN
     scope: "api.hetzner.com/v1/storage_boxes"
-    how_to_obtain: "Create a Hetzner Console API token for the project containing the Storage Box. Use read-only scope for inventory and read-write scope only for approved Storage Box management changes."
+    how_to_obtain: "Create a Hetzner Console API token for the project containing the Storage Box. Use read-only scope for inventory and read-write scope only for approved Storage Box management changes. Set `HETZNER_API_TOKEN` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set HETZNER_API_TOKEN \"<hetzner-console-api-token>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set HETZNER_API_TOKEN \"<hetzner-console-api-token>\"`."
   - id: hetzner-storage-box-basic-auth
     kind: header
     required: false
@@ -21,7 +21,7 @@ credentials:
       source: store
       id: HETZNER_STORAGE_BOX_BASIC_AUTH
     scope: "*.your-storagebox.de WebDAV Authorization header"
-    how_to_obtain: "Base64-encode '<storage-box-username>:<password>' and store only that encoded value. The helper injects it as 'Authorization: Basic <secret>' for WebDAV file operations."
+    how_to_obtain: "Base64-encode '<storage-box-username>:<password>' and store only that encoded value. Set `HETZNER_STORAGE_BOX_BASIC_AUTH` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set HETZNER_STORAGE_BOX_BASIC_AUTH \"<base64-username-password>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set HETZNER_STORAGE_BOX_BASIC_AUTH \"<base64-username-password>\"`. The helper injects it as 'Authorization: Basic <secret>' for WebDAV file operations."
 metadata:
   hybridclaw:
     category: infrastructure
@@ -90,7 +90,12 @@ plus WebDAV file reads and guarded uploads/archives.
 
 ## Secret Setup
 
-API management calls use `HETZNER_API_TOKEN`:
+API management calls use `HETZNER_API_TOKEN`. Set or update it in this order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets`.
+2. Browser `/chat` or TUI fallback:
+   `/secret set HETZNER_API_TOKEN "<hetzner-console-api-token>"`.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set HETZNER_API_TOKEN "<hetzner-console-api-token>"
@@ -101,7 +106,12 @@ management APIs. DNS uses its own `HETZNER_DNS_API_TOKEN` because Hetzner DNS is
 served by a separate DNS API and `Auth-API-Token` header.
 
 WebDAV file operations use a Basic-auth secret containing only the base64
-encoded `username:password` payload:
+encoded `username:password` payload. Set it in the same order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets`.
+2. Browser `/chat` or TUI fallback:
+   `/secret set HETZNER_STORAGE_BOX_BASIC_AUTH "<base64-username-password>"`.
+3. Local console fallback:
 
 ```bash
 printf '%s' 'u00000:storage-box-password' | base64

--- a/skills/hetzner-storage-box/references/operator-setup.md
+++ b/skills/hetzner-storage-box/references/operator-setup.md
@@ -6,7 +6,12 @@ Create a Hetzner Console API token in the project containing the Storage Box.
 Use read-only scope for inventory. Use read-write scope only for approved
 management changes such as snapshots, settings, creation, and deletion.
 
-Store it in the encrypted runtime secret store:
+Set it in the encrypted runtime secret store in this order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets`.
+2. Browser `/chat` or TUI fallback:
+   `/secret set HETZNER_API_TOKEN "<hetzner-console-api-token>"`.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set HETZNER_API_TOKEN "<hetzner-console-api-token>"
@@ -18,7 +23,12 @@ For file operations, create a Storage Box subaccount with the narrowest path and
 permission set that fits the task. Prefer read-only subaccounts for inspection
 and dedicated write subaccounts for archive uploads.
 
-Store only the base64 payload for Basic auth:
+Set only the base64 payload for Basic auth in the same order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets`.
+2. Browser `/chat` or TUI fallback:
+   `/secret set HETZNER_STORAGE_BOX_BASIC_AUTH "<base64-username-password>"`.
+3. Local console fallback:
 
 ```bash
 printf '%s' 'u00000:storage-box-password' | base64

--- a/skills/heygen/SKILL.md
+++ b/skills/heygen/SKILL.md
@@ -13,7 +13,7 @@ credentials:
       source: store
       id: HEYGEN_API_KEY
     scope: HeyGen Direct API video generation and translation.
-    how_to_obtain: Create or regenerate the API token from HeyGen account settings, then store it with `hybridclaw secret set HEYGEN_API_KEY "<api-key>"`.
+    how_to_obtain: "Create or regenerate the API token from HeyGen account settings. Set `HEYGEN_API_KEY` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set HEYGEN_API_KEY \"<api-key>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set HEYGEN_API_KEY \"<api-key>\"`."
 metadata:
   hybridclaw:
     category: marketing
@@ -75,7 +75,12 @@ and distribution to external channels are outside this adapter slice.
 HeyGen Direct API uses an API key sent as `X-API-KEY`. Store it in HybridClaw
 encrypted runtime secrets; never paste it into the prompt.
 
-Recommended setup:
+Recommended setup order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets` and set
+   `HEYGEN_API_KEY`.
+2. Browser `/chat` or TUI fallback: `/secret set HEYGEN_API_KEY "<api-key>"`.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set HEYGEN_API_KEY "<api-key>"

--- a/skills/homematic/SKILL.md
+++ b/skills/homematic/SKILL.md
@@ -16,7 +16,11 @@ credentials:
     how_to_obtain: |
       Enable HCU developer mode, generate an activation key, use
       `node skills/homematic/homematic.cjs http-request auth-token` and
-      `confirm-token`, then store the confirmed Connect API auth token with
+      `confirm-token`, then set the confirmed Connect API auth token as
+      `HOMEMATIC_HCU_AUTH_TOKEN` through browser admin at
+      `/admin/secrets`; if browser admin is unavailable,
+      use `/secret set HOMEMATIC_HCU_AUTH_TOKEN "<token>"` in browser `/chat`
+      or TUI; local console fallback:
       `hybridclaw secret set HOMEMATIC_HCU_AUTH_TOKEN "<token>"`.
   - id: homematic-hcu-activation-key
     kind: header
@@ -26,8 +30,12 @@ credentials:
       id: HOMEMATIC_HCU_ACTIVATION_KEY
     scope: "One-time HCU Connect API token enrollment"
     how_to_obtain: |
-      Generate an activation key from HCUweb developer mode and store it only
-      long enough to enroll the Connect API client:
+      Generate an activation key from HCUweb developer mode and set it only
+      long enough to enroll the Connect API client as
+      `HOMEMATIC_HCU_ACTIVATION_KEY` through browser admin at
+      `/admin/secrets`; if browser admin is unavailable,
+      use `/secret set HOMEMATIC_HCU_ACTIVATION_KEY "<activation-key>"` in
+      browser `/chat` or TUI; local console fallback:
       `hybridclaw secret set HOMEMATIC_HCU_ACTIVATION_KEY "<activation-key>"`.
 metadata:
   hybridclaw:

--- a/skills/hubspot/SKILL.md
+++ b/skills/hubspot/SKILL.md
@@ -13,7 +13,7 @@ credentials:
       source: store
       id: HUBSPOT_ACCESS_TOKEN
     scope: "api.hubapi.com and api.hubspot.com"
-    how_to_obtain: "Create a HubSpot Service Key from Development > Keys > Service keys, copy the key, and store it as HUBSPOT_ACCESS_TOKEN. Service keys are the recommended single-account system-to-system credential for HubSpot REST APIs. Legacy private app access tokens and OAuth access tokens are also accepted bearer credentials; HubSpot personal access keys and developer keys are not valid CRM REST bearer tokens."
+    how_to_obtain: "Create a HubSpot Service Key from Development > Keys > Service keys and copy the key. Set `HUBSPOT_ACCESS_TOKEN` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set HUBSPOT_ACCESS_TOKEN <token>` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set HUBSPOT_ACCESS_TOKEN <token>`. Service keys are the recommended single-account system-to-system credential for HubSpot REST APIs. Legacy private app access tokens and OAuth access tokens are also accepted bearer credentials; HubSpot personal access keys and developer keys are not valid CRM REST bearer tokens."
 metadata:
   hybridclaw:
     category: business
@@ -86,7 +86,13 @@ valid CRM REST bearer tokens for these calls.
 HubSpot Service Key docs:
 <https://developers.hubspot.com/docs/apps/developer-platform/build-apps/authentication/account-service-keys>.
 
-Recommended setup:
+Recommended setup order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets` and set
+   `HUBSPOT_ACCESS_TOKEN`.
+2. Browser `/chat` or TUI fallback:
+   `/secret set HUBSPOT_ACCESS_TOKEN <token>`.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set HUBSPOT_ACCESS_TOKEN

--- a/skills/hue/SKILL.md
+++ b/skills/hue/SKILL.md
@@ -19,7 +19,7 @@ credentials:
       source: store
       id: HUE_APPLICATION_KEY
     scope: "Philips Hue CLIP v2 hue-application-key header"
-    how_to_obtain: "Press the bridge link button, build the link request with `node skills/hue/hue.cjs --format json bridge link --app-name hybridclaw --instance-name lab`, send its `httpRequest` through the gateway, then store the returned Hue credential secret in chat with `/secret set HUE_APPLICATION_KEY \"<application-key>\"`."
+    how_to_obtain: "Press the bridge link button, build the link request with `node skills/hue/hue.cjs --format json bridge link --app-name hybridclaw --instance-name lab`, and send its `httpRequest` through the gateway. Set the returned `HUE_APPLICATION_KEY` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set HUE_APPLICATION_KEY \"<application-key>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set HUE_APPLICATION_KEY \"<application-key>\"`."
   - id: hue-remote-refresh-token
     kind: bearer
     required: false
@@ -27,7 +27,7 @@ credentials:
       source: store
       id: HUE_REMOTE_REFRESH_TOKEN
     scope: "Hue Remote API OAuth token used for off-LAN API calls"
-    how_to_obtain: "Create a Hue developer app, complete the Hue Remote API OAuth flow, and store the refresh/access token in chat with `/secret set HUE_REMOTE_REFRESH_TOKEN \"<token>\"`."
+    how_to_obtain: "Create a Hue developer app and complete the Hue Remote API OAuth flow. Set `HUE_REMOTE_REFRESH_TOKEN` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set HUE_REMOTE_REFRESH_TOKEN \"<token>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set HUE_REMOTE_REFRESH_TOKEN \"<token>\"`."
   - id: hue-remote-access-token
     kind: bearer
     required: false
@@ -284,7 +284,11 @@ Managed LAN HTTP access covers local RFC1918 bridge reads according to the
 workspace policy setting. The helper does not create or modify that setting.
 
 For the Hue Remote API, create a developer app, complete the OAuth flow, then
-store the resulting values:
+set the resulting values in this order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets` and set the
+   `HUE_REMOTE_*` secrets.
+2. Browser `/chat` or TUI fallback:
 
 ```text
 /secret set HUE_REMOTE_CLIENT_ID "<oauth-client-id>"
@@ -294,7 +298,7 @@ node skills/hue/hue.cjs --format json remote oauth-token
 /secret set HUE_REMOTE_BRIDGE_ID "<bridge-id>"
 ```
 
-Or from a local terminal:
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set HUE_REMOTE_CLIENT_ID "<oauth-client-id>"

--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -16,8 +16,12 @@ credentials:
     how_to_obtain: |
       In Langfuse, open Project Settings → API Keys and create a key pair
       (public key `pk-lf-...` and secret key `sk-lf-...`). Locally base64-encode
-      `public-key:secret-key` and store only that encoded credential in chat with
-      `/secret set LANGFUSE_BASIC_AUTH "<base64-public-colon-secret>"`.
+      `public-key:secret-key`. Set only that encoded credential as
+      `LANGFUSE_BASIC_AUTH` through browser admin at
+      `/admin/secrets`; if browser admin is unavailable,
+      use `/secret set LANGFUSE_BASIC_AUTH "<base64-public-colon-secret>"` in
+      browser `/chat` or TUI; local console fallback:
+      `hybridclaw secret set LANGFUSE_BASIC_AUTH "<base64-public-colon-secret>"`.
       The same key reads observability data and writes scores, comments,
       datasets, and prompt versions.
 config_variables:
@@ -105,7 +109,12 @@ and evaluating outputs.
 
 ## HybridClaw setup
 
-The helper never sees credentials. Store two values once:
+The helper never sees credentials. Store two values once. For secrets, use this
+order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets`.
+2. Browser `/chat` or TUI fallback.
+3. Local console fallback.
 
 1. `LANGFUSE_BASIC_AUTH` — base64 of `public-key:secret-key`:
    `/secret set LANGFUSE_BASIC_AUTH "<base64-public-colon-secret>"`
@@ -114,7 +123,7 @@ The helper never sees credentials. Store two values once:
    `https://us.cloud.langfuse.com` for US, `https://jp.cloud.langfuse.com` for
    JP, or your self-hosted origin).
 
-Local-terminal alternative: `hybridclaw secret set LANGFUSE_BASIC_AUTH "<...>"`
+Local console fallback: `hybridclaw secret set LANGFUSE_BASIC_AUTH "<...>"`
 and `hybridclaw env set LANGFUSE_HOST https://cloud.langfuse.com`.
 
 See [references/operator-setup.md](references/operator-setup.md) for key scope,

--- a/skills/langfuse/references/operator-setup.md
+++ b/skills/langfuse/references/operator-setup.md
@@ -16,14 +16,18 @@ amber/grant gating for changes.
 ## Store the Credential and Host
 
 The Langfuse public API uses HTTP Basic auth. Base64-encode `public:secret`
-locally and store only the encoded value, plus your deployment base URL:
+locally and store only the encoded value, plus your deployment base URL. For
+the secret value, use this order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets`.
+2. Browser `/chat` or TUI fallback:
 
 ```text
 /secret set LANGFUSE_BASIC_AUTH "<base64-of-public-key:secret-key>"
 /env set LANGFUSE_HOST https://cloud.langfuse.com
 ```
 
-Local-terminal alternative:
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set LANGFUSE_BASIC_AUTH "<base64-of-public-key:secret-key>"

--- a/skills/lexware-office/SKILL.md
+++ b/skills/lexware-office/SKILL.md
@@ -13,7 +13,7 @@ credentials:
       source: store
       id: LEXWARE_OFFICE_API_KEY
     scope: "https://api.lexware.io/"
-    how_to_obtain: "Create a Lexware Office Public API key at https://app.lexware.de/addons/public-api, then store it with `hybridclaw secret set LEXWARE_OFFICE_API_KEY \"<api-key>\"`."
+    how_to_obtain: "Create a Lexware Office Public API key at https://app.lexware.de/addons/public-api. Set `LEXWARE_OFFICE_API_KEY` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set LEXWARE_OFFICE_API_KEY \"<api-key>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set LEXWARE_OFFICE_API_KEY \"<api-key>\"`."
 metadata:
   hybridclaw:
     category: accounting
@@ -93,7 +93,13 @@ Public API gateway at `https://api.lexware.io`.
 Lexware Office authenticates with a bearer API key. Store the API key in
 HybridClaw encrypted runtime secrets; never paste it into the prompt.
 
-Recommended setup:
+Recommended setup order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets` and set
+   `LEXWARE_OFFICE_API_KEY`.
+2. Browser `/chat` or TUI fallback:
+   `/secret set LEXWARE_OFFICE_API_KEY "<api-key>"`.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set LEXWARE_OFFICE_API_KEY "<api-key>"

--- a/skills/lexware-office/references/operator-setup.md
+++ b/skills/lexware-office/references/operator-setup.md
@@ -9,7 +9,12 @@ Lexware Office account under the Public API add-on page:
 https://app.lexware.de/addons/public-api
 ```
 
-Store the value in the encrypted HybridClaw runtime secret store:
+Set the value in the encrypted HybridClaw runtime secret store in this order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets`.
+2. Browser `/chat` or TUI fallback:
+   `/secret set LEXWARE_OFFICE_API_KEY "<api-key>"`.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set LEXWARE_OFFICE_API_KEY "<api-key>"

--- a/skills/mailchimp/SKILL.md
+++ b/skills/mailchimp/SKILL.md
@@ -15,10 +15,12 @@ credentials:
     scope: "Mailchimp Marketing API Authorization Basic header secret for https://<dc>.api.mailchimp.com/3.0"
     how_to_obtain: |
       Create a Mailchimp Marketing API key with the narrowest useful role for
-      the account. Locally base64-encode `anystring:<api-key>` and store only
-      that encoded credential in chat with
-      `/secret set MAILCHIMP_MARKETING_BASIC_AUTH "<base64-user-colon-api-key>"`.
-      From a local terminal, use
+      the account. Locally base64-encode `anystring:<api-key>`. Set only that
+      encoded credential as `MAILCHIMP_MARKETING_BASIC_AUTH` through browser
+      admin at the active `/admin/secrets` route; if browser admin is
+      unavailable, use
+      `/secret set MAILCHIMP_MARKETING_BASIC_AUTH "<base64-user-colon-api-key>"`
+      in browser `/chat` or TUI; local console fallback:
       `hybridclaw secret set MAILCHIMP_MARKETING_BASIC_AUTH "<base64-user-colon-api-key>"`.
       Set `MAILCHIMP_SERVER_PREFIX` to the data-center suffix after the last
       hyphen, for example `us21` from a key ending in `-us21`.
@@ -30,10 +32,12 @@ credentials:
       id: MAILCHIMP_MARKETING_OAUTH_TOKEN
     scope: "Mailchimp Marketing OAuth bearer token for https://login.mailchimp.com/oauth2/metadata and https://<dc>.api.mailchimp.com/3.0"
     how_to_obtain: |
-      Complete Mailchimp's OAuth authorization flow outside this helper and
-      store the resulting access token in chat with
-      `/secret set MAILCHIMP_MARKETING_OAUTH_TOKEN "<oauth-token>"`.
-      From a local terminal, use
+      Complete Mailchimp's OAuth authorization flow outside this helper. Set
+      the resulting access token as `MAILCHIMP_MARKETING_OAUTH_TOKEN` through
+      browser admin at the active `/admin/secrets` route; if browser admin
+      is unavailable, use
+      `/secret set MAILCHIMP_MARKETING_OAUTH_TOKEN "<oauth-token>"` in browser
+      `/chat` or TUI; local console fallback:
       `hybridclaw secret set MAILCHIMP_MARKETING_OAUTH_TOKEN "<oauth-token>"`.
       Use helper commands with `--auth oauth`.
   - id: mandrill-api-key
@@ -45,9 +49,10 @@ credentials:
     scope: "Mailchimp Transactional / Mandrill API key for https://mandrillapp.com/api/1.0"
     how_to_obtain: |
       In a Mailchimp account with Transactional Email provisioned, create a
-      Transactional API key and store it in chat with
-      `/secret set MANDRILL_API_KEY "<mandrill-key>"`.
-      From a local terminal, use
+      Transactional API key. Set `MANDRILL_API_KEY` through browser admin at
+      `/admin/secrets`; if browser admin is unavailable,
+      use `/secret set MANDRILL_API_KEY "<mandrill-key>"` in browser `/chat` or
+      TUI; local console fallback:
       `hybridclaw secret set MANDRILL_API_KEY "<mandrill-key>"`.
 config_variables:
   - id: mailchimp-server-prefix

--- a/skills/microsoft-365/SKILL.md
+++ b/skills/microsoft-365/SKILL.md
@@ -75,6 +75,11 @@ hybridclaw auth login microsoft365 \
 hybridclaw auth status microsoft365
 ```
 
+Use OAuth login for normal setup. If an operator must manually replace stored
+Microsoft credential material, advise this order: browser admin at
+`/admin/secrets`, `/secret set ...` in browser `/chat` or
+TUI, then `hybridclaw secret set ...` in a local console.
+
 Use a Microsoft Entra app registration with a localhost/mobile-desktop redirect
 URI matching the callback URL printed by the login command. The default scope
 set is read-only: `User.Read`, `Mail.Read`, `Calendars.Read`,

--- a/skills/miro/SKILL.md
+++ b/skills/miro/SKILL.md
@@ -13,7 +13,7 @@ credentials:
       source: store
       id: MIRO_ACCESS_TOKEN
     scope: "api.miro.com/v2 boards:read boards:write"
-    how_to_obtain: "Create a Miro OAuth app or access token with the narrowest needed board scopes, then store it with `hybridclaw secret set MIRO_ACCESS_TOKEN \"<token>\"`."
+    how_to_obtain: "Create a Miro OAuth app or access token with the narrowest needed board scopes. Set `MIRO_ACCESS_TOKEN` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set MIRO_ACCESS_TOKEN \"<token>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set MIRO_ACCESS_TOKEN \"<token>\"`."
   - id: miro-discovery-access-token
     kind: bearer
     required: false
@@ -21,7 +21,7 @@ credentials:
       source: store
       id: MIRO_DISCOVERY_ACCESS_TOKEN
     scope: "api.miro.com/v2 boards:export"
-    how_to_obtain: "Enterprise admins can enable eDiscovery in Miro Enterprise Integrations and store the Discovery token with `hybridclaw secret set MIRO_DISCOVERY_ACCESS_TOKEN \"<token>\"`."
+    how_to_obtain: "Enterprise admins can enable eDiscovery in Miro Enterprise Integrations. Set `MIRO_DISCOVERY_ACCESS_TOKEN` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set MIRO_DISCOVERY_ACCESS_TOKEN \"<token>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set MIRO_DISCOVERY_ACCESS_TOKEN \"<token>\"`."
   - id: miro-oauth-client-id
     kind: oauth
     required: false
@@ -29,7 +29,7 @@ credentials:
       source: store
       id: MIRO_CLIENT_ID
     scope: "https://miro.com/oauth/authorize"
-    how_to_obtain: "Create a Miro app and store its client id with `hybridclaw secret set MIRO_CLIENT_ID \"<client-id>\"` before token exchange."
+    how_to_obtain: "Create a Miro app. Set `MIRO_CLIENT_ID` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set MIRO_CLIENT_ID \"<client-id>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set MIRO_CLIENT_ID \"<client-id>\"`. Do this before token exchange."
   - id: miro-oauth-client-secret
     kind: oauth
     required: false
@@ -37,7 +37,7 @@ credentials:
       source: store
       id: MIRO_CLIENT_SECRET
     scope: "https://api.miro.com/v1/oauth/token"
-    how_to_obtain: "Store the Miro app client secret with `hybridclaw secret set MIRO_CLIENT_SECRET \"<client-secret>\"`; never paste it into prompts or helper arguments."
+    how_to_obtain: "Set the Miro app client secret as `MIRO_CLIENT_SECRET` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set MIRO_CLIENT_SECRET \"<client-secret>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set MIRO_CLIENT_SECRET \"<client-secret>\"`. Never paste it into prompts or helper arguments."
   - id: miro-oauth-code
     kind: oauth
     required: false
@@ -45,7 +45,7 @@ credentials:
       source: store
       id: MIRO_OAUTH_CODE
     scope: "one-time OAuth authorization code"
-    how_to_obtain: "After approving the Miro authorize URL, store the one-time code with `hybridclaw secret set MIRO_OAUTH_CODE \"<code>\"`, then exchange it immediately."
+    how_to_obtain: "After approving the Miro authorize URL, set the one-time code as `MIRO_OAUTH_CODE` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set MIRO_OAUTH_CODE \"<code>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set MIRO_OAUTH_CODE \"<code>\"`. Exchange it immediately."
   - id: miro-refresh-token
     kind: oauth
     required: false
@@ -119,7 +119,14 @@ operator has Discovery access.
 Store Miro tokens in HybridClaw runtime secrets. Never paste a raw Miro token
 into the prompt, a helper argument, a shell environment dump, or a log.
 
-Recommended setup:
+Recommended setup order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets` and set the
+   needed `MIRO_*` secrets.
+2. Browser `/chat` or TUI fallback:
+   `/secret set MIRO_ACCESS_TOKEN "<oauth-or-access-token>"` plus any needed
+   Discovery or OAuth client secrets.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set MIRO_ACCESS_TOKEN "<oauth-or-access-token>"

--- a/skills/mittwald/SKILL.md
+++ b/skills/mittwald/SKILL.md
@@ -15,7 +15,10 @@ credentials:
     scope: "https://api.mittwald.de Authorization bearer"
     how_to_obtain: |
       Create an API token in mittwald mStudio under the user profile API token
-      settings, then store it with
+      settings. Set `MITTWALD_API_TOKEN` through browser admin at
+      `/admin/secrets`; if browser admin is unavailable,
+      use `/secret set MITTWALD_API_TOKEN "<token>"` in browser `/chat` or TUI;
+      local console fallback:
       `hybridclaw secret set MITTWALD_API_TOKEN "<token>"`.
 metadata:
   hybridclaw:
@@ -113,7 +116,10 @@ users, and marketplace/license readouts.
    generation. Do not call `http_request` unless live mittwald data is needed
    for the user's request.
 4. For live calls, stop after the first 401 or 403. Report a credential or API
-   role setup problem and ask the operator to verify:
+   role setup problem and ask the operator to verify `MITTWALD_API_TOKEN` in
+   this order: browser admin at the active `/admin/secrets` route,
+   `/secret set MITTWALD_API_TOKEN "<mittwald-api-token>"` in browser `/chat`
+   or TUI, then local console fallback
    `hybridclaw secret set MITTWALD_API_TOKEN "<mittwald-api-token>"`.
 5. For 429 responses, report rate-limit guidance from `Retry-After`,
    `X-RateLimit-Reset`, `X-RateLimit-Remaining`, and `X-RateLimit-Limit` when

--- a/skills/posthog/SKILL.md
+++ b/skills/posthog/SKILL.md
@@ -13,7 +13,7 @@ credentials:
       source: store
       id: POSTHOG_PROJECT_TOKEN
     scope: "PostHog public capture and flags endpoints on the configured ingestion host"
-    how_to_obtain: "Open PostHog project settings, copy the project token, and store it with `/secret set POSTHOG_PROJECT_TOKEN <token>` or `hybridclaw secret set POSTHOG_PROJECT_TOKEN <token>`."
+    how_to_obtain: "Open PostHog project settings and copy the project token. Set `POSTHOG_PROJECT_TOKEN` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set POSTHOG_PROJECT_TOKEN <token>` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set POSTHOG_PROJECT_TOKEN <token>`."
   - id: posthog-personal-api-key
     kind: bearer
     required: true
@@ -21,7 +21,7 @@ credentials:
       source: store
       id: POSTHOG_PERSONAL_API_KEY
     scope: "PostHog private API for persons, feature flags, and query endpoints"
-    how_to_obtain: "Create a PostHog personal API key with only the needed scopes, then store it with `/secret set POSTHOG_PERSONAL_API_KEY <key>` or `hybridclaw secret set POSTHOG_PERSONAL_API_KEY <key>`."
+    how_to_obtain: "Create a PostHog personal API key with only the needed scopes. Set `POSTHOG_PERSONAL_API_KEY` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set POSTHOG_PERSONAL_API_KEY <key>` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set POSTHOG_PERSONAL_API_KEY <key>`."
 config_variables:
   - id: posthog-host
     env: POSTHOG_HOST
@@ -118,7 +118,11 @@ Never paste either token into chat or helper arguments. The helper emits
 `bearerSecretName: "POSTHOG_PERSONAL_API_KEY"` for private APIs, so the gateway
 injects credentials server-side.
 
-Recommended chat setup:
+Recommended setup order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets` and set
+   `POSTHOG_PROJECT_TOKEN` and `POSTHOG_PERSONAL_API_KEY`.
+2. Browser `/chat` or TUI fallback:
 
 ```bash
 /secret set POSTHOG_PROJECT_TOKEN <project-token>
@@ -129,7 +133,7 @@ Recommended chat setup:
 /env set POSTHOG_ENVIRONMENT_ID "12345"
 ```
 
-Local-terminal equivalent:
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set POSTHOG_PROJECT_TOKEN "<project-token>"

--- a/skills/salesforce/SKILL.md
+++ b/skills/salesforce/SKILL.md
@@ -70,7 +70,11 @@ response and stores it as `SF_ACCESS_TOKEN`; it also captures
 or the agent context. Subsequent API calls reference it via `bearerSecretName`,
 so the gateway injects the bearer token server-side.
 
-Ask the user to set them once from a local HybridClaw session:
+Ask the user to set them once in this order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets` and set the
+   `SF_*` secrets.
+2. Browser `/chat` or TUI fallback:
 
 ```text
 /secret set SF_FULL_USERNAME you@example.com
@@ -80,7 +84,7 @@ Ask the user to set them once from a local HybridClaw session:
 /secret set SF_DOMAIN login
 ```
 
-Shell-side equivalent:
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set SF_FULL_USERNAME you@example.com

--- a/skills/salesforce/references/metadata-and-queries.md
+++ b/skills/salesforce/references/metadata-and-queries.md
@@ -18,6 +18,10 @@ The helper defaults to these store-backed secret refs:
 
 Primary setup flow:
 
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets` and set the
+   `SF_*` secrets.
+2. Browser `/chat` or TUI fallback:
+
 ```text
 /secret set SF_FULL_USERNAME you@example.com
 /secret set SF_FULL_PASSWORD <password-plus-token>
@@ -26,7 +30,7 @@ Primary setup flow:
 /secret set SF_DOMAIN login
 ```
 
-Shell-side equivalent:
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set SF_FULL_USERNAME you@example.com

--- a/skills/shelly/SKILL.md
+++ b/skills/shelly/SKILL.md
@@ -13,7 +13,7 @@ credentials:
       source: store
       id: SHELLY_CLOUD_AUTH_KEY
     scope: "Shelly Cloud Control API tenant host auth_key query parameter"
-    how_to_obtain: "Generate an Authorization cloud key in Shelly Smart Control user settings and store it with `hybridclaw secret set SHELLY_CLOUD_AUTH_KEY \"<key>\"`."
+    how_to_obtain: "Generate an Authorization cloud key in Shelly Smart Control user settings. Set `SHELLY_CLOUD_AUTH_KEY` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set SHELLY_CLOUD_AUTH_KEY \"<key>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set SHELLY_CLOUD_AUTH_KEY \"<key>\"`."
   - id: shelly-cloud-access-token
     kind: bearer
     required: false
@@ -21,7 +21,7 @@ credentials:
       source: store
       id: SHELLY_CLOUD_ACCESS_TOKEN
     scope: "Shelly Cloud Real Time Events HTTP API Authorization bearer"
-    how_to_obtain: "Use Shelly's documented OAuth flow for the Real Time Events API and store the resulting access token with `hybridclaw secret set SHELLY_CLOUD_ACCESS_TOKEN \"<access-token>\"`."
+    how_to_obtain: "Use Shelly's documented OAuth flow for the Real Time Events API. Set `SHELLY_CLOUD_ACCESS_TOKEN` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set SHELLY_CLOUD_ACCESS_TOKEN \"<access-token>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set SHELLY_CLOUD_ACCESS_TOKEN \"<access-token>\"`."
 metadata:
   hybridclaw:
     category: home-automation

--- a/skills/speech.detect-language/SKILL.md
+++ b/skills/speech.detect-language/SKILL.md
@@ -13,7 +13,7 @@ credentials:
       source: store
       id: OPENAI_API_KEY
     scope: OpenAI speech-to-text language detection through transcription metadata.
-    how_to_obtain: Create an OpenAI API key, then store it with `hybridclaw secret set OPENAI_API_KEY "<api-key>"`.
+    how_to_obtain: "Create an OpenAI API key. Set `OPENAI_API_KEY` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set OPENAI_API_KEY \"<api-key>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set OPENAI_API_KEY \"<api-key>\"`."
   - id: deepgram-api-key
     kind: api_key
     required: false
@@ -21,7 +21,7 @@ credentials:
       source: store
       id: DEEPGRAM_API_KEY
     scope: Deepgram speech-to-text language detection.
-    how_to_obtain: Create a Deepgram API key, then store it with `hybridclaw secret set DEEPGRAM_API_KEY "<api-key>"`.
+    how_to_obtain: "Create a Deepgram API key. Set `DEEPGRAM_API_KEY` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set DEEPGRAM_API_KEY \"<api-key>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set DEEPGRAM_API_KEY \"<api-key>\"`."
   - id: assemblyai-api-key
     kind: api_key
     required: false
@@ -29,7 +29,7 @@ credentials:
       source: store
       id: ASSEMBLYAI_API_KEY
     scope: AssemblyAI speech-to-text language detection.
-    how_to_obtain: Create an AssemblyAI API key, then store it with `hybridclaw secret set ASSEMBLYAI_API_KEY "<api-key>"`.
+    how_to_obtain: "Create an AssemblyAI API key. Set `ASSEMBLYAI_API_KEY` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set ASSEMBLYAI_API_KEY \"<api-key>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set ASSEMBLYAI_API_KEY \"<api-key>\"`."
 metadata:
   hybridclaw:
     category: media

--- a/skills/speech.transcribe/SKILL.md
+++ b/skills/speech.transcribe/SKILL.md
@@ -13,7 +13,7 @@ credentials:
       source: store
       id: OPENAI_API_KEY
     scope: OpenAI Whisper speech-to-text transcription.
-    how_to_obtain: Create an OpenAI API key, then store it with `hybridclaw secret set OPENAI_API_KEY "<api-key>"`.
+    how_to_obtain: "Create an OpenAI API key. Set `OPENAI_API_KEY` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set OPENAI_API_KEY \"<api-key>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set OPENAI_API_KEY \"<api-key>\"`."
   - id: deepgram-api-key
     kind: api_key
     required: false
@@ -21,7 +21,7 @@ credentials:
       source: store
       id: DEEPGRAM_API_KEY
     scope: Deepgram speech-to-text transcription, diarization, and word timestamps.
-    how_to_obtain: Create a Deepgram API key, then store it with `hybridclaw secret set DEEPGRAM_API_KEY "<api-key>"`.
+    how_to_obtain: "Create a Deepgram API key. Set `DEEPGRAM_API_KEY` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set DEEPGRAM_API_KEY \"<api-key>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set DEEPGRAM_API_KEY \"<api-key>\"`."
   - id: assemblyai-api-key
     kind: api_key
     required: false
@@ -29,7 +29,7 @@ credentials:
       source: store
       id: ASSEMBLYAI_API_KEY
     scope: AssemblyAI async speech-to-text transcription, diarization, and word timestamps.
-    how_to_obtain: Create an AssemblyAI API key, then store it with `hybridclaw secret set ASSEMBLYAI_API_KEY "<api-key>"`.
+    how_to_obtain: "Create an AssemblyAI API key. Set `ASSEMBLYAI_API_KEY` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set ASSEMBLYAI_API_KEY \"<api-key>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set ASSEMBLYAI_API_KEY \"<api-key>\"`."
 metadata:
   hybridclaw:
     category: media

--- a/skills/t-cloud-public/SKILL.md
+++ b/skills/t-cloud-public/SKILL.md
@@ -13,7 +13,7 @@ credentials:
       source: store
       id: OTC_ACCESS_KEY_ID
     scope: "T Cloud Public / Open Telekom Cloud AK/SK request signing"
-    how_to_obtain: "Create an OTC access key in My Credentials > Access Keys and store the Access Key Id as OTC_ACCESS_KEY_ID. Use a least-privilege IAM user for inventory work."
+    how_to_obtain: "Create an OTC access key in My Credentials > Access Keys. Set `OTC_ACCESS_KEY_ID` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set OTC_ACCESS_KEY_ID \"<access-key-id>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set OTC_ACCESS_KEY_ID \"<access-key-id>\"`. Use a least-privilege IAM user for inventory work."
   - id: otc-secret-access-key
     kind: header
     required: true
@@ -21,7 +21,7 @@ credentials:
       source: store
       id: OTC_SECRET_ACCESS_KEY
     scope: "T Cloud Public / Open Telekom Cloud AK/SK request signing"
-    how_to_obtain: "Save the Secret Access Key from the OTC access key CSV as OTC_SECRET_ACCESS_KEY. Never paste it into chat or project files."
+    how_to_obtain: "Save the Secret Access Key from the OTC access key CSV. Set `OTC_SECRET_ACCESS_KEY` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set OTC_SECRET_ACCESS_KEY \"<secret-access-key>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set OTC_SECRET_ACCESS_KEY \"<secret-access-key>\"`. Never paste it into chat or project files."
   - id: otc-project-id
     kind: header
     required: true
@@ -29,7 +29,7 @@ credentials:
       source: store
       id: OTC_PROJECT_ID
     scope: "T Cloud Public / Open Telekom Cloud regional project paths"
-    how_to_obtain: "Copy the target regional project ID from My Credentials > API Credentials and store it as OTC_PROJECT_ID."
+    how_to_obtain: "Copy the target regional project ID from My Credentials > API Credentials. Set `OTC_PROJECT_ID` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set OTC_PROJECT_ID \"<project-id>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set OTC_PROJECT_ID \"<project-id>\"`."
   - id: otc-enterprise-dashboard-token
     kind: header
     required: false
@@ -37,7 +37,7 @@ credentials:
       source: store
       id: OTC_ENTERPRISE_DASHBOARD_TOKEN
     scope: "T Cloud Public Enterprise Dashboard consumption and spend data"
-    how_to_obtain: "Create an Enterprise Dashboard API key with Admin security level in the organization settings and store it as OTC_ENTERPRISE_DASHBOARD_TOKEN."
+    how_to_obtain: "Create an Enterprise Dashboard API key with Admin security level in organization settings. Set `OTC_ENTERPRISE_DASHBOARD_TOKEN` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set OTC_ENTERPRISE_DASHBOARD_TOKEN \"<enterprise-dashboard-api-token>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set OTC_ENTERPRISE_DASHBOARD_TOKEN \"<enterprise-dashboard-api-token>\"`."
 metadata:
   hybridclaw:
     category: infrastructure

--- a/skills/t-cloud-public/references/operator-setup.md
+++ b/skills/t-cloud-public/references/operator-setup.md
@@ -6,7 +6,11 @@ match the provider's credentials, API docs, and endpoint domains.
 
 ## Secrets
 
-Store OTC credentials in HybridClaw encrypted runtime secrets:
+Set OTC credentials in HybridClaw encrypted runtime secrets in this order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets`.
+2. Browser `/chat` or TUI fallback with `/secret set OTC_* ...`.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set OTC_ACCESS_KEY_ID "<access-key-id>"
@@ -15,13 +19,23 @@ hybridclaw secret set OTC_PROJECT_ID "<project-id>"
 ```
 
 For Enterprise Dashboard billing and spend data, create an Enterprise Dashboard
-API key with Admin security level and store it separately:
+API key with Admin security level and set it separately in the same order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets`.
+2. Browser `/chat` or TUI fallback:
+   `/secret set OTC_ENTERPRISE_DASHBOARD_TOKEN "<enterprise-dashboard-api-token>"`.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set OTC_ENTERPRISE_DASHBOARD_TOKEN "<enterprise-dashboard-api-token>"
 ```
 
-If the access key is temporary, also store:
+If the access key is temporary, also set:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets`.
+2. Browser `/chat` or TUI fallback:
+   `/secret set OTC_SECURITY_TOKEN "<session-token>"`.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set OTC_SECURITY_TOKEN "<session-token>"

--- a/skills/video.from-script/SKILL.md
+++ b/skills/video.from-script/SKILL.md
@@ -13,7 +13,7 @@ credentials:
       source: store
       id: HEYGEN_API_KEY
     scope: HeyGen Direct API avatar video generation.
-    how_to_obtain: Create or regenerate the API token from HeyGen account settings, then store it with `hybridclaw secret set HEYGEN_API_KEY "<api-key>"`.
+    how_to_obtain: "Create or regenerate the API token from HeyGen account settings. Set `HEYGEN_API_KEY` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set HEYGEN_API_KEY \"<api-key>\"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set HEYGEN_API_KEY \"<api-key>\"`."
 metadata:
   hybridclaw:
     category: media

--- a/skills/zabbix/SKILL.md
+++ b/skills/zabbix/SKILL.md
@@ -14,7 +14,11 @@ credentials:
       id: ZABBIX_API_TOKEN
     scope: "https://<zabbix-frontend>/api_jsonrpc.php Authorization bearer"
     how_to_obtain: |
-      Create a Zabbix API token in the Zabbix frontend and store it with
+      Create a Zabbix API token in the Zabbix frontend. Set
+      `ZABBIX_API_TOKEN` through browser admin at
+      `/admin/secrets`; if browser admin is unavailable,
+      use `/secret set ZABBIX_API_TOKEN "<token>"` in browser `/chat` or TUI;
+      local console fallback:
       `hybridclaw secret set ZABBIX_API_TOKEN "<token>"`.
 metadata:
   hybridclaw:
@@ -66,7 +70,13 @@ and include the Zabbix event id and action in the approval text.
 
 ## Credential Rules
 
-Store the API token in HybridClaw encrypted runtime secrets:
+Set or update the API token in this order:
+
+1. Browser admin: open the active HybridClaw admin URL ending in `/admin/secrets` and set
+   `ZABBIX_API_TOKEN`.
+2. Browser `/chat` or TUI fallback:
+   `/secret set ZABBIX_API_TOKEN "<zabbix-api-token>"`.
+3. Local console fallback:
 
 ```bash
 hybridclaw secret set ZABBIX_API_TOKEN "<zabbix-api-token>"

--- a/tests/homematic-skill.test.ts
+++ b/tests/homematic-skill.test.ts
@@ -38,7 +38,11 @@ test('Homematic skill manifest declares HCU credentials and safety metadata', ()
       howToObtain:
         'Enable HCU developer mode, generate an activation key, use\n' +
         '`node skills/homematic/homematic.cjs http-request auth-token` and\n' +
-        '`confirm-token`, then store the confirmed Connect API auth token with\n' +
+        '`confirm-token`, then set the confirmed Connect API auth token as\n' +
+        '`HOMEMATIC_HCU_AUTH_TOKEN` through browser admin at\n' +
+        '`/admin/secrets`; if browser admin is unavailable,\n' +
+        'use `/secret set HOMEMATIC_HCU_AUTH_TOKEN "<token>"` in browser `/chat`\n' +
+        'or TUI; local console fallback:\n' +
         '`hybridclaw secret set HOMEMATIC_HCU_AUTH_TOKEN "<token>"`.',
     },
     {
@@ -51,8 +55,12 @@ test('Homematic skill manifest declares HCU credentials and safety metadata', ()
       },
       scope: 'One-time HCU Connect API token enrollment',
       howToObtain:
-        'Generate an activation key from HCUweb developer mode and store it only\n' +
-        'long enough to enroll the Connect API client:\n' +
+        'Generate an activation key from HCUweb developer mode and set it only\n' +
+        'long enough to enroll the Connect API client as\n' +
+        '`HOMEMATIC_HCU_ACTIVATION_KEY` through browser admin at\n' +
+        '`/admin/secrets`; if browser admin is unavailable,\n' +
+        'use `/secret set HOMEMATIC_HCU_ACTIVATION_KEY "<activation-key>"` in\n' +
+        'browser `/chat` or TUI; local console fallback:\n' +
         '`hybridclaw secret set HOMEMATIC_HCU_ACTIVATION_KEY "<activation-key>"`.',
     },
   ]);

--- a/tests/shelly-skill.test.ts
+++ b/tests/shelly-skill.test.ts
@@ -47,7 +47,7 @@ test('Shelly skill manifest declares optional cloud credential and guarded opera
       },
       scope: 'Shelly Cloud Control API tenant host auth_key query parameter',
       howToObtain:
-        'Generate an Authorization cloud key in Shelly Smart Control user settings and store it with `hybridclaw secret set SHELLY_CLOUD_AUTH_KEY "<key>"`.',
+        'Generate an Authorization cloud key in Shelly Smart Control user settings. Set `SHELLY_CLOUD_AUTH_KEY` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set SHELLY_CLOUD_AUTH_KEY "<key>"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set SHELLY_CLOUD_AUTH_KEY "<key>"`.',
     },
     {
       id: 'shelly-cloud-access-token',
@@ -59,7 +59,7 @@ test('Shelly skill manifest declares optional cloud credential and guarded opera
       },
       scope: 'Shelly Cloud Real Time Events HTTP API Authorization bearer',
       howToObtain:
-        'Use Shelly\'s documented OAuth flow for the Real Time Events API and store the resulting access token with `hybridclaw secret set SHELLY_CLOUD_ACCESS_TOKEN "<access-token>"`.',
+        'Use Shelly\'s documented OAuth flow for the Real Time Events API. Set `SHELLY_CLOUD_ACCESS_TOKEN` through browser admin at the active `/admin/secrets` route; if browser admin is unavailable, use `/secret set SHELLY_CLOUD_ACCESS_TOKEN "<access-token>"` in browser `/chat` or TUI; local console fallback: `hybridclaw secret set SHELLY_CLOUD_ACCESS_TOKEN "<access-token>"`.',
     },
   ]);
   expect(skill).toContain('category: home-automation');

--- a/tests/zabbix-skill.test.ts
+++ b/tests/zabbix-skill.test.ts
@@ -40,7 +40,11 @@ test('Zabbix skill manifest declares SecretRef credential metadata', () => {
       },
       scope: 'https://<zabbix-frontend>/api_jsonrpc.php Authorization bearer',
       howToObtain:
-        'Create a Zabbix API token in the Zabbix frontend and store it with\n' +
+        'Create a Zabbix API token in the Zabbix frontend. Set\n' +
+        '`ZABBIX_API_TOKEN` through browser admin at\n' +
+        '`/admin/secrets`; if browser admin is unavailable,\n' +
+        'use `/secret set ZABBIX_API_TOKEN "<token>"` in browser `/chat` or TUI;\n' +
+        'local console fallback:\n' +
         '`hybridclaw secret set ZABBIX_API_TOKEN "<token>"`.',
     },
   ]);


### PR DESCRIPTION
## Summary
- Update credential-backed bundled skills to prefer the active HybridClaw admin URL ending in `/admin/secrets`
- Keep `/secret set` in browser chat or TUI as the second option
- Keep `hybridclaw secret set` in the console as the fallback option
- Remove local-only `localhost:9090/admin/secrets` guidance from bundled docs

## Validation
- `npm run format`
- `npm run lint`
- `git diff --check`
- Parsed all 81 bundled `SKILL.md` frontmatter blocks with Ruby YAML
- Confirmed no `localhost:9090/admin/secrets` references remain in `docs` or `skills`
