### PR TITLE
[codex] Add Lexware quotation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - **Console navigation config**: The top navigation strip can be customized
   from runtime config with local console paths or HTTP(S) URLs and link text.
+- **Lexware quotations**: The `lexware-office` skill now covers quotation
+  listing, retrieval, creation, and PDF downloads with explicit draft vs.
+  finalized document guidance.
 
 ## [0.25.8](https://github.com/HybridAIOne/hybridclaw/tree/v0.25.8) - 2026-06-27
 

--- a/docs/content/guides/skills/integrations.md
+++ b/docs/content/guides/skills/integrations.md
@@ -245,9 +245,9 @@ hybridclaw auth login hubspot \
 
 ## lexware-office
 
-Work with Lexware Office contacts, invoice articles, invoices, bookkeeping
-vouchers, receipt files, posting categories, payment status, and guarded
-invoice or expense writes through the Lexware Public API.
+Work with Lexware Office contacts, invoice articles, invoices, quotations,
+bookkeeping vouchers, receipt files, posting categories, payment status, and
+guarded invoice, quotation, or expense writes through the Lexware Public API.
 
 **Prerequisites** — a Lexware Office plan with Public API access and an API key
 stored in the encrypted HybridClaw runtime secret store.
@@ -260,9 +260,11 @@ hybridclaw secret set LEXWARE_OFFICE_API_KEY "<api-key>"
 >
 > The helper emits `bearerSecretName: "LEXWARE_OFFICE_API_KEY"` so the gateway injects the API key server-side.
 >
-> Start with read-only calls such as `profile`, `list-contacts`, `list-invoices`, `list-expenses`, `get-payment`, and `posting-categories`.
+> Start with read-only calls such as `profile`, `list-contacts`, `list-invoices`, `list-quotations`, `list-expenses`, `get-payment`, and `posting-categories`.
 >
-> Invoice creation, contact creation, voucher updates, receipt uploads, and expense logging require explicit operator grant.
+> Invoice creation, quotation creation, contact creation, voucher updates, receipt uploads, and expense logging require explicit operator grant.
+>
+> Create invoices and quotations as drafts unless the user clearly asks to finalize or send the document. If intent is ambiguous, ask first.
 >
 > Public API payment reads show payment items. The skill can score bank transactions against open invoices and write an operator-approved reconciliation note, while making clear that the public docs do not expose a direct banking-module assignment mutation.
 
@@ -271,6 +273,8 @@ hybridclaw secret set LEXWARE_OFFICE_API_KEY "<api-key>"
 > `Show the open invoices in Lexware Office`
 >
 > `Generate a draft invoice for Acme GmbH for last month's consulting hours`
+>
+> `Create a draft quotation for Acme GmbH`
 >
 > `Sync this receipt as a Reisekosten expense in Lexware Office`
 >

--- a/skills/lexware-office/SKILL.md
+++ b/skills/lexware-office/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lexware-office
-description: "Work with Lexware Office contacts, products, invoices, bookkeeping vouchers, receipts, payment status, and guarded invoice or expense writes through the Public API."
+description: "Work with Lexware Office contacts, products, invoices, quotations, bookkeeping vouchers, receipts, payment status, and guarded invoice, quotation, or expense writes through the Public API."
 user-invocable: true
 requires:
   bins:
@@ -17,10 +17,11 @@ credentials:
 metadata:
   hybridclaw:
     category: accounting
-    short_description: "Lexware Office invoices, contacts, vouchers, receipts, and payment status."
+    short_description: "Lexware Office invoices, quotations, contacts, vouchers, receipts, and payment status."
     tags:
       - accounting
       - invoices
+      - quotations
       - lexware
       - lexoffice
       - receipts
@@ -34,12 +35,14 @@ metadata:
         - contact-read
         - product-read
         - invoice-read
+        - quotation-read
         - voucher-read
         - payment-read
         - reporting-plan
       amber:
         - contact-create
         - invoice-create
+        - quotation-create
         - expense-log
         - voucher-update
         - receipt-upload
@@ -57,8 +60,8 @@ metadata:
 
 Use this skill when the user wants to inspect or manage Lexware Office data for
 German SME accounting workflows: customers, products/articles, invoices,
