### PR TITLE
[codex] Add live email mailbox reads

### DIFF
--- a/container/src/tools.ts
+++ b/container/src/tools.ts
@@ -3073,19 +3073,36 @@ async function executeToolInternal(
 
       if (action === 'read') {
         const channelId = resolveDiscordMessageChannelTarget(args);
-        if (!channelId) {
-          return failTool(
-            'Error: channelId is required for message action "read".',
-          );
-        }
-        payload.channelId = channelId;
+        if (channelId) payload.channelId = channelId;
 
         if (typeof args.limit === 'number' && Number.isFinite(args.limit)) {
           payload.limit = Math.max(1, Math.min(100, Math.floor(args.limit)));
         }
+        const query =
+          readStringValue(args.query) ||
+          readStringValue(args.search) ||
+          readStringValue(args.text);
+        const folder = readStringValue(args.folder);
+        const folders = readStringListValue(args.folders);
+        const uid = readPositiveNumberValue(args.uid);
+        const from = readStringValue(args.from);
+        const subject =
+          readStringValue(args.subject) || readStringValue(args.title);
+        const since = readStringValue(args.since);
+        const beforeDate =
+          readStringValue(args.beforeDate) || readStringValue(args.until);
         const before = readStringValue(args.before);
         const after = readStringValue(args.after);
         const around = readStringValue(args.around);
+        if (query) payload.query = query;
+        if (folder) payload.folder = folder;
+        if (folders) payload.folders = folders;
+        if (uid !== null) payload.uid = Math.floor(uid);
+        if (args.unreadOnly === true) payload.unreadOnly = true;
+        if (from) payload.from = from;
+        if (subject) payload.subject = subject;
+        if (since) payload.since = since;
+        if (beforeDate) payload.beforeDate = beforeDate;
         if (before) payload.before = before;
         if (after) payload.after = after;
         if (around) payload.around = around;
@@ -4119,6 +4136,53 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
           limit: {
             type: 'number',
             description: 'Read limit for action="read" (default 20, max 100).',
+          },
+          query: {
+            type: 'string',
+            description:
+              'Optional search text for action="read" when the active channel supports mailbox or conversation search.',
+          },
+          search: {
+            type: 'string',
+            description: 'Alias for query in action="read".',
+          },
+          folder: {
+            type: 'string',
+            description:
+              'Optional mailbox folder for action="read" when supported by the active channel.',
+          },
+          folders: {
+            type: ['string', 'array'],
+            items: {
+              type: 'string',
+            },
+            description:
+              'Optional mailbox folder list for action="read" when supported by the active channel.',
+          },
+          uid: {
+            type: 'number',
+            description:
+              'Optional mailbox message UID for action="read" when folder is also provided.',
+          },
+          unreadOnly: {
+            type: 'boolean',
+            description:
+              'Only return unread messages for action="read" when supported by the active channel.',
+          },
+          from: {
+            type: 'string',
+            description:
+              'Optional sender filter for action="read" when supported by the active channel.',
+          },
+          since: {
+            type: 'string',
+            description:
+              'Optional received-after date or ISO timestamp for action="read" when supported by the active channel.',
+          },
+          beforeDate: {
+            type: 'string',
+            description:
+              'Optional received-before date or ISO timestamp for action="read" when supported by the active channel.',
           },
           before: {
             type: 'string',

--- a/src/channels/discord/tool-actions.ts
+++ b/src/channels/discord/tool-actions.ts
@@ -98,6 +98,14 @@ export interface DiscordToolActionRequest {
   bcc?: string[];
   inReplyTo?: string;
   references?: string[];
+  query?: string;
+  folder?: string;
+  folders?: string[];
+  uid?: number;
+  unreadOnly?: boolean;
+  from?: string;
+  since?: string;
+  beforeDate?: string;
   filePath?: string;
   components?: unknown;
   contextChannelId?: string;

--- a/src/channels/email/admin-mailbox.ts
+++ b/src/channels/email/admin-mailbox.ts
@@ -2,6 +2,7 @@ import {
   type FetchMessageObject,
   ImapFlow,
   type MessageAddressObject,
+  type SearchObject,
   type MessageStructureObject,
 } from 'imapflow';
 import { type AddressObject, type ParsedMail, simpleParser } from 'mailparser';
@@ -34,6 +35,8 @@ import {
 
 const DEFAULT_MESSAGE_LIMIT = 40;
 const MAX_MESSAGE_LIMIT = 100;
+const DEFAULT_SEARCH_LIMIT = 20;
+const MAX_SEARCH_LIMIT = 50;
 const PREVIEW_MAX_LENGTH = 220;
 const PREVIEW_MAX_BYTES = 12_000;
 const METADATA_FALLBACK_WINDOW_MS = 15 * 60 * 1000;
@@ -120,6 +123,31 @@ export interface LiveAdminEmailDeleteResult {
   permanent: boolean;
 }
 
+export interface LiveEmailMailboxSearchParams {
+  query?: string;
+  folder?: string;
+  folders?: string[];
+  limit?: number;
+  unreadOnly?: boolean;
+  from?: string;
+  subject?: string;
+  since?: string;
+  beforeDate?: string;
+}
+
+export interface LiveEmailMailboxSearchSnapshot {
+  address: string;
+  query: string | null;
+  folders: string[];
+  limit: number;
+  messages: LiveAdminEmailMessageDetail[];
+}
+
+export type LiveEmailMailboxConnectionConfig = Pick<
+  RuntimeEmailConfig,
+  'address' | 'folders' | 'imapHost' | 'imapPort' | 'imapSecure'
+>;
+
 function resolveConfiguredFolders(folders: string[]): string[] {
   const resolved = folders
     .map((folder) => String(folder || '').trim())
@@ -134,7 +162,7 @@ function normalizeFolderPath(value: string | null | undefined): string {
 }
 
 function createImapClient(
-  config: RuntimeEmailConfig,
+  config: LiveEmailMailboxConnectionConfig,
   password: string,
 ): ImapFlow {
   return new ImapFlow({
@@ -151,7 +179,7 @@ function createImapClient(
 }
 
 async function withLiveEmailClient<T>(
-  config: RuntimeEmailConfig,
+  config: LiveEmailMailboxConnectionConfig,
   password: string,
   fn: (client: ImapFlow) => Promise<T>,
 ): Promise<T> {
@@ -244,6 +272,75 @@ function hasFlag(
 function trimText(value: string | null | undefined): string | null {
   const trimmed = String(value || '').trim();
   return trimmed || null;
+}
+
+function normalizeSearchLimit(limit: number | undefined): number {
+  return Math.max(
+    1,
+    Math.min(MAX_SEARCH_LIMIT, Math.trunc(limit || DEFAULT_SEARCH_LIMIT)),
+  );
+}
+
+function normalizeSearchFolders(params: LiveEmailMailboxSearchParams): string[] {
+  const values = [
+    params.folder,
+    ...(Array.isArray(params.folders) ? params.folders : []),
+  ];
+  return [
+    ...new Set(
+      values
+        .map((folder) => String(folder || '').trim())
+        .filter(Boolean),
+    ),
+  ];
+}
+
+function normalizeSearchDate(value: string | undefined, label: string): string {
+  const trimmed = String(value || '').trim();
+  if (!trimmed) return '';
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`${label} must be a valid date or ISO timestamp.`);
+  }
+  return parsed.toISOString();
+}
+
+function buildMailboxSearchQuery(
+  params: LiveEmailMailboxSearchParams,
+): SearchObject {
+  const search: SearchObject = {};
+  const query = trimText(params.query || null);
+  const from = trimText(params.from || null);
+  const subject = trimText(params.subject || null);
+  const since = normalizeSearchDate(params.since, 'since');
+  const before = normalizeSearchDate(params.beforeDate, 'beforeDate');
+
+  if (query) search.text = query;
+  if (from) search.from = from;
+  if (subject) search.subject = subject;
+  if (since) search.since = since;
+  if (before) search.before = before;
+  if (params.unreadOnly) search.seen = false;
+  if (Object.keys(search).length === 0) search.all = true;
+
+  return search;
+}
+
+async function resolveMailboxSearchFolders(
+  client: ImapFlow,
+  config: LiveEmailMailboxConnectionConfig,
+  params: LiveEmailMailboxSearchParams,
+): Promise<string[]> {
+  const explicit = normalizeSearchFolders(params);
+  if (explicit.length > 0) return explicit;
+
+  const listed = await listSelectableFolders(client);
+  const selectable = listed
+    .map((entry) => String(entry.path || '').trim())
+    .filter(Boolean);
+  return selectable.length > 0
+    ? [...new Set(selectable)]
+    : resolveConfiguredFolders(config.folders);
 }
 
 function normalizeComparableEmailAddress(
@@ -1459,7 +1556,7 @@ async function fetchHeaderLinkedMessagesAcrossFolders(
 }
 
 export async function fetchLiveAdminEmailMailbox(
-  config: RuntimeEmailConfig,
+  config: LiveEmailMailboxConnectionConfig,
   password: string,
 ): Promise<LiveAdminEmailMailboxSnapshot> {
   return withLiveEmailClient(config, password, async (client) => {
@@ -1493,8 +1590,78 @@ export async function fetchLiveAdminEmailMailbox(
   });
 }
 
+async function fetchMailboxSearchFolderMessages(
+  client: ImapFlow,
+  params: {
+    folder: string;
+    search: SearchObject;
+    limit: number;
+  },
+): Promise<LiveAdminEmailMessageDetail[]> {
+  const lock = await client.getMailboxLock(params.folder);
+  try {
+    const uids = (await client.search(params.search, { uid: true })) || [];
+    const selectedUids = [...new Set(uids)]
+      .sort((left, right) => right - left)
+      .slice(0, params.limit);
+    if (selectedUids.length === 0) return [];
+
+    const fetched = await client.fetchAll(
+      selectedUids,
+      MESSAGE_DETAIL_FETCH_QUERY,
+      { uid: true },
+    );
+    const messages = await Promise.all(
+      fetched.map((message) => buildMessageDetail(message, params.folder)),
+    );
+    return messages.filter(
+      (message): message is LiveAdminEmailMessageDetail => message !== null,
+    );
+  } finally {
+    lock.release();
+  }
+}
+
+export async function searchLiveEmailMailbox(
+  config: LiveEmailMailboxConnectionConfig,
+  password: string,
+  params: LiveEmailMailboxSearchParams,
+): Promise<LiveEmailMailboxSearchSnapshot> {
+  return withLiveEmailClient(config, password, async (client) => {
+    const limit = normalizeSearchLimit(params.limit);
+    const folders = await resolveMailboxSearchFolders(client, config, params);
+    const search = buildMailboxSearchQuery(params);
+    const messages = (
+      await Promise.all(
+        folders.map((folder) =>
+          fetchMailboxSearchFolderMessages(client, {
+            folder,
+            search,
+            limit,
+          }),
+        ),
+      )
+    ).flat();
+
+    messages.sort((left, right) => {
+      const leftMs = parseTimestampMs(left.receivedAt);
+      const rightMs = parseTimestampMs(right.receivedAt);
+      if (rightMs !== leftMs) return rightMs - leftMs;
+      return right.uid - left.uid;
+    });
+
+    return {
+      address: config.address,
+      query: trimText(params.query || null),
+      folders,
+      limit,
+      messages: messages.slice(0, limit),
+    };
+  });
+}
+
 export async function fetchLiveAdminEmailFolder(
-  config: RuntimeEmailConfig,
+  config: LiveEmailMailboxConnectionConfig,
   password: string,
   params: {
     folder: string;
@@ -1577,7 +1744,7 @@ export async function fetchLiveAdminEmailFolder(
 }
 
 export async function fetchLiveAdminEmailMessage(
-  config: RuntimeEmailConfig,
+  config: LiveEmailMailboxConnectionConfig,
   password: string,
   params: {
     folder: string;
@@ -1692,7 +1859,7 @@ export async function fetchLiveAdminEmailMessage(
 }
 
 export async function deleteLiveAdminEmailMessage(
-  config: RuntimeEmailConfig,
+  config: LiveEmailMailboxConnectionConfig,
   password: string,
   params: {
     folder: string;

--- a/src/channels/email/admin-mailbox.ts
+++ b/src/channels/email/admin-mailbox.ts
@@ -2,8 +2,8 @@ import {
   type FetchMessageObject,
   ImapFlow,
   type MessageAddressObject,
-  type SearchObject,
   type MessageStructureObject,
+  type SearchObject,
 } from 'imapflow';
 import { type AddressObject, type ParsedMail, simpleParser } from 'mailparser';
 import sanitizeHtml from 'sanitize-html';
@@ -281,16 +281,16 @@ function normalizeSearchLimit(limit: number | undefined): number {
   );
 }
 
-function normalizeSearchFolders(params: LiveEmailMailboxSearchParams): string[] {
+function normalizeSearchFolders(
+  params: LiveEmailMailboxSearchParams,
+): string[] {
   const values = [
     params.folder,
     ...(Array.isArray(params.folders) ? params.folders : []),
   ];
   return [
     ...new Set(
-      values
-        .map((folder) => String(folder || '').trim())
-        .filter(Boolean),
+      values.map((folder) => String(folder || '').trim()).filter(Boolean),
     ),
   ];
 }

--- a/src/channels/email/prompt-adapter.ts
+++ b/src/channels/email/prompt-adapter.ts
@@ -8,11 +8,10 @@ export const emailAgentPromptAdapter: ChannelAgentPromptAdapter = {
     const hints = [
       '- Email replies should stay readable in plain text first and free of Discord-specific syntax. Simple emphasis, bullets, and inline code are fine; outbound email is sent as multipart text + HTML.',
       '- For normal email replies, append a polished corporate signature block derived from the identity details already loaded from `IDENTITY.md`. Prefer full name, role, organization, and any real contact details that are present. Do not invent contact info, and do not use emoji or mascot-style sign-offs.',
-      '- Supported `message` actions here: `read` (ingested thread history for the current peer or an explicit email address) and `send` (reply or start a new outbound thread).',
+      '- Supported `message` actions here: `read` and `send`.',
       '- For a new outbound email thread, start the message body with `[Subject: Your subject here]` on its own line.',
       '- For replies in the current email thread, omit the subject prefix; the runtime keeps `Re:` subject continuity and threading headers automatically.',
-      '- For `message` `read`, omit `channelId` to inspect the current email thread, or pass an explicit email address like `user@example.com`.',
-      '- Email `read` only covers threads already ingested by the gateway; it does not do arbitrary mailbox-wide unread searches.',
+      '- For current email-thread `read`, omit `channelId` in an email thread or pass an explicit email address like `user@example.com`.',
       '- Email `message` sends use a plain email address like `user@example.com` as the target.',
       '- For catch-up or summary requests with incomplete scope, make a reasonable best-effort assumption, do the useful work first, and mention the assumption after the answer instead of blocking on a clarification.',
       '- Keep each outbound email chunk under roughly 50,000 characters.',

--- a/src/channels/email/runtime.ts
+++ b/src/channels/email/runtime.ts
@@ -12,10 +12,10 @@ import { EMAIL_CAPABILITIES } from '../channel.js';
 import { createChannelRuntime } from '../channel-runtime-factory.js';
 import {
   fetchLiveAdminEmailMessage,
-  searchLiveEmailMailbox,
   type LiveAdminEmailMessageThreadSnapshot,
   type LiveEmailMailboxSearchParams,
   type LiveEmailMailboxSearchSnapshot,
+  searchLiveEmailMailbox,
 } from './admin-mailbox.js';
 import { createEmailConnectionManager } from './connection.js';
 import { type EmailSendParams, sendEmail } from './delivery.js';

--- a/src/channels/email/runtime.ts
+++ b/src/channels/email/runtime.ts
@@ -10,6 +10,13 @@ import { logger } from '../../logger.js';
 import type { MediaContextItem } from '../../types/container.js';
 import { EMAIL_CAPABILITIES } from '../channel.js';
 import { createChannelRuntime } from '../channel-runtime-factory.js';
+import {
+  fetchLiveAdminEmailMessage,
+  searchLiveEmailMailbox,
+  type LiveAdminEmailMessageThreadSnapshot,
+  type LiveEmailMailboxSearchParams,
+  type LiveEmailMailboxSearchSnapshot,
+} from './admin-mailbox.js';
 import { createEmailConnectionManager } from './connection.js';
 import { type EmailSendParams, sendEmail } from './delivery.js';
 import { cleanupEmailInboundMedia, processInboundEmail } from './inbound.js';
@@ -93,6 +100,27 @@ export interface EmailTextSendOptions {
   metadata?: EmailDeliveryMetadata | null;
   fromName?: string | null;
 }
+
+export interface EmailMailboxReadParams extends LiveEmailMailboxSearchParams {
+  agentId?: string;
+  uid?: number;
+}
+
+export type EmailMailboxReadResult =
+  | {
+      kind: 'message';
+      accountAddress: string;
+      agentId: string;
+      folder: string;
+      uid: number;
+      snapshot: LiveAdminEmailMessageThreadSnapshot;
+    }
+  | {
+      kind: 'search';
+      accountAddress: string;
+      agentId: string;
+      snapshot: LiveEmailMailboxSearchSnapshot;
+    };
 
 function createEmailShutdownAbortError(): Error {
   return new Error('Email runtime shutting down.');
@@ -493,6 +521,42 @@ export function createEmailRuntime() {
     );
   };
 
+  const readMailboxFromAccount = async (
+    state: EmailAccountState,
+    params: EmailMailboxReadParams,
+  ): Promise<EmailMailboxReadResult> => {
+    const folder = String(params.folder || '').trim();
+    const uid =
+      typeof params.uid === 'number' && Number.isFinite(params.uid)
+        ? Math.trunc(params.uid)
+        : 0;
+    if (folder && uid > 0) {
+      return {
+        kind: 'message',
+        accountAddress: state.account.address,
+        agentId: state.account.agentId,
+        folder,
+        uid,
+        snapshot: await fetchLiveAdminEmailMessage(
+          state.account.config,
+          state.account.password,
+          { folder, uid },
+        ),
+      };
+    }
+
+    return {
+      kind: 'search',
+      accountAddress: state.account.address,
+      agentId: state.account.agentId,
+      snapshot: await searchLiveEmailMailbox(
+        state.account.config,
+        state.account.password,
+        params,
+      ),
+    };
+  };
+
   const ensureConnectionManagers = (
     messageHandler?: EmailMessageHandler,
   ): EmailAccountState[] => {
@@ -638,6 +702,14 @@ export function createEmailRuntime() {
     ): Promise<void> {
       await sendAttachmentToAddress(params);
     },
+    async readEmailMailbox(
+      params: EmailMailboxReadParams,
+    ): Promise<EmailMailboxReadResult> {
+      return readMailboxFromAccount(
+        resolveSendAccountState(params.agentId),
+        params,
+      );
+    },
     shutdownEmail: runtimeLifecycle.shutdown,
   };
 }
@@ -661,6 +733,11 @@ export const sendToEmail = (
 export const sendEmailAttachmentTo = (
   params: EmailAttachmentSendParams,
 ): Promise<void> => ensureDefaultRuntime().sendEmailAttachmentTo(params);
+
+export const readEmailMailbox = (
+  params: EmailMailboxReadParams,
+): Promise<EmailMailboxReadResult> =>
+  ensureDefaultRuntime().readEmailMailbox(params);
 
 export async function shutdownEmail(): Promise<void> {
   const runtime = defaultRuntime;

--- a/src/channels/message-tool-advertising.ts
+++ b/src/channels/message-tool-advertising.ts
@@ -18,7 +18,7 @@ const MESSAGE_TOOL_CHANNEL_ACTIONS: Record<MessageToolChannelKind, string> = {
     'Discord: send/read messages, upload files, inspect members/channels, react, edit, pin, and manage threads.',
   discord_webhook:
     'Discord webhook: send outbound-only messages to configured Discord Incoming Webhook targets.',
-  email: 'Email: send email and read ingested email thread history.',
+  email: 'Email: send and read email.',
   imessage: 'iMessage: send messages to explicit iMessage handles.',
   msteams:
     'Microsoft Teams: send/read known Teams conversations, upload files, and inspect members/channels.',

--- a/src/channels/message/tool-actions.ts
+++ b/src/channels/message/tool-actions.ts
@@ -23,10 +23,10 @@ import { sendToDiscordWebhookTarget } from '../discord-webhook/runtime.js';
 import { normalizeDiscordWebhookChannelTarget } from '../discord-webhook/target.js';
 import { isEmailAddress, normalizeEmailAddress } from '../email/allowlist.js';
 import {
+  type EmailMailboxReadResult,
   readEmailMailbox,
   sendEmailAttachmentTo,
   sendToEmail,
-  type EmailMailboxReadResult,
 } from '../email/runtime.js';
 import { sendToSignalChat } from '../signal/runtime.js';
 import { normalizeSignalChannelId } from '../signal/target.js';
@@ -782,7 +782,9 @@ type EmailMailboxMessage = Extract<
   { kind: 'search' }
 >['snapshot']['messages'][number];
 
-function truncateEmailMailboxText(value: string | null | undefined): string | null {
+function truncateEmailMailboxText(
+  value: string | null | undefined,
+): string | null {
   const normalized = String(value || '').trim();
   if (!normalized) return null;
   if (normalized.length <= MESSAGE_TOOL_EMAIL_BODY_MAX_LENGTH) {

--- a/src/channels/message/tool-actions.ts
+++ b/src/channels/message/tool-actions.ts
@@ -22,7 +22,12 @@ import type { DiscordToolActionRequest } from '../discord/tool-actions.js';
 import { sendToDiscordWebhookTarget } from '../discord-webhook/runtime.js';
 import { normalizeDiscordWebhookChannelTarget } from '../discord-webhook/target.js';
 import { isEmailAddress, normalizeEmailAddress } from '../email/allowlist.js';
-import { sendEmailAttachmentTo, sendToEmail } from '../email/runtime.js';
+import {
+  readEmailMailbox,
+  sendEmailAttachmentTo,
+  sendToEmail,
+  type EmailMailboxReadResult,
+} from '../email/runtime.js';
 import { sendToSignalChat } from '../signal/runtime.js';
 import { normalizeSignalChannelId } from '../signal/target.js';
 import { maybeRunSlackToolAction } from '../slack/tool-actions.js';
@@ -54,6 +59,8 @@ const LOCAL_MESSAGE_QUEUE_LIMIT = 100;
 const MESSAGE_TOOL_READ_DEFAULT_LIMIT = 20;
 const MESSAGE_TOOL_READ_MAX_LIMIT = 100;
 const MESSAGE_TOOL_EMAIL_SESSION_PREFIX = 'email:';
+const MESSAGE_TOOL_EMAIL_MAILBOX_TARGET_RE =
+  /^(?:mailbox|email(?::(?:mailbox|all|inbox|folder:.+|[^@\s]+))?)$/i;
 const MESSAGE_TOOL_DISCORD_WEBHOOK_PREFIX_RE = /^discord[_-]?webhook(?::|$)/i;
 const MESSAGE_TOOL_EMAIL_PREFIX_RE = /^email:/i;
 const MESSAGE_TOOL_SIGNAL_PREFIX_RE = /^signal:/i;
@@ -67,6 +74,7 @@ const MESSAGE_TOOL_DISCORD_CHANNEL_MENTION_RE = /^<#\d{16,22}>$/;
 const MESSAGE_TOOL_DISCORD_PREFIXED_ID_RE =
   /^(?:channel:|discord:|user:)\d{16,22}$/i;
 const MESSAGE_TOOL_LOCAL_SOURCE = 'message-tool';
+const MESSAGE_TOOL_EMAIL_BODY_MAX_LENGTH = 6_000;
 const MESSAGE_TOOL_CHANNEL_INSTRUCTIONS =
   'No message channel matched the request. Specify the channel explicitly: Signal `signal:+15551234567`, Telegram `telegram:<chatId>`, Threema `threema:<id>`/`threema:phone:<number>`/`threema:email:<address>`, WhatsApp `whatsapp:+15551234567` or a WhatsApp JID, Slack `slack:<channelId>`, Slack webhook `slack_webhook`/`slack_webhook:<target>`, Discord webhook `discord_webhook`/`discord_webhook:<target>`, email `user@example.com` or `email:user@example.com`, local `tui`, or Discord with a channel snowflake/`discord:<id>`/`<#id>`/`#name` plus `guildId`.';
 
@@ -296,6 +304,60 @@ function resolveEmailReadTarget(request: DiscordToolActionRequest): {
     channelId,
     sessionId: session.id,
   };
+}
+
+function resolveEmailMailboxTargetFolder(rawChannelId: string): string {
+  const trimmed = String(rawChannelId || '').trim();
+  if (!trimmed) return '';
+  const normalized = trimmed.toLowerCase();
+  if (
+    normalized === 'email' ||
+    normalized === 'mailbox' ||
+    normalized === 'email:mailbox' ||
+    normalized === 'email:all'
+  ) {
+    return '';
+  }
+  if (normalized === 'email:inbox') {
+    return 'INBOX';
+  }
+  const folderMatch = trimmed.match(/^email:folder:(.+)$/i);
+  if (folderMatch) {
+    return folderMatch[1].trim();
+  }
+  const prefixedFolder = trimmed.match(/^email:(.+)$/i);
+  return prefixedFolder ? prefixedFolder[1].trim() : '';
+}
+
+function isEmailMailboxReadTarget(request: DiscordToolActionRequest): boolean {
+  const rawChannelId = String(request.channelId || '').trim();
+  if (!rawChannelId) return true;
+  if (normalizeEmailMessageTarget(rawChannelId)) return false;
+  return MESSAGE_TOOL_EMAIL_MAILBOX_TARGET_RE.test(rawChannelId);
+}
+
+function resolveMessageToolRequestAgentId(
+  request: DiscordToolActionRequest,
+): string | undefined {
+  const sessionId = String(request.sessionId || '').trim();
+  if (!sessionId) return undefined;
+  const session = getSessionById(sessionId);
+  if (!session) return undefined;
+  return resolveAgentForRequest({ session }).agentId;
+}
+
+function normalizeEmailMailboxFolders(
+  request: DiscordToolActionRequest,
+  targetFolder: string,
+): string[] | undefined {
+  const folders = [
+    targetFolder,
+    String(request.folder || '').trim(),
+    ...(Array.isArray(request.folders) ? request.folders : []),
+  ]
+    .map((folder) => String(folder || '').trim())
+    .filter(Boolean);
+  return folders.length > 0 ? [...new Set(folders)] : undefined;
 }
 
 function hasMessageComponents(request: DiscordToolActionRequest): boolean {
@@ -715,6 +777,124 @@ async function runEmailReadAction(
   };
 }
 
+type EmailMailboxMessage = Extract<
+  EmailMailboxReadResult,
+  { kind: 'search' }
+>['snapshot']['messages'][number];
+
+function truncateEmailMailboxText(value: string | null | undefined): string | null {
+  const normalized = String(value || '').trim();
+  if (!normalized) return null;
+  if (normalized.length <= MESSAGE_TOOL_EMAIL_BODY_MAX_LENGTH) {
+    return normalized;
+  }
+  return `${normalized.slice(0, MESSAGE_TOOL_EMAIL_BODY_MAX_LENGTH).trimEnd()}\n[truncated]`;
+}
+
+function mapEmailMailboxParticipants(
+  participants: EmailMailboxMessage['to'],
+): Array<{ name: string | null; address: string | null }> {
+  return participants.map((participant) => ({
+    name: participant.name,
+    address: participant.address,
+  }));
+}
+
+function mapEmailMailboxMessage(message: EmailMailboxMessage) {
+  return {
+    id: `${message.folder}:${message.uid}`,
+    folder: message.folder,
+    uid: message.uid,
+    messageId: message.messageId,
+    subject: message.subject,
+    from: {
+      name: message.fromName,
+      address: message.fromAddress,
+    },
+    to: mapEmailMailboxParticipants(message.to),
+    cc: mapEmailMailboxParticipants(message.cc),
+    replyTo: mapEmailMailboxParticipants(message.replyTo),
+    receivedAt: message.receivedAt,
+    seen: message.seen,
+    flagged: message.flagged,
+    answered: message.answered,
+    hasAttachments: message.hasAttachments,
+    attachments: message.attachments,
+    preview: message.preview,
+    text: truncateEmailMailboxText(message.text),
+  };
+}
+
+async function runEmailMailboxReadAction(
+  request: DiscordToolActionRequest,
+): Promise<Record<string, unknown>> {
+  if (
+    String(request.before || '').trim() ||
+    String(request.after || '').trim() ||
+    String(request.around || '').trim()
+  ) {
+    throw new Error(
+      'before, after, and around are not supported for live email mailbox reads. Use since or beforeDate for date filtering.',
+    );
+  }
+
+  const rawChannelId = String(request.channelId || '').trim();
+  const targetFolder = resolveEmailMailboxTargetFolder(rawChannelId);
+  const folders = normalizeEmailMailboxFolders(request, targetFolder);
+  const uid =
+    typeof request.uid === 'number' && Number.isFinite(request.uid)
+      ? Math.trunc(request.uid)
+      : undefined;
+  const result = await readEmailMailbox({
+    agentId: resolveMessageToolRequestAgentId(request),
+    query: String(request.query || '').trim() || undefined,
+    folder: folders?.[0],
+    folders,
+    limit: resolveMessageToolReadLimit(request.limit),
+    unreadOnly: request.unreadOnly === true,
+    from: String(request.from || '').trim() || undefined,
+    subject: String(request.subject || '').trim() || undefined,
+    since: String(request.since || '').trim() || undefined,
+    beforeDate: String(request.beforeDate || '').trim() || undefined,
+    uid,
+  });
+
+  if (result.kind === 'message') {
+    return {
+      ok: true,
+      action: 'read',
+      channelId: rawChannelId || 'email:mailbox',
+      scope: 'mailbox-message',
+      transport: 'email',
+      accountAddress: result.accountAddress,
+      agentId: result.agentId,
+      folder: result.folder,
+      uid: result.uid,
+      message: result.snapshot.message
+        ? mapEmailMailboxMessage(result.snapshot.message)
+        : null,
+      thread: result.snapshot.thread.map(mapEmailMailboxMessage),
+      count: result.snapshot.thread.length,
+    };
+  }
+
+  const messages = result.snapshot.messages.map(mapEmailMailboxMessage);
+  return {
+    ok: true,
+    action: 'read',
+    channelId: rawChannelId || 'email:mailbox',
+    scope: 'mailbox-search',
+    transport: 'email',
+    accountAddress: result.accountAddress,
+    agentId: result.agentId,
+    query: result.snapshot.query,
+    folders: result.snapshot.folders,
+    limit: result.snapshot.limit,
+    count: messages.length,
+    messages,
+  };
+}
+
 async function runLocalMessageSendAction(
   request: DiscordToolActionRequest,
   channelId: string,
@@ -793,6 +973,9 @@ export async function runMessageToolAction(
     }
     if (shouldDelegateToDiscordToolAction(request)) {
       return await runDiscordToolAction(request);
+    }
+    if (isEmailMailboxReadTarget(request)) {
+      return await runEmailMailboxReadAction(request);
     }
     throw new Error(MESSAGE_TOOL_CHANNEL_INSTRUCTIONS);
   }

--- a/tests/channel-message-tool-hints.test.ts
+++ b/tests/channel-message-tool-hints.test.ts
@@ -210,7 +210,7 @@ test('resolves email hints with read support from explicit email context', () =>
     hints.some((entry) =>
       entry.includes('does not do arbitrary mailbox-wide unread searches'),
     ),
-  ).toBe(true);
+  ).toBe(false);
   expect(
     hints.some((entry) =>
       entry.includes('append a polished corporate signature block'),

--- a/tests/container.message-tool-normalization.test.ts
+++ b/tests/container.message-tool-normalization.test.ts
@@ -174,6 +174,79 @@ describe.sequential('container message tool normalization', () => {
     ]);
   });
 
+  test('read allows omitted channelId for mailbox search', async () => {
+    const fetchMock = mockGatewayFetch({
+      ok: true,
+      action: 'read',
+      channelId: 'email:mailbox',
+    });
+    setGatewayContext('http://gateway.local', 'token', '');
+    setSessionContext('web:session-a');
+
+    const result = await executeTool(
+      'message',
+      JSON.stringify({
+        action: 'read',
+        query: 'invoice',
+        limit: 12,
+        unreadOnly: true,
+      }),
+    );
+
+    expect(result).toContain('"ok": true');
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const payload = JSON.parse(String(init.body || '{}')) as Record<
+      string,
+      unknown
+    >;
+    expect(payload).toMatchObject({
+      action: 'read',
+      query: 'invoice',
+      limit: 12,
+      unreadOnly: true,
+      sessionId: 'web:session-a',
+    });
+    expect(payload.channelId).toBeUndefined();
+  });
+
+  test('read forwards mailbox folder filters to the gateway', async () => {
+    const fetchMock = mockGatewayFetch({
+      ok: true,
+      action: 'read',
+      channelId: 'email:mailbox',
+    });
+    setGatewayContext('http://gateway.local', 'token', '');
+
+    const result = await executeTool(
+      'message',
+      JSON.stringify({
+        action: 'read',
+        channelId: 'email:mailbox',
+        folder: 'INBOX',
+        uid: 44,
+        from: 'billing@example.com',
+        since: '2026-03-01',
+        beforeDate: '2026-04-01',
+      }),
+    );
+
+    expect(result).toContain('"ok": true');
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const payload = JSON.parse(String(init.body || '{}')) as Record<
+      string,
+      unknown
+    >;
+    expect(payload).toMatchObject({
+      action: 'read',
+      channelId: 'email:mailbox',
+      folder: 'INBOX',
+      uid: 44,
+      from: 'billing@example.com',
+      since: '2026-03-01',
+      beforeDate: '2026-04-01',
+    });
+  });
+
   test('send payload includes filePath and sessionId for local uploads', async () => {
     const fetchMock = mockGatewayFetch({
       ok: true,

--- a/tests/container.message-tool-schema.test.ts
+++ b/tests/container.message-tool-schema.test.ts
@@ -43,3 +43,29 @@ test('message tool email threading schema defines references array items', () =>
   expect(references.type).toContain('array');
   expect(references.items).toEqual({ type: 'string' });
 });
+
+test('message tool mailbox read schema defines search fields', () => {
+  const messageTool = TOOL_DEFINITIONS.find(
+    (entry) => entry.type === 'function' && entry.function.name === 'message',
+  );
+  expect(messageTool).toBeDefined();
+
+  const parameters = messageTool?.function.parameters as {
+    properties?: Record<string, unknown>;
+  };
+  const folders = (parameters.properties?.folders || {}) as {
+    type?: unknown;
+    items?: unknown;
+  };
+  const unreadOnly = (parameters.properties?.unreadOnly || {}) as {
+    type?: unknown;
+  };
+
+  expect(parameters.properties?.query).toMatchObject({ type: 'string' });
+  expect(parameters.properties?.folder).toMatchObject({ type: 'string' });
+  expect(Array.isArray(folders.type)).toBe(true);
+  expect(folders.type).toContain('array');
+  expect(folders.items).toEqual({ type: 'string' });
+  expect(parameters.properties?.uid).toMatchObject({ type: 'number' });
+  expect(unreadOnly.type).toBe('boolean');
+});

--- a/tests/message.tool-actions-send.test.ts
+++ b/tests/message.tool-actions-send.test.ts
@@ -3,6 +3,87 @@ import { expect, test, vi } from 'vitest';
 async function importFreshMessageToolActions() {
   vi.resetModules();
 
+  const readEmailMailbox = vi.fn(async (params: Record<string, unknown>) => {
+    if (params.folder === 'INBOX' && params.uid === 44) {
+      return {
+        kind: 'message',
+        accountAddress: 'bot@example.com',
+        agentId: params.agentId || 'main',
+        folder: 'INBOX',
+        uid: 44,
+        snapshot: {
+          message: {
+            folder: 'INBOX',
+            uid: 44,
+            messageId: '<msg-44@example.com>',
+            subject: 'Invoice due',
+            fromAddress: 'billing@example.com',
+            fromName: 'Billing',
+            preview: 'Invoice due Friday',
+            receivedAt: '2026-03-14T09:00:00.000Z',
+            seen: false,
+            flagged: false,
+            answered: false,
+            hasAttachments: true,
+            to: [{ name: null, address: 'bot@example.com' }],
+            cc: [],
+            bcc: [],
+            replyTo: [],
+            text: 'Invoice due Friday.',
+            attachments: [
+              {
+                filename: 'invoice.pdf',
+                contentType: 'application/pdf',
+                size: 1234,
+              },
+            ],
+            metadata: null,
+          },
+          thread: [],
+        },
+      };
+    }
+    return {
+      kind: 'search',
+      accountAddress: 'bot@example.com',
+      agentId: params.agentId || 'main',
+      snapshot: {
+        address: 'bot@example.com',
+        query: String(params.query || '').trim() || null,
+        folders: params.folders || ['INBOX', 'Sent'],
+        limit: params.limit || 20,
+        messages: [
+          {
+            folder: 'INBOX',
+            uid: 44,
+            messageId: '<msg-44@example.com>',
+            subject: 'Invoice due',
+            fromAddress: 'billing@example.com',
+            fromName: 'Billing',
+            preview: 'Invoice due Friday',
+            receivedAt: '2026-03-14T09:00:00.000Z',
+            seen: false,
+            flagged: false,
+            answered: false,
+            hasAttachments: true,
+            to: [{ name: null, address: 'bot@example.com' }],
+            cc: [],
+            bcc: [],
+            replyTo: [],
+            text: 'Invoice due Friday.',
+            attachments: [
+              {
+                filename: 'invoice.pdf',
+                contentType: 'application/pdf',
+                size: 1234,
+              },
+            ],
+            metadata: null,
+          },
+        ],
+      },
+    };
+  });
   const sendEmailAttachmentTo = vi.fn(async () => {});
   const sendToEmail = vi.fn(async () => {});
   const sendToSignalChat = vi.fn(async () => {});
@@ -166,6 +247,7 @@ async function importFreshMessageToolActions() {
     getWhatsAppAuthStatus,
   }));
   vi.doMock('../src/channels/email/runtime.js', () => ({
+    readEmailMailbox,
     sendEmailAttachmentTo,
     sendToEmail,
   }));
@@ -220,6 +302,7 @@ async function importFreshMessageToolActions() {
     ...module,
     sendEmailAttachmentTo,
     sendToEmail,
+    readEmailMailbox,
     getAgentById,
     resolveAgentForRequest,
     sendToSignalChat,
@@ -947,6 +1030,102 @@ test('read action uses current email session when channelId is omitted', async (
     sessionId: 'email:peer@example.com',
     transport: 'email',
     count: 1,
+  });
+});
+
+test('read action searches live email mailbox when no channel target is provided', async () => {
+  const state = await importFreshMessageToolActions();
+
+  const result = await state.runMessageToolAction({
+    action: 'read',
+    sessionId: 'assist-session',
+    query: 'invoice',
+    limit: 7,
+    unreadOnly: true,
+  });
+
+  expect(state.readEmailMailbox).toHaveBeenCalledWith(
+    expect.objectContaining({
+      agentId: 'assist',
+      query: 'invoice',
+      limit: 7,
+      unreadOnly: true,
+    }),
+  );
+  expect(state.getRecentMessages).not.toHaveBeenCalled();
+  expect(state.runDiscordToolAction).not.toHaveBeenCalled();
+  expect(result).toMatchObject({
+    ok: true,
+    action: 'read',
+    channelId: 'email:mailbox',
+    scope: 'mailbox-search',
+    transport: 'email',
+    accountAddress: 'bot@example.com',
+    agentId: 'assist',
+    count: 1,
+  });
+  expect(result.messages).toEqual([
+    expect.objectContaining({
+      id: 'INBOX:44',
+      subject: 'Invoice due',
+      from: expect.objectContaining({ address: 'billing@example.com' }),
+      text: 'Invoice due Friday.',
+    }),
+  ]);
+});
+
+test('read action searches explicit live email mailbox folders', async () => {
+  const state = await importFreshMessageToolActions();
+
+  const result = await state.runMessageToolAction({
+    action: 'read',
+    channelId: 'email:INBOX',
+    from: 'billing@example.com',
+    since: '2026-03-01',
+    limit: 5,
+  });
+
+  expect(state.readEmailMailbox).toHaveBeenCalledWith(
+    expect.objectContaining({
+      folder: 'INBOX',
+      folders: ['INBOX'],
+      from: 'billing@example.com',
+      since: '2026-03-01',
+      limit: 5,
+    }),
+  );
+  expect(result).toMatchObject({
+    scope: 'mailbox-search',
+    channelId: 'email:INBOX',
+    count: 1,
+  });
+});
+
+test('read action fetches a live email mailbox message by folder and uid', async () => {
+  const state = await importFreshMessageToolActions();
+
+  const result = await state.runMessageToolAction({
+    action: 'read',
+    channelId: 'email:mailbox',
+    folder: 'INBOX',
+    uid: 44,
+  });
+
+  expect(state.readEmailMailbox).toHaveBeenCalledWith(
+    expect.objectContaining({
+      folder: 'INBOX',
+      folders: ['INBOX'],
+      uid: 44,
+    }),
+  );
+  expect(result).toMatchObject({
+    scope: 'mailbox-message',
+    folder: 'INBOX',
+    uid: 44,
+    message: expect.objectContaining({
+      id: 'INBOX:44',
+      subject: 'Invoice due',
+    }),
   });
 });
 

--- a/tests/prompt-hooks.tool-summary.test.ts
+++ b/tests/prompt-hooks.tool-summary.test.ts
@@ -434,7 +434,7 @@ test('buildSystemPromptFromHooks includes email signature guidance for email con
     expect(prompt).toContain(
       'Use the `message` tool for sending or reading messages on active communication channels: email.',
     );
-    expect(prompt).toContain('Email: send email and read ingested email');
+    expect(prompt).toContain('Email: send and read email.');
     expect(prompt).not.toContain('WhatsApp: send messages');
     expect(prompt).toContain(
       'append a polished corporate signature block derived from the identity details already loaded from `IDENTITY.md`',
@@ -443,6 +443,7 @@ test('buildSystemPromptFromHooks includes email signature guidance for email con
     expect(prompt).toContain(
       'make a reasonable best-effort assumption, do the useful work first, and mention the assumption after the answer',
     );
+    expect(prompt).not.toContain('Search my email for invoices');
   } finally {
     unregisterChannel('email');
   }


### PR DESCRIPTION
## Summary

Adds live email mailbox read/search support so enabled email agents can inspect their configured mailbox instead of being limited to already ingested email thread history.

## Changes

- Add IMAP-backed mailbox search across selectable folders, with query/from/subject/date/unread filters and bounded newest-first results.
- Add live mailbox read routing through the message tool, including omitted channel targets, `email:INBOX`/folder targets, and exact `folder + uid` message fetches.
- Extend container message tool normalization/schema for mailbox read filters.
- Remove prompt/docs language that framed mailbox search as unavailable; email is now advertised simply as send/read.
- Add focused tests for mailbox search routing, schema, normalization, and prompt hint cleanup.

## Validation

- Focused Vitest: `tests/message.tool-actions-send.test.ts`, `tests/container.message-tool-normalization.test.ts`, `tests/container.message-tool-schema.test.ts`, `tests/channel-message-tool-hints.test.ts`, `tests/prompt-hooks.tool-summary.test.ts` passed (99 tests).
- `npm run typecheck` passed.
- `npm run lint` passed.
- `git diff --check` passed.