-bookkeeping vouchers, receipt files, posting categories, payment status, and
-high-level revenue or income-statement summaries.
+quotations, bookkeeping vouchers, receipt files, posting categories, payment
+status, and high-level revenue or income-statement summaries.
 
 Lexware Office was formerly branded lexoffice. This skill uses the current
 Public API gateway at `https://api.lexware.io`.
@@ -69,6 +72,8 @@ Public API gateway at `https://api.lexware.io`.
 - read articles/products/services used in invoice line items
 - list invoices through `voucherlist` and retrieve invoice details
 - download invoice files from the invoice file subresource
+- list quotations through `voucherlist`, retrieve quotation details, and
+  download quotation PDF files from the quotation file subresource
 - list and retrieve bookkeeping vouchers, including purchase invoices and
   receipt records
 - read payment status and payment items for vouchers through `/v1/payments`
@@ -80,6 +85,7 @@ Public API gateway at `https://api.lexware.io`.
 - aggregate fetched voucher pages into revenue summaries and income statements
 - create contacts only after explicit operator grant
 - create draft or finalized invoices only after explicit operator grant
+- create draft or finalized quotations only after explicit operator grant
 - log expense vouchers and upload receipt files only after explicit operator
   grant
 - match incoming bank transactions against open invoices locally, then prepare
@@ -136,12 +142,20 @@ gateway error that explicitly says `LEXWARE_OFFICE_API_KEY` cannot be resolved.
 4. Pass `--operator-grant` only after explicit approval or an approved F14
    escalation.
 5. Create invoices as drafts unless the user explicitly asks to finalize/send.
-6. Before voucher updates, fetch the current voucher and include its `version`
+6. Create quotations as drafts unless the user explicitly asks to finalize or
+   issue the quotation. Lexware finalizes quotations at creation with
+   `finalize=true`; its public docs say quotation status cannot be changed
+   later through the API.
+7. Only send documents or finalize documents when it is clear the user wants
+   that. If intent is ambiguous, ask whether to keep a draft or produce the
+   final document. The current helper does not expose a Lexware send command,
+   so never claim that a document was sent through Lexware.
+8. Before voucher updates, fetch the current voucher and include its `version`
    property in the write payload.
-7. For income-statement or revenue questions, use `income-statement-plan` or
+9. For income-statement or revenue questions, use `income-statement-plan` or
    `revenue-summary-plan`, execute the returned read requests, then run
    `income-statement` or `revenue-summary` on the saved JSON responses.
-8. For bank-transaction matching, use `list-bank-transactions` and
+10. For bank-transaction matching, use `list-bank-transactions` and
    `match-transaction` to score candidate invoices. Lexware Public API exposes
    payment status and bank-linked payment items but no documented direct bank
    assignment mutation, so the write path records an operator-approved
@@ -169,6 +183,10 @@ node skills/lexware-office/lexware_office.cjs http-request list-contacts --name 
 node skills/lexware-office/lexware_office.cjs http-request list-products --type SERVICE
 node skills/lexware-office/lexware_office.cjs http-request list-invoices --status open --size 25
 node skills/lexware-office/lexware_office.cjs http-request get-invoice --id 11111111-1111-4111-8111-111111111111
+node skills/lexware-office/lexware_office.cjs http-request list-quotations --status open --size 25
+node skills/lexware-office/lexware_office.cjs http-request get-quotation --id 11111111-1111-4111-8111-111111111111
+node skills/lexware-office/lexware_office.cjs http-request download-quotation-file --id 11111111-1111-4111-8111-111111111111
+node skills/lexware-office/lexware_office.cjs http-request render-quotation-document --id 11111111-1111-4111-8111-111111111111
 node skills/lexware-office/lexware_office.cjs http-request list-expenses --status open --start-date 2026-01-01 --end-date 2026-03-31
 node skills/lexware-office/lexware_office.cjs http-request get-payment --voucher-id 11111111-1111-4111-8111-111111111111
 node skills/lexware-office/lexware_office.cjs http-request list-bank-transactions --status paid
@@ -188,6 +206,10 @@ node skills/lexware-office/lexware_office.cjs http-request create-contact \
 
 node skills/lexware-office/lexware_office.cjs http-request create-invoice \
   --json '{"voucherDate":"2026-05-21T00:00:00.000+02:00","address":{"name":"Acme GmbH","street":"Example Str. 1","zip":"10115","city":"Berlin","countryCode":"DE"},"lineItems":[{"type":"custom","name":"Consulting","quantity":8,"unitName":"hours","unitPrice":{"currency":"EUR","netAmount":120,"taxRatePercentage":19}}],"totalPrice":{"currency":"EUR"},"taxConditions":{"taxType":"net"},"paymentConditions":{"paymentTermLabel":"Due in 14 days","paymentTermDuration":14}}' \
+  --operator-grant
+
+node skills/lexware-office/lexware_office.cjs http-request create-quotation \
+  --json '{"voucherDate":"2026-05-21T00:00:00.000+02:00","expirationDate":"2026-06-20T00:00:00.000+02:00","address":{"name":"Acme GmbH","street":"Example Str. 1","zip":"10115","city":"Berlin","countryCode":"DE"},"lineItems":[{"type":"custom","name":"Consulting","quantity":8,"unitName":"hours","unitPrice":{"currency":"EUR","netAmount":120,"taxRatePercentage":19}}],"totalPrice":{"currency":"EUR"},"taxConditions":{"taxType":"net"}}' \
   --operator-grant
 
 node skills/lexware-office/lexware_office.cjs http-request log-expense \
@@ -220,6 +242,7 @@ These helper operations require `--operator-grant`:
 
 - `create-contact`
 - `create-invoice`
+- `create-quotation`
 - `log-expense`
 - `upload-file`
 - `attach-file-to-voucher`
@@ -243,6 +266,12 @@ the voucher after explicit operator grant.
   writing.
 - Default invoice creation to draft. Use `--finalize` only after explicit user
   instruction.
+- Default quotation creation to draft. Use `--finalize` only after explicit
+  user instruction to issue/finalize the quotation, and ask when the wording is
+  ambiguous.
+- Prefer `download-quotation-file` for quotation PDFs. Use the deprecated
+  `render-quotation-document` endpoint only when the user specifically needs a
+  document file id for an older workflow.
 - Treat receipt uploads and voucher changes as account-data mutations.
 - Cost per assistant run is recorded by HybridClaw `UsageTotals`; helper output
   includes `costMeasurement.system = "UsageTotals"` so evals can verify the
@@ -262,6 +291,8 @@ python3 skills/skill-creator/scripts/quick_validate.py skills/lexware-office
 node skills/lexware-office/lexware_office.cjs --help
 node skills/lexware-office/lexware_office.cjs eval-scenarios
 node skills/lexware-office/lexware_office.cjs http-request list-invoices --status open
+node skills/lexware-office/lexware_office.cjs http-request list-quotations --status open
 node skills/lexware-office/lexware_office.cjs http-request list-bank-transactions --status paid
 node skills/lexware-office/lexware_office.cjs http-request create-invoice --json '{"voucherDate":"2026-05-21T00:00:00.000+02:00"}'
+node skills/lexware-office/lexware_office.cjs http-request create-quotation --json '{"voucherDate":"2026-05-21T00:00:00.000+02:00"}'
 ```

--- a/skills/lexware-office/evals/scenarios.json
+++ b/skills/lexware-office/evals/scenarios.json
@@ -61,6 +61,37 @@
     }
   },
   {
+    "id": "quotation-read-open",
+    "category": "quotation_read",
+    "prompt": "Show the open quotations in Lexware Office.",
+    "expected": {
+      "operation": "list-quotations",
+      "requiresEscalation": false,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "quotation-create-draft",
+    "category": "quotation_write",
+    "prompt": "Create a draft quotation for Acme GmbH.",
+    "expected": {
+      "operation": "create-quotation",
+      "requiresEscalation": true,
+      "requiredGrant": "approve-lexware-office-create-quotation",
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
+    "id": "quotation-file",
+    "category": "quotation_read",
+    "prompt": "Download the quotation PDF from Lexware Office.",
+    "expected": {
+      "operation": "download-quotation-file",
+      "requiresEscalation": false,
+      "costSystem": "UsageTotals"
+    }
+  },
+  {
     "id": "customer-list",
     "category": "customer_read",
     "prompt": "Find the Lexware customer record for Acme.",

--- a/skills/lexware-office/lexware_office.cjs
+++ b/skills/lexware-office/lexware_office.cjs
@@ -32,6 +32,10 @@ const READ_OPERATIONS = new Set([
   'list-invoices',
   'get-invoice',
   'download-invoice-file',
+  'list-quotations',
+  'get-quotation',
+  'render-quotation-document',
+  'download-quotation-file',
   'list-expenses',
   'get-voucher',
   'get-payment',
@@ -44,6 +48,7 @@ const READ_OPERATIONS = new Set([
 const WRITE_OPERATIONS = new Set([
   'create-contact',
   'create-invoice',
+  'create-quotation',
   'log-expense',
   'upload-file',
   'attach-file-to-voucher',
@@ -52,6 +57,8 @@ const WRITE_OPERATIONS = new Set([
 ]);
 
 const INVOICE_RE = /\b(invoices?|rechnung|rechnungen|receivables?)\b/i;
+const QUOTATION_RE =
+  /\b(quotations?|quotes?|proposals?|angebot(?:e|s)?)\b/i;
 const CUSTOMER_RE = /\b(customers?|clients?|contacts?|kunden?)\b/i;
 const PRODUCT_RE = /\b(products?|articles?|items?|services?|artikel)\b/i;
 const EXPENSE_RE =
@@ -64,9 +71,11 @@ const REPORT_RE =
 const CREATE_RE =
   /\b(create|generate|draft|add|new|send|log|upload|attach|book|match|sync|erstell(?:e|en)?)\b/i;
 const UPDATE_RE = /\b(update|change|correct|edit|void|remove|replace)\b/i;
+const FINALIZE_RE =
+  /\b(finali[sz]e|final|issue|freigeb(?:e|en)|abschlie(?:ss|ß)(?:e|en)?)\b/i;
 const POSTING_RE =
   /\b(posting categories?|booking categor(?:y|ies)|category ids?|kontierungs?kategorien?)\b/i;
-const FILE_RE = /\b(download|file|pdf|document)\b/i;
+const FILE_RE = /\b(download|file|pdf|document|render)\b/i;
 const READ_ONLY_VOUCHER_FIELDS = new Set([
   'id',
   'organizationId',
@@ -301,6 +310,33 @@ function buildReadRequest(operation, args) {
       headers: { Accept: '*/*' },
     });
   }
+  if (operation === 'list-quotations') {
+    return buildVoucherListRequest(args, {
+      voucherType: 'quotation',
+      voucherStatus: popFlag(args, '--status'),
+    });
+  }
+  if (operation === 'get-quotation') {
+    const id = popFlag(args, '--id');
+    validateUuid(id, '--id');
+    return buildHttpRequest({ url: `${API_BASE}/v1/quotations/${id}` });
+  }
+  if (operation === 'render-quotation-document') {
+    const id = popFlag(args, '--id');
+    validateUuid(id, '--id');
+    return buildHttpRequest({
+      url: `${API_BASE}/v1/quotations/${id}/document`,
+      headers: { Accept: 'application/json' },
+    });
+  }
+  if (operation === 'download-quotation-file') {
+    const id = popFlag(args, '--id');
+    validateUuid(id, '--id');
+    return buildHttpRequest({
+      url: `${API_BASE}/v1/quotations/${id}/file`,
+      headers: { Accept: '*/*' },
+    });
+  }
   if (operation === 'list-expenses') {
     return buildVoucherListRequest(args, {
       voucherType: 'purchaseinvoice,purchasecreditnote',
@@ -425,6 +461,14 @@ function buildWriteRequest(operation, args) {
     const finalize = popBoolean(args, '--finalize');
     return buildHttpRequest({
       url: appendQuery(`${API_BASE}/v1/invoices`, { finalize }),
+      method: 'POST',
+      json: requireJsonPayload(args),
+    });
+  }
+  if (operation === 'create-quotation') {
+    const finalize = popBoolean(args, '--finalize');
+    return buildHttpRequest({
+      url: appendQuery(`${API_BASE}/v1/quotations`, { finalize }),
       method: 'POST',
       json: requireJsonPayload(args),
     });
@@ -572,7 +616,8 @@ function makePlan({
 
 function planRequest(request) {
   const text = request.toLowerCase();
-  const isWrite = CREATE_RE.test(text) || UPDATE_RE.test(text);
+  const isWrite =
+    CREATE_RE.test(text) || UPDATE_RE.test(text) || FINALIZE_RE.test(text);
 
   if (BANK_RE.test(text) && isWrite) {
     return makePlan({
@@ -606,6 +651,19 @@ function planRequest(request) {
       stakesTier: 'amber',
       requiresEscalation: true,
       requiredGrant: 'approve-lexware-office-create-invoice',
+    });
+  }
+  if (QUOTATION_RE.test(text) && isWrite) {
+    return makePlan({
+      request,
+      operation: 'create-quotation',
+      resource: 'quotations',
+      stakesTier: 'amber',
+      requiresEscalation: true,
+      requiredGrant: 'approve-lexware-office-create-quotation',
+      findings: [
+        'Create quotations as drafts unless the user clearly asks to finalize. Lexware finalizes quotations at creation with finalize=true; its public docs say quotation status cannot be changed later via the API.',
+      ],
     });
   }
   if (CUSTOMER_RE.test(text) && isWrite) {
@@ -655,6 +713,13 @@ function planRequest(request) {
       resource: 'articles',
     });
   }
+  if (QUOTATION_RE.test(text) && FILE_RE.test(text)) {
+    return makePlan({
+      request,
+      operation: 'download-quotation-file',
+      resource: 'quotations',
+    });
+  }
   if (INVOICE_RE.test(text) && FILE_RE.test(text)) {
     return makePlan({
       request,
@@ -671,8 +736,15 @@ function planRequest(request) {
   }
   return makePlan({
     request,
-    operation: INVOICE_RE.test(text) ? 'list-invoices' : 'profile',
-    resource: INVOICE_RE.test(text) ? 'voucherlist' : 'profile',
+    operation: QUOTATION_RE.test(text)
+      ? 'list-quotations'
+      : INVOICE_RE.test(text)
+        ? 'list-invoices'
+        : 'profile',
+    resource:
+      QUOTATION_RE.test(text) || INVOICE_RE.test(text)
+        ? 'voucherlist'
+        : 'profile',
   });
 }
 
@@ -914,6 +986,10 @@ Usage:
   node skills/lexware-office/lexware_office.cjs http-request list-products [--article-number VALUE] [--type PRODUCT|SERVICE] [--page N] [--size N]
   node skills/lexware-office/lexware_office.cjs http-request list-invoices [--status open] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--page N] [--size N]
   node skills/lexware-office/lexware_office.cjs http-request get-invoice --id UUID
+  node skills/lexware-office/lexware_office.cjs http-request list-quotations [--status open|accepted|rejected|draft] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--page N] [--size N]
+  node skills/lexware-office/lexware_office.cjs http-request get-quotation --id UUID
+  node skills/lexware-office/lexware_office.cjs http-request download-quotation-file --id UUID
+  node skills/lexware-office/lexware_office.cjs http-request render-quotation-document --id UUID
   node skills/lexware-office/lexware_office.cjs http-request list-expenses [--status open] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--page N] [--size N]
   node skills/lexware-office/lexware_office.cjs http-request get-voucher --id UUID
   node skills/lexware-office/lexware_office.cjs http-request get-payment --voucher-id UUID
@@ -925,6 +1001,7 @@ Usage:
   node skills/lexware-office/lexware_office.cjs match-transaction --transaction-json JSON --invoices-file PATH
   node skills/lexware-office/lexware_office.cjs http-request create-contact --json JSON --operator-grant
   node skills/lexware-office/lexware_office.cjs http-request create-invoice --json JSON [--finalize] --operator-grant
+  node skills/lexware-office/lexware_office.cjs http-request create-quotation --json JSON [--finalize] --operator-grant
   node skills/lexware-office/lexware_office.cjs http-request log-expense --json JSON --operator-grant
   node skills/lexware-office/lexware_office.cjs http-request upload-file --file PATH [--type voucher] --operator-grant
   node skills/lexware-office/lexware_office.cjs http-request attach-file-to-voucher --voucher-id UUID --file PATH --operator-grant

--- a/skills/lexware-office/references/operator-setup.md
+++ b/skills/lexware-office/references/operator-setup.md
@@ -53,6 +53,12 @@ node skills/lexware-office/lexware_office.cjs http-request profile
   endpoints. Use small pages and back off on `429`.
 - Contacts, articles, vouchers, and voucherlist are paginated. Use `--page` and
   `--size`; the helper caps `--size` at 250.
+- Quotations can be created as drafts or finalized at creation time with
+  `--finalize`. Only pass `--finalize` when the user clearly asks to issue or
+  finalize the quotation; otherwise keep a draft and ask when intent is unclear.
+- Quotation PDFs should use `download-quotation-file`. The documented
+  `render-quotation-document` endpoint is deprecated and should only be used
+  when a legacy workflow explicitly needs a document file id.
 - Voucher updates require the current `version` property for optimistic locking.
   Read the voucher first, then update with the returned version.
 - The public payments endpoint is read-only. It can show payment items and
@@ -68,6 +74,7 @@ node skills/lexware-office/lexware_office.cjs http-request profile
 node skills/lexware-office/lexware_office.cjs http-request profile
 node skills/lexware-office/lexware_office.cjs http-request list-contacts --size 5
 node skills/lexware-office/lexware_office.cjs http-request list-invoices --status open --size 5
+node skills/lexware-office/lexware_office.cjs http-request list-quotations --status open --size 5
 node skills/lexware-office/lexware_office.cjs http-request posting-categories
 ```
 

--- a/tests/lexware-office-skill.test.ts
+++ b/tests/lexware-office-skill.test.ts
@@ -45,6 +45,7 @@ test('Lexware Office skill manifest declares accounting category and safety meta
   expect(skill).toContain('category: accounting');
   expect(skill).toContain('LEXWARE_OFFICE_API_KEY');
   expect(skill).toContain('https://api.lexware.io');
+  expect(skill).toContain('quotations');
   expect(skill).toContain('stakes_tiers:');
   expect(skill).toContain('transaction-match-plan');
   expect(skill).toContain('UsageTotals');
@@ -67,6 +68,8 @@ test('Lexware Office helper --help exits cleanly', () => {
   expect(result.stdout).toContain('Lexware Office skill helper');
   expect(result.stdout).toContain('list-contacts');
   expect(result.stdout).toContain('list-invoices');
+  expect(result.stdout).toContain('list-quotations');
+  expect(result.stdout).toContain('create-quotation');
   expect(result.stdout).toContain('log-expense');
   expect(result.stdout).toContain('income-statement-plan');
   expect(result.stdout).toContain('income-statement');
@@ -76,6 +79,9 @@ test('Lexware Office helper --help exits cleanly', () => {
   );
   expect(result.stdout).toContain(
     'list-invoices [--status open] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--page N] [--size N]',
+  );
+  expect(result.stdout).toContain(
+    'list-quotations [--status open|accepted|rejected|draft] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--page N] [--size N]',
   );
   expect(result.stdout).toContain(
     'list-expenses [--status open] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--page N] [--size N]',
@@ -95,6 +101,18 @@ test('Lexware Office helper plans reads, writes, reports, and transaction matchi
     'json',
     'plan',
     'Generate an invoice for Acme GmbH',
+  ]);
+  const quotationRead = runHelper([
+    '--format',
+    'json',
+    'plan',
+    'Show open quotations in Lexware Office',
+  ]);
+  const quotationWrite = runHelper([
+    '--format',
+    'json',
+    'plan',
+    'Create a draft quotation for Acme GmbH',
   ]);
   const report = runHelper([
     '--format',
@@ -117,6 +135,15 @@ test('Lexware Office helper plans reads, writes, reports, and transaction matchi
     operation: 'create-invoice',
     stakesTier: 'amber',
     requiredGrant: 'approve-lexware-office-create-invoice',
+  });
+  expect(JSON.parse(quotationRead.stdout)).toMatchObject({
+    operation: 'list-quotations',
+    requiresEscalation: false,
+  });
+  expect(JSON.parse(quotationWrite.stdout)).toMatchObject({
+    operation: 'create-quotation',
+    stakesTier: 'amber',
+    requiredGrant: 'approve-lexware-office-create-quotation',
   });
   expect(JSON.parse(report.stdout)).toMatchObject({
     operation: 'income-statement-plan',
@@ -156,6 +183,70 @@ test('Lexware Office helper emits gateway-proxied read requests without secrets'
   expect(payload.httpRequest.url).toContain('size=50');
   expect(result.stdout).not.toContain('api-key');
   expect(payload.costMeasurement.system).toBe('UsageTotals');
+});
+
+test('Lexware Office helper emits quotation read requests', () => {
+  const list = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'list-quotations',
+    '--status',
+    'open',
+    '--size',
+    '50',
+  ]);
+  const get = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'get-quotation',
+    '--id',
+    '11111111-1111-4111-8111-111111111111',
+  ]);
+  const download = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'download-quotation-file',
+    '--id',
+    '11111111-1111-4111-8111-111111111111',
+  ]);
+  const render = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'render-quotation-document',
+    '--id',
+    '11111111-1111-4111-8111-111111111111',
+  ]);
+
+  expect(list.status).toBe(0);
+  const listPayload = JSON.parse(list.stdout);
+  expect(listPayload.httpRequest.url).toContain('/v1/voucherlist?');
+  expect(listPayload.httpRequest.url).toContain('voucherType=quotation');
+  expect(listPayload.httpRequest.url).toContain('voucherStatus=open');
+
+  expect(get.status).toBe(0);
+  expect(JSON.parse(get.stdout).httpRequest).toMatchObject({
+    method: 'GET',
+    url: 'https://api.lexware.io/v1/quotations/11111111-1111-4111-8111-111111111111',
+    bearerSecretName: 'LEXWARE_OFFICE_API_KEY',
+  });
+
+  expect(download.status).toBe(0);
+  expect(JSON.parse(download.stdout).httpRequest).toMatchObject({
+    method: 'GET',
+    url: 'https://api.lexware.io/v1/quotations/11111111-1111-4111-8111-111111111111/file',
+    headers: { Accept: '*/*' },
+  });
+
+  expect(render.status).toBe(0);
+  expect(JSON.parse(render.stdout).httpRequest).toMatchObject({
+    method: 'GET',
+    url: 'https://api.lexware.io/v1/quotations/11111111-1111-4111-8111-111111111111/document',
+    headers: { Accept: 'application/json' },
+  });
 });
 
 test('Lexware Office helper builds income statement read sequence', () => {
@@ -333,6 +424,30 @@ test('Lexware Office helper emits invoice write request after grant', () => {
   });
 });
 
+test('Lexware Office helper emits quotation write request after grant', () => {
+  const result = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'create-quotation',
+    '--json',
+    '{"voucherDate":"2026-05-21T00:00:00.000+02:00"}',
+    '--finalize',
+    '--operator-grant',
+  ]);
+
+  expect(result.status).toBe(0);
+  const payload = JSON.parse(result.stdout);
+  expect(payload.httpRequest).toMatchObject({
+    method: 'POST',
+    url: 'https://api.lexware.io/v1/quotations?finalize=true',
+    bearerSecretName: 'LEXWARE_OFFICE_API_KEY',
+  });
+  expect(payload.httpRequest.json).toEqual({
+    voucherDate: '2026-05-21T00:00:00.000+02:00',
+  });
+});
+
 test('Lexware Office helper validates UUIDs and page size bounds', () => {
   const badUuid = runHelper([
     '--format',
@@ -503,11 +618,13 @@ test('Lexware Office helper eval suite covers roadmap behaviors', () => {
   const categories = new Set(scenarios.map((scenario) => scenario.category));
 
   expect(scenarios.length).toBeGreaterThanOrEqual(25);
-  expect(scenarios.length).toBeLessThanOrEqual(30);
+  expect(scenarios.length).toBeLessThanOrEqual(34);
   expect(categories).toEqual(
     new Set([
       'invoice_read',
       'invoice_write',
+      'quotation_read',
+      'quotation_write',
       'customer_read',
       'customer_write',
       'product_read',


### PR DESCRIPTION
## Summary

- Add Lexware quotation helper operations for listing, retrieving, creating, PDF download, and the deprecated document-render endpoint.
- Update the Lexware skill guidance so invoices and quotations stay draft by default and finalization/sending only happens when user intent is clear.
- Extend operator docs, public skill guide text, changelog, eval scenarios, and focused tests for quotation workflows.

## Validation

- `node skills/lexware-office/lexware_office.cjs eval-scenarios`
- `npx vitest run tests/lexware-office-skill.test.ts`
- `python3 skills/skill-creator/scripts/quick_validate.py skills/lexware-office`
- `npm run format`
- `npm run lint`
- `git diff --check`

## Notes

Lexware's public quotation docs support finalization at creation with `?finalize=true`; they state quotation status cannot be changed later through the API, so this PR does not add a separate draft-to-final mutation.